### PR TITLE
cascade: move the apply inlining algorithm into a Cascade.Apply library

### DIFF
--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -1,13 +1,12 @@
 (* [cascade apply <page.html> [extra.css]]: resolve a stylesheet against the
    HTML, write each element's winning declarations into its style attribute, and
    keep the rules with no inline form (:hover, @media, ...) in a <style>. The
-   cascade itself lives in {!Cascade.Resolve}; this command adds the
-   inline-specific policy and the lambdasoup glue. *)
+   projection lives in {!Cascade.Apply}; this command is the lambdasoup glue:
+   parse the HTML, hand the element tree to the library, and write the result
+   back. *)
 
 open Cmdliner
 module Sheet = Cascade.Stylesheet
-module Sel = Cascade.Selector
-module Decl = Cascade.Declaration
 module Css = Cascade.Css
 
 (* ---------- the tree: lambdasoup element nodes ---------- *)
@@ -23,104 +22,7 @@ module Node = struct
   let children n = Soup.children n |> Soup.elements |> Soup.to_list
 end
 
-module R = Cascade.Resolve.Make (Node)
-
-(* ---------- inline policy ---------- *)
-
-(* selectors that can be written as an inline style (no state / condition) *)
-let inlinable (sel : Sel.t) =
-  let rec ok = function
-    | Sel.Universal _ | Sel.Element _ | Sel.Class _ | Sel.Id _ | Sel.Attribute _
-    | Sel.Root | Sel.First_child | Sel.Last_child | Sel.Only_child | Sel.Empty
-      ->
-        true
-    | Sel.Compound ps | Sel.List ps | Sel.Is ps | Sel.Where ps | Sel.Not ps ->
-        List.for_all ok ps
-    | Sel.Combined (a, _, b) -> ok a && ok b
-    | _ -> false
-  in
-  ok sel
-
-(* [html] is stylable so that :root custom properties land on it. *)
-let no_style = [ "head"; "meta"; "title"; "base"; "link"; "style"; "script" ]
-
-(* CSS inherited properties (a conservative set: missing one only keeps a
-   redundant declaration; the differential test guards against dropping a needed
-   one). *)
-let inherited =
-  [
-    "color";
-    "font";
-    "font-family";
-    "font-size";
-    "font-weight";
-    "font-style";
-    "font-variant";
-    "font-stretch";
-    "font-feature-settings";
-    "line-height";
-    "letter-spacing";
-    "word-spacing";
-    "text-align";
-    "text-indent";
-    "text-transform";
-    "text-shadow";
-    "white-space";
-    "word-break";
-    "overflow-wrap";
-    "hyphens";
-    "tab-size";
-    "visibility";
-    "cursor";
-    "direction";
-    "list-style";
-    "list-style-type";
-    "list-style-position";
-    "list-style-image";
-    "quotes";
-    "caption-side";
-    "border-collapse";
-    "border-spacing";
-    "empty-cells";
-  ]
-
-let is_inherited p = List.mem (String.lowercase_ascii p) inherited
-
-let parse_inline s =
-  match Css.of_string ("a{" ^ s ^ "}") with
-  | Ok p -> (
-      match Sheet.rules p.Css.stylesheet with
-      | r :: _ -> Sheet.declarations r
-      | [] -> [])
-  | Error _ -> []
-
-let decl_value d =
-  let s =
-    Sheet.inline_style_of_declarations ~minify:true ~mode:Variables [ d ]
-  in
-  match String.index_opt s ':' with
-  | Some i -> String.sub s (i + 1) (String.length s - i - 1)
-  | None -> s
-
-(* a node's style: the author cascade from {!R.resolve} with the element's own
-   inline style overlaid (inline beats a selector, but an author !important
-   beats a normal inline declaration). *)
-let resolved sheet n =
-  let author = R.resolve sheet n in
-  match Soup.attribute "style" n with
-  | None -> author
-  | Some s ->
-      let overlay map d =
-        let k = Decl.property_name d in
-        match List.assoc_opt k map with
-        | Some cur when Decl.is_important cur && not (Decl.is_important d) ->
-            map
-        | _ -> (k, d) :: List.remove_assoc k map
-      in
-      List.fold_left overlay
-        (List.map (fun d -> (Decl.property_name d, d)) author)
-        (parse_inline s)
-      |> List.rev_map snd
+module Apply = Cascade.Apply.Make (Node)
 
 let style_node node = function
   | [] -> ()
