### PR TITLE
shorthand: an unknown property overlaps what it may write

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,12 @@
 
 ### Minification
 
+- `--lossless` keeps a declaration whose property has no typed spelling in
+  source order against the shorthand that resets it. It sorted
+  `background-position-x` before `background` and `gap` before `grid-row-gap`,
+  changing what the rule rendered, and `--diff=canonical` called the two orders
+  identical for the same reason (#267)
+
 - A `hue-rotate()` with a zero argument drops it inside a custom property, the
   way it already did in `filter` directly. Filter Effects 1 sec. 8.5 makes an
   omitted argument 0, and `hue-rotate` names a filter function and nothing

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -547,6 +547,70 @@ let declaration_overlap_keys decl =
   | Declaration { property; _ } -> property_footprint property
   | _ -> [ key (Declaration.property_name decl) ]
 
+(* Every longhand name the typed footprints mention, sorted for binary search.
+   Taken from [property_footprint] itself rather than respelled, so the two
+   cannot drift: every arm not listed here has a footprint that is a subset of
+   one of these families. *)
+let known_footprint_keys =
+  let keys =
+    List.concat
+      [
+        property_footprint Properties.Margin;
+        property_footprint Properties.Margin_inline;
+        property_footprint Properties.Margin_block;
+        property_footprint Properties.Padding;
+        property_footprint Properties.Padding_inline;
+        property_footprint Properties.Padding_block;
+        property_footprint Properties.Inset;
+        property_footprint Properties.Inset_inline;
+        property_footprint Properties.Inset_block;
+        property_footprint Properties.Background;
+        property_footprint Properties.Flex;
+        property_footprint Properties.Flex_flow;
+        property_footprint Properties.Transition;
+        property_footprint Properties.Border;
+        property_footprint Properties.Border_block;
+        property_footprint Properties.Border_inline;
+        property_footprint Properties.Mask;
+        property_footprint Properties.Font;
+      ]
+  in
+  let arr = Array.of_list keys in
+  Array.sort compare arr;
+  arr
+
+let is_known_footprint_key k =
+  let lo = ref 0 and hi = ref (Array.length known_footprint_keys - 1) in
+  let found = ref false in
+  while (not !found) && !lo <= !hi do
+    let mid = (!lo + !hi) / 2 in
+    let v = Array.unsafe_get known_footprint_keys mid in
+    if overlap_key_equal v k then found := true
+    else if v < k then lo := mid + 1
+    else hi := mid - 1
+  done;
+  !found
+
+(* Whether an [Unknown_property] name can be placed in the footprint model. A
+   name a typed footprint mentions writes exactly the slot it names: a typed
+   longhand is recovered under its own name when its value defeats the typed
+   reader ([margin-top:var(--a) var(--b)] parses that way), and it conflicts
+   with the same declarations the typed spelling would. Any other name may be a
+   shorthand, a legacy alias, or a longhand of a family the footprints do not
+   model - [background-position-x] writes part of [background], [grid-row-gap]
+   is [row-gap] - so it has to be treated as touching whatever it is compared
+   against. *)
+let unknown_name_is_placeable name = is_known_footprint_key (key name)
+
+(* Whether one name is the other with a further hyphenated component, the shape
+   a longhand takes under its shorthand. Two placeable names of that shape write
+   a common slot even though neither footprint mentions the other. *)
+let name_extends other name =
+  let n = String.length other in
+  String.length name > n
+  && String.starts_with ~prefix:other name
+  && Char.equal name.[n] '-'
+
 let declarations_overlap_with_keys a a_keys b b_keys =
   match (unwrap_theme_guard a, unwrap_theme_guard b) with
   | ( Declaration { property = Custom_property a; _ },
@@ -554,15 +618,20 @@ let declarations_overlap_with_keys a a_keys b b_keys =
       String.equal a b
   | Declaration { property = Custom_property _; _ }, _ -> false
   | _, Declaration { property = Custom_property _; _ } -> false
-  | ( Declaration { property = Unknown_property a; _ },
-      Declaration { property = Unknown_property b; _ } ) ->
-      String.equal a b
-  | Declaration { property = Unknown_property _; _ }, _ -> false
-  | _, Declaration { property = Unknown_property _; _ } -> false
   | Declaration { property = All; _ }, Declaration { property; _ } ->
       not (is_excluded_from_all_reset property)
   | Declaration { property; _ }, Declaration { property = All; _ } ->
       not (is_excluded_from_all_reset property)
+  | ( Declaration { property = Unknown_property a; _ },
+      Declaration { property = Unknown_property b; _ } ) ->
+      String.equal a b || name_extends a b || name_extends b a
+      || not (unknown_name_is_placeable a && unknown_name_is_placeable b)
+  | Declaration { property = Unknown_property name; _ }, Declaration _ ->
+      (not (unknown_name_is_placeable name))
+      || overlap_keys_intersect a_keys b_keys
+  | Declaration _, Declaration { property = Unknown_property name; _ } ->
+      (not (unknown_name_is_placeable name))
+      || overlap_keys_intersect a_keys b_keys
   | Declaration _, Declaration _ -> overlap_keys_intersect a_keys b_keys
   | _ -> false
 

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -1030,6 +1030,19 @@ let canonical_same_selector_merge_across_intervening_rules () =
     "canonical diff reconciles split/merged same-selector forms rules" true
     (equal ~mode:`Canonical merged split)
 
+(* A property with no typed spelling still writes cascade slots: [background]
+   resets the X position [background-position-x] set, so the two orders render
+   differently and the canonical projection must keep them apart. *)
+let canonical_unknown_longhand_order () =
+  Alcotest.(check bool)
+    "an unknown longhand swapped past its shorthand is a difference" false
+    (equal ~mode:`Canonical ".a{background:red;background-position-x:10px}"
+       ".a{background-position-x:10px;background:red}");
+  Alcotest.(check bool)
+    "the same order is still equal" true
+    (equal ~mode:`Canonical ".a{background:red;background-position-x:10px}"
+       ".a{background:red;background-position-x:10px}")
+
 (* ===== Suite ===== *)
 
 let suite =
@@ -1044,6 +1057,8 @@ let suite =
       Alcotest.test_case
         "canonical same-selector merge across intervening rules" `Quick
         canonical_same_selector_merge_across_intervening_rules;
+      Alcotest.test_case "canonical unknown longhand order" `Quick
+        canonical_unknown_longhand_order;
       Alcotest.test_case "equal identical" `Quick equal_identical;
       Alcotest.test_case "equal different" `Quick equal_different;
       Alcotest.test_case "equal empty" `Quick equal_empty;

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -877,6 +877,34 @@ let test_lossless_declaration_order () =
     ".a{border-top:1px solid red;border-color:#00f}"
     (opt ~lossless:true ".a{border-top:1px solid red;border-color:blue}")
 
+let test_lossless_keeps_unknown_property_order () =
+  let opt css =
+    match Css.of_string ~strict:false css with
+    | Ok p ->
+        Css.to_string ~minify:true (Css.optimize ~lossless:true p.stylesheet)
+        |> String.trim
+    | Error _ -> Alcotest.fail "parse"
+  in
+  (* A property with no typed spelling still writes cascade slots, so the
+     canonical order must not move it past a shorthand that resets it:
+     [background] resets the X position the longhand set. *)
+  Alcotest.(check string)
+    "an unknown longhand stays after its shorthand"
+    ".a{background:red;background-position-x:10px}"
+    (opt ".a{background:red;background-position-x:10px}");
+  (* [grid-row-gap] is the legacy alias of [row-gap]; moving it after [gap]
+     would make the row gap 9px instead of 1px. *)
+  Alcotest.(check string)
+    "a legacy alias stays before the shorthand that resets it"
+    ".a{grid-row-gap:9px;gap:1px}"
+    (opt ".a{grid-row-gap:9px;gap:1px}");
+  (* A typed longhand whose value defeats the typed reader is recovered as an
+     unknown property under its own name, and is just as order-dependent. *)
+  Alcotest.(check string)
+    "a recovered typed longhand stays after its shorthand"
+    ".a{margin:0;margin-top:var(--a) var(--b)}"
+    (opt ".a{margin:0;margin-top:var(--a) var(--b)}")
+
 (* Regrouping - factoring a shared declaration into a selector list, and
    synthesising nesting from a run of adjacent rules - depends on how the input
    happened to order its rules: a rule sitting between two others decides
@@ -960,6 +988,9 @@ let optimize_tests =
       nesting_synthesis_can_be_disabled );
     ("vendor prefix strip", `Quick, test_vendor_prefix_strip);
     ("lossless declaration order", `Quick, test_lossless_declaration_order);
+    ( "lossless keeps unknown property order",
+      `Quick,
+      test_lossless_keeps_unknown_property_order );
     ( "var() colour functions preserved",
       `Quick,
       test_var_color_functions_preserved );

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -33,6 +33,51 @@ let test_declaration_covers_reset_boundaries () =
        (decl "border:1px solid red")
        (decl "border-top-width:2px"))
 
+let test_unknown_property_overlap () =
+  (* A property with no typed spelling still writes cascade slots. Judging it
+     disjoint from everything lets the canonical declaration order move it past
+     a shorthand that resets it, which changes what the rule renders. *)
+  Alcotest.(check bool)
+    "an unknown longhand overlaps the shorthand that resets it" true
+    (Shorthand.declarations_overlap (decl "background:red")
+       (decl "background-position-x:10px"));
+  Alcotest.(check bool)
+    "the relation is symmetric" true
+    (Shorthand.declarations_overlap
+       (decl "background-position-x:10px")
+       (decl "background:red"));
+  (* [grid-row-gap] is the legacy alias of [row-gap], which [gap] resets. *)
+  Alcotest.(check bool)
+    "an unknown legacy alias overlaps the shorthand it aliases into" true
+    (Shorthand.declarations_overlap (decl "grid-row-gap:9px") (decl "gap:1px"));
+  (* Two names with no typed spelling can still be a shorthand/longhand pair:
+     [grid-gap] is the legacy alias of [gap] and resets [grid-row-gap]. *)
+  Alcotest.(check bool)
+    "two unknown names may be a shorthand and its longhand" true
+    (Shorthand.declarations_overlap (decl "grid-row-gap:9px")
+       (decl "grid-gap:1px"));
+  (* A typed longhand whose value defeats the typed reader is recovered under
+     its own name, so the name is one the footprints know. *)
+  Alcotest.(check bool)
+    "a recovered typed longhand overlaps its shorthand" true
+    (Shorthand.declarations_overlap (decl "margin:0")
+       (decl "margin-top:var(--a) var(--b)"));
+  (* A known longhand name outside the shorthand's footprint stays disjoint. *)
+  Alcotest.(check bool)
+    "a recovered longhand of another family is disjoint" false
+    (Shorthand.declarations_overlap (decl "padding:0")
+       (decl "margin-top:var(--a) var(--b)"));
+  (* CSS Cascade 5 sec. 7.2: [all] resets unknown properties. *)
+  Alcotest.(check bool)
+    "all overlaps an unknown property" true
+    (Shorthand.declarations_overlap (decl "all:initial")
+       (decl "grid-row-gap:9px"));
+  (* Custom properties are their own cascade slots. *)
+  Alcotest.(check bool)
+    "an unknown property and a custom property are disjoint" false
+    (Shorthand.declarations_overlap (decl "grid-row-gap:9px")
+       (decl "--brand:red"))
+
 let test_intentionally_duplicated_properties () =
   Alcotest.(check bool)
     "content duplicates are preserved" true
@@ -229,6 +274,8 @@ let suite =
     [
       Alcotest.test_case "declaration coverage reset boundaries" `Quick
         test_declaration_covers_reset_boundaries;
+      Alcotest.test_case "unknown property overlap" `Quick
+        test_unknown_property_overlap;
       Alcotest.test_case "intentionally duplicated properties" `Quick
         test_intentionally_duplicated_properties;
       Alcotest.test_case "merge overflow longhands" `Quick


### PR DESCRIPTION
declarations_overlap judged every Unknown_property disjoint from every typed property, so --lossless sorted background-position-x before the background shorthand that resets it and --diff=canonical called the two orders identical. An unknown name a typed footprint mentions now takes the ordinary footprint intersection; any other name conservatively overlaps. Also moves the All arms above the unknown ones, so all:initial conflicts with unknown properties as the module comment already claimed.