### PR TITLE
properties: accept comma-separated layer lists for background/mask geometry

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -2701,6 +2701,7 @@ type background_repeat = Properties.background_repeat =
   | No_repeat
   | Repeat_x
   | Repeat_y
+  | Layers of background_repeat list
   | Repeat_repeat
   | Repeat_space
   | Repeat_round
@@ -2730,6 +2731,7 @@ type background_size = Properties.background_size =
   | Contain
   | Length of length
   | Size of length * length
+  | Layers of background_size list
   | Inherit
   | Initial
   | Unset
@@ -3017,6 +3019,7 @@ type background_box = Properties.background_box =
   | Padding_box
   | Content_box
   | Text
+  | Layers of background_box list
   | Inherit
   | Initial
   | Unset
@@ -3042,6 +3045,7 @@ type mask_composite = Properties.mask_composite =
   | Subtract
   | Intersect
   | Exclude
+  | Composites of mask_composite list
   | Inherit
   | Initial
   | Unset
@@ -3090,6 +3094,7 @@ type mask_box = Properties.mask_box =
   | Stroke_box
   | View_box
   | No_clip  (** Only valid for mask-clip *)
+  | Layers of mask_box list
   | Inherit
   | Initial
   | Unset

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1077,14 +1077,15 @@ let read_background_value : type a. a property -> Cursor.t -> declaration option
   | Border -> Some (v Border (read_border t))
   | Background_attachment ->
       Some (v Background_attachment (read_background_attachment t))
-  | Background_origin -> Some (v Background_origin (read_background_box t))
-  | Background_clip -> Some (v Background_clip (read_background_box t))
+  | Background_origin -> Some (v Background_origin (read_background_box_list t))
+  | Background_clip -> Some (v Background_clip (read_background_box_list t))
   | Webkit_background_clip ->
-      Some (v Webkit_background_clip (read_background_box t))
+      Some (v Webkit_background_clip (read_background_box_list t))
   | Background_position ->
       Some (v Background_position (read_background_position t))
-  | Background_repeat -> Some (v Background_repeat (read_background_repeat t))
-  | Background_size -> Some (v Background_size (read_background_size t))
+  | Background_repeat ->
+      Some (v Background_repeat (read_background_repeat_list t))
+  | Background_size -> Some (v Background_size (read_background_size_list t))
   | Background_blend_mode -> Some (read_background_blend_mode_value t)
   | _ -> None
 
@@ -1625,12 +1626,13 @@ let read_mask_value : type a. a property -> Cursor.t -> declaration option =
       Some (v Webkit_mask_composite (read_webkit_mask_composite t))
   | Webkit_mask_source_type ->
       Some (v Webkit_mask_source_type (read_webkit_mask_source_type t))
-  | Webkit_mask_size -> Some (v Webkit_mask_size (read_background_size t))
+  | Webkit_mask_size -> Some (v Webkit_mask_size (read_background_size_list t))
   | Webkit_mask_position ->
       Some (v Webkit_mask_position (read_background_position t))
-  | Webkit_mask_repeat -> Some (v Webkit_mask_repeat (read_background_repeat t))
-  | Webkit_mask_clip -> Some (v Webkit_mask_clip (read_mask_box t))
-  | Webkit_mask_origin -> Some (v Webkit_mask_origin (read_mask_box t))
+  | Webkit_mask_repeat ->
+      Some (v Webkit_mask_repeat (read_background_repeat_list t))
+  | Webkit_mask_clip -> Some (v Webkit_mask_clip (read_mask_box_list t))
+  | Webkit_mask_origin -> Some (v Webkit_mask_origin (read_mask_box_list t))
   | Border_image_source ->
       Some (v Border_image_source (read_background_image t))
   | Border_image_slice ->
@@ -1642,14 +1644,14 @@ let read_mask_value : type a. a property -> Cursor.t -> declaration option =
   | Border_image_outset ->
       Some (v Border_image_outset (read_border_image_outset t))
   | Mask_image -> Some (v Mask_image (read_background_image t))
