### PR TITLE
Canonicalize relative-colour origins

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1204,8 +1204,10 @@ type color = Values.color =
   | Hsl of { h : hue; s : percentage; l : percentage; a : alpha }
   | Hwb of { h : hue; w : percentage; b : percentage; a : alpha }
   | Color of { space : color_space; components : component list; alpha : alpha }
-  | Relative_rgb of string
-  | Relative_color of string * string
+  | Relative_rgb of color * string
+      (** [rgb(from <origin> <channels> [/ <alpha>]?)] with a parsed origin and
+          an opaque channel-expression tail. *)
+  | Relative_color of string * color * string
       (** [<fn>(from <origin> <c1> <c2> <c3> [/ <alpha>]?)] for relative color
           functions other than [rgb()]. *)
   | Contrast_color of color

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -2159,9 +2159,8 @@ and pp_generic_length_calc ~always ctx cv =
 let pp_color_name : color_name Pp.t =
  fun ctx name -> Pp.string ctx (fst (color_name_hex name))
 
-(* The body of a [Relative_rgb] is stored as a verbatim string of the form
-   ["from <origin> r g b/<alpha>"], because the channels and alpha are part of
-   the [<calc>]-derived expression. To match the typed-color path's alpha
+(* Relative-colour channel and alpha expressions remain an opaque tail because
+   they are [<calc>]-derived. To match the typed-color path's alpha
    canonicalisation under [~minify:true], rewrite a trailing ["/<n>%"] alpha
    suffix to its decimal equivalent. *)
 let minify_relative_color_alpha body =
@@ -4285,15 +4284,6 @@ let rec pp_rgb_as_color : rgb Pp.t =
   | Channels { r; g; b } -> pp_rgb_func ctx (r, g, b, None)
   | Var v -> pp_var pp_rgb_as_color ctx v
 
-let pp_relative_color_call ctx name body =
-  let body =
-    if Pp.minified ctx then
-      body |> minify_relative_color_alpha |> minify_relative_color_numbers
-      |> minify_relative_color_spaces
-    else body
-  in
-  Pp.call name (fun ctx body -> Pp.string ctx body) ctx body
-
 let canonical_color_name = function
   | Grey -> Gray
   | Dark_grey -> Dark_gray
@@ -4381,6 +4371,22 @@ and pp_color_mix ctx in_space hue color1 percent1 color2 percent2 =
     ctx
     (in_space, hue, color1, percent1, color2, percent2)
 
+and pp_typed_relative_color_call ctx name origin tail =
+  let tail =
+    if Pp.minified ctx then
+      tail |> minify_relative_color_alpha |> minify_relative_color_numbers
+      |> minify_relative_color_spaces
+    else tail
+  in
+  Pp.call name
+    (fun ctx (origin, tail) ->
+      Pp.string ctx "from";
+      Pp.space ctx ();
+      pp_color ctx origin;
+      Pp.space ctx ();
+      Pp.string ctx tail)
+    ctx (origin, tail)
+
 and pp_rgb_color ctx = function
   | Channels { r; g; b } -> pp_rgb_func ctx (r, g, b, None)
   (* keep the [rgb()] wrapper: a bare [var(--x)] assumes [--x] is a whole
@@ -4455,8 +4461,10 @@ and pp_color_default : color Pp.t =
   | Hsl { h; s; l; a } -> pp_hsl_color ctx h s l a
   | Hwb { h; w; b; a } -> pp_hwb_color ctx h w b a
   | Color { space; components; alpha } -> pp_color' ctx space components alpha
-  | Relative_rgb body -> pp_relative_color_call ctx "rgb" body
-  | Relative_color (name, body) -> pp_relative_color_call ctx name body
+  | Relative_rgb (origin, tail) ->
+      pp_typed_relative_color_call ctx "rgb" origin tail
+  | Relative_color (name, origin, tail) ->
+      pp_typed_relative_color_call ctx name origin tail
   | Contrast_color color -> Pp.call "contrast-color" pp_color ctx color
   | Light_dark (light, dark) -> pp_light_dark_color ctx light dark
   | Attribute (name, fallback) -> pp_color_attr ctx name fallback
@@ -6455,8 +6463,7 @@ and read_relative_rgb t : color =
   if tail = "" then Cursor.err_expected t "relative rgb channels";
   if relative_color_channel_count tail_components <> 3 then
     Cursor.err_expected t "relative rgb channels";
-  let origin = Pp.to_string ~minify:true pp_color origin in
-  Relative_rgb ("from " ^ origin ^ " " ^ tail)
+  Relative_rgb (origin, tail)
 
 and read_contrast_color t : color =
   Cursor.ws t;
@@ -6499,8 +6506,9 @@ and read_color_attr t : color =
 
 and read_relative_color name t : color =
   (* CSS Color 5 sec. 2: any colour function may take [from <origin> <c1> <c2>
-     <c3> [/ <alpha>]?]. We capture the body verbatim so the printer re-emits
-     the function name + parenthesised tail unchanged. *)
+     <c3> [/ <alpha>]?]. The origin has a fixed <color> type, so retain the
+     parsed node while keeping the not-yet-modelled channel expression
+     opaque. *)
   Cursor.ws t;
   Cursor.expect_string "from" t;
   Cursor.ws t;
