### PR TITLE
parser: stop a declaration body at '}' and keep bad strings serialisable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,9 @@
   block or the `@import` (#192)
 - The eleven `scroll-margin` properties take a negative length, as CSS Scroll
   Snap 1 allows; only `scroll-padding` is non-negative (#280)
+- A `}` ends a declaration value in `Parser.block_contents` instead of being
+  swallowed along with the rest of the block, and a bad string serialises back
+  to source that reads as one instead of vanishing from an at-rule prelude (#284)
 
 ### Printing and nesting
 

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -207,7 +207,14 @@ let string_of_token_kind : Token.kind -> string = function
          4.3.5 recovers an unterminated string; the [terminated] flag is
          preserved so one round-trips, emitting without its closing quote. *)
       escape_string ~quote:'"' ~terminated value
-  | Token.Bad_string -> ""
+  | Token.Bad_string ->
+      (* A bad string keeps no text, so serialize the shortest source that
+         re-tokenizes as one, the way [Bad_url] serializes to [url(a b)]. CSS
+         Syntax sec. 4.3.5 makes one only from a newline inside a string and
+         reconsumes that newline, so the quote needs the newline after it and
+         the token is always followed by whitespace -- which is what the
+         reconsumed newline lexes as, keeping the component count stable. *)
+      "\"\n"
   | Token.Url s ->
       let buf = Buffer.create (String.length s + 5) in
       Buffer.add_string buf "url(";
@@ -967,12 +974,21 @@ let declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings cvs :
 
 (* Buffer component values until the terminating ';' or EOF (CSS Syntax section
    5.4.6 declaration body). Shared by the list, single-declaration and
-   block-contents entry points. *)
+   block-contents entry points.
+
+   Section 5.5.7 also stops on a '}' when [nested] is true, the flag section
+   5.5.5 passes to "consume a declaration". A balanced '}' is eaten by
+   [consume_component_value_from] along with its opening brace, so one reaching
+   this loop closes an enclosing block: hand it back rather than swallow it and
+   the rest of the block with it. *)
 let consume_declaration_body lexer =
   let rec loop acc =
     let t = Lexer.next lexer in
     match t.Token.kind with
     | Token.Semicolon | Token.Eof -> List.rev acc
+    | Token.Close Curly ->
+        Lexer.reconsume lexer t;
+        List.rev acc
     | _ -> loop (consume_component_value_from lexer t :: acc)
   in
   loop []

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1009,6 +1009,22 @@ let public_parse_edges () =
         "partial parser reports invalid rules" 2
         (List.length parsed.warnings)
 
+(* A newline inside a string produces a <bad-string-token>. In an at-rule
+   prelude that token used to serialize to nothing, so [@media <bad-string>]
+   reached the media-condition reader as an empty condition: the rule kept its
+   body but lost its condition, with no diagnostic. *)
+let public_bad_string_prelude_edges () =
+  match of_string "@media \"abc\n{ .a { color: red } }" with
+  | Error err ->
+      Alcotest.failf "lenient parse rejected recoverable CSS: %s"
+        (Cascade.Error.to_string err)
+  | Ok parsed ->
+      Alcotest.(check bool)
+        "the lost media condition is reported" true (parsed.warnings <> []);
+      Alcotest.(check bool)
+        "no unconditional @media is emitted" false
+        (Astring.String.is_infix ~affix:"@media{" (minify parsed.stylesheet))
+
 (* The value parsers the [list-style] shorthand is built from, exposed so a
    caller can read a single [list-style-type] / [list-style-image]. *)
 let list_style_value_parsers () =
@@ -1086,4 +1102,6 @@ let suite =
       Alcotest.test_case "public theme var rendering" `Quick
         public_theme_var_rendering_edges;
       Alcotest.test_case "public parse recovery edges" `Quick public_parse_edges;
+      Alcotest.test_case "public bad-string prelude edges" `Quick
+        public_bad_string_prelude_edges;
     ] )

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -404,6 +404,38 @@ let spec_block_flush_stop () =
   | [ `Decls [ { node = { name = "color"; _ }; _ } ] ] -> ()
   | _ -> Alcotest.fail "expected right brace to stop block contents"
 
