### PR TITLE
optimize: strip redundant vendor prefixes by default, keep under --enforce-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ cat style.css | cascade -                                          # read stdin
 | `-m, --minify` | Minify the output. Local linear rewrites always run; the expensive global factoring fixpoint runs only when its preflight predicts useful savings. The top-level pipeline re-runs until the AST stops changing (capped at 5 iterations), so the output is a fixed point: rule-order canonicalisation can expose a merge a single pass would miss. |
 | `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win and drives the factoring fixpoint to convergence, the right objective when the output ships uncompressed (inline style attributes, email HTML), at roughly 10-30x the wall clock. Has no effect without `--minify`. |
 | `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Has no effect without `--minify`. |
-| `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest CSS form it knows, but it keeps every `@supports` and `supports()` guard unless the CSS text and spec alone prove the rewrite. Has no effect without `--minify`. |
+| `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest CSS form it knows, but it keeps every `@supports` and `supports()` guard, and every vendor-prefixed declaration, unless the CSS text and spec alone prove the rewrite. Has no effect without `--minify`. |
 | `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
 | `--flatten-nesting` | Desugar nested rules into flat top-level rules for browsers that pre-date CSS Nesting. By default cascade preserves nesting since modern browsers parse it natively and it is usually shorter. |
 | `--inline-imports` | Resolve `@import` against files relative to the input. Closed-world: assumes you control file resolution. |
@@ -281,12 +281,14 @@ write the optimiser can't see.
 
 The default minify targets maintained evergreen browsers. Cascade may treat
 baseline feature queries like `@supports(display:flex)` as true and remove the
-wrapper, and may use the HTML direction model to shorten `:not(:dir(ltr))` to
-`:dir(rtl)`.
+wrapper, may use the HTML direction model to shorten `:not(:dir(ltr))` to
+`:dir(rtl)`, and may drop a vendor-prefixed declaration (`-moz-box-sizing`)
+whose unprefixed twin is present, since evergreen browsers understand the
+unprefixed form.
 
 `--enforce-spec` drops those facts. Cascade still serialises to the shortest
-CSS form it knows, but feature queries stay and the direction model is not
-assumed.
+CSS form it knows, but feature queries stay, the direction model is not
+assumed, and every vendor prefix is kept.
 
 ## CSS specification coverage
 

--- a/lib/ctx.ml
+++ b/lib/ctx.ml
@@ -9,6 +9,11 @@ type t = {
   extend_lists : bool;
   closed_world : bool;
   objective : objective;
+  enforce_spec : bool;
+      (** Drop the evergreen-browser target. Off by default: cascade may strip a
+          vendor-prefixed declaration whose unprefixed twin modern browsers
+          support. On: keep every prefix (spec-literal, maximal compatibility).
+      *)
 }
 
 let fragment =
@@ -20,10 +25,12 @@ let fragment =
     extend_lists = false;
     closed_world = false;
     objective = `Transfer;
+    enforce_spec = false;
   }
 
 let of_scope ?(lossless = false) ?(aggressive = false) ?(extend_lists = false)
-    ?(closed_world = false) ?(objective = `Transfer) = function
+    ?(closed_world = false) ?(objective = `Transfer) ?(enforce_spec = false) =
+  function
   | Some scope ->
       {
         fragment with
@@ -33,6 +40,7 @@ let of_scope ?(lossless = false) ?(aggressive = false) ?(extend_lists = false)
         extend_lists;
         closed_world;
         objective;
+        enforce_spec;
       }
   | None ->
       {
@@ -42,10 +50,11 @@ let of_scope ?(lossless = false) ?(aggressive = false) ?(extend_lists = false)
         extend_lists;
         closed_world;
         objective;
+        enforce_spec;
       }
 
 let v ?(lossless = false) ?(aggressive = false) ?(extend_lists = false)
-    ?(closed_world = false) ?(objective = `Transfer)
+    ?(closed_world = false) ?(objective = `Transfer) ?(enforce_spec = false)
     ?(registered = fun _ -> false) scope =
   {
     scope;
@@ -55,6 +64,7 @@ let v ?(lossless = false) ?(aggressive = false) ?(extend_lists = false)
     extend_lists;
     closed_world;
     objective;
+    enforce_spec;
   }
 
 let scope t = t.scope
