### PR TITLE
css: keep unrelated @property registrations through resolve_theme

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1278,7 +1278,13 @@ let resolve_theme ?theme ?theme_defaults stylesheet =
       let source = theme_defaults_source defaults in
       match of_string ~strict:false source with
       | Ok { stylesheet = root_stmts; _ } ->
-          inline_vars ~keep_vars (root_stmts @ stylesheet)
+          (* Substitute the resolved theme vars but do NOT run the closed-world
+             [statements_for_inline] cleanup: this is a partial inline, so it
+             must preserve unrelated [@property] registrations and [@layer]
+             structure (the cleanup strips every [@property] and flattens every
+             [@layer], which would drop author registrations like an unrelated
+             [@property --tw-foo]). *)
+          Inline.vars ~keep_vars (root_stmts @ stylesheet)
       | Error _ -> stylesheet
   in
   (* Emit root-scope definitions for theme vars referenced but undefined,

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -981,9 +981,6 @@ let filter_live_custom_decls ~keep ~live_set ~at_path ~selector =
             Some (normalize_custom_value d)
           else None)
 
-let property_is_live ~keep ~live_set ~at_path name =
-  custom_is_live ~keep ~live_set ~at_path ~selector:universal_selector name
-
 let strip_dead_rule ~filter_decls ~map_stmts ~parents ~at_path
     (rule : Stylesheet.rule) : Stylesheet.statement option =
   let eff = effective_selector ~parents rule.selector in
@@ -1016,9 +1013,13 @@ let strip_dead ~keep ~live_set stmts =
     match stmt with
     | Rule rule ->
         strip_dead_rule ~filter_decls ~map_stmts ~parents ~at_path rule
-    | Property rule ->
-        if property_is_live ~keep ~live_set ~at_path rule.name then Some stmt
-        else None
+    | Property _ ->
+        (* A [@property] registration is a global, author-declared binding, not
+           dead code in the cascade sense. The closed-world inline drops the
+           ones for fully-substituted vars via [statements_for_inline]; the
+           dead-declaration pass must not drop them here, or a partial inline
+           (resolve_theme) would lose unrelated registrations. *)
+        Some stmt
     | Declarations decls ->
         strip_dead_declarations ~filter_decls ~parents ~at_path decls
     | Page (sel, decls) ->

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6268,6 +6268,27 @@ let customprops1_transitive_fallback () =
     |> Css.resolve_theme ~theme ~theme_defaults:resolve
     |> Css.to_string ~minify:true)
 
+(* CSS Properties & Values API: resolve_theme is a partial inline - it
+   substitutes resolved theme vars but must leave unrelated [@property]
+   registrations untouched. Inlining one theme token previously dropped every
+   [@property] in the stylesheet. *)
+let customprops1_resolve_keeps_property () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  Alcotest.(check string)
+    "inlining a theme var keeps an unrelated @property registration"
+    "@property --tw-foo{syntax:\"*\";inherits:false}.x{width:24px}"
+    (parse
+       "@property --tw-foo{syntax:\"*\";inherits:false}.x{width:var(--blur-xl)}"
+    |> Css.resolve_theme ~theme:Css.Pp.String_set.empty
+         ~theme_defaults:(function
+         | "blur-xl" -> Some "24px"
+         | _ -> None)
+    |> Css.to_string ~minify:true)
+
 (* CSS Custom Properties L1 section 2: inlining a [var()] inside a [calc()]
    resolves the variable, and the resulting all-constant calc reduces under
    minify. *)
@@ -7057,6 +7078,9 @@ let additional_tests =
     ( "spec custom-properties 1 nested theme var in typed fallback resolves",
       `Quick,
       customprops1_transitive_fallback );
+    ( "spec custom-properties 1 resolve keeps unrelated @property",
+      `Quick,
+      customprops1_resolve_keeps_property );
     ( "spec custom-properties 1 inlined var in calc simplifies",
       `Quick,
       customprops1_calc_inline );


### PR DESCRIPTION
resolve_theme deleted every @property as soon as it inlined one theme token.

A partial inline hit two closed-world paths that drop @property: Css.inline_vars cleanup, and strip_dead pruning any @property whose name is unreferenced. Both are wrong here since most vars stay live.

Fix: resolve_theme uses Inline.vars ~keep_vars directly, and strip_dead keeps @property (a registration stays live even with no references). Css.inline_vars still strips @property for fully-substituted vars.