@@ -6518,9 +6526,7 @@ and read_relative_color name t : color =
       if tail = "" then Cursor.err_expected t (name ^ " channels");
       match fold_relative_color_pass_through name origin tail with
       | Some color -> color
-      | None ->
-          let origin = Pp.to_string ~minify:true pp_color origin in
-          Relative_color (name, "from " ^ origin ^ " " ^ tail))
+      | None -> Relative_color (name, origin, tail))
 
 (* CSS Color 5 sec. 4.1: [color(from <origin> srgb r g b [/ <alpha>]?)] is a
    self-substitution of the origin's sRGB channels. Static folding requires the
@@ -6606,6 +6612,8 @@ let rec color_has_specified_hue = function
   | Mix { hue = Specified; _ } -> true
   | Mix { color1; color2; _ } ->
       color_has_specified_hue color1 || color_has_specified_hue color2
+  | Relative_rgb (origin, _) -> color_has_specified_hue origin
+  | Relative_color (_, origin, _) -> color_has_specified_hue origin
   | Contrast_color color -> color_has_specified_hue color
   | Light_dark (a, b) -> color_has_specified_hue a || color_has_specified_hue b
   | Attribute (_, Some color) -> color_has_specified_hue color
@@ -6620,6 +6628,8 @@ let color_exists p =
     ||
     match c with
     | Mix { color1; color2; _ } -> go color1 || go color2
+    | Relative_rgb (origin, _) -> go origin
+    | Relative_color (_, origin, _) -> go origin
     | Light_dark (a, b) -> go a || go b
     | Contrast_color c -> go c
     | Attribute (_, Some c) -> go c
@@ -7323,28 +7333,11 @@ let rec normalize_color ?(lossless = false) ?(exact_srgb = false)
           normalize_color ~lossless ~in_feature_query d )
   | Contrast_color inner ->
       Contrast_color (normalize_color ~lossless ~in_feature_query inner)
-  | Relative_color (name, body) -> (
-      (* The [from] production fixes the origin's type to <color>. Re-read that
-         one component so equivalent spellings canonicalise even though the
-         channel tail remains verbatim until Cascade models relative channels
-         structurally. *)
-      let t = Cursor.of_string body in
-      match
-        try
-          Cursor.ws t;
-          Cursor.expect_string "from" t;
-          Cursor.ws t;
-          let origin = read_color t in
-          Cursor.ws t;
-          let tail = Cursor.consume_remaining_as_string ~trim:true t in
-          Some (origin, tail)
-        with Cursor.Parse_error _ -> None
-      with
-      | Some (origin, tail) when tail <> "" ->
-          let origin = normalize_color ~lossless ~in_feature_query origin in
-          let origin = Pp.to_string ~minify:true pp_color origin in
-          Relative_color (name, "from " ^ origin ^ " " ^ tail)
-      | _ -> c)
+  | Relative_rgb (origin, tail) ->
+      Relative_rgb (normalize_color ~lossless ~in_feature_query origin, tail)
+  | Relative_color (name, origin, tail) ->
+      Relative_color
+        (name, normalize_color ~lossless ~in_feature_query origin, tail)
   | Var v ->
       (* A typed [var()] fallback / default is a colour, so canonicalise it the
          same way it would be if it stood alone. The opaque [Syntax_fallback] /

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7318,6 +7318,28 @@ let rec normalize_color ?(lossless = false) ?(exact_srgb = false)
           normalize_color ~lossless ~in_feature_query d )
   | Contrast_color inner ->
       Contrast_color (normalize_color ~lossless ~in_feature_query inner)
