### PR TITLE
flatten: @-moz-document groups rules like any other at-rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,9 @@
 - `--minify` optimises the body of `@-moz-document`, `@starting-style`,
   `@when` and `@else`, which it walked past: rules inside one of them kept
   whatever the author wrote (#343)
+- `--flatten-nesting` treats `@-moz-document` as the grouping at-rule it is:
+  nesting inside one flattens, and a rule wrapping one keeps its selector
+  instead of emitting the at-rule at top level under no parent (#344)
 - `@media not all and (X)` minifies to the Level 4 `@media not (X)`. `all` is
   the identity media type (Media Queries 4 sec. 2.3), so the two spell the same
   query, and default minify already spends Level 3 compatibility by lowering

--- a/lib/flatten.ml
+++ b/lib/flatten.ml
@@ -61,6 +61,8 @@ and in_rule_context (parent : Selector.t) : statement -> statement list =
       ]
   | Media (cond, block) ->
       [ Media (cond, List.concat_map (in_rule_context parent) block) ]
+  | Moz_document (cond, block) ->
+      [ Moz_document (cond, List.concat_map (in_rule_context parent) block) ]
   | Container (name, cond, block) ->
       [ Container (name, cond, List.concat_map (in_rule_context parent) block) ]
   | Supports (cond, block) ->
@@ -82,7 +84,17 @@ and in_rule_context (parent : Selector.t) : statement -> statement list =
             Option.map (scope_selector_in_context parent) e,
             List.concat_map (in_rule_context parent) block );
       ]
-  | other -> [ other ]
+  (* Listed rather than closed with a wildcard: a statement that grows a block
+     later has to be classified above before it compiles, or it escapes the
+     parent selector it was written under. Everything below carries no selector
+     context of its own, so it lifts out verbatim. *)
+  | ( Property _ | Bang_comment _ | Charset _ | Import _ | Namespace _
+    | Layer_decl _ | Supports_condition _ | Keyframes _ | Webkit_keyframes _
+    | Moz_keyframes _ | Font_face _ | Counter_style _ | Page _
+    | Page_with_margins _ | Font_palette_values _ | Font_feature_values _
+    | View_transition _ | Position_try _ | Viewport _ | Unknown_at_rule _ ) as
+    other ->
+      [ other ]
 
 let rec top_statement (stmt : statement) : statement list =
   (* A flat rule with declarations is already in final form; a wrapper whose
@@ -96,6 +108,7 @@ let rec top_statement (stmt : statement) : statement list =
   | Rule { nested = []; declarations = _ :: _; _ } -> [ stmt ]
   | Rule rule -> flat_rule rule
   | Media (cond, block) -> wrap block (fun b -> Media (cond, b))
+  | Moz_document (cond, block) -> wrap block (fun b -> Moz_document (cond, b))
   | Container (name, cond, block) ->
       wrap block (fun b -> Container (name, cond, b))
   | Supports (cond, block) -> wrap block (fun b -> Supports (cond, b))
@@ -105,7 +118,13 @@ let rec top_statement (stmt : statement) : statement list =
   | When (cond, block) -> wrap block (fun b -> When (cond, b))
   | Else (cond, block) -> wrap block (fun b -> Else (cond, b))
   | Scope (s, e, block) -> wrap block (fun b -> Scope (s, e, b))
-  | other -> [ other ]
+  | ( Declarations _ | Property _ | Bang_comment _ | Charset _ | Import _
+    | Namespace _ | Layer_decl _ | Supports_condition _ | Keyframes _
+    | Webkit_keyframes _ | Moz_keyframes _ | Font_face _ | Counter_style _
+    | Page _ | Page_with_margins _ | Font_palette_values _
+    | Font_feature_values _ | View_transition _ | Position_try _ | Viewport _
+    | Unknown_at_rule _ ) as other ->
+      [ other ]
 
 and block (block : statement list) : statement list =
   concat_map_preserve top_statement block

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -103,6 +103,18 @@ let test_nested_selector_list_keeps_parent () =
   check ".p{a::before,a::after{color:red}}" ".p a:before,.p a:after{color:red}";
   check ".p{& a,& b{color:red}}" ".p a,.p b{color:red}"
 
+(* [@-moz-document] groups rules like any other conditional at-rule, so nesting
+   inside one flattens and a rule wrapping one keeps its selector: emitting the
+   at-rule verbatim from inside a rule drops the parent it was written under. *)
+let test_flattens_inside_moz_document () =
+  let check src expected =
+    Alcotest.(check string) src expected (render (Flatten.block (block src)))
+  in
+  check "@-moz-document url-prefix(){.a{.b{color:red}}}"
+    "@-moz-document url-prefix(){.a .b{color:red}}";
+  check ".a{@-moz-document url-prefix(){.b{color:red}}}"
+    "@-moz-document url-prefix(){.a .b{color:red}}"
+
 let suite =
   ( "flatten",
     [
@@ -120,4 +132,6 @@ let suite =
         test_nesting_wraps_complex_parent;
       Alcotest.test_case "nested selector list keeps the parent" `Quick
         test_nested_selector_list_keeps_parent;
+      Alcotest.test_case "flattens inside @-moz-document" `Quick
+        test_flattens_inside_moz_document;
     ] )


### PR DESCRIPTION
`Css.flatten_nesting` left `@-moz-document` out of both halves of the walk, so nesting inside one was never flattened and a rule wrapping one lost the parent selector it was written under. Stacked on #343.