### PR TITLE
properties: model stroke-miterlimit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,11 @@
 
 ### New properties and values
 
+- Read `stroke-miterlimit` as the `<number>` SVG 2 sec. 13.3 defines, so it
+  minifies like one (`4.0` is `4`) and a constant `calc()` folds. A value
+  below 1 is out of range, since the limit is a ratio that bottoms out
+  at 1 (#236)
+
 - Read `stroke-linecap` and `stroke-linejoin`, including the SVG 2 sec. 13.3
   additions `miter-clip` and `arcs`. Both parsed as unknown properties (#235)
 

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1647,6 +1647,8 @@ let read_interaction_value : type a.
   | Stroke_linecap -> Some (v Stroke_linecap (Properties.read_stroke_linecap t))
   | Stroke_linejoin ->
       Some (v Stroke_linejoin (Properties.read_stroke_linejoin t))
+  | Stroke_miterlimit ->
+      Some (v Stroke_miterlimit (Properties.read_stroke_miterlimit t))
   | Unicode_bidi -> Some (v Unicode_bidi (read_unicode_bidi t))
   | Writing_mode -> Some (v Writing_mode (read_writing_mode t))
   | Text_combine_upright ->

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4371,6 +4371,28 @@ let normalize_gap : gap -> gap =
            })
   | other -> other
 
+let rec numeric_miterlimit_calc_leaves :
+    stroke_miterlimit calc -> stroke_miterlimit calc = function
+  | Val (Number n) -> Num n
+  | Nested inner -> Nested (numeric_miterlimit_calc_leaves inner)
+  | Parens inner -> Parens (numeric_miterlimit_calc_leaves inner)
+  | Expr (left, op, right) ->
+      Expr
+        ( numeric_miterlimit_calc_leaves left,
+          op,
+          numeric_miterlimit_calc_leaves right )
+  | other -> other
+
+let rec normalize_stroke_miterlimit (value : stroke_miterlimit) :
+    stroke_miterlimit =
+  match value with
+  | Calc c -> (
+      match eval_calc (numeric_miterlimit_calc_leaves c) with
+      | Num f -> Number f
+      | Val v -> normalize_stroke_miterlimit v
+      | folded -> if folded == c then value else Calc folded)
+  | _ -> value
+
 let rec numeric_flex_factor_calc_leaves : flex_factor calc -> flex_factor calc =
   function
   | Val (Number n) -> Num n
@@ -7250,6 +7272,7 @@ let pp_property : type a. a property Pp.t =
   | Clip_rule -> Pp.string ctx "clip-rule"
   | Stroke_linecap -> Pp.string ctx "stroke-linecap"
   | Stroke_linejoin -> Pp.string ctx "stroke-linejoin"
+  | Stroke_miterlimit -> Pp.string ctx "stroke-miterlimit"
   | Stop_color -> Pp.string ctx "stop-color"
   | Flood_color -> Pp.string ctx "flood-color"
   | Lighting_color -> Pp.string ctx "lighting-color"
@@ -9619,6 +9642,17 @@ let rec pp_nav : nav Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_nav ctx v
+
+let rec pp_stroke_miterlimit : stroke_miterlimit Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_stroke_miterlimit ctx v
+  | Number value -> Pp.float ctx value
+  | Calc c -> pp_calc pp_stroke_miterlimit ctx c
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
 
 let rec pp_stroke_linecap : stroke_linecap Pp.t =
  fun ctx -> function
@@ -15312,6 +15346,36 @@ let read_svg_paint t : svg_paint =
     ]
     t
 
