### PR TITLE
shorthand: a logical property overlaps the physical sides it may alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,9 @@
   the rule rendered (#267, #270)
 - `--lossless` keeps a colour's alpha exact, like its other channels;
   `oklch(... / .74567)` printed `/.746` (#278)
+- `--lossless` keeps a flow-relative property in source order against a
+  physical one of the same family, since the writing mode decides which
+  physical side it resolves to (#277)
 - A selector list mixing a vendor pseudo-element with ordinary selectors is
   split, so a browser that ignores `::-webkit-search-cancel-button` keeps the
   other selectors' declarations (#203)

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -374,7 +374,8 @@ let scroll_padding_keys =
     key "scroll-padding-left";
   ]
 
-let property_footprint : type a. a Properties.property -> overlap_key list =
+(* The slots a property names, before flow-relative aliasing. *)
+let property_slots : type a. a Properties.property -> overlap_key list =
   function
   | All -> [ key "*" ]
   | Margin ->
@@ -718,12 +719,12 @@ let property_footprint : type a. a Properties.property -> overlap_key list =
   | Webkit_flex_flow -> [ key "flex-direction"; key "flex-wrap" ]
   | Webkit_flex_direction -> [ key "flex-direction" ]
   | Webkit_flex_wrap -> [ key "flex-wrap" ]
-  (* CSS Overflow 3 sec. 3.3. [overflow-block] / [overflow-inline] are the
-     flow-relative pair and keep their own slots, as the other logical families
-     do here. *)
+  (* CSS Overflow 3 sec. 3.3. *)
   | Overflow -> [ key "overflow-x"; key "overflow-y" ]
   | Overflow_x -> [ key "overflow-x" ]
   | Overflow_y -> [ key "overflow-y" ]
+  | Overflow_block -> [ key "overflow-block" ]
+  | Overflow_inline -> [ key "overflow-inline" ]
   (* CSS Multicol 1 sec. 3.3. *)
   | Columns -> [ key "column-width"; key "column-count" ]
   | Column_width -> [ key "column-width" ]
@@ -837,6 +838,88 @@ let property_footprint : type a. a Properties.property -> overlap_key list =
   | Custom_property name -> [ key ("--" ^ name) ]
   | Unknown_property name -> [ key name ]
   | property -> [ property_key property ]
+
+(* CSS Logical 1 sec. 2 and 4: a flow-relative longhand resolves to a physical
+   side that the writing mode and the text direction pick, so
+   [margin-inline-start] writes [margin-left] under one mode and [margin-right]
+   under another. A stylesheet does not carry the mode of the elements it will
+   match, so each logical family is paired here with the physical family it
+   resolves into, and every logical slot takes the whole physical set. The two
+   logical slots of one family then look like they share a slot, which the
+   perpendicular axes never do; that direction of the approximation costs only a
+   pair kept in source order, and it leaves the physical sides - the common case
+   - naming one slot each. *)
+let logical_alias_families =
+  Properties.
+    [
+      ([ Prop Margin_inline; Prop Margin_block ], Prop Margin);
+      ([ Prop Padding_inline; Prop Padding_block ], Prop Padding);
+      ([ Prop Inset_inline; Prop Inset_block ], Prop Inset);
+      ([ Prop Border_inline_width; Prop Border_block_width ], Prop Border_width);
+      ([ Prop Border_inline_style; Prop Border_block_style ], Prop Border_style);
+      ([ Prop Border_inline_color; Prop Border_block_color ], Prop Border_color);
+      ( [ Prop Scroll_margin_inline; Prop Scroll_margin_block ],
+        Prop Scroll_margin );
+      ( [ Prop Scroll_padding_inline; Prop Scroll_padding_block ],
+        Prop Scroll_padding );
+      ([ Prop Overflow_block; Prop Overflow_inline ], Prop Overflow);
+    ]
+
+(* Each logical slot paired with the physical slots it may alias, sorted for
+   binary search. One family shares a single physical list across its slots, so
+   [add_logical_aliases] can fold the repeats away by physical equality. *)
+let logical_alias_index =
+  let entries =
+    List.concat_map
+      (fun (logical, physical) ->
+        let physical_slots =
+          match physical with Properties.Prop p -> property_slots p
+        in
+        List.concat_map
+          (fun l ->
+            let slots = match l with Properties.Prop p -> property_slots p in
+            List.map (fun k -> (k, physical_slots)) slots)
+          logical)
+      logical_alias_families
+  in
+  let arr = Array.of_list entries in
+  Array.sort (fun (a, _) (b, _) -> compare a b) arr;
+  arr
+
+(* The physical slots [k] may alias, empty when [k] is not a flow-relative slot.
+   Spelled as a search over a sorted array rather than a hashtable lookup: this
+   runs once per footprint key, and an option per key would allocate in the
+   optimizer's hottest path. *)
+let logical_alias_slots k =
+  let lo = ref 0 and hi = ref (Array.length logical_alias_index - 1) in
+  let physical = ref [] in
+  let searching = ref true in
+  while !searching && !lo <= !hi do
+    let mid = (!lo + !hi) / 2 in
+    let v, slots = Array.unsafe_get logical_alias_index mid in
+    if overlap_key_equal v k then (
+      physical := slots;
+      searching := false)
+    else if v < k then lo := mid + 1
+    else hi := mid - 1
+  done;
+  !physical
+
+let add_logical_aliases slots =
+  let rec collect acc = function
+    | [] -> acc
+    | k :: rest -> (
+        match logical_alias_slots k with
+        | [] -> collect acc rest
+        | physical when List.memq physical acc -> collect acc rest
+        | physical -> collect (physical :: acc) rest)
+  in
+  match collect [] slots with
+  | [] -> slots
+  | groups -> List.concat (slots :: groups)
+
+let property_footprint : type a. a Properties.property -> overlap_key list =
+ fun property -> add_logical_aliases (property_slots property)
 
 (* Spelled as explicit recursion rather than [List.exists (overlap_key_equal
    footprint)]: the partial application and the closure over [b] each allocate
@@ -973,13 +1056,15 @@ let is_known_footprint_key k =
   !found
 
 (* Whether an [Unknown_property] name can be placed in the footprint model. A
-   name a typed footprint mentions writes exactly the slot it names: a typed
-   longhand is recovered under its own name when its value defeats the typed
-   reader ([margin-top:var(--a) var(--b)] parses that way), and it conflicts
-   with the same declarations the typed spelling would. Any other name may be a
-   shorthand, a legacy alias, or a longhand of a family the footprints do not
-   model - [background-position-x] writes part of [background], [grid-row-gap]
-   is [row-gap] - so it has to be treated as touching whatever it is compared
+   name a typed footprint mentions writes the slot it names and, for a
+   flow-relative name, the physical slots [add_logical_aliases] gives it: a
+   typed longhand is recovered under its own name when its value defeats the
+   typed reader ([margin-top:var(--a) var(--b)] parses that way), and it
+   conflicts with the same declarations the typed spelling would - the name
+   carries the same footprint either way. Any other name may be a shorthand, a
+   legacy alias, or a longhand of a family the footprints do not model -
+   [background-position-x] writes part of [background], [grid-row-gap] is
+   [row-gap] - so it has to be treated as touching whatever it is compared
    against. *)
 let unknown_name_is_placeable name = is_known_footprint_key (key name)
 

--- a/lib/shorthand.mli
+++ b/lib/shorthand.mli
@@ -17,7 +17,10 @@ val declarations_overlap :
 (** [declarations_overlap a b] is [true] when [a] and [b] may write at least one
     common cascade slot after shorthand expansion. Unlike
     {!val-declaration_covers}, this relation is symmetric: [border-top] and
-    [border-color] overlap because both write [border-top-color]. *)
+    [border-color] overlap because both write [border-top-color]. A
+    flow-relative property overlaps every physical property of its family, since
+    the writing mode of the elements the stylesheet will match decides which
+    physical side it resolves to. *)
 
 type overlap_key
 (** Precomputed declaration-overlap key used by the rule graph. *)

--- a/test/render/render_diff.ml
+++ b/test/render/render_diff.ml
@@ -164,14 +164,6 @@ type input = {
    and stays green on everything else. *)
 let known =
   [
-    ( "corpus-duplicates-0015",
-      "--lossless sorts border-top before border-block, which overwrites it" );
-    ( "corpus-duplicates-0016",
-      "--lossless sorts margin-left before margin-inline-start, which \
-       overwrites it" );
-    ( "corpus-duplicates-0017",
-      "--lossless sorts padding-top before padding-block-start, which \
-       overwrites it" );
     ( "corpus-anchor-0002",
       "position-area: top center folds to top, which Chromium computes as a \
        different area" );

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1021,6 +1021,67 @@ let test_lossless_keeps_shorthand_longhand_order () =
       Alcotest.(check string) name expected (opt input))
     shorthand_longhand_order_cases
 
+(* CSS Logical 1 sec. 2: a flow-relative longhand resolves to a physical side
+   the writing mode picks, so a sheet on its own cannot say whether
+   [margin-inline-start] and [margin-left] name one slot or two. The canonical
+   order therefore has to keep such a pair in source order, in both directions.
+   The first three cases are corpus tests duplicates/0015-0017, each of which a
+   browser renders differently once the pair is swapped. *)
+let logical_physical_order_cases =
+  [
+    ( "border-top before border-block",
+      ".a{border-top:1px solid red;border-block:2px solid red}",
+      ".a{border-top:1px solid red;border-block:2px solid red}" );
+    ( "border-block before border-top",
+      ".a{border-block:2px solid red;border-top:1px solid red}",
+      ".a{border-block:2px solid red;border-top:1px solid red}" );
+    ( "margin-left before margin-inline-start",
+      ".a{margin-left:10px;margin-inline-start:20px}",
+      ".a{margin-left:10px;margin-inline-start:20px}" );
+    ( "margin-inline-start before margin-left",
+      ".a{margin-inline-start:20px;margin-left:10px}",
+      ".a{margin-inline-start:20px;margin-left:10px}" );
+    ( "padding-top before padding-block-start",
+      ".a{padding-top:10px;padding-block-start:20px}",
+      ".a{padding-top:10px;padding-block-start:20px}" );
+    ( "padding-block-start before padding-top",
+      ".a{padding-block-start:20px;padding-top:10px}",
+      ".a{padding-block-start:20px;padding-top:10px}" );
+    (* The inline axis is the horizontal one in [horizontal-tb] and the vertical
+       one in a vertical mode, so a logical border width aliases whichever
+       physical side the mode gives it. *)
+    ( "border-left-width before border-inline-width",
+      ".a{border-left-width:1px;border-inline-width:2px}",
+      ".a{border-left-width:1px;border-inline-width:2px}" );
+    ( "border-inline-width before border-left-width",
+      ".a{border-inline-width:2px;border-left-width:1px}",
+      ".a{border-inline-width:2px;border-left-width:1px}" );
+    (* A logical side also aliases into the physical shorthand that covers every
+       side. *)
+    ( "border before border-block",
+      ".a{border:1px solid red;border-block:2px solid red}",
+      ".a{border:1px solid red;border-block:2px solid red}" );
+    ( "top before inset-inline-start",
+      ".a{top:1px;inset-inline-start:5px}",
+      ".a{top:1px;inset-inline-start:5px}" );
+    ( "scroll-margin-top before scroll-margin-block-start",
+      ".a{scroll-margin-top:1px;scroll-margin-block-start:2px}",
+      ".a{scroll-margin-top:1px;scroll-margin-block-start:2px}" );
+  ]
+
+let test_lossless_keeps_logical_physical_order () =
+  let opt css =
+    match Css.of_string ~strict:false css with
+    | Ok p ->
+        Css.to_string ~minify:true (Css.optimize ~lossless:true p.stylesheet)
+        |> String.trim
+    | Error _ -> Alcotest.fail "parse"
+  in
+  List.iter
+    (fun (name, input, expected) ->
+      Alcotest.(check string) name expected (opt input))
+    logical_physical_order_cases
+
 (* Regrouping - factoring a shared declaration into a selector list, and
    synthesising nesting from a run of adjacent rules - depends on how the input
    happened to order its rules: a rule sitting between two others decides
@@ -1110,6 +1171,9 @@ let optimize_tests =
     ( "lossless keeps shorthand longhand order",
       `Quick,
       test_lossless_keeps_shorthand_longhand_order );
+    ( "lossless keeps logical physical order",
+      `Quick,
+      test_lossless_keeps_logical_physical_order );
     ( "var() colour functions preserved",
       `Quick,
       test_var_color_functions_preserved );

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -133,6 +133,90 @@ let test_shorthand_reset_boundaries () =
     (Shorthand.declarations_overlap (decl "grid-row-gap:9px")
        (decl "grid-row:1/2"))
 
+let test_logical_physical_overlap () =
+  (* CSS Logical 1 sec. 2: a flow-relative longhand resolves to a physical side
+     the writing mode picks, so [margin-inline-start] is [margin-left] in one
+     mode and [margin-right] in another. A sheet does not say which, so the pair
+     may write a common slot and their order has to stand. *)
+  Alcotest.(check bool)
+    "an inline-start margin overlaps the left margin" true
+    (Shorthand.declarations_overlap
+       (decl "margin-inline-start:20px")
+       (decl "margin-left:10px"));
+  Alcotest.(check bool)
+    "the relation is symmetric" true
+    (Shorthand.declarations_overlap (decl "margin-left:10px")
+       (decl "margin-inline-start:20px"));
+  Alcotest.(check bool)
+    "the same longhand overlaps the right margin too" true
+    (Shorthand.declarations_overlap
+       (decl "margin-inline-start:20px")
+       (decl "margin-right:10px"));
+  Alcotest.(check bool)
+    "a logical longhand overlaps the physical shorthand" true
+    (Shorthand.declarations_overlap (decl "margin:0")
+       (decl "margin-inline-start:20px"));
+  Alcotest.(check bool)
+    "a block-start padding overlaps the top padding" true
+    (Shorthand.declarations_overlap
+       (decl "padding-block-start:20px")
+       (decl "padding-top:10px"));
+  Alcotest.(check bool)
+    "an inline-start inset overlaps the top offset" true
+    (Shorthand.declarations_overlap
+       (decl "inset-inline-start:5px")
+       (decl "top:1px"));
+  Alcotest.(check bool)
+    "a logical border side overlaps a physical one" true
+    (Shorthand.declarations_overlap
+       (decl "border-block:2px solid red")
+       (decl "border-top:1px solid red"));
+  Alcotest.(check bool)
+    "a logical border side overlaps the border shorthand" true
+    (Shorthand.declarations_overlap
+       (decl "border-block:2px solid red")
+       (decl "border:1px solid red"));
+  Alcotest.(check bool)
+    "a logical border width overlaps a physical border width" true
+    (Shorthand.declarations_overlap
+       (decl "border-inline-width:2px")
+       (decl "border-left-width:1px"));
+  Alcotest.(check bool)
+    "a logical scroll margin overlaps a physical one" true
+    (Shorthand.declarations_overlap
+       (decl "scroll-margin-block-start:2px")
+       (decl "scroll-margin-top:1px"));
+  (* A recovered longhand keeps the aliasing: its value defeated the typed
+     reader, not the cascade slot it writes. *)
+  Alcotest.(check bool)
+    "a recovered logical longhand overlaps its physical side" true
+    (Shorthand.declarations_overlap
+       (decl "margin-inline-start:var(--a) var(--b)")
+       (decl "margin-left:10px"));
+  (* The block and inline axes are perpendicular in every writing mode, so two
+     logical longhands of one family never resolve to a common side. *)
+  Alcotest.(check bool)
+    "two perpendicular logical longhands are disjoint" false
+    (Shorthand.declarations_overlap
+       (decl "margin-inline-start:20px")
+       (decl "margin-block-start:10px"));
+  (* Two physical sides are two slots whatever the writing mode. *)
+  Alcotest.(check bool)
+    "two physical sides stay disjoint" false
+    (Shorthand.declarations_overlap (decl "margin-top:1px")
+       (decl "margin-bottom:2px"));
+  (* Aliasing is within a family: a margin never resolves to a padding. *)
+  Alcotest.(check bool)
+    "a logical margin and a physical padding are disjoint" false
+    (Shorthand.declarations_overlap
+       (decl "margin-inline-start:20px")
+       (decl "padding-left:10px"));
+  Alcotest.(check bool)
+    "a logical border width and a border colour are disjoint" false
+    (Shorthand.declarations_overlap
+       (decl "border-inline-width:2px")
+       (decl "border-left-color:red"))
+
 let test_intentionally_duplicated_properties () =
   Alcotest.(check bool)
     "content duplicates are preserved" true
@@ -334,6 +418,8 @@ let suite =
       Alcotest.test_case "vendor alias overlap" `Quick test_vendor_alias_overlap;
       Alcotest.test_case "shorthand reset boundaries" `Quick
         test_shorthand_reset_boundaries;
+      Alcotest.test_case "logical physical overlap" `Quick
+        test_logical_physical_overlap;
       Alcotest.test_case "intentionally duplicated properties" `Quick
         test_intentionally_duplicated_properties;
       Alcotest.test_case "merge overflow longhands" `Quick

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -194,9 +194,12 @@ let test_logical_physical_overlap () =
        (decl "margin-inline-start:var(--a) var(--b)")
        (decl "margin-left:10px"));
   (* The block and inline axes are perpendicular in every writing mode, so two
-     logical longhands of one family never resolve to a common side. *)
+     logical longhands of one family never resolve to a common side. The model
+     says they may: it gives each logical slot the family's whole physical set,
+     which is the price of leaving the physical sides one slot each. Overlap is
+     the safe answer either way - it keeps the pair in source order. *)
   Alcotest.(check bool)
-    "two perpendicular logical longhands are disjoint" false
+    "two perpendicular logical longhands are conservatively overlapping" true
     (Shorthand.declarations_overlap
        (decl "margin-inline-start:20px")
        (decl "margin-block-start:10px"));


### PR DESCRIPTION
Per CSS Logical 1 a flow-relative longhand resolves to a physical side, so --lossless sorting margin-inline-start past margin-left changes what renders (border-top-width computed 1px where the source says 2px). Every logical slot in a footprint now pulls in its family's physical set - asymmetric, so the common physical-vs-physical case keeps one key each; writing mode is not modelled, conservative overlap just keeps source order. Retires the three remaining render-differential pins (probe-verified: re-adding them fails the suite). Stacked on #276.