### PR TITLE
diff: equate quoted and unquoted font names in font-typed custom properties

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -398,6 +398,10 @@ let declaration_name = Declaration.property_name
 let declaration_value ?(minify = false) ?(inline = false) decl =
   Declaration.string_of_value ~minify ~inline decl
 
+let declaration_value_for_equivalence decl =
+  Declaration.string_of_value ~minify:false
+    (Declaration.unquote_custom_font_strings decl)
+
 (* Override rule function to return statement directly *)
 let rule ~selector ?nested ?merge_key declarations =
   Rule (Stylesheet.rule ~selector ?nested ?merge_key declarations)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1448,6 +1448,13 @@ val declaration_value : ?minify:bool -> ?inline:bool -> declaration -> string
     [inline] is [true] (default: [false]), variables are resolved to their
     default values. *)
 
+val declaration_value_for_equivalence : declaration -> string
+(** [declaration_value_for_equivalence decl] is the value of [decl] with a
+    quoted multi-word [<string>] in a custom-property token stream rewritten as
+    the equivalent unquoted [<ident>] sequence. Used as a structural-diff key so
+    [--font: "Noto Color Emoji"] and [--font: Noto Color Emoji] compare equal;
+    not for emission, where both forms stay verbatim. *)
+
 val string_of_declaration : ?minify:bool -> declaration -> string
 (** [string_of_declaration ~minify decl] converts a declaration to its string
     representation. If [minify] is [true] (default: [false]), the output is

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -90,6 +90,32 @@ let rec custom_declaration_layer = function
   | Declaration _ -> None
   | Theme_guarded { decl; _ } -> custom_declaration_layer decl
 
+(* Equivalence-only normalisation for structural diffing: rewrite a quoted
+   multi-word [<string>] in a custom-property token stream as the equivalent
+   unquoted [<ident>] sequence ([Properties.unquote_font_family_strings]). The
+   two forms substitute identically into [font-family], so cascade treats them
+   as equal even though it keeps both verbatim on output (a custom property is
+   opaque, so unquoting it for real could corrupt a [content] use). Gated on a
+   generic family being present: an unregistered custom property is otherwise
+   type-unknown ([var(--x)] could land in [content]), so only a value that
+   proves itself a font-family list folds. *)
+let unquote_custom_font_strings = function
+  | Declaration
+      {
+        property = Custom_property _ as property;
+        value = Custom_value ({ value = Tokens components; _ } as cv);
+        important;
+        _;
+      }
+    when Properties.components_have_generic_family components ->
+      v ~important property
+        (Custom_value
+           {
+             cv with
+             value = Tokens (Properties.unquote_font_family_strings components);
+           })
+  | decl -> decl
+
 (* Parser functions *)
 
 (** Parse a property name. Property names are plain idents in the component

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -40,6 +40,12 @@ val custom_property : ?layer:string -> string -> string -> declaration
 val custom_declaration_layer : declaration -> string option
 (** [custom_declaration_layer d] is the layer of [d], if any. *)
 
+val unquote_custom_font_strings : declaration -> declaration
+(** [unquote_custom_font_strings d] rewrites a quoted multi-word [<string>] in a
+    custom-property token stream as the equivalent unquoted [<ident>] sequence.
+    Equivalence-only normalisation for structural diffing; other declarations
+    pass through unchanged. *)
+
 val read_property_name : Cursor.t -> string
 (** [read_property_name t] is the property name read from [t]. *)
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -664,7 +664,7 @@ let strings_of_rule stmt =
 
 let decl_to_prop_value decl =
   let name = Css.declaration_name decl in
-  let value = Css.declaration_value ~minify:false decl in
+  let value = Css.declaration_value_for_equivalence decl in
   let value =
     if Css.declaration_is_important decl then value ^ " !important" else value
   in

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -15740,6 +15740,18 @@ let generic_font_family_keywords =
     "fangsong";
   ]
 
+(* A bare ident matching a generic family ([sans-serif], [ui-monospace], ...) is
+   only valid inside a font-family list, so its presence proves the whole token
+   stream is a font-family value (the same "the type is obviously correct"
+   reasoning that folds a colour function in an opaque stream). *)
+let components_have_generic_family components =
+  List.exists
+    (function
+      | Component.Preserved { kind = Token.Ident name; _ } ->
+          List.mem (String.lowercase_ascii name) generic_font_family_keywords
+      | _ -> false)
+    components
+
 let long_generic_family_start r =
   let is_ws = function
     | Component.Preserved { kind = Token.Whitespace; _ } -> true

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -51,6 +51,12 @@ val unquote_font_family_strings : custom_value -> custom_value
     equivalent in font-family-typed positions). Single-word strings and any
     token that isn't a [<string>] pass through unchanged. *)
 
+val components_have_generic_family : custom_value -> bool
+(** [components_have_generic_family components] is [true] when a bare ident in
+    [components] matches a generic font family ([sans-serif], [ui-monospace],
+    ...). A generic family is only valid in a font-family list, so its presence
+    proves the stream is a font-family value. *)
+
 val try_read_custom_color : custom_value -> custom_property_value option
 (** [try_read_custom_color tokens] parses [tokens] as a [<color>], returning a
     typed payload when the stream matches. *)

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -107,6 +107,24 @@ let canonical_custom_color_function_alpha () =
     (Cascade_diff.Css_compare.equal ~mode:`Canonical ".a { --c: transparent }"
        ".a { --c: #0000 }")
 
+let canonical_custom_font_family_quotes () =
+  (* A quoted multi-word font name and the unquoted ident sequence substitute
+     identically into font-family, so canonical comparison equates them inside a
+     custom-property body even though both forms stay verbatim on output. *)
+  Alcotest.(check bool)
+    "quoted and unquoted multi-word font name compare equal in a custom \
+     property"
+    true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       {|:root { --font-sans: ui-sans-serif, system-ui, "Noto Color Emoji" }|}
+       {|:root { --font-sans: ui-sans-serif, system-ui, Noto Color Emoji }|});
+  (* A single-word string could be a custom-ident in a non-font substitution
+     context, so it stays opaque: "foo" and foo are not equated. *)
+  Alcotest.(check bool)
+    "single-word quoted string stays distinct in a custom property" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical {|.a { --x: "foo" }|}
+       {|.a { --x: foo }|})
+
 let canonical_custom_calc_percentage () =
   let expected = ".a { --tw-translate-x: calc(1 / 2 * 100%) }" in
   let actual = ".a { --tw-translate-x: 50% }" in
@@ -824,6 +842,8 @@ let suite =
         canonical_custom_color_mix_tokens;
       Alcotest.test_case "canonical custom color-function alpha" `Quick
         canonical_custom_color_function_alpha;
+      Alcotest.test_case "canonical custom font-family quotes" `Quick
+        canonical_custom_font_family_quotes;
       Alcotest.test_case "canonical custom calc percentage" `Quick
         canonical_custom_calc_percentage;
       Alcotest.test_case "semantic with recovered warning" `Quick


### PR DESCRIPTION
The canonical comparator already equates a quoted multi-word font name with the unquoted ident sequence for typed `font-family` and `@property`-registered font custom properties, but kept an unregistered custom property distinct because `var(--x)` could feed `content:`. When the token stream contains a generic family (`sans-serif`, `ui-monospace`, ...) it is provably a font-family list, so the fold applies there too. cascade still keeps both forms verbatim on output; this is comparison-only.