### PR TITLE
optimize: fold bare mul and div whitespace in custom values

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20467,6 +20467,29 @@ let strip_math_whitespace comps =
   in
   aux [] comps
 
+let is_mul_or_div_delim = function
+  | Component.Preserved { kind = Token.Delim ("*" | "/"); _ } -> true
+  | _ -> false
+
+(* Outside a math function only the whitespace adjacent to a [*] or [/] delim is
+   insignificant (CSS Values 4 sec. 10.1): [16 / 9] and [16/9] re-tokenise
+   identically wherever the stream is substituted. Every other separator stays
+   (a whitespace token between two values is part of the stream). *)
+let strip_mul_div_whitespace comps =
+  let rec aux acc = function
+    | [] -> List.rev acc
+    | (Component.Preserved { kind = Token.Whitespace; _ } as ws) :: rest ->
+        let prev_md =
+          match acc with [] -> false | p :: _ -> is_mul_or_div_delim p
+        in
+        let next_md =
+          match rest with [] -> false | n :: _ -> is_mul_or_div_delim n
+        in
+        if prev_md || next_md then aux acc rest else aux (ws :: acc) rest
+    | other :: rest -> aux (other :: acc) rest
+  in
+  aux [] comps
+
 (* [in_math] tracks whether the current component list is inside a math
    function's grammar. It enters at the args of a [calc()] / [min()] / ... call,
    propagates through grouping parens ([Block]s) since those are math operands,
@@ -20495,7 +20518,8 @@ let rec canonicalize_math_whitespace_components ?(in_math = false) comps =
         | Component.Preserved _ -> c)
       comps
   in
-  if in_math then strip_math_whitespace comps' else comps'
+  if in_math then strip_math_whitespace comps'
+  else strip_mul_div_whitespace comps'
 
 (* AST-level value normaliser: applies semantic (equivalence) canonicalisation
    so the optimizer holds a canonical AST and [pp] stays a pure serialiser. Add

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -284,6 +284,17 @@ let canonical_top_level_selector_list_permutation_equal () =
    comparison normalizes it - including inside custom-property values, where the
    calc body is otherwise round-tripped verbatim. *)
 
+let canonical_bare_ratio_whitespace_equal () =
+  (* The motivating cross-tool case: Tailwind authors [--aspect-video: 16 / 9]
+     while a typed ratio serialises as [16/9]; the whitespace around [/] is
+     insignificant wherever the stream is substituted, so canonical comparison
+     folds it even outside a math function. *)
+  let expected = ".x{--aspect-video: 16 / 9}" in
+  let actual = ".x{--aspect-video:16/9}" in
+  Alcotest.(check bool)
+    "bare ratio whitespace around / canonicalizes equal" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
+
 let canonical_calc_mul_div_whitespace_equal () =
   let expected = ".x{--v:calc(1 / 2 * 100%)}" in
   let actual = ".x{--v:calc(1/2*100%)}" in
@@ -824,6 +835,8 @@ let suite =
         canonical_nested_where_is_permutation_equal;
       Alcotest.test_case "canonical top-level selector list permutation" `Quick
         canonical_top_level_selector_list_permutation_equal;
+      Alcotest.test_case "canonical bare ratio whitespace" `Quick
+        canonical_bare_ratio_whitespace_equal;
       Alcotest.test_case "canonical calc *,/ whitespace" `Quick
         canonical_calc_mul_div_whitespace_equal;
       Alcotest.test_case "canonical calc paren whitespace" `Quick

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -891,6 +891,8 @@ let custom_properties () =
     "--primary: var(--base-color)";
   check_declaration ~expected:"--size:calc(var(--base) * 2)"
     ~optimized:"--size:calc(var(--base)*2)" "--size: calc(var(--base) * 2)";
+  check_declaration ~expected:"--aspect-video:16 / 9"
+    ~optimized:"--aspect-video:16/9" "--aspect-video: 16 / 9";
   check_declaration ~expected:"--stops:var(--from) var(--from-position)"
     "--stops: var(--from) var(--from-position)";
   check_declaration ~expected:"--fallback:var(--undefined,10px)"

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5834,12 +5834,12 @@ let customprops13_box_shadow_zero_spread () =
 let customprops13_shortest_oklab_sign_boundaries () =
   Alcotest.(check string)
     "unregistered OKLab custom property keeps opaque token stream"
-    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034 / .1)}"
+    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034/.1)}"
     (normalize_minified
        ".prose { --tw-prose-kbd-shadows: oklab(21% -.003 -.034 / .1) }");
   Alcotest.(check string)
     "unregistered OKLab custom property preserves required token boundary"
-    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034 / .1)}"
+    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034/.1)}"
     (normalize_minified
        ".prose { --tw-prose-kbd-shadows: oklab(21% -.003-.034 / .1) }");
   Alcotest.(check string)


### PR DESCRIPTION
The canonical fold only stripped whitespace inside math function arguments, so `--aspect-video: 16 / 9` (an authored token stream) and a typed ratio's `16/9` serialised differently and the semantic diff reported a phantom change. Whitespace adjacent to `*` and `/` re-tokenises identically wherever the stream is substituted (CSS Values 4 section 10.1), so the optimizer now folds it at any nesting level. Every other separator still survives, and the held pp form keeps the authored bytes.

Commit 6becadd adds the spec tests; commit 592e908 extends the fold.