### PR TITLE
githooks: cover dune files in the ASCII gate and fail loudly when grep cannot run it

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,6 +2,7 @@
 # pre-commit hook for cascade.
 #
 # Runs:
+#   0. scripts/check_ascii.sh -- on the staged content, so the commit stays 7-bit.
 #   1. dune fmt -- if it rewrites a staged file, aborts so the change is staged.
 #   2. merlint   -- across the whole project (not only the staged files), so a
 #                   change in one module that breaks a lint elsewhere is caught
@@ -11,41 +12,23 @@
 #
 #   git config core.hooksPath .githooks
 #
-# The hook does nothing when no OCaml or dune files are staged.
+# Every check here has a CI counterpart, so a clone without the hook is still
+# gated; the hook only moves the failure earlier.
 
 set -eu
 
-STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '(\.(ml|mli|mll|mly)|(^|/)dune(-project)?)$' || true)
-[ -n "$STAGED" ] || exit 0
+CHANGED=$(git diff --cached --name-only --diff-filter=ACM)
+[ -n "$CHANGED" ] || exit 0
 
-# 0. ASCII only. Source stays 7-bit: write "sec." not the section sign, "--"
-#    not the em dash, and \u{XXXX} escapes for a glyph a string must emit
-#    (e.g. the diff tree connectors). Checks the staged content, not the
-#    worktree. The class spells out the printable range instead of using
-#    [:print:], which a Unicode-aware grep reads as all of Unicode -- the
-#    complement is then empty and the pattern is rejected. An exit status
-#    above 1 is such a rejection, not a clean file, so it aborts the commit.
-NONASCII=""
-for f in $STAGED; do
-    rc=0
-    git show ":$f" | LC_ALL=C grep -q '[^ -~[:cntrl:]]' || rc=$?
-    case $rc in
-    0) NONASCII="$NONASCII $f" ;;
-    1) ;;
-    *)
-        echo "error: the ASCII check could not run on $f (grep exit $rc)" >&2
-        exit 1
-        ;;
-    esac
-done
-if [ -n "$NONASCII" ]; then
-    echo "error: non-ASCII byte in staged source:" >&2
-    for f in $NONASCII; do
-        git show ":$f" | LC_ALL=C grep -n '[^ -~[:cntrl:]]' | sed "s|^|  $f:|" >&2
-    done
-    echo "use ASCII in comments and \\u{XXXX} escapes in string literals." >&2
-    exit 1
-fi
+# 0. ASCII only, on the staged content rather than the worktree. The script
+#    owns the filter, so what CI covers and what the commit is held to are the
+#    same set by construction.
+printf '%s\n' "$CHANGED" | "$(dirname "$0")/../scripts/check_ascii.sh" --staged
+
+# The fast path below only decides whether dune fmt and merlint are worth
+# running; the ASCII rule above has already seen every staged file.
+STAGED=$(printf '%s\n' "$CHANGED" | grep -E '(\.(ml|mli|mll|mly)|(^|/)dune(-project)?)$' || true)
+[ -n "$STAGED" ] || exit 0
 
 # 1. dune fmt
 if ! dune fmt 2>/dev/null; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,27 +11,37 @@
 #
 #   git config core.hooksPath .githooks
 #
-# The hook does nothing when no OCaml files are staged.
+# The hook does nothing when no OCaml or dune files are staged.
 
 set -eu
 
-STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(ml|mli|mll|mly)$' || true)
+STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -E '(\.(ml|mli|mll|mly)|(^|/)dune(-project)?)$' || true)
 [ -n "$STAGED" ] || exit 0
 
 # 0. ASCII only. Source stays 7-bit: write "sec." not the section sign, "--"
 #    not the em dash, and \u{XXXX} escapes for a glyph a string must emit
 #    (e.g. the diff tree connectors). Checks the staged content, not the
