### PR TITLE
diff: compare the cascade layer order the sheets declare

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -156,6 +156,9 @@
 
 ### Diff report
 
+- The cascade layer order the two sheets declare is compared, and the report
+  names the layer pairs that swapped. Dropping an `@layer a;` pin, which makes
+  the other layer the weaker one, read as no difference at all
 - A rule that writes one property more than once, as a fallback chain does, is
   compared occurrence by occurrence; matching by name alone made
   `a{color:red;color:blue}` against `a{color:red;color:green}` report

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -26,6 +26,7 @@ type stats = {
   rearranged_rules : int;
   regrouped_rules : int;
   container_changes : int;
+  layer_order_swaps : int;
 }
 
 (* ===== Helper Functions ===== *)
@@ -218,7 +219,7 @@ let build_reorder_diff expected_css actual_css =
   let diffs = ref [] in
   Hashtbl.iter (collect_key_diffs ~tbl2 ~diffs) tbl1;
   if !diffs = [] then None
-  else Some D.{ rules = List.rev !diffs; containers = [] }
+  else Some D.{ rules = List.rev !diffs; containers = []; layer_order = None }
 
 let css_for_semantic_comparison ?property css =
   match property with
@@ -479,6 +480,10 @@ let compute_stats ~expected_str ~actual_str diff_result =
         regrouped_rules =
           count_rule_type (function D.Regrouped _ -> true | _ -> false);
         container_changes = List.length d.containers;
+        layer_order_swaps =
+          (match d.layer_order with
+          | None -> 0
+          | Some { swapped; _ } -> List.length swapped);
       }
   | _ ->
       (* For non-tree diffs, just return character stats *)
@@ -494,6 +499,7 @@ let compute_stats ~expected_str ~actual_str diff_result =
         rearranged_rules = 0;
         regrouped_rules = 0;
         container_changes = 0;
+        layer_order_swaps = 0;
       }
 
 (* Alias for compute_stats *)
@@ -603,12 +609,13 @@ let emit_changes buf stats =
     |> List.filter (fun (n, _, _) -> n > 0)
   in
   let container = stats.container_changes in
+  let layers = stats.layer_order_swaps in
   (* Every counter above comes from a tree diff, so they all read zero on the
      results that never reached one: a comparison that fell through to the
      string diff, a side whose content the parser discarded, a parse error. The
      line says what it knows - nothing was classified - and leaves the verdict
      to the report under it. *)
-  if entries = [] && container = 0 then
+  if entries = [] && container = 0 && layers = 0 then
     Buffer.add_string buf
       "Changes: none classified structurally (see report below)\n"
   else (
@@ -621,6 +628,9 @@ let emit_changes buf stats =
     if container > 0 then (
       if entries <> [] then Buffer.add_string buf ", ";
       add_change buf container "changed" "container");
+    if layers > 0 then (
+      if entries <> [] || container > 0 then Buffer.add_string buf ", ";
+      add_change buf layers "swapped" "layer pair");
     Buffer.add_char buf '\n')
 
 let pp_stats buf stats =

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -171,8 +171,11 @@ type stats = {
   rearranged_rules : int;
   regrouped_rules : int;
   container_changes : int;
+  layer_order_swaps : int;
 }
-(** Summary of differences extracted from a {!t}. *)
+(** Summary of differences extracted from a {!t}. [layer_order_swaps] counts the
+    pairs of cascade layers the two sheets declare in the opposite relative
+    order, as {!Tree_diff.type-layer_order_diff} reports them. *)
 
 val stats : expected_str:string -> actual_str:string -> t -> stats
 (** [stats ~expected_str ~actual_str result] computes a {!type-stats} record

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -87,15 +87,31 @@ type container_diff =
           (** (position, rules) for each block in actual *)
     }
 
-type t = { rules : rule_diff list; containers : container_diff list }
+type layer_order_diff = {
+  expected_order : string list;
+  actual_order : string list;
+  swapped : (string * string) list;
+}
+
+type t = {
+  rules : rule_diff list;
+  containers : container_diff list;
+  layer_order : layer_order_diff option;
+}
 
 (* ===== Constants ===== *)
 
 let default_truncation_length = String_diff.default_max_width
 
+(* How many swapped layer pairs the report names before counting the rest. A
+   reversed order of n layers inverts n(n-1)/2 pairs, and reading the first few
+   is enough to place the change. *)
+let max_layer_swaps = 5
+
 (* ===== Helper Functions ===== *)
 
-let is_empty d = d.rules = [] && d.containers = []
+let is_empty d =
+  d.rules = [] && d.containers = [] && Option.is_none d.layer_order
 
 (* ===== Pretty Printing Functions ===== *)
 
