### PR TITLE
css: keep unshared selector lists grouped and dedup coalesced rules

### DIFF
--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -173,34 +173,58 @@ let sort_run ?parent changed (run : (statement * rule list) list) :
         (Array.map (fun i -> fst arr.(Rule_graph.Node_id.to_int i)) order)
     end
 
+let branch_key sel = Pp.to_string ~minify:true Selector.pp sel
+
+(* Selector branches that occur in more than one rule of a block: the only
+   branches a later coalesce can fold. Expanding a list rule is only worthwhile
+   when one of its branches is such a shared branch. *)
+let shared_branches (stmts : statement list) : (string, unit) Hashtbl.t =
+  let counts = Hashtbl.create 64 in
+  List.iter
+    (function
+      | Rule r when r.nested = [] && r.merge_key = None ->
+          List.iter
+            (fun sel ->
+              let k = branch_key sel in
+              Hashtbl.replace counts k
+                (1 + Option.value ~default:0 (Hashtbl.find_opt counts k)))
+            (Edge.selectors r.selector)
+      | _ -> ())
+    stmts;
+  let shared = Hashtbl.create 16 in
+  Hashtbl.iter (fun k n -> if n > 1 then Hashtbl.replace shared k ()) counts;
+  shared
+
 (* A grouped rule is semantically the sequence of its per-branch rules, and a
    hoisted shared declaration is the same declaration written inline, so two
    sheets that factor the same content differently ([.absolute,.sr-only
    {position:absolute}] on one side, the declaration kept inline in [.sr-only]
-   on the other) only project to one canonical form if grouping is undone first:
-   expand every selector-list rule into singleton-branch rules, then coalesce
-   same-selector rules whose merge no intervening write can observe. *)
-let expand_lists (stmt : statement) : statement list =
+   on the other) only project to one canonical form if grouping is undone first.
+   Expand a selector-list rule into singleton-branch rules only when a branch is
+   shared with another rule, so a coalesce can actually fold it; a list whose
+   branches all occur once ([:host,:root], [*,::before,::after]) has nothing to
+   coalesce with, and splitting it only bloats the projection and desynchronises
+   the structural comparison of two otherwise-equivalent sheets. *)
+let expand_lists shared (stmt : statement) : statement list =
   match stmt with
   | Rule r when r.nested = [] && r.merge_key = None -> (
       match Edge.selectors r.selector with
       | [] | [ _ ] -> [ stmt ]
-      | branches -> List.map (fun selector -> Rule { r with selector }) branches
-      )
+      | branches
+        when List.exists
+               (fun sel -> Hashtbl.mem shared (branch_key sel))
+               branches ->
+          List.map (fun selector -> Rule { r with selector }) branches
+      | _ -> [ stmt ])
   | _ -> [ stmt ]
 
-(* Exact duplicates across coalesced occurrences collapse to the later one;
-   distinct values of the same property keep both writes in order, which
-   resolves identically to the split form. *)
-let dedup_keep_last decls =
-  let rec keep = function
-    | [] -> []
-    | d :: rest ->
-        if List.exists (Shorthand.same_minified_declaration d) rest then
-          keep rest
-        else d :: keep rest
-  in
-  keep decls
+(* Coalescing two occurrences of a selector concatenates their declarations, so
+   an earlier write that a later one overrides (as when one occurrence carried a
+   shared default the other specialises) becomes dead. Reduce with the same
+   cascade dedup the optimizer uses - keep the last write of each property,
+   preserving genuine fallback pairs - so a coalesced rule holds the same
+   declaration set a sheet that never split it would. *)
+let coalesced_declarations decls = Shorthand.deduplicate_declarations decls
 
 (* Mutable state of one coalescing scan: the run's elements, the graph nodes
    accumulated into each surviving element, and which elements remain. *)
@@ -236,7 +260,8 @@ let merge scan changed ~from ~into =
           earlier with
           declarations =
             canonical_declarations
-              (dedup_keep_last (earlier.declarations @ later.declarations));
+              (coalesced_declarations
+                 (earlier.declarations @ later.declarations));
         }
       in
       scan.arr.(into) <- (Rule merged, [ merged ])
@@ -359,7 +384,8 @@ and canonicalize_block ~parent changed (stmts : statement list) : statement list
   (* Canonicalise interiors first so run elements are ranked on their canonical
      serialized form, then undo grouping so equivalent factorings converge. *)
   let stmts = List.map (recurse ~parent changed) stmts in
-  let expanded = List.concat_map expand_lists stmts in
+  let shared = shared_branches stmts in
+  let expanded = List.concat_map (expand_lists shared) stmts in
   if List.compare_lengths expanded stmts <> 0 then changed := true;
   let rec go = function
     | [] -> []

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -14,14 +14,15 @@ let sorts_independent_rules_into_content_order () =
     (canonical ".b{color:red}.a{margin:0}")
 
 let keeps_conflicting_rules_in_source_order () =
-  (* Same-selector rules coalesce (the merged declaration order resolves
-     identically), but the write order inside stays cascade-significant: the two
-     source orders must not converge. *)
+  (* Same-selector rules coalesce and the merged declarations reduce with the
+     cascade dedup: the last write of a property wins and the dead earlier one
+     is dropped, so the two source orders keep their opposite winners and stay
+     distinct. *)
   Alcotest.(check string)
