### PR TITLE
context: add Css.var ~runtime to keep theme vars unfolded

### DIFF
--- a/lib/context.ml
+++ b/lib/context.ml
@@ -802,7 +802,9 @@ module Var_residual = struct
     in
     let resolve_var ~(simplify : a simplifier) ~visited (var : a Values.var) :
         a option =
-      if List.mem var.name visited then None
+      (* A [runtime] var stays a [var()] reference so a script can override the
+         custom property; never fold it to its theme value. *)
+      if var.runtime || List.mem var.name visited then None
       else
         match lookup_parsed var.name with
         | Some value ->
@@ -2941,6 +2943,7 @@ let gradient_stop_of_color_var (var : Values.color Values.var) :
         var.default;
     layer = var.layer;
     meta = var.meta;
+    runtime = var.runtime;
   }
 
 let simplify_color_var_gradient_stop (color : Values.color -> Values.color)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7283,10 +7283,11 @@ val var_ref :
   ?default:'a ->
   ?layer:string ->
   ?meta:meta ->
+  ?runtime:bool ->
   string ->
   'a var
-(** [var_ref ?fallback ?default ?layer ?meta name] is a CSS variable reference.
-    This is primarily for the CSS parser to create var() references.
+(** [var_ref ?fallback ?default ?layer ?meta ?runtime name] is a CSS variable
+    reference. This is primarily for the CSS parser to create var() references.
 
     - [name] is the variable name (without the -- prefix)
     - [fallback] is used inside var(--name, fallback) in CSS output
@@ -7340,12 +7341,15 @@ val var :
   ?fallback:'a fallback ->
   ?layer:string ->
   ?meta:meta ->
+  ?runtime:bool ->
   string ->
   'a kind ->
   'a ->
   declaration * 'a var
-(** [var ?default ?fallback ?layer name kind value] returns a declaration and a
-    variable handle.
+(** [var ?default ?fallback ?layer ?runtime name kind value] returns a
+    declaration and a variable handle. With [~runtime:true] a context keeps the
+    [var()] reference instead of folding it to [value], so a runtime stylesheet
+    or script can still override [--name].
 
     - [name] is the variable name without the [--] prefix
     - [kind] specifies the value type (Length, Color, Angle, Float, etc.)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -834,6 +834,7 @@ and justify_var_of_align_var (v : align_self var) : justify_self var =
     default = Option.map justify_self_of_align_self v.default;
     layer = v.layer;
     meta = v.meta;
+    runtime = v.runtime;
   }
 
 let read_place_self_value t =
@@ -2338,10 +2339,26 @@ let aspect_ratio a = v Aspect_ratio a
 let filter value = v Filter value
 
 let filter_var_empty name : filter =
-  Var { name; fallback = Empty; default = None; layer = None; meta = None }
+  Var
+    {
+      name;
+      fallback = Empty;
+      default = None;
+      layer = None;
+      meta = None;
+      runtime = false;
+    }
 
 let background_image_var_none name : background_image =
-  Var { name; fallback = None; default = None; layer = None; meta = None }
+  Var
+    {
+      name;
+      fallback = None;
+      default = None;
+      layer = None;
+      meta = None;
+      runtime = false;
+    }
 
 let word_spacing value = v Word_spacing value
 let quotes value = v Quotes value

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -562,6 +562,7 @@ let color_var_of_length_var (var : Values.length Values.var) :
     default = None;
     layer = var.layer;
     meta = var.meta;
+    runtime = var.runtime;
   }
 
 let rec rewrite_shadow_value color_vars (value : Properties.shadow) :

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -2,11 +2,11 @@
 
 include Values_intf
 
-let var_ref ?fallback ?default ?layer ?meta name =
+let var_ref ?fallback ?default ?layer ?meta ?(runtime = false) name =
   let fallback : _ fallback =
     match fallback with None -> None | Some x -> x
   in
-  { name; fallback; default; layer; meta }
+  { name; fallback; default; layer; meta; runtime }
 
 let syntax_fallback s = Syntax_fallback (Cursor.remaining (Cursor.of_string s))
 
@@ -272,6 +272,7 @@ let color_mix_var_percent ?in_space ?(hue = Default) ~var_name color1 color2 =
            default = None;
            layer = None;
            meta = None;
+           runtime = false;
          })
   in
   Mix { in_space; hue; color1; percent1; color2; percent2 = None }
@@ -287,6 +288,7 @@ let color_mix_var_pct_fallback ?in_space ?(hue = Default) ~var_name ~fallback
            default = None;
            layer = None;
            meta = None;
+           runtime = false;
          })
   in
   Mix { in_space; hue; color1; percent1; color2; percent2 = None }
@@ -948,7 +950,15 @@ let rec map_calc : type a b. (a -> b) -> a calc -> b calc =
         | Var_fallback s -> Var_fallback s
       in
       let default = Option.map f v.default in
