### PR TITLE
values: keep a length's authored precision through minify

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,11 @@
   `-webkit-backdrop-filter`, `-webkit-user-select`, `-webkit-text-size-adjust`
   and `-webkit-print-color-adjust` were dropped against an unprefixed twin no
   shipping Safari understands (#325)
+- A length keeps the coefficient it was written with. `--minify` rounded every
+  printed length to six significant digits, so `.4285714em` came back as
+  `.428571em` and `999999999px` as `1000000000px`, each a different length in
+  the browser; the six-digit budget now belongs to the `calc()` fold that gives
+  up exactness against a math constant (#351)
 
 ### Custom properties
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -890,8 +890,7 @@ let exact_div (a : float) (b : float) : float option =
     let r = a /. b in
     (* Round-trip alone is too lax under IEEE 754 (33.333... * 3 = 100.0 due to
        multiplication rounding). Also require the quotient to survive the
-       6-sig-fig round used by [Pp.float], which is the precision Cascade
-       commits to in serialised output. *)
+       6-significant-digit round, the budget an inexact fold commits to. *)
     if Float.is_finite r && r *. b = a && Pp.round_sig 6 r = r then
       Option.some r
     else Option.none
@@ -1082,7 +1081,8 @@ let rec eval_typed_calc : type a.
           | Some v -> Val v
           | None -> Expr (l, op, r))
       | Num n, Mul, Val a -> (
-          match scale ~exact:true Mul a n with
+          let exact = match l with Math_const _ -> false | _ -> true in
+          match scale ~exact Mul a n with
           | Some v -> Val v
           | None -> Expr (l, op, r))
       (* CSS Values 4 sec. 10.10.1: [1 / (1 / x)] cancels the double
@@ -1125,15 +1125,11 @@ let pp_unit ?always:_ ctx f suffix =
      top-level (a calc / function operand keeps its unit), so it is an AST
      rewrite in the optimize pass, not a printer choice. *)
   (* CSSOM serialization (CSS Values 4 6.7.2) drops a leading zero on fractional
-     values ([.25rem], not [0.25rem]) in both modes; under minify round to 6
-     significant digits so a [calc()]-folded result emits [70.7107px] rather
-     than an 8-decimal float. *)
-  let rendered =
-    if Pp.minified ctx then
-      Pp.string_of_float ~drop_leading_zero:true (Pp.round_sig 6 f)
-    else Pp.string_of_float ~drop_leading_zero:true f
-  in
-  Pp.string ctx rendered;
+     values ([.25rem], not [0.25rem]) in both modes. The coefficient is the
+     node's value, not its spelling: [.4285714em] printed as [.428571em] is a
+     different length, so the precision an inexact [calc()] fold gives up is
+     that fold's to give, not the printer's. *)
+  Pp.string ctx (Pp.string_of_float ~drop_leading_zero:true f);
   Pp.string ctx suffix
 
 (** Try to evaluate a calc expression containing only numbers to a float.
@@ -1348,17 +1344,22 @@ let length_combine op v1 v2 =
       | _ -> None)
   | _ -> None
 
+(* A math constant is irrational, so scaling by one is inexact however the
+   result is printed: the fold commits it to six significant digits. Only a
+   number the fold computed reaches here, never one the author wrote. *)
+let inexact_fold ~exact r = if exact then r else Pp.round_sig 6 r
+
 (* CSS Values 4 sec. 10.10.1: a unitless factor scales a typed length, unit
    unchanged. Division folds only when [exact_div] is exact, else the [calc()]
-   is kept to avoid precision loss. Exception: an irrational divisor (a math
-   constant [pi] / [e] / ...) can never be exact, and keeping [calc()] preserves
-   no more precision than the browser computes, so fold to the rounded value. *)
+   is kept to avoid precision loss. Exception: an irrational divisor can never
+   be exact, and keeping [calc()] preserves no more precision than the browser
+   computes, so fold to the rounded value. *)
 let length_scale ?(exact = true) op v n =
   if not (Float.is_finite n) then Option.none
   else
     match (op, calc_length_unit v) with
     | Mul, Some (unit, value) ->
-        let r = value *. n in
+        let r = inexact_fold ~exact (value *. n) in
         if Float.is_finite r then Option.some (length_from_calc_unit unit r)
         else Option.none
     | Div, Some (unit, value) ->
@@ -1366,7 +1367,7 @@ let length_scale ?(exact = true) op v n =
           Option.map (length_from_calc_unit unit) (exact_div value n)
         else if n = 0. then Option.none
         else
-          let r = value /. n in
+          let r = inexact_fold ~exact (value /. n) in
           if Float.is_finite r then Option.some (length_from_calc_unit unit r)
           else Option.none
     | _ -> Option.none

--- a/test/inline/fixtures/precision.html
+++ b/test/inline/fixtures/precision.html
@@ -1,0 +1,8 @@
+<!doctype html><html><head><style>
+  /* A length's coefficient is part of its value: rounding .4285714em to six
+     significant digits reports a different padding in the browser. */
+  body { font-size: 14px }
+  ul   { padding-left: 1.5714286em; margin: 0 }
+  li   { padding-left: .4285714em; margin-top: .2857143em }
+</style></head>
+<body><ul><li>one</li><li>two</li></ul></body></html>

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -127,9 +127,14 @@ let test_length () =
   check_length "-999999px";
   check_length ~expected:".000001em" "0.000001em";
   check_length ~expected:".0000001rem" "0.0000001rem";
-  (* CSS Values leaves numeric precision/range implementation-defined; the
-     printer rounds this edge value to the nearest representable decimal. *)
-  check_length ~expected:"1000000000px" "999999999px";
+  (* A coefficient is part of the length's value, not its spelling: minify
+     shortens how a number is written, never what it means. Rounding
+     [999999999px] to six significant digits moves the box a whole pixel, and
+     [.4285714em] read back as [.428571em] is a different padding. *)
+  check_length "999999999px";
+  check_length ".4285714em";
+  check_length "1.5714286em";
+  check_length "1.0000001px";
   check_length "-999px";
   check_length ".5px";
 


### PR DESCRIPTION
`--minify` rounded every printed length to six significant digits, so Tailwind Typography's `.4285714em` came back as `.428571em` and `999999999px` as `1000000000px`; the browser then computes a different padding, which is what the last render differences on `test/inline/pages/ocaml.html` were. The six-digit budget moves to the `calc()` fold against a math constant, the only place that has precision to give up.