### PR TITLE
optimize: two same-selector grouping fixes

### DIFF
--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -169,6 +169,29 @@ let drop_nesting_prefix (stmt : statement) : statement =
         }
   | other -> other
 
+(* A selector list holding a vendor pseudo-element is invalidated as a whole by
+   a browser that does not know that pseudo-element, so every other selector in
+   the list silently loses the declarations too. The grouping passes already
+   refuse to build such a list; one the author wrote gets the same treatment
+   here, so the risky branches stand alone and the rest keep their rule. *)
+let split_vendor_selector_lists (stmts : statement list) : statement list =
+  List.concat_map
+    (fun stmt ->
+      match stmt with
+      | Rule ({ selector = Selector.List parts; _ } as nr)
+        when List.length parts > 1
+             && List.exists Merge.vendor parts
+             && not (List.for_all Merge.vendor parts) ->
+          let risky, safe = List.partition Merge.vendor parts in
+          let of_parts = function
+            | [] -> []
+            | [ one ] -> [ Rule { nr with selector = one } ]
+            | many -> [ Rule { nr with selector = Selector.List many } ]
+          in
+          List.concat_map (fun sel -> of_parts [ sel ]) risky @ of_parts safe
+      | other -> [ other ])
+    stmts
+
 let rec statements ?factor_cache ~ctx ~enforce_spec (stmts : statement list) :
     statement list =
   match stmts with
@@ -182,7 +205,8 @@ let rec statements ?factor_cache ~ctx ~enforce_spec (stmts : statement list) :
          after the merge would leave a re-run to combine them). *)
       let stmts' =
         let stmts =
-          drop_misplaced_imports stmts |> merge_named_layers_by_name
+          drop_misplaced_imports stmts
+          |> merge_named_layers_by_name |> split_vendor_selector_lists
         in
         let stmts =
           process_statements ?factor_cache ~ctx ~enforce_spec [] stmts

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -81,6 +81,50 @@ let rule_eligible (r : rule) =
    rules too - unlike the factoring passes, which reorder declarations and would
    disturb a later [var()] resolution. [try_rewrite]'s acyclicity check still
    rejects a group whose merge would cross a conflicting (re)definition. *)
+module String_set = Set.Make (String)
+
+(* Merging a run of same-selector rules into the first one moves each later
+   rule's declarations ahead of any nested block an earlier one carries. That
+   only matters for a property the nested block also sets, so a rule with nested
+   children can still take part as long as those children and the declarations
+   that would move past them are disjoint. *)
+let rec nested_property_names acc (stmts : statement list) =
+  List.fold_left
+    (fun acc stmt ->
+      match stmt with
+      | Rule r ->
+          let acc =
+            List.fold_left
+              (fun acc d -> String_set.add (Declaration.property_name d) acc)
+              acc r.declarations
+          in
+          nested_property_names acc r.nested
+      | _ -> acc)
+    acc stmts
+
+let same_selector_eligible (r : rule) =
+  r.merge_key = Option.None
+  && (not (contains_vendor_pseudo_element r.selector))
+  && not (List.exists Shorthand.is_all_declaration r.declarations)
+
+let nested_merge_is_safe (rules : rule list) =
+  let rec go = function
+    | [] | [ _ ] -> true
+    | r :: rest ->
+        (r.nested = []
+        ||
+        let blocked = nested_property_names String_set.empty r.nested in
+        List.for_all
+          (fun (later : rule) ->
+            List.for_all
+              (fun d ->
+                not (String_set.mem (Declaration.property_name d) blocked))
+              later.declarations)
+          rest)
+        && go rest
+  in
+  go rules
+
 let identical_body_eligible ~ctx (r : rule) =
   r.nested = [] && r.merge_key = Option.None
   && (not (contains_vendor_pseudo_element r.selector))
@@ -620,13 +664,13 @@ let add_same_selector_group ?size_cache ~finalize g ~candidates ids =
   let rules = List.map snd rules_with_ids in
   match rules with
   | [] | [ _ ] -> ()
-  | (first : rule) :: _ -> (
+  | (first : rule) :: _ when nested_merge_is_safe rules -> (
       let merged =
         {
           first with
           declarations =
             List.concat_map (fun (r : rule) -> r.declarations) rules;
-          nested = [];
+          nested = List.concat_map (fun (r : rule) -> r.nested) rules;
           merge_key = Option.None;
         }
       in
@@ -636,13 +680,14 @@ let add_same_selector_group ?size_cache ~finalize g ~candidates ids =
       with
       | Option.None -> ()
       | Option.Some c -> candidates := c :: !candidates)
+  | _ -> ()
 
 let same_selector_candidates ?size_cache ?touching ~finalize g =
   let touching = touching_set touching in
   let buckets = Int_table.create 128 in
   List.iter
     (fun (id, rule) ->
-      if rule_eligible rule then
+      if same_selector_eligible rule then
         add_int_bucket buckets (selector_key_hash rule) id)
     (live_rules g);
   let candidates = ref [] in

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1647,6 +1647,32 @@ let same_selector_merge_past_nested () =
     ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}"
     (canon ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}")
 
