### PR TITLE
values: keep color-mix component order when color and percentage are both var()

### DIFF
--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6609,9 +6609,22 @@ let rec read_color_mix t : color =
   Mix { in_space; hue; color1; percent1; color2; percent2 }
 
 and read_color_mix_component t =
-  match Cursor.option read_color_mix_prefix_percentage t with
+  (* CSS Color 5 §3: a component is [<color> && <percentage>?] - the two may
+     appear in either order. Prefer the [<color> <percentage>?] reading so an
+     ambiguous leading [var()] is taken as the colour ([var(--c) var(--p)] keeps
+     its source order rather than being re-emitted percentage-first). Fall back
+     to [<percentage> <color>] only when the colour-first reading leaves the
+     component unconsumed - i.e. the leading token was really the percentage and
+     a concrete colour follows ([var(--p) red], [30% red]). *)
+  let color_first t =
+    let component = read_color_mix_suffix_percentage t in
+    Cursor.ws t;
+    if Cursor.peek_comma t || Cursor.is_done t then component
+    else Cursor.err_expected t "color-mix component end"
+  in
+  match Cursor.option color_first t with
   | Some component -> component
-  | None -> read_color_mix_suffix_percentage t
+  | None -> read_color_mix_prefix_percentage t
 
 and read_color_mix_prefix_percentage t =
   match read_optional_percentage t with

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -943,6 +943,17 @@ let spec_values_l45_math_color () =
   check_color ~expected:"color-mix(in srgb,var(--c) calc(var(--o)*100%),blue)"
     ~optimized:"color-mix(in srgb,var(--c) calc(var(--o)*100%),#00f)"
     "color-mix(in srgb, var(--c) calc(var(--o) * 100%), blue)";
+  (* Both the colour and the percentage are [var()]: the leading var is the
+     colour, so source order is preserved (regression: the two were swapped,
+     landing the alpha var in the colour slot). *)
+  check_color ~expected:"color-mix(in oklab,var(--a) var(--b),blue)"
+    ~optimized:"color-mix(in oklab,var(--a) var(--b),#00f)"
+    "color-mix(in oklab, var(--a) var(--b), blue)";
+  (* A [var()] followed by a concrete colour can only be the percentage, so it
+     is read percentage-first and re-emitted colour-first. *)
+  check_color ~expected:"color-mix(in oklab,red var(--p),blue)"
+    ~optimized:"color-mix(in oklab,red var(--p),#00f)"
+    "color-mix(in oklab, var(--p) red, blue)";
   check_color ~expected:"hsl(0 50% 50%)" ~optimized:"#bf4040"
     "hsl(none 50% 50%)";
   check_color ~expected:"rgb(from var(--c) r g b/.5)"


### PR DESCRIPTION
A typed `color-mix()` whose first component is two `var()`s — `color-mix(in oklab, var(--color-red-500) var(--tw-drop-shadow-alpha), transparent)` — was re-emitted with the two **swapped** (`var(--tw-drop-shadow-alpha) var(--color-red-500)`), landing the alpha percentage var in the color slot. Semantically broken, not cosmetic.

Cause: `read_color_mix_component` tried the `<percentage> <color>` reading first, and `read_optional_percentage` accepts a `var()`, so the leading var was consumed as the percentage and the second as the color, then re-serialized color-first.

Fix: prefer the `<color> <percentage>?` reading, so an ambiguous leading `var()` is the color and source order is preserved; fall back to percentage-first only when the color-first reading leaves the component unconsumed (`var(--p) red`, `30% red` — where the leading token can only be the percentage).

Surfaced via `resolve_theme` (`normalize_custom_value` does a typed color round-trip when the inline branch runs, matching the "only when a sibling var is hoisted" bisect), but the bug was in the parser, so this fixes it everywhere. Regression tests added; full suite green.