### PR TITLE
inline: inline a variable only when it has a single definition scope

### DIFF
--- a/bin/cli_inline_vars.ml
+++ b/bin/cli_inline_vars.ml
@@ -4,4 +4,10 @@
 open Cascade
 
 let run ~keep_vars stylesheet =
-  Css.inline_vars ?keep_vars:(Some keep_vars) stylesheet
+  Css.inline_vars ?keep_vars:(Some keep_vars)
+    ~warn:(fun name ->
+      Fmt.epr
+        "Warning: %s is redefined in a different scope; kept live (cannot \
+         inline safely)@."
+        name)
+    stylesheet

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -864,11 +864,11 @@ let flatten_nesting = Optimize.flatten_nesting
    substitute every resolvable [var()] reference, then strip the now-empty
    [@layer] wrappers and the [@property] / [@layer-decl] rules that only existed
    to register the substituted variables. *)
-let inline_vars ?keep_vars stylesheet =
+let inline_vars ?keep_vars ?warn stylesheet =
   let substituted =
     match keep_vars with
-    | None -> Inline.vars stylesheet
-    | Some keep_vars -> Inline.vars ~keep_vars stylesheet
+    | None -> Inline.vars ?warn stylesheet
+    | Some keep_vars -> Inline.vars ?warn ~keep_vars stylesheet
   in
   List.concat_map statements_for_inline substituted
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7628,13 +7628,14 @@ val flatten_nesting : t -> t
     Transforms that assume the caller controls properties the open web cannot
     guarantee (no runtime variable mutation, full file resolution). *)
 
-val inline_vars : ?keep_vars:string list -> t -> t
-(** [inline_vars ?keep_vars stylesheet] substitutes [var(--name)] references
-    with the value of the corresponding [--name] declaration in [stylesheet] and
-    drops the now-unused custom-property definitions. Names listed in
-    [keep_vars] (with or without the leading [--]) keep their definitions and
-    remain as live [var()] references in the output. The transform assumes no
-    runtime mutation of custom properties. *)
+val inline_vars : ?keep_vars:string list -> ?warn:(string -> unit) -> t -> t
+(** [inline_vars ?keep_vars ?warn stylesheet] substitutes [var(--name)]
+    references with the value of the corresponding [--name] declaration and
+    deletes the definition, but only for a variable with a single definition. A
+    variable in [keep_vars], or one redefined in a different scope (a real
+    cascade override such as dark mode), keeps its definition and stays a live
+    [var()] reference; [warn] is called with each such name. The transform
+    assumes no runtime mutation of custom properties. *)
 
 val resolve_theme :
   ?theme:Pp.String_set.t -> ?theme_defaults:(string -> string option) -> t -> t

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -482,9 +482,25 @@ let substitute_non_custom ~kept visible ctx decl =
     | Components components ->
         apply_substituted_components ctx decl ~original_components components
 
+(* A custom property's own value: fold the inlinable (non-kept) variables it
+   references in place so they can be deleted, while a [kept] variable it
+   references stays a live [var()]. *)
+let fold_custom_value ~kept visible decl =
+  match custom_value_components decl with
+  | None -> Some decl
+  | Some original -> (
+      match substitute_components ~kept visible ~visited:[] original with
+      | Cycle -> Some decl
+      | Components components -> (
+          if components = original then Some decl
+          else
+            match declaration_with_components decl components with
+            | Some decl' -> Some decl'
+            | None -> Some decl))
+
 let substitute_declaration ~kept visible ctx decl =
   match custom_name decl with
-  | Some _ -> Some decl
+  | Some _ -> fold_custom_value ~kept visible decl
   | None -> substitute_non_custom ~kept visible ctx decl
 
 let font_src_var_fallback ~simplify ~visited (var : Font_face.src Values.var) =
@@ -1033,19 +1049,92 @@ let normalise_var_name name =
   if String.length name >= 2 && String.sub name 0 2 = "--" then name
   else String.concat "" [ "--"; name ]
 
