### PR TITLE
font-face: a descending descriptor range is not an error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,11 @@
   only a negative value illegal, having dropped SVG 1.1's "at least 1" rule
   because CSS parsers never enforced it, and `stroke-miterlimit: 0.5` was
   rejected outright (#334)
+- A descending `@font-face` descriptor range such as `font-weight: 700 400`
+  parses without a warning and `Css.of_string ~strict:true` accepts it. CSS
+  Fonts 4 sec. 4.4 has the user agent swap the endpoints for font matching, so
+  the range is well defined rather than an error, and only `unicode-range`
+  keeps an ordering rule (#335)
 
 ### Minification
 

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -83,18 +83,10 @@ let rec read_font_style t : font_style =
         Cursor.ws t;
         if Cursor.is_done t || Cursor.peek_semicolon t then Oblique_angle first
         else
-          (* CSS Fonts 4 sec. 4.4 wants the first oblique angle <= the second.
-             Browsers keep a descending range ([oblique 20deg 10deg]), so accept
-             it but warn, leaving [Css.of_string ~strict] free to reject it. *)
+          (* CSS Fonts 4 sec. 4.4 swaps the endpoints of a descending [oblique
+             <angle> <angle>] range rather than rejecting it, so the reader
+             keeps the order it was written in. *)
           let second = read_angle t in
-          (match (angle_degrees_opt first, angle_degrees_opt second) with
-          | Some a, Some b when a > b ->
-              Cursor.push_warning t
-                (Error.bad_value (Cursor.position t) ~property:"font-style"
-                   ~reason:
-                     "oblique angle range must run from the smaller angle to \
-                      the larger (CSS Fonts 4 \u{00a7}11.2)")
-          | _ -> ());
           Oblique_range (first, second))
     t
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1786,23 +1786,10 @@ let read_descriptor_block normalize inner =
   in
   loop []
 
-(* CSS Fonts 4 sec. 4.4 wants the first bound of a descriptor range <= the
-   second. Browsers keep a descending range, so the readers accept it but record
-   a warning here; [Css.of_string ~strict] then turns the warning into an
-   error. *)
-let warn_descending_range r property =
-  Cursor.push_warning r
-    (Error.bad_value (Cursor.position r) ~property
-       ~reason:
-         "range must run from the smaller value to the larger (CSS Fonts 4 \
-          \u{00a7}11.2)")
-
-let font_weight_num = function
-  | (Properties.Weight n : Properties.font_weight) -> Some n
-  | Properties.Normal -> Some 400
-  | Properties.Bold -> Some 700
-  | _ -> None
-
+(* CSS Fonts 4 sec. 4.4: a descriptor range whose startpoint is larger than its
+   endpoint is well defined, the user agent swapping the two endpoints for font
+   matching. The swap is on the computed value, so the descriptor keeps the
+   order it was written in. *)
 let read_font_weight_descriptor r =
   read_descriptor_value Declaration.read_property_value
     (fun value ->
@@ -1814,9 +1801,6 @@ let read_font_weight_descriptor r =
         let second = Properties.read_font_weight c in
         Cursor.ws c;
         Cursor.expect_eof c;
-        (match (font_weight_num first, font_weight_num second) with
-        | Some a, Some b when a > b -> warn_descending_range r "font-weight"
-        | _ -> ());
         Font_weight_range (first, second))
     r
 
@@ -1826,18 +1810,12 @@ let read_font_style_descriptor r =
       let c = Cursor.of_string value in
       let first = Properties.read_font_style c in
       Cursor.ws c;
-      let descriptor =
-        if Cursor.is_done c then Font_style first
-        else
-          let second = Properties.read_font_style c in
-          Cursor.ws c;
-          Cursor.expect_eof c;
-          Font_style_range (first, second)
-      in
-      (* [read_font_style] warns on a descending oblique range; the value is
-         parsed in [c], so surface its warnings on the drained cursor [r]. *)
-      List.iter (Cursor.push_warning r) (Cursor.drain_warnings c);
-      descriptor)
+      if Cursor.is_done c then Font_style first
+      else
+        let second = Properties.read_font_style c in
+        Cursor.ws c;
+        Cursor.expect_eof c;
+        Font_style_range (first, second))
     r
 
 let validate_nonempty_descriptor r name value =
@@ -1857,19 +1835,6 @@ let read_font_family_descriptor r =
     (fun v -> Font_family v)
     r
 
