### PR TITLE
media: parse the function form of <general-enclosed>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,10 @@
 - Add `Css.Values.oklch_none_hue` to build achromatic colours with a
   missing hue component, printed as `oklch(55.6% 0 none)` per CSS
   Color 4 (#190)
+- Parse the function form of `<general-enclosed>` in media queries, so a
+  grammatical but unrecognised query such as `theme(static)` is kept as
+  never-matching instead of discarding the `@media` block or
+  `@import` (#192)
 
 ## 1.0.0
 

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -10,6 +10,7 @@ let media_feature_is name (f : Media.feature) =
   | Media.Plain (n, _) | Media.Boolean n -> n = name
   | Media.Range (n, _, _) | Media.Range_rev (_, _, n) -> n = name
   | Media.Interval (_, _, n, _, _) -> n = name
+  | Media.General_enclosed _ -> false
 
 let rec condition_has_feature name (c : Media.condition) =
   match c with

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -1475,6 +1475,9 @@ module Match_media = struct
       | Some actual -> Option.value ~default:false (f actual)
     in
     function
+    (* Media Queries 4 3.1: an unrecognised <general-enclosed> is [unknown], and
+       unknown becomes false where a boolean is expected. *)
+    | General_enclosed _ -> false
     | Boolean name -> feature_present table name
     | Plain (name, value) -> (
         match strip_min_max name with

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -753,6 +753,7 @@ let refs_of_media_feature : Media.feature -> string list = function
       refs_of_media_value value
   | Interval (lower, _, _, _, upper) ->
       refs_of_media_value lower @ refs_of_media_value upper
+  | General_enclosed _ -> []
 
 let rec refs_of_media_condition : Media.condition -> string list = function
   | Feature f -> refs_of_media_feature f

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -122,6 +122,10 @@ type feature =
   | Range of name * cmp * value
   | Range_rev of value * cmp * name
   | Interval of value * cmp * name * cmp * value
+  | General_enclosed of string
+      (** Media Queries 4 Â§3.1 [<general-enclosed>]: a grammatical but
+          unrecognised query, kept verbatim. Its result is [unknown], which
+          becomes false wherever a boolean is expected. *)
 
 type condition =
   | Feature of feature
@@ -365,6 +369,7 @@ let pp_value : value Pp.t =
 
 let pp_feature : feature Pp.t =
  fun ctx -> function
+  | General_enclosed raw -> Pp.string ctx raw
   | Plain (name, value) when Pp.minified ctx ->
       Pp.char ctx '(';
       Pp.string ctx (string_of_name name);
@@ -1021,7 +1026,23 @@ and condition_in_parens sc =
   | Some '(' ->
       advance sc;
       condition_from_paren_content (read_balanced sc)
-  | _ -> failwith "expected '(' in media condition"
+  | _ -> (
+      (* Media Queries 4 §3.1: [<media-in-parens>] also admits
+         [<general-enclosed>], whose first form is a function token. An
+         identifier immediately followed by [(] is one, e.g. [theme(static)]:
+         grammatical, unrecognised, and therefore false. Rejecting it here made
+         a valid query look malformed and cost the whole rule. *)
+      let mark = sc.pos in
+      let id = read_ident sc in
+      match (id, peek sc) with
+      | "", _ | _, None -> failwith "expected '(' in media condition"
+      | _, Some '(' ->
+          advance sc;
+          let args = read_balanced sc in
+          Feature (General_enclosed (String.concat "" [ id; "("; args; ")" ]))
+      | _ ->
+          sc.pos <- mark;
+          failwith "expected '(' in media condition")
 
 and condition_of_string s =
   let sc = mk_scanner s in
@@ -1078,11 +1099,44 @@ let rec next_non_ws s len i : char option =
 
 (* [<media-query>] starts as [<media-condition>] (rather than as a media type)
    when its first non-space token is '(' or "not (". *)
+(* An identifier glued to a [(] is a function token, so the query is a
+   [<general-enclosed>] condition rather than a media type. Without this
+   [theme(static)] is read as the media type [theme] and then trips on the
+   parenthesis. *)
+let function_token_at s pos =
+  let len = String.length s in
+  let rec ident_end i =
+    if i < len then
+      match s.[i] with
+      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> ident_end (i + 1)
+      | _ -> i
+    else i
+  in
+  let stop = ident_end pos in
+  stop > pos && stop < len && s.[stop] = '('
+
+(* [<media-in-parens>] starts a condition either with [(] or, for the
+   [<general-enclosed>] function form, with an identifier glued to a [(]. [not]
+   takes a [<media-in-parens>] too, so it accepts both shapes. *)
+let starts_with_media_in_parens s pos =
+  match next_non_ws s (String.length s) pos with
+  | Some '(' -> true
+  | _ ->
+      let len = String.length s in
+      let rec skip i =
+        if
+          i < len
+          && (s.[i] = ' ' || s.[i] = '\t' || s.[i] = '\n' || s.[i] = '\r')
+        then skip (i + 1)
+        else i
+      in
+      function_token_at s (skip pos)
+
 let starts_with_condition sc =
   match (peek sc, lookahead_ident sc "not") with
   | Some '(', _ -> true
-  | _, true -> next_non_ws sc.s (String.length sc.s) (sc.pos + 3) = Some '('
-  | _ -> false
+  | _, true -> starts_with_media_in_parens sc.s (sc.pos + 3)
+  | _ -> function_token_at sc.s sc.pos
 
 let read_query_prefix sc =
   if lookahead_ident sc "not" then (
@@ -1363,7 +1417,7 @@ let feature_kind (f : feature) : kind =
           | Plain (name, value) -> plain_feature_kind name value
           | Boolean name -> Option.value (preference_kind name) ~default:Other
           | Interval (lo, _, name, _, _) -> interval_feature_kind name lo
-          | Range _ | Range_rev _ -> Other))
+          | Range _ | Range_rev _ | General_enclosed _ -> Other))
 
 let rec condition_kind (c : condition) : kind =
   match c with

--- a/lib/media.mli
+++ b/lib/media.mli
@@ -102,6 +102,10 @@ type feature =
   | Range of name * cmp * value
   | Range_rev of value * cmp * name
   | Interval of value * cmp * name * cmp * value
+  | General_enclosed of string
+      (** Media Queries 4 Â§3.1 [<general-enclosed>]: a grammatical but
+          unrecognised query, kept verbatim. Its result is [unknown], which
+          becomes false wherever a boolean is expected. *)
 
 type condition =
   | Feature of feature

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1496,15 +1496,30 @@ let read_import_supports (r : Cursor.t) =
         Error.fail_bad_condition loc ~at_rule:"@supports" ~reason)
     r
 
+(* In the [@import] prelude [layer(...)] and [supports(...)] are structural, and
+   the grammar allows each once, before the media query list. Reaching the media
+   position still holding one means a duplicate or a misordered prelude. They
+   are function tokens, so the media grammar would otherwise take them as a
+   [<general-enclosed>] query and quietly accept the rule. *)
+let starts_with_import_keyword raw =
+  let lower = String.lowercase_ascii raw in
+  List.exists
+    (fun k -> String.starts_with ~prefix:k lower)
+    [ "layer("; "supports("; "layer " ]
+
 let read_import_media (r : Cursor.t) : Media.t option =
   if Cursor.peek_semicolon r || Cursor.is_done r then None
   else
     let loc = Cursor.position r in
     let raw = Cursor.consume_until_semicolon ~trim:true r in
-    match Media.of_string_strict raw with
-    | media -> Some media
-    | exception Failure reason ->
-        Error.fail_bad_condition loc ~at_rule:"@media" ~reason
+    if starts_with_import_keyword raw then
+      Error.fail_bad_condition loc ~at_rule:"@media"
+        ~reason:"layer()/supports() must precede the media query, and once only"
+    else
+      match Media.of_string_strict raw with
+      | media -> Some media
+      | exception Failure reason ->
+          Error.fail_bad_condition loc ~at_rule:"@media" ~reason
 
 let read_import_prelude ~keep_url_repr (r : Cursor.t) : import_rule =
   Cursor.expect_at_keyword "import" r;

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -231,6 +231,53 @@ let spec_media_query_vectors () =
         (to_string (of_string row.input)))
     Cascade_spec_inventory.Query_grammar.media_positive
 
+(* Media Queries 4 3.1 [<general-enclosed>]: both the [<function-token>] form
+   and the [( <any-value> )] form are grammatical. An unrecognised one is
+   [unknown], which becomes false where a boolean is expected, so the query
+   never matches -- but the rule itself is valid and must survive parsing
+   verbatim. Rejecting it as malformed costs the whole rule. *)
+let general_enclosed_roundtrip () =
+  let check src = Alcotest.(check string) src src (to_string (of_string src)) in
+  (* function-token form *)
+  check "theme(static)";
+  check "foo(bar)";
+  check "unknown-fn(1 2 3)";
+  check "supports-something(a: b)";
+  (* nested parentheses inside the arguments *)
+  check "foo(bar(baz))";
+  (* the ( <ident> ... ) form already parsed; keep it covered *)
+  check "(unknown-feature: 1)";
+  check "(unknown-boolean)"
+
+let general_enclosed_in_context () =
+  let check src = Alcotest.(check string) src src (to_string (of_string src)) in
+  (* negated, listed and combined with a real query *)
+  check "not theme(static)";
+  check "screen and theme(static)";
+  check "theme(static), print";
+  check "print, theme(static)";
+  (* [<media-and>] takes a [<media-in-parens>], so a bare media type cannot
+     follow [and]: that is malformed and becomes [not all], unlike the
+     grammatical forms above. *)
+  Alcotest.(check string)
+    "condition and media type is malformed" "not all"
+    (to_string (of_string "theme(static) and screen"))
+
+(* A function token must not be mistaken for a media type: [theme(static)] is a
+   condition, where [theme] alone would be a type. *)
+let general_enclosed_is_not_a_media_type () =
+  Alcotest.(check string)
+    "bare ident stays a media type" "theme"
+    (to_string (of_string "theme"));
+  Alcotest.(check string)
+    "function token is a condition" "theme(static)"
+    (to_string (of_string "theme(static)"));
+  (* real media types and features keep working *)
+  Alcotest.(check string) "screen" "screen" (to_string (of_string "screen"));
+  Alcotest.(check string)
+    "print and feature" "print and (min-width: 30em)"
+    (to_string (of_string "print and (min-width: 30em)"))
+
 let suite =
   let open Alcotest in
   ( "media",
@@ -250,4 +297,8 @@ let suite =
         spec_media_context_vectors;
       test_case "spec media query boolean and range vectors" `Quick
         spec_media_query_vectors;
+      test_case "general-enclosed roundtrip" `Quick general_enclosed_roundtrip;
+      test_case "general-enclosed in context" `Quick general_enclosed_in_context;
+      test_case "general-enclosed is not a media type" `Quick
+        general_enclosed_is_not_a_media_type;
     ] )


### PR DESCRIPTION
Media Queries 4 §3.1 allows `<function-token> <any-value>? )` as a `<general-enclosed>`, not just the `( <any-value> )` form cascade already took. So `theme(static)` is grammatical — unknown, hence false — but cascade read the identifier as a media type, tripped on the paren, and discarded the whole `@media` block or `@import`. Found on tailwindcss.com, whose entrypoint opens `@import "tailwindcss" theme(static);`.

The `@import` prelude still rejects a `layer()`/`supports()` reaching the media position: allowed once, ahead of the query, so one there is a duplicate.