### PR TITLE
stylesheet: normalise colour custom properties inside @keyframes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,9 @@
 - `Css.inline_vars` preserves runtime-marked `var()` references, including
   typed fallbacks simplified through scalar values or shorthands, instead of
   replacing browser-time override points with compile-time defaults (#315)
+- A registered `<color>` custom property is promoted and fills the colour slot
+  of a `box-shadow` inside `@keyframes`, so the same declaration minifies the
+  same way wherever it sits (#337)
 
 ### Canonical diff
 
@@ -64,6 +67,9 @@
 - `Css.Stylesheet.statement_declarations` returns the declarations a statement
   holds directly; paired with `statement_children` it reaches every declaration
   in a stylesheet (#317)
+- `Css.Stylesheet.map_statement_children` and `map_statement_declarations`
+  rebuild a statement with a function applied to the block or the declarations
+  it holds, the rebuilding counterparts of the two readers (#337)
 
 ### CLI tools
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -699,6 +699,14 @@ let promote_registered_custom_decl ~lossless registry decl =
                 (Custom_value { value = Tokens components'; layer; meta })))
   | _ -> decl
 
+let promote_frames f frames =
+  list_map_preserve
+    (fun (frame : keyframe) ->
+      let declarations = list_map_preserve f frame.declarations in
+      if declarations == frame.declarations then frame
+      else { frame with declarations })
+    frames
+
 let promote_registered_custom_properties ~lossless (stmts : statement list) =
   let registry : (string, Variables.any_syntax) Hashtbl.t = Hashtbl.create 8 in
   (* An [@property] registration is document-global regardless of source order
@@ -725,6 +733,18 @@ let promote_registered_custom_properties ~lossless (stmts : statement list) =
     | Declarations decls ->
         let decls' = list_map_preserve promote_decl decls in
         if decls' == decls then stmt else Declarations decls'
+    (* A keyframe frame declares registered custom properties like any other
+       block, and the registration is what the frame interpolates against (CSS
+       Properties and Values API 1 SS 2.4). *)
+    | Keyframes (name, frames) ->
+        let frames' = promote_frames promote_decl frames in
+        if frames' == frames then stmt else Keyframes (name, frames')
+    | Webkit_keyframes (name, frames) ->
+        let frames' = promote_frames promote_decl frames in
+        if frames' == frames then stmt else Webkit_keyframes (name, frames')
+    | Moz_keyframes (name, frames) ->
+        let frames' = promote_frames promote_decl frames in
+        if frames' == frames then stmt else Moz_keyframes (name, frames')
     | Media _ | Container _ | Supports _ | Layer _ | Origin _ | Scope _
     | Starting_style _ | Moz_document _ | When _ | Else _ ->
         map_statement_block_preserve walk_stmt stmt

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -304,6 +304,67 @@ let statement_declarations = function
   | Viewport _ | Unknown_at_rule _ ->
       []
 
+(* The rebuilding counterparts of the two readers above. A read-only walk can be
+   written on [statement_children] and [statement_declarations] alone; one that
+   rewrites the tree needs to put the result back, and hand-rolling that half is
+   how a block at-rule ends up read but not written. Exhaustive for the same
+   reason as the readers. *)
+let map_statement_children f = function
+  | Rule rule -> Rule { rule with nested = f rule.nested }
+  | Layer (name, block) -> Layer (name, f block)
+  | Media (query, block) -> Media (query, f block)
+  | Container (name, query, block) -> Container (name, query, f block)
+  | Supports (condition, block) -> Supports (condition, f block)
+  | Moz_document (condition, block) -> Moz_document (condition, f block)
+  | When (condition, block) -> When (condition, f block)
+  | Else (condition, block) -> Else (condition, f block)
+  | Starting_style block -> Starting_style (f block)
+  | Origin (origin, block) -> Origin (origin, f block)
+  | Scope (start, end_, block) -> Scope (start, end_, f block)
+  | ( Property _ | Declarations _ | Bang_comment _ | Charset _ | Import _
+    | Namespace _ | Layer_decl _ | Supports_condition _ | Keyframes _
+    | Webkit_keyframes _ | Moz_keyframes _ | Font_face _ | Counter_style _
+    | Page _ | Page_with_margins _ | Font_palette_values _
+    | Font_feature_values _ | View_transition _ | Position_try _ | Viewport _
+    | Unknown_at_rule _ ) as stmt ->
+      stmt
+
+let map_frame_declarations f frames =
+  List.map
+    (fun (frame : keyframe) ->
+      { frame with declarations = f frame.declarations })
+    frames
+
+(* [f] sees each declaration list the statement holds as its own list, not the
+   concatenation [statement_declarations] returns: the frames of [@keyframes]
+   and the margin rules of [@page] each keep their own block. *)
+let map_statement_declarations f = function
+  | Rule rule -> Rule { rule with declarations = f rule.declarations }
+  | Declarations decls -> Declarations (f decls)
+  | Supports_condition (name, decls) -> Supports_condition (name, f decls)
+  | Page (selector, decls) -> Page (selector, f decls)
+  | Position_try (name, decls) -> Position_try (name, f decls)
+  | Keyframes (name, frames) -> Keyframes (name, map_frame_declarations f frames)
+  | Webkit_keyframes (name, frames) ->
+      Webkit_keyframes (name, map_frame_declarations f frames)
+  | Moz_keyframes (name, frames) ->
+      Moz_keyframes (name, map_frame_declarations f frames)
+  | Page_with_margins (selector, descriptors, margins) ->
+      Page_with_margins
+        ( selector,
+          f descriptors,
+          List.map
+            (fun (margin : page_margin_rule) ->
+              { margin with descriptors = f margin.descriptors })
+            margins )
+  | ( Property _ | Bang_comment _ | Charset _ | Import _ | Namespace _
+    | Layer_decl _ | Layer _ | Media _ | Container _ | Supports _
+    | Moz_document _ | When _ | Else _ | Starting_style _ | Origin _ | Scope _
+    | Font_face _ | Counter_style _ | Font_palette_values _
+    | Font_feature_values _ | View_transition _ | Viewport _ | Unknown_at_rule _
+      ) as stmt ->
+      stmt
+
 (** {1 Pretty Printing} *)
 
 let pp_property_rule : 'a property_rule Pp.t =
@@ -569,32 +630,11 @@ let color_custom_property_names stylesheet =
         String_set.add (var_name_of_custom_property name) names
     | _ -> names
   in
-  let declarations names decls = List.fold_left declaration names decls in
-  let rec statement names = function
-    | Rule rule ->
-        let names = declarations names rule.declarations in
-        List.fold_left statement names rule.nested
-    | Declarations decls -> declarations names decls
-    | Layer (_, block)
-    | Media (_, block)
-    | Container (_, _, block)
-    | Supports (_, block)
-    | Moz_document (_, block)
-    | When (_, block)
-    | Else (_, block)
-    | Starting_style block
-    | Origin (_, block)
-    | Scope (_, _, block) ->
-        List.fold_left statement names block
-    | Page (_, decls) | Position_try (_, decls) | Supports_condition (_, decls)
-      ->
-        declarations names decls
-    | Page_with_margins (_, descs, margins) ->
-        let names = declarations names descs in
-        List.fold_left
-          (fun names margin -> declarations names margin.descriptors)
-          names margins
-    | _ -> names
+  let rec statement names stmt =
+    let names =
+      List.fold_left declaration names (statement_declarations stmt)
+    in
+    List.fold_left statement names (statement_children stmt)
   in
   List.fold_left statement String_set.empty stylesheet
 
@@ -682,41 +722,10 @@ let normalise_shadows stylesheet =
   if String_set.is_empty color_vars then stylesheet
   else
     let declarations = List.map (rewrite_shadow_decl color_vars) in
-    let rec statement = function
-      | Rule rule ->
-          Rule
-            {
-              rule with
-              declarations = declarations rule.declarations;
-              nested = List.map statement rule.nested;
-            }
-      | Declarations decls -> Declarations (declarations decls)
-      | Layer (name, block) -> Layer (name, List.map statement block)
-      | Media (query, block) -> Media (query, List.map statement block)
-      | Container (name, query, block) ->
-          Container (name, query, List.map statement block)
-      | Supports (query, block) -> Supports (query, List.map statement block)
-      | Moz_document (query, block) ->
-          Moz_document (query, List.map statement block)
-      | When (query, block) -> When (query, List.map statement block)
-      | Else (query, block) -> Else (query, List.map statement block)
-      | Starting_style block -> Starting_style (List.map statement block)
-      | Origin (origin, block) -> Origin (origin, List.map statement block)
-      | Scope (start, end_, block) ->
-          Scope (start, end_, List.map statement block)
-      | Page (selector, decls) -> Page (selector, declarations decls)
-      | Page_with_margins (selector, descs, margins) ->
-          Page_with_margins
-            ( selector,
-              declarations descs,
-              List.map
-                (fun margin ->
-                  { margin with descriptors = declarations margin.descriptors })
-                margins )
-      | Position_try (name, decls) -> Position_try (name, declarations decls)
-      | Supports_condition (name, decls) ->
-          Supports_condition (name, declarations decls)
-      | other -> other
+    let rec statement stmt =
+      stmt
+      |> map_statement_declarations declarations
+      |> map_statement_children (List.map statement)
     in
     List.map statement stylesheet
 

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -241,6 +241,21 @@ val statement_declarations : statement -> declaration list
     declaration-carrying at-rule added to the AST later does not compile until
     it is listed here. *)
 
+val map_statement_children : (block -> block) -> statement -> statement
+(** [map_statement_children f stmt] rebuilds [stmt] with [f] applied to the
+    block {!statement_children} reads, and returns a statement that holds no
+    block unchanged. It is the rebuilding counterpart of {!statement_children},
+    for a walk that rewrites the tree rather than only reading it. *)
+
+val map_statement_declarations :
+  (declaration list -> declaration list) -> statement -> statement
+(** [map_statement_declarations f stmt] rebuilds [stmt] with [f] applied to the
+    declarations it holds directly, and returns a statement that holds none
+    unchanged. It is the rebuilding counterpart of {!statement_declarations},
+    with one difference: [f] sees each declaration list as its own list rather
+    than the concatenation, so every frame of [@keyframes] and every margin rule
+    of [@page] keeps its own block. *)
+
 (** {1 Reading/Parsing} *)
 
 val read_rule : ?nested:bool -> Cursor.t -> rule

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -882,6 +882,40 @@ let spec_keyframes_selector_matrix () =
   check_stylesheet ~expected:"@keyframes bad{}"
     "@keyframes bad { from, 120% { opacity: 1 } }"
 
+(* CSS Properties and Values API 1 sec. 2: an [@property] registration is
+   document-global, so [var(--ring)] carries a [<color>] wherever it is
+   referenced. In [box-shadow: 0 0 var(--ring)] the reference therefore fills
+   the colour slot, not the blur slot, and a [@keyframes] frame is an ordinary
+   declaration block (CSS Animations 1 sec. 3), so the same declaration
+   normalises the same way inside one. *)
+let spec_keyframes_shadow_color_var () =
+  let sheet css =
+    match Css.of_string ~strict:false css with
+    | Ok { Css.stylesheet; _ } -> stylesheet
+    | Error e -> Alcotest.failf "parse failed: %s" (Cascade.Error.to_string e)
+  in
+  let registration =
+    "@property --ring{syntax:\"<color>\";inherits:false;initial-value:red}"
+  in
+  Alcotest.(check string)
+    "a registered colour var fills the shadow colour slot inside @keyframes"
+    (registration
+   ^ ":root{--ring:red}@keyframes glow{to{box-shadow:0 0 0 var(--ring)}}")
+    (minify
+       (sheet
+          (registration
+         ^ ":root{--ring:rgb(255 0 0)}@keyframes glow{to{box-shadow:0 0 \
+            var(--ring)}}")));
+  Alcotest.(check string)
+    "a colour var declared only inside @keyframes is still a colour var"
+    (registration
+   ^ "@keyframes glow{0%{--ring:red}}.a{box-shadow:0 0 0 var(--ring)}")
+    (minify
+       (sheet
+          (registration
+         ^ "@keyframes glow{from{--ring:rgb(255 0 0)}}.a{box-shadow:0 0 \
+            var(--ring)}")))
+
 let spec_page_margin_descriptor_matrix () =
   check_stylesheet
     ~expected:
@@ -1374,6 +1408,7 @@ let stylesheet_tests =
       `Quick,
       spec_font_face_descriptor_matrix );
     ("spec keyframes selector matrix", `Quick, spec_keyframes_selector_matrix);
+    ("spec keyframes shadow colour var", `Quick, spec_keyframes_shadow_color_var);
     ("page", `Quick, page_case);
     ("page margin edges", `Quick, page_margin_edges);
     ( "spec page margin descriptor matrix",


### PR DESCRIPTION
A registered `<color>` custom property declared or referenced inside `@keyframes` was skipped: the frame declaration never got its typed promotion, and `box-shadow: 0 0 var(--ring)` in a frame kept the reference in the blur slot while the identical declaration in a style rule moved it to the colour slot. Both walks now go through `Stylesheet.statement_children` / `statement_declarations` and their new rebuilding counterparts, so the next block at-rule cannot be missed the same way.