### PR TITLE
properties: fold angle/time calc in opaque custom properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,12 @@ custom-property value stays an opaque token stream, with one exception: a
 substream whose type is fixed by its own syntax. A complete colour function
 (`oklab(...)`, `color-mix(...)`, `rgb(...)`, ...) or a hex colour (`#abc`) is
 unconditionally a colour in every `var()` substitution site, so it folds to its
-shortest spelling and the fold preserves every rendered result. The fold never
-produces a bare colour keyword: a name like `red` is also a valid
+shortest spelling and the fold preserves every rendered result. The same holds
+for a complete math function whose units fix its dimension unambiguously: a
+constant `calc()` reducing to an `<angle>` or `<time>` (`calc(1deg * 0)` ->
+`0deg`) folds, while a `<percentage>` (ambiguous: length vs number percentage)
+or a `calc()` that still references a `var()` stays verbatim. The colour fold
+never produces a bare colour keyword: a name like `red` is also a valid
 `<custom-ident>`, so it stays distinct from `#f00` even though it is shorter,
 and hex stays hex. The fold changes the exact token string a script reads back
 via `getPropertyValue`; cascade does not treat that byte-exact CSSOM
@@ -316,8 +320,9 @@ frameworks.
 - **Comments and source positions** are not preserved across the
   parser/printer round trip.
 - **Unregistered custom properties** stay opaque token streams to the
-  optimizer, apart from complete colour functions inside them, which fold to
-  their shortest spelling.
+  optimizer, apart from substreams whose type their own syntax fixes
+  unambiguously (complete colour functions, and constant math functions
+  reducing to an `<angle>` or `<time>`), which fold to their shortest spelling.
 
 ## Using cascade as a library
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20260,11 +20260,13 @@ let fold_custom_color ~lossless (c : Component.t) ~fallback =
   | _ -> fallback ()
 
 (* A math function ([calc()], [min()], [clamp()], ...) is unconditionally a math
-   expression, so when its operands are all constants it reduces to a single
-   <number> with the same value in every [var()] substitution site - fold it
-   inside an opaque custom-property stream like a complete colour. A function
-   that still references a var or carries units does not reduce to a [Num] and
-   stays verbatim. *)
+   expression whose type is fixed by its operands' units, so when it reduces to
+   a single constant it has that value in every [var()] substitution site - fold
+   it inside an opaque custom-property stream like a complete colour. [<number>]
+   and the unit-unambiguous dimensions ([<angle>] / [<time>]) qualify;
+   [<percentage>] is ambiguous (length vs number percentage) so it stays
+   verbatim, as does a function that still references a [var()] (it does not
+   reduce to a leaf). *)
 let is_math_function name =
   match String.lowercase_ascii name with
   | "calc" | "min" | "max" | "clamp" | "round" | "mod" | "rem" | "abs" | "sign"
@@ -20274,19 +20276,51 @@ let is_math_function name =
 
 let fold_custom_calc (c : Component.t) ~fallback =
   let text = Parser.to_string_custom [ c ] in
-  let cur = Cursor.of_string text in
+  (* Parse the whole token as one typed value and fold only when it reduces to a
+     single concrete leaf (not a [calc()] that still carries a [var()]). *)
+  let try_typed : type a.
+      (Cursor.t -> a) ->
+      (a -> a) ->
+      a Pp.t ->
+      (a -> bool) ->
+      Component.t list option =
+   fun reader normalize pp reduced ->
+    let cur = Cursor.of_string text in
+    match try Some (reader cur) with Cursor.Parse_error _ -> None with
+    | Some v when Cursor.is_done cur ->
+        let folded = normalize v in
+        if reduced folded then
+          match
+            read_custom_property_value
+              (Cursor.of_string (Pp.to_string ~minify:true pp folded))
+          with
+          | Tokens cs -> Some cs
+          | Typed _ -> None
+        else None
+    | _ -> None
+  in
+  let number_reduced = function (Num _ : number) -> true | _ -> false in
+  let angle_reduced = function
+    | (Deg _ | Rad _ | Turn _ | Grad _ : angle) -> true
+    | _ -> false
+  in
+  let time_reduced = function (S _ | Ms _ : duration) -> true | _ -> false in
   match
-    try Some (Values.read_number cur) with Cursor.Parse_error _ -> None
+    List.find_map Fun.id
+      [
+        try_typed read_number
+          (fun n -> normalize_number n)
+          pp_number number_reduced;
+        try_typed read_angle_unit_required
+          (fun a -> normalize_angle a)
+          pp_angle angle_reduced;
+        try_typed read_duration
+          (fun d -> normalize_duration d)
+          pp_duration time_reduced;
+      ]
   with
