### PR TITLE
test: render a sheet against its optimized forms in a browser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,7 +135,7 @@
 - `dune test` renders a stylesheet and its optimized forms in a headless
   browser and compares the computed style of every element, on a document
   derived from the stylesheet's own selectors; it skips where no browser is
-  installed
+  installed (#275)
 
 ## 1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -130,6 +130,13 @@
 - Add `Css.Values.oklch_none_hue` for an achromatic colour with a missing hue,
   printed as `oklch(55.6% 0 none)` (#190)
 
+### Testing
+
+- `dune test` renders a stylesheet and its optimized forms in a headless
+  browser and compares the computed style of every element, on a document
+  derived from the stylesheet's own selectors; it skips where no browser is
+  installed
+
 ## 1.0.0
 
 First public release. Cascade was extracted from the [tw](https://github.com/samoht/tw)

--- a/test/render/dom.js
+++ b/test/render/dom.js
@@ -1,0 +1,43 @@
+// Build the document the OCaml side derived from a stylesheet's selectors.
+//
+// The tree is built with createElement rather than serialised to HTML text: the
+// HTML parser rewrites nesting the selectors asked for (a <div> inside a <p>, a
+// <li> outside a <ul>), and the differential test needs the tree it derived,
+// not the one a parser is willing to spell. The same builder runs in the driver
+// and in the repro pages written next to a failure, so an artefact reproduces
+// the run exactly.
+function rdBuild(doc, spec) {
+  var html = doc.documentElement;
+  (spec.htmlClasses || []).forEach(function (c) { html.classList.add(c); });
+  (spec.htmlAttrs || []).forEach(function (a) { html.setAttribute(a[0], a[1]); });
+  function node(n) {
+    var e = doc.createElement(n.t);
+    if (n.i) e.id = n.i;
+    (n.c || []).forEach(function (c) { e.classList.add(c); });
+    (n.a || []).forEach(function (a) { e.setAttribute(a[0], a[1]); });
+    (n.k || []).forEach(function (k) { e.appendChild(node(k)); });
+    return e;
+  }
+  (spec.dom.k || []).forEach(function (k) { doc.body.appendChild(node(k)); });
+}
+
+// A label a human can find the element by in the repro page.
+function rdPath(el) {
+  var parts = [];
+  while (el && el.nodeType === 1 && el.tagName !== 'BODY') {
+    var s = el.tagName.toLowerCase();
+    if (el.id) s += '#' + el.id;
+    else if (el.className && el.className.baseVal === undefined && el.className)
+      s += '.' + String(el.className).trim().split(/\s+/).join('.');
+    var p = el.parentNode, i = 1;
+    if (p) {
+      for (var c = el.previousElementSibling; c; c = c.previousElementSibling) i++;
+      s += ':nth-child(' + i + ')';
+    }
+    parts.unshift(s);
+    el = el.parentNode;
+  }
+  return parts.join('>');
+}
+
+if (typeof module !== 'undefined') module.exports = { rdBuild: rdBuild, rdPath: rdPath };

--- a/test/render/dom_of_css.ml
+++ b/test/render/dom_of_css.ml
@@ -119,8 +119,18 @@ let check_ns = function
   | Some Selector.None | Some (Selector.Prefix _) ->
       raise (Skip "namespaced selector")
 
+(* createElement rejects anything else, and a selector such as [\\2d foo] does
+   reach the synthesiser as the element name [-foo]. *)
+let valid_tag name =
+  name <> ""
+  && (match name.[0] with 'a' .. 'z' -> true | _ -> false)
+  && String.for_all
+       (function 'a' .. 'z' | '0' .. '9' | '-' -> true | _ -> false)
+       name
+
 let set_tag sp name =
   let name = String.lowercase_ascii name in
+  if not (valid_tag name) then raise (Skip "element name is not an HTML tag");
   match sp.tag with
   | None -> sp.tag <- Some name
   | Some t when t = name -> ()
@@ -208,19 +218,6 @@ let nth_pos sp of_type wrap n =
 
 let filler tag : node =
   { tag; id = None; classes = []; attrs = []; children = [] }
-
-(* The synthesised element carries only what the compound asked for, so a
-   negation holds by construction - except when it rules out the default tag or
-   pins the element away from a position. *)
-let rec negate sp = function
-  | Selector.Element (_, name) ->
-      sp.avoid <- String.lowercase_ascii name :: sp.avoid
-  | Selector.First_child -> if sp.pos = Anywhere then sp.pos <- Nth 2
-  | Selector.Last_child -> if sp.pos = Anywhere then sp.pos <- Nth_last 2
-  | Selector.Compound parts -> List.iter (negate sp) parts
-  | Selector.List l | Selector.Is l | Selector.Where l ->
-      List.iter (negate sp) l
-  | _ -> ()
 
 let node_of_spec sp children : node =
   let children = sp.inner @ children in
@@ -402,6 +399,25 @@ let rec add sp part =
   | Selector.Combined _ | Selector.Relative _ | Selector.List _ ->
       raise (Skip "complex selector inside a compound")
 
+(* The synthesised element carries only what the compound asked for, so a
+   negation holds by construction - except when it rules out the default tag,
+   pins the element away from a position, or negates a state the element has by
+   default. *)
+and negate sp = function
+  | Selector.Element (_, name) ->
+      sp.avoid <- String.lowercase_ascii name :: sp.avoid
+  | Selector.First_child -> if sp.pos = Anywhere then sp.pos <- Nth 2
+  | Selector.Last_child -> if sp.pos = Anywhere then sp.pos <- Nth_last 2
+  | Selector.Enabled ->
+      want_tag sp "input";
+      set_attr sp "disabled" ""
+  | Selector.Dir d -> set_attr sp "dir" (if d = "rtl" then "ltr" else "rtl")
+  | Selector.Not l -> List.iter (add sp) l
+  | Selector.Compound parts -> List.iter (negate sp) parts
+  | Selector.List l | Selector.Is l | Selector.Where l ->
+      List.iter (negate sp) l
+  | _ -> ()
+
 (* :is(a, b) holds when any branch does, so take the first branch that is a
    plain compound; a complex branch would need its own ancestor chain. *)
 and add_branch sp branches =
@@ -499,12 +515,17 @@ let build_fragment sel =
               cur := node_of_spec { sp with inner = [] } kids;
               cur_spec := sp;
               before := []
-          | Some Selector.Next_sibling | Some Selector.Subsequent_sibling ->
-              (match sp.pos with
-              | Last | Only | Nth_last _ ->
-                  raise (Skip "position conflicts with a sibling")
-              | _ -> ());
-              before := node_of_spec sp [] :: !before
+          | Some Selector.Next_sibling | Some Selector.Subsequent_sibling -> (
+              let node = node_of_spec sp [] in
+              let tag = if sp.of_type then node.tag else "span" in
+              (* The siblings are prepended right to left, so the padding an
+                 An+B position needs goes in front of the node itself. *)
+              before :=
+                match sp.pos with
+                | Anywhere | First -> node :: !before
+                | Nth n -> pad (n - 1) tag @ (node :: !before)
+                | Last | Only | Nth_last _ ->
+                    raise (Skip "position conflicts with a sibling"))
           | Some _ -> raise (Skip "legacy combinator"));
           link := comb)
         earlier;

--- a/test/render/dom_of_css.ml
+++ b/test/render/dom_of_css.ml
@@ -1,0 +1,648 @@
+open Cascade
+
+(* A selector component that cannot hold in a synthesised document raises
+   [Skip], carrying the reason the report groups it under. *)
+exception Skip of string
+
+type node = {
+  tag : string;
+  id : string option;
+  classes : string list;
+  attrs : (string * string) list;
+  children : node list;
+}
+
+(* Where the element must sit among its siblings. *)
+type pos = Anywhere | First | Last | Only | Nth of int | Nth_last of int
+
+type spec = {
+  mutable tag : string option;
+  mutable id : string option;
+  mutable classes : string list;
+  mutable attrs : (string * string) list;
+  mutable pos : pos;
+  mutable of_type : bool; (* the position counts same-tag siblings only *)
+  mutable childless : bool; (* :empty *)
+  mutable root : bool; (* :root / :scope *)
+  mutable avoid : string list; (* tags :not() rules out *)
+  mutable inner : node list; (* :has() content *)
+  mutable pseudos : string list; (* pseudo-elements to sample *)
+}
+
+type t = {
+  root_node : node;
+  html_classes : string list;
+  html_attrs : (string * string) list;
+  doc_pseudos : string list;
+  probes : string list;
+  n_selectors : int;
+  n_synthesised : int;
+  n_elements : int;
+  skips : (string * int) list;
+  examples : (string * string) list;
+}
+
+let new_spec () =
+  {
+    tag = None;
+    id = None;
+    classes = [];
+    attrs = [];
+    pos = Anywhere;
+    of_type = false;
+    childless = false;
+    root = false;
+    avoid = [];
+    inner = [];
+    pseudos = [];
+  }
+
+let restore sp saved =
+  sp.tag <- saved.tag;
+  sp.id <- saved.id;
+  sp.classes <- saved.classes;
+  sp.attrs <- saved.attrs;
+  sp.pos <- saved.pos;
+  sp.of_type <- saved.of_type;
+  sp.childless <- saved.childless;
+  sp.root <- saved.root;
+  sp.avoid <- saved.avoid;
+  sp.inner <- saved.inner;
+  sp.pseudos <- saved.pseudos
+
+let is_pseudo_element = function
+  | Selector.Before _ | Selector.After _ | Selector.First_line _
+  | Selector.First_letter _ | Selector.Marker | Selector.Placeholder
+  | Selector.Selection | Selector.Backdrop | Selector.File_selector_button
+  | Selector.Target_text | Selector.Spelling_error | Selector.Grammar_error
+  | Selector.Highlight _ | Selector.Part _ | Selector.Slotted _ | Selector.Cue _
+  | Selector.Cue_region _ | Selector.View_transition
+  | Selector.View_transition_group _ | Selector.View_transition_image_pair _
+  | Selector.View_transition_old _ | Selector.View_transition_new _
+  | Selector.Unknown_pseudo_element _ | Selector.Unknown_pseudo_element_call _
+  | Selector.Moz_placeholder | Selector.Webkit_input_placeholder
+  | Selector.Ms_input_placeholder | Selector.Webkit_scrollbar
+  | Selector.Webkit_search_cancel_button | Selector.Webkit_search_decoration
+  | Selector.Webkit_details_marker | Selector.Details_content
+  | Selector.Webkit_datetime_edit_fields_wrapper
+  | Selector.Webkit_date_and_time_value | Selector.Webkit_datetime_edit
+  | Selector.Webkit_datetime_edit_year_field
+  | Selector.Webkit_datetime_edit_month_field
+  | Selector.Webkit_datetime_edit_day_field
+  | Selector.Webkit_datetime_edit_hour_field
+  | Selector.Webkit_datetime_edit_minute_field
+  | Selector.Webkit_datetime_edit_second_field
+  | Selector.Webkit_datetime_edit_millisecond_field
+  | Selector.Webkit_datetime_edit_meridiem_field
+  | Selector.Webkit_inner_spin_button | Selector.Webkit_outer_spin_button
+  | Selector.Webkit_calendar_picker_indicator ->
+      true
+  | _ -> false
+
+(* querySelectorAll never matches a pseudo-element, so the coverage probe tests
+   the element the rule is attached to. *)
+let rec strip_pseudo_elements sel =
+  match sel with
+  | Selector.Compound parts -> (
+      match List.filter (fun p -> not (is_pseudo_element p)) parts with
+      | [] -> Selector.Universal None
+      | [ one ] -> strip_pseudo_elements one
+      | parts -> Selector.Compound parts)
+  | Selector.Combined (l, c, r) ->
+      Selector.Combined (strip_pseudo_elements l, c, strip_pseudo_elements r)
+  | Selector.List l -> Selector.List (List.map strip_pseudo_elements l)
+  | s when is_pseudo_element s -> Selector.Universal None
+  | s -> s
+
+let check_ns = function
+  | None | Some Selector.Any -> ()
+  | Some Selector.None | Some (Selector.Prefix _) ->
+      raise (Skip "namespaced selector")
+
+let set_tag sp name =
+  let name = String.lowercase_ascii name in
+  match sp.tag with
+  | None -> sp.tag <- Some name
+  | Some t when t = name -> ()
+  | Some _ -> raise (Skip "two type selectors in one compound")
+
+(* A tag the pseudo-class needs (a form control, a <details>) unless a type
+   selector already pinned another one. *)
+let want_tag sp name =
+  match sp.tag with None -> sp.tag <- Some name | Some _ -> ()
+
+let set_attr sp name value =
+  match name with
+  | "class" ->
+      List.iter
+        (fun c ->
+          if c <> "" && not (List.mem c sp.classes) then
+            sp.classes <- sp.classes @ [ c ])
+        (String.split_on_char ' ' value)
+  | "id" -> sp.id <- Some value
+  | _ ->
+      if not (List.mem_assoc name sp.attrs) then
+        sp.attrs <- sp.attrs @ [ (name, value) ]
+
+let note_pseudo sp name =
+  if not (List.mem name sp.pseudos) then sp.pseudos <- sp.pseudos @ [ name ]
+
+(* A value that satisfies the match, built around the operand so the browser
+   agrees rather than merely the synthesiser. *)
+let attribute_value = function
+  | Selector.Presence -> ""
+  | Selector.Exact v | Selector.Exact_quoted (v, _) -> v
+  | Selector.Whitespace_list v | Selector.Whitespace_list_quoted (v, _) ->
+      "zz " ^ v ^ " yy"
+  | Selector.Hyphen_list v | Selector.Hyphen_list_quoted (v, _) -> v ^ "-zz"
+  | Selector.Prefix v | Selector.Prefix_quoted (v, _) -> v ^ "zz"
+  | Selector.Suffix v | Selector.Suffix_quoted (v, _) -> "zz" ^ v
+  | Selector.Substring v | Selector.Substring_quoted (v, _) -> "zz" ^ v ^ "yy"
+
+(* The empty operand of [~=], [|=], [^=], [$=] and [*=] matches nothing, per
+   Selectors 4 sec. 6.2. *)
+let attribute_matchable = function
+  | Selector.Whitespace_list ""
+  | Selector.Whitespace_list_quoted ("", _)
+  | Selector.Hyphen_list ""
+  | Selector.Hyphen_list_quoted ("", _)
+  | Selector.Prefix ""
+  | Selector.Prefix_quoted ("", _)
+  | Selector.Suffix ""
+  | Selector.Suffix_quoted ("", _)
+  | Selector.Substring ""
+  | Selector.Substring_quoted ("", _) ->
+      false
+  | _ -> true
+
+(* The smallest 1-based index An+B selects, or none when the sequence never
+   reaches a real position. *)
+let nth_index = function
+  | Selector.Odd -> Some 1
+  | Selector.Even -> Some 2
+  | Selector.Index b -> if b >= 1 then Some b else None
+  | Selector.An_plus_b (a, b) ->
+      if a = 0 then if b >= 1 then Some b else None
+      else
+        let rec first k =
+          if k > 32 then None
+          else
+            let v = (a * k) + b in
+            if v >= 1 then Some v else first (k + 1)
+        in
+        first 0
+
+let set_pos sp p =
+  match sp.pos with
+  | Anywhere -> sp.pos <- p
+  | existing when existing = p -> ()
+  | _ -> raise (Skip "conflicting position pseudo-classes")
+
+let nth_pos sp of_type wrap n =
+  match nth_index n with
+  | None -> raise (Skip "An+B selects no position")
+  | Some i when i > 12 -> raise (Skip "An+B position out of range")
+  | Some i ->
+      sp.of_type <- of_type;
+      set_pos sp (wrap i)
+
+let filler tag : node =
+  { tag; id = None; classes = []; attrs = []; children = [] }
+
+(* The synthesised element carries only what the compound asked for, so a
+   negation holds by construction - except when it rules out the default tag or
+   pins the element away from a position. *)
+let rec negate sp = function
+  | Selector.Element (_, name) ->
+      sp.avoid <- String.lowercase_ascii name :: sp.avoid
+  | Selector.First_child -> if sp.pos = Anywhere then sp.pos <- Nth 2
+  | Selector.Last_child -> if sp.pos = Anywhere then sp.pos <- Nth_last 2
+  | Selector.Compound parts -> List.iter (negate sp) parts
+  | Selector.List l | Selector.Is l | Selector.Where l ->
+      List.iter (negate sp) l
+  | _ -> ()
+
+let node_of_spec sp children : node =
+  let children = sp.inner @ children in
+  if sp.childless && children <> [] then
+    raise (Skip ":empty with required content");
+  let tag =
+    match sp.tag with
+    | Some t -> t
+    | None -> if List.mem "div" sp.avoid then "section" else "div"
+  in
+  if List.mem tag sp.avoid then raise (Skip "negated type selector");
+  { tag; id = sp.id; classes = sp.classes; attrs = sp.attrs; children }
+
+let rec add sp part =
+  match part with
+  | Selector.Element (ns, name) ->
+      check_ns ns;
+      set_tag sp name
+  | Selector.Class c ->
+      if not (List.mem c sp.classes) then sp.classes <- sp.classes @ [ c ]
+  | Selector.Id i -> sp.id <- Some i
+  | Selector.Universal ns -> check_ns ns
+  | Selector.Attribute (ns, name, m, _flag) ->
+      check_ns ns;
+      if not (attribute_matchable m) then
+        raise (Skip "attribute matches nothing");
+      set_attr sp (Pp.to_string Selector.pp_attr_name name) (attribute_value m)
+  | Selector.Compound parts -> List.iter (add sp) parts
+  (* :is() and :where() hold as soon as one branch does; the CSS Modules and
+     legacy vendor spellings behave the same way. *)
+  | Selector.Is l
+  | Selector.Where l
+  | Selector.Moz_any_call l
+  | Selector.Webkit_any_call l
+  | Selector.Local_call l
+  | Selector.Global_call l ->
+      add_branch sp l
+  | Selector.Not l -> List.iter (negate sp) l
+  | Selector.Has l -> add_has sp l
+  (* Structural pseudo-classes: satisfied by where the element is placed. *)
+  | Selector.Root | Selector.Scope -> sp.root <- true
+  | Selector.Empty -> sp.childless <- true
+  | Selector.First_child -> set_pos sp First
+  | Selector.Last_child -> set_pos sp Last
+  | Selector.Only_child -> set_pos sp Only
+  | Selector.First_of_type ->
+      sp.of_type <- true;
+      set_pos sp First
+  | Selector.Last_of_type ->
+      sp.of_type <- true;
+      set_pos sp Last
+  | Selector.Only_of_type ->
+      sp.of_type <- true;
+      set_pos sp Only
+  | Selector.Nth_child (n, None) -> nth_pos sp false (fun i -> Nth i) n
+  | Selector.Nth_last_child (n, None) ->
+      nth_pos sp false (fun i -> Nth_last i) n
+  | Selector.Nth_of_type (n, None) -> nth_pos sp true (fun i -> Nth i) n
+  | Selector.Nth_last_of_type (n, None) ->
+      nth_pos sp true (fun i -> Nth_last i) n
+  | Selector.Nth_child (_, Some _)
+  | Selector.Nth_last_child (_, Some _)
+  | Selector.Nth_of_type (_, Some _)
+  | Selector.Nth_last_of_type (_, Some _) ->
+      raise (Skip "An+B of S")
+  (* Pseudo-classes an attribute or a tag choice settles. *)
+  | Selector.Link | Selector.Any_link ->
+      want_tag sp "a";
+      set_attr sp "href" "#rd"
+  | Selector.Enabled | Selector.Optional | Selector.Read_write | Selector.Valid
+    ->
+      want_tag sp "input"
+  | Selector.Disabled ->
+      want_tag sp "input";
+      set_attr sp "disabled" ""
+  | Selector.Checked | Selector.Default ->
+      want_tag sp "input";
+      set_attr sp "type" "checkbox";
+      set_attr sp "checked" ""
+  | Selector.Required | Selector.Invalid ->
+      want_tag sp "input";
+      set_attr sp "required" ""
+  | Selector.Read_only ->
+      want_tag sp "input";
+      set_attr sp "readonly" ""
+  | Selector.Placeholder_shown ->
+      want_tag sp "input";
+      set_attr sp "placeholder" "rd"
+  | Selector.In_range | Selector.Out_of_range ->
+      want_tag sp "input";
+      set_attr sp "type" "number";
+      set_attr sp "min" "0";
+      set_attr sp "max" (match part with Selector.In_range -> "9" | _ -> "1");
+      set_attr sp "value" "5"
+  | Selector.Inert -> set_attr sp "inert" ""
+  | Selector.Open ->
+      want_tag sp "details";
+      set_attr sp "open" ""
+  | Selector.Dir d -> set_attr sp "dir" d
+  | Selector.Lang (code :: _) -> set_attr sp "lang" code
+  | Selector.Lang [] -> raise (Skip "empty :lang()")
+  | Selector.Heading -> want_tag sp "h1"
+  (* Every element the driver builds is a known HTML element. *)
+  | Selector.Defined | Selector.Local_scope | Selector.Global_scope -> ()
+  (* Pseudo-elements the driver samples. Three of them also pin the element the
+     pseudo hangs off. *)
+  | Selector.Placeholder ->
+      want_tag sp "input";
+      set_attr sp "placeholder" "rd";
+      note_pseudo sp "::placeholder"
+  | Selector.File_selector_button ->
+      want_tag sp "input";
+      set_attr sp "type" "file";
+      note_pseudo sp "::file-selector-button"
+  | Selector.Marker ->
+      want_tag sp "li";
+      note_pseudo sp "::marker"
+  | Selector.Before _ -> note_pseudo sp "::before"
+  | Selector.After _ -> note_pseudo sp "::after"
+  | Selector.First_line _ -> note_pseudo sp "::first-line"
+  | Selector.First_letter _ -> note_pseudo sp "::first-letter"
+  | Selector.Backdrop -> note_pseudo sp "::backdrop"
+  | Selector.Selection -> note_pseudo sp "::selection"
+  (* Pseudo-elements getComputedStyle cannot sample, or that need a shadow tree,
+     a highlight registry or a running view transition. *)
+  | Selector.Target_text | Selector.Spelling_error | Selector.Grammar_error
+  | Selector.Highlight _ | Selector.Part _ | Selector.Slotted _ | Selector.Cue _
+  | Selector.Cue_region _ | Selector.View_transition
+  | Selector.View_transition_group _ | Selector.View_transition_image_pair _
+  | Selector.View_transition_old _ | Selector.View_transition_new _
+  | Selector.Unknown_pseudo_element _ | Selector.Unknown_pseudo_element_call _
+  | Selector.Moz_placeholder | Selector.Webkit_input_placeholder
+  | Selector.Ms_input_placeholder | Selector.Webkit_scrollbar
+  | Selector.Webkit_search_cancel_button | Selector.Webkit_search_decoration
+  | Selector.Webkit_details_marker | Selector.Details_content
+  | Selector.Webkit_datetime_edit_fields_wrapper
+  | Selector.Webkit_date_and_time_value | Selector.Webkit_datetime_edit
+  | Selector.Webkit_datetime_edit_year_field
+  | Selector.Webkit_datetime_edit_month_field
+  | Selector.Webkit_datetime_edit_day_field
+  | Selector.Webkit_datetime_edit_hour_field
+  | Selector.Webkit_datetime_edit_minute_field
+  | Selector.Webkit_datetime_edit_second_field
+  | Selector.Webkit_datetime_edit_millisecond_field
+  | Selector.Webkit_datetime_edit_meridiem_field
+  | Selector.Webkit_inner_spin_button | Selector.Webkit_outer_spin_button
+  | Selector.Webkit_calendar_picker_indicator ->
+      raise (Skip "pseudo-element not sampled")
+  (* Everything below needs something a static document cannot provide. *)
+  | Selector.Hover | Selector.Active | Selector.Focus | Selector.Focus_visible
+  | Selector.Focus_within | Selector.Target_within | Selector.User_valid
+  | Selector.User_invalid | Selector.Autofill | Selector.Webkit_autofill
+  | Selector.Moz_focusring | Selector.Moz_ui_invalid | Selector.Moz_ui_valid ->
+      raise (Skip "user-interaction pseudo-class")
+  | Selector.Target | Selector.Visited | Selector.Local_link ->
+      raise (Skip "navigation-dependent pseudo-class")
+  | Selector.Fullscreen | Selector.Modal | Selector.Picture_in_picture
+  | Selector.Popover_open | Selector.Playing | Selector.Paused
+  | Selector.Seeking | Selector.Buffering | Selector.Stalled | Selector.Muted
+  | Selector.Volume_locked ->
+      raise (Skip "live-state pseudo-class")
+  | Selector.Indeterminate | Selector.Blank ->
+      raise (Skip "script-only pseudo-class")
+  | Selector.Left | Selector.Right | Selector.First ->
+      raise (Skip "page pseudo-class")
+  | Selector.Future | Selector.Past | Selector.Current | Selector.Current_of _
+    ->
+      raise (Skip "timing pseudo-class")
+  | Selector.Host _ | Selector.Host_context _ | Selector.State _ ->
+      raise (Skip "shadow-tree pseudo-class")
+  | Selector.Active_view_transition | Selector.Active_view_transition_type _ ->
+      raise (Skip "view-transition pseudo-class")
+  | Selector.Nth_col _ | Selector.Nth_last_col _ ->
+      raise (Skip "column pseudo-class")
+  | Selector.Unknown_pseudo_class _ | Selector.Unknown_pseudo_class_call _
+  | Selector.Webkit_any ->
+      raise (Skip "unknown pseudo-class")
+  | Selector.Nesting -> raise (Skip "nesting selector")
+  | Selector.Combined _ | Selector.Relative _ | Selector.List _ ->
+      raise (Skip "complex selector inside a compound")
+
+(* :is(a, b) holds when any branch does, so take the first branch that is a
+   plain compound; a complex branch would need its own ancestor chain. *)
+and add_branch sp branches =
+  let rec first = function
+    | [] -> raise (Skip "no satisfiable :is() branch")
+    | b :: rest -> (
+        let saved = { sp with tag = sp.tag } in
+        try add sp b
+        with Skip _ ->
+          restore sp saved;
+          first rest)
+  in
+  first branches
+
+and add_has sp branches =
+  let inner, relation =
+    match branches with
+    | Selector.Relative (c, s) :: _ -> (s, c)
+    | s :: _ -> (s, Selector.Descendant)
+    | [] -> raise (Skip "empty :has()")
+  in
+  match relation with
+  | Selector.Descendant | Selector.Child ->
+      let child = new_spec () in
+      add child inner;
+      if child.root then raise (Skip ":root inside :has()");
+      sp.pseudos <- sp.pseudos @ child.pseudos;
+      sp.inner <- sp.inner @ [ node_of_spec child [] ]
+  | _ -> raise (Skip "sibling :has()")
+
+(* Split a complex selector into its steps, each carrying the combinator that
+   joins it to the step on its left. *)
+let rec steps sel =
+  match sel with
+  | Selector.Combined (l, c, r) -> (
+      match steps r with
+      | (_, first) :: rest -> steps l @ ((Some c, first) :: rest)
+      | [] -> steps l)
+  | Selector.Relative _ -> raise (Skip "relative selector outside :has()")
+  | s -> [ (None, s) ]
+
+let pad n tag = List.init (max 0 n) (fun _ -> filler tag)
+
+(* Lay the child out among its siblings so its position pseudo-class holds. *)
+let siblings ~parent_inner ~child_spec ~(child : node) before =
+  let tag = if child_spec.of_type then child.tag else "span" in
+  let list =
+    match child_spec.pos with
+    | Anywhere | Last -> before @ [ child ]
+    | First | Only ->
+        if before <> [] then raise (Skip "position conflicts with a sibling")
+        else [ child ]
+    | Nth n ->
+        let need = n - 1 - List.length before in
+        if need < 0 then raise (Skip "position conflicts with a sibling")
+        else pad need tag @ before @ [ child ]
+    | Nth_last n -> before @ [ child ] @ pad (n - 1) tag
+  in
+  match (parent_inner, child_spec.pos) with
+  | [], _ -> list
+  | _, (Last | Only | Nth_last _) ->
+      raise (Skip ":has() conflicts with a trailing position")
+  | inner, _ -> list @ inner
+
+let build_fragment sel =
+  let specs =
+    List.map
+      (fun (comb, part) ->
+        let sp = new_spec () in
+        add sp part;
+        (comb, sp))
+      (steps sel)
+  in
+  (match specs with
+  | [] -> raise (Skip "empty selector")
+  | _ :: rest ->
+      if List.exists (fun (_, sp) -> sp.root) rest then
+        raise (Skip ":root is not the outermost step"));
+  let pseudos = List.concat_map (fun (_, sp) -> sp.pseudos) specs in
+  match List.rev specs with
+  | [] -> raise (Skip "empty selector")
+  | (first_link, target) :: earlier ->
+      let cur = ref (node_of_spec target []) in
+      let cur_spec = ref target in
+      let before = ref [] in
+      let link = ref first_link in
+      List.iter
+        (fun (comb, sp) ->
+          (match !link with
+          | None | Some Selector.Descendant | Some Selector.Child ->
+              let kids =
+                siblings ~parent_inner:sp.inner ~child_spec:!cur_spec
+                  ~child:!cur !before
+              in
+              cur := node_of_spec { sp with inner = [] } kids;
+              cur_spec := sp;
+              before := []
+          | Some Selector.Next_sibling | Some Selector.Subsequent_sibling ->
+              (match sp.pos with
+              | Last | Only | Nth_last _ ->
+                  raise (Skip "position conflicts with a sibling")
+              | _ -> ());
+              before := node_of_spec sp [] :: !before
+          | Some _ -> raise (Skip "legacy combinator"));
+          link := comb)
+        earlier;
+      let nodes =
+        siblings ~parent_inner:[] ~child_spec:!cur_spec ~child:!cur !before
+      in
+      (!cur_spec, nodes, pseudos)
+
+let rec count_nodes n =
+  List.fold_left (fun n c -> count_nodes (n + 1) c.children) n
+
+let all_selectors sheet =
+  let flat = Css.flatten_nesting sheet in
+  List.rev
+    (Css.fold
+       (fun acc stmt ->
+         match Css.as_rule stmt with
+         | Some (sel, _, _) -> List.rev_append (Edge.selectors sel) acc
+         | None -> acc)
+       [] flat)
+
+let bump tbl key =
+  match List.assoc_opt key !tbl with
+  | Some n -> tbl := (key, n + 1) :: List.remove_assoc key !tbl
+  | None -> tbl := !tbl @ [ (key, 1) ]
+
+let of_stylesheet ?(max_elements = 4000) sheet =
+  let selectors = all_selectors sheet in
+  let cases = ref [] in
+  let probes = ref [] in
+  let pseudos = ref [] in
+  let html_classes = ref [] in
+  let html_attrs = ref [] in
+  let skipped = ref [] in
+  let examples = ref [] in
+  let synthesised = ref 0 in
+  let count = ref 0 in
+  let skip sel reason =
+    bump skipped reason;
+    if not (List.mem_assoc reason !examples) then
+      examples := (reason, Selector.to_string sel) :: !examples
+  in
+  List.iter
+    (fun sel ->
+      if !count >= max_elements then skip sel "document element cap"
+      else if Selector.matches_nothing sel then
+        skip sel "selector matches nothing"
+      else
+        match build_fragment sel with
+        | exception Skip reason -> skip sel reason
+        | exception Invalid_argument _ -> skip sel "invalid selector component"
+        | outer, nodes, sel_pseudos ->
+            incr synthesised;
+            count := count_nodes !count nodes;
+            probes := Selector.to_string (strip_pseudo_elements sel) :: !probes;
+            List.iter
+              (fun p ->
+                if not (List.mem p !pseudos) then pseudos := !pseudos @ [ p ])
+              sel_pseudos;
+            if outer.root then (
+              List.iter
+                (fun c ->
+                  if not (List.mem c !html_classes) then
+                    html_classes := !html_classes @ [ c ])
+                outer.classes;
+              List.iter
+                (fun (k, v) ->
+                  if not (List.mem_assoc k !html_attrs) then
+                    html_attrs := !html_attrs @ [ (k, v) ])
+                outer.attrs;
+              (* The outermost step is <html> itself, so its subtree hangs off
+                 <body> rather than off a case wrapper. *)
+              cases := !cases @ List.concat_map (fun n -> n.children) nodes)
+            else
+              cases :=
+                !cases
+                @ [
+                    {
+                      tag = "div";
+                      id = None;
+                      classes = [ "rd-case" ];
+                      attrs = [];
+                      children = nodes;
+                    };
+                  ])
+    selectors;
+  let root_node : node =
+    { tag = "body"; id = None; classes = []; attrs = []; children = !cases }
+  in
+  {
+    root_node;
+    html_classes = !html_classes;
+    html_attrs = !html_attrs;
+    doc_pseudos = !pseudos;
+    probes = List.rev !probes;
+    n_selectors = List.length selectors;
+    n_synthesised = !synthesised;
+    n_elements = count_nodes 0 [ root_node ];
+    skips = List.sort (fun (_, a) (_, b) -> compare b a) !skipped;
+    examples = !examples;
+  }
+
+let rec json_of_node (n : node) =
+  Json.Obj
+    ([ ("t", Json.Str n.tag) ]
+    @ (match n.id with Some i -> [ ("i", Json.Str i) ] | None -> [])
+    @ (if n.classes = [] then []
+       else [ ("c", Json.Arr (List.map (fun c -> Json.Str c) n.classes)) ])
+    @ (if n.attrs = [] then []
+       else
+         [
+           ( "a",
+             Json.Arr
+               (List.map
+                  (fun (k, v) -> Json.Arr [ Json.Str k; Json.Str v ])
+                  n.attrs) );
+         ])
+    @
+    if n.children = [] then []
+    else [ ("k", Json.Arr (List.map json_of_node n.children)) ])
+
+let to_json t =
+  Json.Obj
+    [
+      ("dom", json_of_node t.root_node);
+      ("htmlClasses", Json.Arr (List.map (fun c -> Json.Str c) t.html_classes));
+      ( "htmlAttrs",
+        Json.Arr
+          (List.map
+             (fun (k, v) -> Json.Arr [ Json.Str k; Json.Str v ])
+             t.html_attrs) );
+      ("pseudos", Json.Arr (List.map (fun p -> Json.Str p) t.doc_pseudos));
+      ("probes", Json.Arr (List.map (fun p -> Json.Str p) t.probes));
+    ]
+
+let selectors t = t.n_selectors
+let synthesised t = t.n_synthesised
+let elements t = t.n_elements
+let pseudo_elements t = t.doc_pseudos
+let skipped t = t.skips
+let skipped_example t reason = List.assoc_opt reason t.examples

--- a/test/render/dom_of_css.mli
+++ b/test/render/dom_of_css.mli
@@ -1,0 +1,46 @@
+(** Synthesise an HTML document from the selectors of a stylesheet.
+
+    Random markup matches almost nothing, so the differential test derives its
+    document from the sheet under test: every selector is walked, and elements
+    carrying the tags, classes, ids, attributes, nesting and sibling positions
+    it asks for are added to the document. A selector that cannot hold without a
+    user interaction ([:hover]), a shadow tree ([::part]) or a live document
+    ([:target]) is not synthesised, but it is counted and reported - it is never
+    silently dropped. *)
+
+type t
+(** A synthesised document. *)
+
+val of_stylesheet : ?max_elements:int -> Cascade.Css.t -> t
+(** [of_stylesheet sheet] derives a document from the selectors of [sheet],
+    including the selectors of nested rules and of rules inside [@media],
+    [@layer], [@supports] and [@container]. Synthesis stops once the document
+    reaches [max_elements] elements (default 4000); the selectors left over are
+    counted under the ["document element cap"] reason. *)
+
+val to_json : t -> Json.t
+(** [to_json t] is the document as the browser driver consumes it: the element
+    tree, the classes and attributes the root [html] element must carry, the
+    pseudo-elements to sample, and the probe selectors. *)
+
+val selectors : t -> int
+(** [selectors t] is the number of complex selectors the stylesheet declared,
+    counting each branch of a selector list separately. *)
+
+val synthesised : t -> int
+(** [synthesised t] is the number of those selectors an element was built for.
+*)
+
+val elements : t -> int
+(** [elements t] is the number of elements in the document. *)
+
+val pseudo_elements : t -> string list
+(** [pseudo_elements t] is the pseudo-elements the stylesheet targets that the
+    driver samples with [getComputedStyle], such as [::before]. *)
+
+val skipped : t -> (string * int) list
+(** [skipped t] pairs each reason a selector was not synthesised with how many
+    selectors it covers, most frequent first. *)
+
+val skipped_example : t -> string -> string option
+(** [skipped_example t reason] is one selector skipped for [reason]. *)

--- a/test/render/driver.js
+++ b/test/render/driver.js
@@ -1,0 +1,167 @@
+// Render each job's stylesheets in a headless browser and report, for every
+// element, every computed-style property the variants disagree on.
+//
+//   node driver.js JOBS.json WORKDIR
+//
+// JOBS.json is written by render_diff.exe: an array of jobs, each carrying the
+// derived document, the pseudo-elements to sample, the probe selectors, and the
+// stylesheet variants (the first is the reference the others are compared to).
+//
+// Output is TSV on stdout, one record per line:
+//   d <job> <variant> <index> <element> <property> <reference> <variant value>
+//   c <job> <matched probes> <unmatched probes> <rejected probes>
+//   u <job> <probe that matched no element>
+//   x <job> <error>
+// A tab never appears in a computed-style value, so the fields are unambiguous.
+//
+// All the jobs of one chunk share a single browser launch: the page reuses one
+// iframe, clearing it between jobs. getComputedStyle forces a synchronous style
+// recalculation, so no waiting or polling is involved.
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const CHROME = process.env.CHROME;
+const jobsFile = process.argv[2];
+const workDir = process.argv[3];
+const MAX_DIFFS = 200;
+const CHUNK_BYTES = 512 * 1024;
+
+const domJs = fs.readFileSync(path.join(__dirname, 'dom.js'), 'utf8');
+
+// Runs inside the page.
+const HARNESS = `
+function rdReset(doc) {
+  var root = doc.documentElement, a = root.attributes;
+  for (var i = a.length - 1; i >= 0; i--) root.removeAttribute(a[i].name);
+  doc.head.textContent = '';
+  doc.body.textContent = '';
+  var b = doc.body.attributes;
+  for (var i = b.length - 1; i >= 0; i--) doc.body.removeAttribute(b[i].name);
+}
+function rdProps(cs) {
+  var props = [];
+  // A custom property reaches the render only through a var() in a real
+  // property, and those are resolved in the values compared below.
+  for (var i = 0; i < cs.length; i++)
+    if (cs[i].indexOf('--') !== 0) props.push(cs[i]);
+  return props;
+}
+function rdSnapshot(view, els, pseudos, props) {
+  var snap = [], n = props.length;
+  for (var i = 0; i < els.length; i++) {
+    for (var p = -1; p < pseudos.length; p++) {
+      var cs = p < 0 ? view.getComputedStyle(els[i])
+                     : view.getComputedStyle(els[i], pseudos[p]);
+      var row = new Array(n);
+      for (var j = 0; j < n; j++) row[j] = cs.getPropertyValue(props[j]);
+      snap.push(row);
+    }
+  }
+  return snap;
+}
+function rdJob(doc, job, out) {
+  rdReset(doc);
+  rdBuild(doc, job);
+  var view = doc.defaultView;
+  var pseudos = job.pseudos || [];
+  var els = [doc.documentElement, doc.body];
+  var found = doc.body.querySelectorAll('*');
+  for (var i = 0; i < found.length; i++) els.push(found[i]);
+  var labels = [];
+  for (i = 0; i < els.length; i++)
+    for (var p = -1; p < pseudos.length; p++)
+      labels.push((els[i] === doc.documentElement ? 'html'
+                   : els[i] === doc.body ? 'body' : rdPath(els[i]))
+                  + (p < 0 ? '' : pseudos[p]));
+  var matched = 0, unmatched = 0, rejected = 0, shown = 0;
+  (job.probes || []).forEach(function (sel) {
+    var n;
+    try { n = doc.querySelectorAll(sel).length; }
+    catch (e) { rejected++; return; }
+    if (n > 0) matched++;
+    else {
+      unmatched++;
+      if (shown++ < 10) out.push(['u', job.id, sel].join('\\t'));
+    }
+  });
+  out.push(['c', job.id, matched, unmatched, rejected].join('\\t'));
+  var style = doc.createElement('style');
+  doc.head.appendChild(style);
+  var props = null, base = null;
+  job.sheets.forEach(function (sheet) {
+    style.textContent = sheet.css;
+    if (props === null) props = rdProps(view.getComputedStyle(doc.body));
+    var snap = rdSnapshot(view, els, pseudos, props);
+    if (base === null) { base = snap; return; }
+    var diffs = 0;
+    for (var e = 0; e < base.length && diffs < MAX_DIFFS; e++)
+      for (var j = 0; j < props.length && diffs < MAX_DIFFS; j++)
+        if (base[e][j] !== snap[e][j]) {
+          diffs++;
+          out.push(['d', job.id, sheet.name, e, labels[e], props[j],
+                    base[e][j], snap[e][j]].join('\\t'));
+        }
+  });
+}
+function rdMain(jobs) {
+  var out = [];
+  var frame = document.createElement('iframe');
+  frame.width = 1024;
+  frame.height = 768;
+  frame.style.border = '0';
+  document.body.appendChild(frame);
+  var doc = frame.contentDocument;
+  jobs.forEach(function (job) {
+    try { rdJob(doc, job, out); }
+    catch (e) { out.push(['x', job.id, String((e && e.message) || e)].join('\\t')); }
+  });
+  var text = out.join('\\n');
+  document.body.setAttribute('data-rd',
+    btoa(unescape(encodeURIComponent(text))));
+}
+`;
+
+function page(jobs) {
+  const payload = JSON.stringify(jobs).replace(/</g, '\\u003c');
+  return '<!doctype html><html><head><meta charset="utf-8"></head><body>' +
+    '<script id="rd-jobs" type="application/json">' + payload + '</script>' +
+    '<script>' + domJs + '</script>' +
+    '<script>var MAX_DIFFS = ' + MAX_DIFFS + ';' + HARNESS +
+    'rdMain(JSON.parse(document.getElementById("rd-jobs").textContent));</script>' +
+    '</body></html>';
+}
+
+function chunks(jobs) {
+  const out = [];
+  let cur = [], size = 0;
+  for (const job of jobs) {
+    const n = JSON.stringify(job).length;
+    if (cur.length && size + n > CHUNK_BYTES) { out.push(cur); cur = []; size = 0; }
+    cur.push(job);
+    size += n;
+  }
+  if (cur.length) out.push(cur);
+  return out;
+}
+
+function run(jobs, index) {
+  // Absolute: a file:// URL has no notion of the process's directory.
+  const file = path.resolve(workDir, 'page-' + index + '.html');
+  fs.writeFileSync(file, page(jobs));
+  const dom = execFileSync(CHROME, [
+    '--headless', '--disable-gpu', '--no-sandbox',
+    '--virtual-time-budget=120000', '--dump-dom', 'file://' + file,
+  ], { encoding: 'utf8', maxBuffer: 1 << 28 });
+  const m = dom.match(/data-rd="([^"]*)"/);
+  if (!m) throw new Error('the page produced no result for chunk ' + index);
+  return Buffer.from(m[1], 'base64').toString('utf8');
+}
+
+const jobs = JSON.parse(fs.readFileSync(jobsFile, 'utf8'));
+const parts = chunks(jobs);
+parts.forEach(function (chunk, i) {
+  const text = run(chunk, i);
+  if (text.length) process.stdout.write(text + '\n');
+});

