### PR TITLE
Cite the spec sections the comments claim

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@
 ### Minification
 
 - `@media not all and (X)` minifies to the Level 4 `@media not (X)`. `all` is
-  the identity media type (Media Queries 4 sec. 2.1), so the two spell the same
+  the identity media type (Media Queries 4 sec. 2.3), so the two spell the same
   query, and default minify already spends Level 3 compatibility by lowering
   `min-width` to range syntax inside that very query. `--enforce-spec` keeps
   both Level 3 spellings
@@ -257,7 +257,7 @@
   the flag identical (#271)
 - It rewrites a quoted multi-word font name in a custom property as the
   `<ident>` sequence it unquotes to, the same family name under CSS Fonts 4
-  sec. 15.3: `--font-sans: ui-sans-serif, "Noto Color Emoji"` and
+  sec. 2.1.1: `--font-sans: ui-sans-serif, "Noto Color Emoji"` and
   `--font-sans: ui-sans-serif, Noto Color Emoji` reach one form. The structural
   comparator already folded the two together; the projection did not (#290)
 - Under `--lossless` it keys a `color(srgb ...)` whose channels land on whole

--- a/fuzz/fuzz_properties.ml
+++ b/fuzz/fuzz_properties.ml
@@ -491,7 +491,7 @@ let property_grammar_animation_vectors =
       Css.Properties.pp_overscroll_behavior
       [ "auto"; "contain"; "none" ]
       (* [overscroll-behavior] shorthand allows 1-2 axis values per CSS
-         Overscroll Behavior 1 section 5.1; [contain auto none] is the
+         Overscroll Behavior 1 section 4.1; [contain auto none] is the
          three-value invalid form, [hidden] is not a valid value. *)
       [ "contain auto none"; "hidden" ];
   ]

--- a/fuzz/fuzz_values.ml
+++ b/fuzz/fuzz_values.ml
@@ -403,7 +403,7 @@ let assert_color_branch input =
             serialized
       | Some reparsed ->
           (* After one minification pass the color is in its canonical short
-             form (CSS Color 4 section 12.1 hex shortening, etc.), so further
+             form (CSS Color 4 section 5.2 hex shortening, etc.), so further
              passes must be idempotent at the string level. Direct AST equality
              with [color] does not hold for shortenable inputs like "#112233" ->
              "#123". *)
@@ -680,10 +680,10 @@ let calc_identity_targets =
     ("flex-grow", "var(--a)", Some "0");
   ]
 
-(* CSS Values 4 sec. 10.7 identity law: wrapping a value in a value-independent
-   identity ([x * 1], [1 * x], [x / 1], [x + 0], [0 + x], [x - 0]) and
-   optimising lands on the same normal form as optimising the bare value - the
-   [var()] reference and the [calc()] wrapper survive, only the redundant
+(* CSS Values 4 sec. 10.10.1 identity law: wrapping a value in a
+   value-independent identity ([x * 1], [1 * x], [x / 1], [x + 0], [0 + x], [x -
+   0]) and optimising lands on the same normal form as optimising the bare value
+   - the [var()] reference and the [calc()] wrapper survive, only the redundant
    arithmetic folds. Drives the shared [Values.calc_identity] through every
    evaluator the optimize pass reaches, so the generic and per-type folds cannot
    drift. *)

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -356,7 +356,7 @@ let rec collect_empty_layer_names names remaining =
 
 (* Merge consecutive Layer_decl statements *)
 let merge_layer_declarations (stmts : statement list) : statement list =
-  (* CSS Cascade 5 sec. 6.6.2: [@layer A, B;] declares layers in source order;
+  (* CSS Cascade 5 sec. 6.4.4.2: [@layer A, B;] declares layers in source order;
      re-declaring a layer name is a no-op for cascade order. Merge consecutive
      [@layer ...;] statements and dedupe repeated names so [@layer u; @layer u]
      emits one [@layer u]. *)
@@ -479,10 +479,10 @@ let drop_empty_rules stmts =
       | _ -> true)
     stmts
 
-(* CSS Cascade 5 sec. 6.6.3: a [@layer <name>;] declaration form is
-   prelude-friendly and may interleave with [@charset] / [@import] /
-   [@namespace], so a [Layer_decl] before [@import] / [@namespace] must not flip
-   [seen_body] - otherwise the following [@import] gets dropped as misplaced. *)
+(* CSS Cascade 5 sec. 2: a [@layer <name>;] declaration form is prelude-friendly
+   and may interleave with [@charset] / [@import] / [@namespace], so a
+   [Layer_decl] before [@import] / [@namespace] must not flip [seen_body] -
+   otherwise the following [@import] gets dropped as misplaced. *)
 let drop_misplaced_imports stmts =
   let seen_body = ref false in
   let seen_import_or_namespace = ref false in

--- a/lib/color_space.ml
+++ b/lib/color_space.ml
@@ -1,8 +1,8 @@
 (** Static colour-space conversion arithmetic for the optimiser.
 
-    All matrices and constants are the CSS Color 4 sections 8-16 reference
-    values. The conversions are pure floating-point arithmetic; no CSS syntax
-    knowledge lives here. *)
+    All matrices and constants are the CSS Color 4 sec. 19 reference values. The
+    conversions are pure floating-point arithmetic; no CSS syntax knowledge
+    lives here. *)
 
 type rgb = float * float * float
 type xyz = float * float * float
@@ -14,7 +14,7 @@ let matrix_mul ((a, b, c), (d, e, f), (g, h, i)) (x, y, z) =
     (d *. x) +. (e *. y) +. (f *. z),
     (g *. x) +. (h *. y) +. (i *. z) )
 
-(* sRGB <-> linear-sRGB. CSS Color 4 sec. 11.5.1. *)
+(* sRGB <-> linear-sRGB. CSS Color 4 sec. 10.2. *)
 
 let linear_of_srgb v =
   let s = Float.copy_sign 1.0 v in
@@ -34,7 +34,7 @@ let linear_rgb_of_rgb (r, g, b) =
 let rgb_of_linear_rgb (r, g, b) =
   (srgb_of_linear r, srgb_of_linear g, srgb_of_linear b)
 
