### PR TITLE
properties: type -ms-user-select and -webkit-text-fill-color

### DIFF
--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1569,6 +1569,8 @@ let read_interaction_value : type a.
   match prop with
   | User_select -> Some (v User_select (read_user_select t))
   | Webkit_user_select -> Some (v Webkit_user_select (read_user_select t))
+  | Ms_user_select -> Some (v Ms_user_select (read_user_select t))
+  | Webkit_text_fill_color -> Some (v Webkit_text_fill_color (read_color t))
   | Moz_user_select -> Some (v Moz_user_select (read_user_select t))
   | Pointer_events -> Some (v Pointer_events (read_pointer_events t))
   | Resize -> Some (v Resize (read_resize t))

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -7211,7 +7211,9 @@ let pp_property : type a. a property Pp.t =
   | Font_feature_settings -> Pp.string ctx "font-feature-settings"
   | Font_variation_settings -> Pp.string ctx "font-variation-settings"
   | Webkit_tap_highlight_color -> Pp.string ctx "-webkit-tap-highlight-color"
+  | Webkit_text_fill_color -> Pp.string ctx "-webkit-text-fill-color"
   | Webkit_user_select -> Pp.string ctx "-webkit-user-select"
+  | Ms_user_select -> Pp.string ctx "-ms-user-select"
   | Moz_user_select -> Pp.string ctx "-moz-user-select"
   | Webkit_text_decoration -> Pp.string ctx "-webkit-text-decoration"
   | Webkit_text_decoration_color ->
@@ -19253,7 +19255,9 @@ let read_any_property t =
   | "-moz-box-shadow" -> Prop Moz_box_shadow
   | "-webkit-text-size-adjust" -> Prop Webkit_text_size_adjust
   | "-webkit-tap-highlight-color" -> Prop Webkit_tap_highlight_color
+  | "-webkit-text-fill-color" -> Prop Webkit_text_fill_color
   | "-webkit-user-select" -> Prop Webkit_user_select
+  | "-ms-user-select" -> Prop Ms_user_select
   | "-moz-user-select" -> Prop Moz_user_select
   | "-webkit-text-decoration" -> Prop Webkit_text_decoration
   | "-webkit-text-decoration-color" -> Prop Webkit_text_decoration_color
@@ -21380,6 +21384,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Text_decoration_color -> pp pp_color
   | Webkit_text_decoration_color -> pp pp_color
   | Webkit_tap_highlight_color -> pp pp_color
+  | Webkit_text_fill_color -> pp pp_color
   | Text_indent -> pp pp_text_indent_value
   | Border_spacing -> pp pp_border_spacing
   | Outline_offset -> pp pp_length
@@ -21761,6 +21766,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Pointer_events -> pp pp_pointer_events
   | User_select -> pp pp_user_select
   | Webkit_user_select -> pp pp_user_select
+  | Ms_user_select -> pp pp_user_select
   | Moz_user_select -> pp pp_user_select
   | Font_feature_settings -> pp pp_font_feature_settings
   | Font_variation_settings -> pp pp_font_variation_settings

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4537,8 +4537,10 @@ type 'a property =
   | Webkit_tap_highlight_color : color property
   | Webkit_user_select : user_select property
   | Moz_user_select : user_select property
+  | Ms_user_select : user_select property
   | Webkit_text_decoration : text_decoration property
   | Webkit_text_decoration_color : color property
+  | Webkit_text_fill_color : color property
   | Text_indent : text_indent_value property
   | List_style : list_style property
   | Font : font property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2266,6 +2266,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Webkit_mask_source_type, value -> vars_of_mask_source_type value
   | Webkit_text_size_adjust, value -> vars_of_text_size_adjust value
   | Webkit_user_select, value -> vars_of_user_select value
+  | Ms_user_select, value -> vars_of_user_select value
+  | Webkit_text_fill_color, value -> vars_of_color value
   | Moz_user_select, value -> vars_of_user_select value
   | White_space, value -> vars_of_white_space value
   | Word_break, value -> vars_of_word_break value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -853,6 +853,9 @@ let misc () =
   check_declaration ~expected:"-moz-transform:none" "-moz-transform: NONE";
   check_declaration ~expected:"-o-transform:rotate(45deg)"
     "-o-transform: rotate(45deg)";
+  check_declaration ~expected:"-ms-user-select:none" "-ms-user-select: NONE";
+  check_declaration ~expected:"-webkit-text-fill-color:#fff"
+    "-webkit-text-fill-color: #ffffff";
 
   (* User select *)
   check_declaration ~expected:"user-select:none" "user-select: none";


### PR DESCRIPTION
Types `-ms-user-select` and `-webkit-text-fill-color` (both parsed as `Unknown_property`) by reusing the `user_select` and `color` values, so values canonicalise. Kept by default. Stacked on #182.