### PR TITLE
stats: scope the profiling counters to one run

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,12 @@
   normalisation key and a blind spot in the walk both reading as success.
   ``Css_compare.equal ~mode:`Canonical`` answers on the same bytes, and
   `Css_compare.No_diff` no longer carries the two canonical forms (#290)
+- Optimizer profiling is per run: `Css.optimize` and `Optimize.stylesheet` take
+  `?stats:Stats.t` and `Stats.snapshot` reads back an immutable record.
+  `Optimize.counters`, `Optimize.pass_times`, `Optimize.iteration_stats` and
+  `Optimize.set_profile` are gone, along with the per-pass table and the
+  marginal-stop counter, which no pass had written since the DAG scheduler
+  replaced the multi-pass fixpoint (#288)
 
 ### Parsing
 

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -1,64 +1,38 @@
 open Cascade
 open Cmdliner
 
-let profile_entries () =
-  let module S = Cascade.Stats in
-  let total = ref 0.0 in
-  let entries =
-    Hashtbl.fold
-      (fun name s acc ->
-        total := !total +. s.S.time;
-        (name, s) :: acc)
-      S.pass_times []
-  in
-  let entries =
-    List.sort (fun (_, a) (_, b) -> compare b.S.time a.S.time) entries
-  in
-  (!total, entries)
-
-let print_iteration_profile () =
-  let module S = Cascade.Stats in
-  match S.iteration_stats () with
+let print_iteration_profile (report : Stats.snapshot) =
+  match report.iteration_stats with
   | [] -> ()
   | iteration_stats ->
       Fmt.epr "  %-3s %-4s %-4s %9s %9s %9s %9s %7s %7s %8s@." "fp" "iter"
         "giter" "rules_in" "rules_out" "bytes_in" "saved" "passes" "chg" "time";
       List.iter
-        (fun (s : S.iteration_stat) ->
+        (fun (s : Stats.iteration_stat) ->
           Fmt.epr "  %-3d %-4d %-4d %9d %9d %9d %9d %7d %7d %7.3fs@." s.fixpoint
             s.local_iteration s.iteration s.before_rules s.after_rules
             s.before_bytes s.bytes_saved s.active_passes s.changed_passes
             s.elapsed)
         (List.rev iteration_stats)
 
-let print_pass_profile entries =
-  let module S = Cascade.Stats in
-  Fmt.epr "  %-22s %8s %6s %6s %9s %9s@." "pass" "time" "calls" "chg" "rules_in"
-    "rules_out";
-  List.iter
-    (fun (name, s) ->
-      Fmt.epr "  %-22s %7.3fs %6d %6d %9d %9d@." name s.S.time s.S.calls
-        s.S.changes s.S.rules_in s.S.rules_out)
-    entries
-
-let print_factor_profile_footer () =
-  let module S = Cascade.Stats in
-  Fmt.epr "@.factor stops: %d marginal, committed savings: %d bytes@."
-    S.counters.marginal_stops S.counters.factor_bytes_saved;
+let print_factor_profile_footer (counters : Stats.counters) =
+  Fmt.epr "@.factor committed savings: %d bytes@." counters.factor_bytes_saved;
   Fmt.epr "factor preflight: %d skipped, estimated gain %d bytes@."
-    S.counters.factor_fixpoints_skipped S.counters.factor_preflight_gain;
-  if S.counters.factor_transfer_reverts > 0 then
+    counters.factor_fixpoints_skipped counters.factor_preflight_gain;
+  if counters.factor_transfer_reverts > 0 then
     Fmt.epr "factor transfer gate: %d segments reverted@."
-      S.counters.factor_transfer_reverts
+      counters.factor_transfer_reverts
 
-let report_profile () =
-  let module S = Cascade.Stats in
-  let total, entries = profile_entries () in
+let report_profile (report : Stats.snapshot) =
+  let total =
+    List.fold_left
+      (fun total (s : Stats.iteration_stat) -> total +. s.elapsed)
+      0.0 report.iteration_stats
+  in
   Fmt.epr "factor fixpoint (%d runs, %d iterations, total %.3fs):@."
-    S.counters.factor_fixpoints_run S.counters.iterations total;
-  print_iteration_profile ();
-  print_pass_profile entries;
-  print_factor_profile_footer ()
+    report.counters.factor_fixpoints_run report.counters.iterations total;
+  print_iteration_profile report;
+  print_factor_profile_footer report.counters
 
 let resolve_inline_imports ~input_path stylesheet =
   if input_path = "-" then begin
@@ -93,21 +67,20 @@ let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
       if inline_vars_flag then Cli_inline_vars.run ~keep_vars stylesheet
       else stylesheet
     in
+    let stats = Stats.v ~profile () in
     let stylesheet =
-      if minify then begin
-        Cascade.Stats.set_profile profile;
+      if minify then
         (* Raw output ships uncompressed, so the aggressive global-factoring
            fixpoint is worth its cost only here: under the transfer objective
            its extra raw-byte wins grow gzip and get discarded anyway. *)
         let aggressive = objective = `Raw in
         Css.optimize ~scope ~flatten_nesting ~lossless ~enforce_spec ~aggressive
-          ~closed_world ~objective stylesheet
-      end
+          ~closed_world ~objective ~stats stylesheet
       else stylesheet
     in
     let written = emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet in
     Cli_io.check_not_all_dropped input ~written;
-    if profile then report_profile ()
+    if profile then report_profile (Stats.snapshot stats)
   with
   | Sys_error msg ->
       Fmt.epr "Error: %s@." msg;
@@ -240,9 +213,9 @@ let closed_world_arg =
 
 let profile_arg =
   let doc =
-    "Print per-pass timings of the optimizer factoring fixpoint to stderr \
-     after the run. Use to triage which pass dominates on a slow input. Has no \
-     effect without $(b,--minify)."
+    "Print per-iteration timings of the optimizer factoring fixpoint to stderr \
+     after the run. Use to triage which input shape dominates a slow run. Has \
+     no effect without $(b,--minify)."
   in
   Arg.(value & flag & info [ "profile" ] ~doc)
 

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -881,10 +881,11 @@ let inline_style_of_declarations ?(optimize = false) ?minify ?mode declarations
   inline_style_of_declarations ?minify ?mode declarations
 
 let optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
