### PR TITLE
apply: keep the rules the matcher cannot decide

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@
   `Optimize.set_profile` are gone, along with the per-pass table and the
   marginal-stop counter, which no pass had written since the DAG scheduler
   replaced the multi-pass fixpoint (#288)
+- `Resolve.NODE` gains `text_children`, the data of a node's direct child text
+  nodes, which `:empty` needs (#286)
 
 ### Parsing
 
@@ -104,7 +106,11 @@
   no inline form stays inside its layer (#283)
 - `cascade apply` leaves a declaration in the stylesheet when a rule inside
   `@scope`, `@starting-style`, `@when`, `@else` or `@-moz-document` sets the
-  same property; it moved inline, above the rule that was kept
+  same property; it moved inline, above the rule that was kept (#286)
+- `cascade apply` only inlines a rule whose selector its matcher can represent,
+  so `[data-k="X" i]`, a namespaced selector and the `>>>` and `||` combinators
+  stay in the stylesheet rather than being inlined onto nobody and dropped, and
+  `:empty` counts an element's text: `<p>text</p>` is not empty (#286)
 - `Css.vars_of_declarations` reports the `var()` references of 39 properties it
   answered with none, so `Css.resolve_theme` emits the theme binding for
   `inline-size: var(--w)` as it does for `width: var(--w)` (#266)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,9 @@
 - `cascade apply` weighs cascade layers instead of ignoring them: an unlayered
   declaration beats a layered one, `!important` reverses that, and a rule with
   no inline form stays inside its layer (#283)
+- `cascade apply` leaves a declaration in the stylesheet when a rule inside
+  `@scope`, `@starting-style`, `@when`, `@else` or `@-moz-document` sets the
+  same property; it moved inline, above the rule that was kept
 - `Css.vars_of_declarations` reports the `var()` references of 39 properties it
   answered with none, so `Css.resolve_theme` emits the theme binding for
   `inline-size: var(--w)` as it does for `width: var(--w)` (#266)

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -20,6 +20,15 @@ module Node = struct
   let attribute n k = Soup.attribute k n
   let parent = Soup.parent
   let children n = Soup.children n |> Soup.elements |> Soup.to_list
+
+  (* [children] is the element children the structural selectors count; text is
+     reported apart because [:empty] counts that too. [Soup.texts] of a text
+     node is its own data and of a comment is nothing, so skipping the element
+     children leaves exactly the text that bears on emptiness. *)
+  let text_children n =
+    Soup.children n |> Soup.to_list
+    |> List.concat_map (fun c ->
+        match Soup.element c with Some _ -> [] | None -> Soup.texts c)
 end
 
 module Apply = Cascade.Apply.Make (Node)

--- a/fuzz/fuzz_apply.ml
+++ b/fuzz/fuzz_apply.ml
@@ -16,6 +16,7 @@ module Node = struct
   let attribute _ _ = None
   let parent _ = None
   let children n = n.children
+  let text_children _ = []
 end
 
 module A = Apply.Make (Node)

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -7,24 +7,13 @@
 
 module SSet = Set.Make (String)
 
-(* Selectors that can be written as an inline style (no state / condition). *)
-let inlinable (sel : Selector.t) =
-  let rec ok = function
-    | Selector.Universal _ | Selector.Element _ | Selector.Class _
-    | Selector.Id _ | Selector.Attribute _ | Selector.Root
-    | Selector.First_child | Selector.Last_child | Selector.Only_child
-    | Selector.Empty ->
-        true
-    | Selector.Compound ps
-    | Selector.List ps
-    | Selector.Is ps
-    | Selector.Where ps
-    | Selector.Not ps ->
-        List.for_all ok ps
-    | Selector.Combined (a, _, b) -> ok a && ok b
-    | _ -> false
-  in
-  ok sel
+(* Selectors that can be written as an inline style: no state, no condition -
+   and nothing the matcher cannot decide. Inlining a rule takes it out of the
+   stylesheet, so a selector {!Resolve.supported} does not cover would leave its
+   declarations nowhere at all: matched by nobody here, and gone from the sheet
+   the browser reads. Deriving the set from the matcher is what stops the two
+   from parting ways. *)
+let inlinable = Resolve.supported
 
 (* Elements that never carry inline styles ([html] is stylable so :root custom
    properties land on it). *)

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -88,24 +88,26 @@ let decl_value d =
   | Some i -> String.sub s (i + 1) (String.length s - i - 1)
   | None -> s
 
-(* Every property a kept (conditional / stateful) rule can set, recursing into
-   @media / @supports / @container / @layer blocks. *)
+let add_props acc ds =
+  List.fold_left
+    (fun acc d ->
+      SSet.add (String.lowercase_ascii (Declaration.property_name d)) acc)
+    acc ds
+
+(* Every property a kept (conditional / stateful) rule can set. The descent goes
+   through {!Stylesheet.statement_children}, so every block at-rule is covered:
+   a property missed here is one an inline style could override, and the kept
+   rule would lose a fight it wins in the browser. *)
 let rec props_of_stmts acc stmts =
   List.fold_left
     (fun acc s ->
-      match s with
-      | Stylesheet.Rule r ->
-          List.fold_left
-            (fun a d ->
-              SSet.add (String.lowercase_ascii (Declaration.property_name d)) a)
-            acc
-            (Stylesheet.declarations r)
-      | Stylesheet.Media (_, b)
-      | Stylesheet.Supports (_, b)
-      | Stylesheet.Layer (_, b) ->
-          props_of_stmts acc b
-      | Stylesheet.Container (_, _, b) -> props_of_stmts acc b
-      | _ -> acc)
+      let acc =
+        match s with
+        | Stylesheet.Rule r -> add_props acc (Stylesheet.declarations r)
+        | Stylesheet.Declarations ds -> add_props acc ds
+        | _ -> acc
+      in
+      props_of_stmts acc (Stylesheet.statement_children s))
     acc stmts
 
 (* A [@layer] block applies unconditionally: it only orders competing

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -549,17 +549,7 @@ let map_container_block f = function
   | Origin (origin, content) -> Some (Origin (origin, f content))
   | _ -> None
 
-let statement_children = function
-  | Rule rule -> rule.nested
-  | Layer (_, nested)
-  | Media (_, nested)
-  | Supports (_, nested)
-  | Origin (_, nested)
-  | Starting_style nested
-  | Scope (_, _, nested) ->
-      nested
-  | Container (_, _, nested) -> nested
-  | _ -> []
+let statement_children = Stylesheet.statement_children
 
 let rec map f stmts =
   List.map

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -8,7 +8,34 @@ module type NODE = sig
   val attribute : t -> string -> string option
   val parent : t -> t option
   val children : t -> t list
+  val text_children : t -> string list
 end
+
+type match_result = Matches | No_match | Unsupported
+
+let of_bool b = if b then Matches else No_match
+
+(* [Unsupported] beats both answers in every combining form. That is what keeps
+   it a fact about the selector alone: were a compound to settle on [No_match]
+   because one part failed before an unsupported part was looked at, the same
+   selector would come back unsupported against one node and merely unmatched
+   against another, and {!supported} could not exist. *)
+let conj a b =
+  match (a, b) with
+  | Unsupported, _ | _, Unsupported -> Unsupported
+  | No_match, _ | _, No_match -> No_match
+  | Matches, Matches -> Matches
+
+let disj a b =
+  match (a, b) with
+  | Unsupported, _ | _, Unsupported -> Unsupported
+  | Matches, _ | _, Matches -> Matches
+  | No_match, No_match -> No_match
+
+let negate = function
+  | Matches -> No_match
+  | No_match -> Matches
+  | Unsupported -> Unsupported
 
 let ci a b = String.lowercase_ascii a = String.lowercase_ascii b
 let words s = String.split_on_char ' ' s |> List.filter (( <> ) "")
@@ -157,52 +184,108 @@ module Make (N : NODE) = struct
         | Selector.Hyphen_list s | Selector.Hyphen_list_quoted (s, _) ->
             v = s || starts v (s ^ "-"))
 
-  let rec matches (sel : Selector.t) n : bool =
-    match sel with
-    | Selector.Universal _ -> true
-    | Selector.Element (_, name) -> (
-        match N.name n with Some nm -> ci nm name | None -> false)
-    | Selector.Class c -> List.mem c (N.classes n)
-    | Selector.Id i -> N.id n = Some i
-    | Selector.Attribute (_, name, m, _) -> attr_matches n name m
-    | Selector.Compound ps -> List.for_all (fun p -> matches p n) ps
-    | Selector.List ss | Selector.Is ss | Selector.Where ss ->
-        List.exists (fun s -> matches s n) ss
-    | Selector.Not ss -> not (List.exists (fun s -> matches s n) ss)
-    | Selector.Combined _ -> anchors sel n <> []
-    | Selector.Root -> N.parent n = None
-    | Selector.First_child -> is_first n
-    | Selector.Last_child -> is_last n
-    | Selector.Only_child -> is_first n && is_last n
-    | Selector.Empty -> N.children n = []
-    (* stateful / generated / unknown forms cannot be matched statically *)
+  (* selectors-4 sec. 13.2: [:empty] represents "an element that has no children
+     except, optionally, document white space characters", counting "only
+     element nodes and content nodes ... whose data has a non-zero length", so a
+     comment or a processing instruction never makes an element non-empty and
+     never reaches {!NODE.text_children}. Document white space characters are
+     spaces (U+0020), tabs (U+0009) and segment breaks (css-text-4 sec. 4.3);
+     carriage returns and form feeds become segment breaks when the document is
+     parsed. U+00A0 is none of them, which is why the spec lists
+     [<div>&nbsp;</div>] among the elements [div:empty] does not represent. *)
+  let is_document_white_space = function
+    | ' ' | '\t' | '\n' | '\r' | '\012' -> true
     | _ -> false
+
+  let is_empty n =
+    N.children n = []
+    && List.for_all (String.for_all is_document_white_space) (N.text_children n)
+
+  (* Selectors 4 is far wider than a matcher with no document behind it can
+     decide, so the answer has three values. [Unsupported] is not "does not
+     match": it is "this library has no model for this selector", and a caller
+     must not read it as a negative - {!Apply} keeps such a rule in the
+     stylesheet rather than inline it and drop it. Every arm returning it does
+     so without consulting the node, which is what {!supported} rests on. *)
+  let rec match_selector (sel : Selector.t) n : match_result =
+    match sel with
+    | Selector.Universal None -> Matches
+    | Selector.Element (None, name) ->
+        of_bool (match N.name n with Some nm -> ci nm name | None -> false)
+    | Selector.Class c -> of_bool (List.mem c (N.classes n))
+    | Selector.Id i -> of_bool (N.id n = Some i)
+    | Selector.Attribute (None, name, m, None) ->
+        of_bool (attr_matches n name m)
+    | Selector.Compound ps ->
+        List.fold_left (fun acc p -> conj acc (match_selector p n)) Matches ps
+    | Selector.List ss | Selector.Is ss | Selector.Where ss -> any ss n
+    | Selector.Not ss -> negate (any ss n)
+    | Selector.Combined _ -> (
+        match anchors sel n with
+        | None -> Unsupported
+        | Some [] -> No_match
+        | Some (_ :: _) -> Matches)
+    | Selector.Root -> of_bool (N.parent n = None)
+    | Selector.First_child -> of_bool (is_first n)
+    | Selector.Last_child -> of_bool (is_last n)
+    | Selector.Only_child -> of_bool (is_first n && is_last n)
+    | Selector.Empty -> of_bool (is_empty n)
+    (* A namespace, an attribute case flag, and every stateful, generated or
+       tree-external form. The values compared above are verbatim, so [i] and
+       [s] would both be ignored, and no node here carries a namespace. *)
+    | _ -> Unsupported
+
+  and any ss n =
+    List.fold_left (fun acc s -> disj acc (match_selector s n)) No_match ss
 
   (* [Selector] is right-leaning: [a b > c] is [Combined (a, Descendant,
      Combined (b, Child, c))], so the rightmost compound (the subject) sits at
      the bottom of [right] and each combinator joins its [left] compound to the
      compound *after* it, not to the subject. [anchors sel n] returns the nodes
      where [sel]'s leftmost compound matches when [sel] matches with subject [n]
-     (empty = no match): [right] must match [n], then for every node [a] that
-     [right]'s leftmost compound anchored at, [left] must be [comb]-related to
-     [a]. Threading the anchor this way is what the old subject-only
-     [combinator] missed for any selector with two or more combinators. *)
+     ([Some []] = no match, [None] = no model): [right] must match [n], then for
+     every node [a] that [right]'s leftmost compound anchored at, [left] must be
+     [comb]-related to [a]. Threading the anchor this way is what the old
+     subject-only [combinator] missed for any selector with two or more
+     combinators. *)
   and anchors sel n =
     match sel with
-    | Selector.Combined (left, comb, right) ->
-        anchors right n |> List.concat_map (related left comb)
-    | _ -> if matches sel n then [ n ] else []
+    | Selector.Combined (left, comb, right) -> (
+        (* [left] is asked for its own support, separately from whether [right]
+           found an anchor: stopping at an empty anchor list would let the node
+           decide whether the selector is supported. *)
+        match (anchors right n, match_selector left n, relation comb) with
+        | Some found, left_answer, Some related when left_answer <> Unsupported
+          ->
+            Some (List.concat_map (related left) found)
+        | _ -> None)
+    | _ -> (
+        match match_selector sel n with
+        | Unsupported -> None
+        | No_match -> Some []
+        | Matches -> Some [ n ])
 
-  and related left comb a =
+  (* [None] for a combinator that is not a relation between two nodes of this
+     tree: [||] picks a cell out of the column it belongs to, and the legacy
+     [>>>] and [/deep/] cross a shadow boundary the tree does not have. *)
+  and relation comb =
+    let hits left x = match_selector left x = Matches in
     match comb with
-    | Selector.Descendant -> List.filter (matches left) (ancestors a)
-    | Selector.Child -> (
-        match N.parent a with Some p when matches left p -> [ p ] | _ -> [])
-    | Selector.Next_sibling -> (
-        match imm_pred a with Some s when matches left s -> [ s ] | _ -> [])
+    | Selector.Descendant ->
+        Some (fun left a -> List.filter (hits left) (ancestors a))
+    | Selector.Child ->
+        Some
+          (fun left a ->
+            match N.parent a with Some p when hits left p -> [ p ] | _ -> [])
+    | Selector.Next_sibling ->
+        Some
+          (fun left a ->
+            match imm_pred a with Some s when hits left s -> [ s ] | _ -> [])
     | Selector.Subsequent_sibling ->
-        List.filter (matches left) (preceding_siblings a)
-    | _ -> []
+        Some (fun left a -> List.filter (hits left) (preceding_siblings a))
+    | Selector.Column | Selector.Shadow_piercing | Selector.Shadow_deep -> None
+
+  let matches sel n = match_selector sel n = Matches
 
   (* A selector list has no single specificity: a rule [s1, s2 {...}] cascades
      as if duplicated per branch, so the specificity that applies to [node] is
@@ -264,3 +347,25 @@ module Make (N : NODE) = struct
     List.fold_left upsert [] (bucket ~important:false @ bucket ~important:true)
     |> List.rev_map snd
 end
+
+(* The capability side of the matcher, read off the matcher rather than restated
+   beside it: a second list of the forms it models would be free to drift from
+   the first, and every selector it then wrongly called supported would be one a
+   caller inlines and drops. [Unsupported] never depends on the node, so any
+   node settles the question - this one has nothing on it at all. *)
+module Probe = struct
+  type t = unit
+
+  let equal () () = true
+  let name () = None
+  let id () = None
+  let classes () = []
+  let attribute () _ = None
+  let parent () = None
+  let children () = []
+  let text_children () = []
+end
+
+module Probe_matcher = Make (Probe)
+
+let supported sel = Probe_matcher.match_selector sel () <> Unsupported

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -29,12 +29,54 @@ module type NODE = sig
 
   val children : t -> t list
   (** The child elements, in document order. *)
+
+  val text_children : t -> string list
+  (** The data of the node's direct child text nodes, in document order, and
+      [[]] for an element that holds none. Only text counts: a comment or a
+      processing instruction is not a text node and must not be reported here,
+      since neither affects whether the element is [:empty] (selectors-4 sec.
+      13.2). A backend that answers [[]] for an element that does hold text
+      makes that element match [:empty]. *)
 end
 
+(** What the matcher can say about a selector and a node.
+
+    Selectors 4 describes far more than a matcher with no document behind it can
+    decide, so the negative answer is split in two. [Unsupported] is not "does
+    not match": it says this library has no model for the selector, and a caller
+    must not read it as the selector having been ruled out. *)
+type match_result =
+  | Matches  (** The selector matches the node. *)
+  | No_match  (** The selector is modelled and does not match the node. *)
+  | Unsupported
+      (** The selector is outside what the matcher models, so neither answer is
+          available, for any node. *)
+
+val supported : Selector.t -> bool
+(** [supported sel] is whether the matcher has a model for [sel], that is,
+    whether {!Make.match_selector} answers it with something other than
+    {!constructor-Unsupported}. The answer is a fact about [sel] alone, which is
+    why it needs no node.
+
+    Modelled: the universal, type, class, id and attribute selectors, each
+    without a namespace and, for an attribute, without a case flag; [:root],
+    [:empty], [:first-child], [:last-child], [:only-child]; the descendant,
+    child and sibling combinators; and [:is()], [:where()], [:not()] and
+    selector lists over those - a list is only as modelled as its least modelled
+    branch. Everything else, every stateful pseudo-class and every
+    pseudo-element among it, is not. *)
+
 module Make (N : NODE) : sig
+  val match_selector : Selector.t -> N.t -> match_result
+  (** [match_selector sel node] is what the matcher can say about [sel] and
+      [node]. It is [Unsupported] exactly when [sel] is not {!supported}, for
+      every [node]. *)
+
   val matches : Selector.t -> N.t -> bool
-  (** [matches sel node] is whether [sel] matches [node]. Stateful and generated
-      forms ([:hover], [::before], unknown pseudo-classes, ...) never match. *)
+  (** [matches sel node] is whether [sel] is known to match [node], that is,
+      whether {!match_selector} is [Matches]. It folds [Unsupported] in with
+      [No_match], so a caller that has to tell the two apart wants
+      {!match_selector}. *)
 
   val resolve : Stylesheet.t -> N.t -> Declaration.declaration list
   (** [resolve sheet node] is the declarations that win for [node] after

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -249,6 +249,30 @@ let selector (rule : rule) = rule.selector
 let declarations (rule : rule) = rule.declarations
 let nested (rule : rule) = rule.nested
 
+(* Listed one by one rather than closed with a wildcard: a traversal that
+   descends through this function is only as complete as this match, and a
+   wildcard would silently hide the next block at-rule from every caller. *)
+let statement_children = function
+  | Rule rule -> rule.nested
+  | Layer (_, block)
+  | Media (_, block)
+  | Container (_, _, block)
+  | Supports (_, block)
+  | Moz_document (_, block)
+  | When (_, block)
+  | Else (_, block)
+  | Starting_style block
+  | Origin (_, block)
+  | Scope (_, _, block) ->
+      block
+  | Property _ -> []
+  | Declarations _ | Bang_comment _ | Charset _ | Import _ | Namespace _
+  | Layer_decl _ | Supports_condition _ | Keyframes _ | Webkit_keyframes _
+  | Moz_keyframes _ | Font_face _ | Counter_style _ | Page _
+  | Page_with_margins _ | Font_palette_values _ | Font_feature_values _
+  | View_transition _ | Position_try _ | Viewport _ | Unknown_at_rule _ ->
+      []
+
 (** {1 Pretty Printing} *)
 
 let pp_property_rule : 'a property_rule Pp.t =

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -217,6 +217,16 @@ val declarations : rule -> declaration list
 val nested : rule -> statement list
 (** [nested rule] returns the nested statements of a rule. *)
 
+val statement_children : statement -> block
+(** [statement_children stmt] is the block [stmt] wraps: a rule's nested
+    statements, the body of a grouping at-rule ([@media], [@supports],
+    [@container], [@layer], [@scope], [@starting-style], [@when], [@else],
+    [@-moz-document], and the [Origin] wrapper), and [[]] for a statement that
+    holds no statements of its own. It is the one place that knows which
+    at-rules nest, so a traversal written on top of it cannot miss one: the
+    match is exhaustive, and a block at-rule added to the AST later does not
+    compile until it is listed here. *)
+
 (** {1 Reading/Parsing} *)
 
 val read_rule : ?nested:bool -> Cursor.t -> rule

--- a/test/cli/apply_empty.t
+++ b/test/cli/apply_empty.t
@@ -1,0 +1,34 @@
+CLI: [cascade apply] and the :empty pseudo-class.
+
+Selectors 4 §13.2 says :empty represents "an element that has no
+children except, optionally, document white space characters", and
+that "only element nodes and content nodes (such as [DOM] text nodes,
+and entity references) whose data has a non-zero length must be
+considered as affecting emptiness". Document white space characters
+are spaces (U+0020), tabs (U+0009) and segment breaks (CSS Text 4
+§4.3), so U+00A0 is not one of them.
+
+  $ cat > empty.html <<EOF
+  > <html><head><style>p:empty{color:red}</style></head><body>
+  > <p id="void"></p>
+  > <p id="spaces">  </p>
+  > <p id="text">text</p>
+  > <p id="child"><span></span></p>
+  > <p id="nbsp">&nbsp;</p>
+  > </body></html>
+  > EOF
+
+An element with a text child is not :empty, so it must not be painted;
+one holding nothing but white space is. The entity reference resolves
+to U+00A0, which is not document white space, so that paragraph is not
+empty either.
+
+  $ cascade apply empty.html
+  <html><head></head><body>
+  <p style="color:red" id="void"></p>
+  <p style="color:red" id="spaces">  </p>
+  <p id="text">text</p>
+  <p id="child"><span></span></p>
+  <p id="nbsp">&nbsp;</p>
+  
+  </body></html>

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -5,6 +5,7 @@ type node = {
   id : string option;
   classes : string list;
   attrs : (string * string) list;
+  mutable parent : node option;
   children : node list;
 }
 
@@ -16,14 +17,16 @@ module Node = struct
   let id n = n.id
   let classes n = n.classes
   let attribute n key = List.assoc_opt key n.attrs
-  let parent _ = None
+  let parent n = n.parent
   let children n = n.children
 end
 
 module A = Apply.Make (Node)
 
 let node ?id ?(classes = []) ?(attrs = []) ?(children = []) name =
-  { name; id; classes; attrs; children }
+  let n = { name; id; classes; attrs; parent = None; children } in
+  List.iter (fun c -> c.parent <- Some n) children;
+  n
 
 let inline_style decls =
   Stylesheet.inline_style_of_declarations ~minify:true ~mode:Variables decls
@@ -150,6 +153,85 @@ let non_competing_layers_both_project () =
     "both layers contribute" "color:red;margin:0"
     (projected "@layer a{.x{color:red}}@layer b{.x{margin:0}}")
 
+(* The whole split of [css] over [roots]: the style attribute written onto [n],
+   the <style> body kept beside it, and the count of kept rules. *)
+let check_split name ?roots ~css ~inline ~keep ~kept n =
+  let result = A.compute ~css (Option.value roots ~default:[ n ]) in
+  let decls =
+    match List.find_opt (fun (m, _) -> Node.equal m n) result.styles with
+    | Some (_, decls) -> decls
+    | None -> Alcotest.failf "%s: no assignment for the node" name
+  in
+  Alcotest.(check string) (name ^ ": inline style") inline (inline_style decls);
+  Alcotest.(check string) (name ^ ": kept css") keep result.keep_css;
+  Alcotest.(check int) (name ^ ": kept rules") kept result.kept
+
+(* A [@scope] block gates its rules on where the element sits in the tree, so it
+   has no inline form and stays in the sheet. The properties it sets therefore
+   count as dynamic: moving the competing declaration into the style attribute
+   would place it above the kept rule, which is not where the author put it. *)
+let keeps_property_a_scoped_rule_sets () =
+  check_split "scoped" ~css:".x{color:red}@scope(.root){.x{color:blue}}"
+    ~inline:"" ~keep:".x{color:red}@scope(.root){.x{color:blue}}" ~kept:2
+    (node ~classes:[ "x" ] "p")
+
+(* Same for [@starting-style]: its declarations apply for the frame in which the
+   element is inserted, which no style attribute can express. *)
+let keeps_property_a_starting_style_rule_sets () =
+  check_split "starting-style"
+    ~css:".x{color:red}@starting-style{.x{color:blue}}" ~inline:""
+    ~keep:".x{color:red}@starting-style{.x{color:blue}}" ~kept:2
+    (node ~classes:[ "x" ] "p")
+
+(* A control for both: a conditional block that sets another property competes
+   with nothing, so the split is unchanged. *)
+let non_competing_scoped_rule_still_inlines () =
+  check_split "scoped, other property"
+    ~css:".x{color:red}@scope(.root){.x{margin:0}}" ~inline:"color:red"
+    ~keep:"@scope(.root){.x{margin:0}}" ~kept:1
+    (node ~classes:[ "x" ] "p")
+
+(* The matcher compares attribute values verbatim, so it cannot represent the
+   [i] case flag. A selector it cannot represent has to stay in the sheet:
+   inlining it drops it from the sheet, and it then matches nobody, so the
+   declaration is lost. *)
+let keeps_rule_with_attribute_case_flag () =
+  check_split "case-insensitive attribute" ~css:"p[data-k=\"X\" i]{color:red}"
+    ~inline:"" ~keep:"p[data-k=X i]{color:red}" ~kept:1
+    (node ~attrs:[ ("data-k", "x") ] "p")
+
+(* The control: without the flag the selector is representable, so it projects
+   onto the element and leaves nothing behind. *)
+let projects_attribute_rule_to_inline_style () =
+  check_split "attribute" ~css:"p[data-k=\"X\"]{color:red}" ~inline:"color:red"
+    ~keep:"" ~kept:0
+    (node ~attrs:[ ("data-k", "X") ] "p")
+
+(* Namespaces are not modelled either, so the matcher would answer for [svg|p]
+   what it answers for [p] and paint an HTML paragraph. *)
+let keeps_rule_with_namespaced_element () =
+  check_split "namespaced element"
+    ~css:"@namespace svg url(http://www.w3.org/2000/svg);svg|p{color:red}"
+    ~inline:""
+    ~keep:"@namespace svg url(http://www.w3.org/2000/svg);svg|p{color:red}"
+    ~kept:1 (node "p")
+
+(* [>>>] is a legacy shadow-piercing combinator with no tree relation behind it,
+   so the matcher has no answer for it and the rule stays in the sheet. *)
+let keeps_rule_with_shadow_piercing_combinator () =
+  let span = node "span" in
+  let root = node ~children:[ node ~children:[ span ] "div" ] "section" in
+  check_split "shadow-piercing" ~roots:[ root ] ~css:"div>>>span{color:red}"
+    ~inline:"" ~keep:"div>>>span{color:red}" ~kept:1 span
+
+(* The control: the descendant combinator is modelled, so the same shape of rule
+   projects onto the span. *)
+let projects_descendant_combinator_rule () =
+  let span = node "span" in
+  let root = node ~children:[ node ~children:[ span ] "div" ] "section" in
+  check_split "descendant" ~roots:[ root ] ~css:"div span{color:red}"
+    ~inline:"color:red" ~keep:"" ~kept:0 span
+
 let invalid_css_is_empty () =
   let result = A.compute ~css:"a{" [ node "div" ] in
   Alcotest.(check string)
@@ -182,5 +264,21 @@ let suite =
         layer_outranks_specificity;
       Alcotest.test_case "non-competing layers both project" `Quick
         non_competing_layers_both_project;
+      Alcotest.test_case "keeps the property a scoped rule sets" `Quick
+        keeps_property_a_scoped_rule_sets;
+      Alcotest.test_case "keeps the property a starting-style rule sets" `Quick
+        keeps_property_a_starting_style_rule_sets;
+      Alcotest.test_case "non-competing scoped rule still inlines" `Quick
+        non_competing_scoped_rule_still_inlines;
+      Alcotest.test_case "keeps a rule with an attribute case flag" `Quick
+        keeps_rule_with_attribute_case_flag;
+      Alcotest.test_case "projects an attribute rule to inline style" `Quick
+        projects_attribute_rule_to_inline_style;
+      Alcotest.test_case "keeps a rule with a namespaced element" `Quick
+        keeps_rule_with_namespaced_element;
+      Alcotest.test_case "keeps a rule with a shadow-piercing combinator" `Quick
+        keeps_rule_with_shadow_piercing_combinator;
+      Alcotest.test_case "projects a descendant combinator rule" `Quick
+        projects_descendant_combinator_rule;
       Alcotest.test_case "invalid css is empty" `Quick invalid_css_is_empty;
     ] )

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -19,6 +19,7 @@ module Node = struct
   let attribute n key = List.assoc_opt key n.attrs
   let parent n = n.parent
   let children n = n.children
+  let text_children _ = []
 end
 
 module A = Apply.Make (Node)
@@ -213,8 +214,10 @@ let keeps_rule_with_namespaced_element () =
   check_split "namespaced element"
     ~css:"@namespace svg url(http://www.w3.org/2000/svg);svg|p{color:red}"
     ~inline:""
-    ~keep:"@namespace svg url(http://www.w3.org/2000/svg);svg|p{color:red}"
-    ~kept:1 (node "p")
+      (* The minified printer writes the namespace URL as a string, and the
+         [@namespace] statement counts towards the kept statements. *)
+    ~keep:"@namespace svg\"http://www.w3.org/2000/svg\";svg|p{color:red}"
+    ~kept:2 (node "p")
 
 (* [>>>] is a legacy shadow-piercing combinator with no tree relation behind it,
    so the matcher has no answer for it and the rule stays in the sheet. *)

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -4652,6 +4652,7 @@ module Fuzz = struct
     let attribute _ _ : string option = None
     let parent _ : node option = None
     let children _ = []
+    let text_children _ = []
   end
 
   module R = Resolve.Make (Node)

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -6,16 +6,18 @@ type tree = {
   tname : string;
   tid : string option;
   tclasses : string list;
+  ttext : string list;
   mutable tparent : tree option;
   tchildren : tree list;
 }
 
-let elt ?id ?(classes = []) name children =
+let elt ?id ?(classes = []) ?(text = []) name children =
   let t =
     {
       tname = name;
       tid = id;
       tclasses = classes;
+      ttext = text;
       tparent = None;
       tchildren = children;
     }
@@ -33,6 +35,7 @@ module Node = struct
   let attribute _ _ = None
   let parent t = t.tparent
   let children t = t.tchildren
+  let text_children t = t.ttext
 end
 
 module R = Resolve.Make (Node)
@@ -73,6 +76,68 @@ let test_sibling_then_descendant () =
   yes "sibling then descendant" "div+div span" s2;
   no "descendant of first div" "div+div span" s1;
   yes "subsequent-sibling then child" "div~div>span" s2
+
+let match_result =
+  Alcotest.testable
+    (fun ppf -> function
+      | Resolve.Matches -> Fmt.string ppf "Matches"
+      | Resolve.No_match -> Fmt.string ppf "No_match"
+      | Resolve.Unsupported -> Fmt.string ppf "Unsupported")
+    ( = )
+
+let answers name expected s n =
+  Alcotest.check match_result name expected (R.match_selector (sel s) n)
+
+(* A selector the matcher has no model for is not a selector that fails to
+   match: the caller has to be able to tell the two apart, or it drops a rule it
+   only failed to understand. *)
+let test_unsupported_is_not_no_match () =
+  answers "a modelled hit" Resolve.Matches "span" s2;
+  answers "a modelled miss" Resolve.No_match "div" s2;
+  answers "stateful" Resolve.Unsupported "span:hover" s2;
+  answers "pseudo-element" Resolve.Unsupported "span::before" s2;
+  answers "attribute case flag" Resolve.Unsupported "[id=\"S2\" i]" s2;
+  answers "namespaced type" Resolve.Unsupported "*|span" s2;
+  answers "shadow-piercing combinator" Resolve.Unsupported "div>>>span" s2;
+  (* One unsupported part carries the whole selector, whichever side of the
+     compound, list or negation it sits on, and whether or not the rest
+     matches. *)
+  answers "compound" Resolve.Unsupported "span:hover" s2;
+  answers "list" Resolve.Unsupported "span,div:hover" s2;
+  answers "negation" Resolve.Unsupported ":not(:hover)" s2;
+  answers "left of a combinator" Resolve.Unsupported "div:hover span" s2;
+  answers "left of a combinator that missed" Resolve.Unsupported "p:hover span"
+    s2
+
+(* {!Resolve.supported} is the same answer without a node, which is what lets
+   {!Apply} decide whether a rule may leave the stylesheet. *)
+let test_supported_needs_no_node () =
+  let check name expected s =
+    Alcotest.(check bool) name expected (Resolve.supported (sel s))
+  in
+  check "class" true ".c";
+  check "attribute" true "[data-k=\"X\"]";
+  check "structural" true "p:empty";
+  check "descendant" true "div span";
+  check "attribute case flag" false "[data-k=\"X\" i]";
+  check "namespaced attribute" false "[svg|href]";
+  check "shadow-piercing combinator" false "div>>>span";
+  check "stateful" false ":hover";
+  check "one bad branch spoils the list" false "span,div:hover"
+
+(* selectors-4 sec. 13.2: [:empty] is "an element that has no children except,
+   optionally, document white space characters". White space alone leaves an
+   element empty, any other text does not, and U+00A0 is not document white
+   space (css-text-4 sec. 4.3) - the spec lists [<div>&nbsp;</div>] among the
+   elements [div:empty] does not represent. *)
+let test_empty_counts_text_children () =
+  yes "no children at all" ":empty" (elt "p" []);
+  yes "spaces, tabs and newlines" ":empty" (elt ~text:[ " \t\n" ] "p" []);
+  no "a text child" ":empty" (elt ~text:[ "text" ] "p" []);
+  no "a text child beside white space" ":empty"
+    (elt ~text:[ " "; "text" ] "p" []);
+  no "a no-break space" ":empty" (elt ~text:[ "\u{00a0}" ] "p" []);
+  no "an element child" ":empty" (elt "p" [ elt "span" [] ])
 
 let sheet_of css =
   match Css.of_string css with
@@ -165,6 +230,12 @@ let suite =
       Alcotest.test_case "single combinator" `Quick test_single_combinator;
       Alcotest.test_case "sibling then descendant/child" `Quick
         test_sibling_then_descendant;
+      Alcotest.test_case "unsupported is not no-match" `Quick
+        test_unsupported_is_not_no_match;
+      Alcotest.test_case "supported needs no node" `Quick
+        test_supported_needs_no_node;
+      Alcotest.test_case "empty counts text children" `Quick
+        test_empty_counts_text_children;
       Alcotest.test_case "resolve applies the cascade" `Quick
         test_resolve_cascade;
       Alcotest.test_case "nested layer names order as a tree" `Quick

--- a/test/test_rule_scheduler.ml
+++ b/test/test_rule_scheduler.ml
@@ -38,6 +38,7 @@ module Node = struct
   let attribute _ _ = None
   let parent _ = None
   let children _ = []
+  let text_children _ = []
 end
 
 module R = Resolve.Make (Node)


### PR DESCRIPTION
Two apply gaps: dynamic-property detection missed @scope, @starting-style, @when, @else and @-moz-document (a declaration moved inline above the kept scoped rule that overrides it) - fixed by an exhaustive Stylesheet.statement_children the traversal and Css.fold now share, so an unlisted future at-rule fails to compile. And the inlinable set exceeded the matcher: [data-k="X" i], namespaced selectors and >>> were inlined onto nobody and dropped - the matcher now answers Matches/No_match/Unsupported with Unsupported dominating, capability is derived from a probe instantiation rather than a second list, and :empty counts text children per Selectors 4 sec. 13.2 (space/tab/segment breaks only, so nbsp is non-empty). Resolve.NODE gains text_children (breaking, noted in CHANGES).