### PR TITLE
properties: accept a calc() or general length grid track

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3774,6 +3774,7 @@ type grid_template = Properties.grid_template =
   | Vmin of float
   | Vmax of float
   | Zero
+  | Length of length
   | Fr of float
   | Auto
   | Min_content

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -10023,6 +10023,7 @@ let rec pp_grid_template : grid_template Pp.t =
   | Vmin f -> Pp.unit ctx f "vmin"
   | Vmax f -> Pp.unit ctx f "vmax"
   | Zero -> Pp.char ctx '0'
+  | Length l -> pp_length ctx l
   (* CSS Grid 2 sec. 7.2: [<flex>] is [<number>fr]; the unit-drop rule is for
      [<length>] only. [0fr] is a zero flex factor, distinct from a [0]
      [<length>] in [grid-template]'s union grammar. *)
@@ -12337,7 +12338,11 @@ let read_grid_area t : grid_area =
 
 module Grid_template = struct
   let read_length_as_grid t : grid_template =
-    match read_length t with
+    (* [~with_keywords:false]: track keywords (auto / min-content / ...) are a
+       separate [one_of] alternative, so this reader handles only real lengths -
+       the unit-specific cases below, plus a general [Length] carrier for a
+       [calc()], a [var()] in a [calc()], or a less common unit. *)
+    match read_length ~with_keywords:false t with
     | Px n -> (Px n : grid_template)
     | Rem n -> Rem n
     | Em n -> Em n
@@ -12347,7 +12352,7 @@ module Grid_template = struct
     | Vmax n -> Vmax n
     | Pct n -> Pct n
     | Zero -> Zero
-    | _ -> Cursor.err_expected t "<length-percentage>"
+    | other -> Length other
 
   let read_fr t : grid_template =
     (* [1fr] lexes as a single [Dimension] with unit "fr". *)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -744,6 +744,10 @@ type grid_template =
   | Vmin of float
   | Vmax of float
   | Zero
+  | Length of length
+      (** A track sized by a general [<length-percentage>] that the unit-
+          specific cases above do not carry: a [calc()], a [var()] inside a
+          [calc()], or a less common unit (e.g. [cm], [ch]). *)
   | Fr of float
   | Auto
   | Min_content

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3093,6 +3093,17 @@ let test_grid_template () =
   check_grid_template "1fr 2fr";
   check_grid_template "auto auto";
   check_grid_template "inherit";
+  (* CSS Grid 2 sec. 7.2: a track is any <length-percentage>, so a calc(), a
+     var() inside a calc(), or a less common unit is a valid track, carried by
+     the [Length] track. *)
+  check_grid_template ~roundtrip:true ~expected:"calc(var(--spacing)*4)"
+    "calc(var(--spacing) * 4)";
+  check_grid_template ~roundtrip:true ~expected:"calc(var(--x)*2)1fr"
+    "calc(var(--x) * 2) 1fr";
+  check_grid_template "calc(100px + 1rem)";
+  check_grid_template "10cm";
+  check_grid_template ~expected:"minmax(calc(var(--x)*2),1fr)"
+    "minmax(calc(var(--x) * 2), 1fr)";
   neg_cursor read_grid_template "invalid-template"
 
 let test_grid_template_areas () =


### PR DESCRIPTION
`grid-template-columns` / `grid-template-rows` enumerated only specific length units (`px`, `rem`, `em`, `%`, `vw`, `vh`, `vmin`, `vmax`, `0`) as a track size, so a `calc()` track, a `var()` inside a `calc()`, or a less common unit (`cm`, `ch`, ...) was rejected at parse time with "Expected at least one grid track". A general `Length` track carrier now lets any `<length-percentage>` be a track, including inside `minmax()` and `repeat()`.