### PR TITLE
properties: parse two value forms from cssQuake's stylesheet

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -12609,13 +12609,14 @@ let rec read_aspect_ratio (t : Cursor.t) : aspect_ratio =
   in
   let read_auto t : aspect_ratio =
     match Cursor.peek_ident t with
-    | Some "auto" ->
+    | Some "auto" -> (
         Cursor.skip t;
-        Cursor.ws t;
-        if Cursor.is_done t then Auto
-        else
-          let w, h = read_ratio t in
-          Auto_ratio_calc (w, h)
+        (* [auto] may stand alone or be followed by a [<ratio>]. Only treat a
+           following number as a ratio so a trailing separator / whitespace
+           (e.g. [aspect-ratio: auto;]) resolves to plain [Auto]. *)
+        match Cursor.option read_ratio t with
+        | Some (w, h) -> Auto_ratio_calc (w, h)
+        | None -> Auto)
     | _ -> Cursor.err_expected t "auto"
   in
   Cursor.enum_or_var "aspect-ratio"
@@ -19527,7 +19528,10 @@ let rec read_transform_box (t : Cursor.t) : transform_box =
 
 module Background_shorthand = struct
   let read_image_item t =
-    let img = read_background_image t in
+    (* A single image per layer: commas in the [background] shorthand separate
+       layers, not images (that comma-list is the [background-image]
+       longhand). *)
+    let img = read_bg_image t in
     fun (bg : background_shorthand) ->
       if bg.image = None then { bg with image = Some img } else bg
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -81,6 +81,12 @@ let test_rule () =
 let test_stylesheet () =
   (* Test basic stylesheet parsing *)
   check_stylesheet ".btn{color:red}";
+  (* Regression (cssQuake): [aspect-ratio:auto] before a separator must keep the
+     declaration (the trailing token used to defeat the bare-auto path), and a
+     [background] shorthand layer holds a single image, so commas separate
+     layers rather than being swallowed as a [background-image] list. *)
+  check_stylesheet ".x{aspect-ratio:auto;color:red}";
+  check_stylesheet ".x{background:url(a.png),red}";
   (* pp holds the authored Named node; cross-folding blue -> #00f (hex at most
      as long as the name) is optimize. *)
   assert_minify_and_optimize "body{margin:0}.btn{color:blue}"


### PR DESCRIPTION
Two value parsers rejected spec-valid input and dropped the declaration. `aspect-ratio: auto` failed when a separator followed it, because `read_auto` committed to reading a ratio on any non-empty cursor; it now reads a ratio only when a number follows. A `background` shorthand layer read its image with the `background-image` longhand reader, whose comma-separated image list swallowed the layer separator and a trailing colour; a layer now reads a single image. Stylesheet-level regression tests added; the `quake.css` that surfaced these now round-trips with no warnings.
