### PR TITLE
cli: fold --aggressive into --objective=raw

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -20,12 +20,15 @@ median over 5 runs.
 
 Cascade emits the smallest gzip output on every fixture here, and the smallest
 brotli output on all but guardian (where Lightning CSS keeps a 0.6% edge).
-`--aggressive` changes little under the default objective: the transfer gate
-already discards factoring that would grow the compressed output.
+The default transfer objective stops short of the aggressive factoring
+fixpoint on purpose: the transfer gate discards any factoring that would grow
+the compressed output, so the extra passes would cost wall clock without
+shrinking gzip.
 
-With `--objective=raw` the objective flips to uncompressed bytes and cascade
-emits the smallest raw output on every fixture too (github 178,042 vs csso's
-180,825; netflix 172,500 under `--aggressive` vs cssnano's 218,017).
+`--objective=raw` flips the metric to uncompressed bytes and drives the
+factoring fixpoint to convergence; cascade emits the smallest raw output on
+every fixture too (github 178,042 vs csso's 180,825; netflix 172,500 vs
+cssnano's 218,017).
 
 Lightning CSS and esbuild are well over an order of magnitude faster but emit
 0.4-15% more compressed bytes; csso and cssnano sit in the same wall-clock band

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ dropped in both pretty and minified output.
 ```bash
 cascade style.css > style.formatted.css                            # pretty-print
 cascade --minify style.css > style.min.css                         # minify
-cascade --minify --aggressive style.css > style.min.css            # smallest output
+cascade --minify --objective=raw style.css > style.min.css         # smallest uncompressed
 cascade --inline-imports --inline-vars --minify style.css > out.css # bundle + minify
 cascade --inline-vars --keep-vars=theme,brand style.css > themed.css
 cat style.css | cascade -                                          # read stdin
@@ -84,8 +84,7 @@ cat style.css | cascade -                                          # read stdin
 | Flag | Purpose |
 |---|---|
 | `-m, --minify` | Minify the output. Local linear rewrites always run; the expensive global factoring fixpoint runs only when its preflight predicts useful savings. The top-level pipeline re-runs until the AST stops changing (capped at 5 iterations), so the output is a fixed point: rule-order canonicalisation can expose a merge a single pass would miss. |
-| `--aggressive` | Force the global factoring fixpoint regardless of the preflight, and widen the convergence cap. Trades roughly 10-20x wall clock for the last few percent of bytes. Has no effect without `--minify`. |
-| `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win, the right objective when the output ships uncompressed (inline style attributes, email HTML). Has no effect without `--minify`. |
+| `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win and drives the factoring fixpoint to convergence, the right objective when the output ships uncompressed (inline style attributes, email HTML), at roughly 10-30x the wall clock. Has no effect without `--minify`. |
 | `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Has no effect without `--minify`. |
 | `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest CSS form it knows, but it keeps every `@supports` and `supports()` guard unless the CSS text and spec alone prove the rewrite. Has no effect without `--minify`. |
 | `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
@@ -167,9 +166,9 @@ The exit code is 0 when the inputs are identical under the chosen mode and 1
 otherwise, so cascade slots into any tool that branches on exit codes (`git`
 hooks, `make`, GitHub Actions, ...). The `--minify` pipeline is fast enough
 that a 200 KB stylesheet costs well under 100 ms on the SatCSS corpus;
-`--aggressive` trades roughly an order of magnitude of wall clock for the
-last few percent of bytes and fits a release build rather than a watcher
-loop.
+`--objective=raw` trades roughly an order of magnitude of wall clock for the
+last few percent of uncompressed bytes and fits a release build rather than a
+watcher loop.
 
 ## `--minify` policy
 

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -77,7 +77,7 @@ let emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet =
   Buffer.output_buffer stdout buf
 
 let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
-    ~enforce_spec ~aggressive ~closed_world ~objective ~inline_imports_flag
+    ~enforce_spec ~closed_world ~objective ~inline_imports_flag
     ~inline_vars_flag ~keep_vars ~memtrace_path ~profile =
   Cli_io.start_memtrace memtrace_path;
   try
@@ -91,10 +91,15 @@ let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
       else stylesheet
     in
     let stylesheet =
-      if minify then
-        let () = Cascade.Stats.set_profile profile in
+      if minify then begin
+        Cascade.Stats.set_profile profile;
+        (* Raw output ships uncompressed, so the aggressive global-factoring
+           fixpoint is worth its cost only here: under the transfer objective
+           its extra raw-byte wins grow gzip and get discarded anyway. *)
+        let aggressive = objective = `Raw in
         Css.optimize ~scope ~flatten_nesting ~lossless ~enforce_spec ~aggressive
           ~closed_world ~objective stylesheet
+      end
       else stylesheet
     in
     emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet;
@@ -166,25 +171,15 @@ let lossless_arg =
   in
   Arg.(value & flag & info [ "lossless" ] ~doc)
 
-let aggressive_arg =
-  let doc =
-    "Force the expensive global-factoring fixpoint to run regardless of the \
-     preflight's byte-gain estimate, and re-run the top-level optimisation \
-     pipeline until the AST reaches a structural fixpoint (capped at a small \
-     iteration bound). Use when output size matters more than wall clock; on \
-     small or already-well-factored inputs the gain is usually negligible. Has \
-     no effect without $(b,--minify)."
-  in
-  Arg.(value & flag & info [ "aggressive" ] ~doc)
-
 let objective_arg =
   let doc =
     "Size metric $(b,--minify) optimises for. $(b,transfer) (the default) \
      keeps a global-factoring result only when it also shrinks the estimated \
      gzip (DEFLATE) size of the output, since repeated declaration text is \
-     nearly free once compressed; $(b,raw) keeps every raw-byte win, the right \
-     objective when the output ships uncompressed (inline style attributes, \
-     email HTML). Has no effect without $(b,--minify)."
+     nearly free once compressed; $(b,raw) keeps every raw-byte win and drives \
+     the factoring fixpoint to convergence, the right objective when the \
+     output ships uncompressed (inline style attributes, email HTML), at the \
+     cost of markedly more wall clock. Has no effect without $(b,--minify)."
   in
   Arg.(
     value
@@ -271,7 +266,6 @@ let term =
         flatten_nesting
         lossless
         enforce_spec
-        aggressive
         closed_world
         objective
         inline_imports_flag
@@ -296,19 +290,17 @@ let term =
             (scope = `Stylesheet, "--scope=stylesheet");
             (lossless, "--lossless");
             (enforce_spec, "--enforce-spec");
-            (aggressive, "--aggressive");
             (closed_world, "--closed-world");
             (objective = `Raw, "--objective");
             (profile, "--profile");
           ];
         process_css ~input_path:input ~minify ~scope ~flatten_nesting ~lossless
-          ~enforce_spec ~aggressive ~closed_world ~objective
-          ~inline_imports_flag ~inline_vars_flag ~keep_vars ~memtrace_path
-          ~profile)
+          ~enforce_spec ~closed_world ~objective ~inline_imports_flag
+          ~inline_vars_flag ~keep_vars ~memtrace_path ~profile)
     $ input_arg $ minify_arg $ scope_arg $ flatten_nesting_arg $ lossless_arg
-    $ enforce_spec_arg $ aggressive_arg $ closed_world_arg $ objective_arg
-    $ inline_imports_arg $ inline_vars_arg $ keep_vars_arg $ memtrace_arg
-    $ profile_arg $ Cli_log.term)
+    $ enforce_spec_arg $ closed_world_arg $ objective_arg $ inline_imports_arg
+    $ inline_vars_arg $ keep_vars_arg $ memtrace_arg $ profile_arg
+    $ Cli_log.term)
 
 let man =
   [

--- a/test/cli/objective_raw.t
+++ b/test/cli/objective_raw.t
@@ -1,0 +1,27 @@
+CLI: one size/speed dial. --objective=raw subsumes the old --aggressive flag.
+
+The aggressive global-factoring fixpoint only pays for uncompressed output (the
+transfer gate discards its extra raw-byte wins as gzip growth), so it is folded
+into --objective=raw rather than exposed as a separate flag.
+
+--aggressive is no longer accepted.
+
+  $ printf '.a{color:red}\n' > style.css
+  $ cascade --minify --aggressive style.css >/dev/null 2>&1
+  [124]
+  $ cascade --minify --aggressive style.css 2>&1 | grep -c aggressive
+  1
+
+The default transfer objective skips the low-ROI factoring fixpoint on a large
+input the preflight predicts no compressed gain from.
+
+  $ for i in $(seq 1 1100); do printf '.x%s{width:%spx}\n' "$i" "$i"; done > big.css
+  $ cascade --minify --profile big.css > /dev/null 2>profile.txt
+  $ grep "factor preflight" profile.txt
+  factor preflight: 1 skipped, estimated gain 0 bytes
+
+--objective=raw drives that same fixpoint to convergence instead of skipping it.
+
+  $ cascade --minify --objective=raw --profile big.css > /dev/null 2>profile-raw.txt
+  $ grep "factor preflight" profile-raw.txt
+  factor preflight: 0 skipped, estimated gain 0 bytes


### PR DESCRIPTION
This PR removes the `--aggressive` CLI flag and runs its factoring fixpoint when `--objective=raw` instead, so the CLI has one size/speed dial rather than two overlapping ones.

`--aggressive` forced the expensive global-factoring fixpoint to run regardless of the preflight estimate and widened the pipeline convergence cap. But under the default `transfer` objective the transfer gate discards any factoring that grows the estimated gzip size, which is exactly what the extra aggressive search produces, so `--minify --aggressive` came out a few bytes larger than `--minify` alone on five of the six benchmark fixtures at 10-30x the wall clock. The only regime where it pays is uncompressed output, which is what `--objective=raw` already selects. `--objective=raw` now drives the fixpoint to convergence; `transfer` stops short of it.

The library API is unchanged: `Css.optimize`, `Optimize`, and `Ctx` keep `?aggressive` as an orthogonal knob for callers that want to decouple search depth from the size objective.
