### PR TITLE
optimize: always merge adjacent identical-body rules

### DIFF
--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -400,7 +400,12 @@ and rules_aux ?factor_cache ~ctx ~enforce_spec (rules : rule list) : rule list =
      optimizations above always run; this incremental gate only decides whether
      the expensive global factoring fixpoint is likely to buy enough bytes to
      justify the full indexed scheduler walk. *)
-  factor_rules_incremental ?cache:factor_cache ~ctx prepared
+  let factored = factor_rules_incremental ?cache:factor_cache ~ctx prepared in
+  (* After factoring so the greedy scheduler sees the unconstrained input (a
+     local pre-merge can lock a pair together and hide a larger group): this
+     only picks up the merges factoring did not make because its preflight
+     skipped the run or the transfer gate discarded its result. *)
+  Rule.merge_adjacent_identical ~ctx factored
 
 (* CSS Animations 2 sec. 4.1: [@keyframes name] re-declaration overrides the
    earlier definition in source order. Drop earlier same-name keyframes; the

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -320,3 +320,54 @@ let drop_shadowed_declarations (rules : rule list) : rule list =
 
 let drop_shadowed rules =
   rules |> drop_shadowed_declarations |> drop_shadowed_rules
+
+(* Adjacent identical-body merging. Two neighbouring rules with the same
+   declarations apply those declarations identically whether split or grouped
+   under one selector list, so the merge is cascade-safe for any DOM with no
+   ordering analysis, and it shrinks raw and compressed output alike. It runs
+   with the always-on local rewrites: the global factoring engine also finds
+   these groups (plus non-adjacent ones), but only when its preflight predicts
+   enough total gain, and its result is discarded wholesale when the transfer
+   estimate grows - neither gamble should cost the obvious local merge. *)
+let adjacent_merge_eligible ~ctx (r : rule) =
+  r.nested = [] && r.merge_key = None
+  && (not (Merge.vendor r.selector))
+  && (Ctx.extend_lists ctx || not (Selector.is_compound_list r.selector))
+  && not (List.exists Shorthand.is_all_declaration r.declarations)
+
+let merged_selector group =
+  Selector.canonicalize
+    (Merge.selector_list
+       (List.concat_map (fun (r : rule) -> Edge.selectors r.selector) group))
+
+let merge_adjacent_identical ~ctx (rules : rule list) : rule list =
+  let bodies_equal a b =
+    Merge.declarations_equal ~same:Shorthand.same_minified_declaration a b
+  in
+  let changed = ref false in
+  let rec go = function
+    | [] -> []
+    | r :: rest when adjacent_merge_eligible ~ctx r && r.declarations <> [] ->
+        let rec take group = function
+          | s :: tail
+            when adjacent_merge_eligible ~ctx s
+                 && bodies_equal r.declarations s.declarations
+                 && List.for_all
+                      (fun (g : rule) -> Merge.compatible g.selector s.selector)
+                      group ->
+              take (s :: group) tail
+          | tail -> (group, tail)
+        in
+        let group, rest = take [ r ] rest in
+        let merged =
+          match group with
+          | [ _ ] -> r
+          | group ->
+              changed := true;
+              { r with selector = merged_selector (List.rev group) }
+        in
+        merged :: go rest
+    | r :: rest -> r :: go rest
+  in
+  let result = go rules in
+  if !changed then result else rules

--- a/lib/rule.mli
+++ b/lib/rule.mli
@@ -9,3 +9,10 @@ val finalize :
 
 val drop_shadowed : Stylesheet.rule list -> Stylesheet.rule list
 (** Drop same-selector shadowed rules and declarations. *)
+
+val merge_adjacent_identical :
+  ctx:Ctx.t -> Stylesheet.rule list -> Stylesheet.rule list
+(** Merge each maximal run of adjacent rules whose declaration bodies are
+    identical into one selector-list rule. Cascade-safe for any DOM: the same
+    declarations apply either way. Runs with the always-on local rewrites,
+    independent of the gated global factoring. *)

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -782,6 +782,31 @@ let test_transform_origin_zero_folds () =
   same ".x{transform-origin:50%}" ".x{transform-origin:50% 50%}";
   same ".x{transform-origin:10px 20px}" ".x{transform-origin:10px 20px}"
 
+(* Adjacent identical-body rules must merge even on a sheet whose factoring
+   preflight predicts too little gain to run the global scheduler: the merge is
+   a local always-on rewrite. The filler rules share nothing, so the only
+   predicted gain is the one duplicate body, far below the preflight
+   threshold. *)
+let test_adjacent_merge_survives_preflight_skip () =
+  let filler =
+    List.init 1200 (fun i ->
+        String.concat ""
+          [
+            ".r"; string_of_int i; "{margin-left:"; string_of_int (i + 1); "px}";
+          ])
+  in
+  let css =
+    String.concat ""
+      (filler @ [ ".flex-grow{flex-grow:1}"; ".grow{flex-grow:1}" ])
+  in
+  match Css.of_string css with
+  | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
+  | Ok { Css.stylesheet; _ } ->
+      let out = minify stylesheet in
+      Alcotest.(check bool)
+        "adjacent duplicate bodies merged on a preflight-skipped sheet" true
+        (Astring.String.is_infix ~affix:".flex-grow,.grow{flex-grow:1}" out)
+
 let optimize_tests =
   [
     ( "var() colour functions preserved",
@@ -790,6 +815,9 @@ let optimize_tests =
     ( "transform-origin zero components fold to 0",
       `Quick,
       test_transform_origin_zero_folds );
+    ( "adjacent merge survives preflight skip",
+      `Quick,
+      test_adjacent_merge_survives_preflight_skip );
     ( "optimize preserves physical identity on a fixed point",
       `Quick,
       test_optimize_preserves_physical_identity );

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -56,6 +56,35 @@ let test_drop_shadowed_selector_list_requires_all_branches () =
     [ ".a{color:blue}"; ".b{color:green}" ]
     (rule_strings optimized)
 
+let extend_ctx = Ctx.with_extend_lists true Ctx.fragment
+
+let test_merge_adjacent_identical_bodies () =
+  let merged =
+    Rule.merge_adjacent_identical ~ctx:extend_ctx
+      (rules ".flex-grow{flex-grow:1}.grow{flex-grow:1}.basis-0{flex-basis:0}")
+  in
+  Alcotest.(check (list string))
+    "adjacent identical bodies merge into a selector list"
+    [ ".flex-grow,.grow{flex-grow:1}"; ".basis-0{flex-basis:0}" ]
+    (rule_strings merged)
+
+let test_merge_adjacent_skips_intervening_rule () =
+  let input = rules ".a{color:red}.mid{margin:0}.b{color:red}" in
+  let merged = Rule.merge_adjacent_identical ~ctx:extend_ctx input in
+  Alcotest.(check bool)
+    "non-adjacent identical bodies stay split, input physically unchanged" true
+    (merged == input)
+
+let test_merge_adjacent_skips_vendor_pseudo () =
+  (* A selector list with an unsupported vendor branch invalidates the whole
+     rule in other engines, so vendor pseudo-elements never share a list. *)
+  let input =
+    rules "::-webkit-scrollbar{display:none}::-moz-focus-inner{display:none}"
+  in
+  let merged = Rule.merge_adjacent_identical ~ctx:extend_ctx input in
+  Alcotest.(check bool)
+    "vendor pseudo-element selectors never share a list" true (merged == input)
+
 let suite =
   ( "rule",
     [
@@ -67,4 +96,10 @@ let suite =
         `Quick test_drop_shadowed_declarations_keeps_live_properties;
       Alcotest.test_case "drop shadowed selector list requires all branches"
         `Quick test_drop_shadowed_selector_list_requires_all_branches;
+      Alcotest.test_case "merge adjacent identical bodies" `Quick
+        test_merge_adjacent_identical_bodies;
+      Alcotest.test_case "merge adjacent skips intervening rule" `Quick
+        test_merge_adjacent_skips_intervening_rule;
+      Alcotest.test_case "merge adjacent skips vendor pseudo" `Quick
+        test_merge_adjacent_skips_vendor_pseudo;
     ] )


### PR DESCRIPTION
This PR adds `Rule.merge_adjacent_identical`, an always-on local rewrite that merges each maximal run of adjacent rules with identical declaration bodies into one selector-list rule, and runs it after the global factoring step.

Identical-body grouping used to live only in the gated global factoring engine, so it was skipped whenever the preflight predicted too little total gain (a full Tailwind sheet with a handful of duplicate utility bodies stays far below the threshold) and discarded whenever the transfer gate rejected the factoring result as a whole. `Css.optimize` on tw's generated output left obvious neighbours split:

```
.flex-shrink-0{flex-shrink:0}.shrink-0{flex-shrink:0}.flex-grow{flex-grow:1}.grow{flex-grow:1}
```

The adjacent case needs no ordering analysis (the same declarations apply either way, for any DOM) and shrinks raw and compressed output alike, so it belongs with the local rewrites that always run. It runs after factoring rather than before because a local pre-merge can lock a pair together and hide a larger group from the greedy scheduler (the split-shorthand confluence test catches exactly that). Vendor pseudo-element selectors are excluded as in the factoring engine, since a selector list with an unsupported branch invalidates the whole rule.

On the SatCSS bench this is a small across-the-board win (github gzip 34,287 to 34,275; netflix 29,495 to 29,466).