### PR TITLE
factor: drop the global summary memo

### DIFF
--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -43,12 +43,6 @@ let print_pass_profile entries =
 
 let print_factor_profile_footer () =
   let module S = Cascade.Stats in
-  let hits = S.counters.summary_hits in
-  let misses = S.counters.summary_misses in
-  let total_lookups = hits + misses in
-  let hit_pct =
-    if total_lookups = 0 then 0.0 else 100. *. float hits /. float total_lookups
-  in
   Fmt.epr
     "@.factor stops: %d marginal, committed savings: %d bytes@.factor anchors \
      scored: %d (prefiltered %d), factorings applied: %d@."
@@ -60,9 +54,7 @@ let print_factor_profile_footer () =
   Fmt.epr
     "factor intervals: %d candidates, %d pruned, %d exact-scored, %d selected@."
     S.counters.interval_candidates S.counters.interval_pruned
-    S.counters.interval_scored S.counters.interval_selected;
-  Fmt.epr "summarize_factor_rule cache: %d hits, %d misses (%.1f%% hit rate)@."
-    hits misses hit_pct
+    S.counters.interval_scored S.counters.interval_selected
 
 let report_profile () =
   let module S = Cascade.Stats in

--- a/lib/factor.ml
+++ b/lib/factor.ml
@@ -81,49 +81,11 @@ let prop_ids_mem = Summary.ids_mem
 let prop_ids_disjoint = Summary.ids_disjoint
 let prop_ids_inter = Summary.ids_inter
 
