### PR TITLE
cascade: add an apply subcommand, backed by a library cascade resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ _homebrew_build/
 .claude/
 
 /mono
+
+# Real pages downloaded by test/inline/fetch.sh for the differential test.
+/test/inline/pages/

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -1,4 +1,4 @@
-(* [cascade inline <page.html> [extra.css]]: resolve a stylesheet against the
+(* [cascade apply <page.html> [extra.css]]: resolve a stylesheet against the
    HTML, write each element's winning declarations into its style attribute, and
    keep the rules with no inline form (:hover, @media, ...) in a <style>. The
    cascade itself lives in {!Cascade.Resolve}; this command adds the
@@ -95,7 +95,9 @@ let parse_inline s =
   | Error _ -> []
 
 let decl_value d =
-  let s = Sheet.inline_style_of_declarations ~minify:true ~mode:Variables [ d ] in
+  let s =
+    Sheet.inline_style_of_declarations ~minify:true ~mode:Variables [ d ]
+  in
   match String.index_opt s ':' with
   | Some i -> String.sub s (i + 1) (String.length s - i - 1)
   | None -> s
@@ -298,4 +300,4 @@ let cmd =
          and are kept in a single $(b,<style>) block.";
     ]
   in
-  Cmd.v (Cmd.info "inline" ~doc ~man) Term.(term_result term)
+  Cmd.v (Cmd.info "apply" ~doc ~man) Term.(term_result term)

--- a/bin/cmd_inline.ml
+++ b/bin/cmd_inline.ml
@@ -1,0 +1,396 @@
+(* [cascade inline <page.html> [extra.css]]: resolve a stylesheet against the
+   HTML, write every winning declaration into each element's style attribute,
+   and keep only the rules that have no inline form (:hover, @media, ...) in a
+   single <style>. cascade runs the cascade (selector match + specificity +
+   !important + inline-style priority) and minifies; lambdasoup only parses and
+   serialises the HTML. *)
+
+open Cmdliner
+module Sel = Cascade.Selector
+module Sheet = Cascade.Stylesheet
+module Decl = Cascade.Declaration
+module Css = Cascade.Css
+
+(* ---------- selector matching over a lambdasoup element node ---------- *)
+let ci a b = String.lowercase_ascii a = String.lowercase_ascii b
+let words s = String.split_on_char ' ' s |> List.filter (( <> ) "")
+
+let contains hay needle =
+  let lh = String.length hay and ln = String.length needle in
+  if ln = 0 then true
+  else
+    let rec go i =
+      if i + ln > lh then false
+      else if String.sub hay i ln = needle then true
+      else go (i + 1)
+    in
+    go 0
+
+let starts s p =
+  String.length s >= String.length p && String.sub s 0 (String.length p) = p
+
+let ends s p =
+  let ls = String.length s and lp = String.length p in
+  ls >= lp && String.sub s (ls - lp) lp = p
+
+let attr_key : Sel.attr_name -> string = function
+  | Sel.Regular s -> s
+  | Sel.Data s -> "data-" ^ s
+  | Sel.Aria a -> Cascade.Aria.to_string a
+
+let attr_matches n name (m : Sel.attribute_match) =
+  match Soup.attribute (attr_key name) n with
+  | None -> false
+  | Some v -> (
+      match m with
+      | Sel.Presence -> true
+      | Sel.Exact s | Sel.Exact_quoted (s, _) -> v = s
+      | Sel.Whitespace_list s | Sel.Whitespace_list_quoted (s, _) ->
+          List.mem s (words v)
+      | Sel.Prefix s | Sel.Prefix_quoted (s, _) -> s <> "" && starts v s
+      | Sel.Suffix s | Sel.Suffix_quoted (s, _) -> s <> "" && ends v s
+      | Sel.Substring s | Sel.Substring_quoted (s, _) -> s <> "" && contains v s
+      | Sel.Hyphen_list s | Sel.Hyphen_list_quoted (s, _) ->
+          v = s || starts v (s ^ "-"))
+
+let child_elements p = Soup.children p |> Soup.elements |> Soup.to_list
+
+let preceding_siblings n =
+  match Soup.parent n with
+  | None -> []
+  | Some p ->
+      let rec before acc = function
+        | [] -> List.rev acc
+        | x :: _ when x == n -> List.rev acc
+        | x :: rest -> before (x :: acc) rest
+      in
+      before [] (child_elements p)
+
+let imm_pred n =
+  match List.rev (preceding_siblings n) with x :: _ -> Some x | [] -> None
+
+let is_first n = preceding_siblings n = []
+
+let is_last n =
+  match Soup.parent n with
+  | None -> true
+  | Some p -> (
+      match List.rev (child_elements p) with x :: _ -> x == n | [] -> true)
+
+let rec matches (sel : Sel.t) n : bool =
+  match sel with
+  | Sel.Universal _ -> true
+  | Sel.Element (_, name) -> ci (Soup.name n) name
+  | Sel.Class c -> List.mem c (Soup.classes n)
+  | Sel.Id i -> Soup.id n = Some i
+  | Sel.Attribute (_, name, m, _) -> attr_matches n name m
+  | Sel.Compound ps -> List.for_all (fun p -> matches p n) ps
+  | Sel.List ss | Sel.Is ss | Sel.Where ss ->
+      List.exists (fun s -> matches s n) ss
+  | Sel.Not ss -> not (List.exists (fun s -> matches s n) ss)
+  | Sel.Combined (left, comb, right) ->
+      matches right n && combinator left comb n
+  | Sel.Root -> Soup.parent n = None
+  | Sel.First_child -> is_first n
+  | Sel.Last_child -> is_last n
+  | Sel.Only_child -> is_first n && is_last n
+  | Sel.Empty -> child_elements n = []
+  (* :hover, media queries, pseudo-elements, etc. are stateful or generated and
+     have no inline-style form; they cannot be resolved statically. *)
+  | _ -> false
+
+and combinator left comb n =
+  match comb with
+  | Sel.Descendant ->
+      List.exists (matches left) (Soup.ancestors n |> Soup.to_list)
+  | Sel.Child -> (
+      match Soup.parent n with Some p -> matches left p | None -> false)
+  | Sel.Next_sibling -> (
+      match imm_pred n with Some s -> matches left s | None -> false)
+  | Sel.Subsequent_sibling -> List.exists (matches left) (preceding_siblings n)
+  | _ -> false
+
+let inlinable (sel : Sel.t) =
+  let rec ok = function
+    | Sel.Universal _ | Sel.Element _ | Sel.Class _ | Sel.Id _ | Sel.Attribute _
+    | Sel.Root | Sel.First_child | Sel.Last_child | Sel.Only_child | Sel.Empty
+      ->
+        true
+    | Sel.Compound ps | Sel.List ps | Sel.Is ps | Sel.Where ps | Sel.Not ps ->
+        List.for_all ok ps
+    | Sel.Combined (a, _, b) -> ok a && ok b
+    | _ -> false
+  in
+  ok sel
+
+(* ---------- the cascade (specificity + source order + !important + inline)
+   ---------- *)
+let spec_key s = Sel.(s.ids, s.classes, s.elements)
+
+let upsert acc d =
+  let k = Decl.property_name d in
+  (k, d) :: List.remove_assoc k acc
+
+let parse_inline s =
+  match Css.of_string ("a{" ^ s ^ "}") with
+  | Ok p -> (
+      match Sheet.rules p.Css.stylesheet with
+      | r :: _ -> Sheet.declarations r
+      | [] -> [])
+  | Error _ -> []
+
+(* declarations applied in ascending cascade order; later wins per property *)
+let resolved rules n =
+  let matched =
+    rules
+    |> List.mapi (fun i r ->
+        let sel = Sheet.selector r in
+        if matches sel n then
+          Some (spec_key (Sel.specificity sel), i, Sheet.declarations r)
+        else None)
+    |> List.filter_map Fun.id
+    |> List.stable_sort (fun (s1, i1, _) (s2, i2, _) ->
+        match compare s1 s2 with 0 -> compare i1 i2 | c -> c)
+  in
+  let rule_decls = List.concat_map (fun (_, _, ds) -> ds) matched in
+  let inline =
+    match Soup.attribute "style" n with Some s -> parse_inline s | None -> []
+  in
+  let normal = List.filter (fun d -> not (Decl.is_important d)) in
+  let important = List.filter Decl.is_important in
+  let rule_normal, rule_imp = (normal rule_decls, important rule_decls) in
+  let in_normal, in_imp = (normal inline, important inline) in
+  (* author cascade order, low to high: rule-normal, inline-normal,
+     rule-!important, inline-!important *)
+  List.fold_left upsert [] (rule_normal @ in_normal @ rule_imp @ in_imp)
+  |> List.rev_map snd
+
+(* [html] is stylable: [:root] custom properties must land on it so that [var()]
+   resolves on the descendants that inherit them. *)
+let no_style = [ "head"; "meta"; "title"; "base"; "link"; "style"; "script" ]
+
+(* CSS inherited properties (a conservative set: missing one only keeps a
+   redundant declaration; the x-test guards against ever dropping a needed
+   one). *)
+let inherited =
+  [
+    "color";
+    "font";
+    "font-family";
+    "font-size";
+    "font-weight";
+    "font-style";
+    "font-variant";
+    "font-stretch";
+    "font-feature-settings";
+    "line-height";
+    "letter-spacing";
+    "word-spacing";
+    "text-align";
+    "text-indent";
+    "text-transform";
+    "text-shadow";
+    "white-space";
+    "word-break";
+    "overflow-wrap";
+    "hyphens";
+    "tab-size";
+    "visibility";
+    "cursor";
+    "direction";
+    "list-style";
+    "list-style-type";
+    "list-style-position";
+    "list-style-image";
+    "quotes";
+    "caption-side";
+    "border-collapse";
+    "border-spacing";
+    "empty-cells";
+  ]
+
+let is_inherited p = List.mem (String.lowercase_ascii p) inherited
+
+let decl_value d =
+  let s = Sheet.inline_style_of_declarations ~minify:true [ d ] in
+  match String.index_opt s ':' with
+  | Some i -> String.sub s (i + 1) (String.length s - i - 1)
+  | None -> s
+
+let style_node node = function
+  | [] -> ()
+  | decls ->
+      Soup.set_attribute "style"
+        (Sheet.inline_style_of_declarations ~minify:true decls)
+        node
+
+(* top-down walk: [ctx] maps each inherited property to the value in force from
+   the ancestors, so [minimal] can drop a declaration that only restates it. *)
+let rec walk ~minimal rules ctx node =
+  if List.mem (String.lowercase_ascii (Soup.name node)) no_style then
+    List.iter (walk ~minimal rules ctx) (child_elements node)
+  else begin
+    let decls = resolved rules node in
+    let kept, ctx' =
+      List.fold_left
+        (fun (kept, ctx) d ->
+          let p = String.lowercase_ascii (Decl.property_name d) in
+          if minimal && is_inherited p then
+            let v = decl_value d in
+            match List.assoc_opt p ctx with
+            | Some pv when pv = v -> (kept, ctx) (* inherits the same value *)
+            | _ -> (d :: kept, (p, v) :: List.remove_assoc p ctx)
+          else (d :: kept, ctx))
+        ([], ctx) decls
+    in
+    style_node node (List.rev kept);
+    List.iter (walk ~minimal rules ctx') (child_elements node)
+  end
+
+module SSet = Set.Make (String)
+
+(* every property a kept (conditional / stateful) rule can set, recursing into
+   @media / @supports / @container / @layer blocks. *)
+let rec props_of_stmts acc stmts =
+  List.fold_left
+    (fun acc s ->
+      match s with
+      | Sheet.Rule r ->
+          List.fold_left
+            (fun a d ->
+              SSet.add (String.lowercase_ascii (Decl.property_name d)) a)
+            acc (Sheet.declarations r)
+      | Sheet.Media (_, b) | Sheet.Supports (_, b) | Sheet.Layer (_, b) ->
+          props_of_stmts acc b
+      | Sheet.Container (_, _, b) -> props_of_stmts acc b
+      | _ -> acc)
+    acc stmts
+
+let inline_html ~minimal ~html ~extra =
+  let soup = Soup.parse html in
+  let page_css =
+    Soup.select "style" soup |> Soup.to_list |> List.concat_map Soup.texts
+    |> String.concat "\n"
+  in
+  let css = page_css ^ "\n" ^ extra in
+  let rules, keep_css, kept =
+    match Css.of_string css with
+    | Ok p ->
+        let stmts = p.Css.stylesheet in
+        (* properties a kept rule can override must stay in the cascade, or an
+           inline style would outrank the @media / :hover rule. Collect them
+           from every statement that is not an inlinable static rule. *)
+        let dyn =
+          props_of_stmts SSet.empty
+            (List.filter
+               (function
+                 | Sheet.Rule r -> not (inlinable (Sheet.selector r))
+                 | _ -> true)
+               stmts)
+        in
+        let is_dyn d =
+          SSet.mem (String.lowercase_ascii (Decl.property_name d)) dyn
+        in
+        let inline_rules = ref [] in
+        (* rewrite the sheet in place, preserving order (the cascade breaks
+           specificity ties on it): an inlinable static rule keeps only its
+           overridable declarations; the rest move to the inline list. *)
+        let keep =
+          List.filter_map
+            (fun stmt ->
+              match stmt with
+              | Sheet.Rule r when inlinable (Sheet.selector r) -> (
+                  let sel = Sheet.selector r and ds = Sheet.declarations r in
+                  (match List.filter (fun d -> not (is_dyn d)) ds with
+                  | [] -> ()
+                  | inl ->
+                      inline_rules :=
+                        Sheet.rule ~selector:sel inl :: !inline_rules);
+                  match List.filter is_dyn ds with
+                  | [] -> None
+                  | res -> Some (Sheet.Rule (Sheet.rule ~selector:sel res)))
+              | other -> Some other)
+            stmts
+        in
+        let rules = List.rev !inline_rules in
+        let keep_css =
+          if keep = [] then "" else Css.to_string ~minify:true (Sheet.v keep)
+        in
+        (rules, keep_css, List.length keep)
+    | Error _ -> ([], "", 0)
+  in
+  Soup.children soup |> Soup.elements |> Soup.to_list
+  |> List.iter (walk ~minimal rules []);
+  (* the static rules now live on the elements; replace the <style> blocks with
+     a single one holding just the rules that have no inline form. *)
+  Soup.select "style" soup |> Soup.iter Soup.delete;
+  (if keep_css <> "" then
+     let style = Soup.create_element ~inner_text:keep_css "style" in
+     match Soup.select_one "head" soup with
+     | Some head -> Soup.append_child head style
+     | None -> (
+         match Soup.select_one "html" soup with
+         | Some h -> Soup.prepend_child h style
+         | None -> ()));
+  (Soup.to_string soup, kept)
+
+(* ---------- cmdliner ---------- *)
+let read_file path =
+  try
+    let ic = open_in_bin path in
+    let s = really_input_string ic (in_channel_length ic) in
+    close_in ic;
+    Ok s
+  with Sys_error msg -> Error (`Msg (Fmt.str "Error reading %s: %s" path msg))
+
+let run minimal html_file css_file () =
+  match read_file html_file with
+  | Error _ as e -> e
+  | Ok html ->
+      let extra =
+        match css_file with
+        | Some f -> ( match read_file f with Ok s -> s | Error _ -> "")
+        | None -> ""
+      in
+      let out, kept = inline_html ~minimal ~html ~extra in
+      if kept > 0 then
+        Fmt.epr "Kept %d rule(s) with no inline form in a <style> block.@." kept;
+      print_string out;
+      Ok ()
+
+let html_arg =
+  let doc = "The HTML page to resolve." in
+  Arg.(required & pos 0 (some file) None & info [] ~docv:"PAGE.html" ~doc)
+
+let css_arg =
+  let doc =
+    "An additional stylesheet to apply on top of the page's <style> blocks."
+  in
+  Arg.(value & pos 1 (some file) None & info [] ~docv:"EXTRA.css" ~doc)
+
+let minimal_arg =
+  let doc =
+    "Drop inherited declarations that only restate the parent's value, for the \
+     smallest styled page. By default every matched declaration is kept."
+  in
+  Arg.(value & flag & info [ "minimal" ] ~doc)
+
+let term = Term.(const run $ minimal_arg $ html_arg $ css_arg $ const ())
+
+let cmd =
+  let doc = "Resolve a stylesheet into an HTML page's inline styles" in
+  let man =
+    [
+      `S Manpage.s_description;
+      `P
+        "Project the cascade onto every element of $(i,PAGE.html): selector \
+         matching, specificity, !important and inline-style priority decide \
+         which declarations win, and the result is written into each element's \
+         $(b,style) attribute.";
+      `P
+        "Rules that have no inline form ($(b,:hover), media queries, \
+         pseudo-elements, $(b,@keyframes)) cannot be projected onto an element \
+         and are kept in a single $(b,<style>) block.";
+    ]
+  in
+  Cmd.v (Cmd.info "inline" ~doc ~man) Term.(term_result term)

--- a/bin/cmd_inline.ml
+++ b/bin/cmd_inline.ml
@@ -1,115 +1,33 @@
 (* [cascade inline <page.html> [extra.css]]: resolve a stylesheet against the
-   HTML, write every winning declaration into each element's style attribute,
-   and keep only the rules that have no inline form (:hover, @media, ...) in a
-   single <style>. cascade runs the cascade (selector match + specificity +
-   !important + inline-style priority) and minifies; lambdasoup only parses and
-   serialises the HTML. *)
+   HTML, write each element's winning declarations into its style attribute, and
+   keep the rules with no inline form (:hover, @media, ...) in a <style>. The
+   cascade itself lives in {!Cascade.Resolve}; this command adds the
+   inline-specific policy and the lambdasoup glue. *)
 
 open Cmdliner
-module Sel = Cascade.Selector
 module Sheet = Cascade.Stylesheet
+module Sel = Cascade.Selector
 module Decl = Cascade.Declaration
 module Css = Cascade.Css
 
-(* ---------- selector matching over a lambdasoup element node ---------- *)
-let ci a b = String.lowercase_ascii a = String.lowercase_ascii b
-let words s = String.split_on_char ' ' s |> List.filter (( <> ) "")
+(* ---------- the tree: lambdasoup element nodes ---------- *)
+module Node = struct
+  type t = Soup.element Soup.node
 
-let contains hay needle =
-  let lh = String.length hay and ln = String.length needle in
-  if ln = 0 then true
-  else
-    let rec go i =
-      if i + ln > lh then false
-      else if String.sub hay i ln = needle then true
-      else go (i + 1)
-    in
-    go 0
+  let equal = ( == )
+  let name n = Some (Soup.name n)
+  let id = Soup.id
+  let classes = Soup.classes
+  let attribute n k = Soup.attribute k n
+  let parent = Soup.parent
+  let children n = Soup.children n |> Soup.elements |> Soup.to_list
+end
 
-let starts s p =
-  String.length s >= String.length p && String.sub s 0 (String.length p) = p
+module R = Cascade.Resolve.Make (Node)
 
-let ends s p =
-  let ls = String.length s and lp = String.length p in
-  ls >= lp && String.sub s (ls - lp) lp = p
+(* ---------- inline policy ---------- *)
 
-let attr_key : Sel.attr_name -> string = function
-  | Sel.Regular s -> s
-  | Sel.Data s -> "data-" ^ s
-  | Sel.Aria a -> Cascade.Aria.to_string a
-
-let attr_matches n name (m : Sel.attribute_match) =
-  match Soup.attribute (attr_key name) n with
-  | None -> false
-  | Some v -> (
-      match m with
-      | Sel.Presence -> true
-      | Sel.Exact s | Sel.Exact_quoted (s, _) -> v = s
-      | Sel.Whitespace_list s | Sel.Whitespace_list_quoted (s, _) ->
-          List.mem s (words v)
-      | Sel.Prefix s | Sel.Prefix_quoted (s, _) -> s <> "" && starts v s
-      | Sel.Suffix s | Sel.Suffix_quoted (s, _) -> s <> "" && ends v s
-      | Sel.Substring s | Sel.Substring_quoted (s, _) -> s <> "" && contains v s
-      | Sel.Hyphen_list s | Sel.Hyphen_list_quoted (s, _) ->
-          v = s || starts v (s ^ "-"))
-
-let child_elements p = Soup.children p |> Soup.elements |> Soup.to_list
-
-let preceding_siblings n =
-  match Soup.parent n with
-  | None -> []
-  | Some p ->
-      let rec before acc = function
-        | [] -> List.rev acc
-        | x :: _ when x == n -> List.rev acc
-        | x :: rest -> before (x :: acc) rest
-      in
-      before [] (child_elements p)
-
-let imm_pred n =
-  match List.rev (preceding_siblings n) with x :: _ -> Some x | [] -> None
-
-let is_first n = preceding_siblings n = []
-
-let is_last n =
-  match Soup.parent n with
-  | None -> true
-  | Some p -> (
-      match List.rev (child_elements p) with x :: _ -> x == n | [] -> true)
-
-let rec matches (sel : Sel.t) n : bool =
-  match sel with
-  | Sel.Universal _ -> true
-  | Sel.Element (_, name) -> ci (Soup.name n) name
-  | Sel.Class c -> List.mem c (Soup.classes n)
-  | Sel.Id i -> Soup.id n = Some i
-  | Sel.Attribute (_, name, m, _) -> attr_matches n name m
-  | Sel.Compound ps -> List.for_all (fun p -> matches p n) ps
-  | Sel.List ss | Sel.Is ss | Sel.Where ss ->
-      List.exists (fun s -> matches s n) ss
-  | Sel.Not ss -> not (List.exists (fun s -> matches s n) ss)
-  | Sel.Combined (left, comb, right) ->
-      matches right n && combinator left comb n
-  | Sel.Root -> Soup.parent n = None
-  | Sel.First_child -> is_first n
-  | Sel.Last_child -> is_last n
-  | Sel.Only_child -> is_first n && is_last n
-  | Sel.Empty -> child_elements n = []
-  (* :hover, media queries, pseudo-elements, etc. are stateful or generated and
-     have no inline-style form; they cannot be resolved statically. *)
-  | _ -> false
-
-and combinator left comb n =
-  match comb with
-  | Sel.Descendant ->
-      List.exists (matches left) (Soup.ancestors n |> Soup.to_list)
-  | Sel.Child -> (
-      match Soup.parent n with Some p -> matches left p | None -> false)
-  | Sel.Next_sibling -> (
-      match imm_pred n with Some s -> matches left s | None -> false)
-  | Sel.Subsequent_sibling -> List.exists (matches left) (preceding_siblings n)
-  | _ -> false
-
+(* selectors that can be written as an inline style (no state / condition) *)
 let inlinable (sel : Sel.t) =
   let rec ok = function
     | Sel.Universal _ | Sel.Element _ | Sel.Class _ | Sel.Id _ | Sel.Attribute _
@@ -123,54 +41,11 @@ let inlinable (sel : Sel.t) =
   in
   ok sel
 
-(* ---------- the cascade (specificity + source order + !important + inline)
-   ---------- *)
-let spec_key s = Sel.(s.ids, s.classes, s.elements)
-
-let upsert acc d =
-  let k = Decl.property_name d in
-  (k, d) :: List.remove_assoc k acc
-
-let parse_inline s =
-  match Css.of_string ("a{" ^ s ^ "}") with
-  | Ok p -> (
-      match Sheet.rules p.Css.stylesheet with
-      | r :: _ -> Sheet.declarations r
-      | [] -> [])
-  | Error _ -> []
-
-(* declarations applied in ascending cascade order; later wins per property *)
-let resolved rules n =
-  let matched =
-    rules
-    |> List.mapi (fun i r ->
-        let sel = Sheet.selector r in
-        if matches sel n then
-          Some (spec_key (Sel.specificity sel), i, Sheet.declarations r)
-        else None)
-    |> List.filter_map Fun.id
-    |> List.stable_sort (fun (s1, i1, _) (s2, i2, _) ->
-        match compare s1 s2 with 0 -> compare i1 i2 | c -> c)
-  in
-  let rule_decls = List.concat_map (fun (_, _, ds) -> ds) matched in
-  let inline =
-    match Soup.attribute "style" n with Some s -> parse_inline s | None -> []
-  in
-  let normal = List.filter (fun d -> not (Decl.is_important d)) in
-  let important = List.filter Decl.is_important in
-  let rule_normal, rule_imp = (normal rule_decls, important rule_decls) in
-  let in_normal, in_imp = (normal inline, important inline) in
-  (* author cascade order, low to high: rule-normal, inline-normal,
-     rule-!important, inline-!important *)
-  List.fold_left upsert [] (rule_normal @ in_normal @ rule_imp @ in_imp)
-  |> List.rev_map snd
-
-(* [html] is stylable: [:root] custom properties must land on it so that [var()]
-   resolves on the descendants that inherit them. *)
+(* [html] is stylable so that :root custom properties land on it. *)
 let no_style = [ "head"; "meta"; "title"; "base"; "link"; "style"; "script" ]
 
 (* CSS inherited properties (a conservative set: missing one only keeps a
-   redundant declaration; the x-test guards against ever dropping a needed
+   redundant declaration; the differential test guards against dropping a needed
    one). *)
 let inherited =
   [
@@ -211,11 +86,39 @@ let inherited =
 
 let is_inherited p = List.mem (String.lowercase_ascii p) inherited
 
+let parse_inline s =
+  match Css.of_string ("a{" ^ s ^ "}") with
+  | Ok p -> (
+      match Sheet.rules p.Css.stylesheet with
+      | r :: _ -> Sheet.declarations r
+      | [] -> [])
+  | Error _ -> []
+
 let decl_value d =
   let s = Sheet.inline_style_of_declarations ~minify:true [ d ] in
   match String.index_opt s ':' with
   | Some i -> String.sub s (i + 1) (String.length s - i - 1)
   | None -> s
+
+(* a node's style: the author cascade from {!R.resolve} with the element's own
+   inline style overlaid (inline beats a selector, but an author !important
+   beats a normal inline declaration). *)
+let resolved sheet n =
+  let author = R.resolve sheet n in
+  match Soup.attribute "style" n with
+  | None -> author
+  | Some s ->
+      let overlay map d =
+        let k = Decl.property_name d in
+        match List.assoc_opt k map with
+        | Some cur when Decl.is_important cur && not (Decl.is_important d) ->
+            map
+        | _ -> (k, d) :: List.remove_assoc k map
+      in
+      List.fold_left overlay
+        (List.map (fun d -> (Decl.property_name d, d)) author)
+        (parse_inline s)
+      |> List.rev_map snd
 
 let style_node node = function
   | [] -> ()
@@ -224,29 +127,7 @@ let style_node node = function
         (Sheet.inline_style_of_declarations ~minify:true decls)
         node
 
-(* top-down walk: [ctx] maps each inherited property to the value in force from
-   the ancestors, so [minimal] can drop a declaration that only restates it. *)
-let rec walk ~minimal rules ctx node =
-  if List.mem (String.lowercase_ascii (Soup.name node)) no_style then
-    List.iter (walk ~minimal rules ctx) (child_elements node)
-  else begin
-    let decls = resolved rules node in
-    let kept, ctx' =
-      List.fold_left
-        (fun (kept, ctx) d ->
-          let p = String.lowercase_ascii (Decl.property_name d) in
-          if minimal && is_inherited p then
-            let v = decl_value d in
-            match List.assoc_opt p ctx with
-            | Some pv when pv = v -> (kept, ctx) (* inherits the same value *)
-            | _ -> (d :: kept, (p, v) :: List.remove_assoc p ctx)
-          else (d :: kept, ctx))
-        ([], ctx) decls
-    in
-    style_node node (List.rev kept);
-    List.iter (walk ~minimal rules ctx') (child_elements node)
-  end
-
+(* ---------- splitting static / dynamic ---------- *)
 module SSet = Set.Make (String)
 
 (* every property a kept (conditional / stateful) rule can set, recursing into
@@ -266,6 +147,29 @@ let rec props_of_stmts acc stmts =
       | _ -> acc)
     acc stmts
 
+(* ---------- the walk ---------- *)
+(* [ctx] maps each inherited property to the value in force from the ancestors,
+   so [minimal] can drop a declaration that only restates it. *)
+let rec walk ~minimal sheet ctx node =
+  if List.mem (String.lowercase_ascii (Soup.name node)) no_style then
+    List.iter (walk ~minimal sheet ctx) (Node.children node)
+  else begin
+    let kept, ctx' =
+      List.fold_left
+        (fun (kept, ctx) d ->
+          let p = String.lowercase_ascii (Decl.property_name d) in
+          if minimal && is_inherited p then
+            let v = decl_value d in
+            match List.assoc_opt p ctx with
+            | Some pv when pv = v -> (kept, ctx)
+            | _ -> (d :: kept, (p, v) :: List.remove_assoc p ctx)
+          else (d :: kept, ctx))
+        ([], ctx) (resolved sheet node)
+    in
+    style_node node (List.rev kept);
+    List.iter (walk ~minimal sheet ctx') (Node.children node)
+  end
+
 let inline_html ~minimal ~html ~extra =
   let soup = Soup.parse html in
   let page_css =
@@ -273,13 +177,13 @@ let inline_html ~minimal ~html ~extra =
     |> String.concat "\n"
   in
   let css = page_css ^ "\n" ^ extra in
-  let rules, keep_css, kept =
+  let inline_sheet, keep_css, kept =
     match Css.of_string css with
     | Ok p ->
-        let stmts = p.Css.stylesheet in
-        (* properties a kept rule can override must stay in the cascade, or an
-           inline style would outrank the @media / :hover rule. Collect them
-           from every statement that is not an inlinable static rule. *)
+        (* flatten nesting up front, so the static/dynamic split and
+           {!R.resolve} see the same flat rules. *)
+        let stmts = Cascade.Flatten.block p.Css.stylesheet in
+        (* properties a kept rule can override must stay in the cascade. *)
         let dyn =
           props_of_stmts SSet.empty
             (List.filter
@@ -292,9 +196,6 @@ let inline_html ~minimal ~html ~extra =
           SSet.mem (String.lowercase_ascii (Decl.property_name d)) dyn
         in
         let inline_rules = ref [] in
-        (* rewrite the sheet in place, preserving order (the cascade breaks
-           specificity ties on it): an inlinable static rule keeps only its
-           overridable declarations; the rest move to the inline list. *)
         let keep =
           List.filter_map
             (fun stmt ->
@@ -305,24 +206,24 @@ let inline_html ~minimal ~html ~extra =
                   | [] -> ()
                   | inl ->
                       inline_rules :=
-                        Sheet.rule ~selector:sel inl :: !inline_rules);
+                        Sheet.Rule (Sheet.rule ~selector:sel inl)
+                        :: !inline_rules);
                   match List.filter is_dyn ds with
                   | [] -> None
                   | res -> Some (Sheet.Rule (Sheet.rule ~selector:sel res)))
               | other -> Some other)
             stmts
         in
-        let rules = List.rev !inline_rules in
         let keep_css =
           if keep = [] then "" else Css.to_string ~minify:true (Sheet.v keep)
         in
-        (rules, keep_css, List.length keep)
-    | Error _ -> ([], "", 0)
+        (Sheet.v (List.rev !inline_rules), keep_css, List.length keep)
+    | Error _ -> (Sheet.empty, "", 0)
   in
   Soup.children soup |> Soup.elements |> Soup.to_list
-  |> List.iter (walk ~minimal rules []);
-  (* the static rules now live on the elements; replace the <style> blocks with
-     a single one holding just the rules that have no inline form. *)
+  |> List.iter (walk ~minimal inline_sheet []);
+  (* the static rules now live on the elements; keep only the un-inlinable
+     ones. *)
   Soup.select "style" soup |> Soup.iter Soup.delete;
   (if keep_css <> "" then
      let style = Soup.create_element ~inner_text:keep_css "style" in
@@ -371,7 +272,7 @@ let css_arg =
 let minimal_arg =
   let doc =
     "Drop inherited declarations that only restate the parent's value, for the \
-     smallest styled page. By default every matched declaration is kept."
+     smallest styled page."
   in
   Arg.(value & flag & info [ "minimal" ] ~doc)
 

--- a/bin/cmd_inline.ml
+++ b/bin/cmd_inline.ml
@@ -95,7 +95,7 @@ let parse_inline s =
   | Error _ -> []
 
 let decl_value d =
-  let s = Sheet.inline_style_of_declarations ~minify:true [ d ] in
+  let s = Sheet.inline_style_of_declarations ~minify:true ~mode:Variables [ d ] in
   match String.index_opt s ':' with
   | Some i -> String.sub s (i + 1) (String.length s - i - 1)
   | None -> s
@@ -123,8 +123,12 @@ let resolved sheet n =
 let style_node node = function
   | [] -> ()
   | decls ->
+      (* [~mode:Variables] keeps [var()] references; the element's own custom
+         properties are resolved onto it too, so the browser still resolves
+         them. The [Inline] mode would substitute a var() with its fallback,
+         dropping the reference and changing the render. *)
       Soup.set_attribute "style"
-        (Sheet.inline_style_of_declarations ~minify:true decls)
+        (Sheet.inline_style_of_declarations ~minify:true ~mode:Variables decls)
         node
 
 (* ---------- splitting static / dynamic ---------- *)

--- a/bin/dune
+++ b/bin/dune
@@ -11,4 +11,5 @@
   fmt.tty
   logs
   logs.fmt
-  memtrace))
+  memtrace
+  lambdasoup))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -17,7 +17,9 @@ let info =
   in
   Cmd.info "cascade" ~version:Cascade_info.version ~doc ~man
 
