### PR TITLE
pp: indent at-rule block bodies like style rule bodies

### DIFF
--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -436,15 +436,29 @@ let semicolon_cut ctx () =
   semicolon ctx ();
   cut ctx ()
 
-let braced_list ?sep pp_item ctx items =
+(* [braces] indents the body's first line and emits the cuts around the braces
+   itself, so the body prints the first item bare, re-indents every item after a
+   separator's cut, and adds no leading or trailing cut. *)
+let braced_items ?sep ?(trailing = nop) pp_item ctx items =
   braces
     (fun ctx () ->
-      cut ctx ();
-      nest 2 (list ?sep pp_item) ctx items;
-      cut ctx ())
+      match items with
+      | [] -> ()
+      | first :: rest ->
+          pp_item ctx first;
+          List.iter
+            (fun item ->
+              (match sep with Some s -> s ctx () | None -> ());
+              indent pp_item ctx item)
+            rest;
+          trailing ctx ())
     ctx ()
 
-let braced_semicolon_list pp_item = braced_list ~sep:semicolon_cut pp_item
+let braced_list ?sep pp_item ctx items = braced_items ?sep pp_item ctx items
+let semicolon_if_pretty ctx () = if not ctx.minify then semicolon ctx ()
+
+let braced_semicolon_list pp_item =
+  braced_items ~sep:semicolon_cut ~trailing:semicolon_if_pretty pp_item
 
 let call name pp_args ctx args =
   string ctx name;

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -293,12 +293,14 @@ val semicolon_cut : unit t
 (** [semicolon_cut] outputs a semicolon followed by a layout cut. *)
 
 val braced_list : ?sep:unit t -> 'a t -> 'a list t
-(** [braced_list formatter] wraps a list in braces using the same multiline
-    layout as CSS at-rule bodies. *)
+(** [braced_list formatter] wraps a list in braces with one item per line at one
+    indent level deeper and the closing brace back at the parent's indentation.
+*)
 
 val braced_semicolon_list : 'a t -> 'a list t
-(** [braced_semicolon_list formatter] wraps a list in braces and separates items
-    with {!val-semicolon_cut}. *)
+(** [braced_semicolon_list formatter] is {!val-braced_list} with items separated
+    by {!val-semicolon_cut} and, in pretty output, a trailing semicolon after
+    the last item, matching style rule bodies. *)
 
 val call : string -> 'a t -> 'a t
 (** [call name args] formats a function call: [name( args )]. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -263,9 +263,12 @@ let pp_property_rule : 'a property_rule Pp.t =
   let pp_initial_value ctx v =
     Pp.semicolon ctx ();
     Pp.cut ctx ();
-    Pp.string ctx "initial-value:";
-    Pp.space_if_pretty ctx ();
-    Variables.pp_value syntax ctx v
+    Pp.indent
+      (fun ctx () ->
+        Pp.string ctx "initial-value:";
+        Pp.space_if_pretty ctx ();
+        Variables.pp_value syntax ctx v)
+      ctx ()
   in
   let pp_initial_value_opt ctx =
     if Pp.minified ctx && is_empty_universal_initial syntax initial_value then
@@ -278,20 +281,19 @@ let pp_property_rule : 'a property_rule Pp.t =
   Pp.sp ctx ();
   Pp.braces
     (fun ctx () ->
+      Pp.string ctx "syntax:";
+      Pp.space_if_pretty ctx ();
+      Variables.pp_syntax ctx syntax;
+      Pp.string ctx ";";
       Pp.cut ctx ();
-      Pp.nest 2
+      Pp.indent
         (fun ctx () ->
-          Pp.string ctx "syntax:";
-          Pp.space_if_pretty ctx ();
-          Variables.pp_syntax ctx syntax;
-          Pp.string ctx ";";
-          Pp.cut ctx ();
           Pp.string ctx "inherits:";
           Pp.space_if_pretty ctx ();
-          Pp.string ctx (if inherits then "true" else "false");
-          pp_initial_value_opt ctx)
+          Pp.string ctx (if inherits then "true" else "false"))
         ctx ();
-      Pp.cut ctx ())
+      pp_initial_value_opt ctx;
+      if not ctx.Pp.minify then Pp.semicolon ctx ())
     ctx ()
 
 (* CSS Animations 1 §3 [<keyframes-name>] is [<custom-ident> | <string>]. The
@@ -347,7 +349,9 @@ let pp_keyframes_block_statement ctx header name frames =
   Pp.string ctx header;
   pp_keyframes_name ctx name;
   Pp.sp ctx ();
-  Pp.braced_list ~sep:Pp.cut pp_keyframe ctx frames
+  (* Sibling frame blocks separate with a blank line, like statements in any
+     other block (see [pp_block]). *)
+  Pp.braced_list ~sep:Pp.(cut ++ cut) pp_keyframe ctx frames
 
 let pp_page_pseudo ctx p =
   Pp.char ctx ':';
@@ -383,17 +387,22 @@ let pp_page_margin_rule : page_margin_rule Pp.t =
 let pp_page_with_margins_body ctx descriptors margins =
   Pp.braces
     (fun ctx () ->
-      Pp.cut ctx ();
-      Pp.nest 2
-        (fun ctx () ->
-          Pp.list ~sep:Pp.semicolon_cut Declaration.pp_declaration ctx
-            descriptors;
-          if descriptors <> [] && margins <> [] then (
-            Pp.semicolon ctx ();
-            Pp.cut ctx ());
-          Pp.list ~sep:Pp.cut pp_page_margin_rule ctx margins)
-        ctx ();
-      Pp.cut ctx ())
+      Pp.list ~sep:Pp.semicolon_cut
+        (fun ctx (i, d) ->
+          if i = 0 then Declaration.pp_declaration ctx d
+          else Pp.indent Declaration.pp_declaration ctx d)
+        ctx
+        (List.mapi (fun i d -> (i, d)) descriptors);
+      if descriptors <> [] && margins <> [] then (
+        Pp.semicolon ctx ();
+        Pp.cut ctx ())
+      else if descriptors <> [] && not ctx.Pp.minify then Pp.semicolon ctx ();
+      Pp.list ~sep:Pp.cut
+        (fun ctx (i, m) ->
+          if i = 0 && descriptors = [] then pp_page_margin_rule ctx m
+          else Pp.indent pp_page_margin_rule ctx m)
+        ctx
+        (List.mapi (fun i m -> (i, m)) margins))
     ctx ()
 
 let pp_scope_selector ctx s = Selector.pp ctx s
