### PR TITLE
selector: reduce :is(<single>) to its argument in normalize

### DIFF
--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2159,21 +2159,6 @@ and pp : t Pp.t =
   | Cue selectors -> elem_func ctx "cue" sels selectors
   | Cue_region selectors -> elem_func ctx "cue-region" sels selectors
   (* Functional pseudo-classes *)
-  | Is [ single ]
-    when Pp.minified ctx
-         &&
-         match single with
-         | Combined _ | Relative _ | List _ -> false
-         | _ -> true ->
-      (* CSS Selectors 4 17: a single-argument [:is(s)] matches the same
-         elements as [s] with the same specificity. The forgiving list drops
-         invalid arguments so a [:is(:future-pseudo, .a)] also reduces here,
-         which the spec test asserts. The reduction is sound only when [s] is a
-         single compound: when [s] carries a combinator ([Combined] /
-         [Relative], or a [List]) the [:is()] is a grouping boundary, and
-         splicing the argument into the surrounding compound would re-anchor the
-         combinator and change the match set. *)
-      pp ctx single
   | Is selectors
     when Pp.minified ctx && List.sort compare selectors = [ Link; Visited ] ->
       (* CSS Selectors 4 sec. 8.2: [:any-link] is defined as equivalent to
@@ -2347,7 +2332,20 @@ let canonicalize sel =
               else Compound components')
       | List selectors -> canon (fun xs -> List xs) selectors
       | Where selectors -> canon (fun xs -> Where xs) selectors
-      | Is selectors -> canon (fun xs -> Is xs) selectors
+      | Is selectors -> (
+          (* CSS Selectors 4 sec. 17: a single-argument [:is(s)] matches the
+             same elements as [s] with the same specificity, so it reduces to
+             [s]. Sound only when [s] is a single compound: a combinator
+             ([Combined] / [Relative]) or a [List] makes [:is()] a grouping
+             boundary that cannot be spliced into the surrounding compound. *)
+          let sorted = canonicalize_unordered_list selectors in
+          match sorted with
+          | [ single ]
+            when match single with
+                 | Combined _ | Relative _ | List _ -> false
+                 | _ -> true ->
+              single
+          | _ -> if list_same sorted selectors then node else Is sorted)
       | Not selectors -> canon (fun xs -> Not xs) selectors
       | Has selectors -> canon (fun xs -> Has xs) selectors
       | Moz_any_call selectors -> canon (fun xs -> Moz_any_call xs) selectors

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -1286,11 +1286,12 @@ let test_spec_forgiving_selector_lists () =
      :not(), and :has() remain unforgiving. *)
   check_minified_to ":is(.valid,#id)" ":is(.valid,:future-pseudo,#id)";
   check_minified_to ":where(.valid,#id)" ":where(.valid,:future-pseudo,#id)";
-  (* Per shortest-wins, single-argument [:is(.item)] unwraps to bare [.item]
-     (same match set, same specificity per Selectors L4 §17). [:where()] cannot
-     unwrap because it contributes zero specificity while bare [.item]
-     contributes a class specificity. *)
-  check_minified_to ".item" ":is(, .item)";
+  (* Single-argument [:is(.item)] is spec-equivalent to bare [.item] (same match
+     set and specificity per Selectors L4 §17), but unwrapping it is a node
+     change reserved for the optimizer's [Selector.canonicalize]; pp is
+     lexical-only and holds the [:is()]. [:where()] holds too (and could not
+     unwrap regardless, contributing zero specificity). *)
+  check_minified_to ":is(.item)" ":is(, .item)";
   check_minified_to ":where(.item)" ":where(, .item)";
   check_minified_to ":is()" ":is()";
   check_minified_to ":where()" ":where()";


### PR DESCRIPTION
Moves the single-argument `:is()` reduction from the minify printer into the AST canonicalize pass, so the optimizer and the canonical comparator treat `:is(.a)` and `.a` as equal (it was previously minify-only). Aligns with the policy that node-changing folds live in normalize, not pp. Stacked on #54.