### PR TITLE
css: resolve theme vars nested in a typed var() fallback

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -976,6 +976,40 @@ let bare_theme_name raw_name =
    structurally (see {!Variables.var_refs_in_value_string}). *)
 let var_names_in_theme_value = Variables.var_refs_in_value_string
 
+(* Every [var()] reference (with leading [--]) found by structurally scanning
+   each declaration's serialized value, typed declarations included.
+   [collect_var_names] only records a nested fallback var when it carries the
+   [Var_fallback] spelling; a var nested inside a *typed* fallback
+   ([transition-timing-function: var(--tw-ease, var(--default-...))]) is
+   invisible to it. Seeding theme resolution from this too lets such a nested
+   theme var resolve transitively instead of surviving as a nested [var()]. *)
+let structural_var_refs (stmts : Stylesheet.statement list) : string list =
+  let acc = ref [] in
+  let note d =
+    acc := List.rev_append (var_names_in_theme_value (declaration_value d)) !acc
+  in
+  let rec scan (stmt : Stylesheet.statement) =
+    match stmt with
+    | Stylesheet.Rule r ->
+        List.iter note r.declarations;
+        List.iter scan r.nested
+    | Stylesheet.Declarations decls -> List.iter note decls
+    | Stylesheet.Media (_, b)
+    | Stylesheet.Supports (_, b)
+    | Stylesheet.Container (_, _, b)
+    | Stylesheet.Layer (_, b)
+    | Stylesheet.Origin (_, b)
+    | Stylesheet.Scope (_, _, b)
+    | Stylesheet.Starting_style b
+    | Stylesheet.Moz_document (_, b)
+    | Stylesheet.When (_, b)
+    | Stylesheet.Else (_, b) ->
+        List.iter scan b
+    | _ -> ()
+  in
+  List.iter scan stmts;
+  !acc
+
 let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
   let resolved : (string, string) Hashtbl.t = Hashtbl.create 16 in
   let cyclic = ref [] in
@@ -1004,7 +1038,9 @@ let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
                 Hashtbl.replace resolved raw_name value)
   in
   (match theme with
-  | Option.Some _ -> List.iter dfs (collect_var_names stylesheet)
+  | Option.Some _ ->
+      List.iter dfs
+        (collect_var_names stylesheet @ structural_var_refs stylesheet)
   | Option.None -> ());
   Hashtbl.fold (fun k v acc -> (k, v) :: acc) resolved []
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6242,6 +6242,32 @@ let customprops1_unresolved_fallback () =
     ".x{color:var(--a,var(--b,#00f))}"
     (normalize_minified ".x { color: var(--a, var(--b, blue)) }")
 
+(* CSS Custom Properties L1: a theme var reachable only through another var()'s
+   *typed* fallback ([transition-timing-function: var(--tw-ease, var(--theme))])
+   still resolves transitively. Theme resolution is seeded by a structural value
+   scan, so the nested var is found even though the typed AST spells that
+   fallback as a value rather than a [Var_fallback]; the outer runtime var stays
+   live. *)
+let customprops1_transitive_fallback () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let resolve = function
+    | "default-transition-timing-function" -> Some "ease"
+    | _ -> None
+  in
+  let theme = Css.Pp.String_set.of_list [ "tw-ease" ] in
+  Alcotest.(check string)
+    "nested theme var in a typed fallback inlines, runtime var stays live"
+    ".t{transition-timing-function:var(--tw-ease,ease)}"
+    (parse
+       ".t { transition-timing-function: var(--tw-ease, \
+        var(--default-transition-timing-function)) }"
+    |> Css.resolve_theme ~theme ~theme_defaults:resolve
+    |> Css.to_string ~minify:true)
+
 (* CSS Custom Properties L1 section 2: inlining a [var()] inside a [calc()]
    resolves the variable, and the resulting all-constant calc reduces under
    minify. *)
@@ -7028,6 +7054,9 @@ let additional_tests =
     ( "spec custom-properties 1 fallback preserved when unknown",
       `Quick,
       customprops1_unresolved_fallback );
+    ( "spec custom-properties 1 nested theme var in typed fallback resolves",
+      `Quick,
+      customprops1_transitive_fallback );
     ( "spec custom-properties 1 inlined var in calc simplifies",
       `Quick,
       customprops1_calc_inline );


### PR DESCRIPTION
`resolve_theme` seeds theme-default resolution from `collect_var_names`, which only records a *nested* fallback var when it carries the `Var_fallback` spelling. A typed property parses `var(--a, var(--theme))` with the inner var as a value-shaped fallback, so the nested theme var was invisible to the seed → never resolved → it survived as a nested `var()` instead of inlining.

Concretely, `transition-timing-function: var(--tw-ease, var(--default-transition-timing-function))` with `theme_defaults` resolving the inner var to `ease` produced `var(--tw-ease, var(--default-transition-timing-function))` instead of `var(--tw-ease, ease)`. This is the resolve_theme transitive-inlining regression the tw upstream harness relies on (tw output itself is byte-identical to Tailwind's CLI).

Fix: also seed from a structural value scan (`var_refs_in_value_string` over every declaration), which finds nested vars regardless of typed representation. Verified: an *unresolvable* nested fallback (`var(--a, var(--b, #00f))`) is still preserved verbatim. Regression test added; full suite green.