### PR TITLE
inline: resolve var() across @layer boundaries

### DIFF
--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -18,6 +18,7 @@ let () =
       Fuzz_properties.suite;
       Fuzz_declaration.suite;
       Fuzz_variables.suite;
+      Fuzz_inline.suite;
       Fuzz_stylesheet.suite;
       Fuzz_optimize.suite;
       Fuzz_css.suite;

--- a/fuzz/fuzz_inline.ml
+++ b/fuzz/fuzz_inline.ml
@@ -1,0 +1,77 @@
+(** Fuzz tests for closed-world var() inlining ([Css.inline_vars]). *)
+
+open Cascade
+open Alcobar
+
+let byte_at buf i =
+  if String.length buf = 0 then 0 else Char.code buf.[i mod String.length buf]
+
+let pick xs buf i = List.nth xs (byte_at buf i mod List.length xs)
+let color buf i = pick [ "#abc"; "#123"; "#f00"; "#00f"; "red"; "blue" ] buf i
+
+let inlined_min css =
+  match Css.of_string_exn ~strict:false css with
+  | sheet -> Some (Css.to_string ~minify:true (Css.inline_vars sheet))
+  | exception Error.Parse_error _ -> None
+
+let layer name body = String.concat "" [ "@layer "; name; "{"; body; "}" ]
+
+(* A cascade layer only orders competing declarations; it never scopes
+   custom-property visibility (CSS Cascade 5 section 6.4, CSS Custom Properties
+   1). So a single-definition variable inlines to the same result no matter
+   which layer - or none - holds its definition or its consumers. Build a set of
+   single-def [:root] variables and one consumer each, place them across layers
+   several ways, and assert every placement inlines identically to the fully
+   unlayered stylesheet (which never mishandled layers). *)
+let test_layer_placement_invariant buf =
+  let n = 1 + (byte_at buf 0 mod 4) in
+  let root_block =
+    let body =
+      List.init n (fun i ->
+          String.concat "" [ "--v"; string_of_int i; ":"; color buf (i + 1) ])
+      |> String.concat ";"
+    in
+    String.concat "" [ ":root{"; body; "}" ]
+  in
+  let consumer i =
+    let s = string_of_int i in
+    String.concat "" [ ".c"; s; "{color:var(--v"; s; ")}" ]
+  in
+  let consumers = List.init n consumer in
+  let reference = String.concat "" (root_block :: consumers) in
+  let layered =
+    match byte_at buf 1 mod 4 with
+    | 0 ->
+        (* definition and consumers in two different layers *)
+        String.concat ""
+          [
+            layer "theme" root_block;
+            layer "utilities" (String.concat "" consumers);
+          ]
+    | 1 ->
+        (* definition layered, consumers unlayered *)
+        String.concat "" (layer "theme" root_block :: consumers)
+    | 2 ->
+        (* definition unlayered, consumers layered *)
+        String.concat ""
+          [ root_block; layer "utilities" (String.concat "" consumers) ]
+    | _ ->
+        (* definition layered, each consumer in an alternating layer *)
+        String.concat ""
+          (layer "theme" root_block
+          :: List.mapi
+               (fun i c -> layer (if i land 1 = 0 then "a" else "b") c)
+               consumers)
+  in
+  match (inlined_min reference, inlined_min layered) with
+  | Some r, Some l ->
+      if l <> r then
+        failf "layer placement changed inlining: unlayered %S vs layered %S" r l
+  | _ -> ()
+
+let suite =
+  ( "inline",
+    [
+      test_case "layer placement leaves single-def inlining unchanged" [ bytes ]
+        test_layer_placement_invariant;
+    ] )

--- a/fuzz/fuzz_inline.mli
+++ b/fuzz/fuzz_inline.mli
@@ -1,0 +1,4 @@
+(** Fuzz tests for closed-world var() inlining. *)
+
+val suite : string * Alcobar.test_case list
+(** [suite] declares the [Css.inline_vars] fuzz cases. *)

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -73,13 +73,26 @@ type at_node =
   | Origin of cascade_origin
   | Scope of Selector.t option * Selector.t option
 
+(* A cascade layer never gates custom-property visibility: [--x] defined in one
+   [@layer] resolves for a consumer in any other layer (or none), because layers
+   only order competing declarations, they do not scope the value. Only the
+   conditional wrappers (@media/@supports/@container/...) are real barriers, so
+   drop [Layer] nodes from a path before comparing. *)
+let rec drop_layers = function
+  | [] -> []
+  | Layer _ :: rest -> drop_layers rest
+  | node :: rest -> node :: drop_layers rest
+
 (* Visibility through at-rule wrappers: a custom property defined outside
    (shorter path) is visible to consumers further inside (longer path). *)
