### PR TITLE
variables: surface var() refs from an opaque custom-property value

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1222,10 +1222,22 @@ let resolve_theme ?theme ?theme_defaults stylesheet =
         collect_var_names stylesheet
         |> List.filter (fun n -> not (List.mem n resolved_names))
       in
+      (* Theme substitution only rewrites resolved [var()] references; it must
+         not delete custom-property *definitions*. Keep every declared
+         custom-prop name live so [Inline.vars]' dead-declaration pass leaves
+         unrelated definitions in place - e.g. an @supports polyfill's
+         [--tw-x:initial] that nothing in this stylesheet references. *)
+      let declared_names =
+        Hashtbl.fold
+          (fun n () acc -> n :: acc)
+          (declared_custom_prop_names stylesheet)
+          []
+      in
       let keep_vars =
         List.fold_left
           (fun acc n -> if List.mem n acc then acc else n :: acc)
-          keep_vars unresolved_keep
+          keep_vars
+          (unresolved_keep @ declared_names)
       in
       let source = theme_defaults_source defaults in
       match of_string ~strict:false source with

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2326,10 +2326,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
 
 (* CSS Variables L1 §3: a custom property's value can itself reference other
    custom properties. A [Typed] value embeds real [var] handles, so recurse via
-   the kind. A raw [Tokens] value carries refs as [var()] functions in the
-   stream; surfacing those here changes [resolve_theme]'s prune set, so it is a
-   separate change (a [var()] inside an opaque value is found via
-   [var_refs_in_value_string] where that path needs it). *)
+   the kind; a raw [Tokens] value carries refs as [var()] functions in the
+   stream, recovered structurally by {!vars_of_token_stream}. *)
 let vars_of_kind : type a. a kind -> a -> any_var list =
  fun kind value ->
   match kind with
@@ -2378,10 +2376,24 @@ let vars_of_kind : type a. a kind -> a -> any_var list =
   | Filter -> vars_of_filter value
   | Font_src -> []
 
+(* Names referenced via real [var()] functions in an opaque token stream. The
+   structural scan returns each name with its leading [--]; [Values.var_ref]
+   re-adds it, so strip the prefix before rebuilding the handle. *)
+let vars_of_token_stream (components : Component.t list) : any_var list =
+  List.rev_map
+    (fun name ->
+      let bare =
+        if String.length name >= 2 && name.[0] = '-' && name.[1] = '-' then
+          String.sub name 2 (String.length name - 2)
+        else name
+      in
+      V (Values.var_ref bare))
+    (var_refs_in_components [] components)
+
 let vars_of_custom_property_value : custom_property_value -> any_var list =
   function
   | Typed { kind; value } -> vars_of_kind kind value
-  | Tokens _ -> []
+  | Tokens components -> vars_of_token_stream components
 
 let rec extract_vars_of_declaration : declaration -> any_var list = function
   | Declaration

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -157,7 +157,15 @@ let test_vars_of_declarations () =
   Alcotest.(check bool)
     "standard property exposes the ref" true (has_black standard_ref);
   Alcotest.(check bool)
-    "custom Typed value exposes the ref" true (has_black custom_ref)
+    "custom Typed value exposes the ref" true (has_black custom_ref);
+  (* A custom property whose *opaque* token-stream value references another var
+     exposes it too: the value never went through a typed parser, so the
+     reference is recovered structurally from the component stream. *)
+  let tokens_ref =
+    vars_of_declarations [ of_string "--gradient-bg:var(--color-black)" ]
+  in
+  Alcotest.(check bool)
+    "custom Tokens value exposes the ref" true (has_black tokens_ref)
 
 (* Not a roundtrip test *)
 let test_any_var_name () =


### PR DESCRIPTION
`vars_of_declarations` now surfaces `var()` refs inside an opaque custom-property value (`--gradient-bg:var(--color-black)`), not just typed ones. `resolve_theme` seeds from these, so it also now keeps declared custom-prop definitions live, leaving its substitution pass to rewrite resolved refs without dropping an unrelated `@supports` polyfill.