### PR TITLE
css: expose the font-family value parser

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -483,6 +483,15 @@ let parse_background_image s =
   | value -> value
   | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
 
+let parse_font_family s =
+  match
+    let r = Cursor.of_string s in
+    let v = Properties.read_font_family r in
+    if Cursor.is_done r then Some v else None
+  with
+  | value -> value
+  | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
+
 let parse_list_style_type s =
   match
     let r = Cursor.of_string s in

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7929,6 +7929,11 @@ val parse_shadow : string -> shadow option
 (** [parse_shadow s] parses a CSS shadow string, including comma-separated
     multi-shadow values. Returns {!constructor-None} if parsing fails. *)
 
+val parse_font_family : string -> font_family option
+(** [parse_font_family s] parses a CSS [font-family] value: a single family, a
+    generic keyword, or a comma-separated stack. Returns {!constructor-None} if
+    parsing fails. *)
+
 val parse_list_style_type : string -> list_style_type option
 (** [parse_list_style_type s] parses a CSS [list-style-type] value (a counter
     style keyword, a string, or [symbols()]). Returns {!constructor-None} if

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1024,6 +1024,22 @@ let list_style_value_parsers () =
     "an unknown counter style is rejected" true
     (Css.parse_list_style_type "nonsense-style" = None)
 
+(* [font-family] takes a stack, and a token defined as one is what a theme feeds
+   back in, so a var() among the entries has to survive the read. *)
+let font_family_value_parser () =
+  let roundtrip s =
+    match Css.parse_font_family s with
+    | None -> Alcotest.failf "%s should parse" s
+    | Some v ->
+        Alcotest.(check string)
+          s s
+          (Pp.to_string Css.Properties.pp_font_family v)
+  in
+  roundtrip "Georgia, serif";
+  roundtrip "ui-sans-serif";
+  roundtrip "var(--font-source-sans-pro), system-ui";
+  roundtrip "var(--font-ubuntu-mono)"
+
 let suite =
   ( "css",
     [
@@ -1042,6 +1058,8 @@ let suite =
       Alcotest.test_case "CSS roundtrip parsing" `Quick roundtrip;
       Alcotest.test_case "list-style value parsers" `Quick
         list_style_value_parsers;
+      Alcotest.test_case "font-family value parser" `Quick
+        font_family_value_parser;
       (* AST introspection helpers *)
       Alcotest.test_case "layer_block extraction" `Quick test_layer_block;
       Alcotest.test_case "rules_of_statements" `Quick test_rules_of_statements;


### PR DESCRIPTION
`Properties.read_font_family` was not reachable from `Css`, so a caller reading a font stack out of a theme token had to hand-roll the generic-keyword table, which cannot see a `var()` among the entries.

Stacked on #201.