### PR TITLE
declaration: name the property in a bad-value parse error

### DIFF
--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1952,15 +1952,25 @@ let read_typed_property_declaration t start =
      declaration survives with the auto-closed shape. *)
   match prop_type with
   | Unknown_property name -> read_unknown_property_declaration t name
-  | _ ->
-      let decl = read_value prop_type t in
-      validate_no_extra_tokens t;
-      let is_important = read_importance t in
-      validate_no_extra_tokens t;
-      (match Cursor.peek_delim t with
-      | Some '!' -> Cursor.err_invalid t "duplicate !important"
-      | _ -> ());
-      if is_important then important decl else decl
+  | _ -> (
+      (* The typed value readers and [validate_no_extra_tokens] reject a
+         right-hand side without knowing which property they serve, so a
+         [Bad_value] surfaces with an empty property name ([bad value for :]).
+         Stamp the property back on so the warning names it ([bad value for
+         background-image:]). *)
+      let read () =
+        let decl = read_value prop_type t in
+        validate_no_extra_tokens t;
+        let is_important = read_importance t in
+        validate_no_extra_tokens t;
+        (match Cursor.peek_delim t with
+        | Some '!' -> Cursor.err_invalid t "duplicate !important"
+        | _ -> ());
+        if is_important then important decl else decl
+      in
+      try read ()
+      with Cursor.Parse_error e ->
+        Error.fail (Error.with_property (prop_name prop_type) e))
 
 (** Parse a regular property (name: value) *)
 let read_regular_property_declaration t : declaration =

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -106,6 +106,12 @@ let with_filename ?filename t =
   | None, _ | _, Some _ -> t
   | Some _, None -> { t with filename }
 
+let with_property property t =
+  match t.kind with
+  | Bad_value { property = ""; reason } ->
+      { t with kind = Bad_value { property; reason } }
+  | _ -> t
+
 let fail e = Stdlib.raise (Parse_error e)
 
 let with_context label f =

--- a/lib/error.mli
+++ b/lib/error.mli
@@ -86,6 +86,13 @@ val with_filename : ?filename:string -> t -> t
     already carry one. Used by entry points that know the source filename to
     annotate warnings collected by inner readers. *)
 
+val with_property : string -> t -> t
+(** [with_property property t] fills in the property name of a {!Bad_value}
+    error raised without one - the typed value readers reject a right-hand side
+    without knowing which property they serve, so the declaration parser stamps
+    it back on. A non-{!Bad_value} error, or one that already names a property,
+    is returned unchanged. *)
+
 val context : t -> Loc.Context.t
 (** [context t] is the structured error context. *)
 

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -33,6 +33,23 @@ let bad_value () =
     (Error.bad_value loc ~property:"color" ~reason:"not a color")
     "bad value for color: not a color at [12-13] (in property-value)"
 
+let with_property () =
+  (* A value reader raises [Bad_value] without a property name; the declaration
+     parser stamps it back on. *)
+  check "fills an empty property"
+    (Error.with_property "width"
+       (Error.bad_value loc ~property:"" ~reason:"bad"))
+    "bad value for width: bad at [12-13] (in property-value)";
+  (* An already-named property is left as-is. *)
+  check "keeps an existing property"
+    (Error.with_property "width"
+       (Error.bad_value loc ~property:"color" ~reason:"bad"))
+    "bad value for color: bad at [12-13] (in property-value)";
+  (* A non-[Bad_value] error is untouched. *)
+  check "leaves a non-bad-value error"
+    (Error.with_property "width" (Error.bad_selector loc "double dot"))
+    "bad selector: double dot at [12-13] (in selector)"
+
 let unknown_at_rule () =
   check "unknown at-rule"
     (Error.unknown_at_rule loc "weird")
@@ -62,6 +79,7 @@ let suite =
       Alcotest.test_case "unexpected token" `Quick unexpected_token;
       Alcotest.test_case "missing token" `Quick missing_token;
       Alcotest.test_case "bad selector" `Quick bad_selector;
+      Alcotest.test_case "with_property" `Quick with_property;
       Alcotest.test_case "bad value" `Quick bad_value;
       Alcotest.test_case "unknown at-rule" `Quick unknown_at_rule;
       Alcotest.test_case "unterminated" `Quick unterminated;


### PR DESCRIPTION
A typed value reader rejects a right-hand side without knowing which property it serves, so a dropped declaration surfaced as `bad value for :` (empty property). Now the declaration parser stamps the name back on via `Error.with_property`, so the warning reads `bad value for background-image: unexpected tokens after property value: ...`.

This is the policy-aligned half of the earlier "make --diff complete" thread: the dropped declaration stays out of the AST (no raw sidecar), and the existing warning channel - which `--diff` already surfaces - becomes a precise diagnostic instead of a vague one. Only fills an *empty* property; already-named errors and non-`Bad_value` errors are untouched.