### PR TITLE
properties: model vector-effect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -137,6 +137,11 @@
 
 ### New properties and values
 
+- Read `vector-effect`, the last of the SVG presentation properties that parsed
+  as unknown. SVG 2 sec. 7.10 makes `viewport` what an omitted host space
+  means, so `non-scaling-stroke viewport` minifies to `non-scaling-stroke`;
+  `screen` is kept (#242)
+
 - Read `paint-order`, and minify it to the shortest spelling of the same paint
   order. SVG 2 sec. 13.7 paints an omitted keyword last in the order `normal`
   would use, so `paint-order: stroke fill markers` is `stroke` (the

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1654,6 +1654,7 @@ let read_interaction_value : type a.
   | Stroke_dasharray ->
       Some (v Stroke_dasharray (Properties.read_stroke_dasharray t))
   | Paint_order -> Some (v Paint_order (Properties.read_paint_order t))
+  | Vector_effect -> Some (v Vector_effect (Properties.read_vector_effect t))
   | Unicode_bidi -> Some (v Unicode_bidi (read_unicode_bidi t))
   | Writing_mode -> Some (v Writing_mode (read_writing_mode t))
   | Text_combine_upright ->

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4393,6 +4393,13 @@ let paint_order_normal : paint_order_keyword list = [ Fill; Stroke; Markers ]
 let paint_order_expand (written : paint_order_keyword list) =
   written @ List.filter (fun k -> not (List.mem k written)) paint_order_normal
 
+(* SVG 2 sec. 7.10: [viewport] is what an omitted space means, so writing it is
+   redundant. *)
+let normalize_vector_effect (value : vector_effect) : vector_effect =
+  match value with
+  | Effects (ks, Some Viewport) -> Effects (ks, Option.None)
+  | _ -> value
+
 let normalize_paint_order (value : paint_order) : paint_order =
   match value with
   | Order written ->
@@ -7324,6 +7331,7 @@ let pp_property : type a. a property Pp.t =
   | Stroke_dashoffset -> Pp.string ctx "stroke-dashoffset"
   | Stroke_dasharray -> Pp.string ctx "stroke-dasharray"
   | Paint_order -> Pp.string ctx "paint-order"
+  | Vector_effect -> Pp.string ctx "vector-effect"
   | Stop_color -> Pp.string ctx "stop-color"
   | Flood_color -> Pp.string ctx "flood-color"
   | Lighting_color -> Pp.string ctx "lighting-color"
@@ -9693,6 +9701,35 @@ let rec pp_nav : nav Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_nav ctx v
+
+let pp_vector_effect_keyword : vector_effect_keyword Pp.t =
+ fun ctx -> function
+  | Non_scaling_stroke -> Pp.string ctx "non-scaling-stroke"
+  | Non_scaling_size -> Pp.string ctx "non-scaling-size"
+  | Non_rotation -> Pp.string ctx "non-rotation"
+  | Fixed_position -> Pp.string ctx "fixed-position"
+
+let pp_vector_effect_space : vector_effect_space Pp.t =
+ fun ctx -> function
+  | Viewport -> Pp.string ctx "viewport"
+  | Screen -> Pp.string ctx "screen"
+
+let rec pp_vector_effect : vector_effect Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_vector_effect ctx v
+  | None -> Pp.string ctx "none"
+  | Effects (ks, space) -> (
+      Pp.list ~sep:Pp.space pp_vector_effect_keyword ctx ks;
+      match space with
+      | Some s ->
+          Pp.space ctx ();
+          pp_vector_effect_space ctx s
+      | Option.None -> ())
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
 
 let pp_paint_order_keyword : paint_order_keyword Pp.t =
  fun ctx -> function
@@ -15445,6 +15482,62 @@ let read_svg_paint t : svg_paint =
    The limit is a ratio of miter length to stroke width, and that ratio is 1 at
    its smallest, so anything below 1 is out of range. Only a literal can be
    checked here; calc() and var() resolve later. *)
+let vector_effect_keyword_of = function
+  | "non-scaling-stroke" -> Some (Non_scaling_stroke : vector_effect_keyword)
+  | "non-scaling-size" -> Some Non_scaling_size
+  | "non-rotation" -> Some Non_rotation
+  | "fixed-position" -> Some Fixed_position
+  | _ -> Option.None
+
+let vector_effect_space_of = function
+  | "viewport" -> Some (Viewport : vector_effect_space)
+  | "screen" -> Some Screen
+  | _ -> Option.None
+
+let read_vector_effect_keyword t : vector_effect_keyword =
+  let name = Cursor.ident t in
+  match vector_effect_keyword_of name with
+  | Some k -> k
+  | Option.None -> err_invalid_value t "vector-effect" name
+
+let read_vector_effect_space t : vector_effect_space =
+  let name = Cursor.ident t in
+  match vector_effect_space_of name with
+  | Some s -> s
+  | Option.None -> err_invalid_value t "vector-effect" name
+
+(* [ <effect> ]+ then an optional space keyword, so an ident that names a space
+   ends the effect run. *)
+let rec read_vector_effect t : vector_effect =
+  Cursor.enum_or_calls "vector-effect"
+    [
+      ("none", (None : vector_effect));
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~calls:[ ("var", fun t -> Var (Values.read_var read_vector_effect t)) ]
+    ~default:(fun t ->
+      let rec go acc =
+        Cursor.ws t;
+        match Option.map vector_effect_keyword_of (Cursor.peek_ident t) with
+        | Some (Some k) ->
+            let _ = Cursor.ident t in
+            go (k :: acc)
+        | _ -> List.rev acc
+      in
+      let effects = go [ read_vector_effect_keyword t ] in
+      Cursor.ws t;
+      let space =
+        match Option.map vector_effect_space_of (Cursor.peek_ident t) with
+        | Some (Some _) -> Some (read_vector_effect_space t)
+        | _ -> Option.None
+      in
+      (Effects (effects, space) : vector_effect))
+    t
+
 let paint_order_keyword_of = function
   | "fill" -> Some (Fill : paint_order_keyword)
   | "stroke" -> Some Stroke
@@ -19609,6 +19702,7 @@ let read_any_property t =
   | "stroke-dashoffset" -> Prop Stroke_dashoffset
   | "stroke-dasharray" -> Prop Stroke_dasharray
   | "paint-order" -> Prop Paint_order
+  | "vector-effect" -> Prop Vector_effect
   (* SVG 2 sec. 13.4 / Filter Effects 1 sec. 9.3 and 12.2: each is a plain
      <color>, so they minify like any other colour-valued property. *)
   | "stop-color" -> Prop Stop_color
@@ -21642,6 +21736,7 @@ let normalize_property_value : type a.
   | Stroke_dashoffset -> normalize_stroke_dashoffset ~ctx value
   | Stroke_dasharray -> normalize_stroke_dasharray ~ctx value
   | Paint_order -> normalize_paint_order value
+  | Vector_effect -> normalize_vector_effect value
   | Flex_shrink -> normalize_flex_factor value
   | Flex_basis -> normalize_flex_basis value
   | Flex -> normalize_flex value
@@ -22272,6 +22367,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Stroke_dashoffset -> pp pp_stroke_dashoffset
   | Stroke_dasharray -> pp pp_stroke_dasharray
   | Paint_order -> pp pp_paint_order
+  | Vector_effect -> pp pp_vector_effect
   | Unicode_bidi -> pp pp_unicode_bidi
   | Writing_mode -> pp pp_writing_mode
   | Text_combine_upright -> pp pp_text_combine_upright

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2277,6 +2277,26 @@ val pp_stroke_miterlimit : stroke_miterlimit Pp.t
 val read_stroke_miterlimit : Cursor.t -> stroke_miterlimit
 (** [read_stroke_miterlimit t] is the [stroke_miterlimit] parsed from [t]. *)
 
+val pp_vector_effect_keyword : vector_effect_keyword Pp.t
+(** [pp_vector_effect_keyword] pretty-prints one [vector-effect] operand. *)
+
+val read_vector_effect_keyword : Cursor.t -> vector_effect_keyword
+(** [read_vector_effect_keyword t] is the [vector_effect_keyword] parsed from
+    [t]. *)
+
+val pp_vector_effect_space : vector_effect_space Pp.t
+(** [pp_vector_effect_space] pretty-prints a [vector-effect] host space. *)
+
+val read_vector_effect_space : Cursor.t -> vector_effect_space
+(** [read_vector_effect_space t] is the [vector_effect_space] parsed from [t].
+*)
+
+val pp_vector_effect : vector_effect Pp.t
+(** [pp_vector_effect] pretty-prints a [vector-effect]. *)
+
+val read_vector_effect : Cursor.t -> vector_effect
+(** [read_vector_effect t] is the [vector_effect] parsed from [t]. *)
+
 val pp_paint_order_keyword : paint_order_keyword Pp.t
 (** [pp_paint_order_keyword] pretty-prints one [paint-order] operand. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3977,6 +3977,30 @@ type paint_order =
   | Revert_layer
   | Var of paint_order var
 
+(** SVG 2 sec. 7.10 [vector-effect] operand. *)
+type vector_effect_keyword =
+  | Non_scaling_stroke
+  | Non_scaling_size
+  | Non_rotation
+  | Fixed_position
+
+(** SVG 2 sec. 7.10 host coordinate space for a vector effect. [viewport] is
+    what an omitted space means. *)
+type vector_effect_space = Viewport | Screen
+
+(** SVG 2 sec. 7.10 [vector-effect]:
+    [none | [ non-scaling-stroke | non-scaling-size | non-rotation |
+     fixed-position ]+ [ viewport | screen ]?]. *)
+type vector_effect =
+  | None
+  | Effects of vector_effect_keyword list * vector_effect_space option
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of vector_effect var
+
 (* Direction Types *)
 type direction =
   | Ltr
@@ -4930,6 +4954,7 @@ type 'a property =
   | Stroke_dashoffset : stroke_dashoffset property
   | Stroke_dasharray : stroke_dasharray property
   | Paint_order : paint_order property
+  | Vector_effect : vector_effect property
   | Stop_color : color property
   | Flood_color : color property
   | Lighting_color : color property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1742,6 +1742,9 @@ let vars_of_stroke_dasharray (value : Properties.stroke_dasharray) =
 let vars_of_paint_order (value : Properties.paint_order) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_vector_effect (value : Properties.vector_effect) =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_css_wide (value : Properties.css_wide) =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2187,6 +2190,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Stroke_dashoffset, value -> vars_of_stroke_dashoffset value
   | Stroke_dasharray, value -> vars_of_stroke_dasharray value
   | Paint_order, value -> vars_of_paint_order value
+  | Vector_effect, value -> vars_of_vector_effect value
   | Display, value -> vars_of_display value
   | Fill, value -> vars_of_svg_paint value
   | Flex, value -> vars_of_flex value

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1904,6 +1904,20 @@ let matrix =
         negatives = [ "red"; "4 red" ];
       };
       {
+        property = "vector-effect";
+        positives =
+          [
+            "none";
+            "non-scaling-stroke";
+            "non-scaling-size";
+            "non-rotation";
+            "fixed-position";
+            "non-scaling-stroke screen";
+            "non-scaling-stroke fixed-position";
+          ];
+        negatives = [ "bogus"; "screen"; "none non-scaling-stroke" ];
+      };
+      {
         property = "paint-order";
         positives =
           [

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -169,6 +169,12 @@ let complex_values () =
   decl_optimizes ~prop:"paint-order" ~into:"normal" "fill";
   (* Reordering the tail is load-bearing, so this one keeps both keywords. *)
   decl_optimizes ~prop:"paint-order" ~into:"markers stroke" "markers stroke";
+  (* SVG 2 sec. 7.10 makes [viewport] what an omitted host space means, so
+     writing it is redundant; [screen] is not. *)
+  decl_optimizes ~prop:"vector-effect" ~into:"non-scaling-stroke"
+    "non-scaling-stroke viewport";
+  decl_optimizes ~prop:"vector-effect" ~into:"non-scaling-stroke screen"
+    "non-scaling-stroke screen";
 
   (* Complex nested functions. Per CSS Values 4 section 10.7 the printer
      simplifies all-constant calc subexpressions, reducing same-unit additions
@@ -2395,7 +2401,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 451
+    "property grammar manifest covers every tracked spec property name" 452
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -200,6 +200,17 @@ let check_stroke_miterlimit =
   check_value_cursor "stroke-miterlimit" read_stroke_miterlimit
     pp_stroke_miterlimit
 
+let check_vector_effect_keyword =
+  check_value_cursor "vector-effect-keyword" read_vector_effect_keyword
+    pp_vector_effect_keyword
+
+let check_vector_effect_space =
+  check_value_cursor "vector-effect-space" read_vector_effect_space
+    pp_vector_effect_space
+
+let check_vector_effect =
+  check_value_cursor "vector-effect" read_vector_effect pp_vector_effect
+
 let check_paint_order_keyword =
   check_value_cursor "paint-order-keyword" read_paint_order_keyword
     pp_paint_order_keyword
@@ -2873,6 +2884,26 @@ let test_stroke_miterlimit () =
   neg_cursor read_stroke_miterlimit "-1";
   neg_cursor read_stroke_miterlimit "4px"
 
+let test_vector_effect_keyword () =
+  check_vector_effect_keyword "non-scaling-stroke";
+  check_vector_effect_keyword "non-scaling-size";
+  check_vector_effect_keyword "non-rotation";
+  check_vector_effect_keyword "fixed-position";
+  neg_cursor read_vector_effect_keyword "screen"
+
+let test_vector_effect_space () =
+  check_vector_effect_space "viewport";
+  check_vector_effect_space "screen";
+  neg_cursor read_vector_effect_space "non-scaling-stroke"
+
+let test_vector_effect () =
+  check_vector_effect "none";
+  check_vector_effect "non-scaling-stroke";
+  check_vector_effect "non-scaling-stroke screen";
+  check_vector_effect "non-scaling-stroke fixed-position";
+  check_vector_effect "var(--v)";
+  neg_cursor read_vector_effect "bogus"
+
 let test_paint_order_keyword () =
   check_paint_order_keyword "fill";
   check_paint_order_keyword "stroke";
@@ -4311,6 +4342,9 @@ let additional_tests =
     test_case "stroke_linecap" `Quick test_stroke_linecap;
     test_case "stroke_linejoin" `Quick test_stroke_linejoin;
     test_case "stroke_miterlimit" `Quick test_stroke_miterlimit;
+    test_case "vector_effect_keyword" `Quick test_vector_effect_keyword;
+    test_case "vector_effect_space" `Quick test_vector_effect_space;
+    test_case "vector_effect" `Quick test_vector_effect;
     test_case "paint_order_keyword" `Quick test_paint_order_keyword;
     test_case "paint_order" `Quick test_paint_order;
     test_case "dash_length" `Quick test_dash_length;


### PR DESCRIPTION
The last of the SVG presentation properties that parsed as unknown after #214 and #228.

SVG 2 sec. 7.10 gives `none | [ non-scaling-stroke | non-scaling-size | non-rotation | fixed-position ]+ [ viewport | screen ]?`, and `viewport` is what an omitted host space means, so `non-scaling-stroke viewport` minifies to `non-scaling-stroke`. `screen` is kept.

With this the whole batch is typed. On a rule using all nine, minified output goes from

```css
stroke-dashoffset:0px;stroke-miterlimit:4.0;paint-order:fill stroke markers
```

to

```css
stroke-dashoffset:0;stroke-miterlimit:4;paint-order:normal
```

Stacked on #241.