-  | Mask_composite -> Some (v Mask_composite (read_mask_composite t))
+  | Mask_composite -> Some (v Mask_composite (read_mask_composite_list t))
   | Mask_mode -> Some (v Mask_mode (read_mask_mode t))
   | Mask_border -> Some (v Mask_border (read_border_image t))
-  | Mask_size -> Some (v Mask_size (read_background_size t))
+  | Mask_size -> Some (v Mask_size (read_background_size_list t))
   | Mask_position -> Some (v Mask_position (read_background_position t))
-  | Mask_repeat -> Some (v Mask_repeat (read_background_repeat t))
-  | Mask_clip -> Some (v Mask_clip (read_mask_box t))
-  | Mask_origin -> Some (v Mask_origin (read_mask_box t))
+  | Mask_repeat -> Some (v Mask_repeat (read_background_repeat_list t))
+  | Mask_clip -> Some (v Mask_clip (read_mask_box_list t))
+  | Mask_origin -> Some (v Mask_origin (read_mask_box_list t))
   | Mask_type -> Some (v Mask_type (read_mask_type t))
   | All -> Some (v All (Properties.read_css_wide t))
   | _ -> None

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -7718,6 +7718,7 @@ let rec pp_background_attachment : background_attachment Pp.t =
 let rec pp_background_repeat : background_repeat Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_background_repeat ctx v
+  | Layers layers -> Pp.list ~sep:Pp.comma pp_background_repeat ctx layers
   | Repeat -> Pp.string ctx "repeat"
   | Space -> Pp.string ctx "space"
   | Round -> Pp.string ctx "round"
@@ -7758,6 +7759,7 @@ let rec pp_background_repeat : background_repeat Pp.t =
 let rec pp_background_box : background_box Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_background_box ctx v
+  | Layers layers -> Pp.list ~sep:Pp.comma pp_background_box ctx layers
   | Border_box -> Pp.string ctx "border-box"
   | Padding_box -> Pp.string ctx "padding-box"
   | Content_box -> Pp.string ctx "content-box"
@@ -7786,6 +7788,8 @@ let rec pp_webkit_mask_composite : webkit_mask_composite Pp.t =
 let rec pp_mask_composite : mask_composite Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_mask_composite ctx v
+  | Composites composites ->
+      Pp.list ~sep:Pp.comma pp_mask_composite ctx composites
   | Add -> Pp.string ctx "add"
   | Subtract -> Pp.string ctx "subtract"
   | Intersect -> Pp.string ctx "intersect"
@@ -7835,6 +7839,7 @@ let rec pp_mask_type : mask_type Pp.t =
 let rec pp_mask_box : mask_box Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_mask_box ctx v
+  | Layers layers -> Pp.list ~sep:Pp.comma pp_mask_box ctx layers
   | Border_box -> Pp.string ctx "border-box"
   | Content_box -> Pp.string ctx "content-box"
   | Fill_box -> Pp.string ctx "fill-box"
@@ -7850,6 +7855,7 @@ let rec pp_mask_box : mask_box Pp.t =
 
 let rec pp_background_size : background_size Pp.t =
  fun ctx -> function
+  | Layers layers -> Pp.list ~sep:Pp.comma pp_background_size ctx layers
   | Auto -> Pp.string ctx "auto"
   | Cover -> Pp.string ctx "cover"
   | Contain -> Pp.string ctx "contain"
@@ -17552,6 +17558,16 @@ let rec read_background_repeat t : background_repeat =
     ~var:(fun t -> Var (read_var read_background_repeat t))
     ~default:read_repeats t
 
+(* The standalone [background-repeat] / [mask-repeat] longhand is a
+   comma-separated layer list (CSS Backgrounds 3 §3.6); the [background] /
+   [mask] shorthand reuses the single-value [read_background_repeat] so it does
+   not eat the layer comma. Same split for the box / size / composite readers
+   below. *)
+let read_background_repeat_list t : background_repeat =
+  match Cursor.list ~sep:Cursor.comma ~at_least:1 read_background_repeat t with
+  | [ one ] -> one
+  | many -> Layers many
+
 let rec read_background_size t : background_size =
   let read_pair t : background_size =
     let a, b =
