### PR TITLE
diff: sort @property runs by name in the canonical projection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### Diffing
 
+- `--diff=canonical` sorts a run of `@property` rules by name, keeping the last
+  registration of each, at the top level and inside any block. CSS Properties
+  and Values API 1 sec. 2 makes registrations for different names
+  order-independent and gives the last registration of a name, so two
+  stylesheets registering the same set differed only in the order they happened
+  to emit them (#227)
 - `--diff=canonical` skips the rule-regrouping passes: factoring a shared
   declaration into a selector list, and synthesising nesting from a run of
   adjacent rules. Both depend on how the input happened to order its rules - a

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7658,8 +7658,10 @@ val canonicalize_rule_order : t -> t
     whose transitive content is plain rules moves as one unit, keyed by the
     union of its rules' conflict footprints; conflicting statements keep their
     relative order, and named [@layer] blocks pin the layer order where they
-    stand. This is a comparison-side normalisation; {!val-optimize} stays
-    source-stable. *)
+    stand. A run of [@property] rules sorts by name, keeping the last
+    registration of each, since CSS Properties and Values API 1 sec. 2 makes
+    registrations for different names order-independent. This is a
+    comparison-side normalisation; {!val-optimize} stays source-stable. *)
 
 val optimize :
   ?scope:Optimize.scope ->

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -100,9 +100,10 @@ let strip_tool_header css =
   (* Trim trailing whitespace for consistent comparison *)
   String.trim stripped
 
