### PR TITLE
Enforce merlint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,6 @@ jobs:
           ocaml-compiler: '5.4'
 
       - uses: ocaml/setup-ocaml/lint-fmt@v3
+      - run: opam repo add samoht https://tangled.org/gazagnaire.org/opam-overlay.git
+      - run: opam install . --deps-only --with-dev-setup
+      - run: opam exec -- merlint --build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,6 @@ jobs:
 
       - uses: ocaml/setup-ocaml/lint-fmt@v3
       - run: opam repo add samoht https://tangled.org/gazagnaire.org/opam-overlay.git
-      - run: opam install . --deps-only --with-test --with-dev-setup
+      - run: opam install . --deps-only --with-test
+      - run: opam install merlint
       - run: opam exec -- merlint --build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,5 @@ jobs:
 
       - uses: ocaml/setup-ocaml/lint-fmt@v3
       - run: opam repo add samoht https://tangled.org/gazagnaire.org/opam-overlay.git
-      - run: opam install . --deps-only --with-dev-setup
+      - run: opam install . --deps-only --with-test --with-dev-setup
       - run: opam exec -- merlint --build

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -246,6 +246,7 @@
 
 ### Testing
 
+- CI rejects merlint findings and incomplete library record patterns (#310)
 - `dune test` renders a stylesheet and its optimized forms in a headless
   browser and compares the computed style of every element, on a document
   derived from the stylesheet's own selectors; it skips where no browser is

--- a/cascade.opam
+++ b/cascade.opam
@@ -21,6 +21,7 @@ depends: [
   "eio_main" {>= "0.14" & with-test}
   "lambdasoup"
   "mdx" {with-test}
+  "merlint" {with-dev-setup}
   "re" {with-test}
   "fmt" {>= "0.10.0"}
   "base-unix"

--- a/cascade.opam
+++ b/cascade.opam
@@ -21,7 +21,6 @@ depends: [
   "eio_main" {>= "0.14" & with-test}
   "lambdasoup"
   "mdx" {with-test}
-  "merlint" {with-dev-setup}
   "re" {with-test}
   "fmt" {>= "0.10.0"}
   "base-unix"

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,6 @@
   (eio_main (and (>= 0.14) :with-test))
   lambdasoup
   (mdx :with-test)
-  (merlint :with-dev-setup)
   (re :with-test)
   (fmt (>= 0.10.0))
   base-unix

--- a/dune-project
+++ b/dune-project
@@ -26,6 +26,7 @@
   (eio_main (and (>= 0.14) :with-test))
   lambdasoup
   (mdx :with-test)
+  (merlint :with-dev-setup)
   (re :with-test)
   (fmt (>= 0.10.0))
   base-unix

--- a/fuzz/fuzz_container.ml
+++ b/fuzz/fuzz_container.ml
@@ -48,8 +48,11 @@ let test_non_empty_string_output buf =
 let test_named_kind_matches_inner buf =
   let inner = condition buf 3 in
   let named = Css.Container.Named (name buf 0, inner) in
-  if Css.Container.kind named <> Css.Container.kind inner then
-    fail "named container query changed kind bucket"
+  if
+    not
+      (Css.Container.equal_kind (Css.Container.kind named)
+         (Css.Container.kind inner))
+  then fail "named container query changed kind bucket"
 
 let test_compare_antisymmetric buf =
   let a = condition buf 0 in

--- a/fuzz/fuzz_context.ml
+++ b/fuzz/fuzz_context.ml
@@ -42,7 +42,7 @@ let check_eval_shape label input actual =
   check_same_decl (label ^ " roundtrip") actual reparsed
 
 let check_same_stylesheet label expected actual =
-  if expected <> actual then
+  if not (Css.Stylesheet.equal expected actual) then
     failf "%s: expected %S, got %S" label (pp_stylesheet expected)
       (pp_stylesheet actual)
 
@@ -373,33 +373,57 @@ let test_empty_contexts _buf =
 
 let assert_property_value_lookups ctx custom custom_decl property inherited_decl
     =
-  if Css.Context.custom_property custom ctx <> Some custom_decl then
-    fail "custom property lookup changed";
-  if Css.Context.inherited_value property ctx <> Some inherited_decl then
-    fail "inherited value lookup changed";
+  if
+    not
+      (Option.equal Css.Declaration.equal_declaration
+         (Css.Context.custom_property custom ctx)
+         (Some custom_decl))
+  then fail "custom property lookup changed";
+  if
+    not
+      (Option.equal Css.Declaration.equal_declaration
+         (Css.Context.inherited_value property ctx)
+         (Some inherited_decl))
+  then fail "inherited value lookup changed";
   if Css.Context.custom_property (custom ^ "-missing") ctx <> None then
     fail "custom property lookup stopped being exact";
   if Css.Context.inherited_value (property ^ "-missing") ctx <> None then
     fail "inherited value lookup stopped being exact"
 
 let assert_initial_and_urls (ctx : Css.Context.t) initial_decl =
-  if Css.Context.initial_value "display" ctx <> Some initial_decl then
-    fail "initial value lookup changed";
+  if
+    not
+      (Option.equal Css.Declaration.equal_declaration
+         (Css.Context.initial_value "display" ctx)
+         (Some initial_decl))
+  then fail "initial value lookup changed";
   if ctx.base_url <> Some "https://example.test/a.css" then
     fail "base URL context changed"
 
 let assert_context_dimensions (ctx : Css.Context.t) =
   let open Css.Values in
   if
-    ctx.root_font_size <> Some (Px 16.) || ctx.parent_font_size <> Some (Px 14.)
+    (not
+       (Option.equal Css.Values.equal_length ctx.root_font_size (Some (Px 16.))))
+    || not
+         (Option.equal Css.Values.equal_length ctx.parent_font_size
+            (Some (Px 14.)))
   then fail "font-size context changed";
   if
-    ctx.viewport_width <> Some (Px 1024.)
-    || ctx.viewport_height <> Some (Px 768.)
+    (not
+       (Option.equal Css.Values.equal_length ctx.viewport_width
+          (Some (Px 1024.))))
+    || not
+         (Option.equal Css.Values.equal_length ctx.viewport_height
+            (Some (Px 768.)))
   then fail "viewport context changed";
   if
-    ctx.container_width <> Some (Px 640.)
-    || ctx.container_height <> Some (Px 480.)
+    (not
+       (Option.equal Css.Values.equal_length ctx.container_width
+          (Some (Px 640.))))
+    || not
+         (Option.equal Css.Values.equal_length ctx.container_height
+            (Some (Px 480.)))
   then fail "container dimension context changed"
 
 let test_property_value_context buf =
@@ -488,10 +512,18 @@ let query_context media feature_value inline_size =
     ()
 
 let assert_query_lookup ctx media feature_value inline_size =
-  if Css.Context.media_feature media ctx <> Some feature_value then
-    fail "query context lost media feature";
-  if Css.Context.container_feature "inline-size" ctx <> Some inline_size then
-    fail "query context lost container feature";
+  if
+    not
+      (Option.equal Css.Media.equal_value
+         (Css.Context.media_feature media ctx)
+         (Some feature_value))
+  then fail "query context lost media feature";
+  if
+    not
+      (Option.equal Css.Media.equal_value
+         (Css.Context.container_feature "inline-size" ctx)
+         (Some inline_size))
+  then fail "query context lost container feature";
   if Css.Context.media_feature (media ^ "-missing") ctx <> None then
     fail "query context media lookup stopped being exact";
   if Css.Context.container_feature "block-size" ctx <> None then
@@ -578,8 +610,12 @@ let test_property_registration_context buf =
   let registry =
     Css.Context.property_registry ~property_registrations:[ registration ] ()
   in
-  if Css.Context.registered_property name registry <> Some registration then
-    fail "property registry lost registration";
+  if
+    not
+      (Option.equal Css.Context.equal_property_registration
+         (Css.Context.registered_property name registry)
+         (Some registration))
+  then fail "property registry lost registration";
   let valid_decl = Css.Declaration.of_string (name ^ ": " ^ valid_value) in
   (match
      Css.Context.validate_registered_custom_property registry valid_decl

--- a/fuzz/fuzz_declaration.ml
+++ b/fuzz/fuzz_declaration.ml
@@ -183,8 +183,12 @@ let test_custom_cycle_context buf =
   if not (starts_with ~prefix:(name ^ ":var(") serialized) then
     failf "custom property var() shape changed: %S" serialized;
   let ctx = { Css.Context.empty with custom_properties = [ decl ] } in
-  if Css.Context.custom_property name ctx <> Some decl then
-    fail "custom property context lost var() value"
+  if
+    not
+      (Option.equal Css.Declaration.equal_declaration
+         (Css.Context.custom_property name ctx)
+         (Some decl))
+  then fail "custom property context lost var() value"
 
 let feature_decl_vector buf =
   pick

--- a/fuzz/fuzz_font_face.ml
+++ b/fuzz/fuzz_font_face.ml
@@ -62,12 +62,15 @@ let test_metric_override_non_negative buf =
   match parse_metric buf with
   | None | Some Css.Font_face.Normal -> ()
   | Some (Css.Font_face.Percent p) ->
-      if p < 0. then fail "metric override parsed a negative percentage"
+      if Float.compare p 0. < 0 then
+        fail "metric override parsed a negative percentage"
 
 let test_size_adjust_non_negative buf =
   match parse_size_adjust buf with
   | None -> ()
-  | Some p -> if p < 0. then fail "size-adjust parsed a negative percentage"
+  | Some p ->
+      if Float.compare p 0. < 0 then
+        fail "size-adjust parsed a negative percentage"
 
 let test_metric_override_serialization_idempotent buf =
   match parse_metric buf with
@@ -125,7 +128,7 @@ let test_spec_src_vectors buf =
   | Some src ->
       let serialized = Css.Font_face.string_of_src src in
       let reparsed = Css.Font_face.src_of_string serialized in
-      if src <> reparsed then
+      if not (Css.Font_face.equal_src src reparsed) then
         failf "font-face src structure changed: %S -> %S" input serialized
 
 let test_invalid_src_vectors buf =
@@ -158,7 +161,7 @@ let test_spec_metric_vectors buf =
       buf 3
   in
   match parse_metric input with
-  | Some actual when actual = expected -> ()
+  | Some actual when Css.Font_face.equal_metric_override actual expected -> ()
   | Some actual ->
       failf "font metric structure changed: %S -> %S" input
         (Css.Font_face.string_of_metric_override actual)
@@ -177,7 +180,7 @@ let test_spec_size_adjust_vectors buf =
     pick [ ("0%", 0.); ("100%", 100.); ("125.5%", 125.5) ] buf 5
   in
   match parse_size_adjust input with
-  | Some actual when actual = expected -> ()
+  | Some actual when Css.Font_face.equal_size_adjust actual expected -> ()
   | Some actual ->
       failf "font size-adjust structure changed: %S -> %g" input actual
   | None -> failf "valid font size-adjust vector rejected: %S" input

--- a/fuzz/fuzz_lexer.ml
+++ b/fuzz/fuzz_lexer.ml
@@ -42,7 +42,7 @@ let test_peek_next_consistency buf =
   let lexer = Lexer.of_string (cssish buf) in
   let peeked = Lexer.peek lexer in
   let next = Lexer.next lexer in
-  if peeked.Token.kind <> next.Token.kind then
+  if not (Token.equal_kind peeked.Token.kind next.Token.kind) then
     fail "lexer peek and next returned different token kinds"
 
 let test_reconsume_returns_same_token buf =
@@ -50,7 +50,7 @@ let test_reconsume_returns_same_token buf =
   let tok = Lexer.next lexer in
   Lexer.reconsume lexer tok;
   let again = Lexer.next lexer in
-  if tok.Token.kind <> again.Token.kind then
+  if not (Token.equal_kind tok.Token.kind again.Token.kind) then
     fail "lexer reconsume did not replay the same token kind"
 
 let test_save_restore_replays_prefix buf =
@@ -60,7 +60,8 @@ let test_save_restore_replays_prefix buf =
   let first = take_kinds lexer 8 [] in
   Lexer.restore lexer;
   let second = take_kinds lexer 8 [] in
-  if first <> second then fail "lexer restore did not replay consumed tokens"
+  if not (List.equal Token.equal_kind first second) then
+    fail "lexer restore did not replay consumed tokens"
 
 let test_commit_preserves_outer_restore buf =
   let input = cssish buf in
@@ -72,7 +73,7 @@ let test_commit_preserves_outer_restore buf =
   Lexer.commit lexer;
   Lexer.restore lexer;
   let replayed = Lexer.next lexer in
-  if first.Token.kind <> replayed.Token.kind then
+  if not (Token.equal_kind first.Token.kind replayed.Token.kind) then
     fail "lexer commit did not fold replay log into outer save"
 
 let test_eof_stable buf =

--- a/fuzz/fuzz_media.ml
+++ b/fuzz/fuzz_media.ml
@@ -97,8 +97,9 @@ let test_negated_kind_invariant buf =
   | Css.Media.Cond c ->
       let query = Css.Media.Cond c in
       let twice = Css.Media.Cond (Css.Media.Not (Css.Media.Not c)) in
-      if Css.Media.kind query <> Css.Media.kind twice then
-        fail "double-negated media query changed kind bucket"
+      if
+        not (Css.Media.equal_kind (Css.Media.kind query) (Css.Media.kind twice))
+      then fail "double-negated media query changed kind bucket"
   | _ -> ()
 
 let test_media_context_shape buf =

--- a/fuzz/fuzz_optimize.ml
+++ b/fuzz/fuzz_optimize.ml
@@ -216,8 +216,8 @@ let first_index ~needle haystack =
    directly - independent of the code under test - and admits a dropped wrapper
    only for those two conditions. *)
 let baseline_true_supports condition =
-  condition = Css.Supports.property "display" "grid"
-  || condition = Css.Supports.property "display" "flex"
+  Css.Supports.equal condition (Css.Supports.property "display" "grid")
+  || Css.Supports.equal condition (Css.Supports.property "display" "flex")
 
 let rec boundary_shape = function
   | Css.Stylesheet.Rule _ -> [ "rule" ]
@@ -732,7 +732,7 @@ let test_optimize_preserves_physical_identity buf =
   let canon = Css.Optimize.stylesheet (generated_stylesheet buf) in
   let again = Css.Optimize.stylesheet canon in
   if again == canon then ()
-  else if again = canon then
+  else if Css.Stylesheet.equal again canon then
     fail
       "optimize reallocated an already-optimized stylesheet instead of \
        returning it unchanged (x = optimize x but not x == optimize x)"
@@ -755,7 +755,7 @@ let test_dedup_decls_identity buf =
   let canon = Css.Optimize.deduplicate_declarations props in
   let again = Css.Optimize.deduplicate_declarations canon in
   if again == canon then ()
-  else if again = canon then
+  else if List.equal Css.Declaration.equal_declaration again canon then
     fail
       "deduplicate_declarations reallocated an already-deduplicated list \
        instead of returning it unchanged (x = dedup x but not x == dedup x)"

--- a/fuzz/fuzz_selector.ml
+++ b/fuzz/fuzz_selector.ml
@@ -30,7 +30,7 @@ let assert_stable input =
       | Some reparsed ->
           let before = Css.Selector.specificity sel in
           let after = Css.Selector.specificity reparsed in
-          if before <> after then
+          if not (Css.Selector.equal_specificity before after) then
             failf "specificity changed: %S -> %S" input output)
 
 let assert_reject input =
@@ -111,7 +111,7 @@ let test_specificity_roundtrip buf =
       | Some reparsed ->
           let before = Css.Selector.specificity sel in
           let after = Css.Selector.specificity reparsed in
-          if before <> after then
+          if not (Css.Selector.equal_specificity before after) then
             failf "specificity changed across serialization: %S -> %S" buf
               serialized)
 
@@ -172,7 +172,7 @@ let test_canonicalize_preserves_physical_identity buf =
   let canon = Css.Selector.canonicalize sel in
   let again = Css.Selector.canonicalize canon in
   if again == canon then ()
-  else if again = canon then
+  else if Css.Selector.equal again canon then
     fail
       "canonicalize reallocated an already-canonical selector instead of \
        returning it unchanged (x = canonicalize x but not x == canonicalize x)"
@@ -188,7 +188,7 @@ let test_list_canon_identity buf =
   let canon = Css.Selector.canonicalize selectors in
   let again = Css.Selector.canonicalize canon in
   if again == canon then ()
-  else if again = canon then
+  else if Css.Selector.equal again canon then
     fail
       "canonicalize reallocated an already-canonical selector list instead of \
        returning it unchanged (x = canonicalize x but not x == canonicalize x)"
@@ -314,7 +314,11 @@ let test_selector_specificity_minify buf =
       | None ->
           failf "specificity vector did not reparse after minify: %S" serialized
       | Some reparsed ->
-          if Css.Selector.specificity sel <> Css.Selector.specificity reparsed
+          if
+            not
+              (Css.Selector.equal_specificity
+                 (Css.Selector.specificity sel)
+                 (Css.Selector.specificity reparsed))
           then
             failf "selector minification changed specificity: %S -> %S" input
               serialized)
