### PR TITLE
optimize: drop a redundant font longhand after font

### DIFF
--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3422,6 +3422,22 @@ let implied_longhand covering covered : Declaration.declaration option =
               Option.map border_style s.style
           | _ -> None)
       | _ -> None)
+  | Declaration { property = Properties.Font; value; _ } -> (
+      (* [font] resets style/weight/stretch/line-height to [normal] unless set;
+         font-variant uses a narrower type in the shorthand, so leave it. *)
+      match (value : Properties.font) with
+      | Properties.Shorthand s -> (
+          match unwrap_theme_guard covered with
+          | Declaration { property = Properties.Font_style; _ } ->
+              Some (font_style (Option.value s.style ~default:Normal))
+          | Declaration { property = Properties.Font_weight; _ } ->
+              Some (font_weight (Option.value s.weight ~default:Normal))
+          | Declaration { property = Properties.Font_stretch; _ } ->
+              Some (font_stretch (Option.value s.stretch ~default:Normal))
+          | Declaration { property = Properties.Line_height; _ } ->
+              Some (line_height (Option.value s.line_height ~default:Normal))
+          | _ -> None)
+      | _ -> None)
   | _ -> None
 
 (* CSS Cascade: a shorthand sets every longhand it covers (to its slot value or

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -118,6 +118,20 @@ let test_drop_redundant_border_longhand () =
   decl_optimizes_to ~into:"border:1px solid red;border-color:red green"
     "border:1px solid red;border-color:red green"
 
+let test_drop_redundant_font_longhand () =
+  (* [font] resets style/weight/stretch/line-height to normal; a later longhand
+     equal to that (weight normal folds to 400) is dropped. *)
+  decl_optimizes_to ~into:"font:16px sans-serif"
+    "font:16px sans-serif;font-weight:400";
+  decl_optimizes_to ~into:"font:16px sans-serif"
+    "font:16px sans-serif;font-weight:normal";
+  decl_optimizes_to ~into:"font:16px sans-serif"
+    "font:16px sans-serif;font-style:normal";
+  decl_optimizes_to ~into:"font:700 16px x" "font:bold 16px x;font-weight:bold";
+  (* A differing value is kept. *)
+  decl_optimizes_to ~into:"font:16px sans-serif;font-weight:700"
+    "font:16px sans-serif;font-weight:700"
+
 let test_compose_shorthands_and_runtime_guard () =
   let ctx = Ctx.fragment in
   let composed =
@@ -227,6 +241,8 @@ let suite =
         test_drop_redundant_transition_longhand;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
+      Alcotest.test_case "drop redundant font longhand" `Quick
+        test_drop_redundant_font_longhand;
       Alcotest.test_case "compose shorthands and runtime guard" `Quick
         test_compose_shorthands_and_runtime_guard;
       Alcotest.test_case "stylesheet scope prior longhand guard" `Quick


### PR DESCRIPTION
Extends the drop (#179) to `font`: a later `font-style`/`-weight`/`-stretch`/`line-height` equal to what `font` set (its slot, else the `normal` initial; `normal` folds to `400` for weight) is dropped. `font-variant` uses a narrower type in the shorthand and is left. Stacked on #179.