### PR TITLE
drop unicode characters in source files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,6 +18,25 @@ set -eu
 STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ml|mli|mll|mly)$' || true)
 [ -n "$STAGED" ] || exit 0
 
+# 0. ASCII only. Source stays 7-bit: write "sec." not the section sign, "--"
+#    not the em dash, and \u{XXXX} escapes for a glyph a string must emit
+#    (e.g. the diff tree connectors). Checks the staged content, not the
+#    worktree.
+NONASCII=""
+for f in $STAGED; do
+    if git show ":$f" | LC_ALL=C grep -n '[^[:print:][:cntrl:]]' >/dev/null 2>&1; then
+        NONASCII="$NONASCII $f"
+    fi
+done
+if [ -n "$NONASCII" ]; then
+    echo "error: non-ASCII byte in staged OCaml source:" >&2
+    for f in $NONASCII; do
+        git show ":$f" | LC_ALL=C grep -n '[^[:print:][:cntrl:]]' | sed "s|^|  $f:|" >&2
+    done
+    echo "use ASCII in comments and \\u{XXXX} escapes in string literals." >&2
+    exit 1
+fi
+
 # 1. dune fmt
 if ! dune fmt 2>/dev/null; then
     echo "error: dune fmt failed" >&2

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -1,4 +1,4 @@
-(** CSS parser fuzz tests — main entry point.
+(** CSS parser fuzz tests -- main entry point.
 
     Registers all fuzz test modules and runs them with Alcobar. *)
 

--- a/fuzz/fuzz_font_face.ml
+++ b/fuzz/fuzz_font_face.ml
@@ -23,22 +23,22 @@ let parse_src input =
   try Some (Css.Font_face.src_of_string input)
   with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> None
 
-(** metric_override_of_string — must not crash. *)
+(** metric_override_of_string -- must not crash. *)
 let test_metric_override buf =
   try ignore (Css.Font_face.metric_override_of_string buf)
   with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> ()
 
-(** size_adjust_of_string — must not crash. *)
+(** size_adjust_of_string -- must not crash. *)
 let test_size_adjust buf =
   try ignore (Css.Font_face.size_adjust_of_string buf)
   with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> ()
 
-(** src_of_string — must not crash. *)
+(** src_of_string -- must not crash. *)
 let test_src buf =
   try ignore (Css.Font_face.src_of_string buf)
   with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> ()
 
-(** metric_override roundtrip: parse → to_string → parse. *)
+(** metric_override roundtrip: parse -> to_string -> parse. *)
 let test_metric_override_roundtrip buf =
   match parse_metric buf with
   | None -> ()
@@ -48,7 +48,7 @@ let test_metric_override_roundtrip buf =
       with Reader.Parse_error _ | Invalid_argument _ | Failure _ ->
         fail "metric_override roundtrip failed")
 
-(** src roundtrip: parse → to_string → parse. *)
+(** src roundtrip: parse -> to_string -> parse. *)
 let test_src_roundtrip buf =
   match parse_src buf with
   | None -> ()

--- a/fuzz/fuzz_inline.ml
+++ b/fuzz/fuzz_inline.ml
@@ -69,12 +69,12 @@ let test_layer_placement_invariant buf =
         failf "layer placement changed inlining: unlayered %S vs layered %S" r l
   | _ -> ()
 
-(* CSS Cascade 5 §6.4.2: for normal declarations an unlayered definition beats
-   every layered one, whatever the layers or their order. A variable defined on
-   [:root] across a stack of named layers plus one unlayered definition must
-   therefore fold to the unlayered value. Independent of how the winner is
-   computed, so it catches a wrong winner (e.g. picking the last document
-   order). *)
+(* CSS Cascade 5 sec. 6.4.2: for normal declarations an unlayered definition
+   beats every layered one, whatever the layers or their order. A variable
+   defined on [:root] across a stack of named layers plus one unlayered
+   definition must therefore fold to the unlayered value. Independent of how the
+   winner is computed, so it catches a wrong winner (e.g. picking the last
+   document order). *)
 let test_unlayered_definition_wins buf =
   let n = 1 + (byte_at buf 0 mod 3) in
   let vals = [ "1px"; "2px"; "3px"; "4px" ] in

--- a/fuzz/fuzz_keyframe.ml
+++ b/fuzz/fuzz_keyframe.ml
@@ -5,17 +5,17 @@
 open Cascade
 open Alcobar
 
-(** position_of_string — must not crash. *)
+(** position_of_string -- must not crash. *)
 let test_position buf = ignore (Css.Keyframe.position_of_string buf)
 
-(** selector_of_string — must reject invalid selectors without unexpected
+(** selector_of_string -- must reject invalid selectors without unexpected
     exceptions. *)
 let test_selector buf =
   match Css.Keyframe.selector_of_string buf with
   | _ -> ()
   | exception Invalid_argument _ -> ()
 
-(** position roundtrip: parse → to_string → parse. *)
+(** position roundtrip: parse -> to_string -> parse. *)
 let test_position_roundtrip buf =
   match Css.Keyframe.position_of_string buf with
   | None -> ()
@@ -27,7 +27,7 @@ let test_position_roundtrip buf =
           if Css.Keyframe.position_compare pos pos2 <> 0 then
             fail "position roundtrip mismatch")
 
-(** selector roundtrip: parse → to_string → parse. *)
+(** selector roundtrip: parse -> to_string -> parse. *)
 let test_selector_roundtrip buf =
   match Css.Keyframe.selector_of_string buf with
   | exception Invalid_argument _ -> ()
@@ -69,7 +69,7 @@ let test_position_serialization_idempotent buf =
           let twice = Css.Keyframe.string_of_position pos2 in
           if once <> twice then fail "keyframe position serialization drifted")
 
-(** position_compare — must not crash on any valid pair. *)
+(** position_compare -- must not crash on any valid pair. *)
 let test_position_compare buf1 buf2 =
   match
     (Css.Keyframe.position_of_string buf1, Css.Keyframe.position_of_string buf2)

--- a/fuzz/fuzz_reader.ml
+++ b/fuzz/fuzz_reader.ml
@@ -5,58 +5,58 @@
 open Cascade
 open Alcobar
 
-(** Reader.of_string + is_done — must not crash. *)
+(** Reader.of_string + is_done -- must not crash. *)
 let test_of_string buf =
   let r = Reader.of_string buf in
   ignore (Reader.is_done r)
 
-(** Reader.ident — must not crash on arbitrary input. *)
+(** Reader.ident -- must not crash on arbitrary input. *)
 let test_ident buf =
   let r = Reader.of_string buf in
   try ignore (Reader.ident r) with Reader.Parse_error _ -> ()
 
-(** Reader.token — must not crash. *)
+(** Reader.token -- must not crash. *)
 let test_token buf =
   let r = Reader.of_string buf in
   try ignore (Reader.token r) with Reader.Parse_error _ -> ()
 
-(** Reader.number — must not crash. *)
+(** Reader.number -- must not crash. *)
 let test_number buf =
   let r = Reader.of_string buf in
   try ignore (Reader.number r) with Reader.Parse_error _ -> ()
 
-(** Reader.int — must not crash. *)
+(** Reader.int -- must not crash. *)
 let test_int buf =
   let r = Reader.of_string buf in
   try ignore (Reader.int r) with Reader.Parse_error _ -> ()
 
-(** Reader.string — must not crash (quoted string parser). *)
+(** Reader.string -- must not crash (quoted string parser). *)
 let test_string buf =
   let r = Reader.of_string buf in
   try ignore (Reader.string r) with Reader.Parse_error _ -> ()
 
-(** Reader.hex — must not crash. *)
+(** Reader.hex -- must not crash. *)
 let test_hex buf =
   let r = Reader.of_string buf in
   try ignore (Reader.hex r) with Reader.Parse_error _ -> ()
 
-(** Reader.css_value — must not crash. *)
+(** Reader.css_value -- must not crash. *)
 let test_css_value buf =
   let r = Reader.of_string buf in
   try ignore (Reader.css_value ~stops:[ ';'; '}' ] r)
   with Reader.Parse_error _ -> ()
 
-(** Reader.url — must not crash. *)
+(** Reader.url -- must not crash. *)
 let test_url buf =
   let r = Reader.of_string buf in
   try ignore (Reader.url r) with Reader.Parse_error _ -> ()
 
-(** Reader.bool — must not crash. *)
+(** Reader.bool -- must not crash. *)
 let test_bool buf =
   let r = Reader.of_string buf in
   try ignore (Reader.bool r) with Reader.Parse_error _ -> ()
 
-(** Reader.pct — must not crash. *)
+(** Reader.pct -- must not crash. *)
 let test_pct buf =
   let r = Reader.of_string buf in
   try ignore (Reader.pct r) with Reader.Parse_error _ -> ()

--- a/fuzz/fuzz_selector.ml
+++ b/fuzz/fuzz_selector.ml
@@ -38,40 +38,40 @@ let assert_reject input =
   | None -> ()
   | Some sel -> failf "selector should reject: %S -> %S" input (minified sel)
 
-(** Selector.of_string — must not crash on arbitrary input. *)
+(** Selector.of_string -- must not crash on arbitrary input. *)
 let test_of_string buf =
   try ignore (Css.Selector.of_string buf) with
   | Cursor.Parse_error _ -> ()
   | Invalid_argument _ -> ()
 
-(** Selector.read — must not crash. *)
+(** Selector.read -- must not crash. *)
 let test_read buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Selector.read r) with Cursor.Parse_error _ -> ()
 
-(** Selector.read_selector_list — must not crash. *)
+(** Selector.read_selector_list -- must not crash. *)
 let test_read_selector_list buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Selector.read_selector_list r)
   with Cursor.Parse_error _ -> ()
 
-(** Selector.read_combinator — must not crash. *)
+(** Selector.read_combinator -- must not crash. *)
 let test_read_combinator buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Selector.read_combinator r) with Cursor.Parse_error _ -> ()
 
-(** Selector.read_attribute_match — must not crash. *)
+(** Selector.read_attribute_match -- must not crash. *)
 let test_read_attribute_match buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Selector.read_attribute_match r)
   with Cursor.Parse_error _ -> ()
 
-(** Selector.read_nth — must not crash. *)
+(** Selector.read_nth -- must not crash. *)
 let test_read_nth buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Selector.read_nth r) with Cursor.Parse_error _ -> ()
 
-(** Roundtrip: parse → to_string → parse should not crash. *)
+(** Roundtrip: parse -> to_string -> parse should not crash. *)
 let test_roundtrip buf =
   match
     try Some (Css.Selector.of_string buf)
@@ -84,7 +84,7 @@ let test_roundtrip buf =
       with Cursor.Parse_error _ | Invalid_argument _ ->
         fail "roundtrip re-parse crashed")
 
-(** pp — must not crash on any parsed selector. *)
+(** pp -- must not crash on any parsed selector. *)
 let test_pp buf =
   match
     try Some (Css.Selector.of_string buf)

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -592,59 +592,59 @@ let anonymous_layer_count ss =
   and block_count block = List.fold_left (fun n s -> n + statement s) 0 block in
   block_count ss
 
-(** read_stylesheet — must not crash on arbitrary input. *)
+(** read_stylesheet -- must not crash on arbitrary input. *)
 let test_read_stylesheet buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Stylesheet.read_stylesheet r)
   with Cursor.Parse_error _ -> ()
 
-(** read_rule — must not crash. *)
+(** read_rule -- must not crash. *)
 let test_read_rule buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Stylesheet.read_rule r)
   with Cursor.Parse_error _ | Invalid_argument _ -> ()
 
-(** read_block — must not crash. *)
+(** read_block -- must not crash. *)
 let test_read_block buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Stylesheet.read_block r) with Cursor.Parse_error _ -> ()
 
-(** read (legacy) — must not crash. *)
+(** read (legacy) -- must not crash. *)
 let test_read buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Stylesheet.read r) with Cursor.Parse_error _ -> ()
 
-(** read_import_rule — must not crash. *)
+(** read_import_rule -- must not crash. *)
 let test_read_import_rule buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Stylesheet.read_import_rule r)
   with Cursor.Parse_error _ -> ()
 
-(** read_declaration — must not crash. *)
+(** read_declaration -- must not crash. *)
 let test_read_declaration buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Declaration.read_declaration r)
   with Cursor.Parse_error _ -> ()
 
-(** read_declarations — must not crash. *)
+(** read_declarations -- must not crash. *)
 let test_read_declarations buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Declaration.read_declarations r)
   with Cursor.Parse_error _ -> ()
 
-(** read_property_name — must not crash. *)
+(** read_property_name -- must not crash. *)
 let test_read_property_name buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Declaration.read_property_name r)
   with Cursor.Parse_error _ -> ()
 
-(** read_property_value — must not crash. *)
+(** read_property_value -- must not crash. *)
 let test_read_property_value buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Declaration.read_property_value r)
   with Cursor.Parse_error _ -> ()
 
-(** Stylesheet roundtrip: parse → to_string → parse should not crash. *)
+(** Stylesheet roundtrip: parse -> to_string -> parse should not crash. *)
 let test_stylesheet_roundtrip buf =
   let r = Cursor.of_string buf in
   match

--- a/fuzz/fuzz_supports.ml
+++ b/fuzz/fuzz_supports.ml
@@ -17,11 +17,11 @@ let rec supports_of_expected = function
   | Supports_inventory.Or (left, right) ->
       Css.Supports.Or (supports_of_expected left, supports_of_expected right)
 
-(** Supports.of_string — must not crash on arbitrary input. *)
+(** Supports.of_string -- must not crash on arbitrary input. *)
 let test_of_string buf =
   try ignore (Css.Supports.of_string buf) with Cursor.Parse_error _ -> ()
 
-(** Roundtrip: parse → to_string → parse should not crash. *)
+(** Roundtrip: parse -> to_string -> parse should not crash. *)
 let test_roundtrip buf =
   match
     try Some (Css.Supports.of_string buf) with Cursor.Parse_error _ -> None
@@ -67,7 +67,7 @@ let test_mixed_operator_serialization_reparse buf =
         fail "mixed and/or supports serialization did not reparse"
   | _ -> ()
 
-(** pp — must not crash on any parsed condition. *)
+(** pp -- must not crash on any parsed condition. *)
 let test_pp buf =
   match
     try Some (Css.Supports.of_string buf) with Cursor.Parse_error _ -> None
@@ -75,7 +75,7 @@ let test_pp buf =
   | None -> ()
   | Some cond -> ignore (Css.Supports.to_string cond)
 
-(** compare — must not crash on any pair of parsed conditions. *)
+(** compare -- must not crash on any pair of parsed conditions. *)
 let test_compare buf1 buf2 =
   match
     ( (try Some (Css.Supports.of_string buf1) with Cursor.Parse_error _ -> None),

--- a/fuzz/fuzz_values.ml
+++ b/fuzz/fuzz_values.ml
@@ -14,112 +14,112 @@ let parse_whole parse input =
     if Cursor.is_done r then Some value else None
   with Cursor.Parse_error _ -> None
 
-(** read_color — must not crash on arbitrary input. *)
+(** read_color -- must not crash on arbitrary input. *)
 let test_read_color buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_color r) with Cursor.Parse_error _ -> ()
 
-(** read_length — must not crash. *)
+(** read_length -- must not crash. *)
 let test_read_length buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_length r) with Cursor.Parse_error _ -> ()
 
-(** read_angle — must not crash. *)
+(** read_angle -- must not crash. *)
 let test_read_angle buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_angle r) with Cursor.Parse_error _ -> ()
 
-(** read_duration — must not crash. *)
+(** read_duration -- must not crash. *)
 let test_read_duration buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_duration r) with Cursor.Parse_error _ -> ()
 
-(** read_time — must not crash (can be negative). *)
+(** read_time -- must not crash (can be negative). *)
 let test_read_time buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_time r) with Cursor.Parse_error _ -> ()
 
-(** read_number — must not crash. *)
+(** read_number -- must not crash. *)
 let test_read_number buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_number r) with Cursor.Parse_error _ -> ()
 
-(** read_percentage — must not crash. *)
+(** read_percentage -- must not crash. *)
 let test_read_percentage buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_percentage r) with Cursor.Parse_error _ -> ()
 
-(** read_length_percentage — must not crash. *)
+(** read_length_percentage -- must not crash. *)
 let test_read_length_percentage buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_length_percentage r)
   with Cursor.Parse_error _ -> ()
 
-(** read_number_percentage — must not crash. *)
+(** read_number_percentage -- must not crash. *)
 let test_read_number_percentage buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_number_percentage r)
   with Cursor.Parse_error _ -> ()
 
-(** read_color_name — must not crash. *)
+(** read_color_name -- must not crash. *)
 let test_read_color_name buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_color_name r) with Cursor.Parse_error _ -> ()
 
-(** read_color_space — must not crash. *)
+(** read_color_space -- must not crash. *)
 let test_read_color_space buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_color_space r) with Cursor.Parse_error _ -> ()
 
-(** read_system_color — must not crash. *)
+(** read_system_color -- must not crash. *)
 let test_read_system_color buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_system_color r) with Cursor.Parse_error _ -> ()
 
-(** read_hue — must not crash. *)
+(** read_hue -- must not crash. *)
 let test_read_hue buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_hue r) with Cursor.Parse_error _ -> ()
 
-(** read_alpha — must not crash. *)
+(** read_alpha -- must not crash. *)
 let test_read_alpha buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_alpha r) with Cursor.Parse_error _ -> ()
 
-(** read_hue_interpolation — must not crash. *)
+(** read_hue_interpolation -- must not crash. *)
 let test_read_hue_interpolation buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_hue_interpolation r)
   with Cursor.Parse_error _ -> ()
 
-(** read_calc — must not crash (with read_length as inner parser). *)
+(** read_calc -- must not crash (with read_length as inner parser). *)
 let test_read_calc buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_calc Css.Values.read_length r)
   with Cursor.Parse_error _ -> ()
 
-(** read_channel — must not crash. *)
+(** read_channel -- must not crash. *)
 let test_read_channel buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_channel r) with Cursor.Parse_error _ -> ()
 
-(** read_component — must not crash. *)
+(** read_component -- must not crash. *)
 let test_read_component buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_component r) with Cursor.Parse_error _ -> ()
 
-(** read_rgb — must not crash. *)
+(** read_rgb -- must not crash. *)
 let test_read_rgb buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_rgb r) with Cursor.Parse_error _ -> ()
 
-(** read_transition_behavior — must not crash. *)
+(** read_transition_behavior -- must not crash. *)
 let test_read_transition_behavior buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Values.read_transition_behavior r)
   with Cursor.Parse_error _ -> ()
 
-(** Color roundtrip: parse → pp → parse should not crash. *)
+(** Color roundtrip: parse -> pp -> parse should not crash. *)
 let test_color_roundtrip buf =
   let r = Cursor.of_string buf in
   match
@@ -680,7 +680,7 @@ let calc_identity_targets =
     ("flex-grow", "var(--a)", Some "0");
   ]
 
-(* CSS Values 4 §10.7 identity law: wrapping a value in a value-independent
+(* CSS Values 4 sec. 10.7 identity law: wrapping a value in a value-independent
    identity ([x * 1], [1 * x], [x / 1], [x + 0], [0 + x], [x - 0]) and
    optimising lands on the same normal form as optimising the bare value - the
    [var()] reference and the [calc()] wrapper survive, only the redundant

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -478,10 +478,10 @@ let drop_empty_rules stmts =
       | _ -> true)
     stmts
 
-(* CSS Cascade 5 §6.6.3: a [@layer <name>;] declaration form is prelude-friendly
-   and may interleave with [@charset] / [@import] / [@namespace], so a
-   [Layer_decl] before [@import] / [@namespace] must not flip [seen_body] -
-   otherwise the following [@import] gets dropped as misplaced. *)
+(* CSS Cascade 5 sec. 6.6.3: a [@layer <name>;] declaration form is
+   prelude-friendly and may interleave with [@charset] / [@import] /
+   [@namespace], so a [Layer_decl] before [@import] / [@namespace] must not flip
+   [seen_body] - otherwise the following [@import] gets dropped as misplaced. *)
 let drop_misplaced_imports stmts =
   let seen_body = ref false in
   let seen_import_or_namespace = ref false in

--- a/lib/color_space.ml
+++ b/lib/color_space.ml
@@ -14,7 +14,7 @@ let matrix_mul ((a, b, c), (d, e, f), (g, h, i)) (x, y, z) =
     (d *. x) +. (e *. y) +. (f *. z),
     (g *. x) +. (h *. y) +. (i *. z) )
 
-(* sRGB ↔ linear-sRGB. CSS Color 4 sec. 11.5.1. *)
+(* sRGB <-> linear-sRGB. CSS Color 4 sec. 11.5.1. *)
 
 let linear_of_srgb v =
   let s = Float.copy_sign 1.0 v in
@@ -34,7 +34,7 @@ let linear_rgb_of_rgb (r, g, b) =
 let rgb_of_linear_rgb (r, g, b) =
   (srgb_of_linear r, srgb_of_linear g, srgb_of_linear b)
 
