### PR TITLE
optimize: drop unionFind, document and scale-test the merge loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,22 @@ token boundary, so the space after it is dropped (`drop-shadow(a) drop-shadow(b)
 -> `drop-shadow(a)drop-shadow(b)`). The space after a `var()` / `env()` / `attr()`
 stays, since the substituted value could otherwise merge with its neighbour.
 
+### How rule merging scales
+
+The rule-level rewrites run as an *incremental, priority-driven* merge loop, not
+repeated full passes. Rules live in a pool that keeps cascade order with O(1)
+precedence queries (order-maintenance) and merge classes in a small union-find;
+a priority-search queue holds the frontier of candidate merges, largest
+byte-saving first. Applying a merge re-scores only the rules it touched, so the
+loop never re-scans the whole stylesheet.
+
+The simpler alternative -- a batch fixpoint that re-scans every rule each pass
+until nothing changes -- needs none of that machinery, but is O(passes x rules)
+and tends towards quadratic on large stylesheets. The incremental loop is
+O(n log n): doubling the rule count costs about 2.2x work, well under the 4x a
+quadratic shows (measured in `test/test_loop.ml`). The internals are documented
+in `lib/loop.mli` and `lib/pool.mli`.
+
 ### Color approximation
 
 Cascade folds colors only within `0.002` ΔE<sub>OK</sub> (the CSS Color 4

--- a/cascade.opam
+++ b/cascade.opam
@@ -25,7 +25,6 @@ depends: [
   "fmt"
   "base-unix"
   "uutf"
-  "unionFind"
   "psq"
   "logs"
   "cmdliner"

--- a/dune-project
+++ b/dune-project
@@ -30,7 +30,6 @@
   fmt
   base-unix
   uutf
-  unionFind
   psq
   logs
   cmdliner

--- a/lib/dune
+++ b/lib/dune
@@ -3,7 +3,7 @@
  (name cascade)
  (flags
   (:standard -w -9))
- (libraries uutf unionFind psq logs unix))
+ (libraries uutf psq logs unix))
 
 (mdx
  (files

--- a/lib/loop.mli
+++ b/lib/loop.mli
@@ -1,4 +1,35 @@
-(** Best-first rewrite loop over a mutable pool. *)
+(** Best-first rewrite loop over a mutable rule pool: the incremental engine the
+    minifier uses to merge rules.
+
+    {1 Design: incremental, priority-driven, order-preserving}
+
+    Rules are merged greedily, largest byte-saving first, while keeping cascade
+    order intact. Two structures cooperate with this loop:
+
+    - {!Pool} holds the rules in cascade order (via {!Order_maintenance}, so "is
+      A before B?" is O(1)) with merge classes in a union-find (so a handle to
+      an original rule still resolves to its merged representative);
+    - a priority-search queue is the {b frontier} -- the next merge to try,
+      keyed by saving, with O(log n) removal of a candidate a prior merge
+      invalidated.
+
+    Applying a merge re-scores only the handful of anchors it touched and pushes
+    them back on the frontier; the loop never re-scans the whole stylesheet.
+
+    {1 The simpler alternative}
+
+    A {b batch fixpoint} -- re-scan every rule each pass until a pass changes
+    nothing -- needs none of these structures and is materially less code. Its
+    cost is throughput: each pass is O(rules) and, on a chain that merges
+    pairwise, it tends towards quadratic overall. This loop spends the extra
+    machinery to buy that throughput back.
+
+    {1 Scaling}
+
+    Draining a chain of [n] adjacent merges is O(n log n): each doubling of [n]
+    costs ~2.2x work, well under the 4x a quadratic shows. The "scales
+    sub-quadratically" case in [test/test_loop.ml] measures it on allocation (a
+    deterministic proxy for work) and asserts the ratio. *)
 
 type action
 (** A rewrite action scored for one anchor node. *)

--- a/lib/pool.ml
+++ b/lib/pool.ml
@@ -3,14 +3,55 @@
    elements (so a stale handle still resolves to the merged rule via [find]) and
    drops the merged-away node from the order. *)
 
-module UF = UnionFind
+(* Union-find with path compression and union by rank, carrying a value at each
+   class root. The merge callback combines the two class values. *)
+module UF = struct
+  type 'a elem = 'a node ref
+
+  and 'a node =
+    | Root of { mutable value : 'a; mutable rank : int }
+    | Link of 'a elem
+
+  let v value = ref (Root { value; rank = 0 })
+
+  let rec find e =
+    match !e with
+    | Root _ -> e
+    | Link parent ->
+        let root = find parent in
+        e := Link root;
+        root
+
+  let get e = match !(find e) with Root r -> r.value | Link _ -> assert false
+
+  let set e value =
+    match !(find e) with Root r -> r.value <- value | Link _ -> assert false
+
+  let merge f a b =
+    let ra = find a and rb = find b in
+    if ra == rb then ra
+    else
+      match (!ra, !rb) with
+      | Root da, Root db ->
+          let value = f da.value db.value in
+          if da.rank < db.rank then (
+            db.value <- value;
+            ra := Link rb;
+            rb)
+          else (
+            da.value <- value;
+            if da.rank = db.rank then da.rank <- da.rank + 1;
+            rb := Link ra;
+            ra)
+      | _ -> assert false
+end
 
 type node = Stylesheet.rule UF.elem Order_maintenance.node
 type t = Stylesheet.rule UF.elem Order_maintenance.t
 
 let of_rules rs =
   let t = Order_maintenance.v () in
-  List.iter (fun r -> ignore (Order_maintenance.add_last t (UF.make r))) rs;
+  List.iter (fun r -> ignore (Order_maintenance.add_last t (UF.v r))) rs;
   t
 
 let elem n = Order_maintenance.data n
@@ -30,6 +71,6 @@ let combine t a b f =
   Order_maintenance.remove t b;
   a
 
-let insert_after t n r = Order_maintenance.insert_after t n (UF.make r)
-let insert_before t n r = Order_maintenance.insert_before t n (UF.make r)
+let insert_after t n r = Order_maintenance.insert_after t n (UF.v r)
+let insert_before t n r = Order_maintenance.insert_before t n (UF.v r)
 let remove t n = Order_maintenance.remove t n

--- a/lib/pool.mli
+++ b/lib/pool.mli
@@ -6,9 +6,13 @@
 
     - {b order} is kept by {!Order_maintenance}, so "does rule A come before
       rule B?" stays O(1) as rules are inserted and removed;
-    - {b merge classes} are kept by a union-find (Pottier's [UnionFind]), so
-      combining two rules is near-constant and a handle to an original rule
-      still resolves to its current merged representative.
+    - {b merge classes} are kept by a small in-tree union-find (path-compressed,
+      union-by-rank, in [pool.ml]), so combining two rules is near-constant and
+      a handle to an original rule still resolves to its current merged
+      representative.
+
+    {!Loop} drives the greedy, priority-ordered merging over this pool; its
+    interface documents that design and the simpler batch-fixpoint alternative.
 
     A {!node} is a stable handle to one live rule. Combining or removing a node
     invalidates it; the surviving node keeps the merged rule. *)

--- a/test/test_loop.ml
+++ b/test/test_loop.ml
@@ -202,6 +202,64 @@ let test_fuzz_overlapping_rewrite_queue_matches_greedy_oracle () =
       "final rule order" expected_names (names pool)
   done
 
+(* Scalability. The loop re-scores only the anchors a merge actually touches and
+   keeps its frontier in a priority-search queue, so draining N adjacent merges
+   is O(N log N) work. A batch fixpoint (re-scan every rule each pass until
+   nothing changes) would instead do O(passes x rules); on a chain that merges
+   pairwise it degrades towards quadratic. We measure allocation (a
+   deterministic proxy for work, unlike wall-clock) at growing N and assert each
+   doubling stays well under the 4x a quadratic would show. *)
+let drain_pairwise count =
+  let pool = Pool.of_rules (List.init count (fun _ -> mk "r")) in
+  (* Track the original nodes by stable id (selector-name parsing caps at three
+     digits); a merge replaces its anchor with a non-original ["m"] node, so
+     only original-original adjacencies stay mergeable -- a maximal matching of
+     [count / 2] merges down the chain. *)
+  let originals = Hashtbl.create count in
+  List.iter
+    (fun n -> Hashtbl.replace originals (Pool.id n) ())
+    (Pool.nodes pool);
+  let is_original node = Hashtbl.mem originals (Pool.id node) in
+  let score node =
+    if is_original node then
+      match Pool.next node with
+      | Some next when is_original next ->
+          Some
+            (Loop.action ~replacement:[ mk "m" ] ~consumed:[ next ] ~saving:1)
+      | _ -> None
+    else None
+  in
+  Gc.full_major ();
+  let w0 = Gc.minor_words () in
+  let t0 = Unix.gettimeofday () in
+  let applied = Loop.run (Loop.v pool score) in
+  let ms = (Unix.gettimeofday () -. t0) *. 1000. in
+  (applied, Gc.minor_words () -. w0, ms)
+
+let test_scales_subquadratically () =
+  let sizes = [ 1000; 2000; 4000; 8000 ] in
+  let rows = List.map (fun n -> (n, drain_pairwise n)) sizes in
+  List.iter
+    (fun (n, (applied, words, ms)) ->
+      Alcotest.(check int)
+        (Fmt.str "N=%d merges every adjacent pair" n)
+        (n / 2) applied;
+      Fmt.epr "  N=%-5d  words/rule=%-6.1f  %.2f ms@." n (words /. float n) ms)
+    rows;
+  (* Each doubling of N must keep allocation growth well below the 4x a
+     quadratic shows; O(N log N) lands around 2.1-2.2x. *)
+  let words = List.map (fun (_, (_, w, _)) -> w) rows in
+  let rec doublings = function
+    | a :: (b :: _ as rest) -> (b /. a) :: doublings rest
+    | _ -> []
+  in
+  List.iter
+    (fun r ->
+      Alcotest.(check bool)
+        (Fmt.str "per-doubling work ratio %.2f stays sub-quadratic (< 2.6)" r)
+        true (r < 2.6))
+    (doublings words)
+
 let suite =
   ( "loop",
     [
@@ -217,4 +275,6 @@ let suite =
         test_large_non_overlapping_rewrite_queue;
       Alcotest.test_case "fuzz overlapping rewrite queue matches greedy oracle"
         `Quick test_fuzz_overlapping_rewrite_queue_matches_greedy_oracle;
+      Alcotest.test_case "scales sub-quadratically with rule count" `Quick
+        test_scales_subquadratically;
     ] )


### PR DESCRIPTION
Cleans up and documents the optimizer's rule-merge machinery.

- **deps: drop unionFind** — the rule pool used Pottier's `unionFind` only for `make`/`find`/`get`/`set`/`merge`, so inline a small path-compressed, union-by-rank union-find in `pool.ml` and drop the dependency. Also removes a GitLab-hosted archive whose regenerated tarball checksum intermittently broke `opam install` (and CI) on unrelated PRs.
- **doc** — make the design explicit in `loop.mli`, `pool.mli`, and the README: rule merging is an incremental, priority-driven, order-preserving loop (order-maintenance + in-tree union-find + a priority-search frontier), and why — the simpler batch fixpoint needs none of it but degrades towards quadratic.
- **test** — assert the loop scales sub-quadratically: draining N adjacent merges keeps the per-doubling allocation ratio near 2.2x (O(N log N)), well under the 4x a quadratic shows. Allocation is deterministic, so the assertion is stable, not wall-clock-flaky.