### PR TITLE
selector: cap functional-pseudo-class nesting depth

### DIFF
--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -10,11 +10,22 @@ type t = {
       (* Where to point errors raised at end of this cursor. For a cursor over a
          nested block body this is the block's closing delimiter position, not
          the end of the whole input. *)
+  depth : int;
+      (* Function-call nesting depth, bumped by [call] each time it descends
+         into a function's arguments. Bounds recursion ([calc(calc(...))],
+         [:is(:is(...))]) so [of_string] over untrusted CSS cannot be driven
+         into a stack overflow or super-linear validation by deeply nested
+         input. *)
 }
+
+(* CSS Syntax has no nesting limit, but real authored CSS nests functions only a
+   handful deep; browsers cap too. Generous enough never to reject real input,
+   small enough that the per-level selector validation walks stay linear. *)
+let max_nesting_depth = 100
 
 let of_components ?source ?(recover = false) ?(meta = Loc.default_meta_level)
     ?eof_loc cvs =
-  { cvs; source; warnings = ref []; recover; meta; eof_loc }
+  { cvs; source; warnings = ref []; recover; meta; eof_loc; depth = 0 }
 
 let sub ?eof_loc t cvs =
   {
@@ -24,6 +35,7 @@ let sub ?eof_loc t cvs =
     recover = t.recover;
     meta = t.meta;
     eof_loc = (match eof_loc with Some _ -> eof_loc | None -> t.eof_loc);
+    depth = t.depth;
   }
 
 let push_warning t e = t.warnings := e :: !(t.warnings)
@@ -59,6 +71,7 @@ let of_string ?(meta = Loc.default_meta_level) s =
     recover = false;
     meta;
     eof_loc = None;
+    depth = 0;
   }
 
 let of_reader ?(meta = Loc.default_meta_level) r =
@@ -70,6 +83,7 @@ let of_reader ?(meta = Loc.default_meta_level) r =
     recover = false;
     meta;
     eof_loc = None;
+    depth = 0;
   }
 
 let is_ws_cv : Component.t -> bool = function
@@ -734,7 +748,10 @@ let call name t f =
     when String.lowercase_ascii_preserve fn.node.name
          = String.lowercase_ascii_preserve name ->
       let _ = next t in
-      f (sub ~eof_loc:(closer_loc fn.loc) t fn.node.arguments)
+      let arg = sub ~eof_loc:(closer_loc fn.loc) t fn.node.arguments in
+      let arg = { arg with depth = t.depth + 1 } in
+      if arg.depth > max_nesting_depth then err arg "nesting too deep";
+      f arg
   | _ -> err_expected t (name ^ "(")
 
 (** {1 Enums} *)

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -699,6 +699,24 @@ let parse_errors_pseudo () =
   check_parse_error ".test:not()" "expected at least one selector";
   check_parse_error ".test:has()" "expected at least one selector"
 
+let parse_errors_nesting_depth () =
+  (* A pathologically deep functional-pseudo-class nest is capped rather than
+     driving the per-level selector validation into super-linear time (a
+     parse-time DoS on untrusted CSS). [:not] is non-forgiving, so the cap
+     surfaces as a [Parse_error]; a nest within the cap still parses. *)
+  let nested fn n =
+    let rep s = String.concat "" (List.init n (fun _ -> s)) in
+    ".x" ^ rep (fn ^ "(") ^ "a" ^ rep ")"
+  in
+  check_parse_error (nested ":not" 200) "nesting too deep";
+  List.iter
+    (fun s ->
+      match Cursor.option read (Cursor.of_string s) with
+      | Some _ -> ()
+      | None ->
+          Alcotest.failf "selector within the nesting cap should parse: %s" s)
+    [ nested ":not" 8; nested ":is" 8 ]
+
 let parse_errors_empty_list () =
   check_parse_error ", ," "expected at least one selector";
   check_parse_error ", h1, h2" "expected at least one selector";
@@ -1750,6 +1768,7 @@ let suite =
       test_case "parse errors - combinators" `Quick parse_errors_combinators;
       test_case "parse errors - starts" `Quick parse_errors_starts;
       test_case "parse errors - pseudo" `Quick parse_errors_pseudo;
+      test_case "parse errors - nesting depth" `Quick parse_errors_nesting_depth;
       test_case "parse errors - empty list" `Quick parse_errors_empty_list;
       test_case "parse errors - complex" `Quick parse_errors_complex;
       test_case "callstack accuracy" `Quick callstack_accuracy;


### PR DESCRIPTION
`Css.of_string` placed no bound on selector nesting, and the per-level `:is`/`:not` validation walks (`has_pseudo_element`, `has_unknown_pseudo_class`) re-traverse the just-parsed subtree once per level. A deeply nested `:is(:is(...))` is therefore super-linear: a ~250KB input pinned a core for ~90s, a cheap parse-time denial of service for any service parsing untrusted CSS.

Bounding function-call nesting at the single `Cursor.call` choke point keeps the recursion, and the validation it drives, linear; the same input now parses in ~0.1s. The cap is generous (real CSS nests a handful deep, and browsers cap too), so authored CSS is unaffected, and it covers value functions (`calc`, colour) as well.