### PR TITLE
properties: fold a zero hue-rotate inside a custom property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,12 @@
 
 ### Minification
 
+- A `hue-rotate()` with a zero argument drops it inside a custom property, the
+  way it already did in `filter` directly. Filter Effects 1 sec. 8.5 makes an
+  omitted argument 0, and `hue-rotate` names a filter function and nothing
+  else, so the two spellings are one value wherever the stream is substituted.
+  `--diff=canonical` reported them as a difference (#257)
+
 - Every SVG presentation property is typed, so its value minifies like any
   other rather than surviving as opaque text. `stop-color: #ffffff` is
   `stop-color:#fff`, `fill-opacity: 0.1` is `fill-opacity:.1`,

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -21141,6 +21141,26 @@ let fold_custom_calc (c : Component.t) ~fallback =
   | Some cs -> cs
   | None -> fallback ()
 
+(* Filter Effects 1 sec. 8.5 gives [hue-rotate()] the argument [[ <angle> |
+   <zero> ]?] and 0 when omitted, so a zero argument is redundant. [hue-rotate]
+   names a filter function and nothing else, so this holds wherever the stream
+   is substituted, which is the same argument that lets a colour function fold
+   here. *)
+let hue_rotate_zero_argument (func : Component.func) =
+  String.lowercase_ascii func.name = "hue-rotate"
+  && func.arguments <> []
+  &&
+  let cur = Cursor.of_string (Parser.to_string_custom func.arguments) in
+  match read_angle_unit_required cur with
+  | exception Cursor.Parse_error _ -> false
+  | angle ->
+      Cursor.is_done cur
+      && Values.angle_degrees_opt (normalize_angle angle) = Some 0.
+
+let drop_function_arguments wrapped =
+  Component.Func
+    { wrapped with node = { wrapped.Component.node with arguments = [] } }
+
 let rec canonicalize_custom_colors_components ~lossless comps =
   let fold_color c ~fallback = fold_custom_color ~lossless c ~fallback in
   List.concat_map
@@ -21170,6 +21190,9 @@ let rec canonicalize_custom_colors_components ~lossless comps =
                 Component.Func
                   { wrapped with node = { func with arguments = args } };
               ])
+      | Component.Func wrapped
+        when hue_rotate_zero_argument wrapped.Component.node ->
+          [ drop_function_arguments wrapped ]
       | Component.Func wrapped ->
           let func = wrapped.Component.node in
           let args =

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -99,6 +99,26 @@ let equal_canonical_media_not_all () =
     (Cascade_diff.Css_compare.equal ~mode:`Canonical
        "@media not all{.a{color:red}}" "@media not (hover){.a{color:red}}")
 
+(* Filter Effects 1 sec. 8.5 makes an omitted [hue-rotate()] argument 0, and
+   [hue-rotate] names a filter function and nothing else, so the two spellings
+   are one value wherever the stream is substituted. *)
+let canonical_custom_hue_rotate_zero () =
+  Alcotest.(check bool)
+    "hue-rotate() and hue-rotate(0deg) agree in a custom property" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ".a{--f:hue-rotate();filter:var(--f)}"
+       ".a{--f:hue-rotate(0deg);filter:var(--f)}");
+  (* Any zero angle, since the unit does not survive normalisation. *)
+  Alcotest.(check bool)
+    "a zero turn agrees too" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical ".a{--f:hue-rotate()}"
+       ".a{--f:hue-rotate(0turn)}");
+  (* A non-zero angle is a different filter. *)
+  Alcotest.(check bool)
+    "a non-zero angle still differs" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical ".a{--f:hue-rotate()}"
+       ".a{--f:hue-rotate(90deg)}")
+
 let equal_prune_unused_custom_props () =
   let with_bind = ":root{--spacing:.25rem}.top-0{top:0}" in
   let without = ".top-0{top:0}" in
@@ -1164,6 +1184,8 @@ let suite =
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "opt-in prune-unused-custom-props" `Quick
         equal_prune_unused_custom_props;
+      Alcotest.test_case "canonical folds a zero hue-rotate in a custom value"
+        `Quick canonical_custom_hue_rotate_zero;
       Alcotest.test_case "canonical ignores @property order" `Quick
         equal_canonical_ignores_property_order;
       Alcotest.test_case "canonical equates not all and (X) with not (X)" `Quick


### PR DESCRIPTION
`filter: hue-rotate()` already compared equal to `filter: hue-rotate(0deg)`, but the same pair inside a consumed custom property did not, so `--diff=canonical` reported a difference that is not one:

```
.a{--f:hue-rotate();filter:var(--f)}
.a{--f:hue-rotate(0deg);filter:var(--f)}
```

Filter Effects 1 sec. 8.5 makes an omitted argument 0, and `hue-rotate` names a filter function and nothing else, so the two spellings are one value wherever the stream is substituted. That is the argument that already lets a colour function fold in an opaque stream, so the fold goes in the same walker. A non-zero angle is untouched, and the fold reaches nested functions.