+  | Relative_color (name, body) -> (
+      (* The [from] production fixes the origin's type to <color>. Re-read that
+         one component so equivalent spellings canonicalise even though the
+         channel tail remains verbatim until Cascade models relative channels
+         structurally. *)
+      let t = Cursor.of_string body in
+      match
+        try
+          Cursor.ws t;
+          Cursor.expect_string "from" t;
+          Cursor.ws t;
+          let origin = read_color t in
+          Cursor.ws t;
+          let tail = Cursor.consume_remaining_as_string ~trim:true t in
+          Some (origin, tail)
+        with Cursor.Parse_error _ -> None
+      with
+      | Some (origin, tail) when tail <> "" ->
+          let origin = normalize_color ~lossless ~in_feature_query origin in
+          let origin = Pp.to_string ~minify:true pp_color origin in
+          Relative_color (name, "from " ^ origin ^ " " ^ tail)
+      | _ -> c)
   | Var v ->
       (* A typed [var()] fallback / default is a colour, so canonicalise it the
          same way it would be if it stood alone. The opaque [Syntax_fallback] /

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7160,15 +7160,15 @@ let canonical_color_lightness ~lossless ~pct_scale ~axis_max_decimals
   in
   match l with
   | Some (Pct f) ->
-      (* On an equal-length spelling, keep the percentage. A trailing [%] can
-         also terminate the token before an unsigned following axis, so
-         [oklab(25%20 50)] is one byte shorter than [oklab(.25 20 50)]. Choosing
-         the number on a tie made relative-color origin canonicalisation regress
-         the minifier's shortest-output invariant. *)
+      (* Preserve the node's representation on an equal-length spelling. A
+         trailing [%] can terminate the token before an unsigned following axis,
+         so an authored [oklab(25% 20 50)] stays [oklab(25%20 50)]. *)
       if num_len (f *. pct_scale) < pct_len f then Some (num (f *. pct_scale))
       else Some (pct f)
   | Some (Num f) ->
-      if pct_len (f /. pct_scale) <= num_len f then Some (pct (f /. pct_scale))
+      (* A computed lightness is numeric. Keeping [Num] on a tie avoids turning
+         a colour-mix result such as [.54] into [54%]. *)
+      if pct_len (f /. pct_scale) < num_len f then Some (pct (f /. pct_scale))
       else Some (num f)
   | other -> other
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7160,10 +7160,15 @@ let canonical_color_lightness ~lossless ~pct_scale ~axis_max_decimals
   in
   match l with
   | Some (Pct f) ->
-      if num_len (f *. pct_scale) <= pct_len f then Some (num (f *. pct_scale))
+      (* On an equal-length spelling, keep the percentage. A trailing [%] can
+         also terminate the token before an unsigned following axis, so
+         [oklab(25%20 50)] is one byte shorter than [oklab(.25 20 50)]. Choosing
+         the number on a tie made relative-color origin canonicalisation regress
+         the minifier's shortest-output invariant. *)
+      if num_len (f *. pct_scale) < pct_len f then Some (num (f *. pct_scale))
       else Some (pct f)
   | Some (Num f) ->
-      if pct_len (f /. pct_scale) < num_len f then Some (pct (f /. pct_scale))
+      if pct_len (f /. pct_scale) <= num_len f then Some (pct (f /. pct_scale))
       else Some (num f)
   | other -> other
 

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -509,12 +509,15 @@ type color =
   | Hsl of { h : hue; s : percentage; l : percentage; a : alpha }
   | Hwb of { h : hue; w : percentage; b : percentage; a : alpha }
   | Color of { space : color_space; components : component list; alpha : alpha }
-  | Relative_rgb of string
-  | Relative_color of string * string
+  | Relative_rgb of color * string
+      (** [rgb(from <origin> <channels> [/ <alpha>]?)] with a parsed origin and
+          an opaque channel-expression tail. *)
+  | Relative_color of string * color * string
       (** [<fn>(from <origin> <c1> <c2> <c3> [/ <alpha>]?)] for any color
           function other than [rgb()] (CSS Color 5 sec. 2). The first string is
           the function name ([lab], [lch], [oklab], [oklch], [hsl], [hwb],
-          [color]), the second is the parenthesised body verbatim. *)
+          [color]), the [color] is the parsed origin, and the final string is
+          the channel-expression tail. *)
   | Contrast_color of color
   | Light_dark of color * color
   | Attribute of string * color option

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -476,7 +476,8 @@ let rec vars_of_color (value : Values.color) : any_var list =
       @ vars_of_alpha a
   | Color { components; alpha; _ } ->
       List.concat_map vars_of_component components @ vars_of_alpha alpha
-  | Relative_rgb _ -> []
+  | Relative_rgb (origin, _) -> vars_of_color origin
+  | Relative_color (_, origin, _) -> vars_of_color origin
   | Contrast_color color -> vars_of_color color
   | Light_dark (light, dark) -> vars_of_color light @ vars_of_color dark
   | Attribute (_, fallback) -> Option.fold ~none:[] ~some:vars_of_color fallback

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -264,6 +264,21 @@ let canonical_custom_color_function_alpha () =
     (Cascade_diff.Css_compare.equal ~mode:`Canonical ".a { --c: transparent }"
        ".a { --c: #0000 }")
 
+let canonical_relative_color_origin () =
+  (* A relative colour function fixes its origin's type to <color>, so
+     equivalent spellings of that origin must compare equal, including when the
+     whole function sits inside an otherwise opaque custom-property value. *)
+  Alcotest.(check bool)
+    "named and hex relative-colour origins compare equal" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ".a { color: oklab(from red l a b / var(--x)) }"
+       ".a { color: oklab(from #f00 l a b / var(--x)) }");
+  Alcotest.(check bool)
+    "relative-colour origins compare equal inside a custom property" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ".a { --s: 0 0 8px oklab(from red l a b / var(--x)) }"
+       ".a { --s: 0 0 8px oklab(from #f00 l a b / var(--x)) }")
+
 let canonical_custom_font_family_quotes () =
   (* A quoted multi-word font name and the unquoted ident sequence substitute
      identically into font-family, so canonical comparison equates them inside a
@@ -1209,6 +1224,8 @@ let suite =
         canonical_custom_color_mix_tokens;
       Alcotest.test_case "canonical custom color-function alpha" `Quick
         canonical_custom_color_function_alpha;
+      Alcotest.test_case "canonical relative-colour origin" `Quick
+        canonical_relative_color_origin;
       Alcotest.test_case "canonical custom font-family quotes" `Quick
         canonical_custom_font_family_quotes;
       Alcotest.test_case "canonical custom calc percentage" `Quick

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -268,11 +268,27 @@ let canonical_relative_color_origin () =
   (* A relative colour function fixes its origin's type to <color>, so
      equivalent spellings of that origin must compare equal, including when the
      whole function sits inside an otherwise opaque custom-property value. *)
+  let parsed =
+    Cascade.Css.Values.read_color
+      (Cascade.Cursor.of_string "oklab(from red l a b / var(--x))")
+  in
+  Alcotest.(check bool)
+    "relative-colour parser retains a typed origin" true
+    (match parsed with
+    | Cascade.Css.Relative_color
+        ("oklab", Cascade.Css.Named Cascade.Css.Red, "l a b/var(--x)") ->
+        true
+    | _ -> false);
   Alcotest.(check bool)
     "named and hex relative-colour origins compare equal" true
     (Cascade_diff.Css_compare.equal ~mode:`Canonical
        ".a { color: oklab(from red l a b / var(--x)) }"
        ".a { color: oklab(from #f00 l a b / var(--x)) }");
+  Alcotest.(check bool)
+    "named and hex relative-rgb origins compare equal" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ".a { color: rgb(from red r g b / var(--x)) }"
+       ".a { color: rgb(from #f00 r g b / var(--x)) }");
   Alcotest.(check bool)
     "relative-colour origins compare equal inside a custom property" true
     (Cascade_diff.Css_compare.equal ~mode:`Canonical

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2390,6 +2390,10 @@ let target_minify_enforce_spec_split () =
     "a { color: color-mix(in oklab, var(--a), var(--b)) }"
     ~default:"a{color:color-mix(in oklab,var(--a),var(--b))}"
     ~spec:"a{color:color-mix(in oklab,var(--a),var(--b))}";
+  check_modes "computed oklch lightness keeps its numeric form"
+    "a { color: color-mix(in oklch, red 50%, blue 50%) }"
+    ~default:"a{color:oklch(.54 .285 326.643)}"
+    ~spec:"a{color:oklch(.54 .285 326.643)}";
   (* oklch/oklab chroma takes <number> | <percentage>, exactly interchangeable
      (CSS Color 4: 100% = 0.4 on this axis). Default minify picks the shorter
      spelling per axis - .304 becomes 76%, but .1 stays because 25% is longer.

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1161,8 +1161,7 @@ let test_system_color () =
 let spec_values_color_current () =
   check_color ~expected:"oklch(50%.2 none)" ~optimized:"oklch(.5 .2 none)"
     "oklch(50% 0.2 none)";
-  check_color ~optimized:"rgb(from rebeccapurple r g b)"
-    "rgb(from rebeccapurple r g b)";
+  check_color ~optimized:"rgb(from #639 r g b)" "rgb(from rebeccapurple r g b)";
   check_color ~expected:"contrast-color(white)"
     ~optimized:"contrast-color(#fff)" "contrast-color(white)";
   check_color ~expected:"light-dark(black,white)"


### PR DESCRIPTION
Retain relative-colour origins as typed color nodes at parse time while leaving channel-expression tails opaque. Normalization now walks the origin AST instead of reparsing serialized function bodies.

This makes canonical comparison equate origins such as red and #f00 across rgb() and the other relative-colour functions, including values embedded in otherwise opaque custom properties. It removes the equivalent residual produced by TW shadow opacity modifiers in samoht/tw#323.