+(* A selector list holding a vendor pseudo-element is invalidated as a whole by
+   a browser that does not know it, so the other selectors silently lose the
+   declarations. The grouping passes refuse to build such a list; one the author
+   wrote is split so the risky branches stand alone. *)
+let vendor_pseudo_list_is_split () =
+  let of_string css =
+    match Css.of_string css with
+    | Ok p -> p.Css.stylesheet
+    | Error _ -> Alcotest.failf "could not parse %s" css
+  in
+  let canon css =
+    Css.Optimize.stylesheet (Css.statements (of_string css))
+    |> Css.Stylesheet.to_string ~minify:true
+    |> String.trim
+  in
+  Alcotest.(check string)
+    "the risky branches leave the list"
+    ".i::-webkit-search-cancel-button{display:none}.i::-webkit-search-decoration{display:none}.i::-webkit-search-results-button,.reset{display:none}"
+    (canon
+       ".i::-webkit-search-cancel-button,.i::-webkit-search-decoration,.i::-webkit-search-results-button{display:none}.reset{display:none}");
+  Alcotest.(check string)
+    "a list of only risky branches is left alone"
+    ".i::-webkit-search-cancel-button,.i::-webkit-search-decoration{display:none}"
+    (canon
+       ".i::-webkit-search-cancel-button,.i::-webkit-search-decoration{display:none}")
+
 let c61_no_merge_intervening () =
   (* CSS Cascade 6.1: [.a] and the intervening [.b] tie on specificity (0,1,0),
      so source order is observable for any element matching both. A
@@ -4782,6 +4808,8 @@ module Fuzz = struct
         fuzz_cascade_equivalent;
       Alcotest.test_case "same-selector merge past nested children" `Quick
         same_selector_merge_past_nested;
+      Alcotest.test_case "vendor pseudo-element list is split" `Quick
+        vendor_pseudo_list_is_split;
       Alcotest.test_case "cascade-neutral permutations stay equivalent" `Slow
         fuzz_neutral_permutation_soundness;
       Alcotest.test_case "shorthand longhand cascade preserved" `Slow

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1624,6 +1624,29 @@ let c61_adjacent_later_dedup () =
     "adjacent same-selector rules merge and dedupe by source order"
     ".box{display:flex;color:#00f}" output
 
+(* A rule that carries nested children can still absorb a later same-selector
+   rule: the merge moves the later declarations ahead of the nested block, which
+   is only observable for a property the nested block also sets. *)
+let same_selector_merge_past_nested () =
+  let of_string css =
+    match Css.of_string css with
+    | Ok p -> p.Css.stylesheet
+    | Error _ -> Alcotest.failf "could not parse %s" css
+  in
+  let canon css =
+    Css.Optimize.stylesheet (Css.statements (of_string css))
+    |> Css.Stylesheet.to_string ~minify:true
+    |> String.trim
+  in
+  Alcotest.(check string)
+    "disjoint nested children do not block the merge"
+    ".a{color:red;padding:1rem;&:hover{background:#00f}}"
+    (canon ".a{color:red;&:hover{background:blue}}.a{padding:1rem}");
+  Alcotest.(check string)
+    "a nested child setting the same property does block it"
+    ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}"
+    (canon ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}")
+
 let c61_no_merge_intervening () =
   (* CSS Cascade 6.1: [.a] and the intervening [.b] tie on specificity (0,1,0),
      so source order is observable for any element matching both. A
@@ -4757,6 +4780,8 @@ module Fuzz = struct
         fuzz_valid_and_no_larger;
       Alcotest.test_case "optimize preserves the cascade" `Slow
         fuzz_cascade_equivalent;
+      Alcotest.test_case "same-selector merge past nested children" `Quick
+        same_selector_merge_past_nested;
       Alcotest.test_case "cascade-neutral permutations stay equivalent" `Slow
         fuzz_neutral_permutation_soundness;
       Alcotest.test_case "shorthand longhand cascade preserved" `Slow


### PR DESCRIPTION
Two independent fixes to the grouping passes.

The same-selector merge required every participant to have `nested = []` and dropped nested children from the merged rule, so a single nested block froze a rule against every later rule sharing its selector: `.a{color:red;&:hover{background:blue}}.a{padding:1rem}` stayed two rules. It is now allowed when the nested children and the declarations that would move past them are disjoint, and refused otherwise.

Separately, a selector list that mixes a vendor pseudo-element with ordinary selectors is now split so the risky branches stand alone. A browser that does not know `::-webkit-search-cancel-button` drops the entire rule, so every other selector in the list silently loses its declarations — the grouping passes already refuse to *build* such a list, and this gives one the author wrote the same treatment. Stacked on #202.