@@ -133,49 +35,6 @@ let style_node node = function
         (Sheet.inline_style_of_declarations ~minify:true ~mode:Variables decls)
         node
 
-(* ---------- splitting static / dynamic ---------- *)
-module SSet = Set.Make (String)
-
-(* every property a kept (conditional / stateful) rule can set, recursing into
-   @media / @supports / @container / @layer blocks. *)
-let rec props_of_stmts acc stmts =
-  List.fold_left
-    (fun acc s ->
-      match s with
-      | Sheet.Rule r ->
-          List.fold_left
-            (fun a d ->
-              SSet.add (String.lowercase_ascii (Decl.property_name d)) a)
-            acc (Sheet.declarations r)
-      | Sheet.Media (_, b) | Sheet.Supports (_, b) | Sheet.Layer (_, b) ->
-          props_of_stmts acc b
-      | Sheet.Container (_, _, b) -> props_of_stmts acc b
-      | _ -> acc)
-    acc stmts
-
-(* ---------- the walk ---------- *)
-(* [ctx] maps each inherited property to the value in force from the ancestors,
-   so [minimal] can drop a declaration that only restates it. *)
-let rec walk ~minimal sheet ctx node =
-  if List.mem (String.lowercase_ascii (Soup.name node)) no_style then
-    List.iter (walk ~minimal sheet ctx) (Node.children node)
-  else begin
-    let kept, ctx' =
-      List.fold_left
-        (fun (kept, ctx) d ->
-          let p = String.lowercase_ascii (Decl.property_name d) in
-          if minimal && is_inherited p then
-            let v = decl_value d in
-            match List.assoc_opt p ctx with
-            | Some pv when pv = v -> (kept, ctx)
-            | _ -> (d :: kept, (p, v) :: List.remove_assoc p ctx)
-          else (d :: kept, ctx))
-        ([], ctx) (resolved sheet node)
-    in
-    style_node node (List.rev kept);
-    List.iter (walk ~minimal sheet ctx') (Node.children node)
-  end
-
 let inline_html ~minimal ~html ~extra =
   let soup = Soup.parse html in
   let page_css =
@@ -183,51 +42,11 @@ let inline_html ~minimal ~html ~extra =
     |> String.concat "\n"
   in
   let css = page_css ^ "\n" ^ extra in
-  let inline_sheet, keep_css, kept =
-    match Css.of_string css with
-    | Ok p ->
-        (* flatten nesting up front, so the static/dynamic split and
-           {!R.resolve} see the same flat rules. *)
-        let stmts = Cascade.Flatten.block p.Css.stylesheet in
-        (* properties a kept rule can override must stay in the cascade. *)
-        let dyn =
-          props_of_stmts SSet.empty
-            (List.filter
-               (function
-                 | Sheet.Rule r -> not (inlinable (Sheet.selector r))
-                 | _ -> true)
-               stmts)
-        in
-        let is_dyn d =
-          SSet.mem (String.lowercase_ascii (Decl.property_name d)) dyn
-        in
-        let inline_rules = ref [] in
-        let keep =
-          List.filter_map
-            (fun stmt ->
-              match stmt with
-              | Sheet.Rule r when inlinable (Sheet.selector r) -> (
-                  let sel = Sheet.selector r and ds = Sheet.declarations r in
-                  (match List.filter (fun d -> not (is_dyn d)) ds with
-                  | [] -> ()
-                  | inl ->
-                      inline_rules :=
-                        Sheet.Rule (Sheet.rule ~selector:sel inl)
-                        :: !inline_rules);
-                  match List.filter is_dyn ds with
-                  | [] -> None
-                  | res -> Some (Sheet.Rule (Sheet.rule ~selector:sel res)))
-              | other -> Some other)
-            stmts
-        in
-        let keep_css =
-          if keep = [] then "" else Css.to_string ~minify:true (Sheet.v keep)
-        in
-        (Sheet.v (List.rev !inline_rules), keep_css, List.length keep)
-    | Error _ -> (Sheet.empty, "", 0)
+  let roots = Soup.children soup |> Soup.elements |> Soup.to_list in
+  let { Cascade.Apply.styles; keep_css; kept } =
+    Apply.compute ~minimal ~css roots
   in
-  Soup.children soup |> Soup.elements |> Soup.to_list
-  |> List.iter (walk ~minimal inline_sheet []);
+  List.iter (fun (node, decls) -> style_node node decls) styles;
   (* the static rules now live on the elements; keep only the un-inlinable
      ones. *)
   Soup.select "style" soup |> Soup.iter Soup.delete;

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -1,0 +1,231 @@
+(* Project a stylesheet onto an element tree, producing the inline-style
+   declarations for each element plus the rules that have no inline form
+   (:hover, @media, @keyframes, ...). The cascade itself is {!Resolve}; this
+   adds the inline-specific policy. It is pure: it returns the declarations to
+   apply, it does not mutate the tree (the caller writes them onto each
+   node). *)
+
+module SSet = Set.Make (String)
+
+(* Selectors that can be written as an inline style (no state / condition). *)
+let inlinable (sel : Selector.t) =
+  let rec ok = function
+    | Selector.Universal _ | Selector.Element _ | Selector.Class _
+    | Selector.Id _ | Selector.Attribute _ | Selector.Root
+    | Selector.First_child | Selector.Last_child | Selector.Only_child
+    | Selector.Empty ->
+        true
+    | Selector.Compound ps
+    | Selector.List ps
+    | Selector.Is ps
+    | Selector.Where ps
+    | Selector.Not ps ->
+        List.for_all ok ps
+    | Selector.Combined (a, _, b) -> ok a && ok b
+    | _ -> false
+  in
+  ok sel
+
+(* Elements that never carry inline styles ([html] is stylable so :root custom
+   properties land on it). *)
+let no_style = [ "head"; "meta"; "title"; "base"; "link"; "style"; "script" ]
+
+(* CSS inherited properties (a conservative set: missing one only keeps a
+   redundant declaration; a differential test guards against dropping a needed
+   one). *)
+let inherited =
+  [
+    "color";
+    "font";
+    "font-family";
+    "font-size";
+    "font-weight";
+    "font-style";
+    "font-variant";
+    "font-stretch";
+    "font-feature-settings";
+    "line-height";
+    "letter-spacing";
+    "word-spacing";
+    "text-align";
+    "text-indent";
+    "text-transform";
+    "text-shadow";
+    "white-space";
+    "word-break";
+    "overflow-wrap";
+    "hyphens";
+    "tab-size";
+    "visibility";
+    "cursor";
+    "direction";
+    "list-style";
+    "list-style-type";
+    "list-style-position";
+    "list-style-image";
+    "quotes";
+    "caption-side";
+    "border-collapse";
+    "border-spacing";
+    "empty-cells";
+  ]
+
+let is_inherited p = List.mem (String.lowercase_ascii p) inherited
+
+let parse_inline s =
+  match Css.of_string ("a{" ^ s ^ "}") with
+  | Ok p -> (
+      match Stylesheet.rules p.Css.stylesheet with
+      | r :: _ -> Stylesheet.declarations r
+      | [] -> [])
+  | Error _ -> []
+
+let decl_value d =
+  let s =
+    Stylesheet.inline_style_of_declarations ~minify:true ~mode:Variables [ d ]
+  in
+  match String.index_opt s ':' with
+  | Some i -> String.sub s (i + 1) (String.length s - i - 1)
+  | None -> s
+
+(* Every property a kept (conditional / stateful) rule can set, recursing into
+   @media / @supports / @container / @layer blocks. *)
+let rec props_of_stmts acc stmts =
+  List.fold_left
+    (fun acc s ->
+      match s with
+      | Stylesheet.Rule r ->
+          List.fold_left
+            (fun a d ->
+              SSet.add (String.lowercase_ascii (Declaration.property_name d)) a)
+            acc
+            (Stylesheet.declarations r)
+      | Stylesheet.Media (_, b)
+      | Stylesheet.Supports (_, b)
+      | Stylesheet.Layer (_, b) ->
+          props_of_stmts acc b
+      | Stylesheet.Container (_, _, b) -> props_of_stmts acc b
+      | _ -> acc)
+    acc stmts
+
+type 'node assignment = 'node * Declaration.declaration list
+(** The inline-style declarations to write onto a node. *)
+
+type 'node result = {
+  styles : 'node assignment list;
+      (** Each element with the declarations to set on its [style] attribute. *)
+  keep_css : string;
+      (** The rules with no inline form, serialised as a [<style>] body. *)
+  kept : int;  (** Count of kept rules, for reporting. *)
+}
+
+module Make (Node : Resolve.NODE) = struct
+  module R = Resolve.Make (Node)
+
+  (* A node's style: the author cascade from {!R.resolve} with the element's own
+     inline style overlaid (inline beats a selector, but an author !important
+     beats a normal inline declaration). *)
+  let resolved sheet n =
+    let author = R.resolve sheet n in
+    match Node.attribute n "style" with
+    | None -> author
+    | Some s ->
+        let overlay map d =
+          let k = Declaration.property_name d in
+          match List.assoc_opt k map with
+          | Some cur
+            when Declaration.is_important cur
+                 && not (Declaration.is_important d) ->
+              map
+          | _ -> (k, d) :: List.remove_assoc k map
+        in
+        List.fold_left overlay
+          (List.map (fun d -> (Declaration.property_name d, d)) author)
+          (parse_inline s)
+        |> List.rev_map snd
+
+  (* [ctx] maps each inherited property to the value in force from the
+     ancestors, so [minimal] can drop a declaration that only restates it. *)
+  let rec walk ~minimal sheet ctx node acc =
+    let is_no_style =
+      match Node.name node with
+      | Some n -> List.mem (String.lowercase_ascii n) no_style
+      | None -> false
+    in
+    if is_no_style then
+      List.fold_left
+        (fun acc child -> walk ~minimal sheet ctx child acc)
+        acc (Node.children node)
+    else begin
+      let kept, ctx' =
+        List.fold_left
+          (fun (kept, ctx) d ->
+            let p = String.lowercase_ascii (Declaration.property_name d) in
+            if minimal && is_inherited p then
+              let v = decl_value d in
+              match List.assoc_opt p ctx with
+              | Some pv when pv = v -> (kept, ctx)
+              | _ -> (d :: kept, (p, v) :: List.remove_assoc p ctx)
+            else (d :: kept, ctx))
+          ([], ctx) (resolved sheet node)
+      in
+      let acc = (node, List.rev kept) :: acc in
+      List.fold_left
+        (fun acc child -> walk ~minimal sheet ctx' child acc)
+        acc (Node.children node)
+    end
+
+  let compute ?(minimal = false) ~css roots =
+    match Css.of_string css with
+    | Error _ -> { styles = []; keep_css = ""; kept = 0 }
+    | Ok p ->
+        (* Flatten nesting up front, so the static/dynamic split and
+           {!R.resolve} see the same flat rules. *)
+        let stmts = Flatten.block p.Css.stylesheet in
+        (* Properties a kept rule can override must stay in the cascade. *)
+        let dyn =
+          props_of_stmts SSet.empty
+            (List.filter
+               (function
+                 | Stylesheet.Rule r -> not (inlinable (Stylesheet.selector r))
+                 | _ -> true)
+               stmts)
+        in
+        let is_dyn d =
+          SSet.mem (String.lowercase_ascii (Declaration.property_name d)) dyn
+        in
+        let inline_rules = ref [] in
+        let keep =
+          List.filter_map
+            (fun stmt ->
+              match stmt with
+              | Stylesheet.Rule r when inlinable (Stylesheet.selector r) -> (
+                  let sel = Stylesheet.selector r
+                  and ds = Stylesheet.declarations r in
+                  (match List.filter (fun d -> not (is_dyn d)) ds with
+                  | [] -> ()
+                  | inl ->
+                      inline_rules :=
+                        Stylesheet.Rule (Stylesheet.rule ~selector:sel inl)
+                        :: !inline_rules);
+                  match List.filter is_dyn ds with
+                  | [] -> None
+                  | res ->
+                      Some (Stylesheet.Rule (Stylesheet.rule ~selector:sel res))
+                  )
+              | other -> Some other)
+            stmts
+        in
+        let keep_css =
+          if keep = [] then ""
+          else Css.to_string ~minify:true (Stylesheet.v keep)
+        in
+        let inline_sheet = Stylesheet.v (List.rev !inline_rules) in
+        let styles =
+          List.fold_left
+            (fun acc root -> walk ~minimal inline_sheet [] root acc)
+            [] roots
+          |> List.rev
+        in
+        { styles; keep_css; kept = List.length keep }
+end

--- a/lib/apply.mli
+++ b/lib/apply.mli
@@ -1,0 +1,27 @@
+(** Project a stylesheet onto an element tree: resolve the cascade for each
+    element and return the declarations to write into its [style] attribute,
+    along with the rules that have no inline form. The cascade itself is
+    {!Resolve}; this adds the inline-specific policy. Pure - it returns the
+    declarations to apply, the caller writes them onto the tree. *)
+
+type 'node assignment = 'node * Declaration.declaration list
+(** A node paired with the inline-style declarations to write onto it. *)
+
+type 'node result = {
+  styles : 'node assignment list;
+      (** Each element with the declarations to set on its [style] attribute. *)
+  keep_css : string;
+      (** The rules with no inline form, serialised as a minified [<style>]
+          body, or [""] when there are none. *)
+  kept : int;  (** Count of kept rules, for reporting. *)
+}
+
+module Make (Node : Resolve.NODE) : sig
+  val compute : ?minimal:bool -> css:string -> Node.t list -> Node.t result
+  (** [compute ?minimal ~css roots] resolves [css] against the element trees
+      rooted at [roots] and returns, for each element, the declarations to set
+      on its [style] attribute, the un-inlinable rules as a [<style>] body, and
+      the count of kept rules. [minimal] (default [false]) drops an inherited
+      declaration that only restates the value the element already inherits from
+      its ancestors. A [css] that does not parse yields an empty result. *)
+end

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -100,6 +100,31 @@ let test_resolve_cascade () =
     "sibling-combined rule applies" (Some "font-weight:700")
     (value "font-weight")
 