-(* Note: We do NOT normalize @property order because their order matters for
-   testing property_order values in our implementation. The order of @property
-   rules in @layer properties reflects the intended cascade behavior. *)
+(* The canonical projection sorts a run of [@property] rules by name (see
+   [Css.canonicalize_rule_order]): CSS Properties and Values API 1 sec. 2 makes
+   registrations for different names order-independent. A caller that wants to
+   assert its own emission order should inspect the AST, or use mode [`Tree]. *)
 
 (* Analyze differences between two parsed CSS ASTs, returning structural
    changes *)
@@ -333,7 +334,8 @@ let diff_after_empty_structural ~expected ~actual ~expected_norm ~actual_norm =
   | None -> fallback_to_string_diff ~expected ~actual
 
 let diff_two_parsed ~expected ~actual ~expected_ast ~actual_ast =
-  (* Do NOT normalize @property order - their order matters for tests *)
+  (* Order between [@property] registrations for different names carries no
+     meaning; the canonical projection sorts them. *)
   let expected_norm = expected_ast in
   let actual_norm = actual_ast in
   let structural_diff = tree_diff ~expected:expected_norm ~actual:actual_norm in

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -526,9 +526,63 @@ let rec normalize_custom_values (stmts : statement list) : statement list =
       | other -> other)
     stmts
 
+(* CSS Properties and Values API 1 sec. 2: registrations for different custom
+   property names are order-independent, and for the same name the last one
+   wins. So a run of [@property] rules canonicalises to that run sorted by name,
+   keeping the last registration of each - two sheets that register the same set
+   then differ only in the order they happened to emit them. A non-registration
+   statement splits a run, since reordering across it is not covered by that
+   argument. *)
+let sort_property_run (run : (string * statement) list) : statement list =
+  let last = Hashtbl.create (List.length run) in
+  List.iteri (fun i (name, _) -> Hashtbl.replace last name i) run;
+  run
+  |> List.filteri (fun i (name, _) -> Hashtbl.find last name = i)
+  |> List.stable_sort (fun (a, _) (b, _) -> String.compare a b)
+  |> List.map snd
+
+let rec sort_property_runs (stmts : statement list) : statement list =
+  let name_of stmt =
+    match stmt with Stylesheet_intf.Property p -> Some p.name | _ -> None
+  in
+  (* [@property] is valid inside a conditional group rule and inside [@layer],
+     so every block body is a run context of its own. *)
+  let descend stmt =
+    let here = sort_property_runs in
+    match stmt with
+    | Layer (n, b) -> Layer (n, here b)
+    | Media (m, b) -> Media (m, here b)
+    | Container (n, c, b) -> Container (n, c, here b)
+    | Supports (s, b) -> Supports (s, here b)
+    | Moz_document (c, b) -> Moz_document (c, here b)
+    | When (c, b) -> When (c, here b)
+    | Else (c, b) -> Else (c, here b)
+    | Starting_style b -> Starting_style (here b)
+    | Origin (o, b) -> Origin (o, here b)
+    | Scope (s, e, b) -> Scope (s, e, here b)
+    | other -> other
+  in
+  let rec go acc = function
+    | [] -> List.rev acc
+    | stmt :: rest -> (
+        match name_of stmt with
+        | None -> go (descend stmt :: acc) rest
+        | Some name ->
+            let rec take run = function
+              | s :: r as l -> (
+                  match name_of s with
+                  | Some n -> take ((n, s) :: run) r
+                  | None -> (List.rev run, l))
+              | [] -> (List.rev run, [])
+            in
+            let run, rest = take [ (name, stmt) ] rest in
+            go (List.rev_append (sort_property_run run) acc) rest)
+  in
+  go [] stmts
+
 let canonicalize (stmts : statement list) : statement list =
   let changed = ref false in
-  let normalized = normalize_custom_values stmts in
+  let normalized = sort_property_runs (normalize_custom_values stmts) in
   let result =
     canonicalize_block ~parent:(None : Selector.t option) changed normalized
   in

--- a/lib/rule_order.mli
+++ b/lib/rule_order.mli
@@ -28,5 +28,10 @@ val canonicalize : Stylesheet.statement list -> Stylesheet.statement list
 (** [canonicalize stmts] reorders each maximal run of consecutive reorderable
     style rules into the canonical order described above. At-rules, nested
     rules, and custom-property rules are barriers: they keep their position and
-    split runs. Returns the input list physically unchanged when no run
-    reorders. *)
+    split runs.
+
+    A run of consecutive [@property] rules is the one at-rule exception: it
+    sorts by name, keeping the last registration of each. CSS Properties and
+    Values API 1 sec. 2 makes registrations for different names
+    order-independent and gives a name its last registration, so the emission
+    order carries no meaning. Every block body is its own run context. *)

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -33,6 +33,51 @@ let equal_empty () =
     "empty strings equal" true
     (Cascade_diff.Css_compare.equal "" "")
 
+(* CSS Properties and Values API 1 sec. 2: registrations for different names are
+   order-independent, and for the same name the last wins. Two sheets that
+   register the same set differ only in the order they happened to emit them. *)
+let equal_canonical_ignores_property_order () =
+  let a =
+    "@property --z{syntax:\"*\";inherits:false}@property \
+     --a{syntax:\"*\";inherits:false}"
+  in
+  let b =
+    "@property --a{syntax:\"*\";inherits:false}@property \
+     --z{syntax:\"*\";inherits:false}"
+  in
+  Alcotest.(check bool)
+    "@property order is not a difference" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical a b);
+  (* the last registration of a name still wins, so a differing duplicate is a
+     real difference *)
+  Alcotest.(check bool)
+    "a differing duplicate still differs" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       "@property --a{syntax:\"*\";inherits:false}@property \
+        --a{syntax:\"*\";inherits:true}"
+       "@property --a{syntax:\"*\";inherits:false}");
+  (* @property is valid inside a conditional group rule and inside @layer, which
+     is where a generator emitting a block of registrations puts them *)
+  Alcotest.(check bool)
+    "@property order inside @layer is not a difference" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ("@layer properties{" ^ a ^ "}")
+       ("@layer properties{" ^ b ^ "}"));
+  Alcotest.(check bool)
+    "@property order inside @supports is not a difference" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ("@supports (color:red){" ^ a ^ "}")
+       ("@supports (color:red){" ^ b ^ "}"));
+  (* a run is split by any other statement, so this reordering crosses a barrier
+     and stays a difference *)
+  Alcotest.(check bool)
+    "reordering across an intervening rule still differs" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       "@property --z{syntax:\"*\";inherits:false}.x{top:0}@property \
+        --a{syntax:\"*\";inherits:false}"
+       "@property --a{syntax:\"*\";inherits:false}.x{top:0}@property \
+        --z{syntax:\"*\";inherits:false}")
+
 let equal_prune_unused_custom_props () =
   let with_bind = ":root{--spacing:.25rem}.top-0{top:0}" in
   let without = ".top-0{top:0}" in
@@ -1098,4 +1143,6 @@ let suite =
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "opt-in prune-unused-custom-props" `Quick
         equal_prune_unused_custom_props;
+      Alcotest.test_case "canonical ignores @property order" `Quick
+        equal_canonical_ignores_property_order;
     ] )


### PR DESCRIPTION
CSS Properties and Values API 1 sec. 2: registrations for different custom property names are order-independent, and for the same name the last one wins. So the order a stylesheet happens to emit its `@property` rules in carries no meaning, and two sheets registering the same set were reported as differing.

A run of `@property` rules now canonicalises to that run sorted by name, keeping the last registration of each. On a Tailwind parity run this removed 123 reported reorderings, the whole `@property` category.

The old comment said the order mattered "for testing property_order values in our implementation". Those assertions inspect the AST directly rather than going through the comparator, so they are unaffected; mode `Tree` still reports the order verbatim for anyone who wants it.