### PR TITLE
values: add oklch_none_hue

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1275,6 +1275,11 @@ val oklch : float -> float -> float -> color
 val oklcha : float -> float -> float -> float -> color
 (** [oklcha l c h a] is an OKLCH color with alpha in [0., 1.]. *)
 
+val oklch_none_hue : float -> float -> color
+(** [oklch_none_hue l c] is an OKLCH color whose hue is [none]. The hue of an
+    achromatic color is powerless, and [none] keeps the component missing, so
+    interpolation takes the other color's hue rather than 0. *)
+
 val oklab : float -> float -> float -> color
 (** [oklab l a b] is an OKLAB color. L in percentage (0-100). *)
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -231,6 +231,9 @@ let oklch l c h =
 let oklcha l c h a =
   Oklch { l = Some (Pct l); c = Some c; h = Unitless h; alpha = Num a }
 
+let oklch_none_hue l c =
+  Oklch { l = Some (Pct l); c = Some c; h = Hue_none; alpha = None }
+
 let oklab l a b =
   Oklab { l = Some (Pct l); a = Some a; b = Some b; alpha = None }
 

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -52,6 +52,11 @@ val oklch : float -> float -> float -> color
 val oklcha : float -> float -> float -> float -> color
 (** [oklcha l c h a] creates an OKLCH color with alpha. *)
 
+val oklch_none_hue : float -> float -> color
+(** [oklch_none_hue l c] creates an OKLCH color whose hue is [none]. The hue of
+    an achromatic color is powerless, and [none] keeps the component missing, so
+    interpolation takes the other color's hue rather than 0. *)
+
 val oklab : float -> float -> float -> color
 (** [oklab l a b] creates an OKLAB color. *)
 

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -680,6 +680,20 @@ let test_color_oklch_printing () =
   let s = Css.Pp.to_string pp_color c in
   Alcotest.(check string) "oklch printing" "oklch(50% .123 30)" s
 
+(* A [none] hue is a missing component, not the number zero: it stays [none]
+   through printing, and the colour cannot fold to a hex because a hex would pin
+   the hue that interpolation is meant to take from the other colour. *)
+(* Not a roundtrip test *)
+let test_color_oklch_none_hue () =
+  let open Css.Values in
+  let c = oklch_none_hue 55.6 0.0 in
+  let s = Css.Pp.to_string pp_color c in
+  Alcotest.(check string) "oklch none hue printing" "oklch(55.6% 0 none)" s;
+  (* Optimize still folds the lightness to its shorter number spelling, but the
+     colour stays an oklch(): a hex would pin the missing hue. *)
+  check_color ~expected:"oklch(55.6%0 none)" ~optimized:"oklch(.556 0 none)"
+    "oklch(55.6% 0 none)"
+
 (* Not a roundtrip test *)
 let test_color_mix_printing () =
   let open Css.Values in
@@ -1229,6 +1243,7 @@ let value_tests =
     test_case "minified value formatting" `Quick test_minified_value_formatting;
     test_case "regular value formatting" `Quick test_regular_value_formatting;
     test_case "oklch printing" `Quick test_color_oklch_printing;
+    test_case "oklch none hue" `Quick test_color_oklch_none_hue;
     test_case "color-mix printing" `Quick test_color_mix_printing;
     test_case "var in calc other types" `Quick test_var_in_calc_types;
     test_case "number var printing" `Quick test_number_var_printing;


### PR DESCRIPTION
CSS Color 4 lets a component be `none`, and an achromatic colour's hue is powerless, so it is written `none` rather than `0` — Tailwind's neutral scale does exactly this (`oklch(55.6% 0 none)`). The colour type already carries `Hue_none` and the parser and printer already round-trip it, but no constructor built one, so a caller had to assemble the `Oklch` record by hand.

The distinction is not cosmetic: `none` keeps the component missing, so interpolation takes the other colour's hue, and the value cannot fold to a hex that would pin it. The test pins both the printed form and that optimize folds the lightness while leaving the colour an `oklch()`.