### PR TITLE
diff: honour colour settings and use CI-friendly exit codes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -70,8 +70,10 @@ library, then stabilised over several internal milestones.
   input file, and `cascade --inline-vars` substitutes static custom-property
   references. `--keep-vars=NAMES` preserves selected custom properties.
 - `cascade diff` provides structural CSS diffing between two files with
-  `auto`, `tree`, `string`, and `canonical` modes; respects `NO_COLOR` and
-  `CASCADE_COLOR`. The `canonical` mode projects both sheets to a normal form
+  `auto`, `tree`, `string`, and `canonical` modes; respects `NO_COLOR`,
+  `CASCADE_COLOR`, and `--color`, and colours only when stdout is a tty.
+  Identical files exit 0 and differing files exit 1, so the command slots
+  into CI checks and git hooks. The `canonical` mode projects both sheets to a normal form
   first, so equivalent factorings -- different rule grouping, cascade-safe rule
   and declaration order -- compare identical rather than as spurious changes.
 - The CLI is installable as a binary through the Homebrew tap

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -12,8 +12,16 @@ let read_file path =
     Ok content
   with Sys_error msg -> err_read path msg
 
+let no_color_var = "NO_COLOR"
+
+let no_color_env =
+  Cmd.Env.info no_color_var
+    ~doc:
+      "When set to a non-empty value, disable colour output (see \
+       https://no-color.org/). Overrides $(b,--color) and $(b,CASCADE_COLOR)."
+
 let resolve_style_renderer style_renderer =
