### PR TITLE
values: canonicalize a signed zero to unsigned zero

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -9,6 +9,7 @@ let err_invalid_value ?got t prop_name value =
 (* Generic length parsing helpers *)
 let read_line_height_length t : line_height =
   let n, repr, unit = Cursor.number_repr_with_unit t in
+  let n, repr = normalize_signed_zero n repr in
   if n < 0. then Cursor.err_invalid t "line-height cannot be negative"
   else
     let authored () : line_height = Number { value = n; unit; repr } in

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4718,8 +4718,17 @@ let read_env : type a. (Cursor.t -> a) -> Cursor.t -> a env =
  fun read_value t ->
   Cursor.call "env" t (fun inner -> read_body read_value inner)
 
+(* CSS Values 4 sec. 6.1: a signed zero is the same value as unsigned zero.
+   Collapse any zero to the canonical [0]: normalise [-0.] to [0.] (so the AST
+   never carries a negative-zero float, which breaks structural equality) and
+   regenerate the repr from that value rather than echo the authored sign, so
+   [-0px] / [+0px] serialise as [0px]. *)
+let normalize_signed_zero n repr =
+  if n = 0.0 then (0.0, Pp.string_of_float 0.0) else (n, repr)
+
 let read_length_unit ?(allow_negative = true) t =
   let n, repr, unit_raw = Cursor.number_repr_with_unit t in
+  let n, repr = normalize_signed_zero n repr in
   if (not allow_negative) && n < 0.0 then Cursor.err_invalid t "negative";
   let unit = String.lowercase_ascii (Option.value unit_raw ~default:"") in
   let authored unit =

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -340,6 +340,12 @@ end
 
 (** {1 Parsing Functions} *)
 
+val normalize_signed_zero : float -> string -> float * string
+(** [normalize_signed_zero n repr] collapses any zero to the canonical [0]: when
+    [n] is zero it returns [(0., "0")], dropping a signed or over-precise
+    authored spelling so [-0px] / [+0px] / [0.0px] all read (and serialise) with
+    a [0] repr. Other values pass through unchanged. *)
+
 val read_length :
   ?allow_negative:bool -> ?with_keywords:bool -> Cursor.t -> length
 (** [read_length t] parses a CSS length. *)

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -133,6 +133,14 @@ let test_length () =
   check_length ~expected:".5rem" "0.5rem";
   check_length "-.5rem";
 
+  (* CSS Values 4 sec. 6.1: a signed zero is the same value as unsigned zero, so
+     any zero collapses to the canonical 0 (the unit is kept). *)
+  check_length ~expected:"0px" "-0px";
+  check_length ~expected:"0px" "+0px";
+  check_length ~expected:"0px" "0.0px";
+  check_length ~expected:"0px" "-0.0px";
+  check_length ~expected:"0" "-0";
+
   (* Test var in length context *)
   check_length ~expected:"var(--spacing,10px)" "var(--spacing, 10px)";
 


### PR DESCRIPTION
cascade kept the authored sign of a zero-valued dimension: `-0px` serialised as `-0px`, and the length and line-height readers stored a `-0.` float that breaks structural equality. A signed zero is the same value as an unsigned zero, so any zero now collapses to the canonical `0` (the unit is kept), and `-0px`, `+0px` and `0.0px` all print as `0px`.