### PR TITLE
Canonicalize colours in complete custom shadows

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -1914,6 +1914,21 @@ let drop_function_arguments wrapped =
   Component.Func
     { wrapped with node = { wrapped.Component.node with arguments = [] } }
 
+(* A complete shadow token stream is self-typing: its length sequence and
+   optional final <color> are parsed together, so a bare colour keyword cannot
+   be mistaken for a custom-ident at another substitution site. Canonicalise
+   that typed colour while keeping unrelated opaque custom values untouched. *)
+let canonicalize_custom_shadow_components ~lossless components =
+  let t = Cursor.of_string (Parser.to_string_custom components) in
+  match try Some (read_shadow t) with Cursor.Parse_error _ -> None with
+  | Some shadow when Cursor.is_done t -> (
+      let shadow = normalize_shadow ~lossless shadow in
+      let canonical = Pp.to_string ~minify:true pp_shadow shadow in
+      match read_custom_property_value (Cursor.of_string canonical) with
+      | Tokens components -> components
+      | Typed _ -> components)
+  | _ -> components
+
 let rec canonicalize_custom_colors_components ~lossless comps =
   let fold_color c ~fallback = fold_custom_color ~lossless c ~fallback in
   List.concat_map
@@ -2526,6 +2541,7 @@ let normalize_property_value : type a.
       | Custom_value ({ value = Tokens components; _ } as r) ->
           let components' =
             components
+            |> canonicalize_custom_shadow_components ~lossless
             |> canonicalize_custom_colors_components ~lossless
             |> canonicalize_math_whitespace_components
           in
@@ -2599,7 +2615,8 @@ let normalize_custom_property_value ?(lossless = false)
   | Tokens components ->
       Tokens
         (canonicalize_math_whitespace_components
-           (canonicalize_custom_colors_components ~lossless components))
+           (canonicalize_custom_colors_components ~lossless
+              (canonicalize_custom_shadow_components ~lossless components)))
   | Typed _ as other -> other
 
 let pp_property_value : type a. (a property * a) Pp.t =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -1914,15 +1914,39 @@ let drop_function_arguments wrapped =
   Component.Func
     { wrapped with node = { wrapped.Component.node with arguments = [] } }
 
+let rec normalize_shadow_colors ~lossless (shadow : shadow) =
+  let normalize_body (body : shadow_body) : shadow_body =
+    {
+      body with
+      color =
+        option_map_preserve
+          (Values.normalize_color ~lossless ~in_feature_query:false)
+          body.color;
+    }
+  in
+  match shadow with
+  | Shadow body -> preserve_if_equal shadow (Shadow (normalize_body body))
+  | Inset (Body body) ->
+      preserve_if_equal shadow (Inset (Body (normalize_body body)) : shadow)
+  | Inset (Toggle ({ body; _ } as toggle)) ->
+      preserve_if_equal shadow
+        (Inset (Toggle { toggle with body = normalize_body body }) : shadow)
+  | List shadows ->
+      preserve_if_equal shadow
+        (List (map_preserve (normalize_shadow_colors ~lossless) shadows))
+  | other -> other
+
 (* A complete shadow token stream is self-typing: its length sequence and
    optional final <color> are parsed together, so a bare colour keyword cannot
    be mistaken for a custom-ident at another substitution site. Canonicalise
-   that typed colour while keeping unrelated opaque custom values untouched. *)
+   only that typed colour while preserving the authored shadow shape; applying
+   the full shadow optimiser here would also drop explicit default lengths from
+   an otherwise opaque custom-property token stream. *)
 let canonicalize_custom_shadow_components ~lossless components =
   let t = Cursor.of_string (Parser.to_string_custom components) in
   match try Some (read_shadow t) with Cursor.Parse_error _ -> None with
   | Some shadow when Cursor.is_done t -> (
-      let shadow = normalize_shadow ~lossless shadow in
+      let shadow = normalize_shadow_colors ~lossless shadow in
       let canonical = Pp.to_string ~minify:true pp_shadow shadow in
       match read_custom_property_value (Cursor.of_string canonical) with
       | Tokens components -> components

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -392,7 +392,7 @@ let semantic_custom_var_fallback () =
     ".a { --tw-ring-shadow: 0 0 0 1px var(--tw-ring-color, #0000) }"
   in
   Alcotest.(check bool)
-    "custom property var fallback token streams stay opaque" false
+    "shadow colour var fallbacks compare after typed canonicalization" true
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
 
 let semantic_custom_nested_functions () =

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -264,6 +264,21 @@ let canonical_custom_color_function_alpha () =
     (Cascade_diff.Css_compare.equal ~mode:`Canonical ".a { --c: transparent }"
        ".a { --c: #0000 }")
 
+let canonical_custom_shadow_color () =
+  (* A complete shadow grammar fixes its final keyword's type to <color>, even
+     when the shadow is carried through an unregistered custom property. *)
+  Alcotest.(check bool)
+    "named and hex shadow colours compare equal in a custom property" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical
+       ":root { --drop-shadow-glow: 0 0 8px red }"
+       ":root { --drop-shadow-glow: 0 0 8px #f00 }");
+  (* An arbitrary identifier after the lengths is not a valid shadow colour and
+     must remain opaque. *)
+  Alcotest.(check bool)
+    "a non-colour custom identifier stays distinct" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical ".a { --x: 0 0 8px red }"
+       ".a { --x: 0 0 8px custom-ident }")
+
 let canonical_relative_color_origin () =
   (* A relative colour function fixes its origin's type to <color>, so
      equivalent spellings of that origin must compare equal, including when the
@@ -1262,6 +1277,8 @@ let suite =
         canonical_custom_color_mix_tokens;
       Alcotest.test_case "canonical custom color-function alpha" `Quick
         canonical_custom_color_function_alpha;
+      Alcotest.test_case "canonical custom shadow colour" `Quick
+        canonical_custom_shadow_color;
       Alcotest.test_case "canonical relative-colour origin" `Quick
         canonical_relative_color_origin;
       Alcotest.test_case "canonical fully transparent missing oklab" `Quick


### PR DESCRIPTION
Recognize a complete shadow grammar inside an otherwise opaque custom-property value, then canonicalize its typed colour slot. This equates 0 0 8px red with 0 0 8px #f00 and typed var() colour fallbacks while leaving non-colour custom identifiers untouched.

This removes the equivalent theme residual for TW drop-shadow-* utilities; TW output remains semantically driven rather than matching an optimizer spelling.