### PR TITLE
transform: fold translateX(v) to translate(v)

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -7634,6 +7634,7 @@ let canonicalise_transform : transform -> transform = function
       Translate_z z
   | Translate (x, Some y) when Values.length_is_zero y -> Translate (x, None)
   | Translate (x, Some y) when Values.length_is_zero x -> Translate_y y
+  | Translate_x x -> Translate (x, None)
   | Scale (x, Some (Num 1.)) -> Scale_x x
   | Scale (Num 1., Some y) -> Scale_y y
   | Scale (x, Some y) when x = y -> Scale (x, None)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1700,6 +1700,13 @@ let spec_values_l45_edges () =
   decl_optimizes ~prop:"transform"
     ~into:"translate(10px,20%)rotate(90deg)scale(1.2)"
     "translate(10px, 20%) rotate(.25turn) scale(1.2)";
+  (* translateX(v) is translate(v, 0) = translate(v), one byte shorter; pp holds
+     the authored function, optimize folds it. translateY has no shorter
+     form. *)
+  decl_optimizes ~prop:"transform" ~held:"translateX(10px)"
+    ~into:"translate(10px)" "translateX(10px)";
+  decl_optimizes ~prop:"transform" ~held:"translateY(10px)"
+    ~into:"translateY(10px)" "translateY(10px)";
   decl_optimizes ~prop:"background-position" ~into:"10px 20%"
     "left 10px top 20%";
   decl_optimizes ~prop:"background-position" ~into:"50%" "center";


### PR DESCRIPTION
This PR folds `translateX(v)` to `translate(v)` under `--minify`. `translate(v)` means `translate(v, 0)`, identical to `translateX(v)` and one byte shorter, and both are 2D functions so there is no compositing change.