### PR TITLE
properties: add the zoom property

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7196,6 +7196,21 @@ val scrollbar_color : scrollbar_color -> declaration
 val scrollbar_gutter : scrollbar_gutter -> declaration
 (** [scrollbar_gutter v] is the [scrollbar-gutter] property. *)
 
+type zoom = Properties.zoom =
+  | Normal
+  | Reset
+  | Num of float
+  | Pct of float
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of zoom var
+
+val zoom : zoom -> declaration
+(** [zoom v] is the CSS [zoom] property. *)
+
 val font_variation_settings : font_variation_settings -> declaration
 (** [font_variation_settings settings] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings}

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1218,6 +1218,7 @@ let read_position_value_prop : type a.
       Some (v Forced_color_adjust (read_forced_color_adjust t))
   | Scroll_snap_type -> Some (v Scroll_snap_type (read_scroll_snap_type t))
   | Tab_size -> Some (v Tab_size (read_tab_size t))
+  | Zoom -> Some (v Zoom (read_zoom t))
   | _ -> None
 
 let read_vendor_font_value : type a.
@@ -2360,6 +2361,7 @@ let tab_size_value value = v Tab_size (value : tab_size)
 let scrollbar_width value = v Scrollbar_width value
 let scrollbar_color value = v Scrollbar_color value
 let scrollbar_gutter value = v Scrollbar_gutter value
+let zoom value = v Zoom value
 let webkit_text_size_adjust value = v Webkit_text_size_adjust value
 let font_feature_settings value = v Font_feature_settings value
 let font_variation_settings value = v Font_variation_settings value

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -1518,6 +1518,9 @@ val scrollbar_color : scrollbar_color -> declaration
 val scrollbar_gutter : scrollbar_gutter -> declaration
 (** [scrollbar_gutter v] is the CSS [scrollbar-gutter] property. *)
 
+val zoom : zoom -> declaration
+(** [zoom v] is the CSS [zoom] property. *)
+
 val webkit_text_size_adjust : text_size_adjust -> declaration
 (** [webkit_text_size_adjust v] is the WebKit-only [-webkit-text-size-adjust] p
     roperty. *)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -5151,6 +5151,19 @@ let rec pp_tab_size : tab_size Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_tab_size ctx v
 
+let rec pp_zoom : zoom Pp.t =
+ fun ctx -> function
+  | Normal -> Pp.string ctx "normal"
+  | Reset -> Pp.string ctx "reset"
+  | Num n -> Pp.float ctx n
+  | Pct p -> Pp.pct ctx p
+  | Initial -> Pp.string ctx "initial"
+  | Inherit -> Pp.string ctx "inherit"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_zoom ctx v
+
 let rec pp_order : order Pp.t =
  fun ctx -> function
   | Int i -> Pp.int ctx i
@@ -7035,6 +7048,7 @@ let pp_property : type a. a property Pp.t =
   | Border -> Pp.string ctx "border"
   | Background -> Pp.string ctx "background"
   | Tab_size -> Pp.string ctx "tab-size"
+  | Zoom -> Pp.string ctx "zoom"
   | Webkit_text_size_adjust -> Pp.string ctx "-webkit-text-size-adjust"
   | Font_feature_settings -> Pp.string ctx "font-feature-settings"
   | Font_variation_settings -> Pp.string ctx "font-variation-settings"
@@ -15346,6 +15360,29 @@ let rec read_tab_size (t : Cursor.t) : tab_size =
     ~var:(fun t -> Var (Values.read_var read_tab_size t))
     ~default:read_value t
 