--- a/test/render/dune
+++ b/test/render/dune
@@ -1,0 +1,31 @@
+; Differential render test: a stylesheet and its optimized forms must compute
+; the same style for every element of a real headless browser. The document is
+; derived from the stylesheet's own selectors, so the rules actually match.
+;
+; The test skips, with status 0, when node or a headless Chromium is missing,
+; or when CASCADE_NO_BROWSER is set, so it never fails a machine without a
+; browser. Run the wider sweep by hand with test/render/run.sh.
+
+(executable
+ (name render_diff)
+ (libraries cascade cascade_diff fmt unix))
+
+; render_diff.exe reads the driver and the DOM builder at run time, so they
+; have to sit next to it in the build directory.
+
+(rule
+ (alias default)
+ (deps
+  (glob_files *.js))
+ (action (progn)))
+
+(rule
+ (alias runtest)
+ (deps
+  (glob_files *.js)
+  render_diff.exe)
+ (action
+  (setenv
+   CASCADE_RENDER_ARTIFACTS
+   %{workspace_root}/tmp/render-diff
+   (run %{exe:render_diff.exe}))))

--- a/test/render/dune
+++ b/test/render/dune
@@ -19,10 +19,15 @@
   (glob_files *.js))
  (action (progn)))
 
+; The sweep reads the committed CSS corpora, so the rule has to bring them
+; into the build directory it runs in.
+
 (rule
  (alias runtest)
  (deps
   (glob_files *.js)
+  (source_tree ../interop/css-minify-tests/traces/tests)
+  (source_tree ../examples)
   render_diff.exe)
  (action
   (setenv

--- a/test/render/gen_sheet.ml
+++ b/test/render/gen_sheet.ml
@@ -1,0 +1,126 @@
+open Cascade
+
+(* A linear congruential generator: the sweep needs the same sheet for the same
+   seed on every machine, which Random does not promise across versions. *)
+type rng = { mutable state : int }
+
+let rng seed = { state = seed * 2654435761 land max_int }
+
+let next r =
+  r.state <- ((r.state * 2862933555777941757) + 3037000493) land max_int;
+  r.state
+
+let int r n = if n <= 1 then 0 else next r mod n
+let pick r l = List.nth l (int r (List.length l))
+let chance r n = int r n = 0
+
+(* ===== Selectors ===== *)
+
+let simple =
+  [
+    Selector.class_ "a";
+    Selector.class_ "b";
+    Selector.class_ "card";
+    Selector.element "div";
+    Selector.element "p";
+    Selector.element "li";
+    Selector.element "span";
+    Selector.id "lead";
+    Selector.compound [ Selector.element "li"; Selector.First_child ];
+    Selector.compound [ Selector.element "li"; Selector.Last_child ];
+    Selector.compound
+      [ Selector.class_ "a"; Selector.Nth_child (Selector.Index 2, None) ];
+    Selector.attribute "data-k" (Selector.Exact "v");
+    Selector.compound
+      [ Selector.element "p"; Selector.Not [ Selector.class_ "b" ] ];
+  ]
+
+let combinators =
+  [
+    Selector.Descendant;
+    Selector.Child;
+    Selector.Next_sibling;
+    Selector.Subsequent_sibling;
+  ]
+
+let selector r =
+  let base = pick r simple in
+  if chance r 3 then Selector.combine (pick r simple) (pick r combinators) base
+  else base
+
+(* ===== Values ===== *)
+
+let px r = Css.Values.Px (float_of_int (int r 20))
+let colors = [ "#f00"; "#0f0"; "#00f"; "#123456"; "#abc" ]
+let color r = Css.Values.hex (pick r colors)
+
+(* ===== Declarations =====
+
+   Each family writes cascade slots its partner also writes, so the two
+   declarations render differently when swapped: this is the shape the canonical
+   declaration order has to leave alone. *)
+let overflows : Css.overflow list = [ Hidden; Visible; Auto; Scroll ]
+let displays : Css.display list = [ Block; Flex; Inline_block; Grid ]
+
+let families =
+  [
+    (fun r -> [ Css.margin [ px r ]; Css.margin_top (px r) ]);
+    (fun r -> [ Css.padding [ px r; px r ]; Css.padding_left (px r) ]);
+    (fun r -> [ Css.gap (Css.gaps (px r)); Css.row_gap (px r) ]);
+    (fun r ->
+      [ Css.overflow (pick r overflows); Css.overflow_x (pick r overflows) ]);
+  ]
+
+let singles =
+  [
+    (fun r -> Css.color (color r));
+    (fun r -> Css.background_color (color r));
+    (fun r -> Css.width (px r));
+    (fun r -> Css.opacity (Css.Opacity_number (float_of_int (int r 10) /. 10.)));
+    (fun r -> Css.display (pick r displays));
+  ]
+
+let declarations r =
+  let family = if chance r 2 then (pick r families) r else [] in
+  (* Either order, so the sweep sees the longhand before and after the shorthand
+     that resets it. *)
+  let family = if chance r 2 then List.rev family else family in
+  let rest = List.init (1 + int r 3) (fun _ -> (pick r singles) r) in
+  let all = family @ rest in
+  if chance r 6 then
+    match all with d :: tl -> Css.important d :: tl | [] -> all
+  else all
+
+(* ===== Statements ===== *)
+
+let media_min_width w : Css.Media.t =
+  Css.Media.Cond
+    (Css.Media.Feature
+       (Css.Media.Plain
+          (Css.Media.Min Css.Media.Width, Css.Media.Length (Css.Values.Px w))))
+
+let statement r =
+  let rule = Css.rule ~selector:(selector r) (declarations r) in
+  if chance r 5 then
+    Css.media
+      ~condition:(media_min_width (float_of_int (pick r [ 400; 800 ])))
+      [ rule ]
+  else rule
+
+let stylesheet ~seed =
+  let r = rng seed in
+  let n = 3 + int r 6 in
+  let statements = List.init n (fun _ -> statement r) in
+  (* A repeated selector gives the optimizer rules to merge, and a merge that
+     crosses a conflicting write is the other way it can change a render. *)
+  let repeat =
+    if chance r 2 then
+      match statements with
+      | first :: _ -> (
+          match Css.as_rule first with
+          | Some (sel, _, _) -> [ Css.rule ~selector:sel (declarations r) ]
+          | None -> [])
+      | [] -> []
+    else []
+  in
+  Css.v (statements @ repeat)

--- a/test/render/gen_sheet.mli
+++ b/test/render/gen_sheet.mli
@@ -1,0 +1,10 @@
+(** Seeded stylesheets built from cascade's typed constructors.
+
+    The same seed always gives the same sheet, so a failure the sweep finds
+    reproduces from its seed alone. Breadth matters less than shape: the
+    generator leans on what the optimizer rewrites - a shorthand and a longhand
+    of one family in either order, a property written twice, two rules sharing a
+    selector, [!important], and a [@media] block. *)
+
+val stylesheet : seed:int -> Cascade.Css.t
+(** [stylesheet ~seed] is the sheet for [seed]. *)

--- a/test/render/json.ml
+++ b/test/render/json.ml
@@ -1,0 +1,56 @@
+type t = Str of string | Int of int | Arr of t list | Obj of (string * t) list
+
+let escape buf s =
+  String.iter
+    (fun c ->
+      match c with
+      | '"' -> Buffer.add_string buf "\\\""
+      | '\\' -> Buffer.add_string buf "\\\\"
+      | '\n' -> Buffer.add_string buf "\\n"
+      | '\r' -> Buffer.add_string buf "\\r"
+      | '\t' -> Buffer.add_string buf "\\t"
+      (* The driver embeds the payload in a <script> element, so no character
+         that can close it or start an entity may survive as itself. *)
+      | '<' -> Buffer.add_string buf "\\u003c"
+      | '>' -> Buffer.add_string buf "\\u003e"
+      | '&' -> Buffer.add_string buf "\\u0026"
+      | c when Char.code c < 0x20 ->
+          let hex n = "0123456789abcdef".[n land 0xf] in
+          Buffer.add_string buf "\\u00";
+          Buffer.add_char buf (hex (Char.code c lsr 4));
+          Buffer.add_char buf (hex (Char.code c))
+      | c -> Buffer.add_char buf c)
+    s
+
+let rec write buf = function
+  | Str s ->
+      Buffer.add_char buf '"';
+      escape buf s;
+      Buffer.add_char buf '"'
+  | Int i -> Buffer.add_string buf (string_of_int i)
+  | Arr l ->
+      Buffer.add_char buf '[';
+      List.iteri
+        (fun i v ->
+          if i > 0 then Buffer.add_char buf ',';
+          write buf v)
+        l;
+      Buffer.add_char buf ']'
+  | Obj fields ->
+      Buffer.add_char buf '{';
+      List.iteri
+        (fun i (k, v) ->
+          if i > 0 then Buffer.add_char buf ',';
+          Buffer.add_char buf '"';
+          escape buf k;
+          Buffer.add_string buf "\":";
+          write buf v)
+        fields;
+      Buffer.add_char buf '}'
+
+let to_string v =
+  let buf = Buffer.create 1024 in
+  write buf v;
+  Buffer.contents buf
+
+let pp ppf v = Fmt.string ppf (to_string v)

--- a/test/render/json.mli
+++ b/test/render/json.mli
@@ -1,0 +1,15 @@
+(** Minimal JSON writer for the browser driver's input file. *)
+
+type t =
+  | Str of string  (** JSON string. *)
+  | Int of int  (** JSON number. *)
+  | Arr of t list  (** JSON array. *)
+  | Obj of (string * t) list  (** JSON object. *)
+
+val to_string : t -> string
+(** [to_string json] serialises [json]. Every code point below U+0020 and the
+    characters [<], [>] and [&] are escaped, so the result is safe to embed
+    verbatim in a [<script>] element. *)
+
+val pp : t Fmt.t
+(** [pp] prints {!to_string}. *)

--- a/test/render/render_diff.ml
+++ b/test/render/render_diff.ml
@@ -1,0 +1,491 @@
+(* Render a stylesheet and its optimized forms in a headless browser and check
+   that every element computes the same style under each. A disagreement is an
+   optimizer bug: the two sheets do not render the same page.
+
+   Skips cleanly, with status 0, when node or a headless Chromium is missing, or
+   when CASCADE_NO_BROWSER is set. *)
+
+open Cascade
+
+let ( // ) = Filename.concat
+
+(* ===== Environment ===== *)
+
+let getenv name =
+  match Sys.getenv_opt name with Some "" | None -> None | Some v -> Some v
+
+let executable path =
+  (try Sys.file_exists path && not (Sys.is_directory path)
+   with Sys_error _ -> false)
+  &&
+    try
+      Unix.access path [ Unix.X_OK ];
+      true
+    with Unix.Unix_error _ | Sys_error _ -> false
+
+let on_path name =
+  let dirs =
+    String.split_on_char ':' (Option.value ~default:"" (getenv "PATH"))
+  in
+  List.find_map
+    (fun d ->
+      if d = "" then None
+      else
+        let p = d // name in
+        if executable p then Some p else None)
+    dirs
+
+(* The browser caches keep one directory per version, so the largest path is the
+   newest build. *)
+let rec search_tree root names depth acc =
+  if depth <= 0 then acc
+  else
+    match Sys.readdir root with
+    | exception Sys_error _ -> acc
+    | entries ->
+        Array.fold_left
+          (fun acc entry ->
+            let p = root // entry in
+            if try Sys.is_directory p with Sys_error _ -> false then
+              search_tree p names (depth - 1) acc
+            else if List.mem entry names && executable p then p :: acc
+            else acc)
+          acc entries
+
+let chrome_binary () =
+  match getenv "CHROME" with
+  | Some c when executable c -> Some c
+  | Some _ | None -> (
+      let names =
+        [
+          "chromium";
+          "chromium-browser";
+          "google-chrome";
+          "google-chrome-stable";
+        ]
+      in
+      match List.find_map on_path names with
+      | Some c -> Some c
+      | None -> (
+          let home = Option.value ~default:"" (getenv "HOME") in
+          let caches =
+            [
+              home // ".cache" // "puppeteer";
+              home // "Library" // "Caches" // "ms-playwright";
+              home // ".cache" // "ms-playwright";
+            ]
+          in
+          let binaries =
+            [
+              "chrome-headless-shell";
+              "headless_shell";
+              "Chromium";
+              "Google Chrome for Testing";
+            ]
+          in
+          let found =
+            List.concat_map (fun c -> search_tree c binaries 6 []) caches
+          in
+          match List.sort compare found with
+          | [] ->
+              let app =
+                "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+              in
+              if executable app then Some app else None
+          | l -> Some (List.nth l (List.length l - 1))))
+
+let node_binary () =
+  match getenv "NODE" with
+  | Some n when executable n -> Some n
+  | Some _ | None -> on_path "node"
+
+(* ===== Inputs ===== *)
+
+(* One tiny hand-written sheet, kept next to the harness rather than in a
+   fixture file: it holds a shorthand and a longhand of the same family in each
+   order - the shape behind two render-changing reorders - plus a selector list,
+   a child and a sibling combinator, a position pseudo-class, an attribute
+   selector and a pseudo-element. *)
+let smoke_sheet =
+  {css|
+.card { margin: 0; margin-top: 8px; color: red }
+.card > h2:first-child { row-gap: 9px; gap: 1px; font-weight: bold }
+ul li + li { padding: 4px 8px; padding-left: 2px }
+a[href^="https"], .card p { text-decoration: underline; color: #00f }
+.card p::before { content: "> "; background: red; background-position-x: 10px }
+|css}
+
+(* A sheet paired with a form that renders differently: [gap] resets the row gap
+   the longhand set, so the two orders give the rule a different row gap. The
+   canary fails when the harness reports no difference - a harness that cannot
+   see a known render change proves nothing about the ones it misses. *)
+let canary_sheet = {css|.k { row-gap: 9px; gap: 1px }|css}
+let canary_reordered = {css|.k { gap: 1px; row-gap: 9px }|css}
+
+type input = {
+  id : string;
+  source : string; (* the document is derived from this sheet *)
+  sheets : (string * string) list option; (* None: the optimize variants *)
+  expect_diff : bool;
+}
+
+let sheet id source = { id; source; sheets = None; expect_diff = false }
+
+let inputs () =
+  [
+    sheet "smoke" smoke_sheet;
+    {
+      id = "canary";
+      source = canary_sheet;
+      sheets =
+        Some [ ("original", canary_sheet); ("reordered", canary_reordered) ];
+      expect_diff = true;
+    };
+  ]
+
+(* ===== Variants ===== *)
+
+(* The reference is the printed source: comparing against it isolates what
+   [optimize] did from what the parser and the printer did. *)
+let variants sheet =
+  let optimized = Css.optimize sheet in
+  let minified = Css.to_string ~minify:true optimized in
+  let reparsed =
+    match Css.of_string ~strict:false minified with
+    | Ok { stylesheet; _ } -> Css.to_string ~minify:true stylesheet
+    | Error _ -> minified
+  in
+  [
+    ("original", Css.to_string sheet);
+    ("optimize", minified);
+    ("lossless", Css.to_string ~minify:true (Css.optimize ~lossless:true sheet));
+    ("reparsed", reparsed);
+  ]
+
+(* ===== Canonical filter ===== *)
+
+(* getComputedStyle spells one render more than one way ([0% 0%] against [0px
+   0px], [red] against [rgb(255, 0, 0)]), so a raw string difference is only a
+   candidate. It survives when the two values are not canonically equal, which
+   is when the optimizer changed the render. *)
+let wrap prop value = String.concat "" [ "x{"; prop; ":"; value; "}" ]
+
+let canonically_equal prop a b =
+  try
+    Cascade_diff.Css_compare.equal ~mode:`Canonical (wrap prop a) (wrap prop b)
+  with Reader.Parse_error _ | Failure _ | Invalid_argument _ -> false
+
+(* ===== Driver protocol ===== *)
+
+type diff = {
+  variant : string;
+  element : string;
+  property : string;
+  reference : string;
+  observed : string;
+}
+
+type result = {
+  diffs : diff list;
+  candidates : int;
+  matched : int;
+  unmatched : int;
+  rejected : int;
+  unmatched_examples : string list;
+  errors : string list;
+}
+
+let empty_result =
+  {
+    diffs = [];
+    candidates = 0;
+    matched = 0;
+    unmatched = 0;
+    rejected = 0;
+    unmatched_examples = [];
+    errors = [];
+  }
+
+let int_of s = try int_of_string (String.trim s) with Failure _ -> 0
+
+let parse_driver_output lines =
+  let table = Hashtbl.create 16 in
+  let get id = try Hashtbl.find table id with Not_found -> empty_result in
+  List.iter
+    (fun line ->
+      match String.split_on_char '\t' line with
+      | "d" :: id :: variant :: _index :: element :: property :: reference
+        :: observed :: _ ->
+          let r = get id in
+          let r = { r with candidates = r.candidates + 1 } in
+          let r =
+            if canonically_equal property reference observed then r
+            else
+              {
+                r with
+                diffs =
+                  r.diffs
+                  @ [ { variant; element; property; reference; observed } ];
+              }
+          in
+          Hashtbl.replace table id r
+      | [ "c"; id; matched; unmatched; rejected ] ->
+          let r = get id in
+          Hashtbl.replace table id
+            {
+              r with
+              matched = int_of matched;
+              unmatched = int_of unmatched;
+              rejected = int_of rejected;
+            }
+      | [ "u"; id; selector ] ->
+          let r = get id in
+          Hashtbl.replace table id
+            { r with unmatched_examples = r.unmatched_examples @ [ selector ] }
+      | "x" :: id :: rest ->
+          let r = get id in
+          Hashtbl.replace table id
+            { r with errors = r.errors @ [ String.concat "\t" rest ] }
+      | _ -> ())
+    lines;
+  table
+
+let read_lines ic =
+  let rec loop acc =
+    match input_line ic with
+    | line -> loop (line :: acc)
+    | exception End_of_file -> List.rev acc
+  in
+  loop []
+
+let run_driver ~node ~chrome ~script ~jobs ~work =
+  let errors = work // "driver.err" in
+  let cmd =
+    Fmt.str "CHROME=%s %s %s %s %s 2>%s" (Filename.quote chrome)
+      (Filename.quote node) (Filename.quote script) (Filename.quote jobs)
+      (Filename.quote work) (Filename.quote errors)
+  in
+  let ic = Unix.open_process_in cmd in
+  let lines = read_lines ic in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> Ok lines
+  | _ ->
+      let ic = open_in errors in
+      let text = read_lines ic in
+      close_in ic;
+      Error (String.concat "\n" text)
+
+(* ===== Artefacts ===== *)
+
+let rec mkdir_p dir =
+  if not (Sys.file_exists dir) then (
+    mkdir_p (Filename.dirname dir);
+    try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+
+let write file contents =
+  let oc = open_out file in
+  output_string oc contents;
+  close_out oc
+
+let read_file file =
+  let ic = open_in_bin file in
+  let n = in_channel_length ic in
+  let s = really_input_string ic n in
+  close_in ic;
+  s
+
+(* A page that rebuilds the derived document with the builder the driver used,
+   so opening the artefact in a browser reproduces the run. *)
+let repro ~css ~dom =
+  String.concat ""
+    [
+      "<!doctype html><html><head><meta charset=\"utf-8\"><style>";
+      css;
+      "</style></head><body><script id=\"rd-doc\" type=\"application/json\">";
+      dom;
+      "</script><script src=\"dom.js\"></script><script>rdBuild(document, \
+       JSON.parse(document.getElementById('rd-doc').textContent));</script></body></html>";
+    ]
+
+let write_artefacts ~dir ~script_dir ~dom ~sheets ~diffs =
+  mkdir_p dir;
+  write (dir // "dom.json") dom;
+  write (dir // "dom.js") (read_file (script_dir // "dom.js"));
+  List.iter (fun (name, css) -> write (dir // (name ^ ".css")) css) sheets;
+  List.iter
+    (fun (name, css) ->
+      write (dir // ("page-" ^ name ^ ".html")) (repro ~css ~dom))
+    sheets;
+  let buf = Buffer.create 4096 in
+  let out = Fmt.with_buffer buf in
+  List.iter
+    (fun d ->
+      Fmt.pf out "%s\t%s\t%s\t%s\t%s\n" d.variant d.element d.property
+        d.reference d.observed)
+    diffs;
+  Fmt.flush out ();
+  write (dir // "diff.tsv") (Buffer.contents buf)
+
+(* ===== Main ===== *)
+
+(* Absolute, so the path the run prints can be opened from anywhere and the
+   driver can turn the page into a file:// URL. *)
+let artefact_root () =
+  let dir =
+    match getenv "CASCADE_RENDER_ARTIFACTS" with
+    | Some d -> d
+    | None -> "tmp" // "render-diff"
+  in
+  if Filename.is_relative dir then Sys.getcwd () // dir else dir
+
+let skip reason =
+  print_endline ("SKIP: render_diff (" ^ reason ^ ")");
+  exit 0
+
+let job_of_input input sheets doms unparsed =
+  let id = input.id in
+  match Css.of_string ~strict:false input.source with
+  | Error _ ->
+      incr unparsed;
+      None
+  | Ok { stylesheet; _ } ->
+      let dom = Dom_of_css.of_stylesheet stylesheet in
+      let vs =
+        match input.sheets with Some vs -> vs | None -> variants stylesheet
+      in
+      Hashtbl.replace sheets id vs;
+      Hashtbl.replace doms id dom;
+      let fields =
+        match Dom_of_css.to_json dom with
+        | Json.Obj fields -> fields
+        | other -> [ ("dom", other) ]
+      in
+      Some
+        (Json.Obj
+           ((("id", Json.Str id) :: fields)
+           @ [
+               ( "sheets",
+                 Json.Arr
+                   (List.map
+                      (fun (name, css) ->
+                        Json.Obj
+                          [ ("name", Json.Str name); ("css", Json.Str css) ])
+                      vs) );
+             ]))
+
+let () =
+  if getenv "CASCADE_NO_BROWSER" <> None then skip "CASCADE_NO_BROWSER is set";
+  let node = match node_binary () with Some n -> n | None -> skip "no node" in
+  let chrome =
+    match chrome_binary () with
+    | Some c -> c
+    | None -> skip "no headless browser"
+  in
+  let script_dir = Filename.dirname Sys.executable_name in
+  let root = artefact_root () in
+  let work = root // ".work" in
+  mkdir_p work;
+  let sheets = Hashtbl.create 16 in
+  let doms = Hashtbl.create 16 in
+  let unparsed = ref 0 in
+  let inputs = inputs () in
+  let jobs =
+    List.filter_map (fun i -> job_of_input i sheets doms unparsed) inputs
+  in
+  let jobs_file = work // "jobs.json" in
+  write jobs_file (Json.to_string (Json.Arr jobs));
+  let started = Unix.gettimeofday () in
+  let lines =
+    match
+      run_driver ~node ~chrome
+        ~script:(script_dir // "driver.js")
+        ~jobs:jobs_file ~work
+    with
+    | Ok lines -> lines
+    | Error err ->
+        prerr_endline ("render_diff: the browser driver failed:\n" ^ err);
+        exit 1
+  in
+  let elapsed = Unix.gettimeofday () -. started in
+  let table = parse_driver_output lines in
+  let failures = ref 0 in
+  let selectors = ref 0 and synthesised = ref 0 and elements = ref 0 in
+  let skipped = Hashtbl.create 16 in
+  let matched = ref 0 and unmatched = ref 0 and rejected = ref 0 in
+  let candidates = ref 0 in
+  let surviving = ref 0 in
+  let canaries = ref 0 in
+  let unmatched_shown = ref 0 in
+  List.iter
+    (fun input ->
+      let id = input.id in
+      match Hashtbl.find_opt doms id with
+      | None -> ()
+      | Some dom ->
+          selectors := !selectors + Dom_of_css.selectors dom;
+          synthesised := !synthesised + Dom_of_css.synthesised dom;
+          elements := !elements + Dom_of_css.elements dom;
+          List.iter
+            (fun (reason, n) ->
+              let prev =
+                try Hashtbl.find skipped reason with Not_found -> 0
+              in
+              Hashtbl.replace skipped reason (prev + n))
+            (Dom_of_css.skipped dom);
+          let r = try Hashtbl.find table id with Not_found -> empty_result in
+          matched := !matched + r.matched;
+          unmatched := !unmatched + r.unmatched;
+          rejected := !rejected + r.rejected;
+          candidates := !candidates + r.candidates;
+          List.iter
+            (fun e -> prerr_endline ("render_diff: " ^ id ^ ": " ^ e))
+            r.errors;
+          if r.errors <> [] then incr failures;
+          List.iter
+            (fun s ->
+              if !unmatched_shown < 10 then (
+                incr unmatched_shown;
+                Fmt.pr "  probe matched no element: %s (%s)@." s id))
+            r.unmatched_examples;
+          if input.expect_diff then
+            if r.diffs = [] then (
+              incr failures;
+              Fmt.pr
+                "FAIL %s: the harness saw no difference between two sheets \
+                 that render differently@."
+                id)
+            else incr canaries
+          else if r.diffs <> [] then (
+            surviving := !surviving + List.length r.diffs;
+            incr failures;
+            let dir = root // id in
+            write_artefacts ~dir ~script_dir
+              ~dom:(Json.to_string (Dom_of_css.to_json dom))
+              ~sheets:(Hashtbl.find sheets id) ~diffs:r.diffs;
+            Fmt.pr "FAIL %s: %d computed-style difference(s)@." id
+              (List.length r.diffs);
+            List.iteri
+              (fun i d ->
+                if i < 6 then
+                  Fmt.pr "  [%s] %s %s: %S -> %S@." d.variant d.element
+                    d.property d.reference d.observed)
+              r.diffs;
+            Fmt.pr "  artefacts: %s@." dir))
+    inputs;
+  Fmt.pr
+    "render_diff: %d sheet(s), %d selector(s), %d synthesised, %d element(s), \
+     %.1fs@."
+    (Hashtbl.length doms) !selectors !synthesised !elements elapsed;
+  Fmt.pr "  probes: %d matched, %d unmatched, %d rejected@." !matched !unmatched
+    !rejected;
+  Fmt.pr
+    "  computed-style candidates: %d, render differences: %d, canaries seen: \
+     %d@."
+    !candidates !surviving !canaries;
+  if !unparsed > 0 then Fmt.pr "  unparsed inputs: %d@." !unparsed;
+  Hashtbl.fold (fun reason n acc -> (reason, n) :: acc) skipped []
+  |> List.sort (fun (_, a) (_, b) -> compare b a)
+  |> List.iter (fun (reason, n) ->
+      Fmt.pr "  not synthesised: %-42s %d@." reason n);
+  Fmt.pr "  failures: %d@." !failures;
+  if !failures > 0 then exit 1

--- a/test/render/render_diff.ml
+++ b/test/render/render_diff.ml
@@ -99,6 +99,32 @@ let node_binary () =
   | Some n when executable n -> Some n
   | Some _ | None -> on_path "node"
 
+(* ===== Files ===== *)
+
+let contains haystack needle =
+  let n = String.length needle and h = String.length haystack in
+  let rec at i =
+    i + n <= h && (String.sub haystack i n = needle || at (i + 1))
+  in
+  n = 0 || at 0
+
+let rec mkdir_p dir =
+  if not (Sys.file_exists dir) then (
+    mkdir_p (Filename.dirname dir);
+    try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+
+let write file contents =
+  let oc = open_out file in
+  output_string oc contents;
+  close_out oc
+
+let read_file file =
+  let ic = open_in_bin file in
+  let n = in_channel_length ic in
+  let s = really_input_string ic n in
+  close_in ic;
+  s
+
 (* ===== Inputs ===== *)
 
 (* One tiny hand-written sheet, kept next to the harness rather than in a
@@ -122,26 +148,172 @@ a[href^="https"], .card p { text-decoration: underline; color: #00f }
 let canary_sheet = {css|.k { row-gap: 9px; gap: 1px }|css}
 let canary_reordered = {css|.k { gap: 1px; row-gap: 9px }|css}
 
+(* [Differs] is the expected-failure marker: the harness fails when the pair it
+   names renders the same, so a fix cannot leave the pin behind. *)
+type expectation = Same | Differs of string
+
 type input = {
   id : string;
   source : string; (* the document is derived from this sheet *)
   sheets : (string * string) list option; (* None: the optimize variants *)
-  expect_diff : bool;
+  expect : expectation;
 }
 
-let sheet id source = { id; source; sheets = None; expect_diff = false }
+(* Inputs the sweep is known to fail. Each is a render change the optimizer
+   makes today; fixing one is its own piece of work, so the sweep pins them here
+   and stays green on everything else. *)
+let known =
+  [
+    ( "corpus-duplicates-0015",
+      "--lossless sorts border-top before border-block, which overwrites it" );
+    ( "corpus-duplicates-0016",
+      "--lossless sorts margin-left before margin-inline-start, which \
+       overwrites it" );
+    ( "corpus-duplicates-0017",
+      "--lossless sorts padding-top before padding-block-start, which \
+       overwrites it" );
+    ("corpus-colors-0046", "--lossless rounds the alpha channel to 3 decimals");
+    ("corpus-colors-0047", "--lossless rounds the alpha channel to 3 decimals");
+    ("corpus-colors-0048", "--lossless rounds the alpha channel to 3 decimals");
+    ("corpus-colors-0049", "--lossless rounds the alpha channel to 3 decimals");
+    ( "corpus-anchor-0002",
+      "position-area: top center folds to top, which Chromium computes as a \
+       different area" );
+  ]
+
+let sheet id source =
+  let expect =
+    match List.assoc_opt id known with
+    | Some reason -> Differs reason
+    | None -> Same
+  in
+  { id; source; sheets = None; expect }
+
+(* The committed corpora sit at a fixed place in the tree; the sweep runs both
+   from the repository root and from the build directory a dune rule gives it,
+   so it looks for them upwards from wherever it started. *)
+let repo_relative rel =
+  let rec up dir fuel =
+    if fuel = 0 then None
+    else if Sys.file_exists (dir // rel) then Some (dir // rel)
+    else
+      let parent = Filename.dirname dir in
+      if parent = dir then None else up parent (fuel - 1)
+  in
+  up (Sys.getcwd ()) 12
+
+let entries dir =
+  match Sys.readdir dir with
+  | exception Sys_error _ -> []
+  | e ->
+      Array.sort compare e;
+      Array.to_list e
+
+(* test/interop/css-minify-tests: 398 small sheets across 28 categories, one
+   [source.css] each. Enough shapes - shorthands, nesting, layers, selectors -
+   that the derived documents cover most of what a browser has to agree on. *)
+let corpus_files () =
+  match
+    repo_relative
+      ("test" // "interop" // "css-minify-tests" // "traces" // "tests")
+  with
+  | None -> []
+  | Some root ->
+      List.concat_map
+        (fun category ->
+          let dir = root // category in
+          if not (try Sys.is_directory dir with Sys_error _ -> false) then []
+          else
+            List.filter_map
+              (fun id ->
+                let file = dir // id // "source.css" in
+                if Sys.file_exists file then
+                  Some ("corpus-" ^ category ^ "-" ^ id, file)
+                else None)
+              (entries dir))
+        (entries root)
+
+(* test/examples: the two committed hand-written sheets, an order of magnitude
+   larger than a corpus case. *)
+let example_files () =
+  match repo_relative ("test" // "examples") with
+  | None -> []
+  | Some dir ->
+      List.filter_map
+        (fun file ->
+          if Filename.check_suffix file ".css" then
+            Some ("example-" ^ Filename.remove_extension file, dir // file)
+          else None)
+        (entries dir)
+
+(* Spread the sample over the whole list rather than taking a prefix, so every
+   category is represented. *)
+let sample n l =
+  let total = List.length l in
+  if n <= 0 || total <= n then l
+  else
+    let step = (total + n - 1) / n in
+    List.filteri (fun i _ -> i mod step = 0) l
+
+let full = ref false
+let seeds = ref None
+let corpus = ref None
+let only = ref None
+
+let usage () =
+  Fmt.pr
+    "usage: render_diff [--full] [--seeds N] [--corpus N] [--only SUBSTRING]@.";
+  exit 0
+
+let parse_args () =
+  let rec loop i =
+    if i < Array.length Sys.argv then (
+      let arg n =
+        if i + 1 < Array.length Sys.argv then Sys.argv.(i + 1) else n
+      in
+      (match Sys.argv.(i) with
+      | "--full" -> full := true
+      | "--seeds" -> seeds := int_of_string_opt (arg "")
+      | "--corpus" -> corpus := int_of_string_opt (arg "")
+      | "--only" -> only := Some (arg "")
+      | "-h" | "--help" -> usage ()
+      | _ -> ());
+      loop (i + 1))
+  in
+  loop 1
 
 let inputs () =
-  [
-    sheet "smoke" smoke_sheet;
-    {
-      id = "canary";
-      source = canary_sheet;
-      sheets =
-        Some [ ("original", canary_sheet); ("reordered", canary_reordered) ];
-      expect_diff = true;
-    };
-  ]
+  parse_args ();
+  (* The whole committed corpus renders in under two seconds, so the default
+     sweep takes all of it; [--full] only widens the generated half. *)
+  let n_seeds =
+    match !seeds with Some n -> n | None -> if !full then 256 else 32
+  in
+  let n_corpus = match !corpus with Some n -> n | None -> 0 in
+  let files = sample n_corpus (corpus_files ()) @ example_files () in
+  let generated =
+    List.init n_seeds (fun i ->
+        sheet
+          ("seed-" ^ string_of_int i)
+          (Css.to_string (Gen_sheet.stylesheet ~seed:i)))
+  in
+  let all =
+    [
+      sheet "smoke" smoke_sheet;
+      {
+        id = "canary";
+        source = canary_sheet;
+        sheets =
+          Some [ ("original", canary_sheet); ("reordered", canary_reordered) ];
+        expect = Differs "gap resets the row gap the longhand set";
+      };
+    ]
+    @ List.map (fun (id, file) -> sheet id (read_file file)) files
+    @ generated
+  in
+  match !only with
+  | None -> all
+  | Some needle -> List.filter (fun i -> contains i.id needle) all
 
 (* ===== Variants ===== *)
 
@@ -158,7 +330,9 @@ let variants sheet =
   [
     ("original", Css.to_string sheet);
     ("optimize", minified);
-    ("lossless", Css.to_string ~minify:true (Css.optimize ~lossless:true sheet));
+    ( "lossless",
+      Css.to_string ~minify:true ~lossless:true
+        (Css.optimize ~lossless:true sheet) );
     ("reparsed", reparsed);
   ]
 
@@ -175,6 +349,29 @@ let canonically_equal prop a b =
     Cascade_diff.Css_compare.equal ~mode:`Canonical (wrap prop a) (wrap prop b)
   with Reader.Parse_error _ | Failure _ | Invalid_argument _ -> false
 
+(* [optimize] without [~lossless] approximates colours by design: it rounds a
+   channel and rewrites a colour into whichever space spells it shortest. Both
+   change what getComputedStyle reports for a colour-valued property, so under
+   the lossy variants such a difference is counted and reported rather than
+   failed. Everything else, and every difference at all under [lossless], is a
+   render change the optimizer must not make. *)
+let lossy variant = variant = "optimize" || variant = "reparsed"
+
+let colour_valued prop =
+  contains prop "color"
+  || List.mem prop
+       [
+         "fill";
+         "stroke";
+         "background-image";
+         "border-image-source";
+         "mask-image";
+         "box-shadow";
+         "text-shadow";
+         "filter";
+         "backdrop-filter";
+       ]
+
 (* ===== Driver protocol ===== *)
 
 type diff = {
@@ -188,6 +385,7 @@ type diff = {
 type result = {
   diffs : diff list;
   candidates : int;
+  approximations : int;
   matched : int;
   unmatched : int;
   rejected : int;
@@ -199,6 +397,7 @@ let empty_result =
   {
     diffs = [];
     candidates = 0;
+    approximations = 0;
     matched = 0;
     unmatched = 0;
     rejected = 0;
@@ -220,6 +419,8 @@ let parse_driver_output lines =
           let r = { r with candidates = r.candidates + 1 } in
           let r =
             if canonically_equal property reference observed then r
+            else if lossy variant && colour_valued property then
+              { r with approximations = r.approximations + 1 }
             else
               {
                 r with
@@ -276,23 +477,6 @@ let run_driver ~node ~chrome ~script ~jobs ~work =
       Error (String.concat "\n" text)
 
 (* ===== Artefacts ===== *)
-
-let rec mkdir_p dir =
-  if not (Sys.file_exists dir) then (
-    mkdir_p (Filename.dirname dir);
-    try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
-
-let write file contents =
-  let oc = open_out file in
-  output_string oc contents;
-  close_out oc
-
-let read_file file =
-  let ic = open_in_bin file in
-  let n = in_channel_length ic in
-  let s = really_input_string ic n in
-  close_in ic;
-  s
 
 (* A page that rebuilds the derived document with the builder the driver used,
    so opening the artefact in a browser reproduces the run. *)
@@ -413,6 +597,7 @@ let () =
   let skipped = Hashtbl.create 16 in
   let matched = ref 0 and unmatched = ref 0 and rejected = ref 0 in
   let candidates = ref 0 in
+  let approximations = ref 0 in
   let surviving = ref 0 in
   let canaries = ref 0 in
   let unmatched_shown = ref 0 in
@@ -421,7 +606,7 @@ let () =
       let id = input.id in
       match Hashtbl.find_opt doms id with
       | None -> ()
-      | Some dom ->
+      | Some dom -> (
           selectors := !selectors + Dom_of_css.selectors dom;
           synthesised := !synthesised + Dom_of_css.synthesised dom;
           elements := !elements + Dom_of_css.elements dom;
@@ -437,6 +622,7 @@ let () =
           unmatched := !unmatched + r.unmatched;
           rejected := !rejected + r.rejected;
           candidates := !candidates + r.candidates;
+          approximations := !approximations + r.approximations;
           List.iter
             (fun e -> prerr_endline ("render_diff: " ^ id ^ ": " ^ e))
             r.errors;
@@ -447,30 +633,39 @@ let () =
                 incr unmatched_shown;
                 Fmt.pr "  probe matched no element: %s (%s)@." s id))
             r.unmatched_examples;
-          if input.expect_diff then
-            if r.diffs = [] then (
-              incr failures;
-              Fmt.pr
-                "FAIL %s: the harness saw no difference between two sheets \
-                 that render differently@."
-                id)
-            else incr canaries
-          else if r.diffs <> [] then (
-            surviving := !surviving + List.length r.diffs;
-            incr failures;
-            let dir = root // id in
-            write_artefacts ~dir ~script_dir
-              ~dom:(Json.to_string (Dom_of_css.to_json dom))
-              ~sheets:(Hashtbl.find sheets id) ~diffs:r.diffs;
-            Fmt.pr "FAIL %s: %d computed-style difference(s)@." id
-              (List.length r.diffs);
-            List.iteri
-              (fun i d ->
-                if i < 6 then
-                  Fmt.pr "  [%s] %s %s: %S -> %S@." d.variant d.element
-                    d.property d.reference d.observed)
-              r.diffs;
-            Fmt.pr "  artefacts: %s@." dir))
+          match input.expect with
+          | Differs reason ->
+              if r.diffs = [] then (
+                incr failures;
+                Fmt.pr
+                  "FAIL %s: expected a difference (%s) and saw none; remove \
+                   the pin@."
+                  id reason)
+              else (
+                incr canaries;
+                let dir = root // id in
+                write_artefacts ~dir ~script_dir
+                  ~dom:(Json.to_string (Dom_of_css.to_json dom))
+                  ~sheets:(Hashtbl.find sheets id) ~diffs:r.diffs;
+                Fmt.pr "known %s: %s@." id reason;
+                Fmt.pr "  artefacts: %s@." dir)
+          | Same ->
+              if r.diffs <> [] then (
+                surviving := !surviving + List.length r.diffs;
+                incr failures;
+                let dir = root // id in
+                write_artefacts ~dir ~script_dir
+                  ~dom:(Json.to_string (Dom_of_css.to_json dom))
+                  ~sheets:(Hashtbl.find sheets id) ~diffs:r.diffs;
+                Fmt.pr "FAIL %s: %d computed-style difference(s)@." id
+                  (List.length r.diffs);
+                List.iteri
+                  (fun i d ->
+                    if i < 6 then
+                      Fmt.pr "  [%s] %s %s: %S -> %S@." d.variant d.element
+                        d.property d.reference d.observed)
+                  r.diffs;
+                Fmt.pr "  artefacts: %s@." dir)))
     inputs;
   Fmt.pr
     "render_diff: %d sheet(s), %d selector(s), %d synthesised, %d element(s), \
@@ -479,9 +674,9 @@ let () =
   Fmt.pr "  probes: %d matched, %d unmatched, %d rejected@." !matched !unmatched
     !rejected;
   Fmt.pr
-    "  computed-style candidates: %d, render differences: %d, canaries seen: \
-     %d@."
-    !candidates !surviving !canaries;
+    "  computed-style candidates: %d, lossy colour approximations: %d, render \
+     differences: %d, canaries seen: %d@."
+    !candidates !approximations !surviving !canaries;
   if !unparsed > 0 then Fmt.pr "  unparsed inputs: %d@." !unparsed;
   Hashtbl.fold (fun reason n acc -> (reason, n) :: acc) skipped []
   |> List.sort (fun (_, a) (_, b) -> compare b a)

--- a/test/render/run.sh
+++ b/test/render/run.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Differential render tests in a real headless browser: a stylesheet and its
+# optimized forms must compute the same style for every element of a document
+# derived from the stylesheet's own selectors.
+#
+# [dune test] runs the same harness on a small default sweep; this script runs
+# it from the repository root, so the artefacts of a failure land in tmp/
+# rather than inside _build, and passes its arguments through:
+#
+#   sh test/render/run.sh            # the default sweep
+#   sh test/render/run.sh --full     # every corpus file and more seeds
+#
+# It skips cleanly, with status 0, when node or a headless browser is missing,
+# and honours CASCADE_NO_BROWSER, CHROME and NODE.
+set -eu
+dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+root=$(CDPATH= cd "$dir/../.." && pwd)
+cd "$root"
+dune build test/render/render_diff.exe test/render/driver.js test/render/dom.js
+exec _build/default/test/render/render_diff.exe "$@"


### PR DESCRIPTION
For every corpus sheet and 32 seeded random sheets, render the original and its optimize / optimize ~lossless / minified-reparsed forms in headless Chromium against a document derived from the sheet's own selectors, and compare getComputedStyle for every element (93% of corpus selectors synthesised, coverage measured by querySelectorAll, the rest counted; a canary fails the run if the harness stops seeing differences). Skips cleanly without a browser. The first sweep found and pins three real divergences as expected failures that fire until fixed: --lossless reorders physical/logical longhand pairs (border-top-width renders 1px where the source computes 2px), --lossless rounds the alpha channel to 3 decimals, and the position-area top center -> top fold computes differently in Chromium. Stacked on #274.