### PR TITLE
values: gate angle unit conversion on round-trip

### DIFF
--- a/fuzz/fuzz_optimize.ml
+++ b/fuzz/fuzz_optimize.ml
@@ -8,6 +8,46 @@ let byte_at buf i =
 
 let pick xs buf i = List.nth xs (byte_at buf i mod List.length xs)
 
+(* value(parse(minify(x))) == value(x) for angles. The idempotence properties
+   below cannot catch a value-changing unit conversion, because the wrong output
+   is itself print-stable ([rotate(0turn)] reparses to [rotate(0turn)]); only a
+   numeric check sees it. Printing an angle in its own unit and again after
+   [normalize_angle], then comparing the reparsed degrees, isolates a lossy
+   conversion (deg -> turn zeroing a small angle) from the printer's inherent
+   precision cap, which affects both spellings equally. *)
+let angle_printed_deg a =
+  Css.Values.angle_degrees_opt
+    (Css.Values.read_angle
+       (Cursor.of_string (Css.Pp.to_string ~minify:true Css.Values.pp_angle a)))
+
+let draw_angle buf =
+  let sign = if byte_at buf 0 land 1 = 0 then 1. else -1. in
+  let mantissa = (float_of_int (byte_at buf 1) +. 1.) /. 256. in
+  let f =
+    sign *. mantissa *. (10. ** float_of_int ((byte_at buf 2 mod 20) - 12))
+  in
+  match byte_at buf 3 mod 3 with
+  | 0 -> Css.Values.Deg f
+  | 1 -> Css.Values.Turn f
+  | _ -> Css.Values.Grad f
+
+let test_angle_minify_preserves_value buf =
+  let a = draw_angle buf in
+  match
+    (angle_printed_deg a, angle_printed_deg (Css.Values.normalize_angle a))
+  with
+  | Some d0, Some d1 ->
+      (* Minify must preserve the angle exactly, modulo the float noise of the
+         unit arithmetic. A conversion that re-rounds the value (grad -> deg
+         dropping a significant figure, a small angle collapsing to 0) is a
+         value change, not tolerated: the authored unit is kept instead. *)
+      let scale = Float.max (Float.abs d0) (Float.abs d1) in
+      if Float.abs (d0 -. d1) > (1e-9 *. scale) +. 1e-15 then
+        failf "angle %s minified changed value: %g deg -> %g deg"
+          (Css.Pp.to_string ~minify:true Css.Values.pp_angle a)
+          d0 d1
+  | _, _ -> ()
+
 let selector buf i =
   Css.Selector.class_ (pick [ "card"; "title"; "button"; "panel" ] buf i)
 
@@ -831,5 +871,7 @@ let suite =
         test_layer_before_specificity;
       test_case "name-defining at-rules preserved" [ bytes ]
         test_name_defining_atrules_preserved;
+      test_case "angle minify preserves value" [ bytes ]
+        test_angle_minify_preserves_value;
     ]
     @ identity_cases )

--- a/fuzz/helpers/dune
+++ b/fuzz/helpers/dune
@@ -1,3 +1,3 @@
 (library
  (name fuzz_helpers)
- (libraries cascade alcobar fmt))
+ (libraries cascade alcobar))

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3955,51 +3955,77 @@ let eval_angle_calc ?(ctx = default_calc_ctx) (c : angle calc) : angle calc =
    [rem] on [deg] operands), then pick the shortest of the
    losslessly-interconvertible spellings (deg / turn / grad). [rad] goes through
    pi, so it cannot share one magnitude and is left as-is. *)
-let normalize_angle ?(ctx = default_calc_ctx) =
+(* Shortest spelling of a concrete angle, restricted to unit conversions whose
+   printed form still denotes the same value. [deg -> turn] divides by 360, which
+   floors a small but non-zero angle to [0turn] once the printer caps the
+   mantissa, silently changing the value; comparing the printed forms back in
+   degrees rejects such value-changing rewrites. The original spelling is always
+   kept (the fold seed), and ties prefer deg. *)
+let angle_shortest (a : angle) : angle =
   let render unit f =
     String.length
       (Pp.string_of_float ~drop_leading_zero:true (Pp.round_sig 6 f))
     + String.length unit
   in
-  let shortest (a : angle) : angle =
-    let cands =
-      match a with
-      | Deg f -> [ (f, "deg", a); (f /. 360., "turn", Turn (f /. 360.)) ]
-      | Turn f -> [ (f, "turn", a); (f *. 360., "deg", Deg (f *. 360.)) ]
-      | Grad f -> [ (f, "grad", a); (f *. 0.9, "deg", Deg (f *. 0.9)) ]
-      | _ -> []
-    in
-    match cands with
-    | [] -> a
-    | (f0, u0, n0) :: rest ->
-        snd
-          (List.fold_left
-             (fun (best_len, best) (f, u, n) ->
-               let l = render u f in
-               if l < best_len then (l, n) else (best_len, best))
-             (render u0 f0, n0)
-             rest)
+  let printed_deg unit f =
+    match
+      float_of_string_opt
+        (Pp.string_of_float ~drop_leading_zero:true (Pp.round_sig 6 f))
+    with
+    | Some v -> (
+        match unit with "turn" -> v *. 360. | "grad" -> v *. 0.9 | _ -> v)
+    | None -> Float.nan
   in
