### PR TITLE
diff: answer canonical mode on the canonical bytes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
   exited 0 when the structural walk reached no difference, which left a missing
   normalisation key and a blind spot in the walk both reading as success.
   ``Css_compare.equal ~mode:`Canonical`` answers on the same bytes, and
-  `Css_compare.No_diff` no longer carries the two canonical forms
+  `Css_compare.No_diff` no longer carries the two canonical forms (#290)
 
 ### Parsing
 
@@ -110,7 +110,7 @@
   `<ident>` sequence it unquotes to, the same family name under CSS Fonts 4
   sec. 15.3: `--font-sans: ui-sans-serif, "Noto Color Emoji"` and
   `--font-sans: ui-sans-serif, Noto Color Emoji` reach one form. The structural
-  comparator already folded the two together; the projection did not
+  comparator already folded the two together; the projection did not (#290)
 
 ### Diff report
 
@@ -129,9 +129,9 @@
   claimed equivalence over a comparison that fell through to a string diff, and
   over a side whose content the parser discarded (#285)
 - A canonical-form difference the structural walk did not reach is printed as
-  `Canonical forms differ:` above a string diff of the two forms
+  `Canonical forms differ:` above a string diff of the two forms (#290)
 - A string diff names the two sides with the labels it was given, so `cascade
