### PR TITLE
examples: cascade as a cascade engine over a tree

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,35 @@
+# cascade examples
+
+These show cascade used as a renderer-agnostic **cascade engine**: selector
+matching plus specificity resolution projected onto a tree, rather than just
+parsing and printing CSS text.
+
+## `css-resolve`
+
+Projects a global stylesheet onto each node of a plain OCaml tree (no DOM):
+selector match + specificity cascade + last-wins gives every node its resolved
+declarations. Pure cascade, no extra dependencies.
+
+```
+dune exec examples/css-resolve/main.exe
+```
+
+## `css-inline`
+
+A mode where cascade takes an HTML page (plus an optional extra `.css`) and
+emits **fully resolved HTML**, with the matched declarations written into each
+element's `style=""` attribute (premailer / juice style). cascade is the
+cascade engine and also minifies each inline style; [lambdasoup][] only parses
+and serialises the HTML, since HTML is outside cascade's scope.
+
+```
+dune exec examples/css-inline/main.exe -- page.html [extra.css]
+```
+
+It inlines statically-matchable rules (type, class, id, attribute, descendant /
+child / sibling combinators, structural pseudo-classes). Rules that cannot be
+inlined (`:hover`, media queries, pseudo-elements) are left in the kept
+`<style>`. Author inline styles keep their priority. Inheritance and
+computed-value resolution (`var()` / `calc()`) are not expanded yet.
+
+[lambdasoup]: https://github.com/aantron/lambdasoup

--- a/examples/css-inline/dune
+++ b/examples/css-inline/dune
@@ -1,0 +1,5 @@
+(executable
+ (name main)
+ (flags
+  (:standard -w -a))
+ (libraries cascade lambdasoup))

