### PR TITLE
inline: fold a layer-decided custom property to the cascade winner

### DIFF
--- a/fuzz/fuzz_inline.ml
+++ b/fuzz/fuzz_inline.ml
@@ -69,9 +69,43 @@ let test_layer_placement_invariant buf =
         failf "layer placement changed inlining: unlayered %S vs layered %S" r l
   | _ -> ()
 
+(* CSS Cascade 5 §6.4.2: for normal declarations an unlayered definition beats
+   every layered one, whatever the layers or their order. A variable defined on
+   [:root] across a stack of named layers plus one unlayered definition must
+   therefore fold to the unlayered value. Independent of how the winner is
+   computed, so it catches a wrong winner (e.g. picking the last document
+   order). *)
+let test_unlayered_definition_wins buf =
+  let n = 1 + (byte_at buf 0 mod 3) in
+  let vals = [ "1px"; "2px"; "3px"; "4px" ] in
+  let layered =
+    List.init n (fun i ->
+        let v = List.nth vals (byte_at buf (i + 1) mod List.length vals) in
+        layer
+          (String.concat "" [ "l"; string_of_int i ])
+          (String.concat "" [ ":root{--x:"; v; "}" ]))
+  in
+  let sentinel = "9px" in
+  let unlayered = String.concat "" [ ":root{--x:"; sentinel; "}" ] in
+  let consumer = ".z{width:var(--x)}" in
+  (* Place the unlayered definition before or after the layer stack: it wins
+     from either position. *)
+  let parts =
+    if byte_at buf 9 land 1 = 0 then (unlayered :: layered) @ [ consumer ]
+    else layered @ [ unlayered; consumer ]
+  in
+  match inlined_min (String.concat "" parts) with
+  | None -> ()
+  | Some out ->
+      let expected = String.concat "" [ ".z{width:"; sentinel; "}" ] in
+      if out <> expected then
+        failf "unlayered definition did not win: %S (expected %S)" out expected
+
 let suite =
   ( "inline",
     [
       test_case "layer placement leaves single-def inlining unchanged" [ bytes ]
         test_layer_placement_invariant;
+      test_case "an unlayered definition wins over any layer stack" [ bytes ]
+        test_unlayered_definition_wins;
     ] )

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -344,6 +344,18 @@ let lookup_custom_property ?layer ?layer_order ctx name =
       | Some _ as v -> v
       | None -> pick_normal_custom ?layer ~layer_order normal)
 
+(* The computed winner among a pool of same-property custom-property
+   declarations, resolved by CSS Cascade 5 §6.4.3: important beats normal,
+   [revert-layer] rolls back to the next layer down, and layer order (reversed
+   for important) breaks ties. Layers are read from each declaration's own
+   annotation, so the caller must have tagged them. [None] when the pool is
+   empty or resolves to unset. *)
+let winning_custom_declaration ~layer_order decls =
+  let important, normal = List.partition Declaration.is_important decls in
+  match pick_important_custom ~layer_order important with
+  | Some _ as v -> v
+  | None -> pick_normal_custom ~layer_order normal
+
 (* Extract the value bound to feature [name] from a single media feature. A
    [<name>: <value>] plain and an [<name> = <value>] equality range both pin the
    feature to a concrete value; range / boolean / interval features do not. *)

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -220,6 +220,17 @@ val custom_property : string -> t -> Declaration.declaration option
 (** [custom_property name ctx] is the custom property declaration named [name]
     in [ctx], if any. *)
 
+val winning_custom_declaration :
+  layer_order:string list ->
+  Declaration.declaration list ->
+  Declaration.declaration option
+(** [winning_custom_declaration ~layer_order decls] is the cascade winner among
+    same-property custom-property declarations per CSS Cascade 5 §6.4.3:
+    [!important] beats normal, [revert-layer] rolls back a layer, and layer
+    order (reversed for [!important]) breaks ties. Each declaration's layer is
+    read from its own annotation. [None] when [decls] is empty or resolves to
+    unset. *)
+
 val inherited_value : string -> t -> Declaration.declaration option
 (** [inherited_value property ctx] is the inherited declaration for [property]
     in [ctx], if any. *)

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1111,8 +1111,169 @@ let var_census stylesheet =
   List.iter walk stylesheet;
   (counts, List.sort_uniq compare !referenced)
 