-    ?regroup ?closed_world ?objective ?prune_unused_custom_props stylesheet =
+    ?regroup ?closed_world ?objective ?prune_unused_custom_props ?stats
+    stylesheet =
   Optimize.stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec
     ?aggressive ?regroup ?closed_world ?objective ?prune_unused_custom_props
-    stylesheet
+    ?stats stylesheet
 
 let flatten_nesting = Optimize.flatten_nesting
 let canonicalize_rule_order = Rule_order.canonicalize

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7726,6 +7726,7 @@ val optimize :
   ?closed_world:bool ->
   ?objective:[ `Raw | `Transfer ] ->
   ?prune_unused_custom_props:bool ->
+  ?stats:Stats.t ->
   t ->
   t
 (** [optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
@@ -7770,7 +7771,10 @@ val optimize :
     When [prune_unused_custom_props] is [true] (default [false]) custom-property
     bindings referenced by no [var()] anywhere are dropped. Opt-in: it assumes a
     complete stylesheet with no out-of-band reader (another stylesheet, or
-    [getComputedStyle]), the same closed-world assumption as {!inline_vars}. *)
+    [getComputedStyle]), the same closed-world assumption as {!inline_vars}.
+
+    [stats] records what this run did; read it back with {!Stats.snapshot}.
+    Without it the run counts into a recorder of its own that nobody reads. *)
 
 val flatten_nesting : t -> t
 (** [flatten_nesting stylesheet] returns the stylesheet with every nested rule

--- a/lib/ctx.ml
+++ b/lib/ctx.ml
@@ -19,6 +19,10 @@ type t = {
           vendor-prefixed declaration whose unprefixed twin modern browsers
           support. On: keep every prefix (spec-literal, maximal compatibility).
       *)
+  stats : Stats.t;
+      (** Profiling recorder for the run this context belongs to. Carried here
+          because every pass that counts anything already takes a context, and a
+          context is built per run, so two runs cannot share a recorder. *)
 }
 
 let fragment =
@@ -32,38 +36,31 @@ let fragment =
     closed_world = false;
     objective = `Transfer;
     enforce_spec = false;
+    stats = Stats.v ();
   }
 
 let of_scope ?(lossless = false) ?(aggressive = false) ?(regroup = true)
     ?(extend_lists = false) ?(closed_world = false) ?(objective = `Transfer)