@@ -17582,6 +17598,11 @@ let rec read_background_size t : background_size =
     ~var:read_var_call
     ~default:(fun t -> Cursor.one_of [ read_pair; read_single ] t)
     t
+
+let read_background_size_list t : background_size =
+  match Cursor.list ~sep:Cursor.comma ~at_least:1 read_background_size t with
+  | [ one ] -> one
+  | many -> Layers many
 
 module Gradient_direction = struct
   type keyword = Top | Bottom | Left | Right
@@ -19210,6 +19231,11 @@ let rec read_background_box t : background_box =
     ~var:(fun t -> Var (read_var read_background_box t))
     t
 
+let read_background_box_list t : background_box =
+  match Cursor.list ~sep:Cursor.comma ~at_least:1 read_background_box t with
+  | [ one ] -> one
+  | many -> Layers many
+
 (* Parser for webkit_mask_composite values *)
 let rec read_webkit_mask_composite t : webkit_mask_composite =
   let read_item t =
@@ -19254,6 +19280,11 @@ let rec read_mask_composite t : mask_composite =
     ]
     ~var:(fun t -> Var (Values.read_var read_mask_composite t))
     t
+
+let read_mask_composite_list t : mask_composite =
+  match Cursor.list ~sep:Cursor.comma ~at_least:1 read_mask_composite t with
+  | [ one ] -> one
+  | many -> Composites many
 
 (* Parser for webkit_mask_source_type values *)
 let rec read_webkit_mask_source_type t : webkit_mask_source_type =
@@ -19331,6 +19362,11 @@ let rec read_mask_box t : mask_box =
     ]
     ~var:(fun t -> Var (Values.read_var read_mask_box t))
     t
+
+let read_mask_box_list t : mask_box =
+  match Cursor.list ~sep:Cursor.comma ~at_least:1 read_mask_box t with
+  | [ one ] -> one
+  | many -> Layers many
 
 module Mask_shorthand = struct
   let init =

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1462,13 +1462,23 @@ val pp_background_repeat : background_repeat Pp.t
 (** [pp_background_repeat] is the pretty-printer for [background_repeat]. *)
 
 val read_background_repeat : Cursor.t -> background_repeat
-(** [read_background_repeat t] is the [background_repeat] parsed from [t]. *)
+(** [read_background_repeat t] is the single-layer [background_repeat] parsed
+    from [t] (used by the [background] / [mask] shorthand). *)
+
+val read_background_repeat_list : Cursor.t -> background_repeat
+(** [read_background_repeat_list t] parses the standalone [background-repeat] /
+    [mask-repeat] longhand: a comma-separated layer list. *)
 
 val pp_background_size : background_size Pp.t
 (** [pp_background_size] is the pretty-printer for [background_size]. *)
 
 val read_background_size : Cursor.t -> background_size
-(** [read_background_size t] is the [background_size] parsed from [t]. *)
+(** [read_background_size t] is the single-layer [background_size] parsed from
+    [t] (used by the shorthand). *)
+
+val read_background_size_list : Cursor.t -> background_size
+(** [read_background_size_list t] parses the standalone size longhand: a
+    comma-separated layer list. *)
 
 val pp_gradient_direction : gradient_direction Pp.t
 (** [pp_gradient_direction] is the pretty-printer for [gradient_direction]. *)
@@ -1556,8 +1566,12 @@ val minify_background_image : background_image -> background_image
     their shortest hex form, matching Lightning CSS behavior. *)
 
 val read_background_box : Cursor.t -> background_box
