### PR TITLE
optimize: flatten nested calc(var()) for single-valued @property vars

### DIFF
--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -51,14 +51,15 @@ let rec important = function
 (* Apply AST-level value normalisation so the optimizer holds a canonical AST.
    The pretty-printer is a pure serialiser of the result; this is where semantic
    value folds live (see [Properties.normalize_property_value]). *)
-let rec normalize ?(lossless = false) = function
+let rec normalize ?(lossless = false) ?(ctx = Values.default_calc_ctx) =
+  function
   | Declaration { property; value; important; _ } as decl ->
       let value' =
-        Properties.normalize_property_value ~lossless property value
+        Properties.normalize_property_value ~lossless ~ctx property value
       in
       if value' == value then decl else v ~important property value'
   | Theme_guarded g as themed ->
-      let decl = normalize ~lossless g.decl in
+      let decl = normalize ~lossless ~ctx g.decl in
       if decl == g.decl then themed else theme_guarded ~var_name:g.var_name decl
 
 (* Helper for raw custom properties - primarily for internal use *)

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -20,7 +20,8 @@ val meta_of_declaration : declaration -> Values.meta option
 val important : declaration -> declaration
 (** [important d] is [d] marked as [!important]. *)
 
-val normalize : ?lossless:bool -> declaration -> declaration
+val normalize :
+  ?lossless:bool -> ?ctx:Values.calc_ctx -> declaration -> declaration
 (** [normalize ?lossless d] applies AST-level semantic value canonicalisation so
     the optimizer holds a canonical declaration and the pretty-printer stays a
     pure serialiser. [lossless] disables colour approximation. *)

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -878,28 +878,63 @@ let registered_foldable (stylesheet : t) : string -> bool =
   List.iter collect stylesheet;
   fun name -> Hashtbl.mem tbl name
 
-let normalize_live_declarations ~lossless decls =
+(* CSS Properties and Values API 1: a custom property registered with a
+   single-component [@property] syntax (not a [+]/[#] list, [*], or a transform
+   list) substitutes exactly one calc term, so a redundant [calc(var(--n))]
+   nested in another [calc()] may be unwrapped. *)
+let rec syntax_is_single_valued : type a. a Variables.syntax -> bool = function
+  | Variables.Universal | Variables.Transform_list -> false
+  | Variables.Plus _ | Variables.Hash _ -> false
+  | Variables.Or (a, b) ->
+      syntax_is_single_valued a && syntax_is_single_valued b
+  | _ -> true
+
+(* [@property] registrations are document-global, so collect every single-valued
+   registration up front to build the calc-simplifier context. *)
+let single_valued_calc_ctx (stmts : statement list) : Values.calc_ctx =
+  let tbl : (string, unit) Hashtbl.t = Hashtbl.create 8 in
+  (* [@property] names carry the [--] prefix; calc [Var] leaves store the bare
+     name (the reader strips it), so key the table on the bare name. *)
+  let bare name =
+    if String.length name >= 2 && name.[0] = '-' && name.[1] = '-' then
+      String.sub name 2 (String.length name - 2)
+    else name
+  in
+  let rec collect (stmt : statement) =
+    match stmt with
+    | Property pr ->
+        if syntax_is_single_valued pr.syntax then
+          Hashtbl.replace tbl (bare pr.name) ()
+    | Rule r -> List.iter collect r.nested
+    | _ -> iter_statement_block collect stmt
+  in
+  List.iter collect stmts;
+  { Values.var_is_single_valued = (fun name -> Hashtbl.mem tbl name) }
+
+let normalize_live_declarations ~ctx ~lossless decls =
   list_edit_preserve
     (fun decl ->
-      let decl' = Declaration.normalize ~lossless decl in
+      let decl' = Declaration.normalize ~ctx ~lossless decl in
       if Declaration.is_invalid decl' then List.Drop
       else if decl' == decl then List.Keep
       else List.Replace decl')
     decls
 
-let sanitize_keyframe ~lossless (k : keyframe) : keyframe =
-  let declarations = normalize_live_declarations ~lossless k.declarations in
+let sanitize_keyframe ~ctx ~lossless (k : keyframe) : keyframe =
+  let declarations =
+    normalize_live_declarations ~ctx ~lossless k.declarations
+  in
   if declarations == k.declarations then k else { k with declarations }
 
-let rec sanitize_block ~lossless (b : statement list) : statement list =
-  list_edit_preserve (sanitize_statement ~lossless) b
+let rec sanitize_block ~ctx ~lossless (b : statement list) : statement list =
+  list_edit_preserve (sanitize_statement ~ctx ~lossless) b
 
-and sanitize_statement ~lossless (s : statement) : statement List.edit =
-  let nd = normalize_live_declarations ~lossless in
+and sanitize_statement ~ctx ~lossless (s : statement) : statement List.edit =
+  let nd = normalize_live_declarations ~ctx ~lossless in
   match s with
   | Rule r ->
       let declarations = nd r.declarations in
-      let nested = sanitize_block ~lossless r.nested in
+      let nested = sanitize_block ~ctx ~lossless r.nested in
       let r' = rule_with_declarations_and_nested r declarations nested in
       if r' == r then List.Keep else List.Replace (Rule r')
   | Declarations d ->
@@ -926,43 +961,43 @@ and sanitize_statement ~lossless (s : statement) : statement List.edit =
       let d' = nd d in
       if d' == d then List.Keep else List.Replace (Supports_condition (n, d'))
   | Keyframes (n, ks) ->
-      let ks' = list_map_preserve (sanitize_keyframe ~lossless) ks in
+      let ks' = list_map_preserve (sanitize_keyframe ~ctx ~lossless) ks in
       if ks' == ks then List.Keep else List.Replace (Keyframes (n, ks'))
   | Webkit_keyframes (n, ks) ->
-      let ks' = list_map_preserve (sanitize_keyframe ~lossless) ks in
+      let ks' = list_map_preserve (sanitize_keyframe ~ctx ~lossless) ks in
       if ks' == ks then List.Keep else List.Replace (Webkit_keyframes (n, ks'))
   | Moz_keyframes (n, ks) ->
-      let ks' = list_map_preserve (sanitize_keyframe ~lossless) ks in
+      let ks' = list_map_preserve (sanitize_keyframe ~ctx ~lossless) ks in
       if ks' == ks then List.Keep else List.Replace (Moz_keyframes (n, ks'))
   | Layer (n, b) ->
