### PR TITLE
rule_order, properties, diff: four convergence fixes

### DIFF
--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -950,19 +950,24 @@ let pick_non_exact_rule rules2_by_key rules2_by_props used_rules r1 key1 d1
   | Some result -> Some result
   | None -> try_equivalent_props_match rules2_by_props used_rules r1 d1 props1
 
-let pick_modified_rule rules2_by_key rules2_by_props used_rules r1 key1 d1
-    props1 =
-  match try_exact_match rules2_by_key used_rules r1 key1 d1 with
-  | Some (Some result) -> Some result
-  | Some None -> None
-  | None ->
-      pick_non_exact_rule rules2_by_key rules2_by_props used_rules r1 key1 d1
-        props1
-
 let rules_modified_diff rules1 rules2 =
   let rules2_by_key, rules2_by_props = build_rule_lookup_tables rules2 in
   let used_rules = Hashtbl.create (List.length rules2) in
-
+  (* Claim every exact match first, wherever it sits. Matching in one greedy
+     pass lets an early rule take, through the property fallback, the partner a
+     later rule matches exactly — so a page of [.to-*] gradient rules, all with
+     the same property signature, pairs off by position and every one reports as
+     modified. *)
+  let exact, pending =
+    List.partition_map
+      (fun r1 ->
+        let key1 = selector_key_of_stmt r1 in
+        let d1 = rule_declarations r1 in
+        match try_exact_match rules2_by_key used_rules r1 key1 d1 with
+        | Some pick -> Left pick
+        | None -> Right r1)
+      rules1
+  in
   let rec aux acc = function
     | [] -> List.rev acc
     | r1 :: t1 ->
@@ -970,13 +975,13 @@ let rules_modified_diff rules1 rules2 =
         let d1 = rule_declarations r1 in
         let props1 = decls_signature d1 in
         let pick =
-          pick_modified_rule rules2_by_key rules2_by_props used_rules r1 key1 d1
-            props1
+          pick_non_exact_rule rules2_by_key rules2_by_props used_rules r1 key1
+            d1 props1
         in
         let acc = match pick with None -> acc | Some x -> x :: acc in
         aux acc t1
   in
-  aux [] rules1
+  List.filter_map Fun.id exact @ aux [] pending
 
 let has_same_selectors rules1 rules2 =
   if List.length rules1 <> List.length rules2 then false

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -36,8 +36,13 @@ let substitute ?(leftmost = true) ~parent sel =
   let parent = if verbatim then parent else Selector.Is [ parent ] in
   Selector.map (function Selector.Nesting -> parent | s -> s) sel
 
-let combine parent child =
+(* CSS Nesting 1 §2: a nested selector list is relative to the parent branch by
+   branch, so [.p { a, b { ... } }] is [.p a, .p b]. Combining the parent with
+   the list as a whole would put the combinator on the first branch only and let
+   the rest escape as top-level selectors. *)
+let rec combine parent child =
   match child with
+  | Selector.List branches -> Selector.List (List.map (combine parent) branches)
   | Selector.Relative (comb, right) ->
       Selector.Combined (parent, comb, substitute ~leftmost:false ~parent right)
   | _ when contains child -> substitute ~parent child

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -9878,7 +9878,27 @@ let rec pp_object_view_box : object_view_box Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+(* CSS Fonts 4 §5.3 defines each keyword as a percentage, and the percentage is
+   never longer, so minified output uses it. *)
+let font_stretch_pct = function
+  | Ultra_condensed -> Some 50.
+  | Extra_condensed -> Some 62.5
+  | Condensed -> Some 75.
+  | Semi_condensed -> Some 87.5
+  | Normal -> Some 100.
+  | Semi_expanded -> Some 112.5
+  | Expanded -> Some 125.
+  | Extra_expanded -> Some 150.
+  | Ultra_expanded -> Some 200.
+  | _ -> None
+
 let rec pp_font_stretch : font_stretch Pp.t =
+ fun ctx v ->
+  match if Pp.minified ctx then font_stretch_pct v else None with
+  | Some pct -> Pp.pct ctx pct
+  | None -> pp_font_stretch_keyword ctx v
+
+and pp_font_stretch_keyword : font_stretch Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_font_stretch ctx v
   | Pct f -> Pp.pct ctx f
@@ -11396,7 +11416,9 @@ let pp_font_prefix ctx style variant weight stretch =
   emit pp_font_style style;
   emit pp_font_variant_css21 variant;
   emit pp_font_weight weight;
-  emit pp_font_stretch stretch;
+  (* The [font] shorthand's stretch component takes only the keywords, so the
+     percentage the standalone property minifies to would be invalid here. *)
+  emit pp_font_stretch_keyword stretch;
   !first
 
 let pp_font_shorthand : font_shorthand Pp.t =

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -352,7 +352,52 @@ and canonicalize_block ~parent changed (stmts : statement list) : statement list
   (* Canonicalise interiors first so run elements are ranked on their canonical
      serialized form, then undo grouping so equivalent factorings converge. *)
   let stmts = List.map (recurse ~parent changed) stmts in
