### PR TITLE
properties: fold hex colours in opaque custom values

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,14 +210,15 @@ Rule-level rewrites:
 
 These rules compose wherever cascade has a typed CSS value. An unregistered
 custom-property value stays an opaque token stream, with one exception: a
-complete colour function inside it (`oklab(...)`, `color-mix(...)`,
-`rgb(...)`, ...) is a clearly typed substream and folds to its shortest
-spelling. Such a function is unconditionally a colour in every `var()`
-substitution site, so the fold preserves every rendered result. Bare colour
-keywords stay opaque, since they may be a `<custom-ident>` in a non-colour
-context. The fold changes the exact token string a script reads back via
-`getPropertyValue`; cascade does not treat that byte-exact CSSOM serialization
-as an observable to preserve.
+substream whose type is fixed by its own syntax. A complete colour function
+(`oklab(...)`, `color-mix(...)`, `rgb(...)`, ...) or a hex colour (`#abc`) is
+unconditionally a colour in every `var()` substitution site, so it folds to its
+shortest spelling and the fold preserves every rendered result. The fold never
+produces a bare colour keyword: a name like `red` is also a valid
+`<custom-ident>`, so it stays distinct from `#f00` even though it is shorter,
+and hex stays hex. The fold changes the exact token string a script reads back
+via `getPropertyValue`; cascade does not treat that byte-exact CSSOM
+serialization as an observable to preserve.
 
 ### Color approximation
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20206,35 +20206,45 @@ let is_color_function name =
       true
   | _ -> false
 