+  let cands =
+    match a with
+    | Deg f -> [ (f, "deg", a); (f /. 360., "turn", Turn (f /. 360.)) ]
+    | Turn f -> [ (f, "turn", a); (f *. 360., "deg", Deg (f *. 360.)) ]
+    | Grad f -> [ (f, "grad", a); (f *. 0.9, "deg", Deg (f *. 0.9)) ]
+    | _ -> []
+  in
+  match cands with
+  | [] -> a
+  | (f0, u0, n0) :: rest ->
+      let ref_deg = printed_deg u0 f0 in
+      let round_trips (f, u, _) =
+        (* Exact conversion only: the converted spelling must denote the same
+           angle, modulo the float noise of the unit arithmetic, not merely a
+           close one. A [grad -> deg] re-spelling that drops a significant
+           figure (or a small angle collapsing to [0turn]) is a value change, so
+           the authored unit is kept. *)
+        Float.abs (printed_deg u f -. ref_deg)
+        <= (1e-9 *. Float.abs ref_deg) +. 1e-15
+      in
+      let rest = List.filter round_trips rest in
+      snd
+        (List.fold_left
+           (fun (best_len, best) (f, u, n) ->
+             let l = render u f in
+             if l < best_len then (l, n) else (best_len, best))
+           (render u0 f0, n0)
+           rest)
+
+let normalize_angle ?(ctx = default_calc_ctx) =
   let rec go (a : angle) : angle =
     match a with
     | Round (strategy, v, s) -> (
         match (go v, go s) with
         | Deg v, Deg s when s <> 0. ->
-            shortest (Deg (round_to_step strategy v s))
+            angle_shortest (Deg (round_to_step strategy v s))
         | v, s -> Round (strategy, v, s))
     | Mod (x, y) -> (
         match (go x, go y) with
-        | Deg x, Deg y when y <> 0. -> shortest (Deg (mod_value x y))
+        | Deg x, Deg y when y <> 0. -> angle_shortest (Deg (mod_value x y))
         | x, y -> Mod (x, y))
     | Rem (x, y) -> (
         match (go x, go y) with
-        | Deg x, Deg y when y <> 0. -> shortest (Deg (Float.rem x y))
+        | Deg x, Deg y when y <> 0. -> angle_shortest (Deg (Float.rem x y))
         | x, y -> Rem (x, y))
     | Calc c -> (
         match eval_angle_calc ~ctx c with
         | Val v -> go v
         | folded -> Calc folded)
-    | Deg _ | Turn _ | Grad _ -> shortest a
+    | Deg _ | Turn _ | Grad _ -> angle_shortest a
     | Rad _ | Var _ | Invalid _ -> a
   in
   go

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -445,6 +445,14 @@ let test_angle () =
   decl_optimizes ~prop:"rotate" ~held:"-200grad" ~into:"-180deg" "-200grad";
   decl_optimizes ~prop:"rotate" ~held:"-360deg" ~into:"-1turn" "-360deg";
 
+  (* A [deg -> turn] conversion divides by 360, which floors a small but
+     non-zero angle to [0turn] once the printer caps the mantissa, silently
+     zeroing it. It is only taken when the printed form still denotes the same
+     angle, so a small angle keeps [deg] rather than collapsing to [0turn]. *)
+  decl_optimizes ~prop:"rotate" ~held:".000001deg" ~into:".000001deg"
+    "0.000001deg";
+  decl_optimizes ~prop:"rotate" ~held:".0001deg" ~into:".0001deg" "0.0001deg";
+
   (* CSS Values 4 §10.7: scaling a typed <angle> by a unitless number folds to a
      concrete angle (then picks the shortest unit), so calc(1deg * -45) ->
      -45deg matches what the browser computes. Both operand orders fold. *)


### PR DESCRIPTION
`rotate(0.000001deg)` minifies to `rotate(0turn)` today, even under `--minify --lossless --enforce-spec`: a non-zero angle becomes exactly zero.

`normalize_angle`'s shortest-spelling search converts `deg -> turn` (divide by 360) and picks whichever candidate prints shorter, without checking the pick still denotes the same value. For a small angle the turn form rounds to `0turn` once the printer caps the mantissa, so it prints shorter and wins, silently zeroing the angle. cascade already applies this exactness discipline to calc folds and colour folds; the angle unit conversion skipped it.

This restricts a unit conversion to candidates whose printed form denotes the same angle *exactly* (modulo the float noise of the unit arithmetic), keeping the authored unit otherwise. Exact conversions still fire (`0.25turn -> 90deg`, `100grad -> 90deg`, `360deg -> 1turn`); lossy ones are rejected (`0.000001deg` stays `.000001deg`, and a `grad -> deg` re-spelling that drops a significant figure keeps `grad`).

Adds a numeric fuzz property `value(parse(minify(x))) == value(x)` for angles. The existing idempotence property could not catch this class, because the wrong output is itself print-stable (`rotate(0turn)` reparses to `rotate(0turn)`); only a numeric check sees it. The property caught that a first, looser gate still allowed lossy grad conversions.

82c51af drops a dead `fmt` dependency from `fuzz_helpers` (E956), surfaced by the fuzz change.