### PR TITLE
diff: judge container position on the order keys, and name every entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -159,6 +159,11 @@
 - The cascade layer order the two sheets declare is compared, and the report
   names the layer pairs that swapped. Dropping an `@layer a;` pin, which makes
   the other layer the weaker one, read as no difference at all
+- A container that changed places is reported whether or not its body changed,
+  on the same order keys the rule level uses. Three absolute-index distances
+  gated it before, so swapping an `@media` with the rule below it - which
+  changes which declaration wins above the breakpoint - printed `CSS files are
+  identical` and exited 0
 - A rule that writes one property more than once, as a fallback chain does, is
   compared occurrence by occurrence; matching by name alone made
   `a{color:red;color:blue}` against `a{color:red;color:green}` report

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -159,6 +159,10 @@
 - The cascade layer order the two sheets declare is compared, and the report
   names the layer pairs that swapped. Dropping an `@layer a;` pin, which makes
   the other layer the weaker one, read as no difference at all
+- Every entry the report prints names what it is about. A `@property` or
+  `@keyframes` surplus reached the rule level, which has no rule to name and
+  printed a bare tree connector while still counting the entry towards the
+  summary; `@charset`, `@namespace` and `@layer a, b;` had no name at all
 - A container that changed places is reported whether or not its body changed,
   on the same order keys the rule level uses. Three absolute-index distances
   gated it before, so swapping an `@media` with the rule below it - which

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1417,6 +1417,28 @@ let moved_order_keys stmts1 stmts2 =
 
 let selector_moved moved sel = Hashtbl.mem moved (Rule_order sel)
 
+(* The conditions of the containers that changed places against the rest of the
+   enclosing statement list, judged on the same key space as the rule ordering.
+   The absolute index a container sits at is not that coordinate: one statement
+   inserted ahead of a block renumbers it and everything after it without
+   transposing anything, which is why the index comparisons this replaces
+   carried a slack distance and still answered the wrong question on both sides
+   of it. [moved_order_keys] anchors on a longest order-preserving matching of
+   the statements both sides share, so an insertion moves nothing at any
+   distance and a block that swapped with a rule or another block moves even by
+   one position. *)
+let moved_conditions ~condition_of stmts1 stmts2 =
+  let moved = moved_order_keys stmts1 stmts2 in
+  let conds = Hashtbl.create 8 in
+  List.iter
+    (fun stmt ->
+      match (condition_of stmt, order_key_of_stmt stmt) with
+      | Some cond, Some key when Hashtbl.mem moved key ->
+          Hashtbl.replace conds cond ()
+      | _ -> ())
+    stmts1;
+  conds
+
 (* Locate matching declarations in map2 for a given selector key *)
 let matching_decls_in_map2 sel1_key decls1 map2 decls2 =
   (* Prefer an exact declaration match for the same selector key if available *)
@@ -2146,36 +2168,30 @@ let group_by_condition items =
     items;
   tbl
 
-let block_positions_differ blocks1_list blocks2_list =
-  List.length blocks1_list = List.length blocks2_list
-  &&
-  let pos1_list = List.map fst blocks1_list in
-  let pos2_list = List.map fst blocks2_list in
-  List.exists2 (fun p1 p2 -> abs (p1 - p2) > 10) pos1_list pos2_list
-
-let block_structure_differs blocks1_list blocks2_list =
-  List.length blocks1_list <> List.length blocks2_list
-  || block_positions_differ blocks1_list blocks2_list
-
+(* Two sides holding a different number of blocks under one condition split or
+   merged them. Where those blocks sit is a separate question, and one
+   [moved_conditions] answers: comparing their absolute indices here reported
+   the whole tail of a stylesheet as restructured whenever a block was inserted
+   ahead of it, which is what the slack distance was there to hide. *)
 let detect_block_structure_changes blocks1 blocks2 =
   let block_structure_changed = Hashtbl.create 16 in
   Hashtbl.iter
     (fun cond blocks1_list ->
       match Hashtbl.find_opt blocks2 cond with
       | Some blocks2_list ->
-          if block_structure_differs blocks1_list blocks2_list then
+          if List.length blocks1_list <> List.length blocks2_list then
             Hashtbl.replace block_structure_changed cond
               (blocks1_list, blocks2_list)
       | _ -> ())
     blocks1;
   block_structure_changed
 
