### PR TITLE
properties: add the block-axis start/end border colours

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Add `Css.border_block_start_color` and `Css.border_block_end_color`,
+  the block-axis siblings of the existing inline start/end border colour
+  properties (#199)
 - Add `Css.border_inline_width` and `Css.border_block_width`, the
   logical axis border-width shorthands (one or two `<line-width>`
   values), with the `logical_border_width` type (#198)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1730,6 +1730,16 @@ val border_inline_end_color : color -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-color}
      border-inline-end-color} property. *)
 
+val border_block_start_color : color -> declaration
+(** [border_block_start_color c] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-color}
+     border-block-start-color} property. *)
+
+val border_block_end_color : color -> declaration
+(** [border_block_end_color c] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-color}
+     border-block-end-color} property. *)
+
 val padding_inline_start : length -> declaration
 (** [padding_inline_start len] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start}

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -387,6 +387,8 @@ let property_value_uses_color (type a) (p : Values.color -> bool)
   | Border_left_color -> p value
   | Border_inline_start_color -> p value
   | Border_inline_end_color -> p value
+  | Border_block_start_color -> p value
+  | Border_block_end_color -> p value
   | Outline_color -> p value
   | Text_decoration_color -> p value
   | Text_emphasis_color -> p value
@@ -992,6 +994,8 @@ let read_box_edge_value : type a. a property -> Cursor.t -> declaration option =
   | Border_inline_start_color ->
       Some (v Border_inline_start_color (read_color t))
   | Border_inline_end_color -> Some (v Border_inline_end_color (read_color t))
+  | Border_block_start_color -> Some (v Border_block_start_color (read_color t))
+  | Border_block_end_color -> Some (v Border_block_end_color (read_color t))
   | Border_inline_color ->
       Some (v Border_inline_color (read_logical_border_color t))
   | Border_block_color ->
@@ -1900,6 +1904,7 @@ let is_color_property = function
   | "color" | "background-color" | "border-color" | "border-top-color"
   | "border-right-color" | "border-bottom-color" | "border-left-color"
   | "border-inline-start-color" | "border-inline-end-color"
+  | "border-block-start-color" | "border-block-end-color"
   | "text-decoration-color" | "-webkit-text-decoration-color"
   | "-webkit-tap-highlight-color" | "outline-color" | "accent-color"
   | "caret-color" | "fill" | "stroke" ->
@@ -2581,6 +2586,8 @@ let border_right_color value = v Border_right_color value
 let border_bottom_color value = v Border_bottom_color value
 let border_left_color value = v Border_left_color value
 let border_inline_start_color value = v Border_inline_start_color value
+let border_block_start_color value = v Border_block_start_color value
+let border_block_end_color value = v Border_block_end_color value
 let border_inline_end_color value = v Border_inline_end_color value
 let border_inline_color value = v Border_inline_color value
 let border_block_color value = v Border_block_color value

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -1502,6 +1502,13 @@ val border_inline_end_color : color -> declaration
 (** [border_inline_end_color v] is the CSS [border-inline-end-color] property.
 *)
 
+val border_block_start_color : color -> declaration
+(** [border_block_start_color v] is the CSS [border-block-start-color] property.
+*)
+
+val border_block_end_color : color -> declaration
+(** [border_block_end_color v] is the CSS [border-block-end-color] property. *)
+
 val border_inline_color : logical_border_color -> declaration
 (** [border_inline_color v] is the CSS [border-inline-color] property. *)
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -7160,6 +7160,8 @@ let pp_property : type a. a property Pp.t =
   | Border_left_color -> Pp.string ctx "border-left-color"
   | Border_inline_start_color -> Pp.string ctx "border-inline-start-color"
   | Border_inline_end_color -> Pp.string ctx "border-inline-end-color"
+  | Border_block_start_color -> Pp.string ctx "border-block-start-color"
+  | Border_block_end_color -> Pp.string ctx "border-block-end-color"
   | Border_inline_color -> Pp.string ctx "border-inline-color"
   | Border_block_color -> Pp.string ctx "border-block-color"
   | Border_inline_width -> Pp.string ctx "border-inline-width"
