### PR TITLE
properties: expose gradient-direction parser

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -41,6 +41,11 @@ module Transform = struct
   let of_string s = parse_full ~property:"transform" Properties.read_transform s
 end
 
+module Gradient_direction = struct
+  let of_string s =
+    parse_full ~property:"gradient-direction" Properties.read_gradient_prelude s
+end
+
 module Transform_origin = struct
   let of_string s =
     parse_full ~property:"transform-origin" Properties.read_transform_origin s

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -101,6 +101,12 @@ module Transform : sig
   (** [of_string s] parses [s] as a single {!val-transform} value. *)
 end
 
+module Gradient_direction : sig
+  val of_string : string -> (Properties.gradient_direction, Error.t) result
+  (** [of_string s] parses [s] as a gradient [<direction>] (a side keyword, an
+      [<angle>], or a [<direction> in <color-interpolation>] form). *)
+end
+
 module Transform_origin : sig
   val of_string : string -> (Properties.transform_origin, Error.t) result
   (** [of_string s] parses [s] as a [transform-origin] value. *)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2821,6 +2821,10 @@ let rec pp_gradient_direction : gradient_direction Pp.t =
   | To_left -> Pp.string ctx "to left"
   | To_top_left -> Pp.string ctx "to top left"
   | Angle a -> pp_angle ctx a
+  | With_interpolation (Default_direction, interp) ->
+      (* default direction is omitted: [in <interp>], not [to bottom in
+         <interp>] *)
+      pp_color_interpolation ctx interp
   | With_interpolation (dir, interp) ->
       pp_gradient_direction ctx dir;
       (* After calc() or var(), the closing ) is a delimiter token so no space
@@ -17969,6 +17973,12 @@ let read_linear_prelude_opt t : gradient_direction option =
   | Some d, None -> Option.Some d
   | None, Some i -> Option.Some (With_interpolation (Default_direction, i))
   | None, None -> Option.None
+
+(* Direction plus the optional [in <interpolation>] tail ([45deg in oklab]). *)
+let read_gradient_prelude t : gradient_direction =
+  match read_linear_prelude_opt t with
+  | Some d -> d
+  | None -> Cursor.err_expected t "gradient direction"
 
 let rec read_gradient_position t : gradient_position =
   Cursor.ws t;

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1454,6 +1454,11 @@ val pp_gradient_direction : gradient_direction Pp.t
 val read_gradient_direction : Cursor.t -> gradient_direction
 (** [read_gradient_direction t] is the [gradient_direction] parsed from [t]. *)
 
+val read_gradient_prelude : Cursor.t -> gradient_direction
+(** [read_gradient_prelude t] parses a gradient direction including the optional
+    [in <color-interpolation>] tail ([45deg in oklab]), unlike
+    {!read_gradient_direction} which stops before the tail. *)
+
 val pp_color_interpolation : color_interpolation Pp.t
 (** [pp_color_interpolation] pretty-prints a color interpolation space (e.g.,
     "in oklab"). *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2293,6 +2293,10 @@ let test_gradient_position () =
   check_gradient_position "to right";
   check_gradient_position "45deg";
   check_gradient_position "to right in oklab";
+  (* No explicit direction: the interpolation prints without a redundant [to
+     bottom], distinct from [to bottom in <interp>]. *)
+  check_gradient_position "in oklab";
+  check_gradient_position "in oklch shorter hue";
   check_gradient_position "circle at center";
   check_gradient_position "closest-side";
   check_gradient_position "at center";


### PR DESCRIPTION
`read_gradient_prelude` (a direction plus the optional `in <color-interpolation>` tail like `45deg in oklab`) was internal, so a consumer keeping a gradient direction typed had to assemble token strings by hand. This exposes `Css.Gradient_direction.of_string` and prints `With_interpolation (Default_direction, i)` as just `in <i>`, omitting the redundant default that reparses distinctly from `to bottom`.

Stacked on #35.