### PR TITLE
pp: keep percentages in full precision

### DIFF
--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -396,8 +396,10 @@ let pct ctx f =
   (* CSS Values 4 §6.5 only allows the unit to drop on a zero [<length>]; a zero
      [<percentage>] keeps the [%] (otherwise [opacity:0] vs [opacity:0%] are no
      longer equivalent, and dimension/percentage-typed grammars reject a bare
-     [0]). *)
-  float ctx (if ctx.lossless then f else round_sig 6 f);
+     [0]). The coefficient prints in full, like [float]: rounding it changes the
+     value (a repeating fraction such as [33.333333%] from [w-1/3] would lose
+     digits), so any precision reduction belongs in the optimizer, not here. *)
+  float ctx f;
   string ctx "%"
 
 let sep ctx s =

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -3774,6 +3774,19 @@ let fidelity_alpha_form_preserved () =
   pretty_preserves ".x { color: rgb(255 0 0 / 50%) }" [ "50%" ];
   pretty_preserves ".x { color: hsl(180 50% 25% / 30%) }" [ "30%" ]
 
+let fidelity_percentage_precision_preserved () =
+  (* [w-1/3] and friends author repeating-fraction percentages; the printer
+     keeps every digit (Tailwind does) rather than rounding to six significant
+     figures, in pretty and minified output alike. *)
+  pretty_preserves ".x { width: 33.333333% }" [ "33.333333%" ];
+  Alcotest.(check bool)
+    "minify keeps the full percentage" true
+    (match Css.of_string ~strict:false ".x { width: 66.666667% }" with
+    | Ok parsed ->
+        Astring.String.is_infix ~affix:"66.666667%"
+          (Css.to_string ~minify:true parsed.stylesheet)
+    | Error _ -> false)
+
 (* CSS Values 4 section 6.1 + cascade convention: dropping the unit on a zero
    length is a minify-only optimization; the pretty printer keeps the source
    spelling. *)
@@ -6945,6 +6958,9 @@ let additional_tests =
       `Quick,
       fidelity_universal_in_compound_preserved );
     ("fidelity alpha form preserved", `Quick, fidelity_alpha_form_preserved);
+    ( "fidelity percentage precision preserved",
+      `Quick,
+      fidelity_percentage_precision_preserved );
     ("fidelity zero length preserved", `Quick, fidelity_zero_length_preserved);
     ( "fidelity shorthand form preserved",
       `Quick,


### PR DESCRIPTION
Stacked on #73. `Pp.pct` rounded every percentage to six significant figures, so a repeating fraction like `w-1/3`'s `33.333333%` printed as `33.3333%` and diverged from Tailwind. `Pp.float` already prints plain numbers in full, so this just makes `Pp.pct` consistent: the coefficient round-trips in pretty and minified output, and any precision reduction belongs in the optimizer. No fixture churn (no test relied on the rounding).