### PR TITLE
values: fold calc() that scales a typed angle by a number

### DIFF
--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3809,6 +3809,84 @@ let normalize_duration ?(ctx = default_calc_ctx) (d : duration) : duration =
       match eval_calc ~ctx c with Val v -> v | folded -> Calc folded)
   | _ -> d
 
+(* CSS Values 4 §10.7: a typed [<angle>] multiplied or divided by a unitless
+   number scales the angle's coefficient and keeps its unit, so [calc(1deg *
+   -45)] reduces to [-45deg]. Division folds only when the quotient is [exact]
+   (see [exact_div]); dividing by a math constant ([pi] / ...) is irrational, so
+   it rounds like the matching multiplication. *)
+let angle_scale ?(exact = true) op (a : angle) n : angle option =
+  if not (Float.is_finite n) then Option.none
+  else
+    let scaled rebuild v =
+      match op with
+      | Mul ->
+          let r = v *. n in
+          if Float.is_finite r then Option.some (rebuild r) else Option.none
+      | Div ->
+          if exact then Option.map rebuild (exact_div v n)
+          else if n = 0. then Option.none
+          else
+            let r = v /. n in
+            if Float.is_finite r then Option.some (rebuild r) else Option.none
+      | Add | Sub -> Option.none
+    in
+    match a with
+    | Deg v -> scaled (fun x -> Deg x) v
+    | Rad v -> scaled (fun x -> Rad x) v
+    | Turn v -> scaled (fun x -> Turn x) v
+    | Grad v -> scaled (fun x -> Grad x) v
+    | _ -> Option.none
+
+(* The generic [eval_calc] only folds [<number>] arithmetic; angles also reduce
+   when scaled by a number ([calc(<angle> * <number>)]). Mirrors
+   [eval_length_calc] for the scale cases and otherwise keeps the generic
+   structure so non-scale forms behave exactly as before. *)
+let rec eval_angle_calc : ?ctx:calc_ctx -> angle calc -> angle calc =
+ fun ?(ctx = default_calc_ctx) calc ->
+  match calc with
+  | (Num _ | Val _ | Var _ | Sibling_index | Sibling_count) as leaf -> leaf
+  | Math_const _ as leaf -> leaf
+  | Math_fn fn when math_fn_contains_var fn -> Math_fn fn
+  | Math_fn fn -> (
+      match eval_math_fn fn with Some v -> Num v | None -> Math_fn fn)
+  | Nested inner ->
+      unwrap_grouping ~ctx
+        ~rewrap:(fun r -> Nested r)
+        (eval_angle_calc ~ctx inner)
+  | Parens inner ->
+      unwrap_grouping ~ctx
+        ~rewrap:(fun r -> Parens r)
+        (eval_angle_calc ~ctx inner)
+  | Expr (l, op, r) -> (
+      let l = eval_angle_calc ~ctx l in
+      let r = eval_angle_calc ~ctx r in
+      let lc = calc_operand_value l in
+      let rc = calc_operand_value r in
+      match (lc, op, rc) with
+      | Num a, Add, Num b -> Num (a +. b)
+      | Num a, Sub, Num b -> Num (a -. b)
+      | Num a, Mul, Num b -> Num (a *. b)
+      | Num a, Div, Num b -> (
+          match exact_div a b with Some q -> Num q | None -> Expr (l, op, r))
+      | Val a, ((Mul | Div) as op), Num n -> (
+          let exact = match r with Math_const _ -> false | _ -> true in
+          match angle_scale ~exact op a n with
+          | Some v -> Val v
+          | None -> Expr (l, op, r))
+      | Num n, Mul, Val a -> (
+          match angle_scale Mul a n with
+          | Some v -> Val v
+          | None -> Expr (l, op, r))
+      | _ -> (
+          match
+            calc_identity ~zero:(Num 0.) ~is_zero:(fun _ -> false) l op r
+          with
+          | Some folded -> folded
+          | None -> (
+              match fold_zero_numeric_expr lc op rc with
+              | Some zero -> zero
+              | None -> Expr (l, op, r))))
+
 (* Canonicalise an [<angle>]: fold the static math functions ([round] / [mod] /
    [rem] on [deg] operands), then pick the shortest of the
    losslessly-interconvertible spellings (deg / turn / grad). [rad] goes through
@@ -3854,7 +3932,9 @@ let normalize_angle ?(ctx = default_calc_ctx) =
         | Deg x, Deg y when y <> 0. -> shortest (Deg (Float.rem x y))
         | x, y -> Rem (x, y))
     | Calc c -> (
-        match eval_calc ~ctx c with Val v -> go v | folded -> Calc folded)
+        match eval_angle_calc ~ctx c with
+        | Val v -> go v
+        | folded -> Calc folded)
     | Deg _ | Turn _ | Grad _ -> shortest a
     | Rad _ | Var _ | Invalid _ -> a
   in

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -437,6 +437,34 @@ let test_angle () =
   decl_optimizes ~prop:"rotate" ~held:"-200grad" ~into:"-180deg" "-200grad";
   decl_optimizes ~prop:"rotate" ~held:"-360deg" ~into:"-1turn" "-360deg";
 
