### PR TITLE
css: add minify_smallest for compression-aware variant selection

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -856,6 +856,25 @@ let optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
   Optimize.stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec
     ?aggressive ?prune_unused_custom_props stylesheet
 
+let minify_smallest ~measure ?scope ?flatten_nesting ?lossless ?enforce_spec
+    ?prune_unused_custom_props stylesheet =
+  let minify s = to_string ~minify:true ?lossless ?enforce_spec s in
+  let opt aggressive =
+    optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ~aggressive
+      ?prune_unused_custom_props stylesheet
+  in
+  let s_aggressive = minify (opt true) in
+  let s_default = minify (opt false) in
+  let s_plain = minify stylesheet in
+  (* Most-optimised first, so a tie in [measure] keeps the smaller raw form. *)
+  List.fold_left
+    (fun (best_m, best_s) s ->
+      let m = measure s in
+      if m < best_m then (m, s) else (best_m, best_s))
+    (measure s_aggressive, s_aggressive)
+    [ s_default; s_plain ]
+  |> snd
+
 let flatten_nesting = Optimize.flatten_nesting
 
 (** {1 Closed-world inlining} *)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7541,6 +7541,29 @@ val optimize :
     complete stylesheet with no out-of-band reader (another stylesheet, or
     [getComputedStyle]), the same closed-world assumption as {!inline_vars}. *)
 
+val minify_smallest :
+  measure:(string -> int) ->
+  ?scope:Optimize.scope ->
+  ?flatten_nesting:bool ->
+  ?lossless:bool ->
+  ?enforce_spec:bool ->
+  ?prune_unused_custom_props:bool ->
+  t ->
+  string
+(** [minify_smallest ~measure stylesheet] serialises [stylesheet] minified at
+    three optimisation settings (unoptimised, {!optimize}d, and [~aggressive]ly
+    optimised) and returns the candidate for which [measure] is smallest.
+
+    [measure] is the caller's cost model. Pass [String.length] for the fewest
+    raw bytes, in which case the most-optimised candidate wins. Pass a
+    compressor's output size (e.g. brotli) for the fewest bytes on the wire:
+    that can differ, because a structural rewrite that removes raw bytes can
+    still enlarge the compressed output. Merging near-identical rules fragments
+    the repetition a compressor already exploits, so the unoptimised candidate
+    sometimes compresses smallest. No compressor is linked into the library;
+    [measure] is supplied by the caller. The optional arguments pass through to
+    {!optimize}, and a tie keeps the more-optimised (smaller-raw) candidate. *)
+
 val flatten_nesting : t -> t
 (** [flatten_nesting stylesheet] returns the stylesheet with every nested rule
     flattened into a top-level rule (without running the rest of the

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -865,11 +865,33 @@ let test_var_color_functions_preserved () =
     "a none channel still folds (none computes to 0)" ".x{color:#000}"
     (opt ".x{color:rgb(none 0 0)}")
 
+let test_minify_smallest () =
+  let parsed : Css.t =
+    match Css.of_string ".a{color:red;color:blue}" with
+    | Ok { Css.stylesheet; _ } -> stylesheet
+    | Error _ -> Alcotest.fail "parse error"
+  in
+  let plain = Css.to_string ~minify:true parsed in
+  let optimised = Css.to_string ~minify:true (Css.optimize parsed) in
+  (* The optimiser drops the overridden [color:red], shrinking raw bytes. *)
+  Alcotest.(check bool)
+    "optimise shortens the raw form" true
+    (String.length optimised < String.length plain);
+  (* A size measure keeps the optimised candidate. *)
+  Alcotest.(check string)
+    "size measure keeps the optimised form" optimised
+    (Css.minify_smallest ~measure:String.length parsed);
+  (* A measure that prefers longer output makes it decline optimisation. *)
+  Alcotest.(check string)
+    "measure can decline optimisation" plain
+    (Css.minify_smallest ~measure:(fun s -> -String.length s) parsed)
+
 let optimize_tests =
   [
     ( "var() colour functions preserved",
       `Quick,
       test_var_color_functions_preserved );
+    ("minify smallest by measure", `Quick, test_minify_smallest);
     ( "optimize preserves physical identity on a fixed point",
       `Quick,
       test_optimize_preserves_physical_identity );


### PR DESCRIPTION
This PR adds `Css.minify_smallest`, which serialises a stylesheet at three optimisation settings (unoptimised, default, aggressive) and returns the one smallest under a caller-supplied `measure : string -> int`.

The optimiser scores rewrites by raw byte count, but a structural rewrite that removes raw bytes can enlarge the *compressed* output: merging near-identical rules fragments the repetition a compressor was already exploiting (an unpurged Tailwind build minifies a few percent smaller raw but over 20% larger under brotli). A caller optimising for the wire passes a compressor's output size as `measure` and gets the variant that compresses smallest, which can be the unoptimised one. The compressor stays out of the library; `measure` is supplied by the caller, matching the context-supplied evaluation the library uses elsewhere.

This is the library primitive; a `cascade fmt --minify --smallest` flag wiring `measure` to brotli/gzip is a follow-up.