### PR TITLE
optimize: add opt-in prune of unused custom properties

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -852,9 +852,9 @@ let inline_style_of_declarations ?(optimize = false) ?minify ?mode declarations
   inline_style_of_declarations ?minify ?mode declarations
 
 let optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
-    stylesheet =
+    ?prune_unused_custom_props stylesheet =
   Optimize.stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec
-    ?aggressive stylesheet
+    ?aggressive ?prune_unused_custom_props stylesheet
 
 let flatten_nesting = Optimize.flatten_nesting
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7508,6 +7508,7 @@ val optimize :
   ?lossless:bool ->
   ?enforce_spec:bool ->
   ?aggressive:bool ->
+  ?prune_unused_custom_props:bool ->
   t ->
   t
 (** [optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
@@ -7532,7 +7533,12 @@ val optimize :
     When [aggressive] is [true] (default [false]) the global factoring fixpoint
     runs even when the preflight predicts low gain, and the top-level
     statement-optimisation pipeline iterates until the AST reaches a structural
-    fixpoint (capped at a small bound). *)
+    fixpoint (capped at a small bound).
+
+    When [prune_unused_custom_props] is [true] (default [false]) custom-property
+    bindings referenced by no [var()] anywhere are dropped. Opt-in: it assumes a
+    complete stylesheet with no out-of-band reader (another stylesheet, or
+    [getComputedStyle]), the same closed-world assumption as {!inline_vars}. *)
 
 val flatten_nesting : t -> t
 (** [flatten_nesting stylesheet] returns the stylesheet with every nested rule

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -1188,8 +1188,89 @@ let canonicalize_custom_prop_position (stmts : statement list) : statement list
     =
   canonicalize_custom_prop_blocks (count_custom_prop_decls stmts) stmts
 
+(* Bare names of every custom property referenced through a [var()] anywhere in
+   the tree. Scans the serialized declarations, so it sees references inside
+   opaque custom-property values too and over-keeps (a [var(] inside a string
+   counts) - it must never miss a live reference, or the prune below would drop
+   a binding still in use. *)
+let referenced_custom_props (stmts : statement list) : (string, unit) Hashtbl.t
+    =
+  let tbl = Hashtbl.create 64 in
+  let ident_char c =
+    (c >= 'a' && c <= 'z')
+    || (c >= 'A' && c <= 'Z')
+    || (c >= '0' && c <= '9')
+    || c = '-' || c = '_'
+  in
+  let scan s =
+    let n = String.length s in
+    let i = ref 0 in
+    while !i + 4 <= n do
+      if
+        s.[!i] = 'v' && s.[!i + 1] = 'a' && s.[!i + 2] = 'r' && s.[!i + 3] = '('
+      then (
+        let j = ref (!i + 4) in
+        while !j < n && s.[!j] = ' ' do
+          incr j
+        done;
+        if !j + 2 <= n && s.[!j] = '-' && s.[!j + 1] = '-' then (
+          let k = ref (!j + 2) in
+          while !k < n && ident_char s.[!k] do
+            incr k
+          done;
+          if !k > !j + 2 then
+            Hashtbl.replace tbl (String.sub s (!j + 2) (!k - (!j + 2))) ());
+        i := !i + 4)
+      else incr i
+    done
+  in
+  let note_decls =
+    List.iter (fun d -> scan (Declaration.string_of_declaration ~minify:true d))
+  in
+  let rec walk stmt =
+    match stmt with
+    | Rule r ->
+        note_decls r.declarations;
+        List.iter walk r.nested
+    | Declarations decls -> note_decls decls
+    | _ -> iter_statement_block walk stmt
+  in
+  List.iter walk stmts;
+  tbl
+
+(* Drop custom-property bindings referenced by no [var()] - a dead binding has
+   no rendering effect (an emptied rule is removed at serialization). Caller
+   opt-in only: the no-runtime-reader, complete-stylesheet assumption is theirs,
+   like [Inline.vars]. *)
+let drop_unused_custom_props (stmts : statement list) : statement list =
+  let referenced = referenced_custom_props stmts in
+  let bare name =
+    if String.length name >= 2 && name.[0] = '-' && name.[1] = '-' then
+      String.sub name 2 (String.length name - 2)
+    else name
+  in
+  let keep_decl d =
+    match Variables.custom_declaration_name d with
+    | Some name -> Hashtbl.mem referenced (bare name)
+    | None -> true
+  in
+  let rec prune stmt =
+    match stmt with
+    | Rule r ->
+        let declarations = list_filter_preserve keep_decl r.declarations in
+        let nested = list_map_preserve prune r.nested in
+        if declarations == r.declarations && nested == r.nested then stmt
+        else Rule { r with declarations; nested }
+    | Declarations decls ->
+        let decls' = list_filter_preserve keep_decl decls in
+        if decls' == decls then stmt else Declarations decls'
+    | _ -> map_statement_block_preserve prune stmt
+  in
+  list_map_preserve prune stmts
+
 let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
-    ?(enforce_spec = false) ?(aggressive = false) (stylesheet : t) : t =
+    ?(enforce_spec = false) ?(aggressive = false)
+    ?(prune_unused_custom_props = false) (stylesheet : t) : t =
   Selector_summary.clear_memo ();
   reset_counters ();
   let scope = Option.value scope ~default:`Fragment in
@@ -1206,4 +1287,6 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
     run_pipeline ~ctx ~enforce_spec ~aggressive stylesheet
   in
   let strict = run ~extend_lists:false in
-  race_extend_lists ~run ~strict stylesheet |> canonicalize_custom_prop_position
+  race_extend_lists ~run ~strict stylesheet
+  |> canonicalize_custom_prop_position
+  |> if prune_unused_custom_props then drop_unused_custom_props else Fun.id

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -156,6 +156,7 @@ val stylesheet :
   ?lossless:bool ->
   ?enforce_spec:bool ->
   ?aggressive:bool ->
+  ?prune_unused_custom_props:bool ->
   t ->
   t
 (** [stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec ss] optimizes an
@@ -179,7 +180,13 @@ val stylesheet :
     When [enforce_spec] is [false] (default) the optimizer may treat baseline
     feature queries as known facts and elide [@supports] guards whose condition
     is satisfied in maintained evergreen browsers; [true] keeps every feature
-    query and applies only CSS-text-and-spec-provable rewrites. *)
+    query and applies only CSS-text-and-spec-provable rewrites.
+
+    When [prune_unused_custom_props] is [true] (default [false]) custom-property
+    bindings referenced by no [var()] anywhere are dropped. This is opt-in
+    because it assumes a complete stylesheet with no out-of-band reader (another
+    stylesheet, or [getComputedStyle]) - the same closed-world assumption as
+    {!inline_vars}. *)
 
 val flatten_nesting : t -> t
 (** [flatten_nesting ss] returns [ss] with every nested rule flattened into a

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -774,12 +774,46 @@ let test_optimize_preserves_physical_identity () =
         true (again == canon))
     cases
 
+let test_prune_unused_custom_props () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok p -> p.stylesheet
+    | Error _ -> Alcotest.fail "parse"
+  in
+  let opt ?(prune = false) css =
+    parse css
+    |> Css.optimize ~prune_unused_custom_props:prune
+    |> Css.to_string ~minify:true
+  in
+  let dead = ":root{--spacing:.25rem}.top-0{top:0}" in
+  Alcotest.(check string)
+    "default keeps an unreferenced binding"
+    ":root{--spacing:.25rem}.top-0{top:0}" (opt dead);
+  Alcotest.(check string)
+    "opt-in drops an unreferenced binding" ".top-0{top:0}"
+    (opt ~prune:true dead);
+  Alcotest.(check string)
+    "opt-in keeps a referenced binding"
+    ":root{--spacing:.25rem}.gap{gap:var(--spacing)}"
+    (opt ~prune:true ":root{--spacing:.25rem}.gap{gap:var(--spacing)}");
+  (* A [var()] inside an opaque custom-property value still counts, so the
+     binding it depends on is not pruned. *)
+  Alcotest.(check bool)
+    "opt-in keeps a binding referenced only inside an opaque value" true
+    (Astring.String.is_infix ~affix:"--spacing"
+       (opt ~prune:true
+          ":root{--spacing:.25rem;--shadow:0 0 \
+           var(--spacing)}.x{box-shadow:var(--shadow)}"))
+
 let optimize_tests =
   [
     ( "optimize preserves physical identity on a fixed point",
       `Quick,
       test_optimize_preserves_physical_identity );
     ("deduplicate declarations", `Quick, test_deduplicate_declarations);
+    ( "opt-in prune unused custom properties",
+      `Quick,
+      test_prune_unused_custom_props );
     ( "deduplicate declarations preserves physical identity",
       `Quick,
       test_deduplicate_declarations_physical_identity );


### PR DESCRIPTION
`Css.optimize` (and `Optimize.stylesheet`) gain `?prune_unused_custom_props` (default `false`). When set, custom-property bindings referenced by no `var()` anywhere are dropped; an emptied rule is removed at serialization.

It's opt-in because cascade deliberately preserves custom properties by default: `Css_compare` treats opaque custom-property token streams as distinct, and the closed-world spec fixtures (`optimize ~scope:`Stylesheet`) expect bindings preserved. Gating on an explicit flag (not on scope) leaves every existing caller and the diff comparator untouched. The opt-in carries the same closed-world / no-out-of-band-reader assumption as `inline_vars`.

The reference scan reads serialized declarations, so it counts `var()` occurrences inside opaque custom-property values too (and a `var(` inside a string), over-keeping rather than ever over-pruning a live binding.