@@ -960,9 +976,61 @@ let pp_containers_section ~style buf containers =
       pp_container_diff ~style ~is_last ~parent_prefix:"" buf cont_diff)
     containers
 
+(* A layer path is keyed for the cascade, not for reading: an anonymous [@layer
+   { }] block is a segment starting with U+0000, which a report has to name some
+   other way. *)
+let layer_path_name path =
+  String.split_on_char '.' path
+  |> List.map (fun segment ->
+      if String.length segment > 0 && segment.[0] = '\000' then
+        "(anonymous " ^ String.sub segment 1 (String.length segment - 1) ^ ")"
+      else segment)
+  |> String.concat "."
+
+let layer_path_list paths = String.concat ", " (List.map layer_path_name paths)
+
+let pp_layer_swaps ~style buf swapped =
+  let line ~is_last text =
+    add_strings buf
+      [ tree_prefix ~style ~is_last ~parent_prefix:""; text; "\n" ]
+  in
+  List.iteri
+    (fun i (weaker, stronger) ->
+      if i < max_layer_swaps then
+        line ~is_last:false
+          (layer_path_name stronger ^ " now precedes " ^ layer_path_name weaker))
+    swapped;
+  match List.length swapped - max_layer_swaps with
+  | hidden when hidden > 0 ->
+      let noun = if hidden = 1 then " more pair\n" else " more pairs\n" in
+      add_strings buf
+        [
+          tree_prefix ~style ~is_last:false ~parent_prefix:"";
+          "...";
+          string_of_int hidden;
+          noun;
+        ]
+  | _ -> ()
+
+let pp_layer_order_section ~style buf = function
+  | None -> ()
+  | Some { expected_order; actual_order; swapped } ->
+      Buffer.add_string buf "Cascade layer order changed:\n";
+      pp_children ~style ~parent_prefix:"" buf (fun style buf ->
+          pp_layer_swaps ~style buf swapped;
+          add_strings buf
+            [
+              tree_prefix ~style ~is_last:true ~parent_prefix:"";
+              "order: ";
+              ansi_red ~color:style.color (layer_path_list expected_order);
+              " -> ";
+              ansi_green ~color:style.color (layer_path_list actual_order);
+              "\n";
+            ])
+
 let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
-    ?(depth = unlimited_depth) buf { rules; containers } =
-  if rules = [] && containers = [] then
+    ?(depth = unlimited_depth) buf { rules; containers; layer_order } =
+  if rules = [] && containers = [] && Option.is_none layer_order then
     Buffer.add_string buf
       "Structural differences detected in nested contexts (e.g., @media inside \
        @layer)\n\
@@ -980,6 +1048,8 @@ let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
     (* [depth] counts renderable levels; the roots printed here are level 1. *)
     let style = { tree_style with color; depth = max 0 (depth - 1) } in
     let container_count = List.length containers in
+    (* The layer order leads: it decides which of the rules below it wins. *)
+    pp_layer_order_section ~style buf layer_order;
     pp_rule_list ~style ~container_count buf meaningful;
     pp_reordered_section ~style ~container_count buf reordered_rules;
     pp_containers_section ~style buf containers)
@@ -2897,6 +2967,60 @@ let process_imports stmts1 stmts2 : rule_diff list =
         (fun s -> (Added { selector = s; declarations = [] } : rule_diff))
         (multiset_remove_each ~remove:l1 l2)
 
+(* Cascade layer order. Two sheets can hold the same [@layer] blocks with the
+   same bodies and still resolve a conflict between two layers the opposite way,
+   because a layer's strength comes from where its name is first declared, not
+   from where its rules stand: an [@layer a;] statement ahead of the blocks pins
+   [a] as the weaker layer wherever its block ends up. Nothing else in the walk
+   reads that, so compare the declared orders here. *)
+
+(* A layer only one side declares is the rule and container walk's business: it
+   reports the [@layer] block that came or went. What only the order shows is a
+   pair of layers both sides declare in the opposite relative order, so restrict
+   each order to the shared names before comparing. *)
+let shared_layer_order order other =
+  List.filter (fun name -> List.exists (String.equal name) other) order
+
+(* The pairs [(weaker, stronger)] that [expected] declares weaker-then-stronger
+   and [actual] the other way round. Both lists hold the same names, so a
+   position lookup in [actual] settles each pair. *)
+let swapped_layer_pairs ~expected ~actual =
+  let positions = Hashtbl.create 16 in
+  List.iteri (fun i name -> Hashtbl.replace positions name i) actual;
+  let position name =
+    match Hashtbl.find_opt positions name with Some i -> i | None -> -1
+  in
+  let rec pairs = function
+    | [] -> []
+    | earlier :: rest ->
+        List.filter_map
+          (fun later ->
+            if position later < position earlier then Some (earlier, later)
+            else None)
+          rest
+        @ pairs rest
+  in
+  pairs expected
+
+(* [Resolve.layer_order] keys a sheet's layers by dotted path, so the two orders
+   compare across spellings: [@layer a.b] and [@layer a { @layer b }] reach the
+   same path, and an [@layer a, b;] statement declares its names the same way a
+   block does. *)
+let layer_order_diff stmts1 stmts2 =
+  let order1 = Resolve.layer_order stmts1 in
+  let order2 = Resolve.layer_order stmts2 in
+  let expected_order = shared_layer_order order1 order2 in
+  let actual_order = shared_layer_order order2 order1 in
+  if List.equal String.equal expected_order actual_order then None
+  else
+    Some
+      {
+        expected_order;
+        actual_order;
+        swapped =
+          swapped_layer_pairs ~expected:expected_order ~actual:actual_order;
+      }
+
 let diff ~(expected : Css.t) ~(actual : Css.t) : t =
   let all1 = Css.statements expected in
   let all2 = Css.statements actual in
