### PR TITLE
properties: fold colour functions in opaque custom values

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,16 @@ Rule-level rewrites:
   for the evergreen target.
 - MQ4 range syntax when shorter (`(min-width:48px)` -> `(width>=48px)`).
 
-These rules compose wherever cascade has a typed CSS value. Unregistered
-custom-property values remain opaque token streams.
+These rules compose wherever cascade has a typed CSS value. An unregistered
+custom-property value stays an opaque token stream, with one exception: a
+complete colour function inside it (`oklab(...)`, `color-mix(...)`,
+`rgb(...)`, ...) is a clearly typed substream and folds to its shortest
+spelling. Such a function is unconditionally a colour in every `var()`
+substitution site, so the fold preserves every rendered result. Bare colour
+keywords stay opaque, since they may be a `<custom-ident>` in a non-colour
+context. The fold changes the exact token string a script reads back via
+`getPropertyValue`; cascade does not treat that byte-exact CSSOM serialization
+as an observable to preserve.
 
 ### Color approximation
 
@@ -284,8 +292,9 @@ frameworks.
   context.
 - **Comments and source positions** are not preserved across the
   parser/printer round trip.
-- **Unregistered custom properties** remain opaque token streams to the
-  optimizer.
+- **Unregistered custom properties** stay opaque token streams to the
+  optimizer, apart from complete colour functions inside them, which fold to
+  their shortest spelling.
 
 ## Using cascade as a library
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20197,6 +20197,70 @@ let read_custom_value_as kind read components =
 let read_custom_property_value ?font_family:_ cursor =
   Tokens (Cursor.remaining cursor)
 
+(* A registered [<color>] custom property carries a typed colour once promoted,
+   so canonicalise it the same way a real colour property would. *)
+let is_color_function name =
+  match String.lowercase_ascii name with
+  | "rgb" | "rgba" | "hsl" | "hsla" | "hwb" | "lab" | "lch" | "oklab" | "oklch"
+  | "color" | "color-mix" | "light-dark" ->
+      true
+  | _ -> false
+
+(* A complete colour function is unconditionally a colour in every [var()]
+   substitution site, so folding it to its canonical spelling inside an opaque
+   custom-property token stream preserves every rendered result while collapsing
+   two spellings of the same colour. The only observable change is the exact
+   token string a script reads back via [getPropertyValue]; that readback is the
+   optimizer's domain (it already folds insignificant math whitespace here), so
+   the canonical diff inherits this fold rather than shimming it. Bare keywords
+   are left untouched - they may be a [<custom-ident>] in a non-colour
+   context. *)
+let rec canonicalize_custom_colors_components ~lossless comps =
+  List.concat_map
+    (fun (c : Component.t) ->
+      match c with
+      | Component.Func wrapped
+        when is_color_function wrapped.Component.node.name -> (
+          let text = Parser.to_string_custom [ c ] in
+          let cur = Cursor.of_string text in
+          match
+            try Some (Values.read_color cur) with Cursor.Parse_error _ -> None
+          with
+          | Some col when Cursor.is_done cur -> (
+              let canon =
+                Pp.to_string ~minify:true Values.pp_color
+                  (Values.normalize_color ~lossless ~in_feature_query:false col)
+              in
+              match read_custom_property_value (Cursor.of_string canon) with
+              | Tokens cs -> cs
+              | Typed _ -> [ c ])
+          | _ ->
+              let func = wrapped.Component.node in
+              let args =
+                canonicalize_custom_colors_components ~lossless func.arguments
+              in
+              [
+                Component.Func
+                  { wrapped with node = { func with arguments = args } };
+              ])
+      | Component.Func wrapped ->
+          let func = wrapped.Component.node in
+          let args =
+            canonicalize_custom_colors_components ~lossless func.arguments
+          in
+          [
+            Component.Func
+              { wrapped with node = { func with arguments = args } };
+          ]
+      | Component.Block wrapped ->
+          let block = wrapped.Component.node in
+          let value =
+            canonicalize_custom_colors_components ~lossless block.value
+          in
+          [ Component.Block { wrapped with node = { block with value } } ]
+      | Component.Preserved _ -> [ c ])
+    comps
+
 (* Typed re-readers exposed for the registry pass that consumes [@property]
    declarations. Each reader takes a token stream and tries to parse it as the
    matching typed kind, returning [None] when the stream doesn't match. The
@@ -20715,15 +20779,15 @@ let normalize_property_value : type a. ?lossless:bool -> a property -> a -> a =
       match value with
       | Custom_value ({ value = Tokens components; _ } as r) ->
           let components' =
-            canonicalize_math_whitespace_components components
+            components
+            |> canonicalize_custom_colors_components ~lossless
+            |> canonicalize_math_whitespace_components
           in
           if components' == components then value
           else Custom_value { r with value = Tokens components' }
       | Custom_value _ -> value)
   | _ -> value
 
-(* A registered [<color>] custom property carries a typed colour once promoted,
-   so canonicalise it the same way a real colour property would. *)
 let normalize_custom_property_value ?(lossless = false) :
     custom_property_value -> custom_property_value = function
   | Typed { kind = Length; value } ->
@@ -20752,7 +20816,9 @@ let normalize_custom_property_value ?(lossless = false) :
           value = normalize_gradient_direction value;
         }
   | Tokens components ->
-      Tokens (canonicalize_math_whitespace_components components)
+      Tokens
+        (canonicalize_math_whitespace_components
+           (canonicalize_custom_colors_components ~lossless components))
   | Typed _ as other -> other
 
 let pp_property_value : type a. (a property * a) Pp.t =

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -407,6 +407,16 @@ let normalize_expected ~category ~id expected =
          authored unit. *)
       fixture ~category ~id ~upstream:"a{font-size:16px}"
         ~cascade:"a{font-size:12pt}" upstream
