### PR TITLE
stylesheet: recover invalid @font-face descriptor values, accept valid edges

### DIFF
--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -1040,8 +1040,6 @@ let test_invalid_atrule_descriptor buf =
         "@property --angle-list { syntax: \"<angle>#\"; inherits: false; \
          initial-value: 0 }";
         "@font-face { src: url(\"brand.woff2\"); }";
-        "@font-face { font-family: Brand; src: url(\"brand.woff2\"); \
-         font-weight: 900 100 }";
         "@font-face { font-family: Brand; src: format(\"woff2\"); }";
         "@font-face { font-family: Brand; src: url(font.woff2); unicode-range: \
          U+20-10 }";
@@ -1125,8 +1123,6 @@ let test_invalid_font_face buf =
   let input =
     pick
       [
-        "@font-face { font-family: Brand; src: url(brand.woff2); font-weight: \
-         900 100 }";
         "@font-face { font-family: Brand; src: url(brand.woff2); \
          ascent-override: -1%; }";
         "@font-face { font-family: Brand; src: url(brand.woff2); size-adjust: \

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -168,16 +168,21 @@ let size_adjust_of_string s =
 let read_function_arg name t =
   Cursor.call name t @@ fun inner ->
   Cursor.ws inner;
-  let value =
+  let value, from_string =
     match Cursor.string_opt inner with
-    | Some s -> s
-    | None -> Cursor.consume_remaining_as_string ~trim:true inner
+    | Some s -> (s, true)
+    | None -> (Cursor.consume_remaining_as_string ~trim:true inner, false)
   in
   Cursor.expect_eof inner;
-  (* CSS Fonts 4 §11.1: [local(<family-name>)], [format(<font-format> |
-     <string>)] and [tech(<font-tech>)] all take exactly one argument; an empty
-     body like [format()] is invalid. *)
-  if value = "" then Cursor.err_invalid inner ("empty " ^ name ^ "()");
+  (* CSS Fonts 4 §11.1: each of [local()] / [format()] / [tech()] takes exactly
+     one argument, so an empty body ([format()], [local()]) is invalid. The one
+     exception browsers accept is [local("")] - an explicit empty <string>
+     family name - so keep that. *)
+  let is_empty_local_string =
+    from_string && value = "" && String.lowercase_ascii name = "local"
+  in
+  if value = "" && not is_empty_local_string then
+    Cursor.err_invalid inner ("empty " ^ name ^ "()");
   value
 
 let read_url t =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -742,12 +742,6 @@ let rec read_font_weight t : font_weight =
     t
 
 let rec read_font_style t : font_style =
-  let validate_oblique_range first second =
-    match (angle_degrees_opt first, angle_degrees_opt second) with
-    | Some a, Some b when a <= b -> ()
-    | Some _, Some _ -> Cursor.err_invalid t "font-style oblique range"
-    | _ -> ()
-  in
   Cursor.enum_or_var "font-style"
     [
       ("normal", (Normal : font_style));
@@ -768,8 +762,9 @@ let rec read_font_style t : font_style =
         Cursor.ws t;
         if Cursor.is_done t || Cursor.peek_semicolon t then Oblique_angle first
         else
+          (* CSS Fonts 4 §11.2 wants the first oblique angle <= the second, but
+             browsers do not enforce it ([oblique 20deg 10deg] is kept). *)
           let second = read_angle t in
-          validate_oblique_range first second;
           Oblique_range (first, second))
     t
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -762,9 +762,18 @@ let rec read_font_style t : font_style =
         Cursor.ws t;
         if Cursor.is_done t || Cursor.peek_semicolon t then Oblique_angle first
         else
-          (* CSS Fonts 4 §11.2 wants the first oblique angle <= the second, but
-             browsers do not enforce it ([oblique 20deg 10deg] is kept). *)
+          (* CSS Fonts 4 §11.2 wants the first oblique angle <= the second.
+             Browsers keep a descending range ([oblique 20deg 10deg]), so accept
+             it but warn, leaving [Css.of_string ~strict] free to reject it. *)
           let second = read_angle t in
+          (match (angle_degrees_opt first, angle_degrees_opt second) with
+          | Some a, Some b when a > b ->
+              Cursor.push_warning t
+                (Error.bad_value (Cursor.position t) ~property:"font-style"
+                   ~reason:
+                     "oblique angle range must run from the smaller angle to \
+                      the larger (CSS Fonts 4 §11.2)")
+          | _ -> ());
           Oblique_range (first, second))
     t
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1698,6 +1698,23 @@ let read_descriptor_block normalize inner =
   in
   loop []
 