-  match Sys.getenv_opt "NO_COLOR" with
+  match Sys.getenv_opt no_color_var with
   | Some s when s <> "" -> Some `None
   | _ -> style_renderer
 
@@ -28,14 +36,14 @@ let run_diff mode ~lossless ~prune_unused_custom_props ~css1 ~css2 =
   Cascade_diff.Css_compare.diff ~mode ~lossless ~prune_unused_custom_props css1
     css2
 
-let print_diff_report ~file1 ~file2 ~css1 ~css2 result =
+let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 result =
   let stats =
     Cascade_diff.Css_compare.stats ~expected_str:css1 ~actual_str:css2 result
   in
   let buf = Buffer.create 1024 in
   Cascade_diff.Css_compare.pp_stats buf stats;
   Buffer.add_char buf '\n';
-  Cascade_diff.Css_compare.pp ~expected:file1 ~actual:file2 buf result;
+  Cascade_diff.Css_compare.pp ~expected:file1 ~actual:file2 ~color buf result;
   Buffer.add_char buf '\n';
   print_string (Buffer.contents buf)
 
@@ -46,6 +54,14 @@ let compare_files file1 file2 style_renderer mode opts memtrace_path () =
   Fmt_tty.setup_std_outputs
     ?style_renderer:(resolve_style_renderer style_renderer)
     ();
+  (* The report is built in a plain buffer, so the diff printers cannot see the
+     tty; resolve the colour decision Fmt_tty just made (tty detection, --color,
+     CASCADE_COLOR, NO_COLOR) and pass it down. *)
+  let color =
+    match Fmt.style_renderer Fmt.stdout with
+    | `Ansi_tty -> true
+    | `None -> false
+  in
   match (read_file file1, read_file file2) with
   | Ok css1, Ok css2 -> (
       if css1 = css2 then (
@@ -62,16 +78,17 @@ let compare_files file1 file2 style_renderer mode opts memtrace_path () =
             (* Equal ASTs can still hide parse-dropped declarations; show the
                warnings so the equality verdict is honest about them. *)
             let buf = Buffer.create 256 in
-            Cascade_diff.Css_compare.pp ~expected:file1 ~actual:file2 buf result;
+            Cascade_diff.Css_compare.pp ~expected:file1 ~actual:file2 ~color buf
+              result;
             print_string (Buffer.contents buf);
             Fmt.pr "CSS files are identical@.";
             Ok ()
-        | String_diff _ ->
-            print_diff_report ~file1 ~file2 ~css1 ~css2 result;
-            Error (`Msg "CSS files differ (string diff)")
-        | Tree_diff _ | Both_errors _ | Expected_error _ | Actual_error _ ->
-            print_diff_report ~file1 ~file2 ~css1 ~css2 result;
-            Error (`Msg "CSS files differ"))
+        | String_diff _ | Tree_diff _ | Both_errors _ | Expected_error _
+        | Actual_error _ ->
+            print_diff_report ~color ~file1 ~file2 ~css1 ~css2 result;
+            (* Differing inputs are a result, not a usage error: exit 1 as
+               documented, distinct from cmdliner's reserved error codes. *)
+            exit 1)
   | Error e, _ | _, Error e -> Error e
 
 let file1_arg =
@@ -130,7 +147,13 @@ let memtrace_arg =
 let term =
   let open Term in
   let style_renderer_with_env =
-    Fmt_cli.style_renderer ~env:(Cmd.Env.info "CASCADE_COLOR") ()
+    Fmt_cli.style_renderer
+      ~env:
+        (Cmd.Env.info "CASCADE_COLOR"
+           ~doc:
+             "Set to $(b,auto), $(b,always), or $(b,never) to control colour \
+              output, like $(b,--color) (overridden by $(b,NO_COLOR)).")
+      ()
   in
   let canonical_opts =
     const (fun lossless prune_unused_custom_props ->
@@ -176,17 +199,8 @@ let man =
     `S Manpage.s_exit_status;
     `P "$(tname) exits with:";
     `I ("0", "if the CSS files are identical");
-    `I ("1", "if the CSS files differ or an error occurred");
-    `S Manpage.s_environment;
-    `P "Color output can be controlled via environment variables:";
-    `I
-      ( "NO_COLOR",
-        "When set to any non-empty value, disables color output (see \
-         https://no-color.org/)" );
-    `I
-      ( "CASCADE_COLOR",
-        "Set to 'auto', 'always', or 'never' to control color output \
-         (overridden by NO_COLOR)" );
+    `I ("1", "if the CSS files differ");
+    `I ("124", "on command-line errors or unreadable input files");
     `S Manpage.s_examples;
     `P "Compare two CSS files:";
     `Pre "  cascade diff reference.css output.css";
@@ -198,4 +212,4 @@ let man =
 
 let cmd =
   let doc = "Compare two CSS files with structural analysis" in
-  Cmd.v (Cmd.info "diff" ~doc ~man) term
+  Cmd.v (Cmd.info "diff" ~doc ~man ~envs:[ no_color_env ]) term

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -512,10 +512,11 @@ let pp_parse_warnings buf label warnings =
       add_strings buf [ label; " parse warning: "; Error.to_string w; "\n" ])
     warnings
 
-let pp_result ?(expected = "Expected") ?(actual = "Actual") buf = function
+let pp_result ?(expected = "Expected") ?(actual = "Actual") ?(color = false) buf
+    = function
   | Tree_diff d ->
       (* Show structural differences *)