@@ -2916,4 +3040,4 @@ let diff ~(expected : Css.t) ~(actual : Css.t) : t =
     detect_container_position_changes all1 all2 base_containers
   in
 
-  { rules = rule_changes; containers }
+  { rules = rule_changes; containers; layer_order = layer_order_diff all1 all2 }

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -94,7 +94,30 @@ type container_diff =
           (** (position, rules) for each block in actual *)
     }
 
-type t = { rules : rule_diff list; containers : container_diff list }
+type layer_order_diff = {
+  expected_order : string list;
+  actual_order : string list;
+  swapped : (string * string) list;
+}
+(** The cascade layer order the two sheets declare, when they declare it
+    differently. Layers are named by the dotted paths of
+    {!Cascade.Resolve.layer_order}, weakest first, restricted to the layers both
+    sheets declare: one side declaring a layer the other does not is reported as
+    the [@layer] block that came or went, not as an order change.
+
+    [swapped] holds the pairs [(weaker, stronger)] that [expected_order]
+    declares in that order and [actual_order] the other way round - the layers
+    whose conflicts the two sheets resolve differently. It is never empty.
+
+    The order compared is the sheet's own, so a layer declared inside a
+    conditional group is not part of it, as in {!Cascade.Resolve.layer_order}.
+*)
+
+type t = {
+  rules : rule_diff list;
+  containers : container_diff list;
+  layer_order : layer_order_diff option;
+}
 (** Structured CSS differences. *)
 
 val is_empty : t -> bool

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -140,6 +140,8 @@ let layered_rules stmts =
   let order, rules = go None ([], []) stmts in
   (order, List.rev rules)
 
+let layer_order stmts = fst (layered_rules stmts)
+
 module Make (N : NODE) = struct
   let preceding_siblings n =
     match N.parent n with

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -66,6 +66,21 @@ val supported : Selector.t -> bool
     branch. Everything else, every stateful pseudo-class and every
     pseudo-element among it, is not. *)
 
