### PR TITLE
css: generalize Calc.float and Calc.infinity to any calc leaf

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -890,10 +890,12 @@ module Calc : sig
       expressions. Example: [var "spacing"] or
       [var ~fallback:(Rem 1.2) "tw-leading"]. *)
 
-  val float : float -> length calc
-  (** [float f] is a numeric value for {!type-calc} expressions. *)
+  val float : float -> 'a calc
+  (** [float f] is a numeric value for {!type-calc} expressions. It is unitless,
+      so it works in a calc of any leaf type (e.g. a flex-basis multiplier), not
+      only lengths. *)
 
-  val infinity : length calc
+  val infinity : 'a calc
   (** [infinity] is the CSS infinity value for {!type-calc} expressions. *)
 
   val px : float -> length calc

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -755,6 +755,21 @@ let public_value_combinator_edges () =
     "padding bare var stays bare" ".p-1{padding:var(--spacing)}"
     (to_string ~minify:true bare_var_sheet);
 
+  (* [Calc.float] is generic ['a calc], so a non-length calc - here a flex_basis
+     calc with a numeric multiplier - can be built through the typed API. *)
+  let flex_basis_calc_sheet =
+    v
+      [
+        rule
+          ~selector:(Selector.class_ "basis-4")
+          [ flex_basis (Calc Calc.(var "spacing" * float 4.)) ];
+      ]
+  in
+  Alcotest.(check string)
+    "flex-basis calc multiplier builds via generic Calc.float"
+    ".basis-4{flex-basis:calc(var(--spacing)*4)}"
+    (to_string ~minify:true flex_basis_calc_sheet);
+
   let sheet =
     v
       [


### PR DESCRIPTION
`Css.Calc.float` and `Css.Calc.infinity` were pinned to `length calc` in the interface, even though the underlying `Values.Calc` implementation is already polymorphic. Both are unitless, so this was a needless restriction: a non-length calc such as a flex-basis multiplier (`calc(var(--spacing) * 4)`) could not be assembled through the typed `Calc` API at all.

Widen both signatures to the generic `'a calc` the implementation already returns. Existing length-context callers are unaffected (the return type still unifies to `length calc`).