### PR TITLE
values+properties: fold calc identities in normalize, not the printer

### DIFF
--- a/fuzz/fuzz_values.ml
+++ b/fuzz/fuzz_values.ml
@@ -649,17 +649,35 @@ let optimize_one css =
   | Error _ -> None
 
 (* (property, operand, type-matched zero) triples driving the calc-identity
-   invariants below: [width] / [padding] reach the per-type length /
-   length-percentage evaluators, [opacity] the generic number one. *)
+   invariants below. Spans every value type whose [calc()] folds through the
+   optimize pass now that the printer is a pure serialiser: lengths / percentages
+   ([width], [padding]), the generic number ([opacity]), and the own-typed
+   [line-height] / [<time>] / [font-size] / [vertical-align] / [border-width] /
+   [number-percentage] folds. *)
+(* The third field is the additive identity element when the type folds [x + 0]
+   in the optimize pass: lengths / percentages collapse a typed [0px], numbers a
+   unitless [0]. Own-typed lengths reached only through the generic [eval_calc]
+   ([font-size], [border-width], [<time>]) fold the multiplicative identity but
+   not a typed-zero addition, and a unitless [0] is invalid there, so they carry
+   [None]. *)
 let calc_identity_targets =
   [
-    ("width", "12px", "0px");
-    ("width", "var(--a)", "0px");
-    ("width", "50%", "0px");
-    ("padding", "var(--a)", "0px");
-    ("padding", ".5rem", "0px");
-    ("opacity", "var(--a)", "0");
-    ("opacity", ".5", "0");
+    ("width", "12px", Some "0px");
+    ("width", "var(--a)", Some "0px");
+    ("width", "50%", Some "0px");
+    ("padding", "var(--a)", Some "0px");
+    ("padding", ".5rem", Some "0px");
+    ("opacity", "var(--a)", Some "0");
+    ("opacity", ".5", Some "0");
+    ("line-height", "var(--a)", Some "0");
+    ("transition-duration", "var(--a)", None);
+    ("animation-delay", "var(--a)", None);
+    ("font-size", "16px", None);
+    ("font-size", "var(--a)", None);
+    ("vertical-align", "var(--a)", None);
+    ("border-top-width", "var(--a)", None);
+    ("scale", "var(--a)", Some "0");
+    ("flex-grow", "var(--a)", Some "0");
   ]
 
 (* CSS Values 4 §10.7 identity law: wrapping a value in a value-independent
@@ -670,11 +688,28 @@ let calc_identity_targets =
    evaluator the optimize pass reaches, so the generic and per-type folds cannot
    drift. *)
 let test_calc_identity_law buf =
-  let prop, operand, zero = pick calc_identity_targets buf 0 in
+  let prop, operand, add_zero = pick calc_identity_targets buf 0 in
   let decl v = ".x{" ^ prop ^ ":" ^ v ^ "}" in
   match optimize_one (decl ("calc(" ^ operand ^ ")")) with
   | None -> ()
   | Some bare ->
+      let multiplicative =
+        [
+          "calc(" ^ operand ^ " * 1)";
+          "calc(1 * " ^ operand ^ ")";
+          "calc(" ^ operand ^ " / 1)";
+        ]
+      in
+      let additive =
+        match add_zero with
+        | None -> []
+        | Some z ->
+            [
+              "calc(" ^ operand ^ " + " ^ z ^ ")";
+              "calc(" ^ z ^ " + " ^ operand ^ ")";
+              "calc(" ^ operand ^ " - " ^ z ^ ")";
+            ]
+      in
       List.iter
         (fun w ->
           match optimize_one (decl w) with
@@ -682,20 +717,13 @@ let test_calc_identity_law buf =
           | Some got ->
               if got <> bare then
                 failf "calc identity law broken: %S -> %S (bare %S)" w got bare)
