### PR TITLE
values: keep the required in oklab in color-mix()

### DIFF
--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7491,17 +7491,12 @@ let rec normalize_color ?(lossless = false) ~in_feature_query (c : color) :
 and normalize_mix_color ~lossless ~in_feature_query ~in_space ~hue ~color1
     ~percent1 ~color2 ~percent2 =
   let keep () =
-    (* CSS Color 5 sec. 3 / sec. 13: [shorter] is the default hue and the [in
-       oklab] method is the default, so both drop when the mix is left as a
-       colour-mix; percentages that restate the [100% - other] default drop
-       too. *)
+    (* CSS Color 5 sec. 3 / sec. 13: [shorter] is the default hue and drops, and
+       percentages that restate the [100% - other] default drop too. The
+       interpolation method itself is required syntax, so a written [in oklab]
+       stays - dropping it yields [color-mix(<color>, <color>)], which every
+       browser rejects. *)
     let hue = match hue with Shorter -> Default | h -> h in
-    let in_space : color_space option =
-      match (in_space : color_space option) with
-      | Some Oklab when hue = Default -> None
-      | None -> None
-      | _ -> in_space
-    in
     let pct (p : percentage option) =
       match p with Some (Pct f) -> Some f | _ -> None
     in

--- a/test/interop/css-minify-tests/traces/tests/colors/0033/expected.css
+++ b/test/interop/css-minify-tests/traces/tests/colors/0033/expected.css
@@ -1,1 +1,1 @@
-a{color:color-mix(var(--a),var(--b))}
+a{color:color-mix(in oklab,var(--a),var(--b))}

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1940,10 +1940,10 @@ let target_minify_enforce_spec_split () =
        theme,grid;@layer grid{.x{color:red}}@layer theme{.x{color:#00f}}";
   check_modes "explicit flex zero basis is not one-value shorthand"
     "a { flex: 1 1 0 }" ~default:"a{flex:1 1 0}" ~spec:"a{flex:1 1 0}";
-  check_modes "color-mix default oklab elides in both modes"
+  check_modes "color-mix keeps the required in oklab in both modes"
     "a { color: color-mix(in oklab, var(--a), var(--b)) }"
-    ~default:"a{color:color-mix(var(--a),var(--b))}"
-    ~spec:"a{color:color-mix(var(--a),var(--b))}";
+    ~default:"a{color:color-mix(in oklab,var(--a),var(--b))}"
+    ~spec:"a{color:color-mix(in oklab,var(--a),var(--b))}";
   (* oklch/oklab chroma takes <number> | <percentage>, exactly interchangeable
      (CSS Color 4: 100% = 0.4 on this axis). Default minify picks the shorter
      spelling per axis - .304 becomes 76%, but .1 stays because 25% is longer.

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -374,7 +374,7 @@ let test_color () =
 let lossless_color () =
   decl_lossless ~prop:"color" ~into:"oklch(.552 .016 285.938)"
     "oklch(55.2% .016 285.938)";
-  decl_lossless ~prop:"color" ~into:"color-mix(red,#00f)"
+  decl_lossless ~prop:"color" ~into:"color-mix(in oklab,red,#00f)"
     "color-mix(in oklab, red 50%, blue 50%)";
   decl_lossless ~prop:"color" ~into:"red" "rgb(255 0 0)";
   decl_lossless ~prop:"color" ~into:"#0003" "rgb(0 0 0 / .2)";
@@ -1028,7 +1028,7 @@ let spec_color5_function_edges () =
     ~optimized:"#944b4080"
     "color-mix(in srgb, oklch(50% 0.1 30) 50%, transparent)";
   check_color ~expected:"color-mix(in oklab,var(--a),var(--b))"
-    ~optimized:"color-mix(var(--a),var(--b))"
+    ~optimized:"color-mix(in oklab,var(--a),var(--b))"
     "color-mix(in oklab, var(--a), var(--b))";
   check_color ~expected:"color-mix(var(--a),var(--b))"
     "color-mix(var(--a), var(--b))";


### PR DESCRIPTION
This PR stops the optimiser from dropping the `in oklab` interpolation method from `color-mix()`.

`color-mix(in oklab, var(--a), var(--b))` was minified to `color-mix(var(--a), var(--b))`, but CSS Color 5 makes the `<color-interpolation-method>` *required* syntax — there is no omittable default — so the result is invalid and every browser rejects it. cascade treated `in oklab` as a droppable default. Tailwind v4 builds its colours as `color-mix(in oklab, var(--color-x) …, transparent)`, which can't fold to a static colour, so the dropped form rendered black. The method now stays; the four oracles that asserted the dropped form are updated.