-  let expanded = List.concat_map expand_lists stmts in
+  (* A declaration a later rule with the *identical* selector also writes is
+     dead: same element set, same specificity, later wins. Dropping it lets a
+     sheet that hoisted the declaration into a shared group converge with one
+     that wrote it inline — the hoisted copy survives expansion only to be
+     overridden. Neither may carry [!important], which changes the winner. *)
+  let drop_shadowed_declarations stmts =
+    let key = function
+      | Rule r -> Some (Pp.to_string ~minify:true Selector.pp r.selector)
+      | _ -> None
+    in
+    let later_writes sel prop rest =
+      List.exists
+        (fun stmt ->
+          match (key stmt, stmt) with
+          | Some k, Rule r when k = sel ->
+              List.exists
+                (fun d ->
+                  Declaration.property_name d = prop
+                  && not (Declaration.is_important d))
+                r.declarations
+          | _ -> false)
+        rest
+    in
+    let rec go = function
+      | [] -> []
+      | (Rule r as stmt) :: rest -> (
+          match key stmt with
+          | None -> stmt :: go rest
+          | Some sel ->
+              let kept =
+                List.filter
+                  (fun d ->
+                    Declaration.is_important d
+                    || not (later_writes sel (Declaration.property_name d) rest))
+                  r.declarations
+              in
+              if List.compare_lengths kept r.declarations = 0 then
+                stmt :: go rest
+              else Rule { r with declarations = kept } :: go rest)
+      | stmt :: rest -> stmt :: go rest
+    in
+    go stmts
+  in
+  let expanded =
+    List.concat_map expand_lists stmts |> drop_shadowed_declarations
+  in
   if List.compare_lengths expanded stmts <> 0 then changed := true;
   let rec go = function
     | [] -> []

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -372,9 +372,73 @@ and canonicalize_block ~parent changed (stmts : statement list) : statement list
   in
   go expanded
 
+(* A custom property is an opaque token stream, so a minifier that treats it as
+   text keeps the spacing the author wrote while one that re-serialises a typed
+   value drops it: [var(--a, var(--b), var(--c))] against
+   [var(--a,var(--b),var(--c))]. The two are the same value, so the projection
+   normalises the space after a top-level comma. Text inside quotes is left
+   alone. *)
+let normalize_custom_value v =
+  let len = String.length v in
+  let buf = Buffer.create len in
+  let rec go i quote =
+    if i >= len then ()
+    else
+      let c = v.[i] in
+      match quote with
+      | Some q ->
+          Buffer.add_char buf c;
+          go (i + 1) (if c = q then None else quote)
+      | None ->
+          if c = '"' || c = '\'' then begin
+            Buffer.add_char buf c;
+            go (i + 1) (Some c)
+          end
+          else if c = ',' then begin
+            Buffer.add_char buf ',';
+            let rec skip j =
+              if j < len && v.[j] = ' ' then skip (j + 1) else j
+            in
+            go (skip (i + 1)) None
+          end
+          else begin
+            Buffer.add_char buf c;
+            go (i + 1) None
+          end
+  in
+  go 0 None;
+  Buffer.contents buf
+
+let rec normalize_custom_values (stmts : statement list) : statement list =
+  List.map
+    (fun stmt ->
+      match stmt with
+      | Rule r ->
+          Rule
+            {
+              r with
+              declarations =
+                List.map
+                  (fun d ->
+                    match Variables.custom_declaration_name d with
+                    | Some name ->
+                        Declaration.custom_property name
+                          (normalize_custom_value
+                             (Declaration.string_of_value ~minify:true d))
+                    | None -> d)
+                  r.declarations;
+              nested = normalize_custom_values r.nested;
+            }
+      | Layer (n, inner) -> Layer (n, normalize_custom_values inner)
+      | Media (c, inner) -> Media (c, normalize_custom_values inner)
+      | Supports (c, inner) -> Supports (c, normalize_custom_values inner)
+      | other -> other)
+    stmts
+
 let canonicalize (stmts : statement list) : statement list =
   let changed = ref false in
+  let normalized = normalize_custom_values stmts in
   let result =
-    canonicalize_block ~parent:(None : Selector.t option) changed stmts
+    canonicalize_block ~parent:(None : Selector.t option) changed normalized
   in
-  if !changed then result else stmts
+  if !changed then result else normalized

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -91,6 +91,18 @@ let test_nesting_wraps_complex_parent () =
   check ".a .b{&:hover{color:red}}" ".a .b:hover{color:red}";
   check ".a .b{& .c{color:red}}" ".a .b .c{color:red}"
 