+(* CSS Fonts 4 §11.2 wants the first bound of a descriptor range <= the second.
+   Browsers keep a descending range, so the readers accept it but record a
+   warning here; [Css.of_string ~strict] then turns the warning into an
+   error. *)
+let warn_descending_range r property =
+  Cursor.push_warning r
+    (Error.bad_value (Cursor.position r) ~property
+       ~reason:
+         "range must run from the smaller value to the larger (CSS Fonts 4 \
+          §11.2)")
+
+let font_weight_num = function
+  | (Properties.Weight n : Properties.font_weight) -> Some n
+  | Properties.Normal -> Some 400
+  | Properties.Bold -> Some 700
+  | _ -> None
+
 let read_font_weight_descriptor r =
   read_descriptor_value Declaration.read_property_value
     (fun value ->
@@ -1706,12 +1723,12 @@ let read_font_weight_descriptor r =
       Cursor.ws c;
       if Cursor.is_done c then Font_weight first
       else
-        (* CSS Fonts 4 §11.2 wants the first weight <= the second, but browsers
-           keep a descending range ([font-weight:900 100]), so accept any
-           pair. *)
         let second = Properties.read_font_weight c in
         Cursor.ws c;
         Cursor.expect_eof c;
+        (match (font_weight_num first, font_weight_num second) with
+        | Some a, Some b when a > b -> warn_descending_range r "font-weight"
+        | _ -> ());
         Font_weight_range (first, second))
     r
 
@@ -1721,12 +1738,18 @@ let read_font_style_descriptor r =
       let c = Cursor.of_string value in
       let first = Properties.read_font_style c in
       Cursor.ws c;
-      if Cursor.is_done c then Font_style first
-      else
-        let second = Properties.read_font_style c in
-        Cursor.ws c;
-        Cursor.expect_eof c;
-        Font_style_range (first, second))
+      let descriptor =
+        if Cursor.is_done c then Font_style first
+        else
+          let second = Properties.read_font_style c in
+          Cursor.ws c;
+          Cursor.expect_eof c;
+          Font_style_range (first, second)
+      in
+      (* [read_font_style] warns on a descending oblique range; the value is
+         parsed in [c], so surface its warnings on the drained cursor [r]. *)
+      List.iter (Cursor.push_warning r) (Cursor.drain_warnings c);
+      descriptor)
     r
 
 let validate_nonempty_descriptor r name value =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1698,27 +1698,6 @@ let read_descriptor_block normalize inner =
   in
   loop []
 
-let validate_font_weight_range r first second =
-  match (first, second) with
-  | ( (Properties.Weight a : Properties.font_weight),
-      (Properties.Weight b : Properties.font_weight) )
-    when a <= b ->
-      ()
-  | _ -> Cursor.err_invalid r "invalid font-weight descriptor range"
-
-let validate_font_style_oblique_range r first second =
-  match (Values.angle_degrees_opt first, Values.angle_degrees_opt second) with
-  | Some a, Some b when a <= b -> ()
-  | Some _, Some _ -> Cursor.err_invalid r "invalid font-style descriptor range"
-  | _ -> ()
-
-let validate_font_style_descriptor_range r first second =
-  match (first, second) with
-  | ( (Properties.Oblique_angle first : Properties.font_style),
-      Properties.Oblique_angle second ) ->
-      validate_font_style_oblique_range r first second
-  | _ -> ()
-
 let read_font_weight_descriptor r =
   read_descriptor_value Declaration.read_property_value
     (fun value ->
@@ -1727,10 +1706,12 @@ let read_font_weight_descriptor r =
       Cursor.ws c;
       if Cursor.is_done c then Font_weight first
       else
+        (* CSS Fonts 4 §11.2 wants the first weight <= the second, but browsers
+           keep a descending range ([font-weight:900 100]), so accept any
+           pair. *)
         let second = Properties.read_font_weight c in
         Cursor.ws c;
         Cursor.expect_eof c;
-        validate_font_weight_range r first second;
         Font_weight_range (first, second))
     r
 
