### PR TITLE
context: collapse a literal zero times a kept var

### DIFF
--- a/lib/context.ml
+++ b/lib/context.ml
@@ -878,6 +878,10 @@ module Calc_residual = struct
 
   type 'a ops = {
     of_unitless_number : float -> 'a option;
+    is_zero : 'a -> bool;
+        (** Recognises a literal zero value, so [0 * x] collapses to zero even
+            when [x] is an unresolved [var()]. Conservative [false] is always
+            safe (keeps the multiplication). *)
     combine_values : 'a -> Values.calc_op -> 'a -> 'a option;
     combine_value_num : 'a -> Values.calc_op -> float -> 'a option;
     normalize_value : 'a -> 'a;
@@ -959,14 +963,23 @@ module Calc_residual = struct
 
   (* Multiplicative identities that hold for any operand, so they apply even to
      an unresolved [var()] (a [~runtime] theme var): [x * 0] is zero and [x * 1]
-     / [x / 1] is [x], neither of which reads the variable's value. Tried after
-     the numeric / value folds so a resolved [Val] keeps its typed zero. *)
+     / [x / 1] is [x], neither of which reads the variable's value. A literal
+     zero value ([0px], not just the unitless [0]) collapses the same way, so
+     [divide-x-0]'s [calc(0px * var(--tw-divide-x-reverse))] reduces to [0].
+     Tried after the numeric / value folds so a resolved [Val] keeps its typed
+     zero. *)
   let fold_identity_expr : type a.
-      a Values.calc -> Values.calc_op -> a Values.calc -> a Values.calc option =
-   fun left op right ->
+      is_zero:(a -> bool) ->
+      a Values.calc ->
+      Values.calc_op ->
+      a Values.calc ->
+      a Values.calc option =
+   fun ~is_zero left op right ->
     let open Values in
     match (left, op, right) with
     | _, Mul, Num 0. | Num 0., Mul, _ -> Some (Num 0.)
+    | (Val v as zero), Mul, _ when is_zero v -> Some zero
+    | _, Mul, (Val v as zero) when is_zero v -> Some zero
     | operand, Mul, Num 1. | Num 1., Mul, operand -> Some operand
     | operand, Div, Num 1. -> Some operand
     | _ -> None
@@ -978,7 +991,7 @@ module Calc_residual = struct
         match fold_value_expr ops left op right with
         | Some folded -> folded
         | None -> (
-            match fold_identity_expr left op right with
+            match fold_identity_expr ~is_zero:ops.is_zero left op right with
             | Some folded -> folded
             | None -> Values.Expr (left, op, right)))
 
@@ -1006,20 +1019,25 @@ module Calc_residual = struct
      every other subexpression verbatim. Used when a calc keeps an unresolved
      [var()]: the var() reference is preserved, but [x * 0] / [x * 1] still
      simplify because they never read the variable. *)
-  let rec fold_calc_identities : type a. a Values.calc -> a Values.calc =
-   fun calc ->
+  let rec fold_calc_identities : type a.
+      is_zero:(a -> bool) -> a Values.calc -> a Values.calc =
+   fun ~is_zero calc ->
     let open Values in
     match calc with
     | Expr (left, op, right) -> (
-        let left = fold_calc_identities left in
-        let right = fold_calc_identities right in
-        match fold_identity_expr left op right with
+        let left = fold_calc_identities ~is_zero left in
+        let right = fold_calc_identities ~is_zero right in
+        match fold_identity_expr ~is_zero left op right with
         | Some folded -> folded
         | None -> Expr (left, op, right))
     | Nested inner ->
-        fold_calc_wrapper (fun v -> Nested v) (fold_calc_identities inner)
+        fold_calc_wrapper
+          (fun v -> Nested v)
+          (fold_calc_identities ~is_zero inner)
     | Parens inner ->
