### PR TITLE
parser: never delete a separator inside custom-property values

### DIFF
--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -444,17 +444,6 @@ let word_like_end : Component.t -> bool = function
   | Block { node = { opening = Paren; _ }; _ } -> true
   | Block _ -> false
 
-(* A [Func] or Paren [Block] on the left ends in [)] which closes its token
-   cleanly; the boundary kept by [word_like_end] exists for the following
-   ident-like token (CSS Color 4 sec. 11.1 relative colour channels). When the
-   right side is itself a [Func] or Paren [Block], no grammar needs the
-   separator and [)var(] re-tokenises identically, so the pair elides. *)
-let paren_shaped : Component.t -> bool = function
-  | Func _ | Block { node = { opening = Paren; _ }; _ } -> true
-  | _ -> false
-
-let elidable_paren_pair p next = paren_shaped p && paren_shaped next
-
 let word_like_start : Component.t -> bool = function
   | Preserved
       {
@@ -584,7 +573,6 @@ and cvs_to_buffer_min buf cvs =
            && word_like_end p
            && (not (is_backslash_delim p))
            && word_like_start next
-           && not (elidable_paren_pair p next)
   in
   let rec loop prev separated = function
     | [] -> ()
@@ -657,6 +645,10 @@ let rec drop_whitespace_components = function
   | cv :: rest when is_whitespace cv -> drop_whitespace_components rest
   | other -> other
 
+let custom_min_is_math_delim = function
+  | Component.Preserved { kind = Token.Delim ("*" | "/"); _ } -> true
+  | _ -> false
+
 let custom_min_is_bang = function
   | Component.Preserved { kind = Token.Delim "!"; _ } -> true
   | _ -> false
@@ -684,18 +676,18 @@ let custom_min_word_boundary p next =
   && word_like_end p
   && (not (is_backslash_delim p))
   && word_like_start next
-  && not (elidable_paren_pair p next)
 
-(* CSS Values 4 sec. 10.1 requires whitespace only around [+] and [-] in math
-   expressions, since those can otherwise fuse into a signed-number token. [*]
-   and [/] are unambiguous, so [16/9] is a valid two-number/divide token
-   sequence and dropping whitespace around them is sound everywhere a custom
-   property is substituted, including [calc()]. *)
+(* A whitespace token in a custom-property value is part of the stream a var()
+   substitution receives, so an authored separator around [*] and [/] is
+   collapsed to one space, never deleted: [16 / 9] and [16/9] are different
+   token streams even though both parse in [calc()]. *)
 let custom_min_needs_separator prev next rest =
   match prev with
   | None -> false
   | Some p ->
       pair_forms_multichar_token p next
+      || custom_min_is_math_delim p
+      || custom_min_is_math_delim next
       || custom_min_bang_boundary prev next rest
       || custom_min_word_boundary p next
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3116,16 +3116,12 @@ let rec pp_gradient_stop : gradient_stop Pp.t =
       | None -> ()
       | Some pos1 -> (
           (* CSS Syntax 3 §4: ident- and hash-typed colours absorb the following
-             digit/hex into the same token ([red0%] -> ident [red0] + [%];
-             [#00f50%] -> hash [#00f50] + [%]), so the separator before the
-             position is mandatory. Function-shaped colours ([var(...)] /
-             [rgb(...)] / etc.) end with [)] which closes their token cleanly,
-             so the space is elidable in minified output. *)
-          let ends_with_paren =
-            String.length rendered_color > 0
-            && rendered_color.[String.length rendered_color - 1] = ')'
-          in
-          if not (Pp.minified ctx && ends_with_paren) then Pp.space ctx ();
+             digit/hex into the same token ([red0%] -> ident [red0] + [%]), so
+             the separator is mandatory there; and when the stop lives in a
+             custom-property token stream, the whitespace token between a
+             function-shaped colour and its position is part of the value a
+             var() substitution receives, so it is never elided either. *)
+          Pp.space ctx ();
           pp_length_percentage ~always:true ctx pos1;
           match pos2_opt with
           | None -> ()

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -343,8 +343,9 @@ val read_color : Cursor.t -> color
 
 val read_color_keyword_of_string : string -> color option
 (** [read_color_keyword_of_string s] is the color keyword named by the
-    lower-case ident [s]: a named color, [transparent], [currentcolor], [auto],
-    [inherit], or a system color. [None] when [s] names no color keyword. *)
+    lower-case ident [s]: a named color, {!val-transparent}, [currentcolor],
+    [auto], [inherit], or a system color. [None] when [s] names no color
+    keyword. *)
 
 val fold_custom_value_ident : string -> string
 (** [fold_custom_value_ident s] is the canonical lower-case spelling of [s] when

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -889,8 +889,10 @@ let custom_properties () =
   (* With var() references *)
   check_declaration ~expected:"--primary:var(--base-color)"
     "--primary: var(--base-color)";
-  check_declaration ~expected:"--size:calc(var(--base)*2)"
-    "--size: calc(var(--base) * 2)";
+  check_declaration ~expected:"--size:calc(var(--base) * 2)"
+    ~optimized:"--size:calc(var(--base)*2)" "--size: calc(var(--base) * 2)";
+  check_declaration ~expected:"--stops:var(--from) var(--from-position)"
+    "--stops: var(--from) var(--from-position)";
   check_declaration ~expected:"--fallback:var(--undefined,10px)"
     "--fallback: var(--undefined, 10px)";
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2290,7 +2290,7 @@ let test_gradient_stop () =
   check_gradient_stop "red";
   check_gradient_stop "blue 50%";
   check_gradient_stop ~expected:"#ff5733 25%" "#ff5733 25%";
-  check_gradient_stop ~expected:"rgb(255 0 0)10px" "rgb(255,0,0) 10px";
+  check_gradient_stop ~expected:"rgb(255 0 0) 10px" "rgb(255,0,0) 10px";
   decl_optimizes ~prop:"background-image" ~into:"linear-gradient(#00f 50%,red)"
     "linear-gradient(blue 50%,red)";
   decl_optimizes ~prop:"background-image" ~into:"linear-gradient(red 10px,#00f)"
@@ -2305,13 +2305,10 @@ let test_gradient_stop () =
 
   (* CSS variables in gradient stops *)
   check_gradient_stop "var(--tw-gradient-from)";
-  check_gradient_stop ~expected:"var(--color-blue-500)50%"
-    "var(--color-blue-500) 50%";
+  check_gradient_stop "var(--color-blue-500) 50%";
 
   (* Complex var with fallback *)
-  check_gradient_stop
-    ~expected:"var(--tw-gradient-from)var(--tw-gradient-from-position)"
-    "var(--tw-gradient-from) var(--tw-gradient-from-position)";
+  check_gradient_stop "var(--tw-gradient-from) var(--tw-gradient-from-position)";
 
   (* Multiple vars in sequence (as used in Tailwind gradients) *)
   check_gradient_stop ~expected:"var(--tw-gradient-position)"
@@ -2320,7 +2317,9 @@ let test_gradient_stop () =
   (* Nested var with complex fallback *)
   check_gradient_stop
     ~expected:
-      "var(--tw-gradient-via-stops,var(--tw-gradient-position),var(--tw-gradient-from)var(--tw-gradient-from-position),var(--tw-gradient-to)var(--tw-gradient-to-position))"
+      "var(--tw-gradient-via-stops,var(--tw-gradient-position),var(--tw-gradient-from) \
+       var(--tw-gradient-from-position),var(--tw-gradient-to) \
+       var(--tw-gradient-to-position))"
     "var(--tw-gradient-via-stops, var(--tw-gradient-position), \
      var(--tw-gradient-from) var(--tw-gradient-from-position), \
      var(--tw-gradient-to) var(--tw-gradient-to-position))";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5834,12 +5834,12 @@ let customprops13_box_shadow_zero_spread () =
 let customprops13_shortest_oklab_sign_boundaries () =
   Alcotest.(check string)
     "unregistered OKLab custom property keeps opaque token stream"
-    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034/.1)}"
+    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034 / .1)}"
     (normalize_minified
        ".prose { --tw-prose-kbd-shadows: oklab(21% -.003 -.034 / .1) }");
   Alcotest.(check string)
     "unregistered OKLab custom property preserves required token boundary"
-    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034/.1)}"
+    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034 / .1)}"
     (normalize_minified
        ".prose { --tw-prose-kbd-shadows: oklab(21% -.003-.034 / .1) }");
   Alcotest.(check string)


### PR DESCRIPTION
A whitespace token in a custom-property value is part of the stream a var() substitution receives, so the lexical minifier may collapse a run to one space but never delete the separator. pp's minified mode was deleting them: around [*] and [/] in math (`calc(var(--base) * 2)` became `calc(var(--base)*2)` before the optimizer even ran), between adjacent var() calls in gradient stop fallbacks, and between a function-shaped colour and its stop position.

The fix is confined to the serializer layer. Folding the insignificant math-argument whitespace (CSS Values 4 section 10.1, everything except around [+] and [-]) remains an optimizer transform, so `--minify` canonical output and the semantic diff still equate `calc(1 / 2 * 100%)` with `calc(1/2*100%)`; the spec tests assert the held and optimized forms side by side.

Commit 6f367c3 adds the spec tests; commit 0d5618e fixes the serializers.