### PR TITLE
properties: type -webkit-/-moz-box-sizing

### DIFF
--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1140,6 +1140,8 @@ let read_shadow_content_value : type a.
   | Nav_down -> Some (v Nav_down (read_nav t))
   | Nav_left -> Some (v Nav_left (read_nav t))
   | Box_sizing -> Some (v Box_sizing (read_box_sizing t))
+  | Webkit_box_sizing -> Some (v Webkit_box_sizing (read_box_sizing t))
+  | Moz_box_sizing -> Some (v Moz_box_sizing (read_box_sizing t))
   | Field_sizing -> Some (v Field_sizing (read_field_sizing t))
   | Caption_side -> Some (v Caption_side (read_caption_side t))
   | _ -> None

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -7414,6 +7414,8 @@ let pp_property : type a. a property Pp.t =
   | Scroll_snap_stop -> Pp.string ctx "scroll-snap-stop"
   | Scroll_behavior -> Pp.string ctx "scroll-behavior"
   | Box_sizing -> Pp.string ctx "box-sizing"
+  | Webkit_box_sizing -> Pp.string ctx "-webkit-box-sizing"
+  | Moz_box_sizing -> Pp.string ctx "-moz-box-sizing"
   | Field_sizing -> Pp.string ctx "field-sizing"
   | Caption_side -> Pp.string ctx "caption-side"
   | Resize -> Pp.string ctx "resize"
@@ -19222,6 +19224,8 @@ let read_any_property t =
   | "-webkit-align-content" -> Prop Webkit_align_content
   | "-webkit-align-self" -> Prop Webkit_align_self
   | "-webkit-border-radius" -> Prop Webkit_border_radius
+  | "-webkit-box-sizing" -> Prop Webkit_box_sizing
+  | "-moz-box-sizing" -> Prop Moz_box_sizing
   | "-webkit-box-shadow" -> Prop Webkit_box_shadow
   | "-webkit-background-size" -> Prop Webkit_background_size
   | "-webkit-filter" -> Prop Webkit_filter
@@ -21402,6 +21406,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Scroll_snap_stop -> pp pp_scroll_snap_stop
   | Scroll_behavior -> pp pp_scroll_behavior
   | Box_sizing -> pp pp_box_sizing
+  | Webkit_box_sizing -> pp pp_box_sizing
+  | Moz_box_sizing -> pp pp_box_sizing
   | Field_sizing -> pp pp_field_sizing
   | Caption_side -> pp pp_caption_side
   | Resize -> pp pp_resize

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4567,6 +4567,8 @@ type 'a property =
   | Webkit_align_content : align_content property
   | Webkit_align_self : align_self property
   | Webkit_border_radius : border_radius property
+  | Webkit_box_sizing : box_sizing property
+  | Moz_box_sizing : box_sizing property
   | Webkit_box_shadow : shadow property
   | Webkit_background_size : background_size property
   | Webkit_filter : filter property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2078,6 +2078,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Border_left, value -> vars_of_border value
   | Border_collapse, value -> vars_of_border_collapse value
   | Box_sizing, value -> vars_of_box_sizing value
+  | Webkit_box_sizing, value -> vars_of_box_sizing value
+  | Moz_box_sizing, value -> vars_of_box_sizing value
   | Box_decoration_break, value -> vars_of_box_decoration_break value
   | Break_after, value -> vars_of_break_value value
   | Break_before, value -> vars_of_break_value value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -843,6 +843,12 @@ let misc () =
   (* Box sizing *)
   check_declaration ~expected:"box-sizing:content-box" "box-sizing: content-box";
   check_declaration ~expected:"box-sizing:border-box" "box-sizing: border-box";
+  (* Vendor-prefixed box-sizing is typed, so it round-trips and canonicalises
+     its value (an [Unknown_property] would keep [BORDER-BOX] verbatim). *)
+  check_declaration ~expected:"-webkit-box-sizing:border-box"
+    "-webkit-box-sizing: border-box";
+  check_declaration ~expected:"-moz-box-sizing:border-box"
+    "-moz-box-sizing: BORDER-BOX";
 
   (* User select *)
   check_declaration ~expected:"user-select:none" "user-select: none";


### PR DESCRIPTION
`-webkit-box-sizing` and `-moz-box-sizing` parsed as `Unknown_property`; this types them like the other 70 vendor properties (reusing the `box_sizing` value), so their value canonicalises (`BORDER-BOX` to `border-box`) and an invalid value is rejected. Output is otherwise unchanged: the prefix is kept, which is correct for a no-baseline default. Groundwork for a future opt-in `--targets` strip.