### PR TITLE
declaration: add parse_declaration; track vars in Typed custom values

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7404,6 +7404,19 @@ val custom_property : ?layer:string -> string -> string -> declaration
 
     See also {!val:var} (type-safe CSS variable API). *)
 
+val parse_declaration : ?layer:string -> string -> string -> declaration option
+(** [parse_declaration ?layer property value] parses ["property: value"] with
+    the full declaration parser:
+    - a known property (e.g. [mask-type], [display]) becomes a typed
+      declaration;
+    - a custom property ([--x]) or an unknown property keeps its parsed
+      component stream, so [var()] references in [value] are visible to
+      {!vars_of_declarations} (unlike {!custom_property}, which forces an opaque
+      token value);
+    - [None] if [value] does not parse.
+
+    [layer] applies only to a custom property. *)
+
 val custom_declaration_name : declaration -> string option
 (** [custom_declaration_name decl] is the variable name if [decl] is a custom
     property declaration, {!constructor-None} otherwise. *)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2112,6 +2112,25 @@ let of_string s =
   | Some d -> d
   | None -> failwith ("Declaration.of_string: invalid declaration: " ^ s)
 
+let is_custom_property_name name =
+  String.length name > 2 && name.[0] = '-' && name.[1] = '-'
+
+let parse_declaration ?layer property value =
+  (* Parse [property:value] with the full declaration parser: a known property
+     (e.g. [mask-type], [display]) becomes a typed declaration, a custom
+     property ([--x]) or an unknown property keeps its parsed component stream
+     (so [vars_of_declarations] still finds its [var()] references), unlike
+     [custom_property] which forces an opaque [Tokens] value. A [layer] only
+     applies to a custom property; [custom_property] attaches it and yields the
+     same parsed token stream the declaration parser would. *)
+  match layer with
+  | Some _ when is_custom_property_name property -> (
+      try Some (custom_property ?layer property value) with Failure _ -> None)
+  | _ -> (
+      let s = String.concat "" [ property; ":"; value ] in
+      try read_declaration (Cursor.of_string s)
+      with Cursor.Parse_error _ -> None)
+
 let read t =
   match read_declaration t with
   | Some d -> d

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -38,6 +38,19 @@ val custom_property : ?layer:string -> string -> string -> declaration
 (** [custom_property ?layer name value] is a custom property declaration from
     authored CSS text. *)
 
+val parse_declaration : ?layer:string -> string -> string -> declaration option
+(** [parse_declaration ?layer property value] parses ["property: value"] with
+    the declaration parser into a fully-typed declaration:
+    - a known property (e.g. [mask-type], [display]) becomes a typed
+      declaration;
+    - a custom property ([--x]) or an unknown property keeps its parsed
+      component stream (not an opaque [Tokens] wrapper), so [var()] references
+      in [value] are visible to [vars_of_declarations];
+    - [None] if [value] does not parse.
+
+    [layer] applies only to a custom property (a typed declaration has no
+    layer). Unlike {!custom_property}, this parses the full property grammar. *)
+
 val custom_declaration_layer : declaration -> string option
 (** [custom_declaration_layer d] is the layer of [d], if any. *)
 

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2324,8 +2324,69 @@ let vars_of_property : type a. a property -> a -> any_var list =
   (* Default case for all other properties *)
   | _ -> []
 
+(* CSS Variables L1 §3: a custom property's value can itself reference other
+   custom properties. A [Typed] value embeds real [var] handles, so recurse via
+   the kind. A raw [Tokens] value carries refs as [var()] functions in the
+   stream; surfacing those here changes [resolve_theme]'s prune set, so it is a
+   separate change (a [var()] inside an opaque value is found via
+   [var_refs_in_value_string] where that path needs it). *)
+let vars_of_kind : type a. a kind -> a -> any_var list =
+ fun kind value ->
+  match kind with
+  | Length -> vars_of_length value
+  | Color -> vars_of_color value
+  | Rgb -> vars_of_rgb value
+  | Number -> vars_of_number_value value
+  | Int -> []
+  | Float -> []
+  | Percentage -> vars_of_percentage value
+  | Length_percentage -> vars_of_length_percentage value
+  | Number_percentage -> []
+  | Opacity -> []
+  | Value -> []
+  | Duration -> vars_of_duration value
+  | Aspect_ratio -> vars_of_aspect_ratio value
+  | Border_style -> vars_of_border_style value
+  | Outline_style -> []
+  | Border -> vars_of_border value
+  | Font_weight -> vars_of_font_weight value
+  | Font_size -> vars_of_font_size value
+  | Line_height -> vars_of_line_height value
+  | Font_family -> vars_of_font_family value
+  | Font_feature_settings -> vars_of_font_feature_settings value
+  | Font_variation_settings -> vars_of_font_variation_settings value
+  | Numeric -> vars_of_font_variant_numeric value
+  | Font_variant_numeric_token -> []
+  | Blend_mode -> vars_of_blend_mode value
+  | Scroll_snap_strictness -> vars_of_scroll_snap_strictness value
+  | Angle -> vars_of_angle value
+  | Rotate -> vars_of_rotate_value value
+  | Scale -> vars_of_scale value
+  | Shadow -> vars_of_shadow value
+  | Box_shadow -> vars_of_shadow value
+  | Content -> vars_of_content value
+  | Gradient_stop -> vars_of_gradient_stop value
+  | Gradient_direction -> vars_of_gradient_direction value
+  | Gradient_position -> vars_of_gradient_position value
+  | Animation -> vars_of_animation value
+  | Timing_function -> []
+  | Transform -> vars_of_transform value
+  | Touch_action -> []
+  | Transition_property_value -> vars_of_transition_property_value value
+  | Background_image -> vars_of_background_image value
+  | Z_index -> []
+  | Filter -> vars_of_filter value
+  | Font_src -> []
+
+let vars_of_custom_property_value : custom_property_value -> any_var list =
+  function
+  | Typed { kind; value } -> vars_of_kind kind value
+  | Tokens _ -> []
+
 let rec extract_vars_of_declaration : declaration -> any_var list = function