@@ -64,6 +74,7 @@ let aggressive t = t.aggressive
 let extend_lists t = t.extend_lists
 let closed_world t = t.closed_world
 let objective t = t.objective
+let enforce_spec t = t.enforce_spec
 let with_extend_lists extend_lists t = { t with extend_lists }
 
 let pp_scope ctx = function
@@ -84,4 +95,6 @@ let pp ctx t =
   Pp.string ctx ";objective=";
   Pp.string ctx
     (match t.objective with `Raw -> "raw" | `Transfer -> "transfer");
+  Pp.string ctx ";enforce_spec=";
+  Pp.string ctx (string_of_bool t.enforce_spec);
   Pp.string ctx "}"

--- a/lib/ctx.mli
+++ b/lib/ctx.mli
@@ -19,6 +19,7 @@ val of_scope :
   ?extend_lists:bool ->
   ?closed_world:bool ->
   ?objective:objective ->
+  ?enforce_spec:bool ->
   scope option ->
   t
 (** Build a context from an optional scope. *)
@@ -29,6 +30,7 @@ val v :
   ?extend_lists:bool ->
   ?closed_world:bool ->
   ?objective:objective ->
+  ?enforce_spec:bool ->
   ?registered:(string -> bool) ->
   scope ->
   t
@@ -73,6 +75,11 @@ val objective : t -> objective
     DEFLATE-compressed output; [`Raw] keeps every raw-byte win, the right
     objective when the output ships uncompressed (inline [style], email) or for
     structural comparisons against raw-size oracles. *)
+
+val enforce_spec : t -> bool
+(** Whether the evergreen-browser target is dropped. Off by default: a vendor-
+    prefixed declaration whose unprefixed twin is present may be stripped, since
+    modern browsers understand the unprefixed form. On: keep every prefix. *)
 
 val with_extend_lists : bool -> t -> t
 (** [with_extend_lists enabled ctx] returns [ctx] with only the list-extension

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -1123,7 +1123,8 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
   let registered = registered_foldable stylesheet in
   let stylesheet = prune_position_try_fallbacks ~scope stylesheet in
   let ctx =
-    Ctx.v ~lossless ~aggressive ~closed_world ~objective ~registered scope
+    Ctx.v ~lossless ~aggressive ~closed_world ~objective ~enforce_spec
+      ~registered scope
   in
   run_pipeline
     ~ctx:(Ctx.with_extend_lists true ctx)

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -50,6 +50,7 @@ val ctx_of_scope :
   ?extend_lists:bool ->
   ?closed_world:bool ->
   ?objective:Ctx.objective ->
+  ?enforce_spec:bool ->
   scope option ->
   ctx
 (** [ctx_of_scope ?lossless ?aggressive ?extend_lists ?closed_world scope]

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3280,20 +3280,36 @@ let text_vendor_alias_redundant vendor twin =
       | None -> false)
   | _ -> false
 
+(* Vendor aliases whose unprefixed form is universally understood is a
+   pure-alias drop (always safe); pairs whose prefix an older browser may still
+   need are target-dependent and only drop under the opt-in targets axis. *)
+let vendor_alias_redundant_targeted vendor twin =
+  match (vendor, twin) with
+  | ( Declaration { property = Webkit_box_sizing; value = v1; important = i1 },
+      Declaration { property = Box_sizing; value = v2; important = i2 } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Moz_box_sizing; value = v1; important = i1 },
+      Declaration { property = Box_sizing; value = v2; important = i2 } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | _ -> false
+
 (* Drop a vendor-prefixed declaration when its unprefixed sibling appears in the
    same rule with the same value and importance. The unprefixed form supersedes
    in modern browsers, so the vendor copy is dead under the recent-browser
    policy. *)
-let drop_vendor_aliases (kept : (int * declaration) list) :
+let drop_vendor_aliases ~ctx (kept : (int * declaration) list) :
     (int * declaration) list =
-  let has_unprefixed_twin (_, decl) =
-    List.exists
-      (fun (_, other) ->
-        vendor_alias_redundant decl other
-        || text_vendor_alias_redundant decl other)
-      kept
-  in
-  filter_preserve (fun item -> not (has_unprefixed_twin item)) kept
+  if Ctx.enforce_spec ctx then kept (* spec-literal: keep every vendor prefix *)
+  else
+    let has_unprefixed_twin (_, decl) =
+      List.exists
+        (fun (_, other) ->
+          vendor_alias_redundant decl other
+          || text_vendor_alias_redundant decl other
+          || vendor_alias_redundant_targeted decl other)
+        kept
+    in
+    filter_preserve (fun item -> not (has_unprefixed_twin item)) kept
 
 (* Run every index-based composer against the same Rule_index so we pay one
    [build] + [to_list] per rule for the whole group. *)
@@ -3345,7 +3361,7 @@ let deduplicate_declarations_with ~ctx ?(merge_box = true) props =
   let kept = List.rev (List.fold_left deduplicate_step [] indexed_props) in
   let kept =
     let kept = if merge_box then compose_shorthands ~ctx kept else kept in
-    let kept = drop_vendor_aliases kept in
+    let kept = drop_vendor_aliases ~ctx kept in
     List.map (fun (_, decl) -> decl) kept
   in
   let result = duplicate_buggy_properties kept in

--- a/test/test_ctx.ml
+++ b/test/test_ctx.ml
@@ -28,11 +28,11 @@ let test_of_scope_preserves_defaults () =
 let test_pp () =
   Alcotest.(check string)
     "fragment pp"
-    "{scope=fragment;lossless=false;aggressive=false;extend_lists=false;closed_world=false;objective=transfer}"
+    "{scope=fragment;lossless=false;aggressive=false;extend_lists=false;closed_world=false;objective=transfer;enforce_spec=false}"
     (Pp.to_string ~minify:true Ctx.pp Ctx.fragment);
   Alcotest.(check string)
     "stylesheet lossless pp"
-    "{scope=stylesheet;lossless=true;aggressive=false;extend_lists=false;closed_world=false;objective=transfer}"
+    "{scope=stylesheet;lossless=true;aggressive=false;extend_lists=false;closed_world=false;objective=transfer;enforce_spec=false}"
     (Pp.to_string ~minify:true Ctx.pp
        (Ctx.of_scope ~lossless:true (Some `Stylesheet)))
 

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -829,8 +829,34 @@ let test_adjacent_merge_survives_preflight_skip () =
         "adjacent duplicate bodies merged on a preflight-skipped sheet" true
         (Astring.String.is_infix ~affix:".flex-grow,.grow{flex-grow:1}" out)
 
