### PR TITLE
optimize: sort declarations into a canonical order under --lossless

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ cat style.css | cascade -                                          # read stdin
 |---|---|
 | `-m, --minify` | Minify the output. Local linear rewrites always run; the expensive global factoring fixpoint runs only when its preflight predicts useful savings. The top-level pipeline re-runs until the AST stops changing (capped at 5 iterations), so the output is a fixed point: rule-order canonicalisation can expose a merge a single pass would miss. |
 | `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win and drives the factoring fixpoint to convergence, the right objective when the output ships uncompressed (inline style attributes, email HTML), at roughly 10-30x the wall clock. Has no effect without `--minify`. |
-| `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Has no effect without `--minify`. |
+| `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Also sorts each rule's declarations into a canonical cross-rule order (keeping cascade-significant pairs in place) so gzip back-references line up. Has no effect without `--minify`. |
 | `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest CSS form it knows, but it keeps every `@supports` and `supports()` guard, and every vendor-prefixed declaration, unless the CSS text and spec alone prove the rewrite. Has no effect without `--minify`. |
 | `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
 | `--flatten-nesting` | Desugar nested rules into flat top-level rules for browsers that pre-date CSS Nesting. By default cascade preserves nesting since modern browsers parse it natively and it is usually shorter. |
@@ -262,7 +262,11 @@ its canonical spelling and is not gated by that tolerance.
 
 Pass `--lossless` to keep colour values exact: hex/named canonicalisation and
 modern-syntax rewrites still run, but channel rounding, within-budget
-modern-space folds, and static `color-mix()` resolution are disabled.
+modern-space folds, and static `color-mix()` resolution are disabled. It also
+sorts each rule's declarations into one canonical order across the stylesheet,
+keeping any two whose footprints overlap (same property, or a shorthand and a
+longhand) in place, so gzip back-references line up; the reorder never changes
+a computed value.
 
 ### Scope
 

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -167,7 +167,9 @@ let lossless_arg =
     "Disable colour approximation under $(b,--minify). Exact colour \
      canonicalisation still runs, but static modern colour-space and \
      color-mix() values stay functional and colour channels keep their normal \
-     serialisation precision. Has no effect without $(b,--minify)."
+     serialisation precision. Also sorts each rule's declarations into a \
+     canonical cross-rule order (keeping cascade-significant pairs in place) \
+     so gzip back-references line up. Has no effect without $(b,--minify)."
   in
   Arg.(value & flag & info [ "lossless" ] ~doc)
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -743,6 +743,24 @@ let promote_registered_custom_properties ~lossless (stmts : statement list) =
   in
   list_map_preserve walk_stmt stmts
 
+(* Compressibility pass: put each rule's declarations in a deterministic
+   cross-rule order so gzip back-references line up, keeping cascade-significant
+   (overlapping) pairs in place. A transfer-objective win, so gated to it. *)
+let canonicalize_declaration_order stmts =
+  let rec walk_stmt (stmt : statement) : statement =
+    match stmt with
+    | Rule r ->
+        let declarations = Rule_order.canonical_declarations r.declarations in
+        let nested = list_map_preserve walk_stmt r.nested in
+        let r' = rule_with_declarations_and_nested r declarations nested in
+        if r' == r then stmt else Rule r'
+    | Media _ | Container _ | Supports _ | Layer _ | Origin _ | Scope _
+    | Starting_style _ | Moz_document _ | When _ | Else _ ->
+        map_statement_block_preserve walk_stmt stmt
+    | _ -> stmt
+  in
+  list_map_preserve walk_stmt stmts
+
 (* Under closed-stylesheet scope every [@position-try --name] rule is known. A
    [position-try-fallbacks] entry whose name has no matching rule cannot match
    at runtime, so prune unknown [Name] arms (keeping [Flip_*] and [Var]). When
@@ -1126,7 +1144,13 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
     Ctx.v ~lossless ~aggressive ~closed_world ~objective ~enforce_spec
       ~registered scope
   in
-  run_pipeline
-    ~ctx:(Ctx.with_extend_lists true ctx)
-    ~enforce_spec ~aggressive stylesheet
-  |> if prune_unused_custom_props then drop_unused_custom_props else Fun.id
+  let result =
+    run_pipeline
+      ~ctx:(Ctx.with_extend_lists true ctx)
+      ~enforce_spec ~aggressive stylesheet
+  in
+  let result =
+    if prune_unused_custom_props then drop_unused_custom_props result
+    else result
+  in
+  if lossless then canonicalize_declaration_order result else result

--- a/lib/rule_order.mli
+++ b/lib/rule_order.mli
@@ -16,6 +16,14 @@
     reordering of the input, which is what lets the canonical diff treat such
     reorderings as no-ops. *)
 
+val canonical_declarations :
+  Declaration.declaration list -> Declaration.declaration list
+(** [canonical_declarations decls] reorders a rule's declarations into a
+    deterministic content order for cross-rule gzip alignment, keeping the
+    relative order of any two whose footprints overlap (same property, or a
+    shorthand and a longhand) since that is cascade-significant. Physically
+    unchanged when already canonical. *)
+
 val canonicalize : Stylesheet.statement list -> Stylesheet.statement list
 (** [canonicalize stmts] reorders each maximal run of consecutive reorderable
     style rules into the canonical order described above. At-rules, nested

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -854,9 +854,33 @@ let test_vendor_prefix_strip () =
     ".a{-moz-box-sizing:content-box;box-sizing:border-box}"
     (opt ".a{-moz-box-sizing:content-box;box-sizing:border-box}")
 
+let test_lossless_declaration_order () =
+  let opt ?(lossless = false) css =
+    match Css.of_string css with
+    | Ok p ->
+        Css.to_string ~minify:true (Css.optimize ~lossless p.stylesheet)
+        |> String.trim
+    | Error _ -> Alcotest.fail "parse"
+  in
+  (* Default keeps source order; --lossless sorts declarations into a canonical
+     cross-rule order for gzip alignment. *)
+  Alcotest.(check string)
+    "default keeps source order" ".a{width:1px;color:red}"
+    (opt ".a{width:1px;color:red}");
+  Alcotest.(check string)
+    "lossless sorts independent declarations" ".a{color:red;width:1px}"
+    (opt ~lossless:true ".a{width:1px;color:red}");
+  (* Overlapping declarations keep their relative order (cascade-significant):
+     border-top before border-color decides the top colour. *)
+  Alcotest.(check string)
+    "overlapping declarations keep order"
+    ".a{border-top:1px solid red;border-color:#00f}"
+    (opt ~lossless:true ".a{border-top:1px solid red;border-color:blue}")
+
 let optimize_tests =
   [
     ("vendor prefix strip", `Quick, test_vendor_prefix_strip);
+    ("lossless declaration order", `Quick, test_lossless_declaration_order);
     ( "var() colour functions preserved",
       `Quick,
       test_var_color_functions_preserved );


### PR DESCRIPTION
Under `--lossless`, each rule's declarations are sorted into one deterministic order across the stylesheet so gzip back-references line up, keeping any two whose footprints overlap (same property, or a shorthand and a longhand) in place since that order is cascade-significant. It reuses `Rule_order.canonical_declarations` (the `--diff=canonical` projection), so the cascade-safety is already the diff's proven logic, and the inline getComputedStyle oracle confirms the render is unchanged.

Gated to `--lossless` per its lossless nature, so default output stays byte-identical and no existing test order changes. Applying it to default output instead reorders essentially every multi-declaration rule; that is a larger change (about 30 order-pinned oracles to re-baseline) and can follow if the transfer-objective default should carry it.