-(* A complete colour function is unconditionally a colour in every [var()]
-   substitution site, so folding it to its canonical spelling inside an opaque
-   custom-property token stream preserves every rendered result while collapsing
-   two spellings of the same colour. The only observable change is the exact
-   token string a script reads back via [getPropertyValue]; that readback is the
-   optimizer's domain (it already folds insignificant math whitespace here), so
-   the canonical diff inherits this fold rather than shimming it. Bare keywords
-   are left untouched - they may be a [<custom-ident>] in a non-colour
-   context. *)
+(* A construct whose type is fixed by its own syntax - a complete colour
+   function ([oklab(...)], [color-mix(...)], ...) or a hex colour ([#abc]) - is
+   unconditionally a colour in every [var()] substitution site, so folding it to
+   its canonical spelling inside an opaque custom-property token stream
+   preserves every rendered result while collapsing two spellings of the same
+   colour. The only observable change is the exact token string a script reads
+   back via [getPropertyValue]; that readback is the optimizer's domain (it
+   already folds insignificant math whitespace here), so the canonical diff
+   inherits this fold rather than shimming it. Bare keywords are left untouched
+   - they may be a [<custom-ident>] in a non-colour context, whereas a hex token
+   never can. *)
+(* [c] is one component whose syntax fixes it as a colour; fold it to the
+   shortest non-keyword spelling, falling back to [fallback ()] when it does not
+   actually parse as a complete colour. *)
+let fold_custom_color ~lossless (c : Component.t) ~fallback =
+  let text = Parser.to_string_custom [ c ] in
+  let cur = Cursor.of_string text in
+  match
+    try Some (Values.read_color cur) with Cursor.Parse_error _ -> None
+  with
+  | Some col when Cursor.is_done cur -> (
+      let canon =
+        Pp.to_string ~minify:true Values.pp_color
+          (Values.nonkeyword_color
+             (Values.normalize_color ~lossless ~in_feature_query:false col))
+      in
+      match read_custom_property_value (Cursor.of_string canon) with
+      | Tokens cs -> cs
+      | Typed _ -> [ c ])
+  | _ -> fallback ()
+
 let rec canonicalize_custom_colors_components ~lossless comps =
+  let fold_color c ~fallback = fold_custom_color ~lossless c ~fallback in
   List.concat_map
     (fun (c : Component.t) ->
       match c with
       | Component.Func wrapped
-        when is_color_function wrapped.Component.node.name -> (
-          let text = Parser.to_string_custom [ c ] in
-          let cur = Cursor.of_string text in
-          match
-            try Some (Values.read_color cur) with Cursor.Parse_error _ -> None
-          with
-          | Some col when Cursor.is_done cur -> (
-              let canon =
-                Pp.to_string ~minify:true Values.pp_color
-                  (Values.normalize_color ~lossless ~in_feature_query:false col)
-              in
-              match read_custom_property_value (Cursor.of_string canon) with
-              | Tokens cs -> cs
-              | Typed _ -> [ c ])
-          | _ ->
+        when is_color_function wrapped.Component.node.name ->
+          fold_color c ~fallback:(fun () ->
               let func = wrapped.Component.node in
               let args =
                 canonicalize_custom_colors_components ~lossless func.arguments
@@ -20243,6 +20253,8 @@ let rec canonicalize_custom_colors_components ~lossless comps =
                 Component.Func
                   { wrapped with node = { func with arguments = args } };
               ])
+      | Component.Preserved { kind = Token.Hash _; _ } ->
+          fold_color c ~fallback:(fun () -> [ c ])
       | Component.Func wrapped ->
           let func = wrapped.Component.node in
           let args =

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -2768,6 +2768,19 @@ let static_color_to_srgb_bytes c : (int * int * int * int) option =
       Some (component r, component g, component b, a)
   | _ -> Option.None
 
+(* A bare colour keyword ([red], [transparent]) is also a valid [<custom-ident>]
+   in a non-colour context, so it must not be introduced when folding a colour
+   inside an opaque custom-property token stream: re-spell a named/transparent
+   colour as its hex form, which is a colour or nothing in every context. A
+   hex/function/currentcolor colour already carries no keyword spelling. *)
+let nonkeyword_color (c : color) : color =
+  match c with
+  | Named _ | Transparent -> (
+      match static_color_to_srgb_bytes c with
+      | Some (r, g, b, a) -> Hex { r; g; b; a }
+      | None -> c)
+  | _ -> c
+
 let exact_rgb_to_srgb_bytes c : (int * int * int * int) option =
   match c with
   | Rgb (Channels { r; g; b }) -> (

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -72,6 +72,13 @@ val minify_color : color -> color
 (** [minify_color c] converts named colors to hex when the hex form is shorter
     or equal length, matching Lightning CSS behavior. *)
 
+val nonkeyword_color : color -> color
+(** [nonkeyword_color c] re-spells a colour written as a bare keyword (a named
+    colour, or transparent) as its hex form, leaving every other colour
+    unchanged. A bare colour keyword is also a valid [<custom-ident>], so it
+    must not be introduced when folding a colour inside an opaque
+    custom-property token stream. *)
+
 val current_color : color
 (** [current_color] is the CSS currentcolor value. *)
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5913,6 +5913,29 @@ let customprops13_box_shadow_zero_spread () =
        ".shadow-sm { --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, \
         #0000001a) }")
 
+let customprops13_hex_color_folds () =
+  Alcotest.(check string)
+    "unregistered hex custom property folds to the shortest hex" ".x{--c:#fff}"
+    (normalize_minified ".x { --c: #ffffff }");
+  (* An opaque alpha hex with no shorter form stays verbatim. *)
+  Alcotest.(check string)
+    "8-digit hex without a shorter form is unchanged" ".x{--c:#abcdef12}"
+    (normalize_minified ".x { --c: #abcdef12 }");
+  (* A bare colour keyword is also a valid <custom-ident> in a non-colour
+     substitution site, so the fold must never produce a name: red folds to the
+     hex form, not to [red], even though [red] is one byte shorter. *)
+  Alcotest.(check string)
+    "hex folds to hex, never to a named colour" ".x{--c:#f00}"
+    (normalize_minified ".x { --c: #ff0000 }");
+  Alcotest.(check string)
+    "an rgb() function also folds to hex, not a name" ".x{--c:#f00}"
+    (normalize_minified ".x { --c: rgb(255 0 0) }");
+  (* A hex inside an <image> function (itself a clearly typed substream) folds
+     through the recursion. *)
+  Alcotest.(check string)
+    "hex nested in a gradient folds" ".x{--g:linear-gradient(#f00,#00f)}"
+    (normalize_minified ".x { --g: linear-gradient(#ff0000, #0000ff) }")
+
 let customprops13_shortest_oklab_sign_boundaries () =
   Alcotest.(check string)
     "unregistered OKLab custom property folds the colour function"
@@ -6775,6 +6798,9 @@ let additional_tests =
     ( "spec custom-properties 1 3 unregistered box-shadow token stream",
       `Quick,
       customprops13_box_shadow_zero_spread );
+    ( "spec custom-properties 1 3 hex colour folds",
+      `Quick,
+      customprops13_hex_color_folds );
     ( "spec custom-properties 1 3 registered oklab sign boundaries",
       `Quick,
       customprops13_shortest_oklab_sign_boundaries );


### PR DESCRIPTION
Stacked on #31. Extends the "clearly typed substream" fold beyond colour functions to hex colours: a hex like `#ffffff` in an unregistered custom-property token stream is unconditionally a colour in every `var()` substitution site, so the optimizer folds it to its shortest spelling (`#fff`), including hex nested inside an `<image>` function such as a gradient.

The fold now never introduces a bare colour keyword. A name like `red` is also a valid `<custom-ident>`, so `#ff0000` folds to `#f00` rather than `red` even though the name is one byte shorter; `Values.nonkeyword_color` enforces this. The same guard hardens the colour-function path from #31, which could otherwise turn `rgb(255 0 0)` into `red`.