### PR TITLE
apply: keep the HTML comments a page carries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,12 @@
 
 ### CLI tools
 
+- `cascade apply` keeps the comments a page holds. React writes an empty
+  comment between two adjacent text nodes to keep them apart, and a browser
+  measures and rounds each text run on its own, so merging them moved the
+  element's width; licence headers and conditional comments went missing
+  outright. The page is parsed and printed with markup.ml, which carries
+  comments, in place of lambdasoup, which discards them (#346)
 - `cascade apply` keeps a declaration in the sheet when a kept rule can write
   the same cascade slot under another property name. `p{margin:0}` was
   projected into a style attribute while the `.my-7{margin-top:1.75rem}` it

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -1,34 +1,30 @@
 (* [cascade apply <page.html> [extra.css]]: resolve a stylesheet against the
    HTML, write each element's winning declarations into its style attribute, and
    keep the rules with no inline form (:hover, @media, ...) in a <style>. The
-   projection lives in {!Cascade.Apply}; this command is the lambdasoup glue:
-   parse the HTML, hand the element tree to the library, and write the result
-   back. *)
+   projection lives in {!Cascade.Apply}; this command is the HTML glue: parse
+   the page into an {!Html} tree, hand the element tree to the library, and
+   write the result back. *)
 
 open Cmdliner
 module Sheet = Cascade.Stylesheet
 module Css = Cascade.Css
 
-(* ---------- the tree: lambdasoup element nodes ---------- *)
+(* ---------- the tree ---------- *)
 module Node = struct
-  type t = Soup.element Soup.node
+  type t = Html.element
 
   let equal = ( == )
-  let name n = Some (Soup.name n)
-  let id = Soup.id
-  let classes = Soup.classes
-  let attribute n k = Soup.attribute k n
-  let parent = Soup.parent
-  let children n = Soup.children n |> Soup.elements |> Soup.to_list
+  let name (n : t) = Some n.tag
+  let id n = Html.attribute n "id"
+  let classes = Html.classes
+  let attribute = Html.attribute
+  let parent (n : t) = n.parent
 
   (* [children] is the element children the structural selectors count; text is
-     reported apart because [:empty] counts that too. [Soup.texts] of a text
-     node is its own data and of a comment is nothing, so skipping the element
-     children leaves exactly the text that bears on emptiness. *)
-  let text_children n =
-    Soup.children n |> Soup.to_list
-    |> List.concat_map (fun c ->
-        match Soup.element c with Some _ -> [] | None -> Soup.texts c)
+     reported apart because [:empty] counts that too, and a comment counts for
+     neither. *)
+  let children = Html.element_children
+  let text_children = Html.text_children
 end
 
 module Apply = Cascade.Apply.Make (Node)
@@ -42,9 +38,8 @@ let style_node node = function
          properties are resolved onto it too, so the browser still resolves
          them. The [Inline] mode would substitute a var() with its fallback,
          dropping the reference and changing the render. *)
-      Soup.set_attribute "style"
+      Html.set_attribute node "style"
         (Sheet.inline_style_of_declarations ~minify:true ~mode:Variables decls)
-        node
 
 (* Prefix every line of a multi-line diagnostic so a downstream [grep -v
    "warning"] filters the whole entry, not just the first line. *)
@@ -72,20 +67,20 @@ let parse_source ~filename ~note css =
       else Some stylesheet
 
 let inline_html ~minimal ~filename ~html ~extra =
-  let soup = Soup.parse html in
+  let doc = Html.parse html in
   (* Each <style> block parses on its own, which is how a browser reads them
      too, so a block the parser cannot use is known apart from the rest. *)
   let blocks =
-    Soup.select "style" soup |> Soup.to_list
+    Html.find_all "style" doc
     |> List.mapi (fun i node ->
         let filename = Fmt.str "%s:<style>#%d" filename (i + 1) in
-        let css = String.concat "" (Soup.texts node) in
+        let css = Html.text node in
         (node, parse_source ~filename ~note:"; keeping the block verbatim" css))
   in
   let sheet =
     List.concat_map (fun (_, s) -> Option.value s ~default:[]) blocks @ extra
   in
