### PR TITLE
Fix merlint warnings

### DIFF
--- a/bin/cssdiff.ml
+++ b/bin/cssdiff.ml
@@ -14,63 +14,52 @@ let read_file path =
 
 type diff_mode = Auto | Tree | String
 
-let compare_files file1 file2 style_renderer diff_mode =
-  (* Check NO_COLOR environment variable (https://no-color.org/) When present
-     and not empty, disable colors regardless of other settings *)
-  let style_renderer =
-    match Sys.getenv_opt "NO_COLOR" with
-    | Some s when s <> "" -> Some `None (* NO_COLOR is set and non-empty *)
-    | _ -> style_renderer (* Use command line option *)
-  in
-  (* Setup Fmt with the style renderer from command line/env *)
-  Fmt_tty.setup_std_outputs ?style_renderer ();
+let resolve_style_renderer style_renderer =
+  match Sys.getenv_opt "NO_COLOR" with
+  | Some s when s <> "" -> Some `None
+  | _ -> style_renderer
 
+let run_diff diff_mode ~css1 ~css2 =
+  match diff_mode with
+  | Auto -> Css_tools.Css_compare.diff ~expected:css1 ~actual:css2
+  | Tree ->
+      Css_tools.Css_compare.diff_with_mode ~mode:`Tree ~expected:css1
+        ~actual:css2
+  | String ->
+      Css_tools.Css_compare.diff_with_mode ~mode:`String ~expected:css1
+        ~actual:css2
+
+let print_diff_report ~file1 ~file2 ~css1 ~css2 result =
+  let stats =
+    Css_tools.Css_compare.stats ~expected_str:css1 ~actual_str:css2 result
+  in
+  let buf = Buffer.create 1024 in
+  Css_tools.Css_compare.pp_stats buf stats;
+  Buffer.add_char buf '\n';
+  Css_tools.Css_compare.pp ~expected:file1 ~actual:file2 buf result;
+  Buffer.add_char buf '\n';
+  print_string (Buffer.contents buf)
+
+let compare_files file1 file2 style_renderer diff_mode =
+  Fmt_tty.setup_std_outputs
+    ?style_renderer:(resolve_style_renderer style_renderer)
+    ();
   match (read_file file1, read_file file2) with
   | Ok css1, Ok css2 -> (
       if css1 = css2 then (
         Fmt.pr "✓ CSS files are identical@.";
         Ok ())
       else
-        (* Use css_compare for detailed structural comparison *)
-        let result =
-          match diff_mode with
-          | Auto -> Css_tools.Css_compare.diff ~expected:css1 ~actual:css2
-          | Tree ->
-              Css_tools.Css_compare.diff_with_mode ~mode:`Tree ~expected:css1
-                ~actual:css2
-          | String ->
-              Css_tools.Css_compare.diff_with_mode ~mode:`String ~expected:css1
-                ~actual:css2
-        in
-        match result with
+        match run_diff diff_mode ~css1 ~css2 with
         | No_diff ->
             Fmt.pr "✓ CSS files are identical@.";
             Ok ()
-        | String_diff _ ->
-            (* Treat pure string differences as failures so tests catch ordering
-               changes. Encourage --diff=tree for more detail. *)
-            let stats =
-              Css_tools.Css_compare.stats ~expected_str:css1 ~actual_str:css2
-                result
-            in
-            let buf = Buffer.create 1024 in
-            Css_tools.Css_compare.pp_stats buf stats;
-            Buffer.add_char buf '\n';
-            Css_tools.Css_compare.pp ~expected:file1 ~actual:file2 buf result;
-            Buffer.add_char buf '\n';
-            print_string (Buffer.contents buf);
+        | String_diff _ as result ->
+            print_diff_report ~file1 ~file2 ~css1 ~css2 result;
             Error (`Msg "CSS files differ (string diff)")
-        | Tree_diff _ | Both_errors _ | Expected_error _ | Actual_error _ ->
-            let stats =
-              Css_tools.Css_compare.stats ~expected_str:css1 ~actual_str:css2
-                result
-            in
-            let buf = Buffer.create 1024 in
-            Css_tools.Css_compare.pp_stats buf stats;
-            Buffer.add_char buf '\n';
-            Css_tools.Css_compare.pp ~expected:file1 ~actual:file2 buf result;
-            Buffer.add_char buf '\n';
-            print_string (Buffer.contents buf);
+        | (Tree_diff _ | Both_errors _ | Expected_error _ | Actual_error _) as
+          result ->
+            print_diff_report ~file1 ~file2 ~css1 ~css2 result;
             Error (`Msg "CSS files differ"))
   | Error e, _ | _, Error e -> Error e
 

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -11,16 +11,27 @@
   fuzz_font_face
   fuzz_keyframe))
 
