### PR TITLE
test/inline: make the browser render diff reproducible

### DIFF
--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -37,3 +37,11 @@ over one unchanged pair of pages reported 14, 410, 14 and 14 differences.
 Freezing happens at fetch time, before `cascade apply` ever sees the page, so
 the document cascade resolves is the document the browser lays out. Pages live
 in the gitignored `pages/`; re-run `fetch.sh` to rebuild them.
+
+## Coverage
+
+`fixtures/` is committed and always runs. `pages/` holds real sites downloaded
+by `fetch.sh`, and they gate the run in the same way: a surviving difference is
+a defect in a transform, whichever page found it. A failure that starts the day
+a site is redesigned is still a defect, but re-run `fetch.sh` before reading it
+as a regression in the working tree.

--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -18,5 +18,22 @@ CASCADE=_build/default/bin/main.exe sh test/inline/run.sh
 
 It looks for a headless Chrome on `PATH`, in `$CHROME`, or under the puppeteer
 cache, and skips cleanly if none is found (so it is a no-op in CI). `xtest.js`
-injects an extractor script, runs the browser with `--dump-dom`, and diffs the
+appends an extractor script, runs the browser with `--dump-dom`, and diffs the
 computed styles element by element.
+
+## Reproducibility
+
+A difference list is a measurement, so it has to repeat: run the same
+comparison twice and diff the two outputs, and they match byte for byte.
+
+That takes both halves of the harness. `fetch.sh` freezes each downloaded page
+through `freeze_page.js`, which removes everything that resolves at a moment
+nobody controls: scripts, `@font-face` rules whose relative `.woff2` cannot be
+read under `file://`, and images with an unreachable `src`. `xtest.js` then
+pins the browser, which otherwise brings its own variables (window size,
+device scale factor, scrollbars, name resolution). Without them, four runs
+over one unchanged pair of pages reported 14, 410, 14 and 14 differences.
+
+Freezing happens at fetch time, before `cascade apply` ever sees the page, so
+the document cascade resolves is the document the browser lays out. Pages live
+in the gitignored `pages/`; re-run `fetch.sh` to rebuild them.

--- a/test/inline/fetch.sh
+++ b/test/inline/fetch.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 # Download a few real pages into test/inline/pages/ so run.sh can run the
 # differential test against them. Each page is made self-contained (its external
-# stylesheets are fetched and inlined into a <style> block) so the inliner has
-# CSS to project and the page renders without network access. The downloaded
-# files are large and change upstream, so they are gitignored, never committed.
+# stylesheets are fetched and inlined into a <style> block) and then frozen
+# (scripts, web fonts and remote images removed, see freeze_page.js), so it
+# renders offline and its computed styles are reproducible run to run. The
+# downloaded files are large and change upstream, so they are gitignored, never
+# committed; re-run this script to reproduce them.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 out="$dir/pages"
 mkdir -p "$out"
@@ -13,12 +15,17 @@ fetch() { # name url
   url="$2"
   echo "$name <- $url"
   if curl -sL --max-time 60 -A "Mozilla/5.0" "$url" -o "$out/$name.raw.html"; then
-    node "$dir/inline_css.js" "$url" "$out/$name.raw.html" "$out/$name.html" ||
+    if node "$dir/inline_css.js" "$url" "$out/$name.raw.html" "$out/$name.in.html"
+    then
+      node "$dir/freeze_page.js" "$out/$name.in.html" "$out/$name.html" ||
+        echo "  freeze failed"
+    else
       echo "  inline-css failed"
+    fi
   else
     echo "  download failed"
   fi
-  rm -f "$out/$name.raw.html"
+  rm -f "$out/$name.raw.html" "$out/$name.in.html"
 }
 
 fetch wikipedia https://en.wikipedia.org/wiki/Cascading_Style_Sheets

