### PR TITLE
properties: model paint-order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -137,6 +137,11 @@
 
 ### New properties and values
 
+- Read `paint-order`, and minify it to the shortest spelling of the same paint
+  order. SVG 2 sec. 13.7 paints an omitted keyword last in the order `normal`
+  would use, so `paint-order: stroke fill markers` is `stroke` (the
+  specification's own example) and `fill stroke markers` is `normal` (#241)
+
 - Read `stroke-dasharray` and `stroke-dashoffset`. Both parsed as unknown
   properties, so their lengths kept a zero unit and a trailing zero that every
   other length property sheds. SVG 2 sec. 13.3 separates dashes by comma

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1653,6 +1653,7 @@ let read_interaction_value : type a.
       Some (v Stroke_dashoffset (Properties.read_stroke_dashoffset t))
   | Stroke_dasharray ->
       Some (v Stroke_dasharray (Properties.read_stroke_dasharray t))
+  | Paint_order -> Some (v Paint_order (Properties.read_paint_order t))
   | Unicode_bidi -> Some (v Unicode_bidi (read_unicode_bidi t))
   | Writing_mode -> Some (v Writing_mode (read_writing_mode t))
   | Text_combine_upright ->

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4383,6 +4383,31 @@ let rec numeric_miterlimit_calc_leaves :
           numeric_miterlimit_calc_leaves right )
   | other -> other
 
+(* SVG 2 sec. 13.7: keywords left out are painted last, in the order [normal]
+   would use. So a value denotes the full order [written @ missing-in-normal-
+   order], and the shortest spelling is the shortest prefix of that order which
+   expands back to it. [fill stroke markers] expands from nothing, so it is
+   [normal]; [stroke fill] expands from [stroke]. *)
+let paint_order_normal : paint_order_keyword list = [ Fill; Stroke; Markers ]
+
+let paint_order_expand (written : paint_order_keyword list) =
+  written @ List.filter (fun k -> not (List.mem k written)) paint_order_normal
+
+let normalize_paint_order (value : paint_order) : paint_order =
+  match value with
+  | Order written ->
+      let full = paint_order_expand written in
+      let rec shortest n =
+        if n > List.length full then value
+        else
+          let prefix = List.filteri (fun i _ -> i < n) full in
+          if paint_order_expand prefix = full then
+            if prefix = [] then (Normal : paint_order) else Order prefix
+          else shortest (n + 1)
+      in
+      shortest 0
+  | _ -> value
+
 let normalize_dash_length ~ctx (value : dash_length) : dash_length =
   match value with
   | Number _ -> value
@@ -7298,6 +7323,7 @@ let pp_property : type a. a property Pp.t =
   | Stroke_miterlimit -> Pp.string ctx "stroke-miterlimit"
   | Stroke_dashoffset -> Pp.string ctx "stroke-dashoffset"
   | Stroke_dasharray -> Pp.string ctx "stroke-dasharray"
+  | Paint_order -> Pp.string ctx "paint-order"
   | Stop_color -> Pp.string ctx "stop-color"
   | Flood_color -> Pp.string ctx "flood-color"
   | Lighting_color -> Pp.string ctx "lighting-color"
@@ -9667,6 +9693,23 @@ let rec pp_nav : nav Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_nav ctx v
+
+let pp_paint_order_keyword : paint_order_keyword Pp.t =
+ fun ctx -> function
+  | Fill -> Pp.string ctx "fill"
+  | Stroke -> Pp.string ctx "stroke"
+  | Markers -> Pp.string ctx "markers"
+
+let rec pp_paint_order : paint_order Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_paint_order ctx v
+  | Normal -> Pp.string ctx "normal"
+  | Order ks -> Pp.list ~sep:Pp.space pp_paint_order_keyword ctx ks
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
 
 let pp_dash_length : dash_length Pp.t =
  fun ctx -> function
@@ -15402,6 +15445,46 @@ let read_svg_paint t : svg_paint =
    The limit is a ratio of miter length to stroke width, and that ratio is 1 at
    its smallest, so anything below 1 is out of range. Only a literal can be
    checked here; calc() and var() resolve later. *)