@@ -407,8 +411,10 @@ let test_selector_l4_serialization_matrix buf =
             serialized
       | Some reparsed ->
           if
-            Css.Selector.specificity selector
-            <> Css.Selector.specificity reparsed
+            not
+              (Css.Selector.equal_specificity
+                 (Css.Selector.specificity selector)
+                 (Css.Selector.specificity reparsed))
           then
             failf "selector L4 serialization changed specificity: %S -> %S"
               input serialized)

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -451,8 +451,8 @@ let invalid_platform_declaration_vector buf i =
    only for those two conditions. (--enforce-spec keeps the wrapper, but these
    invariants exercise the default optimizer.) *)
 let supports_is_baseline_true condition =
-  condition = Css.Supports.property "display" "grid"
-  || condition = Css.Supports.property "display" "flex"
+  Css.Supports.equal condition (Css.Supports.property "display" "grid")
+  || Css.Supports.equal condition (Css.Supports.property "display" "flex")
 
 let rec boundary_shape = function
   | Css.Stylesheet.Rule _ -> [ "rule" ]
@@ -1269,8 +1269,12 @@ let test_property_value_context buf =
       ~viewport_width:(Px 1024.) ~viewport_height:(Px 768.)
       ~container_width:(Px 640.) ~container_height:(Px 480.) ()
   in
-  if Css.Context.custom_property name ctx <> Some custom_decl then
-    fail "property-value context lost custom property"
+  if
+    not
+      (Option.equal Css.Declaration.equal_declaration
+         (Css.Context.custom_property name ctx)
+         (Some custom_decl))
+  then fail "property-value context lost custom property"
 
 let test_recovery_keeps_rules buf =
   let bad_decl =

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -7,9 +7,9 @@ let list_filter_preserve = List.filter_preserve
 
 let media_feature_is name (f : Media.feature) =
   match f with
-  | Media.Plain (n, _) | Media.Boolean n -> n = name
-  | Media.Range (n, _, _) | Media.Range_rev (_, _, n) -> n = name
-  | Media.Interval (_, _, n, _, _) -> n = name
+  | Media.Plain (n, _) | Media.Boolean n -> Media.equal_name n name
+  | Media.Range (n, _, _) | Media.Range_rev (_, _, n) -> Media.equal_name n name
+  | Media.Interval (_, _, n, _, _) -> Media.equal_name n name
   | Media.General_enclosed _ -> false
 
 let rec condition_has_feature name (c : Media.condition) =

--- a/lib/component.ml
+++ b/lib/component.ml
@@ -37,6 +37,8 @@ type rule = Qualified of qualified_rule | At of at_rule
 type declaration_body = { name : string; value : t list; important : bool }
 type declaration = declaration_body node
 
+let equal (a : t) b = a = b
+
 let source_loc : t -> Loc.t = function
   | Preserved tok -> tok.Token.loc
   | Block b -> b.loc

--- a/lib/component.mli
+++ b/lib/component.mli
@@ -47,6 +47,9 @@ type rule = Qualified of qualified_rule | At of at_rule
 type declaration_body = { name : string; value : t list; important : bool }
 type declaration = declaration_body node
 
+val equal : t -> t -> bool
+(** [equal a b] tests component values for structural equality. *)
+
 val source_loc : t -> Loc.t
 (** [source_loc cv] is the source range spanned by [cv]. *)
 

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -403,28 +403,33 @@ let rec style_query_components components =
   if components_empty components then failwith "empty style() container query";
   match split_top_level_colon components with
   | Some _ -> style_leaf_components components
-  | None -> (
-      let level, unwrapped =
-        match single_paren_body components with
-        | Some body -> (trim_components body, true)
-        | None -> (components, false)
-      in
-      if has_keyword "and" level && has_keyword "or" level then
-        failwith "mixed style() operators require grouping"
-      else
-        match split_keyword "or" level with
-        | Some (lhs, rhs) ->
-            Any (style_query_components lhs, style_query_components rhs)
-        | None -> (
-            match split_keyword "and" level with
-            | Some (lhs, rhs) ->
-                All (style_query_components lhs, style_query_components rhs)
-            | None -> (
-                match level with
-                | first :: rest when ident_is "not" first ->
-                    Neg (style_query_components rest)
-                | _ when unwrapped -> style_query_components level
-                | _ -> style_leaf_components components)))
+  | None -> style_query_operator components
+
+and style_query_operator components =
+  let level, unwrapped =
+    match single_paren_body components with
+    | Some body -> (trim_components body, true)
+    | None -> (components, false)
+  in
+  if has_keyword "and" level && has_keyword "or" level then
+    failwith "mixed style() operators require grouping"
+  else
+    match split_keyword "or" level with
+    | Some (lhs, rhs) ->
+        Any (style_query_components lhs, style_query_components rhs)
+    | None -> style_query_conjunction ~components ~level ~unwrapped
+
+and style_query_conjunction ~components ~level ~unwrapped =
+  match split_keyword "and" level with
+  | Some (lhs, rhs) ->
+      All (style_query_components lhs, style_query_components rhs)
+  | None -> style_query_unary ~components ~level ~unwrapped
+
+and style_query_unary ~components ~level ~unwrapped =
+  match level with
+  | first :: rest when ident_is "not" first -> Neg (style_query_components rest)
+  | _ when unwrapped -> style_query_components level
+  | _ -> style_leaf_components components
 
 let style_body ~uppercase components =
   let body = string_of_components components in
@@ -485,32 +490,35 @@ let rec scroll_state_query_components components =
     failwith "empty scroll-state() container query";
   match split_top_level_colon components with
   | Some _ -> scroll_state_query_leaf components
-  | None -> (
-      let level, unwrapped =
-        match single_paren_body components with
-        | Some body -> (trim_components body, true)
-        | None -> (components, false)
-      in
-      if has_keyword "and" level && has_keyword "or" level then
-        failwith "mixed scroll-state() operators require grouping"
-      else
-        match split_keyword "or" level with
-        | Some (lhs, rhs) ->
-            Either
-              ( scroll_state_query_components lhs,
-                scroll_state_query_components rhs )
-        | None -> (
-            match split_keyword "and" level with
-            | Some (lhs, rhs) ->
-                Both
-                  ( scroll_state_query_components lhs,
-                    scroll_state_query_components rhs )
-            | None -> (
-                match level with
-                | first :: rest when ident_is "not" first ->
-                    Negated (scroll_state_query_components rest)
-                | _ when unwrapped -> scroll_state_query_components level
-                | _ -> scroll_state_query_leaf components)))
+  | None -> scroll_state_query_operator components
+
+and scroll_state_query_operator components =
+  let level, unwrapped =
+    match single_paren_body components with
+    | Some body -> (trim_components body, true)
+    | None -> (components, false)
+  in
+  if has_keyword "and" level && has_keyword "or" level then
+    failwith "mixed scroll-state() operators require grouping"
+  else
+    match split_keyword "or" level with
+    | Some (lhs, rhs) ->
+        Either
+          (scroll_state_query_components lhs, scroll_state_query_components rhs)
+    | None -> scroll_state_query_conjunction ~components ~level ~unwrapped
+
+and scroll_state_query_conjunction ~components ~level ~unwrapped =
+  match split_keyword "and" level with
+  | Some (lhs, rhs) ->
+      Both (scroll_state_query_components lhs, scroll_state_query_components rhs)
+  | None -> scroll_state_query_unary ~components ~level ~unwrapped
+
+and scroll_state_query_unary ~components ~level ~unwrapped =
+  match level with
+  | first :: rest when ident_is "not" first ->
+      Negated (scroll_state_query_components rest)
+  | _ when unwrapped -> scroll_state_query_components level
+  | _ -> scroll_state_query_leaf components
 
 let scroll_state_body ~uppercase components =
   let body = string_of_components components in
@@ -677,22 +685,24 @@ let rec unnamed_of_components components =
   in
   if has_keyword "and" level && has_keyword "or" level then
     failwith "mixed container query operators require grouping"
-  else
-    match split_keyword "or" level with
-    | Some (lhs, rhs) ->
-        Or (unnamed_of_components lhs, unnamed_of_components rhs)
-    | None -> (
-        match split_keyword "and" level with
-        | Some (lhs, rhs) ->
-            And (unnamed_of_components lhs, unnamed_of_components rhs)
-        | None -> (
-            match level with
-            | first :: rest when ident_is "not" first ->
-                if not (is_query_operand rest) then
-                  failwith
-                    "container query: 'not' requires a query-in-parens operand";
-                Not (unnamed_of_components rest)
-            | _ -> atom_of_components components))
+  else unnamed_or_components ~components level
+
+and unnamed_or_components ~components level =
+  match split_keyword "or" level with
+  | Some (lhs, rhs) -> Or (unnamed_of_components lhs, unnamed_of_components rhs)
+  | None -> unnamed_and_components ~components level
+
+and unnamed_and_components ~components level =
+  match split_keyword "and" level with
+  | Some (lhs, rhs) -> And (unnamed_of_components lhs, unnamed_of_components rhs)
+  | None -> unnamed_unary_components ~components level
+
+and unnamed_unary_components ~components = function
+  | first :: rest when ident_is "not" first ->
+      if not (is_query_operand rest) then
+        failwith "container query: 'not' requires a query-in-parens operand";
+      Not (unnamed_of_components rest)
+  | _ -> atom_of_components components
 
 let of_components components =
   match split_named_components components with

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -187,7 +187,11 @@ let rec compare t1 t2 =
   | Feature_query q1, Feature_query q2 -> Media.compare q1 q2
   | _ -> Stdlib.compare t1 t2
 
+let compare_scroll_state_query (a : scroll_state_query) b = Stdlib.compare a b
+
 type kind = Min_width | Other
+
+let equal_kind (a : kind) b = a = b
 
 let rec kind = function
   | Min_width_rem _ | Min_width_px _ -> Min_width

--- a/lib/container.mli
+++ b/lib/container.mli
@@ -107,3 +107,9 @@ val scroll_state : string -> string -> t
 
 val compare : t -> t -> int
 (** [compare t1 t2] compares two container conditions. *)
+
+val compare_scroll_state_query : scroll_state_query -> scroll_state_query -> int
+(** [compare_scroll_state_query a b] totally orders scroll-state queries. *)
+
+val equal_kind : kind -> kind -> bool
+(** [equal_kind a b] tests container condition categories for equality. *)

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -74,6 +74,8 @@ type property_registration = {
   initial_value : string option;
 }
 
+let equal_property_registration (a : property_registration) b = a = b
+
 type property_registry = { property_registrations : property_registration list }
 
 let empty =
@@ -1594,7 +1596,7 @@ module Match_container = struct
     List.exists
       (function
         | Container.Scroll_state { query = actual; _ } ->
-            Stdlib.compare actual query = 0
+            Container.compare_scroll_state_query actual query = 0
         | _ -> false)
       q.container_features
     || eval_scroll_state_query q query
@@ -3423,7 +3425,7 @@ let rec eval_typed ?layer_order ?layer ctx decl =
   | Declaration.Theme_guarded { var_name; decl; _ } ->
       Declaration.theme_guarded ~var_name
         (eval_typed ~layer_order ?layer ctx decl)
