### PR TITLE
diff: make canonical mode invariant to cascade-neutral position drift

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -858,6 +858,7 @@ let optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
 
 let flatten_nesting = Optimize.flatten_nesting
 let canonicalize_rule_order = Rule_order.canonicalize
+let order_constrained = Rule_order.order_constrained
 
 (** {1 Closed-world inlining} *)
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7593,6 +7593,15 @@ val canonicalize_rule_order : t -> t
     stand. This is a comparison-side normalisation; {!val-optimize} stays
     source-stable. *)
 
+val order_constrained : statement list -> int -> int -> bool
+(** [order_constrained stmts i j] is [true] when reordering the statements at
+    positions [i] and [j] could change a computed value: two run elements (style
+    rules, or [@media] / [@supports] / [@container] blocks over plain rules) are
+    constrained only when their selectors may match a common element at equal
+    specificity and their declarations overlap, while any other statement is a
+    barrier constrained with everything. Lets a structural diff treat a position
+    difference between two mutually unconstrained statements as a no-op. *)
+
 val optimize :
   ?scope:Optimize.scope ->
   ?flatten_nesting:bool ->

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -107,8 +107,9 @@ let strip_tool_header css =
 (* Analyze differences between two parsed CSS ASTs, returning structural
    changes *)
 
-let tree_diff ~(expected : Css.t) ~(actual : Css.t) : Tree_diff.t =
-  D.diff ~expected ~actual
+let tree_diff ~ignore_neutral_reorders ~(expected : Css.t) ~(actual : Css.t) :
+    Tree_diff.t =
+  D.diff ~ignore_neutral_reorders ~expected ~actual ()
 
 (* Collect all rules with their path-qualified selector keys *)
 let rec collect_keyed_rules acc path stmts =
@@ -332,7 +333,10 @@ let diff_two_parsed ~expected ~actual ~expected_ast ~actual_ast =
   (* Do NOT normalize @property order - their order matters for tests *)
   let expected_norm = expected_ast in
   let actual_norm = actual_ast in
-  let structural_diff = tree_diff ~expected:expected_norm ~actual:actual_norm in
+  let structural_diff =
+    tree_diff ~ignore_neutral_reorders:false ~expected:expected_norm
+      ~actual:actual_norm
+  in
   if not (is_empty structural_diff) then Tree_diff structural_diff
   else diff_after_empty_structural ~expected ~actual ~expected_norm ~actual_norm
 
@@ -353,7 +357,8 @@ let diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
   match (Css.of_string expected_canon, Css.of_string actual_canon) with
   | Ok { stylesheet = expected_ast; _ }, Ok { stylesheet = actual_ast; _ } ->
       let structural_diff =
-        tree_diff ~expected:expected_ast ~actual:actual_ast
+        tree_diff ~ignore_neutral_reorders:true ~expected:expected_ast
+          ~actual:actual_ast
       in
       if is_empty structural_diff then
         No_diff { canonical_byte_diff = Some (expected_canon, actual_canon) }
@@ -397,7 +402,8 @@ let diff_tree ~expected_parse ~actual_parse =
   | ( Ok { Css.stylesheet = expected_ast; _ },
       Ok { Css.stylesheet = actual_ast; _ } ) ->
       let structural_diff =
-        tree_diff ~expected:expected_ast ~actual:actual_ast
+        tree_diff ~ignore_neutral_reorders:false ~expected:expected_ast
+          ~actual:actual_ast
       in
       if is_empty structural_diff then No_diff { canonical_byte_diff = None }
       else Tree_diff structural_diff

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1413,11 +1413,6 @@ let reordered ~rules1 ~rules2 sel1 sel2 selector : rule_diff =
      }
     : rule_diff)
 
-let position_changed ~rules1 ~rules2 sel1 sel2 =
-  let expected_pos = selector_position sel1 rules1 in
-  let actual_pos = selector_position sel2 rules2 in
-  expected_pos <> actual_pos
-
 let is_pure_decl_reordering decls1 decls2 =
   let property_changes, added_props, removed_props =
     properties_diff decls1 decls2
@@ -1446,13 +1441,73 @@ let decls_str_equal d1 d2 =
        (fun x y -> decl_to_prop_value x = decl_to_prop_value y)
        d1 d2
 
