### PR TITLE
apply: keep the projection rendering like its input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,26 @@
   holds directly; paired with `statement_children` it reaches every declaration
   in a stylesheet ([#317](https://github.com/samoht/cascade/pull/317))
 
+### CLI tools
+
+- `cascade apply` keeps the author declarations in source order when the
+  element carries a `style` attribute, empty ones included. They came out
+  reversed, so a longhand no longer beat the shorthand it was written after
+  and the projected page rendered differently from its input
+  ([#326](https://github.com/samoht/cascade/pull/326))
+- `cascade apply --minimal` keeps an inherited declaration whose property the
+  user-agent stylesheet declares for the element or for one of its ancestors.
+  css-cascade-5 sec. 6.1 sorts by origin before anything else, so such a
+  property is cascaded rather than inherited, and dropping the declaration
+  uncovered the UA value: link colour, heading size, `b` weight, `em` style,
+  `pre` family and `ol` marker all changed
+  ([#326](https://github.com/samoht/cascade/pull/326))
+- `cascade apply` reads a `style` attribute as a declaration list, so a `}`
+  inside it stays a preserved token (CSS Syntax 3 sec. 5.4) instead of closing
+  a synthetic rule. `style="color:red}p{color:lime"` applied `color:red`,
+  where the whole attribute is one invalid declaration a browser drops
+  ([#326](https://github.com/samoht/cascade/pull/326))
+
 ## 1.1.0
 
 ### Breaking

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -195,9 +195,9 @@ module Make (Node : Resolve.NODE) = struct
      beats a normal inline declaration). *)
   let resolved sheet n =
     let author = R.resolve sheet n in
-    match Node.attribute n "style" with
-    | None -> author
-    | Some s ->
+    match Option.map parse_inline (Node.attribute n "style") with
+    | None | Some [] -> author
+    | Some inline ->
         let overlay map d =
           let k = Declaration.property_name d in
           match List.assoc_opt k map with
@@ -207,9 +207,14 @@ module Make (Node : Resolve.NODE) = struct
               map
           | _ -> (k, d) :: List.remove_assoc k map
         in
+        (* The overlay accumulates in reverse so the closing [rev_map] hands
+           back the author order: css-cascade-5 sec. 6.1 breaks a tie by order
+           of appearance, so a longhand written after its shorthand still wins.
+           An overlaid declaration conses onto the front and so lands last,
+           where it beats the selector it met. *)
         List.fold_left overlay
-          (List.map (fun d -> (Declaration.property_name d, d)) author)
-          (parse_inline s)
+          (List.rev_map (fun d -> (Declaration.property_name d, d)) author)
+          inline
         |> List.rev_map snd
 
   (* [ctx] maps each inherited property to the value in force from the

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -61,6 +61,78 @@ let inherited =
 
 let is_inherited p = List.mem (String.lowercase_ascii p) inherited
 
+module SMap = Map.Make (String)
+
+(* The font and text block a form control takes from the UA. The [font]
+   shorthand sits with its longhands because it is an inherited property in its
+   own right, so an author [font:] on a control has to survive too. *)
+let ua_control =
+  [
+    "color";
+    "cursor";
+    "font";
+    "font-family";
+    "font-feature-settings";
+    "font-size";
+    "font-stretch";
+    "font-style";
+    "font-variant";
+    "font-weight";
+    "letter-spacing";
+    "line-height";
+    "text-align";
+    "text-indent";
+    "text-shadow";
+    "text-transform";
+    "word-spacing";
+  ]
+
+(* The inherited properties the user-agent stylesheet declares for an element,
+   read off a browser in standards mode. css-cascade-5 sec. 6.1 sorts by origin
+   before anything else and sec. 6.2 puts the UA origin under the author one, so
+   a property the UA declares for the element is cascaded there and never
+   inherited: the author declaration covering it has to stay. Over-listing an
+   entry only keeps a redundant declaration; missing one changes the render,
+   which is what the differential test guards. *)
+let ua_groups =
+  [
+    ([ "a" ], [ "color"; "cursor" ]);
+    ([ "address"; "cite"; "dfn"; "em"; "i"; "var" ], [ "font"; "font-style" ]);
+    ([ "b"; "strong" ], [ "font"; "font-weight" ]);
+    ([ "bdi"; "bdo" ], [ "direction" ]);
+    ([ "big"; "small"; "sub"; "sup" ], [ "font"; "font-size" ]);
+    ([ "button"; "input" ], ua_control);
+    ([ "caption"; "center" ], [ "text-align" ]);
+    ([ "code"; "kbd"; "samp"; "tt" ], [ "font"; "font-family" ]);
+    ([ "dialog"; "hr"; "mark" ], [ "color" ]);
+    ([ "dir"; "menu"; "ol"; "ul" ], [ "list-style"; "list-style-type" ]);
+    ( [ "h1"; "h2"; "h3"; "h4"; "h5"; "h6" ],
+      [ "font"; "font-size"; "font-weight" ] );
+    ([ "label" ], [ "cursor" ]);
+    ( [ "listing"; "plaintext"; "pre"; "xmp" ],
+      [ "font"; "font-family"; "white-space" ] );
+    ([ "marquee" ], [ "text-align"; "white-space" ]);
+    ([ "nobr" ], [ "white-space" ]);
+    ([ "optgroup" ], [ "font"; "font-weight" ]);
+    ([ "option" ], [ "font"; "font-weight"; "white-space" ]);
+    ( [ "rt" ],
+      [ "font"; "font-size"; "line-height"; "text-align"; "text-indent" ] );
+    ([ "ruby" ], [ "text-indent" ]);
+    ([ "select" ], "white-space" :: ua_control);
+    ([ "summary" ], [ "list-style"; "list-style-image"; "list-style-type" ]);
+    ([ "table" ], [ "border-collapse"; "border-spacing"; "text-indent" ]);
+    ([ "textarea" ], "overflow-wrap" :: "white-space" :: ua_control);
+    ([ "th" ], [ "font"; "font-weight"; "text-align" ]);
+  ]
+
+let ua_declared =
+  List.fold_left
+    (fun m (names, props) ->
+      List.fold_left
+        (fun m name -> SMap.add name (SSet.of_list props) m)
+        m names)
+    SMap.empty ua_groups
+
 (* CSS Syntax 3 sec. 5.4: a style attribute is a declaration list, not a rule
    body, so a declaration's value runs to the next top-level [;] or the end of
    input, where only [{], [(] and [[] open a block. A [}] is then a preserved
@@ -217,6 +289,21 @@ module Make (Node : Resolve.NODE) = struct
           inline
         |> List.rev_map snd
 
+  (* The inherited properties the UA declares for [node]: the ones its element
+     name carries, plus the [direction] a [dir] attribute maps onto it. *)
+  let ua_props node =
+    let named =
+      match Node.name node with
+      | None -> SSet.empty
+      | Some n -> (
+          match SMap.find_opt (String.lowercase_ascii n) ua_declared with
+          | Some props -> props
+          | None -> SSet.empty)
+    in
+    match Node.attribute node "dir" with
+    | Some _ -> SSet.add "direction" named
+    | None -> named
+
   (* [ctx] maps each inherited property to the value in force from the
      ancestors, so [minimal] can drop a declaration that only restates it. *)
   let rec walk ~minimal sheet ctx node acc =
@@ -230,17 +317,32 @@ module Make (Node : Resolve.NODE) = struct
         (fun acc child -> walk ~minimal sheet ctx child acc)
         acc (Node.children node)
     else begin
+      let decls = resolved sheet node in
+      let ua = ua_props node in
       let kept, ctx' =
         List.fold_left
           (fun (kept, ctx) d ->
             let p = String.lowercase_ascii (Declaration.property_name d) in
-            if minimal && is_inherited p then
+            if not (minimal && is_inherited p) then (d :: kept, ctx)
+            else
               let v = decl_value d in
-              match List.assoc_opt p ctx with
-              | Some pv when pv = v -> (kept, ctx)
-              | _ -> (d :: kept, (p, v) :: List.remove_assoc p ctx)
-            else (d :: kept, ctx))
-          ([], ctx) (resolved sheet node)
+              (* Inheritance only reaches a property nothing declares, so a
+                 value the UA would win back is not a restatement. *)
+              if (not (SSet.mem p ua)) && List.assoc_opt p ctx = Some v then
+                (kept, ctx)
+              else (d :: kept, (p, v) :: List.remove_assoc p ctx))
+          ([], ctx) decls
+      in
+      (* A UA declaration the element does not override is what its children
+         inherit, so the ancestors' value stops here. *)
+      let ctx' =
+        if SSet.is_empty ua then ctx'
+        else
+          let own = add_props SSet.empty decls in
+          SSet.fold
+            (fun p ctx ->
+              if SSet.mem p own then ctx else List.remove_assoc p ctx)
+            ua ctx'
       in
       let acc = (node, List.rev kept) :: acc in
       List.fold_left

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -61,13 +61,21 @@ let inherited =
 
 let is_inherited p = List.mem (String.lowercase_ascii p) inherited
 
+(* CSS Syntax 3 sec. 5.4: a style attribute is a declaration list, not a rule
+   body, so a declaration's value runs to the next top-level [;] or the end of
+   input, where only [{], [(] and [[] open a block. A [}] is then a preserved
+   token inside the value rather than a terminator, and splicing the attribute
+   into [a{...}] lets it close the rule instead, reviving a declaration no
+   browser applies. Recovery drops the invalid declaration and keeps the rest,
+   as the cascade does. *)
 let parse_inline s =
-  match Css.of_string ("a{" ^ s ^ "}") with
-  | Ok p -> (
-      match Stylesheet.rules p.Css.stylesheet with
-      | r :: _ -> Stylesheet.declarations r
-      | [] -> [])
-  | Error _ -> []
+  let cursor =
+    Cursor.of_string s |> Cursor.remaining
+    |> Cursor.of_components ~source:s ~recover:true
+  in
+  match Declaration.read_declarations cursor with
+  | decls -> decls
+  | exception Error.Parse_error _ -> []
 
 let decl_value d =
   let s =

--- a/test/inline/fixtures/style_attr.html
+++ b/test/inline/fixtures/style_attr.html
@@ -1,0 +1,12 @@
+<!doctype html><html><head><style>
+  .shorthand { margin: 0; margin-top: 5px;
+               border: 1px solid black; border-color: red;
+               font: 12px/1 serif; font-size: 20px }
+  .inset     { position: relative; inset: 0; top: 4px }
+  .malformed { color: blue }
+</style></head>
+<body>
+  <p class="shorthand" style="color:green">longhand after shorthand</p>
+  <p class="inset" style="color:green">top after inset</p>
+  <p class="malformed" style="color:red}p{color:lime">malformed style attribute</p>
+</body></html>

--- a/test/inline/fixtures/ua.html
+++ b/test/inline/fixtures/ua.html
@@ -1,0 +1,21 @@
+<!doctype html><html><head><style>
+  body { color: blue; font-size: 16px; font-weight: 400; font-style: normal;
+         white-space: normal; list-style-type: disc; text-indent: 10px;
+         font-family: serif }
+  a    { color: blue }
+  h1   { font-size: 16px }
+  b    { font-weight: 400 }
+  em   { font-style: normal }
+  pre  { white-space: normal; font-family: serif }
+  code { font-family: serif }
+  ol   { list-style-type: disc }
+  table { text-indent: 10px }
+</style></head>
+<body>
+  <a href="#">link</a>
+  <h1>head</h1>
+  <p><b>bold</b> <em>emph</em> <code>code</code></p>
+  <pre>pre</pre>
+  <ol><li>one</li></ol>
+  <table><tr><td>cell</td></tr></table>
+</body></html>

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -101,9 +101,11 @@ let keeps_stateful_rule_inside_layer_in_css () =
   Alcotest.(check int) "kept count" 1 result.kept
 
 (* The inline style [css] projects onto a single [p.x], as a minified
-   declaration list. *)
-let projected css =
-  let n = node ~classes:[ "x" ] "p" in
+   declaration list. [style] is the style attribute the element already
+   carries. *)
+let projected ?style css =
+  let attrs = match style with None -> [] | Some s -> [ ("style", s) ] in
+  let n = node ~classes:[ "x" ] ~attrs "p" in
   let result = A.compute ~sheet:(parse css) [ n ] in
   match result.styles with
   | [ (_, decls) ] -> inline_style decls
@@ -166,6 +168,65 @@ let non_competing_layers_both_project () =
   Alcotest.(check string)
     "both layers contribute" "color:red;margin:0"
     (projected "@layer a{.x{color:red}}@layer b{.x{margin:0}}")
+
+(* css-cascade-5 sec. 6.1: declarations that tie on origin, importance, layer
+   and specificity are sorted by order of appearance, the last one winning. The
+   style attribute is overlaid on top of the author cascade, it does not reorder
+   it: a longhand written after the shorthand it belongs to still wins, whether
+   or not the element carries a style attribute. *)
+let style_attribute_keeps_author_order () =
+  Alcotest.(check string)
+    "author order, then the attribute"
+    "margin:0;margin-top:5px;border:1px solid \
+     black;border-color:red;color:green"
+    (projected ~style:"color:green"
+       ".x{margin:0;margin-top:5px;border:1px solid black;border-color:red}");
+  Alcotest.(check string)
+    "the control: the same sheet with no attribute to overlay"
+    "margin:0;margin-top:5px;border:1px solid black;border-color:red"
+    (projected
+       ".x{margin:0;margin-top:5px;border:1px solid black;border-color:red}")
+
+(* CSS Syntax 3 sec. 5.4: consuming a declaration takes component values to the
+   end of the input, and only [{], [(] and [[] open a block there - a [}] is a
+   preserved token inside the value. A style attribute is one such list, so
+   [color:red}p{color:lime] is a single [color] declaration whose value is
+   invalid, and it is dropped. Splicing the attribute into [a{...}] instead lets
+   the [}] close the rule and revives a declaration no browser applies. *)
+let malformed_style_attribute_is_dropped () =
+  Alcotest.(check string)
+    "the whole attribute is one invalid declaration" "color:blue"
+    (projected ~style:"color:red}p{color:lime" ".x{color:blue}");
+  Alcotest.(check string)
+    "the control: the same attribute with nothing to escape from" "color:red"
+    (projected ~style:"color:red" ".x{color:blue}")
+
+(* [minimal] drops an inherited declaration that restates what the element
+   already inherits. That is only sound where nothing else declares the
+   property: css-cascade-5 sec. 6.1 sorts by origin before anything else and
+   sec. 6.2 puts the UA origin under the author one, so a property the UA
+   declares for the element is cascaded, never inherited. Dropping
+   [a{color:blue}] uncovers the UA link colour and dropping [h1{font-size}]
+   uncovers UA [font-size:2em]. *)
+let minimal_keeps_what_a_ua_rule_would_win () =
+  let a = node ~attrs:[ ("href", "#") ] "a" in
+  let h1 = node "h1" in
+  let p = node "p" in
+  let body = node ~children:[ a; h1; p ] "body" in
+  let css =
+    "body{color:blue;font-size:16px}a{color:blue}h1{font-size:16px}p{color:blue}"
+  in
+  let result = A.compute ~minimal:true ~sheet:(parse css) [ body ] in
+  let style n =
+    match List.find_opt (fun (m, _) -> Node.equal m n) result.styles with
+    | Some (_, decls) -> inline_style decls
+    | None -> Alcotest.fail "no assignment for the node"
+  in
+  Alcotest.(check string)
+    "the UA link colour is underneath" "color:blue" (style a);
+  Alcotest.(check string) "UA h1 is font-size:2em" "font-size:16px" (style h1);
+  Alcotest.(check string)
+    "the control: no UA rule sets a paragraph's colour" "" (style p)
 
 (* The whole split of [css] over [roots]: the style attribute written onto [n],
    the <style> body kept beside it, and the count of kept rules. *)
@@ -330,6 +391,12 @@ let suite =
         layer_outranks_specificity;
       Alcotest.test_case "non-competing layers both project" `Quick
         non_competing_layers_both_project;
+      Alcotest.test_case "style attribute keeps author order" `Quick
+        style_attribute_keeps_author_order;
+      Alcotest.test_case "malformed style attribute is dropped" `Quick
+        malformed_style_attribute_is_dropped;
+      Alcotest.test_case "minimal keeps what a UA rule would win" `Quick
+        minimal_keeps_what_a_ua_rule_would_win;
       Alcotest.test_case "keeps the property a scoped rule sets" `Quick
         keeps_property_a_scoped_rule_sets;
       Alcotest.test_case "keeps the property a starting-style rule sets" `Quick


### PR DESCRIPTION
`cascade apply` produced markup that renders differently from the input page: the author declarations came out reversed on an element carrying a `style` attribute, `--minimal` dropped an inherited declaration the user-agent origin then won back, and a `}` inside a `style` attribute escaped the rule it was spliced into.

One commit per bug, each checked against a real browser by the new `test/inline` fixtures.