-  | Declaration.Declaration { property; value; important } -> (
+  | Declaration.Declaration { property; value; important; _ } -> (
       match Properties.property_value_kind property with
       | Some kind ->
           eval_kind ~layer_order ?layer ctx kind property important value

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -97,6 +97,10 @@ type property_registration = {
     parser-visible data from an [@property] rule without creating live CSSOM
     registration state. *)
 
+val equal_property_registration :
+  property_registration -> property_registration -> bool
+(** [equal_property_registration a b] tests registrations structurally. *)
+
 type property_registry = { property_registrations : property_registration list }
 (** Explicit context for registration-aware custom property validation. *)
 

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -627,7 +627,7 @@ let v = Stylesheet.v
 let theme_guarded = Declaration.theme_guarded
 
 let as_theme_guarded = function
-  | Theme_guarded { var_name; decl } -> Some (var_name, decl)
+  | Theme_guarded { var_name; decl; _ } -> Some (var_name, decl)
   | _ -> None
 
 (* Override to return statements instead of rules *)
@@ -948,7 +948,7 @@ let resolve_theme_guards_in_decls ~(theme : Pp.String_set.t option) decls =
   | Option.Some set ->
       List.filter_map
         (function
-          | Declaration.Theme_guarded { var_name; decl } ->
+          | Declaration.Theme_guarded { var_name; decl; _ } ->
               if Pp.String_set.mem var_name set then Option.Some decl
               else Option.None
           | d -> Option.Some d)

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -588,7 +588,7 @@ let bool t =
 let bool_token (k : Token.kind) t =
   drop_ws t;
   match t.cvs with
-  | Component.Preserved tok :: _ when tok.kind = k ->
+  | Component.Preserved tok :: _ when Token.equal_kind tok.kind k ->
       let _ = next t in
       true
   | _ -> false
@@ -630,7 +630,7 @@ let consume_if c t =
 
 let try_kind k t =
   match peek t with
-  | Some (Component.Preserved tok) when tok.kind = k ->
+  | Some (Component.Preserved tok) when Token.equal_kind tok.kind k ->
       let _ = next t in
       true
   | _ -> false
@@ -680,10 +680,10 @@ let looking_at t s =
 let try_kind_pair k1 k2 t =
   let snap = save t in
   match peek t with
-  | Some (Component.Preserved tok) when tok.kind = k1 -> (
+  | Some (Component.Preserved tok) when Token.equal_kind tok.kind k1 -> (
       let _ = next t in
       match peek_raw t with
-      | Some (Component.Preserved tok2) when tok2.kind = k2 ->
+      | Some (Component.Preserved tok2) when Token.equal_kind tok2.kind k2 ->
           let _ = next_raw t in
           true
       | _ ->

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -472,6 +472,10 @@ let rec property_name decl =
    property name" directly - no [Pp], no [Obj.repr]. *)
 type prop_key = Key : 'a Properties.property -> prop_key [@@unboxed]
 
+let equal_declaration (a : declaration) b = a = b
+let equal_prop_key (a : prop_key) b = a = b
+let hash_prop_key (key : prop_key) = Hashtbl.hash key
+
 let rec property_key decl =
   match decl with
   | Declaration { property; _ } -> Key property
@@ -2348,6 +2352,7 @@ let rec pp_declaration : declaration Pp.t =
         property = Custom_property name;
         value = Custom_value { value; layer; _ };
         important;
+        _;
       } ->
       Pp.string ctx name;
       Pp.string ctx ":";
@@ -2360,7 +2365,7 @@ let rec pp_declaration : declaration Pp.t =
             (Custom_property name, Custom_value { value; layer; meta = None }));
       if important then
         Pp.string ctx (if ctx.minify then "!important" else " !important")
-  | Declaration { property; value; important } ->
+  | Declaration { property; value; important; _ } ->
       pp_property ctx property;
       Pp.string ctx ":";
       Pp.space_if_pretty ctx ();

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -136,6 +136,15 @@ val property_name : declaration -> string
     serialising the name to a string. *)
 type prop_key = Key : 'a Properties.property -> prop_key [@@unboxed]
 
+val equal_declaration : declaration -> declaration -> bool
+(** [equal_declaration a b] tests declarations for structural equality. *)
+
+val equal_prop_key : prop_key -> prop_key -> bool
+(** [equal_prop_key a b] tests property identities for equality. *)
+
+val hash_prop_key : prop_key -> int
+(** [hash_prop_key key] returns a hash consistent with {!equal_prop_key}. *)
+
 val property_key : declaration -> prop_key
 (** [property_key decl] is the identity of [decl]'s property. Two declarations
     have the same property name iff their keys are structurally equal. *)

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -154,7 +154,11 @@ let group_into_table rules =
 let diff_same_key_pair key d1 d2 =
   let sig1 = sig_of_decls d1 in
   let sig2 = sig_of_decls d2 in
-  if sig1 = sig2 && d1 <> d2 && D.reorder_is_significant d1 d2 then
+  if
+    sig1 = sig2
+    && (not (List.equal Declaration.equal_declaration d1 d2))
+    && D.reorder_is_significant d1 d2
+  then
     Some
       (D.Reordered
          {

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -386,7 +386,12 @@ let pp_content_changed_body ~style ~child_prefix buf ~old_declarations
   pp_property_diffs ~style ~parent_prefix:child_prefix buf property_changes;
   pp_reorder ~style ~parent_prefix:child_prefix old_declarations
     new_declarations buf;
-  if (not has_any_changes) && old_declarations <> new_declarations then
+  if
+    (not has_any_changes)
+    && not
+         (List.equal Declaration.equal_declaration old_declarations
+            new_declarations)
+  then
     let old_count = List.length old_declarations in
     let new_count = List.length new_declarations in
     if old_count <> new_count then
@@ -407,7 +412,11 @@ let pp_content_changed ~style ~prefix ~child_prefix buf ~selector
   let has_any_changes =
     property_changes <> [] || added_properties <> [] || removed_properties <> []
   in
-  if (not has_any_changes) && old_declarations = new_declarations then ()
+  if
+    (not has_any_changes)
+    && List.equal Declaration.equal_declaration old_declarations
+         new_declarations
+  then ()
   else if selector = "" then
     (* The parent already named the subject, as it does for an [@property] whose
        descriptors changed. Repeating it as a child label reads as two entries
@@ -561,7 +570,8 @@ let meaningful_rules (rules : rule_diff list) =
             new_declarations;
             _;
           }
-        when old_declarations = new_declarations ->
+        when List.equal Declaration.equal_declaration old_declarations
+               new_declarations ->
           (* Filter out rules that moved to different nesting but have no
              changes *)
           false
@@ -1108,8 +1118,17 @@ let decl_to_prop_value decl =
   in
   (name, value)
 
+let compare_prop_value (name1, value1) (name2, value2) =
+  let by_name = String.compare name1 name2 in
+  if by_name <> 0 then by_name else String.compare value1 value2
+
+let equal_prop_value (name1, value1) (name2, value2) =
+  String.equal name1 name2 && String.equal value1 value2
+
 let decls_signature (decls : Css.declaration list) =
-  List.map decl_to_prop_value decls |> List.sort compare
+  List.map decl_to_prop_value decls |> List.sort compare_prop_value
+
+let equal_decls_signature = List.equal equal_prop_value
 
 (* Normalize a selector string by sorting comma-separated selector items. This
    ensures we consider ".a,.b" equivalent to ".b,.a" when matching.
@@ -1130,7 +1149,9 @@ let rule_selector stmt =
    structural equality + [Hashtbl.hash]. Avoids serialising through
    [Pp.to_string] for every comparison. *)
 let selector_key_of_selector (sel : Css.Selector.t) : Css.Selector.t =
-  match sel with List subs -> List (List.sort compare subs) | _ -> sel
+  match sel with
+  | List subs -> List (List.sort Selector.compare subs)
+  | _ -> sel
 
 let selector_key_of_stmt stmt = selector_key_of_selector (rule_selector stmt)
 
@@ -1246,8 +1267,8 @@ let try_exact_match rules2_by_key used_rules r1 key1 d1 =
     List.find_opt
       (fun r ->
         (not (Hashtbl.mem used_rules r))
-        && rule_declarations r = d1
-        && rule_nested r = rule_nested r1)
+        && List.equal Declaration.equal_declaration (rule_declarations r) d1
+        && Stylesheet.equal (rule_nested r) (rule_nested r1))
       candidates
   with
   | Some exact ->
@@ -1480,13 +1501,17 @@ let matching_decls_in_map2 sel1_key decls1 map2 decls2 =
   (* Prefer an exact declaration match for the same selector key if available *)
   match
     List.find_opt
-      (fun (s, d) -> selector_key_of_selector s = sel1_key && d = decls1)
+      (fun (s, d) ->
+        Selector.equal (selector_key_of_selector s) sel1_key
+        && List.equal Declaration.equal_declaration d decls1)
       map2
   with
   | Some (s, d) -> (d, Some s)
   | None -> (
       match
-        List.find_opt (fun (s, _) -> selector_key_of_selector s = sel1_key) map2
+        List.find_opt
+          (fun (s, _) -> Selector.equal (selector_key_of_selector s) sel1_key)
+          map2
       with
       | Some (s, d) -> (d, Some s)
       | None -> (decls2, None))
@@ -1494,11 +1519,12 @@ let matching_decls_in_map2 sel1_key decls1 map2 decls2 =
 let add_ordering_issue ~moved map2 acc sel1 decls1 sel2 decls2 =
   let sel1_key = selector_key_of_selector sel1 in
   let sel2_key = selector_key_of_selector sel2 in
-  if sel1_key = sel2_key then
+  if Selector.equal sel1_key sel2_key then
     (* Same selector at this position: a difference only when its declarations
        differ, i.e. same-selector rules were reordered so the cascade winner
        flips. *)
-    if decls_signature decls1 = decls_signature decls2 then acc
+    if equal_decls_signature (decls_signature decls1) (decls_signature decls2)
+    then acc
     else (sel1, sel2, decls1, decls2) :: acc
   else if selector_moved moved sel1_key then
     (* Report the selector that moved, not the ones it displaced: a rule pulled
@@ -1581,7 +1607,7 @@ let selector_changes all_added_candidates all_removed_candidates =
         List.find_opt
           (fun added_rule ->
             let added_sel = rule_selector added_rule in
-            removed_sel <> added_sel
+            (not (Selector.equal removed_sel added_sel))
             && selectors_share_parent_ast removed_sel added_sel)
           (added_with_props_sig removed_props)
       in
@@ -1707,13 +1733,16 @@ let detect_pure_regroups added removed =
         | Some (_, subs, _) -> List.map selector_key_of_selector subs
         | None -> [])
       rules
-    |> List.sort compare
+    |> List.sort Selector.compare
   in
   List.filter_map rule_sig (added @ removed)
   |> List.sort_uniq compare
   |> List.filter_map (fun s ->
       let radd = with_sig s added and rrem = with_sig s removed in
-      if radd <> [] && rrem <> [] && single_keys radd = single_keys rrem then
+      if
+        radd <> [] && rrem <> []
+        && List.equal Selector.equal (single_keys radd) (single_keys rrem)
+      then
         Some
           ( s,
             (Regrouped
@@ -1734,6 +1763,19 @@ let reconcile_selector_grouping added removed =
   let removed = List.filter (fun r -> not (in_pure r)) removed in
   let added, removed = partial_trim added removed in
   (added, removed, List.map snd pure)
+
+(* Key reorder detection uses both selector and declarations: two same-selector
+   rules with conflicting declarations cascade last-wins. *)
+let order_signature stmts =
+  List.map
+    (fun stmt ->
+      (selector_key_of_stmt stmt, decls_signature (rule_declarations stmt)))
+    stmts
+
+let equal_order_signature =
+  List.equal (fun (selector1, declarations1) (selector2, declarations2) ->
+      Selector.equal selector1 selector2
+      && equal_decls_signature declarations1 declarations2)
 
 let handle_structural_diff rules1 rules2 =
   let all_added_candidates = rules_added_diff rules1 rules2 in
@@ -1763,18 +1805,12 @@ let handle_structural_diff rules1 rules2 =
   let has_structural_changes =
     added <> [] || removed <> [] || modified <> [] || regrouped <> []
   in
-  (* Key reorder detection on the (selector, declarations) sequence, not the
-     selector alone: two same-selector rules with conflicting declarations
-     cascade last-wins, so swapping them is a real change. *)
-  let order_signature stmts =
-    List.map
-      (fun s -> (selector_key_of_stmt s, decls_signature (rule_declarations s)))
-      stmts
-  in
   let has_ordering_changes =
     (not has_structural_changes)
     && has_same_selectors rules1 rules2
-    && order_signature rules1 <> order_signature rules2
+    && not
+         (equal_order_signature (order_signature rules1)
+            (order_signature rules2))
   in
 
   let modified_with_order =
@@ -1871,7 +1907,9 @@ let selector_position sel rules =
   List.mapi
     (fun i stmt ->
       match Css.as_rule stmt with
-      | Some (s, _, _) when selector_key_of_selector s = sel_key -> Some i
+      | Some (s, _, _) when Selector.equal (selector_key_of_selector s) sel_key
+        ->
+          Some i
       | _ -> None)
     rules
   |> List.find_map Fun.id |> Option.value ~default:(-1)
@@ -1918,7 +1956,7 @@ let is_pure_decl_reordering decls1 decls2 =
   in
   let pure =
     property_changes = [] && added_props = [] && removed_props = []
-    && decls_signature decls1 = decls_signature decls2
+    && equal_decls_signature (decls_signature decls1) (decls_signature decls2)
   in
   (pure, property_changes, added_props, removed_props)
 
@@ -1962,7 +2000,8 @@ let convert_modified_rule ~moved ~rules1 ~rules2 (sel1, sel2, decls1, decls2) =
              new_selector = sel2_str;
              declarations = decls2;
            })
-  | _, _ when decls1 = decls2 -> reorder_or_content sel1_str decls1 decls2
+  | _, _ when List.equal Declaration.equal_declaration decls1 decls2 ->
+      reorder_or_content sel1_str decls1 decls2
   | _, _ ->
       let pure, property_changes, added_props, removed_props =
         is_pure_decl_reordering decls1 decls2
@@ -2024,8 +2063,10 @@ let declarations_of_selector sel stmts =
 let merge_selector_group ~rules1 ~rules2 sel peers =
   let old_all = declarations_of_selector sel rules1
   and new_all = declarations_of_selector sel rules2 in
-  if old_all <> [] && decls_signature old_all = decls_signature new_all then
-    Rearranged { selector = sel; declarations = new_all }
+  if
+    old_all <> []
+    && equal_decls_signature (decls_signature old_all) (decls_signature new_all)
+  then Rearranged { selector = sel; declarations = new_all }
   else
     content_changed sel
       (List.concat_map (fun d -> fst (change_sides d)) peers)
@@ -2461,7 +2502,7 @@ let keyframe_frames_diff frames1 frames2 =
   let key_equal = Css.Keyframe.selector_equal in
   let is_empty_diff (f1 : Css.keyframe) (f2 : Css.keyframe) =
     Css.Keyframe.selector_equal f1.selector f2.selector
-    && f1.declarations = f2.declarations
+    && List.equal Declaration.equal_declaration f1.declarations f2.declarations
   in
   let added, removed, modified_pairs =
     diffs ~key_of ~key_equal ~is_empty_diff frames1 frames2
@@ -2485,7 +2526,11 @@ let keyframe_frames_diff frames1 frames2 =
   let modified_changes =
     List.filter_map
       (fun ((f1 : Css.keyframe), (f2 : Css.keyframe)) ->
-        if f1.declarations <> f2.declarations then
+        if
+          not
+            (List.equal Declaration.equal_declaration f1.declarations
+               f2.declarations)
+        then
           Some
             (Content_changed
                {
@@ -2877,7 +2922,7 @@ and process_nested_rules stmts1 stmts2 =
   List.iter
     (fun (sel1, nested1) ->
       match List.find_opt (fun (s, _) -> s = sel1) items2 with
-      | Some (_, nested2) when nested1 <> nested2 ->
+      | Some (_, nested2) when not (Stylesheet.equal nested1 nested2) ->
           let rule_changes = to_rule_changes nested1 nested2 in
           let nested_containers = nested_differences nested1 nested2 in
           if rule_changes <> [] || nested_containers <> [] then

--- a/lib/dune
+++ b/lib/dune
@@ -23,8 +23,6 @@
   prop_font
   prop_text
   prop_animation)
- (flags
-  (:standard -w -9))
  (libraries uutf uri psq logs unix))
 
 (mdx

--- a/lib/factor.ml
+++ b/lib/factor.ml
@@ -19,7 +19,7 @@ let mix acc x = (acc * 31) + x
 let rule_hash (r : rule) =
   List.fold_left
     (fun acc d -> mix acc (Declaration.hash d))
-    (Hashtbl.hash r.Stylesheet_intf.selector)
+    (Selector.hash r.Stylesheet_intf.selector)
     r.Stylesheet_intf.declarations
 
 module Cache_tbl = Hashtbl.Make (struct

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -38,6 +38,11 @@ and src = src_entry list
 
 type t = src
 
+let equal_metric_override (a : metric_override) b = a = b
+let equal_size_adjust (a : size_adjust) b = Float.equal a b
+let compare_size_adjust (a : size_adjust) b = Float.compare a b
+let equal_src (a : src) b = a = b
+
 (* Emit the optional [format(...)] / [tech(...)] modifiers after a [url()] base.
    Under minify the modifiers run together with the [url()] - CSS Fonts 4 6.3.3
    doesn't require whitespace between the function calls. *)

--- a/lib/font_face.mli
+++ b/lib/font_face.mli
@@ -38,6 +38,18 @@ and src = src_entry list
 type t = src
 (** Font source list. *)
 
+val equal_metric_override : metric_override -> metric_override -> bool
+(** [equal_metric_override a b] tests metric overrides for equality. *)
+
+val equal_size_adjust : size_adjust -> size_adjust -> bool
+(** [equal_size_adjust a b] tests size adjustments for equality. *)
+
+val compare_size_adjust : size_adjust -> size_adjust -> int
+(** [compare_size_adjust a b] orders size adjustments. *)
+
+val equal_src : src -> src -> bool
+(** [equal_src a b] tests font source lists for structural equality. *)
+
 val pp : t Pp.t
 (** [pp] renders a font source list. *)
 

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -29,7 +29,9 @@ let remember seen decl =
   Hashtbl.replace seen hash (decl :: bucket)
 
 let default_same a b =
-  a == b || (Declaration.hash a = Declaration.hash b && a = b)
+  a == b
+  || Declaration.hash a = Declaration.hash b
+     && Declaration.equal_declaration a b
 
 let v ?(same = default_same) ?(keep = fun (_ : Stylesheet.rule) -> true)
     (rules : Stylesheet.rule array) =

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -475,7 +475,8 @@ let should_use_typed_default ~kept visible vars =
    while still applying value-independent simplifications like calc identities,
    so the substituted declaration is always evaluated, kept var or not. *)
 let apply_substituted_components ctx decl ~original_components components =
-  if components = original_components then Some (Context.eval ctx decl)
+  if List.equal Component.equal components original_components then
+    Some (Context.eval ctx decl)
   else
     match declaration_with_components decl components with
     | None -> None
@@ -505,7 +506,7 @@ let fold_custom_value ~kept visible decl =
       match substitute_components ~kept visible ~visited:[] original with
       | Cycle -> Some decl
       | Components components -> (
-          if components = original then Some decl
+          if List.equal Component.equal components original then Some decl
           else
             match declaration_with_components decl components with
             | Some decl' -> Some decl'
@@ -582,6 +583,7 @@ let eval_page_declaration visible ctx decl =
         property = Properties.Margin_top as property;
         value = (Values.Var var : Values.length);
         important;
+        _;
       } ->
       Declaration.v ~important property (resolve_length_var var)
   | _ -> Context.eval ctx decl

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -533,7 +533,7 @@ let non_whitespace_components = List.filter (Fun.negate is_whitespace_component)
 let components_empty components =
   match trim_components components with [] -> true | _ :: _ -> false
 
-let components_to_string components =
+let string_of_components components =
   Cursor.string_of_components ~trim:true components
 
 let ident_component = function
@@ -636,7 +636,7 @@ let value_of_components_opt components =
   ] -> (
       match typed_function_value component with
       | Some _ as value -> value
-      | Option.None -> Some (Function (name, components_to_string arguments)))
+      | Option.None -> Some (Function (name, string_of_components arguments)))
   | _ -> Option.None
 
 let value_of_string s =
@@ -807,36 +807,40 @@ let name_first_range name op components =
       else Option.None
   | Some _, _ | Option.None, Option.None -> Option.None
 
+let range_rev_of_components lower op1 = function
+  | [ name_component ] -> (
+      match ident_component name_component with
+      | Some name ->
+          let name = name_of_string name in
+          if validate_range_feature name lower then
+            Some (Range_rev (lower, op1, name))
+          else Option.None
+      | Option.None -> Option.None)
+  | _ -> Option.None
+
+let interval_of_components lower op1 name_components op2 upper_components =
+  match (name_components, value_of_components_opt upper_components) with
+  | [ name_component ], Some upper -> (
+      match ident_component name_component with
+      | Some name ->
+          let name = name_of_string name in
+          if
+            interval_ops_compatible op1 op2
+            && validate_range_feature name lower
+            && validate_range_feature name upper
+          then Some (Interval (lower, op1, name, op2, upper))
+          else Option.None
+      | Option.None -> Option.None)
+  | _ -> Option.None
+
 let value_first_range_or_interval lhs op1 rhs =
   match value_of_components_opt lhs with
   | Option.None -> Option.None
   | Some lower -> (
       match split_cmp rhs with
-      | Option.None -> (
-          match rhs with
-          | [ name_component ] -> (
-              match ident_component name_component with
-              | Some name ->
-                  let name = name_of_string name in
-                  if validate_range_feature name lower then
-                    Some (Range_rev (lower, op1, name))
-                  else Option.None
-              | Option.None -> Option.None)
-          | _ -> Option.None)
-      | Some (name_components, op2, upper_components) -> (
-          match (name_components, value_of_components_opt upper_components) with
-          | [ name_component ], Some upper -> (
-              match ident_component name_component with
-              | Some name ->
-                  let name = name_of_string name in
-                  if
-                    interval_ops_compatible op1 op2
-                    && validate_range_feature name lower
-                    && validate_range_feature name upper
-                  then Some (Interval (lower, op1, name, op2, upper))
-                  else Option.None
-              | Option.None -> Option.None)
-          | _ -> Option.None))
+      | Option.None -> range_rev_of_components lower op1 rhs
+      | Some (name_components, op2, upper_components) ->
+          interval_of_components lower op1 name_components op2 upper_components)
 
 let parse_feature_components components =
   let components = non_whitespace_components components in
@@ -889,13 +893,13 @@ and condition_in_parens component : condition =
       match parse_feature_components value with
       | Valid_feature feature -> Feature feature
       | Invalid_feature ->
-          failwith ("invalid media feature: " ^ components_to_string value)
+          failwith ("invalid media feature: " ^ string_of_components value)
       | Not_feature -> condition_of_components value)
   | Component.Block { node = { opening = Token.Paren; closed = false; _ }; _ }
     ->
       failwith "unmatched parenthesis in @media condition"
   | Component.Func { node = { terminated = true; _ }; _ } ->
-      Feature (General_enclosed (components_to_string [ component ]))
+      Feature (General_enclosed (string_of_components [ component ]))
   | Component.Func { node = { terminated = false; _ }; _ } ->
       failwith "unmatched function in @media condition"
   | Component.Block _ | Component.Preserved _ ->

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -114,6 +114,8 @@ type value =
           captured as a function name plus its raw argument body for round-trip;
           cascade doesn't yet evaluate them at parse time. *)
 
+let equal_value (a : value) b = a = b
+
 type feature =
   | Plain of name * value
   | Boolean of name
@@ -133,6 +135,8 @@ type condition =
 
 type medium = All | Screen | Print | Other of string
 type prefix = Not | Only
+
+let equal_name (a : name) b = a = b
 
 type t =
   | Cond of condition
@@ -1104,6 +1108,8 @@ type kind =
   | Preference_accessibility
   | Preference_appearance
   | Other
+
+let equal_kind (a : kind) b = a = b
 
 let length_sort_key (l : Values_intf.length) =
   match l with

--- a/lib/media.mli
+++ b/lib/media.mli
@@ -96,6 +96,9 @@ type value =
   | Ident of ident
   | Function of string * string
 
+val equal_value : value -> value -> bool
+(** [equal_value a b] tests media feature values structurally. *)
+
 (** Media Queries 4 sec. 3.1 [<general-enclosed>]: a grammatical but
     unrecognised query, kept verbatim. Its result is [unknown], which becomes
     false wherever a boolean is expected. *)
@@ -115,6 +118,9 @@ type condition =
 
 type medium = All | Screen | Print | Other of string
 type prefix = Not | Only
+
+val equal_name : name -> name -> bool
+(** [equal_name a b] tests media feature names for equality. *)
 
 (** Comma-separated media query list. *)
 type t =
@@ -219,6 +225,9 @@ type kind =
   | Preference_accessibility
   | Preference_appearance
   | Other
+
+val equal_kind : kind -> kind -> bool
+(** [equal_kind a b] tests media query categories for equality. *)
 
 val kind : t -> kind
 (** [kind t] classifies [t] for grouping and ordering. *)

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -58,12 +58,12 @@ let rec merge_lone (rule : rule) =
 
 let rec strip_prefix (parent : Selector.t) (child : Selector.t) =
   match (parent, child) with
-  | _, Selector.Combined (cp, comb, crest) when cp = parent ->
+  | _, Selector.Combined (cp, comb, crest) when Selector.equal cp parent ->
       Some
         (if comb = Selector.Descendant then crest
          else Selector.Relative (comb, crest))
   | Selector.Combined (pp, pcomb, prest), Selector.Combined (cp, ccomb, crest)
-    when pcomb = ccomb && pp = cp ->
+    when Selector.equal_combinator pcomb ccomb && Selector.equal pp cp ->
       strip_prefix prest crest
   | _, Selector.Compound cps -> (
       let pps =

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -669,6 +669,7 @@ let promote_registered_custom_decl ~lossless registry decl =
         property = Custom_property name;
         value = Custom_value { value = Tokens components; layer; meta };
         important;
+        _;
       } -> (
       match Hashtbl.find_opt registry name with
       | None -> decl
@@ -784,6 +785,7 @@ let rec prune_position_try_decl known (decl : Declaration.declaration) :
         property = Position_try_fallbacks;
         value = (Fallbacks items : Properties.position_try_fallbacks);
         important;
+        _;
       } -> (
       let keep = function
         | (Properties.Name s : Properties.position_try_fallback) ->
@@ -1046,7 +1048,7 @@ let run_pipeline ~ctx ~enforce_spec ~aggressive stylesheet =
     else
       let next = statements_top_level ~factor_cache ~ctx ~enforce_spec stmts in
       if next == stmts then stmts
-      else if next = stmts then stmts
+      else if Stylesheet.equal next stmts then stmts
       else
         let next_key = stylesheet_key next in
         if String.equal key next_key then next else loop (n - 1) next_key next

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -34,7 +34,7 @@ and consume_simple_block lexer opening ~start_loc :
     | Token.Eof ->
         let loc = Loc.union start_loc tok.loc in
         { node = { opening; value = List.rev acc; closed = false }; loc }
-    | Token.Close b when b = opening ->
+    | Token.Close b when Token.equal_bracket b opening ->
         let loc = Loc.union start_loc tok.loc in
         { node = { opening; value = List.rev acc; closed = true }; loc }
     | _ ->

--- a/lib/prop_align.ml
+++ b/lib/prop_align.ml
@@ -666,7 +666,7 @@ let rec pp_gap : gap Pp.t =
   | Var v -> pp_var pp_gap ctx v
   | Lengths { row_gap; column_gap } -> (
       match (row_gap, column_gap) with
-      | Some row, Some col when row = col ->
+      | Some row, Some col when Values.equal_length row col ->
           (* Single value when both gaps are equal *)
           pp_length ctx row
       | Some row, Some col ->

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -262,9 +262,11 @@ let rec pp_animation_range : animation_range Pp.t =
   | Range
       ( Named (start_name, Some start_offset),
         Some (Named (end_name, Some end_offset)) )
-    when start_name = end_name
-         && start_offset = (Pct 0. : length_percentage)
-         && end_offset = (Pct 100. : length_percentage) ->
+    when equal_animation_range_name start_name end_name
+         && Values.equal_length_percentage start_offset
+              (Pct 0. : length_percentage)
+         && Values.equal_length_percentage end_offset
+              (Pct 100. : length_percentage) ->
       pp_animation_range_item ctx (Named (start_name, Some start_offset))
   | Range (first, Some second) ->
       pp_animation_range_item ctx first;

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -757,7 +757,7 @@ let rec pp_logical_border_width : logical_border_width Pp.t =
 
 let rec pp_border_spacing : border_spacing Pp.t =
  fun ctx -> function
-  | Lengths [ a; b ] when a = b -> pp_length ctx a
+  | Lengths [ a; b ] when Values.equal_length a b -> pp_length ctx a
   | (Lengths lengths : border_spacing) ->
       Pp.list ~sep:Pp.space pp_length ctx lengths
   | Var v -> pp_var pp_border_spacing ctx v
@@ -1611,7 +1611,7 @@ let read_background_shorthand t : background_shorthand =
   let apply acc upd =
     let new_acc = upd acc in
     (* Check if the update actually changed anything *)
-    if new_acc = acc then
+    if equal_background_shorthand new_acc acc then
       (* Nothing changed, meaning we tried to set a duplicate property *)
       Cursor.err t "Duplicate property in background shorthand"
     else new_acc
@@ -1619,7 +1619,8 @@ let read_background_shorthand t : background_shorthand =
   let acc, _ =
     Cursor.fold_many Background_shorthand.read_item ~init ~f:apply t
   in
-  if acc = init then Cursor.err_expected t "background value";
+  if equal_background_shorthand acc init then
+    Cursor.err_expected t "background value";
   acc
 
 let read_background_vars read_self t =

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -519,7 +519,8 @@ let rec pp_overflow : overflow Pp.t =
   | Unset -> Pp.string ctx "unset"
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
-  | Overflow_pair (x, y) when Pp.minified ctx && x = y -> pp_overflow ctx x
+  | Overflow_pair (x, y) when Pp.minified ctx && equal_overflow x y ->
+      pp_overflow ctx x
   | Overflow_pair (x, y) ->
       pp_overflow ctx x;
       Pp.space ctx ();
@@ -958,7 +959,9 @@ let rec read_min_intrinsic_sizing t : min_intrinsic_sizing =
           read_min_intrinsic_sizing_keyword t
       in
       let duplicate keyword =
-        List.length (List.filter (( = ) keyword) keywords) > 1
+        List.length
+          (List.filter (equal_min_intrinsic_sizing_keyword keyword) keywords)
+        > 1
       in
       if List.exists duplicate keywords then
         Cursor.err_invalid t "min-intrinsic-sizing";

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -86,12 +86,16 @@ let grid_area_default_from (line : grid_line) : grid_line =
 
 let grid_area_compact ~(row_start : grid_line) ~(column_start : grid_line)
     ~(row_end : grid_line) ~(column_end : grid_line) =
-  let drop_column_end = column_end = grid_area_default_from column_start in
+  let drop_column_end =
+    equal_grid_line column_end (grid_area_default_from column_start)
+  in
   let drop_row_end =
-    drop_column_end && row_end = grid_area_default_from row_start
+    drop_column_end
+    && equal_grid_line row_end (grid_area_default_from row_start)
   in
   let drop_column_start =
-    drop_row_end && column_start = grid_area_default_from row_start
+    drop_row_end
+    && equal_grid_line column_start (grid_area_default_from row_start)
   in
   match (drop_column_start, drop_row_end, drop_column_end) with
   | true, true, true -> [ row_start ]

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -834,13 +834,13 @@ let rec fold_double_position_stops stops =
   | Color_percentage (c1, Option.Some p1, Option.None)
     :: Color_percentage (c2, Option.Some p2, Option.None)
     :: rest
-    when c1 = c2 ->
+    when Values.equal_color c1 c2 ->
       Color_percentage (c1, Option.Some p1, Option.Some p2)
       :: fold_double_position_stops rest
   | Color_length (c1, Option.Some l1, Option.None)
     :: Color_length (c2, Option.Some l2, Option.None)
     :: rest
-    when c1 = c2 ->
+    when Values.equal_color c1 c2 ->
       Color_length (c1, Option.Some l1, Option.Some l2)
       :: fold_double_position_stops rest
   | stop :: rest ->

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -193,7 +193,9 @@ let rec pp_position_area : position_area Pp.t =
   (* CSS Anchor Positioning 1 sec. 6: the second axis defaults to [center], so
      [X center] minifies to [X]; both axes equal also collapse. *)
   | Area (first, Some second)
-    when Pp.minified ctx && (first = second || second = Center) ->
+    when Pp.minified ctx
+         && (equal_position_area_keyword first second
+            || equal_position_area_keyword second Center) ->
       pp_position_area_keyword ctx first
   | Area (first, second) ->
       pp_position_area_keyword ctx first;
@@ -790,7 +792,11 @@ let rec read_position_visibility t : position_visibility =
         Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2 read_condition t
       in
       let duplicate condition =
-        List.length (List.filter (( = ) condition) conditions) > 1
+        List.length
+          (List.filter
+             (equal_position_visibility_condition condition)
+             conditions)
+        > 1
       in
       if List.exists duplicate conditions then
         Cursor.err_invalid t "position-visibility";

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -726,14 +726,16 @@ end
 let read_mask_layer t : mask_layer =
   let apply acc upd =
     let next = upd acc in
-    if next = acc then Cursor.err t "Duplicate property in mask shorthand"
+    if equal_mask_layer next acc then
+      Cursor.err t "Duplicate property in mask shorthand"
     else next
   in
   let layer, _ =
     Cursor.fold_many Mask_shorthand.read_item ~init:Mask_shorthand.init ~f:apply
       t
   in
-  if layer = Mask_shorthand.init then Cursor.err_expected t "mask value";
+  if equal_mask_layer layer Mask_shorthand.init then
+    Cursor.err_expected t "mask value";
   layer
 
 let rec read_mask t : mask =

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -47,8 +47,11 @@ let normalize_paint_order (value : paint_order) : paint_order =
         if n > List.length full then value
         else
           let prefix = List.filteri (fun i _ -> i < n) full in
-          if paint_order_expand prefix = full then
-            if prefix = [] then (Normal : paint_order) else Order prefix
+          if
+            List.equal equal_paint_order_keyword
+              (paint_order_expand prefix)
+              full
+          then if prefix = [] then (Normal : paint_order) else Order prefix
           else shortest (n + 1)
       in
       shortest 0

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -494,7 +494,9 @@ let rec read_text_emphasis_skip t : text_emphasis_skip =
       let duplicate =
         List.exists
           (fun keyword ->
-            List.length (List.filter (( = ) keyword) keywords) > 1)
+            List.length
+              (List.filter (equal_text_emphasis_skip_keyword keyword) keywords)
+            > 1)
           keywords
       in
       if duplicate then Cursor.err_invalid t "text-emphasis-skip"
@@ -1671,7 +1673,8 @@ let rec read_ruby_position t : ruby_position =
           read_ruby_position_keyword t
       in
       let duplicate keyword =
-        List.length (List.filter (( = ) keyword) keywords) > 1
+        List.length (List.filter (equal_ruby_position_keyword keyword) keywords)
+        > 1
       in
       let valid =
         match keywords with
@@ -1992,7 +1995,11 @@ let rec read_initial_letter_align t : initial_letter_align =
       let duplicate =
         List.exists
           (fun keyword ->
-            List.length (List.filter (( = ) keyword) keywords) > 1)
+            List.length
+              (List.filter
+                 (equal_initial_letter_align_keyword keyword)
+                 keywords)
+            > 1)
           keywords
       in
       let valid_pair =

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -387,7 +387,7 @@ let canonicalise_transform : transform -> transform = function
   | Translate_x x -> Translate (x, None)
   | Scale (x, Some (Num 1.)) -> Scale_x x
   | Scale (Num 1., Some y) -> Scale_y y
-  | Scale (x, Some y) when x = y -> Scale (x, None)
+  | Scale (x, Some y) when Values.equal_number_percentage x y -> Scale (x, None)
   | Scale_3d (x, y, Num 1.) -> Scale (x, Some y)
   | Rotate_z a -> Rotate a
   | Rotate_3d (1., 0., 0., a) -> Rotate_x a

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -5036,3 +5036,26 @@ type _ property_value_kind =
   | Background_images : background_image list property_value_kind
   | Font_src : Font_face.src property_value_kind
   | Font_family : font_family property_value_kind
+
+let equal_overflow (a : overflow) b = a = b
+let equal_grid_line (a : grid_line) b = a = b
+let equal_text_emphasis_skip_keyword (a : text_emphasis_skip_keyword) b = a = b
+
+let equal_min_intrinsic_sizing_keyword (a : min_intrinsic_sizing_keyword) b =
+  a = b
+
+let equal_initial_letter_align_keyword (a : initial_letter_align_keyword) b =
+  a = b
+
+let equal_ruby_position_keyword (a : ruby_position_keyword) b = a = b
+let equal_background_shorthand (a : background_shorthand) b = a = b
+let equal_mask_layer (a : mask_layer) b = a = b
+let equal_position_area_keyword (a : position_area_keyword) b = a = b
+
+let equal_position_visibility_condition (a : position_visibility_condition) b =
+  a = b
+
+let equal_animation_range_name (a : animation_range_name) b = a = b
+let equal_container_shorthand (a : container_shorthand) b = a = b
+let equal_paint_order_keyword (a : paint_order_keyword) b = a = b
+let equal_paint_order (a : paint_order) b = a = b

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -302,7 +302,7 @@ module Make (N : NODE) = struct
             List.fold_left
               (fun acc b ->
                 let s = Selector.specificity b in
-                if compare s acc > 0 then s else acc)
+                if Selector.compare_specificity s acc > 0 then s else acc)
               (Selector.specificity b) rest)
     | None -> Selector.specificity sel
 
@@ -342,7 +342,11 @@ module Make (N : NODE) = struct
                   i,
                   ds ))
       |> List.stable_sort (fun (l1, s1, i1, _) (l2, s2, i2, _) ->
-          compare (l1, s1, i1) (l2, s2, i2))
+          let layer = Int.compare l1 l2 in
+          if layer <> 0 then layer
+          else
+            let specificity = Selector.compare_specificity s1 s2 in
+            if specificity <> 0 then specificity else Int.compare i1 i2)
       |> List.concat_map (fun (_, _, _, ds) -> ds)
     in
     (* normal first, then !important, last wins per property *)

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -88,13 +88,13 @@ let columns_value_of_longhands width count : Properties.columns_value =
 let synthesize_columns decls =
   let width_of d : (Properties.column_width * bool) option =
     match d with
