### PR TITLE
properties: model stroke-linecap and stroke-linejoin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,9 @@
 
 ### New properties and values
 
+- Read `stroke-linecap` and `stroke-linejoin`, including the SVG 2 sec. 13.3
+  additions `miter-clip` and `arcs`. Both parsed as unknown properties (#235)
+
 - Read `fill-rule` and `clip-rule`, the SVG 2 sec. 13.5 / 14.4 properties that
   share one `<fill-rule>`. Both parsed as unknown properties, so their values
   survived as opaque text (#234)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1644,6 +1644,9 @@ let read_interaction_value : type a.
   | Direction -> Some (v Direction (read_direction t))
   | Fill_rule -> Some (v Fill_rule (Properties.read_fill_rule t))
   | Clip_rule -> Some (v Clip_rule (Properties.read_fill_rule t))
+  | Stroke_linecap -> Some (v Stroke_linecap (Properties.read_stroke_linecap t))
+  | Stroke_linejoin ->
+      Some (v Stroke_linejoin (Properties.read_stroke_linejoin t))
   | Unicode_bidi -> Some (v Unicode_bidi (read_unicode_bidi t))
   | Writing_mode -> Some (v Writing_mode (read_writing_mode t))
   | Text_combine_upright ->

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -7248,6 +7248,8 @@ let pp_property : type a. a property Pp.t =
   | Stroke_width -> Pp.string ctx "stroke-width"
   | Fill_rule -> Pp.string ctx "fill-rule"
   | Clip_rule -> Pp.string ctx "clip-rule"
+  | Stroke_linecap -> Pp.string ctx "stroke-linecap"
+  | Stroke_linejoin -> Pp.string ctx "stroke-linejoin"
   | Stop_color -> Pp.string ctx "stop-color"
   | Flood_color -> Pp.string ctx "flood-color"
   | Lighting_color -> Pp.string ctx "lighting-color"
@@ -9617,6 +9619,32 @@ let rec pp_nav : nav Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_nav ctx v
+
+let rec pp_stroke_linecap : stroke_linecap Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_stroke_linecap ctx v
+  | Butt -> Pp.string ctx "butt"
+  | Round -> Pp.string ctx "round"
+  | Square -> Pp.string ctx "square"
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+
+let rec pp_stroke_linejoin : stroke_linejoin Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_stroke_linejoin ctx v
+  | Miter -> Pp.string ctx "miter"
+  | Miter_clip -> Pp.string ctx "miter-clip"
+  | Round -> Pp.string ctx "round"
+  | Bevel -> Pp.string ctx "bevel"
+  | Arcs -> Pp.string ctx "arcs"
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
 
 let rec pp_fill_rule : fill_rule Pp.t =
  fun ctx -> function
@@ -15284,6 +15312,38 @@ let read_svg_paint t : svg_paint =
     ]
     t
 
+let rec read_stroke_linecap t : stroke_linecap =
+  Cursor.enum_or_var "stroke-linecap"
+    [
+      ("butt", (Butt : stroke_linecap));
+      ("round", Round);
+      ("square", Square);
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (Values.read_var read_stroke_linecap t))
+    t
+
+let rec read_stroke_linejoin t : stroke_linejoin =
+  Cursor.enum_or_var "stroke-linejoin"
+    [
+      ("miter", (Miter : stroke_linejoin));
+      ("miter-clip", Miter_clip);
+      ("round", Round);
+      ("bevel", Bevel);
+      ("arcs", Arcs);
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (Values.read_var read_stroke_linejoin t))
+    t
+
 let rec read_fill_rule t : fill_rule =
   Cursor.enum_or_var "fill-rule"
     [
@@ -19277,6 +19337,8 @@ let read_any_property t =
   (* SVG 2 sec. 13.5 and 14.4: both take the same <fill-rule>. *)
   | "fill-rule" -> Prop Fill_rule
   | "clip-rule" -> Prop Clip_rule
+  | "stroke-linecap" -> Prop Stroke_linecap
+  | "stroke-linejoin" -> Prop Stroke_linejoin
   (* SVG 2 sec. 13.4 / Filter Effects 1 sec. 9.3 and 12.2: each is a plain
      <color>, so they minify like any other colour-valued property. *)
   | "stop-color" -> Prop Stop_color
@@ -21930,6 +21992,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Direction -> pp pp_direction
   | Fill_rule -> pp pp_fill_rule
   | Clip_rule -> pp pp_fill_rule
+  | Stroke_linecap -> pp pp_stroke_linecap
+  | Stroke_linejoin -> pp pp_stroke_linejoin
   | Unicode_bidi -> pp pp_unicode_bidi
   | Writing_mode -> pp pp_writing_mode
   | Text_combine_upright -> pp pp_text_combine_upright

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2259,6 +2259,18 @@ val pp_fill_rule : fill_rule Pp.t
 val read_fill_rule : Cursor.t -> fill_rule
 (** [read_fill_rule t] is the [fill_rule] parsed from [t]. *)
 
+val pp_stroke_linecap : stroke_linecap Pp.t
+(** [pp_stroke_linecap] pretty-prints a [stroke-linecap] keyword. *)
+
+val read_stroke_linecap : Cursor.t -> stroke_linecap
+(** [read_stroke_linecap t] is the [stroke_linecap] parsed from [t]. *)
+
+val pp_stroke_linejoin : stroke_linejoin Pp.t
+(** [pp_stroke_linejoin] pretty-prints a [stroke-linejoin] keyword. *)
+
+val read_stroke_linejoin : Cursor.t -> stroke_linejoin
+(** [read_stroke_linejoin t] is the [stroke_linejoin] parsed from [t]. *)
+
 val pp_unicode_bidi : unicode_bidi Pp.t
 (** [pp_unicode_bidi] is the pretty-printer for [unicode_bidi]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3892,6 +3892,34 @@ type fill_rule =
   | Revert_layer
   | Var of fill_rule var
 
+(** SVG 2 sec. 13.3 [stroke-linecap]: the shape drawn at the ends of an open
+    subpath and at the ends of each dash. *)
+type stroke_linecap =
+  | Butt
+  | Round
+  | Square
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of stroke_linecap var
+
+(** SVG 2 sec. 13.3 [stroke-linejoin]: the shape drawn where two path segments
+    meet. [miter_clip] and [arcs] are the Level 2 additions. *)
+type stroke_linejoin =
+  | Miter
+  | Miter_clip
+  | Round
+  | Bevel
+  | Arcs
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of stroke_linejoin var
+
 (* Direction Types *)
 type direction =
   | Ltr
@@ -4839,6 +4867,8 @@ type 'a property =
   | Stroke_width : length property
   | Fill_rule : fill_rule property
   | Clip_rule : fill_rule property
+  | Stroke_linecap : stroke_linecap property
+  | Stroke_linejoin : stroke_linejoin property
   | Stop_color : color property
   | Flood_color : color property
   | Lighting_color : color property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1724,6 +1724,12 @@ let vars_of_direction (value : Properties.direction) =
 let vars_of_fill_rule (value : Properties.fill_rule) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_stroke_linecap (value : Properties.stroke_linecap) =
+  match value with Var v -> [ V v ] | _ -> []
+
+let vars_of_stroke_linejoin (value : Properties.stroke_linejoin) =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_css_wide (value : Properties.css_wide) =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2163,6 +2169,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Direction, value -> vars_of_direction value
   | Fill_rule, value -> vars_of_fill_rule value
   | Clip_rule, value -> vars_of_fill_rule value
+  | Stroke_linecap, value -> vars_of_stroke_linecap value
+  | Stroke_linejoin, value -> vars_of_stroke_linejoin value
   | Display, value -> vars_of_display value
   | Fill, value -> vars_of_svg_paint value
   | Flex, value -> vars_of_flex value

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1879,6 +1879,16 @@ let matrix =
         negatives = [ "nonzero evenodd"; "even-odd" ];
       };
       {
+        property = "stroke-linecap";
+        positives = [ "butt"; "round"; "square" ];
+        negatives = [ "butt round"; "flat" ];
+      };
+      {
+        property = "stroke-linejoin";
+        positives = [ "miter"; "miter-clip"; "round"; "bevel"; "arcs" ];
+        negatives = [ "miter bevel"; "mitre" ];
+      };
+      {
         property = "unicode-bidi";
         positives = [ "normal"; "embed"; "isolate"; "plaintext" ];
         negatives = [ "normal isolate"; "auto" ];

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -141,6 +141,10 @@ let complex_values () =
   check_declaration ~expected:"fill-rule:evenodd" "fill-rule: evenodd;";
   check_declaration ~expected:"clip-rule:nonzero" "clip-rule: nonzero;";
   check_declaration ~expected:"fill-rule:var(--r)" "fill-rule: var(--r);";
+  (* SVG 2 sec. 13.3. [miter-clip] and [arcs] are the Level 2 additions to
+     [stroke-linejoin]; a reader that takes the grammar takes all five. *)
+  check_declaration ~expected:"stroke-linecap:square" "stroke-linecap: square;";
+  check_declaration ~expected:"stroke-linejoin:arcs" "stroke-linejoin: arcs;";
 
   (* Complex nested functions. Per CSS Values 4 section 10.7 the printer
      simplifies all-constant calc subexpressions, reducing same-unit additions
@@ -2367,7 +2371,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 445
+    "property grammar manifest covers every tracked spec property name" 447
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -190,6 +190,12 @@ let check_svg_paint = check_value_cursor "svg-paint" read_svg_paint pp_svg_paint
 let check_direction = check_value_cursor "direction" read_direction pp_direction
 let check_fill_rule = check_value_cursor "fill-rule" read_fill_rule pp_fill_rule
 
+let check_stroke_linecap =
+  check_value_cursor "stroke-linecap" read_stroke_linecap pp_stroke_linecap
+
+let check_stroke_linejoin =
+  check_value_cursor "stroke-linejoin" read_stroke_linejoin pp_stroke_linejoin
+
 let check_unicode_bidi =
   check_value_cursor "unicode-bidi" read_unicode_bidi pp_unicode_bidi
 
@@ -2819,6 +2825,21 @@ let test_fill_rule () =
   neg_cursor read_fill_rule "even-odd";
   neg_cursor read_fill_rule "nonzero evenodd"
 
+let test_stroke_linecap () =
+  check_stroke_linecap "butt";
+  check_stroke_linecap "round";
+  check_stroke_linecap "square";
+  check_stroke_linecap "var(--c)";
+  neg_cursor read_stroke_linecap "flat"
+
+let test_stroke_linejoin () =
+  check_stroke_linejoin "miter";
+  check_stroke_linejoin "miter-clip";
+  check_stroke_linejoin "round";
+  check_stroke_linejoin "bevel";
+  check_stroke_linejoin "arcs";
+  neg_cursor read_stroke_linejoin "mitre"
+
 let test_unicode_bidi () =
   check_unicode_bidi "normal";
   check_unicode_bidi "embed";
@@ -4215,6 +4236,8 @@ let additional_tests =
     test_case "svg_paint" `Quick test_svg_paint;
     test_case "direction" `Quick test_direction;
     test_case "fill_rule" `Quick test_fill_rule;
+    test_case "stroke_linecap" `Quick test_stroke_linecap;
+    test_case "stroke_linejoin" `Quick test_stroke_linejoin;
     test_case "unicode_bidi" `Quick test_unicode_bidi;
     test_case "writing_mode" `Quick test_writing_mode;
     test_case "webkit_appearance" `Quick test_webkit_appearance;


### PR DESCRIPTION
Both parsed as unknown properties, so their values survived as opaque text.

The reader takes the whole SVG 2 sec. 13.3 grammar, including the `miter-clip` and `arcs` joins Level 2 added: a keyword the property defines is valid CSS whatever any one engine currently does with it, and dropping it would be the worse failure.

Stacked on #234.