-  diff` heads it with the two file names instead of `Expected` and `Actual`
+  diff` heads it with the two file names instead of `Expected` and `Actual` (#290)
 - A declaration reorder that decides the cascade is reported inside `@media`,
   `@layer` and `@supports` (#268), and the at-rules that carry no selector -
   `@page`, `@starting-style`, `@counter-style`, `@scope`, a second

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,12 @@
   `memtrace` dependency (#237)
 - A parse failure that drops every rule makes `cascade fmt` exit 1 instead of
   writing an empty stylesheet with a green status (#273)
+- `cascade diff --diff=canonical` exits 1 whenever the two canonical forms
+  differ, and prints the difference. It called such a pair equivalent and
+  exited 0 when the structural walk reached no difference, which left a missing
+  normalisation key and a blind spot in the walk both reading as success.
+  ``Css_compare.equal ~mode:`Canonical`` answers on the same bytes, and
+  `Css_compare.No_diff` no longer carries the two canonical forms
 
 ### Parsing
 
@@ -122,9 +128,10 @@
   structurally (see report below)`. It read `No structural differences`, which
   claimed equivalence over a comparison that fell through to a string diff, and
   over a side whose content the parser discarded (#285)
-- `cascade diff --diff=canonical` reports the canonical byte difference it
-  records when the structural comparison finds none: the verdict reads `CSS
-  files are equivalent` and `--depth=max` shows the two canonical forms (#285)
+- A canonical-form difference the structural walk did not reach is printed as
+  `Canonical forms differ:` above a string diff of the two forms
+- A string diff names the two sides with the labels it was given, so `cascade
+  diff` heads it with the two file names instead of `Expected` and `Actual`
 - A declaration reorder that decides the cascade is reported inside `@media`,
   `@layer` and `@supports` (#268), and the at-rules that carry no selector -
   `@page`, `@starting-style`, `@counter-style`, `@scope`, a second

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,11 @@
 - A custom property keeps its `!important`, its layer and its metadata through
   the projection, so the differ no longer calls two sheets that disagree about
   the flag identical (#271)
+- It rewrites a quoted multi-word font name in a custom property as the
+  `<ident>` sequence it unquotes to, the same family name under CSS Fonts 4
+  sec. 15.3: `--font-sans: ui-sans-serif, "Noto Color Emoji"` and
+  `--font-sans: ui-sans-serif, Noto Color Emoji` reach one form. The structural
+  comparator already folded the two together; the projection did not
 
 ### Diff report
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ usable as a CI check.
 `--diff=MODE` controls what counts as "no difference":
 
 - `auto` (default): structural diff; falls back to a string diff when the
-  parsed structures match but the strings don't, so cosmetic differences
+  parsed structures match but the strings don't, so formatting differences
   (whitespace, comment position) still surface.
 - `tree`: structural diff only; formatting-only differences collapse to
   "identical".

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -97,7 +97,15 @@ let render_at_depth ~color ~file1 ~file2 ~depth result =
         let level, body = fit_depth render in
         (body, Some level)
 
-let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth result =
+(* Canonical mode compares the two canonical minified forms, so the text under a
+   string diff there is those forms and not the files as written. Say which. *)
+let canonical_forms_note mode result =
+  match (mode, result) with
+  | Canonical, Cascade_diff.Css_compare.String_diff _ ->
+      "Canonical forms differ:\n"
+  | _ -> ""
+
+let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth ~mode result =
   let stats =
     Cascade_diff.Css_compare.stats ~expected_str:css1 ~actual_str:css2 result
   in
@@ -106,6 +114,8 @@ let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth result =
   in
   let buf = Buffer.create 1024 in
   Cascade_diff.Css_compare.pp_stats buf stats;
+  Buffer.add_string buf
+    (canonical_forms_note mode result.Cascade_diff.Css_compare.result);
   Buffer.add_char buf '\n';
   Buffer.add_string buf (render_warnings ~file1 ~file2 ~max:max_warnings result);
   let body, elided_at = render_at_depth ~color ~file1 ~file2 ~depth result in
@@ -121,29 +131,6 @@ let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth result =
           "; use --depth=max for the full report)\n";
         ]);
   print_string (Buffer.contents buf)
-
-(* Canonical mode can find the two sheets equivalent and still hold two
-   different canonical minified forms: a tool banner, a split [@layer] form, an
-   empty layer-order pin, whitespace inside [url()]. Tree-diff is the
-   authoritative comparator here - but dropping it left no trace of a
-   canonical-pass gap anyone could act on. *)
-let print_canonical_residual ~file1 ~file2 ~depth (expected_canon, actual_canon)
-    =
-  match depth with
-  | Fit | Level _ ->
-      Fmt.pr "Canonical minified forms still differ (--depth=max shows it)@."
-  | Full ->
-      Fmt.pr "Canonical minified forms still differ:@.";
-      let buf = Buffer.create 512 in
-      (match
-         Cascade_diff.String_diff.diff ~expected:expected_canon actual_canon
-       with
-      | Some sdiff ->
-          Buffer.add_char buf '\n';
-          Cascade_diff.String_diff.pp ~expected_label:file1 ~actual_label:file2
-            buf sdiff
-      | None -> ());
-      print_string (Buffer.contents buf)
 
 type canonical_opts = { lossless : bool; prune_unused_custom_props : bool }
 
@@ -171,7 +158,7 @@ let compare_files file1 file2 style_renderer mode depth opts () =
             ~css2
         in
         match result.Cascade_diff.Css_compare.result with
-        | No_diff { canonical_byte_diff } ->
+        | No_diff ->
             (* Equal ASTs can still hide parse-dropped declarations; show the
                warnings so the equality verdict is honest about them. *)
             let max =
@@ -180,15 +167,12 @@ let compare_files file1 file2 style_renderer mode depth opts () =
               | Fit | Level _ -> Some auto_warning_budget
             in
             print_string (render_warnings ~file1 ~file2 ~max result);
-            (match canonical_byte_diff with
-            | None -> Fmt.pr "CSS files are identical@."
-            | Some forms ->
-                Fmt.pr "CSS files are equivalent@.";
-                print_canonical_residual ~file1 ~file2 ~depth forms);
+            Fmt.pr "CSS files are identical@.";
             Ok ()
         | String_diff _ | Tree_diff _ | Both_errors _ | Expected_error _
         | Actual_error _ ->
-            print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth result;
+            print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth ~mode
+              result;
             (* Differing inputs are a result, not a usage error: exit 1 as
                documented, distinct from cmdliner's reserved error codes. *)
             Stdlib.exit 1)
@@ -327,11 +311,12 @@ let man =
          values stay functional. No effect outside canonical mode." );
     `S Manpage.s_exit_status;
     `P "$(tname) exits with:";
+    `I ("0", "if the CSS files are identical");
     `I
-      ( "0",
-        "if the CSS files are identical, or structurally equivalent with a \
-         canonical byte difference the report names" );
-    `I ("1", "if the CSS files differ");
+      ( "1",
+        "if the CSS files differ. Under $(b,--diff=canonical) that is any \
+         difference between their canonical forms, whether or not the \
+         structural walk reached it" );
     `I ("124", "on command-line errors or unreadable input files");
     `S Manpage.s_examples;
     `P "Compare two CSS files:";

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -298,14 +298,7 @@ let equivalent_value ?lossless ~property a b =
 type result =
   | Tree_diff of Tree_diff.t (* CSS AST differences found *)
   | String_diff of String_diff.t (* No structural diff but strings differ *)
-  | No_diff of { canonical_byte_diff : (string * string) option }
-      (** Structurally equivalent. [canonical_byte_diff = None] means the two
-          inputs were bytewise equal (after header strip / canonical minify).
-          [Some (expected, actual)] means the structural comparator (tree-diff
-          in [`Canonical] mode) found no difference but the canonical minified
-          forms still differed - i.e. a canonical-pass gap to chip away at in
-          future. The two strings let maintainers inspect what cascade hasn't
-          normalised yet. *)
+  | No_diff (* No difference under the selected mode *)
   | Both_errors of Error.t * Error.t
   | Expected_error of Error.t
   | Actual_error of Error.t
@@ -345,7 +338,7 @@ let diff_two_parsed ~expected ~actual ~expected_ast ~actual_ast =
 
 let diff_auto ~expected ~actual ~expected_parse ~actual_parse =
   (* First check if original strings are identical *)
-  if expected = actual then No_diff { canonical_byte_diff = None }
+  if expected = actual then No_diff
   else
     match (expected_parse, actual_parse) with
     | ( Ok { Css.stylesheet = expected_ast; _ },
@@ -355,6 +348,11 @@ let diff_auto ~expected ~actual ~expected_parse ~actual_parse =
     | Ok _, Error e -> Actual_error e
     | Error e, Ok _ -> Expected_error e
 
+(* The two canonical forms already differ, so this only picks how to say it: the
+   tree diff when its walk reaches the divergence, the bytes themselves when it
+   does not. A tree diff that comes back empty over two differing canonical
+   forms is a blind spot in the walk, and the string diff of the forms is what
+   names it. *)
 let diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
     ~expected_canon ~actual_canon =
   match (Css.of_string expected_canon, Css.of_string actual_canon) with
@@ -363,13 +361,13 @@ let diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
         tree_diff ~expected:expected_ast ~actual:actual_ast
       in
       if is_empty structural_diff then
-        No_diff { canonical_byte_diff = Some (expected_canon, actual_canon) }
+        fallback_to_string_diff ~expected:expected_canon ~actual:actual_canon
       else Tree_diff structural_diff
   | _ -> diff_auto ~expected ~actual ~expected_parse ~actual_parse
 
 let diff_canonical ~lossless ~prune_unused_custom_props ~expected ~actual
     ~expected_parse ~actual_parse =
-  if expected = actual then No_diff { canonical_byte_diff = None }
+  if expected = actual then No_diff
   else
     match
       canonical_diff_inputs_with_fallback ~lossless ~prune_unused_custom_props
@@ -377,27 +375,22 @@ let diff_canonical ~lossless ~prune_unused_custom_props ~expected ~actual
     with
     | None -> diff_auto ~expected ~actual ~expected_parse ~actual_parse
     | Some (expected_canon, actual_canon) ->
-        if String.equal expected_canon actual_canon then
-          No_diff { canonical_byte_diff = None }
+        (* The canonical form is what this mode compares: equivalent inputs
+           reach one form, so two forms that differ are two different
+           stylesheets or one projection missing a normalisation key. Either is
+           a difference here, and either is a finding - the key is added to the
+           projection, the blind spot fixed in the walk. *)
+        if String.equal expected_canon actual_canon then No_diff
         else
-          (* Tree-diff is the authoritative semantic comparator in Canonical
-             mode; canonical-minified byte equality is a fast-path sufficient
-             condition, not a necessary one. When the structural diff is empty,
-             the inputs ARE equivalent - cascade's canonical pass just hasn't
-             (yet) collapsed those particular textual variants (tool headers,
-             [@layer a, b;] vs split-form, empty layer-order pins, whitespace
-             inside [url()], ...). Expose the canonical byte forms on [No_diff]
-             so maintainers can spot which canonical-pass gap to chip away at
-             next, without ever overriding the structural answer. *)
           diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
             ~expected_canon ~actual_canon
 
 let diff_string ~expected ~actual =
-  if expected = actual then No_diff { canonical_byte_diff = None }
+  if expected = actual then No_diff
   else
     match String_diff.diff ~expected actual with
     | Some sdiff -> String_diff sdiff
-    | None -> No_diff { canonical_byte_diff = None }
+    | None -> No_diff
 
 let diff_tree ~expected_parse ~actual_parse =
   match (expected_parse, actual_parse) with
@@ -406,8 +399,7 @@ let diff_tree ~expected_parse ~actual_parse =
       let structural_diff =
         tree_diff ~expected:expected_ast ~actual:actual_ast
       in
-      if is_empty structural_diff then No_diff { canonical_byte_diff = None }
-      else Tree_diff structural_diff
+      if is_empty structural_diff then No_diff else Tree_diff structural_diff
   | Error e1, Error e2 -> Both_errors (e1, e2)
   | Ok _, Error e -> Actual_error e
   | Error e, Ok _ -> Expected_error e
@@ -421,11 +413,7 @@ let diff ?(mode = `Auto) ?(lossless = false)
   let expected = strip_tool_header expected in
   let actual = strip_tool_header actual in
   if expected = actual then
-    {
-      result = No_diff { canonical_byte_diff = None };
-      expected_warnings = [];
-      actual_warnings = [];
-    }
+    { result = No_diff; expected_warnings = []; actual_warnings = [] }
   else
     match mode with
     | `String ->
@@ -453,14 +441,14 @@ let diff ?(mode = `Auto) ?(lossless = false)
 
 let equal ?mode ?lossless ?prune_unused_custom_props a b =
   match (diff ?mode ?lossless ?prune_unused_custom_props a b).result with
-  | No_diff _ -> true
+  | No_diff -> true
   | _ -> false
 
 let as_tree_diff t =
   match t.result with
   | Tree_diff d -> Some d
-  | String_diff _ | No_diff _ | Both_errors _ | Expected_error _
-  | Actual_error _ ->
+  | String_diff _ | No_diff | Both_errors _ | Expected_error _ | Actual_error _
+    ->
       None
 
 (* Compute statistics from diff results *)
@@ -544,11 +532,9 @@ let pp_result ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
   | Tree_diff d ->
       (* Show structural differences *)
       D.pp ~expected ~actual ~color ?depth buf d
-  | String_diff sdiff -> String_diff.pp buf sdiff
-  | No_diff _ ->
-      (* No output for structurally equivalent files (whether or not the
-         canonical-minified bytes also matched). *)
-      ()
+  | String_diff sdiff ->
+      String_diff.pp ~expected_label:expected ~actual_label:actual buf sdiff
+  | No_diff -> ()
   | Both_errors (e1, e2) ->
       let err1 = Error.to_string e1 in
       let err2 = Error.to_string e2 in

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -11,7 +11,20 @@
     leading-/trailing-zero normalisations, optimizer-preserved shorthand
     choices, and other choices the optimizer and pretty-printer make; it does
     {b not} reason about browser computed values or cascade-affecting rule
-    reorderings. *)
+    reorderings.
+
+    Those bytes are the verdict in mode [`Canonical]. Canonical means equivalent
+    inputs project to one form, so two canonical forms that differ are either
+    two different stylesheets or one projection missing a normalisation key -
+    and the comparison reports a difference either way. The tree diff explains a
+    difference (which rule, which declaration, which value); it does not
+    overrule the bytes. A byte difference it walked past comes back as a
+    {!constructor-String_diff} of the two canonical forms.
+
+    Both causes are findings, not tolerances. A missing key is fixed by adding
+    the key to the projection (its normalisations are listed under
+    {!Cascade.Css.canonicalize_rule_order}); a difference the tree diff cannot
+    see is fixed in {!module-Tree_diff}. *)
 
 open Cascade
 
@@ -25,16 +38,7 @@ type result =
   | Tree_diff of Tree_diff.t  (** Structural AST differences. *)
   | String_diff of String_diff.t
       (** Strings differ but no structural change was detected. *)
-  | No_diff of { canonical_byte_diff : (string * string) option }
-      (** Structurally equivalent under the selected {!mode}.
-          [canonical_byte_diff = None] means the inputs were bytewise equal
-          (after header strip / canonical minify). [Some (expected, actual)]
-          appears under [`Canonical] when the structural comparator found no
-          difference but the canonical-minified bytes still differed - i.e.
-          cascade's canonical pass hasn't (yet) collapsed those textual
-          variants. The two strings let maintainers inspect which gap to chip
-          away at; callers matching [No_diff _] get the right equality answer
-          either way. *)
+  | No_diff  (** No difference under the selected {!mode}. *)
   | Both_errors of Error.t * Error.t
   | Expected_error of Error.t
   | Actual_error of Error.t
@@ -62,8 +66,9 @@ type mode = [ `Auto | `Tree | `String | `Canonical ]
     - [`Canonical] -- parse both stylesheets, serialize optimized minified
       outputs, and compare those outputs. This includes value spellings that
       Cascade canonicalizes as equivalent, such as [transparent] and [#0000] in
-      color positions. If the normalized forms differ, the returned diff is
-      reported from those normalized outputs.
+      color positions. Equal outputs are {!No_diff}; differing outputs are a
+      difference, reported as a tree diff of the two when the walk reaches it
+      and as a string diff of them when it does not.
 
     The projection runs no rewrite whose applicability depends on the order the
     input happens to put its rules in. Factoring shared declarations into a
@@ -102,7 +107,8 @@ val equal :
   string ->
   string ->
   bool
-(** [equal ?mode a b] is [true] iff [diff ?mode a b] is {!No_diff}. *)
+(** [equal ?mode a b] is [true] iff [diff ?mode a b] is {!No_diff}. Under
+    [`Canonical] that is exactly byte equality of the two canonical forms. *)
 
 val as_tree_diff : t -> Tree_diff.t option
 (** [as_tree_diff result] returns the underlying [Tree_diff.t] when [result] is

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -503,6 +503,16 @@ let normalize_custom_value v =
   go 0 None;
   Buffer.contents buf
 
+(* A multi-word font name spells the same family quoted or as the bare ident
+   sequence it unquotes to (CSS Fonts 4 sec. 15.3), and a custom property
+   holding a font stack substitutes either form identically into [font-family].
+   Emission keeps whichever the author wrote, so the projection folds the quoted
+   form onto the ident sequence - the same normalisation the structural
+   comparator applies through {!Css.declaration_value_for_equivalence}. *)
+let normalize_custom_declaration d =
+  Declaration.unquote_custom_font_strings
+    (Declaration.map_custom_value normalize_custom_value d)
+
 let rec normalize_custom_values (stmts : statement list) : statement list =
   List.map
     (fun stmt ->
@@ -512,9 +522,7 @@ let rec normalize_custom_values (stmts : statement list) : statement list =
             {
               r with
               declarations =
-                List.map
-                  (Declaration.map_custom_value normalize_custom_value)
-                  r.declarations;
+                List.map normalize_custom_declaration r.declarations;
               nested = normalize_custom_values r.nested;
             }
       | Layer (n, inner) -> Layer (n, normalize_custom_values inner)

--- a/lib/rule_order.mli
+++ b/lib/rule_order.mli
@@ -39,4 +39,10 @@ val canonicalize : Stylesheet.statement list -> Stylesheet.statement list
     A [@media] query of the Level 3 form [not all and (X)] is rewritten to the
     Level 4 [not (X)] it is equal to under Media Queries 4 sec. 2.1, since [all]
     is the identity media type. That direction loses support in a Level 3
-    parser, so it belongs to the projection rather than to emission. *)
+    parser, so it belongs to the projection rather than to emission.
+
+    A custom property holding a font stack has each quoted multi-word family
+    name rewritten as the [<ident>] sequence it unquotes to, which CSS Fonts 4
+    sec. 15.3 makes the same family name. Emission keeps whichever spelling the
+    author wrote, since unquoting an opaque token stream could corrupt a
+    [content] use, so again only the projection can bring the two together. *)

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -159,8 +159,8 @@ The --diff=string mode falls back to character-level diffing.
   
   Strings differ at position 12 (line 0, col 12)
   
-  --- Expected
-  +++ Actual
+  --- g.css
+  +++ h.css
   @@ position 12 @@
   -.x { color: red }
   +.x { color: blue }

--- a/test/cli/diff_canonical_residual.t
+++ b/test/cli/diff_canonical_residual.t
@@ -1,10 +1,9 @@
-CLI: cascade diff - canonical mode's residual byte difference.
+CLI: cascade diff - canonical mode's byte verdict.
 
-Two sheets the structural comparator calls equivalent can still
-canonicalise to different bytes: here an empty layer-order pin the
-projection does not fold away. Tree-diff is the authoritative answer, so
-the verdict stays equivalence and the exit code stays 0, but the report
-names the divergence rather than dropping it.
+The canonical minified form is what canonical mode compares, so two sheets
+that reach different bytes differ even when the tree diff walked past the
+divergence. Here an empty layer-order pin the projection does not fold
+away: the report shows the two canonical forms and the exit code is 1.
 
   $ cat > pinned.css <<EOF
   > @layer a;@layer a{x{top:0}}
@@ -12,21 +11,13 @@ names the divergence rather than dropping it.
   $ cat > unpinned.css <<EOF
   > @layer a{x{top:0}}
   > EOF
-  $ cascade diff --diff=canonical pinned.css unpinned.css
-  CSS files are equivalent
-  Canonical minified forms still differ (--depth=max shows it)
+  $ NO_COLOR=1 cascade diff --diff=canonical pinned.css unpinned.css
+  CSS: 28 chars vs 19 chars (32.1% diff)
+  Changes: none classified structurally (see report below)
+  Canonical forms differ:
 
-  $ cascade diff --diff=canonical pinned.css unpinned.css > /dev/null; echo $?
-  0
-
-Under --depth=max the two canonical forms are shown.
-
-  $ NO_COLOR=1 cascade diff --diff=canonical --depth=max pinned.css unpinned.css
-  CSS files are equivalent
-  Canonical minified forms still differ:
-  
   Strings differ at position 8 (line 0, col 8)
-  
+
   --- pinned.css
   +++ unpinned.css
   @@ position 8 @@
@@ -34,9 +25,13 @@ Under --depth=max the two canonical forms are shown.
   +@layer a{x{top:0}}
            ^
 
+  [1]
 
+  $ cascade diff --diff=canonical pinned.css unpinned.css > /dev/null; echo $?
+  1
 
-A canonical comparison whose bytes do match keeps the plain verdict.
+Two sheets that reach the same canonical form are equal whatever they were
+spelled like.
 
   $ cat > same-a.css <<EOF
   > .x { color: red }

--- a/test/cli/diff_canonical_residual.t
+++ b/test/cli/diff_canonical_residual.t
@@ -15,16 +15,16 @@ away: the report shows the two canonical forms and the exit code is 1.
   CSS: 28 chars vs 19 chars (32.1% diff)
   Changes: none classified structurally (see report below)
   Canonical forms differ:
-
+  
   Strings differ at position 8 (line 0, col 8)
-
+  
   --- pinned.css
   +++ unpinned.css
   @@ position 8 @@
   -@layer a;@layer a{x{top:0}}
   +@layer a{x{top:0}}
            ^
-
+  
   [1]
 
   $ cascade diff --diff=canonical pinned.css unpinned.css > /dev/null; echo $?

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -919,18 +919,38 @@ let zero_counters_unparsed_do_not_claim_equivalence () =
     "a comparison that never parsed is not an absence of differences" false
     (contains_substring output "No structural differences")
 
-(* Canonical mode keeps the two canonical forms on [No_diff] when the structural
-   comparator saw no difference but the bytes still diverge - here an empty
-   layer-order pin the projection does not fold away. *)
-let canonical_byte_residual_is_recorded () =
-  let result =
-    Cascade_diff.Css_compare.diff ~mode:`Canonical "@layer a;@layer a{x{top:0}}"
-      "@layer a{x{top:0}}"
-  in
-  match result.Cascade_diff.Css_compare.result with
-  | Cascade_diff.Css_compare.No_diff { canonical_byte_diff = Some (e, a) } ->
-      Alcotest.(check bool) "the two forms differ" true (e <> a)
-  | _ -> Alcotest.fail "expected No_diff carrying a canonical byte difference"
+(* The canonical minified form is the verdict in [`Canonical] mode: two sheets
+   whose canonical bytes differ differ, whether or not the tree diff reached the
+   divergence. Here an empty layer-order pin the projection does not fold away -
+   either a normalisation key the projection is missing or a blind spot in the
+   tree diff, and both are findings. *)
+let canonical_byte_residual_is_a_difference () =
+  let pinned = "@layer a;@layer a{x{top:0}}" in
+  let unpinned = "@layer a{x{top:0}}" in
+  let result = Cascade_diff.Css_compare.diff ~mode:`Canonical pinned unpinned in
+  (match result.Cascade_diff.Css_compare.result with
+  | Cascade_diff.Css_compare.String_diff _ -> ()
+  | _ ->
+      Alcotest.fail
+        "expected a string diff of the two differing canonical forms");
+  Alcotest.(check bool)
+    "the equality answer follows the bytes" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical pinned unpinned)
+
+let canonical_byte_equal_is_no_diff () =
+  (* The converse: once the two sheets reach one canonical form, the spelling
+     they started from is immaterial and the verdict is equality. [equal] is
+     [true] only on {!No_diff}, so it pins the constructor too. *)
+  let spaced = ".x { color: red }" in
+  let tight = ".x{color:red}" in
+  Alcotest.(check bool)
+    "the equality answer follows the bytes" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical spaced tight);
+  Alcotest.(check bool)
+    "no tree diff is reported over one canonical form" true
+    (Option.is_none
+       (Cascade_diff.Css_compare.as_tree_diff
+          (Cascade_diff.Css_compare.diff ~mode:`Canonical spaced tight)))
 
 (* ===== diff tests ===== *)
 
