### PR TITLE
diff: report repeated properties, deep containers and the string fallback honestly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,6 +107,12 @@
   compared occurrence by occurrence; matching by name alone made
   `a{color:red;color:blue}` against `a{color:red;color:green}` report
   `color: blue -> red`, a value neither side holds
+- Containers are compared however deep they nest. The walk stopped at three
+  levels, so a leaf difference under five at-rules was reported as no
+  difference at all, exit code included
+- A container entry with nothing to show under it reads as `(modified, no
+  details)`; it claimed a position change, which only a `Reordered` entry
+  establishes
 - A declaration reorder that decides the cascade is reported inside `@media`,
   `@layer` and `@supports` (#268), and the at-rules that carry no selector -
   `@page`, `@starting-style`, `@counter-style`, `@scope`, a second

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -106,13 +106,20 @@
 - A rule that writes one property more than once, as a fallback chain does, is
   compared occurrence by occurrence; matching by name alone made
   `a{color:red;color:blue}` against `a{color:red;color:green}` report
-  `color: blue -> red`, a value neither side holds
+  `color: blue -> red`, a value neither side holds (#285)
 - Containers are compared however deep they nest. The walk stopped at three
   levels, so a leaf difference under five at-rules was reported as no
-  difference at all, exit code included
+  difference at all, exit code included (#285)
 - A container entry with nothing to show under it reads as `(modified, no
   details)`; it claimed a position change, which only a `Reordered` entry
-  establishes
+  establishes (#285)
+- A comparison that classified nothing says so: `Changes: none classified
+  structurally (see report below)`. It read `No structural differences`, which
+  claimed equivalence over a comparison that fell through to a string diff, and
+  over a side whose content the parser discarded (#285)
+- `cascade diff --diff=canonical` reports the canonical byte difference it
+  records when the structural comparison finds none: the verdict reads `CSS
+  files are equivalent` and `--depth=max` shows the two canonical forms (#285)
 - A declaration reorder that decides the cascade is reported inside `@media`,
   `@layer` and `@supports` (#268), and the at-rules that carry no selector -
   `@page`, `@starting-style`, `@counter-style`, `@scope`, a second

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -103,6 +103,10 @@
 
 ### Diff report
 
+- A rule that writes one property more than once, as a fallback chain does, is
+  compared occurrence by occurrence; matching by name alone made
+  `a{color:red;color:blue}` against `a{color:red;color:green}` report
+  `color: blue -> red`, a value neither side holds
 - A declaration reorder that decides the cascade is reported inside `@media`,
   `@layer` and `@supports` (#268), and the at-rules that carry no selector -
   `@page`, `@starting-style`, `@counter-style`, `@scope`, a second

--- a/_opam
+++ b/_opam
@@ -1,0 +1,1 @@
+/Users/samoht/git/cascade/_opam

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -122,6 +122,29 @@ let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth result =
         ]);
   print_string (Buffer.contents buf)
 
+(* Canonical mode can find the two sheets equivalent and still hold two
+   different canonical minified forms: a tool banner, a split [@layer] form, an
+   empty layer-order pin, whitespace inside [url()]. Tree-diff is the
+   authoritative comparator here - but dropping it left no trace of a
+   canonical-pass gap anyone could act on. *)
+let print_canonical_residual ~file1 ~file2 ~depth (expected_canon, actual_canon)
+    =
+  match depth with
+  | Fit | Level _ ->
+      Fmt.pr "Canonical minified forms still differ (--depth=max shows it)@."
+  | Full ->
+      Fmt.pr "Canonical minified forms still differ:@.";
+      let buf = Buffer.create 512 in
+      (match
+         Cascade_diff.String_diff.diff ~expected:expected_canon actual_canon
+       with
+      | Some sdiff ->
+          Buffer.add_char buf '\n';
+          Cascade_diff.String_diff.pp ~expected_label:file1 ~actual_label:file2
+            buf sdiff
+      | None -> ());
+      print_string (Buffer.contents buf)
+
 type canonical_opts = { lossless : bool; prune_unused_custom_props : bool }
 
 let compare_files file1 file2 style_renderer mode depth opts () =
@@ -148,7 +171,7 @@ let compare_files file1 file2 style_renderer mode depth opts () =
             ~css2
         in
         match result.Cascade_diff.Css_compare.result with
-        | No_diff _ ->
+        | No_diff { canonical_byte_diff } ->
             (* Equal ASTs can still hide parse-dropped declarations; show the
                warnings so the equality verdict is honest about them. *)
             let max =
@@ -157,7 +180,11 @@ let compare_files file1 file2 style_renderer mode depth opts () =
               | Fit | Level _ -> Some auto_warning_budget
             in
             print_string (render_warnings ~file1 ~file2 ~max result);
-            Fmt.pr "CSS files are identical@.";
+            (match canonical_byte_diff with
+            | None -> Fmt.pr "CSS files are identical@."
+            | Some forms ->
+                Fmt.pr "CSS files are equivalent@.";
+                print_canonical_residual ~file1 ~file2 ~depth forms);
             Ok ()
         | String_diff _ | Tree_diff _ | Both_errors _ | Expected_error _
         | Actual_error _ ->
@@ -300,7 +327,10 @@ let man =
          values stay functional. No effect outside canonical mode." );
     `S Manpage.s_exit_status;
     `P "$(tname) exits with:";
-    `I ("0", "if the CSS files are identical");
+    `I
+      ( "0",
+        "if the CSS files are identical, or structurally equivalent with a \
+         canonical byte difference the report names" );
     `I ("1", "if the CSS files differ");
     `I ("124", "on command-line errors or unreadable input files");
     `S Manpage.s_examples;

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -47,8 +47,9 @@ type depth = Fit | Full | Level of int
    [Auto] drops to the deepest level that still fits. *)
 let auto_line_budget = 40
 
-(* [nested_differences] stops recursing at 3, so probing past that only re-walks
-   a tree that cannot grow. *)
+(* The probe renders the report once per level, and the diff tree is as deep as
+   the stylesheet nests. Stop at a level that summarises any report worth
+   summarising; [--depth=max] is the answer for the rest. *)
 let max_probe_depth = 5
 
 let count_lines s =

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,0 +1,12 @@
+(lang dune 3.21)
+
+(context default)
+
+(env
+ (dev
+  ; -w -58 (no-cmx-file): a flambda missed-inlining hint that fires on
+  ; dune-build-info's link-time module and other cmx-less dependencies. It is
+  ; not a correctness warning.
+  (flags (:standard -w -58)))
+ (release
+  (flags (:standard -w -58))))

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -617,8 +617,14 @@ let emit_changes buf stats =
     |> List.filter (fun (n, _, _) -> n > 0)
   in
   let container = stats.container_changes in
+  (* Every counter above comes from a tree diff, so they all read zero on the
+     results that never reached one: a comparison that fell through to the
+     string diff, a side whose content the parser discarded, a parse error. The
+     line says what it knows - nothing was classified - and leaves the verdict
+     to the report under it. *)
   if entries = [] && container = 0 then
-    Buffer.add_string buf "No structural differences\n"
+    Buffer.add_string buf
+      "Changes: none classified structurally (see report below)\n"
   else (
     Buffer.add_string buf "Changes: ";
     List.iteri

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1657,45 +1657,59 @@ let handle_structural_diff rules1 rules2 =
 
 let rule_diffs rules1 rules2 = handle_structural_diff rules1 rules2
 
+(* The values a rule writes for [name], in the order it writes them. *)
+let occurrences_of name props =
+  List.filter_map (fun (p, v) -> if p = name then Some v else None) props
+
+(* The property names of [props], each once, in first-appearance order. *)
+let names_of props =
+  List.fold_left
+    (fun acc (p, _) -> if List.mem p acc then acc else p :: acc)
+    [] props
+  |> List.rev
+
+(* Zip one name's occurrence lists. A rule may write a property several times -
+   a fallback chain is the usual reason - so occurrence n on one side answers
+   occurrence n on the other, and whichever side has more occurrences carries
+   the surplus. Matching by name alone binds every occurrence to the first entry
+   opposite and reports values neither side holds. *)
+let rec zip_occurrences name (modified, added, removed) values1 values2 =
+  match (values1, values2) with
+  | [], [] -> (modified, added, removed)
+  | v1 :: rest1, v2 :: rest2 ->
+      let modified =
+        if v1 = v2 then modified
+        else
+          { property_name = name; expected_value = v1; actual_value = v2 }
+          :: modified
+      in
+      zip_occurrences name (modified, added, removed) rest1 rest2
+  | _ :: rest1, [] ->
+      zip_occurrences name (modified, added, name :: removed) rest1 []
+  | [], _ :: rest2 ->
+      zip_occurrences name (modified, name :: added, removed) [] rest2
+
 (* Helper function to compute property diffs between two declaration lists,
    including added and removed properties *)
 let properties_diff decls1 decls2 : declaration list * string list * string list
     =
   let props1 = List.map decl_to_prop_value decls1 in
   let props2 = List.map decl_to_prop_value decls2 in
-
-  (* Find modified properties *)
-  let modified =
-    List.fold_left
-      (fun acc (p1, v1) ->
-        match List.assoc_opt p1 props2 with
-        | Some v2 when v1 <> v2 ->
-            { property_name = p1; expected_value = v1; actual_value = v2 }
-            :: acc
-        | _ -> acc)
-      [] props1
-    |> List.rev
+  (* Names the expected side writes first, then the ones only the actual side
+     writes, so the report reads in source order. *)
+  let names =
+    let names1 = names_of props1 in
+    names1 @ List.filter (fun p -> not (List.mem p names1)) (names_of props2)
   in
-
-  (* Find added properties (in actual but not in expected) *)
-  let added =
+  let modified, added, removed =
     List.fold_left
-      (fun acc (p2, _v2) ->
-        if not (List.mem_assoc p2 props1) then p2 :: acc else acc)
-      [] props2
-    |> List.rev
+      (fun acc name ->
+        zip_occurrences name acc
+          (occurrences_of name props1)
+          (occurrences_of name props2))
+      ([], [], []) names
   in
-
-  (* Find removed properties (in expected but not in actual) *)
-  let removed =
-    List.fold_left
-      (fun acc (p1, _v1) ->
-        if not (List.mem_assoc p1 props2) then p1 :: acc else acc)
-      [] props1
-    |> List.rev
-  in
-
-  (modified, added, removed)
+  (List.rev modified, List.rev added, List.rev removed)
 
 (* Helper functions for converting rule changes - moved here for mutual
    recursion *)

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -895,7 +895,10 @@ let rec pp_container_diff ?(style = default_style) ?(is_last = false)
       if changes_parts <> [] then
         add_strings buf [ "("; String.concat ", " changes_parts; ")\n" ]
       else if container_changes = [] then
-        Buffer.add_string buf "(position changed)\n"
+        (* A [Modified] carrying neither a rule nor a container change says only
+           that the container differs. Calling it a position change names a
+           difference nobody established; [Reordered] is what reports one. *)
+        Buffer.add_string buf "(modified, no details)\n"
       else Buffer.add_char buf '\n';
       pp_children ~style ~parent_prefix:child_prefix buf (fun style buf ->
           (* Show rule changes at this level *)
@@ -2331,7 +2334,7 @@ let keyframes_diff items1 items2 =
   in
   diffs ~key_of ~key_equal ~is_empty_diff items1 items2
 
-let process_nested_keyframes ~depth:_ stmts1 stmts2 =
+let process_nested_keyframes stmts1 stmts2 =
   let items1 = List.filter_map Css.as_keyframes stmts1 in
   let items2 = List.filter_map Css.as_keyframes stmts2 in
   let added, removed, modified = keyframes_diff items1 items2 in
@@ -2445,7 +2448,7 @@ let rec media_condition_differs rules_list1 rules_list2 =
   let has_immediate =
     added_r <> [] || removed_r <> [] || modified_r <> [] || regrouped_r <> []
   in
-  let has_nested = nested_differences ~depth:1 all_rules1 all_rules2 <> [] in
+  let has_nested = nested_differences all_rules1 all_rules2 <> [] in
   if has_immediate || has_nested || block_count_differs then
     Some (all_rules1, all_rules2)
   else None
@@ -2484,16 +2487,14 @@ and media_diff items1 items2 =
     groups2;
   (!added, !removed, !modified)
 
-and process_modified_container ~container_type ~extract_fn ~depth ~stmts1
-    ~stmts2 ~block_structure_changed cond rules1 rules2 =
+and process_modified_container ~container_type ~extract_fn ~stmts1 ~stmts2
+    ~block_structure_changed cond rules1 rules2 =
   (* Skip if this condition has a block structure change *)
   if Hashtbl.mem block_structure_changed cond then None
   else
     let rule_changes = to_rule_changes rules1 rules2 in
     (* Recursively check deeper nesting *)
-    let nested_containers =
-      nested_differences ~depth:(depth + 1) rules1 rules2
-    in
+    let nested_containers = nested_differences rules1 rules2 in
     (* Check for position changes within parent container *)
     let pos1 =
       container_position extract_fn cond stmts1 |> Option.value ~default:(-1)
@@ -2513,8 +2514,8 @@ and process_modified_container ~container_type ~extract_fn ~depth ~stmts1
            nested_containers)
     else None
 
-and process_nested_containers ~container_type ~extract_fn ~diff_fn ~depth stmts1
-    stmts2 =
+and process_nested_containers ~container_type ~extract_fn ~diff_fn stmts1 stmts2
+    =
   let items_with_pos1 = extract_items_with_positions extract_fn stmts1 in
   let items_with_pos2 = extract_items_with_positions extract_fn stmts2 in
   let block_structure_changed =
@@ -2544,8 +2545,8 @@ and process_nested_containers ~container_type ~extract_fn ~diff_fn ~depth stmts1
   List.iter
     (fun (cond, rules1, rules2) ->
       match
-        process_modified_container ~container_type ~extract_fn ~depth ~stmts1
-          ~stmts2 ~block_structure_changed cond rules1 rules2
+        process_modified_container ~container_type ~extract_fn ~stmts1 ~stmts2
+          ~block_structure_changed cond rules1 rules2
       with
       | Some diff -> diffs := diff :: !diffs
       | None -> ())
@@ -2570,7 +2571,7 @@ and layer_diff items1 items2 =
     if has_immediate_diffs then false
     else
       (* Also check for nested differences *)
-      let nested_diffs = nested_differences ~depth:1 rules1 rules2 in
+      let nested_diffs = nested_differences rules1 rules2 in
       nested_diffs = []
   in
   let added, removed, modified_pairs =
@@ -2597,7 +2598,7 @@ and layer_diff items1 items2 =
 
 (* Shared helper: collect added/removed container diffs and process modified
    containers with the standard rule-change + nesting logic. *)
-and collect_container_diffs ~container_type ~depth added removed modified =
+and collect_container_diffs ~container_type added removed modified =
   let diffs = ref [] in
   List.iter
     (fun (condition, rules) ->
@@ -2610,9 +2611,7 @@ and collect_container_diffs ~container_type ~depth added removed modified =
   List.iter
     (fun (condition, rules1, rules2) ->
       let rule_changes = to_rule_changes rules1 rules2 in
-      let nested_containers =
-        nested_differences ~depth:(depth + 1) rules1 rules2
-      in
+      let nested_containers = nested_differences rules1 rules2 in
       if rule_changes <> [] || nested_containers <> [] then
         diffs :=
           Modified
@@ -2627,17 +2626,16 @@ and collect_container_diffs ~container_type ~depth added removed modified =
   !diffs
 
 (* Process layers separately due to different type signature *)
-and process_nested_layers ~depth stmts1 stmts2 =
+and process_nested_layers stmts1 stmts2 =
   let items1 = List.filter_map Css.as_layer stmts1 in
   let items2 = List.filter_map Css.as_layer stmts2 in
   let added, removed, modified = layer_diff items1 items2 in
-  collect_container_diffs ~container_type:`Layer ~depth added removed modified
+  collect_container_diffs ~container_type:`Layer added removed modified
 
 and container_has_no_diff (_, _, rules1) (_, _, rules2) =
   let a_r, r_r, m_r, rg_r = rule_diffs rules1 rules2 in
   let has_immediate_diffs = a_r <> [] || r_r <> [] || m_r <> [] || rg_r <> [] in
-  if has_immediate_diffs then false
-  else nested_differences ~depth:1 rules1 rules2 = []
+  if has_immediate_diffs then false else nested_differences rules1 rules2 = []
 
 (* Container diff function for @container rules *)
 and container_diff items1 items2 =
@@ -2653,15 +2651,14 @@ and container_diff items1 items2 =
   (added, removed, modified)
 
 (* Process container rules *)
-and process_nested_containers_with_name ~depth stmts1 stmts2 =
+and process_nested_containers_with_name stmts1 stmts2 =
   let items1 = List.filter_map Css.as_container stmts1 in
   let items2 = List.filter_map Css.as_container stmts2 in
   let added, removed, modified = container_diff items1 items2 in
-  collect_container_diffs ~container_type:`Container ~depth added removed
-    modified
+  collect_container_diffs ~container_type:`Container added removed modified
 
 (* Process CSS nesting: rules with nested child rules (& .foo { ... }) *)
-and process_nested_rules ~depth stmts1 stmts2 =
+and process_nested_rules stmts1 stmts2 =
   (* Extract (selector_key, nested_statements) for all rules, including those
      with empty nesting. This allows detecting when nesting is added/removed. *)
   let extract_nesting stmts =
@@ -2681,9 +2678,7 @@ and process_nested_rules ~depth stmts1 stmts2 =
       match List.find_opt (fun (s, _) -> s = sel1) items2 with
       | Some (_, nested2) when nested1 <> nested2 ->
           let rule_changes = to_rule_changes nested1 nested2 in
-          let nested_containers =
-            nested_differences ~depth:(depth + 1) nested1 nested2
-          in
+          let nested_containers = nested_differences nested1 nested2 in
           if rule_changes <> [] || nested_containers <> [] then
             diffs :=
               Modified
@@ -2706,7 +2701,7 @@ and process_nested_rules ~depth stmts1 stmts2 =
 
 (* Compare one pair of at-rule blocks that occupy the same position under the
    same head. *)
-and at_rule_pair_diff ~depth (head, body1, text1) (_, body2, text2) =
+and at_rule_pair_diff (head, body1, text1) (_, body2, text2) =
   let modified rules actual_rules rule_changes container_changes =
     Modified
       {
@@ -2719,9 +2714,7 @@ and at_rule_pair_diff ~depth (head, body1, text1) (_, body2, text2) =
   match (body1, body2) with
   | Block block1, Block block2 ->
       let rule_changes = to_rule_changes block1 block2 in
-      let container_changes =
-        nested_differences ~depth:(depth + 1) block1 block2
-      in
+      let container_changes = nested_differences block1 block2 in
       if rule_changes = [] && container_changes = [] then None
       else Some (modified block1 block2 rule_changes container_changes)
   | Declarations decls1, Declarations decls2 ->
@@ -2732,7 +2725,7 @@ and at_rule_pair_diff ~depth (head, body1, text1) (_, body2, text2) =
       Some (modified [] [] [ at_rule_text_change text1 text2 ] [])
   | Block _, _ | Declarations _, _ | Opaque, _ -> None
 
-and process_at_rules ~depth stmts1 stmts2 =
+and process_at_rules stmts1 stmts2 =
   let items1 = at_rule_items stmts1 and items2 = at_rule_items stmts2 in
   let added, removed, pairs =
     diffs ~key_of:fst ~key_equal:( = )
@@ -2746,35 +2739,37 @@ and process_at_rules ~depth stmts1 stmts2 =
   List.map (fun (_, item) -> Added (info item)) added
   @ List.map (fun (_, item) -> Removed (info item)) removed
   @ List.filter_map
-      (fun ((_, item1), (_, item2)) -> at_rule_pair_diff ~depth item1 item2)
+      (fun ((_, item1), (_, item2)) -> at_rule_pair_diff item1 item2)
       pairs
 
 (* Main recursive function for nested differences *)
-and nested_differences ?(depth = 0) (stmts1 : Css.statement list)
+(* Every branch below recurses on the statements of a block, which is a strictly
+   smaller list than the one holding it, so the walk terminates on the depth of
+   the stylesheet. A cutoff here is a cutoff of the answer: the detection
+   helpers ([media_condition_differs], [layer_diff]'s [is_empty_diff],
+   [container_has_no_diff]) call back in to decide whether a container differs
+   at all, so a container past the cutoff was reported as identical, verdict and
+   exit code included. *)
+and nested_differences (stmts1 : Css.statement list)
     (stmts2 : Css.statement list) : container_diff list =
-  if depth > 3 then [] (* Prevent infinite recursion *)
-  else
-    (* Process CSS nesting (& .foo { ... } inside rules) *)
-    process_nested_rules ~depth stmts1 stmts2
-    (* Process media queries *)
-    @ process_nested_containers ~container_type:`Media
-        ~extract_fn:extract_media_as_string ~diff_fn:media_diff ~depth stmts1
-        stmts2
-    (* Process layers - different type signature *)
-    @ process_nested_layers ~depth stmts1 stmts2
-    (* Process supports - reuses media_diff since they have the same
-       structure *)
-    @ process_nested_containers ~container_type:`Supports
-        ~extract_fn:extract_supports_as_string ~diff_fn:media_diff ~depth stmts1
-        stmts2
-    (* Process container queries *)
-    @ process_nested_containers_with_name ~depth stmts1 stmts2
-    (* Process property declarations *)
-    @ process_nested_properties stmts1 stmts2
-    (* Process keyframes animations *)
-    @ process_nested_keyframes ~depth stmts1 stmts2
-    (* Process the at-rules that carry no selector of their own *)
-    @ process_at_rules ~depth stmts1 stmts2
+  (* Process CSS nesting (& .foo { ... } inside rules) *)
+  process_nested_rules stmts1 stmts2
+  (* Process media queries *)
+  @ process_nested_containers ~container_type:`Media
+      ~extract_fn:extract_media_as_string ~diff_fn:media_diff stmts1 stmts2
+  (* Process layers - different type signature *)
+  @ process_nested_layers stmts1 stmts2
+  (* Process supports - reuses media_diff since they have the same structure *)
+  @ process_nested_containers ~container_type:`Supports
+      ~extract_fn:extract_supports_as_string ~diff_fn:media_diff stmts1 stmts2
+  (* Process container queries *)
+  @ process_nested_containers_with_name stmts1 stmts2
+  (* Process property declarations *)
+  @ process_nested_properties stmts1 stmts2
+  (* Process keyframes animations *)
+  @ process_nested_keyframes stmts1 stmts2
+  (* Process the at-rules that carry no selector of their own *)
+  @ process_at_rules stmts1 stmts2
 
 (* Check if containers appear at different positions in statement sequence *)
 let detect_container_position_changes stmts1 stmts2 containers =
@@ -2917,7 +2912,7 @@ let diff ~(expected : Css.t) ~(actual : Css.t) : t =
 
   (* Delegate all container and nested-container diffs to the generic walker *)
   let containers =
-    let base_containers = nested_differences ~depth:0 all1 all2 in
+    let base_containers = nested_differences all1 all2 in
     detect_container_position_changes all1 all2 base_containers
   in
 

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -155,7 +155,7 @@ The --diff=string mode falls back to character-level diffing.
   > EOF
   $ NO_COLOR=1 cascade diff --diff=string g.css h.css
   CSS: 18 chars vs 19 chars (5.6% diff)
-  No structural differences
+  Changes: none classified structurally (see report below)
   
   Strings differ at position 12 (line 0, col 12)
   

--- a/test/cli/diff_canonical_residual.t
+++ b/test/cli/diff_canonical_residual.t
@@ -14,7 +14,7 @@ names the divergence rather than dropping it.
   > EOF
   $ cascade diff --diff=canonical pinned.css unpinned.css
   CSS files are equivalent
-  Canonical minified forms still differ (cosmetic; --depth=max shows it)
+  Canonical minified forms still differ (--depth=max shows it)
 
   $ cascade diff --diff=canonical pinned.css unpinned.css > /dev/null; echo $?
   0
@@ -24,15 +24,17 @@ Under --depth=max the two canonical forms are shown.
   $ NO_COLOR=1 cascade diff --diff=canonical --depth=max pinned.css unpinned.css
   CSS files are equivalent
   Canonical minified forms still differ:
-
+  
   Strings differ at position 8 (line 0, col 8)
-
+  
   --- pinned.css
   +++ unpinned.css
   @@ position 8 @@
   -@layer a;@layer a{x{top:0}}
   +@layer a{x{top:0}}
            ^
+
+
 
 A canonical comparison whose bytes do match keeps the plain verdict.
 

--- a/test/cli/diff_canonical_residual.t
+++ b/test/cli/diff_canonical_residual.t
@@ -1,0 +1,46 @@
+CLI: cascade diff - canonical mode's residual byte difference.
+
+Two sheets the structural comparator calls equivalent can still
+canonicalise to different bytes: here an empty layer-order pin the
+projection does not fold away. Tree-diff is the authoritative answer, so
+the verdict stays equivalence and the exit code stays 0, but the report
+names the divergence rather than dropping it.
+
+  $ cat > pinned.css <<EOF
+  > @layer a;@layer a{x{top:0}}
+  > EOF
+  $ cat > unpinned.css <<EOF
+  > @layer a{x{top:0}}
+  > EOF
+  $ cascade diff --diff=canonical pinned.css unpinned.css
+  CSS files are equivalent
+  Canonical minified forms still differ (cosmetic; --depth=max shows it)
+
+  $ cascade diff --diff=canonical pinned.css unpinned.css > /dev/null; echo $?
+  0
+
+Under --depth=max the two canonical forms are shown.
+
+  $ NO_COLOR=1 cascade diff --diff=canonical --depth=max pinned.css unpinned.css
+  CSS files are equivalent
+  Canonical minified forms still differ:
+
+  Strings differ at position 8 (line 0, col 8)
+
+  --- pinned.css
+  +++ unpinned.css
+  @@ position 8 @@
+  -@layer a;@layer a{x{top:0}}
+  +@layer a{x{top:0}}
+           ^
+
+A canonical comparison whose bytes do match keeps the plain verdict.
+
+  $ cat > same-a.css <<EOF
+  > .x { color: red }
+  > EOF
+  $ cat > same-b.css <<EOF
+  > .x{color:red}
+  > EOF
+  $ cascade diff --diff=canonical same-a.css same-b.css
+  CSS files are identical

--- a/test/cli/diff_nesting.t
+++ b/test/cli/diff_nesting.t
@@ -11,20 +11,22 @@ node it stopped at.
   > @media (min-width:1px){@supports (display:grid){@media (min-width:2px){@supports (display:flex){@media (min-width:3px){a{color:blue}}}}}}
   > EOF
   $ NO_COLOR=1 cascade diff --diff=tree --depth=max deep-a.css deep-b.css
-  CSS: 135 chars vs 136 chars (0.7% diff)
+  CSS: 137 chars vs 138 chars (0.7% diff)
   Changes: 1 changed container
-
+  
   --- deep-a.css
   +++ deep-b.css
-  └─ @media (min-width: 1px)
-     └─ @supports (display: grid)
-        └─ @media (min-width: 2px)
-           └─ @supports (display: flex)
+  └─ @media (min-width: 1px) 
+     └─ @supports (display: grid) 
+        └─ @media (min-width: 2px) 
+           └─ @supports (display: flex) 
               └─ @media (min-width: 3px) (1 modified)
                  └─ a
                        * color: red -> blue
-
+  
   [1]
+
+
 
 The same nesting with no leaf change stays identical.
 

--- a/test/cli/diff_nesting.t
+++ b/test/cli/diff_nesting.t
@@ -1,0 +1,32 @@
+CLI: cascade diff - containers nested several levels deep.
+
+A leaf difference under five at-rules is still a difference, and the
+report walks down to it rather than stopping partway and labelling the
+node it stopped at.
+
+  $ cat > deep-a.css <<EOF
+  > @media (min-width:1px){@supports (display:grid){@media (min-width:2px){@supports (display:flex){@media (min-width:3px){a{color:red}}}}}}
+  > EOF
+  $ cat > deep-b.css <<EOF
+  > @media (min-width:1px){@supports (display:grid){@media (min-width:2px){@supports (display:flex){@media (min-width:3px){a{color:blue}}}}}}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=tree --depth=max deep-a.css deep-b.css
+  CSS: 135 chars vs 136 chars (0.7% diff)
+  Changes: 1 changed container
+
+  --- deep-a.css
+  +++ deep-b.css
+  └─ @media (min-width: 1px)
+     └─ @supports (display: grid)
+        └─ @media (min-width: 2px)
+           └─ @supports (display: flex)
+              └─ @media (min-width: 3px) (1 modified)
+                 └─ a
+                       * color: red -> blue
+
+  [1]
+
+The same nesting with no leaf change stays identical.
+
+  $ cascade diff --diff=tree deep-a.css deep-a.css
+  CSS files are identical

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -885,6 +885,53 @@ let pp_stats_does_not_crash () =
     "pp_stats produces output" true
     (String.length output > 0)
 
+(* The counters only ever count a tree diff, so they read zero on every result
+   that never reached one: a comparison that fell through to strings, and a side
+   whose content the parser discarded. Announcing that as an absence of
+   structural differences states a conclusion the comparator never drew. *)
+
+let rendered_stats ?mode expected actual =
+  let result = Cascade_diff.Css_compare.diff ?mode expected actual in
+  let s =
+    Cascade_diff.Css_compare.stats ~expected_str:expected ~actual_str:actual
+      result
+  in
+  let buf = Buffer.create 256 in
+  Cascade_diff.Css_compare.pp_stats buf s;
+  Buffer.contents buf
+
+let zero_counters_do_not_claim_equivalence () =
+  (* The stray braces are dropped with a parse warning, so both sides reach the
+     same AST and the report falls through to a string diff. *)
+  let output = rendered_stats "a{color:red}" "a{color:red}}}}" in
+  Alcotest.(check bool)
+    "does not claim the two sheets match structurally" false
+    (contains_substring output "No structural differences");
+  Alcotest.(check bool)
+    "says the changes were not classified" true
+    (contains_substring output "none classified structurally")
+
+let zero_counters_unparsed_do_not_claim_equivalence () =
+  (* Mode [`String] never parses, so the counters read zero over two sheets that
+     paint differently. *)
+  let output = rendered_stats ~mode:`String "a{color:red}" "a{color:blue}" in
+  Alcotest.(check bool)
+    "a comparison that never parsed is not an absence of differences" false
+    (contains_substring output "No structural differences")
+
+(* Canonical mode keeps the two canonical forms on [No_diff] when the structural
+   comparator saw no difference but the bytes still diverge - here an empty
+   layer-order pin the projection does not fold away. *)
+let canonical_byte_residual_is_recorded () =
+  let result =
+    Cascade_diff.Css_compare.diff ~mode:`Canonical "@layer a;@layer a{x{top:0}}"
+      "@layer a{x{top:0}}"
+  in
+  match result.Cascade_diff.Css_compare.result with
+  | Cascade_diff.Css_compare.No_diff { canonical_byte_diff = Some (e, a) } ->
+      Alcotest.(check bool) "the two forms differ" true (e <> a)
+  | _ -> Alcotest.fail "expected No_diff carrying a canonical byte difference"
+
 (* ===== diff tests ===== *)
 
 let diff_auto () =
@@ -1217,6 +1264,12 @@ let suite =
       Alcotest.test_case "stats with tree diff" `Quick stats_with_tree_diff;
       Alcotest.test_case "pp_stats does not crash" `Quick
         pp_stats_does_not_crash;
+      Alcotest.test_case "zero counters do not claim equivalence" `Quick
+        zero_counters_do_not_claim_equivalence;
+      Alcotest.test_case "zero counters unparsed do not claim equivalence"
+        `Quick zero_counters_unparsed_do_not_claim_equivalence;
+      Alcotest.test_case "canonical byte residual is recorded" `Quick
+        canonical_byte_residual_is_recorded;
       Alcotest.test_case "diff auto" `Quick diff_auto;
       Alcotest.test_case "diff tree" `Quick diff_tree;
       Alcotest.test_case "diff string" `Quick diff_string;

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -886,6 +886,41 @@ let repeated_property_surplus_is_added () =
     "the occurrence with no counterpart is added" [ "color" ]
     (rule_added_properties d)
 
+(* ===== Containers nested past the old recursion cutoff ===== *)
+
+(* The walker recurses on strictly smaller statement lists, so nothing needs a
+   depth cutoff to terminate; one at five levels of at-rule nesting made a leaf
+   difference vanish, verdict and exit code included. *)
+
+let nested_at_rules leaf =
+  "@media (min-width:1px){@supports (display:grid){@media \
+   (min-width:2px){@supports (display:flex){@media (min-width:3px){a{color:"
+  ^ leaf ^ "}}}}}}"
+
+let deeply_nested_leaf_change_reported () =
+  let d =
+    diff_of ~expected:(nested_at_rules "red") ~actual:(nested_at_rules "blue")
+  in
+  Alcotest.(check bool)
+    "a leaf five containers down is still a difference" false
+    (Cascade_diff.Tree_diff.is_empty d)
+
+let deeply_nested_leaf_change_named () =
+  let d =
+    diff_of ~expected:(nested_at_rules "red") ~actual:(nested_at_rules "blue")
+  in
+  let s = render d in
+  Alcotest.(check bool)
+    "and the report names the value that changed" true
+    (string_contains ~needle:"color: red -> blue" s)
+
+let deeply_nested_identical_is_empty () =
+  let css = nested_at_rules "red" in
+  let d = diff_of ~expected:css ~actual:css in
+  Alcotest.(check bool)
+    "identical deep nesting stays empty" true
+    (Cascade_diff.Tree_diff.is_empty d)
+
 let suite =
   ( "tree_diff",
     [
@@ -1002,6 +1037,12 @@ let suite =
         repeated_property_surplus_is_removed;
       Alcotest.test_case "repeated property surplus is added" `Quick
         repeated_property_surplus_is_added;
+      Alcotest.test_case "deeply nested leaf change reported" `Quick
+        deeply_nested_leaf_change_reported;
+      Alcotest.test_case "deeply nested leaf change named" `Quick
+        deeply_nested_leaf_change_named;
+      Alcotest.test_case "deeply nested identical is empty" `Quick
+        deeply_nested_identical_is_empty;
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "pp_rule_diff_simple does not crash" `Quick
         pp_rule_diff_simple_ok;

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -817,6 +817,75 @@ let font_face_added_reported () =
     "an added @font-face is a difference" false
     (Cascade_diff.Tree_diff.is_empty d)
 
+(* ===== One property written more than once in a rule ===== *)
+
+(* A fallback chain writes one property several times, so a rule holds one value
+   per occurrence and occurrence n on one side answers occurrence n on the
+   other. Matching by name alone binds every occurrence to the first entry
+   opposite, which names values neither side holds. *)
+
+let rule_property_changes d =
+  List.concat_map
+    (fun (diff : Cascade_diff.Tree_diff.rule_diff) ->
+      match diff with
+      | Content_changed { property_changes; _ } ->
+          List.map
+            (fun (p : Cascade_diff.Tree_diff.declaration) ->
+              p.property_name ^ ": " ^ p.expected_value ^ " -> "
+              ^ p.actual_value)
+            property_changes
+      | _ -> [])
+    d.Cascade_diff.Tree_diff.rules
+
+let rule_added_properties d =
+  List.concat_map
+    (fun (diff : Cascade_diff.Tree_diff.rule_diff) ->
+      match diff with
+      | Content_changed { added_properties; _ } -> added_properties
+      | _ -> [])
+    d.Cascade_diff.Tree_diff.rules
+
+let rule_removed_properties d =
+  List.concat_map
+    (fun (diff : Cascade_diff.Tree_diff.rule_diff) ->
+      match diff with
+      | Content_changed { removed_properties; _ } -> removed_properties
+      | _ -> [])
+    d.Cascade_diff.Tree_diff.rules
+
+let repeated_property_pairs_by_occurrence () =
+  let d =
+    diff_of ~expected:"a{color:red;color:blue}"
+      ~actual:"a{color:red;color:green}"
+  in
+  Alcotest.(check (list string))
+    "the occurrence that changed, against its counterpart"
+    [ "color: blue -> green" ] (rule_property_changes d)
+
+let repeated_property_pairs_every_occurrence () =
+  let d =
+    diff_of ~expected:"a{color:teal;color:red}"
+      ~actual:"a{color:green;color:blue}"
+  in
+  Alcotest.(check (list string))
+    "each occurrence against the one at its own index"
+    [ "color: teal -> green"; "color: red -> blue" ]
+    (rule_property_changes d)
+
+let repeated_property_surplus_is_removed () =
+  let d = diff_of ~expected:"a{color:red;color:blue}" ~actual:"a{color:red}" in
+  Alcotest.(check (list string)) "no value changed" [] (rule_property_changes d);
+  Alcotest.(check (list string))
+    "the occurrence with no counterpart is removed" [ "color" ]
+    (rule_removed_properties d)
+
+let repeated_property_surplus_is_added () =
+  let d = diff_of ~expected:"a{color:red}" ~actual:"a{color:red;color:blue}" in
+  Alcotest.(check (list string)) "no value changed" [] (rule_property_changes d);
+  Alcotest.(check (list string))
+    "the occurrence with no counterpart is added" [ "color" ]
+    (rule_added_properties d)
+
 let suite =
   ( "tree_diff",
     [
@@ -925,6 +994,14 @@ let suite =
       Alcotest.test_case "@page removed reported" `Quick page_removed_reported;
       Alcotest.test_case "@font-face added reported" `Quick
         font_face_added_reported;
+      Alcotest.test_case "repeated property pairs by occurrence" `Quick
+        repeated_property_pairs_by_occurrence;
+      Alcotest.test_case "repeated property pairs every occurrence" `Quick
+        repeated_property_pairs_every_occurrence;
+      Alcotest.test_case "repeated property surplus is removed" `Quick
+        repeated_property_surplus_is_removed;
+      Alcotest.test_case "repeated property surplus is added" `Quick
+        repeated_property_surplus_is_added;
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "pp_rule_diff_simple does not crash" `Quick
         pp_rule_diff_simple_ok;


### PR DESCRIPTION
Three report-fidelity fixes: a repeated property now pairs occurrence by occurrence instead of by name (the report printed values neither side held); containers compare however deep they nest - the depth cap at 3 made a leaf change five at-rules deep report 'CSS files are identical' with exit 0, and since the recursion is structurally decreasing the cap bought no termination; and the zero-counter line no longer claims 'No structural differences' when the comparison fell through to strings, with --diff=canonical printing the canonical byte difference it records. #290 on top makes that byte difference the verdict.