### PR TITLE
properties: print a position per background layer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,13 @@
   never-matching instead of discarding the `@media` block or
   `@import` (#192)
 
+### Printing
+
+- `background-position` and `mask-position` print one position per layer,
+  comma-separated. The layers were joined with spaces, so
+  `background-position: 30% 50%, 70% 50%` read back as a single four-value
+  position and minified to `30% 70%` (#209)
+
 ### Minification
 
 - A rule with nested children absorbs a later rule with the same

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -8035,8 +8035,11 @@ let rec pp_background_size : background_size Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_background_size ctx v
 
+(* CSS Backgrounds 3 sec. 3.6: the value is one position per background layer,
+   comma-separated. It is not a box shorthand, so the layers neither join with
+   spaces nor collapse the way margins do. *)
 let pp_background_position : background_position Pp.t =
- fun ctx positions -> pp_box_shorthand pp_position_value ctx positions
+ fun ctx positions -> Pp.list ~sep:Pp.comma pp_position_value ctx positions
 
 let pp_bg_prop maybe_space pp_func ctx = function
   | Some value ->
@@ -9878,8 +9881,8 @@ let rec pp_object_view_box : object_view_box Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
-(* CSS Fonts 4 §5.3 defines each keyword as a percentage, and the percentage is
-   never longer, so minified output uses it. *)
+(* CSS Fonts 4 sec. 5.3 defines each keyword as a percentage, and the percentage
+   is never longer, so minified output uses it. *)
 let font_stretch_pct = function
   | Ultra_condensed -> Some 50.
   | Extra_condensed -> Some 62.5

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -302,7 +302,15 @@ let special_cases () =
   (* Multiple backgrounds *)
   check_declaration ~expected:"background:url(x.png),linear-gradient(red,blue)"
     ~optimized:"background:url(x.png),linear-gradient(red,#00f)"
-    "background: url(x.png), linear-gradient(red, blue);"
+    "background: url(x.png), linear-gradient(red, blue);";
+
+  (* One position per background layer, comma-separated: joining the layers with
+     spaces reads as a single four-value position. *)
+  check_declaration ~expected:"background-position:30% 50%,70% 50%"
+    ~optimized:"background-position:30%,70%"
+    "background-position: 30% 50%, 70% 50%;";
+  check_declaration ~expected:"mask-position:0 0,10px 10px"
+    "mask-position: 0 0, 10px 10px;"
 
 let colors () =
   (* Same-node spellings the printer keeps (case-fold, hex shorten). The


### PR DESCRIPTION
`background-position` and `mask-position` hold one position per background layer, comma-separated, but the printer joined the list with spaces the way a box shorthand does. A two-layer value such as `background-position: 30% 50%, 70% 50%` came back as a single four-value position and minified to `30% 70%`.