@@ -1268,8 +1288,10 @@ let suite =
         zero_counters_do_not_claim_equivalence;
       Alcotest.test_case "zero counters unparsed do not claim equivalence"
         `Quick zero_counters_unparsed_do_not_claim_equivalence;
-      Alcotest.test_case "canonical byte residual is recorded" `Quick
-        canonical_byte_residual_is_recorded;
+      Alcotest.test_case "canonical byte residual is a difference" `Quick
+        canonical_byte_residual_is_a_difference;
+      Alcotest.test_case "canonical byte equality is no diff" `Quick
+        canonical_byte_equal_is_no_diff;
       Alcotest.test_case "diff auto" `Quick diff_auto;
       Alcotest.test_case "diff tree" `Quick diff_tree;
       Alcotest.test_case "diff string" `Quick diff_string;

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -675,7 +675,7 @@ let semantic_legacy_pseudo_element_alias () =
     (Cascade_diff.Css_compare.diff ~mode:`Canonical legacy modern)
       .Cascade_diff.Css_compare.result
   with
-  | Cascade_diff.Css_compare.No_diff _ -> ()
+  | Cascade_diff.Css_compare.No_diff -> ()
   | _ -> Alcotest.fail "expected :before and ::before to canonicalize equally"
 
 let semantic_vendor_recovered () =