-    | Declaration { property = Column_width; value; important } ->
+    | Declaration { property = Column_width; value; important; _ } ->
         Some (value, important)
     | _ -> None
   in
   let count_of d : (Properties.column_count * bool) option =
     match d with
-    | Declaration { property = Column_count; value; important } ->
+    | Declaration { property = Column_count; value; important; _ } ->
         Some (value, important)
     | _ -> None
   in
@@ -143,13 +143,13 @@ let synthesize_columns decls =
 let synthesize_position_try decls =
   let order_of d : (Properties.position_try_order * bool) option =
     match d with
-    | Declaration { property = Position_try_order; value; important } ->
+    | Declaration { property = Position_try_order; value; important; _ } ->
         Some (value, important)
     | _ -> None
   in
   let fallbacks_of d : (Properties.position_try_fallbacks * bool) option =
     match d with
-    | Declaration { property = Position_try_fallbacks; value; important } ->
+    | Declaration { property = Position_try_fallbacks; value; important; _ } ->
         Some (value, important)
     | _ -> None
   in

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -991,10 +991,15 @@ type property_key = {
 let declaration_property_key decl : property_key =
   let prop = Declaration.property_key decl in
   let important = Declaration.is_important decl in
-  { prop; important; hash = mix_int (Hashtbl.hash prop) (hash_bool important) }
+  {
+    prop;
+    important;
+    hash = mix_int (Declaration.hash_prop_key prop) (hash_bool important);
+  }
 
 let property_key_equal left right =
-  Bool.equal left.important right.important && left.prop = right.prop
+  Bool.equal left.important right.important
+  && Declaration.equal_prop_key left.prop right.prop
 
 let property_key_hash key = key.hash
 

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -545,7 +545,10 @@ let rec normalize_custom_values (stmts : statement list) : statement list =
 let canonical_color_spelling decl =
   let folded = Declaration.normalize ~lossless:true ~exact_srgb:true decl in
   if folded == decl then decl
-  else if folded = Declaration.normalize ~lossless:true decl then decl
+  else if
+    Declaration.equal_declaration folded
+      (Declaration.normalize ~lossless:true decl)
+  then decl
   else folded
 
 let rec canonical_color_spellings (stmts : statement list) : statement list =

--- a/lib/rule_rewrite.ml
+++ b/lib/rule_rewrite.ml
@@ -17,6 +17,8 @@ type kind =
   | Selector_branch_inline
   | Default_factoring
 
+let equal_kind (a : kind) b = a = b
+
 type candidate = {
   generation : int;
   kind : kind;

--- a/lib/rule_rewrite.mli
+++ b/lib/rule_rewrite.mli
@@ -9,6 +9,9 @@ type kind =
   | Selector_branch_inline
   | Default_factoring
 
+val equal_kind : kind -> kind -> bool
+(** [equal_kind a b] tests rewrite families for equality. *)
+
 type candidate = {
   generation : int;
   kind : kind;

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2643,3 +2643,4 @@ let modifier_prefix sel =
 
 let ( && ) sel1 sel2 = compound [ sel1; sel2 ]
 let ( || ) s1 s2 = combine s1 Column s2
+let compare (a : t) b = Stdlib.compare a b

--- a/lib/selector.mli
+++ b/lib/selector.mli
@@ -94,11 +94,29 @@ val to_string : ?minify:bool -> t -> string
 val to_buffer : ?minify:bool -> Buffer.t -> t -> unit
 (** [to_buffer ?minify buf sel] renders a selector into [buf]. *)
 
+val equal : t -> t -> bool
+(** [equal a b] tests selectors for structural equality. *)
+
+val compare : t -> t -> int
+(** [compare a b] totally orders selectors structurally. *)
+
+val hash : t -> int
+(** [hash selector] returns a hash consistent with {!equal}. *)
+
+val equal_specificity : specificity -> specificity -> bool
+(** [equal_specificity a b] tests specificity triples for equality. *)
+
+val equal_combinator : combinator -> combinator -> bool
+(** [equal_combinator a b] tests selector combinators for equality. *)
+
 val specificity : t -> specificity
 (** [specificity selector] computes Selectors specificity as
     [(ids, classes, elements)]. For selector-list-like pseudos such as [:is()],
     [:not()], and [:has()], the most specific argument is used; [:where()]
     contributes zero. *)
+
+val compare_specificity : specificity -> specificity -> int
+(** [compare_specificity a b] orders specificity triples lexicographically. *)
 
 val map : (t -> t) -> t -> t
 (** [map f selector] recursively applies [f] to all selectors in the tree. The

--- a/lib/selector_intf.ml
+++ b/lib/selector_intf.ml
@@ -238,3 +238,8 @@ type t =
        :has() *)
   | List of t list
   | Nesting (* & - CSS nesting selector *)
+
+let equal (a : t) b = a = b
+let hash (selector : t) = Hashtbl.hash selector
+let equal_specificity (a : specificity) b = a = b
+let equal_combinator (a : combinator) b = a = b

--- a/lib/selector_summary.ml
+++ b/lib/selector_summary.ml
@@ -133,7 +133,7 @@ let rec fold_simple s (sel : Selector.t) =
       in
       match s.pseudo_element with
       | None -> { s with pseudo_element = Some canonical }
-      | Some prev when prev = canonical -> s
+      | Some prev when Selector.equal prev canonical -> s
       | Some _ -> mark_complex s)
   | Attribute (ns, attr_name, matcher, flag) ->
       {
@@ -248,7 +248,7 @@ let direct_facts_disjoint a b =
     match (a.pseudo_element, b.pseudo_element) with
     | None, None -> false
     | Some _, None | None, Some _ -> true
-    | Some x, Some y -> x <> y
+    | Some x, Some y -> not (Selector.equal x y)
   in
   if pe_disjoint then true
   else

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -1218,7 +1218,7 @@ let collapse_box_by same = function
 (* Both sides are the same [length] type, so structural equality is the
    minified-equality test once lengths are canonical - no need to render and
    compare text. *)
-let same_minified_length (a : Values.length) (b : Values.length) = a = b
+let same_minified_length = Values.equal_length
 let collapse_box_lengths vs = collapse_box_by same_minified_length vs
 
 type sides = Values.length * Values.length * Values.length * Values.length
@@ -1238,16 +1238,16 @@ let sides_have_runtime_subst ((top, right, bottom, left) : sides) =
 let absorb_margin_corner ~important ((top, right, bottom, left) : sides) d :
     sides option =
   match d with
-  | Declaration { property = Margin_top; value = v; important = i }
+  | Declaration { property = Margin_top; value = v; important = i; _ }
     when i = important ->
       Some (v, right, bottom, left)
-  | Declaration { property = Margin_right; value = v; important = i }
+  | Declaration { property = Margin_right; value = v; important = i; _ }
     when i = important ->
       Some (top, v, bottom, left)
-  | Declaration { property = Margin_bottom; value = v; important = i }
+  | Declaration { property = Margin_bottom; value = v; important = i; _ }
     when i = important ->
       Some (top, right, v, left)
-  | Declaration { property = Margin_left; value = v; important = i }
+  | Declaration { property = Margin_left; value = v; important = i; _ }
     when i = important ->
       Some (top, right, bottom, v)
   | _ -> None
@@ -1255,16 +1255,16 @@ let absorb_margin_corner ~important ((top, right, bottom, left) : sides) d :
 let absorb_padding_corner ~important ((top, right, bottom, left) : sides) d :
     sides option =
   match d with
-  | Declaration { property = Padding_top; value = v; important = i }
+  | Declaration { property = Padding_top; value = v; important = i; _ }
     when i = important ->
       Some (v, right, bottom, left)
-  | Declaration { property = Padding_right; value = v; important = i }
+  | Declaration { property = Padding_right; value = v; important = i; _ }
     when i = important ->
       Some (top, v, bottom, left)
-  | Declaration { property = Padding_bottom; value = v; important = i }
+  | Declaration { property = Padding_bottom; value = v; important = i; _ }
     when i = important ->
       Some (top, right, v, left)
-  | Declaration { property = Padding_left; value = v; important = i }
+  | Declaration { property = Padding_left; value = v; important = i; _ }
     when i = important ->
       Some (top, right, bottom, v)
   | _ -> None
@@ -1348,14 +1348,14 @@ let try_merge_box_shorthand ~original ~property ~vs ~important ~absorb
    side is later shadowed within the same block, fold them into [overflow] -
    single value when the two axes match, two values otherwise. *)
 let combined_overflow v_x v_y : Properties.overflow =
-  if v_x = v_y then v_x else Overflow_pair (v_x, v_y)
+  if Properties.equal_overflow v_x v_y then v_x else Overflow_pair (v_x, v_y)
 
 let try_take_overflow_y ~important rest =
   let rec loop acc :
       (int * declaration) list ->
       (Properties.overflow * (int * declaration) list) option = function
     | [] -> None
-    | (_, Declaration { property = Overflow_y; value = v_y; important = i' })
+    | (_, Declaration { property = Overflow_y; value = v_y; important = i'; _ })
       :: rest
       when i' = important ->
         Some (v_y, List.rev_append acc rest)
@@ -1371,7 +1371,7 @@ let try_take_overflow_x ~important rest =
       (int * declaration) list ->
       (Properties.overflow * (int * declaration) list) option = function
     | [] -> None
-    | (_, Declaration { property = Overflow_x; value = v_x; important = i' })
+    | (_, Declaration { property = Overflow_x; value = v_x; important = i'; _ })
       :: rest
       when i' = important ->
         Some (v_x, List.rev_append acc rest)
@@ -1385,8 +1385,8 @@ let try_take_overflow_x ~important rest =
 let merge_overflow_longhands decls =
   let rec go acc = function
     | [] -> List.rev acc
-    | ((idx, Declaration { property = Overflow_x; value = v_x; important }) as
-       item)
+    | ((idx, Declaration { property = Overflow_x; value = v_x; important; _ })
+       as item)
       :: rest -> (
         match try_take_overflow_y ~important rest with
         | None -> go (item :: acc) rest
@@ -1395,8 +1395,8 @@ let merge_overflow_longhands decls =
               Declaration.v ~important Overflow (combined_overflow v_x v_y)
             in
             go ((idx, merged) :: acc) rest')
-    | ((idx, Declaration { property = Overflow_y; value = v_y; important }) as
-       item)
+    | ((idx, Declaration { property = Overflow_y; value = v_y; important; _ })
+       as item)
       :: rest -> (
         match try_take_overflow_x ~important rest with
         | None -> go (item :: acc) rest
@@ -1417,25 +1417,25 @@ type box_side = Top | Right | Bottom | Left
 
 let extract_margin_side :
     declaration -> (box_side * Values.length * bool) option = function
-  | Declaration { property = Margin_top; value; important } ->
+  | Declaration { property = Margin_top; value; important; _ } ->
       Some (Top, value, important)
-  | Declaration { property = Margin_right; value; important } ->
+  | Declaration { property = Margin_right; value; important; _ } ->
       Some (Right, value, important)
-  | Declaration { property = Margin_bottom; value; important } ->
+  | Declaration { property = Margin_bottom; value; important; _ } ->
       Some (Bottom, value, important)
-  | Declaration { property = Margin_left; value; important } ->
+  | Declaration { property = Margin_left; value; important; _ } ->
       Some (Left, value, important)
   | _ -> None
 
 let extract_padding_side :
     declaration -> (box_side * Values.length * bool) option = function
-  | Declaration { property = Padding_top; value; important } ->
+  | Declaration { property = Padding_top; value; important; _ } ->
       Some (Top, value, important)
-  | Declaration { property = Padding_right; value; important } ->
+  | Declaration { property = Padding_right; value; important; _ } ->
       Some (Right, value, important)
-  | Declaration { property = Padding_bottom; value; important } ->
+  | Declaration { property = Padding_bottom; value; important; _ } ->
       Some (Bottom, value, important)
-  | Declaration { property = Padding_left; value; important } ->
+  | Declaration { property = Padding_left; value; important; _ } ->
       Some (Left, value, important)
   | _ -> None
 
@@ -1444,25 +1444,26 @@ let extract_padding_side :
    carry exactly one length per side. *)
 let extract_inset_side : declaration -> (box_side * Values.length * bool) option
     = function
-  | Declaration { property = Top; value = [ v ]; important } ->
+  | Declaration { property = Top; value = [ v ]; important; _ } ->
       Some (Top, v, important)
-  | Declaration { property = Right; value = [ v ]; important } ->
+  | Declaration { property = Right; value = [ v ]; important; _ } ->
       Some (Right, v, important)
-  | Declaration { property = Bottom; value = [ v ]; important } ->
+  | Declaration { property = Bottom; value = [ v ]; important; _ } ->
       Some (Bottom, v, important)
-  | Declaration { property = Left; value = [ v ]; important } ->
+  | Declaration { property = Left; value = [ v ]; important; _ } ->
       Some (Left, v, important)
   | _ -> None
 
 let extract_border_radius_corner :
     declaration -> (box_side * Values.length * bool) option = function
-  | Declaration { property = Border_top_left_radius; value; important } ->
+  | Declaration { property = Border_top_left_radius; value; important; _ } ->
       Some (Top, value, important)
-  | Declaration { property = Border_top_right_radius; value; important } ->
+  | Declaration { property = Border_top_right_radius; value; important; _ } ->
       Some (Right, value, important)
-  | Declaration { property = Border_bottom_right_radius; value; important } ->
+  | Declaration { property = Border_bottom_right_radius; value; important; _ }
+    ->
       Some (Bottom, value, important)
-  | Declaration { property = Border_bottom_left_radius; value; important } ->
+  | Declaration { property = Border_bottom_left_radius; value; important; _ } ->
       Some (Left, value, important)
   | _ -> None
 
@@ -1647,9 +1648,9 @@ type pair_side = Row | Column
 
 let extract_gap_side : declaration -> (pair_side * Values.length * bool) option
     = function
-  | Declaration { property = Row_gap; value; important } ->
+  | Declaration { property = Row_gap; value; important; _ } ->
       Some (Row, value, important)
-  | Declaration { property = Column_gap; value; important } ->
+  | Declaration { property = Column_gap; value; important; _ } ->
       Some (Column, value, important)
   | _ -> None
 
@@ -1701,56 +1702,58 @@ let try_compose_axis_pair_at idx ~extract ~build i =
         let v_start = List.assoc Start pair in
         let v_end = List.assoc End pair in
         let value =
-          if v_start = v_end then [ v_start ] else [ v_start; v_end ]
+          if Values.equal_length v_start v_end then [ v_start ]
+          else [ v_start; v_end ]
         in
         Some (build ~important:imp1 ~value)
     | _ -> None
 
 let extract_margin_inline_side :
     declaration -> (axis_side * Values.length * bool) option = function
-  | Declaration { property = Margin_inline_start; value; important } ->
+  | Declaration { property = Margin_inline_start; value; important; _ } ->
       Some (Start, value, important)
-  | Declaration { property = Margin_inline_end; value; important } ->
+  | Declaration { property = Margin_inline_end; value; important; _ } ->
       Some (End, value, important)
   | _ -> None
 
 let extract_margin_block_side :
     declaration -> (axis_side * Values.length * bool) option = function
-  | Declaration { property = Margin_block_start; value; important } ->
+  | Declaration { property = Margin_block_start; value; important; _ } ->
       Some (Start, value, important)
-  | Declaration { property = Margin_block_end; value; important } ->
+  | Declaration { property = Margin_block_end; value; important; _ } ->
       Some (End, value, important)
   | _ -> None
 
 let extract_padding_inline_side :
     declaration -> (axis_side * Values.length * bool) option = function
-  | Declaration { property = Padding_inline_start; value; important } ->
+  | Declaration { property = Padding_inline_start; value; important; _ } ->
       Some (Start, value, important)
-  | Declaration { property = Padding_inline_end; value; important } ->
+  | Declaration { property = Padding_inline_end; value; important; _ } ->
       Some (End, value, important)
   | _ -> None
 
 let extract_padding_block_side :
     declaration -> (axis_side * Values.length * bool) option = function
-  | Declaration { property = Padding_block_start; value; important } ->
+  | Declaration { property = Padding_block_start; value; important; _ } ->
       Some (Start, value, important)
-  | Declaration { property = Padding_block_end; value; important } ->
+  | Declaration { property = Padding_block_end; value; important; _ } ->
       Some (End, value, important)
   | _ -> None
 
 let extract_inset_inline_side :
     declaration -> (axis_side * Values.length * bool) option = function
-  | Declaration { property = Inset_inline_start; value = [ v ]; important } ->
+  | Declaration { property = Inset_inline_start; value = [ v ]; important; _ }
+    ->
       Some (Start, v, important)
-  | Declaration { property = Inset_inline_end; value = [ v ]; important } ->
+  | Declaration { property = Inset_inline_end; value = [ v ]; important; _ } ->
       Some (End, v, important)
   | _ -> None
 
 let extract_inset_block_side :
     declaration -> (axis_side * Values.length * bool) option = function
-  | Declaration { property = Inset_block_start; value = [ v ]; important } ->
+  | Declaration { property = Inset_block_start; value = [ v ]; important; _ } ->
       Some (Start, v, important)
-  | Declaration { property = Inset_block_end; value = [ v ]; important } ->
+  | Declaration { property = Inset_block_end; value = [ v ]; important; _ } ->
       Some (End, v, important)
   | _ -> None
 
@@ -1769,36 +1772,37 @@ let try_compose_place_at idx i =
     let d1 = Rule_index.decl_at idx i in
     let d2 = Rule_index.decl_at idx (i + 1) in
     match (d1, d2) with
-    | ( Declaration { property = Align_items; value = a; important = i1 },
-        Declaration { property = Justify_items; value = j; important = i2 } )
+    | ( Declaration { property = Align_items; value = a; important = i1; _ },
+        Declaration { property = Justify_items; value = j; important = i2; _ } )
       when i1 = i2 ->
         Some
           (Declaration.v ~important:i1 Place_items
              (Align_justify (a, j) : Properties.place_items))
-    | ( Declaration { property = Justify_items; value = j; important = i1 },
-        Declaration { property = Align_items; value = a; important = i2 } )
+    | ( Declaration { property = Justify_items; value = j; important = i1; _ },
+        Declaration { property = Align_items; value = a; important = i2; _ } )
       when i1 = i2 ->
         Some
           (Declaration.v ~important:i1 Place_items
              (Align_justify (a, j) : Properties.place_items))
-    | ( Declaration { property = Align_content; value = a; important = i1 },
-        Declaration { property = Justify_content; value = j; important = i2 } )
+    | ( Declaration { property = Align_content; value = a; important = i1; _ },
+        Declaration { property = Justify_content; value = j; important = i2; _ }
+      )
       when i1 = i2 ->
         Some
           (Declaration.v ~important:i1 Place_content
              (Align_justify (a, j) : Properties.place_content))
-    | ( Declaration { property = Justify_content; value = j; important = i1 },
-        Declaration { property = Align_content; value = a; important = i2 } )
+    | ( Declaration { property = Justify_content; value = j; important = i1; _ },
+        Declaration { property = Align_content; value = a; important = i2; _ } )
       when i1 = i2 ->
         Some
           (Declaration.v ~important:i1 Place_content
              (Align_justify (a, j) : Properties.place_content))
-    | ( Declaration { property = Align_self; value = a; important = i1 },
-        Declaration { property = Justify_self; value = j; important = i2 } )
+    | ( Declaration { property = Align_self; value = a; important = i1; _ },
+        Declaration { property = Justify_self; value = j; important = i2; _ } )
       when i1 = i2 ->
         Some (Declaration.v ~important:i1 Place_self (a, j))
-    | ( Declaration { property = Justify_self; value = j; important = i1 },
-        Declaration { property = Align_self; value = a; important = i2 } )
+    | ( Declaration { property = Justify_self; value = j; important = i1; _ },
+        Declaration { property = Align_self; value = a; important = i2; _ } )
       when i1 = i2 ->
         Some (Declaration.v ~important:i1 Place_self (a, j))
     | _ -> None
@@ -2261,37 +2265,37 @@ let compose_text_decoration_via_index idx =
    value would change the resolved shape. *)
 let border_width_of :
     declaration -> (box_side * Properties.border_width * bool) option = function
-  | Declaration { property = Border_top_width; value; important } ->
+  | Declaration { property = Border_top_width; value; important; _ } ->
       Some (Top, value, important)
-  | Declaration { property = Border_right_width; value; important } ->
+  | Declaration { property = Border_right_width; value; important; _ } ->
       Some (Right, value, important)
-  | Declaration { property = Border_bottom_width; value; important } ->
+  | Declaration { property = Border_bottom_width; value; important; _ } ->
       Some (Bottom, value, important)
-  | Declaration { property = Border_left_width; value; important } ->
+  | Declaration { property = Border_left_width; value; important; _ } ->
       Some (Left, value, important)
   | _ -> None
 
 let border_style_of :
     declaration -> (box_side * Properties.border_style * bool) option = function
-  | Declaration { property = Border_top_style; value; important } ->
+  | Declaration { property = Border_top_style; value; important; _ } ->
       Some (Top, value, important)
-  | Declaration { property = Border_right_style; value; important } ->
+  | Declaration { property = Border_right_style; value; important; _ } ->
       Some (Right, value, important)
-  | Declaration { property = Border_bottom_style; value; important } ->
+  | Declaration { property = Border_bottom_style; value; important; _ } ->
       Some (Bottom, value, important)
-  | Declaration { property = Border_left_style; value; important } ->
+  | Declaration { property = Border_left_style; value; important; _ } ->
       Some (Left, value, important)
   | _ -> None
 
 let border_color_of : declaration -> (box_side * Values.color * bool) option =
   function
-  | Declaration { property = Border_top_color; value; important } ->
+  | Declaration { property = Border_top_color; value; important; _ } ->
       Some (Top, value, important)
-  | Declaration { property = Border_right_color; value; important } ->
+  | Declaration { property = Border_right_color; value; important; _ } ->
       Some (Right, value, important)
-  | Declaration { property = Border_bottom_color; value; important } ->
+  | Declaration { property = Border_bottom_color; value; important; _ } ->
       Some (Bottom, value, important)
-  | Declaration { property = Border_left_color; value; important } ->
+  | Declaration { property = Border_left_color; value; important; _ } ->
       Some (Left, value, important)
   | _ -> None
 
@@ -3409,8 +3413,8 @@ let merge_box_shorthand_longhands source decls =
      with its index - the head stays physically shared on a no-op. *)
   let rec go acc = function
     | [] -> List.rev acc
-    | ((idx, (Declaration { property = Margin; value = vs; important } as d)) as
-       item)
+    | ((idx, (Declaration { property = Margin; value = vs; important; _ } as d))
+       as item)
       :: rest
       when not (box_shorthand_had_prior_longhand source idx d) ->
         let merged, rest =
@@ -3420,7 +3424,7 @@ let merge_box_shorthand_longhands source decls =
         in
         let head = if merged == d then item else (idx, merged) in
         go (head :: acc) rest
-    | ((idx, (Declaration { property = Padding; value = vs; important } as d))
+    | ((idx, (Declaration { property = Padding; value = vs; important; _ } as d))
        as item)
       :: rest
       when not (box_shorthand_had_prior_longhand source idx d) ->
@@ -3458,7 +3462,8 @@ let rec without_importance = function
    first, so the two declarations share a value type and this is a structural
    value comparison: on canonical ASTs it matches minified-text equality without
    rendering. *)
-let same_value a b = without_importance a = without_importance b
+let same_value a b =
+  Declaration.equal_declaration (without_importance a) (without_importance b)
 
 (* Two declarations minify to the same text exactly when their canonical ASTs
    are equal (property, value, and importance). After the optimizer's
@@ -3473,7 +3478,9 @@ let same_value a b = without_importance a = without_importance b
    compare without walking the AST; we only fall through to structural equality
    on a hash collision. *)
 let same_minified_declaration (a : declaration) (b : declaration) =
-  a == b || (Declaration.hash a = Declaration.hash b && a = b)
+  a == b
+  || Declaration.hash a = Declaration.hash b
+     && Declaration.equal_declaration a b
 
 let legacy_vendor_fallback new_decl existing =
   (* Different-value duplicates are kept when one value is vendor-prefixed: the
@@ -3559,104 +3566,125 @@ let deduplicate_step kept (idx, decl) =
 (* WebKit animation longhand vendor-alias pairs ([-webkit-] vs unprefixed). *)
 let vendor_alias_redundant_webkit_animation vendor twin =
   match (vendor, twin) with
-  | ( Declaration { property = Webkit_animation; value = v1; important = i1 },
-      Declaration { property = Animation; value = v2; important = i2 } ) ->
+  | ( Declaration { property = Webkit_animation; value = v1; important = i1; _ },
+      Declaration { property = Animation; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Webkit_animation_delay; value = v1; important = i1 },
-      Declaration { property = Animation_delay; value = v2; important = i2 } )
-    ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration
-        { property = Webkit_animation_duration; value = v1; important = i1 },
-      Declaration { property = Animation_duration; value = v2; important = i2 }
+        { property = Webkit_animation_delay; value = v1; important = i1; _ },
+      Declaration { property = Animation_delay; value = v2; important = i2; _ }
     ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Webkit_animation_direction; value = v1; important = i1 },
-      Declaration { property = Animation_direction; value = v2; important = i2 }
-    ) ->
+        { property = Webkit_animation_duration; value = v1; important = i1; _ },
+      Declaration
+        { property = Animation_duration; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        { property = Webkit_animation_direction; value = v1; important = i1; _ },
+      Declaration
+        { property = Animation_direction; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
         {
           property = Webkit_animation_iteration_count;
           value = v1;
           important = i1;
+          _;
         },
       Declaration
-        { property = Animation_iteration_count; value = v2; important = i2 } )
-    ->
+        { property = Animation_iteration_count; value = v2; important = i2; _ }
+    ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Webkit_animation_name; value = v1; important = i1 },
-      Declaration { property = Animation_name; value = v2; important = i2 } ) ->
+        { property = Webkit_animation_name; value = v1; important = i1; _ },
+      Declaration { property = Animation_name; value = v2; important = i2; _ } )
+    ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
         {
           property = Webkit_animation_timing_function;
           value = v1;
           important = i1;
+          _;
         },
       Declaration
-        { property = Animation_timing_function; value = v2; important = i2 } )
-    ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration
-        { property = Webkit_animation_fill_mode; value = v1; important = i1 },
-      Declaration { property = Animation_fill_mode; value = v2; important = i2 }
+        { property = Animation_timing_function; value = v2; important = i2; _ }
     ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Webkit_animation_play_state; value = v1; important = i1 },
+        { property = Webkit_animation_fill_mode; value = v1; important = i1; _ },
       Declaration
-        { property = Animation_play_state; value = v2; important = i2 } ) ->
+        { property = Animation_fill_mode; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        {
+          property = Webkit_animation_play_state;
+          value = v1;
+          important = i1;
+          _;
+        },
+      Declaration
+        { property = Animation_play_state; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | _ -> false
 
 (* Mozilla animation longhand vendor-alias pairs ([-moz-] vs unprefixed). *)
 let vendor_alias_redundant_moz_animation vendor twin =
   match (vendor, twin) with
-  | ( Declaration { property = Moz_animation; value = v1; important = i1 },
-      Declaration { property = Animation; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_animation_delay; value = v1; important = i1 },
-      Declaration { property = Animation_delay; value = v2; important = i2 } )
-    ->
+  | ( Declaration { property = Moz_animation; value = v1; important = i1; _ },
+      Declaration { property = Animation; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Moz_animation_duration; value = v1; important = i1 },
-      Declaration { property = Animation_duration; value = v2; important = i2 }
+        { property = Moz_animation_delay; value = v1; important = i1; _ },
+      Declaration { property = Animation_delay; value = v2; important = i2; _ }
     ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Moz_animation_direction; value = v1; important = i1 },
-      Declaration { property = Animation_direction; value = v2; important = i2 }
+        { property = Moz_animation_duration; value = v1; important = i1; _ },
+      Declaration
+        { property = Animation_duration; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        { property = Moz_animation_direction; value = v1; important = i1; _ },
+      Declaration
+        { property = Animation_direction; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        {
+          property = Moz_animation_iteration_count;
+          value = v1;
+          important = i1;
+          _;
+        },
+      Declaration
+        { property = Animation_iteration_count; value = v2; important = i2; _ }
     ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Moz_animation_iteration_count; value = v1; important = i1 },
-      Declaration
-        { property = Animation_iteration_count; value = v2; important = i2 } )
-    ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_animation_name; value = v1; important = i1 },
-      Declaration { property = Animation_name; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration
-        { property = Moz_animation_timing_function; value = v1; important = i1 },
-      Declaration
-        { property = Animation_timing_function; value = v2; important = i2 } )
+        { property = Moz_animation_name; value = v1; important = i1; _ },
+      Declaration { property = Animation_name; value = v2; important = i2; _ } )
     ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Moz_animation_fill_mode; value = v1; important = i1 },
-      Declaration { property = Animation_fill_mode; value = v2; important = i2 }
+        {
+          property = Moz_animation_timing_function;
+          value = v1;
+          important = i1;
+          _;
+        },
+      Declaration
+        { property = Animation_timing_function; value = v2; important = i2; _ }
     ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Moz_animation_play_state; value = v1; important = i1 },
+        { property = Moz_animation_fill_mode; value = v1; important = i1; _ },
       Declaration
-        { property = Animation_play_state; value = v2; important = i2 } ) ->
+        { property = Animation_fill_mode; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        { property = Moz_animation_play_state; value = v1; important = i1; _ },
+      Declaration
+        { property = Animation_play_state; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | _ -> false
 
@@ -3668,63 +3696,66 @@ let vendor_alias_redundant_animation vendor twin =
    unprefixed). *)
 let vendor_alias_redundant_transition vendor twin =
   match (vendor, twin) with
