### PR TITLE
properties: accept a unitless 0 for vertical-align

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -6747,6 +6747,7 @@ type vertical_align = Properties.vertical_align =
   | Text_bottom
   | Sub
   | Super
+  | Zero
   | Px of float
   | Rem of float
   | Em of float

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -40,6 +40,9 @@ let read_vertical_align_length t : vertical_align =
   | Some "rem" -> Rem n
   | Some "em" -> Em n
   | Some "%" -> Pct n
+  (* A unitless [0] is the valid zero <length> (CSS Values 4 §6.1); any other
+     unitless number is not a length and is rejected. *)
+  | None when n = 0. -> Zero
   | None -> Cursor.err_invalid t "vertical-align requires a unit"
   | Some u -> Cursor.err_invalid t ("invalid vertical-align unit: " ^ u)
 
@@ -6432,6 +6435,7 @@ let rec pp_vertical_align : vertical_align Pp.t =
   | Text_bottom -> Pp.string ctx "text-bottom"
   | Sub -> Pp.string ctx "sub"
   | Super -> Pp.string ctx "super"
+  | Zero -> Pp.string ctx "0"
   | Px f -> Pp.unit ctx f "px"
   | Rem f -> Pp.unit ctx f "rem"
   | Em f -> Pp.unit ctx f "em"

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1642,6 +1642,7 @@ type vertical_align =
   | Text_bottom
   | Sub
   | Super
+  | Zero
   | Px of float
   | Rem of float
   | Em of float

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2041,6 +2041,10 @@ let test_vertical_align () =
   check_vertical_align "10px";
   check_vertical_align "var(--v)";
   check_vertical_align "calc(50% + 10px)";
+  (* A unitless 0 is the valid zero <length> and stays unitless; any other
+     unitless number is not a length. *)
+  check_vertical_align "0";
+  neg_cursor read_vertical_align "5";
   neg_cursor read_vertical_align "invalid-align"
 
 let test_font_family () =


### PR DESCRIPTION
vertical-align takes a `<length-percentage>`, and a unitless `0` is the valid zero `<length>` (CSS Values 4 §6.1). The reader required a unit, so `vertical-align:0` (shipped by Bootstrap, kept by Chrome as `0px`) was dropped. Adds a `Zero` constructor so it round-trips as the shortest spelling `0`; a unitless non-zero number stays rejected (not a length).