### PR TITLE
diff: ignore cascade-neutral declaration reorders

### DIFF
--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -145,7 +145,7 @@ let group_into_table rules =
 let diff_same_key_pair key d1 d2 =
   let sig1 = sig_of_decls d1 in
   let sig2 = sig_of_decls d2 in
-  if sig1 = sig2 && d1 <> d2 then
+  if sig1 = sig2 && d1 <> d2 && D.reorder_is_significant d1 d2 then
     Some
       (D.Reordered
          {

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -258,6 +258,36 @@ let pp_same_property_reorder buf indent prop_names1 prop_names2 =
        ^ "\n")
   | None -> pp_property_move_summary buf indent prop_names1 prop_names2
 
+(* A declaration reorder changes the cascade only when two overlapping
+   declarations swap relative order; disjoint declarations commute, so their
+   reorder is no difference (README contract). Duplicated property names are a
+   same-property override, reported conservatively. *)
+let reorder_is_significant decls1 decls2 =
+  let name = Css.declaration_name in
+  let names1 = List.map name decls1 in
+  let has_dup =
+    let s = List.sort String.compare names1 in
+    let rec go = function a :: (b :: _ as t) -> a = b || go t | _ -> false in
+    go s
+  in
+  has_dup
+  ||
+  let pos2 = Hashtbl.create 16 in
+  List.iteri (fun i d -> Hashtbl.replace pos2 (name d) i) decls2;
+  let pos d = Option.value ~default:(-1) (Hashtbl.find_opt pos2 (name d)) in
+  let arr = Array.of_list decls1 in
+  let n = Array.length arr in
+  let flipped = ref false in
+  for i = 0 to n - 1 do
+    for j = i + 1 to n - 1 do
+      if
+        Shorthand.declarations_overlap arr.(i) arr.(j)
+        && pos arr.(i) >= pos arr.(j)
+      then flipped := true
+    done
+  done;
+  !flipped
+
 let pp_reorder ?(style = default_style) ?(parent_prefix = "") decls1 decls2 buf
     =
   let indent =
@@ -270,8 +300,10 @@ let pp_reorder ?(style = default_style) ?(parent_prefix = "") decls1 decls2 buf
     && List.sort String.compare prop_names1
        = List.sort String.compare prop_names2
   in
-  if same_props && prop_names1 <> prop_names2 then
-    pp_same_property_reorder buf indent prop_names1 prop_names2
+  if
+    same_props && prop_names1 <> prop_names2
+    && reorder_is_significant decls1 decls2
+  then pp_same_property_reorder buf indent prop_names1 prop_names2
 
 let pp_content_changed ~style ~prefix ~child_prefix buf ~selector
     ~old_declarations ~new_declarations ~property_changes ~added_properties
@@ -1508,7 +1540,9 @@ let convert_modified_rule ~rules1 ~rules2 (sel1, sel2, decls1, decls2) =
           (* OCaml ASTs differ but string output is identical (e.g., Nested vs
              bare expression after calc() normalization) — no real difference *)
           None
-        else Some (decl_level_reorder sel1_str decls1 decls2)
+        else if reorder_is_significant decls1 decls2 then
+          Some (decl_level_reorder sel1_str decls1 decls2)
+        else (* cascade-neutral reorder of disjoint declarations *) None
       else if property_changes <> [] || added_props <> [] || removed_props <> []
       then Some (content_changed sel1_str decls1 decls2)
       else reorder_or_content sel1_str decls1 decls2

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -79,6 +79,12 @@ type t = { rules : rule_diff list; containers : container_diff list }
 val is_empty : t -> bool
 (** [is_empty d] returns [true] if [d] contains no differences. *)
 
+val reorder_is_significant :
+  Css.declaration list -> Css.declaration list -> bool
+(** [reorder_is_significant d1 d2] is [true] when reordering the declarations
+    changes the cascade, i.e. two overlapping declarations swap relative order.
+    A reorder of disjoint declarations is no difference. *)
+
 val diff : expected:Css.t -> actual:Css.t -> t
 (** [diff ~expected ~actual] computes structural differences between two CSS
     ASTs. *)

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -101,6 +101,25 @@ let diff_rule_reordered () =
   in
   Alcotest.(check bool) "has Reordered" true has_reordered
 
+let diff_neutral_decl_reorder_is_empty () =
+  (* Disjoint declarations commute, so reordering them is no difference. *)
+  let expected = parse ".a { color: red; background: blue }" in
+  let actual = parse ".a { background: blue; color: red }" in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check bool)
+    "neutral declaration reorder is empty" true
+    (Cascade_diff.Tree_diff.is_empty d)
+
+let diff_overlapping_decl_reorder_flagged () =
+  (* A shorthand and its longhand overlap, so their order decides the
+     cascade. *)
+  let expected = parse ".a { margin: 1px; margin-top: 2px }" in
+  let actual = parse ".a { margin-top: 2px; margin: 1px }" in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check bool)
+    "overlapping declaration reorder is not empty" false
+    (Cascade_diff.Tree_diff.is_empty d)
+
 (* ===== Container (media) changes ===== *)
 
 let diff_media_added () =
@@ -363,6 +382,10 @@ let suite =
       Alcotest.test_case "property added to rule" `Quick
         diff_rule_added_property;
       Alcotest.test_case "rule reordered" `Quick diff_rule_reordered;
+      Alcotest.test_case "neutral declaration reorder is empty" `Quick
+        diff_neutral_decl_reorder_is_empty;
+      Alcotest.test_case "overlapping declaration reorder flagged" `Quick
+        diff_overlapping_decl_reorder_flagged;
       Alcotest.test_case "media added" `Quick diff_media_added;
       Alcotest.test_case "media removed" `Quick diff_media_removed;
       Alcotest.test_case "layer added" `Quick diff_layer_added;


### PR DESCRIPTION
`cascade diff` reported cascade-neutral declaration reorders (disjoint properties swapped) as differences, burying real value changes in ordering noise. It now ignores them, so a structural diff surfaces only what changes the cascade; overlapping declarations like a shorthand and its longhand still flag.