### PR TITLE
properties: add the border-block-color logical property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Add `Css.border_block_color`, the block-axis sibling of the existing
+  `Css.border_inline_color`; the `border-block-color` logical property is
+  now typed, parsed, printed and normalised (#197)
 - `Css.inline_vars` resolves `var()` across `@layer` boundaries: a layer
   only orders competing declarations, it never scopes custom-property
   visibility, so a layered stylesheet now inlines like its unlayered

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -5249,6 +5249,11 @@ val border_inline_color : logical_border_color -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-color}
      border-inline-color} property. *)
 
+val border_block_color : logical_border_color -> declaration
+(** [border_block_color v] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-color}
+     border-block-color} property. *)
+
 val border_radius : border_radius -> declaration
 (** [border_radius v] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius}

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -395,6 +395,7 @@ let property_value_uses_color (type a) (p : Values.color -> bool)
   | Webkit_tap_highlight_color -> p value
   | Webkit_text_decoration_color -> p value
   | Border_inline_color -> logical_color_uses p value
+  | Border_block_color -> logical_color_uses p value
   | Box_shadow -> shadow_uses_color p value
   | Text_shadow -> List.exists (text_shadow_uses_color p) value
   | Border -> border_uses_color p value
@@ -993,6 +994,8 @@ let read_box_edge_value : type a. a property -> Cursor.t -> declaration option =
   | Border_inline_end_color -> Some (v Border_inline_end_color (read_color t))
   | Border_inline_color ->
       Some (v Border_inline_color (read_logical_border_color t))
+  | Border_block_color ->
+      Some (v Border_block_color (read_logical_border_color t))
   | Border_inline_style -> Some (v Border_inline_style (read_border_style t))
   | Border_block_style -> Some (v Border_block_style (read_border_style t))
   | _ -> None
@@ -2576,6 +2579,7 @@ let border_left_color value = v Border_left_color value
 let border_inline_start_color value = v Border_inline_start_color value
 let border_inline_end_color value = v Border_inline_end_color value
 let border_inline_color value = v Border_inline_color value
+let border_block_color value = v Border_block_color value
 let border_inline_style value = v Border_inline_style value
 let border_block_style value = v Border_block_style value
 let border_start_start_radius value = v Border_start_start_radius value

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -1505,6 +1505,9 @@ val border_inline_end_color : color -> declaration
 val border_inline_color : logical_border_color -> declaration
 (** [border_inline_color v] is the CSS [border-inline-color] property. *)
 
+val border_block_color : logical_border_color -> declaration
+(** [border_block_color v] is the CSS [border-block-color] property. *)
+
 val quotes : Properties.quotes -> declaration
 (** [quotes v] is the CSS [quotes] property. *)
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -7147,6 +7147,7 @@ let pp_property : type a. a property Pp.t =
   | Border_inline_start_color -> Pp.string ctx "border-inline-start-color"
   | Border_inline_end_color -> Pp.string ctx "border-inline-end-color"
   | Border_inline_color -> Pp.string ctx "border-inline-color"
+  | Border_block_color -> Pp.string ctx "border-block-color"
   | Border_inline_style -> Pp.string ctx "border-inline-style"
   | Border_block_style -> Pp.string ctx "border-block-style"
   | Border_start_start_radius -> Pp.string ctx "border-start-start-radius"
@@ -18782,6 +18783,7 @@ let read_any_property t =
   | "border-bottom-color" -> Prop Border_bottom_color
   | "border-left-color" -> Prop Border_left_color
   | "border-inline-color" -> Prop Border_inline_color
+  | "border-block-color" -> Prop Border_block_color
   | "border-style" -> Prop Border_style
   | "border-top-style" -> Prop Border_top_style
   | "border-right-style" -> Prop Border_right_style
