### PR TITLE
values: canonicalise a zero angle written in radians

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,11 @@
 
 ### Minification
 
+- A zero angle written in radians canonicalises to `0deg`, so it reaches the
+  folds the other units already reached: `filter: hue-rotate(0rad)` is
+  `filter:hue-rotate()`. Radians are otherwise left alone, since the
+  conversion goes through pi and is not exact, but zero is the same angle in
+  every unit (#229)
 - `stop-color`, `flood-color` and `lighting-color` minify as the `<color>`
   SVG 2 and Filter Effects 1 define them to be, rather than surviving as
   opaque unknown-property text: `stop-color: #ffffff` is

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4013,6 +4013,11 @@ let normalize_angle ?(ctx = default_calc_ctx) =
         | Val v -> go v
         | folded -> Calc folded)
     | Deg _ | Turn _ | Grad _ -> angle_shortest a
+    (* [angle_shortest] leaves radians alone because deg/rad conversion goes
+       through pi and so is never exactly value-preserving. Zero is the one
+       radian value that converts exactly, and it is the one that matters: a
+       zero angle is what the grammars let you drop. *)
+    | Rad f when f = 0. -> Deg 0.
     | Rad _ | Var _ | Invalid _ -> a
   in
   go

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1525,7 +1525,16 @@ let angle_units () =
   (* deg/turn/grad conversion is an optimize rewrite, not a pp spelling: pp
      holds the authored units, optimize converts to the shortest. *)
   decl_optimizes_to ~held:"transform:skew(.25turn,100grad)"
-    ~into:"transform:skew(90deg,90deg)" "transform: skew(0.25turn, 100grad)"
+    ~into:"transform:skew(90deg,90deg)" "transform: skew(0.25turn, 100grad)";
+  (* A radian converts through pi, so it is never exactly a whole number of
+     degrees - except at zero, which is the same angle in every unit. *)
+  decl_optimizes_to ~held:"transform:rotate(0rad)"
+    ~into:"transform:rotate(0deg)" "transform: rotate(0rad)";
+  decl_optimizes_to ~held:"filter:hue-rotate(0rad)" ~into:"filter:hue-rotate()"
+    "filter: hue-rotate(0rad)";
+  (* hue-rotate() takes [ <angle> | <zero> ]? and means 0 when omitted, so the
+     other zero spellings drop the argument as well. *)
+  decl_optimizes ~prop:"filter" ~into:"hue-rotate()" "hue-rotate(0turn)"
 
 let property_case () =
   (* Property names are ASCII case-insensitive *)


### PR DESCRIPTION
`angle_shortest` skips radians because deg/rad conversion goes through pi and so is never exactly value-preserving. Zero is the one radian value that converts exactly, and skipping it kept `0rad` out of every fold the other units already reach, so `filter: hue-rotate(0rad)` stayed spelled out while `hue-rotate(0deg)`, `hue-rotate(0turn)` and `hue-rotate(0grad)` all became `hue-rotate()`.