### PR TITLE
properties: don't collapse font-family to a lone generic keyword

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3460,6 +3460,13 @@ let unquote_font_family_strings components =
   in
   if !changed then result else components
 
+let is_generic_family : font_family -> bool = function
+  | Sans_serif | Serif | Monospace | Cursive | Fantasy | System_ui
+  | Ui_sans_serif | Ui_serif | Ui_monospace | Ui_rounded | Emoji | Math
+  | Fangsong ->
+      true
+  | _ -> false
+
 let rec pp_font_family : font_family Pp.t =
  fun ctx -> function
   (* Generic CSS font families *)
@@ -3609,18 +3616,28 @@ let rec pp_font_family : font_family Pp.t =
       in
       (* CSS Fonts 4 sec. 4.1: [font-family] is a fallback list, so a duplicate
          entry never wins under cascade resolution - drop it under minify (the
-         first occurrence keeps the source position). *)
+         first occurrence keeps the source position). A bare generic keyword
+         (notably [monospace]) takes the UA generic-font size, so the
+         [monospace, monospace] idiom opts back into the normal size; a dedup
+         must not collapse a list to a single generic, which would shrink the
+         text. *)
       let fonts =
         if Pp.minified ctx then
           let seen = Hashtbl.create 8 in
-          List.filter
-            (fun f ->
-              let key = Pp.to_string ~minify:true pp_font_family f in
-              if Hashtbl.mem seen key then false
-              else (
-                Hashtbl.add seen key ();
-                true))
-            fonts
+          let deduped =
+            List.filter
+              (fun f ->
+                let key = Pp.to_string ~minify:true pp_font_family f in
+                if Hashtbl.mem seen key then false
+                else (
+                  Hashtbl.add seen key ();
+                  true))
+              fonts
+          in
+          match deduped with
+          | [ single ] when is_generic_family single && List.length fonts > 1 ->
+              fonts
+          | _ -> deduped
         else fonts
       in
       Pp.list_wrap ~threshold:90 ~sep:Pp.comma ~wrap_indent:(level_chars + 2)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -431,6 +431,15 @@ let font_properties () =
     "font-family: \"Helvetica Neue\", Helvetica, Arial, sans-serif";
   check_declaration ~expected:"font-family:Georgia,serif"
     "font-family: Georgia, serif";
+  (* minify dedups a repeated family, but must not collapse the list to a lone
+     generic keyword - [monospace, monospace] opts a bare generic back into the
+     normal UA size, so dropping the duplicate would shrink the text. *)
+  check_declaration ~expected:"font-family:Arial,Helvetica"
+    "font-family: Arial, Helvetica, Arial";
+  check_declaration ~expected:"font-family:monospace,monospace"
+    "font-family: monospace, monospace";
+  check_declaration ~expected:"font-family:serif,serif"
+    "font-family: serif, serif";
   (* CSS Fonts 4 defines font-family names as <custom-ident> sequences. Quoted
      reserved words are family names; unquoted CSS-wide keywords remain CSS-wide
      keywords and must not be reinterpreted as family names. *)


### PR DESCRIPTION
This PR stops minify from deduping a font-family list down to a single generic keyword, which silently changes the rendered text size.

`monospace, monospace` is the well-known idiom that opts a bare generic keyword back into the document's normal font size: browsers render a lone `monospace` at a separate, smaller UA default, and a second entry defeats that. Minify deduped repeated family names, so it turned `monospace, monospace` into `monospace` and shrank the text. The dedup now keeps the list whenever dropping a duplicate would leave a single generic keyword; it still collapses `Arial, Arial` and `Arial, Helvetica, Arial`.