@@ -21066,6 +21068,7 @@ let normalize_property_value : type a.
   | Border_inline_start_color -> normalize_color value
   | Border_inline_end_color -> normalize_color value
   | Border_inline_color -> normalize_logical_border_color ~lossless value
+  | Border_block_color -> normalize_logical_border_color ~lossless value
   | Text_decoration_color -> normalize_color value
   | Webkit_text_decoration_color -> normalize_color value
   | Webkit_tap_highlight_color -> normalize_color value
@@ -21375,6 +21378,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Border_inline_start_color -> pp pp_color
   | Border_inline_end_color -> pp pp_color
   | Border_inline_color -> pp pp_logical_border_color
+  | Border_block_color -> pp pp_logical_border_color
   | Border_inline_style -> pp pp_border_style
   | Border_block_style -> pp pp_border_style
   | Border_start_start_radius -> pp pp_length

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4473,6 +4473,7 @@ type 'a property =
   | Border_inline_start_color : color property
   | Border_inline_end_color : color property
   | Border_inline_color : logical_border_color property
+  | Border_block_color : logical_border_color property
   | Border_inline_style : border_style property
   | Border_block_style : border_style property
   | Border_start_start_radius : length property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -448,6 +448,8 @@ let property_footprint : type a. a Properties.property -> overlap_key list =
   | Border_inline_end_color -> [ key "border-inline-end-color" ]
   | Border_inline_color ->
       [ key "border-inline-start-color"; key "border-inline-end-color" ]
+  | Border_block_color ->
+      [ key "border-block-start-color"; key "border-block-end-color" ]
   | Border_inline_style ->
       [ key "border-inline-start-style"; key "border-inline-end-style" ]
   | Border_block_style ->

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1867,6 +1867,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Border_inline_start_color, value -> vars_of_color value
   | Border_inline_end_color, value -> vars_of_color value
   | Border_inline_color, value -> vars_of_logical_border_color value
+  | Border_block_color, value -> vars_of_logical_border_color value
   | Border_inline_style, value -> vars_of_border_style value
   | Border_block_style, value -> vars_of_border_style value
   | Border_start_start_radius, value -> vars_of_length value

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -567,6 +567,11 @@ let matrix =
         positives = [ "red"; "red blue"; "currentColor" ];
         negatives = [ "red blue green"; "1px" ];
       };
+      {
+        property = "border-block-color";
+        positives = [ "red"; "red blue"; "currentColor" ];
+        negatives = [ "red blue green"; "1px" ];
+      };
     ]
   @ rows_for [ "inset" ]
       [ "auto"; "1px"; "10%"; "1px 2px 3px 4px" ]

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1890,6 +1890,8 @@ let spec_remaining_prop_vectors () =
     ];
   check_declaration ~expected:"border-inline-color:red blue"
     ~optimized:"border-inline-color:red #00f" "border-inline-color: red blue";
+  check_declaration ~expected:"border-block-color:red blue"
+    ~optimized:"border-block-color:red #00f" "border-block-color: red blue";
   List.iter
     (fun input -> neg_cursor read_declaration input)
     [
@@ -1911,6 +1913,7 @@ let spec_remaining_prop_vectors () =
       "background-origin: border-box padding-box content-box border-box";
       "background-size: contain cover";
       "border-inline-color: red blue green";
+      "border-block-color: red blue green";
       "border-start-start-radius: 1rem /";
       "text-decoration: underline none";
       "text-underline-position: auto under";
@@ -2265,7 +2268,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 431
+    "property grammar manifest covers every tracked spec property name" 432
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 


### PR DESCRIPTION
`Css.border_inline_color` was typed but its block-axis sibling was not, so `border-block-color` could not be represented, parsed, printed or normalised. This adds `Css.border_block_color` mirroring `border_inline_color` across the property GADT, parser, printer, normaliser, shorthand expansion and variable scanner. It unblocks downstream callers that need the block axis (for example a `border-y-<color>` utility, which maps to `border-block-color`).
