### PR TITLE
fmt: exit 1 when parse recovery drops the whole stylesheet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 - `cascade fmt` and `cascade diff` drop `--memtrace`, and the library drops the
   `memtrace` dependency, which failed the build outright on a switch without it
   (#237)
+- A parse failure in `cascade fmt` is an error, not a warning: the command
+  exits 1 instead of writing an empty stylesheet and reporting success, so
+  `cascade fmt src.css > dist.css` no longer hands a build a 0-byte file with a
+  green exit status (#273)
 
 ### Minification
 

--- a/bin/cli_io.ml
+++ b/bin/cli_io.ml
@@ -18,26 +18,47 @@ let read_stdin () =
     Buffer.contents buf
   with End_of_file -> Buffer.contents buf
 
-let parse_css ?(enforce_spec = false) ~filename css =
+let report_warning w =
+  (* Prefix every line of a multi-line diagnostic so a downstream [grep -v
+     "warning"] filters the whole entry, not just the first line. *)
+  Cascade.Error.to_string w |> String.split_on_char '\n'
+  |> List.iter (fun line -> Fmt.epr "warning: %s@." line)
+
+(* [Error.to_string] already carries the filename the parse was stamped with. *)
+let die_parse_error e =
+  Fmt.epr "Error: %s@." (Cascade.Error.to_string e);
+  Stdlib.exit 1
+
+let parse ?(enforce_spec = false) ~filename css =
   match Css.of_string ~filename ~enforce_spec css with
   | Ok { Css.stylesheet; warnings } ->
-      List.iter
-        (fun w ->
-          (* Prefix every line of a multi-line diagnostic so a downstream [grep
-             -v "warning"] filters the whole entry, not just the first line. *)
-          let msg = Cascade.Error.to_string w in
-          String.split_on_char '\n' msg
-          |> List.iter (fun line -> Fmt.epr "warning: %s@." line))
-        warnings;
-      stylesheet
-  | Error _ ->
-      Fmt.epr "warning: %s: parse failed, dropping content@." filename;
-      Css.empty
+      List.iter report_warning warnings;
+      (stylesheet, warnings)
+  | Error e -> die_parse_error e
+
+let parse_css ?enforce_spec ~filename css =
+  fst (parse ?enforce_spec ~filename css)
+
+type input = { stylesheet : Css.t; filename : string; recovered : bool }
 
 let read_input ?enforce_spec path =
   let css = if path = "-" then read_stdin () else read_file path in
   let filename = if path = "-" then "<stdin>" else path in
-  parse_css ?enforce_spec ~filename css
+  let stylesheet, warnings = parse ?enforce_spec ~filename css in
+  { stylesheet; filename; recovered = warnings <> [] }
+
+(* Recovery that drops every rule leaves nothing to serialise, so [cascade fmt
+   src.css > dist.css] writes a 0-byte file. Warnings on stderr are not
+   something a build can gate on; the exit status is. An input that had nothing
+   to drop (comments only, an empty rule) stays a plain empty result. *)
+let check_not_all_dropped input ~written =
+  if written = 0 && input.recovered then begin
+    Fmt.epr
+      "Error: %s: parse dropped every rule; refusing to write an empty \
+       stylesheet@."
+      input.filename;
+    Stdlib.exit 1
+  end
 
 let split_comma s =
   String.split_on_char ',' s |> List.map String.trim

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -69,18 +69,22 @@ let resolve_inline_imports ~input_path stylesheet =
   end
   else Cli_inline_imports.run ~base_url:input_path stylesheet
 
+(* Returns the number of bytes written, so the caller can tell a stylesheet that
+   serialised to nothing from one that had nothing to serialise. *)
 let emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet =
   let buf = Buffer.create 4096 in
   Css.to_buffer buf ~minify ~lossless ~enforce_spec stylesheet;
   let len = Buffer.length buf in
   if len > 0 && Buffer.nth buf (len - 1) <> '\n' then Buffer.add_char buf '\n';
-  Buffer.output_buffer stdout buf
+  Buffer.output_buffer stdout buf;
+  len
 
 let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
     ~enforce_spec ~closed_world ~objective ~inline_imports_flag
     ~inline_vars_flag ~keep_vars ~profile =
   try
-    let stylesheet = Cli_io.read_input ~enforce_spec input_path in
+    let input = Cli_io.read_input ~enforce_spec input_path in
+    let stylesheet = input.Cli_io.stylesheet in
     let stylesheet =
       if inline_imports_flag then resolve_inline_imports ~input_path stylesheet
       else stylesheet
@@ -101,7 +105,8 @@ let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
       end
       else stylesheet
     in
-    emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet;
+    let written = emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet in
+    Cli_io.check_not_all_dropped input ~written;
     if profile then report_profile ()
   with
   | Sys_error msg ->
@@ -309,6 +314,13 @@ let man =
       "The two $(b,--inline-*) flags are explicit closed-world opt-ins: \
        $(b,--inline-imports) assumes you control file resolution and \
        $(b,--inline-vars) assumes no runtime mutation of custom properties.";
+    `S Manpage.s_exit_status;
+    `P "$(tname) exits with:";
+    `I ("0", "on success, including a parse that recovered some of the input");
+    `I
+      ( "1",
+        "if the input cannot be read, or if parse recovery dropped everything \
+         and the output would be an empty stylesheet" );
     `S Manpage.s_examples;
     `P "Pretty-print a CSS file:";
     `Pre "  cascade fmt style.css";

--- a/test/cli/fmt_parse_failure.t
+++ b/test/cli/fmt_parse_failure.t
@@ -1,0 +1,60 @@
+CLI: `fmt` refuses to report success when it produced nothing.
+
+`cascade fmt src.css > dist.css` is a build step. When the input parses
+to an empty stylesheet the redirect writes a 0-byte file, and exiting 0
+there hands CI a green build and a site with no CSS. The warnings on
+stderr are easy to miss and impossible to gate on.
+
+An entirely unparseable stylesheet: every rule is dropped, so the run is
+an error, stdout stays empty and the exit status is non-zero.
+
+  $ cat > broken.css <<EOF
+  > @@@@ }}} {{{ !!! ;;;
+  > EOF
+  $ cascade fmt broken.css > out.css 2> err.txt
+  [1]
+  $ wc -c < out.css | tr -d ' '
+  0
+  $ grep '^Error' err.txt
+  Error: broken.css: parse dropped every rule; refusing to write an empty stylesheet
+
+The warnings that explain the drop are still reported.
+
+  $ grep -c '^warning' err.txt
+  4
+
+A single rule whose value does not validate is the same case: the one
+rule is dropped and nothing is left to write.
+
+  $ cat > one-bad-rule.css <<EOF
+  > .b { color: notacolor }
+  > EOF
+  $ cascade fmt one-bad-rule.css > out2.css 2> err2.txt
+  [1]
+  $ wc -c < out2.css | tr -d ' '
+  0
+
+Reading from stdin reports the same way.
+
+  $ cascade fmt - < broken.css > out3.css 2> err3.txt
+  [1]
+  $ grep '^Error' err3.txt
+  Error: <stdin>: parse dropped every rule; refusing to write an empty stylesheet
+
+Partial recovery is not an error: the rules that survive are written and
+the exit status stays 0.
+
+  $ cat > partial.css <<EOF
+  > .b { color: notacolor }
+  > .ok { color: blue }
+  > EOF
+  $ cascade fmt --minify partial.css 2> /dev/null
+  .ok{color:#00f}
+
+An input with no rules to begin with is legitimately empty: nothing was
+dropped, so there is nothing to report.
+
+  $ cat > comment-only.css <<EOF
+  > /* nothing but a comment */
+  > EOF
+  $ cascade fmt comment-only.css


### PR DESCRIPTION
cascade fmt on an unparseable file wrote empty output and exited 0, so a fmt src.css > dist.css pipeline shipped a 0-byte stylesheet with a green status. When recovery drops every rule the command now reports an error and exits 1, keyed on bytes serialised (a rule surviving with zero declarations still counts as output); files pulled in by --inline-imports stay lenient as their cram test documents. Stacked on #272.