### PR TITLE
optimize: gate global factoring on estimated transfer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ $ cascade diff a.css b.css
 ```
 
 Cascade aims to be the smallest minifier on real-world stylesheets while
-staying competitive on speed: smallest output of any tool tested on three of
-the four SatCSS fixtures with `--minify`, and on every fixture with
-`--aggressive`. The diff subcommand reads structure, so refactors that move
-rules around without changing semantics show up as a no-op rather than as a
-wall of red and green. Both modes round-trip through a typed CSS AST, so the
-output is always valid CSS.
+staying competitive on speed. `--minify` optimises the bytes that actually
+ship: it is the smallest gzip-compressed output of any tool tested on all
+four SatCSS fixtures, and `--objective=raw` is the smallest uncompressed
+output on all four. The diff subcommand reads structure, so refactors that
+move rules around without changing semantics show up as a no-op rather than
+as a wall of red and green. Both modes round-trip through a typed CSS AST, so
+the output is always valid CSS.
 
 ## Install
 
@@ -80,6 +81,7 @@ cat style.css | cascade -                                          # read stdin
 |---|---|
 | `-m, --minify` | Minify the output. Local linear rewrites always run; the expensive global factoring fixpoint runs only when its preflight predicts useful savings. The top-level pipeline re-runs until the AST stops changing (capped at 5 iterations), so the output is a fixed point: rule-order canonicalisation can expose a merge a single pass would miss. |
 | `--aggressive` | Force the global factoring fixpoint regardless of the preflight, and widen the convergence cap. Trades roughly 10-20x wall clock for the last few percent of bytes. Has no effect without `--minify`. |
+| `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win, the right objective when the output ships uncompressed (inline style attributes, email HTML). Has no effect without `--minify`. |
 | `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Has no effect without `--minify`. |
 | `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest CSS form it knows, but it keeps every `@supports` and `supports()` guard unless the CSS text and spec alone prove the rewrite. Has no effect without `--minify`. |
 | `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
@@ -93,23 +95,28 @@ cat style.css | cascade -                                          # read stdin
 
 ### How it compares
 
-Cascade's `--minify` is a fast, safe default; `--aggressive` is the
-size-optimal mode. Benchmarked on the SatCSS corpus (Hague, Lin, Hong, TOPLAS
-2019), median wall clock over 5 runs, against the major minifiers:
+Cascade's `--minify` optimises the metric that matters for shipped CSS: the
+compressed transfer size. Benchmarked on the SatCSS corpus (Hague, Lin, Hong,
+TOPLAS 2019), gzip -9 bytes of the emitted CSS and median wall clock over 5
+runs:
 
-| fixture | cascade `--minify` | cascade `--aggressive` | csso | lightningcss | esbuild | cssnano |
-|---|---|---|---|---|---|---|
-| github | 181,408 / 40 ms | **173,194** / 1,280 ms | 180,825 / 120 ms | 182,772 / 10 ms | 183,965 / 10 ms | 182,039 / 240 ms |
-| guardian | **158,382** / 410 ms | **158,382** / 880 ms | 168,671 / 100 ms | 170,266 / 0 ms | 190,082 / 10 ms | 166,617 / 220 ms |
-| youtube | **220,324** / 40 ms | **213,955** / 1,270 ms | 224,878 / 130 ms | 224,538 / 10 ms | 229,566 / 10 ms | 221,002 / 270 ms |
-| netflix | **192,151** / 60 ms | **177,945** / 1,730 ms | 223,780 / 140 ms | 231,113 / 10 ms | 247,294 / 10 ms | 218,017 / 290 ms |
+| fixture | cascade `--minify` | csso | lightningcss | esbuild | cssnano |
+|---|---|---|---|---|---|
+| github | **34,289** / 570 ms | 34,887 / 120 ms | 34,420 / 10 ms | 34,736 / 10 ms | 34,729 / 240 ms |
+| guardian | **25,979** / 290 ms | 26,653 / 100 ms | 26,008 / 0 ms | 27,616 / 10 ms | 26,408 / 220 ms |
+| youtube | **33,779** / 680 ms | 34,841 / 130 ms | 34,321 / 10 ms | 34,782 / 10 ms | 33,930 / 300 ms |
+| netflix | **29,497** / 740 ms | 33,102 / 140 ms | 31,948 / 10 ms | 33,820 / 10 ms | 31,411 / 280 ms |
 
-Cascade `--aggressive` emits the smallest output on every fixture. Cascade
-`--minify` (default) is smallest on three of four fixtures; on github it
-trails csso by 583 bytes (0.3%) at a third of csso's wall clock. Lightning CSS
-and esbuild are 4-40x faster than cascade `--minify` but emit 1-30% more
-bytes; csso and cssnano are in the same wall-clock band as cascade `--minify`
-on most fixtures but emit more bytes.
+Cascade emits the smallest gzip output on every fixture, and the smallest
+brotli output on all but guardian (where Lightning CSS keeps a 0.6% edge).
+`--aggressive` changes little under the default objective: the transfer gate
+already discards factoring that would grow the compressed output. With
+`--objective=raw` the objective flips to uncompressed bytes and cascade emits
+the smallest raw output on every fixture too (github 178,042 vs csso's
+180,825; netflix 172,500 under `--aggressive` vs cssnano's 218,017). Lightning
+CSS and esbuild are well over an order of magnitude faster but emit 0.4-15%
+more compressed bytes; csso and cssnano sit in the same wall-clock band as
+cascade and emit more bytes.
 
 ## `cascade diff`: structural CSS diff
 

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -46,7 +46,10 @@ let print_factor_profile_footer () =
   Fmt.epr "@.factor stops: %d marginal, committed savings: %d bytes@."
     S.counters.marginal_stops S.counters.factor_bytes_saved;
   Fmt.epr "factor preflight: %d skipped, estimated gain %d bytes@."
-    S.counters.factor_fixpoints_skipped S.counters.factor_preflight_gain
+    S.counters.factor_fixpoints_skipped S.counters.factor_preflight_gain;
+  if S.counters.factor_transfer_reverts > 0 then
+    Fmt.epr "factor transfer gate: %d segments reverted@."
+      S.counters.factor_transfer_reverts
 
 let report_profile () =
   let module S = Cascade.Stats in
@@ -74,7 +77,7 @@ let emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet =
   Buffer.output_buffer stdout buf
 
 let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
-    ~enforce_spec ~aggressive ~closed_world ~inline_imports_flag
+    ~enforce_spec ~aggressive ~closed_world ~objective ~inline_imports_flag
     ~inline_vars_flag ~keep_vars ~memtrace_path ~profile =
   Cli_io.start_memtrace memtrace_path;
   try
@@ -91,7 +94,7 @@ let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
       if minify then
         let () = Cascade.Stats.set_profile profile in
         Css.optimize ~scope ~flatten_nesting ~lossless ~enforce_spec ~aggressive
-          ~closed_world stylesheet
+          ~closed_world ~objective stylesheet
       else stylesheet
     in
     emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet;
@@ -174,6 +177,20 @@ let aggressive_arg =
   in
   Arg.(value & flag & info [ "aggressive" ] ~doc)
 
+let objective_arg =
+  let doc =
+    "Size metric $(b,--minify) optimises for. $(b,transfer) (the default) \
+     keeps a global-factoring result only when it also shrinks the estimated \
+     gzip (DEFLATE) size of the output, since repeated declaration text is \
+     nearly free once compressed; $(b,raw) keeps every raw-byte win, the right \
+     objective when the output ships uncompressed (inline style attributes, \
+     email HTML). Has no effect without $(b,--minify)."
+  in
+  Arg.(
+    value
+    & opt (enum [ ("transfer", `Transfer); ("raw", `Raw) ]) `Transfer
+    & info [ "objective" ] ~doc ~docv:"OBJECTIVE")
+
 let flatten_nesting_arg =
   let doc =
     "Compatibility transform: flatten nested style rules into top-level rules \
@@ -247,6 +264,7 @@ let term =
         enforce_spec
         aggressive
         closed_world