+let test_vendor_prefix_strip () =
+  let opt ?(enforce_spec = false) css =
+    match Css.of_string css with
+    | Ok p ->
+        Css.to_string ~minify:true (Css.optimize ~enforce_spec p.stylesheet)
+        |> String.trim
+    | Error _ -> Alcotest.fail "parse"
+  in
+  (* Default targets evergreen browsers: a vendor prefix whose unprefixed twin
+     is present with the same value is redundant and dropped. *)
+  Alcotest.(check string)
+    "box-sizing prefix drops by default" ".a{box-sizing:border-box}"
+    (opt ".a{-moz-box-sizing:border-box;box-sizing:border-box}");
+  (* --enforce-spec drops the evergreen target: every prefix is kept. *)
+  Alcotest.(check string)
+    "enforce-spec keeps every prefix"
+    ".a{-moz-box-sizing:border-box;box-sizing:border-box}"
+    (opt ~enforce_spec:true
+       ".a{-moz-box-sizing:border-box;box-sizing:border-box}");
+  (* A differing value is not a redundant twin. *)
+  Alcotest.(check string)
+    "differing value kept"
+    ".a{-moz-box-sizing:content-box;box-sizing:border-box}"
+    (opt ".a{-moz-box-sizing:content-box;box-sizing:border-box}")
+
 let optimize_tests =
   [
+    ("vendor prefix strip", `Quick, test_vendor_prefix_strip);
     ( "var() colour functions preserved",
       `Quick,
       test_var_color_functions_preserved );


### PR DESCRIPTION
cascade's default already targets evergreen browsers (it elides `@supports` guards), so a vendor-prefixed declaration whose unprefixed twin is present with the same value is dead weight and now drops, with `-webkit-/-moz-box-sizing` joining the set. `--enforce-spec` keeps every prefix, consistent with how it keeps `@supports` guards; the existing vendor-alias drop previously ignored it. No new flag: this is the `--enforce-spec` axis, not the opt-in `--targets` first considered. Stacked on #183.