### PR TITLE
optimize: fold constant clamp() to a single value

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20516,6 +20516,11 @@ let rec canonicalize_math_whitespace_components ?(in_math = false) comps =
    so the optimizer holds a canonical AST and [pp] stays a pure serialiser. Add
    property cases here as their folds migrate out of [pp]; everything else is
    identity. *)
+let normalize_font_size (fs : font_size) : font_size =
+  match fs with
+  | Length l -> preserve_if_equal fs (Length (Values.normalize_length l))
+  | _ -> fs
+
 let normalize_property_value : type a. ?lossless:bool -> a property -> a -> a =
  fun ?(lossless = false) property value ->
   let normalize_color =
@@ -20625,6 +20630,7 @@ let normalize_property_value : type a. ?lossless:bool -> a property -> a -> a =
   | Grid_auto_rows -> normalize_grid_template value
   | Aspect_ratio -> normalize_aspect_ratio value
   | Gap -> normalize_gap value
+  | Font_size -> normalize_font_size value
   | Padding_left -> Values.normalize_length value
   | Padding_right -> Values.normalize_length value
   | Padding_bottom -> Values.normalize_length value

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3543,9 +3543,18 @@ let rec normalize_length ?(strip = true) (l : length) : length =
         with
         | Val v -> v
         | folded -> Calc folded)
-    | Clamp (mn, v, mx) ->
+    | Clamp (mn, v, mx) -> (
         let mn = nf mn and v = nf v and mx = nf mx in
-        if mn = v && v = mx then v else Clamp (mn, v, mx)
+        if mn = v && v = mx then v
+        else
+          (* clamp(lo, v, hi) = max(lo, min(v, hi)); folds to one value when all
+             three share a unit, returning lo when lo > hi. *)
+          match try_reduce_typed_min_max [ v; mx ] Float.min with
+          | Some inner -> (
+              match try_reduce_typed_min_max [ mn; inner ] Float.max with
+              | Some r -> r
+              | None -> Clamp (mn, v, mx))
+          | None -> Clamp (mn, v, mx))
     | Min xs -> (
         let xs = List.map nf xs in
         match try_reduce_typed_min_max xs Float.min with

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4693,7 +4693,10 @@ let v4107_minmax_reduction () =
   Alcotest.(check string)
     "clamp(1rem, 2vw, 3rem) stays (mixed units)"
     ".x{width:clamp(1rem,2vw,3rem)}"
-    (normalize ".x { width: clamp(1rem, 2vw, 3rem) }")
+    (normalize ".x { width: clamp(1rem, 2vw, 3rem) }");
+  Alcotest.(check string)
+    "font-size folds a constant clamp too" ".x{font-size:2rem}"
+    (normalize ".x { font-size: clamp(1rem, 2rem, 3rem) }")
 
 (* CSS Selectors L4 section 17 (:is()): a single-argument [:is(.x)] matches the
    same elements as bare [.x] with the same specificity. Per shortest-wins

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4680,7 +4680,20 @@ let v4107_minmax_reduction () =
     (normalize ".x { width: max(1px, 2px) }");
   Alcotest.(check string)
     "min(min(1px, 2px), 3px) -> 1px" ".x{width:1px}"
-    (normalize ".x { width: min(min(1px, 2px), 3px) }")
+    (normalize ".x { width: min(min(1px, 2px), 3px) }");
+  (* CSS Values 4 section 10: [clamp(lo, v, hi)] is [max(lo, min(v, hi))], so a
+     clamp of three same-unit literals folds to a single value (returning [lo]
+     when [lo > hi]). Mixed units cannot be compared and are preserved. *)
+  Alcotest.(check string)
+    "clamp(1rem, 2rem, 3rem) -> 2rem" ".x{width:2rem}"
+    (normalize ".x { width: clamp(1rem, 2rem, 3rem) }");
+  Alcotest.(check string)
+    "clamp(3rem, 2rem, 1rem) -> 3rem" ".x{width:3rem}"
+    (normalize ".x { width: clamp(3rem, 2rem, 1rem) }");
+  Alcotest.(check string)
+    "clamp(1rem, 2vw, 3rem) stays (mixed units)"
+    ".x{width:clamp(1rem,2vw,3rem)}"
+    (normalize ".x { width: clamp(1rem, 2vw, 3rem) }")
 
 (* CSS Selectors L4 section 17 (:is()): a single-argument [:is(.x)] matches the
    same elements as bare [.x] with the same specificity. Per shortest-wins


### PR DESCRIPTION
Stacked on #28. `normalize_length` only collapsed `clamp()` when all three bounds were identical. Since `clamp(lo, v, hi)` is `max(lo, min(v, hi))` (CSS Values 4 section 10), three same-unit literals fold to one value (`lo` when `lo > hi`); mixed-unit clamps stay. Reuses the existing typed min/max reducer.

Commit adds the spec test; the fold is in the optimize/normalize pass, so pretty output keeps the authored `clamp()`.