### PR TITLE
properties: add the logical axis border-width shorthands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Add `Css.border_inline_width` and `Css.border_block_width`, the
+  logical axis border-width shorthands (one or two `<line-width>`
+  values), with the `logical_border_width` type (#198)
 - Add `Css.border_block_color`, the block-axis sibling of the existing
   `Css.border_inline_color`; the `border-block-color` logical property is
   now typed, parsed, printed and normalised (#197)

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -372,6 +372,11 @@ let logical_border_color value = (Single value : logical_border_color)
 let logical_border_colors start end_ =
   (Pair (start, end_) : logical_border_color)
 
+let logical_border_width value = (Single value : logical_border_width)
+
+let logical_border_widths start end_ =
+  (Pair (start, end_) : logical_border_width)
+
 let transform_list items = (List items : transform)
 let filter_list items = (List items : filter)
 let cursor_url ?hotspot ~fallback url = (Url (url, hotspot, fallback) : cursor)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -5162,6 +5162,22 @@ val logical_border_color : color -> logical_border_color
 val logical_border_colors : color -> color -> logical_border_color
 (** [logical_border_colors start end_] is a two-value logical border color. *)
 
+type logical_border_width = Properties.logical_border_width =
+  | Single of border_width
+  | Pair of border_width * border_width
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of logical_border_width var
+
+val logical_border_width : border_width -> logical_border_width
+(** [logical_border_width w] is a one-value logical border width. *)
+
+val logical_border_widths : border_width -> border_width -> logical_border_width
+(** [logical_border_widths start end_] is a two-value logical border width. *)
+
 type outline_style = Properties.outline_style =
   | None
   | Solid
@@ -5253,6 +5269,16 @@ val border_block_color : logical_border_color -> declaration
 (** [border_block_color v] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-color}
      border-block-color} property. *)
+
+val border_inline_width : logical_border_width -> declaration
+(** [border_inline_width v] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-width}
+     border-inline-width} property. *)
+
+val border_block_width : logical_border_width -> declaration
+(** [border_block_width v] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-width}
+     border-block-width} property. *)
 
 val border_radius : border_radius -> declaration
 (** [border_radius v] is the

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -996,6 +996,10 @@ let read_box_edge_value : type a. a property -> Cursor.t -> declaration option =
       Some (v Border_inline_color (read_logical_border_color t))
   | Border_block_color ->
       Some (v Border_block_color (read_logical_border_color t))
+  | Border_inline_width ->
+      Some (v Border_inline_width (read_logical_border_width t))
+  | Border_block_width ->
+      Some (v Border_block_width (read_logical_border_width t))
   | Border_inline_style -> Some (v Border_inline_style (read_border_style t))
   | Border_block_style -> Some (v Border_block_style (read_border_style t))
   | _ -> None
@@ -2580,6 +2584,8 @@ let border_inline_start_color value = v Border_inline_start_color value
 let border_inline_end_color value = v Border_inline_end_color value
 let border_inline_color value = v Border_inline_color value
 let border_block_color value = v Border_block_color value
+let border_inline_width value = v Border_inline_width value
+let border_block_width value = v Border_block_width value
 let border_inline_style value = v Border_inline_style value
 let border_block_style value = v Border_block_style value
 let border_start_start_radius value = v Border_start_start_radius value

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -1508,6 +1508,12 @@ val border_inline_color : logical_border_color -> declaration
 val border_block_color : logical_border_color -> declaration
 (** [border_block_color v] is the CSS [border-block-color] property. *)
 
+val border_inline_width : logical_border_width -> declaration
+(** [border_inline_width v] is the CSS [border-inline-width] property. *)
+
+val border_block_width : logical_border_width -> declaration
+(** [border_block_width v] is the CSS [border-block-width] property. *)
+
 val quotes : Properties.quotes -> declaration
 (** [quotes v] is the CSS [quotes] property. *)
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -5070,6 +5070,20 @@ let rec pp_logical_border_color : logical_border_color Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_logical_border_color ctx v
 
+let rec pp_logical_border_width : logical_border_width Pp.t =
+ fun ctx -> function
+  | Single w -> pp_border_width ctx w
+  | Pair (start_, end_) ->
+      pp_border_width ctx start_;
+      Pp.space ctx ();
+      pp_border_width ctx end_
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_logical_border_width ctx v
+
 let rec pp_display : display Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"
@@ -7148,6 +7162,8 @@ let pp_property : type a. a property Pp.t =
   | Border_inline_end_color -> Pp.string ctx "border-inline-end-color"
   | Border_inline_color -> Pp.string ctx "border-inline-color"
   | Border_block_color -> Pp.string ctx "border-block-color"
+  | Border_inline_width -> Pp.string ctx "border-inline-width"
+  | Border_block_width -> Pp.string ctx "border-block-width"
   | Border_inline_style -> Pp.string ctx "border-inline-style"
   | Border_block_style -> Pp.string ctx "border-block-style"
   | Border_start_start_radius -> Pp.string ctx "border-start-start-radius"
@@ -11698,6 +11714,26 @@ let rec read_logical_border_color t : logical_border_color =
     ]
     ~var:(fun t -> Var (Values.read_var read_logical_border_color t))
     ~default:read_colors t
