### PR TITLE
lib: trim over-long code comments

### DIFF
--- a/lib/block.ml
+++ b/lib/block.ml
@@ -457,13 +457,11 @@ let drop_redundant_layer_decls stmts =
   loop [] [] stmts
 
 (* Main statement processing function with layer optimization *)
-(* CSS Cascade 6.1: a rule with no declarations and no nested rules
-   contributes nothing to the cascade. Drop it under [~optimize:true]
-   (Lightning CSS / cssnano convention). [@media] / [@supports] /
-   [@container] / [@scope] / [@starting-style] blocks with an empty body
-   are likewise no-ops and removed. Empty named [@layer] blocks survive
-   as a [Layer_decl] (the layer name still contributes to the layer order
-   per CSS Cascade L6 6.4). *)
+(* CSS Cascade 6.1: an empty rule (no declarations, no nested rules) contributes
+   nothing, so drop it under [~optimize:true]; an empty [@media]/[@supports]/
+   [@container]/[@scope]/[@starting-style] body is likewise removed. An empty
+   named [@layer] survives as a [Layer_decl] since the name still orders the
+   layer (CSS Cascade L6 6.4). *)
 let drop_empty_rules stmts =
   list_filter_preserve
     (function

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -11,10 +11,9 @@ type cascade_rule = {
 type t = {
   custom_properties : Declaration.declaration list;
   runtime_vars : string list;
-      (** Custom-property names (without the [--] prefix) that must stay live
-          [var()] references: a resolver keeps them like a [~runtime] var rather
-          than folding to a theme value, so the closed-world inliner can still
-          apply value-independent simplifications (calc identities) without
+      (** Custom-property names (no [--] prefix) that must stay live [var()]
+          references: a resolver keeps them like a [~runtime] var, so the
+          inliner can still apply value-independent simplifications without
           collapsing the reference. *)
   inherited_values : Declaration.declaration list;
   initial_values : Declaration.declaration list;
@@ -48,11 +47,10 @@ type query = {
       (** Media features the rendering environment claims to expose. Build
           entries with [Media.feature] or [Media.boolean]. *)
   supports : Supports.t list;
-      (** Capability flags the rendering environment claims to support. Each
-          entry is normally a [Supports.Property] or [Supports.Func] leaf, built
-          with [Supports.property] / [Supports.func]. Compound forms ([And] /
-          [Or] / [Not]) are accepted but only match a query that is structurally
-          identical. *)
+      (** Capability flags the environment claims to support, normally a
+          [Supports.Property]/[Supports.Func] leaf. Compound forms
+          ([And]/[Or]/[Not]) are accepted but match only a structurally
+          identical query. *)
   container_name : string option;
   container_features : Container.t list;
       (** Container capabilities exposed by the matching container. Build size
@@ -242,12 +240,10 @@ let scope ?layer_order ?layer ctx =
     layer = (match layer with Some _ -> layer | None -> ctx.layer);
   }
 
-(* CSS Cascade 5 §6.4.3 layered custom-property lookup.
-
-   Important-flagged declarations beat normal ones. For normal author rules the
-   unlayered declaration wins, otherwise later layers beat earlier layers. For
-   important author rules the order reverses: earlier layers beat later layers,
-   and unlayered ranks below them. *)
+(* CSS Cascade 5 §6.4.3 layered custom-property lookup. Important beats normal.
+   Normal author: unlayered wins, else later layers beat earlier. Important
+   author: the order reverses (earlier layers beat later, unlayered ranks
+   below). *)
 let custom_layer_index ~layer_order = function
   | None -> max_int
   | Some name ->
@@ -964,13 +960,11 @@ module Calc_residual = struct
           (ops.combine_value_num value Values.Mul n)
     | _ -> None
 
-  (* The value-independent identities ([x * 0], [x * 1], [x + 0], ...) live in
-     [Values.calc_identity], shared with the AST evaluators so the two paths
-     never drift. They hold for any operand, so they apply even to an unresolved
-     [var()] (a [~runtime] theme var). [ops.is_zero] lets a literal zero value
-     ([0px], not just the unitless [0]) collapse too, so [divide-x-0]'s
-     [calc(0px * var(--tw-divide-x-reverse))] reduces to [0]. Tried after the
-     numeric / value folds so a resolved [Val] keeps its typed zero. *)
+  (* Value-independent identities ([x * 0], [x * 1], [x + 0], ...) live in
+     [Values.calc_identity], shared with the AST evaluators so the paths never
+     drift. They hold for any operand, so they apply to an unresolved [var()]
+     too; [ops.is_zero] collapses a literal zero ([0px], not just [0]). Tried
+     after the numeric/value folds so a resolved [Val] keeps its typed zero. *)
   let fold_identity_expr ops left op right =
     Values.calc_identity ~zero:ops.zero ~is_zero:ops.is_zero left op right
 
@@ -1134,10 +1128,9 @@ module Length = struct
   }
 
   (* CSS Media Queries 4 §1.3: relative units in @media/@container resolve
-     against the initial value of font-size on the root element. Pre-fill
-     [parent_font_size] / [root_font_size] with the 16px default so [em] / [rem]
-     in queries always have a reference, while a fresh user-supplied
-     [Length.ctx] without these fields will reject relative units. *)
+     against root font-size. Pre-fill [parent_font_size]/[root_font_size] with
+     the 16px default so [em]/[rem] in queries always have a reference; a fresh
+     [Length.ctx] without these rejects relative units. *)
   let media_default =
     {
       root_font_size = Some 16.;
@@ -1219,12 +1212,10 @@ module Length = struct
       container_height = unwrap_px ctx.container_height;
     }
 
-  (* CSS Values 4 §10.11 simplification of a typed [length calc]. Folds every
-     subtree whose operands the [ctx] can collapse to absolute lengths, and
-     leaves [Var] / [Sibling_*] / unresolvable subtrees in place. The result is
-     still a [length calc]: a fully reducible body collapses to [Val (Px _)]
-     (caller decides whether to keep the [calc()] wrapper); a partially
-     reducible body keeps the [Expr] structure with the simplified operands. *)
+  (* CSS Values 4 §10.11 simplification of a typed [length calc]: fold every
+     subtree the [ctx] can collapse to absolute lengths, leaving
+     [Var]/[Sibling_*]/unresolvable subtrees. The result stays a [length calc] -
+     [Val (Px _)] when fully reducible, else [Expr] with simplified operands. *)
   let eval_combine_lengths ctx la lb (op : Values.calc_op) :
       Values.length option =
     match (to_px ctx la, to_px ctx lb, op) with
@@ -3702,9 +3693,7 @@ and resolve_css_wide_keyword ~layer_order ctx ~important ~property_name keyword
           eval_source ctx decl |> declaration_with_importance important)
         source
 
-(* [eval] is a declaration-level abstract interpreter: it rewrites a CSS
-   declaration to a more-defined declaration in the same typed AST, preserving
-   unresolved subtrees as residual syntax. The typed walker is the only semantic
-   path; string computed-value resolution is deliberately not used as an
-   alternate evaluator. *)
+(* [eval] is a declaration-level abstract interpreter: it rewrites a declaration
+   to a more-defined one in the same typed AST, keeping unresolved subtrees as
+   residual syntax. The typed walker is the only semantic path. *)
 let eval ?layer_order ?layer ctx decl = eval_typed ?layer_order ?layer ctx decl

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -633,12 +633,10 @@ let media_queries t =
 
 (* AST Introspection Helpers *)
 
-(* Per CSS Cascade 6 section 6.4.3, a dotted layer name like [foo.bar] is
-   shorthand for the nested form [@layer foo { @layer bar { ... } }]: both forms
-   declare the layers [foo] and [foo.bar] and place the block contents in
-   [foo.bar]. We walk the @layer tree once, expanding any dotted names into
-   their nested equivalent and prefixing each block with its parent's path, so
-   [foo.bar] is reachable under one canonical name regardless of input shape. *)
+(* CSS Cascade 6 sec. 6.4.3: a dotted layer name [foo.bar] is shorthand for the
+   nested [@layer foo { @layer bar { ... } }]. Walk the @layer tree once,
+   expanding dotted names and prefixing each block with its parent's path, so
+   [foo.bar] is reachable under one canonical name whatever the input shape. *)
 let qualified_layer_blocks sheet =
   let prefix_with parent name =
     if parent = "" then name else parent ^ "." ^ name
@@ -817,14 +815,11 @@ let rec statements_for_inline statement =
   | Starting_style block -> [ Starting_style (inline_block block) ]
   | statement -> [ statement ]
 
-(* Pure serialiser. Walks the AST and emits CSS text. No optimisation, no theme
-   resolution, no inline-vars rewriting. Spec recovery (drop invalid
-   declarations, unknown at-rules, empty rules) still applies because the parser
-   already preserved those shapes for round-trip and browsers discard them
-   during parse - that isn't an optimisation, just keeping the output
-   observationally equivalent to what a fresh parse would produce. Compose
-   {!optimize}, {!resolve_theme}, {!inline_vars} upstream when those rewrites
-   are needed. *)
+(* Pure serialiser: walk the AST and emit CSS, no optimise/theme/inline-vars
+   rewriting. Spec recovery (drop invalid declarations, unknown at-rules, empty
+   rules) still applies - browsers discard those at parse, so it keeps the
+   output observationally equal to a fresh parse, not an optimisation. Compose
+   {!optimize}, {!resolve_theme}, {!inline_vars} upstream when needed. *)
 let to_string ?(minify = false) ?indent ?lossless ?enforce_spec stylesheet =
   let stylesheet =
     stylesheet |> Optimize.drop_invalid |> Optimize.drop_unknown_at_rules
@@ -977,13 +972,11 @@ let bare_theme_name raw_name =
    structurally (see {!Variables.var_refs_in_value_string}). *)
 let var_names_in_theme_value = Variables.var_refs_in_value_string
 
-(* Every [var()] reference (with leading [--]) found by structurally scanning
-   each declaration's serialized value, typed declarations included.
-   [collect_var_names] only records a nested fallback var when it carries the
-   [Var_fallback] spelling; a var nested inside a *typed* fallback
-   ([transition-timing-function: var(--tw-ease, var(--default-...))]) is
-   invisible to it. Seeding theme resolution from this too lets such a nested
-   theme var resolve transitively instead of surviving as a nested [var()]. *)
+(* Every [var()] reference found by structurally scanning each declaration's
+   serialized value, typed declarations included. [collect_var_names] misses a
+   var nested inside a *typed* fallback (var(--tw-ease, var(--default-...))), so
+   seeding theme resolution from this too lets such a nested theme var resolve
+   transitively instead of surviving. *)
 let structural_var_refs (stmts : Stylesheet.statement list) : string list =
   let acc = ref [] in
   let note d =
@@ -1221,17 +1214,14 @@ let emit_transitive_theme_refs ~theme_defaults stylesheet =
         let result, merged = merge_into_root_scope injected_decls stylesheet in
         if merged then result else injected @ stylesheet
 
-(* Inline the theme defaults the resolver could resolve, leaving every other
-   [var()] reference live. Only resolved names get substituted: [Inline.vars]
-   alone would also collapse [var(--x, fallback)] for names the resolver
-   returned [None] on (its built-in fallback arm fires when no declaration is
-   visible). A [:root] binding is injected only for resolved names with no
-   declaration of their own; an already-declared theme token inlines from that
-   declaration, so a second binding - which would make it look multiply-defined
-   and keep it live - is skipped. [keep_vars] gains every unresolved name and
-   every declared custom-prop EXCEPT the ones being resolved, so unrelated
-   definitions (e.g. an @supports polyfill's [--tw-x:initial]) stay while a
-   resolved token is inlined and dropped. *)
+(* Inline only the theme defaults the resolver resolved, leaving every other
+   [var()] live. [Inline.vars] alone would also collapse [var(--x, fallback)]
+   for unresolved names (its fallback arm fires when no declaration is visible).
+   A [:root] binding is injected only for resolved names with no declaration of
+   their own; an already-declared token inlines from that declaration, and a
+   second binding would keep it live. [keep_vars] gains every name except the
+   ones being resolved, so unrelated definitions (an @supports polyfill's
+   [--tw-x:initial]) stay. *)
 let inline_theme_defaults ?theme ?theme_defaults ~keep_set stylesheet =
   let keep_vars = Pp.String_set.elements keep_set in
   let defaults =

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -241,11 +241,10 @@ let lookahead p t =
   restore t snap;
   v
 
-(* Common shape for "typed reader for a [<basic-shape>] / math call, with a
-   verbatim-preserve fallback when the typed reduction refuses the input":
-   snapshot the cursor, capture the function call, run the typed reader, and on
-   [Parse_error] restore + skip + return the captured call so the caller can
-   wrap it in an [Invalid] arm. *)
+(* Typed reader for a [<basic-shape>] / math call with a verbatim fallback:
+   snapshot the cursor, run the typed reader, and on [Parse_error] restore +
+   skip + return the captured call for the caller to wrap in an [Invalid]
+   arm. *)
 let try_typed_call (typed : t -> 'a) (t : t) : ('a, Component.t) result =
   let snap = save t in
   match peek t with

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -16,11 +16,10 @@ let rec meta_of_declaration : declaration -> meta option = function
   | Declaration _ -> None
   | Theme_guarded { decl; _ } -> meta_of_declaration decl
 
-(* Smart constructor for declarations. The [hash] field is computed here from
-   the (property, value, important) triple via the stdlib bounded structural
-   hash so two structurally-equal declarations always carry the same hash --
-   which is the property [Optimize.same_minified_declaration] relies on for its
-   O(1) inequality short-circuit. Bounded depth keeps construction O(1) even for
+(* Smart constructor. The [hash] field is the stdlib bounded structural hash of
+   the (property, value, important) triple, so structurally-equal declarations
+   share a hash (the invariant [Optimize.same_minified_declaration] uses for its
+   O(1) inequality short-circuit). Bounded depth keeps construction O(1) on
    large value subtrees. *)
 let v (type a) ?(important = false) (property : a Properties.property)
     (value : a) =
@@ -92,14 +91,12 @@ let rec custom_declaration_layer = function
   | Theme_guarded { decl; _ } -> custom_declaration_layer decl
 
 (* Equivalence-only normalisation for structural diffing: rewrite a quoted
-   multi-word [<string>] in a custom-property token stream as the equivalent
-   unquoted [<ident>] sequence ([Properties.unquote_font_family_strings]). The
-   two forms substitute identically into [font-family], so cascade treats them
-   as equal even though it keeps both verbatim on output (a custom property is
-   opaque, so unquoting it for real could corrupt a [content] use). Gated on a
-   generic family being present: an unregistered custom property is otherwise
-   type-unknown ([var(--x)] could land in [content]), so only a value that
-   proves itself a font-family list folds. *)
+   multi-word [<string>] in a custom-property stream as the equivalent unquoted
+   [<ident>] sequence. The forms substitute identically into [font-family] so
+   cascade treats them as equal, but keeps both verbatim on output (unquoting an
+   opaque custom property could corrupt a [content] use). Gated on a generic
+   family being present, since an unregistered property is otherwise
+   type-unknown. *)
 let unquote_custom_font_strings = function
   | Declaration
       {
@@ -223,12 +220,10 @@ let raw_value_has_invalid_var raw_value =
   Cursor.of_string raw_value |> Cursor.remaining |> components_have_invalid_var
 
 let raw_value_contains_var raw_value =
-  (* CSS Custom Properties Level 1 section 3: a top-level [var()] in a
-     declaration value makes the typed reader unable to validate the substituted
-     result at parse time, so cascade preserves the value verbatim. A nested
-     [var()] inside another function (e.g. [attr(name type(<color>), var(--fb,
-     red))]) doesn't extend that leniency to the surrounding tokens - it's only
-     relevant if it's a top-level component of the value. *)
+  (* CSS Custom Properties 1 section 3: a top-level [var()] leaves the typed
+     reader unable to validate the substituted result, so cascade keeps the
+     value verbatim. A [var()] nested inside another function does not extend
+     that leniency to the surrounding tokens; only a top-level one counts. *)
   let is_top_level_var = function
     | Component.Func { node = { name; _ }; _ }
       when String.lowercase_ascii_preserve name = "var" ->
@@ -309,14 +304,11 @@ let is_decl_unknown_property_name name =
           Cursor.is_done r
       | exception Cursor.Parse_error _ -> false)
 
-(** [is_invalid decl] is [true] when [decl]'s typed value is a known
-    spec-violation cascade detected at parse time. The minify-time
-    [Optimize.drop_invalid] pass removes such declarations.
-
-    Unknown property names are not invalid - browsers preserve unrecognized
-    declarations (CSS Syntax 3 §5.4 ignores them at used-value time but keeps
-    them in the cascade), and Cascade emits them as raw component lists.
-    Vendor-prefix extensions are also preserved unchanged. *)
+(** [is_invalid decl] is [true] when [decl]'s typed value is a known spec
+    violation detected at parse time; [Optimize.drop_invalid] removes such
+    declarations under minify. An unknown property is not invalid: browsers keep
+    unrecognised declarations (CSS Syntax 3 §5.4), and cascade emits them (and
+    vendor-prefix extensions) as raw component lists. *)
 let rec is_invalid = function
   | Declaration { property = Unknown_property _; _ } -> false
   | Declaration { property; value; _ } ->
@@ -479,13 +471,11 @@ let rec property_key decl =
   | Theme_guarded { decl; _ } -> property_key decl
 
 (* Equality of the typed property tag. The [property] GADT has only two
-   payload-carrying constructors ([Custom_property] / [Unknown_property], both
-   string), compared on their payload. Every other constructor is nullary and
-   interned by the compiler, so physical equality of the unboxed [prop_key]
-   short-circuits the common case ([Width]/[Width], ...) and answers a mismatch
-   ([Custom_property]/[Width]) correctly, with no allocation. The [property]
-   values are existentially typed (two [Declaration] nodes carry different
-   ['a]), so they are packed into [prop_key] to compare under one type. *)
+   payload-carrying constructors ([Custom_property]/[Unknown_property], both
+   string); every other is nullary and interned, so physical equality of the
+   unboxed [prop_key] short-circuits the common case allocation-free.
+   Existential [property] values are packed into [prop_key] to compare under one
+   type. *)
 let same_property d1 d2 =
   match (property_key d1, property_key d2) with
   | Key (Custom_property a), Key (Custom_property b) -> String.equal a b
@@ -1776,12 +1766,10 @@ let read_custom_property_declaration t : declaration =
     Cursor.err_invalid t ("expected <dashed-ident>, got: " ^ name);
   Cursor.ws t;
   if not (Cursor.colon t) then Cursor.err_expected t "':'";
-  (* CSS Custom Properties for Cascading Variables 1 sec. 2.1: the
-     [<declaration-value>] production matches "any sequence of one or more
-     tokens". The whitespace between [:] and the value IS the value when it's
-     the only thing there ([--foo: ;] declares the property with a single
-     whitespace token); don't skip it before [consume_until_semicolon] or the
-     value's token count becomes input-dependent. *)
+  (* CSS Custom Properties 1 sec. 2.1: [<declaration-value>] matches "any
+     sequence of one or more tokens", so the whitespace after [:] IS the value
+     when nothing else follows ([--foo: ;]). Don't skip it before
+     [consume_until_semicolon], or the token count becomes input-dependent. *)
   let raw_value = Cursor.consume_until_semicolon ~trim:false t in
   let raw_is_whitespace_only = raw_value <> "" && String.trim raw_value = "" in
   let value_str, is_important = split_custom_important raw_value in

--- a/lib/factor.ml
+++ b/lib/factor.ml
@@ -10,11 +10,9 @@ type cache = (string * rule list, rule list) Hashtbl.t
 
 let cache () = Hashtbl.create 16
 
-(* Cache identity for a context: every value-typed knob that changes factoring,
-   built explicitly rather than from {!Ctx.pp} so a debug-printer change cannot
-   silently break cache correctness. [registered] is a closure that cannot be
-   keyed; it is constant for a cache's lifetime (one context per top-level
-   optimize), so it does not need to appear here. *)
+(* Cache key over the value-typed knobs that change factoring, built explicitly
+   so a {!Ctx.pp} debug-printer change cannot break cache correctness;
+   [registered] is a constant closure, omitted. *)
 let ctx_key ctx =
   let b x = if x then "1" else "0" in
   String.concat ""
@@ -27,9 +25,8 @@ let ctx_key ctx =
       (match Ctx.objective ctx with `Raw -> "r" | `Transfer -> "t");
     ]
 
-(* Structural key: the rule list keys the cache directly (sound poly hash/equal
-   over the immutable AST), so a lookup hashes a sample instead of rendering
-   every rule to CSS. *)
+(* The rule list keys the cache directly: poly hash/equal is sound over the
+   immutable AST, so a lookup need not render every rule to CSS. *)
 let cache_key ~ctx rules = (ctx_key ctx, rules)
 
 let order_is_original rules graph order =
@@ -73,32 +70,25 @@ let optimize_graph ~ctx ~finalize ~fixpoint ~local_iteration rules graph =
   let after_bytes = if Stats.profile () then rules_pp_size rules' else 0 in
   let elapsed = Unix.gettimeofday () -. started_at in
   let bytes_saved = Stats.saving () in
-  (* [ordered_rules] and [list_map_preserve] return the input list unchanged by
-     physical identity on a no-op, so a pointer compare detects whether
-     factoring changed anything - no need to render both sides to CSS and
-     compare. *)
+  (* Both return the input unchanged by physical identity on a no-op, so a
+     pointer compare detects change without rendering to CSS. *)
   let changed = rules' != rules in
   record_iteration ~fixpoint ~local_iteration ~before_rules ~before_bytes
     ~after_rules:(List.length rules') ~after_bytes ~bytes_saved ~changed
     ~elapsed;
   if changed then rules' else rules
 
-(* Factoring rewrites are chosen by raw-byte gain, but stylesheets ship
-   DEFLATE-compressed: replacing repeated declaration text (nearly free under
-   LZ77) with unique selector-list structure can grow the compressed output even
-   as raw bytes shrink. Under the [`Transfer] objective, keep a segment's
-   factoring only when the estimated transfer size does not grow. Below
-   [transfer_gate_min_bytes] the estimate is noise against DEFLATE's block
-   overhead, so raw-byte wins stand unchallenged. *)
+(* Stylesheets ship DEFLATE-compressed, so a raw-byte factoring win can grow the
+   compressed output (LZ77-cheap repeated text traded for unique selector
+   structure). Under [`Transfer] keep a segment's factoring only if estimated
+   transfer size does not grow; below this floor the estimate is DEFLATE
+   block-overhead noise, so raw wins stand. *)
 let transfer_gate_min_bytes = 4096
 
-(* The estimate is a greedy-LZ77 approximation, and it costs a factored group by
-   the whole segment's compressibility, so an unrelated grouping elsewhere in
-   the segment shifts it by a byte or two. Revert only when factoring grows the
-   estimate beyond that noise floor, so a sub-percent difference does not flip a
-   distant, otherwise raw-smaller factoring; real regressions (the youtube-class
-   case, ~2% of the segment) stay well clear of it. Reverting on the noise also
-   hurt real gzip - the estimate's error swamps the byte it was chasing. *)
+(* The greedy-LZ77 estimate prices a group by the whole segment's
+   compressibility, so unrelated groupings jitter it a byte or two. Revert only
+   past this margin, so noise cannot flip a distant raw-smaller factoring; real
+   regressions (youtube-class, ~2% of the segment) stay well clear. *)
 let transfer_gate_margin before = max 16 (before / 100)
 
 let render_rules rules =
@@ -157,10 +147,9 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
       | _ -> ());
       result
 
-(* Custom-property rules are no longer cascade barriers: the DAG's conflict
-   model keys each custom property by name (a [var()] consumer writes its own
-   property, not the one it reads), so same-custom-property writes stay ordered
-   while disjoint ones merge and reorder freely. The whole rule list is one DAG
+(* Custom-property rules are not cascade barriers: the DAG keys each custom
+   property by name (a [var()] consumer writes its own property, not the one it
+   reads), so disjoint writes reorder freely and the whole list is one
    segment. *)
 let run ?cache ~ctx ~finalize (rules : rule list) =
   run_segment ?cache ~ctx ~finalize rules

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1,17 +1,14 @@
 (** Closed-world inlining transforms (var() and \@import).
 
-    The [vars] entry point implements a typed substitution pass layered on top
-    of {!Context} (typed evaluator) and {!Selector}. Visibility of a custom
-    property is computed from the rule structure: a custom property defined on a
-    rule applies to itself and to any rule whose effective selector descends
-    from it, and only if the consumer is inside the same chain of [\@media],
-    [\@layer], [\@supports] blocks.
+    [vars] is a typed substitution pass over {!Context} and {!Selector}. A
+    custom property is visible to itself and to any rule whose effective
+    selector descends from its own, within the same chain of
+    [\@media]/[\@layer]/ [\@supports] blocks.
 
-    The [imports] entry point inlines [\@import] rules from a closed
-    [Context.loader] table. Layer / supports / media guards on the [\@import]
-    prelude are evaluated against [?query] and [?layer_order] when supplied;
-    rejected imports are dropped, accepted ones lose the matched guard from
-    their wrapping. Cyclic imports terminate by dropping the repeat visit. *)
+    [imports] inlines [\@import] rules from a closed [Context.loader] table.
+    Layer/supports/media guards on the prelude are evaluated against [?query]
+    and [?layer_order]; rejected imports drop, accepted ones lose the matched
+    guard, and a repeat visit (cycle) is dropped. *)
 
 open Stylesheet
 open Syntax
@@ -39,19 +36,19 @@ let effective_selector ~parents sel =
         (fun child parent -> combine_with_parent parent child)
         sel parents
 
-(* A selector reaches the whole subtree when one of its comma branches is a
-   universal/root selector: [:root] (and [html]) inherit to every element and
-   [*] matches every element, so [:root,:host] covers via its [:root] branch
-   while a lone [:host] (shadow root only) does not. *)
+(* A selector reaches the whole subtree when a comma branch is universal/root:
+   [:root]/[html] inherit to every element and [*] matches every element, so
+   [:root,:host] covers via [:root] but a lone [:host] (shadow root) does
+   not. *)
 let universal_selector_text s =
   String.split_on_char ',' s
   |> List.exists (fun p ->
       match String.trim p with ":root" | "html" | "*" -> true | _ -> false)
 
-(* [.theme] is an ancestor of [.theme .descendant] (descendant-prefix); not of
-   [.other]. Universal selectors always cover. The text comparison is
-   conservative - exact rather than structural - which mirrors the "static
-   prefix" semantics expected by the cram suite. *)
+(* [.theme] is an ancestor of [.theme .descendant] (descendant-prefix), not of
+   [.other]; universals always cover. The comparison is conservatively exact
+   (not structural), matching the "static prefix" semantics the cram suite
+   expects. *)
 let selector_covers ~ancestor ~consumer =
   let a = Selector.to_string ~minify:true ancestor in
   let c = Selector.to_string ~minify:true consumer in
@@ -353,10 +350,9 @@ let rec substitute_components ~kept visible ~visited components =
   loop [] components
 
 and substitute_var ~kept visible ~visited original name fallback =
-  (* An unresolved var() with no fallback is kept verbatim at the top level for
-     the cascade engine, but inside another custom property's value it is
-     guaranteed-invalid and propagates failure to the nearest enclosing
-     fallback. *)
+  (* An unresolved var() with no fallback is kept verbatim at the top level, but
+     inside another custom property's value it is guaranteed-invalid and
+     propagates failure to the nearest enclosing fallback. *)
   let keep_or_fail () =
     if visited = [] then Components [ Component.Func original ] else Cycle
   in
@@ -384,10 +380,9 @@ and substitute_var ~kept visible ~visited original name fallback =
         else fallback_or_original ()
     | Some value -> resolved_or_fallback value
 
-(* A kept var stays a live [var(--name, ...)] reference, but its fallback may
-   still hold resolvable vars ([var(--tw-ease, var(--default-ease))] becomes
-   [var(--tw-ease, ease)]), so substitute inside the fallback and rebuild the
-   wrapper rather than collapsing to the fallback. *)
+(* A kept var stays a live [var(--name, ...)], but its fallback may hold
+   resolvable vars ([var(--tw-ease, var(--default-ease))] -> [var(--tw-ease,
+   ease)]), so substitute inside the fallback and rebuild the wrapper. *)
 and keep_wrapper ~kept visible ~visited original fallback =
   match fallback with
   | None -> Components [ Component.Func original ]
@@ -463,11 +458,9 @@ let should_use_typed_default ~kept visible vars =
          && not (List.mem (String.concat "" [ "--"; var.Values.name ]) kept))
        vars
 
-(* [Context.eval] keeps a kept var live (the context lists it in [runtime_vars],
-   so the resolver leaves the [var()] reference intact and never collapses it to
-   a fallback) while still applying the value-independent simplifications such
-   as the calc identities. So the substituted declaration is always evaluated,
-   whether or not it still references a kept var. *)
+(* [Context.eval] leaves a kept var's [var()] intact (it is in [runtime_vars])
+   while still applying value-independent simplifications like calc identities,
+   so the substituted declaration is always evaluated, kept var or not. *)
 let apply_substituted_components ctx decl ~original_components components =
   if components = original_components then Some (Context.eval ctx decl)
   else
@@ -805,11 +798,10 @@ let refs_of_declaration decl =
       refs_of_components (Properties.components_of_custom_property_value value)
   | _ -> names_of_vars (Variables.vars_of_declarations [ decl ])
 
-(* Walk the stylesheet to collect, for each declaration, the scope at which it
-   appears and the var names its body references. [consumers] lists non-custom
-   declarations (which determine direct liveness); [customs] lists custom-prop
-   declarations along with the var names their bodies reference (used to
-   propagate liveness through chains like [--quad: calc(var(--double) * 2)]). *)
+(* Collect, per declaration, its scope and the var names its body references.
+   [consumers] are non-custom declarations (direct liveness); [customs] are
+   custom-prop declarations with their referenced vars, propagating liveness
+   through chains like [--quad: calc(var(--double) * 2)]. *)
 let refs_of_at_node = function
   | Media query -> refs_of_media query
   | Supports query -> refs_of_supports query

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -1,11 +1,9 @@
 (** Stage 2 stream: characters -> Token.t.
 
-    Wraps a {!Reader.t} char cursor, maintains a token-buffer pushback for
-    {!reconsume}, and exposes the CSS Syntax section 4 tokenizer through the
-    uniform [next / peek / reconsume] triple. The buffer doubles as a
-    backtracking stack: {!save} marks a point in the buffered prefix and
-    {!restore} replays the tokens consumed after it, mirroring
-    {!Reader.save}/{!Reader.restore} for the Token layer. *)
+    Wraps a {!Reader.t} char cursor and exposes the CSS Syntax section 4
+    tokenizer through the uniform [next / peek / reconsume] triple. The token
+    buffer doubles as a backtracking stack: {!save}/{!restore} mark and replay,
+    mirroring {!Reader.save}/{!Reader.restore} for the Token layer. *)
 
 open Token
 
@@ -35,10 +33,9 @@ let is_hex c = is_digit c || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
 let is_ws c = c = ' ' || c = '\n' || c = '\t' || c = '\r' || c = '\012'
 let is_newline c = c = '\n' || c = '\r' || c = '\012'
 
-(* CSS Syntax Level 3 section 4.2 "non-ASCII ident code point": the specific
-   code-point ranges allowed in identifiers. Kept as a sealed check so that
-   byte-level heuristics ([>= 0x80]) don't over-accept code points the spec
-   explicitly excludes (e.g. most symbols, emoji, BMP non-characters). *)
+(* CSS Syntax 3 section 4.2 "non-ASCII ident code point" ranges. A sealed check,
+   so a byte-level [>= 0x80] heuristic can't over-accept code points the spec
+   excludes (most symbols, emoji, BMP non-characters). *)
 let is_non_ascii_ident_cp cp =
   cp = 0xB7
   || (cp >= 0xC0 && cp <= 0xD6)
@@ -58,10 +55,8 @@ let is_non_ascii_ident_cp cp =
 let is_name_start_ascii c =
   (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c = '_'
 
-(* [is_name_start_at r offset] checks whether the code point at offset is a
-   valid ident-start. ASCII bytes answer directly without UTF-8 decoding; only
-   bytes [>= 0x80] fall back to [peek_utf8_at]. [peek_byte_at] returns [-1] at
-   end of input. *)
+(* Whether the code point at [offset] is a valid ident-start. ASCII bytes answer
+   directly; only [>= 0x80] falls back to [peek_utf8_at]. *)
 let is_name_start_at r offset =
   let b = Reader.peek_byte_at r offset in
   if b < 0 then false
@@ -83,9 +78,8 @@ let is_name_at r offset =
     | None -> false
     | Some (cp, _) -> is_non_ascii_ident_cp cp
 
-(* Legacy byte-level helpers kept for the hot paths where the caller has already
-   materialised the byte. For anything ASCII they match spec; for bytes [>=
-   0x80] they are now conservative (reject), and callers that might see
+(* Byte-level helpers for hot paths where the caller already has the byte. ASCII
+   matches spec; [>= 0x80] is conservative (reject), so callers that may see
    non-ASCII must use the [_at] variants above. *)
 (* 4.3.3 Check if two code points are a valid escape. The reader is at the
    first; check whether ('\\', next) forms a valid escape (i.e. first is '\\'
@@ -201,11 +195,10 @@ let consume_escape r =
       Reader.skip r;
       String.make 1 c
 
-(* Hot loop: walk bytes directly from the source string. ASCII name bytes (the
-   overwhelming majority of CSS identifiers) advance by one without allocating;
-   a backslash bails to the escape-handling slow path; bytes >= 0x80 fall back
-   to the UTF-8 decode for spec-conformant rejection of non-ident code
-   points. *)
+(* Hot loop: walk bytes directly from the source. ASCII name bytes (nearly all
+   idents) advance by one without allocating; a backslash bails to the slow
+   escape path; [>= 0x80] falls back to UTF-8 decode for spec-conformant
+   rejection. *)
 let rec scan_ident_fast r src src_len =
   let pos = Reader.position r in
   if pos >= src_len then `End
@@ -269,15 +262,9 @@ let scan_ident_slow r src buf =
   loop ();
   Buffer.contents buf
 
-(* 4.3.8 Consume an ident sequence. Iterates at the code-point level so
-   multi-byte characters are accepted only when their code point is a valid
-   ident code point per section 4.2 (see [is_name_at]).
-
-   Fast path: when the ident has no [\] escape, the result is exactly the
-   substring of the source between the start position and the position where we
-   stopped, so we return [String.sub src start len] without ever allocating a
-   Buffer. The slow path (escape encountered) seeds a Buffer with the prefix
-   already copied and continues with the original byte-by-byte build. *)
+(* 4.3.8 Consume an ident sequence, at the code-point level (section 4.2, see
+   [is_name_at]). Fast path (no [\] escape) returns [String.sub] of the source
+   with no Buffer; the slow path seeds a Buffer with the copied prefix. *)
 let consume_ident_sequence r =
   let src = Reader.source r in
   let src_len = String.length src in
@@ -417,9 +404,8 @@ let consume_url_token r =
   skip_ws ();
   let rec loop () =
     match Reader.peek r with
-    (* CSS Syntax 3 section 4.3.6: hitting EOF inside [url(] is a parse error,
-       but the algorithm still returns a [<url-token>] - the parse error
-       surfaces via the partial-recovery warnings, not by morphing into
+    (* CSS Syntax 3 section 4.3.6: EOF inside [url(] is a parse error but still
+       returns a [<url-token>], surfacing via recovery warnings rather than a
        [<bad-url-token>]. *)
     | None -> Url (Buffer.contents buf)
     | Some ')' ->
@@ -576,11 +562,9 @@ let rec skip_comment_body r =
     Reader.skip r;
     skip_comment_body r)
 
-(* Skip a run of comments without consuming surrounding whitespace, so a comment
-   between two non-whitespace code points disappears from the token stream
-   rather than synthesising a <whitespace-token>. CSS Syntax §4.3.2 says
-   comments are treated as "nothing"; only actual whitespace produces a
-   <whitespace-token>. *)
+(* Skip a run of comments without consuming surrounding whitespace: CSS Syntax
+   §4.3.2 treats comments as "nothing", so a comment between two non-whitespace
+   points disappears rather than becoming a <whitespace-token>. *)
 let rec skip_comment_run r =
   if Reader.looking_at r "/*" then (
     Reader.skip r;
@@ -648,10 +632,9 @@ let consume_at_start r =
   else Delim "@"
 
 (* 4.3.1 Consume a token. *)
-(* Multi-byte lead or ASCII name-start: either consume a full ident-like token
-   when the code point really starts an ident, or emit a single-code-point
-   [Delim] (CSS Syntax section 4.3.1) - the UTF-8 byte sequence is consumed
-   atomically so the delim token carries the whole code point. *)
+(* Multi-byte lead or ASCII name-start: consume a full ident-like token, or emit
+   a single-code-point [Delim] whose UTF-8 bytes are consumed atomically so the
+   delim carries the whole code point. *)
 let consume_name_start_or_delim ~force_url_function r c =
   if is_name_start_at r 0 then consume_ident_like_token ~force_url_function r
   else if c >= '\x80' then (
@@ -751,11 +734,9 @@ let tokenize_with_loc ?(force_url_function = false) reader =
   let end_pos = Reader.position reader in
   Token.v ~kind ~loc:(Loc.v ~start_pos ~end_pos)
 
-(* [history] only needs to retain tokens consumed since the last active [save]:
-   [force_url_function] and [reconsume] both look at the head, and [save]
-   snapshots [t.history] for [restore]. With no saves active, the head is all we
-   need, so write a single-element list instead of growing one; when saves are
-   active we keep the full list so restore can rewind. *)
+(* [history] need only retain tokens since the last active [save]. With no saves
+   the head is all [force_url_function]/[reconsume] read, so keep a one-element
+   list; with saves active keep the full list so [restore] can rewind. *)
 let record_consume t tok =
   match t.saves with
   | [] -> t.history <- [ tok ]
@@ -763,12 +744,10 @@ let record_consume t tok =
       t.history <- tok :: t.history;
       List.iter (fun save -> save.trace := tok :: !(save.trace)) saves
 
-(* True iff the previous emitted token was a [Url(...)] AND no separator
-   (whitespace or comment) follows. The next [url(...)] in that case would
-   otherwise re-enter the lexer's url branch and merge with the previous token;
-   treat it as a function-call instead so the two stay distinct. Per CSS Syntax
-   4.3.2, comments behave like whitespace, so a [/* */] between the two urls
-   also disarms this guard. *)
+(* True iff the previous token was [Url(...)] with no separator (whitespace or
+   comment) after: the next [url(...)] would re-enter the url branch and merge,
+   so force a function-call to keep them distinct. Per CSS Syntax 4.3.2 comments
+   act like whitespace, so a [/* */] between the urls also disarms this. *)
 let force_url_function t =
   match t.history with
   | { kind = Url _; loc; _ } :: _ when loc.end_pos = Reader.position t.reader

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -413,12 +413,10 @@ let pp_feature : feature Pp.t =
       pp_value ctx b;
       Pp.char ctx ')'
 
-(* CSS Media Queries 4 sec. 3.3: a lower bound and an upper bound on the same
-   feature combine into the two-sided [<value> <op> <name> <op> <value>]
-   interval, which is shorter than repeating the feature name across an [and].
-   [feature_bound] normalises a single-bound feature ([min-]/[max-] plains and
-   the [<name> <op> <value>] / [<value> <op> <name>] range forms) into a [(name,
-   side, op, value)] view so two bounds can be paired. *)
+(* CSS Media Queries 4 sec. 3.3: a lower and an upper bound on the same feature
+   combine into the two-sided [<value> <op> <name> <op> <value>] interval.
+   [feature_bound] normalises a single-bound feature into a [(name, side, op,
+   value)] view so two bounds can be paired. *)
 type bound_side = Lower | Upper
 
 let feature_bound (f : feature) : (name * bound_side * cmp * value) option =
@@ -815,10 +813,8 @@ let validate_plain_feature (name : name) value =
     | Some _ -> name
     | None -> name
   in
-  (* [env()] / [var()] / [calc()] etc. produce a typed value at use time;
-     cascade can't determine the resolved type at parse time, so accept them
-     wherever a typed numeric is allowed and let the consumer do its own
-     validation. *)
+  (* [env()] / [var()] / [calc()] resolve their type at use time, so accept them
+     wherever a typed numeric is allowed and let the consumer validate. *)
   let is_typed_function = function Function _ -> true | _ -> false in
   let valid_numeric_value (name : name) value =
     is_typed_function value
@@ -1227,11 +1223,10 @@ let feature name value : t =
 
 let boolean name : t = Cond (Feature (Boolean (name_of_string name)))
 
-(* CSS Media Queries 4 sec. 3.4 / 3.3: under minify the optimizer rewrites
-   [min-X]/[max-X] plains into the range form [X>=V]/[X<=V], and pairs a lower
-   and upper bound on the same feature across an [and] into the two-sided
-   interval. These are target-fact grammar upgrades, so they live in the
-   optimize phase (gated by [~enforce_spec]) rather than the printer. *)
+(* CSS Media Queries 4 sec. 3.4 / 3.3: the optimizer rewrites [min-X]/[max-X]
+   into the range form and pairs a lower and upper bound into the two-sided
+   interval. Target-fact grammar upgrades, so they live in optimize (gated by
+   [~enforce_spec]), not the printer. *)
 let lower_feature : feature -> feature = function
   | Plain (Min base, v) -> Range (base, Ge, v)
   | Plain (Max base, v) -> Range (base, Le, v)
@@ -1314,11 +1309,10 @@ let value_sort_key = function
   | Ident _ -> (100, 0.)
   | Function _ -> (200, 0.)
 
-(* A width feature classifies into the responsive buckets by which side of the
-   range it bounds: a lower bound ([min-width] / [width>=] / [width<=value]) is
-   [Responsive], an upper bound ([max-width] / [width<=] / [width>=value]) is
-   [Responsive_max]. Other width plains and [height] keep the plain
-   length-sorted [Responsive] classification. *)
+(* A width feature buckets by which side it bounds: a lower bound ([min-width] /
+   [width>=]) is [Responsive], an upper bound ([max-width] / [width<=]) is
+   [Responsive_max]. Other width plains and [height] stay length-sorted
+   [Responsive]. *)
 let width_bound_kind name side value : kind option =
   match name with
   | Width ->
@@ -1462,25 +1456,21 @@ let responsive_subkind : t -> int = function
   | Type { trailing = Some c; _ } -> condition_subkind c
   | Type _ | List _ -> 2
 
-(* Within a responsive bucket, sort by decreasing specificity: an element
-   matching [(min-width: 768px)] also matches [(min-width: 640px)], so the
-   largest [min] is the most specific and sorts last; symmetrically the smallest
-   [max] is the most specific and sorts last. The [Responsive_max] value is
-   negated so a single ascending comparator gives the largest-first order
-   ([1024, 768, 640]). *)
+(* Within a responsive bucket, sort by decreasing specificity: the largest [min]
+   (and smallest [max]) is most specific and sorts last. [Responsive_max] is
+   negated so one ascending comparator yields largest-first ([1024, 768,
+   640]). *)
 let responsive_value k =
   match k with
   | Responsive (unit_ord, value) -> (Float.of_int unit_ord *. 1e9) +. value
   | Responsive_max (unit_ord, value) -> (Float.of_int unit_ord *. 1e9) -. value
   | _ -> 0.
 
-(* The sort order is decided by four cheap ordinal keys and, only when those all
-   tie, the serialized text. Extracting the kinds and serializing both allocate
-   ([feature_bound], [Pp.v]), so a sort that re-derives them on every comparison
-   pays that cost O(n log n) times - and queries sharing a breakpoint tie on
-   every ordinal key, so they always reach the text. [key] captures all five
-   components; compute it once per query with [sort_key] and compare with
-   [compare_keys], which allocates nothing. *)
+(* Sort by four cheap ordinal keys, then serialized text on a full tie.
+   Extracting kinds and serializing allocate, and breakpoint-sharing queries tie
+   on every ordinal key so they always reach the text; [sort_key] computes the
+   five components once per query and [compare_keys] compares them
+   alloc-free. *)
 type key = {
   group : int;
   subkind : int;

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -13,12 +13,11 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 type scope = Ctx.scope
 
-(* Optimisation context threaded by the entry points ([stylesheet], [rules],
-   [single_rule], [deduplicate_declarations]) down to the shorthand composers.
-   [scope] drives the fragment-vs-stylesheet decisions; [registered] reports
-   whether a custom property is registered with an [@property] initial-value, so
-   folding its [var()] into a shorthand cannot widen an invalid-at-
-   computed-value failure. Default: fragment, nothing registered. *)
+(* Optimisation context threaded from the entry points to the shorthand
+   composers. [scope] drives fragment-vs-stylesheet decisions; [registered]
+   reports whether a custom property has an [@property] initial-value, so
+   folding its [var()] into a shorthand cannot widen an
+   invalid-at-computed-value failure. Default: fragment, nothing registered. *)
 type ctx = Ctx.t
 
 let ctx_of_scope = Ctx.of_scope
@@ -125,20 +124,18 @@ let synthesize_nesting_statements = Nest.statements
 let stylesheet_key stmts = Pp.to_string ~minify:true pp_stylesheet stmts
 
 (* A block holds a conditional named layer when it directly contains a named
-   [@layer] block with content. Unwrapping a known-true [@supports] around such
-   a block would move that layer's rules - and its place in the layer order (CSS
-   Cascade 6.4) - from conditional to unconditional, so the wrapper must stay
-   even when the condition is baseline-true. A bare [@layer name;] declaration
-   carries no rules, and self-guarding declarations carry no side effect, so
-   both unwrap freely. *)
+   [@layer] block with content. Unwrapping a known-true [@supports] around it
+   would move that layer's rules and its place in the layer order (CSS Cascade
+   6.4) from conditional to unconditional, so the wrapper stays even when
+   baseline-true. Bare [@layer name;] and self-guarding declarations carry no
+   rules or side effect, so both unwrap freely. *)
 let block_introduces_layer_order stmts =
   List.exists (function Layer (Some _, _ :: _) -> true | _ -> false) stmts
 
-(* Pop the run of [Rule]s most recently pushed onto a reversed accumulator,
-   returning them in forward order alongside the remaining accumulator. Used
-   when unwrapping a known-true [@supports] exposes its inner rules to rules
-   already emitted: those preceding rules must rejoin the merge pass so an
-   adjacency the wrapper had hidden can collapse. *)
+(* Pop the run of [Rule]s most recently pushed onto a reversed accumulator, in
+   forward order, with the remaining accumulator. When unwrapping a known-true
+   [@supports] exposes its inner rules, the preceding rules rejoin the merge
+   pass so an adjacency the wrapper hid can collapse. *)
 let pop_trailing_rules acc =
   let rec loop acc rules =
     match acc with
@@ -179,11 +176,10 @@ let rec statements ?factor_cache ~ctx ~enforce_spec (stmts : statement list) :
   | _ ->
       let optimize_merged_block = statements ?factor_cache ~ctx ~enforce_spec in
       (* [drop_misplaced_imports] runs first: an [@import] after a style rule is
-         invalid and ignored by every browser, so it is a no-op that must not
-         act as a cascade boundary. Stripping it up front lets the rules it
-         falsely separated merge in this same pass, which keeps [statements]
-         idempotent - stripping after the merge would leave two adjacent
-         same-selector rules that only a re-run would combine. *)
+         invalid and ignored by browsers, so it must not act as a cascade
+         boundary. Stripping it up front lets the rules it falsely separated
+         merge in this same pass, keeping [statements] idempotent (stripping
+         after the merge would leave a re-run to combine them). *)
       let stmts' =
         let stmts =
           drop_misplaced_imports stmts |> merge_named_layers_by_name
@@ -203,11 +199,10 @@ let rec statements ?factor_cache ~ctx ~enforce_spec (stmts : statement list) :
       in
       preserve_list stmts stmts'
 
-(* Process a "cursor" of (reverse acc, current remaining list, pending segment
-   stack). When the current list is exhausted, pop the next segment from
-   pending; when both are empty, return the final reversed list. This shape lets
-   [process_supports_statement] splice three segments without first
-   materialising their concatenation. *)
+(* Process a cursor of (reverse acc, remaining list, pending segment stack),
+   popping the next pending segment when the list is exhausted. This lets
+   [process_supports_statement] splice three segments without materialising
+   their concatenation. *)
 and process_statements ?factor_cache ~ctx ~enforce_spec
     ?(pending : statement list list = []) (acc : statement list)
     (remaining : statement list) : statement list =
@@ -314,12 +309,11 @@ and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~pending acc
         rest
   | `True ->
       let trailing, acc = pop_trailing_rules acc in
-      (* [trailing], [optimized_block], and [rest] must be visible to
+      (* [trailing], [optimized_block], and [rest] must reach
          [process_statements] as a SINGLE list so [collect_rules] can pull
-         adjacent rules across the segment boundary into one rule run - that
-         adjacency-aware merge is exactly the point of unwrapping a
-         baseline-true @supports. Use tail-recursive [List.concat] so a long
-         [optimized_block] doesn't stack-overflow. *)
+         adjacent rules across the segment boundary into one run - the whole
+         point of unwrapping a baseline-true @supports. Tail-recursive
+         [List.concat] so a long [optimized_block] cannot stack-overflow. *)
       process_statements ?factor_cache ~ctx ~enforce_spec ~pending acc
         (List.concat [ trailing; optimized_block; rest ])
   | `False ->
@@ -437,13 +431,11 @@ let drop_shadowed_keyframes (stmts : statement list) : statement list =
   in
   walk [] stmts
 
-(* CSS Cascade 5 sec. 6.4.2: when a named layer is declared multiple times the
-   rules from all occurrences accumulate into the layer. Merge same-name blocks
-   at the position of the FIRST NON-EMPTY occurrence so the merged content stays
-   where the author placed the layer's first real declaration. Leading empty
-   blocks ([@layer name {}]) stay in place so the [empty-named-layer ->
-   Layer_decl] normalisation in [process_statements] still folds them into the
-   order-only declaration. *)
+(* CSS Cascade 5 sec. 6.4.2: rules from all occurrences of a named layer
+   accumulate. Merge same-name blocks at the FIRST NON-EMPTY occurrence so
+   content stays where the author placed the layer's first real declaration.
+   Leading empty blocks ([@layer name {}]) stay in place for the
+   [empty-named-layer -> Layer_decl] normalisation in [process_statements]. *)
 let statements_top_level ?factor_cache ~ctx ~enforce_spec
     (stmts : statement list) : statement list =
   let optimize_merged_block = statements ?factor_cache ~ctx ~enforce_spec in
@@ -652,12 +644,10 @@ let drop_unknown_at_rules (stylesheet : t) : t =
   in
   list_edit_preserve statement stylesheet
 
-(* CSS Properties and Values API 1 sec. 2: an [@property --name { syntax: ... }]
-   declaration registers [name] with a typed CSS syntax, lifting later [--name:
-   ...] uses out of the unregistered opaque-token-stream rule. Apply
-   registrations in source order so a [@property] only affects uses that follow
-   it; later registrations of the same name overwrite, matching how the browser
-   registry resolves duplicate declarations. *)
+(* CSS Properties and Values API 1 sec. 2: an [@property --name] registers a
+   typed syntax, lifting later [--name: ...] uses out of the opaque-token-stream
+   rule. Apply in source order so a registration only affects later uses; a
+   duplicate name overwrites, matching the browser registry. *)
 let try_promote_custom_with (type a) (syntax : a Variables.syntax) components =
   match syntax with
   | Variables.Color -> Properties.try_read_custom_color components
@@ -753,12 +743,11 @@ let promote_registered_custom_properties ~lossless (stmts : statement list) =
   in
   list_map_preserve walk_stmt stmts
 
-(* Under closed-stylesheet scope the optimiser knows every [@position-try
-   --name] rule defined in the sheet. A [position-try-fallbacks: --x, --y] entry
-   whose name has no matching [@position-try] rule cannot match at runtime, so
-   prune unknown [Name] arms. Keep the [Flip_*] tactics and any [Var]
-   indirection untouched. When every arm gets pruned the whole declaration drops
-   (the property becomes equivalent to its initial). *)
+(* Under closed-stylesheet scope every [@position-try --name] rule is known. A
+   [position-try-fallbacks] entry whose name has no matching rule cannot match
+   at runtime, so prune unknown [Name] arms (keeping [Flip_*] and [Var]). When
+   every arm is pruned the whole declaration drops (equivalent to its
+   initial). *)
 let collect_position_try_names stylesheet =
   let known : (string, unit) Hashtbl.t = Hashtbl.create 8 in
   let rec collect (stmt : statement) =
@@ -1035,13 +1024,11 @@ let stylesheet_rule_count stmts =
   List.fold_left (fun count stmt -> count + statement_rule_count stmt) 0 stmts
 
 let run_pipeline ~ctx ~enforce_spec ~aggressive stylesheet =
-  (* Re-run the top-level pipeline until the AST stops changing or a small
-     iteration cap fires. Each subsequent pass may shrink the input again
-     because an earlier pass (vendor-alias drop, shorthand composition, media /
-     support merging) exposed a rule run that the DAG factor pass can now
-     optimize. Rule order projection is folded into [Factor.run], so the hot
-     loop does not build a separate ordering graph. Rule count is non-increasing
-     across passes, so this converges. [aggressive] only widens the cap. *)
+  (* Re-run the top-level pipeline until the AST stops changing or a small cap
+     fires. A pass may shrink the input again because an earlier one
+     (vendor-alias drop, shorthand composition, media/support merging) exposed a
+     rule run the DAG factor pass can now optimize. Rule count is
+     non-increasing, so this converges; [aggressive] only widens the cap. *)
   let cap =
     if aggressive then 6
     else if stylesheet_rule_count stylesheet > 128 then 1
@@ -1060,11 +1047,10 @@ let run_pipeline ~ctx ~enforce_spec ~aggressive stylesheet =
   in
   loop cap (stylesheet_key stylesheet) stylesheet
 
-(* Bare names of every custom property referenced through a [var()] anywhere in
-   the tree. Scans the serialized declarations, so it sees references inside
-   opaque custom-property values too and over-keeps (a [var(] inside a string
-   counts) - it must never miss a live reference, or the prune below would drop
-   a binding still in use. *)
+(* Bare names of every custom property referenced through [var()] in the tree.
+   Scans the serialized declarations, so it sees references inside opaque values
+   too and over-keeps (a [var(] inside a string counts): it must never miss a
+   live reference, or the prune below drops a binding still in use. *)
 let referenced_custom_props (stmts : statement list) : (string, unit) Hashtbl.t
     =
   let tbl = Hashtbl.create 64 in

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -147,10 +147,9 @@ let escape_ident_emit_item buf starts () i = function
          same ident. Hex-escape each byte so the serialized form round-trips. *)
       String.iter (fun c -> add_hex_escape buf c) bs
 
-(* True when every byte of [s] is in the ASCII ident-continue set and the
-   leading byte is in the ASCII ident-start set. Such idents serialise to
-   themselves byte-for-byte; the buffer + Uutf walk inside [escape_ident] then
-   allocates nothing useful. *)
+(* An all-ASCII ident (start byte in ident-start, rest in ident-continue)
+   serialises to itself byte-for-byte, so [escape_ident]'s buffer + Uutf walk
+   would allocate nothing useful. *)
 let escape_ident_needs_no_escape s n =
   if n = 0 then true
   else if not (Syntax.is_ascii_ident_start s.[0]) then false
@@ -203,12 +202,10 @@ let string_of_token_kind : Token.kind -> string = function
   | Token.At_keyword s -> "@" ^ escape_ident s
   | Token.Hash { value; _ } -> "#" ^ escape_name value
   | Token.String { value; quote = _; terminated } ->
-      (* Normalize string quoting to double-quote on serialization. The original
-         quote is recorded on the token only so quote-sensitive lookups (e.g.
-         @charset) can inspect it. CSS Syntax §4.3.5 recovers an unterminated
-         string token but the serializer preserves the [terminated] flag so the
-         original byte sequence round-trips: a string the lexer flagged as
-         unterminated emits without its closing quote. *)
+      (* Normalize quoting to double-quote (the original quote is kept on the
+         token only for quote-sensitive lookups like @charset). CSS Syntax
+         §4.3.5 recovers an unterminated string; the [terminated] flag is
+         preserved so one round-trips, emitting without its closing quote. *)
       escape_string ~quote:'"' ~terminated value
   | Token.Bad_string -> ""
   | Token.Url s ->
@@ -233,10 +230,9 @@ let string_of_token_kind : Token.kind -> string = function
   | Token.Number_tok { repr; _ } -> repr
   | Token.Percentage { repr; _ } -> repr ^ "%"
   | Token.Dimension { number; unit_ } ->
-      (* CSS Syntax §9.1 ambiguous-dimension rule: a unit starting with [e]/[E]
-         followed by a digit (with optional sign) round-trips as scientific
-         notation rather than a dimension. Escape the leading letter via the hex
-         form so the lexer cannot fold it into the number's exponent. *)
+      (* CSS Syntax §9.1 ambiguous-dimension rule: a unit of [e]/[E] then a
+         (signed) digit would re-read as scientific notation, so hex-escape the
+         leading letter to keep it out of the number's exponent. *)
       let unit_serialized =
         let len = String.length unit_ in
         let next_is_digit i = i < len && unit_.[i] >= '0' && unit_.[i] <= '9' in
@@ -371,11 +367,10 @@ let rec cv_to_buffer buf : Component.t -> unit = function
       cvs_to_buffer buf value;
       Buffer.add_char buf (closing_char opening)
   | Func { node = { name; arguments; _ }; _ } ->
-      (* Always emit the closing [)] - section 5.4.6 says EOF inside a function
-         is a parse error but the function token is still produced; a
-         deserialised round-trip should match the lexer's tokenisation, not the
-         original truncated bytes. The [terminated] flag is for typed validators
-         that want to reject the rule. *)
+      (* Always emit the closing [)]: section 5.4.6 still produces the function
+         token on EOF, so the round-trip should match the lexer, not the
+         truncated bytes. [terminated] is left for typed validators to
+         reject. *)
       Buffer.add_string buf (escape_ident name);
       Buffer.add_char buf '(';
       cvs_to_buffer buf arguments;
@@ -405,19 +400,11 @@ let string_of_components cvs =
   cvs_to_buffer buf cvs;
   Buffer.contents buf
 
-(* CSS Syntax Level 3 section 9.1: when serialising adjacent tokens, the
-   serialiser must keep them lexically separate. Two predicates are needed
-   because the relevant property is what byte the previous token *ends* with and
-   what byte the next token *starts* with:
-
-   - [word_like_end p]: [p] ends with a code point that could continue an
-   ident-like or numeric token (so an adjacent ident-continue or [-] would merge
-   in). - [word_like_start n]: [n] starts with a code point that an ident-like
-   or numeric token could absorb on its left.
-
-   {!Func} components begin with [ident(] (word-like at the start) but end with
-   [)] (self-delimiting). {!Block} is self-delimiting at both ends.
-   Self-delimiting tokens never need separation from a neighbour. *)
+(* CSS Syntax 3 section 9.1: adjacent tokens must stay lexically separate.
+   [word_like_end p]/[word_like_start n] test the byte [p] ends with / [n]
+   starts with, since a merge depends on both. {!Func} is word-like at the start
+   ([ident(]) but self-delimiting at the end ([)]); {!Block} is self-delimiting
+   both ends and never needs separation. *)
 let word_like_end : Component.t -> bool = function
   | Preserved
       {
@@ -434,12 +421,11 @@ let word_like_end : Component.t -> bool = function
       } ->
       false
   | Preserved _ -> true
-  (* CSS Color 4 sec. 11.1 (relative colour) and similar grammars use whitespace
-     as the separator between a [<color>] argument expressed as a [var()] (or
-     another function call) and the following channel ident. [oklab(from
-     var(--c) l a b)] tokenises fine with [var(--c)l] adjacent, but spec-strict
-     parsers expect the separator. Treat a [Func] (and a Paren [Block]) as
-     word-like-end so [Func] + [Ident] keeps its boundary. *)
+  (* CSS Color 4 sec. 11.1 relative colour needs whitespace between a [var()]
+     (or other function) [<color>] arg and the following channel ident:
+     [oklab(from var(--c) l a b)] tokenises fine as [var(--c)l] but spec-strict
+     parsers expect the separator. So [Func]/Paren [Block] count as
+     word-like-end to keep the [Func] + [Ident] boundary. *)
   | Func _ -> true
   | Block { node = { opening = Paren; _ }; _ } -> true
   | Block _ -> false
@@ -612,11 +598,10 @@ let to_string_custom cvs =
   cvs_to_buffer buf cvs;
   Buffer.contents buf
 
-(* CSS Custom Properties Level 1: specified custom-property values are opaque
-   token streams, so authored whitespace is preserved by [to_string_custom].
-   This minified rendering is only for canonical output: it collapses optional
-   whitespace in blocks and function arguments while preserving token
-   boundaries. *)
+(* Custom-property values are opaque token streams (CSS Custom Properties 1), so
+   [to_string_custom] keeps authored whitespace. This minified rendering is for
+   canonical output only: collapse optional whitespace in blocks and function
+   args while preserving token boundaries. *)
 let url_string_can_unquote s =
   not
     (String.exists
@@ -677,10 +662,9 @@ let custom_min_word_boundary p next =
   && (not (is_backslash_delim p))
   && word_like_start next
 
-(* A whitespace token in a custom-property value is part of the stream a var()
-   substitution receives, so an authored separator around [*] and [/] is
-   collapsed to one space, never deleted: [16 / 9] and [16/9] are different
-   token streams even though both parse in [calc()]. *)
+(* Whitespace in a custom-property value is part of the stream a var()
+   substitution receives, so a separator around [*] and [/] is collapsed to one
+   space, never deleted: [16 / 9] and [16/9] are distinct streams. *)
 let custom_min_needs_separator prev next rest =
   match prev with
   | None -> false
@@ -704,15 +688,12 @@ let custom_min_item_separator buf prev separated cv =
       Buffer.add_char buf ' '
   | _ -> ()
 
-(* CSS Syntax 3 sec. 3 says ident tokens are ASCII-case-insensitive at the
-   tokenizer level, but the parser keeps the source case so selectors stay
-   case-sensitive. Inside a custom-property value the tokens are always
-   interpreted as value-context idents, where the canonical spelling of a
-   CSS-wide keyword or [currentcolor] / [transparent] is lower-case. Fold those
-   specific idents here so [--c: currentColor] and [--c: currentcolor] serialise
-   to the same canonical bytes. The set is conservative on purpose: a tw class
-   name token that happens to live inside a custom property body must not
-   collapse, so unrecognised idents pass through unchanged. *)
+(* Idents are ASCII-case-insensitive per CSS Syntax 3 sec. 3, but the parser
+   keeps source case so selectors stay case-sensitive. In a custom-property
+   value only these keywords have a canonical lower-case spelling, so fold them
+   ([--c:currentColor] == [--c:currentcolor]). Kept conservative: an
+   unrecognised ident (e.g. a tw class name in a var body) passes through
+   unchanged. *)
 let case_insensitive_value_idents =
   let s = Hashtbl.create 16 in
   List.iter

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -5272,9 +5272,8 @@ let rec pp_order : order Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_order ctx v
 
-(* Opacity as float (0.0-1.0). While CSS accepts both number and percentage
-   formats, Tailwind's minifier converts percentages to decimals (50% → .5), so
-   we output decimals directly for minified output compatibility. *)
+(* Opacity as a float (0.0-1.0). Tailwind's minifier writes percentages as
+   decimals (50% -> .5), so minified output emits decimals to match. *)
 let rec pp_opacity : opacity Pp.t =
  fun ctx -> function
   | Opacity_number f -> Pp.float ctx f
@@ -16002,11 +16001,9 @@ let read_optional_line_height r =
       Some (read_shorthand_line_height_typed r)
   | _ -> None
 
-(* Parse the [font] shorthand body into a typed [font_shorthand] record. The
-   keyword prefix loop ([italic] / [bold] / etc.) populates style / variant /
-   weight / stretch as it sees the relevant keywords; [normal] is consumed
-   without binding a slot. Once a non-prefix token appears, the required [size]
-   [/ <line-height>?] <family>+ tail is read. *)
+(* Parse the [font] shorthand body: a keyword prefix loop fills style / variant
+   / weight / stretch (a [normal] binds no slot), then the required [size
+   [/<line-height>]? <family>+] tail. *)
 let read_font_shorthand r : font_shorthand =
   let style : font_style option ref = ref Option.None in
   let variant : font_variant_css21 option ref = ref Option.None in
@@ -16337,18 +16334,12 @@ let rec read_backface_visibility t : backface_visibility =
     t
 
 let rec read_scale t : scale =
-  (* Per CSS Transforms 2 §3.6: [<number-percentage>{1,3}]. There are two
-     [var()] shapes to keep distinct:
-
-     - [scale: var(--s)] — the var resolves to the whole [scale] value (which
-     itself can be 1 to 3 components). Produce [Var _]. - [scale: var(--x)
-     var(--y)] — each slot is independently a number- percentage that may be a
-     [var()]. Produce [XY (_, _)] etc.
-
-     We can't tell which shape we're in until we try to read a second component,
-     so we speculatively peel the first [var()] off as a whole- value [Var]; if
-     another component follows, the lookahead-saved snapshot lets us re-read it
-     as a per-slot [Var] and continue with [read_numbers]. *)
+  (* CSS Transforms 2 §3.6: [<number-percentage>{1,3}]. Two [var()] shapes to
+     keep distinct: [scale: var(--s)] is a whole-value var (produce [Var _]);
+     [scale: var(--x) var(--y)] is per-slot (produce [XY _]). They are
+     indistinguishable until a second component appears, so peel the first
+     [var()] as a whole-value [Var]; if another follows, the saved snapshot
+     re-reads it as a per-slot number-percentage. *)
   let read_numbers_from t (x : number_percentage) : scale =
     match Cursor.option Values.read_number_percentage t with
     | None -> X x
@@ -20735,9 +20726,8 @@ let pp_custom_property ctx (Custom_value { value; _ }) =
   pp_custom_property_value ctx value
 
 (* CSS Sizing 3 sec. 3.1: [min-width] / [min-height] / [min-inline-size] /
-   [min-block-size] have the [auto] keyword as their initial value (not the
-   generic [0]). Under minify [initial] rewrites to [auto] which is the shorter
-   shorter equivalent, and the typed value parses identically. *)
+   [min-block-size] have [auto] as their initial value (not the generic [0]), so
+   under minify [initial] rewrites to the shorter [auto]. *)
 let pp_length_min_max ctx (v : length_percentage) =
   let v : length_percentage =
     match v with Length Initial when Pp.minified ctx -> Length Auto | _ -> v

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -116,16 +116,12 @@ let utf8_byte_length cp =
   else if cp < 0x10000 then 3
   else 4
 
-(* Decode the UTF-8 code point starting at [t.pos + offset]. Returns [Some
-   (code_point, byte_length)] or [None] at EOF or on a malformed sequence. Uses
-   Uutf for the byte-level decode so overlong, surrogate, and out-of-range
-   sequences are rejected consistently with the Unicode spec.
-
-   Only returns [Some] when the *first* decoded element is a valid [Uchar].
-   [Uutf.String.fold_utf_8] resyncs after a [Malformed] start and yields the
-   next valid codepoint, which would let the caller pretend the malformed bytes
-   were part of the same code point - bad bytes in an ident-like context end up
-   in the unit token. *)
+(* Decode the UTF-8 code point at [t.pos + offset] to [Some (cp, byte_length)],
+   [None] at EOF or on a malformed sequence. Uutf rejects overlong/surrogate/
+   out-of-range sequences per the Unicode spec. Returns [Some] only when the
+   *first* decoded element is a valid [Uchar]: [fold_utf_8] resyncs past a
+   [Malformed] start, which would fold bad bytes into the following code point
+   (and into an ident-like unit token). *)
 (* ASCII fast path before falling back to Uutf: skips the ref/closure
    allocation that a [Uutf.String.fold_utf_8] requires per peek. *)
 let first_utf8_chunk_at input p len =

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -71,11 +71,10 @@ let single ~ctx (rule : rule) : rule =
   in
   with_declarations rule declarations
 
-(* CSS Multicol 2 sec. 6.1: [column-width] + [column-count] in the same rule
-   collapse to the [columns] shorthand. [columns] resets exactly those two
-   longhands, so the rewrite preserves every other property's cascade and needs
-   no closed-world assumption. Cascade models the longhands as unknown
-   properties, so their values are re-parsed from text here. *)
+(* CSS Multicol 2 sec. 6.1: [column-width] + [column-count] collapse to
+   [columns], which resets exactly those two longhands, so the rewrite is
+   cascade-safe with no closed-world assumption. The longhands are unknown
+   properties, so their values are re-parsed here. *)
 let columns_value_of_longhands width count : Properties.columns_value =
   match (width, count) with
   | `Auto, `Auto -> (Auto : Properties.columns_value)
@@ -83,10 +82,9 @@ let columns_value_of_longhands width count : Properties.columns_value =
   | `Width w, `Auto -> Width w
   | `Width w, `Count n -> Both (w, n)
 
-(* CSS Multicol 2 sec. 6.1: [column-width] + [column-count] collapse to the
-   [columns] shorthand, which resets exactly those two longhands. Compose the
-   unique pair of matching importance when both carry a plain (non-[var()],
-   non-CSS-wide) value, emitting the shorthand where the first appeared. *)
+(* Compose the unique [column-width]/[column-count] pair into [columns] when
+   both carry a plain (non-[var()], non-CSS-wide) matching-importance value, at
+   the position of the first. *)
 let synthesize_columns decls =
   let width_of d : (Properties.column_width * bool) option =
     match d with
@@ -139,10 +137,9 @@ let synthesize_columns decls =
       | _ -> decls)
   | _ -> decls
 
-(* CSS Anchor Positioning 1: [position-try] is [<'position-try-order'> ||
-   <'position-try-fallbacks'>]. [position-try-order: normal] is the initial
-   value and folds away. Cascade has no typed [position-try] shorthand, so the
-   synthesised value is re-parsed into the (round-tripping) unknown property. *)
+(* CSS Anchor Positioning 1: [position-try] is [<order> || <fallbacks>]. No
+   typed [position-try] shorthand exists, so the synthesised value is re-parsed
+   into the round-tripping unknown property. *)
 let synthesize_position_try decls =
   let order_of d : (Properties.position_try_order * bool) option =
     match d with
@@ -161,9 +158,8 @@ let synthesize_position_try decls =
   in
   match (uniq order_of, uniq fallbacks_of) with
   | Some (order, oi), Some (fallbacks, fi) when oi = fi -> (
-      (* Compose only plain component values; a CSS-wide keyword or [var()] in
-         one longhand cannot share a shorthand with a real value in the
-         other. *)
+      (* Compose only plain values: a CSS-wide keyword or [var()] in one
+         longhand cannot share a shorthand with a real value in the other. *)
       let plain_order : Properties.position_try_order -> bool = function
         | Normal | Most_width | Most_height | Most_block_size | Most_inline_size
           ->
@@ -202,8 +198,8 @@ let finalize ?(canonicalize_selector = true) ~ctx (rule : rule) : rule =
     |> sort_commuting ~selector:rule.selector
     |> preserve_list rule.declarations
   in
-  (* Selectors merged during factoring are fresh comma lists, so re-canonicalise
-     before emission; unchanged selectors keep their identity for the
+  (* Selectors merged during factoring are fresh comma lists, so
+     re-canonicalise; unchanged selectors keep their identity for the
      fixpoint. *)
   let rule =
     if canonicalize_selector then
@@ -240,21 +236,13 @@ let drop_shadowed_rules (rules : rule list) : rule list =
   in
   if !changed then filter 0 rules else rules
 
-(* Finer-grained sibling of [drop_shadowed_rules]: keep the rule but drop the
-   individual declarations whose property is rewritten by a later rule for every
-   selector this rule targets. The later same-selector write masks the earlier
-   value for every matching element regardless of intervening rules' specificity
-   or [!important] state (cleancss and csso both rely on this to collapse
-   repeated declaration blocks).
-
-   For list selectors ([.x, .y { width: 100px }]), the declaration is dead only
-   when EACH selector in the list is shadowed by some later rule whose selector
-   list contains that selector at same-or-stronger importance. We index later
-   rules per individual selector key so the per-selector check is linear in the
-   size of the list.
-
-   Empty rules left behind are pruned downstream by [drop_empty_rules] on the
-   statement-list pass. *)
+(* Finer-grained sibling of [drop_shadowed_rules]: keep the rule but drop
+   declarations whose property a later same-selector rule rewrites for every
+   selector this rule targets, at same-or-stronger importance (regardless of
+   intervening specificity; cleancss and csso rely on this). For a list selector
+   each selector must be independently shadowed, so later rules are indexed per
+   selector key to keep the check linear. Empty rules left behind are pruned by
+   [drop_empty_rules] downstream. *)
 let selector_keys (r : rule) =
   match Selector.as_list r.Stylesheet_intf.selector with
   | Some xs -> List.map canonical_selector_key xs
@@ -321,14 +309,12 @@ let drop_shadowed_declarations (rules : rule list) : rule list =
 let drop_shadowed rules =
   rules |> drop_shadowed_declarations |> drop_shadowed_rules
 
-(* Adjacent identical-body merging. Two neighbouring rules with the same
-   declarations apply those declarations identically whether split or grouped
-   under one selector list, so the merge is cascade-safe for any DOM with no
-   ordering analysis, and it shrinks raw and compressed output alike. It runs
-   with the always-on local rewrites: the global factoring engine also finds
-   these groups (plus non-adjacent ones), but only when its preflight predicts
-   enough total gain, and its result is discarded wholesale when the transfer
-   estimate grows - neither gamble should cost the obvious local merge. *)
+(* Adjacent identical-body merging: two neighbouring rules with the same
+   declarations apply identically whether split or grouped, so the merge is
+   cascade-safe for any DOM with no ordering analysis. It runs locally because
+   global factoring finds these groups only when its preflight predicts enough
+   gain and discards its result when the transfer estimate grows - neither
+   gamble should cost the obvious local merge. *)
 let adjacent_merge_eligible ~ctx (r : rule) =
   r.nested = [] && r.merge_key = None
   && (not (Merge.vendor r.selector))

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -445,14 +445,12 @@ let canonical_order t : node_id array =
 
 let canonical_linearization = canonical_order
 
-(* Replace the live nodes [consume] with the new nodes [produce]: a graph
-   transaction. Produced nodes inherit each consumed node's edge with an
-   external node they still conflict with, so the partial order is preserved;
-   produced nodes are mutually ordered by their position in [produce]. The
-   rewrite is rejected (returns [Option.None]) if a consumed node is already
-   dead/stale or if the resulting partial order has a cycle (the factoring would
-   not preserve the cascade). [generation] is bumped so candidates captured
-   against the old graph can be detected as stale. *)
+(* Replace live nodes [consume] with [produce] as one transaction. Produced
+   nodes inherit each consumed node's still-conflicting external edge (partial
+   order preserved) and are mutually ordered by their position in [produce].
+   Rejected ([Option.None]) if a consumed node is dead/stale or the result has a
+   cycle (the factoring would break the cascade). [generation] bumps so stale
+   captured candidates are detectable. *)
 let duplicate_node xs =
   let sorted = List.sort Int.compare xs in
   let rec loop = function
@@ -889,13 +887,11 @@ let rewrite_successors t ~consume ~consumed ~total graph :
       add_produced_edges t ~consume ~total ~produced_count graph succ
       |> Result.map (fun () -> succ)
 
-(* The graph is acyclic before a rewrite, and every edge a rewrite adds involves
-   a produced node (indices [total..node_count)), so any new cycle must pass
-   through one. A forward DFS from the produced nodes therefore detects a cycle
-   while only visiting their reachable cone, instead of the full [topo_order]
-   over every live node (O(reachable) per commit, not O(n)). State is shared
-   across the produced roots within one rewrite, so each node/edge is walked at
-   most once. *)
+(* The graph is acyclic before a rewrite and every new edge touches a produced
+   node ([total..node_count)), so any new cycle passes through one. A forward
+   DFS from the produced nodes detects it visiting only their reachable cone
+   (O(reachable) per commit, not the O(n) [topo_order]); shared state across the
+   produced roots walks each node/edge at most once. *)
 let rewrite_introduces_cycle graph ~total =
   let n = node_count graph in
   let state = Hashtbl.create 64 in

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -3,16 +3,14 @@
 
 open Stylesheet
 
-(* A run element is a plain style rule with no nested block, or a conditional
-   at-rule block ([@media] / [@supports] / [@container]) whose transitive
-   content is itself only such elements. The block moves atomically; its
-   contained rules supply the conflict footprint. Custom-property declarations
-   are reorderable too: the dependency graph keys each custom property by name,
-   so two writers of the same property on overlapping selectors keep their
-   order, while a [var()] reader - which writes its own property, not the one it
-   reads - moves freely past the definition. A named [@layer] block or [@layer]
-   declaration pins the layer order at its first occurrence, so it stays a
-   barrier, as does everything else. *)
+(* A run element is a plain style rule, or a conditional at-rule block
+   ([@media]/[@supports]/[@container]) whose transitive content is only such
+   elements; the block moves atomically and its rules supply the conflict
+   footprint. Custom properties are keyed by name in the dependency graph, so
+   two writers of one property on overlapping selectors keep order while a
+   [var()] reader (which writes its own property, not the one it reads) moves
+   freely. A named [@layer] block or declaration pins the layer order at its
+   first occurrence, so it stays a barrier. *)
 let rec element_rules (stmt : statement) : rule list option =
   match stmt with
   | Rule r -> if r.nested = [] then Some [ r ] else None
@@ -195,16 +193,14 @@ let shared_branches (stmts : statement list) : (string, unit) Hashtbl.t =
   Hashtbl.iter (fun k n -> if n > 1 then Hashtbl.replace shared k ()) counts;
   shared
 
-(* A grouped rule is semantically the sequence of its per-branch rules, and a
-   hoisted shared declaration is the same declaration written inline, so two
-   sheets that factor the same content differently ([.absolute,.sr-only
-   {position:absolute}] on one side, the declaration kept inline in [.sr-only]
-   on the other) only project to one canonical form if grouping is undone first.
-   Expand a selector-list rule into singleton-branch rules only when a branch is
-   shared with another rule, so a coalesce can actually fold it; a list whose
-   branches all occur once ([:host,:root], [*,::before,::after]) has nothing to
-   coalesce with, and splitting it only bloats the projection and desynchronises
-   the structural comparison of two otherwise-equivalent sheets. *)
+(* A grouped rule is the sequence of its per-branch rules, and a hoisted shared
+   declaration is the same declaration written inline, so two sheets that factor
+   the same content differently ([.absolute,.sr-only {position:absolute}] vs the
+   declaration inline in [.sr-only]) only converge once grouping is undone.
+   Expand a selector-list rule into singletons only when a branch is shared with
+   another rule, so a coalesce can fold it; a list whose branches each occur
+   once ([:host,:root]) has nothing to coalesce with, and splitting it only
+   bloats the projection. *)
 let expand_lists shared (stmt : statement) : statement list =
   match stmt with
   | Rule r when r.nested = [] && r.merge_key = None -> (

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -661,22 +661,12 @@ let read_attribute t =
       Attribute (ns, attr_name, matcher, flag))
     t
 
-(** Parse the An+B microsyntax per Selectors Level 4 section 9.2 / CSS Syntax
-    Level 3 section 6. The grammar is handled as a set of shape patterns against
-    the component stream:
-
-    - Keywords [odd] / [even].
-    - Bare [<integer>].
-    - [<n-dimension>] (e.g. [5n]) optionally followed by an offset.
-    - [<ndashdigit-dimension>] like [5n-5] (single token with unit [n-5]).
-    - [<ndash-dimension>] like [5n-] followed by a signless integer.
-    - Ident forms: [n], [-n], [n-5], [-n-5], [n-], [-n-] with same offset
-      handling.
-    - A leading [+] Delim (no whitespace before [n]) promoting the ident forms.
-
-    Case-insensitivity per CSS idents (section 3.3). Whitespace between a
-    leading [+] sign and the ident is invalid: the [+] is part of the ident form
-    lexically, so [+n] is valid but [+ n] is not. *)
+(** Parse the An+B microsyntax (Selectors 4 section 9.2 / CSS Syntax 3 section
+    6) as shape patterns over the component stream: [odd]/[even], bare
+    [<integer>], [<n-dimension>] with optional offset, the [5n-5]/[5n-] token
+    variants, and the [n]/[-n]/[n-5]/... ident forms with an optional leading
+    [+]. Idents are case-insensitive (section 3.3); [+ n] (whitespace after [+])
+    is invalid since [+] is lexically part of the ident form. *)
 
 (* Numeric helpers: split an arbitrary ident's tail into an optional [-digits]
    suffix, for ndashdigit / ndash / n patterns. *)
@@ -1555,13 +1545,11 @@ and read_compound t =
         || Cursor.peek_ident t <> None
   in
   let prepend_simple acc =
-    (* CSS Selectors 4 §3.5: at non-forgiving sites we still tolerate unknown
-       pseudo-classes for forward compatibility - vendor pseudos like
-       [::-webkit-scrollbar:horizontal] and authored future-pseudos must
-       round-trip through the parser. The non-forgiving rejection lives where
-       the spec actually requires it: inside [:not()] / [:has()] (see
-       [read_not_content] / [read_has_content]) and inside the rule reader when
-       an entire selector list is unknown. *)
+    (* CSS Selectors 4 §3.5: tolerate unknown pseudo-classes for forward compat
+       (vendor pseudos, authored future-pseudos must round-trip). Non-forgiving
+       rejection lives where the spec requires it: inside [:not()]/[:has()]
+       ([read_not_content]/[read_has_content]) and in the rule reader when a
+       whole selector list is unknown. *)
     let s = read_simple ~allow_unknown_pseudo_class:true t in
     if List.exists is_pseudo_element_selector acc && not (is_pe_action s) then
       Cursor.err t "pseudo-element must be last in compound selector"
@@ -1608,12 +1596,11 @@ and read_complex t =
         combine left Descendant (read_complex t)
       else left
 
-(* CSS Selectors 4 section 3.5: the top-level rule selector list (and any
-   non-forgiving alias of it) is an unforgiving site. [read_compound] keeps
-   [Unknown_pseudo_class] in the AST so authored vendor pseudos and
-   forward-compat selectors can round-trip, but a top-level selector that
-   carries one is a spec deviation; raise here so [Selector.of_string
-   ".ok,:future-pseudo"] surfaces a [Parse_error]. *)
+(* CSS Selectors 4 section 3.5: the top-level rule selector list is an
+   unforgiving site. [read_compound] keeps [Unknown_pseudo_class] so vendor and
+   forward-compat pseudos round-trip, but one at top level is a spec deviation;
+   raise so [Selector.of_string ".ok,:future-pseudo"] surfaces a
+   [Parse_error]. *)
 let validate_unforgiving_pseudo t sel =
   if has_unknown_pseudo_class sel then
     Cursor.err t "unknown pseudo-class in unforgiving selector list"
@@ -1662,12 +1649,10 @@ let read_relative t =
     Cursor.err t "unexpected characters after selector";
   match selectors with [ s ] -> s | _ -> List selectors
 
-(* CSS Nesting 1 sec. 2: inside a nested rule a selector is implicitly relative
-   to the parent [&], so an explicit leading [& <combinator>] is redundant. Drop
-   it: [& .bar] -> [.bar] (the bare nested form is itself [& .bar]); [& > .bar]
-   -> [> .bar] (the relative form keeps the combinator). Only the leading [&]
-   that is the whole left operand of a combinator is removed; [&.bar] (compound)
-   and a deeper [&] stay untouched. *)
+(* CSS Nesting 1 sec. 2: a nested selector is implicitly relative to [&], so a
+   leading [& <combinator>] is redundant: [& .bar] -> [.bar], [& > .bar] -> [>
+   .bar]. Only a leading [&] that is the whole left operand of a combinator is
+   removed; [&.bar] (compound) and a deeper [&] stay. *)
 let rec drop_redundant_nesting_prefix (sel : t) : t =
   match sel with
   | Combined (Nesting, Descendant, right) -> right
@@ -2325,15 +2310,12 @@ let canonicalize_unordered_list selectors =
   in
   List.sort (fun (k1, _) (k2, _) -> String.compare k1 k2) uniq |> List.map snd
 
-(* Rewrite a selector to its canonical representation so that selectors denoting
-   the same thing are structurally equal. Drops the implied [*] from a
-   multi-part compound ([*::before] -> [::before], [*.foo] -> [.foo]), collapses
-   a one-part compound to that part, and de-duplicates and sorts selector-list
-   alternatives by printed form - both the top-level [List] list and the
-   unordered-union pseudo-class lists ([:is], [:where], [:not], [:has], plus the
-   legacy [:-moz-any] / [:-webkit-any] aliases of [:is]). Per Selectors 4 the
-   matching of these lists is set-based, so their order has no effect on
-   matching or specificity. *)
+(* Canonicalise so selectors denoting the same thing are structurally equal:
+   drop the implied [*] from a multi-part compound ([*.foo] -> [.foo]), collapse
+   a one-part compound, and dedup/sort selector-list alternatives by printed
+   form (both [List] and the set-based [:is]/[:where]/[:not]/[:has] lists, incl.
+   the [:-moz-any]/[:-webkit-any] aliases, whose order Selectors 4 makes
+   irrelevant to matching and specificity). *)
 let canonicalize sel =
   map
     (fun node ->
@@ -2492,11 +2474,10 @@ let rec specificity = function
   | Relative (_, sel) -> specificity sel
   | List xs -> xs |> List.map specificity |> max_specificity
 
-(* Real [top_level_is_unwrap]: unwrap [:is(s1, s2, ...)] to a selector list only
-   when every argument has the same specificity AND is structurally simple. CSS
-   Selectors 4 sec. 17 makes [:is(...)] take the [max] specificity of its
-   arguments, so unwrapping changes per-element specificity unless all arguments
-   are already equal. *)
+(* Unwrap [:is(s1, s2, ...)] to a selector list only when every argument has the
+   same specificity AND is structurally simple. Selectors 4 sec. 17 gives [:is]
+   the [max] specificity of its arguments, so unwrapping changes specificity
+   unless all are already equal. *)
 let rec is_unwrap_safe_is_arg : t -> bool = function
   | Element _ | Class _ | Id _ | Universal _ | Attribute _ -> true
   | Compound parts -> List.for_all is_unwrap_safe_is_arg parts
@@ -2524,11 +2505,9 @@ let rec top_level_is_unwrap : t -> t = function
   | other -> other
 
 (* Public [pp] applies the top-level [:is()] unwrap under [minify] so every
-   caller (including direct [Selector.pp ctx sel] uses in the test harness) sees
-   the canonical form. The internal [pp] above still recurses through the
-   un-unwrapped tree because the unwrap is only sound at the entry point -
-   nested [Is] inside [Combinator] / [Compound] would change matching if
-   distributed. *)
+   caller sees the canonical form. The internal [pp] recurses through the
+   un-unwrapped tree because the unwrap is sound only at the entry point: a
+   nested [Is] inside [Combinator]/[Compound] would change matching. *)
 let pp_inner = pp
 
 let pp ctx sel =
@@ -2628,11 +2607,10 @@ let rec has_peer_marker = function
     peer-* variants. *)
 let has_is_where_pattern sel = has_group_marker sel || has_peer_marker sel
 
-(** Check if a pseudo-class is a "newer" one with limited browser support. These
-    should not be combined in selector lists with :is(:where()) variants because
-    if the browser doesn't support the pseudo-class, the entire rule would be
-    dropped — whereas the :is(:where()) variant would survive on its own due to
-    forgiving selector parsing. *)
+(** A "newer" pseudo-class with limited browser support: it must not be combined
+    in a selector list with an [:is(:where())] variant, since a browser that
+    lacks it drops the whole rule, whereas the forgiving variant would survive.
+*)
 let is_newer_pseudo_class = function
   | User_valid | User_invalid -> true
   | _ -> false

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -35,12 +35,11 @@ let is_intentionally_duplicated decl =
       | _ -> false)
   | Declaration { property; _ } -> is_intentionally_duplicated_typed property
 
-(* Typed shorthand -> longhand coverage relation. Each match arm spells out a
-   reachable [(shorthand, longhand)] pair, including transitive cases ([border]
-   covers [border-top-width] both directly and through [border-width] /
-   [border-top]). Properties not listed have no shorthand relation; they
-   self-cover by exact identity, never reset others. Custom and unknown
-   properties are handled by [declaration_covers] separately. *)
+(* Typed shorthand -> longhand coverage relation. Each arm is a reachable
+   [(shorthand, longhand)] pair, transitive cases included ([border] covers
+   [border-top-width] directly and via [border-width] / [border-top]). Unlisted
+   properties self-cover by identity, never reset others; custom and unknown
+   ones go through [declaration_covers]. *)
 let covers_longhand : type a b.
     a Properties.property -> b Properties.property -> bool =
  fun sh lh ->
@@ -572,14 +571,11 @@ let background_image_is_vendor : Properties.background_image -> bool = function
       true
   | _ -> false
 
-(* A value whose rendering begins with a CSS vendor prefix (-webkit-, -moz-,
-   -ms-, -o-). Only [display] keywords and [background-image] gradients render
-   that way, so a structural match on those value types is exhaustive - no
-   rendering needed. Used to preserve legacy fallbacks like
-   [display:-webkit-box;display:flex]: the spec value cascades over the prefixed
-   value in modern browsers, but old browsers only understand the prefixed
-   spelling, so dropping the earlier declaration removes a real browser-compat
-   fallback. *)
+(* A value whose rendering begins with a vendor prefix (-webkit-, -moz-, -ms-,
+   -o-). Only [display] keywords and [background-image] gradients render that
+   way, so a structural match is exhaustive. Preserves legacy fallbacks like
+   [display:-webkit-box;display:flex]: old browsers understand only the prefixed
+   spelling, so dropping the earlier declaration removes a real compat fallback. *)
 (* All the intrinsic sizing properties carry a [length_percentage] value. A GADT
    or-pattern does not refine the value type, so each constructor is matched on
    its own; everything else is not a sizing fallback. *)
@@ -842,12 +838,10 @@ let merge_overflow_longhands decls =
   in
   preserve_list decls (go [] decls)
 
-(* Compose 4 contiguous box-side longhands ([margin-top / -right / -bottom /
-   -left], or the [padding-] equivalents) into a single shorthand. Runs before
-   [merge_box_shorthand_longhands] so the absorption pass can pick up any
-   remaining stragglers. Conservative: requires all four sides present in the
-   next four positions (any order), matching importance, and no
-   runtime-substitution leaves on any side. *)
+(* Compose 4 contiguous box-side longhands ([margin-*] or [padding-*]) into one
+   shorthand. Runs before [merge_box_shorthand_longhands] so the absorption pass
+   picks up stragglers. Requires all four sides in the next four positions (any
+   order), matching importance, and no runtime-substitution leaves. *)
 type box_side = Top | Right | Bottom | Left
 
 let extract_margin_side :
@@ -1348,12 +1342,11 @@ let compose_outline_via_index idx =
         i := !i + 3
   done
 
-(* CSS Fonts 4 sec. 2.7: [font] shorthand reads [<style>? <weight>?
+(* CSS Fonts 4 sec. 2.7: [font] reads [<style>? <weight>?
    <size>[/<line-height>]? <family>+]. Cascade stores [font] as a string, so
-   composition renders each longhand via its pretty-printer and stitches the
-   shorthand together. Default-valued components ([normal] style, [400] weight,
-   [normal] line-height) drop on emit. Requires both font-size and
-   font-family. *)
+   composition renders each longhand and stitches them together; default-valued
+   components ([normal] style, [400] weight, [normal] line-height) drop on emit.
+   Requires font-size and font-family. *)
 let is_font_longhand : declaration -> bool = function
   | Declaration { property = Font_style; _ } -> true
   | Declaration { property = Font_weight; _ } -> true
@@ -1443,13 +1436,12 @@ let compose_font_via_index idx =
           i := !i + 5
   done
 
-(* The [font] shorthand resets the [font-variant-*] / [font-variation-settings]
-   / [font-feature-settings] / [font-size-adjust] / [font-kerning] /
+(* [font] resets the [font-variant-*] / [font-variation-settings] /
+   [font-feature-settings] / [font-size-adjust] / [font-kerning] /
    [font-optical-sizing] subproperties to their initials. When such a reset
-   declaration precedes a run of [font] longhands that [compose_font_shorthand]
-   will fold (the run carries the mandatory [font-size] and [font-family]), move
-   it after the run so the synthesised [font] does not clobber it - the same
-   pattern as [reorder_border_image_before_border]. *)
+   precedes a foldable run of [font] longhands, move it after the run so the
+   synthesised [font] does not clobber it (as
+   [reorder_border_image_before_border]). *)
 let reorder_font_resets_before_font decls =
   let prop d = property_name (snd d) in
   let is_font_reset d =
@@ -1887,14 +1879,12 @@ let try_compose_border_whole_at ~ctx idx i =
                     }))
         | _ -> None
 
-(* [border-image*] and [border-width/style/color] are independent properties, so
-   a border-image declaration (or longhand run) that immediately precedes the
-   whole-border longhands can move after them without changing any property's
-   cascade. Doing so lets [compose_border_whole_shorthand] synthesise [border]
-   in place: the synthesised [border] resets border-image, but the now-trailing
-   border-image declaration overrides that reset back. Only swap when the
-   following run carries the full width/style/color trio, so the move happens
-   exactly where it enables composition. *)
+(* [border-image*] and [border-width/style/color] are independent, so a
+   border-image declaration immediately preceding the whole-border longhands can
+   move after them without changing any cascade. That lets
+   [compose_border_whole_shorthand] synthesise [border] in place: its
+   border-image reset is overridden back by the now-trailing declaration. Only
+   swap when the following run carries the full width/style/color trio. *)
 let is_border_image_decl = function
   | Declaration { property = Border_image; _ }
   | Declaration { property = Border_image_source; _ }

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1606,12 +1606,11 @@ let read_keyframes_block inner =
   in
   read_frames []
 
-(* CSS Animations 1 §3: [@keyframes <keyframes-name> { ... }], where
-   [<keyframes-name> = <custom-ident> | <string>]. The reserved spellings
-   ([none], the CSS-wide keywords, and [default]) are excluded from
-   [<keyframes-name>] per the spec, but every mainstream minifier accepts them
-   in [<string>] form, so cascade keeps them in the AST too: rejecting would
-   leak unparsable input that tools downstream already preserve verbatim. *)
+(* CSS Animations 1 §3: [@keyframes <keyframes-name>], [<keyframes-name> =
+   <custom-ident> | <string>]. The reserved spellings ([none], CSS-wide
+   keywords, [default]) are excluded from [<custom-ident>], but every mainstream
+   minifier accepts them as [<string>], so cascade keeps them too rather than
+   leak input that downstream tools preserve verbatim. *)
 let read_keyframes_name r =
   Cursor.ws r;
   match Cursor.string_opt r with
@@ -2900,11 +2899,10 @@ let read_rule_selector ?(nested = false) r =
   in
   let c = Cursor.sub ?eof_loc r prelude in
   (* Re-raise the original [Parse_error] so its loc/kind/path/snippet reach the
-     caller intact. Previously we rewrapped via [Cursor.err r (Error.to_string
-     e)], which erased the structured error and relocated it to the parent
-     cursor's current position. CSS Nesting 1 sec. 2: a nested rule's prelude is
-     a [<relative-selector-list>], so it may start with a combinator ([> .bar])
-     which is implicitly relative to the parent [&]. *)
+     caller intact, rather than rewrapping (which erases the structured error
+     and relocates it). CSS Nesting 1 sec. 2: a nested rule's prelude is a
+     [<relative-selector-list>], so it may start with a combinator ([> .bar])
+     implicitly relative to the parent [&]. *)
   Cursor.with_context c "selector" (fun () ->
       if nested then Selector.read_relative c
       else Selector.read_strict_selector_list c)
@@ -3573,13 +3571,11 @@ let validate_partial_statement loc = function
            ~reason:"forbidden keyframes name")
   | _ -> None
 
-(* @page descriptors, @font-face descriptors, etc. flow through
-   [Declaration.read_declaration] just like ordinary rule declarations and show
-   up as [Unknown_property "marks"] / [Unknown_property "src"] in the AST. The
-   reader already enforces each at-rule's allowed-descriptor list, so an
-   [Unknown_property] arriving in a descriptor block is by construction a known
-   descriptor - skip the [is_invalid] check that would otherwise flag it as a
-   spec-noncompliant unknown property. *)
+(* @page / @font-face descriptors flow through [Declaration.read_declaration]
+   like ordinary declarations and show up as [Unknown_property "marks"] / "src".
+   The reader already enforces each at-rule's allowed-descriptor list, so an
+   [Unknown_property] in a descriptor block is by construction a known
+   descriptor - skip the [is_invalid] check that would flag it. *)
 let descriptor_has_typed_invalid_value = function
   | Declaration.Declaration { property = Properties.Unknown_property _; _ } ->
       false
@@ -3770,10 +3766,9 @@ let parse_stylesheet_partial ?(meta = Loc.default_meta_level) (source : string)
   let bangs = extract_bang_comments source in
   (* Compare a comment's offset against each rule's END, not its start: a rule's
      start absorbs an immediately-preceding comment ([/*!x*/a{}] starts at 0),
-     which would push a leading comment after its rule, but the closing-brace
-     end is unaffected by leading trivia. A leading comment always precedes its
-     rule's end; a comment between two rules precedes the later rule's end and
-     is emitted before it. *)
+     pushing a leading comment after its rule, but the closing-brace end is
+     unaffected by leading trivia, so leading and between-rule comments order
+     before their rule. *)
   let rule_ends = List.map (fun r -> (rule_loc r).Loc.end_pos) out.value in
   let rec interleave bangs rule_ends sheet =
     match (bangs, rule_ends, sheet) with

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -197,12 +197,11 @@ let read_color_keyword_of_string keyword : color option =
   (* CSS system colors - case-insensitive matching *)
   | _ -> read_system_color_of_string keyword
 
-(* Inside a custom-property body, colour keywords (the named colours,
-   [transparent], [currentcolor], [auto], [inherit]) are ASCII-case-insensitive
-   value idents whose canonical spelling is lower-case, like the CSS-wide
-   keywords [Parser.fold_value_ident] already folds. System colours stay
-   untouched because their canonical spelling is mixed-case; idents that name no
-   colour keyword pass through so a class-name token keeps its source case. *)
+(* Inside a custom-property body, colour keywords ([transparent], named colours,
+   ...) are ASCII-case-insensitive idents whose canonical spelling is
+   lower-case. System colours are left alone (canonical spelling is mixed-case);
+   non-colour idents pass through so a class-name token keeps its source
+   case. *)
 let fold_custom_value_ident s =
   let lower = String.lowercase_ascii s in
   if
@@ -820,17 +819,13 @@ let fold_zero_numeric_expr : type a.
       match value with Some 0. -> Some (Num 0.) | _ -> None)
   | _ -> None
 
-(* CSS Values 4 §10.7 value-independent calc identities. These hold for any
-   finite operand, so they fold even across a kept [var()]: inside [calc()] a
-   [var()] is single-valued, so [var * 1 = var] regardless of what the variable
-   resolves to. The identities that keep an operand ([x * 1], [1 * x], [x / 1],
-   [x + 0], [0 + x], [x - 0]) return that operand verbatim, so the result is
-   always the same type. The zero-producing cases need the type's canonical zero
-   ([Num 0.] for numbers, [Val Zero] for lengths): [~zero] supplies it.
-   [~is_zero] recognises a typed zero leaf ([0px], not just the unitless [0]) so
-   a literal zero length collapses [0px * x] too. Operands are the
-   already-evaluated subtrees; numeric [op] numeric must be folded by the caller
-   first. *)
+(* CSS Values 4 §10.7 value-independent calc identities: hold for any finite
+   operand, so they fold even across a kept [var()] (single-valued inside
+   [calc()], so [var * 1 = var]). Identity cases ([x * 1], [x / 1], [x + 0],
+   ...) return the operand verbatim; zero-producing cases take the type's
+   canonical zero from [~zero], and [~is_zero] recognises a typed zero leaf
+   ([0px], not just [0]) so [0px * x] collapses too. Operands are
+   already-evaluated; numeric op numeric is the caller's job. *)
 let calc_identity : type a.
     zero:a calc ->
     is_zero:(a -> bool) ->
@@ -861,12 +856,10 @@ let calc_identity : type a.
    ([calc_identity]). The per-type evaluators ([eval_length_calc] /
    [eval_lp_calc]) add the typed [Val] combinations ([1px + 2px], [2px * 3]) and
    pass their own [~zero] / [~is_zero] so a typed zero collapses too. *)
-(* Context threaded through the calc simplifier for rewrites that depend on the
-   surrounding stylesheet. [var_is_single_valued n] reports whether [--n] is
-   registered with a single-component [@property] syntax, so its [var()]
-   substitutes exactly one calc term and a redundant nested [calc(var(--n))]
-   grouping may be dropped. The default knows nothing, so every such rewrite is
-   a no-op. *)
+(* Context threaded through the calc simplifier. [var_is_single_valued n] reports
+   whether [--n] has a single-component [@property] syntax, so [calc(var(--n))]
+   substitutes one term and its redundant grouping may be dropped. The default
+   knows nothing, so every such rewrite is a no-op. *)
 type calc_ctx = { var_is_single_valued : string -> bool }
 
 let default_calc_ctx = { var_is_single_valued = (fun _ -> false) }
@@ -920,13 +913,10 @@ let rec eval_calc : type a. ?ctx:calc_ctx -> a calc -> a calc =
               | None -> Expr (l, op, r))))
 
 (* CSS Values 4 §10.7 typed [calc()] reduction, shared by every dimensioned
-   type. The [Expr] dispatch is identical across types; only the per-type leaf
-   operations differ, so they are passed in: [math_fn] reduces a static math
-   function to a typed leaf, [scale] multiplies or divides a [Val] by a unitless
-   number, [combine] adds or subtracts two [Val]s, and [zero] / [is_zero] drive
-   the additive and multiplicative identities. A type with no [scale] /
-   [combine] for a given operand shape returns [None] and the [calc()] is kept
-   verbatim. *)
+   type: the [Expr] dispatch is identical, only the per-type leaves differ and
+   are passed in ([math_fn], [scale], [combine], [zero] / [is_zero] for the
+   identities). A shape with no [scale] / [combine] returns [None] and the
+   [calc()] is kept verbatim. *)
 let rec eval_typed_calc : type a.
     math_fn:(math_fn -> a calc) ->
     scale:(exact:bool -> calc_op -> a -> float -> a option) ->
@@ -1233,13 +1223,11 @@ let length_combine op v1 v2 =
       | _ -> None)
   | _ -> None
 
-(* CSS Values 4 10.7: multiplying a typed length by a unitless number scales the
-   length, leaving the unit unchanged. Division folds only when the quotient is
-   [exact] (see [exact_div]); otherwise the caller keeps the [calc()] wrapper to
-   avoid precision loss. Dividing by a math constant ([pi] / [e] / ...) is an
-   exception: the divisor is irrational, so the quotient can never be exact and
-   keeping [calc()] preserves no more precision than the browser computes - fold
-   to the rounded value, matching multiplication by the same constant. *)
+(* CSS Values 4 §10.7: a unitless factor scales a typed length, unit unchanged.
+   Division folds only when [exact_div] is exact, else the [calc()] is kept to
+   avoid precision loss. Exception: an irrational divisor (a math constant [pi]
+   / [e] / ...) can never be exact, and keeping [calc()] preserves no more
+   precision than the browser computes, so fold to the rounded value. *)
 let length_scale ?(exact = true) op v n =
   if not (Float.is_finite n) then Option.none
   else
@@ -1550,13 +1538,11 @@ let ordered_linear_terms terms =
           Hashtbl.replace table unit
             { term with value = term.value +. n; count = term.count + 1 })
     terms;
-  (* CSS Values 4 sec. 10.10: a calc() expression's resulting type is the union
-     of its argument types. Dropping a zero-percentage term from [calc(100px +
-     0%)] would narrow [<length-percentage>] to [<length>] and break transitions
-     / animations interpolating against another [<length- percentage>], so [0%]
-     is kept as a type sentinel. Other zero-valued terms (e.g. [0px] when
-     another [px] term carries the value) are dropped because their unit is
-     already represented in the result. *)
+  (* CSS Values 4 §10.10: a calc()'s type is the union of its argument types.
+     Dropping [0%] from [calc(100px + 0%)] would narrow [<length-percentage>] to
+     [<length>] and break interpolation, so [0%] is kept as a type sentinel.
+     Other zero terms (e.g. [0px] beside another [px]) drop, their unit already
+     in the result. *)
   let keep_zero_term term =
     length_unit_is_pct term.unit
     && Hashtbl.fold
@@ -2221,11 +2207,10 @@ let pp_color_name : color_name Pp.t =
   | White_smoke -> Pp.string ctx "whitesmoke"
   | Yellow_green -> Pp.string ctx "yellowgreen"
 
-(* CSS Color 4 §6.4: every CSS named colour has a canonical sRGB byte triple.
-   The minify path routes [Named n] through this table to pick the shortest
-   spec-equivalent spelling (name vs [#hex]). Hex values are stored in their
-   shortest form ([shorten_hex] folds 6-char [rrggbb] into 3-char [rgb] when
-   each pair is identical), so [pp_color]'s back-conversion is a no-op. *)
+(* CSS Color 4 §6.4: every named colour has a canonical sRGB byte triple. Minify
+   routes [Named n] through this table for the shortest spelling (name vs
+   [#hex]). Hex is stored shortest ([shorten_hex] folds [rrggbb] to [rgb]), so
+   [pp_color]'s back-conversion is a no-op. *)
 
 (** Convert a named color to its hex equivalent (name, hex_value). Returns the
     shortest representation matching Lightning CSS behavior. *)
@@ -2859,14 +2844,12 @@ let lerp_byte b1 b2 w1 w2 =
   Float.to_int
     (Float.round ((Float.of_int b1 *. w1) +. (Float.of_int b2 *. w2)))
 
-(* Mix two static colours in sRGB per CSS Color 5 sec. 5. Returns [None] if
-   either operand can't be folded statically (e.g. contains [Var] / [Calc]) or
-   the percentages reduce to zero weight. CSS Color 4 sec. 4.2.3 [none]
-   sentinel: a channel that is [none] in one operand inherits the other
-   operand's analogous channel instead of being averaged in as a zero; if both
-   are [none] the mix result is also [none] for that channel (returned as zero
-   here because the caller routes the mixed bytes through [Hex] and [#000000] is
-   the shortest spelling for a fully-[none] mix). *)
+(* Mix two static colours in sRGB per CSS Color 5 §5. [None] if either operand
+   can't fold statically ([Var] / [Calc]) or the weights reduce to zero. CSS
+   Color 4 §4.2.3 [none] sentinel: a [none] channel inherits the other operand's
+   channel rather than averaging in a zero; both [none] yields [none] (returned
+   as zero, since the caller routes through [Hex] and [#000000] is the shortest
+   fully-[none] spelling). *)
 let mix_srgb_bytes c1 c2 ~p1 ~p2 =
   match
     (static_color_to_srgb_channels c1, static_color_to_srgb_channels c2)
@@ -3955,12 +3938,11 @@ let eval_angle_calc ?(ctx = default_calc_ctx) (c : angle calc) : angle calc =
    [rem] on [deg] operands), then pick the shortest of the
    losslessly-interconvertible spellings (deg / turn / grad). [rad] goes through
    pi, so it cannot share one magnitude and is left as-is. *)
-(* Shortest spelling of a concrete angle, restricted to unit conversions whose
-   printed form still denotes the same value. [deg -> turn] divides by 360, which
-   floors a small but non-zero angle to [0turn] once the printer caps the
-   mantissa, silently changing the value; comparing the printed forms back in
-   degrees rejects such value-changing rewrites. The original spelling is always
-   kept (the fold seed), and ties prefer deg. *)
+(* Shortest spelling of a concrete angle, via unit conversions whose printed form
+   still denotes the same value. [deg -> turn] can floor a small angle to [0turn]
+   once the printer caps the mantissa; comparing printed forms back in degrees
+   rejects such value changes. The original spelling seeds the fold; ties prefer
+   deg. *)
 let angle_shortest (a : angle) : angle =
   let render unit f =
     String.length
@@ -4046,11 +4028,10 @@ let rec pp_length_percentage ?(always = false) : length_percentage Pp.t =
         (if Pp.minified ctx then Parser.to_string_minified tokens
          else Parser.string_of_components tokens)
 
-(* Pure serialiser: the [Pct] <-> [Num] shortest-spelling choice (including [Pct
-   0. -> 0]) is a node-changing fold that lives in [normalize_number_per-
-   centage], not here. pp now serialises whichever node it is given faithfully.
-   The [~always] flag is retained for caller signature parity; with the swap
-   gone it has no effect on top-level emission. *)
+(* Pure serialiser: the [Pct] <-> [Num] shortest-spelling choice ([Pct 0. -> 0]
+   included) is a node-changing fold in [normalize_number_percentage], not here.
+   [~always] is kept for caller signature parity but has no effect on top-level
+   emission. *)
 let rec pp_number_percentage ?(always = false) : number_percentage Pp.t =
  fun ctx -> function
   | Num f -> Pp.float ctx f
@@ -4058,12 +4039,10 @@ let rec pp_number_percentage ?(always = false) : number_percentage Pp.t =
   | Var v -> pp_var (pp_number_percentage ~always) ctx v
   | Calc c -> pp_calc (pp_number_percentage ~always) ctx c
 
-(* AST-level [<number-percentage>] canonicalisation: at a typed leaf where
-   [<percentage>] and [<number>] are spec-equivalent (100% = 1), pick the
-   shorter spelling so [pp_number_percentage] serialises a canonical node
-   faithfully. [Var] and [Calc] sub-forms are left untouched - inside a calc(),
-   [%] and number are not interchangeable, and a [var()] reference is
-   context-free. *)
+(* AST-level [<number-percentage>] canonicalisation: at a typed leaf where [%] and
+   number are spec-equivalent (100% = 1), pick the shorter so
+   [pp_number_percentage] serialises a canonical node. [Var] / [Calc] are left
+   alone (inside calc() [%] and number aren't interchangeable). *)
 (* [<number-percentage>] shares [<percentage>]'s scaling/combining; the type is
    distinct, so the helpers are too. *)
 let np_scale ?(exact = true) op (np : number_percentage) n :
@@ -4323,12 +4302,11 @@ let string_of_scaled_color_axis ~pct_scale ctx f =
      shortest-spelling minify win, but [%] on these axes is an evergreen-target
      fact; [--enforce-spec] keeps the spec-canonical number serialisation. *)
   if ctx.Pp.minify && (not ctx.Pp.lossless) && not ctx.Pp.enforce_spec then
-    (* Derive the percentage form from the value the number string [n] actually
-       re-parses to, not from the raw float [f]. Otherwise an [f] that rounds to
-       [n] (e.g. -0.00798 -> "-.008") can keep the number because its raw
-       percentage is long ("-1.995%"), while the re-parsed -0.008 has a short
-       percentage ("-2%") and flips on the next pass - making the spelling
-       non-idempotent. *)
+    (* Derive the percentage form from what the number string [n] re-parses to,
+       not the raw float [f]: an [f] rounding to [n] ([-0.00798] -> "-.008")
+       could keep the number for a long raw percentage ("-1.995%") while the
+       re-parsed [-0.008] has a short one ("-2%"), flipping on the next pass
+       (non-idempotent). *)
     let n_value = try float_of_string n with Failure _ -> f in
     let pct = string_of_lab_float (n_value /. pct_scale) ^ "%" in
     if String.length pct < String.length n then pct else n

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -203,12 +203,10 @@ let apply_syntax_modifier r (Syntax inner) (modifier : char option) : any_syntax
         (String.concat ""
            [ "Unsupported CSS syntax modifier: '"; String.make 1 c; "'" ])
 
-(* CSS Properties and Values API 1 strictly allows one modifier per
-   syntax-component, but the [+#] chain is the natural shape for
-   font-family-like registrations (a comma-separated list of space-separated
-   ident sequences). Allow exactly that chain so [<custom-ident>+#] parses; keep
-   duplicate-same chains ([++], [##]) and the reverse order ([#+]) rejecting via
-   the unrecognised body. *)
+(* CSS Properties and Values API 1 allows one modifier per syntax-component, but
+   the [+#] chain is the natural shape for font-family-like registrations, so
+   allow exactly that ([<custom-ident>+#]); [++], [##] and the reverse [#+]
+   still reject via the unrecognised body. *)
 let split_syntax_modifiers s : string * char list =
   let n = String.length s in
   if n = 0 then (s, [])
@@ -2482,12 +2480,10 @@ let string_of_fallback inner =
     information which would need to be resolved from a variable registry or
     context. *)
 let read_reference (r : Cursor.t) : string * string option =
-  (* CSS Syntax 3 §4.3.6: EOF inside a function is a parse error. We tolerate it
-     only when the fallback list was opened with a comma — the trailing
-     [<string-token>] from §4.3.5 may have eaten the function's closing [)] — so
-     the declaration still carries a recoverable name + fallback pair. Without a
-     fallback there is no recovery signal and the malformed var() is
-     rejected. *)
+  (* CSS Syntax 3 §4.3.6: EOF inside a function is a parse error, tolerated only
+     when the fallback list opened with a comma (a §4.3.5 [<string-token>] may
+     have eaten the closing [)]) so a recoverable name + fallback survives.
+     Without a fallback there is no recovery signal, so it is rejected. *)
   let terminated =
     match Cursor.peek r with
     | Some (Component.Func fn) -> fn.node.terminated


### PR DESCRIPTION
This PR trims over-long code comments across `lib`. A comment earns its length by stating something the code cannot show, so this cuts the ones that restated the adjacent code, narrated a function step by step, or preserved superseded history, while keeping every spec citation and cascade-safety invariant (tightened, not dropped).
