### PR TITLE
values: accept calc() in the color-mix weight

### DIFF
--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6368,11 +6368,22 @@ let read_color_function t : color =
   let alpha = read_optional_alpha t in
   Color { space; components; alpha }
 
+(* A bare [<percentage>] leaf inside a color-mix weight [calc()]. Unlike the
+   top-level weight it is not range-checked: CSS Values 4 §10 clamps the math
+   function's result, not its individual operands. [read_calc] handles the
+   [var()] and nested-[calc()] factors itself, so the leaf only sees a token. *)
+let read_color_mix_calc_pct t : percentage = Pct (Cursor.pct t)
+
 (** Forward declaration for percentage reader used in color-mix *)
 let rec read_percentage_in_color_mix t : percentage =
   Cursor.ws t;
   if Cursor.looking_at t "var(" then
     Var (read_var read_percentage_in_color_mix t)
+  else if Cursor.looking_at_calc t then
+    (* CSS Color 5 §3: the weight may be a math function. We can't bound-check a
+       [calc()] statically (it may carry a [var()]), so we keep it verbatim and
+       let substitution-time clamping apply. *)
+    Calc (read_calc read_color_mix_calc_pct t)
   else
     let n = Cursor.number t in
     Cursor.expect '%' t;
@@ -6389,6 +6400,8 @@ let read_optional_percentage t : percentage option =
   Cursor.ws t;
   if Cursor.looking_at t "var(" then
     Some (Var (read_var read_percentage_in_color_mix t))
+  else if Cursor.looking_at_calc t then
+    Some (Calc (read_calc read_color_mix_calc_pct t))
   else
     match Cursor.percentage_opt t with
     | Some n ->

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -926,6 +926,15 @@ let spec_values_l45_math_color () =
   check_color ~expected:"color-mix(in srgb longer hue,red,blue)"
     ~optimized:"color-mix(in srgb longer hue,red,#00f)"
     "color-mix(in srgb longer hue, red, blue)";
+  (* CSS Color 5 §3: the color-mix weight may be a [calc()]. A constant folds to
+     a plain percentage; a [var()]-bearing one is kept verbatim. The weight
+     reader previously rejected any [calc()] here. *)
+  check_color ~expected:"color-mix(in srgb,red 30%,blue)"
+    ~optimized:"color-mix(in srgb,red 30%,#00f)"
+    "color-mix(in srgb, red calc(30%), blue)";
+  check_color ~expected:"color-mix(in srgb,var(--c) calc(var(--o)*100%),blue)"
+    ~optimized:"color-mix(in srgb,var(--c) calc(var(--o)*100%),#00f)"
+    "color-mix(in srgb, var(--c) calc(var(--o) * 100%), blue)";
   check_color ~expected:"hsl(0 50% 50%)" ~optimized:"#bf4040"
     "hsl(none 50% 50%)";
   check_color ~expected:"rgb(from var(--c) r g b/.5)"
@@ -937,6 +946,7 @@ let spec_values_l45_math_color () =
   neg_cursor read_length "anchor-size()";
   neg_cursor read_number "sibling-index(1)";
   neg_cursor read_color "color-mix(in oklab)";
+  neg_cursor read_color "color-mix(in oklab, red calc(50%) calc(20%), blue)";
   neg_cursor read_color "rgb(from red r g)";
   neg_cursor read_color "color(display-p3 1 0)"
 


### PR DESCRIPTION
The color-mix weight reader accepted only a bare `<percentage>` or `var()`, so any `calc()` in that position failed and the whole declaration was dropped. Per CSS Color 5 §3 the weight is `<percentage [0,100]>?` where a percentage may be a math function.

`color-mix(in oklab, red calc(50%), blue)` and Tailwind v4 opacity utilities like `color-mix(in oklab, var(--c) calc(var(--o) * 100%), transparent)` are valid CSS; Chrome resolves the latter to `oklab(0.627966 0.22488 0.125859 / 0.5)`.

The fix adds a `calc()` branch to the weight reader using a percentage leaf that reads the token (the prior leaf assumed `<number>` `%` as two tokens, which fails on a single percentage token inside `calc()`). A constant weight still folds (`calc(30%)` -> `30%`); a `var()`-bearing one is kept verbatim. Calc operands are not range-checked since CSS Values 4 clamps the result, not the operands.