### PR TITLE
diff: surface parse warnings in comparison reports

### DIFF
--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -49,15 +49,20 @@ let compare_files file1 file2 style_renderer mode lossless memtrace_path () =
         Fmt.pr "CSS files are identical@.";
         Ok ())
       else
-        match run_diff mode ~lossless ~css1 ~css2 with
+        let result = run_diff mode ~lossless ~css1 ~css2 in
+        match result.Cascade_diff.Css_compare.result with
         | No_diff _ ->
+            (* Equal ASTs can still hide parse-dropped declarations; show the
+               warnings so the equality verdict is honest about them. *)
+            let buf = Buffer.create 256 in
+            Cascade_diff.Css_compare.pp ~expected:file1 ~actual:file2 buf result;
+            print_string (Buffer.contents buf);
             Fmt.pr "CSS files are identical@.";
             Ok ()
-        | String_diff _ as result ->
+        | String_diff _ ->
             print_diff_report ~file1 ~file2 ~css1 ~css2 result;
             Error (`Msg "CSS files differ (string diff)")
-        | (Tree_diff _ | Both_errors _ | Expected_error _ | Actual_error _) as
-          result ->
+        | Tree_diff _ | Both_errors _ | Expected_error _ | Actual_error _ ->
             print_diff_report ~file1 ~file2 ~css1 ~css2 result;
             Error (`Msg "CSS files differ"))
   | Error e, _ | _, Error e -> Error e

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -278,7 +278,7 @@ let equivalent_value ?lossless ~property a b =
   semantic_equal ?lossless ~property a b
 
 (* Parse two CSS strings and return their diff or parse errors *)
-type t =
+type result =
   | Tree_diff of Tree_diff.t (* CSS AST differences found *)
   | String_diff of String_diff.t (* No structural diff but strings differ *)
   | No_diff of { canonical_byte_diff : (string * string) option }
@@ -292,6 +292,12 @@ type t =
   | Both_errors of Error.t * Error.t
   | Expected_error of Error.t
   | Actual_error of Error.t
+
+type t = {
+  result : result;
+  expected_warnings : Error.t list;
+  actual_warnings : Error.t list;
+}
 
 type mode = [ `Auto | `Tree | `String | `Canonical ]
 
@@ -319,20 +325,20 @@ let diff_two_parsed ~expected ~actual ~expected_ast ~actual_ast =
   if not (is_empty structural_diff) then Tree_diff structural_diff
   else diff_after_empty_structural ~expected ~actual ~expected_norm ~actual_norm
 
-let diff_auto ~expected ~actual =
-  let expected = strip_tool_header expected in
-  let actual = strip_tool_header actual in
+let diff_auto ~expected ~actual ~expected_parse ~actual_parse =
   (* First check if original strings are identical *)
   if expected = actual then No_diff { canonical_byte_diff = None }
   else
-    match (Css.of_string expected, Css.of_string actual) with
-    | Ok { stylesheet = expected_ast; _ }, Ok { stylesheet = actual_ast; _ } ->
+    match (expected_parse, actual_parse) with
+    | ( Ok { Css.stylesheet = expected_ast; _ },
+        Ok { Css.stylesheet = actual_ast; _ } ) ->
         diff_two_parsed ~expected ~actual ~expected_ast ~actual_ast
     | Error e1, Error e2 -> Both_errors (e1, e2)
     | Ok _, Error e -> Actual_error e
     | Error e, Ok _ -> Expected_error e
 
-let diff_canonical_parsed ~expected ~actual ~expected_canon ~actual_canon =
+let diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
+    ~expected_canon ~actual_canon =
   match (Css.of_string expected_canon, Css.of_string actual_canon) with
   | Ok { stylesheet = expected_ast; _ }, Ok { stylesheet = actual_ast; _ } ->
       let structural_diff =
@@ -341,15 +347,13 @@ let diff_canonical_parsed ~expected ~actual ~expected_canon ~actual_canon =
       if is_empty structural_diff then
         No_diff { canonical_byte_diff = Some (expected_canon, actual_canon) }
       else Tree_diff structural_diff