+        objective
         inline_imports_flag
         inline_vars_flag
         keep_vars_str
@@ -274,15 +292,18 @@ let term =
           Fmt.epr "Warning: --aggressive has no effect without --minify@.";
         if closed_world && not minify then
           Fmt.epr "Warning: --closed-world has no effect without --minify@.";
+        if objective = `Raw && not minify then
+          Fmt.epr "Warning: --objective has no effect without --minify@.";
         if profile && not minify then
           Fmt.epr "Warning: --profile has no effect without --minify@.";
         process_css ~input_path:input ~minify ~scope ~flatten_nesting ~lossless
-          ~enforce_spec ~aggressive ~closed_world ~inline_imports_flag
-          ~inline_vars_flag ~keep_vars ~memtrace_path ~profile)
+          ~enforce_spec ~aggressive ~closed_world ~objective
+          ~inline_imports_flag ~inline_vars_flag ~keep_vars ~memtrace_path
+          ~profile)
     $ input_arg $ minify_arg $ scope_arg $ flatten_nesting_arg $ lossless_arg
-    $ enforce_spec_arg $ aggressive_arg $ closed_world_arg $ inline_imports_arg
-    $ inline_vars_arg $ keep_vars_arg $ memtrace_arg $ profile_arg
-    $ Cli_log.term)
+    $ enforce_spec_arg $ aggressive_arg $ closed_world_arg $ objective_arg
+    $ inline_imports_arg $ inline_vars_arg $ keep_vars_arg $ memtrace_arg
+    $ profile_arg $ Cli_log.term)
 
 let man =
   [

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -852,9 +852,9 @@ let inline_style_of_declarations ?(optimize = false) ?minify ?mode declarations
   inline_style_of_declarations ?minify ?mode declarations
 
 let optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
-    ?closed_world ?prune_unused_custom_props stylesheet =
+    ?closed_world ?objective ?prune_unused_custom_props stylesheet =
   Optimize.stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec
-    ?aggressive ?closed_world ?prune_unused_custom_props stylesheet
+    ?aggressive ?closed_world ?objective ?prune_unused_custom_props stylesheet
 
 let flatten_nesting = Optimize.flatten_nesting
 let canonicalize_rule_order = Rule_order.canonicalize

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7592,6 +7592,7 @@ val optimize :
   ?enforce_spec:bool ->
   ?aggressive:bool ->
   ?closed_world:bool ->
+  ?objective:[ `Raw | `Transfer ] ->
   ?prune_unused_custom_props:bool ->
   t ->
   t
@@ -7626,6 +7627,13 @@ val optimize :
     page can render wrong if such an element appears, including one a script
     adds at runtime. This is about the HTML, separate from [scope] (how much of
     the CSS you control). The default is safe for any page.
+
+    [objective] (default [`Transfer]) is the size metric factoring is judged by:
+    under [`Transfer], a global factoring result that grows the estimated
+    DEFLATE (gzip) size of the output is discarded even when it shrinks raw
+    bytes, since repeated declaration text is nearly free once compressed. Pass
+    [`Raw] to keep every raw-byte win, the right objective when the output ships
+    uncompressed (inline [style] attributes, email HTML).
 
     When [prune_unused_custom_props] is [true] (default [false]) custom-property
     bindings referenced by no [var()] anywhere are dropped. Opt-in: it assumes a

--- a/lib/ctx.ml
+++ b/lib/ctx.ml
@@ -1,4 +1,5 @@
 type scope = [ `Fragment | `Stylesheet ]
+type objective = [ `Raw | `Transfer ]
 
 type t = {
   scope : scope;
@@ -7,6 +8,7 @@ type t = {
   aggressive : bool;
   extend_lists : bool;
   closed_world : bool;
+  objective : objective;
 }
 
 let fragment =
@@ -17,17 +19,43 @@ let fragment =
     aggressive = false;
     extend_lists = false;
     closed_world = false;
+    objective = `Transfer;
   }
 
 let of_scope ?(lossless = false) ?(aggressive = false) ?(extend_lists = false)
-    ?(closed_world = false) = function
+    ?(closed_world = false) ?(objective = `Transfer) = function
   | Some scope ->
-      { fragment with scope; lossless; aggressive; extend_lists; closed_world }
-  | None -> { fragment with lossless; aggressive; extend_lists; closed_world }
+      {
+        fragment with
+        scope;
+        lossless;
+        aggressive;
+        extend_lists;
+        closed_world;
+        objective;
+      }
+  | None ->
+      {
+        fragment with
+        lossless;
+        aggressive;
+        extend_lists;
+        closed_world;
+        objective;
+      }
 
 let v ?(lossless = false) ?(aggressive = false) ?(extend_lists = false)
