### PR TITLE
selector: keep :is() wrapper around a complex single argument

### DIFF
--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2159,11 +2159,20 @@ and pp : t Pp.t =
   | Cue selectors -> elem_func ctx "cue" sels selectors
   | Cue_region selectors -> elem_func ctx "cue-region" sels selectors
   (* Functional pseudo-classes *)
-  | Is [ single ] when Pp.minified ctx ->
+  | Is [ single ]
+    when Pp.minified ctx
+         &&
+         match single with
+         | Combined _ | Relative _ | List _ -> false
+         | _ -> true ->
       (* CSS Selectors 4 17: a single-argument [:is(s)] matches the same
          elements as [s] with the same specificity. The forgiving list drops
          invalid arguments so a [:is(:future-pseudo, .a)] also reduces here,
-         which the spec test asserts. *)
+         which the spec test asserts. The reduction is sound only when [s] is a
+         single compound: when [s] carries a combinator ([Combined] /
+         [Relative], or a [List]) the [:is()] is a grouping boundary, and
+         splicing the argument into the surrounding compound would re-anchor the
+         combinator and change the match set. *)
       pp ctx single
   | Is selectors
     when Pp.minified ctx && List.sort compare selectors = [ Link; Visited ] ->

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -1298,6 +1298,15 @@ let test_spec_forgiving_selector_lists () =
   check_minified_to ":where()" ":where(,)";
   check_minified_to ":is()" ":is(:future-pseudo,::before)";
   check_minified_to ":where()" ":where(:future-pseudo,::before)";
+  (* A single-argument [:is(s)] only unwraps when [s] is itself a single
+     compound. When [s] contains a combinator the [:is()] is a grouping
+     boundary: splicing its argument into the surrounding compound would
+     re-anchor the combinator and change the match set, so the wrapper stays.
+     [.a:is(.b .c)] must NOT become [.a.b .c]. *)
+  check_minified_to ".a:is(.b .c)" ".a:is(.b .c)";
+  check_minified_to "div:is(.b>.c)" "div:is(.b > .c)";
+  check_minified_to ".flex:is(:where(.group):focus *)"
+    ".flex:is(:where(.group):focus *)";
   check ":not(.a,#b)";
   neg_cursor read ".a,:future-pseudo";
   neg_cursor read ":not(.a,:future-pseudo)";


### PR DESCRIPTION
The minifier reduced every single-argument `:is(s)` to bare `s`, but that equivalence only holds when `s` is a single compound. When `s` carries a combinator, the `:is()` is a grouping boundary: `.a:is(.b .c)` minified to `.a.b .c` (a descendant of `.a`, a different match set), and group-/peer-variant selectors like `.flex:is(:where(.group):focus *)` lost the universal that anchored the descendant combinator, splicing into `.flex:where(.group):focus *`.

The reduction is now restricted to `single` arguments that are not `Combined`, `Relative`, or `List`; a standalone `:is(.b .c)` keeps its wrapper (still valid, just not shortened). Simple compound cases like `.x:is(.y)` still reduce.

Commit 6e60bc1 adds the spec test; commit ecc479f restricts the reduction.