### PR TITLE
values: keep alpha exact under --lossless

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,8 @@
 - `--lossless` keeps a longhand in source order against the shorthand that
   resets it, whether the property is typed or not; moving the pair changed what
   the rule rendered (#267, #270)
+- `--lossless` keeps a colour's alpha exact, like its other channels;
+  `oklch(... / .74567)` printed `/.746` (#278)
 - A selector list mixing a vendor pseudo-element with ordinary selectors is
   split, so a browser that ignores `::-webkit-search-cancel-button` keeps the
   other selectors' declarations (#203)

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3604,8 +3604,12 @@ let rec pp_alpha : alpha Pp.t =
   | Num f ->
       (* CSSOM serialisation (CSS Values 4 sec. 6.7.2) drops a leading zero on
          fractional numbers: emit [.25] not [0.25] in both modes. Under minify,
-         round to 3 decimals (alpha precision is 1/255 ~ 0.004 in sRGB). *)
-      let max_decimals = if Pp.minified ctx then 3 else 8 in
+         round to 3 decimals (alpha precision is 1/255 ~ 0.004 in sRGB); alpha
+         is a colour channel, so [lossless] opts out of that fold like the other
+         channels. *)
+      let max_decimals =
+        if Pp.minified ctx && not ctx.Pp.lossless then 3 else 8
+      in
       Pp.string ctx (Pp.string_of_float ~drop_leading_zero:true ~max_decimals f)
   | Pct f ->
       Pp.float ctx f;

--- a/test/render/render_diff.ml
+++ b/test/render/render_diff.ml
@@ -172,10 +172,6 @@ let known =
     ( "corpus-duplicates-0017",
       "--lossless sorts padding-top before padding-block-start, which \
        overwrites it" );
-    ("corpus-colors-0046", "--lossless rounds the alpha channel to 3 decimals");
-    ("corpus-colors-0047", "--lossless rounds the alpha channel to 3 decimals");
-    ("corpus-colors-0048", "--lossless rounds the alpha channel to 3 decimals");
-    ("corpus-colors-0049", "--lossless rounds the alpha channel to 3 decimals");
     ( "corpus-anchor-0002",
       "position-area: top center folds to top, which Chromium computes as a \
        different area" );

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -418,6 +418,35 @@ let lossless_color () =
   check_value_cursor "color" read_color pp_color ~minify:false
     ~expected:"oklch(55.2% .016 285.938)" "oklch(55.2% 0.016 285.938)"
 
+(* Alpha is a colour channel like any other, so --lossless suppresses its
+   rounding too: every colour function keeps the authored 0.74567. *)
+let lossless_alpha () =
+  decl_lossless ~prop:"color" ~into:"rgb(10 20 30/.74567)"
+    "rgb(10 20 30 / 0.74567)";
+  decl_lossless ~prop:"color" ~into:"hsl(200 50% 40%/.74567)"
+    "hsl(200 50% 40% / 0.74567)";
+  decl_lossless ~prop:"color" ~into:"hwb(200 20% 30%/.74567)"
+    "hwb(200 20% 30% / 0.74567)";
+  decl_lossless ~prop:"color" ~into:"oklch(.55432 .12276 180.4567/.74567)"
+    "oklch(0.55432 0.12276 180.4567 / 0.74567)";
+  decl_lossless ~prop:"color" ~into:"lch(54.321 100.456 274.456/.74567)"
+    "lch(54.321 100.456 274.456 / 0.74567)";
+  decl_lossless ~prop:"color" ~into:"oklab(.65432-.23456 .18901/.74567)"
+    "oklab(0.65432 -0.23456 0.18901 / 0.74567)";
+  decl_lossless ~prop:"color" ~into:"lab(54.321-60.456 70.789/.74567)"
+    "lab(54.321 -60.456 70.789 / 0.74567)";
+  decl_lossless ~prop:"color"
+    ~into:"color(display-p3 .97654 .12345 .01789/.74567)"
+    "color(display-p3 0.97654 0.12345 0.01789 / 0.74567)";
+  (* Control: plain minify keeps the 3-decimal alpha fold. It is a deliberate
+     minification - sRGB alpha resolves to 1/255 ~ 0.004 - and only --lossless
+     opts out of it. *)
+  decl_optimizes ~prop:"color" ~into:"#0a141ebe" "rgb(10 20 30 / 0.74567)";
+  decl_optimizes ~prop:"color" ~into:"oklch(.554 .123 180.457/.746)"
+    "oklch(0.55432 0.12276 180.4567 / 0.74567)";
+  decl_optimizes ~prop:"color" ~into:"color(display-p3 .977 .123 .018/.746)"
+    "color(display-p3 0.97654 0.12345 0.01789 / 0.74567)"
+
 let test_angle () =
   (* pp holds the authored angle unit verbatim: the unit is part of the value
      node and cross-unit conversion is lossy (1rad has no exact degree
@@ -1246,6 +1275,7 @@ let value_tests =
     test_case "length" `Quick test_length;
     test_case "color" `Quick test_color;
     test_case "lossless color" `Quick lossless_color;
+    test_case "lossless alpha" `Quick lossless_alpha;
     test_case "angle" `Quick test_angle;
     test_case "duration" `Quick test_duration;
     test_case "percentage" `Quick test_percentage;


### PR DESCRIPTION
Reopens #276, which GitHub closed instead of retargeting when its merged base branch was deleted. pp_alpha folded the alpha channel to 3 decimals whenever output was minified, with no lossless check, so optimize ~lossless:true printed oklch(.../.74567) as /.746 while keeping every other channel exact. Guard the fold like the sibling pp_float_drop_zero already does; the bug was per-colour-function (rgb/hsl/hwb/oklch/lch/color() wrong, lab/oklab already correct) and the tests now cover all eight. Non-lossless minified output is byte-identical across the whole corpus. Retires four render-differential pins.