### PR TITLE
properties: accept -webkit-sticky and -webkit-match-parent

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1839,6 +1839,7 @@ type position = Properties.position =
   | Absolute
   | Fixed
   | Sticky
+  | Webkit_sticky
   | Initial
   | Inherit
   | Unset
@@ -4035,6 +4036,7 @@ type text_align = Properties.text_align =
   | Start
   | End
   | Match_parent
+  | Webkit_match_parent
   | Inherit
   | Initial
   | Unset

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -182,6 +182,7 @@ let rec read_position t : position =
       ("absolute", Absolute);
       ("fixed", Fixed);
       ("sticky", Sticky);
+      ("-webkit-sticky", Webkit_sticky);
       ("initial", Initial);
       ("inherit", Inherit);
       ("unset", Unset);
@@ -817,6 +818,7 @@ let rec read_text_align t : text_align =
       ("start", Start);
       ("end", End);
       ("match-parent", Match_parent);
+      ("-webkit-match-parent", Webkit_match_parent);
       ("inherit", Inherit);
       ("initial", Initial);
       ("unset", Unset);
@@ -5076,6 +5078,7 @@ let rec pp_position : position Pp.t =
   | Absolute -> Pp.string ctx "absolute"
   | Fixed -> Pp.string ctx "fixed"
   | Sticky -> Pp.string ctx "sticky"
+  | Webkit_sticky -> Pp.string ctx "-webkit-sticky"
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -5696,6 +5699,7 @@ let rec pp_text_align : text_align Pp.t =
   | Start -> Pp.string ctx "start"
   | End -> Pp.string ctx "end"
   | Match_parent -> Pp.string ctx "match-parent"
+  | Webkit_match_parent -> Pp.string ctx "-webkit-match-parent"
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -101,6 +101,7 @@ type position =
   | Absolute
   | Fixed
   | Sticky
+  | Webkit_sticky
   | Initial
   | Inherit
   | Unset
@@ -871,6 +872,7 @@ type text_align =
   | Start
   | End
   | Match_parent
+  | Webkit_match_parent
   | Inherit
   | Initial
   | Unset

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -254,6 +254,12 @@ let rec value_is_vendor_prefixed decl =
       background_image_is_vendor value
   | Declaration { property = Border_image_source; value; _ } ->
       background_image_is_vendor value
+  (* [position:-webkit-sticky;position:sticky] and the [text-align] equivalent
+     are the same browser-compat pattern: old Safari only understands the
+     prefixed keyword, so the earlier declaration is a real fallback. *)
+  | Declaration { property = Position; value = Webkit_sticky; _ } -> true
+  | Declaration { property = Text_align; value = Webkit_match_parent; _ } ->
+      true
   | Declaration _ -> false
 
 (* CSS Box 4 7.1: a 1/2/3/4-value box shorthand expands to four explicit sides.

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1153,6 +1153,7 @@ let test_position () =
   check_position "absolute";
   check_position "fixed";
   check_position "sticky";
+  check_position "-webkit-sticky";
   neg_cursor read_position "invalid-position";
   (* multiple values *)
   neg_cursor read_position "absolute relative";
@@ -1349,6 +1350,8 @@ let test_text_align () =
   check_text_align "justify";
   check_text_align "start";
   check_text_align "end";
+  check_text_align "match-parent";
+  check_text_align "-webkit-match-parent";
   check_text_align "inherit";
   neg_cursor read_text_align "invalid-align";
   (* vertical align, not text align *)

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -121,6 +121,21 @@ let test_deduplicate_keeps_legacy_fallbacks () =
   Alcotest.(check (list string))
     "vendor fallback is kept but ordinary duplicate is dropped"
     [ "display:-webkit-box"; "display:flex"; "color:blue" ]
+    (decl_strings result);
+  (* The prefixed-keyword fallbacks for position / text-align are kept too: old
+     Safari only understands -webkit-sticky / -webkit-match-parent. *)
+  let result =
+    ".a{position:-webkit-sticky;position:sticky;text-align:-webkit-match-parent;text-align:start}"
+    |> decls |> Shorthand.deduplicate_declarations
+  in
+  Alcotest.(check (list string))
+    "prefixed-keyword position/text-align fallbacks are kept"
+    [
+      "position:-webkit-sticky";
+      "position:sticky";
+      "text-align:-webkit-match-parent";
+      "text-align:start";
+    ]
     (decl_strings result)
 
 let suite =


### PR DESCRIPTION
Bootstrap ships `position:-webkit-sticky` (old Safari only understands the prefix) and `text-align:-webkit-match-parent`; cascade dropped both declarations.

Adds typed `Webkit_sticky` / `Webkit_match_parent` constructors. The prefixed and unprefixed declarations are a deliberate browser-compat fallback, not a redundant duplicate, so the optimiser must keep both: `value_is_vendor_prefixed` now recognises these (it already preserved `display:-webkit-box;display:flex`), and `position:-webkit-sticky;position:sticky` survives minify+optimize. A true duplicate (`position:sticky;position:sticky`) and a dead override (`color:red;color:blue`) are still optimised.

Vendor-prefixed intrinsic sizing keywords (`-webkit-/-moz- max-content` etc.) are deliberately left out: those live on the core `length-percentage` type with a large exhaustiveness surface, so they warrant their own change.