### PR TITLE
apply: project rules inside @layer onto elements

### DIFF
--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -24,4 +24,5 @@ let () =
       Fuzz_supports.suite;
       Fuzz_font_face.suite;
       Fuzz_keyframe.suite;
+      Fuzz_apply.suite;
     ]

--- a/fuzz/fuzz_apply.ml
+++ b/fuzz/fuzz_apply.ml
@@ -1,0 +1,84 @@
+(** Fuzz tests for projecting a stylesheet onto an element tree
+    ([Cascade.Apply]). *)
+
+open Cascade
+open Alcobar
+
+type node = { name : string; classes : string list; children : node list }
+
+module Node = struct
+  type t = node
+
+  let equal = ( == )
+  let name n = Some n.name
+  let id _ = None
+  let classes n = n.classes
+  let attribute _ _ = None
+  let parent _ = None
+  let children n = n.children
+end
+
+module A = Apply.Make (Node)
+
+let byte_at buf i =
+  if String.length buf = 0 then 0 else Char.code buf.[i mod String.length buf]
+
+let pick xs buf i = List.nth xs (byte_at buf i mod List.length xs)
+let color buf i = pick [ "#abc"; "#123"; "#f00"; "#00f"; "red"; "blue" ] buf i
+
+let inline_style ds =
+  Stylesheet.inline_style_of_declarations ~minify:true ~mode:Variables ds
+
+(* Compare two projections structurally: the inline style written onto each node
+   in tree order, plus the kept <style> body and its rule count. *)
+let summary (r : node Apply.result) =
+  (List.map (fun (_, ds) -> inline_style ds) r.styles, r.keep_css, r.kept)
+
+let layer name body = String.concat "" [ "@layer "; name; "{"; body; "}" ]
+
+(* A @layer block applies unconditionally, so wrapping author rules in one (or
+   several) layers must not change what [Apply.compute] projects onto the tree
+   or keeps in the <style>: the projection is identical to the unlayered rules.
+   Each class carries a single declaration so no two rules compete, keeping the
+   comparison free of cascade-winner ambiguity between layers. *)
+let test_layer_wrapping_invariant buf =
+  let k = 1 + (byte_at buf 0 mod 4) in
+  let classes =
+    List.init k (fun i -> String.concat "" [ "c"; string_of_int i ])
+  in
+  let roots =
+    List.map (fun c -> { name = "div"; classes = [ c ]; children = [] }) classes
+  in
+  let static_rule i c =
+    String.concat ""
+      [ "."; c; "{color:var(--"; string_of_int i; ","; color buf (i + 1); ")}" ]
+  in
+  (* Give one class a :hover rule, so a property turns dynamic and its static
+     declaration is kept in <style> rather than inlined - the split must survive
+     layer wrapping too. *)
+  let hover_at = byte_at buf 1 mod k in
+  let hover_rule =
+    String.concat "" [ ".c"; string_of_int hover_at; ":hover{color:red}" ]
+  in
+  let rules = List.mapi static_rule classes @ [ hover_rule ] in
+  let reference = String.concat "" rules in
+  let layered =
+    if byte_at buf 2 land 1 = 0 then layer "utilities" reference
+    else
+      (* static rules in one layer, the stateful rule in another *)
+      String.concat ""
+        [
+          layer "base" (String.concat "" (List.mapi static_rule classes));
+          layer "states" hover_rule;
+        ]
+  in
+  let r0 = summary (A.compute ~css:reference roots) in
+  let r1 = summary (A.compute ~css:layered roots) in
+  if r0 <> r1 then fail "layer wrapping changed the projected styles"
+
+let suite =
+  ( "apply",
+    [
+      test_case "layer wrapping leaves the projection unchanged" [ bytes ]
+        test_layer_wrapping_invariant;
+    ] )

--- a/fuzz/fuzz_apply.mli
+++ b/fuzz/fuzz_apply.mli
@@ -1,0 +1,4 @@
+(** Fuzz tests for projecting a stylesheet onto an element tree. *)
+
+val suite : string * Alcobar.test_case list
+(** [suite] declares the [Cascade.Apply] fuzz cases. *)

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -108,6 +108,18 @@ let rec props_of_stmts acc stmts =
       | _ -> acc)
     acc stmts
 
