### PR TITLE
fuzz: compare lists with an element equality

### DIFF
--- a/fuzz/fuzz_context.ml
+++ b/fuzz/fuzz_context.ml
@@ -452,9 +452,9 @@ let assert_document_lookup ctx class_name id attr =
 
 let assert_document_fields (ctx : Css.Context.document) =
   if ctx.element <> Some "div" then fail "document context lost element";
-  if ctx.pseudo_classes <> [ "hover" ] then
+  if not (List.equal String.equal ctx.pseudo_classes [ "hover" ]) then
     fail "document context lost pseudo-class list";
-  if ctx.pseudo_elements <> [ "before" ] then
+  if not (List.equal String.equal ctx.pseudo_elements [ "before" ]) then
     fail "document context lost pseudo-element list"
 
 let test_document_context buf =
@@ -514,7 +514,8 @@ let assert_query_supports ctx =
 
 let assert_query_fields (ctx : Css.Context.query) =
   if ctx.media_type <> Some "screen" then fail "query context lost media type";
-  if ctx.supports <> query_supports then fail "query context lost supports list";
+  if not (List.equal Css.Supports.equal ctx.supports query_supports) then
+    fail "query context lost supports list";
   if ctx.container_name <> Some "card" then
     fail "query context lost container name"
 

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -825,7 +825,7 @@ let test_declared_order_stable buf =
   let important =
     List.map (fun (d : Css.Stylesheet.declared_value) -> d.important) colors
   in
-  if orders <> [ 0; 2 ] then
+  if not (List.equal Int.equal orders [ 0; 2 ]) then
     failf "declared color source order changed: %s"
       (String.concat "," (List.map string_of_int orders));
   if important <> [ false; true ] then
@@ -1282,7 +1282,7 @@ let test_recovery_keeps_rules buf =
     recovered_css "recovery keeps sibling rules" css
   in
   let counts = recovered_declaration_counts stylesheet in
-  if counts <> [ 1; 0; 1 ] then
+  if not (List.equal Int.equal counts [ 1; 0; 1 ]) then
     failf "CSS Syntax recovery changed rule/declaration shape: %S" css;
   if warnings = [] then failf "recovery emitted no warning: %S" css
 
@@ -1302,7 +1302,7 @@ let test_recovery_invalid_rule_boundary buf =
     recovered_css "invalid rule boundary recovery" css
   in
   let counts = recovered_declaration_counts stylesheet in
-  if counts <> [ 1; 1 ] then
+  if not (List.equal Int.equal counts [ 1; 1 ]) then
     failf "CSS Syntax invalid-rule recovery did not preserve sibling rules: %S"
       css;
   if warnings = [] then failf "invalid rule emitted no warning: %S" css
@@ -1319,7 +1319,7 @@ let test_recovery_bad_declaration buf =
     recovered_css "bad declaration recovery" css
   in
   let counts = recovered_declaration_counts stylesheet in
-  if counts <> [ 1 ] then
+  if not (List.equal Int.equal counts [ 1 ]) then
     failf "CSS Syntax recovery dropped valid declaration after invalid one: %S"
       css;
   if warnings = [] then failf "bad declaration emitted no warning: %S" css


### PR DESCRIPTION
Seven polymorphic list comparisons in the fuzz suite tripped merlint E106, which blocks the pre-commit hook on any commit to the tree. Six compare lists of scalars and were only unidiomatic; fuzz_context.ml's supports check compared a Supports.t list, walking an abstract type from another module past its abstraction - that one now calls Supports.equal, which the module already exports. No behaviour change: same assertions, same failures.