### PR TITLE
test: pin that !important survives duplicate elimination

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -35,6 +35,31 @@ Lightning CSS and esbuild are well over an order of magnitude faster but emit
 0.4-15% more compressed bytes; csso and cssnano sit in the same wall-clock band
 as cascade and emit more bytes.
 
+## Correctness
+
+Smaller output only counts while it still means the same thing. Eliminating a
+non-adjacent duplicate declaration is where that is easy to get wrong, because
+it takes reading the importance flag to know which of the two is dead:
+
+```css
+.a{color:red!important}.b{color:green}.a{color:blue}
+```
+
+The `!important` declaration is the cascade winner, so `color:blue` is the dead
+one. Dropping it is sound; dropping the winner changes what `.a` renders as.
+
+| tool | output | `.a` computes to |
+|---|---|---|
+| cascade `--minify` | `.a{color:red!important}.b{color:green}` | red |
+| esbuild | `.a{color:red!important}.b{color:green}.a{color:#00f}` | red |
+| csso | `.a{color:red!important}.b{color:green}.a{}` | red |
+| lightningcss 1.0.0-alpha.71 | `.b{color:green}.a{color:#00f}` | blue |
+
+Lightning CSS drops the winner, so `.a` renders blue instead of red. Cascade
+drops the dead declaration and the rule it empties, which is both sound and the
+smallest of the four. `test/test_optimize.ml` pins it, along with the three
+mirror cases (a later `!important`, two of them, and neither).
+
 ## Reproducing
 
 The scripts and their requirements (the corpus is regenerated locally, not

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -882,6 +882,36 @@ let test_lossless_declaration_order () =
    happened to order its rules: a rule sitting between two others decides
    whether either applies. A canonical projection therefore turns regrouping
    off, so the same stylesheet written either way maps to one form. *)
+(* Eliminating a non-adjacent duplicate declaration has to read the importance
+   flag: with an [!important] earlier write in play, the later normal write is
+   the dead one, not the winner. Dropping the wrong one changes what [.a]
+   computes to, and it is the failure mode a peer minifier ships (Lightning CSS
+   1.0.0-alpha.71 emits [.b{color:green}.a{color:#00f}] here, so [.a] resolves
+   to blue rather than red). *)
+let important_survives_non_adjacent_duplicate () =
+  let out src =
+    Css.to_string ~minify:true (Css.optimize (Css.of_string_exn src))
+  in
+  Alcotest.(check string)
+    "the !important winner is kept and the dead write dropped"
+    ".a{color:red!important}.b{color:green}"
+    (out ".a{color:red!important}.b{color:green}.a{color:blue}");
+  (* The mirror image: when the later write carries the flag it is the winner,
+     so the earlier one is what goes. *)
+  Alcotest.(check string)
+    "a later !important wins over an earlier normal write"
+    ".b{color:green}.a{color:#00f!important}"
+    (out ".a{color:red}.b{color:green}.a{color:blue!important}");
+  (* Neither carries the flag, so the plain last-wins rule applies. *)
+  Alcotest.(check string)
+    "without !important the later write wins" ".b{color:green}.a{color:#00f}"
+    (out ".a{color:red}.b{color:green}.a{color:blue}");
+  (* Both carry it, so last-wins applies among them. *)
+  Alcotest.(check string)
+    "between two !important writes the later wins"
+    ".b{color:green}.a{color:#00f!important}"
+    (out ".a{color:red!important}.b{color:green}.a{color:blue!important}")
+
 let regrouping_can_be_disabled () =
   let src =
     ".text-xs{font-size:var(--text-xs);line-height:1}.text-xs\\/4{font-size:var(--text-xs);line-height:4}.text-xs\\/5{font-size:var(--text-xs);line-height:5}.text-xs\\/6{font-size:var(--text-xs);line-height:6}.text-xs\\/7{font-size:var(--text-xs);line-height:7}"
@@ -921,6 +951,9 @@ let nesting_synthesis_can_be_disabled () =
 
 let optimize_tests =
   [
+    ( "!important survives non-adjacent duplicate elimination",
+      `Quick,
+      important_survives_non_adjacent_duplicate );
     ("regrouping can be disabled", `Quick, regrouping_can_be_disabled);
     ( "nesting synthesis can be disabled",
       `Quick,


### PR DESCRIPTION
Eliminating a non-adjacent duplicate declaration takes reading the importance flag to know which of the two writes is dead. Given `.a{color:red!important}.b{color:green}.a{color:blue}` the `!important` declaration is the cascade winner and `color:blue` is dead, so dropping the latter is sound and dropping the former changes what `.a` renders as.

Cascade drops the dead declaration and the rule it empties. Lightning CSS 1.0.0-alpha.71 drops the winner instead, so `.a` renders blue rather than red; esbuild and csso are both sound. That makes the behaviour worth pinning, and worth a line in BENCHMARKS.md next to the size numbers.