### PR TITLE
lib: close the statement-walker wildcards in inline and css

### DIFF
--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -229,7 +229,18 @@ let add_props acc ds =
 (* Every property a kept (conditional / stateful) rule can set. The descent goes
    through {!Stylesheet.statement_children}, so every block at-rule is covered:
    a property missed here is one an inline style could override, and the kept
-   rule would lose a fight it wins in the browser. *)
+   rule would lose a fight it wins in the browser.
+
+   The declarations come off [Rule] and [Declarations] alone, not through
+   {!Stylesheet.statement_declarations}. This set decides which declarations may
+   move into a [style] attribute, which shifts cascade position only against
+   author-origin rules of the same importance (css-cascade-5 sec. 6.1), and the
+   other declaration-carrying at-rules contribute none: [@keyframes] declares in
+   the animation origin, [@position-try] in the position fallback origin,
+   [@page] applies to a page box rather than an element, and
+   [@supports-condition] is never applied to a box. Widening it forces
+   [transform], [opacity] and [color] back into [<style>] on any page that has a
+   spinner keyframe. *)
 let rec props_of_stmts acc stmts =
   List.fold_left
     (fun acc s ->

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -540,14 +540,27 @@ let as_origin = function
   | Origin (origin, content) -> Some (origin, content)
   | _ -> None
 
+(* The block at-rules [map] and [sort] rebuild. Listed one by one rather than
+   closed with a wildcard, so a statement that grows a block later has to be
+   classified here before it compiles. [Scope], [Starting_style],
+   [Moz_document], [When] and [Else] wrap rules too; whether the public
+   [map]/[sort] reach them is a contract question rather than a traversal one,
+   so they stay out until it is answered. *)
 let map_container_block f = function
-  | Media (condition, content) -> Some (media ~condition (f content))
-  | Supports (condition, content) -> Some (supports ~condition (f content))
-  | Layer (name, content) -> Some (layer ?name (f content))
+  | Media (condition, content) -> media ~condition (f content)
+  | Supports (condition, content) -> supports ~condition (f content)
+  | Layer (name, content) -> layer ?name (f content)
   | Container (name, condition, content) ->
-      Some (container ?name ?condition (f content))
-  | Origin (origin, content) -> Some (Origin (origin, f content))
-  | _ -> None
+      container ?name ?condition (f content)
+  | Origin (origin, content) -> Origin (origin, f content)
+  | ( Rule _ | Property _ | Declarations _ | Bang_comment _ | Charset _
+    | Import _ | Namespace _ | Layer_decl _ | Supports_condition _ | Scope _
+    | Starting_style _ | Moz_document _ | When _ | Else _ | Keyframes _
+    | Webkit_keyframes _ | Moz_keyframes _ | Font_face _ | Counter_style _
+    | Page _ | Page_with_margins _ | Font_palette_values _
+    | Font_feature_values _ | View_transition _ | Position_try _ | Viewport _
+    | Unknown_at_rule _ ) as stmt ->
+      stmt
 
 let statement_children = Stylesheet.statement_children
 
@@ -566,10 +579,7 @@ let rec map f stmts =
               (* Callback supplied its own nested (or returned a non-Rule);
                  trust it and replace the original. *)
               other)
-      | None -> (
-          match map_container_block (map f) stmt with
-          | Some stmt -> stmt
-          | None -> stmt))
+      | None -> map_container_block (map f) stmt)
     stmts
 
 let rec sort cmp stmts =
@@ -579,10 +589,7 @@ let rec sort cmp stmts =
       (fun stmt ->
         match stmt with
         | Rule rule -> Rule { rule with nested = sort cmp rule.nested }
-        | _ -> (
-            match map_container_block (sort cmp) stmt with
-            | Some stmt -> stmt
-            | None -> stmt))
+        | stmt -> map_container_block (sort cmp) stmt)
       stmts
   in
 

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -122,7 +122,22 @@ let at_wrapper : statement -> (at_node * t * (t -> statement)) option = function
         ( (Scope (a, b) : at_node),
           body,
           fun body -> Stylesheet.Scope (a, b, body) )
-  | _ -> None
+  (* Listed rather than closed with a wildcard: a statement that grows a block
+     later has to be classified here before it compiles, so it cannot fall
+     through the path-tracking walks as a leaf. [Rule] is a block too, but its
+     selector is a scope boundary rather than an at-rule wrapper, so the callers
+     descend into it themselves. *)
+  | Stylesheet.Rule _ | Stylesheet.Property _ | Stylesheet.Declarations _
+  | Stylesheet.Bang_comment _ | Stylesheet.Charset _ | Stylesheet.Import _
+  | Stylesheet.Namespace _ | Stylesheet.Layer_decl _
+  | Stylesheet.Supports_condition _ | Stylesheet.Keyframes _
+  | Stylesheet.Webkit_keyframes _ | Stylesheet.Moz_keyframes _
+  | Stylesheet.Font_face _ | Stylesheet.Counter_style _ | Stylesheet.Page _
+  | Stylesheet.Page_with_margins _ | Stylesheet.Font_palette_values _
+  | Stylesheet.Font_feature_values _ | Stylesheet.View_transition _
+  | Stylesheet.Position_try _ | Stylesheet.Viewport _
+  | Stylesheet.Unknown_at_rule _ ->
+      None
 
 (** {1 Scope record} *)
 


### PR DESCRIPTION
The at-rule classifier in `Inline` and the block rebuilder `Css.map` and `Css.sort` share both ended in a wildcard, so a block at-rule added to the AST would have looked like a leaf to them without a compile error. Neither changes the set of statements it acts on, so output is unchanged; stacked on #337, which fixes the one gap of this shape that reached the output.