### PR TITLE
properties: type radial and conic gradient preludes as gradient_position

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -2768,33 +2768,6 @@ type gradient_direction = Properties.gradient_direction =
   | With_interpolation of gradient_direction * color_interpolation
   | Var of gradient_direction var  (** Gradient stop values *)
 
-type gradient_stop = Properties.gradient_stop =
-  | Color_percentage of
-      color * length_percentage option * length_percentage option
-      (** Color with optional percentage positions *)
-  | Color_length of color * length option * length option
-      (** Color with optional length positions *)
-  | Length of length  (** Interpolation hint with length, e.g., "50px" *)
-  | Channel of channel
-      (** Residual numeric channel token from custom-property substitution. *)
-  | List of gradient_stop list
-      (** Multiple gradient stops - used for var fallbacks *)
-  | Percentage of percentage
-      (** Interpolation hint with percentage, e.g., "50%" *)
-  | Direction of gradient_direction
-      (** Gradient direction for stops, e.g., "to right" or Var *)
-  | Var of gradient_stop var
-
-val gradient_stops : gradient_stop list -> gradient_stop
-(** [gradient_stops stops] groups multiple gradient stops, usually for variable
-    fallbacks. *)
-
-val gradient_hint_length : length -> gradient_stop
-(** [gradient_hint_length value] is a length interpolation hint. *)
-
-val gradient_hint_percentage : percentage -> gradient_stop
-(** [gradient_hint_percentage value] is a percentage interpolation hint. *)
-
 (** Shape of a radial gradient *)
 type radial_shape = Properties.radial_shape =
   | Circle
@@ -2827,6 +2800,40 @@ type conic_gradient_config = Properties.conic_gradient_config = {
 }
 (** Configuration for conic-gradient prefix: starting angle, center, and
     optional [in <color-interpolation-method>] clause. *)
+
+type gradient_position = Properties.gradient_position =
+  | Linear_position of gradient_direction
+  | Radial_position of radial_gradient_config
+  | Conic_position of conic_gradient_config
+  | Var of gradient_position var
+
+type gradient_stop = Properties.gradient_stop =
+  | Color_percentage of
+      color * length_percentage option * length_percentage option
+      (** Color with optional percentage positions *)
+  | Color_length of color * length option * length option
+      (** Color with optional length positions *)
+  | Length of length  (** Interpolation hint with length, e.g., "50px" *)
+  | Channel of channel
+      (** Residual numeric channel token from custom-property substitution. *)
+  | List of gradient_stop list
+      (** Multiple gradient stops - used for var fallbacks *)
+  | Percentage of percentage
+      (** Interpolation hint with percentage, e.g., "50%" *)
+  | Position of gradient_position
+  | Direction of gradient_direction
+      (** Gradient direction for stops, e.g., "to right" or Var *)
+  | Var of gradient_stop var
+
+val gradient_stops : gradient_stop list -> gradient_stop
+(** [gradient_stops stops] groups multiple gradient stops, usually for variable
+    fallbacks. *)
+
+val gradient_hint_length : length -> gradient_stop
+(** [gradient_hint_length value] is a length interpolation hint. *)
+
+val gradient_hint_percentage : percentage -> gradient_stop
+(** [gradient_hint_percentage value] is a percentage interpolation hint. *)
 
 val radial_gradient_config :
   ?shape:radial_shape ->
@@ -7173,6 +7180,7 @@ type 'a kind = 'a Properties.kind =
   | Content : content kind
   | Gradient_stop : gradient_stop kind
   | Gradient_direction : gradient_direction kind
+  | Gradient_position : gradient_position kind
   | Animation : animation kind
   | Timing_function : timing_function kind
   | Transform : transform kind

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3082,30 +3082,20 @@ let position_value_is_center : position_value -> bool = function
   | XY (Pct 50., Pct 50.) -> true
   | _ -> false
 
-let radial_shape_kept ~drop_default (s : radial_shape option) :
-    radial_shape option =
-  match s with
-  | Some s when drop_default && radial_shape_is_default s -> None
-  | s -> s
+let radial_shape_kept (s : radial_shape option) : radial_shape option =
+  match s with Some s when radial_shape_is_default s -> None | s -> s
 
