### PR TITLE
optimize: drop a redundant border longhand after border

### DIFF
--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3408,6 +3408,20 @@ let implied_longhand covering covered : Declaration.declaration option =
                    (Option.value s.behavior ~default:Properties.Normal))
           | _ -> None)
       | _ -> None)
+  | Declaration { property = Properties.Border; value; _ } -> (
+      (* Only the slots [border] sets explicitly; its initials (medium / none /
+         currentcolor) are rarely written back, so leave those. *)
+      match (value : Properties.border) with
+      | Properties.Shorthand s -> (
+          match unwrap_theme_guard covered with
+          | Declaration { property = Properties.Border_color; _ } ->
+              Option.map border_color s.color
+          | Declaration { property = Properties.Border_width; _ } ->
+              Option.map border_width s.width
+          | Declaration { property = Properties.Border_style; _ } ->
+              Option.map border_style s.style
+          | _ -> None)
+      | _ -> None)
   | _ -> None
 
 (* CSS Cascade: a shorthand sets every longhand it covers (to its slot value or

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -104,6 +104,20 @@ let test_drop_redundant_transition_longhand () =
   decl_optimizes_to ~into:"transition:all 1s;transition-delay:1s"
     "transition:all 1s;transition-delay:1s"
 
+let test_drop_redundant_border_longhand () =
+  (* [border] sets width/style/color; a later longhand equal to an explicit slot
+     is dropped. A differing value or a per-side list is kept. *)
+  decl_optimizes_to ~into:"border:1px solid red"
+    "border:1px solid red;border-color:red";
+  decl_optimizes_to ~into:"border:1px solid red"
+    "border:1px solid red;border-width:1px";
+  decl_optimizes_to ~into:"border:1px solid red"
+    "border:1px solid red;border-style:solid";
+  decl_optimizes_to ~into:"border:1px solid red;border-color:#00f"
+    "border:1px solid red;border-color:blue";
+  decl_optimizes_to ~into:"border:1px solid red;border-color:red green"
+    "border:1px solid red;border-color:red green"
+
 let test_compose_shorthands_and_runtime_guard () =
   let ctx = Ctx.fragment in
   let composed =
@@ -211,6 +225,8 @@ let suite =
         test_drop_redundant_flex_longhand;
       Alcotest.test_case "drop redundant transition longhand" `Quick
         test_drop_redundant_transition_longhand;
+      Alcotest.test_case "drop redundant border longhand" `Quick
+        test_drop_redundant_border_longhand;
       Alcotest.test_case "compose shorthands and runtime guard" `Quick
         test_compose_shorthands_and_runtime_guard;
       Alcotest.test_case "stylesheet scope prior longhand guard" `Quick


### PR DESCRIPTION
Extends the drop (#178) to `border`: a later `border-width`/`-style`/`-color` equal to the slot `border` set explicitly is dropped. Only explicit slots, so a differing value or a per-side list (`border-color:red green`) is kept. Stacked on #178.