-let container_position extract_fn cond stmts =
+let condition_position ~condition_of cond stmts =
   let rec go i = function
     | [] -> None
     | stmt :: rest -> (
-        match extract_fn stmt with
-        | Some (c, _) when c = cond -> Some i
+        match condition_of stmt with
+        | Some c when c = cond -> Some i
         | _ -> go (i + 1) rest)
   in
   go 0 stmts
@@ -2187,6 +2203,33 @@ let reordered_container container_type cond rules1 pos1 pos2 =
       expected_pos = pos1;
       actual_pos = pos2;
     }
+
+(* The entry for a container that changed places, naming where it went. *)
+let container_moved ~container_type ~condition_of ~stmts1 ~stmts2 cond rules =
+  match
+    ( condition_position ~condition_of cond stmts1,
+      condition_position ~condition_of cond stmts2 )
+  with
+  | Some pos1, Some pos2 ->
+      Some (reordered_container container_type cond rules pos1 pos2)
+  | None, _ | _, None -> None
+
+(* One entry per container that only changed places. [reported] holds the
+   conditions an entry already names, so a block that also changed content is
+   named once, by the entry that says what changed, and a condition several
+   blocks share is named once for the group. Every condition both sides hold is
+   asked, not only the ones whose bodies differ: a block that kept its body and
+   swapped with the rule below it changes which declaration wins. *)
+let container_reorders ~container_type ~condition_of ~moved_conds ~reported
+    ~stmts1 ~stmts2 items =
+  List.filter_map
+    (fun (cond, rules) ->
+      if (not (Hashtbl.mem moved_conds cond)) || Hashtbl.mem reported cond then
+        None
+      else (
+        Hashtbl.replace reported cond ();
+        container_moved ~container_type ~condition_of ~stmts1 ~stmts2 cond rules))
+    items
 
 let modified_container container_type cond rules1 rules2 rule_changes
     nested_containers =
@@ -2348,6 +2391,13 @@ let extract_supports_as_string stmt =
   | Some (cond, rules) -> Some (Css.Supports.to_string cond, rules)
   | None -> None
 
