### PR TITLE
pp: keep sub-floor magnitudes from rounding to zero

### DIFF
--- a/fuzz/fuzz_optimize.ml
+++ b/fuzz/fuzz_optimize.ml
@@ -48,6 +48,35 @@ let test_angle_minify_preserves_value buf =
           d0 d1
   | _, _ -> ()
 
+(* A nonzero length must not minify to zero. The printer's fixed-point cap once
+   floored a small magnitude to "0", a value change the idempotence property
+   cannot see ([0em] reparses to [0em]). *)
+let em_value = function
+  | Css.Values.Zero -> Some 0.0
+  | Css.Values.Em f -> Some f
+  | Css.Values.Dimension { value; unit; _ }
+    when String.lowercase_ascii unit = "em" ->
+      Some value
+  | _ -> None
+
+let draw_length_coeff buf =
+  let sign = if byte_at buf 0 land 1 = 0 then 1. else -1. in
+  let mantissa = (float_of_int (byte_at buf 1) +. 1.) /. 256. in
+  sign *. mantissa *. (10. ** float_of_int ((byte_at buf 2 mod 20) - 12))
+
+let test_length_minify_preserves_nonzero buf =
+  let f = draw_length_coeff buf in
+  if f <> 0.0 then begin
+    let printed =
+      Css.Pp.to_string ~minify:true Css.Values.pp_length (Css.Values.Em f)
+    in
+    match em_value (Css.Values.read_length (Cursor.of_string printed)) with
+    | Some g when g = 0.0 ->
+        failf "length %gem minified to %s: nonzero value collapsed to 0" f
+          printed
+    | _ -> ()
+  end
+
 let selector buf i =
   Css.Selector.class_ (pick [ "card"; "title"; "button"; "panel" ] buf i)
 
@@ -873,5 +902,7 @@ let suite =
         test_name_defining_atrules_preserved;
       test_case "angle minify preserves value" [ bytes ]
         test_angle_minify_preserves_value;
+      test_case "length minify preserves nonzero" [ bytes ]
+        test_length_minify_preserves_nonzero;
     ]
     @ identity_cases )

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -313,6 +313,16 @@ let format_integer is_neg abs_f f =
 let format_decimal_value ~drop_leading_zero max_decimals is_neg abs_f =
   let scale = 10.0 ** float_of_int max_decimals in
   let scaled = floor ((abs_f *. scale) +. 0.5) in
+  (* Extend the cap past the leading zeros only for a magnitude that would
+     otherwise round to "0", so [0.000000001em] keeps its digits while a coarse
+     [max_decimals] and colour-channel precision stay untouched. *)
+  let max_decimals, scaled =
+    if scaled <> 0.0 then (max_decimals, scaled)
+    else
+      let leading_zeros = -1 - int_of_float (floor (log10 abs_f)) in
+      let d = max_decimals + min 24 (max 0 leading_zeros) in
+      (d, floor ((abs_f *. (10.0 ** float_of_int d)) +. 0.5))
+  in
   let s =
     if scaled <= float_of_int max_int then string_of_int (int_of_float scaled)
     else string_of_float scaled

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -136,6 +136,12 @@ let test_length () =
   (* Edge cases for very small values *)
   check_length ~expected:".00001px" "0.00001px";
   check_length ~expected:"-.001em" "-0.001em";
+  (* Below the printer's fixed-point floor: a nonzero magnitude must keep its
+     digits, not round to 0. *)
+  check_length ~expected:".000000001em" "0.000000001em";
+  check_length ~expected:".000000001em" "1e-9em";
+  check_length ~expected:".0000000012em" "0.0000000012em";
+  check_length ~expected:"-.000000001em" "-0.000000001em";
 
   (* Float formatting with lengths *)
   check_length ~expected:".5rem" "0.5rem";


### PR DESCRIPTION
This PR stops `--minify` from rounding a nonzero length to `0`. `letter-spacing: 0.000000001em` (and any magnitude below the printer's fixed-point floor) survives instead of collapsing to `0em`.

`Pp.string_of_float` caps precision at a fixed number of decimal places (8 by default). A magnitude below `10^-max_decimals` has every digit rounded away, so a deliberate epsilon printed as `0` under `--minify`, silently changing the value on a run whose whole contract (`--lossless`) is that it does not. `format_decimal_value` now extends the decimal cap past the value's leading zeros, but only for a value that would otherwise round to `0`: a value that already rounds to something nonzero is untouched, so a deliberately coarse `max_decimals` (`0.999` to 2 places stays `1`, not `.999`) and colour-channel precision are preserved.

The angle value-preservation fuzz property added in the earlier round-trip fix only covered angles, which is why 327 property tests missed this; the general idempotence property is blind because `0em` is itself print-stable. This adds the `<length>` analogue (a nonzero length must not minify to zero) plus regression cases in `test_values`. With the fix reverted, both the new property and the regression fail on `0.000000001em`.
