### PR TITLE
apply: --minimal must account for what a shorthand resets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,13 @@
   `var()`, `light-dark()` or `currentColor` inside `color-mix()` names two
   values across two elements, so `div{font-size:2em}div p{font-size:2em}`
   halved the paragraph (#326, #329)
+- `cascade apply --minimal` keeps a restated inherited shorthand when an
+  element in between sets one of the longhands it resets. A shorthand resets
+  every longhand it does not mention (css-fonts-4 sec. 2.7 for `font`), so the
+  restatement is what puts that longhand back, and
+  `#p{font:16px serif}#mid{font-weight:bold}#c{font:16px serif}` left `#c`
+  bold. `all` and a property cascade does not type reset everything, so neither
+  is dropped either (#332)
 
 ## 1.1.0
 

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -220,6 +220,37 @@ let element_independent v =
   in
   scan []
 
+(* The cascade slots a declaration writes, as {!Shorthand} models them for the
+   optimizer's conflict graph. A shorthand names every longhand it resets there
+   - [font] names [font-weight] and [line-height] (css-fonts-4 sec. 2.7),
+   [list-style] names [list-style-image] (css-lists-3 sec. 3.4), [white-space]
+   names [text-wrap-mode] (css-text-4 sec. 3) - which is exactly what the
+   restatement check needs, so the reset sets come from that model rather than
+   from a second table beside it. [all] resets every property (css-cascade-5
+   sec. 3.2), and a property cascade does not type carries no reset set at all -
+   [font-variant] is one - so both count as writing every slot. *)
+type footprint = Every_slot | Slots of Shorthand.overlap_key list
+
+let rec footprint = function
+  | Declaration.Theme_guarded { decl; _ } -> footprint decl
+  | Declaration.Declaration { property = All; _ } -> Every_slot
+  | Declaration.Declaration { property = Unknown_property _; _ } -> Every_slot
+  | d -> Slots (Shorthand.declaration_overlap_keys d)
+
+(* Whether [v] only restates the value the ancestors have in force for [p]. *)
+let restates p v ctx =
+  match List.assoc_opt p ctx with
+  | Some (w, _) -> String.equal w v
+  | None -> false
+
+(* Drop every context entry [keys] can write: a value the ancestors put in force
+   stops being in force as soon as something on the way down resets one of its
+   slots. *)
+let forget keys ctx =
+  List.filter
+    (fun (_, (_, k)) -> not (Shorthand.overlap_keys_intersect keys k))
+    ctx
+
 let add_props acc ds =
   List.fold_left
     (fun acc d ->
@@ -367,8 +398,10 @@ module Make (Node : Resolve.NODE) = struct
     | Some _ -> SSet.add "direction" named
     | None -> named
 
-  (* [ctx] maps each inherited property to the value in force from the
-     ancestors, so [minimal] can drop a declaration that only restates it. *)
+  (* [ctx] maps each inherited property to the value in force from the ancestors
+     and the slots that value covers, so [minimal] can drop a declaration that
+     only restates it, and can tell when something on the way down has reset one
+     of those slots. *)
   let rec walk ~minimal sheet ctx node acc =
     let is_no_style =
       match Node.name node with
@@ -382,24 +415,29 @@ module Make (Node : Resolve.NODE) = struct
     else begin
       let decls = resolved sheet node in
       let ua = ua_props node in
+      (* Without [minimal] nothing is dropped, so no context is needed. *)
       let kept, ctx' =
-        List.fold_left
-          (fun (kept, ctx) d ->
-            let p = String.lowercase_ascii (Declaration.property_name d) in
-            if not (minimal && is_inherited p) then (d :: kept, ctx)
-            else
-              let v = decl_value d in
-              (* Inheritance only reaches a property nothing declares, so a
-                 value the UA would win back is not a restatement, and equal
-                 text is only equal computed values where nothing in it resolves
-                 against the element. *)
-              if
-                (not (SSet.mem p ua))
-                && List.assoc_opt p ctx = Some v
-                && element_independent v
-              then (kept, ctx)
-              else (d :: kept, (p, v) :: List.remove_assoc p ctx))
-          ([], ctx) decls
+        if not minimal then (List.rev decls, ctx)
+        else
+          List.fold_left
+            (fun (kept, ctx) d ->
+              let p = String.lowercase_ascii (Declaration.property_name d) in
+              match footprint d with
+              | Every_slot -> (d :: kept, [])
+              | Slots keys when not (is_inherited p) ->
+                  (d :: kept, forget keys ctx)
+              | Slots keys ->
+                  let v = decl_value d in
+                  (* Inheritance only reaches a property nothing declares, so a
+                     value the UA would win back is not a restatement, and equal
+                     text is only equal computed values where nothing in it
+                     resolves against the element. *)
+                  if
+                    (not (SSet.mem p ua))
+                    && restates p v ctx && element_independent v
+                  then (kept, ctx)
+                  else (d :: kept, (p, (v, keys)) :: forget keys ctx))
+            ([], ctx) decls
       in
       (* A UA declaration the element does not override is what its children
          inherit, so the ancestors' value stops here. *)

--- a/test/inline/fixtures/shorthand.html
+++ b/test/inline/fixtures/shorthand.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+<head><style>
+  /* Every group writes the same text on an ancestor and a descendant, so
+     --minimal sees a restatement, and puts an element in between that sets one
+     of the longhands the restatement resets. The restatement is what puts that
+     longhand back, so it has to survive. */
+  #fw          { font: 16px serif }
+  #fw .m       { font-weight: bold }
+  #fw .d       { font: 16px serif }
+  #lh          { font: 16px serif }
+  #lh .m       { line-height: 48px }
+  #lh .d       { font: 16px serif }
+  #fs          { font: 16px serif }
+  #fs .m       { font-style: italic }
+  #fs .d       { font: 16px serif }
+  #ls          { list-style: square }
+  #ls .m       { list-style-image: url(data:image/gif;base64,R0lGODlhAQABAAAAACw=) }
+  #ls .d       { list-style: square }
+  #fv          { font-variant: normal }
+  #fv .m       { font-variant-caps: small-caps }
+  #fv .d       { font-variant: normal }
+  #ws          { white-space: pre-wrap }
+  #ws .m       { text-wrap-mode: nowrap }
+  #ws .d       { white-space: pre-wrap }
+  /* The other way round: the shorthand in between resets the longhand the
+     descendant restates. */
+  #rev         { font-weight: 700 }
+  #rev .m      { font: 16px serif }
+  #rev .d      { font-weight: 700 }
+  /* A shorthand with no typed reset set, and the one that resets the lot. */
+  #fvsh        { font: 16px serif }
+  #fvsh .m     { font-variant: small-caps }
+  #fvsh .d     { font: 16px serif }
+  #all         { color: red }
+  #all .m      { all: initial }
+  #all .d      { color: red }
+  /* Controls: nothing in between touches a slot the restatement writes, so
+     --minimal may drop it. */
+  #ctl         { font: 16px serif; color: red }
+  #ctl .m      { text-align: right }
+  #ctl .d      { font: 16px serif; color: red }
+</style></head>
+<body>
+  <p id="fw">a <span class="m">c <span class="d">b</span></span></p>
+  <p id="lh">a <span class="m">c <span class="d">b</span></span></p>
+  <p id="fs">a <span class="m">c <span class="d">b</span></span></p>
+  <p id="ls">a <span class="m">c <span class="d">b</span></span></p>
+  <p id="fv">a <span class="m">c <span class="d">b</span></span></p>
+  <p id="ws">a <span class="m">c <span class="d">b</span></span></p>
+  <p id="rev">a <span class="m">c <span class="d">b</span></span></p>
+  <p id="fvsh">a <span class="m">c <span class="d">b</span></span></p>
+  <p id="all">a <span class="m">c <span class="d">b</span></span></p>
+  <p id="ctl">a <span class="m">c <span class="d">b</span></span></p>
+</body>
+</html>

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -283,6 +283,60 @@ let minimal_keeps_a_relative_value () =
   dropped "color:hsl(210 40% 96%)";
   dropped "color:#f1f5f9"
 
+(* [minimal] drops a restated inherited declaration because the same text is
+   already in force from an ancestor, but a shorthand also resets every longhand
+   it does not mention, and an element in between can set one of those: the
+   restatement is then the thing that puts it back. css-cascade-5 sec. 6.1 lets
+   the middle element's declaration cascade onto the descendant by inheritance,
+   so dropping the descendant's shorthand changes the render. The reset sets:
+   css-fonts-4 sec. 2.7 for [font], sec. 6.10 for [font-variant], css-lists-3
+   sec. 3.4 for [list-style], css-text-4 sec. 3 for [white-space], and
+   css-cascade-5 sec. 3.2 for [all], which resets every property there is. A
+   property cascade does not type carries no reset set at all, so it counts as
+   resetting everything.
+
+   Chrome 146 on [#p{font:16px serif}#mid{font-weight:bold}#c{font:16px serif}]:
+   the innermost element computes font-weight 700, and 400 once the [font]
+   declaration is dropped. *)
+let minimal_keeps_a_restatement_that_resets_a_longhand () =
+  let projected ~middle decl =
+    let c = node ~id:"c" "span" in
+    let mid = node ~id:"mid" ~children:[ c ] "span" in
+    let root = node ~id:"p" ~children:[ mid ] "div" in
+    let css =
+      String.concat "" [ "#p{"; decl; "}#mid{"; middle; "}#c{"; decl; "}" ]
+    in
+    let result = A.compute ~minimal:true ~sheet:(parse css) [ root ] in
+    match List.find_opt (fun (m, _) -> Node.equal m c) result.styles with
+    | Some (_, decls) -> inline_style decls
+    | None -> Alcotest.fail "no assignment for the innermost element"
+  in
+  let case expected ~middle decl =
+    Alcotest.(check string)
+      (decl ^ " under " ^ middle)
+      expected (projected ~middle decl)
+  in
+  let kept ~middle decl = case decl ~middle decl in
+  let dropped ~middle decl = case "" ~middle decl in
+  (* A longhand in between, and the shorthand restated below it. *)
+  kept ~middle:"font-weight:bold" "font:16px serif";
+  kept ~middle:"line-height:48px" "font:16px serif";
+  kept ~middle:"font-style:italic" "font:16px serif";
+  kept ~middle:"list-style-image:url(a.gif)" "list-style:square";
+  kept ~middle:"font-variant-caps:small-caps" "font-variant:normal";
+  kept ~middle:"text-wrap-mode:nowrap" "white-space:pre-wrap";
+  (* The other way round: the shorthand in between resets the longhand the
+     descendant restates. *)
+  kept ~middle:"font:16px serif" "font-weight:700";
+  (* A shorthand cascade does not type, and the one that resets everything. *)
+  kept ~middle:"font-variant:small-caps" "font:16px serif";
+  kept ~middle:"all:initial" "color:red";
+  (* The controls: nothing in between touches a slot the restatement writes, so
+     the restatement still goes. *)
+  dropped ~middle:"color:red" "font:16px serif";
+  dropped ~middle:"font-weight:700" "color:red";
+  dropped ~middle:"font-style:italic" "color:red"
+
 (* The whole split of [css] over [roots]: the style attribute written onto [n],
    the <style> body kept beside it, and the count of kept rules. *)
 let check_split name ?roots ~css ~inline ~keep ~kept n =
@@ -454,6 +508,8 @@ let suite =
         minimal_keeps_what_a_ua_rule_would_win;
       Alcotest.test_case "minimal keeps a relative value" `Quick
         minimal_keeps_a_relative_value;
+      Alcotest.test_case "minimal keeps a restatement that resets a longhand"
+        `Quick minimal_keeps_a_restatement_that_resets_a_longhand;
       Alcotest.test_case "keeps the property a scoped rule sets" `Quick
         keeps_property_a_scoped_rule_sets;
       Alcotest.test_case "keeps the property a starting-style rule sets" `Quick


### PR DESCRIPTION
`cascade apply --minimal` used to drop a restated inherited shorthand whenever the ancestor's copy had the same text, without accounting for the longhands the shorthand resets; an element in between can set one of them, and the restatement is what puts it back. Chrome 146 computes `font-weight: 700` for `#c` under `#p{font:16px serif}#mid{font-weight:bold}#c{font:16px serif}`, and 400 once the declaration is dropped.