-let convert_modified_rule ~rules1 ~rules2 (sel1, sel2, decls1, decls2) =
+let stmt_key stmt =
+  Css.Stylesheet.to_string ~minify:true (Css.v [ stmt ]) |> String.trim
+
+(* Statements genuinely reordered between [rules1] and [rules2], keyed by
+   minified serialisation. A statement is reordered only when it and some
+   order-constrained statement flipped relative order; a position difference
+   measured only against statements it cannot cascade-conflict with is neutral
+   drift (a regular rule sliding past disjoint [@media] blocks, or two
+   same-condition blocks sitting at different absolute indices), not a
+   reorder. *)
+let significant_reorder_keys ~ignore_neutral rules1 rules2 =
+  let a1 = Array.of_list rules1 in
+  let n = Array.length a1 in
+  let keys1 = Array.map stmt_key a1 in
+  let pos2 = Hashtbl.create (List.length rules2 + 1) in
+  List.iteri
+    (fun i s ->
+      let k = stmt_key s in
+      if not (Hashtbl.mem pos2 k) then Hashtbl.add pos2 k i)
+    rules2;
+  let reordered = Hashtbl.create 16 in
+  if not ignore_neutral then
+    (* Structural mode: any absolute position change is a reorder. *)
+    Array.iteri
+      (fun i k ->
+        match Hashtbl.find_opt pos2 k with
+        | Some p2 when p2 <> i -> Hashtbl.replace reordered k ()
+        | _ -> ())
+      keys1
+  else begin
+    (* Cascade mode: only a pair of order-constrained statements whose relative
+       order flipped is a reorder; drift past disjoint statements is neutral. *)
+    let constrained = Css.order_constrained rules1 in
+    let flipped i j =
+      match
+        (Hashtbl.find_opt pos2 keys1.(i), Hashtbl.find_opt pos2 keys1.(j))
+      with
+      | Some pi, Some pj -> pi > pj
+      | _ -> false
+    in
+    let mark i j =
+      if constrained i j && flipped i j then begin
+        Hashtbl.replace reordered keys1.(i) ();
+        Hashtbl.replace reordered keys1.(j) ()
+      end
+    in
+    for i = 0 to n - 1 do
+      for j = i + 1 to n - 1 do
+        mark i j
+      done
+    done
+  end;
+  reordered
+
+let convert_modified_rule ~reordered_keys ~rules1 ~rules2
+    (sel1, sel2, decls1, decls2) =
   let sel1_str = Css.Selector.to_string sel1 in
   let sel2_str = Css.Selector.to_string sel2 in
-  let position_changed () = position_changed ~rules1 ~rules2 sel1 sel2 in
+  let position_changed () =
+    match List.nth_opt rules1 (selector_position sel1 rules1) with
+    | Some stmt -> Hashtbl.mem reordered_keys (stmt_key stmt)
+    | None -> false
+  in
   let reordered selector = reordered ~rules1 ~rules2 sel1 sel2 selector in
   let reorder_or_content selector d1 d2 =
     if position_changed () then Some (reordered selector)
+    else if decls_str_equal d1 d2 then None
     else Some (content_changed selector d1 d2)
   in
 
@@ -1485,11 +1540,14 @@ let convert_modified_rule ~rules1 ~rules2 (sel1, sel2, decls1, decls2) =
       else reorder_or_content sel1_str decls1 decls2
 
 (* Assemble rule changes (added/removed/modified) between two rule lists *)
-let to_rule_changes rules1 rules2 : rule_diff list =
+let to_rule_changes ~ignore_neutral rules1 rules2 : rule_diff list =
   let r_added, r_removed, r_modified, r_regrouped = rule_diffs rules1 rules2 in
+  let reordered_keys = significant_reorder_keys ~ignore_neutral rules1 rules2 in
   List.map convert_added_rule r_added
   @ List.map convert_removed_rule r_removed
-  @ List.filter_map (convert_modified_rule ~rules1 ~rules2) r_modified
+  @ List.filter_map
+      (convert_modified_rule ~reordered_keys ~rules1 ~rules2)
+      r_modified
   @ r_regrouped
 
 (* Generic helpers for processing nested containers *)
@@ -1511,24 +1569,29 @@ let group_by_condition items =
     items;
   tbl
 
-let block_positions_differ blocks1_list blocks2_list =
+let block_positions_differ ~reordered_keys ~stmts1 blocks1_list blocks2_list =
   List.length blocks1_list = List.length blocks2_list
-  &&
-  let pos1_list = List.map fst blocks1_list in
-  let pos2_list = List.map fst blocks2_list in
-  List.exists2 (fun p1 p2 -> abs (p1 - p2) > 10) pos1_list pos2_list
+  && List.exists
+       (fun (p1, _) ->
+         match List.nth_opt stmts1 p1 with
+         | Some stmt -> Hashtbl.mem reordered_keys (stmt_key stmt)
+         | None -> false)
+       blocks1_list
 
-let block_structure_differs blocks1_list blocks2_list =
+let block_structure_differs ~reordered_keys ~stmts1 blocks1_list blocks2_list =
   List.length blocks1_list <> List.length blocks2_list
-  || block_positions_differ blocks1_list blocks2_list
+  || block_positions_differ ~reordered_keys ~stmts1 blocks1_list blocks2_list
 
-let detect_block_structure_changes blocks1 blocks2 =
+let detect_block_structure_changes ~reordered_keys ~stmts1 blocks1 blocks2 =
   let block_structure_changed = Hashtbl.create 16 in
   Hashtbl.iter
     (fun cond blocks1_list ->
       match Hashtbl.find_opt blocks2 cond with
       | Some blocks2_list ->
-          if block_structure_differs blocks1_list blocks2_list then
+          if
+            block_structure_differs ~reordered_keys ~stmts1 blocks1_list
+              blocks2_list
+          then
             Hashtbl.replace block_structure_changed cond
               (blocks1_list, blocks2_list)
       | _ -> ())
@@ -1830,7 +1893,7 @@ let modified_container_of_pair ((name_opt, condition, rules1), (_, _, rules2)) =
 
 (* Mutual recursion declarations *)
 (* Check if two rule-lists under the same media condition differ *)
-let rec media_condition_differs rules_list1 rules_list2 =
+let rec media_condition_differs ~ignore_neutral rules_list1 rules_list2 =
   let block_count_differs =
     List.length rules_list1 <> List.length rules_list2
   in
@@ -1842,12 +1905,14 @@ let rec media_condition_differs rules_list1 rules_list2 =
   let has_immediate =
     added_r <> [] || removed_r <> [] || modified_r <> [] || regrouped_r <> []
   in
