### PR TITLE
diff: reconcile blocks that share a condition one for one

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -161,6 +161,12 @@ identical, rather than as spurious changes.
 
 ### Diff report
 
+- Blocks sharing a condition are reconciled one for one instead of by whether
+  the condition appears at all. Three `@container` blocks with one condition
+  against two of them reported two changed containers, each inventing an added
+  rule, rather than the one block that was removed. The same pairing decides
+  media, layer and supports blocks (#258)
+
 - `cascade diff` bounds its report: it prints the whole difference tree while
   that stays short, and otherwise falls back to the deepest level that fits,
   with `--depth` to pin a level or ask for the tree in full. A whole-stylesheet

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1004,32 +1004,39 @@ let rule_nested stmt =
 let diffs ~(key_of : 'item -> 'key) ~(key_equal : 'key -> 'key -> bool)
     ~(is_empty_diff : 'item -> 'item -> bool) items1 items2 =
   let items1_keyed = List.map (fun i -> (i, key_of i)) items1 in
-  let items2_keyed = List.map (fun i -> (i, key_of i)) items2 in
-  let find_by_key key items =
-    List.find_opt (fun (_, k) -> key_equal k key) items
+  let items2_keyed = Array.of_list (List.map (fun i -> (i, key_of i)) items2) in
+  (* Each right-hand item is claimed by at most one left-hand item. Testing
+     existence instead would hide a duplicate key entirely: with two blocks
+     carrying one condition and one on the other side, neither counts as added
+     or removed, and the survivor is paired twice, so both pairings report
+     differences that are not there. *)
+  let claimed = Array.make (Array.length items2_keyed) false in
+  let claim key =
+    let rec scan i =
+      if i >= Array.length items2_keyed then None
+      else if (not claimed.(i)) && key_equal (snd items2_keyed.(i)) key then (
+        claimed.(i) <- true;
+        Some (fst items2_keyed.(i)))
+      else scan (i + 1)
+    in
+    scan 0
   in
+  let pairs, removed =
+    List.fold_left
+      (fun (pairs, removed) (item1, key1) ->
+        match claim key1 with
+        | Some item2 -> ((item1, item2) :: pairs, removed)
+        | None -> (pairs, item1 :: removed))
+      ([], []) items1_keyed
+  in
+  let pairs = List.rev pairs and removed = List.rev removed in
   let added =
-    List.filter_map
-      (fun (item2, key2) ->
-        if List.exists (fun (_, k1) -> key_equal k1 key2) items1_keyed then None
-        else Some item2)
-      items2_keyed
-  in
-  let removed =
-    List.filter_map
-      (fun (item1, key1) ->
-        if List.exists (fun (_, k2) -> key_equal key1 k2) items2_keyed then None
-        else Some item1)
-      items1_keyed
+    Array.to_list items2_keyed
+    |> List.filteri (fun i _ -> not claimed.(i))
+    |> List.map fst
   in
   let modified =
-    List.filter_map
-      (fun (item1, key1) ->
-        match find_by_key key1 items2_keyed with
-        | Some (item2, _) when not (is_empty_diff item1 item2) ->
-            Some (item1, item2)
-        | _ -> None)
-      items1_keyed
+    List.filter (fun (item1, item2) -> not (is_empty_diff item1 item2)) pairs
   in
   (added, removed, modified)
 

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -363,6 +363,33 @@ let diff_selector_group_partial_change () =
 
 (* ===== Suite ===== *)
 
+(* Three blocks carrying one condition against two of them. Testing existence
+   rather than claiming each right-hand block once hides the duplicate: neither
+   side counts as added or removed, and the survivors are paired twice, so the
+   report shows two changed containers inventing an added rule apiece. *)
+let duplicate_condition_blocks_reconcile () =
+  let expected =
+    parse
+      "@container (width>=48rem){.a{color:red}}\n\
+       @container (width>=48rem){.b{color:blue}}\n\
+       @container (width>=48rem){.c{color:lime}}"
+  in
+  let actual =
+    parse
+      "@container (width>=48rem){.a{color:red}}\n\
+       @container (width>=48rem){.b{color:blue}}"
+  in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check int)
+    "one container difference, not one per duplicate" 1
+    (List.length d.containers);
+  Alcotest.(check bool)
+    "the third block is removed" true
+    (Cascade_diff.Tree_diff.has_container_removed_of_type `Container d);
+  Alcotest.(check bool)
+    "and nothing is added" false
+    (Cascade_diff.Tree_diff.has_container_added_of_type `Container d)
+
 let suite =
   ( "tree_diff",
     [
@@ -405,6 +432,8 @@ let suite =
       Alcotest.test_case "nesting deep" `Quick diff_nesting_deep;
       Alcotest.test_case "nesting only parent props changed" `Quick
         diff_nesting_parent_props_only;
+      Alcotest.test_case "duplicate condition blocks reconcile" `Quick
+        duplicate_condition_blocks_reconcile;
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "pp_rule_diff_simple does not crash" `Quick
         pp_rule_diff_simple_ok;


### PR DESCRIPTION
The pairing asked whether a key appeared on the other side rather than claiming a match, so a duplicate condition was invisible. Three `@container` blocks under one condition against two of them:

```
└─ @container (width >= 48rem) (1 added, 1 removed)     └─ @container (width >= 48rem) (removed)
   ├─ .a                                                   └─ .c (removed)
   │     + color red
   └─ .c
         - color lime
└─ @container (width >= 48rem) (1 added, 1 removed)
   ├─ .a
   ...
```

Neither side counted as added or removed, because the condition existed on both, and the survivors were paired twice, so each pairing reported differences that were not there. Each right-hand item is now claimed by at most one left-hand item, leaving the surplus on either side as the real addition or removal.

This is the pairing behind the false `@min-md:@max-xl:hidden` removal in the tw parity run, where two of the four classes share an outer condition. It is the same helper for media, layer and supports blocks.

Stacked on #257.