+  | "values", "0057" ->
+      (* The upstream oracle keeps [rgb(0 0 0)] verbatim to preserve the exact
+         token string a script reads back via [getPropertyValue]. A complete
+         colour function is unconditionally a colour in every [var()]
+         substitution site, so folding it to the shortest spelling preserves
+         every rendered result; the only loss is byte-exact CSSOM readback,
+         which is not an evergreen-rendering fact. [rgb(0 0 0)] is black, so
+         [#000] is the shortest spelling. *)
+      fixture ~category ~id ~upstream:"a{--brand-color: rgb(0 0 0)}"
+        ~cascade:"a{--brand-color:#000}" upstream
   | "whitespace", "0009" ->
       (* The default minifier may use maintained-evergreen target facts.
          [display:flex] is true for that target, so [@supports not

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -82,11 +82,30 @@ let registered_custom_property_tokens () =
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
 
 let canonical_custom_color_mix_tokens () =
+  (* color-mix() is unconditionally a colour wherever it is substituted, so two
+     spellings of the same colour-mix are equal under canonical comparison even
+     inside an unregistered custom property. transparent and #0000 are the same
+     colour, so these two forms compare equal. *)
   let expected = ".a { --tw-gradient: " ^ color_mix_transparent ^ " }" in
   let actual = ".a { --tw-gradient: " ^ color_mix_transparent_hex ^ " }" in
   Alcotest.(check bool)
-    "unregistered custom color-mix token streams stay opaque" false
+    "custom color-mix spellings of one colour compare equal" true
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
+
+let canonical_custom_color_function_alpha () =
+  (* oklab() is unconditionally a colour, so an alpha written as 25% or .25 is
+     the same value; canonical comparison equates them inside a custom-property
+     body. *)
+  Alcotest.(check bool)
+    "oklab alpha 25% and .25 compare equal in a custom property" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ".a { --s: oklab(50% 0 0 / 25%) }" ".a { --s: oklab(50% 0 0 / .25) }");
+  (* A bare colour keyword could be a custom-ident in a non-colour substitution
+     context, so it stays opaque: transparent and #0000 are not equated. *)
+  Alcotest.(check bool)
+    "bare transparent and #0000 stay distinct in a custom property" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical ".a { --c: transparent }"
+       ".a { --c: #0000 }")
 
 let canonical_custom_calc_percentage () =
   let expected = ".a { --tw-translate-x: calc(1 / 2 * 100%) }" in
@@ -803,6 +822,8 @@ let suite =
         registered_custom_property_tokens;
       Alcotest.test_case "canonical custom color-mix tokens" `Quick
         canonical_custom_color_mix_tokens;
+      Alcotest.test_case "canonical custom color-function alpha" `Quick
+        canonical_custom_color_function_alpha;
       Alcotest.test_case "canonical custom calc percentage" `Quick
         canonical_custom_calc_percentage;
       Alcotest.test_case "semantic with recovered warning" `Quick

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5849,8 +5849,8 @@ let customprops13_registered_numeric_calc () =
 
 let customprops13_registered_oklch_chroma () =
   Alcotest.(check string)
-    "unregistered OKLCH custom property keeps token stream"
-    ".x{--color-zinc-500:oklch(55.2% .016 285.938)}"
+    "unregistered OKLCH custom property folds the colour function"
+    ".x{--color-zinc-500:#71717b}"
     (normalize_minified ".x { --color-zinc-500: oklch(55.2% .016 285.938) }");
   Alcotest.(check string)
     "registered OKLCH custom property uses typed color minification"
@@ -5915,13 +5915,13 @@ let customprops13_box_shadow_zero_spread () =
 
 let customprops13_shortest_oklab_sign_boundaries () =
   Alcotest.(check string)
-    "unregistered OKLab custom property keeps opaque token stream"
-    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034/.1)}"
+    "unregistered OKLab custom property folds the colour function"
+    ".prose{--tw-prose-kbd-shadows:#1118281a}"
     (normalize_minified
        ".prose { --tw-prose-kbd-shadows: oklab(21% -.003 -.034 / .1) }");
   Alcotest.(check string)
-    "unregistered OKLab custom property preserves required token boundary"
-    ".prose{--tw-prose-kbd-shadows:oklab(21% -.003-.034/.1)}"
+    "unregistered OKLab custom property folds regardless of source sign spacing"
+    ".prose{--tw-prose-kbd-shadows:#1118281a}"
     (normalize_minified
        ".prose { --tw-prose-kbd-shadows: oklab(21% -.003-.034 / .1) }");
   Alcotest.(check string)


### PR DESCRIPTION
An unregistered custom-property value is an opaque token stream, but a complete colour function inside it (`oklab(...)`, `color-mix(...)`, `rgb(...)`, ...) is unconditionally a colour in every `var()` substitution site. The optimizer now folds such a function to its shortest spelling, so two spellings of one colour (`oklab(.../25%)` and `oklab(.../.25)`; `color-mix(... transparent)` and `color-mix(... #0000)`) collapse to one form.

The fold lives in the optimizer, so the canonical diff inherits it and `--minify` and canonical comparison stay in lockstep, with no comparison-only shim in the diff library. Bare colour keywords stay opaque, since they may be a `<custom-ident>` in a non-colour context. The only thing lost is byte-exact `getPropertyValue` readback, which is not an evergreen-rendering fact.