### PR TITLE
properties: always emit the separator after a shadow inset-var prefix

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2720,7 +2720,11 @@ let pp_shadow_parts ctx ~inset ~inset_var ~inset_var_no_fallback h v blur spread
   let has_inset_var =
     pp_shadow_inset ctx ~inset ~inset_var ~inset_var_no_fallback
   in
-  if has_inset_var then Pp.space_if_pretty ctx ();
+  (* The [var(--name,)] prefix stands in for the optional [inset] keyword, so
+     the separator before the offsets is load-bearing (a var resolving to
+     [inset] must read [inset 0 ...], never [inset0 ...]); emit it
+     unconditionally, not only in pretty mode. *)
+  if has_inset_var then Pp.space ctx ();
   pp_length ctx h;
   Pp.space ctx ();
   pp_length ctx v;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2855,7 +2855,19 @@ let test_shadow () =
     "0 0 rgba(0,0,0,0)";
   check_shadow "inherit";
   neg_cursor read_shadow "invalid-shadow";
-  neg_cursor read_shadow "10px"
+  neg_cursor read_shadow "10px";
+  (* A [var(--name,)] inset prefix stands in for the optional [inset] keyword,
+     so the separator before the offset is load-bearing: if the var resolves to
+     [inset] the result must read [inset 0 ...], never [inset0 ...]. The space
+     must survive minification. *)
+  let inset_var_shadow =
+    shadow ~inset_var:"tw-ring-inset" ~h_offset:Zero ~v_offset:Zero ~blur:Zero
+      ~spread:(Px 1.) ~color:(Values.hex "#000") ()
+  in
+  Alcotest.(check string)
+    "inset-var shadow keeps the separator after the var prefix when minified"
+    "var(--tw-ring-inset,) 0 0 0 1px #000"
+    (Css.Pp.to_string ~minify:true pp_shadow inset_var_shadow)
 
 let test_align_items () =
   check_align_items "stretch";


### PR DESCRIPTION
A typed shadow built with an `inset_var` (the `--tw-ring-inset` ring pattern) serialized its `var(--name,)` prefix followed by `Pp.space_if_pretty`, so minified output dropped the space: `var(--tw-ring-inset,)0 0 0 ...`. That separator is load-bearing — the empty-fallback var stands in for the optional `inset` keyword, and when it resolves to `inset` the value must read `inset 0 ...`, never `inset0 ...`.

The space is now emitted unconditionally, matching the separator-preservation rule the custom-value minifier already follows. Completes that work for the typed-shadow serializer.

Commit adds a constructed-value spec test; the fix is one line.