-let radial_size_kept ~drop_default (s : radial_size option) : radial_size option
-    =
-  match s with
-  | Some s when drop_default && radial_size_is_default s -> None
-  | s -> s
+let radial_size_kept (s : radial_size option) : radial_size option =
+  match s with Some s when radial_size_is_default s -> None | s -> s
 
-let radial_position_kept ~drop_default (p : position_value option) :
-    position_value option =
-  match p with
-  | Some p when drop_default && position_value_is_center p -> None
-  | p -> p
+let radial_position_kept (p : position_value option) : position_value option =
+  match p with Some p when position_value_is_center p -> None | p -> p
 
 let pp_radial_gradient_config : radial_gradient_config Pp.t =
  fun ctx config ->
-  let drop_default = Pp.minified ctx in
-  let shape = radial_shape_kept ~drop_default config.shape in
-  let size = radial_size_kept ~drop_default config.size in
-  let position = radial_position_kept ~drop_default config.position in
+  let shape = config.shape in
+  let size = config.size in
+  let position = config.position in
   let has_output = ref false in
   let emit_space_if_needed () =
     if !has_output then Pp.space ctx () else has_output := true
@@ -3303,11 +3293,8 @@ let pp_webkit_linear_gradient_named name ctx (dir, stops) =
 let pp_radial_gradient_named name ctx (config, stops) =
   Pp.call name
     (fun ctx (config, stops) ->
-      let drop_default = Pp.minified ctx in
       let has_config =
-        radial_shape_kept ~drop_default config.shape <> None
-        || radial_size_kept ~drop_default config.size <> None
-        || radial_position_kept ~drop_default config.position <> None
+        config.shape <> None || config.size <> None || config.position <> None
         || config.interpolation <> None
       in
       if has_config then (
@@ -3882,12 +3869,21 @@ let normalize_position_value ?(strip = true) : position_value -> position_value
   | other -> other
 
 let normalize_radial_config (c : radial_gradient_config) =
-  let size = option_map_preserve normalize_radial_size c.size in
-  let position =
-    option_map_preserve (normalize_position_value ~strip:false) c.position
+  (* CSS Images 4 section 3.1: inside a radial-gradient() prelude the default
+     shape (ellipse), size (farthest-corner) and position (center) are implied,
+     so the canonical form drops them. pp stays faithful to the AST; this
+     elision is an optimize-side rewrite. *)
+  let shape = radial_shape_kept c.shape in
+  let size =
+    option_map_preserve normalize_radial_size (radial_size_kept c.size)
   in
-  if size == c.size && position == c.position then c
-  else { c with size; position }
+  let position =
+    option_map_preserve
+      (normalize_position_value ~strip:false)
+      (radial_position_kept c.position)
+  in
+  if shape == c.shape && size == c.size && position == c.position then c
+  else { shape; size; position; interpolation = c.interpolation }
 
 let normalize_conic_config (c : conic_gradient_config) =
   let angle = option_map_preserve Values.normalize_angle c.angle in

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2915,57 +2915,6 @@ let canonicalise_gradient_stops stops =
       strip_pos first :: strip_last rest
   | _ -> strip_last stops
 
-let rec pp_gradient_stop : gradient_stop Pp.t =
- fun ctx -> function
-  | Var v -> pp_var pp_gradient_stop ctx v
-  | Color_percentage (c, pos1_opt, pos2_opt) -> (
-      let rendered_color =
-        Pp.to_string ~minify:(Pp.minified ctx) ~lossless:ctx.Pp.lossless
-          pp_color c
-      in
-      Pp.string ctx rendered_color;
-      match pos1_opt with
-      | None -> () (* No positions *)
-      | Some pos1 -> (
-          (* CSS Syntax 3 §4: ident- and hash-typed colours absorb the following
-             digit/hex into the same token ([red0%] -> ident [red0] + [%];
-             [#00f50%] -> hash [#00f50] + [%]), so the separator before the
-             position is mandatory. Function-shaped colours ([var(...)] /
-             [rgb(...)] / etc.) end with [)] which closes their token cleanly,
-             so the space is elidable in minified output. *)
-          let ends_with_paren =
-            String.length rendered_color > 0
-            && rendered_color.[String.length rendered_color - 1] = ')'
-          in
-          if not (Pp.minified ctx && ends_with_paren) then Pp.space ctx ();
-          pp_length_percentage ~always:true ctx pos1;
-          match pos2_opt with
-          | None -> ()
-          | Some pos2 ->
-              Pp.space ctx ();
-              pp_length_percentage ~always:true ctx pos2))
-  | Color_length (c, len1_opt, len2_opt) -> (
-      pp_color ctx c;
-      match len1_opt with
-      | None -> () (* No positions *)
-      | Some len1 -> (
-          (* Space between color and length, even for variables *)
-          Pp.space ctx ();
-          pp_length ctx len1;
-          match len2_opt with
-          | None -> ()
-          | Some len2 ->
-              Pp.space ctx ();
-              pp_length ctx len2))
-  | Length len -> pp_length ctx len
-  | Channel channel -> pp_channel ctx channel
-  | Percentage pct -> pp_percentage ctx pct
-  | List stops ->
-      (* Pretty-print multiple gradient stops separated by commas *)
-      Pp.list ~sep:Pp.comma pp_gradient_stop ctx
-        (if Pp.minified ctx then canonicalise_gradient_stops stops else stops)
-  | Direction dir -> pp_gradient_direction ctx dir
-
 let rec pp_filter : filter Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"
@@ -3146,6 +3095,63 @@ let pp_conic_gradient_config : conic_gradient_config Pp.t =
       Pp.space ctx ();
       pp_position_value ctx p
   | None -> ()
+
+let rec pp_gradient_position : gradient_position Pp.t =
+ fun ctx -> function
+  | Linear_position dir -> pp_gradient_direction ctx dir
+  | Radial_position config -> pp_radial_gradient_config ctx config
+  | Conic_position config -> pp_conic_gradient_config ctx config
+  | Var v -> pp_var pp_gradient_position ctx v
+
+let rec pp_gradient_stop : gradient_stop Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_gradient_stop ctx v
+  | Color_percentage (c, pos1_opt, pos2_opt) -> (
+      let rendered_color =
+        Pp.to_string ~minify:(Pp.minified ctx) ~lossless:ctx.Pp.lossless
+          pp_color c
+      in
+      Pp.string ctx rendered_color;
+      match pos1_opt with
+      | None -> ()
+      | Some pos1 -> (
+          (* CSS Syntax 3 §4: ident- and hash-typed colours absorb the following
+             digit/hex into the same token ([red0%] -> ident [red0] + [%];
+             [#00f50%] -> hash [#00f50] + [%]), so the separator before the
+             position is mandatory. Function-shaped colours ([var(...)] /
+             [rgb(...)] / etc.) end with [)] which closes their token cleanly,
+             so the space is elidable in minified output. *)
+          let ends_with_paren =
+            String.length rendered_color > 0
+            && rendered_color.[String.length rendered_color - 1] = ')'
+          in
+          if not (Pp.minified ctx && ends_with_paren) then Pp.space ctx ();
+          pp_length_percentage ~always:true ctx pos1;
+          match pos2_opt with
+          | None -> ()
+          | Some pos2 ->
+              Pp.space ctx ();
+              pp_length_percentage ~always:true ctx pos2))
+  | Color_length (c, len1_opt, len2_opt) -> (
+      pp_color ctx c;
+      match len1_opt with
+      | None -> ()
+      | Some len1 -> (
+          Pp.space ctx ();
+          pp_length ctx len1;
+          match len2_opt with
+          | None -> ()
+          | Some len2 ->
+              Pp.space ctx ();
+              pp_length ctx len2))
+  | Length len -> pp_length ctx len
+  | Channel channel -> pp_channel ctx channel
+  | Percentage pct -> pp_percentage ctx pct
+  | List stops ->
+      Pp.list ~sep:Pp.comma pp_gradient_stop ctx
+        (if Pp.minified ctx then canonicalise_gradient_stops stops else stops)
+  | Position pos -> pp_gradient_position ctx pos
+  | Direction dir -> pp_gradient_direction ctx dir
 
 let pp_webkit_gradient_point ctx = function
   | Webkit_gradient.Left_top ->
@@ -17940,12 +17946,11 @@ let read_conic_gradient_config t : conic_gradient_config =
   then Cursor.err_invalid t "conic-gradient config";
   { angle = !angle; position = !position; interpolation = !interpolation }
 
-let read_linear_gradient_body_stops t =
-  (* CSS Images 4 §6.1 [linear-gradient] prelude: [ <angle> | to
-     <side-or-corner> ]? || <color-interpolation-method> A bare interpolation, a
-     bare direction, or both in either order are all valid. After the prelude
-     the comma separating it from the colour-stop list is required if and only
-     if the prelude consumed any tokens. *)
+(* CSS Images 4 §6.1 [linear-gradient] prelude: [ <angle> | to <side-or-corner>
+   ]? || <color-interpolation-method> A bare interpolation, a bare direction, or
+   both in either order are all valid. Returns [None] when the prelude consumed
+   no tokens. *)
+let read_linear_prelude_opt t : gradient_direction option =
   let direction : gradient_direction option ref = ref Option.None in
   let interpolation : color_interpolation option ref = ref Option.None in
   let try_direction () =
@@ -17971,15 +17976,43 @@ let read_linear_gradient_body_stops t =
     if try_direction () || try_interpolation () then loop ()
   in
   loop ();
-  let prelude_consumed =
-    !direction <> Option.None || !interpolation <> Option.None
-  in
+  match (!direction, !interpolation) with
+  | Some d, Some i -> Option.Some (With_interpolation (d, i))
+  | Some d, None -> Option.Some d
+  | None, Some i -> Option.Some (With_interpolation (Default_direction, i))
+  | None, None -> Option.None
+
+let rec read_gradient_position t : gradient_position =
+  Cursor.ws t;
+  match Cursor.peek t with
+  | Some (Component.Func { node = { name = "var"; _ }; _ }) ->
+      (Var (Values.read_var read_gradient_position t) : gradient_position)
+  | _ -> (
+      match Cursor.peek_ident t with
+      | Some "from" -> Conic_position (read_conic_gradient_config t)
+      | Some
+          ( "circle" | "ellipse" | "closest-side" | "closest-corner"
+          | "farthest-side" | "farthest-corner" | "at" ) ->
+          Radial_position (read_radial_gradient_config t)
+      | _ ->
+          Cursor.one_of
+            [
+              (fun t ->
+                match read_linear_prelude_opt t with
+                | Option.Some direction ->
+                    (Linear_position direction : gradient_position)
+                | Option.None -> Cursor.err_expected t "gradient position");
+              (fun t -> Radial_position (read_radial_gradient_config t));
+            ]
+            t)
+
+let read_linear_gradient_body_stops t =
+  (* After the prelude the comma separating it from the colour-stop list is
+     required if and only if the prelude consumed any tokens. *)
+  let prelude = read_linear_prelude_opt t in
+  let prelude_consumed = prelude <> Option.None in
   let direction =
-    match (!direction, !interpolation) with
-    | Some d, Some i -> With_interpolation (d, i)
-    | Some d, None -> d
-    | None, Some i -> With_interpolation (Default_direction, i)
-    | None, None -> Default_direction
+    match prelude with Option.Some d -> d | Option.None -> Default_direction
   in
   if prelude_consumed then (
     Cursor.ws t;
@@ -20260,6 +20293,7 @@ let pp_value : type a. (a kind * a) Pp.t =
   | Content -> pp pp_content
   | Gradient_stop -> pp pp_gradient_stop
   | Gradient_direction -> pp pp_gradient_direction
+  | Gradient_position -> pp pp_gradient_position
   | Animation -> pp pp_animation
   | Timing_function -> pp pp_timing_function
   | Transform -> pp pp_transform
@@ -20317,6 +20351,7 @@ let string_of_kind_value : type a. a kind -> a -> string =
       | Var _ -> "initial")
   | Animation -> Pp.to_string pp_animation value
   | Gradient_direction -> Pp.to_string pp_gradient_direction value
+  | Gradient_position -> Pp.to_string pp_gradient_position value
   | _ -> "initial"
 
 let pp_custom_property_value ctx = function

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1497,6 +1497,13 @@ val read_conic_gradient_config : Cursor.t -> conic_gradient_config
 (** [read_conic_gradient_config t] parses a conic-gradient prefix configuration.
 *)
 
+val pp_gradient_position : gradient_position Pp.t
+(** [pp_gradient_position] pretty-prints a gradient prelude/position value. *)
+
+val read_gradient_position : Cursor.t -> gradient_position
+(** [read_gradient_position t] parses a linear, radial, or conic gradient
+    prelude/position value. *)
+
 val pp_gradient_stop : gradient_stop Pp.t
 (** [pp_gradient_stop] is the pretty-printer for [gradient_stop]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2433,25 +2433,6 @@ type gradient_direction =
   | With_interpolation of gradient_direction * color_interpolation
   | Var of gradient_direction var
 
-type gradient_stop =
-  | Color_percentage of
-      color * length_percentage option * length_percentage option
-    (* Color with optional length-percentage position *)
-  | Color_length of
-      color
-      * length option
-      * length option (* Color with optional length position *)
-  | Length of length (* Interpolation hint with length, e.g., "50px" *)
-  | Channel of channel
-      (** Residual numeric channel token from custom-property substitution. *)
-  | List of
-      gradient_stop list (* Multiple gradient stops - used for var fallbacks *)
-  | Percentage of
-      percentage (* Interpolation hint with percentage, e.g., "50%" *)
-  | Direction of gradient_direction
-  | Var of gradient_stop var
-(* Gradient direction for stops, e.g., "to right" or Var *)
-
 type radial_shape = Circle | Ellipse | Var of radial_shape var
 
 type radial_size =
@@ -2526,6 +2507,32 @@ type conic_gradient_config = {
   interpolation : color_interpolation option;
       (** Optional [in <color-interpolation-method>] clause. *)
 }
+
+type gradient_position =
+  | Linear_position of gradient_direction
+  | Radial_position of radial_gradient_config
+  | Conic_position of conic_gradient_config
+  | Var of gradient_position var
+
+type gradient_stop =
+  | Color_percentage of
+      color * length_percentage option * length_percentage option
+    (* Color with optional length-percentage position *)
+  | Color_length of
+      color
+      * length option
+      * length option (* Color with optional length position *)
+  | Length of length (* Interpolation hint with length, e.g., "50px" *)
+  | Channel of channel
+      (** Residual numeric channel token from custom-property substitution. *)
+  | List of
+      gradient_stop list (* Multiple gradient stops - used for var fallbacks *)
+  | Percentage of
+      percentage (* Interpolation hint with percentage, e.g., "50%" *)
+  | Position of gradient_position
+  | Direction of gradient_direction
+  | Var of gradient_stop var
+(* Gradient direction for stops, e.g., "to right" or Var *)
 
 module Webkit_gradient = struct
   type point = Left_top | Left_bottom | Center | Position of position_value
@@ -4197,6 +4204,7 @@ type _ kind =
   | Content : content kind
   | Gradient_stop : gradient_stop kind
   | Gradient_direction : gradient_direction kind
+  | Gradient_position : gradient_position kind
   | Animation : animation kind
   | Timing_function : timing_function kind
   | Transform : transform kind

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -663,6 +663,17 @@ let vars_of_color_interpolation (value : Properties.color_interpolation) :
     any_var list =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_position_value (value : Properties.position_value) : any_var list =
+  match value with
+  | Var v -> [ V v ]
+  | Single l -> vars_of_length l
+  | XY (l1, l2) -> vars_of_length l1 @ vars_of_length l2
+  | Edge_offset_axis (_, lp, _) -> vars_of_length_percentage lp
+  | Axis_edge_offset (_, _, length) -> vars_of_length length
+  | Edge_offset_edge_offset (_, lp1, _, lp2) ->
+      vars_of_length_percentage lp1 @ vars_of_length_percentage lp2
+  | _ -> []
+
 let rec vars_of_gradient_direction (value : Properties.gradient_direction) :
     any_var list =
   match value with
@@ -672,6 +683,38 @@ let rec vars_of_gradient_direction (value : Properties.gradient_direction) :
       @ vars_of_color_interpolation interpolation
   | Var v -> [ V v ]
   | _ -> []
+
+let vars_of_radial_shape (value : Properties.radial_shape) : any_var list =
+  match value with Var v -> [ V v ] | _ -> []
+
+let vars_of_radial_size (value : Properties.radial_size) : any_var list =
+  match value with
+  | Circle_radius length -> vars_of_length length
+  | Ellipse_radii (lp1, lp2) ->
+      vars_of_length_percentage lp1 @ vars_of_length_percentage lp2
+  | Var v -> [ V v ]
+  | _ -> []
+
+let vars_of_radial_gradient_config (value : Properties.radial_gradient_config) :
+    any_var list =
+  Option.fold ~none:[] ~some:vars_of_radial_shape value.shape
+  @ Option.fold ~none:[] ~some:vars_of_radial_size value.size
+  @ Option.fold ~none:[] ~some:vars_of_position_value value.position
+  @ Option.fold ~none:[] ~some:vars_of_color_interpolation value.interpolation
+
+let vars_of_conic_gradient_config (value : Properties.conic_gradient_config) :
+    any_var list =
+  Option.fold ~none:[] ~some:vars_of_angle value.angle
+  @ Option.fold ~none:[] ~some:vars_of_position_value value.position
+  @ Option.fold ~none:[] ~some:vars_of_color_interpolation value.interpolation
+
+let vars_of_gradient_position (value : Properties.gradient_position) :
+    any_var list =
+  match value with
+  | Linear_position direction -> vars_of_gradient_direction direction
+  | Radial_position config -> vars_of_radial_gradient_config config
+  | Conic_position config -> vars_of_conic_gradient_config config
+  | Var v -> [ V v ]
 
 let rec vars_of_gradient_stop (value : Properties.gradient_stop) : any_var list
     =
@@ -689,6 +732,7 @@ let rec vars_of_gradient_stop (value : Properties.gradient_stop) : any_var list
   | Channel channel -> vars_of_channel channel
   | Percentage percentage -> vars_of_percentage percentage
   | List stops -> List.concat_map vars_of_gradient_stop stops
+  | Position position -> vars_of_gradient_position position
   | Direction direction -> vars_of_gradient_direction direction
 
 let vars_of_background_image (value : Properties.background_image) :
@@ -824,17 +868,6 @@ let vars_of_list_style_image (value : Properties.list_style_image) :
 let vars_of_list_style_type (value : Properties.list_style_type) : any_var list
     =
   match value with Var v -> [ V v ] | _ -> []
-
-let vars_of_position_value (value : Properties.position_value) : any_var list =
-  match value with
-  | Var v -> [ V v ]
-  | Single l -> vars_of_length l
-  | XY (l1, l2) -> vars_of_length l1 @ vars_of_length l2
-  | Edge_offset_axis (_, lp, _) -> vars_of_length_percentage lp
-  | Axis_edge_offset (_, _, length) -> vars_of_length length
-  | Edge_offset_edge_offset (_, lp1, _, lp2) ->
-      vars_of_length_percentage lp1 @ vars_of_length_percentage lp2
-  | _ -> []
 
 let vars_of_outline_style (value : Properties.outline_style) : any_var list =
   match value with Var v -> [ V v ] | _ -> []

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -413,6 +413,10 @@ let check_gradient_direction =
   check_value_cursor "gradient-direction" read_gradient_direction
     pp_gradient_direction
 
+let check_gradient_position =
+  check_value_cursor "gradient-position" read_gradient_position
+    pp_gradient_position
+
 let check_gradient_stop =
   check_value_cursor "gradient-stop" read_gradient_stop pp_gradient_stop
 
@@ -2266,6 +2270,21 @@ let test_gradient_direction () =
   optimizes ~into:"270deg" "to left";
   neg_cursor read_gradient_direction "invalid-direction"
 
+(* CSS Images 4 sections 6.1-6.3: the gradient prelude is a linear direction, a
+   radial shape/size/position, or a conic angle/position; a typed custom
+   property holding a gradient prelude accepts any of the three. *)
+let test_gradient_position () =
+  check_gradient_position "to right";
+  check_gradient_position "45deg";
+  check_gradient_position "to right in oklab";
+  check_gradient_position "circle at center";
+  check_gradient_position "closest-side";
+  check_gradient_position "at center";
+  check_gradient_position "from 45deg";
+  check_gradient_position "from 90deg at left top";
+  check_gradient_position "var(--gradient-position)";
+  neg_cursor read_gradient_position "invalid-position"
+
 let test_gradient_stop () =
   (* Basic color stops *)
   check_gradient_stop "red";
@@ -3771,6 +3790,7 @@ let tests =
     test_case "transform" `Quick test_transform;
     test_case "transforms" `Quick test_transforms;
     test_case "gradient direction" `Quick test_gradient_direction;
+    test_case "gradient position" `Quick test_gradient_position;
     test_case "gradient stop" `Quick test_gradient_stop;
     test_case "color interpolation" `Quick test_color_interpolation;
     test_case "overscroll-behavior" `Quick test_overscroll_behavior;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2371,9 +2371,11 @@ let test_background_image () =
     "linear-gradient(in oklab to right, red, blue)";
   check_background_image ~expected:"radial-gradient(in oklab,red,blue)"
     "radial-gradient(in oklab, red, blue)";
-  check_background_image ~expected:"radial-gradient(in oklab circle,red,blue)"
+  check_background_image
+    ~expected:"radial-gradient(in oklab circle at center,red,blue)"
     "radial-gradient(in oklab circle at center, red, blue)";
-  check_background_image ~expected:"radial-gradient(in oklab circle,red,blue)"
+  check_background_image
+    ~expected:"radial-gradient(in oklab circle at center,red,blue)"
     "radial-gradient(circle at center in oklab, red, blue)";
   decl_optimizes ~prop:"background-image"
     ~into:"radial-gradient(in oklab,red,#00f)"
@@ -2425,10 +2427,20 @@ let test_radial_size () =
 
 let test_radial_gradient_config () =
   check_radial_gradient_config "circle";
-  check_radial_gradient_config ~expected:"" "ellipse";
+  check_radial_gradient_config "ellipse";
   check_radial_gradient_config "circle closest-side";
-  check_radial_gradient_config ~expected:"circle" "circle at center";
-  neg_cursor read_radial_gradient_config "invalid-config"
+  check_radial_gradient_config "circle at center";
+  neg_cursor read_radial_gradient_config "invalid-config";
+  (* pp holds the authored defaults; the optimizer elides them (CSS Images 4
+     section 3.1: ellipse / farthest-corner / center are implied). *)
+  decl_optimizes ~prop:"background"
+    ~held:"radial-gradient(circle at center,red,#123456)"
+    ~into:"radial-gradient(circle,red,#123456)"
+    "radial-gradient(circle at center, red, #123456)";
+  decl_optimizes ~prop:"background"
+    ~held:"radial-gradient(ellipse farthest-corner,red,#123456)"
+    ~into:"radial-gradient(red,#123456)"
+    "radial-gradient(ellipse farthest-corner, red, #123456)"
 
 let test_conic_gradient_config () =
   check_conic_gradient_config "from 45deg";


### PR DESCRIPTION
A gradient prelude (`circle at center`, `from 45deg`, `to right in oklab`) is a value in its own right once it lives in a typed custom property, but only the linear direction had a type. `gradient_position` types the three prelude forms as one value, a `Position` arm on `gradient_stop` carries it through `var()` fallbacks, and `read_gradient_position` shares the direction-plus-interpolation prelude reader with `linear-gradient()`.

Commit 1f160b1 first moves the radial default elision (shape `ellipse`, size `farthest-corner`, position `center`) out of minified pp and into `normalize_radial_config`, per the pp purity policy: pp serialises the AST faithfully and the minify+optimize output is unchanged. Commit 46d6b9f adds the type, readers, printers, and variable collection.