### PR TITLE
font-face: drop a descriptor var() nothing can resolve

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 ## Unreleased
 
+### Parsing
+
+- An `@font-face` descriptor whose value holds a `var()` is dropped with a
+  warning, and `Css.of_string ~strict:true` rejects it. `var()` substitutes in
+  property values only (CSS Variables 1), so no descriptor grammar accepts one
+  and browsers drop the declaration. `src` and `unicode-range` keep theirs,
+  since `Css.inline_vars` resolves those references at build time
+  ([#322](https://github.com/samoht/cascade/pull/322))
+
 ### Custom properties
 
 - `Css.inline_vars` preserves runtime-marked `var()` references, including

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2054,6 +2054,37 @@ let read_font_face_desc name r =
         r
   | _ -> Cursor.err_invalid r ("unknown font-face descriptor: " ^ name)
 
+(* CSS Variables 1 sec. 3 substitutes [var()] in a property value; an @font-face
+   descriptor is not a property, so no descriptor grammar accepts a var() and
+   browsers drop the whole declaration. The descriptor readers delegate to the
+   shared property readers, which accept var() legitimately in property
+   position, so the rejection belongs at the descriptor boundary. *)
+let rec components_have_var (components : Component.t list) =
+  List.exists
+    (fun (component : Component.t) ->
+      match component with
+      | Component.Func { node = { name; arguments; _ }; _ } ->
+          String.lowercase_ascii name = "var" || components_have_var arguments
+      | Component.Block { node = { value; _ }; _ } -> components_have_var value
+      | Component.Preserved _ -> false)
+    components
+
+let rec components_upto_semicolon = function
+  | [] | Component.Preserved { kind = Token.Semicolon; _ } :: _ -> []
+  | component :: rest -> component :: components_upto_semicolon rest
+
+(* cascade generates CSS, so a var() it substitutes at build time never reaches
+   a browser. [Inline.simplify_font_face_descriptor] resolves exactly these two
+   under [--inline-vars], so their readers keep the var(); every other
+   descriptor has no resolution path, leaving the var() unresolvable. *)
+let descriptor_resolves_var = function
+  | "src" | "unicode-range" -> true
+  | _ -> false
+
+let descriptor_value_has_var name r =
+  (not (descriptor_resolves_var name))
+  && components_have_var (components_upto_semicolon (Cursor.remaining r))
+
 let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
   Cursor.ws r;
   if Cursor.is_done r then None
@@ -2062,7 +2093,11 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
     None)
   else
     let name = Cursor.ident ~keep_case:false r in
-    match read_font_face_desc name r with
+    match
+      if descriptor_value_has_var name r then
+        Cursor.err_invalid r ("var() in @font-face descriptor: " ^ name)
+      else read_font_face_desc name r
+    with
     | descriptor ->
         Cursor.ws r;
         if Cursor.peek_semicolon r then Cursor.skip r;

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -320,6 +320,8 @@ let spec_fontface_var_descriptor_edges () =
     in
     lenient @ strict
   in
+  (* [unicode-range] is exempt for the same reason as [src]: [--inline-vars]
+     resolves its var() at build time, so cascade keeps it. *)
   match
     List.concat_map mismatches
       [
@@ -329,7 +331,6 @@ let spec_fontface_var_descriptor_edges () =
         "line-gap-override";
         "font-display";
         "font-weight";
-        "unicode-range";
         "font-style";
         "font-stretch";
       ]

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -283,6 +283,62 @@ let spec_fontface_metric_numeric_edges () =
       Alcotest.failf "accepted invalid font metric cases:\n%s"
         (String.concat "\n" accepted)
 
+(* CSS Custom Properties 1 sec. 3 substitutes var() in properties only, and
+   @font-face descriptors are not properties: no descriptor grammar accepts it.
+   Every one of them is therefore dropped with a warning while the rest of the
+   block is kept (CSS Fonts 4 sec. 11.2, CSS Syntax 3 sec. 5.4.4), and
+   ~strict:true turns that warning into an error. *)
+let spec_fontface_var_descriptor_edges () =
+  let kept = "@font-face{font-family:Brand;src:url(font.woff2)}" in
+  let source descriptor =
+    Fmt.str "@font-face{font-family:Brand;src:url(font.woff2);%s:var(--b)}"
+      descriptor
+  in
+  let mismatches descriptor =
+    let input = source descriptor in
+    let lenient =
+      match Css.of_string input with
+      | Error _ -> [ Fmt.str "%s: lenient parse rejected %S" descriptor input ]
+      | Ok { Css.stylesheet; warnings } -> (
+          let printed = Css.to_string ~minify:true stylesheet |> String.trim in
+          (if String.equal printed kept then []
+           else
+             [ Fmt.str "%s: printed %S, expected %S" descriptor printed kept ])
+          @
+          match warnings with
+          | [ _ ] -> []
+          | _ ->
+              [
+                Fmt.str "%s: %d parse warnings, expected 1" descriptor
+                  (List.length warnings);
+              ])
+    in
+    let strict =
+      match Css.of_string ~strict:true input with
+      | Error _ -> []
+      | Ok _ -> [ Fmt.str "%s: strict parse accepted %S" descriptor input ]
+    in
+    lenient @ strict
+  in
+  match
+    List.concat_map mismatches
+      [
+        "size-adjust";
+        "ascent-override";
+        "descent-override";
+        "line-gap-override";
+        "font-display";
+        "font-weight";
+        "unicode-range";
+        "font-style";
+        "font-stretch";
+      ]
+  with
+  | [] -> ()
+  | mismatches ->
+      Alcotest.failf "@font-face descriptors keeping var():\n%s"
+        (String.concat "\n" mismatches)
+
 let suite =
   let open Alcotest in
   ( "font_face",
@@ -307,4 +363,6 @@ let suite =
         spec_fontface_src_invalid_edges;
       test_case "spec font-face metric numeric edges" `Quick
         spec_fontface_metric_numeric_edges;
+      test_case "spec font-face var() descriptor edges" `Quick
+        spec_fontface_var_descriptor_edges;
     ] )


### PR DESCRIPTION
No @font-face descriptor grammar substitutes var(), so a browser drops the whole declaration, but cascade kept it in most of them and left ~strict:true firing on an arbitrary subset. src and unicode-range are exempt because --inline-vars resolves them at build time, so a var() there never reaches a browser.
