### PR TITLE
diff: report significant declaration reorders inside at-rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -174,6 +174,12 @@ identical, rather than as spurious changes.
 
 ### Diff report
 
+- A declaration reorder that decides the cascade is reported inside `@media`,
+  `@layer` and `@supports` too. Every declaration reorder under a container was
+  dropped, and a cascade-neutral one is already no difference before it gets
+  there, so what was dropped was the significant case and `--diff=tree` called
+  the two stylesheets identical (#268)
+
 - An `@property` is compared on its whole body, and the entry names the
   descriptors that differ. Two registrations for one name differing in `syntax`
   or `initial-value` compared equal, so `--diff=canonical` called the

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1959,18 +1959,6 @@ let detect_block_structure_changes blocks1 blocks2 =
     blocks1;
   block_structure_changed
 
-let only_declaration_reorders rule_changes nested_containers =
-  rule_changes <> []
-  && List.for_all
-       (fun (diff : rule_diff) ->
-         match diff with
-         | Reordered { old_declarations = Some _; new_declarations = Some _; _ }
-           ->
-             true
-         | _ -> false)
-       rule_changes
-  && nested_containers = []
-
 let container_position extract_fn cond stmts =
   let rec go i = function
     | [] -> None
@@ -2415,7 +2403,7 @@ and process_modified_container ~container_type ~extract_fn ~depth ~stmts1
     (* If only position changed with no content changes, report as reordered *)
     if position_changed && rule_changes = [] && nested_containers = [] then
       Some (reordered_container container_type cond rules1 pos1 pos2)
-    else if not (only_declaration_reorders rule_changes nested_containers) then
+    else if rule_changes <> [] || nested_containers <> [] then
       (* Container was modified in content, not just position *)
       Some
         (modified_container container_type cond rules1 rules2 rule_changes
@@ -2522,10 +2510,7 @@ and collect_container_diffs ~container_type ~depth added removed modified =
       let nested_containers =
         nested_differences ~depth:(depth + 1) rules1 rules2
       in
-      if
-        (rule_changes <> [] || nested_containers <> [])
-        && not (only_declaration_reorders rule_changes nested_containers)
-      then
+      if rule_changes <> [] || nested_containers <> [] then
         diffs :=
           Modified
             {

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -182,6 +182,59 @@ let diff_overlapping_decl_reorder_flagged () =
     "overlapping declaration reorder is not empty" false
     (Cascade_diff.Tree_diff.is_empty d)
 
+(* The selectors whose declarations were reordered, from every container the
+   diff reports, at any nesting depth. *)
+let rec nested_decl_reorders (c : Cascade_diff.Tree_diff.container_diff) =
+  match c with
+  | Cascade_diff.Tree_diff.Modified { rule_changes; container_changes; _ } ->
+      List.filter_map
+        (fun (r : Cascade_diff.Tree_diff.rule_diff) ->
+          match r with
+          | Cascade_diff.Tree_diff.Reordered
+              { selector; old_declarations = Some _; _ } ->
+              Some selector
+          | _ -> None)
+        rule_changes
+      @ List.concat_map nested_decl_reorders container_changes
+  | _ -> []
+
+let decl_reorders_in_containers d =
+  List.concat_map nested_decl_reorders d.Cascade_diff.Tree_diff.containers
+
+(* An at-rule does not commute the declarations it wraps: a swap that decides
+   the cascade at the top level decides it inside @media, @layer and @supports
+   too. *)
+let significant_reorder_inside wrap () =
+  let expected = parse (wrap ".a { margin: 1px; margin-top: 2px }") in
+  let actual = parse (wrap ".a { margin-top: 2px; margin: 1px }") in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check bool)
+    "overlapping reorder inside an at-rule is not empty" false
+    (Cascade_diff.Tree_diff.is_empty d);
+  Alcotest.(check (list string))
+    "the report names the rule that was reordered" [ ".a" ]
+    (decl_reorders_in_containers d)
+
+let neutral_reorder_inside wrap () =
+  let expected = parse (wrap ".a { color: red; background: blue }") in
+  let actual = parse (wrap ".a { background: blue; color: red }") in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check bool)
+    "neutral reorder inside an at-rule is empty" true
+    (Cascade_diff.Tree_diff.is_empty d)
+
+let in_media body = "@media (min-width: 10px) { " ^ body ^ " }"
+let in_layer body = "@layer base { " ^ body ^ " }"
+let in_supports body = "@supports (color: red) { " ^ body ^ " }"
+let diff_media_decl_reorder_flagged = significant_reorder_inside in_media
+let diff_layer_decl_reorder_flagged = significant_reorder_inside in_layer
+let diff_supports_decl_reorder_flagged = significant_reorder_inside in_supports
+let diff_media_neutral_decl_reorder_empty = neutral_reorder_inside in_media
+let diff_layer_neutral_decl_reorder_empty = neutral_reorder_inside in_layer
+
+let diff_supports_neutral_decl_reorder_empty =
+  neutral_reorder_inside in_supports
+
 (* ===== @property registrations ===== *)
 
 (* The descriptor changes a modified [@property] reports, as "name: expected ->
@@ -733,6 +786,18 @@ let suite =
         diff_neutral_decl_reorder_is_empty;
       Alcotest.test_case "overlapping declaration reorder flagged" `Quick
         diff_overlapping_decl_reorder_flagged;
+      Alcotest.test_case "declaration reorder in media flagged" `Quick
+        diff_media_decl_reorder_flagged;
+      Alcotest.test_case "declaration reorder in layer flagged" `Quick
+        diff_layer_decl_reorder_flagged;
+      Alcotest.test_case "declaration reorder in supports flagged" `Quick
+        diff_supports_decl_reorder_flagged;
+      Alcotest.test_case "neutral declaration reorder in media is empty" `Quick
+        diff_media_neutral_decl_reorder_empty;
+      Alcotest.test_case "neutral declaration reorder in layer is empty" `Quick
+        diff_layer_neutral_decl_reorder_empty;
+      Alcotest.test_case "neutral declaration reorder in supports is empty"
+        `Quick diff_supports_neutral_decl_reorder_empty;
       Alcotest.test_case "property syntax changed" `Quick
         diff_property_syntax_changed;
       Alcotest.test_case "property inherits changed" `Quick


### PR DESCRIPTION
only_declaration_reorders dropped every declaration-level reorder under a container, but since 190df068 the producer only emits those payloads when the reorder decides the cascade - so what was dropped was exactly the significant case, and --diff=tree called the two sheets identical. Replace the predicate with the emptiness guard the @layer path already used, which also stops @media/@supports rendering an empty Modified as "(position changed)" for cascade-neutral reorders.