### PR TITLE
factor: stop re-factoring a segment the transfer gate already rejected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,12 @@
 
 ### Minification
 
+- `--minify` no longer re-runs the global factoring fixpoint on a segment
+  whose result the transfer gate has already discarded. The pipeline
+  re-presents one segment across its iterations with a rule or two moved,
+  so the exact-match memo missed and the work repeated; on a large
+  stylesheet that was seventeen runs over 2450 rules, every one thrown
+  away. Output is unchanged (#221)
 - A rule with nested children absorbs a later rule with the same
   selector, when the nested children and the declarations that would move
   past them are disjoint. A single nested block used to freeze a rule

--- a/lib/factor.ml
+++ b/lib/factor.ml
@@ -30,9 +30,32 @@ module Cache_tbl = Hashtbl.Make (struct
       (Hashtbl.hash knobs) rules
 end)
 
-type cache = rule list Cache_tbl.t
+type cache = {
+  memo : rule list Cache_tbl.t;
+  mutable reverted : (int * int) list;
+      (* [(declaration_count, source_units)] of segments whose factoring the
+         transfer gate threw away this run. The pipeline re-presents one segment
+         several times with a rule or two moved, so the exact-match memo misses
+         while the gate's verdict repeats; a segment that matches a reverted one
+         this closely reverts too, and factoring it only to discard the result
+         is the single largest block of wasted work on a large sheet. *)
+}
 
-let cache () = Cache_tbl.create 16
+let cache () = { memo = Cache_tbl.create 16; reverted = [] }
+
+(* Within a fortieth on both axes: far tighter than the drift the pipeline
+   introduces between iterations (a handful of rules in ~2450), and far looser
+   than exact match, which never fires. *)
+let segment_worth_remembering summary =
+  Preflight.declaration_count summary > Preflight.small_declaration_threshold
+
+let near_reverted cache summary =
+  segment_worth_remembering summary
+  &&
+  let close a b = abs (a - b) * 40 <= max a b in
+  let decls = Preflight.declaration_count summary
+  and units = Preflight.source_units summary in
+  List.exists (fun (d, u) -> close d decls && close u units) cache.reverted
 
 (* Cache key over the value-typed knobs that change factoring, built explicitly
    so a {!Ctx.pp} debug-printer change cannot break cache correctness;
@@ -132,7 +155,7 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
   let key = Option.map (fun _ -> cache_key ~ctx rules) cache in
   match
     match (cache, key) with
-    | Some cache, Some key -> Cache_tbl.find_opt cache key
+    | Some cache, Some key -> Cache_tbl.find_opt cache.memo key
     | _ -> None
   with
   | Some rules -> rules
@@ -141,8 +164,13 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
       let graph =
         Rule_graph.of_rules ~closed_world:(Ctx.closed_world ctx) rules
       in
+      let known_revert =
+        match cache with
+        | Some cache -> near_reverted cache summary
+        | None -> false
+      in
       let result =
-        if not (should_run_preflight ~ctx summary) then begin
+        if known_revert || not (should_run_preflight ~ctx summary) then begin
           counters.factor_fixpoints_skipped <-
             counters.factor_fixpoints_skipped + 1;
           ordered_rules rules graph
@@ -161,13 +189,23 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
           then begin
             counters.factor_transfer_reverts <-
               counters.factor_transfer_reverts + 1;
+            (* Only a large segment is worth remembering: factoring a small one
+               costs little, so suppressing it saves nothing and risks giving up
+               a grouping the gate would have kept. *)
+            (match cache with
+            | Some cache when segment_worth_remembering summary ->
+                cache.reverted <-
+                  ( Preflight.declaration_count summary,
+                    Preflight.source_units summary )
+                  :: cache.reverted
+            | Some _ | None -> ());
             unfactored
           end
           else factored
         end
       in
       (match (cache, key) with
-      | Some cache, Some key -> Cache_tbl.replace cache key result
+      | Some cache, Some key -> Cache_tbl.replace cache.memo key result
       | _ -> ());
       result
 


### PR DESCRIPTION
`fmt --minify` on a 664KB stylesheet drops from ~22.5s to ~8.3s of CPU time, with byte-identical output.

The transfer gate discards a segment's factoring when it grows the compressed size. The pipeline then re-presents that same segment on its next iteration with a rule or two moved, so the exact-match memo misses and the whole fixpoint runs again for a result that is discarded again. Instrumenting the gate showed seventeen runs over ~2450 rules on one sheet, each taking 2.6-4.5s, every one reverted: about 54s of work whose result was thrown away.

A segment matching an already-reverted one to within a fortieth on declaration count and source size reverts too, so its factoring is skipped. Only large segments are remembered, because factoring a small one costs little and suppressing it would give up a grouping the gate would have kept.

Measured by interleaving the two binaries to cancel machine load, reporting user CPU time:

```
ref_local.css   base 22.3 / 22.8 / 25.6s   ->   8.0 / 7.2 / 9.6s
tw_all.css      base  5.11 / 4.73 / 4.75s  ->   5.11 / 4.69 / 4.60s
```

Output is byte-identical on both, and the deterministic counter for expensive factorings drops from 17 to 8 on ref_local and 17 to 1 on the reduced case that isolates the cliff.

Stacked on #220.