+(* The name [layer_diff] keys a layer on: an anonymous [@layer { ... }] has
+   none, so it keys on the empty string like every other anonymous one. *)
+let extract_layer_name stmt =
+  match Css.as_layer stmt with
+  | Some (name_opt, rules) -> Some (Option.value ~default:"" name_opt, rules)
+  | None -> None
+
 let keyframes_container_info name =
   { container_type = `Layer; condition = "@keyframes " ^ name; rules = [] }
 
@@ -2453,6 +2503,9 @@ let container_key (name_opt, condition, _) =
 let condition_rules_of_container (name_opt, condition, rules) =
   (container_condition_string name_opt condition, rules)
 
+let extract_container_as_string stmt =
+  Option.map condition_rules_of_container (Css.as_container stmt)
+
 let modified_container_of_pair ((name_opt, condition, rules1), (_, _, rules2)) =
   (container_condition_string name_opt condition, rules1, rules2)
 
@@ -2557,35 +2610,27 @@ and media_diff items1 items2 =
     groups2;
   (!added, !removed, !modified)
 
-and process_modified_container ~container_type ~extract_fn ~stmts1 ~stmts2
-    ~block_structure_changed cond rules1 rules2 =
+and process_modified_container ~container_type ~condition_of ~moved_conds
+    ~stmts1 ~stmts2 ~block_structure_changed ~reported cond rules1 rules2 =
   (* Skip if this condition has a block structure change *)
   if Hashtbl.mem block_structure_changed cond then None
   else
     let rule_changes = to_rule_changes rules1 rules2 in
     (* Recursively check deeper nesting *)
     let nested_containers = nested_differences rules1 rules2 in
-    (* Check for position changes within parent container *)
-    let pos1 =
-      container_position extract_fn cond stmts1 |> Option.value ~default:(-1)
-    in
-    let pos2 =
-      container_position extract_fn cond stmts2 |> Option.value ~default:(-1)
-    in
-    let position_changed = pos1 >= 0 && pos2 >= 0 && abs (pos2 - pos1) > 3 in
-
-    (* If only position changed with no content changes, report as reordered *)
-    if position_changed && rule_changes = [] && nested_containers = [] then
-      Some (reordered_container container_type cond rules1 pos1 pos2)
-    else if rule_changes <> [] || nested_containers <> [] then
+    Hashtbl.replace reported cond ();
+    if rule_changes <> [] || nested_containers <> [] then
       (* Container was modified in content, not just position *)
       Some
         (modified_container container_type cond rules1 rules2 rule_changes
            nested_containers)
+    else if Hashtbl.mem moved_conds cond then
+      container_moved ~container_type ~condition_of ~stmts1 ~stmts2 cond rules1
     else None
 
 and process_nested_containers ~container_type ~extract_fn ~diff_fn stmts1 stmts2
     =
+  let condition_of stmt = Option.map fst (extract_fn stmt) in
   let items_with_pos1 = extract_items_with_positions extract_fn stmts1 in
   let items_with_pos2 = extract_items_with_positions extract_fn stmts2 in
   let block_structure_changed =
@@ -2593,12 +2638,15 @@ and process_nested_containers ~container_type ~extract_fn ~diff_fn stmts1 stmts2
       (group_by_condition items_with_pos1)
       (group_by_condition items_with_pos2)
   in
+  let moved_conds = moved_conditions ~condition_of stmts1 stmts2 in
+  let reported = Hashtbl.create 8 in
   let items1 = List.filter_map extract_fn stmts1 in
   let items2 = List.filter_map extract_fn stmts2 in
   let added, removed, modified = diff_fn items1 items2 in
   let diffs = ref [] in
   Hashtbl.iter
     (fun cond (expected_blocks, actual_blocks) ->
+      Hashtbl.replace reported cond ();
       diffs :=
         Block_structure_changed
           { container_type; condition = cond; expected_blocks; actual_blocks }
@@ -2606,21 +2654,27 @@ and process_nested_containers ~container_type ~extract_fn ~diff_fn stmts1 stmts2
     block_structure_changed;
   List.iter
     (fun (cond, rules) ->
+      Hashtbl.replace reported cond ();
       diffs := Added { container_type; condition = cond; rules } :: !diffs)
     added;
   List.iter
     (fun (cond, rules) ->
+      Hashtbl.replace reported cond ();
       diffs := Removed { container_type; condition = cond; rules } :: !diffs)
     removed;
   List.iter
     (fun (cond, rules1, rules2) ->
       match
-        process_modified_container ~container_type ~extract_fn ~stmts1 ~stmts2
-          ~block_structure_changed cond rules1 rules2
+        process_modified_container ~container_type ~condition_of ~moved_conds
+          ~stmts1 ~stmts2 ~block_structure_changed ~reported cond rules1 rules2
       with
       | Some diff -> diffs := diff :: !diffs
       | None -> ())
     modified;
+  diffs :=
+    container_reorders ~container_type ~condition_of ~moved_conds ~reported
+      ~stmts1 ~stmts2 items1
+    @ !diffs;
   (if !diffs = [] then
      match
        detect_order_only_change ~container_type added removed items1 items2
@@ -2667,21 +2721,30 @@ and layer_diff items1 items2 =
   (added, removed, modified)
 
 (* Shared helper: collect added/removed container diffs and process modified
-   containers with the standard rule-change + nesting logic. *)
-and collect_container_diffs ~container_type added removed modified =
+   containers with the standard rule-change + nesting logic. [extract_fn] names
+   the containers in the enclosing statement list, which is what decides whether
+   one of them moved. *)
+and collect_container_diffs ~container_type ~extract_fn ~stmts1 ~stmts2 added
+    removed modified =
+  let condition_of stmt = Option.map fst (extract_fn stmt) in
+  let moved_conds = moved_conditions ~condition_of stmts1 stmts2 in
+  let reported = Hashtbl.create 8 in
   let diffs = ref [] in
   List.iter
     (fun (condition, rules) ->
+      Hashtbl.replace reported condition ();
       diffs := Added { container_type; condition; rules } :: !diffs)
     added;
   List.iter
     (fun (condition, rules) ->
+      Hashtbl.replace reported condition ();
       diffs := Removed { container_type; condition; rules } :: !diffs)
     removed;
   List.iter
     (fun (condition, rules1, rules2) ->
       let rule_changes = to_rule_changes rules1 rules2 in
       let nested_containers = nested_differences rules1 rules2 in
+      Hashtbl.replace reported condition ();
       if rule_changes <> [] || nested_containers <> [] then
         diffs :=
           Modified
@@ -2691,16 +2754,27 @@ and collect_container_diffs ~container_type added removed modified =
               rule_changes;
               container_changes = nested_containers;
             }
-          :: !diffs)
+          :: !diffs
+      else if Hashtbl.mem moved_conds condition then
+        match
+          container_moved ~container_type ~condition_of ~stmts1 ~stmts2
+            condition rules1
+        with
+        | Some diff -> diffs := diff :: !diffs
+        | None -> ())
     modified;
-  !diffs
+  container_reorders ~container_type ~condition_of ~moved_conds ~reported
+    ~stmts1 ~stmts2
+    (List.filter_map extract_fn stmts1)
+  @ !diffs
 
 (* Process layers separately due to different type signature *)
 and process_nested_layers stmts1 stmts2 =
   let items1 = List.filter_map Css.as_layer stmts1 in
   let items2 = List.filter_map Css.as_layer stmts2 in
   let added, removed, modified = layer_diff items1 items2 in
-  collect_container_diffs ~container_type:`Layer added removed modified
+  collect_container_diffs ~container_type:`Layer ~extract_fn:extract_layer_name
+    ~stmts1 ~stmts2 added removed modified
 
 and container_has_no_diff (_, _, rules1) (_, _, rules2) =
   let a_r, r_r, m_r, rg_r = rule_diffs rules1 rules2 in
@@ -2725,7 +2799,9 @@ and process_nested_containers_with_name stmts1 stmts2 =
   let items1 = List.filter_map Css.as_container stmts1 in
   let items2 = List.filter_map Css.as_container stmts2 in
   let added, removed, modified = container_diff items1 items2 in
-  collect_container_diffs ~container_type:`Container added removed modified
+  collect_container_diffs ~container_type:`Container
+    ~extract_fn:extract_container_as_string ~stmts1 ~stmts2 added removed
+    modified
 
 (* Process CSS nesting: rules with nested child rules (& .foo { ... }) *)
 and process_nested_rules stmts1 stmts2 =
@@ -2840,55 +2916,6 @@ and nested_differences (stmts1 : Css.statement list)
   @ process_nested_keyframes stmts1 stmts2
   (* Process the at-rules that carry no selector of their own *)
   @ process_at_rules stmts1 stmts2
-
-(* Check if containers appear at different positions in statement sequence *)
-let detect_container_position_changes stmts1 stmts2 containers =
-  (* Build position maps for @media containers *)
-  let build_media_position_map stmts =
-    List.mapi
-      (fun i stmt ->
-        match Css.as_media stmt with
-        | Some (cond, _) -> Some (Css.Media.to_string cond, i)
-        | None -> None)
-      stmts
-    |> List.filter_map (fun x -> x)
-    |> List.fold_left
-         (fun acc (cond, pos) ->
-           let existing = try List.assoc cond acc with Not_found -> [] in
-           (cond, pos :: existing) :: List.remove_assoc cond acc)
-         []
-  in
-
-  let pos_map1 = build_media_position_map stmts1 in
-  let pos_map2 = build_media_position_map stmts2 in
-
-  (* Enhance container_diffs with position info *)
-  List.map
-    (function
-      | Modified
-          ({
-             info = { container_type = `Media; condition; _ };
-             rule_changes;
-             container_changes;
-             _;
-           } as cm)
-        when rule_changes = [] && container_changes = [] ->
-          (* No content changes - check if position changed *)
-          let pos1 =
-            try List.assoc condition pos_map1 |> List.hd
-            with Not_found | Failure _ -> -1
-          in
-          let pos2 =
-            try List.assoc condition pos_map2 |> List.hd
-            with Not_found | Failure _ -> -1
-          in
-          if pos1 >= 0 && pos2 >= 0 && abs (pos2 - pos1) > 5 then
-            (* Significant position change - report as structure difference *)
-            Modified
-              { cm with info = { cm.info with rules = [] }; actual_rules = [] }
-          else Modified cm
-      | other -> other)
-    containers
 
 (* Main diff function *)
 (* @import and the other selectorless leaf rules collapse onto the universal
@@ -3035,9 +3062,5 @@ let diff ~(expected : Css.t) ~(actual : Css.t) : t =
   in
 
   (* Delegate all container and nested-container diffs to the generic walker *)
-  let containers =
-    let base_containers = nested_differences all1 all2 in
-    detect_container_position_changes all1 all2 base_containers
-  in
-
+  let containers = nested_differences all1 all2 in
   { rules = rule_changes; containers; layer_order = layer_order_diff all1 all2 }

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -654,6 +654,22 @@ let describe_statement stmt =
       (fun s ->
         Option.map (fun (name, _) -> "@keyframes " ^ name) (Css.as_keyframes s));
       (fun s -> Option.map (fun _ -> "@font-face") (Css.as_font_face s));
+      (* The statements that carry neither a selector nor a block. Naming them
+         apart also keeps them apart in the order keys, where one shared "(other
+         statement)" made a [@charset] and a [@namespace] the same statement. *)
+      (fun (s : Css.statement) ->
+        match s with
+        | Charset encoding -> Some ("@charset \"" ^ encoding ^ "\";")
+        | Namespace (prefix, _) ->
+            Some
+              ("@namespace"
+              ^ (match prefix with Some p -> " " ^ p | None -> "")
+              ^ ";")
+        (* The semicolon is what tells a layer-order pin from the block of the
+           same name: [@layer a;] ahead of [@layer a { ... }] is a second
+           statement, not the block again. *)
+        | Layer_decl names -> Some ("@layer " ^ String.concat ", " names ^ ";")
+        | _ -> None);
     ]
   in
   match List.find_map try_desc matchers with
