### PR TITLE
stylesheet: recover per-rule inside at-rule blocks

### DIFF
--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3016,13 +3016,32 @@ let rec read_statement (r : Cursor.t) : statement =
   | _ -> Rule (read_rule r)
 
 and read_block (r : Cursor.t) : block =
+  (* Skip a statement that failed to parse: consume to the end of its block
+     ([{...}]) or its terminating [;], leaving the cursor at the next rule. *)
+  let rec skip_bad_statement () =
+    match Cursor.next_raw r with
+    | None -> ()
+    | Some (Component.Block _)
+    | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
+        ()
+    | Some _ -> skip_bad_statement ()
+  in
   let rec read_statements acc =
     Cursor.ws r;
     if Cursor.is_done r then List.rev acc
     else
       let loc = Cursor.position r in
-      let stmt = read_statement r in
-      match stmt with
+      let snap = Cursor.save r in
+      match read_statement r with
+      (* CSS Syntax 3 §5.4.1: a rule that fails to parse (e.g. an invalid
+         selector) is dropped, and parsing resumes at the next rule - one bad
+         rule must not take the rest of the [@layer] / [@media] block with it.
+         Strict mode ([not (Cursor.recover r)]) still raises. *)
+      | exception Error.Parse_error e when Cursor.recover r ->
+          Cursor.restore r snap;
+          Cursor.push_warning r e;
+          skip_bad_statement ();
+          read_statements acc
       | Import _ ->
           (* CSS Cascade L6 §2: @import is only valid at the top of the
              stylesheet. Drop a misplaced one rather than emitting it. *)
@@ -3032,7 +3051,7 @@ and read_block (r : Cursor.t) : block =
           read_statements acc
       | Else _ when not (List.exists follows_conditional acc) ->
           Cursor.err_invalid r "@else without preceding @when"
-      | _ -> read_statements (stmt :: acc)
+      | stmt -> read_statements (stmt :: acc)
   in
   read_statements []
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -204,6 +204,30 @@ let test_nested_container_recovers () =
   recovers
     {|.x { @container (width > 1px) and (height > 1px) or (width > 2px) { .y { color: red } } }|}
 
+(* ignore-test: error-recovery contract, not a per-statement constructor. *)
+let test_layer_rule_recovery () =
+  (* CSS Syntax 3 §5.4.1: an invalid rule inside an @layer / @media block is
+     dropped on its own; its sibling rules must survive. [.x→y] has a literal
+     arrow (U+2192), which is not a valid ident code point, so the browser drops
+     that rule too - but keeps the rest of the block. *)
+  let keeps_siblings input =
+    match Css.of_string input with
+    | Ok { Css.stylesheet; warnings; _ } ->
+        let out = Css.to_string ~minify:true stylesheet in
+        Alcotest.(check bool) ("warns: " ^ input) true (warnings <> []);
+        Alcotest.(check bool)
+          ("keeps .a and .b: " ^ out)
+          true
+          (Astring.String.is_infix ~affix:".a{" out
+          && Astring.String.is_infix ~affix:".b{" out)
+    | Error e ->
+        Alcotest.failf "expected recovery: %s" (Cascade.Error.to_string e)
+  in
+  keeps_siblings "@layer u{.a{color:red}.x→y{color:lime}.b{color:blue}}";
+  keeps_siblings "@media screen{.a{color:red}.x→y{color:lime}.b{color:blue}}";
+  keeps_siblings
+    "@supports (display:grid){.a{color:red}.x→y{color:lime}.b{color:blue}}"
+
 (* Not a roundtrip test *)
 let test_supports_rule_creation () =
   let decl = Css.Declaration.display Css.Properties.Grid in
@@ -1297,6 +1321,7 @@ let stylesheet_tests =
     ("media rule creation", `Quick, test_media_rule_creation);
     ("container rule creation", `Quick, test_container_rule_creation);
     ("nested container recovers", `Quick, test_nested_container_recovers);
+    ("invalid rule in a block recovers", `Quick, test_layer_rule_recovery);
     ("supports rule creation", `Quick, test_supports_rule_creation);
     ("supports nested creation", `Quick, test_supports_nested_creation);
     ("property rule creation", `Quick, test_property_rule_creation);


### PR DESCRIPTION
This PR makes at-rule blocks (`@layer`, `@media`, `@supports`, `@container`) recover per-rule: an invalid rule is dropped on its own instead of taking the whole block with it.

Block content was parsed by `read_statements`, which let a `Parse_error` from one rule abort the entire block. The top level already recovers per-rule (CSS Syntax 3 §5.4.1, `read_stylesheet_of_rules`); `read_statements` now mirrors it, dropping the bad rule with a warning and resuming at the next one. Strict mode still raises.

This surfaced on tailwindcss.com, whose `@layer utilities` contains a utility whose class name has a literal arrow (`content-['↗']`). cascade rejects that selector — it implements the CSS Syntax non-ASCII ident ranges (the XML NameChar ranges, which exclude U+2190–U+2BFF), as does its WPT trace test. (Chrome is more lenient and accepts it; whether cascade should match Chrome here is a separate question.) Whatever the verdict on that one rule, one invalid rule must not drop its siblings: before this fix cascade dropped the entire 589 KB layer; after it, `cascade fmt` keeps 7546 of 7548 rules (was 582).
