### PR TITLE
values+context: unify the value-independent calc identity fold

### DIFF
--- a/fuzz/fuzz_values.ml
+++ b/fuzz/fuzz_values.ml
@@ -642,6 +642,69 @@ let test_invalid_value_mutations buf =
   let kind, input = invalid_value_mutation buf in
   assert_value_reject kind input
 
+let optimize_one css =
+  match Css.of_string ~strict:false css with
+  | Ok parsed ->
+      Some (parsed.stylesheet |> Css.optimize |> Css.to_string ~minify:true)
+  | Error _ -> None
+
+(* (property, operand, type-matched zero) triples driving the calc-identity
+   invariants below: [width] / [padding] reach the per-type length /
+   length-percentage evaluators, [opacity] the generic number one. *)
+let calc_identity_targets =
+  [
+    ("width", "12px", "0px");
+    ("width", "var(--a)", "0px");
+    ("width", "50%", "0px");
+    ("padding", "var(--a)", "0px");
+    ("padding", ".5rem", "0px");
+    ("opacity", "var(--a)", "0");
+    ("opacity", ".5", "0");
+  ]
+
+(* CSS Values 4 §10.7 identity law: wrapping a value in a value-independent
+   identity ([x * 1], [1 * x], [x / 1], [x + 0], [0 + x], [x - 0]) and
+   optimising lands on the same normal form as optimising the bare value - the
+   [var()] reference and the [calc()] wrapper survive, only the redundant
+   arithmetic folds. Drives the shared [Values.calc_identity] through every
+   evaluator the optimize pass reaches, so the generic and per-type folds cannot
+   drift. *)
+let test_calc_identity_law buf =
+  let prop, operand, zero = pick calc_identity_targets buf 0 in
+  let decl v = ".x{" ^ prop ^ ":" ^ v ^ "}" in
+  match optimize_one (decl ("calc(" ^ operand ^ ")")) with
+  | None -> ()
+  | Some bare ->
+      List.iter
+        (fun w ->
+          match optimize_one (decl w) with
+          | None -> failf "calc identity wrapper did not optimise: %S" w
+          | Some got ->
+              if got <> bare then
+                failf "calc identity law broken: %S -> %S (bare %S)" w got bare)
+        [
+          "calc(" ^ operand ^ " * 1)";
+          "calc(1 * " ^ operand ^ ")";
+          "calc(" ^ operand ^ " / 1)";
+          "calc(" ^ operand ^ " + " ^ zero ^ ")";
+          "calc(" ^ zero ^ " + " ^ operand ^ ")";
+          "calc(" ^ operand ^ " - " ^ zero ^ ")";
+        ]
+
+(* The identity and constant folds both converge, so a second optimize pass over
+   a calc is a no-op. *)
+let test_calc_optimize_idempotent buf =
+  let prop, operand, zero = pick calc_identity_targets buf 0 in
+  let css = ".x{" ^ prop ^ ":calc(" ^ operand ^ " * 1 + " ^ zero ^ ")}" in
+  match optimize_one css with
+  | None -> ()
+  | Some once -> (
+      match optimize_one once with
+      | None -> failf "optimised calc did not reparse: %S" once
+      | Some twice ->
+          if once <> twice then
+            failf "optimise not idempotent: %S -> %S -> %S" css once twice)
+
 let reader_cases =
   [
     test_case "read_color crash safety" [ bytes ] test_read_color;
@@ -686,6 +749,8 @@ let roundtrip_cases =
     test_case "pp size matches serialized length" [ bytes ]
       test_pp_size_matches_length;
     test_case "pp preserves the AST node" [ bytes ] test_pp_preserves_ast;
+    test_case "calc identity law" [ bytes ] test_calc_identity_law;
+    test_case "calc optimize idempotent" [ bytes ] test_calc_optimize_idempotent;
   ]
 
 let grammar_cases =

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -878,6 +878,9 @@ module Calc_residual = struct
 
   type 'a ops = {
     of_unitless_number : float -> 'a option;
