### PR TITLE
css: emit theme defaults at root scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,31 @@ Structural diff lives in the separate `cascade.diff` sub-library
 (`Cascade_diff.Css_compare`, `Cascade_diff.Tree_diff`,
 `Cascade_diff.String_diff`); it is what `cascade diff` is built on.
 
+### Theme resolution
+
+`Css.resolve_theme ?theme ?theme_defaults` is the AST-level form of the
+`--inline-vars --keep-vars` recipe above: it resolves design-token variables
+against caller-supplied data.
+
+- `theme` is the set of variable names whose `var()` references stay live. When
+  `theme` is given, references to any other name are inlined to the value
+  `theme_defaults` resolves for it.
+- `theme_defaults` maps a custom-property name to its value and supplies the
+  global token definitions. Every `var()` reference that is undefined in the
+  stylesheet and resolvable through `theme_defaults` is emitted as a definition
+  in the root-scope theme block: an existing `:root` / `:host` rule, or a fresh
+  `:root`. Resolution is transitive, and a chain that cycles or hits a dead end
+  is dropped. A name `theme_defaults` returns `None` on (for example a runtime
+  `--tw-*` variable) is left free.
+
+The definition lands at root scope by design. Custom properties are inherited
+and resolved per element
+([Custom Properties Level 1](https://www.w3.org/TR/css-variables-1/)), so
+`var(--x)` needs `--x` defined on the element or an ancestor. A theme token is
+global: defining it on `:root` / `:host` makes it inherit to every element and
+stay globally overridable, whereas defining it on the element-scoped rule that
+happens to reference it would confine and shadow it.
+
 ### Parsing modes
 
 `Css.of_string ~strict:false s` always returns

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1087,87 +1087,134 @@ let declared_custom_prop_names (stmts : Stylesheet.statement list) :
   List.iter scan stmts;
   tbl
 
-(* Apply [f] to every [Rule] in the tree, recursing through nested rules and
-   block at-rules. *)
-let rec map_rule_statements f (stmts : Stylesheet.statement list) :
-    Stylesheet.statement list =
-  List.map (map_rule_statement f) stmts
+(* Bare names of every [var()] reference. [collect_var_names] reads typed
+   values; the byte scan covers only opaque custom-property streams, so a [var(]
+   inside a string ([content: "var(--x)"]) is not counted as a reference. *)
+let referenced_var_names (stmts : Stylesheet.statement list) : string list =
+  let opaque = ref [] in
+  let note d =
+    match Variables.custom_declaration_name d with
+    | Option.Some _ ->
+        opaque :=
+          List.rev_append
+            (var_names_in_theme_value (declaration_value d))
+            !opaque
+    | Option.None -> ()
+  in
+  let rec scan (stmt : Stylesheet.statement) =
+    match stmt with
+    | Stylesheet.Rule r ->
+        List.iter note r.declarations;
+        List.iter scan r.nested
+    | Stylesheet.Declarations decls -> List.iter note decls
+    | Stylesheet.Media (_, b)
+    | Stylesheet.Supports (_, b)
+    | Stylesheet.Container (_, _, b)
+    | Stylesheet.Layer (_, b)
+    | Stylesheet.Origin (_, b)
+    | Stylesheet.Scope (_, _, b)
+    | Stylesheet.Starting_style b
+    | Stylesheet.Moz_document (_, b)
+    | Stylesheet.When (_, b)
+    | Stylesheet.Else (_, b) ->
+        List.iter scan b
+    | _ -> ()
+  in
+  List.iter scan stmts;
+  List.map bare_theme_name (collect_var_names stmts @ !opaque)
 
-and map_rule_statement f (stmt : Stylesheet.statement) : Stylesheet.statement =
-  match stmt with
-  | Stylesheet.Rule r ->
-      let r = f r in
-      Stylesheet.Rule { r with nested = map_rule_statements f r.nested }
-  | Stylesheet.Media (c, b) -> Stylesheet.Media (c, map_rule_statements f b)
-  | Stylesheet.Supports (c, b) ->
-      Stylesheet.Supports (c, map_rule_statements f b)
-  | Stylesheet.Container (n, c, b) ->
-      Stylesheet.Container (n, c, map_rule_statements f b)
-  | Stylesheet.Layer (n, b) -> Stylesheet.Layer (n, map_rule_statements f b)
-  | Stylesheet.Origin (o, b) -> Stylesheet.Origin (o, map_rule_statements f b)
-  | Stylesheet.Scope (s, e, b) ->
-      Stylesheet.Scope (s, e, map_rule_statements f b)
-  | Stylesheet.Starting_style b ->
-      Stylesheet.Starting_style (map_rule_statements f b)
-  | Stylesheet.Moz_document (c, b) ->
-      Stylesheet.Moz_document (c, map_rule_statements f b)
-  | Stylesheet.When (c, b) -> Stylesheet.When (c, map_rule_statements f b)
-  | Stylesheet.Else (c, b) -> Stylesheet.Else (c, map_rule_statements f b)
-  | other -> other
+(* [:root], [:host], or a comma list of only those. *)
+let is_root_scope_selector sel =
+  let parts = String.split_on_char ',' (Selector.to_string ~minify:true sel) in
+  parts <> []
+  && List.for_all
+       (fun p ->
+         match String.trim p with ":root" | ":host" -> true | _ -> false)
+       parts
 
-(* A custom property referenced only inside an emitted theme var's opaque value
-   (e.g. [--shadow: ... var(--spacing) ...]) is invisible to the AST var
-   collector, so a value the caller supplies only through [theme_defaults]
-   ([--spacing: .25rem]) goes undefined. Resolve such references transitively
-   and merge the resulting declarations into the same rule that emits the kept
-   theme var, so the dependency is defined in place. Only rules declaring a kept
-   theme var are touched (so unrelated [@property] / polyfill defaults are never
-   pulled in), a var already declared anywhere is left alone (no duplicate or
-   cascade conflict), and a kept var is skipped (it is emitted elsewhere). *)
-let emit_transitive_theme_refs ~keep_set ~theme_defaults stylesheet =
+(* Prepend [decls] to the first root-scope rule reachable without crossing a
+   conditional at-rule (descend through [@layer] only, not [@supports] /
+   [@media] whose [:root] is conditional). Returns the tree and whether a merge
+   happened. *)
+let merge_into_root_scope decls (stmts : Stylesheet.statement list) :
+    Stylesheet.statement list * bool =
+  let merged = ref false in
+  let rec go = function
+    | [] -> []
+    | stmt :: rest when !merged -> stmt :: go rest
+    | stmt :: rest ->
+        let stmt' =
+          match stmt with
+          | Stylesheet.Rule r when is_root_scope_selector r.selector ->
+              merged := true;
+              Stylesheet.Rule { r with declarations = decls @ r.declarations }
+          | Stylesheet.Layer (n, b) -> Stylesheet.Layer (n, go b)
+          | other -> other
+        in
+        stmt' :: go rest
+  in
+  let result = go stmts in
+  (result, !merged)
+
+(* From [roots], the [(name, value)] bindings for each free variable resolvable
+   through [lookup]. [emittable] keeps only names that close: unbound in
+   [declared], and every [var()] in the value declared or itself emittable, no
+   cycle. A cyclic ([--a: var(--b)], [--b: var(--a)]) or dead-end chain is
+   dropped: its [:root] binding would be guaranteed-invalid. *)
+let resolve_theme_defaults ~declared ~lookup roots =
+  let rec emittable path name =
+    let bare = bare_theme_name name in
+    if Hashtbl.mem declared bare then true
+    else if List.mem bare path then false
+    else
+      match lookup bare with
+      | Option.None -> false
+      | Option.Some value ->
+          List.for_all
+            (emittable (bare :: path))
+            (var_names_in_theme_value value)
+  in
+  let rec resolve acc name =
+    let bare = bare_theme_name name in
+    if List.mem_assoc bare acc || Hashtbl.mem declared bare then acc
+    else if not (emittable [] bare) then acc
+    else
+      match lookup bare with
+      | Option.None -> acc
+      | Option.Some value ->
+          List.fold_left resolve ((bare, value) :: acc)
+            (var_names_in_theme_value value)
+  in
+  List.rev (List.fold_left resolve [] roots)
+
+(* Bind every free theme variable at root scope: each [var()] reference
+   resolvable through [theme_defaults] (see [resolve_theme_defaults]) is emitted
+   into the root-scope theme block - an existing [:root] / [:host] rule, else a
+   fresh [:root]. [theme_defaults] returning [None] leaves the variable free.
+   See [resolve_theme]'s interface doc for why root scope. *)
+let emit_transitive_theme_refs ~theme_defaults stylesheet =
   match theme_defaults with
   | Option.None -> stylesheet
   | Option.Some lookup ->
       let declared = declared_custom_prop_names stylesheet in
-      let rec resolve acc name =
-        let bare = bare_theme_name name in
-        if
-          List.mem_assoc name acc
-          || Pp.String_set.mem bare keep_set
-          || Hashtbl.mem declared bare
-        then acc
+      let to_emit =
+        resolve_theme_defaults ~declared ~lookup
+          (referenced_var_names stylesheet)
+      in
+      let injected =
+        if to_emit = [] then []
         else
-          match lookup bare with
-          | Option.None -> acc
-          | Option.Some value ->
-              List.fold_left resolve ((name, value) :: acc)
-                (var_names_in_theme_value value)
+          match of_string ~strict:false (theme_defaults_source to_emit) with
+          | Ok { stylesheet = root_stmts; _ } -> root_stmts
+          | Error _ -> []
       in
-      let declares_kept (r : Stylesheet.rule) =
-        List.exists
-          (fun d ->
-            match Variables.custom_declaration_name d with
-            | Some n -> Pp.String_set.mem (bare_theme_name n) keep_set
-            | None -> false)
-          r.declarations
+      let injected_decls =
+        match injected with [ Stylesheet.Rule r ] -> r.declarations | _ -> []
       in
-      let augment (r : Stylesheet.rule) : Stylesheet.rule =
-        if not (declares_kept r) then r
-        else
-          let refs =
-            List.concat_map
-              (fun d -> var_names_in_theme_value (declaration_value d))
-              (Variables.custom_declarations r.declarations)
-          in
-          let to_add = List.rev (List.fold_left resolve [] refs) in
-          if to_add = [] then r
-          else
-            match of_string ~strict:false (theme_defaults_source to_add) with
-            | Ok { stylesheet = [ Stylesheet.Rule injected ]; _ } ->
-                { r with declarations = injected.declarations @ r.declarations }
-            | _ -> r
-      in
-      map_rule_statements augment stylesheet
+      if injected_decls = [] then stylesheet
+      else
+        let result, merged = merge_into_root_scope injected_decls stylesheet in
+        if merged then result else injected @ stylesheet
 
 (* Theme resolution as an explicit AST step. [theme] names the variables whose
    [var()] references should survive (handed to [Inline.vars]' keep-set) and
@@ -1218,10 +1265,10 @@ let resolve_theme ?theme ?theme_defaults stylesheet =
           inline_vars ~keep_vars (root_stmts @ stylesheet)
       | Error _ -> stylesheet
   in
-  (* Pull in a theme var referenced only inside another emitted theme var's
-     opaque value (the AST collector above cannot see it), merged into the same
-     rule. *)
-  emit_transitive_theme_refs ~keep_set ~theme_defaults stylesheet
+  (* Emit root-scope definitions for theme vars referenced but undefined,
+     including references the AST collector above cannot see inside opaque
+     values. *)
+  emit_transitive_theme_refs ~theme_defaults stylesheet
 
 let decode_import_url = Inline.decode_import_url
 let inline_imports = Inline.imports

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7549,9 +7549,27 @@ val resolve_theme :
   ?theme:Pp.String_set.t -> ?theme_defaults:(string -> string option) -> t -> t
 (** [resolve_theme ?theme ?theme_defaults stylesheet] is the explicit AST step
     matching the print-time [~theme] / [~theme_defaults] knobs on {!to_string}.
-    [theme] names the variables that should keep their [var()] reference live;
-    [theme_defaults] is the external default resolver consulted at print time
-    for variables not in [theme]. *)
+
+    [theme] names the variables whose [var()] references stay live. When [theme]
+    is given, references to any other name are inlined to the value
+    [theme_defaults] resolves for it.
+
+    [theme_defaults] maps a custom-property name to its value and is the source
+    of global theme-token definitions. Every [var()] reference that is undefined
+    in [stylesheet] and resolvable through [theme_defaults] - transitively, and
+    only when the whole chain closes without a cycle or dead end - is emitted as
+    a definition in the root-scope theme block: merged into an existing [:root]
+    / [:host] rule, or a fresh [:root]. A name with no [theme_defaults] value
+    (e.g. a runtime [--tw-*] variable) is left free, so non-theme variables are
+    gated out.
+
+    Root scope is deliberate. Per CSS Custom Properties L1 a custom property is
+    inherited and resolved per element at computed-value time, so [var(--x)]
+    needs [--x] defined on the element or an ancestor. A value [theme_defaults]
+    supplies is a global token: defining it at [:root] / [:host] makes it
+    inherit to every element and stay globally overridable, whereas defining it
+    on the element-scoped rule that happens to reference it would confine and
+    shadow it. *)
 
 val decode_import_url : string -> string
 (** [decode_import_url s] strips the [url(...)] wrapper and any surrounding

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -873,18 +873,18 @@ let public_theme_var_rendering_edges () =
     sheet |> Css.resolve_theme ?theme ?theme_defaults |> to_string ~minify:true
   in
   Alcotest.(check string)
-    "normal stylesheet keeps theme var reference"
-    ".font-sans{font-family:var(--font-sans)}"
+    "kept theme var keeps its reference and gains a :root default"
+    ":root{--font-sans:Arial,sans-serif}.font-sans{font-family:var(--font-sans)}"
     (render_theme ~theme:font_theme ~theme_defaults:resolve_font
        (sheet_for (Var font_sans)));
   Alcotest.(check string)
-    "normal stylesheet keeps theme var fallback reference"
-    ".font-sans{font-family:var(--font-fallback,Arial,sans-serif)}"
+    "kept theme var with fallback gains a :root default"
+    ":root{--font-fallback:Arial,sans-serif}.font-sans{font-family:var(--font-fallback,Arial,sans-serif)}"
     (render_theme ~theme:fallback_theme ~theme_defaults:resolve_font
        (sheet_for (Var font_fallback)));
   Alcotest.(check string)
-    "normal stylesheet without explicit theme keeps var reference"
-    ".font-sans{font-family:var(--font-sans)}"
+    "theme default emitted in :root without an explicit theme"
+    ":root{--font-sans:Arial,sans-serif}.font-sans{font-family:var(--font-sans)}"
     (render_theme ~theme_defaults:resolve_font (sheet_for (Var font_sans)));
   Alcotest.(check string)
     "inline stylesheet may use typed default"

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6176,10 +6176,12 @@ let customprops1_calc_inline () =
     |> Css.resolve_theme ~theme:Css.Pp.String_set.empty ~theme_defaults:resolve
     |> Css.to_string ~minify:true)
 
-(* CSS Custom Properties L1: a theme var referenced only inside another emitted
-   theme var's opaque value is resolved through [theme_defaults] and merged into
-   the same rule - in place, with no spurious extra block and without pulling in
-   unrelated defaults. *)
+(* CSS Custom Properties L1: a theme var referenced anywhere - inside another
+   var's opaque value or inside a utility rule - and resolvable through
+   [theme_defaults] is emitted at root scope, the global token's cascade scope.
+   It merges into an existing :root,:host block (no spurious extra block), is
+   never injected into the element-scoped rule that references it, and an
+   unrelated @supports polyfill default is not pulled in. *)
 let customprops1_transitive_merge () =
   let parse css =
     match Css.of_string ~strict:false css with
@@ -6197,6 +6199,10 @@ let customprops1_transitive_merge () =
     "transitive theme var merges into the same :root,:host block"
     ":root,:host{--spacing:.25rem;--shadow:0 0 var(--spacing) black}"
     (render ":root,:host{--shadow:0 0 var(--spacing) black}");
+  Alcotest.(check string)
+    "a theme var referenced from a utility lands in :root, not the utility"
+    ":root{--spacing:.25rem}.shadow{--shadow:0 0 var(--spacing) black}"
+    (render ".shadow{--shadow:0 0 var(--spacing) black}");
   Alcotest.(check string)
     "an unrelated @supports polyfill default is not pulled in"
     "@supports(color:lab(0 0 \


### PR DESCRIPTION
`Css.resolve_theme` used to inject a theme variable's default into whichever rule referenced it. A value supplied through `theme_defaults` is a global token: per CSS Custom Properties Level 1 a custom property is inherited and resolved per element, so it must be defined on an ancestor of every referencing element. Defining it on the element-scoped rule confined it to that subtree and shadowed the intended global value.

It now lands in the root-scope theme block (`:root` / `:host`), merged into an existing one or a fresh `:root`, with transitive resolution that drops chains that cycle or hit a dead end. Supersedes #87.