### PR TITLE
Resolve URLs with uri

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@
 
 ### Parsing
 
+- URL references use RFC 3986 resolution, preserving data, scheme-relative,
+  query-only and fragment-only URLs (#304)
 - Typed `-webkit-` and `-moz-` aliases use their standard value grammar.
 - `shape-outside` reads its whole grammar. Only `none`, `circle()`, a non-empty
   `inset()` and the CSS-wide keywords were accepted, so `margin-box`,

--- a/bin/cli_inline_imports.ml
+++ b/bin/cli_inline_imports.ml
@@ -5,14 +5,7 @@ open Cascade
 (* CSS allows [@import url("foo.css?v=1")] and [#fragment]. The host filesystem
    doesn't, so strip them before opening the file. *)
 let strip_url_suffix = Syntax.strip_url_suffix
-
-let is_remote url =
-  let starts_with prefix =
-    String.length url >= String.length prefix
-    && String.sub url 0 (String.length prefix) = prefix
-  in
-  starts_with "http://" || starts_with "https://" || starts_with "data:"
-  || starts_with "//"
+let is_remote = Syntax.is_remote_url
 
 (* Walk the parsed stylesheet, follow every [@import] URL on disk and parse each
    referenced file once, recursing through transitive imports. The resulting
@@ -21,9 +14,10 @@ let cache_resolved imports resolved =
   if Hashtbl.mem imports resolved then None
   else
     try
-      let content = Cli_io.read_file resolved in
+      let filename = Syntax.url_file_path resolved in
+      let content = Cli_io.read_file filename in
       Hashtbl.add imports resolved content;
-      Some (Cli_io.parse_css ~filename:resolved content)
+      Some (Cli_io.parse_css ~filename content)
     with Sys_error msg ->
       Fmt.epr "warning: cannot read %s: %s@." resolved msg;
       None

--- a/cascade.opam
+++ b/cascade.opam
@@ -25,6 +25,7 @@ depends: [
   "fmt" {>= "0.10.0"}
   "base-unix"
   "uutf"
+  "uri"
   "psq"
   "logs"
   "cmdliner" {>= "1.1.0"}

--- a/dune-project
+++ b/dune-project
@@ -30,6 +30,7 @@
   (fmt (>= 0.10.0))
   base-unix
   uutf
+  uri
   psq
   logs
   (cmdliner (>= 1.1.0))))

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -1744,73 +1744,13 @@ end
 (** {2 URL resolution (RFC 3986)} *)
 
 module Url = struct
-  let starts_with ~prefix s =
-    let n = String.length prefix in
-    String.length s >= n && String.sub s 0 n = prefix
-
-  let cut ?(rev = false) ~sep s =
-    let sep_len = String.length sep in
-    let len = String.length s in
-    let matches i = i + sep_len <= len && String.sub s i sep_len = sep in
-    let rec forward i =
-      if i + sep_len > len then None
-      else if matches i then Some i
-      else forward (i + 1)
-    in
-    let rec backward i =
-      if i < 0 then None else if matches i then Some i else backward (i - 1)
-    in
-    match if rev then backward (len - sep_len) else forward 0 with
-    | None -> None
-    | Some i ->
-        Some (String.sub s 0 i, String.sub s (i + sep_len) (len - i - sep_len))
-
-  (* Collapse a single [..]/[.] segment in [path]. Returns [None] when the path
-     has no segments left to normalise. *)
-  let normalise_path path =
-    let parts = String.split_on_char '/' path in
-    let rec loop acc = function
-      | [] -> List.rev acc
-      | "." :: rest -> loop acc rest
-      | ".." :: rest -> (
-          match acc with [] -> loop acc rest | _ :: tl -> loop tl rest)
-      | seg :: rest -> loop (seg :: acc) rest
-    in
-    String.concat "/" (loop [] parts)
-
-  let resolve_absolute base href =
-    match cut ~sep:"://" base with
-    | None -> Ok href
-    | Some (scheme, rest) -> (
-        match cut ~sep:"/" rest with
-        | None -> Ok (scheme ^ "://" ^ rest ^ href)
-        | Some (host, _) -> Ok (scheme ^ "://" ^ host ^ href))
-
-  let resolve_combined combined =
-    match cut ~sep:"://" combined with
-    | None -> Ok (normalise_path combined)
-    | Some (scheme, rest) -> (
-        match cut ~sep:"/" rest with
-        | None -> Ok (scheme ^ "://" ^ normalise_path rest)
-        | Some (host, path) ->
-            Ok (scheme ^ "://" ^ host ^ "/" ^ normalise_path path))
-
-  let resolve_relative base href =
-    match cut ~rev:true ~sep:"/" base with
-    | None -> Ok href
-    | Some (dir, _) -> resolve_combined (dir ^ "/" ^ href)
-
-  let is_absolute_url href =
-    starts_with ~prefix:"http://" href || starts_with ~prefix:"https://" href
-
   let resolve loader href =
-    if is_absolute_url href then Ok href
-    else
-      match loader.base_url with
-      | None -> Error ("no base URL to resolve " ^ href)
-      | Some base when starts_with ~prefix:"/" href ->
-          resolve_absolute base href
-      | Some base -> resolve_relative base href
+    let reference = Uri.of_string href in
+    match (Uri.scheme reference, loader.base_url) with
+    | Some _, _ -> Ok (Uri.to_string reference)
+    | None, None -> Error ("no base URL to resolve " ^ href)
+    | None, Some base ->
+        Ok (Uri.resolve "" (Uri.of_string base) reference |> Uri.to_string)
 end
 
 (** {2 [@import] loader (CSS Cascade 5 sec. 6)}

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -285,7 +285,7 @@ val matches_container : query -> ?name:string -> Container.t -> bool
 
 val resolve_url : loader -> string -> (string, string) result
 (** [resolve_url loader href] resolves [href] against
-    {!type-loader.field-base_url} using simple relative-URL handling. *)
+    {!type-loader.field-base_url} according to RFC 3986. *)
 
 val import_source : string -> loader -> string option
 (** [import_source url ctx] looks up imported stylesheet text. *)

--- a/lib/dune
+++ b/lib/dune
@@ -25,7 +25,7 @@
   prop_animation)
  (flags
   (:standard -w -9))
- (libraries uutf psq logs unix))
+ (libraries uutf uri psq logs unix))
 
 (mdx
  (files

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -25,7 +25,10 @@ let split_top_level_colon cvs =
   loop [] cvs
 
 let strip_url_suffix url =
-  let cut_at c s =
-    match String.index_opt s c with Some i -> String.sub s 0 i | None -> s
-  in
-  url |> cut_at '?' |> cut_at '#'
+  Uri.of_string url |> Uri.with_uri ~query:None ~fragment:None |> Uri.to_string
+
+let url_file_path url = Uri.of_string url |> Uri.path |> Uri.pct_decode
+
+let is_remote_url url =
+  let uri = Uri.of_string url in
+  Option.is_some (Uri.scheme uri) || Option.is_some (Uri.host uri)

--- a/lib/syntax.mli
+++ b/lib/syntax.mli
@@ -29,3 +29,10 @@ val strip_url_suffix : string -> string
 (** [strip_url_suffix url] strips a query string ([?...]) and fragment ([#...])
     from [url]. Used when resolving [@import] URLs against the host filesystem,
     where neither suffix is meaningful. *)
+
+val url_file_path : string -> string
+(** [url_file_path url] decodes the path component of [url] for a filesystem
+    lookup. *)
+
+val is_remote_url : string -> bool
+(** [is_remote_url url] is true when [url] has a scheme or authority. *)

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -1258,6 +1258,17 @@ let test_loader_context_contract () =
   check_resolved_url "absolute URL remains absolute" ~loader
     ~expected:"https://cdn.example.test/site.css"
     "https://cdn.example.test/site.css";
+  check_resolved_url "data URL remains absolute" ~loader
+    ~expected:"data:image/png;base64,x" "data:image/png;base64,x";
+  check_resolved_url "scheme-relative URL inherits scheme" ~loader
+    ~expected:"https://cdn.example.test/site.css" "//cdn.example.test/site.css";
+  check_resolved_url "query reference keeps base path" ~loader
+    ~expected:"https://example.test/css/app.css?v=1" "?v=1";
+  check_resolved_url "fragment reference keeps base path" ~loader
+    ~expected:"https://example.test/css/app.css#icon" "#icon";
+  check_resolved_url "scheme matching is case-insensitive" ~loader
+    ~expected:"https://cdn.example.test/site.css"
+    "HTTPS://cdn.example.test/site.css";
   check_url_error "relative URL without base is unresolved"
     ~loader:Css.Context.empty_loader "theme.css";
   check_import_loaded "loads same-directory import" ~loader

--- a/test/test_syntax.ml
+++ b/test/test_syntax.ml
@@ -43,7 +43,27 @@ let strip_url_suffix () =
     (Syntax.strip_url_suffix "foo.css#top");
   Alcotest.(check string)
     "both" "foo.css"
-    (Syntax.strip_url_suffix "foo.css?v=1#top")
+    (Syntax.strip_url_suffix "foo.css?v=1#top");
+  Alcotest.(check string)
+    "encoded delimiters stay in path" "foo%3Fbar%23baz.css"
+    (Syntax.strip_url_suffix "foo%3Fbar%23baz.css?v=1#top");
+  Alcotest.(check string)
+    "space is encoded" "foo%20bar.css"
+    (Syntax.strip_url_suffix "foo bar.css")
+
+let url_file_path () =
+  Alcotest.(check string)
+    "encoded path becomes filesystem path" "foo?bar#baz.css"
+    (Syntax.url_file_path "foo%3Fbar%23baz.css?v=1#top");
+  Alcotest.(check string)
+    "encoded space becomes filesystem space" "foo bar.css"
+    (Syntax.url_file_path "foo%20bar.css")
+
+let remote_url () =
+  check_true "https" (Syntax.is_remote_url "HTTPS://example.test/a.css");
+  check_true "data" (Syntax.is_remote_url "data:text/css,a{}");
+  check_true "authority" (Syntax.is_remote_url "//example.test/a.css");
+  check_false "relative" (Syntax.is_remote_url "a.css")
 
 let suite =
   ( "syntax",
@@ -54,4 +74,6 @@ let suite =
       Alcotest.test_case "is_hex" `Quick is_hex;
       Alcotest.test_case "url_needs_quotes" `Quick url_needs_quotes;
       Alcotest.test_case "strip_url_suffix" `Quick strip_url_suffix;
+      Alcotest.test_case "url_file_path" `Quick url_file_path;
+      Alcotest.test_case "remote_url" `Quick remote_url;
     ] )


### PR DESCRIPTION
Resolve CSS URL references with uri instead of a local RFC3986 approximation.

Covers data, scheme-relative, query-only, fragment-only, and case-insensitive schemes. URI identity stays separate from decoded filesystem paths.