### PR TITLE
optimize: fold insignificant whitespace after a hard close-paren in custom values

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ and hex stays hex. The fold changes the exact token string a script reads back
 via `getPropertyValue`; cascade does not treat that byte-exact CSSOM
 serialization as an observable to preserve.
 
+Whitespace inside an opaque value is likewise folded only where it is
+insignificant: a `)` closing a non-substitution function or a block is a hard
+token boundary, so the space after it is dropped (`drop-shadow(a) drop-shadow(b)`
+-> `drop-shadow(a)drop-shadow(b)`). The space after a `var()` / `env()` / `attr()`
+stays, since the substituted value could otherwise merge with its neighbour.
+
 ### Color approximation
 
 Cascade folds colors only within `0.002` ΔE<sub>OK</sub> (the CSS Color 4

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20563,6 +20563,38 @@ let strip_mul_div_whitespace comps =
   in
   aux [] comps
 
+(* CSS Values 4 sec. 2.5: [var()] / [env()] / [attr()] substitute a token stream
+   textually, so the whitespace next to one is significant - dropping it lets
+   the substituted values merge ([var(--a) var(--b)] could become [1px2px]).
+   Every other function and every block closes with a hard token boundary ([)],
+   []], [}]) that no neighbour can merge across. *)
+let is_substitution_func_name name =
+  match String.lowercase_ascii name with
+  | "var" | "env" | "attr" -> true
+  | _ -> false
+
+(* Whitespace immediately after a function or block that closes with a hard
+   token boundary is insignificant: [drop-shadow(a) drop-shadow(b)] and
+   [calc(45deg*-1) in oklab] re-tokenise identically without it, wherever the
+   stream is substituted. Whitespace after a substitution function stays. *)
+let strip_after_close_paren comps =
+  let closes_hard = function
+    | Component.Func wrapped ->
+        not (is_substitution_func_name wrapped.Component.node.name)
+    | Component.Block _ -> true
+    | _ -> false
+  in
+  let rec aux acc = function
+    | [] -> List.rev acc
+    | (Component.Preserved { kind = Token.Whitespace; _ } as ws) :: rest ->
+        let prev_hard =
+          match acc with [] -> false | p :: _ -> closes_hard p
+        in
+        if prev_hard then aux acc rest else aux (ws :: acc) rest
+    | other :: rest -> aux (other :: acc) rest
+  in
+  aux [] comps
+
 (* [in_math] tracks whether the current component list is inside a math
    function's grammar. It enters at the args of a [calc()] / [min()] / ... call,
    propagates through grouping parens ([Block]s) since those are math operands,
@@ -20591,8 +20623,11 @@ let rec canonicalize_math_whitespace_components ?(in_math = false) comps =
         | Component.Preserved _ -> c)
       comps
   in
-  if in_math then strip_math_whitespace comps'
-  else strip_mul_div_whitespace comps'
+  let comps' =
+    if in_math then strip_math_whitespace comps'
+    else strip_mul_div_whitespace comps'
+  in
+  strip_after_close_paren comps'
 
 (* AST-level value normaliser: applies semantic (equivalence) canonicalisation
    so the optimizer holds a canonical AST and [pp] stays a pure serialiser. Add

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1023,6 +1023,29 @@ let test_keep_var_border_spaces () =
     "a{border:var(--bw) var(--bs) var(--bc)}"
     (minify_str "a{border:var(--bw) var(--bs) var(--bc)}")
 
+let test_custom_value_close_paren_whitespace () =
+  (* A [)] closing a non-substitution function or a block is a hard token
+     boundary that no neighbour can merge across, so the whitespace after it is
+     insignificant: optimize folds it out (and the canonical diff inherits
+     that), while pp keeps it because pp is a pure serializer. *)
+  Alcotest.(check string)
+    "pp keeps whitespace after a function close (held)"
+    "a{--x:drop-shadow(0 0 0) drop-shadow(1px 1px)}"
+    (pp_min "a{--x:drop-shadow(0 0 0) drop-shadow(1px 1px)}");
+  Alcotest.(check string)
+    "optimize folds whitespace after a function close (canonical)"
+    "a{--x:drop-shadow(0 0 0)drop-shadow(1px 1px)}"
+    (minify_str "a{--x:drop-shadow(0 0 0) drop-shadow(1px 1px)}");
+  Alcotest.(check string)
+    "optimize folds whitespace after calc() before an ident"
+    "a{--x:calc(45deg*-1)in oklab}"
+    (minify_str "a{--x:calc(45deg * -1) in oklab}");
+  (* A [var()] substitutes a token stream textually, so dropping the whitespace
+     after it could merge the substituted values ([1px2px]); it stays. *)
+  Alcotest.(check string)
+    "optimize keeps whitespace after var()" "a{--x:var(--a) var(--b)}"
+    (minify_str "a{--x:var(--a) var(--b)}")
+
 let test_keep_bang_comment_leading () =
   (* A bang comment (/*! ... */) is preserved by minify; it stays where it was
      authored rather than being moved past the following rule. *)
@@ -3676,6 +3699,9 @@ let selector_merging_tests =
       `Quick,
       test_keep_zero_duration_transition );
     ("var border keeps significant spaces", `Quick, test_keep_var_border_spaces);
+    ( "custom value folds whitespace after a hard close-paren",
+      `Quick,
+      test_custom_value_close_paren_whitespace );
     ( "leading bang comment stays leading",
       `Quick,
       test_keep_bang_comment_leading );


### PR DESCRIPTION
An unregistered custom-property value is an opaque token stream, but not every byte in it is significant. A `)` closing a non-substitution function or a block is a hard token boundary that no neighbour can merge across, so the whitespace after it is insignificant: the optimizer now folds it out (`drop-shadow(a) drop-shadow(b)` -> `drop-shadow(a)drop-shadow(b)`, `calc(45deg*-1) in oklab` -> `calc(45deg*-1)in oklab`), and the canonical diff inherits the fold.

Whitespace after `var()` / `env()` / `attr()` is kept, since those substitute a token stream textually and dropping the space could merge the substituted values (`var(--a) var(--b)` must not become `1px2px`). `pp` still keeps the space; this is an optimizer canonical transform, parallel to the existing math-whitespace fold.