### PR TITLE
media: classify a negated media query by what it matches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,10 @@
   instead of with the lower bound it negates, and a doubled `not` cancels.
   `Css.Media.sort_key`, `group_order` and `compare` follow
   ([#328](https://github.com/samoht/cascade/pull/328))
+- The negation of a width range, such as `not (640px <= width <= 1024px)`,
+  classifies as `Other`: it matches the viewports on either side of the range,
+  which no single bound describes
+  ([#328](https://github.com/samoht/cascade/pull/328))
 - `Css.Stylesheet.statement_declarations` returns the declarations a statement
   holds directly; paired with `statement_children` it reaches every declaration
   in a stylesheet ([#317](https://github.com/samoht/cascade/pull/317))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,11 @@
 
 ### Library
 
+- `Css.Media.kind` classifies a negated width bound by the side it bounds, so
+  `not (min-width: 640px)` groups and sorts with the upper bounds it matches
+  instead of with the lower bound it negates, and a doubled `not` cancels.
+  `Css.Media.sort_key`, `group_order` and `compare` follow
+  ([#328](https://github.com/samoht/cascade/pull/328))
 - `Css.Stylesheet.statement_declarations` returns the declarations a statement
   holds directly; paired with `statement_children` it reaches every declaration
   in a stylesheet ([#317](https://github.com/samoht/cascade/pull/317))

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -1210,10 +1210,29 @@ let feature_kind (f : feature) : kind =
           | Interval (lo, _, name, _, _) -> interval_feature_kind name lo
           | Range _ | Range_rev _ | General_enclosed _ -> Other))
 
+(* Media Queries 4 sec. 3: [not] matches the complement, so negating a width
+   bound swaps the side it bounds. Only [width] records a side; the other
+   buckets name a feature rather than a bound, so a negated query keeps the
+   bucket its feature picks. *)
+let negated_feature_kind (f : feature) : kind =
+  let flipped =
+    match feature_bound f with
+    | Some (name, Lower, _, value) -> width_bound_kind name Upper value
+    | Some (name, Upper, _, value) -> width_bound_kind name Lower value
+    | None -> None
+  in
+  Option.value flipped ~default:(feature_kind f)
+
 let rec condition_kind (c : condition) : kind =
   match c with
   | Feature f -> feature_kind f
-  | Not c -> condition_kind c
+  | Not (Feature f) -> negated_feature_kind f
+  | Not (Not c) -> condition_kind c
+  | Not ((And _ | Or _) as c) -> (
+      match condition_kind c with
+      | Responsive (u, v) -> Responsive_max (u, v)
+      | Responsive_max (u, v) -> Responsive (u, v)
+      | k -> k)
   | And (a, b) | Or (a, b) -> (
       match (condition_kind a, condition_kind b) with
       | Other, other | other, Other -> other
@@ -1221,14 +1240,10 @@ let rec condition_kind (c : condition) : kind =
 
 let kind : t -> kind = function
   | Cond c -> condition_kind c
-  (* [not all and X] negates a single feature: a negated width lower bound
-     covers the complementary upper range, so it classifies as [Responsive_max]
-     and vice versa. *)
-  | Type { prefix = Some Not; type_ = All; trailing = Some c } -> (
-      match condition_kind c with
-      | Responsive (u, v) -> Responsive_max (u, v)
-      | Responsive_max (u, v) -> Responsive (u, v)
-      | other -> other)
+  (* [all] matches every medium, so [not all and X] matches the complement of
+     [X], exactly like the bare [not X]. *)
+  | Type { prefix = Some Not; type_ = All; trailing = Some c } ->
+      condition_kind (Not c)
   | Type _ | List _ -> Other
 
 let group_order = function
@@ -1283,21 +1298,18 @@ let preference_order : t -> int = function
   | Type { trailing = Some c; _ } -> condition_preference_order c
   | Type _ | List _ -> 30
 
-(* Within a responsive bucket, a negated lower bound sorts first, then an upper
-   bound, then a lower bound. *)
+(* Within a responsive bucket, an upper bound written as a negated lower bound
+   sorts first, then a plain upper bound, then a lower bound. *)
 let condition_subkind (c : condition) : int =
-  match condition_kind c with
-  | Responsive_max _ -> 1
-  | Responsive _ -> 2
+  match (c, condition_kind c) with
+  | Not _, Responsive_max _ -> 0
+  | _, Responsive_max _ -> 1
   | _ -> 2
 
 let responsive_subkind : t -> int = function
   | Cond c -> condition_subkind c
-  | Type { prefix = Some Not; type_ = All; trailing = Some c } -> (
-      (* [not all and (min-width)] is a negated lower-bound query. *)
-      match condition_kind c with
-      | Responsive _ -> 0
-      | _ -> 2)
+  | Type { prefix = Some Not; type_ = All; trailing = Some c } ->
+      condition_subkind (Not c)
   | Type { trailing = Some c; _ } -> condition_subkind c
   | Type _ | List _ -> 2
 

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -1226,13 +1226,12 @@ let negated_feature_kind (f : feature) : kind =
 let rec condition_kind (c : condition) : kind =
   match c with
   | Feature f -> feature_kind f
-  | Not (Feature f) -> negated_feature_kind f
   | Not (Not c) -> condition_kind c
-  | Not ((And _ | Or _) as c) -> (
-      match condition_kind c with
-      | Responsive (u, v) -> Responsive_max (u, v)
-      | Responsive_max (u, v) -> Responsive (u, v)
-      | k -> k)
+  (* The complement of a width range is the two ranges outside it, and an
+     [and]/[or] takes its kind from one operand, so the complement of that
+     leaves the other operand's range uncovered. Neither is a single bound. *)
+  | Not (Feature (Interval _)) | Not (And _ | Or _) -> Other
+  | Not (Feature f) -> negated_feature_kind f
   | And (a, b) | Or (a, b) -> (
       match (condition_kind a, condition_kind b) with
       | Other, other | other, Other -> other

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -143,6 +143,63 @@ let test_kind () =
     | Preference_accessibility -> true
     | _ -> false)
 
+let pp_kind ppf : kind -> unit = function
+  | Hover -> Fmt.string ppf "interaction"
+  | Responsive (unit_ord, v) ->
+      Fmt.pf ppf "lower width bound (%d, %g)" unit_ord v
+  | Responsive_max (unit_ord, v) ->
+      Fmt.pf ppf "upper width bound (%d, %g)" unit_ord v
+  | Preference_accessibility -> Fmt.string ppf "accessibility preference"
+  | Preference_appearance -> Fmt.string ppf "appearance preference"
+  | Other -> Fmt.string ppf "other"
+
+let kind_testable = Alcotest.testable pp_kind equal_kind
+
+(* Media Queries 4 sec. 2.1 and sec. 3: [all] is the identity media type and
+   [not] negates the condition it wraps, so [not all and (X)] and [not (X)]
+   match the same viewports and a doubled [not] cancels. The bucket a query
+   sorts into follows what it matches, never how it is spelled: [not (min-width:
+   640px)] matches viewports narrower than 640px, bounding width from above like
+   [(max-width: 640px)] rather than from below. *)
+let kind_follows_meaning_not_spelling () =
+  let kind_of source = kind (of_string source) in
+  let check name expected source =
+    Alcotest.check kind_testable name expected (kind_of source)
+  in
+  let bounds name side source =
+    Alcotest.(check bool) name true (side (kind_of source))
+  in
+  let from_below = function Responsive _ -> true | _ -> false in
+  let from_above = function Responsive_max _ -> true | _ -> false in
+  (* Guards: the un-negated forms fix which constructor each side of a bound is,
+     so the negated cases can be stated against them and a fix that flips every
+     width query fails here. *)
+  bounds "(min-width: 640px) bounds from below" from_below "(min-width: 640px)";
+  bounds "(max-width: 640px) bounds from above" from_above "(max-width: 640px)";
+  bounds "(width >= 640px) bounds from below" from_below "(width >= 640px)";
+  bounds "(width < 640px) bounds from above" from_above "(width < 640px)";
+  check "(hover) bounds no width" Hover "(hover)";
+  check "print bounds no width" Other "print";
+  let lower_640 = kind_of "(min-width: 640px)" in
+  let upper_640 = kind_of "(width < 640px)" in
+  (* One query, two spellings. *)
+  check "not (min-width: 640px) matches width < 640px" upper_640
+    "not (min-width: 640px)";
+  check "not all and (min-width: 640px) matches width < 640px" upper_640
+    "not all and (min-width: 640px)";
+  (* Two negations cancel, leaving the lower bound they wrap. *)
+  check "not (not (min-width: 640px)) matches width >= 640px" lower_640
+    "not (not (min-width: 640px))";
+  check "not all and not (min-width: 640px) matches width >= 640px" lower_640
+    "not all and not (min-width: 640px)";
+  (* A sort consumes [group_order], which reads the kind, so a query classified
+     by spelling is grouped with the queries it is the complement of. *)
+  let group source = fst (group_order (kind_of source)) in
+  Alcotest.(check int)
+    "not (min-width: 640px) groups with (max-width: 640px)"
+    (group "(max-width: 640px)")
+    (group "not (min-width: 640px)")
+
 let test_compare () =
   let cmp = compare (min_width 640.) (min_width 768.) in
   Alcotest.(check bool) "640 < 768" true (cmp < 0)
@@ -382,6 +439,8 @@ let suite =
       test_case "spec media query error recovery vectors" `Quick
         spec_media_error_recovery_vectors;
       test_case "kind" `Quick test_kind;
+      test_case "kind follows meaning not spelling" `Quick
+        kind_follows_meaning_not_spelling;
       test_case "compare" `Quick test_compare;
       test_case "sort_key" `Quick test_sort_key;
       test_case "spec media sorting edges" `Quick test_spec_media_sorting_edges;

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -200,6 +200,31 @@ let kind_follows_meaning_not_spelling () =
     (group "(max-width: 640px)")
     (group "not (min-width: 640px)")
 
+(* Media Queries 4 sec. 3: [not] matches the complement, and the complement of a
+   width range is not a range. [not ((min-width: 640px) and (max-width:
+   1024px))] matches the viewports narrower than 640px together with those wider
+   than 1024px, and the [or] form matches nothing at all; neither is a single
+   bound. Minification folds the two operands into the Level 4 interval and [not
+   all and X] into [not X], so every spelling has to agree. *)
+let negated_range_bounds_neither_side () =
+  let kind_of source = kind (of_string source) in
+  let bounds_neither name source =
+    Alcotest.check kind_testable name Other (kind_of source)
+  in
+  (* Guard: the range on its own is a bound, so [Other] below comes from the
+     negation and not from a shape the classifier never read. *)
+  Alcotest.check kind_testable "(640px <= width <= 1024px) bounds from below"
+    (kind_of "(min-width: 640px)")
+    (kind_of "(640px <= width <= 1024px)");
+  bounds_neither "not ((min-width: 640px) and (max-width: 1024px))"
+    "not ((min-width: 640px) and (max-width: 1024px))";
+  bounds_neither "not (640px <= width <= 1024px)"
+    "not (640px <= width <= 1024px)";
+  bounds_neither "not all and (min-width: 640px) and (max-width: 1024px)"
+    "not all and (min-width: 640px) and (max-width: 1024px)";
+  bounds_neither "not ((min-width: 640px) or (max-width: 1024px))"
+    "not ((min-width: 640px) or (max-width: 1024px))"
+
 let test_compare () =
   let cmp = compare (min_width 640.) (min_width 768.) in
   Alcotest.(check bool) "640 < 768" true (cmp < 0)
@@ -441,6 +466,8 @@ let suite =
       test_case "kind" `Quick test_kind;
       test_case "kind follows meaning not spelling" `Quick
         kind_follows_meaning_not_spelling;
+      test_case "negated range bounds neither side" `Quick
+        negated_range_bounds_neither_side;
       test_case "compare" `Quick test_compare;
       test_case "sort_key" `Quick test_sort_key;
       test_case "spec media sorting edges" `Quick test_spec_media_sorting_edges;


### PR DESCRIPTION
`Css.Media.kind` used to drop the `not` from a condition, so `@media not (min-width: 640px)` was classified as the lower bound it negates and sorted with `(min-width: 640px)` instead of with the upper bounds it matches. Callers that sort on `Css.Media.sort_key`, `group_order` or `compare` see the new order; cascade's own output over the interop corpus is unchanged, and so is tw's.