### PR TITLE
values: reject a malformed hex instead of returning black

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -116,6 +116,15 @@
   layered stylesheet (such as Tailwind v4 output) previously inlined
   nothing (#188)
 
+### Breaking
+
+- `Css.hex` raises `Invalid_argument` on a string that is not one of `#rgb`,
+  `#rrggbb`, `#rgba` or `#rrggbbaa`. It used to return opaque black, so a
+  caller's own bad hex reached the output as a plausible wrong colour instead
+  of a failure. `Css.hex_opt` is the deciding form for callers that want to
+  handle it. Parsing is unaffected: the declaration reader already warned and
+  dropped (#232)
+
 ### New properties and values
 
 - Complete the logical border properties: `Css.border_block_color`,

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1250,7 +1250,13 @@ type color = Values.color =
 
 val hex : string -> color
 (** [hex s] is a hexadecimal color. Accepts with or without leading [#].
-    Examples: [hex "#3b82f6"], [hex "ffffff"]. *)
+    Examples: [hex "#3b82f6"], [hex "ffffff"]. Raises [Invalid_argument] when
+    [s] is not one of [#rgb], [#rrggbb], [#rgba] or [#rrggbbaa]; see
+    {!val-hex_opt} to decide. *)
+
+val hex_opt : string -> color option
+(** [hex_opt s] is {!val-hex} without the exception: the colour when [s] is a
+    hex spelling, and nothing otherwise. *)
 
 val rgb : ?alpha:float -> int -> int -> int -> color
 (** [rgb ?alpha r g b] is an RGB color (0-255 components) with optional alpha.

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -2734,16 +2734,23 @@ let hex_of_byte i =
 
 (* Decode a hex spelling ([#rgb] / [#rrggbb] / [#rgba] / [#rrggbbaa], with or
    without the leading [#]) to its sRGB byte components. Every equivalent
-   spelling decodes to the same node. Invalid input folds to opaque black. *)
+   spelling decodes to the same node. Malformed input raises: there is no colour
+   it denotes, and a caller that guessed one would emit a plausible wrong colour
+   rather than a failure. Use [hex_opt] to decide. *)
+let strip_hash s =
+  if String.length s > 0 && s.[0] = '#' then String.sub s 1 (String.length s - 1)
+  else s
+
+let hex_opt s : color option =
+  match rgba_of_hex (strip_hash s) with
+  | Some (r, g, b, a) -> Some (Hex { r; g; b; a })
+  | None -> Option.None
+
 let hex s : color =
-  let s =
-    if String.length s > 0 && s.[0] = '#' then
-      String.sub s 1 (String.length s - 1)
-    else s
-  in
-  match rgba_of_hex s with
-  | Some (r, g, b, a) -> Hex { r; g; b; a }
-  | None -> Hex { r = 0; g = 0; b = 0; a = 255 }
+  match hex_opt s with
+  | Some c -> c
+  | Option.None ->
+      invalid_arg (String.concat "" [ "Values.hex: not a hex colour: "; s ])
 
 (* CSS Color 4 sec. 4.2.3 [none] sentinel: per-channel folding of a static
    colour to sRGB. Each channel is [Some byte] when the colour resolves

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -29,7 +29,14 @@ val string_of_number_percentage : number_percentage -> string
 (** {1 Constructor Functions} *)
 
 val hex : string -> color
-(** [hex s] creates a hex color value. *)
+(** [hex s] is the colour of the hex spelling [s], with or without the leading
+    [#]. Raises [Invalid_argument] when [s] is not one of [#rgb], [#rrggbb],
+    [#rgba] or [#rrggbbaa]: no colour is denoted, and returning one would put a
+    plausible wrong colour into the output. See {!hex_opt} to decide. *)
+
+val hex_opt : string -> color option
+(** [hex_opt s] is {!val-hex} without the exception: the colour when [s] is a
+    hex spelling, and nothing otherwise. *)
 
 val rgb : ?alpha:float -> int -> int -> int -> color
 (** [rgb ?alpha r g b] creates an RGB color with optional alpha. *)

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -259,6 +259,25 @@ let test_color () =
   check_color ~optimized:"#639" "rebeccapurple";
   check_color ~optimized:"#f0f8ff" "aliceblue";
 
+  (* [hex] is a constructor, not a parser: a string it cannot decode denotes no
+     colour, so it raises rather than handing back one the caller did not ask
+     for. [hex_opt] is the deciding form. *)
+  Alcotest.(check string)
+    "hex accepts a bare spelling" "#fff"
+    (Pp.to_string ~minify:true pp_color (hex "ffffff"));
+  let rejects s =
+    match hex s with _ -> false | exception Invalid_argument _ -> true
+  in
+  Alcotest.(check bool) "hex rejects a bad length" true (rejects "#12345");
+  Alcotest.(check bool) "hex rejects a bad digit" true (rejects "gggggg");
+  Alcotest.(check bool)
+    "hex rejects an over-long spelling" true (rejects "#1234567");
+  Alcotest.(check bool) "hex rejects the empty string" true (rejects "");
+  Alcotest.(check bool) "hex_opt decides instead" true (hex_opt "#12345" = None);
+  Alcotest.(check bool)
+    "hex_opt accepts a good spelling" true
+    (hex_opt "#abc" <> None);
+
   (* Modern color notations. pp preserves the authored function node; the
      equivalent hex form is the optimize+minify oracle. *)
   check_color ~expected:"hsl(180 50% 25%)" ~optimized:"#206060"


### PR DESCRIPTION
`Css.hex` folded any string it could not decode to opaque black, so a caller's own bad hex reached the output as valid CSS with a plausible wrong colour in it rather than as a failure. It now raises `Invalid_argument`, and `Css.hex_opt` is there for callers that want to decide.

This is a behaviour change for existing callers of `Css.hex`. Parsing is unaffected: the declaration reader already warned and dropped a malformed hex.