-    ?(closed_world = false) ?(registered = fun _ -> false) scope =
-  { scope; registered; lossless; aggressive; extend_lists; closed_world }
+    ?(closed_world = false) ?(objective = `Transfer)
+    ?(registered = fun _ -> false) scope =
+  {
+    scope;
+    registered;
+    lossless;
+    aggressive;
+    extend_lists;
+    closed_world;
+    objective;
+  }
 
 let scope t = t.scope
 let registered t = t.registered
@@ -35,6 +63,7 @@ let lossless t = t.lossless
 let aggressive t = t.aggressive
 let extend_lists t = t.extend_lists
 let closed_world t = t.closed_world
+let objective t = t.objective
 let with_extend_lists extend_lists t = { t with extend_lists }
 
 let pp_scope ctx = function
@@ -52,4 +81,7 @@ let pp ctx t =
   Pp.string ctx (string_of_bool t.extend_lists);
   Pp.string ctx ";closed_world=";
   Pp.string ctx (string_of_bool t.closed_world);
+  Pp.string ctx ";objective=";
+  Pp.string ctx
+    (match t.objective with `Raw -> "raw" | `Transfer -> "transfer");
   Pp.string ctx "}"

--- a/lib/ctx.mli
+++ b/lib/ctx.mli
@@ -3,6 +3,10 @@
 type scope = [ `Fragment | `Stylesheet ]
 (** Surrounding CSS context assumed by optimizations. *)
 
+type objective = [ `Raw | `Transfer ]
+(** Size metric optimizations are judged by: raw bytes, or estimated DEFLATE
+    (gzip) transfer bytes. *)
+
 type t
 (** Shared optimizer context. *)
 
@@ -14,6 +18,7 @@ val of_scope :
   ?aggressive:bool ->
   ?extend_lists:bool ->
   ?closed_world:bool ->
+  ?objective:objective ->
   scope option ->
   t
 (** Build a context from an optional scope. *)
@@ -23,6 +28,7 @@ val v :
   ?aggressive:bool ->
   ?extend_lists:bool ->
   ?closed_world:bool ->
+  ?objective:objective ->
   ?registered:(string -> bool) ->
   scope ->
   t
@@ -60,6 +66,13 @@ val closed_world : t -> bool
     element does turn up, including one a script adds at runtime. This is about
     the HTML, separate from {!scope}, which is about how much of the CSS you
     control. *)
+
+val objective : t -> objective
+(** Size metric optimizations are judged by. Under [`Transfer] (the default) the
+    global factoring result is kept only when it does not grow the estimated
+    DEFLATE-compressed output; [`Raw] keeps every raw-byte win, the right
+    objective when the output ships uncompressed (inline [style], email) or for
+    structural comparisons against raw-size oracles. *)
 
 val with_extend_lists : bool -> t -> t
 (** [with_extend_lists enabled ctx] returns [ctx] with only the list-extension

--- a/lib/factor.ml
+++ b/lib/factor.ml
@@ -24,6 +24,7 @@ let ctx_key ctx =
       b (Ctx.aggressive ctx);
       b (Ctx.extend_lists ctx);
       b (Ctx.closed_world ctx);
+      (match Ctx.objective ctx with `Raw -> "r" | `Transfer -> "t");
     ]
 
 (* Structural key: the rule list keys the cache directly (sound poly hash/equal
@@ -82,6 +83,25 @@ let optimize_graph ~ctx ~finalize ~fixpoint ~local_iteration rules graph =
     ~elapsed;
   if changed then rules' else rules
 
+(* Factoring rewrites are chosen by raw-byte gain, but stylesheets ship
+   DEFLATE-compressed: replacing repeated declaration text (nearly free under
+   LZ77) with unique selector-list structure can grow the compressed output even
+   as raw bytes shrink. Under the [`Transfer] objective, keep a segment's
+   factoring only when the estimated transfer size does not grow. Below
+   [transfer_gate_min_bytes] the estimate is noise against DEFLATE's block
+   overhead, so raw-byte wins stand unchallenged. *)
+let transfer_gate_min_bytes = 4096
+
+let render_rules rules =
+  Pp.to_string ~minify:true (fun ctx -> List.iter (pp_rule ctx)) rules
+
+let factored_grows_transfer ~ctx ~unfactored ~factored =
+  Ctx.objective ctx = `Transfer
+  &&
+  let before = render_rules unfactored in
+  String.length before >= transfer_gate_min_bytes
+  && Gzip_size.estimate (render_rules factored) > Gzip_size.estimate before
+
 let run_segment ?cache ~ctx ~finalize (rules : rule list) =
   let key = Option.map (fun _ -> cache_key ~ctx rules) cache in
   match
@@ -104,7 +124,20 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
         else begin
           counters.factor_fixpoints_run <- counters.factor_fixpoints_run + 1;
           let fixpoint = counters.factor_fixpoints_run in
-          optimize_graph ~ctx ~finalize ~fixpoint ~local_iteration:1 rules graph
+          let unfactored = ordered_rules rules graph in
+          let factored =
+            optimize_graph ~ctx ~finalize ~fixpoint ~local_iteration:1 rules
+              graph
+          in
+          if
+            factored != rules
+            && factored_grows_transfer ~ctx ~unfactored ~factored
+          then begin
+            counters.factor_transfer_reverts <-
+              counters.factor_transfer_reverts + 1;
+            unfactored
+          end
+          else factored
         end
       in
       (match (cache, key) with

--- a/lib/gzip_size.ml
+++ b/lib/gzip_size.ml
@@ -1,0 +1,136 @@
+(* Estimated DEFLATE (gzip) output size.
+
+   Greedy LZ77 parse -- zlib-style hash chains, 32 KiB window, match lengths
+   3..258 -- costed with RFC 1951's extra-bit tables and an order-0 entropy
+   estimate for literal bytes. A size oracle, not a compressor: absolute values
+   are approximate, differences between candidate spellings of the same
+   stylesheet are what it is for. *)
+
+let window = 32768
+let min_match = 3
+let max_match = 258
+let hash_mask = (1 lsl 15) - 1
+let max_chain = 64
+
+(* RFC 1951 sec. 3.2.5: extra bits of the length code for a match length. *)
+let length_extra_bits len =
+  if len <= 10 then 0
+  else if len <= 18 then 1
+  else if len <= 34 then 2
+  else if len <= 66 then 3
+  else if len <= 130 then 4
+  else if len <= 257 then 5
+  else 0
+
+(* RFC 1951 sec. 3.2.5: extra bits of the distance code for a distance. *)
+let distance_extra_bits dist =
+  let rec log2 n acc = if n <= 1 then acc else log2 (n lsr 1) (acc + 1) in
+  if dist <= 4 then 0 else max 0 (log2 (dist - 1) 0 - 1)
+
+(* Typical dynamic-Huffman code lengths for length and distance symbols; a fixed
+   per-symbol cost is enough when only deltas matter. *)
+let length_symbol_bits = 7
+let distance_symbol_bits = 5
+
+(* Block header, code-length tree, end-of-block and gzip wrapper, in bytes.
+   Constant across candidates; kept so absolute values stay plausible. *)
+let overhead = 24
+
+let hash3 s i =
+  (Char.code (String.unsafe_get s i) lsl 10)
+  lxor (Char.code (String.unsafe_get s (i + 1)) lsl 5)
+  lxor Char.code (String.unsafe_get s (i + 2))
+  land hash_mask
+
+let match_length s i j n =
+  let limit = min max_match (n - i) in
+  let k = ref 0 in
+  while
+    !k < limit && String.unsafe_get s (i + !k) = String.unsafe_get s (j + !k)
+  do
+    incr k
+  done;
+  !k
+
+let match_bits_of ~len ~dist =
+  length_symbol_bits + length_extra_bits len + distance_symbol_bits
+  + distance_extra_bits dist
+
+(* Greedy LZ77 parse of [s]: count each literal byte in [lit_freq] via [literal]
+   and accumulate match token costs into [match_bits]. *)
+let parse s ~literal ~match_bits =
+  let n = String.length s in
+  let i = ref 0 in
+  if n >= min_match then begin
+    let head = Array.make (hash_mask + 1) (-1) in
+    (* [prev] is indexed by absolute position, so chains strictly decrease and
+       need no aliasing guard; the window bound cuts them instead. *)
+    let prev = Array.make n (-1) in
+    let insert i =
+      let h = hash3 s i in
+      prev.(i) <- head.(h);
+      head.(h) <- i
+    in
+    let hash_limit = n - min_match + 1 in
+    while !i < hash_limit do
+      let best_len = ref 0 and best_dist = ref 0 in
+      let j = ref head.(hash3 s !i) and chain = ref max_chain in
+      while !j >= 0 && !chain > 0 && !i - !j <= window do
+        let len = match_length s !i !j n in
+        if len > !best_len then begin
+          best_len := len;
+          best_dist := !i - !j
+        end;
+        decr chain;
+        j := prev.(!j)
+      done;
+      if !best_len >= min_match then begin
+        match_bits :=
+          !match_bits + match_bits_of ~len:!best_len ~dist:!best_dist;
+        let stop = min (!i + !best_len) hash_limit in
+        let next = !i + !best_len in
+        while !i < stop do
+          insert !i;
+          incr i
+        done;
+        i := next
+      end
+      else begin
+        literal !i;
+        insert !i;
+        incr i
+      end
+    done
+  end;
+  while !i < n do
+    literal !i;
+    incr i
+  done
+
+(* Order-0 entropy of the emitted literals, in bits. *)
+let literal_bits lit_freq lit_count =
+  if lit_count = 0 then 0.
+  else begin
+    let total = float_of_int lit_count in
+    let bits = ref 0. in
+    Array.iter
+      (fun f ->
+        if f > 0 then
+          let f = float_of_int f in
+          bits := !bits +. (f *. (log (total /. f) /. log 2.)))
+      lit_freq;
+    !bits
+  end
+
+let estimate s =
+  let lit_freq = Array.make 256 0 in
+  let lit_count = ref 0 in
+  let match_bits = ref 0 in
+  let literal i =
+    let c = Char.code (String.unsafe_get s i) in
+    lit_freq.(c) <- lit_freq.(c) + 1;
+    incr lit_count
+  in
+  parse s ~literal ~match_bits;
+  let bits = float_of_int !match_bits +. literal_bits lit_freq !lit_count in
+  int_of_float (ceil (bits /. 8.)) + overhead

--- a/lib/gzip_size.mli
+++ b/lib/gzip_size.mli
@@ -1,0 +1,8 @@
+(** Estimated DEFLATE (gzip) transfer size. *)
+
+val estimate : string -> int
+(** [estimate s] is the approximate size in bytes of [s] after DEFLATE
+    compression: a greedy LZ77 parse over a 32 KiB window, costed with RFC
+    1951's extra-bit tables and an order-0 entropy estimate for literals.
+    Absolute values are rough; compare candidate spellings of the same CSS,
+    where the sign of the difference is what matters. *)

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -100,6 +100,7 @@ type counters = Stats.counters = {
   mutable factor_fixpoints_skipped : int;
   mutable factor_preflight_gain : int;
   mutable factor_bytes_saved : int;
+  mutable factor_transfer_reverts : int;
 }
 
 let counters = Stats.counters
@@ -1117,7 +1118,8 @@ let drop_unused_custom_props (stmts : statement list) : statement list =
 
 let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
     ?(enforce_spec = false) ?(aggressive = false) ?(closed_world = false)
-    ?(prune_unused_custom_props = false) (stylesheet : t) : t =
+    ?(objective = `Transfer) ?(prune_unused_custom_props = false)
+    (stylesheet : t) : t =
   Selector_summary.clear_memo ();
   reset_counters ();
   let scope = Option.value scope ~default:`Fragment in
@@ -1129,7 +1131,9 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
   let stylesheet = promote_registered_custom_properties ~lossless stylesheet in
   let registered = registered_foldable stylesheet in
   let stylesheet = prune_position_try_fallbacks ~scope stylesheet in
-  let ctx = Ctx.v ~lossless ~aggressive ~closed_world ~registered scope in
+  let ctx =
+    Ctx.v ~lossless ~aggressive ~closed_world ~objective ~registered scope
+  in
   run_pipeline
     ~ctx:(Ctx.with_extend_lists true ctx)
     ~enforce_spec ~aggressive stylesheet

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -49,6 +49,7 @@ val ctx_of_scope :
   ?aggressive:bool ->
   ?extend_lists:bool ->
   ?closed_world:bool ->
+  ?objective:Ctx.objective ->
   scope option ->
   ctx
 (** [ctx_of_scope ?lossless ?aggressive ?extend_lists ?closed_world scope]
@@ -147,6 +148,7 @@ val stylesheet :
   ?enforce_spec:bool ->
   ?aggressive:bool ->
   ?closed_world:bool ->
+  ?objective:Ctx.objective ->
   ?prune_unused_custom_props:bool ->
   t ->
   t
@@ -240,6 +242,8 @@ type counters = {
       (** total raw-byte gain estimated by the global factoring preflight *)
   mutable factor_bytes_saved : int;
       (** total committed byte savings reported by global factoring passes *)
+  mutable factor_transfer_reverts : int;
+      (** factoring results discarded because the estimated DEFLATE size grew *)
 }
 (** Global counters across the last [Optimize.stylesheet] run. *)
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2930,20 +2930,8 @@ let rec pp_filter : filter Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_filter ctx v
 
-(* CSS Backgrounds 3 sec. 3.6: a <position> offset resolves as [offset = P% *
-   (positioning_area - object_size)], so at [0%] the offset is 0 regardless of
-   any size - [0%] is unconditionally [0] here. Fold it under minify (sound only
-   at the <position> boundary; <length-percentage> sizing keeps [0%] because
-   definiteness can make them differ). *)
-let pp_position_length ctx (l : Values.length) =
-  match l with
-  | Pct 0. when Pp.minified ctx -> Pp.char ctx '0'
-  | _ -> pp_length ctx l
-
 let pp_position_offset ctx (lp : Values.length_percentage) =
-  match lp with
-  | (Pct 0. | Length (Pct 0.)) when Pp.minified ctx -> Pp.char ctx '0'
-  | _ -> pp_length_percentage ~always:true ctx lp
+  pp_length_percentage ~always:true ctx lp
 
 let rec pp_position_value : position_value Pp.t =
  fun ctx -> function
@@ -2969,18 +2957,11 @@ let rec pp_position_value : position_value Pp.t =
   | Top_right -> Pp.string ctx "top right"
   | Bottom_left -> Pp.string ctx "bottom left"
   | Bottom_right -> Pp.string ctx "bottom right"
-  | XY (a, b)
-    when Pp.minified ctx && match b with Pct 50. -> true | _ -> false ->
-      (* CSS Backgrounds 3 sec. 3.6: a single-value position sets the horizontal
-         component and defaults the vertical to [center] ([50%]). So [<a> 50%]
-         (e.g. [50% 50%], [10px 50%]) collapses to the single value [<a>], but a
-         non-centred vertical like [0 0] must keep both values. *)
-      pp_position_length ctx a
   | XY (a, b) ->
-      pp_position_length ctx a;
+      pp_length ctx a;
       Pp.space ctx ();
-      pp_position_length ctx b
-  | Single l -> pp_position_length ctx l
+      pp_length ctx b
+  | Single l -> pp_length ctx l
   | Edge_offset_axis (edge, offset, axis) ->
       Pp.string ctx edge;
       Pp.space ctx ();
@@ -2992,7 +2973,7 @@ let rec pp_position_value : position_value Pp.t =
       Pp.space ctx ();
       Pp.string ctx edge;
       Pp.space ctx ();
-      pp_position_length ctx offset
+      pp_length ctx offset
   | Edge_offset_edge_offset (edge1, offset1, edge2, offset2) ->
       Pp.string ctx edge1;
       Pp.space ctx ();
@@ -3018,6 +2999,7 @@ let radial_size_is_default : radial_size -> bool = function
 let position_value_is_center : position_value -> bool = function
   | Center -> true
   | XY (Pct 50., Pct 50.) -> true
+  | Single (Pct 50.) -> true
   | _ -> false
 
 let radial_shape_kept (s : radial_shape option) : radial_shape option =
@@ -3850,29 +3832,89 @@ let normalize_webkit_gradient ?(lossless = false) :
       in
       if stops == r.stops then value else Radial { r with stops }
 
+(* [<position>] spelling canonicalization. CSS Values 4 sec. 6.1: the edge
+   keywords are percentage synonyms ([left] = [top] = [0%], [center] = [50%],
+   [right] = [bottom] = [100%]), a percentage offset of [0%] and the length [0]
+   resolve to the same point, and a single value defaults the vertical component
+   to [center]. Fold every statically-known position to the node the parser
+   produces for its shortest spelling; the printer stays faithful to the node,
+   so a normalized AST and the reparse of its output agree (the structural-hash
+   invariant of [Declaration.v]). *)
+let position_zero (l : Values.length) : Values.length =
+  match l with Pct 0. -> Zero | l -> l
+
+let position_offset_zero (lp : Values.length_percentage) :
+    Values.length_percentage =
+  match lp with Pct 0. | Length (Pct 0.) -> Length Zero | lp -> lp
+
+(* The horizontal and vertical components of a statically-known position; [None]
+   when a component is dynamic ([var()], [calc()], [env()]) or offset from a
+   non-zero edge ([right]/[bottom] offsets need the box size). *)
+let position_xy : position_value -> (Values.length * Values.length) option =
+  let pct n : Values.length = Pct n in
+  let static_offset : Values.length_percentage -> Values.length option =
+    function
+    | Length l -> Some l
+    | Pct n -> Some (pct n)
+    | Env _ | Var _ | Calc _ | Invalid _ -> None
+  in
+  function
+  | Center -> Some (pct 50., pct 50.)
+  | Left -> Some (pct 0., pct 50.)
+  | Right -> Some (pct 100., pct 50.)
+  | Top -> Some (pct 50., pct 0.)
+  | Bottom -> Some (pct 50., pct 100.)
+  | Left_top | Top_left -> Some (pct 0., pct 0.)
+  | Left_center -> Some (pct 0., pct 50.)
+  | Left_bottom | Bottom_left -> Some (pct 0., pct 100.)
+  | Right_top | Top_right -> Some (pct 100., pct 0.)
+  | Right_center -> Some (pct 100., pct 50.)
+  | Right_bottom | Bottom_right -> Some (pct 100., pct 100.)
+  | Center_top -> Some (pct 50., pct 0.)
+  | Center_bottom -> Some (pct 50., pct 100.)
+  | XY (x, y) -> Some (x, y)
+  | Single x -> Some (x, pct 50.)
+  | Edge_offset_axis ("left", off, "center") ->
+      Option.map (fun x -> (x, pct 50.)) (static_offset off)
+  | Edge_offset_axis ("left", off, "top") ->
+      Option.map (fun x -> (x, pct 0.)) (static_offset off)
+  | Axis_edge_offset ("center", "top", off) -> Some (pct 50., off)
+  | Edge_offset_edge_offset ("left", x, "top", y) -> (
+      match (static_offset x, static_offset y) with
+      | Some x, Some y -> Some (x, y)
+      | _ -> None)
+  | _ -> None
+
+(* The parser's node for the shortest spelling of a static (x, y) position: [x]
+   alone when [y] is centred, the [top] / [bottom] keywords when they beat [50%
+   0] / [50% 100%], a plain pair otherwise. *)
+let position_of_xy (x : Values.length) (y : Values.length) : position_value =
+  match (position_zero x, position_zero y) with
+  | x, Pct 50. -> Single x
+  | Pct 50., Zero -> Top
+  | Pct 50., Pct 100. -> Bottom
+  | x, y -> XY (x, y)
+
 let normalize_position_value ?(strip = true) : position_value -> position_value
     =
  fun value ->
-  match value with
-  | XY (x, y) ->
-      preserve_if_equal value
-        (XY (Values.normalize_length ~strip x, Values.normalize_length ~strip y))
-  | Single l ->
-      preserve_if_equal value (Single (Values.normalize_length ~strip l))
-  | Edge_offset_axis (e, lp, a) ->
-      preserve_if_equal value
-        (Edge_offset_axis (e, Values.normalize_length_percentage ~strip lp, a))
-  | Axis_edge_offset (a, e, l) ->
-      preserve_if_equal value
-        (Axis_edge_offset (a, e, Values.normalize_length ~strip l))
-  | Edge_offset_edge_offset (e1, lp1, e2, lp2) ->
-      preserve_if_equal value
-        (Edge_offset_edge_offset
-           ( e1,
-             Values.normalize_length_percentage ~strip lp1,
-             e2,
-             Values.normalize_length_percentage ~strip lp2 ))
-  | other -> other
+  let length l = position_zero (Values.normalize_length ~strip l) in
+  let offset lp =
+    position_offset_zero (Values.normalize_length_percentage ~strip lp)
+  in
+  match position_xy value with
+  | Some (x, y) ->
+      preserve_if_equal value (position_of_xy (length x) (length y))
+  | None -> (
+      match value with
+      | Edge_offset_axis (e, lp, a) ->
+          preserve_if_equal value (Edge_offset_axis (e, offset lp, a))
+      | Axis_edge_offset (a, e, l) ->
+          preserve_if_equal value (Axis_edge_offset (a, e, length l))
+      | Edge_offset_edge_offset (e1, lp1, e2, lp2) ->
+          preserve_if_equal value
+            (Edge_offset_edge_offset (e1, offset lp1, e2, offset lp2))
+      | other -> other)
 
 let normalize_radial_config (c : radial_gradient_config) =
   (* CSS Images 4 section 3.1: inside a radial-gradient() prelude the default
@@ -7952,57 +7994,8 @@ let rec pp_background_size : background_size Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_background_size ctx v
 
-let pp_background_position_value : position_value Pp.t =
- fun ctx value ->
-  let pct n = (Pct n : length) in
-  let length_of_lp : length_percentage -> length option = function
-    | Length l -> Some l
-    | Pct n -> Some (pct n)
-    | Env _ | Var _ | Calc _ | Invalid _ -> None
-  in
-  (* Use [pp_position_length], not [pp_length]: a [<position>] component zero is
-     spelled [0] rather than [0%], so converting a keyword edge to its
-     percentage must compose the same [Pct 0.] -> [0] fold the directly-parsed
-     form gets. Otherwise [left center] prints [0%] here but [0] after a
-     reparse, and the optimizer is not a fixed point. *)
-  let pp_pair ctx x y =
-    pp_position_length ctx x;
-    Pp.space ctx ();
-    pp_position_length ctx y
-  in
-  match value with
-  | Center when Pp.minified ctx -> pp_position_length ctx (pct 50.)
-  | (Left_top | Top_left) when Pp.minified ctx -> pp_pair ctx Zero Zero
-  | (Bottom_left | Left_bottom) when Pp.minified ctx ->
-      pp_pair ctx (pct 0.) (pct 100.)
-  | (Bottom_right | Right_bottom) when Pp.minified ctx ->
-      pp_pair ctx (pct 100.) (pct 100.)
-  | Left_center when Pp.minified ctx -> pp_position_length ctx (pct 0.)
-  | Right_center when Pp.minified ctx -> pp_position_length ctx (pct 100.)
-  | Center_top when Pp.minified ctx -> Pp.string ctx "top"
-  | Center_bottom when Pp.minified ctx -> Pp.string ctx "bottom"
-  | Axis_edge_offset ("center", "top", offset) when Pp.minified ctx ->
-      pp_pair ctx (pct 50.) offset
-  | Edge_offset_axis ("left", offset, "center") -> (
-      match length_of_lp offset with
-      | Some x -> pp_position_length ctx x
-      | None ->
-          pp_position_value ctx (Edge_offset_axis ("left", offset, "center")))
-  | Edge_offset_axis ("left", offset, "top") -> (
-      match length_of_lp offset with
-      | Some x -> pp_pair ctx x (pct 0.)
-      | None -> pp_position_value ctx (Edge_offset_axis ("left", offset, "top"))
-      )
-  | Edge_offset_edge_offset ("left", x, "top", y) -> (
-      match (length_of_lp x, length_of_lp y) with
-      | Some x, Some y -> pp_pair ctx x y
-      | _ ->
-          pp_position_value ctx (Edge_offset_edge_offset ("left", x, "top", y)))
-  | value -> pp_position_value ctx value
-
 let pp_background_position : background_position Pp.t =
- fun ctx positions ->
-  pp_box_shorthand pp_background_position_value ctx positions
+ fun ctx positions -> pp_box_shorthand pp_position_value ctx positions
 
 let pp_bg_prop maybe_space pp_func ctx = function
   | Some value ->
@@ -8225,7 +8218,7 @@ let pp_background_shorthand : background_shorthand Pp.t =
   in
 
   pp_bg_prop maybe_space pp_background_image ctx image;
-  pp_bg_prop maybe_space pp_background_position_value ctx position;
+  pp_bg_prop maybe_space pp_position_value ctx position;
   pp_bg_size_with_position maybe_space { bg with position; size } ctx;
   pp_bg_prop maybe_space pp_background_repeat ctx repeat;
   pp_bg_prop maybe_space pp_background_attachment ctx attachment;

--- a/lib/stats.ml
+++ b/lib/stats.ml
@@ -52,6 +52,7 @@ type counters = {
   mutable factor_fixpoints_skipped : int;
   mutable factor_preflight_gain : int;
   mutable factor_bytes_saved : int;
+  mutable factor_transfer_reverts : int;
 }
 
 let counters =
@@ -62,6 +63,7 @@ let counters =
     factor_fixpoints_skipped = 0;
     factor_preflight_gain = 0;
     factor_bytes_saved = 0;
+    factor_transfer_reverts = 0;
   }
 
 let record_iteration ~fixpoint ~local_iteration ~before_rules ~before_bytes
@@ -93,4 +95,5 @@ let reset () =
   counters.marginal_stops <- 0;
   counters.factor_fixpoints_skipped <- 0;
   counters.factor_preflight_gain <- 0;
-  counters.factor_bytes_saved <- 0
+  counters.factor_bytes_saved <- 0;
+  counters.factor_transfer_reverts <- 0

--- a/lib/stats.mli
+++ b/lib/stats.mli
@@ -60,6 +60,8 @@ type counters = {
       (** total raw-byte gain estimated by the global factoring preflight *)
   mutable factor_bytes_saved : int;
       (** total committed byte savings reported by global factoring passes *)
+  mutable factor_transfer_reverts : int;
+      (** factoring results discarded because the estimated DEFLATE size grew *)
 }
 (** Global counters across the last optimizer run. *)
 

--- a/test/interop/satcss/test.ml
+++ b/test/interop/satcss/test.ml
@@ -17,10 +17,12 @@ let parse path css =
    merges only safe for that specific DOM. [~closed_world:true] is the matching
    opt-in: the caller asserts no element matches two distinct selectors that
    would otherwise tie, so cascade makes the same DOM-dependent merges and the
-   comparison is like-for-like. (cascade's default still assumes any DOM.) *)
+   comparison is like-for-like. (cascade's default still assumes any DOM.)
+   [~objective:`Raw] matches SatCSS's raw-character objective: this suite
+   compares structural rule-merging power, not compressed transfer size. *)
 let cascade_output input =
   input |> parse "input.css"
