### PR TITLE
svg: accept a stroke-miterlimit between 0 and 1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@
   property values only (CSS Variables 1), so no descriptor grammar accepts one
   and browsers drop the declaration. `src` and `unicode-range` keep theirs,
   since `Css.inline_vars` resolves those references at build time (#322)
+- `stroke-miterlimit` accepts a value between 0 and 1. SVG 2 sec. 13.5.5 makes
+  only a negative value illegal, having dropped SVG 1.1's "at least 1" rule
+  because CSS parsers never enforced it, and `stroke-miterlimit: 0.5` was
+  rejected outright (#334)
 
 ### Minification
 

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -276,10 +276,6 @@ let read_svg_paint t : svg_paint =
     ]
     t
 
-(* SVG 2 sec. 13.3: "A value of zero is invalid; a negative value is an error".
-   The limit is a ratio of miter length to stroke width, and that ratio is 1 at
-   its smallest, so anything below 1 is out of range. Only a literal can be
-   checked here; calc() and var() resolve later. *)
 let vector_effect_keyword_of = function
   | "non-scaling-stroke" -> Some (Non_scaling_stroke : vector_effect_keyword)
   | "non-scaling-size" -> Some Non_scaling_size
@@ -443,13 +439,17 @@ let rec read_stroke_dasharray t : stroke_dasharray =
       (Dashes (go []) : stroke_dasharray))
     t
 
+(* SVG 2 sec. 13.5.5: "A negative value for stroke-miterlimit must be treated as
+   an illegal value". SVG 1.1 sec. 11.4 also required at least 1, but SVG 2
+   dropped that because CSS parsers never enforced it. Only a literal can be
+   checked here; calc() and var() resolve later. *)
 let read_miterlimit_number t =
   let value =
     match (Values.read_number t : Values.number) with
     | Values.Num value -> value
     | _ -> Cursor.err_invalid t "stroke-miterlimit must resolve to a number"
   in
-  if value < 1. then Cursor.err_invalid t "stroke-miterlimit below 1";
+  if value < 0. then Cursor.err_invalid t "negative stroke-miterlimit";
   value
 
 let rec read_stroke_miterlimit t : stroke_miterlimit =

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3921,7 +3921,7 @@ type stroke_linejoin =
   | Var of stroke_linejoin var
 
 (** SVG 2 sec. 13.5.5 [stroke-miterlimit]: the ratio at which a miter join is
-    converted to a bevel. The specification makes a value below 1 invalid. *)
+    converted to a bevel. Only a negative value is illegal. *)
 type stroke_miterlimit =
   | Number of float
   | Calc of stroke_miterlimit calc

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1893,8 +1893,8 @@ let matrix =
       };
       {
         property = "stroke-miterlimit";
-        positives = [ "1"; "4"; "10.5"; "calc(2 * 3)" ];
-        negatives = [ ".5"; "-1"; "4px"; "4 4" ];
+        positives = [ "0"; ".5"; "1"; "4"; "10.5"; "calc(2 * 3)" ];
+        negatives = [ "-1"; "4px"; "4 4" ];
       };
       {
         property = "stroke-dashoffset";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -146,8 +146,8 @@ let complex_values () =
      five. *)
   check_declaration ~expected:"stroke-linecap:square" "stroke-linecap: square;";
   check_declaration ~expected:"stroke-linejoin:arcs" "stroke-linejoin: arcs;";
-  (* SVG 2 sec. 13.5.5 makes the miter limit a <number> that cannot go below 1,
-     so it minifies like one and a constant calc() folds. *)
+  (* SVG 2 sec. 13.5.5 makes the miter limit a plain <number>, so it minifies
+     like one and a constant calc() folds. *)
   check_declaration ~expected:"stroke-miterlimit:4" "stroke-miterlimit: 4.0;";
   decl_optimizes ~prop:"stroke-miterlimit" ~into:"6" "calc(2 * 3)";
   (* SVG 2 sec. 13.5.6 separates dashes by comma and/or whitespace and the

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2880,9 +2880,10 @@ let test_stroke_miterlimit () =
   check_stroke_miterlimit "4";
   check_stroke_miterlimit "10.5";
   check_stroke_miterlimit "var(--m)";
-  (* The limit is a ratio of miter length to stroke width, which is 1 at its
-     smallest, so the specification makes anything below that invalid. *)
-  neg_cursor read_stroke_miterlimit ".5";
+  (* SVG 2 sec. 13.5.5 makes only a negative miter limit illegal; the SVG 1.1
+     "at least 1" rule went because CSS parsers never enforced it. *)
+  check_stroke_miterlimit "0";
+  check_stroke_miterlimit ~expected:".5" "0.5";
   neg_cursor read_stroke_miterlimit "-1";
   neg_cursor read_stroke_miterlimit "4px"
 


### PR DESCRIPTION
`stroke-miterlimit: 0.5` was rejected on a rule SVG 2 sec. 13.5.5 dropped, since CSS parsers never enforced it; only a negative value is illegal, which is what Chrome and the WPT parsing tests expect. The comment carrying the old rule quoted a sentence that appears in no version of the specification.