### PR TITLE
properties: normalize -webkit-mask-image gradients

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20765,6 +20765,7 @@ let normalize_property_value : type a.
   | Background_image ->
       map_preserve (normalize_background_image ~lossless) value
   | Mask_image -> normalize_background_image ~lossless value
+  | Webkit_mask_image -> normalize_background_image ~lossless value
   | Border_image_source -> normalize_background_image ~lossless value
   | Background -> map_preserve (normalize_background ~lossless) value
   | Mask -> normalize_mask ~lossless value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -145,7 +145,12 @@ let vendor_prefixes () =
   check_declaration ~expected:"-webkit-print-color-adjust:exact"
     "-webkit-print-color-adjust: exact;";
   check_declaration ~expected:"-webkit-mask-image:linear-gradient(red,blue)"
-    "-webkit-mask-image: linear-gradient(red, blue);"
+    "-webkit-mask-image: linear-gradient(red, blue);";
+  (* -webkit-mask-image normalizes like mask-image: its gradient angle and
+     colours fold under optimize (200grad -> 180deg, the default direction, is
+     dropped; blue -> #00f). *)
+  decl_optimizes ~prop:"-webkit-mask-image" ~into:"linear-gradient(red,#00f)"
+    "linear-gradient(200grad, red, blue)"
 
 let multiple () =
   (* Basic multiple declarations *)


### PR DESCRIPTION
`-webkit-mask-image` carries the same `Background_image` value as `mask-image` and parses its gradient identically, but it was missing from the optimize dispatch, so the gradient was printed back verbatim - the angle and colours never folded (`mask-image` and `background` did). Routing it through `normalize_background_image` closes the gap, so a mask gradient minifies the same whether or not it is vendor-prefixed.