-  | _ -> diff_auto ~expected ~actual
+  | _ -> diff_auto ~expected ~actual ~expected_parse ~actual_parse
 
-let diff_canonical ~lossless ~expected ~actual =
-  let expected = strip_tool_header expected in
-  let actual = strip_tool_header actual in
+let diff_canonical ~lossless ~expected ~actual ~expected_parse ~actual_parse =
   if expected = actual then No_diff { canonical_byte_diff = None }
   else
     match canonical_diff_inputs_with_fallback ~lossless expected actual with
-    | None -> diff_auto ~expected ~actual
+    | None -> diff_auto ~expected ~actual ~expected_parse ~actual_parse
     | Some (expected_canon, actual_canon) ->
         if String.equal expected_canon actual_canon then
           No_diff { canonical_byte_diff = None }
@@ -363,7 +367,8 @@ let diff_canonical ~lossless ~expected ~actual =
              inside [url()], ...). Expose the canonical byte forms on [No_diff]
              so maintainers can spot which canonical-pass gap to chip away at
              next, without ever overriding the structural answer. *)
-          diff_canonical_parsed ~expected ~actual ~expected_canon ~actual_canon
+          diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
+            ~expected_canon ~actual_canon
 
 let diff_string ~expected ~actual =
   if expected = actual then No_diff { canonical_byte_diff = None }
@@ -372,9 +377,10 @@ let diff_string ~expected ~actual =
     | Some sdiff -> String_diff sdiff
     | None -> No_diff { canonical_byte_diff = None }
 
-let diff_tree ~expected ~actual =
-  match (Css.of_string expected, Css.of_string actual) with
-  | Ok { stylesheet = expected_ast; _ }, Ok { stylesheet = actual_ast; _ } ->
+let diff_tree ~expected_parse ~actual_parse =
+  match (expected_parse, actual_parse) with
+  | ( Ok { Css.stylesheet = expected_ast; _ },
+      Ok { Css.stylesheet = actual_ast; _ } ) ->
       let structural_diff =
         tree_diff ~expected:expected_ast ~actual:actual_ast
       in
@@ -384,19 +390,49 @@ let diff_tree ~expected ~actual =
   | Ok _, Error e -> Actual_error e
   | Error e, Ok _ -> Expected_error e
 
