### PR TITLE
diff: report a selector's declarations moving between its rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -161,11 +161,15 @@ identical, rather than as spurious changes.
 
 ### Diff report
 
-- A selector written by more than one rule in a container is reported once.
-  Two rules under one selector produced a node each, carrying the same label,
-  one saying a declaration was added and the other that a different one was
-  removed, which reads as a contradiction rather than as the declarations
-  sitting on different rules (#259)
+- A selector written by more than one rule is reported once, at the top level
+  as well as inside a container. Two rules under one selector produced a node
+  each carrying the same label, one saying a declaration was added and the
+  other that a different one was removed, which reads as a contradiction. When
+  every declaration the selector writes survives on both sides, spread
+  differently over those rules, the entry names the move and lists them, and
+  the summary counts it as a rearranged rule. The difference is still reported:
+  which rule carries a declaration decides how it resolves against an
+  overlapping selector's rules (#259, #260)
 
 - Blocks sharing a condition are reconciled one for one instead of by whether
   the condition appears at all. Three `@container` blocks with one condition

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -23,6 +23,7 @@ type stats = {
   removed_rules : int;
   modified_rules : int;
   reordered_rules : int;
+  rearranged_rules : int;
   regrouped_rules : int;
   container_changes : int;
 }
@@ -485,6 +486,8 @@ let compute_stats ~expected_str ~actual_str diff_result =
             | _ -> false);
         reordered_rules =
           count_rule_type (function D.Reordered _ -> true | _ -> false);
+        rearranged_rules =
+          count_rule_type (function D.Rearranged _ -> true | _ -> false);
         regrouped_rules =
           count_rule_type (function D.Regrouped _ -> true | _ -> false);
         container_changes = List.length d.containers;
@@ -500,6 +503,7 @@ let compute_stats ~expected_str ~actual_str diff_result =
         removed_rules = 0;
         modified_rules = 0;
         reordered_rules = 0;
+        rearranged_rules = 0;
         regrouped_rules = 0;
         container_changes = 0;
       }
@@ -607,6 +611,7 @@ let emit_changes buf stats =
       (stats.removed_rules, "removed", "rule");
       (stats.modified_rules, "modified", "rule");
       (stats.reordered_rules, "reordered", "rule");
+      (stats.rearranged_rules, "rearranged", "rule");
       (stats.regrouped_rules, "regrouped", "rule");
     ]
     |> List.filter (fun (n, _, _) -> n > 0)

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -162,6 +162,7 @@ type stats = {
   removed_rules : int;
   modified_rules : int;
   reordered_rules : int;
+  rearranged_rules : int;
   regrouped_rules : int;
   container_changes : int;
 }

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -37,6 +37,10 @@ type rule_diff =
       old_declarations : Css.declaration list option;
       new_declarations : Css.declaration list option;
     }
+  | Rearranged of { selector : string; declarations : Css.declaration list }
+    (* Every declaration the selector carries survives on both sides, spread
+       differently over the rules that write it. An element that also matches an
+       overlapping selector can resolve differently. *)
   | Regrouped of {
       from_selectors : string list; (* rule selectors in expected *)
       to_selectors : string list; (* rule selectors in actual *)
@@ -159,6 +163,7 @@ let pp_declarations ?(style = default_style) ?(parent_prefix = "") buf action
     match action with
     | "add" -> "+"
     | "remove" -> "-"
+    | "same" -> " " (* context marker: present on both sides *)
     | _ -> action (* fallback for other actions like "declarations" *)
   in
   (* Properties don't get tree connectors - just indentation continuation *)
@@ -470,6 +475,13 @@ let pp_rule_diff ?(style = default_style) ?(is_last = false)
           pp_position_reorder ~prefix buf ~selector:r.selector
             ~expected_pos:r.expected_pos ~actual_pos:r.actual_pos
             ~swapped_with:r.swapped_with)
+  | Rearranged { selector; declarations } ->
+      let prefix = tree_prefix ~style ~is_last ~parent_prefix in
+      let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
+      add_strings buf [ prefix; selector; " (moved between rules)\n" ];
+      pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
+          pp_declarations ~style ~parent_prefix:child_prefix buf "same"
+            declarations)
   | Regrouped { from_selectors; to_selectors } ->
       let prefix = tree_prefix ~style ~is_last ~parent_prefix in
       let child_prefix = tree_continuation ~style ~is_last ~parent_prefix in
