### PR TITLE
diff: compare the whole @property body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -161,14 +161,16 @@ identical, rather than as spurious changes.
 
 ### Diff report
 
-- A rule is reported as reordered only when its order against a statement both
-  sides have actually inverted. Order was judged on absolute position, so
-  dropping a rule shifted every statement after it: a rule whose declarations
-  merely commute was reported as moved, and one holding a real declaration
-  reorder had it overwritten by a claim about the rule's position, which is not
-  what changed and drops the declarations the entry needs to name it. A rule
-  that moves past others is now reported once, on the rule that moved, rather
-  than on each rule it passed (#263)
+- An `@property` is compared on its whole body, and the entry names the
+  descriptors that differ. Two registrations for one name differing in `syntax`
+  or `initial-value` compared equal, so `--diff=canonical` called the
+  stylesheets identical, and an `inherits`-only change was reported as a
+  position change (#264)
+
+- A rule is reported as reordered only when it moved against another rule.
+  Dropping a rule shifted every position after it, so an unmoved rule was
+  reported as reordered, and one move was reported on every rule it passed
+  (#263)
 
 - The size summary lists the two files in the order of the `---` and `+++`
   headers below it. It printed the second file first, so a comparison that

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -380,6 +380,13 @@ let pp_content_changed ~style ~prefix ~child_prefix buf ~selector
     property_changes <> [] || added_properties <> [] || removed_properties <> []
   in
   if (not has_any_changes) && old_declarations = new_declarations then ()
+  else if selector = "" then
+    (* The parent already named the subject, as it does for an [@property] whose
+       descriptors changed. Repeating it as a child label reads as two entries
+       for one registration. *)
+    pp_content_changed_body ~style ~child_prefix buf ~old_declarations
+      ~new_declarations ~property_changes ~added_properties ~removed_properties
+      ~has_any_changes
   else (
     add_strings buf [ prefix; selector; "\n" ];
     pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
@@ -2012,13 +2019,51 @@ let detect_order_only_change ~container_type added removed items1 items2 =
                })
       | _ -> None
 
+(* The descriptors an [@property] body carries, in the order CSS Properties and
+   Values 1 sec. 2 defines them. The syntax and the initial value are
+   existentially typed and share that existential, so they are compared on the
+   form they serialise to rather than on the value. *)
+let property_descriptors = function
+  | Css.Property_info { syntax; inherits; initial_value; _ } ->
+      ("syntax", Pp.to_string ~minify:true Css.Variables.pp_syntax syntax)
+      :: ("inherits", if inherits then "true" else "false")
+      ::
+      (match initial_value with
+      | None -> []
+      | Some value ->
+          [
+            ( "initial-value",
+              Pp.to_string ~minify:true (Css.Variables.pp_value syntax) value );
+          ])
+
+(* A registration decides how every use of the custom property parses, animates
+   and inherits, so a descriptor that differs is a difference. *)
+let property_descriptor_changes prop1 prop2 =
+  let descs1 = property_descriptors prop1 in
+  let descs2 = property_descriptors prop2 in
+  let changed =
+    List.filter_map
+      (fun (name, expected_value) ->
+        match List.assoc_opt name descs2 with
+        | Some actual_value when actual_value <> expected_value ->
+            Some { property_name = name; expected_value; actual_value }
+        | _ -> None)
+      descs1
+  in
+  let only_in others (name, _) =
+    if List.mem_assoc name others then None else Some name
+  in
+  ( changed,
+    List.filter_map (only_in descs1) descs2,
+    List.filter_map (only_in descs2) descs1 )
+
 let property_diff items1 items2 =
   let key_of (Css.Property_info { name; _ }) = name in
   let key_equal = String.equal in
   let is_empty_diff prop1 prop2 =
-    let (Css.Property_info { name = n1; inherits = i1; _ }) = prop1 in
-    let (Css.Property_info { name = n2; inherits = i2; _ }) = prop2 in
-    n1 = n2 && i1 = i2
+    let (Css.Property_info { name = n1; _ }) = prop1 in
+    let (Css.Property_info { name = n2; _ }) = prop2 in
+    n1 = n2 && property_descriptors prop1 = property_descriptors prop2
   in
   let added, removed, modified_pairs =
     diffs ~key_of ~key_equal ~is_empty_diff items1 items2
@@ -2031,7 +2076,9 @@ let property_diff items1 items2 =
   in
   let modified =
     List.map
-      (fun (Css.Property_info { name; _ }, _) -> (name, [], []))
+      (fun ((Css.Property_info { name; _ } as prop1), prop2) ->
+        let changed, added, removed = property_descriptor_changes prop1 prop2 in
+        (name, changed, added, removed))
       modified_pairs
   in
   (added, removed, modified)
@@ -2244,6 +2291,54 @@ let condition_rules_of_container (name_opt, condition, rules) =
 
 let modified_container_of_pair ((name_opt, condition, rules1), (_, _, rules2)) =
   (container_condition_string name_opt condition, rules1, rules2)
+
+(* Process property rules. An [@property] body holds descriptors, not
+   statements, so there is nothing below it to recurse into. *)
+let process_nested_properties stmts1 stmts2 =
+  let items1 = List.filter_map Css.as_property stmts1 in
+  let items2 = List.filter_map Css.as_property stmts2 in
+  let added, removed, modified = property_diff items1 items2 in
+  let diffs = ref [] in
+  List.iter
+    (fun (name, rules) ->
+      diffs :=
+        Added { container_type = `Property; condition = name; rules } :: !diffs)
+    added;
+  List.iter
+    (fun (name, rules) ->
+      diffs :=
+        Removed { container_type = `Property; condition = name; rules }
+        :: !diffs)
+    removed;
+  List.iter
+    (fun (name, property_changes, added_properties, removed_properties) ->
+      (* The body is reported as the descriptors that changed. Left empty, the
+         renderer has nothing to show and falls back to calling the entry a
+         position change, which is not what differs. *)
+      let rule_changes =
+        [
+          Content_changed
+            {
+              selector = "";
+              old_declarations = [];
+              new_declarations = [];
+              property_changes;
+              added_properties;
+              removed_properties;
+            };
+        ]
+      in
+      diffs :=
+        Modified
+          {
+            info = { container_type = `Property; condition = name; rules = [] };
+            actual_rules = [];
+            rule_changes;
+            container_changes = [];
+          }
+        :: !diffs)
+    modified;
+  !diffs @ property_reorder_diffs stmts1 stmts2 items1 items2
 
 (* Mutual recursion declarations *)
 (* Check if two rule-lists under the same media condition differ *)
@@ -2477,42 +2572,6 @@ and process_nested_containers_with_name ~depth stmts1 stmts2 =
   collect_container_diffs ~container_type:`Container ~depth added removed
     modified
 
-(* Process property rules *)
-and process_nested_properties ~depth stmts1 stmts2 =
-  let items1 = List.filter_map Css.as_property stmts1 in
-  let items2 = List.filter_map Css.as_property stmts2 in
-  let added, removed, modified = property_diff items1 items2 in
-  let diffs = ref [] in
-  List.iter
-    (fun (name, rules) ->
-      diffs :=
-        Added { container_type = `Property; condition = name; rules } :: !diffs)
-    added;
-  List.iter
-    (fun (name, rules) ->
-      diffs :=
-        Removed { container_type = `Property; condition = name; rules }
-        :: !diffs)
-    removed;
-  List.iter
-    (fun (name, rules1, rules2) ->
-      let rule_changes = to_rule_changes rules1 rules2 in
-      let nested_containers =
-        nested_differences ~depth:(depth + 1) rules1 rules2
-      in
-      diffs :=
-        Modified
-          {
-            info =
-              { container_type = `Property; condition = name; rules = rules1 };
-            actual_rules = rules2;
-            rule_changes;
-            container_changes = nested_containers;
-          }
-        :: !diffs)
-    modified;
-  !diffs @ property_reorder_diffs stmts1 stmts2 items1 items2
-
 (* Process CSS nesting: rules with nested child rules (& .foo { ... }) *)
 and process_nested_rules ~depth stmts1 stmts2 =
   (* Extract (selector_key, nested_statements) for all rules, including those
@@ -2578,7 +2637,7 @@ and nested_differences ?(depth = 0) (stmts1 : Css.statement list)
     (* Process container queries *)
     @ process_nested_containers_with_name ~depth stmts1 stmts2
     (* Process property declarations *)
-    @ process_nested_properties ~depth stmts1 stmts2
+    @ process_nested_properties stmts1 stmts2
     (* Process keyframes animations *)
     @ process_nested_keyframes ~depth stmts1 stmts2
     (* Process font-face rules *)

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -182,6 +182,99 @@ let diff_overlapping_decl_reorder_flagged () =
     "overlapping declaration reorder is not empty" false
     (Cascade_diff.Tree_diff.is_empty d)
 
+(* ===== @property registrations ===== *)
+
+(* The descriptor changes a modified [@property] reports, as "name: expected ->
+   actual". *)
+let property_descriptor_changes d =
+  List.concat_map
+    (fun (c : Cascade_diff.Tree_diff.container_diff) ->
+      match c with
+      | Cascade_diff.Tree_diff.Modified
+          { info = { container_type = `Property; _ }; rule_changes; _ } ->
+          List.concat_map
+            (fun (r : Cascade_diff.Tree_diff.rule_diff) ->
+              match r with
+              | Cascade_diff.Tree_diff.Content_changed { property_changes; _ }
+                ->
+                  List.map
+                    (fun (p : Cascade_diff.Tree_diff.declaration) ->
+                      p.property_name ^ ": " ^ p.expected_value ^ " -> "
+                      ^ p.actual_value)
+                    property_changes
+              | _ -> [])
+            rule_changes
+      | _ -> [])
+    d.Cascade_diff.Tree_diff.containers
+
+let diff_property_syntax_changed () =
+  (* A registration decides how every use of the custom property parses, so a
+     different syntax and initial value is a difference, not a match. *)
+  let expected =
+    parse
+      "@property --x { syntax: '<length>'; inherits: false; initial-value: 0px \
+       }"
+  in
+  let actual =
+    parse
+      "@property --x { syntax: '<color>'; inherits: false; initial-value: red }"
+  in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check bool)
+    "changed registration is not empty" false
+    (Cascade_diff.Tree_diff.is_empty d);
+  Alcotest.(check (list string))
+    "names both descriptors"
+    [ "syntax: \"<length>\" -> \"<color>\""; "initial-value: 0px -> red" ]
+    (property_descriptor_changes d)
+
+let diff_property_inherits_changed () =
+  (* [inherits] was the one descriptor compared, but the entry carried no change
+     detail and rendered as a position change. *)
+  let expected = parse "@property --x { syntax: '*'; inherits: false }" in
+  let actual = parse "@property --x { syntax: '*'; inherits: true }" in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check (list string))
+    "names the descriptor that changed"
+    [ "inherits: false -> true" ]
+    (property_descriptor_changes d)
+
+let diff_property_identical_is_empty () =
+  let css =
+    parse
+      "@property --x { syntax: '<length>'; inherits: false; initial-value: 0px \
+       }"
+  in
+  let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css in
+  Alcotest.(check bool)
+    "identical registration is empty" true
+    (Cascade_diff.Tree_diff.is_empty d)
+
+let diff_property_initial_value_added () =
+  let expected = parse "@property --x { syntax: '*'; inherits: false }" in
+  let actual =
+    parse "@property --x { syntax: '*'; inherits: false; initial-value: red }"
+  in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  let added =
+    List.concat_map
+      (fun (c : Cascade_diff.Tree_diff.container_diff) ->
+        match c with
+        | Cascade_diff.Tree_diff.Modified { rule_changes; _ } ->
+            List.concat_map
+              (fun (r : Cascade_diff.Tree_diff.rule_diff) ->
+                match r with
+                | Cascade_diff.Tree_diff.Content_changed { added_properties; _ }
+                  ->
+                    added_properties
+                | _ -> [])
+              rule_changes
+        | _ -> [])
+      d.containers
+  in
+  Alcotest.(check (list string))
+    "names the descriptor gained" [ "initial-value" ] added
+
 (* ===== Container (media) changes ===== *)
 
 let diff_media_added () =
@@ -640,6 +733,14 @@ let suite =
         diff_neutral_decl_reorder_is_empty;
       Alcotest.test_case "overlapping declaration reorder flagged" `Quick
         diff_overlapping_decl_reorder_flagged;
+      Alcotest.test_case "property syntax changed" `Quick
+        diff_property_syntax_changed;
+      Alcotest.test_case "property inherits changed" `Quick
+        diff_property_inherits_changed;
+      Alcotest.test_case "property identical is empty" `Quick
+        diff_property_identical_is_empty;
+      Alcotest.test_case "property initial-value added" `Quick
+        diff_property_initial_value_added;
       Alcotest.test_case "media added" `Quick diff_media_added;
       Alcotest.test_case "media removed" `Quick diff_media_removed;
       Alcotest.test_case "layer added" `Quick diff_layer_added;


### PR DESCRIPTION
`property_diff` compared only a registration's name and `inherits`, so two `@property` blocks for one name differing in `syntax` or `initial-value` compared equal and `--diff=canonical` reported the two stylesheets as identical. The descriptors decide how every use of the custom property parses, animates and inherits, so they are now compared, and the entry names the ones that differ.

That also fixes the second half: a modified registration carried no change detail, so the renderer fell back to labelling it a position change even when nothing had moved. Follow-up to #263, which fixed the position claim for rules.