### PR TITLE
diff: expose prune-unused-custom-props through Css_compare and CLI

### DIFF
--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -17,7 +17,7 @@ let resolve_style_renderer style_renderer =
   | Some s when s <> "" -> Some `None
   | _ -> style_renderer
 
-let run_diff mode ~lossless ~css1 ~css2 =
+let run_diff mode ~lossless ~prune_unused_custom_props ~css1 ~css2 =
   let mode =
     match mode with
     | Auto -> `Auto
@@ -25,7 +25,8 @@ let run_diff mode ~lossless ~css1 ~css2 =
     | String -> `String
     | Canonical -> `Canonical
   in
-  Cascade_diff.Css_compare.diff ~mode ~lossless css1 css2
+  Cascade_diff.Css_compare.diff ~mode ~lossless ~prune_unused_custom_props css1
+    css2
 
 let print_diff_report ~file1 ~file2 ~css1 ~css2 result =
   let stats =
@@ -38,7 +39,9 @@ let print_diff_report ~file1 ~file2 ~css1 ~css2 result =
   Buffer.add_char buf '\n';
   print_string (Buffer.contents buf)
 
-let compare_files file1 file2 style_renderer mode lossless memtrace_path () =
+type semantic_opts = { lossless : bool; prune_unused_custom_props : bool }
+
+let compare_files file1 file2 style_renderer mode opts memtrace_path () =
   Cli_io.start_memtrace memtrace_path;
   Fmt_tty.setup_std_outputs
     ?style_renderer:(resolve_style_renderer style_renderer)
@@ -49,7 +52,11 @@ let compare_files file1 file2 style_renderer mode lossless memtrace_path () =
         Fmt.pr "CSS files are identical@.";
         Ok ())
       else