-    ?(enforce_spec = false) = function
-  | Some scope ->
-      {
-        fragment with
-        scope;
-        lossless;
-        aggressive;
-        regroup;
-        extend_lists;
-        closed_world;
-        objective;
-        enforce_spec;
-      }
-  | None ->
-      {
-        fragment with
-        lossless;
-        aggressive;
-        regroup;
-        extend_lists;
-        closed_world;
-        objective;
-        enforce_spec;
-      }
+    ?(enforce_spec = false) ?stats scope =
+  let stats = match stats with Some stats -> stats | None -> Stats.v () in
+  let scope = match scope with Some scope -> scope | None -> fragment.scope in
+  {
+    fragment with
+    scope;
+    lossless;
+    aggressive;
+    regroup;
+    extend_lists;
+    closed_world;
+    objective;
+    enforce_spec;
+    stats;
+  }
 
 let v ?(lossless = false) ?(aggressive = false) ?(regroup = true)
     ?(extend_lists = false) ?(closed_world = false) ?(objective = `Transfer)
-    ?(enforce_spec = false) ?(registered = fun _ -> false) scope =
+    ?(enforce_spec = false) ?(registered = fun _ -> false) ?stats scope =
+  let stats = match stats with Some stats -> stats | None -> Stats.v () in
   {
     scope;
     registered;
@@ -74,6 +71,7 @@ let v ?(lossless = false) ?(aggressive = false) ?(regroup = true)
     closed_world;
     objective;
     enforce_spec;
+    stats;
   }
 
 let scope t = t.scope
@@ -85,6 +83,7 @@ let extend_lists t = t.extend_lists
 let closed_world t = t.closed_world
 let objective t = t.objective
 let enforce_spec t = t.enforce_spec
+let stats t = t.stats
 let with_extend_lists extend_lists t = { t with extend_lists }
 
 let pp_scope ctx = function

--- a/lib/ctx.mli
+++ b/lib/ctx.mli
@@ -8,10 +8,13 @@ type objective = [ `Raw | `Transfer ]
     (gzip) transfer bytes. *)
 
 type t
-(** Shared optimizer context. *)
+(** Shared optimizer context. One is built per optimizer run and threaded to
+    every pass, so it also carries the run's profiling recorder. *)
 
 val fragment : t
-(** Default fragment context. *)
+(** Default fragment context. Being a constant it carries a recorder shared by
+    everything that uses it; build a context with {!v} to collect a run's
+    profile. *)
 
 val of_scope :
   ?lossless:bool ->
@@ -21,6 +24,7 @@ val of_scope :
   ?closed_world:bool ->
   ?objective:objective ->
   ?enforce_spec:bool ->
+  ?stats:Stats.t ->
   scope option ->
   t
 (** Build a context from an optional scope. *)
@@ -34,9 +38,12 @@ val v :
   ?objective:objective ->
   ?enforce_spec:bool ->
   ?registered:(string -> bool) ->
+  ?stats:Stats.t ->
   scope ->
   t
-(** Build a context explicitly. *)
+(** Build a context explicitly. [stats] defaults to a fresh recorder, so a
+    context that is not handed one still counts its run's work, into a recorder
+    nobody reads. *)
 
 val scope : t -> scope
 (** Scope assumed by optimizations. *)
@@ -89,6 +96,9 @@ val enforce_spec : t -> bool
 (** Whether the evergreen-browser target is dropped. Off by default: a vendor-
     prefixed declaration whose unprefixed twin is present may be stripped, since
     modern browsers understand the unprefixed form. On: keep every prefix. *)
+
+val stats : t -> Stats.t
+(** Profiling recorder for the run this context belongs to. *)
 
 val with_extend_lists : bool -> t -> t
 (** [with_extend_lists enabled ctx] returns [ctx] with only the list-extension

--- a/lib/factor.ml
+++ b/lib/factor.ml
@@ -6,7 +6,6 @@ let src = Logs.Src.create "cascade.factor" ~doc:"Cascade rule factoring"
 
 module Log = (val Logs.src_log src : Logs.LOG)
 
-let counters = Stats.counters
 let rules_pp_size = Size.rules
 let list_map_preserve = Common.List.map_preserve
 
@@ -98,34 +97,34 @@ let ordered_rules rules graph =
 let should_run_preflight ~ctx summary =
   if Preflight.declaration_count summary > Preflight.small_declaration_threshold
   then
-    counters.factor_preflight_gain <-
-      counters.factor_preflight_gain + Preflight.estimated_gain summary;
+    Stats.add_preflight_gain (Ctx.stats ctx) (Preflight.estimated_gain summary);
   Preflight.useful summary || Ctx.aggressive ctx
 
-let record_iteration ~fixpoint ~local_iteration ~before_rules ~before_bytes
-    ~after_rules ~after_bytes ~bytes_saved ~changed ~elapsed =
-  Stats.record_iteration ~fixpoint ~local_iteration ~before_rules ~before_bytes
-    ~after_rules ~after_bytes ~bytes_saved ~active_passes:1
+let record_iteration stats ~fixpoint ~local_iteration ~before_rules
+    ~before_bytes ~after_rules ~after_bytes ~bytes_saved ~changed ~elapsed =
+  Stats.record_iteration stats ~fixpoint ~local_iteration ~before_rules
+    ~before_bytes ~after_rules ~after_bytes ~bytes_saved ~active_passes:1
     ~changed_passes:(if changed then 1 else 0)
     ~elapsed
 
 let optimize_graph ~ctx ~finalize ~fixpoint ~local_iteration rules graph =
-  counters.iterations <- counters.iterations + 1;
-  Stats.reset_saving ();
+  let stats = Ctx.stats ctx in
+  Stats.reset_saving stats;
   let before_rules = List.length rules in
-  let before_bytes = if Stats.profile () then rules_pp_size rules else 0 in
+  let profile = Stats.profile stats in
+  let before_bytes = if profile then rules_pp_size rules else 0 in
   let started_at = Unix.gettimeofday () in
   let graph = Rule_scheduler.run ~ctx ~finalize graph in
   let ordered = ordered_rules rules graph in
   let rules' = list_map_preserve finalize ordered in
-  let after_bytes = if Stats.profile () then rules_pp_size rules' else 0 in
+  let after_bytes = if profile then rules_pp_size rules' else 0 in
   let elapsed = Unix.gettimeofday () -. started_at in
-  let bytes_saved = Stats.saving () in
+  let bytes_saved = Stats.saving stats in
   (* Both return the input unchanged by physical identity on a no-op, so a
      pointer compare detects change without rendering to CSS. *)
   let changed = rules' != rules in
   let after_rules = List.length rules' in
-  record_iteration ~fixpoint ~local_iteration ~before_rules ~before_bytes
+  record_iteration stats ~fixpoint ~local_iteration ~before_rules ~before_bytes
     ~after_rules ~after_bytes ~bytes_saved ~changed ~elapsed;
   (* Per fixpoint iteration, not per rule, so the closure cost is noise. The
      byte columns are only computed under [--profile]; rules and savings are
@@ -190,6 +189,7 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
   with
   | Some rules -> rules
   | None ->
+      let stats = Ctx.stats ctx in
       let summary = Preflight.summarize rules in
       let graph =
         Rule_graph.of_rules ~closed_world:(Ctx.closed_world ctx) rules
@@ -201,14 +201,12 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
       in
       let result =
         if known_revert || not (should_run_preflight ~ctx summary) then begin
-          counters.factor_fixpoints_skipped <-
-            counters.factor_fixpoints_skipped + 1;
+          Stats.skip_fixpoint stats;
           log_skip ~known_revert summary;
           ordered_rules rules graph
         end
         else begin
-          counters.factor_fixpoints_run <- counters.factor_fixpoints_run + 1;
-          let fixpoint = counters.factor_fixpoints_run in
+          let fixpoint = Stats.start_fixpoint stats in
           let unfactored = ordered_rules rules graph in
           let factored =
             optimize_graph ~ctx ~finalize ~fixpoint ~local_iteration:1 rules
@@ -218,8 +216,7 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
             factored != rules
             && factored_grows_transfer ~ctx ~unfactored ~factored
           then begin
-            counters.factor_transfer_reverts <-
-              counters.factor_transfer_reverts + 1;
+            Stats.revert_fixpoint stats;
             log_transfer_revert ~fixpoint summary;
             (* Only a large segment is worth remembering: factoring a small one
                costs little, so suppressing it saves nothing and risks giving up

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -63,48 +63,6 @@ let deduplicate_declarations = Shorthand.deduplicate_declarations
 let single_rule_without_nested = Rule.single
 let finalize_rule_without_nested = Rule.finalize
 
-(* Per-pass and global counters for the --profile CLI flag. Reset at each
-   [Optimize.stylesheet] entry; bumped from the hot loops below. *)
-type pass_stat = Stats.pass_stat = {
-  mutable time : float;
-  mutable calls : int;
-  mutable changes : int;
-  mutable rules_in : int;
-  mutable rules_out : int;
-}
-
-let pass_times = Stats.pass_times
-let set_profile = Stats.set_profile
-
-type iteration_stat = Stats.iteration_stat = {
-  fixpoint : int;
-  iteration : int;
-  local_iteration : int;
-  before_rules : int;
-  after_rules : int;
-  before_bytes : int;
-  after_bytes : int;
-  bytes_saved : int;
-  active_passes : int;
-  changed_passes : int;
-  elapsed : float;
-}
-
-let iteration_stats = Stats.iteration_stats
-
-type counters = Stats.counters = {
-  mutable iterations : int;
-  mutable factor_fixpoints_run : int;
-  mutable marginal_stops : int;
-  mutable factor_fixpoints_skipped : int;
-  mutable factor_preflight_gain : int;
-  mutable factor_bytes_saved : int;
-  mutable factor_transfer_reverts : int;
-}
-
-let counters = Stats.counters
-let reset_counters () = Stats.reset ()
-
 (** {1 Statement Optimization} *)
 
 let merge_consecutive_layers = Block.merge_consecutive_layers
@@ -1158,9 +1116,8 @@ let drop_unused_custom_props (stmts : statement list) : statement list =
 let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
     ?(enforce_spec = false) ?(aggressive = false) ?(regroup = true)
     ?(closed_world = false) ?(objective = `Transfer)
