### PR TITLE
opam: require cmdliner >= 1.1.0 and fmt >= 0.10.0

### DIFF
--- a/cascade.opam
+++ b/cascade.opam
@@ -22,12 +22,12 @@ depends: [
   "lambdasoup"
   "mdx" {with-test}
   "re" {with-test}
-  "fmt"
+  "fmt" {>= "0.10.0"}
   "base-unix"
   "uutf"
   "psq"
   "logs"
-  "cmdliner"
+  "cmdliner" {>= "1.1.0"}
   "memtrace"
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -27,10 +27,10 @@
   lambdasoup
   (mdx :with-test)
   (re :with-test)
-  fmt
+  (fmt (>= 0.10.0))
   base-unix
   uutf
   psq
   logs
-  cmdliner
+  (cmdliner (>= 1.1.0))
   memtrace))


### PR DESCRIPTION
The CLI uses cmdliner's `Cmd` module (`Cmd.v`, `Cmd.info`, `Cmd.Env.info`) and `Fmt_cli.style_renderer`'s `?env:Cmdliner.Cmd.Env.info` argument. `cmdliner` introduced `Cmd` in 1.1.0 and `fmt` gained the `Cmd.Env`-aware `?env` in 0.10.0 (the "handle cmdliner deprecations" release; 0.9.0 predates cmdliner 1.1.0). Both deps were unconstrained, so the opam-repository `lower-bounds` job resolved older versions and failed with `Unbound module Cmd` (opam-repository#30263).