-        let result = run_diff mode ~lossless ~css1 ~css2 in
+        let result =
+          run_diff mode ~lossless:opts.lossless
+            ~prune_unused_custom_props:opts.prune_unused_custom_props ~css1
+            ~css2
+        in
         match result.Cascade_diff.Css_compare.result with
         | No_diff _ ->
             (* Equal ASTs can still hide parse-dropped declarations; show the
@@ -102,6 +109,16 @@ let lossless_arg =
   in
   Arg.(value & flag & info [ "lossless" ] ~doc)
 
+let prune_unused_custom_props_arg =
+  let doc =
+    "Drop custom-property bindings referenced by nothing on both sides before \
+     comparing in $(b,--diff=semantic), so two stylesheets that differ only by \
+     a dead binding compare equal. Makes the comparison blind to \
+     dead-custom-property divergences (a render-no-op); enable only when that \
+     difference is immaterial. Has no effect outside $(b,--diff=semantic)."
+  in
+  Arg.(value & flag & info [ "prune-unused-custom-props" ] ~doc)
+
 let memtrace_arg =
   let doc =
     "Write a Memtrace allocation profile to $(docv) covering the diff run. \
@@ -114,9 +131,14 @@ let term =
   let style_renderer_with_env =
     Fmt_cli.style_renderer ~env:(Cmd.Env.info "CASCADE_COLOR") ()
   in
+  let semantic_opts =
+    const (fun lossless prune_unused_custom_props ->
+        { lossless; prune_unused_custom_props })
+    $ lossless_arg $ prune_unused_custom_props_arg
+  in
   term_result
     (const compare_files $ file1_arg $ file2_arg $ style_renderer_with_env
-   $ mode_arg $ lossless_arg $ memtrace_arg $ Cli_log.term)
+   $ mode_arg $ semantic_opts $ memtrace_arg $ Cli_log.term)
 
 let man =
   [

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -222,18 +222,20 @@ let css_for_semantic_comparison ?property css =
   | None -> css
   | Some property -> ":root{" ^ property ^ ":" ^ css ^ "}"
 
-let canonical_semantic_css ~strict ~lossless css =
+let canonical_semantic_css ~strict ~lossless
+    ?(prune_unused_custom_props = false) css =
   match Css.of_string ~strict css with
   | Ok { stylesheet; _ } -> (
       try
         Some
-          (stylesheet |> Css.optimize ~lossless
+          (stylesheet
+          |> Css.optimize ~lossless ~prune_unused_custom_props
           |> Css.to_string ~minify:true ~lossless)
       with Invalid_argument _ -> None)
   | Error _ -> None
 
-let canonical_css ~strict ~lossless css =
-  canonical_semantic_css ~strict ~lossless css
+let canonical_css ~strict ~lossless ?(prune_unused_custom_props = false) css =
+  canonical_semantic_css ~strict ~lossless ~prune_unused_custom_props css
 
 let canonical_pair ~strict ~lossless expected actual =
   match
@@ -244,18 +246,25 @@ let canonical_pair ~strict ~lossless expected actual =
       Some (String.equal expected_norm actual_norm)
   | _ -> None
 
-let canonical_diff_inputs ~strict ~lossless expected actual =
+let canonical_diff_inputs ~strict ~lossless ?(prune_unused_custom_props = false)
+    expected actual =
   match
-    ( canonical_css ~strict ~lossless expected,
-      canonical_css ~strict ~lossless actual )
+    ( canonical_css ~strict ~lossless ~prune_unused_custom_props expected,
+      canonical_css ~strict ~lossless ~prune_unused_custom_props actual )
   with
   | Some expected, Some actual -> Some (expected, actual)
   | _ -> None
 
-let canonical_diff_inputs_with_fallback ~lossless expected actual =
-  match canonical_diff_inputs ~strict:true ~lossless expected actual with
+let canonical_diff_inputs_with_fallback ~lossless
+    ?(prune_unused_custom_props = false) expected actual =
+  match
+    canonical_diff_inputs ~strict:true ~lossless ~prune_unused_custom_props
+      expected actual
+  with
   | Some _ as result -> result
-  | None -> canonical_diff_inputs ~strict:false ~lossless expected actual
+  | None ->
+      canonical_diff_inputs ~strict:false ~lossless ~prune_unused_custom_props
+        expected actual
 
 (* Internal: full-stylesheet equality under the canonical minified form. *)
 let semantic_equal ?property ?(lossless = false) expected actual =
@@ -349,10 +358,14 @@ let diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
       else Tree_diff structural_diff
   | _ -> diff_auto ~expected ~actual ~expected_parse ~actual_parse
 
-let diff_canonical ~lossless ~expected ~actual ~expected_parse ~actual_parse =
+let diff_canonical ~lossless ~prune_unused_custom_props ~expected ~actual
+    ~expected_parse ~actual_parse =
   if expected = actual then No_diff { canonical_byte_diff = None }
   else
-    match canonical_diff_inputs_with_fallback ~lossless expected actual with
+    match
+      canonical_diff_inputs_with_fallback ~lossless ~prune_unused_custom_props
+        expected actual
+    with
     | None -> diff_auto ~expected ~actual ~expected_parse ~actual_parse
     | Some (expected_canon, actual_canon) ->
         if String.equal expected_canon actual_canon then
@@ -394,7 +407,8 @@ let parse_warnings = function
   | Ok { Css.warnings; _ } -> warnings
   | Error _ -> []
 
-let diff ?(mode = `Auto) ?(lossless = false) expected actual =
+let diff ?(mode = `Auto) ?(lossless = false)
+    ?(prune_unused_custom_props = false) expected actual =
   let expected = strip_tool_header expected in
   let actual = strip_tool_header actual in
   if expected = actual then
@@ -418,8 +432,8 @@ let diff ?(mode = `Auto) ?(lossless = false) expected actual =
           match mode with
           | `Auto -> diff_auto ~expected ~actual ~expected_parse ~actual_parse
           | `Canonical ->
-              diff_canonical ~lossless ~expected ~actual ~expected_parse
-                ~actual_parse
+              diff_canonical ~lossless ~prune_unused_custom_props ~expected
+                ~actual ~expected_parse ~actual_parse
           | `Tree -> diff_tree ~expected_parse ~actual_parse
         in
         {
@@ -428,8 +442,10 @@ let diff ?(mode = `Auto) ?(lossless = false) expected actual =
           actual_warnings = parse_warnings actual_parse;
         }
 
-let equal ?mode ?lossless a b =
-  match (diff ?mode ?lossless a b).result with No_diff _ -> true | _ -> false
+let equal ?mode ?lossless ?prune_unused_custom_props a b =
+  match (diff ?mode ?lossless ?prune_unused_custom_props a b).result with
+  | No_diff _ -> true
+  | _ -> false
 
 let as_tree_diff t =
   match t.result with

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -64,13 +64,32 @@ type mode = [ `Auto | `Tree | `String | `Canonical ]
       color positions. If the normalized forms differ, the returned diff is
       reported from those normalized outputs. *)
 
-val diff : ?mode:mode -> ?lossless:bool -> string -> string -> t
+val diff :
+  ?mode:mode ->
+  ?lossless:bool ->
+  ?prune_unused_custom_props:bool ->
+  string ->
+  string ->
+  t
 (** [diff ?mode expected actual] returns the diff between two CSS strings. A
     leading [/*! ... */] tool banner on either side is stripped before
     comparison. Parsing failures surface as [_error] variants. [lossless]
-    preserves exact color channels during canonical comparison. *)
+    preserves exact color channels during canonical comparison.
 
-val equal : ?mode:mode -> ?lossless:bool -> string -> string -> bool
+    [prune_unused_custom_props] (default [false], [`Canonical] mode only) drops
+    custom-property bindings referenced by nothing on both sides before
+    comparing, so two stylesheets that differ only by a dead binding compare
+    equal. Opt-in: it makes the comparator blind to dead-custom-property
+    divergences, so enable it only when that render-no-op difference is
+    immaterial (e.g. a parity harness against output that omits the binding). *)
+
+val equal :
+  ?mode:mode ->
+  ?lossless:bool ->
+  ?prune_unused_custom_props:bool ->
+  string ->
+  string ->
+  bool
 (** [equal ?mode a b] is [true] iff [diff ?mode a b] is {!No_diff}. *)
 
 val as_tree_diff : t -> Tree_diff.t option

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -33,6 +33,23 @@ let equal_empty () =
     "empty strings equal" true
     (Cascade_diff.Css_compare.equal "" "")
 
+let equal_prune_unused_custom_props () =
+  let with_bind = ":root{--spacing:.25rem}.top-0{top:0}" in
+  let without = ".top-0{top:0}" in
+  Alcotest.(check bool)
+    "default: a dead binding is a real difference" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical with_bind without);
+  Alcotest.(check bool)
+    "opt-in: a dead binding compares equal" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ~prune_unused_custom_props:true with_bind without);
+  Alcotest.(check bool)
+    "opt-in: a referenced binding still differs" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ~prune_unused_custom_props:true
+       ":root{--spacing:.25rem}.gap{gap:var(--spacing)}"
+       ".gap{gap:var(--spacing)}")
+
 let equal_whitespace_difference () =
   (* Structurally same but different formatting - default mode does not collapse
      formatting, so this returns false. *)
