### PR TITLE
diff: bound the report so a large comparison stays readable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -74,6 +74,23 @@
   missing hue component, printed as `oklch(55.6% 0 none)` per CSS
   Color 4 (#190)
 
+### Diff report
+
+- `cascade diff` bounds its report: it prints the whole difference tree
+  while that stays short, and otherwise falls back to the deepest level
+  that fits, with `--depth` to pin a level or ask for the tree in full.
+  A whole-stylesheet comparison used to print every level, so the shape
+  of the change was only reachable by grepping the tree connectors out of
+  the output (#210)
+- Parse warnings print above the difference report instead of below it,
+  capped per side with the remainder counted. A declaration the parser
+  dropped qualifies every difference under it, and a stylesheet that
+  trips one unsupported syntax repeatedly used to bury the report (#210)
+- Conditional blocks that only changed position are reported as a shift
+  run. Merging two same-condition blocks renumbers every block after
+  them, and each was listed twice, once per side, so a single merge read
+  as a wholesale rewrite of the container (#210)
+
 ### Canonical diff
 
 - `--diff=canonical` expands every selector-list rule onto its branches

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -4,6 +4,11 @@ type mode = Auto | Tree | String | Canonical
 
 let err_read path msg = Error (`Msg (Fmt.str "Error reading %s: %s" path msg))
 
+let err_depth s =
+  Error
+    (`Msg
+       (Fmt.str "invalid depth %S: expected auto, max, or a positive integer" s))
+
 let read_file path =
   try
     let ic = open_in path in
@@ -36,20 +41,89 @@ let run_diff mode ~lossless ~prune_unused_custom_props ~css1 ~css2 =
   Cascade_diff.Css_compare.diff ~mode ~lossless ~prune_unused_custom_props css1
     css2
 
-let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 result =
+type depth = Fit | Full | Level of int
+
+(* A report past this many lines has stopped summarising and started dumping, so
+   [Auto] drops to the deepest level that still fits. *)
+let auto_line_budget = 40
+
+(* [nested_differences] stops recursing at 3, so probing past that only re-walks
+   a tree that cannot grow. *)
+let max_probe_depth = 5
+
+let count_lines s =
+  let n = ref 0 in
+  String.iter (fun c -> if c = '\n' then incr n) s;
+  !n
+
+(* Parse warnings shown per side before the rest is counted. *)
+let auto_warning_budget = 3
+
+let render_diff ~color ~file1 ~file2 ~depth result =
+  let buf = Buffer.create 1024 in
+  Cascade_diff.Css_compare.pp_diff ~expected:file1 ~actual:file2 ~color ?depth
+    buf result;
+  Buffer.contents buf
+
+let render_warnings ~file1 ~file2 ~max result =
+  let buf = Buffer.create 256 in
+  Cascade_diff.Css_compare.pp_warnings ~expected:file1 ~actual:file2 ?max buf
+    result;
+  if Cascade_diff.Css_compare.has_warnings result then Buffer.add_char buf '\n';
+  Buffer.contents buf
+
+(* Deepest level whose report still fits the budget, or level 1 when even the
+   roots overflow: the roots are the one thing always worth printing. *)
+let fit_depth render =
+  let rec go level best =
+    if level > max_probe_depth then best
+    else
+      let body = render (Some level) in
+      if count_lines body <= auto_line_budget then go (level + 1) (level, body)
+      else best
+  in
+  go 2 (1, render (Some 1))
+
+let render_at_depth ~color ~file1 ~file2 ~depth result =
+  let render depth = render_diff ~color ~file1 ~file2 ~depth result in
+  match depth with
+  | Full -> (render None, None)
+  | Level n -> (render (Some n), None)
+  | Fit ->
+      let full = render None in
+      if count_lines full <= auto_line_budget then (full, None)
+      else
+        let level, body = fit_depth render in
+        (body, Some level)
+
+let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth result =
   let stats =
     Cascade_diff.Css_compare.stats ~expected_str:css1 ~actual_str:css2 result
+  in
+  let max_warnings =
+    match depth with Full -> None | Fit | Level _ -> Some auto_warning_budget
   in
   let buf = Buffer.create 1024 in
   Cascade_diff.Css_compare.pp_stats buf stats;
   Buffer.add_char buf '\n';
-  Cascade_diff.Css_compare.pp ~expected:file1 ~actual:file2 ~color buf result;
+  Buffer.add_string buf (render_warnings ~file1 ~file2 ~max:max_warnings result);
+  let body, elided_at = render_at_depth ~color ~file1 ~file2 ~depth result in
+  Buffer.add_string buf body;
   Buffer.add_char buf '\n';
+  (match elided_at with
+  | None -> ()
+  | Some level ->
+      List.iter (Buffer.add_string buf)
+        [
+          "(depth ";
+          string_of_int level;
+          "; use --depth=max for the full report)\n";
+        ]);
   print_string (Buffer.contents buf)
 
 type canonical_opts = { lossless : bool; prune_unused_custom_props : bool }
 
-let compare_files file1 file2 style_renderer mode opts memtrace_path () =
+let compare_files file1 file2 style_renderer mode depth opts memtrace_path () =
   Cli_io.start_memtrace memtrace_path;
   Fmt_tty.setup_std_outputs
     ?style_renderer:(resolve_style_renderer style_renderer)
@@ -77,15 +151,17 @@ let compare_files file1 file2 style_renderer mode opts memtrace_path () =
         | No_diff _ ->
             (* Equal ASTs can still hide parse-dropped declarations; show the
                warnings so the equality verdict is honest about them. *)
-            let buf = Buffer.create 256 in
-            Cascade_diff.Css_compare.pp ~expected:file1 ~actual:file2 ~color buf
-              result;
-            print_string (Buffer.contents buf);
+            let max =
+              match depth with
+              | Full -> None
+              | Fit | Level _ -> Some auto_warning_budget
+            in
+            print_string (render_warnings ~file1 ~file2 ~max result);
             Fmt.pr "CSS files are identical@.";
             Ok ()
         | String_diff _ | Tree_diff _ | Both_errors _ | Expected_error _
         | Actual_error _ ->
-            print_diff_report ~color ~file1 ~file2 ~css1 ~css2 result;
+            print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth result;
             (* Differing inputs are a result, not a usage error: exit 1 as
                documented, distinct from cmdliner's reserved error codes. *)
             Stdlib.exit 1)
@@ -115,6 +191,33 @@ let mode_arg =
       ]
   in
   Arg.(value & opt mode_conv Auto & info [ "diff" ] ~docv:"MODE" ~doc)
+
+let depth_arg =
+  let doc =
+    "How many levels of the difference tree to print: $(b,auto) (default) \
+     prints the whole tree when it is short and otherwise falls back to the \
+     deepest level that stays readable, $(b,max) always prints it in full, and \
+     an integer pins an exact level ($(b,1) is the top-level entries alone). \
+     Wherever children are cut off, a $(b,... N more lines) marker records how \
+     much is hidden."
+  in
+  let parse = function
+    | "auto" -> Ok Fit
+    | "max" | "full" -> Ok Full
+    | s -> (
+        match int_of_string_opt s with
+        | Some n when n >= 1 -> Ok (Level n)
+        | Some _ | None -> err_depth s)
+  in
+  let print ppf = function
+    | Fit -> Fmt.string ppf "auto"
+    | Full -> Fmt.string ppf "max"
+    | Level n -> Fmt.int ppf n
+  in
+  Arg.(
+    value
+    & opt (conv ~docv:"DEPTH" (parse, print)) Fit
+    & info [ "depth" ] ~docv:"DEPTH" ~doc)
 
 let lossless_arg =
   let doc =
@@ -162,7 +265,7 @@ let term =
   in
   term_result
     (const compare_files $ file1_arg $ file2_arg $ style_renderer_with_env
-   $ mode_arg $ canonical_opts $ memtrace_arg $ Cli_log.term)
+   $ mode_arg $ depth_arg $ canonical_opts $ memtrace_arg $ Cli_log.term)
 
 let man =
   [
@@ -191,6 +294,12 @@ let man =
     `I
       ( "--diff=canonical",
         "Compare canonical minified CSS before reporting a diff" );
+    `I
+      ( "--depth=auto|max|N",
+        "Levels of the difference tree to print. $(b,auto) (default) prints it \
+         whole while it stays short, then falls back to the deepest level that \
+         fits; $(b,max) always prints it whole; an integer pins a level. Cut \
+         subtrees are marked with the number of lines hidden." );
     `I
       ( "--lossless",
         "Disable colour approximation under $(b,--diff=canonical): colour \

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -503,20 +503,37 @@ let stats = compute_stats
 let add_strings b ls = List.iter (Buffer.add_string b) ls
 
 (* Render each side's parse warnings so a declaration the parser dropped never
-   reads as a phantom structural difference on the side that parsed. *)
-let pp_parse_warnings buf label warnings =
+   reads as a phantom structural difference on the side that parsed. Past [max]
+   they are counted rather than printed: a stylesheet that trips the same
+   unsupported syntax hundreds of times would otherwise bury the diff it is
+   meant to qualify. *)
+let pp_parse_warnings ?(max = Stdlib.max_int) buf label warnings =
+  let shown, hidden =
+    let n = List.length warnings in
+    if n <= max then (warnings, 0)
+    else (List.filteri (fun i _ -> i < max) warnings, n - max)
+  in
   List.iter
     (fun w ->
       if Buffer.length buf > 0 && Buffer.nth buf (Buffer.length buf - 1) <> '\n'
       then Buffer.add_char buf '\n';
       add_strings buf [ label; " parse warning: "; Error.to_string w; "\n" ])
-    warnings
+    shown;
+  if hidden > 0 then
+    add_strings buf
+      [
+        label;
+        ": ";
+        string_of_int hidden;
+        (if hidden = 1 then " more parse warning\n"
+         else " more parse warnings\n");
+      ]
 
-let pp_result ?(expected = "Expected") ?(actual = "Actual") ?(color = false) buf
-    = function
+let pp_result ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
+    ?depth buf = function
   | Tree_diff d ->
       (* Show structural differences *)
-      D.pp ~expected ~actual ~color buf d
+      D.pp ~expected ~actual ~color ?depth buf d
   | String_diff sdiff -> String_diff.pp buf sdiff
   | No_diff _ ->
       (* No output for structurally equivalent files (whether or not the
@@ -544,10 +561,23 @@ let pp_result ?(expected = "Expected") ?(actual = "Actual") ?(color = false) buf
   | Actual_error e ->
       add_strings buf [ actual; " CSS parse error: "; Error.to_string e ]
 
-let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false) buf t =
-  pp_result ~expected ~actual ~color buf t.result;
-  pp_parse_warnings buf expected t.expected_warnings;
-  pp_parse_warnings buf actual t.actual_warnings
+let pp_warnings ?(expected = "Expected") ?(actual = "Actual") ?max buf t =
+  pp_parse_warnings ?max buf expected t.expected_warnings;
+  pp_parse_warnings ?max buf actual t.actual_warnings
+
+let has_warnings t = t.expected_warnings <> [] || t.actual_warnings <> []
+
+let pp_diff ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
+    ?depth buf t =
+  pp_result ~expected ~actual ~color ?depth buf t.result
+
+let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false) ?depth buf
+    t =
+  (* Warnings come first: a dropped declaration qualifies every line below it,
+     and trailing them puts that caveat past the end of a long report. *)
+  pp_warnings ~expected ~actual buf t;
+  if has_warnings t then Buffer.add_char buf '\n';
+  pp_diff ~expected ~actual ~color ?depth buf t
 
 let add_pct buf char_diff_pct =
   let rounded = Float.round (char_diff_pct *. 10.0) /. 10.0 in

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -617,7 +617,7 @@ let emit_changes buf stats =
       entries;
     if container > 0 then (
       if entries <> [] then Buffer.add_string buf ", ";
-      add_strings buf [ string_of_int container; " containers" ]);
+      add_change buf container "changed" "container");
     Buffer.add_char buf '\n')
 
 let pp_stats buf stats =

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -98,12 +98,47 @@ val as_tree_diff : t -> Tree_diff.t option
     a {!constructor-Tree_diff}; [None] otherwise. *)
 
 val pp :
-  ?expected:string -> ?actual:string -> ?color:bool -> Buffer.t -> t -> unit
-(** [pp ?expected ?actual ?color buf result] formats [result] into [buf], then
-    renders each side's parse warnings. The [expected]/[actual] labels are used
-    in the rendered header and warning lines (defaults: ["Expected"],
-    ["Actual"]). [color] (default [false]) wraps diff markers in ANSI escapes;
-    the caller decides whether the destination supports colour. *)
+  ?expected:string ->
+  ?actual:string ->
+  ?color:bool ->
+  ?depth:int ->
+  Buffer.t ->
+  t ->
+  unit
+(** [pp ?expected ?actual ?color ?depth buf result] renders each side's parse
+    warnings into [buf], then formats [result] below them. Warnings lead because
+    a declaration the parser dropped qualifies every difference that follows.
+    The [expected]/[actual] labels are used in the rendered header and warning
+    lines (defaults: ["Expected"], ["Actual"]). [color] (default [false]) wraps
+    diff markers in ANSI escapes; the caller decides whether the destination
+    supports colour. [depth] bounds the rendered tree levels as in
+    {!Tree_diff.pp} (default: unbounded).
+
+    {!pp_warnings} and {!pp_diff} are the two halves, for callers that need to
+    size or bound the sections independently. *)
+
+val pp_warnings :
+  ?expected:string -> ?actual:string -> ?max:int -> Buffer.t -> t -> unit
+(** [pp_warnings ?expected ?actual ?max buf result] renders only the parse
+    warnings each side accumulated. [max] caps how many are printed per side
+    (default: all); the remainder is reported as a count, so a stylesheet that
+    trips the same unsupported syntax hundreds of times cannot bury the diff
+    those warnings qualify. *)
+
+val pp_diff :
+  ?expected:string ->
+  ?actual:string ->
+  ?color:bool ->
+  ?depth:int ->
+  Buffer.t ->
+  t ->
+  unit
+(** [pp_diff ?expected ?actual ?color ?depth buf result] renders only the
+    difference report, without the parse warnings. *)
+
+val has_warnings : t -> bool
+(** [has_warnings result] is [true] when either side accumulated a parse
+    warning. *)
 
 (** {1:stats Statistics} *)
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -87,10 +87,12 @@ let is_empty d = d.rules = [] && d.containers = []
 type tree_style = {
   use_tree : bool; (* Whether to use tree-style box-drawing characters *)
   color : bool; (* Whether to wrap diff markers in ANSI colors *)
+  depth : int; (* Levels still renderable below the current node *)
 }
 
-let default_style = { use_tree = false; color = false }
-let tree_style = { use_tree = true; color = false }
+let unlimited_depth = max_int
+let default_style = { use_tree = false; color = false; depth = unlimited_depth }
+let tree_style = { use_tree = true; color = false; depth = unlimited_depth }
 
 (* ANSI color helpers. Plain text unless [color] is set: the printers write into
    a [Buffer.t], so tty detection cannot happen here; the caller decides. *)
@@ -122,6 +124,33 @@ let tree_continuation ~style ~is_last ~parent_prefix =
   else
     let continuation = if is_last then "   " else "\u{2502}  " in
     parent_prefix ^ continuation
+
+(* Leaf lines (declarations, block listings) hang off the continuation prefix
+   without a connector of their own. *)
+let child_indent ~style ~parent_prefix =
+  if style.use_tree then parent_prefix ^ "   " else parent_prefix ^ "    "
+
+let add_strings buf ls = List.iter (Buffer.add_string buf) ls
+
+let count_lines buf =
+  let n = ref 0 in
+  String.iter (fun c -> if c = '\n' then incr n) (Buffer.contents buf);
+  !n
+
+(* Render a node's children under the depth budget. Past the budget the subtree
+   is still rendered, but only to report how much it hides: a diff that silently
+   stopped at depth N would read as "nothing more to see". *)
+let pp_children ~style ~parent_prefix buf render =
+  if style.depth > 0 then render { style with depth = style.depth - 1 } buf
+  else
+    let sub = Buffer.create 256 in
+    render { style with depth = unlimited_depth } sub;
+    match count_lines sub with
+    | 0 -> ()
+    | n ->
+        let noun = if n = 1 then " more line\n" else " more lines\n" in
+        add_strings buf
+          [ child_indent ~style ~parent_prefix; "..."; string_of_int n; noun ]
 
 (* Print a list of CSS declarations with an action prefix *)
 let pp_declarations ?(style = default_style) ?(parent_prefix = "") buf action
@@ -307,40 +336,51 @@ let pp_reorder ?(style = default_style) ?(parent_prefix = "") decls1 decls2 buf
     && reorder_is_significant decls1 decls2
   then pp_same_property_reorder buf indent prop_names1 prop_names2
 
+let pp_content_changed_body ~style ~child_prefix buf ~old_declarations
+    ~new_declarations ~property_changes ~added_properties ~removed_properties
+    ~has_any_changes =
+  let indent = child_indent ~style ~parent_prefix:child_prefix in
+  List.iter
+    (fun prop_name ->
+      add_strings buf
+        [ indent; ansi_red ~color:style.color ("- " ^ prop_name); "\n" ])
+    removed_properties;
+  List.iter
+    (fun prop_name ->
+      add_strings buf
+        [ indent; ansi_green ~color:style.color ("+ " ^ prop_name); "\n" ])
+    added_properties;
+  pp_property_diffs ~style ~parent_prefix:child_prefix buf property_changes;
+  pp_reorder ~style ~parent_prefix:child_prefix old_declarations
+    new_declarations buf;
+  if (not has_any_changes) && old_declarations <> new_declarations then
+    let old_count = List.length old_declarations in
+    let new_count = List.length new_declarations in
+    if old_count <> new_count then
+      add_strings buf
+        [
+          indent;
+          "(declaration count: ";
+          string_of_int old_count;
+          " -> ";
+          string_of_int new_count;
+          ")\n";
+        ]
+    else add_strings buf [ indent; "(declarations differ in subtle ways)\n" ]
+
 let pp_content_changed ~style ~prefix ~child_prefix buf ~selector
     ~old_declarations ~new_declarations ~property_changes ~added_properties
     ~removed_properties =
-  let indent =
-    if style.use_tree then child_prefix ^ "   " else child_prefix ^ "    "
-  in
   let has_any_changes =
     property_changes <> [] || added_properties <> [] || removed_properties <> []
   in
   if (not has_any_changes) && old_declarations = new_declarations then ()
   else (
-    Buffer.add_string buf (prefix ^ selector ^ "\n");
-    List.iter
-      (fun prop_name ->
-        Buffer.add_string buf
-          (indent ^ ansi_red ~color:style.color ("- " ^ prop_name) ^ "\n"))
-      removed_properties;
-    List.iter
-      (fun prop_name ->
-        Buffer.add_string buf
-          (indent ^ ansi_green ~color:style.color ("+ " ^ prop_name) ^ "\n"))
-      added_properties;
-    pp_property_diffs ~style ~parent_prefix:child_prefix buf property_changes;
-    pp_reorder ~style ~parent_prefix:child_prefix old_declarations
-      new_declarations buf;
-    if (not has_any_changes) && old_declarations <> new_declarations then
-      let old_count = List.length old_declarations in
-      let new_count = List.length new_declarations in
-      if old_count <> new_count then
-        Buffer.add_string buf
-          (indent ^ "(declaration count: " ^ string_of_int old_count ^ " -> "
-         ^ string_of_int new_count ^ ")\n")
-      else
-        Buffer.add_string buf (indent ^ "(declarations differ in subtle ways)\n"))
+    add_strings buf [ prefix; selector; "\n" ];
+    pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
+        pp_content_changed_body ~style ~child_prefix buf ~old_declarations
+          ~new_declarations ~property_changes ~added_properties
+          ~removed_properties ~has_any_changes))
 
 let pp_position_reorder ~prefix buf ~selector ~expected_pos ~actual_pos
     ~swapped_with =
@@ -366,20 +406,19 @@ let pp_regrouped ~style ~prefix ~child_prefix buf ~from_selectors ~to_selectors
   let verb =
     if nf > nt then "merged" else if nf < nt then "split" else "regrouped"
   in
-  Buffer.add_string buf (prefix ^ "selectors " ^ verb ^ "\n");
-  let indent =
-    if style.use_tree then child_prefix ^ "   " else child_prefix ^ "    "
-  in
-  List.iter
-    (fun s ->
-      Buffer.add_string buf
-        (indent ^ ansi_red ~color:style.color ("- " ^ s) ^ "\n"))
-    from_selectors;
-  List.iter
-    (fun s ->
-      Buffer.add_string buf
-        (indent ^ ansi_green ~color:style.color ("+ " ^ s) ^ "\n"))
-    to_selectors
+  add_strings buf [ prefix; "selectors "; verb; "\n" ];
+  pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
+      let indent = child_indent ~style ~parent_prefix:child_prefix in
+      List.iter
+        (fun s ->
+          add_strings buf
+            [ indent; ansi_red ~color:style.color ("- " ^ s); "\n" ])
+        from_selectors;
+      List.iter
+        (fun s ->
+          add_strings buf
+            [ indent; ansi_green ~color:style.color ("+ " ^ s); "\n" ])
+        to_selectors)
 
 let pp_rule_diff ?(style = default_style) ?(is_last = false)
     ?(parent_prefix = "") buf (diff : rule_diff) =
@@ -387,14 +426,17 @@ let pp_rule_diff ?(style = default_style) ?(is_last = false)
   | Added { selector; declarations } ->
       let prefix = tree_prefix ~style ~is_last ~parent_prefix in
       let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
-      Buffer.add_string buf (prefix ^ selector ^ "\n");
-      pp_declarations ~style ~parent_prefix:child_prefix buf "add" declarations
+      add_strings buf [ prefix; selector; "\n" ];
+      pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
+          pp_declarations ~style ~parent_prefix:child_prefix buf "add"
+            declarations)
   | Removed { selector; declarations } ->
       let prefix = tree_prefix ~style ~is_last ~parent_prefix in
       let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
-      Buffer.add_string buf (prefix ^ selector ^ "\n");
-      pp_declarations ~style ~parent_prefix:child_prefix buf "remove"
-        declarations
+      add_strings buf [ prefix; selector; "\n" ];
+      pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
+          pp_declarations ~style ~parent_prefix:child_prefix buf "remove"
+            declarations)
   | Content_changed r ->
       let prefix = tree_prefix ~style ~is_last ~parent_prefix in
       let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
@@ -407,22 +449,23 @@ let pp_rule_diff ?(style = default_style) ?(is_last = false)
   | Selector_changed { old_selector; new_selector; declarations } ->
       let prefix = tree_prefix ~style ~is_last ~parent_prefix in
       let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
-      Buffer.add_string buf (prefix ^ "selector changed:\n");
-      let indent =
-        if style.use_tree then child_prefix ^ "   " else child_prefix ^ "    "
-      in
-      Buffer.add_string buf (indent ^ "from: " ^ old_selector ^ "\n");
-      Buffer.add_string buf (indent ^ "to:   " ^ new_selector ^ "\n");
-      if declarations <> [] then
-        pp_declarations ~style ~parent_prefix:child_prefix buf "declarations"
-          declarations
+      add_strings buf [ prefix; "selector changed:\n" ];
+      pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
+          let indent = child_indent ~style ~parent_prefix:child_prefix in
+          add_strings buf [ indent; "from: "; old_selector; "\n" ];
+          add_strings buf [ indent; "to:   "; new_selector; "\n" ];
+          if declarations <> [] then
+            pp_declarations ~style ~parent_prefix:child_prefix buf
+              "declarations" declarations)
   | Reordered r -> (
       let prefix = tree_prefix ~style ~is_last ~parent_prefix in
       match (r.old_declarations, r.new_declarations) with
       | Some old_decls, Some new_decls ->
           let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
-          Buffer.add_string buf (prefix ^ r.selector ^ "\n");
-          pp_reorder ~style ~parent_prefix:child_prefix old_decls new_decls buf
+          add_strings buf [ prefix; r.selector; "\n" ];
+          pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
+              pp_reorder ~style ~parent_prefix:child_prefix old_decls new_decls
+                buf)
       | _ ->
           pp_position_reorder ~prefix buf ~selector:r.selector
             ~expected_pos:r.expected_pos ~actual_pos:r.actual_pos
@@ -592,55 +635,57 @@ let pp_block_structure_changed ~style ~is_last ~parent_prefix buf
   let cont_prefix = container_prefix container_type in
   let prefix = tree_prefix ~style ~is_last ~parent_prefix in
   let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
-  let indent =
-    if style.use_tree then child_prefix ^ "   " else child_prefix ^ "    "
-  in
-
-  (* Show the merge/split summary *)
   let exp_count = List.length expected_blocks in
   let act_count = List.length actual_blocks in
-
   (* Report block structure changes - this is a meaningful difference even if
      selectors are identical *)
-  if exp_count > act_count then
-    Buffer.add_string buf
-      (prefix ^ cont_prefix ^ " " ^ condition ^ " (" ^ string_of_int exp_count
-     ^ " blocks merged into " ^ string_of_int act_count ^ ")\n")
-  else if exp_count < act_count then
-    Buffer.add_string buf
-      (prefix ^ cont_prefix ^ " " ^ condition ^ " (" ^ string_of_int exp_count
-     ^ " block split into " ^ string_of_int act_count ^ ")\n")
-  else
-    (* Same count but different positions *)
-    Buffer.add_string buf
-      (prefix ^ cont_prefix ^ " " ^ condition ^ " (" ^ string_of_int exp_count
-     ^ " blocks at different positions)\n");
-
-  let pp_blocks sign style_fn blocks =
-    List.iter
-      (fun (pos, rules) ->
-        let selectors = selectors_of_rules rules in
-        if selectors <> [] then
-          Buffer.add_string buf
-            (indent
-            ^ style_fn
-                (sign ^ " Block at position " ^ string_of_int pos ^ ": "
-                ^ String.concat ", " selectors)
-            ^ "\n"))
-      blocks
+  let summary =
+    if exp_count > act_count then
+      [
+        string_of_int exp_count; " blocks merged into "; string_of_int act_count;
+      ]
+    else if exp_count < act_count then
+      [ string_of_int exp_count; " block split into "; string_of_int act_count ]
+    else [ string_of_int exp_count; " blocks at different positions" ]
   in
-  pp_blocks "-" (ansi_red ~color:style.color) expected_blocks;
-  pp_blocks "+" (ansi_green ~color:style.color) actual_blocks
+  add_strings buf ([ prefix; cont_prefix; " "; condition; " (" ] @ summary);
+  Buffer.add_string buf ")\n";
+  pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
+      let indent = child_indent ~style ~parent_prefix:child_prefix in
+      let pp_blocks sign style_fn blocks =
+        List.iter
+          (fun (pos, rules) ->
+            let selectors = selectors_of_rules rules in
+            if selectors <> [] then
+              add_strings buf
+                [
+                  indent;
+                  style_fn
+                    (sign ^ " Block at position " ^ string_of_int pos ^ ": "
+                    ^ String.concat ", " selectors);
+                  "\n";
+                ])
+          blocks
+      in
+      pp_blocks "-" (ansi_red ~color:style.color) expected_blocks;
+      pp_blocks "+" (ansi_green ~color:style.color) actual_blocks)
 
 let pp_container_add_remove ~style ~is_last ~parent_prefix ~label buf
     container_type condition rules =
   let prefix = tree_prefix ~style ~is_last ~parent_prefix in
   let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
-  Buffer.add_string buf
-    (prefix
-    ^ container_prefix container_type
-    ^ " " ^ condition ^ " (" ^ label ^ ")\n");
-  pp_container_rules ~style ~parent_prefix:child_prefix ~label buf rules
+  add_strings buf
+    [
+      prefix;
+      container_prefix container_type;
+      " ";
+      condition;
+      " (";
+      label;
+      ")\n";
+    ];
+  pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
+      pp_container_rules ~style ~parent_prefix:child_prefix ~label buf rules)
 
 let rec pp_container_diff ?(style = default_style) ?(is_last = false)
     ?(parent_prefix = "") buf = function
@@ -661,30 +706,30 @@ let rec pp_container_diff ?(style = default_style) ?(is_last = false)
       let prefix = tree_prefix ~style ~is_last ~parent_prefix in
       let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
       let changes_parts = count_rule_changes rule_changes in
-      Buffer.add_string buf (prefix ^ cont_prefix ^ " " ^ condition ^ " ");
+      add_strings buf [ prefix; cont_prefix; " "; condition; " " ];
       if changes_parts <> [] then
-        Buffer.add_string buf ("(" ^ String.concat ", " changes_parts ^ ")\n")
+        add_strings buf [ "("; String.concat ", " changes_parts; ")\n" ]
       else if container_changes = [] then
         Buffer.add_string buf "(position changed)\n"
       else Buffer.add_char buf '\n';
-
-      (* Show rule changes at this level *)
-      List.iteri
-        (fun i rule_diff ->
-          let is_last_item =
-            i = List.length rule_changes - 1 && container_changes = []
-          in
-          pp_rule_diff ~style ~is_last:is_last_item ~parent_prefix:child_prefix
-            buf rule_diff)
-        rule_changes;
-      (* Show nested container changes with increased indentation *)
-      let container_count = List.length container_changes in
-      List.iteri
-        (fun i cont_diff ->
-          let is_last_cont = i = container_count - 1 in
-          pp_container_diff ~style ~is_last:is_last_cont
-            ~parent_prefix:child_prefix buf cont_diff)
-        container_changes
+      pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
+          (* Show rule changes at this level *)
+          List.iteri
+            (fun i rule_diff ->
+              let is_last_item =
+                i = List.length rule_changes - 1 && container_changes = []
+              in
+              pp_rule_diff ~style ~is_last:is_last_item
+                ~parent_prefix:child_prefix buf rule_diff)
+            rule_changes;
+          (* Show nested container changes with increased indentation *)
+          let container_count = List.length container_changes in
+          List.iteri
+            (fun i cont_diff ->
+              let is_last_cont = i = container_count - 1 in
+              pp_container_diff ~style ~is_last:is_last_cont
+                ~parent_prefix:child_prefix buf cont_diff)
+            container_changes)
   | Reordered
       { info = { container_type; condition; _ }; expected_pos; actual_pos } ->
       let cont_prefix = container_prefix container_type in
@@ -727,8 +772,8 @@ let pp_containers_section ~style buf containers =
       pp_container_diff ~style ~is_last ~parent_prefix:"" buf cont_diff)
     containers
 
-let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false) buf
-    { rules; containers } =
+let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
+    ?(depth = unlimited_depth) buf { rules; containers } =
   if rules = [] && containers = [] then
     Buffer.add_string buf
       "Structural differences detected in nested contexts (e.g., @media inside \
@@ -744,7 +789,8 @@ let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false) buf
           match diff with Reordered _ -> true | _ -> false)
         rules
     in
-    let style = { tree_style with color } in
+    (* [depth] counts renderable levels; the roots printed here are level 1. *)
+    let style = { tree_style with color; depth = max 0 (depth - 1) } in
     let container_count = List.length containers in
     pp_rule_list ~style ~container_count buf meaningful;
     pp_reordered_section ~style ~container_count buf reordered_rules;

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -630,6 +630,113 @@ let selectors_of_rules rules =
       | None -> None)
     rules
 
+(* Position + selector signature for every block that names at least one
+   rule. *)
+let block_signatures blocks =
+  List.filter_map
+    (fun (pos, rules) ->
+      match selectors_of_rules rules with
+      | [] -> None
+      | selectors -> Some (pos, String.concat ", " selectors))
+    blocks
+
+(* Queue of still-unmatched positions per signature, in ascending order, so
+   repeated signatures pair off one-for-one between the two sides. *)
+let signature_queues blocks =
+  let tbl = Hashtbl.create 64 in
+  List.iter
+    (fun (pos, sign) ->
+      let q = Option.value ~default:[] (Hashtbl.find_opt tbl sign) in
+      Hashtbl.replace tbl sign (pos :: q))
+    (List.rev blocks);
+  tbl
+
+let take_signature tbl sign =
+  match Hashtbl.find_opt tbl sign with
+  | Some (pos :: rest) ->
+      Hashtbl.replace tbl sign rest;
+      Some pos
+  | Some [] | None -> None
+
+type block_pairing = {
+  removed : (int * string) list; (* expected-only blocks *)
+  added : (int * string) list; (* actual-only blocks *)
+  shifts : (int * int) list; (* (delta, run length), expected order *)
+  unchanged : int; (* paired blocks that kept their position *)
+}
+
+(* Group consecutive equal deltas so one insertion upstream reads as a single
+   run rather than one line per renumbered block. *)
+let shift_runs deltas =
+  let flush acc = function Some (d, n) -> (d, n) :: acc | None -> acc in
+  let acc, current =
+    List.fold_left
+      (fun (acc, current) d ->
+        match current with
+        | Some (d', n) when d' = d -> (acc, Some (d, n + 1))
+        | _ -> (flush acc current, Some (d, 1)))
+      ([], None) deltas
+  in
+  List.rev (flush acc current)
+
+let pair_blocks ~expected_blocks ~actual_blocks =
+  let expected = block_signatures expected_blocks in
+  let actual = block_signatures actual_blocks in
+  let queues = signature_queues actual in
+  let matched = Hashtbl.create 64 in
+  let removed, deltas =
+    List.fold_left
+      (fun (removed, deltas) (pos, sign) ->
+        match take_signature queues sign with
+        | None -> ((pos, sign) :: removed, deltas)
+        | Some actual_pos ->
+            Hashtbl.replace matched actual_pos ();
+            (removed, (actual_pos - pos) :: deltas))
+      ([], []) expected
+  in
+  let deltas = List.rev deltas in
+  {
+    removed = List.rev removed;
+    added = List.filter (fun (pos, _) -> not (Hashtbl.mem matched pos)) actual;
+    shifts = shift_runs (List.filter (fun d -> d <> 0) deltas);
+    unchanged = List.length (List.filter (fun d -> d = 0) deltas);
+  }
+
+let pp_block_pairing ~style ~child_prefix buf pairing =
+  let indent = child_indent ~style ~parent_prefix:child_prefix in
+  let pp_block sign style_fn (pos, selectors) =
+    add_strings buf
+      [
+        indent;
+        style_fn
+          (sign ^ " Block at position " ^ string_of_int pos ^ ": " ^ selectors);
+        "\n";
+      ]
+  in
+  List.iter (pp_block "-" (ansi_red ~color:style.color)) pairing.removed;
+  List.iter (pp_block "+" (ansi_green ~color:style.color)) pairing.added;
+  List.iter
+    (fun (delta, n) ->
+      let sign = if delta > 0 then "+" else "-" in
+      add_strings buf
+        [
+          indent;
+          string_of_int n;
+          (if n = 1 then " block shifted by " else " blocks shifted by ");
+          sign;
+          string_of_int (abs delta);
+          "\n";
+        ])
+    pairing.shifts;
+  if pairing.unchanged > 0 then
+    add_strings buf
+      [
+        indent;
+        string_of_int pairing.unchanged;
+        (if pairing.unchanged = 1 then " block unchanged\n"
+         else " blocks unchanged\n");
+      ]
+
 let pp_block_structure_changed ~style ~is_last ~parent_prefix buf
     ~container_type ~condition ~expected_blocks ~actual_blocks =
   let cont_prefix = container_prefix container_type in
@@ -650,25 +757,9 @@ let pp_block_structure_changed ~style ~is_last ~parent_prefix buf
   in
   add_strings buf ([ prefix; cont_prefix; " "; condition; " (" ] @ summary);
   Buffer.add_string buf ")\n";
+  let pairing = pair_blocks ~expected_blocks ~actual_blocks in
   pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
-      let indent = child_indent ~style ~parent_prefix:child_prefix in
-      let pp_blocks sign style_fn blocks =
-        List.iter
-          (fun (pos, rules) ->
-            let selectors = selectors_of_rules rules in
-            if selectors <> [] then
-              add_strings buf
-                [
-                  indent;
-                  style_fn
-                    (sign ^ " Block at position " ^ string_of_int pos ^ ": "
-                    ^ String.concat ", " selectors);
-                  "\n";
-                ])
-          blocks
-      in
-      pp_blocks "-" (ansi_red ~color:style.color) expected_blocks;
-      pp_blocks "+" (ansi_green ~color:style.color) actual_blocks)
+      pp_block_pairing ~style ~child_prefix buf pairing)
 
 let pp_container_add_remove ~style ~is_last ~parent_prefix ~label buf
     container_type condition rules =

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -90,11 +90,23 @@ val diff : expected:Css.t -> actual:Css.t -> t
     ASTs. *)
 
 val pp :
-  ?expected:string -> ?actual:string -> ?color:bool -> Buffer.t -> t -> unit
-(** [pp ?expected ?actual ?color buf t] pretty-prints a tree diff with optional
-    labels. Default labels are "Expected" and "Actual". [color] (default
-    [false]) wraps diff markers in ANSI escapes; the printer writes into a
-    buffer, so the caller decides whether the destination supports colour. *)
+  ?expected:string ->
+  ?actual:string ->
+  ?color:bool ->
+  ?depth:int ->
+  Buffer.t ->
+  t ->
+  unit
+(** [pp ?expected ?actual ?color ?depth buf t] pretty-prints a tree diff with
+    optional labels. Default labels are "Expected" and "Actual". [color]
+    (default [false]) wraps diff markers in ANSI escapes; the printer writes
+    into a buffer, so the caller decides whether the destination supports
+    colour.
+
+    [depth] bounds how many tree levels are rendered, the top-level entries
+    being level 1 (default: unbounded). A node whose children are cut off is
+    followed by a ["... N more lines"] marker, so the report never reads as if
+    the elided subtree were empty. *)
 
 val pp_rule_diff_simple : Buffer.t -> rule_diff -> unit
 (** [pp_rule_diff_simple buf rule] pretty-prints a rule diff in a simple format

--- a/test/cli/diff_blocks.t
+++ b/test/cli/diff_blocks.t
@@ -1,0 +1,41 @@
+CLI: cascade diff - conditional block structure.
+
+Merging two same-condition blocks renumbers every block after them.
+The blocks that only moved are reported as a shift run, so the one
+real change stays legible instead of being repeated once per block on
+each side.
+
+  $ cat > blocks-split.css <<EOF
+  > @media print{.a{color:red}}
+  > .x{display:block}
+  > @media print{.b{color:blue}}
+  > .s1{order:1}
+  > @media print{.t1{color:#0f0}}
+  > .s2{order:2}
+  > @media print{.t2{color:#0f0}}
+  > .s3{order:3}
+  > @media print{.t3{color:#0f0}}
+  > EOF
+  $ cat > blocks-merged.css <<EOF
+  > @media print{.a{color:red}.b{color:blue}}
+  > .x{display:block}
+  > .s1{order:1}
+  > @media print{.t1{color:#0f0}}
+  > .s2{order:2}
+  > @media print{.t2{color:#0f0}}
+  > .s3{order:3}
+  > @media print{.t3{color:#0f0}}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=tree --depth=max blocks-split.css blocks-merged.css
+  CSS: 189 chars vs 204 chars (7.4% diff)
+  Changes: 1 changed container
+  
+  --- blocks-split.css
+  +++ blocks-merged.css
+  └─ @media print (5 blocks merged into 4)
+        - Block at position 0: .a
+        - Block at position 2: .b
+        + Block at position 0: .a, .b
+        3 blocks shifted by -1
+  
+  [1]

--- a/test/cli/diff_depth.t
+++ b/test/cli/diff_depth.t
@@ -1,0 +1,64 @@
+CLI: cascade diff - report shaping (depth, warnings, block runs).
+
+A small diff prints in full: --depth=auto only steps back once the
+report stops fitting.
+
+  $ cat > a.css <<EOF
+  > .x { color: red; margin: 0 }
+  > EOF
+  $ cat > b.css <<EOF
+  > .x { color: blue; margin: 1px }
+  > EOF
+  $ NO_COLOR=1 cascade diff a.css b.css
+  CSS: 32 chars vs 29 chars (10.3% diff)
+  Changes: 1 modified rule
+  
+  --- a.css
+  +++ b.css
+  └─ .x
+        * color: red -> blue
+        * margin: 0 -> 1px
+  
+  [1]
+
+
+
+Pinning a depth cuts the tree there and records what it hid, so an
+elided subtree never reads as an empty one.
+
+  $ NO_COLOR=1 cascade diff --depth=1 a.css b.css
+  CSS: 32 chars vs 29 chars (10.3% diff)
+  Changes: 1 modified rule
+  
+  --- a.css
+  +++ b.css
+  └─ .x
+        ...2 more lines
+  
+  [1]
+
+
+
+Parse warnings lead the report: a declaration the parser dropped
+qualifies every difference below it.
+
+  $ cat > warn.css <<EOF
+  > .x { color: red; width: <value> }
+  > EOF
+  $ NO_COLOR=1 cascade diff a.css warn.css
+  CSS: 34 chars vs 29 chars (17.2% diff)
+  Changes: 1 modified rule
+  
+  warn.css parse warning: <string>: read_declaration/width: bad value for width: expected one of at [24-25] (in component)
+  .x { color: red; width: <value> }
+                          ^
+  
+  --- a.css
+  +++ warn.css
+  └─ .x
+        - margin
+  
+  [1]
+
+
+


### PR DESCRIPTION
`cascade diff` printed every level of the difference tree and trailed the parse warnings, so on a whole-stylesheet comparison the shape of the change was only reachable by grepping the tree connectors out of a few thousand lines. The report is now bounded: the tree prints in full while it stays short and otherwise falls back to the deepest level that fits, `--depth` pins a level or asks for all of them, warnings lead because they qualify every difference under them, and each elision keeps a visible count so a cut subtree never reads as an empty one.

Two smaller fixes land first: f794eb07 pluralises the container count in the change summary, and 17aadf0e reports conditional blocks that only moved as a shift run rather than listing every renumbered block twice.