+let spec_declaration_body_right_brace () =
+  (* CSS Syntax Level 3 section 5.5.7 "consume a list of component values": on a
+     [<}-token>] with [nested] true, return the list. Section 5.5.5 consumes a
+     declaration with [nested] set to true and 5.5.6 forwards that flag, so a
+     right brace ends the declaration value and, because "process" acts on the
+     next token without consuming it, stays available to the caller. *)
+  let block_items css = (Parser.block_contents (Reader.of_string css)).value in
+  (match block_items "a:1} b:2" with
+  | [ `Decls [ { node = { name = "a"; value; _ }; _ } ] ] ->
+      Alcotest.(check string)
+        "right brace ends the declaration value" "1"
+        (Parser.to_string_minified value)
+  | items ->
+      Alcotest.failf "expected one declaration before the right brace, got %d"
+        (List.length items));
+  let decls css = (Parser.list_of_declarations (Reader.of_string css)).value in
+  match decls "a:1} b:2" with
+  | [
+   `Decl { node = { name = "a"; value = first; _ }; _ };
+   `Decl { node = { name = "b"; value = second; _ }; _ };
+  ] ->
+      Alcotest.(check string)
+        "value before the right brace" "1"
+        (Parser.to_string_minified first);
+      Alcotest.(check string)
+        "declaration after the right brace" "2"
+        (Parser.to_string_minified second)
+  | items ->
+      Alcotest.failf
+        "expected the right brace to release the following declaration, got %d"
+        (List.length items)
+
 let spec_block_custom_props () =
   (* CSS Syntax Level 3 section 5.5.5 treats custom-property-shaped input as a
      declaration attempt, so it is not reparsed as a qualified rule. *)
@@ -658,6 +690,55 @@ let spec_serialization_roundtrip_boundaries () =
   Alcotest.(check string)
     "backslash delim serialization" "\\\n"
     (Parser.string_of_components (parse_list "\\"))
+
+let spec_serialization_bad_string_roundtrip () =
+  (* CSS Syntax Level 3 section 9: serialization round-trips through
+     tokenization. A <bad-string-token> carries no text, so - like the
+     <bad-url-token>, which serializes to [url(a b)] - it has to serialize to
+     some source that re-tokenizes as a <bad-string-token> rather than to
+     nothing. Section 4.3.5 only produces one from a newline inside a string,
+     and reconsumes that newline, so the token is always followed by
+     whitespace. *)
+  let list css =
+    (Parser.list_of_component_values (Reader.of_string css)).value
+  in
+  let components = list "\"abc\nx" in
+  (match components with
+  | [
+   Component.Preserved { kind = Token.Bad_string; _ };
+   Component.Preserved { kind = Token.Whitespace; _ };
+   Component.Preserved { kind = Token.Ident "x"; _ };
+  ] ->
+      ()
+  | _ -> Alcotest.fail "expected bad-string, whitespace and ident");
+  let serialized = Parser.string_of_components components in
+  match list serialized with
+  | [
+   Component.Preserved { kind = Token.Bad_string; _ };
+   Component.Preserved { kind = Token.Whitespace; _ };
+   Component.Preserved { kind = Token.Ident "x"; _ };
+  ] ->
+      ()
+  | reparsed ->
+      Alcotest.failf "serialized %S no longer holds a bad string: %d components"
+        serialized (List.length reparsed)
+
+let spec_bad_string_prelude_kept () =
+  (* An at-rule prelude holding a <bad-string-token> must not serialize to an
+     empty prelude: [@media <bad-string>] would silently become an unconditional
+     [@media]. *)
+  let source = "@media \"abc\n{ .a { color: red } }" in
+  match (Parser.stylesheet (Reader.of_string source)).value with
+  | [ Component.At { node = { name = "media"; prelude; _ }; _ } ] -> (
+      let serialized = Parser.to_string_minified prelude in
+      match
+        (Parser.list_of_component_values (Reader.of_string serialized)).value
+      with
+      | Component.Preserved { kind = Token.Bad_string; _ } :: _ -> ()
+      | _ ->
+          Alcotest.failf "prelude %S no longer starts with a bad string"
+            serialized)
+  | _ -> Alcotest.fail "expected a single @media at-rule"
 
 let spec_wpt_unclosed_construct_edges () =
   (* WPT unclosed-constructs vectors at the component parser layer. *)
@@ -1325,6 +1406,8 @@ let suite =
       Alcotest.test_case
         "spec section 5.5.5 block contents custom property edges" `Quick
         spec_block_custom_props;
+      Alcotest.test_case "spec section 5.5.7 declaration body right brace"
+        `Quick spec_declaration_body_right_brace;
       Alcotest.test_case "spec section 5.4.7 parse declaration entry point"
         `Quick spec_parse_declaration_entry_point;
       Alcotest.test_case "spec section 5.4.8 parse component value entry point"
@@ -1342,6 +1425,10 @@ let suite =
         spec_serialization_string_escaping;
       Alcotest.test_case "spec section 9 serialization boundaries" `Quick
         spec_serialization_roundtrip_boundaries;
+      Alcotest.test_case "spec section 9 bad-string serialization" `Quick
+        spec_serialization_bad_string_roundtrip;
+      Alcotest.test_case "spec section 9 bad-string at-rule prelude" `Quick
+        spec_bad_string_prelude_kept;
       Alcotest.test_case "spec WPT unclosed construct edges" `Quick
         spec_wpt_unclosed_construct_edges;
       Alcotest.test_case "spec WPT trailing brace edges" `Quick


### PR DESCRIPTION
Two public-contract violations in the parser, both spec-cited: consume_declaration_body terminated only on semicolon/EOF, so Parser.block_contents on 'a:1} b:2' absorbed the brace and the next declaration into one value with zero warnings (CSS Syntax 3 sec. 5.5.7 says an unbalanced } returns when nested); and Bad_string serialised to the empty string, so a bad-string prelude vanished on round-trip - '@media "abc<newline>{...}' silently became an unconditional @media. It now serialises to a quote+newline, the only spelling that re-lexes as Bad_string, mirroring the deliberate Bad_url choice.