### PR TITLE
Parse media queries structurally

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,8 @@
   query-only and fragment-only URLs (#304)
 - Container conditions parse component values directly, so strings and escaped
   or case-insensitive boolean keywords keep their CSS meaning (#305)
+- Media queries parse component values directly, so escaped identifiers and
+  balanced general-enclosed values keep their CSS meaning (#306)
 - Typed `-webkit-` and `-moz-` aliases use their standard value grammar.
 - `shape-outside` reads its whole grammar. Only `none`, `circle()`, a non-empty
   `inset()` and the CSS-wide keywords were accepted, so `margin-box`,

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -17,8 +17,6 @@
                | <mf-value> <gt-op> <mf-name> <gt-op> <mf-value>
     v} *)
 
-open Syntax
-
 type cmp = Lt | Le | Eq | Gt | Ge
 
 type name =
@@ -508,121 +506,40 @@ let to_string ?(minify = false) t = Pp.to_string ~minify pp t
 
 (* ===== Parser ===== *)
 
-(* A lightweight character scanner sufficient for media-query syntax. *)
-type scanner = { s : string; mutable pos : int }
 type recovery_scope = Branch | Query_list
 
 exception Parse_error of recovery_scope * string
 
 let fail_parse ?(scope = Branch) reason = raise (Parse_error (scope, reason))
-let mk_scanner s = { s = String.trim s; pos = 0 }
-let at_end sc = sc.pos >= String.length sc.s
 
-let peek sc : char option =
-  if at_end sc then Option.None else Some sc.s.[sc.pos]
+let is_whitespace_component = function
+  | Component.Preserved { kind = Token.Whitespace; _ } -> true
+  | _ -> false
 
-let advance sc = sc.pos <- sc.pos + 1
+let rec drop_whitespace = function
+  | component :: rest when is_whitespace_component component ->
+      drop_whitespace rest
+  | components -> components
 
-let skip_ws sc =
-  while
-    (not (at_end sc))
-    &&
-    let c = sc.s.[sc.pos] in
-    c = ' ' || c = '\t' || c = '\n' || c = '\r' || c = '\012'
-  do
-    advance sc
-  done
+let trim_components components =
+  components |> drop_whitespace |> List.rev |> drop_whitespace |> List.rev
 
-let read_ident sc =
-  skip_ws sc;
-  let start = sc.pos in
-  if at_end sc then ""
-  else if not (is_ascii_ident_start sc.s.[sc.pos]) then ""
-  else (
-    advance sc;
-    while (not (at_end sc)) && is_ascii_ident_continue sc.s.[sc.pos] do
-      advance sc
-    done;
-    String.sub sc.s start (sc.pos - start))
+let non_whitespace_components = List.filter (Fun.negate is_whitespace_component)
 
-let lookahead_ident sc kw =
-  let kw_len = String.length kw in
-  let s_len = String.length sc.s in
-  if sc.pos + kw_len > s_len then false
-  else
-    let ok = ref true in
-    for k = 0 to kw_len - 1 do
-      if Char.lowercase_ascii sc.s.[sc.pos + k] <> Char.lowercase_ascii kw.[k]
-      then ok := false
-    done;
-    !ok
-    && (sc.pos + kw_len >= s_len
-       ||
-       let c = sc.s.[sc.pos + kw_len] in
-       not (is_ascii_ident_continue c))
+let components_empty components =
+  match trim_components components with [] -> true | _ :: _ -> false
 
-let consume_keyword sc kw = sc.pos <- sc.pos + String.length kw
+let components_to_string components =
+  Cursor.string_of_components ~trim:true components
 
-(* Parse an mf-value: number/integer + optional unit, ratio, or ident. *)
-let is_digit c = c >= '0' && c <= '9'
+let ident_component = function
+  | Component.Preserved { kind = Token.Ident name; _ } -> Some name
+  | _ -> Option.None
 
-let consume_digits sc =
-  let saw_digit = ref false in
-  while (not (at_end sc)) && is_digit sc.s.[sc.pos] do
-    saw_digit := true;
-    advance sc
-  done;
-  !saw_digit
-
-let consume_sign sc =
-  match peek sc with Some ('+' | '-') -> advance sc | _ -> ()
-
-let consume_exponent sc =
-  match peek sc with
-  | Some ('e' | 'E') ->
-      let mark = sc.pos in
-      advance sc;
-      consume_sign sc;
-      if not (consume_digits sc) then sc.pos <- mark
-  | _ -> ()
-
-let read_number_lit sc : ([ `Int of int | `Float of float ] * string) option =
-  let start = sc.pos in
-  consume_sign sc;
-  let saw_int = consume_digits sc in
-  let saw_dot =
-    match peek sc with
-    | Some '.' ->
-        advance sc;
-        true
-    | _ -> false
-  in
-  let saw_frac = saw_dot && consume_digits sc in
-  consume_exponent sc;
-  if not (saw_int || saw_frac) then (
-    sc.pos <- start;
-    None)
-  else
-    let txt = String.sub sc.s start (sc.pos - start) in
-    let is_int =
-      (not saw_dot) && not (String.contains txt 'e' || String.contains txt 'E')
-    in
-    if is_int then Some (`Int (int_of_string txt), txt)
-    else Some (`Float (float_of_string txt), txt)
-
-let read_unit sc =
-  let start = sc.pos in
-  if at_end sc then ""
-  else if sc.s.[sc.pos] = '%' then (
-    advance sc;
-    "%")
-  else if is_ascii_ident_start sc.s.[sc.pos] then (
-    advance sc;
-    while (not (at_end sc)) && is_ascii_ident_continue sc.s.[sc.pos] do
-      advance sc
-    done;
-    String.sub sc.s start (sc.pos - start))
-  else ""
+let ident_is keyword component =
+  match ident_component component with
+  | Some name -> String.equal (String.lowercase_ascii name) keyword
+  | Option.None -> false
 
 let length_of_value f unit : Values_intf.length option =
   let module L = Values_intf in
@@ -661,139 +578,70 @@ let length_of_value f unit : Values_intf.length option =
   | "svw" -> Some (L.Svw f)
   | "svmin" -> Some (L.Svmin f)
   | "svmax" -> Some (L.Svmax f)
-  | _ -> None
+  | _ -> Option.None
 
 let resolution_units = [ "dpi"; "dpcm"; "dppx"; "x" ]
 
-(* Read balanced parens content into a string. Assumes '(' already consumed. *)
-let read_balanced sc =
-  let buf = Buffer.create 32 in
-  let depth = ref 1 in
-  let continue = ref true in
-  while !continue do
-    match peek sc with
-    | None -> failwith "Unmatched parenthesis in @media condition"
-    | Some '(' ->
-        incr depth;
-        Buffer.add_char buf '(';
-        advance sc
-    | Some ')' ->
-        decr depth;
-        if !depth = 0 then (
-          advance sc;
-          continue := false)
-        else (
-          Buffer.add_char buf ')';
-          advance sc)
-    | Some c ->
-        Buffer.add_char buf c;
-        advance sc
-  done;
-  Buffer.contents buf
-
-let typed_function_value name args : value option =
-  let raw = name ^ "(" ^ args ^ ")" in
-  let cursor = Cursor.of_string raw in
+let typed_function_value component : value option =
+  let cursor = Cursor.of_components [ component ] in
   match Values.read_length cursor with
   | length ->
       Cursor.ws cursor;
       Cursor.expect_eof cursor;
       Some (Length length)
-  | exception Cursor.Parse_error _ -> None
+  | exception Cursor.Parse_error _ -> Option.None
 
-let number_as_scalar : [ `Int of int | `Float of float ] -> value = function
-  | `Int n -> Integer n
-  | `Float f -> Number f
+let value_of_number (number : Token.number) =
+  match number.number_flag with
+  | Token.Integer -> Integer (int_of_float number.value)
+  | Token.Number -> Number number.value
 
-let number_as_int : [ `Int of int | `Float of float ] -> int = function
-  | `Int n -> n
-  | `Float f -> int_of_float f
-
-let read_value_with_unit num unit : value option =
-  let f = match num with `Int n -> float_of_int n | `Float f -> f in
-  match length_of_value f unit with
+let read_value_with_unit value unit : value option =
+  match length_of_value value unit with
   | Some l -> Some (Length l)
-  | None ->
+  | Option.None ->
       if List.mem (String.lowercase_ascii unit) resolution_units then
-        Some (Resolution_value (f, unit))
-      else None
+        Some (Resolution_value (value, unit))
+      else Option.None
 
-let read_ratio_tail sc num : value option =
-  (* Could be a ratio: "n / m" *)
-  let mark = sc.pos in
-  skip_ws sc;
-  match peek sc with
-  | Some '/' -> (
-      advance sc;
-      skip_ws sc;
-      match read_number_lit sc with
-      | Some (`Int d, _) -> Some (Ratio (number_as_int num, d))
-      | _ ->
-          sc.pos <- mark;
-          Some (number_as_scalar num))
-  | _ ->
-      sc.pos <- mark;
-      Some (number_as_scalar num)
-
-let read_numeric_value sc : value option =
-  match read_number_lit sc with
-  | None -> None
-  | Some (num, _) ->
-      let unit = read_unit sc in
-      if unit = "" then read_ratio_tail sc num
-      else read_value_with_unit num unit
-
-let read_ident_value sc : value option =
-  let id = read_ident sc in
-  if id = "" then None
-  else (
-    skip_ws sc;
-    match peek sc with
-    | Some '(' -> (
-        advance sc;
-        let args = read_balanced sc in
-        match typed_function_value id args with
-        | Some _ as value -> value
-        | None -> Some (Function (id, args)))
-    | _ -> Some (Ident (ident_of_string id)))
-
-let read_value sc : value option =
-  skip_ws sc;
-  match peek sc with
-  | None -> None
-  | Some c when (c >= '0' && c <= '9') || c = '.' || c = '+' || c = '-' ->
-      read_numeric_value sc
-  | Some _ -> read_ident_value sc
+let value_of_components_opt components =
+  match non_whitespace_components components with
+  | [ Component.Preserved { kind = Token.Number_tok number; _ } ] ->
+      Some (value_of_number number)
+  | [ Component.Preserved { kind = Token.Percentage number; _ } ] ->
+      Some (Length (Values_intf.Pct number.value))
+  | [ Component.Preserved { kind = Token.Dimension { number; unit_ }; _ } ] ->
+      read_value_with_unit number.value unit_
+  | [
+   Component.Preserved { kind = Token.Number_tok numerator; _ };
+   Component.Preserved { kind = Token.Delim "/"; _ };
+   Component.Preserved
+     {
+       kind =
+         Token.Number_tok
+           { value = denominator; number_flag = Token.Integer; _ };
+       _;
+     };
+  ] ->
+      Some (Ratio (int_of_float numerator.value, int_of_float denominator))
+  | [ Component.Preserved { kind = Token.Ident name; _ } ] ->
+      Some (Ident (ident_of_string name))
+  | [
+   (Component.Func { node = { name; arguments; terminated = true }; _ } as
+    component);
+  ] -> (
+      match typed_function_value component with
+      | Some _ as value -> value
+      | Option.None -> Some (Function (name, components_to_string arguments)))
+  | _ -> Option.None
 
 let value_of_string s =
-  let sc = mk_scanner s in
-  match read_value sc with
-  | Some value ->
-      skip_ws sc;
-      if at_end sc then value else failwith ("invalid media value: " ^ s)
-  | None -> failwith ("invalid media value: " ^ s)
+  let components = Cursor.of_string s |> Cursor.remaining in
+  match value_of_components_opt components with
+  | Some value -> value
+  | Option.None -> failwith ("invalid media value: " ^ s)
 
 let boolean_feature name : feature = Boolean name
-
-let read_cmp sc : cmp option =
-  skip_ws sc;
-  match peek sc with
-  | Some '<' ->
-      advance sc;
-      if peek sc = Some '=' then (
-        advance sc;
-        Some Le)
-      else Some Lt
-  | Some '>' ->
-      advance sc;
-      if peek sc = Some '=' then (
-        advance sc;
-        Some Ge)
-      else Some Gt
-  | Some '=' ->
-      advance sc;
-      Some Eq
-  | _ -> None
 
 let interval_ops_compatible op1 op2 =
   match (op1, op2) with
@@ -902,186 +750,169 @@ let plain_feature name value : feature =
      ^ "'s grammar (see Media.validate_plain_feature)");
   Plain (name, value)
 
-(* Parse content already inside parens (no surrounding parens). *)
-let value_first_interval_tail sc v1 op1 name op2 : feature option =
-  skip_ws sc;
-  match read_value sc with
-  | None -> None
-  | Some v2 ->
-      skip_ws sc;
-      if
-        at_end sc
-        && interval_ops_compatible op1 op2
-        && validate_range_feature name v1
-        && validate_range_feature name v2
-      then Some (Interval (v1, op1, name, op2, v2))
-      else None
+let take_cmp = function
+  | Component.Preserved { kind = Token.Delim "<"; _ }
+    :: Component.Preserved { kind = Token.Delim "="; _ }
+    :: rest ->
+      Some (Le, rest)
+  | Component.Preserved { kind = Token.Delim ">"; _ }
+    :: Component.Preserved { kind = Token.Delim "="; _ }
+    :: rest ->
+      Some (Ge, rest)
+  | Component.Preserved { kind = Token.Delim "<"; _ } :: rest -> Some (Lt, rest)
+  | Component.Preserved { kind = Token.Delim ">"; _ } :: rest -> Some (Gt, rest)
+  | Component.Preserved { kind = Token.Delim "="; _ } :: rest -> Some (Eq, rest)
+  | _ -> Option.None
 
-let value_first_range_or_interval sc v1 op1 name : feature option =
-  match read_cmp sc with
-  | Some op2 -> value_first_interval_tail sc v1 op1 name op2
-  | None ->
-      skip_ws sc;
-      if at_end sc && validate_range_feature name v1 then
-        Some (Range_rev (v1, op1, name))
-      else None
-
-let value_first_after_op sc ~mark v1 op1 : feature option =
-  skip_ws sc;
-  let name = read_ident sc in
-  if name = "" then (
-    sc.pos <- mark;
-    None)
-  else
-    let name = name_of_string name in
-    value_first_range_or_interval sc v1 op1 name
-
-let value_first_feature content : feature option =
-  let sc = mk_scanner content in
-  skip_ws sc;
-  (* Try value-first form: V op name [op V] *)
-  let mark = sc.pos in
-  match read_value sc with
-  | None -> None
-  | Some v1 -> (
-      match read_cmp sc with
-      | Some op1 -> value_first_after_op sc ~mark v1 op1
-      | None ->
-          sc.pos <- mark;
-          None)
-
-let boolean_or_none_feature id : feature option =
-  if Option.is_some (prefixed_range_feature_name (name_of_string id)) then None
-  else Some (boolean_feature (name_of_string id))
-
-let plain_feature_after_colon sc id : feature option =
-  advance sc;
-  skip_ws sc;
-  match read_value sc with
-  | None -> None
-  | Some value ->
-      skip_ws sc;
-      let name = name_of_string id in
-      if at_end sc && validate_plain_feature name value then
-        Some (plain_feature name value)
-      else None
-
-let range_after_value sc id op v2 : feature option =
-  match read_cmp sc with
-  | Some _ -> None
-  | None ->
-      skip_ws sc;
-      let name = name_of_string id in
-      if at_end sc && validate_range_feature name v2 then
-        Some (Range (name, op, v2))
-      else None
-
-let range_after_op sc id op : feature option =
-  skip_ws sc;
-  match read_value sc with
-  | None -> None
-  | Some v2 -> range_after_value sc id op v2
-
-let name_first_range sc id content : feature option =
-  match read_cmp sc with
-  | None -> value_first_feature content
-  | Some op -> range_after_op sc id op
-
-let feature_after_ident sc id content : feature option =
-  skip_ws sc;
-  match peek sc with
-  | None -> boolean_or_none_feature id
-  | Some ':' -> plain_feature_after_colon sc id
-  | Some _ -> name_first_range sc id content
-
-let feature_in_parens content : feature option =
-  let sc = mk_scanner content in
-  skip_ws sc;
-  if at_end sc then None
-  else
-    let id = read_ident sc in
-    if id = "" then value_first_feature content
-    else feature_after_ident sc id content
-
-let extract_feature_or_fail content =
-  match feature_in_parens content with
-  | Some f -> f
-  | None -> failwith ("invalid media feature: " ^ content)
-
-let rec condition_from_paren_content content =
-  let trimmed = String.trim content in
-  (* Could be either ( <condition> ) or ( <feature> ). *)
-  let inner = mk_scanner trimmed in
-  skip_ws inner;
-  if lookahead_ident inner "not" then condition_of_string trimmed
-  else if lookahead_ident inner "and" || lookahead_ident inner "or" then
-    Feature (extract_feature_or_fail trimmed)
-  else if peek inner = Some '(' then condition_of_string trimmed
-  else Feature (extract_feature_or_fail trimmed)
-
-(* Parser for media-condition (sequence of (...) with and/or/not). *)
-and condition_in_parens sc =
-  skip_ws sc;
-  match peek sc with
-  | Some '(' ->
-      advance sc;
-      condition_from_paren_content (read_balanced sc)
-  | _ -> (
-      (* Media Queries 4 sec. 3.1: [<media-in-parens>] also admits
-         [<general-enclosed>], whose first form is a function token. An
-         identifier immediately followed by [(] is one, e.g. [theme(static)]:
-         grammatical, unrecognised, and therefore false. Rejecting it here made
-         a valid query look malformed and cost the whole rule. *)
-      let mark = sc.pos in
-      let id = read_ident sc in
-      match (id, peek sc) with
-      | "", _ | _, None -> failwith "expected '(' in media condition"
-      | _, Some '(' ->
-          advance sc;
-          let args = read_balanced sc in
-          Feature (General_enclosed (String.concat "" [ id; "("; args; ")" ]))
-      | _ ->
-          sc.pos <- mark;
-          failwith "expected '(' in media condition")
-
-and condition_of_string s =
-  let sc = mk_scanner s in
-  condition sc
-
-and condition sc =
-  skip_ws sc;
-  if lookahead_ident sc "not" then (
-    consume_keyword sc "not";
-    skip_ws sc;
-    let inner = condition_in_parens sc in
-    skip_ws sc;
-    if at_end sc then Not inner
-    else failwith "trailing content after 'not <media-in-parens>'")
-  else
-    let left = condition_in_parens sc in
-    chain sc left
-
-and chain sc (acc : condition) =
-  let rec loop op (acc : condition) : condition =
-    skip_ws sc;
-    if at_end sc then acc
-    else if lookahead_ident sc "and" then (
-      (match op with
-      | Some `Or -> failwith "mixed 'and'/'or' media condition"
-      | _ -> ());
-      consume_keyword sc "and";
-      let right = condition_in_parens sc in
-      loop (Some `And) (And (acc, right) : condition))
-    else if lookahead_ident sc "or" then (
-      (match op with
-      | Some `And -> failwith "mixed 'and'/'or' media condition"
-      | _ -> ());
-      consume_keyword sc "or";
-      let right = condition_in_parens sc in
-      loop (Some `Or) (Or (acc, right) : condition))
-    else acc
+let split_cmp components =
+  let rec loop before rest =
+    match take_cmp rest with
+    | Some (op, after) -> Some (List.rev before, op, after)
+    | Option.None -> (
+        match rest with
+        | [] -> Option.None
+        | component :: after -> loop (component :: before) after)
   in
-  loop None acc
+  loop [] (non_whitespace_components components)
+
+type parsed_feature = Valid_feature of feature | Invalid_feature | Not_feature
+
+let valid_or_invalid feature =
+  match feature with
+  | Some feature -> Valid_feature feature
+  | Option.None -> Invalid_feature
+
+let boolean_feature_of_name name =
+  let name = name_of_string name in
+  if Option.is_some (prefixed_range_feature_name name) then Option.None
+  else Some (boolean_feature name)
+
+let plain_feature_of_components name components =
+  match value_of_components_opt components with
+  | Some value ->
+      let name = name_of_string name in
+      if validate_plain_feature name value then Some (plain_feature name value)
+      else Option.None
+  | Option.None -> Option.None
+
+let name_first_range name op components =
+  match (split_cmp components, value_of_components_opt components) with
+  | Option.None, Some value ->
+      let name = name_of_string name in
+      if validate_range_feature name value then Some (Range (name, op, value))
+      else Option.None
+  | Some _, _ | Option.None, Option.None -> Option.None
+
+let value_first_range_or_interval lhs op1 rhs =
+  match value_of_components_opt lhs with
+  | Option.None -> Option.None
+  | Some lower -> (
+      match split_cmp rhs with
+      | Option.None -> (
+          match rhs with
+          | [ name_component ] -> (
+              match ident_component name_component with
+              | Some name ->
+                  let name = name_of_string name in
+                  if validate_range_feature name lower then
+                    Some (Range_rev (lower, op1, name))
+                  else Option.None
+              | Option.None -> Option.None)
+          | _ -> Option.None)
+      | Some (name_components, op2, upper_components) -> (
+          match (name_components, value_of_components_opt upper_components) with
+          | [ name_component ], Some upper -> (
+              match ident_component name_component with
+              | Some name ->
+                  let name = name_of_string name in
+                  if
+                    interval_ops_compatible op1 op2
+                    && validate_range_feature name lower
+                    && validate_range_feature name upper
+                  then Some (Interval (lower, op1, name, op2, upper))
+                  else Option.None
+              | Option.None -> Option.None)
+          | _ -> Option.None))
+
+let parse_feature_components components =
+  let components = non_whitespace_components components in
+  match components with
+  | [] -> Invalid_feature
+  | [ name_component ] -> (
+      match ident_component name_component with
+      | Some name -> valid_or_invalid (boolean_feature_of_name name)
+      | Option.None -> Not_feature)
+  | Component.Preserved { kind = Token.Ident name; _ }
+    :: Component.Preserved { kind = Token.Colon; _ }
+    :: value_components ->
+      valid_or_invalid (plain_feature_of_components name value_components)
+  | _ -> (
+      match split_cmp components with
+      | Some ([ name_component ], op, rhs) -> (
+          match ident_component name_component with
+          | Some name -> valid_or_invalid (name_first_range name op rhs)
+          | Option.None ->
+              valid_or_invalid
+                (value_first_range_or_interval [ name_component ] op rhs))
+      | Some (lhs, op, rhs) ->
+          valid_or_invalid (value_first_range_or_interval lhs op rhs)
+      | Option.None -> (
+          match components with
+          | Component.Preserved { kind = Token.Ident _; _ } :: _ -> Not_feature
+          | _ -> Not_feature))
+
+let feature_in_components components =
+  match parse_feature_components components with
+  | Valid_feature feature -> Some feature
+  | Invalid_feature | Not_feature -> Option.None
+
+let rec condition_of_components components : condition =
+  let components = non_whitespace_components components in
+  match components with
+  | first :: rest when ident_is "not" first -> (
+      match rest with
+      | [ operand ] -> Not (condition_in_parens operand)
+      | _ -> failwith "trailing content after 'not <media-in-parens>'")
+  | first :: rest ->
+      let left = condition_in_parens first in
+      condition_chain Option.None left rest
+  | [] -> failwith "empty media condition"
+
+and condition_in_parens component : condition =
+  match component with
+  | Component.Block
+      { node = { opening = Token.Paren; value; closed = true }; _ } -> (
+      match parse_feature_components value with
+      | Valid_feature feature -> Feature feature
+      | Invalid_feature ->
+          failwith ("invalid media feature: " ^ components_to_string value)
+      | Not_feature -> condition_of_components value)
+  | Component.Block { node = { opening = Token.Paren; closed = false; _ }; _ }
+    ->
+      failwith "unmatched parenthesis in @media condition"
+  | Component.Func { node = { terminated = true; _ }; _ } ->
+      Feature (General_enclosed (components_to_string [ component ]))
+  | Component.Func { node = { terminated = false; _ }; _ } ->
+      failwith "unmatched function in @media condition"
+  | Component.Block _ | Component.Preserved _ ->
+      failwith "expected media-in-parens"
+
+and condition_chain operator acc components : condition =
+  match components with
+  | [] -> acc
+  | keyword :: operand :: rest when ident_is "and" keyword ->
+      (match operator with
+      | Some `Or -> failwith "mixed 'and'/'or' media condition"
+      | Some `And | Option.None -> ());
+      let right = condition_in_parens operand in
+      condition_chain (Some `And) (And (acc, right)) rest
+  | keyword :: operand :: rest when ident_is "or" keyword ->
+      (match operator with
+      | Some `And -> failwith "mixed 'and'/'or' media condition"
+      | Some `Or | Option.None -> ());
+      let right = condition_in_parens operand in
+      condition_chain (Some `Or) (Or (acc, right)) rest
+  | _ -> failwith "trailing content in media condition"
 
 let medium_of_ident s : medium =
   match String.lowercase_ascii s with
@@ -1093,184 +924,119 @@ let medium_of_ident s : medium =
 let is_reserved_media_type_keyword s =
   match String.lowercase_ascii s with "and" | "or" -> true | _ -> false
 
-let rec next_non_ws s len i : char option =
-  if i >= len then None
-  else match s.[i] with ' ' | '\t' -> next_non_ws s len (i + 1) | c -> Some c
+let is_media_in_parens = function
+  | Component.Block { node = { opening = Token.Paren; _ }; _ }
+  | Component.Func _ ->
+      true
+  | Component.Block _ | Component.Preserved _ -> false
 
-(* [<media-query>] starts as [<media-condition>] (rather than as a media type)
-   when its first non-space token is '(' or "not (". *)
-(* An identifier glued to a [(] is a function token, so the query is a
-   [<general-enclosed>] condition rather than a media type. Without this
-   [theme(static)] is read as the media type [theme] and then trips on the
-   parenthesis. *)
-let function_token_at s pos =
-  let len = String.length s in
-  let rec ident_end i =
-    if i < len then
-      match s.[i] with
-      | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> ident_end (i + 1)
-      | _ -> i
-    else i
-  in
-  let stop = ident_end pos in
-  stop > pos && stop < len && s.[stop] = '('
+let starts_with_condition components =
+  match non_whitespace_components components with
+  | first :: _ when is_media_in_parens first -> true
+  | first :: second :: _ when ident_is "not" first -> is_media_in_parens second
+  | _ -> false
 
-(* [<media-in-parens>] starts a condition either with [(] or, for the
-   [<general-enclosed>] function form, with an identifier glued to a [(]. [not]
-   takes a [<media-in-parens>] too, so it accepts both shapes. *)
-let starts_with_media_in_parens s pos =
-  match next_non_ws s (String.length s) pos with
-  | Some '(' -> true
-  | _ ->
-      let len = String.length s in
-      let rec skip i =
-        if
-          i < len
-          && (s.[i] = ' ' || s.[i] = '\t' || s.[i] = '\n' || s.[i] = '\r')
-        then skip (i + 1)
-        else i
-      in
-      function_token_at s (skip pos)
+let read_query_prefix = function
+  | first :: rest when ident_is "not" first -> (Some Not, rest)
+  | first :: rest when ident_is "only" first -> (Some Only, rest)
+  | components -> (Option.None, components)
 
-let starts_with_condition sc =
-  match (peek sc, lookahead_ident sc "not") with
-  | Some '(', _ -> true
-  | _, true -> starts_with_media_in_parens sc.s (sc.pos + 3)
-  | _ -> function_token_at sc.s sc.pos
-
-let read_query_prefix sc =
-  if lookahead_ident sc "not" then (
-    consume_keyword sc "not";
-    skip_ws sc;
-    Some Not)
-  else if lookahead_ident sc "only" then (
-    consume_keyword sc "only";
-    skip_ws sc;
-    Some Only)
-  else None
-
-let read_media_type_query sc =
-  let prefix = read_query_prefix sc in
-  (match prefix with
-  | Some _ when lookahead_ident sc "not" || lookahead_ident sc "only" ->
+let read_media_type_query components =
+  let components = non_whitespace_components components in
+  let prefix, components = read_query_prefix components in
+  (match (prefix, components) with
+  | Some _, first :: _ when ident_is "not" first || ident_is "only" first ->
       fail_parse ~scope:Query_list "duplicate media query prefix"
   | _ -> ());
-  let id = read_ident sc in
-  if id = "" then failwith "expected media type or condition"
-  else if is_reserved_media_type_keyword id then
-    failwith "reserved media condition keyword cannot be a media type"
-  else
-    let type_ = medium_of_ident id in
-    skip_ws sc;
-    if at_end sc || peek sc = Some ',' then
-      Type { prefix; type_; trailing = None }
-    else if lookahead_ident sc "and" then (
-      consume_keyword sc "and";
-      let cond = condition_in_parens sc in
-      let cond = chain sc cond in
-      Type { prefix; type_; trailing = Some cond })
-    else
-      failwith
-        (String.concat ""
-           [
-             "expected 'and' or end of query after media type, got: ";
-             String.sub sc.s sc.pos (String.length sc.s - sc.pos);
-           ])
+  match components with
+  | name_component :: rest -> (
+      match ident_component name_component with
+      | Option.None -> failwith "expected media type or condition"
+      | Some name when is_reserved_media_type_keyword name ->
+          failwith "reserved media condition keyword cannot be a media type"
+      | Some name -> (
+          let type_ = medium_of_ident name in
+          match rest with
+          | [] -> Type { prefix; type_; trailing = Option.None }
+          | keyword :: condition when ident_is "and" keyword ->
+              Type
+                {
+                  prefix;
+                  type_;
+                  trailing = Some (condition_of_components condition);
+                }
+          | _ -> failwith "expected 'and' or end of query after media type"))
+  | [] -> failwith "expected media type or condition"
 
-let single_query sc =
-  skip_ws sc;
-  if at_end sc then failwith "empty media query"
-  else if starts_with_condition sc then Cond (condition sc)
-  else read_media_type_query sc
+let single_query components =
+  if components_empty components then failwith "empty media query"
+  else if starts_with_condition components then
+    Cond (condition_of_components components)
+  else read_media_type_query components
 
-let not_all_query : t = Type { prefix = Some Not; type_ = All; trailing = None }
+let not_all_query : t =
+  Type { prefix = Some Not; type_ = All; trailing = Option.None }
 
-let skip_recovery_branch sc =
-  let depth = ref 0 in
-  let continue = ref true in
-  while (not (at_end sc)) && !continue do
-    match peek sc with
-    | Some '(' ->
-        incr depth;
-        advance sc
-    | Some ')' ->
-        if !depth > 0 then decr depth;
-        advance sc
-    | Some ',' when !depth = 0 -> continue := false
-    | Some _ -> advance sc
-    | None -> continue := false
-  done
+let is_comma_component = function
+  | Component.Preserved { kind = Token.Comma; _ } -> true
+  | _ -> false
 
-let query_branch ~recover ~recovered_at_eof sc =
-  let mark = sc.pos in
-  try
-    let query = single_query sc in
-    skip_ws sc;
-    match peek sc with
-    | None | Some ',' -> query
-    | _ -> failwith "trailing content in media query branch"
-  with
-  | Parse_error (scope, reason) ->
-      if not recover then raise (Failure reason);
-      if scope = Query_list then sc.pos <- String.length sc.s
-      else (
-        sc.pos <- mark;
-        skip_recovery_branch sc);
-      skip_ws sc;
-      if at_end sc then recovered_at_eof := true;
-      not_all_query
-  | Failure _ ->
-      if not recover then raise (Failure "invalid media query branch");
-      sc.pos <- mark;
-      skip_recovery_branch sc;
-      skip_ws sc;
-      if at_end sc then recovered_at_eof := true;
-      not_all_query
-
-let trailing_content_failure sc =
-  failwith
-    (String.concat ""
-       [
-         "trailing content in media query: ";
-         String.sub sc.s sc.pos (String.length sc.s - sc.pos);
-       ])
-
-let query_of_string ?(recover = true) s : t =
-  let comma_query_list sc branch first recovered_at_eof =
-    let rec loop acc =
-      match peek sc with
-      | Some ',' ->
-          advance sc;
-          skip_ws sc;
-          let q = branch () in
-          skip_ws sc;
-          loop (q :: acc)
-      | _ -> List.rev acc
-    in
-    let rest = loop [] in
-    skip_ws sc;
-    if not (at_end sc) then trailing_content_failure sc;
-    if !recovered_at_eof then not_all_query else List (first :: rest)
+let split_query_list components =
+  let rec loop current branches saw_comma = function
+    | [] -> (List.rev (List.rev current :: branches), saw_comma)
+    | component :: rest when is_comma_component component ->
+        loop [] (List.rev current :: branches) true rest
+    | component :: rest -> loop (component :: current) branches saw_comma rest
   in
-  let sc = mk_scanner s in
-  if at_end sc then (List [] : t)
+  loop [] [] false components
+
+let parse_query_branch components =
+  try Ok (single_query components) with
+  | Parse_error (scope, reason) -> Error (scope, reason)
+  | Failure reason -> Error (Branch, reason)
+
+let of_components ?(recover = true) components =
+  let branches, saw_comma = split_query_list components in
+  if (not saw_comma) && List.for_all components_empty branches then
+    (List [] : t)
   else
-    let recovered_at_eof = ref false in
-    let branch () = query_branch ~recover ~recovered_at_eof sc in
-    let first = branch () in
-    skip_ws sc;
-    match (at_end sc, peek sc) with
-    | true, _ -> first
-    | false, Some ',' -> comma_query_list sc branch first recovered_at_eof
-    | false, _ -> trailing_content_failure sc
+    let rec parse acc = function
+      | [] -> List.rev acc
+      | [ branch ] -> (
+          match parse_query_branch branch with
+          | Ok query -> List.rev (query :: acc)
+          | Error (_, reason) ->
+              if recover then [ not_all_query ] else raise (Failure reason))
+      | branch :: rest -> (
+          match parse_query_branch branch with
+          | Ok query -> parse (query :: acc) rest
+          | Error (Query_list, reason) ->
+              if recover then [ not_all_query ] else raise (Failure reason)
+          | Error (Branch, reason) ->
+              if recover then parse (not_all_query :: acc) rest
+              else raise (Failure reason))
+    in
+    match (saw_comma, parse [] branches) with
+    | false, [ query ] -> query
+    | false, [] -> List []
+    | false, _ :: _ :: _ -> assert false
+    | true, [ Type { prefix = Some Not; type_ = All; trailing = Option.None } ]
+      ->
+        not_all_query
+    | true, queries -> List queries
 
-let of_string s = query_of_string s
-let of_string_strict s = query_of_string ~recover:false s
+let of_string s = Cursor.of_string s |> Cursor.remaining |> of_components
 
-let of_function_body s : t =
-  match feature_in_parens s with
+let of_string_strict s =
+  Cursor.of_string s |> Cursor.remaining |> of_components ~recover:false
+
+let of_function_components components =
+  match feature_in_components components with
   | Some feature -> Cond (Feature feature)
-  | None -> of_string s
+  | Option.None -> of_components components
+
+let of_function_body s =
+  Cursor.of_string s |> Cursor.remaining |> of_function_components
 
 let feature name value : t =
   Cond (Feature (plain_feature (name_of_string name) value))

--- a/lib/media.mli
+++ b/lib/media.mli
@@ -132,10 +132,18 @@ val of_string : string -> t
 val of_string_strict : string -> t
 (** [of_string_strict s] parses [s] as a media query without branch recovery. *)
 
+val of_components : ?recover:bool -> Component.t list -> t
+(** [of_components components] parses an already-tokenized media query. Invalid
+    branches recover to [not all] unless [recover] is [false]. *)
+
 val of_function_body : string -> t
 (** [of_function_body s] parses the body of a conditional [media(...)] function.
     Unlike a standalone media query, a single feature appears without its outer
     parentheses in this grammar. *)
+
+val of_function_components : Component.t list -> t
+(** [of_function_components components] parses an already-tokenized conditional
+    [media(...)] body. *)
 
 val value_of_string : string -> value
 (** [value_of_string s] parses [s] as a media-feature value. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1529,22 +1529,37 @@ let read_import_supports (r : Cursor.t) =
    position still holding one means a duplicate or a misordered prelude. They
    are function tokens, so the media grammar would otherwise take them as a
    [<general-enclosed>] query and quietly accept the rule. *)
-let starts_with_import_keyword raw =
-  let lower = String.lowercase_ascii raw in
-  List.exists
-    (fun k -> String.starts_with ~prefix:k lower)
-    [ "layer("; "supports("; "layer " ]
+let starts_with_import_keyword components =
+  let cursor = Cursor.of_components components in
+  match Cursor.peek cursor with
+  | Some (Component.Func { node = { name; _ }; _ }) ->
+      let name = String.lowercase_ascii name in
+      String.equal name "layer" || String.equal name "supports"
+  | Some (Component.Preserved { kind = Token.Ident name; _ }) ->
+      String.equal (String.lowercase_ascii name) "layer"
+  | Some (Component.Block _ | Component.Preserved _) | None -> false
+
+let drain_until_semicolon r =
+  let rec loop acc =
+    match Cursor.peek_raw r with
+    | None | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
+        List.rev acc
+    | Some component ->
+        ignore (Cursor.next_raw r);
+        loop (component :: acc)
+  in
+  loop []
 
 let read_import_media (r : Cursor.t) : Media.t option =
   if Cursor.peek_semicolon r || Cursor.is_done r then None
   else
     let loc = Cursor.position r in
-    let raw = Cursor.consume_until_semicolon ~trim:true r in
-    if starts_with_import_keyword raw then
+    let components = drain_until_semicolon r in
+    if starts_with_import_keyword components then
       Error.fail_bad_condition loc ~at_rule:"@media"
         ~reason:"layer()/supports() must precede the media query, and once only"
     else
-      match Media.of_string_strict raw with
+      match Media.of_components ~recover:false components with
       | media -> Some media
       | exception Failure reason ->
           Error.fail_bad_condition loc ~at_rule:"@media" ~reason
@@ -2824,9 +2839,14 @@ let conditional_args (fn : Component.func Component.node) =
   if not fn.node.terminated then failwith "unterminated conditional function";
   Cursor.string_of_components ~trim:true fn.node.arguments
 
+let conditional_arguments (fn : Component.func Component.node) =
+  if not fn.node.terminated then failwith "unterminated conditional function";
+  fn.node.arguments
+
 let conditional_atom (fn : Component.func Component.node) =
   match String.lowercase_ascii fn.Component.node.name with
-  | "media" -> Media_condition (Media.of_function_body (conditional_args fn))
+  | "media" ->
+      Media_condition (Media.of_function_components (conditional_arguments fn))
   | "supports" ->
       Supports_condition_test
         (Supports.of_string ~allow_unwrapped_decl:true (conditional_args fn))
@@ -2923,10 +2943,10 @@ let read_supports_condition (r : Cursor.t) : statement =
 
 let read_layer_name (r : Cursor.t) : string = read_layer_name_component r
 
-let read_nested_media_condition condition_str =
-  if String.length condition_str = 0 then Media.List []
+let read_nested_media_condition components =
+  if Cursor.of_components components |> Cursor.is_done then Media.List []
   else
-    try Media.of_string_strict condition_str
+    try Media.of_components ~recover:false components
     with Failure _ -> Media.of_string "not all"
 
 let read_rule_selector ?(nested = false) r =
@@ -3172,12 +3192,13 @@ and read_else (r : Cursor.t) : statement =
 and read_media (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "media" r;
   Cursor.ws r;
-  let condition_str = Cursor.drain_until_block_as_string ~trim:true r in
+  let condition_components = Cursor.drain_until_block r in
   let content = Cursor.braces (fun inner -> read_block inner) r in
   let condition =
-    if String.length condition_str = 0 then Media.List []
+    if Cursor.of_components condition_components |> Cursor.is_done then
+      Media.List []
     else
-      try Media.of_string_strict condition_str
+      try Media.of_components ~recover:false condition_components
       with Failure reason ->
         Cursor.err_invalid r ("invalid @media condition: " ^ reason)
   in
@@ -3378,9 +3399,9 @@ and read_nested_supports_rule r =
   Supports (supports_condition ~loc:cond_loc condition, content)
 
 and read_nested_media_rule r =
-  let condition_str = Cursor.drain_until_block_as_string ~trim:true r in
+  let condition_components = Cursor.drain_until_block r in
   let content = Cursor.braces (fun inner -> read_nesting_block inner) r in
-  Media (read_nested_media_condition condition_str, content)
+  Media (read_nested_media_condition condition_components, content)
 
 and read_nested_scope_rule r =
   let prelude_components = Cursor.drain_until_block r in

--- a/test/cli/parse_error_locations.t
+++ b/test/cli/parse_error_locations.t
@@ -40,5 +40,5 @@ import URL's span.
   > .ok { color: red }
   > EOF
   $ cascade --minify bad-media.css 2>&1 | grep -E "warning|color" | head
-  warning: bad-media.css: bad condition for @media: invalid media query branch at [21-32] (in at-rule)
+  warning: bad-media.css: bad condition for @media: expected media-in-parens at [21-32] (in at-rule)
   .ok{color:red}

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -278,6 +278,26 @@ let general_enclosed_is_not_a_media_type () =
     "print and feature" "print and (min-width: 30em)"
     (to_string (of_string "print and (min-width: 30em)"))
 
+let component_parser_edges () =
+  let check name expected input =
+    Alcotest.(check string) name expected (to_string (of_string input))
+  in
+  check "escaped feature value" "(prefers-color-scheme: dark)"
+    "(prefers-color-scheme: d\\61 rk)";
+  check "escaped conjunction" "screen and (width >= 40em)"
+    "screen \\61 nd (width >= 40em)";
+  check "parenthesis in a string" "theme(\") and (\")" "theme(\") and (\")";
+  let source =
+    "@media screen \\61 nd (prefers-color-scheme:d\\61 rk){a{color:red}}"
+  in
+  match Css.of_string ~strict:false source with
+  | Error error -> Alcotest.fail (Cascade.Error.to_string error)
+  | Ok parsed ->
+      Alcotest.(check string)
+        "stylesheet prelude"
+        "@media screen and (prefers-color-scheme:dark){a{color:red}}"
+        (Css.to_string ~minify:true parsed.stylesheet)
+
 let suite =
   let open Alcotest in
   ( "media",
@@ -301,4 +321,5 @@ let suite =
       test_case "general-enclosed in context" `Quick general_enclosed_in_context;
       test_case "general-enclosed is not a media type" `Quick
         general_enclosed_is_not_a_media_type;
+      test_case "component parser edges" `Quick component_parser_edges;
     ] )


### PR DESCRIPTION
Parse media queries from `Component.t` instead of maintaining a second character scanner.

Escaped identifiers and balanced general-enclosed values now keep their CSS meaning in direct and stylesheet parsing.