### PR TITLE
properties: carry a typed calc in z-index

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1860,7 +1860,7 @@ type visibility = Properties.visibility =
 type z_index = Properties.z_index =
   | Auto
   | Index of int
-  | Calc of string
+  | Calc of z_index calc
   | Inherit
   | Initial
   | Unset

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -5133,7 +5133,7 @@ let rec pp_z_index : z_index Pp.t =
  fun ctx -> function
   | Auto -> Pp.string ctx "auto"
   | Index i -> Pp.int ctx i
-  | Calc s -> Pp.string ctx s
+  | Calc c -> pp_calc pp_z_index ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -11701,7 +11701,7 @@ let rec read_z_index t : z_index =
     match eval_numeric_calc expr with
     | Some f when Float.is_integer f -> Index (int_of_float f)
     | Some _ -> Cursor.err_invalid t "z-index calc must evaluate to integer"
-    | None -> Calc (string_of_calc expr)
+    | None -> Calc expr
   in
   let read_var_z t : z_index = Var (read_var read_z_index t) in
   Cursor.enum_or_calls "z-index"

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -164,7 +164,7 @@ type baseline_shift =
 type z_index =
   | Auto
   | Index of int
-  | Calc of string
+  | Calc of z_index calc
   | Inherit
   | Initial
   | Unset

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -769,6 +769,18 @@ let public_value_combinator_edges () =
     "flex-basis calc multiplier builds via generic Calc.float"
     ".basis-4{flex-basis:calc(var(--spacing)*4)}"
     (to_string ~minify:true flex_basis_calc_sheet);
+  (* z-index carries a typed calc, so a var-based z-index calc builds through
+     the typed API rather than a raw string. *)
+  let z_index_calc_sheet =
+    v
+      [
+        rule ~selector:(Selector.class_ "z")
+          [ z_index (Calc (Calc.var "layer")) ];
+      ]
+  in
+  Alcotest.(check string)
+    "z-index calc builds via typed calc" ".z{z-index:calc(var(--layer))}"
+    (to_string ~minify:true z_index_calc_sheet);
 
   let sheet =
     v

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -777,6 +777,11 @@ let misc () =
   check_declaration ~expected:"z-index:10" "z-index: 10";
   check_declaration ~expected:"z-index:-1" "z-index: -1";
   check_declaration ~expected:"z-index:9999" "z-index: 9999";
+  (* A calc that cannot const-fold (carries a var) is kept as a typed calc and
+     round-trips; an all-numeric calc still folds to an integer. *)
+  check_declaration ~expected:"z-index:calc(var(--z)*-1)"
+    "z-index: calc(var(--z) * -1)";
+  check_declaration ~expected:"z-index:10" "z-index: calc(5 * 2)";
 
   (* Cursor *)
   check_declaration ~expected:"cursor:auto" "cursor: auto";


### PR DESCRIPTION
`z_index`'s `Calc` constructor held a raw `string`, so a `z-index: calc(...)` that cannot const-fold (one carrying a `var()`, e.g. `calc(var(--x) * -1)`) could only be assembled by serializing the expression to a string. That is out of step with every other typed-calc property (`line_height`, `opacity`, `flex_basis`, `border_width`, `font_size`, `vertical_align`, ...) and forces callers into string assembly.

`Calc of string` becomes `Calc of z_index calc`. The reader already builds the typed expression (it only stringified it when a `var()` blocked const-folding), so the change is local to the type, the reader's fallback arm, and the printer. With the typed value, a `z-index` calc builds through the `Calc` API directly.

First of three: `order` and `grid_line` are the remaining `Calc of string` stragglers.