@@ -714,13 +714,13 @@ let diff_no_diff () =
   let css = ".a { color: red }" in
   let result = Cascade_diff.Css_compare.diff css css in
   match result.Cascade_diff.Css_compare.result with
-  | Cascade_diff.Css_compare.No_diff _ -> ()
+  | Cascade_diff.Css_compare.No_diff -> ()
   | _ -> Alcotest.fail "expected No_diff"
 
 let diff_no_diff_empty () =
   let result = Cascade_diff.Css_compare.diff "" "" in
   match result.Cascade_diff.Css_compare.result with
-  | Cascade_diff.Css_compare.No_diff _ -> ()
+  | Cascade_diff.Css_compare.No_diff -> ()
   | _ -> Alcotest.fail "expected No_diff for empty strings"
 
 (* ===== diff returning Tree_diff ===== *)
@@ -756,7 +756,7 @@ let diff_string_diff () =
   match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.String_diff d ->
       Alcotest.(check bool) "string diff has position" true (d.position >= 0)
-  | Cascade_diff.Css_compare.No_diff _ ->
+  | Cascade_diff.Css_compare.No_diff ->
       (* Strings might be considered equal after strip_tool_header/trim *)
       ()
   | _ -> Alcotest.fail "expected String_diff or No_diff"
@@ -976,14 +976,14 @@ let diff_string () =
   let result = Cascade_diff.Css_compare.diff ~mode:`String expected actual in
   match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.String_diff _ -> ()
-  | Cascade_diff.Css_compare.No_diff _ -> ()
+  | Cascade_diff.Css_compare.No_diff -> ()
   | _ -> Alcotest.fail "expected String_diff or No_diff in string mode"
 
 let diff_string_identical () =
   let css = ".a { color: red }" in
   let result = Cascade_diff.Css_compare.diff ~mode:`String css css in
   match result.Cascade_diff.Css_compare.result with
