### PR TITLE
inline: read a var() reference through the exhaustive walkers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -116,6 +116,10 @@
   frame, `@page` and its margin boxes, `@position-try` or
   `@supports-condition` as a reference, instead of deleting a binding those
   at-rules still use (#341)
+- `Css.inline_vars` counts a `var()` in a page margin box or a
+  `@supports-condition` body as a reference, so it no longer emits a name whose
+  definition it deleted, and reports an overridden variable referenced from any
+  of those at-rules through `~warn` (#342)
 
 ### Canonical diff
 

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -857,11 +857,6 @@ let record_at_node_refs consumers ~parents ~at_path node =
       let sel = selector_for_parents_universal parents in
       consumers := (at_path, sel, refs) :: !consumers
 
-let record_keyframe_decls ~record_decl ~at_path ~sel frames =
-  List.iter
-    (fun fr -> List.iter (record_decl ~at_path ~selector:sel) fr.declarations)
-    frames
-
 let collect_scoped_refs stylesheet =
   let consumers = ref [] in
   let customs = ref [] in
@@ -882,7 +877,8 @@ let collect_scoped_refs stylesheet =
         record_at_node_refs consumers ~parents ~at_path node;
         List.iter (walk_stmt ~parents ~at_path:(at_path @ [ node ])) body
     | None -> walk_non_at ~parents ~at_path stmt
-  and walk_non_at ~parents ~at_path = function
+  and walk_non_at ~parents ~at_path stmt =
+    match stmt with
     | Rule rule ->
         let eff = effective_selector ~parents rule.selector in
         List.iter (record_decl ~at_path ~selector:eff) rule.declarations;
@@ -890,15 +886,19 @@ let collect_scoped_refs stylesheet =
     | Declarations decls ->
         let sel = selector_for_parents_universal parents in
         List.iter (record_decl ~at_path ~selector:sel) decls
-    | Page (_, decls) | Position_try (_, decls) ->
-        let sel = Selector.Universal None in
-        List.iter (record_decl ~at_path ~selector:sel) decls
-    | Keyframes (_, frames)
-    | Webkit_keyframes (_, frames)
-    | Moz_keyframes (_, frames) ->
-        let sel = Selector.Universal None in
-        record_keyframe_decls ~record_decl ~at_path ~sel frames
-    | _ -> ()
+    (* Everything else that carries declarations - [@keyframes] frames, [@page]
+       and its margin boxes, [@position-try], [@supports-condition] - through
+       the exhaustive reader, so a reference cannot escape the census by sitting
+       in an at-rule this match never listed. They apply to no element in
+       particular, so a custom declared on [:root], [html] or [*] covers
+       them. *)
+    | stmt ->
+        List.iter
+          (record_decl ~at_path ~selector:(Selector.Universal None))
+          (Stylesheet.statement_declarations stmt);
+        List.iter
+          (walk_stmt ~parents ~at_path)
+          (Stylesheet.statement_children stmt)
   in
   List.iter (walk_stmt ~parents:[] ~at_path:[]) stylesheet;
   (!consumers, !customs, List.sort_uniq compare !runtime_refs)
@@ -1130,13 +1130,9 @@ let var_census stylesheet =
   let rec walk stmt =
     match at_wrapper stmt with
     | Some (_, body, _) -> List.iter walk body
-    | None -> (
-        match stmt with
-        | Rule r ->
-            add_refs r.declarations;
-            List.iter walk r.nested
-        | Declarations decls -> add_refs decls
-        | _ -> ())
+    | None ->
+        add_refs (Stylesheet.statement_declarations stmt);
+        List.iter walk (Stylesheet.statement_children stmt)
   in
   List.iter walk stylesheet;
   (counts, List.sort_uniq compare !referenced)

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -75,6 +75,34 @@ let test_inline_fold_deletes_defs () =
   Alcotest.(check (list string))
     "an overridden variable is reported via warn" [ "--palette-red" ] !warned
 
+(* An at-rule that carries declarations outside a nested block consumes a
+   [var()] like any rule does. Whatever the substitution manages to resolve
+   there, a reference left in the output must keep the definition it names, or
+   the sheet ships a name nothing defines. *)
+let test_inline_at_rule_reference_keeps_its_binding () =
+  let same name css =
+    Alcotest.(check string) name css (minified (Css.inline_vars (parse css)))
+  in
+  same "a page margin box reference keeps its definition"
+    ":root{--t:\"x\"}@page{@top-center{content:var(--t)}}";
+  (* A [@supports-condition] body is a feature test rather than applied style
+     (CSS Conditional 5 sec. 3), so the reference stays as authored. *)
+  same "a @supports-condition reference keeps its definition"
+    ":root{--c:red}@supports-condition --x{color:var(--c)}"
+
+(* The census decides which overridden variable to report, so it has to see a
+   reference wherever declarations live. *)
+let test_inline_warns_for_an_at_rule_reference () =
+  let warned = ref [] in
+  ignore
+    (parse
+       ":root{--c:red}@media print{:root{--c:blue}}@keyframes \
+        k{from{color:var(--c)}}"
+    |> Css.inline_vars ~warn:(fun n -> warned := n :: !warned));
+  Alcotest.(check (list string))
+    "an override referenced only from a keyframe frame is reported" [ "--c" ]
+    !warned
+
 let test_inline_keep_vars_calc_identity () =
   (* A kept theme var stays a live reference, but the value-independent calc
      identities still simplify: [p-1] expands to [calc(var(--spacing) * 1)],
@@ -332,6 +360,10 @@ let suite =
         test_inline_keep_vars;
       Alcotest.test_case "inline vars fold and delete non-kept definitions"
         `Quick test_inline_fold_deletes_defs;
+      Alcotest.test_case "inline vars keep an at-rule reference's binding"
+        `Quick test_inline_at_rule_reference_keeps_its_binding;
+      Alcotest.test_case "inline vars warn for an at-rule reference" `Quick
+        test_inline_warns_for_an_at_rule_reference;
       Alcotest.test_case "inline vars apply calc identities to kept vars" `Quick
         test_inline_keep_vars_calc_identity;
       Alcotest.test_case "inline vars collapse a literal zero times a kept var"


### PR DESCRIPTION
`Css.inline_vars` collected references from a different set of at-rules than it substituted in, so a name used only from a page margin box or a `@supports-condition` body had its definition deleted while the reference stayed in the output. Stacked on #341.