### PR TITLE
container: parse not before a style() or scroll-state() query

### DIFF
--- a/lib/container.ml
+++ b/lib/container.ml
@@ -640,15 +640,21 @@ let atom_of_string s =
 let rec unnamed_query_not s stripped =
   if String.length stripped >= 4 && String.sub stripped 0 4 = "not " then
     (* CSS Containment 3 §4 and Conditional Rules: [not] takes exactly one
-       [<query-in-parens>], so [not not (x)] is a parse error. The inner
-       expression must be wrapped in parens (a feature query, a
-       style()/scroll-state() function, or a parenthesised compound
-       condition). *)
+       [<query-in-parens>], so [not not (x)] is a parse error. The operand is a
+       parenthesised compound condition or a [style()] / [scroll-state()]
+       function; the latter carry their own parentheses, so they need no extra
+       wrapping ([not style(--a)] is valid, not just [not (style(--a))]). *)
     let inner =
       String.trim (String.sub stripped 4 (String.length stripped - 4))
     in
-    if String.length inner = 0 || inner.[0] <> '(' then
-      failwith "container query: 'not' requires a parenthesised operand"
+    let is_function_operand =
+      match classify_query_surface inner with
+      | Style_func _ | Scroll_state_func _ -> true
+      | Parenthesized_feature | Other_query -> false
+      | exception Failure _ -> false
+    in
+    if String.length inner = 0 || (inner.[0] <> '(' && not is_function_operand)
+    then failwith "container query: 'not' requires a query-in-parens operand"
     else Not (unnamed_of_string inner)
   else atom_of_string s
 

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -34,6 +34,14 @@ let test_string_output () =
   Alcotest.(check string)
     "named style query raw" "card style(--variant: featured)"
     (to_string (Named ("card", of_string "style(--variant: featured)")));
+  (* CSS Conditional Rules 5 §4: [not] takes one query-in-parens, and a
+     [style()] function is one, so [not style(--a)] needs no extra wrapping. *)
+  Alcotest.(check string)
+    "negated style query" "not style(--a)"
+    (to_string ~minify:true (of_string "not style(--a)"));
+  Alcotest.(check string)
+    "named negated style query" "card not style(--variant)"
+    (to_string ~minify:true (Named ("card", of_string "not style(--variant)")));
   Alcotest.(check string)
     "chained range query raw" "(30em <= inline-size < 60em)"
     (to_string (of_string "(30em <= inline-size < 60em)"));


### PR DESCRIPTION
The container-query parser required the operand after `not` to start with `(`, so `@container not style(--a)` was rejected even though a `style()` function is itself a query-in-parens (`@container not (style(--a))` parsed). The `not` operand now also accepts the bare `style()` and `scroll-state()` function forms.