### PR TITLE
properties: stop scroll-snap-align at the end of the value

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -14529,17 +14529,17 @@ let rec read_scroll_snap_align (t : Cursor.t) : scroll_snap_align =
       t
   in
   let first = read_single t in
-  Cursor.ws t;
-  if Cursor.is_done t then first
-  else (
-    (match first with
-    | Inherit | Initial | Unset | Revert | Revert_layer ->
-        Cursor.err_invalid t "scroll-snap-align CSS-wide value in pair"
-    | _ -> ());
-    let second = read_single t in
-    Cursor.ws t;
-    Cursor.expect_eof t;
-    Snap_align_pair (first, second))
+  (* The optional second keyword is probed with backtracking so the reader stops
+     cleanly at whatever follows the value (the declaration's [;], a block
+     close, ...). *)
+  match Cursor.option read_single t with
+  | Option.None -> first
+  | Option.Some second ->
+      (match first with
+      | Inherit | Initial | Unset | Revert | Revert_layer ->
+          Cursor.err_invalid t "scroll-snap-align CSS-wide value in pair"
+      | _ -> ());
+      Snap_align_pair (first, second)
 
 let rec read_timeline_axis t : timeline_axis =
   Cursor.enum_or_var "timeline-axis"

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5739,6 +5739,19 @@ let normalize_minified css =
    declarations as opaque token streams. CSS Properties and Values API 1 section
    2 lifts a custom property into a typed value only after an @property
    registration for that name. *)
+(* CSS Scroll Snap 1 section 6.2: [scroll-snap-align] takes one or two
+   keywords; the reader must stop at the end of the value, not consume the
+   declaration's trailing semicolon as a missing second keyword. *)
+let scroll_snap_align_trailing_semicolon () =
+  Alcotest.(check string)
+    "scroll-snap-align value followed by a semicolon parses"
+    ".x{scroll-snap-align:none}"
+    (normalize_minified ".x { scroll-snap-align: none; }");
+  Alcotest.(check string)
+    "scroll-snap-align pair followed by a semicolon parses"
+    ".x{scroll-snap-align:start end}"
+    (normalize_minified ".x { scroll-snap-align: start end; }")
+
 let customprops13_unregistered_font_stack () =
   Alcotest.(check string)
     "unregistered font-stack custom property keeps string tokens"
@@ -6663,6 +6676,9 @@ let additional_tests =
     ( "spec custom-properties 1 3 custom property declaration",
       `Quick,
       customprops13_declaration );
+    ( "spec scroll-snap 6.2 trailing semicolon",
+      `Quick,
+      scroll_snap_align_trailing_semicolon );
     ( "spec custom-properties 1 3 colour keyword case fold",
       `Quick,
       customprops13_color_keyword_case_fold );


### PR DESCRIPTION
`read_scroll_snap_align` treated any leftover component after the first keyword as a mandatory second keyword, so `scroll-snap-align: none;` (with the declaration's trailing semicolon still in the value cursor) raised and the declaration was parse-dropped — Tailwind's snap utilities then showed up as phantom additions in the diff. The optional second keyword is now probed with backtracking, like the other two-keyword readers.

Commit f0a463b adds the spec test; commit 77e0e0d fixes the reader.