-        [
-          "calc(" ^ operand ^ " * 1)";
-          "calc(1 * " ^ operand ^ ")";
-          "calc(" ^ operand ^ " / 1)";
-          "calc(" ^ operand ^ " + " ^ zero ^ ")";
-          "calc(" ^ zero ^ " + " ^ operand ^ ")";
-          "calc(" ^ operand ^ " - " ^ zero ^ ")";
-        ]
+        (multiplicative @ additive)
 
 (* The identity and constant folds both converge, so a second optimize pass over
    a calc is a no-op. *)
 let test_calc_optimize_idempotent buf =
-  let prop, operand, zero = pick calc_identity_targets buf 0 in
-  let css = ".x{" ^ prop ^ ":calc(" ^ operand ^ " * 1 + " ^ zero ^ ")}" in
+  let prop, operand, _ = pick calc_identity_targets buf 0 in
+  let css = ".x{" ^ prop ^ ":calc(" ^ operand ^ " * 1)}" in
   match optimize_one css with
   | None -> ()
   | Some once -> (

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20715,7 +20715,43 @@ let rec canonicalize_math_whitespace_components ?(in_math = false) comps =
 let normalize_font_size (fs : font_size) : font_size =
   match fs with
   | Length l -> preserve_if_equal fs (Length (Values.normalize_length l))
+  | Calc c -> (
+      match Values.eval_calc c with Values.Val v -> v | folded -> Calc folded)
   | _ -> fs
+
+(* Fold the value-independent parts of these own-typed [calc()]s ([calc(var(--x)
+   * 1)] -> [calc(var(--x))], [calc(10 / 2)] -> [5]), keeping any [var()]. The
+   printer is a pure serialiser, so these AST-level folds replace the numeric /
+   identity reduction the printer did under minify. *)
+let normalize_opacity (o : opacity) : opacity =
+  match o with
+  | Calc c -> (
+      match Values.eval_calc c with
+      | Values.Num f -> Opacity_number f
+      | Values.Val v -> v
+      | folded -> Calc folded)
+  | _ -> o
+
+let normalize_line_height (lh : line_height) : line_height =
+  match lh with
+  | Calc c -> (
+      match Values.eval_calc c with
+      | Values.Num f -> Num f
+      | Values.Val v -> v
+      | folded -> Calc folded)
+  | _ -> lh
+
+let normalize_vertical_align (va : vertical_align) : vertical_align =
+  match va with
+  | Calc c -> (
+      match Values.eval_calc c with Values.Val v -> v | folded -> Calc folded)
+  | _ -> va
+
+let normalize_border_width (bw : border_width) : border_width =
+  match bw with
+  | Calc c -> (
+      match Values.eval_calc c with Values.Val v -> v | folded -> Calc folded)
+  | _ -> bw
 
 let normalize_property_value : type a. ?lossless:bool -> a property -> a -> a =
  fun ?(lossless = false) property value ->
@@ -20912,6 +20948,29 @@ let normalize_property_value : type a. ?lossless:bool -> a property -> a -> a =
           if components' == components then value
           else Custom_value { r with value = Tokens components' }
       | Custom_value _ -> value)
+  | Opacity -> normalize_opacity value
+  | Line_height -> normalize_line_height value
+  | Vertical_align -> normalize_vertical_align value
+  | Border_top_width -> normalize_border_width value
+  | Border_right_width -> normalize_border_width value
+  | Border_bottom_width -> normalize_border_width value
+  | Border_left_width -> normalize_border_width value
+  | Border_inline_start_width -> normalize_border_width value
+  | Border_inline_end_width -> normalize_border_width value
+  | Border_block_start_width -> normalize_border_width value
+  | Border_block_end_width -> normalize_border_width value
+  | Transition_duration -> Values.normalize_duration value
+  | Transition_delay -> Values.normalize_duration value
+  | Animation_duration -> Values.normalize_duration value
+  | Animation_delay -> Values.normalize_duration value
+  | Webkit_transition_duration -> Values.normalize_duration value
+  | Webkit_transition_delay -> Values.normalize_duration value
+  | Webkit_animation_duration -> Values.normalize_duration value
+  | Webkit_animation_delay -> Values.normalize_duration value
+  | Moz_transition_duration -> Values.normalize_duration value
+  | Moz_transition_delay -> Values.normalize_duration value
+  | Moz_animation_duration -> Values.normalize_duration value
+  | Moz_animation_delay -> Values.normalize_duration value
   | _ -> value
 
 let normalize_custom_property_value ?(lossless = false) :
@@ -20926,7 +20985,8 @@ let normalize_custom_property_value ?(lossless = false) :
         }
   | Typed { kind = Number; value } ->
       Typed { kind = Number; value = Values.normalize_number value }
