### PR TITLE
optimize: merge non-adjacent same-condition @media when safe

### DIFF
--- a/lib/block.ml
+++ b/lib/block.ml
@@ -145,6 +145,103 @@ let merge_consecutive_media ~optimize_merged_block (stmts : statement list) :
     merge_media_blocks ~optimize_merged_block stmts
   else stmts
 
+(* Leaf rules reachable from a statement, descending into nested blocks. *)
+let rec leaf_rules stmt =
+  match stmt with
+  | Rule r -> r :: List.concat_map leaf_rules r.nested
+  | Media (_, b)
+  | Supports (_, b)
+  | Layer (_, b)
+  | Container (_, _, b)
+  | Starting_style b
+  | Origin (_, b)
+  | Moz_document (_, b)
+  | Scope (_, _, b)
+  | When (_, b)
+  | Else (_, b) ->
+      List.concat_map leaf_rules b
+  | _ -> []
+
+let decl_value_key d =
+  ( Declaration.property_name d,
+    Declaration.string_of_value ~minify:true d,
+    Declaration.is_important d )
+
+(* Two rules whose declarations would reorder unsafely: overlapping selectors
+   and a shared property set to a different value. Equal values reorder
+   freely. *)
+let rules_conflict (r1 : rule) (r2 : rule) =
+  Selector_summary.may_overlap
+    (Selector_summary.of_selector r1.selector)
+    (Selector_summary.of_selector r2.selector)
+  && List.exists
+       (fun a ->
+         let pa = Declaration.property_name a in
+         List.exists
+           (fun b ->
+             Declaration.property_name b = pa
+             && decl_value_key a <> decl_value_key b)
+           r2.declarations)
+       r1.declarations
+
+let needs_distant_media_merge stmts =
+  let conds =
+    List.filter_map (function Media (c, _) -> Some c | _ -> None) stmts
+  in
+  let rec dup = function
+    | [] -> false
+    | c :: rest -> List.exists (Media.equal c) rest || dup rest
+  in
+  dup conds
+
+(* CSS Conditional 3: same-condition [@media] blocks are spec-equivalent to one
+   block. Merge a later block into the first occurrence when hoisting it past
+   the intervening statements cannot reorder a conflicting rule. *)
+let merge_distant_media ~optimize_merged_block stmts =
+  if not (needs_distant_media_merge stmts) then stmts
+  else
+    let try_merge out cond block : statement list option =
+      let hoisted = List.concat_map leaf_rules block in
+      let rec split before :
+          statement list ->
+          (statement list * statement list * statement list) option = function
+        | [] -> None
+        | Media (c, b) :: after when Media.equal c cond ->
+            Some (List.rev before, b, after)
+        | x :: rest -> split (x :: before) rest
+      in
+      (* Only cross statements whose cascade is pure source order: plain rules
+         and conditional groups. Layers, origins, scopes, imports, etc.
+         establish ordering/context that hoisting past would change. *)
+      let crossable = function
+        | Rule _ | Declarations _ | Media _ | Supports _ | Container _ -> true
+        | _ -> false
+      in
+      match split [] out with
+      | None -> None
+      | Some (before, target, after) when List.for_all crossable after ->
+          let crossed = List.concat_map leaf_rules after in
+          if
+            List.exists
+              (fun h -> List.exists (rules_conflict h) crossed)
+              hoisted
+          then None
+          else Some (before @ [ Media (cond, target @ block) ] @ after)
+      | Some _ -> None
+    in
+    List.fold_left
+      (fun out stmt ->
+        match stmt with
+        | Media (cond, block) when not (has_nested_preference_media block) -> (
+            match try_merge out cond block with
+            | Some out' -> out'
+            | None -> out @ [ stmt ])
+        | _ -> out @ [ stmt ])
+      [] stmts
+    |> List.map (function
+      | Media (c, b) -> Media (c, optimize_merged_block b)
+      | s -> s)
+
 (* CSS Conditional Rules 5: adjacent same-condition [@supports] / [@container]
    blocks may be merged because the cascade evaluates them identically. Mirror
    the [@media] approach. *)

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -12,6 +12,15 @@ val merge_consecutive_media :
   Stylesheet.statement list
 (** Merge adjacent [@media] blocks with identical conditions. *)
 
+val merge_distant_media :
+  optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->
+  Stylesheet.statement list ->
+  Stylesheet.statement list
+(** Merge a later same-condition [@media] block into the first occurrence when
+    hoisting it past the intervening statements cannot reorder a conflicting
+    rule (overlapping selector with a shared property set to a different value).
+*)
+
 val merge_consecutive_supports :
   optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->
   Stylesheet.statement list ->

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -125,6 +125,7 @@ let reset_counters () =
 
 let merge_consecutive_layers = Block.merge_consecutive_layers
 let merge_consecutive_media = Block.merge_consecutive_media
