### PR TITLE
Reject invalid UTF-8 peek offsets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@
 
 ### Parsing
 
+- `Reader.peek_utf8_at` returns `None` for negative and out-of-range offsets
+  instead of indexing outside the input (#308)
 - URL references use RFC 3986 resolution, preserving data, scheme-relative,
   query-only and fragment-only URLs (#304)
 - Container conditions parse component values directly, so strings and escaped

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -155,9 +155,9 @@ let first_utf8_chunk_at input p len =
       !result
 
 let peek_utf8_at t offset =
-  let p = t.pos + offset in
-  if p >= t.len then None
+  if offset < 0 || offset >= t.len - t.pos then None
   else
+    let p = t.pos + offset in
     let b = Char.code (String.unsafe_get t.input p) in
     if b < 0x80 then Some (b, 1)
     else

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -55,7 +55,8 @@ val peek_utf8 : t -> (int * int) option
 
 val peek_utf8_at : t -> int -> (int * int) option
 (** [peek_utf8_at t off] decodes the UTF-8 code point at [position t + off],
-    without advancing. *)
+    without advancing. Returns [None] when [off] is negative or outside the
+    remaining input. *)
 
 val skip_utf8 : t -> unit
 (** [skip_utf8 t] advances past the next UTF-8 code point. If the lead byte is

--- a/test/test_reader.ml
+++ b/test/test_reader.ml
@@ -66,6 +66,20 @@ let basic () =
   ignore (char r);
   Alcotest.(check bool) "done after read" true (is_done r)
 
+let utf8_peek_bounds () =
+  let r = of_string "ab" in
+  skip r;
+  let position = position r in
+  Alcotest.(check (option (pair int int)))
+    "negative offset" None (peek_utf8_at r (-1));
+  Alcotest.(check (option (pair int int)))
+    "past end" None (peek_utf8_at r max_int);
+  Alcotest.(check (option (pair int int)))
+    "current byte"
+    (Some (Char.code 'b', 1))
+    (peek_utf8_at r 0);
+  Alcotest.(check int) "does not advance" position (Reader.position r)
+
 (* Test string operations *)
 let string_ops () =
   (* peek_string *)
@@ -1469,6 +1483,7 @@ let suite =
     [
       (* Basic operations *)
       test_case "basic" `Quick basic;
+      test_case "UTF-8 peek bounds" `Quick utf8_peek_bounds;
       test_case "string" `Quick string_ops;
       test_case "whitespace" `Quick whitespace;
       test_case "comments" `Quick comments;


### PR DESCRIPTION
Reject negative and overflowing offsets before computing the reader index.

`peek_utf8_at` now returns `None` outside the remaining input and never advances the reader.