### PR TITLE
factor: let --aggressive run the fixpoint to convergence

### DIFF
--- a/lib/factor.ml
+++ b/lib/factor.ml
@@ -1782,11 +1782,14 @@ let run ~ctx ~finalize (rules : Stylesheet.rule list) =
   then
     counters.factor_preflight_gain <-
       counters.factor_preflight_gain + Preflight.estimated_gain summary;
-  (* [--aggressive] forces the fixpoint regardless of the preflight estimate. *)
+  (* [--aggressive] forces the fixpoint regardless of the preflight estimate,
+     and disables the adaptive marginal-stall early-out so it runs to true
+     convergence even above [small_declaration_threshold]. *)
   if Preflight.useful summary || Ctx.aggressive ctx then
     let adaptive =
-      Preflight.declaration_count summary
-      > Preflight.small_declaration_threshold
+      (not (Ctx.aggressive ctx))
+      && Preflight.declaration_count summary
+         > Preflight.small_declaration_threshold
     in
     to_fixpoint ~adaptive ~ctx ~finalize 16 rules
   else begin


### PR DESCRIPTION
`--aggressive` bypassed the preflight skip but still derived `adaptive` from the declaration count, so above `small_declaration_threshold` the marginal-stall early-out could stop the fixpoint while rules were still changing. It now also clears `adaptive`, so `--aggressive` runs to convergence. The default path is unchanged.