@@ -1029,4 +1046,6 @@ let suite =
       Alcotest.test_case "as_tree_diff with tree" `Quick as_tree_diff_with_tree;
       Alcotest.test_case "as_tree_diff with no diff" `Quick as_tree_diff_no_diff;
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
+      Alcotest.test_case "opt-in prune-unused-custom-props" `Quick
+        equal_prune_unused_custom_props;
     ] )


### PR DESCRIPTION
Follow-up to #94. `Css.optimize` gained `?prune_unused_custom_props`, but every parity consumer goes through `Css_compare.diff ~mode:Canonical` or `cascade diff --diff=semantic`, neither of which exposed it — so the knob was unreachable from the comparators.

Thread it through `Css_compare.diff` / `equal` (it only affects the `Canonical` path, where optimize runs) and add a `cascade diff --prune-unused-custom-props` CLI flag. Both default to `false`, so the default strict comparison is unchanged: a dead custom-property binding stays a real difference. A caller opts in when that render-no-op difference is immaterial (e.g. a parity harness comparing against output that omits the binding).

Note this is deliberately narrow: enabling it makes the comparator blind only to *dead* (unreferenced) custom-property divergences, not the broad closed-world equivalences (partial shorthand synthesis, etc.) that a `Canonical`-scope flip would have switched on.