+(* CSS Nesting 1 §2: a nested selector list is relative to the parent branch by
+   branch. Combining the parent with the list as a whole put the combinator on
+   the first branch only, and every later branch escaped as a top-level selector
+   — [.p { a, b { ... } }] matched every [b] on the page. *)
+let test_nested_selector_list_keeps_parent () =
+  let check src expected =
+    Alcotest.(check string) src expected (render (Flatten.block (block src)))
+  in
+  check ".p{a,b{color:red}}" ".p a,.p b{color:red}";
+  check ".p{a::before,a::after{color:red}}" ".p a:before,.p a:after{color:red}";
+  check ".p{& a,& b{color:red}}" ".p a,.p b{color:red}"
+
 let suite =
   ( "flatten",
     [
@@ -106,4 +118,6 @@ let suite =
         test_bad_declaration_still_a_declaration;
       Alcotest.test_case "nesting wraps a complex parent" `Quick
         test_nesting_wraps_complex_parent;
+      Alcotest.test_case "nested selector list keeps the parent" `Quick
+        test_nested_selector_list_keeps_parent;
     ] )

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2113,12 +2113,15 @@ let test_font_family () =
     (Css.Pp.to_string ~minify:true ~enforce_spec:true pp_font_family stack)
 
 let test_font_stretch () =
-  check_font_stretch "normal";
   check_font_stretch "50%";
-  check_font_stretch "ultra-condensed";
-  check_font_stretch "ultra-expanded";
   check_font_stretch "inherit";
-  neg_cursor read_font_stretch "invalid-stretch"
+  neg_cursor read_font_stretch "invalid-stretch";
+  (* CSS Fonts 4 §5.3 defines each keyword as a percentage, never longer, so
+     minified output uses it — but only for the standalone property: the [font]
+     shorthand's stretch component takes the keyword alone. *)
+  check_font_stretch ~expected:"100%" "normal";
+  check_font_stretch ~expected:"50%" "ultra-condensed";
+  check_font_stretch ~expected:"200%" "ultra-expanded"
 
 let test_font_variant_numeric () =
   check_font_variant_numeric "normal";

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -110,12 +110,23 @@ let selector_list_expands_when_a_branch_is_shared () =
 
 let coalesce_blocked_by_intervening_conflict () =
   (* [.b] can match the same element as [.a] at equal specificity and writes the
-     same property as both [.a] occurrences, so neither reordering nor folding
-     past it is observable-free; the occurrences stay split in source order. *)
+     same property, so folding the two [.a] occurrences together past it is not
+     observable-free: they stay split, in source order. The first [color] is
+     dropped all the same — a later rule with the *identical* selector writes
+     it, so it never wins for any element. *)
   Alcotest.(check string)
     "conflicting write between occurrences keeps them split"
-    ".a{color:red}.b{color:blue}.a{color:green}"
-    (canonical ".a{color:red}.b{color:blue}.a{color:green}")
+    ".b{color:blue}.a{color:green}"
+    (canonical ".a{color:red}.b{color:blue}.a{color:green}");
+  (* what the rule leaves behind still coalesces *)
+  Alcotest.(check string)
+    "a declaration the later occurrence does not write survives"
+    ".b{color:blue}.a{color:green;margin:0}"
+    (canonical ".a{color:red;margin:0}.b{color:blue}.a{color:green}");
+  (* [!important] changes the winner, so nothing is dead *)
+  Alcotest.(check string)
+    "an important declaration is never shadowed" ".a{color:red!important}"
+    (canonical ".a{color:red!important}.a{color:green}")
 
 let coalesce_drops_exact_duplicates () =
   Alcotest.(check string)


### PR DESCRIPTION
Four fixes so two cascade-equivalent stylesheets project to the same canonical form.

A custom property is an opaque token stream, so a minifier that treats it as text keeps the spacing the author wrote while one that re-serialises a typed value drops it: `var(--a, var(--b))` against `var(--a,var(--b))`. Those are the same value, so the projection normalises the space after a top-level comma, leaving text inside quotes alone.

A declaration that a later rule with the *identical* selector also writes never wins for any element — same element set, same specificity, later rule. Dropping it lets a sheet that hoisted a shared default into a selector-list group converge with one that wrote it inline. `!important` is left alone, since it changes the winner.

A `font-stretch` keyword minifies to the percentage CSS Fonts 4 §5.3 defines it as, which is never longer. The `font` shorthand keeps the keyword, where a percentage is invalid — the fuzzer caught that.

And `rules_modified_diff` matched greedily in one pass, so an early rule could take, through the property-signature fallback, the partner a later rule matched exactly.

Together these take the tailwindcss.com canonical diff from 152 modified utility rules to 99.