### PR TITLE
Cite the right Filter Effects sections

### DIFF
--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -1573,7 +1573,7 @@ let read_any_property t =
   | "stroke-dasharray" -> Prop Stroke_dasharray
   | "paint-order" -> Prop Paint_order
   | "vector-effect" -> Prop Vector_effect
-  (* SVG 2 sec. 13.4 / Filter Effects 1 sec. 9.3 and 12.2: each is a plain
+  (* SVG 2 sec. 13.4 / Filter Effects 1 sec. 9.13.1 and 11.5: each is a plain
      <color>, so they minify like any other colour-valued property. *)
   | "stop-color" -> Prop Stop_color
   | "flood-color" -> Prop Flood_color
@@ -1894,7 +1894,7 @@ let fold_custom_calc (c : Component.t) ~fallback =
   | Some cs -> cs
   | None -> fallback ()
 
-(* Filter Effects 1 sec. 8.5 gives [hue-rotate()] the argument [[ <angle> |
+(* Filter Effects 1 sec. 6.1 gives [hue-rotate()] the argument [[ <angle> |
    <zero> ]?] and 0 when omitted, so a zero argument is redundant. [hue-rotate]
    names a filter function and nothing else, so this holds wherever the stream
    is substituted, which is the same argument that lets a colour function fold

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -134,7 +134,7 @@ let equal_canonical_lossless_exact_srgb () =
     "an off-grid channel keeps its function" false
     (equal ".a{color:color(srgb .501 0 0)}" ".a{color:maroon}")
 
-(* Filter Effects 1 sec. 8.5 makes an omitted [hue-rotate()] argument 0, and
+(* Filter Effects 1 sec. 6.1 makes an omitted [hue-rotate()] argument 0, and
    [hue-rotate] names a filter function and nothing else, so the two spellings
    are one value wherever the stream is substituted. *)
 let canonical_custom_hue_rotate_zero () =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -122,8 +122,8 @@ let complex_values () =
      longer. *)
   decl_optimizes ~prop:"flood-opacity" ~into:".5" "50%";
 
-  (* SVG 2 sec. 13.4 and Filter Effects 1 sec. 9.3 / 12.2 make each of these a
-     plain <color>, so they shorten like any other colour-valued property
+  (* SVG 2 sec. 13.4 and Filter Effects 1 sec. 9.13.1 / 11.5 make each of these
+     a plain <color>, so they shorten like any other colour-valued property
      instead of surviving as opaque unknown-property text. *)
   check_declaration ~expected:"stop-color:#fff" "stop-color: #ffffff;";
   check_declaration ~expected:"lighting-color:currentColor"


### PR DESCRIPTION
Three comments cited Filter Effects 1 sections that do not say what they were cited for: sec. 8.5 does not exist (sec. 8 is Filter Region, no subsections), sec. 9.3 is the filter primitive tree and sec. 12.2 does not exist either. The hue-rotate() grammar `hue-rotate( [ <angle> | <zero> ]? )` is in sec. 6.1 Supported Filter Functions, and flood-color and lighting-color are defined in sec. 9.13.1 and 11.5, per https://drafts.csswg.org/filter-effects-1/ (drafts.fxtf.org now forwards there).