@@ -1056,13 +1072,33 @@ let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
 
 (* ===== Tree Diff Computation Functions ===== *)
 
+(* The text a statement prints to, cut at its block, for the statements no
+   selector names: [@charset "UTF-8";], [@layer a, b;], [@namespace ...]. An
+   entry with no name cannot be classified, so it corrupts every count the
+   summary derives from the same list, and it renders as a bare tree
+   connector. *)
+let statement_head stmt =
+  let text =
+    Css.Stylesheet.to_string ~minify:true (Css.v [ stmt ]) |> String.trim
+  in
+  let head =
+    match String.index_opt text '{' with
+    | Some i -> String.trim (String.sub text 0 i)
+    | None -> text
+  in
+  if head = "" then
+    Option.value ~default:"(other statement)" (describe_statement stmt)
+  else head
+
 (* Helper to extract rule information from statements *)
 let strings_of_rule stmt =
   match Css.as_rule stmt with
   | Some (selector, decls, _) ->
       let selector_str = Css.Selector.to_string selector in
       (selector_str, decls)
-  | None -> ("", [])
+  | None ->
+      ( statement_head stmt,
+        Option.value ~default:[] (Css.statement_declarations stmt) )
 
 let decl_to_prop_value decl =
   let name = Css.declaration_name decl in