+    zero : 'a Values.calc;
+        (** The type's canonical unitless zero, returned by [x * 0] when neither
+            operand carries a unit. *)
     is_zero : 'a -> bool;
         (** Recognises a literal zero value, so [0 * x] collapses to zero even
             when [x] is an unresolved [var()]. Conservative [false] is always
@@ -961,28 +964,15 @@ module Calc_residual = struct
           (ops.combine_value_num value Values.Mul n)
     | _ -> None
 
-  (* Multiplicative identities that hold for any operand, so they apply even to
-     an unresolved [var()] (a [~runtime] theme var): [x * 0] is zero and [x * 1]
-     / [x / 1] is [x], neither of which reads the variable's value. A literal
-     zero value ([0px], not just the unitless [0]) collapses the same way, so
-     [divide-x-0]'s [calc(0px * var(--tw-divide-x-reverse))] reduces to [0].
-     Tried after the numeric / value folds so a resolved [Val] keeps its typed
-     zero. *)
-  let fold_identity_expr : type a.
-      is_zero:(a -> bool) ->
-      a Values.calc ->
-      Values.calc_op ->
-      a Values.calc ->
-      a Values.calc option =
-   fun ~is_zero left op right ->
-    let open Values in
-    match (left, op, right) with
-    | _, Mul, Num 0. | Num 0., Mul, _ -> Some (Num 0.)
-    | (Val v as zero), Mul, _ when is_zero v -> Some zero
-    | _, Mul, (Val v as zero) when is_zero v -> Some zero
-    | operand, Mul, Num 1. | Num 1., Mul, operand -> Some operand
-    | operand, Div, Num 1. -> Some operand
-    | _ -> None
+  (* The value-independent identities ([x * 0], [x * 1], [x + 0], ...) live in
+     [Values.calc_identity], shared with the AST evaluators so the two paths
+     never drift. They hold for any operand, so they apply even to an unresolved
+     [var()] (a [~runtime] theme var). [ops.is_zero] lets a literal zero value
+     ([0px], not just the unitless [0]) collapse too, so [divide-x-0]'s
+     [calc(0px * var(--tw-divide-x-reverse))] reduces to [0]. Tried after the
+     numeric / value folds so a resolved [Val] keeps its typed zero. *)
+  let fold_identity_expr ops left op right =
+    Values.calc_identity ~zero:ops.zero ~is_zero:ops.is_zero left op right
 
   let fold_calc_expr ops left op right =
     match fold_num_expr left op right with
@@ -991,7 +981,7 @@ module Calc_residual = struct
         match fold_value_expr ops left op right with
         | Some folded -> folded
         | None -> (
-            match fold_identity_expr ~is_zero:ops.is_zero left op right with
+            match fold_identity_expr ops left op right with
             | Some folded -> folded
             | None -> Values.Expr (left, op, right)))
 
@@ -1019,25 +1009,21 @@ module Calc_residual = struct
      every other subexpression verbatim. Used when a calc keeps an unresolved
      [var()]: the var() reference is preserved, but [x * 0] / [x * 1] still
      simplify because they never read the variable. *)
-  let rec fold_calc_identities : type a.
-      is_zero:(a -> bool) -> a Values.calc -> a Values.calc =
-   fun ~is_zero calc ->
+  let rec fold_calc_identities : type a. a ops -> a Values.calc -> a Values.calc
+      =
+   fun ops calc ->
     let open Values in
     match calc with
     | Expr (left, op, right) -> (
-        let left = fold_calc_identities ~is_zero left in
-        let right = fold_calc_identities ~is_zero right in
-        match fold_identity_expr ~is_zero left op right with
+        let left = fold_calc_identities ops left in
+        let right = fold_calc_identities ops right in
+        match fold_identity_expr ops left op right with
         | Some folded -> folded
         | None -> Expr (left, op, right))
     | Nested inner ->
