### PR TITLE
resolve: specificity of a selector list is its matching branch

### DIFF
--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -127,6 +127,23 @@ module Make (N : NODE) = struct
         List.filter (matches left) (preceding_siblings a)
     | _ -> []
 
+  (* A selector list has no single specificity: a rule [s1, s2 {...}] cascades
+     as if duplicated per branch, so the specificity that applies to [node] is
+     that of the highest-specificity branch matching [node], not the whole
+     list. *)
+  let matched_specificity sel node =
+    match Selector.as_list sel with
+    | Some branches -> (
+        match List.filter (fun b -> matches b node) branches with
+        | [] -> Selector.specificity sel
+        | b :: rest ->
+            List.fold_left
+              (fun acc b ->
+                let s = Selector.specificity b in
+                if compare s acc > 0 then s else acc)
+              (Selector.specificity b) rest)
+    | None -> Selector.specificity sel
+
   let resolve sheet node =
     let upsert acc d =
       let k = Declaration.property_name d in
@@ -138,7 +155,7 @@ module Make (N : NODE) = struct
       |> List.mapi (fun i r ->
           let sel = Stylesheet.selector r in
           if matches sel node then
-            Some (Selector.specificity sel, i, Stylesheet.declarations r)
+            Some (matched_specificity sel node, i, Stylesheet.declarations r)
           else None)
       |> List.filter_map Fun.id
       |> List.stable_sort (fun (s1, i1, _) (s2, i2, _) ->

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -100,6 +100,28 @@ let test_resolve_cascade () =
     "sibling-combined rule applies" (Some "font-weight:700")
     (value "font-weight")
 
+(* A selector list has no single specificity. Only the [.x] branch (one class)
+   matches [node]; the unmatched [#y] branch must not lend its id specificity to
+   the rule, so the later two-class rule wins. The old code keyed the rule at
+   the whole list's max specificity (the id), wrongly beating [.x.w]. *)
+let test_resolve_list_specificity () =
+  let node = elt ~classes:[ "x"; "w" ] "div" [] in
+  let sheet =
+    match Css.of_string ".x,#y{color:red}.x.w{color:blue}" with
+    | Ok { stylesheet; _ } -> stylesheet
+    | Error e -> Alcotest.failf "parse: %s" (Error.to_string e)
+  in
+  let color =
+    R.resolve sheet node
+    |> List.find_map (fun d ->
+        if Declaration.property_name d = "color" then
+          Some (Declaration.string_of_declaration ~minify:true d)
+        else None)
+  in
+  Alcotest.(check (option string))
+    "two-class rule beats a list matched only on its one-class branch"
+    (Some "color:blue") color
+
 (* {!Apply.Make} reuses the same {!Node} adapter: a static rule projects onto
    the element, a rule with no inline form ([:hover]) stays in a <style>
    block. *)
@@ -134,6 +156,8 @@ let suite =
         test_sibling_then_descendant;
       Alcotest.test_case "resolve applies the cascade" `Quick
         test_resolve_cascade;
+      Alcotest.test_case "selector-list specificity is the matching branch"
+        `Quick test_resolve_list_specificity;
       Alcotest.test_case "apply projects a static rule, keeps a dynamic one"
         `Quick test_apply_compute;
     ] )


### PR DESCRIPTION
`Resolve` used the whole-list specificity for a rule whose selector is a list; now it uses the highest-specificity branch that matches the element.

A list like `.a, #b` cascades as if duplicated per branch, so the specificity applying to an element is its highest-specificity matching branch, not the whole list's maximum. The old behaviour let an unmatched id branch outrank a later, more specific rule for an element that only matched the class branch.