### PR TITLE
css: emit a kept-but-undeclared theme var's transitive default

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1122,20 +1122,20 @@ and map_rule_statement f (stmt : Stylesheet.statement) : Stylesheet.statement =
    and merge the resulting declarations into the same rule that emits the kept
    theme var, so the dependency is defined in place. Only rules declaring a kept
    theme var are touched (so unrelated [@property] / polyfill defaults are never
-   pulled in), a var already declared anywhere is left alone (no duplicate or
-   cascade conflict), and a kept var is skipped (it is emitted elsewhere). *)
+   pulled in), and a var already declared anywhere is left alone (no duplicate
+   or cascade conflict) - a kept-but-undeclared var still gets its default. *)
 let emit_transitive_theme_refs ~keep_set ~theme_defaults stylesheet =
   match theme_defaults with
   | Option.None -> stylesheet
   | Option.Some lookup ->
       let declared = declared_custom_prop_names stylesheet in
+      (* [keep_set] means "keep this [var()] reference live", not "already
+         defined": a kept var can be undefined and rely on [theme_defaults], so
+         it is not a skip reason here. Skip only an actually-declared var (no
+         duplicate) or one already collected (cycle guard). *)
       let rec resolve acc name =
         let bare = bare_theme_name name in
-        if
-          List.mem_assoc name acc
-          || Pp.String_set.mem bare keep_set
-          || Hashtbl.mem declared bare
-        then acc
+        if List.mem_assoc name acc || Hashtbl.mem declared bare then acc
         else
           match lookup bare with
           | Option.None -> acc

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6197,6 +6197,17 @@ let customprops1_transitive_merge () =
     "transitive theme var merges into the same :root,:host block"
     ":root,:host{--spacing:.25rem;--shadow:0 0 var(--spacing) black}"
     (render ":root,:host{--shadow:0 0 var(--spacing) black}");
+  (* The referenced var being in the keep-set means its reference is kept live,
+     not that it is defined: a kept-but-undeclared var still gets its
+     default. *)
+  Alcotest.(check string)
+    "a kept-but-undeclared referenced var still gets its default"
+    ":root,:host{--spacing:.25rem;--shadow:0 0 var(--spacing) black}"
+    (parse ":root,:host{--shadow:0 0 var(--spacing) black}"
+    |> Css.resolve_theme
+         ~theme:(Css.Pp.String_set.of_list [ "shadow"; "spacing" ])
+         ~theme_defaults:spacing
+    |> Css.to_string ~minify:true);
   Alcotest.(check string)
     "an unrelated @supports polyfill default is not pulled in"
     "@supports(color:lab(0 0 \


### PR DESCRIPTION
`emit_transitive_theme_refs` (#86) skipped a referenced var when it was in the keep-set, but keep-set membership means "keep the `var()` reference live", not "already defined". A kept var can be undefined and rely on `theme_defaults` (e.g. `--spacing` appears in the expected `:root,:host` but is supplied only by the resolver), so the keep-set clause conflated *kept-live* with *declared* and suppressed exactly the emission that was wanted. The skip now relies only on the actually-declared check (and the cycle guard), so a kept-but-undeclared var gets its default while a genuinely-declared var is still left alone (no duplicate). Follow-up to #86.