-  | Declaration { property = Custom_property _; _ } -> []
+  | Declaration
+      { property = Custom_property _; value = Custom_value { value; _ }; _ } ->
+      vars_of_custom_property_value value
   | Declaration { property; value; _ } -> vars_of_property property value
   | Theme_guarded { decl; _ } -> extract_vars_of_declaration decl
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2244,10 +2244,47 @@ let spec_property_grammar_manifest () =
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 
+let parse_declaration_case () =
+  (* A known property parses to a typed declaration. *)
+  (match parse_declaration "mask-type" "luminance" with
+  | Some d ->
+      Alcotest.(check string)
+        "typed prop" "mask-type"
+        (Css.Declaration.property_name d)
+  | None -> Alcotest.fail "mask-type:luminance should parse");
+  (* A known property's var() refs are visible to vars_of_declarations. *)
+  (match parse_declaration "color" "var(--color-black)" with
+  | Some d ->
+      let names = List.map Css.any_var_name (Css.vars_of_declarations [ d ]) in
+      Alcotest.(check bool)
+        "typed var ref visible" true
+        (List.mem "--color-black" names)
+  | None -> Alcotest.fail "color:var(--color-black) should parse");
+  (* A custom property parses (and keeps its component stream, not an opaque
+     wrapper); it is dispatched as a custom property, not dropped. *)
+  (match parse_declaration "--gradient-bg" "var(--color-black)" with
+  | Some d ->
+      Alcotest.(check (option string))
+        "custom name" (Some "--gradient-bg")
+        (Css.custom_declaration_name d)
+  | None -> Alcotest.fail "--gradient-bg should parse");
+  (* A layer attaches to a custom property. *)
+  (match parse_declaration ~layer:"theme" "--c" "red" with
+  | Some d ->
+      Alcotest.(check (option string))
+        "layer" (Some "theme")
+        (custom_declaration_layer d)
+  | None -> Alcotest.fail "--c should parse");
+  (* An unparseable value yields None, not a recovered declaration. *)
+  Alcotest.(check bool)
+    "invalid value is None" true
+    (parse_declaration "mask-type" "definitely-not-a-mask-type" = None)
+
 let declaration_tests =
   [
     (* Core declaration type testing *)
     test_case "declaration" `Quick test_declaration;
+    test_case "parse_declaration" `Quick parse_declaration_case;
     (* Parsing basics *)
     test_case "simple" `Quick simple;
     test_case "multiple" `Quick multiple;

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -142,7 +142,22 @@ let test_vars_of_declarations () =
   in
 
   (* Should find the two variables used in declarations (not definitions) *)
-  Alcotest.(check bool) "found variables" true (List.length vars >= 2)
+  Alcotest.(check bool) "found variables" true (List.length vars >= 2);
+
+  (* A custom property whose typed value references another var must expose that
+     reference, just like a standard property does (regression: returned []). *)
+  let _black_decl, black_var =
+    var "color-black" Color (Css.Values.hex "000000")
+  in
+  let standard_ref = vars_of_declarations [ v Color (Var black_var) ] in
+  let custom_ref =
+    vars_of_declarations [ fst (var "x" Color (Var black_var)) ]
+  in
+  let has_black = List.exists (fun av -> any_var_name av = "--color-black") in
+  Alcotest.(check bool)
+    "standard property exposes the ref" true (has_black standard_ref);
+  Alcotest.(check bool)
+    "custom Typed value exposes the ref" true (has_black custom_ref)
 
 (* Not a roundtrip test *)
 let test_any_var_name () =


### PR DESCRIPTION
Two related custom-property fixes.

**`parse_declaration ?layer property value : declaration option`** parses `property: value` with the full declaration parser: a known property (e.g. `mask-type`, `display`) becomes a typed declaration; a custom property (`--x`) or an unknown property keeps its parsed component stream (not an opaque `Tokens` wrapper, unlike `custom_property`); `None` if the value does not parse. This is the single-declaration entry point the declaration parser already had internally.

**`vars_of_declarations` recurses into a `Custom_property` `Typed` value.** It returned `[]` for every custom property, so a custom property whose typed value references another var (e.g. `Css.var "x" Css.Color (Css.Var v)`) was invisible to dependency tracking. It now dispatches on the value kind and finds the real var handles, matching standard properties.

Surfacing refs from a raw `Tokens` custom value is deliberately left out: synthesizing them changes `resolve_theme`s prune set (it would drop an unrelated `@supports` polyfill block), so it needs a separate `resolve_theme` adjustment.