-let font_stretch_pct_opt = function
-  | (Properties.Pct value : Properties.font_stretch) -> Some value
-  | Properties.Ultra_condensed -> Some 50.
-  | Properties.Extra_condensed -> Some 62.5
-  | Properties.Condensed -> Some 75.
-  | Properties.Semi_condensed -> Some 87.5
-  | Properties.Normal -> Some 100.
-  | Properties.Semi_expanded -> Some 112.5
-  | Properties.Expanded -> Some 125.
-  | Properties.Extra_expanded -> Some 150.
-  | Properties.Ultra_expanded -> Some 200.
-  | _ -> None
-
 let read_font_stretch_descriptor r =
   read_descriptor_value Declaration.read_property_value
     (fun value ->
@@ -1878,12 +1843,11 @@ let read_font_stretch_descriptor r =
       Cursor.ws c;
       if Cursor.is_done c then Font_stretch first
       else begin
-        let second = Properties.read_font_stretch c in
+        (* The endpoint is parsed for validation only: the range keeps the raw
+           [value], which already carries both bounds. *)
+        ignore (Properties.read_font_stretch c : Properties.font_stretch);
         Cursor.ws c;
         Cursor.expect_eof c;
-        (match (font_stretch_pct_opt first, font_stretch_pct_opt second) with
-        | Some a, Some b when a > b -> warn_descending_range r "font-stretch"
-        | _ -> ());
         Font_stretch_range value
       end)
     r

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -739,7 +739,8 @@ let spec_fontface_descriptors () =
     "@font-face { font-family: Brand; src: url(font.woff2); font-variant: \
      common-ligatures no-common-ligatures; }";
   (* A descending font-stretch range is kept like the font-weight / oblique
-     ranges below: browsers do not enforce CSS Fonts 4 sec. 4.4. *)
+     ranges below: CSS Fonts 4 sec. 4.4 swaps the endpoints for font matching
+     and leaves the descriptor as it was written. *)
   check_stylesheet
     ~expected:
       "@font-face{font-family:Brand;src:url(font.woff2);font-stretch:200% 50%}"

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1153,6 +1153,18 @@ let spec_strict_accepts_valid_stylesheets () =
       ( "font-face wildcard unicode range",
         "@font-face { font-family: Icons; src: url(icons.woff2); \
          unicode-range: U+4?? }" );
+      (* CSS Fonts 4 sec. 4.4 makes a descending descriptor range well defined
+         rather than an error: the user agent swaps the two endpoints. Only
+         [unicode-range] keeps an ordering rule. *)
+      ( "font-face descending font-weight range",
+        "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
+         900 100 }" );
+      ( "font-face descending oblique angle range",
+        "@font-face { font-family: Brand; src: url(font.woff2); font-style: \
+         oblique 20deg 10deg }" );
+      ( "font-face descending font-stretch range",
+        "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: \
+         200% 50% }" );
       ( "counter-style cyclic",
         "@counter-style thumbs { system: cyclic; symbols: \"*\" \"x\"; suffix: \
          \" \" }" );
@@ -1263,18 +1275,6 @@ let spec_strict_rejects_invalid_stylesheets () =
       ( "font-face unicode-range descending range",
         "@font-face { font-family: Brand; src: url(font.woff2); unicode-range: \
          U+20-10 }" );
-      (* Browsers keep a descending font-weight / oblique-angle range, so the
-         lenient parse keeps it with a warning; strict turns that into an error
-         (CSS Fonts 4 sec. 4.4 wants the first bound <= the second). *)
-      ( "font-face descending font-weight range",
-        "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
-         900 100 }" );
-      ( "font-face descending oblique angle range",
-        "@font-face { font-family: Brand; src: url(font.woff2); font-style: \
-         oblique 20deg 10deg }" );
-      ( "font-face descending font-stretch range",
-        "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: \
-         200% 50% }" );
       ( "font-face invalid font-display list",
         "@font-face { font-family: Brand; src: url(font.woff2); font-display: \
          block swap }" );


### PR DESCRIPTION
`font-weight: 700 400` in an `@font-face` warned and was rejected under `~strict:true`, on a rule CSS Fonts 4 does not state: sec. 4.4 has the user agent swap the endpoints, so the range is well defined and browsers keep it. The oracle change lands as its own commit ahead of the fix.