--- a/examples/css-inline/main.ml
+++ b/examples/css-inline/main.ml
@@ -1,0 +1,174 @@
+(* cascade "inline" mode: HTML page + CSS -> fully resolved HTML. Parse HTML
+   (lambdasoup), run cascade's selector match + specificity cascade over every
+   element, and write the resolved declarations into style="". cascade is the
+   cascade engine; lambdasoup only does HTML parse/serialise. *)
+
+module Sel = Cascade.Selector
+module Sheet = Cascade.Stylesheet
+module Decl = Cascade.Declaration
+module Css = Cascade.Css
+
+(* ---------- selector matching over a lambdasoup element node ---------- *)
+let ci a b = String.lowercase_ascii a = String.lowercase_ascii b
+let words s = String.split_on_char ' ' s |> List.filter (( <> ) "")
+
+let contains hay needle =
+  let lh = String.length hay and ln = String.length needle in
+  if ln = 0 then true
+  else
+    let rec go i =
+      if i + ln > lh then false
+      else if String.sub hay i ln = needle then true
+      else go (i + 1)
+    in
+    go 0
+
+let starts s p =
+  String.length s >= String.length p && String.sub s 0 (String.length p) = p
+
+let ends s p =
+  let ls = String.length s and lp = String.length p in
+  ls >= lp && String.sub s (ls - lp) lp = p
+
+let attr_key : Sel.attr_name -> string = function
+  | Sel.Regular s -> s
+  | Sel.Data s -> "data-" ^ s
+  | Sel.Aria a -> Cascade.Aria.to_string a
+
+let attr_matches n name (m : Sel.attribute_match) =
+  match Soup.attribute (attr_key name) n with
+  | None -> false
+  | Some v -> (
+      match m with
+      | Sel.Presence -> true
+      | Sel.Exact s | Sel.Exact_quoted (s, _) -> v = s
+      | Sel.Whitespace_list s | Sel.Whitespace_list_quoted (s, _) ->
+          List.mem s (words v)
+      | Sel.Prefix s | Sel.Prefix_quoted (s, _) -> s <> "" && starts v s
+      | Sel.Suffix s | Sel.Suffix_quoted (s, _) -> s <> "" && ends v s
+      | Sel.Substring s | Sel.Substring_quoted (s, _) -> s <> "" && contains v s
+      | Sel.Hyphen_list s | Sel.Hyphen_list_quoted (s, _) ->
+          v = s || starts v (s ^ "-"))
+
+let child_elements p = Soup.children p |> Soup.elements |> Soup.to_list
+
+let preceding_siblings n =
+  match Soup.parent n with
+  | None -> []
+  | Some p ->
+      let rec before acc = function
+        | [] -> List.rev acc
+        | x :: _ when x == n -> List.rev acc
+        | x :: rest -> before (x :: acc) rest
+      in
+      before [] (child_elements p)
+
+let imm_pred n =
+  match List.rev (preceding_siblings n) with x :: _ -> Some x | [] -> None
+
+let is_first n = preceding_siblings n = []
+
+let is_last n =
+  match Soup.parent n with
+  | None -> true
+  | Some p -> (
+      match List.rev (child_elements p) with x :: _ -> x == n | [] -> true)
+
+let rec matches (sel : Sel.t) n : bool =
+  match sel with
+  | Sel.Universal _ -> true
+  | Sel.Element (_, name) -> ci (Soup.name n) name
+  | Sel.Class c -> List.mem c (Soup.classes n)
+  | Sel.Id i -> Soup.id n = Some i
+  | Sel.Attribute (_, name, m, _) -> attr_matches n name m
+  | Sel.Compound ps -> List.for_all (fun p -> matches p n) ps
+  | Sel.List ss | Sel.Is ss | Sel.Where ss ->
+      List.exists (fun s -> matches s n) ss
+  | Sel.Not ss -> not (List.exists (fun s -> matches s n) ss)
+  | Sel.Combined (left, comb, right) ->
+      matches right n && combinator left comb n
+  | Sel.Root -> Soup.parent n = None
+  | Sel.First_child -> is_first n
+  | Sel.Last_child -> is_last n
+  | Sel.Only_child -> is_first n && is_last n
+  | Sel.Empty -> child_elements n = []
+  | _ -> false (* dynamic pseudo / pseudo-elements: not statically inlinable *)
+
+and combinator left comb n =
+  match comb with
+  | Sel.Descendant ->
+      List.exists (matches left) (Soup.ancestors n |> Soup.to_list)
+  | Sel.Child -> (
+      match Soup.parent n with Some p -> matches left p | None -> false)
+  | Sel.Next_sibling -> (
+      match imm_pred n with Some s -> matches left s | None -> false)
+  | Sel.Subsequent_sibling -> List.exists (matches left) (preceding_siblings n)
+  | _ -> false
+
+(* ---------- the cascade ---------- *)
+let spec_key s = Sel.(s.ids, s.classes, s.elements)
+
+let upsert acc d =
+  let k = Decl.property_name d in
+  (k, d) :: List.remove_assoc k acc
+
+let parse_inline s =
+  match Css.of_string ("a{" ^ s ^ "}") with
+  | Ok p -> (
+      match Sheet.rules p.Css.stylesheet with
+      | r :: _ -> Sheet.declarations r
+      | [] -> [])
+  | Error _ -> []
+
+let resolved_style sheet n =
+  let matched =
+    Sheet.rules sheet
+    |> List.mapi (fun i r ->
+        let sel = Sheet.selector r in
+        if matches sel n then
+          Some (spec_key (Sel.specificity sel), i, Sheet.declarations r)
+        else None)
+    |> List.filter_map Fun.id
+    |> List.stable_sort (fun (s1, i1, _) (s2, i2, _) ->
+        match compare s1 s2 with 0 -> compare i1 i2 | c -> c)
+  in
+  let existing =
+    match Soup.attribute "style" n with Some s -> parse_inline s | None -> []
+  in
+  (* author inline style is highest priority, applied last *)
+  let final =
+    List.fold_left
+      (fun acc (_, _, ds) -> List.fold_left upsert acc ds)
+      [] matched
+    |> fun acc -> List.fold_left upsert acc existing
+  in
+  List.rev_map snd final
+
+(* ---------- driver ---------- *)
+let () =
+  let html = In_channel.with_open_bin Sys.argv.(1) In_channel.input_all in
+  let extra =
+    if Array.length Sys.argv > 2 then
+      In_channel.with_open_bin Sys.argv.(2) In_channel.input_all
+    else ""
+  in
+  let soup = Soup.parse html in
+  let page_css =
+    Soup.select "style" soup |> Soup.to_list |> List.concat_map Soup.texts
+    |> String.concat "\n"
+  in
+  let css = page_css ^ "\n" ^ extra in
+  let sheet =
+    match Css.of_string css with
+    | Ok p -> p.Css.stylesheet
+    | Error _ -> Sheet.empty
+  in
+  Soup.descendants soup |> Soup.elements
+  |> Soup.iter (fun n ->
+      match (ci (Soup.name n) "style", resolved_style sheet n) with
+      | true, _ | _, [] -> ()
+      | false, decls ->
+          Soup.set_attribute "style"
+            (Sheet.inline_style_of_declarations ~minify:true decls)
+            n);
+  print_string (Soup.to_string soup)

--- a/examples/css-resolve/dune
+++ b/examples/css-resolve/dune
@@ -1,0 +1,5 @@
+(executable
+ (name main)
+ (flags
+  (:standard -w -a))
+ (libraries cascade))