@@ -490,6 +502,8 @@ let pp_rule_diff_simple buf (diff : rule_diff) =
       Buffer.add_string buf
         ("Reordered(" ^ selector ^ ":" ^ string_of_int expected_pos ^ "->"
        ^ string_of_int actual_pos ^ ")")
+  | Rearranged { selector; _ } ->
+      Buffer.add_string buf ("Rearranged(" ^ selector ^ ")")
   | Regrouped { from_selectors; to_selectors } ->
       Buffer.add_string buf
         ("Regrouped("
@@ -666,6 +680,11 @@ let count_rule_changes (rule_changes : rule_diff list) =
                match diff with Reordered _ -> true | _ -> false)
          in
          if n > 0 then Some (string_of_int n ^ " reordered") else None);
+        (let n =
+           count (fun (diff : rule_diff) ->
+               match diff with Rearranged _ -> true | _ -> false)
+         in
+         if n > 0 then Some (string_of_int n ^ " rearranged") else None);
         (let n =
            count (fun (diff : rule_diff) ->
                match diff with Selector_changed _ -> true | _ -> false)
@@ -1735,6 +1754,55 @@ let convert_modified_rule ~rules1 ~rules2 (sel1, sel2, decls1, decls2) =
       else reorder_or_content sel1_str decls1 decls2
 
 (* Assemble rule changes (added/removed/modified) between two rule lists *)
+
+(* The selector a change is about, when it names one. *)
+let changed_selector : rule_diff -> string option = function
+  | Added { selector; _ }
+  | Removed { selector; _ }
+  | Content_changed { selector; _ } ->
+      Some selector
+  | Rearranged { selector; _ } -> Some selector
+  | Reordered _ | Selector_changed _ | Regrouped _ -> None
+
+let change_sides : rule_diff -> Css.declaration list * Css.declaration list =
+  function
+  | Added { declarations; _ } -> ([], declarations)
+  | Removed { declarations; _ } -> (declarations, [])
+  | Content_changed { old_declarations; new_declarations; _ } ->
+      (old_declarations, new_declarations)
+  | _ -> ([], [])
+
+let change_gains : rule_diff -> bool = function
+  | Added _ | Content_changed _ -> true
+  | _ -> false
+
+let change_loses : rule_diff -> bool = function
+  | Removed _ | Content_changed _ -> true
+  | _ -> false
+
+(* Every declaration [sel] writes on one side, across all of its rules. *)
+let declarations_of_selector sel stmts =
+  List.concat_map
+    (fun stmt ->
+      match Css.as_rule stmt with
+      | Some (selector, decls, _) when Css.Selector.to_string selector = sel ->
+          decls
+      | _ -> [])
+    stmts
+
+(* Judge on every rule of the selector, not only the differing ones: a
+   declaration a matching rule already carries distinguishes a move from a
+   loss. *)
+let merge_selector_group ~rules1 ~rules2 sel peers =
+  let old_all = declarations_of_selector sel rules1
+  and new_all = declarations_of_selector sel rules2 in
+  if old_all <> [] && decls_signature old_all = decls_signature new_all then
+    Rearranged { selector = sel; declarations = new_all }
+  else
+    content_changed sel
+      (List.concat_map (fun d -> fst (change_sides d)) peers)
+      (List.concat_map (fun d -> snd (change_sides d)) peers)
+
 (* One selector, one node. Two rules writing the same selector in a container
    produced two sibling entries under the same label, one reporting a
    declaration added and the other a different one removed, which reads as a
@@ -1744,46 +1812,24 @@ let convert_modified_rule ~rules1 ~rules2 (sel1, sel2, decls1, decls2) =
    Only a group that both gains and loses collapses: several rules added under
    one selector really are several additions, and merging those would hide the
    count. *)
-let merge_same_selector_changes (changes : rule_diff list) : rule_diff list =
-  let selector_of : rule_diff -> string option = function
-    | Added { selector; _ }
-    | Removed { selector; _ }
-    | Content_changed { selector; _ } ->
-        Some selector
-    | Reordered _ | Selector_changed _ | Regrouped _ -> None
-  in
-  let sides : rule_diff -> Css.declaration list * Css.declaration list =
-    function
-    | Added { declarations; _ } -> ([], declarations)
-    | Removed { declarations; _ } -> (declarations, [])
-    | Content_changed { old_declarations; new_declarations; _ } ->
-        (old_declarations, new_declarations)
-    | _ -> ([], [])
-  in
-  let gains : rule_diff -> bool = function
-    | Added _ | Content_changed _ -> true
-    | _ -> false
-  in
-  let loses : rule_diff -> bool = function
-    | Removed _ | Content_changed _ -> true
-    | _ -> false
-  in
+let merge_same_selector_changes ~rules1 ~rules2 (changes : rule_diff list) :
+    rule_diff list =
   let done_ = Hashtbl.create 8 in
   List.filter_map
     (fun diff ->
-      match selector_of diff with
+      match changed_selector diff with
       | None -> Some diff
       | Some sel when Hashtbl.mem done_ sel -> None
       | Some sel -> (
-          let peers = List.filter (fun d -> selector_of d = Some sel) changes in
+          let peers =
+            List.filter (fun d -> changed_selector d = Some sel) changes
+          in
           match peers with
-          | _ :: _ :: _ when List.exists gains peers && List.exists loses peers
-            ->
+          | _ :: _ :: _
+            when List.exists change_gains peers
+                 && List.exists change_loses peers ->
               Hashtbl.replace done_ sel ();
-              Some
-                (content_changed sel
-                   (List.concat_map (fun d -> fst (sides d)) peers)
-                   (List.concat_map (fun d -> snd (sides d)) peers))
+              Some (merge_selector_group ~rules1 ~rules2 sel peers)
           | _ -> Some diff))
     changes
 
@@ -1793,7 +1839,7 @@ let to_rule_changes rules1 rules2 : rule_diff list =
   @ List.filter_map convert_removed_rule r_removed
   @ List.filter_map (convert_modified_rule ~rules1 ~rules2) r_modified
   @ r_regrouped
-  |> merge_same_selector_changes
+  |> merge_same_selector_changes ~rules1 ~rules2
 
 (* Generic helpers for processing nested containers *)
 let extract_items_with_positions extract_fn stmts =
@@ -2603,13 +2649,10 @@ let diff ~(expected : Css.t) ~(actual : Css.t) : t =
      keeps [rule_diffs] from matching every import on the universal key. *)
   let rules1 = List.filter (fun s -> Css.as_import s = None) all1 in
   let rules2 = List.filter (fun s -> Css.as_import s = None) all2 in
