### PR TITLE
properties: keep font-family quotes under enforce_spec

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3432,7 +3432,10 @@ let is_font_family_ident_word s =
   && String.for_all is_ident_char s
 
 let pp_font_family_name ctx s =
-  if Pp.minified ctx then Pp.string ctx s
+  (* A multi-word named family unquotes under minify (shorter, valid), but the
+     CSSOM-canonical serialization quotes it, so enforce_spec keeps the
+     quotes. *)
+  if Pp.minified ctx && not ctx.Pp.enforce_spec then Pp.string ctx s
   else (
     Pp.char ctx '"';
     Pp.string ctx s;
@@ -3615,7 +3618,10 @@ let rec pp_font_family : font_family Pp.t =
             "default";
           ]
       in
-      if Pp.minified ctx && can_unquote_font_family_name s then Pp.string ctx s
+      if
+        Pp.minified ctx && (not ctx.Pp.enforce_spec)
+        && can_unquote_font_family_name s
+      then Pp.string ctx s
       else if
         s = ""
         || (not (String.for_all safe_ident_char s))

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2040,7 +2040,23 @@ let test_font_family () =
   (* Test actual invalid cases *)
   neg_cursor read_font_family "123invalid";
   (* identifier can't start with number *)
-  neg_cursor read_font_family ""
+  neg_cursor read_font_family "";
+  (* Default minify unquotes a multi-word [<family-name>] (CSS Fonts 4 sec. 4.1:
+     an ident sequence is a valid family name and the unquoted form is shorter).
+     [enforce_spec] keeps the quotes, matching the CSSOM-canonical
+     serialization, so a font stack stored verbatim in a custom property keeps
+     its authored quoting. *)
+  let stack =
+    read_font_family (Cursor.of_string "\"Segoe UI Symbol\",monospace")
+  in
+  Alcotest.(check string)
+    "default minify unquotes a multi-word family name"
+    "Segoe UI Symbol,monospace"
+    (Css.Pp.to_string ~minify:true pp_font_family stack);
+  Alcotest.(check string)
+    "enforce_spec keeps a multi-word family name quoted"
+    "\"Segoe UI Symbol\",monospace"
+    (Css.Pp.to_string ~minify:true ~enforce_spec:true pp_font_family stack)
 
 let test_font_stretch () =
   check_font_stretch "normal";


### PR DESCRIPTION
Default minify unquotes a multi-word `<family-name>` (`"Segoe UI Symbol"` -> `Segoe UI Symbol`), which is shorter and valid per CSS Fonts 4 section 4.1. But the CSSOM-canonical serialization quotes it, so `--enforce-spec` now keeps the quotes (both the named-family and custom-ident paths). This lets a font stack stored verbatim in a custom property round-trip with its authored quoting. Default minify is unchanged.

Commit adds the spec test for both paths; the fix gates the two unquoting sites.