@@ -1810,9 +1846,8 @@ let properties_diff decls1 decls2 : declaration list * string list * string list
    recursion *)
 (* A container still takes part in the ordering comparison, since swapping a
    rule with an [@media] is cascade-significant, but [container_changes] is what
-   reports it. Converting it here as well produced a second entry for the same
-   block, with an empty selector because [strings_of_rule] has no rule to
-   name. *)
+   reports it. Converting it here as well gives a second entry for the same
+   block. *)
 let is_container_statement stmt =
   Css.as_media stmt <> None
   || Css.as_supports stmt <> None
@@ -2061,6 +2096,18 @@ let at_rule_body (stmt : Css.statement) : at_rule_body option =
    well would report one change twice, once against the universal selector. *)
 let is_selectorless_at_rule stmt = at_rule_body stmt <> None
 
+(* Every statement a processor of its own reads and names.
+   [selector_key_of_stmt] gives all of them the universal selector, so the rule
+   matcher pairs a [@property] with a [@keyframes] with a [@media] and hands
+   whichever it has one too many of to the report, where nothing can name it.
+   Containers are the exception and stay: [moved_order_keys] reads their
+   position, and [convert_added_rule]/[convert_removed_rule] keep them out of
+   the entries. *)
+let is_reported_by_own_processor stmt =
+  is_selectorless_at_rule stmt
+  || Css.as_property stmt <> None
+  || Css.as_keyframes stmt <> None
+
 (* The at-rule text split at its block: the head keys the statement, the body is
    what a descriptor-only at-rule is compared on. *)
 let at_rule_text stmt =
