### PR TITLE
apply: weigh cascade layers when resolving

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,9 @@
   stylesheet inlines like its unlayered form (#187, #189)
 - `cascade apply` projects rules inside `@layer` onto elements; a fully layered
   stylesheet, such as Tailwind v4 output, inlined nothing (#188)
+- `cascade apply` weighs cascade layers instead of ignoring them: an unlayered
+  declaration beats a layered one, `!important` reverses that, and a rule with
+  no inline form stays inside its layer (#283)
 - `Css.vars_of_declarations` reports the `var()` references of 39 properties it
   answered with none, so `Css.resolve_theme` emits the theme binding for
   `inline-size: var(--w)` as it does for `width: var(--w)` (#266)

--- a/fuzz/fuzz_apply.ml
+++ b/fuzz/fuzz_apply.ml
@@ -30,17 +30,19 @@ let inline_style ds =
   Stylesheet.inline_style_of_declarations ~minify:true ~mode:Variables ds
 
 (* Compare two projections structurally: the inline style written onto each node
-   in tree order, plus the kept <style> body and its rule count. *)
+   in tree order, plus the number of rules kept in the <style>. The kept body
+   itself is left out because a kept rule stays inside its layer, so its text
+   differs by the wrapper. *)
 let summary (r : node Apply.result) =
-  (List.map (fun (_, ds) -> inline_style ds) r.styles, r.keep_css, r.kept)
+  (List.map (fun (_, ds) -> inline_style ds) r.styles, r.kept)
 
 let layer name body = String.concat "" [ "@layer "; name; "{"; body; "}" ]
 
 (* A @layer block applies unconditionally, so wrapping author rules in one (or
-   several) layers must not change what [Apply.compute] projects onto the tree
-   or keeps in the <style>: the projection is identical to the unlayered rules.
-   Each class carries a single declaration so no two rules compete, keeping the
-   comparison free of cascade-winner ambiguity between layers. *)
+   several) layers must not change what [Apply.compute] projects onto the tree,
+   nor how many rules it keeps in the <style>. Each class carries a single
+   declaration so no two rules compete, which is what makes the wrapping
+   invisible: layers only decide between competing declarations. *)
 let test_layer_wrapping_invariant buf =
   let k = 1 + (byte_at buf 0 mod 4) in
   let classes =

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -110,15 +110,64 @@ let rec props_of_stmts acc stmts =
 
 (* A [@layer] block applies unconditionally: it only orders competing
    declarations, it does not gate them behind a condition the way
-   @media/@supports/@container do. So its rules can be projected onto elements
-   just like top-level rules - splice their contents in place (recursing into
-   nested layers) instead of keeping the whole block in the un-inlinable
-   <style>. *)
-let rec unwrap_layers stmts =
-  List.concat_map
-    (function
-      | Stylesheet.Layer (_, body) -> unwrap_layers body | other -> [ other ])
-    stmts
+   @media/@supports/@container do. So the properties its rules can override are
+   those of its own un-inlinable rules, exactly as at the top level, while a
+   conditional block contributes all of them. *)
+let rec dynamic_props acc stmts =
+  List.fold_left
+    (fun acc s ->
+      match s with
+      | Stylesheet.Rule r when inlinable (Stylesheet.selector r) -> acc
+      | Stylesheet.Layer (_, b) -> dynamic_props acc b
+      | s -> props_of_stmts acc [ s ])
+    acc stmts
+
+(* Split each statement into the part with no inline form and the part that
+   projects onto elements. A [@layer] block splits like the top level, but the
+   wrapper survives on both sides: the layer decides which of two competing
+   declarations wins, so dropping it would change the result. A layer left with
+   nothing on one side disappears from that side - it has no rule there to
+   order, and removing it does not disturb the relative order of the others. *)
+let rec split ~is_dyn stmts =
+  let keep, inline =
+    List.fold_left
+      (fun (keep, inline) stmt ->
+        match stmt with
+        | Stylesheet.Layer (name, body) ->
+            let k, i = split ~is_dyn body in
+            ( (if k = [] then keep else Stylesheet.Layer (name, k) :: keep),
+              if i = [] then inline else Stylesheet.Layer (name, i) :: inline )
+        | Stylesheet.Layer_decl _ ->
+            (* The statement orders layers on both sides. *)
+            (stmt :: keep, stmt :: inline)
+        | Stylesheet.Rule r when inlinable (Stylesheet.selector r) ->
+            let sel = Stylesheet.selector r
+            and ds = Stylesheet.declarations r in
+            let of_part ds =
+              Stylesheet.Rule (Stylesheet.rule ~selector:sel ds)
+            in
+            let keep =
+              match List.filter is_dyn ds with
+              | [] -> keep
+              | res -> of_part res :: keep
+            in
+            let inline =
+              match List.filter (fun d -> not (is_dyn d)) ds with
+              | [] -> inline
+              | inl -> of_part inl :: inline
+            in
+            (keep, inline)
+        | other -> (other :: keep, inline))
+      ([], []) stmts
+  in
+  (List.rev keep, List.rev inline)
+
+(* Kept rules, for reporting: a [@layer] wrapper is not itself a rule. *)
+let rec count_kept stmts =
+  List.fold_left
+    (fun n -> function
+      | Stylesheet.Layer (_, b) -> n + count_kept b | _ -> n + 1)
+    0 stmts
 
 type 'node assignment = 'node * Declaration.declaration list
 (** The inline-style declarations to write onto a node. *)
