### PR TITLE
diff: report a selector once per container

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -161,6 +161,12 @@ identical, rather than as spurious changes.
 
 ### Diff report
 
+- A selector written by more than one rule in a container is reported once.
+  Two rules under one selector produced a node each, carrying the same label,
+  one saying a declaration was added and the other that a different one was
+  removed, which reads as a contradiction rather than as the declarations
+  sitting on different rules (#259)
+
 - Blocks sharing a condition are reconciled one for one instead of by whether
   the condition appears at all. Three `@container` blocks with one condition
   against two of them reported two changed containers, each inventing an added

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1735,12 +1735,65 @@ let convert_modified_rule ~rules1 ~rules2 (sel1, sel2, decls1, decls2) =
       else reorder_or_content sel1_str decls1 decls2
 
 (* Assemble rule changes (added/removed/modified) between two rule lists *)
+(* One selector, one node. Two rules writing the same selector in a container
+   produced two sibling entries under the same label, one reporting a
+   declaration added and the other a different one removed, which reads as a
+   contradiction rather than as a declaration moving between them. The group
+   collapses to a single before-and-after for that selector.
+
+   Only a group that both gains and loses collapses: several rules added under
+   one selector really are several additions, and merging those would hide the
+   count. *)
+let merge_same_selector_changes (changes : rule_diff list) : rule_diff list =
+  let selector_of : rule_diff -> string option = function
+    | Added { selector; _ }
+    | Removed { selector; _ }
+    | Content_changed { selector; _ } ->
+        Some selector
+    | Reordered _ | Selector_changed _ | Regrouped _ -> None
+  in
+  let sides : rule_diff -> Css.declaration list * Css.declaration list =
+    function
+    | Added { declarations; _ } -> ([], declarations)
+    | Removed { declarations; _ } -> (declarations, [])
+    | Content_changed { old_declarations; new_declarations; _ } ->
+        (old_declarations, new_declarations)
+    | _ -> ([], [])
+  in
+  let gains : rule_diff -> bool = function
+    | Added _ | Content_changed _ -> true
+    | _ -> false
+  in
+  let loses : rule_diff -> bool = function
+    | Removed _ | Content_changed _ -> true
+    | _ -> false
+  in
+  let done_ = Hashtbl.create 8 in
+  List.filter_map
+    (fun diff ->
+      match selector_of diff with
+      | None -> Some diff
+      | Some sel when Hashtbl.mem done_ sel -> None
+      | Some sel -> (
+          let peers = List.filter (fun d -> selector_of d = Some sel) changes in
+          match peers with
+          | _ :: _ :: _ when List.exists gains peers && List.exists loses peers
+            ->
+              Hashtbl.replace done_ sel ();
+              Some
+                (content_changed sel
+                   (List.concat_map (fun d -> fst (sides d)) peers)
+                   (List.concat_map (fun d -> snd (sides d)) peers))
+          | _ -> Some diff))
+    changes
+
 let to_rule_changes rules1 rules2 : rule_diff list =
   let r_added, r_removed, r_modified, r_regrouped = rule_diffs rules1 rules2 in
   List.filter_map convert_added_rule r_added
   @ List.filter_map convert_removed_rule r_removed
   @ List.filter_map (convert_modified_rule ~rules1 ~rules2) r_modified
   @ r_regrouped
+  |> merge_same_selector_changes
 
 (* Generic helpers for processing nested containers *)
 let extract_items_with_positions extract_fn stmts =

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -1,0 +1,31 @@
+CLI: cascade diff - one node per selector.
+
+A selector written by more than one rule in a container used to produce a
+node per rule, each carrying the same label: one saying a declaration was
+added and another that a different one was removed, which reads as a
+contradiction rather than as the declarations sitting on different rules.
+The group is reported once.
+
+These two are a reduced Tailwind utilities layer: each utility is a bare
+rule, an @supports rule and another bare rule, and the two sides emit the
+blue group and the indigo group in the opposite order. That order is
+cascade-significant for an element carrying both classes, so the difference
+is real and must still be reported.
+
+  $ cat > ref.css <<'EOF'
+  > @layer utilities{.drop-shadow-sm{--tw-drop-shadow-size:drop-shadow(0 1px 2px var(--tw-drop-shadow-color,#00000026));--tw-drop-shadow:drop-shadow(var(--drop-shadow-sm));filter:var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,)}.drop-shadow-blue-500\/50{--tw-drop-shadow-color:#3080ff80}@supports (color:color-mix(in lab, red, red)){.drop-shadow-blue-500\/50{--tw-drop-shadow-color:color-mix(in oklab, color-mix(in oklab, var(--color-blue-500) 50%, transparent) var(--tw-drop-shadow-alpha), transparent)}}.drop-shadow-blue-500\/50{--tw-drop-shadow:var(--tw-drop-shadow-size)}.drop-shadow-indigo-500{--tw-drop-shadow-color:oklch(58.5% .233 277.117)}@supports (color:color-mix(in lab, red, red)){.drop-shadow-indigo-500{--tw-drop-shadow-color:color-mix(in oklab, var(--color-indigo-500) var(--tw-drop-shadow-alpha), transparent)}}.drop-shadow-indigo-500{--tw-drop-shadow:var(--tw-drop-shadow-size)}}
+  > EOF
+  $ cat > tw.css <<'EOF'
+  > @layer utilities{.drop-shadow-sm{--tw-drop-shadow-size:drop-shadow(0 1px 2px var(--tw-drop-shadow-color,#00000026));--tw-drop-shadow:drop-shadow(var(--drop-shadow-sm));filter:var(--tw-blur,)var(--tw-brightness,)var(--tw-contrast,)var(--tw-grayscale,)var(--tw-hue-rotate,)var(--tw-invert,)var(--tw-saturate,)var(--tw-sepia,)var(--tw-drop-shadow,)}.drop-shadow-indigo-500{--tw-drop-shadow-color:oklch(58.5%.233 277.117)}@supports(color:color-mix(in lab,red,red)){.drop-shadow-indigo-500{--tw-drop-shadow-color:color-mix(in oklab,var(--color-indigo-500) var(--tw-drop-shadow-alpha),transparent)}}.drop-shadow-indigo-500{--tw-drop-shadow:var(--tw-drop-shadow-size)}.drop-shadow-blue-500\/50{--tw-drop-shadow-color:#3080ff80}@supports(color:color-mix(in lab,red,red)){.drop-shadow-blue-500\/50{--tw-drop-shadow-color:color-mix(in oklab,color-mix(in oklab,var(--color-blue-500) 50%,transparent) var(--tw-drop-shadow-alpha),transparent)}}.drop-shadow-blue-500\/50{--tw-drop-shadow:var(--tw-drop-shadow-size)}}
+  > EOF
+  $ cascade diff --diff=canonical --prune-unused-custom-props --depth=max ref.css tw.css
+  CSS: 1003 chars vs 1024 chars (2.1% diff)
+  Changes: 1 changed container
+  
+  --- ref.css
+  +++ tw.css
+  └─ @layer utilities (1 modified)
+     └─ .drop-shadow-indigo-500
+           - --tw-drop-shadow-color
+  
+  [1]


### PR DESCRIPTION
A selector written by more than one rule in a container produced a node per rule, each carrying the same label: one saying a declaration was added and another that a different one was removed. That reads as a contradiction rather than as the declarations sitting on different rules of that selector.

On the drop-shadow repro:

```
└─ @layer utilities (1 added, 1 modified)        └─ @layer utilities (1 modified)
   ├─ .drop-shadow-indigo-500                       └─ .drop-shadow-indigo-500
   │     + --tw-drop-shadow var(...)                      - --tw-drop-shadow-color
   └─ .drop-shadow-indigo-500
         - --tw-drop-shadow-color
```

Only a group that both gains and loses collapses, so several rules genuinely added under one selector still count as several additions.

The difference itself is real and stays reported: the two sides emit the blue group and the indigo group in the opposite order, and that order decides the value for an element carrying both classes, which `cascade apply` confirms. An earlier attempt at this compared the selector's declarations across all its rules and, finding them equal, reported the sheets identical; that silenced a genuine difference and was dropped. The cram test pins the difference as well as the shape.

What this does not fix: the remaining line still reads as a property loss, where the accurate story is that the declaration sits on a different rule. Saying that needs a classification the tree does not have.