### PR TITLE
apply: split on cascade slots rather than property names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,11 @@
 
 ### CLI tools
 
+- `cascade apply` keeps a declaration in the sheet when a kept rule can write
+  the same cascade slot under another property name. `p{margin:0}` was
+  projected into a style attribute while the `.my-7{margin-top:1.75rem}` it
+  loses to stayed behind, and a style attribute outranks every selector, so the
+  paragraph rendered with no margin (#340)
 - `cascade apply` empties the `<style>` blocks it projects instead of removing
   them. A `<style>` element is a sibling like any other, so unlinking it stops
   a kept rule such as `.navbox + style + .portal-bar` from matching what it

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -257,10 +257,10 @@ let add_props acc ds =
       SSet.add (String.lowercase_ascii (Declaration.property_name d)) acc)
     acc ds
 
-(* Every property a kept (conditional / stateful) rule can set. The descent goes
-   through {!Stylesheet.statement_children}, so every block at-rule is covered:
-   a property missed here is one an inline style could override, and the kept
-   rule would lose a fight it wins in the browser.
+(* Every declaration a kept (conditional / stateful) rule can set. The descent
+   goes through {!Stylesheet.statement_children}, so every block at-rule is
+   covered: a declaration missed here is one an inline style could override, and
+   the kept rule would lose a fight it wins in the browser.
 
    The declarations come off [Rule] and [Declarations] alone, not through
    {!Stylesheet.statement_declarations}. This set decides which declarations may
@@ -272,31 +272,61 @@ let add_props acc ds =
    [@supports-condition] is never applied to a box. Widening it forces
    [transform], [opacity] and [color] back into [<style>] on any page that has a
    spinner keyframe. *)
-let rec props_of_stmts acc stmts =
+let rec decls_of_stmts acc stmts =
   List.fold_left
     (fun acc s ->
       let acc =
         match s with
-        | Stylesheet.Rule r -> add_props acc (Stylesheet.declarations r)
-        | Stylesheet.Declarations ds -> add_props acc ds
+        | Stylesheet.Rule r -> List.rev_append (Stylesheet.declarations r) acc
+        | Stylesheet.Declarations ds -> List.rev_append ds acc
         | _ -> acc
       in
-      props_of_stmts acc (Stylesheet.statement_children s))
+      decls_of_stmts acc (Stylesheet.statement_children s))
     acc stmts
 
 (* A [@layer] block applies unconditionally: it only orders competing
    declarations, it does not gate them behind a condition the way
-   @media/@supports/@container do. So the properties its rules can override are
-   those of its own un-inlinable rules, exactly as at the top level, while a
+   @media/@supports/@container do. So the declarations its rules can override
+   are those of its own un-inlinable rules, exactly as at the top level, while a
    conditional block contributes all of them. *)
-let rec dynamic_props acc stmts =
+let rec dynamic_decls acc stmts =
   List.fold_left
     (fun acc s ->
       match s with
       | Stylesheet.Rule r when inlinable (Stylesheet.selector r) -> acc
-      | Stylesheet.Layer (_, b) -> dynamic_props acc b
-      | s -> props_of_stmts acc [ s ])
+      | Stylesheet.Layer (_, b) -> dynamic_decls acc b
+      | s -> decls_of_stmts acc [ s ])
     acc stmts