-      D.pp ~expected ~actual buf d
+      D.pp ~expected ~actual ~color buf d
   | String_diff sdiff -> String_diff.pp buf sdiff
   | No_diff _ ->
       (* No output for structurally equivalent files (whether or not the
@@ -543,8 +544,8 @@ let pp_result ?(expected = "Expected") ?(actual = "Actual") buf = function
   | Actual_error e ->
       add_strings buf [ actual; " CSS parse error: "; Error.to_string e ]
 
-let pp ?(expected = "Expected") ?(actual = "Actual") buf t =
-  pp_result ~expected ~actual buf t.result;
+let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false) buf t =
+  pp_result ~expected ~actual ~color buf t.result;
   pp_parse_warnings buf expected t.expected_warnings;
   pp_parse_warnings buf actual t.actual_warnings
 

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -96,10 +96,13 @@ val as_tree_diff : t -> Tree_diff.t option
 (** [as_tree_diff result] returns the underlying [Tree_diff.t] when [result] is
     a {!constructor-Tree_diff}; [None] otherwise. *)
 
-val pp : ?expected:string -> ?actual:string -> Buffer.t -> t -> unit
-(** [pp ?expected ?actual buf result] formats [result] into [buf], then renders
-    each side's parse warnings. The [expected]/[actual] labels are used in the
-    rendered header and warning lines (defaults: ["Expected"], ["Actual"]). *)
+val pp :
+  ?expected:string -> ?actual:string -> ?color:bool -> Buffer.t -> t -> unit
+(** [pp ?expected ?actual ?color buf result] formats [result] into [buf], then
+    renders each side's parse warnings. The [expected]/[actual] labels are used
+    in the rendered header and warning lines (defaults: ["Expected"],
+    ["Actual"]). [color] (default [false]) wraps diff markers in ANSI escapes;
+    the caller decides whether the destination supports colour. *)
 
 (** {1:stats Statistics} *)
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -86,18 +86,26 @@ let is_empty d = d.rules = [] && d.containers = []
 (* Tree-style formatting helpers *)
 type tree_style = {
   use_tree : bool; (* Whether to use tree-style box-drawing characters *)
+  color : bool; (* Whether to wrap diff markers in ANSI colors *)
 }
 
-let default_style = { use_tree = false }
-let tree_style = { use_tree = true }
+let default_style = { use_tree = false; color = false }
+let tree_style = { use_tree = true; color = false }
 
-(* ANSI color helpers *)
-let ansi_green s = "\027[32m" ^ s ^ "\027[0m"
-let ansi_red s = "\027[31m" ^ s ^ "\027[0m"
-let ansi_yellow s = "\027[33m" ^ s ^ "\027[0m"
+(* ANSI color helpers. Plain text unless [color] is set: the printers write into
+   a [Buffer.t], so tty detection cannot happen here; the caller decides. *)
+let ansi code ~color s =
+  if color then "\027[" ^ code ^ "m" ^ s ^ "\027[0m" else s
 
-let style_text action s =
-  match action with "add" -> ansi_green s | "remove" -> ansi_red s | _ -> s
+let ansi_green ~color s = ansi "32" ~color s
+let ansi_red ~color s = ansi "31" ~color s
+let ansi_yellow ~color s = ansi "33" ~color s
+
+let style_text ~color action s =
+  match action with
+  | "add" -> ansi_green ~color s
+  | "remove" -> ansi_red ~color s
+  | _ -> s
 
 (* Get the appropriate prefix for tree-style formatting *)
 let tree_prefix ~style ~is_last ~parent_prefix =
@@ -136,7 +144,7 @@ let pp_declarations ?(style = default_style) ?(parent_prefix = "") buf action
       in
       Buffer.add_string buf
         (indent
-        ^ style_text action
+        ^ style_text ~color:style.color action
             (prefix_symbol ^ " " ^ prop_name ^ " " ^ truncated_value)
         ^ "\n"))
     decls
@@ -157,8 +165,11 @@ let pp_property_diff ?(style = default_style) ?(parent_prefix = "") buf
       if len1 <= 30 && len2 <= 30 then
         (* Short values: show inline with red for old, green for new *)
         Buffer.add_string buf
-          (indent ^ "* " ^ property_name ^ ": " ^ ansi_red expected_value
-         ^ " -> " ^ ansi_green actual_value ^ "\n")
+          (indent ^ "* " ^ property_name ^ ": "
+          ^ ansi_red ~color:style.color expected_value
+          ^ " -> "
+          ^ ansi_green ~color:style.color actual_value
+          ^ "\n")
       else
         (* Long values: truncate and show as separate lines *)
         let exp_truncated =
@@ -169,9 +180,13 @@ let pp_property_diff ?(style = default_style) ?(parent_prefix = "") buf
         in
         Buffer.add_string buf (indent ^ "* " ^ property_name ^ ":\n");
         Buffer.add_string buf
