### PR TITLE
optimize: keep the prefixed intrinsic sizing keyword fallback through minify

### DIFF
--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -241,6 +241,28 @@ let background_image_is_vendor : Properties.background_image -> bool = function
    value in modern browsers, but old browsers only understand the prefixed
    spelling, so dropping the earlier declaration removes a real browser-compat
    fallback. *)
+(* All the intrinsic sizing properties carry a [length_percentage] value. A GADT
+   or-pattern does not refine the value type, so each constructor is matched on
+   its own; everything else is not a sizing fallback. *)
+let sizing_value_is_vendor_prefixed : type a. a Properties.property -> a -> bool
+    =
+ fun property value ->
+  let pfx = Values.length_percentage_is_vendor_prefixed in
+  match property with
+  | Width -> pfx value
+  | Height -> pfx value
+  | Min_width -> pfx value
+  | Min_height -> pfx value
+  | Max_width -> pfx value
+  | Max_height -> pfx value
+  | Block_size -> pfx value
+  | Inline_size -> pfx value
+  | Min_block_size -> pfx value
+  | Min_inline_size -> pfx value
+  | Max_block_size -> pfx value
+  | Max_inline_size -> pfx value
+  | _ -> false
+
 let rec value_is_vendor_prefixed decl =
   match decl with
   | Theme_guarded { decl; _ } -> value_is_vendor_prefixed decl
@@ -260,7 +282,11 @@ let rec value_is_vendor_prefixed decl =
   | Declaration { property = Position; value = Webkit_sticky; _ } -> true
   | Declaration { property = Text_align; value = Webkit_match_parent; _ } ->
       true
-  | Declaration _ -> false
+  (* [width:-webkit-max-content;width:max-content] and the other intrinsic
+     sizing properties: the prefixed keyword is a fallback for old Safari /
+     Firefox, so the earlier declaration must survive minify dedup. *)
+  | Declaration { property; value; _ } ->
+      sizing_value_is_vendor_prefixed property value
 
 (* CSS Box 4 7.1: a 1/2/3/4-value box shorthand expands to four explicit sides.
    Authored shorthands stay as authored when optimise has no longhand to absorb;

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1272,6 +1272,19 @@ let length_math_fn_value (fn : math_fn) : float option =
 
 (* CSS Values 4 §10.10: identity-rule simplifications around a runtime
    substitution would change the substituted-grammar context. *)
+(* A [-webkit-] / [-moz-] intrinsic sizing keyword, the legacy fallback an
+   author pairs with the unprefixed form ([width:-webkit-max-content;
+   width:max-content]). *)
+let length_is_vendor_prefixed_sizing : length -> bool = function
+  | Webkit_max_content | Webkit_min_content | Webkit_fit_content
+  | Moz_max_content | Moz_min_content | Moz_fit_content ->
+      true
+  | _ -> false
+
+let length_percentage_is_vendor_prefixed : length_percentage -> bool = function
+  | Length l -> length_is_vendor_prefixed_sizing l
+  | _ -> false
+
 let rec length_has_runtime_subst : length -> bool = function
   | Var _ | Env _ | Attr _ | Anchor _ | Anchor_size _ -> true
   | Calc c -> length_calc_has_runtime_subst c

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -130,6 +130,10 @@ val pp_length : ?always:bool -> length Pp.t
     units are always included even for zero values (required for CSS [@property]
     initial-value). *)
 
+val length_percentage_is_vendor_prefixed : length_percentage -> bool
+(** [length_percentage_is_vendor_prefixed v] is [true] when [v] is a legacy
+    vendor-prefixed intrinsic sizing keyword ([-webkit-max-content] etc.). *)
+
 val length_has_runtime_subst : length -> bool
 (** [length_has_runtime_subst l] is [true] when [l] is [var()] / [env()] /
     [attr()] / an anchor query, or a [calc()] containing one. *)

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -136,6 +136,21 @@ let test_deduplicate_keeps_legacy_fallbacks () =
       "text-align:-webkit-match-parent";
       "text-align:start";
     ]
+    (decl_strings result);
+  (* The prefixed intrinsic sizing keywords are kept against the unprefixed
+     form, on a length-percentage and a min-* property. *)
+  let result =
+    ".a{width:-webkit-max-content;width:max-content;min-width:-moz-fit-content;min-width:fit-content}"
+    |> decls |> Shorthand.deduplicate_declarations
+  in
+  Alcotest.(check (list string))
+    "prefixed sizing keyword fallbacks are kept"
+    [
+      "width:-webkit-max-content";
+      "width:max-content";
+      "min-width:-moz-fit-content";
+      "min-width:fit-content";
+    ]
     (decl_strings result)
 
 let suite =


### PR DESCRIPTION
Follow-up to the prefixed intrinsic sizing keyword parse fix. That landed the parse, but minify+optimize dedup still collapsed the fallback (`width:-webkit-max-content;width:max-content` -> `width:max-content`), losing old Safari/Firefox support.

`value_is_vendor_prefixed` now recognises the `-webkit-/-moz- max-content/min-content/fit-content` keywords on the intrinsic sizing properties (`width`/`height`/`min-*`/`max-*`, all of which carry a `length-percentage` value), so the earlier declaration survives the dedup - matching the existing `display:-webkit-box` and `position:-webkit-sticky` handling. A true duplicate (`width:max-content;width:max-content`) and a dead override (`width:100px;width:200px`) are still optimised.