-#    worktree.
+#    worktree. The class spells out the printable range instead of using
+#    [:print:], which a Unicode-aware grep reads as all of Unicode -- the
+#    complement is then empty and the pattern is rejected. An exit status
+#    above 1 is such a rejection, not a clean file, so it aborts the commit.
 NONASCII=""
 for f in $STAGED; do
-    if git show ":$f" | LC_ALL=C grep -n '[^[:print:][:cntrl:]]' >/dev/null 2>&1; then
-        NONASCII="$NONASCII $f"
-    fi
+    rc=0
+    git show ":$f" | LC_ALL=C grep -q '[^ -~[:cntrl:]]' || rc=$?
+    case $rc in
+    0) NONASCII="$NONASCII $f" ;;
+    1) ;;
+    *)
+        echo "error: the ASCII check could not run on $f (grep exit $rc)" >&2
+        exit 1
+        ;;
+    esac
 done
 if [ -n "$NONASCII" ]; then
-    echo "error: non-ASCII byte in staged OCaml source:" >&2
+    echo "error: non-ASCII byte in staged source:" >&2
     for f in $NONASCII; do
-        git show ":$f" | LC_ALL=C grep -n '[^[:print:][:cntrl:]]' | sed "s|^|  $f:|" >&2
+        git show ":$f" | LC_ALL=C grep -n '[^ -~[:cntrl:]]' | sed "s|^|  $f:|" >&2
     done
     echo "use ASCII in comments and \\u{XXXX} escapes in string literals." >&2
     exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,19 @@ jobs:
       - run: opam exec -- dune build
       - run: opam exec -- dune test
 
+  ascii:
+    name: ASCII source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The same script the pre-commit hook runs, on the tracked files rather
+      # than the index. Kept out of the lint job so the rule reports in seconds
+      # instead of waiting on an opam switch it does not need. [shell: bash]
+      # turns on pipefail, so a failing [git ls-files] cannot read as clean.
+      - shell: bash
+        run: git ls-files | scripts/check_ascii.sh
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -9,7 +9,7 @@
   cascade_spec_inventory
   fuzz_helpers))
 
-; Property-based testing — runs with dune test
+; Property-based testing -- runs with dune test
 
 (rule
  (alias runtest)
@@ -19,7 +19,7 @@
  (action
   (run %{exe:fuzz.exe})))
 
