### PR TITLE
Make diff grouping linear

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -173,6 +173,8 @@
 
 ### Diff report
 
+- Grouping repeated selectors and conditions is linear in the number of rules
+  while preserving source order (#307)
 - The cascade layer order the two sheets declare is compared, and the report
   names the layer pairs that swapped. Dropping an `@layer a;` pin, which makes
   the other layer the weaker one, read as no difference at all

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -135,14 +135,20 @@ let sig_of_decls decls =
       let c = String.compare a1 a2 in
       if c <> 0 then c else String.compare b1 b2)
 
+let restore_group_order table =
+  Hashtbl.to_seq_keys table |> List.of_seq
+  |> List.iter (fun key ->
+      Hashtbl.replace table key (List.rev (Hashtbl.find table key)));
+  table
+
 let group_into_table rules =
   let tbl = Hashtbl.create 128 in
   List.iter
     (fun (k, d) ->
       let lst = match Hashtbl.find_opt tbl k with Some l -> l | None -> [] in
-      Hashtbl.replace tbl k (lst @ [ d ]))
+      Hashtbl.replace tbl k (d :: lst))
     rules;
-  tbl
+  restore_group_order tbl
 
 (* Compare two declaration lists with the same key and emit diffs *)
 let diff_same_key_pair key d1 d2 =

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2208,14 +2208,20 @@ let extract_items_with_positions extract_fn stmts =
     stmts
   |> List.filter_map (fun x -> x)
 
+let restore_group_order table =
+  Hashtbl.to_seq_keys table |> List.of_seq
+  |> List.iter (fun key ->
+      Hashtbl.replace table key (List.rev (Hashtbl.find table key)));
+  table
+
 let group_by_condition items =
   let tbl = Hashtbl.create 16 in
   List.iter
     (fun (pos, cond, rules) ->
       let existing = try Hashtbl.find tbl cond with Not_found -> [] in
-      Hashtbl.replace tbl cond (existing @ [ (pos, rules) ]))
+      Hashtbl.replace tbl cond ((pos, rules) :: existing))
     items;
-  tbl
+  restore_group_order tbl
 
 (* Two sides holding a different number of blocks under one condition split or
    merged them. Where those blocks sit is a separate question, and one
@@ -2631,9 +2637,9 @@ and media_diff items1 items2 =
     List.iter
       (fun (cond, rules) ->
         let existing = try Hashtbl.find tbl cond with Not_found -> [] in
-        Hashtbl.replace tbl cond (existing @ [ rules ]))
+        Hashtbl.replace tbl cond (rules :: existing))
       items;
-    tbl
+    restore_group_order tbl
   in
   let groups1 = group items1 in
   let groups2 = group items2 in


### PR DESCRIPTION
Build repeated-selector and repeated-condition groups by prepending, then reverse each group once.

This preserves source-order pairing while removing quadratic list appends from large diff reports.