### PR TITLE
properties: add single-side logical border-*-style

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -5391,6 +5391,26 @@ val border_block_style : border_style -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-style}
      border-block-style} property. *)
 
+val border_inline_start_style : border_style -> declaration
+(** [border_inline_start_style s] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-style}
+     border-inline-start-style} property. *)
+
+val border_inline_end_style : border_style -> declaration
+(** [border_inline_end_style s] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-style}
+     border-inline-end-style} property. *)
+
+val border_block_start_style : border_style -> declaration
+(** [border_block_start_style s] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-style}
+     border-block-start-style} property. *)
+
+val border_block_end_style : border_style -> declaration
+(** [border_block_end_style s] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style}
+     border-block-end-style} property. *)
+
 val border_start_start_radius : length -> declaration
 (** [border_start_start_radius len] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius}

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1006,6 +1006,14 @@ let read_box_edge_value : type a. a property -> Cursor.t -> declaration option =
       Some (v Border_block_width (read_logical_border_width t))
   | Border_inline_style -> Some (v Border_inline_style (read_border_style t))
   | Border_block_style -> Some (v Border_block_style (read_border_style t))
+  | Border_inline_start_style ->
+      Some (v Border_inline_start_style (read_border_style t))
+  | Border_inline_end_style ->
+      Some (v Border_inline_end_style (read_border_style t))
+  | Border_block_start_style ->
+      Some (v Border_block_start_style (read_border_style t))
+  | Border_block_end_style ->
+      Some (v Border_block_end_style (read_border_style t))
   | _ -> None
 
 let read_type_value : type a. a property -> Cursor.t -> declaration option =
@@ -2595,6 +2603,10 @@ let border_inline_width value = v Border_inline_width value
 let border_block_width value = v Border_block_width value
 let border_inline_style value = v Border_inline_style value
 let border_block_style value = v Border_block_style value
+let border_inline_start_style value = v Border_inline_start_style value
+let border_inline_end_style value = v Border_inline_end_style value
+let border_block_start_style value = v Border_block_start_style value
+let border_block_end_style value = v Border_block_end_style value
 let border_start_start_radius value = v Border_start_start_radius value
 let border_start_end_radius value = v Border_start_end_radius value
 let border_end_start_radius value = v Border_end_start_radius value

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -264,6 +264,26 @@ val border_block_style : border_style -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-style}
      border-block-style} property. *)
 
+val border_inline_start_style : border_style -> declaration
+(** [border_inline_start_style v] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-style}
+     border-inline-start-style} property. *)
+
+val border_inline_end_style : border_style -> declaration
+(** [border_inline_end_style v] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-style}
+     border-inline-end-style} property. *)
+
+val border_block_start_style : border_style -> declaration
+(** [border_block_start_style v] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-style}
+     border-block-start-style} property. *)
+
+val border_block_end_style : border_style -> declaration
+(** [border_block_end_style v] is the
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style}
+     border-block-end-style} property. *)
+
 val border_start_start_radius : length -> declaration
 (** [border_start_start_radius len] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius}

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -7037,6 +7037,10 @@ let pp_property : type a. a property Pp.t =
   | Border_right_style -> Pp.string ctx "border-right-style"
   | Border_bottom_style -> Pp.string ctx "border-bottom-style"
   | Border_left_style -> Pp.string ctx "border-left-style"
+  | Border_inline_start_style -> Pp.string ctx "border-inline-start-style"
+  | Border_inline_end_style -> Pp.string ctx "border-inline-end-style"
+  | Border_block_start_style -> Pp.string ctx "border-block-start-style"
+  | Border_block_end_style -> Pp.string ctx "border-block-end-style"
   | Padding -> Pp.string ctx "padding"
   | Padding_left -> Pp.string ctx "padding-left"
   | Padding_right -> Pp.string ctx "padding-right"
@@ -18829,6 +18833,10 @@ let read_any_property t =
   | "border-right-style" -> Prop Border_right_style
   | "border-bottom-style" -> Prop Border_bottom_style
   | "border-left-style" -> Prop Border_left_style
+  | "border-inline-start-style" -> Prop Border_inline_start_style
+  | "border-inline-end-style" -> Prop Border_inline_end_style
+  | "border-block-start-style" -> Prop Border_block_start_style
+  | "border-block-end-style" -> Prop Border_block_end_style
   | "border-width" -> Prop Border_width
   | "border-top-width" -> Prop Border_top_width
   | "border-right-width" -> Prop Border_right_width
@@ -21339,6 +21347,10 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Border_right_style -> pp pp_border_style
   | Border_bottom_style -> pp pp_border_style
   | Border_left_style -> pp pp_border_style
+  | Border_inline_start_style -> pp pp_border_style
+  | Border_inline_end_style -> pp pp_border_style
+  | Border_block_start_style -> pp pp_border_style
+  | Border_block_end_style -> pp pp_border_style
   | Padding -> pp (pp_box_shorthand pp_length)
   | Padding_left -> pp pp_length
   | Padding_right -> pp pp_length

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4352,6 +4352,10 @@ type 'a property =
   | Border_right_style : border_style property
   | Border_bottom_style : border_style property
   | Border_left_style : border_style property
+  | Border_inline_start_style : border_style property
+  | Border_inline_end_style : border_style property
+  | Border_block_start_style : border_style property
+  | Border_block_end_style : border_style property
   | Padding : length list property
   | Padding_left : length property
   | Padding_right : length property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1942,6 +1942,10 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Border_right_style, value -> vars_of_border_style value
   | Border_bottom_style, value -> vars_of_border_style value
   | Border_left_style, value -> vars_of_border_style value
+  | Border_inline_start_style, value -> vars_of_border_style value
+  | Border_inline_end_style, value -> vars_of_border_style value
+  | Border_block_start_style, value -> vars_of_border_style value
+  | Border_block_end_style, value -> vars_of_border_style value
   (* Font properties *)
   | Font_weight, value -> vars_of_font_weight value
   | Font_family, value -> vars_of_font_family value

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -421,6 +421,10 @@ let matrix =
         "border-left-style";
         "border-inline-style";
         "border-block-style";
+        "border-inline-start-style";
+        "border-inline-end-style";
+        "border-block-start-style";
+        "border-block-end-style";
       ]
       [ "none"; "solid"; "dashed"; "hidden" ]
       [ "solid dashed"; "foo" ]

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2272,7 +2272,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 436
+    "property grammar manifest covers every tracked spec property name" 440
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 


### PR DESCRIPTION
The property GADT carried the logical `border-inline`/`border-block` `start`/`end` longhands for width and color, but not for style. A valid declaration like `border-inline-start-style: dashed` was therefore rejected with `unsupported property reader`. This adds `Border_inline_start_style`, `Border_inline_end_style`, `Border_block_start_style`, and `Border_block_end_style` alongside the existing width/color siblings, with parse, pp, declaration helpers, and grammar-manifest coverage.