### PR TITLE
repo: ignore the _opam symlink a worktree uses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 _build/
-_opam/
+# Not `_opam/`: a worktree points `_opam` at the main checkout's switch with a
+# symlink, and a directory rule leaves that showing up as untracked.
+_opam
 _homebrew_build/
 *~
 .DS_Store


### PR DESCRIPTION
`.gitignore` had `_opam/`, which matches a directory only. Every git worktree here points `_opam` at the main checkout's switch with a symlink, so git listed it as untracked in every `git status` — and that is how it ended up committed to main earlier today (undone by #294, with the switch path of one machine baked into it).

Dropping the trailing slash covers the file, the symlink and the directory. Verified all three: `git check-ignore` matches `_opam` as a symlink, as a directory, and `_opam/lib` inside it, and a fresh worktree now has a clean `git status`.