### PR TITLE
diff: name a selectorless at-rule by the head it prints to

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -163,6 +163,10 @@
   element's width; licence headers and conditional comments went missing
   outright. The page is parsed and printed with markup.ml, which carries
   comments, in place of lambdasoup, which discards them (#346)
+- `cascade diff` names an at-rule that carries no condition of its own by the
+  head it prints to, rather than describing every one of them identically. That
+  description keys the ordering comparison, so a `@media` that moved between a
+  `@page` and a `@starting-style` was reported as no change (#345)
 - `cascade apply` keeps a declaration in the sheet when a kept rule can write
   the same cascade slot under another property name. `p{margin:0}` was
   projected into a style attribute while the `.my-7{margin-top:1.75rem}` it

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -641,6 +641,39 @@ let container_label container_type condition =
   | "" -> condition
   | prefix -> prefix ^ " " ^ condition
 
+(* The statements that carry neither a selector nor a block. Naming them apart
+   also keeps them apart in the order keys, where one shared "(other statement)"
+   made a [@charset] and a [@namespace] the same statement. *)
+let describe_prelude_statement (s : Css.statement) =
+  match s with
+  | Charset encoding -> Some ("@charset \"" ^ encoding ^ "\";")
+  | Namespace (prefix, _) ->
+      Some
+        ("@namespace"
+        ^ (match prefix with Some p -> " " ^ p | None -> "")
+        ^ ";")
+  (* The semicolon is what tells a layer-order pin from the block of the same
+     name: [@layer a;] ahead of [@layer a { ... }] is a second statement, not
+     the block again. *)
+  | Layer_decl names -> Some ("@layer " ^ String.concat ", " names ^ ";")
+  | _ -> None
+
+(* A statement's own text, split at its block: the head names it, the body is
+   what a descriptor-only at-rule is compared on. *)
+let statement_text_split stmt =
+  let text = Css.Stylesheet.to_string ~minify:true (Css.v [ stmt ]) in
+  match String.index_opt text '{' with
+  | None -> (String.trim text, "")
+  | Some i ->
+      let head = String.sub text 0 i in
+      let last = String.length text - 1 in
+      let body =
+        if last > i && text.[last] = '}' then
+          String.sub text (i + 1) (last - i - 1)
+        else String.sub text (i + 1) (last - i)
+      in
+      (String.trim head, body)
+
 let describe_statement stmt =
   let try_desc f = f stmt in
   let matchers =
@@ -673,27 +706,19 @@ let describe_statement stmt =
       (fun s ->
         Option.map (fun (name, _) -> "@keyframes " ^ name) (Css.as_keyframes s));
       (fun s -> Option.map (fun _ -> "@font-face") (Css.as_font_face s));
-      (* The statements that carry neither a selector nor a block. Naming them
-         apart also keeps them apart in the order keys, where one shared "(other
-         statement)" made a [@charset] and a [@namespace] the same statement. *)
-      (fun (s : Css.statement) ->
-        match s with
-        | Charset encoding -> Some ("@charset \"" ^ encoding ^ "\";")
-        | Namespace (prefix, _) ->
-            Some
-              ("@namespace"
-              ^ (match prefix with Some p -> " " ^ p | None -> "")
-              ^ ";")
-        (* The semicolon is what tells a layer-order pin from the block of the
-           same name: [@layer a;] ahead of [@layer a { ... }] is a second
-           statement, not the block again. *)
-        | Layer_decl names -> Some ("@layer " ^ String.concat ", " names ^ ";")
-        | _ -> None);
+      describe_prelude_statement;
     ]
   in
   match List.find_map try_desc matchers with
   | Some desc -> Some desc
-  | None -> Some "(other statement)"
+  (* Everything left names itself by the head it prints to, for the same reason
+     [@charset] and [@namespace] are named apart above: one shared description
+     is one shared order key, and [@page] swapped with [@starting-style] then
+     reads as no change at all. *)
+  | None -> (
+      match fst (statement_text_split stmt) with
+      | "" -> Some "(other statement)"
+      | head -> Some head)
 
 (* The body of a container that was added or removed wholesale. Every statement
    gets a line, including the ones [Css.as_rule] cannot see: a statement the
@@ -2158,22 +2183,6 @@ let is_reported_by_own_processor stmt =
   || Css.as_property stmt <> None
   || Css.as_keyframes stmt <> None
 
-(* The at-rule text split at its block: the head keys the statement, the body is
-   what a descriptor-only at-rule is compared on. *)
-let at_rule_text stmt =
-  let text = Css.Stylesheet.to_string ~minify:true (Css.v [ stmt ]) in
-  match String.index_opt text '{' with
-  | None -> (String.trim text, "")
-  | Some i ->
-      let head = String.sub text 0 i in
-      let last = String.length text - 1 in
-      let body =
-        if last > i && text.[last] = '}' then
-          String.sub text (i + 1) (last - i - 1)
-        else String.sub text (i + 1) (last - i)
-      in
-      (String.trim head, body)
-
 (* A stylesheet may repeat one at-rule (several [@font-face] blocks, several
    [@page] rules), so the head alone does not name a block. Number the blocks
    that share a head and pair them in order. *)
@@ -2184,7 +2193,7 @@ let at_rule_items stmts =
       match at_rule_body stmt with
       | None -> None
       | Some body ->
-          let head, text = at_rule_text stmt in
+          let head, text = statement_text_split stmt in
           let n = Option.value ~default:0 (Hashtbl.find_opt seen head) in
           Hashtbl.replace seen head (n + 1);
           Some ((head, n), (head, body, text)))

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -808,6 +808,25 @@ let page_removed_reported () =
     "a dropped @page is a difference" false
     (Cascade_diff.Tree_diff.is_empty d)
 
+(* An at-rule that carries no condition still has an identity of its own, and
+   the ordering comparison reads it as a position marker. Describing every one
+   of them the same way collapsed [@page] and [@starting-style] onto a single
+   key, and a [@media] that moved between them read as no change - the very
+   collapse the [@charset] versus [@namespace] naming above avoids. *)
+let selectorless_at_rules_key_the_ordering () =
+  let d =
+    diff_of
+      ~expected:
+        "@page{margin:1cm}@media \
+         print{a{color:red}}@starting-style{b{color:red}}"
+      ~actual:
+        "@page{margin:1cm}@starting-style{b{color:red}}@media \
+         print{a{color:red}}"
+  in
+  Alcotest.(check bool)
+    "a @media that moved between two of them is a difference" false
+    (Cascade_diff.Tree_diff.is_empty d)
+
 let font_face_added_reported () =
   let d =
     diff_of ~expected:".a{color:red}"
@@ -1228,6 +1247,8 @@ let suite =
       Alcotest.test_case "repeated @font-face change reported" `Quick
         repeated_font_face_change_reported;
       Alcotest.test_case "@page removed reported" `Quick page_removed_reported;
+      Alcotest.test_case "selectorless at-rules key the ordering" `Quick
+        selectorless_at_rules_key_the_ordering;
       Alcotest.test_case "@font-face added reported" `Quick
         font_face_added_reported;
       Alcotest.test_case "repeated property pairs by occurrence" `Quick


### PR DESCRIPTION
`describe_statement` gave `@page`, `@scope`, `@starting-style`, `@-moz-document`, `@when` and `@else` one shared description, and that description is the ordering key, so a `@media` that moved between two of them was reported as no change. This changes `cascade diff` output, so it wants a look before it lands: the labels those at-rules print under change from `(other statement)` to their own head, and a move that was previously silent is now reported. Stacked on #344.