### PR TITLE
properties: accept var() as a grid repeat() count

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3757,6 +3757,7 @@ type repeat_count = Properties.repeat_count =
   | Count of int
   | Auto_fill
   | Auto_fit
+  | Var of repeat_count var
 
 (** CSS grid-auto-flow values *)
 type grid_auto_flow = Properties.grid_auto_flow =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -10001,11 +10001,12 @@ let rec pp_scroll_snap_type : scroll_snap_type Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_scroll_snap_type ctx v
 
-let pp_repeat_count ctx (count : repeat_count) =
+let rec pp_repeat_count ctx (count : repeat_count) =
   match count with
   | Count n -> Pp.int ctx n
   | Auto_fill -> Pp.string ctx "auto-fill"
   | Auto_fit -> Pp.string ctx "auto-fit"
+  | Var v -> pp_var pp_repeat_count ctx v
 
 let pp_grid_auto_flow_shorthand ctx = function
   | Row | Column -> Pp.string ctx "auto-flow"
@@ -12370,14 +12371,16 @@ module Grid_template = struct
     Cursor.ws inner;
     Fit_content (read_length inner)
 
-  let read_repeat_count t : repeat_count =
-    match Cursor.option Cursor.int t with
-    | Some n -> Count n
-    | None -> (
-        match Cursor.ident t with
-        | "auto-fill" -> Auto_fill
-        | "auto-fit" -> Auto_fit
-        | ident -> Cursor.err_invalid t ("repeat count: " ^ ident))
+  let rec read_repeat_count t : repeat_count =
+    if Cursor.looking_at t "var(" then Var (Values.read_var read_repeat_count t)
+    else
+      match Cursor.option Cursor.int t with
+      | Some n -> Count n
+      | None -> (
+          match Cursor.ident t with
+          | "auto-fill" -> Auto_fill
+          | "auto-fit" -> Auto_fit
+          | ident -> Cursor.err_invalid t ("repeat count: " ^ ident))
 
   let read_line_names t : grid_template =
     Cursor.brackets

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -740,9 +740,14 @@ type grid_auto_flow =
   | Revert_layer
   | Var of grid_auto_flow var
 
-(** [repeat()] count argument: an explicit integer or one of the auto-track-list
-    keywords (CSS Grid 1 §7.2.3.1 / 2). *)
-type repeat_count = Count of int | Auto_fill | Auto_fit
+(** [repeat()] count argument: an explicit integer, one of the auto-track-list
+    keywords (CSS Grid 1 §7.2.3.1 / 2), or a [var()] standing in for the count.
+*)
+type repeat_count =
+  | Count of int
+  | Auto_fill
+  | Auto_fit
+  | Var of repeat_count var
 
 type grid_template =
   | None

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -742,6 +742,12 @@ let grid () =
     "grid-template-columns: 1fr 2fr";
   check_declaration ~expected:"grid-template-columns:repeat(3,1fr)"
     "grid-template-columns: repeat(3, 1fr)";
+  (* a var() in the repeat count is a pending-substitution count, kept verbatim
+     rather than dropped *)
+  check_declaration ~expected:"grid-template-columns:repeat(var(--n),1fr)"
+    "grid-template-columns: repeat(var(--n), 1fr)";
+  check_declaration ~expected:"grid-template-columns:repeat(var(--n,3),1fr)"
+    "grid-template-columns: repeat(var(--n, 3), 1fr)";
 
   (* minmax with fr units *)
   check_declaration ~expected:"grid-template-columns:minmax(100px,1fr)200px"


### PR DESCRIPTION
This PR makes `repeat()` accept a `var()` in its count, so `grid-template-columns: repeat(var(--n), 1fr)` survives parsing instead of being dropped.

The count reader accepted only an integer or `auto-fill` / `auto-fit`; a `var()` made it fail, and the whole declaration was dropped. A `var()` count is a pending-substitution value that may resolve to a valid integer, which browsers keep, so the typed reader now accepts it, mirroring the `var()` handling already in channels and lengths. The other `var()` positions inside `repeat()` (track breadth, `minmax()`) already parsed; only the count slot was missing.