-  let has_nested = nested_differences ~depth:1 all_rules1 all_rules2 <> [] in
+  let has_nested =
+    nested_differences ~ignore_neutral ~depth:1 all_rules1 all_rules2 <> []
+  in
   if has_immediate || has_nested || block_count_differs then
     Some (all_rules1, all_rules2)
   else None
 
-and media_diff items1 items2 =
+and media_diff ~ignore_neutral items1 items2 =
   let group items =
     let tbl = Hashtbl.create 16 in
     List.iter
@@ -1870,7 +1935,9 @@ and media_diff items1 items2 =
             (fun rules -> removed := (cond, rules) :: !removed)
             rules_list1
       | Some rules_list2 -> (
-          match media_condition_differs rules_list1 rules_list2 with
+          match
+            media_condition_differs ~ignore_neutral rules_list1 rules_list2
+          with
           | Some (r1, r2) -> modified := (cond, r1, r2) :: !modified
           | None -> ()))
     groups1;
@@ -1881,15 +1948,15 @@ and media_diff items1 items2 =
     groups2;
   (!added, !removed, !modified)
 
-and process_modified_container ~container_type ~extract_fn ~depth ~stmts1
-    ~stmts2 ~block_structure_changed cond rules1 rules2 =
+and process_modified_container ~ignore_neutral ~container_type ~extract_fn
+    ~depth ~stmts1 ~stmts2 ~block_structure_changed cond rules1 rules2 =
   (* Skip if this condition has a block structure change *)
   if Hashtbl.mem block_structure_changed cond then None
   else
-    let rule_changes = to_rule_changes rules1 rules2 in
+    let rule_changes = to_rule_changes ~ignore_neutral rules1 rules2 in
     (* Recursively check deeper nesting *)
     let nested_containers =
-      nested_differences ~depth:(depth + 1) rules1 rules2
+      nested_differences ~ignore_neutral ~depth:(depth + 1) rules1 rules2
     in
     (* Check for position changes within parent container *)
     let pos1 =
@@ -1910,12 +1977,14 @@ and process_modified_container ~container_type ~extract_fn ~depth ~stmts1
            nested_containers)
     else None
 
-and process_nested_containers ~container_type ~extract_fn ~diff_fn ~depth stmts1
-    stmts2 =
+and process_nested_containers ~ignore_neutral ~container_type ~extract_fn
+    ~diff_fn ~depth stmts1 stmts2 =
   let items_with_pos1 = extract_items_with_positions extract_fn stmts1 in
   let items_with_pos2 = extract_items_with_positions extract_fn stmts2 in
   let block_structure_changed =
     detect_block_structure_changes
+      ~reordered_keys:(significant_reorder_keys ~ignore_neutral stmts1 stmts2)
+      ~stmts1
       (group_by_condition items_with_pos1)
       (group_by_condition items_with_pos2)
   in
@@ -1941,8 +2010,8 @@ and process_nested_containers ~container_type ~extract_fn ~diff_fn ~depth stmts1
   List.iter
     (fun (cond, rules1, rules2) ->
       match
-        process_modified_container ~container_type ~extract_fn ~depth ~stmts1
-          ~stmts2 ~block_structure_changed cond rules1 rules2
+        process_modified_container ~ignore_neutral ~container_type ~extract_fn
+          ~depth ~stmts1 ~stmts2 ~block_structure_changed cond rules1 rules2
       with
       | Some diff -> diffs := diff :: !diffs
       | None -> ())
@@ -1956,7 +2025,7 @@ and process_nested_containers ~container_type ~extract_fn ~diff_fn ~depth stmts1
   !diffs
 
 (* Layer diff function *)
-and layer_diff items1 items2 =
+and layer_diff ~ignore_neutral items1 items2 =
   let key_of (name_opt, _) = Option.value ~default:"" name_opt in
   let key_equal = String.equal in
   let is_empty_diff (_, rules1) (_, rules2) =
@@ -1967,7 +2036,9 @@ and layer_diff items1 items2 =
     if has_immediate_diffs then false
     else
       (* Also check for nested differences *)
-      let nested_diffs = nested_differences ~depth:1 rules1 rules2 in
+      let nested_diffs =
+        nested_differences ~ignore_neutral ~depth:1 rules1 rules2
+      in
       nested_diffs = []
   in
   let added, removed, modified_pairs =
@@ -1994,7 +2065,8 @@ and layer_diff items1 items2 =
 
 (* Shared helper: collect added/removed container diffs and process modified
    containers with the standard rule-change + nesting logic. *)