@@ -1745,7 +1726,6 @@ let read_font_style_descriptor r =
         let second = Properties.read_font_style c in
         Cursor.ws c;
         Cursor.expect_eof c;
-        validate_font_style_descriptor_range r first second;
         Font_style_range (first, second))
     r
 
@@ -1966,19 +1946,6 @@ let read_font_face_desc name r =
         r
   | _ -> Cursor.err_invalid r ("unknown font-face descriptor: " ^ name)
 
-(* Keep in sync with [read_font_face_desc]. CSS Fonts 4 §11.2 / CSS Syntax 3
-   §5.4.4: an unknown descriptor is dropped and the rest of the @font-face is
-   kept (browsers ignore it, e.g. Fontsource's non-standard
-   [font-named-instance]). A known descriptor with a bad value still rejects the
-   rule (cascade is stricter than browsers here on purpose). *)
-let is_known_font_face_descriptor = function
-  | "font-family" | "src" | "font-style" | "font-weight" | "font-stretch"
-  | "font-display" | "unicode-range" | "font-variant" | "font-feature-settings"
-  | "font-variation-settings" | "font-tech" | "size-adjust" | "ascent-override"
-  | "descent-override" | "line-gap-override" ->
-      true
-  | _ -> false
-
 let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
   Cursor.ws r;
   if Cursor.is_done r then None
@@ -1992,8 +1959,11 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
         Cursor.ws r;
         if Cursor.peek_semicolon r then Cursor.skip r;
         Some descriptor