+let paint_order_keyword_of = function
+  | "fill" -> Some (Fill : paint_order_keyword)
+  | "stroke" -> Some Stroke
+  | "markers" -> Some Markers
+  | _ -> None
+
+let read_paint_order_keyword t : paint_order_keyword =
+  let name = Cursor.ident t in
+  match paint_order_keyword_of name with
+  | Some k -> k
+  | None -> err_invalid_value t "paint-order" name
+
+(* [||] takes each operand at most once, so a repeat ends the list rather than
+   extending it. *)
+let rec read_paint_order t : paint_order =
+  Cursor.enum_or_calls "paint-order"
+    [
+      ("normal", (Normal : paint_order));
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~calls:[ ("var", fun t -> Var (Values.read_var read_paint_order t)) ]
+    ~default:(fun t ->
+      let rec go acc =
+        if List.length acc = 3 then List.rev acc
+        else begin
+          Cursor.ws t;
+          match Option.map paint_order_keyword_of (Cursor.peek_ident t) with
+          | Some (Some k) when not (List.mem k acc) ->
+              let _ = Cursor.ident t in
+              go (k :: acc)
+          | _ -> List.rev acc
+        end
+      in
+      (Order (go [ read_paint_order_keyword t ]) : paint_order))
+    t
+
 (* A bare number is user units; anything with a unit or a percent sign is a
    <length-percentage>. *)
 let read_dash_length t : dash_length =
@@ -19525,6 +19608,7 @@ let read_any_property t =
   | "stroke-miterlimit" -> Prop Stroke_miterlimit
   | "stroke-dashoffset" -> Prop Stroke_dashoffset
   | "stroke-dasharray" -> Prop Stroke_dasharray
+  | "paint-order" -> Prop Paint_order
   (* SVG 2 sec. 13.4 / Filter Effects 1 sec. 9.3 and 12.2: each is a plain
      <color>, so they minify like any other colour-valued property. *)
   | "stop-color" -> Prop Stop_color
@@ -21557,6 +21641,7 @@ let normalize_property_value : type a.
   | Stroke_miterlimit -> normalize_stroke_miterlimit value
   | Stroke_dashoffset -> normalize_stroke_dashoffset ~ctx value
   | Stroke_dasharray -> normalize_stroke_dasharray ~ctx value
+  | Paint_order -> normalize_paint_order value
   | Flex_shrink -> normalize_flex_factor value
   | Flex_basis -> normalize_flex_basis value
   | Flex -> normalize_flex value
@@ -22186,6 +22271,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Stroke_miterlimit -> pp pp_stroke_miterlimit
   | Stroke_dashoffset -> pp pp_stroke_dashoffset
   | Stroke_dasharray -> pp pp_stroke_dasharray
+  | Paint_order -> pp pp_paint_order
   | Unicode_bidi -> pp pp_unicode_bidi
   | Writing_mode -> pp pp_writing_mode
   | Text_combine_upright -> pp pp_text_combine_upright

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2277,6 +2277,19 @@ val pp_stroke_miterlimit : stroke_miterlimit Pp.t
 val read_stroke_miterlimit : Cursor.t -> stroke_miterlimit
 (** [read_stroke_miterlimit t] is the [stroke_miterlimit] parsed from [t]. *)
 
+val pp_paint_order_keyword : paint_order_keyword Pp.t
+(** [pp_paint_order_keyword] pretty-prints one [paint-order] operand. *)
+
+val read_paint_order_keyword : Cursor.t -> paint_order_keyword
+(** [read_paint_order_keyword t] is the [paint_order_keyword] parsed from [t].
+*)
+
+val pp_paint_order : paint_order Pp.t
+(** [pp_paint_order] pretty-prints a [paint-order]. *)
+
+val read_paint_order : Cursor.t -> paint_order
+(** [read_paint_order t] is the [paint_order] parsed from [t]. *)
+
 val pp_dash_length : dash_length Pp.t
 (** [pp_dash_length] pretty-prints one SVG dash length. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3959,6 +3959,24 @@ type stroke_dasharray =
   | Revert_layer
   | Var of stroke_dasharray var
 
+(** SVG 2 sec. 13.7 [paint-order] operand. *)
+type paint_order_keyword = Fill | Stroke | Markers
+
+(** SVG 2 sec. 13.7 [paint-order]: [normal | [ fill || stroke || markers ]]. The
+    written order is the paint order, and any keyword left out is painted last
+    in the order [normal] would use, so a trailing run that already matches
+    [normal] is redundant. Entries are distinct: [||] takes each operand at most
+    once. *)
+type paint_order =
+  | Normal
+  | Order of paint_order_keyword list
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of paint_order var
+
 (* Direction Types *)
 type direction =
   | Ltr
@@ -4911,6 +4929,7 @@ type 'a property =
   | Stroke_miterlimit : stroke_miterlimit property
   | Stroke_dashoffset : stroke_dashoffset property
   | Stroke_dasharray : stroke_dasharray property
+  | Paint_order : paint_order property
   | Stop_color : color property
   | Flood_color : color property
   | Lighting_color : color property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1739,6 +1739,9 @@ let vars_of_stroke_dashoffset (value : Properties.stroke_dashoffset) =
 let vars_of_stroke_dasharray (value : Properties.stroke_dasharray) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_paint_order (value : Properties.paint_order) =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_css_wide (value : Properties.css_wide) =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2183,6 +2186,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Stroke_miterlimit, value -> vars_of_stroke_miterlimit value
   | Stroke_dashoffset, value -> vars_of_stroke_dashoffset value
   | Stroke_dasharray, value -> vars_of_stroke_dasharray value
+  | Paint_order, value -> vars_of_paint_order value
   | Display, value -> vars_of_display value
   | Fill, value -> vars_of_svg_paint value
   | Flex, value -> vars_of_flex value

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1904,6 +1904,19 @@ let matrix =
         negatives = [ "red"; "4 red" ];
       };
       {
+        property = "paint-order";
+        positives =
+          [
+            "normal";
+            "fill";
+            "stroke";
+            "markers";
+            "stroke fill";
+            "markers stroke fill";
+          ];
+        negatives = [ "fill fill"; "normal fill"; "bogus"; "fill bogus" ];
+      };
+      {
         property = "unicode-bidi";
         positives = [ "normal"; "embed"; "isolate"; "plaintext" ];
         negatives = [ "normal isolate"; "auto" ];

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -160,6 +160,15 @@ let complex_values () =
   decl_optimizes ~prop:"stroke-dasharray" ~into:"0 4px" "0px 4px";
   check_declaration ~expected:"stroke-dashoffset:.5px"
     "stroke-dashoffset: 0.50px;";
+  (* SVG 2 sec. 13.7: a keyword left out is painted last, in the order [normal]
+     would use, so the specification's own example is that [paint-order: stroke]
+     equals [paint-order: stroke fill markers]. The shortest spelling is the
+     shortest prefix that expands back to the same order. *)
+  decl_optimizes ~prop:"paint-order" ~into:"stroke" "stroke fill markers";
+  decl_optimizes ~prop:"paint-order" ~into:"normal" "fill stroke markers";
+  decl_optimizes ~prop:"paint-order" ~into:"normal" "fill";
+  (* Reordering the tail is load-bearing, so this one keeps both keywords. *)
+  decl_optimizes ~prop:"paint-order" ~into:"markers stroke" "markers stroke";
 
   (* Complex nested functions. Per CSS Values 4 section 10.7 the printer
      simplifies all-constant calc subexpressions, reducing same-unit additions
@@ -2386,7 +2395,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 450
+    "property grammar manifest covers every tracked spec property name" 451
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -200,6 +200,13 @@ let check_stroke_miterlimit =
   check_value_cursor "stroke-miterlimit" read_stroke_miterlimit
     pp_stroke_miterlimit
 
+let check_paint_order_keyword =
+  check_value_cursor "paint-order-keyword" read_paint_order_keyword
+    pp_paint_order_keyword
+
+let check_paint_order =
+  check_value_cursor "paint-order" read_paint_order pp_paint_order
+
 let check_dash_length =
   check_value_cursor "dash-length" read_dash_length pp_dash_length
 
@@ -2866,6 +2873,20 @@ let test_stroke_miterlimit () =
   neg_cursor read_stroke_miterlimit "-1";
   neg_cursor read_stroke_miterlimit "4px"
 
+let test_paint_order_keyword () =
+  check_paint_order_keyword "fill";
+  check_paint_order_keyword "stroke";
+  check_paint_order_keyword "markers";
+  neg_cursor read_paint_order_keyword "normal"
+
+let test_paint_order () =
+  check_paint_order "normal";
+  check_paint_order "stroke";
+  check_paint_order "markers stroke";
+  check_paint_order "var(--p)";
+  (* [||] takes each operand at most once. *)
+  neg_cursor read_paint_order "bogus"
+
 let test_dash_length () =
   check_dash_length "4";
   check_dash_length "4px";
@@ -4290,6 +4311,8 @@ let additional_tests =
     test_case "stroke_linecap" `Quick test_stroke_linecap;
     test_case "stroke_linejoin" `Quick test_stroke_linejoin;
     test_case "stroke_miterlimit" `Quick test_stroke_miterlimit;
+    test_case "paint_order_keyword" `Quick test_paint_order_keyword;
+    test_case "paint_order" `Quick test_paint_order;
     test_case "dash_length" `Quick test_dash_length;
     test_case "stroke_dashoffset" `Quick test_stroke_dashoffset;
     test_case "stroke_dasharray" `Quick test_stroke_dasharray;


### PR DESCRIPTION
It parsed as an unknown property, so the value survived as opaque text.

SVG 2 sec. 13.7: "the order of the paint operations for painting the element is as given, from left to right. If any of the three keywords are omitted, they are painted last, in the order they would be painted with `paint-order: normal`." A value therefore denotes the written keywords followed by the missing ones in normal order, and the shortest spelling is the shortest prefix that expands back to that same order:

| written | minified |
|---|---|
| `stroke fill markers` | `stroke` (the specification's own example) |
| `fill stroke markers` | `normal` |
| `fill` | `normal` |
| `markers stroke` | unchanged, the tail order is load-bearing |

`||` takes each operand at most once, so `fill fill` is rejected, as are `normal fill` and an unknown keyword.

Stacked on #240.