-    "same selector and property remains ordered" ".a{color:red;color:blue}"
+    "same selector and property keeps the last winner" ".a{color:blue}"
     (canonical ".a{color:red}.a{color:blue}");
   Alcotest.(check string)
-    "opposite source order keeps the opposite winner" ".a{color:blue;color:red}"
+    "opposite source order keeps the opposite winner" ".a{color:red}"
     (canonical ".a{color:blue}.a{color:red}")
 
 let custom_property_position_converges () =
@@ -89,10 +90,21 @@ let hoisted_group_converges_with_inline () =
     (canonical
        ".absolute,.sr-only{position:absolute}.sr-only{white-space:nowrap}")
 
-let selector_list_expands_to_branches () =
+let selector_list_stays_grouped_without_coalesce () =
+  (* A selector-list rule whose branches occur nowhere else has nothing to
+     coalesce with, so it is left grouped rather than split into singletons -
+     splitting would only bloat the projection. *)
   Alcotest.(check string)
-    "list rule projects onto its branches" ".a{margin:0}.b{margin:0}"
+    "list rule with no shared branch stays grouped" ".a,.b{margin:0}"
     (canonical ".a,.b{margin:0}")
+
+let selector_list_expands_when_a_branch_is_shared () =
+  (* When a branch also appears in another rule, the list is expanded so the
+     coalesce can fold that branch; the non-shared branch keeps its
+     declarations. *)
+  Alcotest.(check string)
+    "shared branch expands and coalesces" ".a{margin:0}.b{color:red;margin:0}"
+    (canonical ".a,.b{margin:0}.b{color:red}")
 
 let coalesce_blocked_by_intervening_conflict () =
   (* [.b] can match the same element as [.a] at equal specificity and writes the
@@ -108,6 +120,18 @@ let coalesce_drops_exact_duplicates () =
     "duplicate declaration collapses to the later occurrence"
     ".a{color:red;margin:0}"
     (canonical ".a{color:red}.a{color:red;margin:0}")
+
+let coalesce_drops_dead_override () =
+  (* When optimize factors a shared default into a group and specialises one
+     branch ([.a,.b{color:red}] then [.b{color:blue}]), expanding and coalescing
+     [.b] must drop the dead default so the coalesced rule holds the same
+     declarations a sheet that folded [.b] directly would - otherwise the two
+     project to different declaration sets and the structural comparison
+     desynchronises (the tw-parity shadow/scrollbar regression). *)
+  Alcotest.(check string)
+    "coalesced branch drops the overridden default"
+    ".a{color:red}.b{color:blue}"
+    (canonical ".a,.b{color:red}.b{color:blue}")
 
 let commuting_declarations_converge () =
   (* Declarations that write disjoint cascade slots sort into one canonical
@@ -155,12 +179,16 @@ let suite =
       Alcotest.test_case "layer blocks stay put" `Quick layer_blocks_stay_put;
       Alcotest.test_case "hoisted group converges with inline" `Quick
         hoisted_group_converges_with_inline;
-      Alcotest.test_case "selector list expands to branches" `Quick
-        selector_list_expands_to_branches;
+      Alcotest.test_case "selector list stays grouped without coalesce" `Quick
+        selector_list_stays_grouped_without_coalesce;
+      Alcotest.test_case "selector list expands when a branch is shared" `Quick
+        selector_list_expands_when_a_branch_is_shared;
       Alcotest.test_case "coalesce blocked by intervening conflict" `Quick
         coalesce_blocked_by_intervening_conflict;
       Alcotest.test_case "coalesce drops exact duplicates" `Quick
         coalesce_drops_exact_duplicates;
+      Alcotest.test_case "coalesce drops dead override" `Quick
+        coalesce_drops_dead_override;
       Alcotest.test_case "commuting declarations converge" `Quick
         commuting_declarations_converge;
       Alcotest.test_case "overlapping declarations keep order" `Quick


### PR DESCRIPTION
`canonicalize_rule_order` projected two cascade-equivalent stylesheets to different *structures*, which regressed the tw upstream byte-parity harness on 8 utility groups (scrollbar-thumb/-track, gradient from/via/to, text-shadow, shadow, inset-shadow) once #151/#153/#154 made the projection aggressive. The failures rendered as an oklab-rounding value diff no longer being tolerated, but the value fold was byte-identical before and after; the real cause was structural.

Two mechanisms. First, `expand_lists` split *every* selector-list rule into singletons, but `coalesce` only re-merges same-*selector* rules, so a list whose branches occur nowhere else (`:host,:root`, `*,::before,::after`) stayed split and nearly doubled the projected form, desynchronising the tree-diff's rule and declaration alignment. It now expands a list only when one of its branches is shared with another rule, so a coalesce can actually fold it; unshared lists stay grouped.

Second, coalescing a selector's occurrences concatenated their declarations but dropped only exact duplicates. When optimize factored a shared default into a group and specialised one branch (`.a,.b{color:red}` then `.b{color:blue}`), the coalesced `.b` kept the dead `color:red` while a sheet that folded `.b` directly held a single write, so the two projected to different declaration sets. Coalesced declarations now reduce with the optimizer's same-property dedup (last write wins, genuine fallback pairs preserved).

All 8 regressed parity tests pass again, the cascade suite and the ocaml.org convergence from #153/#154 are green, and `Rule_order` gains tests for both behaviours. The remaining `filter` parity failure is pre-existing (it fails on the pre-#150 pin too) and out of scope.