### PR TITLE
Preserve logical aliases in lossless mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,7 @@
 
 ### Minification
 
+- `--lossless` preserves logical sizing and corner aliases in source order.
 - A hex colour folds to its name whenever the name is no longer, which the
   hand-copied inversion table missed for `bisque`, `indigo`, `orchid`,
   `salmon`, `sienna`, `tomato` and `violet`: `#ffe4c4` stayed hex where

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -852,17 +852,36 @@ let property_slots : type a. a Properties.property -> overlap_key list =
 let logical_alias_families =
   Properties.
     [
-      ([ Prop Margin_inline; Prop Margin_block ], Prop Margin);
-      ([ Prop Padding_inline; Prop Padding_block ], Prop Padding);
-      ([ Prop Inset_inline; Prop Inset_block ], Prop Inset);
-      ([ Prop Border_inline_width; Prop Border_block_width ], Prop Border_width);
-      ([ Prop Border_inline_style; Prop Border_block_style ], Prop Border_style);
-      ([ Prop Border_inline_color; Prop Border_block_color ], Prop Border_color);
+      ([ Prop Margin_inline; Prop Margin_block ], [ Prop Margin ]);
+      ([ Prop Padding_inline; Prop Padding_block ], [ Prop Padding ]);
+      ([ Prop Inset_inline; Prop Inset_block ], [ Prop Inset ]);
+      ( [ Prop Border_inline_width; Prop Border_block_width ],
+        [ Prop Border_width ] );
+      ( [ Prop Border_inline_style; Prop Border_block_style ],
+        [ Prop Border_style ] );
+      ( [ Prop Border_inline_color; Prop Border_block_color ],
+        [ Prop Border_color ] );
       ( [ Prop Scroll_margin_inline; Prop Scroll_margin_block ],
-        Prop Scroll_margin );
+        [ Prop Scroll_margin ] );
       ( [ Prop Scroll_padding_inline; Prop Scroll_padding_block ],
-        Prop Scroll_padding );
-      ([ Prop Overflow_block; Prop Overflow_inline ], Prop Overflow);
+        [ Prop Scroll_padding ] );
+      ([ Prop Overflow_block; Prop Overflow_inline ], [ Prop Overflow ]);
+      ([ Prop Inline_size; Prop Block_size ], [ Prop Width; Prop Height ]);
+      ( [ Prop Min_inline_size; Prop Min_block_size ],
+        [ Prop Min_width; Prop Min_height ] );
+      ( [ Prop Max_inline_size; Prop Max_block_size ],
+        [ Prop Max_width; Prop Max_height ] );
+      ( [
+          Prop Border_start_start_radius;
+          Prop Border_start_end_radius;
+          Prop Border_end_start_radius;
+          Prop Border_end_end_radius;
+        ],
+        [ Prop Border_radius ] );
+      ( [ Prop Contain_intrinsic_inline_size; Prop Contain_intrinsic_block_size ],
+        [ Prop Contain_intrinsic_width; Prop Contain_intrinsic_height ] );
+      ( [ Prop Overscroll_behavior_inline; Prop Overscroll_behavior_block ],
+        [ Prop Overscroll_behavior_x; Prop Overscroll_behavior_y ] );
     ]
 
 (* Each logical slot paired with the physical slots it may alias, sorted for
@@ -873,7 +892,7 @@ let logical_alias_index =
     List.concat_map
       (fun (logical, physical) ->
         let physical_slots =
-          match physical with Properties.Prop p -> property_slots p
+          List.concat_map (fun (Properties.Prop p) -> property_slots p) physical
         in
         List.concat_map
           (fun l ->

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1067,6 +1067,37 @@ let logical_physical_order_cases =
     ( "scroll-margin-top before scroll-margin-block-start",
       ".a{scroll-margin-top:1px;scroll-margin-block-start:2px}",
       ".a{scroll-margin-top:1px;scroll-margin-block-start:2px}" );
+    (* CSS Logical 1 sec. 4.4: the sizing family aliases the same way, with no
+       physical shorthand covering the two axes. *)
+    ( "width before inline-size",
+      ".a{width:10px;inline-size:20px}",
+      ".a{width:10px;inline-size:20px}" );
+    ( "inline-size before width",
+      ".a{inline-size:20px;width:10px}",
+      ".a{inline-size:20px;width:10px}" );
+    ( "height before block-size",
+      ".a{height:10px;block-size:20px}",
+      ".a{height:10px;block-size:20px}" );
+    ( "min-width before min-inline-size",
+      ".a{min-width:10px;min-inline-size:20px}",
+      ".a{min-width:10px;min-inline-size:20px}" );
+    ( "max-width before max-inline-size",
+      ".a{max-width:10px;max-inline-size:20px}",
+      ".a{max-width:10px;max-inline-size:20px}" );
+    (* CSS Logical 1 sec. 4.3: a flow-relative corner resolves to whichever
+       physical corner the writing mode and the direction give it. *)
+    ( "border-top-left-radius before border-start-start-radius",
+      ".a{border-top-left-radius:1px;border-start-start-radius:2px}",
+      ".a{border-top-left-radius:1px;border-start-start-radius:2px}" );
+    ( "border-start-start-radius before border-top-left-radius",
+      ".a{border-start-start-radius:2px;border-top-left-radius:1px}",
+      ".a{border-start-start-radius:2px;border-top-left-radius:1px}" );
+    ( "contain-intrinsic-width before contain-intrinsic-inline-size",
+      ".a{contain-intrinsic-width:1px;contain-intrinsic-inline-size:2px}",
+      ".a{contain-intrinsic-width:1px;contain-intrinsic-inline-size:2px}" );
+    ( "overscroll-behavior-x before overscroll-behavior-inline",
+      ".a{overscroll-behavior-x:none;overscroll-behavior-inline:contain}",
+      ".a{overscroll-behavior-x:none;overscroll-behavior-inline:contain}" );
   ]
 
 let test_lossless_keeps_logical_physical_order () =

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -220,6 +220,106 @@ let test_logical_physical_overlap () =
        (decl "border-inline-width:2px")
        (decl "border-left-color:red"))
 
+let test_logical_axis_overlap () =
+  (* CSS Logical 1 sec. 4.4: [inline-size] is [width] in a horizontal writing
+     mode and [height] in a vertical one, so it may write either slot. The
+     sizing family has no physical shorthand, which does not change the
+     aliasing. *)
+  Alcotest.(check bool)
+    "an inline size overlaps the physical width" true
+    (Shorthand.declarations_overlap (decl "inline-size:20px")
+       (decl "width:10px"));
+  Alcotest.(check bool)
+    "the relation is symmetric" true
+    (Shorthand.declarations_overlap (decl "width:10px")
+       (decl "inline-size:20px"));
+  Alcotest.(check bool)
+    "the same logical size overlaps the physical height too" true
+    (Shorthand.declarations_overlap (decl "inline-size:20px")
+       (decl "height:10px"));
+  Alcotest.(check bool)
+    "a block size overlaps the physical height" true
+    (Shorthand.declarations_overlap (decl "block-size:20px")
+       (decl "height:10px"));
+  Alcotest.(check bool)
+    "a logical minimum overlaps the physical minimum" true
+    (Shorthand.declarations_overlap
+       (decl "min-inline-size:20px")
+       (decl "min-width:10px"));
+  Alcotest.(check bool)
+    "a logical maximum overlaps the physical maximum" true
+    (Shorthand.declarations_overlap
+       (decl "max-block-size:20px")
+       (decl "max-height:10px"));
+  (* A recovered longhand keeps the aliasing: its value defeated the typed
+     reader, not the cascade slot it writes. *)
+  Alcotest.(check bool)
+    "a recovered logical size overlaps its physical property" true
+    (Shorthand.declarations_overlap
+       (decl "inline-size:var(--a) var(--b)")
+       (decl "width:10px"));
+  (* CSS Sizing 4 sec. 5.2 gives [contain-intrinsic-size] the same two axes. *)
+  Alcotest.(check bool)
+    "a logical intrinsic size overlaps the physical one" true
+    (Shorthand.declarations_overlap
+       (decl "contain-intrinsic-inline-size:20px")
+       (decl "contain-intrinsic-width:10px"));
+  (* CSS Overscroll Behavior 1 sec. 3: the [-inline] and [-block] longhands are
+     the flow-relative spellings of [-x] and [-y]. *)
+  Alcotest.(check bool)
+    "a logical overscroll behaviour overlaps the physical one" true
+    (Shorthand.declarations_overlap
+       (decl "overscroll-behavior-inline:contain")
+       (decl "overscroll-behavior-x:none"));
+  (* Aliasing is within a family: a size never resolves to a minimum, and the
+     two physical axes are two slots whatever the writing mode. *)
+  Alcotest.(check bool)
+    "a logical size and a physical minimum are disjoint" false
+    (Shorthand.declarations_overlap (decl "inline-size:20px")
+       (decl "min-width:10px"));
+  Alcotest.(check bool)
+    "the two physical sizes stay disjoint" false
+    (Shorthand.declarations_overlap (decl "width:10px") (decl "height:20px"));
+  Alcotest.(check bool)
+    "a logical size and an intrinsic size are disjoint" false
+    (Shorthand.declarations_overlap (decl "inline-size:20px")
+       (decl "contain-intrinsic-width:10px"))
+
+let test_logical_corner_overlap () =
+  (* CSS Logical 1 sec. 4.3: a flow-relative corner resolves to one of the four
+     physical corners, which one depending on the writing mode and the
+     direction. *)
+  Alcotest.(check bool)
+    "a start-start corner overlaps the top-left corner" true
+    (Shorthand.declarations_overlap
+       (decl "border-start-start-radius:2px")
+       (decl "border-top-left-radius:1px"));
+  Alcotest.(check bool)
+    "the relation is symmetric" true
+    (Shorthand.declarations_overlap
+       (decl "border-top-left-radius:1px")
+       (decl "border-start-start-radius:2px"));
+  Alcotest.(check bool)
+    "the same corner overlaps the opposite physical corner too" true
+    (Shorthand.declarations_overlap
+       (decl "border-start-start-radius:2px")
+       (decl "border-bottom-right-radius:1px"));
+  Alcotest.(check bool)
+    "an end-end corner overlaps the top-right corner" true
+    (Shorthand.declarations_overlap
+       (decl "border-end-end-radius:2px")
+       (decl "border-top-right-radius:1px"));
+  Alcotest.(check bool)
+    "a logical corner overlaps the radius shorthand" true
+    (Shorthand.declarations_overlap (decl "border-radius:4px")
+       (decl "border-start-end-radius:2px"));
+  (* A corner radius is not a border width, style or colour. *)
+  Alcotest.(check bool)
+    "a logical corner and a physical border width are disjoint" false
+    (Shorthand.declarations_overlap
+       (decl "border-end-start-radius:2px")
+       (decl "border-left-width:1px"))
+
 let test_intentionally_duplicated_properties () =
   Alcotest.(check bool)
     "content duplicates are preserved" true
@@ -446,6 +546,9 @@ let suite =
         test_shorthand_reset_boundaries;
       Alcotest.test_case "logical physical overlap" `Quick
         test_logical_physical_overlap;
+      Alcotest.test_case "logical axis overlap" `Quick test_logical_axis_overlap;
+      Alcotest.test_case "logical corner overlap" `Quick
+        test_logical_corner_overlap;
       Alcotest.test_case "intentionally duplicated properties" `Quick
         test_intentionally_duplicated_properties;
       Alcotest.test_case "merge overflow longhands" `Quick


### PR DESCRIPTION
Keeps logical sizing, radius and overscroll declarations in source order.