### PR TITLE
optimize: fold a constant math function in opaque custom values

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20238,6 +20238,35 @@ let fold_custom_color ~lossless (c : Component.t) ~fallback =
       | Typed _ -> [ c ])
   | _ -> fallback ()
 
+(* A math function ([calc()], [min()], [clamp()], ...) is unconditionally a math
+   expression, so when its operands are all constants it reduces to a single
+   <number> with the same value in every [var()] substitution site - fold it
+   inside an opaque custom-property stream like a complete colour. A function
+   that still references a var or carries units does not reduce to a [Num] and
+   stays verbatim. *)
+let is_math_function name =
+  match String.lowercase_ascii name with
+  | "calc" | "min" | "max" | "clamp" | "round" | "mod" | "rem" | "abs" | "sign"
+  | "hypot" | "pow" | "sqrt" | "exp" | "log" ->
+      true
+  | _ -> false
+
+let fold_custom_calc (c : Component.t) ~fallback =
+  let text = Parser.to_string_custom [ c ] in
+  let cur = Cursor.of_string text in
+  match
+    try Some (Values.read_number cur) with Cursor.Parse_error _ -> None
+  with
+  | Some n when Cursor.is_done cur -> (
+      match Values.normalize_number n with
+      | Num _ as folded -> (
+          let canon = Pp.to_string ~minify:true Values.pp_number folded in
+          match read_custom_property_value (Cursor.of_string canon) with
+          | Tokens cs -> cs
+          | Typed _ -> [ c ])
+      | _ -> fallback ())
+  | _ -> fallback ()
+
 let rec canonicalize_custom_colors_components ~lossless comps =
   let fold_color c ~fallback = fold_custom_color ~lossless c ~fallback in
   List.concat_map
@@ -20256,6 +20285,17 @@ let rec canonicalize_custom_colors_components ~lossless comps =
               ])
       | Component.Preserved { kind = Token.Hash _; _ } ->
           fold_color c ~fallback:(fun () -> [ c ])
+      | Component.Func wrapped when is_math_function wrapped.Component.node.name
+        ->
+          fold_custom_calc c ~fallback:(fun () ->
+              let func = wrapped.Component.node in
+              let args =
+                canonicalize_custom_colors_components ~lossless func.arguments
+              in
+              [
+                Component.Func
+                  { wrapped with node = { func with arguments = args } };
+              ])
       | Component.Func wrapped ->
           let func = wrapped.Component.node in
           let args =

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -132,6 +132,20 @@ let canonical_custom_calc_percentage () =
     "unregistered custom calc token streams stay opaque" false
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
 
+let canonical_custom_calc_constant_fold () =
+  (* A math function whose operands are all constants reduces to the same number
+     in every substitution site, so [calc(2.25/1.875)] and [1.2] compare equal
+     inside a custom property. A calc that carries units or a var() does not
+     reduce and stays opaque. *)
+  Alcotest.(check bool)
+    "constant number calc folds in a custom property" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ".a { --lh: calc(2.25 / 1.875) }" ".a { --lh: 1.2 }");
+  Alcotest.(check bool)
+    "calc with a var stays distinct in a custom property" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ".a { --x: calc(var(--y) * 2) }" ".a { --x: 2 }")
+
 let semantic_with_recovered_warning () =
   let expected =
     "@unknown { color: red } .a { -webkit-tap-highlight-color: transparent; \
@@ -900,6 +914,8 @@ let suite =
         canonical_custom_font_family_quotes;
       Alcotest.test_case "canonical custom calc percentage" `Quick
         canonical_custom_calc_percentage;
+      Alcotest.test_case "canonical custom calc constant fold" `Quick
+        canonical_custom_calc_constant_fold;
       Alcotest.test_case "semantic with recovered warning" `Quick
         semantic_with_recovered_warning;
       Alcotest.test_case "semantic custom var fallback" `Quick


### PR DESCRIPTION
A `calc()` / `min()` / `clamp()` (and the rest of the math family) whose operands are all constants reduces to a single `<number>` with the same value in every `var()` substitution site, so cascade now folds it inside an opaque custom-property token stream just like a complete colour function (#31) or hex colour (#32). A function that still carries units or a `var()` does not reduce to a number and stays verbatim.

This lets a theme variable like `--text-3xl--line-height: calc(2.25/1.875)` compare equal to the folded `1.2` under canonical diff, which a downstream consumer emitting the same ratio as a typed value needs.