--- a/examples/css-resolve/main.ml
+++ b/examples/css-resolve/main.ml
@@ -1,0 +1,175 @@
+(* Project a global stylesheet onto each node of a foreign (non-DOM) tree:
+   selector match + specificity cascade -> the node's resolved declarations.
+   This is the browser's style-resolution stage, renderer-agnostic. *)
+
+module Sel = Cascade.Selector
+module Sheet = Cascade.Stylesheet
+module Decl = Cascade.Declaration
+module Css = Cascade.Css
+
+(* ---- a tiny tree that is NOT a DOM ---- *)
+type elt = {
+  name : string;
+  id : string option;
+  classes : string list;
+  attrs : (string * string) list;
+  kids : elt list;
+}
+
+let e ?id ?(cls = []) ?(attrs = []) ?(kids = []) name =
+  { name; id; classes = cls; attrs; kids }
+
+(* zipper: element + parent + index among siblings *)
+type loc = { self : elt; up : loc option; idx : int; sibs : elt list }
+
+let root e = { self = e; up = None; idx = 0; sibs = [ e ] }
+
+let kids_of l =
+  List.mapi
+    (fun i k -> { self = k; up = Some l; idx = i; sibs = l.self.kids })
+    l.self.kids
+
+let rec ancestors l = match l.up with None -> [] | Some p -> p :: ancestors p
+
+let sib_loc l j =
+  { self = List.nth l.sibs j; up = l.up; idx = j; sibs = l.sibs }
+
+let preceding l = List.init l.idx (fun j -> sib_loc l j)
+let imm_pred l = if l.idx > 0 then Some (sib_loc l (l.idx - 1)) else None
+let ci a b = String.lowercase_ascii a = String.lowercase_ascii b
+let words s = String.split_on_char ' ' s |> List.filter (( <> ) "")
+
+let contains hay needle =
+  let lh = String.length hay and ln = String.length needle in
+  if ln = 0 then true
+  else
+    let rec go i =
+      if i + ln > lh then false
+      else if String.sub hay i ln = needle then true
+      else go (i + 1)
+    in
+    go 0
+
+let starts s p =
+  String.length s >= String.length p && String.sub s 0 (String.length p) = p
+
+let ends s p =
+  let ls = String.length s and lp = String.length p in
+  ls >= lp && String.sub s (ls - lp) lp = p
+
+let attr_key : Sel.attr_name -> string = function
+  | Sel.Regular s -> s
+  | Sel.Data s -> "data-" ^ s
+  | Sel.Aria a -> Cascade.Aria.to_string a
+
+let attr_matches self name (m : Sel.attribute_match) =
+  match List.assoc_opt (attr_key name) self.attrs with
+  | None -> false
+  | Some v -> (
+      match m with
+      | Sel.Presence -> true
+      | Sel.Exact s | Sel.Exact_quoted (s, _) -> v = s
+      | Sel.Whitespace_list s | Sel.Whitespace_list_quoted (s, _) ->
+          List.mem s (words v)
+      | Sel.Prefix s | Sel.Prefix_quoted (s, _) -> s <> "" && starts v s
+      | Sel.Suffix s | Sel.Suffix_quoted (s, _) -> s <> "" && ends v s
+      | Sel.Substring s | Sel.Substring_quoted (s, _) -> s <> "" && contains v s
+      | Sel.Hyphen_list s | Sel.Hyphen_list_quoted (s, _) ->
+          v = s || starts v (s ^ "-"))
+
+let rec matches (sel : Sel.t) l : bool =
+  match sel with
+  | Sel.Universal _ -> true
+  | Sel.Element (_, n) -> ci l.self.name n
+  | Sel.Class c -> List.mem c l.self.classes
+  | Sel.Id i -> l.self.id = Some i
+  | Sel.Attribute (_, name, m, _) -> attr_matches l.self name m
+  | Sel.Compound ps -> List.for_all (fun p -> matches p l) ps
+  | Sel.List ss | Sel.Is ss | Sel.Where ss ->
+      List.exists (fun s -> matches s l) ss
+  | Sel.Not ss -> not (List.exists (fun s -> matches s l) ss)
+  | Sel.Combined (left, comb, right) ->
+      matches right l && combinator left comb l
+  | Sel.Root -> l.up = None
+  | Sel.First_child -> l.idx = 0
+  | Sel.Last_child -> l.idx = List.length l.sibs - 1
+  | Sel.Only_child -> List.length l.sibs = 1
+  | Sel.Empty -> l.self.kids = []
+  (* dynamic pseudo-classes, pseudo-elements, etc.: not statically matchable *)
+  | _ -> false
+
+and combinator left comb l =
+  match comb with
+  | Sel.Descendant -> List.exists (matches left) (ancestors l)
+  | Sel.Child -> ( match l.up with Some p -> matches left p | None -> false)
+  | Sel.Next_sibling -> (
+      match imm_pred l with Some s -> matches left s | None -> false)
+  | Sel.Subsequent_sibling -> List.exists (matches left) (preceding l)
+  | _ -> false
+
+let spec_key s = Sel.(s.ids, s.classes, s.elements)
+
+(* project: the cascade. gather matching rules, order by (specificity, source),
+   last wins per property. *)
+let project sheet l : Decl.declaration list =
+  let matched =
+    Sheet.rules sheet
+    |> List.mapi (fun i r ->
+        let sel = Sheet.selector r in
+        if matches sel l then
+          Some (spec_key (Sel.specificity sel), i, Sheet.declarations r)
+        else None)
+    |> List.filter_map Fun.id
+  in
+  let sorted =
+    List.stable_sort
+      (fun (s1, i1, _) (s2, i2, _) ->
+        match compare s1 s2 with 0 -> compare i1 i2 | c -> c)
+      matched
+  in
+  let upsert acc d =
+    let k = Decl.property_name d in
+    (k, d) :: List.remove_assoc k acc
+  in
+  List.fold_left (fun acc (_, _, ds) -> List.fold_left upsert acc ds) [] sorted
+  |> List.rev_map snd
+
+let style_of sheet l =
+  Sheet.inline_style_of_declarations ~minify:false (project sheet l)
+
+let () =
+  let css =
+    {|
+      section          { color: black; padding: 4px }
+      .card            { color: navy; border: 1px solid gray }
+      #hero            { color: crimson }
+      .card > p        { font-weight: bold }
+      .card p          { margin: 2px }
+      a[href^="https"] { text-decoration: underline }
+      ul > li + li     { color: teal }
+    |}
+  in
+  let sheet =
+    match Css.of_string css with
+    | Ok p -> p.Css.stylesheet
+    | Error _ -> failwith "parse failed"
+  in
+  let tree =
+    e "section" ~id:"hero" ~cls:[ "card" ]
+      ~kids:
+        [
+          e "p" ~kids:[ e "a" ~attrs:[ ("href", "https://x") ] ];
+          e "ul" ~kids:[ e "li"; e "li" ];
+        ]
+  in
+  let label l =
+    let id = match l.self.id with Some i -> "#" ^ i | None -> "" in
+    let cls = String.concat "" (List.map (fun c -> "." ^ c) l.self.classes) in
+    l.self.name ^ id ^ cls
+  in
+  let rec walk pad l =
+    Printf.printf "%s%-18s -> %s\n" pad (label l) (style_of sheet l);
+    List.iter (walk (pad ^ "  ")) (kids_of l)
+  in
+  print_endline "project global CSS onto each node (no DOM):";
+  walk "  " (root tree)


### PR DESCRIPTION
Two small examples that use cascade for what it can do beyond parse/print: **selector matching + specificity + last-wins**, projected onto a tree. This is the browser's style-resolution stage, decoupled from the DOM, with cascade as the engine.

### `examples/css-resolve`
Projects a global stylesheet onto each node of a plain OCaml tree (no DOM). Pure cascade, no extra deps. Demonstrates the cascade on a small tree:

```
section#hero.card  -> padding: 4px; border: 1px solid gray; color: crimson
  p                  -> font-weight: bold; margin: 2px      (.card>p and .card p)
    a                  -> text-decoration: underline          (a[href^="https"])
  ul
    li
    li                 -> color: teal                          (ul > li + li, 2nd only)
```

`#hero` (id) wins `color` over `.card` (class); the attribute and `li + li` combinators fire correctly.

### `examples/css-inline`
A mode where cascade takes an **HTML page + optional CSS and emits fully resolved HTML**: the matched declarations are written into each element's `style=""` attribute (premailer / juice style). cascade is the cascade engine *and* minifies each inline style (`font-weight:bold` -> `700`); [lambdasoup](https://github.com/aantron/lambdasoup) only parses and serialises the HTML, since HTML is outside cascade's scope.

```
dune exec examples/css-inline/main.exe -- page.html [extra.css]
```

Scope (premailer parity, not a browser): it inlines statically-matchable rules; `:hover` / media / pseudo-elements stay in the kept `<style>`; author inline styles keep priority. Inheritance and `var()` / `calc()` computed-value resolution are not expanded yet (the natural phase-2 that would make headless-Chrome `getComputedStyle` a valid differential oracle).

Both are plain executables (no `public_name`), so they build in the dev/CI environment (lambdasoup is already a `:with-test` dep) but are not part of the installed package.