-          (indent ^ "  " ^ ansi_red ("- " ^ exp_truncated) ^ "\n");
+          (indent ^ "  "
+          ^ ansi_red ~color:style.color ("- " ^ exp_truncated)
+          ^ "\n");
         Buffer.add_string buf
-          (indent ^ "  " ^ ansi_green ("+ " ^ act_truncated) ^ "\n")
+          (indent ^ "  "
+          ^ ansi_green ~color:style.color ("+ " ^ act_truncated)
+          ^ "\n")
 
 let pp_property_diffs ?(style = default_style) ?(parent_prefix = "") buf
     prop_diffs =
@@ -272,11 +287,13 @@ let pp_content_changed ~style ~prefix ~child_prefix buf ~selector
     Buffer.add_string buf (prefix ^ selector ^ "\n");
     List.iter
       (fun prop_name ->
-        Buffer.add_string buf (indent ^ ansi_red ("- " ^ prop_name) ^ "\n"))
+        Buffer.add_string buf
+          (indent ^ ansi_red ~color:style.color ("- " ^ prop_name) ^ "\n"))
       removed_properties;
     List.iter
       (fun prop_name ->
-        Buffer.add_string buf (indent ^ ansi_green ("+ " ^ prop_name) ^ "\n"))
+        Buffer.add_string buf
+          (indent ^ ansi_green ~color:style.color ("+ " ^ prop_name) ^ "\n"))
       added_properties;
     pp_property_diffs ~style ~parent_prefix:child_prefix buf property_changes;
     pp_reorder ~style ~parent_prefix:child_prefix old_declarations
@@ -308,6 +325,27 @@ let pp_position_reorder ~prefix buf ~selector ~expected_pos ~actual_pos
       Buffer.add_string buf
         (prefix ^ truncate selector ^ " (position " ^ string_of_int expected_pos
        ^ " \xe2\x86\x92 " ^ string_of_int actual_pos ^ ")\n")
+
+let pp_regrouped ~style ~prefix ~child_prefix buf ~from_selectors ~to_selectors
+    =
+  let nf = List.length from_selectors and nt = List.length to_selectors in
+  let verb =
+    if nf > nt then "merged" else if nf < nt then "split" else "regrouped"
+  in
+  Buffer.add_string buf (prefix ^ "selectors " ^ verb ^ "\n");
+  let indent =
+    if style.use_tree then child_prefix ^ "   " else child_prefix ^ "    "
+  in
+  List.iter
+    (fun s ->
+      Buffer.add_string buf
+        (indent ^ ansi_red ~color:style.color ("- " ^ s) ^ "\n"))
+    from_selectors;
+  List.iter
+    (fun s ->
+      Buffer.add_string buf
+        (indent ^ ansi_green ~color:style.color ("+ " ^ s) ^ "\n"))
+    to_selectors
 
 let pp_rule_diff ?(style = default_style) ?(is_last = false)
     ?(parent_prefix = "") buf (diff : rule_diff) =
@@ -358,20 +396,8 @@ let pp_rule_diff ?(style = default_style) ?(is_last = false)
   | Regrouped { from_selectors; to_selectors } ->
       let prefix = tree_prefix ~style ~is_last ~parent_prefix in
       let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
-      let nf = List.length from_selectors and nt = List.length to_selectors in
-      let verb =
-        if nf > nt then "merged" else if nf < nt then "split" else "regrouped"
-      in
-      Buffer.add_string buf (prefix ^ "selectors " ^ verb ^ "\n");
-      let indent =
-        if style.use_tree then child_prefix ^ "   " else child_prefix ^ "    "
-      in
-      List.iter
-        (fun s -> Buffer.add_string buf (indent ^ ansi_red ("- " ^ s) ^ "\n"))
-        from_selectors;
-      List.iter
-        (fun s -> Buffer.add_string buf (indent ^ ansi_green ("+ " ^ s) ^ "\n"))
-        to_selectors
+      pp_regrouped ~style ~prefix ~child_prefix buf ~from_selectors
+        ~to_selectors
 
 let pp_rule_diff_simple buf (diff : rule_diff) =
   match diff with