--- a/test/inline/freeze_page.js
+++ b/test/inline/freeze_page.js
@@ -1,0 +1,46 @@
+// Freeze a fetched page so its layout is a pure function of its CSS.
+//
+// A page straight off the wire has three resolvers that finish at a moment
+// nobody controls, and each of them moves computed styles: <script> mutates the
+// DOM, an @font-face whose relative .woff2 src cannot be read under file://
+// swaps text metrics from the fallback to the webfont mid-render, and an <img>
+// with an unreachable src settles on its broken-image box whenever the load
+// finally fails. Measured unfrozen, one unchanged pair of pages returned 14,
+// 410, 14 and 14 differences on four consecutive runs.
+//
+// Everything asynchronous is therefore removed, or replaced by something that
+// resolves before layout. <noscript> goes too: the browser leaves its content
+// as inert text while scripting is on, so an HTML parser that reads it as
+// markup styles elements the browser never lays out.
+//
+// Usage: node freeze_page.js <in.html> <out.html>
+const fs = require('fs');
+
+// A 1x1 transparent GIF: an intrinsic size that is known before layout.
+const PIXEL =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+const paired = (tag) =>
+  new RegExp('<' + tag + '\\b[^>]*>[\\s\\S]*?<\\/' + tag + '\\s*>', 'gi');
+
+function freeze(html) {
+  // Self-closing scripts first: to the paired pattern they read as an opener,
+  // and it would swallow the document down to the next </script>.
+  html = html.replace(/<script\b[^>]*\/>/gi, '');
+  for (const tag of ['script', 'noscript', 'iframe', 'video', 'audio'])
+    html = html.replace(paired(tag), '');
+  html = html.replace(/<source\b[^>]*>/gi, '');
+  html = html.replace(/@font-face\s*\{[^}]*\}/gi, '');
+  html = html.replace(/<img\b[^>]*>/gi, (tag) => {
+    // Leading \s keeps data-src and friends, which are inert without scripts.
+    const bare = tag.replace(
+      /\s(?:src|srcset|sizes)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi,
+      ''
+    );
+    return bare.replace(/^<img/i, '<img src="' + PIXEL + '"');
+  });
+  return html;
+}
+
+const [, , inPath, outPath] = process.argv;
+fs.writeFileSync(outPath, freeze(fs.readFileSync(inPath, 'utf8')));

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -3,6 +3,10 @@
 # complete computed style must be identical before and after a transform.
 # Covers `cascade apply` (both modes) and `cascade --minify` (each <style>
 # block minified in place). Skips cleanly with no browser or node (e.g. in CI).
+#
+# A difference list is reproducible, so two runs can be diffed against each
+# other: fetch.sh freezes every downloaded page (freeze_page.js) and xtest.js
+# pins the browser, leaving computed style a function of the CSS alone.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 export CASCADE=${CASCADE:-cascade}
 if [ -z "$CHROME" ]; then
@@ -23,41 +27,44 @@ if "$root/scripts/with_switch.sh" dune build test/inline/canon_filter.exe; then
   [ -n "$CANON_FILTER" ] && export CANON_FILTER="$root/$CANON_FILTER"
 fi
 fail=0
