### PR TITLE
inline: apply calc identities to kept theme vars

### DIFF
--- a/lib/context.ml
+++ b/lib/context.ml
@@ -10,6 +10,12 @@ type cascade_rule = {
 
 type t = {
   custom_properties : Declaration.declaration list;
+  runtime_vars : string list;
+      (** Custom-property names (without the [--] prefix) that must stay live
+          [var()] references: a resolver keeps them like a [~runtime] var rather
+          than folding to a theme value, so the closed-world inliner can still
+          apply value-independent simplifications (calc identities) without
+          collapsing the reference. *)
   inherited_values : Declaration.declaration list;
   initial_values : Declaration.declaration list;
   layer_order : string list;
@@ -75,6 +81,7 @@ type property_registry = { property_registrations : property_registration list }
 let empty =
   {
     custom_properties = [];
+    runtime_vars = [];
     inherited_values = [];
     initial_values = [];
     layer_order = [];
@@ -90,12 +97,13 @@ let empty =
     container_height = None;
   }
 
-let v ?(custom_properties = []) ?(inherited_values = []) ?(initial_values = [])
-    ?(layer_order = []) ?layer ?cascade_rules ?base_url ?root_font_size
-    ?parent_font_size ?current_color ?viewport_width ?viewport_height
-    ?container_width ?container_height () =
+let v ?(custom_properties = []) ?(runtime_vars = []) ?(inherited_values = [])
+    ?(initial_values = []) ?(layer_order = []) ?layer ?cascade_rules ?base_url
+    ?root_font_size ?parent_font_size ?current_color ?viewport_width
+    ?viewport_height ?container_width ?container_height () =
   {
     custom_properties;
+    runtime_vars;
     inherited_values;
     initial_values;
     layer_order;
@@ -802,9 +810,14 @@ module Var_residual = struct
     in
     let resolve_var ~(simplify : a simplifier) ~visited (var : a Values.var) :
         a option =
-      (* A [runtime] var stays a [var()] reference so a script can override the
+      (* A [runtime] var - either flagged on the value or named in the context's
+         [runtime_vars] - stays a [var()] reference so a script can override the
          custom property; never fold it to its theme value. *)
-      if var.runtime || List.mem var.name visited then None
+      if
+        var.runtime
+        || List.mem var.name cascade.runtime_vars
+        || List.mem var.name visited
+      then None
       else
         match lookup_parsed var.name with
         | Some value ->

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -17,6 +17,11 @@ type cascade_rule = {
 type t = {
   custom_properties : Declaration.declaration list;
       (** Custom property declarations, e.g. [--gap: 1rem]. *)
+  runtime_vars : string list;
+      (** Custom-property names (without the [--] prefix) kept as live [var()]
+          references: a resolver treats them like a [~runtime] var, folding only
+          value-independent simplifications (calc identities) and never
+          collapsing the reference to a theme value. *)
   inherited_values : Declaration.declaration list;
       (** Parent/inherited property declarations. *)
   initial_values : Declaration.declaration list;
@@ -101,6 +106,7 @@ val empty : t
 
 val v :
   ?custom_properties:Declaration.declaration list ->
+  ?runtime_vars:string list ->
   ?inherited_values:Declaration.declaration list ->
   ?initial_values:Declaration.declaration list ->
   ?layer_order:string list ->

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -180,7 +180,19 @@ let visible_customs ~scopes ~at_path ~selector =
       else [])
     scopes
 
-let context_for visible = Context.v ~custom_properties:(List.rev visible) ()
+(* [kept] names carry the [--] prefix; [Context.runtime_vars] expects the bare
+   custom-property name. *)
+let runtime_var_names kept =
+  List.map
+    (fun name ->
+      if String.length name >= 2 && String.sub name 0 2 = "--" then
+        String.sub name 2 (String.length name - 2)
+      else name)
+    kept
+
+let context_for ?(kept = []) visible =
+  Context.v ~custom_properties:(List.rev visible)
+    ~runtime_vars:(runtime_var_names kept) ()
 
 let read_custom_components read = function
   | Declaration.Declaration
@@ -444,35 +456,17 @@ let should_use_typed_default ~kept visible vars =
          && not (List.mem (String.concat "" [ "--"; var.Values.name ]) kept))
        vars
 
-(* True when [components] still reference a kept var. [Context.eval] is a
-   closed-world fold that would collapse [var(--kept, fallback)] to its
-   fallback; a kept var must stay a live reference, so its declaration keeps the
-   substituted components verbatim instead. *)
-let rec components_reference_kept ~kept components =
-  List.exists
-    (fun (c : Component.t) ->
-      match c with
-      | Component.Func { node = { name; arguments; _ }; _ } ->
-          (String.lowercase_ascii name = "var"
-          &&
-          match parse_var_components arguments with
-          | Some (n, _) -> List.mem (String.concat "" [ "--"; n ]) kept
-          | None -> false)
-          || components_reference_kept ~kept arguments
-      | Component.Block { node = { value; _ }; _ } ->
-          components_reference_kept ~kept value
-      | Component.Preserved _ -> false)
-    components
-
-let apply_substituted_components ~kept ctx decl ~original_components components
-    =
+(* [Context.eval] keeps a kept var live (the context lists it in [runtime_vars],
+   so the resolver leaves the [var()] reference intact and never collapses it to
+   a fallback) while still applying the value-independent simplifications such
+   as the calc identities. So the substituted declaration is always evaluated,
+   whether or not it still references a kept var. *)
+let apply_substituted_components ctx decl ~original_components components =
   if components = original_components then Some (Context.eval ctx decl)
   else
     match declaration_with_components decl components with
     | None -> None
-    | Some decl ->
-        if components_reference_kept ~kept components then Some decl
-        else Some (Context.eval ctx decl)
+    | Some decl -> Some (Context.eval ctx decl)
 
 let substitute_non_custom ~kept visible ctx decl =
   let vars = Variables.vars_of_declarations [ decl ] in
@@ -486,8 +480,7 @@ let substitute_non_custom ~kept visible ctx decl =
     with
     | Cycle -> Some (Context.eval ctx decl)
     | Components components ->
-        apply_substituted_components ~kept ctx decl ~original_components
-          components
+        apply_substituted_components ctx decl ~original_components components
 
 let substitute_declaration ~kept visible ctx decl =
   match custom_name decl with
@@ -577,7 +570,7 @@ let universal_visible_customs ~scopes ~at_path =
 
 let eval_decls ~kept ~scopes ~at_path selector decls =
   let visible = visible_customs ~scopes ~at_path ~selector in
-  let ctx = context_for visible in
+  let ctx = context_for ~kept visible in
   List.filter_map (substitute_declaration ~kept visible ctx) decls
 
 (* @page, @keyframes, and @position-try declarations apply to elements whose

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -2518,7 +2518,16 @@ let runtime_var_not_folded_contract () =
     (eval (Expr (Var spacing, Mul, Num 1.)));
   Alcotest.(check string)
     "runtime var * 4 keeps the var() reference" "width:calc(var(--spacing)*4)"
-    (eval (Expr (Var spacing, Mul, Num 4.)))
+    (eval (Expr (Var spacing, Mul, Num 4.)));
+  (* The spacing utilities multiply the theme var, so the [* 1] case must reach
+     the operand through a property shorthand too: [p-N] for N=1 is [padding:
+     var(--spacing)], not [calc(var(--spacing) * 1)]. *)
+  Alcotest.(check string)
+    "runtime var * 1 in the padding shorthand folds to the operand"
+    "padding:var(--spacing)"
+    (Css.Declaration.string_of_declaration ~minify:true
+       (Css.eval_declaration Css.Context.empty
+          (Css.padding [ Calc (Expr (Var spacing, Mul, Num 1.)) ])))
 
 let suite =
   ( "context",

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -43,6 +43,28 @@ let test_inline_keep_vars () =
     ":root{--brand:blue}.button{color:var(--brand);border-color:#00f}"
     (optimized_minified inlined)
 
+let test_inline_keep_vars_calc_identity () =
+  (* A kept theme var stays a live reference, but the value-independent calc
+     identities still simplify: [p-1] expands to [calc(var(--spacing) * 1)],
+     which must collapse to [var(--spacing)] (Tailwind's form), and [* 0] to a
+     bare zero. Only value resolution ([* n], n >= 2) keeps the
+     multiplication. *)
+  let inline css = parse css |> Css.inline_vars ~keep_vars:[ "spacing" ] in
+  Alcotest.(check string)
+    "kept var times one folds to the operand"
+    ":root{--spacing:.25rem}.p{padding:var(--spacing)}"
+    (minified
+       (inline ":root{--spacing:.25rem}.p{padding:calc(var(--spacing) * 1)}"));
+  Alcotest.(check string)
+    "kept var times zero folds to zero" ":root{--spacing:.25rem}.p{padding:0}"
+    (minified
+       (inline ":root{--spacing:.25rem}.p{padding:calc(var(--spacing) * 0)}"));
+  Alcotest.(check string)
+    "kept var times four keeps the var() reference"
+    ":root{--spacing:.25rem}.p{padding:calc(var(--spacing)*4)}"
+    (minified
+       (inline ":root{--spacing:.25rem}.p{padding:calc(var(--spacing) * 4)}"))
+
 let test_decode_import_url () =
   Alcotest.(check string)
     "url form" "theme.css"
@@ -167,6 +189,8 @@ let suite =
         `Quick test_inline_substitutes_vars;
       Alcotest.test_case "inline vars keep requested references" `Quick
         test_inline_keep_vars;
+      Alcotest.test_case "inline vars apply calc identities to kept vars" `Quick
+        test_inline_keep_vars_calc_identity;
       Alcotest.test_case "decode import url forms" `Quick test_decode_import_url;
       Alcotest.test_case "inline imports resolves loader stylesheet" `Quick
         test_inline_import_loader;


### PR DESCRIPTION
Follow-up to #72. #72 made the calc identities (`x*0`, `x*1`, `x/1`) fire for runtime vars in `Context`/`optimize`, but the path the upstream test runs (`Tw.to_css |> Css.resolve_theme |> Css.to_string ~minify`) goes through the closed-world inliner, which returned a kept-var declaration **verbatim** — `apply_substituted_components` deliberately skipped `Context.eval` so a live `var(--kept, fallback)` wouldn't collapse to its fallback. So `calc(var(--spacing) * 1)` reached the output unsimplified, where Tailwind emits `var(--spacing)`.

`Context` now carries a `runtime_vars` set (custom-property names kept live, treated by the resolver exactly like a `~runtime` var: the `var()` reference is preserved and never collapsed). `Inline.vars` passes its keep set into the context, so the substituted declaration is always evaluated — the kept reference survives by construction while the value-independent identities fold. `calc(var(--spacing) * 1)` → `var(--spacing)`, `* 0` → `0`, and `* 4` keeps the reference. Full suite green, including the group-*/peer-* variants that share this path.