-  |> Cascade.Css.optimize ~scope:`Stylesheet ~closed_world:true
+  |> Cascade.Css.optimize ~scope:`Stylesheet ~closed_world:true ~objective:`Raw
   |> Cascade.Css.to_string ~minify:false
 
 let satcss_output expected =

--- a/test/test.ml
+++ b/test/test.ml
@@ -37,6 +37,7 @@ let () =
       Test_pool.suite;
       Test_loop.suite;
       Test_stats.suite;
+      Test_gzip_size.suite;
       Test_edge.suite;
       Test_shorthand.suite;
       Test_merge.suite;

--- a/test/test_ctx.ml
+++ b/test/test_ctx.ml
@@ -28,11 +28,11 @@ let test_of_scope_preserves_defaults () =
 let test_pp () =
   Alcotest.(check string)
     "fragment pp"
-    "{scope=fragment;lossless=false;aggressive=false;extend_lists=false;closed_world=false}"
+    "{scope=fragment;lossless=false;aggressive=false;extend_lists=false;closed_world=false;objective=transfer}"
     (Pp.to_string ~minify:true Ctx.pp Ctx.fragment);
   Alcotest.(check string)
     "stylesheet lossless pp"
-    "{scope=stylesheet;lossless=true;aggressive=false;extend_lists=false;closed_world=false}"
+    "{scope=stylesheet;lossless=true;aggressive=false;extend_lists=false;closed_world=false;objective=transfer}"
     (Pp.to_string ~minify:true Ctx.pp
        (Ctx.of_scope ~lossless:true (Some `Stylesheet)))
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1123,12 +1123,13 @@ let spec_property_grammar_table_expansion () =
             ( Some "border-image:linear-gradient(red,blue)30",
               Some "border-image:linear-gradient(red,blue)30" )
         | "background", "url(bg.png) no-repeat center / cover border-box" ->