-  let roots = Soup.children soup |> Soup.elements |> Soup.to_list in
+  let roots = Html.roots doc in
   let { Cascade.Apply.styles; keep_css; kept } =
     Apply.compute ~minimal ~sheet roots
   in
@@ -98,18 +93,18 @@ let inline_html ~minimal ~filename ~html ~extra =
      too: emptying it would ship a page with neither the inline styles it should
      have had nor the CSS text a browser might still make something of. *)
   List.iter
-    (fun (node, sheet) -> if Option.is_some sheet then Soup.clear node)
+    (fun (node, sheet) -> if Option.is_some sheet then Html.clear node)
     blocks;
   (if keep_css <> "" then
-     let style = Soup.create_element ~inner_text:keep_css "style" in
-     match Soup.select_one "head" soup with
-     | Some head -> Soup.append_child head style
+     let style = Html.element "style" ~text:keep_css in
+     match Html.find "head" doc with
+     | Some head -> Html.append_child head style
      | None -> (
-         match Soup.select_one "html" soup with
-         | Some h -> Soup.prepend_child h style
+         match Html.find "html" doc with
+         | Some h -> Html.prepend_child h style
          | None -> ()));
   let lost = List.exists (fun (_, s) -> Option.is_none s) blocks in
-  (Soup.to_string soup, kept, lost)
+  (Html.to_string doc, kept, lost)
 
 (* ---------- cmdliner ---------- *)
 let read_file path =

--- a/bin/dune
+++ b/bin/dune
@@ -11,4 +11,4 @@
   fmt.tty
   logs
   logs.fmt
-  lambdasoup))
+  markup))

--- a/bin/html.ml
+++ b/bin/html.ml
@@ -1,0 +1,119 @@
+type t = node list
+
+and node =
+  | Element of element
+  | Text of string
+  | Comment of string
+  | Doctype of Markup.doctype
+
+and element = {
+  ns : string;
+  tag : string;
+  mutable attributes : (string * string) list;
+  mutable children : node list;
+  mutable parent : element option;
+}
+
+(* markup.ml reports an attribute namespace as the prefix the source wrote
+   ([("x-on", "click")] for [x-on:click]), and its HTML writer only knows how to
+   put back the four it has URIs for. Joining the two here keeps every other
+   prefix, which is most of what a page carries: Alpine, Vue, Angular. *)
+let attribute_name (prefix, local) =
+  if prefix = "" then local else String.concat ":" [ prefix; local ]
+
+let parse html =
+  Markup.string html |> Markup.parse_html |> Markup.signals
+  |> Markup.trees
+       ~text:(fun ss -> Text (String.concat "" ss))
+       ~comment:(fun s -> Comment s)
+       ~doctype:(fun d -> Doctype d)
+       ~element:(fun (ns, tag) attributes children ->
+         let attributes =
+           List.map (fun (name, v) -> (attribute_name name, v)) attributes
+         in
+         let e = { ns; tag; attributes; children; parent = None } in
+         List.iter
+           (function Element c -> c.parent <- Some e | _ -> ())
+           children;
+         Element e)
+  |> Markup.to_list
+
+let to_string nodes =
+  let signal = function
+    | Element { ns; tag; attributes; children; _ } ->
+        let attributes = List.map (fun (n, v) -> (("", n), v)) attributes in
+        `Element ((ns, tag), attributes, children)
+    | Text s -> `Text s
+    | Comment s -> `Comment s
+    | Doctype d -> `Doctype d
+  in
+  List.concat_map (fun n -> Markup.from_tree signal n |> Markup.to_list) nodes
+  |> Markup.of_list |> Markup.write_html |> Markup.to_string
+
+let pp ppf doc = Fmt.string ppf (to_string doc)
+
+let roots nodes =
+  List.filter_map (function Element e -> Some e | _ -> None) nodes
+
+let element_children e = roots e.children
+
+let rec find_all tag nodes =
+  List.concat_map
+    (function
+      | Element e ->
+          let here = if e.tag = tag then [ e ] else [] in
+          here @ find_all tag e.children
+      | _ -> [])
+    nodes
+
+let find tag nodes =
+  match find_all tag nodes with [] -> None | e :: _ -> Some e
+
+let rec text e =
+  String.concat ""
+    (List.map
+       (function Element c -> text c | Text s -> s | _ -> "")
+       e.children)
+
+let attribute e name = List.assoc_opt name e.attributes
+
+(* Setting an attribute puts it at the head of the list, so a page's own
+   attribute order is what survives and the [style] this command writes reads
+   first. *)
+let set_attribute e name value =
+  let others = List.filter (fun (n, _) -> n <> name) e.attributes in
+  e.attributes <- (name, value) :: others
+
+let is_ascii_whitespace = function
+  | ' ' | '\t' | '\n' | '\012' | '\r' -> true
+  | _ -> false
+
+let classes e =
+  match attribute e "class" with
+  | None -> []
+  | Some v ->
+      String.split_on_char ' '
+        (String.map (fun c -> if is_ascii_whitespace c then ' ' else c) v)
+      |> List.filter (fun s -> s <> "")
+
+let text_children e =
+  List.filter_map (function Text s -> Some s | _ -> None) e.children
+
+let clear e = e.children <- []
+
+let element tag ~text =
+  {
+    ns = Markup.Ns.html;
+    tag;
+    attributes = [];
+    children = (if text = "" then [] else [ Text text ]);
+    parent = None;
+  }
+
+let append_child parent child =
+  child.parent <- Some parent;
+  parent.children <- parent.children @ [ Element child ]
+
+let prepend_child parent child =
+  child.parent <- Some parent;
+  parent.children <- Element child :: parent.children

