### PR TITLE
css: resolve theme guards inside declaration at-rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,10 @@
   from inside `@keyframes`, `@page`, `@position-try` or `@supports-condition`,
   instead of leaving the name undefined in the emitted sheet
   ([#317](https://github.com/samoht/cascade/pull/317))
+- `Css.resolve_theme` drops a theme guard the keep-set rejects from
+  `@keyframes`, `@page`, `@position-try` and `@supports-condition`, instead of
+  printing it as a declaration the theme never selected
+  ([#324](https://github.com/samoht/cascade/pull/324))
 
 ### Canonical diff
 

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -936,6 +936,28 @@ let resolve_theme_guards_in_decls ~(theme : Pp.String_set.t option) decls =
           | d -> Option.Some d)
         decls
 
+let resolve_theme_guards_in_frames ~theme frames =
+  List.map
+    (fun (frame : Stylesheet.keyframe) ->
+      {
+        frame with
+        declarations = resolve_theme_guards_in_decls ~theme frame.declarations;
+      })
+    frames
+
+let resolve_theme_guards_in_margins ~theme margins =
+  List.map
+    (fun (margin : Stylesheet.page_margin_rule) ->
+      {
+        margin with
+        descriptors = resolve_theme_guards_in_decls ~theme margin.descriptors;
+      })
+    margins
+
+(* Listed one by one rather than closed with a wildcard, for the same reason as
+   [Stylesheet.statement_declarations]: a guard the keep-set rejects has to be
+   dropped wherever the declaration sits, and a wildcard would silently leak the
+   next declaration-carrying at-rule's guards into the output. *)
 let rec resolve_theme_guards_in_stmts ~theme = function
   | [] -> []
   | stmt :: rest ->
@@ -964,7 +986,29 @@ let rec resolve_theme_guards_in_stmts ~theme = function
             Moz_document (c, resolve_theme_guards_in_stmts ~theme b)
         | When (c, b) -> When (c, resolve_theme_guards_in_stmts ~theme b)
         | Else (c, b) -> Else (c, resolve_theme_guards_in_stmts ~theme b)
-        | other -> other
+        | Keyframes (n, frames) ->
+            Keyframes (n, resolve_theme_guards_in_frames ~theme frames)
+        | Webkit_keyframes (n, frames) ->
+            Webkit_keyframes (n, resolve_theme_guards_in_frames ~theme frames)
+        | Moz_keyframes (n, frames) ->
+            Moz_keyframes (n, resolve_theme_guards_in_frames ~theme frames)
+        | Page (sel, decls) ->
+            Page (sel, resolve_theme_guards_in_decls ~theme decls)
+        | Page_with_margins (sel, descriptors, margins) ->
+            Page_with_margins
+              ( sel,
+                resolve_theme_guards_in_decls ~theme descriptors,
+                resolve_theme_guards_in_margins ~theme margins )
+        | Position_try (n, decls) ->
+            Position_try (n, resolve_theme_guards_in_decls ~theme decls)
+        | Supports_condition (n, decls) ->
+            Supports_condition (n, resolve_theme_guards_in_decls ~theme decls)
+        | Property _ -> stmt
+        | Bang_comment _ | Charset _ | Import _ | Namespace _ | Layer_decl _
+        | Font_face _ | Counter_style _ | Font_palette_values _
+        | Font_feature_values _ | View_transition _ | Viewport _
+        | Unknown_at_rule _ ->
+            stmt
       in
       stmt :: resolve_theme_guards_in_stmts ~theme rest
 

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -671,6 +671,55 @@ let public_theme_edges () =
     |> Css.resolve_theme ~theme:brand_theme
     |> Css.optimize |> to_string ~minify:true)
 
+(* A theme guard is a compile-time filter on the declaration it wraps, so the
+   keep-set decides its fate wherever that declaration sits. [@keyframes],
+   [@page], [@position-try] and [@supports-condition] hold declarations directly
+   rather than in a nested block, so a walk that only descends through blocks
+   never reaches their guards and prints them as declarations the theme never
+   selected. *)
+let public_theme_guards_in_declaration_at_rules () =
+  let guarded () = theme_guarded ~var_name:"brand" (color (hex "#ff0000")) in
+  let resolved stmts =
+    v stmts
+    |> Css.resolve_theme ~theme:Css.Pp.String_set.empty
+    |> to_string ~minify:true
+  in
+  let frame : Stylesheet.keyframe =
+    {
+      selector = Keyframe.Positions [ Keyframe.From ];
+      declarations = [ guarded () ];
+    }
+  in
+  let margin : Stylesheet.page_margin_rule =
+    { name = "top-left"; descriptors = [ guarded () ] }
+  in
+  let cases =
+    [
+      ("@keyframes", [ Stylesheet.keyframes "k" [ frame ] ]);
+      ("@-webkit-keyframes", [ Stylesheet.Webkit_keyframes ("k", [ frame ]) ]);
+      ("@-moz-keyframes", [ Stylesheet.Moz_keyframes ("k", [ frame ]) ]);
+      ("@page", [ Stylesheet.Page ([], [ guarded () ]) ]);
+      ("@page margin box", [ Stylesheet.Page_with_margins ([], [], [ margin ]) ]);
+      ("@position-try", [ Stylesheet.Position_try ("--pt", [ guarded () ]) ]);
+      ( "@supports-condition",
+        [ Stylesheet.Supports_condition ("--sc", [ guarded () ]) ] );
+    ]
+  in
+  match
+    List.filter_map
+      (fun (name, stmts) ->
+        let printed = resolved stmts in
+        if Astring.String.is_infix ~affix:"color" printed then
+          Fmt.kstr Option.some "%s kept the guarded declaration: %S" name
+            printed
+        else Option.none)
+      cases
+  with
+  | [] -> ()
+  | kept ->
+      Alcotest.failf "theme guards left unresolved:\n%s"
+        (String.concat "\n" kept)
+
 let public_value_combinator_edges () =
   let _spacing_decl, spacing = var "spacing" Length (Rem 0.25) in
   let check_padding_calc ?optimized label expected calc =
@@ -1097,6 +1146,8 @@ let suite =
       Alcotest.test_case "public property introspection" `Quick
         public_property_edges;
       Alcotest.test_case "public theme guards" `Quick public_theme_edges;
+      Alcotest.test_case "public theme guards in declaration at-rules" `Quick
+        public_theme_guards_in_declaration_at_rules;
       Alcotest.test_case "public value combinators" `Quick
         public_value_combinator_edges;
       Alcotest.test_case "public theme var rendering" `Quick


### PR DESCRIPTION
`Css.resolve_theme` used to drop a theme guard the keep-set rejects only from style rules and the at-rules that nest a block; a guard inside `@keyframes`, `@page`, `@position-try` or `@supports-condition` survived and printed as an ordinary declaration the theme never selected. The walker now covers the at-rules that hold declarations directly, and is exhaustive so the next one cannot be missed silently.

Follow-up to #317, which fixed the same blind spot on the `var()` reference side.