### PR TITLE
properties: carry a typed calc in grid-line

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3830,7 +3830,7 @@ type grid_line = Properties.grid_line =
   | Span of int  (** span 2, span 3, etc. *)
   | Span_name of string  (** span <custom-ident> *)
   | Span_num_name of int * string  (** span <integer> <custom-ident> *)
-  | Calc of string  (** calc(12 * -1), etc. *)
+  | Calc of grid_line calc  (** calc(12 * -1), etc. *)
   | Var of grid_line var
 
 type grid_line_pair = Properties.grid_line_pair =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -6463,7 +6463,7 @@ let rec pp_grid_line : grid_line Pp.t =
       Pp.int ctx n;
       Pp.char ctx ' ';
       Pp.string ctx name
-  | Calc s -> Pp.string ctx s
+  | Calc c -> pp_calc pp_grid_line ctx c
   | Var v -> pp_var pp_grid_line ctx v
 
 let rec pp_grid_line_pair : grid_line_pair Pp.t =
@@ -11647,62 +11647,6 @@ let rec read_baseline_shift t : baseline_shift =
       Shift (Values.read_length_percentage ~with_keywords:false t))
     t
 
-let string_of_calc_const = function
-  | Pi -> "pi"
-  | E -> "e"
-  | Infinity -> "infinity"
-  | Neg_infinity -> "-infinity"
-  | Nan -> "NaN"
-
-let string_of_calc_op (op : calc_op) =
-  match op with Add -> " + " | Sub -> " - " | Mul -> " * " | Div -> " / "
-
-let add_string_of_calc_var : type a. (string -> unit) -> a var -> unit =
- fun add v ->
-  add "var(--";
-  add v.Values.name;
-  (match v.Values.fallback with
-  | Fallback _ | Syntax_fallback _ -> add ", <fallback>"
-  | Var_fallback name ->
-      add ", var(--";
-      add name;
-      add ")"
-  | Empty -> add ","
-  | Empty2 -> add ",  "
-  | None -> ());
-  add ")"
-
-let string_of_calc (type a) (expr : a calc) : string =
-  let buf = Buffer.create 32 in
-  let add = Buffer.add_string buf in
-  let rec pp_expr : type a. a calc -> unit = function
-    | Num n ->
-        if Float.is_integer n then add (string_of_int (int_of_float n))
-        else add (string_of_float n)
-    | Math_const c -> add (string_of_calc_const c)
-    | Sibling_index -> add "sibling-index()"
-    | Sibling_count -> add "sibling-count()"
-    | Var v -> add_string_of_calc_var add v
-    | Val _ -> add "<val>"
-    | Math_fn _ -> add "<math-fn>"
-    | Nested inner ->
-        add "calc(";
-        pp_expr inner;
-        add ")"
-    | Parens inner ->
-        add "(";
-        pp_expr inner;
-        add ")"
-    | Expr (left, op, right) ->
-        pp_expr left;
-        add (string_of_calc_op op);
-        pp_expr right
-  in
-  add "calc(";
-  pp_expr expr;
-  add ")";
-  Buffer.contents buf
-
 let rec read_z_index t : z_index =
   let read_calc_z t =
     (* read_calc handles the calc(...) wrapper itself *)
@@ -12299,7 +12243,7 @@ let read_grid_line_calc t : grid_line =
   match eval_numeric_calc expr with
   | Some f when Float.is_integer f -> Num (int_of_float f)
   | Some _ -> Cursor.err_invalid t "grid-line calc must evaluate to integer"
-  | None -> Calc (string_of_calc expr)
+  | None -> Calc expr
 
 let rec read_grid_line t : grid_line =
   Cursor.enum_or_calls "grid-line"

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -807,7 +807,7 @@ type grid_line =
   | Span of int
   | Span_name of string
   | Span_num_name of int * string
-  | Calc of string
+  | Calc of grid_line calc
   | Var of grid_line var
 
 type grid_line_pair =

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -789,6 +789,19 @@ let public_value_combinator_edges () =
   Alcotest.(check string)
     "order calc builds via typed calc" ".o{order:calc(var(--o))}"
     (to_string ~minify:true order_calc_sheet);
+  (* grid-line carries a typed calc, so col-start-[calc(...)] and similar
+     arbitraries build through the typed API rather than a raw string. *)
+  let grid_line_calc_sheet =
+    v
+      [
+        rule ~selector:(Selector.class_ "g")
+          [ grid_column_start (Calc (Calc.var "n")) ];
+      ]
+  in
+  Alcotest.(check string)
+    "grid-line calc builds via typed calc"
+    ".g{grid-column-start:calc(var(--n))}"
+    (to_string ~minify:true grid_line_calc_sheet);
 
   let sheet =
     v

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -765,6 +765,11 @@ let grid () =
   check_declaration ~expected:"grid-row-end:3" "grid-row-end: 3";
   check_declaration ~expected:"grid-column-start:1" "grid-column-start: 1";
   check_declaration ~expected:"grid-column-end:-1" "grid-column-end: -1";
+  (* A grid-line calc carrying a var is kept as a typed calc and round-trips; an
+     all-numeric grid-line calc folds to an integer. *)
+  check_declaration ~expected:"grid-column-start:calc(var(--n)*-1)"
+    "grid-column-start: calc(var(--n) * -1)";
+  check_declaration ~expected:"grid-column-end:6" "grid-column-end: calc(3 * 2)";
 
   (* Grid auto flow *)
   check_declaration ~expected:"grid-auto-flow:row" "grid-auto-flow: row";


### PR DESCRIPTION
`grid_line` was the last property whose `Calc` constructor held a raw `string`, so arbitrary grid placements (`col-start-[calc(...)]`, `col-end-[...]`, `col-span-[...]`) carrying a `var()` could only be assembled by serializing the expression.

`Calc of string` becomes `Calc of grid_line calc`, matching `z-index` (#90) and `order` (#91). The reader already builds the typed expression. With `z-index`/`order`/`grid-line` all converted, nothing uses `string_of_calc` any more, so that dead serializer (and its three helpers) is removed.

Completes the `Calc of string` elimination.