@@ -2137,10 +2184,12 @@ let at_rule_text_change text1 text2 =
     }
 
 let to_rule_changes rules1 rules2 : rule_diff list =
-  (* [process_at_rules] reads these statements, and a rule diff can only see
-     them as one more universal selector. *)
-  let rules1 = List.filter (fun s -> not (is_selectorless_at_rule s)) rules1 in
-  let rules2 = List.filter (fun s -> not (is_selectorless_at_rule s)) rules2 in
+  let rules1 =
+    List.filter (fun s -> not (is_reported_by_own_processor s)) rules1
+  in
+  let rules2 =
+    List.filter (fun s -> not (is_reported_by_own_processor s)) rules2
+  in
   let r_added, r_removed, r_modified, r_regrouped = rule_diffs rules1 rules2 in
   let moved = moved_order_keys rules1 rules2 in
   List.filter_map convert_added_rule r_added

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -143,6 +143,26 @@ stays ordered: swapping it with the rule is a real difference.
   
   [1]
 
+The same swap the other way round, with the block ahead of the rule. Which
+of the two the walk names is its own choice; what may not happen is calling
+the pair identical.
+
+  $ NO_COLOR=1 cascade diff --diff=tree before.css after.css > /dev/null; echo $?
+  1
+  $ NO_COLOR=1 cascade diff --diff=tree after.css before.css > /dev/null; echo $?
+  1
+
+  $ cat > swap-a.css <<EOF
+  > @media (min-width:10px){a{color:red}}a{color:blue}
+  > EOF
+  $ cat > swap-b.css <<EOF
+  > a{color:blue}@media (min-width:10px){a{color:red}}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=tree swap-a.css swap-b.css > /dev/null; echo $?
+  1
+  $ NO_COLOR=1 cascade diff --diff=canonical swap-a.css swap-b.css > /dev/null; echo $?
+  1
+
 
 
 The --diff=string mode falls back to character-level diffing.

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -921,6 +921,130 @@ let deeply_nested_identical_is_empty () =
     "identical deep nesting stays empty" true
     (Cascade_diff.Tree_diff.is_empty d)
 