-(* Memoise summaries by physical identity. Rules are persistent records, so the
-   same rule heap object is inspected by many overlapping factoring windows in a
-   single [to_fixpoint] iteration; [rule_pp_size] does two [Pp.size] traversals
-   each call, which made the inner factoring loops quadratic in the window size.
-   We key on the boxed [Obj.repr] of the rule: [Hashtbl] uses our [equal =
-   (==)], so misses on identity, never false hits. The hash function is
-   fixed-depth (stdlib default depth, capped) so it is bounded regardless of the
-   rule's structure. *)
-module Rule_id_tbl = Hashtbl.Make (struct
-  type t = Stylesheet.rule
-
-  let equal = ( == )
-
-  (* O(1) bucket hash combining the cached [Declaration.hash] of the first two
-     declarations -- both are field loads on the structural fingerprint stored
-     at declaration construction. With [equal = (==)], a bucket collision falls
-     through to a physical pointer scan, so we never walk the rule structure on
-     lookup. *)
-  let hash (r : t) =
-    match r.Stylesheet_intf.declarations with
-    | [] -> 0
-    | [ d ] -> Declaration.hash d
-    | d1 :: d2 :: _ -> Declaration.hash d1 lxor (Declaration.hash d2 lsl 1)
-end)
-
-let summary_memo : summary Rule_id_tbl.t = Rule_id_tbl.create 4096
-let clear () = Rule_id_tbl.reset summary_memo
-
 let summarize_factor_rule factor_rule =
-  match Rule_id_tbl.find_opt summary_memo factor_rule with
-  | Some s ->
-      counters.summary_hits <- counters.summary_hits + 1;
-      s
-  | None ->
-      counters.summary_misses <- counters.summary_misses + 1;
-      let s =
-        Summary.v ~rule_size:rule_pp_size
-          ~decl_size:(Pp.size ~minify:true Declaration.pp_declaration)
-          ~selector_size:(Pp.size ~minify:true Selector.pp)
-          factor_rule
-      in
-      Rule_id_tbl.add summary_memo factor_rule s;
-      s
+  Summary.v ~rule_size:rule_pp_size
+    ~decl_size:(Pp.size ~minify:true Declaration.pp_declaration)
+    ~selector_size:(Pp.size ~minify:true Selector.pp)
+    factor_rule
 
 let declares_all summary props = Summary.declares_all summary props
 let declares_ids summary props = Summary.declares_ids summary props

--- a/lib/factor.mli
+++ b/lib/factor.mli
@@ -1,8 +1,5 @@
 (** Cascade-aware rule factoring. *)
 
-val clear : unit -> unit
-(** Clear physical-identity summary caches. *)
-
 val common : Stylesheet.rule list -> Stylesheet.rule list
 (** Factor common declaration groups from adjacent and indexed lookahead runs.
 *)

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -66,7 +66,6 @@ let finalize_rule_without_nested = Rule.finalize
 let merge_rules = Rule.merge
 let combine_identical_rules = Rule.identical
 let factor_anchor_gaps = Factor.anchor
-let clear_summary_memo = Factor.clear
 
 (* Per-pass and global counters for the --profile CLI flag. Reset at each
    [Optimize.stylesheet] entry; bumped from the hot loops below. *)
@@ -101,8 +100,6 @@ type counters = Stats.counters = {
   mutable iterations : int;
   mutable factor_fixpoints_run : int;
   mutable marginal_stops : int;
-  mutable summary_hits : int;
-  mutable summary_misses : int;
   mutable factor_fixpoints_skipped : int;
   mutable factor_preflight_gain : int;
   mutable factor_bytes_saved : int;
@@ -1019,7 +1016,6 @@ let race_extend_lists ~run ~strict stylesheet =
 
 let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
     ?(enforce_spec = false) ?(aggressive = false) (stylesheet : t) : t =
-  clear_summary_memo ();
   Selector_summary.clear_memo ();
   reset_counters ();
   let scope = Option.value scope ~default:`Fragment in

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -227,8 +227,6 @@ type counters = {
       (** global factoring fixpoints attempted after the preflight *)
   mutable marginal_stops : int;
       (** fixpoints stopped because consecutive iterations had low byte gain *)
-  mutable summary_hits : int;  (** [factor_rule_summary] memo hits *)
-  mutable summary_misses : int;  (** [factor_rule_summary] memo misses *)
   mutable factor_fixpoints_skipped : int;
       (** global factoring fixpoints skipped by the incremental preflight *)
   mutable factor_preflight_gain : int;

--- a/lib/stats.ml
+++ b/lib/stats.ml
@@ -49,8 +49,6 @@ type counters = {
   mutable iterations : int;
   mutable factor_fixpoints_run : int;
   mutable marginal_stops : int;
-  mutable summary_hits : int;
-  mutable summary_misses : int;
   mutable factor_fixpoints_skipped : int;
   mutable factor_preflight_gain : int;
   mutable factor_bytes_saved : int;
@@ -68,8 +66,6 @@ let counters =
     iterations = 0;
     factor_fixpoints_run = 0;
     marginal_stops = 0;
-    summary_hits = 0;
-    summary_misses = 0;
     factor_fixpoints_skipped = 0;
     factor_preflight_gain = 0;
     factor_bytes_saved = 0;
@@ -109,8 +105,6 @@ let reset () =
   counters.iterations <- 0;
   counters.factor_fixpoints_run <- 0;
   counters.marginal_stops <- 0;
-  counters.summary_hits <- 0;
-  counters.summary_misses <- 0;
   counters.factor_fixpoints_skipped <- 0;
   counters.factor_preflight_gain <- 0;
   counters.factor_bytes_saved <- 0;

--- a/lib/stats.mli
+++ b/lib/stats.mli
@@ -54,8 +54,6 @@ type counters = {
       (** global factoring fixpoints attempted after the preflight *)
   mutable marginal_stops : int;
       (** fixpoints stopped because consecutive iterations had low byte gain *)
-  mutable summary_hits : int;  (** summary memo hits *)
-  mutable summary_misses : int;  (** summary memo misses *)
   mutable factor_fixpoints_skipped : int;
       (** global factoring fixpoints skipped by the incremental preflight *)
   mutable factor_preflight_gain : int;

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -13,7 +13,6 @@ let render rules =
     (List.map (Pp.to_string ~minify:true Stylesheet.pp_rule) rules)
 
 let test_common_hoists_profitable_adjacent_run () =
-  Factor.clear ();
   let optimized =
     Factor.common
       (rules
@@ -25,14 +24,12 @@ let test_common_hoists_profitable_adjacent_run () =
     (render optimized)
 
 let test_common_rejects_duplicate_property_member () =
-  Factor.clear ();
   let css = ".a{display:flex;display:block}.b{display:flex}" in
   Alcotest.(check string)
     "unsafe duplicate property run is untouched" css
     (Factor.common (rules css) |> render)
 
 let test_anchor_hoists_across_unrelated_gap () =
-  Factor.clear ();
   let optimized =
     Factor.anchor
       (rules
@@ -44,14 +41,12 @@ let test_anchor_hoists_across_unrelated_gap () =
     (render optimized)
 
 let test_anchor_respects_tied_overlap () =
-  Factor.clear ();
   let css = ".a{color:red}.x.a{color:green}.a{color:blue}" in
   Alcotest.(check string)
     "intervening same-specificity overlap blocks merge" css
     (Factor.anchor (rules css) |> render)
 
 let test_run_reaches_fixpoint_with_finalizer () =
-  Factor.clear ();
   let optimized =
     Factor.run ~ctx:Ctx.fragment
       ~finalize:(Rule.finalize ~ctx:Ctx.fragment)

--- a/test/test_stats.ml
+++ b/test/test_stats.ml
@@ -7,8 +7,6 @@ let check_zeroed_counters label =
     (label ^ " factor_fixpoints_run")
     0 S.counters.factor_fixpoints_run;
   Alcotest.(check int) (label ^ " marginal_stops") 0 S.counters.marginal_stops;
-  Alcotest.(check int) (label ^ " summary_hits") 0 S.counters.summary_hits;
-  Alcotest.(check int) (label ^ " summary_misses") 0 S.counters.summary_misses;
   Alcotest.(check int)
     (label ^ " factor_fixpoints_skipped")
     0 S.counters.factor_fixpoints_skipped;
@@ -103,8 +101,6 @@ let test_reset_clears_mutable_state () =
   S.counters.iterations <- 1;
   S.counters.factor_fixpoints_run <- 2;
   S.counters.marginal_stops <- 3;
-  S.counters.summary_hits <- 4;
-  S.counters.summary_misses <- 5;
   S.counters.factor_fixpoints_skipped <- 6;
   S.counters.factor_preflight_gain <- 7;
   S.counters.factor_bytes_saved <- 8;


### PR DESCRIPTION
`Factor.summarize_factor_rule` memoised rule summaries in a module-global `Hashtbl` keyed by physical rule identity, reset once per `Optimize.stylesheet` run. A library should not carry global mutable caches.

The memo is also vestigial now: each factoring pass already decorates its input rules with summaries once at entry, so the memo's cross-pass reuse is marginal. Removing it is allocation- and time-neutral on the 4k-utility benchmark (`words/op` and wall-clock unchanged), and factoring output is identical since `Summary.v` is pure. This drops the table, the `clear` hook the optimizer called per run, and the `summary_hits`/`summary_misses` counters that only described the memo.