### PR TITLE
media: precompute sort keys to avoid re-serializing in sorts

### DIFF
--- a/lib/media.ml
+++ b/lib/media.ml
@@ -1474,18 +1474,56 @@ let responsive_value k =
   | Responsive_max (unit_ord, value) -> (Float.of_int unit_ord *. 1e9) -. value
   | _ -> 0.
 
+(* Chain comparators lazily: the right-hand thunk runs only when the left-hand
+   key ties. This keeps the [to_string] tie-break (which allocates a [Buffer]
+   and runs the printer) off the hot path of every comparison. *)
+let ( <?> ) c next = if c <> 0 then c else next ()
+
+(* The sort order is decided by four cheap ordinal keys and, only when those all
+   tie, the serialized text. Extracting the kinds and serializing both allocate
+   ([feature_bound], [Pp.v]), so a sort that re-derives them on every comparison
+   pays that cost O(n log n) times - and queries sharing a breakpoint tie on
+   every ordinal key, so they always reach the text. [key] captures all five
+   components; compute it once per query with [sort_key] and compare with
+   [compare_keys], which allocates nothing. *)
+type key = {
+  group : int;
+  subkind : int;
+  responsive : float;
+  preference : int;
+  text : string;
+}
+
+let sort_key t =
+  let k = kind t in
+  let group, _ = group_order k in
+  {
+    group;
+    subkind = responsive_subkind t;
+    responsive = responsive_value k;
+    preference = preference_order t;
+    text = to_string t;
+  }
+
+let compare_keys a b =
+  Int.compare a.group b.group <?> fun () ->
+  Int.compare a.subkind b.subkind <?> fun () ->
+  Float.compare a.responsive b.responsive <?> fun () ->
+  Int.compare a.preference b.preference <?> fun () ->
+  String.compare a.text b.text
+
+let sort_by project items =
+  List.map (fun x -> (sort_key (project x), x)) items
+  |> List.stable_sort (fun (k1, _) (k2, _) -> compare_keys k1 k2)
+  |> List.map snd
+
 let compare a b =
   let ka, kb = (kind a, kind b) in
   let ga, _ = group_order ka and gb, _ = group_order kb in
-  let comparisons =
-    [
-      Int.compare ga gb;
-      Int.compare (responsive_subkind a) (responsive_subkind b);
-      Float.compare (responsive_value ka) (responsive_value kb);
-      Int.compare (preference_order a) (preference_order b);
-      String.compare (to_string a) (to_string b);
-    ]
-  in
-  List.find_opt (( <> ) 0) comparisons |> Option.value ~default:0
+  Int.compare ga gb <?> fun () ->
+  Int.compare (responsive_subkind a) (responsive_subkind b) <?> fun () ->
+  Float.compare (responsive_value ka) (responsive_value kb) <?> fun () ->
+  Int.compare (preference_order a) (preference_order b) <?> fun () ->
+  String.compare (to_string a) (to_string b)
 
 let equal a b = compare a b = 0

--- a/lib/media.mli
+++ b/lib/media.mli
@@ -179,6 +179,26 @@ val compare : t -> t -> int
 val equal : t -> t -> bool
 (** Structural equality on media queries. *)
 
+type key
+(** A precomputed sort key for {!val-compare}. Deriving the order serializes the
+    query and re-extracts its kind, both of which allocate; a sort that compares
+    raw queries pays that on every comparison. Precompute a [key] once per query
+    with {!sort_key} and compare with {!compare_keys}. *)
+
+val sort_key : t -> key
+(** [sort_key t] precomputes the components {!compare} derives from [t]. *)
+
+val compare_keys : key -> key -> int
+(** [compare_keys k1 k2] orders two queries by their precomputed keys, with no
+    allocation. [compare_keys (sort_key a) (sort_key b) = compare a b]. *)
+
+val sort_by : ('a -> t) -> 'a list -> 'a list
+(** [sort_by project items] orders [items] by the media query [project] returns
+    for each, serializing each query exactly once. Sorting this way, rather than
+    with [List.sort (fun a b -> compare (project a) (project b))], is the point
+    of {!val-key}: the comparator form re-derives and re-serializes a query on
+    every comparison, which a sort does O(n log n) times. The sort is stable. *)
+
 type kind =
   | Hover
   | Responsive of int * float

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -177,6 +177,33 @@ let test_spec_media_sorting_edges () =
     ]
     sorted
 
+let test_sort_key () =
+  let qs =
+    [
+      plain "prefers-color-scheme" (Ident Dark);
+      min_width 768.;
+      plain "hover" (Ident Hover);
+      max_width 1024.;
+      plain "prefers-reduced-motion" (Ident Reduce);
+      print_type;
+      not_all_and (Plain (Min Width, Length (Css.Values.Px 768.)));
+      min_width 320.;
+    ]
+  in
+  List.iter
+    (fun a ->
+      List.iter
+        (fun b ->
+          Alcotest.(check int)
+            "compare_keys (sort_key a) (sort_key b) = compare a b" (compare a b)
+            (compare_keys (sort_key a) (sort_key b)))
+        qs)
+    qs;
+  Alcotest.(check (list string))
+    "sort_by reproduces List.sort compare"
+    (List.sort compare qs |> List.map to_string)
+    (sort_by Fun.id qs |> List.map to_string)
+
 let spec_media_context_vectors () =
   let check condition expected =
     Alcotest.(check string)
@@ -217,6 +244,7 @@ let suite =
         spec_media_error_recovery_vectors;
       test_case "kind" `Quick test_kind;
       test_case "compare" `Quick test_compare;
+      test_case "sort_key" `Quick test_sort_key;
       test_case "spec media sorting edges" `Quick test_spec_media_sorting_edges;
       test_case "spec media query context syntax vectors" `Quick
         spec_media_context_vectors;


### PR DESCRIPTION
`Media.compare` serializes the query (allocating a buffer and running the printer) and re-extracts its kind on every call. In a sort that is O(n log n) comparisons, and queries that share a breakpoint tie on every cheap ordinal key, so they always fall through to the serialized tie-break.

This adds an abstract `key` with `sort_key`/`compare_keys` (and a `sort_by` that owns the key computation) so a caller can serialize each query once and compare precomputed keys; `compare_keys (sort_key a) (sort_key b) = compare a b`. Wiring tw's rule sort through it cut total allocation of the `tocss` benchmark from 4.93 GB to 3.44 GB (-30%), with the media `Pp.v`/`Buffer.create`/`feature_bound` sites dropping 78-100%.