### PR TITLE
css: canonicalise commuting declaration order in rule-order projection

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7582,13 +7582,16 @@ val canonicalize_rule_order : t -> t
     deterministic form: selector-list rules expand onto their branches,
     same-selector rules coalesce when no intervening write can observe the move
     (so a declaration hoisted into a shared group and the same declaration
-    written inline converge), and cascade-independent statements sort into a
-    content-keyed linear extension of the cascade-conflict graph. A [@media] /
-    [@supports] / [@container] block whose transitive content is plain rules
-    moves as one unit, keyed by the union of its rules' conflict footprints;
-    conflicting statements keep their relative order, and named [@layer] blocks
-    pin the layer order where they stand. This is a comparison-side
-    normalisation; {!val-optimize} stays source-stable. *)
+    written inline converge), each rule's declarations sort into a canonical
+    order among those with disjoint footprints (a shorthand and its longhand, or
+    two writes of the same property, keep their cascade-significant order), and
+    cascade-independent statements sort into a content-keyed linear extension of
+    the cascade-conflict graph. A [@media] / [@supports] / [@container] block
+    whose transitive content is plain rules moves as one unit, keyed by the
+    union of its rules' conflict footprints; conflicting statements keep their
+    relative order, and named [@layer] blocks pin the layer order where they
+    stand. This is a comparison-side normalisation; {!val-optimize} stays
+    source-stable. *)
 
 val optimize :
   ?scope:Optimize.scope ->

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -65,6 +65,72 @@ let is_identity order =
     order;
   !id
 
+(* Source-order-preserving edge count: [indeg.(j)] is the number of
+   source-earlier declarations that overlap [j], which must all be emitted
+   before [j]. *)
+let overlap_indegrees (arr : Declaration.declaration array) : int array =
+  let n = Array.length arr in
+  let indeg = Array.make n 0 in
+  for j = 0 to n - 1 do
+    for i = 0 to j - 1 do
+      if Shorthand.declarations_overlap arr.(i) arr.(j) then
+        indeg.(j) <- indeg.(j) + 1
+    done
+  done;
+  indeg
+
+(* Among not-yet-emitted declarations whose overlapping predecessors are all
+   emitted ([indeg = 0]), the one with the smallest content key (then index). *)
+let ready_min ~emitted ~indeg ~keys =
+  let best = ref (-1) in
+  for i = 0 to Array.length keys - 1 do
+    if (not emitted.(i)) && indeg.(i) = 0 then
+      if
+        !best < 0
+        ||
+        let c = String.compare keys.(i) keys.(!best) in
+        c < 0 || (c = 0 && i < !best)
+      then best := i
+  done;
+  !best
+
+(* Canonical order for a rule's declarations. Two declarations whose footprints
+   overlap - the same property, or a shorthand and a longhand writing a common
+   slot - keep their source order because it is cascade-significant; two with
+   disjoint footprints can never change each other's computed value, so they
+   sort into a deterministic content order. The declaration-level analogue of
+   the rule-level reordering, so two rules holding the same declarations in a
+   different commuting order project to one canonical form. Preserves physical
+   identity when the source order is already canonical. *)
+let canonical_declarations (decls : Declaration.declaration list) :
+    Declaration.declaration list =
+  match decls with
+  | [] | [ _ ] -> decls
+  | _ ->
+      let arr = Array.of_list decls in
+      let n = Array.length arr in
+      let keys =
+        Array.map
+          (fun d -> Pp.to_string ~minify:true Declaration.pp_declaration d)
+          arr
+      in
+      let indeg = overlap_indegrees arr in
+      let emitted = Array.make n false in
+      let order = Array.make n 0 in
+      let changed = ref false in
+      for pos = 0 to n - 1 do
+        let b = ready_min ~emitted ~indeg ~keys in
+        if b <> pos then changed := true;
+        emitted.(b) <- true;
+        order.(pos) <- b;
+        for j = b + 1 to n - 1 do
+          if (not emitted.(j)) && Shorthand.declarations_overlap arr.(b) arr.(j)
+          then indeg.(j) <- indeg.(j) - 1
+        done
+      done;
+      if not !changed then decls
+      else Array.to_list (Array.map (fun i -> arr.(i)) order)
+
 (* Reorder one maximal run of elements into a canonical linear extension of its
    dependency graph, breaking ties among independent elements by serialized
    statement content so two source orderings converge to one form, while
@@ -169,7 +235,8 @@ let merge scan changed ~from ~into =
         {
           earlier with
           declarations =
-            dedup_keep_last (earlier.declarations @ later.declarations);
+            canonical_declarations
+              (dedup_keep_last (earlier.declarations @ later.declarations));
         }
       in
       scan.arr.(into) <- (Rule merged, [ merged ])
@@ -271,7 +338,10 @@ let rec recurse ~(parent : Selector.t option) changed (stmt : statement) :
       let nested =
         canonicalize_block ~parent:(Some child_parent) changed r.nested
       in
-      if nested == r.nested then stmt else Rule { r with nested }
+      let declarations = canonical_declarations r.declarations in
+      if declarations != r.declarations then changed := true;
+      if nested == r.nested && declarations == r.declarations then stmt
+      else Rule { r with declarations; nested }
   | Layer (n, b) -> Layer (n, here b)
   | Media (m, b) -> Media (m, here b)
   | Container (n, c, b) -> Container (n, c, here b)

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -82,6 +82,29 @@ others), including when a same-condition block was split around the rule.
   $ cascade diff --diff=canonical grouped.css split.css
   CSS files are identical
 