+  (* CSS Values 4 §10.7: scaling a typed <angle> by a unitless number folds to a
+     concrete angle (then picks the shortest unit), so calc(1deg * -45) ->
+     -45deg matches what the browser computes. Both operand orders fold. *)
+  decl_optimizes ~prop:"rotate" ~held:"calc(1deg*-45)" ~into:"-45deg"
+    "calc(1deg * -45)";
+  decl_optimizes ~prop:"rotate" ~held:"calc(45deg*2)" ~into:"90deg"
+    "calc(45deg * 2)";
+  decl_optimizes ~prop:"rotate" ~held:"calc(-45*1deg)" ~into:"-45deg"
+    "calc(-45 * 1deg)";
+  decl_optimizes ~prop:"rotate" ~held:"calc(1turn*.5)" ~into:".5turn"
+    "calc(1turn * 0.5)";
+  (* Division folds only when the quotient is exact: 90/2 reduces, 45/7 keeps
+     the calc() so no precision is lost. *)
+  decl_optimizes ~prop:"rotate" ~held:"calc(90deg/2)" ~into:"45deg"
+    "calc(90deg / 2)";
+  decl_optimizes ~prop:"rotate" ~held:"calc(45deg/7)" ~into:"calc(45deg/7)"
+    "calc(45deg / 7)";
+  (* A var() operand is a runtime substitution boundary and stays unfolded; only
+     the static 45deg*2 sub-expression reduces. *)
+  decl_optimizes ~prop:"rotate" ~held:"calc(var(--x)*1deg)"
+    ~into:"calc(var(--x)*1deg)" "calc(var(--x) * 1deg)";
+  decl_optimizes ~prop:"rotate" ~held:"calc(45deg*2*var(--x))"
+    ~into:"calc(90deg*var(--x))" "calc(45deg * 2 * var(--x))";
+  (* Out of scope: combining two angles (add/sub) is a different operation and
+     stays unfolded. *)
+  decl_optimizes ~prop:"rotate" ~held:"calc(45deg + 45deg)"
+    ~into:"calc(45deg + 45deg)" "calc(45deg + 45deg)";
+
   (* Var with angle fallback *)
   check_angle ~expected:"var(--custom-angle,45deg)" "var(--custom-angle, 45deg)";
 


### PR DESCRIPTION
`normalize_angle` reduced an angle `calc()` through the generic `eval_calc`, which only folds `<number>` arithmetic, so `calc(1deg * -45)` was kept verbatim where the browser computes `-45deg`. The cascade CLI and any library caller left the expression unfolded, missing a safe size win.

Scaling a typed `<angle>` by a unitless number is exact, so an angle-aware evaluator now folds it, mirroring the existing length path; division stays gated on an exact quotient (`calc(45deg / 7)` is preserved) and `var()` operands stay unfolded.