### PR TITLE
optimize: descend into every conditional group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,9 @@
 - A declaration whose value is spec-invalid is discarded inside a `@keyframes`
   frame, matching what a browser does with it there and what cascade already
   did in a style rule (#341)
+- `--minify` optimises the body of `@-moz-document`, `@starting-style`,
+  `@when` and `@else`, which it walked past: rules inside one of them kept
+  whatever the author wrote (#343)
 - `@media not all and (X)` minifies to the Level 4 `@media not (X)`. `all` is
   the identity media type (Media Queries 4 sec. 2.3), so the two spell the same
   query, and default minify already spends Level 3 compatibility by lowering

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -220,23 +220,60 @@ and process_statements ?factor_cache ~ctx ~enforce_spec
       process_statements ?factor_cache ~ctx ~enforce_spec ~pending
         (optimized :: acc) rest
   | (Origin (origin, block) as stmt) :: rest ->
-      let optimized_block = statements ?factor_cache ~ctx ~enforce_spec block in
-      let optimized =
-        if optimized_block == block then stmt
-        else Origin (origin, optimized_block)
-      in
-      process_statements ?factor_cache ~ctx ~enforce_spec ~pending
-        (optimized :: acc) rest
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
+        block
+        (fun block -> Origin (origin, block))
+        rest
+  (* The wrapper is opaque but its body is an ordinary block, so it optimises
+     like [@media]'s: a group left out here keeps whatever the author wrote and
+     [--minify] does nothing inside it. *)
+  | (Moz_document (cond, block) as stmt) :: rest ->
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
+        block
+        (fun block -> Moz_document (cond, block))
+        rest
+  | (When (cond, block) as stmt) :: rest ->
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
+        block
+        (fun block -> When (cond, block))
+        rest
+  | (Else (cond, block) as stmt) :: rest ->
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
+        block
+        (fun block -> Else (cond, block))
+        rest
+  | (Starting_style block as stmt) :: rest ->
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
+        block
+        (fun block -> Starting_style block)
+        rest
   | (Layer (name, block) as stmt) :: rest ->
       process_layer_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
         name block rest
   | (Import import as stmt) :: rest ->
       process_import_statement ?factor_cache ~ctx ~enforce_spec ~pending acc
         stmt import rest
-  | hd :: rest ->
-      (* Other statement types - keep as-is *)
+  (* Listed rather than closed with a wildcard: everything left holds no block,
+     so a statement that grows one has to be classified above before it
+     compiles. *)
+  | (( Declarations _ | Property _ | Bang_comment _ | Charset _ | Namespace _
+     | Layer_decl _ | Supports_condition _ | Keyframes _ | Webkit_keyframes _
+     | Moz_keyframes _ | Font_face _ | Counter_style _ | Page _
+     | Page_with_margins _ | Font_palette_values _ | Font_feature_values _
+     | View_transition _ | Position_try _ | Viewport _ | Unknown_at_rule _ ) as
+     hd)
+    :: rest ->
       process_statements ?factor_cache ~ctx ~enforce_spec ~pending (hd :: acc)
         rest
+
+and process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
+    block rebuild rest =
+  let optimized_block = statements ?factor_cache ~ctx ~enforce_spec block in
+  let optimized =
+    if optimized_block == block then stmt else rebuild optimized_block
+  in
+  process_statements ?factor_cache ~ctx ~enforce_spec ~pending
+    (optimized :: acc) rest
 
 and process_rule_run ?factor_cache ~ctx ~enforce_spec ~pending acc stmt r rest =
   let plain_stmts, plain_rules, rest = collect_rules [ stmt ] [ r ] rest in

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -766,6 +766,25 @@ let test_drop_invalid_reaches_keyframe_frames () =
     "so does a vendor-prefixed one" "@-webkit-keyframes k{0%{opacity:0}}"
     (recovered "@-webkit-keyframes k{from{width:asin(sin(45deg));opacity:0}}")
 
+(* Every conditional group wraps ordinary rules, so the optimizer's main
+   recursion has to descend into all of them: a body it walks past keeps
+   whatever the author wrote, and [--minify] silently does nothing there. *)
+let test_optimize_descends_into_every_conditional_group () =
+  let check name css expected =
+    Alcotest.(check string) name expected (minify (Css.of_string_exn css))
+  in
+  check "@media" "@media print{a{color:#f00}a{color:#f00}}"
+    "@media print{a{color:red}}";
+  check "@-moz-document"
+    "@-moz-document url-prefix(){a{color:#f00}a{color:#f00}}"
+    "@-moz-document url-prefix(){a{color:red}}";
+  check "@starting-style" "@starting-style{a{color:#f00}a{color:#f00}}"
+    "@starting-style{a{color:red}}";
+  check "@when and @else"
+    "@when \
+     media(print){a{color:#f00}a{color:#f00}}@else{b{color:#f00}b{color:#f00}}"
+    "@when media(print){a{color:red}}@else{b{color:red}}"
+
 (* A colour function carrying a var() is a pending-substitution value (CSS
    Variables L1 section 3): its arity and legacy/modern separator style aren't
    known until substitution, so minify+optimize must keep it verbatim - never
@@ -1329,6 +1348,9 @@ let optimize_tests =
     ( "drop_invalid reaches keyframe frames",
       `Quick,
       test_drop_invalid_reaches_keyframe_frames );
+    ( "optimize descends into every conditional group",
+      `Quick,
+      test_optimize_descends_into_every_conditional_group );
     ( "deduplicate declarations preserves physical identity",
       `Quick,
       test_deduplicate_declarations_physical_identity );


### PR DESCRIPTION
The optimizer's main recursion listed only some of the block at-rules, so a rule inside `@-moz-document`, `@starting-style`, `@when` or `@else` came out exactly as authored under `--minify`. Stacked on #342.