-    ?(prune_unused_custom_props = false) (stylesheet : t) : t =
+    ?(prune_unused_custom_props = false) ?stats (stylesheet : t) : t =
   Selector_summary.clear_memo ();
-  reset_counters ();
   let scope = Option.value scope ~default:`Fragment in
   let ctx = single_valued_calc_ctx stylesheet in
   let stylesheet = sanitize_block ~ctx ~lossless stylesheet in
@@ -1172,7 +1129,7 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
   let stylesheet = prune_position_try_fallbacks ~scope stylesheet in
   let ctx =
     Ctx.v ~lossless ~aggressive ~regroup ~closed_world ~objective ~enforce_spec
-      ~registered scope
+      ~registered ?stats scope
   in
   let result =
     run_pipeline
@@ -1187,7 +1144,7 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
     if lossless then canonicalize_declaration_order result else result
   in
   Log.debug (fun m ->
-      let c = counters in
+      let c = (Stats.snapshot (Ctx.stats ctx)).counters in
       m
         "optimized: %d factoring fixpoints run, %d skipped, %d reverted by the \
          transfer gate, %d bytes saved"

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -52,6 +52,7 @@ val ctx_of_scope :
   ?closed_world:bool ->
   ?objective:Ctx.objective ->
   ?enforce_spec:bool ->
+  ?stats:Stats.t ->
   scope option ->
   ctx
 (** [ctx_of_scope ?lossless ?aggressive ?extend_lists ?closed_world scope]
@@ -151,6 +152,7 @@ val stylesheet :
   ?closed_world:bool ->
   ?objective:Ctx.objective ->
   ?prune_unused_custom_props:bool ->
+  ?stats:Stats.t ->
   t ->
   t
 (** [stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec ss] optimizes an
@@ -189,65 +191,12 @@ val stylesheet :
     bindings referenced by no [var()] anywhere are dropped. This is opt-in
     because it assumes a complete stylesheet with no out-of-band reader (another
     stylesheet, or [getComputedStyle]) - the same closed-world assumption as
-    {!Css.inline_vars}. *)
+    {!Css.inline_vars}.
+
+    [stats] records what this run did; read it back with {!Stats.snapshot}.
+    Without it the run counts into a recorder of its own that nobody reads. *)
 
 val flatten_nesting : t -> t
 (** [flatten_nesting ss] returns [ss] with every nested rule flattened into a
     top-level rule. Equivalent to the [~flatten_nesting:true] mode of
     {!stylesheet} but without the deduplication / merge passes. *)
-
-type pass_stat = {
-  mutable time : float;  (** accumulated wall-clock, seconds *)
-  mutable calls : int;  (** times the pass ran across all fixpoint iterations *)
-  mutable changes : int;  (** times the pass returned a structurally new list *)
-  mutable rules_in : int;  (** total input rule count summed across calls *)
-  mutable rules_out : int;  (** total output rule count summed across calls *)
-}
-(** One pass's contribution to a single [Optimize.stylesheet] run. *)
-
-val pass_times : (string, pass_stat) Hashtbl.t
-(** Per-pass stats for [factor_rules_to_fixpoint]. Populated as a side effect
-    during {!val-stylesheet} runs; reset at each entry. Keys are pass names. *)
-
-val set_profile : bool -> unit
-(** Enable or disable exact diagnostic size collection for subsequent optimizer
-    runs. Default is [false]. *)
-
-type iteration_stat = {
-  fixpoint : int;
-  iteration : int;
-  local_iteration : int;
-  before_rules : int;
-  after_rules : int;
-  before_bytes : int;
-  after_bytes : int;
-  bytes_saved : int;
-  active_passes : int;
-  changed_passes : int;
-  elapsed : float;
-}
-(** One global factoring fixpoint iteration. *)
-
-val iteration_stats : unit -> iteration_stat list
-(** Per-iteration stats for [factor_rules_to_fixpoint], newest first. *)
-
-type counters = {
-  mutable iterations : int;  (** [factor_rules_to_fixpoint] iterations *)
-  mutable factor_fixpoints_run : int;
-      (** global factoring fixpoints attempted after the preflight *)
-  mutable marginal_stops : int;
-      (** fixpoints stopped because consecutive iterations had low byte gain *)
-  mutable factor_fixpoints_skipped : int;
-      (** global factoring fixpoints skipped by the incremental preflight *)
-  mutable factor_preflight_gain : int;
-      (** total raw-byte gain estimated by the global factoring preflight *)
-  mutable factor_bytes_saved : int;
-      (** total committed byte savings reported by global factoring passes *)
-  mutable factor_transfer_reverts : int;
-      (** factoring results discarded because the estimated DEFLATE size grew *)
-}
-(** Global counters across the last [Optimize.stylesheet] run. *)
-
-val counters : counters
-(** The counters; mutated by the optimizer, reset at each {!val-stylesheet}
-    entry. *)

--- a/lib/rule_scheduler.ml
+++ b/lib/rule_scheduler.ml
@@ -133,7 +133,7 @@ let run ~ctx ~finalize graph =
               with
               | Error _ -> loop iteration refreshed graph next_key queue
               | Ok graph' ->
-                  Stats.add_saving candidate.saving;
+                  Stats.add_saving (Ctx.stats ctx) candidate.saving;
                   (* Refresh affected-neighborhood candidates per commit only
                      for small graphs; on large graphs the cumulative per-commit
                      enumeration cost dominates, so defer to drain-time

--- a/lib/stats.ml
+++ b/lib/stats.ml
@@ -1,23 +1,3 @@
-type pass_stat = {
-  mutable time : float;
-  mutable calls : int;
-  mutable changes : int;
-  mutable rules_in : int;
-  mutable rules_out : int;
-}
-
-let pass_times : (string, pass_stat) Hashtbl.t = Hashtbl.create 16
-let profile_enabled = ref false
-let set_profile enabled = profile_enabled := enabled
-let profile () = !profile_enabled
-let factor_saving = ref 0
-
-let add_saving saving =
-  if saving > 0 then factor_saving := !factor_saving + saving
-
-let reset_saving () = factor_saving := 0
-let saving () = !factor_saving
-
 type iteration_stat = {
   fixpoint : int;
   iteration : int;
@@ -32,48 +12,86 @@ type iteration_stat = {
   elapsed : float;
 }
 
-let iteration_stats_rev = ref []
-let iteration_stats () = !iteration_stats_rev
-
-let pass name =
-  match Hashtbl.find_opt pass_times name with
-  | Some s -> s
-  | None ->
-      let s =
-        { time = 0.0; calls = 0; changes = 0; rules_in = 0; rules_out = 0 }
-      in
-      Hashtbl.add pass_times name s;
-      s
-
 type counters = {
-  mutable iterations : int;
-  mutable factor_fixpoints_run : int;
-  mutable marginal_stops : int;
-  mutable factor_fixpoints_skipped : int;
-  mutable factor_preflight_gain : int;
-  mutable factor_bytes_saved : int;
-  mutable factor_transfer_reverts : int;
+  iterations : int;
+  factor_fixpoints_run : int;
+  factor_fixpoints_skipped : int;
+  factor_preflight_gain : int;
+  factor_bytes_saved : int;
+  factor_transfer_reverts : int;
 }
 
-let counters =
+type snapshot = { counters : counters; iteration_stats : iteration_stat list }
+
+type t = {
+  profile : bool;
+  mutable counters : counters;
+  mutable iteration_stats_rev : iteration_stat list;
+  mutable saving : int;
+}
+
+let no_counters =
   {
     iterations = 0;
     factor_fixpoints_run = 0;
-    marginal_stops = 0;
     factor_fixpoints_skipped = 0;
     factor_preflight_gain = 0;
     factor_bytes_saved = 0;
     factor_transfer_reverts = 0;
   }
 
-let record_iteration ~fixpoint ~local_iteration ~before_rules ~before_bytes
+let v ?(profile = false) () =
+  { profile; counters = no_counters; iteration_stats_rev = []; saving = 0 }
+
+let profile t = t.profile
+
+let snapshot t =
+  { counters = t.counters; iteration_stats = t.iteration_stats_rev }
+
+let add_saving t saving = if saving > 0 then t.saving <- t.saving + saving
+let reset_saving t = t.saving <- 0
+let saving t = t.saving
+
+let start_fixpoint t =
+  let run = t.counters.factor_fixpoints_run + 1 in
+  t.counters <- { t.counters with factor_fixpoints_run = run };
+  run
+
+let skip_fixpoint t =
+  t.counters <-
+    {
+      t.counters with
+      factor_fixpoints_skipped = t.counters.factor_fixpoints_skipped + 1;
+    }
+
+let revert_fixpoint t =
+  t.counters <-
+    {
+      t.counters with
+      factor_transfer_reverts = t.counters.factor_transfer_reverts + 1;
+    }
+
+let add_preflight_gain t gain =
+  t.counters <-
+    {
+      t.counters with
+      factor_preflight_gain = t.counters.factor_preflight_gain + gain;
+    }
+
+let record_iteration t ~fixpoint ~local_iteration ~before_rules ~before_bytes
     ~after_rules ~after_bytes ~bytes_saved ~active_passes ~changed_passes
     ~elapsed =
-  counters.factor_bytes_saved <- counters.factor_bytes_saved + bytes_saved;
-  iteration_stats_rev :=
+  let iteration = t.counters.iterations + 1 in
+  t.counters <-
+    {
+      t.counters with
+      iterations = iteration;
+      factor_bytes_saved = t.counters.factor_bytes_saved + bytes_saved;
+    };
+  t.iteration_stats_rev <-
     {
       fixpoint;
-      iteration = counters.iterations;
+      iteration;
       local_iteration;
       before_rules;
       after_rules;
@@ -84,16 +102,4 @@ let record_iteration ~fixpoint ~local_iteration ~before_rules ~before_bytes
       changed_passes;
       elapsed;
     }
-    :: !iteration_stats_rev
-
-let reset () =
-  Hashtbl.reset pass_times;
-  iteration_stats_rev := [];
-  factor_saving := 0;
-  counters.iterations <- 0;
-  counters.factor_fixpoints_run <- 0;
-  counters.marginal_stops <- 0;
-  counters.factor_fixpoints_skipped <- 0;
-  counters.factor_preflight_gain <- 0;
-  counters.factor_bytes_saved <- 0;
-  counters.factor_transfer_reverts <- 0
+    :: t.iteration_stats_rev

--- a/lib/stats.mli
+++ b/lib/stats.mli
@@ -1,34 +1,21 @@
-(** Optimizer profiling counters. *)
+(** Optimizer profiling counters, scoped to one run.
 
-type pass_stat = {
-  mutable time : float;  (** accumulated wall-clock, seconds *)
-  mutable calls : int;  (** times the pass ran across all fixpoint iterations *)
-  mutable changes : int;  (** times the pass returned a structurally new list *)
-  mutable rules_in : int;  (** total input rule count summed across calls *)
-  mutable rules_out : int;  (** total output rule count summed across calls *)
-}
-(** One pass's contribution to a single optimizer run. *)
+    A recorder belongs to the optimizer run that created it and is reachable
+    only through that run's {!Ctx.t}, so an optimization started while another
+    is in progress counts its own work. Readers take a {!snapshot}: a value, not
+    a view, so a later run cannot rewrite what an earlier one reported. *)
 
-val pass_times : (string, pass_stat) Hashtbl.t
-(** Per-pass stats for the factor fixpoint. *)
+type t
+(** One run's recorder. *)
 
-val pass : string -> pass_stat
-(** [pass name] returns the mutable stats bucket for [name]. *)
+val v : ?profile:bool -> unit -> t
+(** [v ()] is a recorder for one optimizer run. [profile] (default [false])
+    turns on exact size accounting: the byte columns cost a full serialization
+    of the rule list on either side of every fixpoint iteration, so they are
+    collected only when asked for. *)
 
-val set_profile : bool -> unit
-(** Enable or disable exact diagnostic size collection. *)
-
-val profile : unit -> bool
-(** Whether exact diagnostic size collection is enabled. *)
-
-val add_saving : int -> unit
-(** Add committed factoring savings for the current iteration. *)
-
-val reset_saving : unit -> unit
-(** Reset committed factoring savings for the current iteration. *)
-
-val saving : unit -> int
-(** Committed factoring savings for the current iteration. *)
+val profile : t -> bool
+(** Whether exact size accounting is enabled for this run. *)
 
 type iteration_stat = {
   fixpoint : int;
@@ -45,30 +32,49 @@ type iteration_stat = {
 }
 (** One global factoring fixpoint iteration. *)
 
-val iteration_stats : unit -> iteration_stat list
-(** Per-iteration stats, newest first. *)
-
 type counters = {
-  mutable iterations : int;  (** [factor_rules_to_fixpoint] iterations *)
-  mutable factor_fixpoints_run : int;
+  iterations : int;  (** [factor_rules_to_fixpoint] iterations *)
+  factor_fixpoints_run : int;
       (** global factoring fixpoints attempted after the preflight *)
-  mutable marginal_stops : int;
-      (** fixpoints stopped because consecutive iterations had low byte gain *)
-  mutable factor_fixpoints_skipped : int;
+  factor_fixpoints_skipped : int;
       (** global factoring fixpoints skipped by the incremental preflight *)
-  mutable factor_preflight_gain : int;
+  factor_preflight_gain : int;
       (** total raw-byte gain estimated by the global factoring preflight *)
-  mutable factor_bytes_saved : int;
+  factor_bytes_saved : int;
       (** total committed byte savings reported by global factoring passes *)
-  mutable factor_transfer_reverts : int;
+  factor_transfer_reverts : int;
       (** factoring results discarded because the estimated DEFLATE size grew *)
 }
-(** Global counters across the last optimizer run. *)
+(** Counters over one run. *)
 
-val counters : counters
-(** The global mutable counters. *)
+type snapshot = {
+  counters : counters;
+  iteration_stats : iteration_stat list;  (** newest first *)
+}
+(** What a run recorded, as of the moment it was taken. *)
+
+val snapshot : t -> snapshot
+(** [snapshot t] is what [t] has recorded so far. *)
+
+(** {1 Recording}
+
+    Called by the factoring passes; a caller holding a recorder can add to a run
+    it does not own, which only skews that run's own report. *)
+
+val start_fixpoint : t -> int
+(** [start_fixpoint t] counts one factoring fixpoint and returns its number. *)
+
+val skip_fixpoint : t -> unit
+(** Count one fixpoint the preflight declined to run. *)
+
+val revert_fixpoint : t -> unit
+(** Count one factoring result the transfer gate threw away. *)
+
+val add_preflight_gain : t -> int -> unit
+(** Add the preflight's raw-byte gain estimate for one segment. *)
 
 val record_iteration :
+  t ->
   fixpoint:int ->
   local_iteration:int ->
   before_rules:int ->
@@ -82,5 +88,11 @@ val record_iteration :
   unit
 (** Record one factor-fixpoint iteration. *)
 
-val reset : unit -> unit
-(** Reset all counters and pass timings. *)
+val add_saving : t -> int -> unit
+(** Add committed factoring savings for the current iteration. *)
+
+val reset_saving : t -> unit
+(** Reset committed factoring savings for the current iteration. *)
+
+val saving : t -> int
+(** Committed factoring savings for the current iteration. *)

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -47,20 +47,22 @@ let test_run_reaches_fixpoint_with_finalizer () =
     ".a,.b,.c{display:flex;margin:1px}.b{margin:2px}.c{margin:3px}"
     (render optimized)
 
+let fixpoints_run stats = (Stats.snapshot stats).counters.factor_fixpoints_run
+
 let test_cache_reuses_identical_rule_run () =
-  Stats.reset ();
+  let stats = Stats.v () in
+  let ctx = Ctx.v ~stats `Fragment in
   let cache = Factor.cache () in
   let input =
     rules
       ".a{display:flex;margin:1px}.b{display:flex;margin:2px}.c{display:flex;margin:3px}"
   in
