### PR TITLE
nest: distribute the parent over a nested selector list

### DIFF
--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -36,8 +36,13 @@ let substitute ?(leftmost = true) ~parent sel =
   let parent = if verbatim then parent else Selector.Is [ parent ] in
   Selector.map (function Selector.Nesting -> parent | s -> s) sel
 
-let combine parent child =
+(* CSS Nesting 1 §2: a nested selector list is relative to the parent branch by
+   branch, so [.p { a, b { ... } }] is [.p a, .p b]. Combining the parent with
+   the list as a whole would put the combinator on the first branch only and let
+   the rest escape as top-level selectors. *)
+let rec combine parent child =
   match child with
+  | Selector.List branches -> Selector.List (List.map (combine parent) branches)
   | Selector.Relative (comb, right) ->
       Selector.Combined (parent, comb, substitute ~leftmost:false ~parent right)
   | _ when contains child -> substitute ~parent child

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -91,6 +91,18 @@ let test_nesting_wraps_complex_parent () =
   check ".a .b{&:hover{color:red}}" ".a .b:hover{color:red}";
   check ".a .b{& .c{color:red}}" ".a .b .c{color:red}"
 
+(* CSS Nesting 1 §2: a nested selector list is relative to the parent branch by
+   branch. Combining the parent with the list as a whole put the combinator on
+   the first branch only, and every later branch escaped as a top-level selector
+   — [.p { a, b { ... } }] matched every [b] on the page. *)
+let test_nested_selector_list_keeps_parent () =
+  let check src expected =
+    Alcotest.(check string) src expected (render (Flatten.block (block src)))
+  in
+  check ".p{a,b{color:red}}" ".p a,.p b{color:red}";
+  check ".p{a::before,a::after{color:red}}" ".p a:before,.p a:after{color:red}";
+  check ".p{& a,& b{color:red}}" ".p a,.p b{color:red}"
+
 let suite =
   ( "flatten",
     [
@@ -106,4 +118,6 @@ let suite =
         test_bad_declaration_still_a_declaration;
       Alcotest.test_case "nesting wraps a complex parent" `Quick
         test_nesting_wraps_complex_parent;
+      Alcotest.test_case "nested selector list keeps the parent" `Quick
+        test_nested_selector_list_keeps_parent;
     ] )


### PR DESCRIPTION
CSS Nesting 1 §2 makes a nested selector list relative to the parent branch by branch: `.p { a, b { ... } }` is `.p a, .p b`. `Nest.combine` combined the parent with the list as a whole, producing `Combined (parent, Descendant, List [a; b])` — which serialises as `.p a,b`, so the combinator lands on the first branch and every later one escapes as a top-level selector.

On the tailwindcss.com sheet that made `code:where(...)::after { content: "`" }` apply to every `<code>` on the page rather than only inside `.prose`.