### PR TITLE
css: keep an authored zero blur before a var() shadow colour

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4464,9 +4464,20 @@ let rec normalize_shadow ?(lossless = false) : shadow -> shadow =
     let spread : length option =
       match spread with Some sp when is_zero_length sp -> None | _ -> spread
     in
+    (* A [var()] colour could resolve to a length, so dropping a zero blur
+       before it lets the shortened form re-bind the colour as the blur: [0 3px
+       0 var(--c)] is blur [0] + colour, but [0 3px var(--c)] parses [var(--c)]
+       as the blur. Keep the explicit [0] there; a concrete colour is
+       unambiguous and the [0] still drops. *)
+    let colour_may_be_length =
+      match color with Some (Var _) -> true | _ -> false
+    in
     let blur : length option =
       match blur with
-      | Some b when is_zero_length b && Option.is_none spread -> None
+      | Some b
+        when is_zero_length b && Option.is_none spread
+             && not colour_may_be_length ->
+          None
       | _ -> blur
     in
     {

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2993,20 +2993,37 @@ let test_shadow () =
     "inset-var shadow keeps the separator after the var prefix when minified"
     "var(--tw-ring-inset,) 0 0 0 1px #000"
     (Css.Pp.to_string ~minify:true pp_shadow inset_var_shadow);
-  (* A var() colour with no blur/spread serialises to [12px 12px var(--c)] - the
-     shortest form. cascade does not pad it with an explicit [0] blur: a
-     var-colour shadow and a var-blur shadow produce identical tokens (the var
-     is opaque), so the [0] would only preserve a cascade-internal AST
-     distinction at the cost of a longer, browser-equivalent value. *)
+  (* A var() colour with an unspecified blur (blur = None) serialises to [12px
+     12px var(--c)]: pp does not pad in a [0] the author never wrote. An
+     authored zero blur (Some Zero) before a var colour is the opposite case -
+     it must keep the [0] (see the optimize test below), because a var() can
+     resolve to a length, so dropping it would let [12px 12px var(--c)] re-bind
+     the var as the blur. Some Zero and None are not interchangeable here. *)
   let var_color_shadow =
     shadow ~h_offset:(Px 12.) ~v_offset:(Px 12.)
       ~color:(Values.Var (Values.var_ref "c"))
       ()
   in
   Alcotest.(check string)
-    "var-colour shadow serialises to the shortest form (no padding 0 blur)"
+    "unspecified blur before a var colour is not padded with a 0"
     "12px 12px var(--c)"
-    (Css.Pp.to_string ~minify:true pp_shadow var_color_shadow)
+    (Css.Pp.to_string ~minify:true pp_shadow var_color_shadow);
+  (* [normalize_shadow] drops a zero blur when no spread follows, but not before
+     a var() colour: dropping it there changes the value. *)
+  let some_zero_var_shadow =
+    Css.box_shadow
+      (shadow ~h_offset:Zero ~v_offset:(Px 3.) ~blur:Zero
+         ~color:(Values.Var (Values.var_ref "c"))
+         ())
+  in
+  let optimized =
+    Css.v
+      [ Css.rule ~selector:(Css.Selector.class_ "k") [ some_zero_var_shadow ] ]
+    |> Css.optimize |> Css.to_string ~minify:true
+  in
+  Alcotest.(check string)
+    "an authored zero blur before a var colour survives optimization"
+    ".k{box-shadow:0 3px 0 var(--c)}" optimized
 
 let test_align_items () =
   check_align_items "stretch";


### PR DESCRIPTION
`normalize_shadow` dropped a zero blur whenever no spread followed it. That is safe before a concrete colour, but not before a `var()`: a `var()` can resolve to a length, so the shortened form is ambiguous. `0 3px 0 var(--c)` means blur `0` plus colour, while `0 3px var(--c)` re-binds the `var()` as the blur. Cascade emitted the latter for a value tw builds as `{blur = Some Zero; colour = Some (Var ...)}`, changing its meaning and diverging from lightningcss by a token.

The drop now keeps the explicit `0` when the colour is a `var()`; a concrete colour stays unambiguous, so the `0` still drops there. Unspecified blur (`None`) is still never padded - `Some Zero` and `None` now serialise differently, as they must. This is the box-shadow half of the ocaml.org byte-parity work.

Reverses a prior decision (the old test comment argued a var-colour zero blur was "browser-equivalent" and droppable; it is not, for a length-valued var).