### PR TITLE
properties: model inset shadows as their own typed form

### DIFF
--- a/lib/context.ml
+++ b/lib/context.ml
@@ -2839,29 +2839,26 @@ let simplify_color ?(layer_order = []) ?layer ctx (value : Values.color) :
 
 let simplify_shadow_leaf length color simplify ~authored ~visited
     (value : Properties.shadow) =
+  let simplify_body
+      ({ h_offset; v_offset; blur; spread; color = shadow_color } :
+        Properties.shadow_body) : Properties.shadow_body =
+    {
+      h_offset = length authored h_offset;
+      v_offset = length authored v_offset;
+      blur = Option.map (length authored) blur;
+      spread = Option.map (length authored) spread;
+      color = Option.map color shadow_color;
+    }
+  in
   match value with
-  | Properties.Shadow
-      {
-        inset;
-        inset_var;
-        inset_var_no_fallback;
-        h_offset;
-        v_offset;
-        blur;
-        spread;
-        color = shadow_color;
-      } ->
-      (Properties.Shadow
-         {
-           inset;
-           inset_var;
-           inset_var_no_fallback;
-           h_offset = length authored h_offset;
-           v_offset = length authored v_offset;
-           blur = Option.map (length authored) blur;
-           spread = Option.map (length authored) spread;
-           color = Option.map color shadow_color;
-         }
+  | Properties.Shadow body ->
+      (Properties.Shadow (simplify_body body) : Properties.shadow)
+  | Properties.Inset (Properties.Body body) ->
+      (Properties.Inset (Properties.Body (simplify_body body))
+        : Properties.shadow)
+  | Properties.Inset (Properties.Toggle { name; no_fallback; body }) ->
+      (Properties.Inset
+         (Properties.Toggle { name; no_fallback; body = simplify_body body })
         : Properties.shadow)
   | Properties.List shadows ->
       (Properties.List (List.map (simplify ~authored ~visited) shadows)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -4872,21 +4872,25 @@ val font_feature_settings : font_feature_settings -> declaration
      font-feature-settings} property. *)
 
 (** CSS shadow values *)
