### PR TITLE
diff: suppress cascade-neutral reorders in canonical mode

### DIFF
--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -353,6 +353,7 @@ let diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
   | Ok { stylesheet = expected_ast; _ }, Ok { stylesheet = actual_ast; _ } ->
       let structural_diff =
         tree_diff ~expected:expected_ast ~actual:actual_ast
+        |> D.suppress_neutral_reorders ~expected:expected_ast ~actual:actual_ast
       in
       if is_empty structural_diff then
         No_diff { canonical_byte_diff = Some (expected_canon, actual_canon) }

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2316,3 +2316,129 @@ let diff ~(expected : Css.t) ~(actual : Css.t) : t =
   in
 
   { rules = rule_changes; containers }
+
+(* ===== Canonical-mode reorder suppression =====
+
+   In canonical mode a reorder is reportable only when it can change a cascade
+   outcome. Both suppressions below are sound: each drops a report only when the
+   reorder provably cannot affect the cascade.
+
+   - @property registrations with unique names register independently, so their
+   relative order is irrelevant. Only a duplicate name (last-wins) makes order
+   observable. - A rule-position reorder is neutral when the moved rule shares
+   no cascade-conflicting property (shorthand / [all]-aware) with any statement
+   whose order relative to it flipped. Selector overlap is overestimated (any
+   shared or covered property counts as a conflict, and any flipped container or
+   ambiguous match counts as a conflict), so a real change is never hidden. *)
+
+let property_names_of stmts =
+  List.filter_map
+    (fun s ->
+      match Css.as_property s with
+      | Some (Css.Property_info { name; _ }) -> Some name
+      | None -> None)
+    stmts
+
+let stmts_have_duplicate_property_names stmts =
+  let names = property_names_of stmts in
+  List.length names <> List.length (List.sort_uniq String.compare names)
+
+let is_unique_property_reorder : container_diff -> bool = function
+  | Modified
+      {
+        info = { container_type = `Property; rules; _ };
+        actual_rules;
+        rule_changes;
+        _;
+      } ->
+      List.for_all
+        (function (Reordered _ : rule_diff) -> true | _ -> false)
+        rule_changes
+      && (not (stmts_have_duplicate_property_names rules))
+      && not (stmts_have_duplicate_property_names actual_rules)
+  | _ -> false
+
+let decls_cascade_conflict d1 d2 =
+  List.exists
+    (fun a ->
+      List.exists
+        (fun b ->
+          Css.declaration_name a = Css.declaration_name b
+          || Shorthand.declaration_covers a b
+          || Shorthand.declaration_covers b a)
+        d2)
+    d1
+
+(* [(key, decls option)] per top-level statement, in source order. [None] decls
+   marks a container or other opaque statement that we cannot see into. *)
+let keyed_statements (sheet : Css.t) =
+  Css.statements sheet
+  |> List.filter_map (fun st ->
+      match describe_statement st with
+      | None -> None
+      | Some key -> Some (key, Option.map (fun (_, d, _) -> d) (Css.as_rule st)))
+
+(* Index of [key] only when it occurs exactly once; absent or ambiguous keys
+   yield [None] so the caller falls back to "not neutral". *)
+let unique_index key items =
+  match List.filter (fun (k, _) -> k = key) items with
+  | [ _ ] -> List.find_index (fun (k, _) -> k = key) items
+  | _ -> None
+
+let rule_reorder_is_neutral ~expected ~actual ~selector =
+  let er = keyed_statements expected in
+  let ar = keyed_statements actual in
+  match (unique_index selector er, unique_index selector ar) with
+  | Some ie, Some ia -> (
+      match List.nth er ie with
+      | _, None -> false
+      | _, Some a_decls ->
+          List.for_all
+            (fun (key, _) ->
+              key = selector
+              ||
+              match (unique_index key er, unique_index key ar) with
+              | Some je, Some ja -> (
+                  (* order relative to the moved rule preserved: irrelevant *)
+                  je < ie = (ja < ia)
+                  ||
+                  (* flipped: neutral only against a non-conflicting rule *)
+                  match List.nth ar ja with
+                  | _, Some d -> not (decls_cascade_conflict a_decls d)
+                  | _, None -> false)
+              | _ -> false)
+            er)
+  | _ -> false
+
+let is_neutral_rule_reorder ~expected ~actual : rule_diff -> bool = function
+  | Reordered { old_declarations = None; selector; _ } ->
+      rule_reorder_is_neutral ~expected ~actual ~selector
+  | _ -> false
+
+let rec suppress_neutral_reorders ~expected ~actual (t : t) : t =
+  {
+    rules =
+      List.filter
+        (fun rd -> not (is_neutral_rule_reorder ~expected ~actual rd))
+        t.rules;
+    containers =
+      List.filter_map (suppress_container ~expected ~actual) t.containers;
+  }
+
+and suppress_container ~expected ~actual c =
+  if is_unique_property_reorder c then None
+  else
+    match c with
+    | Modified m ->
+        let inner =
+          suppress_neutral_reorders ~expected ~actual
+            { rules = m.rule_changes; containers = m.container_changes }
+        in
+        Some
+          (Modified
+             {
+               m with
+               rule_changes = inner.rules;
+               container_changes = inner.containers;
+             })
+    | other -> Some other

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -83,6 +83,16 @@ val diff : expected:Css.t -> actual:Css.t -> t
 (** [diff ~expected ~actual] computes structural differences between two CSS
     ASTs. *)
 
+val suppress_neutral_reorders : expected:Css.t -> actual:Css.t -> t -> t
+(** [suppress_neutral_reorders ~expected ~actual t] drops the reorder reports in
+    [t] that cannot change a cascade outcome: [@property] reorders among
+    uniquely-named registrations, and rule-position reorders where the moved
+    rule shares no cascade-conflicting property (shorthand / [all]-aware) with
+    any statement whose order relative to it flipped. Overlap is overestimated,
+    so a real difference is never suppressed. Intended for [`Canonical]
+    comparison, where source order matters only where it affects the cascade;
+    [`Tree] / [`String] keep exact structural fidelity. *)
+
 val pp : ?expected:string -> ?actual:string -> Buffer.t -> t -> unit
 (** [pp ?expected ?actual buf t] pretty-prints a tree diff with optional labels.
     Default labels are "Expected" and "Actual". *)

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -823,6 +823,46 @@ let diff_canonical_uses_outputs () =
         (contains_substring rendered "color:")
   | _ -> Alcotest.fail "expected canonical diff on normalized outputs"
 
