### PR TITLE
info: report PROJECT_VERSION when a packaging build exports it

### DIFF
--- a/lib/info/cascade_info.ml
+++ b/lib/info/cascade_info.ml
@@ -1,4 +1,7 @@
 let version =
-  match Build_info.V1.version () with
-  | Some v -> Build_info.V1.Version.to_string v
-  | None -> Git_hash.hash
+  match Project_version.env with
+  | "dev" -> (
+      match Build_info.V1.version () with
+      | Some v -> Build_info.V1.Version.to_string v
+      | None -> "dev")
+  | v -> v

--- a/lib/info/cascade_info.mli
+++ b/lib/info/cascade_info.mli
@@ -1,10 +1,11 @@
 (** Build-time metadata for the Cascade library.
 
-    Exposes a {!version} string derived from [dune-build-info] (for tagged
-    releases), the git short hash (for release builds), or ["dev"] during
+    Exposes a {!version} string taken from the [PROJECT_VERSION] environment
+    variable when the build exports one (packaging builds such as bottler), from
+    [dune-build-info] otherwise (tagged opam releases), or ["dev"] during
     development. *)
 
 val version : string
-(** [version] is the current version string. Uses the dune-build-info version
-    when available (tagged releases), falls back to the git short hash in
-    release builds, or ["dev"] during development. *)
+(** [version] is the current version string: the [PROJECT_VERSION] environment
+    variable when set at build time, the dune-build-info version when available,
+    or ["dev"]. *)

--- a/lib/info/dune
+++ b/lib/info/dune
@@ -3,26 +3,15 @@
  (public_name cascade.info)
  (libraries dune-build-info))
 
-; In release mode, compute YYYYMMDD-HASH version (uses universe dep to always refresh)
+; Packaging builds (bottler) export PROJECT_VERSION and expect the binary to
+; report that exact string; Cascade_info falls back to dune-build-info and
+; then "dev" when it is unset.
 
 (rule
- (target git_hash.ml)
- (deps (universe))
- (enabled_if
-  (= %{profile} release))
+ (target project_version.ml)
+ (deps
+  (env_var PROJECT_VERSION))
  (action
   (with-stdout-to
    %{target}
-   (bash
-    "echo 'let hash = \"'$(date +%Y%m%d)-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)'\"'"))))
-
-; In dev mode, just use "dev" to avoid rebuilds on every commit
-
-(rule
- (target git_hash.ml)
- (enabled_if
-  (<> %{profile} release))
- (action
-  (with-stdout-to
-   %{target}
-   (echo "let hash = \"dev\""))))
+   (bash "printf 'let env = \"%s\"\\n' \"${PROJECT_VERSION:-dev}\""))))


### PR DESCRIPTION
`cascade --version` now echoes `PROJECT_VERSION` when the packaging build exports it.