### PR TITLE
diff: list the two files in header order in the size summary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -161,6 +161,11 @@ identical, rather than as spurious changes.
 
 ### Diff report
 
+- The size summary lists the two files in the order of the `---` and `+++`
+  headers below it. It printed the second file first, so a comparison that
+  added rules read as a shrink and every percentage was measured against the
+  wrong baseline (#261)
+
 - A selector written by more than one rule is reported once, at the top level
   as well as inside a container. Two rules under one selector produced a node
   each carrying the same label, one saying a declaration was added and the

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -638,12 +638,13 @@ let pp_stats buf stats =
       float_of_int char_diff *. 100.0 /. float_of_int stats.expected_chars
     else 0.0
   in
+  (* Same order as the [---] / [+++] headers below: expected, then actual. *)
   add_strings buf
     [
       "CSS: ";
-      string_of_int stats.actual_chars;
-      " chars vs ";
       string_of_int stats.expected_chars;
+      " chars vs ";
+      string_of_int stats.actual_chars;
       " chars (";
     ];
   add_pct buf char_diff_pct;

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -21,7 +21,7 @@ edit.
   > .x { color: blue }
   > EOF
   $ NO_COLOR=1 cascade diff c.css d.css
-  CSS: 19 chars vs 18 chars (5.6% diff)
+  CSS: 18 chars vs 19 chars (5.6% diff)
   Changes: 1 modified rule
   
   --- c.css
@@ -35,7 +35,7 @@ Forcing colour on emits ANSI markers even into a pipe; the default
 resolves to plain off-tty, as the NO_COLOR run above shows.
 
   $ cascade diff --color=always c.css d.css | cat -v | head -5
-  CSS: 19 chars vs 18 chars (5.6% diff)
+  CSS: 18 chars vs 19 chars (5.6% diff)
   Changes: 1 modified rule
   
   ^[[33m---^[[0m ^[[33mc.css^[[0m
@@ -52,7 +52,7 @@ diffing).
   > .x { color: #f00 }
   > EOF
   $ NO_COLOR=1 cascade diff --diff=tree e.css f.css
-  CSS: 19 chars vs 18 chars (5.6% diff)
+  CSS: 18 chars vs 19 chars (5.6% diff)
   Changes: 1 modified rule
   
   --- e.css
@@ -154,7 +154,7 @@ The --diff=string mode falls back to character-level diffing.
   > .x { color: blue }
   > EOF
   $ NO_COLOR=1 cascade diff --diff=string g.css h.css
-  CSS: 19 chars vs 18 chars (5.6% diff)
+  CSS: 18 chars vs 19 chars (5.6% diff)
   No structural differences
   
   Strings differ at position 12 (line 0, col 12)
@@ -169,3 +169,25 @@ The --diff=string mode falls back to character-level diffing.
   [1]
 
 
+
+The size summary lists the two files in the order of the headers below it:
+the first file given, then the second.
+
+  $ cat > one.css <<EOF
+  > .x { color: red }
+  > EOF
+  $ cat > many.css <<EOF
+  > .x { color: red } .y { top: 0 } .z { left: 0 }
+  > EOF
+  $ NO_COLOR=1 cascade diff one.css many.css
+  CSS: 18 chars vs 47 chars (161.1% diff)
+  Changes: 2 added rules
+  
+  --- one.css
+  +++ many.css
+  ├─ .y
+  │     + top 0
+  └─ .z
+        + left 0
+  
+  [1]

--- a/test/cli/diff_blocks.t
+++ b/test/cli/diff_blocks.t
@@ -27,7 +27,7 @@ each side.
   > @media print{.t3{color:#0f0}}
   > EOF
   $ NO_COLOR=1 cascade diff --diff=tree --depth=max blocks-split.css blocks-merged.css
-  CSS: 189 chars vs 204 chars (7.4% diff)
+  CSS: 204 chars vs 189 chars (7.4% diff)
   Changes: 1 changed container
   
   --- blocks-split.css

--- a/test/cli/diff_depth.t
+++ b/test/cli/diff_depth.t
@@ -10,7 +10,7 @@ report stops fitting.
   > .x { color: blue; margin: 1px }
   > EOF
   $ NO_COLOR=1 cascade diff a.css b.css
-  CSS: 32 chars vs 29 chars (10.3% diff)
+  CSS: 29 chars vs 32 chars (10.3% diff)
   Changes: 1 modified rule
   
   --- a.css
@@ -27,7 +27,7 @@ Pinning a depth cuts the tree there and records what it hid, so an
 elided subtree never reads as an empty one.
 
   $ NO_COLOR=1 cascade diff --depth=1 a.css b.css
-  CSS: 32 chars vs 29 chars (10.3% diff)
+  CSS: 29 chars vs 32 chars (10.3% diff)
   Changes: 1 modified rule
   
   --- a.css
@@ -46,7 +46,7 @@ qualifies every difference below it.
   > .x { color: red; width: <value> }
   > EOF
   $ NO_COLOR=1 cascade diff a.css warn.css
-  CSS: 34 chars vs 29 chars (17.2% diff)
+  CSS: 29 chars vs 34 chars (17.2% diff)
   Changes: 1 modified rule
   
   warn.css parse warning: <string>: read_declaration/width: bad value for width: expected one of at [24-25] (in component)

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -18,7 +18,7 @@ is real and must still be reported.
   > @layer utilities{.drop-shadow-sm{--tw-drop-shadow-size:drop-shadow(0 1px 2px var(--tw-drop-shadow-color,#00000026));--tw-drop-shadow:drop-shadow(var(--drop-shadow-sm));filter:var(--tw-blur,)var(--tw-brightness,)var(--tw-contrast,)var(--tw-grayscale,)var(--tw-hue-rotate,)var(--tw-invert,)var(--tw-saturate,)var(--tw-sepia,)var(--tw-drop-shadow,)}.drop-shadow-indigo-500{--tw-drop-shadow-color:oklch(58.5%.233 277.117)}@supports(color:color-mix(in lab,red,red)){.drop-shadow-indigo-500{--tw-drop-shadow-color:color-mix(in oklab,var(--color-indigo-500) var(--tw-drop-shadow-alpha),transparent)}}.drop-shadow-indigo-500{--tw-drop-shadow:var(--tw-drop-shadow-size)}.drop-shadow-blue-500\/50{--tw-drop-shadow-color:#3080ff80}@supports(color:color-mix(in lab,red,red)){.drop-shadow-blue-500\/50{--tw-drop-shadow-color:color-mix(in oklab,color-mix(in oklab,var(--color-blue-500) 50%,transparent) var(--tw-drop-shadow-alpha),transparent)}}.drop-shadow-blue-500\/50{--tw-drop-shadow:var(--tw-drop-shadow-size)}}
   > EOF
   $ cascade diff --diff=canonical --prune-unused-custom-props --depth=max ref.css tw.css
-  CSS: 1003 chars vs 1024 chars (2.1% diff)
+  CSS: 1024 chars vs 1003 chars (2.1% diff)
   Changes: 1 changed container
   
   --- ref.css
@@ -41,7 +41,7 @@ A top-level group reports the same way as one inside a container.
   > .a{color:red;margin:0}.b{color:blue}
   > EOF
   $ cascade diff --depth=max split.css joined.css
-  CSS: 37 chars vs 40 chars (7.5% diff)
+  CSS: 40 chars vs 37 chars (7.5% diff)
   Changes: 1 rearranged rule
   
   --- split.css
@@ -61,7 +61,7 @@ A top-level group reports the same way as one inside a container.
   > @layer u{.a{color:red;margin:0}.b{color:blue}}
   > EOF
   $ cascade diff --depth=max split_layer.css joined_layer.css
-  CSS: 47 chars vs 50 chars (6.0% diff)
+  CSS: 50 chars vs 47 chars (6.0% diff)
   Changes: 1 changed container
   
   --- split_layer.css
@@ -81,7 +81,7 @@ A declaration that does not survive is reported as a loss.
   > .a{color:red}.b{color:blue}
   > EOF
   $ cascade diff --depth=max split.css lost.css
-  CSS: 28 chars vs 40 chars (30.0% diff)
+  CSS: 40 chars vs 28 chars (30.0% diff)
   Changes: 1 removed rule
   
   --- split.css
@@ -100,7 +100,7 @@ an added !important changes what the selector writes.
   > .a{color:red;margin:0 !important}.b{color:blue}
   > EOF
   $ cascade diff --depth=max split.css weighted.css
-  CSS: 48 chars vs 40 chars (20.0% diff)
+  CSS: 40 chars vs 48 chars (20.0% diff)
   Changes: 1 modified rule
   
   --- split.css


### PR DESCRIPTION
The `CSS: X chars vs Y chars` line printed the second file first, contradicting the `---` and `+++` headers two lines below it: a comparison that added rules read as a shrink, and the percentage was measured against the file the report calls the actual one rather than the expected one.

Stacked on #260, which rewrites some of the same cram expectations.