+let rec read_zoom (t : Cursor.t) : zoom =
+  let read_value t =
+    match Cursor.percentage_opt t with
+    | Some p -> (Pct p : zoom)
+    | None -> (
+        match Cursor.number_opt t with
+        | Some n -> Num n
+        | None ->
+            Cursor.err_invalid t "expected a number or percentage for zoom")
+  in
+  Cursor.enum_or_var "zoom"
+    [
+      ("normal", (Normal : zoom));
+      ("reset", Reset);
+      ("initial", Initial);
+      ("inherit", Inherit);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (Values.read_var read_zoom t))
+    ~default:read_value t
+
 let rec read_text_decoration_skip_ink t : text_decoration_skip_ink =
   Cursor.enum_or_var "text-decoration-skip-ink"
     [
@@ -18715,6 +18752,7 @@ let read_any_property t =
   | "font" -> Prop Font
   | "outline" -> Prop Outline
   | "z-index" -> Prop Z_index
+  | "zoom" -> Prop Zoom
   | "inset" -> Prop Inset
   | "inset-inline" -> Prop Inset_inline
   | "inset-inline-start" -> Prop Inset_inline_start
@@ -20986,6 +21024,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Mix_blend_mode -> pp pp_blend_mode
   | Z_index -> pp pp_z_index
   | Tab_size -> pp pp_tab_size
+  | Zoom -> pp pp_zoom
   | Webkit_line_clamp -> pp pp_webkit_line_clamp
   | Webkit_box_orient -> pp pp_webkit_box_orient
   | Inset -> pp (pp_box_shorthand pp_length)

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -659,8 +659,14 @@ val read_z_index : Cursor.t -> z_index
 val pp_tab_size : tab_size Pp.t
 (** [pp_tab_size] is the pretty-printer for [tab_size]. *)
 
+val pp_zoom : zoom Pp.t
+(** [pp_zoom] is the pretty-printer for [zoom]. *)
+
 val read_tab_size : Cursor.t -> tab_size
 (** [read_tab_size t] is the [tab_size] parsed from [t]. *)
+
+val read_zoom : Cursor.t -> zoom
+(** [read_zoom t] is the [zoom] value parsed from [t]. *)
 
 val pp_order : order Pp.t
 (** [pp_order] is the pretty-printer for [order]. *)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -203,6 +203,18 @@ type tab_size =
   | Revert_layer
   | Var of tab_size var
 
+type zoom =
+  | Normal
+  | Reset
+  | Num of float
+  | Pct of float
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of zoom var
+
 type order =
   | Int of int
   | Calc of string
@@ -4442,6 +4454,7 @@ type 'a property =
   | Border_inline_end : border property
   | Background : background list property
   | Tab_size : tab_size property
+  | Zoom : zoom property
   | Webkit_text_size_adjust : text_size_adjust property
   | Font_feature_settings : font_feature_settings property
   | Font_variation_settings : font_variation_settings property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -933,6 +933,13 @@ let vars_of_tab_size (value : Properties.tab_size) : any_var list =
   | Var v -> [ V v ]
   | Initial | Inherit | Unset | Revert | Revert_layer -> []
 
+let vars_of_zoom (value : Properties.zoom) : any_var list =
+  match value with
+  | Var v -> [ V v ]
+  | Normal | Reset | Num _ | Pct _ | Initial | Inherit | Unset | Revert
+  | Revert_layer ->
+      []
+
 let compare_vars_by_name (V x) (V y) = String.compare x.name y.name
 
 (** {1 Variable name utilities} *)
@@ -2006,6 +2013,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   (* Opacity (typed math) *)
   | Opacity, value -> vars_of_opacity value
   | Tab_size, value -> vars_of_tab_size value
+  | Zoom, value -> vars_of_zoom value
   | Align_content, value -> vars_of_align_content value
   | Align_items, value -> vars_of_align_items value
   | Align_self, value -> vars_of_align_self value

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -984,6 +984,7 @@ let check_shape_image_threshold =
     pp_shape_image_threshold
 
 let check_tab_size = check_value_cursor "tab_size" read_tab_size pp_tab_size
+let check_zoom = check_value_cursor "zoom" read_zoom pp_zoom
 let check_text_box = check_value_cursor "text_box" read_text_box pp_text_box
 
 let check_text_box_edge =
@@ -1174,6 +1175,13 @@ let test_overflow () =
   neg_cursor read_overflow "none";
   (* overflow accepts at most two axes *)
   neg_cursor read_overflow "visible hidden scroll"
+
+let test_zoom () =
+  check_zoom "normal";
+  check_zoom "reset";
+  check_zoom "50%";
+  check_zoom "1.5";
+  neg_cursor read_zoom "not-a-zoom"
 
 let test_border_style () =
   check_border_style "none";
@@ -3589,6 +3597,8 @@ let spec_generated_box_layout_edges () =
   check_overflow_clip_margin "content-box 1px";
   check_shape_image_threshold ".5";
   check_tab_size "4";
+  check_zoom "50%";
+  check_zoom "normal";
   neg_cursor read_alignment_baseline "baseline middle";
   neg_cursor read_baseline_shift "sub super";
   neg_cursor read_baseline_source "middle";
@@ -3816,6 +3826,7 @@ let tests =
     test_case "display" `Quick test_display;
     test_case "position" `Quick test_position;
     test_case "overflow" `Quick test_overflow;
+    test_case "zoom" `Quick test_zoom;
     test_case "border-style" `Quick test_border_style;
     test_case "border" `Quick test_border;
     test_case "visibility" `Quick test_visibility;


### PR DESCRIPTION
Adds the `zoom` property with typed values (normal, reset, number, percentage, var). Stacked on #54.