@@ -19028,6 +19030,8 @@ let read_any_property t =
   | "border-end-end-radius" -> Prop Border_end_end_radius
   | "border-end-start-radius" -> Prop Border_end_start_radius
   | "border-inline-end-color" -> Prop Border_inline_end_color
+  | "border-block-start-color" -> Prop Border_block_start_color
+  | "border-block-end-color" -> Prop Border_block_end_color
   | "border-block-end-width" -> Prop Border_block_end_width
   | "border-block-start-width" -> Prop Border_block_start_width
   | "border-block-style" -> Prop Border_block_style
@@ -21113,6 +21117,8 @@ let normalize_property_value : type a.
   | Border_left_color -> normalize_color value
   | Border_inline_start_color -> normalize_color value
   | Border_inline_end_color -> normalize_color value
+  | Border_block_start_color -> normalize_color value
+  | Border_block_end_color -> normalize_color value
   | Border_inline_color -> normalize_logical_border_color ~lossless value
   | Border_block_color -> normalize_logical_border_color ~lossless value
   | Text_decoration_color -> normalize_color value
@@ -21425,6 +21431,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Border_left_color -> pp pp_color
   | Border_inline_start_color -> pp pp_color
   | Border_inline_end_color -> pp pp_color
+  | Border_block_start_color -> pp pp_color
+  | Border_block_end_color -> pp pp_color
   | Border_inline_color -> pp pp_logical_border_color
   | Border_block_color -> pp pp_logical_border_color
   | Border_inline_width -> pp pp_logical_border_width

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4486,6 +4486,8 @@ type 'a property =
   | Border_left_color : color property
   | Border_inline_start_color : color property
   | Border_inline_end_color : color property
+  | Border_block_start_color : color property
+  | Border_block_end_color : color property
   | Border_inline_color : logical_border_color property
   | Border_block_color : logical_border_color property
   | Border_inline_style : border_style property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -446,6 +446,8 @@ let property_footprint : type a. a Properties.property -> overlap_key list =
   | Border_block_end_width -> [ key "border-block-end-width" ]
   | Border_inline_start_color -> [ key "border-inline-start-color" ]
   | Border_inline_end_color -> [ key "border-inline-end-color" ]
+  | Border_block_start_color -> [ key "border-block-start-color" ]
+  | Border_block_end_color -> [ key "border-block-end-color" ]
   | Border_inline_color ->
       [ key "border-inline-start-color"; key "border-inline-end-color" ]
   | Border_block_color ->

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1874,6 +1874,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Border_left_color, value -> vars_of_color value
   | Border_inline_start_color, value -> vars_of_color value
   | Border_inline_end_color, value -> vars_of_color value
+  | Border_block_start_color, value -> vars_of_color value
+  | Border_block_end_color, value -> vars_of_color value
   | Border_inline_color, value -> vars_of_logical_border_color value
   | Border_block_color, value -> vars_of_logical_border_color value
   | Border_inline_width, value -> vars_of_logical_border_width value

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -392,6 +392,8 @@ let matrix =
         "border-left-color";
         "border-inline-start-color";
         "border-inline-end-color";
+        "border-block-start-color";
+        "border-block-end-color";
         "text-decoration-color";
         "-webkit-text-decoration-color";
         "-webkit-tap-highlight-color";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2272,7 +2272,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 434
+    "property grammar manifest covers every tracked spec property name" 436
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 


### PR DESCRIPTION
`border-block-start-color` and `border-block-end-color` had no typed representation, while their inline siblings (`border-inline-start-color` / `border-inline-end-color`) were already typed. This adds both, mirroring the inline start/end colour properties across the property GADT, parser, printer, normaliser, shorthand expansion and variable scanner. It unblocks downstream callers needing the block-axis side colours (for example `border-bs`/`border-be` utilities).

Stacked on #198.
