### PR TITLE
rule_candidate: stop materialising every live rule per candidate

### DIFF
--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -885,11 +885,17 @@ let group_crosses_external_conflict g ~ids (grouped : rule) =
   match origin_bounds g ids with
   | Option.None -> false
   | Option.Some (min_origin, max_origin) ->
-      live_rules g
-      |> List.exists (fun (external_id, (external_rule : rule)) ->
+      (* Walk the ids, not a freshly built (id, rule) list: this runs once per
+         candidate, so materialising every live rule up front cost more than the
+         scan itself, which usually stops on the first crossing node. The origin
+         range is the cheapest filter, so it goes first. *)
+      Rule_graph.live_nodes g
+      |> List.exists (fun external_id ->
           (not (id_mem external_id ids))
           && crosses_bounds g ~min_origin ~max_origin external_id
-          && selectors_tie_and_overlap grouped.selector external_rule.selector
+          &&
+          let external_rule : rule = Rule_graph.node_rule g external_id in
+          selectors_tie_and_overlap grouped.selector external_rule.selector
           && declarations_cross_order grouped.declarations
                external_rule.declarations)
 


### PR DESCRIPTION
`group_crosses_external_conflict` built an `(id, rule)` list of every live node before scanning it, once per candidate, even though the scan usually stops on the first crossing node. Walking the node ids and fetching the rule only after the origin-range filter admits it keeps the short circuit and removes the allocation.

```
fmt --minify tw_all.css      4.5s -> 3.0s
fmt --minify ref_local.css  15.0s -> 15.3s   (unchanged, within noise)
```

Output byte-identical on both. Stacked on #219.