### PR TITLE
css: reorder conditional blocks in the canonical rule order

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,14 @@ usable as a CI check.
 - `string`: character-level comparison.
 - `canonical`: passes when the two inputs share cascade's canonical minified
   form, modulo cascade-neutral reordering. Declarations or rules whose
-  footprints are disjoint (they write different properties) may swap freely, and
-  distinct custom properties may swap within any rule, since none of those moves
-  can change a computed value. Cascade-significant order is kept distinct (two
+  footprints are disjoint (they write different properties) may swap freely,
+  a `@media`/`@supports`/`@container` block containing only plain rules moves
+  as a unit past statements its rules cannot conflict with, and distinct
+  custom properties may swap within any rule, since none of those moves can
+  change a computed value. Cascade-significant order is kept distinct (two
   writes of the same property, a shorthand and its longhand, a vendor-prefixed
-  alias). Equivalent shorthand decompositions are still not modelled.
+  alias, `@layer` blocks). Equivalent shorthand decompositions are still not
+  modelled.
 
 <!-- $MDX skip -->
 ```bash

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7578,11 +7578,14 @@ val of_string_exn :
     Tools for optimizing CSS output for performance and file size. *)
 
 val canonicalize_rule_order : t -> t
-(** [canonicalize_rule_order t] reorders cascade-independent rules into a
+(** [canonicalize_rule_order t] reorders cascade-independent statements into a
     deterministic order (a content-keyed linear extension of the
     cascade-conflict graph), so two stylesheets that differ only by a
-    cascade-safe rule reorder project to the same form. Conflicting rules keep
-    their relative order. This is a comparison-side normalisation;
+    cascade-safe reorder project to the same form. A [@media] / [@supports] /
+    [@container] block whose transitive content is plain rules moves as one
+    unit, keyed by the union of its rules' conflict footprints; conflicting
+    statements keep their relative order, and named [@layer] blocks pin the
+    layer order where they stand. This is a comparison-side normalisation;
     {!val-optimize} stays source-stable. *)
 
 val optimize :

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -1,18 +1,62 @@
-(** Canonical cascade-safe rule ordering: project each run of reorderable rules
-    through {!Rule_graph} to its canonical linear extension. *)
+(** Canonical cascade-safe rule ordering: project each run of reorderable
+    statements through {!Rule_graph} to its canonical linear extension. *)
 
 open Stylesheet
 
-(* A rule is reorderable only when it is a plain style rule with no nested
-   block; a rule that carries nesting is a barrier whose own body is
-   canonicalised separately. Custom-property declarations are reorderable too:
-   the dependency graph keys each custom property by name, so two writers of the
-   same property on overlapping selectors keep their order, while a [var()]
-   reader - which writes its own property, not the one it reads - moves freely
-   past the definition. At-rules and everything else are barriers that split a
-   run. *)
-let reorderable = function Rule r -> r.nested = [] | _ -> false
-let rule_of = function Rule r -> r | _ -> invalid_arg "Rule_order.rule_of"
+(* A run element is a plain style rule with no nested block, or a conditional
+   at-rule block ([@media] / [@supports] / [@container]) whose transitive
+   content is itself only such elements. The block moves atomically; its
+   contained rules supply the conflict footprint. Custom-property declarations
+   are reorderable too: the dependency graph keys each custom property by name,
+   so two writers of the same property on overlapping selectors keep their
+   order, while a [var()] reader - which writes its own property, not the one it
+   reads - moves freely past the definition. A named [@layer] block or [@layer]
+   declaration pins the layer order at its first occurrence, so it stays a
+   barrier, as does everything else. *)
+let rec element_rules (stmt : statement) : rule list option =
+  match stmt with
+  | Rule r -> if r.nested = [] then Some [ r ] else None
+  | Media (_, b) | Supports (_, b) | Container (_, _, b) -> block_rules b
+  | _ -> None
+
+and block_rules (stmts : statement list) : rule list option =
+  List.fold_left
+    (fun acc stmt ->
+      match (acc, element_rules stmt) with
+      | Some acc, Some rules -> Some (List.rev_append rules acc)
+      | _ -> None)
+    (Some []) stmts
+
+(* The graph node standing for one element. A block collapses to a single
+   pseudo-rule holding every contained selector branch and declaration: its edge
+   set is the cross product, a superset of the true per-rule edges, so conflict
+   detection stays conservative while the block reorders as one unit. The
+   applicability condition itself is irrelevant to safety: whether or not the
+   condition holds, a swap with a non-conflicting neighbour cannot change any
+   computed value. *)
+let element_node (stmt : statement) (rules : rule list) : rule =
+  match (stmt, rules) with
+  | Rule r, _ -> r
+  | _, [] ->
+      {
+        selector = Selector.universal;
+        declarations = [];
+        nested = [];
+        merge_key = None;
+      }
+  | _, rules ->
+      let branches =
+        List.concat_map (fun (r : rule) -> Edge.selectors r.selector) rules
+      in
+      let selector =
+        match branches with [ sel ] -> sel | sels -> Selector.List sels
+      in
+      {
+        selector;
+        declarations = List.concat_map (fun (r : rule) -> r.declarations) rules;
+        nested = [];
+        merge_key = None;
+      }
 
 let is_identity order =
   let id = ref true in
@@ -21,21 +65,27 @@ let is_identity order =
     order;
   !id
 
-(* Reorder one maximal run of reorderable rules into a canonical linear
-   extension of its dependency graph, breaking ties among independent rules by
-   serialized rule content so two source orderings converge to one form, while
+(* Reorder one maximal run of elements into a canonical linear extension of its
+   dependency graph, breaking ties among independent elements by serialized
+   statement content so two source orderings converge to one form, while
    preserving physical identity when that order already matches the input.
    [parent], when set, is the enclosing nesting context: the graph expands each
-   rule's relative selector against it so overlap is computed on the effective
-   selector. *)
-let sort_run ?parent changed (run : statement list) : statement list =
+   element's relative selectors against it so overlap is computed on the
+   effective selector. *)
+let sort_run ?parent changed (run : (statement * rule list) list) :
+    statement list =
   let arr = Array.of_list run in
   let n = Array.length arr in
-  if n < 2 then run
+  if n < 2 then List.map fst run
   else
-    let g = Rule_graph.of_rules ?parent (List.map rule_of run) in
+    let g =
+      Rule_graph.of_rules ?parent
+        (List.map (fun (stmt, rules) -> element_node stmt rules) run)
+    in
     let keys =
-      Array.map (fun s -> Pp.to_string ~minify:true pp_rule (rule_of s)) arr
+      Array.map
+        (fun (stmt, _) -> Pp.to_string ~minify:true pp_stylesheet [ stmt ])
+        arr
     in
     let ranked = Array.init n (fun i -> i) in
     Array.sort
@@ -50,11 +100,11 @@ let sort_run ?parent changed (run : statement list) : statement list =
       Rule_graph.canonical_order_by g (fun node ->
           rank.(Rule_graph.Node_id.to_int node))
     in
-    if is_identity order then run
+    if is_identity order then List.map fst run
     else begin
       changed := true;
       Array.to_list
-        (Array.map (fun i -> arr.(Rule_graph.Node_id.to_int i)) order)
+        (Array.map (fun i -> fst arr.(Rule_graph.Node_id.to_int i)) order)
     end
 
 (* Canonicalise every cascade context. At-rule block bodies inherit the current
@@ -89,16 +139,24 @@ let rec recurse ~(parent : Selector.t option) changed (stmt : statement) :
 
 and canonicalize_block ~parent changed (stmts : statement list) : statement list
     =
+  (* Canonicalise interiors first so run elements are ranked on their canonical
+     serialized form. *)
+  let stmts = List.map (recurse ~parent changed) stmts in
   let rec go = function
     | [] -> []
-    | stmt :: rest when reorderable stmt ->
-        let rec take acc = function
-          | s :: r when reorderable s -> take (s :: acc) r
-          | r -> (List.rev acc, r)
-        in
-        let run, rest = take [ stmt ] rest in
-        sort_run ?parent changed run @ go rest
-    | stmt :: rest -> recurse ~parent changed stmt :: go rest
+    | stmt :: rest -> (
+        match element_rules stmt with
+        | Some rules ->
+            let rec take acc = function
+              | s :: r as l -> (
+                  match element_rules s with
+                  | Some rs -> take ((s, rs) :: acc) r
+                  | None -> (List.rev acc, l))
+              | [] -> (List.rev acc, [])
+            in
+            let run, rest = take [ (stmt, rules) ] rest in
+            sort_run ?parent changed run @ go rest
+        | None -> stmt :: go rest)
   in
   go stmts
 

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -69,6 +69,40 @@ equivalent spellings.
   $ cascade diff --diff=canonical i.css j.css
   CSS files are identical
 
+Canonical mode also accepts moving a rule past a conditional block when their
+contents cannot conflict (here [display] on one selector vs [flex-grow] on
+others), including when a same-condition block was split around the rule.
+
+  $ cat > grouped.css <<EOF
+  > @layer utilities{.md\:block{display:block}@media (min-width:48rem){.md\:flex-grow,.md\:grow{flex-grow:1}}}
+  > EOF
+  $ cat > split.css <<EOF
+  > @layer utilities{@media (min-width:48rem){.md\:flex-grow{flex-grow:1}}.md\:block{display:block}@media (min-width:48rem){.md\:grow{flex-grow:1}}}
+  > EOF
+  $ cascade diff --diff=canonical grouped.css split.css
+  CSS files are identical
+
+A conditional block whose rules write the same property on the same selector
+stays ordered: swapping it with the rule is a real difference.
+
+  $ cat > before.css <<EOF
+  > .a{display:block}@media print{.a{display:flex}}
+  > EOF
+  $ cat > after.css <<EOF
+  > @media print{.a{display:flex}}.a{display:block}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=canonical before.css after.css
+  cascade: CSS files differ
+  CSS: 48 chars vs 48 chars (0.0% diff)
+  Changes: 1 reordered rule
+  
+  --- before.css
+  +++ after.css
+  Rules reordered (1 rules):
+  └─ .a ↔  @media print
+  
+  [124]
+
 
 
 The --diff=string mode falls back to character-level diffing.

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -29,6 +29,58 @@ let custom_property_position_converges () =
     "definition before the user" want
     (canonical ":root{--b:1}.x{filter:blur(var(--b))}")
 
+let media_and_independent_rule_converge () =
+  (* A conditional block whose rules cannot conflict with a neighbouring rule
+     reorders with it, so both source orderings reach one canonical form. *)
+  let grouped = ".a{display:block}@media (min-width:48rem){.b{flex-grow:1}}" in
+  let split = "@media (min-width:48rem){.b{flex-grow:1}}.a{display:block}" in
+  Alcotest.(check string)
+    "both orders converge" (canonical grouped) (canonical split);
+  Alcotest.(check bool)
+    "rule sorts before the block" true
+    (String.length (canonical split) > 2
+    && String.sub (canonical split) 0 2 = ".a")
+
+let media_conflict_keeps_source_order () =
+  (* The media rule writes the same property on the same selector, so the
+     relative order is cascade-significant and both spellings stay put. *)
+  let media_first = "@media print{.a{display:flex}}.a{display:block}" in
+  let rule_first = ".a{display:block}@media print{.a{display:flex}}" in
+  Alcotest.(check string)
+    "media first stays"
+    (render (statements media_first))
+    (canonical media_first);
+  Alcotest.(check string)
+    "rule first stays"
+    (render (statements rule_first))
+    (canonical rule_first)
+
+let layer_blocks_stay_put () =
+  (* [@layer] order pins cascade-layer priority at first occurrence; layer
+     blocks are barriers. *)
+  let css = "@layer b{.y{color:blue}}@layer a{.x{color:red}}" in
+  Alcotest.(check string)
+    "layer blocks keep source order"
+    (render (statements css))
+    (canonical css)
+
+let block_with_layer_content_is_barrier () =
+  (* A conditional block is only reorderable when its transitive content is
+     plain rules; a nested [@layer] pins it in place. *)
+  let css = "@media print{@layer a{.x{color:red}}}.b{margin:0}" in
+  Alcotest.(check string)
+    "media wrapping a layer stays put"
+    (render (statements css))
+    (canonical css)
+
+let nested_conditionals_participate () =
+  let css =
+    "@media print{@supports (display:flex){.z{color:red}}}.b{margin:0}"
+  in
+  Alcotest.(check bool)
+    "independent rule sorts before the nested block" true
+    (String.length (canonical css) > 2 && String.sub (canonical css) 0 2 = ".b")
+
 let suite =
   ( "rule_order",
     [
@@ -38,4 +90,13 @@ let suite =
         keeps_conflicting_rules_in_source_order;
       Alcotest.test_case "custom-property position converges" `Quick
         custom_property_position_converges;