-type shadow = Properties.shadow =
-  | Shadow of {
-      inset : bool;
-      inset_var : string option;
-          (** If set, outputs var(--<name>) before shadow values. Used by
-              Tailwind's ring system for dynamic inset toggle. *)
-      inset_var_no_fallback : bool;
-          (** When true, emits [var(--name)] without fallback instead of
-              [var(--name,)] with empty fallback. Used by the forms plugin. *)
-      h_offset : length;
-      v_offset : length;
-      blur : length option;
-      spread : length option;
-      color : color option;
-    }
+type shadow_body = Properties.shadow_body = {
+  h_offset : length;
+  v_offset : length;
+  blur : length option;
+  spread : length option;
+  color : color option;
+}
+(** The [<length>{2,4} && <color>?] part of a single [<shadow>]. *)
+
+and inset = Properties.inset =
+  | Var of shadow var  (** [inset var(--x)]: the whole body from one var. *)
+  | Body of shadow_body  (** [inset 2px 4px red]: a concrete inset body. *)
+  | Toggle of { name : string; no_fallback : bool; body : shadow_body }
+      (** [var(--name) <body>]: a dynamic inset toggle (Tailwind's ring system).
+      *)
+
+and shadow = Properties.shadow =
+  | Shadow of shadow_body  (** A non-inset shadow. *)
+  | Inset of inset  (** An inset shadow. *)
   | None
   | Inherit
   | Initial

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2345,35 +2345,41 @@ module Shadow = struct
           blur = None && spread = None && !color = None && h_offset = Zero
           && v_offset = Zero
         then err_invalid_value t "shadow" "blur, spread, or color is required";
-        (Shadow
-           {
-             inset = !inset;
-             inset_var = None;
-             inset_var_no_fallback = false;
-             h_offset;
-             v_offset;
-             blur;
-             spread;
-             color = !color;
-           }
-          : shadow)
+        let body = { h_offset; v_offset; blur; spread; color = !color } in
+        (if !inset then Inset (Body body) else Shadow body : shadow)
     | None -> err_invalid_value t "shadow" "at least two lengths are required"
 end
 
 let rec read_shadow_single t : shadow =
-  let read_var t : shadow = Var (read_var read_shadow_single t) in
+  let read_var_shadow t : shadow = Var (read_var read_shadow_single t) in
   Cursor.ws t;
-  Cursor.enum_or_calls "shadow"
-    [
-      ("none", None);
-      ("inherit", Inherit);
-      ("initial", Initial);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-    ]
-    ~calls:[ ("var", read_var) ]
-    ~default:Shadow.read t
+  (* inset var(--x): Shadow.read needs concrete offsets, so handle it here. *)
+  let snap = Cursor.save t in
+  let inset_var : shadow option =
+    match Cursor.ident_opt t with
+    | Some "inset" -> (
+        Cursor.ws t;
+        match Cursor.peek t with
+        | Some (Component.Func { node = { name = "var"; _ }; _ }) ->
+            Some (Inset (Var (read_var read_shadow_single t)))
+        | _ -> Option.None)
+    | _ -> Option.None
+  in
+  match inset_var with
+  | Some shadow -> shadow
+  | Option.None ->
+      Cursor.restore t snap;
+      Cursor.enum_or_calls "shadow"
+        [
+          ("none", None);
+          ("inherit", Inherit);
+          ("initial", Initial);
+          ("unset", Unset);
+          ("revert", Revert);
+          ("revert-layer", Revert_layer);
+        ]
+        ~calls:[ ("var", read_var_shadow) ]
+        ~default:Shadow.read t
 
 let read_shadow t : shadow =
   match Cursor.list ~sep:Cursor.comma ~at_least:1 read_shadow_single t with
@@ -2679,66 +2685,50 @@ let pp_color_after_length ctx color =
   Pp.space ctx ();
   pp_color ctx color
 
-let pp_shadow_inset ctx ~inset ~inset_var ~inset_var_no_fallback =
-  (* If inset_var is set, output var(--<name>,) or var(--<name>) before shadow
-     values. The variable value includes trailing space when set to "inset ".
-     Otherwise use the bool inset flag. *)
-  match inset_var with
-  | Some var_name ->
-      if inset_var_no_fallback then Pp.string ctx ("var(--" ^ var_name ^ ")")
-      else (
-        (* Empty fallback: var(--name, ) in pretty, var(--name,) in minified.
-           The two pretty-mode spaces are: comma-space + fallback-space. *)
-        Pp.string ctx ("var(--" ^ var_name ^ ",");
-        Pp.space_if_pretty ctx ();
-        Pp.space_if_pretty ctx ();
-        Pp.string ctx ")");
-      true
-  | None ->
-      if inset then (
-        Pp.string ctx "inset";
-        Pp.space ctx ());
-      false
-
 (* Faithful: a default-zero spread is dropped in [normalize_shadow], not here.
    [Some Zero] re-parses differently from [None] ([0 1px 3px 0] vs [0 1px 3px]),
    so collapsing it is a node-changing fold that belongs in the AST normalize
    pass, leaving pp a pure serialiser. *)
 let pp_shadow_spread _ctx (spread : length option) : length option = spread
 
-let pp_shadow_parts ctx ~inset ~inset_var ~inset_var_no_fallback h v blur spread
-    color =
-  let has_inset_var =
-    pp_shadow_inset ctx ~inset ~inset_var ~inset_var_no_fallback
-  in
-  (* The [var(--name,)] prefix stands in for the optional [inset] keyword, so
-     the separator before the offsets is load-bearing (a var resolving to
-     [inset] must read [inset 0 ...], never [inset0 ...]); emit it
-     unconditionally, not only in pretty mode. *)
-  if has_inset_var then Pp.space ctx ();
-  pp_length ctx h;
+let pp_shadow_body ctx { h_offset; v_offset; blur; spread; color } =
+  pp_length ctx h_offset;
   Pp.space ctx ();
-  pp_length ctx v;
+  pp_length ctx v_offset;
   let spread = pp_shadow_spread ctx spread in
   pp_opt_space pp_length ctx blur;
   pp_opt_space pp_length ctx spread;
   match color with Some c -> pp_color_after_length ctx c | None -> ()
 
+(* The [var(--name,)] prefix stands in for the optional [inset] keyword (a var
+   resolving to [inset] must read [inset 0 ...], never [inset0 ...]), so the
+   separator after it is load-bearing. *)
+let pp_inset_toggle ctx ~name ~no_fallback =
+  Pp.string ctx "var(--";
+  Pp.string ctx name;
+  if no_fallback then Pp.string ctx ")"
+  else (
+    (* Empty fallback: var(--name, ) in pretty, var(--name,) in minified. *)
+    Pp.char ctx ',';
+    Pp.space_if_pretty ctx ();
+    Pp.space_if_pretty ctx ();
+    Pp.string ctx ")")
+
 let rec pp_shadow : shadow Pp.t =
  fun ctx -> function
-  | Shadow
-      {
-        inset;
-        inset_var;
-        inset_var_no_fallback;
-        h_offset;
-        v_offset;
-        blur;
-        spread;
-        color;
-      } ->
-      pp_shadow_parts ctx ~inset ~inset_var ~inset_var_no_fallback h_offset
-        v_offset blur spread color
+  | Shadow body -> pp_shadow_body ctx body
+  | Inset (Body body) ->
+      Pp.string ctx "inset";
+      Pp.space ctx ();
+      pp_shadow_body ctx body
+  | Inset (Var v) ->
+      Pp.string ctx "inset";
+      Pp.space ctx ();
+      pp_var pp_shadow ctx v
+  | Inset (Toggle { name; no_fallback; body }) ->
+      pp_inset_toggle ctx ~name ~no_fallback;
+      Pp.space ctx ();
+      pp_shadow_body ctx body
   | None -> Pp.string ctx "none"
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
@@ -4403,34 +4393,39 @@ let normalize_text_emphasis ?(lossless = false) : text_emphasis -> text_emphasis
 
 let rec normalize_shadow ?(lossless = false) : shadow -> shadow =
  fun value ->
+  let normalize_body (s : shadow_body) : shadow_body =
+    let blur = option_map_preserve Values.normalize_length s.blur in
+    let spread = option_map_preserve Values.normalize_length s.spread in
+    let color = option_map_preserve (normalize_color ~lossless) s.color in
+    (* Drop a trailing optional length equal to its [0] default, contiguously
+       from the end. [spread] is always the last token, so a zero spread drops
+       freely; a zero blur drops only when no spread follows - otherwise it is
+       positional and dropping it would re-bind the spread as the blur (e.g. [0
+       1px 0 5px] must keep the [0] blur). *)
+    let spread : length option =
+      match spread with Some sp when is_zero_length sp -> None | _ -> spread
+    in
+    let blur : length option =
+      match blur with
+      | Some b when is_zero_length b && Option.is_none spread -> None
+      | _ -> blur
+    in
+    {
+      h_offset = Values.normalize_length s.h_offset;
+      v_offset = Values.normalize_length s.v_offset;
+      blur;
+      spread;
+      color;
+    }
+  in
   match value with
-  | Shadow s ->
-      let blur = option_map_preserve Values.normalize_length s.blur in
-      let spread = option_map_preserve Values.normalize_length s.spread in
-      let color = option_map_preserve (normalize_color ~lossless) s.color in
-      (* Drop a trailing optional length equal to its [0] default, contiguously
-         from the end. [spread] is always the last token, so a zero spread drops
-         freely; a zero blur drops only when no spread follows - otherwise it is
-         positional and dropping it would re-bind the spread as the blur (e.g.
-         [0 1px 0 5px] must keep the [0] blur). *)
-      let spread : length option =
-        match spread with Some sp when is_zero_length sp -> None | _ -> spread
-      in
-      let blur : length option =
-        match blur with
-        | Some b when is_zero_length b && Option.is_none spread -> None
-        | _ -> blur
-      in
+  | Shadow s -> preserve_if_equal value (Shadow (normalize_body s))
+  | Inset (Body s) ->
+      preserve_if_equal value (Inset (Body (normalize_body s)) : shadow)
+  | Inset (Toggle { name; no_fallback; body }) ->
       preserve_if_equal value
-        (Shadow
-           {
-             s with
-             h_offset = Values.normalize_length s.h_offset;
-             v_offset = Values.normalize_length s.v_offset;
-             blur;
-             spread;
-             color;
-           })
+        (Inset (Toggle { name; no_fallback; body = normalize_body body })
+          : shadow)
   | List shadows ->
       preserve_if_equal value
         (List (map_preserve (normalize_shadow ~lossless) shadows))
@@ -19076,34 +19071,26 @@ let shadow ?(inset = false) ?(inset_var : string option)
     ?(v_offset : length option) ?(blur : length option)
     ?(spread : length option) ?(color : color option) () : shadow =
   let default_color = rgb_black in
-  Shadow
+  let body =
     {
-      inset;
-      inset_var;
-      inset_var_no_fallback;
       h_offset = Option.value h_offset ~default:(Px 0.);
       v_offset = Option.value v_offset ~default:(Px 0.);
       blur;
       spread;
       color = Some (Option.value color ~default:default_color);
     }
+  in
+  match inset_var with
+  | Some name ->
+      Inset (Toggle { name; no_fallback = inset_var_no_fallback; body })
+  | None -> if inset then Inset (Body body) else Shadow body
 
 let inset_ring_shadow ?(h_offset : length option) ?(v_offset : length option)
     ?(blur : length option) ?(spread : length option) ?(color : color option) ()
     : shadow =
   let h_offset = Option.value h_offset ~default:(Zero : length) in
   let v_offset = Option.value v_offset ~default:(Zero : length) in
-  Shadow
-    {
-      inset = true;
-      inset_var = None;
-      inset_var_no_fallback = false;
-      h_offset;
-      v_offset;
-      blur;
-      spread;
-      color;
-    }
+  (Inset (Body { h_offset; v_offset; blur; spread; color }) : shadow)
 
 let url path : background_image = Url path
 let linear_gradient dir stops = Linear_gradient (dir, stops)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2278,21 +2278,8 @@ type blend_mode =
   | Var of blend_mode var
 
 type shadow =
-  | Shadow of {
-      inset : bool;
-      inset_var : string option;
-          (** If set, outputs var(--<name>) before shadow values. Used by
-              Tailwind's ring system for dynamic inset toggle. *)
-      inset_var_no_fallback : bool;
-          (** When true, emits [var(--name)] without fallback instead of
-              [var(--name,)] with empty fallback. Used by the forms plugin where
-              the variable is always set in the same rule. *)
-      h_offset : length;
-      v_offset : length;
-      blur : length option;
-      spread : length option;
-      color : color option;
-    }
+  | Shadow of shadow_body
+  | Inset of inset
   | None
   | Inherit
   | Initial
@@ -2301,6 +2288,21 @@ type shadow =
   | Revert_layer
   | List of shadow list
   | Var of shadow var
+
+and shadow_body = {
+  h_offset : length;
+  v_offset : length;
+  blur : length option;
+  spread : length option;
+  color : color option;
+}
+(** The [<length>{2,4} && <color>?] body of a single [<shadow>]. *)
+
+and inset =
+  | Var of shadow var (* inset var(--x): whole body from one var *)
+  | Body of shadow_body (* inset 2px 4px red *)
+  | Toggle of { name : string; no_fallback : bool; body : shadow_body }
+(* var(--name) <body>: ring inset toggle *)
 
 type text_shadow =
   | None

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2863,6 +2863,10 @@ let test_shadow () =
   check_shadow "red inset 2px 2px" ~expected:"inset 2px 2px red";
   check_shadow "red inset 2px 2px 4px" ~expected:"inset 2px 2px 4px red";
   check_shadow "red inset 2px 2px 4px 1px" ~expected:"inset 2px 2px 4px 1px red";
+  (* [inset var(--x)]: the [<length>{2,4} && <color>?] body supplied wholesale
+     by one var, which the concrete-offset [Shadow] record cannot hold. *)
+  check_shadow "inset var(--shadow)";
+  check_shadow "var(--a),inset var(--b)";
   (* Test compact printing - when blur and spread are not provided, should print
      compactly. Cross-form colour canonicalization is an optimize transform. *)
   check_shadow "0 0 #0000" ~expected:"0 0 #0000";


### PR DESCRIPTION
`box-shadow`'s inset flag and Tailwind's `var(--tw-ring-inset)` toggle lived as three fields on the shadow record, which cannot represent `inset var(--x)` (an inset shadow whose whole `<length>{2,4} && <color>?` body comes from one var). This lifts them into a typed `inset` form so a shadow shorthand can have a subpart that is itself a variable; the smart constructor maps the old optional arguments onto the new variants, so callers are unchanged.

Bottom of a stack draining the tw upstream parity suite: #36, #37, #38.