### PR TITLE
declaration: replace Obj.repr in same_property with a typed match

### DIFF
--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -467,20 +467,19 @@ let rec property_key decl =
   | Declaration { property; _ } -> Key property
   | Theme_guarded { decl; _ } -> property_key decl
 
-(* Fast-path equality of the typed property tag without allocating a
-   [Key]-wrapped [prop_key]. Nullary GADT constructors are interned by the
-   compiler, so [Obj.repr p1 == Obj.repr p2] short-circuits the common case
-   ([Width]/[Width], [Padding_top]/[Padding_top], ...). Parameterised
-   constructors ([Custom_property "foo"], [Unknown_property "bar"]) fall through
-   to the structural compare on the boxed [Obj.t] values, which matches the
-   string payload. *)
-let rec same_property d1 d2 =
-  match (d1, d2) with
-  | Declaration { property = p1; _ }, Declaration { property = p2; _ } ->
-      let r1 = Obj.repr p1 and r2 = Obj.repr p2 in
-      r1 == r2 || r1 = r2
-  | Theme_guarded { decl = d1; _ }, _ -> same_property d1 d2
-  | _, Theme_guarded { decl = d2; _ } -> same_property d1 d2
+(* Equality of the typed property tag. The [property] GADT has only two
+   payload-carrying constructors ([Custom_property] / [Unknown_property], both
+   string), compared on their payload. Every other constructor is nullary and
+   interned by the compiler, so physical equality of the unboxed [prop_key]
+   short-circuits the common case ([Width]/[Width], ...) and answers a mismatch
+   ([Custom_property]/[Width]) correctly, with no allocation. The [property]
+   values are existentially typed (two [Declaration] nodes carry different
+   ['a]), so they are packed into [prop_key] to compare under one type. *)
+let same_property d1 d2 =
+  match (property_key d1, property_key d2) with
+  | Key (Custom_property a), Key (Custom_property b) -> String.equal a b
+  | Key (Unknown_property a), Key (Unknown_property b) -> String.equal a b
+  | k1, k2 -> k1 == k2
 
 let pp_value = Properties.pp_value
 


### PR DESCRIPTION
`same_property` compared the typed `property` GADT through `Obj.repr` to erase the existential types of two `Declaration` nodes (`p1 = p2` is ill-typed across them). It now packs each property into the unboxed `prop_key` and matches: the two string-carrying constructors (`Custom_property`/`Unknown_property`) compare on their string payload, and every interned nullary constructor falls through to physical equality of the key. Same result, no `Obj`, still allocation-free.