+(* {!Apply.Make} reuses the same {!Node} adapter: a static rule projects onto
+   the element, a rule with no inline form ([:hover]) stays in a <style>
+   block. *)
+let test_apply_compute () =
+  let module A = Apply.Make (Node) in
+  let result : tree Apply.result =
+    A.compute ~css:"#s2{font-weight:700}#s2:hover{color:#00f}" [ _section ]
+  in
+  let s2_decls =
+    List.find_map
+      (fun (n, decls) -> if Node.equal n s2 then Some decls else None)
+      result.styles
+    |> Option.value ~default:[]
+  in
+  Alcotest.(check bool)
+    "static rule projected onto s2" true
+    (List.exists
+       (fun d -> Declaration.property_name d = "font-weight")
+       s2_decls);
+  Alcotest.(check bool)
+    "dynamic property not projected" false
+    (List.exists (fun d -> Declaration.property_name d = "color") s2_decls);
+  Alcotest.(check int) "the :hover rule is kept in a <style>" 1 result.kept;
+  Alcotest.(check bool) "kept css is non-empty" true (result.keep_css <> "")
+
 let suite =
   ( "resolve",
     [
@@ -109,4 +134,6 @@ let suite =
         test_sibling_then_descendant;
       Alcotest.test_case "resolve applies the cascade" `Quick
         test_resolve_cascade;
+      Alcotest.test_case "apply projects a static rule, keeps a dynamic one"
+        `Quick test_apply_compute;
     ] )


### PR DESCRIPTION
The `cascade apply` inlining lived in `bin/cmd_apply.ml`: ~250 lines of cascade logic (selector-inlinability policy, the inherited-property table, the static/dynamic rule split, the projection walk) mixed with the lambdasoup glue, which contradicts keeping CSS/cascade logic in the library.

New `Cascade.Apply.Make(NODE)` (over the same `Resolve.NODE`) is **pure**: `compute ~minimal ~css roots` returns, per element, the declarations to write onto its `style` attribute, the un-inlinable rules as a `<style>` body, and the kept count. It mutates nothing.

`bin/cmd_apply.ml` is now just the lambdasoup `NODE` adapter, HTML parse / `<style>` extraction, the attribute writes and cmdliner. Verified behaviour-preserving: the differential test (headless Chrome `getComputedStyle`) renders identically on every fixture and on Bootstrap / Wikipedia (IDENTICAL), with the ocaml/tailwind diffs unchanged. Adds a library-level `Apply.compute` test reusing the `Resolve` mock tree.