### PR TITLE
properties: model stroke-dasharray and stroke-dashoffset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -137,6 +137,12 @@
 
 ### New properties and values
 
+- Read `stroke-dasharray` and `stroke-dashoffset`. Both parsed as unknown
+  properties, so their lengths kept a zero unit and a trailing zero that every
+  other length property sheds. SVG 2 sec. 13.3 separates dashes by comma
+  and/or whitespace for one flat pattern, so `4, 2` and `4 2` are one value
+  and print with the shorter separator (#240)
+
 - Read `stroke-miterlimit` as the `<number>` SVG 2 sec. 13.3 defines, so it
   minifies like one (`4.0` is `4`) and a constant `calc()` folds. A value
   below 1 is out of range, since the limit is a ratio that bottoms out

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1649,6 +1649,10 @@ let read_interaction_value : type a.
       Some (v Stroke_linejoin (Properties.read_stroke_linejoin t))
   | Stroke_miterlimit ->
       Some (v Stroke_miterlimit (Properties.read_stroke_miterlimit t))
+  | Stroke_dashoffset ->
+      Some (v Stroke_dashoffset (Properties.read_stroke_dashoffset t))
+  | Stroke_dasharray ->
+      Some (v Stroke_dasharray (Properties.read_stroke_dasharray t))
   | Unicode_bidi -> Some (v Unicode_bidi (read_unicode_bidi t))
   | Writing_mode -> Some (v Writing_mode (read_writing_mode t))
   | Text_combine_upright ->

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4383,6 +4383,29 @@ let rec numeric_miterlimit_calc_leaves :
           numeric_miterlimit_calc_leaves right )
   | other -> other
 
+let normalize_dash_length ~ctx (value : dash_length) : dash_length =
+  match value with
+  | Number _ -> value
+  | Length lp ->
+      let lp' = Values.normalize_length_percentage ~ctx lp in
+      if lp' == lp then value else Length lp'
+
+let normalize_stroke_dashoffset ~ctx (value : stroke_dashoffset) :
+    stroke_dashoffset =
+  match value with
+  | Dash d ->
+      let d' = normalize_dash_length ~ctx d in
+      if d' == d then value else Dash d'
+  | _ -> value
+
+let normalize_stroke_dasharray ~ctx (value : stroke_dasharray) :
+    stroke_dasharray =
+  match value with
+  | Dashes ds ->
+      let ds' = map_preserve (normalize_dash_length ~ctx) ds in
+      if ds' == ds then value else Dashes ds'
+  | _ -> value
+
 let rec normalize_stroke_miterlimit (value : stroke_miterlimit) :
     stroke_miterlimit =
   match value with
@@ -7273,6 +7296,8 @@ let pp_property : type a. a property Pp.t =
   | Stroke_linecap -> Pp.string ctx "stroke-linecap"
   | Stroke_linejoin -> Pp.string ctx "stroke-linejoin"
   | Stroke_miterlimit -> Pp.string ctx "stroke-miterlimit"
+  | Stroke_dashoffset -> Pp.string ctx "stroke-dashoffset"
+  | Stroke_dasharray -> Pp.string ctx "stroke-dasharray"
   | Stop_color -> Pp.string ctx "stop-color"
   | Flood_color -> Pp.string ctx "flood-color"
   | Lighting_color -> Pp.string ctx "lighting-color"
@@ -9642,6 +9667,33 @@ let rec pp_nav : nav Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_nav ctx v
+
+let pp_dash_length : dash_length Pp.t =
+ fun ctx -> function
+  | Number n -> Pp.float ctx n
+  | Length lp -> Values.pp_length_percentage ctx lp
+
+let rec pp_stroke_dashoffset : stroke_dashoffset Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_stroke_dashoffset ctx v
+  | Dash d -> pp_dash_length ctx d
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+
+let rec pp_stroke_dasharray : stroke_dasharray Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_stroke_dasharray ctx v
+  | None -> Pp.string ctx "none"
+  (* Whitespace is the shorter of the two separators the grammar allows. *)
+  | Dashes ds -> Pp.list ~sep:Pp.space pp_dash_length ctx ds
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
 
 let rec pp_stroke_miterlimit : stroke_miterlimit Pp.t =
  fun ctx -> function
@@ -15350,6 +15402,73 @@ let read_svg_paint t : svg_paint =
    The limit is a ratio of miter length to stroke width, and that ratio is 1 at
    its smallest, so anything below 1 is out of range. Only a literal can be
    checked here; calc() and var() resolve later. *)