-  let finalize = Rule.finalize ~ctx:Ctx.fragment in
-  let first = Factor.run ~cache ~ctx:Ctx.fragment ~finalize input in
-  let fixpoints = Stats.counters.factor_fixpoints_run in
-  ignore (Factor.run ~cache ~ctx:Ctx.fragment ~finalize input);
+  let finalize = Rule.finalize ~ctx in
+  let first = Factor.run ~cache ~ctx ~finalize input in
+  let fixpoints = fixpoints_run stats in
+  ignore (Factor.run ~cache ~ctx ~finalize input);
   Alcotest.(check int)
-    "cached run does not start another fixpoint" fixpoints
-    Stats.counters.factor_fixpoints_run;
+    "cached run does not start another fixpoint" fixpoints (fixpoints_run stats);
   Alcotest.(check string)
     "first run still optimizes"
     ".a,.b,.c{display:flex;margin:1px}.b{margin:2px}.c{margin:3px}"

--- a/test/test_stats.ml
+++ b/test/test_stats.ml
@@ -20,18 +20,19 @@ let factorable =
    finalizer the scheduler applies to each produced rule, so whatever it does
    happens in the middle of this run. *)
 let run_counters ?(nest = fun () -> ()) css =
-  S.reset ();
-  let ctx = Ctx.fragment in
+  let stats = S.v () in
+  let ctx = Ctx.v ~stats `Fragment in
   let finalize r =
     nest ();
     Rule.finalize ~ctx r
   in
   ignore (Factor.run ~ctx ~finalize (rules css));
-  S.counters
+  (S.snapshot stats).counters
 
 let optimize_counters css =
-  ignore (Css.optimize (sheet css));
-  S.counters
+  let stats = S.v () in
+  ignore (Css.optimize ~stats (sheet css));
+  (S.snapshot stats).counters
 
 (* An optimization started while another is running has its own work to count.
    Neither run may see the other's numbers, whether they interleave through a
@@ -61,72 +62,50 @@ let test_report_survives_a_later_run () =
     "the first run's report still describes the first run" fixpoints
     report.factor_fixpoints_run
 
-let check_zeroed_counters label =
-  Alcotest.(check int) (label ^ " iterations") 0 S.counters.iterations;
+(* A recorder starts empty, and every optimizer run gets a fresh one. *)
+let test_fresh_recorder_is_empty () =
+  let report = S.snapshot (S.v ()) in
+  Alcotest.(check int) "iterations" 0 report.counters.iterations;
   Alcotest.(check int)
-    (label ^ " factor_fixpoints_run")
-    0 S.counters.factor_fixpoints_run;
-  Alcotest.(check int) (label ^ " marginal_stops") 0 S.counters.marginal_stops;
+    "factor_fixpoints_run" 0 report.counters.factor_fixpoints_run;
   Alcotest.(check int)
-    (label ^ " factor_fixpoints_skipped")
-    0 S.counters.factor_fixpoints_skipped;
+    "factor_fixpoints_skipped" 0 report.counters.factor_fixpoints_skipped;
   Alcotest.(check int)
-    (label ^ " factor_preflight_gain")
-    0 S.counters.factor_preflight_gain;
+    "factor_preflight_gain" 0 report.counters.factor_preflight_gain;
+  Alcotest.(check int) "factor_bytes_saved" 0 report.counters.factor_bytes_saved;
   Alcotest.(check int)
-    (label ^ " factor_bytes_saved")
-    0 S.counters.factor_bytes_saved
+    "factor_transfer_reverts" 0 report.counters.factor_transfer_reverts;
+  Alcotest.(check int) "iteration stats" 0 (List.length report.iteration_stats);
+  Alcotest.(check bool) "profile off by default" false (S.profile (S.v ()));
+  Alcotest.(check bool)
+    "profile on when asked" true
+    (S.profile (S.v ~profile:true ()))
 
-let test_pass_bucket_reuse_and_reset () =
-  S.reset ();
-  let first = S.pass "merge" in
-  first.time <- 1.25;
-  first.calls <- 3;
-  first.changes <- 2;
-  first.rules_in <- 17;
-  first.rules_out <- 11;
-  let second = S.pass "merge" in
-  Alcotest.(check bool) "same pass bucket reused" true (first == second);
-  Alcotest.(check int) "one pass bucket" 1 (Hashtbl.length S.pass_times);
-  S.reset ();
-  Alcotest.(check int) "pass buckets cleared" 0 (Hashtbl.length S.pass_times);
-  let fresh = S.pass "merge" in
-  Alcotest.(check bool) "new bucket after reset" false (first == fresh);
-  Alcotest.(check (float 0.0001)) "fresh time" 0.0 fresh.time;
-  Alcotest.(check int) "fresh calls" 0 fresh.calls;
-  Alcotest.(check int) "fresh changes" 0 fresh.changes;
-  Alcotest.(check int) "fresh rules_in" 0 fresh.rules_in;
-  Alcotest.(check int) "fresh rules_out" 0 fresh.rules_out
-
-let test_profile_flag_and_savings () =
-  S.reset ();
-  Alcotest.(check bool) "profile starts disabled" false (S.profile ());
-  S.set_profile true;
-  Alcotest.(check bool) "profile enabled" true (S.profile ());
-  S.add_saving 10;
-  S.add_saving 0;
-  S.add_saving (-5);
-  S.add_saving 7;
-  Alcotest.(check int) "only positive savings accumulate" 17 (S.saving ());
-  S.reset_saving ();
-  Alcotest.(check int) "saving reset" 0 (S.saving ());
-  S.reset ();
-  Alcotest.(check bool) "reset keeps profile flag" true (S.profile ());
-  S.set_profile false;
-  Alcotest.(check bool) "profile disabled" false (S.profile ())
+(* Savings are the running total for one fixpoint iteration, so they only count
+   up and start again at each iteration. *)
+let test_savings_accumulate_per_iteration () =
+  let stats = S.v () in
+  S.add_saving stats 10;
+  S.add_saving stats 0;
+  S.add_saving stats (-5);
+  S.add_saving stats 7;
+  Alcotest.(check int) "only positive savings accumulate" 17 (S.saving stats);
+  S.reset_saving stats;
+  Alcotest.(check int) "saving reset" 0 (S.saving stats)
 
 let test_record_iteration_updates_history_and_counters () =
-  S.reset ();
-  S.counters.iterations <- 42;
-  S.record_iteration ~fixpoint:2 ~local_iteration:5 ~before_rules:17
+  let stats = S.v () in
+  S.record_iteration stats ~fixpoint:2 ~local_iteration:5 ~before_rules:17
     ~before_bytes:300 ~after_rules:13 ~after_bytes:240 ~bytes_saved:60
     ~active_passes:4 ~changed_passes:3 ~elapsed:0.125;
+  let report = S.snapshot stats in
   Alcotest.(check int)
-    "factor bytes saved counter updated" 60 S.counters.factor_bytes_saved;
-  match S.iteration_stats () with
+    "factor bytes saved counter updated" 60 report.counters.factor_bytes_saved;
+  Alcotest.(check int) "iteration counted" 1 report.counters.iterations;
+  match report.iteration_stats with
   | [ s ] ->
       Alcotest.(check int) "fixpoint" 2 s.fixpoint;
-      Alcotest.(check int) "global iteration snapshot" 42 s.iteration;
+      Alcotest.(check int) "global iteration" 1 s.iteration;
       Alcotest.(check int) "local iteration" 5 s.local_iteration;
       Alcotest.(check int) "before rules" 17 s.before_rules;
       Alcotest.(check int) "after rules" 13 s.after_rules;
@@ -139,26 +118,24 @@ let test_record_iteration_updates_history_and_counters () =
   | stats ->
       Alcotest.failf "expected one iteration stat, got %d" (List.length stats)
 
-let test_reset_clears_mutable_state () =
-  S.reset ();
-  ignore (S.pass "merge");
-  S.add_saving 9;
-  S.counters.iterations <- 1;
-  S.counters.factor_fixpoints_run <- 2;
-  S.counters.marginal_stops <- 3;
-  S.counters.factor_fixpoints_skipped <- 6;
-  S.counters.factor_preflight_gain <- 7;
-  S.counters.factor_bytes_saved <- 8;
-  S.record_iteration ~fixpoint:1 ~local_iteration:1 ~before_rules:1
-    ~before_bytes:1 ~after_rules:1 ~after_bytes:1 ~bytes_saved:1
-    ~active_passes:1 ~changed_passes:1 ~elapsed:0.0;
-  S.reset ();
-  Alcotest.(check int) "saving cleared" 0 (S.saving ());
-  Alcotest.(check int) "pass_times cleared" 0 (Hashtbl.length S.pass_times);
+let test_fixpoints_are_numbered_within_the_run () =
+  let stats = S.v () in
+  Alcotest.(check int) "first fixpoint" 1 (S.start_fixpoint stats);
+  Alcotest.(check int) "second fixpoint" 2 (S.start_fixpoint stats);
+  S.skip_fixpoint stats;
+  S.revert_fixpoint stats;
+  S.add_preflight_gain stats 40;
+  S.add_preflight_gain stats 2;
+  let report = S.snapshot stats in
+  Alcotest.(check int) "fixpoints run" 2 report.counters.factor_fixpoints_run;
   Alcotest.(check int)
-    "iteration stats cleared" 0
-    (List.length (S.iteration_stats ()));
-  check_zeroed_counters "reset"
+    "fixpoints skipped" 1 report.counters.factor_fixpoints_skipped;
+  Alcotest.(check int)
+    "transfer reverts" 1 report.counters.factor_transfer_reverts;
+  Alcotest.(check int) "preflight gain" 42 report.counters.factor_preflight_gain;
+  Alcotest.(check int)
+    "a fresh recorder numbers from one again" 1
+    (S.start_fixpoint (S.v ()))
 
 let suite =
   ( "stats",
@@ -167,12 +144,12 @@ let suite =
         test_nested_run_keeps_its_counts_to_itself;
       Alcotest.test_case "report survives a later run" `Quick
         test_report_survives_a_later_run;
