### PR TITLE
apply: keep a projected <style> element in the tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,10 @@
 
 ### CLI tools
 
+- `cascade apply` empties the `<style>` blocks it projects instead of removing
+  them. A `<style>` element is a sibling like any other, so unlinking it stops
+  a kept rule such as `.navbox + style + .portal-bar` from matching what it
+  matches in the browser (#339)
 - `cascade apply` reads a `style` attribute as a declaration list in source
   order. The declarations came out reversed, so a longhand beat the shorthand
   it was written after, and an empty attribute was enough to trigger it. A `}`

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -90,12 +90,15 @@ let inline_html ~minimal ~filename ~html ~extra =
     Apply.compute ~minimal ~sheet roots
   in
   List.iter (fun (node, decls) -> style_node node decls) styles;
-  (* The static rules now live on the elements, so the blocks they came from go.
-     A block the parser could not use stays exactly where it was: deleting it
-     would ship a page with neither the inline styles it should have had nor the
-     CSS text a browser might still make something of. *)
+  (* The static rules now live on the elements, so the CSS the blocks they came
+     from held goes. The element itself stays, emptied: a [<style>] is a sibling
+     like any other, and [.navbox + style + .portal-bar] is a real selector on a
+     real page, so unlinking the node would stop a kept rule from matching what
+     it matches in the browser. A block the parser could not use keeps its text
+     too: emptying it would ship a page with neither the inline styles it should
+     have had nor the CSS text a browser might still make something of. *)
   List.iter
-    (fun (node, sheet) -> if Option.is_some sheet then Soup.delete node)
+    (fun (node, sheet) -> if Option.is_some sheet then Soup.clear node)
     blocks;
   (if keep_css <> "" then
      let style = Soup.create_element ~inner_text:keep_css "style" in
@@ -176,9 +179,10 @@ let cmd =
          pseudo-elements, $(b,@keyframes)) cannot be projected onto an element \
          and are kept in a single $(b,<style>) block.";
       `P
-        "A $(b,<style>) block the parser cannot use is left in the page \
-         exactly as it was, rather than deleted along with the blocks that \
-         were projected.";
+        "A projected $(b,<style>) block is emptied rather than removed: the \
+         element is a sibling like any other, and a kept rule may select \
+         across it. A block the parser cannot use keeps its text as well, \
+         rather than being emptied along with the blocks that were projected.";
       `S Manpage.s_exit_status;
       `P "$(tname) exits with:";
       `I ("0", "on success, including a parse that recovered some of the input");

--- a/test/cli/apply_empty.t
+++ b/test/cli/apply_empty.t
@@ -24,7 +24,7 @@ to U+00A0, which is not document white space, so that paragraph is not
 empty either.
 
   $ cascade apply empty.html
-  <html><head></head><body>
+  <html><head><style></style></head><body>
   <p style="color:red" id="void"></p>
   <p style="color:red" id="spaces">  </p>
   <p id="text">text</p>

--- a/test/cli/apply_errors.t
+++ b/test/cli/apply_errors.t
@@ -32,7 +32,7 @@ exit status stays 0.
   > <html><head><style>p{color:red}p:hover{margin:0}</style></head><body><p>hi</p></body></html>
   > EOF
   $ cascade apply ok.html 2> /dev/null
-  <html><head><style>p:hover{margin:0}</style></head><body><p style="color:red">hi</p>
+  <html><head><style></style><style>p:hover{margin:0}</style></head><body><p style="color:red">hi</p>
   </body></html>
 
 A supplementary stylesheet that does not parse is an error too. There is no

--- a/test/cli/apply_style_sibling.t
+++ b/test/cli/apply_style_sibling.t
@@ -1,0 +1,25 @@
+CLI: [cascade apply] and the <style> element as a sibling.
+
+A <style> element is a sibling like any other, and Selectors 4 §15 lets
+a rule reach across it: [.navbox + style + .portal-bar] is a rule on
+Wikipedia today. Projecting a block takes away its CSS, not its place
+in the tree, or a rule kept in the sheet stops matching in the output
+page what it matches in the input one.
+
+  $ cat > sibling.html <<EOF
+  > <html><head><style>
+  > @media (min-width: 1px) { .a + style + .b { color: red } }
+  > </style></head><body>
+  > <p class="a">a</p><style>.mid{padding:1px}</style><p class="b">b</p><p class="mid">m</p>
+  > </body></html>
+  > EOF
+
+The middle block's rule projects onto the element it matches, so no CSS
+is left in it, and the emptied element still separates the two
+paragraphs the kept @media rule reaches across.
+
+  $ cascade apply sibling.html 2> /dev/null
+  <html><head><style></style><style>@media(min-width:1px){.a+style+.b{color:red}}</style></head><body>
+  <p class="a">a</p><style></style><p class="b">b</p><p style="padding:1px" class="mid">m</p>
+  
+  </body></html>

--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -5,7 +5,7 @@ Two transforms must leave the rendered page unchanged: for every element, the
 before and after.
 
 - **`cascade apply`** resolves the stylesheet into each element's `style`
-  attribute and drops the `<style>` blocks, in both the default (full) and
+  attribute and empties the `<style>` blocks, in both the default (full) and
   `--minimal` modes.
 - **`cascade --minify`** rewrites each `<style>` block in place (via
   `minify_page.js`). Idempotence, size and reparse checks all pass on output

--- a/test/inline/fixtures/sibling.html
+++ b/test/inline/fixtures/sibling.html
@@ -1,0 +1,5 @@
+<!doctype html><html><head><style>
+  @media (min-width: 1px) { .a + style + .b { margin-top: 20px } }
+</style></head><body>
+<p class="a">a</p><style>.mid{padding:1px}</style><p class="b">b</p><p class="mid">m</p>
+</body></html>


### PR DESCRIPTION
`cascade apply` used to unlink every `<style>` block it projected, which breaks a kept rule that selects across one, such as Wikipedia's `.navbox + style + .portal-bar`; the blocks are now emptied instead, so the element keeps its place among its siblings.