+(** {1 Layer-decided custom-property folding} *)
+
+(* A variable redefined across cascade layers on the same element is a real
+   override, but - unlike an @media or dark-mode override - its winner is
+   statically decidable, so it can be folded to that winner instead of kept
+   live. [statements_for_inline] later drops the [@layer] wrappers, which would
+   otherwise leave the losing definitions competing by document order and pick
+   the wrong value. Resolving the winner here keeps the folded value correct. *)
+
+(* Document-order cascade layer names (dotted for nesting), low precedence
+   first: the order in which layers are first introduced. *)
+let stylesheet_layer_order stylesheet =
+  let seen = Hashtbl.create 16 in
+  let order = ref [] in
+  let add name =
+    if not (Hashtbl.mem seen name) then begin
+      Hashtbl.add seen name ();
+      order := name :: !order
+    end
+  in
+  let dotted prefix name =
+    if prefix = "" then name else String.concat "." [ prefix; name ]
+  in
+  let rec walk prefix = function
+    | [] -> ()
+    | stmt :: rest ->
+        (match stmt with
+        | Stylesheet.Layer_decl names ->
+            List.iter (fun n -> add (dotted prefix n)) names
+        | Stylesheet.Layer (Some n, body) ->
+            let full = dotted prefix n in
+            add full;
+            walk full body
+        | Stylesheet.Layer (None, body) -> walk prefix body
+        | _ -> ());
+        walk prefix rest
+  in
+  walk "" stylesheet;
+  List.rev !order
+
+(* [Some layer] for a purely-layered path ([layer = None] unlayered, [Some name]
+   the dotted layer), [None] when the path is conditional or holds an anonymous
+   layer - those are not statically foldable. *)
+let foldable_layer_of_at_path at_path : string option option =
+  let rec go names : at_node list -> string option option = function
+    | [] -> (
+        match List.rev names with
+        | [] -> Some None
+        | ns -> Some (Some (String.concat "." ns)))
+    | Layer (Some n) :: rest -> go (n :: names) rest
+    | Layer None :: _ -> None
+    | _ :: _ -> None
+  in
+  go [] at_path
+
+(* A copy of [d] tagged with [layer] and its own importance, for the cascade
+   resolver. *)
+let annotate_layer (layer : string option) d =
+  let name = Declaration.property_name d in
+  let value = Declaration.string_of_value ~minify:true d in
+  let base =
+    match layer with
+    | None -> Declaration.custom_property name value
+    | Some l -> Declaration.custom_property ~layer:l name value
+  in
+  if Declaration.is_important d then Declaration.important base else base
+
+(* Names whose every definition is unconditional, on one selector, and spread
+   over two or more layers, mapped to the resolved cascade winner ([`Unset] when
+   it resolves to no value). A single scope with repeated declarations is left
+   alone: the census already treats it as one inlinable definition. *)
+let layer_decided_customs ~keep stylesheet =
+  let scopes = collect_scopes ~kept:keep stylesheet in
+  let by_name = Hashtbl.create 64 in
+  List.iter
+    (fun (s : scope) ->
+      let sel = Selector.to_string ~minify:true s.selector in
+      let fl = foldable_layer_of_at_path s.at_path in
+      List.iter
+        (fun d ->
+          match custom_name d with
+          | None -> ()
+          | Some name ->
+              let prev =
+                Option.value ~default:[] (Hashtbl.find_opt by_name name)
+              in
+              Hashtbl.replace by_name name ((sel, fl, d) :: prev))
+        s.customs)
+    scopes;
+  let layer_order = stylesheet_layer_order stylesheet in
+  let fold = Hashtbl.create 16 in
+  Hashtbl.iter
+    (fun name entries ->
+      let entries = List.rev entries in
+      let unconditional =
+        List.for_all (fun (_, fl, _) -> Option.is_some fl) entries
+      in
+      let one_selector =
+        match entries with
+        | (sel0, _, _) :: rest -> List.for_all (fun (s, _, _) -> s = sel0) rest
+        | [] -> true
+      in
+      let distinct_layers =
+        entries
+        |> List.filter_map (fun (_, fl, _) -> fl)
+        |> List.sort_uniq compare |> List.length
+      in
+      if unconditional && one_selector && distinct_layers >= 2 then
+        let annotated =
+          List.filter_map
+            (fun (_, fl, d) -> Option.map (fun l -> annotate_layer l d) fl)
+            entries
+        in
+        match Context.winning_custom_declaration ~layer_order annotated with
+        | Some w ->
+            Hashtbl.replace fold name
+              (`Value (Declaration.string_of_value ~minify:true w))
+        | None -> Hashtbl.replace fold name `Unset)
+    by_name;
+  fold
+
+(* Replace every layer-decided definition with a single unlayered definition of
+   the winner (or drop it entirely when unset), so the census sees one inlinable
+   definition. *)
+let collapse_layer_decided ~keep stylesheet =
+  let fold = layer_decided_customs ~keep stylesheet in
+  if Hashtbl.length fold = 0 then stylesheet
+  else
+    let emitted = Hashtbl.create 16 in
+    let filter_decls decls =
+      List.filter_map
+        (fun d ->
+          match custom_name d with
+          | Some n when Hashtbl.mem fold n -> (
+              match Hashtbl.find fold n with
+              | `Unset -> None
+              | `Value _ when Hashtbl.mem emitted n -> None
+              | `Value v ->
+                  Hashtbl.add emitted n ();
+                  Some (Declaration.custom_property n v))
+          | _ -> Some d)
+        decls
+    in
+    let rec map_stmt stmt =
+      match at_wrapper stmt with
+      | Some (_, body, rebuild) -> rebuild (List.map map_stmt body)
+      | None -> (
+          match stmt with
+          | Rule r ->
+              Rule
+                {
+                  r with
+                  declarations = filter_decls r.declarations;
+                  nested = List.map map_stmt r.nested;
+                }
+          | Declarations decls -> Declarations (filter_decls decls)
+          | other -> other)
+    in
+    List.map map_stmt stylesheet
+
 let vars ?(keep_vars = []) ?(warn = fun _ -> ()) stylesheet =
   let keep = List.map normalise_var_name keep_vars in
