### PR TITLE
stylesheet: pair statement_children with statement_declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
   typed fallbacks simplified through scalar values or shorthands, instead of
   replacing browser-time override points with compile-time defaults
   ([#315](https://github.com/samoht/cascade/pull/315))
+- `Css.resolve_theme` emits the theme binding for a `var()` referenced only
+  from inside `@keyframes`, `@page`, `@position-try` or `@supports-condition`,
+  instead of leaving the name undefined in the emitted sheet
+  ([#317](https://github.com/samoht/cascade/pull/317))
 
 ### Canonical diff
 
@@ -21,6 +25,12 @@
   slot, so named and hex colours and typed `var()` fallbacks compare
   canonically while non-colour identifiers remain opaque
   ([#314](https://github.com/samoht/cascade/pull/314))
+
+### Library
+
+- `Css.Stylesheet.statement_declarations` returns the declarations a statement
+  holds directly; paired with `statement_children` it reaches every declaration
+  in a stylesheet ([#317](https://github.com/samoht/cascade/pull/317))
 
 ## 1.1.0
 

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -912,29 +912,11 @@ let collect_var_names stylesheet =
         | _ -> ())
       (Variables.vars_of_declarations decls)
   in
-  let rec walk = function
-    | [] -> ()
-    | stmt :: rest ->
-        (match stmt with
-        | Stylesheet.Rule r ->
-            record_decls r.declarations;
-            walk r.nested
-        | Declarations decls -> record_decls decls
-        | Media (_, b)
-        | Supports (_, b)
-        | Container (_, _, b)
-        | Layer (_, b)
-        | Origin (_, b)
-        | Scope (_, _, b)
-        | Starting_style b
-        | Moz_document (_, b)
-        | When (_, b)
-        | Else (_, b) ->
-            walk b
-        | _ -> ());
-        walk rest
+  let rec walk stmt =
+    record_decls (Stylesheet.statement_declarations stmt);
+    List.iter walk (Stylesheet.statement_children stmt)
   in
-  walk stylesheet;
+  List.iter walk stylesheet;
   Hashtbl.fold (fun k () acc -> k :: acc) seen []
 
 (* Resolve [Theme_guarded { var_name; decl }] declarations against the theme
@@ -1009,23 +991,8 @@ let structural_var_refs (stmts : Stylesheet.statement list) : string list =
     acc := List.rev_append (var_names_in_theme_value (declaration_value d)) !acc
   in
   let rec scan (stmt : Stylesheet.statement) =
-    match stmt with
-    | Stylesheet.Rule r ->
-        List.iter note r.declarations;
-        List.iter scan r.nested
-    | Stylesheet.Declarations decls -> List.iter note decls
-    | Stylesheet.Media (_, b)
-    | Stylesheet.Supports (_, b)
-    | Stylesheet.Container (_, _, b)
-    | Stylesheet.Layer (_, b)
-    | Stylesheet.Origin (_, b)
-    | Stylesheet.Scope (_, _, b)
-    | Stylesheet.Starting_style b
-    | Stylesheet.Moz_document (_, b)
-    | Stylesheet.When (_, b)
-    | Stylesheet.Else (_, b) ->
-        List.iter scan b
-    | _ -> ()
+    List.iter note (Stylesheet.statement_declarations stmt);
+    List.iter scan (Stylesheet.statement_children stmt)
   in
   List.iter scan stmts;
   !acc
@@ -1090,23 +1057,8 @@ let declared_custom_prop_names (stmts : Stylesheet.statement list) :
       decls
   in
   let rec scan (stmt : Stylesheet.statement) =
-    match stmt with
-    | Stylesheet.Rule r ->
-        note r.declarations;
-        List.iter scan r.nested
-    | Stylesheet.Declarations decls -> note decls
-    | Stylesheet.Media (_, b)
-    | Stylesheet.Supports (_, b)
-    | Stylesheet.Container (_, _, b)
-    | Stylesheet.Layer (_, b)
-    | Stylesheet.Origin (_, b)
-    | Stylesheet.Scope (_, _, b)
-    | Stylesheet.Starting_style b
-    | Stylesheet.Moz_document (_, b)
-    | Stylesheet.When (_, b)
-    | Stylesheet.Else (_, b) ->
-        List.iter scan b
-    | _ -> ()
+    note (Stylesheet.statement_declarations stmt);
+    List.iter scan (Stylesheet.statement_children stmt)
   in
   List.iter scan stmts;
   tbl
@@ -1126,23 +1078,8 @@ let referenced_var_names (stmts : Stylesheet.statement list) : string list =
     | Option.None -> ()
   in
   let rec scan (stmt : Stylesheet.statement) =
-    match stmt with
-    | Stylesheet.Rule r ->
-        List.iter note r.declarations;
-        List.iter scan r.nested
-    | Stylesheet.Declarations decls -> List.iter note decls
-    | Stylesheet.Media (_, b)
-    | Stylesheet.Supports (_, b)
-    | Stylesheet.Container (_, _, b)
-    | Stylesheet.Layer (_, b)
-    | Stylesheet.Origin (_, b)
-    | Stylesheet.Scope (_, _, b)
-    | Stylesheet.Starting_style b
-    | Stylesheet.Moz_document (_, b)
-    | Stylesheet.When (_, b)
-    | Stylesheet.Else (_, b) ->
-        List.iter scan b
-    | _ -> ()
+    List.iter note (Stylesheet.statement_declarations stmt);
+    List.iter scan (Stylesheet.statement_children stmt)
   in
   List.iter scan stmts;
   List.map bare_theme_name (collect_var_names stmts @ !opaque)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -273,6 +273,37 @@ let statement_children = function
   | View_transition _ | Position_try _ | Viewport _ | Unknown_at_rule _ ->
       []
 
+(* The companion to [statement_children]: the declarations a statement holds
+   itself. At-rules like [@keyframes] and [@page] hold declarations without
+   wrapping them in a block, so a walk that only descends through
+   [statement_children] never sees them. Exhaustive for the same reason: a
+   wildcard would hide the next declaration-carrying at-rule from every caller.
+   Descriptor at-rules ([@font-face], [@counter-style], [@viewport], ...) hold
+   their own descriptor types rather than declarations. *)
+let statement_declarations = function
+  | Rule rule -> rule.declarations
+  | Declarations decls
+  | Supports_condition (_, decls)
+  | Page (_, decls)
+  | Position_try (_, decls) ->
+      decls
+  | Keyframes (_, frames)
+  | Webkit_keyframes (_, frames)
+  | Moz_keyframes (_, frames) ->
+      List.concat_map (fun (frame : keyframe) -> frame.declarations) frames
+  | Page_with_margins (_, descriptors, margins) ->
+      descriptors
+      @ List.concat_map
+          (fun (margin : page_margin_rule) -> margin.descriptors)
+          margins
+  | Property _ -> []
+  | Bang_comment _ | Charset _ | Import _ | Namespace _ | Layer_decl _ | Layer _
+  | Media _ | Container _ | Supports _ | Moz_document _ | When _ | Else _
+  | Starting_style _ | Origin _ | Scope _ | Font_face _ | Counter_style _
+  | Font_palette_values _ | Font_feature_values _ | View_transition _
+  | Viewport _ | Unknown_at_rule _ ->
+      []
+
 (** {1 Pretty Printing} *)
 
 let pp_property_rule : 'a property_rule Pp.t =

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -227,6 +227,20 @@ val statement_children : statement -> block
     match is exhaustive, and a block at-rule added to the AST later does not
     compile until it is listed here. *)
 
+val statement_declarations : statement -> declaration list
+(** [statement_declarations stmt] is the declarations [stmt] holds directly: a
+    rule's or a bare [Declarations] block's own declarations, the descriptors of
+    [@page], [@position-try] and [@supports-condition], the margin-rule
+    descriptors of a [@page] with margins, and the concatenated declarations of
+    every frame of [@keyframes] (and its [-webkit-]/[-moz-] spellings). It is
+    [[]] for a grouping at-rule, whose declarations live in the block
+    {!statement_children} returns, and for a descriptor at-rule such as
+    [@font-face] or [@counter-style], which holds descriptor values rather than
+    declarations. Paired with {!statement_children} it visits every declaration
+    in a stylesheet, and it is exhaustive for the same reason: a
+    declaration-carrying at-rule added to the AST later does not compile until
+    it is listed here. *)
+
 (** {1 Reading/Parsing} *)
 
 val read_rule : ?nested:bool -> Cursor.t -> rule

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -211,6 +211,35 @@ let spec_theme_binding_for_logical_property () =
     ":root{--w:10px}.a{inline-size:var(--w)}"
     (render ".a { inline-size: var(--w) }")
 
+(* CSS Animations L1 sec. 3: a keyframe block holds ordinary property
+   declarations. CSS Custom Properties L1 sec. 3: var() in one is substituted
+   against the animated element, so a name referenced only from a keyframe needs
+   the same root binding as one referenced from a rule. *)
+let spec_theme_binding_inside_keyframes () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let theme = Css.Pp.String_set.singleton "w" in
+  let theme_defaults = function "w" -> Some "10px" | _ -> None in
+  let render css =
+    parse css
+    |> Css.resolve_theme ~theme ~theme_defaults
+    |> Css.to_string ~minify:true
+  in
+  Alcotest.(check string)
+    "rule emits the theme binding" ":root{--w:10px}.a{width:var(--w)}"
+    (render ".a { width: var(--w) }");
+  Alcotest.(check string)
+    "keyframe block emits the theme binding"
+    ":root{--w:10px}@keyframes k{0%{width:var(--w)}}"
+    (render "@keyframes k { from { width: var(--w) } }");
+  Alcotest.(check string)
+    "keyframes in a layer emits the theme binding"
+    ":root{--w:10px}@layer l{@keyframes k{0%{width:var(--w)}}}"
+    (render "@layer l { @keyframes k { from { width: var(--w) } } }")
+
 (* Not a roundtrip test *)
 let test_vars_of_declarations () =
   let custom_color_decl, color_var =
@@ -485,6 +514,9 @@ let tests =
     ( "spec theme binding for logical property",
       `Quick,
       spec_theme_binding_for_logical_property );
+    ( "spec theme binding inside keyframes",
+      `Quick,
+      spec_theme_binding_inside_keyframes );
     ("vars of declarations", `Quick, test_vars_of_declarations);
     ("any_var_name", `Quick, test_any_var_name);
     ("extract custom declarations", `Quick, test_extract_custom_declarations);


### PR DESCRIPTION
A `var()` referenced only from inside `@keyframes` got no `:root` theme binding, so `resolve_theme` emitted a sheet that animates an undefined value. This PR adds `Stylesheet.statement_declarations` to pair with the existing `statement_children`, and rewrites the four theme walkers in `css.ml` on top of both.

The new accessor names all 30 statement constructors with no wildcard, so the next declaration-carrying at-rule is a compile error rather than another silent gap.