+(* A [@layer] block applies unconditionally: it only orders competing
+   declarations, it does not gate them behind a condition the way
+   @media/@supports/@container do. So its rules can be projected onto elements
+   just like top-level rules - splice their contents in place (recursing into
+   nested layers) instead of keeping the whole block in the un-inlinable
+   <style>. *)
+let rec unwrap_layers stmts =
+  List.concat_map
+    (function
+      | Stylesheet.Layer (_, body) -> unwrap_layers body | other -> [ other ])
+    stmts
+
 type 'node assignment = 'node * Declaration.declaration list
 (** The inline-style declarations to write onto a node. *)
 
@@ -180,8 +192,9 @@ module Make (Node : Resolve.NODE) = struct
     | Error _ -> { styles = []; keep_css = ""; kept = 0 }
     | Ok p ->
         (* Flatten nesting up front, so the static/dynamic split and
-           {!R.resolve} see the same flat rules. *)
-        let stmts = Flatten.block p.Css.stylesheet in
+           {!R.resolve} see the same flat rules, then unwrap [@layer] so its
+           rules join the split instead of being kept wholesale. *)
+        let stmts = unwrap_layers (Flatten.block p.Css.stylesheet) in
         (* Properties a kept rule can override must stay in the cascade. *)
         let dyn =
           props_of_stmts SSet.empty

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -52,6 +52,36 @@ let keeps_stateful_rule_in_css () =
     "kept dynamic rule" ".card:hover{color:blue}" result.keep_css;
   Alcotest.(check int) "kept count" 1 result.kept
 
+(* A @layer block applies unconditionally, so its rules project onto elements
+   just like top-level ones instead of being kept wholesale in a <style>. *)
+let projects_layered_rule_to_inline_style () =
+  let n = node ~classes:[ "card" ] "div" in
+  let result = A.compute ~css:"@layer u{.card{color:red;margin:0}}" [ n ] in
+  match result.styles with
+  | [ (node, decls) ] ->
+      Alcotest.(check bool) "same node" true (Node.equal node n);
+      Alcotest.(check string)
+        "inline declarations" "color:red;margin:0" (inline_style decls);
+      Alcotest.(check string) "no kept css" "" result.keep_css;
+      Alcotest.(check int) "kept count" 0 result.kept
+  | _ -> Alcotest.fail "expected one inline assignment"
+
+(* Inside a layer the static/dynamic split still holds: the plain rule inlines,
+   the stateful one stays in the kept <style>. *)
+let keeps_stateful_rule_inside_layer_in_css () =
+  let n = node ~classes:[ "card" ] "div" in
+  let result =
+    A.compute ~css:"@layer u{.card{margin:0}.card:hover{color:blue}}" [ n ]
+  in
+  Alcotest.(check string)
+    "inline static rule" "margin:0"
+    (match result.styles with
+    | [ (_, decls) ] -> inline_style decls
+    | _ -> Alcotest.fail "expected one inline assignment");
+  Alcotest.(check string)
+    "kept dynamic rule" ".card:hover{color:blue}" result.keep_css;
+  Alcotest.(check int) "kept count" 1 result.kept
+
 let invalid_css_is_empty () =
   let result = A.compute ~css:"a{" [ node "div" ] in
   Alcotest.(check string)
@@ -69,5 +99,9 @@ let suite =
         projects_static_rule_to_inline_style;
       Alcotest.test_case "keeps stateful rule in css" `Quick
         keeps_stateful_rule_in_css;
+      Alcotest.test_case "projects layered rule to inline style" `Quick
+        projects_layered_rule_to_inline_style;
+      Alcotest.test_case "keeps stateful rule inside layer in css" `Quick
+        keeps_stateful_rule_inside_layer_in_css;
       Alcotest.test_case "invalid css is empty" `Quick invalid_css_is_empty;
     ] )


### PR DESCRIPTION
`cascade apply` kept every `@layer` block whole in the emitted `<style>` and projected none of its rules onto elements, so full variables-mode `tw` output (where every rule is layered) inlined nothing. A `@layer` block applies unconditionally, unlike the conditional `@media`/`@supports`/`@container`, so unwrapping it before the static/dynamic split lets its rules project onto elements exactly like top-level ones, while conditional parts (`:hover`, `@media`) stay in the kept `<style>`.

A property fuzz test asserts that wrapping author rules in one or more layers leaves the projected inline styles and the kept `<style>` unchanged versus the unlayered rules.