### PR TITLE
fix cascade's sandboxed opam install (exit, bounds, script paths)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,23 @@ jobs:
       - run: opam exec -- dune build
       - run: opam exec -- dune test
 
+  lower-bounds:
+    name: Lower bounds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: '5.2'
+
+      # Resolve every dependency to the oldest version its lower bound allows,
+      # so a call that only compiles against a newer API (a deprecated function
+      # removed upstream) fails here rather than in a downstream opam build.
+      - run: opam install . --deps-only --with-test --criteria="+count[version-lag,solution]"
+      - run: opam exec -- dune build
+      - run: opam exec -- dune test
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -88,7 +88,7 @@ let compare_files file1 file2 style_renderer mode opts memtrace_path () =
             print_diff_report ~color ~file1 ~file2 ~css1 ~css2 result;
             (* Differing inputs are a result, not a usage error: exit 1 as
                documented, distinct from cmdliner's reserved error codes. *)
-            exit 1)
+            Stdlib.exit 1)
   | Error e, _ | _, Error e -> Error e
 
 let file1_arg =

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -65,7 +65,7 @@ let resolve_inline_imports ~input_path stylesheet =
     Fmt.epr
       "Error: --inline-imports requires a file path (cannot resolve relative \
        URLs from stdin)@.";
-    exit 1
+    Stdlib.exit 1
   end
   else Cli_inline_imports.run ~base_url:input_path stylesheet
 
@@ -107,12 +107,12 @@ let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
   with
   | Sys_error msg ->
       Fmt.epr "Error: %s@." msg;
-      exit 1
+      Stdlib.exit 1
   | e ->
       Fmt.epr "Unexpected error: %s@." (Printexc.to_string e);
       let bt = Printexc.get_backtrace () in
       if bt <> "" then Fmt.epr "%s@." bt;
-      exit 1
+      Stdlib.exit 1
 
 let input_arg =
   let doc = "CSS file to process (use - for stdin)" in
@@ -283,7 +283,7 @@ let term =
             "Error: --keep-vars does not accept the wildcard \"*\"; list names \
              explicitly.@.";
           Fmt.epr "[1]@.";
-          exit 1
+          Stdlib.exit 1
         end;
         if keep_vars <> [] && not inline_vars_flag then
           Fmt.epr "Warning: --keep-vars has no effect without --inline-vars@.";

--- a/cascade.opam
+++ b/cascade.opam
@@ -14,11 +14,11 @@ depends: [
   "ocaml" {>= "5.2"}
   "dune" {>= "3.21"}
   "dune-build-info"
-  "alcotest" {with-test}
+  "alcotest" {>= "1.7.0" & with-test}
   "alcobar" {with-test}
   "astring" {with-test}
-  "eio" {with-test}
-  "eio_main" {with-test}
+  "eio" {>= "0.14" & with-test}
+  "eio_main" {>= "0.14" & with-test}
   "lambdasoup"
   "mdx" {with-test}
   "re" {with-test}

--- a/dune-project
+++ b/dune-project
@@ -19,11 +19,11 @@
   (ocaml (>= 5.2))
   dune
   dune-build-info
-  (alcotest :with-test)
+  (alcotest (and (>= 1.7.0) :with-test))
   (alcobar :with-test)
   (astring :with-test)
-  (eio :with-test)
-  (eio_main :with-test)
+  (eio (and (>= 0.14) :with-test))
+  (eio_main (and (>= 0.14) :with-test))
   lambdasoup
   (mdx :with-test)
   (re :with-test)

--- a/scripts/check_api_consistency.ml
+++ b/scripts/check_api_consistency.ml
@@ -436,11 +436,10 @@ let print_module_results
       (List.sort compare missing_neg) (fun n ->
         print_string ("  test_" ^ n ^ "\n")))
 
-(* The script lives in <root>/scripts inside the build tree, so the enclosing
-   cascade root is one directory up from the executable. Walking up from the cwd
-   to the nearest dune-project breaks when cascade is vendored inside another
-   dune workspace. *)
-let project_root () = Filename.dirname (Filename.dirname Sys.executable_name)
+(* dune runs this runtest action from _build/default/scripts with the lib and
+   test deps materialised at ../lib and ../test; anchor there, as
+   Sys.executable_name is relative in an opam sandbox. *)
+let project_root () = ".."
 let root = project_root ()
 let lib_dir = root // "lib"
 let test_dir = root // "test"

--- a/scripts/check_properties.ml
+++ b/scripts/check_properties.ml
@@ -91,11 +91,10 @@ let extract_handled_properties content =
   extract_from_string region
 
 let () =
-  (* The script lives in <root>/scripts inside the build tree, so the enclosing
-     cascade root is one directory up from the executable. Walking up from the
-     cwd to the nearest dune-project breaks when cascade is vendored inside
-     another dune workspace. *)
-  let project_root = Filename.dirname (Filename.dirname Sys.executable_name) in
+  (* dune runs this runtest action from _build/default/scripts with the lib deps
+     materialised at ../lib; anchor there, as Sys.executable_name is relative in
+     an opam sandbox. *)
+  let project_root = ".." in
   let intf_file = Filename.concat project_root "lib/properties_intf.ml" in
   let impl_file = Filename.concat project_root "lib/properties.ml" in
 


### PR DESCRIPTION
Three reasons the released tarball fails a clean sandboxed `opam install cascade --with-test`, none of which reproduce on a dev machine or in GitHub CI.

9b5c5f4 `exit` inside `Term.(...)` resolved to the deprecated `Cmdliner.Term.exit` (removed in cmdliner 2.0.0), so a build at the declared `>= 1.1.0` floor failed to type; it is now `Stdlib.exit`. 8d71ab5 adds a lower-bounds CI job (oldest allowed versions) that then flagged two unbounded `with-test` deps, `Alcotest.skip` (alcotest 1.7.0) and `Eio.Executor_pool` (eio 0.14). adcef39 stops the `scripts/` consistency checks deriving their project root from `Sys.executable_name`, which is relative in an opam sandbox, so `check_properties` could not find `lib/properties_intf.ml` and exited 1, failing `@runtest`; they now anchor on the build cwd that dune guarantees.
