### PR TITLE
properties: serialize color-scheme with the scheme before only

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -8393,20 +8393,23 @@ let rec pp_color_scheme : color_scheme Pp.t =
       Pp.string ctx "light";
       Pp.space ctx ();
       Pp.string ctx "dark"
+  (* Color Adjust 1 SS 2.1: [only] is unordered relative to the scheme keywords;
+     the canonical serialization (CSSOM, browsers) puts the scheme first and
+     [only] last. *)
   | Only_light ->
-      Pp.string ctx "only";
-      Pp.space ctx ();
-      Pp.string ctx "light"
-  | Only_dark ->
-      Pp.string ctx "only";
-      Pp.space ctx ();
-      Pp.string ctx "dark"
-  | Only_light_dark ->
-      Pp.string ctx "only";
-      Pp.space ctx ();
       Pp.string ctx "light";
       Pp.space ctx ();
-      Pp.string ctx "dark"
+      Pp.string ctx "only"
+  | Only_dark ->
+      Pp.string ctx "dark";
+      Pp.space ctx ();
+      Pp.string ctx "only"
+  | Only_light_dark ->
+      Pp.string ctx "light";
+      Pp.space ctx ();
+      Pp.string ctx "dark";
+      Pp.space ctx ();
+      Pp.string ctx "only"
   | Custom names -> Pp.list ~sep:Pp.space Pp.string ctx names
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
@@ -15232,9 +15235,12 @@ let rec read_color_scheme t : color_scheme =
     | [ "light" ] -> Light
     | [ "dark" ] -> Dark
     | [ "light"; "dark" ] | [ "dark"; "light" ] -> Light_dark
-    | [ "only"; "light" ] -> Only_light
-    | [ "only"; "dark" ] -> Only_dark
-    | [ "only"; "light"; "dark" ] | [ "only"; "dark"; "light" ] ->
+    | [ "only"; "light" ] | [ "light"; "only" ] -> Only_light
+    | [ "only"; "dark" ] | [ "dark"; "only" ] -> Only_dark
+    | [ "only"; "light"; "dark" ]
+    | [ "only"; "dark"; "light" ]
+    | [ "light"; "dark"; "only" ]
+    | [ "dark"; "light"; "only" ] ->
         Only_light_dark
     | [ "inherit" ] -> Inherit
     | [ "initial" ] -> Initial

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1786,7 +1786,7 @@ let spec_remaining_prop_vectors () =
       ( "position-visibility: anchors-visible",
         "position-visibility:anchors-visible" );
       ("accent-color: auto", "accent-color:auto");
-      ("color-scheme: only light dark", "color-scheme:only light dark");
+      ("color-scheme: only light dark", "color-scheme:light dark only");
       ( "forced-color-adjust: preserve-parent-color",
         "forced-color-adjust:preserve-parent-color" );
       ("print-color-adjust: exact", "print-color-adjust:exact");

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3206,6 +3206,14 @@ let test_color_scheme () =
   (* Color Adjust 1 SS 2.1: <custom-ident> is in the grammar for forward
      compatibility, so unknown idents are accepted. *)
   check_color_scheme "future-scheme";
+  (* Color Adjust 1 SS 2.1: [only] is unordered relative to the scheme keywords,
+     but the canonical serialization (CSSOM, browsers, Tailwind) puts the scheme
+     first and [only] last. *)
+  check_color_scheme "dark only";
+  check_color_scheme "light only";
+  check_color_scheme ~expected:"dark only" "only dark";
+  check_color_scheme ~expected:"light only" "only light";
+  check_color_scheme ~expected:"light dark only" "only light dark";
   neg_cursor read_color_scheme "normal light"
 
 let test_columns_value () =


### PR DESCRIPTION
`pp_color_scheme` emitted the `Only_*` constructors as `only dark`, but `color-scheme`'s canonical serialization (CSSOM, browsers, Tailwind) puts the scheme keywords first and `only` last. The value is stored as a typed constructor that does not retain the authored order, so pp must pick the canonical spelling: `dark only`, `light only`, `light dark only`. The reader now also accepts that order so the value round-trips.

Commit adds the spec test (and updates the one existing oracle that pinned the old order); the fix reorders the printer and widens the reader.