### PR TITLE
properties: fold grid-auto-flow row dense to dense

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,9 @@
 
 ### Minification
 
+- `grid-auto-flow: row dense` minifies to `dense`. CSS Grid 2 sec. 7.6 gives
+  the property as `[ row | column ] || dense` with `row` as the omitted axis,
+  so the two are one value. `column dense` keeps its axis (#230)
 - A zero angle written in radians canonicalises to `0deg`, so it reaches the
   folds the other units already reached: `filter: hue-rotate(0rad)` is
   `filter:hue-rotate()`. Radians are otherwise left alone, since the

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4465,6 +4465,11 @@ let normalize_aspect_ratio : aspect_ratio -> aspect_ratio =
         (Ratio_calc (Values.normalize_number a, Values.normalize_number b))
   | other -> other
 
+(* CSS Grid 2 sec. 7.6: [grid-auto-flow] is [ row | column ] || dense, and an
+   omitted axis means [row], so [row dense] and [dense] are one value. *)
+let normalize_grid_auto_flow : grid_auto_flow -> grid_auto_flow =
+ fun value -> match value with Row_dense -> Dense | other -> other
+
 let normalize_border ?(lossless = false) : border -> border =
  fun value ->
   match value with
@@ -21280,6 +21285,7 @@ let normalize_property_value : type a.
   | Grid -> normalize_grid_template value
   | Grid_auto_columns -> normalize_grid_template value
   | Grid_auto_rows -> normalize_grid_template value
+  | Grid_auto_flow -> normalize_grid_auto_flow value
   | Aspect_ratio -> normalize_aspect_ratio value
   | Gap -> normalize_gap value
   | Font_size -> normalize_font_size value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -869,6 +869,14 @@ let grid () =
     "grid-auto-flow: row dense";
   check_declaration ~expected:"grid-auto-flow:column dense"
     "grid-auto-flow: column dense";
+  (* CSS Grid 2 sec. 7.6 gives [ row | column ] || dense with [row] as the
+     omitted axis, so [row dense] and [dense] are one value and the optimizer
+     picks the shorter. The axis is load-bearing on [column dense]. *)
+  decl_optimizes_to ~held:"grid-auto-flow:row dense"
+    ~into:"grid-auto-flow:dense" "grid-auto-flow: row dense";
+  decl_optimizes_to ~held:"grid-auto-flow:row dense"
+    ~into:"grid-auto-flow:dense" "grid-auto-flow: dense row";
+  decl_optimizes ~prop:"grid-auto-flow" ~into:"column dense" "column dense";
 
   (* Grid gaps *)
   check_declaration ~expected:"gap:10px" "gap: 10px";


### PR DESCRIPTION
CSS Grid 2 sec. 7.6 gives `grid-auto-flow` as `[ row | column ] || dense` with `row` as the omitted axis, so `row dense` and `dense` are one value and the `row` was pure weight. The two spellings also parsed to distinct constructors, which left the canonical projection reporting them as different values. `column dense` keeps its axis.