### PR TITLE
apply: take the parsed stylesheet, not the CSS text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,11 +28,13 @@
   the parse failed, so a caller could not tell invalid CSS from empty CSS; the
   parse, and the warnings `Css.of_string` collects with it, now stay with the
   caller
+- `Apply.result.kept` counts the rules it says it counts. A block at-rule
+  counted once for its wrapper, so a `@media` holding three rules reported one (#287)
 - `cascade apply` exits 1 when a `<style>` block or the supplementary
   stylesheet parses to nothing, and leaves such a block in the page instead of
   deleting it. It used to delete the block and exit 0, shipping an unstyled
   page under a green status. A supplementary stylesheet that cannot be read is
-  an error rather than no stylesheet at all
+  an error rather than no stylesheet at all (#287)
 
 ### Parsing
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@
   replaced the multi-pass fixpoint (#288)
 - `Resolve.NODE` gains `text_children`, the data of a node's direct child text
   nodes, which `:empty` needs (#286)
+- `Apply.Make(...).compute` takes `~sheet:Stylesheet.t` instead of
+  `~css:string`. It parsed the text itself and answered an empty result when
+  the parse failed, so a caller could not tell invalid CSS from empty CSS; the
+  parse, and the warnings `Css.of_string` collects with it, now stay with the
+  caller
 
 ### Parsing
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,11 @@
   the parse failed, so a caller could not tell invalid CSS from empty CSS; the
   parse, and the warnings `Css.of_string` collects with it, now stay with the
   caller
+- `cascade apply` exits 1 when a `<style>` block or the supplementary
+  stylesheet parses to nothing, and leaves such a block in the page instead of
+  deleting it. It used to delete the block and exit 0, shipping an unstyled
+  page under a green status. A supplementary stylesheet that cannot be read is
+  an error rather than no stylesheet at all
 
 ### Parsing
 

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -53,9 +53,14 @@ let inline_html ~minimal ~html ~extra =
     |> String.concat "\n"
   in
   let css = page_css ^ "\n" ^ extra in
+  let sheet =
+    match Css.of_string css with
+    | Ok p -> p.Css.stylesheet
+    | Error _ -> Cascade.Stylesheet.empty_stylesheet
+  in
   let roots = Soup.children soup |> Soup.elements |> Soup.to_list in
   let { Cascade.Apply.styles; keep_css; kept } =
-    Apply.compute ~minimal ~css roots
+    Apply.compute ~minimal ~sheet roots
   in
   List.iter (fun (node, decls) -> style_node node decls) styles;
   (* the static rules now live on the elements; keep only the un-inlinable

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -46,26 +46,57 @@ let style_node node = function
         (Sheet.inline_style_of_declarations ~minify:true ~mode:Variables decls)
         node
 
-let inline_html ~minimal ~html ~extra =
+(* Prefix every line of a multi-line diagnostic so a downstream [grep -v
+   "warning"] filters the whole entry, not just the first line. *)
+let report_warning w =
+  Cascade.Error.to_string w |> String.split_on_char '\n'
+  |> List.iter (fun line -> Fmt.epr "warning: %s@." line)
+
+(* [Some sheet] is CSS the projection can use. [None] is a source the parser
+   could not turn into any: a fatal syntax error, or - keyed as in [cascade fmt]
+   - a recovery that left nothing to serialise from an input that had something
+   to drop. Neither is a source that was legitimately empty, which parses
+   without a word and contributes nothing. [note] says what the caller does
+   about the loss. *)
+let parse_source ~filename ~note css =
+  match Css.of_string ~filename css with
+  | Error e ->
+      Fmt.epr "Error: %s@." (Cascade.Error.to_string e);
+      None
+  | Ok { Css.stylesheet; warnings } ->
+      List.iter report_warning warnings;
+      if warnings <> [] && Css.to_string ~minify:true stylesheet = "" then begin
+        Fmt.epr "Error: %s: parse dropped every rule%s@." filename note;
+        None
+      end
+      else Some stylesheet
+
+let inline_html ~minimal ~filename ~html ~extra =
   let soup = Soup.parse html in
-  let page_css =
-    Soup.select "style" soup |> Soup.to_list |> List.concat_map Soup.texts
-    |> String.concat "\n"
+  (* Each <style> block parses on its own, which is how a browser reads them
+     too, so a block the parser cannot use is known apart from the rest. *)
+  let blocks =
+    Soup.select "style" soup |> Soup.to_list
+    |> List.mapi (fun i node ->
+        let filename = Fmt.str "%s:<style>#%d" filename (i + 1) in
+        let css = String.concat "" (Soup.texts node) in
+        (node, parse_source ~filename ~note:"; keeping the block verbatim" css))
   in
-  let css = page_css ^ "\n" ^ extra in
   let sheet =
-    match Css.of_string css with
-    | Ok p -> p.Css.stylesheet
-    | Error _ -> Cascade.Stylesheet.empty_stylesheet
+    List.concat_map (fun (_, s) -> Option.value s ~default:[]) blocks @ extra
   in
   let roots = Soup.children soup |> Soup.elements |> Soup.to_list in
   let { Cascade.Apply.styles; keep_css; kept } =
     Apply.compute ~minimal ~sheet roots
   in
   List.iter (fun (node, decls) -> style_node node decls) styles;
-  (* the static rules now live on the elements; keep only the un-inlinable
-     ones. *)
-  Soup.select "style" soup |> Soup.iter Soup.delete;
+  (* The static rules now live on the elements, so the blocks they came from go.
+     A block the parser could not use stays exactly where it was: deleting it
+     would ship a page with neither the inline styles it should have had nor the
+     CSS text a browser might still make something of. *)
+  List.iter
+    (fun (node, sheet) -> if Option.is_some sheet then Soup.delete node)
+    blocks;
   (if keep_css <> "" then
      let style = Soup.create_element ~inner_text:keep_css "style" in
      match Soup.select_one "head" soup with
@@ -74,7 +105,8 @@ let inline_html ~minimal ~html ~extra =
          match Soup.select_one "html" soup with
          | Some h -> Soup.prepend_child h style
          | None -> ()));
-  (Soup.to_string soup, kept)
+  let lost = List.exists (fun (_, s) -> Option.is_none s) blocks in
+  (Soup.to_string soup, kept, lost)
 
 (* ---------- cmdliner ---------- *)
 let read_file path =
@@ -85,19 +117,33 @@ let read_file path =
     Ok s
   with Sys_error msg -> err_msg "Error reading %s: %s" path msg
 
+(* Cmdliner's [file] conv only checks that the path exists, so a directory or a
+   file with no read permission reaches the command. That is a usage error, and
+   it stops the run before it writes a page silently missing those styles - a
+   stylesheet nobody can read is not the same thing as no stylesheet. A file
+   that reads but does not parse is reported and the page is still written,
+   without it. *)
+let read_extra = function
+  | None -> Ok (Some Sheet.empty_stylesheet)
+  | Some f -> Result.map (parse_source ~filename:f ~note:"") (read_file f)
+
 let run minimal html_file css_file () =
-  match read_file html_file with
-  | Error _ as e -> e
-  | Ok html ->
-      let extra =
-        match css_file with
-        | Some f -> ( match read_file f with Ok s -> s | Error _ -> "")
-        | None -> ""
+  match
+    Result.bind (read_file html_file) (fun html ->
+        Result.map (fun extra -> (html, extra)) (read_extra css_file))
+  with
+  | Error e -> Error e
+  | Ok (html, extra) ->
+      let out, kept, lost =
+        inline_html ~minimal ~filename:html_file ~html
+          ~extra:(Option.value extra ~default:Sheet.empty_stylesheet)
       in
-      let out, kept = inline_html ~minimal ~html ~extra in
       if kept > 0 then
         Fmt.epr "Kept %d rule(s) with no inline form in a <style> block.@." kept;
       print_string out;
+      (* CSS that went missing is a result, not a usage error: exit 1, distinct
+         from cmdliner's reserved codes, so a build can gate on it. *)
+      if lost || Option.is_none extra then Stdlib.exit 1;
       Ok ()
 
 let html_arg =
@@ -133,6 +179,17 @@ let cmd =
         "Rules that have no inline form ($(b,:hover), media queries, \
          pseudo-elements, $(b,@keyframes)) cannot be projected onto an element \
          and are kept in a single $(b,<style>) block.";
+      `P
+        "A $(b,<style>) block the parser cannot use is left in the page \
+         exactly as it was, rather than deleted along with the blocks that \
+         were projected.";
+      `S Manpage.s_exit_status;
+      `P "$(tname) exits with:";
+      `I ("0", "on success, including a parse that recovered some of the input");
+      `I
+        ( "1",
+          "if a $(b,<style>) block or $(i,EXTRA.css) parsed to nothing; the \
+           page is still written, without those styles" );
     ]
   in
   Cmd.v (Cmd.info "apply" ~doc ~man) Term.(term_result term)

--- a/fuzz/fuzz_apply.ml
+++ b/fuzz/fuzz_apply.ml
@@ -30,6 +30,13 @@ let color buf i = pick [ "#abc"; "#123"; "#f00"; "#00f"; "red"; "blue" ] buf i
 let inline_style ds =
   Stylesheet.inline_style_of_declarations ~minify:true ~mode:Variables ds
 
+(* [A.compute] takes a parsed sheet. The generator only assembles well-formed
+   rules, so a fatal parse error is a bug in the generator, not a finding. *)
+let parse css =
+  match Css.of_string css with
+  | Ok p -> p.Css.stylesheet
+  | Error e -> fail (Error.to_string e)
+
 (* Compare two projections structurally: the inline style written onto each node
    in tree order, plus the number of rules kept in the <style>. The kept body
    itself is left out because a kept rule stays inside its layer, so its text
@@ -75,8 +82,8 @@ let test_layer_wrapping_invariant buf =
           layer "states" hover_rule;
         ]
   in
-  let r0 = summary (A.compute ~css:reference roots) in
-  let r1 = summary (A.compute ~css:layered roots) in
+  let r0 = summary (A.compute ~sheet:(parse reference) roots) in
+  let r1 = summary (A.compute ~sheet:(parse layered) roots) in
   if r0 <> r1 then fail "layer wrapping changed the projected styles"
 
 let suite =

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -153,11 +153,19 @@ let rec split ~is_dyn stmts =
   in
   (List.rev keep, List.rev inline)
 
-(* Kept rules, for reporting: a [@layer] wrapper is not itself a rule. *)
+(* Kept rules, for reporting. A block at-rule is not itself a rule: what it
+   keeps out of the inline projection is the rules it holds, so a [@media] with
+   three rules kept three. One that holds no statements of its own - a
+   [@font-face], a [@keyframes], a [@layer] statement - is itself the one thing
+   kept, so it counts once. *)
 let rec count_kept stmts =
   List.fold_left
-    (fun n -> function
-      | Stylesheet.Layer (_, b) -> n + count_kept b | _ -> n + 1)
+    (fun n s ->
+      let inner = count_kept (Stylesheet.statement_children s) in
+      match s with
+      | Stylesheet.Rule _ -> n + 1 + inner
+      | _ when inner = 0 -> n + 1
+      | _ -> n + inner)
     0 stmts
 
 type 'node assignment = 'node * Declaration.declaration list
@@ -168,7 +176,7 @@ type 'node result = {
       (** Each element with the declarations to set on its [style] attribute. *)
   keep_css : string;
       (** The rules with no inline form, serialised as a [<style>] body. *)
-  kept : int;  (** Count of kept rules, for reporting. *)
+  kept : int;  (** How many rules [keep_css] holds, for reporting. *)
 }
 
 module Make (Node : Resolve.NODE) = struct

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -227,29 +227,25 @@ module Make (Node : Resolve.NODE) = struct
         acc (Node.children node)
     end
 
-  let compute ?(minimal = false) ~css roots =
-    match Css.of_string css with
-    | Error _ -> { styles = []; keep_css = ""; kept = 0 }
-    | Ok p ->
-        (* Flatten nesting up front, so the split and {!R.resolve} see the same
-           flat rules. *)
-        let stmts = Flatten.block p.Css.stylesheet in
-        (* Properties a kept rule can override must stay in the cascade. *)
-        let dyn = dynamic_props SSet.empty stmts in
-        let is_dyn d =
-          SSet.mem (String.lowercase_ascii (Declaration.property_name d)) dyn
-        in
-        let keep, inline = split ~is_dyn stmts in
-        let keep_css =
-          if keep = [] then ""
-          else Css.to_string ~minify:true (Stylesheet.v keep)
-        in
-        let inline_sheet = Stylesheet.v inline in
-        let styles =
-          List.fold_left
-            (fun acc root -> walk ~minimal inline_sheet [] root acc)
-            [] roots
-          |> List.rev
-        in
-        { styles; keep_css; kept = count_kept keep }
+  let compute ?(minimal = false) ~sheet roots =
+    (* Flatten nesting up front, so the split and {!R.resolve} see the same flat
+       rules. *)
+    let stmts = Flatten.block sheet in
+    (* Properties a kept rule can override must stay in the cascade. *)
+    let dyn = dynamic_props SSet.empty stmts in
+    let is_dyn d =
+      SSet.mem (String.lowercase_ascii (Declaration.property_name d)) dyn
+    in
+    let keep, inline = split ~is_dyn stmts in
+    let keep_css =
+      if keep = [] then "" else Css.to_string ~minify:true (Stylesheet.v keep)
+    in
+    let inline_sheet = Stylesheet.v inline in
+    let styles =
+      List.fold_left
+        (fun acc root -> walk ~minimal inline_sheet [] root acc)
+        [] roots
+      |> List.rev
+    in
+    { styles; keep_css; kept = count_kept keep }
 end

--- a/lib/apply.mli
+++ b/lib/apply.mli
@@ -17,11 +17,18 @@ type 'node result = {
 }
 
 module Make (Node : Resolve.NODE) : sig
-  val compute : ?minimal:bool -> css:string -> Node.t list -> Node.t result
-  (** [compute ?minimal ~css roots] resolves [css] against the element trees
+  val compute :
+    ?minimal:bool -> sheet:Stylesheet.t -> Node.t list -> Node.t result
+  (** [compute ?minimal ~sheet roots] resolves [sheet] against the element trees
       rooted at [roots] and returns, for each element, the declarations to set
       on its [style] attribute, the un-inlinable rules as a [<style>] body, and
       the count of kept rules. [minimal] (default [false]) drops an inherited
       declaration that only restates the value the element already inherits from
-      its ancestors. A [css] that does not parse yields an empty result. *)
+      its ancestors.
+
+      The argument is a parsed stylesheet rather than CSS text so that the parse
+      stays with the caller: a stylesheet {!Css.of_string} had to recover, and
+      one that was empty to begin with, both project onto nothing, and only the
+      {!Css.field-warnings} it returns tell them apart. Parsing here would
+      swallow that difference and report the two as the same empty result. *)
 end

--- a/lib/apply.mli
+++ b/lib/apply.mli
@@ -13,7 +13,11 @@ type 'node result = {
   keep_css : string;
       (** The rules with no inline form, serialised as a minified [<style>]
           body, or [""] when there are none. *)
-  kept : int;  (** Count of kept rules, for reporting. *)
+  kept : int;
+      (** How many rules {!field-keep_css} holds, for reporting. A block at-rule
+          contributes the rules inside it rather than itself; one that holds no
+          statements of its own ([@font-face], [@keyframes]) counts as the one
+          thing it keeps. *)
 }
 
 module Make (Node : Resolve.NODE) : sig

--- a/test/cli/apply_errors.t
+++ b/test/cli/apply_errors.t
@@ -1,0 +1,73 @@
+CLI: `apply` must not report success when it lost CSS.
+
+`cascade apply page.html > out.html` is a build step. CSS it cannot parse
+is dropped and the command exits 0, so the redirect writes a page with no
+styling and the build sees a green status. The warnings on stderr are easy
+to miss and impossible to gate on; the exit status is not.
+
+A `<style>` block the parser cannot use is kept exactly as it was. Deleting
+it would ship a page with neither the inline styles it should have had nor
+the CSS text a browser might still make something of.
+
+  $ cat > broken.html <<EOF
+  > <html><head><style>@@@@ }}} {{{ !!! ;;;</style></head><body><p>hi</p></body></html>
+  > EOF
+  $ cascade apply broken.html > out.html 2> err.txt
+  [1]
+  $ cat out.html
+  <html><head><style>@@@@ }}} {{{ !!! ;;;</style></head><body><p>hi</p>
+  </body></html>
+  $ grep '^Error' err.txt
+  Error: broken.html:<style>#1: parse dropped every rule; keeping the block verbatim
+
+The warnings that explain the drop are still reported.
+
+  $ grep -c '^warning' err.txt
+  4
+
+The control: a page whose CSS parses is projected exactly as before, and the
+exit status stays 0.
+
+  $ cat > ok.html <<EOF
+  > <html><head><style>p{color:red}p:hover{margin:0}</style></head><body><p>hi</p></body></html>
+  > EOF
+  $ cascade apply ok.html 2> /dev/null
+  <html><head><style>p:hover{margin:0}</style></head><body><p style="color:red">hi</p>
+  </body></html>
+
+A supplementary stylesheet that does not parse is an error too. There is no
+block to keep here, so the page is written with whatever its own `<style>`
+blocks gave it and the exit status says the extra sheet did not apply.
+
+  $ cat > page.html <<EOF
+  > <html><head></head><body><p>hi</p></body></html>
+  > EOF
+  $ cat > bad.css <<EOF
+  > @@@@ }}} {{{ !!! ;;;
+  > EOF
+  $ cascade apply page.html bad.css > out2.html 2> err2.txt
+  [1]
+  $ grep '^Error' err2.txt
+  Error: bad.css: parse dropped every rule
+
+A supplementary stylesheet that cannot be read at all never reaches the
+parser: cmdliner's `file` conv only checks that the path exists, so a
+directory gets through. Reading it fails, and an unreadable stylesheet is
+not the same thing as no stylesheet.
+
+  $ mkdir extra.d
+  $ cascade apply page.html extra.d > out3.html 2> err3.txt
+  [124]
+  $ grep -c '^cascade: Error reading extra.d' err3.txt
+  1
+  $ wc -c < out3.html | tr -d ' '
+  0
+
+The control: a supplementary stylesheet that reads and parses still applies.
+
+  $ cat > good.css <<EOF
+  > p{margin:0}
+  > EOF
+  $ cascade apply page.html good.css 2> /dev/null
+  <html><head></head><body><p style="margin:0">hi</p>
+  </body></html>

--- a/test/cli/apply_errors.t
+++ b/test/cli/apply_errors.t
@@ -23,7 +23,7 @@ the CSS text a browser might still make something of.
 The warnings that explain the drop are still reported.
 
   $ grep -c '^warning' err.txt
-  4
+  3
 
 The control: a page whose CSS parses is projected exactly as before, and the
 exit status stays 0.

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -235,6 +235,28 @@ let projects_descendant_combinator_rule () =
   check_split "descendant" ~roots:[ root ] ~css:"div span{color:red}"
     ~inline:"color:red" ~keep:"" ~kept:0 span
 
+(* [kept] is reported to the user as a number of rules, so a grouping at-rule
+   contributes the rules inside it rather than counting once for its wrapper: a
+   @media block holding three rules keeps three rules out of the inline
+   projection. *)
+let kept_counts_the_rules_a_media_block_holds () =
+  let n = node ~classes:[ "a" ] "p" in
+  let result =
+    A.compute
+      ~css:"@media(min-width:10px){.a{color:red}.b{color:blue}.c{color:green}}"
+      [ n ]
+  in
+  Alcotest.(check int) "kept rules" 3 result.kept
+
+(* An at-rule that holds no rules of its own is itself the one thing kept, so it
+   counts once. *)
+let kept_counts_a_rule_less_at_rule_once () =
+  let n = node ~classes:[ "a" ] "p" in
+  let result =
+    A.compute ~css:"@font-face{font-family:x;src:url(a.woff2)}" [ n ]
+  in
+  Alcotest.(check int) "kept rules" 1 result.kept
+
 let invalid_css_is_empty () =
   let result = A.compute ~css:"a{" [ node "div" ] in
   Alcotest.(check string)
@@ -283,5 +305,9 @@ let suite =
         keeps_rule_with_shadow_piercing_combinator;
       Alcotest.test_case "projects a descendant combinator rule" `Quick
         projects_descendant_combinator_rule;
+      Alcotest.test_case "kept counts the rules a media block holds" `Quick
+        kept_counts_the_rules_a_media_block_holds;
+      Alcotest.test_case "kept counts a rule-less at-rule once" `Quick
+        kept_counts_a_rule_less_at_rule_once;
       Alcotest.test_case "invalid css is empty" `Quick invalid_css_is_empty;
     ] )

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -32,9 +32,16 @@ let node ?id ?(classes = []) ?(attrs = []) ?(children = []) name =
 let inline_style decls =
   Stylesheet.inline_style_of_declarations ~minify:true ~mode:Variables decls
 
+(* [A.compute] takes a parsed sheet, so the fixtures parse here. They are all
+   meant to parse; one that does not is a broken test, not a case under test. *)
+let parse css =
+  match Css.of_string css with
+  | Ok p -> p.Css.stylesheet
+  | Error e -> Alcotest.failf "fixture did not parse: %s" (Error.to_string e)
+
 let projects_static_rule_to_inline_style () =
   let n = node ~classes:[ "card" ] "div" in
-  let result = A.compute ~css:".card{color:red;margin:0}" [ n ] in
+  let result = A.compute ~sheet:(parse ".card{color:red;margin:0}") [ n ] in
   match result.styles with
   | [ (node, decls) ] ->
       Alcotest.(check bool) "same node" true (Node.equal node n);
@@ -46,7 +53,9 @@ let projects_static_rule_to_inline_style () =
 
 let keeps_stateful_rule_in_css () =
   let n = node ~classes:[ "card" ] "div" in
-  let result = A.compute ~css:".card{margin:0}.card:hover{color:blue}" [ n ] in
+  let result =
+    A.compute ~sheet:(parse ".card{margin:0}.card:hover{color:blue}") [ n ]
+  in
   Alcotest.(check string)
     "inline static rule" "margin:0"
     (match result.styles with
@@ -60,7 +69,9 @@ let keeps_stateful_rule_in_css () =
    just like top-level ones instead of being kept wholesale in a <style>. *)
 let projects_layered_rule_to_inline_style () =
   let n = node ~classes:[ "card" ] "div" in
-  let result = A.compute ~css:"@layer u{.card{color:red;margin:0}}" [ n ] in
+  let result =
+    A.compute ~sheet:(parse "@layer u{.card{color:red;margin:0}}") [ n ]
+  in
   match result.styles with
   | [ (node, decls) ] ->
       Alcotest.(check bool) "same node" true (Node.equal node n);
@@ -76,7 +87,9 @@ let projects_layered_rule_to_inline_style () =
 let keeps_stateful_rule_inside_layer_in_css () =
   let n = node ~classes:[ "card" ] "div" in
   let result =
-    A.compute ~css:"@layer u{.card{margin:0}.card:hover{color:blue}}" [ n ]
+    A.compute
+      ~sheet:(parse "@layer u{.card{margin:0}.card:hover{color:blue}}")
+      [ n ]
   in
   Alcotest.(check string)
     "inline static rule" "margin:0"
@@ -91,7 +104,7 @@ let keeps_stateful_rule_inside_layer_in_css () =
    declaration list. *)
 let projected css =
   let n = node ~classes:[ "x" ] "p" in
-  let result = A.compute ~css [ n ] in
+  let result = A.compute ~sheet:(parse css) [ n ] in
   match result.styles with
   | [ (_, decls) ] -> inline_style decls
   | _ -> Alcotest.fail "expected one inline assignment"
@@ -157,7 +170,9 @@ let non_competing_layers_both_project () =
 (* The whole split of [css] over [roots]: the style attribute written onto [n],
    the <style> body kept beside it, and the count of kept rules. *)
 let check_split name ?roots ~css ~inline ~keep ~kept n =
-  let result = A.compute ~css (Option.value roots ~default:[ n ]) in
+  let result =
+    A.compute ~sheet:(parse css) (Option.value roots ~default:[ n ])
+  in
   let decls =
     match List.find_opt (fun (m, _) -> Node.equal m n) result.styles with
     | Some (_, decls) -> decls
@@ -243,7 +258,9 @@ let kept_counts_the_rules_a_media_block_holds () =
   let n = node ~classes:[ "a" ] "p" in
   let result =
     A.compute
-      ~css:"@media(min-width:10px){.a{color:red}.b{color:blue}.c{color:green}}"
+      ~sheet:
+        (parse
+           "@media(min-width:10px){.a{color:red}.b{color:blue}.c{color:green}}")
       [ n ]
   in
   Alcotest.(check int) "kept rules" 3 result.kept
@@ -253,19 +270,43 @@ let kept_counts_the_rules_a_media_block_holds () =
 let kept_counts_a_rule_less_at_rule_once () =
   let n = node ~classes:[ "a" ] "p" in
   let result =
-    A.compute ~css:"@font-face{font-family:x;src:url(a.woff2)}" [ n ]
+    A.compute ~sheet:(parse "@font-face{font-family:x;src:url(a.woff2)}") [ n ]
   in
   Alcotest.(check int) "kept rules" 1 result.kept
 
-let invalid_css_is_empty () =
-  let result = A.compute ~css:"a{" [ node "div" ] in
-  Alcotest.(check string)
-    "inline declarations" ""
-    (match result.styles with
-    | [ (_, decls) ] -> inline_style decls
-    | _ -> Alcotest.fail "expected one inline assignment");
-  Alcotest.(check string) "kept css" "" result.keep_css;
-  Alcotest.(check int) "kept count" 0 result.kept
+(* A stylesheet the parser had to recover and an empty one project onto exactly
+   the same nothing, so the projection cannot be what tells them apart. Taking a
+   parsed sheet leaves that to {!Css.of_string}, whose warnings the caller reads
+   before any of this runs; parsing the CSS text here would swallow them and
+   report both as the same empty result. ["a{"] is neither case: CSS Syntax 3
+   sec. 5.4 closes the block at EOF, so it is a valid rule with no
+   declarations. *)
+let invalid_css_is_not_empty_css () =
+  let warnings css =
+    match Css.of_string css with
+    | Ok p -> p.Css.warnings
+    | Error e ->
+        Alcotest.failf "unexpected fatal parse error: %s" (Error.to_string e)
+  in
+  Alcotest.(check bool)
+    "recovered CSS carries diagnostics" true
+    (warnings "@@@@ }}} {{{ !!! ;;;" <> []);
+  Alcotest.(check bool) "empty CSS carries none" true (warnings "" = []);
+  Alcotest.(check bool)
+    "a block closed at EOF carries none either" true
+    (warnings "a{" = []);
+  List.iter
+    (fun css ->
+      let result = A.compute ~sheet:(parse css) [ node "div" ] in
+      Alcotest.(check string)
+        ("inline declarations: " ^ css)
+        ""
+        (match result.styles with
+        | [ (_, decls) ] -> inline_style decls
+        | _ -> Alcotest.fail "expected one inline assignment");
+      Alcotest.(check string) ("kept css: " ^ css) "" result.keep_css;
+      Alcotest.(check int) ("kept count: " ^ css) 0 result.kept)
+    [ "@@@@ }}} {{{ !!! ;;;"; ""; "a{" ]
 
 let suite =
   ( "apply",
@@ -309,5 +350,6 @@ let suite =
         kept_counts_the_rules_a_media_block_holds;
       Alcotest.test_case "kept counts a rule-less at-rule once" `Quick
         kept_counts_a_rule_less_at_rule_once;
-      Alcotest.test_case "invalid css is empty" `Quick invalid_css_is_empty;
+      Alcotest.test_case "invalid css is not empty css" `Quick
+        invalid_css_is_not_empty_css;
     ] )

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -203,9 +203,12 @@ let test_resolve_anonymous_layers () =
    block. *)
 let test_apply_compute () =
   let module A = Apply.Make (Node) in
-  let result : tree Apply.result =
-    A.compute ~css:"#s2{font-weight:700}#s2:hover{color:#00f}" [ section ]
+  let sheet =
+    match Css.of_string "#s2{font-weight:700}#s2:hover{color:#00f}" with
+    | Ok p -> p.Css.stylesheet
+    | Error e -> Alcotest.failf "fixture did not parse: %s" (Error.to_string e)
   in
+  let result : tree Apply.result = A.compute ~sheet [ section ] in
   let s2_decls =
     List.find_map
       (fun (n, decls) -> if Node.equal n s2 then Some decls else None)


### PR DESCRIPTION
cascade apply deleted a <style> block it could not parse (page shipped unstyled, exit 0) and treated an unreadable supplementary stylesheet as no CSS at all. The root cause is that Css.of_string returns Ok with warnings and an empty sheet for garbage, so no result type on compute could see it: Apply.Make(_).compute now takes ~sheet:Stylesheet.t and the parse stays with the caller (breaking, in CHANGES). The CLI keeps an unusable block verbatim and exits 1, mirroring fmt's #273 contract; style blocks now parse independently as a browser reads them; and result.kept counts rules, not wrapper statements. Stacked on #286.