@@ -191,54 +240,25 @@ module Make (Node : Resolve.NODE) = struct
     match Css.of_string css with
     | Error _ -> { styles = []; keep_css = ""; kept = 0 }
     | Ok p ->
-        (* Flatten nesting up front, so the static/dynamic split and
-           {!R.resolve} see the same flat rules, then unwrap [@layer] so its
-           rules join the split instead of being kept wholesale. *)
-        let stmts = unwrap_layers (Flatten.block p.Css.stylesheet) in
+        (* Flatten nesting up front, so the split and {!R.resolve} see the same
+           flat rules. *)
+        let stmts = Flatten.block p.Css.stylesheet in
         (* Properties a kept rule can override must stay in the cascade. *)
-        let dyn =
-          props_of_stmts SSet.empty
-            (List.filter
-               (function
-                 | Stylesheet.Rule r -> not (inlinable (Stylesheet.selector r))
-                 | _ -> true)
-               stmts)
-        in
+        let dyn = dynamic_props SSet.empty stmts in
         let is_dyn d =
           SSet.mem (String.lowercase_ascii (Declaration.property_name d)) dyn
         in
-        let inline_rules = ref [] in
-        let keep =
-          List.filter_map
-            (fun stmt ->
-              match stmt with
-              | Stylesheet.Rule r when inlinable (Stylesheet.selector r) -> (
-                  let sel = Stylesheet.selector r
-                  and ds = Stylesheet.declarations r in
-                  (match List.filter (fun d -> not (is_dyn d)) ds with
-                  | [] -> ()
-                  | inl ->
-                      inline_rules :=
-                        Stylesheet.Rule (Stylesheet.rule ~selector:sel inl)
-                        :: !inline_rules);
-                  match List.filter is_dyn ds with
-                  | [] -> None
-                  | res ->
-                      Some (Stylesheet.Rule (Stylesheet.rule ~selector:sel res))
-                  )
-              | other -> Some other)
-            stmts
-        in
+        let keep, inline = split ~is_dyn stmts in
         let keep_css =
           if keep = [] then ""
           else Css.to_string ~minify:true (Stylesheet.v keep)
         in
-        let inline_sheet = Stylesheet.v (List.rev !inline_rules) in
+        let inline_sheet = Stylesheet.v inline in
         let styles =
           List.fold_left
             (fun acc root -> walk ~minimal inline_sheet [] root acc)
             [] roots
           |> List.rev
         in
-        { styles; keep_css; kept = List.length keep }
+        { styles; keep_css; kept = count_kept keep }
 end

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -36,6 +36,83 @@ let attr_key : Selector.attr_name -> string = function
   | Selector.Data s -> "data-" ^ s
   | Selector.Aria a -> Aria.to_string a
 
