### PR TITLE
properties: collapse a zero border-width to 0

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -20782,10 +20782,21 @@ let normalize_vertical_align (va : vertical_align) : vertical_align =
       match Values.eval_calc c with Values.Val v -> v | folded -> Calc folded)
   | _ -> va
 
+(* A zero-valued border-width unit ([0px], [0em]) is the bare length [0]
+   ([border-width: 0] = [border-width: 0px]); collapse it to [Zero] like every
+   other zero length ([width: 0px] -> [0]), which [<length>]-valued properties
+   already do via [normalize_length]. *)
+let border_width_is_zero (bw : border_width) =
+  match length_of_border_width bw with
+  | Some l -> (
+      match Values.normalize_length l with Values.Zero -> true | _ -> false)
+  | None -> false
+
 let normalize_border_width (bw : border_width) : border_width =
   match bw with
   | Calc c -> (
       match Values.eval_calc c with Values.Val v -> v | folded -> Calc folded)
+  | _ when border_width_is_zero bw -> Zero
   | _ -> bw
 
 let normalize_property_value : type a.
@@ -20988,6 +20999,7 @@ let normalize_property_value : type a.
   | Opacity -> normalize_opacity value
   | Line_height -> normalize_line_height value
   | Vertical_align -> normalize_vertical_align value
+  | Border_width -> map_preserve normalize_border_width value
   | Border_top_width -> normalize_border_width value
   | Border_right_width -> normalize_border_width value
   | Border_bottom_width -> normalize_border_width value

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1757,6 +1757,16 @@ let test_border_width () =
   check_border_width "thick";
   check_border_width "2px";
   check_border_width ".0625rem";
+  (* A zero-valued border-width collapses the unit like any other zero length
+     (border-width: 0px -> 0), matching width/outline-width. Holds for the
+     longhand, the logical longhand, and the 1-4 value shorthand; non-zero
+     values keep their unit. *)
+  decl_optimizes ~prop:"border-width" ~held:"0px" ~into:"0" "0px";
+  decl_optimizes ~prop:"border-right-width" ~held:"0px" ~into:"0" "0px";
+  decl_optimizes ~prop:"border-inline-start-width" ~held:"0px" ~into:"0" "0px";
+  decl_optimizes ~prop:"border-width" ~held:"0px 1px 0 2rem"
+    ~into:"0 1px 0 2rem" "0px 1px 0 2rem";
+  decl_optimizes ~prop:"border-width" ~held:"2px" ~into:"2px" "2px";
   neg_cursor read_border_width "invalid-width";
   neg_cursor read_border_width "-2px";
   (* negative width *)


### PR DESCRIPTION
`border-width: 0px` used to stay `0px`; now it collapses to `0` like every other zero length.

The border-width longhands and the 1-4 value shorthand normalize through `normalize_border_width`, which only folded `calc()`, so a zero-valued unit was left untouched even though `width` and `outline-width` already collapse `0px` to `0` via `normalize_length`. A zero border width now strips its unit the same way, while the shorthand keeps non-zero values (`0px 1px` becomes `0 1px`).