### PR TITLE
Preserve runtime var fallbacks while inlining

### DIFF
--- a/lib/context.ml
+++ b/lib/context.ml
@@ -861,7 +861,12 @@ module Var_residual = struct
       | Values.Empty2 | Values.None ->
           ops.of_var (simplify_var_record ~simplify ~visited var)
     and on_var ~visited (var : a Values.var) =
-      if List.mem var.name visited then
+      if var.runtime || List.mem var.name cascade.runtime_vars then
+        (* A runtime var remains a live browser-time reference, including its
+           fallback. Treating it like an ordinary unresolved variable would
+           select a typed [Fallback] here and erase the override point. *)
+        ops.of_var (simplify_var_record ~simplify ~visited var)
+      else if List.mem var.name visited then
         (* A var() forming a cycle is invalid at computed-value time; its own
            fallback does not rescue it (CSS Variables L1 sec 3). Leave it as an
            unresolved residual so an outer consumer's fallback can apply. *)
@@ -3404,6 +3409,9 @@ let simplify_float_side ~layer_order ?layer ctx (value : Properties.float_side)
 let simplify_lengths_value ~layer_order ?layer ctx length_ctx value =
   let simplify_one = Length.simplify ~layer_order ?layer ctx length_ctx in
   match value with
+  | [ (Values.Var var : Values.length) ]
+    when var.Values.runtime || List.mem var.Values.name ctx.runtime_vars ->
+      [ simplify_one (Values.Var var) ]
   | [ (Values.Var var : Values.length) ] -> (
       match
         Option.bind

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -844,8 +844,13 @@ let record_keyframe_decls ~record_decl ~at_path ~sel frames =
 let collect_scoped_refs stylesheet =
   let consumers = ref [] in
   let customs = ref [] in
+  let runtime_refs = ref [] in
   let record_decl ~at_path ~selector decl =
     let refs = refs_of_declaration decl in
+    Variables.vars_of_declarations [ decl ]
+    |> List.iter (fun (Variables.V var) ->
+        if var.Values.runtime then
+          runtime_refs := ("--" ^ var.Values.name) :: !runtime_refs);
     match custom_name decl with
     | Some name -> customs := (at_path, selector, name, refs) :: !customs
     | None -> consumers := (at_path, selector, refs) :: !consumers
@@ -875,7 +880,7 @@ let collect_scoped_refs stylesheet =
     | _ -> ()
   in
   List.iter (walk_stmt ~parents:[] ~at_path:[]) stylesheet;
-  (!consumers, !customs)
+  (!consumers, !customs, List.sort_uniq compare !runtime_refs)
 
 (* Closure: a custom-prop declaration is live iff some consumer at a compatible
    at-rule path (any [@media]/[@layer]/[@supports] chain that contains the
@@ -1275,7 +1280,11 @@ let collapse_layer_decided ~keep stylesheet =
     List.map map_stmt stylesheet
 
 let vars ?(keep_vars = []) ?(warn = fun _ -> ()) stylesheet =
-  let keep = List.map normalise_var_name keep_vars in
+  let _, _, runtime_refs = collect_scoped_refs stylesheet in
+  let keep =
+    List.map normalise_var_name keep_vars @ runtime_refs
+    |> List.sort_uniq compare
+  in
   let stylesheet = collapse_layer_decided ~keep stylesheet in
   let counts, referenced = var_census stylesheet in
   let inlinable name =
@@ -1298,14 +1307,16 @@ let vars ?(keep_vars = []) ?(warn = fun _ -> ()) stylesheet =
       then warn name)
     counts;
   let scopes = collect_scopes ~kept stylesheet in
-  let original_consumers, original_customs = collect_scoped_refs stylesheet in
+  let original_consumers, original_customs, _ =
+    collect_scoped_refs stylesheet
+  in
   let cyclic_live_set =
     cyclic_live_customs ~consumers:original_consumers ~customs:original_customs
   in
   let substituted =
     substitute ~kept ~scopes ~parents:[] ~at_path:[] stylesheet
   in
-  let consumers, customs = collect_scoped_refs substituted in
+  let consumers, customs, _ = collect_scoped_refs substituted in
   let live_set = live_customs ~consumers ~customs @ cyclic_live_set in
   (* Keep every definition of a kept variable (including a cross-scope override
      like an @media one), so the live chain stays complete; single-def

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -244,16 +244,24 @@ let test_inline_runtime_var_metadata () =
       ~fallback:(Css.Values.syntax_fallback "var(--fallback)")
       "external"
   in
+  let runtime_cursor : Css.cursor Css.var =
+    Css.var_ref ~runtime:true
+      ~fallback:(Css.Values.syntax_fallback "var(--cursor-fallback)")
+      "cursor"
+  in
   let stylesheet =
     Css.v
       [
         Css.rule ~selector:(Css.Selector.class_ "x")
-          [ Css.padding [ Css.Var runtime_ref ] ];
+          [
+            Css.padding [ Css.Var runtime_ref ];
+            Css.cursor (Css.Var runtime_cursor);
+          ];
       ]
   in
   Alcotest.(check string)
-    "runtime var keeps its live fallback wrapper"
-    ".x{padding:var(--external,var(--fallback))}"
+    "runtime vars keep their live fallback wrappers"
+    ".x{padding:var(--external,var(--fallback));cursor:var(--cursor,var(--cursor-fallback))}"
     (stylesheet |> Css.inline_vars |> minified)
 
 let test_inline_across_layers () =

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -238,6 +238,24 @@ let test_inline_vars_runtime_boundaries () =
     ":root{--bp:30em}@container (min-width:var(--bp)){.x{color:red}}"
     ":root{--bp:30em}@container(min-width:var(--bp)){.x{color:red}}"
 
+let test_inline_runtime_var_metadata () =
+  let runtime_ref : Css.length Css.var =
+    Css.var_ref ~runtime:true
+      ~fallback:(Css.Values.syntax_fallback "var(--fallback)")
+      "external"
+  in
+  let stylesheet =
+    Css.v
+      [
+        Css.rule ~selector:(Css.Selector.class_ "x")
+          [ Css.padding [ Css.Var runtime_ref ] ];
+      ]
+  in
+  Alcotest.(check string)
+    "runtime var keeps its live fallback wrapper"
+    ".x{padding:var(--external,var(--fallback))}"
+    (stylesheet |> Css.inline_vars |> minified)
+
 let test_inline_across_layers () =
   (* A cascade layer never scopes custom-property visibility: layers only order
      competing declarations, so a variable defined in one @layer resolves for a
@@ -329,6 +347,8 @@ let suite =
         test_inline_shorthand_functions;
       Alcotest.test_case "inline vars runtime boundaries" `Quick
         test_inline_vars_runtime_boundaries;
+      Alcotest.test_case "inline vars honour runtime metadata" `Quick
+        test_inline_runtime_var_metadata;
       Alcotest.test_case "inline vars substitute across cascade layers" `Quick
         test_inline_across_layers;
       Alcotest.test_case


### PR DESCRIPTION
Runtime-marked var() references are browser-time override points. inline_vars currently treats typed fallbacks as compile-time defaults and erases the outer wrapper.

This derives the keep set from runtime metadata and retains typed fallbacks across shorthand and scalar value simplification.