### PR TITLE
properties: keep the author's digits on a registered <number>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -176,6 +176,10 @@
   `.428571em`, which is `5.99999px` rather than `6px` at a `14px` font size, and
   `999999999px` came out a pixel wider. The six-figure budget now belongs to the
   fold that computes a value, so `calc(2px * pi)` is still `6.28319px` (#350)
+- A `--name` registered by `@property` as a `<number>` keeps the digits it was
+  written with: `--n: 1.4285714` came out as `1.42857`. The six-figure budget
+  stays on the `calc()` the printer folds itself, so `calc(1 / 3)` is still
+  `.333333` (#354)
 - An empty `@layer name` inside a style rule keeps its block form. The
   statement form is a layer-order declaration, which no style rule accepts, so
   `.a { @layer n {} }` minified to `.a{@layer n;}`, which neither a browser nor

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2038,12 +2038,14 @@ let try_read_custom_time components =
   read_custom_value_as Duration read_duration components
 
 let pp_number_value ctx (value : number) =
-  let pp_rounded f = Pp.float ctx (Pp.round_sig 6 f) in
   match value with
-  | Num f when Pp.minified ctx -> pp_rounded f
   | Calc c when Pp.minified ctx -> (
+      (* [eval_numeric_calc] is Cascade's own arithmetic, so its result takes
+         the six significant figures Cascade commits to in serialised output. An
+         authored coefficient is the author's digits and keeps every one of
+         them, so it falls through to [pp_number]. *)
       match eval_numeric_calc c with
-      | Some f -> pp_rounded f
+      | Some f -> Pp.float ctx (Pp.round_sig 6 f)
       | None -> pp_number ctx (Calc (eval_calc c)))
   | _ -> pp_number ctx value
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6889,6 +6889,23 @@ let authored_precision_preserved () =
     | Ok parsed -> minify parsed.stylesheet
     | Error _ -> Alcotest.failf "failed to parse: %s" css
   in
+  (* An [@property --n] registration, and the minified form it prints as, so the
+     [--n] declaration under it is read as a typed [<number>]. *)
+  let registered decl =
+    String.concat ""
+      [
+        "@property --n { syntax: \"<number>\"; inherits: false; initial-value: \
+         0 }";
+        decl;
+      ]
+  in
+  let registered_min decl =
+    String.concat ""
+      [
+        "@property --n{syntax:\"<number>\";inherits:false;initial-value:0}";
+        decl;
+      ]
+  in
   List.iter
     (fun (name, input, expected) ->
       Alcotest.(check string) name expected (normalize input);
@@ -6931,6 +6948,30 @@ let authored_precision_preserved () =
       ( "authored opacity keeps its digits",
         ".x { opacity: .12345678 }",
         ".x{opacity:.12345678}" );
+      ( "authored unregistered custom property keeps its digits",
+        ".x { --raw: 1.4285714 }",
+        ".x{--raw:1.4285714}" );
+      (* CSS Properties and Values API 1 sec. 2: an [@property] registration
+         lifts a [--name] use into the typed [<number>] shape, which must not
+         change the author's digits either. *)
+      ( "registered <number> keeps its digits",
+        registered ".x { --n: 1.4285714 }",
+        registered_min ".x{--n:1.4285714}" );
+      ( "registered <number> keeps its magnitude",
+        registered ".x { --n: 999999999999 }",
+        registered_min ".x{--n:999999999999}" );
+      ( "registered <number> shortens the fold the printer runs",
+        registered ".x { --n: calc(1 / 3) }",
+        registered_min ".x{--n:.333333}" );
+      (* A [calc()] the optimizer already collapsed reaches the printer as a
+         bare coefficient, where the registered shape has to print what an
+         untyped [<number>] prints. *)
+      ( "registered <number> prints a collapsed fold like an untyped one",
+        registered ".x { --n: calc(2 * pi) }",
+        registered_min ".x{--n:6.28318531}" );
+      ( "untyped <number> prints the same collapsed fold",
+        ".x { line-height: calc(2 * pi) }",
+        ".x{line-height:6.28318531}" );
     ]
 
 let v4107_mod_rem () =


### PR DESCRIPTION
`--n: 1.4285714` under an `@property` registration of `syntax: "<number>"` printed as `--n:1.42857` with `--minify`, silently moving a value the author wrote. The six-figure budget stays on the `calc()` the printer folds itself, so `calc(1 / 3)` is still `.333333`.

Stacked on #350.