### PR TITLE
optimize: canonicalize @property registration order

### DIFF
--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -1142,6 +1142,48 @@ let rec segment_hoist counts = function
       let seg, after = span [] stmts in
       hoist_custom_prop_segment counts seg @ segment_hoist counts after
 
+(* CSS Properties & Values API: a [@property] registration takes effect
+   document-wide regardless of source order, so a run of registrations with
+   unique names is order-independent. Sort each such run by name into a
+   canonical order, so two stylesheets differing only by registration order
+   optimise to the same output. A run that repeats a name is left untouched: a
+   duplicate registration is last-wins, so its order is significant. *)
+let at_property_name = function Property r -> Some r.name | _ -> None
+
+let sort_property_runs (stmts : statement list) : statement list =
+  if not (List.exists (fun s -> at_property_name s <> None) stmts) then stmts
+  else
+    let changed = ref false in
+    let rec go = function
+      | [] -> []
+      | Property _ :: _ as l ->
+          let rec span acc = function
+            | (Property _ as p) :: tl -> span (p :: acc) tl
+            | tl -> (List.rev acc, tl)
+          in
+          let run, rest = span [] l in
+          let names = List.filter_map at_property_name run in
+          let run =
+            if
+              List.length names
+              = List.length (List.sort_uniq String.compare names)
+              && names <> List.sort String.compare names
+            then (
+              changed := true;
+              List.stable_sort
+                (fun a b ->
+                  String.compare
+                    (Option.value ~default:"" (at_property_name a))
+                    (Option.value ~default:"" (at_property_name b)))
+                run)
+            else run
+          in
+          run @ go rest
+      | s :: rest -> s :: go rest
+    in
+    let result = go stmts in
+    if !changed then result else stmts
+
 let rec recurse_custom_prop_blocks counts (stmt : statement) : statement =
   let go b = canonicalize_custom_prop_blocks counts b in
   match stmt with
@@ -1184,7 +1226,8 @@ and canonicalize_custom_prop_blocks counts (stmts : statement list) :
     statement list =
   let recursed = list_map_preserve (recurse_custom_prop_blocks counts) stmts in
   let hoisted = segment_hoist counts recursed in
-  if phys_equal_list hoisted recursed then recursed else hoisted
+  let sorted = sort_property_runs hoisted in
+  if phys_equal_list sorted recursed then recursed else sorted
 
 let canonicalize_custom_prop_position (stmts : statement list) : statement list
     =

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -402,6 +402,27 @@ let normalize_expected ~category ~id expected =
       fixture ~category ~id
         ~upstream:"a{mask:linear-gradient(#000,transparent)}"
         ~cascade:"a{mask:linear-gradient(#000,#0000)}" upstream
+  | "shorthands", "0061" ->
+      (* A [@property] registration takes effect document-wide regardless of
+         source order, so a run of uniquely-named registrations has no
+         observable source-order effect. The stable minified oracle sorts them
+         by name, the same canonicalization as the selector-branch sort in
+         duplicates/0009. *)
+      fixture ~category ~id
+        ~upstream:
+          {|@property --pt{syntax:"<length>";inherits:false;initial-value:0px}@property --pr{syntax:"<length>";inherits:false;initial-value:0px}@property --pb{syntax:"<length>";inherits:false;initial-value:0px}@property --pl{syntax:"<length>";inherits:false;initial-value:0px}a{padding:var(--pt) var(--pr) var(--pb) var(--pl)}|}
+        ~cascade:
+          {|@property --pb{syntax:"<length>";inherits:false;initial-value:0px}@property --pl{syntax:"<length>";inherits:false;initial-value:0px}@property --pr{syntax:"<length>";inherits:false;initial-value:0px}@property --pt{syntax:"<length>";inherits:false;initial-value:0px}a{padding:var(--pt) var(--pr) var(--pb) var(--pl)}|}
+        upstream
+  | "shorthands", "0062" ->
+      (* Same unique-name [@property] canonical-order policy as
+         shorthands/0061. *)
+      fixture ~category ~id
+        ~upstream:
+          {|@property --bw{syntax:"<length>";inherits:false;initial-value:0px}@property --bs{syntax:"<custom-ident>";inherits:false;initial-value:none}@property --bc{syntax:"<color>";inherits:false;initial-value:#000}a{border:var(--bw) var(--bs) var(--bc)}|}
+        ~cascade:
+          {|@property --bc{syntax:"<color>";inherits:false;initial-value:#000}@property --bs{syntax:"<custom-ident>";inherits:false;initial-value:none}@property --bw{syntax:"<length>";inherits:false;initial-value:0px}a{border:var(--bw) var(--bs) var(--bc)}|}
+        upstream
   | "shorthands", "0065" ->
       (* The fixture runs under stylesheet scope: [--custom] has no matching
          @position-try rule anywhere in the fixture, so the fallback list can

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -3878,8 +3878,26 @@ let c734_revert_origin_candidates () =
     [ "ua-important"; "user-important" ]
     (List.map origin_value important_author_rollback)
 
+(* CSS Properties & Values API: a [@property] registration takes effect
+   document-wide regardless of source order, so a run of registrations with
+   unique names is order-independent. Optimize sorts each such run into a
+   canonical by-name order; a run repeating a name (last-wins) is left to the
+   deduplication pass. *)
+let test_property_canonical_order () =
+  Alcotest.(check string)
+    "unique @property run sorts by name"
+    {|@property --a{syntax:"*";inherits:false}@property --z{syntax:"*";inherits:false}|}
+    (minify_str
+       {|@property --z{syntax:"*";inherits:false}@property --a{syntax:"*";inherits:false}|});
+  Alcotest.(check string)
+    "@property runs sort within rule-bounded segments"
+    {|@property --a{syntax:"*";inherits:false}@property --m{syntax:"*";inherits:false}.x{color:red}|}
+    (minify_str
+       {|@property --m{syntax:"*";inherits:false}@property --a{syntax:"*";inherits:false}.x{color:red}|})
+
 let selector_merging_tests =
   [
+    ("property canonical order", `Quick, test_property_canonical_order);
     ("merge consecutive identical", `Quick, test_merge_consecutive_identical);
     ( "combine identical oklab(none) rules",
       `Quick,


### PR DESCRIPTION
Re-do of #139 the right way. A `@property` registration takes effect document-wide regardless of source order, so a run of uniquely-named registrations is order-independent. The optimizer now sorts each such run by name — **normalization in `optimize`** (per the README), so canonical comparison (`Css_compare ~mode:`Canonical`) treats a `@property` reorder as a no-op without any diff-layer pass. Duplicate-name runs (last-wins) are left to the dedup pass.

Two keithamus css-minify-tests fixtures (`shorthands/0061`, `0062`) pin source `@property` order. Unlike #139, the **vendored traces are untouched** — they get a harness `fixture` override that records both the upstream and cascade values (asserting the upstream still matches, so it stays in sync on re-vendor). This is the exact mechanism `duplicates/0009` already uses for the analogous selector-branch canonical sort.

Full suite green; css-minify-tests pass with the vendored fixtures pristine.