-  | ( Declaration { property = Webkit_transition; value = v1; important = i1 },
-      Declaration { property = Transition; value = v2; important = i2 } ) ->
+  | ( Declaration { property = Webkit_transition; value = v1; important = i1; _ },
+      Declaration { property = Transition; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Webkit_transition_delay; value = v1; important = i1 },
-      Declaration { property = Transition_delay; value = v2; important = i2 } )
-    ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration
-        { property = Webkit_transition_duration; value = v1; important = i1 },
-      Declaration { property = Transition_duration; value = v2; important = i2 }
+        { property = Webkit_transition_delay; value = v1; important = i1; _ },
+      Declaration { property = Transition_delay; value = v2; important = i2; _ }
     ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Webkit_transition_property; value = v1; important = i1 },
-      Declaration { property = Transition_property; value = v2; important = i2 }
-    ) ->
+        { property = Webkit_transition_duration; value = v1; important = i1; _ },
+      Declaration
+        { property = Transition_duration; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        { property = Webkit_transition_property; value = v1; important = i1; _ },
+      Declaration
+        { property = Transition_property; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
         {
           property = Webkit_transition_timing_function;
           value = v1;
           important = i1;
+          _;
         },
       Declaration
-        { property = Transition_timing_function; value = v2; important = i2 } )
-    ->
+        { property = Transition_timing_function; value = v2; important = i2; _ }
+    ) ->
       v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_transition; value = v1; important = i1 },
