### PR TITLE
cli, docs: clear merlint findings from the transfer-objective work

### DIFF
--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -252,6 +252,15 @@ let profile_arg =
   in
   Arg.(value & flag & info [ "profile" ] ~doc)
 
+(* Flags that only act under [--minify]; warn when set without it. *)
+let warn_minify_only ~minify checks =
+  if not minify then
+    List.iter
+      (fun (active, flag) ->
+        if active then
+          Fmt.epr "Warning: %s has no effect without --minify@." flag)
+      checks
+
 let term =
   Term.(
     const
@@ -282,20 +291,16 @@ let term =
         end;
         if keep_vars <> [] && not inline_vars_flag then
           Fmt.epr "Warning: --keep-vars has no effect without --inline-vars@.";
-        if scope = `Stylesheet && not minify then
-          Fmt.epr "Warning: --scope=stylesheet has no effect without --minify@.";
-        if lossless && not minify then
-          Fmt.epr "Warning: --lossless has no effect without --minify@.";
-        if enforce_spec && not minify then
-          Fmt.epr "Warning: --enforce-spec has no effect without --minify@.";
-        if aggressive && not minify then
-          Fmt.epr "Warning: --aggressive has no effect without --minify@.";
-        if closed_world && not minify then
-          Fmt.epr "Warning: --closed-world has no effect without --minify@.";
-        if objective = `Raw && not minify then
-          Fmt.epr "Warning: --objective has no effect without --minify@.";
-        if profile && not minify then
-          Fmt.epr "Warning: --profile has no effect without --minify@.";
+        warn_minify_only ~minify
+          [
+            (scope = `Stylesheet, "--scope=stylesheet");
+            (lossless, "--lossless");
+            (enforce_spec, "--enforce-spec");
+            (aggressive, "--aggressive");
+            (closed_world, "--closed-world");
+            (objective = `Raw, "--objective");
+            (profile, "--profile");
+          ];
         process_css ~input_path:input ~minify ~scope ~flatten_nesting ~lossless
           ~enforce_spec ~aggressive ~closed_world ~objective
           ~inline_imports_flag ~inline_vars_flag ~keep_vars ~memtrace_path

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7641,7 +7641,7 @@ val optimize :
     DEFLATE (gzip) size of the output is discarded even when it shrinks raw
     bytes, since repeated declaration text is nearly free once compressed. Pass
     [`Raw] to keep every raw-byte win, the right objective when the output ships
-    uncompressed (inline [style] attributes, email HTML).
+    uncompressed (inline HTML style attributes, email HTML).
 
     When [prune_unused_custom_props] is [true] (default [false]) custom-property
     bindings referenced by no [var()] anywhere are dropped. Opt-in: it assumes a

--- a/test/test_gzip_size.mli
+++ b/test/test_gzip_size.mli
@@ -1,3 +1,4 @@
 (** Unit tests for [Gzip_size]. *)
 
 val suite : string * unit Alcotest.test_case list
+(** Alcotest suite for [Gzip_size]. *)


### PR DESCRIPTION
Three merlint findings accumulated in the transfer-objective PRs (#150), which CI's ocamlformat-only Lint step does not catch:

- `cmd_fmt`'s `term` grew past the length threshold once the `--objective` warning was threaded in; the minify-only flag warnings move into a small `warn_minify_only` helper (E005).
- `test_gzip_size`'s `suite` value gains a doc comment (E405).
- the `optimize` doc's mention of inline HTML `style` attributes no longer reads as an odoc reference to an exported `style` field (E420).

No behaviour change.