-  | Typed { kind = Percentage; value } -> Typed { kind = Percentage; value }
+  | Typed { kind = Percentage; value } ->
+      Typed { kind = Percentage; value = Values.normalize_percentage value }
   | Typed { kind = Length_percentage; value } ->
       Typed
         {

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5214,8 +5214,15 @@ and read_calc_non_paren_factor : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
       read_sibling_count_factor;
       read_calc_zero;
       read_calc_numeric_function;
-      (fun t -> Val (read_a t));
+      (* A plain unitless [<number>] in a calc is the [<number>] type, not the
+         surrounding property's value, so read it as a [Num] leaf before the
+         typed reader. Otherwise a property that accepts a bare number (e.g.
+         line-height, opacity) reads it as a [Val], which the multiplication
+         dimension check then mistakes for a dimension and rejects [2 * 3]. A
+         dimension ([2px]) or percentage token is not a [Number_tok], so it
+         still falls through to the typed [Val] reader. *)
       (fun t -> (Num (Cursor.number t) : a calc));
+      (fun t -> Val (read_a t));
       read_math_constant_factor;
     ]
     t

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -902,7 +902,6 @@ let rec eval_calc : type a. a calc -> a calc = function
 
 let pp_calc : type a. a Pp.t -> a calc Pp.t =
  fun pp_value ctx calc ->