-      Var { name = v.name; fallback; default; layer = v.layer; meta = v.meta }
+      Var
+        {
+          name = v.name;
+          fallback;
+          default;
+          layer = v.layer;
+          meta = v.meta;
+          runtime = v.runtime;
+        }
   | Num f -> Num f
   | Sibling_index -> Sibling_index
   | Sibling_count -> Sibling_count

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -10,10 +10,13 @@ val var_ref :
   ?default:'a ->
   ?layer:string ->
   ?meta:meta ->
+  ?runtime:bool ->
   string ->
   'a var
-(** [var_ref ?fallback ?default ?layer ?meta name] creates a CSS variable
-    reference to [--name]. *)
+(** [var_ref ?fallback ?default ?layer ?meta ?runtime name] creates a CSS
+    variable reference to [--name]. With [~runtime:true] a context keeps the
+    [var()] reference instead of folding it to its [default], so a runtime
+    stylesheet or script can still override [--name]. *)
 
 val syntax_fallback : string -> 'a fallback
 (** [syntax_fallback s] parses [s] as a CSS declaration-value fallback for a

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -29,6 +29,11 @@ type 'a var = {
   default : 'a option;
   layer : string option;
   meta : meta option;
+  runtime : bool;
+      (** When [true], a context never folds this var to its [default]: the
+          [var()] reference is kept so a runtime stylesheet or script can still
+          override the custom property. The [default] then acts only as a
+          browser-time fallback hint. *)
 }
 
 type 'a env = { name : string; indices : int list; fallback : 'a option }

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -295,11 +295,12 @@ let var : type a.
     ?fallback:a fallback ->
     ?layer:string ->
     ?meta:meta ->
+    ?runtime:bool ->
     string ->
     a kind ->
     a ->
     declaration * a var =
- fun ?default ?fallback ?layer ?meta name kind value ->
+ fun ?default ?fallback ?layer ?meta ?(runtime = false) name kind value ->
   (* Create the declaration directly with the value *)
   let decl =
     Declaration.v
@@ -313,7 +314,9 @@ let var : type a.
   let default_value =
     match default with Some d -> Some d | None -> Some value
   in
-  let var_handle = { name; fallback; default = default_value; layer; meta } in
+  let var_handle =
+    { name; fallback; default = default_value; layer; meta; runtime }
+  in
   (decl, var_handle)
 
 (** {1 Variable extraction} *)

--- a/lib/variables.mli
+++ b/lib/variables.mli
@@ -48,6 +48,7 @@ val var :
   ?fallback:'a fallback ->
   ?layer:string ->
   ?meta:meta ->
+  ?runtime:bool ->
   string ->
   'a kind ->
   'a ->

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -2484,9 +2484,31 @@ let cascade_rule_resolver_contract () =
       @layer theme { .btn { outline-color: red; } }
     |}
 
+let runtime_var_not_folded_contract () =
+  let open Css.Values in
+  (* A [~runtime:true] theme var keeps its var() reference even when its default
+     is known, so a script can still override --spacing at runtime. *)
+  let _decl, spacing = Css.var ~runtime:true "spacing" Length (Px 4.) in
+  let decl = Css.width (Calc (Expr (Var spacing, Mul, Num 4.))) in
+  Alcotest.(check decl_t)
+    "runtime var stays a var() in calc" decl
+    (Css.eval_declaration Css.Context.empty decl);
+  (* Without [~runtime] the same calc folds to a constant through the
+     default. *)
+  let _decl, fixed = Css.var "fixed-spacing" Length (Px 4.) in
+  let folding = Css.width (Calc (Expr (Var fixed, Mul, Num 4.))) in
+  Alcotest.(check bool)
+    "non-runtime var folds" false
+    (String.equal
+       (Css.Declaration.string_of_declaration folding)
+       (Css.Declaration.string_of_declaration
+          (Css.eval_declaration Css.Context.empty folding)))
+
 let suite =
   ( "context",
     [
+      Alcotest.test_case "runtime var not folded" `Quick
+        runtime_var_not_folded_contract;
       Alcotest.test_case "empty property value context" `Quick
         test_empty_property_value;
       Alcotest.test_case "empty side contexts" `Quick test_empty_side_contexts;


### PR DESCRIPTION
`Context` resolves a `var()` to its `~default` when it simplifies a value, so `calc(var(--spacing)*4)` collapses to a constant length once the default is known. For Tailwind-style theme variables that's wrong: they are emitted as custom properties a stylesheet or script can override at runtime, so the `var()` reference must survive.

`Css.var ~runtime:true` (and `var_ref ~runtime`) marks such a variable; `resolve_var` then treats it as opaque and keeps the reference, while the `default` still serves as the browser-time fallback hint. Parsed and ordinary vars are unaffected (`runtime` defaults to false). A context consumer (tw) sets it for theme-role vars so utilities like `p-4` keep `calc(var(--spacing)*4)` instead of folding.