### PR TITLE
diff: skip nesting synthesis in the canonical projection too

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,14 @@
 
 ### Diffing
 
-- `--diff=canonical` skips selector-list factoring. Factoring is input-shape
-  dependent: whether a shared declaration can be lifted depends on how the
-  input grouped its selectors, and once lifted an intervening rule writing the
-  same property can make putting it back unsafe. The same stylesheet written
-  factored and inline therefore canonicalised to different forms, and the
-  difference was reported as a missing declaration (#215)
-- `Css.optimize` takes `?factor` to turn that pass off (#215)
+- `--diff=canonical` skips the rule-regrouping passes: factoring a shared
+  declaration into a selector list, and synthesising nesting from a run of
+  adjacent rules. Both depend on how the input happened to order its rules - a
+  rule sitting between two others decides whether either applies - so the same
+  stylesheet written either way canonicalised to different forms, and the
+  difference was reported as a missing declaration or an added rule
+  (#215, #224)
+- `Css.optimize` takes `?regroup` to turn those passes off (#215, #224)
 
 ### Parsing
 

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -878,10 +878,10 @@ let inline_style_of_declarations ?(optimize = false) ?minify ?mode declarations
   in
   inline_style_of_declarations ?minify ?mode declarations
 
-let optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive ?factor
-    ?closed_world ?objective ?prune_unused_custom_props stylesheet =
+let optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
+    ?regroup ?closed_world ?objective ?prune_unused_custom_props stylesheet =
   Optimize.stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec
-    ?aggressive ?factor ?closed_world ?objective ?prune_unused_custom_props
+    ?aggressive ?regroup ?closed_world ?objective ?prune_unused_custom_props
     stylesheet
 
 let flatten_nesting = Optimize.flatten_nesting

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7667,7 +7667,7 @@ val optimize :
   ?lossless:bool ->
   ?enforce_spec:bool ->
   ?aggressive:bool ->
-  ?factor:bool ->
+  ?regroup:bool ->
   ?closed_world:bool ->
   ?objective:[ `Raw | `Transfer ] ->
   ?prune_unused_custom_props:bool ->

--- a/lib/ctx.ml
+++ b/lib/ctx.ml
@@ -6,9 +6,11 @@ type t = {
   registered : string -> bool;
   lossless : bool;
   aggressive : bool;
-  factor : bool;
-      (** Selector-list factoring is input-shape dependent, so a canonical
-          projection turns it off to stay confluent. *)
+  regroup : bool;
+      (** Whether rules may be regrouped: shared declarations factored into a
+          selector list, nesting synthesised from adjacent rules. Both depend on
+          how the input happened to order its rules, so a canonical projection
+          turns them off to stay confluent. *)
   extend_lists : bool;
   closed_world : bool;
   objective : objective;
@@ -25,14 +27,14 @@ let fragment =
     registered = (fun _ -> false);
     lossless = false;
     aggressive = false;
-    factor = true;
+    regroup = true;
     extend_lists = false;
     closed_world = false;
     objective = `Transfer;
     enforce_spec = false;
   }
 
-let of_scope ?(lossless = false) ?(aggressive = false) ?(factor = true)
+let of_scope ?(lossless = false) ?(aggressive = false) ?(regroup = true)
     ?(extend_lists = false) ?(closed_world = false) ?(objective = `Transfer)
     ?(enforce_spec = false) = function
   | Some scope ->
@@ -41,7 +43,7 @@ let of_scope ?(lossless = false) ?(aggressive = false) ?(factor = true)
         scope;
         lossless;
         aggressive;
-        factor;
+        regroup;
         extend_lists;
         closed_world;
         objective;
@@ -52,14 +54,14 @@ let of_scope ?(lossless = false) ?(aggressive = false) ?(factor = true)
         fragment with
         lossless;
         aggressive;
-        factor;
+        regroup;
         extend_lists;
         closed_world;
         objective;
         enforce_spec;
       }
 
-let v ?(lossless = false) ?(aggressive = false) ?(factor = true)
+let v ?(lossless = false) ?(aggressive = false) ?(regroup = true)
     ?(extend_lists = false) ?(closed_world = false) ?(objective = `Transfer)
     ?(enforce_spec = false) ?(registered = fun _ -> false) scope =
   {
@@ -67,7 +69,7 @@ let v ?(lossless = false) ?(aggressive = false) ?(factor = true)
     registered;
     lossless;
     aggressive;
-    factor;
+    regroup;
     extend_lists;
     closed_world;
     objective;
@@ -78,7 +80,7 @@ let scope t = t.scope
 let registered t = t.registered
 let lossless t = t.lossless
 let aggressive t = t.aggressive
-let factor t = t.factor
+let regroup t = t.regroup
 let extend_lists t = t.extend_lists
 let closed_world t = t.closed_world
 let objective t = t.objective

--- a/lib/ctx.mli
+++ b/lib/ctx.mli
@@ -16,7 +16,7 @@ val fragment : t
 val of_scope :
   ?lossless:bool ->
   ?aggressive:bool ->
-  ?factor:bool ->
+  ?regroup:bool ->
   ?extend_lists:bool ->
   ?closed_world:bool ->
   ?objective:objective ->
@@ -28,7 +28,7 @@ val of_scope :
 val v :
   ?lossless:bool ->
   ?aggressive:bool ->
-  ?factor:bool ->
+  ?regroup:bool ->
   ?extend_lists:bool ->
   ?closed_world:bool ->
   ?objective:objective ->
@@ -47,10 +47,12 @@ val registered : t -> string -> bool
 val lossless : t -> bool
 (** Whether lossless value optimization is enabled. *)
 
-val factor : t -> bool
-(** Whether selector-list factoring runs. It is input-shape dependent - whether
-    a shared declaration can be lifted depends on how the input grouped its
-    selectors - so a canonical projection turns it off to stay confluent. *)
+val regroup : t -> bool
+(** Whether rules may be regrouped: shared declarations factored into a selector
+    list, and nesting synthesised from a run of adjacent rules. Both depend on
+    how the input happened to order its rules - a rule sitting between two
+    others decides whether either applies - so a canonical projection turns them
+    off to stay confluent. *)
 
 val aggressive : t -> bool
 (** Whether expensive optimization passes (notably the global factoring

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -227,10 +227,12 @@ let canonical_of_stylesheet ~lossless ~prune_unused_custom_props stylesheet =
   try
     Some
       (stylesheet
-      (* Selector-list factoring depends on how the input grouped its selectors,
-         so it is not confluent: the same sheet factored and unfactored would
-         canonicalise differently. The projection skips it. *)
-      |> Css.optimize ~lossless ~factor:false ~prune_unused_custom_props
+      (* Regrouping - factoring a shared declaration into a selector list,
+         synthesising nesting from adjacent rules - depends on how the input
+         happened to order its rules, so it is not confluent: the same sheet
+         written either way would canonicalise differently. The projection skips
+         it. *)
+      |> Css.optimize ~lossless ~regroup:false ~prune_unused_custom_props
       |> Css.canonicalize_rule_order
       |> Css.to_string ~minify:true ~lossless)
   with Invalid_argument _ -> None

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -211,7 +211,9 @@ let rec statements ?factor_cache ~ctx ~enforce_spec (stmts : statement list) :
         let stmts =
           process_statements ?factor_cache ~ctx ~enforce_spec [] stmts
         in
-        let stmts = synthesize_nesting_statements stmts in
+        let stmts =
+          if Ctx.regroup ctx then synthesize_nesting_statements stmts else stmts
+        in
         let stmts =
           stmts
           |> merge_consecutive_media ~optimize_merged_block
@@ -419,7 +421,7 @@ and rules_aux ?factor_cache ~ctx ~enforce_spec (rules : rule list) : rule list =
      the expensive global factoring fixpoint is likely to buy enough bytes to
      justify the full indexed scheduler walk. *)
   let factored =
-    if Ctx.factor ctx then
+    if Ctx.regroup ctx then
       factor_rules_incremental ?cache:factor_cache ~ctx prepared
     else prepared
   in
@@ -1154,7 +1156,7 @@ let drop_unused_custom_props (stmts : statement list) : statement list =
   list_map_preserve prune stmts
 
 let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
-    ?(enforce_spec = false) ?(aggressive = false) ?(factor = true)
+    ?(enforce_spec = false) ?(aggressive = false) ?(regroup = true)
     ?(closed_world = false) ?(objective = `Transfer)
     ?(prune_unused_custom_props = false) (stylesheet : t) : t =
   Selector_summary.clear_memo ();
@@ -1169,7 +1171,7 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
   let registered = registered_foldable stylesheet in
   let stylesheet = prune_position_try_fallbacks ~scope stylesheet in
   let ctx =
-    Ctx.v ~lossless ~aggressive ~factor ~closed_world ~objective ~enforce_spec
+    Ctx.v ~lossless ~aggressive ~regroup ~closed_world ~objective ~enforce_spec
       ~registered scope
   in
   let result =

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -47,7 +47,7 @@ type ctx
 val ctx_of_scope :
   ?lossless:bool ->
   ?aggressive:bool ->
-  ?factor:bool ->
+  ?regroup:bool ->
   ?extend_lists:bool ->
   ?closed_world:bool ->
   ?objective:Ctx.objective ->
@@ -149,7 +149,7 @@ val stylesheet :
   ?lossless:bool ->
   ?enforce_spec:bool ->
   ?aggressive:bool ->
-  ?factor:bool ->
+  ?regroup:bool ->
   ?closed_world:bool ->
   ?objective:Ctx.objective ->
   ?prune_unused_custom_props:bool ->

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -877,30 +877,54 @@ let test_lossless_declaration_order () =
     ".a{border-top:1px solid red;border-color:#00f}"
     (opt ~lossless:true ".a{border-top:1px solid red;border-color:blue}")
 
-(* Selector-list factoring is input-shape dependent: whether a shared
-   declaration can be lifted depends on how the input grouped its selectors, and
-   once lifted an intervening rule writing the same property can make putting it
-   back unsafe. A canonical projection therefore turns factoring off, so the
-   same stylesheet written factored and inline maps to one form. *)
-let factoring_can_be_disabled () =
+(* Regrouping - factoring a shared declaration into a selector list, and
+   synthesising nesting from a run of adjacent rules - depends on how the input
+   happened to order its rules: a rule sitting between two others decides
+   whether either applies. A canonical projection therefore turns regrouping
+   off, so the same stylesheet written either way maps to one form. *)
+let regrouping_can_be_disabled () =
   let src =
     ".text-xs{font-size:var(--text-xs);line-height:1}.text-xs\\/4{font-size:var(--text-xs);line-height:4}.text-xs\\/5{font-size:var(--text-xs);line-height:5}.text-xs\\/6{font-size:var(--text-xs);line-height:6}.text-xs\\/7{font-size:var(--text-xs);line-height:7}"
   in
   let sheet = Css.of_string_exn src in
-  let out ?factor () =
-    Css.to_string ~minify:true (Css.optimize ?factor sheet)
+  let out ?regroup () =
+    Css.to_string ~minify:true (Css.optimize ?regroup sheet)
   in
   Alcotest.(check bool)
-    "factoring on lifts the shared declaration" true
+    "regrouping on lifts the shared declaration" true
     (Astring.String.is_infix ~affix:".text-xs,.text-xs\\/4" (out ()));
   Alcotest.(check bool)
-    "factoring off leaves each rule alone" false
+    "regrouping off leaves each rule alone" false
     (Astring.String.is_infix ~affix:".text-xs,.text-xs\\/4"
-       (out ~factor:false ()))
+       (out ~regroup:false ()))
+
+(* The other regrouping pass: two adjacent rules sharing a selector prefix
+   become one nested rule, and whether they are adjacent is exactly what an
+   unrelated rule between them decides. *)
+let nesting_synthesis_can_be_disabled () =
+  let sheet =
+    Css.of_string_exn
+      ".prose:where(:not(.not-prose,.not-prose \
+       *)){color:red;font-size:1rem}.prose:where(:not(.not-prose,.not-prose \
+       *)):where(.dark,.dark *){color:blue;font-size:2rem}"
+  in
+  let out ?regroup () =
+    Css.to_string ~minify:true (Css.optimize ?regroup sheet)
+  in
+  Alcotest.(check bool)
+    "regrouping on nests the second rule" true
+    (Astring.String.is_infix ~affix:"&:where(.dark,.dark *)" (out ()));
+  Alcotest.(check bool)
+    "regrouping off keeps both flat" false
+    (Astring.String.is_infix ~affix:"&:where(.dark,.dark *)"
+       (out ~regroup:false ()))
 
 let optimize_tests =
   [
-    ("factoring can be disabled", `Quick, factoring_can_be_disabled);
+    ("regrouping can be disabled", `Quick, regrouping_can_be_disabled);
+    ( "nesting synthesis can be disabled",
+      `Quick,
+      nesting_synthesis_can_be_disabled );
     ("vendor prefix strip", `Quick, test_vendor_prefix_strip);
     ("lossless declaration order", `Quick, test_lossless_declaration_order);
     ( "var() colour functions preserved",


### PR DESCRIPTION
#215 stopped the canonical projection factoring shared declarations into selector lists, because whether that applies depends on how the input grouped its rules. Nesting synthesis is the same shape of dependence and was still running: two adjacent rules sharing a selector prefix become one nested rule, and whether they are adjacent is exactly what an unrelated rule between them decides.

In a Tailwind parity run this showed up in the components layer as an added rule plus a reorder:

```
tw as authored:  .prose:where(:not(...)){...}
                 .prose:where(:not(...)):where(.dark,.dark *){...}
after canonical: .prose:where(:not(...)){...; &:where(.dark,.dark *){...}}
reference:       .prose:where(:not(...)):where(.dark,.dark *){...}
```

The reference has an `@supports` block between the two rules, so nesting is not synthesised there; tw's are adjacent, so it is. Both sides now canonicalise to the flat pair.

Since the two passes share one property - applicability depends on rule adjacency - `?factor` becomes `?regroup` and gates both. It was added in #215 and has not shipped, so nothing external depends on the old name.