+(* Cascade layers. Layer names form a tree: [@layer a.b] names the sublayer [b]
+   of [a], and so does [@layer a { @layer b { ... } }]. The cascade only needs
+   the flattened pre-order of that tree, so a layer is keyed by its dotted path
+   and the order is a list of paths, oldest first (css-cascade-5 sec. 6.4.2). *)
+
+let parent_layer name =
+  match String.rindex_opt name '.' with
+  | None -> None
+  | Some i -> Some (String.sub name 0 i)
+
+(* Each unnamed [@layer { }] block is a layer of its own, distinct from every
+   other one, so key it by a counter behind a prefix no author can write: NUL
+   never survives tokenisation, css-syntax-3 sec. 3.3 turns it into U+FFFD. *)
+let anonymous_layer n = "\000" ^ string_of_int n
+
+let qualify parent name =
+  match parent with None -> name | Some p -> p ^ "." ^ name
+
+(* A sublayer is ordered inside its parent, not at the end of the sheet: in
+   [@layer a.b {} @layer c {} @layer a.d {}] the layer [a.d] joins [a]'s subtree
+   and so still precedes [c]. *)
+let insert_layer order name =
+  if List.mem name order then order
+  else
+    match parent_layer name with
+    | None -> order @ [ name ]
+    | Some p ->
+        let inside n = n = p || starts n (p ^ ".") in
+        (* [p]'s subtree is contiguous, so the insertion point is just past its
+           last member; [entered] says the scan has reached it. *)
+        let rec insert entered = function
+          | x :: rest when inside x -> x :: insert true rest
+          | rest when entered -> name :: rest
+          | [] -> [ name ]
+          | x :: rest -> x :: insert entered rest
+        in
+        insert false order
+
+(* Naming a sublayer creates its ancestors first, so [@layer a.b] declares [a]
+   then [a.b]. *)
+let declare_layer order name =
+  let rec path n acc =
+    match parent_layer n with None -> n :: acc | Some p -> path p (n :: acc)
+  in
+  List.fold_left insert_layer order (path name [])
+
+(* [layered_rules stmts] is the sheet's layer order together with every rule
+   paired with the layer it sits in ([None] for the unlayered ones), both in
+   source order. An [@layer a, b;] statement declares its names without
+   contributing a rule. *)
+let layered_rules stmts =
+  let anon = ref 0 in
+  let rec go parent acc stmts =
+    List.fold_left
+      (fun (order, rules) stmt ->
+        match stmt with
+        | Stylesheet.Rule r -> (order, (parent, r) :: rules)
+        | Stylesheet.Layer_decl names ->
+            ( List.fold_left
+                (fun order name -> declare_layer order (qualify parent name))
+                order names,
+              rules )
+        | Stylesheet.Layer (name, body) ->
+            let name =
+              match name with
+              | Some n -> qualify parent n
+              | None ->
+                  incr anon;
+                  qualify parent (anonymous_layer !anon)
+            in
+            go (Some name) (declare_layer order name, rules) body
+        | _ -> (order, rules))
+      acc stmts
+  in
+  let order, rules = go None ([], []) stmts in
+  (order, List.rev rules)
+
 module Make (N : NODE) = struct
   let preceding_siblings n =
     match N.parent n with
@@ -149,23 +226,41 @@ module Make (N : NODE) = struct
       let k = Declaration.property_name d in
       (k, d) :: List.remove_assoc k acc
     in
+    let layer_order, rules = layered_rules (Flatten.block sheet) in
     let matched =
