### PR TITLE
values: cite the real rule for RGB channel rounding

### DIFF
--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5656,10 +5656,13 @@ let rec read_channel t : channel =
         (* Clamp percentage to 0-100 per CSS spec *)
         Pct (max 0. (min 100. n))
     | None ->
-        (* CSS Color 4 sec. 15.1: when serialising an RGB channel back as an
-           integer, round to the nearest byte (not truncate); [rgb(127.6 ...)]
-           is [128], not [127]. Decimals in (0, 1) stay as [Num] so alpha
-           helpers can still see them as fractional. *)
+        (* CSS Color 4 sec. 5.1 rounds a channel that cannot be kept at full
+           precision "towards +infinity". Sec. 16.5's worked example reads that
+           as nearest-with-ties-up, not as a ceiling: 0.964 serialises as 0.96
+           and 0.787 as 0.79. [Float.round] is exactly that for a non-negative
+           channel, so [rgb(127.6 ...)] is [128] and [rgb(127.2 ...)] is [127],
+           matching Chrome. Decimals in (0, 1) stay as [Num] so alpha helpers
+           can still see them as fractional. *)
         if n <= 1.0 && n <> floor n then Num n
         else Int (int_of_float (max 0. (min 255. (Float.round n))))
     | Some _ -> Cursor.err_invalid t "channel value"

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1133,6 +1133,12 @@ let test_channel () =
   check_channel ~expected:"255" "256";
   check_channel ~expected:"0" "-1";
   check_channel ~expected:"100%" "150%";
+  (* CSS Color 4 sec. 5.1 rounds an out-of-precision channel towards +infinity,
+     which is nearest-with-ties-up rather than a ceiling. *)
+  check_channel ~expected:"127" "127.2";
+  check_channel ~expected:"128" "127.6";
+  check_channel ~expected:"128" "127.5";
+  check_channel ~expected:"127" "126.5";
   neg_cursor read_channel ""
 
 let test_rgb () =


### PR DESCRIPTION
The comment on the RGB channel reader cited CSS Color 4 sec. 15.1, which carries no rounding rule, and "round to the nearest byte" left open whether "rounded towards +infinity" means a ceiling; it does not, and `Float.round` was already right. The parse is unchanged and the tests now pin the direction.