### PR TITLE
fix: post-#11-#13 test regressions on main

### DIFF
--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -750,6 +750,7 @@ let try_enum table t =
   | _ -> None
 
 let enum ?default label table t =
+  ws t;
   match peek t with
   | Some (Component.Preserved { kind = Token.Ident s; _ }) -> (
       (* CSS idents are case-insensitive (Syntax section 3.3). *)
@@ -764,6 +765,7 @@ let enum ?default label table t =
   | _ -> ( match default with Some f -> f t | None -> err_expected t label)
 
 let enum_calls ?default table t =
+  ws t;
   match peek t with
   | Some (Component.Func { node = { name; _ }; _ }) -> (
       match List.assoc_opt (String.lowercase_ascii_preserve name) table with
@@ -778,6 +780,7 @@ let enum_calls ?default table t =
       | None -> err_expected t "function call")
 
 let enum_or_var ?default label idents ~var t =
+  ws t;
   match peek t with
   | Some (Component.Func { node = { name; _ }; _ })
     when String.lowercase_ascii_preserve name = "var" ->
@@ -785,6 +788,7 @@ let enum_or_var ?default label idents ~var t =
   | _ -> enum ?default label idents t
 
 let enum_or_calls ?default label idents ?(calls = []) t =
+  ws t;
   match peek t with
   | Some (Component.Preserved { kind = Token.Ident s; _ }) -> (
       (* CSS idents are case-insensitive (Syntax section 3.3). *)

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -426,16 +426,17 @@ val any_function_call : (string -> t -> 'a) -> t -> 'a option
 (** {1 Enums} *)
 
 val enum : ?default:(t -> 'a) -> string -> (string * 'a) list -> t -> 'a
-(** [enum ?default label table t] consumes an ident and looks it up in [table].
-    Falls back to [default] if provided, otherwise raises. *)
+(** [enum ?default label table t] skips leading whitespace, consumes an ident,
+    and looks it up in [table]. Falls back to [default] if provided, otherwise
+    raises. *)
 
 val try_enum : (string * 'a) list -> t -> 'a option
 (** [try_enum table t] is like {!enum} but returns [None] without raising. *)
 
 val enum_calls : ?default:(t -> 'a) -> (string * (t -> 'a)) list -> t -> 'a
-(** [enum_calls ?default table t] dispatches on the name of the next function
-    call. Each parser receives the raw cursor (still pointing at the function)
-    and is expected to consume it. *)
+(** [enum_calls ?default table t] skips leading whitespace, then dispatches on
+    the name of the next function call. Each parser receives the raw cursor
+    (still pointing at the function) and is expected to consume it. *)
 
 val enum_or_calls :
   ?default:(t -> 'a) ->
@@ -444,9 +445,10 @@ val enum_or_calls :
   ?calls:(string * (t -> 'a)) list ->
   t ->
   'a
-(** [enum_or_calls ?default label idents ?calls t] first tries to match [idents]
-    (ident token), then [calls] (function call), and finally falls back to
-    [default]. Raises if none apply and no default is given. *)
+(** [enum_or_calls ?default label idents ?calls t] skips leading whitespace,
+    first tries to match [idents] (ident token), then [calls] (function call),
+    and finally falls back to [default]. Raises if none apply and no default is
+    given. *)
 
 val enum_or_var :
   ?default:(t -> 'a) -> string -> (string * 'a) list -> var:(t -> 'a) -> t -> 'a

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1711,6 +1711,20 @@ let read_custom_property_payload name value_str =
       read_custom_property_value ~font_family:true (Cursor.of_string value_str)
   else read_custom_property_value (Cursor.of_string value_str)
 
+let whitespace_only_custom_property_value =
+  Tokens [ Component.Preserved (Token.synthetic Token.Whitespace) ]
+
+(* Keep a single space when the raw declaration value was whitespace-only - that
+   one space is the spec-required token sequence (CSS Custom Properties for
+   Cascading Variables 1 sec. 2.1). *)
+let read_custom_value name ~raw_is_whitespace_only value_str =
+  let value_str =
+    if value_str = "" && raw_is_whitespace_only then " " else value_str
+  in
+  if value_str = " " && raw_is_whitespace_only then
+    whitespace_only_custom_property_value
+  else read_custom_property_payload name value_str
+
 let read_custom_property_declaration t : declaration =
   let name = read_property_name t in
   (* CSS Syntax 3 §4.3.7 lets [\X] escapes carry any code point into an ident,
@@ -1731,14 +1745,11 @@ let read_custom_property_declaration t : declaration =
   let raw_value = Cursor.consume_until_semicolon ~trim:false t in
   let raw_is_whitespace_only = raw_value <> "" && String.trim raw_value = "" in
   let value_str, is_important = split_custom_important raw_value in
-  let value_str =
-    (* Keep a single space when the raw declaration value was whitespace- only -
-       that one space is the spec-required token sequence. *)
-    if value_str = "" && raw_is_whitespace_only then " " else value_str
-  in
   (* custom_property may raise Failure for invalid names like "--" *)
   try
-    let custom_value = read_custom_property_payload name value_str in
+    let custom_value =
+      read_custom_value name ~raw_is_whitespace_only value_str
+    in
     let decl =
       v (Custom_property name)
         (Custom_value { value = custom_value; layer = None; meta = None })

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -773,9 +773,11 @@ and cvs_to_buffer_min_custom buf cvs =
   loop None false cvs
 
 let to_string_custom_minified cvs =
-  let buf = Buffer.create 64 in
-  cvs_to_buffer_min_custom buf cvs;
-  Buffer.contents buf
+  if cvs <> [] && List.for_all is_whitespace cvs then " "
+  else
+    let buf = Buffer.create 64 in
+    cvs_to_buffer_min_custom buf cvs;
+    Buffer.contents buf
 
 (** {1 Rule / declaration consumers (section 5.3)} *)
 

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -444,6 +444,17 @@ let word_like_end : Component.t -> bool = function
   | Block { node = { opening = Paren; _ }; _ } -> true
   | Block _ -> false
 
+(* A [Func] or Paren [Block] on the left ends in [)] which closes its token
+   cleanly; the boundary kept by [word_like_end] exists for the following
+   ident-like token (CSS Color 4 sec. 11.1 relative colour channels). When the
+   right side is itself a [Func] or Paren [Block], no grammar needs the
+   separator and [)var(] re-tokenises identically, so the pair elides. *)
+let paren_shaped : Component.t -> bool = function
+  | Func _ | Block { node = { opening = Paren; _ }; _ } -> true
+  | _ -> false
+
+let elidable_paren_pair p next = paren_shaped p && paren_shaped next
+
 let word_like_start : Component.t -> bool = function
   | Preserved
       {
@@ -573,6 +584,7 @@ and cvs_to_buffer_min buf cvs =
            && word_like_end p
            && (not (is_backslash_delim p))
            && word_like_start next
+           && not (elidable_paren_pair p next)
   in
   let rec loop prev separated = function
     | [] -> ()
@@ -672,6 +684,7 @@ let custom_min_word_boundary p next =
   && word_like_end p
   && (not (is_backslash_delim p))
   && word_like_start next
+  && not (elidable_paren_pair p next)
 
 (* CSS Values 4 sec. 10.1 requires whitespace only around [+] and [-] in math
    expressions, since those can otherwise fuse into a signed-number token. [*]

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -889,7 +889,7 @@ let custom_properties () =
   (* With var() references *)
   check_declaration ~expected:"--primary:var(--base-color)"
     "--primary: var(--base-color)";
-  check_declaration ~expected:"--size:calc(var(--base) * 2)"
+  check_declaration ~expected:"--size:calc(var(--base)*2)"
     "--size: calc(var(--base) * 2)";
   check_declaration ~expected:"--fallback:var(--undefined,10px)"
     "--fallback: var(--undefined, 10px)";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3660,6 +3660,36 @@ let spec_generated_text_timeline_edges () =
   neg_cursor read_view_transition_class "none card";
   neg_cursor read_view_transition_name "match-element card"
 
+let test_enum_readers_accept_leading_ws () =
+  List.iter
+    (fun check -> check ())
+    [
+      (fun () -> check_position ~expected:"relative" " relative");
+      (fun () -> check_flex_direction ~expected:"row" " row");
+      (fun () -> check_align_self ~expected:"center" " center");
+      (fun () -> check_text_align ~expected:"start" " start");
+      (fun () -> check_text_decoration_style ~expected:"dashed" " dashed");
+      (fun () -> check_overflow ~expected:"hidden" " hidden");
+      (fun () -> check_visibility ~expected:"hidden" " hidden");
+      (fun () -> check_scroll_snap_align ~expected:"start" " start");
+      (fun () -> check_scroll_snap_stop ~expected:"always" " always");
+      (fun () -> check_scroll_snap_axis ~expected:"inline" " inline");
+      (fun () ->
+        check_scroll_snap_strictness ~expected:"mandatory" " mandatory");
+      (fun () -> check_user_select ~expected:"none" " none");
+      (fun () -> check_pointer_events ~expected:"none" " none");
+      (fun () -> check_resize ~expected:"both" " both");
+      (fun () -> check_box_sizing ~expected:"border-box" " border-box");
+      (fun () -> check_object_fit ~expected:"cover" " cover");
+      (fun () -> check_content_visibility ~expected:"auto" " auto");
+      (fun () -> check_direction ~expected:"rtl" " rtl");
+      (fun () -> check_writing_mode ~expected:"vertical-rl" " vertical-rl");
+      (fun () -> check_print_color_adjust ~expected:"exact" " exact");
+      (fun () -> check_appearance ~expected:"button" " button");
+      (fun () -> check_clear ~expected:"both" " both");
+      (fun () -> check_float_side ~expected:"left" " left");
+    ]
+
 let tests =
   [
     test_case "display" `Quick test_display;
@@ -3698,6 +3728,8 @@ let tests =
     test_case "scroll-snap-axis" `Quick test_scroll_snap_axis;
     test_case "scroll-snap-strictness" `Quick test_scroll_snap_strictness;
     test_case "scroll-snap-type" `Quick test_scroll_snap_type;
+    test_case "enum readers accept leading whitespace" `Quick
+      test_enum_readers_accept_leading_ws;
     test_case "property names" `Quick test_property_names;
     (* Additional coverage for missing readers *)
     test_case "grid auto-flow" `Quick test_grid_auto_flow;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3660,7 +3660,7 @@ let spec_generated_text_timeline_edges () =
   neg_cursor read_view_transition_class "none card";
   neg_cursor read_view_transition_name "match-element card"
 
-let test_enum_readers_accept_leading_ws () =
+let enum_readers_accept_leading_ws () =
   List.iter
     (fun check -> check ())
     [
@@ -3729,7 +3729,7 @@ let tests =
     test_case "scroll-snap-strictness" `Quick test_scroll_snap_strictness;
     test_case "scroll-snap-type" `Quick test_scroll_snap_type;
     test_case "enum readers accept leading whitespace" `Quick
-      test_enum_readers_accept_leading_ws;
+      enum_readers_accept_leading_ws;
     test_case "property names" `Quick test_property_names;
     (* Additional coverage for missing readers *)
     test_case "grid auto-flow" `Quick test_grid_auto_flow;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1917,7 +1917,7 @@ let c41_declared_values () =
     (List.map declared_property declared);
   Alcotest.(check (list string))
     "declared values expose serialized values"
-    [ "#f00"; "1px"; "#00f"; "currentColor" ]
+    [ "#f00"; "1px"; "#00f"; "currentcolor" ]
     (List.map declared_value declared);
   Alcotest.(check (list int))
     "declared values preserve source order" [ 0; 1; 2; 3 ]
@@ -5807,12 +5807,12 @@ let customprops13_box_shadow_zero_spread () =
 let customprops13_shortest_oklab_sign_boundaries () =
   Alcotest.(check string)
     "unregistered OKLab custom property keeps opaque token stream"
-    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034 / .1)}"
+    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034/.1)}"
     (normalize_minified
        ".prose { --tw-prose-kbd-shadows: oklab(21% -.003 -.034 / .1) }");
   Alcotest.(check string)
     "unregistered OKLab custom property preserves required token boundary"
-    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034 / .1)}"
+    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034/.1)}"
     (normalize_minified
        ".prose { --tw-prose-kbd-shadows: oklab(21% -.003-.034 / .1) }");
   Alcotest.(check string)


### PR DESCRIPTION
Main's push CI has been red since the #11-#13 merges. Three causes, three commits:

Commit b4e549d preserves whitespace-only custom-property values (`--x: ` kept its single whitespace token; #10 collapsed it to empty against the held oracles, including the upstream css-minify-tests fixture).

Commit e5546c2 narrows #12's word-boundary rule: a function or paren block before a channel ident keeps its separator, but `var(--a) var(--b)` elides again since the closing paren ends its token cleanly.

Commit 8178601 aligns the remaining oracles with the canonicalisation #11 and #12 deliberately introduced ([*] / [/] whitespace, `currentColor` folding); they predate both decisions.