### PR TITLE
test/inline: add a cascade --minify render differential

### DIFF
--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -1,10 +1,16 @@
-# `cascade apply` differential test
+# Differential render tests
 
-`cascade apply` resolves a stylesheet into each element's `style` attribute and
-drops the `<style>` blocks. This checks that the result is equivalent to the
-original: for every element, the **complete `getComputedStyle`** in a real
-headless browser must be identical between the original page and the inlined
-output, in both the default (full) and `--minimal` modes.
+Two transforms must leave the rendered page unchanged: for every element, the
+**complete `getComputedStyle`** in a real headless browser must be identical
+before and after.
+
+- **`cascade apply`** resolves the stylesheet into each element's `style`
+  attribute and drops the `<style>` blocks, in both the default (full) and
+  `--minimal` modes.
+- **`cascade --minify`** rewrites each `<style>` block in place (via
+  `minify_page.js`). Idempotence, size and reparse checks all pass on output
+  that renders differently; only this catches a minification that changes the
+  computed style.
 
 ```sh
 CASCADE=_build/default/bin/main.exe sh test/inline/run.sh

--- a/test/inline/minify_page.js
+++ b/test/inline/minify_page.js
@@ -1,0 +1,11 @@
+// Copy an HTML page with every <style> block minified through cascade, so the
+// differential test can check that minification preserves the render.
+const { execSync } = require('child_process');
+const fs = require('fs');
+const CASCADE = process.env.CASCADE || 'cascade';
+const src = fs.readFileSync(process.argv[2], 'utf8');
+const out = src.replace(/<style([^>]*)>([\s\S]*?)<\/style>/gi, (_m, attrs, css) => {
+  const min = execSync(`"${CASCADE}" fmt --minify -`, { input: css, encoding: 'utf8' });
+  return `<style${attrs}>${min.trim()}</style>`;
+});
+process.stdout.write(out);

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-# Differential test for `cascade apply`: the resolved page must produce the
-# same computed style, for every element, as the original page with its
-# <style> blocks, in a real headless browser. Both output modes are checked.
-# Skips cleanly when no headless browser or node is available (e.g. in CI).
+# Differential render tests in a real headless browser: for every element the
+# complete computed style must be identical before and after a transform.
+# Covers `cascade apply` (both modes) and `cascade --minify` (each <style>
+# block minified in place). Skips cleanly with no browser or node (e.g. in CI).
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
-CASCADE=${CASCADE:-cascade}
+export CASCADE=${CASCADE:-cascade}
 if [ -z "$CHROME" ]; then
   CHROME=$(command -v chromium 2>/dev/null || command -v google-chrome 2>/dev/null || true)
 fi
@@ -32,6 +32,18 @@ for f in "$dir"/fixtures/*.html; do
     fi
     rm -f "$out"
   done
+done
+# cascade --minify preserves the render too: minify each <style> block in place
+# and compare computed styles against the original page.
+for f in "$dir"/fixtures/*.html; do
+  out=$(mktemp)
+  node "$dir/minify_page.js" "$f" > "$out" 2>/dev/null
+  if node "$dir/xtest.js" "$f" "$out" 2>&1 | grep -q "IDENTICAL"; then
+    echo "ok   $(basename "$f") minify"
+  else
+    echo "FAIL $(basename "$f") minify"; node "$dir/xtest.js" "$f" "$out" 2>&1 | tail -6; fail=1
+  fi
+  rm -f "$out"
 done
 # Real pages downloaded by fetch.sh (gitignored): reported for coverage, but
 # they do not gate the run - they change upstream and exercise features still


### PR DESCRIPTION
This PR adds a `cascade --minify` render differential to the `test/inline` harness, so a minification that changes what the page computes is caught rather than passing the weaker checks.

The optimizer suite asserts idempotence, size bounds, and that output reparses, but all three pass on output that renders differently: none of them look at a real browser. The existing `test/inline` harness already renders a page in headless Chrome and diffs the complete `getComputedStyle` element by element (for `cascade apply`). This reuses it for minification: `minify_page.js` rewrites each `<style>` block in place through `cascade fmt --minify`, and the run requires the computed style of every element to be identical to the original. Like the apply test it looks for a browser and node and skips cleanly when neither is present, so CI is unaffected.

All five committed fixtures pass, covering nesting synthesis, `!important`, media queries, and custom properties.
