### PR TITLE
properties: carry a typed calc in order

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1882,7 +1882,7 @@ type opacity = Properties.opacity =
 
 type order = Properties.order =
   | Int of int
-  | Calc of string
+  | Calc of order calc
   | Inherit
   | Initial
   | Unset

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -5168,7 +5168,7 @@ let rec pp_zoom : zoom Pp.t =
 let rec pp_order : order Pp.t =
  fun ctx -> function
   | Int i -> Pp.int ctx i
-  | Calc s -> Pp.string ctx s
+  | Calc c -> pp_calc pp_order ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -11740,7 +11740,7 @@ let rec read_order t : order =
     match eval_numeric_calc expr with
     | Some f when Float.is_integer f -> (Int (int_of_float f) : order)
     | Some _ -> Cursor.err_invalid t "order calc must evaluate to integer"
-    | None -> (Calc (string_of_calc expr) : order)
+    | None -> (Calc expr : order)
   in
   let read_var t : order = Var (read_var read_order t) in
   Cursor.enum_or_calls "order"

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -217,7 +217,7 @@ type zoom =
 
 type order =
   | Int of int
-  | Calc of string
+  | Calc of order calc
   | Inherit
   | Initial
   | Unset

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -781,6 +781,14 @@ let public_value_combinator_edges () =
   Alcotest.(check string)
     "z-index calc builds via typed calc" ".z{z-index:calc(var(--layer))}"
     (to_string ~minify:true z_index_calc_sheet);
+  (* order carries a typed calc, so a var-based order calc builds through the
+     typed API rather than a raw string. *)
+  let order_calc_sheet =
+    v [ rule ~selector:(Selector.class_ "o") [ order (Calc (Calc.var "o")) ] ]
+  in
+  Alcotest.(check string)
+    "order calc builds via typed calc" ".o{order:calc(var(--o))}"
+    (to_string ~minify:true order_calc_sheet);
 
   let sheet =
     v

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -528,7 +528,13 @@ let flexbox_flex_and_basis () =
     "flex-basis: clamp(1px, var(--spacing), 100%)";
   check_declaration ~expected:"flex-basis:abs(var(--x))"
     "flex-basis: abs(var(--x))";
-  neg_cursor read_declaration "flex-basis: sign(var(--x))"
+  neg_cursor read_declaration "flex-basis: sign(var(--x))";
+  (* order: a calc carrying a var stays a typed calc and round-trips; an
+     all-numeric order calc folds to an integer. *)
+  check_declaration ~expected:"order:2" "order: 2";
+  check_declaration ~expected:"order:calc(var(--o)*-1)"
+    "order: calc(var(--o) * -1)";
+  check_declaration ~expected:"order:6" "order: calc(3 * 2)"
 
 let flexbox_alignment () =
   (* Align items *)


### PR DESCRIPTION
`order`'s `Calc` constructor held a raw `string`, the same shape `z-index` had. An `order: calc(...)` carrying a `var()` (e.g. `calc(var(--o) * -1)`) could only be assembled by serializing the expression.

`Calc of string` becomes `Calc of order calc`. The reader already builds the typed expression; the change is local to the type, the reader's fallback arm, and the printer.

Sibling of #90 (z-index); `grid_line` is the last `Calc of string`, and is a different shape (it carries `span N`, not a calc) so it needs separate treatment.