-(* Linear sRGB ↔ XYZ-D65. CSS Color 4 sec. 9.1 reference matrix. *)
+(* Linear sRGB <-> XYZ-D65. CSS Color 4 sec. 9.1 reference matrix. *)
 
 let m_xyz65_of_linear_srgb =
   ( (0.4123907992659593, 0.357584339383878, 0.1804807884018343),
@@ -49,7 +49,7 @@ let m_linear_srgb_of_xyz65 =
 let xyz65_of_linear_srgb rgb = matrix_mul m_xyz65_of_linear_srgb rgb
 let linear_srgb_of_xyz65 xyz = matrix_mul m_linear_srgb_of_xyz65 xyz
 
-(* Display-P3 ↔ XYZ-D65. CSS Color 4 sec. 10.4 reference matrix. The
+(* Display-P3 <-> XYZ-D65. CSS Color 4 sec. 10.4 reference matrix. The
    non-linearity is identical to sRGB. *)
 
 let linear_of_display_p3 = linear_of_srgb
@@ -68,7 +68,7 @@ let m_xyz65_p3 =
 let xyz65_of_linear_p3 rgb = matrix_mul m_p3_xyz65 rgb
 let linear_p3_of_xyz65 xyz = matrix_mul m_xyz65_p3 xyz
 
-(* A98-RGB ↔ XYZ-D65. CSS Color 4 sec. 10.2: the non-linearity is a fixed
+(* A98-RGB <-> XYZ-D65. CSS Color 4 sec. 10.2: the non-linearity is a fixed
    [256/563] power, equivalent to a gamma of [1/(563/256)] = [1/2.1992...]. *)
 
 let a98_rgb_gamma = 563.0 /. 256.0
@@ -94,7 +94,7 @@ let m_linear_a98_of_xyz65 =
 let xyz65_of_linear_a98 rgb = matrix_mul m_xyz65_of_linear_a98 rgb
 let linear_a98_of_xyz65 xyz = matrix_mul m_linear_a98_of_xyz65 xyz
 
-(* ProPhoto-RGB ↔ XYZ-D50. CSS Color 4 sec. 10.3: piecewise gamma with toe at
+(* ProPhoto-RGB <-> XYZ-D50. CSS Color 4 sec. 10.3: piecewise gamma with toe at
    [1/512] and a fixed 1.8 exponent above. *)
 
 let linear_of_prophoto_rgb v =
@@ -120,7 +120,7 @@ let m_xyz50_prophoto =
 let xyz50_of_linear_prophoto rgb = matrix_mul m_prophoto_xyz50 rgb
 let linear_prophoto_of_xyz50 xyz = matrix_mul m_xyz50_prophoto xyz
 
-(* Rec2020 ↔ XYZ-D65. CSS Color 4 sec. 10.5: piecewise gamma with a low-end
+(* Rec2020 <-> XYZ-D65. CSS Color 4 sec. 10.5: piecewise gamma with a low-end
    linear segment and a 1/0.45 power for the upper segment. *)
 
 let rec2020_alpha = 1.09929682680944
@@ -166,7 +166,7 @@ let m_d65_of_xyz50 =
 let d50_of_xyz65 xyz = matrix_mul m_d50_of_xyz65 xyz
 let d65_of_xyz50 xyz = matrix_mul m_d65_of_xyz50 xyz
 
-(* CIE Lab ↔ XYZ-D50. CSS Color 4 sec. 8.2 with D50 white point. *)
+(* CIE Lab <-> XYZ-D50. CSS Color 4 sec. 8.2 with D50 white point. *)
 
 let lab_kappa = 24389.0 /. 27.0
 let lab_epsilon = 216.0 /. 24389.0
@@ -194,7 +194,7 @@ let xyz50_of_lab (l, a, b) =
   let wx, wy, wz = lab_d50_white in
   (wx *. f_lab_inv fx, wy *. f_lab_inv fy, wz *. f_lab_inv fz)
 
-(* OKLab ↔ linear sRGB. CSS Color 4 sec. 8.3: a two-stage matrix with a
+(* OKLab <-> linear sRGB. CSS Color 4 sec. 8.3: a two-stage matrix with a
    cube-root non-linearity sandwiched between the two stages. *)
 
 let m_linear_srgb_to_lms =

--- a/lib/component.mli
+++ b/lib/component.mli
@@ -19,8 +19,8 @@ and block = {
   value : t list;
   closed : bool;
       (** [false] when the lexer reached EOF before the matching closer (CSS
-          Syntax §5.4.6 parse error). The serializer still emits the synthetic
-          closer so reserialised output round-trips. *)
+          Syntax sec. 5.4.6 parse error). The serializer still emits the
+          synthetic closer so reserialised output round-trips. *)
 }
 
 and func = {

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -648,7 +648,7 @@ let atom_of_string s =
 
 let rec unnamed_query_not s stripped =
   if String.length stripped >= 4 && String.sub stripped 0 4 = "not " then
-    (* CSS Containment 3 §4 and Conditional Rules: [not] takes exactly one
+    (* CSS Containment 3 sec. 4 and Conditional Rules: [not] takes exactly one
        [<query-in-parens>], so [not not (x)] is a parse error. The operand is a
        parenthesised compound condition or a [style()] / [scroll-state()]
        function; the latter carry their own parentheses, so they need no extra

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -240,10 +240,10 @@ let scope ?layer_order ?layer ctx =
     layer = (match layer with Some _ -> layer | None -> ctx.layer);
   }
 
-(* CSS Cascade 5 §6.4.3 layered custom-property lookup. Important beats normal.
-   Normal author: unlayered wins, else later layers beat earlier. Important
-   author: the order reverses (earlier layers beat later, unlayered ranks
-   below). *)
+(* CSS Cascade 5 sec. 6.4.3 layered custom-property lookup. Important beats
+   normal. Normal author: unlayered wins, else later layers beat earlier.
+   Important author: the order reverses (earlier layers beat later, unlayered
+   ranks below). *)
 let custom_layer_index ~layer_order = function
   | None -> max_int
   | Some name ->
@@ -345,7 +345,7 @@ let lookup_custom_property ?layer ?layer_order ctx name =
       | None -> pick_normal_custom ?layer ~layer_order normal)
 
 (* The computed winner among a pool of same-property custom-property
-   declarations, resolved by CSS Cascade 5 §6.4.3: important beats normal,
+   declarations, resolved by CSS Cascade 5 sec. 6.4.3: important beats normal,
    [revert-layer] rolls back to the next layer down, and layer order (reversed
    for important) breaks ties. Layers are read from each declaration's own
    annotation, so the caller must have tagged them. [None] when the pool is
@@ -671,7 +671,7 @@ let kind_equal : type a b.
   | Properties.Font_src, Properties.Font_src -> Some Refl
   | _ -> None
 
-(* CSS Cascade 5 §6.4 lists inherited properties; the rest default to the
+(* CSS Cascade 5 sec. 6.4 lists inherited properties; the rest default to the
    property's initial value when no value is supplied. *)
 let property_is_inherited = function
   | "color" | "cursor" | "direction" | "font-family" | "font-feature-settings"
@@ -1121,7 +1121,7 @@ module Calc_residual = struct
     run_simplify ops ~resolve_var ~simplify_var_record value
 end
 
-(** {2 Length canonicalisation (CSS Values 4 §6)}
+(** {2 Length canonicalisation (CSS Values 4 sec. 6)}
 
     All length units convert to pixels. Absolute units come from the fixed 1in =
     96px conversion table; font-relative and viewport-relative units require the
@@ -1139,7 +1139,7 @@ module Length = struct
     container_height : float option;
   }
 
-  (* CSS Media Queries 4 §1.3: relative units in @media/@container resolve
+  (* CSS Media Queries 4 sec. 1.3: relative units in @media/@container resolve
      against root font-size. Pre-fill [parent_font_size]/[root_font_size] with
      the 16px default so [em]/[rem] in queries always have a reference; a fresh
      [Length.ctx] without these rejects relative units. *)
@@ -1224,7 +1224,7 @@ module Length = struct
       container_height = unwrap_px ctx.container_height;
     }
 
-  (* CSS Values 4 §10.11 simplification of a typed [length calc]: fold every
+  (* CSS Values 4 sec. 10.11 simplification of a typed [length calc]: fold every
      subtree the [ctx] can collapse to absolute lengths, leaving
      [Var]/[Sibling_*]/unresolvable subtrees. The result stays a [length calc] -
      [Val (Px _)] when fully reducible, else [Expr] with simplified operands. *)
@@ -1261,7 +1261,7 @@ module Length = struct
     | Val la, _, Num n ->
         Option.map (fun out -> Val out) (eval_combine_length_num ctx la n op)
     | Num n, Mul, Val lb ->
-        (* Multiplication is commutative on length × number. *)
+        (* Multiplication is commutative on length x number. *)
         Option.map (fun out -> Val out) (eval_combine_length_num ctx lb n Mul)
     | _ -> None
 
@@ -1389,7 +1389,7 @@ module Length = struct
     | value -> normalize_zero value
 end
 
-(** {2 Media-feature value comparison (CSS Media Queries 4 §3)}
+(** {2 Media-feature value comparison (CSS Media Queries 4 sec. 3)}
 
     [query.media_features] stores typed [Media.feature]s parsed at construction;
     this module is just the numeric comparison glue used when matching range
@@ -1425,7 +1425,7 @@ module Media_value = struct
         | _ -> None)
 end
 
-(** {2 [@supports] evaluation (CSS Conditional 4 §3)}
+(** {2 [@supports] evaluation (CSS Conditional 4 sec. 3)}
 
     Each [Supports.t] constructor has a dedicated evaluator. The structural
     cases ([Not]/[And]/[Or]) recurse into [eval]; the leaves ([Property]/[Func])
@@ -1447,7 +1447,7 @@ end
     [Media.feature], [eval_condition] for [Media.condition], [eval_query] for
     [Media.query], [eval_medium] for [Media.medium], and [eval] for the
     typed-shorthand wrapper [Media.t]. Lengths resolve against a 16px base per
-    §1.3; [min-]/[max-] feature prefixes desugar to range comparisons. *)
+    sec. 1.3; [min-]/[max-] feature prefixes desugar to range comparisons. *)
 
 module Match_media = struct
   open Media
@@ -1523,7 +1523,7 @@ module Match_media = struct
     | List qs -> List.exists (eval q) qs
 end
 
-(** {2 Container-query evaluation (CSS Containment 3 §3.4)}
+(** {2 Container-query evaluation (CSS Containment 3 sec. 3.4)}
 
     Container queries reuse the media-feature evaluator applied to the container
     feature table; they additionally guard on the container name (when supplied)
@@ -1813,7 +1813,7 @@ module Url = struct
       | Some base -> resolve_relative base href
 end
 
-(** {2 [@import] loader (CSS Cascade 5 §6)}
+(** {2 [@import] loader (CSS Cascade 5 sec. 6)}
 
     Resolves the import URL through {!Url}, looks up the body in
     [loader.imports], parses it, and applies any media/supports/layer guards on

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -225,7 +225,7 @@ val winning_custom_declaration :
   Declaration.declaration list ->
   Declaration.declaration option
 (** [winning_custom_declaration ~layer_order decls] is the cascade winner among
-    same-property custom-property declarations per CSS Cascade 5 §6.4.3:
+    same-property custom-property declarations per CSS Cascade 5 sec. 6.4.3:
     [!important] beats normal, [revert-layer] rolls back a layer, and layer
     order (reversed for [!important]) breaks ties. Each declaration's layer is
     read from its own annotation. [None] when [decls] is empty or resolves to

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -649,12 +649,12 @@ val custom_declarations : ?layer:string -> declaration list -> declaration list
 (** CSS calc operations. *)
 type calc_op = Values.calc_op = Add | Sub | Mul | Div
 
-(** CSS Values 4 §10.7.1 math constants - emitted at the source byte sequence so
-    pretty pp preserves [calc(2 * pi)] instead of writing [calc(6.28318530718)].
-*)
+(** CSS Values 4 sec. 10.7.1 math constants - emitted at the source byte
+    sequence so pretty pp preserves [calc(2 * pi)] instead of writing
+    [calc(6.28318530718)]. *)
 type math_const = Values.math_const = Pi | E | Infinity | Neg_infinity | Nan
 
-(** CSS Values 4 §10.7 numeric math function arguments. *)
+(** CSS Values 4 sec. 10.7 numeric math function arguments. *)
 type math_arg = Values.math_arg =
   | Lit of float
   | Dim of float * string  (** A dimension argument (e.g. [1vw], [1%]). *)
@@ -664,7 +664,7 @@ type math_arg = Values.math_arg =
   | Parens_arg of math_arg
   | Math_call of math_fn
 
-(** CSS Values 4 §10.7 numeric math functions. *)
+(** CSS Values 4 sec. 10.7 numeric math functions. *)
 and math_fn = Values.math_fn =
   | Sin of angle_arg
   | Cos of angle_arg
@@ -699,14 +699,15 @@ type 'a calc = 'a Values.calc =
   | Val of 'a
   | Num of float  (** Unitless number *)
   | Math_const of math_const
-      (** CSS Values 4 §10.7.1 math constant ([pi], [e], [infinity],
+      (** CSS Values 4 sec. 10.7.1 math constant ([pi], [e], [infinity],
           [-infinity], [NaN]) preserved verbatim through pretty pp. *)
   | Sibling_index  (** CSS [sibling-index()] math function. *)
   | Sibling_count  (** CSS [sibling-count()] math function. *)
   | Expr of 'a calc * calc_op * 'a calc
   | Nested of 'a calc  (** Explicitly nested calc() *)
   | Parens of 'a calc  (** Parenthesized expression *)
-  | Math_fn of math_fn  (** CSS Values 4 §10.7 numeric math function call. *)
+  | Math_fn of math_fn
+      (** CSS Values 4 sec. 10.7 numeric math function call. *)
 
 type component_values = Component.t list
 (** Parsed CSS component values preserved for fallback and invalid-value
@@ -722,7 +723,7 @@ type custom_value = component_values
 type 'a fallback = 'a Values.fallback =
   | Empty  (** Empty fallback: var(--name,) *)
   | Empty2
-      (** 2-char empty fallback: var(--name, ) — matches tailwindcss output,
+      (** 2-char empty fallback: var(--name, ) -- matches tailwindcss output,
           likely a bug in tailwindcss *)
   | None  (** No fallback: var(--name) *)
   | Fallback of 'a  (** Value fallback: var(--name, value) *)
@@ -857,7 +858,7 @@ type length = Values.length =
   | Anchor of string option * string * length option
       (** CSS [anchor()] function: optional anchor name, side, and fallback. *)
   | Attr of length attr_call
-      (** CSS [attr()] in typed value contexts (CSS Values 5 §10). *)
+      (** CSS [attr()] in typed value contexts (CSS Values 5 sec. 10). *)
   | Env of length env  (** CSS [env()] reference. *)
   | Var of length var  (** CSS variable reference *)
   | Calc of length calc  (** Calculated expressions *)
@@ -1099,9 +1100,9 @@ type color_name = Values.color_name =
 
 (** CSS channel values (for RGB) *)
 type channel = Values.channel =
-  | Int of int (* 0–255, legacy/comma syntax *)
-  | Num of float (* 0–255, modern/space syntax *)
-  | Pct of float (* 0%–100% *)
+  | Int of int (* 0-255, legacy/comma syntax *)
+  | Num of float (* 0-255, modern/space syntax *)
+  | Pct of float (* 0%-100% *)
   | Var of channel var
   | None (* CSS Color 4 [none] sentinel *)
 
@@ -1135,7 +1136,7 @@ type component = Values.component =
 
 (** CSS percentage values *)
 type percentage = Values.percentage =
-  | Pct of float (* 0%–100% as a % token *)
+  | Pct of float (* 0%-100% as a % token *)
   | Num of float (* Numeric value in percentage context, e.g., opacity 0.5 *)
   | Var of percentage var
   | Calc of percentage calc (* calc(...) that resolves to a % *)
@@ -1252,7 +1253,7 @@ val hex : string -> color
     Examples: [hex "#3b82f6"], [hex "ffffff"]. *)
 
 val rgb : ?alpha:float -> int -> int -> int -> color
-(** [rgb ?alpha r g b] is an RGB color (0–255 components) with optional alpha.
+(** [rgb ?alpha r g b] is an RGB color (0-255 components) with optional alpha.
 *)
 
 val hsl : float -> float -> float -> color
@@ -1841,7 +1842,7 @@ type display = Properties.display =
   | Revert_layer
   | Multi of display * display
       (** Two-value [<display-outside> <display-inside>] syntax per CSS Display
-          3 §2.1, e.g. [inline flow-root] or [list-item flow-root]. *)
+          3 sec. 2.1, e.g. [inline flow-root] or [list-item flow-root]. *)
   | Var of display var  (** CSS position values. *)
 
 type position = Properties.position =
@@ -2047,7 +2048,7 @@ type break_inside_value = Properties.break_inside_value =
 val break_inside : break_inside_value -> declaration
 (** [break_inside v] is the break-inside property. *)
 
-(** CSS Fragmentation 3 §6 deprecated [page-break-before / -after] alias
+(** CSS Fragmentation 3 sec. 6 deprecated [page-break-before / -after] alias
     vocabulary; the shorter value list makes these their own type rather than
     overload {!type-break_value}. *)
 type page_break_value = Properties.page_break_value =
@@ -2058,7 +2059,8 @@ type page_break_value = Properties.page_break_value =
   | Right
   | Inherit
   | Var of page_break_value var
-      (** CSS Fragmentation 3 §6 deprecated [page-break-inside] vocabulary. *)
+      (** CSS Fragmentation 3 sec. 6 deprecated [page-break-inside] vocabulary.
+      *)
 
 type page_break_inside_value = Properties.page_break_inside_value =
   | Auto
@@ -2897,7 +2899,7 @@ type border_radius = Properties.border_radius =
   | Unset
   | Revert
   | Revert_layer
-  | Var of border_radius var  (** Per CSS Backgrounds and Borders 3 §5. *)
+  | Var of border_radius var  (** Per CSS Backgrounds and Borders 3 sec. 5. *)
 
 val radius : length -> border_radius
 (** [radius len] is a one-value [border-radius] shorthand value.
@@ -2979,7 +2981,7 @@ type background_image = Properties.background_image =
   | Repeating_linear_gradient of gradient_direction * gradient_stop list
   | Repeating_radial_gradient of radial_gradient_config * gradient_stop list
   | Repeating_conic_gradient of conic_gradient_config * gradient_stop list
-      (** [repeating-{linear,radial,conic}-gradient()] CSS Images 4 §3. *)
+      (** [repeating-{linear,radial,conic}-gradient()] CSS Images 4 sec. 3. *)
   | Webkit_linear_gradient of gradient_direction * gradient_stop list
   | Webkit_repeating_linear_gradient of gradient_direction * gradient_stop list
   | Webkit_radial_gradient of radial_gradient_config * gradient_stop list
@@ -3769,7 +3771,7 @@ val column_gap : length -> declaration
     @see <https://www.w3.org/TR/css-grid-2/> CSS Grid Layout Module Level 2 *)
 
 (** [repeat()] count argument: an integer or [auto-fill] / [auto-fit] (CSS Grid
-    1 §7.2.3.1). *)
+    1 sec. 7.2.3.1). *)
 type repeat_count = Properties.repeat_count =
   | Count of int
   | Auto_fill
@@ -7397,7 +7399,7 @@ type 'a syntax = 'a Variables.syntax =
   | Hash : 'a syntax -> 'a list syntax
   | Ident_keyword : string -> unit syntax
       (** Type-safe syntax descriptors for CSS [@property] rules per CSS
-          Properties and Values API 1 §2. *)
+          Properties and Values API 1 sec. 2. *)
 
 val property :
   name:string -> 'a syntax -> ?initial_value:'a -> ?inherits:bool -> unit -> t

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -307,8 +307,8 @@ let is_decl_unknown_property_name name =
 (** [is_invalid decl] is [true] when [decl]'s typed value is a known spec
     violation detected at parse time; [Optimize.drop_invalid] removes such
     declarations under minify. An unknown property is not invalid: browsers keep
-    unrecognised declarations (CSS Syntax 3 §5.4), and cascade emits them (and
-    vendor-prefix extensions) as raw component lists. *)
+    unrecognised declarations (CSS Syntax 3 sec. 5.4), and cascade emits them
+    (and vendor-prefix extensions) as raw component lists. *)
 let rec is_invalid = function
   | Declaration { property = Unknown_property _; _ } -> false
   | Declaration { property; value; _ } ->
@@ -755,9 +755,9 @@ let read_border_radius_vertical t =
       Some (read_border_radius_radii t)
   | _ -> None
 
-(* CSS Backgrounds and Borders 3 §5: [border-radius = <length-percentage>{1,4}
-   [/ <length-percentage>{1,4}]?]. Reads 1-4 horizontal radii then, after [/],
-   1-4 vertical radii. *)
+(* CSS Backgrounds and Borders 3 sec. 5: [border-radius =
+   <length-percentage>{1,4} [/ <length-percentage>{1,4}]?]. Reads 1-4 horizontal
+   radii then, after [/], 1-4 vertical radii. *)
 let rec read_border_radius (t : Cursor.t) : Properties.border_radius =
   Cursor.ws t;
   Cursor.enum_or_var "border-radius"
@@ -1764,10 +1764,10 @@ let read_custom_value name ~raw_is_whitespace_only value_str =
 
 let read_custom_property_declaration t : declaration =
   let name = read_property_name t in
-  (* CSS Syntax 3 §4.3.7 lets [\X] escapes carry any code point into an ident,
-     so the name may contain characters ([/], whitespace, etc.) that don't
-     tokenize as a bare ident on a string round-trip. We trust the original
-     lexer's tokenization: the only validation we still run is the
+  (* CSS Syntax 3 sec. 4.3.7 lets [\X] escapes carry any code point into an
+     ident, so the name may contain characters ([/], whitespace, etc.) that
+     don't tokenize as a bare ident on a string round-trip. We trust the
+     original lexer's tokenization: the only validation we still run is the
      [<dashed-ident>] prefix check. *)
   if String.length name <= 2 || name.[0] <> '-' || name.[1] <> '-' then
     Cursor.err_invalid t ("expected <dashed-ident>, got: " ^ name);
@@ -1796,7 +1796,7 @@ let read_custom_property_declaration t : declaration =
    can legitimately appear as a non-special ident. [animation-name] /
    [grid-area] / [will-change] / etc. accept arbitrary ident lists.
    [font-family] also takes a [<custom-ident>#] list, so a CSS-wide keyword
-   inside the list is invalid CSS (CSS Cascade 5 §7.3) but upstream tools
+   inside the list is invalid CSS (CSS Cascade 5 sec. 7.3) but upstream tools
    (lightningcss, csso) preserve the source verbatim. *)
 let property_allows_keyword_as_ident = function
   | "animation-name" | "grid-area" | "grid-row" | "grid-column"
@@ -1942,9 +1942,9 @@ let read_typed_property_declaration t start =
   Cursor.ws t;
   if not (Cursor.colon t) then Cursor.err_expected t "':'";
   Cursor.ws t;
-  (* CSS Syntax 3 §5.3.7 / §4.3.5 auto-close unterminated functions, brackets
-     and strings at EOF. Typed readers consume the spec-recovered tokens; the
-     declaration survives with the auto-closed shape. *)
+  (* CSS Syntax 3 sec. 5.3.7 / sec. 4.3.5 auto-close unterminated functions,
+     brackets and strings at EOF. Typed readers consume the spec-recovered
+     tokens; the declaration survives with the auto-closed shape. *)
   match prop_type with
   | Unknown_property name -> read_unknown_property_declaration t name
   | _ -> (

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -54,11 +54,12 @@ type t = {
 type mode = [ `Auto | `Tree | `String | `Canonical ]
 (** CSS comparison mode.
 
-    - [`Auto] (default) — tree diff when the ASTs differ, string diff otherwise.
-    - [`Tree] — structural diff only; formatting-only differences collapse to
+    - [`Auto] (default) -- tree diff when the ASTs differ, string diff
+      otherwise.
+    - [`Tree] -- structural diff only; formatting-only differences collapse to
       {!No_diff}.
-    - [`String] — character-level diff; the inputs are not parsed.
-    - [`Canonical] — parse both stylesheets, serialize optimized minified
+    - [`String] -- character-level diff; the inputs are not parsed.
+    - [`Canonical] -- parse both stylesheets, serialize optimized minified
       outputs, and compare those outputs. This includes value spellings that
       Cascade canonicalizes as equivalent, such as [transparent] and [#0000] in
       color positions. If the normalized forms differ, the returned diff is
@@ -146,7 +147,7 @@ val equivalent_value :
     Minifier output frequently starts with a [/*! ... */] banner identifying the
     tool. These helpers normalise that banner away so two outputs can be
     compared on their CSS content. {!diff} and {!equal} already strip the banner
-    internally — these are exposed only for callers that want to do their own
+    internally -- these are exposed only for callers that want to do their own
     pre-processing. *)
 
 val strip_tool_header : string -> string

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -111,14 +111,16 @@ let style_text ~color action s =
 let tree_prefix ~style ~is_last ~parent_prefix =
   if not style.use_tree then ""
   else
-    let connector = if is_last then "└─ " else "├─ " in
+    let connector =
+      if is_last then "\u{2514}\u{2500} " else "\u{251c}\u{2500} "
+    in
     parent_prefix ^ connector
 
 (* Get the continuation prefix for children *)
 let tree_continuation ~style ~is_last ~parent_prefix =
   if not style.use_tree then parent_prefix
   else
-    let continuation = if is_last then "   " else "│  " in
+    let continuation = if is_last then "   " else "\u{2502}  " in
     parent_prefix ^ continuation
 
 (* Print a list of CSS declarations with an action prefix *)
@@ -1538,7 +1540,8 @@ let convert_modified_rule ~rules1 ~rules2 (sel1, sel2, decls1, decls2) =
         if position_changed () then Some (reordered sel1_str)
         else if decls_str_equal decls1 decls2 then
           (* OCaml ASTs differ but string output is identical (e.g., Nested vs
-             bare expression after calc() normalization) — no real difference *)
+             bare expression after calc() normalization) -- no real
+             difference *)
           None
         else if reorder_is_significant decls1 decls2 then
           Some (decl_level_reorder sel1_str decls1 decls2)

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -174,10 +174,10 @@ let read_function_arg name t =
     | None -> (Cursor.consume_remaining_as_string ~trim:true inner, false)
   in
   Cursor.expect_eof inner;
-  (* CSS Fonts 4 §11.1: each of [local()] / [format()] / [tech()] takes exactly
-     one argument, so an empty body ([format()], [local()]) is invalid. The one
-     exception browsers accept is [local("")] - an explicit empty <string>
-     family name - so keep that. *)
+  (* CSS Fonts 4 sec. 11.1: each of [local()] / [format()] / [tech()] takes
+     exactly one argument, so an empty body ([format()], [local()]) is invalid.
+     The one exception browsers accept is [local("")] - an explicit empty
+     <string> family name - so keep that. *)
   let is_empty_local_string =
     from_string && value = "" && String.lowercase_ascii name = "local"
   in
@@ -247,7 +247,7 @@ let rec read_src_entry t =
       let url = read_url t in
       read_src_url_modifiers t url
 
-(** Parse a src string into a list of typed entries. CSS Fonts 4 §4.3 spells
+(** Parse a src string into a list of typed entries. CSS Fonts 4 sec. 4.3 spells
     [src] as a comma-separated list, but real-world input occasionally drops the
     comma between entries ([src: local("") url(test.woff)]). Match cleancss /
     lightningcss / esbuild and accept the whitespace-only form too, treating it

--- a/lib/keyframe.ml
+++ b/lib/keyframe.ml
@@ -63,7 +63,7 @@ let parse_percent s =
   else None
 
 (** Parse a [<timeline-range-name> <percentage>] string (Scroll-Driven
-    Animations 1 §8.1). *)
+    Animations 1 sec. 8.1). *)
 let parse_timeline_range_position s =
   match String.index_opt s ' ' with
   | None -> None

--- a/lib/keyframe.mli
+++ b/lib/keyframe.mli
@@ -6,8 +6,8 @@ type position =
   | To  (** [to] or [100%] *)
   | Percent of float  (** Percentage like [50%] *)
   | Timeline_range of string * float
-      (** Scroll-Driven Animations 1 §8.1 [<timeline-range-name> <percentage>]
-          selector such as [entry 0%]. *)
+      (** Scroll-Driven Animations 1 sec. 8.1
+          [<timeline-range-name> <percentage>] selector such as [entry 0%]. *)
 
 val string_of_position : position -> string
 (** [string_of_position pos] renders a position as CSS string. *)

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -563,8 +563,9 @@ let rec skip_comment_body r =
     skip_comment_body r)
 
 (* Skip a run of comments without consuming surrounding whitespace: CSS Syntax
-   §4.3.2 treats comments as "nothing", so a comment between two non-whitespace
-   points disappears rather than becoming a <whitespace-token>. *)
+   sec. 4.3.2 treats comments as "nothing", so a comment between two
+   non-whitespace points disappears rather than becoming a
+   <whitespace-token>. *)
 let rec skip_comment_run r =
   if Reader.looking_at r "/*" then (
     Reader.skip r;

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -123,7 +123,7 @@ type feature =
   | Range_rev of value * cmp * name
   | Interval of value * cmp * name * cmp * value
   | General_enclosed of string
-      (** Media Queries 4 Â§3.1 [<general-enclosed>]: a grammatical but
+      (** Media Queries 4 sec. 3.1 [<general-enclosed>]: a grammatical but
           unrecognised query, kept verbatim. Its result is [unknown], which
           becomes false wherever a boolean is expected. *)
 
@@ -1027,7 +1027,7 @@ and condition_in_parens sc =
       advance sc;
       condition_from_paren_content (read_balanced sc)
   | _ -> (
-      (* Media Queries 4 §3.1: [<media-in-parens>] also admits
+      (* Media Queries 4 sec. 3.1: [<media-in-parens>] also admits
          [<general-enclosed>], whose first form is a function token. An
          identifier immediately followed by [(] is one, e.g. [theme(static)]:
          grammatical, unrecognised, and therefore false. Rejecting it here made

--- a/lib/media.mli
+++ b/lib/media.mli
@@ -103,7 +103,7 @@ type feature =
   | Range_rev of value * cmp * name
   | Interval of value * cmp * name * cmp * value
   | General_enclosed of string
-      (** Media Queries 4 Â§3.1 [<general-enclosed>]: a grammatical but
+      (** Media Queries 4 sec. 3.1 [<general-enclosed>]: a grammatical but
           unrecognised query, kept verbatim. Its result is [unknown], which
           becomes false wherever a boolean is expected. *)
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -595,7 +595,7 @@ let drop_invalid (stylesheet : t) : t =
 (** [drop_unknown_at_rules] removes [Unknown_at_rule] statements at every block
     depth. Used in [--minify] alongside [drop_invalid] so the typed warnings
     emitted at parse time materialise as a dropped rule, matching CSS Syntax 3
-    §5.4.1 (unknown at-rules are discarded). *)
+    sec. 5.4.1 (unknown at-rules are discarded). *)
 let drop_unknown_at_rules (stylesheet : t) : t =
   let rec statement stmt =
     match stmt with

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -92,8 +92,8 @@ val drop_invalid : t -> t
 
 val drop_unknown_at_rules : t -> t
 (** [drop_unknown_at_rules ss] removes every [Unknown_at_rule] statement at any
-    block depth. CSS Syntax 3 §5.4.1 says an unknown at-rule is discarded; the
-    parser preserves them in the AST for fidelity, and minify-time
+    block depth. CSS Syntax 3 sec. 5.4.1 says an unknown at-rule is discarded;
+    the parser preserves them in the AST for fidelity, and minify-time
     canonicalization then drops them. *)
 
 val drop_empty_rules : t -> t

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -203,8 +203,8 @@ let string_of_token_kind : Token.kind -> string = function
   | Token.Hash { value; _ } -> "#" ^ escape_name value
   | Token.String { value; quote = _; terminated } ->
       (* Normalize quoting to double-quote (the original quote is kept on the
-         token only for quote-sensitive lookups like @charset). CSS Syntax
-         §4.3.5 recovers an unterminated string; the [terminated] flag is
+         token only for quote-sensitive lookups like @charset). CSS Syntax sec.
+         4.3.5 recovers an unterminated string; the [terminated] flag is
          preserved so one round-trips, emitting without its closing quote. *)
       escape_string ~quote:'"' ~terminated value
   | Token.Bad_string -> ""
@@ -230,7 +230,7 @@ let string_of_token_kind : Token.kind -> string = function
   | Token.Number_tok { repr; _ } -> repr
   | Token.Percentage { repr; _ } -> repr ^ "%"
   | Token.Dimension { number; unit_ } ->
-      (* CSS Syntax §9.1 ambiguous-dimension rule: a unit of [e]/[E] then a
+      (* CSS Syntax sec. 9.1 ambiguous-dimension rule: a unit of [e]/[E] then a
          (signed) digit would re-read as scientific notation, so hex-escape the
          leading letter to keep it out of the number's exponent. *)
       let unit_serialized =
@@ -611,7 +611,7 @@ let url_string_can_unquote s =
 
 (* If [args] is a single [<string-token>] argument we can fold it into the
    bare-URL form [url(X)] when X has no special characters - per CSS Values L4
-   §3.4 the two notations are equivalent and the bare form is shorter. *)
+   sec. 3.4 the two notations are equivalent and the bare form is shorter. *)
 let url_args_as_bare_string args =
   let stripped =
     List.filter

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -296,7 +296,7 @@ let trim_decimal_suffix s =
   else s
 
 let strip_exponent_plus s =
-  (* Remove redundant '+' in exponent notation: "3.40282e+38" → "3.40282e38" *)
+  (* Remove redundant '+' in exponent notation: "3.40282e+38" -> "3.40282e38" *)
   match String.index_opt s 'e' with
   | Some i when i + 1 < String.length s && s.[i + 1] = '+' ->
       String.sub s 0 (i + 1) ^ String.sub s (i + 2) (String.length s - i - 2)
@@ -403,12 +403,13 @@ let unit ctx f suffix =
   string ctx suffix
 
 let pct ctx f =
-  (* CSS Values 4 §6.5 only allows the unit to drop on a zero [<length>]; a zero
-     [<percentage>] keeps the [%] (otherwise [opacity:0] vs [opacity:0%] are no
-     longer equivalent, and dimension/percentage-typed grammars reject a bare
-     [0]). The coefficient prints in full, like [float]: rounding it changes the
-     value (a repeating fraction such as [33.333333%] from [w-1/3] would lose
-     digits), so any precision reduction belongs in the optimizer, not here. *)
+  (* CSS Values 4 sec. 6.5 only allows the unit to drop on a zero [<length>]; a
+     zero [<percentage>] keeps the [%] (otherwise [opacity:0] vs [opacity:0%]
+     are no longer equivalent, and dimension/percentage-typed grammars reject a
+     bare [0]). The coefficient prints in full, like [float]: rounding it
+     changes the value (a repeating fraction such as [33.333333%] from [w-1/3]
+     would lose digits), so any precision reduction belongs in the optimizer,
+     not here. *)
   float ctx f;
   string ctx "%"
 

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -236,7 +236,7 @@ val unit : ctx -> float -> string -> unit
 val pct : ctx -> float -> unit
 (** [pct ctx f] formats a percentage value with the [%] suffix. The value is
     expected to be in the range 0-100. The unit is always emitted: CSS Values 4
-    §6.5 only allows the unit to drop on a zero [<length>], not a zero
+    sec. 6.5 only allows the unit to drop on a zero [<length>], not a zero
     [<percentage>]. *)
 
 val comma : unit t

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -40,13 +40,13 @@ let read_vertical_align_length t : vertical_align =
   | Some "rem" -> Rem n
   | Some "em" -> Em n
   | Some "%" -> Pct n
-  (* A unitless [0] is the valid zero <length> (CSS Values 4 §6.1); any other
-     unitless number is not a length and is rejected. *)
+  (* A unitless [0] is the valid zero <length> (CSS Values 4 sec. 6.1); any
+     other unitless number is not a length and is rejected. *)
   | None when n = 0. -> Zero
   | None -> Cursor.err_invalid t "vertical-align requires a unit"
   | Some u -> Cursor.err_invalid t ("invalid vertical-align unit: " ^ u)
 
-(* CSS Display 3 §2.1 [display-outside]: pre-existing aliases inside the
+(* CSS Display 3 sec. 2.1 [display-outside]: pre-existing aliases inside the
    single-value vocabulary that compose with a [display-inside] in the two-value
    form. The composite [<outside> <inside>] is a [Multi]. *)
 let display_outside_idents : (string * display) list =
@@ -116,7 +116,7 @@ let read_display_legacy t : display =
     t
 
 let read_display_two_value t : display =
-  (* CSS Display 3 §2.1 two-value form [<display-outside> <display-inside>].
+  (* CSS Display 3 sec. 2.1 two-value form [<display-outside> <display-inside>].
      Both keywords must come from their respective vocabularies; otherwise
      reject so the caller can fall back to the legacy single-value form. *)
   let outside = Cursor.enum "display-outside" display_outside_idents t in
@@ -762,7 +762,7 @@ let rec read_font_style t : font_style =
         Cursor.ws t;
         if Cursor.is_done t || Cursor.peek_semicolon t then Oblique_angle first
         else
-          (* CSS Fonts 4 §11.2 wants the first oblique angle <= the second.
+          (* CSS Fonts 4 sec. 11.2 wants the first oblique angle <= the second.
              Browsers keep a descending range ([oblique 20deg 10deg]), so accept
              it but warn, leaving [Css.of_string ~strict] free to reject it. *)
           let second = read_angle t in
@@ -772,7 +772,7 @@ let rec read_font_style t : font_style =
                 (Error.bad_value (Cursor.position t) ~property:"font-style"
                    ~reason:
                      "oblique angle range must run from the smaller angle to \
-                      the larger (CSS Fonts 4 §11.2)")
+                      the larger (CSS Fonts 4 \u{00a7}11.2)")
           | _ -> ());
           Oblique_range (first, second))
     t
@@ -2102,7 +2102,7 @@ module Cursor_prop = struct
   let rec read_url_cursor (t : Cursor.t) : cursor =
     let (url, hotspot) : string * (float * float) option =
       (* Bare [url(foo.cur)] is a [Token.Url]; quoted [url("foo.cur")] is a
-         [Func "url"] — handle both. *)
+         [Func "url"] -- handle both. *)
       match Cursor.url_opt t with
       | Some url -> (url, None)
       | None -> Cursor.call "url" t read_url_with_hotspot
@@ -3086,10 +3086,10 @@ let rec pp_gradient_stop : gradient_stop Pp.t =
       match pos1_opt with
       | None -> ()
       | Some pos1 -> (
-          (* CSS Syntax 3 §4: ident- and hash-typed colours absorb the following
-             digit/hex into the same token ([red0%] -> ident [red0] + [%]), so
-             the separator is mandatory there; and when the stop lives in a
-             custom-property token stream, the whitespace token between a
+          (* CSS Syntax 3 sec. 4: ident- and hash-typed colours absorb the
+             following digit/hex into the same token ([red0%] -> ident [red0] +
+             [%]), so the separator is mandatory there; and when the stop lives
+             in a custom-property token stream, the whitespace token between a
              function-shaped colour and its position is part of the value a
              var() substitution receives, so it is never elided either. *)
           Pp.space ctx ();
@@ -3209,7 +3209,7 @@ let pp_conic_gradient_named name ctx (config, stops) =
 let pp_linear_gradient_named name ctx (dir, stops) =
   Pp.call name
     (fun ctx (dir, stops) ->
-      (* CSS Images 4 §5.1: the default linear-gradient direction is [to
+      (* CSS Images 4 sec. 5.1: the default linear-gradient direction is [to
          bottom], equivalent to [180deg]; both spellings can be elided. *)
       let is_default_direction = function
         | Default_direction -> true
@@ -3403,7 +3403,7 @@ let pp_font_family_name ctx s =
 let can_unquote_font_family_name s =
   match String.split_on_char ' ' s with
   | _ :: _ :: _ as words ->
-      (* CSS Fonts 4 §4.1: a [<family-name>] formed of two or more
+      (* CSS Fonts 4 sec. 4.1: a [<family-name>] formed of two or more
          [<custom-ident>]s is unambiguous - none of its words can be picked up
          as a property-level CSS-wide keyword once the parser has committed to a
          multi-token value. So [inherit test] / [revert serif] etc. round-trip
@@ -5009,7 +5009,7 @@ let pp_border_shorthand : border_shorthand Pp.t =
         (None : border_style option)
     | style, _, _ -> style
   in
-  (* CSS Backgrounds 3 §4.4: [<border-width>] defaults to [medium]. When the
+  (* CSS Backgrounds 3 sec. 4.4: [<border-width>] defaults to [medium]. When the
      user spelled it explicitly and another slot is non-default, the keyword is
      redundant - drop it. *)
   let width : border_width option =
@@ -7866,8 +7866,8 @@ let rec pp_background_repeat : background_repeat Pp.t =
   | No_repeat -> Pp.string ctx "no-repeat"
   | Repeat_x -> Pp.string ctx "repeat-x"
   | Repeat_y -> Pp.string ctx "repeat-y"
-  (* CSS Backgrounds 3 §3.6.1: the two-value forms collapse when both axes match
-     ([X X] -> [X]) or when they alias a single-keyword shorthand ([repeat
+  (* CSS Backgrounds 3 sec. 3.6.1: the two-value forms collapse when both axes
+     match ([X X] -> [X]) or when they alias a single-keyword shorthand ([repeat
      no-repeat] -> [repeat-x], [no-repeat repeat] -> [repeat-y]). *)
   | Repeat_repeat when Pp.minified ctx -> Pp.string ctx "repeat"
   | Space_space when Pp.minified ctx -> Pp.string ctx "space"
@@ -8038,7 +8038,7 @@ let pp_bg_size_with_position maybe_space (bg : background_shorthand) ctx =
 let pp_mask_layer : mask_layer Pp.t =
  fun ctx layer ->
   let first = ref true in
-  (* CSS Syntax 3 §5.4.6: a token ending with [)], [\]] or [}] is
+  (* CSS Syntax 3 sec. 5.4.6: a token ending with [)], [\]] or [}] is
      self-delimiting, so under minify we can drop the inter-slot space after
      [url(...)] / [<image>]. *)
   let last_is_self_delim () =
@@ -8146,7 +8146,7 @@ let pp_mask_border_mode ctx = function
 let pp_border_image : border_image Pp.t =
  fun ctx { source; slice; width; outset; repeat; mode } ->
   let first = ref true in
-  (* CSS Syntax 3 §5.4.6: tokens ending with [)] are self-delimiting, so the
+  (* CSS Syntax 3 sec. 5.4.6: tokens ending with [)] are self-delimiting, so the
      inter-slot space after [url(...)] / [<image>] can be elided under
      minify. *)
   let last_is_self_delim () =
@@ -8172,7 +8172,7 @@ let pp_border_image : border_image Pp.t =
   pp_bg_prop maybe_space
     (Pp.list ~sep:Pp.space pp_border_image_repeat_keyword)
     ctx repeat;
-  (* CSS Masking 1 §6: [alpha] is the default mode, so drop it under minify;
+  (* CSS Masking 1 sec. 6: [alpha] is the default mode, so drop it under minify;
      [luminance] always prints. *)
   let mode =
     match mode with
@@ -8373,9 +8373,9 @@ let rec pp_background : background Pp.t =
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
   | None ->
-      (* CSS Backgrounds 3 §3.10: [background: none] and [background: 0 0] are
-         computed-value-equivalent (both clear the image and set position to [0
-         0]). Pick the shorter form under minify. *)
+      (* CSS Backgrounds 3 sec. 3.10: [background: none] and [background: 0 0]
+         are computed-value-equivalent (both clear the image and set position to
+         [0 0]). Pick the shorter form under minify. *)
       Pp.string ctx (if Pp.minified ctx then "0 0" else "none")
   | Var v -> pp_var pp_background ctx v
   | Vars vars -> Pp.list ~sep:Pp.space (pp_var pp_background) ctx vars
@@ -8435,10 +8435,10 @@ let rec pp_animation_name : animation_name Pp.t =
   | Name name -> Pp.string ctx name
   | Ambiguous name -> Pp.string ctx name
   | Quoted name ->
-      (* CSS Animations 1 §3.3: [<keyframes-name>] excludes [none], the CSS-wide
-         keywords, and [default]. A source [animation-name: "none"] therefore
-         can't refer to a real [@keyframes none] - it's invalid input that
-         browsers tolerate. Minified output drops the quotes so the value
+      (* CSS Animations 1 sec. 3.3: [<keyframes-name>] excludes [none], the
+         CSS-wide keywords, and [default]. A source [animation-name: "none"]
+         therefore can't refer to a real [@keyframes none] - it's invalid input
+         that browsers tolerate. Minified output drops the quotes so the value
          collapses to the equivalent (and shorter) keyword form. *)
       if Pp.minified ctx then Pp.string ctx name else Pp.quoted_string ctx name
   | Names names -> Pp.list ~sep:Pp.comma pp_animation_name ctx names
@@ -8790,8 +8790,8 @@ let rec pp_position_area : position_area Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_position_area ctx v
   | None -> Pp.string ctx "none"
-  (* CSS Anchor Positioning 1 §6: the second axis defaults to [center], so [X
-     center] minifies to [X]; both axes equal also collapse. *)
+  (* CSS Anchor Positioning 1 sec. 6: the second axis defaults to [center], so
+     [X center] minifies to [X]; both axes equal also collapse. *)
   | Area (first, Some second)
     when Pp.minified ctx && (first = second || second = Center) ->
       pp_position_area_keyword ctx first
@@ -10312,7 +10312,7 @@ let grid_template_area_row_cells row =
   in
   loop [] 0
 
-(* CSS Grid Layout 2 §7.3: a "null cell token" is one or more sequential
+(* CSS Grid Layout 2 sec. 7.3: a "null cell token" is one or more sequential
    periods, all denoting the same single empty cell. Collapse multi-dot
    spellings ([....] / [..]) to the canonical single [.]. *)
 let normalize_grid_template_area_cell c =
@@ -10601,8 +10601,8 @@ let rec pp_place_items : place_items Pp.t =
   | Align_justify (a, j) ->
       let a_s = Pp.to_string ~minify:(Pp.minified ctx) pp_align_items a in
       let j_s = Pp.to_string ~minify:(Pp.minified ctx) pp_justify_items j in
-      (* CSS Align 3 §6.1: when align and justify render to the same token, the
-         single-value spelling is canonical. *)
+      (* CSS Align 3 sec. 6.1: when align and justify render to the same token,
+         the single-value spelling is canonical. *)
       if Pp.minified ctx && a_s = j_s then Pp.string ctx a_s
       else (
         Pp.string ctx a_s;
@@ -10646,7 +10646,7 @@ let rec pp_timing_function : timing_function Pp.t =
   | Step_start -> Pp.string ctx "step-start"
   | Step_end -> Pp.string ctx "step-end"
   | Steps (1, Some (Jump_start | Start)) when Pp.minified ctx ->
-      (* CSS Easing 1 §2: [steps(1, jump-start)] = [steps(1, start)] = the
+      (* CSS Easing 1 sec. 2: [steps(1, jump-start)] = [steps(1, start)] = the
          [step-start] alias; the [end] / [jump-end] equivalents fold to
          [step-end]. *)
       Pp.string ctx "step-start"
@@ -10704,7 +10704,7 @@ let rec pp_svg_paint : svg_paint Pp.t =
       match fallback with
       | None -> ()
       | Some fb ->
-          (* CSS Syntax 3 §5.4.6: a [url(...)] token closes with [)], so the
+          (* CSS Syntax 3 sec. 5.4.6: a [url(...)] token closes with [)], so the
              whitespace before a fallback keyword/colour can be elided under
              minify. *)
           Pp.sp ctx ();
@@ -10789,12 +10789,12 @@ let rec pp_transition : transition Pp.t =
   | Var v -> pp_var pp_transition ctx v
   | Shorthand s -> pp_transition_shorthand ctx s
 
-(* CSS Syntax 3 §4: two adjacent [<number-percentage>] tokens need a separator
-   unless the boundary is unambiguous - the previous ends with [%] (the unit
-   terminates the token), or the next starts with [-]/[+] (a sign starts a new
-   number). Render values to strings first since [pp_number_percentage] picks
-   between [<number>] and [<percentage>] spelling and the spacing depends on the
-   choice. *)
+(* CSS Syntax 3 sec. 4: two adjacent [<number-percentage>] tokens need a
+   separator unless the boundary is unambiguous - the previous ends with [%]
+   (the unit terminates the token), or the next starts with [-]/[+] (a sign
+   starts a new number). Render values to strings first since
+   [pp_number_percentage] picks between [<number>] and [<percentage>] spelling
+   and the spacing depends on the choice. *)
 let render_number_percentages ctx vs =
   List.map (Pp.to_string ~minify:(Pp.minified ctx) pp_number_percentage) vs
 
@@ -10869,11 +10869,11 @@ let rec pp_translate_value : translate_value Pp.t =
   | Var v -> pp_var pp_translate_value ctx v
 
 let rec read_translate_value t : translate_value =
-  (* Per CSS Transforms 2 §3.5: [<length-percentage> <length-percentage>?
+  (* Per CSS Transforms 2 sec. 3.5: [<length-percentage> <length-percentage>?
      <length>?]. Same two [var()] shapes as [read_scale]:
 
-     - [translate: var(--t)] is a whole-value [var()] — produce [Var _]. -
-     [translate: var(--x) var(--y)] is per-slot — produce [XY (_, _)]. *)
+     - [translate: var(--t)] is a whole-value [var()] -- produce [Var _]. -
+     [translate: var(--x) var(--y)] is per-slot -- produce [XY (_, _)]. *)
   let read_lengths_from t (x : length) : translate_value =
     Cursor.ws t;
     match Cursor.option read_length t with
@@ -11013,9 +11013,9 @@ let read_rotate_angle_axis_tail angle t =
       let third = Cursor.number t in
       (Axis (first, second, third, angle) : rotate_value)
 
-(* CSS Transforms 2 §3.3 [rotate] also accepts angle then axis: [<angle> x|y|z]
-   or [<angle> <number>{3}]. Try angle-first after the plain forms; consume the
-   angle, then look for a trailing axis. *)
+(* CSS Transforms 2 sec. 3.3 [rotate] also accepts angle then axis: [<angle>
+   x|y|z] or [<angle> <number>{3}]. Try angle-first after the plain forms;
+   consume the angle, then look for a trailing axis. *)
 let read_rotate_angle_then_axis t : rotate_value =
   let angle = read_angle t in
   Cursor.ws t;
@@ -12392,10 +12392,10 @@ let read_grid_line_pair t : grid_line_pair =
     (Var (Values.read_var read_pair t) : grid_line_pair)
   else read_pair t
 
-(* CSS Grid 2 §8.4: an omitted slot inherits from the corresponding row/column
-   start when that's a [<custom-ident>], else defaults to [auto]. The forward
-   helper is [grid_area_default_from] (defined above with the printer); both
-   directions share it. *)
+(* CSS Grid 2 sec. 8.4: an omitted slot inherits from the corresponding
+   row/column start when that's a [<custom-ident>], else defaults to [auto]. The
+   forward helper is [grid_area_default_from] (defined above with the printer);
+   both directions share it. *)
 let read_grid_area t : grid_area =
   let first = read_grid_line t in
   let rest =
@@ -12682,7 +12682,7 @@ let rec read_grid t : grid_template =
   if Cursor.looking_at_func "var" t then
     (Var (Values.read_var read_grid t) : grid_template)
   else if grid_template_needs_raw_template (Cursor.remaining t) then
-    (* CSS Grid 1 §10.1 [<'grid-template'>] form of [grid]: when the input
+    (* CSS Grid 1 sec. 10.1 [<'grid-template'>] form of [grid]: when the input
        contains a [<string>] token, the value is the [<line-names>? <string>
        <track-size>? <line-names>?]+ form, which [read_grid_template] already
        handles. *)
@@ -14474,10 +14474,10 @@ let rec read_break_value t : break_value =
       ("auto", (Auto : break_value));
       ("avoid", Avoid);
       ("all", All);
-      (* CSS Fragmentation 3 §6: legacy [page-break-*: always] maps to [break-*:
-         page]. The reader accepts the legacy spelling so the page-break alias
-         dispatch (which routes to [Break_before/after]) can keep using this
-         reader. *)
+      (* CSS Fragmentation 3 sec. 6: legacy [page-break-*: always] maps to
+         [break-*: page]. The reader accepts the legacy spelling so the
+         page-break alias dispatch (which routes to [Break_before/after]) can
+         keep using this reader. *)
       ("always", Page);
       ("avoid-page", Avoid_page);
       ("page", Page);
@@ -15863,8 +15863,8 @@ let rec read_font_family_single t : font_family =
   | None -> Cursor.err t "expected font-family value"
 
 and read_font_family t : font_family =
-  (* CSS Cascade 5 §7.3: a CSS-wide keyword ([inherit] / [initial] / [unset] /
-     [revert] / [revert-layer]) must stand alone; mixed inside a
+  (* CSS Cascade 5 sec. 7.3: a CSS-wide keyword ([inherit] / [initial] / [unset]
+     / [revert] / [revert-layer]) must stand alone; mixed inside a
      [<custom-ident>#] list it makes the whole declaration invalid. *)
   let rec loop acc =
     Cursor.ws t;
@@ -16085,7 +16085,7 @@ let rec read_font t : font =
 let rec read_font_stretch t : font_stretch =
   let read_percentage t : font_stretch =
     let n = Cursor.pct t in
-    (* CSS Fonts 4 §6.1.2: font-stretch percentage is non-negative. *)
+    (* CSS Fonts 4 sec. 6.1.2: font-stretch percentage is non-negative. *)
     if n < 0. then err_invalid_value t "font-stretch" (string_of_float n);
     Pct n
   in
@@ -16342,8 +16342,8 @@ let rec read_backface_visibility t : backface_visibility =
     t
 
 let rec read_scale t : scale =
-  (* CSS Transforms 2 §3.6: [<number-percentage>{1,3}]. Two [var()] shapes to
-     keep distinct: [scale: var(--s)] is a whole-value var (produce [Var _]);
+  (* CSS Transforms 2 sec. 3.6: [<number-percentage>{1,3}]. Two [var()] shapes
+     to keep distinct: [scale: var(--s)] is a whole-value var (produce [Var _]);
      [scale: var(--x) var(--y)] is per-slot (produce [XY _]). They are
      indistinguishable until a second component appears, so peel the first
      [var()] as a whole-value [Var]; if another follows, the saved snapshot
@@ -17691,7 +17691,7 @@ let rec read_background_repeat t : background_repeat =
     ~default:read_repeats t
 
 (* The standalone [background-repeat] / [mask-repeat] longhand is a
-   comma-separated layer list (CSS Backgrounds 3 §3.6); the [background] /
+   comma-separated layer list (CSS Backgrounds 3 sec. 3.6); the [background] /
    [mask] shorthand reuses the single-value [read_background_repeat] so it does
    not eat the layer comma. Same split for the box / size / composite readers
    below. *)
@@ -18139,10 +18139,10 @@ let read_conic_gradient_config t : conic_gradient_config =
   then Cursor.err_invalid t "conic-gradient config";
   { angle = !angle; position = !position; interpolation = !interpolation }
 
-(* CSS Images 4 §6.1 [linear-gradient] prelude: [ <angle> | to <side-or-corner>
-   ]? || <color-interpolation-method> A bare interpolation, a bare direction, or
-   both in either order are all valid. Returns [None] when the prelude consumed
-   no tokens. *)
+(* CSS Images 4 sec. 6.1 [linear-gradient] prelude: [ <angle> | to
+   <side-or-corner> ]? || <color-interpolation-method> A bare interpolation, a
+   bare direction, or both in either order are all valid. Returns [None] when
+   the prelude consumed no tokens. *)
 let read_linear_prelude_opt t : gradient_direction option =
   let direction : gradient_direction option ref = ref Option.None in
   let interpolation : color_interpolation option ref = ref Option.None in
@@ -18224,8 +18224,8 @@ let read_linear_gradient_body_stops t =
 
 let read_linear_gradient_body t =
   Cursor.ws t;
-  (* CSS Variables 1 §3: a single [var()] can stand in for the entire body of
-     [linear-gradient(...)], since the variable's value may itself contain
+  (* CSS Variables 1 sec. 3: a single [var()] can stand in for the entire body
+     of [linear-gradient(...)], since the variable's value may itself contain
      commas and stops. Check this case first so the var() does not get
      mis-parsed as an [Angle (Var _)] direction by the prelude reader. *)
   let var_only =
@@ -18755,7 +18755,7 @@ let minify_background_image : background_image -> background_image = function
   | img -> img
 
 let read_any_property t =
-  (* CSS property names are case-insensitive per Syntax §3.3. *)
+  (* CSS property names are case-insensitive per Syntax sec. 3.3. *)
   let prop_name = String.lowercase_ascii_preserve (Cursor.ident t) in
   (* PROPERTY_MATCHING_START - Used by scripts/check_properties.ml *)
   match prop_name with
@@ -19002,7 +19002,7 @@ let read_any_property t =
   | "break-after" -> Prop Break_after
   | "break-inside" -> Prop Break_inside
   | "size" -> Prop Page_size
-  (* CSS Fragmentation 3 §6 page-break-* aliases. Keep them as typed legacy
+  (* CSS Fragmentation 3 sec. 6 page-break-* aliases. Keep them as typed legacy
      properties so pretty output preserves the authored property name; minified
      output still serializes through the shorter modern break-* spelling. *)
   | "page-break-before" -> Prop Page_break_before
@@ -20272,7 +20272,7 @@ let rec read_clip_path (t : Cursor.t) : clip_path =
       ]
       t
   in
-  (* CSS Masking 1 §3.6 [<basic-shape> || <geometry-box>]: a shape and a
+  (* CSS Masking 1 sec. 3.6 [<basic-shape> || <geometry-box>]: a shape and a
      reference box may appear in either order, or just a box on its own. *)
   let at_end t = Cursor.is_done t || Cursor.peek_semicolon t in
   match read_clip_geometry_box_opt t with
@@ -22857,10 +22857,10 @@ let read_mask_border_mode t =
 let read_border_image t : border_image =
   let source = Cursor.option read_background_image t in
   Cursor.ws t;
-  (* CSS Masking 1 §6 [mask-border-mode] is in [&&] juxtaposition with the other
-     slots, so the keyword may appear after [<source>] (before the slice) or
-     after [<repeat>]. Try the early slot first; combine with the trailing slot
-     below. *)
+  (* CSS Masking 1 sec. 6 [mask-border-mode] is in [&&] juxtaposition with the
+     other slots, so the keyword may appear after [<source>] (before the slice)
+     or after [<repeat>]. Try the early slot first; combine with the trailing
+     slot below. *)
   let mode_early = Cursor.option read_mask_border_mode t in
   Cursor.ws t;
   let slice = Cursor.option read_border_image_slice t in

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -92,7 +92,7 @@ type display =
   | Revert_layer
   | Multi of display * display
       (** Two-value [<display-outside> <display-inside>] syntax per CSS Display
-          3 §2.1, e.g. [inline flow-root] or [list-item flow-root]. *)
+          3 sec. 2.1, e.g. [inline flow-root] or [list-item flow-root]. *)
   | Var of display var
 
 type position =
@@ -587,8 +587,8 @@ type flex_basis =
   | Max_content
   | Min_content
   | From_font
-  (* Math functions over [<length-percentage>] (CSS Values 4 §10). Args reuse
-     [length] (which already carries [Pct]) and mirror the [length]
+  (* Math functions over [<length-percentage>] (CSS Values 4 sec. 10). Args
+     reuse [length] (which already carries [Pct]) and mirror the [length]
      constructors; [flex_basis_of_length] carries them across and the printer
      delegates to [pp_length]. *)
   | Clamp of length * length * length
@@ -742,8 +742,8 @@ type grid_auto_flow =
   | Var of grid_auto_flow var
 
 (** [repeat()] count argument: an explicit integer, one of the auto-track-list
-    keywords (CSS Grid 1 §7.2.3.1 / 2), or a [var()] standing in for the count.
-*)
+    keywords (CSS Grid 1 sec. 7.2.3.1 / 2), or a [var()] standing in for the
+    count. *)
 type repeat_count =
   | Count of int
   | Auto_fill
@@ -820,10 +820,10 @@ type grid_line_pair =
   | Lines of grid_line * grid_line
   | Var of grid_line_pair var
 
-(* CSS Grid 2 §8.4: [grid-area: <grid-line> [/ <grid-line>]{0,3}] - row-start /
-   column-start / row-end / column-end. The 1/2/3-value source forms are
-   defaulting per the spec; they all canonicalise to the four-line record so the
-   printer can pick the shortest equivalent spelling. *)
+(* CSS Grid 2 sec. 8.4: [grid-area: <grid-line> [/ <grid-line>]{0,3}] -
+   row-start / column-start / row-end / column-end. The 1/2/3-value source forms
+   are defaulting per the spec; they all canonicalise to the four-line record so
+   the printer can pick the shortest equivalent spelling. *)
 type grid_area =
   | Lines of {
       row_start : grid_line;
@@ -886,13 +886,13 @@ type text_decoration_line =
   | Overline
   | Line_through
   | Blink
-      (** CSS Text Decoration 4 §2.1: deprecated but still part of the
+      (** CSS Text Decoration 4 sec. 2.1: deprecated but still part of the
           [<text-decoration-line>] grammar; UAs typically render it as no-op. *)
   | Spelling_error
-      (** CSS Text Decoration 4 §2.1 [spelling-error]: lets authors style the
-          UA's spelling-error mark via [text-decoration]. *)
+      (** CSS Text Decoration 4 sec. 2.1 [spelling-error]: lets authors style
+          the UA's spelling-error mark via [text-decoration]. *)
   | Grammar_error
-      (** CSS Text Decoration 4 §2.1 [grammar-error]: parallel to
+      (** CSS Text Decoration 4 sec. 2.1 [grammar-error]: parallel to
           [spelling-error]. *)
   | Inherit
   | Initial
@@ -1027,7 +1027,7 @@ type text_emphasis_position =
   | Revert_layer
   | Var of text_emphasis_position var
 
-(** CSS Text 4 §6.1
+(** CSS Text 4 sec. 6.1
     [text-indent: <length-percentage> && hanging? && each-line?]. Each component
     is optional except the length, but the three may appear in any order. *)
 type text_indent_value =
@@ -1073,7 +1073,7 @@ type glyph_orientation_vertical =
   | Revert_layer
   | Var of glyph_orientation_vertical var
 
-(** CSS Text 4 §6.3
+(** CSS Text 4 sec. 6.3
     [text-transform = none | [capitalize | uppercase | lowercase] || full-width
      || full-size-kana]: case + width + kana width are independent and can
     combine. *)
@@ -1879,9 +1879,9 @@ type font_family =
   | List of font_family list
   | Var of font_family var
   | Invalid of invalid_value
-      (** CSS Cascade 5 §7.3: a CSS-wide keyword (e.g. [inherit]) is only valid
-          as a sole top-level value. [font-family: Arial, inherit] mixes it
-          inside a [<custom-ident>#] list and is therefore invalid. Cascade
+      (** CSS Cascade 5 sec. 7.3: a CSS-wide keyword (e.g. [inherit]) is only
+          valid as a sole top-level value. [font-family: Arial, inherit] mixes
+          it inside a [<custom-ident>#] list and is therefore invalid. Cascade
           preserves the source verbatim for round-trip; [Optimize.drop_invalid]
           removes the declaration under [--minify]. *)
 
@@ -2587,7 +2587,7 @@ type border_radius =
   | Unset
   | Revert
   | Revert_layer
-  | Var of border_radius var  (** Per CSS Backgrounds and Borders 3 §5. *)
+  | Var of border_radius var  (** Per CSS Backgrounds and Borders 3 sec. 5. *)
 
 type conic_gradient_config = {
   angle : angle option;  (** [from <angle>] starting angle *)
@@ -2655,7 +2655,7 @@ type background_image =
   | Repeating_linear_gradient of gradient_direction * gradient_stop list
   | Repeating_radial_gradient of radial_gradient_config * gradient_stop list
   | Repeating_conic_gradient of conic_gradient_config * gradient_stop list
-      (** [repeating-{linear,radial,conic}-gradient()] CSS Images 4 §3. *)
+      (** [repeating-{linear,radial,conic}-gradient()] CSS Images 4 sec. 3. *)
   | Webkit_linear_gradient of gradient_direction * gradient_stop list
   | Webkit_repeating_linear_gradient of gradient_direction * gradient_stop list
   | Webkit_radial_gradient of radial_gradient_config * gradient_stop list
@@ -2876,9 +2876,9 @@ type border_image_outset =
   | Revert_layer
   | Var of border_image_outset var
 
-(** CSS Masking 1 §6 [<mask-border-mode>]: shared with the [border_image] record
-    because [mask-border] is otherwise the same shorthand as [border-image] (the
-    mode is always [None] for the latter). *)
+(** CSS Masking 1 sec. 6 [<mask-border-mode>]: shared with the [border_image]
+    record because [mask-border] is otherwise the same shorthand as
+    [border-image] (the mode is always [None] for the latter). *)
 type mask_border_mode = Alpha | Luminance
 
 type border_image = {
@@ -3633,7 +3633,7 @@ type break_inside_value =
   | Revert_layer
   | Var of break_inside_value var
 
-(* CSS Fragmentation 3 §6 deprecated [page-break-before / -after / -inside]
+(* CSS Fragmentation 3 sec. 6 deprecated [page-break-before / -after / -inside]
    aliases. The shorter value vocabulary makes them their own type rather than
    overload [break_value]. *)
 type page_break_value =
@@ -3651,9 +3651,9 @@ type page_break_inside_value =
   | Inherit
   | Var of page_break_inside_value var
 
-(* CSS Paged Media 3 §6.1 [size] descriptor: optional page size keyword (paper
-   sheet name), explicit dimensions, [auto], or a page size combined with an
-   orientation. *)
+(* CSS Paged Media 3 sec. 6.1 [size] descriptor: optional page size keyword
+   (paper sheet name), explicit dimensions, [auto], or a page size combined with
+   an orientation. *)
 type page_size_name =
   | A5
   | A4
@@ -3860,10 +3860,10 @@ type svg_paint =
   | Color of color
   | Url of string * svg_paint option
   | Context_fill
-      (** SVG2 §11.2 [context-fill] - inherits the fill paint of the context
+      (** SVG2 sec. 11.2 [context-fill] - inherits the fill paint of the context
           element, used in marker / pattern / use trees. *)
   | Context_stroke
-      (** SVG2 §11.2 [context-stroke] - mirror of [Context_fill]. *)
+      (** SVG2 sec. 11.2 [context-stroke] - mirror of [Context_fill]. *)
   | Var of svg_paint var
 
 (* Direction Types *)
@@ -4173,7 +4173,7 @@ type clip =
   | Revert_layer
   | Var of clip var
 
-(** CSS Masking 1 §3.6 [<geometry-box>] reference box for [clip-path]: the
+(** CSS Masking 1 sec. 3.6 [<geometry-box>] reference box for [clip-path]: the
     [<shape-box>] from CSS Shapes 1 plus the SVG-specific boxes. *)
 type clip_geometry_box =
   | Margin_box
@@ -4184,7 +4184,7 @@ type clip_geometry_box =
   | Stroke_box
   | View_box
 
-(** CSS Shapes 1 §3.1 [<shape-radius>] for [circle()] / [ellipse()]: a
+(** CSS Shapes 1 sec. 3.1 [<shape-radius>] for [circle()] / [ellipse()]: a
     [<length-percentage>] or one of the extent keywords. *)
 type clip_path_extent = Extent_length of length | Closest_side | Farthest_side
 
@@ -4317,8 +4317,8 @@ and custom_property_value =
   | Typed : { kind : 'a kind; value : 'a } -> custom_property_value
   | Tokens of custom_value
 
-(** [all] shorthand value (CSS Cascade 5 §3.2). The [all] property only accepts
-    CSS-wide keywords - no other syntax is valid. *)
+(** [all] shorthand value (CSS Cascade 5 sec. 3.2). The [all] property only
+    accepts CSS-wide keywords - no other syntax is valid. *)
 type css_wide =
   | Initial
   | Inherit
@@ -4431,7 +4431,7 @@ type 'a property =
   | Grid_template_areas : grid_template_areas property
   | Grid_template : grid_template property
   | Grid : grid_template property
-      (** CSS Grid 1 §8 [grid] shorthand. Cascade treats it as a free-form
+      (** CSS Grid 1 sec. 8 [grid] shorthand. Cascade treats it as a free-form
           [grid_template] for now: the simple cases (track-list, grid-template
           syntax with area strings) round-trip through the same AST as
           [grid-template], and inputs that exercise the auto-flow branches fall

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -1,4 +1,4 @@
-(** Simple CSS parser API — direct and readable.
+(** Simple CSS parser API -- direct and readable.
 
     Cascade parses already-decoded UTF-8 text. It does not implement the CSS
     Syntax section 3.2 byte-stream decoding layer: BOM handling, HTTP or

--- a/lib/rule_index.mli
+++ b/lib/rule_index.mli
@@ -2,7 +2,7 @@
 
     A shorthand composer looks for a contiguous run of specific longhands (e.g.
     [outline-width / -style / -color], or the 12
-    [border-* per side × width/style/color] longhands) and merges them into a
+    [border-* per side x width/style/color] longhands) and merges them into a
     shorthand declaration. Naively each composer scans the rule's declaration
     list once, so running 14 composers per rule walks the list 14 times. The
     index answers "where in the rule does property P appear?" in O(1), so each

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -331,7 +331,7 @@ let read_lang_content t =
   Lang langs
 
 let read_dir_content t =
-  (* :dir() accepts only [ltr] or [rtl] per Selectors 4 §6.5.1. *)
+  (* :dir() accepts only [ltr] or [rtl] per Selectors 4 sec. 6.5.1. *)
   let dir = Cursor.ident t in
   if dir <> "ltr" && dir <> "rtl" then
     Cursor.err_invalid t (":dir() expects ltr or rtl, got: " ^ dir);
@@ -453,7 +453,7 @@ let read_class t =
      including parser-valid double-dash identifiers such as .--x. *)
   Class name
 
-(** Parse an ID selector ([#id]). Per CSS Selectors §6.6, an ID must be an
+(** Parse an ID selector ([#id]). Per CSS Selectors sec. 6.6, an ID must be an
     ident-type hash; unrestricted hashes such as digit-only [#123] are not valid
     IDs. *)
 let read_id t =
@@ -1093,9 +1093,9 @@ let rec matches_nothing = function
   | List xs -> List.for_all matches_nothing xs
   | _ -> false
 
-(* CSS Pseudo-Elements 4 §3.5 / Selectors 4 §3.6.4: a pseudo-element compound
-   may only be followed by pseudo-classes. Class/id/type/attribute selectors
-   after the pseudo-element still make the compound invalid. *)
+(* CSS Pseudo-Elements 4 sec. 3.5 / Selectors 4 sec. 3.6.4: a pseudo-element
+   compound may only be followed by pseudo-classes. Class/id/type/attribute
+   selectors after the pseudo-element still make the compound invalid. *)
 let is_pe_action = function
   | Element _ | Class _ | Id _ | Universal _ | Attribute _ | Nesting -> false
   | sel -> not (is_pseudo_element_selector sel)
@@ -1119,7 +1119,7 @@ let pseudo_element_unknown_idents =
 let read_unknown_pseudo_class_call ~all_idents t =
   match Cursor.peek t with
   | Some (Component.Func { node = { name; arguments; _ }; _ }) ->
-      (* CSS Selectors 4 §3.5: a known non-functional pseudo ([:checked],
+      (* CSS Selectors 4 sec. 3.5: a known non-functional pseudo ([:checked],
          [:hover], ...) called with parens ([:checked()]) is invalid. Reject so
          the rule reader drops it rather than passing through as an unknown
          call. *)
@@ -1184,14 +1184,14 @@ let read_nth_col t = Cursor.call "nth-col" t read_nth_col_content
 let read_nth_last_col t = Cursor.call "nth-last-col" t read_nth_last_col_content
 
 let read_highlight_content t =
-  (* ::highlight() takes a single custom-ident per CSS Custom Highlight API
-     §3.1; comma-separated names are rejected. *)
+  (* ::highlight() takes a single custom-ident per CSS Custom Highlight API sec.
+     3.1; comma-separated names are rejected. *)
   let name = Cursor.ident t in
   ensure_call_done t "highlight";
   Highlight [ name ]
 
 let read_vt_class_selector t : vt_class_selector =
-  (* CSS View Transitions 2 §3.4.1 [<vt-class-selector>] = [<vt-name>?
+  (* CSS View Transitions 2 sec. 3.4.1 [<vt-class-selector>] = [<vt-name>?
      [.<custom-ident>]*]. The name is [<custom-ident> | *]; either the name or
      at least one class must be present. *)
   Cursor.ws t;
@@ -1332,7 +1332,7 @@ and read_has_content t =
 
 and read_not_content t =
   let selectors = read_complex_list t in
-  (* CSS Selectors 4 §6.2: [:not()] is non-forgiving, so an unknown selector
+  (* CSS Selectors 4 sec. 6.2: [:not()] is non-forgiving, so an unknown selector
      inside it invalidates the whole rule. Top-level lists keep unknown
      pseudo-classes for forward compatibility. *)
   List.iter
@@ -1501,7 +1501,7 @@ and read_pseudo_element t =
         t)
     t
 
-(** Parse a simple selector (one part). Does not skip leading whitespace — the
+(** Parse a simple selector (one part). Does not skip leading whitespace -- the
     caller (read_compound) uses whitespace as a compound / descendant boundary
     marker. *)
 and read_simple ?(allow_unknown_pseudo_class = false) t =
@@ -1545,11 +1545,11 @@ and read_compound t =
         || Cursor.peek_ident t <> None
   in
   let prepend_simple acc =
-    (* CSS Selectors 4 §3.5: tolerate unknown pseudo-classes for forward compat
-       (vendor pseudos, authored future-pseudos must round-trip). Non-forgiving
-       rejection lives where the spec requires it: inside [:not()]/[:has()]
-       ([read_not_content]/[read_has_content]) and in the rule reader when a
-       whole selector list is unknown. *)
+    (* CSS Selectors 4 sec. 3.5: tolerate unknown pseudo-classes for forward
+       compat (vendor pseudos, authored future-pseudos must round-trip).
+       Non-forgiving rejection lives where the spec requires it: inside
+       [:not()]/[:has()] ([read_not_content]/[read_has_content]) and in the rule
+       reader when a whole selector list is unknown. *)
     let s = read_simple ~allow_unknown_pseudo_class:true t in
     if List.exists is_pseudo_element_selector acc && not (is_pe_action s) then
       Cursor.err t "pseudo-element must be last in compound selector"
@@ -1733,10 +1733,10 @@ let elem ctx name = Pp.string ctx ("::" ^ name)
 let vendor ctx name = Pp.string ctx (":-" ^ name)
 let vendor_elem ctx name = Pp.string ctx ("::-" ^ name)
 
-(* CSS Selectors 4 §3.7 keeps [:before] (CSS 2.1) as a deprecated compatibility
-   spelling for the four original pseudo-elements. Minified output uses the
-   shorter valid alias; pretty output preserves the parsed colon form so the
-   authored spelling round-trips. *)
+(* CSS Selectors 4 sec. 3.7 keeps [:before] (CSS 2.1) as a deprecated
+   compatibility spelling for the four original pseudo-elements. Minified output
+   uses the shorter valid alias; pretty output preserves the parsed colon form
+   so the authored spelling round-trips. *)
 let legacy_elem ctx form name =
   let prefix =
     if Pp.minified ctx then ":"
@@ -2624,7 +2624,7 @@ let rec has_newer_pseudo_class = function
   | Relative (_, b) -> has_newer_pseudo_class b
   | List xs -> List.exists has_newer_pseudo_class xs
   | Current_of xs -> List.exists has_newer_pseudo_class xs
-  (* Stop recursion at forgiving selectors — :is()/:where() have forgiving
+  (* Stop recursion at forgiving selectors -- :is()/:where() have forgiving
      parsing, so newer pseudo-classes inside them don't cause the whole rule to
      fail *)
   | Is _ | Where _ | Moz_any_call _ | Webkit_any_call _ -> false

--- a/lib/selector_intf.ml
+++ b/lib/selector_intf.ml
@@ -56,7 +56,7 @@ type nth =
   | An_plus_b of int * int (* An+B: a is coefficient, b is offset *)
 
 type vt_class_selector = { name : string option; classes : string list }
-(** CSS View Transitions 2 §3.4.1 [<vt-class-selector>]: an optional vt-name
+(** CSS View Transitions 2 sec. 3.4.1 [<vt-class-selector>]: an optional vt-name
     ([<custom-ident>] or [*]) followed by zero or more [.<custom-ident>] class
     qualifiers. The empty case (no name and no classes) does not appear in
     cascade output - the parser always reads at least one component. *)
@@ -216,7 +216,7 @@ type t =
   | Cue_region of t list (* ::cue-region(...) - takes selectors *)
   | Highlight of
       string list (* ::highlight(...) - takes custom highlight names *)
-  | View_transition (* ::view-transition (CSS View Transitions 1 §3.2) *)
+  | View_transition (* ::view-transition (CSS View Transitions 1 sec. 3.2) *)
   | View_transition_group of vt_class_selector
       (** ::view-transition-group with optional name and class suffixes. *)
   | View_transition_image_pair of vt_class_selector

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -772,7 +772,7 @@ let try_merge_box_shorthand ~original ~property ~vs ~important ~absorb
             in
             (Declaration.v ~important property value, rest'))
 
-(* CSS Overflow 3 §3.1: [overflow] is the [overflow-x overflow-y] shorthand.
+(* CSS Overflow 3 sec. 3.1: [overflow] is the [overflow-x overflow-y] shorthand.
    When the two longhands appear together with matching importance and neither
    side is later shadowed within the same block, fold them into [overflow] -
    single value when the two axes match, two values otherwise. *)
@@ -868,9 +868,9 @@ let extract_padding_side :
       Some (Left, value, important)
   | _ -> None
 
-(* CSS Position 3 §3.1: [inset] is the [top right bottom left] shorthand. The
-   longhand values are wrapped in a [length list] for grammar reasons but carry
-   exactly one length per side. *)
+(* CSS Position 3 sec. 3.1: [inset] is the [top right bottom left] shorthand.
+   The longhand values are wrapped in a [length list] for grammar reasons but
+   carry exactly one length per side. *)
 let extract_inset_side : declaration -> (box_side * Values.length * bool) option
     = function
   | Declaration { property = Top; value = [ v ]; important } ->
@@ -1183,7 +1183,7 @@ let extract_inset_block_side :
       Some (End, v, important)
   | _ -> None
 
-(* CSS Align 3 §6.1: [place-items] / [place-content] / [place-self] are the
+(* CSS Align 3 sec. 6.1: [place-items] / [place-content] / [place-self] are the
    [<align> <justify>] shorthands. When the two longhands appear contiguously
    with matching importance, fold them; the per-property printer then collapses
    matching pairs to a single value. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -296,9 +296,9 @@ let pp_property_rule : 'a property_rule Pp.t =
       if not ctx.Pp.minify then Pp.semicolon ctx ())
     ctx ()
 
-(* CSS Animations 1 §3 [<keyframes-name>] is [<custom-ident> | <string>]. The
-   reader normalizes either form to a plain OCaml string; on output we prefer
-   the bare identifier when the value is a syntactically valid CSS ident
+(* CSS Animations 1 sec. 3 [<keyframes-name>] is [<custom-ident> | <string>].
+   The reader normalizes either form to a plain OCaml string; on output we
+   prefer the bare identifier when the value is a syntactically valid CSS ident
    (shorter than the quoted form), falling back to a double-quoted string when
    the name contains characters that would otherwise need escaping. *)
 let pp_keyframes_name ctx name =
@@ -1621,7 +1621,7 @@ let read_keyframes_block inner =
   in
   read_frames []
 
-(* CSS Animations 1 §3: [@keyframes <keyframes-name>], [<keyframes-name> =
+(* CSS Animations 1 sec. 3: [@keyframes <keyframes-name>], [<keyframes-name> =
    <custom-ident> | <string>]. The reserved spellings ([none], CSS-wide
    keywords, [default]) are excluded from [<custom-ident>], but every mainstream
    minifier accepts them as [<string>], so cascade keeps them too rather than
@@ -1712,16 +1712,16 @@ let read_descriptor_block normalize inner =
   in
   loop []
 
-(* CSS Fonts 4 §11.2 wants the first bound of a descriptor range <= the second.
-   Browsers keep a descending range, so the readers accept it but record a
-   warning here; [Css.of_string ~strict] then turns the warning into an
+(* CSS Fonts 4 sec. 11.2 wants the first bound of a descriptor range <= the
+   second. Browsers keep a descending range, so the readers accept it but record
+   a warning here; [Css.of_string ~strict] then turns the warning into an
    error. *)
 let warn_descending_range r property =
   Cursor.push_warning r
     (Error.bad_value (Cursor.position r) ~property
        ~reason:
          "range must run from the smaller value to the larger (CSS Fonts 4 \
-          §11.2)")
+          \u{00a7}11.2)")
 
 let font_weight_num = function
   | (Properties.Weight n : Properties.font_weight) -> Some n
@@ -1994,10 +1994,10 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
         if Cursor.peek_semicolon r then Cursor.skip r;
         Some descriptor
     | exception Error.Parse_error e ->
-        (* CSS Fonts 4 §11.2 / CSS Syntax 3 §5.4.4: a descriptor that does not
-           parse - an unknown name (Fontsource's [font-named-instance]) or an
-           invalid value of a known one ([font-display:maybe]) - is dropped and
-           the rest of the @font-face is kept, matching browsers. *)
+        (* CSS Fonts 4 sec. 11.2 / CSS Syntax 3 sec. 5.4.4: a descriptor that
+           does not parse - an unknown name (Fontsource's [font-named-instance])
+           or an invalid value of a known one ([font-display:maybe]) - is
+           dropped and the rest of the @font-face is kept, matching browsers. *)
         Cursor.push_warning r e;
         let rec skip_to_semicolon () =
           match Cursor.next_raw r with
@@ -2022,9 +2022,9 @@ let read_font_face (r : Cursor.t) : statement =
   Cursor.with_context r "@font-face" @@ fun () ->
   Cursor.expect_at_keyword "font-face" r;
   Cursor.ws r;
-  (* CSS Fonts 4 §11.2.1: missing [font-family] / [src] is a semantic mismatch,
-     not a syntax one. [validate_partial_statement] flags it; the syntactic
-     reader accepts. *)
+  (* CSS Fonts 4 sec. 11.2.1: missing [font-family] / [src] is a semantic
+     mismatch, not a syntax one. [validate_partial_statement] flags it; the
+     syntactic reader accepts. *)
   let descriptors = Cursor.braces read_font_face_block r in
   Font_face descriptors
 
@@ -2196,8 +2196,8 @@ let read_counter_style (r : Cursor.t) : statement =
   counter_style_validate r descriptors;
   Counter_style (name, descriptors)
 
-(* CSS Paged Media 3 §3.1: a page selector is an optional page name followed by
-   zero or more pseudo-pages from [:first | :left | :right | :blank]. *)
+(* CSS Paged Media 3 sec. 3.1: a page selector is an optional page name followed
+   by zero or more pseudo-pages from [:first | :left | :right | :blank]. *)
 let page_selector_error r s =
   Cursor.err_invalid r ("invalid @page selector: " ^ s)
 
@@ -2325,8 +2325,8 @@ let read_page_margin_rule r =
     when List.mem name allowed_page_margin_names ->
       Cursor.skip r;
       Cursor.ws r;
-      (* CSS Paged Media §5: a page-margin box accepts every descriptor valid in
-         [@page] plus [content]. *)
+      (* CSS Paged Media sec. 5: a page-margin box accepts every descriptor
+         valid in [@page] plus [content]. *)
       let descriptors =
         Cursor.braces
           (fun inner ->
@@ -2731,7 +2731,7 @@ let unknown_block_body slice value =
       in
       slice first.Loc.start_pos last.Loc.end_pos |> trim_unknown_block_body
 
-(* CSS Syntax 3 §5.4.2 "consume an at-rule": after the at-keyword has been
+(* CSS Syntax 3 sec. 5.4.2 "consume an at-rule": after the at-keyword has been
    consumed, walk components until we hit [;] (no block) or [{...}] (block). Raw
    prelude/block strings are sliced from the original source so the at-rule
    round-trips byte-for-byte even when its grammar is unknown. *)
@@ -3050,7 +3050,7 @@ let rec read_statement (r : Cursor.t) : statement =
       match List.assoc_opt name table with
       | Some p -> p r
       | None ->
-          (* CSS Syntax 3 §5.4.1: an at-rule with no registered handler is
+          (* CSS Syntax 3 sec. 5.4.1: an at-rule with no registered handler is
              reported via a typed warning so [Css.of_string] partial-recovery
              can surface it to callers. The prelude/block stay in the AST as
              [Unknown_at_rule], and [Optimize.drop_unknown] removes them under
@@ -3079,7 +3079,7 @@ and read_block (r : Cursor.t) : block =
       let loc = Cursor.position r in
       let snap = Cursor.save r in
       match read_statement r with
-      (* CSS Syntax 3 §5.4.1: a rule that fails to parse (e.g. an invalid
+      (* CSS Syntax 3 sec. 5.4.1: a rule that fails to parse (e.g. an invalid
          selector) is dropped, and parsing resumes at the next rule - one bad
          rule must not take the rest of the [@layer] / [@media] block with it.
          Strict mode ([not (Cursor.recover r)]) still raises. *)
@@ -3089,7 +3089,7 @@ and read_block (r : Cursor.t) : block =
           skip_bad_statement ();
           read_statements acc
       | Import _ ->
-          (* CSS Cascade L6 §2: @import is only valid at the top of the
+          (* CSS Cascade L6 sec. 2: @import is only valid at the top of the
              stylesheet. Drop a misplaced one rather than emitting it. *)
           Cursor.push_warning r
             (Error.bad_value loc ~property:"stylesheet"
@@ -3407,7 +3407,7 @@ and read_rule_decl_or_nested selector inner decls nested =
       if Cursor.peek_semicolon inner then Cursor.skip inner;
       `Continue (d :: decls, nested)
   | None -> read_nested_rule_or_done selector inner decls nested
-  (* CSS Nesting 1 §2 lets a nested rule start with an identifier, so
+  (* CSS Nesting 1 sec. 2 lets a nested rule start with an identifier, so
      [h2:where(...) { ... }] reads as a declaration up to the [{]. Rewind and
      take it as a rule; a genuine bad declaration has no block and still reports
      as one. *)

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -186,9 +186,9 @@ and statement =
       prelude : string;
       block : string option;
     }
-      (** CSS Syntax 3 §5.4.2 "consume an at-rule" preserves any unrecognised
-          at-rule as raw text so authors can ship unknown vendor or future
-          at-rules without dropping the whole stylesheet. *)
+      (** CSS Syntax 3 sec. 5.4.2 "consume an at-rule" preserves any
+          unrecognised at-rule as raw text so authors can ship unknown vendor or
+          future at-rules without dropping the whole stylesheet. *)
 
 and block = statement list
 (** A block contains a list of statements *)
@@ -288,7 +288,7 @@ and font_face_descriptor =
   | Font_display of Properties.font_display
       (** auto, block, swap, fallback, optional *)
   | Unicode_range of Properties.unicode_range list
-      (** CSS Fonts 4 §4.5 comma-separated [unicode-range] list. *)
+      (** CSS Fonts 4 sec. 4.5 comma-separated [unicode-range] list. *)
   | Font_variant of font_variant_descriptor  (** [font-variant] descriptor *)
   | Font_feature_settings of Properties.font_feature_settings
       (** OpenType feature settings *)

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -1,6 +1,6 @@
 (** CSS Syntax Module Level 3 section 4.2: token taxonomy.
 
-    Types only; the §4.3 tokenization algorithm lives in {!Lexer}. *)
+    Types only; the sec. 4.3 tokenization algorithm lives in {!Lexer}. *)
 
 type hash_flag = Id | Unrestricted
 type number_flag = Integer | Number

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -787,7 +787,7 @@ let pp_calc_contents : type a. a Pp.t -> a calc Pp.t =
 
 (* Fold [a / b] only when the float quotient round-trips through multiplication:
    exact divisions like [100/4 = 25] survive but [100/3 = 33.333...] does not,
-   so the calc wrapper stays and CSS Values 4 §10.7's precision requirement
+   so the calc wrapper stays and CSS Values 4 sec. 10.7's precision requirement
    holds. *)
 let exact_div (a : float) (b : float) : float option =
   if b = 0. then Option.none
@@ -822,7 +822,7 @@ let fold_zero_numeric_expr : type a.
       match value with Some 0. -> Some (Num 0.) | _ -> None)
   | _ -> None
 
-(* CSS Values 4 §10.7 value-independent calc identities: hold for any finite
+(* CSS Values 4 sec. 10.7 value-independent calc identities: hold for any finite
    operand, so they fold even across a kept [var()] (single-valued inside
    [calc()], so [var * 1 = var]). Identity cases ([x * 1], [x / 1], [x + 0],
    ...) return the operand verbatim; zero-producing cases take the type's
@@ -870,7 +870,7 @@ let default_calc_ctx = { var_is_single_valued = (fun _ -> false) }
 (* A nested [calc()] or a parenthesised group around a single leaf is redundant
    grouping: drop it. A [var()] leaf is only safe to unwrap when the var is
    single-valued; otherwise its substitution could be a multi-term expression
-   that needs the grouping (CSS Values 4 §10.10). *)
+   that needs the grouping (CSS Values 4 sec. 10.10). *)
 let unwrap_grouping : type a.
     ctx:calc_ctx -> rewrap:(a calc -> a calc) -> a calc -> a calc =
  fun ~ctx ~rewrap reduced ->
@@ -915,7 +915,7 @@ let rec eval_calc : type a. ?ctx:calc_ctx -> a calc -> a calc =
               | Some zero -> zero
               | None -> Expr (l, op, r))))
 
-(* CSS Values 4 §10.7 typed [calc()] reduction, shared by every dimensioned
+(* CSS Values 4 sec. 10.7 typed [calc()] reduction, shared by every dimensioned
    type: the [Expr] dispatch is identical, only the per-type leaves differ and
    are passed in ([math_fn], [scale], [combine], [zero] / [is_zero] for the
    identities). A shape with no [scale] / [combine] returns [None] and the
@@ -965,7 +965,7 @@ let rec eval_typed_calc : type a.
           match scale ~exact:true Mul a n with
           | Some v -> Val v
           | None -> Expr (l, op, r))
-      (* CSS Values 4 §10.7: [1 / (1 / x)] cancels the double inversion. *)
+      (* CSS Values 4 sec. 10.7: [1 / (1 / x)] cancels the double inversion. *)
       | Num 1., Div, Parens (Expr (Num 1., Div, x)) -> x
       | Num 1., Div, Expr (Num 1., Div, x) -> x
       | _ -> (
@@ -976,10 +976,11 @@ let rec eval_typed_calc : type a.
 let pp_calc : type a. a Pp.t -> a calc Pp.t =
  fun pp_value ctx calc ->
   match calc with
-  (* CSS Values 4 §10.10: a [var()] inside [calc()] is a runtime substitution
-     boundary - the substituted tokens go through calc's typed grammar, not the
-     surrounding property's grammar. Unwrapping [calc(var(--x))] to bare
-     [var(--x)] would change which substitution shape is valid. *)
+  (* CSS Values 4 sec. 10.10: a [var()] inside [calc()] is a runtime
+     substitution boundary - the substituted tokens go through calc's typed
+     grammar, not the surrounding property's grammar. Unwrapping
+     [calc(var(--x))] to bare [var(--x)] would change which substitution shape
+     is valid. *)
   | Val v when Pp.minified ctx -> pp_value ctx v
   | Num n when Pp.minified ctx -> Pp.float ctx n
   | _ ->
@@ -1196,7 +1197,7 @@ let rec resolve_length_calc_vars ctx : length calc -> length calc = function
     as leaf ->
       leaf
 
-(* CSS Values 4 §6.1: the absolute lengths share px as a canonical unit. *)
+(* CSS Values 4 sec. 6.1: the absolute lengths share px as a canonical unit. *)
 let absolute_unit_px_ratio = function
   | "px" -> Some 1.
   | "in" -> Some 96.
@@ -1207,9 +1208,9 @@ let absolute_unit_px_ratio = function
   | "pc" -> Some (96. /. 6.)
   | _ -> None
 
-(* CSS Values 4 §10.7: same-unit add/sub of two typed lengths reduces to a
+(* CSS Values 4 sec. 10.7: same-unit add/sub of two typed lengths reduces to a
    single length. Mixed cases reduce when both operands are absolute units
-   (px-compatible per §6.1) by combining in the canonical px form; relative
+   (px-compatible per sec. 6.1) by combining in the canonical px form; relative
    units (em/rem/vw/...) still require cascade context and stay unfolded. *)
 let length_combine op v1 v2 =
   let combine a b =
@@ -1226,11 +1227,11 @@ let length_combine op v1 v2 =
       | _ -> None)
   | _ -> None
 
-(* CSS Values 4 §10.7: a unitless factor scales a typed length, unit unchanged.
-   Division folds only when [exact_div] is exact, else the [calc()] is kept to
-   avoid precision loss. Exception: an irrational divisor (a math constant [pi]
-   / [e] / ...) can never be exact, and keeping [calc()] preserves no more
-   precision than the browser computes, so fold to the rounded value. *)
+(* CSS Values 4 sec. 10.7: a unitless factor scales a typed length, unit
+   unchanged. Division folds only when [exact_div] is exact, else the [calc()]
+   is kept to avoid precision loss. Exception: an irrational divisor (a math
+   constant [pi] / [e] / ...) can never be exact, and keeping [calc()] preserves
+   no more precision than the browser computes, so fold to the rounded value. *)
 let length_scale ?(exact = true) op v n =
   if not (Float.is_finite n) then Option.none
   else
@@ -1249,9 +1250,10 @@ let length_scale ?(exact = true) op v n =
           else Option.none
     | _ -> Option.none
 
-(* CSS Values 4 §10.7: [abs()] preserves the input's type, so [abs(<length>)]
-   returns a [<length>]. The generic [Math_fn -> Num] reduction strips the unit;
-   reconstruct a length [Val] when the argument's [Dim] carries one. *)
+(* CSS Values 4 sec. 10.7: [abs()] preserves the input's type, so
+   [abs(<length>)] returns a [<length>]. The generic [Math_fn -> Num] reduction
+   strips the unit; reconstruct a length [Val] when the argument's [Dim] carries
+   one. *)
 let length_of_math_fn (fn : math_fn) : length option =
   match fn with
   | Abs_n (Dim (n, unit)) ->
@@ -1261,7 +1263,7 @@ let length_of_math_fn (fn : math_fn) : length option =
 let length_math_fn_value (fn : math_fn) : float option =
   match fn with Sin _ | Cos _ -> None | fn -> eval_math_fn fn
 
-(* CSS Values 4 §10.10: identity-rule simplifications around a runtime
+(* CSS Values 4 sec. 10.10: identity-rule simplifications around a runtime
    substitution would change the substituted-grammar context. *)
 (* A [-webkit-] / [-moz-] intrinsic sizing keyword, the legacy fallback an
    author pairs with the unprefixed form ([width:-webkit-max-content;
@@ -1541,11 +1543,11 @@ let ordered_linear_terms terms =
           Hashtbl.replace table unit
             { term with value = term.value +. n; count = term.count + 1 })
     terms;
-  (* CSS Values 4 §10.10: a calc()'s type is the union of its argument types.
-     Dropping [0%] from [calc(100px + 0%)] would narrow [<length-percentage>] to
-     [<length>] and break interpolation, so [0%] is kept as a type sentinel.
-     Other zero terms (e.g. [0px] beside another [px]) drop, their unit already
-     in the result. *)
+  (* CSS Values 4 sec. 10.10: a calc()'s type is the union of its argument
+     types. Dropping [0%] from [calc(100px + 0%)] would narrow
+     [<length-percentage>] to [<length>] and break interpolation, so [0%] is
+     kept as a type sentinel. Other zero terms (e.g. [0px] beside another [px])
+     drop, their unit already in the result. *)
   let keep_zero_term term =
     length_unit_is_pct term.unit
     && Hashtbl.fold
@@ -2210,8 +2212,8 @@ let pp_color_name : color_name Pp.t =
   | White_smoke -> Pp.string ctx "whitesmoke"
   | Yellow_green -> Pp.string ctx "yellowgreen"
 
-(* CSS Color 4 §6.4: every named colour has a canonical sRGB byte triple. Minify
-   routes [Named n] through this table for the shortest spelling (name vs
+(* CSS Color 4 sec. 6.4: every named colour has a canonical sRGB byte triple.
+   Minify routes [Named n] through this table for the shortest spelling (name vs
    [#hex]). Hex is stored shortest ([shorten_hex] folds [rrggbb] to [rgb]), so
    [pp_color]'s back-conversion is a no-op. *)
 
@@ -2847,12 +2849,12 @@ let lerp_byte b1 b2 w1 w2 =
   Float.to_int
     (Float.round ((Float.of_int b1 *. w1) +. (Float.of_int b2 *. w2)))
 
-(* Mix two static colours in sRGB per CSS Color 5 §5. [None] if either operand
-   can't fold statically ([Var] / [Calc]) or the weights reduce to zero. CSS
-   Color 4 §4.2.3 [none] sentinel: a [none] channel inherits the other operand's
-   channel rather than averaging in a zero; both [none] yields [none] (returned
-   as zero, since the caller routes through [Hex] and [#000000] is the shortest
-   fully-[none] spelling). *)
+(* Mix two static colours in sRGB per CSS Color 5 sec. 5. [None] if either
+   operand can't fold statically ([Var] / [Calc]) or the weights reduce to zero.
+   CSS Color 4 sec. 4.2.3 [none] sentinel: a [none] channel inherits the other
+   operand's channel rather than averaging in a zero; both [none] yields [none]
+   (returned as zero, since the caller routes through [Hex] and [#000000] is the
+   shortest fully-[none] spelling). *)
 let mix_srgb_bytes c1 c2 ~p1 ~p2 =
   match
     (static_color_to_srgb_channels c1, static_color_to_srgb_channels c2)
@@ -3409,7 +3411,7 @@ let named_for_hex value =
     matching Lightning CSS behavior. *)
 let shorten_hex value =
   let len = String.length value in
-  (* #RRGGBB → #RGB when R=R, G=G, B=B *)
+  (* #RRGGBB -> #RGB when R=R, G=G, B=B *)
   if
     len = 6
     && value.[0] = value.[1]
@@ -3420,7 +3422,7 @@ let shorten_hex value =
     Bytes.set s 0 value.[0];
     Bytes.set s 1 value.[2];
     Bytes.set s 2 value.[4];
-    Bytes.to_string s (* #RRGGBBAA → #RGBA when R=R, G=G, B=B, A=A *))
+    Bytes.to_string s (* #RRGGBBAA -> #RGBA when R=R, G=G, B=B, A=A *))
   else if
     len = 8
     && value.[0] = value.[1]
@@ -3429,7 +3431,7 @@ let shorten_hex value =
     && value.[6] = value.[7]
   then (
     if
-      (* Further shorten #RGBA → #RGB when A=f (fully opaque) *)
+      (* Further shorten #RGBA -> #RGB when A=f (fully opaque) *)
       value.[6] = 'f' || value.[6] = 'F'
     then (
       let s = Bytes.create 3 in
@@ -3445,13 +3447,13 @@ let shorten_hex value =
       Bytes.set s 3 value.[6];
       Bytes.to_string s)
   else if
-    (* #RRGGBBFF → #RRGGBB when fully opaque *)
+    (* #RRGGBBFF -> #RRGGBB when fully opaque *)
     len = 8
     && (value.[6] = 'f' || value.[6] = 'F')
     && (value.[7] = 'f' || value.[7] = 'F')
   then String.sub value 0 6
   else if
-    (* #RGBA → #RGB when A=f (fully opaque) *)
+    (* #RGBA -> #RGB when A=f (fully opaque) *)
     len = 4 && (value.[3] = 'f' || value.[3] = 'F')
   then String.sub value 0 3
   else value
@@ -3478,7 +3480,7 @@ let minify_color : color -> color = function
       else Named n
   | c -> c
 
-(* CSS Color 4 §11 normalises system colour keywords to lowercase ASCII. *)
+(* CSS Color 4 sec. 11 normalises system colour keywords to lowercase ASCII. *)
 let pp_system_color : system_color Pp.t =
  fun ctx -> function
   | Accent_color -> Pp.string ctx "accentcolor"
@@ -3593,7 +3595,7 @@ let rec pp_alpha : alpha Pp.t =
  fun ctx -> function
   | None -> ()
   | Num f ->
-      (* CSSOM serialisation (CSS Values 4 §6.7.2) drops a leading zero on
+      (* CSSOM serialisation (CSS Values 4 sec. 6.7.2) drops a leading zero on
          fractional numbers: emit [.25] not [0.25] in both modes. Under minify,
          round to 3 decimals (alpha precision is 1/255 ~ 0.004 in sRGB). *)
       let max_decimals = if Pp.minified ctx then 3 else 8 in
@@ -3880,7 +3882,7 @@ let normalize_duration ?(ctx = default_calc_ctx) (d : duration) : duration =
       match eval_time_calc ~ctx c with Val v -> v | folded -> Calc folded)
   | _ -> d
 
-(* CSS Values 4 §10.7: a typed [<angle>] multiplied or divided by a unitless
+(* CSS Values 4 sec. 10.7: a typed [<angle>] multiplied or divided by a unitless
    number scales the angle's coefficient and keeps its unit, so [calc(1deg *
    -45)] reduces to [-45deg]. Division folds only when the quotient is [exact]
    (see [exact_div]); dividing by a math constant ([pi] / ...) is irrational, so
@@ -3912,7 +3914,7 @@ let angle_is_zero : angle -> bool = function
   | Deg f | Rad f | Turn f | Grad f -> f = 0.
   | _ -> false
 
-(* CSS Values 4 §10.7: same-unit add/sub of two typed angles reduces to one
+(* CSS Values 4 sec. 10.7: same-unit add/sub of two typed angles reduces to one
    angle ([calc(45deg + 45deg)] -> [90deg]). Cross-unit operands (e.g. [1turn +
    90deg]) stay unfolded; [normalize_angle] picks the shortest spelling of a
    single folded operand, not across a mixed sum. *)
@@ -4285,7 +4287,7 @@ let rec pp_rgb : rgb Pp.t =
   | Channels { r; g; b } -> Pp.list ~sep:Pp.space pp_channel ctx [ r; g; b ]
   | Var v -> pp_var pp_rgb ctx v
 
-(** Lab-like float string. CSSOM serialisation (CSS Values 4 §6.7.2) drops a
+(** Lab-like float string. CSSOM serialisation (CSS Values 4 sec. 6.7.2) drops a
     leading zero on fractional numbers; the coefficient prints in full so the
     value round-trips, with precision reduction left to [normalize_color]. *)
 let string_of_lab_float f =
@@ -4692,7 +4694,7 @@ and pp_color_default : color Pp.t =
 
 let pp_specified_color = pp_color_default
 
-(* CSS Values 4 §6.3: [ms] and [s] are interchangeable; pick the shorter
+(* CSS Values 4 sec. 6.3: [ms] and [s] are interchangeable; pick the shorter
    spelling when minifying. The "s" suffix is one character shorter than "ms",
    so a millisecond value collapses to seconds when its second-form digits are
    no longer than the millisecond-form digits. *)
@@ -5086,7 +5088,7 @@ let read_math_constant_name t name =
   | _ -> Cursor.err t "expected math constant"
 
 let read_math_number_with_unit t =
-  (* CSS Values 5 §10.7 [sign()] / [abs()] accept a [<calc-sum>] over any
+  (* CSS Values 5 sec. 10.7 [sign()] / [abs()] accept a [<calc-sum>] over any
      numeric type, including dimensions and percentages. Capture the leading
      number plus its unit so [sign(-1vw)] and [sign(1%)] preserve their source
      shape. *)
@@ -5170,8 +5172,8 @@ let math_constant_factor_of_name : type a. Cursor.t -> _ -> string -> a calc =
 
 let read_math_constant_factor : type a. Cursor.t -> a calc =
  fun t ->
-  (* CSS Values 4 §10.7.1 math constants ([pi], [e], [infinity], [-infinity],
-     [NaN]) appear as bare identifiers inside [calc()]. *)
+  (* CSS Values 4 sec. 10.7.1 math constants ([pi], [e], [infinity],
+     [-infinity], [NaN]) appear as bare identifiers inside [calc()]. *)
   let snap = Cursor.save t in
   match Cursor.ident_opt t with
   | Some name -> math_constant_factor_of_name t snap name
@@ -5257,7 +5259,7 @@ and read_calc_numeric_function : type a. Cursor.t -> a calc =
       | "min" -> read_numeric_list_call "min" Float.min Float.infinity t
       | "max" -> read_numeric_list_call "max" Float.max Float.neg_infinity t
       | "clamp" -> read_numeric_clamp t
-      (* CSS Values 4 §10.7 numeric math functions: parsed into the typed
+      (* CSS Values 4 sec. 10.7 numeric math functions: parsed into the typed
          [Math_fn] AST so pretty pp re-emits [name(args)]; the optimizer (or
          minify pp) folds via [eval_math_fn]. *)
       | "sqrt" -> Math_fn (Sqrt (read_math_call_arg "sqrt" t))
@@ -5927,7 +5929,7 @@ and read_rgb t : rgb =
 
 let read_rgb_space_separated t : color =
   (* The cursor wraps the [rgb(...)] [Func] arguments, so there is no closing
-     [)] to consume — it's the block boundary. *)
+     [)] to consume -- it's the block boundary. *)
   Cursor.ws t;
   if Cursor.looking_at t "var(" then (
     let snap = Cursor.save t in
@@ -6060,7 +6062,7 @@ let read_atan2_scalar t : atan2_category * float =
   match unit with
   | "" -> (Number, n)
   | "%" -> (Percentage, n)
-  (* CSS Values 4 §6.2 absolute lengths converted to [px]. *)
+  (* CSS Values 4 sec. 6.2 absolute lengths converted to [px]. *)
   | "px" -> (Length, n)
   | "cm" -> (Length, n *. (96. /. 2.54))
   | "mm" -> (Length, n *. (96. /. 25.4))
@@ -6147,7 +6149,7 @@ let read_angle_trig kind name t =
 let read_angle_atan2 t =
   let typed t =
     Cursor.call "atan2" t (fun inner ->
-        (* CSS Values 4 §10.7: atan2(y, x) accepts <number>|<dimension>|
+        (* CSS Values 4 sec. 10.7: atan2(y, x) accepts <number>|<dimension>|
            <percentage> for both arguments (must match types). When both
            arguments reduce to a scalar in a shared category, the ratio is
            unit-free and the result folds to a [Deg] constant. *)
@@ -6404,8 +6406,8 @@ let read_color_function t : color =
   Color { space; components; alpha }
 
 (* A bare [<percentage>] leaf inside a color-mix weight [calc()]. Unlike the
-   top-level weight it is not range-checked: CSS Values 4 §10 clamps the math
-   function's result, not its individual operands. [read_calc] handles the
+   top-level weight it is not range-checked: CSS Values 4 sec. 10 clamps the
+   math function's result, not its individual operands. [read_calc] handles the
    [var()] and nested-[calc()] factors itself, so the leaf only sees a token. *)
 let read_color_mix_calc_pct t : percentage = Pct (Cursor.pct t)
 
@@ -6415,9 +6417,9 @@ let rec read_percentage_in_color_mix t : percentage =
   if Cursor.looking_at t "var(" then
     Var (read_var read_percentage_in_color_mix t)
   else if Cursor.looking_at_calc t then
-    (* CSS Color 5 §3: the weight may be a math function. We can't bound-check a
-       [calc()] statically (it may carry a [var()]), so we keep it verbatim and
-       let substitution-time clamping apply. *)
+    (* CSS Color 5 sec. 3: the weight may be a math function. We can't
+       bound-check a [calc()] statically (it may carry a [var()]), so we keep it
+       verbatim and let substitution-time clamping apply. *)
     Calc (read_calc read_color_mix_calc_pct t)
   else
     let n = Cursor.number t in
@@ -6427,7 +6429,7 @@ let rec read_percentage_in_color_mix t : percentage =
     (Pct n : percentage)
 
 let read_optional_percentage t : percentage option =
-  (* CSS Color 5 §3 (https://drafts.csswg.org/css-color-5/#color-mix): the
+  (* CSS Color 5 sec. 3 (https://drafts.csswg.org/css-color-5/#color-mix): the
      [color-mix()] weight grammar is [<percentage [0,100]>?] - strictly a
      percentage token, no [<number>] alternative. We don't accept a bare decimal
      here even though some minifiers (cssnano) ship the [0% -> 0] shortcut as a
@@ -6616,7 +6618,7 @@ let rec read_color_mix t : color =
   Mix { in_space; hue; color1; percent1; color2; percent2 }
 
 and read_color_mix_component t =
-  (* CSS Color 5 §3: a component is [<color> && <percentage>?] - the two may
+  (* CSS Color 5 sec. 3: a component is [<color> && <percentage>?] - the two may
      appear in either order. Prefer the [<color> <percentage>?] reading so an
      ambiguous leading [var()] is taken as the colour ([var(--c) var(--p)] keeps
      its source order rather than being re-emitted percentage-first). Fall back
@@ -6709,9 +6711,9 @@ and read_color_attr t : color =
   Attribute (name, fallback)
 
 and read_relative_color name t : color =
-  (* CSS Color 5 §2: any colour function may take [from <origin> <c1> <c2> <c3>
-     [/ <alpha>]?]. We capture the body verbatim so the printer re-emits the
-     function name + parenthesised tail unchanged. *)
+  (* CSS Color 5 sec. 2: any colour function may take [from <origin> <c1> <c2>
+     <c3> [/ <alpha>]?]. We capture the body verbatim so the printer re-emits
+     the function name + parenthesised tail unchanged. *)
   Cursor.ws t;
   Cursor.expect_string "from" t;
   Cursor.ws t;
@@ -7131,7 +7133,7 @@ let rec read_percentage t : percentage =
   else if Cursor.looking_at_calc t then Calc (read_calc read_percentage t)
   else Pct (Cursor.pct t)
 
-(* CSS Values 5 §10: math functions that produce a non-length type ([asin] /
+(* CSS Values 5 sec. 10: math functions that produce a non-length type ([asin] /
    [acos] / [atan] / [atan2] return angles, [sin] / [cos] / [tan] return
    numbers). Used in a [<length-percentage>] context they are spec-invalid;
    lightning et al. preserve verbatim, so cascade captures the original call as

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -247,11 +247,11 @@ val normalize_duration : ?ctx:calc_ctx -> duration -> duration
 val normalize_color : ?lossless:bool -> in_feature_query:bool -> color -> color
 (** [normalize_color ?lossless ~in_feature_query c] canonicalises a color to its
     shortest spelling: a static colour in any space folds through sRGB to
-    hex/named, hex shortens, and named↔hex picks the shorter. [in_feature_query]
-    keeps a colour untouched inside an [@supports] test, where the exact
-    spelling is the capability being probed. [lossless] disables lossy static
-    colour-space and color-mix folds while preserving exact named/hex and
-    byte-exact rgb folds. *)
+    hex/named, hex shortens, and named<->hex picks the shorter.
+    [in_feature_query] keeps a colour untouched inside an [@supports] test,
+    where the exact spelling is the capability being probed. [lossless] disables
+    lossy static colour-space and color-mix folds while preserving exact
+    named/hex and byte-exact rgb folds. *)
 
 val pp_number_percentage : ?always:bool -> number_percentage Pp.t
 (** [pp_number_percentage ?always] pretty-prints {!number_percentage} values.
@@ -516,7 +516,7 @@ val read_calc : (Cursor.t -> 'a) -> Cursor.t -> 'a calc
 (** [read_calc read t] parses a [calc(...)] expression or a promotable value. *)
 
 val read_calc_expr : (Cursor.t -> 'a) -> Cursor.t -> 'a calc
-(** [read_calc_expr read t] parses a calc expression body — the contents of a
+(** [read_calc_expr read t] parses a calc expression body -- the contents of a
     [calc(...)] form without the surrounding [calc(] and [)]. *)
 
 val eval_numeric_calc : 'a calc -> float option
@@ -525,8 +525,9 @@ val eval_numeric_calc : 'a calc -> float option
     non-numeric values. *)
 
 val eval_math_fn : math_fn -> float option
-(** [eval_math_fn fn] evaluates a CSS Values 4 §10.7 numeric math function call
-    to a float. Returns [None] when an arg references an unresolved variable. *)
+(** [eval_math_fn fn] evaluates a CSS Values 4 sec. 10.7 numeric math function
+    call to a float. Returns [None] when an arg references an unresolved
+    variable. *)
 
 val read_numeric_expression : Cursor.t -> float
 (** [read_numeric_expression t] parses and evaluates a numeric math expression,
@@ -538,12 +539,12 @@ val map_calc : ('a -> 'b) -> 'a calc -> 'b calc
     structure (operators, [Nested], [Parens], [Var] fallbacks). *)
 
 val eval_calc : ?ctx:calc_ctx -> 'a calc -> 'a calc
-(** [eval_calc calc] applies CSS Values 4 §10.7 structural simplification: folds
-    [Expr (Num _, op, Num _)] subtrees into a single [Num] and unwraps trivial
-    [Nested] / [Parens] around leaves. [Val] / [Var] leaves and mixed-type
-    operands survive — type-specific simplification (e.g., length arithmetic) is
-    the caller's job. With [~ctx], a [Nested] / [Parens] around a single-valued
-    [Var] leaf is also unwrapped (see {!calc_ctx}). *)
+(** [eval_calc calc] applies CSS Values 4 sec. 10.7 structural simplification:
+    folds [Expr (Num _, op, Num _)] subtrees into a single [Num] and unwraps
+    trivial [Nested] / [Parens] around leaves. [Val] / [Var] leaves and
+    mixed-type operands survive -- type-specific simplification (e.g., length
+    arithmetic) is the caller's job. With [~ctx], a [Nested] / [Parens] around a
+    single-valued [Var] leaf is also unwrapped (see {!calc_ctx}). *)
 
 val calc_identity :
   zero:'a calc ->
@@ -553,7 +554,7 @@ val calc_identity :
   'a calc ->
   'a calc option
 (** [calc_identity ~zero ~is_zero l op r] applies the value-independent CSS
-    Values 4 §10.7 identities to one [Expr (l, op, r)] node, returning the
+    Values 4 sec. 10.7 identities to one [Expr (l, op, r)] node, returning the
     folded operand when one applies. These hold for any operand including a kept
     [var()] (inside [calc()] a [var()] is single-valued): [x * 1], [1 * x],
     [x / 1], [x + 0], [0 + x], [x - 0] keep [x]; [x * 0] / [0 * x] reduce to

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -14,8 +14,8 @@ type custom_value = component_values
 type 'a fallback =
   | Empty (* Empty fallback: var(--name,) *)
   | Empty2
-    (* 2-char empty fallback: var(--name, ) — matches tailwindcss output, likely
-       a bug in tailwindcss *)
+    (* 2-char empty fallback: var(--name, ) -- matches tailwindcss output,
+       likely a bug in tailwindcss *)
   | None (* No fallback: var(--name) *)
   | Fallback of 'a (* Value fallback: var(--name, value) *)
   | Syntax_fallback of component_values
@@ -39,14 +39,15 @@ type 'a var = {
 type 'a env = { name : string; indices : int list; fallback : 'a option }
 type calc_op = Add | Sub | Mul | Div
 
-(** CSS Values 4 §10.7.1 math constants - emitted at the source byte sequence
-    (e.g. [pi], [e]) rather than their floating-point evaluation, so pretty pp
-    preserves [calc(2 * pi)] instead of writing [calc(6.28318530718)]. *)
+(** CSS Values 4 sec. 10.7.1 math constants - emitted at the source byte
+    sequence (e.g. [pi], [e]) rather than their floating-point evaluation, so
+    pretty pp preserves [calc(2 * pi)] instead of writing [calc(6.28318530718)].
+*)
 type math_const = Pi | E | Infinity | Neg_infinity | Nan
 
-(** CSS Values 4 §10.7 numeric math function arguments. Self-recursive so nested
-    calls round-trip ([pow(2, sqrt(100))]) and arithmetic with constants stays
-    as a tree ([(e - exp(1))]). *)
+(** CSS Values 4 sec. 10.7 numeric math function arguments. Self-recursive so
+    nested calls round-trip ([pow(2, sqrt(100))]) and arithmetic with constants
+    stays as a tree ([(e - exp(1))]). *)
 type math_arg =
   | Lit of float
   | Dim of float * string
@@ -59,9 +60,9 @@ type math_arg =
   | Parens_arg of math_arg
   | Math_call of math_fn
 
-(** CSS Values 4 §10.7 numeric math functions. Each arm preserves its source arg
-    shape so pretty pp re-emits [name(args)]; the optimizer evaluates to [Num]
-    under minify. *)
+(** CSS Values 4 sec. 10.7 numeric math functions. Each arm preserves its source
+    arg shape so pretty pp re-emits [name(args)]; the optimizer evaluates to
+    [Num] under minify. *)
 and math_fn =
   | Sin of angle_arg
   | Cos of angle_arg
@@ -101,7 +102,7 @@ type 'a calc =
   | Nested of 'a calc (* Explicitly nested calc(), rendered as calc(inner) *)
   | Parens of 'a calc (* Parenthesized expression, rendered as (inner) *)
   | Math_fn of math_fn
-(* CSS Values 4 §10.7 numeric math functions ([sin], [cos], [hypot], ...).
+(* CSS Values 4 sec. 10.7 numeric math functions ([sin], [cos], [hypot], ...).
    Pretty pp emits [name(args)] preserving source shape; minify pp / optimizer
    evaluates to [Num]. *)
 
@@ -179,11 +180,11 @@ type length =
   | Revert_layer
   | Fit_content
   | Fit_content_arg of length
-      (** [fit-content(<length-percentage>)] - CSS Sizing 3 §5.1. The argument
-          is a [<length-percentage>]; we store it via the [length] type because
-          [length] already has a [Pct of float] case for the percentage form (a
-          separate [length_percentage] would force a mutually-recursive type).
-      *)
+      (** [fit-content(<length-percentage>)] - CSS Sizing 3 sec. 5.1. The
+          argument is a [<length-percentage>]; we store it via the [length] type
+          because [length] already has a [Pct of float] case for the percentage
+          form (a separate [length_percentage] would force a mutually-recursive
+          type). *)
   | Content
   | Contain
   | Max_content
@@ -214,7 +215,7 @@ type length =
   | Anchor_size of string
   | Anchor of string option * string * length option
   | Attr of length attr_call
-      (** CSS Values 5 §10 [attr(<attr-name> <attr-type>?, <fallback>?)] for
+      (** CSS Values 5 sec. 10 [attr(<attr-name> <attr-type>?, <fallback>?)] for
           typed-value contexts. *)
   | Env of length env
   | Var of length var
@@ -466,7 +467,7 @@ type hue_interpolation =
   | Increasing
   | Decreasing
   | Specified
-      (** CSS Color 5 §13 [specified hue] - keep authored hue values without
+      (** CSS Color 5 sec. 13 [specified hue] - keep authored hue values without
           interpolation rotation. *)
   | Default
 
@@ -511,9 +512,9 @@ type color =
   | Relative_rgb of string
   | Relative_color of string * string
       (** [<fn>(from <origin> <c1> <c2> <c3> [/ <alpha>]?)] for any color
-          function other than [rgb()] (CSS Color 5 §2). The first string is the
-          function name ([lab], [lch], [oklab], [oklch], [hsl], [hwb], [color]),
-          the second is the parenthesised body verbatim. *)
+          function other than [rgb()] (CSS Color 5 sec. 2). The first string is
+          the function name ([lab], [lch], [oklab], [oklch], [hsl], [hwb],
+          [color]), the second is the parenthesised body verbatim. *)
   | Contrast_color of color
   | Light_dark of color * color
   | Attribute of string * color option

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -190,7 +190,7 @@ let read_simple_syntax_component r s : any_syntax =
   | s when is_ident_keyword s -> Syntax (Ident_keyword s)
   | s -> Cursor.err_invalid r ("Unsupported CSS syntax: " ^ s)
 
-(* CSS Properties and Values API 1 §2: only [+] and [#] are valid syntax
+(* CSS Properties and Values API 1 sec. 2: only [+] and [#] are valid syntax
    multipliers. *)
 let apply_syntax_modifier r (Syntax inner) (modifier : char option) : any_syntax
     =
@@ -247,7 +247,7 @@ let rec read_value : type a. Cursor.t -> a syntax -> a =
  fun reader syntax ->
   match syntax with
   | Universal ->
-      (* For universal syntax "*", accept any CSS value — consume the remaining
+      (* For universal syntax "*", accept any CSS value -- consume the remaining
          components and serialise them back to source text so the surrounding
          [expect_eof] sees an empty cursor. *)
       Cursor.consume_remaining_as_string ~trim:true reader
@@ -2329,7 +2329,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   (* Default case for all other properties *)
   | _ -> []
 
-(* CSS Variables L1 §3: a custom property's value can itself reference other
+(* CSS Variables L1 sec. 3: a custom property's value can itself reference other
    custom properties. A [Typed] value embeds real [var] handles, so recurse via
    the kind; a raw [Tokens] value carries refs as [var()] functions in the
    stream, recovered structurally by {!vars_of_token_stream}. *)
@@ -2462,11 +2462,11 @@ let read_any_syntax (r : Cursor.t) : any_syntax =
   (* Reuse the main read_syntax function *)
   read_syntax r
 
-(* CSS Custom Properties §3 requires [var()] fallbacks to round-trip including
-   author-written comments. The token stream silently drops comments, so slice
-   the original source between the first and last fallback component instead of
-   re-serialising tokens. Falls back to component-based serialisation when the
-   source is not retained on the cursor. *)
+(* CSS Custom Properties sec. 3 requires [var()] fallbacks to round-trip
+   including author-written comments. The token stream silently drops comments,
+   so slice the original source between the first and last fallback component
+   instead of re-serialising tokens. Falls back to component-based serialisation
+   when the source is not retained on the cursor. *)
 let string_of_fallback inner =
   let cvs = Cursor.remaining inner in
   match (cvs, Cursor.source inner) with
@@ -2487,10 +2487,11 @@ let string_of_fallback inner =
     information which would need to be resolved from a variable registry or
     context. *)
 let read_reference (r : Cursor.t) : string * string option =
-  (* CSS Syntax 3 §4.3.6: EOF inside a function is a parse error, tolerated only
-     when the fallback list opened with a comma (a §4.3.5 [<string-token>] may
-     have eaten the closing [)]) so a recoverable name + fallback survives.
-     Without a fallback there is no recovery signal, so it is rejected. *)
+  (* CSS Syntax 3 sec. 4.3.6: EOF inside a function is a parse error, tolerated
+     only when the fallback list opened with a comma (a sec. 4.3.5
+     [<string-token>] may have eaten the closing [)]) so a recoverable name +
+     fallback survives. Without a fallback there is no recovery signal, so it is
+     rejected. *)
   let terminated =
     match Cursor.peek r with
     | Some (Component.Func fn) -> fn.node.terminated

--- a/lib/variables_intf.ml
+++ b/lib/variables_intf.ml
@@ -6,9 +6,9 @@ open Properties
 (** {1 Custom Property Syntax} *)
 
 (** Type-safe CSS [@property] syntax descriptors per CSS Properties and Values
-    API 1 §2 (https://drafts.css-houdini.org/css-properties-values-api-1/). The
-    spec admits only the named [<...>] type references below, the universal [*],
-    bare [<ident>] keywords, and the [+]/[#] multipliers; alternatives are
+    API 1 sec. 2 (https://drafts.css-houdini.org/css-properties-values-api-1/).
+    The spec admits only the named [<...>] type references below, the universal
+    [*], bare [<ident>] keywords, and the [+]/[#] multipliers; alternatives are
     joined by [|]. *)
 type 'a syntax =
   | Length : length syntax

--- a/scripts/check_api_consistency.ml
+++ b/scripts/check_api_consistency.ml
@@ -574,7 +574,7 @@ let () =
   if stats.missing_modules <> [] then (
     print_string (colored red "Critical:" ^ " Missing module interfaces:\n");
     List.iter
-      (fun m -> print_string ("  • " ^ m ^ ".mli\n"))
+      (fun m -> print_string ("  \u{2022} " ^ m ^ ".mli\n"))
       (List.rev stats.missing_modules);
     print_string "\n");
 

--- a/scripts/check_properties.ml
+++ b/scripts/check_properties.ml
@@ -131,6 +131,6 @@ let () =
     StringSet.iter (fun s -> print_string ("  - " ^ s ^ "\n")) extra);
 
   print_string
-    ("✓ All "
+    ("\u{2713} All "
     ^ string_of_int (StringSet.cardinal all_set)
     ^ " properties are properly mapped in read_property\n")

--- a/test/spec/test.ml
+++ b/test/spec/test.ml
@@ -379,8 +379,8 @@ let selectors_where_is () =
   (* Forgiving-parse drops the invalid branch, leaving a single-argument
      [:is(.a)]. Per shortest-wins (Lightning CSS) the single-argument [:is()]
      unwraps to the bare selector, since [:is(.a)] is spec- equivalent to [.a]
-     (same match set, same specificity per Selectors L4 §17). [:where()] cannot
-     unwrap the same way because it contributes zero specificity. *)
+     (same match set, same specificity per Selectors L4 sec. 17). [:where()]
+     cannot unwrap the same way because it contributes zero specificity. *)
   roundtrip ":is(:future-pseudo, .a) { color: red }" ".a{color:red}";
   roundtrip ":where(:future-pseudo, .a) { color: red }" ":where(.a){color:red}"
 

--- a/test/test_color_space.ml
+++ b/test/test_color_space.ml
@@ -55,7 +55,7 @@ let test_xyz65_of_linear_srgb () =
 
 let test_oklab_of_linear_srgb_known () =
   (* Reference values from the OKLab paper (Ottosson) and confirmed by web.dev /
-     WebKit fixtures: linear-sRGB red -> OKLab ≈ (0.628 0.226 0.126); blue ->
+     WebKit fixtures: linear-sRGB red -> OKLab ~= (0.628 0.226 0.126); blue ->
      (0.452 -0.032 -0.312); white -> (1.0 0 0). *)
   let red = Color_space.oklab_of_linear_srgb (1.0, 0.0, 0.0) in
   Alcotest.(check triplet)

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -34,7 +34,7 @@ let test_string_output () =
   Alcotest.(check string)
     "named style query raw" "card style(--variant: featured)"
     (to_string (Named ("card", of_string "style(--variant: featured)")));
-  (* CSS Conditional Rules 5 §4: [not] takes one query-in-parens, and a
+  (* CSS Conditional Rules 5 sec. 4: [not] takes one query-in-parens, and a
      [style()] function is one, so [not style(--a)] needs no extra wrapping. *)
   Alcotest.(check string)
     "negated style query" "not style(--a)"

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -260,7 +260,7 @@ let test_query_context_boundaries () =
   Alcotest.(check bool)
     "supports declaration is exact on value" false
     (Css.Context.matches_supports ctx (Css.Supports.property "display" "flex"));
-  (* CSS property names are ASCII case-insensitive (CSS Syntax §3.6), so
+  (* CSS property names are ASCII case-insensitive (CSS Syntax sec. 3.6), so
      "Display" and "display" name the same property. *)
   Alcotest.(check bool)
     "supports declaration normalises property case" true

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -200,7 +200,7 @@ let custom_properties_integration () =
     (minify stylesheet)
 
 (* Regression: a custom property name starting with a digit after the -- is a
-   valid dashed-ident per CSS Syntax §4.3.11. Tailwind emits these for
+   valid dashed-ident per CSS Syntax sec. 4.3.11. Tailwind emits these for
    arbitrary-value classes like text-[1A202C]. *)
 let var_digit_after_dashes () =
   let css = ".x{font-size:var(--1A202C)}" in

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -731,7 +731,7 @@ let transforms () =
     "transform: scale(2) translateY(20px) rotate(180deg)";
 
   (* Transform origin *)
-  (* Per CSS Transforms 1 §6 [center] is shorthand for [50% 50%] and the
+  (* Per CSS Transforms 1 sec. 6 [center] is shorthand for [50% 50%] and the
      keyword pair [top left] is [0 0]. A single [0] would mean [0 50%], so the
      two-value form must be preserved. *)
   check_declaration ~expected:"transform-origin:50%" "transform-origin: center";
@@ -1373,7 +1373,7 @@ let number_formats () =
 let unterminated () =
   (* CSS Syntax 5.3.7 / 4.3.5 auto-close unterminated strings, brackets and
      function calls at EOF. Assert the recovered declaration matches the shape
-     an explicit closer would have produced — the parser must not silently drop
+     an explicit closer would have produced -- the parser must not silently drop
      content. *)
   check_declaration ~expected:"content:\"abc\"" "content: \"abc";
   (* The auto-closed inner parens collapse to a single value, leaving the outer

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -39,10 +39,10 @@ let test_empty_block_is_empty () =
     "empty input yields empty output" 0
     (List.length (Flatten.block stmts))
 
-(* CSS Nesting 1 §2 lets a nested rule start with an identifier, so its prelude
-   is ambiguous with a declaration until the block appears: [h2:where(...)]
-   reads as the property [h2] with value [where(...)]. Parsing has to fall back
-   to a rule, or the whole nested block is dropped. *)
+(* CSS Nesting 1 sec. 2 lets a nested rule start with an identifier, so its
+   prelude is ambiguous with a declaration until the block appears:
+   [h2:where(...)] reads as the property [h2] with value [where(...)]. Parsing
+   has to fall back to a rule, or the whole nested block is dropped. *)
 let test_nested_rule_starting_with_ident () =
   let check src expected =
     Alcotest.(check string) src expected (render (block src))

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -269,9 +269,9 @@ let test_inline_across_layers () =
 
 (* A cascade layer only orders competing declarations, so a variable defined on
    the same element across several layers has a statically decidable winner and
-   folds to it (CSS Cascade 5 §6.4.3). An override that depends on runtime state
-   (a media query, a different selector) cannot be decided statically and stays
-   a live var(). *)
+   folds to it (CSS Cascade 5 sec. 6.4.3). An override that depends on runtime
+   state (a media query, a different selector) cannot be decided statically and
+   stays a live var(). *)
 let test_inline_layer_winner () =
   check_inline_case ~optimized:".z{width:2px}"
     "the later layer wins for a normal declaration"

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2603,8 +2603,8 @@ let calc_flatten_registered_single_valued () =
      * 2)}"
     "@property \
      --x{syntax:\"<length>\";inherits:false;initial-value:0px}.a{width:calc(var(--x)*2)}";
-  (* CSS Values 4 §10.10: an unregistered var() could substitute a multi-term
-     value, so the grouping must stay. *)
+  (* CSS Values 4 sec. 10.10: an unregistered var() could substitute a
+     multi-term value, so the grouping must stay. *)
   check "unregistered var keeps the nested calc"
     ".a{width:calc(calc(var(--x)) * 2)}" ".a{width:calc(calc(var(--x))*2)}";
   (* A universal syntax is not a single term, so it is not unwrapped. *)
@@ -3564,7 +3564,7 @@ let c64_child_layer_one_anonymous () =
   let optimized = Css.Optimize.stylesheet input in
   (* Per shortest-wins, two adjacent [@layer foo] blocks inside the same
      anonymous parent merge into one - they refer to the same nested layer per
-     Cascade L6 §6.4.2.1, so collapsing is spec-allowed. *)
+     Cascade L6 sec. 6.4.2.1, so collapsing is spec-allowed. *)
   let output = Css.Stylesheet.to_string ~minify:true optimized |> String.trim in
   Alcotest.(check bool)
     "anonymous parent preserved" true

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1691,9 +1691,9 @@ let test_background () =
     "linear-gradient(to right, red, blue)";
   check_background ~expected:"url(image.png)center/cover no-repeat fixed red"
     "red url(image.png) center/cover no-repeat fixed";
-  (* Multi-layer shorthand (CSS Backgrounds 3 §2.1): the layer comma separates
-     layers and must not be eaten by a per-component reader. [repeat] is the
-     default and folds away; the second layer's [space] stays. *)
+  (* Multi-layer shorthand (CSS Backgrounds 3 sec. 2.1): the layer comma
+     separates layers and must not be eaten by a per-component reader. [repeat]
+     is the default and folds away; the second layer's [space] stays. *)
   decl_optimizes ~prop:"background" ~into:"url(a.png),url(b.png)space"
     "url(a.png) repeat,url(b.png) space";
   check_background ~expected:"0 0" "none";
@@ -2027,7 +2027,7 @@ let test_list_style_type () =
   check_list_style_type "upper-alpha";
   check_list_style_type "lower-roman";
   check_list_style_type "upper-roman";
-  (* Predefined counter styles (CSS Counter Styles 3 §6). *)
+  (* Predefined counter styles (CSS Counter Styles 3 sec. 6). *)
   check_list_style_type "decimal-leading-zero";
   check_list_style_type "lower-greek";
   check_list_style_type "lower-latin";
@@ -2294,7 +2294,8 @@ let test_background_repeat () =
   check_background_repeat "repeat-x";
   check_background_repeat "repeat-y";
   check_background_repeat "inherit";
-  (* CSS Backgrounds 3 §3.6: the longhand is a comma-separated layer list. *)
+  (* CSS Backgrounds 3 sec. 3.6: the longhand is a comma-separated layer
+     list. *)
   decl_optimizes ~prop:"background-repeat" ~into:"no-repeat,repeat-y,no-repeat"
     "no-repeat,repeat-y,no-repeat";
   decl_optimizes ~prop:"background-repeat" ~into:"repeat-x,repeat-y"
@@ -2316,7 +2317,7 @@ let test_background_size () =
   check_background_size "var(--s)";
   check_background_size "calc(50% + 10px)";
   check_background_size "calc(50% + 10px) auto";
-  (* Comma-separated layer list (CSS Backgrounds 3 §3.9). *)
+  (* Comma-separated layer list (CSS Backgrounds 3 sec. 3.9). *)
   decl_optimizes ~prop:"background-size" ~into:"cover,contain" "cover,contain";
   decl_optimizes ~prop:"background-size" ~into:"100px 200px,auto"
     "100px 200px,auto";
@@ -2903,7 +2904,7 @@ let test_text_decoration_skip_ink () =
   neg_cursor read_text_decoration_skip_ink "invalid-skip"
 
 let test_transform_origin () =
-  (* Per CSS Transforms 1 §6 the keyword [center] is shorthand for [50%] and
+  (* Per CSS Transforms 1 sec. 6 the keyword [center] is shorthand for [50%] and
      matched-pair shorthand collapses to a single value. Per shortest- wins
      (Lightning CSS) the printer emits the numeric form. *)
   check_transform_origin ~expected:"50%" "center";

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -52,7 +52,7 @@ let check_minified_to expected input =
 (* Extra minifier invariant: minify is idempotent (a second pass produces no
    further change), and specificity is preserved. Strict AST equality between
    [original] and [reparsed] does not hold for inputs the minifier rewrites
-   (e.g. CSS Selectors 4 §3.5 lets the printer drop a redundant [*] from a
+   (e.g. CSS Selectors 4 sec. 3.5 lets the printer drop a redundant [*] from a
    compound), so we compare the minified form against itself after re-parsing
    and re-minifying. *)
 let check_minified_equiv input =
@@ -371,7 +371,7 @@ let attribute_cases () =
   check_construct "[ns|attr]" (attribute ~ns:(Prefix "ns") "attr" Presence);
   check_construct "[*|attr]" (attribute ~ns:Any "attr" Presence);
 
-  (* Negative cases: CSS Syntax §5.3.7 / §4.3.5 mandate recovery for
+  (* Negative cases: CSS Syntax sec. 5.3.7 / sec. 4.3.5 mandate recovery for
      unterminated brackets (['\[']) and strings at EOF, so those are spec-valid
      and not tested here. *)
   neg_cursor read "[attr=]";
@@ -650,7 +650,7 @@ let invalid () =
     Alcotest.(check bool) label true (Option.is_none (Cursor.option read c))
   in
   (* CSS Syntax 5.3.7 / 4.3.5 mandate recovery for unterminated blocks and
-     strings at EOF — assert the recovered AST matches what an explicit closing
+     strings at EOF -- assert the recovered AST matches what an explicit closing
      bracket / quote would have produced, rather than silently dropping
      content. *)
   check ~expected:"[href]" "[href";
@@ -1041,7 +1041,7 @@ let test_ns () =
   ()
 
 let test_nth () =
-  (* Test nth type — odd/even are canonicalized to 2n+1/2n *)
+  (* Test nth type -- odd/even are canonicalized to 2n+1/2n *)
   Alcotest.(check bool)
     "odd parses to Odd AST" true
     (read_nth (Cursor.of_string "odd") = Odd);
@@ -1305,7 +1305,7 @@ let test_spec_forgiving_selector_lists () =
   check_minified_to ":is(.valid,#id)" ":is(.valid,:future-pseudo,#id)";
   check_minified_to ":where(.valid,#id)" ":where(.valid,:future-pseudo,#id)";
   (* Single-argument [:is(.item)] is spec-equivalent to bare [.item] (same match
-     set and specificity per Selectors L4 §17), but unwrapping it is a node
+     set and specificity per Selectors L4 sec. 17), but unwrapping it is a node
      change reserved for the optimizer's [Selector.canonicalize]; pp is
      lexical-only and holds the [:is()]. [:where()] holds too (and could not
      unwrap regardless, contributing zero specificity). *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -72,7 +72,7 @@ let test_rule () =
   neg_cursor read_stylesheet "{color:red}";
   (* Missing selector *)
   neg_cursor read_stylesheet ".btn";
-  (* Missing declarations. CSS Syntax §5.3.7 auto-closes [.btn{] so it is
+  (* Missing declarations. CSS Syntax sec. 5.3.7 auto-closes [.btn{] so it is
      spec-valid and not asserted here. *)
   neg_cursor read_stylesheet ".btn{color}";
   (* Missing value *)
@@ -131,7 +131,7 @@ let test_stylesheet () =
     "@page :first { margin: 1in }";
   check_stylesheet ~expected:".test{color:red}" ".test { color: red }";
 
-  (* MQ5 §2.1: an empty media query list is valid and evaluates like all. *)
+  (* MQ5 sec. 2.1: an empty media query list is valid and evaluates like all. *)
   check_stylesheet ~expected:"@media{.test{color:red}}"
     "@media { .test { color: red } }";
   check_stylesheet ~expected:"@media{}" "@media { }";
@@ -206,8 +206,8 @@ let test_nested_container_recovers () =
 
 (* ignore-test: error-recovery contract, not a per-statement constructor. *)
 let test_layer_rule_recovery () =
-  (* CSS Syntax 3 §5.4.1: an invalid rule inside an @layer / @media block is
-     dropped on its own; its sibling rules must survive. [.x→y] has a literal
+  (* CSS Syntax 3 sec. 5.4.1: an invalid rule inside an @layer / @media block is
+     dropped on its own; its sibling rules must survive. [.x->y] has a literal
      arrow (U+2192), which is not a valid ident code point, so the browser drops
      that rule too - but keeps the rest of the block. *)
   let keeps_siblings input =
@@ -223,10 +223,12 @@ let test_layer_rule_recovery () =
     | Error e ->
         Alcotest.failf "expected recovery: %s" (Cascade.Error.to_string e)
   in
-  keeps_siblings "@layer u{.a{color:red}.x→y{color:lime}.b{color:blue}}";
-  keeps_siblings "@media screen{.a{color:red}.x→y{color:lime}.b{color:blue}}";
+  keeps_siblings "@layer u{.a{color:red}.x\u{2192}y{color:lime}.b{color:blue}}";
   keeps_siblings
-    "@supports (display:grid){.a{color:red}.x→y{color:lime}.b{color:blue}}"
+    "@media screen{.a{color:red}.x\u{2192}y{color:lime}.b{color:blue}}";
+  keeps_siblings
+    "@supports \
+     (display:grid){.a{color:red}.x\u{2192}y{color:lime}.b{color:blue}}"
 
 (* Not a roundtrip test *)
 let test_supports_rule_creation () =
@@ -731,7 +733,7 @@ let spec_fontface_descriptors () =
     "@font-face { font-family: Foo; src: url(foo.woff2); font-named-instance: \
      'Regular'; font-style: normal; }";
   (* An invalid value of a *known* descriptor drops just that descriptor and
-     keeps the rest of the @font-face, like browsers (CSS Fonts 4 §11.2). *)
+     keeps the rest of the @font-face, like browsers (CSS Fonts 4 sec. 11.2). *)
   check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
     "@font-face { font-family: Brand; src: url(font.woff2); font-display: \
      maybe; }";
@@ -739,7 +741,7 @@ let spec_fontface_descriptors () =
     "@font-face { font-family: Brand; src: url(font.woff2); font-variant: \
      common-ligatures no-common-ligatures; }";
   (* A descending font-stretch range is kept like the font-weight / oblique
-     ranges below: browsers do not enforce CSS Fonts 4 §11.2. *)
+     ranges below: browsers do not enforce CSS Fonts 4 sec. 11.2. *)
   check_stylesheet
     ~expected:
       "@font-face{font-family:Brand;src:url(font.woff2);font-stretch:200% 50%}"
@@ -1265,7 +1267,7 @@ let spec_strict_rejects_invalid_stylesheets () =
          U+20-10 }" );
       (* Browsers keep a descending font-weight / oblique-angle range, so the
          lenient parse keeps it with a warning; strict turns that into an error
-         (CSS Fonts 4 §11.2 wants the first bound <= the second). *)
+         (CSS Fonts 4 sec. 11.2 wants the first bound <= the second). *)
       ( "font-face descending font-weight range",
         "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
          900 100 }" );
@@ -1425,7 +1427,7 @@ let test_import_rule () =
   (* Missing quotes *)
   neg_cursor read_import_rule "import 'test.css'";
   (* Missing @ *)
-  (* Unclosed quote at EOF — per CSS Syntax §4.3.5 the lexer still returns a
+  (* Unclosed quote at EOF -- per CSS Syntax sec. 4.3.5 the lexer still returns a
      string-token (the ill-formedness is a parse-error warning, not a
      token-level failure), so [\@import 'test.css] parses as a valid import. *)
   check_import_rule ~expected:"@import\"test.css\";" "@import 'test.css"
@@ -1585,7 +1587,7 @@ let test_invalid_properties () =
 
 (* Not a roundtrip test *)
 let test_invalid_syntax () =
-  (* CSS Syntax §5.3.7: unclosed blocks auto-close at EOF and the inner
+  (* CSS Syntax sec. 5.3.7: unclosed blocks auto-close at EOF and the inner
      declaration is preserved. Verify the AST, don't just accept "didn't
      crash". *)
   check_stylesheet ~expected:".btn{color:red}" ".btn { color: red ";
@@ -3244,7 +3246,7 @@ let v465_zero_percentage_equiv () =
    form puts ":" between property name and value with no surrounding spaces in
    minified mode, and "!important" follows the value with no extra whitespace.
    The property name is serialized as-is (already lowercased by the syntax layer
-   per CSS Syntax §3.3) regardless of input case. *)
+   per CSS Syntax sec. 3.3) regardless of input case. *)
 let cssom662_decl_serialization () =
   let normalize css =
     match Css.of_string ~strict:false css with
@@ -4246,8 +4248,8 @@ let bg336_position_keyword () =
     | Ok parsed -> minify parsed.stylesheet
     | Error _ -> Alcotest.failf "failed to parse: %s" css
   in
-  (* Per CSS Backgrounds L3 §3.6 [top left], [left top], and [0% 0%] all denote
-     position [0 0]. *)
+  (* Per CSS Backgrounds L3 sec. 3.6 [top left], [left top], and [0% 0%] all
+     denote position [0 0]. *)
   Alcotest.(check string)
     "background-position: top left -> 0 0" ".x{background-position:0 0}"
     (normalize ".x { background-position: top left }");
@@ -4792,7 +4794,7 @@ let v4107_minmax_reduction () =
    same elements as bare [.x] with the same specificity. Per shortest-wins
    cascade picks the unwrapped form. *)
 let s417_is_unwrap () =
-  (* CSS Selectors L4 §17: a single-argument [:is(.a)] is spec-equivalent to
+  (* CSS Selectors L4 sec. 17: a single-argument [:is(.a)] is spec-equivalent to
      bare [.a] (same match set, same specificity). Under [~minify:true] the
      printer picks the shortest spec-equivalent spelling - the unwrapped form,
      matching Lightning CSS. Non-minified output preserves the wrapper (see
@@ -4859,10 +4861,10 @@ let transforms1_11_chain_whitespace_dropped () =
    optimizer cannot inline a variable without a context that resolves it (a
    [theme] map keyed on custom property names), so the [var()] reference and its
    [calc()] wrapper round-trip preserved. The value-independent CSS Values 4
-   §10.7 identities ([x * 1], [x + 0], ...) still fold: they hold for every
+   sec. 10.7 identities ([x * 1], [x + 0], ...) still fold: they hold for every
    possible substitution because the [var()] stays inside calc()'s grammar, so
    [calc(var(--x) * 1)] shortens to [calc(var(--x))] (not to bare [var(--x)],
-   which §10.10 forbids without knowing the value). *)
+   which sec. 10.10 forbids without knowing the value). *)
 let customprops12_inlining () =
   let normalize css =
     match Css.of_string ~strict:false css with
@@ -5074,7 +5076,7 @@ let fidelity_easing_preserved () =
   pretty_preserves ".x { transition: 0.3s cubic-bezier(0.25, 0.1, 0.25, 1) }"
     [ "cubic-bezier(0.25, 0.1, 0.25, 1)" ]
 
-(* {2 Background shorthand (CSS Backgrounds L3 §2.1)} *)
+(* {2 Background shorthand (CSS Backgrounds L3 sec. 2.1)} *)
 
 (* CSS Backgrounds and Borders L3, section 2.1 (background shorthand): the
    shorthand expands to several longhands. Default values ([background-position]
@@ -5109,7 +5111,7 @@ let fidelity_background_preserved () =
     [ "50% 50%"; "cover"; "no-repeat" ];
   pretty_preserves ".x { background: red, url(x.png) }" [ "red"; "url(x.png)" ]
 
-(* {2 Strings and escapes (CSS Syntax L3 §4.3.7)} *)
+(* {2 Strings and escapes (CSS Syntax L3 sec. 4.3.7)} *)
 
 (* CSS Syntax L3, section 4.3.7 (Consume an escaped code point): hex escapes
    [\41] decode to the Unicode code point [U+0041 = 'A']. The trailing
@@ -5209,7 +5211,7 @@ let fidelity_color_space_preserved () =
     "minify pp keeps full oklch hue" true
     (Astring.String.is_infix ~affix:"264.123456" hue)
 
-(* {2 @supports (CSS Conditional L4 §2)} *)
+(* {2 @supports (CSS Conditional L4 sec. 2)} *)
 
 (* CSS Conditional Rules Module Level 4, section 2 (The @supports rule): the
    rule body parses as a rule list (like a stylesheet) and round- trips
@@ -5319,7 +5321,7 @@ let fidelity_logical_property_preserved () =
   pretty_preserves ".x { margin-inline-start: 10px }" [ "margin-inline-start" ];
   pretty_preserves ".x { padding-block: 5px 10px }" [ "padding-block" ]
 
-(* {2 Container Queries (CSS Containment L3 §6)} *)
+(* {2 Container Queries (CSS Containment L3 sec. 6)} *)
 
 (* CSS Containment Module Level 3, section 6 (Container Queries): the
    [@container] rule supports an optional name and a query expression. Both
@@ -5350,11 +5352,11 @@ let fidelity_container_query_preserved () =
   pretty_preserves "@container card (inline-size > 30em) { .x { color: red } }"
     [ "card"; "inline-size > 30em" ]
 
-(* {2 Font shorthand (CSS Fonts L4 §6.5)} *)
+(* {2 Font shorthand (CSS Fonts L4 sec. 6.5)} *)
 
 (* CSS Fonts Module Level 4, section 6.5 (Shorthand font property): the [font]
    shorthand expands to several longhands; the keyword [bold] inside the
-   shorthand canonicalizes to [700] under minify per §5.1.2. System font
+   shorthand canonicalizes to [700] under minify per sec. 5.1.2. System font
    keywords ([caption], [icon], [menu]) round-trip preserved. *)
 let fonts4_6_5_font_shorthand () =
   let normalize css =
@@ -5389,7 +5391,7 @@ let fidelity_font_shorthand_preserved () =
     [ "italic"; "small-caps"; "bold" ];
   pretty_preserves ".x { font: caption }" [ "caption" ]
 
-(* {2 List-style shorthand (CSS Lists L3 §3)} *)
+(* {2 List-style shorthand (CSS Lists L3 sec. 3)} *)
 
 (* CSS Lists Module Level 3, section 3 (list-style shorthand): the shorthand
    sets [list-style-type], [list-style-position], and [list- style-image].
@@ -5415,7 +5417,7 @@ let fidelity_list_style_preserved () =
   pretty_preserves ".x { list-style: disc inside }" [ "disc"; "inside" ];
   pretty_preserves ".x { list-style-type: none }" [ "list-style-type" ]
 
-(* {2 Cascade origin + !important interaction (Cascade L6 §6.3)} *)
+(* {2 Cascade origin + !important interaction (Cascade L6 sec. 6.3)} *)
 
 (* CSS Cascading and Inheritance Module Level 6, section 6.3 (Importance): for
    important declarations the origin precedence is inverted - user-agent

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -459,8 +459,8 @@ let test_angle () =
     "0.000001deg";
   decl_optimizes ~prop:"rotate" ~held:".0001deg" ~into:".0001deg" "0.0001deg";
 
-  (* CSS Values 4 §10.7: scaling a typed <angle> by a unitless number folds to a
-     concrete angle (then picks the shortest unit), so calc(1deg * -45) ->
+  (* CSS Values 4 sec. 10.7: scaling a typed <angle> by a unitless number folds
+     to a concrete angle (then picks the shortest unit), so calc(1deg * -45) ->
      -45deg matches what the browser computes. Both operand orders fold. *)
   decl_optimizes ~prop:"rotate" ~held:"calc(1deg*-45)" ~into:"-45deg"
     "calc(1deg * -45)";
@@ -482,7 +482,7 @@ let test_angle () =
     ~into:"calc(var(--x)*1deg)" "calc(var(--x) * 1deg)";
   decl_optimizes ~prop:"rotate" ~held:"calc(45deg*2*var(--x))"
     ~into:"calc(90deg*var(--x))" "calc(45deg * 2 * var(--x))";
-  (* Same-unit add/sub of two angles combines into one (CSS Values 4 §10.7);
+  (* Same-unit add/sub of two angles combines into one (CSS Values 4 sec. 10.7);
      cross-unit operands stay unfolded. *)
   decl_optimizes ~prop:"rotate" ~held:"calc(45deg + 45deg)" ~into:"90deg"
     "calc(45deg + 45deg)";
@@ -525,7 +525,7 @@ let test_duration () =
   check_duration ~expected:".15s" "150ms";
   check_duration "1.5s";
 
-  (* CSS Values 4 §10.7: a typed <time> scales by a number and same-unit
+  (* CSS Values 4 sec. 10.7: a typed <time> scales by a number and same-unit
      operands combine. s and ms stay distinct, and an inexact division keeps the
      calc() so no precision is lost. *)
   decl_optimizes ~prop:"transition-duration" ~held:"calc(1s*2)" ~into:"2s"
@@ -553,7 +553,7 @@ let test_duration () =
 let test_percentage () =
   check_percentage "50%";
   check_percentage "100%";
-  (* CSS Values 4 §6.5 only lets a [<length>] zero drop the unit; a zero
+  (* CSS Values 4 sec. 6.5 only lets a [<length>] zero drop the unit; a zero
      [<percentage>] keeps the [%] (otherwise it would type as a [<number>] and
      the dimension/percentage grammars would reject it). *)
   check_percentage "0%";
@@ -831,7 +831,7 @@ let test_alpha () =
   check_alpha ~expected:"0" "-0.5";
   check_alpha ~expected:"100%" "150%";
   decl_optimizes ~prop:"color" ~into:"#000" "rgb(0 0 0 / 150%)";
-  (* CSS Values 4 §10.7: an alpha calc() resolves - a scaled or added alpha
+  (* CSS Values 4 sec. 10.7: an alpha calc() resolves - a scaled or added alpha
      folds, and a percentage alpha that reaches 100% drops the channel. *)
   decl_optimizes ~prop:"color" ~into:"#ff000080" "rgb(255 0 0 / calc(0.5 * 1))";
   decl_optimizes ~prop:"color" ~into:"#ff00004d"
@@ -962,9 +962,9 @@ let spec_values_l45_math_color () =
   check_color ~expected:"color-mix(in srgb longer hue,red,blue)"
     ~optimized:"color-mix(in srgb longer hue,red,#00f)"
     "color-mix(in srgb longer hue, red, blue)";
-  (* CSS Color 5 §3: the color-mix weight may be a [calc()]. A constant folds to
-     a plain percentage; a [var()]-bearing one is kept verbatim. The weight
-     reader previously rejected any [calc()] here. *)
+  (* CSS Color 5 sec. 3: the color-mix weight may be a [calc()]. A constant
+     folds to a plain percentage; a [var()]-bearing one is kept verbatim. The
+     weight reader previously rejected any [calc()] here. *)
   check_color ~expected:"color-mix(in srgb,red 30%,blue)"
     ~optimized:"color-mix(in srgb,red 30%,#00f)"
     "color-mix(in srgb, red calc(30%), blue)";

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -341,8 +341,8 @@ let spec_custom_fallback_edges () =
   check_var_ref "var(--commented, a /*x*/ b)" "commented" (Some "a /*x*/ b");
   check_var_ref "var(--string, \"a,b\")" "string" (Some "\"a,b\"");
   check_var_ref "var(--empty-block, {})" "empty-block" (Some "{}");
-  (* CSS Syntax §4.3.5 consumes ')' as part of an unterminated string at EOF; it
-     is not a function close token. *)
+  (* CSS Syntax sec. 4.3.5 consumes ')' as part of an unterminated string at
+     EOF; it is not a function close token. *)
   check_var_ref "var(--bad-string, \"unterminated)" "bad-string"
     (Some "\"unterminated)");
   let neg input =


### PR DESCRIPTION
Source stays 7-bit ASCII. Comments spell their spec references in ASCII ("sec.", "--", "->"); the few string literals that must emit a glyph, such as the diff tree connectors and the invalid-selector test inputs, use `\u{XXXX}` escapes so the runtime bytes are unchanged. A pre-commit hook rejects a non-ASCII byte in staged OCaml source so it cannot creep back.