-      Alcotest.test_case "pass bucket reuse and reset" `Quick
-        test_pass_bucket_reuse_and_reset;
-      Alcotest.test_case "profile flag and savings" `Quick
-        test_profile_flag_and_savings;
+      Alcotest.test_case "fresh recorder is empty" `Quick
+        test_fresh_recorder_is_empty;
+      Alcotest.test_case "savings accumulate per iteration" `Quick
+        test_savings_accumulate_per_iteration;
       Alcotest.test_case "record iteration updates history and counters" `Quick
         test_record_iteration_updates_history_and_counters;
-      Alcotest.test_case "reset clears mutable state" `Quick
-        test_reset_clears_mutable_state;
+      Alcotest.test_case "fixpoints are numbered within the run" `Quick
+        test_fixpoints_are_numbered_within_the_run;
     ] )

--- a/test/test_stats.ml
+++ b/test/test_stats.ml
@@ -1,6 +1,66 @@
 open Cascade
 module S = Stats
 
+let sheet css =
+  match Css.of_string css with
+  | Ok { stylesheet; _ } -> stylesheet
+  | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
+
+let rules css =
+  List.filter_map
+    (function Stylesheet.Rule r -> Some r | _ -> None)
+    (Css.statements (sheet css))
+
+(* Three rules sharing [display:flex]: enough for the preflight to rate the
+   factoring worth running, so a run over them reports a fixpoint. *)
+let factorable =
+  ".a{display:flex;margin:1px}.b{display:flex;margin:2px}.c{display:flex;margin:3px}"
+
+(* Counters reported for one factoring run over [css]. [nest] runs from the
+   finalizer the scheduler applies to each produced rule, so whatever it does
+   happens in the middle of this run. *)
+let run_counters ?(nest = fun () -> ()) css =
+  S.reset ();
+  let ctx = Ctx.fragment in
+  let finalize r =
+    nest ();
+    Rule.finalize ~ctx r
+  in
+  ignore (Factor.run ~ctx ~finalize (rules css));
+  S.counters
+
+let optimize_counters css =
+  ignore (Css.optimize (sheet css));
+  S.counters
+
+(* An optimization started while another is running has its own work to count.
+   Neither run may see the other's numbers, whether they interleave through a
+   callback the outer run makes (here) or across threads. *)
+let test_nested_run_keeps_its_counts_to_itself () =
+  let alone = (run_counters factorable).factor_fixpoints_run in
+  let fired = ref false in
+  let nest () =
+    if not !fired then begin
+      fired := true;
+      ignore (Css.optimize (sheet factorable))
+    end
+  in
+  let nested = (run_counters ~nest factorable).factor_fixpoints_run in
+  Alcotest.(check int)
+    "an optimization nested in the finalizer leaves the outer count alone" alone
+    nested
+
+(* What a run hands back describes that run. A later optimization - the
+   caller's, or one started by a library the caller passed the report to -
+   cannot rewrite it. *)
+let test_report_survives_a_later_run () =
+  let report = optimize_counters factorable in
+  let fixpoints = report.factor_fixpoints_run in
+  ignore (optimize_counters ".a{color:red}");
+  Alcotest.(check int)
+    "the first run's report still describes the first run" fixpoints
+    report.factor_fixpoints_run
+
 let check_zeroed_counters label =
   Alcotest.(check int) (label ^ " iterations") 0 S.counters.iterations;
   Alcotest.(check int)
@@ -103,6 +163,10 @@ let test_reset_clears_mutable_state () =
 let suite =
   ( "stats",
     [
+      Alcotest.test_case "nested run keeps its counts to itself" `Quick
+        test_nested_run_keeps_its_counts_to_itself;
+      Alcotest.test_case "report survives a later run" `Quick
+        test_report_survives_a_later_run;
       Alcotest.test_case "pass bucket reuse and reset" `Quick
         test_pass_bucket_reuse_and_reset;
       Alcotest.test_case "profile flag and savings" `Quick


### PR DESCRIPTION
The profiling counters were process-global refs reset at every optimize entry, so nested runs clobbered each other and any caller could mutate the tables. Stats.t is now a per-run recorder living in the Ctx the passes already carry, with an immutable snapshot; Css.optimize takes ?stats. The dead per-pass table (no writer since the DAG scheduler) and the never-exported Optimize profiling re-exports are gone - one Breaking line covers the moved surface. Byte-identical over all 504 fixtures; -vv debug output identical on the largest corpus files.