### PR TITLE
variables: recognise var() in opaque values structurally

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -969,44 +969,12 @@ let bare_theme_name raw_name =
     String.sub raw_name 2 (String.length raw_name - 2)
   else raw_name
 
-let is_theme_var_call value i =
-  i + 4 <= String.length value && String.sub value i 4 = "var("
-
-let rec skip_theme_var_space value i =
-  if i < String.length value && (value.[i] = ' ' || value.[i] = '\t') then
-    skip_theme_var_space value (i + 1)
-  else i
-
-let is_theme_var_name_start value i =
-  i + 1 < String.length value && value.[i] = '-' && value.[i + 1] = '-'
-
-let theme_var_name_end value start =
-  let n = String.length value in
-  let rec loop i =
-    if i >= n then i
-    else match value.[i] with ',' | ')' | ' ' | '\t' -> i | _ -> loop (i + 1)
-  in
-  loop start
-
-(* The [var()] references nested anywhere inside a default value (e.g. [calc(1px
-   + var(--foo))]), so resolving one default pulls its targets into the inject
-   set, and [Inline.vars]' recursive substitution chains them. Scan the value
-   text for [var(--name)] starts; a custom-property value is an opaque token
-   stream, so the AST var collector does not see inside it. *)
-let var_names_in_theme_value value =
-  let n = String.length value in
-  let names = ref [] in
-  let i = ref 0 in
-  while !i + 4 <= n do
-    if is_theme_var_call value !i then (
-      let j = skip_theme_var_space value (!i + 4) in
-      (if is_theme_var_name_start value j then
-         let k = theme_var_name_end value j in
-         names := String.sub value j (k - j) :: !names);
-      i := !i + 4)
-    else incr i
-  done;
-  !names
+(* [var()] references nested anywhere inside a value, so resolving one theme
+   default pulls its targets into the inject set and [Inline.vars]' recursive
+   substitution chains them. A custom-property value is an opaque token stream,
+   so the typed AST var collector does not see inside it; recognise references
+   structurally (see {!Variables.var_refs_in_value_string}). *)
+let var_names_in_theme_value = Variables.var_refs_in_value_string
 
 let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
   let resolved : (string, string) Hashtbl.t = Hashtbl.create 16 in

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -1196,36 +1196,17 @@ let canonicalize_custom_prop_position (stmts : statement list) : statement list
 let referenced_custom_props (stmts : statement list) : (string, unit) Hashtbl.t
     =
   let tbl = Hashtbl.create 64 in
-  let ident_char c =
-    (c >= 'a' && c <= 'z')
-    || (c >= 'A' && c <= 'Z')
-    || (c >= '0' && c <= '9')
-    || c = '-' || c = '_'
-  in
-  let scan s =
-    let n = String.length s in
-    let i = ref 0 in
-    while !i + 4 <= n do
-      if
-        s.[!i] = 'v' && s.[!i + 1] = 'a' && s.[!i + 2] = 'r' && s.[!i + 3] = '('
-      then (
-        let j = ref (!i + 4) in
-        while !j < n && s.[!j] = ' ' do
-          incr j
-        done;
-        if !j + 2 <= n && s.[!j] = '-' && s.[!j + 1] = '-' then (
-          let k = ref (!j + 2) in
-          while !k < n && ident_char s.[!k] do
-            incr k
-          done;
-          if !k > !j + 2 then
-            Hashtbl.replace tbl (String.sub s (!j + 2) (!k - (!j + 2))) ());
-        i := !i + 4)
-      else incr i
-    done
+  let bare n =
+    if String.length n >= 2 && n.[0] = '-' && n.[1] = '-' then
+      String.sub n 2 (String.length n - 2)
+    else n
   in
   let note_decls =
-    List.iter (fun d -> scan (Declaration.string_of_declaration ~minify:true d))
+    List.iter (fun d ->
+        List.iter
+          (fun n -> Hashtbl.replace tbl (bare n) ())
+          (Variables.var_refs_in_value_string
+             (Declaration.string_of_declaration ~minify:true d)))
   in
   let rec walk stmt =
     match stmt with

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -27,6 +27,46 @@ let custom_value_var_empty_fallback name =
 
 let string_of_custom_value = Parser.to_string_custom
 
