### PR TITLE
ci: run on pull requests targeting any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
Drops the `branches: [main]` filter on the `pull_request` trigger so CI runs on stacked PRs whose base is a feature branch, not only PRs targeting `main`. Push events stay limited to `main`.