-  | Cascade_diff.Css_compare.No_diff _ -> ()
+  | Cascade_diff.Css_compare.No_diff -> ()
   | _ -> Alcotest.fail "expected No_diff for identical in string mode"
 
 let semantic_color_mix_mode () =
@@ -991,7 +991,7 @@ let semantic_color_mix_mode () =
   let actual = ".a { color: " ^ color_mix_transparent_hex ^ " }" in
   let result = Cascade_diff.Css_compare.diff ~mode:`Canonical expected actual in
   match result.Cascade_diff.Css_compare.result with
-  | Cascade_diff.Css_compare.No_diff _ -> ()
+  | Cascade_diff.Css_compare.No_diff -> ()
   | _ -> Alcotest.fail "expected No_diff for semantically equivalent CSS"
 
 let diff_canonical_uses_outputs () =

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -71,6 +71,28 @@ let custom_property_layer_and_meta_survive () =
       Alcotest.failf "expected one rule holding one declaration, got %d rules"
         (List.length ds)
 
+let custom_property_font_name_quoting_converges () =
+  (* CSS Fonts 4 sec. 15.3: a multi-word family name spells the same family
+     quoted or as the ident sequence it unquotes to, and a custom property
+     holding a font stack substitutes either form identically into
+     [font-family]. Emission keeps whichever the author wrote, so only the
+     projection can bring the two spellings together. *)
+  let quoted =
+    {|:root{--font-sans:ui-sans-serif,system-ui,"Noto Color Emoji"}|}
+  in
+  let unquoted =
+    ":root{--font-sans:ui-sans-serif,system-ui,Noto Color Emoji}"
+  in
+  Alcotest.(check string)
+    "the quoted spelling folds onto the ident sequence" (canonical unquoted)
+    (canonical quoted);
+  (* Gated on a generic family being present: without one the property is
+     type-unknown, and a single-word string could be a [<custom-ident>] some
+     other substitution context reads as a string. *)
+  Alcotest.(check bool)
+    "a single-word string stays opaque" true
+    (canonical {|.a{--x:"foo"}|} <> canonical ".a{--x:foo}")
+
 let media_and_independent_rule_converge () =
   (* A conditional block whose rules cannot conflict with a neighbouring rule
      reorders with it, so both source orderings reach one canonical form. *)
@@ -253,6 +275,8 @@ let suite =
         custom_property_importance_survives;
       Alcotest.test_case "custom-property layer and meta survive" `Quick
         custom_property_layer_and_meta_survive;
