### PR TITLE
test/interop/satcss: commit the regen rule instead of ignoring it

### DIFF
--- a/test/interop/satcss/dune
+++ b/test/interop/satcss/dune
@@ -8,13 +8,4 @@
  (deps
   (source_tree traces)))
 
-; Regenerate the SatCSS oracle: dune build @regen-traces
-
-(rule
- (alias regen-traces)
- (deps
-  (source_tree scripts))
- (action
-  (chdir
-   scripts
-   (run ./generate.sh))))
+; Regenerate the SatCSS oracle: REGEN=1 dune build @regen (see traces/dune)

--- a/test/interop/satcss/scripts/generate.sh
+++ b/test/interop/satcss/scripts/generate.sh
@@ -15,7 +15,7 @@
 #
 # traces/ is gitignored on purpose: the corpus is third-party website CSS with
 # no redistribution license, so the oracle is generated locally and never
-# committed. Single trigger: dune build @regen-traces
+# committed. Single trigger: REGEN=1 dune build @regen
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/test/interop/satcss/traces/.gitignore
+++ b/test/interop/satcss/traces/.gitignore
@@ -1,2 +1,3 @@
 *
+!dune
 !.gitignore

--- a/test/interop/satcss/traces/dune
+++ b/test/interop/satcss/traces/dune
@@ -1,0 +1,9 @@
+(rule
+ (alias regen)
+ (mode promote)
+ (enabled_if
+  (= %{env:REGEN=0} 1))
+ (deps
+  (source_tree ../scripts))
+ (action
+  (run ../scripts/generate.sh .)))


### PR DESCRIPTION
The regen rule for the SatCSS oracle existed only as a local file: traces/.gitignore swallowed traces/dune, so a fresh checkout had no regen alias and merlint's pre-commit gate failed on every commit. This PR tracks the rule, keeps the corpus itself ignored, and retires the old `regen-traces` alias so `REGEN=1 dune build @regen` is the single trigger. Split out of #190.