-      let b' = sanitize_block ~lossless b in
+      let b' = sanitize_block ~ctx ~lossless b in
       if b' == b then List.Keep else List.Replace (Layer (n, b'))
   | Media (c, b) ->
-      let b' = sanitize_block ~lossless b in
+      let b' = sanitize_block ~ctx ~lossless b in
       if b' == b then List.Keep else List.Replace (Media (c, b'))
   | Container (n, c, b) ->
-      let b' = sanitize_block ~lossless b in
+      let b' = sanitize_block ~ctx ~lossless b in
       if b' == b then List.Keep else List.Replace (Container (n, c, b'))
   | Supports (c, b) ->
-      let b' = sanitize_block ~lossless b in
+      let b' = sanitize_block ~ctx ~lossless b in
       if b' == b then List.Keep else List.Replace (Supports (c, b'))
   | Moz_document (c, b) ->
-      let b' = sanitize_block ~lossless b in
+      let b' = sanitize_block ~ctx ~lossless b in
       if b' == b then List.Keep else List.Replace (Moz_document (c, b'))
   | Starting_style b ->
-      let b' = sanitize_block ~lossless b in
+      let b' = sanitize_block ~ctx ~lossless b in
       if b' == b then List.Keep else List.Replace (Starting_style b')
   | When (c, b) ->
-      let b' = sanitize_block ~lossless b in
+      let b' = sanitize_block ~ctx ~lossless b in
       if b' == b then List.Keep else List.Replace (When (c, b'))
   | Else (c, b) ->
-      let b' = sanitize_block ~lossless b in
+      let b' = sanitize_block ~ctx ~lossless b in
       if b' == b then List.Keep else List.Replace (Else (c, b'))
   | Origin (o, b) ->
-      let b' = sanitize_block ~lossless b in
+      let b' = sanitize_block ~ctx ~lossless b in
       if b' == b then List.Keep else List.Replace (Origin (o, b'))
   | Scope (s1, s2, b) ->
-      let b' = sanitize_block ~lossless b in
+      let b' = sanitize_block ~ctx ~lossless b in
       if b' == b then List.Keep else List.Replace (Scope (s1, s2, b'))
   | Property r ->
       let initial_value =
