### PR TITLE
lexer: read any non-ASCII ident code point by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,14 @@
 
 ### Parsing
 
+- A non-ASCII identifier is read as any code point at or above U+0080, so a
+  selector such as `.text-\u{2197}` parses instead of being dropped with a
+  warning. `Css.of_string` takes `?enforce_spec` and `cascade` takes
+  `--enforce-spec` to restrict identifiers to the CSS Syntax 3 sec. 4.2 range
+  list, which excludes most BMP symbols. Output is unaffected either way: a
+  code point outside the range list is hex-escaped, so `.text-\u{2197}` and
+  `.text-\2197` read to the same selector and compare equal (#252)
+
 - Read `perspective: none` and `text-underline-offset: auto`, and allow a
   negative `text-underline-offset`. Both keywords are the properties' own
   grammar (and `none` is `perspective`'s initial value), but the readers took

--- a/bin/cli_io.ml
+++ b/bin/cli_io.ml
@@ -18,8 +18,8 @@ let read_stdin () =
     Buffer.contents buf
   with End_of_file -> Buffer.contents buf
 
-let parse_css ~filename css =
-  match Css.of_string ~filename css with
+let parse_css ?(enforce_spec = false) ~filename css =
+  match Css.of_string ~filename ~enforce_spec css with
   | Ok { Css.stylesheet; warnings } ->
       List.iter
         (fun w ->
@@ -34,10 +34,10 @@ let parse_css ~filename css =
       Fmt.epr "warning: %s: parse failed, dropping content@." filename;
       Css.empty
 
-let read_input path =
+let read_input ?enforce_spec path =
   let css = if path = "-" then read_stdin () else read_file path in
   let filename = if path = "-" then "<stdin>" else path in
-  parse_css ~filename css
+  parse_css ?enforce_spec ~filename css
 
 let split_comma s =
   String.split_on_char ',' s |> List.map String.trim

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -80,7 +80,7 @@ let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
     ~enforce_spec ~closed_world ~objective ~inline_imports_flag
     ~inline_vars_flag ~keep_vars ~profile =
   try
-    let stylesheet = Cli_io.read_input input_path in
+    let stylesheet = Cli_io.read_input ~enforce_spec input_path in
     let stylesheet =
       if inline_imports_flag then resolve_inline_imports ~input_path stylesheet
       else stylesheet

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -812,10 +812,12 @@ let vars_of_rules statements =
 type parse = { stylesheet : t; warnings : Error.t list }
 
 let of_string ?(strict = false) ?(filename = "<string>")
-    ?(meta = Loc.default_meta_level) css =
+    ?(meta = Loc.default_meta_level) ?(enforce_spec = false) css =
   let stamp e = Error.with_filename ~filename e in
   try
-    let stylesheet, warnings = Stylesheet.parse_stylesheet_partial ~meta css in
+    let stylesheet, warnings =
+      Stylesheet.parse_stylesheet_partial ~meta ~enforce_spec css
+    in
     let warnings = List.map stamp warnings in
     if strict then
       match warnings with
@@ -824,8 +826,8 @@ let of_string ?(strict = false) ?(filename = "<string>")
     else Ok { stylesheet; warnings }
   with Error.Parse_error error -> Error (stamp error)
 
-let of_string_exn ?strict ?filename ?meta css =
-  match of_string ?strict ?filename ?meta css with
+let of_string_exn ?strict ?filename ?meta ?enforce_spec css =
+  match of_string ?strict ?filename ?meta ?enforce_spec css with
   | Ok { stylesheet; _ } -> stylesheet
   | Error error -> Error.fail error
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7662,6 +7662,7 @@ val of_string :
   ?strict:bool ->
   ?filename:string ->
   ?meta:Loc.meta_level ->
+  ?enforce_spec:bool ->
   string ->
   (parse, Error.t) result
 (** [of_string ?strict css] parses [css] with CSS Syntax 3 section 5.4 recovery.
@@ -7671,10 +7672,20 @@ val of_string :
     [~strict:true] a non-empty {!field-warnings} list collapses to [Error]
     (first warning) - useful in linters and CI gates that want to fail on any
     spec deviation. [?meta] controls diagnostic richness; see {!Loc.meta_level}.
-*)
+
+    [enforce_spec] (default [false]) restricts non-ASCII identifiers to the CSS
+    Syntax 3 sec. 4.2 range list, which excludes most BMP symbols. The default
+    accepts any code point [>= U+0080], so a selector such as [.text-\u{2197}]
+    reads rather than being dropped with a warning. Output is unaffected either
+    way: a code point outside the range list is hex-escaped. *)
 
 val of_string_exn :
-  ?strict:bool -> ?filename:string -> ?meta:Loc.meta_level -> string -> t
+  ?strict:bool ->
+  ?filename:string ->
+  ?meta:Loc.meta_level ->
+  ?enforce_spec:bool ->
+  string ->
+  t
 (** [of_string_exn ?strict css] parses [css] like {!of_string}, raises
     {!Error.Parse_error} instead of returning [Error], and discards the
     {!field-warnings} list. In non-strict mode warnings are silently dropped;

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -21,7 +21,7 @@ type t = {
 and save = { trace : Token.t list ref; saved_history : Token.t list }
 
 let of_reader reader = { reader; buffer = []; history = []; saves = [] }
-let of_string s = of_reader (Reader.of_string s)
+let of_string ?enforce_spec s = of_reader (Reader.of_string ?enforce_spec s)
 let source t = Reader.source t.reader
 
 (** {1 Tokenization} *)
@@ -33,10 +33,16 @@ let is_hex c = is_digit c || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
 let is_ws c = c = ' ' || c = '\n' || c = '\t' || c = '\r' || c = '\012'
 let is_newline c = c = '\n' || c = '\r' || c = '\012'
 
-(* CSS Syntax 3 section 4.2 "non-ASCII ident code point" ranges. A sealed check,
-   so a byte-level [>= 0x80] heuristic can't over-accept code points the spec
-   excludes (most symbols, emoji, BMP non-characters). *)
-let is_non_ascii_ident_cp cp =
+(* CSS Syntax 3 section 4.2 "non-ASCII ident code point" ranges: a sealed list
+   that excludes most BMP symbols, among them the arrows.
+
+   Real stylesheets carry those anyway - Tailwind emits [.text-\u{2197}] - and
+   dropping a rule is a worse failure for a minifier than accepting a code point
+   the list omits, so reading takes any code point >= U+0080 by default and this
+   list is what [~enforce_spec:true] selects. Writing is unaffected: a code
+   point outside the list is emitted as a hex escape, which every parser
+   reads. *)
+let spec_non_ascii_ident_cp cp =
   cp = 0xB7
   || (cp >= 0xC0 && cp <= 0xD6)
   || (cp >= 0xD8 && cp <= 0xF6)
@@ -49,6 +55,9 @@ let is_non_ascii_ident_cp cp =
   || (cp >= 0xF900 && cp <= 0xFDCF)
   || (cp >= 0xFDF0 && cp <= 0xFFFD)
   || cp >= 0x10000
+
+let is_non_ascii_ident_cp r cp =
+  (not (Reader.enforce_spec r)) || spec_non_ascii_ident_cp cp
 
 (* [is_name_start_byte] answers the ASCII fast-path only. Callers that have a
    byte [>= 0x80] must decode and consult [is_non_ascii_ident_cp] directly. *)
@@ -64,7 +73,7 @@ let is_name_start_at r offset =
   else
     match Reader.peek_utf8_at r offset with
     | None -> false
-    | Some (cp, _) -> is_non_ascii_ident_cp cp
+    | Some (cp, _) -> is_non_ascii_ident_cp r cp
 
 (* [is_name_at r offset] is ident-start or digit or [-]. *)
 let is_name_at r offset =
@@ -76,7 +85,7 @@ let is_name_at r offset =
   else
     match Reader.peek_utf8_at r offset with
     | None -> false
-    | Some (cp, _) -> is_non_ascii_ident_cp cp
+    | Some (cp, _) -> is_non_ascii_ident_cp r cp
 
 (* Byte-level helpers for hot paths where the caller already has the byte. ASCII
    matches spec; [>= 0x80] is conservative (reject), so callers that may see
@@ -214,7 +223,7 @@ let rec scan_ident_fast r src src_len =
     else
       match Reader.peek_utf8_at r 0 with
       | None -> `End
-      | Some (cp, nbytes) when is_non_ascii_ident_cp cp ->
+      | Some (cp, nbytes) when is_non_ascii_ident_cp r cp ->
           for _ = 1 to nbytes do
             Reader.skip r
           done;

--- a/lib/lexer.mli
+++ b/lib/lexer.mli
@@ -13,9 +13,9 @@ type t
 val of_reader : Reader.t -> t
 (** [of_reader r] wraps an existing character reader. *)
 
-val of_string : string -> t
+val of_string : ?enforce_spec:bool -> string -> t
 (** [of_string s] builds a fresh reader from an already-decoded UTF-8 string and
-    wraps it. *)
+    wraps it. [enforce_spec] is passed to {!Reader.of_string}. *)
 
 val source : t -> string
 (** [source t] is the full input string the underlying reader was built from. *)
@@ -50,8 +50,9 @@ val commit : t -> unit
 val is_done : t -> bool
 (** [is_done t] is [true] when no more tokens remain. *)
 
-val is_non_ascii_ident_cp : int -> bool
-(** [is_non_ascii_ident_cp cp] is the CSS Syntax section 4.2 predicate: is [cp]
-    one of the non-ASCII code points allowed inside an ident sequence? Exposed
-    for serialisers that decide whether to emit a code point verbatim or
-    hex-escape it. *)
+val spec_non_ascii_ident_cp : int -> bool
+(** [spec_non_ascii_ident_cp cp] is the CSS Syntax section 4.2 predicate: is
+    [cp] in that section's range list of non-ASCII ident code points? Exposed
+    for serialisers, which hex-escape anything outside it; an escape is read by
+    every parser, so emission stays on this list even though reading accepts any
+    code point [>= U+0080] unless [~enforce_spec:true]. *)

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -124,7 +124,7 @@ let escape_ident_emit_cp buf ~needs_leading_escape u =
   if needs_leading_escape then add_hex_escape_cp buf cp
   else if cp < 0x20 || cp = 0x7F then add_hex_escape_cp buf cp
   else if cp < 0x80 then escape_ident_emit_ascii buf cp
-  else if Lexer.is_non_ascii_ident_cp cp then Uutf.Buffer.add_utf_8 buf u
+  else if Lexer.spec_non_ascii_ident_cp cp then Uutf.Buffer.add_utf_8 buf u
   else add_hex_escape_cp buf cp
 
 let escape_ident_starts s n =

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -3,6 +3,11 @@
 type t = {
   input : string;
   len : int;
+  (* Restrict non-ASCII identifiers to the CSS Syntax 3 sec. 4.2 range list
+     rather than accepting any code point >= U+0080. Rides on the reader so
+     every [_at] predicate reaches it without threading a parameter through the
+     tokenizer. *)
+  enforce_spec : bool;
   mutable pos : int;
   mutable saved : int list; (* Stack of saved positions for backtracking *)
   mutable call_stack : string list; (* Stack of parsing contexts for debugging *)
@@ -103,11 +108,19 @@ let preprocess input =
   if (not bom) && not (needs_preprocess input len 0) then input
   else copy_preprocessed input len start
 
-let of_string input =
+let of_string ?(enforce_spec = false) input =
   let input = preprocess input in
-  { input; len = String.length input; pos = 0; saved = []; call_stack = [] }
+  {
+    input;
+    len = String.length input;
+    enforce_spec;
+    pos = 0;
+    saved = [];
+    call_stack = [];
+  }
 
 let source t = t.input
+let enforce_spec t = t.enforce_spec
 let is_done t = t.pos >= t.len
 
 let utf8_byte_length cp =

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -33,8 +33,14 @@ val pp_parse_error : parse_error -> string
 
 (** {1 Core} *)
 
-val of_string : string -> t
-(** [of_string s] creates a parser from an already-decoded UTF-8 string. *)
+val of_string : ?enforce_spec:bool -> string -> t
+(** [of_string s] creates a parser from an already-decoded UTF-8 string.
+    [enforce_spec] (default [false]) restricts non-ASCII identifiers to the CSS
+    Syntax 3 sec. 4.2 range list. *)
+
+val enforce_spec : t -> bool
+(** [enforce_spec t] is the identifier rule [t] was built with; see
+    {!val-of_string}. *)
 
 val source : t -> string
 (** [source t] is the full input string the reader was built from. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3792,9 +3792,9 @@ let extract_bang_comments (source : string) : (int * string) list =
 
 (* Top-level partial-recovery entry point: combine section 5.3 syntax warnings
    from [Parser.stylesheet] with per-rule typed-validation warnings. *)
-let parse_stylesheet_partial ?(meta = Loc.default_meta_level) (source : string)
-    : stylesheet * Error.t list =
-  let reader = Reader.of_string source in
+let parse_stylesheet_partial ?(meta = Loc.default_meta_level)
+    ?(enforce_spec = false) (source : string) : stylesheet * Error.t list =
+  let reader = Reader.of_string ~enforce_spec source in
   let out = Parser.stylesheet ~meta reader in
   let sheet, typed_warnings =
     read_stylesheet_of_rules ~source:(Reader.source reader) ~meta out.value

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -246,7 +246,10 @@ val read_stylesheet_of_rules :
     snippets. *)
 
 val parse_stylesheet_partial :
-  ?meta:Loc.meta_level -> string -> stylesheet * Error.t list
+  ?meta:Loc.meta_level ->
+  ?enforce_spec:bool ->
+  string ->
+  stylesheet * Error.t list
 (** [parse_stylesheet_partial ?meta source] runs section 5.3 recovery via
     {!Parser.stylesheet} and then typed-validates each recovered rule via
     {!read_stylesheet_of_rules}. Warnings from both stages are combined in

--- a/test/interop/wpt/test.ml
+++ b/test/interop/wpt/test.ml
@@ -301,7 +301,9 @@ let non_ascii_codepoints =
   in
   let ident_accepts cp =
     let css = Fmt.str ".f%soo { color: red; }" (utf8_of_cp cp) in
-    match Cascade.Css.of_string ~strict:false css with
+    (* The range list is what [~enforce_spec:true] selects; reading defaults to
+       any code point >= U+0080, which these counter-tests would not see. *)
+    match Cascade.Css.of_string ~strict:false ~enforce_spec:true css with
     | Ok { Cascade.Css.stylesheet; warnings = _ } ->
         List.length (Cascade.Css.rule_statements stylesheet) = 1
     | Error _ -> false
@@ -334,7 +336,7 @@ let non_ascii_codepoints =
      Test both. *)
   let leads_ident cp =
     let css = Fmt.str "%sfoo { color: red }" (utf8_of_cp cp) in
-    match Cascade.Css.of_string ~strict:false css with
+    match Cascade.Css.of_string ~strict:false ~enforce_spec:true css with
     | Ok r -> List.length (Cascade.Css.rule_statements r.stylesheet) = 1
     | Error _ -> false
   in

--- a/test/test_lexer.ml
+++ b/test/test_lexer.ml
@@ -2,8 +2,8 @@
 
 open Cascade
 
-let tokens_of css =
-  let lexer = Lexer.of_string css in
+let tokens_of ?enforce_spec css =
+  let lexer = Lexer.of_string ?enforce_spec css in
   let rec loop acc =
     let tok = Lexer.next lexer in
     match tok.Token.kind with
@@ -15,8 +15,8 @@ let tokens_of css =
 let pp_tokens kinds =
   String.concat " " (List.map (Css.Pp.to_string Token.pp_kind) kinds)
 
-let check input expected_summary =
-  let got = pp_tokens (tokens_of input) in
+let check ?enforce_spec input expected_summary =
+  let got = pp_tokens (tokens_of ?enforce_spec input) in
   Alcotest.(check string) (Fmt.str "tokenize %S" input) expected_summary got
 
 let check_first_hash input expected_value expected_flag =
@@ -90,9 +90,11 @@ let spec_definitions () =
      decisions before the section 4.3 algorithms run. *)
   check "url(a\x07b)" "<bad-url>";
   check "a\u{00B7}b" "<ident a\u{00B7}b>";
-  (* U+200B is not in the non-ASCII ident ranges, so it should fall through to a
-     single delim token with that code point. *)
-  check "\u{200B}" "<delim '\u{200B}'>"
+  (* U+200B is not in the section 4.2 ranges, so under [~enforce_spec:true] it
+     falls through to a single delim token with that code point. Reading
+     defaults to any code point >= U+0080, where it is an ident. *)
+  check ~enforce_spec:true "\u{200B}" "<delim '\u{200B}'>";
+  check "\u{200B}" "<ident \u{200B}>"
 
 let spec_hash_flags () =
   (* CSS Syntax Level 3 section 4.3.1: hash tokens remember whether the

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -207,9 +207,9 @@ let test_nested_container_recovers () =
 (* ignore-test: error-recovery contract, not a per-statement constructor. *)
 let test_layer_rule_recovery () =
   (* CSS Syntax 3 sec. 5.4.1: an invalid rule inside an @layer / @media block is
-     dropped on its own; its sibling rules must survive. [.x->y] has a literal
-     arrow (U+2192), which is not a valid ident code point, so the browser drops
-     that rule too - but keeps the rest of the block. *)
+     dropped on its own; its sibling rules must survive. [!] is a delim wherever
+     it appears in a selector, so [.x!y] is invalid under any reading of the
+     ident rules. *)
   let keeps_siblings input =
     match Css.of_string input with
     | Ok { Css.stylesheet; warnings; _ } ->
@@ -223,12 +223,10 @@ let test_layer_rule_recovery () =
     | Error e ->
         Alcotest.failf "expected recovery: %s" (Cascade.Error.to_string e)
   in
-  keeps_siblings "@layer u{.a{color:red}.x\u{2192}y{color:lime}.b{color:blue}}";
+  keeps_siblings "@layer u{.a{color:red}.x!y{color:lime}.b{color:blue}}";
+  keeps_siblings "@media screen{.a{color:red}.x!y{color:lime}.b{color:blue}}";
   keeps_siblings
-    "@media screen{.a{color:red}.x\u{2192}y{color:lime}.b{color:blue}}";
-  keeps_siblings
-    "@supports \
-     (display:grid){.a{color:red}.x\u{2192}y{color:lime}.b{color:blue}}"
+    "@supports (display:grid){.a{color:red}.x!y{color:lime}.b{color:blue}}"
 
 (* Not a roundtrip test *)
 let test_supports_rule_creation () =


### PR DESCRIPTION
CSS Syntax 3 sec. 4.2 lists the non-ASCII code points an identifier may contain, and the list excludes most BMP symbols, the arrows among them. Real stylesheets carry those anyway (Tailwind emits `.text-↗`), and dropping a rule is a worse failure for a minifier than accepting a code point the list omits, so reading now takes anything at or above U+0080. `Css.of_string` takes `?enforce_spec` and `cascade` takes `--enforce-spec` to select the range list.

Writing is unchanged: a code point outside the list is hex-escaped, which every parser reads. So the raw and escaped spellings of one selector now converge, and `.text-↗` compares equal to `.text-\2197` instead of one side being dropped with a warning.

The spec-list assertions move to `~enforce_spec:true` rather than going away. Worth knowing about them: `test/interop/wpt/test.ml` is cascade's own port, and its comment says WPT mutates `animationName` via CSSOM while the port asks whether a class selector parses. The selector claim was the port's inference, not something WPT establishes, which is why the earlier reading of it as settling this question was wrong.

`test_stylesheet`'s block-recovery case swaps its invalid selector from `.x→y` to `.x!y`, since that test is about section 5.4 recovery and `!` does not depend on the ident rules at all.