### PR TITLE
properties: skip leading whitespace in scroll-snap-align/stop parsers

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -14512,6 +14512,7 @@ let rec read_scroll_behavior (t : Cursor.t) : scroll_behavior =
     t
 
 let rec read_scroll_snap_align (t : Cursor.t) : scroll_snap_align =
+  Cursor.ws t;
   let read_single t =
     Cursor.enum_or_var "scroll-snap-align"
       [
@@ -14875,6 +14876,7 @@ let rec read_page_size t : page_size =
     t
 
 let rec read_scroll_snap_stop (t : Cursor.t) : scroll_snap_stop =
+  Cursor.ws t;
   Cursor.enum_or_var "scroll-snap-stop"
     [
       ("normal", (Normal : scroll_snap_stop));


### PR DESCRIPTION
`read_scroll_snap_align` and `read_scroll_snap_stop` dropped straight into `Cursor.enum_or_var`, which peeks at the current token and fails when it is whitespace. `.x { scroll-snap-align: none }` (any indented form) hit a "bad value" warning, the parser dropped the rule, and a tree diff against the same input minified reported the declaration as added on the side that parsed. Skip leading whitespace at the start of both parsers, matching the pattern `read_display` and other typed-value parsers already use.

Stacked on #12. Closes the `scroll-snap-align` tree-diff false positive.