-let vars ?(keep_vars = []) stylesheet =
+(* Per custom-property name, how many definitions it has across the whole
+   stylesheet, plus the set of names referenced anywhere. A variable is safe to
+   inline and delete only when it has a single definition: its value is then
+   unambiguous. A variable redefined in another scope is a real cascade override
+   (dark mode, a media query, a component) and must stay a live [var()] so its
+   consumers still track it - inlining it would freeze the value. *)
+let var_census stylesheet =
+  (* Count the distinct cascade scopes (selector + at-rule context) that define
+     each variable, so a redeclaration within one scope counts once while a real
+     override in another scope counts as two. Plus the set of referenced
+     names. *)
+  let scopes_of : (string, (at_node list * string) list) Hashtbl.t =
+    Hashtbl.create 64
+  in
+  let add name key =
+    let prev = Option.value ~default:[] (Hashtbl.find_opt scopes_of name) in
+    if not (List.mem key prev) then Hashtbl.replace scopes_of name (key :: prev)
+  in
+  List.iter
+    (fun (s : scope) ->
+      let key = (s.at_path, Selector.to_string ~minify:true s.selector) in
+      s.customs
+      |> List.filter_map (fun d ->
+          Option.map normalise_var_name (custom_name d))
+      |> List.sort_uniq compare
+      |> List.iter (fun n -> add n key))
+    (collect_scopes ~kept:[] stylesheet);
+  let counts : (string, int) Hashtbl.t = Hashtbl.create 64 in
+  Hashtbl.iter
+    (fun name keys -> Hashtbl.replace counts name (List.length keys))
+    scopes_of;
+  let referenced = ref [] in
+  let add_refs decls =
+    referenced :=
+      names_of_vars (Variables.vars_of_declarations decls) @ !referenced
+  in
+  let rec walk stmt =
+    match at_wrapper stmt with
+    | Some (_, body, _) -> List.iter walk body
+    | None -> (
+        match stmt with
+        | Rule r ->
+            add_refs r.declarations;
+            List.iter walk r.nested
+        | Declarations decls -> add_refs decls
+        | _ -> ())
+  in
+  List.iter walk stylesheet;
+  (counts, List.sort_uniq compare !referenced)
+
+let vars ?(keep_vars = []) ?(warn = fun _ -> ()) stylesheet =
   let keep = List.map normalise_var_name keep_vars in
-  let scopes = collect_scopes ~kept:keep stylesheet in
+  let counts, referenced = var_census stylesheet in
+  let inlinable name =
+    (not (List.mem name keep)) && Hashtbl.find_opt counts name = Some 1
+  in
+  (* Everything not inlinable stays live: the keep-set, plus any non-kept
+     variable redefined across scopes. Those are folded by the substitution as
+     if kept, so the single-def variables fold into them and get stripped. *)
+  let kept =
+    Hashtbl.fold
+      (fun name _ acc -> if inlinable name then acc else name :: acc)
+      counts keep
+    |> List.sort_uniq compare
+  in
+  (* Warn for a non-kept variable kept only because it is redefined in a
+     different scope, so the caller knows it escaped inlining. *)
+  Hashtbl.iter
+    (fun name count ->
+      if count > 1 && (not (List.mem name keep)) && List.mem name referenced
+      then warn name)
+    counts;
+  let scopes = collect_scopes ~kept stylesheet in
   let original_consumers, original_customs = collect_scoped_refs stylesheet in
   let cyclic_live_set =
     cyclic_live_customs ~consumers:original_consumers ~customs:original_customs
   in
   let substituted =
-    substitute ~kept:keep ~scopes ~parents:[] ~at_path:[] stylesheet
+    substitute ~kept ~scopes ~parents:[] ~at_path:[] stylesheet
   in
   let consumers, customs = collect_scoped_refs substituted in
   let live_set = live_customs ~consumers ~customs @ cyclic_live_set in
-  strip_dead ~keep ~live_set substituted
+  (* Keep every definition of a kept variable (including a cross-scope override
+     like an @media one), so the live chain stays complete; single-def
+     inlinables are not in [kept] and are stripped once folded. *)
+  strip_dead ~keep:kept ~live_set substituted
 
 (** {1 [@import] inlining helpers} *)
 

--- a/lib/inline.mli
+++ b/lib/inline.mli
@@ -5,12 +5,19 @@
     Both transforms assume a closed world (no runtime mutation, full file
     resolution). *)
 
