### PR TITLE
stylesheet: parse nested rules starting with an identifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@
 - `cascade apply` projects rules inside `@layer` onto elements; a fully
   layered stylesheet (such as Tailwind v4 output) previously inlined
   nothing (#188)
+- Parse a nested rule whose selector starts with an identifier, such as
+  `h2:where(...)`. CSS Nesting 1 makes that prelude ambiguous with a
+  declaration until the block appears, and the rule was dropped with a
+  warning (#193)
 - Add `Css.Values.oklch_none_hue` to build achromatic colours with a
   missing hue component, printed as `oklch(55.6% 0 none)` per CSS
   Color 4 (#190)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2980,6 +2980,24 @@ let read_property_rule (r : Cursor.t) : statement =
       in
       Property { name; syntax; inherits; initial_value }
 
+(* Does the item ahead hold a curly block before its terminating [;]? Then it is
+   a nested rule, not a declaration, however much its prelude looks like one.
+   Leaves the cursor where it found it. *)
+let item_opens_block inner =
+  let start = Cursor.save inner in
+  let rec scan () =
+    match Cursor.peek inner with
+    | None -> false
+    | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> false
+    | Some (Component.Block { node = { opening = Token.Curly; _ }; _ }) -> true
+    | Some _ ->
+        Cursor.skip inner;
+        scan ()
+  in
+  let found = scan () in
+  Cursor.restore inner start;
+  found
+
 let rec read_statement (r : Cursor.t) : statement =
   Cursor.ws r;
   let table : (string * (Cursor.t -> statement)) list =
@@ -3367,12 +3385,21 @@ and read_rule_item selector inner decls nested =
   | _ -> read_rule_decl_or_nested selector inner decls nested
 
 and read_rule_decl_or_nested selector inner decls nested =
+  let start = Cursor.save inner in
   match Declaration.read_declaration inner with
   | Some d ->
       Cursor.ws inner;
       if Cursor.peek_semicolon inner then Cursor.skip inner;
       `Continue (d :: decls, nested)
   | None -> read_nested_rule_or_done selector inner decls nested
+  (* CSS Nesting 1 §2 lets a nested rule start with an identifier, so
+     [h2:where(...) { ... }] reads as a declaration up to the [{]. Rewind and
+     take it as a rule; a genuine bad declaration has no block and still reports
+     as one. *)
+  | exception Error.Parse_error _
+    when Cursor.restore inner start;
+         item_opens_block inner ->
+      read_nested_rule_or_done selector inner decls nested
 
 and read_nested_rule_or_done selector inner decls nested =
   if Cursor.is_done inner then `Done (List.rev decls, List.rev nested)

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -39,6 +39,37 @@ let test_empty_block_is_empty () =
     "empty input yields empty output" 0
     (List.length (Flatten.block stmts))
 
+(* CSS Nesting 1 §2 lets a nested rule start with an identifier, so its prelude
+   is ambiguous with a declaration until the block appears: [h2:where(...)]
+   reads as the property [h2] with value [where(...)]. Parsing has to fall back
+   to a rule, or the whole nested block is dropped. *)
+let test_nested_rule_starting_with_ident () =
+  let check src expected =
+    Alcotest.(check string) src expected (render (block src))
+  in
+  (* the shape that motivated this: element + pseudo-class *)
+  check ".a{color:red;h2:where(:not(.x)){font-size:1px}}"
+    ".a{color:red;h2:where(:not(.x)){font-size:1px}}";
+  (* a bare element with a pseudo-class, and a pseudo-element *)
+  check ".a{p:hover{color:red}}" ".a{p:hover{color:red}}";
+  (* minify canonicalises the legacy one-colon form, as it does at top level *)
+  check ".a{li::before{color:red}}" ".a{li:before{color:red}}";
+  (* several in a row, after and between declarations *)
+  check ".a{color:red;h2:hover{width:1px}h3:hover{width:2px};height:2px}"
+    ".a{color:red;height:2px;h2:hover{width:1px}h3:hover{width:2px}}";
+  (* the shapes that already worked must keep working *)
+  check ".a{&:hover{color:red}}" ".a{&:hover{color:red}}";
+  check ".a{.b{color:red}}" ".a{.b{color:red}}";
+  check ".a{h2+h3{color:red}}" ".a{h2+h3{color:red}}"
+
+(* A declaration that is merely invalid has no block, so it still reports as a
+   bad declaration rather than being retried as a selector. *)
+let test_bad_declaration_still_a_declaration () =
+  let stmts = block ".a{color:;width:1px}" in
+  Alcotest.(check string)
+    "the invalid declaration drops, the good one stays" ".a{width:1px}"
+    (render stmts)
+
 let suite =
   ( "flatten",
     [
@@ -48,4 +79,8 @@ let suite =
         test_flattens_descendant_nesting;
       Alcotest.test_case "empty block stays empty" `Quick
         test_empty_block_is_empty;
+      Alcotest.test_case "nested rule starting with an ident" `Quick
+        test_nested_rule_starting_with_ident;
+      Alcotest.test_case "bad declaration stays a declaration" `Quick
+        test_bad_declaration_still_a_declaration;
     ] )


### PR DESCRIPTION
A nested rule whose selector starts with an identifier, such as `h2:where(:not(.x)) { ... }`, was dropped with a "curly block in declaration value" warning: CSS Nesting 1 makes that prelude ambiguous with a declaration until the block appears, and the declaration parser raised rather than letting the existing nested-rule fallback run. Parsing now rewinds and retries as a rule when a block follows, so a declaration that is merely invalid still reports as one.

Found against the Tailwind typography stylesheet, where cascade parsed 2 of its 47 blocks.