### PR TITLE
nest: wrap a complex parent in :is() when substituting &

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,10 @@
   `h2:where(...)`. CSS Nesting 1 makes that prelude ambiguous with a
   declaration until the block appears, and the rule was dropped with a
   warning (#193)
+- Wrap a complex parent selector in `:is()` when substituting `&`, per
+  CSS Nesting 1. Flattening `.a .b { .dark & { ... } }` produced
+  `.dark .a .b`, which matches a different set of elements than
+  `.dark :is(.a .b)` (#194)
 - Add `Css.Values.oklch_none_hue` to build achromatic colours with a
   missing hue component, printed as `oklch(55.6% 0 none)` per CSS
   Color 4 (#190)

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -3,13 +3,43 @@ open Stylesheet
 let contains sel =
   Selector.any (function Selector.Nesting -> true | _ -> false) sel
 
-let substitute ~parent sel =
+(* CSS Nesting 1 sec. 2.1: [&] stands for [:is(<parent selector list>)]. A
+   parent that carries a combinator or lists alternatives needs that wrapper, or
+   its own structure escapes: dropping it turns [.dark &] over parent [.a .b]
+   into [.dark .a .b], which demands that [.a] itself sit inside [.dark]. Where
+   [&] heads the selector nothing can escape to its left, so the wrapper is
+   redundant there and the parent goes in verbatim. *)
+let complex = function
+  | Selector.List _ | Selector.Combined _ | Selector.Relative _ -> true
+  | _ -> false
+
+let count_nesting sel =
+  let n = ref 0 in
+  ignore
+    (Selector.any
+       (fun s ->
+         (match s with Selector.Nesting -> incr n | _ -> ());
+         false)
+       sel);
+  !n
+
+let rec heads = function
+  | Selector.Nesting -> true
+  | Selector.Compound (x :: _) -> heads x
+  | Selector.Combined (l, _, _) -> heads l
+  | _ -> false
+
+let substitute ?(leftmost = true) ~parent sel =
+  let verbatim =
+    (not (complex parent)) || (leftmost && heads sel && count_nesting sel = 1)
+  in
+  let parent = if verbatim then parent else Selector.Is [ parent ] in
   Selector.map (function Selector.Nesting -> parent | s -> s) sel
 
 let combine parent child =
   match child with
   | Selector.Relative (comb, right) ->
-      Selector.Combined (parent, comb, substitute ~parent right)
+      Selector.Combined (parent, comb, substitute ~leftmost:false ~parent right)
   | _ when contains child -> substitute ~parent child
   | _ -> Selector.Combined (parent, Selector.Descendant, child)
 

--- a/lib/nest.mli
+++ b/lib/nest.mli
@@ -3,7 +3,7 @@
 val contains : Selector.t -> bool
 (** [contains selector] is [true] when [selector] contains [&]. *)
 
-val substitute : parent:Selector.t -> Selector.t -> Selector.t
+val substitute : ?leftmost:bool -> parent:Selector.t -> Selector.t -> Selector.t
 (** Replace every [&] in a selector with [parent]. *)
 
 val combine : Selector.t -> Selector.t -> Selector.t

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3407,7 +3407,7 @@ and read_rule_decl_or_nested selector inner decls nested =
       if Cursor.peek_semicolon inner then Cursor.skip inner;
       `Continue (d :: decls, nested)
   | None -> read_nested_rule_or_done selector inner decls nested
-  (* CSS Nesting 1 §2 lets a nested rule start with an identifier, so
+  (* CSS Nesting 1 sec. 2 lets a nested rule start with an identifier, so
      [h2:where(...) { ... }] reads as a declaration up to the [{]. Rewind and
      take it as a rule; a genuine bad declaration has no block and still reports
      as one. *)

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -39,10 +39,10 @@ let test_empty_block_is_empty () =
     "empty input yields empty output" 0
     (List.length (Flatten.block stmts))
 
-(* CSS Nesting 1 §2 lets a nested rule start with an identifier, so its prelude
-   is ambiguous with a declaration until the block appears: [h2:where(...)]
-   reads as the property [h2] with value [where(...)]. Parsing has to fall back
-   to a rule, or the whole nested block is dropped. *)
+(* CSS Nesting 1 sec. 2 lets a nested rule start with an identifier, so its
+   prelude is ambiguous with a declaration until the block appears:
+   [h2:where(...)] reads as the property [h2] with value [where(...)]. Parsing
+   has to fall back to a rule, or the whole nested block is dropped. *)
 let test_nested_rule_starting_with_ident () =
   let check src expected =
     Alcotest.(check string) src expected (render (block src))
@@ -70,6 +70,27 @@ let test_bad_declaration_still_a_declaration () =
     "the invalid declaration drops, the good one stays" ".a{width:1px}"
     (render stmts)
 
+(* CSS Nesting 1 sec. 2.1: [&] stands for [:is(<parent selector list>)]. The
+   wrapper is load-bearing whenever the parent carries a combinator and [&] does
+   not head the selector, since the parent's own structure would otherwise
+   escape into the surrounding context. *)
+let test_nesting_wraps_complex_parent () =
+  let check src expected =
+    Alcotest.(check string) src expected (render (Flatten.block (block src)))
+  in
+  (* without the wrapper this reads as ".dark .a .b", which additionally demands
+     that ".a" sit inside ".dark" *)
+  check ".a .b{.dark &{color:red}}" ".dark :is(.a .b){color:red}";
+  (* [&] in the middle, and [&] appended to a compound, escape the same way *)
+  check ".a .b{.x & .y{color:red}}" ".x :is(.a .b) .y{color:red}";
+  check ".a .b{.foo&{color:red}}" ".foo:is(.a .b){color:red}";
+  (* a parent with no combinator matches and scores the same either way, so it
+     goes in verbatim *)
+  check ".a{.dark &{color:red}}" ".dark .a{color:red}";
+  (* nothing can escape to the left of a leading [&], so no wrapper there *)
+  check ".a .b{&:hover{color:red}}" ".a .b:hover{color:red}";
+  check ".a .b{& .c{color:red}}" ".a .b .c{color:red}"
+
 let suite =
   ( "flatten",
     [
@@ -83,4 +104,6 @@ let suite =
         test_nested_rule_starting_with_ident;
       Alcotest.test_case "bad declaration stays a declaration" `Quick
         test_bad_declaration_still_a_declaration;
+      Alcotest.test_case "nesting wraps a complex parent" `Quick
+        test_nesting_wraps_complex_parent;
     ] )


### PR DESCRIPTION
CSS Nesting 1 (sec. 2.1) makes `&` equivalent to `:is()` of the parent selector list. Cascade substituted the parent verbatim, so flattening `.a .b { .dark & { ... } }` produced `.dark .a .b`, which additionally requires `.a` to sit inside `.dark` and so matches a different set of elements than `.dark :is(.a .b)`.

The wrapper is added only where it changes meaning: a parent with no combinator, or a `&` heading the selector, still goes in verbatim.