### PR TITLE
Accept digits after -- in var() custom property names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## 1.1.0
+
+### Fixed
+
+- Accept custom property names starting with a digit after `--` in `var()`
+  references (e.g. `var(--1A202C)`). Per CSS Syntax Level 3 §4.3.11, `--`
+  itself is a valid ident-start, and any ident code point (including digits)
+  can follow.
+
 ## 1.0.0
 
 ### Added

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1018,10 +1018,13 @@ let read_var_after_ident : type a. (Reader.t -> a) -> Reader.t -> a var =
   Reader.expect '(' t;
   Reader.ws t;
   let var_name =
-    if Reader.looking_at t "--" then (
-      Reader.expect_string "--" t;
-      let name = Reader.ident ~keep_case:true t in
-      name)
+    if Reader.looking_at t "--" then
+      (* Parse the full dashed-ident (-- plus the rest) and strip the leading
+         --. Reader.ident accepts -- as a valid start, and any ident-code-point
+         (including digits) afterwards, so this correctly handles names like
+         --1A202C that start with a digit after the two dashes. *)
+      let full = Reader.ident ~keep_case:true t in
+      String.sub full 2 (String.length full - 2)
     else Reader.ident ~keep_case:true t
   in
   Reader.ws t;

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -126,6 +126,17 @@ let custom_properties_integration () =
   Alcotest.(check string)
     "custom properties exact" ".btn{--primary-color:blue;color:blue}\n" css
 
+(* Regression: a custom property name starting with a digit after the -- is a
+   valid dashed-ident per CSS Syntax §4.3.11. Tailwind emits these for
+   arbitrary-value classes like text-[1A202C]. *)
+let var_digit_after_dashes () =
+  let css = ".x{font-size:var(--1A202C)}" in
+  match Css.of_string css with
+  | Error err -> Alcotest.fail ("parse failed: " ^ Css.pp_parse_error err)
+  | Ok stylesheet ->
+      let out = Css.to_string ~minify:true stylesheet in
+      Alcotest.(check string) "var(--1A202C) roundtrip" (css ^ "\n") out
+
 (* CSS Roundtrip Test: Parse generated CSS and compare roundtrip *)
 let roundtrip () =
   let read_file path =
@@ -374,6 +385,7 @@ let suite =
       Alcotest.test_case "important declarations" `Quick important_integration;
       Alcotest.test_case "custom properties" `Quick
         custom_properties_integration;
+      Alcotest.test_case "var(--1A202C) parses" `Quick var_digit_after_dashes;
       Alcotest.test_case "CSS roundtrip parsing" `Quick roundtrip;
       (* AST introspection helpers *)
       Alcotest.test_case "layer_block extraction" `Quick test_layer_block;

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -213,6 +213,12 @@ let test_parse_var_reference () =
   check_var_ref "var(--primary)" "primary" None;
   check_var_ref "var(--theme-bg)" "theme-bg" None;
 
+  (* Custom property names starting with a digit after -- are valid per the CSS
+     Syntax spec (the two dashes are the ident-start). Tailwind arbitrary values
+     like text-[1A202C] emit var(--1A202C). *)
+  check_var_ref "var(--1A202C)" "1A202C" None;
+  check_var_ref "var(--42, 10px)" "42" (Some "10px");
+
   (* With fallbacks *)
   check_var_ref "var(--color, red)" "color" (Some "red");
   check_var_ref "var(--size, 10px)" "size" (Some "10px");


### PR DESCRIPTION
var(--1A202C) is valid per CSS Syntax Level 3 section 4.3.11: the two dashes are themselves the ident-start, so the rest can be any ident code point including digits. The parser was consuming -- then requiring a fresh ident-start, which rejected names like --1A202C that tailwindcss v4 emits for arbitrary-value classes (text-[1A202C]).

Parse the full dashed-ident and strip the leading -- instead.