### PR TITLE
css: emit transitively-referenced theme defaults, merged in place

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1053,6 +1053,122 @@ let theme_defaults_source defaults =
   in
   ":root{" ^ body ^ "}"
 
+(* Names declared as a custom property anywhere in the tree (bare, no [--]). *)
+let declared_custom_prop_names (stmts : Stylesheet.statement list) :
+    (string, unit) Hashtbl.t =
+  let tbl = Hashtbl.create 16 in
+  let note decls =
+    List.iter
+      (fun d ->
+        match Variables.custom_declaration_name d with
+        | Some n -> Hashtbl.replace tbl (bare_theme_name n) ()
+        | None -> ())
+      decls
+  in
+  let rec scan (stmt : Stylesheet.statement) =
+    match stmt with
+    | Stylesheet.Rule r ->
+        note r.declarations;
+        List.iter scan r.nested
+    | Stylesheet.Declarations decls -> note decls
+    | Stylesheet.Media (_, b)
+    | Stylesheet.Supports (_, b)
+    | Stylesheet.Container (_, _, b)
+    | Stylesheet.Layer (_, b)
+    | Stylesheet.Origin (_, b)
+    | Stylesheet.Scope (_, _, b)
+    | Stylesheet.Starting_style b
+    | Stylesheet.Moz_document (_, b)
+    | Stylesheet.When (_, b)
+    | Stylesheet.Else (_, b) ->
+        List.iter scan b
+    | _ -> ()
+  in
+  List.iter scan stmts;
+  tbl
+
+(* Apply [f] to every [Rule] in the tree, recursing through nested rules and
+   block at-rules. *)
+let rec map_rule_statements f (stmts : Stylesheet.statement list) :
+    Stylesheet.statement list =
+  List.map (map_rule_statement f) stmts
+
+and map_rule_statement f (stmt : Stylesheet.statement) : Stylesheet.statement =
+  match stmt with
+  | Stylesheet.Rule r ->
+      let r = f r in
+      Stylesheet.Rule { r with nested = map_rule_statements f r.nested }
+  | Stylesheet.Media (c, b) -> Stylesheet.Media (c, map_rule_statements f b)
+  | Stylesheet.Supports (c, b) ->
+      Stylesheet.Supports (c, map_rule_statements f b)
+  | Stylesheet.Container (n, c, b) ->
+      Stylesheet.Container (n, c, map_rule_statements f b)
+  | Stylesheet.Layer (n, b) -> Stylesheet.Layer (n, map_rule_statements f b)
+  | Stylesheet.Origin (o, b) -> Stylesheet.Origin (o, map_rule_statements f b)
+  | Stylesheet.Scope (s, e, b) ->
+      Stylesheet.Scope (s, e, map_rule_statements f b)
+  | Stylesheet.Starting_style b ->
+      Stylesheet.Starting_style (map_rule_statements f b)
+  | Stylesheet.Moz_document (c, b) ->
+      Stylesheet.Moz_document (c, map_rule_statements f b)
+  | Stylesheet.When (c, b) -> Stylesheet.When (c, map_rule_statements f b)
+  | Stylesheet.Else (c, b) -> Stylesheet.Else (c, map_rule_statements f b)
+  | other -> other
+
+(* A custom property referenced only inside an emitted theme var's opaque value
+   (e.g. [--shadow: ... var(--spacing) ...]) is invisible to the AST var
+   collector, so a value the caller supplies only through [theme_defaults]
+   ([--spacing: .25rem]) goes undefined. Resolve such references transitively
+   and merge the resulting declarations into the same rule that emits the kept
+   theme var, so the dependency is defined in place. Only rules declaring a kept
+   theme var are touched (so unrelated [@property] / polyfill defaults are never
+   pulled in), a var already declared anywhere is left alone (no duplicate or
+   cascade conflict), and a kept var is skipped (it is emitted elsewhere). *)
+let emit_transitive_theme_refs ~keep_set ~theme_defaults stylesheet =
+  match theme_defaults with
+  | Option.None -> stylesheet
+  | Option.Some lookup ->
+      let declared = declared_custom_prop_names stylesheet in
+      let rec resolve acc name =
+        let bare = bare_theme_name name in
+        if
+          List.mem_assoc name acc
+          || Pp.String_set.mem bare keep_set
+          || Hashtbl.mem declared bare
+        then acc
+        else
+          match lookup bare with
+          | Option.None -> acc
+          | Option.Some value ->
+              List.fold_left resolve ((name, value) :: acc)
+                (var_names_in_theme_value value)
+      in
+      let declares_kept (r : Stylesheet.rule) =
+        List.exists
+          (fun d ->
+            match Variables.custom_declaration_name d with
+            | Some n -> Pp.String_set.mem (bare_theme_name n) keep_set
+            | None -> false)
+          r.declarations
+      in
+      let augment (r : Stylesheet.rule) : Stylesheet.rule =
+        if not (declares_kept r) then r
+        else
+          let refs =
+            List.concat_map
+              (fun d -> var_names_in_theme_value (declaration_value d))
+              (Variables.custom_declarations r.declarations)
+          in
+          let to_add = List.rev (List.fold_left resolve [] refs) in
+          if to_add = [] then r
+          else
+            match of_string ~strict:false (theme_defaults_source to_add) with
+            | Ok { stylesheet = [ Stylesheet.Rule injected ]; _ } ->
+                { r with declarations = injected.declarations @ r.declarations }
+            | _ -> r
+      in
+      map_rule_statements augment stylesheet
+
 (* Theme resolution as an explicit AST step. [theme] names the variables whose
    [var()] references should survive (handed to [Inline.vars]' keep-set) and
    filters [Theme_guarded] declarations to keep only those whose [var_name] is
@@ -1067,38 +1183,45 @@ let resolve_theme ?theme ?theme_defaults stylesheet =
   let keep_set =
     match theme with None -> Pp.String_set.empty | Some set -> set
   in
-  let keep_vars = Pp.String_set.elements keep_set in
-  let defaults =
-    collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet
+  let stylesheet =
+    let keep_vars = Pp.String_set.elements keep_set in
+    let defaults =
+      collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet
+    in
+    if defaults = [] then stylesheet
+    else
+      (* Only the names [theme_defaults] resolved get their [var()] references
+         substituted. [Inline.vars] applied here would also collapse [var(--x,
+         fallback)] references for names the resolver returned [None] on
+         (because [var()]'s built-in fallback arm is consulted when no
+         declaration is visible); the explicit semantics keep those references
+         live. Limit [Inline.vars] to a stylesheet containing only the injected
+         [:root] declarations and the matching subtrees, then merge the result
+         back at the source's position. We achieve that by injecting a [:root]
+         rule plus extending [keep_vars] with every var name we did *not*
+         resolve, so the unresolved sites keep their declarations live and the
+         substitution falls through to [fallback_or_original]'s original-Func
+         branch. *)
+      let resolved_names = List.map fst defaults in
+      let unresolved_keep =
+        collect_var_names stylesheet
+        |> List.filter (fun n -> not (List.mem n resolved_names))
+      in
+      let keep_vars =
+        List.fold_left
+          (fun acc n -> if List.mem n acc then acc else n :: acc)
+          keep_vars unresolved_keep
+      in
+      let source = theme_defaults_source defaults in
+      match of_string ~strict:false source with
+      | Ok { stylesheet = root_stmts; _ } ->
+          inline_vars ~keep_vars (root_stmts @ stylesheet)
+      | Error _ -> stylesheet
   in
-  if defaults = [] then stylesheet
-  else
-    (* Only the names [theme_defaults] resolved get their [var()] references
-       substituted. [Inline.vars] applied here would also collapse [var(--x,
-       fallback)] references for names the resolver returned [None] on (because
-       [var()]'s built-in fallback arm is consulted when no declaration is
-       visible); the explicit semantics keep those references live. Limit
-       [Inline.vars] to a stylesheet containing only the injected [:root]
-       declarations and the matching subtrees, then merge the result back at the
-       source's position. We achieve that by injecting a [:root] rule plus
-       extending [keep_vars] with every var name we did *not* resolve, so the
-       unresolved sites keep their declarations live and the substitution falls
-       through to [fallback_or_original]'s original-Func branch. *)
-    let resolved_names = List.map fst defaults in
-    let unresolved_keep =
-      collect_var_names stylesheet
-      |> List.filter (fun n -> not (List.mem n resolved_names))
-    in
-    let keep_vars =
-      List.fold_left
-        (fun acc n -> if List.mem n acc then acc else n :: acc)
-        keep_vars unresolved_keep
-    in
-    let source = theme_defaults_source defaults in
-    match of_string ~strict:false source with
-    | Ok { stylesheet = root_stmts; _ } ->
-        inline_vars ~keep_vars (root_stmts @ stylesheet)
-    | Error _ -> stylesheet
+  (* Pull in a theme var referenced only inside another emitted theme var's
+     opaque value (the AST collector above cannot see it), merged into the same
+     rule. *)
+  emit_transitive_theme_refs ~keep_set ~theme_defaults stylesheet
 
 let decode_import_url = Inline.decode_import_url
 let inline_imports = Inline.imports

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6176,6 +6176,42 @@ let customprops1_calc_inline () =
     |> Css.resolve_theme ~theme:Css.Pp.String_set.empty ~theme_defaults:resolve
     |> Css.to_string ~minify:true)
 
+(* CSS Custom Properties L1: a theme var referenced only inside another emitted
+   theme var's opaque value is resolved through [theme_defaults] and merged into
+   the same rule - in place, with no spurious extra block and without pulling in
+   unrelated defaults. *)
+let customprops1_transitive_merge () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let theme = Css.Pp.String_set.of_list [ "shadow" ] in
+  let spacing = function "spacing" -> Some ".25rem" | _ -> None in
+  let render ?(theme_defaults = spacing) css =
+    parse css
+    |> Css.resolve_theme ~theme ~theme_defaults
+    |> Css.to_string ~minify:true
+  in
+  Alcotest.(check string)
+    "transitive theme var merges into the same :root,:host block"
+    ":root,:host{--spacing:.25rem;--shadow:0 0 var(--spacing) black}"
+    (render ":root,:host{--shadow:0 0 var(--spacing) black}");
+  Alcotest.(check string)
+    "an unrelated @supports polyfill default is not pulled in"
+    "@supports(color:lab(0 0 \
+     0)){:root{--tw-x:initial}}:root,:host{--spacing:.25rem;--shadow:0 0 \
+     var(--spacing) black}"
+    (render
+       "@supports (color: lab(0 0 0)){:root{--tw-x:initial}} \
+        :root,:host{--shadow:0 0 var(--spacing) black}");
+  Alcotest.(check string)
+    "an unresolved reference is kept live, not materialised"
+    ":root,:host{--shadow:0 0 var(--spacing) black}"
+    (render
+       ~theme_defaults:(fun _ -> None)
+       ":root,:host{--shadow:0 0 var(--spacing) black}")
+
 (* CSS Custom Properties L1 section 2: a [var()] used inside a fallback list
    ([var(--font, "Helvetica", sans-serif)]) inlines if the variable resolves,
    otherwise the fallback list is kept intact. *)
@@ -6904,6 +6940,9 @@ let additional_tests =
     ( "spec custom-properties 1 inlined var in calc simplifies",
       `Quick,
       customprops1_calc_inline );
+    ( "spec custom-properties 1 transitive theme var merges in place",
+      `Quick,
+      customprops1_transitive_merge );
     ( "spec custom-properties 1 fallback list with inlining",
       `Quick,
       customprops1_fallback_list );


### PR DESCRIPTION
A custom property referenced only inside another emitted theme var's opaque value (e.g. `--shadow: ... var(--spacing) ...`) is invisible to the AST var collector, so a value the caller supplies only through `theme_defaults` (e.g. `--spacing: .25rem`) goes undefined. `Css.resolve_theme` now resolves such references transitively and merges the resulting declarations into the **same** rule that emits the referencing theme var, so the dependency is defined in place with the same selector coverage. It is scoped tightly: only rules that declare a kept theme var are touched (so unrelated `@property`/polyfill defaults are never pulled in), a var already declared anywhere is left alone (no duplicate or cascade conflict), and a var the resolver does not answer for stays a live `var()`. This re-does the transitive emission from #81 (reverted in #83) without the spurious extra `:root` block that the first attempt produced.