-  | Some n when Cursor.is_done cur -> (
-      match Values.normalize_number n with
-      | Num _ as folded -> (
-          let canon = Pp.to_string ~minify:true Values.pp_number folded in
-          match read_custom_property_value (Cursor.of_string canon) with
-          | Tokens cs -> cs
-          | Typed _ -> [ c ])
-      | _ -> fallback ())
-  | _ -> fallback ()
+  | Some cs -> cs
+  | None -> fallback ()
 
 let rec canonicalize_custom_colors_components ~lossless comps =
   let fold_color c ~fallback = fold_custom_color ~lossless c ~fallback in

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1077,10 +1077,13 @@ let test_custom_value_close_paren_whitespace () =
     "optimize folds whitespace after a function close (canonical)"
     "a{--x:drop-shadow(0 0 0)drop-shadow(1px 1px)}"
     (minify_str "a{--x:drop-shadow(0 0 0) drop-shadow(1px 1px)}");
+  (* A [var()]-carrying calc does not reduce to a leaf, so it stays a function
+     and exercises the whitespace-after-[)] fold (a fully-constant angle calc
+     instead folds to a dimension - see the custom-property folding tests). *)
   Alcotest.(check string)
     "optimize folds whitespace after calc() before an ident"
-    "a{--x:calc(45deg*-1)in oklab}"
-    (minify_str "a{--x:calc(45deg * -1) in oklab}");
+    "a{--x:calc(45deg*var(--n))in oklab}"
+    (minify_str "a{--x:calc(45deg * var(--n)) in oklab}");
   (* A [var()] substitutes a token stream textually, so dropping the whitespace
      after it could merge the substituted values ([1px2px]); it stays. *)
   Alcotest.(check string)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5976,12 +5976,19 @@ let customprops13_registered_negative_dimension_calc () =
         initial-value: 0px } .x { --tw-tracking: calc(.05em * -1) }")
 
 let customprops13_registered_angle_time_calc () =
-  (* Registered <angle>/<time> custom properties fold their calc() like
-     <length>/<percentage>; unregistered ones stay opaque token streams. *)
+  (* <angle>/<time> custom properties fold their calc() whether or not they are
+     registered: the unit unambiguously fixes the type, so a complete math
+     function reduces to its dimension in every var() site (like a complete
+     colour). The registered path uses the typed kind; the unregistered path
+     folds the opaque substream. *)
   Alcotest.(check string)
-    "unregistered angle calc custom property keeps token stream"
-    ".x{--tw-rotate:calc(1deg*0)}"
+    "unregistered angle calc custom property folds to an angle"
+    ".x{--tw-rotate:0deg}"
     (normalize_minified ".x { --tw-rotate: calc(1deg * 0) }");
+  Alcotest.(check string)
+    "unregistered time calc custom property folds to a duration"
+    ".x{--tw-delay:2s}"
+    (normalize_minified ".x { --tw-delay: calc(1s * 2) }");
   Alcotest.(check string)
     "registered angle custom property reduces to an angle"
     "@property \
@@ -5995,7 +6002,13 @@ let customprops13_registered_angle_time_calc () =
      --tw-delay{syntax:\"<time>\";inherits:false;initial-value:0s}.x{--tw-delay:2s}"
     (normalize_minified
        "@property --tw-delay { syntax: \"<time>\"; inherits: false; \
-        initial-value: 0s } .x { --tw-delay: calc(1s * 2) }")
+        initial-value: 0s } .x { --tw-delay: calc(1s * 2) }");
+  (* A percentage is ambiguous (length vs number percentage) so an unregistered
+     percentage calc stays an opaque token stream. *)
+  Alcotest.(check string)
+    "unregistered percentage calc custom property stays opaque"
+    ".x{--a:calc(50%*2)}"
+    (normalize_minified ".x { --a: calc(50% * 2) }")
 
 let customprops13_shortest_unresolved_calc_spacing () =
   Alcotest.(check string)


### PR DESCRIPTION
`fold_custom_calc` used to fold only a constant `<number>` calc inside an unregistered custom property; now it also folds a constant `calc()` whose units fix it unambiguously as an `<angle>` or `<time>`.

The README already treats a substream whose type its own syntax fixes as foldable inside an opaque custom-property stream (a complete colour function or a hex colour). A constant `calc(1deg * 0)` is the same case: it is an `<angle>` in every `var()` substitution site, so it folds to `0deg` whether or not the property is `@property`-registered. A `<percentage>` stays verbatim (ambiguous between length and number percentage), as does a `calc()` that still references a `var()`.

Follow-up to #103.