### PR TITLE
Parenthesise compound operands in @media conditions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ### Parsing
 
+- A compound operand of `not`, `and` or `or` in a `@media` condition keeps the
+  parentheses Media Queries 4 sec. 3 requires around a `<media-in-parens>`:
+  `not ((min-width:1px) or (max-width:2px))` printed as
+  `not (min-width:1px)or (max-width:2px)`, which browsers and cascade's own
+  reader reject, losing the whole block
+  ([#317](https://github.com/samoht/cascade/pull/317))
 - An `@font-face` descriptor whose value holds a `var()` is dropped with a
   warning, and `Css.of_string ~strict:true` rejects it. `var()` substitutes in
   property values only (CSS Variables 1), so no descriptor grammar accepts one

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
   `not ((min-width:1px) or (max-width:2px))` printed as
   `not (min-width:1px)or (max-width:2px)`, which browsers and cascade's own
   reader reject, losing the whole block
-  ([#317](https://github.com/samoht/cascade/pull/317))
+  ([#319](https://github.com/samoht/cascade/pull/319))
 - An `@font-face` descriptor whose value holds a `var()` is dropped with a
   warning, and `Css.of_string ~strict:true` rejects it. `var()` substitutes in
   property values only (CSS Variables 1), so no descriptor grammar accepts one

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -453,20 +453,33 @@ let merge_interval_bounds (a : feature) (b : feature) : feature option =
       Some (Interval (lv, lop, n1, uop, uv))
   | _ -> None
 
+(* CSS Media Queries 4 sec. 3: every operand of [not], [and] and [or] is a
+   [<media-in-parens>], so a compound operand keeps its wrapper. A feature is
+   already parenthesised and a [<general-enclosed>] is its own block, so both
+   stand alone. The left of a chain is the exception: [<media-in-parens>
+   <media-and>*] lets a same-operator chain continue unwrapped. *)
 let rec pp_condition : condition Pp.t =
  fun ctx -> function
   | Feature f -> pp_feature ctx f
   | Not c ->
       Pp.string ctx "not ";
-      pp_condition ctx c
+      pp_in_parens ctx c
   | And (a, b) ->
-      pp_condition ctx a;
+      (match a with And _ -> pp_condition ctx a | _ -> pp_in_parens ctx a);
       Pp.string ctx (if Pp.minified ctx then "and " else " and ");
-      pp_condition ctx b
+      pp_in_parens ctx b
   | Or (a, b) ->
-      pp_condition ctx a;
+      (match a with Or _ -> pp_condition ctx a | _ -> pp_in_parens ctx a);
       Pp.string ctx (if Pp.minified ctx then "or " else " or ");
-      pp_condition ctx b
+      pp_in_parens ctx b
+
+and pp_in_parens : condition Pp.t =
+ fun ctx -> function
+  | Feature f -> pp_feature ctx f
+  | (Not _ | And _ | Or _) as c ->
+      Pp.char ctx '(';
+      pp_condition ctx c;
+      Pp.char ctx ')'
 
 let rec pp : t Pp.t =
  fun ctx -> function
@@ -489,11 +502,8 @@ let rec pp : t Pp.t =
           (* CSS Media Queries 4 sec. 3 [media-condition-without-or]: Or
              sub-expressions need explicit parens in this context. *)
           match c with
-          | Or _ ->
-              Pp.char ctx '(';
-              pp_condition ctx c;
-              Pp.char ctx ')'
-          | _ -> pp_condition ctx c))
+          | Or _ -> pp_in_parens ctx c
+          | Feature _ | Not _ | And _ -> pp_condition ctx c))
   | List qs ->
       let rec loop = function
         | [] -> ()

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -298,6 +298,43 @@ let component_parser_edges () =
         "@media screen and (prefers-color-scheme:dark){a{color:red}}"
         (Css.to_string ~minify:true parsed.stylesheet)
 
+(* Media Queries 4 sec. 3 [<media-not> = not <media-in-parens>]: the operand of
+   [not] is one parenthesised block, and nothing may follow it at that level. A
+   negated disjunction therefore keeps the wrapper the author wrote; without it
+   the query no longer reads back. *)
+let media_not_takes_media_in_parens () =
+  let minified ?(enforce_spec = false) source =
+    match Css.of_string ~strict:false source with
+    | Error error -> Alcotest.fail (Cascade.Error.to_string error)
+    | Ok parsed ->
+        Css.optimize ~enforce_spec parsed.stylesheet
+        |> Css.to_string ~minify:true ~enforce_spec
+  in
+  let check_modes name input ~default ~spec =
+    Alcotest.(check string) (name ^ " default") default (minified input);
+    Alcotest.(check string)
+      (name ^ " enforce-spec") spec
+      (minified ~enforce_spec:true input)
+  in
+  let negated_or =
+    "@media not ((min-width:1px) or (max-width:2px)){a{color:red}}"
+  in
+  check_modes "negated disjunction" negated_or
+    ~default:"@media not ((width>=1px)or (width<=2px)){a{color:red}}"
+    ~spec:"@media not ((min-width:1px)or (max-width:2px)){a{color:red}}";
+  (* Losing the wrapper costs the whole block: the reader rejects trailing
+     content after [not <media-in-parens>]. *)
+  Alcotest.(check string)
+    "negated disjunction reparses"
+    "@media not ((width>=1px)or (width<=2px)){a{color:red}}"
+    (minified (minified negated_or));
+  (* A single [<media-in-parens>] operand is already wrapped, so no second pair
+     of parentheses appears. *)
+  check_modes "negated single condition"
+    "@media not (min-width:1px){a{color:red}}"
+    ~default:"@media not (width>=1px){a{color:red}}"
+    ~spec:"@media not (min-width:1px){a{color:red}}"
+
 let suite =
   let open Alcotest in
   ( "media",
@@ -322,4 +359,6 @@ let suite =
       test_case "general-enclosed is not a media type" `Quick
         general_enclosed_is_not_a_media_type;
       test_case "component parser edges" `Quick component_parser_edges;
+      test_case "media-not takes a media-in-parens" `Quick
+        media_not_takes_media_in_parens;
     ] )


### PR DESCRIPTION
Media Queries 4 sec. 3 makes every operand of `not`, `and` and `or` a `<media-in-parens>`, and cascade was dropping that wrapper, so `@media not ((min-width:1px) or (max-width:2px))` printed as a query browsers and cascade's own reader reject, losing the whole block on a round trip. Nested negations were worse: the `and` in `(not ((a) or (b))) and (c)` escaped the negation's scope, which changes what the query matches.