@@ -569,8 +595,8 @@ let pp_block_structure_changed ~style ~is_last ~parent_prefix buf
             ^ "\n"))
       blocks
   in
-  pp_blocks "-" ansi_red expected_blocks;
-  pp_blocks "+" ansi_green actual_blocks
+  pp_blocks "-" (ansi_red ~color:style.color) expected_blocks;
+  pp_blocks "+" (ansi_green ~color:style.color) actual_blocks
 
 let pp_container_add_remove ~style ~is_last ~parent_prefix ~label buf
     container_type condition rules =
@@ -638,9 +664,11 @@ let rec pp_container_diff ?(style = default_style) ?(is_last = false)
       pp_block_structure_changed ~style ~is_last ~parent_prefix buf
         ~container_type ~condition ~expected_blocks ~actual_blocks
 
-let pp_diff_headers buf expected actual =
-  Buffer.add_string buf (ansi_yellow "---" ^ " " ^ ansi_yellow expected ^ "\n");
-  Buffer.add_string buf (ansi_yellow "+++" ^ " " ^ ansi_yellow actual ^ "\n")
+let pp_diff_headers ~color buf expected actual =
+  Buffer.add_string buf
+    (ansi_yellow ~color "---" ^ " " ^ ansi_yellow ~color expected ^ "\n");
+  Buffer.add_string buf
+    (ansi_yellow ~color "+++" ^ " " ^ ansi_yellow ~color actual ^ "\n")
 
 let pp_rule_list ~style ~container_count buf rule_list =
   let rule_count = List.length rule_list in
@@ -665,7 +693,8 @@ let pp_containers_section ~style buf containers =
       pp_container_diff ~style ~is_last ~parent_prefix:"" buf cont_diff)
     containers
 
-let pp ?(expected = "Expected") ?(actual = "Actual") buf { rules; containers } =
+let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false) buf
+    { rules; containers } =
   if rules = [] && containers = [] then
     Buffer.add_string buf
       "Structural differences detected in nested contexts (e.g., @media inside \
@@ -673,7 +702,7 @@ let pp ?(expected = "Expected") ?(actual = "Actual") buf { rules; containers } =
        but no rule-level differences found.\n\
        This may indicate reordering or subtle changes in rule organization."
   else (
-    pp_diff_headers buf expected actual;
+    pp_diff_headers ~color buf expected actual;
     let meaningful = meaningful_rules rules in
     let reordered_rules =
       List.filter
@@ -681,7 +710,7 @@ let pp ?(expected = "Expected") ?(actual = "Actual") buf { rules; containers } =
           match diff with Reordered _ -> true | _ -> false)
         rules
     in
-    let style = tree_style in
+    let style = { tree_style with color } in
     let container_count = List.length containers in
     pp_rule_list ~style ~container_count buf meaningful;
     pp_reordered_section ~style ~container_count buf reordered_rules;

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -83,9 +83,12 @@ val diff : expected:Css.t -> actual:Css.t -> t
 (** [diff ~expected ~actual] computes structural differences between two CSS
     ASTs. *)
 