-    | exception Error.Parse_error e
-      when not (is_known_font_face_descriptor name) ->
+    | exception Error.Parse_error e ->
+        (* CSS Fonts 4 §11.2 / CSS Syntax 3 §5.4.4: a descriptor that does not
+           parse - an unknown name (Fontsource's [font-named-instance]) or an
+           invalid value of a known one ([font-display:maybe]) - is dropped and
+           the rest of the @font-face is kept, matching browsers. *)
         Cursor.push_warning r e;
         let rec skip_to_semicolon () =
           match Cursor.next_raw r with

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1782,26 +1782,23 @@ let font_stretch_pct_opt = function
   | Properties.Ultra_expanded -> Some 200.
   | _ -> None
 
-let validate_font_stretch_range r first second =
-  match (font_stretch_pct_opt first, font_stretch_pct_opt second) with
-  | Some a, Some b when a <= b -> ()
-  | _ -> Cursor.err_invalid r "invalid font-stretch descriptor range"
-
-let read_font_stretch_descriptor_value value =
-  let c = Cursor.of_string value in
-  let first = Properties.read_font_stretch c in
-  Cursor.ws c;
-  if Cursor.is_done c then Font_stretch first
-  else
-    let second = Properties.read_font_stretch c in
-    Cursor.ws c;
-    Cursor.expect_eof c;
-    validate_font_stretch_range c first second;
-    Font_stretch_range value
-
 let read_font_stretch_descriptor r =
   read_descriptor_value Declaration.read_property_value
-    read_font_stretch_descriptor_value r
+    (fun value ->
+      let c = Cursor.of_string value in
+      let first = Properties.read_font_stretch c in
+      Cursor.ws c;
+      if Cursor.is_done c then Font_stretch first
+      else begin
+        let second = Properties.read_font_stretch c in
+        Cursor.ws c;
+        Cursor.expect_eof c;
+        (match (font_stretch_pct_opt first, font_stretch_pct_opt second) with
+        | Some a, Some b when a > b -> warn_descending_range r "font-stretch"
+        | _ -> ());
+        Font_stretch_range value
+      end)
+    r
 
 let read_unicode_range_descriptor r =
   read_descriptor_value

--- a/test/spec/inventory/at_rule_grammar.ml
+++ b/test/spec/inventory/at_rule_grammar.ml
@@ -139,9 +139,6 @@ let negative =
     invalid "font-face" "nested-rule"
       "@font-face { font-family: Brand; src: url(brand.woff2); @media screen { \
        .x { color: red } } }";
-    invalid "font-face" "bad-range"
-      "@font-face { font-family: Brand; src: url(brand.woff2); font-weight: \
-       900 100 }";
     invalid "page" "invalid-pseudo" "@page :unknown { margin: 1cm }";
     invalid "page" "invalid-margin-descriptor"
       "@page { @top-center { display: block } }";

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -250,7 +250,6 @@ let spec_fontface_src_invalid_edges () =
       "";
       "url()";
       "url(\"\")";
-      "local(\"\")";
       "url(\"font.woff2\"),";
       "url(\"font.woff2\") garbage";
       "url(\"font.woff2\") format(\"woff2\") garbage";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1259,6 +1259,15 @@ let spec_strict_rejects_invalid_stylesheets () =
       ( "font-face unicode-range descending range",
         "@font-face { font-family: Brand; src: url(font.woff2); unicode-range: \
          U+20-10 }" );
+      (* Browsers keep a descending font-weight / oblique-angle range, so the
+         lenient parse keeps it with a warning; strict turns that into an error
+         (CSS Fonts 4 §11.2 wants the first bound <= the second). *)
+      ( "font-face descending font-weight range",
+        "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
+         900 100 }" );
+      ( "font-face descending oblique angle range",
+        "@font-face { font-family: Brand; src: url(font.woff2); font-style: \
+         oblique 20deg 10deg }" );
       ( "font-face invalid font-display list",
         "@font-face { font-family: Brand; src: url(font.woff2); font-display: \
          block swap }" );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -683,28 +683,6 @@ let font_face_case () =
      font-display: swap; }"
 
 let spec_fontface_descriptors () =
-  let expect_stylesheets_rejected inputs =
-    let accepted =
-      List.filter_map
-        (fun input ->
-          let c = Cursor.of_string input in
-          match read_stylesheet c with
-          | exception Error.Parse_error _ -> None
-          | sheet ->
-              if Cursor.is_done c then
-                Fmt.kstr
-                  (fun s -> Some s)
-                  "%S -> %S" input
-                  (Css.Pp.to_string ~minify:true pp_stylesheet sheet)
-              else None)
-        inputs
-    in
-    match accepted with
-    | [] -> ()
-    | _ ->
-        Alcotest.failf "accepted invalid @font-face cases:\n%s"
-          (String.concat "\n" accepted)
-  in
   check_stylesheet
     ~expected:
       "@font-face{font-family:Brand;src:local(Brand),url(brand.woff2)format(woff2)tech(variations);font-weight:400 \
@@ -752,18 +730,28 @@ let spec_fontface_descriptors () =
     ~expected:"@font-face{font-family:Foo;src:url(foo.woff2);font-style:normal}"
     "@font-face { font-family: Foo; src: url(foo.woff2); font-named-instance: \
      'Regular'; font-style: normal; }";
