### PR TITLE
Minify a negated all media type to the Level 4 not

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,15 @@
   since `Css.inline_vars` resolves those references at build time
   ([#322](https://github.com/samoht/cascade/pull/322))
 
+### Minification
+
+- `@media not all and (X)` minifies to the Level 4 `@media not (X)`. `all` is
+  the identity media type (Media Queries 4 sec. 2.1), so the two spell the same
+  query, and default minify already spends Level 3 compatibility by lowering
+  `min-width` to range syntax inside that very query. `--enforce-spec` keeps
+  both Level 3 spellings
+  ([#323](https://github.com/samoht/cascade/pull/323))
+
 ### Custom properties
 
 - `Css.inline_vars` preserves runtime-marked `var()` references, including

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -1098,6 +1098,11 @@ let rec lower_for_minify : t -> t = function
   | Cond c as query ->
       let c' = lower_condition c in
       if c' == c then query else Cond c'
+  (* CSS Media Queries 4 sec. 2.1: [all] is the identity media type, so [not all
+     and (X)] is the Level 3 spelling of [not (X)]. Bare [not all] has no
+     condition form and stays. *)
+  | Type { prefix = Some Not; type_ = All; trailing = Some c } ->
+      Cond (Not (lower_condition c))
   | Type ({ trailing; _ } as r) as query -> (
       match trailing with
       | None -> query

--- a/lib/media.mli
+++ b/lib/media.mli
@@ -183,8 +183,9 @@ val pp : t Pp.t
 val lower_for_minify : t -> t
 (** [lower_for_minify t] applies the target-fact grammar upgrades used under
     minify: [min-X]/[max-X] plain features become the range form [X>=V]/[X<=V],
-    and a lower bound paired with an upper bound on the same feature across an
-    [and] collapses into the two-sided interval [V<=name<=V]. *)
+    a lower bound paired with an upper bound on the same feature across an [and]
+    collapses into the two-sided interval [V<=name<=V], and [not all and (X)]
+    becomes the Level 4 [not (X)]. *)
 
 val pp_condition : condition Pp.t
 (** Pretty-printer for media query conditions. *)

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -630,10 +630,10 @@ let rec sort_property_runs (stmts : statement list) : statement list =
    condition form - it matches nothing - so it stays, and the unnegated [all and
    (X)] never reaches here because {!Optimize} already drops it.
 
-   Projection only. The Level 4 form is eight characters shorter, but a Level 3
-   parser rejects a [not] with no media type and an unrecognised query never
-   matches, so rewriting one to the other on output would silently drop the
-   block in those browsers. *)
+   Default minify emits the Level 4 form itself ({!Media.lower_for_minify}), so
+   this fires on the input that pass leaves alone: statements a caller projects
+   without optimizing, and [--enforce-spec] output, which keeps the Level 3
+   spelling. *)
 let rec canonical_media (query : Media.t) : Media.t =
   match query with
   | Media.Type { prefix = Some Media.Not; type_ = Media.All; trailing = Some c }

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -335,6 +335,41 @@ let media_not_takes_media_in_parens () =
     ~default:"@media not (width>=1px){a{color:red}}"
     ~spec:"@media not (min-width:1px){a{color:red}}"
 
+(* Media Queries 4 sec. 2.1: [all] is the identity media type, so [not all and
+   (X)] and [not (X)] are the same query. Default minify already spends Level 3
+   compatibility by lowering [min-width] to range syntax, so it takes the
+   shorter Level 4 [not] as well; [--enforce-spec] keeps both Level 3
+   spellings. *)
+let negated_all_is_level4_not () =
+  let minified ?(enforce_spec = false) css =
+    match Css.of_string css with
+    | Error error -> Alcotest.fail (Cascade.Error.to_string error)
+    | Ok parsed ->
+        Css.optimize ~enforce_spec parsed.stylesheet
+        |> Css.to_string ~minify:true ~enforce_spec
+        |> String.trim
+  in
+  let check_modes name input ~default ~spec =
+    Alcotest.(check string) (name ^ " default") default (minified input);
+    Alcotest.(check string)
+      (name ^ " enforce-spec") spec
+      (minified ~enforce_spec:true input)
+  in
+  check_modes "negated feature"
+    "@media not all and (min-width:100px){a{color:red}}"
+    ~default:"@media not (width>=100px){a{color:red}}"
+    ~spec:"@media not all and (min-width:100px){a{color:red}}";
+  (* [<media-type> and <media-condition-without-or>] forbids a top-level [or],
+     so the inner parentheses are what keeps the moved condition grammatical
+     under a bare [not]. *)
+  check_modes "negated or condition"
+    "@media not all and ((min-width:1px) or (max-width:2px)){a{color:red}}"
+    ~default:"@media not ((width>=1px)or (width<=2px)){a{color:red}}"
+    ~spec:"@media not all and ((min-width:1px)or (max-width:2px)){a{color:red}}";
+  (* Bare [not all] has no condition form and matches nothing: verbatim. *)
+  check_modes "bare not all" "@media not all{a{color:red}}"
+    ~default:"@media not all{a{color:red}}" ~spec:"@media not all{a{color:red}}"
+
 let suite =
   let open Alcotest in
   ( "media",
@@ -361,4 +396,5 @@ let suite =
       test_case "component parser edges" `Quick component_parser_edges;
       test_case "media-not takes a media-in-parens" `Quick
         media_not_takes_media_in_parens;
+      test_case "negated all is level 4 not" `Quick negated_all_is_level4_not;
     ] )

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2311,14 +2311,14 @@ let c61_conditional_competitor_order () =
      media condition would change the winning declaration. *)
   Alcotest.(check string)
     "overlapping media competitors preserve authored order"
-    "@media not all and (width>=1024px){.u{display:flex}}@media not all and \
+    "@media not (width>=1024px){.u{display:flex}}@media not \
      (width>=640px){.u{display:grid}}"
     (optimized_string
        "@media not all and (min-width:1024px){.u{display:flex}}@media not all \
         and (min-width:640px){.u{display:grid}}");
   Alcotest.(check string)
     "reverse authored order is also preserved"
-    "@media not all and (width>=640px){.u{display:grid}}@media not all and \
+    "@media not (width>=640px){.u{display:grid}}@media not \
      (width>=1024px){.u{display:flex}}"
     (optimized_string
        "@media not all and (min-width:640px){.u{display:grid}}@media not all \
@@ -2415,7 +2415,7 @@ let target_minify_enforce_spec_split () =
     ~spec:"@media(min-width:700px){a{color:red}}";
   check_modes "media not all min-width grammar"
     "@media not all and (min-width: 700px) { a { color: red } }"
-    ~default:"@media not all and (width>=700px){a{color:red}}"
+    ~default:"@media not (width>=700px){a{color:red}}"
     ~spec:"@media not all and (min-width:700px){a{color:red}}";
   check_modes "media interval grammar"
     "@media (min-width: 768px) and (max-width: 1024px) { a { color: red } }"


### PR DESCRIPTION
Media Queries 4 sec. 2.1 makes `all` the identity media type, so `@media not all and (X)` and `@media not (X)` are the same query and default minify now emits the shorter Level 4 form. Keeping `not all and` protected a Level 3 parser that the same query already locks out by lowering `min-width` to range syntax, and `--enforce-spec` keeps both Level 3 spellings.