-      Flatten.block sheet
-      |> List.filter_map (function Stylesheet.Rule r -> Some r | _ -> None)
-      |> List.mapi (fun i r ->
+      rules
+      |> List.mapi (fun i (layer, r) ->
           let sel = Stylesheet.selector r in
           if matches sel node then
-            Some (matched_specificity sel node, i, Stylesheet.declarations r)
+            Some
+              (layer, matched_specificity sel node, i, Stylesheet.declarations r)
           else None)
       |> List.filter_map Fun.id
-      |> List.stable_sort (fun (s1, i1, _) (s2, i2, _) ->
-          match compare s1 s2 with 0 -> compare i1 i2 | c -> c)
     in
-    let decls = List.concat_map (fun (_, _, ds) -> ds) matched in
-    let normal =
-      List.filter (fun d -> not (Declaration.is_important d)) decls
+    (* The cascade sorting order (css-cascade-5 sec. 6) weighs the layer above
+       specificity and above source order, and its direction depends on
+       importance: among normal declarations the last layer wins and the
+       unlayered ones beat them all, among important ones that reverses. So rank
+       each importance bucket on its own. *)
+    let bucket ~important =
+      matched
+      |> List.filter_map (fun (layer, spec, i, ds) ->
+          match
+            List.filter (fun d -> Declaration.is_important d = important) ds
+          with
+          | [] -> None
+          | ds ->
+              Some
+                ( Stylesheet.cascade_layer_precedence_rank ~layer_order
+                    ~important layer,
+                  spec,
+                  i,
+                  ds ))
+      |> List.stable_sort (fun (l1, s1, i1, _) (l2, s2, i2, _) ->
+          compare (l1, s1, i1) (l2, s2, i2))
+      |> List.concat_map (fun (_, _, _, ds) -> ds)
     in
-    let important = List.filter Declaration.is_important decls in
     (* normal first, then !important, last wins per property *)
-    List.fold_left upsert [] (normal @ important) |> List.rev_map snd
+    List.fold_left upsert [] (bucket ~important:false @ bucket ~important:true)
+    |> List.rev_map snd
 end

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -39,6 +39,10 @@ module Make (N : NODE) : sig
   val resolve : Stylesheet.t -> N.t -> Declaration.declaration list
   (** [resolve sheet node] is the declarations that win for [node] after
       flattening nesting and applying the cascade: selector matching,
-      specificity, source order, then [!important] over normal. Conditional and
-      at-rule groups ([@media], [@layer], ...) are not considered. *)
+      [!important] over normal, then cascade layer, specificity and source
+      order. [@layer] blocks and [@layer a, b;] statements order the layers by
+      first appearance, sublayers included; among normal declarations the last
+      layer wins and an unlayered declaration beats them all, and for
+      [!important] declarations that order reverses. Conditional groups
+      ([@media], [@supports], [@container]) are not considered. *)
 end

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -67,7 +67,8 @@ let projects_layered_rule_to_inline_style () =
   | _ -> Alcotest.fail "expected one inline assignment"
 
 (* Inside a layer the static/dynamic split still holds: the plain rule inlines,
-   the stateful one stays in the kept <style>. *)
+   the stateful one stays in the kept <style>, and it stays in its layer because
+   that is what orders it against the other kept rules. *)
 let keeps_stateful_rule_inside_layer_in_css () =
   let n = node ~classes:[ "card" ] "div" in
   let result =
@@ -79,7 +80,7 @@ let keeps_stateful_rule_inside_layer_in_css () =
     | [ (_, decls) ] -> inline_style decls
     | _ -> Alcotest.fail "expected one inline assignment");
   Alcotest.(check string)
