### PR TITLE
optimize: drop a redundant transition longhand after transition

### DIFF
--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3385,6 +3385,29 @@ let implied_longhand covering covered : Declaration.declaration option =
       | Declaration { property = Properties.Flex_shrink; _ }, Some (_, s) ->
           Some (flex_shrink s)
       | _ -> None)
+  | Declaration { property = Properties.Transition; value; _ } -> (
+      (* Single transition only; a comma list assigns per-item values. *)
+      match (value : Properties.transition list) with
+      | [ Properties.Shorthand s ] -> (
+          match unwrap_theme_guard covered with
+          | Declaration { property = Properties.Transition_duration; _ } ->
+              Some
+                (transition_duration
+                   (Option.value s.duration ~default:(Values.S 0.)))
+          | Declaration { property = Properties.Transition_delay; _ } ->
+              Some
+                (transition_delay (Option.value s.delay ~default:(Values.S 0.)))
+          | Declaration { property = Properties.Transition_timing_function; _ }
+            ->
+              Some
+                (transition_timing_function
+                   (Option.value s.timing_function ~default:Properties.Ease))
+          | Declaration { property = Properties.Transition_behavior; _ } ->
+              Some
+                (transition_behavior
+                   (Option.value s.behavior ~default:Properties.Normal))
+          | _ -> None)
+      | _ -> None)
   | _ -> None
 
 (* CSS Cascade: a shorthand sets every longhand it covers (to its slot value or

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -91,6 +91,19 @@ let test_drop_redundant_flex_longhand () =
   (* A differing factor is kept. *)
   decl_optimizes_to ~into:"flex:1;flex-grow:2" "flex:1;flex-grow:2"
 
+let test_drop_redundant_transition_longhand () =
+  (* [transition] sets duration/timing/delay/behavior; a later longhand equal to
+     its slot (else the initial 0s/ease/normal) is dropped. *)
+  decl_optimizes_to ~into:"transition:all 1s"
+    "transition:all 1s;transition-delay:0s";
+  decl_optimizes_to ~into:"transition:all 1s"
+    "transition:all 1s;transition-timing-function:ease";
+  decl_optimizes_to ~into:"transition:all 1s 2s"
+    "transition:all 1s 2s;transition-delay:2s";
+  (* A differing value is kept. *)
+  decl_optimizes_to ~into:"transition:all 1s;transition-delay:1s"
+    "transition:all 1s;transition-delay:1s"
+
 let test_compose_shorthands_and_runtime_guard () =
   let ctx = Ctx.fragment in
   let composed =
@@ -196,6 +209,8 @@ let suite =
         test_drop_redundant_longhand_after_shorthand;
       Alcotest.test_case "drop redundant flex longhand" `Quick
         test_drop_redundant_flex_longhand;
+      Alcotest.test_case "drop redundant transition longhand" `Quick
+        test_drop_redundant_transition_longhand;
       Alcotest.test_case "compose shorthands and runtime guard" `Quick
         test_compose_shorthands_and_runtime_guard;
       Alcotest.test_case "stylesheet scope prior longhand guard" `Quick


### PR DESCRIPTION
Extends the drop (#177) to a single `transition`: a later `transition-duration`/`-delay`/`-timing-function`/`-behavior` equal to its slot value, else the initial (`0s`/`ease`/`normal`), is dropped. Multi-transition lists stay conservative. Stacked on #177.