### PR TITLE
rule_order: keep what a custom declaration carries besides its value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -179,6 +179,10 @@ identical, rather than as spurious changes.
   identical selector also writes (leaving `!important` alone, since that
   changes the winner), and pairs rules that match exactly before falling back
   to the property signature (#206)
+- A custom property keeps its `!important`, its layer and its metadata through
+  the projection, which rebuilt the declaration from its value alone. An
+  important custom property beats a later normal one, so `--diff=canonical`
+  called two sheets that disagreed about the flag identical (#271)
 
 ### Diff report
 

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -496,6 +496,28 @@ let rec string_of_value ?(minify = true) ?(inline = false) decl =
       Pp.to_string ~minify ~inline pp_property_value (property, value)
   | Theme_guarded { decl; _ } -> string_of_value ~minify ~inline decl
 
+(* Rewrite the value of a custom declaration through [f], which sees its
+   minified serialisation. Everything else the declaration carries - its
+   importance, its cascade layer, its metadata and any theme guard - belongs to
+   the declaration and not to the value, so it is kept: rebuilding with
+   [custom_property] instead silently drops all four. *)
+let rec map_custom_value f decl =
+  match decl with
+  | Declaration
+      {
+        property = Custom_property _ as property;
+        value = Custom_value cv;
+        important;
+        _;
+      } ->
+      let value = f (string_of_value ~minify:true decl) in
+      let components = Cursor.remaining (Cursor.of_string value) in
+      v ~important property (Custom_value { cv with value = Tokens components })
+  | Declaration _ -> decl
+  | Theme_guarded g ->
+      let decl' = map_custom_value f g.decl in
+      if decl' == g.decl then decl else theme_guarded ~var_name:g.var_name decl'
+
 (* Byte length of [string_of_value] with no allocation; see
    [property_name_size]. *)
 let rec value_size ?(minify = true) ?(inline = false) decl =

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -54,6 +54,12 @@ val parse_declaration : ?layer:string -> string -> string -> declaration option
 val custom_declaration_layer : declaration -> string option
 (** [custom_declaration_layer d] is the layer of [d], if any. *)
 
+val map_custom_value : (string -> string) -> declaration -> declaration
+(** [map_custom_value f d] is [d] with its custom-property value replaced by
+    [f]'s rewrite of the minified serialisation. The importance, layer, metadata
+    and theme guard of [d] are kept; any other declaration passes through
+    unchanged. *)
+
 val unquote_custom_font_strings : declaration -> declaration
 (** [unquote_custom_font_strings d] rewrites a quoted multi-word [<string>] in a
     custom-property token stream as the equivalent unquoted [<ident>] sequence.

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -513,13 +513,7 @@ let rec normalize_custom_values (stmts : statement list) : statement list =
               r with
               declarations =
                 List.map
-                  (fun d ->
-                    match Variables.custom_declaration_name d with
-                    | Some name ->
-                        Declaration.custom_property name
-                          (normalize_custom_value
-                             (Declaration.string_of_value ~minify:true d))
-                    | None -> d)
+                  (Declaration.map_custom_value normalize_custom_value)
                   r.declarations;
               nested = normalize_custom_values r.nested;
             }

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -119,6 +119,25 @@ let canonical_custom_hue_rotate_zero () =
     (Cascade_diff.Css_compare.equal ~mode:`Canonical ".a{--f:hue-rotate()}"
        ".a{--f:hue-rotate(90deg)}")
 
+(* Cascade 5 sec. 6.2: an important custom property beats a later normal one, so
+   the flag is part of what the declaration means and two sheets that disagree
+   about it are different sheets. *)
+let canonical_important_custom_property_distinct () =
+  Alcotest.(check bool)
+    "an important custom property differs from a normal one" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical ":root{--x:red!important}"
+       ":root{--x:red}");
+  (* the same importance on both sides is not a difference *)
+  Alcotest.(check bool)
+    "matching important custom properties agree" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical ":root{--x:red!important}"
+       ":root{--x:red !important}");
+  (* the flag also decides which of two definitions of one name survives *)
+  Alcotest.(check bool)
+    "an important definition is not shadowed by a later normal one" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ":root{--x:red!important}:root{--x:blue}" ":root{--x:blue}")
+
 let equal_prune_unused_custom_props () =
   let with_bind = ":root{--spacing:.25rem}.top-0{top:0}" in
   let without = ".top-0{top:0}" in
@@ -1213,6 +1232,8 @@ let suite =
         equal_prune_unused_custom_props;
       Alcotest.test_case "canonical folds a zero hue-rotate in a custom value"
         `Quick canonical_custom_hue_rotate_zero;
+      Alcotest.test_case "canonical keeps custom-property importance" `Quick
+        canonical_important_custom_property_distinct;
       Alcotest.test_case "canonical ignores @property order" `Quick
         equal_canonical_ignores_property_order;
       Alcotest.test_case "canonical equates not all and (X) with not (X)" `Quick

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -36,6 +36,41 @@ let custom_property_position_converges () =
     "definition before the user" want
     (canonical ":root{--b:1}.x{filter:blur(var(--b))}")
 
+let custom_property_importance_survives () =
+  (* Cascade 5 sec. 6.2: an important declaration beats a normal one whatever
+     the order, so [!important] on a custom property is cascade-significant and
+     the projection has to carry it over. *)
+  Alcotest.(check string)
+    "important is kept" ":root{--x:red!important}"
+    (canonical ":root{--x:red !important}");
+  Alcotest.(check bool)
+    "an important definition does not project like a normal one" true
+    (canonical ":root{--x:red !important}" <> canonical ":root{--x:red}")
+
+let custom_property_layer_and_meta_survive () =
+  (* A custom declaration also carries the cascade layer it was written in and
+     its caller metadata. The projection rebuilds the declaration from its
+     value, so both have to be carried over with it. *)
+  let inject, project = Css.meta () in
+  let decl, _ =
+    Css.var ~layer:"theme" ~meta:(inject "tag") "x" Css.Length (Css.Rem 1.)
+  in
+  let projected =
+    Rule_order.canonicalize
+      [ Css.rule ~selector:(Selector.of_string ":root") [ decl ] ]
+  in
+  match List.filter_map Css.statement_declarations projected with
+  | [ [ d ] ] ->
+      Alcotest.(check (option string))
+        "layer survives" (Some "theme")
+        (Declaration.custom_declaration_layer d);
+      Alcotest.(check (option string))
+        "meta survives" (Some "tag")
+        (Option.bind (Declaration.meta_of_declaration d) project)
+  | ds ->
+      Alcotest.failf "expected one rule holding one declaration, got %d rules"
+        (List.length ds)
+
 let media_and_independent_rule_converge () =
   (* A conditional block whose rules cannot conflict with a neighbouring rule
      reorders with it, so both source orderings reach one canonical form. *)
@@ -112,7 +147,7 @@ let coalesce_blocked_by_intervening_conflict () =
   (* [.b] can match the same element as [.a] at equal specificity and writes the
      same property, so folding the two [.a] occurrences together past it is not
      observable-free: they stay split, in source order. The first [color] is
-     dropped all the same — a later rule with the *identical* selector writes
+     dropped all the same - a later rule with the *identical* selector writes
      it, so it never wins for any element. *)
   Alcotest.(check string)
     "conflicting write between occurrences keeps them split"
@@ -214,6 +249,10 @@ let suite =
         keeps_conflicting_rules_in_source_order;
       Alcotest.test_case "custom-property position converges" `Quick
         custom_property_position_converges;
+      Alcotest.test_case "custom-property importance survives" `Quick
+        custom_property_importance_survives;
+      Alcotest.test_case "custom-property layer and meta survive" `Quick
+        custom_property_layer_and_meta_survive;
       Alcotest.test_case "media and independent rule converge" `Quick
         media_and_independent_rule_converge;
       Alcotest.test_case "media conflict keeps source order" `Quick


### PR DESCRIPTION
The canonical projection rebuilt every custom declaration from its serialised value alone, discarding !important, the layer, the metadata and any theme guard, so --diff=canonical called ':root{--x:red !important}' and ':root{--x:red}' identical. Map only the value and keep the rest of the declaration. Stacked on #270.