+val layer_order : Stylesheet.t -> string list
+(** [layer_order sheet] is the cascade layer order [sheet] declares, weakest
+    first, as one dotted path per layer: [a.b] is the sublayer [b] of [a],
+    however it was written ([@layer a.b] or [@layer a { @layer b }]). Layers
+    come in order of first appearance with each sublayer inside its parent's run
+    (css-cascade-5 sec. 6.4.2), and an [@layer a, b;] statement declares its
+    names there just as a block does. Every anonymous [@layer { ... }] block is
+    a layer of its own, keyed by a path holding a U+0000 that no author can
+    write - a caller that prints these paths has to spell those out itself.
+    Layers declared inside a conditional group are not counted, as
+    {!Make.resolve} does not consider such groups either.
+
+    This is the [~layer_order] that {!Stylesheet.cascade_layer_precedence_rank}
+    expects. *)
+
 module Make (N : NODE) : sig
   val match_selector : Selector.t -> N.t -> match_result
   (** [match_selector sel node] is what the matcher can say about [sel] and

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -921,30 +921,70 @@ let deeply_nested_identical_is_empty () =
     "identical deep nesting stays empty" true
     (Cascade_diff.Tree_diff.is_empty d)
 
-(* Known gap, pinned rather than fixed here. An empty [@layer] statement pins
-   the layer order at the point it stands, so [@layer a;] ahead of a [@layer b]
-   block makes [a] the weaker layer, and dropping it makes [b] weaker instead.
-   The walk pairs the two [@layer] blocks and finds their bodies equal, so it
-   reports nothing over two sheets that resolve a conflict the opposite way.
-   Canonical mode catches the pair on the bytes; the fix belongs in the walk. *)
-let layer_order_pin_is_not_reported () =
+(* ===== Cascade layer order ===== *)
+
+(* An empty [@layer] statement pins the layer order at the point it stands, so
+   [@layer a;] ahead of a [@layer b] block makes [a] the weaker layer, and
+   dropping it makes [b] weaker instead. The two sheets hold the same two
+   [@layer] blocks with the same bodies, so nothing but the declared order tells
+   them apart, and they resolve a conflict between [a] and [b] the opposite
+   way. *)
+let layer_order_pin_is_reported () =
   let expected = parse "@layer a;@layer b{y{top:1px}}@layer a{x{top:0}}" in
   let actual = parse "@layer b{y{top:1px}}@layer a{x{top:0}}" in
   let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
   Alcotest.(check bool)
-    "the layer-order difference is not reported structurally" true
+    "dropping the pin swaps the two layers" false
     (Cascade_diff.Tree_diff.is_empty d);
+  let s = render d in
   Alcotest.(check bool)
-    "canonical mode reports it" false
+    "and the report names the pair that swapped" true
+    (string_contains ~needle:"b now precedes a" s);
+  Alcotest.(check bool)
+    "canonical mode reports it too" false
     (Cascade_diff.Css_compare.equal ~mode:`Canonical
        "@layer a;@layer b{y{top:1px}}@layer a{x{top:0}}"
        "@layer b{y{top:1px}}@layer a{x{top:0}}")
 
+(* Same order, two spellings of the pin: [@layer a;@layer b;] and [@layer a,b;]
+   both declare [a] weaker than [b]. Nothing changed, so the report stays
+   quiet. *)
+let layer_order_declared_two_ways_is_quiet () =
+  let expected =
+    parse "@layer a;@layer b;@layer b{y{top:1px}}@layer a{x{top:0}}"
+  in
+  let actual = parse "@layer a,b;@layer b{y{top:1px}}@layer a{x{top:0}}" in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check bool)
+    "one order written two ways is no difference" true
+    (Cascade_diff.Tree_diff.is_empty d)
+
+(* A sublayer sorts inside its parent, so [@layer a.b;] pins [a.b] ahead of the
+   [a.c] that the block below declares first. Dropping the pin swaps the two
+   sublayers while leaving [a] itself, and both bodies, where they were. *)
+let nested_layer_order_pin_is_reported () =
+  let expected =
+    parse "@layer a.b;@layer a{@layer c{x{top:0}}@layer b{y{top:1px}}}"
+  in
+  let actual = parse "@layer a{@layer c{x{top:0}}@layer b{y{top:1px}}}" in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check bool)
+    "the sublayers swapped" false
+    (Cascade_diff.Tree_diff.is_empty d);
+  let s = render d in
+  Alcotest.(check bool)
+    "and the report names them by their dotted paths" true
+    (string_contains ~needle:"a.c now precedes a.b" s)
+
 let suite =
   ( "tree_diff",
     [
-      Alcotest.test_case "layer-order pin is not reported" `Quick
-        layer_order_pin_is_not_reported;
+      Alcotest.test_case "layer-order pin reported" `Quick
+        layer_order_pin_is_reported;
+      Alcotest.test_case "one layer order written two ways is quiet" `Quick
+        layer_order_declared_two_ways_is_quiet;
+      Alcotest.test_case "nested layer-order pin reported" `Quick
+        nested_layer_order_pin_is_reported;
       Alcotest.test_case "selector group split reported" `Quick
         diff_selector_group_split_reported;
       Alcotest.test_case "selector group merge reported" `Quick


### PR DESCRIPTION
The tree walk paired two `@layer` blocks, found their bodies equal and reported nothing — even when the two sheets declare the layers in opposite orders and so resolve a conflict between them the opposite way.

`@layer a;` ahead of a `@layer b` block makes `a` the weaker layer. Drop that one statement and `b` becomes weaker instead: the same rules now win differently. The walk read the two sheets as identical.

It now compares the declared layer order and names the pairs that swapped:

```
Cascade layer order changed:
├─ b now precedes a
└─ order: a, b -> b, a
```

The order comes from `Resolve.layered_rules`, the model that already backs `cascade_layer_precedence_rank` — exposed as `Resolve.layer_order` rather than written a second time. Layers only one sheet declares are left to the existing added/removed reporting, so the comparison is over the layers both sides have. A layer declared inside `@media`/`@supports`/`@container` is not part of it, matching what `Resolve.layer_order` counts; that boundary is documented in both mlis.

Tests: the case that was pinned as a known gap is now a positive assertion, alongside a nested-sublayer case and a control — `@layer a;@layer b;` against `@layer a,b;` is one order in two spellings and stays quiet.

`Tree_diff.t` gains a `layer_order` field and `Css_compare.stats` a `layer_order_swaps` count, so a layer-order-only diff reads `Changes: 1 swapped layer pair` instead of falling through to "none classified structurally".