-(* Linear sRGB <-> XYZ-D65. CSS Color 4 sec. 9.1 reference matrix. *)
+(* Linear sRGB <-> XYZ-D65. CSS Color 4 sec. 19 reference matrix. *)
 
 let m_xyz65_of_linear_srgb =
   ( (0.4123907992659593, 0.357584339383878, 0.1804807884018343),
@@ -49,7 +49,7 @@ let m_linear_srgb_of_xyz65 =
 let xyz65_of_linear_srgb rgb = matrix_mul m_xyz65_of_linear_srgb rgb
 let linear_srgb_of_xyz65 xyz = matrix_mul m_linear_srgb_of_xyz65 xyz
 
-(* Display-P3 <-> XYZ-D65. CSS Color 4 sec. 10.4 reference matrix. The
+(* Display-P3 <-> XYZ-D65. CSS Color 4 sec. 19 reference matrix. The
    non-linearity is identical to sRGB. *)
 
 let linear_of_display_p3 = linear_of_srgb
@@ -68,7 +68,7 @@ let m_xyz65_p3 =
 let xyz65_of_linear_p3 rgb = matrix_mul m_p3_xyz65 rgb
 let linear_p3_of_xyz65 xyz = matrix_mul m_xyz65_p3 xyz
 
-(* A98-RGB <-> XYZ-D65. CSS Color 4 sec. 10.2: the non-linearity is a fixed
+(* A98-RGB <-> XYZ-D65. CSS Color 4 sec. 10.6: the non-linearity is a fixed
    [256/563] power, equivalent to a gamma of [1/(563/256)] = [1/2.1992...]. *)
 
 let a98_rgb_gamma = 563.0 /. 256.0
@@ -94,7 +94,7 @@ let m_linear_a98_of_xyz65 =
 let xyz65_of_linear_a98 rgb = matrix_mul m_xyz65_of_linear_a98 rgb
 let linear_a98_of_xyz65 xyz = matrix_mul m_linear_a98_of_xyz65 xyz
 
-(* ProPhoto-RGB <-> XYZ-D50. CSS Color 4 sec. 10.3: piecewise gamma with toe at
+(* ProPhoto-RGB <-> XYZ-D50. CSS Color 4 sec. 10.7: piecewise gamma with toe at
    [1/512] and a fixed 1.8 exponent above. *)
 
 let linear_of_prophoto_rgb v =
@@ -120,7 +120,7 @@ let m_xyz50_prophoto =
 let xyz50_of_linear_prophoto rgb = matrix_mul m_prophoto_xyz50 rgb
 let linear_prophoto_of_xyz50 xyz = matrix_mul m_xyz50_prophoto xyz
 
-(* Rec2020 <-> XYZ-D65. CSS Color 4 sec. 10.5: piecewise gamma with a low-end
+(* Rec2020 <-> XYZ-D65. CSS Color 4 sec. 10.8: piecewise gamma with a low-end
    linear segment and a 1/0.45 power for the upper segment. *)
 
 let rec2020_alpha = 1.09929682680944
@@ -151,7 +151,7 @@ let m_linear_rec2020_of_xyz65 =
 let xyz65_of_linear_rec2020 rgb = matrix_mul m_xyz65_of_linear_rec2020 rgb
 let linear_rec2020_of_xyz65 xyz = matrix_mul m_linear_rec2020_of_xyz65 xyz
 
-(* XYZ chromatic adaptation, Bradford method. CSS Color 4 sec. 16.4. *)
+(* XYZ chromatic adaptation, Bradford method. CSS Color 4 sec. 19. *)
 
 let m_d50_of_xyz65 =
   ( (1.0479298208405488, 0.022946793341019088, -0.05019222954313557),
@@ -166,7 +166,7 @@ let m_d65_of_xyz50 =
 let d50_of_xyz65 xyz = matrix_mul m_d50_of_xyz65 xyz
 let d65_of_xyz50 xyz = matrix_mul m_d65_of_xyz50 xyz
 
-(* CIE Lab <-> XYZ-D50. CSS Color 4 sec. 8.2 with D50 white point. *)
+(* CIE Lab <-> XYZ-D50. CSS Color 4 sec. 19 with D50 white point. *)
 
 let lab_kappa = 24389.0 /. 27.0
 let lab_epsilon = 216.0 /. 24389.0
@@ -194,7 +194,7 @@ let xyz50_of_lab (l, a, b) =
   let wx, wy, wz = lab_d50_white in
   (wx *. f_lab_inv fx, wy *. f_lab_inv fy, wz *. f_lab_inv fz)
 
-(* OKLab <-> linear sRGB. CSS Color 4 sec. 8.3: a two-stage matrix with a
+(* OKLab <-> linear sRGB. CSS Color 4 sec. 19: a two-stage matrix with a
    cube-root non-linearity sandwiched between the two stages. *)
 
 let m_linear_srgb_to_lms =
@@ -229,8 +229,8 @@ let linear_srgb_of_oklab lab =
   let l, m, s = matrix_mul m_oklab_to_lms lab in
   matrix_mul m_lms_to_linear_srgb (l *. l *. l, m *. m *. m, s *. s *. s)
 
-(* Lab / LCH polar form. CSS Color 4 sec. 8.4 (CIE Lab) and sec. 8.6 (OKLab)
-   share the same polar transform. *)
+(* Lab / LCH polar form. CSS Color 4 sec. 9.5: CIE Lab and OKLab share the same
+   polar transform. *)
 
 let lch_of_lab (l, a, b) =
   let c = Float.sqrt ((a *. a) +. (b *. b)) in
@@ -274,7 +274,7 @@ let srgb_bytes_of_linear ?(budget = 0.002) (linear : rgb) :
     then Some (rb, gb, bb)
     else None
 
-(* Hue interpolation. CSS Color 4 sec. 12.4. *)
+(* Hue interpolation. CSS Color 4 sec. 13.4. *)
 
 type hue_interpolation = Shorter | Longer | Increasing | Decreasing
 

--- a/lib/color_space.mli
+++ b/lib/color_space.mli
@@ -1,8 +1,8 @@
 (** Static colour-space conversion arithmetic for the optimiser.
 
-    Implements the matrices and gamma-correction functions in CSS Color 4
-    sections 8-16. All functions operate on [float] triples where each component
-    is the canonical floating-point representation for the named space (sRGB /
+    Implements the matrices and gamma-correction functions in CSS Color 4 sec.
+    19. All functions operate on [float] triples where each component is the
+    canonical floating-point representation for the named space (sRGB /
     Display-P3 in [[0, 1]], XYZ in tristimulus units, Lab L* in [[0, 100]],
     OKLab L in [[0, 1]], hue in degrees, ...).
 
@@ -18,7 +18,7 @@ type lch = float * float * float
 (** {1 sRGB} *)
 
 val linear_of_srgb : float -> float
-(** CSS Color 4 sec. 11.5.1: [<R G B>] in [[0, 1]] linearised via the standard
+(** CSS Color 4 sec. 10.2: [<R G B>] in [[0, 1]] linearised via the standard
     [(v + 0.055) / 1.055)^2.4] curve below the toe at [0.04045]. *)
 
 val srgb_of_linear : float -> float
@@ -135,7 +135,7 @@ val srgb_bytes_of_linear : ?budget:float -> rgb -> (int * int * int) option
 (** {1 Hue interpolation} *)
 
 type hue_interpolation =
-  | Shorter  (** Default per CSS Color 4 sec. 12.4. *)
+  | Shorter  (** Default per CSS Color 4 sec. 13.4. *)
   | Longer
   | Increasing
   | Decreasing

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -381,7 +381,7 @@ let style_leaf_boolean components =
   match style_strip_ws components with
   | [ name_component ] -> (
       match ident_component name_component with
-      (* CSS Conditional Rules 5 section 4.4: a boolean [style()] query tests
+      (* CSS Conditional Rules 5 section 6.2: a boolean [style()] query tests
          whether a custom property has any value, so the ident must start with
          [--]. A bare property name like [style(color)] is not a valid boolean
          form. *)

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -673,7 +673,7 @@ let kind_equal : type a b.
   | Properties.Font_src, Properties.Font_src -> Some Refl
   | _ -> None
 
-(* CSS Cascade 5 sec. 6.4 lists inherited properties; the rest default to the
+(* CSS Cascade 5 sec. 7.2 lists inherited properties; the rest default to the
    property's initial value when no value is supplied. *)
 let property_is_inherited = function
   | "color" | "cursor" | "direction" | "font-family" | "font-feature-settings"
@@ -1432,7 +1432,7 @@ module Media_value = struct
         | _ -> None)
 end
 
-(** {2 [@supports] evaluation (CSS Conditional 4 sec. 3)}
+(** {2 [@supports] evaluation (CSS Conditional 3 sec. 6)}
 
     Each [Supports.t] constructor has a dedicated evaluator. The structural
     cases ([Not]/[And]/[Or]) recurse into [eval]; the leaves ([Property]/[Func])
@@ -1530,7 +1530,7 @@ module Match_media = struct
     | List qs -> List.exists (eval q) qs
 end
 
-(** {2 Container-query evaluation (CSS Containment 3 sec. 3.4)}
+(** {2 Container-query evaluation (CSS Conditional 5 sec. 5.4)}
 
     Container queries reuse the media-feature evaluator applied to the container
     feature table; they additionally guard on the container name (when supplied)
@@ -1760,7 +1760,7 @@ module Url = struct
         Ok (Uri.resolve "" (Uri.of_string base) reference |> Uri.to_string)
 end
 
-(** {2 [@import] loader (CSS Cascade 5 sec. 6)}
+(** {2 [@import] loader (CSS Cascade 5 sec. 2)}
 
     Resolves the import URL through {!Url}, looks up the body in
     [loader.imports], parses it, and applies any media/supports/layer guards on

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -655,7 +655,7 @@ let media_queries t =
 
 (* AST Introspection Helpers *)
 
-(* CSS Cascade 6 sec. 6.4.3: a dotted layer name [foo.bar] is shorthand for the
+(* CSS Cascade 5 sec. 6.4.2: a dotted layer name [foo.bar] is shorthand for the
    nested [@layer foo { @layer bar { ... } }]. Walk the @layer tree once,
    expanding dotted names and prefixing each block with its parent's path, so
    [foo.bar] is reachable under one canonical name whatever the input shape. *)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -655,7 +655,7 @@ type calc_op = Values.calc_op = Add | Sub | Mul | Div
     [calc(6.28318530718)]. *)
 type math_const = Values.math_const = Pi | E | Infinity | Neg_infinity | Nan
 
-(** CSS Values 4 sec. 10.7 numeric math function arguments. *)
+(** CSS Values 4 sec. 9.1 numeric math function arguments. *)
 type math_arg = Values.math_arg =
   | Lit of float
   | Dim of float * string  (** A dimension argument (e.g. [1vw], [1%]). *)
@@ -665,7 +665,7 @@ type math_arg = Values.math_arg =
   | Parens_arg of math_arg
   | Math_call of math_fn
 
-(** CSS Values 4 sec. 10.7 numeric math functions. *)
+(** CSS Values 4 sec. 9.1 numeric math functions. *)
 and math_fn = Values.math_fn =
   | Sin of angle_arg
   | Cos of angle_arg
@@ -707,8 +707,7 @@ type 'a calc = 'a Values.calc =
   | Expr of 'a calc * calc_op * 'a calc
   | Nested of 'a calc  (** Explicitly nested calc() *)
   | Parens of 'a calc  (** Parenthesized expression *)
-  | Math_fn of math_fn
-      (** CSS Values 4 sec. 10.7 numeric math function call. *)
+  | Math_fn of math_fn  (** CSS Values 4 sec. 9.1 numeric math function call. *)
 
 type component_values = Component.t list
 (** Parsed CSS component values preserved for fallback and invalid-value
@@ -859,7 +858,7 @@ type length = Values.length =
   | Anchor of string option * string * length option
       (** CSS [anchor()] function: optional anchor name, side, and fallback. *)
   | Attr of length attr_call
-      (** CSS [attr()] in typed value contexts (CSS Values 5 sec. 10). *)
+      (** CSS [attr()] in typed value contexts (CSS Values 5 sec. 8.7). *)
   | Env of length env  (** CSS [env()] reference. *)
   | Var of length var  (** CSS variable reference *)
   | Calc of length calc  (** Calculated expressions *)
@@ -2075,7 +2074,7 @@ type break_inside_value = Properties.break_inside_value =
 val break_inside : break_inside_value -> declaration
 (** [break_inside v] is the break-inside property. *)
 
-(** CSS Fragmentation 3 sec. 6 deprecated [page-break-before / -after] alias
+(** CSS Fragmentation 3 sec. 3.4 deprecated [page-break-before / -after] alias
     vocabulary; the shorter value list makes these their own type rather than
     overload {!type-break_value}. *)
 type page_break_value = Properties.page_break_value =
@@ -2086,8 +2085,8 @@ type page_break_value = Properties.page_break_value =
   | Right
   | Inherit
   | Var of page_break_value var
-      (** CSS Fragmentation 3 sec. 6 deprecated [page-break-inside] vocabulary.
-      *)
+      (** CSS Fragmentation 3 sec. 3.4 deprecated [page-break-inside]
+          vocabulary. *)
 
 type page_break_inside_value = Properties.page_break_inside_value =
   | Auto
@@ -2799,8 +2798,8 @@ type background_attachment = Properties.background_attachment =
   | Revert_layer
   | Var of background_attachment var
 
-(** CSS Color 5 section 12: hue-interpolation method for polar color spaces (lch
-    / oklch / hsl / hwb). *)
+(** CSS Color 5 section 9.1: hue-interpolation method for polar color spaces
+    (lch / oklch / hsl / hwb). *)
 type hue_interpolation_method = Properties.hue_interpolation_method =
   | Shorter
   | Longer
@@ -2918,7 +2917,7 @@ val conic_gradient_config :
 (** [conic_gradient_config ?angle ?position ?interpolation ()] builds a
     conic-gradient prefix. *)
 
-(** Per CSS Backgrounds and Borders 3 sec. 5. *)
+(** Per CSS Backgrounds and Borders 3 sec. 4.1. *)
 type border_radius = Properties.border_radius =
   | Radius of {
       horizontal : length_percentage list;

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -769,7 +769,7 @@ let enum ?default label table t =
   ws t;
   match peek t with
   | Some (Component.Preserved { kind = Token.Ident s; _ }) -> (
-      (* CSS idents are case-insensitive (Syntax section 3.3). *)
+      (* CSS idents are case-insensitive (CSS Values 4 section 4.1). *)
       match List.assoc_opt (String.lowercase_ascii_preserve s) table with
       | Some v ->
           let _ = next t in
@@ -807,7 +807,7 @@ let enum_or_calls ?default label idents ?(calls = []) t =
   ws t;
   match peek t with
   | Some (Component.Preserved { kind = Token.Ident s; _ }) -> (
-      (* CSS idents are case-insensitive (Syntax section 3.3). *)
+      (* CSS idents are case-insensitive (CSS Values 4 section 4.1). *)
       match List.assoc_opt (String.lowercase_ascii_preserve s) idents with
       | Some v ->
           let _ = next t in

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -583,7 +583,7 @@ let read_text_decoration_lines t =
   if duplicates lines then Cursor.err_invalid t "duplicate text-decoration-line";
   lines
 
-(* CSS Shapes 1 sec. 2.2: [<shape-box>] is [<visual-box> | margin-box], so the
+(* CSS Shapes 1 sec. 5: [<shape-box>] is [<visual-box> | margin-box], so the
    three SVG boxes [<geometry-box>] adds are not valid here. *)
 let check_shape_box t (box : clip_geometry_box) =
   match box with
@@ -593,7 +593,7 @@ let check_shape_box t (box : clip_geometry_box) =
 
 (* [read_clip_path] reads [<basic-shape> || <geometry-box>], the same double-bar
    pair shape-outside uses, along with [none], [url()] and the CSS-wide
-   keywords. Shapes 1 sec. 2 differs on two points, checked here: the box is a
+   keywords. Shapes 1 sec. 6.1 differs on two points, checked here: the box is a
    [<shape-box>], and everything outside [<basic-shape>] is an alternative to
    the pair rather than a member of it. *)
 let check_shape_outside_shape t =
@@ -616,7 +616,7 @@ let check_shape_outside_shape t =
       Cursor.err_invalid t "shape-outside pairs a <shape-box> with a shape"
   | _ -> ()
 
-(* CSS Shapes 1 sec. 2: [shape-outside] is [none | [<basic-shape> ||
+(* CSS Shapes 1 sec. 6.1: [shape-outside] is [none | [<basic-shape> ||
    <shape-box>] | <image>]. The value is the raw source text ([Shape_outside :
    string property]): typing it would mean a sum of the [clip_path] shapes and
    the whole [background_image] type for [<image>], so the reader validates the
@@ -682,9 +682,8 @@ let read_nn_length_or_global t =
     ~default:(read_non_negative_length ~with_keywords:false)
     t
 
-(* CSS Text 3 section 10: [letter-spacing] is [normal | <length>],
-   [word-spacing] is [normal | <length-percentage>]; both accept negative
-   values. *)
+(* CSS Text 3 section 7: [letter-spacing] is [normal | <length>], [word-spacing]
+   is [normal | <length-percentage>]; both accept negative values. *)
 let read_normal_or_length name t =
   Cursor.enum name
     [
@@ -713,7 +712,7 @@ let read_perspective_value t =
     ~default:(read_non_negative_length ~with_keywords:false)
     t
 
-(* CSS Text Decoration 4 sec. 5: [text-underline-offset] is [auto |
+(* CSS Text Decoration 4 sec. 2.8: [text-underline-offset] is [auto |
    <length-percentage>], and unlike the lengths above it may be negative. *)
 let read_underline_offset t =
   Cursor.enum "text-underline-offset"
@@ -847,7 +846,7 @@ let read_border_radius_vertical t =
       Some (read_border_radius_radii t)
   | _ -> None
 
-(* CSS Backgrounds and Borders 3 sec. 5: [border-radius =
+(* CSS Backgrounds and Borders 3 sec. 4.1: [border-radius =
    <length-percentage>{1,4} [/ <length-percentage>{1,4}]?]. Reads 1-4 horizontal
    radii then, after [/], 1-4 vertical radii. *)
 let rec read_border_radius (t : Cursor.t) : Properties.border_radius =
@@ -959,7 +958,7 @@ let read_color_value : type a. a property -> Cursor.t -> declaration option =
   | Color -> Some (v Color (read_color t))
   | Background_color -> Some (v Background_color (read_color t))
   | Border_color ->
-      (* CSS Backgrounds 3 sec. 4.4: [border-color] is a 1-4 value box shorthand
+      (* CSS Backgrounds 3 sec. 3.1: [border-color] is a 1-4 value box shorthand
          (top / right / bottom / left). *)
       Some (v Border_color (Cursor.list ~at_least:1 ~at_most:4 read_color t))
   | Outline_color -> Some (v Outline_color (read_color t))
@@ -2143,7 +2142,7 @@ let read_typed_property_declaration t start =
   Cursor.ws t;
   if not (Cursor.colon t) then Cursor.err_expected t "':'";
   Cursor.ws t;
-  (* CSS Syntax 3 sec. 5.3.7 / sec. 4.3.5 auto-close unterminated functions,
+  (* CSS Syntax 3 sec. 2.2 / sec. 4.3.5 auto-close unterminated functions,
      brackets and strings at EOF. Typed readers consume the spec-recovered
      tokens; the declaration survives with the auto-closed shape. *)
   match prop_type with
@@ -2245,7 +2244,7 @@ let read_declaration t : declaration option =
 
 (* Skip from the current cursor position to just past the next top-level [;], or
    stop at EOF. Used to recover from a failed declaration inside a block: per
-   CSS Syntax section 5.4.4 ("consume a list of declarations"), an invalid
+   CSS Syntax section 5.5.5 ("consume a block's contents"), an invalid
    declaration is dropped, parsing resumes at the next [;], and the surrounding
    rule survives. *)
 let skip_to_next_declaration t =

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -179,7 +179,7 @@ let read_function_arg name t =
     | None -> (Cursor.consume_remaining_as_string ~trim:true inner, false)
   in
   Cursor.expect_eof inner;
-  (* CSS Fonts 4 sec. 11.1: each of [local()] / [format()] / [tech()] takes
+  (* CSS Fonts 4 sec. 4.3: each of [local()] / [format()] / [tech()] takes
      exactly one argument, so an empty body ([format()], [local()]) is invalid.
      The one exception browsers accept is [local("")] - an explicit empty
      <string> family name - so keep that. *)

--- a/lib/keyframe.ml
+++ b/lib/keyframe.ml
@@ -62,8 +62,8 @@ let parse_percent s =
     | exception (Failure _ | Invalid_argument _) -> None
   else None
 
-(** Parse a [<timeline-range-name> <percentage>] string (Scroll-Driven
-    Animations 1 sec. 8.1). *)
+(** Parse a [<timeline-range-name> <percentage>] string (CSS Animations 2 sec.
+    3.2). *)
 let parse_timeline_range_position s =
   match String.index_opt s ' ' with
   | None -> None

--- a/lib/keyframe.mli
+++ b/lib/keyframe.mli
@@ -6,8 +6,8 @@ type position =
   | To  (** [to] or [100%] *)
   | Percent of float  (** Percentage like [50%] *)
   | Timeline_range of string * float
-      (** Scroll-Driven Animations 1 sec. 8.1
-          [<timeline-range-name> <percentage>] selector such as [entry 0%]. *)
+      (** CSS Animations 2 sec. 3.2 [<timeline-range-name> <percentage>]
+          selector such as [entry 0%]. *)
 
 val string_of_position : position -> string
 (** [string_of_position pos] renders a position as CSS string. *)

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -271,7 +271,7 @@ let scan_ident_slow r src buf =
   loop ();
   Buffer.contents buf
 
-(* 4.3.8 Consume an ident sequence, at the code-point level (section 4.2, see
+(* 4.3.12 Consume an ident sequence, at the code-point level (section 4.2, see
    [is_name_at]). Fast path (no [\] escape) returns [String.sub] of the source
    with no Buffer; the slow path seeds a Buffer with the copied prefix. *)
 let consume_ident_sequence r =

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -420,10 +420,10 @@ let pp_feature : feature Pp.t =
       pp_value ctx b;
       Pp.char ctx ')'
 
-(* CSS Media Queries 4 sec. 3.3: a lower and an upper bound on the same feature
-   combine into the two-sided [<value> <op> <name> <op> <value>] interval.
-   [feature_bound] normalises a single-bound feature into a [(name, side, op,
-   value)] view so two bounds can be paired. *)
+(* CSS Media Queries 4 sec. 2.4.3: a lower and an upper bound on the same
+   feature combine into the two-sided [<value> <op> <name> <op> <value>]
+   interval. [feature_bound] normalises a single-bound feature into a [(name,
+   side, op, value)] view so two bounds can be paired. *)
 type bound_side = Lower | Upper
 
 let feature_bound (f : feature) : (name * bound_side * cmp * value) option =
@@ -1061,10 +1061,10 @@ let feature name value : t =
 
 let boolean name : t = Cond (Feature (Boolean (name_of_string name)))
 
-(* CSS Media Queries 4 sec. 3.4 / 3.3: the optimizer rewrites [min-X]/[max-X]
-   into the range form and pairs a lower and upper bound into the two-sided
-   interval. Target-fact grammar upgrades, so they live in optimize (gated by
-   [~enforce_spec]), not the printer. *)
+(* CSS Media Queries 4 sec. 2.4.4 / 2.4.3: the optimizer rewrites
+   [min-X]/[max-X] into the range form and pairs a lower and upper bound into
+   the two-sided interval. Target-fact grammar upgrades, so they live in
+   optimize (gated by [~enforce_spec]), not the printer. *)
 let lower_feature : feature -> feature = function
   | Plain (Min base, v) -> Range (base, Ge, v)
   | Plain (Max base, v) -> Range (base, Le, v)
@@ -1098,7 +1098,7 @@ let rec lower_for_minify : t -> t = function
   | Cond c as query ->
       let c' = lower_condition c in
       if c' == c then query else Cond c'
-  (* CSS Media Queries 4 sec. 2.1: [all] is the identity media type, so [not all
+  (* CSS Media Queries 4 sec. 2.3: [all] is the identity media type, so [not all
      and (X)] is the Level 3 spelling of [not (X)]. Bare [not all] has no
      condition form and stays. *)
   | Type { prefix = Some Not; type_ = All; trailing = Some c } ->

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -3,11 +3,11 @@ open Stylesheet
 let contains sel =
   Selector.any (function Selector.Nesting -> true | _ -> false) sel
 
-(* CSS Nesting 1 sec. 2.1: [&] stands for [:is(<parent selector list>)]. A
-   parent that carries a combinator or lists alternatives needs that wrapper, or
-   its own structure escapes: dropping it turns [.dark &] over parent [.a .b]
-   into [.dark .a .b], which demands that [.a] itself sit inside [.dark]. Where
-   [&] heads the selector nothing can escape to its left, so the wrapper is
+(* CSS Nesting 1 sec. 4: [&] stands for [:is(<parent selector list>)]. A parent
+   that carries a combinator or lists alternatives needs that wrapper, or its
+   own structure escapes: dropping it turns [.dark &] over parent [.a .b] into
+   [.dark .a .b], which demands that [.a] itself sit inside [.dark]. Where [&]
+   heads the selector nothing can escape to its left, so the wrapper is
    redundant there and the parent goes in verbatim. *)
 let complex = function
   | Selector.List _ | Selector.Combined _ | Selector.Relative _ -> true
@@ -36,7 +36,7 @@ let substitute ?(leftmost = true) ~parent sel =
   let parent = if verbatim then parent else Selector.Is [ parent ] in
   Selector.map (function Selector.Nesting -> parent | s -> s) sel
 
-(* CSS Nesting 1 sec. 2: a nested selector list is relative to the parent branch
+(* CSS Nesting 1 sec. 3: a nested selector list is relative to the parent branch
    by branch, so [.p { a, b { ... } }] is [.p a, .p b]. Combining the parent
    with the list as a whole would put the combinator on the first branch only
    and let the rest escape as top-level selectors. *)

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -116,7 +116,7 @@ let factor_rules_incremental ?cache ~ctx rules =
 let canonicalize_scope_selector sel = Selector.canonicalize sel
 
 (* Nested rule selectors are implicitly relative to the parent [&], so drop a
-   redundant leading [& <combinator>] (CSS Nesting 1 sec. 2). *)
+   redundant leading [& <combinator>] (CSS Nesting 1 sec. 3). *)
 let drop_nesting_prefix (stmt : statement) : statement =
   match stmt with
   | Rule nr ->
@@ -389,7 +389,7 @@ and rules_aux ?factor_cache ~ctx ~enforce_spec (rules : rule list) : rule list =
      skipped the run or the transfer gate discarded its result. *)
   Rule.merge_adjacent_identical ~ctx factored
 
-(* CSS Animations 2 sec. 4.1: [@keyframes name] re-declaration overrides the
+(* CSS Animations 1 sec. 3: [@keyframes name] re-declaration overrides the
    earlier definition in source order. Drop earlier same-name keyframes; the
    later one wins. Vendor-prefixed [-webkit-] / [-moz-] variants are separate
    namespaces, so they are not dedup'd against the unprefixed form. *)
@@ -650,7 +650,7 @@ let try_promote_custom_with (type a) (syntax : a Variables.syntax) components =
 
 (* Does the registered syntax somewhere accept a [<custom-ident>] (possibly
    under [+] / [#] / [|] modifiers)? When yes, a [<string>] whose content is a
-   multi-word identifier sequence is spec-equivalent (CSS Fonts 4 sec. 15.3 for
+   multi-word identifier sequence is spec-equivalent (CSS Fonts 4 sec. 2.1.1 for
    font-family-shaped registrations), so the promotion pass rewrites it to the
    equivalent ident sequence before parsing. *)
 let rec syntax_accepts_ident_sequence : type a. a Variables.syntax -> bool =

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -374,7 +374,7 @@ let rec cv_to_buffer buf : Component.t -> unit = function
       cvs_to_buffer buf value;
       Buffer.add_char buf (closing_char opening)
   | Func { node = { name; arguments; _ }; _ } ->
-      (* Always emit the closing [)]: section 5.4.6 still produces the function
+      (* Always emit the closing [)]: section 5.5.10 still produces the function
          token on EOF, so the round-trip should match the lexer, not the
          truncated bytes. [terminated] is left for typed validators to
          reject. *)
@@ -428,11 +428,11 @@ let word_like_end : Component.t -> bool = function
       } ->
       false
   | Preserved _ -> true
-  (* CSS Color 4 sec. 11.1 relative colour needs whitespace between a [var()]
-     (or other function) [<color>] arg and the following channel ident:
-     [oklab(from var(--c) l a b)] tokenises fine as [var(--c)l] but spec-strict
-     parsers expect the separator. So [Func]/Paren [Block] count as
-     word-like-end to keep the [Func] + [Ident] boundary. *)
+  (* CSS Color 5 sec. 4.2 relative colour needs whitespace between a [var()] (or
+     other function) [<color>] arg and the following channel ident: [oklab(from
+     var(--c) l a b)] tokenises fine as [var(--c)l] but spec-strict parsers
+     expect the separator. So [Func]/Paren [Block] count as word-like-end to
+     keep the [Func] + [Ident] boundary. *)
   | Func _ -> true
   | Block { node = { opening = Paren; _ }; _ } -> true
   | Block _ -> false
@@ -618,7 +618,7 @@ let url_string_can_unquote s =
 
 (* If [args] is a single [<string-token>] argument we can fold it into the
    bare-URL form [url(X)] when X has no special characters - per CSS Values L4
-   sec. 3.4 the two notations are equivalent and the bare form is shorter. *)
+   sec. 4.5 the two notations are equivalent and the bare form is shorter. *)
 let url_args_as_bare_string args =
   let stripped =
     List.filter
@@ -695,7 +695,7 @@ let custom_min_item_separator buf prev separated cv =
       Buffer.add_char buf ' '
   | _ -> ()
 
-(* Idents are ASCII-case-insensitive per CSS Syntax 3 sec. 3, but the parser
+(* Idents are ASCII-case-insensitive per CSS Values 4 sec. 4.1, but the parser
    keeps source case so selectors stay case-sensitive. In a custom-property
    value only these keywords have a canonical lower-case spelling, so fold them
    ([--c:currentColor] == [--c:currentcolor]). Kept conservative: an

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -127,7 +127,7 @@ val list_of_declarations :
   ?meta:Loc.meta_level ->
   Reader.t ->
   [ `Decl of Component.declaration | `At of Component.at_rule ] list output
-(** [list_of_declarations ?meta r] runs section 5.4.8. *)
+(** [list_of_declarations ?meta r] runs section 5.4.5. *)
 
 val component_value : Reader.t -> Component.t option output
 (** [component_value r] runs section 5.4.8: discard surrounding whitespace,

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -140,7 +140,7 @@ let hex_escape_byte ctx ~next c =
   | Some c when is_hex_digit c -> char ctx ' '
   | _ -> ()
 
-(* Output a string literal with CSS section 9.2 escaping: backslash for the
+(* Output a string literal with CSSOM 1 sec. 2.1 escaping: backslash for the
    delimiter and for '\', hex escapes for control bytes (U+0000..U+001F, U+007F)
    so the serialized form parses back to the same string. *)
 let quoted_string ?(quote = '"') ctx s =
@@ -409,7 +409,7 @@ let unit ctx f suffix =
   string ctx suffix
 
 let pct ctx f =
-  (* CSS Values 4 sec. 6.5 only allows the unit to drop on a zero [<length>]; a
+  (* CSS Values 4 sec. 6 only allows the unit to drop on a zero [<length>]; a
      zero [<percentage>] keeps the [%] (otherwise [opacity:0] vs [opacity:0%]
      are no longer equivalent, and dimension/percentage-typed grammars reject a
      bare [0]). The coefficient prints in full, like [float]: rounding it

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -236,7 +236,7 @@ val unit : ctx -> float -> string -> unit
 val pct : ctx -> float -> unit
 (** [pct ctx f] formats a percentage value with the [%] suffix. The value is
     expected to be in the range 0-100. The unit is always emitted: CSS Values 4
-    sec. 6.5 only allows the unit to drop on a zero [<length>], not a zero
+    sec. 6 only allows the unit to drop on a zero [<length>], not a zero
     [<percentage>]. *)
 
 val comma : unit t

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -98,7 +98,7 @@ let rec pp_animation_name : animation_name Pp.t =
   | Name name -> Pp.string ctx name
   | Ambiguous name -> Pp.string ctx name
   | Quoted name ->
-      (* CSS Animations 1 sec. 3.3: [<keyframes-name>] excludes [none], the
+      (* CSS Animations 1 sec. 3: [<keyframes-name>] excludes [none], the
          CSS-wide keywords, and [default]. A source [animation-name: "none"]
          therefore can't refer to a real [@keyframes none] - it's invalid input
          that browsers tolerate. Minified output drops the quotes so the value
@@ -410,8 +410,8 @@ let rec pp_timing_function : timing_function Pp.t =
   | Cubic_bezier (0.42, 0.0, 0.58, 1.0) when Pp.minified ctx ->
       Pp.string ctx "ease-in-out"
   | Cubic_bezier (0.0, 0.0, 1.0, 1.0) when Pp.minified ctx ->
-      (* CSS Easing 1 sec. 3: [cubic-bezier(0, 0, 1, 1)] is the identity curve,
-         equivalent to the [linear] keyword. *)
+      (* CSS Easing 1 sec. 2.2: [cubic-bezier(0, 0, 1, 1)] is the identity
+         curve, equivalent to the [linear] keyword. *)
       Pp.string ctx "linear"
   | Cubic_bezier (x1, y1, x2, y2) -> pp_cubic_bezier ctx (x1, y1, x2, y2)
   | Timing_functions timings ->
@@ -1287,7 +1287,7 @@ module Animation = struct
 
   let apply_iteration t state acc ic =
     if !(state.iteration_seen) then
-      (* CSS Animations 1 section 8.5: [<single-animation-iteration-count>] is
+      (* CSS Animations 1 section 4.4: [<single-animation-iteration-count>] is
          [infinite | <number>]; [infinite] is a reserved keyword that cannot be
          a [<custom-ident>] animation name. Reject the duplicate rather than
          coercing it into the name slot. *)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -680,7 +680,7 @@ let pp_border_shorthand : border_shorthand Pp.t =
         (None : border_style option)
     | style, _, _ -> style
   in
-  (* CSS Backgrounds 3 sec. 4.4: [<border-width>] defaults to [medium]. When the
+  (* CSS Backgrounds 3 sec. 3.3: [<border-width>] defaults to [medium]. When the
      user spelled it explicitly and another slot is non-default, the keyword is
      redundant - drop it. *)
   let width : border_width option =
@@ -785,7 +785,7 @@ let rec pp_background_repeat : background_repeat Pp.t =
   | No_repeat -> Pp.string ctx "no-repeat"
   | Repeat_x -> Pp.string ctx "repeat-x"
   | Repeat_y -> Pp.string ctx "repeat-y"
-  (* CSS Backgrounds 3 sec. 3.6.1: the two-value forms collapse when both axes
+  (* CSS Backgrounds 3 sec. 2.6.1: the two-value forms collapse when both axes
      match ([X X] -> [X]) or when they alias a single-keyword shorthand ([repeat
      no-repeat] -> [repeat-x], [no-repeat repeat] -> [repeat-y]). *)
   | Repeat_repeat when Pp.minified ctx -> Pp.string ctx "repeat"
@@ -848,7 +848,7 @@ let rec pp_background_size : background_size Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_background_size ctx v
 
-(* CSS Backgrounds 3 sec. 3.6: the value is one position per background layer,
+(* CSS Backgrounds 3 sec. 2.6: the value is one position per background layer,
    comma-separated. It is not a box shorthand, so the layers neither join with
    spaces nor collapse the way margins do. *)
 let pp_background_position : background_position Pp.t =
@@ -936,7 +936,7 @@ let pp_mask_border_mode ctx = function
 let pp_border_image : border_image Pp.t =
  fun ctx { source; slice; width; outset; repeat; mode } ->
   let first = ref true in
-  (* CSS Syntax 3 sec. 5.4.6: tokens ending with [)] are self-delimiting, so the
+  (* CSS Syntax 3 sec. 9: tokens ending with [)] are self-delimiting, so the
      inter-slot space after [url(...)] / [<image>] can be elided under
      minify. *)
   let last_is_self_delim () =
@@ -962,8 +962,8 @@ let pp_border_image : border_image Pp.t =
   pp_bg_prop maybe_space
     (Pp.list ~sep:Pp.space pp_border_image_repeat_keyword)
     ctx repeat;
-  (* CSS Masking 1 sec. 6: [alpha] is the default mode, so drop it under minify;
-     [luminance] always prints. *)
+  (* CSS Masking 1 sec. 8.2: [alpha] is the default mode, so drop it under
+     minify; [luminance] always prints. *)
   let mode =
     match mode with
     | Some Alpha when Pp.minified ctx -> (None : mask_border_mode option)
@@ -981,7 +981,7 @@ let position_is_default_origin (p : position_value) =
   | Left_top | Top_left -> true
   | _ -> false
 
-(* CSS Backgrounds 3 sec. 3.10: under minify, drop a longhand whose value equals
+(* CSS Backgrounds 3 sec. 2.10: under minify, drop a longhand whose value equals
    its [background] shorthand initial. The resolved cascade is unchanged because
    the omitted slot inherits that same initial. *)
 let drop_initial_when_minified : 'a. Pp.ctx -> 'a -> 'a option -> 'a option =
@@ -1042,7 +1042,7 @@ let rec pp_background : background Pp.t =
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
   | None ->
-      (* CSS Backgrounds 3 sec. 3.10: [background: none] and [background: 0 0]
+      (* CSS Backgrounds 3 sec. 2.10: [background: none] and [background: 0 0]
          are computed-value-equivalent (both clear the image and set position to
          [0 0]). Pick the shorter form under minify. *)
       Pp.string ctx (if Pp.minified ctx then "0 0" else "none")
@@ -1433,7 +1433,7 @@ let rec read_background_repeat t : background_repeat =
     ~default:read_repeats t
 
 (* The standalone [background-repeat] / [mask-repeat] longhand is a
-   comma-separated layer list (CSS Backgrounds 3 sec. 3.6); the [background] /
+   comma-separated layer list (CSS Backgrounds 3 sec. 2.6); the [background] /
    [mask] shorthand reuses the single-value [read_background_repeat] so it does
    not eat the layer comma. Same split for the box / size / composite readers
    below. *)
@@ -1936,7 +1936,7 @@ let read_mask_border_mode t =
 let read_border_image t : border_image =
   let source = Cursor.option read_background_image t in
   Cursor.ws t;
-  (* CSS Masking 1 sec. 6 [mask-border-mode] is in [&&] juxtaposition with the
+  (* CSS Masking 1 sec. 8.7 [mask-border-mode] is in [&&] juxtaposition with the
      other slots, so the keyword may appear after [<source>] (before the slice)
      or after [<repeat>]. Try the early slot first; combine with the trailing
      slot below. *)

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -179,7 +179,7 @@ let option_is_phys_same a b =
   | Option.Some a, Option.Some b -> a == b
   | _ -> false
 
-(* CSS Lists 3 sec. 4.1: under minify, drop components equal to their longhand
+(* CSS Lists 3 sec. 3.6: under minify, drop components equal to their longhand
    initial ([type_: Disc], [position: Outside], [image: None]). When both
    [type_] and [image] are [None] and [position] is omitted, emit the single
    [none] keyword. If every component is defaulted, leave [outside] so the value

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -378,7 +378,7 @@ let rec read_flex_flow t : flex_flow =
       in
       let wrap : flex_wrap option ref = ref (None : flex_wrap option) in
       let seen = ref false in
-      (* CSS Flexbox 1 sec. 6.3: [flex-flow] is at most two values
+      (* CSS Flexbox 1 sec. 5.3: [flex-flow] is at most two values
          ([flex-direction] || [flex-wrap]). Stop once both slots are filled, and
          break on the first iteration where neither matches instead of letting
          [read_flex_flow_part] raise on the trailing [;] / [!important]. *)

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -83,7 +83,7 @@ let rec read_font_style t : font_style =
         Cursor.ws t;
         if Cursor.is_done t || Cursor.peek_semicolon t then Oblique_angle first
         else
-          (* CSS Fonts 4 sec. 11.2 wants the first oblique angle <= the second.
+          (* CSS Fonts 4 sec. 4.4 wants the first oblique angle <= the second.
              Browsers keep a descending range ([oblique 20deg 10deg]), so accept
              it but warn, leaving [Css.of_string ~strict] free to reject it. *)
           let second = read_angle t in
@@ -551,7 +551,7 @@ let pp_font_family_name ctx s =
 let can_unquote_font_family_name s =
   match String.split_on_char ' ' s with
   | _ :: _ :: _ as words ->
-      (* CSS Fonts 4 sec. 4.1: a [<family-name>] formed of two or more
+      (* CSS Fonts 4 sec. 2.1.1: a [<family-name>] formed of two or more
          [<custom-ident>]s is unambiguous - none of its words can be picked up
          as a property-level CSS-wide keyword once the parser has committed to a
          multi-token value. So [inherit test] / [revert serif] etc. round-trip
@@ -564,7 +564,7 @@ let can_unquote_font_family_name s =
    an explicit [<ident>] sequence. Used by the [@property]-registered custom
    property promotion path when the registered syntax accepts [<custom-ident>+]
    - the two forms ([custom-ident>+] vs [<string>]) are spec-equivalent there
-   (CSS Fonts 4 sec. 15.3), so the rewrite produces a single canonical AST. The
+   (CSS Fonts 4 sec. 2.1.1), so the rewrite produces a single canonical AST. The
    guard's "two or more words" rule avoids the CSS-wide-keyword trap (a quoted
    ["inherit"] never collapses to the bare keyword). *)
 let unquote_font_family_strings components =
@@ -652,7 +652,7 @@ let rec pp_font_family : font_family Pp.t =
   | Mulish -> Pp.string ctx "Mulish"
   | Josefin_sans -> Pp.string ctx "\"Josefin Sans\""
   (* Platform-specific fonts. Multi-word names emit unquoted under minify (CSS
-     Fonts 4 sec. 4.1: a [<family-name>] of two or more [<custom-ident>] words
+     Fonts 4 sec. 2.1.1: a [<family-name>] of two or more [<custom-ident>] words
      parses without quotes and is the shorter spelling). Pretty mode keeps the
      quoted form for readability. *)
   | Helvetica -> Pp.string ctx "Helvetica"
@@ -747,7 +747,7 @@ let rec pp_font_family : font_family Pp.t =
       let level_chars =
         match ctx.Pp.indent with Some w -> w * ctx.Pp.level | None -> 0
       in
-      (* CSS Fonts 4 sec. 4.1: [font-family] is a fallback list, so a duplicate
+      (* CSS Fonts 4 sec. 2.1: [font-family] is a fallback list, so a duplicate
          entry never wins under cascade resolution - drop it under minify (the
          first occurrence keeps the source position). A bare generic keyword
          (notably [monospace]) takes the UA generic-font size, so the
@@ -902,7 +902,7 @@ let rec pp_font_synthesis : font_synthesis Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
-(* CSS Fonts 4 sec. 5.3 defines each keyword as a percentage, and the percentage
+(* CSS Fonts 4 sec. 2.3 defines each keyword as a percentage, and the percentage
    is never longer, so minified output uses it. *)
 let font_stretch_pct = function
   | Ultra_condensed -> Some 50.
@@ -1540,7 +1540,7 @@ let font_family_of_quoted_name name =
 
 let rec read_font_family_single t : font_family =
   let read_var t : font_family = Var (read_var read_font_family t) in
-  (* CSS Fonts 4 sec. 2.1 / CSS Cascade 5 sec. 7.3: the CSS-wide keywords and
+  (* CSS Fonts 4 sec. 2.1.1 / CSS Cascade 5 sec. 7.3: the CSS-wide keywords and
      the reserved [default] are excluded from [<custom-ident>], so none may
      appear as any word of an unquoted family name. *)
   let is_reserved_word word =
@@ -1565,7 +1565,7 @@ let rec read_font_family_single t : font_family =
        ~calls:[ ("var", read_var) ]
        ~default:(fun t ->
          let name = Cursor.ident ~keep_case:true t in
-         (* CSS Fonts 4 sec. 2.1: [default] is reserved and is not a valid
+         (* CSS Fonts 4 sec. 2.1.1: [default] is reserved and is not a valid
             unquoted [<custom-ident>] family name; it must be quoted. *)
          if String.lowercase_ascii name = "default" then
            Cursor.err_invalid t
@@ -1820,7 +1820,7 @@ let rec read_font t : font =
 let rec read_font_stretch t : font_stretch =
   let read_percentage t : font_stretch =
     let n = Cursor.pct t in
-    (* CSS Fonts 4 sec. 6.1.2: font-stretch percentage is non-negative. *)
+    (* CSS Fonts 4 sec. 2.3: font-stretch percentage is non-negative. *)
     if n < 0. then err_invalid_value t "font-stretch" (string_of_float n);
     Pct n
   in
@@ -1950,7 +1950,7 @@ let read_font_variant_numeric_tokens t : font_variant_numeric =
   match tokens with
   | [] -> err_invalid_value t "font-variant-numeric" "<empty>"
   | tokens ->
-      (* CSS Fonts 4 section 6.6: [normal] resets all sub-properties and must
+      (* CSS Fonts 4 section 6.7: [normal] resets all sub-properties and must
          stand alone; it can't be mixed with other numeric tokens. *)
       if List.exists numeric_token_is_normal tokens && List.length tokens > 1
       then

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -16,7 +16,7 @@ open Properties_intf
 open Prop_common
 open Prop_align
 
-(* CSS Grid 2 sec. 7.6: [grid-auto-flow] is [ row | column ] || dense, and an
+(* CSS Grid 2 sec. 7.7: [grid-auto-flow] is [ row | column ] || dense, and an
    omitted axis means [row], so [row dense] and [dense] are one value. *)
 let normalize_grid_auto_flow : grid_auto_flow -> grid_auto_flow =
  fun value -> match value with Row_dense -> Dense | other -> other
@@ -159,7 +159,7 @@ let rec pp_grid_template : grid_template Pp.t =
   | Vmax f -> Pp.unit ctx f "vmax"
   | Zero -> Pp.char ctx '0'
   | Length l -> pp_length ctx l
-  (* CSS Grid 2 sec. 7.2: [<flex>] is [<number>fr]; the unit-drop rule is for
+  (* CSS Grid 2 sec. 7.2.4: [<flex>] is [<number>fr]; the unit-drop rule is for
      [<length>] only. [0fr] is a zero flex factor, distinct from a [0]
      [<length>] in [grid-template]'s union grammar. *)
   | Fr f ->
@@ -426,7 +426,7 @@ let rec pp_place_items : place_items Pp.t =
   | Align_justify (a, j) ->
       let a_s = Pp.to_string ~minify:(Pp.minified ctx) pp_align_items a in
       let j_s = Pp.to_string ~minify:(Pp.minified ctx) pp_justify_items j in
-      (* CSS Align 3 sec. 6.1: when align and justify render to the same token,
+      (* CSS Align 3 sec. 7.3: when align and justify render to the same token,
          the single-value spelling is canonical. *)
       if Pp.minified ctx && a_s = j_s then Pp.string ctx a_s
       else (
@@ -985,7 +985,7 @@ let rec read_grid t : grid_template =
   if Cursor.looking_at_func "var" t then
     (Var (Values.read_var read_grid t) : grid_template)
   else if grid_template_needs_raw_template (Cursor.remaining t) then
-    (* CSS Grid 1 sec. 10.1 [<'grid-template'>] form of [grid]: when the input
+    (* CSS Grid 1 sec. 7.8 [<'grid-template'>] form of [grid]: when the input
        contains a [<string>] token, the value is the [<line-names>? <string>
        <track-size>? <line-names>?]+ form, which [read_grid_template] already
        handles. *)

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -40,7 +40,7 @@ let rec pp_color_interpolation : color_interpolation Pp.t =
   | In_lab -> Pp.string ctx "in lab"
   | In_lch hue -> pp_polar_with_hue ctx "lch" hue
 
-(* CSS Color 5 section 12: after a polar color space (lch / oklch / hsl / hwb),
+(* CSS Color 5 section 9.1: after a polar color space (lch / oklch / hsl / hwb),
    the [<color-interpolation-method>] may carry a trailing
    [<hue-interpolation-method>] followed by [hue]. *)
 let read_hue_interpolation_method t =
@@ -454,7 +454,7 @@ let pp_conic_gradient_named name ctx (config, stops) =
 let pp_linear_gradient_named name ctx (dir, stops) =
   Pp.call name
     (fun ctx (dir, stops) ->
-      (* CSS Images 4 sec. 5.1: the default linear-gradient direction is [to
+      (* CSS Images 4 sec. 3.1: the default linear-gradient direction is [to
          bottom], equivalent to [180deg]; both spellings can be elided. *)
       let is_default_direction = function
         | Default_direction -> true
@@ -714,7 +714,7 @@ let normalize_webkit_gradient ?(lossless = false) :
       in
       if stops == r.stops then value else Radial { r with stops }
 
-(* [<position>] spelling canonicalization. CSS Values 4 sec. 6.1: the edge
+(* [<position>] spelling canonicalization. CSS Values 4 sec. 8.3: the edge
    keywords are percentage synonyms ([left] = [top] = [0%], [center] = [50%],
    [right] = [bottom] = [100%]), a percentage offset of [0%] and the length [0]
    resolve to the same point, and a single value defaults the vertical component
@@ -799,7 +799,7 @@ let normalize_position_value ?(strip = true) : position_value -> position_value
       | other -> other)
 
 let normalize_radial_config (c : radial_gradient_config) =
-  (* CSS Images 4 section 3.1: inside a radial-gradient() prelude the default
+  (* CSS Images 4 section 3.2: inside a radial-gradient() prelude the default
      shape (ellipse), size (farthest-corner) and position (center) are implied,
      so the canonical form drops them. pp stays faithful to the AST; this
      elision is an optimize-side rewrite. *)
@@ -823,7 +823,7 @@ let normalize_conic_config (c : conic_gradient_config) =
   if angle == c.angle && position == c.position then c
   else { c with angle; position }
 
-(* CSS Images 4 sec. 3.4.1: [<color> <p1> <p2>] is defined as exactly [<color>
+(* CSS Images 4 sec. 3.5.1: [<color> <p1> <p2>] is defined as exactly [<color>
    <p1>, <color> <p2>], so two adjacent stops of one colour, each carrying a
    single position, are one stop carrying both. Left to right, so a longer run
    folds pairwise; a stop already holding two positions has nothing left to
@@ -1458,7 +1458,7 @@ module Radial_config = struct
     read_position_value t
 
   let read t : radial_gradient_config =
-    (* CSS Images 4 section 6.2: the [radial-gradient] prelude is
+    (* CSS Images 4 section 3.2: the [radial-gradient] prelude is
        [<ending-shape> || <size> || at <position> ||
        <color-interpolation-method>]? - the [||] combinator allows any order.
        Loop trying each missing slot until no progress is made. *)
@@ -1506,7 +1506,7 @@ let read_radial_gradient_config t : radial_gradient_config =
   Radial_config.read t
 
 let read_conic_gradient_config t : conic_gradient_config =
-  (* CSS Images 4 section 3.5.1: the [conic-gradient] prelude is [[from
+  (* CSS Images 4 section 3.3.1: the [conic-gradient] prelude is [[from
      <angle>]? || [at <position>]? || <color-interpolation-method>]? - the [||]
      combinator allows any order. Loop trying each missing slot until no
      progress is made. *)
@@ -1553,7 +1553,7 @@ let read_conic_gradient_config t : conic_gradient_config =
   then Cursor.err_invalid t "conic-gradient config";
   { angle = !angle; position = !position; interpolation = !interpolation }
 
-(* CSS Images 4 sec. 6.1 [linear-gradient] prelude: [ <angle> | to
+(* CSS Images 4 sec. 3.1 [linear-gradient] prelude: [ <angle> | to
    <side-or-corner> ]? || <color-interpolation-method> A bare interpolation, a
    bare direction, or both in either order are all valid. Returns [None] when
    the prelude consumed no tokens. *)

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -190,7 +190,7 @@ let rec pp_position_area : position_area Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_position_area ctx v
   | None -> Pp.string ctx "none"
-  (* CSS Anchor Positioning 1 sec. 6: the second axis defaults to [center], so
+  (* CSS Anchor Positioning 1 sec. 3.1: the second axis defaults to [center], so
      [X center] minifies to [X]; both axes equal also collapse. *)
   | Area (first, Some second)
     when Pp.minified ctx

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -477,7 +477,7 @@ let rec pp_mask_box : mask_box Pp.t =
 let pp_mask_layer : mask_layer Pp.t =
  fun ctx layer ->
   let first = ref true in
-  (* CSS Syntax 3 sec. 5.4.6: a token ending with [)], [\]] or [}] is
+  (* CSS Syntax 3 sec. 9: a token ending with [)], [\]] or [}] is
      self-delimiting, so under minify we can drop the inter-slot space after
      [url(...)] / [<image>]. *)
   let last_is_self_delim () =
@@ -1029,7 +1029,7 @@ let rec read_clip_path (t : Cursor.t) : clip_path =
       ]
       t
   in
-  (* CSS Masking 1 sec. 3.6 [<basic-shape> || <geometry-box>]: a shape and a
+  (* CSS Masking 1 sec. 5.1 [<basic-shape> || <geometry-box>]: a shape and a
      reference box may appear in either order, or just a box on its own. *)
   let at_end t = Cursor.is_done t || Cursor.peek_semicolon t in
   match read_clip_geometry_box_opt t with

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -190,7 +190,7 @@ let rec read_break_value t : break_value =
       ("auto", (Auto : break_value));
       ("avoid", Avoid);
       ("all", All);
-      (* CSS Fragmentation 3 sec. 6: legacy [page-break-*: always] maps to
+      (* CSS Fragmentation 3 sec. 3.4: legacy [page-break-*: always] maps to
          [break-*: page]. The reader accepts the legacy spelling so the
          page-break alias dispatch (which routes to [Break_before/after]) can
          keep using this reader. *)
@@ -291,7 +291,7 @@ let read_columns_components t : columns_value =
   | None -> columns_value_of_component first
 
 let rec read_columns_value t : columns_value =
-  (* CSS Multicol 2 sec. 6.1: [<'column-width'> || <'column-count'>], where
+  (* CSS Multicol 2 sec. 4.5: [<'column-width'> || <'column-count'>], where
      column-width is [auto | <length>] and column-count is [auto | <integer>].
      Read up to two space-separated components in any order, then assign the
      length to the width slot and the integer to the count slot. An explicit

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -22,7 +22,7 @@ let rec numeric_miterlimit_calc_leaves :
           numeric_miterlimit_calc_leaves right )
   | other -> other
 
-(* SVG 2 sec. 13.7: keywords left out are painted last, in the order [normal]
+(* SVG 2 sec. 13.8: keywords left out are painted last, in the order [normal]
    would use. So a value denotes the full order [written @ missing-in-normal-
    order], and the shortest spelling is the shortest prefix of that order which
    expands back to it. [fill stroke markers] expands from nothing, so it is
@@ -32,7 +32,7 @@ let paint_order_normal : paint_order_keyword list = [ Fill; Stroke; Markers ]
 let paint_order_expand (written : paint_order_keyword list) =
   written @ List.filter (fun k -> not (List.mem k written)) paint_order_normal
 
-(* SVG 2 sec. 7.10: [viewport] is what an omitted space means, so writing it is
+(* SVG 2 sec. 8.13: [viewport] is what an omitted space means, so writing it is
    redundant. *)
 let normalize_vector_effect (value : vector_effect) : vector_effect =
   match value with
@@ -234,7 +234,7 @@ let rec pp_svg_paint : svg_paint Pp.t =
       match fallback with
       | None -> ()
       | Some fb ->
-          (* CSS Syntax 3 sec. 5.4.6: a [url(...)] token closes with [)], so the
+          (* CSS Syntax 3 sec. 9: a [url(...)] token closes with [)], so the
              whitespace before a fallback keyword/colour can be elided under
              minify. *)
           Pp.sp ctx ();

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -20,8 +20,8 @@ let read_vertical_align_length t : vertical_align =
   | Some "rem" -> Rem n
   | Some "em" -> Em n
   | Some "%" -> Pct n
-  (* A unitless [0] is the valid zero <length> (CSS Values 4 sec. 6.1); any
-     other unitless number is not a length and is rejected. *)
+  (* A unitless [0] is the valid zero <length> (CSS Values 4 sec. 6); any other
+     unitless number is not a length and is rejected. *)
   | None when n = 0. -> Zero
   | None -> Cursor.err_invalid t "vertical-align requires a unit"
   | Some u -> Cursor.err_invalid t ("invalid vertical-align unit: " ^ u)

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -369,7 +369,7 @@ let pp_matrix_3d : _ Pp.t =
    normal transform functions. This helper determines if a transform is a Var *)
 let is_transform_var : transform -> bool = function Var _ -> true | _ -> false
 
-(* CSS Transforms 1 sec. 11: collapse a transform function to a shorter
+(* CSS Transforms 1 sec. 12: collapse a transform function to a shorter
    equivalent when an axis is zero / unity / matches another. Spec-equivalent in
    every case - they all map to the same matrix. *)
 let canonicalise_transform : transform -> transform = function
@@ -828,7 +828,7 @@ let rec pp_translate_value : translate_value Pp.t =
   | Var v -> pp_var pp_translate_value ctx v
 
 let rec read_translate_value t : translate_value =
-  (* Per CSS Transforms 2 sec. 3.5: [<length-percentage> <length-percentage>?
+  (* Per CSS Transforms 2 sec. 5: [<length-percentage> <length-percentage>?
      <length>?]. Same two [var()] shapes as [read_scale]:
 
      - [translate: var(--t)] is a whole-value [var()] -- produce [Var _]. -
@@ -869,7 +869,7 @@ let rec read_translate_value t : translate_value =
     ~calls:[ ("var", read_var_or_components) ]
     ~default:read_lengths t
 
-(* CSS Transforms 2 sec. 3.3: the standalone [rotate] / individual transform
+(* CSS Transforms 2 sec. 5: the standalone [rotate] / individual transform
    properties accept [<angle>] but reject the bare [0] from the CSS Values
    [<zero>] token shortcut (browsers don't apply the parse-time fallback). Emit
    the unit even on zero so [rotate: 0deg] survives minification. *)
@@ -907,9 +907,9 @@ let rec pp_rotate_value : rotate_value Pp.t =
   | Axis (0., 1., 0., a) when Pp.minified ctx -> pp_rotate_value ctx (Y a)
   | Axis (0., 0., 1., a) when Pp.minified ctx -> pp_rotate_value ctx (Z a)
   | Axis (x, y, z, a) ->
-      (* CSS Transforms 2 sec. 3.3 [rotate] [<angle> <number>{3}] is shorter
-         under minify when the angle leads (csso convention) and the second /
-         third numbers drop the separator if they start with a sign. *)
+      (* CSS Transforms 2 sec. 5 [rotate] [<angle> <number>{3}] is shorter under
+         minify when the angle leads (csso convention) and the second / third
+         numbers drop the separator if they start with a sign. *)
       let pp_sep ctx (next : float) =
         if Pp.minified ctx && next < 0. then () else Pp.space ctx ()
       in
@@ -972,7 +972,7 @@ let read_rotate_angle_axis_tail angle t =
       let third = Cursor.number t in
       (Axis (first, second, third, angle) : rotate_value)
 
-(* CSS Transforms 2 sec. 3.3 [rotate] also accepts angle then axis: [<angle>
+(* CSS Transforms 2 sec. 5 [rotate] also accepts angle then axis: [<angle>
    x|y|z] or [<angle> <number>{3}]. Try angle-first after the plain forms;
    consume the angle, then look for a trailing axis. *)
 let read_rotate_angle_then_axis t : rotate_value =
@@ -1037,8 +1037,8 @@ let rec read_backface_visibility t : backface_visibility =
     t
 
 let rec read_scale t : scale =
-  (* CSS Transforms 2 sec. 3.6: [<number-percentage>{1,3}]. Two [var()] shapes
-     to keep distinct: [scale: var(--s)] is a whole-value var (produce [Var _]);
+  (* CSS Transforms 2 sec. 5: [<number-percentage>{1,3}]. Two [var()] shapes to
+     keep distinct: [scale: var(--s)] is a whole-value var (produce [Var _]);
      [scale: var(--x) var(--y)] is per-slot (produce [XY _]). They are
      indistinguishable until a second component appears, so peel the first
      [var()] as a whole-value [Var]; if another follows, the saved snapshot
@@ -1103,7 +1103,7 @@ module Transform_origin = struct
         match Cursor.option read_length t with
         | Some z -> XYZ (x, y, z)
         | None -> XY (x, y))
-    (* CSS Transforms 1 sec. 3: a single <length-percentage> sets the X origin
+    (* CSS Transforms 1 sec. 4: a single <length-percentage> sets the X origin
        and defaults Y to [center] ([50%]); it is not duplicated into Y. *)
     | None -> X x
 

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -1098,7 +1098,7 @@ let color_scheme_of_idents t names : color_scheme =
   | [ "revert-layer" ] -> Revert_layer
   | [] -> Cursor.err t "empty color-scheme"
   | _ ->
-      (* CSS Color Adjust 1 section 2.1: [color-scheme] is [normal | [light |
+      (* CSS Color Adjust 1 section 2.2: [color-scheme] is [normal | [light |
          dark | <custom-ident>]+ && only?]. [normal] is mutually exclusive with
          the list form; [only] is a modifier that must accompany a non-empty
          list; CSS-wide keywords can only stand alone. *)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -966,7 +966,7 @@ let rec read_list_style_image t : list_style_image =
 
 (* Parse the [list-style] shorthand into a typed [list_style_shorthand] record.
    Each slot is recognised by the longhand reader; a single bare [none]
-   populates both [type_] and [image] per CSS Lists 3 sec. 4.1. *)
+   populates both [type_] and [image] per CSS Lists 3 sec. 3.6. *)
 let try_list_style_slot r read_fn (slot : 'a option ref) =
   if !slot <> Option.None then false
   else
@@ -1212,7 +1212,7 @@ let rec read_quotes t : quotes =
     ~default:read_pairs t
 
 let read_any_property t =
-  (* CSS property names are case-insensitive per Syntax sec. 3.3. *)
+  (* CSS property names are case-insensitive per Syntax sec. 8.1. *)
   let prop_name = String.lowercase_ascii_preserve (Cursor.ident t) in
   (* PROPERTY_MATCHING_START - Used by scripts/check_properties.ml *)
   match prop_name with
@@ -1328,8 +1328,8 @@ let read_any_property t =
   | "align-items" -> Prop Align_items
   | "justify-content" -> Prop Justify_content
   | "opacity" -> Prop Opacity
-  (* SVG 1.1 sec. 11.4 / Filter Effects 1: each is an <alpha-value>, the same
-     number-or-percentage as [opacity]. *)
+  (* SVG 2 sec. 13.4.3, 13.5.2 and 14.2.4.2 / Filter Effects 1 sec. 9.13.2: each
+     is an <alpha-value>, the same number-or-percentage as [opacity]. *)
   | "fill-opacity" -> Prop Fill_opacity
   | "stroke-opacity" -> Prop Stroke_opacity
   | "stop-opacity" -> Prop Stop_opacity
@@ -1474,9 +1474,10 @@ let read_any_property t =
   | "break-after" -> Prop Break_after
   | "break-inside" -> Prop Break_inside
   | "size" -> Prop Page_size
-  (* CSS Fragmentation 3 sec. 6 page-break-* aliases. Keep them as typed legacy
-     properties so pretty output preserves the authored property name; minified
-     output still serializes through the shorter modern break-* spelling. *)
+  (* CSS Fragmentation 3 sec. 3.4 page-break-* aliases. Keep them as typed
+     legacy properties so pretty output preserves the authored property name;
+     minified output still serializes through the shorter modern break-*
+     spelling. *)
   | "page-break-before" -> Prop Page_break_before
   | "page-break-after" -> Prop Page_break_after
   | "page-break-inside" -> Prop Page_break_inside
@@ -1563,7 +1564,8 @@ let read_any_property t =
   | "content-visibility" -> Prop Content_visibility
   | "direction" -> Prop Direction
   | "fill" -> Prop Fill
-  (* SVG 2 sec. 13.5 and 14.4: both take the same <fill-rule>. *)
+  (* SVG 2 sec. 13.4.2 and CSS Masking 1 sec. 6.2: both take the same
+     <fill-rule>. *)
   | "fill-rule" -> Prop Fill_rule
   | "clip-rule" -> Prop Clip_rule
   | "stroke-linecap" -> Prop Stroke_linecap
@@ -1573,8 +1575,8 @@ let read_any_property t =
   | "stroke-dasharray" -> Prop Stroke_dasharray
   | "paint-order" -> Prop Paint_order
   | "vector-effect" -> Prop Vector_effect
-  (* SVG 2 sec. 13.4 / Filter Effects 1 sec. 9.13.1 and 11.5: each is a plain
-     <color>, so they minify like any other colour-valued property. *)
+  (* SVG 2 sec. 14.2.4.2 / Filter Effects 1 sec. 9.13.1 and 11.5: each is a
+     plain <color>, so they minify like any other colour-valued property. *)
   | "stop-color" -> Prop Stop_color
   | "flood-color" -> Prop Flood_color
   | "lighting-color" -> Prop Lighting_color
@@ -2172,7 +2174,7 @@ let components_of_custom_property_value = function
 let pp_custom_property ctx (Custom_value { value; _ }) =
   pp_custom_property_value ctx value
 
-(* CSS Values 4 sec. 6.5: the [initial] keyword resolves to the property's
+(* CSS Values 4 sec. 4.1.1: the [initial] keyword resolves to the property's
    spec-defined initial value at computed time. Under [--minify] swap the
    keyword for that value when its serialization is shorter (or the same length
    but a more canonical spelling that cleancss / csso emit). *)

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -60,7 +60,7 @@ val unquote_font_family_strings : custom_value -> custom_value
     whose content is a multi-word identifier sequence as the equivalent
     [<ident> <whitespace> <ident> ...] component sequence. Used by the
     [@property]-registered custom-property promotion when the registered syntax
-    accepts [<custom-ident>+] (CSS Fonts 4 sec. 15.3 makes the two forms
+    accepts [<custom-ident>+] (CSS Fonts 4 sec. 2.1.1 makes the two forms
     equivalent in font-family-typed positions). Single-word strings and any
     token that isn't a [<string>] pass through unchanged. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1651,7 +1651,7 @@ type list_style_image =
   | Revert_layer
   | Var of list_style_image var
 
-(* CSS Lists 3 sec. 4.1: [list-style] is the shorthand for [list-style-type],
+(* CSS Lists 3 sec. 3.6: [list-style] is the shorthand for [list-style-type],
    [list-style-position], and [list-style-image]. All components are optional;
    omitted ones reset to the longhand initial ([disc] / [outside] / [none]). The
    single bare [none] keyword in the source sets both [type_] and [image] to
@@ -2506,7 +2506,7 @@ type background_size =
   | Revert_layer
   | Var of background_size var
 
-(** CSS Color 5 section 12: optional hue-interpolation method that follows a
+(** CSS Color 5 section 9.1: optional hue-interpolation method that follows a
     polar color space (lch / oklch / hsl / hwb). *)
 type hue_interpolation_method = Shorter | Longer | Increasing | Decreasing
 
@@ -2599,7 +2599,7 @@ type border_radius =
   | Unset
   | Revert
   | Revert_layer
-  | Var of border_radius var  (** Per CSS Backgrounds and Borders 3 sec. 5. *)
+  | Var of border_radius var  (** Per CSS Backgrounds and Borders 3 sec. 4.1. *)
 
 type conic_gradient_config = {
   angle : angle option;  (** [from <angle>] starting angle *)
@@ -2855,7 +2855,7 @@ type border_image_width_item =
 type border_image_outset_item = Number of float | Length of length
 type border_image_repeat_keyword = Stretch | Repeat | Round | Space
 
-(* CSS Backgrounds 3 sec. 6.3: [border-image-repeat] is one or two keywords
+(* CSS Backgrounds 3 sec. 5.5: [border-image-repeat] is one or two keywords
    (block then inline); the longhand also takes the CSS-wide keywords. *)
 type border_image_repeat =
   | Repeats of border_image_repeat_keyword list
@@ -2866,7 +2866,7 @@ type border_image_repeat =
   | Revert_layer
   | Var of border_image_repeat var
 
-(* CSS Backgrounds 3 sec. 6.2: [border-image-width] is one to four items; the
+(* CSS Backgrounds 3 sec. 5.3: [border-image-width] is one to four items; the
    longhand also takes the CSS-wide keywords. *)
 type border_image_width =
   | Widths of border_image_width_item list
@@ -2877,7 +2877,7 @@ type border_image_width =
   | Revert_layer
   | Var of border_image_width var
 
-(* CSS Backgrounds 3 sec. 6.4: [border-image-outset] is one to four items; the
+(* CSS Backgrounds 3 sec. 5.4: [border-image-outset] is one to four items; the
    longhand also takes the CSS-wide keywords. *)
 type border_image_outset =
   | Outsets of border_image_outset_item list
@@ -2888,7 +2888,7 @@ type border_image_outset =
   | Revert_layer
   | Var of border_image_outset var
 
-(** CSS Masking 1 sec. 6 [<mask-border-mode>]: shared with the [border_image]
+(** CSS Masking 1 sec. 8.2 [<mask-border-mode>]: shared with the [border_image]
     record because [mask-border] is otherwise the same shorthand as
     [border-image] (the mode is always [None] for the latter). *)
 type mask_border_mode = Alpha | Luminance
@@ -3283,8 +3283,8 @@ type position_try_order =
   | Revert_layer
   | Var of position_try_order var
 
-(* CSS Anchor Positioning 1 sec. 4: [position-try] is [<'position-try-order'> ||
-   <'position-try-fallbacks'>]. A [Normal] order is the initial value and is
+(* CSS Anchor Positioning 1 sec. 6.3: [position-try] is [<'position-try-order'>
+   || <'position-try-fallbacks'>]. A [Normal] order is the initial value and is
    omitted from the serialisation. *)
 type position_try =
   | Try of position_try_order * position_try_fallbacks
@@ -3645,9 +3645,9 @@ type break_inside_value =
   | Revert_layer
   | Var of break_inside_value var
 
-(* CSS Fragmentation 3 sec. 6 deprecated [page-break-before / -after / -inside]
-   aliases. The shorter value vocabulary makes them their own type rather than
-   overload [break_value]. *)
+(* CSS Fragmentation 3 sec. 3.4 deprecated [page-break-before / -after /
+   -inside] aliases. The shorter value vocabulary makes them their own type
+   rather than overload [break_value]. *)
 type page_break_value =
   | Auto
   | Always (* maps to [break-before/after: page] *)
@@ -3663,7 +3663,7 @@ type page_break_inside_value =
   | Inherit
   | Var of page_break_inside_value var
 
-(* CSS Paged Media 3 sec. 6.1 [size] descriptor: optional page size keyword
+(* CSS Paged Media 3 sec. 7.1 [size] descriptor: optional page size keyword
    (paper sheet name), explicit dimensions, [auto], or a page size combined with
    an orientation. *)
 type page_size_name =
@@ -3700,7 +3700,7 @@ type columns_value =
   | Count of int
   | Width of length
   | Both of length * int
-      (** [<column-width> <column-count>] per CSS Multicol 2 sec. 6.1. The two
+      (** [<column-width> <column-count>] per CSS Multicol 2 sec. 4.5. The two
           components can appear in either order in the source; we canonicalise
           to [<width>, <count>] internally so the printer always emits the width
           first. *)
@@ -3715,7 +3715,7 @@ type columns_value =
   | Revert_layer
   | Var of columns_value var
 
-(* CSS Multicol 2 sec. 4: [column-width] is [auto | <length [0,inf]>]. *)
+(* CSS Multicol 2 sec. 4.1: [column-width] is [auto | <length [0,inf]>]. *)
 type column_width =
   | Auto
   | Width of length
@@ -3726,7 +3726,7 @@ type column_width =
   | Revert_layer
   | Var of column_width var
 
-(* CSS Multicol 2 sec. 3: [column-count] is [auto | <integer [1,inf]>]. *)
+(* CSS Multicol 2 sec. 4.3: [column-count] is [auto | <integer [1,inf]>]. *)
 type column_count =
   | Auto
   | Count of int
@@ -3872,16 +3872,16 @@ type svg_paint =
   | Color of color
   | Url of string * svg_paint option
   | Context_fill
-      (** SVG2 sec. 11.2 [context-fill] - inherits the fill paint of the context
+      (** SVG2 sec. 13.2 [context-fill] - inherits the fill paint of the context
           element, used in marker / pattern / use trees. *)
   | Context_stroke
-      (** SVG2 sec. 11.2 [context-stroke] - mirror of [Context_fill]. *)
+      (** SVG2 sec. 13.2 [context-stroke] - mirror of [Context_fill]. *)
   | Var of svg_paint var
 
-(** SVG 2 sec. 13.5 / 14.4 [<fill-rule>]: which points count as inside a shape
-    when its subpaths overlap. Shared by [fill-rule] and [clip-rule]; the
-    argument form inside [polygon()] is {!clip_path_fill_rule}, which carries no
-    CSS-wide keywords. *)
+(** SVG 2 sec. 13.4.2 and CSS Masking 1 sec. 6.2 [<fill-rule>]: which points
+    count as inside a shape when its subpaths overlap. Shared by [fill-rule] and
+    [clip-rule]; the argument form inside [polygon()] is {!clip_path_fill_rule},
+    which carries no CSS-wide keywords. *)
 type fill_rule =
   | Nonzero
   | Evenodd
@@ -3892,7 +3892,7 @@ type fill_rule =
   | Revert_layer
   | Var of fill_rule var
 
-(** SVG 2 sec. 13.3 [stroke-linecap]: the shape drawn at the ends of an open
+(** SVG 2 sec. 13.5.4 [stroke-linecap]: the shape drawn at the ends of an open
     subpath and at the ends of each dash. *)
 type stroke_linecap =
   | Butt
@@ -3905,7 +3905,7 @@ type stroke_linecap =
   | Revert_layer
   | Var of stroke_linecap var
 
-(** SVG 2 sec. 13.3 [stroke-linejoin]: the shape drawn where two path segments
+(** SVG 2 sec. 13.5.5 [stroke-linejoin]: the shape drawn where two path segments
     meet. [miter_clip] and [arcs] are the Level 2 additions. *)
 type stroke_linejoin =
   | Miter
@@ -3920,7 +3920,7 @@ type stroke_linejoin =
   | Revert_layer
   | Var of stroke_linejoin var
 
-(** SVG 2 sec. 13.3 [stroke-miterlimit]: the ratio at which a miter join is
+(** SVG 2 sec. 13.5.5 [stroke-miterlimit]: the ratio at which a miter join is
     converted to a bevel. The specification makes a value below 1 invalid. *)
 type stroke_miterlimit =
   | Number of float
@@ -3932,11 +3932,11 @@ type stroke_miterlimit =
   | Revert_layer
   | Var of stroke_miterlimit var
 
-(** SVG 2 sec. 13.3: one dash length. A bare [<number>] is in user units, which
-    is why this is not plain [length_percentage]. *)
+(** SVG 2 sec. 13.5.6: one dash length. A bare [<number>] is in user units,
+    which is why this is not plain [length_percentage]. *)
 type dash_length = Number of float | Length of length_percentage
 
-(** SVG 2 sec. 13.3 [stroke-dashoffset]. *)
+(** SVG 2 sec. 13.5.6 [stroke-dashoffset]. *)
 type stroke_dashoffset =
   | Dash of dash_length
   | Inherit
@@ -3946,7 +3946,7 @@ type stroke_dashoffset =
   | Revert_layer
   | Var of stroke_dashoffset var
 
-(** SVG 2 sec. 13.3 [stroke-dasharray]: [none] or a dash pattern. The grammar
+(** SVG 2 sec. 13.5.6 [stroke-dasharray]: [none] or a dash pattern. The grammar
     separates entries by comma and/or whitespace and the rendered pattern is the
     flat sequence either way, so both spellings read to one list. *)
 type stroke_dasharray =
@@ -3959,10 +3959,10 @@ type stroke_dasharray =
   | Revert_layer
   | Var of stroke_dasharray var
 
-(** SVG 2 sec. 13.7 [paint-order] operand. *)
+(** SVG 2 sec. 13.8 [paint-order] operand. *)
 type paint_order_keyword = Fill | Stroke | Markers
 
-(** SVG 2 sec. 13.7 [paint-order]: [normal | [ fill || stroke || markers ]]. The
+(** SVG 2 sec. 13.8 [paint-order]: [normal | [ fill || stroke || markers ]]. The
     written order is the paint order, and any keyword left out is painted last
     in the order [normal] would use, so a trailing run that already matches
     [normal] is redundant. Entries are distinct: [||] takes each operand at most
@@ -3977,18 +3977,18 @@ type paint_order =
   | Revert_layer
   | Var of paint_order var
 
-(** SVG 2 sec. 7.10 [vector-effect] operand. *)
+(** SVG 2 sec. 8.13 [vector-effect] operand. *)
 type vector_effect_keyword =
   | Non_scaling_stroke
   | Non_scaling_size
   | Non_rotation
   | Fixed_position
 
-(** SVG 2 sec. 7.10 host coordinate space for a vector effect. [viewport] is
+(** SVG 2 sec. 8.13 host coordinate space for a vector effect. [viewport] is
     what an omitted space means. *)
 type vector_effect_space = Viewport | Screen
 
-(** SVG 2 sec. 7.10 [vector-effect]:
+(** SVG 2 sec. 8.13 [vector-effect]:
     [none | [ non-scaling-stroke | non-scaling-size | non-rotation |
      fixed-position ]+ [ viewport | screen ]?]. *)
 type vector_effect =
@@ -4308,7 +4308,7 @@ type clip =
   | Revert_layer
   | Var of clip var
 
-(** CSS Masking 1 sec. 3.6 [<geometry-box>] reference box for [clip-path]: the
+(** CSS Masking 1 sec. 5.1 [<geometry-box>] reference box for [clip-path]: the
     [<shape-box>] from CSS Shapes 1 plus the SVG-specific boxes. *)
 type clip_geometry_box =
   | Margin_box
@@ -4570,7 +4570,7 @@ type 'a property =
   | Grid_template_areas : grid_template_areas property
   | Grid_template : grid_template property
   | Grid : grid_template property
-      (** CSS Grid 1 sec. 8 [grid] shorthand. Cascade treats it as a free-form
+      (** CSS Grid 1 sec. 7.8 [grid] shorthand. Cascade treats it as a free-form
           [grid_template] for now: the simple cases (track-list, grid-template
           syntax with area strings) round-trip through the same AST as
           [grid-template], and inputs that exercise the auto-flow branches fall

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -71,7 +71,7 @@ let single ~ctx (rule : rule) : rule =
   in
   with_declarations rule declarations
 
-(* CSS Multicol 2 sec. 6.1: [column-width] + [column-count] collapse to
+(* CSS Multicol 2 sec. 4.5: [column-width] + [column-count] collapse to
    [columns], which resets exactly those two longhands, so the rewrite is
    cascade-safe with no closed-world assumption. The longhands are unknown
    properties, so their values are re-parsed here. *)

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -504,7 +504,7 @@ let normalize_custom_value v =
   Buffer.contents buf
 
 (* A multi-word font name spells the same family quoted or as the bare ident
-   sequence it unquotes to (CSS Fonts 4 sec. 15.3), and a custom property
+   sequence it unquotes to (CSS Fonts 4 sec. 2.1.1), and a custom property
    holding a font stack substitutes either form identically into [font-family].
    Emission keeps whichever the author wrote, so the projection folds the quoted
    form onto the ident sequence - the same normalisation the structural
@@ -531,7 +531,7 @@ let rec normalize_custom_values (stmts : statement list) : statement list =
       | other -> other)
     stmts
 
-(* CSS Color 4 sec. 10: [color(srgb r g b)] scales each channel by 255, so
+(* CSS Color 4 sec. 10.2: [color(srgb r g b)] scales each channel by 255, so
    [color(srgb 1 0 0)] and [rgb(255 0 0)] are one colour written two ways. Under
    [--lossless] the optimizer keeps whichever function the author used, which
    leaves the projection reading the spelling as a difference. Fold the
@@ -624,7 +624,7 @@ let rec sort_property_runs (stmts : statement list) : statement list =
   in
   go [] stmts
 
-(* Media Queries 4 sec. 2.1: [all] matches every media type, so it is the
+(* Media Queries 4 sec. 2.3: [all] matches every media type, so it is the
    identity in [<media-type> and <condition>] and the Level 3 spelling [not all
    and (X)] is the same query as the Level 4 [not (X)]. Bare [not all] has no
    condition form - it matches nothing - so it stays, and the unnegated [all and

--- a/lib/rule_order.mli
+++ b/lib/rule_order.mli
@@ -37,13 +37,13 @@ val canonicalize : Stylesheet.statement list -> Stylesheet.statement list
     order carries no meaning. Every block body is its own run context.
 
     A [@media] query of the Level 3 form [not all and (X)] is rewritten to the
-    Level 4 [not (X)] it is equal to under Media Queries 4 sec. 2.1, since [all]
+    Level 4 [not (X)] it is equal to under Media Queries 4 sec. 2.3, since [all]
     is the identity media type. That direction loses support in a Level 3
     parser, so it belongs to the projection rather than to emission.
 
     A custom property holding a font stack has each quoted multi-word family
     name rewritten as the [<ident>] sequence it unquotes to, which CSS Fonts 4
-    sec. 15.3 makes the same family name. Emission keeps whichever spelling the
+    sec. 2.1.1 makes the same family name. Emission keeps whichever spelling the
     author wrote, since unquoting an opaque token stream could corrupt a
     [content] use, so again only the projection can bring the two together.
 

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -331,7 +331,7 @@ let read_lang_content t =
   Lang langs
 
 let read_dir_content t =
-  (* :dir() accepts only [ltr] or [rtl] per Selectors 4 sec. 6.5.1. *)
+  (* :dir() accepts only [ltr] or [rtl] per Selectors 4 sec. 7.1. *)
   let dir = Cursor.ident t in
   if dir <> "ltr" && dir <> "rtl" then
     Cursor.err_invalid t (":dir() expects ltr or rtl, got: " ^ dir);
@@ -362,7 +362,7 @@ let read_active_view_transition_type t =
     read_active_view_transition_content
 
 let read_part_content t =
-  (* CSS Shadow Parts section 3 [::part()]: a whitespace-separated list of ident
+  (* CSS Shadow 1 section 5.4 [::part()]: a whitespace-separated list of ident
      tokens, *not* comma-separated. *)
   let rec read_idents acc =
     Cursor.ws t;
@@ -453,7 +453,7 @@ let read_class t =
      including parser-valid double-dash identifiers such as .--x. *)
   Class name
 
-(** Parse an ID selector ([#id]). Per CSS Selectors sec. 6.6, an ID must be an
+(** Parse an ID selector ([#id]). Per CSS Selectors sec. 6.7, an ID must be an
     ident-type hash; unrestricted hashes such as digit-only [#123] are not valid
     IDs. *)
 let read_id t =
@@ -661,12 +661,12 @@ let read_attribute t =
       Attribute (ns, attr_name, matcher, flag))
     t
 
-(** Parse the An+B microsyntax (Selectors 4 section 9.2 / CSS Syntax 3 section
-    6) as shape patterns over the component stream: [odd]/[even], bare
+(** Parse the An+B microsyntax (Selectors 4 section 13.3.1 / CSS Syntax 3
+    section 6) as shape patterns over the component stream: [odd]/[even], bare
     [<integer>], [<n-dimension>] with optional offset, the [5n-5]/[5n-] token
     variants, and the [n]/[-n]/[n-5]/... ident forms with an optional leading
-    [+]. Idents are case-insensitive (section 3.3); [+ n] (whitespace after [+])
-    is invalid since [+] is lexically part of the ident form. *)
+    [+]. Idents are case-insensitive (CSS Values 4 sec. 4.1); [+ n] (whitespace
+    after [+]) is invalid since [+] is lexically part of the ident form. *)
 
 (* Numeric helpers: split an arbitrary ident's tail into an optional [-digits]
    suffix, for ndashdigit / ndash / n patterns. *)
@@ -765,7 +765,7 @@ let ensure_no_ws_after_plus t =
   | _ -> ()
 
 (* Dimension forms [<n-dimension>, <ndashdigit-dimension>, <ndash-dimension>]
-   from Selectors Level 4 section 9.2. Assumes the cursor is positioned on a
+   from CSS Syntax 3 section 6.2. Assumes the cursor is positioned on a
    [Dimension] component. *)
 let read_nth_dimension t number unit_ =
   if is_n_unit unit_ then (
@@ -1093,9 +1093,9 @@ let rec matches_nothing = function
   | List xs -> List.for_all matches_nothing xs
   | _ -> false
 
-(* CSS Pseudo-Elements 4 sec. 3.5 / Selectors 4 sec. 3.6.4: a pseudo-element
-   compound may only be followed by pseudo-classes. Class/id/type/attribute
-   selectors after the pseudo-element still make the compound invalid. *)
+(* CSS Selectors 4 sec. 3.6.3: a pseudo-element compound may only be followed by
+   pseudo-classes. Class/id/type/attribute selectors after the pseudo-element
+   still make the compound invalid. *)
 let is_pe_action = function
   | Element _ | Class _ | Id _ | Universal _ | Attribute _ | Nesting -> false
   | sel -> not (is_pseudo_element_selector sel)
@@ -1191,7 +1191,7 @@ let read_highlight_content t =
   Highlight [ name ]
 
 let read_vt_class_selector t : vt_class_selector =
-  (* CSS View Transitions 2 sec. 3.4.1 [<vt-class-selector>] = [<vt-name>?
+  (* CSS View Transitions 2 sec. 10.4 [<vt-class-selector>] = [<vt-name>?
      [.<custom-ident>]*]. The name is [<custom-ident> | *]; either the name or
      at least one class must be present. *)
   Cursor.ws t;
@@ -1283,7 +1283,7 @@ and read_nth_selector t : nth * t list option =
         Cursor.list ~sep:Cursor.comma ~at_least:1 read_complex t)
       t
   in
-  (* Per Selectors Level 4 section 9.2, the An+B (plus optional [of S]) must
+  (* Per Selectors Level 4 section 13.3.1, the An+B (plus optional [of S]) must
      consume the entire [<nth-child>] argument list. Leftover tokens (e.g.
      [:nth-child(1 - n)] or [:nth-child(2 n + 2)]) are a parse error, not a
      silently-dropped tail. *)
@@ -1332,7 +1332,7 @@ and read_has_content t =
 
 and read_not_content t =
   let selectors = read_complex_list t in
-  (* CSS Selectors 4 sec. 6.2: [:not()] is non-forgiving, so an unknown selector
+  (* CSS Selectors 4 sec. 4.3: [:not()] is non-forgiving, so an unknown selector
      inside it invalidates the whole rule. Top-level lists keep unknown
      pseudo-classes for forward compatibility. *)
   List.iter
@@ -1391,7 +1391,7 @@ and read_current t = Cursor.call "current" t read_current_content
 
 (* Helper readers for pseudo-element functions that need recursion *)
 and read_slotted_content t =
-  (* CSS Shadow Parts section 4 [::slotted()] takes a single compound selector;
+  (* CSS Shadow 1 section 3.2.4 [::slotted()] takes a single compound selector;
      comma-separated lists are a syntax error. *)
   let sel = read_complex t in
   Cursor.ws t;
@@ -1596,7 +1596,7 @@ and read_complex t =
         combine left Descendant (read_complex t)
       else left
 
-(* CSS Selectors 4 section 3.5: the top-level rule selector list is an
+(* CSS Selectors 4 section 3.9: the top-level rule selector list is an
    unforgiving site. [read_compound] keeps [Unknown_pseudo_class] so vendor and
    forward-compat pseudos round-trip, but one at top level is a spec deviation;
    raise so [Selector.of_string ".ok,:future-pseudo"] surfaces a
@@ -1649,7 +1649,7 @@ let read_relative t =
     Cursor.err t "unexpected characters after selector";
   match selectors with [ s ] -> s | _ -> List selectors
 
-(* CSS Nesting 1 sec. 2: a nested selector is implicitly relative to [&], so a
+(* CSS Nesting 1 sec. 3: a nested selector is implicitly relative to [&], so a
    leading [& <combinator>] is redundant: [& .bar] -> [.bar], [& > .bar] -> [>
    .bar]. Only a leading [&] that is the whole left operand of a combinator is
    removed; [&.bar] (compound) and a deeper [&] stay. *)
@@ -1733,7 +1733,7 @@ let elem ctx name = Pp.string ctx ("::" ^ name)
 let vendor ctx name = Pp.string ctx (":-" ^ name)
 let vendor_elem ctx name = Pp.string ctx ("::-" ^ name)
 
-(* CSS Selectors 4 sec. 3.7 keeps [:before] (CSS 2.1) as a deprecated
+(* CSS Selectors 4 sec. 3.6.1 keeps [:before] (CSS 2.1) as a deprecated
    compatibility spelling for the four original pseudo-elements. Minified output
    uses the shorter valid alias; pretty output preserves the parsed colon form
    so the authored spelling round-trips. *)
@@ -2166,13 +2166,13 @@ and pp : t Pp.t =
   (* Functional pseudo-classes *)
   | Is selectors
     when Pp.minified ctx && List.sort compare selectors = [ Link; Visited ] ->
-      (* CSS Selectors 4 sec. 8.2: [:any-link] is defined as equivalent to
+      (* CSS Selectors 4 sec. 8.1: [:any-link] is defined as equivalent to
          [:is(:link, :visited)], same specificity and shorter. *)
       pp ctx Any_link
   | Is selectors -> func ctx "is" sels selectors
   | Where selectors -> func ctx "where" sels selectors
   | Not [ Not [ inner ] ] when Pp.minified ctx ->
-      (* CSS Selectors 4 sec. 5: double negation [:not(:not(X))] is
+      (* CSS Selectors 4 sec. 4.3: double negation [:not(:not(X))] is
          spec-equivalent to [X] (and shorter under minify). *)
       pp ctx inner
   | Not [ Enabled ] when Pp.minified ctx -> pseudo ctx "disabled"
@@ -2182,7 +2182,7 @@ and pp : t Pp.t =
   | Not [ Required ] when Pp.minified ctx -> pseudo ctx "optional"
   | Not [ Optional ] when Pp.minified ctx -> pseudo ctx "required"
   | Not [ Dir "ltr" ] when Pp.minified ctx ->
-      (* CSS Selectors 4 sec. 6.5.1: directionality is binary, so
+      (* CSS Selectors 4 sec. 7.1: directionality is binary, so
          [:not(:dir(ltr))] is spec-equivalent to [:dir(rtl)] (and shorter). *)
       func ctx "dir" Pp.string "rtl"
   | Not [ Dir "rtl" ] when Pp.minified ctx -> func ctx "dir" Pp.string "ltr"
@@ -2335,7 +2335,7 @@ let canonicalize sel =
       | List selectors -> canon (fun xs -> List xs) selectors
       | Where selectors -> canon (fun xs -> Where xs) selectors
       | Is selectors -> (
-          (* CSS Selectors 4 sec. 17: a single-argument [:is(s)] matches the
+          (* CSS Selectors 4 sec. 4.2: a single-argument [:is(s)] matches the
              same elements as [s] with the same specificity, so it reduces to
              [s]. Sound only when [s] is a single compound: a combinator
              ([Combined] / [Relative]) or a [List] makes [:is()] a grouping
@@ -2477,7 +2477,7 @@ let rec specificity = function
   | List xs -> xs |> List.map specificity |> max_specificity
 
 (* Unwrap [:is(s1, s2, ...)] to a selector list only when every argument has the
-   same specificity AND is structurally simple. Selectors 4 sec. 17 gives [:is]
+   same specificity AND is structurally simple. Selectors 4 sec. 4.2 gives [:is]
    the [max] specificity of its arguments, so unwrapping changes specificity
    unless all are already equal. *)
 let rec is_unwrap_safe_is_arg : t -> bool = function

--- a/lib/selector.mli
+++ b/lib/selector.mli
@@ -81,12 +81,12 @@ val pp : t Pp.t
 (** [pp] pretty-prints selectors. *)
 
 val top_level_is_unwrap : t -> t
-(** [top_level_is_unwrap sel] applies the CSS Selectors 4 sec. 17 [:is()] unwrap
-    at the top level of a rule selector: a whole-selector [:is(s1, s2, ...)] or
-    [:is] members of a top-level list flatten into the enclosing selector list
-    when each argument is a structurally simple selector ([Element] / [Class] /
-    [Id] / [Universal] / [Attribute], or a [Compound] of those). Returns [sel]
-    unchanged otherwise. *)
+(** [top_level_is_unwrap sel] applies the CSS Selectors 4 sec. 4.2 [:is()]
+    unwrap at the top level of a rule selector: a whole-selector
+    [:is(s1, s2, ...)] or [:is] members of a top-level list flatten into the
+    enclosing selector list when each argument is a structurally simple selector
+    ([Element] / [Class] / [Id] / [Universal] / [Attribute], or a [Compound] of
+    those). Returns [sel] unchanged otherwise. *)
 
 val to_string : ?minify:bool -> t -> string
 (** [to_string ?minify sel] renders a selector to a string. *)
@@ -184,7 +184,7 @@ val read_relative : Cursor.t -> t
 val drop_redundant_nesting_prefix : t -> t
 (** [drop_redundant_nesting_prefix sel] removes a redundant leading [&] from a
     nested-rule selector: [& .bar] -> [.bar], [& > .bar] -> [> .bar]. A nested
-    selector is implicitly relative to the parent [&] (CSS Nesting 1 sec. 2), so
+    selector is implicitly relative to the parent [&] (CSS Nesting 1 sec. 3), so
     this is shape-preserving for selectors used in a nested position. *)
 
 val read_combinator : Cursor.t -> combinator

--- a/lib/selector_intf.ml
+++ b/lib/selector_intf.ml
@@ -56,7 +56,7 @@ type nth =
   | An_plus_b of int * int (* An+B: a is coefficient, b is offset *)
 
 type vt_class_selector = { name : string option; classes : string list }
-(** CSS View Transitions 2 sec. 3.4.1 [<vt-class-selector>]: an optional vt-name
+(** CSS View Transitions 2 sec. 10.4 [<vt-class-selector>]: an optional vt-name
     ([<custom-ident>] or [*]) followed by zero or more [.<custom-ident>] class
     qualifiers. The empty case (no name and no classes) does not appear in
     cascade output - the parser always reads at least one component. *)

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -88,7 +88,7 @@ let covers_longhand : type a b.
   | Inset_inline, Inset_inline_end -> true
   | Inset_block, Inset_block_start -> true
   | Inset_block, Inset_block_end -> true
-  (* CSS Backgrounds 3 sec. 4: [border] resets every per-side longhand and the
+  (* CSS Backgrounds 3 sec. 3.4: [border] resets every per-side longhand and the
      per-axis [width / style / color] groupings; the transitive closure is
      listed explicitly so the match is one-shot. *)
   | Border, Border_width -> true
@@ -135,13 +135,13 @@ let covers_longhand : type a b.
   | Border_left, Border_left_style -> true
   | Border_left, Border_left_color -> true
   | Border, Border_image -> true
-  (* CSS Logical 1 sec. 4.2: [border-block] / [border-inline] reset their two
+  (* CSS Logical 1 sec. 4.5.4: [border-block] / [border-inline] reset their two
      flow-relative middle-tier longhands. *)
   | Border_block, Border_block_start -> true
   | Border_block, Border_block_end -> true
   | Border_inline, Border_inline_start -> true
   | Border_inline, Border_inline_end -> true
-  (* CSS Masking 1 sec. 6.1: [mask] resets every mask layer longhand and
+  (* CSS Masking 1 sec. 7.9: [mask] resets every mask layer longhand and
      [mask-border]. *)
   | Mask, Mask_image -> true
   | Mask, Mask_repeat -> true
@@ -176,7 +176,7 @@ let covers_longhand : type a b.
   | Font, Font_optical_sizing -> true
   | _ -> false
 
-(* CSS Cascade 5 sec. 7.2: [all] resets every property except [direction],
+(* CSS Cascade 5 sec. 3.2: [all] resets every property except [direction],
    [unicode-bidi], and custom properties. [Unknown_property _] is reset by [all]
    (an unrecognised non-custom property is still a CSS property). *)
 let is_excluded_from_all_reset : type a. a Properties.property -> bool =
@@ -190,7 +190,7 @@ let rec unwrap_theme_guard = function
   | Theme_guarded { decl; _ } -> unwrap_theme_guard decl
   | d -> d
 
-(* CSS Cascade 5 sec. 7.2: [direction] and [unicode-bidi] keep their relative
+(* CSS Cascade 5 sec. 3.2: [direction] and [unicode-bidi] keep their relative
    position after an [all] declaration; partition uses this to anchor them. *)
 let is_all_preserved_reorder : type a. a Properties.property -> bool = function
   | Direction -> true
@@ -281,8 +281,8 @@ let border_inline_end_keys =
     key "border-inline-end-color";
   ]
 
-(* CSS Backgrounds 3 sec. 6.1: [border-image] resets the five image longhands,
-   and sec. 4.5 makes [border] reset [border-image] in turn. *)
+(* CSS Backgrounds 3 sec. 5.7: [border-image] resets the five image longhands,
+   and sec. 3.4 makes [border] reset [border-image] in turn. *)
 let border_image_keys =
   [
     key "border-image-source";
@@ -300,17 +300,17 @@ let border_radius_keys =
     key "border-bottom-left-radius";
   ]
 
-(* CSS Box Alignment 3 sec. 8.3. The legacy [grid-row-gap] / [grid-column-gap]
-   spellings name the same cascade slots as the modern ones, so each axis
-   carries both names. [grid-gap] itself is deliberately absent: it has no typed
-   spelling, and leaving its name out of every footprint keeps it in the
-   conservative [Unknown_property] path. *)
+(* CSS Gaps 1 sec. 2.4. The legacy [grid-row-gap] / [grid-column-gap] spellings
+   name the same cascade slots as the modern ones, so each axis carries both
+   names. [grid-gap] itself is deliberately absent: it has no typed spelling,
+   and leaving its name out of every footprint keeps it in the conservative
+   [Unknown_property] path. *)
 let row_gap_keys = [ key "row-gap"; key "grid-row-gap" ]
 let column_gap_keys = [ key "column-gap"; key "grid-column-gap" ]
 
-(* CSS Animations 2 sec. 4 plus Scroll-driven Animations 1 sec. 4.3, which makes
-   [animation] reset [animation-timeline]. [animation-composition] and the
-   [animation-range-*] longhands are not part of the shorthand. *)
+(* CSS Animations 2 sec. 4.11 and 4.12, which make [animation] reset
+   [animation-timeline]. [animation-composition] and the [animation-range-*]
+   longhands are not part of the shorthand. *)
 let animation_keys =
   [
     key "animation-name";
@@ -333,7 +333,7 @@ let transition_keys =
     key "transition-behavior";
   ]
 
-(* CSS Grid 1 sec. 7.4 and 8.1: [grid-template] resets the three template
+(* CSS Grid 1 sec. 7.4 and 7.8: [grid-template] resets the three template
    longhands, and [grid] resets those plus the three [grid-auto-*] ones. *)
 let grid_template_keys =
   [
@@ -348,7 +348,7 @@ let grid_auto_keys =
 let grid_row_keys = [ key "grid-row-start"; key "grid-row-end" ]
 let grid_column_keys = [ key "grid-column-start"; key "grid-column-end" ]
 
-(* CSS Text Decoration 4 sec. 2.5. [text-underline-offset] and the
+(* CSS Text Decoration 4 sec. 2.6. [text-underline-offset] and the
    [text-decoration-skip-*] longhands are outside the shorthand. *)
 let text_decoration_keys =
   [
@@ -667,7 +667,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Font_optical_sizing -> [ key "font-optical-sizing" ]
   | Font_language_override -> [ key "font-language-override" ]
   | Font_palette -> [ key "font-palette" ]
-  (* CSS Fonts 4 sec. 6.6: [font-synthesis] is its own shorthand, outside the
+  (* CSS Fonts 4 sec. 2.8.5: [font-synthesis] is its own shorthand, outside the
      set [font] resets. *)
   | Font_synthesis ->
       [
@@ -683,7 +683,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Gap -> row_gap_keys @ column_gap_keys
   | Row_gap -> row_gap_keys
   | Column_gap -> column_gap_keys
-  (* CSS UI 4 sec. 6.4: [outline] resets width, style and colour. It leaves
+  (* CSS UI 4 sec. 3.1: [outline] resets width, style and colour. It leaves
      [outline-offset] alone - that one is a sibling, not a longhand. *)
   | Outline -> [ key "outline-width"; key "outline-style"; key "outline-color" ]
   | Outline_width -> [ key "outline-width" ]
@@ -706,7 +706,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Grid_row_end -> [ key "grid-row-end" ]
   | Grid_column_start -> [ key "grid-column-start" ]
   | Grid_column_end -> [ key "grid-column-end" ]
-  (* CSS Box Alignment 3 sec. 4.5, 5.5 and 6.5. *)
+  (* CSS Box Alignment 3 sec. 5.2, 6.3 and 7.3. *)
   | Place_content -> [ key "align-content"; key "justify-content" ]
   | Place_items -> [ key "align-items"; key "justify-items" ]
   | Place_self -> [ key "align-self"; key "justify-self" ]
@@ -719,7 +719,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Webkit_flex_flow -> [ key "flex-direction"; key "flex-wrap" ]
   | Webkit_flex_direction -> [ key "flex-direction" ]
   | Webkit_flex_wrap -> [ key "flex-wrap" ]
-  (* CSS Overflow 3 sec. 3.3. *)
+  (* CSS Overflow 3 sec. 3.1. *)
   | Overflow -> [ key "overflow-x"; key "overflow-y" ]
   | Overflow_x -> [ key "overflow-x" ]
   | Overflow_y -> [ key "overflow-y" ]
@@ -729,7 +729,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Columns -> [ key "column-width"; key "column-count" ]
   | Column_width -> [ key "column-width" ]
   | Column_count -> [ key "column-count" ]
-  (* CSS Lists 3 sec. 3.4. *)
+  (* CSS Lists 3 sec. 3.6. *)
   | List_style ->
       [
         key "list-style-type"; key "list-style-position"; key "list-style-image";
@@ -743,8 +743,8 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Text_decoration_color | Webkit_text_decoration_color ->
       [ key "text-decoration-color" ]
   | Text_decoration_thickness -> [ key "text-decoration-thickness" ]
-  (* CSS Text Decoration 4 sec. 2.7: [text-decoration-skip] is its own shorthand
-     over the five skip longhands. *)
+  (* CSS Text Decoration 4 sec. 2.10: [text-decoration-skip] is its own
+     shorthand over the five skip longhands. *)
   | Text_decoration_skip ->
       [
         key "text-decoration-skip-self";
@@ -768,7 +768,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
       [ key "contain-intrinsic-width"; key "contain-intrinsic-height" ]
   | Contain_intrinsic_width -> [ key "contain-intrinsic-width" ]
   | Contain_intrinsic_height -> [ key "contain-intrinsic-height" ]
-  (* CSS Scroll Snap 1 sec. 5 and 6. *)
+  (* CSS Scroll Snap 1 sec. 4.2 and 5.1. *)
   | Scroll_margin -> scroll_margin_keys
   | Scroll_margin_top -> [ key "scroll-margin-top" ]
   | Scroll_margin_right -> [ key "scroll-margin-right" ]
@@ -804,8 +804,8 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Container -> [ key "container-name"; key "container-type" ]
   | Container_name -> [ key "container-name" ]
   | Container_type -> [ key "container-type" ]
-  (* Scroll-driven Animations 1 sec. 4.1 and 4.2. [view-timeline-inset] is not
-     part of [view-timeline]. *)
+  (* Scroll-driven Animations 1 sec. 2.3.3 and 3.4.4. [view-timeline-inset] is
+     not part of [view-timeline]. *)
   | Scroll_timeline ->
       [ key "scroll-timeline-name"; key "scroll-timeline-axis" ]
   | Scroll_timeline_name -> [ key "scroll-timeline-name" ]
@@ -813,7 +813,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | View_timeline -> [ key "view-timeline-name"; key "view-timeline-axis" ]
   | View_timeline_name -> [ key "view-timeline-name" ]
   | View_timeline_axis -> [ key "view-timeline-axis" ]
-  (* CSS UI 4 sec. 7.4. *)
+  (* CSS UI 4 sec. 5.2.4. *)
   | Caret -> [ key "caret-color"; key "caret-animation"; key "caret-shape" ]
   | Caret_color -> [ key "caret-color" ]
   | Caret_animation -> [ key "caret-animation" ]
@@ -821,7 +821,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Interest_delay -> [ key "interest-delay-start"; key "interest-delay-end" ]
   | Interest_delay_start -> [ key "interest-delay-start" ]
   | Interest_delay_end -> [ key "interest-delay-end" ]
-  (* CSS Inline 3 sec. 5.3. *)
+  (* CSS Inline 3 sec. 6.1. *)
   | Text_box -> [ key "text-box-trim"; key "text-box-edge" ]
   | Text_box_trim -> [ key "text-box-trim" ]
   | Text_box_edge -> [ key "text-box-edge" ]
@@ -831,7 +831,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Text_wrap -> [ key "text-wrap-mode"; key "text-wrap-style" ]
   | Text_wrap_mode -> [ key "text-wrap-mode" ]
   | Text_wrap_style -> [ key "text-wrap-style" ]
-  (* CSS Anchor Positioning 1 sec. 5.4. *)
+  (* CSS Anchor Positioning 1 sec. 6.3. *)
   | Position_try -> [ key "position-try-order"; key "position-try-fallbacks" ]
   | Position_try_order -> [ key "position-try-order" ]
   | Position_try_fallbacks -> [ key "position-try-fallbacks" ]
@@ -1757,10 +1757,10 @@ let extract_inset_block_side :
       Some (End, v, important)
   | _ -> None
 
-(* CSS Align 3 sec. 6.1: [place-items] / [place-content] / [place-self] are the
-   [<align> <justify>] shorthands. When the two longhands appear contiguously
-   with matching importance, fold them; the per-property printer then collapses
-   matching pairs to a single value. *)
+(* CSS Align 3 sec. 5.2, 6.3 and 7.3: [place-items] / [place-content] /
+   [place-self] are the [<align> <justify>] shorthands. When the two longhands
+   appear contiguously with matching importance, fold them; the per-property
+   printer then collapses matching pairs to a single value. *)
 let try_compose_place_at idx i =
   let n = Rule_index.length idx in
   if
@@ -2056,7 +2056,7 @@ let reorder_font_resets_before_font decls =
   in
   go [] decls
 
-(* CSS Lists 3 sec. 1.2: [list-style: <position> <image> <type>] in any order,
+(* CSS Lists 3 sec. 3.6: [list-style: <position> <image> <type>] in any order,
    any subset of components. Cascade stores [List_style] as a string. Drop
    defaults ([outside] / [none] / [disc]) on emit; if all three are defaulted,
    leave a single [outside] - never an empty value. *)
@@ -2258,7 +2258,7 @@ let compose_text_decoration_via_index idx =
         i := !i + 3
   done
 
-(* CSS Backgrounds 3 sec. 4.1: [border] is the shorthand for [border-{top,
+(* CSS Backgrounds 3 sec. 3.4: [border] is the shorthand for [border-{top,
    right,bottom,left}-{width,style,color}]. Cascade composes when all 12
    longhands appear in a contiguous run with matching importance, every width /
    style / color is uniform across the four sides, and no runtime-substitution
@@ -2564,7 +2564,7 @@ let drop_bimg_shadowed_by_border kept =
   in
   List.filteri (fun i item -> not (is_bimg item && dead i)) kept
 
-(* CSS Backgrounds 3 sec. 6.1: compose [border-image] from a contiguous run of
+(* CSS Backgrounds 3 sec. 5.7: compose [border-image] from a contiguous run of
    its longhands ([source] / [slice] [/ width [/ outset]] / [repeat]). The
    longhands are unknown properties, so the shorthand value is rebuilt from
    their text and re-parsed. The shorthand resets any longhand the run omits, so
@@ -2691,7 +2691,7 @@ let compose_border_image_shorthand ~ctx decls =
   compose_border_image_via_index ~ctx idx;
   List.mapi (fun i d -> (i, d)) (Rule_index.to_list idx)
 
-(* CSS Backgrounds 3 sec. 3.10: [background] is the shorthand for the eight
+(* CSS Backgrounds 3 sec. 2.10: [background] is the shorthand for the eight
    per-layer longhands. Cascade composes when a contiguous run of bg-* longhands
    covers a single layer: every longhand carries a single-layer value, no entry
    uses a CSS-wide keyword or [var()], and all share the same importance. *)
@@ -2907,7 +2907,7 @@ let compose_background_shorthand ~ctx decls =
   compose_background_via_index ~ctx idx;
   List.mapi (fun i d -> (i, d)) (Rule_index.to_list idx)
 
-(* CSS Masking 1 sec. 6.1: [mask] is the layer shorthand for [mask-image] /
+(* CSS Masking 1 sec. 7.9: [mask] is the layer shorthand for [mask-image] /
    [mask-position] / [mask-size] / [mask-repeat] / [mask-origin] / [mask-clip] /
    [mask-mode] / [mask-composite] (analogous to [background]). Compose a
    contiguous run that carries a [mask-image]; like [border], [mask] resets
@@ -3056,7 +3056,7 @@ let is_mask_layer_longhand d =
       true
   | _ -> false
 
-(* The [mask] shorthand resets [mask-border] (CSS Masking 1 sec. 6.1), so a
+(* The [mask] shorthand resets [mask-border] (CSS Masking 1 sec. 7.9), so a
    [mask-border] that precedes a run of mask layer longhands can move after them
    without changing any property's cascade: the synthesised [mask] resets
    [mask-border], but the now-trailing [mask-border] overrides that reset back.

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -488,7 +488,7 @@ let trim_unknown_at_prelude prelude =
   String.sub prelude 0 (trim_end (n - 1))
 
 let pp_unknown_at_rule_statement ctx name prelude (block : string option) =
-  (* CSS Syntax 3 section 5.4.2: an at-rule terminates on [;], [}], or EOF. When
+  (* CSS Syntax 3 section 5.5.2: an at-rule terminates on [;], [}], or EOF. When
      the Parser captures an unterminated nested block ([(...], [[...], [{...])
      its source slice can include the at-rule terminator or the enclosing
      block's close - don't echo them as part of the prelude or each round-trip
@@ -531,7 +531,7 @@ let printable_statements ctx statements =
 module String_set = Pp.String_set
 
 let normalise_charset statements =
-  (* CSS Syntax 3 sec. 2.2: [@charset] is an encoding-declaration byte pattern
+  (* CSS Syntax 3 sec. 8.3: [@charset] is an encoding-declaration byte pattern
      recognised before tokenization, not a stylesheet at-rule after parsing. In
      minified output the serializer emits UTF-8, so [@charset "UTF-8"] is
      redundant; keep at most the first non-UTF-8 declaration for byte-level
@@ -1502,12 +1502,12 @@ let read_layer_name_component (r : Cursor.t) : string =
   extend ();
   Buffer.contents buf
 
-(* CSS Conditional Rules section 3 [@import] prelude: [<url> [layer |
-   layer(<layer-name>)]? [supports(<supports-condition>)]? <media-query-list>?].
-   The [~keep_url_repr] flavour preserves the original quote / [url(...)] form
-   in [url] so the at-rule dispatch can round-trip author input verbatim; the
-   canonical flavour ([keep_url_repr=false]) stores the decoded string for the
-   top-level [read_import_rule] reader. *)
+(* CSS Cascade 5 sec. 2 [@import] prelude: [<url> [layer | layer(<layer-name>)]?
+   [supports(<supports-condition>)]? <media-query-list>?]. The [~keep_url_repr]
+   flavour preserves the original quote / [url(...)] form in [url] so the
+   at-rule dispatch can round-trip author input verbatim; the canonical flavour
+   ([keep_url_repr=false]) stores the decoded string for the top-level
+   [read_import_rule] reader. *)
 let read_import_url ~keep_url_repr (r : Cursor.t) =
   let pos = Cursor.position r in
   let value = Cursor.one_of [ Cursor.url; Cursor.string ] r in
@@ -1786,7 +1786,7 @@ let read_descriptor_block normalize inner =
   in
   loop []
 
-(* CSS Fonts 4 sec. 11.2 wants the first bound of a descriptor range <= the
+(* CSS Fonts 4 sec. 4.4 wants the first bound of a descriptor range <= the
    second. Browsers keep a descending range, so the readers accept it but record
    a warning here; [Css.of_string ~strict] then turns the warning into an
    error. *)
@@ -2103,7 +2103,7 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
         if Cursor.peek_semicolon r then Cursor.skip r;
         Some descriptor
     | exception Error.Parse_error e ->
-        (* CSS Fonts 4 sec. 11.2 / CSS Syntax 3 sec. 5.4.4: a descriptor that
+        (* CSS Fonts 4 sec. 4.1 / CSS Syntax 3 sec. 5.5.5: a descriptor that
            does not parse - an unknown name (Fontsource's [font-named-instance])
            or an invalid value of a known one ([font-display:maybe]) - is
            dropped and the rest of the @font-face is kept, matching browsers. *)
@@ -2131,9 +2131,9 @@ let read_font_face (r : Cursor.t) : statement =
   Cursor.with_context r "@font-face" @@ fun () ->
   Cursor.expect_at_keyword "font-face" r;
   Cursor.ws r;
-  (* CSS Fonts 4 sec. 11.2.1: missing [font-family] / [src] is a semantic
-     mismatch, not a syntax one. [validate_partial_statement] flags it; the
-     syntactic reader accepts. *)
+  (* CSS Fonts 4 sec. 4.1: missing [font-family] / [src] is a semantic mismatch,
+     not a syntax one. [validate_partial_statement] flags it; the syntactic
+     reader accepts. *)
   let descriptors = Cursor.braces read_font_face_block r in
   Font_face descriptors
 
@@ -2305,7 +2305,7 @@ let read_counter_style (r : Cursor.t) : statement =
   counter_style_validate r descriptors;
   Counter_style (name, descriptors)
 
-(* CSS Paged Media 3 sec. 3.1: a page selector is an optional page name followed
+(* CSS Paged Media 3 sec. 4.2: a page selector is an optional page name followed
    by zero or more pseudo-pages from [:first | :left | :right | :blank]. *)
 let page_selector_error r s =
   Cursor.err_invalid r ("invalid @page selector: " ^ s)
@@ -2330,7 +2330,7 @@ let rec page_selector_skip_ws s len i =
     page_selector_skip_ws s len (i + 1)
   else i
 
-(* CSS Paged Media 3 section 3.1: [<page-selector-list> = <page-selector>#],
+(* CSS Paged Media 3 section 4.3: [<page-selector-list> = <page-selector>#],
    [<page-selector> = <ident-token>? <pseudo-page>*], with each pseudo-page from
    the closed set [first | left | right | blank], so [@page invoice:blank:first]
    is well-formed. *)
@@ -2840,7 +2840,7 @@ let unknown_block_body slice value =
       in
       slice first.Loc.start_pos last.Loc.end_pos |> trim_unknown_block_body
 
-(* CSS Syntax 3 sec. 5.4.2 "consume an at-rule": after the at-keyword has been
+(* CSS Syntax 3 sec. 5.5.2 "consume an at-rule": after the at-keyword has been
    consumed, walk components until we hit [;] (no block) or [{...}] (block). Raw
    prelude/block strings are sliced from the original source so the at-rule
    round-trips byte-for-byte even when its grammar is unknown. *)
@@ -2861,7 +2861,7 @@ let read_unknown_at_rule name (r : Cursor.t) : statement =
         ignore (Cursor.next_raw r)
     | Some (Component.Block { node = { opening = Token.Curly; value; _ }; _ })
       ->
-        (* CSS Syntax 3 section 5.4.2: when an unterminated nested block
+        (* CSS Syntax 3 section 5.5.2: when an unterminated nested block
            ([(...], [[...]) inside the at-rule's body extends to EOF, the
            Parser's source slice carries the close [}] and any trailing
            whitespace from outside the block - trim them so the serializer
@@ -3029,7 +3029,7 @@ let read_rule_selector ?(nested = false) r =
   let c = Cursor.sub ?eof_loc r prelude in
   (* Re-raise the original [Parse_error] so its loc/kind/path/snippet reach the
      caller intact, rather than rewrapping (which erases the structured error
-     and relocates it). CSS Nesting 1 sec. 2: a nested rule's prelude is a
+     and relocates it). CSS Nesting 1 sec. 3: a nested rule's prelude is a
      [<relative-selector-list>], so it may start with a combinator ([> .bar])
      implicitly relative to the parent [&]. *)
   Cursor.with_context c "selector" (fun () ->
@@ -3296,8 +3296,8 @@ and read_moz_document (r : Cursor.t) : statement =
   Moz_document (conditions, content)
 
 and read_scope (r : Cursor.t) : statement =
-  (* CSS Scoping section 3: [@scope <start> to <end> { ... }]. The two selectors
-     are kept as raw strings; the block is consumed normally. *)
+  (* CSS Cascade 6 sec. 3.5.2: [@scope <start> to <end> { ... }]. The two
+     selectors are kept as raw strings; the block is consumed normally. *)
   Cursor.expect_at_keyword "scope" r;
   Cursor.ws r;
   let prelude_components = Cursor.drain_until_block r in
@@ -3523,7 +3523,7 @@ and read_rule_decl_or_nested selector inner decls nested =
       if Cursor.peek_semicolon inner then Cursor.skip inner;
       `Continue (d :: decls, nested)
   | None -> read_nested_rule_or_done selector inner decls nested
-  (* CSS Nesting 1 sec. 2 lets a nested rule start with an identifier, so
+  (* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so
      [h2:where(...) { ... }] reads as a declaration up to the [{]. Rewind and
      take it as a rule; a genuine bad declaration has no block and still reports
      as one. *)
@@ -3637,7 +3637,7 @@ let cursor_of_rule ?source ?meta : Component.rule -> Cursor.t = function
         match block with
         | Some b -> [ Component.Block b ]
         | None ->
-            (* Section 5.4.2 "consume an at-rule" terminates on [;] or EOF and
+            (* Section 5.5.2 "consume an at-rule" terminates on [;] or EOF and
                drops the terminator. Readers like [read_layer] and
                [read_charset] then expect a trailing semicolon; synthesize one
                so the replayed cursor matches the original token shape
@@ -3839,8 +3839,8 @@ let read_stylesheet_of_rules ?source ?meta (rules : Component.rule list) :
     stylesheet * Error.t list =
   let warnings = ref [] in
   let validate_prelude = validate_partial_prelude () in
-  (* CSS Conditional Rules 5 section 4.6: [@else] is a continuation rule and
-     must follow [@when] or another [@else]. A bare top-level [@else] is a parse
+  (* CSS Conditional Rules 5 section 4: [@else] is a continuation rule and must
+     follow [@when] or another [@else]. A bare top-level [@else] is a parse
      error. *)
   let previous : statement option ref = ref Option.None in
   let statements =

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -186,7 +186,7 @@ and statement =
       prelude : string;
       block : string option;
     }
-      (** CSS Syntax 3 sec. 5.4.2 "consume an at-rule" preserves any
+      (** CSS Syntax 3 sec. 5.5.2 "consume an at-rule" preserves any
           unrecognised at-rule as raw text so authors can ship unknown vendor or
           future at-rules without dropping the whole stylesheet. *)
 

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -292,9 +292,9 @@ and pp_and_branch ctx = function
 
 and pp_and ctx a b =
   pp_and_branch ctx a;
-  (* CSS Conditional 5 sec. 4.4: a [)and ] sequence is unambiguous so the
-     leading space is droppable under minify; the trailing space is required to
-     keep [and(] from re-tokenising as a function call. *)
+  (* CSS Conditional 3 sec. 6: a [)and ] sequence is unambiguous so the leading
+     space is droppable under minify; the trailing space is required to keep
+     [and(] from re-tokenising as a function call. *)
   Pp.sp ctx ();
   Pp.string ctx "and ";
   pp_and_branch ctx b

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -36,9 +36,9 @@ let read_system_color_of_string keyword : color option =
   | "-webkit-focus-ring-color" -> Some (System Webkit_focus_ring_color)
   | _ -> None
 
-(* CSS Color 4 sec. 6.1 and 6.4: the named colours, each with its canonical CSS
-   spelling and its sRGB bytes. This list is the only place either is written
-   down. [pp_color_name], [color_name_hex], the colour-keyword reader,
+(* CSS Color 4 sec. 6.1: the named colours, each with its canonical CSS spelling
+   and its sRGB bytes. This list is the only place either is written down.
+   [pp_color_name], [color_name_hex], the colour-keyword reader,
    [read_color_name] and the hex inversion all derive from it, so a name and its
    bytes cannot drift apart and every view covers the same 148 colours. Hex is
    stored in its shortest spelling ([rrggbb] folded to [rgb]), which is what
@@ -882,7 +882,7 @@ let pp_calc_contents : type a. a Pp.t -> a calc Pp.t =
 
 (* Fold [a / b] only when the float quotient round-trips through multiplication:
    exact divisions like [100/4 = 25] survive but [100/3 = 33.333...] does not,
-   so the calc wrapper stays and CSS Values 4 sec. 10.7's precision requirement
+   so the calc wrapper stays and CSS Values 4 sec. 10.13's precision requirement
    holds. *)
 let exact_div (a : float) (b : float) : float option =
   if b = 0. then Option.none
@@ -942,8 +942,8 @@ let fold_zero_numeric_expr : type a.
       match value with Some 0. -> Some (Num 0.) | _ -> None)
   | _ -> None
 
-(* CSS Values 4 sec. 10.7 value-independent calc identities: hold for any finite
-   operand, so they fold even across a kept [var()] (single-valued inside
+(* CSS Values 4 sec. 10.10.1 value-independent calc identities: hold for any
+   finite operand, so they fold even across a kept [var()] (single-valued inside
    [calc()], so [var * 1 = var]). Identity cases ([x * 1], [x / 1], [x + 0],
    ...) return the operand verbatim; zero-producing cases take the type's
    canonical zero from [~zero], and [~is_zero] recognises a typed zero leaf
@@ -1035,11 +1035,11 @@ let rec eval_calc : type a. ?ctx:calc_ctx -> a calc -> a calc =
               | Some zero -> zero
               | None -> Expr (l, op, r))))
 
-(* CSS Values 4 sec. 10.7 typed [calc()] reduction, shared by every dimensioned
-   type: the [Expr] dispatch is identical, only the per-type leaves differ and
-   are passed in ([math_fn], [scale], [combine], [zero] / [is_zero] for the
-   identities). A shape with no [scale] / [combine] returns [None] and the
-   [calc()] is kept verbatim. *)
+(* CSS Values 4 sec. 10.10.1 typed [calc()] reduction, shared by every
+   dimensioned type: the [Expr] dispatch is identical, only the per-type leaves
+   differ and are passed in ([math_fn], [scale], [combine], [zero] / [is_zero]
+   for the identities). A shape with no [scale] / [combine] returns [None] and
+   the [calc()] is kept verbatim. *)
 let rec eval_typed_calc : type a.
     math_fn:(math_fn -> a calc) ->
     scale:(exact:bool -> calc_op -> a -> float -> a option) ->
@@ -1085,7 +1085,8 @@ let rec eval_typed_calc : type a.
           match scale ~exact:true Mul a n with
           | Some v -> Val v
           | None -> Expr (l, op, r))
-      (* CSS Values 4 sec. 10.7: [1 / (1 / x)] cancels the double inversion. *)
+      (* CSS Values 4 sec. 10.10.1: [1 / (1 / x)] cancels the double
+         inversion. *)
       | Num 1., Div, Parens (Expr (Num 1., Div, x)) -> x
       | Num 1., Div, Expr (Num 1., Div, x) -> x
       | _ -> (
@@ -1317,7 +1318,7 @@ let rec resolve_length_calc_vars ctx : length calc -> length calc = function
     as leaf ->
       leaf
 
-(* CSS Values 4 sec. 6.1: the absolute lengths share px as a canonical unit. *)
+(* CSS Values 4 sec. 6.2: the absolute lengths share px as a canonical unit. *)
 let absolute_unit_px_ratio = function
   | "px" -> Some 1.
   | "in" -> Some 96.
@@ -1328,9 +1329,9 @@ let absolute_unit_px_ratio = function
   | "pc" -> Some (96. /. 6.)
   | _ -> None
 
-(* CSS Values 4 sec. 10.7: same-unit add/sub of two typed lengths reduces to a
-   single length. Mixed cases reduce when both operands are absolute units
-   (px-compatible per sec. 6.1) by combining in the canonical px form; relative
+(* CSS Values 4 sec. 10.10.1: same-unit add/sub of two typed lengths reduces to
+   a single length. Mixed cases reduce when both operands are absolute units
+   (px-compatible per sec. 6.2) by combining in the canonical px form; relative
    units (em/rem/vw/...) still require cascade context and stay unfolded. *)
 let length_combine op v1 v2 =
   let combine a b =
@@ -1347,7 +1348,7 @@ let length_combine op v1 v2 =
       | _ -> None)
   | _ -> None
 
-(* CSS Values 4 sec. 10.7: a unitless factor scales a typed length, unit
+(* CSS Values 4 sec. 10.10.1: a unitless factor scales a typed length, unit
    unchanged. Division folds only when [exact_div] is exact, else the [calc()]
    is kept to avoid precision loss. Exception: an irrational divisor (a math
    constant [pi] / [e] / ...) can never be exact, and keeping [calc()] preserves
@@ -1370,7 +1371,7 @@ let length_scale ?(exact = true) op v n =
           else Option.none
     | _ -> Option.none
 
-(* CSS Values 4 sec. 10.7: [abs()] preserves the input's type, so
+(* CSS Values 4 sec. 10.6: [abs()] preserves the input's type, so
    [abs(<length>)] returns a [<length>]. The generic [Math_fn -> Num] reduction
    strips the unit; reconstruct a length [Val] when the argument's [Dim] carries
    one. *)
@@ -1887,7 +1888,7 @@ let pp_typed_math_call ctx name pp_arg args =
   Pp.list ~sep pp_arg ctx args;
   Pp.char ctx ')'
 
-(* CSS Values 4 sec. 10.7 [min()] / [max()] reduce when every argument is a
+(* CSS Values 4 sec. 10.2 [min()] / [max()] reduce when every argument is a
    plain dimension of the same unit (so [min(1px, 2px)] -> [1px], [max(1em,
    .5em, 2em)] -> [2em]). Mixed units or any non-literal argument (variables,
    calc(), nested math) bail out and keep the function call. *)
@@ -2004,7 +2005,7 @@ let rec pp_length ?(always = false) : length Pp.t =
   | Ic f -> pp_unit_fn f "ic"
   | Ric f -> pp_unit_fn f "ric"
   | Rlh f -> pp_unit_fn f "rlh"
-  (* CSS Values 4 sec. 6.5: the unit-drop on a zero is for [<length>] only; [Pct
+  (* CSS Values 4 sec. 6: the unit-drop on a zero is for [<length>] only; [Pct
      0.] is a [<percentage>] zero and must keep [%] - dropping it would change
      the value's type from percentage to length. *)
   | Pct f -> Pp.pct ctx f
@@ -2107,7 +2108,7 @@ and pp_calc_wrapped_length ~always ctx length =
   pp_length ~always ctx length;
   Pp.char ctx ')'
 
-(* CSS Values 4 sec. 10.5: arguments to math functions ([clamp()], [min()],
+(* CSS Values 4 sec. 10.2: arguments to math functions ([clamp()], [min()],
    [max()], [minmax()]) are implicit calc expressions. A top-level [Calc] node
    is emitted as its bare expression body (no surrounding [calc(...)]). Nested
    [Calc] inside other length shapes still serializes through [pp_length]. *)
@@ -2566,11 +2567,11 @@ let hex s : color =
   | Option.None ->
       invalid_arg (String.concat "" [ "Values.hex: not a hex colour: "; s ])
 
-(* CSS Color 4 sec. 4.2.3 [none] sentinel: per-channel folding of a static
-   colour to sRGB. Each channel is [Some byte] when the colour resolves
-   statically and the channel is a numeric value, [Option.None] when the channel
-   is the [none] keyword. The outer [Option.None] means the whole colour can't
-   be folded (e.g. contains [Var] / [Calc] / unsupported space). *)
+(* CSS Color 4 sec. 4.4 [none] sentinel: per-channel folding of a static colour
+   to sRGB. Each channel is [Some byte] when the colour resolves statically and
+   the channel is a numeric value, [Option.None] when the channel is the [none]
+   keyword. The outer [Option.None] means the whole colour can't be folded (e.g.
+   contains [Var] / [Calc] / unsupported space). *)
 let static_color_to_srgb_channels :
     color -> (int option * int option * int option * int option) option =
   function
@@ -2653,11 +2654,11 @@ let exact_rgb_to_srgb_bytes c : (int * int * int * int) option =
   | Transparent -> Some (0, 0, 0, 0)
   | _ -> None
 
-(* CSS Color 4 sec. 10: [color(srgb r g b)] is [rgb()] with its channels scaled
-   to [0..1], so the two functions spell one colour exactly when every channel
-   lands on a whole byte. No other [color()] space converts to sRGB without a
-   transfer function or a matrix, so nothing else here is exact; a channel
-   outside the gamut, a [none] and a [var()] are all left alone. *)
+(* CSS Color 4 sec. 10.2: [color(srgb r g b)] is [rgb()] with its channels
+   scaled to [0..1], so the two functions spell one colour exactly when every
+   channel lands on a whole byte. No other [color()] space converts to sRGB
+   without a transfer function or a matrix, so nothing else here is exact; a
+   channel outside the gamut, a [none] and a [var()] are all left alone. *)
 let exact_srgb_function_channels c : (int * int * int * alpha) option =
   let byte : component -> int option = function
     | Num f when f >= 0. && f <= 1. ->
@@ -2692,9 +2693,9 @@ let lerp_byte b1 b2 w1 w2 =
   Float.to_int
     (Float.round ((Float.of_int b1 *. w1) +. (Float.of_int b2 *. w2)))
 
-(* Mix two static colours in sRGB per CSS Color 5 sec. 5. [None] if either
+(* Mix two static colours in sRGB per CSS Color 5 sec. 3. [None] if either
    operand can't fold statically ([Var] / [Calc]) or the weights reduce to zero.
-   CSS Color 4 sec. 4.2.3 [none] sentinel: a [none] channel inherits the other
+   CSS Color 4 sec. 4.4 [none] sentinel: a [none] channel inherits the other
    operand's channel rather than averaging in a zero; both [none] yields [none]
    (returned as zero, since the caller routes through [Hex] and [#000000] is the
    shortest fully-[none] spelling). *)
@@ -2706,7 +2707,7 @@ let mix_srgb_bytes c1 c2 ~p1 ~p2 =
       match mix_weights p1 p2 with
       | None -> Option.None
       | Some (w1, w2, alpha_mult) ->
-          (* CSS Color 4 sec. 12.3: colours with alpha interpolate
+          (* CSS Color 4 sec. 13.3: colours with alpha interpolate
              premultiplied, then un-premultiply by the result alpha - otherwise
              a transparent operand ([#0000]) bleeds its zero channels in and
              darkens the result. A [none] (or absent) alpha contributes as fully
@@ -3057,11 +3058,11 @@ let resolve_static_srgb (c : color) : color =
           | None -> c)
       | None -> c)
 
-(* CSS Color 4 sec. 12.2 [hue interpolation method] mapping into the simpler
+(* CSS Color 4 sec. 13.4 [hue interpolation method] mapping into the simpler
    [Color_space.hue_interpolation] enum. [Default] and [Specified] both collapse
-   to [Shorter] for the static fold; CSS Color 5 sec. 13 makes [shorter hue] the
-   default and [specified hue] is a no-op for [color-mix] inputs that aren't
-   already in a polar space. *)
+   to [Shorter] for the static fold; sec. 13.4 makes [shorter hue] the default
+   and [specified hue] is a no-op for [color-mix] inputs that aren't already in
+   a polar space. *)
 let color_space_hue (h : hue_interpolation) : Color_space.hue_interpolation =
   match h with
   | Shorter | Default | Specified -> Color_space.Shorter
@@ -3072,7 +3073,7 @@ let color_space_hue (h : hue_interpolation) : Color_space.hue_interpolation =
 let alpha_of_unit_float a : alpha =
   if a >= 1.0 -. 1e-6 then None else if a <= 1e-6 then Num 0.0 else Num a
 
-(* Premultiplied interpolation (CSS Color 4 sec. 12.3): each coordinate is
+(* Premultiplied interpolation (CSS Color 4 sec. 13.3): each coordinate is
    multiplied by its operand alpha before mixing and the sum divided by the
    interpolated alpha, so a [transparent] operand contributes only alpha and not
    its zero coordinates. The [alpha_mult] (<100%-sum) scaling lands on the final
@@ -3087,7 +3088,7 @@ let premult_mix3 ~w1 ~w2 ~a1 ~a2 (x1, y1, z1) (x2, y2, z2) =
 
 (* Polar variant: lightness and chroma premultiply like rectangular axes, but
    the hue angle never does. A zero-chroma operand ([transparent], grey, white)
-   has a powerless hue (CSS Color 4 sec. 12.2): it carries the other operand's
+   has a powerless hue (CSS Color 4 sec. 4.4.1): it carries the other operand's
    hue over instead of dragging the mix toward an undefined angle. *)
 let premult_mix_polar ~w1 ~w2 ~a1 ~a2 ~hue (l1, c1, h1) (l2, c2, h2) =
   let interp_alpha = (a1 *. w1) +. (a2 *. w2) in
@@ -3282,7 +3283,8 @@ let minify_color : color -> color = function
         | None -> Named n)
   | c -> c
 
-(* CSS Color 4 sec. 11 normalises system colour keywords to lowercase ASCII. *)
+(* CSS Color 4 sec. 15.5 normalises system colour keywords to lowercase
+   ASCII. *)
 let pp_system_color : system_color Pp.t =
  fun ctx -> function
   | Accent_color -> Pp.string ctx "accentcolor"
@@ -3397,7 +3399,7 @@ let rec pp_alpha : alpha Pp.t =
  fun ctx -> function
   | None -> ()
   | Num f ->
-      (* CSSOM serialisation (CSS Values 4 sec. 6.7.2) drops a leading zero on
+      (* CSSOM serialisation (CSSOM 1 sec. 6.7.2) drops a leading zero on
          fractional numbers: emit [.25] not [0.25] in both modes. Under minify,
          round to 3 decimals (alpha precision is 1/255 ~ 0.004 in sRGB); alpha
          is a colour channel, so [lossless] opts out of that fold like the other
@@ -3432,7 +3434,7 @@ let rec pp_percentage ?(always = false) : percentage Pp.t =
    clamp reduce to one dimension when the operands share a unit; round / mod /
    rem / hypot / abs fold on [px] operands; calc folds through the generic
    simplifier. A non-static operand keeps the call. *)
-(* CSS Values 4 sec. 6.5: a zero [<length>] drops its unit ([0px] -> [0]). That
+(* CSS Values 4 sec. 6: a zero [<length>] drops its unit ([0px] -> [0]). That
    leaves [<length>] for [<number>], so it is a type-changing rewrite, not a
    shorter spelling - the printer keeps [0px] and the strip happens here. Only a
    top-level [<length>] strips: a calc / function operand keeps its unit, and a
@@ -3654,11 +3656,11 @@ let normalize_duration ?(ctx = default_calc_ctx) (d : duration) : duration =
       match eval_time_calc ~ctx c with Val v -> v | folded -> Calc folded)
   | _ -> d
 
-(* CSS Values 4 sec. 10.7: a typed [<angle>] multiplied or divided by a unitless
-   number scales the angle's coefficient and keeps its unit, so [calc(1deg *
-   -45)] reduces to [-45deg]. Division folds only when the quotient is [exact]
-   (see [exact_div]); dividing by a math constant ([pi] / ...) is irrational, so
-   it rounds like the matching multiplication. *)
+(* CSS Values 4 sec. 10.10.1: a typed [<angle>] multiplied or divided by a
+   unitless number scales the angle's coefficient and keeps its unit, so
+   [calc(1deg * -45)] reduces to [-45deg]. Division folds only when the quotient
+   is [exact] (see [exact_div]); dividing by a math constant ([pi] / ...) is
+   irrational, so it rounds like the matching multiplication. *)
 let angle_scale ?(exact = true) op (a : angle) n : angle option =
   if not (Float.is_finite n) then Option.none
   else
@@ -3674,10 +3676,10 @@ let angle_is_zero : angle -> bool = function
   | Deg f | Rad f | Turn f | Grad f -> f = 0.
   | _ -> false
 
-(* CSS Values 4 sec. 10.7: same-unit add/sub of two typed angles reduces to one
-   angle ([calc(45deg + 45deg)] -> [90deg]). Cross-unit operands (e.g. [1turn +
-   90deg]) stay unfolded; [normalize_angle] picks the shortest spelling of a
-   single folded operand, not across a mixed sum. *)
+(* CSS Values 4 sec. 10.10.1: same-unit add/sub of two typed angles reduces to
+   one angle ([calc(45deg + 45deg)] -> [90deg]). Cross-unit operands (e.g.
+   [1turn + 90deg]) stay unfolded; [normalize_angle] picks the shortest spelling
+   of a single folded operand, not across a mixed sum. *)
 let angle_combine op (a : angle) (b : angle) : angle option =
   let f = combine_leaf op in
   match (a, b) with
@@ -4030,7 +4032,7 @@ let rec pp_rgb : rgb Pp.t =
   | Channels { r; g; b } -> Pp.list ~sep:Pp.space pp_channel ctx [ r; g; b ]
   | Var v -> pp_var pp_rgb ctx v
 
-(** Lab-like float string. CSSOM serialisation (CSS Values 4 sec. 6.7.2) drops a
+(** Lab-like float string. CSSOM serialisation (CSSOM 1 sec. 6.7.2) drops a
     leading zero on fractional numbers; the coefficient prints in full so the
     value round-trips, with precision reduction left to [normalize_color]. *)
 let string_of_lab_float f =
@@ -4446,7 +4448,7 @@ and pp_color_default : color Pp.t =
 
 let pp_specified_color = pp_color_default
 
-(* CSS Values 4 sec. 6.3: [ms] and [s] are interchangeable; pick the shorter
+(* CSS Values 4 sec. 7.2: [ms] and [s] are interchangeable; pick the shorter
    spelling when minifying. The "s" suffix is one character shorter than "ms",
    so a millisecond value collapses to seconds when its second-form digits are
    no longer than the millisecond-form digits. *)
@@ -4738,7 +4740,7 @@ let read_env : type a. (Cursor.t -> a) -> Cursor.t -> a env =
  fun read_value t ->
   Cursor.call "env" t (fun inner -> read_body read_value inner)
 
-(* CSS Values 4 sec. 6.1: a signed zero is the same value as unsigned zero.
+(* CSS Values 4 sec. 5.3: a signed zero is the same value as unsigned zero.
    Collapse any zero to the canonical [0]: normalise [-0.] to [0.] (so the AST
    never carries a negative-zero float, which breaks structural equality) and
    regenerate the repr from that value rather than echo the authored sign, so
@@ -4760,7 +4762,7 @@ let read_length_unit ?(allow_negative = true) t =
         Dimension { value = n; unit = Option.value unit_raw ~default:""; repr }
   in
   match unit with
-  (* CSS Values 4 sec. 6.5: a [<percentage>] is its own type, so [0%] is [Pct
+  (* CSS Values 4 sec. 5.5: a [<percentage>] is its own type, so [0%] is [Pct
      0.] and keeps [%]; folding it to the length zero would change its type (and
      is unsound for definiteness-sensitive properties like [height]). *)
   | "%" -> (Pct n : length)
@@ -4770,7 +4772,7 @@ let read_length_unit ?(allow_negative = true) t =
       match unit_of_string unit with
       | Some unit -> authored unit
       | None ->
-          (* Unknown / future unit (CSS Values 5 section 6.5 reserves dimension
+          (* Unknown / future unit (CSS Values 4 section 5.4 reserves dimension
              tokens for future units). Readers stay binary: raise here, and the
              declaration-level recovery in [Declaration.read_declaration]
              catches the [Parse_error] and emits a warning that strict mode
@@ -4840,7 +4842,7 @@ let read_math_constant_name t name =
   | _ -> Cursor.err t "expected math constant"
 
 let read_math_number_with_unit t =
-  (* CSS Values 5 sec. 10.7 [sign()] / [abs()] accept a [<calc-sum>] over any
+  (* CSS Values 4 sec. 10.6 [sign()] / [abs()] accept a [<calc-sum>] over any
      numeric type, including dimensions and percentages. Capture the leading
      number plus its unit so [sign(-1vw)] and [sign(1%)] preserve their source
      shape. *)
@@ -5011,7 +5013,7 @@ and read_calc_numeric_function : type a. Cursor.t -> a calc =
       | "min" -> read_numeric_list_call "min" Float.min Float.infinity t
       | "max" -> read_numeric_list_call "max" Float.max Float.neg_infinity t
       | "clamp" -> read_numeric_clamp t
-      (* CSS Values 4 sec. 10.7 numeric math functions: parsed into the typed
+      (* CSS Values 4 sec. 9.1 numeric math functions: parsed into the typed
          [Math_fn] AST so pretty pp re-emits [name(args)]; the optimizer (or
          minify pp) folds via [eval_math_fn]. *)
       | "sqrt" -> Math_fn (Sqrt (read_math_call_arg "sqrt" t))
@@ -5415,7 +5417,7 @@ and length_function_readers ~allow_negative ~with_keywords =
     ("attr", read_attr_length ~allow_negative ~with_keywords);
   ]
 
-(* CSS Values 4 sec. 10.5: arguments to [clamp()], [min()], [max()], [minmax()]
+(* CSS Values 4 sec. 10.2: arguments to [clamp()], [min()], [max()], [minmax()]
    are implicit math expressions, so [clamp(.5rem, 2vw + .5rem, 2rem)] is valid
    without a surrounding [calc()]. Parse each argument with [read_calc_expr] and
    collapse a singleton [Val] back to the plain length so the AST stays compact
@@ -5901,7 +5903,7 @@ let read_angle_trig kind name t =
 let read_angle_atan2 t =
   let typed t =
     Cursor.call "atan2" t (fun inner ->
-        (* CSS Values 4 sec. 10.7: atan2(y, x) accepts <number>|<dimension>|
+        (* CSS Values 4 sec. 10.4: atan2(y, x) accepts <number>|<dimension>|
            <percentage> for both arguments (must match types). When both
            arguments reduce to a scalar in a shared category, the ratio is
            unit-free and the result folds to a [Deg] constant. *)
@@ -6046,7 +6048,7 @@ let read_ok_lightness t : percentage option =
     Option.None)
   else
     let n, unit = Cursor.number_with_unit t in
-    (* CSS Color 4 sec. 9.2/9.3: an out-of-range lightness clamps (to [0, 1] for
+    (* CSS Color 4 sec. 9.3/9.4: an out-of-range lightness clamps (to [0, 1] for
        a bare number) rather than invalidating the colour, matching lab/lch. *)
     match unit with
     | Some "%" -> Some (Pct n : percentage)
@@ -6097,7 +6099,7 @@ let read_oklab t : color =
 
 let read_lab t : color =
   Cursor.ws t;
-  (* CSS Color 4 sec. 10: lab() L accepts [<percentage>] or [<number>]; keep
+  (* CSS Color 4 sec. 9.3: lab() L accepts [<percentage>] or [<number>]; keep
      them distinct ([Pct] vs [Num]) so the printer can drive different precision
      (1 decimal for [<number>] over [0, 100], 4 decimals for [<percentage>]
      which scales by 100). *)
@@ -6128,7 +6130,7 @@ let read_lch t : color =
       Cursor.expect_string "none" t;
       Option.None)
     else
-      (* CSS Color 4 sec. 6.2 lch(): the L channel is [<percentage> | <number>],
+      (* CSS Color 4 sec. 9.3 lch(): the L channel is [<percentage> | <number>],
          distinguish so [lch(54.321 ...)] doesn't round-trip as [lch(54.321%
          ...)] - the [Pct] / [Num] variants drive different printers (the
          [%]-typed one scales the precision by 100 and emits [%]). *)
@@ -6462,7 +6464,7 @@ and read_color_attr t : color =
   Attribute (name, fallback)
 
 and read_relative_color name t : color =
-  (* CSS Color 5 sec. 2: any colour function may take [from <origin> <c1> <c2>
+  (* CSS Color 5 sec. 4.2: any colour function may take [from <origin> <c1> <c2>
      <c3> [/ <alpha>]?]. The origin has a fixed <color> type, so retain the
      parsed node while keeping the not-yet-modelled channel expression
      opaque. *)
@@ -6485,7 +6487,7 @@ and read_relative_color name t : color =
       | Some color -> color
       | None -> Relative_color (name, origin, tail))
 
-(* CSS Color 5 sec. 4.1: [color(from <origin> srgb r g b [/ <alpha>]?)] is a
+(* CSS Color 5 sec. 5.1: [color(from <origin> srgb r g b [/ <alpha>]?)] is a
    self-substitution of the origin's sRGB channels. Static folding requires the
    origin to be reducible to sRGB bytes and the three channel slots to be the
    bare [r] [g] [b] keywords. Wider Color 5 substitutions (other spaces,
@@ -6887,8 +6889,8 @@ let rec read_percentage t : percentage =
   else if Cursor.looking_at_calc t then Calc (read_calc read_percentage t)
   else Pct (Cursor.pct t)
 
-(* CSS Values 5 sec. 10: math functions that produce a non-length type ([asin] /
-   [acos] / [atan] / [atan2] return angles, [sin] / [cos] / [tan] return
+(* CSS Values 4 sec. 10.4: math functions that produce a non-length type ([asin]
+   / [acos] / [atan] / [atan2] return angles, [sin] / [cos] / [tan] return
    numbers). Used in a [<length-percentage>] context they are spec-invalid;
    lightning et al. preserve verbatim, so cascade captures the original call as
    [Invalid [<call>]]. *)
@@ -7002,7 +7004,7 @@ let canonical_color_of_hex r g b a : color =
   | None -> Hex { r; g; b; a }
 
 (* Canonicalise a colour's alpha for a colour the static fold leaves alone (e.g.
-   a [var()] channel). CSS Color 4 sec. 4.1: a fully-opaque [/ 1] / [/ 100%] is
+   a [var()] channel). CSS Color 4 sec. 4.2: a fully-opaque [/ 1] / [/ 100%] is
    redundant and drops; an alpha [<percentage>] is the [<number>] divided by 100
    and serialises as the number. *)
 let alpha_scale ?(exact = true) op (a : alpha) n : alpha option =
@@ -7305,11 +7307,11 @@ let rec normalize_color ?(lossless = false) ?(exact_srgb = false)
 and normalize_mix_color ~lossless ~in_feature_query ~in_space ~hue ~color1
     ~percent1 ~color2 ~percent2 =
   let keep () =
-    (* CSS Color 5 sec. 3 / sec. 13: [shorter] is the default hue and drops, and
-       percentages that restate the [100% - other] default drop too. The
-       interpolation method itself is required syntax, so a written [in oklab]
-       stays - dropping it yields [color-mix(<color>, <color>)], which every
-       browser rejects. *)
+    (* CSS Color 5 sec. 3 / CSS Color 4 sec. 13.4: [shorter] is the default hue
+       and drops, and percentages that restate the [100% - other] default drop
+       too. The interpolation method itself is required syntax, so a written [in
+       oklab] stays - dropping it yields [color-mix(<color>, <color>)], which
+       every browser rejects. *)
     let hue = match hue with Shorter -> Default | h -> h in
     let pct (p : percentage option) =
       match p with Some (Pct f) -> Some f | _ -> None

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -542,7 +542,7 @@ val eval_numeric_calc : 'a calc -> float option
     non-numeric values. *)
 
 val eval_math_fn : math_fn -> float option
-(** [eval_math_fn fn] evaluates a CSS Values 4 sec. 10.7 numeric math function
+(** [eval_math_fn fn] evaluates a CSS Values 4 sec. 9.1 numeric math function
     call to a float. Returns [None] when an arg references an unresolved
     variable. *)
 
@@ -556,12 +556,12 @@ val map_calc : ('a -> 'b) -> 'a calc -> 'b calc
     structure (operators, [Nested], [Parens], [Var] fallbacks). *)
 
 val eval_calc : ?ctx:calc_ctx -> 'a calc -> 'a calc
-(** [eval_calc calc] applies CSS Values 4 sec. 10.7 structural simplification:
-    folds [Expr (Num _, op, Num _)] subtrees into a single [Num] and unwraps
-    trivial [Nested] / [Parens] around leaves. [Val] / [Var] leaves and
-    mixed-type operands survive -- type-specific simplification (e.g., length
-    arithmetic) is the caller's job. With [~ctx], a [Nested] / [Parens] around a
-    single-valued [Var] leaf is also unwrapped (see {!calc_ctx}). *)
+(** [eval_calc calc] applies CSS Values 4 sec. 10.10.1 structural
+    simplification: folds [Expr (Num _, op, Num _)] subtrees into a single [Num]
+    and unwraps trivial [Nested] / [Parens] around leaves. [Val] / [Var] leaves
+    and mixed-type operands survive -- type-specific simplification (e.g.,
+    length arithmetic) is the caller's job. With [~ctx], a [Nested] / [Parens]
+    around a single-valued [Var] leaf is also unwrapped (see {!calc_ctx}). *)
 
 val calc_identity :
   zero:'a calc ->
@@ -571,9 +571,9 @@ val calc_identity :
   'a calc ->
   'a calc option
 (** [calc_identity ~zero ~is_zero l op r] applies the value-independent CSS
-    Values 4 sec. 10.7 identities to one [Expr (l, op, r)] node, returning the
-    folded operand when one applies. These hold for any operand including a kept
-    [var()] (inside [calc()] a [var()] is single-valued): [x * 1], [1 * x],
+    Values 4 sec. 10.10.1 identities to one [Expr (l, op, r)] node, returning
+    the folded operand when one applies. These hold for any operand including a
+    kept [var()] (inside [calc()] a [var()] is single-valued): [x * 1], [1 * x],
     [x / 1], [x + 0], [0 + x], [x - 0] keep [x]; [x * 0] / [0 * x] reduce to
     [zero]. [is_zero] recognises a typed zero leaf ([0px]). Numeric [op] numeric
     is the caller's job. *)

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -45,7 +45,7 @@ type calc_op = Add | Sub | Mul | Div
 *)
 type math_const = Pi | E | Infinity | Neg_infinity | Nan
 
-(** CSS Values 4 sec. 10.7 numeric math function arguments. Self-recursive so
+(** CSS Values 4 sec. 9.1 numeric math function arguments. Self-recursive so
     nested calls round-trip ([pow(2, sqrt(100))]) and arithmetic with constants
     stays as a tree ([(e - exp(1))]). *)
 type math_arg =
@@ -60,7 +60,7 @@ type math_arg =
   | Parens_arg of math_arg
   | Math_call of math_fn
 
-(** CSS Values 4 sec. 10.7 numeric math functions. Each arm preserves its source
+(** CSS Values 4 sec. 9.1 numeric math functions. Each arm preserves its source
     arg shape so pretty pp re-emits [name(args)]; the optimizer evaluates to
     [Num] under minify. *)
 and math_fn =
@@ -102,7 +102,7 @@ type 'a calc =
   | Nested of 'a calc (* Explicitly nested calc(), rendered as calc(inner) *)
   | Parens of 'a calc (* Parenthesized expression, rendered as (inner) *)
   | Math_fn of math_fn
-(* CSS Values 4 sec. 10.7 numeric math functions ([sin], [cos], [hypot], ...).
+(* CSS Values 4 sec. 9.1 numeric math functions ([sin], [cos], [hypot], ...).
    Pretty pp emits [name(args)] preserving source shape; minify pp / optimizer
    evaluates to [Num]. *)
 
@@ -215,8 +215,8 @@ type length =
   | Anchor_size of string
   | Anchor of string option * string * length option
   | Attr of length attr_call
-      (** CSS Values 5 sec. 10 [attr(<attr-name> <attr-type>?, <fallback>?)] for
-          typed-value contexts. *)
+      (** CSS Values 5 sec. 8.7 [attr(<attr-name> <attr-type>?, <fallback>?)]
+          for typed-value contexts. *)
   | Env of length env
   | Var of length var
   | Calc of length calc
@@ -394,7 +394,7 @@ type channel =
   | Pct of float
   | Var of channel var
   | None
-      (** CSS Color 4 sec. 4.2.3 [none] sentinel. Carries through to the
+      (** CSS Color 4 sec. 4.4 [none] sentinel. Carries through to the
           serialised output as the [none] keyword and participates in
           [color-mix] / relative-color substitution by adopting the other
           operand's analogous channel instead of being treated as a zero. *)
@@ -514,8 +514,8 @@ type color =
           an opaque channel-expression tail. *)
   | Relative_color of string * color * string
       (** [<fn>(from <origin> <c1> <c2> <c3> [/ <alpha>]?)] for any color
-          function other than [rgb()] (CSS Color 5 sec. 2). The first string is
-          the function name ([lab], [lch], [oklab], [oklch], [hsl], [hwb],
+          function other than [rgb()] (CSS Color 5 sec. 4.2). The first string
+          is the function name ([lab], [lch], [oklab], [oklch], [hsl], [hwb],
           [color]), the [color] is the parsed origin, and the final string is
           the channel-expression tail. *)
   | Contrast_color of color

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2464,7 +2464,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Border_inline, value -> vars_of_border value
   | Border_inline_start, value -> vars_of_border value
   | Border_inline_end, value -> vars_of_border value
-  (* Logical sizing longhands (CSS Logical 1 sec. 4.2): the same
+  (* Logical sizing longhands (CSS Logical 1 sec. 4.1): the same
      <length-percentage> as the physical property each maps to. *)
   | Inline_size, value -> vars_of_length_percentage value
   | Min_inline_size, value -> vars_of_length_percentage value
@@ -2505,11 +2505,11 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Line_height_step, value -> vars_of_length value
   | Offset_distance, value -> vars_of_length_percentage value
   | Transition_property, value -> vars_of_transition_property_list value
-  (* CSS Box Alignment 3 sec. 6.5: a one-value [place-self] sets both, so the
+  (* CSS Box Alignment 3 sec. 6.3: a one-value [place-self] sets both, so the
      reader stores the [var()] in each half; the dedup collapses them. *)
   | Place_self, (align, justify) ->
       vars_of_align_self align @ vars_of_justify_self justify
-  (* CSS Backgrounds 3 sec. 6.2: [border-image-slice] is numbers, percentages
+  (* CSS Backgrounds 3 sec. 5.2: [border-image-slice] is numbers, percentages
      and the [fill] keyword, none of which carries a var handle. *)
   | Border_image_slice, _ -> []
   (* [shape-outside] and an unrecognised property are held as raw text and an

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -241,7 +241,7 @@ let normalize_expected ~category ~id expected =
         ~upstream:"a{color:color(srgb-linear .2159 .0451 1.5312/.877)}"
         ~cascade:"a{color:color(srgb-linear .216 .045 1.531/.877)}" upstream
   | "colors", "0053" ->
-      (* CSS Color 4 sec. 10.1: [xyz] and [xyz-d65] are spec-equivalent aliases.
+      (* CSS Color 4 sec. 10.9: [xyz] and [xyz-d65] are spec-equivalent aliases.
          The shorter alias is the better minified spelling. The rounded
          3-decimal channels stay below the documented Oklab perceptual error
          budget. *)

--- a/test/render/dom_of_css.ml
+++ b/test/render/dom_of_css.ml
@@ -170,7 +170,7 @@ let attribute_value = function
   | Selector.Substring v | Selector.Substring_quoted (v, _) -> "zz" ^ v ^ "yy"
 
 (* The empty operand of [~=], [|=], [^=], [$=] and [*=] matches nothing, per
-   Selectors 4 sec. 6.2. *)
+   Selectors 4 sec. 6.1 and 6.2. *)
 let attribute_matchable = function
   | Selector.Whitespace_list ""
   | Selector.Whitespace_list_quoted ("", _)

--- a/test/spec/test.ml
+++ b/test/spec/test.ml
@@ -210,7 +210,7 @@ let css2_chapter_matrix () =
     [
       ( "html, body { display: block; min-height: 100% }",
         "body,html{display:block;min-height:100%}" );
-      (* CSS Selectors 4 section 3.5: [*] in a non-solitary compound is
+      (* CSS Selectors 4 section 5.2: [*] in a non-solitary compound is
          redundant, so [*[lang|=en]] serializes as [[lang|=en]]. *)
       ( "body *[lang|=\"en\"] + p:first-line { text-transform: uppercase }",
         "body [lang|=en]+p:first-line{text-transform:uppercase}" );
@@ -284,7 +284,7 @@ let syntax_escapes () =
 (* SS 5.3.7 / 5.4 - Parse errors recover locally *)
 let syntax_recovery () =
   recover ".a { color: invalid; color: red }" ".a{color:red}" 1;
-  (* CSS Selectors 4 section 3.5: an unknown pseudo-class at an unforgiving site
+  (* CSS Selectors 4 section 3.9: an unknown pseudo-class at an unforgiving site
      is a spec deviation. Lenient mode preserves it for forward compatibility
      and warns; strict mode escalates (pinned by [cross_mode_pinning]). *)
   recover ".a,:future-pseudo { color: red } .b { color: blue }" ".b{color:#00f}"
@@ -338,8 +338,8 @@ let selectors_pseudo_classes () =
   roundtrip ":hover { color: red }" ":hover{color:red}";
   roundtrip ":first-child { color: red }" ":first-child{color:red}";
   roundtrip ":last-child { margin: 0 }" ":last-child{margin:0}";
-  (* CSS Selectors 4 section 14: the printer canonicalizes [:nth-child(<an+b>)]
-     to the shortest spec-equivalent spelling. *)
+  (* CSS Selectors 4 section 13.3.1: the printer canonicalizes
+     [:nth-child(<an+b>)] to the shortest spec-equivalent spelling. *)
   roundtrip ":nth-child(2n+1) { color: red }" ":nth-child(odd){color:red}";
   roundtrip ":nth-child(even) { color: blue }" ":nth-child(2n){color:#00f}";
   roundtrip ":nth-child(odd) { color: red }" ":nth-child(odd){color:red}";
@@ -379,7 +379,7 @@ let selectors_where_is () =
   (* Forgiving-parse drops the invalid branch, leaving a single-argument
      [:is(.a)]. Per shortest-wins (Lightning CSS) the single-argument [:is()]
      unwraps to the bare selector, since [:is(.a)] is spec- equivalent to [.a]
-     (same match set, same specificity per Selectors L4 sec. 17). [:where()]
+     (same match set, same specificity per Selectors L4 sec. 4.2). [:where()]
      cannot unwrap the same way because it contributes zero specificity. *)
   roundtrip ":is(:future-pseudo, .a) { color: red }" ".a{color:red}";
   roundtrip ":where(:future-pseudo, .a) { color: red }" ":where(.a){color:red}"
@@ -409,7 +409,7 @@ let values_relative_lengths () =
   roundtrip ".x { height: 100vh }" ".x{height:100vh}";
   roundtrip ".x { width: 50% }" ".x{width:50%}"
 
-(* SS 10.1 - calc() expressions. Per CSS Values 4 section 10.7 the printer
+(* SS 10.1 - calc() expressions. Per CSS Values 4 section 10.10.1 the printer
    simplifies all-constant calc subexpressions and reduces a single
    multiplicative operand to its product. Mixed-unit forms that cannot reduce at
    parse time still drop redundant nested calc() under minify when doing so is
@@ -441,12 +441,12 @@ let color_named () =
   (* SS 6.1 - rebeccapurple *)
   roundtrip ".x { color: rebeccapurple }" ".x{color:#639}"
 
-(* SS 5.1 - Hex notation. Per CSS Color 4 section 12.1, [#rrggbb] and the
-   3-digit shorthand [#rgb] (and likewise [#rrggbbaa]/[#rgba]) denote the
-   identical color, and a fully-opaque alpha channel ([f]/[ff]) is equivalent to
-   omitting alpha. Under [~minify:true] the printer canonicalizes to the
-   shortest equivalent form, including the CSS-named color when shorter (cssnano
-   / Lightning CSS / clean-css conventions). *)
+(* SS 5.1 - Hex notation. Per CSS Color 4 section 5.2, [#rrggbb] and the 3-digit
+   shorthand [#rgb] (and likewise [#rrggbbaa]/[#rgba]) denote the identical
+   color, and a fully-opaque alpha channel ([f]/[ff]) is equivalent to omitting
+   alpha. Under [~minify:true] the printer canonicalizes to the shortest
+   equivalent form, including the CSS-named color when shorter (cssnano /
+   Lightning CSS / clean-css conventions). *)
 let color_hex () =
   (* All these forms denote pure red; the shortest spelling is the named color
      [red]. *)
@@ -458,15 +458,15 @@ let color_hex () =
 (* SS 5.2.3 - rgb() function *)
 let color_rgb () =
   roundtrip ".x { color: rgb(255 0 0) }" ".x{color:red}";
-  (* CSS Color 4 section 1.3: alpha as [<number>] in [\[0, 1\]] is
+  (* CSS Color 4 section 4.2: alpha as [<number>] in [\[0, 1\]] is
      spec-equivalent to [<percentage>] in [\[0%, 100%\]]; the printer
      canonicalizes to the [<number>] form per cssnano. *)
   roundtrip ".x { color: rgb(255 0 0 / 50%) }" ".x{color:#ff000080}";
-  (* CSS Color 4 section 1.4: rgb() with all-percent channels denotes the same
+  (* CSS Color 4 section 5.1: rgb() with all-percent channels denotes the same
      color as the equivalent named/hex form; rgb(100% 0% 0%) is red. *)
   roundtrip ".x { color: rgb(100% 0% 0%) }" ".x{color:red}"
 
-(* SS 5.2.4 - hsl() function. Per CSS Color 4 section 1.4 the hsl() form denotes
+(* SS 5.2.4 - hsl() function. Per CSS Color 4 section 7 the hsl() form denotes
    the same color as a named color or hex when applicable; minified output
    canonicalizes to the shortest equivalent spelling. Equal-length named/hex
    ties use the hex spelling, matching the Lightning CSS oracle in
@@ -492,7 +492,7 @@ let color_mix () =
 
 (* SS 5.3 - transparent and currentcolor keywords *)
 let color_keywords () =
-  (* Per CSS Color 4 section 6.4 the printer canonicalizes the fully-transparent
+  (* Per CSS Color 4 section 6.3 the printer canonicalizes the fully-transparent
      color to the shortest equivalent spelling [#0000]. *)
   roundtrip ".x { color: transparent }" ".x{color:#0000}";
   (* currentColor preserves its camelCase form *)
@@ -637,7 +637,7 @@ let font_face () =
 
 (* {2 CSS Animations Level 1} https://www.w3.org/TR/css-animations-1/ *)
 
-(* SS 7 - @keyframes rule. CSS Animations 1 section 7.1: [from] / [to] are
+(* SS 7 - @keyframes rule. CSS Animations 1 section 3: [from] / [to] are
    spec-equivalent to [0%] / [100%]. The printer canonicalizes to the shorter
    spelling per cssnano / Lightning CSS - [0%] beats [from], [to] beats
    [100%]. *)

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -111,7 +111,7 @@ let projected ?style css =
   | [ (_, decls) ] -> inline_style decls
   | _ -> Alcotest.fail "expected one inline assignment"
 
-(* css-cascade-5 sec. 6.4.4: among normal declarations an unlayered one beats
+(* css-cascade-5 sec. 6.4.3: among normal declarations an unlayered one beats
    every layer, whatever the source order. *)
 let unlayered_beats_layer () =
   Alcotest.(check string)

--- a/test/test_color_space.ml
+++ b/test/test_color_space.ml
@@ -25,7 +25,7 @@ let srgb_blue = (0.0, 0.0, 1.0)
 let srgb_green = (0.0, 1.0, 0.0)
 let srgb_white = (1.0, 1.0, 1.0)
 
-(* CSS Color 4 sec. 11.5.1 reference values for sRGB / linear sRGB. *)
+(* CSS Color 4 sec. 10.2 reference values for sRGB / linear sRGB. *)
 let test_srgb_linearise () =
   Alcotest.(check approx_float) "0 -> 0" 0.0 (Color_space.linear_of_srgb 0.0);
   Alcotest.(check approx_float) "1 -> 1" 1.0 (Color_space.linear_of_srgb 1.0);
@@ -43,8 +43,8 @@ let test_srgb_roundtrip () =
   Alcotest.(check approx_float) "0.5" 0.5 (roundtrip 0.5);
   Alcotest.(check approx_float) "1" 1.0 (roundtrip 1.0)
 
-(* CSS Color 4 sec. 9.1: D65 white in XYZ should land at [(0.9505, 1.0, 1.0890)]
-   (CIE 1931 D65 with Y = 1). *)
+(* CSS Color 4 sec. 10.9: D65 white in XYZ should land at [(0.9505, 1.0,
+   1.0890)] (CIE 1931 D65 with Y = 1). *)
 let test_xyz65_of_linear_srgb () =
   let xyz_white = Color_space.xyz65_of_linear_srgb (1.0, 1.0, 1.0) in
   Alcotest.(check triplet)

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -260,7 +260,7 @@ let test_query_context_boundaries () =
   Alcotest.(check bool)
     "supports declaration is exact on value" false
     (Css.Context.matches_supports ctx (Css.Supports.property "display" "flex"));
-  (* CSS property names are ASCII case-insensitive (CSS Syntax sec. 3.6), so
+  (* CSS property names are ASCII case-insensitive (CSS Syntax sec. 8.1), so
      "Display" and "display" name the same property. *)
   Alcotest.(check bool)
     "supports declaration normalises property case" true

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -200,7 +200,7 @@ let custom_properties_integration () =
     (minify stylesheet)
 
 (* Regression: a custom property name starting with a digit after the -- is a
-   valid dashed-ident per CSS Syntax sec. 4.3.11. Tailwind emits these for
+   valid dashed-ident per CSS Values 4 sec. 4.3. Tailwind emits these for
    arbitrary-value classes like text-[1A202C]. *)
 let var_digit_after_dashes () =
   let css = ".x{font-size:var(--1A202C)}" in

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -78,7 +78,7 @@ let equal_canonical_ignores_property_order () =
        "@property --a{syntax:\"*\";inherits:false}.x{top:0}@property \
         --z{syntax:\"*\";inherits:false}")
 
-(* Media Queries 4 sec. 2.1: [all] matches every media type, so [not all and
+(* Media Queries 4 sec. 2.3: [all] matches every media type, so [not all and
    (X)] and [not (X)] are the same query. Equating them is projection-only - a
    Level 3 parser rejects the shorter form, so emission keeps what it read. *)
 let equal_canonical_media_not_all () =
@@ -99,7 +99,7 @@ let equal_canonical_media_not_all () =
     (Cascade_diff.Css_compare.equal ~mode:`Canonical
        "@media not all{.a{color:red}}" "@media not (hover){.a{color:red}}")
 
-(* CSS Color 4 sec. 10: [color(srgb r g b)] scales each channel by 255, so
+(* CSS Color 4 sec. 10.2: [color(srgb r g b)] scales each channel by 255, so
    [color(srgb 1 0 0)] and [rgb(255 0 0)] are one colour in two spellings.
    [--lossless] keeps a modern colour function on output, which leaves the
    projection reading the spelling as a difference. The fold is exact-only: a
@@ -645,7 +645,7 @@ let canonical_calc_plus_minus_whitespace_distinct () =
     "calc(...) + and - whitespace stays distinct (required for parse)" false
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
 
-(* Fonts L4 sec. 15.3: a font family name is either a <string> or a sequence of
+(* Fonts L4 sec. 2.1.1: a font family name is either a <string> or a sequence of
    <custom-ident>s joined with single spaces; the two forms are equivalent for
    matching whenever the unquoted form would be valid identifiers. The
    equivalence is consumer-dependent (it only holds in font-family-typed

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -72,7 +72,7 @@ let complex_values () =
   decl_optimizes ~prop:"background" ~into:"linear-gradient(90deg,red,#00f)"
     "linear-gradient(to right, red, blue)";
 
-  (* CSS Images 4 section 3.4.1 defines [<color> <p1> <p2>] as exactly [<color>
+  (* CSS Images 4 section 3.5.1 defines [<color> <p1> <p2>] as exactly [<color>
      <p1>, <color> <p2>], so adjacent stops of one colour fold into a
      double-position stop. pp holds the pair; the fold is an optimize step. *)
   check_declaration
@@ -122,9 +122,9 @@ let complex_values () =
      longer. *)
   decl_optimizes ~prop:"flood-opacity" ~into:".5" "50%";
 
-  (* SVG 2 sec. 13.4 and Filter Effects 1 sec. 9.13.1 / 11.5 make each of these
-     a plain <color>, so they shorten like any other colour-valued property
-     instead of surviving as opaque unknown-property text. *)
+  (* SVG 2 sec. 14.2.4.2 and Filter Effects 1 sec. 9.13.1 / 11.5 make each of
+     these a plain <color>, so they shorten like any other colour-valued
+     property instead of surviving as opaque unknown-property text. *)
   check_declaration ~expected:"stop-color:#fff" "stop-color: #ffffff;";
   check_declaration ~expected:"lighting-color:currentColor"
     "lighting-color: currentColor;";
@@ -135,21 +135,22 @@ let complex_values () =
   decl_optimizes ~prop:"flood-color" ~into:"red" "rgb(255, 0, 0)";
   decl_optimizes ~prop:"stop-color" ~into:"#0000" "rgba(0, 0, 0, 0)";
 
-  (* SVG 2 sec. 13.5 and 14.4 give [fill-rule] and [clip-rule] the same
-     <fill-rule>, which is the keyword pair alone: the argument form inside
-     polygon() is a different production. *)
+  (* SVG 2 sec. 13.4.2 and CSS Masking 1 sec. 6.2 give [fill-rule] and
+     [clip-rule] the same <fill-rule>, which is the keyword pair alone: the
+     argument form inside polygon() is a different production. *)
   check_declaration ~expected:"fill-rule:evenodd" "fill-rule: evenodd;";
   check_declaration ~expected:"clip-rule:nonzero" "clip-rule: nonzero;";
   check_declaration ~expected:"fill-rule:var(--r)" "fill-rule: var(--r);";
-  (* SVG 2 sec. 13.3. [miter-clip] and [arcs] are the Level 2 additions to
-     [stroke-linejoin]; a reader that takes the grammar takes all five. *)
+  (* SVG 2 sec. 13.5.4 and 13.5.5. [miter-clip] and [arcs] are the Level 2
+     additions to [stroke-linejoin]; a reader that takes the grammar takes all
+     five. *)
   check_declaration ~expected:"stroke-linecap:square" "stroke-linecap: square;";
   check_declaration ~expected:"stroke-linejoin:arcs" "stroke-linejoin: arcs;";
-  (* SVG 2 sec. 13.3 makes the miter limit a <number> that cannot go below 1, so
-     it minifies like one and a constant calc() folds. *)
+  (* SVG 2 sec. 13.5.5 makes the miter limit a <number> that cannot go below 1,
+     so it minifies like one and a constant calc() folds. *)
   check_declaration ~expected:"stroke-miterlimit:4" "stroke-miterlimit: 4.0;";
   decl_optimizes ~prop:"stroke-miterlimit" ~into:"6" "calc(2 * 3)";
-  (* SVG 2 sec. 13.3 separates dashes by comma and/or whitespace and the
+  (* SVG 2 sec. 13.5.6 separates dashes by comma and/or whitespace and the
      rendered pattern is the flat sequence either way, so both spellings read to
      one list and print with the shorter separator. *)
   check_declaration ~expected:"stroke-dasharray:4 2" "stroke-dasharray: 4, 2;";
@@ -160,7 +161,7 @@ let complex_values () =
   decl_optimizes ~prop:"stroke-dasharray" ~into:"0 4px" "0px 4px";
   check_declaration ~expected:"stroke-dashoffset:.5px"
     "stroke-dashoffset: 0.50px;";
-  (* SVG 2 sec. 13.7: a keyword left out is painted last, in the order [normal]
+  (* SVG 2 sec. 13.8: a keyword left out is painted last, in the order [normal]
      would use, so the specification's own example is that [paint-order: stroke]
      equals [paint-order: stroke fill markers]. The shortest spelling is the
      shortest prefix that expands back to the same order. *)
@@ -169,14 +170,14 @@ let complex_values () =
   decl_optimizes ~prop:"paint-order" ~into:"normal" "fill";
   (* Reordering the tail is load-bearing, so this one keeps both keywords. *)
   decl_optimizes ~prop:"paint-order" ~into:"markers stroke" "markers stroke";
-  (* SVG 2 sec. 7.10 makes [viewport] what an omitted host space means, so
+  (* SVG 2 sec. 8.13 makes [viewport] what an omitted host space means, so
      writing it is redundant; [screen] is not. *)
   decl_optimizes ~prop:"vector-effect" ~into:"non-scaling-stroke"
     "non-scaling-stroke viewport";
   decl_optimizes ~prop:"vector-effect" ~into:"non-scaling-stroke screen"
     "non-scaling-stroke screen";
 
-  (* Complex nested functions. Per CSS Values 4 section 10.7 the printer
+  (* Complex nested functions. Per CSS Values 4 section 10.10.1 the printer
      simplifies all-constant calc subexpressions, reducing same-unit additions
      to a single value. Calcs containing [var()] cannot reduce at syntax time
      and are preserved. *)
@@ -395,7 +396,7 @@ let error_unclosed_block () =
   ignore (read_block r : Css.Declaration.declaration list)
 
 let special_cases () =
-  (* Per CSS Values 4 section 10.7 the inner all-constant calc reduces to
+  (* Per CSS Values 4 section 10.10.1 the inner all-constant calc reduces to
      [60px], leaving the mixed-unit outer calc preserved. *)
   check_declaration ~expected:"width:calc(100% - calc(50px + 10px))"
     "width: calc(100% - calc(50px + 10px));";
@@ -519,7 +520,7 @@ let position () =
   c ~expected:"position:sticky" "position: sticky"
 
 let font_properties () =
-  (* Font weight. Per CSS Fonts 4 section 5.1.2 the keywords [normal] and [bold]
+  (* Font weight. Per CSS Fonts 4 section 2.2 the keywords [normal] and [bold]
      map to [400] / [700]; the printer canonicalizes to the numeric form under
      minify. *)
   check_declaration ~expected:"font-weight:400" "font-weight: normal";
@@ -778,7 +779,7 @@ let animations_timing () =
     ~expected:"animation-timing-function:cubic-bezier(.4,0,.2,1)"
     "animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1)";
 
-  (* Per CSS Values 4 section 6.6 the time unit ([s] or [ms]) is required for
+  (* Per CSS Values 4 section 7.2 the time unit ([s] or [ms]) is required for
      [<time>]. [0s] does not drop the unit. *)
   check_declaration ~expected:"animation-delay:0s" "animation-delay: 0s";
   check_declaration ~expected:"animation-delay:1s" "animation-delay: 1s";
@@ -834,7 +835,7 @@ let transforms () =
   check_declaration ~expected:"transform:matrix(1,0,0,1,0,0)"
     "transform: matrix(1, 0, 0, 1, 0, 0)";
 
-  (* Multiple transforms. Per CSS Transforms 1 section 11 the printer drops
+  (* Multiple transforms. Per CSS Transforms 1 section 8 the printer drops
      whitespace between back-to-back transform functions under minify, matching
      Lightning CSS. *)
   check_declaration ~expected:"transform:translateX(10px)rotate(45deg)"
@@ -843,7 +844,7 @@ let transforms () =
     "transform: scale(2) translateY(20px) rotate(180deg)";
 
   (* Transform origin *)
-  (* Per CSS Transforms 1 sec. 6 [center] is shorthand for [50% 50%] and the
+  (* Per CSS Transforms 1 sec. 4 [center] is shorthand for [50% 50%] and the
      keyword pair [top left] is [0 0]. A single [0] would mean [0 50%], so the
      two-value form must be preserved. *)
   check_declaration ~expected:"transform-origin:50%" "transform-origin: center";
@@ -910,7 +911,7 @@ let grid () =
     "grid-auto-flow: row dense";
   check_declaration ~expected:"grid-auto-flow:column dense"
     "grid-auto-flow: column dense";
-  (* CSS Grid 2 sec. 7.6 gives [ row | column ] || dense with [row] as the
+  (* CSS Grid 2 sec. 7.7 gives [ row | column ] || dense with [row] as the
      omitted axis, so [row dense] and [dense] are one value and the optimizer
      picks the shorter. The axis is load-bearing on [column dense]. *)
   decl_optimizes_to ~held:"grid-auto-flow:row dense"
@@ -1378,7 +1379,7 @@ let edge_cases () =
   check_declaration ~expected:"height:calc(100vh - calc(50px + 1em))"
     "height: calc(100vh - calc(50px + 1em))";
 
-  (* Per CSS Values 4 section 10.7 the printer fully simplifies all-constant
+  (* Per CSS Values 4 section 10.10.1 the printer fully simplifies all-constant
      calcs and reduces multiplicative subexpressions against same-unit
      operands. *)
   check_declaration ~expected:"width:calc((10px + 5px)*2)"
@@ -2131,8 +2132,8 @@ let test_declaration () =
   check "color:red!important";
   check "--custom:value!important";
 
-  (* Complex values. Per CSS Transforms 1 section 11 the printer drops
-     whitespace between back-to-back transform functions under minify. *)
+  (* Complex values. Per CSS Transforms 1 section 8 the printer drops whitespace
+     between back-to-back transform functions under minify. *)
   check_declaration ~expected:"background:linear-gradient(to right,red,blue)"
     "background:linear-gradient(to right,red,blue)";
   decl_optimizes ~prop:"background" ~into:"linear-gradient(90deg,red,#00f)"
@@ -2535,7 +2536,7 @@ let check_sheet_roundtrip name css =
         (String.trim (Css.to_string ~minify:true stylesheet))
   | Error e -> Alcotest.failf "%s: %s" css (Error.to_string e)
 
-(* CSS Shapes 1 sec. 2: [shape-outside] is [none | [<basic-shape> ||
+(* CSS Shapes 1 sec. 6.1: [shape-outside] is [none | [<basic-shape> ||
    <shape-box>] | <image>]. The reader only looked at the first component and
    only knew [none], [circle()] and [inset()] there, so a reference box, a
    box/shape pair, the other basic shapes and an image were all rejected and the

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -39,7 +39,7 @@ let test_empty_block_is_empty () =
     "empty input yields empty output" 0
     (List.length (Flatten.block stmts))
 
-(* CSS Nesting 1 sec. 2 lets a nested rule start with an identifier, so its
+(* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so its
    prelude is ambiguous with a declaration until the block appears:
    [h2:where(...)] reads as the property [h2] with value [where(...)]. Parsing
    has to fall back to a rule, or the whole nested block is dropped. *)
@@ -70,7 +70,7 @@ let test_bad_declaration_still_a_declaration () =
     "the invalid declaration drops, the good one stays" ".a{width:1px}"
     (render stmts)
 
-(* CSS Nesting 1 sec. 2.1: [&] stands for [:is(<parent selector list>)]. The
+(* CSS Nesting 1 sec. 4: [&] stands for [:is(<parent selector list>)]. The
    wrapper is load-bearing whenever the parent carries a combinator and [&] does
    not head the selector, since the parent's own structure would otherwise
    escape into the surrounding context. *)
@@ -91,7 +91,7 @@ let test_nesting_wraps_complex_parent () =
   check ".a .b{&:hover{color:red}}" ".a .b:hover{color:red}";
   check ".a .b{& .c{color:red}}" ".a .b .c{color:red}"
 
-(* CSS Nesting 1 sec. 2: a nested selector list is relative to the parent branch
+(* CSS Nesting 1 sec. 3: a nested selector list is relative to the parent branch
    by branch. Combining the parent with the list as a whole put the combinator
    on the first branch only, and every later branch escaped as a top-level
    selector -- [.p { a, b { ... } }] matched every [b] on the page. *)

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -286,7 +286,7 @@ let spec_fontface_metric_numeric_edges () =
 (* CSS Custom Properties 1 sec. 3 substitutes var() in properties only, and
    @font-face descriptors are not properties: no descriptor grammar accepts it.
    Every one of them is therefore dropped with a warning while the rest of the
-   block is kept (CSS Fonts 4 sec. 11.2, CSS Syntax 3 sec. 5.4.4), and
+   block is kept (CSS Fonts 4 sec. 4.1, CSS Syntax 3 sec. 5.5.5), and
    ~strict:true turns that warning into an error. *)
 let spec_fontface_var_descriptor_edges () =
   let kept = "@font-face{font-family:Brand;src:url(font.woff2)}" in

--- a/test/test_lexer.ml
+++ b/test/test_lexer.ml
@@ -264,7 +264,7 @@ let spec12_tokenization_checklist () =
   check "U+26 u+a" "<unicode-range U+26> <ws> <unicode-range U+A>"
 
 let spec_token_boundary_edges () =
-  (* CSS Syntax Level 3 section 9.4 serialization constraints are driven by
+  (* CSS Syntax Level 3 section 9 serialization constraints are driven by
      tokenizer ambiguities. These vectors pin down pairs that must remain
      distinct after any serializer inserts a boundary. *)
   check "a b" "<ident a> <ws> <ident b>";

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -335,7 +335,7 @@ let media_not_takes_media_in_parens () =
     ~default:"@media not (width>=1px){a{color:red}}"
     ~spec:"@media not (min-width:1px){a{color:red}}"
 
-(* Media Queries 4 sec. 2.1: [all] is the identity media type, so [not all and
+(* Media Queries 4 sec. 2.3: [all] is the identity media type, so [not all and
    (X)] and [not (X)] are the same query. Default minify already spends Level 3
    compatibility by lowering [min-width] to range syntax, so it takes the
    shorter Level 4 [not] as well; [--enforce-spec] keeps both Level 3

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1356,7 +1356,7 @@ let test_merge_consecutive_identical () =
 
 let test_combine_identical_oklab_none () =
   (* A [none] channel in oklab() is a missing component that matters only for
-     color interpolation (CSS Color 4 sec. 4.2.3): color-mix, gradients, and
+     color interpolation (CSS Color 4 sec. 4.4): color-mix, gradients, and
      transitions carry it forward. It does not affect rule grouping, which is
      set union (Selectors 4 sec. 4.2) and never interpolates. So two rules with
      byte-identical oklab-none declarations combine into one comma-selector rule
@@ -2962,11 +2962,11 @@ let c61_no_merge_starting_style () =
 
 let c61_import_substitution_point () =
   (* A misplaced @import - one that follows a style rule - is invalid, and every
-     browser ignores it (CSS Cascade 5 section 3.5, CSS 2.1 section 6.3). It is
-     a no-op, not a cascade boundary and not a live substitution point: an
-     invalid import is never resolved, even under inline-imports. So the
-     optimizer drops it, and the now-adjacent same-selector rules merge. Matches
-     browsers and csso, and stays idempotent in a single pass. *)
+     browser ignores it (CSS Cascade 5 section 2, CSS 2.1 section 6.3). It is a
+     no-op, not a cascade boundary and not a live substitution point: an invalid
+     import is never resolved, even under inline-imports. So the optimizer drops
+     it, and the now-adjacent same-selector rules merge. Matches browsers and
+     csso, and stays idempotent in a single pass. *)
   let stylesheet =
     match
       Css.of_string ~strict:false
@@ -4015,7 +4015,7 @@ let c64_child_layer_one_anonymous () =
   let optimized = Css.Optimize.stylesheet input in
   (* Per shortest-wins, two adjacent [@layer foo] blocks inside the same
      anonymous parent merge into one - they refer to the same nested layer per
-     Cascade L6 sec. 6.4.2.1, so collapsing is spec-allowed. *)
+     Cascade L5 sec. 6.4.2.1, so collapsing is spec-allowed. *)
   let output = Css.Stylesheet.to_string ~minify:true optimized |> String.trim in
   Alcotest.(check bool)
     "anonymous parent preserved" true

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -618,7 +618,7 @@ let spec_arbitrary_value_productions () =
     (parse_any "url(foo\"bar)" = None)
 
 let spec_serialization_string_escaping () =
-  (* CSS Syntax Level 3 section 9.2: strings are serialized in a form that
+  (* CSS Syntax Level 3 section 9: strings are serialized in a form that
      round-trips, escaping quote and backslash characters and not emitting raw
      newlines inside the string token. *)
   let parse_one css = (Parser.component_value (Reader.of_string css)).value in

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1656,7 +1656,7 @@ let test_transforms () =
       "var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) \
        var(--tw-skew-x,) var(--tw-skew-y,)"
     "var(--tw-rotate-x,)var(--tw-rotate-y,)var(--tw-rotate-z,)var(--tw-skew-x,)var(--tw-skew-y,)";
-  (* Per CSS Transforms 1 section 11 the printer drops whitespace between
+  (* Per CSS Transforms 1 section 8 the printer drops whitespace between
      back-to-back transform functions under minify. *)
   check_transforms ~expected:"translateX(10px)var(--my-rotate)"
     "translateX(10px) var(--my-rotate)";
@@ -1753,7 +1753,7 @@ let test_background () =
   neg_cursor read_background "10px 20px 30px 40px 50px"
 
 let test_font_weight () =
-  (* CSS Fonts 4 section 5.1.2: [normal] and [bold] canonicalize to the numeric
+  (* CSS Fonts 4 section 2.2: [normal] and [bold] canonicalize to the numeric
      forms [400] and [700] under minify. *)
   check_font_weight ~expected:"400" "normal";
   check_font_weight ~expected:"700" "bold";
@@ -2137,9 +2137,9 @@ let test_font_family () =
   neg_cursor read_font_family "123invalid";
   (* identifier can't start with number *)
   neg_cursor read_font_family "";
-  (* Default minify unquotes a multi-word [<family-name>] (CSS Fonts 4 sec. 4.1:
-     an ident sequence is a valid family name and the unquoted form is shorter).
-     [enforce_spec] keeps the quotes, matching the CSSOM-canonical
+  (* Default minify unquotes a multi-word [<family-name>] (CSS Fonts 4 sec.
+     2.1.1: an ident sequence is a valid family name and the unquoted form is
+     shorter). [enforce_spec] keeps the quotes, matching the CSSOM-canonical
      serialization, so a font stack stored verbatim in a custom property keeps
      its authored quoting. *)
   let stack =
@@ -2158,7 +2158,7 @@ let test_font_stretch () =
   check_font_stretch "50%";
   check_font_stretch "inherit";
   neg_cursor read_font_stretch "invalid-stretch";
-  (* CSS Fonts 4 sec. 5.3 defines each keyword as a percentage, never longer, so
+  (* CSS Fonts 4 sec. 2.3 defines each keyword as a percentage, never longer, so
      minified output uses it, but only for the standalone property: the [font]
      shorthand's stretch component takes the keyword alone. *)
   check_font_stretch ~expected:"100%" "normal";
@@ -2343,7 +2343,7 @@ let test_background_repeat () =
   check_background_repeat "repeat-x";
   check_background_repeat "repeat-y";
   check_background_repeat "inherit";
-  (* CSS Backgrounds 3 sec. 3.6: the longhand is a comma-separated layer
+  (* CSS Backgrounds 3 sec. 2.6: the longhand is a comma-separated layer
      list. *)
   decl_optimizes ~prop:"background-repeat" ~into:"no-repeat,repeat-y,no-repeat"
     "no-repeat,repeat-y,no-repeat";
@@ -2366,7 +2366,7 @@ let test_background_size () =
   check_background_size "var(--s)";
   check_background_size "calc(50% + 10px)";
   check_background_size "calc(50% + 10px) auto";
-  (* Comma-separated layer list (CSS Backgrounds 3 sec. 3.9). *)
+  (* Comma-separated layer list (CSS Backgrounds 3 sec. 2.9). *)
   decl_optimizes ~prop:"background-size" ~into:"cover,contain" "cover,contain";
   decl_optimizes ~prop:"background-size" ~into:"100px 200px,auto"
     "100px 200px,auto";
@@ -2618,7 +2618,7 @@ let test_radial_gradient_config () =
   check_radial_gradient_config "circle at center";
   neg_cursor read_radial_gradient_config "invalid-config";
   (* pp holds the authored defaults; the optimizer elides them (CSS Images 4
-     section 3.1: ellipse / farthest-corner / center are implied). *)
+     section 3.2: ellipse / farthest-corner / center are implied). *)
   decl_optimizes ~prop:"background"
     ~held:"radial-gradient(circle at center,red,#123456)"
     ~into:"radial-gradient(circle,red,#123456)"
@@ -3049,7 +3049,7 @@ let test_text_decoration_skip_ink () =
   neg_cursor read_text_decoration_skip_ink "invalid-skip"
 
 let test_transform_origin () =
-  (* Per CSS Transforms 1 sec. 6 the keyword [center] is shorthand for [50%] and
+  (* Per CSS Transforms 1 sec. 4 the keyword [center] is shorthand for [50%] and
      matched-pair shorthand collapses to a single value. Per shortest- wins
      (Lightning CSS) the printer emits the numeric form. *)
   check_transform_origin ~expected:"50%" "center";
@@ -3057,7 +3057,7 @@ let test_transform_origin () =
   (* A single value sets the X origin; Y defaults to center (50%), so it must
      not be duplicated onto the Y axis: [100%] means [100% 50%], not [100%
      100%], and [0] means [0 50%], not [0 0]. Only [50%] coincides with center.
-     CSS Transforms 1 section 6; lightningcss and csso keep the single value. *)
+     CSS Transforms 1 section 4; lightningcss and csso keep the single value. *)
   check_transform_origin "100%";
   check_transform_origin "0";
   check_transform_origin "50% 25%";
@@ -4196,10 +4196,10 @@ let test_clip_path () =
   check_clip_path "inset(10% 20% 30%)";
   (* 3 values: top, left/right, bottom *)
   check_clip_path "inset(0px 10px 20px 30px)";
-  (* CSS Values L4 sec. 6.1: a zero in <length>/<length-percentage> position
-     drops its unit under canonical minification; the fold is a node-changing
-     rewrite (Length{Px,0} -> Length{None,0}) and so lives in normalize, not pp.
-     The held (~held) form stays pp-faithful with the unit; only the canonical
+  (* CSS Values L4 sec. 6: a zero in <length>/<length-percentage> position drops
+     its unit under canonical minification; the fold is a node-changing rewrite
+     (Length{Px,0} -> Length{None,0}) and so lives in normalize, not pp. The
+     held (~held) form stays pp-faithful with the unit; only the canonical
      (~into) form drops it. Same fold applies recursively inside basic shapes
      (inset, polygon, rect, etc.) - all <length-percentage> arg positions, none
      of them inside a math context. *)

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -72,7 +72,7 @@ let custom_property_layer_and_meta_survive () =
         (List.length ds)
 
 let custom_property_font_name_quoting_converges () =
-  (* CSS Fonts 4 sec. 15.3: a multi-word family name spells the same family
+  (* CSS Fonts 4 sec. 2.1.1: a multi-word family name spells the same family
      quoted or as the ident sequence it unquotes to, and a custom property
      holding a font stack substitutes either form identically into
      [font-family]. Emission keeps whichever the author wrote, so only the

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -53,7 +53,7 @@ let check_minified_to expected input =
 (* Extra minifier invariant: minify is idempotent (a second pass produces no
    further change), and specificity is preserved. Strict AST equality between
    [original] and [reparsed] does not hold for inputs the minifier rewrites
-   (e.g. CSS Selectors 4 sec. 3.5 lets the printer drop a redundant [*] from a
+   (e.g. CSS Selectors 4 sec. 5.2 lets the printer drop a redundant [*] from a
    compound), so we compare the minified form against itself after re-parsing
    and re-minifying. *)
 let check_minified_equiv input =
@@ -159,13 +159,13 @@ let pseudo_class_cases () =
   check_construct ":last-child" Last_child;
   check_construct ":nth-child(2)" (nth_child (An_plus_b (0, 2)));
   check_construct ":nth-child(odd)" (nth_child Odd);
-  (* Per CSS Selectors 4 section 14 the printer canonicalizes [even] to [2n] and
-     [2n+1] to [odd] under minify. *)
+  (* Per CSS Selectors 4 section 13.3.1 the printer canonicalizes [even] to [2n]
+     and [2n+1] to [odd] under minify. *)
   check_construct ":nth-child(2n)" (nth_child Even);
   check_construct ":nth-child(odd)" (nth_child (An_plus_b (2, 1)));
-  (* nth with Index and of clause. Per CSS Selectors 4 section 14 the printer
-     canonicalizes [<an+b>] to the shortest equivalent spelling - [(0n+5)] ->
-     [(5)] / [(1)] -> [:first-child]. *)
+  (* nth with Index and of clause. Per CSS Selectors 4 section 13.3.1 the
+     printer canonicalizes [<an+b>] to the shortest equivalent spelling -
+     [(0n+5)] -> [(5)] / [(1)] -> [:first-child]. *)
   check ~expected:":first-child" ":nth-child(1)";
   check ":nth-child(5)";
   check ~expected:":nth-child(odd of.item)" ":nth-child( odd of .item )";
@@ -372,7 +372,7 @@ let attribute_cases () =
   check_construct "[ns|attr]" (attribute ~ns:(Prefix "ns") "attr" Presence);
   check_construct "[*|attr]" (attribute ~ns:Any "attr" Presence);
 
-  (* Negative cases: CSS Syntax sec. 5.3.7 / sec. 4.3.5 mandate recovery for
+  (* Negative cases: CSS Syntax sec. 2.2 / sec. 4.3.5 mandate recovery for
      unterminated brackets (['\[']) and strings at EOF, so those are spec-valid
      and not tested here. *)
   neg_cursor read "[attr=]";
@@ -490,8 +490,9 @@ let roundtrip () =
   check "#id";
   check "*";
 
-  (* Pseudo-classes. Per CSS Selectors 4 section 14 the printer canonicalizes
-     [:nth-child] formulas to the shortest spec-equivalent spelling. *)
+  (* Pseudo-classes. Per CSS Selectors 4 section 13.3.1 the printer
+     canonicalizes [:nth-child] formulas to the shortest spec-equivalent
+     spelling. *)
   check ":hover";
   check ":nth-child(2)";
   check ~expected:":nth-child(odd)" ":nth-child(2n+1)";
@@ -1306,7 +1307,7 @@ let test_spec_forgiving_selector_lists () =
   check_minified_to ":is(.valid,#id)" ":is(.valid,:future-pseudo,#id)";
   check_minified_to ":where(.valid,#id)" ":where(.valid,:future-pseudo,#id)";
   (* Single-argument [:is(.item)] is spec-equivalent to bare [.item] (same match
-     set and specificity per Selectors L4 sec. 17), but unwrapping it is a node
+     set and specificity per Selectors L4 sec. 4.2), but unwrapping it is a node
      change reserved for the optimizer's [Selector.canonicalize]; pp is
      lexical-only and holds the [:is()]. [:where()] holds too (and could not
      unwrap regardless, contributing zero specificity). *)
@@ -1389,7 +1390,7 @@ let spec_selector_scope_pseudo_edges () =
     "input:not([type], [type=hidden])";
   check_minified_to "a:before" "a::before";
   check_minified_to ".a:before:hover" ".a::before:hover";
-  (* CSS Selectors 4 section 3.5: [*] in a non-solitary compound is redundant,
+  (* CSS Selectors 4 section 5.2: [*] in a non-solitary compound is redundant,
      but dropping it is a node change reserved for the optimizer's
      [Selector.canonicalize]; pp is lexical-only and holds it. *)
   check_minified_to "::slotted(*:not([hidden]))" "::slotted(*:not([hidden]))";

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -67,7 +67,7 @@ let test_unknown_property_overlap () =
     "a recovered longhand of another family is disjoint" false
     (Shorthand.declarations_overlap (decl "padding:0")
        (decl "margin-top:var(--a) var(--b)"));
-  (* CSS Cascade 5 sec. 7.2: [all] resets unknown properties. *)
+  (* CSS Cascade 5 sec. 3.2: [all] resets unknown properties. *)
   Alcotest.(check bool)
     "all overlaps an unknown property" true
     (Shorthand.declarations_overlap (decl "all:initial")
@@ -98,7 +98,7 @@ let test_vendor_alias_overlap () =
        (decl "text-decoration-color:red"))
 
 let test_shorthand_reset_boundaries () =
-  (* CSS UI 4 sec. 6.4: [outline] resets width, style and colour, and leaves
+  (* CSS UI 4 sec. 3.1: [outline] resets width, style and colour, and leaves
      [outline-offset] alone. *)
   Alcotest.(check bool)
     "outline overlaps its colour longhand" true
@@ -116,7 +116,7 @@ let test_shorthand_reset_boundaries () =
     "text-emphasis and its position longhand are disjoint" false
     (Shorthand.declarations_overlap (decl "text-emphasis:dot")
        (decl "text-emphasis-position:over"));
-  (* CSS Grid 1 sec. 7.4: [grid] resets the template and auto tracks, not the
+  (* CSS Grid 1 sec. 7.8: [grid] resets the template and auto tracks, not the
      placement longhands. *)
   Alcotest.(check bool)
     "grid overlaps a template longhand" true
@@ -221,7 +221,7 @@ let test_logical_physical_overlap () =
        (decl "border-left-color:red"))
 
 let test_logical_axis_overlap () =
-  (* CSS Logical 1 sec. 4.4: [inline-size] is [width] in a horizontal writing
+  (* CSS Logical 1 sec. 4.1: [inline-size] is [width] in a horizontal writing
      mode and [height] in a vertical one, so it may write either slot. The
      sizing family has no physical shorthand, which does not change the
      aliasing. *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -72,7 +72,7 @@ let test_rule () =
   neg_cursor read_stylesheet "{color:red}";
   (* Missing selector *)
   neg_cursor read_stylesheet ".btn";
-  (* Missing declarations. CSS Syntax sec. 5.3.7 auto-closes [.btn{] so it is
+  (* Missing declarations. CSS Syntax sec. 2.2 auto-closes [.btn{] so it is
      spec-valid and not asserted here. *)
   neg_cursor read_stylesheet ".btn{color}";
   (* Missing value *)
@@ -640,8 +640,8 @@ let namespace_case () =
 
 (** Test [@keyframes] rules *)
 let keyframes_case () =
-  (* CSS Animations 1 section 7.1: [from] and [to] are spec-equivalent to [0%]
-     and [100%]; under [~minify:true] the printer canonicalizes to the shorter
+  (* CSS Animations 1 section 3: [from] and [to] are spec-equivalent to [0%] and
+     [100%]; under [~minify:true] the printer canonicalizes to the shorter
      spelling - [0%] beats [from] and [to] beats [100%], matching cssnano and
      Lightning CSS. *)
   check_stylesheet ~expected:"@keyframes slide{0%{opacity:0}to{opacity:1}}"
@@ -731,7 +731,7 @@ let spec_fontface_descriptors () =
     "@font-face { font-family: Foo; src: url(foo.woff2); font-named-instance: \
      'Regular'; font-style: normal; }";
   (* An invalid value of a *known* descriptor drops just that descriptor and
-     keeps the rest of the @font-face, like browsers (CSS Fonts 4 sec. 11.2). *)
+     keeps the rest of the @font-face, like browsers (CSS Fonts 4 sec. 4.1). *)
   check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
     "@font-face { font-family: Brand; src: url(font.woff2); font-display: \
      maybe; }";
@@ -739,7 +739,7 @@ let spec_fontface_descriptors () =
     "@font-face { font-family: Brand; src: url(font.woff2); font-variant: \
      common-ligatures no-common-ligatures; }";
   (* A descending font-stretch range is kept like the font-weight / oblique
-     ranges below: browsers do not enforce CSS Fonts 4 sec. 11.2. *)
+     ranges below: browsers do not enforce CSS Fonts 4 sec. 4.4. *)
   check_stylesheet
     ~expected:
       "@font-face{font-family:Brand;src:url(font.woff2);font-stretch:200% 50%}"
@@ -868,7 +868,7 @@ let spec_font_face_descriptor_matrix () =
      normal; }"
 
 let spec_keyframes_selector_matrix () =
-  (* CSS Animations 1 section 7.1: [from] / [to] / [0%] / [100%] are pairwise
+  (* CSS Animations 1 section 3: [from] / [to] / [0%] / [100%] are pairwise
      spec-equivalent. The printer canonicalizes to the shorter spelling - [0%]
      beats [from], [to] beats [100%]. *)
   check_stylesheet
@@ -1265,7 +1265,7 @@ let spec_strict_rejects_invalid_stylesheets () =
          U+20-10 }" );
       (* Browsers keep a descending font-weight / oblique-angle range, so the
          lenient parse keeps it with a warning; strict turns that into an error
-         (CSS Fonts 4 sec. 11.2 wants the first bound <= the second). *)
+         (CSS Fonts 4 sec. 4.4 wants the first bound <= the second). *)
       ( "font-face descending font-weight range",
         "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
          900 100 }" );
@@ -1585,7 +1585,7 @@ let test_invalid_properties () =
 
 (* Not a roundtrip test *)
 let test_invalid_syntax () =
-  (* CSS Syntax sec. 5.3.7: unclosed blocks auto-close at EOF and the inner
+  (* CSS Syntax sec. 2.2: unclosed blocks auto-close at EOF and the inner
      declaration is preserved. Verify the AST, don't just accept "didn't
      crash". *)
   check_stylesheet ~expected:".btn{color:red}" ".btn { color: red ";
@@ -3016,7 +3016,7 @@ let s3432_sourcemap_comment () =
       Alcotest.(check string) name expected printed)
     cases
 
-(* CSS Cascade Module Level 6, section 6.4.4.2 (The Layer Statement Rule): the
+(* CSS Cascade Module Level 5, section 6.4.4.2 (The Layer Statement Rule): the
    statement form [@layer foo, bar;] is defined as equivalent to declaring each
    named layer with an empty block in the same order. The two surface shapes
    must therefore parse to the same effective layer order and produce the same
@@ -3045,11 +3045,11 @@ let c6442_empty_blocks_equiv () =
     "subsequent block in a previously-declared layer is order-equivalent"
     statement_then_block two_blocks
 
-(* CSS Cascade Module Level 6, section 6.4.3 (Nesting Layers): a dotted layer
-   name is shorthand for nested layer blocks. The spec says [@layer foo.bar {
-   ... }] declares the same nested layer as [@layer foo { @layer bar { ... } }],
-   so the rule placed inside either form must end up in the same effective
-   cascade layer named [foo.bar]. *)
+(* CSS Cascade Module Level 5, section 6.4.2 (Layer Naming and Nesting): a
+   dotted layer name is shorthand for nested layer blocks. The spec says [@layer
+   foo.bar { ... }] declares the same nested layer as [@layer foo { @layer bar {
+   ... } }], so the rule placed inside either form must end up in the same
+   effective cascade layer named [foo.bar]. *)
 let c643_dotted_nested_layer () =
   let parse css =
     match Css.of_string ~strict:false css with
@@ -3104,8 +3104,8 @@ let s3432_no_sourcemap_print () =
         (Astring.String.is_infix ~affix:"sourceURL" printed))
     inputs
 
-(* CSS Values and Units Module Level 4, section 6.1 (Distance Units): "A 0
-   length is unitless and may be substituted for 0px or 0em (etc.) in any
+(* CSS Values and Units Module Level 4, section 6 (Distance Units): "A 0 length
+   is unitless and may be substituted for 0px or 0em (etc.) in any
    length-accepting context." Two property values that differ only in the
    spelling of a zero length are spec-equivalent, so the optimizer is free to
    pick any of them - but parsing two equivalent forms must produce the same
@@ -3127,7 +3127,7 @@ let v461_zero_length_equiv () =
   Alcotest.(check string)
     "0 and 0rem are spec-equivalent for <length>" zero_unitless zero_rem
 
-(* CSS Color Module Level 4, section 12.1 (Hex Notation): a 6-digit hex color
+(* CSS Color Module Level 4, section 5.2 (Hex Notation): a 6-digit hex color
    [#rrggbb] and the equivalent 3-digit shorthand [#rgb] (where each pair is the
    same character) denote the identical sRGB color. They are spec- equivalent
    forms; the optimizer may choose either, but a round trip must yield the same
@@ -3155,7 +3155,7 @@ let color4121_hex_equiv () =
         long_form short_form)
     pairs
 
-(* CSS Cascade and Inheritance Module Level 6, section 6.1 (Cascade Sorting
+(* CSS Cascade and Inheritance Module Level 5, section 6.1 (Cascade Sorting
    Order): when all higher-priority criteria tie, declarations are ordered by
    source order, with later declarations winning. The optimizer is free to merge
    or rewrite rules, but it MUST NOT reorder declarations of the same property
@@ -3194,12 +3194,12 @@ let c61_keeps_winner () =
     (Some "#00f")
     (winning_color ".a { color: red } .a { color: blue }")
 
-(* CSS Color Module Level 4, section 1.4 (Notational Conventions): the named
-   color [red], the hex notations [#f00] and [#ff0000], and the rgb function
-   [rgb(255, 0, 0)] all denote the same sRGB color. Under industry-standard
-   minification (cssnano / Lightning CSS / clean-css) the printer canonicalizes
-   to the shortest equivalent form, so all of these resolve to the same
-   serialized output. *)
+(* CSS Color Module Level 4, section 5.1 (The RGB functions): the named color
+   [red], the hex notations [#f00] and [#ff0000], and the rgb function [rgb(255,
+   0, 0)] all denote the same sRGB color. Under industry-standard minification
+   (cssnano / Lightning CSS / clean-css) the printer canonicalizes to the
+   shortest equivalent form, so all of these resolve to the same serialized
+   output. *)
 let color414_form_equiv () =
   (* These forms parse to distinct color nodes; collapsing them to the shortest
      spelling is an optimize transform, not a pp same-node choice. Canonicalize
@@ -3260,7 +3260,7 @@ let color4_hex_tie_policy () =
       Alcotest.(check string) name expected (normalize css))
     cases
 
-(* CSS Values and Units Module Level 4, section 6.5 only allows dropping units
+(* CSS Values and Units Module Level 4, section 6 only allows dropping units
    from zero lengths. Percentages keep their percent sign because [0%] is still
    a percentage token, not the bare number [0]. *)
 let v465_zero_percentage_equiv () =
@@ -3280,11 +3280,11 @@ let v465_zero_percentage_equiv () =
     "0 and 0% stay distinct for width" false
     (String.equal zero zero_pct)
 
-(* CSSOM Level 1, section 6.6.2 (Serialize a CSS declaration): the serialized
-   form puts ":" between property name and value with no surrounding spaces in
+(* CSSOM Level 1, section 6.6 (Serialize a CSS declaration): the serialized form
+   puts ":" between property name and value with no surrounding spaces in
    minified mode, and "!important" follows the value with no extra whitespace.
    The property name is serialized as-is (already lowercased by the syntax layer
-   per CSS Syntax sec. 3.3) regardless of input case. *)
+   per CSS Syntax sec. 8.1) regardless of input case. *)
 let cssom662_decl_serialization () =
   let normalize css =
     match Css.of_string ~strict:false css with
@@ -3305,10 +3305,10 @@ let cssom662_decl_serialization () =
     "important whitespace after ! collapsed" ".a{color:red!important}"
     (normalize ".a { color: red !  IMPORTANT }")
 
-(* CSS Color Module Level 4, section 6.4 (The "transparent" color keyword): the
+(* CSS Color Module Level 4, section 6.3 (The "transparent" color keyword): the
    [transparent] keyword is defined as equivalent to [rgba(0, 0, 0, 0)]. The
    8-digit hex [#00000000] (or its 4-digit shorthand [#0000]) is also equivalent
-   to that fully-transparent black per section 12.1. The optimizer may pick any
+   to that fully-transparent black per section 5.2. The optimizer may pick any
    spec-equivalent form; the test asserts the parsed colors denote the same
    value via the canonical printer. *)
 let color4_6_4_transparent_equivalence () =
@@ -3358,7 +3358,7 @@ let color461_named_case () =
         (canonical lower) (canonical mixed))
     cases
 
-(* CSS Values and Units Module Level 4, section 8.1 (Numbers and Numeric Data
+(* CSS Values and Units Module Level 4, section 5.3 (Numbers and Numeric Data
    Types): [<number>] tokens accept several syntactic spellings of the same
    numeric value. [.5], [0.5] and [0.50] all denote 0.5; [1.0] and [1] denote
    the integer 1. The optimizer is free to pick the shortest spelling, but a
@@ -3383,7 +3383,7 @@ let v481_number_format () =
         a_form b_form)
     pairs
 
-(* CSS Selectors Module Level 4, section 3.5 (The Universal Selector): "If the
+(* CSS Selectors Module Level 4, section 5.2 (The Universal Selector): "If the
    universal selector is not the only component of a compound selector, the [*]
    may be omitted." So [*.foo] and [.foo] are spec-equivalent compound
    selectors, and [*#id] and [#id] are equivalent. *)
@@ -3459,12 +3459,12 @@ let scope_selector_list_canonical () =
     ~minified:"@scope(.b,.a)to (.d,.c){.x{color:red}}"
     ~optimized:"@scope(.a,.b)to (.c,.d){.x{color:red}}"
 
-(* CSS Color Module Level 4, section 3 (Color Syntax): the [<hue>] component
-   accepts angles or numbers and is normalised modulo 360deg. So [hsl(360 100%
-   50%)] denotes the same color as [hsl(0 100% 50%)] and as the named color
-   [red]; [hsl(720 ...)] is also red. Hue values outside [0, 360) must reduce,
-   and the fully-saturated red hue must canonicalize to the named color under
-   industry-standard minification. *)
+(* CSS Color Module Level 4, section 4.3 (the <hue> syntax): the [<hue>]
+   component accepts angles or numbers and is normalised modulo 360deg. So
+   [hsl(360 100% 50%)] denotes the same color as [hsl(0 100% 50%)] and as the
+   named color [red]; [hsl(720 ...)] is also red. Hue values outside [0, 360)
+   must reduce, and the fully-saturated red hue must canonicalize to the named
+   color under industry-standard minification. *)
 let color4_3_hue_modulo_canonicalization () =
   (* Hue-modulo reduction and hsl -> named are optimize transforms, not pp
      same-node spellings; route each form through optimize+minify. *)
@@ -3489,7 +3489,7 @@ let color4_3_hue_modulo_canonicalization () =
     "hsl(-360 100% 50%) reduces modulo 360" red
     (canonical "hsl(-360 100% 50%)")
 
-(* CSS Color Module Level 4, section 1.3 (Color Component Values): an alpha
+(* CSS Color Module Level 4, section 4.2 (the <alpha-value> syntax): an alpha
    value may be expressed as a [<number>] in the closed interval [\[0, 1\]] or
    as a [<percentage>] in [\[0%, 100%\]]; the two forms are spec-equivalent.
    [rgb(255 0 0 / .5)] and [rgb(255 0 0 / 50%)] denote the identical color. *)
@@ -3513,7 +3513,7 @@ let color413_alpha_equiv () =
         (canonical number_form) (canonical percent_form))
     pairs
 
-(* CSS Animations Module Level 1, section 7.1 (Keyframe Selectors): the keyframe
+(* CSS Animations Module Level 1, section 3 (Keyframe Selectors): the keyframe
    selectors [from] and [to] are defined as equivalent to [0%] and [100%]
    respectively. A round trip through the parser and printer therefore places
    the rule in the same logical keyframe regardless of which spelling was used
@@ -3551,7 +3551,7 @@ let color4_12_rgb_clamp_canonicalization () =
     "rgb(-10, 0, 0) clamps to black and canonicalizes to #000" ".x{color:#000}"
     (normalize ".x { color: rgb(-10, 0, 0) }")
 
-(* CSS Color Module Level 4, section 1.3 (Color Component Values): an alpha
+(* CSS Color Module Level 4, section 4.2 (the <alpha-value> syntax): an alpha
    value of [1] (or [100%]) means fully opaque, which is by definition the same
    color as the form without an alpha channel. So [rgba(255, 0, 0, 1)] is
    spec-equivalent to [rgb(255, 0, 0)] and to [red]. Both Lightning CSS and
@@ -3572,7 +3572,7 @@ let color413_opaque_alpha_collapse () =
     "rgba(0, 0, 0, 100%) collapses to #000" ".x{color:#000}"
     (normalize ".x { color: rgba(0, 0, 0, 100%) }")
 
-(* CSS Values and Units Module Level 4, section 8.1 (Numbers): [<number>] tokens
+(* CSS Values and Units Module Level 4, section 5.3 (Numbers): [<number>] tokens
    with trailing zeroes after a decimal point ([1.000], [1.500]) are equivalent
    to the same value without the trailing zeroes ([1], [1.5]). Both Lightning
    CSS and cssnano normalise these. *)
@@ -3592,7 +3592,7 @@ let v481_trailing_zero () =
     "0.500 loses both leading and trailing zero" ".x{opacity:.5}"
     (normalize ".x { opacity: 0.500 }")
 
-(* CSS Fonts Module Level 4, section 5.1.2 (Common Weight Name Mapping): the
+(* CSS Fonts Module Level 4, section 2.2 (Common Weight Name Mapping): the
    keywords [normal] and [bold] for [font-weight] are defined as numeric values
    [400] and [700] respectively. Both Lightning CSS and cssnano canonicalize to
    the numeric form. *)
@@ -3634,7 +3634,7 @@ let box4_margin_shorthand_collapse () =
     (normalize ".x { padding: 1px 2px }")
     (normalize ".x { padding: 1px 2px 1px 2px }")
 
-(* CSS Color Module Level 4, section 6.4 (The transparent keyword): all forms of
+(* CSS Color Module Level 4, section 6.3 (The transparent keyword): all forms of
    fully-transparent black ([transparent], [rgba(0, 0, 0, 0)], [#00000000],
    [#0000]) denote the same color. The spec leaves the canonical serialized form
    to implementations; the printer canonicalizes to the shortest spec-equivalent
@@ -3656,7 +3656,7 @@ let color464_transparent_shortest () =
     "#00000000 canonicalizes to #0000" canonical
     (normalize ".x { color: #00000000 }")
 
-(* CSS Values and Units Module Level 4, section 6.5 lets zero lengths drop their
+(* CSS Values and Units Module Level 4, section 6 lets zero lengths drop their
    unit. It does not turn zero percentages into numbers. *)
 let v465_zero_length_shortest () =
   let normalize css =
@@ -3678,7 +3678,7 @@ let v465_zero_length_shortest () =
     "0vh canonicalizes to 0" canonical
     (normalize ".x { width: 0vh }")
 
-(* CSS Backgrounds and Borders Module Level 3, section 5 (Border Radius):
+(* CSS Backgrounds and Borders Module Level 3, section 4.1 (Border Radius):
    [border-radius] takes one to four [<length-percentage>] values. When all four
    sides are equal, the shorthand collapses to a single value. The spec does not
    mandate the collapsed form; the printer takes the freedom and picks the
@@ -3717,7 +3717,7 @@ let v410_calc_add_zero () =
     "calc(1px + 0px) simplifies to 1px" ".x{width:1px}"
     (normalize ".x { width: calc(1px + 0px) }")
 
-(* CSS Backgrounds and Borders Module Level 3, section 3.6
+(* CSS Backgrounds and Borders Module Level 3, section 2.6
    (background-position): the two-value form [<x> <y>] collapses to the
    single-value form when [x = y]. The single-value form is the shortest
    spec-equivalent spelling that Lightning CSS picks. *)
@@ -3771,7 +3771,7 @@ let pretty_preserves css fragments =
             (Astring.String.is_infix ~affix:fragment printed))
         fragments
 
-(* CSS Color 4 section 12.1 + cascade convention: authored hex colours decode to
+(* CSS Color 4 section 5.2 + cascade convention: authored hex colours decode to
    sRGB bytes but keep their source spelling for pretty-printing, while
    minify+optimize emits the shorter equivalent spelling. *)
 (* The pretty printer formats every braced at-rule body with the same line
@@ -3823,7 +3823,7 @@ let fidelity_hex_form_preserved () =
   assert_minify_and_optimize ".x { color: #ff0000 }" ~minified:".x{color:#f00}"
     ~optimized:".x{color:red}"
 
-(* CSS Color 4 section 1.4 + cascade convention: under non-minified output, the
+(* CSS Color 4 section 5.1 + cascade convention: under non-minified output, the
    named-color and rgb() forms are preserved as written - no cross-form
    canonicalization. *)
 let fidelity_color_form_preserved () =
@@ -3838,7 +3838,7 @@ let fidelity_color_form_preserved () =
   pretty_preserves ".x { color: rgba(0, 0, 0, 0) }" [ "rgb(0 0 0 / 0)" ];
   pretty_preserves ".x { color: #0000 }" [ "#0000" ]
 
-(* CSS Animations 1 section 7.1 + cascade convention: [from] / [to] are
+(* CSS Animations 1 section 3 + cascade convention: [from] / [to] are
    canonicalized to [0%] / [100%] only under minify; the pretty printer keeps
    the source keyword. *)
 let fidelity_keyframe_selector_preserved () =
@@ -3847,7 +3847,7 @@ let fidelity_keyframe_selector_preserved () =
   pretty_preserves "@keyframes fade { 0% { opacity: 0 } 100% { opacity: 1 } }"
     [ "0%"; "100%" ]
 
-(* CSS Selectors 4 section 3.5 + cascade convention: stripping [*] in a
+(* CSS Selectors 4 section 5.2 + cascade convention: stripping [*] in a
    non-solitary compound is a minify-only optimization; the pretty printer keeps
    the universal selector as written. *)
 let fidelity_universal_in_compound_preserved () =
@@ -3855,7 +3855,7 @@ let fidelity_universal_in_compound_preserved () =
   pretty_preserves "*#main { color: red }" [ "*#main" ];
   pretty_preserves "*[data-x] { color: red }" [ "*[data-x]" ]
 
-(* CSS Color 4 section 1.3 + cascade convention: alpha unit form is preserved in
+(* CSS Color 4 section 4.2 + cascade convention: alpha unit form is preserved in
    pretty output, while numeric spelling follows the shared shortest decimal
    convention. *)
 let fidelity_alpha_form_preserved () =
@@ -3876,7 +3876,7 @@ let fidelity_percentage_precision_preserved () =
           (Css.to_string ~minify:true parsed.stylesheet)
     | Error _ -> false)
 
-(* CSS Values 4 section 6.1 + cascade convention: dropping the unit on a zero
+(* CSS Values 4 section 6 + cascade convention: dropping the unit on a zero
    length is a minify-only optimization; the pretty printer keeps the source
    spelling. *)
 let fidelity_zero_length_preserved () =
@@ -3885,7 +3885,7 @@ let fidelity_zero_length_preserved () =
   pretty_preserves ".x { width: 0% }" [ "0%" ];
   pretty_preserves ".x { margin: 0px 0px 0px 0px }" [ "0px 0px 0px 0px" ]
 
-(* CSS Animations 1 section 7.1 + cascade convention: shorthand collapses
+(* CSS Animations 1 section 3 + cascade convention: shorthand collapses
    ([margin: 1px 1px 1px 1px] -> [margin: 1px], [border-radius: 0 0 0 0] -> [0])
    are minify-only optimizations; the pretty printer keeps the source
    spelling. *)
@@ -3895,14 +3895,14 @@ let fidelity_shorthand_form_preserved () =
   pretty_preserves ".x { border-radius: 0 0 0 0 }" [ "0 0 0 0" ];
   pretty_preserves ".x { background-position: 50% 50% }" [ "50% 50%" ]
 
-(* CSS Fonts 4 section 5.1.2 + cascade convention: mapping the [normal] / [bold]
+(* CSS Fonts 4 section 2.2 + cascade convention: mapping the [normal] / [bold]
    keywords to the numeric weights [400] / [700] is a minify-only optimization;
    the pretty printer keeps the keyword. *)
 let fidelity_font_weight_keyword_preserved () =
   pretty_preserves ".x { font-weight: normal }" [ "normal" ];
   pretty_preserves ".x { font-weight: bold }" [ "bold" ]
 
-(* CSS Selectors Level 4, section 14 (The :nth-child() Pseudo-class): the
+(* CSS Selectors Level 4, section 13.3.1 (The :nth-child() Pseudo-class): the
    [<an+b>] microsyntax has multiple spec-equivalent spellings - [2n+1] is the
    same set as [odd]; [2n+0] equals [2n] (matches even); a constant b like
    [(0n+5)] equals [(5)]; and [(1)] is equivalent to the [:first-child]
@@ -3927,7 +3927,7 @@ let s4_14_nth_child_canonicalization () =
     (normalize ".x :first-child { color: red }")
     (normalize ".x :nth-child(1) { color: red }")
 
-(* CSS Selectors Level 4, section 6.2 (Attribute selectors): the value in
+(* CSS Selectors Level 4, section 6.1 (Attribute selectors): the value in
    [\[attr=value\]] may be an identifier or a string. When the value matches the
    [<ident-token>] grammar, the quotes are redundant and may be dropped; both
    single and double quotes are equivalent. Both minifiers strip redundant
@@ -3947,7 +3947,7 @@ let s462_attr_quote_canonical () =
     (normalize ".x [data-x=hello] { color: red }")
     (normalize ".x [data-x='hello'] { color: red }")
 
-(* CSS Values and Units Module Level 4, section 8.1 (Numbers): scientific
+(* CSS Values and Units Module Level 4, section 5.3 (Numbers): scientific
    notation [<number>] tokens like [1e3] and [1.5e2] are spec-equivalent to
    their decimal expansion. Both minifiers expand these to the decimal form when
    shorter. *)
@@ -3964,7 +3964,7 @@ let v481_scientific_notation () =
     "1.5e2px expands to 150px" ".x{width:150px}"
     (normalize ".x { width: 1.5e2px }")
 
-(* CSS Values and Units Module Level 4, section 8.1 (Numbers): negative zero is
+(* CSS Values and Units Module Level 4, section 5.3 (Numbers): negative zero is
    the same value as zero; [-0px] is the same length as [0]. Both minifiers
    normalise. *)
 let v481_negative_zero () =
@@ -3980,7 +3980,7 @@ let v481_negative_zero () =
     "-0 canonicalizes to 0" ".x{width:0}"
     (normalize ".x { width: -0 }")
 
-(* CSS Values and Units Module Level 4, section 7 (URLs): the [<url>] type
+(* CSS Values and Units Module Level 4, section 4.5 (URLs): the [<url>] type
    accepts both quoted strings and unquoted token sequences when the URL does
    not contain whitespace, parentheses, or non-printable characters. Both
    minifiers drop the quotes when not needed. *)
@@ -4014,7 +4014,7 @@ let v410_calc_nested_constant () =
     "calc(1px + 2px) simplifies to 3px" ".x{width:3px}"
     (normalize ".x { width: calc(1px + 2px) }")
 
-(* CSS Cascading and Inheritance Module Level 6, section 6.1 (Cascade Sorting
+(* CSS Cascading and Inheritance Module Level 5, section 6.1 (Cascade Sorting
    Order): consecutive rules with the same condition (same [@media], same
    [@layer]) may be merged into one block, since the cascade evaluates them
    identically. The merge is spec-allowed when no rule with conflicting
@@ -4084,7 +4084,7 @@ let fidelity_calc_form_preserved () =
   pretty_preserves ".x { width: calc(calc(1px + 2px)) }"
     [ "calc(calc(1px + 2px))" ]
 
-(* CSS Cascading and Inheritance Module Level 6, section 6.1 (Cascade Sorting
+(* CSS Cascading and Inheritance Module Level 5, section 6.1 (Cascade Sorting
    Order): when two declarations of the same property tie on every higher-
    priority criterion, only the later wins. The earlier declaration is dead and
    may be removed. Both Lightning CSS and cssnano drop dead duplicates for
@@ -4103,7 +4103,7 @@ let c6_1_dead_shorthand_removed () =
     "exact duplicate property collapsed" ".x{color:red}"
     (normalize ".x { color: red; color: red }")
 
-(* CSS Cascading and Inheritance Module Level 6, section 6.1: an empty
+(* CSS Cascading and Inheritance Module Level 5, section 6.1: an empty
    declaration block contributes no declared values to the cascade. The rule may
    be removed entirely as a no-op. Both minifiers drop empty rules. *)
 let c6_1_empty_rule_removed () =
@@ -4119,11 +4119,11 @@ let c6_1_empty_rule_removed () =
     "empty rule after populated rule is dropped" ".y{color:red}"
     (normalize ".y { color: red } .x { }")
 
-(* CSS Cascading and Inheritance Module Level 6, section 7 (CSS-Wide Keywords):
-   the keywords [initial], [inherit], [unset], [revert], and [revert-layer] are
-   valid for every property. Implementations must preserve them through
-   serialization since they have observable cascade semantics that no shorter
-   spelling captures. *)
+(* CSS Cascading and Inheritance Module Level 5, section 7.3 (CSS-Wide
+   Keywords): the keywords [initial], [inherit], [unset], [revert], and
+   [revert-layer] are valid for every property. Implementations must preserve
+   them through serialization since they have observable cascade semantics that
+   no shorter spelling captures. *)
 let c67_css_wide_kept () =
   let normalize css =
     match Css.of_string ~strict:false css with
@@ -4157,7 +4157,7 @@ let c67_bad_css_wide_list () =
     "invalid CSS-wide list item drops under minify" ".y{color:red}"
     (minified ".x { font-family: Arial, inherit }.y { color: red }")
 
-(* CSS Cascading and Inheritance Module Level 6, section 3.2 (The all
+(* CSS Cascading and Inheritance Module Level 5, section 3.2 (The all
    Shorthand): the [all] property is a shorthand that sets every CSS-wide
    keyword for all properties. It only accepts CSS-wide keywords as values and
    must round-trip through the printer unchanged. *)
@@ -4177,7 +4177,7 @@ let c632_all_shorthand_kept () =
     "all: initial preserved" ".x{all:initial}"
     (normalize ".x { all: initial }")
 
-(* CSS Cascading and Inheritance Module Level 6, section 6.4 (Cascade Layers):
+(* CSS Cascading and Inheritance Module Level 5, section 6.4 (Cascade Layers):
    named layers preserve their declared order. Two non-adjacent [@layer base]
    blocks separated by an [@layer theme] block still contribute to the same
    layer, so they may be serialized in one [base] block at the first [base]
@@ -4209,7 +4209,7 @@ let c64_named_layers_order () =
      | Some r, Some t, Some p -> r < p && p < t
      | _ -> false)
 
-(* CSS Cascade L6 section 2.4 (Conditional @import) and CSS Custom Properties L1
+(* CSS Cascade L5 section 2.1 (Conditional @import) and CSS Custom Properties L1
    section 2 (var()): a [var()] reference with a fallback must be preserved
    end-to-end. The optimizer cannot resolve [var(--undef, red)] to [red] without
    a context that says [--undef] is undefined - that's a cascade-time fact, not
@@ -4227,7 +4227,7 @@ let css_var_fallback_preserved () =
     "nested var() preserved" ".x{color:var(--a,var(--b,red))}"
     (normalize ".x { color: var(--a, var(--b, red)) }")
 
-(* CSS Cascade L6 section 6.4.4 (anonymous @layer): two anonymous layers are
+(* CSS Cascade L5 section 6.4.2.1 (anonymous @layer): two anonymous layers are
    distinct - they must NOT merge, because the spec states that each [@layer {
    ... }] without a name creates a new, independent layer. *)
 let c644_anonymous_layers_distinct () =
@@ -4275,7 +4275,7 @@ let fidelity_css_wide_keywords_preserved () =
   pretty_preserves ".x { color: unset }" [ "unset" ];
   pretty_preserves ".x { all: initial }" [ "all"; "initial" ]
 
-(* CSS Backgrounds and Borders Module Level 3, section 3.6
+(* CSS Backgrounds and Borders Module Level 3, section 2.6
    (background-position): the keyword pairs [top left] / [left top] denote the
    same position as [0% 0%], and [bottom right] denotes [100% 100%]. Both
    Lightning CSS and cssnano canonicalize the keyword form to the numeric
@@ -4286,7 +4286,7 @@ let bg336_position_keyword () =
     | Ok parsed -> minify parsed.stylesheet
     | Error _ -> Alcotest.failf "failed to parse: %s" css
   in
-  (* Per CSS Backgrounds L3 sec. 3.6 [top left], [left top], and [0% 0%] all
+  (* Per CSS Backgrounds L3 sec. 2.6 [top left], [left top], and [0% 0%] all
      denote position [0 0]. *)
   Alcotest.(check string)
     "background-position: top left -> 0 0" ".x{background-position:0 0}"
@@ -4299,7 +4299,7 @@ let bg336_position_keyword () =
     ".x{background-position:100% 100%}"
     (normalize ".x { background-position: bottom right }")
 
-(* CSS Cascade L6 section 6.1: when two rules with different selectors share the
+(* CSS Cascade L5 section 6.1: when two rules with different selectors share the
    same declaration block, they may be grouped into a selector list with one
    block. The cascade evaluates the grouped form identically because each
    selector contributes the same declared values at its own specificity. Both
@@ -4326,10 +4326,11 @@ let c6_1_selector_grouping () =
      in
      count 0 0 = 1)
 
-(* CSS Syntax L3 section 4.3.10 (Identifier escapes): vendor-prefixed properties
-   such as [-webkit-transform] and [-moz-user-select] use the dashed-ident
-   escape hatch and are unknown to the CSS spec. The printer must round-trip
-   them unchanged - both Lightning CSS and cssnano keep vendor prefixes. *)
+(* CSS Syntax L3 section 4.3.9 (Check if three code points would start an ident
+   sequence): vendor-prefixed properties such as [-webkit-transform] and
+   [-moz-user-select] use the dashed-ident escape hatch and are unknown to the
+   CSS spec. The printer must round-trip them unchanged - both Lightning CSS and
+   cssnano keep vendor prefixes. *)
 let vendor_prefix_preservation () =
   let normalize css =
     match Css.of_string ~strict:false css with
@@ -4442,7 +4443,7 @@ let fidelity_not_form_preserved () =
   pretty_preserves ".x :not(.a, .b) { color: red }" [ ":not(.a, .b)" ];
   pretty_preserves ".x :not(.a):not(.b) { color: red }" [ ":not(.a):not(.b)" ]
 
-(* CSS Values and Units Module Level 4, section 6.6 (Time Units): [s] and [ms]
+(* CSS Values and Units Module Level 4, section 7.2 (Time Units): [s] and [ms]
    are the two units of [<time>], with [1s = 1000ms]. Both minifiers
    canonicalize to the shorter spelling - [0s] for any zero, [1s] over [1000ms],
    [.1s] over [100ms]. *)
@@ -4465,7 +4466,7 @@ let v466_time_unit_canonical () =
     "500ms canonicalizes to .5s" ".x{transition-duration:.5s}"
     (normalize ".x { transition-duration: 500ms }")
 
-(* CSS Values and Units Module Level 4, section 6.1 (Distance Units): absolute
+(* CSS Values and Units Module Level 4, section 6.2 (Absolute Lengths): absolute
    lengths ([in], [cm], [mm], [pt], [pc], [q]) are mathematically
    inter-convertible to [px] but the conversion produces non-terminating
    decimals or longer spellings in most cases. Industry minifiers (Lightning CSS
@@ -4493,7 +4494,7 @@ let v461_absolute_units_minify () =
     "25.4mm preserved" ".x{width:25.4mm}"
     (normalize ".x { width: 25.4mm }")
 
-(* CSS Values and Units Module Level 4, section 8.1 (Numbers): negative lengths
+(* CSS Values and Units Module Level 4, section 5.3 (Numbers): negative lengths
    and percentages are valid in many contexts (margin, transform translate,
    etc.) and must round-trip preserved. The leading [-] is part of the value,
    not a separate token. *)
@@ -4516,7 +4517,7 @@ let v481_negative_units_kept () =
     "negative angle -90deg preserved" ".x{transform:rotate(-90deg)}"
     (normalize ".x { transform: rotate(-90deg) }")
 
-(* CSS Values and Units Module Level 4, section 8 (Numeric Data Types): trailing
+(* CSS Values and Units Module Level 4, section 5 (Numeric Data Types): trailing
    zeros after a decimal point are not significant - [10.0px] is the same number
    as [10px], [10.50px] is [10.5px]. Both minifiers normalise to drop trailing
    zeros. *)
@@ -4536,7 +4537,7 @@ let v4_8_trailing_zero_drop () =
     "1.0 line-height drops trailing zero to 1" ".x{line-height:1}"
     (normalize ".x { line-height: 1.0 }")
 
-(* CSS Sizing Module Level 4, section 5 (aspect-ratio): the [aspect-ratio]
+(* CSS Sizing Module Level 4, section 4.1 (aspect-ratio): the [aspect-ratio]
    property accepts [<ratio>] which is two [<number>]s separated by [/]. Both
    minifiers preserve [16/9] (with whitespace dropped) and the single-value form
    [1] (which is shorthand for [1/1]). *)
@@ -4553,7 +4554,7 @@ let sizing4_5_aspect_ratio_preservation () =
     "aspect-ratio: 1 preserved" ".x{aspect-ratio:1}"
     (normalize ".x { aspect-ratio: 1 }")
 
-(* CSS Values and Units Module Level 4, section 8.1 + spec rejection: a bare
+(* CSS Values and Units Module Level 4, section 6 + spec rejection: a bare
    number without a unit is not a valid [<length>] outside of zero. Both parsers
    reject [width: 10] (no unit), [margin: 5] (no unit). *)
 let v481_negative_unit_length () =
@@ -4573,7 +4574,7 @@ let v481_negative_unit_length () =
     | Error _ -> true
     | _ -> false)
 
-(* CSS Values and Units Module Level 4, section 6.6 + spec rejection: a bare
+(* CSS Values and Units Module Level 4, section 7.2 + spec rejection: a bare
    number is not a valid [<time>] - units [s] or [ms] are required. Exception:
    [0] is valid as zero in some contexts but [transition-duration: 1] (no unit)
    must be rejected. *)
@@ -4589,7 +4590,7 @@ let v466_time_unit_required () =
     | Error _ -> true
     | _ -> false)
 
-(* CSS Values and Units Module Level 4, section 6.1 + spec rejection: unknown
+(* CSS Values and Units Module Level 4, section 6 + spec rejection: unknown
    length units like [10pp], [10foo] must be rejected as parse errors. *)
 let v461_unknown_length_unit () =
   Alcotest.(check bool)
@@ -4632,12 +4633,12 @@ let fidelity_aspect_ratio_preserved () =
   pretty_preserves ".x { aspect-ratio: 16 / 9 }" [ "16 / 9" ];
   pretty_preserves ".x { aspect-ratio: 1 }" [ "1" ]
 
-(* CSS Values and Units Module Level 4, section 10.2 (Computed Value of calc()):
-   calc() simplifies under spec rules - a single-operand calc collapses to the
-   operand; multiplication/division/addition with constants in the same unit
-   fold to the result; calc() with a [var()] reference must be preserved because
-   the value is unknown at parse time. Both Lightning CSS and cssnano agree on
-   these simplifications. *)
+(* CSS Values and Units Module Level 4, section 10.10.1 (Simplification): calc()
+   simplifies under spec rules - a single-operand calc collapses to the operand;
+   multiplication/division/addition with constants in the same unit fold to the
+   result; calc() with a [var()] reference must be preserved because the value
+   is unknown at parse time. Both Lightning CSS and cssnano agree on these
+   simplifications. *)
 let v4102_calc_single () =
   let normalize css =
     match Css.of_string ~strict:false css with
@@ -4720,7 +4721,7 @@ let v4102_calc_percentage () =
     "calc(100% * 2) -> 200%" ".x{width:200%}"
     (normalize ".x { width: calc(100% * 2) }")
 
-(* CSS Values and Units Module Level 4, section 10.2: calc() with mixed units
+(* CSS Values and Units Module Level 4, section 10.10.1: calc() with mixed units
    that cannot be reduced at parse time must be preserved. Examples are
    [calc(100vh - 50px)] (mixed viewport + absolute), [calc(100% - 10px)] (mixed
    percentage + absolute), and any expression containing [var()] - their values
@@ -4774,7 +4775,7 @@ let fidelity_calc_mixed_unit_preserved () =
   pretty_preserves ".x { width: calc(var(--x) + 10px) }"
     [ "calc(var(--x) + 10px)" ]
 
-(* CSS Values L4 section 10.2: nested calc() collapses to a single calc() and
+(* CSS Values L4 section 10.10.1: nested calc() collapses to a single calc() and
    all-constant nested forms reduce to a single value. Both minifiers fully
    unwrap. *)
 let v4102_calc_nested () =
@@ -4793,7 +4794,7 @@ let v4102_calc_nested () =
     "calc(calc(1px + 2px) * 2) -> 6px" ".x{width:6px}"
     (normalize ".x { width: calc(calc(1px + 2px) * 2) }")
 
-(* CSS Values L4 section 10.7 (min(), max()): when all arguments are constants
+(* CSS Values L4 section 10.2 (min(), max()): when all arguments are constants
    reducible at parse time the result is a single value. Per shortest-wins
    cascade picks the reduced form. *)
 let v4107_minmax_reduction () =
@@ -4828,12 +4829,12 @@ let v4107_minmax_reduction () =
     "font-size folds a constant clamp too" ".x{font-size:2rem}"
     (normalize ".x { font-size: clamp(1rem, 2rem, 3rem) }")
 
-(* CSS Selectors L4 section 17 (:is()): a single-argument [:is(.x)] matches the
+(* CSS Selectors L4 section 4.2 (:is()): a single-argument [:is(.x)] matches the
    same elements as bare [.x] with the same specificity. Per shortest-wins
    cascade picks the unwrapped form. *)
 let s417_is_unwrap () =
-  (* CSS Selectors L4 sec. 17: a single-argument [:is(.a)] is spec-equivalent to
-     bare [.a] (same match set, same specificity). Under [~minify:true] the
+  (* CSS Selectors L4 sec. 4.2: a single-argument [:is(.a)] is spec-equivalent
+     to bare [.a] (same match set, same specificity). Under [~minify:true] the
      printer picks the shortest spec-equivalent spelling - the unwrapped form,
      matching Lightning CSS. Non-minified output preserves the wrapper (see
      fidelity_nested_is_preserved). *)
@@ -4855,7 +4856,7 @@ let s417_is_unwrap () =
     (normalize ".x .a.b { color: red }")
     (normalize ".x :is(.a):is(.b) { color: red }")
 
-(* CSS Selectors L4 section 6.2: attribute compound selectors drop quotes per
+(* CSS Selectors L4 section 6.1: attribute compound selectors drop quotes per
    attribute when the value is a valid identifier. *)
 let s462_compound_attr () =
   let normalize css =
@@ -4868,7 +4869,7 @@ let s462_compound_attr () =
     ".x [data-x=a][data-y=b]{color:red}"
     (normalize ".x [data-x=\"a\"][data-y=\"b\"] { color: red }")
 
-(* CSS Selectors L4 section 4.2 (compound selector): chained pseudo- classes
+(* CSS Selectors L4 section 3.1 (compound selector): chained pseudo- classes
    preserve their order and do not deduplicate. *)
 let s442_compound_pseudo_kept () =
   let normalize css =
@@ -4880,7 +4881,7 @@ let s442_compound_pseudo_kept () =
     ":hover:focus:active preserved" ".x :hover:focus:active{color:red}"
     (normalize ".x :hover:focus:active { color: red }")
 
-(* CSS Transforms L1 section 11: multiple transform functions stack in source
+(* CSS Transforms L1 section 8: multiple transform functions stack in source
    order; whitespace between them is optional for parsing. Lightning CSS drops
    it; per shortest-wins cascade follows. *)
 let transforms1_11_chain_whitespace_dropped () =
@@ -4899,10 +4900,10 @@ let transforms1_11_chain_whitespace_dropped () =
    optimizer cannot inline a variable without a context that resolves it (a
    [theme] map keyed on custom property names), so the [var()] reference and its
    [calc()] wrapper round-trip preserved. The value-independent CSS Values 4
-   sec. 10.7 identities ([x * 1], [x + 0], ...) still fold: they hold for every
-   possible substitution because the [var()] stays inside calc()'s grammar, so
-   [calc(var(--x) * 1)] shortens to [calc(var(--x))] (not to bare [var(--x)],
-   which sec. 10.10 forbids without knowing the value). *)
+   sec. 10.10.1 identities ([x * 1], [x + 0], ...) still fold: they hold for
+   every possible substitution because the [var()] stays inside calc()'s
+   grammar, so [calc(var(--x) * 1)] shortens to [calc(var(--x))] (not to bare
+   [var(--x)], which sec. 10.10 forbids without knowing the value). *)
 let customprops12_inlining () =
   let normalize css =
     match Css.of_string ~strict:false css with
@@ -5026,7 +5027,7 @@ let customprops12_text_payload () =
      Astring.String.is_infix ~affix:"var(--brand)" out
      && not (Astring.String.is_infix ~affix:"red" out))
 
-(* CSS Custom Properties L1 section 5 (Resolving Dependency Cycles): a variable
+(* CSS Custom Properties L1 section 3 (Resolving Dependency Cycles): a variable
    that references itself directly or indirectly is invalid at computed time. At
    syntax time the chain is preserved - the cycle detection happens in the
    cascade. *)
@@ -5359,9 +5360,9 @@ let fidelity_logical_property_preserved () =
   pretty_preserves ".x { margin-inline-start: 10px }" [ "margin-inline-start" ];
   pretty_preserves ".x { padding-block: 5px 10px }" [ "padding-block" ]
 
-(* {2 Container Queries (CSS Containment L3 sec. 6)} *)
+(* {2 Container Queries (CSS Containment L3 sec. 4.4)} *)
 
-(* CSS Containment Module Level 3, section 6 (Container Queries): the
+(* CSS Containment Module Level 3, section 4.4 (Container Queries): the
    [@container] rule supports an optional name and a query expression. Both
    forms round-trip preserved, including the named form [@container card
    (...)]. *)
@@ -5390,11 +5391,11 @@ let fidelity_container_query_preserved () =
   pretty_preserves "@container card (inline-size > 30em) { .x { color: red } }"
     [ "card"; "inline-size > 30em" ]
 
-(* {2 Font shorthand (CSS Fonts L4 sec. 6.5)} *)
+(* {2 Font shorthand (CSS Fonts L4 sec. 2.7)} *)
 
-(* CSS Fonts Module Level 4, section 6.5 (Shorthand font property): the [font]
+(* CSS Fonts Module Level 4, section 2.7 (Shorthand font property): the [font]
    shorthand expands to several longhands; the keyword [bold] inside the
-   shorthand canonicalizes to [700] under minify per sec. 5.1.2. System font
+   shorthand canonicalizes to [700] under minify per sec. 2.2. System font
    keywords ([caption], [icon], [menu]) round-trip preserved. *)
 let fonts4_6_5_font_shorthand () =
   let normalize css =
@@ -5429,9 +5430,9 @@ let fidelity_font_shorthand_preserved () =
     [ "italic"; "small-caps"; "bold" ];
   pretty_preserves ".x { font: caption }" [ "caption" ]
 
-(* {2 List-style shorthand (CSS Lists L3 sec. 3)} *)
+(* {2 List-style shorthand (CSS Lists L3 sec. 3.6)} *)
 
-(* CSS Lists Module Level 3, section 3 (list-style shorthand): the shorthand
+(* CSS Lists Module Level 3, section 3.6 (list-style shorthand): the shorthand
    sets [list-style-type], [list-style-position], and [list- style-image].
    Default values may be elided per shortest-wins. *)
 let lists3_list_style_shorthand () =
@@ -5455,9 +5456,9 @@ let fidelity_list_style_preserved () =
   pretty_preserves ".x { list-style: disc inside }" [ "disc"; "inside" ];
   pretty_preserves ".x { list-style-type: none }" [ "list-style-type" ]
 
-(* {2 Cascade origin + !important interaction (Cascade L6 sec. 6.3)} *)
+(* {2 Cascade origin + !important interaction (Cascade L5 sec. 6.3)} *)
 
-(* CSS Cascading and Inheritance Module Level 6, section 6.3 (Importance): for
+(* CSS Cascading and Inheritance Module Level 5, section 6.3 (Importance): for
    important declarations the origin precedence is inverted - user-agent
    !important > user !important > author !important. The cascade test surface
    validates that important declarations preserve their authored !important
@@ -5961,7 +5962,7 @@ let normalize_minified css =
    declarations as opaque token streams. CSS Properties and Values API 1 section
    2 lifts a custom property into a typed value only after an @property
    registration for that name. *)
-(* CSS Scroll Snap 1 section 6.2: [scroll-snap-align] takes one or two
+(* CSS Scroll Snap 1 section 5.2: [scroll-snap-align] takes one or two
    keywords; the reader must stop at the end of the value, not consume the
    declaration's trailing semicolon as a missing second keyword. *)
 let scroll_snap_align_trailing_semicolon () =
@@ -6545,12 +6546,12 @@ let theme_chain_resolution () =
     ".x{text-shadow:0 0 2px red}"
     (render_optimized ".x { text-shadow: 0 0 2px var(--shadow-color) }")
 
-(* CSS Custom Properties L1 section 2.3: a real per-element dependency cycle
-   makes the variables in that cycle invalid at computed-value time. A
-   caller-provided theme resolver is not that full computed-value graph, so a
-   cycle in resolver output should stop resolution and preserve the authored
-   runtime expression at the boundary instead of looping or guessing that the
-   fallback is safe to select statically. *)
+(* CSS Custom Properties L1 section 3: a real per-element dependency cycle makes
+   the variables in that cycle invalid at computed-value time. A caller-provided
+   theme resolver is not that full computed-value graph, so a cycle in resolver
+   output should stop resolution and preserve the authored runtime expression at
+   the boundary instead of looping or guessing that the fallback is safe to
+   select statically. *)
 let theme_cycle_preserved () =
   let parse css =
     match Css.of_string ~strict:false css with
@@ -7556,7 +7557,7 @@ let additional_tests =
     ( "semicolon-terminated at-rule survives partial parse",
       `Quick,
       fun () ->
-        (* [@layer base;] parses through section 5.4.2 to an at-rule with [block
+        (* [@layer base;] parses through section 5.5.2 to an at-rule with [block
            = None]. The replay cursor must still present a terminating [;] to
            [read_layer], otherwise the at-rule is silently dropped. *)
         let { Css.stylesheet; warnings } =

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -147,7 +147,7 @@ let test_length () =
   check_length ~expected:".5rem" "0.5rem";
   check_length "-.5rem";
 
-  (* CSS Values 4 sec. 6.1: a signed zero is the same value as unsigned zero, so
+  (* CSS Values 4 sec. 5.3: a signed zero is the same value as unsigned zero, so
      any zero collapses to the canonical 0 (the unit is kept). *)
   check_length ~expected:"0px" "-0px";
   check_length ~expected:"0px" "+0px";
@@ -239,7 +239,7 @@ let test_length () =
   neg_cursor (read_calc read_length) "calc(10px +)"
 
 let test_color () =
-  (* Hex colors with #. Per CSS Color 4 section 12.1 the printer canonicalizes
+  (* Hex colors with #. Per CSS Color 4 section 5.2 the printer canonicalizes
      [#rrggbb] to [#rgb] under [~minify:true] when each channel pair matches,
      and lowercases the digits to match the consensus across Lightning CSS,
      esbuild, csso, cssnano, and clean-css. *)
@@ -289,7 +289,7 @@ let test_color () =
   check_color ~expected:"hwb(90 10% 20%)" ~optimized:"#73cc1a" "hwb(90 10% 20%)";
   check_color ~expected:"hwb(90 10% 20%/.25)" ~optimized:"#73cc1a40"
     "hwb(90 10% 20% / 0.25)";
-  (* CSS Color 4 section 1.3: alpha [<percentage>] is spec-equivalent to the
+  (* CSS Color 4 section 4.2: alpha [<percentage>] is spec-equivalent to the
      corresponding [<number>] in [\[0, 1\]]; the printer canonicalizes to the
      number form per cssnano. *)
   check_color ~expected:"hsl(180 50% 25%/30%)" ~optimized:"#2060604d"
@@ -304,7 +304,7 @@ let test_color () =
   (* Additional color functions and forms *)
   check_color ~expected:"oklch(50%.2 30)" ~optimized:"#ba0d01"
     "oklch(50% 0.2 30)";
-  (* Per CSS Color 4 section 1.4 the printer canonicalizes a percentage rgb()
+  (* Per CSS Color 4 section 5.1 the printer canonicalizes a percentage rgb()
      form to the equivalent named/hex spelling. *)
   check_color ~expected:"rgb(100% 0% 0%)" ~optimized:"red" "rgb(100% 0% 0%)";
   check_color ~expected:"oklab(50%.1-.05)" ~optimized:"#88497e"
@@ -313,7 +313,7 @@ let test_color () =
   check_color ~expected:"rgb(255 0 0/50%)" ~optimized:"#ff000080"
     "rgb(255 0 0 / 50%)";
 
-  (* Mixed channel formats in modern rgb() syntax. Per CSS Color 4 section 1.4
+  (* Mixed channel formats in modern rgb() syntax. Per CSS Color 4 section 5.1
      the printer canonicalizes a fully-opaque rgb() to the equivalent named/hex
      form when shorter, regardless of input channel format. *)
   check_color ~optimized:"olive" "rgb(50% 128 0)";
@@ -348,7 +348,7 @@ let test_color () =
   check_color "teal";
   check_color ~optimized:"#0ff" "aqua";
 
-  (* Special keywords. Per CSS Color 4 section 6.4 [transparent] canonicalizes
+  (* Special keywords. Per CSS Color 4 section 6.3 [transparent] canonicalizes
      to the shortest spec-equivalent spelling [#0000] under minify. *)
   check_color ~optimized:"#0000" "transparent";
   check_color ~expected:"currentColor" "currentcolor";
@@ -374,7 +374,7 @@ let test_color () =
   check_color ~expected:"var(--accent,rgb(255 0 128/80%))"
     ~optimized:"var(--accent,#ff0080cc)" "var(--accent, rgb(255 0 128 / 80%))";
 
-  (* RGB functions - various formats. Per CSS Color 4 section 1.4 the printer
+  (* RGB functions - various formats. Per CSS Color 4 section 5.1 the printer
      canonicalizes a fully-opaque rgb() to the named-or-hex equivalent when
      shorter. *)
   check_color ~expected:"rgb(255 0 0)" ~optimized:"red" "rgb(255, 0, 0)";
@@ -507,9 +507,10 @@ let test_angle () =
     "0.000001deg";
   decl_optimizes ~prop:"rotate" ~held:".0001deg" ~into:".0001deg" "0.0001deg";
 
-  (* CSS Values 4 sec. 10.7: scaling a typed <angle> by a unitless number folds
-     to a concrete angle (then picks the shortest unit), so calc(1deg * -45) ->
-     -45deg matches what the browser computes. Both operand orders fold. *)
+  (* CSS Values 4 sec. 10.10.1: scaling a typed <angle> by a unitless number
+     folds to a concrete angle (then picks the shortest unit), so calc(1deg *
+     -45) -> -45deg matches what the browser computes. Both operand orders
+     fold. *)
   decl_optimizes ~prop:"rotate" ~held:"calc(1deg*-45)" ~into:"-45deg"
     "calc(1deg * -45)";
   decl_optimizes ~prop:"rotate" ~held:"calc(45deg*2)" ~into:"90deg"
@@ -530,8 +531,8 @@ let test_angle () =
     ~into:"calc(var(--x)*1deg)" "calc(var(--x) * 1deg)";
   decl_optimizes ~prop:"rotate" ~held:"calc(45deg*2*var(--x))"
     ~into:"calc(90deg*var(--x))" "calc(45deg * 2 * var(--x))";
-  (* Same-unit add/sub of two angles combines into one (CSS Values 4 sec. 10.7);
-     cross-unit operands stay unfolded. *)
+  (* Same-unit add/sub of two angles combines into one (CSS Values 4 sec.
+     10.10.1); cross-unit operands stay unfolded. *)
   decl_optimizes ~prop:"rotate" ~held:"calc(45deg + 45deg)" ~into:"90deg"
     "calc(45deg + 45deg)";
   decl_optimizes ~prop:"rotate" ~held:"calc(90deg - 45deg)" ~into:"45deg"
@@ -551,7 +552,7 @@ let test_angle () =
   neg_cursor read_angle "360.5.5deg"
 
 let test_duration () =
-  (* CSS Values 4 section 6.6: [<time>] requires a unit. s and ms convert
+  (* CSS Values 4 section 7.2: [<time>] requires a unit. s and ms convert
      exactly (1s = 1000ms), so a duration decodes to one canonical magnitude and
      pp prints its shortest spelling - whichever of s/ms is shorter - as a
      same-node choice. (Contrast <angle>, where rad does not convert exactly, so
@@ -573,7 +574,7 @@ let test_duration () =
   check_duration ~expected:".15s" "150ms";
   check_duration "1.5s";
 
-  (* CSS Values 4 sec. 10.7: a typed <time> scales by a number and same-unit
+  (* CSS Values 4 sec. 10.10.1: a typed <time> scales by a number and same-unit
      operands combine. s and ms stay distinct, and an inexact division keeps the
      calc() so no precision is lost. *)
   decl_optimizes ~prop:"transition-duration" ~held:"calc(1s*2)" ~into:"2s"
@@ -601,7 +602,7 @@ let test_duration () =
 let test_percentage () =
   check_percentage "50%";
   check_percentage "100%";
-  (* CSS Values 4 sec. 6.5 only lets a [<length>] zero drop the unit; a zero
+  (* CSS Values 4 sec. 6 only lets a [<length>] zero drop the unit; a zero
      [<percentage>] keeps the [%] (otherwise it would type as a [<number>] and
      the dimension/percentage grammars would reject it). *)
   check_percentage "0%";
@@ -1062,8 +1063,8 @@ let test_alpha () =
   check_alpha ~expected:"0" "-0.5";
   check_alpha ~expected:"100%" "150%";
   decl_optimizes ~prop:"color" ~into:"#000" "rgb(0 0 0 / 150%)";
-  (* CSS Values 4 sec. 10.7: an alpha calc() resolves - a scaled or added alpha
-     folds, and a percentage alpha that reaches 100% drops the channel. *)
+  (* CSS Values 4 sec. 10.10.1: an alpha calc() resolves - a scaled or added
+     alpha folds, and a percentage alpha that reaches 100% drops the channel. *)
   decl_optimizes ~prop:"color" ~into:"#ff000080" "rgb(255 0 0 / calc(0.5 * 1))";
   decl_optimizes ~prop:"color" ~into:"#ff00004d"
     "rgb(255 0 0 / calc(0.2 + 0.1))";
@@ -1080,7 +1081,7 @@ let test_hue_interpolation () =
   neg_cursor read_hue_interpolation ""
 
 let test_calc_op () =
-  (* Per CSS Values 4 section 10.7 the [+] and [-] operators require surrounding
+  (* Per CSS Values 4 section 10.8 the [+] and [-] operators require surrounding
      whitespace; [*] and [/] do not. Per shortest-wins the printer omits the
      spaces around [*] and [/] (matches cssnano). *)
   check_calc_op ~expected:" + " "+";
@@ -1264,7 +1265,7 @@ let spec_color5_function_edges () =
     "color-mix(in oklch, oklch(0.7 0.15 350), oklch(0.7 0.15 10))";
   check_color ~expected:"color-mix(in lch,lch(70 50 350),lch(70 50 10))"
     ~optimized:"#fc84ae" "color-mix(in lch, lch(70 50 350), lch(70 50 10))";
-  (* CSS Color 4 sec. 12.3: [color-mix(in srgb, ...)] interpolates premultiplied
+  (* CSS Color 4 sec. 13.3: [color-mix(in srgb, ...)] interpolates premultiplied
      channels then un-premultiplies by the interpolated alpha; the <100%-sum
      scaling applies only to the result alpha. *)
   (* Opaque 50/50: straight average. *)
@@ -1278,7 +1279,7 @@ let spec_color5_function_edges () =
     "color-mix(in srgb, #0000, red)";
   check_color ~expected:"color-mix(in srgb,transparent,red)"
     ~optimized:"#ff000080" "color-mix(in srgb, transparent, red)";
-  (* Sec. 12.3 premultiplication applies in every interpolation space, not just
+  (* Sec. 13.3 premultiplication applies in every interpolation space, not just
      sRGB. Mixing #0088cc 50% with transparent must restore #0088cc at half
      alpha in oklab/oklch/lab/lch too, never bleed transparent's zero
      coordinates in and darken the result. *)
@@ -1295,7 +1296,7 @@ let spec_color5_function_edges () =
   check_color ~expected:"color-mix(in oklab,#08c,transparent)"
     ~optimized:"#0088cc80" "color-mix(in oklab, #0088cc, transparent)";
   (* A zero-chroma operand (transparent) has a powerless hue in the polar spaces
-     (sec. 12.2): it carries the opaque operand's hue over instead of
+     (sec. 4.4.1): it carries the opaque operand's hue over instead of
      interpolating toward an undefined angle, so red at half alpha stays red. *)
   check_color ~expected:"color-mix(in oklch,red 50%,transparent)"
     ~optimized:"#ff000080" "color-mix(in oklch, red 50%, transparent)";


### PR DESCRIPTION
Comments and docstrings across the library and tests cited section numbers that either do not exist or cover a different topic, and a number that exists but says something else reads as verified. Every numbered citation was checked against its spec's table of contents, one document at a time.