### PR TITLE
css: project equivalent factorings to one canonical form

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,15 +139,17 @@ usable as a CI check.
   "identical".
 - `string`: character-level comparison.
 - `canonical`: passes when the two inputs share cascade's canonical minified
-  form, modulo cascade-neutral reordering. Declarations or rules whose
-  footprints are disjoint (they write different properties) may swap freely,
-  a `@media`/`@supports`/`@container` block containing only plain rules moves
-  as a unit past statements its rules cannot conflict with, and distinct
-  custom properties may swap within any rule, since none of those moves can
-  change a computed value. Cascade-significant order is kept distinct (two
-  writes of the same property, a shorthand and its longhand, a vendor-prefixed
-  alias, `@layer` blocks). Equivalent shorthand decompositions are still not
-  modelled.
+  form, modulo cascade-neutral reordering and regrouping. Declarations or
+  rules whose footprints are disjoint (they write different properties) may
+  swap freely, a `@media`/`@supports`/`@container` block containing only
+  plain rules moves as a unit past statements its rules cannot conflict with,
+  distinct custom properties may swap within any rule, and different
+  factorings of the same content (a declaration hoisted into a shared
+  selector-list group vs written inline, split vs grouped selector lists)
+  compare equal, since none of those moves can change a computed value.
+  Cascade-significant order is kept distinct (two writes of the same
+  property, a shorthand and its longhand, a vendor-prefixed alias, `@layer`
+  blocks). Equivalent shorthand decompositions are still not modelled.
 
 <!-- $MDX skip -->
 ```bash

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7578,15 +7578,17 @@ val of_string_exn :
     Tools for optimizing CSS output for performance and file size. *)
 
 val canonicalize_rule_order : t -> t
-(** [canonicalize_rule_order t] reorders cascade-independent statements into a
-    deterministic order (a content-keyed linear extension of the
-    cascade-conflict graph), so two stylesheets that differ only by a
-    cascade-safe reorder project to the same form. A [@media] / [@supports] /
-    [@container] block whose transitive content is plain rules moves as one
-    unit, keyed by the union of its rules' conflict footprints; conflicting
-    statements keep their relative order, and named [@layer] blocks pin the
-    layer order where they stand. This is a comparison-side normalisation;
-    {!val-optimize} stays source-stable. *)
+(** [canonicalize_rule_order t] projects cascade-equivalent stylesheets to one
+    deterministic form: selector-list rules expand onto their branches,
+    same-selector rules coalesce when no intervening write can observe the move
+    (so a declaration hoisted into a shared group and the same declaration
+    written inline converge), and cascade-independent statements sort into a
+    content-keyed linear extension of the cascade-conflict graph. A [@media] /
+    [@supports] / [@container] block whose transitive content is plain rules
+    moves as one unit, keyed by the union of its rules' conflict footprints;
+    conflicting statements keep their relative order, and named [@layer] blocks
+    pin the layer order where they stand. This is a comparison-side
+    normalisation; {!val-optimize} stays source-stable. *)
 
 val optimize :
   ?scope:Optimize.scope ->

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -107,6 +107,153 @@ let sort_run ?parent changed (run : (statement * rule list) list) :
         (Array.map (fun i -> fst arr.(Rule_graph.Node_id.to_int i)) order)
     end
 
+(* A grouped rule is semantically the sequence of its per-branch rules, and a
+   hoisted shared declaration is the same declaration written inline, so two
+   sheets that factor the same content differently ([.absolute,.sr-only
+   {position:absolute}] on one side, the declaration kept inline in [.sr-only]
+   on the other) only project to one canonical form if grouping is undone first:
+   expand every selector-list rule into singleton-branch rules, then coalesce
+   same-selector rules whose merge no intervening write can observe. *)
+let expand_lists (stmt : statement) : statement list =
+  match stmt with
+  | Rule r when r.nested = [] && r.merge_key = None -> (
+      match Edge.selectors r.selector with
+      | [] | [ _ ] -> [ stmt ]
+      | branches -> List.map (fun selector -> Rule { r with selector }) branches
+      )
+  | _ -> [ stmt ]
+
+(* Exact duplicates across coalesced occurrences collapse to the later one;
+   distinct values of the same property keep both writes in order, which
+   resolves identically to the split form. *)
+let dedup_keep_last decls =
+  let rec keep = function
+    | [] -> []
+    | d :: rest ->
+        if List.exists (Shorthand.same_minified_declaration d) rest then
+          keep rest
+        else d :: keep rest
+  in
+  keep decls
+
+(* Mutable state of one coalescing scan: the run's elements, the graph nodes
+   accumulated into each surviving element, and which elements remain. *)
+type scan = {
+  graph : Rule_graph.t;
+  arr : (statement * rule list) array;
+  members : int list array;
+  alive : bool array;
+  mutable merged_any : bool;
+}
+
+(* Nothing strictly between [lo] and [hi] conflicts with any accumulated
+   occurrence in [mems]: moving those writes across the interval is
+   unobservable. *)
+let interval_clear scan ~lo ~hi mems =
+  let node i = Rule_graph.Node_id.of_int_exn i in
+  let ok = ref true in
+  for m = lo + 1 to hi - 1 do
+    if
+      List.exists
+        (fun a -> Rule_graph.conflict scan.graph (node m) (node a))
+        mems
+    then ok := false
+  done;
+  !ok
+
+let merge scan changed ~from ~into =
+  (match (scan.arr.(from), scan.arr.(into)) with
+  | (Rule rf, _), (Rule ri, _) ->
+      let earlier, later = if from < into then (rf, ri) else (ri, rf) in
+      let merged =
+        {
+          earlier with
+          declarations =
+            dedup_keep_last (earlier.declarations @ later.declarations);
+        }
+      in
+      scan.arr.(into) <- (Rule merged, [ merged ])
+  | _ -> assert false);
+  scan.members.(into) <- scan.members.(from) @ scan.members.(into);
+  scan.alive.(from) <- false;
+  scan.merged_any <- true;
+  changed := true
+
+(* Fold the earlier occurrence [i] down into [j] when nothing in between
+   observes its writes moving; otherwise fold [j]'s writes up into [i] when
+   nothing in between observes those. *)
+let try_merge scan changed ~last ~key i j =
+  if interval_clear scan ~lo:i ~hi:j scan.members.(i) then begin
+    merge scan changed ~from:i ~into:j;
+    Hashtbl.replace last key j
+  end
+  else if interval_clear scan ~lo:i ~hi:j scan.members.(j) then
+    merge scan changed ~from:j ~into:i
+  else Hashtbl.replace last key j
+
+(* Coalesce same-selector singleton rules within one run. Folding an occurrence
+   into another moves its declarations past every element in between, which is
+   observable only if one of those elements conflicts with the moved rule; the
+   conflict test is the graph's, against every original occurrence already
+   accumulated into the surviving element. *)
+let coalesce ?parent changed (run : (statement * rule list) list) :
+    (statement * rule list) list =
+  match run with
+  | [] | [ _ ] -> run
+  | _ ->
+      let arr = Array.of_list run in
+      let n = Array.length arr in
+      let graph =
+        Rule_graph.of_rules ?parent
+          (List.map (fun (stmt, rules) -> element_node stmt rules) run)
+      in
+      let scan =
+        {
+          graph;
+          arr;
+          members = Array.init n (fun i -> [ i ]);
+          alive = Array.make n true;
+          merged_any = false;
+        }
+      in
+      let selector_key i =
+        match arr.(i) with
+        | Rule r, _ when r.merge_key = None ->
+            Some (Pp.to_string ~minify:true Selector.pp r.selector)
+        | _ -> None
+      in
+      let last = Hashtbl.create 16 in
+      for j = 0 to n - 1 do
+        match selector_key j with
+        | None -> ()
+        | Some key -> (
+            match Hashtbl.find_opt last key with
+            | Some i when scan.alive.(i) ->
+                try_merge scan changed ~last ~key i j
+            | _ -> Hashtbl.replace last key j)
+      done;
+      if not scan.merged_any then run
+      else Array.to_list arr |> List.filteri (fun i _ -> scan.alive.(i))
+
+(* Sort and coalesce to a fixed point: sorting can empty the interval between
+   two same-selector occurrences that a conflicting element previously kept
+   apart, enabling a merge the source order hid, so equivalent sheets converge
+   regardless of which arrangement they started from. Each merging round removes
+   at least one element, so this terminates. *)
+let rec settle ?parent changed (run : (statement * rule list) list) :
+    statement list =
+  let stmts = sort_run ?parent changed run in
+  let sorted =
+    List.filter_map
+      (fun s ->
+        match element_rules s with
+        | Some rules -> Some (s, rules)
+        | None -> None)
+      stmts
+  in
+  let coalesced = coalesce ?parent changed sorted in
+  if coalesced == sorted then stmts else settle ?parent changed coalesced
+
 (* Canonicalise every cascade context. At-rule block bodies inherit the current
    nesting [parent]; a style rule's nested body is canonicalised under the
    rule's own (expanded) selector as the new parent, so nested relative
@@ -140,8 +287,10 @@ let rec recurse ~(parent : Selector.t option) changed (stmt : statement) :
 and canonicalize_block ~parent changed (stmts : statement list) : statement list
     =
   (* Canonicalise interiors first so run elements are ranked on their canonical
-     serialized form. *)
+     serialized form, then undo grouping so equivalent factorings converge. *)
   let stmts = List.map (recurse ~parent changed) stmts in
+  let expanded = List.concat_map expand_lists stmts in
+  if List.compare_lengths expanded stmts <> 0 then changed := true;
   let rec go = function
     | [] -> []
     | stmt :: rest -> (
@@ -155,10 +304,10 @@ and canonicalize_block ~parent changed (stmts : statement list) : statement list
               | [] -> (List.rev acc, [])
             in
             let run, rest = take [ (stmt, rules) ] rest in
-            sort_run ?parent changed run @ go rest
+            settle ?parent changed run @ go rest
         | None -> stmt :: go rest)
   in
-  go stmts
+  go expanded
 
 let canonicalize (stmts : statement list) : statement list =
   let changed = ref false in

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -82,6 +82,19 @@ others), including when a same-condition block was split around the rule.
   $ cascade diff --diff=canonical grouped.css split.css
   CSS files are identical
 
+Canonical mode also equates different factorings of the same content: a
+declaration hoisted into a shared selector-list group is the same declaration
+written inline.
+
+  $ cat > hoisted.css <<EOF
+  > .absolute,.sr-only{position:absolute}.sr-only{white-space:nowrap}
+  > EOF
+  $ cat > inline.css <<EOF
+  > .absolute{position:absolute}.sr-only{white-space:nowrap;position:absolute}
+  > EOF
+  $ cascade diff --diff=canonical hoisted.css inline.css
+  CSS files are identical
+
 A conditional block whose rules write the same property on the same selector
 stays ordered: swapping it with the rule is a real difference.
 

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -14,9 +14,15 @@ let sorts_independent_rules_into_content_order () =
     (canonical ".b{color:red}.a{margin:0}")
 
 let keeps_conflicting_rules_in_source_order () =
+  (* Same-selector rules coalesce (the merged declaration order resolves
+     identically), but the write order inside stays cascade-significant: the two
+     source orders must not converge. *)
   Alcotest.(check string)
-    "same selector and property remains ordered" ".a{color:red}.a{color:blue}"
-    (canonical ".a{color:red}.a{color:blue}")
+    "same selector and property remains ordered" ".a{color:red;color:blue}"
+    (canonical ".a{color:red}.a{color:blue}");
+  Alcotest.(check string)
+    "opposite source order keeps the opposite winner" ".a{color:blue;color:red}"
+    (canonical ".a{color:blue}.a{color:red}")
 
 let custom_property_position_converges () =
   (* A custom-property definition and a [var()] user are cascade-independent, so
@@ -73,6 +79,36 @@ let block_with_layer_content_is_barrier () =
     (render (statements css))
     (canonical css)
 
+let hoisted_group_converges_with_inline () =
+  (* A shared declaration hoisted into a selector-list group is the same
+     declaration written inline, so both factorings project to one form. *)
+  Alcotest.(check string)
+    "hoisted and inline forms converge"
+    (canonical
+       ".absolute{position:absolute}.sr-only{position:absolute;white-space:nowrap}")
+    (canonical
+       ".absolute,.sr-only{position:absolute}.sr-only{white-space:nowrap}")
+
+let selector_list_expands_to_branches () =
+  Alcotest.(check string)
+    "list rule projects onto its branches" ".a{margin:0}.b{margin:0}"
+    (canonical ".a,.b{margin:0}")
+
+let coalesce_blocked_by_intervening_conflict () =
+  (* [.b] can match the same element as [.a] at equal specificity and writes the
+     same property as both [.a] occurrences, so neither reordering nor folding
+     past it is observable-free; the occurrences stay split in source order. *)
+  Alcotest.(check string)
+    "conflicting write between occurrences keeps them split"
+    ".a{color:red}.b{color:blue}.a{color:green}"
+    (canonical ".a{color:red}.b{color:blue}.a{color:green}")
+
+let coalesce_drops_exact_duplicates () =
+  Alcotest.(check string)
+    "duplicate declaration collapses to the later occurrence"
+    ".a{color:red;margin:0}"
+    (canonical ".a{color:red}.a{color:red;margin:0}")
+
 let nested_conditionals_participate () =
   let css =
     "@media print{@supports (display:flex){.z{color:red}}}.b{margin:0}"
@@ -95,6 +131,14 @@ let suite =
       Alcotest.test_case "media conflict keeps source order" `Quick
         media_conflict_keeps_source_order;
       Alcotest.test_case "layer blocks stay put" `Quick layer_blocks_stay_put;
+      Alcotest.test_case "hoisted group converges with inline" `Quick
+        hoisted_group_converges_with_inline;
+      Alcotest.test_case "selector list expands to branches" `Quick
+        selector_list_expands_to_branches;
+      Alcotest.test_case "coalesce blocked by intervening conflict" `Quick
+        coalesce_blocked_by_intervening_conflict;
+      Alcotest.test_case "coalesce drops exact duplicates" `Quick
+        coalesce_drops_exact_duplicates;
       Alcotest.test_case "block with layer content is barrier" `Quick
         block_with_layer_content_is_barrier;
       Alcotest.test_case "nested conditionals participate" `Quick


### PR DESCRIPTION
This PR makes `canonicalize_rule_order` undo grouping before ordering: selector-list rules expand onto their branches, and same-selector rules coalesce whenever no intervening write can observe the move, with sort and coalesce iterated to a fixed point. Stacked on #151, which lets conditional blocks participate in the canonical order.

The tw-vs-Tailwind parity sweep over ocaml.org reported phantom diffs on semantically identical content: both inputs contain a byte-identical `.sr-only` rule, but one side's global factoring hoists its `position:absolute` into a shared `.absolute,.sr-only` group while the other keeps it inline, and the canonical comparator treated the two factorings as a modified rule (`- position absolute` / `+ position`), with the same mechanism behind the `selectors split` and `blocks at different positions` residuals. Greedy factoring is input-order-sensitive, so equivalent sheets routinely reach different groupings; the comparator has to be invariant to that rather than hope both sides factor identically.

Coalescing is gated on the same conflict model as the ordering: folding an occurrence across an element that writes an overlapping property on a co-matchable equal-specificity selector would change what an element carrying both classes resolves to, so such occurrences stay split (`.a{color:red}.b{color:blue}.a{color:green}` keeps all three rules). After this change the ocaml.org sweep reports only genuine divergences (utility classes present on one side only, and one real utility-order difference); the phantom entries are gone.