### PR TITLE
Speed up the canonical diff on large stylesheets

### DIFF
--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -223,43 +223,41 @@ let css_for_semantic_comparison ?property css =
   | None -> css
   | Some property -> ":root{" ^ property ^ ":" ^ css ^ "}"
 
-let canonical_semantic_css ~strict ~lossless
-    ?(prune_unused_custom_props = false) css =
-  match Css.of_string ~strict css with
-  | Ok { stylesheet; _ } -> (
-      try
-        Some
-          (stylesheet
-          (* Selector-list factoring depends on how the input grouped its
-             selectors, so it is not confluent: the same sheet factored and
-             unfactored would canonicalise differently. The projection skips
-             it. *)
-          |> Css.optimize ~lossless ~factor:false ~prune_unused_custom_props
-          |> Css.canonicalize_rule_order
-          |> Css.to_string ~minify:true ~lossless)
-      with Invalid_argument _ -> None)
-  | Error _ -> None
+let canonical_of_stylesheet ~lossless ~prune_unused_custom_props stylesheet =
+  try
+    Some
+      (stylesheet
+      (* Selector-list factoring depends on how the input grouped its selectors,
+         so it is not confluent: the same sheet factored and unfactored would
+         canonicalise differently. The projection skips it. *)
+      |> Css.optimize ~lossless ~factor:false ~prune_unused_custom_props
+      |> Css.canonicalize_rule_order
+      |> Css.to_string ~minify:true ~lossless)
+  with Invalid_argument _ -> None
 