-let cmd = Cmd.group info ~default:Cmd_fmt.term [ Cmd_fmt.cmd; Cmd_diff.cmd ]
+let cmd =
+  Cmd.group info ~default:Cmd_fmt.term
+    [ Cmd_fmt.cmd; Cmd_diff.cmd; Cmd_inline.cmd ]
 
 (* cmdliner's [Cmd.group ~default] only invokes the default term when the
    command line is empty or the first positional is a known subcommand name; any
@@ -28,7 +30,9 @@ let rewrite_argv_for_default argv =
   if Array.length argv <= 1 then argv
   else
     let first = argv.(1) in
-    let is_known_subcommand = first = "fmt" || first = "diff" in
+    let is_known_subcommand =
+      first = "fmt" || first = "diff" || first = "inline"
+    in
     let is_help_or_version =
       first = "--help" || first = "-h" || first = "--version"
     in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -8,9 +8,10 @@ let info =
     [
       `S Manpage.s_description;
       `P
-        "Cascade ships two subcommands: $(b,fmt) (format, minify, inline) and \
-         $(b,diff) (structural CSS diff). When no subcommand is given, \
-         $(b,fmt) is used.";
+        "Cascade ships three subcommands: $(b,fmt) (format, minify, inline \
+         imports), $(b,diff) (structural CSS diff) and $(b,apply) (resolve a \
+         stylesheet into an HTML page's inline styles). When no subcommand is \
+         given, $(b,fmt) is used.";
       `S Manpage.s_bugs;
       `P "Report bugs at https://github.com/samoht/cascade";
     ]
@@ -19,7 +20,7 @@ let info =
 
 let cmd =
   Cmd.group info ~default:Cmd_fmt.term
-    [ Cmd_fmt.cmd; Cmd_diff.cmd; Cmd_inline.cmd ]
+    [ Cmd_fmt.cmd; Cmd_diff.cmd; Cmd_apply.cmd ]
 
 (* cmdliner's [Cmd.group ~default] only invokes the default term when the
    command line is empty or the first positional is a known subcommand name; any
@@ -31,7 +32,7 @@ let rewrite_argv_for_default argv =
   else
     let first = argv.(1) in
     let is_known_subcommand =
-      first = "fmt" || first = "diff" || first = "inline"
+      first = "fmt" || first = "diff" || first = "apply"
     in
     let is_help_or_version =
       first = "--help" || first = "-h" || first = "--version"

--- a/cascade.opam
+++ b/cascade.opam
@@ -19,7 +19,7 @@ depends: [
   "astring" {with-test}
   "eio" {with-test}
   "eio_main" {with-test}
-  "lambdasoup" {with-test}
+  "lambdasoup"
   "mdx" {with-test}
   "re" {with-test}
   "fmt"

--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@
   (astring :with-test)
   (eio :with-test)
   (eio_main :with-test)
-  (lambdasoup :with-test)
+  lambdasoup
   (mdx :with-test)
   (re :with-test)
   fmt

--- a/lib/dune
+++ b/lib/dune
@@ -42,6 +42,7 @@
   pp.mli
   properties.mli
   reader.mli
+  resolve.mli
   rule.mli
   rule_index.mli
   selector.mli

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4505,6 +4505,28 @@ let normalize_scale : scale -> scale =
   | XYZ (x, y, z) -> preserve_if_equal value (XYZ (np x, np y, np z))
   | other -> other
 
+(* [transform-origin] had no normalize pass, so [0px 50%] and [0% 50%] (and
+   [left center]) stayed in distinct spellings of the same origin. [0], [0px]
+   and [0%] all place the origin at the same edge, so fold every zero component
+   to the unitless [0] - the canonical form the [left]/[top] keywords already
+   minify to. *)
+let normalize_transform_origin : transform_origin -> transform_origin =
+  let z l =
+    match (l : Values.length) with
+    | Pct 0. -> (Zero : Values.length)
+    | _ -> Values.normalize_length l
+  in
+  fun value ->
+    match value with
+    | X a -> preserve_if_equal value (X (z a))
+    | XY (a, b) -> preserve_if_equal value (XY (z a, z b))
+    | XYZ (a, b, c) -> preserve_if_equal value (XYZ (z a, z b, z c))
+    | Position p ->
+        preserve_if_equal value (Position (normalize_position_value p))
+    | Position_z (p, c) ->
+        preserve_if_equal value (Position_z (normalize_position_value p, z c))
+    | other -> other
+
 let normalize_ray_size : ray_size -> ray_size =
  fun value ->
   match value with
@@ -20845,6 +20867,7 @@ let normalize_property_value : type a.
   | Rotate -> normalize_rotate value
   | Scale -> normalize_scale value
   | Translate -> normalize_translate_value value
+  | Transform_origin -> normalize_transform_origin value
   | Offset_path -> normalize_offset_path value
   | Offset_rotate -> normalize_offset_rotate value
   | Font_style -> normalize_font_style value

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -92,8 +92,7 @@ module Make (N : NODE) = struct
     | Selector.List ss | Selector.Is ss | Selector.Where ss ->
         List.exists (fun s -> matches s n) ss
     | Selector.Not ss -> not (List.exists (fun s -> matches s n) ss)
-    | Selector.Combined (left, comb, right) ->
-        matches right n && combinator left comb n
+    | Selector.Combined _ -> anchors sel n <> []
     | Selector.Root -> N.parent n = None
     | Selector.First_child -> is_first n
     | Selector.Last_child -> is_last n
@@ -102,16 +101,31 @@ module Make (N : NODE) = struct
     (* stateful / generated / unknown forms cannot be matched statically *)
     | _ -> false
 
-  and combinator left comb n =
+  (* [Selector] is right-leaning: [a b > c] is [Combined (a, Descendant,
+     Combined (b, Child, c))], so the rightmost compound (the subject) sits at
+     the bottom of [right] and each combinator joins its [left] compound to the
+     compound *after* it, not to the subject. [anchors sel n] returns the nodes
+     where [sel]'s leftmost compound matches when [sel] matches with subject [n]
+     (empty = no match): [right] must match [n], then for every node [a] that
+     [right]'s leftmost compound anchored at, [left] must be [comb]-related to
+     [a]. Threading the anchor this way is what the old subject-only
+     [combinator] missed for any selector with two or more combinators. *)
+  and anchors sel n =
+    match sel with
+    | Selector.Combined (left, comb, right) ->
+        anchors right n |> List.concat_map (related left comb)
+    | _ -> if matches sel n then [ n ] else []
+
+  and related left comb a =
     match comb with
-    | Selector.Descendant -> List.exists (matches left) (ancestors n)
+    | Selector.Descendant -> List.filter (matches left) (ancestors a)
     | Selector.Child -> (
-        match N.parent n with Some p -> matches left p | None -> false)
+        match N.parent a with Some p when matches left p -> [ p ] | _ -> [])
     | Selector.Next_sibling -> (
-        match imm_pred n with Some s -> matches left s | None -> false)
+        match imm_pred a with Some s when matches left s -> [ s ] | _ -> [])
     | Selector.Subsequent_sibling ->
-        List.exists (matches left) (preceding_siblings n)
-    | _ -> false
+        List.filter (matches left) (preceding_siblings a)
+    | _ -> []
 
   let resolve sheet node =
     let upsert acc d =

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -1,0 +1,140 @@
+module type NODE = sig
+  type t
+
+  val equal : t -> t -> bool
+  val name : t -> string option
+  val id : t -> string option
+  val classes : t -> string list
+  val attribute : t -> string -> string option
+  val parent : t -> t option
+  val children : t -> t list
+end
+
+let ci a b = String.lowercase_ascii a = String.lowercase_ascii b
+let words s = String.split_on_char ' ' s |> List.filter (( <> ) "")
+
+let contains hay needle =
+  let lh = String.length hay and ln = String.length needle in
+  if ln = 0 then true
+  else
+    let rec go i =
+      if i + ln > lh then false
+      else if String.sub hay i ln = needle then true
+      else go (i + 1)
+    in
+    go 0
+
+let starts s p =
+  String.length s >= String.length p && String.sub s 0 (String.length p) = p
+
+let ends s p =
+  let ls = String.length s and lp = String.length p in
+  ls >= lp && String.sub s (ls - lp) lp = p
+
+let attr_key : Selector.attr_name -> string = function
+  | Selector.Regular s -> s
+  | Selector.Data s -> "data-" ^ s
+  | Selector.Aria a -> Aria.to_string a
+
+module Make (N : NODE) = struct
+  let preceding_siblings n =
+    match N.parent n with
+    | None -> []
+    | Some p ->
+        let rec before acc = function
+          | [] -> List.rev acc
+          | x :: _ when N.equal x n -> List.rev acc
+          | x :: rest -> before (x :: acc) rest
+        in
+        before [] (N.children p)
+
+  let imm_pred n =
+    match List.rev (preceding_siblings n) with x :: _ -> Some x | [] -> None
+
+  let is_first n = preceding_siblings n = []
+
+  let is_last n =
+    match N.parent n with
+    | None -> true
+    | Some p -> (
+        match List.rev (N.children p) with x :: _ -> N.equal x n | [] -> true)
+
+  let rec ancestors n =
+    match N.parent n with None -> [] | Some p -> p :: ancestors p
+
+  let attr_matches n name (m : Selector.attribute_match) =
+    match N.attribute n (attr_key name) with
+    | None -> false
+    | Some v -> (
+        match m with
+        | Selector.Presence -> true
+        | Selector.Exact s | Selector.Exact_quoted (s, _) -> v = s
+        | Selector.Whitespace_list s | Selector.Whitespace_list_quoted (s, _) ->
+            List.mem s (words v)
+        | Selector.Prefix s | Selector.Prefix_quoted (s, _) ->
+            s <> "" && starts v s
+        | Selector.Suffix s | Selector.Suffix_quoted (s, _) ->
+            s <> "" && ends v s
+        | Selector.Substring s | Selector.Substring_quoted (s, _) ->
+            s <> "" && contains v s
+        | Selector.Hyphen_list s | Selector.Hyphen_list_quoted (s, _) ->
+            v = s || starts v (s ^ "-"))
+
+  let rec matches (sel : Selector.t) n : bool =
+    match sel with
+    | Selector.Universal _ -> true
+    | Selector.Element (_, name) -> (
+        match N.name n with Some nm -> ci nm name | None -> false)
+    | Selector.Class c -> List.mem c (N.classes n)
+    | Selector.Id i -> N.id n = Some i
+    | Selector.Attribute (_, name, m, _) -> attr_matches n name m
+    | Selector.Compound ps -> List.for_all (fun p -> matches p n) ps
+    | Selector.List ss | Selector.Is ss | Selector.Where ss ->
+        List.exists (fun s -> matches s n) ss
+    | Selector.Not ss -> not (List.exists (fun s -> matches s n) ss)
+    | Selector.Combined (left, comb, right) ->
+        matches right n && combinator left comb n
+    | Selector.Root -> N.parent n = None
+    | Selector.First_child -> is_first n
+    | Selector.Last_child -> is_last n
+    | Selector.Only_child -> is_first n && is_last n
+    | Selector.Empty -> N.children n = []
+    (* stateful / generated / unknown forms cannot be matched statically *)
+    | _ -> false
+
+  and combinator left comb n =
+    match comb with
+    | Selector.Descendant -> List.exists (matches left) (ancestors n)
+    | Selector.Child -> (
+        match N.parent n with Some p -> matches left p | None -> false)
+    | Selector.Next_sibling -> (
+        match imm_pred n with Some s -> matches left s | None -> false)
+    | Selector.Subsequent_sibling ->
+        List.exists (matches left) (preceding_siblings n)
+    | _ -> false
+
+  let resolve sheet node =
+    let upsert acc d =
+      let k = Declaration.property_name d in
+      (k, d) :: List.remove_assoc k acc
+    in
+    let matched =
+      Flatten.block sheet
+      |> List.filter_map (function Stylesheet.Rule r -> Some r | _ -> None)
+      |> List.mapi (fun i r ->
+          let sel = Stylesheet.selector r in
+          if matches sel node then
+            Some (Selector.specificity sel, i, Stylesheet.declarations r)
+          else None)
+      |> List.filter_map Fun.id
+      |> List.stable_sort (fun (s1, i1, _) (s2, i2, _) ->
+          match compare s1 s2 with 0 -> compare i1 i2 | c -> c)
+    in
+    let decls = List.concat_map (fun (_, _, ds) -> ds) matched in
+    let normal =
+      List.filter (fun d -> not (Declaration.is_important d)) decls
+    in
+    let important = List.filter Declaration.is_important decls in
+    (* normal first, then !important, last wins per property *)
+    List.fold_left upsert [] (normal @ important) |> List.rev_map snd
+end

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -1,0 +1,39 @@
+(** Resolve a stylesheet against the nodes of a tree: selector matching and the
+    cascade, decoupled from any particular DOM.
+
+    A caller supplies its node type through {!NODE}; {!Make} then matches
+    selectors and resolves the winning declarations per node. Nesting is
+    flattened with {!Flatten}, so a stylesheet produced by the optimiser
+    resolves the same as the authored form. *)
+
+module type NODE = sig
+  type t
+
+  val equal : t -> t -> bool
+  (** Node identity, used to locate a node among its siblings. *)
+
+  val name : t -> string option
+  (** The element name (e.g. ["div"]), or [None] for an anonymous node. *)
+
+  val id : t -> string option
+  val classes : t -> string list
+  val attribute : t -> string -> string option
+
+  val parent : t -> t option
+  (** The parent element, or [None] at the root. *)
+
+  val children : t -> t list
+  (** The child elements, in document order. *)
+end
+
+module Make (N : NODE) : sig
+  val matches : Selector.t -> N.t -> bool
+  (** [matches sel node] is whether [sel] matches [node]. Stateful and generated
+      forms ([:hover], [::before], unknown pseudo-classes, ...) never match. *)
+
+  val resolve : Stylesheet.t -> N.t -> Declaration.declaration list
+  (** [resolve sheet node] is the declarations that win for [node] after
+      flattening nesting and applying the cascade: selector matching,
+      specificity, source order, then [!important] over normal. Conditional and
+      at-rule groups ([@media], [@layer], ...) are not considered. *)
+end

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -16,8 +16,13 @@ module type NODE = sig
   (** The element name (e.g. ["div"]), or [None] for an anonymous node. *)
 
   val id : t -> string option
+  (** The [id] attribute, or [None]. *)
+
   val classes : t -> string list
+  (** The class names from the [class] attribute. *)
+
   val attribute : t -> string -> string option
+  (** [attribute t name] is the value of attribute [name], or [None]. *)
 
   val parent : t -> t option
   (** The parent element, or [None] at the root. *)

--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -1,6 +1,6 @@
-# `cascade inline` differential test
+# `cascade apply` differential test
 
-`cascade inline` resolves a stylesheet into each element's `style` attribute and
+`cascade apply` resolves a stylesheet into each element's `style` attribute and
 drops the `<style>` blocks. This checks that the result is equivalent to the
 original: for every element, the **complete `getComputedStyle`** in a real
 headless browser must be identical between the original page and the inlined

--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -1,0 +1,16 @@
+# `cascade inline` differential test
+
+`cascade inline` resolves a stylesheet into each element's `style` attribute and
+drops the `<style>` blocks. This checks that the result is equivalent to the
+original: for every element, the **complete `getComputedStyle`** in a real
+headless browser must be identical between the original page and the inlined
+output, in both the default (full) and `--minimal` modes.
+
+```sh
+CASCADE=_build/default/bin/main.exe sh test/inline/run.sh
+```
+
+It looks for a headless Chrome on `PATH`, in `$CHROME`, or under the puppeteer
+cache, and skips cleanly if none is found (so it is a no-op in CI). `xtest.js`
+injects an extractor script, runs the browser with `--dump-dom`, and diffs the
+computed styles element by element.

--- a/test/inline/canon_filter.ml
+++ b/test/inline/canon_filter.ml
@@ -1,0 +1,23 @@
+(* Reduce computed-style differences to the render-real ones. The differential
+   test compares getComputedStyle strings, which differ for spellings cascade
+   considers equivalent ([0% 0%] vs [0px 0px], [red] vs [rgb(255, 0, 0)]). Each
+   line on stdin is [index<TAB>tag<TAB>property<TAB>valueA<TAB>valueB]; a line is
+   echoed only when its two values are not [Css_compare]-canonically equal, i.e.
+   when inlining actually changed the render. *)
+
+let wrap prop value = String.concat "" [ "x{"; prop; ":"; value; "}" ]
+
+let canon_equal prop a b =
+  try Cascade_diff.Css_compare.equal ~mode:`Canonical (wrap prop a) (wrap prop b)
+  with _ -> false
+
+let () =
+  try
+    while true do
+      let line = input_line stdin in
+      match String.split_on_char '\t' line with
+      | _ :: _ :: prop :: a :: b :: _ ->
+          if not (canon_equal prop a b) then print_endline line
+      | _ -> ()
+    done
+  with End_of_file -> ()

--- a/test/inline/canon_filter.ml
+++ b/test/inline/canon_filter.ml
@@ -1,14 +1,15 @@
 (* Reduce computed-style differences to the render-real ones. The differential
    test compares getComputedStyle strings, which differ for spellings cascade
    considers equivalent ([0% 0%] vs [0px 0px], [red] vs [rgb(255, 0, 0)]). Each
-   line on stdin is [index<TAB>tag<TAB>property<TAB>valueA<TAB>valueB]; a line is
-   echoed only when its two values are not [Css_compare]-canonically equal, i.e.
-   when inlining actually changed the render. *)
+   line on stdin is [index<TAB>tag<TAB>property<TAB>valueA<TAB>valueB]; a line
+   is echoed only when its two values are not [Css_compare]-canonically equal,
+   i.e. when inlining actually changed the render. *)
 
 let wrap prop value = String.concat "" [ "x{"; prop; ":"; value; "}" ]
 
 let canon_equal prop a b =
-  try Cascade_diff.Css_compare.equal ~mode:`Canonical (wrap prop a) (wrap prop b)
+  try
+    Cascade_diff.Css_compare.equal ~mode:`Canonical (wrap prop a) (wrap prop b)
   with _ -> false
 
 let () =

--- a/test/inline/dune
+++ b/test/inline/dune
@@ -1,0 +1,6 @@
+; Developer-run differential test helper: filters getComputedStyle differences
+; down to the ones cascade considers a real render change. Not part of the
+; default test run; driven by run.sh.
+(executable
+ (name canon_filter)
+ (libraries cascade cascade_diff))

--- a/test/inline/dune
+++ b/test/inline/dune
@@ -1,6 +1,7 @@
 ; Developer-run differential test helper: filters getComputedStyle differences
 ; down to the ones cascade considers a real render change. Not part of the
 ; default test run; driven by run.sh.
+
 (executable
  (name canon_filter)
  (libraries cascade cascade_diff))

--- a/test/inline/fetch.sh
+++ b/test/inline/fetch.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Download a few real pages into test/inline/pages/ so run.sh can run the
+# differential test against them. Each page is made self-contained (its external
+# stylesheets are fetched and inlined into a <style> block) so the inliner has
+# CSS to project and the page renders without network access. The downloaded
+# files are large and change upstream, so they are gitignored, never committed.
+dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+out="$dir/pages"
+mkdir -p "$out"
+
+fetch() { # name url
+  name="$1"
+  url="$2"
+  echo "$name <- $url"
+  if curl -sL --max-time 60 -A "Mozilla/5.0" "$url" -o "$out/$name.raw.html"; then
+    node "$dir/inline_css.js" "$url" "$out/$name.raw.html" "$out/$name.html" ||
+      echo "  inline-css failed"
+  else
+    echo "  download failed"
+  fi
+  rm -f "$out/$name.raw.html"
+}
+
+fetch wikipedia https://en.wikipedia.org/wiki/Cascading_Style_Sheets
+fetch ocaml https://ocaml.org/
+fetch bootstrap https://getbootstrap.com/docs/5.3/examples/album/
+fetch tailwind https://tailwindcss.com/

--- a/test/inline/fixtures/basic.html
+++ b/test/inline/fixtures/basic.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head><style>
+  body { font-family: sans-serif; color: #222 }
+  .card { border: 1px solid #ccc; padding: 16px }
+  .card > h2 { color: navy; margin: 0 }
+  #lead { color: crimson; font-weight: bold }
+  a[href^="https"] { color: green }
+  ul li + li { margin-top: 4px }
+</style></head>
+<body>
+  <div class="card">
+    <h2 id="lead">Title</h2>
+    <p>See <a href="https:// x">link</a> and <a href="/local">local</a>.</p>
+    <ul><li>one</li><li>two</li><li>three</li></ul>
+  </div>
+</body>
+</html>

--- a/test/inline/fixtures/dynamic.html
+++ b/test/inline/fixtures/dynamic.html
@@ -1,0 +1,7 @@
+<!doctype html><html><head><style>
+  .b { color: red; padding: 4px }
+  .b:hover { color: blue }
+  @media (max-width: 600px) { .b { padding: 8px } }
+  @keyframes spin { to { transform: rotate(360deg) } }
+</style></head>
+<body><div class="b">x</div></body></html>

--- a/test/inline/fixtures/important.html
+++ b/test/inline/fixtures/important.html
@@ -1,0 +1,12 @@
+<!doctype html><html><head><style>
+  p          { color: blue !important; font-size: 10px; margin: 1px }
+  .hi        { color: red; font-size: 20px }
+  #x         { color: green }
+  div p      { margin: 5px }
+  div > .hi  { padding: 3px }
+  [data-k="v"] { background: yellow }
+  body       { font-family: serif }
+</style></head>
+<body>
+  <div><p class="hi" id="x" data-k="v" style="font-size:30px;color:black">text</p></div>
+</body></html>

--- a/test/inline/fixtures/responsive.html
+++ b/test/inline/fixtures/responsive.html
@@ -1,0 +1,4 @@
+<!doctype html><html><head><style>
+  .c { width: 100% }
+  @media (min-width: 300px) { .c { width: 50% } }
+</style></head><body><div class="c">x</div></body></html>

--- a/test/inline/fixtures/variables.html
+++ b/test/inline/fixtures/variables.html
@@ -1,0 +1,4 @@
+<!doctype html><html><head><style>
+  :root { --x: #212529; --bg: #fff }
+  body { color: var(--x); background: var(--bg) }
+</style></head><body><p>hi</p></body></html>

--- a/test/inline/inline_css.js
+++ b/test/inline/inline_css.js
@@ -1,0 +1,38 @@
+// Make a fetched page self-contained: download every linked stylesheet and
+// inline it into a single <style> block, dropping the <link rel=stylesheet>
+// tags. The inliner reads CSS from <style>, and a self-contained page renders
+// in the headless browser without network access, so the differential test is
+// reproducible. Usage: node inline_css.js <page-url> <raw.html> <out.html>
+const { execSync } = require('child_process');
+const fs = require('fs');
+const [, , pageUrl, rawPath, outPath] = process.argv;
+
+let html = fs.readFileSync(rawPath, 'utf8');
+const base = new URL(pageUrl);
+
+const hrefs = [];
+html.replace(/<link\b[^>]*>/gi, (tag) => {
+  if (/rel\s*=\s*["']?stylesheet/i.test(tag)) {
+    const m = tag.match(/href\s*=\s*["']([^"']+)["']/i);
+    if (m) hrefs.push(m[1]);
+  }
+  return tag;
+});
+
+let css = '';
+for (const href of hrefs) {
+  const u = new URL(href, base).toString();
+  try {
+    css += '\n' + execSync(`curl -sL --max-time 60 -A "Mozilla/5.0" "${u}"`, {
+      encoding: 'utf8', maxBuffer: 5e8,
+    });
+  } catch (e) {
+    console.error('  css fetch failed: ' + u);
+  }
+}
+
+html = html.replace(/<link\b[^>]*rel\s*=\s*["']?stylesheet[^>]*>/gi, '');
+const style = '<style>' + css + '</style>';
+html = html.includes('</head>') ? html.replace('</head>', style + '</head>') : style + html;
+fs.writeFileSync(outPath, html);
+console.log('  wrote ' + outPath + ' (' + html.length + ' bytes, ' + hrefs.length + ' stylesheet(s))');

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Differential test for `cascade inline`: the resolved page must produce the
+# same computed style, for every element, as the original page with its
+# <style> blocks, in a real headless browser. Both output modes are checked.
+# Skips cleanly when no headless browser or node is available (e.g. in CI).
+dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+CASCADE=${CASCADE:-cascade}
+if [ -z "$CHROME" ]; then
+  CHROME=$(command -v chromium 2>/dev/null || command -v google-chrome 2>/dev/null || true)
+fi
+[ -z "$CHROME" ] && CHROME=$(find "$HOME/.cache/puppeteer" -type f -name chrome-headless-shell 2>/dev/null | sort | tail -1)
+if [ -z "$CHROME" ] || ! command -v node >/dev/null 2>&1; then
+  echo "SKIP: no headless browser or node available"; exit 0
+fi
+export CHROME
+fail=0
+for f in "$dir"/fixtures/*.html; do
+  for mode in "" "--minimal"; do
+    out=$(mktemp)
+    "$CASCADE" inline $mode "$f" > "$out" 2>/dev/null
+    if node "$dir/xtest.js" "$f" "$out" 2>&1 | grep -q "IDENTICAL"; then
+      echo "ok   $(basename "$f") ${mode:-full}"
+    else
+      echo "FAIL $(basename "$f") ${mode:-full}"; node "$dir/xtest.js" "$f" "$out" 2>&1 | tail -6; fail=1
+    fi
+    rm -f "$out"
+  done
+done
+exit $fail

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -13,6 +13,13 @@ if [ -z "$CHROME" ] || ! command -v node >/dev/null 2>&1; then
   echo "SKIP: no headless browser or node available"; exit 0
 fi
 export CHROME
+# Canonical-difference filter: compares values the way cascade does, so
+# render-equivalent spellings (0% vs 0px, red vs rgb(...)) are not reported.
+if command -v dune >/dev/null 2>&1; then
+  dune build test/inline/canon_filter.exe 2>/dev/null
+  CANON_FILTER=$(cd "$dir/../.." && find _build -name canon_filter.exe 2>/dev/null | head -1)
+  [ -n "$CANON_FILTER" ] && export CANON_FILTER="$(cd "$dir/../.." && pwd)/$CANON_FILTER"
+fi
 fail=0
 for f in "$dir"/fixtures/*.html; do
   for mode in "" "--minimal"; do

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Differential test for `cascade inline`: the resolved page must produce the
+# Differential test for `cascade apply`: the resolved page must produce the
 # same computed style, for every element, as the original page with its
 # <style> blocks, in a real headless browser. Both output modes are checked.
 # Skips cleanly when no headless browser or node is available (e.g. in CI).
@@ -24,7 +24,7 @@ fail=0
 for f in "$dir"/fixtures/*.html; do
   for mode in "" "--minimal"; do
     out=$(mktemp)
-    "$CASCADE" inline $mode "$f" > "$out" 2>/dev/null
+    "$CASCADE" apply $mode "$f" > "$out" 2>/dev/null
     if node "$dir/xtest.js" "$f" "$out" 2>&1 | grep -q "IDENTICAL"; then
       echo "ok   $(basename "$f") ${mode:-full}"
     else
@@ -40,7 +40,7 @@ if [ -d "$dir/pages" ]; then
   for f in "$dir"/pages/*.html; do
     [ -e "$f" ] || continue
     out=$(mktemp)
-    "$CASCADE" inline --minimal "$f" > "$out" 2>/dev/null
+    "$CASCADE" apply --minimal "$f" > "$out" 2>/dev/null
     res=$(node "$dir/xtest.js" "$f" "$out" 2>/dev/null | grep RESULT)
     echo "real $(basename "$f"): ${res:-no result}"
     rm -f "$out"

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -33,4 +33,17 @@ for f in "$dir"/fixtures/*.html; do
     rm -f "$out"
   done
 done
+# Real pages downloaded by fetch.sh (gitignored): reported for coverage, but
+# they do not gate the run - they change upstream and exercise features still
+# being grown, so only the committed fixtures decide pass/fail.
+if [ -d "$dir/pages" ]; then
+  for f in "$dir"/pages/*.html; do
+    [ -e "$f" ] || continue
+    out=$(mktemp)
+    "$CASCADE" inline --minimal "$f" > "$out" 2>/dev/null
+    res=$(node "$dir/xtest.js" "$f" "$out" 2>/dev/null | grep RESULT)
+    echo "real $(basename "$f"): ${res:-no result}"
+    rm -f "$out"
+  done
+fi
 exit $fail

--- a/test/inline/xtest.js
+++ b/test/inline/xtest.js
@@ -4,7 +4,9 @@ const CHROME = process.env.CHROME;
 const SKIP = { STYLE:1, SCRIPT:1, HEAD:1, META:1, TITLE:1, BASE:1, LINK:1, HTML:1 };
 const EXTRACTOR = '<script>(function(){var s=' + JSON.stringify(SKIP) +
   ';var e=document.querySelectorAll("*"),o=[];for(var i=0;i<e.length;i++){var x=e[i];if(s[x.tagName])continue;' +
-  'var c=getComputedStyle(x),r={_tag:x.tagName};for(var j=0;j<c.length;j++){var p=c[j];r[p]=c.getPropertyValue(p);}o.push(r);}' +
+  // skip custom properties (--*): they affect rendering only through var() in
+  // real properties, which are already resolved and compared below.
+  'var c=getComputedStyle(x),r={_tag:x.tagName};for(var j=0;j<c.length;j++){var p=c[j];if(p.indexOf("--")===0)continue;r[p]=c.getPropertyValue(p);}o.push(r);}' +
   'document.body.setAttribute("data-xtest",btoa(unescape(encodeURIComponent(JSON.stringify(o)))));})();</script>';
 function computed(path){
   let h = fs.readFileSync(path,'utf8');

--- a/test/inline/xtest.js
+++ b/test/inline/xtest.js
@@ -19,10 +19,23 @@ function computed(path){
   return JSON.parse(Buffer.from(m[1],'base64').toString('utf8'));
 }
 const a = computed(process.argv[2]), b = computed(process.argv[3]);
-const diffs = [];
-if (a.length !== b.length) diffs.push('element count '+a.length+' vs '+b.length);
 const n = Math.min(a.length,b.length);
-for (let i=0;i<n;i++) for (const p in a[i]) if (a[i][p]!==b[i][p]) diffs.push('['+i+' '+a[i]._tag+'] '+p+': "'+a[i][p]+'" vs "'+b[i][p]+'"');
-console.log('visual elements: '+n+', computed props/elem: ~'+Object.keys(a[0]||{}).length);
+// Candidate differences: any property whose getComputedStyle string differs.
+const cand = [];
+for (let i=0;i<n;i++) for (const p in a[i]) if (a[i][p]!==b[i][p])
+  cand.push(i+'\t'+a[i]._tag+'\t'+p+'\t'+a[i][p]+'\t'+b[i][p]);
+// Reduce to render-real differences: a pair like "0% 0%" vs "0px 0px" or "red"
+// vs "rgb(255, 0, 0)" is the same render, so canon_filter (Css_compare
+// ~mode:Canonical) drops it; only an actual render change survives.
+let lines = cand;
+const CANON = process.env.CANON_FILTER;
+if (CANON && cand.length) {
+  const tmp = '/tmp/canon_'+process.pid+'.tsv';
+  fs.writeFileSync(tmp, cand.join('\n'));
+  lines = execSync(`"${CANON}" < "${tmp}"`,{encoding:'utf8',maxBuffer:1e8}).split('\n').filter(Boolean);
+}
+const diffs = lines.map(l=>{const f=l.split('\t');return '['+f[0]+' '+f[1]+'] '+f[2]+': "'+f[3]+'" vs "'+f[4]+'"';});
+if (a.length !== b.length) diffs.unshift('element count '+a.length+' vs '+b.length);
+console.log('visual elements: '+n+', computed props/elem: ~'+Object.keys(a[0]||{}).length+(CANON?' (canonical compare)':''));
 if (!diffs.length) console.log('RESULT: IDENTICAL computed styles (inlining preserves the render)');
 else { console.log('RESULT: '+diffs.length+' difference(s):'); diffs.slice(0,40).forEach(d=>console.log('  '+d)); }

--- a/test/inline/xtest.js
+++ b/test/inline/xtest.js
@@ -1,0 +1,26 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const CHROME = process.env.CHROME;
+const SKIP = { STYLE:1, SCRIPT:1, HEAD:1, META:1, TITLE:1, BASE:1, LINK:1, HTML:1 };
+const EXTRACTOR = '<script>(function(){var s=' + JSON.stringify(SKIP) +
+  ';var e=document.querySelectorAll("*"),o=[];for(var i=0;i<e.length;i++){var x=e[i];if(s[x.tagName])continue;' +
+  'var c=getComputedStyle(x),r={_tag:x.tagName};for(var j=0;j<c.length;j++){var p=c[j];r[p]=c.getPropertyValue(p);}o.push(r);}' +
+  'document.body.setAttribute("data-xtest",btoa(unescape(encodeURIComponent(JSON.stringify(o)))));})();</script>';
+function computed(path){
+  let h = fs.readFileSync(path,'utf8');
+  h = h.includes('</body>') ? h.replace('</body>', EXTRACTOR+'</body>') : h+EXTRACTOR;
+  const tmp = '/tmp/xt_'+path.replace(/\W/g,'_')+'.html';
+  fs.writeFileSync(tmp,h);
+  const dom = execSync(`"${CHROME}" --headless --disable-gpu --no-sandbox --virtual-time-budget=2000 --dump-dom "file://${tmp}"`,{encoding:'utf8',maxBuffer:1e8});
+  const m = dom.match(/data-xtest="([^"]*)"/);
+  if(!m) throw new Error('no data-xtest for '+path);
+  return JSON.parse(Buffer.from(m[1],'base64').toString('utf8'));
+}
+const a = computed(process.argv[2]), b = computed(process.argv[3]);
+const diffs = [];
+if (a.length !== b.length) diffs.push('element count '+a.length+' vs '+b.length);
+const n = Math.min(a.length,b.length);
+for (let i=0;i<n;i++) for (const p in a[i]) if (a[i][p]!==b[i][p]) diffs.push('['+i+' '+a[i]._tag+'] '+p+': "'+a[i][p]+'" vs "'+b[i][p]+'"');
+console.log('visual elements: '+n+', computed props/elem: ~'+Object.keys(a[0]||{}).length);
+if (!diffs.length) console.log('RESULT: IDENTICAL computed styles (inlining preserves the render)');
+else { console.log('RESULT: '+diffs.length+' difference(s):'); diffs.slice(0,40).forEach(d=>console.log('  '+d)); }

--- a/test/test.ml
+++ b/test/test.ml
@@ -24,6 +24,7 @@ let () =
       Test_parser.suite;
       Test_cursor.suite;
       Test_error.suite;
+      Test_resolve.suite;
       Test_sort.suite;
       Test_order_maintenance.suite;
       Test_common.suite;

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -1,0 +1,112 @@
+open Cascade
+
+(* A minimal in-memory element tree to exercise {!Resolve.Make} without a
+   DOM. *)
+type tree = {
+  tname : string;
+  tid : string option;
+  tclasses : string list;
+  mutable tparent : tree option;
+  tchildren : tree list;
+}
+
+let elt ?id ?(classes = []) name children =
+  let t =
+    {
+      tname = name;
+      tid = id;
+      tclasses = classes;
+      tparent = None;
+      tchildren = children;
+    }
+  in
+  List.iter (fun c -> c.tparent <- Some t) children;
+  t
+
+module Node = struct
+  type t = tree
+
+  let equal = ( == )
+  let name t = Some t.tname
+  let id t = t.tid
+  let classes t = t.tclasses
+  let attribute _ _ = None
+  let parent t = t.tparent
+  let children t = t.tchildren
+end
+
+module R = Resolve.Make (Node)
+
+let sel = Selector.of_string
+
+(* section div (#a) span (#s1) div (#b) span (#s2) *)
+let s1 = elt ~id:"s1" "span" []
+let s2 = elt ~id:"s2" "span" []
+let a = elt ~id:"a" "div" [ s1 ]
+let b = elt ~id:"b" "div" [ s2 ]
+let _section = elt "section" [ a; b ]
+let yes name s n = Alcotest.(check bool) name true (R.matches (sel s) n)
+let no name s n = Alcotest.(check bool) name false (R.matches (sel s) n)
+
+let test_simple () =
+  yes "element" "span" s1;
+  yes "id" "#s2" s2;
+  no "wrong id" "#s1" s2;
+  yes "compound element+id" "div#a" a;
+  no "compound mismatch" "div#b" a
+
+let test_single_combinator () =
+  yes "descendant" "section span" s2;
+  yes "child" "div>span" s2;
+  no "child needs direct parent" "section>span" s2;
+  yes "next-sibling on div" "div+div" b;
+  no "next-sibling: first has no predecessor" "div+div" a;
+  yes "subsequent-sibling" "div~div" b
+
+(* The regression: a sibling combinator followed by a descendant/child
+   combinator. The subject ([span]) sits past two combinators, so the matcher
+   must thread the anchor: [div+div] applies between the two divs, not at the
+   span. *)
+let test_sibling_then_descendant () =
+  yes "sibling then child" "div+div>span" s2;
+  no "first branch has no preceding sibling" "div+div>span" s1;
+  yes "sibling then descendant" "div+div span" s2;
+  no "descendant of first div" "div+div span" s1;
+  yes "subsequent-sibling then child" "div~div>span" s2
+
+let test_resolve_cascade () =
+  let sheet =
+    match
+      Css.of_string
+        "span{color:red}#s2{color:#0f0}div+div>span{font-weight:700}"
+    with
+    | Ok { stylesheet; _ } -> stylesheet
+    | Error e -> Alcotest.failf "parse: %s" (Error.to_string e)
+  in
+  let decls = R.resolve sheet s2 in
+  let value p =
+    List.find_map
+      (fun d ->
+        if Declaration.property_name d = p then
+          Some (Declaration.string_of_declaration ~minify:true d)
+        else None)
+      decls
+  in
+  (* higher specificity #s2 beats the element rule *)
+  Alcotest.(check (option string))
+    "id wins over element" (Some "color:#0f0") (value "color");
+  (* the sibling+child rule that the old matcher missed now contributes *)
+  Alcotest.(check (option string))
+    "sibling-combined rule applies" (Some "font-weight:700")
+    (value "font-weight")
+
+let suite =
+  ( "resolve",
+    [
+      Alcotest.test_case "simple selectors" `Quick test_simple;
+      Alcotest.test_case "single combinator" `Quick test_single_combinator;
+      Alcotest.test_case "sibling then descendant/child" `Quick
+        test_sibling_then_descendant;
+      Alcotest.test_case "resolve applies the cascade" `Quick
+        test_resolve_cascade;
+    ] )

--- a/test/test_resolve.mli
+++ b/test/test_resolve.mli
@@ -1,0 +1,4 @@
+(** Unit tests for [Resolve]. *)
+
+val suite : string * unit Alcotest.test_case list
+(** Alcotest suite for [Resolve]. *)


### PR DESCRIPTION
This PR adds `cascade inline`, a CLI subcommand that resolves a stylesheet into an HTML page's inline `style` attributes, and `Cascade.Resolve`, the library cascade engine it builds on. It re-applies #114 (reverted in #115) with the matcher and resolver moved out of the CLI and into the library.

`Resolve.Make (Node)` takes a node type (name, id, classes, attribute, parent, children) and resolves a stylesheet against it: selector matching, specificity, source order, and `!important`, last winner per property. Nesting is flattened through the existing `Flatten`, so optimiser output resolves the same as the authored form.

`cascade inline <page.html> [extra.css]` writes each element's resolved declarations into its `style` attribute. Rules with no inline form (`:hover`, `@media`, `@keyframes`, pseudo-elements) stay in a single `<style>`, and a property such a rule can override is left in the cascade rather than inlined, since an inline style would outrank it. `:root` declarations land on `<html>` so its custom properties reach descendants that read them through `var()`. `--minimal` drops an inherited declaration the element already inherits.

`test/inline` is a developer-run differential test, skipped without a headless browser: it loads the original page and the inlined output in the same Chrome and asserts every element's `getComputedStyle` matches. It passes on the fixtures covering static, responsive, dynamic, custom-property and nested stylesheets.
