### PR TITLE
pp: print a large decimal as a number, not spliced digits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,9 @@
   comma-separated. The layers were joined with spaces, so
   `background-position: 30% 50%, 70% 50%` read back as a single four-value
   position and minified to `30% 70%` (#209)
+- A non-integer above roughly 4.6e10 prints as a number again:
+  `transform: scale(123456789012.25)` printed `scale(1.2345678.9012e+19)`,
+  which read back as two arguments (#265)
 
 ### New properties and values
 

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -323,12 +323,18 @@ let format_decimal_value ~drop_leading_zero max_decimals is_neg abs_f =
       let d = max_decimals + min 24 (max 0 leading_zeros) in
       (d, floor ((abs_f *. (10.0 ** float_of_int d)) +. 0.5))
   in
-  let s =
-    if scaled <= float_of_int max_int then string_of_int (int_of_float scaled)
-    else string_of_float scaled
-  in
-  let s = trim_decimal_suffix s in
-  format_decimal ~drop_leading_zero s max_decimals is_neg
+  if scaled > float_of_int max_int then
+    (* [format_decimal] splices the decimal point into what it takes for a pure
+       digit string, but a scaled magnitude past [max_int] only stringifies
+       through exponent notation. Print the magnitude itself, the way
+       [format_integer] does over the same range. *)
+    let s =
+      trim_decimal_suffix (string_of_float abs_f) |> strip_exponent_plus
+    in
+    if is_neg then "-" ^ s else s
+  else
+    let s = string_of_int (int_of_float scaled) in
+    format_decimal ~drop_leading_zero s max_decimals is_neg
 
 let string_of_float ?(drop_leading_zero = false) ?(max_decimals = 8) f =
   (* Handle special cases first *)

--- a/test/test_pp.ml
+++ b/test/test_pp.ml
@@ -111,6 +111,42 @@ let float_rounding_and_trim () =
   check_float_n ~minify:true 3 0.25 ~expected:".25";
   check_float_n ~minify:true 2 0.999 ~expected:"1"
 
+let float_large_decimal () =
+  (* A non-integer whose scaled magnitude passes [max_int] stringifies through
+     exponent notation, and the decimal point is then spliced into what is no
+     longer a pure digit string. Print the magnitude itself instead. *)
+  check_float (1e11 +. 0.5) ~expected:"100000000000";
+  check_float 123456789012.25 ~expected:"123456789012";
+  check_float 999999999999.75 ~expected:"1e12";
+  check_float (-123456789012.25) ~expected:"-123456789012";
+  (* Below the overflow the scaled-integer path stays byte for byte the same. *)
+  check_float (1e10 +. 0.5) ~expected:"10000000000.5"
+
+let float_large_decimal_reparses () =
+  let check_reparse f =
+    let printed = Pp.to_string ~minify:true Pp.float f in
+    match float_of_string_opt printed with
+    | None -> failf "%S is not a number" printed
+    | Some v ->
+        check bool
+          (Fmt.str "%s reads back as %f" printed f)
+          true
+          (Float.abs (v -. f) <= Float.abs f *. 1e-9)
+  in
+  List.iter check_reparse
+    [ 1e11 +. 0.5; 123456789012.25; 999999999999.75; -123456789012.25 ]
+
+let float_large_decimal_in_stylesheet () =
+  let check_sheet name input expected =
+    match of_string input with
+    | Error e -> failf "%s: %s" name (Pp.to_string Error.pp e)
+    | Ok { stylesheet; _ } ->
+        check string name expected (to_string ~minify:true stylesheet)
+  in
+  check_sheet "scale" "a{transform:scale(123456789012.25)}"
+    "a{transform:scale(123456789012)}";
+  check_sheet "opacity" "b{opacity:calc(999999999999.75)}" "b{opacity:1e12}"
+
 let cond_case () =
   let pp = Pp.cond (fun ctx -> not (Pp.minified ctx)) Pp.string Pp.nop in
 
@@ -161,6 +197,11 @@ let suite =
       Alcotest.test_case "float zero nan inf" `Quick float_zero_and_nan_inf;
       Alcotest.test_case "float rounding and trim" `Quick
         float_rounding_and_trim;
+      Alcotest.test_case "float large decimal" `Quick float_large_decimal;
+      Alcotest.test_case "float large decimal reparses" `Quick
+        float_large_decimal_reparses;
+      Alcotest.test_case "float large decimal in stylesheet" `Quick
+        float_large_decimal_in_stylesheet;
       Alcotest.test_case "cond" `Quick cond_case;
       Alcotest.test_case "space if pretty" `Quick space_if_pretty_case;
       Alcotest.test_case "combinations" `Quick combinations;


### PR DESCRIPTION
A non-integer whose scaled magnitude passes max_int stringifies through exponent notation, and format_decimal then splices a decimal point into what is no longer a pure digit string: `scale(123456789012.25)` printed `scale(1.2345678.9012e+19)`, which reads back as two arguments. Print the magnitude itself in that range, the way format_integer already does.