### PR TITLE
cursor: skip whitespace before enum dispatch

### DIFF
--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -750,6 +750,7 @@ let try_enum table t =
   | _ -> None
 
 let enum ?default label table t =
+  ws t;
   match peek t with
   | Some (Component.Preserved { kind = Token.Ident s; _ }) -> (
       (* CSS idents are case-insensitive (Syntax section 3.3). *)
@@ -764,6 +765,7 @@ let enum ?default label table t =
   | _ -> ( match default with Some f -> f t | None -> err_expected t label)
 
 let enum_calls ?default table t =
+  ws t;
   match peek t with
   | Some (Component.Func { node = { name; _ }; _ }) -> (
       match List.assoc_opt (String.lowercase_ascii_preserve name) table with
@@ -778,6 +780,7 @@ let enum_calls ?default table t =
       | None -> err_expected t "function call")
 
 let enum_or_var ?default label idents ~var t =
+  ws t;
   match peek t with
   | Some (Component.Func { node = { name; _ }; _ })
     when String.lowercase_ascii_preserve name = "var" ->
@@ -785,6 +788,7 @@ let enum_or_var ?default label idents ~var t =
   | _ -> enum ?default label idents t
 
 let enum_or_calls ?default label idents ?(calls = []) t =
+  ws t;
   match peek t with
   | Some (Component.Preserved { kind = Token.Ident s; _ }) -> (
       (* CSS idents are case-insensitive (Syntax section 3.3). *)

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -426,16 +426,17 @@ val any_function_call : (string -> t -> 'a) -> t -> 'a option
 (** {1 Enums} *)
 
 val enum : ?default:(t -> 'a) -> string -> (string * 'a) list -> t -> 'a
-(** [enum ?default label table t] consumes an ident and looks it up in [table].
-    Falls back to [default] if provided, otherwise raises. *)
+(** [enum ?default label table t] skips leading whitespace, consumes an ident,
+    and looks it up in [table]. Falls back to [default] if provided, otherwise
+    raises. *)
 
 val try_enum : (string * 'a) list -> t -> 'a option
 (** [try_enum table t] is like {!enum} but returns [None] without raising. *)
 
 val enum_calls : ?default:(t -> 'a) -> (string * (t -> 'a)) list -> t -> 'a
-(** [enum_calls ?default table t] dispatches on the name of the next function
-    call. Each parser receives the raw cursor (still pointing at the function)
-    and is expected to consume it. *)
+(** [enum_calls ?default table t] skips leading whitespace, then dispatches on
+    the name of the next function call. Each parser receives the raw cursor
+    (still pointing at the function) and is expected to consume it. *)
 
 val enum_or_calls :
   ?default:(t -> 'a) ->
@@ -444,9 +445,10 @@ val enum_or_calls :
   ?calls:(string * (t -> 'a)) list ->
   t ->
   'a
-(** [enum_or_calls ?default label idents ?calls t] first tries to match [idents]
-    (ident token), then [calls] (function call), and finally falls back to
-    [default]. Raises if none apply and no default is given. *)
+(** [enum_or_calls ?default label idents ?calls t] skips leading whitespace,
+    first tries to match [idents] (ident token), then [calls] (function call),
+    and finally falls back to [default]. Raises if none apply and no default is
+    given. *)
 
 val enum_or_var :
   ?default:(t -> 'a) -> string -> (string * 'a) list -> var:(t -> 'a) -> t -> 'a

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3660,6 +3660,36 @@ let spec_generated_text_timeline_edges () =
   neg_cursor read_view_transition_class "none card";
   neg_cursor read_view_transition_name "match-element card"
 
+let test_enum_readers_accept_leading_ws () =
+  List.iter
+    (fun check -> check ())
+    [
+      (fun () -> check_position ~expected:"relative" " relative");
+      (fun () -> check_flex_direction ~expected:"row" " row");
+      (fun () -> check_align_self ~expected:"center" " center");
+      (fun () -> check_text_align ~expected:"start" " start");
+      (fun () -> check_text_decoration_style ~expected:"dashed" " dashed");
+      (fun () -> check_overflow ~expected:"hidden" " hidden");
+      (fun () -> check_visibility ~expected:"hidden" " hidden");
+      (fun () -> check_scroll_snap_align ~expected:"start" " start");
+      (fun () -> check_scroll_snap_stop ~expected:"always" " always");
+      (fun () -> check_scroll_snap_axis ~expected:"inline" " inline");
+      (fun () ->
+        check_scroll_snap_strictness ~expected:"mandatory" " mandatory");
+      (fun () -> check_user_select ~expected:"none" " none");
+      (fun () -> check_pointer_events ~expected:"none" " none");
+      (fun () -> check_resize ~expected:"both" " both");
+      (fun () -> check_box_sizing ~expected:"border-box" " border-box");
+      (fun () -> check_object_fit ~expected:"cover" " cover");
+      (fun () -> check_content_visibility ~expected:"auto" " auto");
+      (fun () -> check_direction ~expected:"rtl" " rtl");
+      (fun () -> check_writing_mode ~expected:"vertical-rl" " vertical-rl");
+      (fun () -> check_print_color_adjust ~expected:"exact" " exact");
+      (fun () -> check_appearance ~expected:"button" " button");
+      (fun () -> check_clear ~expected:"both" " both");
+      (fun () -> check_float_side ~expected:"left" " left");
+    ]
+
 let tests =
   [
     test_case "display" `Quick test_display;
@@ -3698,6 +3728,8 @@ let tests =
     test_case "scroll-snap-axis" `Quick test_scroll_snap_axis;
     test_case "scroll-snap-strictness" `Quick test_scroll_snap_strictness;
     test_case "scroll-snap-type" `Quick test_scroll_snap_type;
+    test_case "enum readers accept leading whitespace" `Quick
+      test_enum_readers_accept_leading_ws;
     test_case "property names" `Quick test_property_names;
     (* Additional coverage for missing readers *)
     test_case "grid auto-flow" `Quick test_grid_auto_flow;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3660,7 +3660,7 @@ let spec_generated_text_timeline_edges () =
   neg_cursor read_view_transition_class "none card";
   neg_cursor read_view_transition_name "match-element card"
 
-let test_enum_readers_accept_leading_ws () =
+let enum_readers_accept_leading_ws () =
   List.iter
     (fun check -> check ())
     [
@@ -3729,7 +3729,7 @@ let tests =
     test_case "scroll-snap-strictness" `Quick test_scroll_snap_strictness;
     test_case "scroll-snap-type" `Quick test_scroll_snap_type;
     test_case "enum readers accept leading whitespace" `Quick
-      test_enum_readers_accept_leading_ws;
+      enum_readers_accept_leading_ws;
     test_case "property names" `Quick test_property_names;
     (* Additional coverage for missing readers *)
     test_case "grid auto-flow" `Quick test_grid_auto_flow;


### PR DESCRIPTION
Stacked on #13. `Cursor.enum` and its variants dispatched on the next component without skipping leading whitespace, so every enum-valued property reader had to remember to call `ws` first; the scroll-snap readers fixed in #13 were the ones that forgot. The dispatch helpers now skip whitespace themselves, covering all enum readers at once.

Commit 66c4843 adds the regression coverage across the enum readers; commit 12e405d moves the skip into the dispatch helpers.