### PR TITLE
preflight: size the factoring gate in bytes, not declaration counts

### DIFF
--- a/lib/preflight.ml
+++ b/lib/preflight.ml
@@ -2,6 +2,10 @@ let small_declaration_threshold = 4_000
 let useful_gain_units = 2_048
 let useful_gain_ratio_ppm = 140_000
 
+(* Source size and both gains are tracked in approximate minified bytes so a few
+   repeated long declarations register their real weight, not just a count. *)
+let decl_size = Pp.size ~minify:true Declaration.pp_declaration
+
 type t = {
   mutable source_units : int;
   mutable rule_count : int;
@@ -13,7 +17,7 @@ type t = {
 type state = {
   summary : t;
   body_groups : (int list, int) Hashtbl.t;
-  declaration_counts : (int, int * int) Hashtbl.t;
+  declaration_counts : (int, int) Hashtbl.t;
 }
 
 let v () =
@@ -30,37 +34,38 @@ let v () =
     declaration_counts = Hashtbl.create 1024;
   }
 
-let record_declaration state decl =
+let record_declaration state decl size =
   let hash = Declaration.hash decl in
-  let count, _size_unit =
+  let seen =
     match Hashtbl.find_opt state.declaration_counts hash with
-    | Some entry -> entry
-    | None -> (0, 1)
+    | Some n -> n
+    | None -> 0
   in
-  if count > 0 then
+  if seen > 0 then
     state.summary.shared_declaration_gain <-
-      state.summary.shared_declaration_gain + 1;
-  Hashtbl.replace state.declaration_counts hash (count + 1, 1)
+      state.summary.shared_declaration_gain + size;
+  Hashtbl.replace state.declaration_counts hash (seen + 1)
 
-let record_identical_body state decls =
+let record_identical_body state ~body_size decls =
   let key = List.map Declaration.hash decls in
   match Hashtbl.find_opt state.body_groups key with
   | Some count ->
       state.summary.identical_body_gain <-
-        state.summary.identical_body_gain + max 0 (List.length decls);
+        state.summary.identical_body_gain + body_size;
       Hashtbl.replace state.body_groups key (count + 1)
   | None -> Hashtbl.add state.body_groups key 1
 
 let record_rule state (rule : Stylesheet.rule) =
   let decls = rule.Stylesheet_intf.declarations in
+  let sizes = List.map decl_size decls in
   let decl_count = List.length decls in
+  let body_size = List.fold_left ( + ) 0 sizes in
   state.summary.rule_count <- state.summary.rule_count + 1;
-  state.summary.source_units <-
-    state.summary.source_units + 8 + (16 * decl_count);
+  state.summary.source_units <- state.summary.source_units + 8 + body_size;
   state.summary.declaration_count <-
     state.summary.declaration_count + decl_count;
-  List.iter (record_declaration state) decls;
-  if decl_count > 0 then record_identical_body state decls
+  List.iter2 (record_declaration state) decls sizes;
+  if decl_count > 0 then record_identical_body state ~body_size decls
 
 let summarize rules =
   let state = v () in
@@ -69,7 +74,12 @@ let summarize rules =
 
 let declaration_count t = t.declaration_count
 let source_units t = t.source_units
-let estimated_gain t = t.identical_body_gain + (t.shared_declaration_gain / 32)
+
+(* Both gains are approximate minified bytes. Identical bodies merge with no
+   per-use overhead, so they count in full; a shared declaration factored into a
+   grouping rule realizes only a fraction of its duplicate bytes once the new
+   selector list is paid for, so discount it. *)
+let estimated_gain t = t.identical_body_gain + (t.shared_declaration_gain / 4)
 
 let useful t =
   t.declaration_count <= small_declaration_threshold


### PR DESCRIPTION
The opportunity gate counted duplicate *declarations*, so a few repeated long declarations weighed the same as short ones and fell under the threshold, skipping factoring on large inputs that would compress. Track source size and both gains in approximate minified bytes (the per-entry size slot was reserved but unused), and discount shared declarations by 4 instead of 32. The gate only decides whether the output-preserving fixpoint runs, so only the run/skip decision above `small_declaration_threshold` changes; output is unaffected.