-; AFL campaign — only runs under --profile=afl. Generates the seed corpus
+; AFL campaign -- only runs under --profile=afl. Generates the seed corpus
 ; via fuzz.exe --gen-corpus before handing off to AFL.
 
 (rule

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -36,10 +36,10 @@ let substitute ?(leftmost = true) ~parent sel =
   let parent = if verbatim then parent else Selector.Is [ parent ] in
   Selector.map (function Selector.Nesting -> parent | s -> s) sel
 
-(* CSS Nesting 1 §2: a nested selector list is relative to the parent branch by
-   branch, so [.p { a, b { ... } }] is [.p a, .p b]. Combining the parent with
-   the list as a whole would put the combinator on the first branch only and let
-   the rest escape as top-level selectors. *)
+(* CSS Nesting 1 sec. 2: a nested selector list is relative to the parent branch
+   by branch, so [.p { a, b { ... } }] is [.p a, .p b]. Combining the parent
+   with the list as a whole would put the combinator on the first branch only
+   and let the rest escape as top-level selectors. *)
 let rec combine parent child =
   match child with
   | Selector.List branches -> Selector.List (List.map (combine parent) branches)

--- a/scripts/check_ascii.sh
+++ b/scripts/check_ascii.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Reject non-ASCII bytes in cascade source.
+#
+# Reads candidate paths from the arguments, or from stdin when there are none,
+# keeps the ones the rule covers and reports every non-ASCII byte in them. With
+# [--staged] the staged content is read instead of the worktree, so the
+# pre-commit hook sees what the commit will contain.
+#
+# Source stays 7-bit: write "sec." not the section sign, "--" not the em dash,
+# and \u{XXXX} escapes for a glyph a string must emit (e.g. the diff tree
+# connectors). Prose (README.md, CHANGES.md) and the test fixtures are outside
+# the filter, so they keep their non-ASCII content.
+#
+# The pre-commit hook pipes the staged names in; CI pipes [git ls-files] in.
+# Both go through this one filter and this one pattern so the two cannot drift.
+
+set -eu
+
+# Covers the files that carry OCaml source or build rules.
+COVERED='(\.(ml|mli|mll|mly)|(^|/)dune(-project)?)$'
+
+# The class spells out the printable range instead of using [:print:], which a
+# Unicode-aware grep reads as all of Unicode -- the complement is then empty and
+# the pattern is rejected. [\x00-\x7F] is no better: neither BSD nor GNU grep
+# expands \x inside a bracket expression, so it matches a literal x. An exit
+# status above 1 is a rejected pattern rather than a clean file, so it aborts.
+PATTERN='[^ -~[:cntrl:]]'
+
+staged=false
+if [ "${1-}" = "--staged" ]; then
+    staged=true
+    shift
+fi
+
+if [ "$#" -gt 0 ]; then
+    names=$(printf '%s\n' "$@")
+else
+    names=$(cat)
+fi
+files=$(printf '%s\n' "$names" | grep -E "$COVERED" || true)
+[ -n "$files" ] || exit 0
+
+scan() {
+    if [ "$staged" = true ]; then
+        git show ":$1" | LC_ALL=C grep -n "$PATTERN"
+    else
+        LC_ALL=C grep -n "$PATTERN" -- "$1"
+    fi
+}
+
+status=0
+while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    rc=0
+    hits=$(scan "$f") || rc=$?
+    case $rc in
+    0)
+        [ "$status" -eq 1 ] || echo "error: non-ASCII byte in source:" >&2
+        status=1
+        printf '%s\n' "$hits" | sed "s|^|  $f:|" >&2
+        ;;
+    1) ;;
+    *)
+        echo "error: the ASCII check could not run on $f (grep exit $rc)" >&2
+        exit 1
+        ;;
+    esac
+done <<EOF
+$files
+EOF
+
+if [ "$status" -ne 0 ]; then
+    echo "use ASCII in comments and \\u{XXXX} escapes in string literals." >&2
+fi
+exit $status

--- a/test/examples/dune
+++ b/test/examples/dune
@@ -1,1 +1,1 @@
-; Empty — fixture files only, no build rules needed
+; Empty -- fixture files only, no build rules needed

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -91,10 +91,10 @@ let test_nesting_wraps_complex_parent () =
   check ".a .b{&:hover{color:red}}" ".a .b:hover{color:red}";
   check ".a .b{& .c{color:red}}" ".a .b .c{color:red}"
 
-(* CSS Nesting 1 §2: a nested selector list is relative to the parent branch by
-   branch. Combining the parent with the list as a whole put the combinator on
-   the first branch only, and every later branch escaped as a top-level selector
-   — [.p { a, b { ... } }] matched every [b] on the page. *)
+(* CSS Nesting 1 sec. 2: a nested selector list is relative to the parent branch
+   by branch. Combining the parent with the list as a whole put the combinator
+   on the first branch only, and every later branch escaped as a top-level
+   selector -- [.p { a, b { ... } }] matched every [b] on the page. *)
 let test_nested_selector_list_keeps_parent () =
   let check src expected =
     Alcotest.(check string) src expected (render (Flatten.block (block src)))


### PR DESCRIPTION
The gate only ever looked at OCaml sources, so two dune files kept their em dashes, and because it swallowed grep's stderr an exit status of 2 from a grep that cannot compile the character class read as a clean file rather than as a failure to run. The source edits are the section signs and em dashes the widened gate now rejects.
