### PR TITLE
diff: thread --lossless through Css_compare and the cascade diff CLI

### DIFF
--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -17,7 +17,7 @@ let resolve_style_renderer style_renderer =
   | Some s when s <> "" -> Some `None
   | _ -> style_renderer
 
-let run_diff mode ~css1 ~css2 =
+let run_diff mode ~lossless ~css1 ~css2 =
   let mode =
     match mode with
     | Auto -> `Auto
@@ -25,7 +25,7 @@ let run_diff mode ~css1 ~css2 =
     | String -> `String
     | Canonical -> `Canonical
   in
-  Cascade_diff.Css_compare.diff ~mode css1 css2
+  Cascade_diff.Css_compare.diff ~mode ~lossless css1 css2
 
 let print_diff_report ~file1 ~file2 ~css1 ~css2 result =
   let stats =
@@ -38,7 +38,7 @@ let print_diff_report ~file1 ~file2 ~css1 ~css2 result =
   Buffer.add_char buf '\n';
   print_string (Buffer.contents buf)
 
-let compare_files file1 file2 style_renderer mode memtrace_path () =
+let compare_files file1 file2 style_renderer mode lossless memtrace_path () =
   Cli_io.start_memtrace memtrace_path;
   Fmt_tty.setup_std_outputs
     ?style_renderer:(resolve_style_renderer style_renderer)
@@ -49,7 +49,7 @@ let compare_files file1 file2 style_renderer mode memtrace_path () =
         Fmt.pr "CSS files are identical@.";
         Ok ())
       else
-        match run_diff mode ~css1 ~css2 with
+        match run_diff mode ~lossless ~css1 ~css2 with
         | No_diff _ ->
             Fmt.pr "CSS files are identical@.";
             Ok ()
@@ -86,6 +86,17 @@ let mode_arg =
   in
   Arg.(value & opt mode_conv Auto & info [ "diff" ] ~docv:"MODE" ~doc)
 
