### PR TITLE
shorthand: rebuild the importance-stripped declaration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,9 @@
 - `--lossless` keeps a flow-relative property in source order against a
   physical one of the same family, since the writing mode decides which
   physical side it resolves to (#277)
+- A vendor-prefixed value repeated with `!important` collapses to the later
+  declaration; only a genuine value difference is kept as a legacy fallback.
+  `display:-webkit-box;display:-webkit-box!important` survived as both
 - A selector list mixing a vendor pseudo-element with ordinary selectors is
   split, so a browser that ignores `::-webkit-search-cancel-button` keeps the
   other selectors' declarations (#203)

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3426,9 +3426,14 @@ let property_covered_by_important kept decl =
 
 let same_property = Declaration.same_property
 
+(* Rebuilt through the smart constructors: they recompute the cached
+   [Declaration.hash] over the new payload, and a record update would leave it
+   fingerprinting the importance that was just cleared. *)
 let rec without_importance = function
-  | Declaration r -> Declaration { r with important = false }
-  | Theme_guarded t -> Theme_guarded { t with decl = without_importance t.decl }
+  | Declaration { property; value; _ } ->
+      Declaration.v ~important:false property value
+  | Theme_guarded { var_name; decl; _ } ->
+      Declaration.theme_guarded ~var_name (without_importance decl)
 
 (* Value equality ignoring importance. Every caller establishes [same_property]
    first, so the two declarations share a value type and this is a structural

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -411,6 +411,29 @@ let test_deduplicate_keeps_legacy_fallbacks () =
     ]
     (decl_strings result)
 
+let test_same_value_ignores_importance () =
+  Alcotest.(check bool)
+    "importance alone does not change the value" true
+    (Shorthand.same_value
+       (decl "display:-webkit-box")
+       (decl "display:-webkit-box!important"));
+  Alcotest.(check bool)
+    "the same holds under a theme guard" true
+    (Shorthand.same_value
+       (Declaration.theme_guarded ~var_name:"--x" (decl "display:-webkit-box"))
+       (Declaration.theme_guarded ~var_name:"--x"
+          (decl "display:-webkit-box!important")));
+  (* Equal values are not a vendor fallback, so the earlier declaration is
+     dropped even though the later one adds [!important]. *)
+  let result =
+    ".a{display:-webkit-box;display:-webkit-box!important}" |> decls
+    |> Shorthand.deduplicate_declarations
+  in
+  Alcotest.(check (list string))
+    "a vendor value repeated with !important collapses"
+    [ "display:-webkit-box!important" ]
+    (decl_strings result)
+
 let suite =
   ( "shorthand",
     [
@@ -443,4 +466,6 @@ let suite =
         test_stylesheet_scope_prior_longhand_guard;
       Alcotest.test_case "deduplicate keeps legacy fallbacks" `Quick
         test_deduplicate_keeps_legacy_fallbacks;
+      Alcotest.test_case "same value ignores importance" `Quick
+        test_same_value_ignores_importance;
     ] )


### PR DESCRIPTION
Stacked on #297 (chain: #295 → #297 → #298 → #299). Review the last two commits; the rest is the base.

`without_importance` built `Declaration { r with important = false }`, copying the cached `hash` field that was computed over `(property, value, important)` — so the copy carried a fingerprint of the importance it had just cleared. `same_value` compares with polymorphic `=`, which walks that field, so `legacy_vendor_fallback`'s `not (same_value ...)` guard read two equal values as different:

```
a{display:-webkit-box;display:-webkit-box!important}
  before: a{display:-webkit-box;display:-webkit-box!important}
  after:  a{display:-webkit-box!important}
```

The equal-importance pair collapsed correctly all along; only the pair differing in importance leaked through.

Impact is output size — the wrong answer keeps a redundant declaration, and no mis-hashed declaration escapes the module — but a record update on a type whose smart constructor is meant to be the sole path is a landmine. Both arms now rebuild through `Declaration.v` and `Declaration.theme_guarded`, which recompute the hash; that is the shape `Declaration.important` already used two lines away.