+(* A bare number is user units; anything with a unit or a percent sign is a
+   <length-percentage>. *)
+let read_dash_length t : dash_length =
+  match Cursor.peek t with
+  | Some (Component.Preserved { kind = Token.Number_tok _; _ }) ->
+      Number (Cursor.number t)
+  (* The grammar is <length-percentage> | <number>, with no keyword branch, so
+     the intrinsic-sizing keywords a bare length would accept are out. *)
+  | _ -> Length (Values.read_length_percentage ~with_keywords:false t)
+
+let rec read_stroke_dashoffset t : stroke_dashoffset =
+  Cursor.enum_or_calls "stroke-dashoffset"
+    [
+      ("inherit", (Inherit : stroke_dashoffset));
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~calls:[ ("var", fun t -> Var (Values.read_var read_stroke_dashoffset t)) ]
+    ~default:(fun t -> (Dash (read_dash_length t) : stroke_dashoffset))
+    t
+
+(* The grammar separates dashes by comma and/or whitespace and the rendered
+   pattern is the flat sequence either way, so both spellings read to one
+   list. *)
+let rec read_stroke_dasharray t : stroke_dasharray =
+  Cursor.enum_or_calls "stroke-dasharray"
+    [
+      ("none", (None : stroke_dasharray));
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~calls:[ ("var", fun t -> Var (Values.read_var read_stroke_dasharray t)) ]
+    ~default:(fun t ->
+      (* Only a numeric token continues the pattern. Anything else ends it, so a
+         trailing [;] or [!important] is left for the caller rather than read as
+         another dash. *)
+      let starts_dash t =
+        match Cursor.peek t with
+        | Some
+            (Component.Preserved
+               {
+                 kind =
+                   Token.Number_tok _ | Token.Percentage _ | Token.Dimension _;
+                 _;
+               }) ->
+            true
+        | _ -> false
+      in
+      let rec go acc =
+        let acc = read_dash_length t :: acc in
+        Cursor.ws t;
+        if Cursor.peek_comma t then begin
+          Cursor.comma t;
+          Cursor.ws t;
+          go acc
+        end
+        else if starts_dash t then go acc
+        else List.rev acc
+      in
+      (Dashes (go []) : stroke_dasharray))
+    t
+
 let read_miterlimit_number t =
   let value =
     match (Values.read_number t : Values.number) with
@@ -19404,6 +19523,8 @@ let read_any_property t =
   | "stroke-linecap" -> Prop Stroke_linecap
   | "stroke-linejoin" -> Prop Stroke_linejoin
   | "stroke-miterlimit" -> Prop Stroke_miterlimit
+  | "stroke-dashoffset" -> Prop Stroke_dashoffset
+  | "stroke-dasharray" -> Prop Stroke_dasharray
   (* SVG 2 sec. 13.4 / Filter Effects 1 sec. 9.3 and 12.2: each is a plain
      <color>, so they minify like any other colour-valued property. *)
   | "stop-color" -> Prop Stop_color
@@ -21434,6 +21555,8 @@ let normalize_property_value : type a.
   | Webkit_backdrop_filter -> normalize_filter ~lossless value
   | Flex_grow -> normalize_flex_factor value
   | Stroke_miterlimit -> normalize_stroke_miterlimit value
+  | Stroke_dashoffset -> normalize_stroke_dashoffset ~ctx value
+  | Stroke_dasharray -> normalize_stroke_dasharray ~ctx value
   | Flex_shrink -> normalize_flex_factor value
   | Flex_basis -> normalize_flex_basis value
   | Flex -> normalize_flex value
@@ -22061,6 +22184,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Stroke_linecap -> pp pp_stroke_linecap
   | Stroke_linejoin -> pp pp_stroke_linejoin
   | Stroke_miterlimit -> pp pp_stroke_miterlimit
+  | Stroke_dashoffset -> pp pp_stroke_dashoffset
+  | Stroke_dasharray -> pp pp_stroke_dasharray
   | Unicode_bidi -> pp pp_unicode_bidi
   | Writing_mode -> pp pp_writing_mode
   | Text_combine_upright -> pp pp_text_combine_upright

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2277,6 +2277,26 @@ val pp_stroke_miterlimit : stroke_miterlimit Pp.t
 val read_stroke_miterlimit : Cursor.t -> stroke_miterlimit
 (** [read_stroke_miterlimit t] is the [stroke_miterlimit] parsed from [t]. *)
 
+val pp_dash_length : dash_length Pp.t
+(** [pp_dash_length] pretty-prints one SVG dash length. *)
+
+val read_dash_length : Cursor.t -> dash_length
+(** [read_dash_length t] is the [dash_length] parsed from [t]. A bare number is
+    in user units; anything carrying a unit or a percent sign is a
+    [<length-percentage>]. *)
+
+val pp_stroke_dashoffset : stroke_dashoffset Pp.t
+(** [pp_stroke_dashoffset] pretty-prints a [stroke-dashoffset]. *)
+
+val read_stroke_dashoffset : Cursor.t -> stroke_dashoffset
+(** [read_stroke_dashoffset t] is the [stroke_dashoffset] parsed from [t]. *)
+
+val pp_stroke_dasharray : stroke_dasharray Pp.t
+(** [pp_stroke_dasharray] pretty-prints a [stroke-dasharray]. *)
+
+val read_stroke_dasharray : Cursor.t -> stroke_dasharray
+(** [read_stroke_dasharray t] is the [stroke_dasharray] parsed from [t]. *)
+
 val pp_unicode_bidi : unicode_bidi Pp.t
 (** [pp_unicode_bidi] is the pretty-printer for [unicode_bidi]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3932,6 +3932,33 @@ type stroke_miterlimit =
   | Revert_layer
   | Var of stroke_miterlimit var
 
+(** SVG 2 sec. 13.3: one dash length. A bare [<number>] is in user units, which
+    is why this is not plain [length_percentage]. *)
+type dash_length = Number of float | Length of length_percentage
+
+(** SVG 2 sec. 13.3 [stroke-dashoffset]. *)
+type stroke_dashoffset =
+  | Dash of dash_length
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of stroke_dashoffset var
+
+(** SVG 2 sec. 13.3 [stroke-dasharray]: [none] or a dash pattern. The grammar
+    separates entries by comma and/or whitespace and the rendered pattern is the
+    flat sequence either way, so both spellings read to one list. *)
+type stroke_dasharray =
+  | None
+  | Dashes of dash_length list
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of stroke_dasharray var
+
 (* Direction Types *)
 type direction =
   | Ltr
@@ -4882,6 +4909,8 @@ type 'a property =
   | Stroke_linecap : stroke_linecap property
   | Stroke_linejoin : stroke_linejoin property
   | Stroke_miterlimit : stroke_miterlimit property
+  | Stroke_dashoffset : stroke_dashoffset property
+  | Stroke_dasharray : stroke_dasharray property
   | Stop_color : color property
   | Flood_color : color property
   | Lighting_color : color property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1733,6 +1733,12 @@ let vars_of_stroke_linejoin (value : Properties.stroke_linejoin) =
 let vars_of_stroke_miterlimit (value : Properties.stroke_miterlimit) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_stroke_dashoffset (value : Properties.stroke_dashoffset) =
+  match value with Var v -> [ V v ] | _ -> []
+
+let vars_of_stroke_dasharray (value : Properties.stroke_dasharray) =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_css_wide (value : Properties.css_wide) =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2175,6 +2181,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Stroke_linecap, value -> vars_of_stroke_linecap value
   | Stroke_linejoin, value -> vars_of_stroke_linejoin value
   | Stroke_miterlimit, value -> vars_of_stroke_miterlimit value
+  | Stroke_dashoffset, value -> vars_of_stroke_dashoffset value
+  | Stroke_dasharray, value -> vars_of_stroke_dasharray value
   | Display, value -> vars_of_display value
   | Fill, value -> vars_of_svg_paint value
   | Flex, value -> vars_of_flex value

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1894,6 +1894,16 @@ let matrix =
         negatives = [ ".5"; "-1"; "4px"; "4 4" ];
       };
       {
+        property = "stroke-dashoffset";
+        positives = [ "0"; "4"; "4px"; "10%"; "-2px" ];
+        negatives = [ "none"; "4 2"; "red" ];
+      };
+      {
+        property = "stroke-dasharray";
+        positives = [ "none"; "4"; "4 2"; "4, 2"; "4px 2px"; "10% 5%" ];
+        negatives = [ "red"; "4 red" ];
+      };
+      {
         property = "unicode-bidi";
         positives = [ "normal"; "embed"; "isolate"; "plaintext" ];
         negatives = [ "normal isolate"; "auto" ];

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -149,6 +149,17 @@ let complex_values () =
      it minifies like one and a constant calc() folds. *)
   check_declaration ~expected:"stroke-miterlimit:4" "stroke-miterlimit: 4.0;";
   decl_optimizes ~prop:"stroke-miterlimit" ~into:"6" "calc(2 * 3)";
+  (* SVG 2 sec. 13.3 separates dashes by comma and/or whitespace and the
+     rendered pattern is the flat sequence either way, so both spellings read to
+     one list and print with the shorter separator. *)
+  check_declaration ~expected:"stroke-dasharray:4 2" "stroke-dasharray: 4, 2;";
+  check_declaration ~expected:"stroke-dasharray:none" "stroke-dasharray: none;";
+  (* A dash length is a <length-percentage> or a bare <number> in user units,
+     and it minifies like every other length. *)
+  decl_optimizes ~prop:"stroke-dashoffset" ~into:"0" "0px";
+  decl_optimizes ~prop:"stroke-dasharray" ~into:"0 4px" "0px 4px";
+  check_declaration ~expected:"stroke-dashoffset:.5px"
+    "stroke-dashoffset: 0.50px;";
 
   (* Complex nested functions. Per CSS Values 4 section 10.7 the printer
      simplifies all-constant calc subexpressions, reducing same-unit additions
@@ -2375,7 +2386,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 448
+    "property grammar manifest covers every tracked spec property name" 450
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -200,6 +200,17 @@ let check_stroke_miterlimit =
   check_value_cursor "stroke-miterlimit" read_stroke_miterlimit
     pp_stroke_miterlimit
 
+let check_dash_length =
+  check_value_cursor "dash-length" read_dash_length pp_dash_length
+
+let check_stroke_dashoffset =
+  check_value_cursor "stroke-dashoffset" read_stroke_dashoffset
+    pp_stroke_dashoffset
+
+let check_stroke_dasharray =
+  check_value_cursor "stroke-dasharray" read_stroke_dasharray
+    pp_stroke_dasharray
+
 let check_unicode_bidi =
   check_value_cursor "unicode-bidi" read_unicode_bidi pp_unicode_bidi
 
@@ -2855,6 +2866,31 @@ let test_stroke_miterlimit () =
   neg_cursor read_stroke_miterlimit "-1";
   neg_cursor read_stroke_miterlimit "4px"
 
+let test_dash_length () =
+  check_dash_length "4";
+  check_dash_length "4px";
+  check_dash_length "10%";
+  neg_cursor read_dash_length "red"
+
+let test_stroke_dashoffset () =
+  check_stroke_dashoffset "0";
+  check_stroke_dashoffset "4";
+  check_stroke_dashoffset "4px";
+  check_stroke_dashoffset "10%";
+  check_stroke_dashoffset "var(--o)";
+  neg_cursor read_stroke_dashoffset "none"
+
+let test_stroke_dasharray () =
+  check_stroke_dasharray "none";
+  check_stroke_dasharray "4";
+  check_stroke_dasharray "4 2";
+  check_stroke_dasharray "4px 2px";
+  check_stroke_dasharray "10% 5%";
+  (* Comma and whitespace are the same separator here. *)
+  check_stroke_dasharray ~expected:"4 2" "4, 2";
+  check_stroke_dasharray "var(--d)";
+  neg_cursor read_stroke_dasharray "red"
+
 let test_unicode_bidi () =
   check_unicode_bidi "normal";
   check_unicode_bidi "embed";
@@ -4254,6 +4290,9 @@ let additional_tests =
     test_case "stroke_linecap" `Quick test_stroke_linecap;
     test_case "stroke_linejoin" `Quick test_stroke_linejoin;
     test_case "stroke_miterlimit" `Quick test_stroke_miterlimit;
+    test_case "dash_length" `Quick test_dash_length;
+    test_case "stroke_dashoffset" `Quick test_stroke_dashoffset;
+    test_case "stroke_dasharray" `Quick test_stroke_dasharray;
     test_case "unicode_bidi" `Quick test_unicode_bidi;
     test_case "writing_mode" `Quick test_writing_mode;
     test_case "webkit_appearance" `Quick test_webkit_appearance;


### PR DESCRIPTION
Both parsed as unknown properties, so their lengths kept a zero unit and a trailing zero that every other length property sheds: `stroke-dashoffset: 0px` is now `0` and `0.50px` is `.5px`, matching `margin` and `stroke-width`.

SVG 2 sec. 13.3 separates dashes by comma and/or whitespace for one flat pattern, so `4, 2` and `4 2` read to the same list and print with the shorter separator. A dash length is a `<length-percentage>` or a bare `<number>` in user units, with no keyword branch, so the intrinsic-sizing keywords a plain length would accept are rejected.

Fourth of the SVG presentation properties left after #214 and #228; `paint-order` and `vector-effect` remain, both set-valued rather than plain enums.