### PR TITLE
stylesheet: separate an unknown at-rule name from its prelude

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,6 +117,8 @@
 - A non-integer above roughly 4.6e10 prints as a number again:
   `transform: scale(123456789012.25)` printed `scale(1.2345678.9012e+19)`,
   which read back as two arguments (#265)
+- An unknown at-rule keeps the space before its prelude under `--minify`:
+  `@foo bar {x:1}` printed `@foobar{x:1}`, a different at-rule (#272)
 
 ### New properties and values
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -445,8 +445,12 @@ let pp_unknown_at_rule_statement ctx name prelude (block : string option) =
      [escape_ident] so the serialized [\6 T] re-tokenizes back to the same
      at-keyword token. *)
   Pp.string ctx (Parser.escape_ident name);
+  (* CSS Syntax 3 sec. 4.3.1: the at-keyword consumes an ident sequence, so the
+     whitespace before the prelude is the only thing keeping them apart. It is a
+     hard space, not layout - minifying [@foo bar] to [@foobar] names a
+     different at-rule. *)
   if prelude <> "" then (
-    Pp.sp ctx ();
+    Pp.space ctx ();
     Pp.string ctx prelude);
   match block with
   | None -> Pp.semicolon ctx ()

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1684,6 +1684,46 @@ let css_syntax_recovery_structural () =
   check_counts "unclosed block auto-closed"
     ".a { color: red; .b { color: blue }" [ 1 ] 0
 
+(* CSS Syntax 3 sections 4.3.1 and 5.4.2: an unknown at-rule's at-keyword and
+   its prelude are separate tokens, and the whitespace between them is the only
+   thing that keeps them apart. Minified output that drops it turns [@foo bar]
+   into the at-keyword [@foobar], so the printed text no longer re-parses to the
+   value that produced it. Lightning CSS, esbuild, csso, clean-css, and cssnano
+   all keep the space. An at-rule with no prelude has no boundary to preserve
+   and stays unspaced. *)
+let s3431_unknown_at_rule_prelude_separator () =
+  let parse input = read_stylesheet (Cursor.of_string input) in
+  let unknown input =
+    match parse input with
+    | [ Unknown_at_rule { name; prelude; block } ] -> (name, prelude, block)
+    | _ -> Alcotest.failf "expected a single unknown at-rule for %S" input
+  in
+  let roundtrips input =
+    let printed =
+      String.trim (Css.Stylesheet.to_string ~minify:true (parse input))
+    in
+    let at_rule = Alcotest.(triple string string (option string)) in
+    Alcotest.check at_rule (input ^ " roundtrip") (unknown input)
+      (unknown printed);
+    printed
+  in
+  Alcotest.(check string)
+    "block form keeps the at-keyword boundary" "@foo bar{x:1}"
+    (roundtrips "@foo bar{x:1}");
+  Alcotest.(check string)
+    "statement form keeps the at-keyword boundary" "@foo bar;"
+    (roundtrips "@foo bar;");
+  Alcotest.(check string)
+    "multi-token prelude keeps the at-keyword boundary" "@foo bar baz{x:1}"
+    (roundtrips "@foo bar baz{x:1}");
+  (* Control: no prelude, so no separator to emit. *)
+  Alcotest.(check string)
+    "block form without a prelude stays unspaced" "@foo{x:1}"
+    (roundtrips "@foo{x:1}");
+  Alcotest.(check string)
+    "statement form without a prelude stays unspaced" "@foo;"
+    (roundtrips "@foo;")
+
 (* Not a roundtrip test *)
 let test_invalid_functions () =
   expect_parse_error ".btn { color: rgb(300); }";
@@ -6759,6 +6799,9 @@ let additional_tests =
     ( "spec CSS Syntax structural recovery",
       `Quick,
       css_syntax_recovery_structural );
+    ( "spec CSS Syntax 4.3.1 unknown at-rule prelude separator",
+      `Quick,
+      s3431_unknown_at_rule_prelude_separator );
     (* CSS nesting round-trip tests *)
     ("nesting basic", `Quick, test_nesting_basic);
     ("nesting ampersand hover", `Quick, test_nesting_ampersand_hover);


### PR DESCRIPTION
Pp.sp drops the space under --minify, so @foo bar{x:1} serialised to @foobar{x:1}, a different at-rule that does not re-parse to the same AST. Use a hard space at the name/prelude boundary; every other Pp.sp site in the printer was audited and sits before its own delimiter. Stacked on #271.