### PR TITLE
properties: accept math functions in flex-basis

### DIFF
--- a/lib/context.ml
+++ b/lib/context.ml
@@ -2032,9 +2032,11 @@ let simplify_opacity ?layer_order ?layer cascade value =
     | Properties.Opacity_number n -> Some n
     | _ -> None
   in
-  let simplify_leaf simplify _simplify_calc ~visited = function
-    | Properties.Abs value -> Properties.Abs (simplify ~visited value)
-    | Properties.Sign value -> Properties.Sign (simplify ~visited value)
+  let simplify_leaf simplify _simplify_calc ~visited (leaf : Properties.opacity)
+      : Properties.opacity =
+    match leaf with
+    | Abs value -> Abs (simplify ~visited value)
+    | Sign value -> Sign (simplify ~visited value)
     | value -> value
   in
   let ops : Properties.opacity Calc_residual.ops =

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3346,6 +3346,14 @@ type flex_basis = Properties.flex_basis =
   | Max_content
   | Min_content
   | From_font
+  | Clamp of length * length * length
+  | Min of length list
+  | Max of length list
+  | Round of string * length * length
+  | Mod of length * length
+  | Rem_fn of length * length
+  | Hypot of length list
+  | Abs of length
   | Calc of flex_basis calc
   | Var of flex_basis var  (** CSS flex shorthand values. *)
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -5241,11 +5241,13 @@ let rec read_opacity t : opacity =
         ("max", read_numeric_math);
         ("clamp", read_numeric_math);
         ( "abs",
-          fun t -> Cursor.call "abs" t (fun inner -> Abs (read_opacity inner))
-        );
+          fun t ->
+            Cursor.call "abs" t (fun inner ->
+                (Abs (read_opacity inner) : opacity)) );
         ( "sign",
-          fun t -> Cursor.call "sign" t (fun inner -> Sign (read_opacity inner))
-        );
+          fun t ->
+            Cursor.call "sign" t (fun inner ->
+                (Sign (read_opacity inner) : opacity)) );
       ]
     ~default:read_number_or_percentage t
 
@@ -10295,6 +10297,15 @@ let rec pp_flex_basis : flex_basis Pp.t =
   | Max_content -> Pp.string ctx "max-content"
   | Min_content -> Pp.string ctx "min-content"
   | From_font -> Pp.string ctx "from-font"
+  (* Math functions mirror [length]; reuse its printer. *)
+  | Clamp (a, b, c) -> pp_length ctx (Clamp (a, b, c))
+  | Min xs -> pp_length ctx (Min xs)
+  | Max xs -> pp_length ctx (Max xs)
+  | Round (s, a, b) -> pp_length ctx (Round (s, a, b))
+  | Mod (a, b) -> pp_length ctx (Mod (a, b))
+  | Rem_fn (a, b) -> pp_length ctx (Rem_fn (a, b))
+  | Hypot xs -> pp_length ctx (Hypot xs)
+  | Abs a -> pp_length ctx (Abs a)
   | Var v -> pp_var pp_flex_basis ctx v
   | Calc cv -> pp_calc pp_flex_basis ctx cv
 
@@ -11955,6 +11966,17 @@ let flex_basis_of_length t (length : length) : flex_basis =
   | Dimension { value = 0.; unit = "svmax"; _ } -> Svmax 0.
   | Dimension { value = 0.; unit = "ch"; _ } -> Ch 0.
   | Dimension { value = 0.; unit = "lh"; _ } -> Lh 0.
+  (* Math functions over <length-percentage> carry across unchanged:
+     [flex_basis] mirrors [length]'s constructors. [Sign] (a <number>) and
+     [Minmax] (grid only) are not valid here, so they stay rejected. *)
+  | Clamp (a, b, c) -> Clamp (a, b, c)
+  | Min xs -> Min xs
+  | Max xs -> Max xs
+  | Round (s, a, b) -> Round (s, a, b)
+  | Mod (a, b) -> Mod (a, b)
+  | Rem_fn (a, b) -> Rem_fn (a, b)
+  | Hypot xs -> Hypot xs
+  | Abs a -> Abs a
   | _ -> Cursor.err_invalid t "unsupported flex-basis value"
 
 let rec read_flex_basis t : flex_basis =

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -586,6 +586,18 @@ type flex_basis =
   | Max_content
   | Min_content
   | From_font
+  (* Math functions over [<length-percentage>] (CSS Values 4 §10). Args reuse
+     [length] (which already carries [Pct]) and mirror the [length]
+     constructors; [flex_basis_of_length] carries them across and the printer
+     delegates to [pp_length]. *)
+  | Clamp of length * length * length
+  | Min of length list
+  | Max of length list
+  | Round of string * length * length
+  | Mod of length * length
+  | Rem_fn of length * length
+  | Hypot of length list
+  | Abs of length
   | Calc of flex_basis calc
   | Var of flex_basis var
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -519,7 +519,16 @@ let flexbox_flex_and_basis () =
      dimensionally neutral and unifies with any typed calc context), this is
      what the typed flex-basis Calc emitter has to round-trip to. *)
   check_declaration ~expected:"flex-basis:calc(var(--spacing)*4)"
-    "flex-basis: calc(var(--spacing) * 4)"
+    "flex-basis: calc(var(--spacing) * 4)";
+  (* Math functions over <length-percentage> are valid flex-basis values and
+     round-trip; sign() yields a <number> and is rejected. *)
+  check_declaration ~expected:"flex-basis:min(10px,100%)"
+    "flex-basis: min(10px, 100%)";
+  check_declaration ~expected:"flex-basis:clamp(1px,var(--spacing),100%)"
+    "flex-basis: clamp(1px, var(--spacing), 100%)";
+  check_declaration ~expected:"flex-basis:abs(var(--x))"
+    "flex-basis: abs(var(--x))";
+  neg_cursor read_declaration "flex-basis: sign(var(--x))"
 
 let flexbox_alignment () =
   (* Align items *)


### PR DESCRIPTION
`flex-basis` accepts `<length-percentage>`, which admits the CSS Values 4 math functions (`min`, `max`, `clamp`, `round`, `mod`, `rem`, `hypot`, `abs`). But `flex_basis_of_length` only enumerated scalar dimensions and rejected everything else, so `flex-basis: min(10px, 100%)` (no `var()` even needed) failed to parse.

The type-safe fix carries the length-percentage math forms across as typed `flex_basis` constructors, mirroring the `length` type and reusing `length` for their args. `flex_basis_of_length` maps them through and the printer delegates to `pp_length`. `sign()` (a `<number>`) and `minmax()` (grid only) are not length-percentages, so they stay correctly rejected. Two `opacity` sites needed explicit disambiguation because these constructor names are shared across `length`/`opacity`/`flex_basis`.

An escape hatch (`Length of length`) was rejected as unsound: `length` carries keywords like `thick`/`normal`/`stretch` that are invalid for `flex-basis`, so it would make invalid values representable.