+let parse_warnings = function
+  | Ok { Css.warnings; _ } -> warnings
+  | Error _ -> []
+
 let diff ?(mode = `Auto) ?(lossless = false) expected actual =
   let expected = strip_tool_header expected in
   let actual = strip_tool_header actual in
-  match mode with
-  | `Auto -> diff_auto ~expected ~actual
-  | `Canonical -> diff_canonical ~lossless ~expected ~actual
-  | `String -> diff_string ~expected ~actual
-  | `Tree -> diff_tree ~expected ~actual
+  if expected = actual then
+    {
+      result = No_diff { canonical_byte_diff = None };
+      expected_warnings = [];
+      actual_warnings = [];
+    }
+  else
+    match mode with
+    | `String ->
+        {
+          result = diff_string ~expected ~actual;
+          expected_warnings = [];
+          actual_warnings = [];
+        }
+    | (`Auto | `Tree | `Canonical) as mode ->
+        let expected_parse = Css.of_string expected in
+        let actual_parse = Css.of_string actual in
+        let result =
+          match mode with
+          | `Auto -> diff_auto ~expected ~actual ~expected_parse ~actual_parse
+          | `Canonical ->
+              diff_canonical ~lossless ~expected ~actual ~expected_parse
+                ~actual_parse
+          | `Tree -> diff_tree ~expected_parse ~actual_parse
+        in
+        {
+          result;
+          expected_warnings = parse_warnings expected_parse;
+          actual_warnings = parse_warnings actual_parse;
+        }
 
 let equal ?mode ?lossless a b =
-  match diff ?mode ?lossless a b with No_diff _ -> true | _ -> false
+  match (diff ?mode ?lossless a b).result with No_diff _ -> true | _ -> false
 
-let as_tree_diff = function
+let as_tree_diff t =
+  match t.result with
   | Tree_diff d -> Some d
   | String_diff _ | No_diff _ | Both_errors _ | Expected_error _
   | Actual_error _ ->
@@ -407,7 +443,7 @@ let compute_stats ~expected_str ~actual_str diff_result =
   let expected_chars = String.length expected_str in
   let actual_chars = String.length actual_str in
 
-  match diff_result with
+  match diff_result.result with
   | Tree_diff d ->
       let count_rule_type pred = List.filter pred d.rules |> List.length in
       {
@@ -445,8 +481,17 @@ let compute_stats ~expected_str ~actual_str diff_result =
 let stats = compute_stats
 let add_strings b ls = List.iter (Buffer.add_string b) ls
 
-(* Format the result of diff with optional labels *)
-let pp ?(expected = "Expected") ?(actual = "Actual") buf = function
+(* Render each side's parse warnings so a declaration the parser dropped never
+   reads as a phantom structural difference on the side that parsed. *)
+let pp_parse_warnings buf label warnings =
+  List.iter
+    (fun w ->
+      if Buffer.length buf > 0 && Buffer.nth buf (Buffer.length buf - 1) <> '\n'
+      then Buffer.add_char buf '\n';
+      add_strings buf [ label; " parse warning: "; Error.to_string w; "\n" ])
+    warnings
+
+let pp_result ?(expected = "Expected") ?(actual = "Actual") buf = function
   | Tree_diff d ->
       (* Show structural differences *)
       D.pp ~expected ~actual buf d
@@ -476,6 +521,11 @@ let pp ?(expected = "Expected") ?(actual = "Actual") buf = function
       add_strings buf [ expected; " CSS parse error: "; Error.to_string e ]
   | Actual_error e ->
       add_strings buf [ actual; " CSS parse error: "; Error.to_string e ]
+
+let pp ?(expected = "Expected") ?(actual = "Actual") buf t =
+  pp_result ~expected ~actual buf t.result;
+  pp_parse_warnings buf expected t.expected_warnings;
+  pp_parse_warnings buf actual t.actual_warnings
 
 let add_pct buf char_diff_pct =
   let rounded = Float.round (char_diff_pct *. 10.0) /. 10.0 in

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -21,7 +21,7 @@ open Cascade
     this module wraps it with parse-error handling and a string-diff fallback.
 *)
 
-type t =
+type result =
   | Tree_diff of Tree_diff.t  (** Structural AST differences. *)
   | String_diff of String_diff.t
       (** Strings differ but no structural change was detected. *)
@@ -38,6 +38,18 @@ type t =
   | Both_errors of Error.t * Error.t
   | Expected_error of Error.t
   | Actual_error of Error.t
+
+type t = {
+  result : result;
+  expected_warnings : Error.t list;
+  actual_warnings : Error.t list;
+}
+(** A comparison outcome plus the parse warnings each side accumulated. A
+    declaration the parser rejects is dropped from that side's AST, so without
+    the warnings a structural diff would read as a phantom addition on the side
+    that parsed (or as no difference at all when both sides collapse to the same
+    AST). The warnings are empty in mode [`String], which never parses, and when
+    the header-stripped inputs are bytewise equal. *)
 
 type mode = [ `Auto | `Tree | `String | `Canonical ]
 (** CSS comparison mode.
@@ -66,9 +78,9 @@ val as_tree_diff : t -> Tree_diff.t option
     a {!Tree_diff}; [None] otherwise. *)
 
 val pp : ?expected:string -> ?actual:string -> Buffer.t -> t -> unit
-(** [pp ?expected ?actual buf result] formats [result] into [buf]. The
-    [expected]/[actual] labels are used in the rendered header (defaults:
-    ["Expected"], ["Actual"]). *)
+(** [pp ?expected ?actual buf result] formats [result] into [buf], then renders
+    each side's parse warnings. The [expected]/[actual] labels are used in the
+    rendered header and warning lines (defaults: ["Expected"], ["Actual"]). *)
 
 (** {1:stats Statistics} *)
 

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -466,7 +466,10 @@ let semantic_legacy_pseudo_element_alias () =
      p:first-of-type):not(:where([class~=not-prose],[class~=not-prose] \
      *))::before{content:\"\"}}"
   in
-  match Cascade_diff.Css_compare.diff ~mode:`Canonical legacy modern with
+  match
+    (Cascade_diff.Css_compare.diff ~mode:`Canonical legacy modern)
+      .Cascade_diff.Css_compare.result
+  with
   | Cascade_diff.Css_compare.No_diff _ -> ()
   | _ -> Alcotest.fail "expected :before and ::before to canonicalize equally"
 
@@ -505,13 +508,13 @@ let semantically_equivalent_rejects_different_colors () =
 let diff_no_diff () =
   let css = ".a { color: red }" in
   let result = Cascade_diff.Css_compare.diff css css in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.No_diff _ -> ()
   | _ -> Alcotest.fail "expected No_diff"
 
 let diff_no_diff_empty () =
   let result = Cascade_diff.Css_compare.diff "" "" in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.No_diff _ -> ()
   | _ -> Alcotest.fail "expected No_diff for empty strings"
 
@@ -521,7 +524,7 @@ let diff_tree_diff () =
   let expected = ".a { color: red }" in
   let actual = ".a { color: blue }" in
   let result = Cascade_diff.Css_compare.diff expected actual in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.Tree_diff d ->
       Alcotest.(check bool)
         "tree diff is not empty" false
@@ -532,7 +535,7 @@ let diff_tree_diff_added_rule () =
   let expected = ".a { color: red }" in
   let actual = ".a { color: red } .b { margin: 0 }" in
   let result = Cascade_diff.Css_compare.diff expected actual in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.Tree_diff _ -> ()
   | _ -> Alcotest.fail "expected Tree_diff for added rule"
 
@@ -545,7 +548,7 @@ let diff_string_diff () =
   let expected = ".a { color: red }" in
   let actual = ".a  { color: red }" in
   let result = Cascade_diff.Css_compare.diff ~mode:`String expected actual in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.String_diff d ->
       Alcotest.(check bool) "string diff has position" true (d.position >= 0)
   | Cascade_diff.Css_compare.No_diff _ ->
@@ -683,7 +686,7 @@ let diff_auto () =
   let expected = ".a { color: red }" in
   let actual = ".a { color: blue }" in
   let result = Cascade_diff.Css_compare.diff ~mode:`Auto expected actual in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.Tree_diff _ -> ()
   | _ -> Alcotest.fail "expected Tree_diff in auto mode"
 
@@ -691,7 +694,7 @@ let diff_tree () =
   let expected = ".a { color: red }" in
   let actual = ".a { color: blue }" in
   let result = Cascade_diff.Css_compare.diff ~mode:`Tree expected actual in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.Tree_diff _ -> ()
   | _ -> Alcotest.fail "expected Tree_diff in tree mode"
 
@@ -699,7 +702,7 @@ let diff_string () =
   let expected = ".a { color: red }" in
   let actual = ".a { color: blue }" in
   let result = Cascade_diff.Css_compare.diff ~mode:`String expected actual in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.String_diff _ -> ()
   | Cascade_diff.Css_compare.No_diff _ -> ()
   | _ -> Alcotest.fail "expected String_diff or No_diff in string mode"
@@ -707,7 +710,7 @@ let diff_string () =
 let diff_string_identical () =
   let css = ".a { color: red }" in
   let result = Cascade_diff.Css_compare.diff ~mode:`String css css in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.No_diff _ -> ()
   | _ -> Alcotest.fail "expected No_diff for identical in string mode"
 
@@ -715,7 +718,7 @@ let semantic_color_mix_mode () =
   let expected = ".a { color: " ^ color_mix_transparent ^ " }" in
   let actual = ".a { color: " ^ color_mix_transparent_hex ^ " }" in
   let result = Cascade_diff.Css_compare.diff ~mode:`Canonical expected actual in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.No_diff _ -> ()
   | _ -> Alcotest.fail "expected No_diff for semantically equivalent CSS"
 
@@ -728,7 +731,7 @@ let diff_canonical_uses_outputs () =
     "@unknown{color:red}.a{-webkit-tap-highlight-color:#0000;color:blue}"
   in
   let result = Cascade_diff.Css_compare.diff ~mode:`Canonical expected actual in
-  match result with
+  match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.Tree_diff _ ->
       let buf = Buffer.create 256 in
       Cascade_diff.Css_compare.pp buf result;

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -568,6 +568,40 @@ let diff_expected_error () =
   let result = Cascade_diff.Css_compare.diff expected actual in
   ignore result
 
+(* ===== parse warnings surfaced in diff reports ===== *)
+
+(* When one side's declaration is rejected by the value parser, the declaration
+   is dropped from the AST and the structural diff alone reads as a phantom
+   addition on the side that parsed. The rendered report must surface the parse
+   warning so the reader sees the real cause. *)
+let diff_surfaces_parse_warnings () =
+  let expected = ".a { color: red; scroll-snap-align: corner }" in
+  let actual = ".a { color: red; scroll-snap-align: start }" in
+  let result = Cascade_diff.Css_compare.diff expected actual in
+  let buf = Buffer.create 256 in
+  Cascade_diff.Css_compare.pp buf result;
+  let rendered = Buffer.contents buf in
+  Alcotest.(check bool)
+    "report mentions the rejected value" true
+    (contains_substring rendered "corner");
+  Alcotest.(check bool)
+    "report labels the parse warning" true
+    (contains_substring rendered "parse warning")
+
+let diff_surfaces_parse_warnings_same_ast () =
+  (* Both sides parse to the same AST once the bad declaration is dropped; the
+     report must still surface the warning instead of presenting the difference
+     as purely textual. *)
+  let expected = ".a { scroll-snap-align: corner }" in
+  let actual = ".a { }" in
+  let result = Cascade_diff.Css_compare.diff expected actual in
+  let buf = Buffer.create 256 in
+  Cascade_diff.Css_compare.pp buf result;
+  let rendered = Buffer.contents buf in
+  Alcotest.(check bool)
+    "report labels the parse warning" true
+    (contains_substring rendered "parse warning")
+
 (* ===== strip_tool_header tests ===== *)
 
 let strip_tool_header_no_header () =
@@ -839,6 +873,10 @@ let suite =
       Alcotest.test_case "diff String_diff" `Quick diff_string_diff;
       Alcotest.test_case "diff actual error" `Quick diff_actual_error;
       Alcotest.test_case "diff expected error" `Quick diff_expected_error;
+      Alcotest.test_case "diff surfaces parse warnings" `Quick
+        diff_surfaces_parse_warnings;
+      Alcotest.test_case "diff surfaces parse warnings on same AST" `Quick
+        diff_surfaces_parse_warnings_same_ast;
       Alcotest.test_case "strip_tool_header no header" `Quick
         strip_tool_header_no_header;
       Alcotest.test_case "strip_tool_header with header" `Quick


### PR DESCRIPTION
`Css_compare.diff` discarded the warnings the parser accumulated on each side, so a declaration the value parser rejected was silently dropped from that side's AST and the structural diff read as a phantom addition on the side that parsed (or as no difference at all when both sides collapsed to the same AST). The result now carries each side's parse warnings and `pp` renders them after the structural report, so `cascade diff` shows the real cause.

Commit eb1e579 adds the spec test; commit e0d2663 threads the warnings through `Css_compare` and the diff CLI.