+
+(* The kept declarations to test an inlinable one against, one per property
+   name: {!Shorthand.declarations_overlap} reads the property, never the value,
+   so a second declaration of the same property answers exactly as the first.
+   Each keeps its precomputed footprint, since the test runs once per property
+   for every declaration in the sheet. *)
+let overlap_probes ds =
+  let seen = Hashtbl.create 64 in
+  List.filter_map
+    (fun d ->
+      let name = String.lowercase_ascii (Declaration.property_name d) in
+      if Hashtbl.mem seen name then None
+      else begin
+        Hashtbl.add seen name ();
+        Some (d, Shorthand.declaration_overlap_keys d)
+      end)
+    ds
+
+(* Whether a kept rule can overwrite what [d] sets. Matching property names is
+   not enough: [margin] and [margin-top] write a common cascade slot under
+   different names, so a kept [.mt-6{margin-top}] and an inlinable [p{margin:0}]
+   compete. Inlining the shorthand there puts it in a style attribute, which
+   outranks every selector, and the kept rule loses a fight it wins in the
+   browser. *)
+let overlaps_kept probes d =
+  let keys = Shorthand.declaration_overlap_keys d in
+  List.exists
+    (fun (kept, kept_keys) ->
+      Shorthand.declarations_overlap_with_keys d keys kept kept_keys)
+    probes
 
 (* Split each statement into the part with no inline form and the part that
    projects onto elements. A [@layer] block splits like the top level, but the
@@ -471,11 +501,9 @@ module Make (Node : Resolve.NODE) = struct
     (* Flatten nesting up front, so the split and {!R.resolve} see the same flat
        rules. *)
     let stmts = Flatten.block sheet in
-    (* Properties a kept rule can override must stay in the cascade. *)
-    let dyn = dynamic_props SSet.empty stmts in
-    let is_dyn d =
-      SSet.mem (String.lowercase_ascii (Declaration.property_name d)) dyn
-    in
+    (* Declarations a kept rule can override must stay in the cascade. *)
+    let dyn = overlap_probes (dynamic_decls [] stmts) in
+    let is_dyn d = overlaps_kept dyn d in
     let keep, inline = split ~is_dyn stmts in
     let keep_css =
       if keep = [] then "" else Css.to_string ~minify:true (Stylesheet.v keep)

--- a/test/inline/fixtures/overlap.html
+++ b/test/inline/fixtures/overlap.html
@@ -1,0 +1,14 @@
+<!doctype html><html><head><style>
+  ul { margin: 0; list-style: none }
+  li { color: rgb(0, 128, 0) }
+  .m { margin-right: 20px }
+  .l { list-style-type: square }
+  ul.e { margin-inline-end: 30px }
+  @media (min-width: 1px) {
+    .q { margin-right: 0; list-style-type: none }
+    ul.q { margin-right: 5px }
+  }
+</style></head><body>
+<ul class="m l"><li>x</li></ul>
+<ul class="e"><li>y</li></ul>
+</body></html>

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -377,6 +377,49 @@ let non_competing_scoped_rule_still_inlines () =
     ~keep:"@scope(.root){.x{margin:0}}" ~kept:1
     (node ~classes:[ "x" ] "p")
 
+(* A kept rule and an inlinable one can compete under different property names:
+   [margin] resets [margin-right] (css-box-4 sec. 4.2), so a kept rule setting
+   the longhand is one the shorthand can overwrite. Inlining the shorthand puts
+   it in a style attribute, which css-cascade-5 sec. 6.3 ranks above every
+   selector, and the kept rule loses a fight it wins in the browser. *)
+let keeps_shorthand_a_kept_longhand_writes () =
+  check_split "shorthand over kept longhand"
+    ~css:
+      "ul{margin:0}.m{margin-right:20px}@media(min-width:1px){.q{margin-right:0}}"
+    ~inline:""
+    ~keep:
+      "ul{margin:0}.m{margin-right:20px}@media(min-width:1px){.q{margin-right:0}}"
+    ~kept:3
+    (node ~classes:[ "m" ] "ul")
+
+(* The same the other way round: a kept shorthand can overwrite an inlinable
+   longhand, so the longhand has to stay in the sheet too. *)
+let keeps_longhand_a_kept_shorthand_writes () =
+  check_split "longhand under kept shorthand"
+    ~css:".x{margin-top:1px}@media(min-width:1px){.q{margin:0}}" ~inline:""
+    ~keep:".x{margin-top:1px}@media(min-width:1px){.q{margin:0}}" ~kept:2
+    (node ~classes:[ "x" ] "p")
+
+(* A flow-relative property and its physical twin write one slot once the
+   writing mode is known (css-logical-1 sec. 2), and the stylesheet does not
+   know it, so [margin-inline-end] and [margin-right] have to be treated as the
+   same competition. *)
+let keeps_logical_a_kept_physical_writes () =
+  check_split "logical under kept physical"
+    ~css:".x{margin-inline-end:30px}@media(min-width:1px){.q{margin-right:0}}"
+    ~inline:""
+    ~keep:".x{margin-inline-end:30px}@media(min-width:1px){.q{margin-right:0}}"
+    ~kept:2
+    (node ~classes:[ "x" ] "p")
+
+(* The control: a kept rule that writes another family competes with nothing, so
+   the shorthand still projects onto the element. *)
+let unrelated_kept_property_still_inlines () =
+  check_split "shorthand, unrelated kept property"
+    ~css:"ul{margin:0}@media(min-width:1px){.q{color:red}}" ~inline:"margin:0"
+    ~keep:"@media(min-width:1px){.q{color:red}}" ~kept:1
+    (node ~classes:[ "m" ] "ul")
+
 (* The matcher compares attribute values verbatim, so it cannot represent the
    [i] case flag. A selector it cannot represent has to stay in the sheet:
    inlining it drops it from the sheet, and it then matches nobody, so the
@@ -516,6 +559,14 @@ let suite =
         keeps_property_a_starting_style_rule_sets;
       Alcotest.test_case "non-competing scoped rule still inlines" `Quick
         non_competing_scoped_rule_still_inlines;
+      Alcotest.test_case "keeps a shorthand a kept longhand writes" `Quick
+        keeps_shorthand_a_kept_longhand_writes;
+      Alcotest.test_case "keeps a longhand a kept shorthand writes" `Quick
+        keeps_longhand_a_kept_shorthand_writes;
+      Alcotest.test_case "keeps a logical property a kept physical one writes"
+        `Quick keeps_logical_a_kept_physical_writes;
+      Alcotest.test_case "unrelated kept property still inlines" `Quick
+        unrelated_kept_property_still_inlines;
       Alcotest.test_case "keeps a rule with an attribute case flag" `Quick
         keeps_rule_with_attribute_case_flag;
       Alcotest.test_case "projects an attribute rule to inline style" `Quick


### PR DESCRIPTION
A declaration may only be projected into a style attribute when no kept rule can write what it writes, and `cascade apply` decided that by property name, so `p{margin:0}` was inlined over the `.my-7{margin-top:1.75rem}` left in the sheet and the paragraph rendered with no margin. Stacked on #339, which the same real page needs.