-            (Some "background:url(bg.png)50%/cover no-repeat border-box", None)
+            ( Some "background:url(bg.png)center/cover no-repeat border-box",
+              Some "background:url(bg.png)50%/cover no-repeat border-box" )
         | "scrollbar-color", "red blue" ->
             (Some "scrollbar-color:red blue", Some "scrollbar-color:red #00f")
         | "border", "1px solid currentColor" -> (Some "border:1px solid", None)
         | "background-position", "left 10px top 20px" ->
-            ( Some "background-position:10px 20px",
+            ( Some "background-position:left 10px top 20px",
               Some "background-position:10px 20px" )
         | "box-shadow", "0 1px 2px rgb(0 0 0 / .2)" ->
             ( Some "box-shadow:0 1px 2px rgb(0 0 0/.2)",
@@ -1680,7 +1681,8 @@ let spec_values_l45_edges () =
         "filter:drop-shadow(0 0 2px rgb(0 0 0/.4))" );
       ( "transform: translate(10px, 20%) rotate(.25turn) scale(1.2)",
         "transform:translate(10px,20%)rotate(.25turn)scale(1.2)" );
-      ("background-position: left 10px top 20%", "background-position:10px 20%");
+      ( "background-position: left 10px top 20%",
+        "background-position:left 10px top 20%" );
       ("border-radius: 10px / 20px", "border-radius:10px/20px");
       ( "clip-path: xywh(0 0 100% 100% round 10px)",
         "clip-path:xywh(0 0 100% 100% round 10px)" );
@@ -1700,6 +1702,9 @@ let spec_values_l45_edges () =
     "translate(10px, 20%) rotate(.25turn) scale(1.2)";
   decl_optimizes ~prop:"background-position" ~into:"10px 20%"
     "left 10px top 20%";
+  decl_optimizes ~prop:"background-position" ~into:"50%" "center";
+  decl_optimizes ~prop:"background-position" ~into:"top" "center top";
+  decl_optimizes ~prop:"mask-position" ~into:"10px 20px" "left 10px top 20px";
   List.iter
     (fun input -> neg_cursor read_declaration input)
     [
@@ -1812,7 +1817,7 @@ let spec_remaining_prop_vectors () =
       ("mask-border: url(mask.svg) 30 fill", "mask-border:url(mask.svg)30 fill");
       ("mask-size: contain", "mask-size:contain");
       ("mask-repeat: no-repeat", "mask-repeat:no-repeat");
-      ("mask-position: left 10px top 20px", "mask-position:10px 20px");
+      ("mask-position: left 10px top 20px", "mask-position:left 10px top 20px");
       ( "backdrop-filter: blur(4px) saturate(120%)",
         "backdrop-filter:blur(4px)saturate(120%)" );
       ("will-change: transform, opacity", "will-change:transform,opacity");

--- a/test/test_gzip_size.ml
+++ b/test/test_gzip_size.ml
@@ -1,0 +1,86 @@
+(** Tests for the DEFLATE transfer-size estimator. *)
+
+open Cascade
+
+(* Deterministic byte stream with no useful LZ structure (xorshift). *)
+let noise n =
+  let state = ref 0x2545F491 in
+  String.init n (fun _ ->
+      let x = !state in
+      let x = x lxor (x lsl 13) in
+      let x = x lxor (x lsr 17) in
+      let x = x lxor (x lsl 5) in
+      state := x land 0x3FFFFFFF;
+      Char.chr (x land 0xff))
+
+let repeat n s = String.concat "" (List.init n (fun _ -> s))
+
+let test_empty () =
+  Alcotest.(check bool)
+    "empty input costs only the wrapper" true
+    (Gzip_size.estimate "" < 32)
+
+let test_repetition_is_cheap () =
+  let block = ".card{color:red;margin:0;padding:4px}" in
+  let sheet = repeat 200 block in
+  let estimate = Gzip_size.estimate sheet in
+  Alcotest.(check bool)
+    "200 identical rules estimate under a tenth of raw size" true
+    (estimate * 10 < String.length sheet)
+
+let test_noise_is_incompressible () =
+  let s = noise 8192 in
+  Alcotest.(check bool)
+    "random bytes estimate near raw size" true
+    (Gzip_size.estimate s * 10 > String.length s * 9)
+
+let test_monotone_in_content () =
+  let a = noise 4096 in
+  let b = String.concat "" [ a; noise 4096 ] in
+  Alcotest.(check bool)
+    "more content never estimates smaller" true
+    (Gzip_size.estimate a <= Gzip_size.estimate b)
+
+let test_repeat_beats_distinct () =
+  (* Same raw length: one declaration block repeated across rules vs distinct
+     declarations per rule; the repeated form must estimate smaller, the
+     property the factoring transfer gate relies on. [100 + i] keeps every index
+     three digits wide so both variants have equal raw length. *)
+  let sel i = String.concat "" [ ".c"; string_of_int (100 + i) ] in
+  let repeated =
+    String.concat ""
+      (List.init 100 (fun i ->
+           String.concat "" [ sel i; "{margin:0;color:red}" ]))
+  in
+  let distinct =
+    String.concat ""
+      (List.init 100 (fun i ->
+           String.concat ""
+             [ sel i; "{margin:"; string_of_int (100 + i); "px 40em}" ]))
+  in
+  Alcotest.(check bool)
+    "same-length repeated declarations estimate smaller" true
+    (Gzip_size.estimate repeated < Gzip_size.estimate distinct)
+
+let test_window_bound () =
+  (* A repeat farther back than 32 KiB cannot be referenced, so two copies of an
+     incompressible block estimate about twice one copy. *)
+  let block = noise 40000 in
+  let one = Gzip_size.estimate block in
+  let two = Gzip_size.estimate (String.concat "" [ block; block ]) in
+  Alcotest.(check bool)
+    "distant repeat pays full price" true
+    (two * 10 > one * 19)
+
+let suite =
+  ( "gzip_size",
+    [
+      Alcotest.test_case "empty" `Quick test_empty;
+      Alcotest.test_case "repetition is cheap" `Quick test_repetition_is_cheap;
+      Alcotest.test_case "noise is incompressible" `Quick
+        test_noise_is_incompressible;
+      Alcotest.test_case "monotone in content" `Quick test_monotone_in_content;
+      Alcotest.test_case "repeat beats distinct" `Quick
+        test_repeat_beats_distinct;
+      Alcotest.test_case "window bound" `Quick test_window_bound;
+    ] )

--- a/test/test_gzip_size.mli
+++ b/test/test_gzip_size.mli
@@ -1,0 +1,3 @@
+(** Unit tests for [Gzip_size]. *)
+
+val suite : string * unit Alcotest.test_case list

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1689,7 +1689,7 @@ let test_background () =
     "linear-gradient(to right, red, blue)";
   decl_optimizes ~prop:"background" ~into:"linear-gradient(90deg,red,#00f)"
     "linear-gradient(to right, red, blue)";
-  check_background ~expected:"url(image.png)50%/cover no-repeat fixed red"
+  check_background ~expected:"url(image.png)center/cover no-repeat fixed red"
     "red url(image.png) center/cover no-repeat fixed";
   (* Multi-layer shorthand (CSS Backgrounds 3 §2.1): the layer comma separates
      layers and must not be eaten by a per-component reader. [repeat] is the
@@ -1959,13 +1959,13 @@ let test_flex_basis () =
 let test_background_shorthand () =
   check_background_shorthand "red";
   check_background_shorthand "url(image.png)";
-  check_background_shorthand ~expected:"50%" "center";
+  check_background_shorthand "center";
   check_background_shorthand "no-repeat";
   check_background_shorthand ~expected:"repeat" "repeat repeat";
   check_background_shorthand ~expected:"url(image.png)red" "red url(image.png)";
-  check_background_shorthand ~expected:"url(image.png)50%"
+  check_background_shorthand ~expected:"url(image.png)center"
     "url(image.png) center";
-  check_background_shorthand ~expected:"url(image.png)50%no-repeat red"
+  check_background_shorthand ~expected:"url(image.png)center no-repeat red"
     "red url(image.png) center no-repeat";
   neg_cursor read_background_shorthand "invalid invalid";
   neg_cursor read_background_shorthand "red blue green";
@@ -2531,10 +2531,10 @@ let test_background_image () =
     ~into:"conic-gradient(in hsl longer hue,red,#00f)"
     "conic-gradient(in hsl longer hue, red, blue)";
   decl_optimizes ~prop:"background-image"
-    ~into:"conic-gradient(in hsl longer hue from 45deg at center,red,#00f)"
+    ~into:"conic-gradient(in hsl longer hue from 45deg at 50%,red,#00f)"
     "conic-gradient(in hsl longer hue from 45deg at center, red, blue)";
   decl_optimizes ~prop:"background-image"
-    ~into:"conic-gradient(in hsl longer hue from 45deg at center,red,#00f)"
+    ~into:"conic-gradient(in hsl longer hue from 45deg at 50%,red,#00f)"
     "conic-gradient(from 45deg at center in hsl longer hue, red, blue)";
   check_background_image ~minify:false
     ~expected:"radial-gradient(in oklab, red, blue)"
@@ -2584,8 +2584,8 @@ let test_conic_gradient_config () =
   neg_cursor read_conic_gradient_config "from"
 
 let test_background_position () =
-  check_background_position ~expected:"50%" "center";
-  check_background_position ~expected:"0 0" "left top";
+  check_background_position "center";
+  check_background_position "left top";
   check_background_position ~expected:"100% 0" "right 0";
   check_background_position ~expected:"100% -15.625rem" "right -15.625rem";
   check_background_position "right .5rem center";


### PR DESCRIPTION
This PR makes `--minify` judge global factoring by estimated gzip transfer size instead of raw bytes: a factored segment whose DEFLATE-estimated size grows is reverted, and a new `objective` knob (`Transfer` default, `Raw` opt-out, CLI `--objective=raw`) keeps the raw-byte behaviour for uncompressed targets and for the SatCSS structural-oracle suite.

Factoring replaces repeated declaration text with unique selector-list structure. Raw bytes shrink, but repeats within DEFLATE's window are nearly free, so on the real-world benchmark sheets the factored output gzipped larger than the unfactored one (on youtube, larger than the unminified input). With the gate, cascade emits the smallest gzip output of the compared minifiers on all four bench sites:

```
site      cascade   next best
github      34287   34420 (lightningcss)
guardian    25977   26008 (lightningcss)
youtube     33777   33930 (cssnano)
netflix     29495   31411 (cssnano)
```

(bench/minifier_comparison.sh, gzip -9 bytes; brotli is smallest on three of four sites)

Commit f5482eb4 is a prerequisite fix: pp folded `<position>` keyword and `0%` spellings only under minify, so a normalized AST and the reparse of its own output could print identically yet hash differently, making factoring order depend on which spelling produced the AST; the folds now live in normalize and pp serialises faithfully.