+let merge_distant_media = Block.merge_distant_media
 let merge_consecutive_supports = Block.merge_consecutive_supports
 let merge_consecutive_containers = Block.merge_consecutive_containers
 let is_layer_empty = Block.is_layer_empty
@@ -206,6 +207,7 @@ let rec statements ~ctx ~enforce_spec (stmts : statement list) : statement list
         let stmts =
           stmts
           |> merge_consecutive_media ~optimize_merged_block
+          |> merge_distant_media ~optimize_merged_block
           |> merge_consecutive_supports ~optimize_merged_block
           |> merge_consecutive_containers ~optimize_merged_block
         in

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -407,6 +407,20 @@ let normalize_expected ~category ~id expected =
          authored unit. *)
       fixture ~category ~id ~upstream:"a{font-size:16px}"
         ~cascade:"a{font-size:12pt}" upstream
+  | "merging", "0008" ->
+      (* The upstream oracle keeps the two [@media (width>=1px)] blocks apart,
+         assuming a non-adjacent merge is always cascade-unsafe. Here it is
+         safe: the second block sets [background] while the intervening
+         [a{color:green}] sets [color], so no element's computed value changes
+         when the blocks merge. cascade merges them (and only when no shared
+         property reorders to a different value). *)
+      fixture ~category ~id
+        ~upstream:
+          "@media (width>=1px){a{color:red}}a{color:green}@media \
+           (width>=1px){a{background:#0b0}}"
+        ~cascade:
+          "@media(width>=1px){a{color:red;background:#0b0}}a{color:green}"
+        upstream
   | "values", "0057" ->
       (* The upstream oracle keeps [rgb(0 0 0)] verbatim to preserve the exact
          token string a script reads back via [getPropertyValue]. A complete

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1046,6 +1046,32 @@ let test_custom_value_close_paren_whitespace () =
     "optimize keeps whitespace after var()" "a{--x:var(--a) var(--b)}"
     (minify_str "a{--x:var(--a) var(--b)}")
 
+let test_distant_media_merge () =
+  (* Non-adjacent same-condition @media merge: safe when the crossed rule sets a
+     different property, so no element's computed value changes. *)
+  Alcotest.(check string)
+    "merges across a non-conflicting intervening rule"
+    "@media(width>=1px){a{color:red;background:#0b0}}a{color:green}"
+    (minify_str
+       "@media (width>=1px){a{color:red}}a{color:green}@media \
+        (width>=1px){a{background:#0b0}}");
+  (* A crossed rule that reorders the same property to a different value blocks
+     the merge. *)
+  Alcotest.(check string)
+    "keeps blocks apart on a conflicting reorder"
+    "@media(width>=1px){a{color:red}}a{color:green}@media(width>=1px){a{color:#00f}}"
+    (minify_str
+       "@media (width>=1px){a{color:red}}a{color:green}@media \
+        (width>=1px){a{color:blue}}");
+  (* A layer statement establishes cascade order; never merge across it. *)
+  Alcotest.(check string)
+    "no merge across a layer statement"
+    "@media(width>=1px){a{color:red}}@layer \
+     theme;@media(width>=1px){a{color:#00f}}"
+    (minify_str
+       "@media (width>=1px){a{color:red}}@layer theme;@media \
+        (width>=1px){a{color:blue}}")
+
 let test_keep_bang_comment_leading () =
   (* A bang comment (/*! ... */) is preserved by minify; it stays where it was
      authored rather than being moved past the following rule. *)
@@ -3702,6 +3728,7 @@ let selector_merging_tests =
     ( "custom value folds whitespace after a hard close-paren",
       `Quick,
       test_custom_value_close_paren_whitespace );
+    ("distant @media merge when safe", `Quick, test_distant_media_merge);
     ( "leading bang comment stays leading",
       `Quick,
       test_keep_bang_comment_leading );


### PR DESCRIPTION
`merge_consecutive_media` only joined adjacent `@media` blocks, so a stylesheet that reuses a media condition after intervening rules kept duplicate blocks. This adds `merge_distant_media`, which hoists a later same-condition block into the first occurrence when crossing the intervening statements cannot change any computed value: only plain rules and conditional groups may be crossed (not layers, scopes, or origins), and a crossed rule blocks the merge only when it shares a selector and sets a common property to a different value.