### PR TITLE
css: drop the non-exhaustive twin of statement_declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+### Breaking
+
+- `Css.statement_declarations` is gone. It answered for a rule and a bare
+  nesting block only, sharing its name with the exhaustive
+  `Css.Stylesheet.statement_declarations`, which reaches every declaration a
+  statement holds; call that one instead (#348)
+
 ### Parsing
 
 - A compound operand of `not`, `and` or `or` in a `@media` condition keeps the

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -1354,10 +1354,9 @@ let test_random_stylesheet_contract buf =
 let count_important sheet =
   Css.fold
     (fun acc stmt ->
-      match Css.statement_declarations stmt with
-      | None -> acc
-      | Some decls ->
-          acc + List.length (List.filter Css.declaration_is_important decls))
+      Css.Stylesheet.statement_declarations stmt
+      |> List.filter Css.declaration_is_important
+      |> List.length |> ( + ) acc)
     0 sheet
 
 (* [!important] preservation: round-tripping must not lose, gain, or

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -422,11 +422,6 @@ let statement_selector = function
   | Rule r -> Some (Stylesheet.selector r)
   | _ -> None
 
-let statement_declarations = function
-  | Rule r -> Some (Stylesheet.declarations r)
-  | Declarations decls -> Some decls
-  | _ -> None
-
 let as_rule = function
   | Rule r ->
       Some

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -160,10 +160,6 @@ val statement_selector : statement -> Selector.t option
 (** [statement_selector stmt] returns [Some selector] if the statement is a
     rule, {!constructor-None} otherwise. *)
 
-val statement_declarations : statement -> declaration list option
-(** [statement_declarations stmt] returns [Some declarations] if the statement
-    is a rule, {!constructor-None} otherwise. *)
-
 val as_rule :
   statement -> (Selector.t * declaration list * statement list) option
 (** [as_rule stmt] returns [Some (selector, declarations, nested)] if the

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1140,9 +1140,7 @@ let strings_of_rule stmt =
   | Some (selector, decls, _) ->
       let selector_str = Css.Selector.to_string selector in
       (selector_str, decls)
-  | None ->
-      ( statement_head stmt,
-        Option.value ~default:[] (Css.statement_declarations stmt) )
+  | None -> (statement_head stmt, Css.Stylesheet.statement_declarations stmt)
 
 let decl_to_prop_value decl =
   let name = Css.declaration_name decl in
@@ -1188,9 +1186,7 @@ let selector_key_of_selector (sel : Css.Selector.t) : Css.Selector.t =
   | _ -> sel
 
 let selector_key_of_stmt stmt = selector_key_of_selector (rule_selector stmt)
-
-let rule_declarations stmt =
-  match Css.statement_declarations stmt with Some d -> d | None -> []
+let rule_declarations = Css.Stylesheet.statement_declarations
 
 let rule_nested stmt =
   match Css.as_rule stmt with Some (_, _, nested) -> nested | None -> []

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -59,7 +59,7 @@ let custom_property_layer_and_meta_survive () =
     Rule_order.canonicalize
       [ Css.rule ~selector:(Selector.of_string ":root") [ decl ] ]
   in
-  match List.filter_map Css.statement_declarations projected with
+  match List.map Css.Stylesheet.statement_declarations projected with
   | [ [ d ] ] ->
       Alcotest.(check (option string))
         "layer survives" (Some "theme")


### PR DESCRIPTION
`Css.statement_declarations` answered for a rule and a bare nesting block only, while `Css.Stylesheet.statement_declarations` of the same name reaches every declaration a statement holds; the two callers in the diff both wanted the exhaustive one. Breaking for anyone calling it, so it is its own PR. Stacked on #345.