-let canonical_css ~strict ~lossless ?(prune_unused_custom_props = false) css =
-  canonical_semantic_css ~strict ~lossless ~prune_unused_custom_props css
+(* Parse both sides before canonicalising either. A caller that retries at a
+   different strictness needs only to know that one side failed to parse, and
+   canonicalising the other first is the whole pipeline's work thrown away. *)
+let canonical_both ~strict ~lossless ~prune_unused_custom_props expected actual
+    =
+  match (Css.of_string ~strict expected, Css.of_string ~strict actual) with
+  | Ok { stylesheet = expected; _ }, Ok { stylesheet = actual; _ } -> (
+      let canonical =
+        canonical_of_stylesheet ~lossless ~prune_unused_custom_props
+      in
+      match (canonical expected, canonical actual) with
+      | Some expected, Some actual -> Some (expected, actual)
+      | _ -> None)
+  | _ -> None
 
 let canonical_pair ~strict ~lossless expected actual =
-  match
-    ( canonical_css ~strict ~lossless expected,
-      canonical_css ~strict ~lossless actual )
-  with
-  | Some expected_norm, Some actual_norm ->
-      Some (String.equal expected_norm actual_norm)
-  | _ -> None
+  canonical_both ~strict ~lossless ~prune_unused_custom_props:false expected
+    actual
+  |> Option.map (fun (expected, actual) -> String.equal expected actual)
 
 let canonical_diff_inputs ~strict ~lossless ?(prune_unused_custom_props = false)
     expected actual =
-  match
-    ( canonical_css ~strict ~lossless ~prune_unused_custom_props expected,
-      canonical_css ~strict ~lossless ~prune_unused_custom_props actual )
-  with
-  | Some expected, Some actual -> Some (expected, actual)
-  | _ -> None
+  canonical_both ~strict ~lossless ~prune_unused_custom_props expected actual
 
 let canonical_diff_inputs_with_fallback ~lossless
     ?(prune_unused_custom_props = false) expected actual =

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -3,6 +3,24 @@
 open Stylesheet
 open Stdlib
 
+(* The declaration-keyed bucket index is probed once per overlap key per node
+   while a graph is built, and a generic [Hashtbl] compares whole declaration
+   subtrees on every probe. The cached [Declaration.hash] buckets in constant
+   time and the structural check runs only when two hashes collide. *)
+module Decl_tbl = Hashtbl.Make (struct
+  type t = Declaration.declaration
+
+  let equal = Shorthand.same_minified_declaration
+  let hash = Declaration.hash
+end)
+
+module Key_tbl = Hashtbl.Make (struct
+  type t = Shorthand.overlap_key
+
+  let equal = Shorthand.overlap_key_equal
+  let hash = Shorthand.overlap_key_hash
+end)
+
 module Node_id = struct
   type t = int
 
@@ -62,10 +80,7 @@ type t = {
           order they were created in (source order for [of_rules], inherited
           order for rewrites). A valid linear extension is any topological order
           of the live sub-graph. *)
-  key_index :
-    ( Shorthand.overlap_key,
-      (Declaration.declaration, node_id list) Hashtbl.t )
-    Hashtbl.t;
+  key_index : node_id list Decl_tbl.t Key_tbl.t;
       (** overlap key -> (declaration writing it -> node ids), so a rewrite
           finds an external node's potential conflicts without scanning every
           node, and {e without even iterating} the nodes that write the same
@@ -284,12 +299,16 @@ let index_add tbl key node =
   Hashtbl.replace tbl key
     (node :: Option.value ~default:[] (Hashtbl.find_opt tbl key))
 
+let decl_index_add tbl key node =
+  Decl_tbl.replace tbl key
+    (node :: Option.value ~default:[] (Decl_tbl.find_opt tbl key))
+
 let key_inner t key =
-  match Hashtbl.find_opt t.key_index key with
+  match Key_tbl.find_opt t.key_index key with
   | Some inner -> inner
   | None ->
-      let inner = Hashtbl.create 4 in
-      Hashtbl.replace t.key_index key inner;
+      let inner = Decl_tbl.create 4 in
+      Key_tbl.replace t.key_index key inner;
       inner
 
 (* Add [node]'s overlap keys (partitioned by the declaration that writes each)
@@ -299,7 +318,7 @@ let index_node t (node : node_id) =
   List.iter
     (fun (ov : decl_overlap) ->
       List.iter
-        (fun key -> index_add (key_inner t key) ov.decl node)
+        (fun key -> decl_index_add (key_inner t key) ov.decl node)
         ov.footprint)
     t.decl_overlaps.(i);
   List.iter (fun branch -> index_add t.branch_index branch node) t.branches.(i)
@@ -332,7 +351,7 @@ let of_rules ?parent ?(closed_world = false) (rules : rule list) : t =
       decl_overlaps;
       overlap_keys;
       succ = [||];
-      key_index = Hashtbl.create (max 16 (n * 2));
+      key_index = Key_tbl.create (max 16 (n * 2));
       branch_index = Hashtbl.create (max 16 (n * 2));
     }
   in
@@ -753,9 +772,9 @@ let external_candidates graph ~total ~consumed ~seen p =
       (fun (ov : decl_overlap) ->
         List.iter
           (fun key ->
-            match Hashtbl.find_opt graph.key_index key with
+            match Key_tbl.find_opt graph.key_index key with
             | Some inner ->
-                Hashtbl.iter
+                Decl_tbl.iter
                   (fun decl' ids ->
                     if not (Shorthand.same_minified_declaration ov.decl decl')
                     then push_ids ids)
@@ -765,8 +784,8 @@ let external_candidates graph ~total ~consumed ~seen p =
       graph.decl_overlaps.(p);
     (* The broad key ([all]) conflicts with everything, so collect every node
        under it regardless of declaration. *)
-    (match Hashtbl.find_opt graph.key_index Shorthand.broad_overlap_key with
-    | Some inner -> Hashtbl.iter (fun _ ids -> push_ids ids) inner
+    (match Key_tbl.find_opt graph.key_index Shorthand.broad_overlap_key with
+    | Some inner -> Decl_tbl.iter (fun _ ids -> push_ids ids) inner
     | None -> ());
     List.iter
       (fun b ->


### PR DESCRIPTION
Two output-preserving changes, measured on a 660KB Tailwind stylesheet compared against its Lightning-minified reference. Best of three runs, and the rendered diff is byte-identical before and after.

```
origin/main  35.9s
this branch  28.8s
```

The graph's per-overlap-key bucket index was a generic `Hashtbl` keyed by whole declarations, so building a graph compared declaration subtrees structurally on every probe; polymorphic compare was about a quarter of the optimizer's samples. It now keys on the cached `Declaration.hash`, with the structural check only on a collision. Separately, the canonical comparison retries at a lower strictness when one side fails to parse, and it was canonicalising the side that did parse before discovering that, throwing away a full pipeline run.