### PR TITLE
optimize: keep a same-selector merge behind a nested conditional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -267,6 +267,10 @@
   conflict test walks the two key lists in step instead of scanning one per
   element of the other, and collecting them no longer rescans what it has
   already collected (#422)
+- Merging same-selector rules keeps a later declaration behind a nested
+  conditional group that sets the same property. The safety check saw a nested
+  style rule only, so `@media`, `@container` and friends let the merge hoist
+  the declaration past them and hand the conditional the win (#352)
 - A `font-family` name that cannot be spelled as an identifier keeps its
   quotes. The unquoting guard checked which characters a name is made of but
   not how CSS Syntax 3 sec. 4.3.9 lets an ident sequence start, so `"2Brand"`,

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2216,7 +2216,19 @@ let same_selector_merge_past_nested () =
   Alcotest.(check string)
     "a nested child setting the same property keeps its place"
     ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}"
-    (canon ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}")
+    (canon ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}");
+  (* A nested conditional group sets properties just as a nested rule does:
+     hoisting [padding:1rem] ahead of it hands the conditional the win wherever
+     it applies, which is a different rendered padding. *)
+  Alcotest.(check string)
+    "a nested @media setting the same property blocks it"
+    ".a{color:red;@media(width>=1px){padding:2rem}}.a{padding:1rem}"
+    (canon ".a{color:red;@media (min-width:1px){padding:2rem}}.a{padding:1rem}");
+  Alcotest.(check string)
+    "a nested @container setting the same property blocks it"
+    ".a{color:red;@container(width>=1px){padding:2rem}}.a{padding:1rem}"
+    (canon
+       ".a{color:red;@container (min-width:1px){padding:2rem}}.a{padding:1rem}")
 
 (* A run of declarations written after a nested statement (CSS Nesting 1 sec.
    3.4) is a declaration list like any other, with nothing between two writes


### PR DESCRIPTION
`.a{color:red;@media (min-width:1px){padding:2rem}}.a{padding:1rem}` minified to a single rule with `padding:1rem` hoisted ahead of the `@media`, so Chrome rendered 2rem where the source renders 1rem. The merge's safety check counted the properties a nested style rule sets but ignored every nested conditional group.