### PR TITLE
declaration: add tab_size_value for length-valued tab-size

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7151,6 +7151,10 @@ val tab_size : int -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size} tab-size}
     property. *)
 
+val tab_size_value : tab_size -> declaration
+(** [tab_size_value v] is the [tab-size] property from a typed value, allowing a
+    [<length>] in addition to an integer. *)
+
 val font_variation_settings : font_variation_settings -> declaration
 (** [font_variation_settings settings] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings}

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2356,6 +2356,7 @@ let border ?width ?style ?color () =
 
 let border_block value = v Border_block value
 let tab_size value = v Tab_size (Int value : tab_size)
+let tab_size_value value = v Tab_size (value : tab_size)
 let webkit_text_size_adjust value = v Webkit_text_size_adjust value
 let font_feature_settings value = v Font_feature_settings value
 let font_variation_settings value = v Font_variation_settings value

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -1505,6 +1505,10 @@ val border :
 val tab_size : int -> declaration
 (** [tab_size v] is the CSS [tab-size] property. *)
 
+val tab_size_value : tab_size -> declaration
+(** [tab_size_value v] is the CSS [tab-size] property from a typed value,
+    allowing a [<length>] in addition to an integer. *)
+
 val webkit_text_size_adjust : text_size_adjust -> declaration
 (** [webkit_text_size_adjust v] is the WebKit-only [-webkit-text-size-adjust] p
     roperty. *)


### PR DESCRIPTION
Adds a `tab_size_value` declaration helper accepting an integer or a length, so a tab-size can be set from a length value rather than only an integer. Needed to model Tailwind's `tab-*` utilities.