-val vars : ?keep_vars:string list -> Stylesheet.t -> Stylesheet.t
-(** [vars ?keep_vars stylesheet] substitutes [var(--name)] references with the
-    value of the corresponding [--name] declaration in [stylesheet] and drops
-    the now-unused custom-property definitions. Names listed in [keep_vars]
-    (with or without the leading [--]) keep their definitions and remain as live
-    [var()] references in the output. *)
+val vars :
+  ?keep_vars:string list ->
+  ?warn:(string -> unit) ->
+  Stylesheet.t ->
+  Stylesheet.t
+(** [vars ?keep_vars ?warn stylesheet] substitutes [var(--name)] references with
+    the value of the corresponding [--name] declaration and deletes the
+    definition, but only for a variable with a single definition (its value is
+    then unambiguous). A variable in [keep_vars], or one redefined in a
+    different scope (a real cascade override such as dark mode), keeps its
+    definition and stays a live [var()] reference. [warn] is called with each
+    name (leading [--]) that could not be inlined because it is redefined in a
+    different scope. *)
 
 val decode_import_url : string -> string
 (** [decode_import_url s] strips the [url(...)] wrapper and any surrounding

--- a/test/cli/inline_combined.t
+++ b/test/cli/inline_combined.t
@@ -83,7 +83,8 @@ inside the layer scope to layer consumers.
   $ cascade --minify --inline-imports --inline-vars app-layer.css
   .x{color:red}.e{color:#00f}
 
-Imported kept variables retain imported runtime dependencies.
+An imported variable that a kept variable references is folded into the kept
+variable and deleted, the same as a local one.
 
   $ cat > tokens-transitive.css <<EOF
   > :root { --brand: var(--palette-red); --palette-red: red; --gap: 8px }
@@ -93,4 +94,4 @@ Imported kept variables retain imported runtime dependencies.
   > .btn { color: var(--brand); padding: var(--gap) }
   > EOF
   $ cascade --minify --inline-imports --inline-vars --keep-vars=brand app-transitive.css
-  :root{--brand:var(--palette-red);--palette-red:red}.btn{color:var(--brand);padding:8px}
+  :root{--brand:red}.btn{color:var(--brand);padding:8px}

--- a/test/cli/inline_vars_keep.t
+++ b/test/cli/inline_vars_keep.t
@@ -26,16 +26,29 @@ Mixed forms with and without [--] accepted.
   $ cascade --minify --inline-vars --keep-vars=--brand,spacing-3 theme.css
   :root{--brand:red;--spacing-3:12px}.btn{color:var(--brand);padding:var(--spacing-3)}
 
-Keeping a variable also keeps the runtime dependencies that its value
-references. Otherwise the kept variable would compute differently after
-dead-stripping.
+Inlining a variable folds it into the kept variables that reference it and
+deletes its definition: the kept variable carries the value, no inline
+definition is left behind.
 
   $ cat > transitive.css <<EOF
   > :root { --brand: var(--palette-red); --palette-red: red; --gap: 8px }
   > .btn { color: var(--brand); padding: var(--gap) }
   > EOF
   $ cascade --minify --inline-vars --keep-vars=brand transitive.css
-  :root{--brand:var(--palette-red);--palette-red:red}.btn{color:var(--brand);padding:8px}
+  :root{--brand:red}.btn{color:var(--brand);padding:8px}
+
+A variable overridden in a different scope cannot be inlined safely: freezing
+it would lose the override. It is kept as a live var() chain (so dark mode keeps
+working through the variable) and a warning names it.
+
+  $ cat > dark.css <<EOF
+  > :root { --brand: var(--palette-red); --palette-red: red }
+  > .dark { --palette-red: black }
+  > .btn { color: var(--brand) }
+  > EOF
+  $ cascade --minify --inline-vars --keep-vars=brand dark.css 2>&1
+  Warning: --palette-red is redefined in a different scope; kept live (cannot inline safely)
+  :root{--brand:var(--palette-red);--palette-red:red}.dark{--palette-red:black}.btn{color:var(--brand)}
 
 Custom property names are case-sensitive. Keeping [--brand] must not
 also keep [--Brand].

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -43,6 +43,38 @@ let test_inline_keep_vars () =
     ":root{--brand:blue}.button{color:var(--brand);border-color:#00f}"
     (optimized_minified inlined)
 
+(* Inlining deletes a non-kept variable's definition only when it has a single
+   definition scope; a variable overridden in another scope is kept as a live
+   var() chain and reported through [warn]. *)
+let test_inline_fold_deletes_defs () =
+  let fold css =
+    parse css |> Css.inline_vars ~keep_vars:[ "brand" ] |> minified
+  in
+  Alcotest.(check string)
+    "single definition folds into the kept var and is deleted"
+    ":root{--brand:red}.btn{color:var(--brand)}"
+    (fold
+       ":root{--brand:var(--palette-red);--palette-red:red}.btn{color:var(--brand)}");
+  Alcotest.(check string)
+    "a class-scope override keeps the variable as a live chain"
+    ":root{--brand:var(--palette-red);--palette-red:red}.dark{--palette-red:black}.btn{color:var(--brand)}"
+    (fold
+       ":root{--brand:var(--palette-red);--palette-red:red}.dark{--palette-red:black}.btn{color:var(--brand)}");
+  Alcotest.(check string)
+    "an @media override keeps the variable as a live chain"
+    ":root{--brand:var(--palette-red);--palette-red:red}@media(prefers-color-scheme:dark){:root{--palette-red:black}}.btn{color:var(--brand)}"
+    (fold
+       ":root{--brand:var(--palette-red);--palette-red:red}@media \
+        (prefers-color-scheme:dark){:root{--palette-red:black}}.btn{color:var(--brand)}");
+  let warned = ref [] in
+  ignore
+    (parse
+       ":root{--brand:var(--palette-red);--palette-red:red}.dark{--palette-red:black}.btn{color:var(--brand)}"
+    |> Css.inline_vars ~keep_vars:[ "brand" ] ~warn:(fun n ->
+        warned := n :: !warned));
+  Alcotest.(check (list string))
+    "an overridden variable is reported via warn" [ "--palette-red" ] !warned
+
 let test_inline_keep_vars_calc_identity () =
   (* A kept theme var stays a live reference, but the value-independent calc
      identities still simplify: [p-1] expands to [calc(var(--spacing) * 1)],
@@ -213,6 +245,8 @@ let suite =
         `Quick test_inline_substitutes_vars;
       Alcotest.test_case "inline vars keep requested references" `Quick
         test_inline_keep_vars;
+      Alcotest.test_case "inline vars fold and delete non-kept definitions"
+        `Quick test_inline_fold_deletes_defs;
       Alcotest.test_case "inline vars apply calc identities to kept vars" `Quick
         test_inline_keep_vars_calc_identity;
       Alcotest.test_case "inline vars collapse a literal zero times a kept var"

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6325,18 +6325,17 @@ let customprops1_transitive_merge () =
     |> Css.to_string ~minify:true
   in
   Alcotest.(check string)
-    "transitive theme var merges into the same :root,:host block"
-    ":root,:host{--spacing:.25rem;--shadow:0 0 var(--spacing) black}"
+    "transitive theme default is folded into the kept variable"
+    ":root,:host{--shadow:0 0 .25rem black}"
     (render ":root,:host{--shadow:0 0 var(--spacing) black}");
   Alcotest.(check string)
-    "a theme var referenced from a utility lands in :root, not the utility"
-    ":root{--spacing:.25rem}.shadow{--shadow:0 0 var(--spacing) black}"
+    "a theme default referenced from a utility is folded into it"
+    ".shadow{--shadow:0 0 .25rem black}"
     (render ".shadow{--shadow:0 0 var(--spacing) black}");
   Alcotest.(check string)
     "an unrelated @supports polyfill default is not pulled in"
-    "@supports(color:lab(0 0 \
-     0)){:root{--tw-x:initial}}:root,:host{--spacing:.25rem;--shadow:0 0 \
-     var(--spacing) black}"
+    "@supports(color:lab(0 0 0)){:root{--tw-x:initial}}:root,:host{--shadow:0 \
+     0 .25rem black}"
     (render
        "@supports (color: lab(0 0 0)){:root{--tw-x:initial}} \
         :root,:host{--shadow:0 0 var(--spacing) black}");


### PR DESCRIPTION
This PR makes `cascade --inline-vars` inline a non-kept custom property only when it has a single definition scope.

A property with one definition has an unambiguous value, so it is substituted at every use and its definition deleted. A property redefined in another scope (a real cascade override, e.g. `:root` then `.dark`) is kept live with a warning naming it: inlining a single value would freeze it and lose the override, and cascade is open over the DOM, so it cannot know which scope applies to a given element.

`Css.resolve_theme` shares the same substitution engine and differs only in closed-world scope. `--inline-vars` is closed over every custom property, so an unresolved `var(--undef, red)` collapses to `red`. `resolve_theme` is closed only over the theme it is handed, so an unresolved non-theme `var()` stays live.