-  expect_stylesheets_rejected
-    [
-      "@font-face { font-family: Brand; src: url(font.woff2); font-display: \
-       maybe; }";
-      "@font-face { font-family: Brand; src: url(font.woff2); font-variant: \
-       common-ligatures no-common-ligatures; }";
-      "@font-face { font-family: Brand; src: url(font.woff2); font-style: \
-       oblique 20deg 10deg; }";
-      "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: \
-       200% 50%; }";
-      "@font-face { font-family: Brand; src: local(\"\"); }";
-    ]
+  (* An invalid value of a *known* descriptor drops just that descriptor and
+     keeps the rest of the @font-face, like browsers (CSS Fonts 4 §11.2). *)
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-display: \
+     maybe; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-variant: \
+     common-ligatures no-common-ligatures; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: 200% \
+     50%; }";
+  (* [oblique <angle> <angle>] is kept even when the first angle is larger than
+     the second, and [local("")] is a valid empty family name; browsers accept
+     both, so cascade keeps them rather than dropping the @font-face. *)
+  check_stylesheet
+    ~expected:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-style:oblique \
+       20deg 10deg}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-style: \
+     oblique 20deg 10deg; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:local(\"\")}"
+    "@font-face { font-family: Brand; src: local(\"\"); }"
 
 (** Test [@page] rules *)
 let page_case () =
@@ -858,16 +846,22 @@ let spec_font_face_descriptor_matrix () =
          ascent-override: 120%; descent-override: 125%; line-gap-override: 0%; \
          }" );
     ];
-  List.iter
-    (neg_cursor read_stylesheet)
-    [
-      "@font-face { font-family: Brand; src: url(brand.woff2); font-weight: \
-       900 100 }";
-      "@font-face { font-family: Brand; src: url(brand.woff2); \
-       ascent-override: -1%; }";
-      "@font-face { font-family: Brand; src: url(brand.woff2); size-adjust: \
-       normal; }";
-    ]
+  (* A descending font-weight range is kept (browsers accept it, like the
+     oblique range above). *)
+  check_stylesheet
+    ~expected:
+      "@font-face{font-family:Brand;src:url(brand.woff2);font-weight:900 100}"
+    "@font-face { font-family: Brand; src: url(brand.woff2); font-weight: 900 \
+     100 }";
+  (* An invalid metric / size-adjust value drops just that descriptor. *)
+  check_stylesheet
+    ~expected:"@font-face{font-family:Brand;src:url(brand.woff2)}"
+    "@font-face { font-family: Brand; src: url(brand.woff2); ascent-override: \
+     -1%; }";
+  check_stylesheet
+    ~expected:"@font-face{font-family:Brand;src:url(brand.woff2)}"
+    "@font-face { font-family: Brand; src: url(brand.woff2); size-adjust: \
+     normal; }"
 
 let spec_keyframes_selector_matrix () =
   (* CSS Animations 1 section 7.1: [from] / [to] / [0%] / [100%] are pairwise

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -738,7 +738,11 @@ let spec_fontface_descriptors () =
   check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
     "@font-face { font-family: Brand; src: url(font.woff2); font-variant: \
      common-ligatures no-common-ligatures; }";
-  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+  (* A descending font-stretch range is kept like the font-weight / oblique
+     ranges below: browsers do not enforce CSS Fonts 4 §11.2. *)
+  check_stylesheet
+    ~expected:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-stretch:200% 50%}"
     "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: 200% \
      50%; }";
   (* [oblique <angle> <angle>] is kept even when the first angle is larger than
@@ -1268,6 +1272,9 @@ let spec_strict_rejects_invalid_stylesheets () =
       ( "font-face descending oblique angle range",
         "@font-face { font-family: Brand; src: url(font.woff2); font-style: \
          oblique 20deg 10deg }" );
+      ( "font-face descending font-stretch range",
+        "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: \
+         200% 50% }" );
       ( "font-face invalid font-display list",
         "@font-face { font-family: Brand; src: url(font.woff2); font-display: \
          block swap }" );


### PR DESCRIPTION
Three @font-face fixes, each matching headless Chrome: recover from an invalid value of a known descriptor (drop the descriptor, keep the rule); keep a descending font-weight / oblique / font-stretch range but warn, so `~strict` still rejects it (browsers ignore CSS Fonts 4 §11.2's first `<=` second); accept `local("")` while still rejecting `local()`. Oracles updated to match.