+; Property-based testing — runs with dune test
+
 (rule
  (alias runtest)
+ (enabled_if
+  (<> %{profile} afl))
  (deps fuzz.exe)
  (action
   (run %{exe:fuzz.exe})))
 
+; AFL campaign — only runs under --profile=afl. Generates the seed corpus
+; via fuzz.exe --gen-corpus before handing off to AFL.
+
 (rule
  (alias fuzz)
+ (enabled_if
+  (= %{profile} afl))
  (deps
   (source_tree corpus)
   fuzz.exe)
  (action
-  (run %{exe:fuzz.exe} --fuzz)))
+  (progn
+   (run %{exe:fuzz.exe} --gen-corpus corpus)
+   (echo "AFL fuzzer built: %{exe:fuzz.exe}\n"))))

--- a/fuzz/fuzz_font_face.mli
+++ b/fuzz/fuzz_font_face.mli
@@ -1,0 +1,4 @@
+(** Fuzz tests for [@font-face] rule parsing. *)
+
+val suite : string * Alcobar.test_case list
+(** [suite] is the collection of fuzz tests for [@font-face] rules. *)

--- a/fuzz/fuzz_keyframe.mli
+++ b/fuzz/fuzz_keyframe.mli
@@ -1,0 +1,4 @@
+(** Fuzz tests for [@keyframes] rule parsing. *)
+
+val suite : string * Alcobar.test_case list
+(** [suite] is the collection of fuzz tests for [@keyframes] rules. *)

--- a/fuzz/fuzz_reader.mli
+++ b/fuzz/fuzz_reader.mli
@@ -1,0 +1,4 @@
+(** Fuzz tests for the CSS Reader module. *)
+
+val suite : string * Alcobar.test_case list
+(** [suite] is the collection of fuzz tests for the CSS reader. *)

--- a/fuzz/fuzz_selector.mli
+++ b/fuzz/fuzz_selector.mli
@@ -1,0 +1,4 @@
+(** Fuzz tests for the CSS Selector module. *)
+
+val suite : string * Alcobar.test_case list
+(** [suite] is the collection of fuzz tests for CSS selectors. *)

--- a/fuzz/fuzz_stylesheet.mli
+++ b/fuzz/fuzz_stylesheet.mli
@@ -1,0 +1,4 @@
+(** Fuzz tests for the CSS Stylesheet module. *)
+
+val suite : string * Alcobar.test_case list
+(** [suite] is the collection of fuzz tests for CSS stylesheets. *)

--- a/fuzz/fuzz_supports.mli
+++ b/fuzz/fuzz_supports.mli
@@ -1,0 +1,4 @@
+(** Fuzz tests for [@supports] condition parsing. *)
+
+val suite : string * Alcobar.test_case list
+(** [suite] is the collection of fuzz tests for [@supports] conditions. *)

--- a/fuzz/fuzz_values.mli
+++ b/fuzz/fuzz_values.mli
@@ -1,0 +1,4 @@
+(** Fuzz tests for CSS value parsers. *)
+
+val suite : string * Alcobar.test_case list
+(** [suite] is the collection of fuzz tests for CSS values. *)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -4481,8 +4481,8 @@ val var_meta : 'a var -> meta option
 (** [var_meta v] is the optional metadata associated with [v]. *)
 
 val meta : unit -> ('a -> meta) * (meta -> 'a option)
