### PR TITLE
values: keep oklab/oklch coefficients in full under pretty pp

### DIFF
--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3969,9 +3969,12 @@ let rec pp_rgb : rgb Pp.t =
     and minified output; minified output additionally rounds to 6 sig digits for
     compactness. *)
 let string_of_lab_float ~max_decimals ctx f =
-  let max_decimals = if ctx.Pp.lossless then 8 else max_decimals in
-  Pp.string_of_float ~drop_leading_zero:true ~max_decimals
-    (if ctx.Pp.minify && not ctx.Pp.lossless then Pp.round_sig 6 f else f)
+  if ctx.Pp.minify && not ctx.Pp.lossless then
+    (* Minify shortens to the per-axis decimal budget; pretty (and lossless)
+       keep the authored coefficient in full so the value round-trips, matching
+       [pp_component_float] for the [color()] function. *)
+    Pp.string_of_float ~drop_leading_zero:true ~max_decimals (Pp.round_sig 6 f)
+  else Pp.string_of_float ~drop_leading_zero:true f
 
 let pp_lab_float ~max_decimals ctx f =
   Pp.string ctx (string_of_lab_float ~max_decimals ctx f)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5101,7 +5101,21 @@ let color4_invalid_color_function_rejected () =
 let fidelity_color_space_preserved () =
   pretty_preserves ".x { color: oklch(0.628 0.258 29.23) }" [ ".258"; "29.23" ];
   pretty_preserves ".x { color: lab(54.29 80.81 69.89) }" [ "lab" ];
-  pretty_preserves ".x { color: color(srgb 1 0 0) }" [ "color(srgb 1 0 0)" ]
+  pretty_preserves ".x { color: color(srgb 1 0 0) }" [ "color(srgb 1 0 0)" ];
+  (* Pretty keeps oklab/oklch coefficients in full so the value round-trips,
+     matching the [color()] function; the per-axis decimal budget is a minify
+     shortening only. *)
+  pretty_preserves ".x { color: oklab(21% -0.00316127 -0.0338527 / 0.1) }"
+    [ "-.00316127"; "-.0338527" ];
+  Alcotest.(check bool)
+    "minify still rounds oklch chroma to the per-axis budget" true
+    (match
+       Css.of_string ~strict:false ".x { color: oklch(0.628 0.2584567 29.23) }"
+     with
+    | Ok parsed ->
+        Astring.String.is_infix ~affix:"oklch(.628 .258 29.23"
+          (minify parsed.stylesheet)
+    | Error _ -> false)
 
 (* {2 @supports (CSS Conditional L4 §2)} *)
 


### PR DESCRIPTION
`string_of_lab_float` applied its per-axis decimal cap in both pretty and minified output, so pretty printing rounded `oklab` / `oklch` / `lab` / `lch` coefficients (3 decimals for oklab/oklch, 1 for lab/lch) and the value no longer round-tripped: `oklab(21% -0.00316127 -0.0338527)` came back as `oklab(21% -.003 -.034)`.

The `color()` function already preserves the authored float in pretty and caps only under minify (`pp_component_float`). This mirrors that for the long-form colour functions, so pretty output preserves the authored coefficients and minify keeps shortening them to the per-axis budget. The perceptual budget stays a minify-only shortener; pretty is the faithful round-trip path.