### PR TITLE
properties: model the SVG and filter colour properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,10 @@
 
 ### Minification
 
+- `stop-color`, `flood-color` and `lighting-color` minify as the `<color>`
+  SVG 2 and Filter Effects 1 define them to be, rather than surviving as
+  opaque unknown-property text: `stop-color: #ffffff` is
+  `stop-color:#fff` (#228)
 - `--minify` no longer re-runs the global factoring fixpoint on a segment
   whose result the transfer gate has already discarded. The pipeline
   re-presents one segment across its iterations with a rule or two moved,

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -394,6 +394,9 @@ let property_value_uses_color (type a) (p : Values.color -> bool)
   | Text_emphasis_color -> p value
   | Accent_color -> p value
   | Caret_color -> p value
+  | Stop_color -> p value
+  | Flood_color -> p value
+  | Lighting_color -> p value
   | Webkit_tap_highlight_color -> p value
   | Webkit_text_decoration_color -> p value
   | Border_inline_color -> logical_color_uses p value
@@ -912,6 +915,9 @@ let read_color_value : type a. a property -> Cursor.t -> declaration option =
   | Text_emphasis_color -> Some (v Text_emphasis_color (read_color t))
   | Accent_color -> Some (v Accent_color (read_color t))
   | Caret_color -> Some (v Caret_color (read_color t))
+  | Stop_color -> Some (v Stop_color (read_color t))
+  | Flood_color -> Some (v Flood_color (read_color t))
+  | Lighting_color -> Some (v Lighting_color (read_color t))
   | Webkit_tap_highlight_color ->
       Some (v Webkit_tap_highlight_color (read_color t))
   | Webkit_text_decoration_color ->

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -7241,6 +7241,9 @@ let pp_property : type a. a property Pp.t =
   | Fill -> Pp.string ctx "fill"
   | Stroke -> Pp.string ctx "stroke"
   | Stroke_width -> Pp.string ctx "stroke-width"
+  | Stop_color -> Pp.string ctx "stop-color"
+  | Flood_color -> Pp.string ctx "flood-color"
+  | Lighting_color -> Pp.string ctx "lighting-color"
   | Opacity -> Pp.string ctx "opacity"
   | Fill_opacity -> Pp.string ctx "fill-opacity"
   | Stroke_opacity -> Pp.string ctx "stroke-opacity"
@@ -19239,6 +19242,11 @@ let read_any_property t =
   | "content-visibility" -> Prop Content_visibility
   | "direction" -> Prop Direction
   | "fill" -> Prop Fill
+  (* SVG 2 sec. 13.4 / Filter Effects 1 sec. 9.3 and 12.2: each is a plain
+     <color>, so they minify like any other colour-valued property. *)
+  | "stop-color" -> Prop Stop_color
+  | "flood-color" -> Prop Flood_color
+  | "lighting-color" -> Prop Lighting_color
   | "flex-basis" -> Prop Flex_basis
   | "flex-grow" -> Prop Flex_grow
   | "flex-shrink" -> Prop Flex_shrink
@@ -21232,6 +21240,9 @@ let normalize_property_value : type a.
   | Outline_color -> normalize_color value
   | Accent_color -> normalize_color value
   | Caret_color -> normalize_color value
+  | Stop_color -> normalize_color value
+  | Flood_color -> normalize_color value
+  | Lighting_color -> normalize_color value
   | Border -> normalize_border ~lossless value
   | Border_block -> normalize_border ~lossless value
   | Border_block_start -> normalize_border ~lossless value
@@ -21924,6 +21935,9 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Overscroll_behavior_inline -> pp pp_overscroll_behavior
   | Accent_color -> pp pp_color
   | Caret_color -> pp pp_color
+  | Stop_color -> pp pp_color
+  | Flood_color -> pp pp_color
+  | Lighting_color -> pp pp_color
   | List_style -> pp pp_list_style
   | Font -> pp pp_font
   | Source -> pp pp_font_src
@@ -22204,6 +22218,9 @@ let property_value_kind : type a. a property -> a property_value_kind option =
   | Webkit_text_decoration_color -> Some Color
   | Accent_color -> Some Color
   | Caret_color -> Some Color
+  | Stop_color -> Some Color
+  | Flood_color -> Some Color
+  | Lighting_color -> Some Color
   | Background_image -> Some Background_images
   | Background -> Some Background
   | Webkit_mask_image -> Some Background_image

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4823,6 +4823,9 @@ type 'a property =
   | Fill : svg_paint property
   | Stroke : svg_paint property
   | Stroke_width : length property
+  | Stop_color : color property
+  | Flood_color : color property
+  | Lighting_color : color property
   | Direction : direction property
   | Unicode_bidi : unicode_bidi property
   | Writing_mode : writing_mode property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1921,6 +1921,9 @@ let vars_of_property : type a. a property -> a -> any_var list =
   (* Color properties *)
   | Accent_color, value -> vars_of_color value
   | Caret_color, value -> vars_of_color value
+  | Stop_color, value -> vars_of_color value
+  | Flood_color, value -> vars_of_color value
+  | Lighting_color, value -> vars_of_color value
   (* Rotate property *)
   | Rotate, value -> vars_of_rotate_value value
   (* Duration properties *)

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -402,6 +402,9 @@ let matrix =
         "stroke";
         "accent-color";
         "caret-color";
+        "stop-color";
+        "flood-color";
+        "lighting-color";
       ]
       [ "red"; "currentColor"; "rgb(0 0 0 / 50%)" ]
       [ "1px"; "red blue" ]

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -122,6 +122,19 @@ let complex_values () =
      longer. *)
   decl_optimizes ~prop:"flood-opacity" ~into:".5" "50%";
 
+  (* SVG 2 sec. 13.4 and Filter Effects 1 sec. 9.3 / 12.2 make each of these a
+     plain <color>, so they shorten like any other colour-valued property
+     instead of surviving as opaque unknown-property text. *)
+  check_declaration ~expected:"stop-color:#fff" "stop-color: #ffffff;";
+  check_declaration ~expected:"lighting-color:currentColor"
+    "lighting-color: currentColor;";
+  (* Cross-notation folds are node changes, so they belong to the optimizer
+     rather than the printer. *)
+  check_declaration ~expected:"flood-color:rgb(255 0 0)"
+    "flood-color: rgb(255, 0, 0);";
+  decl_optimizes ~prop:"flood-color" ~into:"red" "rgb(255, 0, 0)";
+  decl_optimizes ~prop:"stop-color" ~into:"#0000" "rgba(0, 0, 0, 0)";
+
   (* Complex nested functions. Per CSS Values 4 section 10.7 the printer
      simplifies all-constant calc subexpressions, reducing same-unit additions
      to a single value. Calcs containing [var()] cannot reduce at syntax time
@@ -2330,7 +2343,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 440
+    "property grammar manifest covers every tracked spec property name" 443
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 


### PR DESCRIPTION
`stop-color`, `flood-color` and `lighting-color` parsed as unknown properties, so their values survived as opaque text and missed even hex shortening. Each is a plain `<color>` per SVG 2 sec. 13.4 and Filter Effects 1 sec. 9.3 / 12.2, so they reuse the colour reader, printer and normaliser wholesale.

Follow-up to #214, which did the same for the four `<alpha-value>` properties.