### PR TITLE
css: expose the list-style value parsers

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -483,6 +483,24 @@ let parse_background_image s =
   | value -> value
   | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
 
+let parse_list_style_type s =
+  match
+    let r = Cursor.of_string s in
+    let v = Properties.read_list_style_type r in
+    if Cursor.is_done r then Some v else None
+  with
+  | value -> value
+  | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
+
+let parse_list_style_image s =
+  match
+    let r = Cursor.of_string s in
+    let v = Properties.read_list_style_image r in
+    if Cursor.is_done r then Some v else None
+  with
+  | value -> value
+  | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
+
 let as_layer = function
   | Layer (name, content) -> Some (name, content)
   | _ -> None

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7929,6 +7929,15 @@ val parse_shadow : string -> shadow option
 (** [parse_shadow s] parses a CSS shadow string, including comma-separated
     multi-shadow values. Returns {!constructor-None} if parsing fails. *)
 
+val parse_list_style_type : string -> list_style_type option
+(** [parse_list_style_type s] parses a CSS [list-style-type] value (a counter
+    style keyword, a string, or [symbols()]). Returns {!constructor-None} if
+    parsing fails. *)
+
+val parse_list_style_image : string -> list_style_image option
+(** [parse_list_style_image s] parses a CSS [list-style-image] value ([none], a
+    [url()], or a gradient). Returns {!constructor-None} if parsing fails. *)
+
 val parse_background_image : string -> background_image list option
 (** [parse_background_image s] parses a CSS background-image value, including
     comma-separated multiple images. Returns {!constructor-None} if parsing

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1009,6 +1009,21 @@ let public_parse_edges () =
         "partial parser reports invalid rules" 2
         (List.length parsed.warnings)
 
+(* The value parsers the [list-style] shorthand is built from, exposed so a
+   caller can read a single [list-style-type] / [list-style-image]. *)
+let list_style_value_parsers () =
+  let ok what = function
+    | Some _ -> ()
+    | None -> Alcotest.failf "%s should parse" what
+  in
+  ok "square" (Css.parse_list_style_type "square");
+  ok "upper-roman" (Css.parse_list_style_type "upper-roman");
+  ok "url()" (Css.parse_list_style_image "url(/carrot.png)");
+  ok "none" (Css.parse_list_style_image "none");
+  Alcotest.(check bool)
+    "an unknown counter style is rejected" true
+    (Css.parse_list_style_type "nonsense-style" = None)
+
 let suite =
   ( "css",
     [
@@ -1025,6 +1040,8 @@ let suite =
         custom_properties_integration;
       Alcotest.test_case "var(--1A202C) parses" `Quick var_digit_after_dashes;
       Alcotest.test_case "CSS roundtrip parsing" `Quick roundtrip;
+      Alcotest.test_case "list-style value parsers" `Quick
+        list_style_value_parsers;
       (* AST introspection helpers *)
       Alcotest.test_case "layer_block extraction" `Quick test_layer_block;
       Alcotest.test_case "rules_of_statements" `Quick test_rules_of_statements;


### PR DESCRIPTION
The `list-style` shorthand reader could already parse a type or an image, but neither was reachable on its own, so a caller wanting to read a single `list-style-type` had to hand-roll the keyword table.

Needed by tw for `list-[square]` and `list-image-[url(...)]`.