-(** [read_background_box t] parses a background-clip or background-origin value.
-*)
+(** [read_background_box t] parses a single-layer background-clip or
+    background-origin value (used by the shorthand). *)
+
+val read_background_box_list : Cursor.t -> background_box
+(** [read_background_box_list t] parses the standalone background-clip /
+    background-origin longhand: a comma-separated layer list. *)
 
 val pp_background_box : background_box Pp.t
 (** [pp_background_box] pretty-prints a background-clip or background-origin
@@ -1570,7 +1584,12 @@ val pp_webkit_mask_composite : webkit_mask_composite Pp.t
 (** [pp_webkit_mask_composite] pretty-prints a webkit-mask-composite value. *)
 
 val read_mask_composite : Cursor.t -> mask_composite
-(** [read_mask_composite t] parses a standard mask-composite value. *)
+(** [read_mask_composite t] parses a single-layer standard mask-composite value
+    (used by the shorthand). *)
+
+val read_mask_composite_list : Cursor.t -> mask_composite
+(** [read_mask_composite_list t] parses the standalone mask-composite longhand:
+    a comma-separated layer list. *)
 
 val pp_mask_composite : mask_composite Pp.t
 (** [pp_mask_composite] pretty-prints a standard mask-composite value. *)
@@ -1595,7 +1614,12 @@ val pp_mask_type : mask_type Pp.t
 (** [pp_mask_type] pretty-prints a mask-type value. *)
 
 val read_mask_box : Cursor.t -> mask_box
-(** [read_mask_box t] parses a mask-clip or mask-origin value. *)
+(** [read_mask_box t] parses a single-layer mask-clip or mask-origin value (used
+    by the shorthand). *)
+
+val read_mask_box_list : Cursor.t -> mask_box
+(** [read_mask_box_list t] parses the standalone mask-clip / mask-origin
+    longhand: a comma-separated layer list. *)
 
 val pp_mask_box : mask_box Pp.t
 (** [pp_mask_box] pretty-prints a mask-clip or mask-origin value. *)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2391,6 +2391,7 @@ type background_box =
   | Padding_box
   | Content_box
   | Text
+  | Layers of background_box list
   | Inherit
   | Initial
   | Unset
@@ -2405,6 +2406,7 @@ type background_repeat =
   | No_repeat
   | Repeat_x
   | Repeat_y
+  | Layers of background_repeat list
   | Repeat_repeat
   | Repeat_space
   | Repeat_round
@@ -2434,6 +2436,7 @@ type background_size =
   | Contain
   | Length of length
   | Size of length * length
+  | Layers of background_size list
   | Inherit
   | Initial
   | Unset
@@ -2693,6 +2696,7 @@ type mask_composite =
   | Subtract
   | Intersect
   | Exclude
+  | Composites of mask_composite list
   | Inherit
   | Initial
   | Unset
@@ -2743,6 +2747,7 @@ type mask_box =
   | Stroke_box
   | View_box
   | No_clip  (** Only valid for mask-clip *)
+  | Layers of mask_box list
   | Inherit
   | Initial
   | Unset

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -324,6 +324,9 @@ let check_background_repeat =
   check_value_cursor "background-repeat" read_background_repeat
     pp_background_repeat
 
+(* The standalone longhand (comma-separated layer list) goes through the [_list]
+   readers; the single-value [check_*] above is the per-layer / shorthand
+   path. *)
 let check_background_size =
   check_value_cursor "background-size" read_background_size pp_background_size
 
@@ -1660,6 +1663,10 @@ let test_background_box () =
   check_background_box "border-box";
   check_background_box "padding-box";
   check_background_box "content-box";
+  (* Comma-separated layers are valid; space-separated is not. *)
+  decl_optimizes ~prop:"background-clip"
+    ~into:"border-box,padding-box,content-box"
+    "border-box,padding-box,content-box";
   neg_cursor read_background_box "invalid-box";
   neg_cursor read_background_box "margin-box";
   (* doesn't exist for background *)
@@ -1681,6 +1688,11 @@ let test_background () =
     "linear-gradient(to right, red, blue)";
   check_background ~expected:"url(image.png)50%/cover no-repeat fixed red"
     "red url(image.png) center/cover no-repeat fixed";
+  (* Multi-layer shorthand (CSS Backgrounds 3 §2.1): the layer comma separates
+     layers and must not be eaten by a per-component reader. [repeat] is the
+     default and folds away; the second layer's [space] stays. *)
+  decl_optimizes ~prop:"background" ~into:"url(a.png),url(b.png)space"
+    "url(a.png) repeat,url(b.png) space";
   check_background ~expected:"0 0" "none";
   neg_cursor read_background "invalid-background";
   neg_cursor read_background "red blue";
@@ -2251,6 +2263,7 @@ let test_background_attachment () =
   check_background_attachment "fixed";
   check_background_attachment "local";
   check_background_attachment "inherit";
+  check_background_attachment "scroll,fixed,local";
   neg_cursor read_background_attachment "invalid-attachment"
 
 let test_background_repeat () =
@@ -2261,6 +2274,13 @@ let test_background_repeat () =
   check_background_repeat "repeat-x";
   check_background_repeat "repeat-y";
   check_background_repeat "inherit";
+  (* CSS Backgrounds 3 §3.6: the longhand is a comma-separated layer list. *)
+  decl_optimizes ~prop:"background-repeat" ~into:"no-repeat,repeat-y,no-repeat"
+    "no-repeat,repeat-y,no-repeat";
+  decl_optimizes ~prop:"background-repeat" ~into:"repeat-x,repeat-y"
+    "repeat-x,repeat-y";
+  decl_optimizes ~prop:"background-repeat" ~into:"repeat space,no-repeat"
+    "repeat space,no-repeat";
   neg_cursor read_background_repeat "invalid-repeat"
 
 let test_background_size () =
@@ -2276,6 +2296,10 @@ let test_background_size () =
   check_background_size "var(--s)";
   check_background_size "calc(50% + 10px)";
   check_background_size "calc(50% + 10px) auto";
+  (* Comma-separated layer list (CSS Backgrounds 3 §3.9). *)
+  decl_optimizes ~prop:"background-size" ~into:"cover,contain" "cover,contain";
+  decl_optimizes ~prop:"background-size" ~into:"100px 200px,auto"
+    "100px 200px,auto";
   neg_cursor read_background_size "invalid-size"
 
 let test_gradient_direction () =
@@ -3360,6 +3384,8 @@ let test_mask_box () =
   check_mask_box "padding-box";
   check_mask_box "fill-box";
   check_mask_box "inherit";
+  decl_optimizes ~prop:"mask-clip" ~into:"border-box,fill-box,no-clip"
+    "border-box,fill-box,no-clip";
   neg_cursor read_mask_box "invalid-mask-box"
 
 let test_mask_composite () =
@@ -3368,6 +3394,8 @@ let test_mask_composite () =
   check_mask_composite "intersect";
   check_mask_composite "exclude";
   check_mask_composite "inherit";
+  decl_optimizes ~prop:"mask-composite" ~into:"add,subtract,intersect"
+    "add,subtract,intersect";
   neg_cursor read_mask_composite "invalid-composite"
 
 let test_mask_mode () =


### PR DESCRIPTION
The geometry sub-properties of `background` and `mask` are comma-separated layer lists (CSS Backgrounds 3 §3, CSS Masking 1). `background-attachment` and `-webkit-mask-composite` already modelled this with a list variant, but `background-repeat`, `background-clip`, `background-origin`, `background-size`, `mask-clip`, `mask-origin` and `mask-composite` did not, so a multi-layer value dropped the whole declaration.

Found by parsing tailwindcss.com (`background-repeat:no-repeat,repeat-y,no-repeat`); confirmed in headless Chrome that the first layer applies (computed value differs from the initial), so the value is valid and was being lost.

Adds a `Layers`/`Composites` variant to `background_repeat`, `background_box`, `background_size`, `mask_box`, `mask_composite` and reads the longhand as a comma list. The single-value path and the (single-layer) `background` shorthand are unchanged; `repeat-x`/`repeat-y` move into the per-layer reader so each layer can take them.