### PR TITLE
css: resolve theme defaults referenced inside custom-property values

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1008,6 +1008,47 @@ let var_names_in_theme_value value =
   done;
   !names
 
+(* The AST var collector records the names a custom property *defines*, but not
+   the [var()] references nested inside its opaque value token stream. So a
+   target referenced only from a kept custom property (e.g. an emitted
+   [--shadow: ... var(--spacing) ...]) is never a resolution root. Scan the
+   serialized value of every custom-property declaration so those references
+   pull their targets into the inject set too. *)
+let var_refs_in_custom_values stylesheet =
+  let acc = ref [] in
+  let scan_decls decls =
+    List.iter
+      (fun decl ->
+        List.iter
+          (fun n -> acc := n :: !acc)
+          (var_names_in_theme_value (declaration_value decl)))
+      (Variables.custom_declarations decls)
+  in
+  let rec walk = function
+    | [] -> ()
+    | stmt :: rest ->
+        (match stmt with
+        | Stylesheet.Rule r ->
+            scan_decls r.declarations;
+            walk r.nested
+        | Declarations decls -> scan_decls decls
+        | Media (_, b)
+        | Supports (_, b)
+        | Container (_, _, b)
+        | Layer (_, b)
+        | Origin (_, b)
+        | Scope (_, _, b)
+        | Starting_style b
+        | Moz_document (_, b)
+        | When (_, b)
+        | Else (_, b) ->
+            walk b
+        | _ -> ());
+        walk rest
+  in
+  walk stylesheet;
+  !acc
+
 let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
   let resolved : (string, string) Hashtbl.t = Hashtbl.create 16 in
   let cyclic = ref [] in
@@ -1036,7 +1077,9 @@ let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
                 Hashtbl.replace resolved raw_name value)
   in
   (match theme with
-  | Option.Some _ -> List.iter dfs (collect_var_names stylesheet)
+  | Option.Some _ ->
+      List.iter dfs (collect_var_names stylesheet);
+      List.iter dfs (var_refs_in_custom_values stylesheet)
   | Option.None -> ());
   Hashtbl.fold (fun k v acc -> (k, v) :: acc) resolved []
 
@@ -1089,10 +1132,14 @@ let resolve_theme ?theme ?theme_defaults stylesheet =
       collect_var_names stylesheet
       |> List.filter (fun n -> not (List.mem n resolved_names))
     in
+    (* A var referenced only inside a kept custom property's opaque value cannot
+       be inlined there, so its injected definition must survive: keep those
+       names live too (the resolved ones are emitted into [:root] above). *)
+    let keep_extra = unresolved_keep @ var_refs_in_custom_values stylesheet in
     let keep_vars =
       List.fold_left
         (fun acc n -> if List.mem n acc then acc else n :: acc)
-        keep_vars unresolved_keep
+        keep_vars keep_extra
     in
     let source = theme_defaults_source defaults in
     match of_string ~strict:false source with

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6176,6 +6176,32 @@ let customprops1_calc_inline () =
     |> Css.resolve_theme ~theme:Css.Pp.String_set.empty ~theme_defaults:resolve
     |> Css.to_string ~minify:true)
 
+(* CSS Custom Properties L1: a [var()] referenced only inside a custom
+   property's opaque value is invisible to the AST var collector, so its
+   [theme_defaults] definition must still be pulled into [:root]. The reference
+   stays live (it cannot be inlined inside the opaque value); when the resolver
+   has no answer, nothing is materialised. *)
+let customprops1_transitive_custom_value () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let theme = Css.Pp.String_set.of_list [ "shadow" ] in
+  let resolve = function "spacing" -> Some ".25rem" | _ -> None in
+  Alcotest.(check string)
+    "var() inside a custom value pulls its theme default into :root"
+    ":root{--spacing:.25rem}:root{--shadow:0 0 var(--spacing) black}"
+    (parse ":root { --shadow: 0 0 var(--spacing) black }"
+    |> Css.resolve_theme ~theme ~theme_defaults:resolve
+    |> Css.to_string ~minify:true);
+  Alcotest.(check string)
+    "an unresolved nested var() is kept live, not materialised"
+    ":root{--shadow:0 0 var(--spacing) black}"
+    (parse ":root { --shadow: 0 0 var(--spacing) black }"
+    |> Css.resolve_theme ~theme ~theme_defaults:(fun _ -> None)
+    |> Css.to_string ~minify:true)
+
 (* CSS Custom Properties L1 section 2: a [var()] used inside a fallback list
    ([var(--font, "Helvetica", sans-serif)]) inlines if the variable resolves,
    otherwise the fallback list is kept intact. *)
@@ -6904,6 +6930,9 @@ let additional_tests =
     ( "spec custom-properties 1 inlined var in calc simplifies",
       `Quick,
       customprops1_calc_inline );
+    ( "spec custom-properties 1 transitive default via custom value",
+      `Quick,
+      customprops1_transitive_custom_value );
     ( "spec custom-properties 1 fallback list with inlining",
       `Quick,
       customprops1_fallback_list );


### PR DESCRIPTION
`Css.resolve_theme`'s variable collector does not look inside a custom property's opaque value token stream, so a theme default referenced only there (an emitted `--shadow: ... var(--spacing) ...`) was never pulled into `:root` and `--spacing` went undefined. Custom-property values are now scanned for `var()` references and kept live, so the injected `:root` definition survives while the reference stays in place.