### PR TITLE
properties: model fill-rule and clip-rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,10 @@
 
 ### New properties and values
 
+- Read `fill-rule` and `clip-rule`, the SVG 2 sec. 13.5 / 14.4 properties that
+  share one `<fill-rule>`. Both parsed as unknown properties, so their values
+  survived as opaque text (#234)
+
 - Complete the logical border properties: `Css.border_block_color`,
   `Css.border_block_start_color` and `Css.border_block_end_color`, the
   `Css.border_inline_width` and `Css.border_block_width` shorthands (with

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1642,6 +1642,8 @@ let read_interaction_value : type a.
   | Fill -> Some (v Fill (read_svg_paint t))
   | Stroke -> Some (v Stroke (read_svg_paint t))
   | Direction -> Some (v Direction (read_direction t))
+  | Fill_rule -> Some (v Fill_rule (Properties.read_fill_rule t))
+  | Clip_rule -> Some (v Clip_rule (Properties.read_fill_rule t))
   | Unicode_bidi -> Some (v Unicode_bidi (read_unicode_bidi t))
   | Writing_mode -> Some (v Writing_mode (read_writing_mode t))
   | Text_combine_upright ->

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -7246,6 +7246,8 @@ let pp_property : type a. a property Pp.t =
   | Fill -> Pp.string ctx "fill"
   | Stroke -> Pp.string ctx "stroke"
   | Stroke_width -> Pp.string ctx "stroke-width"
+  | Fill_rule -> Pp.string ctx "fill-rule"
+  | Clip_rule -> Pp.string ctx "clip-rule"
   | Stop_color -> Pp.string ctx "stop-color"
   | Flood_color -> Pp.string ctx "flood-color"
   | Lighting_color -> Pp.string ctx "lighting-color"
@@ -9615,6 +9617,17 @@ let rec pp_nav : nav Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_nav ctx v
+
+let rec pp_fill_rule : fill_rule Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_fill_rule ctx v
+  | Nonzero -> Pp.string ctx "nonzero"
+  | Evenodd -> Pp.string ctx "evenodd"
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
 
 let rec pp_direction : direction Pp.t =
  fun ctx -> function
@@ -15271,6 +15284,20 @@ let read_svg_paint t : svg_paint =
     ]
     t
 
+let rec read_fill_rule t : fill_rule =
+  Cursor.enum_or_var "fill-rule"
+    [
+      ("nonzero", (Nonzero : fill_rule));
+      ("evenodd", Evenodd);
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (Values.read_var read_fill_rule t))
+    t
+
 let rec read_direction t : direction =
   Cursor.enum_or_var "direction"
     [
@@ -19247,6 +19274,9 @@ let read_any_property t =
   | "content-visibility" -> Prop Content_visibility
   | "direction" -> Prop Direction
   | "fill" -> Prop Fill
+  (* SVG 2 sec. 13.5 and 14.4: both take the same <fill-rule>. *)
+  | "fill-rule" -> Prop Fill_rule
+  | "clip-rule" -> Prop Clip_rule
   (* SVG 2 sec. 13.4 / Filter Effects 1 sec. 9.3 and 12.2: each is a plain
      <color>, so they minify like any other colour-valued property. *)
   | "stop-color" -> Prop Stop_color
@@ -21898,6 +21928,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Text_size_adjust -> pp pp_text_size_adjust
   | Touch_action -> pp pp_touch_action
   | Direction -> pp pp_direction
+  | Fill_rule -> pp pp_fill_rule
+  | Clip_rule -> pp pp_fill_rule
   | Unicode_bidi -> pp pp_unicode_bidi
   | Writing_mode -> pp pp_writing_mode
   | Text_combine_upright -> pp pp_text_combine_upright

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2253,6 +2253,12 @@ val pp_direction : direction Pp.t
 val read_direction : Cursor.t -> direction
 (** [read_direction t] is the [direction] parsed from [t]. *)
 
+val pp_fill_rule : fill_rule Pp.t
+(** [pp_fill_rule] pretty-prints an SVG [<fill-rule>]. *)
+
+val read_fill_rule : Cursor.t -> fill_rule
+(** [read_fill_rule t] is the [fill_rule] parsed from [t]. *)
+
 val pp_unicode_bidi : unicode_bidi Pp.t
 (** [pp_unicode_bidi] is the pretty-printer for [unicode_bidi]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3878,6 +3878,20 @@ type svg_paint =
       (** SVG2 sec. 11.2 [context-stroke] - mirror of [Context_fill]. *)
   | Var of svg_paint var
 
+(** SVG 2 sec. 13.5 / 14.4 [<fill-rule>]: which points count as inside a shape
+    when its subpaths overlap. Shared by [fill-rule] and [clip-rule]; the
+    argument form inside [polygon()] is {!clip_path_fill_rule}, which carries no
+    CSS-wide keywords. *)
+type fill_rule =
+  | Nonzero
+  | Evenodd
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of fill_rule var
+
 (* Direction Types *)
 type direction =
   | Ltr
@@ -4823,6 +4837,8 @@ type 'a property =
   | Fill : svg_paint property
   | Stroke : svg_paint property
   | Stroke_width : length property
+  | Fill_rule : fill_rule property
+  | Clip_rule : fill_rule property
   | Stop_color : color property
   | Flood_color : color property
   | Lighting_color : color property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1721,6 +1721,9 @@ let vars_of_timeline_inset (value : Properties.timeline_inset) =
 let vars_of_direction (value : Properties.direction) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_fill_rule (value : Properties.fill_rule) =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_css_wide (value : Properties.css_wide) =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2158,6 +2161,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Offset_rotate, value -> vars_of_offset_rotate value
   | All, value -> vars_of_css_wide value
   | Direction, value -> vars_of_direction value
+  | Fill_rule, value -> vars_of_fill_rule value
+  | Clip_rule, value -> vars_of_fill_rule value
   | Display, value -> vars_of_display value
   | Fill, value -> vars_of_svg_paint value
   | Flex, value -> vars_of_flex value

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1869,6 +1869,16 @@ let matrix =
         negatives = [ "ltr rtl"; "auto" ];
       };
       {
+        property = "fill-rule";
+        positives = [ "nonzero"; "evenodd" ];
+        negatives = [ "nonzero evenodd"; "even-odd" ];
+      };
+      {
+        property = "clip-rule";
+        positives = [ "nonzero"; "evenodd" ];
+        negatives = [ "nonzero evenodd"; "even-odd" ];
+      };
+      {
         property = "unicode-bidi";
         positives = [ "normal"; "embed"; "isolate"; "plaintext" ];
         negatives = [ "normal isolate"; "auto" ];

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -135,6 +135,13 @@ let complex_values () =
   decl_optimizes ~prop:"flood-color" ~into:"red" "rgb(255, 0, 0)";
   decl_optimizes ~prop:"stop-color" ~into:"#0000" "rgba(0, 0, 0, 0)";
 
+  (* SVG 2 sec. 13.5 and 14.4 give [fill-rule] and [clip-rule] the same
+     <fill-rule>, which is the keyword pair alone: the argument form inside
+     polygon() is a different production. *)
+  check_declaration ~expected:"fill-rule:evenodd" "fill-rule: evenodd;";
+  check_declaration ~expected:"clip-rule:nonzero" "clip-rule: nonzero;";
+  check_declaration ~expected:"fill-rule:var(--r)" "fill-rule: var(--r);";
+
   (* Complex nested functions. Per CSS Values 4 section 10.7 the printer
      simplifies all-constant calc subexpressions, reducing same-unit additions
      to a single value. Calcs containing [var()] cannot reduce at syntax time
@@ -2360,7 +2367,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 443
+    "property grammar manifest covers every tracked spec property name" 445
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -188,6 +188,7 @@ let check_scroll_snap_type =
 
 let check_svg_paint = check_value_cursor "svg-paint" read_svg_paint pp_svg_paint
 let check_direction = check_value_cursor "direction" read_direction pp_direction
+let check_fill_rule = check_value_cursor "fill-rule" read_fill_rule pp_fill_rule
 
 let check_unicode_bidi =
   check_value_cursor "unicode-bidi" read_unicode_bidi pp_unicode_bidi
@@ -2116,8 +2117,8 @@ let test_font_stretch () =
   check_font_stretch "50%";
   check_font_stretch "inherit";
   neg_cursor read_font_stretch "invalid-stretch";
-  (* CSS Fonts 4 §5.3 defines each keyword as a percentage, never longer, so
-     minified output uses it — but only for the standalone property: the [font]
+  (* CSS Fonts 4 sec. 5.3 defines each keyword as a percentage, never longer, so
+     minified output uses it, but only for the standalone property: the [font]
      shorthand's stretch component takes the keyword alone. *)
   check_font_stretch ~expected:"100%" "normal";
   check_font_stretch ~expected:"50%" "ultra-condensed";
@@ -2809,6 +2810,14 @@ let test_direction () =
   check_direction "rtl";
   check_direction "inherit";
   neg_cursor read_direction "invalid-direction"
+
+let test_fill_rule () =
+  check_fill_rule "nonzero";
+  check_fill_rule "evenodd";
+  check_fill_rule "inherit";
+  check_fill_rule "var(--r)";
+  neg_cursor read_fill_rule "even-odd";
+  neg_cursor read_fill_rule "nonzero evenodd"
 
 let test_unicode_bidi () =
   check_unicode_bidi "normal";
@@ -4205,6 +4214,7 @@ let additional_tests =
     test_case "overscroll_behavior" `Quick test_overscroll_behavior;
     test_case "svg_paint" `Quick test_svg_paint;
     test_case "direction" `Quick test_direction;
+    test_case "fill_rule" `Quick test_fill_rule;
     test_case "unicode_bidi" `Quick test_unicode_bidi;
     test_case "writing_mode" `Quick test_writing_mode;
     test_case "webkit_appearance" `Quick test_webkit_appearance;


### PR DESCRIPTION
Both parsed as unknown properties, so their values survived as opaque text. SVG 2 sec. 13.5 and 14.4 give them one shared `<fill-rule>`, distinct from the `polygon()` argument form (`clip_path_fill_rule`) in that it also takes the CSS-wide keywords.

First of the SVG presentation properties still unmodelled after #214 and #228; the rest each need their own value type.