+(* ===== Container position ===== *)
+
+(* The container names carried by every [Reordered] container entry, at any
+   depth. *)
+let rec container_reorders (c : Cascade_diff.Tree_diff.container_diff) =
+  match c with
+  | Reordered { info = { condition; _ }; _ } -> [ condition ]
+  | Modified { container_changes; _ } ->
+      List.concat_map container_reorders container_changes
+  | Added _ | Removed _ | Block_structure_changed _ -> []
+
+let reordered_containers d =
+  List.concat_map container_reorders d.Cascade_diff.Tree_diff.containers
+
+(* Source order decides the winner between a conditional block and a rule that
+   writes the same property on the same selector, so swapping the two is a
+   difference whichever side the block starts on. *)
+let media_swapped_with_rule_is_reported () =
+  let d =
+    diff_of ~expected:"@media (min-width:10px){a{color:red}}a{color:blue}"
+      ~actual:"a{color:blue}@media (min-width:10px){a{color:red}}"
+  in
+  Alcotest.(check bool)
+    "swapping a block with a rule is a difference" false
+    (Cascade_diff.Tree_diff.is_empty d)
+
+(* The mirror image of the case above, which the rule-level ordering already
+   caught: both directions must report, and neither may report twice. *)
+let rule_swapped_with_media_is_reported () =
+  let d =
+    diff_of ~expected:"a{color:blue}@media (min-width:10px){a{color:red}}"
+      ~actual:"@media (min-width:10px){a{color:red}}a{color:blue}"
+  in
+  Alcotest.(check bool)
+    "the swap is a difference in the other direction too" false
+    (Cascade_diff.Tree_diff.is_empty d)
+
+(* Control. Inserting a rule ahead of a block shifts its absolute index without
+   moving it past anything, so the block did not move and must stay quiet. *)
+let insertion_ahead_of_media_is_not_a_move () =
+  let d =
+    diff_of ~expected:"a{color:red}@media print{.b{top:0}}"
+      ~actual:"a{color:red}.c{left:0}@media print{.b{top:0}}"
+  in
+  Alcotest.(check (list string))
+    "an insertion is not a container move" [] (reordered_containers d)
+
+(* Control. Same, with the insertion far enough ahead to shift the block past
+   any fixed distance: absolute index is not the coordinate. *)
+let distant_insertion_is_not_a_move () =
+  let filler n =
+    String.concat ""
+      (List.init n (fun i ->
+           let s = string_of_int i in
+           ".f" ^ s ^ "{order:" ^ s ^ "}"))
+  in
+  let d =
+    diff_of
+      ~expected:("a{color:red}" ^ "@media print{.b{top:0}}")
+      ~actual:("a{color:red}" ^ filler 12 ^ "@media print{.b{top:0}}")
+  in
+  Alcotest.(check (list string))
+    "twelve insertions are still not a container move" []
+    (reordered_containers d)
+
+(* ===== Entries the report cannot name ===== *)
+
+(* The names every rule-level entry claiming an addition or a removal carries.
+   An entry with no name cannot be classified, so it corrupts the counts the
+   summary prints from the same list. *)
+let added_or_removed_names d =
+  List.filter_map
+    (fun (diff : Cascade_diff.Tree_diff.rule_diff) ->
+      match diff with
+      | Added { selector; _ } | Removed { selector; _ } -> Some selector
+      | _ -> None)
+    d.Cascade_diff.Tree_diff.rules
+
+(* [@property] has a container processor of its own, which names the block it
+   dropped; the rule level has no rule to name and prints a bare tree
+   connector. *)
+let removed_property_rule_is_named () =
+  let d =
+    diff_of ~expected:"@property --a{syntax:\"*\";inherits:false}.x{color:red}"
+      ~actual:".x{color:red}"
+  in
+  Alcotest.(check bool)
+    "dropping a registration is a difference" false
+    (Cascade_diff.Tree_diff.is_empty d);
+  Alcotest.(check (list string))
+    "no rule-level entry without a name" [] (added_or_removed_names d)
+
+let removed_keyframes_is_named () =
+  let d =
+    diff_of ~expected:"@keyframes k{from{opacity:0}}.x{color:red}"
+      ~actual:".x{color:red}"
+  in
+  Alcotest.(check (list string))
+    "no rule-level entry without a name" [] (added_or_removed_names d)
+
+(* Nothing else reports a [@charset], so the rule level has to keep it - and
+   name it. *)
+let removed_charset_is_named () =
+  let d =
+    diff_of ~expected:"@charset \"UTF-8\";.x{color:red}" ~actual:".x{color:red}"
+  in
+  Alcotest.(check bool)
+    "dropping the charset is a difference" false
+    (Cascade_diff.Tree_diff.is_empty d);
+  Alcotest.(check bool)
+    "the entry names what was dropped" true
+    (string_contains ~needle:"@charset" (render d))
+
+let removed_layer_statement_is_named () =
+  let d =
+    diff_of ~expected:"@layer a,b;.x{color:red}" ~actual:".x{color:red}"
+  in
+  Alcotest.(check bool)
+    "dropping the layer order is a difference" false
+    (Cascade_diff.Tree_diff.is_empty d);
+  Alcotest.(check bool)
+    "the entry names what was dropped" true
+    (string_contains ~needle:"@layer" (render d))
+
 (* ===== Cascade layer order ===== *)
 
 (* An empty [@layer] statement pins the layer order at the point it stands, so
@@ -985,6 +1109,22 @@ let suite =
         layer_order_declared_two_ways_is_quiet;
       Alcotest.test_case "nested layer-order pin reported" `Quick
         nested_layer_order_pin_is_reported;
+      Alcotest.test_case "media swapped with rule is reported" `Quick
+        media_swapped_with_rule_is_reported;
+      Alcotest.test_case "rule swapped with media is reported" `Quick
+        rule_swapped_with_media_is_reported;
+      Alcotest.test_case "insertion ahead of media is not a move" `Quick
+        insertion_ahead_of_media_is_not_a_move;
+      Alcotest.test_case "distant insertion is not a move" `Quick
+        distant_insertion_is_not_a_move;
+      Alcotest.test_case "removed property rule is named" `Quick
+        removed_property_rule_is_named;
+      Alcotest.test_case "removed keyframes is named" `Quick
+        removed_keyframes_is_named;
+      Alcotest.test_case "removed charset is named" `Quick
+        removed_charset_is_named;
+      Alcotest.test_case "removed layer statement is named" `Quick
+        removed_layer_statement_is_named;
       Alcotest.test_case "selector group split reported" `Quick
         diff_selector_group_split_reported;
       Alcotest.test_case "selector group merge reported" `Quick


### PR DESCRIPTION
Stacked on #295 (chain: #295 → #297 → #298 → #299) — #295 and this one rewrite the same walk. Review the top three commits.

## A moved container went unreported

`@media (min-width:10px){a{color:red}}` followed by `a{color:blue}`, against the same two statements swapped, printed `CSS files are identical` and exited 0 under both `--diff=tree` and `--diff=canonical`. The two sheets are genuinely different: above the breakpoint, source order decides whether `red` or `blue` wins. `cascade fmt --minify` shows the two canonical forms plainly disagree.

Two causes. Container position was gated behind three absolute-index distances — `abs (pos2 - pos1) > 3`, `> 5` and `> 10` — so a one-place move never cleared the bar. And a container was only position-checked when its *body* also differed, so a block that merely moved was never examined at all.

Position now goes through the same `moved_order_keys` / `increasing_subsequence` key space the rule level uses: threshold-free, stable under insertions, and checked whether or not the body changed. All three magic distances are gone.

```
└─ @media (min-width: 10px) (position 0 → 1)
```

Tests pin both swap directions, plus two controls — inserting a rule ahead of a block shifts its absolute index without moving it past anything, and must stay quiet.

## Entries with no name

The report printed bare tree connectors: `├─ ` and a newline, no selector, no body — while still counting those entries in the summary, so it read `Changes: 3 removed rules` while naming one. A `@property` or `@keyframes` surplus reached the rule level, which has no rule to name; `@charset`, `@namespace` and `@layer a, b;` had no name at all. An entry that cannot be named cannot be classified, so it corrupted every downstream count.

Every entry now names what it is about.