### PR TITLE
shorthand: gate the vendor-alias drop on Baseline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,12 @@
   `min-width` to range syntax inside that very query. `--enforce-spec` keeps
   both Level 3 spellings
   ([#323](https://github.com/samoht/cascade/pull/323))
+- A vendor prefix is dropped only when its unprefixed twin is Baseline "widely
+  available", so `--minify` keeps the prefix a maintained browser still reads:
+  `-webkit-backdrop-filter`, `-webkit-user-select`, `-webkit-text-size-adjust`
+  and `-webkit-print-color-adjust` were dropped against an unprefixed twin no
+  shipping Safari understands
+  ([#325](https://github.com/samoht/cascade/pull/325))
 
 ### Custom properties
 

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3554,17 +3554,27 @@ let deduplicate_step kept (idx, decl) =
     if is_all_declaration decl then add_all_declaration_rev idx decl kept
     else (idx, decl) :: kept
 
-(* [vendor_alias_redundant vendor twin] is [true] when [vendor] is a
-   vendor-prefixed declaration made redundant by its unprefixed [twin] carrying
-   the same value and importance. Each pair is matched on both property
-   constructors so the two values share a type and compare with a typed (=) - no
-   rendering. [-webkit-appearance] is intentionally absent: its value type
-   [webkit_appearance] is a superset of [appearance] (extra non-standard values
-   like [listbox]/[checkbox]/[radio]), so there is no typed equality between the
-   two. [text-decoration] is also absent because dropping the WebKit copy
-   regresses documented inheritance quirks. *)
+(* [vendor_alias_twin vendor twin] is [true] when [vendor] is the
+   vendor-prefixed spelling of its unprefixed [twin], carrying the same value
+   and importance. Each pair is matched on both property constructors so the two
+   values share a type and compare with a typed (=) - no rendering. This
+   relation records only which constructors alias each other; whether the prefix
+   is then dead is a Baseline question, answered in [drop_vendor_aliases].
+
+   Absent on purpose:
+   - [-webkit-appearance]: its value type [webkit_appearance] is a superset of
+     [appearance] (extra non-standard values like [listbox]/[checkbox]/[radio]),
+     so there is no typed equality between the two.
+   - [-webkit-text-decoration]: dropping the WebKit copy regresses documented
+     inheritance quirks.
+   - [-webkit-background-clip]: its prefix is value-dependent, not
+     property-dependent. web-features tracks [background-clip-text] as its own
+     feature, so [background-clip] reads widely available at property
+     granularity while [-webkit-background-clip: text] is still the spelling
+     WebKit honours. Baseline cannot see that at property granularity, so the
+     pair stays out of the relation. *)
 (* WebKit animation longhand vendor-alias pairs ([-webkit-] vs unprefixed). *)
-let vendor_alias_redundant_webkit_animation vendor twin =
+let vendor_alias_twin_webkit_animation vendor twin =
   match (vendor, twin) with
   | ( Declaration { property = Webkit_animation; value = v1; important = i1; _ },
       Declaration { property = Animation; value = v2; important = i2; _ } ) ->
@@ -3629,7 +3639,7 @@ let vendor_alias_redundant_webkit_animation vendor twin =
   | _ -> false
 
 (* Mozilla animation longhand vendor-alias pairs ([-moz-] vs unprefixed). *)
-let vendor_alias_redundant_moz_animation vendor twin =
+let vendor_alias_twin_moz_animation vendor twin =
   match (vendor, twin) with
   | ( Declaration { property = Moz_animation; value = v1; important = i1; _ },
       Declaration { property = Animation; value = v2; important = i2; _ } ) ->
@@ -3688,13 +3698,13 @@ let vendor_alias_redundant_moz_animation vendor twin =
       v1 = v2 && Bool.equal i1 i2
   | _ -> false
 
-let vendor_alias_redundant_animation vendor twin =
-  vendor_alias_redundant_webkit_animation vendor twin
-  || vendor_alias_redundant_moz_animation vendor twin
+let vendor_alias_twin_animation vendor twin =
+  vendor_alias_twin_webkit_animation vendor twin
+  || vendor_alias_twin_moz_animation vendor twin
 
 (* Transition longhand vendor-alias pairs ([-webkit-]/[-moz-]/[-o-] vs
    unprefixed). *)
-let vendor_alias_redundant_transition vendor twin =
+let vendor_alias_twin_transition vendor twin =
   match (vendor, twin) with
   | ( Declaration { property = Webkit_transition; value = v1; important = i1; _ },
       Declaration { property = Transition; value = v2; important = i2; _ } ) ->
@@ -3760,7 +3770,7 @@ let vendor_alias_redundant_transition vendor twin =
   | _ -> false
 
 (* Modern flexbox alignment vendor-alias pairs (-webkit- vs unprefixed). *)
-let vendor_alias_redundant_flex vendor twin =
+let vendor_alias_twin_flex vendor twin =
   match (vendor, twin) with
   | ( Declaration
         { property = Webkit_flex_direction; value = v1; important = i1; _ },
@@ -3793,7 +3803,7 @@ let vendor_alias_redundant_flex vendor twin =
   | _ -> false
 
 (* Border-radius / box-shadow / background-size / filter vendor-alias pairs. *)
-let vendor_alias_redundant_visual vendor twin =
+let vendor_alias_twin_visual vendor twin =
   match (vendor, twin) with
   | ( Declaration
         { property = Webkit_border_radius; value = v1; important = i1; _ },
@@ -3825,10 +3835,29 @@ let vendor_alias_redundant_visual vendor twin =
       v1 = v2 && Bool.equal i1 i2
   | _ -> false
 
-let vendor_alias_redundant vendor twin =
+let vendor_alias_twin vendor twin =
   match (vendor, twin) with
   | ( Declaration { property = Webkit_transform; value = v1; important = i1; _ },
       Declaration { property = Transform; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_box_sizing; value = v1; important = i1; _ },
+      Declaration { property = Box_sizing; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Moz_box_sizing; value = v1; important = i1; _ },
+      Declaration { property = Box_sizing; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration
+        {
+          property = Webkit_text_decoration_color;
+          value = v1;
+          important = i1;
+          _;
+        },
+      Declaration
+        { property = Text_decoration_color; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_mask_image; value = v1; important = i1; _ },
+      Declaration { property = Mask_image; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | ( Declaration
         { property = Webkit_user_select; value = v1; important = i1; _ },
@@ -3851,10 +3880,10 @@ let vendor_alias_redundant vendor twin =
         { property = Print_color_adjust; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
   | _ ->
-      vendor_alias_redundant_animation vendor twin
-      || vendor_alias_redundant_transition vendor twin
-      || vendor_alias_redundant_flex vendor twin
-      || vendor_alias_redundant_visual vendor twin
+      vendor_alias_twin_animation vendor twin
+      || vendor_alias_twin_transition vendor twin
+      || vendor_alias_twin_flex vendor twin
+      || vendor_alias_twin_visual vendor twin
 
 (* If [name] starts with a CSS vendor prefix ([-webkit-] / [-moz-] / [-ms-] /
    [-o-]) return the unprefixed remainder; otherwise [None]. *)
@@ -3883,7 +3912,7 @@ let strip_vendor_prefix name =
    vendor [Unknown_property "-webkit-animation-delay"] + modern
    [Animation_delay]) needs typed vendor longhand properties to compare
    structurally; that remains a follow-up. *)
-let text_vendor_alias_redundant vendor twin =
+let text_vendor_alias_twin vendor twin =
   match (vendor, twin) with
   | ( Declaration
         { property = Unknown_property vname; value = vv; important = vi; _ },
@@ -3895,36 +3924,31 @@ let text_vendor_alias_redundant vendor twin =
       | None -> false)
   | _ -> false
 
-(* Vendor aliases whose unprefixed form is universally understood is a
-   pure-alias drop (always safe); pairs whose prefix an older browser may still
-   need are target-dependent and only drop under the opt-in targets axis. *)
-let vendor_alias_redundant_targeted vendor twin =
-  match (vendor, twin) with
-  | ( Declaration { property = Webkit_box_sizing; value = v1; important = i1; _ },
-      Declaration { property = Box_sizing; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | ( Declaration { property = Moz_box_sizing; value = v1; important = i1; _ },
-      Declaration { property = Box_sizing; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
-  | _ -> false
+(* An unprefixed property supersedes its prefix only once every maintained
+   browser reads it. {!Baseline.greenfield_properties}, generated from
+   web-features, lists the properties that are not yet Baseline "widely
+   available", which is exactly the set whose prefix is still load-bearing:
+   Safari reads only [-webkit-backdrop-filter] up to 17.6, and
+   [-webkit-text-size-adjust] has no unprefixed Safari support at all. *)
+let unprefixed_is_widely_available twin =
+  let name = String.lowercase_ascii_preserve (property_name twin) in
+  not (List.mem name Baseline.greenfield_properties)
 
 (* Drop a vendor-prefixed declaration when its unprefixed sibling appears in the
-   same rule with the same value and importance. The unprefixed form supersedes
-   in modern browsers, so the vendor copy is dead under the recent-browser
-   policy. *)
+   same rule with the same value and importance and is widely available. The
+   name is only rendered once the cheap typed twin match has fired. *)
 let drop_vendor_aliases ~ctx (kept : (int * declaration) list) :
     (int * declaration) list =
   if Ctx.enforce_spec ctx then kept (* spec-literal: keep every vendor prefix *)
   else
-    let has_unprefixed_twin (_, decl) =
+    let has_dead_prefix (_, decl) =
       List.exists
         (fun (_, other) ->
-          vendor_alias_redundant decl other
-          || text_vendor_alias_redundant decl other
-          || vendor_alias_redundant_targeted decl other)
+          (vendor_alias_twin decl other || text_vendor_alias_twin decl other)
+          && unprefixed_is_widely_available other)
         kept
     in
-    filter_preserve (fun item -> not (has_unprefixed_twin item)) kept
+    filter_preserve (fun item -> not (has_dead_prefix item)) kept
 
 (* Run every index-based composer against the same Rule_index so we pay one
    [build] + [to_list] per rule for the whole group. *)

--- a/test/cli/dead_code.t
+++ b/test/cli/dead_code.t
@@ -71,14 +71,24 @@ A later !important shadows an earlier !important of the same property.
   .x{color:#00f!important}
 
 A vendor-prefixed property followed by the unprefixed equivalent is
-NOT dead - the cascade picks whichever the browser understands. Both
-must round-trip.
+NOT dead while a maintained browser still reads only the prefix, which
+is what Baseline "widely available" decides. Safari reads only
+[-webkit-backdrop-filter] up to 17.6, so both must round-trip.
 
   $ cat > prefix.css <<EOF
-  > .x { -webkit-mask-image: url(a.png); mask-image: url(a.png) }
+  > .x { -webkit-backdrop-filter: blur(2px); backdrop-filter: blur(2px) }
   > EOF
   $ cascade --minify prefix.css
-  .x{-webkit-mask-image:url(a.png);mask-image:url(a.png)}
+  .x{-webkit-backdrop-filter:blur(2px);backdrop-filter:blur(2px)}
+
+The same pair is dead once the unprefixed property is widely available:
+no maintained browser reaches for the WebKit copy.
+
+  $ cat > prefix-dead.css <<EOF
+  > .x { -webkit-mask-image: url(a.png); mask-image: url(a.png) }
+  > EOF
+  $ cascade --minify prefix-dead.css
+  .x{mask-image:url(a.png)}
 
 
 # Rule-level dead code

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -855,6 +855,76 @@ let test_vendor_prefix_strip () =
     ".a{-moz-box-sizing:content-box;box-sizing:border-box}"
     (opt ".a{-moz-box-sizing:content-box;box-sizing:border-box}")
 
+(* The evergreen-target vendor drop is a Baseline question, not a hand-kept pair
+   list: a prefixed declaration is dead when its unprefixed twin sits in the
+   same rule with the same value and importance AND that unprefixed property is
+   Baseline "widely available". [Baseline.greenfield_properties] holds the
+   properties that are not, which is exactly the set whose prefix a maintained
+   browser may still need. *)
+let test_vendor_prefix_baseline_gate () =
+  let opt ?(enforce_spec = false) css =
+    match Css.of_string css with
+    | Ok p ->
+        Css.to_string ~minify:true (Css.optimize ~enforce_spec p.stylesheet)
+        |> String.trim
+    | Error _ -> Alcotest.fail "parse"
+  in
+  (* Widely available: every maintained browser reads the unprefixed form, so
+     the WebKit copy is dead weight. *)
+  Alcotest.(check string)
+    "text-decoration-color prefix drops" ".a{text-decoration-color:red}"
+    (opt ".a{-webkit-text-decoration-color:red;text-decoration-color:red}");
+  Alcotest.(check string)
+    "mask-image prefix drops" ".a{mask-image:none}"
+    (opt ".a{-webkit-mask-image:none;mask-image:none}");
+  (* box-sizing is the same rule and already collapses; keep it pinned. *)
+  Alcotest.(check string)
+    "webkit box-sizing prefix drops" ".a{box-sizing:border-box}"
+    (opt ".a{-webkit-box-sizing:border-box;box-sizing:border-box}");
+  Alcotest.(check string)
+    "moz box-sizing prefix drops" ".a{box-sizing:border-box}"
+    (opt ".a{-moz-box-sizing:border-box;box-sizing:border-box}");
+  (* Not widely available: [backdrop-filter] and [user-select] are both in
+     [Baseline.greenfield_properties], so their prefix is still load-bearing
+     (Safari reads only -webkit-backdrop-filter up to 17.6) and stays. *)
+  Alcotest.(check string)
+    "backdrop-filter prefix kept"
+    ".a{-webkit-backdrop-filter:blur(2px);backdrop-filter:blur(2px)}"
+    (opt ".a{-webkit-backdrop-filter:blur(2px);backdrop-filter:blur(2px)}");
+  Alcotest.(check string)
+    "user-select prefix kept" ".a{-webkit-user-select:none;user-select:none}"
+    (opt ".a{-webkit-user-select:none;user-select:none}");
+  (* --enforce-spec drops the evergreen target, so every prefix survives. *)
+  Alcotest.(check string)
+    "enforce-spec keeps the text-decoration-color prefix"
+    ".a{-webkit-text-decoration-color:red;text-decoration-color:red}"
+    (opt ~enforce_spec:true
+       ".a{-webkit-text-decoration-color:red;text-decoration-color:red}");
+  Alcotest.(check string)
+    "enforce-spec keeps the mask-image prefix"
+    ".a{-webkit-mask-image:none;mask-image:none}"
+    (opt ~enforce_spec:true ".a{-webkit-mask-image:none;mask-image:none}");
+  Alcotest.(check string)
+    "enforce-spec keeps the box-sizing prefix"
+    ".a{-webkit-box-sizing:border-box;box-sizing:border-box}"
+    (opt ~enforce_spec:true
+       ".a{-webkit-box-sizing:border-box;box-sizing:border-box}");
+  Alcotest.(check string)
+    "enforce-spec keeps the backdrop-filter prefix"
+    ".a{-webkit-backdrop-filter:blur(2px);backdrop-filter:blur(2px)}"
+    (opt ~enforce_spec:true
+       ".a{-webkit-backdrop-filter:blur(2px);backdrop-filter:blur(2px)}");
+  (* A twin only supersedes at the same value and the same importance, whatever
+     the Baseline status of the property. *)
+  Alcotest.(check string)
+    "differing value keeps the prefix"
+    ".a{-webkit-text-decoration-color:red;text-decoration-color:green}"
+    (opt ".a{-webkit-text-decoration-color:red;text-decoration-color:green}");
+  Alcotest.(check string)
+    "differing importance keeps the prefix"
+    ".a{-moz-box-sizing:border-box!important;box-sizing:border-box}"
+    (opt ".a{-moz-box-sizing:border-box!important;box-sizing:border-box}")
+
 let test_lossless_declaration_order () =
   let opt ?(lossless = false) css =
     match Css.of_string css with
@@ -1196,6 +1266,7 @@ let optimize_tests =
       `Quick,
       nesting_synthesis_can_be_disabled );
     ("vendor prefix strip", `Quick, test_vendor_prefix_strip);
+    ("vendor prefix baseline gate", `Quick, test_vendor_prefix_baseline_gate);
     ("lossless declaration order", `Quick, test_lossless_declaration_order);
     ( "lossless keeps unknown property order",
       `Quick,


### PR DESCRIPTION
Default `--minify` dropped `-webkit-backdrop-filter`, `-webkit-user-select`, `-webkit-text-size-adjust` and `-webkit-print-color-adjust` whenever the unprefixed twin sat in the same rule, which silently breaks pages on shipping Safari; the drop is now gated on that twin being Baseline "widely available", which in the other direction also retires `-webkit-text-decoration-color` and `-webkit-mask-image`.

`-webkit-background-clip` deliberately stays out of the alias relation: its prefix is value-dependent, and web-features tracks `background-clip-text` as its own feature, which property-granular Baseline cannot see. `test/cli/dead_code.t` illustrated a not-dead prefix with `-webkit-mask-image`, which is now dead, so its example moves to `-webkit-backdrop-filter`.
