### PR TITLE
optimize: type a registered custom property wherever it is declared

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -133,6 +133,10 @@
   `@supports-condition` body as a reference, so it no longer emits a name whose
   definition it deleted, and reports an overridden variable referenced from any
   of those at-rules through `~warn` (#342)
+- A custom property registered by `@property` is typed wherever it is
+  declared, including inside `@keyframes`, `@position-try` and
+  `@supports-condition`, so the same registered value canonicalises the same
+  way in every one of them (#349)
 
 ### Canonical diff
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -770,14 +770,6 @@ let promote_registered_custom_decl ~lossless registry decl =
                 (Custom_value { value = Tokens components'; layer; meta })))
   | _ -> decl
 
-let promote_frames f frames =
-  list_map_preserve
-    (fun (frame : keyframe) ->
-      let declarations = list_map_preserve f frame.declarations in
-      if declarations == frame.declarations then frame
-      else { frame with declarations })
-    frames
-
 let promote_registered_custom_properties ~lossless (stmts : statement list) =
   let registry : (string, Variables.any_syntax) Hashtbl.t = Hashtbl.create 8 in
   (* An [@property] registration is document-global regardless of source order
@@ -792,34 +784,20 @@ let promote_registered_custom_properties ~lossless (stmts : statement list) =
     | _ -> iter_statement_block collect_stmt stmt
   in
   List.iter collect_stmt stmts;
-  let promote_decl = promote_registered_custom_decl ~lossless registry in
+  let promote_decls =
+    list_map_preserve (promote_registered_custom_decl ~lossless registry)
+  in
+  (* A registration is document-global, so every declaration of that name is
+     typed wherever it is written: through the declaration walker rather than a
+     list of the at-rules that came to mind. *)
   let rec walk_stmt (stmt : statement) : statement =
+    let stmt = map_statement_declarations_preserve promote_decls stmt in
     match stmt with
-    | Property _ -> stmt
     | Rule r ->
-        let declarations = list_map_preserve promote_decl r.declarations in
         let nested = list_map_preserve walk_stmt r.nested in
-        let r' = rule_with_declarations_and_nested r declarations nested in
+        let r' = rule_with_nested r nested in
         if r' == r then stmt else Rule r'
-    | Declarations decls ->
-        let decls' = list_map_preserve promote_decl decls in
-        if decls' == decls then stmt else Declarations decls'
-    (* A keyframe frame declares registered custom properties like any other
-       block, and the registration is what the frame interpolates against (CSS
-       Properties and Values API 1 SS 2.4). *)
-    | Keyframes (name, frames) ->
-        let frames' = promote_frames promote_decl frames in
-        if frames' == frames then stmt else Keyframes (name, frames')
-    | Webkit_keyframes (name, frames) ->
-        let frames' = promote_frames promote_decl frames in
-        if frames' == frames then stmt else Webkit_keyframes (name, frames')
-    | Moz_keyframes (name, frames) ->
-        let frames' = promote_frames promote_decl frames in
-        if frames' == frames then stmt else Moz_keyframes (name, frames')
-    | Media _ | Container _ | Supports _ | Layer _ | Origin _ | Scope _
-    | Starting_style _ | Moz_document _ | When _ | Else _ ->
-        map_statement_block_preserve walk_stmt stmt
-    | _ -> stmt
+    | stmt -> map_statement_block_preserve walk_stmt stmt
   in
   list_map_preserve walk_stmt stmts
 

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -785,6 +785,27 @@ let test_optimize_descends_into_every_conditional_group () =
      media(print){a{color:#f00}a{color:#f00}}@else{b{color:#f00}b{color:#f00}}"
     "@when media(print){a{color:red}}@else{b{color:red}}"
 
+(* An [@property] registration is document-global (CSS Properties and Values API
+   1 sec. 2), so a declaration of that name is typed wherever it is written.
+   Promotion has to reach the at-rules that hold declarations outside a nested
+   block, or the same registered value canonicalises one way in a rule and
+   another inside one of them. *)
+let test_promote_registered_reaches_at_rule_declarations () =
+  let registration =
+    "@property --c{syntax:\"<color>\";inherits:false;initial-value:red}"
+  in
+  let check name body expected =
+    Alcotest.(check string)
+      name (registration ^ expected)
+      (minify (Css.of_string_exn ~strict:false (registration ^ body)))
+  in
+  check "a style rule types the declaration" "a{--c:rgb(255 0 0)}" "a{--c:red}";
+  check "@position-try types it too" "@position-try --p{--c:rgb(255 0 0)}"
+    "@position-try --p{--c:red}";
+  check "@supports-condition types it too"
+    "@supports-condition --x{--c:rgb(255 0 0)}"
+    "@supports-condition --x{--c:red}"
+
 (* A colour function carrying a var() is a pending-substitution value (CSS
    Variables L1 section 3): its arity and legacy/modern separator style aren't
    known until substitution, so minify+optimize must keep it verbatim - never
@@ -1351,6 +1372,9 @@ let optimize_tests =
     ( "optimize descends into every conditional group",
       `Quick,
       test_optimize_descends_into_every_conditional_group );
+    ( "promote registered reaches at-rule declarations",
+      `Quick,
+      test_promote_registered_reaches_at_rule_declarations );
     ( "deduplicate declarations preserves physical identity",
       `Quick,
       test_deduplicate_declarations_physical_identity );


### PR DESCRIPTION
An `@property` registration is document-global, but the promotion pass listed the at-rules it descended into, so `--c: rgb(255 0 0)` canonicalised to `red` in a style rule and stayed as authored inside `@position-try` or `@supports-condition`. It goes through the declaration walker added in #341 instead, which subsumes the per-constructor keyframe arms #337 added. Stacked on #348.