### PR TITLE
properties: fold transform-origin zero components to 0

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4505,6 +4505,28 @@ let normalize_scale : scale -> scale =
   | XYZ (x, y, z) -> preserve_if_equal value (XYZ (np x, np y, np z))
   | other -> other
 
+(* [transform-origin] had no normalize pass, so [0px 50%] and [0% 50%] (and
+   [left center]) stayed in distinct spellings of the same origin. [0], [0px]
+   and [0%] all place the origin at the same edge, so fold every zero component
+   to the unitless [0] - the canonical form the [left]/[top] keywords already
+   minify to. *)
+let normalize_transform_origin : transform_origin -> transform_origin =
+  let z l =
+    match (l : Values.length) with
+    | Pct 0. -> (Zero : Values.length)
+    | _ -> Values.normalize_length l
+  in
+  fun value ->
+    match value with
+    | X a -> preserve_if_equal value (X (z a))
+    | XY (a, b) -> preserve_if_equal value (XY (z a, z b))
+    | XYZ (a, b, c) -> preserve_if_equal value (XYZ (z a, z b, z c))
+    | Position p ->
+        preserve_if_equal value (Position (normalize_position_value p))
+    | Position_z (p, c) ->
+        preserve_if_equal value (Position_z (normalize_position_value p, z c))
+    | other -> other
+
 let normalize_ray_size : ray_size -> ray_size =
  fun value ->
   match value with
@@ -20845,6 +20867,7 @@ let normalize_property_value : type a.
   | Rotate -> normalize_rotate value
   | Scale -> normalize_scale value
   | Translate -> normalize_translate_value value
+  | Transform_origin -> normalize_transform_origin value
   | Offset_path -> normalize_offset_path value
   | Offset_rotate -> normalize_offset_rotate value
   | Font_style -> normalize_font_style value

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -865,11 +865,33 @@ let test_var_color_functions_preserved () =
     "a none channel still folds (none computes to 0)" ".x{color:#000}"
     (opt ".x{color:rgb(none 0 0)}")
 
+(* [0], [0px], [0%] and the [left]/[top] keywords all name the same origin, so
+   the optimiser folds every zero transform-origin component to the unitless
+   [0]; a non-zero origin is left alone. *)
+let test_transform_origin_zero_folds () =
+  let opt css =
+    match Css.of_string css with
+    | Ok { Css.stylesheet; _ } -> minify stylesheet
+    | Error _ -> Alcotest.failf "expected %s to parse" css
+  in
+  let same canonical input =
+    Alcotest.(check string) input canonical (opt input)
+  in
+  same ".x{transform-origin:0}" ".x{transform-origin:0% 50%}";
+  same ".x{transform-origin:0}" ".x{transform-origin:0px 50%}";
+  same ".x{transform-origin:0}" ".x{transform-origin:left center}";
+  same ".x{transform-origin:0 0}" ".x{transform-origin:0% 0px}";
+  same ".x{transform-origin:50%}" ".x{transform-origin:50% 50%}";
+  same ".x{transform-origin:10px 20px}" ".x{transform-origin:10px 20px}"
+
 let optimize_tests =
   [
     ( "var() colour functions preserved",
       `Quick,
       test_var_color_functions_preserved );
+    ( "transform-origin zero components fold to 0",
+      `Quick,
+      test_transform_origin_zero_folds );
     ( "optimize preserves physical identity on a fixed point",
       `Quick,
       test_optimize_preserves_physical_identity );


### PR DESCRIPTION
This PR adds a normalize pass for `transform-origin`, folding every zero component to the unitless `0`.

`transform-origin` had no normalize pass, so `0px 50%`, `0% 50%` and `left center` stayed in distinct spellings of the same origin: `0`, `0px` and `0%` all place the origin at the same edge, and the `left`/`top` keywords already minify to `0`. The optimiser now canonicalises them together, so for example `transform-origin: 0px 50%` and `transform-origin: 0% 50%` are equal under `Css_compare ~mode:Canonical`.
