### PR TITLE
Speed up the optimizer: hashtable keys and graph growth

### DIFF
--- a/lib/factor.ml
+++ b/lib/factor.ml
@@ -6,9 +6,33 @@ let counters = Stats.counters
 let rules_pp_size = Size.rules
 let list_map_preserve = Common.List.map_preserve
 
-type cache = (string * rule list, rule list) Hashtbl.t
+(* The memo key carries a whole run of rules. The default structural hash reads
+   only the first handful of nodes in it, so runs sharing a prefix land in one
+   bucket and each probe then compares rule lists in full; folding the cached
+   per-declaration hashes separates the buckets in one cheap integer pass, and
+   the structural check is left to confirm the one entry that matches. *)
+let mix acc x = (acc * 31) + x
 
-let cache () = Hashtbl.create 16
+let rule_hash (r : rule) =
+  List.fold_left
+    (fun acc d -> mix acc (Declaration.hash d))
+    (Hashtbl.hash r.Stylesheet_intf.selector)
+    r.Stylesheet_intf.declarations
+
+module Cache_tbl = Hashtbl.Make (struct
+  type t = string * rule list
+
+  let equal = ( = )
+
+  let hash (knobs, rules) =
+    List.fold_left
+      (fun acc r -> mix acc (rule_hash r))
+      (Hashtbl.hash knobs) rules
+end)
+
+type cache = rule list Cache_tbl.t
+
+let cache () = Cache_tbl.create 16
 
 (* Cache key over the value-typed knobs that change factoring, built explicitly
    so a {!Ctx.pp} debug-printer change cannot break cache correctness;
@@ -108,7 +132,7 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
   let key = Option.map (fun _ -> cache_key ~ctx rules) cache in
   match
     match (cache, key) with
-    | Some cache, Some key -> Hashtbl.find_opt cache key
+    | Some cache, Some key -> Cache_tbl.find_opt cache key
     | _ -> None
   with
   | Some rules -> rules
@@ -143,7 +167,7 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
         end
       in
       (match (cache, key) with
-      | Some cache, Some key -> Hashtbl.replace cache key result
+      | Some cache, Some key -> Cache_tbl.replace cache key result
       | _ -> ());
       result
 

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -63,6 +63,10 @@ type t = {
       (** the enclosing nesting context; every node's overlap is computed on its
           selector expanded against this, and rewrites reuse it so produced
           nodes are indexed the same way as existing ones. *)
+  count : int;
+      (** live extent of the node arrays. They are allocated with slack and
+          appended to in place, so their length is a capacity, not a node count.
+      *)
   rules : rule array;  (** all nodes ever created, dead ones included *)
   summaries : Summary.t array;
       (** declaration-side facts and byte sizes, precomputed once per node *)
@@ -255,7 +259,7 @@ let collect_string_bucket bucket key stamp seen acc =
   |> List.fold_left (add_candidate stamp seen) acc
 
 let source_order_edges t =
-  let n = Array.length t.rules in
+  let n = t.count in
   let succ = Array.make n [] in
   let by_decl_key = Overlap_key_table.create 256 in
   let by_branch = String_table.create 256 in
@@ -341,6 +345,7 @@ let of_rules ?parent ?(closed_world = false) (rules : rule list) : t =
       generation = 0;
       closed_world;
       parent;
+      count = n;
       rules;
       summaries;
       origin = Array.init n Fun.id;
@@ -360,7 +365,7 @@ let of_rules ?parent ?(closed_world = false) (rules : rule list) : t =
   done;
   { t with succ = source_order_edges t }
 
-let node_count t = Array.length t.rules
+let node_count t = t.count
 let node_rule t i = t.rules.(i)
 let node_size t i = Summary.size t.summaries.(i)
 let node_origin t i = t.origin.(i)
@@ -521,6 +526,29 @@ let produced_origins t consume produced_branches =
       |> fun origin -> if origin = max_int then fallback else origin)
     produced_branches
 
+(* [rewrite] has a single caller, which threads one graph and discards the
+   parent as soon as a rewrite is accepted, so a produced graph can extend these
+   append-only arrays in place and share them: the parent's [count] never covers
+   the new slots, and a rejected rewrite simply leaves them to be overwritten by
+   the next attempt. Growing geometrically turns a full copy of every array per
+   rewrite into an amortised append. [live] and [succ] stay copies, since a
+   rewrite mutates both and the parent must not see that. *)
+let append_slack arr ~count (items : 'a array) =
+  let added = Array.length items in
+  let needed = count + added in
+  let arr =
+    if Array.length arr >= needed then arr
+    else begin
+      let grown =
+        Array.make (max needed (2 * max 1 (Array.length arr))) items.(0)
+      in
+      Array.blit arr 0 grown 0 count;
+      grown
+    end
+  in
+  Array.blit items 0 arr count added;
+  arr
+
 let rewrite_live t ~total ~new_n ~consume =
   let live = Array.make new_n false in
   Array.blit t.live 0 live 0 total;
@@ -570,18 +598,25 @@ let rewrite_base t ~consume ~produce :
             generation = t.generation + 1;
             closed_world = t.closed_world;
             parent = t.parent;
-            rules = Array.append t.rules produced;
-            summaries = Array.append t.summaries p_summaries;
+            count = new_n;
+            rules = append_slack t.rules ~count:total produced;
+            summaries = append_slack t.summaries ~count:total p_summaries;
             origin =
-              Array.append t.origin (produced_origins t consume p_branches);
+              append_slack t.origin ~count:total
+                (produced_origins t consume p_branches);
             live = rewrite_live t ~total ~new_n ~consume;
-            selectors = Array.append t.selectors p_selectors;
+            selectors = append_slack t.selectors ~count:total p_selectors;
             selector_summaries =
-              Array.append t.selector_summaries p_selector_summaries;
-            branches = Array.append t.branches p_branches;
-            decl_overlaps = Array.append t.decl_overlaps p_decl_overlaps;
-            overlap_keys = Array.append t.overlap_keys p_overlap_keys;
-            succ = Array.append t.succ (Array.make (Array.length produced) []);
+              append_slack t.selector_summaries ~count:total
+                p_selector_summaries;
+            branches = append_slack t.branches ~count:total p_branches;
+            decl_overlaps =
+              append_slack t.decl_overlaps ~count:total p_decl_overlaps;
+            overlap_keys =
+              append_slack t.overlap_keys ~count:total p_overlap_keys;
+            succ =
+              Array.append (Array.sub t.succ 0 total)
+                (Array.make (Array.length produced) []);
             (* shared with [t]: holds the existing nodes; produced nodes are
                added by {!rewrite} only once the rewrite is accepted, so
                [add_external_edges] below sees the pre-rewrite index. *)

--- a/lib/rule_rewrite.ml
+++ b/lib/rule_rewrite.ml
@@ -1,5 +1,15 @@
 (** Local DAG rewrite candidates and byte scoring. *)
 
+(* The size memo is probed a few hundred thousand times on a large stylesheet,
+   and a generic [Hashtbl] keyed by a rule compares rule subtrees structurally
+   on every probe. *)
+module Rule_tbl = Hashtbl.Make (struct
+  type t = Stylesheet.rule
+
+  let equal = ( = )
+  let hash = Stylesheet.rule_hash
+end)
+
 type kind =
   | Identical_body
   | Same_selector
@@ -18,11 +28,11 @@ type candidate = {
 type size_cache = {
   graph : Rule_graph.t;
   node_sizes : (Rule_graph.node_id, int) Hashtbl.t;
-  rule_sizes : (Stylesheet.rule, int) Hashtbl.t;
+  rule_sizes : int Rule_tbl.t;
 }
 
 let size_cache graph =
-  { graph; node_sizes = Hashtbl.create 256; rule_sizes = Hashtbl.create 256 }
+  { graph; node_sizes = Hashtbl.create 256; rule_sizes = Rule_tbl.create 256 }
 
 let node_size cache id =
   match Hashtbl.find_opt cache.node_sizes id with
@@ -33,11 +43,11 @@ let node_size cache id =
       size
 
 let produced_rule_size cache rule =
-  match Hashtbl.find_opt cache.rule_sizes rule with
+  match Rule_tbl.find_opt cache.rule_sizes rule with
   | Option.Some size -> size
   | Option.None ->
       let size = Size.rule rule in
-      Hashtbl.replace cache.rule_sizes rule size;
+      Rule_tbl.replace cache.rule_sizes rule size;
       size
 
 let consumed_size cache ids =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3912,3 +3912,12 @@ let pp_import_rule : import_rule Pp.t =
 let read_import_rule (r : Cursor.t) : import_rule =
   Cursor.ws r;
   read_import_prelude ~keep_url_repr:false r
+
+(* A cheap discriminating hash for a rule, folding the hash each declaration
+   already caches. The stdlib structural hash reads only the first few nodes of
+   a rule, so rules sharing a selector collide and any table keyed by one then
+   compares whole rule subtrees on every probe. *)
+let rule_hash (r : rule) =
+  List.fold_left
+    (fun acc d -> (acc * 31) + Declaration.hash d)
+    (Hashtbl.hash r.selector) r.declarations

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -320,3 +320,8 @@ val pp_import_rule : import_rule Pp.t
 
 val read_import_rule : Cursor.t -> import_rule
 (** [read_import_rule r] parses an import rule. *)
+
+val rule_hash : rule -> int
+(** [rule_hash r] is a cheap hash that discriminates rules by their cached
+    declaration hashes. Equal rules hash equally; unequal rules may collide, so
+    callers still confirm with structural equality. *)


### PR DESCRIPTION
Three output-preserving changes to `fmt --minify`, measured on a 660KB stylesheet, best of two runs, byte-identical output on both test inputs.

```
before  19.8s
after   15.0s
```

Polymorphic compare inside `Hashtbl` was the largest single cost, but it was not one table: it was spread across three keyed by structured values, each worth about 4%. The factoring memo is keyed by a whole run of rules and the size memo by a whole rule, and in both cases the default structural hash reads only the first few nodes, so entries sharing a prefix shared a bucket and every probe compared subtrees in full. Both now fold the hash each declaration already caches. `Stylesheet.rule_hash` is the shared helper.

With those out of the way `Array.append` became the dominant cost at 36% of samples, two thirds of it in major GC: every graph rewrite rebuilt nine arrays, so a run of rewrites copied the whole graph once per accepted candidate. Those arrays are append-only, and `rewrite` has a single caller that discards the parent once a rewrite is accepted, so a produced graph now extends them in place behind its own `count`. `live` and `succ` stay copies because a rewrite mutates both.

Stacked on #218.