### PR TITLE
css: inline resolvable theme defaults at their reference site

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1220,65 +1220,64 @@ let emit_transitive_theme_refs ~theme_defaults stylesheet =
         let result, merged = merge_into_root_scope injected_decls stylesheet in
         if merged then result else injected @ stylesheet
 
-(* Inline the theme defaults the resolver could resolve, leaving every other
-   [var()] reference live. Only resolved names get substituted: [Inline.vars]
-   alone would also collapse [var(--x, fallback)] for names the resolver
-   returned [None] on (its built-in fallback arm fires when no declaration is
-   visible). We inject a [:root] rule for the resolved names and extend
-   [keep_vars] with every name we did *not* resolve, so unresolved sites keep
-   their declarations live and fall through to the original-Func branch. Every
-   declared custom-prop name is kept too, so the dead-declaration pass leaves
-   unrelated definitions (e.g. an @supports polyfill's [--tw-x:initial]) in
-   place. *)
-let inline_theme_defaults ?theme ?theme_defaults ~keep_set stylesheet =
-  let keep_vars = Pp.String_set.elements keep_set in
-  let defaults =
-    collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet
+let keep_vars_for_theme_inline stylesheet ~keep_vars defaults =
+  (* Only the names [theme_defaults] resolved get their [var()] references
+     substituted. Unresolved references must stay live, including fallback
+     forms; custom-property definitions must also stay live so unrelated
+     registrations and polyfills are preserved. *)
+  let resolved_names =
+    List.map (fun (name, _) -> bare_theme_name name) defaults
   in
-  if defaults = [] then stylesheet
-  else
-    let resolved_names = List.map fst defaults in
-    let unresolved_keep =
-      collect_var_names stylesheet
-      |> List.filter (fun n -> not (List.mem n resolved_names))
-    in
-    let declared_names =
-      Hashtbl.fold
-        (fun n () acc -> n :: acc)
-        (declared_custom_prop_names stylesheet)
-        []
-    in
-    let keep_vars =
-      List.fold_left
-        (fun acc n -> if List.mem n acc then acc else n :: acc)
-        keep_vars
-        (unresolved_keep @ declared_names)
-    in
-    let source = theme_defaults_source defaults in
-    match of_string ~strict:false source with
-    | Ok { stylesheet = root_stmts; _ } ->
-        (* Do NOT run the closed-world [statements_for_inline] cleanup: this is
-           a partial inline, so it must preserve unrelated [@property]
-           registrations and [@layer] structure (the cleanup strips every
-           [@property] and flattens every [@layer], dropping author
-           registrations like an unrelated [@property --tw-foo]). *)
-        Inline.vars ~keep_vars (root_stmts @ stylesheet)
-    | Error _ -> stylesheet
+  let unresolved_keep =
+    collect_var_names stylesheet
+    |> List.filter (fun n -> not (List.mem (bare_theme_name n) resolved_names))
+  in
+  let declared_names =
+    Hashtbl.fold
+      (fun n () acc -> n :: acc)
+      (declared_custom_prop_names stylesheet)
+      []
+    |> List.filter (fun n -> not (List.mem n resolved_names))
+  in
+  List.fold_left
+    (fun acc n -> if List.mem n acc then acc else n :: acc)
+    keep_vars
+    (unresolved_keep @ declared_names)
+
+let inline_theme_defaults stylesheet ~keep_vars defaults =
+  let keep_vars = keep_vars_for_theme_inline stylesheet ~keep_vars defaults in
+  match of_string ~strict:false (theme_defaults_source defaults) with
+  | Ok { stylesheet = root_stmts; _ } ->
+      (* This is a partial inline. Do not run [statements_for_inline], which
+         would strip unrelated [@property] registrations and flatten layers. *)
+      Inline.vars ~inline_kept_values:true ~keep_vars (root_stmts @ stylesheet)
+  | Error _ -> stylesheet
+
+let keep_set_of_theme (theme : Pp.String_set.t option) =
+  match theme with None -> Pp.String_set.empty | Some set -> set
 
 (* Theme resolution as an explicit AST step. [theme] names the variables whose
    [var()] references should survive (handed to [Inline.vars]' keep-set) and
    filters [Theme_guarded] declarations to keep only those whose [var_name] is
    in the set. [theme_defaults] supplies external defaults for the other
-   variables; [inline_theme_defaults] resolves and inlines them, and
-   [emit_transitive_theme_refs] then injects root definitions for references the
-   AST collector could not see. *)
+   variables: each [var(--name)] reference whose [name] isn't in [theme] is
+   collected, the resolver is asked for a default, and any returned value is
+   injected as a [:root { --name: <default> }] declaration so the subsequent
+   [Inline.vars] pass substitutes the reference in place. Names the resolver
+   returns [None] for stay as live [var()] sites. *)
 let resolve_theme ?theme ?theme_defaults stylesheet =
   let stylesheet = resolve_theme_guards_in_stmts ~theme stylesheet in
-  let keep_set =
-    match theme with None -> Pp.String_set.empty | Some set -> set
+  let keep_set = keep_set_of_theme theme in
+  let defaults =
+    collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet
   in
   let stylesheet =
-    inline_theme_defaults ?theme ?theme_defaults ~keep_set stylesheet
+    match defaults with
+    | [] -> stylesheet
+    | defaults ->
+        inline_theme_defaults stylesheet
+          ~keep_vars:(Pp.String_set.elements keep_set)
+          defaults
   in
   (* Emit root-scope definitions for theme vars referenced but undefined,
      including references the AST collector above cannot see inside opaque

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -482,8 +482,30 @@ let substitute_non_custom ~kept visible ctx decl =
     | Components components ->
         apply_substituted_components ctx decl ~original_components components
 
-let substitute_declaration ~kept visible ctx decl =
+(* A kept custom property's definition survives (its [var()] references stay
+   live), so inline any resolvable, non-kept [var()] inside its own value rather
+   than leaving it to leak a [:root] binding. A non-kept custom property is
+   dropped once its references inline, so keeping it verbatim costs nothing. *)
+let substitute_custom ~kept visible decl =
+  match custom_value_components decl with
+  | None -> Some decl
+  | Some original_components -> (
+      match
+        substitute_components ~kept visible ~visited:[] original_components
+      with
+      | Cycle -> Some decl
+      | Components components -> (
+          if components = original_components then Some decl
+          else
+            match declaration_with_components decl components with
+            | Some decl' -> Some decl'
+            | None -> Some decl))
+
+let substitute_declaration ~inline_kept_values ~kept visible ctx decl =
   match custom_name decl with
+  | Some name when List.mem name kept || List.mem ("--" ^ name) kept ->
+      if inline_kept_values then substitute_custom ~kept visible decl
+      else Some decl
   | Some _ -> Some decl
   | None -> substitute_non_custom ~kept visible ctx decl
 
@@ -568,10 +590,12 @@ let selector_for_parents = function [] -> universal_selector | p :: _ -> p
 let universal_visible_customs ~scopes ~at_path =
   visible_customs ~scopes ~at_path ~selector:universal_selector
 
-let eval_decls ~kept ~scopes ~at_path selector decls =
+let eval_decls ~inline_kept_values ~kept ~scopes ~at_path selector decls =
   let visible = visible_customs ~scopes ~at_path ~selector in
   let ctx = context_for ~kept visible in
-  List.filter_map (substitute_declaration ~kept visible ctx) decls
+  List.filter_map
+    (substitute_declaration ~inline_kept_values ~kept visible ctx)
+    decls
 
 (* @page, @keyframes, and @position-try declarations apply to elements whose
    effective selector is universal at this at-path. Customs declared on [:root],
@@ -597,14 +621,17 @@ let substitute_page_with_margins ~scopes ~at_path sel descriptors margins =
   Page_with_margins
     (sel, List.map eval_page descriptors, List.map update_margin margins)
 
-let rec substitute ~kept ~scopes ~parents ~at_path stmts =
-  List.map (substitute_stmt ~kept ~scopes ~parents ~at_path) stmts
+let rec substitute ~inline_kept_values ~kept ~scopes ~parents ~at_path stmts =
+  List.map
+    (substitute_stmt ~inline_kept_values ~kept ~scopes ~parents ~at_path)
+    stmts
 
-and substitute_stmt ~kept ~scopes ~parents ~at_path stmt =
+and substitute_stmt ~inline_kept_values ~kept ~scopes ~parents ~at_path stmt =
   match at_wrapper stmt with
   | Some (node, body, rebuild) ->
       rebuild
-        (substitute ~kept ~scopes ~parents ~at_path:(at_path @ [ node ]) body)
+        (substitute ~inline_kept_values ~kept ~scopes ~parents
+           ~at_path:(at_path @ [ node ]) body)
   | None -> (
       match stmt with
       | Rule rule ->
@@ -613,14 +640,15 @@ and substitute_stmt ~kept ~scopes ~parents ~at_path stmt =
             {
               rule with
               declarations =
-                eval_decls ~kept ~scopes ~at_path eff rule.declarations;
+                eval_decls ~inline_kept_values ~kept ~scopes ~at_path eff
+                  rule.declarations;
               nested =
-                substitute ~kept ~scopes ~parents:(eff :: parents) ~at_path
-                  rule.nested;
+                substitute ~inline_kept_values ~kept ~scopes
+                  ~parents:(eff :: parents) ~at_path rule.nested;
             }
       | Declarations decls ->
           Declarations
-            (eval_decls ~kept ~scopes ~at_path
+            (eval_decls ~inline_kept_values ~kept ~scopes ~at_path
                (selector_for_parents parents)
                decls)
       | Page (sel, decls) ->
@@ -1033,7 +1061,7 @@ let normalise_var_name name =
   if String.length name >= 2 && String.sub name 0 2 = "--" then name
   else String.concat "" [ "--"; name ]
 
-let vars ?(keep_vars = []) stylesheet =
+let vars ?(inline_kept_values = false) ?(keep_vars = []) stylesheet =
   let keep = List.map normalise_var_name keep_vars in
   let scopes = collect_scopes ~kept:keep stylesheet in
   let original_consumers, original_customs = collect_scoped_refs stylesheet in
@@ -1041,7 +1069,8 @@ let vars ?(keep_vars = []) stylesheet =
     cyclic_live_customs ~consumers:original_consumers ~customs:original_customs
   in
   let substituted =
-    substitute ~kept:keep ~scopes ~parents:[] ~at_path:[] stylesheet
+    substitute ~inline_kept_values ~kept:keep ~scopes ~parents:[] ~at_path:[]
+      stylesheet
   in
   let consumers, customs = collect_scoped_refs substituted in
   let live_set = live_customs ~consumers ~customs @ cyclic_live_set in

--- a/lib/inline.mli
+++ b/lib/inline.mli
@@ -5,12 +5,20 @@
     Both transforms assume a closed world (no runtime mutation, full file
     resolution). *)
 
-val vars : ?keep_vars:string list -> Stylesheet.t -> Stylesheet.t
-(** [vars ?keep_vars stylesheet] substitutes [var(--name)] references with the
-    value of the corresponding [--name] declaration in [stylesheet] and drops
-    the now-unused custom-property definitions. Names listed in [keep_vars]
-    (with or without the leading [--]) keep their definitions and remain as live
-    [var()] references in the output. *)
+val vars :
+  ?inline_kept_values:bool ->
+  ?keep_vars:string list ->
+  Stylesheet.t ->
+  Stylesheet.t
+(** [vars ?inline_kept_values ?keep_vars stylesheet] substitutes [var(--name)]
+    references with the value of the corresponding [--name] declaration in
+    [stylesheet] and drops the now-unused custom-property definitions. Names
+    listed in [keep_vars] (with or without the leading [--]) keep their
+    definitions and remain as live [var()] references in the output.
+
+    When [inline_kept_values] is true, resolvable references inside kept custom
+    property definitions may still be substituted. This is for partial theme
+    default resolution; the default keeps user-requested variables verbatim. *)
 
 val decode_import_url : string -> string
 (** [decode_import_url s] strips the [url(...)] wrapper and any surrounding

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6266,6 +6266,13 @@ let customprops1_transitive_fallback () =
        ".t { transition-timing-function: var(--tw-ease, \
         var(--default-transition-timing-function)) }"
     |> Css.resolve_theme ~theme ~theme_defaults:resolve
+    |> Css.to_string ~minify:true);
+  Alcotest.(check string)
+    "declared theme default still inlines into a kept runtime var fallback"
+    ":root,:host{--tw-ease:initial}.t{transition-timing-function:var(--tw-ease,ease)}"
+    (parse
+       ":root,:host{--default-transition-timing-function:ease;--tw-ease:initial}.t{transition-timing-function:var(--tw-ease,var(--default-transition-timing-function))}"
+    |> Css.resolve_theme ~theme ~theme_defaults:resolve
     |> Css.to_string ~minify:true)
 
 (* CSS Properties & Values API: resolve_theme is a partial inline - it
@@ -6306,11 +6313,12 @@ let customprops1_calc_inline () =
     |> Css.to_string ~minify:true)
 
 (* CSS Custom Properties L1: a theme var referenced anywhere - inside another
-   var's opaque value or inside a utility rule - and resolvable through
-   [theme_defaults] is emitted at root scope, the global token's cascade scope.
-   It merges into an existing :root,:host block (no spurious extra block), is
-   never injected into the element-scoped rule that references it, and an
-   unrelated @supports polyfill default is not pulled in. *)
+   custom property's opaque value or inside a utility rule - and resolvable
+   through [theme_defaults] is inlined at the reference site, including inside
+   the opaque value of a kept custom property. It is not materialised as a :root
+   binding merely to back a reference; an unrelated @supports polyfill default
+   is not pulled in; and a reference the resolver returns [None] for stays a
+   live var(). *)
 let customprops1_transitive_merge () =
   let parse css =
     match Css.of_string ~strict:false css with
@@ -6325,18 +6333,17 @@ let customprops1_transitive_merge () =
     |> Css.to_string ~minify:true
   in
   Alcotest.(check string)
-    "transitive theme var merges into the same :root,:host block"
-    ":root,:host{--spacing:.25rem;--shadow:0 0 var(--spacing) black}"
+    "a resolvable theme var inlines into a kept custom property's opaque value"
+    ":root,:host{--shadow:0 0 .25rem black}"
     (render ":root,:host{--shadow:0 0 var(--spacing) black}");
   Alcotest.(check string)
-    "a theme var referenced from a utility lands in :root, not the utility"
-    ":root{--spacing:.25rem}.shadow{--shadow:0 0 var(--spacing) black}"
+    "it inlines at the utility reference site, not as a :root binding"
+    ".shadow{--shadow:0 0 .25rem black}"
     (render ".shadow{--shadow:0 0 var(--spacing) black}");
   Alcotest.(check string)
     "an unrelated @supports polyfill default is not pulled in"
-    "@supports(color:lab(0 0 \
-     0)){:root{--tw-x:initial}}:root,:host{--spacing:.25rem;--shadow:0 0 \
-     var(--spacing) black}"
+    "@supports(color:lab(0 0 0)){:root{--tw-x:initial}}:root,:host{--shadow:0 \
+     0 .25rem black}"
     (render
        "@supports (color: lab(0 0 0)){:root{--tw-x:initial}} \
         :root,:host{--shadow:0 0 var(--spacing) black}");


### PR DESCRIPTION
This PR reworks `Css.resolve_theme` to inline resolvable theme defaults at their reference site instead of materialising a `:root` binding for each.

A theme default reachable only through a `var()` reference, including one inside an opaque custom-property value, is now substituted in place; a variable in the keep-set still keeps its live `var()` and its root definition. `Inline.vars` gains an `inline_kept_values` option so a kept custom-property definition's own resolvable references can be substituted during this partial inline — this is the opt-in `resolve_theme` needs, distinct from the default `--keep-vars` behaviour, which keeps a kept variable's runtime dependency chain intact.

Split out of the DAG-engine PR; independent of it.