+      Alcotest.test_case "custom-property font-name quoting converges" `Quick
+        custom_property_font_name_quoting_converges;
       Alcotest.test_case "media and independent rule converge" `Quick
         media_and_independent_rule_converge;
       Alcotest.test_case "media conflict keeps source order" `Quick

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -921,9 +921,30 @@ let deeply_nested_identical_is_empty () =
     "identical deep nesting stays empty" true
     (Cascade_diff.Tree_diff.is_empty d)
 
+(* Known gap, pinned rather than fixed here. An empty [@layer] statement pins
+   the layer order at the point it stands, so [@layer a;] ahead of a [@layer b]
+   block makes [a] the weaker layer, and dropping it makes [b] weaker instead.
+   The walk pairs the two [@layer] blocks and finds their bodies equal, so it
+   reports nothing over two sheets that resolve a conflict the opposite way.
+   Canonical mode catches the pair on the bytes; the fix belongs in the walk. *)
+let layer_order_pin_is_not_reported () =
+  let expected = parse "@layer a;@layer b{y{top:1px}}@layer a{x{top:0}}" in
+  let actual = parse "@layer b{y{top:1px}}@layer a{x{top:0}}" in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check bool)
+    "the layer-order difference is not reported structurally" true
+    (Cascade_diff.Tree_diff.is_empty d);
+  Alcotest.(check bool)
+    "canonical mode reports it" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       "@layer a;@layer b{y{top:1px}}@layer a{x{top:0}}"
+       "@layer b{y{top:1px}}@layer a{x{top:0}}")
+
 let suite =
   ( "tree_diff",
     [
+      Alcotest.test_case "layer-order pin is not reported" `Quick
+        layer_order_pin_is_not_reported;
       Alcotest.test_case "selector group split reported" `Quick
         diff_selector_group_split_reported;
       Alcotest.test_case "selector group merge reported" `Quick


### PR DESCRIPTION
Maintainer ruling: it's canonical or it's not. --diff=canonical now exits 1 whenever the two canonical forms differ and prints the difference; Css_compare.equal answers on the same bytes; No_diff loses its residual payload and the word cosmetic leaves the repo. The mli defines canonical as equivalent inputs projecting to one form, so a surviving byte difference is either two different stylesheets or a missing normalization key - findings either way. Fallout was small: one key added (quoted font names in custom properties, matching what the tree walk already normalized), one narrow key left as a work item (redundant single-name @layer pins need layer-order redundancy analysis), and one real blind spot exposed and pinned - a dropped @layer pin reverses cascade layer order and the tree walk called the sheets identical. Note for tw: five No_diff _ patterns need their underscore dropped at the next pin bump. Stacked on #285.