### PR TITLE
css: revert transitive custom-value emission from resolve_theme

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1008,47 +1008,6 @@ let var_names_in_theme_value value =
   done;
   !names
 
-(* The AST var collector records the names a custom property *defines*, but not
-   the [var()] references nested inside its opaque value token stream. So a
-   target referenced only from a kept custom property (e.g. an emitted
-   [--shadow: ... var(--spacing) ...]) is never a resolution root. Scan the
-   serialized value of every custom-property declaration so those references
-   pull their targets into the inject set too. *)
-let var_refs_in_custom_values stylesheet =
-  let acc = ref [] in
-  let scan_decls decls =
-    List.iter
-      (fun decl ->
-        List.iter
-          (fun n -> acc := n :: !acc)
-          (var_names_in_theme_value (declaration_value decl)))
-      (Variables.custom_declarations decls)
-  in
-  let rec walk = function
-    | [] -> ()
-    | stmt :: rest ->
-        (match stmt with
-        | Stylesheet.Rule r ->
-            scan_decls r.declarations;
-            walk r.nested
-        | Declarations decls -> scan_decls decls
-        | Media (_, b)
-        | Supports (_, b)
-        | Container (_, _, b)
-        | Layer (_, b)
-        | Origin (_, b)
-        | Scope (_, _, b)
-        | Starting_style b
-        | Moz_document (_, b)
-        | When (_, b)
-        | Else (_, b) ->
-            walk b
-        | _ -> ());
-        walk rest
-  in
-  walk stylesheet;
-  !acc
-
 let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
   let resolved : (string, string) Hashtbl.t = Hashtbl.create 16 in
   let cyclic = ref [] in
@@ -1077,9 +1036,7 @@ let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
                 Hashtbl.replace resolved raw_name value)
   in
   (match theme with
-  | Option.Some _ ->
-      List.iter dfs (collect_var_names stylesheet);
-      List.iter dfs (var_refs_in_custom_values stylesheet)
+  | Option.Some _ -> List.iter dfs (collect_var_names stylesheet)
   | Option.None -> ());
   Hashtbl.fold (fun k v acc -> (k, v) :: acc) resolved []
 
@@ -1132,14 +1089,10 @@ let resolve_theme ?theme ?theme_defaults stylesheet =
       collect_var_names stylesheet
       |> List.filter (fun n -> not (List.mem n resolved_names))
     in
-    (* A var referenced only inside a kept custom property's opaque value cannot
-       be inlined there, so its injected definition must survive: keep those
-       names live too (the resolved ones are emitted into [:root] above). *)
-    let keep_extra = unresolved_keep @ var_refs_in_custom_values stylesheet in
     let keep_vars =
       List.fold_left
         (fun acc n -> if List.mem n acc then acc else n :: acc)
-        keep_vars keep_extra
+        keep_vars unresolved_keep
     in
     let source = theme_defaults_source defaults in
     match of_string ~strict:false source with

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6176,32 +6176,6 @@ let customprops1_calc_inline () =
     |> Css.resolve_theme ~theme:Css.Pp.String_set.empty ~theme_defaults:resolve
     |> Css.to_string ~minify:true)
 
-(* CSS Custom Properties L1: a [var()] referenced only inside a custom
-   property's opaque value is invisible to the AST var collector, so its
-   [theme_defaults] definition must still be pulled into [:root]. The reference
-   stays live (it cannot be inlined inside the opaque value); when the resolver
-   has no answer, nothing is materialised. *)
-let customprops1_transitive_custom_value () =
-  let parse css =
-    match Css.of_string ~strict:false css with
-    | Ok parsed -> parsed.stylesheet
-    | Error _ -> Alcotest.failf "failed to parse: %s" css
-  in
-  let theme = Css.Pp.String_set.of_list [ "shadow" ] in
-  let resolve = function "spacing" -> Some ".25rem" | _ -> None in
-  Alcotest.(check string)
-    "var() inside a custom value pulls its theme default into :root"
-    ":root{--spacing:.25rem}:root{--shadow:0 0 var(--spacing) black}"
-    (parse ":root { --shadow: 0 0 var(--spacing) black }"
-    |> Css.resolve_theme ~theme ~theme_defaults:resolve
-    |> Css.to_string ~minify:true);
-  Alcotest.(check string)
-    "an unresolved nested var() is kept live, not materialised"
-    ":root{--shadow:0 0 var(--spacing) black}"
-    (parse ":root { --shadow: 0 0 var(--spacing) black }"
-    |> Css.resolve_theme ~theme ~theme_defaults:(fun _ -> None)
-    |> Css.to_string ~minify:true)
-
 (* CSS Custom Properties L1 section 2: a [var()] used inside a fallback list
    ([var(--font, "Helvetica", sans-serif)]) inlines if the variable resolves,
    otherwise the fallback list is kept intact. *)
@@ -6930,9 +6904,6 @@ let additional_tests =
     ( "spec custom-properties 1 inlined var in calc simplifies",
       `Quick,
       customprops1_calc_inline );
-    ( "spec custom-properties 1 transitive default via custom value",
-      `Quick,
-      customprops1_transitive_custom_value );
     ( "spec custom-properties 1 fallback list with inlining",
       `Quick,
       customprops1_fallback_list );


### PR DESCRIPTION
#81 made `Css.resolve_theme` scan custom-property values for `var()` references and pull their `theme_defaults` into `:root`. That was a misfix: a var referenced only inside an opaque custom-property value (e.g. `--shadow: ... var(--spacing) ...`) should stay a live `var()`, not be materialised. Emitting `:root{--spacing:...}` duplicates a default the caller already provides through the resolver and produces a spurious `:root` block. This restores `resolve_theme` to leave opaque custom-property `var()` references alone. Reverts #81.