### PR TITLE
optimize: drop a redundant flex-grow/shrink after flex

### DIFF
--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3365,6 +3365,26 @@ let implied_longhand covering covered : Declaration.declaration option =
                    (Option.value s.attachment ~default:Properties.Scroll))
           | _ -> None)
       | _ -> None)
+  | Declaration { property = Properties.Flex; value; _ } -> (
+      (* [flex] always sets grow/shrink/basis; expand the keyword and numeric
+         forms. flex-basis (the [0%] default) is left for a follow-up. *)
+      let grow_shrink =
+        match (value : Properties.flex) with
+        | Initial -> Some (0., 1.)
+        | Auto -> Some (1., 1.)
+        | None -> Some (0., 0.)
+        | Grow (Number g) -> Some (g, 1.)
+        | Basis _ -> Some (1., 1.)
+        | Grow_shrink (Number g, Number s) -> Some (g, s)
+        | Full (Number g, Number s, _) -> Some (g, s)
+        | _ -> Option.none
+      in
+      match (unwrap_theme_guard covered, grow_shrink) with
+      | Declaration { property = Properties.Flex_grow; _ }, Some (g, _) ->
+          Some (flex_grow g)
+      | Declaration { property = Properties.Flex_shrink; _ }, Some (_, s) ->
+          Some (flex_shrink s)
+      | _ -> None)
   | _ -> None
 
 (* CSS Cascade: a shorthand sets every longhand it covers (to its slot value or

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -80,6 +80,17 @@ let test_drop_redundant_longhand_after_shorthand () =
   decl_optimizes_to ~into:"background:red;background-size:auto!important"
     "background:red;background-size:auto!important"
 
+let test_drop_redundant_flex_longhand () =
+  (* [flex] expands to grow/shrink/basis: a later grow/shrink equal to what it
+     set is dropped. flex:1 is [1 1 0], auto is [1 1 auto], none is [0 0
+     auto]. *)
+  decl_optimizes_to ~into:"flex:1" "flex:1;flex-grow:1";
+  decl_optimizes_to ~into:"flex:auto" "flex:auto;flex-grow:1";
+  decl_optimizes_to ~into:"flex:none" "flex:none;flex-shrink:0";
+  decl_optimizes_to ~into:"flex:2 3" "flex:2 3;flex-grow:2";
+  (* A differing factor is kept. *)
+  decl_optimizes_to ~into:"flex:1;flex-grow:2" "flex:1;flex-grow:2"
+
 let test_compose_shorthands_and_runtime_guard () =
   let ctx = Ctx.fragment in
   let composed =
@@ -183,6 +194,8 @@ let suite =
         test_merge_overflow_longhands;
       Alcotest.test_case "drop redundant longhand after shorthand" `Quick
         test_drop_redundant_longhand_after_shorthand;
+      Alcotest.test_case "drop redundant flex longhand" `Quick
+        test_drop_redundant_flex_longhand;
       Alcotest.test_case "compose shorthands and runtime guard" `Quick
         test_compose_shorthands_and_runtime_guard;
       Alcotest.test_case "stylesheet scope prior longhand guard" `Quick


### PR DESCRIPTION
Extends the shorthand-implies-longhand drop (#176) to `flex`: its keyword and numeric forms expand to grow/shrink, so a later `flex-grow`/`flex-shrink` equal to what `flex` set is dropped, and a differing factor is kept. `flex-basis` stacks in a follow-up. Stacked on #176.