-        fold_calc_wrapper
-          (fun v -> Nested v)
-          (fold_calc_identities ~is_zero inner)
+        fold_calc_wrapper (fun v -> Nested v) (fold_calc_identities ops inner)
     | Parens inner ->
-        fold_calc_wrapper
-          (fun v -> Parens v)
-          (fold_calc_identities ~is_zero inner)
+        fold_calc_wrapper (fun v -> Parens v) (fold_calc_identities ops inner)
     | leaf -> leaf
 
   let calc_result_to_value (type a) (ops : a ops) simplify ~visited
@@ -1105,8 +1091,7 @@ module Calc_residual = struct
           Values.Expr (walk_calc ~visited left, op, walk_calc ~visited right)
     and simplify_calc ?(preserve = false) ~visited calc =
       let calc = walk_calc ~visited calc in
-      if preserve && contains_var calc then
-        fold_calc_identities ~is_zero:ops.is_zero calc
+      if preserve && contains_var calc then fold_calc_identities ops calc
       else fold_calc ops calc
     and simplify ~authored ~visited value =
       let simplify_resolved ~authored:_ = simplify ~authored:false in
@@ -1365,6 +1350,7 @@ module Length = struct
       let of_number px = Values.Px px in
       {
         of_unitless_number = (fun _ -> None);
+        zero = Values.Num 0.;
         is_zero = Values.length_is_zero;
         combine_values = combine_numeric_values ~to_number ~of_number;
         combine_value_num = combine_numeric_value_num ~to_number ~of_number;
@@ -1923,6 +1909,7 @@ let simplify_length_percentage ?layer_order ?layer cascade length_ctx value =
     in
     {
       Calc_residual.of_unitless_number = (fun _ -> None);
+      zero = Values.Num 0.;
       is_zero = (fun v -> match to_px v with Some n -> n = 0. | None -> false);
       combine_values;
       combine_value_num;
@@ -1967,6 +1954,7 @@ let simplify_border_width ?layer_order ?layer cascade (length_ctx : Length.ctx)
   let ops : Properties.border_width Calc_residual.ops =
     {
       of_unitless_number = (fun _ -> None);
+      zero = Values.Num 0.;
       is_zero =
         (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
@@ -2014,6 +2002,7 @@ let simplify_font_size ?layer_order ?layer cascade (length_ctx : Length.ctx)
   let ops : Properties.font_size Calc_residual.ops =
     {
       of_unitless_number = (fun _ -> None);
+      zero = Values.Num 0.;
       is_zero =
         (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
@@ -2052,6 +2041,7 @@ let simplify_opacity ?layer_order ?layer cascade value =
     let of_number n = Properties.Opacity_number n in
     {
       of_unitless_number = (fun n -> Some (Properties.Opacity_number n));
+      zero = Values.Num 0.;
       is_zero =
         (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
@@ -2092,6 +2082,7 @@ let simplify_angle ?layer_order ?layer cascade value =
     let of_number deg = Values.Deg deg in
     {
       of_unitless_number = (fun _ -> None);
+      zero = Values.Num 0.;
       is_zero =
         (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
@@ -2122,6 +2113,7 @@ let simplify_duration ?layer_order ?layer cascade value =
     let of_number seconds = Values.S seconds in
     {
       of_unitless_number = (fun _ -> None);
+      zero = Values.Num 0.;
       is_zero =
         (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
@@ -2174,6 +2166,7 @@ let simplify_number_percentage ?layer_order ?layer cascade value =
     {
       Calc_residual.of_unitless_number =
         (fun n -> Some (number_percentage_num n));
+      zero = Values.Num 0.;
       is_zero = (fun _ -> false);
       combine_values = combine_number_percentage_values;
       combine_value_num = combine_number_percentage_value_num;
@@ -2708,6 +2701,7 @@ let simplify_component ?layer_order ?layer ctx value =
   let ops : Values.component Calc_residual.ops =
     {
       Calc_residual.of_unitless_number = (fun n -> Some (Values.Num n));
+      zero = Values.Num 0.;
       is_zero = (fun _ -> false);
       combine_values;
       combine_value_num;
@@ -2735,6 +2729,7 @@ let simplify_percentage ?layer_order ?layer ctx value =
   let ops : Values.percentage Calc_residual.ops =
     {
       of_unitless_number = (fun n -> Some (Values.Num n));
+      zero = Values.Num 0.;
       is_zero =
         (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
@@ -2779,6 +2774,7 @@ let simplify_alpha ?layer_order ?layer ctx value =
   let ops : Values.alpha Calc_residual.ops =
     {
       of_unitless_number = (fun n -> Some (alpha_num n));
+      zero = Values.Num 0.;
       is_zero =
         (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values;

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -2725,6 +2725,19 @@ let simplify_percentage ?layer_order ?layer ctx value =
     | _ -> None
   in
   let of_number n = (Values.Pct n : Values.percentage) in
+  (* A [<percentage>] slot also accepts a bare [<number>] (e.g. an oklch
+     lightness: [.7] and [70%] are equal, but [.7%] is not [.7]). Canonicalise
+     the float spelling without collapsing the [Num] / [Pct] distinction, which
+     [of_number] would, since it always reissues a [Pct]. *)
+  let normalize_value (value : Values.percentage) : Values.percentage =
+    let canon n =
+      try float_of_string (Pp.string_of_float n) with Failure _ -> n
+    in
+    match value with
+    | Values.Num n -> Values.Num (canon n)
+    | Values.Pct n -> Values.Pct (canon n)
+    | other -> other
+  in
   let simplify_leaf _simplify _simplify_calc ~visited:_ value = value in
   let ops : Values.percentage Calc_residual.ops =
     {
@@ -2734,7 +2747,7 @@ let simplify_percentage ?layer_order ?layer ctx value =
         (fun v -> match to_number v with Some n -> n = 0. | None -> false);
       combine_values = combine_numeric_values ~to_number ~of_number;
       combine_value_num = combine_numeric_value_num ~to_number ~of_number;
-      normalize_value = normalize_numeric_value ~to_number ~of_number;
+      normalize_value;
       as_var =
         (function (Values.Var var : Values.percentage) -> Some var | _ -> None);
       of_var = (fun var -> Values.Var var);

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -820,12 +820,47 @@ let fold_zero_numeric_expr : type a.
       match value with Some 0. -> Some (Num 0.) | _ -> None)
   | _ -> None
 
+(* CSS Values 4 §10.7 value-independent calc identities. These hold for any
+   finite operand, so they fold even across a kept [var()]: inside [calc()] a
+   [var()] is single-valued, so [var * 1 = var] regardless of what the variable
+   resolves to. The identities that keep an operand ([x * 1], [1 * x], [x / 1],
+   [x + 0], [0 + x], [x - 0]) return that operand verbatim, so the result is
+   always the same type. The zero-producing cases need the type's canonical zero
+   ([Num 0.] for numbers, [Val Zero] for lengths): [~zero] supplies it.
+   [~is_zero] recognises a typed zero leaf ([0px], not just the unitless [0]) so
+   a literal zero length collapses [0px * x] too. Operands are the
+   already-evaluated subtrees; numeric [op] numeric must be folded by the caller
+   first. *)
+let calc_identity : type a.
+    zero:a calc ->
+    is_zero:(a -> bool) ->
+    a calc ->
+    calc_op ->
+    a calc ->
+    a calc option =
+ fun ~zero ~is_zero l op r ->
+  match (l, op, r) with
+  | _, Mul, Num 1. | _, Div, Num 1. -> Some l
+  | Num 1., Mul, _ -> Some r
+  (* Additive identity holds for the unitless [0] and for a typed zero ([0px]).
+     [0 - x] is [-x], not [x], so only the [0 +] direction folds on the left. *)
+  | _, (Add | Sub), Num 0. -> Some l
+  | _, (Add | Sub), Val v when is_zero v -> Some l
+  | Num 0., Add, _ -> Some r
+  | Val v, Add, _ when is_zero v -> Some r
+  | _, Mul, Num 0. | Num 0., Mul, _ -> Some zero
+  (* A typed zero ([0px]) keeps its own spelling here; the optimizer's
+     zero-length strip canonicalises it, so a non-optimised serialisation still
+     reads [0px] rather than a bare [0]. *)
+  | (Val v as z), Mul, _ when is_zero v -> Some z
+  | _, Mul, (Val v as z) when is_zero v -> Some z
+  | _ -> None
+
 (* CSS Values 4 10.7 structural simplification of a typed calc AST. Folds [Expr
-   (Num _, op, Num _)] subtrees and constant-identity patterns ([x + 0], [0 +
-   x], [x - 0], [x * 1], [1 * x], [x / 1]) into shorter equivalents. The
-   per-type "zero is the identity" cases involving typed [Val] leaves (e.g. [Val
-   Zero] for [length]) are handled by per-type pre-passes that rewrite typed
-   zeros to [Num 0.] before this generic fold. *)
+   (Num _, op, Num _)] subtrees and the value-independent identities
+   ([calc_identity]). The per-type evaluators ([eval_length_calc] /
+   [eval_lp_calc]) add the typed [Val] combinations ([1px + 2px], [2px * 3]) and
+   pass their own [~zero] / [~is_zero] so a typed zero collapses too. *)
 let rec eval_calc : type a. a calc -> a calc = function
   | (Num _ | Val _ | Var _ | Sibling_index | Sibling_count) as leaf -> leaf
   | Math_const _ as leaf -> leaf
@@ -855,16 +890,15 @@ let rec eval_calc : type a. a calc -> a calc = function
       | Num a, Mul, Num b -> Num (a *. b)
       | Num a, Div, Num b -> (
           match exact_div a b with Some q -> Num q | None -> Expr (l, op, r))
-      (* Multiplicative identities hold for any finite operand, so they fold
-         even when the other side is a [var()] or other opaque term: [x * 1] and
-         [1 * x] reduce to [x], [x * 0] and [0 * x] reduce to [0]. *)
-      | _, Mul, Num 1. -> l
-      | Num 1., Mul, _ -> r
-      | _, Mul, Num 0. | Num 0., Mul, _ -> Num 0.
       | _ -> (
-          match fold_zero_numeric_expr lc op rc with
-          | Some zero -> zero
-          | None -> Expr (l, op, r)))
+          match
+            calc_identity ~zero:(Num 0.) ~is_zero:(fun _ -> false) l op r
+          with
+          | Some folded -> folded
+          | None -> (
+              match fold_zero_numeric_expr lc op rc with
+              | Some zero -> zero
+              | None -> Expr (l, op, r))))
 
 let pp_calc : type a. a Pp.t -> a calc Pp.t =
  fun pp_value ctx calc ->
@@ -1203,7 +1237,6 @@ let rec eval_length_calc : length calc -> length calc =
          decimal. *)
       let lc = calc_operand_value l in
       let rc = calc_operand_value r in
-      let identity_safe x = not (length_calc_has_runtime_subst x) in
       match (lc, op, rc) with
       | Num a, Add, Num b -> Num (a +. b)
       | Num a, Sub, Num b -> Num (a -. b)
@@ -1212,12 +1245,6 @@ let rec eval_length_calc : length calc -> length calc =
           match exact_div a b with Some q -> Num q | None -> Expr (l, op, r))
       | _ when Option.is_some (fold_zero_numeric_expr lc op rc) ->
           Option.get (fold_zero_numeric_expr lc op rc)
-      | x, Add, Num 0. when identity_safe x -> x
-      | Num 0., Add, x when identity_safe x -> x
-      | x, Sub, Num 0. when identity_safe x -> x
-      | x, Mul, Num 1. when identity_safe x -> x
-      | Num 1., Mul, x when identity_safe x -> x
-      | x, Div, Num 1. when identity_safe x -> x
       | Val a, op, Val b -> (
           match length_combine op a b with
           | Some v -> Val v
@@ -1234,9 +1261,14 @@ let rec eval_length_calc : length calc -> length calc =
           | None -> Expr (l, op, r))
       (* CSS Values 4 §10.7: [1 / (1 / x)] cancels the double inversion and
          reduces back to [x]. *)
-      | Num 1., Div, Parens (Expr (Num 1., Div, x)) when identity_safe x -> x
-      | Num 1., Div, Expr (Num 1., Div, x) when identity_safe x -> x
-      | _ -> Expr (l, op, r))
+      | Num 1., Div, Parens (Expr (Num 1., Div, x)) -> x
+      | Num 1., Div, Expr (Num 1., Div, x) -> x
+      | _ -> (
+          match
+            calc_identity ~zero:(Val Zero) ~is_zero:length_is_zero l op r
+          with
+          | Some folded -> folded
+          | None -> Expr (l, op, r)))
 
 type length_unit =
   | Px
@@ -1635,20 +1667,10 @@ let lp_of_math_fn (fn : math_fn) : length_percentage option =
       |> Option.some
   | _ -> None
 
-(* See [length_has_runtime_subst]. *)
-let rec lp_has_runtime_subst : length_percentage -> bool = function
-  | Env _ | Var _ -> true
-  | Length l -> length_has_runtime_subst l
-  | Calc c -> lp_calc_has_runtime_subst c
-  | Pct _ | Invalid _ -> false
-
-and lp_calc_has_runtime_subst : length_percentage calc -> bool = function
-  | Var _ -> true
-  | Val v -> lp_has_runtime_subst v
-  | Num _ | Math_const _ | Sibling_index | Sibling_count -> false
-  | Math_fn fn -> math_fn_contains_var fn
-  | Nested inner | Parens inner -> lp_calc_has_runtime_subst inner
-  | Expr (l, _, r) -> lp_calc_has_runtime_subst l || lp_calc_has_runtime_subst r
+let lp_is_zero : length_percentage -> bool = function
+  | Length l -> length_is_zero l
+  | Pct f -> f = 0.
+  | _ -> false
 
 let rec eval_lp_calc : length_percentage calc -> length_percentage calc =
  fun calc ->
@@ -1680,7 +1702,6 @@ let rec eval_lp_calc : length_percentage calc -> length_percentage calc =
          leaking the decimal. *)
       let lc = calc_operand_value l in
       let rc = calc_operand_value r in
-      let identity_safe x = not (lp_calc_has_runtime_subst x) in
       match (lc, op, rc) with
       | Num a, Add, Num b -> Num (a +. b)
       | Num a, Sub, Num b -> Num (a -. b)
@@ -1689,12 +1710,6 @@ let rec eval_lp_calc : length_percentage calc -> length_percentage calc =
           match exact_div a b with Some q -> Num q | None -> Expr (l, op, r))
       | _ when Option.is_some (fold_zero_numeric_expr lc op rc) ->
           Option.get (fold_zero_numeric_expr lc op rc)
-      | x, Add, Num 0. when identity_safe x -> x
-      | Num 0., Add, x when identity_safe x -> x
-      | x, Sub, Num 0. when identity_safe x -> x
-      | x, Mul, Num 1. when identity_safe x -> x
-      | Num 1., Mul, x when identity_safe x -> x
-      | x, Div, Num 1. when identity_safe x -> x
       | Val a, op, Val b -> (
           match lp_combine op a b with
           | Some v -> Val v
@@ -1709,9 +1724,14 @@ let rec eval_lp_calc : length_percentage calc -> length_percentage calc =
           match lp_scale Mul a n with Some v -> Val v | None -> Expr (l, op, r))
       (* CSS Values 4 §10.7: [1 / (1 / x)] cancels the double inversion and
          reduces back to [x]. *)
-      | Num 1., Div, Parens (Expr (Num 1., Div, x)) when identity_safe x -> x
-      | Num 1., Div, Expr (Num 1., Div, x) when identity_safe x -> x
-      | _ -> Expr (l, op, r))
+      | Num 1., Div, Parens (Expr (Num 1., Div, x)) -> x
+      | Num 1., Div, Expr (Num 1., Div, x) -> x
+      | _ -> (
+          match
+            calc_identity ~zero:(Val (Length Zero)) ~is_zero:lp_is_zero l op r
+          with
+          | Some folded -> folded
+          | None -> Expr (l, op, r)))
 
 let unit_of_lp : length_percentage -> (length_unit * float) option = function
   | Pct n -> Some (Pct, n)

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -507,6 +507,21 @@ val eval_calc : 'a calc -> 'a calc
     operands survive — type-specific simplification (e.g., length arithmetic) is
     the caller's job. *)
 
+val calc_identity :
+  zero:'a calc ->
+  is_zero:('a -> bool) ->
+  'a calc ->
+  calc_op ->
+  'a calc ->
+  'a calc option
+(** [calc_identity ~zero ~is_zero l op r] applies the value-independent CSS
+    Values 4 §10.7 identities to one [Expr (l, op, r)] node, returning the
+    folded operand when one applies. These hold for any operand including a kept
+    [var()] (inside [calc()] a [var()] is single-valued): [x * 1], [1 * x],
+    [x / 1], [x + 0], [0 + x], [x - 0] keep [x]; [x * 0] / [0 * x] reduce to
+    [zero]. [is_zero] recognises a typed zero leaf ([0px]). Numeric [op] numeric
+    is the caller's job. *)
+
 val var_name : 'a var -> string
 (** [var_name v] is [v]'s variable name (without --). *)
 

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -81,6 +81,14 @@ let test_inline_zero_value_collapse () =
           ":root{--tw-divide-x-reverse:0}.d{border-inline-start-width:calc(0px \
            * var(--tw-divide-x-reverse))}"))
 
+let test_inline_oklch_number_lightness () =
+  (* An oklch lightness written as a bare number ([.7]) is the number 0.7, equal
+     to [70%] but not to [.7%]. Simplifying the colour while inlining must keep
+     the number form rather than reissue it as a percentage, which would corrupt
+     [.7] into [.7%] (0.7%). *)
+  check_inline_case "oklch number lightness keeps its number form"
+    ".b{color:oklch(.7 .15 145.5)}" ".b{color:oklch(.7 .15 145.5)}"
+
 let test_decode_import_url () =
   Alcotest.(check string)
     "url form" "theme.css"
@@ -209,6 +217,8 @@ let suite =
         test_inline_keep_vars_calc_identity;
       Alcotest.test_case "inline vars collapse a literal zero times a kept var"
         `Quick test_inline_zero_value_collapse;
+      Alcotest.test_case "inline vars keep an oklch number lightness" `Quick
+        test_inline_oklch_number_lightness;
       Alcotest.test_case "decode import url forms" `Quick test_decode_import_url;
       Alcotest.test_case "inline imports resolves loader stylesheet" `Quick
         test_inline_import_loader;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4799,8 +4799,12 @@ let transforms1_11_chain_whitespace_dropped () =
 (* CSS Custom Properties L1 section 2 (var()): variable references are
    late-bound through the cascade and resolved at computed-value time. The
    optimizer cannot inline a variable without a context that resolves it (a
-   [theme] map keyed on custom property names). At syntax time, [var(--x,
-   fallback)] must round-trip preserved. *)
+   [theme] map keyed on custom property names), so the [var()] reference and its
+   [calc()] wrapper round-trip preserved. The value-independent CSS Values 4
+   §10.7 identities ([x * 1], [x + 0], ...) still fold: they hold for every
+   possible substitution because the [var()] stays inside calc()'s grammar, so
+   [calc(var(--x) * 1)] shortens to [calc(var(--x))] (not to bare [var(--x)],
+   which §10.10 forbids without knowing the value). *)
 let customprops12_inlining () =
   let normalize css =
     match Css.of_string ~strict:false css with
@@ -4821,32 +4825,32 @@ let customprops12_inlining () =
     ".x{padding:calc(var(--spacing))}"
     (normalize ".x { padding: calc(var(--spacing)) }");
   Alcotest.(check string)
-    "calc var times one keeps var arithmetic"
-    ".x{padding:calc(var(--spacing)*1)}"
+    "calc var times one folds, keeping the var reference"
+    ".x{padding:calc(var(--spacing))}"
     (normalize ".x { padding: calc(var(--spacing) * 1) }");
   Alcotest.(check string)
-    "calc one times var keeps var arithmetic"
-    ".x{padding:calc(1*var(--spacing))}"
+    "calc one times var folds, keeping the var reference"
+    ".x{padding:calc(var(--spacing))}"
     (normalize ".x { padding: calc(1 * var(--spacing)) }");
   Alcotest.(check string)
-    "calc var divided by one keeps var arithmetic"
-    ".x{padding:calc(var(--spacing)/1)}"
+    "calc var divided by one folds, keeping the var reference"
+    ".x{padding:calc(var(--spacing))}"
     (normalize ".x { padding: calc(var(--spacing) / 1) }");
   Alcotest.(check string)
-    "calc var plus zero keeps var arithmetic"
-    ".x{padding:calc(var(--spacing) + 0px)}"
+    "calc var plus zero folds, keeping the var reference"
+    ".x{padding:calc(var(--spacing))}"
     (normalize ".x { padding: calc(var(--spacing) + 0px) }");
   Alcotest.(check string)
-    "calc zero plus var keeps var arithmetic"
-    ".x{padding:calc(0px + var(--spacing))}"
+    "calc zero plus var folds, keeping the var reference"
+    ".x{padding:calc(var(--spacing))}"
     (normalize ".x { padding: calc(0px + var(--spacing)) }");
   Alcotest.(check string)
-    "calc var minus zero keeps var arithmetic"
-    ".x{padding:calc(var(--spacing) - 0px)}"
+    "calc var minus zero folds, keeping the var reference"
+    ".x{padding:calc(var(--spacing))}"
     (normalize ".x { padding: calc(var(--spacing) - 0px) }");
   Alcotest.(check string)
-    "calc nested var identities keep var arithmetic"
-    ".x{padding:calc(var(--spacing)*1 + 0px)}"
+    "calc nested var identities fold, keeping the var reference"
+    ".x{padding:calc(var(--spacing))}"
     (normalize ".x { padding: calc((var(--spacing) * 1) + 0px) }");
   Alcotest.(check string)
     "calc var-free left subtree may fold before var"


### PR DESCRIPTION
`Values.calc_identity` is now the single definition of the value-independent calc identities (`x * 1`, `x + 0`, `x * 0`, and friends). They were folded in three places that disagreed: the generic `eval_calc` applied them ungated, the per-type length evaluators gated them behind a runtime-substitution check, and `Context.Calc_residual` reimplemented them, so `calc(var(--spacing) * 1)` collapsed through the inline path but survived `optimize` untouched. Routing every path through one helper makes them agree, and the per-type gate is dropped: inside `calc()` a `var()` is single-valued, so `var * 1 = var` holds for any substitution.

Folding keeps the `calc()` wrapper, which is sound for every substitution. Unwrapping `calc(var(--x))` to a bare `var(--x)` is not, because the value could be `auto`, a keyword, or a multi-value stream, so the optimize path keeps the wrapper and only the resolver, which knows the value, drops it.

The second commit fixes an unrelated bug surfaced along the way: simplifying a colour reissued an oklch lightness written as a bare number (`.7`) through the percentage builder, turning it into `.7%` (0.7%) and changing the rendered colour.