### PR TITLE
css: bind theme defaults past a non-cascading declaration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,11 @@
 
 ### Custom properties
 
+- `Css.resolve_theme` emits the root theme binding for a name whose only
+  declaration sits in `@keyframes` or `@position-try`. Those belong to the
+  animation and position fallback origins, so they never defined the name for
+  the element referencing it, which was left with a free `var()`
+  ([#327](https://github.com/samoht/cascade/pull/327))
 - `Css.inline_vars` preserves runtime-marked `var()` references, including
   typed fallbacks simplified through scalar values or shorthands, instead of
   replacing browser-time override points with compile-time defaults

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1088,7 +1088,21 @@ let theme_defaults_source defaults =
   in
   ":root{" ^ body ^ "}"
 
-(* Names declared as a custom property anywhere in the tree (bare, no [--]). *)
+(* The declarations a statement contributes to ordinary element matching. Unlike
+   [Stylesheet.statement_declarations], which reaches every declaration in the
+   tree, this stops at the at-rules whose declarations belong to another cascade
+   origin or to no element at all (CSS Cascading 5 sec. 6.1): [@keyframes] is
+   the animation origin, [@position-try] the position fallback origin, [@page]
+   and its margin boxes are not elements, and [@supports-condition] is never
+   applied to a box. None of them declares a name for an element that merely
+   references it. *)
+let cascading_declarations (stmt : Stylesheet.statement) =
+  match stmt with
+  | Stylesheet.Rule rule -> rule.declarations
+  | Stylesheet.Declarations decls -> decls
+  | _ -> []
+
+(* Names a style rule declares as a custom property (bare, no [--]). *)
 let declared_custom_prop_names (stmts : Stylesheet.statement list) :
     (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create 16 in
@@ -1101,7 +1115,7 @@ let declared_custom_prop_names (stmts : Stylesheet.statement list) :
       decls
   in
   let rec scan (stmt : Stylesheet.statement) =
-    note (Stylesheet.statement_declarations stmt);
+    note (cascading_declarations stmt);
     List.iter scan (Stylesheet.statement_children stmt)
   in
   List.iter scan stmts;

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -240,6 +240,42 @@ let spec_theme_binding_inside_keyframes () =
     ":root{--w:10px}@layer l{@keyframes k{0%{width:var(--w)}}}"
     (render "@layer l { @keyframes k { from { width: var(--w) } } }")
 
+(* CSS Cascading 5 sec. 6.1: a declaration inside [@keyframes] belongs to the
+   animation origin and one inside [@position-try] to the position fallback
+   origin, so neither applies to an element that merely references the name.
+   Only a style rule declares a custom property for ordinary matching, so those
+   at-rules must not suppress the root binding: suppressed, the reference is
+   left free and the property falls back to its initial value. *)
+let spec_theme_binding_past_non_cascading_declaration () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let theme_defaults = function "w" -> Some "10px" | _ -> None in
+  let render css =
+    parse css
+    |> Css.resolve_theme ~theme:Css.Pp.String_set.empty ~theme_defaults
+    |> Css.to_string ~minify:true
+  in
+  let bound = ".a{width:10px}" in
+  Alcotest.(check string)
+    "no declaration anywhere" bound
+    (render ".a { width: var(--w) }");
+  Alcotest.(check string)
+    "keyframe declaration does not suppress the binding"
+    ("@keyframes k{0%{--w:1px}}" ^ bound)
+    (render "@keyframes k { from { --w: 1px } } .a { width: var(--w) }");
+  Alcotest.(check string)
+    "position-try declaration does not suppress the binding"
+    ("@position-try --pt{--w:1px}" ^ bound)
+    (render "@position-try --pt { --w: 1px } .a { width: var(--w) }");
+  (* A style rule does declare the name for ordinary matching, so the reference
+     stays live for the elements the cascade may reach. *)
+  Alcotest.(check string)
+    "rule declaration keeps the reference live" ".b{--w:1px}.a{width:var(--w)}"
+    (render ".b { --w: 1px } .a { width: var(--w) }")
+
 (* Not a roundtrip test *)
 let test_vars_of_declarations () =
   let custom_color_decl, color_var =
@@ -517,6 +553,9 @@ let tests =
     ( "spec theme binding inside keyframes",
       `Quick,
       spec_theme_binding_inside_keyframes );
+    ( "spec theme binding past non-cascading declaration",
+      `Quick,
+      spec_theme_binding_past_non_cascading_declaration );
     ("vars of declarations", `Quick, test_vars_of_declarations);
     ("any_var_name", `Quick, test_any_var_name);
     ("extract custom declarations", `Quick, test_extract_custom_declarations);


### PR DESCRIPTION
`Css.resolve_theme` used to treat a custom property declared anywhere in the tree as defining that name, so a `--w` declared only inside `@keyframes` or `@position-try` suppressed the root binding and left `.a{width:var(--w)}` referencing a name the sheet never defines, dropping the property to its initial value. Those declarations belong to the animation and position fallback origins, so only a style rule counts now.

Regression from #317, which routed this walker through `statement_declarations`; the `var()` reference side that #317 fixed is unchanged.