-and collect_container_diffs ~container_type ~depth added removed modified =
+and collect_container_diffs ~ignore_neutral ~container_type ~depth added removed
+    modified =
   let diffs = ref [] in
   List.iter
     (fun (condition, rules) ->
@@ -2006,9 +2078,9 @@ and collect_container_diffs ~container_type ~depth added removed modified =
     removed;
   List.iter
     (fun (condition, rules1, rules2) ->
-      let rule_changes = to_rule_changes rules1 rules2 in
+      let rule_changes = to_rule_changes ~ignore_neutral rules1 rules2 in
       let nested_containers =
-        nested_differences ~depth:(depth + 1) rules1 rules2
+        nested_differences ~ignore_neutral ~depth:(depth + 1) rules1 rules2
       in
       if
         (rule_changes <> [] || nested_containers <> [])
@@ -2027,23 +2099,25 @@ and collect_container_diffs ~container_type ~depth added removed modified =
   !diffs
 
 (* Process layers separately due to different type signature *)
-and process_nested_layers ~depth stmts1 stmts2 =
+and process_nested_layers ~ignore_neutral ~depth stmts1 stmts2 =
   let items1 = List.filter_map Css.as_layer stmts1 in
   let items2 = List.filter_map Css.as_layer stmts2 in
-  let added, removed, modified = layer_diff items1 items2 in
-  collect_container_diffs ~container_type:`Layer ~depth added removed modified
+  let added, removed, modified = layer_diff ~ignore_neutral items1 items2 in
+  collect_container_diffs ~ignore_neutral ~container_type:`Layer ~depth added
+    removed modified
 
-and container_has_no_diff (_, _, rules1) (_, _, rules2) =
+and container_has_no_diff ~ignore_neutral (_, _, rules1) (_, _, rules2) =
   let a_r, r_r, m_r, rg_r = rule_diffs rules1 rules2 in
   let has_immediate_diffs = a_r <> [] || r_r <> [] || m_r <> [] || rg_r <> [] in
   if has_immediate_diffs then false
-  else nested_differences ~depth:1 rules1 rules2 = []
+  else nested_differences ~ignore_neutral ~depth:1 rules1 rules2 = []
 
 (* Container diff function for @container rules *)
-and container_diff items1 items2 =
+and container_diff ~ignore_neutral items1 items2 =
   let key_equal = String.equal in
   let added, removed, modified_pairs =
-    diffs ~key_of:container_key ~key_equal ~is_empty_diff:container_has_no_diff
+    diffs ~key_of:container_key ~key_equal
+      ~is_empty_diff:(container_has_no_diff ~ignore_neutral)
       items1 items2
   in
   (* Transform to consistent format with media_diff. *)
@@ -2053,15 +2127,15 @@ and container_diff items1 items2 =
   (added, removed, modified)
 
 (* Process container rules *)
-and process_nested_containers_with_name ~depth stmts1 stmts2 =
+and process_nested_containers_with_name ~ignore_neutral ~depth stmts1 stmts2 =
   let items1 = List.filter_map Css.as_container stmts1 in
   let items2 = List.filter_map Css.as_container stmts2 in
-  let added, removed, modified = container_diff items1 items2 in
-  collect_container_diffs ~container_type:`Container ~depth added removed
-    modified
+  let added, removed, modified = container_diff ~ignore_neutral items1 items2 in
+  collect_container_diffs ~ignore_neutral ~container_type:`Container ~depth
+    added removed modified
 
 (* Process property rules *)
-and process_nested_properties ~depth stmts1 stmts2 =
+and process_nested_properties ~ignore_neutral ~depth stmts1 stmts2 =
   let items1 = List.filter_map Css.as_property stmts1 in
   let items2 = List.filter_map Css.as_property stmts2 in
   let added, removed, modified = property_diff items1 items2 in
@@ -2079,9 +2153,9 @@ and process_nested_properties ~depth stmts1 stmts2 =
     removed;
   List.iter
     (fun (name, rules1, rules2) ->
-      let rule_changes = to_rule_changes rules1 rules2 in
+      let rule_changes = to_rule_changes ~ignore_neutral rules1 rules2 in
       let nested_containers =
-        nested_differences ~depth:(depth + 1) rules1 rules2
+        nested_differences ~ignore_neutral ~depth:(depth + 1) rules1 rules2
       in
       diffs :=
         Modified
@@ -2097,7 +2171,7 @@ and process_nested_properties ~depth stmts1 stmts2 =
   !diffs @ property_reorder_diffs stmts1 stmts2 items1 items2
 
 (* Process CSS nesting: rules with nested child rules (& .foo { ... }) *)
-and process_nested_rules ~depth stmts1 stmts2 =
+and process_nested_rules ~ignore_neutral ~depth stmts1 stmts2 =
   (* Extract (selector_key, nested_statements) for all rules, including those
      with empty nesting. This allows detecting when nesting is added/removed. *)
   let extract_nesting stmts =
@@ -2116,9 +2190,10 @@ and process_nested_rules ~depth stmts1 stmts2 =
     (fun (sel1, nested1) ->
       match List.find_opt (fun (s, _) -> s = sel1) items2 with
       | Some (_, nested2) when nested1 <> nested2 ->
-          let rule_changes = to_rule_changes nested1 nested2 in
+          let rule_changes = to_rule_changes ~ignore_neutral nested1 nested2 in
           let nested_containers =
-            nested_differences ~depth:(depth + 1) nested1 nested2
+            nested_differences ~ignore_neutral ~depth:(depth + 1) nested1
+              nested2
           in
           if rule_changes <> [] || nested_containers <> [] then
             diffs :=
@@ -2141,54 +2216,70 @@ and process_nested_rules ~depth stmts1 stmts2 =
   !diffs
 
 (* Main recursive function for nested differences *)
-and nested_differences ?(depth = 0) (stmts1 : Css.statement list)
-    (stmts2 : Css.statement list) : container_diff list =
+and nested_differences ~ignore_neutral ?(depth = 0)
+    (stmts1 : Css.statement list) (stmts2 : Css.statement list) :
+    container_diff list =
   if depth > 3 then [] (* Prevent infinite recursion *)
   else
     (* Process CSS nesting (& .foo { ... } inside rules) *)
-    process_nested_rules ~depth stmts1 stmts2
+    process_nested_rules ~ignore_neutral ~depth stmts1 stmts2
     (* Process media queries *)
-    @ process_nested_containers ~container_type:`Media
-        ~extract_fn:extract_media_as_string ~diff_fn:media_diff ~depth stmts1
-        stmts2
+    @ process_nested_containers ~ignore_neutral ~container_type:`Media
+        ~extract_fn:extract_media_as_string
+        ~diff_fn:(media_diff ~ignore_neutral)
+        ~depth stmts1 stmts2
     (* Process layers - different type signature *)
-    @ process_nested_layers ~depth stmts1 stmts2
+    @ process_nested_layers ~ignore_neutral ~depth stmts1 stmts2
     (* Process supports - reuses media_diff since they have the same
        structure *)
-    @ process_nested_containers ~container_type:`Supports
-        ~extract_fn:extract_supports_as_string ~diff_fn:media_diff ~depth stmts1
-        stmts2
+    @ process_nested_containers ~ignore_neutral ~container_type:`Supports
+        ~extract_fn:extract_supports_as_string
+        ~diff_fn:(media_diff ~ignore_neutral)
+        ~depth stmts1 stmts2
     (* Process container queries *)
-    @ process_nested_containers_with_name ~depth stmts1 stmts2
+    @ process_nested_containers_with_name ~ignore_neutral ~depth stmts1 stmts2
     (* Process property declarations *)
-    @ process_nested_properties ~depth stmts1 stmts2
+    @ process_nested_properties ~ignore_neutral ~depth stmts1 stmts2
     (* Process keyframes animations *)
     @ process_nested_keyframes ~depth stmts1 stmts2
     (* Process font-face rules *)
     @ process_font_face_rules ~depth stmts1 stmts2
 
-(* Check if containers appear at different positions in statement sequence *)
-let detect_container_position_changes stmts1 stmts2 containers =
-  (* Build position maps for @media containers *)
-  let build_media_position_map stmts =
-    List.mapi
-      (fun i stmt ->
-        match Css.as_media stmt with
-        | Some (cond, _) -> Some (Css.Media.to_string cond, i)
-        | None -> None)
-      stmts
-    |> List.filter_map (fun x -> x)
-    |> List.fold_left
-         (fun acc (cond, pos) ->
-           let existing = try List.assoc cond acc with Not_found -> [] in
-           (cond, pos :: existing) :: List.remove_assoc cond acc)
-         []
-  in
+let build_media_position_map stmts =
+  List.mapi
+    (fun i stmt ->
+      match Css.as_media stmt with
+      | Some (cond, _) -> Some (Css.Media.to_string cond, i)
+      | None -> None)
+    stmts
+  |> List.filter_map Fun.id
+  |> List.fold_left
+       (fun acc (cond, pos) ->
+         let existing = try List.assoc cond acc with Not_found -> [] in
+         (cond, pos :: existing) :: List.remove_assoc cond acc)
+       []
 
+let media_present pos_map condition =
+  match List.assoc_opt condition pos_map with
+  | Some (_ :: _) -> true
+  | _ -> false
+
+(* A same-condition [@media] block differs only when it is genuinely reordered -
+   it and some order-constrained statement flipped. Two blocks sitting at
+   different absolute indices because unrelated content grew between them is
+   neutral drift. *)
+let media_block_reordered ~reordered_keys ~stmts1 ~pos_map1 condition =
+  List.exists
+    (fun p ->
+      match List.nth_opt stmts1 p with
+      | Some stmt -> Hashtbl.mem reordered_keys (stmt_key stmt)
+      | None -> false)
+    (Option.value ~default:[] (List.assoc_opt condition pos_map1))
+
+(* Check if containers appear at different positions in statement sequence *)
+let detect_container_position_changes ~reordered_keys stmts1 stmts2 containers =
   let pos_map1 = build_media_position_map stmts1 in
   let pos_map2 = build_media_position_map stmts2 in
-
-  (* Enhance container_diffs with position info *)
   List.map
     (function
       | Modified
@@ -2198,21 +2289,13 @@ let detect_container_position_changes stmts1 stmts2 containers =
              container_changes;
              _;
            } as cm)
-        when rule_changes = [] && container_changes = [] ->
-          (* No content changes - check if position changed *)
-          let pos1 =
-            try List.assoc condition pos_map1 |> List.hd
-            with Not_found | Failure _ -> -1
-          in
-          let pos2 =
-            try List.assoc condition pos_map2 |> List.hd
-            with Not_found | Failure _ -> -1
-          in
-          if pos1 >= 0 && pos2 >= 0 && abs (pos2 - pos1) > 5 then
-            (* Significant position change - report as structure difference *)
-            Modified
-              { cm with info = { cm.info with rules = [] }; actual_rules = [] }
-          else Modified cm
+        when rule_changes = [] && container_changes = []
+             && media_present pos_map1 condition
+             && media_present pos_map2 condition
+             && media_block_reordered ~reordered_keys ~stmts1 ~pos_map1
+                  condition ->
+          Modified
+            { cm with info = { cm.info with rules = [] }; actual_rules = [] }
       | other -> other)
     containers
 
@@ -2293,7 +2376,9 @@ let process_imports stmts1 stmts2 : rule_diff list =
         (fun s -> (Added { selector = s; declarations = [] } : rule_diff))
         (multiset_remove_each ~remove:l1 l2)
 
-let diff ~(expected : Css.t) ~(actual : Css.t) : t =
+let diff ?(ignore_neutral_reorders = false) ~(expected : Css.t)
+    ~(actual : Css.t) () : t =
+  let ignore_neutral = ignore_neutral_reorders in
   let all1 = Css.statements expected in
   let all2 = Css.statements actual in
   (* Imports are diffed separately ([process_imports]); excluding them here
@@ -2301,18 +2386,23 @@ let diff ~(expected : Css.t) ~(actual : Css.t) : t =
   let rules1 = List.filter (fun s -> Css.as_import s = None) all1 in
   let rules2 = List.filter (fun s -> Css.as_import s = None) all2 in
   let added, removed, modified, regrouped = rule_diffs rules1 rules2 in
+  let reordered_keys = significant_reorder_keys ~ignore_neutral rules1 rules2 in
 
   let rule_changes =
     List.map convert_added_rule added
     @ List.map convert_removed_rule removed
-    @ List.filter_map (convert_modified_rule ~rules1 ~rules2) modified
+    @ List.filter_map
+        (convert_modified_rule ~reordered_keys ~rules1 ~rules2)
+        modified
     @ regrouped @ process_imports all1 all2
   in
 
   (* Delegate all container and nested-container diffs to the generic walker *)
   let containers =
-    let base_containers = nested_differences ~depth:0 all1 all2 in
-    detect_container_position_changes all1 all2 base_containers
+    let base_containers =
+      nested_differences ~ignore_neutral ~depth:0 all1 all2
+    in
+    detect_container_position_changes ~reordered_keys all1 all2 base_containers
   in
 
   { rules = rule_changes; containers }

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -79,9 +79,13 @@ type t = { rules : rule_diff list; containers : container_diff list }
 val is_empty : t -> bool
 (** [is_empty d] returns [true] if [d] contains no differences. *)
 
-val diff : expected:Css.t -> actual:Css.t -> t
-(** [diff ~expected ~actual] computes structural differences between two CSS
-    ASTs. *)
+val diff :
+  ?ignore_neutral_reorders:bool -> expected:Css.t -> actual:Css.t -> unit -> t
+(** [diff ~expected ~actual ()] computes structural differences between two CSS
+    ASTs. With [~ignore_neutral_reorders:true] a position difference between two
+    statements that cannot cascade-conflict is treated as a no-op rather than a
+    reorder - used by the canonical comparison, whose inputs are already
+    cascade-equivalent up to neutral reordering. *)
 
 val pp : ?expected:string -> ?actual:string -> Buffer.t -> t -> unit
 (** [pp ?expected ?actual buf t] pretty-prints a tree diff with optional labels.

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -439,3 +439,49 @@ let canonicalize (stmts : statement list) : statement list =
     canonicalize_block ~parent:(None : Selector.t option) changed stmts
   in
   if !changed then result else stmts
+
+(* Order-constraint predicate over a flat statement list. [order_constrained
+   stmts i j] is true when reordering the statements at positions [i] and [j]
+   could change a computed value: run elements (style rules and
+   [@media]/[@supports]/[@container] blocks over plain rules) use the dependency
+   graph's conflict test, and any other statement is a barrier, order-
+   constrained with everything. The diff uses this to separate a cascade-neutral
+   position drift (both endpoints unconstrained) from a real reorder. *)
+let order_constrained (stmts : statement list) : int -> int -> bool =
+  let arr = Array.of_list stmts in
+  let n = Array.length arr in
+  let is_element = Array.map (fun s -> Option.is_some (element_rules s)) arr in
+  (* Compare per contained rule, not on a block's union footprint: an [@media]
+     taken over the union of its rules' selectors and declarations conflicts
+     with far more than any single rule does. Flatten every element to its rules
+     and constrain two elements exactly when some rule of one conflicts with
+     some rule of the other. *)
+  let rules_of s = match element_rules s with Some rs -> rs | None -> [] in
+  let ranges = Array.make n (0, 0) in
+  let flat = ref [] in
+  let acc = ref 0 in
+  Array.iteri
+    (fun i s ->
+      let rs = rules_of s in
+      ranges.(i) <- (!acc, List.length rs);
+      List.iter
+        (fun r ->
+          flat := r :: !flat;
+          incr acc)
+        rs)
+    arr;
+  let g = Rule_graph.of_rules (List.rev !flat) in
+  let node = Rule_graph.Node_id.of_int_exn in
+  fun i j ->
+    if i = j || i < 0 || j < 0 || i >= n || j >= n then false
+    else if (not is_element.(i)) || not is_element.(j) then true
+    else
+      let si, ci = ranges.(i) and sj, cj = ranges.(j) in
+      let found = ref false in
+      for a = si to si + ci - 1 do
+        for b = sj to sj + cj - 1 do
+          if (not !found) && Rule_graph.conflict g (node a) (node b) then
+            found := true
+        done
+      done;
+      !found

--- a/lib/rule_order.mli
+++ b/lib/rule_order.mli
@@ -22,3 +22,13 @@ val canonicalize : Stylesheet.statement list -> Stylesheet.statement list
     rules, and custom-property rules are barriers: they keep their position and
     split runs. Returns the input list physically unchanged when no run
     reorders. *)
+
+val order_constrained : Stylesheet.statement list -> int -> int -> bool
+(** [order_constrained stmts i j] is [true] when reordering the statements at
+    positions [i] and [j] could change a computed value. Partially applying it
+    to [stmts] alone returns the predicate over positions. Two run elements
+    (style rules, or [@media]/[@supports]/[@container] blocks over plain rules)
+    are constrained only when their selectors may match a common element at
+    equal specificity and their declarations overlap; any other statement is a
+    barrier constrained with everything. Lets a structural diff treat a position
+    difference between two mutually unconstrained statements as a no-op. *)

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -130,12 +130,15 @@ stays ordered: swapping it with the rule is a real difference.
   $ NO_COLOR=1 cascade diff --diff=canonical before.css after.css
   cascade: CSS files differ
   CSS: 48 chars vs 48 chars (0.0% diff)
-  Changes: 1 reordered rule
+  Changes: 1 reordered rule, 1 containers
   
   --- before.css
   +++ after.css
   Rules reordered (1 rules):
-  └─ .a ↔  @media print
+  ├─ .a ↔  @media print
+  └─ @media print (1 blocks at different positions)
+        - Block at position 1: .a
+        + Block at position 0: .a
   
   [124]
 

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -8,21 +8,21 @@ let parse css = Css.of_string_exn ~strict:false css
 
 let diff_identical () =
   let css = parse ".a { color: red }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css in
+  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css () in
   Alcotest.(check bool)
     "identical is empty" true
     (Cascade_diff.Tree_diff.is_empty d)
 
 let diff_identical_multiple_rules () =
   let css = parse ".a { color: red } .b { margin: 0 }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css in
+  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css () in
   Alcotest.(check bool)
     "identical multi-rule is empty" true
     (Cascade_diff.Tree_diff.is_empty d)
 
 let diff_empty_stylesheets () =
   let css = parse "" in
-  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css in
+  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css () in
   Alcotest.(check bool)
     "empty stylesheets is empty" true
     (Cascade_diff.Tree_diff.is_empty d)
@@ -32,7 +32,7 @@ let diff_empty_stylesheets () =
 let diff_rule_added () =
   let expected = parse ".a { color: red }" in
   let actual = parse ".a { color: red } .b { margin: 0 }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "addition is not empty" false
     (Cascade_diff.Tree_diff.is_empty d);
@@ -51,7 +51,7 @@ let diff_rule_added () =
 let diff_rule_removed () =
   let expected = parse ".a { color: red } .b { margin: 0 }" in
   let actual = parse ".a { color: red }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "removal is not empty" false
     (Cascade_diff.Tree_diff.is_empty d);
@@ -68,7 +68,7 @@ let diff_rule_removed () =
 let diff_property_changed () =
   let expected = parse ".a { color: red }" in
   let actual = parse ".a { color: blue }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "property change is not empty" false
     (Cascade_diff.Tree_diff.is_empty d);
@@ -77,7 +77,7 @@ let diff_property_changed () =
 let diff_rule_added_property () =
   let expected = parse ".a { color: red }" in
   let actual = parse ".a { color: red; margin: 0 }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "added property is not empty" false
     (Cascade_diff.Tree_diff.is_empty d)
@@ -87,7 +87,7 @@ let diff_rule_added_property () =
 let diff_rule_reordered () =
   let expected = parse ".a { color: red } .b { margin: 0 }" in
   let actual = parse ".b { margin: 0 } .a { color: red }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "reorder is not empty" false
     (Cascade_diff.Tree_diff.is_empty d);
@@ -108,7 +108,7 @@ let diff_media_added () =
   let actual =
     parse ".a { color: red } @media (min-width: 768px) { .b { margin: 0 } }"
   in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "media addition is not empty" false
     (Cascade_diff.Tree_diff.is_empty d);
@@ -122,7 +122,7 @@ let diff_media_removed () =
     parse ".a { color: red } @media (min-width: 768px) { .b { margin: 0 } }"
   in
   let actual = parse ".a { color: red }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "media removal is not empty" false
     (Cascade_diff.Tree_diff.is_empty d);
@@ -133,7 +133,7 @@ let diff_media_removed () =
 let diff_layer_added () =
   let expected = parse ".a { color: red }" in
   let actual = parse ".a { color: red } @layer base { .b { margin: 0 } }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "layer addition not empty" false
     (Cascade_diff.Tree_diff.is_empty d);
@@ -154,7 +154,7 @@ let diff_nesting_modified () =
       ".card { padding: 1.5rem; & .title { font-size: 1.25rem; color: #000; \
        font-weight: 600 } }"
   in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "nesting diff not empty" false
     (d.rules = [] && d.containers = []);
@@ -166,7 +166,7 @@ let diff_nesting_modified () =
 
 let diff_nesting_identical () =
   let css = parse ".card { padding: 1rem; & .title { font-size: 1.5rem } }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css in
+  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css () in
   Alcotest.(check bool)
     "identical nesting is empty" true
     (Cascade_diff.Tree_diff.is_empty d)
@@ -176,7 +176,7 @@ let diff_nesting_child_added () =
   let actual =
     parse ".card { padding: 1rem; & .title { font-size: 1.5rem } }"
   in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "nested child added not empty" false
     (Cascade_diff.Tree_diff.is_empty d)
@@ -186,7 +186,7 @@ let diff_nesting_child_removed () =
     parse ".card { padding: 1rem; & .title { font-size: 1.5rem } }"
   in
   let actual = parse ".card { padding: 1rem }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "nested child removed not empty" false
     (Cascade_diff.Tree_diff.is_empty d)
@@ -194,7 +194,7 @@ let diff_nesting_child_removed () =
 let diff_nesting_deep () =
   let expected = parse ".a { & .b { & .c { color: red } } }" in
   let actual = parse ".a { & .b { & .c { color: blue } } }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "deep nesting diff not empty" false
     (Cascade_diff.Tree_diff.is_empty d)
@@ -204,7 +204,7 @@ let diff_nesting_parent_props_only () =
     parse ".card { padding: 1rem; & .title { font-size: 1rem } }"
   in
   let actual = parse ".card { padding: 2rem; & .title { font-size: 1rem } }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "parent-only change not empty" false
     (Cascade_diff.Tree_diff.is_empty d);
@@ -219,14 +219,14 @@ let diff_nesting_parent_props_only () =
 let single_rule_diff_one_change () =
   let expected = parse ".a { color: red }" in
   let actual = parse ".a { color: blue }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "single_rule_diff returns Some" true
     (Option.is_some (Cascade_diff.Tree_diff.single_rule_diff d))
 
 let single_rule_diff_no_change () =
   let css = parse ".a { color: red }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css in
+  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css () in
   Alcotest.(check bool)
     "single_rule_diff returns None" true
     (Option.is_none (Cascade_diff.Tree_diff.single_rule_diff d))
@@ -234,7 +234,7 @@ let single_rule_diff_no_change () =
 let single_rule_diff_multiple_changes () =
   let expected = parse ".a { color: red } .b { margin: 0 }" in
   let actual = parse ".a { color: blue } .b { margin: 10px }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   (* Multiple rule changes means single_rule_diff should return None *)
   let result = Cascade_diff.Tree_diff.single_rule_diff d in
   (* Only None when there are exactly != 1 rule changes *)
@@ -249,13 +249,13 @@ let count_containers_media () =
   let actual =
     parse ".a { color: red } @media (min-width: 768px) { .b { margin: 0 } }"
   in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   let count = Cascade_diff.Tree_diff.count_containers_by_type `Media d in
   Alcotest.(check bool) "at least one media container" true (count >= 1)
 
 let count_containers_zero () =
   let css = parse ".a { color: red }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css in
+  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css () in
   let count = Cascade_diff.Tree_diff.count_containers_by_type `Media d in
   Alcotest.(check int) "zero media containers" 0 count
 
@@ -264,7 +264,7 @@ let count_containers_zero () =
 let pp_does_not_crash () =
   let expected = parse ".a { color: red }" in
   let actual = parse ".a { color: blue }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   let buf = Buffer.create 256 in
   Cascade_diff.Tree_diff.pp buf d;
   let output = Buffer.contents buf in
@@ -273,7 +273,7 @@ let pp_does_not_crash () =
 let pp_rule_diff_simple_ok () =
   let expected = parse ".a { color: red }" in
   let actual = parse ".a { color: blue }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   match d.rules with
   | [] -> Alcotest.fail "expected rule diffs"
   | rule :: _ ->
@@ -301,7 +301,7 @@ let diff_selector_group_split_reported () =
      regroup (not add/remove noise, not silently identical). *)
   let expected = parse ".a, .b { color: red }" in
   let actual = parse ".a { color: red } .b { color: red }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "split is reported, not identical" false
     (Cascade_diff.Tree_diff.is_empty d);
@@ -316,7 +316,7 @@ let diff_selector_group_split_reported () =
 let diff_selector_group_merge_reported () =
   let expected = parse ".a { color: red } .b { color: red }" in
   let actual = parse ".a, .b { color: red }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "merge is reported, not identical" false
     (Cascade_diff.Tree_diff.is_empty d);
@@ -330,7 +330,7 @@ let diff_selector_group_partial_change () =
      surfaces, the unchanged one is reconciled away (not add/remove noise). *)
   let expected = parse ".a, .b { color: red }" in
   let actual = parse ".a { color: red } .b { color: blue }" in
-  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual () in
   Alcotest.(check bool)
     "partial regroup is not empty" false
     (Cascade_diff.Tree_diff.is_empty d);


### PR DESCRIPTION
`Css_compare` canonical mode flagged a rule or `@media` block as reordered whenever its absolute index differed between the two sheets. When two cascade-equivalent stylesheets group `@media` blocks to a different degree (as tw and lightningcss do on the ocaml.org corpus), every later statement's index shifts, so the comparison reported dozens of spurious "reordered" / "blocks at different positions" markers on output that renders identically.

This compares *relative order against conflicting statements* instead of absolute index. It adds `Css.order_constrained`, a per-rule conflict predicate (flattening each block to its rules rather than taking a block's union footprint, so an `@media` no longer conflicts with everything its rules touch), and marks a statement reordered only when it and some order-constrained statement flipped relative order. Drift past statements it cannot cascade-conflict with is a no-op. The suppression is gated to canonical mode with `~ignore_neutral_reorders`; `--diff=tree` still reports structural reorders.

On the ocaml.org corpus this cuts the markers from ~62 to 15; the remainder are genuine any-DOM reorders of overlapping utilities (e.g. `.rounded-l-*` flips with `.rounded-b`, which share `border-bottom-left-radius`), which lightningcss reorders under Tailwind's one-utility-per-property invariant and cascade's any-DOM comparison correctly keeps.