@@ -1229,7 +1238,9 @@ and pp_statement : statement Pp.t =
       Pp.string ctx "@font-feature-values ";
       Pp.list ~sep:Pp.comma Properties.pp_font_family ctx families;
       Pp.sp ctx ();
-      Pp.braced_list ~sep:Pp.cut pp_font_feature_values_block ctx blocks
+      Pp.braced_list
+        ~sep:Pp.(cut ++ cut)
+        pp_font_feature_values_block ctx blocks
   | View_transition descriptors ->
       Pp.string ctx "@view-transition";
       Pp.sp ctx ();

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -3666,6 +3666,47 @@ let pretty_preserves css fragments =
 (* CSS Color 4 section 12.1 + cascade convention: authored hex colours decode to
    sRGB bytes but keep their source spelling for pretty-printing, while
    minify+optimize emits the shorter equivalent spelling. *)
+(* The pretty printer formats every braced at-rule body with the same line
+   discipline as a style rule body: one declaration per line at one indent
+   level deeper, a trailing semicolon on the last declaration, and the closing
+   brace back at the parent's indentation. Sibling blocks inside @keyframes
+   are separated by a blank line, like statements in any other block. The
+   oracle is Tailwind's authored output format (e.g. the @keyframes bounce
+   block in tailwindcss theme.css). *)
+let pretty_at_rule_block_bodies () =
+  let pretty css =
+    match Css.of_string ~strict:false css with
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+    | Ok parsed -> Css.to_string parsed.stylesheet |> String.trim
+  in
+  Alcotest.(check string)
+    "@property body formats like a rule body"
+    "@property --x {\n\
+    \  syntax: \"<length>\";\n\
+    \  inherits: true;\n\
+    \  initial-value: 0px;\n\
+     }"
+    (pretty
+       "@property --x { syntax: \"<length>\"; inherits: true; initial-value: \
+        0px }");
+  Alcotest.(check string)
+    "@font-face body formats like a rule body"
+    "@font-face {\n  font-family: MyFont;\n  src: url(font.woff2);\n}"
+    (pretty "@font-face { font-family: MyFont; src: url(font.woff2) }");
+  Alcotest.(check string)
+    "@keyframes frames format like sibling blocks"
+    "@keyframes spin {\n\
+    \  from {\n\
+    \    transform: rotate(0deg);\n\
+    \  }\n\n\
+    \  to {\n\
+    \    transform: rotate(360deg);\n\
+    \  }\n\
+     }"
+    (pretty
+       "@keyframes spin { from { transform: rotate(0deg) } to { transform: \
+        rotate(360deg) } }")
+
 let fidelity_hex_form_preserved () =
   pretty_preserves ".x { color: #ff0000 }" [ "#ff0000" ];
   pretty_preserves ".x { color: #f00 }" [ "#f00" ];
@@ -6774,6 +6815,7 @@ let additional_tests =
       `Quick,
       bg336_bgpos_collapse );
     (* Non-minified fidelity: pretty printer preserves the source spelling. *)
+    ("pretty at-rule block bodies", `Quick, pretty_at_rule_block_bodies);
     ("fidelity hex form preserved", `Quick, fidelity_hex_form_preserved);
     ("fidelity color form preserved", `Quick, fidelity_color_form_preserved);
     ( "fidelity keyframe selector preserved",


### PR DESCRIPTION
`Pp.braced_list` emitted a leading cut after `braces` had already indented the first line, separated items with bare cuts that nothing re-indented, and doubled the closing cut, so `@property`, `@font-face`, `@keyframes`, `@page`, and the other braced at-rule bodies pretty-printed flush left with stray blank lines:

```
@property --tw-scale-z {
  
syntax: "*";
inherits: false;
initial-value: 1

}
```

The body now prints the first item bare (its indentation comes from `braces`) and re-indents each item after its separator, with a trailing semicolon in pretty output to match style rule bodies; `@keyframes` frames separate with a blank line like sibling statements in any other block, matching Tailwind's authored format. Minified output is byte-identical, so the optimizer oracles and interop size gates are unaffected.

Commit 75d5718 adds the spec test; commit b3af839 fixes the printer.