-        fold_calc_wrapper (fun v -> Parens v) (fold_calc_identities inner)
+        fold_calc_wrapper
+          (fun v -> Parens v)
+          (fold_calc_identities ~is_zero inner)
     | leaf -> leaf
 
   let calc_result_to_value (type a) (ops : a ops) simplify ~visited
@@ -1087,7 +1105,8 @@ module Calc_residual = struct
           Values.Expr (walk_calc ~visited left, op, walk_calc ~visited right)
     and simplify_calc ?(preserve = false) ~visited calc =
       let calc = walk_calc ~visited calc in
-      if preserve && contains_var calc then fold_calc_identities calc
+      if preserve && contains_var calc then
+        fold_calc_identities ~is_zero:ops.is_zero calc
       else fold_calc ops calc
     and simplify ~authored ~visited value =
       let simplify_resolved ~authored:_ = simplify ~authored:false in
@@ -1346,6 +1365,7 @@ module Length = struct
       let of_number px = Values.Px px in
       {
         of_unitless_number = (fun _ -> None);
+        is_zero = Values.length_is_zero;
         combine_values = combine_numeric_values ~to_number ~of_number;
         combine_value_num = combine_numeric_value_num ~to_number ~of_number;
         normalize_value = normalize_numeric_value ~to_number ~of_number;
@@ -1903,6 +1923,7 @@ let simplify_length_percentage ?layer_order ?layer cascade length_ctx value =
     in
     {
       Calc_residual.of_unitless_number = (fun _ -> None);
+      is_zero = (fun v -> match to_px v with Some n -> n = 0. | None -> false);
       combine_values;
       combine_value_num;
       normalize_value = normalize_numeric_value ~to_number:to_px ~of_number;
@@ -1946,6 +1967,8 @@ let simplify_border_width ?layer_order ?layer cascade (length_ctx : Length.ctx)
   let ops : Properties.border_width Calc_residual.ops =
     {
       of_unitless_number = (fun _ -> None);
+      is_zero =
+        (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
       combine_value_num = combine_numeric_value_num ~to_number ~of_number;
       normalize_value = normalize_numeric_value ~to_number ~of_number;
@@ -1991,6 +2014,8 @@ let simplify_font_size ?layer_order ?layer cascade (length_ctx : Length.ctx)
   let ops : Properties.font_size Calc_residual.ops =
     {
       of_unitless_number = (fun _ -> None);
+      is_zero =
+        (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
       combine_value_num = combine_numeric_value_num ~to_number ~of_number;
       normalize_value = normalize_numeric_value ~to_number ~of_number;
@@ -2027,6 +2052,8 @@ let simplify_opacity ?layer_order ?layer cascade value =
     let of_number n = Properties.Opacity_number n in
     {
       of_unitless_number = (fun n -> Some (Properties.Opacity_number n));
+      is_zero =
+        (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
       combine_value_num = combine_numeric_value_num ~to_number ~of_number;
       normalize_value = normalize_numeric_value ~to_number ~of_number;
@@ -2065,6 +2092,8 @@ let simplify_angle ?layer_order ?layer cascade value =
     let of_number deg = Values.Deg deg in
     {
       of_unitless_number = (fun _ -> None);
+      is_zero =
+        (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
       combine_value_num = combine_numeric_value_num ~to_number ~of_number;
       normalize_value = normalize_numeric_value ~to_number ~of_number;
@@ -2093,6 +2122,8 @@ let simplify_duration ?layer_order ?layer cascade value =
     let of_number seconds = Values.S seconds in
     {
       of_unitless_number = (fun _ -> None);
+      is_zero =
+        (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
       combine_value_num = combine_numeric_value_num ~to_number ~of_number;
       normalize_value = normalize_numeric_value ~to_number ~of_number;
@@ -2143,6 +2174,7 @@ let simplify_number_percentage ?layer_order ?layer cascade value =
     {
       Calc_residual.of_unitless_number =
         (fun n -> Some (number_percentage_num n));
+      is_zero = (fun _ -> false);
       combine_values = combine_number_percentage_values;
       combine_value_num = combine_number_percentage_value_num;
       normalize_value = (fun value -> value);
@@ -2676,6 +2708,7 @@ let simplify_component ?layer_order ?layer ctx value =
   let ops : Values.component Calc_residual.ops =
     {
       Calc_residual.of_unitless_number = (fun n -> Some (Values.Num n));
+      is_zero = (fun _ -> false);
       combine_values;
       combine_value_num;
       normalize_value = Fun.id;
@@ -2702,6 +2735,8 @@ let simplify_percentage ?layer_order ?layer ctx value =
   let ops : Values.percentage Calc_residual.ops =
     {
       of_unitless_number = (fun n -> Some (Values.Num n));
+      is_zero =
+        (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
       combine_value_num = combine_numeric_value_num ~to_number ~of_number;
       normalize_value = normalize_numeric_value ~to_number ~of_number;
@@ -2744,6 +2779,8 @@ let simplify_alpha ?layer_order ?layer ctx value =
   let ops : Values.alpha Calc_residual.ops =
     {
       of_unitless_number = (fun n -> Some (alpha_num n));
+      is_zero =
+        (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values;
       combine_value_num;
       normalize_value = normalize_numeric_value ~to_number ~of_number:alpha_num;

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -65,6 +65,22 @@ let test_inline_keep_vars_calc_identity () =
     (minified
        (inline ":root{--spacing:.25rem}.p{padding:calc(var(--spacing) * 4)}"))
 
+let test_inline_zero_value_collapse () =
+  (* [divide-x-0] multiplies a literal [0px] by a kept reverse var; [0 * x] is
+     zero for every [x], so the [calc()] and the [var()] both drop out. The
+     printer keeps the zero's unit ([0px]); stripping it to [0] is the
+     optimizer's zero-length minification, not the printer's job. *)
+  let inline css =
+    parse css |> Css.inline_vars ~keep_vars:[ "tw-divide-x-reverse" ]
+  in
+  Alcotest.(check string)
+    "literal zero times a kept var collapses, dropping the calc and var"
+    ":root{--tw-divide-x-reverse:0}.d{border-inline-start-width:0px}"
+    (minified
+       (inline
+          ":root{--tw-divide-x-reverse:0}.d{border-inline-start-width:calc(0px \
+           * var(--tw-divide-x-reverse))}"))
+
 let test_decode_import_url () =
   Alcotest.(check string)
     "url form" "theme.css"
@@ -191,6 +207,8 @@ let suite =
         test_inline_keep_vars;
       Alcotest.test_case "inline vars apply calc identities to kept vars" `Quick
         test_inline_keep_vars_calc_identity;
+      Alcotest.test_case "inline vars collapse a literal zero times a kept var"
+        `Quick test_inline_zero_value_collapse;
       Alcotest.test_case "decode import url forms" `Quick test_decode_import_url;
       Alcotest.test_case "inline imports resolves loader stylesheet" `Quick
         test_inline_import_loader;


### PR DESCRIPTION
Stacked on #74. The third upstream-parity item: `divide-x-0` emits `border-inline-start-width: calc(0px * var(--tw-divide-x-reverse))`, and the reverse var is kept live, so the `calc()` survived. But `0 * x = 0` for every `x`, so it should collapse to a plain zero regardless of the var.

#72's calc identity handled the unitless `Num 0`; this extends it to a zero-*valued* operand (`0px`, `0%`) via an `is_zero` predicate on the calc ops (real for the length-like types, conservative `false` elsewhere). The `var()` reference drops out because the result no longer depends on it. The printer keeps the zero's unit (`0px`); stripping it to `0` is the optimizer's existing zero-length minification. `space-x-0` was already covered by #72 (its zero is `var(--spacing) * 0` → `Num 0`).