### PR TITLE
Canonicalize fully transparent missing-axis OKLab

### DIFF
--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7292,6 +7292,9 @@ let rec normalize_color ?(lossless = false) ?(exact_srgb = false)
       (normalize_static_modern_color ~in_feature_query ~exact_srgb ~lossless c)
   in
   match c with
+  | Oklab { l = Some l; a = None; b = None; alpha }
+    when pct_is_zero l && alpha_is_zero alpha ->
+      Transparent
   | Oklch { l = Some _; c = Some _; _ } -> static_fold ()
   | Oklab { l = Some _; a = Some _; b = Some _; _ } -> static_fold ()
   | Lch { l = Some _; c = Some _; _ } -> static_fold ()

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -264,6 +264,24 @@ let canonical_custom_color_function_alpha () =
     (Cascade_diff.Css_compare.equal ~mode:`Canonical ".a { --c: transparent }"
        ".a { --c: #0000 }")
 
+let canonical_fully_transparent_missing_oklab () =
+  let equivalent property =
+    Cascade_diff.Css_compare.equal ~mode:`Canonical
+      (Fmt.str ".a { %s: oklab(0%% none none / 0) }" property)
+      (Fmt.str ".a { %s: #0000 }" property)
+  in
+  Alcotest.(check bool)
+    "fully transparent missing-component oklab equals #0000 in a colour property"
+    true (equivalent "background-color");
+  Alcotest.(check bool)
+    "fully transparent missing-component oklab equals #0000 in a custom property"
+    true (equivalent "--tw-gradient-via");
+  Alcotest.(check bool)
+    "non-transparent missing-component oklab stays distinct from #0000" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ".a { background-color: oklab(0% none none / .5) }"
+       ".a { background-color: #0000 }")
+
 let canonical_custom_font_family_quotes () =
   (* A quoted multi-word font name and the unquoted ident sequence substitute
      identically into font-family, so canonical comparison equates them inside a
@@ -1209,6 +1227,8 @@ let suite =
         canonical_custom_color_mix_tokens;
       Alcotest.test_case "canonical custom color-function alpha" `Quick
         canonical_custom_color_function_alpha;
+      Alcotest.test_case "canonical fully transparent missing oklab" `Quick
+        canonical_fully_transparent_missing_oklab;
       Alcotest.test_case "canonical custom font-family quotes" `Quick
         canonical_custom_font_family_quotes;
       Alcotest.test_case "canonical custom calc percentage" `Quick

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -271,11 +271,15 @@ let canonical_fully_transparent_missing_oklab () =
       (Fmt.str ".a { %s: #0000 }" property)
   in
   Alcotest.(check bool)
-    "fully transparent missing-component oklab equals #0000 in a colour property"
-    true (equivalent "background-color");
+    "fully transparent missing-component oklab equals #0000 in a colour \
+     property"
+    true
+    (equivalent "background-color");
   Alcotest.(check bool)
-    "fully transparent missing-component oklab equals #0000 in a custom property"
-    true (equivalent "--tw-gradient-via");
+    "fully transparent missing-component oklab equals #0000 in a custom \
+     property"
+    true
+    (equivalent "--tw-gradient-via");
   Alcotest.(check bool)
     "non-transparent missing-component oklab stays distinct from #0000" false
     (Cascade_diff.Css_compare.equal ~mode:`Canonical


### PR DESCRIPTION
Treat `oklab(0% none none / 0)` as transparent black during canonical comparison.

The normalization is intentionally limited to zero lightness, missing axes, and zero alpha; non-transparent forms remain distinct.