+(* SVG 2 sec. 13.3: "A value of zero is invalid; a negative value is an error".
+   The limit is a ratio of miter length to stroke width, and that ratio is 1 at
+   its smallest, so anything below 1 is out of range. Only a literal can be
+   checked here; calc() and var() resolve later. *)
+let read_miterlimit_number t =
+  let value =
+    match (Values.read_number t : Values.number) with
+    | Values.Num value -> value
+    | _ -> Cursor.err_invalid t "stroke-miterlimit must resolve to a number"
+  in
+  if value < 1. then Cursor.err_invalid t "stroke-miterlimit below 1";
+  value
+
+let rec read_stroke_miterlimit t : stroke_miterlimit =
+  Cursor.enum_or_calls "stroke-miterlimit"
+    [
+      ("inherit", (Inherit : stroke_miterlimit));
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~calls:
+      [
+        ("var", fun t -> Var (Values.read_var read_stroke_miterlimit t));
+        ("calc", fun t -> Calc (read_calc read_stroke_miterlimit t));
+      ]
+    ~default:(fun t -> (Number (read_miterlimit_number t) : stroke_miterlimit))
+    t
+
 let rec read_stroke_linecap t : stroke_linecap =
   Cursor.enum_or_var "stroke-linecap"
     [
@@ -19339,6 +19403,7 @@ let read_any_property t =
   | "clip-rule" -> Prop Clip_rule
   | "stroke-linecap" -> Prop Stroke_linecap
   | "stroke-linejoin" -> Prop Stroke_linejoin
+  | "stroke-miterlimit" -> Prop Stroke_miterlimit
   (* SVG 2 sec. 13.4 / Filter Effects 1 sec. 9.3 and 12.2: each is a plain
      <color>, so they minify like any other colour-valued property. *)
   | "stop-color" -> Prop Stop_color
@@ -21368,6 +21433,7 @@ let normalize_property_value : type a.
   | Backdrop_filter -> normalize_filter ~lossless value
   | Webkit_backdrop_filter -> normalize_filter ~lossless value
   | Flex_grow -> normalize_flex_factor value
+  | Stroke_miterlimit -> normalize_stroke_miterlimit value
   | Flex_shrink -> normalize_flex_factor value
   | Flex_basis -> normalize_flex_basis value
   | Flex -> normalize_flex value
@@ -21994,6 +22060,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Clip_rule -> pp pp_fill_rule
   | Stroke_linecap -> pp pp_stroke_linecap
   | Stroke_linejoin -> pp pp_stroke_linejoin
+  | Stroke_miterlimit -> pp pp_stroke_miterlimit
   | Unicode_bidi -> pp pp_unicode_bidi
   | Writing_mode -> pp pp_writing_mode
   | Text_combine_upright -> pp pp_text_combine_upright

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2271,6 +2271,12 @@ val pp_stroke_linejoin : stroke_linejoin Pp.t
 val read_stroke_linejoin : Cursor.t -> stroke_linejoin
 (** [read_stroke_linejoin t] is the [stroke_linejoin] parsed from [t]. *)
 
+val pp_stroke_miterlimit : stroke_miterlimit Pp.t
+(** [pp_stroke_miterlimit] pretty-prints a [stroke-miterlimit]. *)
+
+val read_stroke_miterlimit : Cursor.t -> stroke_miterlimit
+(** [read_stroke_miterlimit t] is the [stroke_miterlimit] parsed from [t]. *)
+
 val pp_unicode_bidi : unicode_bidi Pp.t
 (** [pp_unicode_bidi] is the pretty-printer for [unicode_bidi]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3920,6 +3920,18 @@ type stroke_linejoin =
   | Revert_layer
   | Var of stroke_linejoin var
 
+(** SVG 2 sec. 13.3 [stroke-miterlimit]: the ratio at which a miter join is
+    converted to a bevel. The specification makes a value below 1 invalid. *)
+type stroke_miterlimit =
+  | Number of float
+  | Calc of stroke_miterlimit calc
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of stroke_miterlimit var
+
 (* Direction Types *)
 type direction =
   | Ltr
@@ -4869,6 +4881,7 @@ type 'a property =
   | Clip_rule : fill_rule property
   | Stroke_linecap : stroke_linecap property
   | Stroke_linejoin : stroke_linejoin property
+  | Stroke_miterlimit : stroke_miterlimit property
   | Stop_color : color property
   | Flood_color : color property
   | Lighting_color : color property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1730,6 +1730,9 @@ let vars_of_stroke_linecap (value : Properties.stroke_linecap) =
 let vars_of_stroke_linejoin (value : Properties.stroke_linejoin) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_stroke_miterlimit (value : Properties.stroke_miterlimit) =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_css_wide (value : Properties.css_wide) =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2171,6 +2174,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Clip_rule, value -> vars_of_fill_rule value
   | Stroke_linecap, value -> vars_of_stroke_linecap value
   | Stroke_linejoin, value -> vars_of_stroke_linejoin value
+  | Stroke_miterlimit, value -> vars_of_stroke_miterlimit value
   | Display, value -> vars_of_display value
   | Fill, value -> vars_of_svg_paint value
   | Flex, value -> vars_of_flex value

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1889,6 +1889,11 @@ let matrix =
         negatives = [ "miter bevel"; "mitre" ];
       };
       {
+        property = "stroke-miterlimit";
+        positives = [ "1"; "4"; "10.5"; "calc(2 * 3)" ];
+        negatives = [ ".5"; "-1"; "4px"; "4 4" ];
+      };
+      {
         property = "unicode-bidi";
         positives = [ "normal"; "embed"; "isolate"; "plaintext" ];
         negatives = [ "normal isolate"; "auto" ];

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -145,6 +145,10 @@ let complex_values () =
      [stroke-linejoin]; a reader that takes the grammar takes all five. *)
   check_declaration ~expected:"stroke-linecap:square" "stroke-linecap: square;";
   check_declaration ~expected:"stroke-linejoin:arcs" "stroke-linejoin: arcs;";
+  (* SVG 2 sec. 13.3 makes the miter limit a <number> that cannot go below 1, so
+     it minifies like one and a constant calc() folds. *)
+  check_declaration ~expected:"stroke-miterlimit:4" "stroke-miterlimit: 4.0;";
+  decl_optimizes ~prop:"stroke-miterlimit" ~into:"6" "calc(2 * 3)";
 
   (* Complex nested functions. Per CSS Values 4 section 10.7 the printer
      simplifies all-constant calc subexpressions, reducing same-unit additions
@@ -2371,7 +2375,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 447
+    "property grammar manifest covers every tracked spec property name" 448
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -196,6 +196,10 @@ let check_stroke_linecap =
 let check_stroke_linejoin =
   check_value_cursor "stroke-linejoin" read_stroke_linejoin pp_stroke_linejoin
 
+let check_stroke_miterlimit =
+  check_value_cursor "stroke-miterlimit" read_stroke_miterlimit
+    pp_stroke_miterlimit
+
 let check_unicode_bidi =
   check_value_cursor "unicode-bidi" read_unicode_bidi pp_unicode_bidi
 
@@ -2840,6 +2844,17 @@ let test_stroke_linejoin () =
   check_stroke_linejoin "arcs";
   neg_cursor read_stroke_linejoin "mitre"
 
+let test_stroke_miterlimit () =
+  check_stroke_miterlimit "1";
+  check_stroke_miterlimit "4";
+  check_stroke_miterlimit "10.5";
+  check_stroke_miterlimit "var(--m)";
+  (* The limit is a ratio of miter length to stroke width, which is 1 at its
+     smallest, so the specification makes anything below that invalid. *)
+  neg_cursor read_stroke_miterlimit ".5";
+  neg_cursor read_stroke_miterlimit "-1";
+  neg_cursor read_stroke_miterlimit "4px"
+
 let test_unicode_bidi () =
   check_unicode_bidi "normal";
   check_unicode_bidi "embed";
@@ -4238,6 +4253,7 @@ let additional_tests =
     test_case "fill_rule" `Quick test_fill_rule;
     test_case "stroke_linecap" `Quick test_stroke_linecap;
     test_case "stroke_linejoin" `Quick test_stroke_linejoin;
+    test_case "stroke_miterlimit" `Quick test_stroke_miterlimit;
     test_case "unicode_bidi" `Quick test_unicode_bidi;
     test_case "writing_mode" `Quick test_writing_mode;
     test_case "webkit_appearance" `Quick test_webkit_appearance;


### PR DESCRIPTION
It parsed as an unknown property, so a value as ordinary as `4.0` kept its trailing zero. Typed as the `<number>` SVG 2 sec. 13.3 defines it minifies like one and a constant `calc()` folds.

The limit is a ratio of miter length to stroke width, which bottoms out at 1, so a literal below that is out of range and rejected; `calc()` and `var()` resolve too late to check and pass through.

Stacked on #235.