+  let stylesheet = collapse_layer_decided ~keep stylesheet in
   let counts, referenced = var_census stylesheet in
   let inlinable name =
     (not (List.mem name keep)) && Hashtbl.find_opt counts name = Some 1

--- a/test/cli/inline_vars_scope.t
+++ b/test/cli/inline_vars_scope.t
@@ -37,6 +37,39 @@ outside the layer alike, exactly as without the layer wrapper.
   $ cascade --minify --inline-vars layer.css
   .a,.b{color:red}
 
+A variable redefined on the same element across layers has a statically
+decidable winner (CSS Cascade 5 6.4.3), so it folds to that winner rather
+than staying a live var(). For normal declarations the later layer wins.
+
+  $ cat > layer-order.css <<EOF
+  > @layer a { :root { --x: 1px } }
+  > @layer b { :root { --x: 2px } }
+  > .z { width: var(--x) }
+  > EOF
+  $ cascade --minify --inline-vars layer-order.css
+  .z{width:2px}
+
+An unlayered definition wins over a layered one, whatever the document
+order.
+
+  $ cat > layer-unlayered.css <<EOF
+  > :root { --x: 2px }
+  > @layer a { :root { --x: 1px } }
+  > .z { width: var(--x) }
+  > EOF
+  $ cascade --minify --inline-vars layer-unlayered.css
+  .z{width:2px}
+
+A [revert-layer] winner rolls back to the value from the layer below it.
+
+  $ cat > layer-revert.css <<EOF
+  > @layer a { :root { --x: 1px } }
+  > @layer b { :root { --x: revert-layer } }
+  > .z { width: var(--x) }
+  > EOF
+  $ cascade --minify --inline-vars layer-revert.css
+  .z{width:1px}
+
 A variable used in a @container query value is preserved (container
 queries evaluate at layout time, not at the syntax layer).
 

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -257,14 +257,45 @@ let test_inline_across_layers () =
     "definition at top level, consumer inside a layer"
     ":root{--s:.25rem}@layer u{.x{padding:calc(var(--s)*4)}}"
     ".x{padding:calc(.25rem*4)}";
