### PR TITLE
declaration: read perspective: none and text-underline-offset: auto

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### Parsing
+
+- Read `perspective: none` and `text-underline-offset: auto`, and allow a
+  negative `text-underline-offset`. Both keywords are the properties' own
+  grammar (and `none` is `perspective`'s initial value), but the readers took
+  a non-negative length only, so the declaration was dropped with a
+  warning (#212)
+
 ### Nesting
 
 - Flattening a nested rule distributes the parent over every branch of a

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -643,6 +643,36 @@ let read_normal_or_length name t =
     ~default:(Values.read_length ~with_keywords:false)
     t
 
+(* CSS Transforms 2 sec. 3: [perspective] is [none | <length [0,inf]>]; the
+   keyword is its initial value, so it has to read. *)
+let read_perspective_value t =
+  Cursor.enum "perspective"
+    [
+      ("none", (None : length));
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~default:(read_non_negative_length ~with_keywords:false)
+    t
+
+(* CSS Text Decoration 4 sec. 5: [text-underline-offset] is [auto |
+   <length-percentage>], and unlike the lengths above it may be negative. *)
+let read_underline_offset t =
+  Cursor.enum "text-underline-offset"
+    [
+      ("auto", (Auto : length));
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~default:(Values.read_length ~with_keywords:false)
+    t
+
 let read_letter_spacing t = read_normal_or_length "letter-spacing" t
 let read_word_spacing t = read_normal_or_length "word-spacing" t
 
@@ -914,7 +944,7 @@ let read_sizing_value : type a. a property -> Cursor.t -> declaration option =
   | Max_block_size ->
       Some (v Max_block_size (read_length_percentage ~allow_negative:false t))
   | Font_size -> Some (v Font_size (Properties.read_font_size t))
-  | Perspective -> Some (v Perspective (read_nn_length_or_global t))
+  | Perspective -> Some (v Perspective (read_perspective_value t))
   | Offset_distance -> Some (v Offset_distance (read_nn_lp_or_global t))
   | Shape_margin -> Some (v Shape_margin (read_nn_lp_or_global t))
   | Line_height_step -> Some (v Line_height_step (read_nn_length_or_global t))
@@ -1034,7 +1064,7 @@ let read_type_value : type a. a property -> Cursor.t -> declaration option =
   | Text_decoration_style ->
       Some (v Text_decoration_style (read_text_decoration_style t))
   | Text_underline_offset ->
-      Some (v Text_underline_offset (read_nn_length_or_global t))
+      Some (v Text_underline_offset (read_underline_offset t))
   | Text_emphasis -> Some (v Text_emphasis (read_text_emphasis t))
   | Text_emphasis_style ->
       Some (v Text_emphasis_style (read_text_emphasis_style t))

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -449,18 +449,31 @@ let matrix =
         "stroke-width";
         "outline-width";
         "outline-offset";
-        "text-underline-offset";
         "letter-spacing";
         "text-indent";
         "word-spacing";
         "line-height-step";
         "overflow-clip-margin";
         "offset-distance";
-        "perspective";
         "shape-margin";
       ]
       [ "0"; "1px"; "calc(1rem + 2px)" ]
       [ "auto"; "red"; "1px 2px" ]
+  (* CSS Transforms 2 sec. 3: [perspective] takes [none], its initial value. CSS
+     Text Decoration 4 sec. 5: [text-underline-offset] takes [auto] and may be
+     negative. *)
+  @ [
+      {
+        property = "perspective";
+        positives = [ "0"; "1px"; "none"; "calc(1rem + 2px)" ];
+        negatives = [ "auto"; "red"; "1px 2px"; "-1px" ];
+      };
+      {
+        property = "text-underline-offset";
+        positives = [ "0"; "1px"; "auto"; "-2px"; "10%" ];
+        negatives = [ "red"; "1px 2px" ];
+      };
+    ]
   @ rows_for
       [ "margin-left"; "margin-right"; "margin-top"; "margin-bottom" ]
       [ "0"; "1px"; "10%"; "auto"; "anchor-size(width)" ]


### PR DESCRIPTION
Both keywords belong to those properties' grammar — `none` is in fact `perspective`'s initial value — but the readers accepted a non-negative length only, so the declarations were dropped with a parse warning. `text-underline-offset` also accepts a negative length, which the non-negative reader rejected.

Found by the new parse-warning reporting in `cascade diff`: both sides of a Tailwind parity comparison were losing these declarations.