-(** [meta () inject project] returns an injection/projection pair for metadata.
-*)
+(** [meta ()] returns a fresh injection/projection pair for storing values of
+    type ['a] inside {!type-meta}. *)
 
 val var_ref :
   ?fallback:'a fallback ->

--- a/lib/info/cascade_info.mli
+++ b/lib/info/cascade_info.mli
@@ -1,3 +1,9 @@
+(** Build-time metadata for the Cascade library.
+
+    Exposes a {!version} string derived from [dune-build-info] (for tagged
+    releases), the git short hash (for release builds), or ["dev"] during
+    development. *)
+
 val version : string
 (** [version] is the current version string. Uses the dune-build-info version
     when available (tagged releases), falls back to the git short hash in

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -6583,70 +6583,67 @@ let read_radial_size t : radial_size =
 let read_radial_gradient_config t : radial_gradient_config =
   Radial_config.read t
 
-let read_background_image t : background_image =
-  let read_linear_body t =
-    Reader.ws t;
-    let direction =
-      match Reader.option read_gradient_direction t with
-      | Some d ->
+let read_linear_gradient_body t =
+  Reader.ws t;
+  let direction =
+    match Reader.option read_gradient_direction t with
+    | Some d ->
+        ignore (Reader.comma_opt t);
+        d
+    | None -> To_bottom
+  in
+  Linear_gradient (direction, read_gradient_stops t)
+
+let read_radial_gradient_body t =
+  Reader.ws t;
+  let config =
+    match
+      Reader.option
+        (fun t ->
+          let cfg = Radial_config.read t in
+          if cfg.shape = None && cfg.size = None && cfg.position = None then
+            Reader.err_invalid t "no radial config";
+          Reader.ws t;
           ignore (Reader.comma_opt t);
-          d
-      | None -> To_bottom
-    in
-    Linear_gradient (direction, read_gradient_stops t)
+          cfg)
+        t
+    with
+    | Some cfg -> cfg
+    | None -> { shape = None; size = None; position = None }
   in
-  let read_radial_body t =
-    Reader.ws t;
-    let config =
-      match
-        Reader.option
-          (fun t ->
-            let cfg = Radial_config.read t in
-            if cfg.shape = None && cfg.size = None && cfg.position = None then
-              Reader.err_invalid t "no radial config";
-            Reader.ws t;
-            ignore (Reader.comma_opt t);
-            cfg)
-          t
-      with
-      | Some cfg -> cfg
-      | None -> { shape = None; size = None; position = None }
-    in
-    Radial_gradient (config, read_gradient_stops t)
-  in
-  let read_conic_body t =
-    Reader.ws t;
-    Conic_gradient (read_gradient_stops t)
-  in
-  let rec read_bg_image t =
-    Reader.enum_or_calls "background-image"
+  Radial_gradient (config, read_gradient_stops t)
+
+let read_conic_gradient_body t =
+  Reader.ws t;
+  Conic_gradient (read_gradient_stops t)
+
+let rec read_bg_image t =
+  Reader.enum_or_calls "background-image"
+    [
+      ("none", (None : background_image));
+      ("initial", Initial);
+      ("inherit", Inherit);
+    ]
+    ~calls:
       [
-        ("none", (None : background_image));
-        ("initial", Initial);
-        ("inherit", Inherit);
+        ("url", fun t -> Url (Reader.url t));
+        ( "linear-gradient",
+          fun t -> Reader.call "linear-gradient" t read_linear_gradient_body );
+        ( "radial-gradient",
+          fun t -> Reader.call "radial-gradient" t read_radial_gradient_body );
+        ( "conic-gradient",
+          fun t -> Reader.call "conic-gradient" t read_conic_gradient_body );
+        ( "var",
+          fun t ->
+            let _ = Reader.ident t in
+            Var (Values.read_var_after_ident read_bg_image t) );
       ]
-      ~calls:
-        [
-          ("url", fun t -> Url (Reader.url t));
-          ( "linear-gradient",
-            fun t -> Reader.call "linear-gradient" t read_linear_body );
-          ( "radial-gradient",
-            fun t -> Reader.call "radial-gradient" t read_radial_body );
-          ( "conic-gradient",
-            fun t -> Reader.call "conic-gradient" t read_conic_body );
-          ( "var",
-            fun t ->
-              let _ = Reader.ident t in
-              (* consume "var" *)
-              Var (Values.read_var_after_ident read_bg_image t) );
-        ]
-      t
-  in
-  (* Read first image, then check for comma-separated list *)
+    t
+
+let read_background_image t : background_image =
   let first = read_bg_image t in
   Reader.ws t;
   if Reader.comma_opt t then
-    (* There are more images - read as list *)
     let rest = Reader.list ~sep:Reader.comma ~at_least:1 read_bg_image t in
     List (first :: rest)
   else first

--- a/lib/test/info/dune
+++ b/lib/test/info/dune
@@ -1,0 +1,3 @@
+(test
+ (name test)
+ (libraries cascade.info alcotest))

--- a/lib/test/info/test.ml
+++ b/lib/test/info/test.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "cascade_info" [ Test_cascade_info.suite ]

--- a/lib/test/info/test_cascade_info.ml
+++ b/lib/test/info/test_cascade_info.ml
@@ -1,0 +1,8 @@
+let test_version_not_empty () =
+  Alcotest.(check bool)
+    "version is non-empty" true
+    (String.length Cascade_info.version > 0)
+
+let suite =
+  ( "cascade_info",
+    [ Alcotest.test_case "version not empty" `Quick test_version_not_empty ] )

--- a/lib/test/info/test_cascade_info.mli
+++ b/lib/test/info/test_cascade_info.mli
@@ -1,0 +1,2 @@
+val suite : string * unit Alcotest.test_case list
+(** [suite] is the test suite for the {!Cascade_info} module. *)

--- a/lib/tools/css_compare.ml
+++ b/lib/tools/css_compare.ml
@@ -319,6 +319,7 @@ let compute_stats ~expected_str ~actual_str diff_result =
 
 (* Alias for compute_stats *)
 let stats = compute_stats
+let add_strings b ls = List.iter (Buffer.add_string b) ls
 
 (* Format the result of diff with optional labels *)
 let pp ?(expected = "Expected") ?(actual = "Actual") buf = function
@@ -333,17 +334,63 @@ let pp ?(expected = "Expected") ?(actual = "Actual") buf = function
       let err1 = Css.pp_parse_error e1 in
       let err2 = Css.pp_parse_error e2 in
       if String.equal err1 err2 then
-        Buffer.add_string buf ("Both CSS have same parse error: " ^ err1)
+        add_strings buf [ "Both CSS have same parse error: "; err1 ]
       else
-        Buffer.add_string buf
-          ("Parse errors:\n  " ^ expected ^ ": " ^ err1 ^ "\n  " ^ actual ^ ": "
-         ^ err2)
+        add_strings buf
+          [
+            "Parse errors:\n  ";
+            expected;
+            ": ";
+            err1;
+            "\n  ";
+            actual;
+            ": ";
+            err2;
+          ]
   | Expected_error e ->
-      Buffer.add_string buf
-        (expected ^ " CSS parse error: " ^ Css.pp_parse_error e)
+      add_strings buf [ expected; " CSS parse error: "; Css.pp_parse_error e ]
   | Actual_error e ->
-      Buffer.add_string buf
-        (actual ^ " CSS parse error: " ^ Css.pp_parse_error e)
+      add_strings buf [ actual; " CSS parse error: "; Css.pp_parse_error e ]
+
+let add_pct buf char_diff_pct =
+  let rounded = Float.round (char_diff_pct *. 10.0) /. 10.0 in
+  let s = string_of_float rounded in
+  if String.contains s '.' then
+    match String.split_on_char '.' s with
+    | [ i; d ] ->
+        let frac = if String.length d >= 1 then String.sub d 0 1 else d ^ "0" in
+        add_strings buf [ i; "."; frac ]
+    | _ -> Buffer.add_string buf s
+  else add_strings buf [ s; ".0" ]
+
+let add_change buf count action singular =
+  let noun = if count = 1 then singular else singular ^ "s" in
+  add_strings buf [ string_of_int count; " "; action; " "; noun ]
+
+let emit_changes buf stats =
+  let entries =
+    [
+      (stats.added_rules, "added", "rule");
+      (stats.removed_rules, "removed", "rule");
+      (stats.modified_rules, "modified", "rule");
+      (stats.reordered_rules, "reordered", "rule");
+    ]
+    |> List.filter (fun (n, _, _) -> n > 0)
+  in
+  let container = stats.container_changes in
+  if entries = [] && container = 0 then
+    Buffer.add_string buf "No structural differences\n"
+  else (
+    Buffer.add_string buf "Changes: ";
+    List.iteri
+      (fun i (n, action, singular) ->
+        if i > 0 then Buffer.add_string buf ", ";
+        add_change buf n action singular)
+      entries;
+    if container > 0 then (
+      if entries <> [] then Buffer.add_string buf ", ";
+      add_strings buf [ string_of_int container; " containers" ]);
+    Buffer.add_char buf '\n')
 
 let pp_stats buf stats =
   let char_diff = abs (stats.actual_chars - stats.expected_chars) in
@@ -352,56 +399,14 @@ let pp_stats buf stats =
       float_of_int char_diff *. 100.0 /. float_of_int stats.expected_chars
     else 0.0
   in
-
-  let pct_str =
-    (* Round to 1 decimal place: multiply by 10, round, divide by 10 *)
-    let rounded = Float.round (char_diff_pct *. 10.0) /. 10.0 in
-    let s = string_of_float rounded in
-    (* Ensure we always have one decimal place *)
-    if String.contains s '.' then
-      let parts = String.split_on_char '.' s in
-      match parts with
-      | [ i; d ] ->
-          if String.length d >= 1 then i ^ "." ^ String.sub d 0 1
-          else i ^ "." ^ d ^ "0"
-      | _ -> s
-    else s ^ ".0"
-  in
-
-  Buffer.add_string buf
-    ("CSS: "
-    ^ string_of_int stats.actual_chars
-    ^ " chars vs "
-    ^ string_of_int stats.expected_chars
-    ^ " chars (" ^ pct_str ^ "% diff)\n");
-
-  (* Helper to add change description if count > 0 *)
-  let add_change count action singular changes =
-    if count > 0 then
-      (string_of_int count ^ " " ^ action ^ " "
-      ^ if count = 1 then singular else singular ^ "s")
-      :: changes
-    else changes
-  in
-
-  (* Build list of non-zero changes *)
-  let changes =
-    []
-    |> add_change stats.added_rules "added" "rule"
-    |> add_change stats.removed_rules "removed" "rule"
-    |> add_change stats.modified_rules "modified" "rule"
-    |> add_change stats.reordered_rules "reordered" "rule"
-    |> List.rev
-  in
-
-  (* Add container changes *)
-  let container_changes =
-    if stats.container_changes > 0 then
-      [ string_of_int stats.container_changes ^ " containers" ]
-    else []
-  in
-  let all_changes = changes @ container_changes in
-
-  if all_changes <> [] then
-    Buffer.add_string buf ("Changes: " ^ String.concat ", " all_changes ^ "\n")
-  else Buffer.add_string buf "No structural differences\n"
+  add_strings buf
+    [
+      "CSS: ";
+      string_of_int stats.actual_chars;
+      " chars vs ";
+      string_of_int stats.expected_chars;
+      " chars (";
+    ];
+  add_pct buf char_diff_pct;
+  Buffer.add_string buf "% diff)\n";
+  emit_changes buf stats

--- a/lib/variables.mli
+++ b/lib/variables.mli
@@ -22,8 +22,8 @@ val read_value : Reader.t -> 'a syntax -> 'a
 (** {1 Meta handling} *)
 
 val meta : unit -> ('a -> meta) * (meta -> 'a option)
-(** [meta () inject project] returns an injection/projection pair for metadata.
-*)
+(** [meta ()] returns a fresh injection/projection pair for storing values of
+    type ['a] inside {!type-meta}. *)
 
 (** {1 Variable creation} *)
 

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -195,7 +195,7 @@ let diff_nesting_deep () =
     "deep nesting diff not empty" false
     (Css_tools.Tree_diff.is_empty d)
 
-let diff_nesting_only_parent_props_changed () =
+let diff_nesting_parent_props_only () =
   let expected =
     parse ".card { padding: 1rem; & .title { font-size: 1rem } }"
   in
@@ -311,7 +311,7 @@ let suite =
         diff_nesting_child_removed;
       Alcotest.test_case "nesting deep" `Quick diff_nesting_deep;
       Alcotest.test_case "nesting only parent props changed" `Quick
-        diff_nesting_only_parent_props_changed;
+        diff_nesting_parent_props_only;
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "pp_rule_diff_simple does not crash" `Quick
         pp_rule_diff_simple_ok;


### PR DESCRIPTION
Split the long functions in properties.ml, css_compare.ml, and cssdiff.ml, rename diff_nesting_only_parent_props_changed for clarity, and add module and function documentation throughout. Replace the `^`, Fmt, and Printf chains in css_compare.ml with a Buffer-based renderer. Add .mli files for every fuzz module, and split fuzz/dune into runtest and afl-profile rules via --gen-corpus. Add a lib/test/info/ suite covering cascade_info.