### PR TITLE
cli: rename --diff=semantic to --diff=canonical

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ usable as a CI check.
 - `tree`: structural diff only; formatting-only differences collapse to
   "identical".
 - `string`: character-level comparison.
-- `semantic`: passes when the two inputs share cascade's canonical minified
+- `canonical`: passes when the two inputs share cascade's canonical minified
   form. This is not full CSS semantic equivalence: equivalent shorthand
   decompositions and cascade-affecting rule reorderings are not modelled.
 
@@ -139,7 +139,7 @@ usable as a CI check.
 ```bash
 cascade diff reference.css output.css
 cascade diff --diff=tree reference.css output.css
-cascade diff --diff=semantic reference.css output.css
+cascade diff --diff=canonical reference.css output.css
 NO_COLOR=1 cascade diff reference.css output.css
 ```
 
@@ -157,8 +157,8 @@ cascade --minify --inline-vars src/style.css > dist/style.min.css
 cascade src/style.css > /tmp/fmt.css
 cascade diff --diff=tree src/style.css /tmp/fmt.css
 
-# pre-commit: catch semantic-only changes
-cascade diff --diff=semantic origin/main:src/style.css src/style.css
+# pre-commit: catch changes beyond formatting
+cascade diff --diff=canonical origin/main:src/style.css src/style.css
 ```
 
 The exit code is 0 when the inputs are identical under the chosen mode and 1

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -39,7 +39,7 @@ let print_diff_report ~file1 ~file2 ~css1 ~css2 result =
   Buffer.add_char buf '\n';
   print_string (Buffer.contents buf)
 
-type semantic_opts = { lossless : bool; prune_unused_custom_props : bool }
+type canonical_opts = { lossless : bool; prune_unused_custom_props : bool }
 
 let compare_files file1 file2 style_renderer mode opts memtrace_path () =
   Cli_io.start_memtrace memtrace_path;
@@ -85,7 +85,8 @@ let file2_arg =
 let mode_arg =
   let doc =
     "Diff mode: 'auto' (smart detection), 'tree' (force structural diff), \
-     'string' (force string diff), or 'semantic' (canonical semantic compare)"
+     'string' (force string diff), or 'canonical' (compare optimized canonical \
+     minified serialization)"
   in
   let mode_conv =
     Arg.enum
@@ -93,29 +94,29 @@ let mode_arg =
         ("auto", Auto);
         ("tree", Tree);
         ("string", String);
-        ("semantic", Canonical);
+        ("canonical", Canonical);
       ]
   in
   Arg.(value & opt mode_conv Auto & info [ "diff" ] ~docv:"MODE" ~doc)
 
 let lossless_arg =
   let doc =
-    "Disable colour approximation in $(b,--diff=semantic) canonicalisation. \
+    "Disable colour approximation in $(b,--diff=canonical) canonicalisation. \
      Exact colour canonicalisation still runs, but static modern colour-space \
      and color-mix() values stay functional and channels keep their full \
      precision. Two stylesheets that only differ by colours folded within the \
      approximation budget then report as different rather than collapsing to \
-     equal. Has no effect outside $(b,--diff=semantic)."
+     equal. Has no effect outside $(b,--diff=canonical)."
   in
   Arg.(value & flag & info [ "lossless" ] ~doc)
 
 let prune_unused_custom_props_arg =
   let doc =
     "Drop custom-property bindings referenced by nothing on both sides before \
-     comparing in $(b,--diff=semantic), so two stylesheets that differ only by \
-     a dead binding compare equal. Makes the comparison blind to \
+     comparing in $(b,--diff=canonical), so two stylesheets that differ only \
+     by a dead binding compare equal. Makes the comparison blind to \
      dead-custom-property divergences (a render-no-op); enable only when that \
-     difference is immaterial. Has no effect outside $(b,--diff=semantic)."
+     difference is immaterial. Has no effect outside $(b,--diff=canonical)."
   in
   Arg.(value & flag & info [ "prune-unused-custom-props" ] ~doc)
 
@@ -131,14 +132,14 @@ let term =
   let style_renderer_with_env =
     Fmt_cli.style_renderer ~env:(Cmd.Env.info "CASCADE_COLOR") ()
   in
-  let semantic_opts =
+  let canonical_opts =
     const (fun lossless prune_unused_custom_props ->
         { lossless; prune_unused_custom_props })
     $ lossless_arg $ prune_unused_custom_props_arg
   in
   term_result
     (const compare_files $ file1_arg $ file2_arg $ style_renderer_with_env
-   $ mode_arg $ semantic_opts $ memtrace_arg $ Cli_log.term)
+   $ mode_arg $ canonical_opts $ memtrace_arg $ Cli_log.term)
 
 let man =
   [
@@ -165,13 +166,13 @@ let man =
       ( "--diff=string",
         "Force character-by-character string diff (faster, less intelligent)" );
     `I
-      ( "--diff=semantic",
+      ( "--diff=canonical",
         "Compare canonical minified CSS before reporting a diff" );
     `I
       ( "--lossless",
-        "Disable colour approximation under $(b,--diff=semantic): colour \
+        "Disable colour approximation under $(b,--diff=canonical): colour \
          channels keep their authored precision and static modern colour-space \
-         values stay functional. No effect outside semantic mode." );
+         values stay functional. No effect outside canonical mode." );
     `S Manpage.s_exit_status;
     `P "$(tname) exits with:";
     `I ("0", "if the CSS files are identical");

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -57,7 +57,7 @@ diffing).
   [124]
 
 
-The semantic diff mode compares canonical minified CSS and accepts
+The canonical diff mode compares canonical minified CSS and accepts
 equivalent spellings.
 
   $ cat > i.css <<EOF
@@ -66,7 +66,7 @@ equivalent spellings.
   $ cat > j.css <<EOF
   > .x { color: color-mix(in oklab, currentcolor 50%, #0000) }
   > EOF
-  $ cascade diff --diff=semantic i.css j.css
+  $ cascade diff --diff=canonical i.css j.css
   CSS files are identical
 
 


### PR DESCRIPTION
The CLI flag selected the library's `\`Canonical` mode but was spelled `--diff=semantic`. The library deliberately calls it `Canonical`, not semantic, because it compares optimized canonical serialization, not true semantic equivalence (its mli says so explicitly). Renamed the flag to match; `--diff=semantic` is now rejected (no alias, per request). Docs/README updated.