### PR TITLE
optimize: collect @property registrations before promoting usages

### DIFF
--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -531,6 +531,21 @@ let map_statement_block_preserve f stmt =
       if block' == block then stmt else Scope (a, b, block')
   | _ -> stmt
 
+let iter_statement_block f stmt =
+  match stmt with
+  | Layer (_, block)
+  | Media (_, block)
+  | Container (_, _, block)
+  | Supports (_, block)
+  | Moz_document (_, block)
+  | When (_, block)
+  | Else (_, block)
+  | Starting_style block
+  | Origin (_, block)
+  | Scope (_, _, block) ->
+      List.iter f block
+  | _ -> ()
+
 (** [drop_invalid] walks every declaration list in the stylesheet (rules, bare
     nesting blocks, [@page] / [@font-palette-values] / [@view-transition] /
     [@position-try]) and removes declarations whose typed value contains an
@@ -698,12 +713,22 @@ let promote_registered_custom_decl ~lossless registry decl =
 
 let promote_registered_custom_properties ~lossless (stmts : statement list) =
   let registry : (string, Variables.any_syntax) Hashtbl.t = Hashtbl.create 8 in
+  (* An [@property] registration is document-global regardless of source order
+     (CSS Properties and Values API 1 SS 2). Tailwind emits its [@property]
+     rules after the [@layer] that uses them, so collect every registration in a
+     first pass before promoting any declaration. *)
+  let rec collect_stmt (stmt : statement) : unit =
+    match stmt with
+    | Property pr ->
+        Hashtbl.replace registry pr.name (Variables.Syntax pr.syntax)
+    | Rule r -> List.iter collect_stmt r.nested
+    | _ -> iter_statement_block collect_stmt stmt
+  in
+  List.iter collect_stmt stmts;
   let promote_decl = promote_registered_custom_decl ~lossless registry in
   let rec walk_stmt (stmt : statement) : statement =
     match stmt with
-    | Property pr ->
-        Hashtbl.replace registry pr.name (Variables.Syntax pr.syntax);
-        stmt
+    | Property _ -> stmt
     | Rule r ->
         let declarations = list_map_preserve promote_decl r.declarations in
         let nested = list_map_preserve walk_stmt r.nested in

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5843,7 +5843,19 @@ let customprops13_registered_oklch_chroma () =
     (normalize_minified
        "@property --color-zinc-500 { syntax: \"<color>\"; inherits: true; \
         initial-value: black } .x { --color-zinc-500: oklch(55.2% .016 \
-        285.938) }")
+        285.938) }");
+  (* A [@property] registration is document-global regardless of source order
+     (CSS Properties and Values API 1 SS 2), so a usage inside [@layer] that
+     precedes its [@property] rule (the Tailwind output shape) is still promoted
+     and colour-canonicalised. *)
+  Alcotest.(check string)
+    "registration applies to a prior usage nested in a layer"
+    "@layer utilities{.x{--color-zinc-500:#71717b}}@property \
+     --color-zinc-500{syntax:\"<color>\";inherits:true;initial-value:#000}"
+    (normalize_minified
+       "@layer utilities { .x { --color-zinc-500: oklch(55.2% .016 285.938) } \
+        } @property --color-zinc-500 { syntax: \"<color>\"; inherits: true; \
+        initial-value: black }")
 
 let customprops13_registered_percent_calc () =
   Alcotest.(check string)


### PR DESCRIPTION
`promote_registered_custom_properties` built its registry in a single forward walk, so an `@property` rule that appears *after* a usage was never applied. Tailwind emits its `@property` registrations at the end of the stylesheet, after the `@layer` rules that use them, so every registered custom property (gradient/ring/shadow colours, lengths) stayed an opaque token stream instead of being promoted to its typed form and canonicalised. That left equal values spelled differently (`oklab(... -.124 ...)` vs `oklab(... -31%...)`) reported as differences.

An `@property` registration is document-global regardless of source order (CSS Properties and Values API 1 section 2). The registry is now collected in a first pass over every nesting level, then promotion runs in a second pass, so order no longer matters.

Commit adds the spec test (usage in `@layer` preceding its `@property`); the fix splits the walk into collect-then-promote.