+
+let rec read_logical_border_width t : logical_border_width =
+  let read_widths t =
+    match
+      Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2 read_border_width t
+    with
+    | [ w ] -> (Single w : logical_border_width)
+    | [ start_; end_ ] -> Pair (start_, end_)
+    | _ -> Cursor.err_expected t "one or two widths"
+  in
+  Cursor.enum_or_var "logical border width"
+    [
+      ("inherit", (Inherit : logical_border_width));
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (Values.read_var read_logical_border_width t))
+    ~default:read_widths t
 
 let rec read_visibility t : visibility =
   Cursor.enum_or_var "visibility"
@@ -18784,6 +18820,8 @@ let read_any_property t =
   | "border-left-color" -> Prop Border_left_color
   | "border-inline-color" -> Prop Border_inline_color
   | "border-block-color" -> Prop Border_block_color
+  | "border-inline-width" -> Prop Border_inline_width
+  | "border-block-width" -> Prop Border_block_width
   | "border-style" -> Prop Border_style
   | "border-top-style" -> Prop Border_top_style
   | "border-right-style" -> Prop Border_right_style
@@ -21002,6 +21040,14 @@ let normalize_border_width (bw : border_width) : border_width =
   | _ when border_width_is_zero bw -> Zero
   | _ -> bw
 
+let normalize_logical_border_width :
+    logical_border_width -> logical_border_width =
+ fun value ->
+  match value with
+  | Single w -> Single (normalize_border_width w)
+  | Pair (a, b) -> Pair (normalize_border_width a, normalize_border_width b)
+  | other -> other
+
 let normalize_property_value : type a.
     ?lossless:bool -> ?ctx:Values.calc_ctx -> a property -> a -> a =
  fun ?(lossless = false) ?(ctx = Values.default_calc_ctx) property value ->
@@ -21213,6 +21259,8 @@ let normalize_property_value : type a.
   | Border_inline_end_width -> normalize_border_width value
   | Border_block_start_width -> normalize_border_width value
   | Border_block_end_width -> normalize_border_width value
+  | Border_inline_width -> normalize_logical_border_width value
+  | Border_block_width -> normalize_logical_border_width value
   | Transition_duration -> Values.normalize_duration ~ctx value
   | Transition_delay -> Values.normalize_duration ~ctx value
   | Animation_duration -> Values.normalize_duration ~ctx value
@@ -21379,6 +21427,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Border_inline_end_color -> pp pp_color
   | Border_inline_color -> pp pp_logical_border_color
   | Border_block_color -> pp pp_logical_border_color
+  | Border_inline_width -> pp pp_logical_border_width
+  | Border_block_width -> pp pp_logical_border_width
   | Border_inline_style -> pp pp_border_style
   | Border_block_style -> pp pp_border_style
   | Border_start_start_radius -> pp pp_length

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1984,6 +1984,14 @@ val read_logical_border_color : Cursor.t -> logical_border_color
 (** [read_logical_border_color t] is the [logical_border_color] parsed from [t].
 *)
 
+val pp_logical_border_width : logical_border_width Pp.t
+(** [pp_logical_border_width] is the pretty-printer for [logical_border_width].
+*)
+
+val read_logical_border_width : Cursor.t -> logical_border_width
+(** [read_logical_border_width t] is the [logical_border_width] parsed from [t].
+*)
+
 val pp_column_span : column_span Pp.t
 (** [pp_column_span] is the pretty-printer for [column_span]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1742,6 +1742,18 @@ type logical_border_color =
   | Revert_layer
   | Var of logical_border_color var
 
+(* border-inline-width / border-block-width take one or two <line-width> values,
+   mirroring logical_border_color. *)
+type logical_border_width =
+  | Single of border_width
+  | Pair of border_width * border_width
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of logical_border_width var
+
 type outline_style =
   | None
   | Solid
@@ -4455,6 +4467,8 @@ type 'a property =
   | Border_inline_end_width : border_width property
   | Border_block_start_width : border_width property
   | Border_block_end_width : border_width property
+  | Border_inline_width : logical_border_width property
+  | Border_block_width : logical_border_width property
   | Border_image : border_image property
   | Border_image_source : background_image property
   | Border_image_slice : border_image_slice property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -450,6 +450,10 @@ let property_footprint : type a. a Properties.property -> overlap_key list =
       [ key "border-inline-start-color"; key "border-inline-end-color" ]
   | Border_block_color ->
       [ key "border-block-start-color"; key "border-block-end-color" ]
+  | Border_inline_width ->
+      [ key "border-inline-start-width"; key "border-inline-end-width" ]
+  | Border_block_width ->
+      [ key "border-block-start-width"; key "border-block-end-width" ]
   | Border_inline_style ->
       [ key "border-inline-start-style"; key "border-inline-end-style" ]
   | Border_block_style ->

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1330,6 +1330,14 @@ let vars_of_logical_border_color (value : Properties.logical_border_color) =
   | Pair (start_, end_) -> vars_of_color start_ @ vars_of_color end_
   | _ -> []
 
+let vars_of_logical_border_width (value : Properties.logical_border_width) =
+  match value with
+  | Var v -> [ V v ]
+  | Single w -> vars_of_border_width w
+  | Pair (start_, end_) ->
+      vars_of_border_width start_ @ vars_of_border_width end_
+  | _ -> []
+
 let vars_of_outline (value : Properties.outline) =
   match value with
   | Var v -> [ V v ]
@@ -1868,6 +1876,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Border_inline_end_color, value -> vars_of_color value
   | Border_inline_color, value -> vars_of_logical_border_color value
   | Border_block_color, value -> vars_of_logical_border_color value
+  | Border_inline_width, value -> vars_of_logical_border_width value
+  | Border_block_width, value -> vars_of_logical_border_width value
   | Border_inline_style, value -> vars_of_border_style value
   | Border_block_style, value -> vars_of_border_style value
   | Border_start_start_radius, value -> vars_of_length value

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -572,6 +572,16 @@ let matrix =
         positives = [ "red"; "red blue"; "currentColor" ];
         negatives = [ "red blue green"; "1px" ];
       };