--- a/bin/html.mli
+++ b/bin/html.mli
@@ -1,0 +1,78 @@
+(** A mutable HTML tree, parsed and printed with markup.ml.
+
+    {!Cascade.Resolve} needs a tree with parent links and settable attributes;
+    markup.ml gives a signal stream. This is the tree in between, and it holds
+    every node HTML has, comments included: [<p>v<!-- -->4.3</p>] keeps two text
+    nodes, and a browser measures the two apart, so dropping the comment changes
+    the render. Licence headers and conditional comments are the other reason
+    they are content, not decoration. *)
+
+type t = node list
+(** A parsed document: the top-level nodes, in order. *)
+
+and node =
+  | Element of element
+  | Text of string
+  | Comment of string
+  | Doctype of Markup.doctype
+
+and element = {
+  ns : string;  (** Namespace URI, so SVG and MathML print as themselves. *)
+  tag : string;  (** Local name, lowercased by the HTML parser. *)
+  mutable attributes : (string * string) list;
+  mutable children : node list;
+  mutable parent : element option;
+}
+
+val parse : string -> t
+(** [parse html] is the document [html] denotes: a doctype, the [<html>] element
+    the parser builds whether or not the source wrote one, and any comment
+    outside it. *)
+
+val to_string : t -> string
+(** [to_string doc] serialises [doc] as HTML5. *)
+
+val pp : t Fmt.t
+(** [pp] prints a document as HTML5. *)
+
+val find_all : string -> t -> element list
+(** [find_all tag doc] is every [tag] element in [doc], in document order. *)
+
+val find : string -> t -> element option
+(** [find tag doc] is the first [tag] element in [doc]. *)
+
+val roots : t -> element list
+(** [roots doc] is the elements among [doc]'s top-level nodes, the trees to
+    resolve against. *)
+
+val text : element -> string
+(** [text e] is the data of every text node under [e], concatenated. *)
+
+val attribute : element -> string -> string option
+(** [attribute e name] is the value of [e]'s [name] attribute, or [None]. *)
+
+val set_attribute : element -> string -> string -> unit
+(** [set_attribute e name value] sets [e]'s [name] attribute. *)
+
+val classes : element -> string list
+(** [classes e] is the class names in [e]'s [class] attribute (HTML sec. 2.4.7:
+    a set of space-separated tokens splits on ASCII whitespace). *)
+
+val element_children : element -> element list
+(** [element_children e] is [e]'s child elements, in document order. *)
+
+val text_children : element -> string list
+(** [text_children e] is the data of [e]'s direct child text nodes. A comment is
+    not one: it does not stop an element being [:empty]. *)
+
+val clear : element -> unit
+(** [clear e] removes [e]'s children, leaving the element in the tree. *)
+
+val element : string -> text:string -> element
+(** [element tag ~text] is a new HTML element named [tag] holding [text]. *)
+
+val append_child : element -> element -> unit
+(** [append_child parent child] adds [child] as [parent]'s last child. *)
+
+val prepend_child : element -> element -> unit
+(** [prepend_child parent child] adds [child] as [parent]'s first child. *)

--- a/cascade.opam
+++ b/cascade.opam
@@ -19,7 +19,6 @@ depends: [
   "astring" {with-test}
   "eio" {>= "0.14" & with-test}
   "eio_main" {>= "0.14" & with-test}
-  "lambdasoup"
   "markup"
   "mdx" {with-test}
   "re" {with-test}

--- a/cascade.opam
+++ b/cascade.opam
@@ -20,6 +20,7 @@ depends: [
   "eio" {>= "0.14" & with-test}
   "eio_main" {>= "0.14" & with-test}
   "lambdasoup"
+  "markup"
   "mdx" {with-test}
   "re" {with-test}
   "fmt" {>= "0.10.0"}

--- a/dune-project
+++ b/dune-project
@@ -25,6 +25,7 @@
   (eio (and (>= 0.14) :with-test))
   (eio_main (and (>= 0.14) :with-test))
   lambdasoup
+  markup
   (mdx :with-test)
   (re :with-test)
   (fmt (>= 0.10.0))

--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,6 @@
   (astring :with-test)
   (eio (and (>= 0.14) :with-test))
   (eio_main (and (>= 0.14) :with-test))
-  lambdasoup
   markup
   (mdx :with-test)
   (re :with-test)

--- a/test/cli/apply_comments.t
+++ b/test/cli/apply_comments.t
@@ -1,0 +1,40 @@
+CLI: [cascade apply] and HTML comments.
+
+A comment is content. A licence header has to reach the output page,
+and React writes an empty comment between two adjacent text nodes on
+purpose: it keeps them two nodes, and a browser measures and rounds
+each run on its own, so merging them moves the element's width.
+
+  $ cat > page.html <<EOF
+  > <!-- Copyright 2026. -->
+  > <html><head><style>p{color:red}</style></head><body>
+  > <p>v<!-- -->4.3</p>
+  > <!--[if IE]><p>legacy</p><![endif]-->
+  > <p><!-- empty but for this --></p>
+  > </body></html>
+  > EOF
+
+  $ cascade apply page.html 2> /dev/null
+  <!-- Copyright 2026. --><html><head><style></style></head><body>
+  <p style="color:red">v<!-- -->4.3</p>
+  <!--[if IE]><p>legacy</p><![endif]-->
+  <p style="color:red"><!-- empty but for this --></p>
+  
+  </body></html>
+
+A comment is not a text node, so it does not stop an element being
+:empty (Selectors 4 sec. 13.2).
+
+  $ cat > empty.html <<EOF
+  > <html><head><style>p:empty{color:red}</style></head><body>
+  > <p id="comment"><!-- c --></p>
+  > <p id="text">t</p>
+  > </body></html>
+  > EOF
+
+  $ cascade apply empty.html 2> /dev/null
+  <html><head><style></style></head><body>
+  <p style="color:red" id="comment"><!-- c --></p>
+  <p id="text">t</p>
+  
+  </body></html>

--- a/test/inline/fixtures/comment.html
+++ b/test/inline/fixtures/comment.html
@@ -1,0 +1,12 @@
+<!doctype html><html><head><style>
+  .measure { display: inline-block; font-family: serif; font-size: 100px }
+  .note    { color: red }
+</style></head><body>
+<!-- A licence header is content: it has to reach the output page. -->
+<div class="measure">V<!-- -->A</div>
+<div class="measure">To<!-- -->wn</div>
+<div class="measure">W<!-- -->A<!-- -->V<!-- -->E</div>
+<p class="note">React writes <!-- --> between adjacent text nodes on purpose;
+each run is measured and rounded on its own, so merging them moves the width.</p>
+<p class="note"><!-- a comment does not stop :empty --></p>
+</body></html>

--- a/test/interop/wpt/dune
+++ b/test/interop/wpt/dune
@@ -2,7 +2,7 @@
  (name test)
  (deps
   (source_tree traces))
- (libraries cascade alcotest fmt lambdasoup))
+ (libraries cascade alcotest fmt markup))
 
 ; Refresh traces/css-syntax from the WPT repo at the pinned commit.
 

--- a/test/interop/wpt/test.ml
+++ b/test/interop/wpt/test.ml
@@ -6,7 +6,7 @@
     loops, [document.querySelector] checks, etc.) have dedicated per-file ports
     at the bottom of this module that re-encode the test logic in OCaml.
 
-    Static extraction uses {!Soup.parse}, so we pick up:
+    Static extraction folds over the markup.ml signal stream, so we pick up:
 
     - [<style>] element bodies.
     - [style="..."] attributes on any element.
@@ -70,7 +70,7 @@ let extract_template_args ~call_name s =
   in
   loop [] 0
 
-(** {1 HTML-level extraction via lambdasoup} *)
+(** {1 HTML-level extraction} *)
 
 type case = {
   source_file : string;
@@ -79,73 +79,97 @@ type case = {
   kind : [ `Stylesheet | `Inline_declarations ];
 }
 
+(* What a vector can hold, in document order. Extraction needs no tree: a fold
+   over the signal stream sees each element with its attributes, and the body of
+   a raw-text element is the text between its start and end tags. *)
+type found =
+  | Style of string
+  | Inline of string
+  | Link of string
+  | Script of string
+
+let attribute name attributes =
+  List.find_map
+    (fun ((_, n), v) -> if n = name then Some v else None)
+    attributes
+
+(* The body of a <style> or <script>: each text chunk trimmed, the empty ones
+   dropped, and the whole trimmed again. *)
+let body chunks =
+  List.rev chunks |> List.map String.trim
+  |> List.filter (fun s -> s <> "")
+  |> String.concat "" |> String.trim
+
+let found_in contents =
+  let close kind chunks =
+    match kind with
+    | `Style -> Style (body chunks)
+    | `Script -> Script (body chunks)
+  in
+  let step (acc, raw) signal =
+    match (signal, raw) with
+    | `Text ss, Some (kind, chunks) ->
+        (acc, Some (kind, String.concat "" ss :: chunks))
+    | `End_element, Some (kind, chunks) -> (close kind chunks :: acc, None)
+    | `Start_element ((_, name), attributes), _ ->
+        let raw =
+          match name with
+          | "style" -> Some (`Style, [])
+          | "script" -> Some (`Script, [])
+          | _ -> raw
+        in
+        let acc =
+          match attribute "style" attributes with
+          | Some v -> Inline (String.trim v) :: acc
+          | None -> acc
+        in
+        let stylesheet_link =
+          name = "link" && attribute "rel" attributes = Some "stylesheet"
+        in
+        let acc =
+          match attribute "href" attributes with
+          | Some h when stylesheet_link -> Link h :: acc
+          | Some _ | None -> acc
+        in
+        (acc, raw)
+    | _ -> (acc, raw)
+  in
+  Markup.string contents |> Markup.parse_html |> Markup.signals
+  |> Markup.fold step ([], None)
+  |> fst |> List.rev
+
 let cases_of_html ~source_file contents : case list =
-  let soup = Soup.parse contents in
+  let found = found_in contents in
+  let pick f = List.filter_map f found in
+  let case origin css kind = { source_file; origin; css; kind } in
   let style_cases =
-    Soup.(soup $$ "style")
-    |> Soup.to_list
-    |> List.mapi (fun i node ->
-        let body = Soup.trimmed_texts node |> String.concat "" |> String.trim in
-        {
-          source_file;
-          origin = Fmt.str "<style>[%d]" i;
-          css = body;
-          kind = `Stylesheet;
-        })
-    |> List.filter (fun c -> c.css <> "")
+    pick (function Style b -> Some b | _ -> None)
+    |> List.mapi (fun i css -> case (Fmt.str "<style>[%d]" i) css `Stylesheet)
   in
   let inline_cases =
-    Soup.(soup $$ "[style]")
-    |> Soup.to_list
-    |> List.mapi (fun i node ->
-        let body =
-          match Soup.attribute "style" node with
-          | Some v -> String.trim v
-          | None -> ""
-        in
-        {
-          source_file;
-          origin = Fmt.str "[style][%d]" i;
-          css = body;
-          kind = `Inline_declarations;
-        })
-    |> List.filter (fun c -> c.css <> "")
+    pick (function Inline v -> Some v | _ -> None)
+    |> List.mapi (fun i css ->
+        case (Fmt.str "[style][%d]" i) css `Inline_declarations)
   in
   let link_cases =
-    Soup.(soup $$ "link[rel=stylesheet]")
-    |> Soup.to_list
-    |> List.filter_map (fun node ->
-        match Soup.attribute "href" node with None -> None | Some h -> Some h)
-    |> List.mapi (fun i href ->
+    pick (function Link h -> Some h | _ -> None)
+    |> List.mapi (fun i href -> (i, href))
+    |> List.filter_map (fun (i, href) ->
         let resolved = Filename.concat vectors_dir href in
         if not (Sys.file_exists resolved) then None
         else
           Some
-            {
-              source_file;
-              origin = Fmt.str "<link href=%S>[%d]" href i;
-              css = read_file resolved;
-              kind = `Stylesheet;
-            })
-    |> List.filter_map (fun x -> x)
-    |> List.filter (fun c -> c.css <> "")
+            (case
+               (Fmt.str "<link href=%S>[%d]" href i)
+               (read_file resolved) `Stylesheet))
   in
   let script_cases =
-    Soup.(soup $$ "script")
-    |> Soup.to_list
-    |> List.concat_map (fun node ->
-        let js = Soup.trimmed_texts node |> String.concat "" |> String.trim in
-        extract_template_args ~call_name:"parseRule" js)
-    |> List.mapi (fun i body ->
-        {
-          source_file;
-          origin = Fmt.str "parseRule[%d]" i;
-          css = body;
-          kind = `Stylesheet;
-        })
-    |> List.filter (fun c -> c.css <> "")
+    pick (function Script b -> Some b | _ -> None)
+    |> List.concat_map (extract_template_args ~call_name:"parseRule")
+    |> List.mapi (fun i css -> case (Fmt.str "parseRule[%d]" i) css `Stylesheet)
   in
   style_cases @ inline_cases @ link_cases @ script_cases
+  |> List.filter (fun c -> c.css <> "")
 
 let cases_of_css ~source_file contents =
   [ { source_file; origin = "<file>"; css = contents; kind = `Stylesheet } ]


### PR DESCRIPTION
`cascade apply` dropped every HTML comment, so licence headers vanished and React's `<!-- -->` text-node separator was merged away, which changes how a browser measures the surrounding text. The page is now parsed and printed with markup.ml, the parser lambdasoup itself runs on, so nothing new enters the dependency cone and lambdasoup leaves it; this closes the last render difference on the tailwind.com page under `test/inline`.

Stacked on #340.