### PR TITLE
css: inline a theme token already declared at root scope

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1042,7 +1042,7 @@ let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
       List.iter dfs
         (collect_var_names stylesheet @ structural_var_refs stylesheet)
   | Option.None -> ());
-  Hashtbl.fold (fun k v acc -> (k, v) :: acc) resolved []
+  Hashtbl.fold (fun k v acc -> (bare_theme_name k, v) :: acc) resolved []
 
 let theme_defaults_source defaults =
   let body =
@@ -1224,12 +1224,13 @@ let emit_transitive_theme_refs ~theme_defaults stylesheet =
    [var()] reference live. Only resolved names get substituted: [Inline.vars]
    alone would also collapse [var(--x, fallback)] for names the resolver
    returned [None] on (its built-in fallback arm fires when no declaration is
-   visible). We inject a [:root] rule for the resolved names and extend
-   [keep_vars] with every name we did *not* resolve, so unresolved sites keep
-   their declarations live and fall through to the original-Func branch. Every
-   declared custom-prop name is kept too, so the dead-declaration pass leaves
-   unrelated definitions (e.g. an @supports polyfill's [--tw-x:initial]) in
-   place. *)
+   visible). A [:root] binding is injected only for resolved names with no
+   declaration of their own; an already-declared theme token inlines from that
+   declaration, so a second binding - which would make it look multiply-defined
+   and keep it live - is skipped. [keep_vars] gains every unresolved name and
+   every declared custom-prop EXCEPT the ones being resolved, so unrelated
+   definitions (e.g. an @supports polyfill's [--tw-x:initial]) stay while a
+   resolved token is inlined and dropped. *)
 let inline_theme_defaults ?theme ?theme_defaults ~keep_set stylesheet =
   let keep_vars = Pp.String_set.elements keep_set in
   let defaults =
@@ -1237,33 +1238,36 @@ let inline_theme_defaults ?theme ?theme_defaults ~keep_set stylesheet =
   in
   if defaults = [] then stylesheet
   else
-    let resolved_names = List.map fst defaults in
+    let declared = declared_custom_prop_names stylesheet in
+    let resolved = List.map fst defaults in
     let unresolved_keep =
-      collect_var_names stylesheet
-      |> List.filter (fun n -> not (List.mem n resolved_names))
+      referenced_var_names stylesheet
+      |> List.filter (fun n -> not (List.mem n resolved))
     in
-    let declared_names =
-      Hashtbl.fold
-        (fun n () acc -> n :: acc)
-        (declared_custom_prop_names stylesheet)
-        []
+    let declared_keep =
+      Hashtbl.fold (fun n () acc -> n :: acc) declared []
+      |> List.filter (fun n -> not (List.mem n resolved))
     in
     let keep_vars =
       List.fold_left
         (fun acc n -> if List.mem n acc then acc else n :: acc)
         keep_vars
-        (unresolved_keep @ declared_names)
+        (unresolved_keep @ declared_keep)
     in