-      Declaration { property = Transition; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_transition_delay; value = v1; important = i1 },
-      Declaration { property = Transition_delay; value = v2; important = i2 } )
-    ->
+  | ( Declaration { property = Moz_transition; value = v1; important = i1; _ },
+      Declaration { property = Transition; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Moz_transition_duration; value = v1; important = i1 },
-      Declaration { property = Transition_duration; value = v2; important = i2 }
+        { property = Moz_transition_delay; value = v1; important = i1; _ },
+      Declaration { property = Transition_delay; value = v2; important = i2; _ }
     ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Moz_transition_property; value = v1; important = i1 },
-      Declaration { property = Transition_property; value = v2; important = i2 }
-    ) ->
+        { property = Moz_transition_duration; value = v1; important = i1; _ },
+      Declaration
+        { property = Transition_duration; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        { property = Moz_transition_property; value = v1; important = i1; _ },
+      Declaration
+        { property = Transition_property; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
         {
           property = Moz_transition_timing_function;
           value = v1;
           important = i1;
+          _;
         },
       Declaration
-        { property = Transition_timing_function; value = v2; important = i2 } )
-    ->
+        { property = Transition_timing_function; value = v2; important = i2; _ }
+    ) ->
       v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = O_transition; value = v1; important = i1 },
-      Declaration { property = Transition; value = v2; important = i2 } ) ->
+  | ( Declaration { property = O_transition; value = v1; important = i1; _ },
+      Declaration { property = Transition; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | _ -> false
 
@@ -3732,84 +3763,92 @@ let vendor_alias_redundant_transition vendor twin =
 let vendor_alias_redundant_flex vendor twin =
   match (vendor, twin) with
   | ( Declaration
-        { property = Webkit_flex_direction; value = v1; important = i1 },
-      Declaration { property = Flex_direction; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_flex_wrap; value = v1; important = i1 },
-      Declaration { property = Flex_wrap; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_flex_flow; value = v1; important = i1 },
-      Declaration { property = Flex_flow; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration
-        { property = Webkit_justify_content; value = v1; important = i1 },
-      Declaration { property = Justify_content; value = v2; important = i2 } )
+        { property = Webkit_flex_direction; value = v1; important = i1; _ },
+      Declaration { property = Flex_direction; value = v2; important = i2; _ } )
     ->
       v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_align_items; value = v1; important = i1 },
-      Declaration { property = Align_items; value = v2; important = i2 } ) ->
+  | ( Declaration { property = Webkit_flex_wrap; value = v1; important = i1; _ },
+      Declaration { property = Flex_wrap; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_align_content; value = v1; important = i1 },
-      Declaration { property = Align_content; value = v2; important = i2 } ) ->
+  | ( Declaration { property = Webkit_flex_flow; value = v1; important = i1; _ },
+      Declaration { property = Flex_flow; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_align_self; value = v1; important = i1 },
-      Declaration { property = Align_self; value = v2; important = i2 } ) ->
+  | ( Declaration
+        { property = Webkit_justify_content; value = v1; important = i1; _ },
+      Declaration { property = Justify_content; value = v2; important = i2; _ }
+    ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        { property = Webkit_align_items; value = v1; important = i1; _ },
+      Declaration { property = Align_items; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        { property = Webkit_align_content; value = v1; important = i1; _ },
+      Declaration { property = Align_content; value = v2; important = i2; _ } )
+    ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_align_self; value = v1; important = i1; _ },
+      Declaration { property = Align_self; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | _ -> false
 
 (* Border-radius / box-shadow / background-size / filter vendor-alias pairs. *)
 let vendor_alias_redundant_visual vendor twin =
   match (vendor, twin) with
-  | ( Declaration { property = Webkit_border_radius; value = v1; important = i1 },
-      Declaration { property = Border_radius; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_border_radius; value = v1; important = i1 },
-      Declaration { property = Border_radius; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_box_shadow; value = v1; important = i1 },
-      Declaration { property = Box_shadow; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_box_shadow; value = v1; important = i1 },
-      Declaration { property = Box_shadow; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Webkit_background_size; value = v1; important = i1 },
-      Declaration { property = Background_size; value = v2; important = i2 } )
+        { property = Webkit_border_radius; value = v1; important = i1; _ },
+      Declaration { property = Border_radius; value = v2; important = i2; _ } )
     ->
       v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_filter; value = v1; important = i1 },