+      {
+        property = "border-inline-width";
+        positives = [ "1px"; "1px 2px"; "thin"; "medium thick" ];
+        negatives = [ "1px 2px 3px"; "red" ];
+      };
+      {
+        property = "border-block-width";
+        positives = [ "1px"; "1px 2px"; "thin"; "medium thick" ];
+        negatives = [ "1px 2px 3px"; "red" ];
+      };
     ]
   @ rows_for [ "inset" ]
       [ "auto"; "1px"; "10%"; "1px 2px 3px 4px" ]

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1892,6 +1892,9 @@ let spec_remaining_prop_vectors () =
     ~optimized:"border-inline-color:red #00f" "border-inline-color: red blue";
   check_declaration ~expected:"border-block-color:red blue"
     ~optimized:"border-block-color:red #00f" "border-block-color: red blue";
+  check_declaration ~expected:"border-inline-width:1px 2px"
+    "border-inline-width: 1px 2px";
+  check_declaration ~expected:"border-block-width:4px" "border-block-width: 4px";
   List.iter
     (fun input -> neg_cursor read_declaration input)
     [
@@ -1914,6 +1917,7 @@ let spec_remaining_prop_vectors () =
       "background-size: contain cover";
       "border-inline-color: red blue green";
       "border-block-color: red blue green";
+      "border-inline-width: 1px 2px 3px";
       "border-start-start-radius: 1rem /";
       "text-decoration: underline none";
       "text-underline-position: auto under";
@@ -2268,7 +2272,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 432
+    "property grammar manifest covers every tracked spec property name" 434
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -867,6 +867,10 @@ let check_logical_border_color =
   check_value_cursor "logical_border_color" read_logical_border_color
     pp_logical_border_color
 
+let check_logical_border_width =
+  check_value_cursor "logical_border_width" read_logical_border_width
+    pp_logical_border_width
+
 let check_margin_trim =
   check_value_cursor "margin_trim" read_margin_trim pp_margin_trim
 
@@ -3690,6 +3694,7 @@ let spec_generated_box_layout_edges () =
   check_line_fit_edge "text alphabetic";
   check_line_fit_edge_keyword "ideographic-ink";
   check_logical_border_color "red blue";
+  check_logical_border_width "1px 2px";
   decl_optimizes ~prop:"border-inline-color" ~held:"red blue" ~into:"red #00f"
     "red blue";
   check_min_intrinsic_sizing "legacy zero-if-scroll";
@@ -3732,6 +3737,7 @@ let spec_generated_box_layout_edges () =
   neg_cursor read_line_fit_edge "text text";
   neg_cursor read_line_fit_edge_keyword "baseline";
   neg_cursor read_logical_border_color "red blue green";
+  neg_cursor read_logical_border_width "1px 2px 3px";
   neg_cursor read_min_intrinsic_sizing "legacy legacy";
   neg_cursor read_min_intrinsic_sizing_keyword "zero";
   neg_cursor read_overflow_clip_box "margin-box";


### PR DESCRIPTION
`border-inline-width` and `border-block-width` (the logical axis border-width shorthands, `<line-width>{1,2}`) had no typed representation. This adds `Css.border_inline_width`/`Css.border_block_width` and the `logical_border_width` type, mirroring the existing `logical_border_color` machinery across the property GADT, parser, printer, normaliser, shorthand expansion and variable scanner. It unblocks downstream callers needing axis border widths (for example a `border-x/y-N` utility, which maps to `border-inline-width`/`border-block-width`).