+      Alcotest.test_case "media and independent rule converge" `Quick
+        media_and_independent_rule_converge;
+      Alcotest.test_case "media conflict keeps source order" `Quick
+        media_conflict_keeps_source_order;
+      Alcotest.test_case "layer blocks stay put" `Quick layer_blocks_stay_put;
+      Alcotest.test_case "block with layer content is barrier" `Quick
+        block_with_layer_content_is_barrier;
+      Alcotest.test_case "nested conditionals participate" `Quick
+        nested_conditionals_participate;
     ] )


### PR DESCRIPTION
This PR extends `canonicalize_rule_order` so a `@media`/`@supports`/`@container` block whose transitive content is plain rules participates in the canonical statement order as one atomic unit, keyed by the union of its rules' conflict footprints.

Previously every at-rule was a reorder barrier, so `cascade diff --diff=canonical` reported a reorder between two semantically identical sheets whenever a same-condition media block was split around a rule it cannot conflict with (the optimizer merges the split blocks at the first occurrence, leaving the two sides differing only in rule-vs-block order):

```
$ cascade diff --diff=canonical d-grouped.css d-split.css
└─ @layer utilities (1 reordered)
   └─ .md\:block ↔  @media (width >= 48rem)
```

Both orders now canonicalize to the same form and compare identical. Conflict detection reuses the existing `Rule_graph` machinery (the block collapses to a pseudo-rule whose edge set is a conservative superset of its rules'), so a block that writes the same property on an overlapping equal-specificity selector still keeps its source order, and `@layer` blocks (whose order pins cascade-layer priority) stay barriers.