### PR TITLE
docs: prepare 1.0.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 0.9.0
+## 1.0.0
 
 First public release. Cascade was extracted from the [tw](https://github.com/samoht/tw)
 (Tailwind CSS v4 in OCaml) project as a standalone CSS command-line tool and
@@ -22,7 +22,13 @@ library, then stabilised over several internal milestones.
   `inline_imports`) and structural CSS diff utilities via the
   `cascade.diff` sub-library.
 - Optimizer with deduplication, rule merging, selector combining, and
-  shorthand/longhand coverage including `all` reset folding.
+  shorthand/longhand coverage including `all` reset folding. Rule merging is
+  order-independent: rules are scheduled through a conflict DAG so cascade-safe
+  reorderings converge on the same output regardless of source order.
+- Minification optimises estimated compressed (gzip) transfer size by default:
+  a global factoring that shrinks raw bytes but would grow the compressed
+  output is not applied. Pass `~objective:\`Raw` (CLI `--objective=raw`) to
+  optimise raw bytes instead, for output that ships uncompressed.
 - Spec coverage:
   - Selectors Level 4 -- including `:has()`, `:is()`, `:where()`, `:not()`,
     nesting `&`, and full attribute syntax.
@@ -58,13 +64,16 @@ library, then stabilised over several internal milestones.
   or a missing file argument, and writes output to stdout.
 - `cascade --minify` applies the standard safe transforms, including
   deduplication, rule merging, selector grouping, empty-rule elimination, and
-  nested-rule flattening.
+  nested-rule flattening, optimising estimated gzip transfer size by default
+  (`--objective=raw` optimises raw bytes instead).
 - `cascade --inline-imports` resolves local `@import` rules relative to the
   input file, and `cascade --inline-vars` substitutes static custom-property
   references. `--keep-vars=NAMES` preserves selected custom properties.
 - `cascade diff` provides structural CSS diffing between two files with
-  `auto`, `tree`, `string`, and `semantic` modes; respects `NO_COLOR` and
-  `CASCADE_COLOR`.
+  `auto`, `tree`, `string`, and `canonical` modes; respects `NO_COLOR` and
+  `CASCADE_COLOR`. The `canonical` mode projects both sheets to a normal form
+  first, so equivalent factorings -- different rule grouping, cascade-safe rule
+  and declaration order -- compare identical rather than as spurious changes.
 - The CLI is installable as a binary through the Homebrew tap
   `samoht/tap/cascade`, with opam installation still available for OCaml users.
 

--- a/lib/ctx.mli
+++ b/lib/ctx.mli
@@ -64,8 +64,8 @@ val closed_world : t -> bool
     On: the caller promises the clashing selector combinations never appear on a
     real element, which lets the optimizer merge more. It is unsafe if such an
     element does turn up, including one a script adds at runtime. This is about
-    the HTML, separate from {!scope}, which is about how much of the CSS you
-    control. *)
+    the HTML, separate from {!type-scope}, which is about how much of the CSS
+    you control. *)
 
 val objective : t -> objective
 (** Size metric optimizations are judged by. Under [`Transfer] (the default) the

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -94,7 +94,7 @@ val equal :
 
 val as_tree_diff : t -> Tree_diff.t option
 (** [as_tree_diff result] returns the underlying [Tree_diff.t] when [result] is
-    a {!Tree_diff}; [None] otherwise. *)
+    a {!constructor-Tree_diff}; [None] otherwise. *)
 
 val pp : ?expected:string -> ?actual:string -> Buffer.t -> t -> unit
 (** [pp ?expected ?actual buf result] formats [result] into [buf], then renders
@@ -118,8 +118,8 @@ type stats = {
 (** Summary of differences extracted from a {!t}. *)
 
 val stats : expected_str:string -> actual_str:string -> t -> stats
-(** [stats ~expected_str ~actual_str result] computes a {!stats} record from a
-    diff [result]. *)
+(** [stats ~expected_str ~actual_str result] computes a {!type-stats} record
+    from a diff [result]. *)
 
 val pp_stats : Buffer.t -> stats -> unit
 (** [pp_stats buf stats] formats a stats record into [buf]. *)

--- a/lib/loc.mli
+++ b/lib/loc.mli
@@ -85,6 +85,7 @@ end
 
 val snippet : ?window:int -> string -> t -> Context.snippet
 (** [snippet source loc] extracts a snippet of [source] around [loc]:
-    {!field-text} is the byte window (default: 40 bytes on each side of the
-    location), {!field-marker_pos} points at [loc.start_pos] within
-    {!field-text}, and {!field-marker_len} spans the located range. *)
+    {!Context.field-text} is the byte window (default: 40 bytes on each side of
+    the location), {!Context.field-marker_pos} points at [loc.start_pos] within
+    {!Context.field-text}, and {!Context.field-marker_len} spans the located
+    range. *)

--- a/lib/media.mli
+++ b/lib/media.mli
@@ -196,7 +196,7 @@ val sort_by : ('a -> t) -> 'a list -> 'a list
 (** [sort_by project items] orders [items] by the media query [project] returns
     for each, serializing each query exactly once. Sorting this way, rather than
     with [List.sort (fun a b -> compare (project a) (project b))], is the point
-    of {!val-key}: the comparator form re-derives and re-serializes a query on
+    of {!sort_key}: the comparator form re-derives and re-serializes a query on
     every comparison, which a sort does O(n log n) times. The sort is stable. *)
 
 type kind =

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -188,7 +188,7 @@ val stylesheet :
     bindings referenced by no [var()] anywhere are dropped. This is opt-in
     because it assumes a complete stylesheet with no out-of-band reader (another
     stylesheet, or [getComputedStyle]) - the same closed-world assumption as
-    {!inline_vars}. *)
+    {!Css.inline_vars}. *)
 
 val flatten_nesting : t -> t
 (** [flatten_nesting ss] returns [ss] with every nested rule flattened into a

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -203,7 +203,7 @@ val normalize_length_percentage :
 val normalize_length : ?strip:bool -> ?ctx:calc_ctx -> length -> length
 (** [normalize_length ?strip l] evaluates the static CSS math functions on a
     [<length>] (min / max / clamp reduce to one dimension on shared units; round
-    / mod / rem / hypot / abs fold on {!val-px}; calc folds through the
+    / mod / rem / hypot / abs fold on {!Calc.px}; calc folds through the
     simplifier), recursing into nested calls; a non-static operand keeps the
     call. [strip] (default [true]) additionally drops the unit on a top-level
     zero ([0px] -> [0]); pass [strip:false] for a calc / function operand, which


### PR DESCRIPTION
Documentation prep for the first opam release, in two commits: 0d45d437 resolves odoc reference warnings, 2b12a167 prepares the changelog.

The doc comments referenced values, fields, and types that odoc could not resolve or found ambiguous (a submodule value, sibling-module record fields, a cross-module value, and bare names colliding with a same-named type or constructor); each is now qualified, so `dune build @doc` is free of source doc-comment warnings. The changelog entry is retitled to 1.0.0 and folds in the work since the draft was written: the transfer-size minification objective and `--objective` flag, the order-independent DAG rule scheduler, and the canonical diff normal form, and corrects the `semantic` mode name to `canonical`.