### PR TITLE
docs: inline_vars keeps a runtime-marked reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cat style.css | cascade -                                          # read stdin
 | `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
 | `--flatten-nesting` | Desugar nested rules into flat top-level rules for browsers that pre-date CSS Nesting. By default cascade preserves nesting since modern browsers parse it natively and it is usually shorter. |
 | `--inline-imports` | Resolve `@import` against files relative to the input. Closed-world: assumes you control file resolution. |
-| `--inline-vars` | Substitute `var(--name)` references with their declared values, then drop unused custom properties. Closed-world: assumes no runtime mutation. |
+| `--inline-vars` | Substitute `var(--name)` references with their declared values, then drop unused custom properties. Closed-world: assumes no runtime mutation of the variables it inlines. |
 | `--keep-vars=NAMES` | Comma-separated custom-property names to preserve under `--inline-vars`. |
 | `--profile` | Print per-pass timings of the optimiser to stderr after the run. Useful to triage which pass dominates on a slow input. Has no effect without `--minify`. |
 | `-q, --quiet` / `-v, --verbose` | Standard verbosity controls. |

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7791,7 +7791,7 @@ val flatten_nesting : t -> t
 (** {2 Closed-world inlining}
 
     Transforms that assume the caller controls properties the open web cannot
-    guarantee (no runtime variable mutation, full file resolution). *)
+    guarantee (no undeclared runtime mutation, full file resolution). *)
 
 val inline_vars : ?keep_vars:string list -> ?warn:(string -> unit) -> t -> t
 (** [inline_vars ?keep_vars ?warn stylesheet] substitutes [var(--name)]
@@ -7800,7 +7800,9 @@ val inline_vars : ?keep_vars:string list -> ?warn:(string -> unit) -> t -> t
     variable in [keep_vars], or one redefined in a different scope (a real
     cascade override such as dark mode), keeps its definition and stays a live
     [var()] reference; [warn] is called with each such name. The transform
-    assumes no runtime mutation of custom properties. *)
+    assumes no runtime mutation of the variables it inlines: a reference marked
+    [~runtime] on {!var_ref} also stays live, fallback included, so a
+    browser-time override point survives. *)
 
 val resolve_theme :
   ?theme:Pp.String_set.t -> ?theme_defaults:(string -> string option) -> t -> t

--- a/lib/inline.mli
+++ b/lib/inline.mli
@@ -2,8 +2,8 @@
 
     Lives one layer above {!Context}: drives the typed-evaluator primitives
     ({!Context.eval}, custom-property lookup) and threads scope through the AST.
-    Both transforms assume a closed world (no runtime mutation, full file
-    resolution). *)
+    Both transforms assume a closed world (no undeclared runtime mutation, full
+    file resolution). *)
 
 val vars :
   ?keep_vars:string list ->


### PR DESCRIPTION
The `Css.inline_vars` docstring promised no runtime mutation of custom properties without naming the carve-out #315 added, and a downstream test pinned the pre-#315 behaviour on that sentence.