-val pp : ?expected:string -> ?actual:string -> Buffer.t -> t -> unit
-(** [pp ?expected ?actual buf t] pretty-prints a tree diff with optional labels.
-    Default labels are "Expected" and "Actual". *)
+val pp :
+  ?expected:string -> ?actual:string -> ?color:bool -> Buffer.t -> t -> unit
+(** [pp ?expected ?actual ?color buf t] pretty-prints a tree diff with optional
+    labels. Default labels are "Expected" and "Actual". [color] (default
+    [false]) wraps diff markers in ANSI escapes; the printer writes into a
+    buffer, so the caller decides whether the destination supports colour. *)
 
 val pp_rule_diff_simple : Buffer.t -> rule_diff -> unit
 (** [pp_rule_diff_simple buf rule] pretty-prints a rule diff in a simple format

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -21,7 +21,6 @@ edit.
   > .x { color: blue }
   > EOF
   $ NO_COLOR=1 cascade diff c.css d.css
-  cascade: CSS files differ
   CSS: 19 chars vs 18 chars (5.6% diff)
   Changes: 1 modified rule
   
@@ -30,9 +29,17 @@ edit.
   └─ .x
         * color: red -> blue
   
-  [124]
+  [1]
 
+Forcing colour on emits ANSI markers even into a pipe; the default
+resolves to plain off-tty, as the NO_COLOR run above shows.
 
+  $ cascade diff --color=always c.css d.css | cat -v | head -5
+  CSS: 19 chars vs 18 chars (5.6% diff)
+  Changes: 1 modified rule
+  
+  ^[[33m---^[[0m ^[[33mc.css^[[0m
+  ^[[33m+++^[[0m ^[[33md.css^[[0m
 
 Equivalent colours under different spellings still surface as a
 modified rule under --diff=tree (cascade does not minify before
@@ -45,7 +52,6 @@ diffing).
   > .x { color: #f00 }
   > EOF
   $ NO_COLOR=1 cascade diff --diff=tree e.css f.css
-  cascade: CSS files differ
   CSS: 19 chars vs 18 chars (5.6% diff)
   Changes: 1 modified rule
   
@@ -54,7 +60,7 @@ diffing).
   └─ .x
         * color: red -> #f00
   
-  [124]
+  [1]
 
 
 The canonical diff mode compares canonical minified CSS and accepts
@@ -102,8 +108,7 @@ identical, while a shorthand and its longhand (which overlap) stay ordered.
   > .x{margin-top:5px;margin:0}
   > EOF
   $ NO_COLOR=1 cascade diff --diff=canonical over-a.css over-b.css > /dev/null; echo $?
-  cascade: CSS files differ
-  124
+  1
 
 Canonical mode also equates different factorings of the same content: a
 declaration hoisted into a shared selector-list group is the same declaration
@@ -128,7 +133,6 @@ stays ordered: swapping it with the rule is a real difference.
   > @media print{.a{display:flex}}.a{display:block}
   > EOF
   $ NO_COLOR=1 cascade diff --diff=canonical before.css after.css
-  cascade: CSS files differ
   CSS: 48 chars vs 48 chars (0.0% diff)
   Changes: 1 reordered rule
   
@@ -137,7 +141,7 @@ stays ordered: swapping it with the rule is a real difference.
   Rules reordered (1 rules):
   └─ .a ↔  @media print
   
-  [124]
+  [1]
 
 
 
@@ -150,7 +154,6 @@ The --diff=string mode falls back to character-level diffing.
   > .x { color: blue }
   > EOF
   $ NO_COLOR=1 cascade diff --diff=string g.css h.css
-  cascade: CSS files differ (string diff)
   CSS: 19 chars vs 18 chars (5.6% diff)
   No structural differences
   
@@ -163,6 +166,6 @@ The --diff=string mode falls back to character-level diffing.
   +.x { color: blue }
                ^
   
-  [124]
+  [1]
 
 


### PR DESCRIPTION
`cascade diff` now resolves colour from the terminal state instead of always emitting ANSI escapes, and returns CI-friendly exit codes.

The tree diff is built in a plain buffer, so it wrapped markers in ANSI escapes unconditionally and leaked them into pipes and redirected files. The colour decision is now resolved once from `Fmt_tty` (tty detection, `--color` and `CASCADE_COLOR` via `Fmt_cli`, `NO_COLOR` via a `Cmd.Env` that cmdliner documents, so the man page's ENVIRONMENT section is generated rather than hand-written and no longer duplicates `CASCADE_COLOR`) and threaded into the printers. The command exits 0 when the files are identical, 1 when they differ, and 124 on unreadable input or command-line errors, so it can drive CI checks and git hooks.