+(* ===== canonical-mode reorder suppression ===== *)
+
+let eq_canonical a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b
+
+let canonical_suppresses_property_reorder () =
+  (* Unique @property names register independently: order is irrelevant. *)
+  let a =
+    {|@property --a{syntax:"*";inherits:false}@property --b{syntax:"*";inherits:false}.x{color:red}|}
+  in
+  let b =
+    {|@property --b{syntax:"*";inherits:false}@property --a{syntax:"*";inherits:false}.x{color:red}|}
+  in
+  Alcotest.(check bool)
+    "unique @property reorder is cascade-neutral" true (eq_canonical a b)
+
+let canonical_suppresses_disjoint_rule_reorder () =
+  (* Rules with disjoint property sets cannot conflict, so reordering them does
+     not change any cascade outcome. *)
+  Alcotest.(check bool)
+    "disjoint-property rule reorder is neutral" true
+    (eq_canonical ".a{position:absolute}.b{color:red}.c{margin:0}"
+       ".c{margin:0}.a{position:absolute}.b{color:red}")
+
+let canonical_keeps_conflicting_rule_reorder () =
+  (* Same property on overlapping rules: order is last-wins, so the reorder is a
+     real difference and must still be reported. *)
+  Alcotest.(check bool)
+    "same-property reorder is reported" false
+    (eq_canonical ".a{color:red}.b{color:blue}" ".b{color:blue}.a{color:red}");
+  (* Shorthand / longhand overlap is a conflict too. *)
+  Alcotest.(check bool)
+    "shorthand/longhand reorder is reported" false
+    (eq_canonical ".a{margin:0}.b{margin-top:5px}"
+       ".b{margin-top:5px}.a{margin:0}");
+  (* A move that crosses a conflicting middle rule is reported. *)
+  Alcotest.(check bool)
+    "reorder crossing a conflicting rule is reported" false
+    (eq_canonical ".a{color:red}.mid{color:green}.b{margin:0}"
+       ".mid{color:green}.b{margin:0}.a{color:red}")
+
 (* ===== as_tree_diff tests ===== *)
 
 let as_tree_diff_with_tree () =
@@ -1048,4 +1088,10 @@ let suite =
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "opt-in prune-unused-custom-props" `Quick
         equal_prune_unused_custom_props;
+      Alcotest.test_case "canonical suppresses unique @property reorder" `Quick
+        canonical_suppresses_property_reorder;
+      Alcotest.test_case "canonical suppresses disjoint rule reorder" `Quick
+        canonical_suppresses_disjoint_rule_reorder;
+      Alcotest.test_case "canonical keeps conflicting rule reorder" `Quick
+        canonical_keeps_conflicting_rule_reorder;
     ] )


### PR DESCRIPTION
Canonical comparison (the `--diff=semantic` CLI flag, `\`Canonical` in the library API) reported two kinds of reordering that cannot change a cascade outcome: a swap of uniquely-named `@property` registrations (each registers independently, so order is irrelevant) and a swap of rules with disjoint property sets (no shared property means no conflict). Both are now dropped in this mode only; `tree`/`string` keep exact structural fidelity.

Soundness: overlap is overestimated (shorthand/`all`-aware via `Shorthand.declaration_covers`; any flipped container or ambiguous selector match counts as a conflict), so a real difference is never suppressed. A same-property swap, a shorthand/longhand swap, a move crossing a conflicting rule, and a duplicate-name `@property` swap all still report.

(Note: the CLI flag is `--diff=semantic` for this mode; the library calls it `\`Canonical`. They are the same thing — a naming split worth unifying separately.)