-let rec at_path_prefix ~outer ~inner =
-  match (outer, inner) with
-  | [], _ -> true
-  | _, [] -> false
-  | a :: outer, b :: inner -> a = b && at_path_prefix ~outer ~inner
+let at_path_prefix ~outer ~inner =
+  let rec prefix outer inner =
+    match (outer, inner) with
+    | [], _ -> true
+    | _, [] -> false
+    | a :: outer, b :: inner -> a = b && prefix outer inner
+  in
+  prefix (drop_layers outer) (drop_layers inner)
 
 let at_wrapper : statement -> (at_node * t * (t -> statement)) option = function
   | Stylesheet.Layer (n, b) ->

--- a/test/cli/inline_vars_scope.t
+++ b/test/cli/inline_vars_scope.t
@@ -25,15 +25,17 @@ that @media block.
   $ cascade --minify --inline-vars media.css
   @media(width>=30em){.a{color:red}}.b{color:var(--brand)}
 
-A variable declared inside @layer applies to consumers within the same
-layer; outside-layer use stays as var().
+A cascade layer only orders competing declarations, it does not scope
+custom-property visibility (unlike the conditional @media / @container),
+so a variable declared inside @layer resolves for consumers inside and
+outside the layer alike, exactly as without the layer wrapper.
 
   $ cat > layer.css <<EOF
   > @layer theme { :root { --brand: red } .a { color: var(--brand) } }
   > .b { color: var(--brand) }
   > EOF
   $ cascade --minify --inline-vars layer.css
-  .a{color:red}.b{color:var(--brand)}
+  .a,.b{color:red}
 
 A variable used in a @container query value is preserved (container
 queries evaluate at layout time, not at the syntax layer).

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -238,6 +238,34 @@ let test_inline_vars_runtime_boundaries () =
     ":root{--bp:30em}@container (min-width:var(--bp)){.x{color:red}}"
     ":root{--bp:30em}@container(min-width:var(--bp)){.x{color:red}}"
 
+let test_inline_across_layers () =
+  (* A cascade layer never scopes custom-property visibility: layers only order
+     competing declarations, so a variable defined in one @layer resolves for a
+     consumer in another layer (or none). inline_vars must substitute across the
+     boundary and drop the now unused definition, exactly as for unlayered
+     rules. *)
+  check_inline_case ~optimized:".p-6{padding:1.5rem}"
+    "definition and reference in different layers substitute"
+    "@layer theme{:root{--spacing:.25rem}}@layer \
+     utilities{.p-6{padding:calc(var(--spacing)*6)}}"
+    ".p-6{padding:calc(.25rem*6)}";
+  check_inline_case ~optimized:".x{padding:1rem}"
+    "definition in a layer, consumer at top level"
+    "@layer t{:root{--s:.25rem}}.x{padding:calc(var(--s)*4)}"
+    ".x{padding:calc(.25rem*4)}";
+  check_inline_case ~optimized:".x{padding:1rem}"
+    "definition at top level, consumer inside a layer"
+    ":root{--s:.25rem}@layer u{.x{padding:calc(var(--s)*4)}}"
+    ".x{padding:calc(.25rem*4)}";
+  (* A variable redefined in a second layer is a real cascade override, so it
+     stays a live var() with every definition, like a cross-scope redefinition
+     without layers. *)
+  check_inline_case ~optimized:":root{--c:blue}.x{color:var(--c)}"
+    "a cross-layer redefinition stays a live reference"
+    "@layer a{:root{--c:red}}@layer b{:root{--c:blue}}@layer \
+     u{.x{color:var(--c)}}"
+    ":root{--c:red}:root{--c:blue}.x{color:var(--c)}"
+
 let suite =
   ( "inline",
     [
@@ -270,4 +298,6 @@ let suite =
         test_inline_shorthand_functions;
       Alcotest.test_case "inline vars runtime boundaries" `Quick
         test_inline_vars_runtime_boundaries;
+      Alcotest.test_case "inline vars substitute across cascade layers" `Quick
+        test_inline_across_layers;
     ] )


### PR DESCRIPTION
A cascade layer only orders competing declarations; per CSS Cascade 5 it never scopes custom-property visibility. `inline_vars` treated `@layer` as a barrier like `@media`, so a variable defined in one layer stayed an unresolved `var()` for a consumer in a different layer (or none), which is why `tw --inline` leaked `var(--spacing)` on every layered padding/gap/margin utility. Making layers transparent to the resolution check lets a layered stylesheet inline exactly like its unlayered form.

A property fuzz test asserts that placing a single-definition variable and its consumers across any combination of layers inlines identically to the unlayered stylesheet.