+# xtest.js renders two pages, which is the whole cost of the run: keep its
+# report rather than paying for it a second time to print the failure.
+check() { # label before after
+  report=$(node "$dir/xtest.js" "$2" "$3" 2>&1)
+  case $report in
+    *IDENTICAL*) echo "ok   $1" ;;
+    *) echo "FAIL $1"
+       printf '%s\n' "$report" | head -8 | sed 's/^/     /'
+       fail=1 ;;
+  esac
+}
 for f in "$dir"/fixtures/*.html; do
   for mode in "" "--minimal"; do
-    out=$(mktemp)
-    "$CASCADE" apply $mode "$f" > "$out" 2>/dev/null
-    if node "$dir/xtest.js" "$f" "$out" 2>&1 | grep -q "IDENTICAL"; then
-      echo "ok   $(basename "$f") ${mode:-full}"
-    else
-      echo "FAIL $(basename "$f") ${mode:-full}"; node "$dir/xtest.js" "$f" "$out" 2>&1 | tail -6; fail=1
-    fi
-    rm -f "$out"
+    tmp=$(mktemp)
+    # shellcheck disable=SC2086 # an empty $mode must vanish, not pass ""
+    "$CASCADE" apply $mode "$f" > "$tmp" 2>/dev/null
+    check "$(basename "$f") ${mode:-full}" "$f" "$tmp"
+    rm -f "$tmp"
   done
 done
 # cascade --minify preserves the render too: minify each <style> block in place
 # and compare computed styles against the original page.
 for f in "$dir"/fixtures/*.html; do
-  out=$(mktemp)
-  node "$dir/minify_page.js" "$f" > "$out" 2>/dev/null
-  if node "$dir/xtest.js" "$f" "$out" 2>&1 | grep -q "IDENTICAL"; then
-    echo "ok   $(basename "$f") minify"
-  else
-    echo "FAIL $(basename "$f") minify"; node "$dir/xtest.js" "$f" "$out" 2>&1 | tail -6; fail=1
-  fi
-  rm -f "$out"
+  tmp=$(mktemp)
+  node "$dir/minify_page.js" "$f" > "$tmp" 2>/dev/null
+  check "$(basename "$f") minify" "$f" "$tmp"
+  rm -f "$tmp"
 done
-# Real pages downloaded by fetch.sh (gitignored): reported for coverage, but
-# they do not gate the run - they change upstream and exercise features still
-# being grown, so only the committed fixtures decide pass/fail.
-if [ -d "$dir/pages" ]; then
-  for f in "$dir"/pages/*.html; do
-    [ -e "$f" ] || continue
-    out=$(mktemp)
-    "$CASCADE" apply --minimal "$f" > "$out" 2>/dev/null
-    res=$(node "$dir/xtest.js" "$f" "$out" 2>/dev/null | grep RESULT)
-    echo "real $(basename "$f"): ${res:-no result}"
-    rm -f "$out"
-  done
-fi
+# Real pages downloaded by fetch.sh (gitignored, so absent until it is run).
+# They gate like the fixtures do: a surviving difference is a defect in the
+# transform, whichever page happened to find it. One that appears the day a
+# site is redesigned is still a defect, but re-run fetch.sh before reading it
+# as a regression in the working tree.
+for f in "$dir"/pages/*.html; do
+  [ -e "$f" ] || continue
+  tmp=$(mktemp)
+  "$CASCADE" apply --minimal "$f" > "$tmp" 2>/dev/null
+  check "real $(basename "$f") minimal" "$f" "$tmp"
+  rm -f "$tmp"
+done
 exit $fail

--- a/test/inline/xtest.js
+++ b/test/inline/xtest.js
@@ -8,12 +8,29 @@ const EXTRACTOR = '<script>(function(){var s=' + JSON.stringify(SKIP) +
   // real properties, which are already resolved and compared below.
   'var c=getComputedStyle(x),r={_tag:x.tagName};for(var j=0;j<c.length;j++){var p=c[j];if(p.indexOf("--")===0)continue;r[p]=c.getPropertyValue(p);}o.push(r);}' +
   'document.body.setAttribute("data-xtest",btoa(unescape(encodeURIComponent(JSON.stringify(o)))));})();</script>';
+// Rendering has to be a pure function of the page: a computed style that
+// depends on when the network gave up, how wide the window is or what the
+// display scale is makes the difference list change run to run. The pages
+// themselves are frozen by freeze_page.js at fetch time; these pin the browser.
+//   host-resolver-rules   nothing resolves, so a stray remote URL fails at once
+//   window-size, scale    viewport units and device pixels are fixed
+//   hide-scrollbars       a scrollbar does not eat viewport width
+const FLAGS = '--headless --disable-gpu --no-sandbox' +
+  ' --host-resolver-rules="MAP * ~NOTFOUND" --window-size=1280,900' +
+  ' --force-device-scale-factor=1 --hide-scrollbars --virtual-time-budget=4000';
 function computed(path){
-  let h = fs.readFileSync(path,'utf8');
-  h = h.includes('</body>') ? h.replace('</body>', EXTRACTOR+'</body>') : h+EXTRACTOR;
-  const tmp = '/tmp/xt_'+path.replace(/\W/g,'_')+'.html';
+  // Appended, not spliced in at </body>: a page can carry that text inside an
+  // attribute value (wikipedia's CSS article quotes a whole HTML document in
+  // one), and splicing there puts the extractor somewhere it never runs. The
+  // parser reparents trailing content into the body, so the end of the file
+  // reaches the same place.
+  const h = fs.readFileSync(path,'utf8') + EXTRACTOR;
+  const tmp = '/tmp/xt_'+process.pid+'_'+path.replace(/\W/g,'_')+'.html';
   fs.writeFileSync(tmp,h);
-  const dom = execSync(`"${CHROME}" --headless --disable-gpu --no-sandbox --virtual-time-budget=2000 --dump-dom "file://${tmp}"`,{encoding:'utf8',maxBuffer:1e8});
+  // Chrome's stderr is console chatter from the page (a blocked preload, a
+  // CORS notice); dropping it keeps a caller's failure report readable. A
+  // browser that fails outright still shows up: there is no data-xtest.
+  const dom = execSync(`"${CHROME}" ${FLAGS} --dump-dom "file://${tmp}"`,{encoding:'utf8',maxBuffer:1e8,stdio:['ignore','pipe','ignore']});
   const m = dom.match(/data-xtest="([^"]*)"/);
   if(!m) throw new Error('no data-xtest for '+path);
   return JSON.parse(Buffer.from(m[1],'base64').toString('utf8'));
@@ -38,4 +55,5 @@ const diffs = lines.map(l=>{const f=l.split('\t');return '['+f[0]+' '+f[1]+'] '+
 if (a.length !== b.length) diffs.unshift('element count '+a.length+' vs '+b.length);
 console.log('visual elements: '+n+', computed props/elem: ~'+Object.keys(a[0]||{}).length+(CANON?' (canonical compare)':''));
 if (!diffs.length) console.log('RESULT: IDENTICAL computed styles (inlining preserves the render)');
-else { console.log('RESULT: '+diffs.length+' difference(s):'); diffs.slice(0,40).forEach(d=>console.log('  '+d)); }
+// The whole list, not a sample: it is the artifact you diff between runs.
+else { console.log('RESULT: '+diffs.length+' difference(s):'); diffs.forEach(d=>console.log('  '+d)); }


### PR DESCRIPTION
The differential test measured each page while its scripts, web fonts and images were still resolving, so one unchanged comparison returned 14, 410, 14 and 14 differences over four runs; `fetch.sh` now freezes every page it downloads and `xtest.js` pins the browser, and the fetched pages gate the run instead of only reporting a count. That leaves `ocaml.html` and `tailwind.html` failing on current main, both from `cascade apply` defects that are now measurable rather than noise, and #346 clears the tailwind one.