-    "kept dynamic rule" ".card:hover{color:blue}" result.keep_css;
+    "kept dynamic rule" "@layer u{.card:hover{color:blue}}" result.keep_css;
   Alcotest.(check int) "kept count" 1 result.kept
 
 (* The inline style [css] projects onto a single [p.x], as a minified

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -82,6 +82,73 @@ let keeps_stateful_rule_inside_layer_in_css () =
     "kept dynamic rule" ".card:hover{color:blue}" result.keep_css;
   Alcotest.(check int) "kept count" 1 result.kept
 
+(* The inline style [css] projects onto a single [p.x], as a minified
+   declaration list. *)
+let projected css =
+  let n = node ~classes:[ "x" ] "p" in
+  let result = A.compute ~css [ n ] in
+  match result.styles with
+  | [ (_, decls) ] -> inline_style decls
+  | _ -> Alcotest.fail "expected one inline assignment"
+
+(* css-cascade-5 sec. 6.4.4: among normal declarations an unlayered one beats
+   every layer, whatever the source order. *)
+let unlayered_beats_layer () =
+  Alcotest.(check string)
+    "unlayered beats the layer" "color:red"
+    (projected ".x{color:red}@layer u{.x{color:blue}}");
+  Alcotest.(check string)
+    "and still beats it when the layer comes last" "color:red"
+    (projected "@layer u{.x{color:blue}}.x{color:red}")
+
+(* The criterion reverses for important declarations: a layered important beats
+   an unlayered one, again whatever the source order. *)
+let layer_beats_unlayered_important () =
+  Alcotest.(check string)
+    "layered important wins" "color:blue!important"
+    (projected ".x{color:red!important}@layer u{.x{color:blue!important}}");
+  Alcotest.(check string)
+    "and still wins when it comes first" "color:blue!important"
+    (projected "@layer u{.x{color:blue!important}}.x{color:red!important}")
+
+(* Between two layers the last declared wins for normal declarations and the
+   first for important ones. *)
+let later_layer_wins_normal_earlier_wins_important () =
+  Alcotest.(check string)
+    "later layer wins" "color:blue"
+    (projected "@layer a{.x{color:red}}@layer b{.x{color:blue}}");
+  Alcotest.(check string)
+    "earlier layer wins for important" "color:red!important"
+    (projected
+       "@layer a{.x{color:red!important}}@layer b{.x{color:blue!important}}")
+
+(* An [@layer b, a;] statement fixes the order before any block appears, so the
+   blocks that follow do not order themselves. *)
+let layer_statement_orders_the_blocks () =
+  Alcotest.(check string)
+    "the statement decides which layer is last" "color:red"
+    (projected "@layer b,a;@layer a{.x{color:red}}@layer b{.x{color:blue}}");
+  Alcotest.(check string)
+    "and the important order follows it" "color:blue!important"
+    (projected
+       "@layer b,a;@layer a{.x{color:red!important}}@layer \
+        b{.x{color:blue!important}}")
+
+(* Layers outrank specificity in the cascade sorting order (css-cascade-5 sec.
+   6), so the plain class in the later layer beats the compound selector in the
+   earlier one. *)
+let layer_outranks_specificity () =
+  Alcotest.(check string)
+    "later layer beats higher specificity" "color:blue"
+    (projected "@layer a{p.x{color:red}}@layer b{.x{color:blue}}")
+
+(* A control: layers that set different properties do not compete, so both
+   declarations project as they did before. *)
+let non_competing_layers_both_project () =
+  Alcotest.(check string)
+    "both layers contribute" "color:red;margin:0"
+    (projected "@layer a{.x{color:red}}@layer b{.x{margin:0}}")
+
 let invalid_css_is_empty () =
   let result = A.compute ~css:"a{" [ node "div" ] in
   Alcotest.(check string)
@@ -103,5 +170,16 @@ let suite =
         projects_layered_rule_to_inline_style;
       Alcotest.test_case "keeps stateful rule inside layer in css" `Quick
         keeps_stateful_rule_inside_layer_in_css;
+      Alcotest.test_case "unlayered beats layer" `Quick unlayered_beats_layer;
+      Alcotest.test_case "layer beats unlayered for important" `Quick
+        layer_beats_unlayered_important;
+      Alcotest.test_case "later layer wins normal, earlier wins important"
+        `Quick later_layer_wins_normal_earlier_wins_important;
+      Alcotest.test_case "layer statement orders the blocks" `Quick
+        layer_statement_orders_the_blocks;
+      Alcotest.test_case "layer outranks specificity" `Quick
+        layer_outranks_specificity;
+      Alcotest.test_case "non-competing layers both project" `Quick
+        non_competing_layers_both_project;
       Alcotest.test_case "invalid css is empty" `Quick invalid_css_is_empty;
     ] )

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -116,7 +116,7 @@ let test_resolve_nested_layers () =
     "a sublayer comes after its parent" (Some "color:red")
     (resolved_color "@layer a.b{span{color:red}}@layer a{span{color:blue}}");
   Alcotest.(check (option string))
