### PR TITLE
css: preserve var() inside colour functions

### DIFF
--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -209,6 +209,16 @@ and component_has_invalid_var = function
       components_have_invalid_var value
   | Component.Preserved _ -> false
 
+let rec components_contain_var components =
+  List.exists component_contains_var components
+
+and component_contains_var = function
+  | Component.Func { node = { name; arguments; _ }; _ } ->
+      String.lowercase_ascii_preserve name = "var"
+      || components_contain_var arguments
+  | Component.Block { node = { value; _ }; _ } -> components_contain_var value
+  | Component.Preserved _ -> false
+
 let raw_value_has_invalid_var raw_value =
   Cursor.of_string raw_value |> Cursor.remaining |> components_have_invalid_var
 
@@ -1855,10 +1865,34 @@ let color_fallback_function raw_value =
            ])
   | _ -> false
 
-let is_unsupported_color_fallback name raw_value =
-  color_fallback_function raw_value
-  &&
-  match name with
+(* A colour function whose arguments contain a [var()] can't be validated until
+   substitution (CSS Variables L1 section 3): the var() may stand for several
+   channels or the alpha, so the arity and legacy/modern separator style aren't
+   known at parse time. [rgba(var(--rgb), var(--a))] with a comma-list [--rgb]
+   only stays valid as the legacy comma form, so cascade keeps the declaration
+   verbatim. The function may be nested (a gradient stop, a shadow colour), so
+   the search recurses. (A math function whose return type is wrong regardless
+   of the var, e.g. [flex-basis: sign(var(--x))], is still rejected by the
+   reader.) *)
+let rec components_have_var_color_function components =
+  List.exists component_has_var_color_function components
+
+and component_has_var_color_function = function
+  | Component.Func { node = { name; arguments; _ }; _ } ->
+      List.mem
+        (String.lowercase_ascii_preserve name)
+        [ "rgb"; "rgba"; "hsl"; "hsla"; "hwb"; "lab"; "lch"; "oklab"; "oklch" ]
+      && components_contain_var arguments
+      || components_have_var_color_function arguments
+  | Component.Block { node = { value; _ }; _ } ->
+      components_have_var_color_function value
+  | Component.Preserved _ -> false
+
+let has_var_color_function raw_value =
+  Cursor.of_string raw_value |> Cursor.remaining
+  |> components_have_var_color_function
+
+let is_color_property = function
   | "color" | "background-color" | "border-color" | "border-top-color"
   | "border-right-color" | "border-bottom-color" | "border-left-color"
   | "border-inline-start-color" | "border-inline-end-color"
@@ -1867,6 +1901,9 @@ let is_unsupported_color_fallback name raw_value =
   | "caret-color" | "fill" | "stroke" ->
       true
   | _ -> false
+
+let is_unsupported_color_fallback name raw_value =
+  color_fallback_function raw_value && is_color_property name
 
 let is_unknown_property_name = is_decl_unknown_property_name
 
@@ -1878,6 +1915,7 @@ let allows_unknown_fallback name raw_value =
   (not (raw_value_has_invalid_var raw_value))
   && (is_unknown_property_name name
      || is_unsupported_color_fallback name raw_value
+     || has_var_color_function raw_value
      || raw_value_contains_var raw_value)
 
 let read_font_src_declaration t raw_value =

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -2696,6 +2696,16 @@ let channel_byte_value (c : channel) =
       Some (Float.to_int (Float.round (f *. 255. /. 100.)))
   | _ -> None
 
+(* Classify a channel for static sRGB folding. [Some (Some byte)] is numeric;
+   [Some Option.None] is the [none] keyword (foldable, no byte); the outer
+   [Option.None] is a [Var] which makes the whole colour unfoldable. Conflating
+   the two [None]s would fold [rgb(var(--r) var(--g) var(--b))] to black. *)
+let channel_srgb_slot (c : channel) : int option option =
+  match c with
+  | None -> Some Option.None
+  | Var _ -> Option.None
+  | _ -> Option.map (fun b -> Some b) (channel_byte_value c)
+
 let exact_channel_byte_value (c : channel) =
   match c with
   | Int i when i >= 0 && i <= 255 -> Some i
@@ -2736,18 +2746,14 @@ let static_color_to_srgb_channels :
   function
   | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
       Some (Some r, Some g, Some b, Some a)
