### PR TITLE
scripts: resolve the cascade root without project_root

### DIFF
--- a/scripts/check_api_consistency.ml
+++ b/scripts/check_api_consistency.ml
@@ -436,18 +436,11 @@ let print_module_results
       (List.sort compare missing_neg) (fun n ->
         print_string ("  test_" ^ n ^ "\n")))
 
-(* Project root detected by looking for dune-project file. *)
-let project_root () =
-  let rec search dir =
-    if Sys.file_exists (dir // "dune-project") then dir
-    else
-      let parent = Filename.dirname dir in
-      if parent = dir then
-        failwith "Could not find project root (no dune-project file found)"
-      else search parent
-  in
-  search (Sys.getcwd ())
-
+(* The script lives in <root>/scripts inside the build tree, so the enclosing
+   cascade root is one directory up from the executable. Walking up from the cwd
+   to the nearest dune-project breaks when cascade is vendored inside another
+   dune workspace. *)
+let project_root () = Filename.dirname (Filename.dirname Sys.executable_name)
 let root = project_root ()
 let lib_dir = root // "lib"
 let test_dir = root // "test"

--- a/scripts/check_properties.ml
+++ b/scripts/check_properties.ml
@@ -91,15 +91,11 @@ let extract_handled_properties content =
   extract_from_string region
 
 let () =
-  (* Try to find the project root *)
-  let rec find_project_root dir =
-    if Sys.file_exists (Filename.concat dir "dune-project") then dir
-    else
-      let parent = Filename.dirname dir in
-      if parent = dir then "." else find_project_root parent
-  in
-
-  let project_root = find_project_root (Sys.getcwd ()) in
+  (* The script lives in <root>/scripts inside the build tree, so the enclosing
+     cascade root is one directory up from the executable. Walking up from the
+     cwd to the nearest dune-project breaks when cascade is vendored inside
+     another dune workspace. *)
+  let project_root = Filename.dirname (Filename.dirname Sys.executable_name) in
   let intf_file = Filename.concat project_root "lib/properties_intf.ml" in
   let impl_file = Filename.concat project_root "lib/properties.ml" in
 

--- a/scripts/dune
+++ b/scripts/dune
@@ -5,8 +5,8 @@
 (rule
  (alias runtest)
  (deps
-  (:properties %{project_root}/lib/properties.ml)
-  (:properties_intf %{project_root}/lib/properties_intf.ml)
+  (:properties ../lib/properties.ml)
+  (:properties_intf ../lib/properties_intf.ml)
   (:script check_properties.exe))
  (action
   (run %{script})))
@@ -17,9 +17,9 @@
 (rule
  (alias runtest)
  (deps
-  (glob_files %{project_root}/lib/*_intf.ml)
-  (glob_files %{project_root}/lib/*.mli)
-  (glob_files %{project_root}/test/test_*.ml)
+  (glob_files ../lib/*_intf.ml)
+  (glob_files ../lib/*.mli)
+  (glob_files ../test/test_*.ml)
   (:script check_api_consistency.exe))
  (action
   (run %{script})))


### PR DESCRIPTION
dune expands `%{project_root}` to the enclosing workspace when cascade is vendored inside another dune project, so `dune test cascade` from a host workspace failed to resolve `lib/properties_intf.ml`, and the checker scripts walked up from the cwd to the host's dune-project. The runtest rules now use paths relative to `scripts/` and the scripts derive the root from their own executable path, which is correct both standalone and vendored.