### PR TITLE
shorthand: drop the per-element closures in the overlap test

### DIFF
--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -528,10 +528,19 @@ let property_footprint : type a. a Properties.property -> overlap_key list =
   | Unknown_property name -> [ key name ]
   | property -> [ property_key property ]
 
-let footprint_mem footprint = List.exists (overlap_key_equal footprint)
+(* Spelled as explicit recursion rather than [List.exists (overlap_key_equal
+   footprint)]: the partial application and the closure over [b] each allocate
+   once per element, and this pair sits in the conflict test's inner loop, which
+   made them the two largest allocation sites in the optimizer. *)
+let rec footprint_mem footprint = function
+  | [] -> false
+  | k :: rest -> overlap_key_equal footprint k || footprint_mem footprint rest
 
-let overlap_keys_intersect a b =
-  List.exists (fun footprint -> footprint_mem footprint b) a
+let rec overlap_keys_intersect a b =
+  match a with
+  | [] -> false
+  | footprint :: rest ->
+      footprint_mem footprint b || overlap_keys_intersect rest b
 
 let declaration_overlap_keys decl =
   match unwrap_theme_guard decl with


### PR DESCRIPTION
`List.exists (overlap_key_equal footprint)` allocates a closure for the partial application on every call, and the lambda capturing `b` allocates another. Both sit in the conflict test's inner loop, which made them the two largest allocation sites in the optimizer: 33,024,999 and 9,299,999 allocations on one corpus fixture, 27.7% of all bytes allocated.

Found with `obs run` / `obs hotspots` on the slowest SatCSS fixture. Allocation on that file drops from 4.29 GB to 3.12 GB, matching the predicted ceiling.

Output is byte-identical on all 504 corpus fixtures.

One caveat, measured and stated plainly: on `bench/corpus_sweep.sh` this is about 5% *slower* in CPU time, reproducibly (1.051x, 1.069x, 1.049x). OCaml minor allocation is a pointer bump, and the closure form evidently compiles to a tighter loop than the explicit recursion, so the GC time saved is less than the loop time added. It is merged for the allocation and memory-pressure win rather than for speed.