+(* The first dashed-ident argument of a [var()] is the referenced custom
+   property; leading whitespace is skipped. *)
+let rec first_var_ref_ident = function
+  | [] -> Option.None
+  | Component.Preserved { Token.kind = Token.Ident n; _ } :: _
+    when String.length n >= 2 && n.[0] = '-' && n.[1] = '-' ->
+      Option.Some n
+  | _ :: rest -> first_var_ref_ident rest
+
+(* Custom-property names referenced through a real [var()] function anywhere in
+   a component stream, recursing into function arguments and bracketed blocks. A
+   [var(] inside a string or url is an atomic [Preserved] token, never a [Func],
+   so it is correctly ignored - the false positive a text scan would produce. *)
+let rec var_refs_in_components acc (components : Component.t list) =
+  List.fold_left
+    (fun acc (c : Component.t) ->
+      match c with
+      | Component.Func { node = { name; arguments; _ }; _ } ->
+          let acc =
+            if String.lowercase_ascii name = "var" then
+              match first_var_ref_ident arguments with
+              | Option.Some n -> n :: acc
+              | Option.None -> acc
+            else acc
+          in
+          var_refs_in_components acc arguments
+      | Component.Block { node = { value; _ }; _ } ->
+          var_refs_in_components acc value
+      | Component.Preserved _ -> acc)
+    acc components
+
+let var_refs_in_value_string value =
+  let p = Parser.of_string value in
+  let rec collect acc =
+    match Parser.next p with
+    | Component.Preserved { Token.kind = Token.Eof; _ } -> List.rev acc
+    | c -> collect (c :: acc)
+  in
+  var_refs_in_components [] (collect [])
+
 (** Pretty-print a syntax descriptor to CSS syntax string *)
 let rec pp_syntax_inner : type a. a syntax Pp.t =
  fun ctx syn ->

--- a/lib/variables.mli
+++ b/lib/variables.mli
@@ -18,6 +18,13 @@ val custom_value_var_empty_fallback : string -> custom_value
 val string_of_custom_value : custom_value -> string
 (** [string_of_custom_value value] serializes a custom-property token stream. *)
 
+val var_refs_in_value_string : string -> string list
+(** [var_refs_in_value_string value] is the [--name]s referenced through a real
+    [var()] function anywhere in [value] (including nested in [calc()] and
+    inside opaque custom-property streams). It parses [value] to components and
+    walks them, so a [var(] inside a string or [url()] is recognised as data,
+    not a reference - unlike a textual scan. *)
+
 val pp_syntax : 'a syntax Pp.t
 (** [pp_syntax] pretty-prints a syntax descriptor to a CSS syntax string. *)
 

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -803,7 +803,14 @@ let test_prune_unused_custom_props () =
     (Astring.String.is_infix ~affix:"--spacing"
        (opt ~prune:true
           ":root{--spacing:.25rem;--shadow:0 0 \
-           var(--spacing)}.x{box-shadow:var(--shadow)}"))
+           var(--spacing)}.x{box-shadow:var(--shadow)}"));
+  (* A [var()] inside a string literal is data, not a reference (recognised
+     structurally, not by text), so a binding referenced only there is
+     pruned. *)
+  Alcotest.(check string)
+    "opt-in: a var() inside a string is not a reference"
+    ":root{--x:\"var(--y)\"}.a{width:var(--x)}"
+    (opt ~prune:true ".a{width:var(--x)}:root{--x:\"var(--y)\";--y:1px}")
 
 let optimize_tests =
   [


### PR DESCRIPTION
`var()` references inside opaque custom-property values were located by byte-scanning the serialised text — in `resolve_theme`'s transitive theme-default emit and in the unused-binding prune. A text scan matches the substring `var(` even inside a string or `url()` token, where CSS performs no substitution, so it reports phantom references.

A custom-property value is already stored as a structured `Component.t list`, and the component model distinguishes a `Func` node from an atomic `Preserved` string/url token. So `var()` can be recognised *precisely* — exactly the way colours and numbers are already typed inside those streams. This replaces both byte scanners with one shared walk, `Variables.var_refs_in_value_string`, that parses to components and recurses `Func` arguments and `Block` values, collecting real `var()` references and ignoring strings/urls.

Net effect: a `var(--y)` written inside a string literal (`--x: "var(--y)"`) is correctly treated as data, not a reference — so e.g. the prune no longer keeps a binding alive on the strength of a string. Two ad-hoc text scanners are deleted in favour of the typed walk.