+Canonical mode reorders declarations that write disjoint cascade slots, so two
+rules holding the same declarations in a different commuting order compare
+identical, while a shorthand and its longhand (which overlap) stay ordered.
+
+  $ cat > order-a.css <<EOF
+  > .sr-only{position:absolute;clip-path:inset(50%);width:1px;overflow:hidden}
+  > EOF
+  $ cat > order-b.css <<EOF
+  > .sr-only{width:1px;overflow:hidden;position:absolute;clip-path:inset(50%)}
+  > EOF
+  $ cascade diff --diff=canonical order-a.css order-b.css
+  CSS files are identical
+
+  $ cat > over-a.css <<EOF
+  > .x{margin:0;margin-top:5px}
+  > EOF
+  $ cat > over-b.css <<EOF
+  > .x{margin-top:5px;margin:0}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=canonical over-a.css over-b.css > /dev/null; echo $?
+  cascade: CSS files differ
+  124
+
 Canonical mode also equates different factorings of the same content: a
 declaration hoisted into a shared selector-list group is the same declaration
 written inline.

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -494,9 +494,10 @@ let canonical_registered_font_family_quoted_unquoted_equal () =
    so canonical comparison sorts them alphabetically by name. This restores the
    "all paths canonicalize the same" invariant for theme blocks regardless of
    the source's emission order (Tailwind's (priority, suborder) convention, a
-   typed Var.binding constructor's order, or hand-written CSS all converge).
-   Sort only applies to :root/:host blocks; regular rules preserve declaration
-   order (cascade semantics). *)
+   typed Var.binding constructor's order, or hand-written CSS all converge). In
+   a regular rule the sort is footprint-gated instead: declarations that write
+   no common cascade slot sort into a deterministic order, while overlapping
+   ones (same property, shorthand and longhand) keep source order. *)
 
 let canonical_root_custom_props_permutation_equal () =
   let expected = ":root{--zebra:1;--apple:2;--mango:3}" in
@@ -512,27 +513,47 @@ let canonical_host_custom_props_permutation_equal () =
     ":host custom-property permutations canonicalize equal" true
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
 
-(* SAFETY: outside :root/:host the alphabetical sort must not apply - in a
-   regular rule, custom-property declarations participate in the normal cascade
-   (later same-name wins), so reordering them is semantically load-bearing.
-   Permutations must stay distinct. *)
-let canonical_non_root_custom_props_distinct () =
+(* Two custom-property declarations for DIFFERENT names write disjoint cascade
+   slots and resolve independently, so their order in a regular rule cannot
+   change a computed value; canonical mode reorders them into a deterministic
+   order. Two declarations of the SAME name still stay ordered (later wins), but
+   optimize already dedups those to the last value. *)
+let canonical_distinct_custom_props_permutation_equal () =
   let expected = ".x{--zebra:1;--apple:2}" in
   let actual = ".x{--apple:2;--zebra:1}" in
   Alcotest.(check bool)
-    "non-:root/:host custom-property permutations stay distinct" false
+    "distinct custom-property permutations canonicalize equal" true
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
 