@@ -1019,7 +1054,8 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
   Selector_summary.clear_memo ();
   reset_counters ();
   let scope = Option.value scope ~default:`Fragment in
-  let stylesheet = sanitize_block ~lossless stylesheet in
+  let ctx = single_valued_calc_ctx stylesheet in
+  let stylesheet = sanitize_block ~ctx ~lossless stylesheet in
   let stylesheet =
     if flatten_nesting then Flatten.block stylesheet else stylesheet
   in

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20754,8 +20754,9 @@ let normalize_border_width (bw : border_width) : border_width =
       match Values.eval_calc c with Values.Val v -> v | folded -> Calc folded)
   | _ -> bw
 
-let normalize_property_value : type a. ?lossless:bool -> a property -> a -> a =
- fun ?(lossless = false) property value ->
+let normalize_property_value : type a.
+    ?lossless:bool -> ?ctx:Values.calc_ctx -> a property -> a -> a =
+ fun ?(lossless = false) ?(ctx = Values.default_calc_ctx) property value ->
   let normalize_color =
     Values.normalize_color ~lossless ~in_feature_query:false
   in
@@ -20775,20 +20776,20 @@ let normalize_property_value : type a. ?lossless:bool -> a property -> a -> a =
   | Offset_path -> normalize_offset_path value
   | Offset_rotate -> normalize_offset_rotate value
   | Font_style -> normalize_font_style value
-  | Width -> Values.normalize_length_percentage value
-  | Height -> Values.normalize_length_percentage value
-  | Min_width -> Values.normalize_length_percentage value
-  | Min_height -> Values.normalize_length_percentage value
-  | Min_inline_size -> Values.normalize_length_percentage value
-  | Min_block_size -> Values.normalize_length_percentage value
-  | Max_width -> Values.normalize_length_percentage value
-  | Max_height -> Values.normalize_length_percentage value
-  | Inline_size -> Values.normalize_length_percentage value
-  | Max_inline_size -> Values.normalize_length_percentage value
-  | Block_size -> Values.normalize_length_percentage value
-  | Max_block_size -> Values.normalize_length_percentage value
-  | Shape_margin -> Values.normalize_length_percentage value
-  | Offset_distance -> Values.normalize_length_percentage value
+  | Width -> Values.normalize_length_percentage ~ctx value
+  | Height -> Values.normalize_length_percentage ~ctx value
+  | Min_width -> Values.normalize_length_percentage ~ctx value
+  | Min_height -> Values.normalize_length_percentage ~ctx value
+  | Min_inline_size -> Values.normalize_length_percentage ~ctx value
+  | Min_block_size -> Values.normalize_length_percentage ~ctx value
+  | Max_width -> Values.normalize_length_percentage ~ctx value
+  | Max_height -> Values.normalize_length_percentage ~ctx value
+  | Inline_size -> Values.normalize_length_percentage ~ctx value
+  | Max_inline_size -> Values.normalize_length_percentage ~ctx value
+  | Block_size -> Values.normalize_length_percentage ~ctx value
+  | Max_block_size -> Values.normalize_length_percentage ~ctx value
+  | Shape_margin -> Values.normalize_length_percentage ~ctx value
+  | Offset_distance -> Values.normalize_length_percentage ~ctx value
   | Border_radius -> normalize_border_radius value
   | Background_image ->
       map_preserve (normalize_background_image ~lossless) value
@@ -20864,80 +20865,80 @@ let normalize_property_value : type a. ?lossless:bool -> a property -> a -> a =
   | Aspect_ratio -> normalize_aspect_ratio value
   | Gap -> normalize_gap value
   | Font_size -> normalize_font_size value
-  | Padding_left -> Values.normalize_length value
-  | Padding_right -> Values.normalize_length value
-  | Padding_bottom -> Values.normalize_length value
-  | Padding_top -> Values.normalize_length value
-  | Padding_inline_start -> Values.normalize_length value
-  | Padding_inline_end -> Values.normalize_length value
-  | Padding_block_start -> Values.normalize_length value
-  | Padding_block_end -> Values.normalize_length value
-  | Margin_inline_end -> Values.normalize_length value
-  | Margin_inline_start -> Values.normalize_length value
-  | Margin_left -> Values.normalize_length value
-  | Margin_right -> Values.normalize_length value
-  | Margin_top -> Values.normalize_length value
-  | Margin_bottom -> Values.normalize_length value
-  | Margin_block_start -> Values.normalize_length value
-  | Margin_block_end -> Values.normalize_length value
-  | Column_gap -> Values.normalize_length value
-  | Row_gap -> Values.normalize_length value
-  | Text_underline_offset -> Values.normalize_length value
-  | Letter_spacing -> Values.normalize_length value
-  | Border_top_left_radius -> Values.normalize_length value
-  | Border_top_right_radius -> Values.normalize_length value
-  | Border_bottom_left_radius -> Values.normalize_length value
-  | Border_bottom_right_radius -> Values.normalize_length value
-  | Border_start_start_radius -> Values.normalize_length value
-  | Border_start_end_radius -> Values.normalize_length value
-  | Border_end_start_radius -> Values.normalize_length value
-  | Border_end_end_radius -> Values.normalize_length value
-  | Outline_width -> Values.normalize_length value
-  | Outline_offset -> Values.normalize_length value
-  | Line_height_step -> Values.normalize_length value
-  | Perspective -> Values.normalize_length value
-  | Word_spacing -> Values.normalize_length value
-  | Text_decoration_thickness -> Values.normalize_length value
-  | Stroke_width -> Values.normalize_length value
-  | Scroll_margin_top -> Values.normalize_length value
-  | Scroll_margin_right -> Values.normalize_length value
-  | Scroll_margin_bottom -> Values.normalize_length value
-  | Scroll_margin_left -> Values.normalize_length value
-  | Scroll_margin_inline_start -> Values.normalize_length value
-  | Scroll_margin_inline_end -> Values.normalize_length value
-  | Scroll_margin_block_start -> Values.normalize_length value
-  | Scroll_margin_block_end -> Values.normalize_length value
-  | Scroll_padding_top -> Values.normalize_length value
-  | Scroll_padding_right -> Values.normalize_length value
-  | Scroll_padding_bottom -> Values.normalize_length value
-  | Scroll_padding_left -> Values.normalize_length value
-  | Scroll_padding_inline_start -> Values.normalize_length value
-  | Scroll_padding_inline_end -> Values.normalize_length value
-  | Scroll_padding_block_start -> Values.normalize_length value
-  | Scroll_padding_block_end -> Values.normalize_length value
-  | Padding -> map_preserve Values.normalize_length value
-  | Padding_inline -> map_preserve Values.normalize_length value
-  | Padding_block -> map_preserve Values.normalize_length value
-  | Margin -> map_preserve Values.normalize_length value
-  | Margin_inline -> map_preserve Values.normalize_length value
-  | Margin_block -> map_preserve Values.normalize_length value
-  | Inset -> map_preserve Values.normalize_length value
-  | Inset_inline -> map_preserve Values.normalize_length value
-  | Inset_inline_start -> map_preserve Values.normalize_length value
-  | Inset_inline_end -> map_preserve Values.normalize_length value
-  | Inset_block -> map_preserve Values.normalize_length value
-  | Inset_block_start -> map_preserve Values.normalize_length value
-  | Inset_block_end -> map_preserve Values.normalize_length value
-  | Top -> map_preserve Values.normalize_length value
-  | Right -> map_preserve Values.normalize_length value
-  | Bottom -> map_preserve Values.normalize_length value
-  | Left -> map_preserve Values.normalize_length value
-  | Scroll_margin -> map_preserve Values.normalize_length value
-  | Scroll_margin_inline -> map_preserve Values.normalize_length value
-  | Scroll_margin_block -> map_preserve Values.normalize_length value
-  | Scroll_padding -> map_preserve Values.normalize_length value
-  | Scroll_padding_inline -> map_preserve Values.normalize_length value
-  | Scroll_padding_block -> map_preserve Values.normalize_length value
+  | Padding_left -> Values.normalize_length ~ctx value
+  | Padding_right -> Values.normalize_length ~ctx value
+  | Padding_bottom -> Values.normalize_length ~ctx value
+  | Padding_top -> Values.normalize_length ~ctx value
+  | Padding_inline_start -> Values.normalize_length ~ctx value
+  | Padding_inline_end -> Values.normalize_length ~ctx value
+  | Padding_block_start -> Values.normalize_length ~ctx value
+  | Padding_block_end -> Values.normalize_length ~ctx value
+  | Margin_inline_end -> Values.normalize_length ~ctx value
+  | Margin_inline_start -> Values.normalize_length ~ctx value
+  | Margin_left -> Values.normalize_length ~ctx value
+  | Margin_right -> Values.normalize_length ~ctx value
+  | Margin_top -> Values.normalize_length ~ctx value
+  | Margin_bottom -> Values.normalize_length ~ctx value
+  | Margin_block_start -> Values.normalize_length ~ctx value
+  | Margin_block_end -> Values.normalize_length ~ctx value
+  | Column_gap -> Values.normalize_length ~ctx value
+  | Row_gap -> Values.normalize_length ~ctx value
+  | Text_underline_offset -> Values.normalize_length ~ctx value
+  | Letter_spacing -> Values.normalize_length ~ctx value
+  | Border_top_left_radius -> Values.normalize_length ~ctx value
+  | Border_top_right_radius -> Values.normalize_length ~ctx value
+  | Border_bottom_left_radius -> Values.normalize_length ~ctx value
+  | Border_bottom_right_radius -> Values.normalize_length ~ctx value
+  | Border_start_start_radius -> Values.normalize_length ~ctx value
+  | Border_start_end_radius -> Values.normalize_length ~ctx value
+  | Border_end_start_radius -> Values.normalize_length ~ctx value
+  | Border_end_end_radius -> Values.normalize_length ~ctx value
+  | Outline_width -> Values.normalize_length ~ctx value
+  | Outline_offset -> Values.normalize_length ~ctx value
+  | Line_height_step -> Values.normalize_length ~ctx value
+  | Perspective -> Values.normalize_length ~ctx value
+  | Word_spacing -> Values.normalize_length ~ctx value
+  | Text_decoration_thickness -> Values.normalize_length ~ctx value
+  | Stroke_width -> Values.normalize_length ~ctx value
+  | Scroll_margin_top -> Values.normalize_length ~ctx value
+  | Scroll_margin_right -> Values.normalize_length ~ctx value
+  | Scroll_margin_bottom -> Values.normalize_length ~ctx value
+  | Scroll_margin_left -> Values.normalize_length ~ctx value
+  | Scroll_margin_inline_start -> Values.normalize_length ~ctx value
+  | Scroll_margin_inline_end -> Values.normalize_length ~ctx value
+  | Scroll_margin_block_start -> Values.normalize_length ~ctx value
+  | Scroll_margin_block_end -> Values.normalize_length ~ctx value
+  | Scroll_padding_top -> Values.normalize_length ~ctx value
+  | Scroll_padding_right -> Values.normalize_length ~ctx value
+  | Scroll_padding_bottom -> Values.normalize_length ~ctx value
+  | Scroll_padding_left -> Values.normalize_length ~ctx value
+  | Scroll_padding_inline_start -> Values.normalize_length ~ctx value
+  | Scroll_padding_inline_end -> Values.normalize_length ~ctx value
+  | Scroll_padding_block_start -> Values.normalize_length ~ctx value
+  | Scroll_padding_block_end -> Values.normalize_length ~ctx value
+  | Padding -> map_preserve (Values.normalize_length ~ctx) value
+  | Padding_inline -> map_preserve (Values.normalize_length ~ctx) value
+  | Padding_block -> map_preserve (Values.normalize_length ~ctx) value
+  | Margin -> map_preserve (Values.normalize_length ~ctx) value
+  | Margin_inline -> map_preserve (Values.normalize_length ~ctx) value
+  | Margin_block -> map_preserve (Values.normalize_length ~ctx) value
+  | Inset -> map_preserve (Values.normalize_length ~ctx) value
+  | Inset_inline -> map_preserve (Values.normalize_length ~ctx) value
+  | Inset_inline_start -> map_preserve (Values.normalize_length ~ctx) value
+  | Inset_inline_end -> map_preserve (Values.normalize_length ~ctx) value
+  | Inset_block -> map_preserve (Values.normalize_length ~ctx) value
+  | Inset_block_start -> map_preserve (Values.normalize_length ~ctx) value
+  | Inset_block_end -> map_preserve (Values.normalize_length ~ctx) value
+  | Top -> map_preserve (Values.normalize_length ~ctx) value
+  | Right -> map_preserve (Values.normalize_length ~ctx) value
+  | Bottom -> map_preserve (Values.normalize_length ~ctx) value
+  | Left -> map_preserve (Values.normalize_length ~ctx) value
+  | Scroll_margin -> map_preserve (Values.normalize_length ~ctx) value
+  | Scroll_margin_inline -> map_preserve (Values.normalize_length ~ctx) value
+  | Scroll_margin_block -> map_preserve (Values.normalize_length ~ctx) value
+  | Scroll_padding -> map_preserve (Values.normalize_length ~ctx) value
+  | Scroll_padding_inline -> map_preserve (Values.normalize_length ~ctx) value
+  | Scroll_padding_block -> map_preserve (Values.normalize_length ~ctx) value
   | Custom_property _ -> (
       match value with
       | Custom_value ({ value = Tokens components; _ } as r) ->
@@ -20960,24 +20961,25 @@ let normalize_property_value : type a. ?lossless:bool -> a property -> a -> a =
   | Border_inline_end_width -> normalize_border_width value
   | Border_block_start_width -> normalize_border_width value
   | Border_block_end_width -> normalize_border_width value
-  | Transition_duration -> Values.normalize_duration value
-  | Transition_delay -> Values.normalize_duration value
-  | Animation_duration -> Values.normalize_duration value
-  | Animation_delay -> Values.normalize_duration value
-  | Webkit_transition_duration -> Values.normalize_duration value
-  | Webkit_transition_delay -> Values.normalize_duration value
-  | Webkit_animation_duration -> Values.normalize_duration value
-  | Webkit_animation_delay -> Values.normalize_duration value
-  | Moz_transition_duration -> Values.normalize_duration value
-  | Moz_transition_delay -> Values.normalize_duration value
-  | Moz_animation_duration -> Values.normalize_duration value
-  | Moz_animation_delay -> Values.normalize_duration value
+  | Transition_duration -> Values.normalize_duration ~ctx value
+  | Transition_delay -> Values.normalize_duration ~ctx value
+  | Animation_duration -> Values.normalize_duration ~ctx value
+  | Animation_delay -> Values.normalize_duration ~ctx value
+  | Webkit_transition_duration -> Values.normalize_duration ~ctx value
+  | Webkit_transition_delay -> Values.normalize_duration ~ctx value
+  | Webkit_animation_duration -> Values.normalize_duration ~ctx value
+  | Webkit_animation_delay -> Values.normalize_duration ~ctx value
+  | Moz_transition_duration -> Values.normalize_duration ~ctx value
+  | Moz_transition_delay -> Values.normalize_duration ~ctx value
+  | Moz_animation_duration -> Values.normalize_duration ~ctx value
+  | Moz_animation_delay -> Values.normalize_duration ~ctx value
   | _ -> value
 
-let normalize_custom_property_value ?(lossless = false) :
+let normalize_custom_property_value ?(lossless = false)
+    ?(ctx = Values.default_calc_ctx) :
     custom_property_value -> custom_property_value = function
   | Typed { kind = Length; value } ->
-      Typed { kind = Length; value = Values.normalize_length value }
+      Typed { kind = Length; value = Values.normalize_length ~ctx value }
   | Typed { kind = Color; value } ->
       Typed
         {
@@ -20985,17 +20987,18 @@ let normalize_custom_property_value ?(lossless = false) :
           value = Values.normalize_color ~lossless ~in_feature_query:false value;
         }
   | Typed { kind = Number; value } ->
-      Typed { kind = Number; value = Values.normalize_number value }
+      Typed { kind = Number; value = Values.normalize_number ~ctx value }
   | Typed { kind = Percentage; value } ->
-      Typed { kind = Percentage; value = Values.normalize_percentage value }
+      Typed
+        { kind = Percentage; value = Values.normalize_percentage ~ctx value }
   | Typed { kind = Length_percentage; value } ->
       Typed
         {
           kind = Length_percentage;
-          value = Values.normalize_length_percentage value;
+          value = Values.normalize_length_percentage ~ctx value;
         }
   | Typed { kind = Angle; value } ->
-      Typed { kind = Angle; value = Values.normalize_angle value }
+      Typed { kind = Angle; value = Values.normalize_angle ~ctx value }
   | Typed { kind = Gradient_direction; value } ->
       Typed
         {

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -10,7 +10,8 @@ val pp_property_value : ('a property * 'a) Pp.t
 (** [pp_property_value] is the pretty-printer for a property and its typed
     value. *)
 
-val normalize_property_value : ?lossless:bool -> 'a property -> 'a -> 'a
+val normalize_property_value :
+  ?lossless:bool -> ?ctx:Values.calc_ctx -> 'a property -> 'a -> 'a
 (** [normalize_property_value ?lossless prop value] applies semantic
     (equivalence) canonicalisation to [value] so the optimizer holds a canonical
     AST and the pretty-printer stays a pure serialiser. Identity for properties
@@ -18,7 +19,10 @@ val normalize_property_value : ?lossless:bool -> 'a property -> 'a -> 'a
     approximation while keeping exact colour canonicalisation. *)
 
 val normalize_custom_property_value :
-  ?lossless:bool -> custom_property_value -> custom_property_value
+  ?lossless:bool ->
+  ?ctx:Values.calc_ctx ->
+  custom_property_value ->
+  custom_property_value
 (** [normalize_custom_property_value v] canonicalises the typed value of a
     registered custom property (currently the [<color>] syntax) so a promoted
     custom-property value folds the same way a typed colour property would. *)

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -861,23 +861,42 @@ let calc_identity : type a.
    ([calc_identity]). The per-type evaluators ([eval_length_calc] /
    [eval_lp_calc]) add the typed [Val] combinations ([1px + 2px], [2px * 3]) and
    pass their own [~zero] / [~is_zero] so a typed zero collapses too. *)
-let rec eval_calc : type a. a calc -> a calc = function
+(* Context threaded through the calc simplifier for rewrites that depend on the
+   surrounding stylesheet. [var_is_single_valued n] reports whether [--n] is
+   registered with a single-component [@property] syntax, so its [var()]
+   substitutes exactly one calc term and a redundant nested [calc(var(--n))]
+   grouping may be dropped. The default knows nothing, so every such rewrite is
+   a no-op. *)
+type calc_ctx = { var_is_single_valued : string -> bool }
+
+let default_calc_ctx = { var_is_single_valued = (fun _ -> false) }
+
+(* A nested [calc()] or a parenthesised group around a single leaf is redundant
+   grouping: drop it. A [var()] leaf is only safe to unwrap when the var is
+   single-valued; otherwise its substitution could be a multi-term expression
+   that needs the grouping (CSS Values 4 §10.10). *)
+let unwrap_grouping : type a.
+    ctx:calc_ctx -> rewrap:(a calc -> a calc) -> a calc -> a calc =
+ fun ~ctx ~rewrap reduced ->
+  match reduced with
+  | (Val _ | Num _) as leaf -> leaf
+  | Var v as leaf when ctx.var_is_single_valued v.name -> leaf
+  | reduced -> rewrap reduced
+
+let rec eval_calc : type a. ?ctx:calc_ctx -> a calc -> a calc =
+ fun ?(ctx = default_calc_ctx) -> function
   | (Num _ | Val _ | Var _ | Sibling_index | Sibling_count) as leaf -> leaf
   | Math_const _ as leaf -> leaf
   | Math_fn fn when math_fn_contains_var fn -> Math_fn fn
   | Math_fn fn -> (
       match eval_math_fn fn with Some v -> Num v | None -> Math_fn fn)
-  | Nested inner -> (
-      match eval_calc inner with
-      | (Val _ | Num _) as leaf -> leaf
-      | reduced -> Nested reduced)
-  | Parens inner -> (
-      match eval_calc inner with
-      | (Val _ | Num _) as leaf -> leaf
-      | reduced -> Parens reduced)
+  | Nested inner ->
+      unwrap_grouping ~ctx ~rewrap:(fun r -> Nested r) (eval_calc ~ctx inner)
+  | Parens inner ->
+      unwrap_grouping ~ctx ~rewrap:(fun r -> Parens r) (eval_calc ~ctx inner)
   | Expr (l, op, r) -> (
-      let l = eval_calc l in
-      let r = eval_calc r in
+      let l = eval_calc ~ctx l in
+      let r = eval_calc ~ctx r in
       (* Match on the const-folded operands but keep [l] / [r] in the no-fold
          results, so an unreduced expression keeps the short [calc(.. pi ..)].
          Identity rules need a type-aware [Val] inspection (runtime subst?);
@@ -1206,8 +1225,8 @@ and length_calc_has_runtime_subst : length calc -> bool = function
   | Expr (l, _, r) ->
       length_calc_has_runtime_subst l || length_calc_has_runtime_subst r
 
-let rec eval_length_calc : length calc -> length calc =
- fun calc ->
+let rec eval_length_calc : ?ctx:calc_ctx -> length calc -> length calc =
+ fun ?(ctx = default_calc_ctx) calc ->
   match calc with
   | (Num _ | Val _ | Var _ | Sibling_index | Sibling_count) as leaf -> leaf
   | Math_const _ as leaf -> leaf
@@ -1219,17 +1238,17 @@ let rec eval_length_calc : length calc -> length calc =
           match length_math_fn_value fn with
           | Some v -> Num v
           | None -> Math_fn fn))
-  | Nested inner -> (
-      match eval_length_calc inner with
-      | (Val _ | Num _) as leaf -> leaf
-      | reduced -> Nested reduced)
-  | Parens inner -> (
-      match eval_length_calc inner with
-      | (Val _ | Num _) as leaf -> leaf
-      | reduced -> Parens reduced)
+  | Nested inner ->
+      unwrap_grouping ~ctx
+        ~rewrap:(fun r -> Nested r)
+        (eval_length_calc ~ctx inner)
+  | Parens inner ->
+      unwrap_grouping ~ctx
+        ~rewrap:(fun r -> Parens r)
+        (eval_length_calc ~ctx inner)
   | Expr (l, op, r) -> (
-      let l = eval_length_calc l in
-      let r = eval_length_calc r in
+      let l = eval_length_calc ~ctx l in
+      let r = eval_length_calc ~ctx r in
       (* Match on the const-folded operands ([pi] -> its value) but keep [l] /
          [r] in the no-fold results, so an expression that does not reduce to a
          leaf keeps the short [calc(.. pi ..)] rather than leaking the
@@ -1671,8 +1690,9 @@ let lp_is_zero : length_percentage -> bool = function
   | Pct f -> f = 0.
   | _ -> false
 
-let rec eval_lp_calc : length_percentage calc -> length_percentage calc =
- fun calc ->
+let rec eval_lp_calc :
+    ?ctx:calc_ctx -> length_percentage calc -> length_percentage calc =
+ fun ?(ctx = default_calc_ctx) calc ->
   match calc with
   | (Num _ | Val _ | Var _ | Sibling_index | Sibling_count) as leaf -> leaf
   | Math_const _ as leaf -> leaf
@@ -1684,17 +1704,13 @@ let rec eval_lp_calc : length_percentage calc -> length_percentage calc =
           match length_math_fn_value fn with
           | Some v -> Num v
           | None -> Math_fn fn))
-  | Nested inner -> (
-      match eval_lp_calc inner with
-      | (Val _ | Num _) as leaf -> leaf
-      | reduced -> Nested reduced)
-  | Parens inner -> (
-      match eval_lp_calc inner with
-      | (Val _ | Num _) as leaf -> leaf
-      | reduced -> Parens reduced)
+  | Nested inner ->
+      unwrap_grouping ~ctx ~rewrap:(fun r -> Nested r) (eval_lp_calc ~ctx inner)
+  | Parens inner ->
+      unwrap_grouping ~ctx ~rewrap:(fun r -> Parens r) (eval_lp_calc ~ctx inner)
   | Expr (l, op, r) -> (
-      let l = eval_lp_calc l in
-      let r = eval_lp_calc r in
+      let l = eval_lp_calc ~ctx l in
+      let r = eval_lp_calc ~ctx r in
       (* Match on the const-folded operands ([pi] -> its value) but keep [l] /
          [r] in the no-fold results, so an expression that does not reduce to a
          leaf (e.g. [2px / pi]) keeps the short [calc(2px/pi)] rather than
@@ -3604,13 +3620,15 @@ let strip_zero_length (l : length) : length =
 
 (* [strip] is true for a top-level [<length>] (a direct property/shorthand
    value) and false for a calc / math-function operand, which keeps its unit. *)
-let rec normalize_length ?(strip = true) (l : length) : length =
-  let nf = normalize_length ~strip:false in
+let rec normalize_length ?(strip = true) ?(ctx = default_calc_ctx) (l : length)
+    : length =
+  let nf = normalize_length ~strip:false ~ctx in
   let result =
     match l with
     | Calc cv -> (
         match
-          cv |> eval_length_calc |> linear_length_calc |> eval_length_calc
+          cv |> eval_length_calc ~ctx |> linear_length_calc
+          |> eval_length_calc ~ctx
         with
         | Val v -> v
         | folded -> Calc folded)
@@ -3666,7 +3684,8 @@ let rec normalize_length ?(strip = true) (l : length) : length =
     | Calc_size (basis, calc) -> (
         let basis = nf basis in
         match
-          calc |> eval_length_calc |> linear_length_calc |> eval_length_calc
+          calc |> eval_length_calc ~ctx |> linear_length_calc
+          |> eval_length_calc ~ctx
         with
         | folded -> Calc_size (basis, folded))
     | _ -> l
@@ -3676,15 +3695,15 @@ let rec normalize_length ?(strip = true) (l : length) : length =
 (* Fold the numeric parts of a length-percentage [calc()], keeping any [var()]:
    [calc(var(--x) + 1px + 2px)] -> [calc(var(--x) + 3px)], [calc(1px + 2px)] ->
    [3px]. A wrapped [<length>] folds its own math functions. *)
-let normalize_length_percentage ?(strip = true) (lp : length_percentage) :
-    length_percentage =
+let normalize_length_percentage ?(strip = true) ?(ctx = default_calc_ctx)
+    (lp : length_percentage) : length_percentage =
   match lp with
   | Calc c -> (
-      match c |> eval_lp_calc |> linear_lp_calc |> eval_lp_calc with
+      match c |> eval_lp_calc ~ctx |> linear_lp_calc |> eval_lp_calc ~ctx with
       | Val v -> v
       | folded -> Calc folded)
   | Length l ->
-      let l' = normalize_length ~strip l in
+      let l' = normalize_length ~strip ~ctx l in
       if l' == l then lp else Length l'
   | _ -> lp
 
@@ -3692,51 +3711,50 @@ let normalize_length_percentage ?(strip = true) (lp : length_percentage) :
    used to do under minify), so the printer stays a pure serialiser. Recurses so
    nested calls fold ([abs(hypot(3, 4))] -> [5]); a non-static operand keeps the
    call. *)
-let rec normalize_number (n : number) : number =
+let rec normalize_number ?(ctx = default_calc_ctx) (n : number) : number =
+  let nf = normalize_number ~ctx in
   match n with
   | Calc c -> (
-      match eval_calc c with
+      match eval_calc ~ctx c with
       | Num f -> Num f
-      | Val v -> normalize_number v
+      | Val v -> nf v
       | folded -> Calc folded)
   | Round (strategy, a, b) -> (
-      match (normalize_number a, normalize_number b) with
+      match (nf a, nf b) with
       | Num value, Num step when step <> 0. ->
           Num (round_to_step strategy value step)
       | a, b -> Round (strategy, a, b))
   | Mod (a, b) -> (
-      match (normalize_number a, normalize_number b) with
+      match (nf a, nf b) with
       | Num a, Num b when b <> 0. -> Num (mod_value a b)
       | a, b -> Mod (a, b))
   | Rem (a, b) -> (
-      match (normalize_number a, normalize_number b) with
+      match (nf a, nf b) with
       | Num a, Num b when b <> 0. -> Num (Float.rem a b)
       | a, b -> Rem (a, b))
   | Hypot (a, b) -> (
-      match (normalize_number a, normalize_number b) with
+      match (nf a, nf b) with
       | Num a, Num b -> Num (Float.sqrt ((a *. a) +. (b *. b)))
       | a, b -> Hypot (a, b))
   | Pow (a, b) -> (
-      match (normalize_number a, normalize_number b) with
+      match (nf a, nf b) with
       | Num a, Num b -> Num (Float.pow a b)
       | a, b -> Pow (a, b))
   | Sqrt v -> (
-      match normalize_number v with
-      | Num a when a >= 0. -> Num (Float.sqrt a)
-      | v -> Sqrt v)
-  | Abs v -> (
-      match normalize_number v with Num a -> Num (Float.abs a) | v -> Abs v)
-  | Sign v -> Sign (normalize_number v)
+      match nf v with Num a when a >= 0. -> Num (Float.sqrt a) | v -> Sqrt v)
+  | Abs v -> ( match nf v with Num a -> Num (Float.abs a) | v -> Abs v)
+  | Sign v -> Sign (nf v)
   | Sin _ | Num _ | Var _ -> n
 
 (* Fold the value-independent parts of a [<percentage>] [calc()] ([calc(1 / 2 *
    100%)] -> [calc(.5*100%)]), keeping any [var()]. Replaces the numeric /
    identity reduction the printer did under minify, now that pp is a pure
    serialiser. *)
-let normalize_percentage (p : percentage) : percentage =
+let normalize_percentage ?(ctx = default_calc_ctx) (p : percentage) : percentage
+    =
   match p with
   | Calc c -> (
-      match eval_calc c with
+      match eval_calc ~ctx c with
       | Num f -> Num f
       | Val v -> v
       | folded -> Calc folded)
@@ -3745,16 +3763,17 @@ let normalize_percentage (p : percentage) : percentage =
 (* Fold the value-independent parts of a [<time>] [calc()] ([calc(var(--d) * 1)]
    -> [calc(var(--d))]), keeping any [var()]. A bare-number reduction stays
    wrapped (a [<number>] is not a [<time>]). *)
-let normalize_duration (d : duration) : duration =
+let normalize_duration ?(ctx = default_calc_ctx) (d : duration) : duration =
   match d with
-  | Calc c -> ( match eval_calc c with Val v -> v | folded -> Calc folded)
+  | Calc c -> (
+      match eval_calc ~ctx c with Val v -> v | folded -> Calc folded)
   | _ -> d
 
 (* Canonicalise an [<angle>]: fold the static math functions ([round] / [mod] /
    [rem] on [deg] operands), then pick the shortest of the
    losslessly-interconvertible spellings (deg / turn / grad). [rad] goes through
    pi, so it cannot share one magnitude and is left as-is. *)
-let normalize_angle =
+let normalize_angle ?(ctx = default_calc_ctx) =
   let render unit f =
     String.length
       (Pp.string_of_float ~drop_leading_zero:true (Pp.round_sig 6 f))
@@ -3795,7 +3814,7 @@ let normalize_angle =
         | Deg x, Deg y when y <> 0. -> shortest (Deg (Float.rem x y))
         | x, y -> Rem (x, y))
     | Calc c -> (
-        match eval_calc c with Val v -> go v | folded -> Calc folded)
+        match eval_calc ~ctx c with Val v -> go v | folded -> Calc folded)
     | Deg _ | Turn _ | Grad _ -> shortest a
     | Rad _ | Var _ | Invalid _ -> a
   in
@@ -3835,14 +3854,14 @@ let rec pp_number_percentage ?(always = false) : number_percentage Pp.t =
    faithfully. [Var] and [Calc] sub-forms are left untouched - inside a calc(),
    [%] and number are not interchangeable, and a [var()] reference is
    context-free. *)
-let rec normalize_number_percentage (np : number_percentage) : number_percentage
-    =
+let rec normalize_number_percentage ?(ctx = default_calc_ctx)
+    (np : number_percentage) : number_percentage =
   let len f = String.length (Pp.string_of_float ~drop_leading_zero:true f) in
   match np with
   | Calc c -> (
-      match eval_calc c with
-      | Num f -> normalize_number_percentage (Num f)
-      | Val v -> normalize_number_percentage v
+      match eval_calc ~ctx c with
+      | Num f -> normalize_number_percentage ~ctx (Num f)
+      | Val v -> normalize_number_percentage ~ctx v
       | folded -> Calc folded)
   | Pct f ->
       let num_f = f /. 100. in

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -177,15 +177,26 @@ val pp_length_percentage : ?always:bool -> length_percentage Pp.t
 (** [pp_length_percentage ?always] pretty-prints {!length_percentage} values.
     When [always] is true, always includes units even for 0. *)
 
+type calc_ctx = { var_is_single_valued : string -> bool }
+(** Context threaded through the calc folds for stylesheet-dependent rewrites.
+    [var_is_single_valued n] reports whether [--n] is registered with a
+    single-component [@property] syntax, so its [var()] substitutes exactly one
+    calc term and a redundant [calc(var(--n))] nested inside another [calc()]
+    may be unwrapped. *)
+
+val default_calc_ctx : calc_ctx
+(** [default_calc_ctx] knows of no single-valued variables, so every
+    context-dependent calc rewrite is a no-op. *)
+
 val normalize_length_percentage :
-  ?strip:bool -> length_percentage -> length_percentage
+  ?strip:bool -> ?ctx:calc_ctx -> length_percentage -> length_percentage
 (** [normalize_length_percentage lp] folds the numeric parts of a [calc()],
     keeping any [var()]: [calc(var(--x) + 1px + 2px)] becomes
     [calc(var(--x) + 3px)], and [calc(1px + 2px)] becomes [3px]. [strip]
     (default [true]) also drops a wrapped zero length's unit; pass [strip:false]
     for CSS function operands. *)
 
-val normalize_length : ?strip:bool -> length -> length
+val normalize_length : ?strip:bool -> ?ctx:calc_ctx -> length -> length
 (** [normalize_length ?strip l] evaluates the static CSS math functions on a
     [<length>] (min / max / clamp reduce to one dimension on shared units; round
     / mod / rem / hypot / abs fold on {!val-px}; calc folds through the
@@ -194,13 +205,14 @@ val normalize_length : ?strip:bool -> length -> length
     zero ([0px] -> [0]); pass [strip:false] for a calc / function operand, which
     keeps its unit. *)
 
-val normalize_angle : angle -> angle
+val normalize_angle : ?ctx:calc_ctx -> angle -> angle
 (** [normalize_angle a] folds the static angle math functions (round / mod / rem
     on [deg] operands) and converts to the shortest of the
     losslessly-interconvertible units (deg / turn / grad); [rad] (irrational via
     pi) stays as-is. *)
 
-val normalize_number_percentage : number_percentage -> number_percentage
+val normalize_number_percentage :
+  ?ctx:calc_ctx -> number_percentage -> number_percentage
 (** [normalize_number_percentage np] picks the shorter spelling for a typed
     [<number-percentage>] leaf where percentage and number are spec-equivalent
     (100% = 1, e.g. transform [scale()], the [scale] property, and the [filter]
@@ -208,17 +220,17 @@ val normalize_number_percentage : number_percentage -> number_percentage
     sub-forms stay opaque - inside a [calc()], the two spellings are not
     interchangeable. *)
 
-val normalize_number : number -> number
+val normalize_number : ?ctx:calc_ctx -> number -> number
 (** [normalize_number n] evaluates the static CSS math functions on a [<number>]
     ([hypot(3, 4)] becomes [5], [calc(1 + 2)] becomes [3]), recursing into
     nested calls; an operand with a [var()] keeps the call. *)
 
-val normalize_percentage : percentage -> percentage
+val normalize_percentage : ?ctx:calc_ctx -> percentage -> percentage
 (** [normalize_percentage p] folds the value-independent parts of a
     [<percentage>] [calc()] ([calc(1 / 2 * 100%)] becomes [calc(.5*100%)]),
     keeping any [var()]. *)
 
-val normalize_duration : duration -> duration
+val normalize_duration : ?ctx:calc_ctx -> duration -> duration
 (** [normalize_duration d] folds the value-independent parts of a [<time>]
     [calc()] ([calc(var(--d) * 1)] becomes [calc(var(--d))]), keeping any
     [var()]. *)
@@ -516,12 +528,13 @@ val map_calc : ('a -> 'b) -> 'a calc -> 'b calc
 (** [map_calc f calc] rewrites every [Val] leaf via [f], preserving the calc
     structure (operators, [Nested], [Parens], [Var] fallbacks). *)
 
-val eval_calc : 'a calc -> 'a calc
+val eval_calc : ?ctx:calc_ctx -> 'a calc -> 'a calc
 (** [eval_calc calc] applies CSS Values 4 §10.7 structural simplification: folds
     [Expr (Num _, op, Num _)] subtrees into a single [Num] and unwraps trivial
     [Nested] / [Parens] around leaves. [Val] / [Var] leaves and mixed-type
     operands survive — type-specific simplification (e.g., length arithmetic) is
-    the caller's job. *)
+    the caller's job. With [~ctx], a [Nested] / [Parens] around a single-valued
+    [Var] leaf is also unwrapped (see {!calc_ctx}). *)
 
 val calc_identity :
   zero:'a calc ->

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2389,6 +2389,33 @@ let c61_no_named_atrule_merge () =
     ".theme{color:red}@view-transition{navigation:auto}.theme{display:flex}"
     ".theme{color:red}@view-transition{navigation:auto}.theme{display:flex}"
 
+let calc_flatten_registered_single_valued () =
+  let check label css expected =
+    let input = Css.Stylesheet.read (Cursor.of_string css) in
+    let optimized = Css.Optimize.stylesheet input in
+    Alcotest.(check string)
+      label expected
+      (Css.Stylesheet.to_string ~minify:true optimized |> String.trim)
+  in
+  (* CSS Properties and Values API 1: a single-component [@property] syntax
+     substitutes exactly one calc term, so a redundant nested [calc(var)] folds
+     to a bare reference. *)
+  check "single-valued registration flattens the nested calc"
+    "@property \
+     --x{syntax:\"<length>\";inherits:false;initial-value:0px}.a{width:calc(calc(var(--x)) \
+     * 2)}"
+    "@property \
+     --x{syntax:\"<length>\";inherits:false;initial-value:0px}.a{width:calc(var(--x)*2)}";
+  (* CSS Values 4 §10.10: an unregistered var() could substitute a multi-term
+     value, so the grouping must stay. *)
+  check "unregistered var keeps the nested calc"
+    ".a{width:calc(calc(var(--x)) * 2)}" ".a{width:calc(calc(var(--x))*2)}";
+  (* A universal syntax is not a single term, so it is not unwrapped. *)
+  check "universal-syntax registration keeps the nested calc"
+    "@property --x{syntax:\"*\";inherits:false}.a{width:calc(calc(var(--x)) * \
+     2)}"
+    "@property --x{syntax:\"*\";inherits:false}.a{width:calc(calc(var(--x))*2)}"
+
 let c61_no_nested_boundary_merge () =
   (* Scope proximity and page context are cascade-visible boundaries. The same
      is true when @scope appears as a nested group rule inside a style rule. *)
@@ -3876,6 +3903,9 @@ let selector_merging_tests =
     ( "spec cascade 6.1 scope/page/nested boundaries are opaque",
       `Quick,
       c61_no_nested_boundary_merge );
+    ( "calc flatten gated on single-valued @property registration",
+      `Quick,
+      calc_flatten_registered_single_valued );
     ( "spec cascade 6.1 nesting synthesis preserves source order",
       `Quick,
       c61_nesting_synthesis_source_order );


### PR DESCRIPTION
LightningCSS flattens `calc(calc(var(--x)) * Y)` to `calc(var(--x) * Y)`, but cascade kept the redundant inner `calc()` because unwrapping a `var()` is unsound in general: `var()` inside `calc()` is a substitution boundary (CSS Values 4 section 10.10), so the value could be multi-term (with `--x: 1px + 2px`, `calc(calc(var(--x)) * 2)` is `6px`, not the `5px` the flattened form would give). When `--x` is registered with a single-component `@property` syntax it substitutes exactly one calc term, making the unwrap sound. A calc-simplifier context carrying the single-valued registered names, built from the stylesheet's `@property` rules, is threaded through the calc folds; unregistered, universal (`*`), and list (`+`/`#`) syntaxes keep the grouping.