-  | Rgb (Channels { r; g; b }) ->
-      Some
-        ( channel_byte_value r,
-          channel_byte_value g,
-          channel_byte_value b,
-          Some 255 )
-  | Rgba { rgb = Channels { r; g; b }; a } ->
-      Some
-        ( channel_byte_value r,
-          channel_byte_value g,
-          channel_byte_value b,
-          alpha_value_byte a )
+  | Rgb (Channels { r; g; b }) -> (
+      match (channel_srgb_slot r, channel_srgb_slot g, channel_srgb_slot b) with
+      | Some r, Some g, Some b -> Some (r, g, b, Some 255)
+      | _ -> Option.None)
+  | Rgba { rgb = Channels { r; g; b }; a } -> (
+      match (channel_srgb_slot r, channel_srgb_slot g, channel_srgb_slot b) with
+      | Some r, Some g, Some b -> Some (r, g, b, alpha_value_byte a)
+      | _ -> Option.None)
   | Hsl { h; s; l; a } -> (
       match (deg_of_hue h, float_of_percentage s, float_of_percentage l) with
       | Some hue, Some saturation, Some lightness ->
@@ -4562,7 +4568,12 @@ and pp_color_mix ctx in_space hue color1 percent1 color2 percent2 =
 
 and pp_rgb_color ctx = function
   | Channels { r; g; b } -> pp_rgb_func ctx (r, g, b, None)
-  | Var v -> pp_rgb_as_color ctx (Var v)
+  (* keep the [rgb()] wrapper: a bare [var(--x)] assumes [--x] is a whole
+     colour, whereas [rgb(var(--x))] takes [--x] as the channel list - dropping
+     the wrapper changes the value (and renders black instead of the colour).
+     The var prints with [pp_rgb] so a fallback stays bare channels, not a
+     nested [rgb()]. *)
+  | Var v -> Pp.call "rgb" pp_rgb ctx (Var v)
 
 and pp_rgba_color ctx rgb a =
   match rgb with

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -812,8 +812,64 @@ let test_prune_unused_custom_props () =
     ":root{--x:\"var(--y)\"}.a{width:var(--x)}"
     (opt ~prune:true ".a{width:var(--x)}:root{--x:\"var(--y)\";--y:1px}")
 
+(* A colour function carrying a var() is a pending-substitution value (CSS
+   Variables L1 section 3): its arity and legacy/modern separator style aren't
+   known until substitution, so minify+optimize must keep it verbatim - never
+   dropped, never re-spelled (a comma-list var like [--bs-*-rgb: 255, 255, 255]
+   only stays valid in the legacy comma form). *)
+let test_var_color_functions_preserved () =
+  let opt css =
+    match Css.of_string css with
+    | Ok { Css.stylesheet; _ } -> minify stylesheet
+    | Error _ -> Alcotest.failf "expected %s to parse, not be dropped" css
+  in
+  let same css = Alcotest.(check string) css css (opt css) in
+  same ".x{color:rgba(var(--rgb),var(--op))}";
+  same ".x{background-color:rgba(var(--rgb),var(--op))}";
+  same ".x{border-color:rgba(var(--rgb),var(--op))}";
+  same ".x{outline-color:rgba(var(--rgb),var(--op))}";
+  same ".x{text-decoration-color:rgba(var(--rgb),var(--op))}";
+  same ".x{caret-color:rgba(var(--rgb),var(--op))}";
+  same ".x{fill:rgba(var(--rgb),var(--op))}";
+  same ".x{stroke:rgba(var(--rgb),var(--op))}";
+  same ".x{color:hsla(var(--hsl),var(--a))}";
+  same ".x{color:rgba(var(--rgb),.5)}";
+  (* nested in a gradient stop, a shadow colour, a border shorthand *)
+  same
+    ".x{background:linear-gradient(90deg,rgba(var(--rgb),var(--op)),transparent)}";
+  same ".x{box-shadow:0 0 4px rgba(var(--rgb),var(--op))}";
+  same ".x{text-shadow:0 1px rgba(var(--rgb),var(--op))}";
+  same ".x{border:1px solid rgba(var(--rgb),var(--op))}";
+  (* a var() in any channel slot must never be read as 0 and folded to black *)
+  same ".x{color:rgb(var(--r) var(--g) var(--b))}";
+  same ".x{color:rgb(255 var(--g) 0)}";
+  same ".x{color:rgb(var(--rgb)/var(--op))}";
+  (* the rgb() wrapper around a whole-channels var must survive: a bare
+     [var(--x)] is a different value and renders black *)
+  same ".x{color:rgb(var(--rgb))}";
+  same ".x{color:rgb(var(--x,1 2 3))}";
+  Alcotest.(check string)
+    "distinct channel vars canonicalise to the space form, not black"
+    ".x{color:rgb(var(--r) var(--g) var(--b))}"
+    (opt ".x{color:rgb(var(--r),var(--g),var(--b))}");
+  (* a sub-byte fractional channel stays verbatim, not floored to black *)
+  same ".x{color:rgb(.5 0 0)}";
+  (* guard: fully static colours still fold *)
+  Alcotest.(check string)
+    "static rgb still folds to hex" ".x{color:#fff}"
+    (opt ".x{color:rgb(255,255,255)}");
+  Alcotest.(check string)
+    "static rgb still folds to a keyword" ".x{color:red}"
+    (opt ".x{color:rgb(255 0 0)}");
+  Alcotest.(check string)
+    "a none channel still folds (none computes to 0)" ".x{color:#000}"
+    (opt ".x{color:rgb(none 0 0)}")
+
 let optimize_tests =
   [
+    ( "var() colour functions preserved",
+      `Quick,
+      test_var_color_functions_preserved );
     ( "optimize preserves physical identity on a fixed point",
       `Quick,
       test_optimize_preserves_physical_identity );


### PR DESCRIPTION
This PR fixes three ways cascade mishandles a colour function whose arguments contain `var()`, each of which silently changes or drops the declared colour.

A colour function carrying a `var()` is a pending-substitution value: its arity and legacy/modern separator style are unknown until substitution, so the value can be neither validated nor canonicalised at parse time. `color: rgba(var(--rgb), var(--op))` (the `--bs-*-rgb: 255, 255, 255` utility pattern) was dropped, because the comma reader assumes three channels; it is now kept verbatim, at any nesting depth, so gradient stops and shadow colours are covered too. `rgb(var(--r) var(--g) var(--b))` minified to `#000`, because a `Var` channel was conflated with the `none` keyword and read as `0`; a `Var` now makes the whole colour unfoldable. `rgb(var(--x))` was rewritten to a bare `var(--x)`, which renders black rather than the colour, since a bare `var()` assumes `--x` is a whole colour while `rgb(var(--x))` takes it as the channel list; the `rgb()` wrapper is now kept.

A math function whose return type is wrong regardless of the var (`flex-basis: sign(var(--x))`) is still rejected, so the existing type check is unchanged. The new cases live in `test/test_optimize.ml`, across the colour properties, gradients and shadows, with guards that fully static colours still fold.
