### PR TITLE
optimize: promote registered angle and time custom properties

### DIFF
--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -658,6 +658,8 @@ let try_promote_custom_with (type a) (syntax : a Variables.syntax) components =
       Properties.try_read_custom_length_percentage components
   | Variables.Number -> Properties.try_read_custom_number components
   | Variables.Percentage -> Properties.try_read_custom_percentage components
+  | Variables.Angle -> Properties.try_read_custom_angle components
+  | Variables.Time -> Properties.try_read_custom_time components
   | _ -> None
 
 (* Does the registered syntax somewhere accept a [<custom-ident>] (possibly

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20357,6 +20357,12 @@ let try_read_custom_number components =
 let try_read_custom_percentage components =
   read_custom_value_as Percentage read_percentage components
 
+let try_read_custom_angle components =
+  read_custom_value_as Angle read_angle_unit_required components
+
+let try_read_custom_time components =
+  read_custom_value_as Duration read_duration components
+
 let pp_number_value ctx (value : number) =
   let pp_rounded f = Pp.float ctx (Pp.round_sig 6 f) in
   match value with
@@ -20994,6 +21000,8 @@ let normalize_custom_property_value ?(lossless = false)
         }
   | Typed { kind = Angle; value } ->
       Typed { kind = Angle; value = Values.normalize_angle ~ctx value }
+  | Typed { kind = Duration; value } ->
+      Typed { kind = Duration; value = Values.normalize_duration ~ctx value }
   | Typed { kind = Gradient_direction; value } ->
       Typed
         {

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -79,6 +79,12 @@ val try_read_custom_number : custom_value -> custom_property_value option
 val try_read_custom_percentage : custom_value -> custom_property_value option
 (** [try_read_custom_percentage tokens] parses [tokens] as a [<percentage>]. *)
 
+val try_read_custom_angle : custom_value -> custom_property_value option
+(** [try_read_custom_angle tokens] parses [tokens] as an [<angle>]. *)
+
+val try_read_custom_time : custom_value -> custom_property_value option
+(** [try_read_custom_time tokens] parses [tokens] as a [<time>]. *)
+
 val components_of_custom_property_value :
   custom_property_value -> Component.t list
 (** [components_of_custom_property_value value] returns the component stream

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5975,6 +5975,28 @@ let customprops13_registered_negative_dimension_calc () =
        "@property --tw-tracking { syntax: \"<length>\"; inherits: false; \
         initial-value: 0px } .x { --tw-tracking: calc(.05em * -1) }")
 
+let customprops13_registered_angle_time_calc () =
+  (* Registered <angle>/<time> custom properties fold their calc() like
+     <length>/<percentage>; unregistered ones stay opaque token streams. *)
+  Alcotest.(check string)
+    "unregistered angle calc custom property keeps token stream"
+    ".x{--tw-rotate:calc(1deg*0)}"
+    (normalize_minified ".x { --tw-rotate: calc(1deg * 0) }");
+  Alcotest.(check string)
+    "registered angle custom property reduces to an angle"
+    "@property \
+     --tw-rotate{syntax:\"<angle>\";inherits:false;initial-value:0deg}.x{--tw-rotate:0deg}"
+    (normalize_minified
+       "@property --tw-rotate { syntax: \"<angle>\"; inherits: false; \
+        initial-value: 0deg } .x { --tw-rotate: calc(1deg * 0) }");
+  Alcotest.(check string)
+    "registered time custom property reduces to a duration"
+    "@property \
+     --tw-delay{syntax:\"<time>\";inherits:false;initial-value:0s}.x{--tw-delay:2s}"
+    (normalize_minified
+       "@property --tw-delay { syntax: \"<time>\"; inherits: false; \
+        initial-value: 0s } .x { --tw-delay: calc(1s * 2) }")
+
 let customprops13_shortest_unresolved_calc_spacing () =
   Alcotest.(check string)
     "unregistered unresolved calc custom property keeps token stream"
@@ -6910,6 +6932,9 @@ let additional_tests =
     ( "spec custom-properties 1 3 registered negative dimension calc",
       `Quick,
       customprops13_registered_negative_dimension_calc );
+    ( "spec custom-properties 1 3 registered angle and time calc",
+      `Quick,
+      customprops13_registered_angle_time_calc );
     ( "spec custom-properties 1 3 unregistered unresolved calc spacing",
       `Quick,
       customprops13_shortest_unresolved_calc_spacing );


### PR DESCRIPTION
A registered custom-property value is promoted to a typed value (so its `calc()` folds) only for `<color>`, `<length>`, `<length-percentage>`, `<number>`, and `<percentage>`. `<angle>` and `<time>` fell through to an opaque `Tokens` stream, so `@property --x { syntax: "<angle>" }; --x: calc(1deg * 0)` stayed verbatim even though `normalize_angle` already knows how to reduce it (and the registered `<length>`/`<percentage>` cases already fold).

Adding the two promotion arms (plus the missing `<time>` normalize case) closes the gap, so a registered `<angle>` or `<time>` custom property folds its `calc()` like the others: `calc(1deg * 0)` -> `0deg`, `calc(1s * 2)` -> `2s`. Unregistered custom properties stay opaque, unchanged.

Follow-up to #100.