### PR TITLE
values: keep 3 hue decimals under minify

### DIFF
--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3499,7 +3499,11 @@ let rec pp_angle : angle Pp.t =
    and matches the shipping-minifier convention. *)
 let pp_hue_float ctx f =
   if Pp.minified ctx then
-    let max_decimals = if ctx.Pp.lossless then 8 else 1 in
+    (* 3 decimals, matching the oklch/lch colour axes: at high chroma a hue
+       rounded to 1 decimal shifts the rendered colour (e.g. an oklch hue of
+       262.881 must not collapse to 262.9). Trailing zeros are dropped, so
+       integer hues stay integers. *)
+    let max_decimals = if ctx.Pp.lossless then 8 else 3 in
     Pp.string ctx (Pp.string_of_float ~drop_leading_zero:true ~max_decimals f)
   else Pp.float ctx f
 

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -190,15 +190,35 @@ let normalize_expected ~category ~id expected =
   let upstream = expected in
   let expected = normalize_expected_tokens expected in
   match (category, id) with
+  | "colors", "0029" ->
+      (* color-mix(in oklch, red, blue) folds to a static oklch(). cascade keeps
+         3 hue decimals (326.643) where the keithamus oracle rounds to 1
+         (326.6): a 1-decimal hue at this chroma shifts the rendered colour. *)
+      fixture ~category ~id ~upstream:"a{color:oklch(.54 .285 326.6)}"
+        ~cascade:"a{color:oklch(.54 .285 326.643)}" upstream
   | "colors", "0044" ->
       (* color-mix(in oklch, lime, blue) folds to a static oklch(). On the
          evergreen default target oklch chroma takes a <percentage> (CSS Color
          4: 100% = 0.4 on this axis), so chroma .304 serializes as the exact,
          shorter 76% - the same number->% chroma canonicalization as
          colors/0047. The keithamus oracle keeps the number form, which
-         --enforce-spec emits. *)
+         --enforce-spec emits. cascade keeps 3 hue decimals (203.274) where the
+         oracle rounds to 1 (203.3): at this chroma a 1-decimal hue shifts the
+         rendered colour. *)
       fixture ~category ~id ~upstream:"a{color:oklch(.659 .304 203.3)}"
-        ~cascade:"a{color:oklch(.659 76% 203.3)}" upstream
+        ~cascade:"a{color:oklch(.659 76% 203.274)}" upstream
+  | "colors", "0046" ->
+      (* cascade keeps 3 hue decimals (180.457 vs the oracle's 180.5); the
+         oklab() leading-channel space elision is the usual safe-token-boundary
+         normalization. *)
+      fixture ~category ~id
+        ~upstream:
+          "a{color:oklch(.554 .123 180.5/.746);background-color:oklab(.654 \
+           -.235 .189)}"
+        ~cascade:
+          "a{color:oklch(.554 .123 \
+           180.457/.746);background-color:oklab(.654-.235 .189)}"
+        upstream
   | "colors", "0047" ->
       (* CSS Color 4 defines 100% lch() chroma as 150 on this axis, so rounded
          chroma 100.5 is exactly 67%, and [67%] is shorter. The lab() channel
@@ -209,7 +229,7 @@ let normalize_expected ~category ~id expected =
           "a{color:lch(54.3 100.5 274.5/.746);background-color:lab(54.3 -60.5 \
            70.8)}"
         ~cascade:
-          "a{color:lch(54.3 67% 274.5/.746);background-color:lab(54.3-60.5 \
+          "a{color:lch(54.3 67% 274.456/.746);background-color:lab(54.3-60.5 \
            70.8)}"
         upstream
   | "colors", "0048" ->


### PR DESCRIPTION
A minified oklch/lch hue was rounded to 1 decimal. At high chroma that shifts the rendered colour: oklch hue `262.881` collapsed to `262.9`, turning `blue-600` into `#165dfc` instead of Tailwind's `#155dfc`. Match the 3-decimal precision already used for the colour axes (trailing zeros still drop).

The css-minify interop oracle gains cascade overrides for `colors` 0029/0044/0046/0047, where the 3-decimal hue now diverges from the Lightning CSS oracle's 1-decimal rounding (the traces stay pristine; the override records both oracles).