+let lossless_arg =
+  let doc =
+    "Disable colour approximation in $(b,--diff=semantic) canonicalisation. \
+     Exact colour canonicalisation still runs, but static modern colour-space \
+     and color-mix() values stay functional and channels keep their full \
+     precision. Two stylesheets that only differ by colours folded within the \
+     approximation budget then report as different rather than collapsing to \
+     equal. Has no effect outside $(b,--diff=semantic)."
+  in
+  Arg.(value & flag & info [ "lossless" ] ~doc)
+
 let memtrace_arg =
   let doc =
     "Write a Memtrace allocation profile to $(docv) covering the diff run. \
@@ -100,7 +111,7 @@ let term =
   in
   term_result
     (const compare_files $ file1_arg $ file2_arg $ style_renderer_with_env
-   $ mode_arg $ memtrace_arg $ Cli_log.term)
+   $ mode_arg $ lossless_arg $ memtrace_arg $ Cli_log.term)
 
 let man =
   [
@@ -129,6 +140,11 @@ let man =
     `I
       ( "--diff=semantic",
         "Compare canonical minified CSS before reporting a diff" );
+    `I
+      ( "--lossless",
+        "Disable colour approximation under $(b,--diff=semantic): colour \
+         channels keep their authored precision and static modern colour-space \
+         values stay functional. No effect outside semantic mode." );
     `S Manpage.s_exit_status;
     `P "$(tname) exits with:";
     `I ("0", "if the CSS files are identical");

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -222,47 +222,60 @@ let css_for_semantic_comparison ?property css =
   | None -> css
   | Some property -> ":root{" ^ property ^ ":" ^ css ^ "}"
 
-let canonical_semantic_css ~strict css =
+let canonical_semantic_css ~strict ~lossless css =
   match Css.of_string ~strict css with
   | Ok { stylesheet; _ } -> (
-      try Some (stylesheet |> Css.optimize |> Css.to_string ~minify:true)
+      try
+        Some
+          (stylesheet |> Css.optimize ~lossless
+          |> Css.to_string ~minify:true ~lossless)
       with Invalid_argument _ -> None)
   | Error _ -> None
 
-let canonical_css ~strict css = canonical_semantic_css ~strict css
+let canonical_css ~strict ~lossless css =
+  canonical_semantic_css ~strict ~lossless css
 
-let canonical_pair ~strict expected actual =
-  match (canonical_css ~strict expected, canonical_css ~strict actual) with
+let canonical_pair ~strict ~lossless expected actual =
+  match
+    ( canonical_css ~strict ~lossless expected,
+      canonical_css ~strict ~lossless actual )
+  with
   | Some expected_norm, Some actual_norm ->
       Some (String.equal expected_norm actual_norm)
   | _ -> None
 
-let canonical_diff_inputs ~strict expected actual =
-  match (canonical_css ~strict expected, canonical_css ~strict actual) with
+let canonical_diff_inputs ~strict ~lossless expected actual =
+  match
+    ( canonical_css ~strict ~lossless expected,
+      canonical_css ~strict ~lossless actual )
+  with
   | Some expected, Some actual -> Some (expected, actual)
   | _ -> None
 
-let canonical_diff_inputs_with_fallback expected actual =
-  match canonical_diff_inputs ~strict:true expected actual with
+let canonical_diff_inputs_with_fallback ~lossless expected actual =
+  match canonical_diff_inputs ~strict:true ~lossless expected actual with
   | Some _ as result -> result
-  | None -> canonical_diff_inputs ~strict:false expected actual
+  | None -> canonical_diff_inputs ~strict:false ~lossless expected actual
 
 (* Internal: full-stylesheet equality under the canonical minified form. *)
-let semantic_equal ?property expected actual =
+let semantic_equal ?property ?(lossless = false) expected actual =
   let expected = strip_tool_header expected in
   let actual = strip_tool_header actual in
   if expected = actual then true
   else
     let expected_css = css_for_semantic_comparison ?property expected in
     let actual_css = css_for_semantic_comparison ?property actual in
-    match canonical_pair ~strict:true expected_css actual_css with
+    match canonical_pair ~strict:true ~lossless expected_css actual_css with
     | Some equal -> equal
     | None -> (
-        match canonical_pair ~strict:false expected_css actual_css with
+        match
+          canonical_pair ~strict:false ~lossless expected_css actual_css
+        with
         | Some equal -> equal
         | None -> false)
 
-let equivalent_value ~property a b = semantic_equal ~property a b
+let equivalent_value ?lossless ~property a b =
+  semantic_equal ?lossless ~property a b
 
 (* Parse two CSS strings and return their diff or parse errors *)
 type t =
@@ -330,12 +343,12 @@ let diff_canonical_parsed ~expected ~actual ~expected_canon ~actual_canon =
       else Tree_diff structural_diff
   | _ -> diff_auto ~expected ~actual
 
-let diff_canonical ~expected ~actual =
+let diff_canonical ~lossless ~expected ~actual =
   let expected = strip_tool_header expected in
   let actual = strip_tool_header actual in
   if expected = actual then No_diff { canonical_byte_diff = None }
   else
-    match canonical_diff_inputs_with_fallback expected actual with
+    match canonical_diff_inputs_with_fallback ~lossless expected actual with
     | None -> diff_auto ~expected ~actual
     | Some (expected_canon, actual_canon) ->
         if String.equal expected_canon actual_canon then
@@ -371,16 +384,17 @@ let diff_tree ~expected ~actual =
   | Ok _, Error e -> Actual_error e
   | Error e, Ok _ -> Expected_error e
 
-let diff ?(mode = `Auto) expected actual =
+let diff ?(mode = `Auto) ?(lossless = false) expected actual =
   let expected = strip_tool_header expected in
   let actual = strip_tool_header actual in
   match mode with
   | `Auto -> diff_auto ~expected ~actual
-  | `Canonical -> diff_canonical ~expected ~actual
+  | `Canonical -> diff_canonical ~lossless ~expected ~actual
   | `String -> diff_string ~expected ~actual
   | `Tree -> diff_tree ~expected ~actual
 
-let equal ?mode a b = match diff ?mode a b with No_diff _ -> true | _ -> false
+let equal ?mode ?lossless a b =
+  match diff ?mode ?lossless a b with No_diff _ -> true | _ -> false
 
 let as_tree_diff = function
   | Tree_diff d -> Some d

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -52,12 +52,13 @@ type mode = [ `Auto | `Tree | `String | `Canonical ]
       color positions. If the normalized forms differ, the returned diff is
       reported from those normalized outputs. *)
 
-val diff : ?mode:mode -> string -> string -> t
+val diff : ?mode:mode -> ?lossless:bool -> string -> string -> t
 (** [diff ?mode expected actual] returns the diff between two CSS strings. A
     leading [/*! ... */] tool banner on either side is stripped before
-    comparison. Parsing failures surface as [_error] variants. *)
+    comparison. Parsing failures surface as [_error] variants. [lossless]
+    preserves exact color channels during canonical comparison. *)
 
-val equal : ?mode:mode -> string -> string -> bool
+val equal : ?mode:mode -> ?lossless:bool -> string -> string -> bool
 (** [equal ?mode a b] is [true] iff [diff ?mode a b] is {!No_diff}. *)
 
 val as_tree_diff : t -> Tree_diff.t option
@@ -93,7 +94,8 @@ val pp_stats : Buffer.t -> stats -> unit
 
 (** {1:property_values Property-scoped value comparison} *)
 
-val equivalent_value : property:string -> string -> string -> bool
+val equivalent_value :
+  ?lossless:bool -> property:string -> string -> string -> bool
 (** [equivalent_value ~property a b] returns [true] when [a] and [b], parsed as
     the right-hand side of a [property:] declaration, share the same canonical
     declaration serialization through {!Cascade.Css.to_string}. This is the


### PR DESCRIPTION
Semantic mode silently rounded colours within cascade's ΔE_OK budget, so two stylesheets that only differ by an in-budget approximation collapsed to "no diff" with no way to opt out.

Add a [lossless] argument to `Css_compare.diff` / `equal` / `equivalent_value` and a `--lossless` flag on `cascade diff` that threads through to `Css.optimize` / `Css.to_string`. No effect outside `--diff=semantic`.