-  (* A variable redefined in a second layer is a real cascade override, so it
-     stays a live var() with every definition, like a cross-scope redefinition
-     without layers. *)
-  check_inline_case ~optimized:":root{--c:blue}.x{color:var(--c)}"
-    "a cross-layer redefinition stays a live reference"
+  (* A variable redefined across layers on the same element is a statically
+     decidable cascade override, so it folds to the winning layer's value (the
+     later layer wins for normal declarations) instead of staying a live
+     reference. *)
+  check_inline_case ~optimized:".x{color:#00f}"
+    "a cross-layer redefinition folds to the winning layer"
     "@layer a{:root{--c:red}}@layer b{:root{--c:blue}}@layer \
      u{.x{color:var(--c)}}"
-    ":root{--c:red}:root{--c:blue}.x{color:var(--c)}"
+    ".x{color:blue}"
+
+(* A cascade layer only orders competing declarations, so a variable defined on
+   the same element across several layers has a statically decidable winner and
+   folds to it (CSS Cascade 5 §6.4.3). An override that depends on runtime state
+   (a media query, a different selector) cannot be decided statically and stays
+   a live var(). *)
+let test_inline_layer_winner () =
+  check_inline_case ~optimized:".z{width:2px}"
+    "the later layer wins for a normal declaration"
+    "@layer a{:root{--x:1px}}@layer b{:root{--x:2px}}.z{width:var(--x)}"
+    ".z{width:2px}";
+  check_inline_case ~optimized:".z{width:2px}"
+    "an unlayered definition beats a layered one regardless of order"
+    ":root{--x:2px}@layer a{:root{--x:1px}}.z{width:var(--x)}" ".z{width:2px}";
+  check_inline_case ~optimized:".z{width:1px}"
+    "revert-layer rolls back to the earlier layer"
+    "@layer a{:root{--x:1px}}@layer \
+     b{:root{--x:revert-layer}}.z{width:var(--x)}"
+    ".z{width:1px}";
+  check_inline_case ~optimized:".z{width:1px}"
+    "an important definition inverts the layer order"
+    "@layer a{:root{--x:1px!important}}@layer \
+     b{:root{--x:2px}}.z{width:var(--x)}"
+    ".z{width:1px}";
+  check_inline_case "a media-query override stays a live reference"
+    ":root{--c:red}@media(prefers-color-scheme:dark){:root{--c:blue}}.x{color:var(--c)}"
+    ":root{--c:red}@media(prefers-color-scheme:dark){:root{--c:blue}}.x{color:var(--c)}";
+  check_inline_case "a different-selector override stays a live reference"
+    ":root{--c:red}.dark{--c:blue}.x{color:var(--c)}"
+    ":root{--c:red}.dark{--c:blue}.x{color:var(--c)}"
 
 let suite =
   ( "inline",
@@ -300,4 +331,7 @@ let suite =
         test_inline_vars_runtime_boundaries;
       Alcotest.test_case "inline vars substitute across cascade layers" `Quick
         test_inline_across_layers;
+      Alcotest.test_case
+        "inline vars fold a layer-decided override to its winner" `Quick
+        test_inline_layer_winner;
     ] )


### PR DESCRIPTION
A variable redefined across cascade layers on the same element used to stay a live `var()`. `Css.statements_for_inline` then drops the `@layer` wrappers, leaving the losing definitions to compete by plain document order, so `inline_vars` could emit the wrong value: an unlayered definition placed *before* a layer resolved to the layered value, and a `revert-layer` winner lost its rollback.

Unlike an `@media` or dark-mode override, this winner is statically decidable, so a pre-pass resolves it up front (CSS Cascade 5 §6.4.3, reusing `Context`'s tested resolver: `!important` inversion and `revert-layer` rollback included) and folds the variable to that single winning value. Overrides that depend on runtime state (a media query, a different selector) are not decidable and still stay live.

A property fuzz test asserts the spec invariant that an unlayered normal definition wins over any stack of layered ones regardless of document order.