### PR TITLE
variables: enumerate every property in vars_of_property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -128,6 +128,10 @@
   wrong definition (#187, #189)
 - `cascade apply` projects rules inside `@layer` onto elements; a fully layered
   stylesheet, such as Tailwind v4 output, previously inlined nothing (#188)
+- `Css.vars_of_declarations` reports the `var()` references of the 39 properties
+  a wildcard used to answer with none, so `Css.resolve_theme` emits the theme
+  binding for `inline-size: var(--w)` as it already did for `width: var(--w)`
+  instead of leaving the reference undefined (#266)
 
 ### Canonical diff
 

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1832,6 +1832,86 @@ let vars_of_list_style (value : Properties.list_style) : any_var list =
       @ opt vars_of_list_style_image image
   | _ -> []
 
+(* CSS Variables L1 sec. 3: a custom property's value can itself reference other
+   custom properties. A [Typed] value embeds real [var] handles, so recurse via
+   the kind; a raw [Tokens] value carries refs as [var()] functions in the
+   stream, recovered structurally by {!vars_of_token_stream}. *)
+let vars_of_kind : type a. a kind -> a -> any_var list =
+ fun kind value ->
+  match kind with
+  | Length -> vars_of_length value
+  | Color -> vars_of_color value
+  | Rgb -> vars_of_rgb value
+  | Number -> vars_of_number_value value
+  | Int -> []
+  | Float -> []
+  | Percentage -> vars_of_percentage value
+  | Length_percentage -> vars_of_length_percentage value
+  | Number_percentage -> []
+  | Opacity -> []
+  | Value -> []
+  | Duration -> vars_of_duration value
+  | Aspect_ratio -> vars_of_aspect_ratio value
+  | Border_style -> vars_of_border_style value
+  | Outline_style -> []
+  | Border -> vars_of_border value
+  | Font_weight -> vars_of_font_weight value
+  | Font_size -> vars_of_font_size value
+  | Line_height -> vars_of_line_height value
+  | Font_family -> vars_of_font_family value
+  | Font_feature_settings -> vars_of_font_feature_settings value
+  | Font_variation_settings -> vars_of_font_variation_settings value
+  | Numeric -> vars_of_font_variant_numeric value
+  | Font_variant_numeric_token -> []
+  | Blend_mode -> vars_of_blend_mode value
+  | Scroll_snap_strictness -> vars_of_scroll_snap_strictness value
+  | Angle -> vars_of_angle value
+  | Rotate -> vars_of_rotate_value value
+  | Scale -> vars_of_scale value
+  | Shadow -> vars_of_shadow value
+  | Box_shadow -> vars_of_shadow value
+  | Content -> vars_of_content value
+  | Gradient_stop -> vars_of_gradient_stop value
+  | Gradient_direction -> vars_of_gradient_direction value
+  | Gradient_position -> vars_of_gradient_position value
+  | Animation -> vars_of_animation value
+  | Timing_function -> []
+  | Transform -> vars_of_transform value
+  | Touch_action -> []
+  | Transition_property_value -> vars_of_transition_property_value value
+  | Background_image -> vars_of_background_image value
+  | Z_index -> []
+  | Filter -> vars_of_filter value
+  | Font_src -> []
+
+(* The structural scans return each name with its leading [--]; [Values.var_ref]
+   re-adds it, so strip the prefix before rebuilding the handle. *)
+let vars_of_ref_names names : any_var list =
+  List.rev_map
+    (fun name ->
+      let bare =
+        if String.length name >= 2 && name.[0] = '-' && name.[1] = '-' then
+          String.sub name 2 (String.length name - 2)
+        else name
+      in
+      V (Values.var_ref bare))
+    names
+
+(* Names referenced via real [var()] functions in an opaque token stream. *)
+let vars_of_token_stream (components : Component.t list) : any_var list =
+  vars_of_ref_names (var_refs_in_components [] components)
+
+(* Names referenced by a property whose value the reader keeps as raw text. The
+   text never went through a typed parser, so a [var()] in it is recoverable
+   only by re-tokenising, exactly as for an opaque custom-property stream. *)
+let vars_of_value_string (value : string) : any_var list =
+  vars_of_ref_names (var_refs_in_value_string value)
+
+let vars_of_custom_property_value : custom_property_value -> any_var list =
+  function
+  | Typed { kind; value } -> vars_of_kind kind value
+  | Tokens components -> vars_of_token_stream components
+
 (* Extract variables from CSS property values using type-specific extraction
    functions *)
 let vars_of_property : type a. a property -> a -> any_var list =
@@ -2383,79 +2463,60 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Border_inline, value -> vars_of_border value
   | Border_inline_start, value -> vars_of_border value
   | Border_inline_end, value -> vars_of_border value
-  (* Default case for all other properties *)
-  | _ -> []
-
-(* CSS Variables L1 sec. 3: a custom property's value can itself reference other
-   custom properties. A [Typed] value embeds real [var] handles, so recurse via
-   the kind; a raw [Tokens] value carries refs as [var()] functions in the
-   stream, recovered structurally by {!vars_of_token_stream}. *)
-let vars_of_kind : type a. a kind -> a -> any_var list =
- fun kind value ->
-  match kind with
-  | Length -> vars_of_length value
-  | Color -> vars_of_color value
-  | Rgb -> vars_of_rgb value
-  | Number -> vars_of_number_value value
-  | Int -> []
-  | Float -> []
-  | Percentage -> vars_of_percentage value
-  | Length_percentage -> vars_of_length_percentage value
-  | Number_percentage -> []
-  | Opacity -> []
-  | Value -> []
-  | Duration -> vars_of_duration value
-  | Aspect_ratio -> vars_of_aspect_ratio value
-  | Border_style -> vars_of_border_style value
-  | Outline_style -> []
-  | Border -> vars_of_border value
-  | Font_weight -> vars_of_font_weight value
-  | Font_size -> vars_of_font_size value
-  | Line_height -> vars_of_line_height value
-  | Font_family -> vars_of_font_family value
-  | Font_feature_settings -> vars_of_font_feature_settings value
-  | Font_variation_settings -> vars_of_font_variation_settings value
-  | Numeric -> vars_of_font_variant_numeric value
-  | Font_variant_numeric_token -> []
-  | Blend_mode -> vars_of_blend_mode value
-  | Scroll_snap_strictness -> vars_of_scroll_snap_strictness value
-  | Angle -> vars_of_angle value
-  | Rotate -> vars_of_rotate_value value
-  | Scale -> vars_of_scale value
-  | Shadow -> vars_of_shadow value
-  | Box_shadow -> vars_of_shadow value
-  | Content -> vars_of_content value
-  | Gradient_stop -> vars_of_gradient_stop value
-  | Gradient_direction -> vars_of_gradient_direction value
-  | Gradient_position -> vars_of_gradient_position value
-  | Animation -> vars_of_animation value
-  | Timing_function -> []
-  | Transform -> vars_of_transform value
-  | Touch_action -> []
-  | Transition_property_value -> vars_of_transition_property_value value
-  | Background_image -> vars_of_background_image value
-  | Z_index -> []
-  | Filter -> vars_of_filter value
-  | Font_src -> []
-
-(* Names referenced via real [var()] functions in an opaque token stream. The
-   structural scan returns each name with its leading [--]; [Values.var_ref]
-   re-adds it, so strip the prefix before rebuilding the handle. *)
-let vars_of_token_stream (components : Component.t list) : any_var list =
-  List.rev_map
-    (fun name ->
-      let bare =
-        if String.length name >= 2 && name.[0] = '-' && name.[1] = '-' then
-          String.sub name 2 (String.length name - 2)
-        else name
-      in
-      V (Values.var_ref bare))
-    (var_refs_in_components [] components)
-
-let vars_of_custom_property_value : custom_property_value -> any_var list =
-  function
-  | Typed { kind; value } -> vars_of_kind kind value
-  | Tokens components -> vars_of_token_stream components
+  (* Logical sizing longhands (CSS Logical 1 sec. 4.2): the same
+     <length-percentage> as the physical property each maps to. *)
+  | Inline_size, value -> vars_of_length_percentage value
+  | Min_inline_size, value -> vars_of_length_percentage value
+  | Max_inline_size, value -> vars_of_length_percentage value
+  | Block_size, value -> vars_of_length_percentage value
+  | Min_block_size, value -> vars_of_length_percentage value
+  | Max_block_size, value -> vars_of_length_percentage value
+  (* [inset] and its logical longhands hold a length list, like [top]. *)
+  | Inset, value -> vars_of_length_list value
+  | Inset_inline, value -> vars_of_length_list value
+  | Inset_inline_start, value -> vars_of_length_list value
+  | Inset_inline_end, value -> vars_of_length_list value
+  | Inset_block, value -> vars_of_length_list value
+  | Inset_block_start, value -> vars_of_length_list value
+  | Inset_block_end, value -> vars_of_length_list value
+  (* Logical scroll-margin / scroll-padding, matching the physical arms: the
+     two-value forms hold a list, the single-side longhands one length. *)
+  | Scroll_margin_inline, value -> vars_of_length_list value
+  | Scroll_margin_inline_start, value -> vars_of_length value
+  | Scroll_margin_inline_end, value -> vars_of_length value
+  | Scroll_margin_block, value -> vars_of_length_list value
+  | Scroll_margin_block_start, value -> vars_of_length value
+  | Scroll_margin_block_end, value -> vars_of_length value
+  | Scroll_padding_inline, value -> vars_of_length_list value
+  | Scroll_padding_inline_start, value -> vars_of_length value
+  | Scroll_padding_inline_end, value -> vars_of_length value
+  | Scroll_padding_block, value -> vars_of_length_list value
+  | Scroll_padding_block_start, value -> vars_of_length value
+  | Scroll_padding_block_end, value -> vars_of_length value
+  (* One position per background / mask layer, as for [object-position]. *)
+  | Background_position, value -> List.concat_map vars_of_position_value value
+  | Mask_position, value -> List.concat_map vars_of_position_value value
+  | Webkit_mask_position, value -> List.concat_map vars_of_position_value value
+  (* Remaining typed longhands. *)
+  | Text_emphasis_color, value -> vars_of_color value
+  | Text_underline_offset, value -> vars_of_length value
+  | Shape_margin, value -> vars_of_length_percentage value
+  | Line_height_step, value -> vars_of_length value
+  | Offset_distance, value -> vars_of_length_percentage value
+  | Transition_property, value -> vars_of_transition_property_list value
+  (* CSS Box Alignment 3 sec. 6.5: a one-value [place-self] sets both, so the
+     reader stores the [var()] in each half; the dedup collapses them. *)
+  | Place_self, (align, justify) ->
+      vars_of_align_self align @ vars_of_justify_self justify
+  (* CSS Backgrounds 3 sec. 6.2: [border-image-slice] is numbers, percentages
+     and the [fill] keyword, none of which carries a var handle. *)
+  | Border_image_slice, _ -> []
+  (* [shape-outside] and an unrecognised property are held as raw text and an
+     opaque token stream respectively; scan both structurally. *)
+  | Shape_outside, value -> vars_of_value_string value
+  | Unknown_property _, value -> vars_of_token_stream value
+  | Custom_property _, Custom_value { value; _ } ->
+      vars_of_custom_property_value value
 
 let rec extract_vars_of_declaration : declaration -> any_var list = function
   | Declaration

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -125,6 +125,92 @@ let spec_vars_of_property_matrix () =
       ("z-index", "z-index: var(--spec-z-index)");
     ]
 
+(* CSS Custom Properties L1 sec. 3: a var() reference is a reference whatever
+   property holds it. A logical property, a shorthand taking a length list and a
+   position-valued property each carry the reference exactly as their physical
+   or longhand twin does. *)
+let spec_vars_of_property_logical_matrix () =
+  let check property_name declaration =
+    let decl = Css.Declaration.of_string declaration in
+    let vars = vars_of_declarations [ decl ] in
+    Alcotest.(check int) property_name 1 (List.length vars)
+  in
+  List.iter
+    (fun (property_name, declaration) -> check property_name declaration)
+    [
+      ("inline-size", "inline-size: var(--spec-inline-size)");
+      ("min-inline-size", "min-inline-size: var(--spec-min-inline-size)");
+      ("max-inline-size", "max-inline-size: var(--spec-max-inline-size)");
+      ("block-size", "block-size: var(--spec-block-size)");
+      ("min-block-size", "min-block-size: var(--spec-min-block-size)");
+      ("max-block-size", "max-block-size: var(--spec-max-block-size)");
+      ("inset", "inset: var(--spec-inset)");
+      ("inset-inline", "inset-inline: var(--spec-inset-inline)");
+      ( "inset-inline-start",
+        "inset-inline-start: var(--spec-inset-inline-start)" );
+      ("inset-inline-end", "inset-inline-end: var(--spec-inset-inline-end)");
+      ("inset-block", "inset-block: var(--spec-inset-block)");
+      ("inset-block-start", "inset-block-start: var(--spec-inset-block-start)");
+      ("inset-block-end", "inset-block-end: var(--spec-inset-block-end)");
+      ("scroll-margin-inline", "scroll-margin-inline: var(--spec-sm-inline)");
+      ( "scroll-margin-inline-start",
+        "scroll-margin-inline-start: var(--spec-sm-inline-start)" );
+      ( "scroll-margin-inline-end",
+        "scroll-margin-inline-end: var(--spec-sm-inline-end)" );
+      ("scroll-margin-block", "scroll-margin-block: var(--spec-sm-block)");
+      ( "scroll-margin-block-start",
+        "scroll-margin-block-start: var(--spec-sm-block-start)" );
+      ( "scroll-margin-block-end",
+        "scroll-margin-block-end: var(--spec-sm-block-end)" );
+      ("scroll-padding-inline", "scroll-padding-inline: var(--spec-sp-inline)");
+      ( "scroll-padding-inline-start",
+        "scroll-padding-inline-start: var(--spec-sp-inline-start)" );
+      ( "scroll-padding-inline-end",
+        "scroll-padding-inline-end: var(--spec-sp-inline-end)" );
+      ("scroll-padding-block", "scroll-padding-block: var(--spec-sp-block)");
+      ( "scroll-padding-block-start",
+        "scroll-padding-block-start: var(--spec-sp-block-start)" );
+      ( "scroll-padding-block-end",
+        "scroll-padding-block-end: var(--spec-sp-block-end)" );
+      ("background-position", "background-position: var(--spec-bg-position)");
+      ("mask-position", "mask-position: var(--spec-mask-position)");
+      ( "-webkit-mask-position",
+        "-webkit-mask-position: var(--spec-webkit-mask-position)" );
+      ("text-emphasis-color", "text-emphasis-color: var(--spec-te-color)");
+      ("text-underline-offset", "text-underline-offset: var(--spec-tu-offset)");
+      ("shape-margin", "shape-margin: var(--spec-shape-margin)");
+      ("shape-outside", "shape-outside: var(--spec-shape-outside)");
+      ("line-height-step", "line-height-step: var(--spec-line-height-step)");
+      ("offset-distance", "offset-distance: var(--spec-offset-distance)");
+      ("transition-property", "transition-property: var(--spec-transition-prop)");
+      ("place-self", "place-self: var(--spec-place-self)");
+    ]
+
+(* CSS Custom Properties L1 sec. 3: [resolve_theme] emits a root definition for
+   every var() the sheet references and the theme resolves. A logical property
+   holding the reference must get the same binding as its physical twin, or the
+   emitted sheet carries an undefined var(). *)
+let spec_theme_binding_for_logical_property () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let theme = Css.Pp.String_set.singleton "w" in
+  let theme_defaults = function "w" -> Some "10px" | _ -> None in
+  let render css =
+    parse css
+    |> Css.resolve_theme ~theme ~theme_defaults
+    |> Css.to_string ~minify:true
+  in
+  Alcotest.(check string)
+    "width emits the theme binding" ":root{--w:10px}.a{width:var(--w)}"
+    (render ".a { width: var(--w) }");
+  Alcotest.(check string)
+    "inline-size emits the theme binding"
+    ":root{--w:10px}.a{inline-size:var(--w)}"
+    (render ".a { inline-size: var(--w) }")
+
 (* Not a roundtrip test *)
 let test_vars_of_declarations () =
   let custom_color_decl, color_var =
@@ -393,6 +479,12 @@ let tests =
     ("vars of calc", `Quick, test_vars_of_calc);
     ("vars of property", `Quick, test_vars_of_property);
     ("spec vars of property matrix", `Quick, spec_vars_of_property_matrix);
+    ( "spec vars of property logical matrix",
+      `Quick,
+      spec_vars_of_property_logical_matrix );
+    ( "spec theme binding for logical property",
+      `Quick,
+      spec_theme_binding_for_logical_property );
     ("vars of declarations", `Quick, test_vars_of_declarations);
     ("any_var_name", `Quick, test_any_var_name);
     ("extract custom declarations", `Quick, test_extract_custom_declarations);


### PR DESCRIPTION
vars_of_property ended in a wildcard that answered "no variables" for 39 properties, so resolve_theme left var() references in logical properties (inline-size, inset, scroll-margin-block, ...) dangling while their physical twins resolved. Delete the wildcard and enumerate every constructor, so the match is exhaustive and the next property addition fails to compile instead of silently inheriting the wrong answer.