### PR TITLE
apply: --minimal must not drop a value that resolves per element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,13 @@
   a synthetic rule. `style="color:red}p{color:lime"` applied `color:red`,
   where the whole attribute is one invalid declaration a browser drops
   ([#326](https://github.com/samoht/cascade/pull/326))
+- `cascade apply --minimal` keeps an inherited declaration whose value resolves
+  against the element it lands on, instead of dropping it as a restatement of
+  the ancestor's identical text. A font-relative unit, a percentage,
+  `larger`/`bolder`, a container unit, `var()`, `light-dark()` and
+  `currentColor` inside `color-mix()` each name two values across two elements,
+  so `div{font-size:2em}div p{font-size:2em}` halved the paragraph
+  ([#329](https://github.com/samoht/cascade/pull/329))
 
 ## 1.1.0
 

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -157,6 +157,69 @@ let decl_value d =
   | Some i -> String.sub s (i + 1) (String.length s - i - 1)
   | None -> s
 
+(* Colour functions (css-color-4 sec. 4 to 12, css-color-5 sec. 3): their
+   arguments are channel coordinates, so a percentage or an angle inside one is
+   not a fraction of anything the element decides. [light-dark()] is absent on
+   purpose - it reads the inherited [color-scheme]. *)
+let color_functions =
+  [
+    "rgb";
+    "rgba";
+    "hsl";
+    "hsla";
+    "hwb";
+    "lab";
+    "lch";
+    "oklab";
+    "oklch";
+    "color";
+    "color-mix";
+  ]
+
+(* css-values-4 sec. 5.2: the absolute length units. Every other unit resolves
+   against something the declaration does not carry - the element's own font
+   (sec. 6.1), the root's, the viewport (sec. 6.2), the query container (sec.
+   6.4) - so a unit this list does not name counts as relative, and so does one
+   CSS grows later. *)
+let absolute_units = [ "px"; "cm"; "mm"; "q"; "in"; "pt"; "pc" ]
+
+(* Keywords that read a value off another element: css-fonts-4 sec. 3.5 scales
+   [larger]/[smaller] off the parent font size and sec. 3.2 steps
+   [bolder]/[lighter] off the parent weight. css-color-4 sec. 15 resolves
+   [currentcolor] against the element's own [color], which [color-mix()] then
+   bakes into the computed value. *)
+let relative_keywords =
+  [ "larger"; "smaller"; "bolder"; "lighter"; "currentcolor" ]
+
+(* Whether the value [v] computes to the same thing wherever it lands. The
+   restatement check below compares an ancestor's value with a descendant's as
+   written, and the two elements differ in font, in query container and in the
+   custom properties in scope, so [2em], [5cqw] and [var(--x)] each name two
+   values. The scan whitelists: a shape it does not recognise is relative. *)
+let element_independent v =
+  let lexer = Lexer.of_string v in
+  (* [stack] holds, per open paren, whether it is a colour function's. *)
+  let rec scan stack =
+    let in_color = match stack with c :: _ -> c | [] -> false in
+    match (Lexer.next lexer).Token.kind with
+    | Token.Eof -> true
+    | Token.Function f ->
+        List.mem (String.lowercase_ascii f) color_functions
+        && scan (true :: stack)
+    | Token.Open Token.Paren -> scan (in_color :: stack)
+    | Token.Close Token.Paren ->
+        scan (match stack with _ :: rest -> rest | [] -> [])
+    | Token.Percentage _ -> in_color && scan stack
+    | Token.Dimension { unit_; _ } ->
+        (in_color || List.mem (String.lowercase_ascii unit_) absolute_units)
+        && scan stack
+    | Token.Ident i ->
+        (not (List.mem (String.lowercase_ascii i) relative_keywords))
+        && scan stack
+    | _ -> scan stack
+  in
+  scan []
+
 let add_props acc ds =
   List.fold_left
     (fun acc d ->
@@ -327,9 +390,14 @@ module Make (Node : Resolve.NODE) = struct
             else
               let v = decl_value d in
               (* Inheritance only reaches a property nothing declares, so a
-                 value the UA would win back is not a restatement. *)
-              if (not (SSet.mem p ua)) && List.assoc_opt p ctx = Some v then
-                (kept, ctx)
+                 value the UA would win back is not a restatement, and equal
+                 text is only equal computed values where nothing in it resolves
+                 against the element. *)
+              if
+                (not (SSet.mem p ua))
+                && List.assoc_opt p ctx = Some v
+                && element_independent v
+              then (kept, ctx)
               else (d :: kept, (p, v) :: List.remove_assoc p ctx))
           ([], ctx) decls
       in

--- a/test/inline/fixtures/relative.html
+++ b/test/inline/fixtures/relative.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+<head><style>
+  /* Every pair below writes the same text on an ancestor and a descendant, so
+     --minimal sees a restatement. Each value resolves against the element it
+     lands on, so the two computed values differ. */
+  html { font-size: 2rem }
+  #em         { font-size: 2em }
+  #em i       { font-size: 2em }
+  #pct        { font-size: 150% }
+  #pct i      { font-size: 150% }
+  #kw         { font-size: larger; font-weight: bolder }
+  #kw i       { font-size: larger; font-weight: bolder }
+  #rem        { font-size: 2rem }
+  #rem i      { font-size: 2rem }
+  #font       { font-size: 12px; letter-spacing: 1ex; word-spacing: 1ch;
+                text-indent: 1em; line-height: 1.5em; tab-size: 2em }
+  #font i     { font-size: 24px; letter-spacing: 1ex; word-spacing: 1ch;
+                text-indent: 1em; line-height: 1.5em; tab-size: 2em }
+  #calc       { font-size: 12px; letter-spacing: calc(1em + 2px) }
+  #calc i     { font-size: 24px; letter-spacing: calc(1em + 2px) }
+  #var        { --tone: red; color: var(--tone) }
+  #var span   { --tone: lime }
+  #var i      { color: var(--tone) }
+  #cq         { container-type: inline-size; width: 400px; text-indent: 5cqw }
+  #cq span    { container-type: inline-size; width: 100px; display: block }
+  #cq i       { text-indent: 5cqw }
+  #scheme     { color-scheme: light; color: light-dark(black, white) }
+  #scheme span{ color-scheme: dark }
+  #scheme i   { color: light-dark(black, white) }
+  #mix        { color: color-mix(in srgb, currentColor, white) }
+  #mix i      { color: color-mix(in srgb, currentColor, white) }
+  /* Controls: values with nothing to resolve, which --minimal may drop. */
+  #abs        { font-size: 12px; color: hsl(210 40% 96%); font-weight: 700 }
+  #abs i      { font-size: 12px; color: hsl(210 40% 96%); font-weight: 700 }
+  #num        { font-size: 12px; line-height: 1.5 }
+  #num i      { font-size: 24px; line-height: 1.5 }
+</style></head>
+<body>
+  <p id="em">a <i>b</i></p>
+  <p id="pct">a <i>b</i></p>
+  <p id="kw">a <i>b</i></p>
+  <p id="rem">a <i>b</i></p>
+  <p id="font">a <i>b</i></p>
+  <p id="calc">a <i>b</i></p>
+  <p id="var">a <span>c <i>b</i></span></p>
+  <div id="cq">a <span>c <i>b</i></span></div>
+  <p id="scheme">a <span>c <i>b</i></span></p>
+  <p id="mix">a <i>b</i></p>
+  <p id="abs">a <i>b</i></p>
+  <p id="num">a <i>b</i></p>
+</body>
+</html>

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -228,6 +228,61 @@ let minimal_keeps_what_a_ua_rule_would_win () =
   Alcotest.(check string)
     "the control: no UA rule sets a paragraph's colour" "" (style p)
 
+(* [minimal] compares the value as written, but a relative one resolves against
+   the element it lands on, so the same text one level down is a different
+   computed value. css-values-4 sec. 6.1 makes a font-relative unit a multiple
+   of the element's own font, and [rem] a multiple of the root's - which the
+   ancestor holding the value may itself be, where [font-size] instead resolves
+   against the initial value. Sec. 6.4 makes a container unit a fraction of the
+   query container, which an element in between can become. A percentage
+   resolves against a per-property basis, and css-fonts-4 sec. 3.5 reads the
+   parent outright for [larger] and [bolder]. A [var()] reads a custom property
+   an element in between can redefine, [light-dark()] reads the inherited
+   [color-scheme], and [currentColor] inside [color-mix()] is resolved at
+   computed-value time rather than carried through.
+
+   Chrome 146 on [div{font-size:2em}div p{font-size:2em}]: the paragraph
+   computes 64px, and 32px once the declaration is dropped. *)
+let minimal_keeps_a_relative_value () =
+  let projected ?(parent = "div") decl =
+    let child = node "p" in
+    let root = node ~children:[ child ] parent in
+    let css =
+      String.concat "" [ parent; "{"; decl; "}"; parent; " p{"; decl; "}" ]
+    in
+    let result = A.compute ~minimal:true ~sheet:(parse css) [ root ] in
+    match List.find_opt (fun (m, _) -> Node.equal m child) result.styles with
+    | Some (_, decls) -> inline_style decls
+    | None -> Alcotest.failf "no assignment for the child of %s" parent
+  in
+  let kept ?parent decl =
+    Alcotest.(check string) decl decl (projected ?parent decl)
+  in
+  let dropped ?parent decl =
+    Alcotest.(check string) decl "" (projected ?parent decl)
+  in
+  kept "font-size:2em";
+  kept "font-size:150%";
+  kept "font-size:larger";
+  kept "font-weight:bolder";
+  kept "letter-spacing:1ex";
+  kept "letter-spacing:calc(1em + 2px)";
+  kept "text-indent:5cqw";
+  kept "color:var(--tone)";
+  kept "color:light-dark(black,white)";
+  kept "color:color-mix(in srgb,currentcolor,white)";
+  (* [rem] on the root: [html{font-size:2rem}] is twice the initial font size, a
+     descendant's [2rem] twice that. *)
+  kept ~parent:"html" "font-size:2rem";
+  (* Nothing left to resolve, so the restatement goes. A percentage inside a
+     colour function is a channel coordinate, not a fraction of the element. *)
+  dropped "font-size:16px";
+  dropped "font-weight:700";
+  dropped "line-height:1.5";
+  dropped "letter-spacing:normal";
+  dropped "color:hsl(210 40% 96%)";
+  dropped "color:#f1f5f9"
+
 (* The whole split of [css] over [roots]: the style attribute written onto [n],
    the <style> body kept beside it, and the count of kept rules. *)
 let check_split name ?roots ~css ~inline ~keep ~kept n =
@@ -397,6 +452,8 @@ let suite =
         malformed_style_attribute_is_dropped;
       Alcotest.test_case "minimal keeps what a UA rule would win" `Quick
         minimal_keeps_what_a_ua_rule_would_win;
+      Alcotest.test_case "minimal keeps a relative value" `Quick
+        minimal_keeps_a_relative_value;
       Alcotest.test_case "keeps the property a scoped rule sets" `Quick
         keeps_property_a_scoped_rule_sets;
       Alcotest.test_case "keeps the property a starting-style rule sets" `Quick


### PR DESCRIPTION
`cascade apply --minimal` compares an ancestor's inherited value with a descendant's as written, so it dropped `div p{font-size:2em}` under `div{font-size:2em}` and Chrome then rendered the paragraph at half the size; it now drops only a value with nothing left to resolve against the element. Follow-up to #326.