-    let source = theme_defaults_source defaults in
-    match of_string ~strict:false source with
-    | Ok { stylesheet = root_stmts; _ } ->
-        (* Do NOT run the closed-world [statements_for_inline] cleanup: this is
-           a partial inline, so it must preserve unrelated [@property]
-           registrations and [@layer] structure (the cleanup strips every
-           [@property] and flattens every [@layer], dropping author
-           registrations like an unrelated [@property --tw-foo]). *)
-        Inline.vars ~keep_vars (root_stmts @ stylesheet)
-    | Error _ -> stylesheet
+    let inject =
+      List.filter (fun (n, _) -> not (Hashtbl.mem declared n)) defaults
+    in
+    if inject = [] then Inline.vars ~keep_vars stylesheet
+    else
+      match of_string ~strict:false (theme_defaults_source inject) with
+      | Ok { stylesheet = root_stmts; _ } ->
+          (* Do NOT run the closed-world [statements_for_inline] cleanup: this
+             is a partial inline, so it must preserve unrelated [@property]
+             registrations and [@layer] structure (the cleanup strips every
+             [@property] and flattens every [@layer], dropping author
+             registrations like an unrelated [@property --tw-foo]). *)
+          Inline.vars ~keep_vars (root_stmts @ stylesheet)
+      | Error _ -> stylesheet
 
 (* Theme resolution as an explicit AST step. [theme] names the variables whose
    [var()] references should survive (handed to [Inline.vars]' keep-set) and

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -39,7 +39,14 @@ let effective_selector ~parents sel =
         (fun child parent -> combine_with_parent parent child)
         sel parents
 
-let universal_selector_text s = s = ":root" || s = "html" || s = "*"
+(* A selector reaches the whole subtree when one of its comma branches is a
+   universal/root selector: [:root] (and [html]) inherit to every element and
+   [*] matches every element, so [:root,:host] covers via its [:root] branch
+   while a lone [:host] (shadow root only) does not. *)
+let universal_selector_text s =
+  String.split_on_char ',' s
+  |> List.exists (fun p ->
+      match String.trim p with ":root" | "html" | "*" -> true | _ -> false)
 
 (* [.theme] is an ancestor of [.theme .descendant] (descendant-prefix); not of
    [.other]. Universal selectors always cover. The text comparison is

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6289,6 +6289,31 @@ let customprops1_resolve_keeps_property () =
          | _ -> None)
     |> Css.to_string ~minify:true)
 
+(* CSS Custom Properties L1: a theme token already declared in the input on a
+   root-scope block ([:root,:host], as Tailwind emits) and resolvable through
+   [theme_defaults] inlines from that declaration and is dropped - the existing
+   binding must not survive, be duplicated, or block the substitution. The
+   declared value wins over the theme default (cascade). *)
+let customprops1_inline_declared_root_token () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let blur = function "blur-xl" -> Some "24px" | _ -> None in
+  let render css =
+    parse css
+    |> Css.resolve_theme ~theme:Css.Pp.String_set.empty ~theme_defaults:blur
+    |> Css.to_string ~minify:true
+  in
+  Alcotest.(check string)
+    "a declared :root,:host theme token inlines and its block is dropped"
+    ".x{filter:blur(24px)}"
+    (render ":root,:host{--blur-xl:24px}.x{filter:blur(var(--blur-xl))}");
+  Alcotest.(check string)
+    "the declared value wins over the theme default" ".x{filter:blur(9px)}"
+    (render ":root{--blur-xl:9px}.x{filter:blur(var(--blur-xl))}")
+
 (* CSS Custom Properties L1 section 2: inlining a [var()] inside a [calc()]
    resolves the variable, and the resulting all-constant calc reduces under
    minify. *)
@@ -7080,6 +7105,9 @@ let additional_tests =
     ( "spec custom-properties 1 resolve keeps unrelated @property",
       `Quick,
       customprops1_resolve_keeps_property );
+    ( "spec custom-properties 1 inline declared root-scope token",
+      `Quick,
+      customprops1_inline_declared_root_token );
     ( "spec custom-properties 1 inlined var in calc simplifies",
       `Quick,
       customprops1_calc_inline );


### PR DESCRIPTION
This PR makes `resolve_theme` inline a theme token whose definition is already present in the input.

When a stylesheet already carries a token's own root-scope definition (`:root,:host{--blur-xl:24px}`, which is exactly what Tailwind's codegen emits for theme tokens), `resolve_theme` used to keep the token live and inject a second `:root` binding, leaving `var(--blur-xl)` unresolved beside two definitions. It now inlines the reference from the existing declaration and drops it, injecting a `:root` binding only for tokens that have no declaration of their own; the in-stylesheet value wins over the `theme_defaults` default, matching the cascade.

Two supporting changes make that work: the inline engine now recognises a `:root,:host` list (or any list with a `:root` branch), not just a bare `:root`, as a whole-tree value source, so the declared value actually reaches the references; and the theme-resolution layer is unified on bare custom-property names so the keep/declared/resolved sets compare directly instead of mixing `--`-prefixed and bare spellings.

Follow-up to #148.
