### PR TITLE
diff: key @media not all and (X) as @media not (X)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### Diffing
 
+- `--diff=canonical` keys a `@media not all and (X)` block as the
+  `@media not (X)` that Media Queries 4 sec. 2.1 makes it equal to, since
+  `all` is the identity media type. The two spellings used to compare as a
+  removed container plus an added one. Emission still keeps what it read: a
+  Level 3 parser rejects the shorter form, and an unrecognised query never
+  matches (#231)
 - `--diff=canonical` sorts a run of `@property` rules by name, keeping the last
   registration of each, at the top level and inside any block. CSS Properties
   and Values API 1 sec. 2 makes registrations for different names

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7660,8 +7660,11 @@ val canonicalize_rule_order : t -> t
     relative order, and named [@layer] blocks pin the layer order where they
     stand. A run of [@property] rules sorts by name, keeping the last
     registration of each, since CSS Properties and Values API 1 sec. 2 makes
-    registrations for different names order-independent. This is a
-    comparison-side normalisation; {!val-optimize} stays source-stable. *)
+    registrations for different names order-independent. A
+    [@media not all and (X)] block is keyed as the [@media not (X)] that Media
+    Queries 4 makes it equal to, which emission cannot do because a Level 3
+    parser rejects the shorter form. This is a comparison-side normalisation;
+    {!val-optimize} stays source-stable. *)
 
 val optimize :
   ?scope:Optimize.scope ->

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -580,9 +580,43 @@ let rec sort_property_runs (stmts : statement list) : statement list =
   in
   go [] stmts
 
+(* Media Queries 4 sec. 2.1: [all] matches every media type, so it is the
+   identity in [<media-type> and <condition>] and the Level 3 spelling [not all
+   and (X)] is the same query as the Level 4 [not (X)]. Bare [not all] has no
+   condition form - it matches nothing - so it stays, and the unnegated [all and
+   (X)] never reaches here because {!Optimize} already drops it.
+
+   Projection only. The Level 4 form is eight characters shorter, but a Level 3
+   parser rejects a [not] with no media type and an unrecognised query never
+   matches, so rewriting one to the other on output would silently drop the
+   block in those browsers. *)
+let rec canonical_media (query : Media.t) : Media.t =
+  match query with
+  | Media.Type { prefix = Some Media.Not; type_ = Media.All; trailing = Some c }
+    ->
+      Media.Cond (Media.Not c)
+  | Media.List qs -> Media.List (List.map canonical_media qs)
+  | query -> query
+
+let rec canonical_media_queries (stmts : statement list) : statement list =
+  List.map
+    (fun stmt ->
+      match stmt with
+      | Rule r -> Rule { r with nested = canonical_media_queries r.nested }
+      | Media (q, inner) ->
+          Media (canonical_media q, canonical_media_queries inner)
+      | Layer (n, inner) -> Layer (n, canonical_media_queries inner)
+      | Supports (c, inner) -> Supports (c, canonical_media_queries inner)
+      | Container (n, c, inner) ->
+          Container (n, c, canonical_media_queries inner)
+      | other -> other)
+    stmts
+
 let canonicalize (stmts : statement list) : statement list =
   let changed = ref false in
-  let normalized = sort_property_runs (normalize_custom_values stmts) in
+  let normalized =
+    canonical_media_queries (sort_property_runs (normalize_custom_values stmts))
+  in
   let result =
     canonicalize_block ~parent:(None : Selector.t option) changed normalized
   in

--- a/lib/rule_order.mli
+++ b/lib/rule_order.mli
@@ -34,4 +34,9 @@ val canonicalize : Stylesheet.statement list -> Stylesheet.statement list
     sorts by name, keeping the last registration of each. CSS Properties and
     Values API 1 sec. 2 makes registrations for different names
     order-independent and gives a name its last registration, so the emission
-    order carries no meaning. Every block body is its own run context. *)
+    order carries no meaning. Every block body is its own run context.
+
+    A [@media] query of the Level 3 form [not all and (X)] is rewritten to the
+    Level 4 [not (X)] it is equal to under Media Queries 4 sec. 2.1, since [all]
+    is the identity media type. That direction loses support in a Level 3
+    parser, so it belongs to the projection rather than to emission. *)

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -78,6 +78,27 @@ let equal_canonical_ignores_property_order () =
        "@property --a{syntax:\"*\";inherits:false}.x{top:0}@property \
         --z{syntax:\"*\";inherits:false}")
 
+(* Media Queries 4 sec. 2.1: [all] matches every media type, so [not all and
+   (X)] and [not (X)] are the same query. Equating them is projection-only - a
+   Level 3 parser rejects the shorter form, so emission keeps what it read. *)
+let equal_canonical_media_not_all () =
+  Alcotest.(check bool)
+    "not all and (X) is not a difference against not (X)" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       "@media not all and (hover){.a{color:red}}"
+       "@media not (hover){.a{color:red}}");
+  (* A media type other than [all] restricts the query, so it stays. *)
+  Alcotest.(check bool)
+    "not screen and (X) still differs from not (X)" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       "@media not screen and (hover){.a{color:red}}"
+       "@media not (hover){.a{color:red}}");
+  (* Bare [not all] matches nothing, which no condition spells. *)
+  Alcotest.(check bool)
+    "not all still differs from not (X)" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       "@media not all{.a{color:red}}" "@media not (hover){.a{color:red}}")
+
 let equal_prune_unused_custom_props () =
   let with_bind = ":root{--spacing:.25rem}.top-0{top:0}" in
   let without = ".top-0{top:0}" in
@@ -1145,4 +1166,6 @@ let suite =
         equal_prune_unused_custom_props;
       Alcotest.test_case "canonical ignores @property order" `Quick
         equal_canonical_ignores_property_order;
+      Alcotest.test_case "canonical equates not all and (X) with not (X)" `Quick
+        equal_canonical_media_not_all;
     ] )


### PR DESCRIPTION
Media Queries 4 sec. 2.1 makes `all` the identity media type, so `not all and (X)` and `not (X)` are the same query, but the canonical projection reported them as a removed container plus an added one.

Equating them belongs to the projection rather than to emission: the Level 4 form is eight characters shorter, but a Level 3 parser rejects a `not` with no media type and an unrecognised query never matches, so rewriting it on output would silently drop the block in those browsers.