-  let calc = if Pp.minified ctx then eval_calc calc else calc in
   match calc with
   (* CSS Values 4 §10.10: a [var()] inside [calc()] is a runtime substitution
      boundary - the substituted tokens go through calc's typed grammar, not the
@@ -3730,6 +3729,27 @@ let rec normalize_number (n : number) : number =
   | Sign v -> Sign (normalize_number v)
   | Sin _ | Num _ | Var _ -> n
 
+(* Fold the value-independent parts of a [<percentage>] [calc()] ([calc(1 / 2 *
+   100%)] -> [calc(.5*100%)]), keeping any [var()]. Replaces the numeric /
+   identity reduction the printer did under minify, now that pp is a pure
+   serialiser. *)
+let normalize_percentage (p : percentage) : percentage =
+  match p with
+  | Calc c -> (
+      match eval_calc c with
+      | Num f -> Num f
+      | Val v -> v
+      | folded -> Calc folded)
+  | Pct _ | Num _ | Var _ -> p
+
+(* Fold the value-independent parts of a [<time>] [calc()] ([calc(var(--d) * 1)]
+   -> [calc(var(--d))]), keeping any [var()]. A bare-number reduction stays
+   wrapped (a [<number>] is not a [<time>]). *)
+let normalize_duration (d : duration) : duration =
+  match d with
+  | Calc c -> ( match eval_calc c with Val v -> v | folded -> Calc folded)
+  | _ -> d
+
 (* Canonicalise an [<angle>]: fold the static math functions ([round] / [mod] /
    [rem] on [deg] operands), then pick the shortest of the
    losslessly-interconvertible spellings (deg / turn / grad). [rad] goes through
@@ -3815,9 +3835,15 @@ let rec pp_number_percentage ?(always = false) : number_percentage Pp.t =
    faithfully. [Var] and [Calc] sub-forms are left untouched - inside a calc(),
    [%] and number are not interchangeable, and a [var()] reference is
    context-free. *)
-let normalize_number_percentage (np : number_percentage) : number_percentage =
+let rec normalize_number_percentage (np : number_percentage) : number_percentage
+    =
   let len f = String.length (Pp.string_of_float ~drop_leading_zero:true f) in
   match np with
+  | Calc c -> (
+      match eval_calc c with
+      | Num f -> normalize_number_percentage (Num f)
+      | Val v -> normalize_number_percentage v
+      | folded -> Calc folded)
   | Pct f ->
       let num_f = f /. 100. in
       (* num spelling vs pct spelling (one extra '%' character); Num wins on tie

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -213,6 +213,16 @@ val normalize_number : number -> number
     ([hypot(3, 4)] becomes [5], [calc(1 + 2)] becomes [3]), recursing into
     nested calls; an operand with a [var()] keeps the call. *)
 
+val normalize_percentage : percentage -> percentage
+(** [normalize_percentage p] folds the value-independent parts of a
+    [<percentage>] [calc()] ([calc(1 / 2 * 100%)] becomes [calc(.5*100%)]),
+    keeping any [var()]. *)
+
+val normalize_duration : duration -> duration
+(** [normalize_duration d] folds the value-independent parts of a [<time>]
+    [calc()] ([calc(var(--d) * 1)] becomes [calc(var(--d))]), keeping any
+    [var()]. *)
+
 val normalize_color : ?lossless:bool -> in_feature_query:bool -> color -> color
 (** [normalize_color ?lossless ~in_feature_query c] canonicalises a color to its
     shortest spelling: a static colour in any space folds through sRGB to

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4580,6 +4580,15 @@ let v4_10_2_calc_arithmetic () =
   Alcotest.(check string)
     "calc(2 * 3) -> 6" ".x{aspect-ratio:6}"
     (normalize ".x { aspect-ratio: calc(2 * 3) }");
+  (* A property whose value accepts a bare [<number>] (line-height) must still
+     read the [<number>] operands of a calc multiplication as numbers, not as
+     typed values that the dimension check rejects. *)
+  Alcotest.(check string)
+    "line-height calc(2 * 3) -> 6" ".x{line-height:6}"
+    (normalize ".x { line-height: calc(2 * 3) }");
+  Alcotest.(check string)
+    "line-height calc(2px * 1) -> 2px" ".x{line-height:2px}"
+    (normalize ".x { line-height: calc(2px * 1) }");
   Alcotest.(check string)
     "calc(1px - 1px) -> 0" ".x{width:0}"
     (normalize ".x { width: calc(1px - 1px) }");


### PR DESCRIPTION
Two related calc-correctness fixes; the second was surfaced by the first.

`pp_calc` reduced numeric and value-independent identity calc under minify (`calc(10/2)` -> `5`, `calc(var(--x)*1)` -> `calc(var(--x))`). That was the fourth divergence from the calc-identity cleanup (#76), where the printer folded while `pp_calc_presolved` did not. The fold moves out of `pp_calc` into the AST normalize pass, through the shared `Values.calc_identity` from #76, with a folding normalize for every value type that relied on it: percentage, duration, opacity, line-height, vertical-align, border-width, font-size, and the number-percentage leaf. The fuzz `calc identity law` is extended to probe each type, since the existing suite stays green through these silent gaps.

The second commit fixes a pre-existing parser bug that surfaced once line-height calc folded through normalize. `read_calc_non_paren_factor` read a bare unitless `<number>` calc operand through the property's typed leaf reader before the number reader, so for a property that accepts a bare number (line-height, opacity) `2` became a typed value that the multiplication dimension check rejected, dropping `line-height: calc(2 * 3)` / `calc(2px * 1)` at parse time. A plain number token is now read as a `Num` leaf first; a dimension or percentage token is not a `Number_tok`, so `2px * 3px` stays correctly rejected.