### PR TITLE
Make CLI file reads exception-safe

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -313,6 +313,8 @@ library, then stabilised over several internal milestones.
 
 ### CLI tools
 
+- CLI commands share one binary file reader that closes its descriptor when a
+  read fails (#309)
 - `cascade` -- pretty-print and minify CSS files. It accepts stdin via `-`
   or a missing file argument, and writes output to stdout.
 - `cascade --minify` applies the standard safe transforms, including

--- a/bin/cli_io.ml
+++ b/bin/cli_io.ml
@@ -2,11 +2,7 @@
 
 open Cascade
 
-let read_file path =
-  let ic = open_in path in
-  let content = really_input_string ic (in_channel_length ic) in
-  close_in ic;
-  content
+let read_file path = In_channel.with_open_bin path In_channel.input_all
 
 let read_stdin () =
   let buf = Buffer.create 4096 in

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -110,11 +110,7 @@ let inline_html ~minimal ~filename ~html ~extra =
 
 (* ---------- cmdliner ---------- *)
 let read_file path =
-  try
-    let ic = open_in_bin path in
-    let s = really_input_string ic (in_channel_length ic) in
-    close_in ic;
-    Ok s
+  try Ok (Cli_io.read_file path)
   with Sys_error msg -> err_msg "Error reading %s: %s" path msg
 
 (* Cmdliner's [file] conv only checks that the path exists, so a directory or a

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -10,12 +10,7 @@ let err_depth s =
        (Fmt.str "invalid depth %S: expected auto, max, or a positive integer" s))
 
 let read_file path =
-  try
-    let ic = open_in path in
-    let content = really_input_string ic (in_channel_length ic) in
-    close_in ic;
-    Ok content
-  with Sys_error msg -> err_read path msg
+  try Ok (Cli_io.read_file path) with Sys_error msg -> err_read path msg
 
 let no_color_var = "NO_COLOR"
 


### PR DESCRIPTION
Use one binary file reader for `fmt`, `diff`, `apply`, and import inlining.

The shared reader closes its descriptor even when length or input operations fail.