-    "a top-level layer sorts after the whole subtree" (Some "color:#008000")
+    "a top-level layer sorts after the whole subtree" (Some "color:green")
     (resolved_color
        "@layer a.b{span{color:red}}@layer c{span{color:green}}@layer \
         a.d{span{color:blue}}")

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -74,14 +74,14 @@ let test_sibling_then_descendant () =
   no "descendant of first div" "div+div span" s1;
   yes "subsequent-sibling then child" "div~div>span" s2
 
+let sheet_of css =
+  match Css.of_string css with
+  | Ok { stylesheet; _ } -> stylesheet
+  | Error e -> Alcotest.failf "parse: %s" (Error.to_string e)
+
 let test_resolve_cascade () =
   let sheet =
-    match
-      Css.of_string
-        "span{color:red}#s2{color:#0f0}div+div>span{font-weight:700}"
-    with
-    | Ok { stylesheet; _ } -> stylesheet
-    | Error e -> Alcotest.failf "parse: %s" (Error.to_string e)
+    sheet_of "span{color:red}#s2{color:#0f0}div+div>span{font-weight:700}"
   in
   let decls = R.resolve sheet s2 in
   let value p =
@@ -99,6 +99,39 @@ let test_resolve_cascade () =
   Alcotest.(check (option string))
     "sibling-combined rule applies" (Some "font-weight:700")
     (value "font-weight")
+
+let resolved_color css =
+  List.find_map
+    (fun d ->
+      if Declaration.property_name d = "color" then
+        Some (Declaration.string_of_declaration ~minify:true d)
+      else None)
+    (R.resolve (sheet_of css) s2)
+
+(* Layer names form a tree (css-cascade-5 sec. 6.4.2): [@layer a.b] creates [a]
+   first and nests [b] inside it, and a later [@layer a.d] is ordered inside [a]
+   too, so it stays before a top-level layer declared in between. *)
+let test_resolve_nested_layers () =
+  Alcotest.(check (option string))
+    "a sublayer comes after its parent" (Some "color:red")
+    (resolved_color "@layer a.b{span{color:red}}@layer a{span{color:blue}}");
+  Alcotest.(check (option string))
+    "a top-level layer sorts after the whole subtree" (Some "color:#008000")
+    (resolved_color
+       "@layer a.b{span{color:red}}@layer c{span{color:green}}@layer \
+        a.d{span{color:blue}}")
+
+(* Each unnamed [@layer { }] block is a layer of its own, so two of them order
+   like any other pair: the last wins for normal declarations, the first for
+   important ones. *)
+let test_resolve_anonymous_layers () =
+  Alcotest.(check (option string))
+    "the last anonymous layer wins" (Some "color:blue")
+    (resolved_color "@layer{span{color:red}}@layer{span{color:blue}}");
+  Alcotest.(check (option string))
+    "the first wins for important" (Some "color:red!important")
+    (resolved_color
+       "@layer{span{color:red!important}}@layer{span{color:blue!important}}")
 
 (* {!Apply.Make} reuses the same {!Node} adapter: a static rule projects onto
    the element, a rule with no inline form ([:hover]) stays in a <style>
@@ -134,6 +167,10 @@ let suite =
         test_sibling_then_descendant;
       Alcotest.test_case "resolve applies the cascade" `Quick
         test_resolve_cascade;
+      Alcotest.test_case "nested layer names order as a tree" `Quick
+        test_resolve_nested_layers;
+      Alcotest.test_case "anonymous layers are distinct" `Quick
+        test_resolve_anonymous_layers;
       Alcotest.test_case "apply projects a static rule, keeps a dynamic one"
         `Quick test_apply_compute;
     ] )


### PR DESCRIPTION
apply flattened @layer blocks before resolution, so the resolver weighed only specificity, importance and source order: an unlayered declaration lost to a later layered one and the !important inversions were ignored, per none of css-cascade-5 sec. 6. The layer rank now feeds the existing cascade_layer_precedence_rank model (which stylesheet.ml already exported and tested - the resolver never called it), rules kept in the output stay inside their layer, and @layer a, b; statements are preserved on both sides since they order the layers.