-      Declaration { property = Filter; value = v2; important = i2 } ) ->
+  | ( Declaration { property = Moz_border_radius; value = v1; important = i1; _ },
+      Declaration { property = Border_radius; value = v2; important = i2; _ } )
+    ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_box_shadow; value = v1; important = i1; _ },
+      Declaration { property = Box_shadow; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Moz_box_shadow; value = v1; important = i1; _ },
+      Declaration { property = Box_shadow; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Webkit_backdrop_filter; value = v1; important = i1 },
-      Declaration { property = Backdrop_filter; value = v2; important = i2 } )
-    ->
+        { property = Webkit_background_size; value = v1; important = i1; _ },
+      Declaration { property = Background_size; value = v2; important = i2; _ }
+    ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_filter; value = v1; important = i1; _ },
+      Declaration { property = Filter; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        { property = Webkit_backdrop_filter; value = v1; important = i1; _ },
+      Declaration { property = Backdrop_filter; value = v2; important = i2; _ }
+    ) ->
       v1 = v2 && Bool.equal i1 i2
   | _ -> false
 
 let vendor_alias_redundant vendor twin =
   match (vendor, twin) with
-  | ( Declaration { property = Webkit_transform; value = v1; important = i1 },
-      Declaration { property = Transform; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_user_select; value = v1; important = i1 },
-      Declaration { property = User_select; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_user_select; value = v1; important = i1 },
-      Declaration { property = User_select; value = v2; important = i2 } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Webkit_hyphens; value = v1; important = i1 },
-      Declaration { property = Hyphens; value = v2; important = i2 } ) ->
+  | ( Declaration { property = Webkit_transform; value = v1; important = i1; _ },
+      Declaration { property = Transform; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Webkit_text_size_adjust; value = v1; important = i1 },
-      Declaration { property = Text_size_adjust; value = v2; important = i2 } )
-    ->
+        { property = Webkit_user_select; value = v1; important = i1; _ },
+      Declaration { property = User_select; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Moz_user_select; value = v1; important = i1; _ },
+      Declaration { property = User_select; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_hyphens; value = v1; important = i1; _ },
+      Declaration { property = Hyphens; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
-        { property = Webkit_print_color_adjust; value = v1; important = i1 },
-      Declaration { property = Print_color_adjust; value = v2; important = i2 }
+        { property = Webkit_text_size_adjust; value = v1; important = i1; _ },
+      Declaration { property = Text_size_adjust; value = v2; important = i2; _ }
     ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        { property = Webkit_print_color_adjust; value = v1; important = i1; _ },
+      Declaration
+        { property = Print_color_adjust; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | _ ->
       vendor_alias_redundant_animation vendor twin
@@ -3847,9 +3886,9 @@ let strip_vendor_prefix name =
 let text_vendor_alias_redundant vendor twin =
   match (vendor, twin) with
   | ( Declaration
-        { property = Unknown_property vname; value = vv; important = vi },
+        { property = Unknown_property vname; value = vv; important = vi; _ },
       Declaration
-        { property = Unknown_property tname; value = tv; important = ti } )
+        { property = Unknown_property tname; value = tv; important = ti; _ } )
     when Bool.equal vi ti -> (
       match strip_vendor_prefix vname with
       | Some modern -> String.equal tname modern && vv = tv
@@ -3861,11 +3900,11 @@ let text_vendor_alias_redundant vendor twin =
    need are target-dependent and only drop under the opt-in targets axis. *)
 let vendor_alias_redundant_targeted vendor twin =
   match (vendor, twin) with
-  | ( Declaration { property = Webkit_box_sizing; value = v1; important = i1 },
-      Declaration { property = Box_sizing; value = v2; important = i2 } ) ->
+  | ( Declaration { property = Webkit_box_sizing; value = v1; important = i1; _ },
+      Declaration { property = Box_sizing; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_box_sizing; value = v1; important = i1 },
-      Declaration { property = Box_sizing; value = v2; important = i2 } ) ->
+  | ( Declaration { property = Moz_box_sizing; value = v1; important = i1; _ },
+      Declaration { property = Box_sizing; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | _ -> false
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3970,4 +3970,4 @@ let read_import_rule (r : Cursor.t) : import_rule =
 let rule_hash (r : rule) =
   List.fold_left
     (fun acc d -> (acc * 31) + Declaration.hash d)
-    (Hashtbl.hash r.selector) r.declarations
+    (Selector.hash r.selector) r.declarations

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -313,3 +313,6 @@ type t = stylesheet
 (** {1 Rendering} *)
 
 type mode = Variables | Inline  (** Rendering mode for CSS output *)
+
+let equal_cascade_origin (a : cascade_origin) b = a = b
+let equal (a : stylesheet) b = a = b

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -42,6 +42,10 @@ type kind =
 
 type t = { kind : kind; loc : Loc.t }
 
+let equal_hash_flag (a : hash_flag) b = a = b
+let equal_number_flag (a : number_flag) b = a = b
+let equal_bracket (a : bracket) b = a = b
+let equal_kind (a : kind) b = a = b
 let v ~kind ~loc = { kind; loc }
 let synthetic kind = { kind; loc = Loc.dummy }
 

--- a/lib/token.mli
+++ b/lib/token.mli
@@ -73,6 +73,18 @@ type kind =
 type t = { kind : kind; loc : Loc.t }
 (** A located token: the section 4.2 payload plus the source range it covers. *)
 
+val equal_hash_flag : hash_flag -> hash_flag -> bool
+(** [equal_hash_flag a b] tests hash token flags for equality. *)
+
+val equal_number_flag : number_flag -> number_flag -> bool
+(** [equal_number_flag a b] tests number token flags for equality. *)
+
+val equal_bracket : bracket -> bracket -> bool
+(** [equal_bracket a b] tests bracket kinds for equality. *)
+
+val equal_kind : kind -> kind -> bool
+(** [equal_kind a b] tests token payloads for structural equality. *)
+
 val v : kind:kind -> loc:Loc.t -> t
 (** [v ~kind ~loc] is a token with the given payload and location. *)
 

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -583,3 +583,8 @@ type number =
   | Sin of angle
 
 type transition_behavior = Normal | Allow_discrete
+
+let equal_length (a : length) b = a = b
+let equal_length_percentage (a : length_percentage) b = a = b
+let equal_number_percentage (a : number_percentage) b = a = b
+let equal_color (a : color) b = a = b

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -644,7 +644,7 @@ let declaration_value_source decl =
 let scope_selector_matches (document : Css.Context.document) = function
   | None -> true
   | Some selector ->
-      document.scope = Some selector
+      Option.equal Css.Selector.equal document.scope (Some selector)
       || Css.Context.matches_selector document selector
 
 let scope_boundary_allows document start boundary =
@@ -839,7 +839,8 @@ let same_layer_candidate (c : Css.Stylesheet.cascade_candidate)
 
 let same_origin_candidate (c : Css.Stylesheet.cascade_candidate)
     (l : Css.Stylesheet.cascade_origin_candidate) =
-  l.origin = c.origin && l.important = c.important
+  Css.Stylesheet.equal_cascade_origin l.origin c.origin
+  && l.important = c.important
   && l.source_order = c.source_order
 
 let lower_layer_candidates ~layer_order

--- a/test/test_factor_safe.ml
+++ b/test/test_factor_safe.ml
@@ -14,7 +14,11 @@ let rule css =
   | rs -> Alcotest.failf "expected one rule, got %d" (List.length rs)
 
 let decl css = Declaration.of_string css
-let same_decl a b = a == b || (Declaration.hash a = Declaration.hash b && a = b)
+
+let same_decl a b =
+  a == b
+  || Declaration.hash a = Declaration.hash b
+     && Declaration.equal_declaration a b
 
 let safe =
   Factor_safe.v ~same_minified_declaration:same_decl

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -78,11 +78,11 @@ let expect_rejected_cases label parse render inputs =
 let test_spec_src_parser_vectors () =
   let check_src name input expected =
     let parsed = src_of_string input in
-    Alcotest.(check bool) name true (parsed = expected);
+    Alcotest.(check bool) name true (equal_src parsed expected);
     Alcotest.(check bool)
       (name ^ " serialization idempotent")
       true
-      (src_of_string (string_of_src parsed) = parsed)
+      (equal_src (src_of_string (string_of_src parsed)) parsed)
   in
   check_src "url format tech"
     "url(\"color.woff2\") format(\"woff2\") tech(color-COLRv1)"

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -9,7 +9,11 @@ let rules css =
       |> Array.of_list
   | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
 
-let same a b = a == b || (Declaration.hash a = Declaration.hash b && a = b)
+let same a b =
+  a == b
+  || Declaration.hash a = Declaration.hash b
+     && Declaration.equal_declaration a b
+
 let decl css = Declaration.of_string css
 
 let test_rows_are_sorted_unique () =

--- a/test/test_lexer.ml
+++ b/test/test_lexer.ml
@@ -28,7 +28,7 @@ let check_first_hash input expected_value expected_flag =
       Alcotest.(check bool)
         (Fmt.str "hash flag for %S" input)
         true
-        (hash_flag = expected_flag)
+        (Token.equal_hash_flag hash_flag expected_flag)
   | kinds ->
       Alcotest.failf "tokenize %S: expected one hash token, got %s" input
         (pp_tokens kinds)
@@ -42,7 +42,7 @@ let check_first_number_flag input expected_repr expected_flag =
       Alcotest.(check bool)
         (Fmt.str "number flag for %S" input)
         true
-        (number_flag = expected_flag)
+        (Token.equal_number_flag number_flag expected_flag)
   | kinds ->
       Alcotest.failf "tokenize %S: expected one number token, got %s" input
         (pp_tokens kinds)

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -126,7 +126,8 @@ let test_deduplicate_declarations () =
 let test_deduplicate_declarations_physical_identity () =
   let no_op = [ custom_property "--a" "red"; custom_property "--b" "blue" ] in
   let result = deduplicate_declarations no_op in
-  check bool "no-op deduplicate is structurally unchanged" true (result = no_op);
+  check bool "no-op deduplicate is structurally unchanged" true
+    (List.equal Declaration.equal_declaration result no_op);
   check bool "no-op deduplicate preserves physical identity" true
     (result == no_op);
   let overriding =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -162,11 +162,13 @@ let check_container_shorthand ?expected input =
   let expected_value = read_container_shorthand (Cursor.of_string expected) in
   Alcotest.(check bool)
     (Fmt.str "container structural expected %s" input)
-    true (value = expected_value);
+    true
+    (equal_container_shorthand value expected_value);
   let reparsed = read_container_shorthand (Cursor.of_string serialized) in
   Alcotest.(check bool)
     (Fmt.str "container structural roundtrip %s" input)
-    true (value = reparsed)
+    true
+    (equal_container_shorthand value reparsed)
 
 let check_contain = check_value_cursor "contain" read_contain pp_contain
 let check_isolation = check_value_cursor "isolation" read_isolation pp_isolation

--- a/test/test_rule_candidate.ml
+++ b/test/test_rule_candidate.ml
@@ -30,7 +30,7 @@ let large_normal_css prefix =
 let has_candidate ~kind ~produce candidates =
   List.exists
     (fun candidate ->
-      candidate.Rule_rewrite.kind = kind
+      Rule_rewrite.equal_kind candidate.Rule_rewrite.kind kind
       && String.equal produce (render candidate.produce))
     candidates
 

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -44,7 +44,8 @@ let check_minified_to expected input =
   let expected_ast = of_string expected in
   Alcotest.(check bool)
     ("minified selector reparses to expected AST: " ^ input)
-    true (reparsed = expected_ast);
+    true
+    (equal reparsed expected_ast);
   check_spec_tuple
     ("specificity preserved: " ^ input)
     (specificity original) (specificity reparsed)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -155,7 +155,7 @@ let test_rule_creation () =
   (* Just check we can get selector back *)
   Alcotest.(check bool)
     "selector exists" true
-    (selector = Css.Selector.class_ "red");
+    (Css.Selector.equal selector (Css.Selector.class_ "red"));
   Alcotest.(check int)
     "rule declarations count" 1
     (List.length (declarations rule))

--- a/test/test_summary.ml
+++ b/test/test_summary.ml
@@ -24,7 +24,10 @@ let selector_size selector =
 let summary rule =
   Summary.v ~rule_size:(fun _ -> 123) ~decl_size ~selector_size rule
 
-let same a b = a == b || (Declaration.hash a = Declaration.hash b && a = b)
+let same a b =
+  a == b
+  || Declaration.hash a = Declaration.hash b
+     && Declaration.equal_declaration a b
 
 let custom_rule ?(selector = ".a") decls =
   rule (selector ^ "{" ^ String.concat ";" decls ^ "}")


### PR DESCRIPTION
Make merlint a required lint check.

- Use type-owned equality and hash helpers.
- Remove the blanket record-pattern warning suppression.