-(* SAFETY: regular property declarations are never alphabetised - source order
-   is cascade-meaningful for any property (shorthand interactions, same-name
-   dedup, etc.). Permutations stay distinct even when the properties themselves
-   don't conflict. *)
-let canonical_regular_decls_permutation_distinct () =
+(* Regular declarations whose footprints are disjoint (they write no common
+   cascade slot after shorthand expansion) can never change each other's
+   computed value, so canonical mode sorts them into a deterministic order and
+   permutations compare equal. *)
+let canonical_disjoint_decls_permutation_equal () =
   let expected = ".x{color:red;background:blue;margin:1px}" in
   let actual = ".x{background:blue;margin:1px;color:red}" in
   Alcotest.(check bool)
-    "regular property declaration permutations stay distinct" false
+    "disjoint property declaration permutations canonicalize equal" true
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
+
+(* SAFETY: overlapping declarations keep their source order. A shorthand and a
+   longhand that write a common slot, and two writes that expand onto a shared
+   sub-property, resolve differently when swapped, so canonical mode must keep
+   such permutations distinct. *)
+let canonical_overlapping_decls_stay_distinct () =
+  let check desc a b =
+    Alcotest.(check bool)
+      desc false
+      (Cascade_diff.Css_compare.equal ~mode:`Canonical a b)
+  in
+  check "shorthand and its longhand stay ordered" ".x{margin:0;margin-top:5px}"
+    ".x{margin-top:5px;margin:0}";
+  check "overlapping shorthands stay ordered"
+    ".x{border-top:1px solid red;border-color:blue}"
+    ".x{border-color:blue;border-top:1px solid red}";
+  check "background shorthand over its longhand stays ordered"
+    ".x{background:blue;background-color:red}"
+    ".x{background-color:red;background:blue}"
 
 let semantic_legacy_pseudo_element_alias () =
   let legacy =
@@ -1022,10 +1043,12 @@ let suite =
         canonical_root_custom_props_permutation_equal;
       Alcotest.test_case "canonical :host custom-props alphabetised" `Quick
         canonical_host_custom_props_permutation_equal;
-      Alcotest.test_case "canonical non-:root custom-props stay distinct" `Quick
-        canonical_non_root_custom_props_distinct;
-      Alcotest.test_case "canonical regular decls stay distinct" `Quick
-        canonical_regular_decls_permutation_distinct;
+      Alcotest.test_case "canonical distinct custom-props canonicalize equal"
+        `Quick canonical_distinct_custom_props_permutation_equal;
+      Alcotest.test_case "canonical disjoint decls canonicalize equal" `Quick
+        canonical_disjoint_decls_permutation_equal;
+      Alcotest.test_case "canonical overlapping decls stay distinct" `Quick
+        canonical_overlapping_decls_stay_distinct;
       Alcotest.test_case "semantic legacy pseudo-element alias" `Quick
         semantic_legacy_pseudo_element_alias;
       Alcotest.test_case "semantic vendor color with recovered warning" `Quick

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -109,6 +109,28 @@ let coalesce_drops_exact_duplicates () =
     ".a{color:red;margin:0}"
     (canonical ".a{color:red}.a{color:red;margin:0}")
 
+let commuting_declarations_converge () =
+  (* Declarations that write disjoint cascade slots sort into one canonical
+     order, so two rules holding the same set in a different commuting order
+     converge (the .sr-only phantom: every declaration writes a distinct
+     property). *)
+  let a =
+    ".x{position:absolute;clip-path:inset(50%);width:1px;overflow:hidden}"
+  in
+  let b =
+    ".x{width:1px;overflow:hidden;position:absolute;clip-path:inset(50%)}"
+  in
+  Alcotest.(check string)
+    "both commuting orders converge" (canonical a) (canonical b)
+
+let overlapping_declarations_keep_order () =
+  (* A shorthand and its longhand write a common slot, so their relative order
+     is cascade-significant and the two source orders must not converge. *)
+  Alcotest.(check bool)
+    "shorthand/longhand order stays distinct" true
+    (canonical ".x{margin:0;margin-top:5px}"
+    <> canonical ".x{margin-top:5px;margin:0}")
+
 let nested_conditionals_participate () =
   let css =
     "@media print{@supports (display:flex){.z{color:red}}}.b{margin:0}"
@@ -139,6 +161,10 @@ let suite =
         coalesce_blocked_by_intervening_conflict;
       Alcotest.test_case "coalesce drops exact duplicates" `Quick
         coalesce_drops_exact_duplicates;
+      Alcotest.test_case "commuting declarations converge" `Quick
+        commuting_declarations_converge;
+      Alcotest.test_case "overlapping declarations keep order" `Quick
+        overlapping_declarations_keep_order;
       Alcotest.test_case "block with layer content is barrier" `Quick
         block_with_layer_content_is_barrier;
       Alcotest.test_case "nested conditionals participate" `Quick


### PR DESCRIPTION
`canonicalize_rule_order` reordered and coalesced rules but left each rule's declaration order verbatim, so canonical diff still counted intra-rule declaration order. On the tw-vs-Tailwind sweeps this surfaced as a phantom modified rule: both sides emit a byte-identical `.sr-only` rule, but its nine declarations (each writing a distinct cascade slot) sit in a different order, which resolves identically yet compared as `- position absolute` / `+ position`.

Each rule's declarations now sort into a canonical order among those with disjoint footprints, gated by the same `Shorthand.declarations_overlap` predicate the rule graph already trusts for factoring: a shorthand and its longhand, or two writes of one property, keep their cascade-significant source order, while declarations that write no common slot converge. This is the declaration-level analogue of the existing rule-level projection and matches the README's documented canonical contract ("declarations whose footprints are disjoint may swap freely").

The two tests that asserted intra-rule declaration order is never normalised were over-conservative and had contradicted that documented contract since before this change; each genuine hazard they hedged against (a shorthand over its longhand, overlapping shorthands, same-property or same-name-custom-property writes) is caught by the overlap predicate and optimize's existing dedup, verified by new negative tests. They now assert the footprint-gated rule.

The `@media` block-level residuals on the same sweep (blocks at different positions, and same-condition blocks merged in one sheet but not the other) are a separate structural-normalisation question and are left for follow-up.