### PR TITLE
rule_graph: walk sorted branch lists in step

### DIFF
--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -149,6 +149,7 @@ let selectors_order_conflict ?(closed_world = false) selectors_a summaries_a
 (* Canonical, list-order-independent branch strings of a selector: canonicalize
    each comma branch, then sort. [.foo,.bar] and [.bar,.foo] yield the same
    list. *)
+(* Sorted, which is what lets [share_branch] merge-walk two of these. *)
 let selector_branch_keys selectors =
   selectors
   |> List.map (fun s ->
@@ -158,9 +159,21 @@ let selector_branch_keys selectors =
 (* Two rules share a selector branch when a factoring produced one as a residual
    of the other (e.g. [.a] and [.a,.b]) or they are the same selector. Such
    rules are pinned so a factored group stays contiguous and its declaration
-   order is left to the declaration canonicalization. *)
-let share_branch a b =
-  List.exists (fun branch -> List.exists (String.equal branch) b) a
+   order is left to the declaration canonicalization.
+
+   Both arguments come from [selector_branch_keys], which sorts, so this walks
+   the two in step rather than scanning one per element of the other: linear
+   instead of quadratic, and it allocates nothing, where the nested
+   [List.exists] built a closure per element of the left list and a partial
+   application per pair. *)
+let rec share_branch a b =
+  match (a, b) with
+  | [], _ | _, [] -> false
+  | x :: xs, y :: ys ->
+      let c = String.compare x y in
+      if c = 0 then true
+      else if c < 0 then share_branch xs b
+      else share_branch a ys
 
 let declaration_size decl = Pp.size ~minify:true Declaration.pp_declaration decl
 


### PR DESCRIPTION
`share_branch` scanned one list per element of the other, building a closure per element of the left list and a partial application of `String.equal` per pair. Both lists come from `selector_branch_keys`, which ends in `List.sort String.compare`, so a merge walk answers the same question in one pass and allocates nothing.

Sortedness holds at every call site: both producers are `Array.map selector_branch_keys selectors` (`of_rules`, and the rewrite path), and every consumer reads `t.branches` or `p_branches`.

`obs` ranked this site #2 at 4.6% of all allocation before the change, independently confirming the 4.8% the TODO recorded. On `nytimes-stripmq-yui.css` with release binaries the site goes to zero:

```
rule_graph.ml:163   31.28 MB -> 0 B  (-100%)
baseline_total=679.78 MB  current_total=639.34 MB  delta=-5.9%
```

Corpus-wide the time win is small. The full interleaved sweep over all 504 SatCSS fixtures:

```
cascade cpu    : 138.65s
baseline cpu   : 140.04s
ratio          : 0.990x  (below 1 is faster)
output         : byte-identical on every file
```

1%, not the 29% wall-clock drop that one file showed under memtrace, which is the reason the sweep is the gate rather than a single profile. The allocation removal and the quadratic-to-linear change are real; the corpus is simply not dominated by this site. Byte-identical output on every file is the property that makes it safe.