-  let added, removed, modified, regrouped = rule_diffs rules1 rules2 in
-
+  (* Same assembly as inside a container, so a difference reports the same way
+     at either depth. *)
   let rule_changes =
-    List.filter_map convert_added_rule added
-    @ List.filter_map convert_removed_rule removed
-    @ List.filter_map (convert_modified_rule ~rules1 ~rules2) modified
-    @ regrouped @ process_imports all1 all2
+    to_rule_changes rules1 rules2 @ process_imports all1 all2
   in
 
   (* Delegate all container and nested-container diffs to the generic walker *)

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -38,6 +38,12 @@ type rule_diff =
       old_declarations : Css.declaration list option;
       new_declarations : Css.declaration list option;
     }
+  | Rearranged of { selector : string; declarations : Css.declaration list }
+      (** Every declaration the selector carries survives on both sides, spread
+          differently over the rules that write it. An element that also matches
+          an overlapping selector can resolve differently, since which rule
+          carries a declaration decides where it sits relative to the other
+          selector's rules. *)
   | Regrouped of { from_selectors : string list; to_selectors : string list }
       (** A comma group merged or split across rules with identical
           declarations: the same selectors survive, only the grouping differs.

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -1,10 +1,9 @@
 CLI: cascade diff - one node per selector.
 
-A selector written by more than one rule in a container used to produce a
-node per rule, each carrying the same label: one saying a declaration was
-added and another that a different one was removed, which reads as a
-contradiction rather than as the declarations sitting on different rules.
-The group is reported once.
+A selector written by more than one rule reports once. When every declaration
+it writes survives on both sides, spread differently over those rules, the
+entry names the move, where the selector was named twice, once losing a
+declaration and once gaining another.
 
 These two are a reduced Tailwind utilities layer: each utility is a bare
 rule, an @supports rule and another bare rule, and the two sides emit the
@@ -24,8 +23,91 @@ is real and must still be reported.
   
   --- ref.css
   +++ tw.css
-  └─ @layer utilities (1 modified)
-     └─ .drop-shadow-indigo-500
-           - --tw-drop-shadow-color
+  └─ @layer utilities (1 rearranged)
+     └─ .drop-shadow-indigo-500 (moved between rules)
+             --tw-drop-shadow-color color-mix(in oklab,var(--col...tw-drop-shadow-alpha),#0000)
+             --tw-drop-shadow var(--tw-drop-shadow-size)
   
   [1]
+
+
+
+A top-level group reports the same way as one inside a container.
+
+  $ cat > split.css <<'EOF'
+  > .a{color:red}.b{color:blue}.a{margin:0}
+  > EOF
+  $ cat > joined.css <<'EOF'
+  > .a{color:red;margin:0}.b{color:blue}
+  > EOF
+  $ cascade diff --depth=max split.css joined.css
+  CSS: 37 chars vs 40 chars (7.5% diff)
+  Changes: 1 rearranged rule
+  
+  --- split.css
+  +++ joined.css
+  └─ .a (moved between rules)
+          color red
+          margin 0
+  
+  [1]
+
+
+
+  $ cat > split_layer.css <<'EOF'
+  > @layer u{.a{color:red}.b{color:blue}.a{margin:0}}
+  > EOF
+  $ cat > joined_layer.css <<'EOF'
+  > @layer u{.a{color:red;margin:0}.b{color:blue}}
+  > EOF
+  $ cascade diff --depth=max split_layer.css joined_layer.css
+  CSS: 47 chars vs 50 chars (6.0% diff)
+  Changes: 1 changed container
+  
+  --- split_layer.css
+  +++ joined_layer.css
+  └─ @layer u (1 rearranged)
+     └─ .a (moved between rules)
+             color red
+             margin 0
+  
+  [1]
+
+
+
+A declaration that does not survive is reported as a loss.
+
+  $ cat > lost.css <<'EOF'
+  > .a{color:red}.b{color:blue}
+  > EOF
+  $ cascade diff --depth=max split.css lost.css
+  CSS: 28 chars vs 40 chars (30.0% diff)
+  Changes: 1 removed rule
+  
+  --- split.css
+  +++ lost.css
+  └─ .a
+        - margin 0
+  
+  [1]
+
+
+
+The property name appearing on both sides is not enough: a changed value or
+an added !important changes what the selector writes.
+
+  $ cat > weighted.css <<'EOF'
+  > .a{color:red;margin:0 !important}.b{color:blue}
+  > EOF
+  $ cascade diff --depth=max split.css weighted.css
+  CSS: 48 chars vs 40 chars (20.0% diff)
+  Changes: 1 modified rule
+  
+  --- split.css
+  +++ weighted.css
+  └─ .a
+        * margin: 0 -> 0 !important
+  
+  [1]
+
+

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -390,6 +390,163 @@ let duplicate_condition_blocks_reconcile () =
     "and nothing is added" false
     (Cascade_diff.Tree_diff.has_container_added_of_type `Container d)
 
+(* ===== Declarations redistributed between rules of one selector ===== *)
+
+let rearranged_of (d : Cascade_diff.Tree_diff.t) =
+  List.filter_map
+    (fun (diff : Cascade_diff.Tree_diff.rule_diff) ->
+      match diff with
+      | Rearranged { selector; declarations } -> Some (selector, declarations)
+      | _ -> None)
+    d.rules
+
+let render d =
+  let buf = Buffer.create 256 in
+  Cascade_diff.Tree_diff.pp buf d;
+  Buffer.contents buf
+
+let diff_of ~expected ~actual =
+  Cascade_diff.Tree_diff.diff ~expected:(parse expected) ~actual:(parse actual)
+
+(* [.a] writes both declarations on both sides, split over two rules on one and
+   one rule on the other. *)
+let split = ".a{color:red}.b{color:blue}.a{margin:0}"
+let joined = ".a{color:red;margin:0}.b{color:blue}"
+
+let rearranged_reported () =
+  let d = diff_of ~expected:split ~actual:joined in
+  match rearranged_of d with
+  | [ (selector, declarations) ] ->
+      Alcotest.(check string) "the selector that moved" ".a" selector;
+      Alcotest.(check (list string))
+        "carries every declaration it writes" [ "color"; "margin" ]
+        (List.map Css.declaration_name declarations |> List.sort compare)
+  | rs ->
+      Alcotest.failf "expected one rearranged rule, got %d:\n%s"
+        (List.length rs) (render d)
+
+let rearranged_is_a_difference () =
+  let d = diff_of ~expected:split ~actual:joined in
+  Alcotest.(check bool)
+    "a move between rules is still reported, not folded away" false
+    (Cascade_diff.Tree_diff.is_empty d)
+
+let rearranged_reports_one_node () =
+  (* One selector was named twice, once losing the declaration and once gaining
+     it, which read as an unrelated addition and removal. *)
+  let d = diff_of ~expected:split ~actual:joined in
+  Alcotest.(check int) "one entry for the one selector" 1 (List.length d.rules)
+
+let rearranged_names_the_move () =
+  let out = render (diff_of ~expected:split ~actual:joined) in
+  Alcotest.(check bool)
+    "the report says the declarations moved" true
+    (Astring.String.is_infix ~affix:"moved between rules" out);
+  Alcotest.(check bool)
+    "and shows what moved" true
+    (Astring.String.is_infix ~affix:"margin" out)
+
+let rearranged_same_at_either_depth () =
+  (* Top-level rules and rules inside a container are assembled the same way, so
+     one difference does not report two ways. *)
+  let top = render (diff_of ~expected:split ~actual:joined) in
+  let layered =
+    render
+      (diff_of
+         ~expected:("@layer u{" ^ split ^ "}")
+         ~actual:("@layer u{" ^ joined ^ "}"))
+  in
+  Alcotest.(check bool)
+    "the container report names the move too" true
+    (Astring.String.is_infix ~affix:"moved between rules" layered);
+  Alcotest.(check bool)
+    "and counts it by name rather than as a position change" true
+    (Astring.String.is_infix ~affix:"1 rearranged" layered);
+  Alcotest.(check bool)
+    "the top-level report names it as well" true
+    (Astring.String.is_infix ~affix:"moved between rules" top)
+
+(* These pin the classification against silencing a real difference. *)
+
+let lost_declaration_is_not_a_move () =
+  let d = diff_of ~expected:split ~actual:".a{color:red}.b{color:blue}" in
+  Alcotest.(check int)
+    "nothing is called a move" 0
+    (List.length (rearranged_of d));
+  Alcotest.(check bool)
+    "the loss is still reported" true
+    (Astring.String.is_infix ~affix:"- margin" (render d))
+
+let gained_declaration_is_not_a_move () =
+  let d =
+    diff_of ~expected:".a{color:red}.b{color:blue}"
+      ~actual:".a{color:red;margin:0}.b{color:blue}.a{top:0}"
+  in
+  Alcotest.(check int)
+    "nothing is called a move" 0
+    (List.length (rearranged_of d));
+  Alcotest.(check bool)
+    "the difference is still reported" false
+    (Cascade_diff.Tree_diff.is_empty d)
+
+let changed_value_is_not_a_move () =
+  let d =
+    diff_of ~expected:".a{color:red}.b{x:1}.a{margin:0}"
+      ~actual:".a{color:green;margin:0}.b{x:1}"
+  in
+  Alcotest.(check int)
+    "nothing is called a move" 0
+    (List.length (rearranged_of d));
+  Alcotest.(check bool)
+    "the value change is named" true
+    (Astring.String.is_infix ~affix:"red -> green" (render d))
+
+let added_important_is_not_a_move () =
+  (* [!important] decides the cascade winner, so the same property and value
+     with it added is not the declaration that left. *)
+  let d =
+    diff_of ~expected:".a{color:red}.b{x:1}.a{margin:0}"
+      ~actual:".a{color:red;margin:0 !important}.b{x:1}"
+  in
+  Alcotest.(check int)
+    "nothing is called a move" 0
+    (List.length (rearranged_of d));
+  Alcotest.(check bool)
+    "the change of weight is named" true
+    (Astring.String.is_infix ~affix:"!important" (render d))
+
+let one_of_two_duplicates_lost_is_not_a_move () =
+  (* Declarations are compared as a multiset, so dropping one of two identical
+     ones is a loss even though the property still appears on both sides. *)
+  let d =
+    diff_of ~expected:".a{top:0}.b{x:1}.a{top:0}" ~actual:".a{top:0}.b{x:1}"
+  in
+  Alcotest.(check int)
+    "nothing is called a move" 0
+    (List.length (rearranged_of d))
+
+let unrelated_selectors_are_not_a_move () =
+  (* The declaration moves to a different selector, changing what it applies
+     to. *)
+  let d =
+    diff_of ~expected:".a{color:red}.b{margin:0}"
+      ~actual:".a{color:red;margin:0}.b{}"
+  in
+  Alcotest.(check int)
+    "nothing is called a move" 0
+    (List.length (rearranged_of d))
+
+let rearranged_survives_pp_simple () =
+  match rearranged_of (diff_of ~expected:split ~actual:joined) with
+  | [ _ ] ->
+      let d = diff_of ~expected:split ~actual:joined in
+      let buf = Buffer.create 64 in
+      List.iter (Cascade_diff.Tree_diff.pp_rule_diff_simple buf) d.rules;
+      Alcotest.(check bool)
+        "the compact form names it" true
+        (Astring.String.is_infix ~affix:"Rearranged" (Buffer.contents buf))
+  | _ -> Alcotest.fail "expected one rearranged rule"
+
 let suite =
   ( "tree_diff",
     [
@@ -434,6 +591,29 @@ let suite =
         diff_nesting_parent_props_only;
       Alcotest.test_case "duplicate condition blocks reconcile" `Quick
         duplicate_condition_blocks_reconcile;
+      Alcotest.test_case "rearranged reported" `Quick rearranged_reported;
+      Alcotest.test_case "rearranged is a difference" `Quick
+        rearranged_is_a_difference;
+      Alcotest.test_case "rearranged reports one node" `Quick
+        rearranged_reports_one_node;
+      Alcotest.test_case "rearranged names the move" `Quick
+        rearranged_names_the_move;
+      Alcotest.test_case "rearranged same at either depth" `Quick
+        rearranged_same_at_either_depth;
+      Alcotest.test_case "lost declaration is not a move" `Quick
+        lost_declaration_is_not_a_move;
+      Alcotest.test_case "gained declaration is not a move" `Quick
+        gained_declaration_is_not_a_move;
+      Alcotest.test_case "changed value is not a move" `Quick
+        changed_value_is_not_a_move;
+      Alcotest.test_case "added important is not a move" `Quick
+        added_important_is_not_a_move;
+      Alcotest.test_case "one of two duplicates lost is not a move" `Quick
+        one_of_two_duplicates_lost_is_not_a_move;
+      Alcotest.test_case "unrelated selectors are not a move" `Quick
+        unrelated_selectors_are_not_a_move;
+      Alcotest.test_case "rearranged survives pp_rule_diff_simple" `Quick
+        rearranged_survives_pp_simple;
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "pp_rule_diff_simple does not crash" `Quick
         pp_rule_diff_simple_ok;


### PR DESCRIPTION
`cascade diff` named a selector twice when its declarations sat on different rules on the two sides, once losing one and once gaining another, which reads as a contradiction. Such a group now reports as one entry saying the declarations moved between rules, listing them. The difference is still reported and still exits 1: which rule carries a declaration decides how it resolves against an overlapping selector's rules, which is the real ordering difference the tw parity run found.

Top-level rules skipped the same-selector merge that rules inside a container go through, so one difference reported two ways depending on depth; both depths now use the same assembly. Follow-up to #259.