### PR TITLE
stylesheet: keep an unchanged statement when a map changes nothing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -165,6 +165,10 @@
 - `Css.Stylesheet.map_statement_children` and `map_statement_declarations`
   rebuild a statement with a function applied to the block or the declarations
   it holds, the rebuilding counterparts of the two readers (#337)
+- `Css.Stylesheet.map_statement_children` and `map_statement_declarations`
+  return the very statement they were given when the function they run leaves
+  every list physically unchanged. A pass that short-circuits on physical
+  equality can now call them instead of hand-rolling its own walk (#355)
 
 ### CLI tools
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -520,118 +520,6 @@ let apply_property_duplication (stylesheet : t) : t =
   in
   apply_to_statements stylesheet
 
-let map_statement_block_preserve f stmt =
-  let map block = list_map_preserve f block in
-  match stmt with
-  | Layer (name, block) ->
-      let block' = map block in
-      if block' == block then stmt else Layer (name, block')
-  | Media (m, block) ->
-      let block' = map block in
-      if block' == block then stmt else Media (m, block')
-  | Container (n, c, block) ->
-      let block' = map block in
-      if block' == block then stmt else Container (n, c, block')
-  | Supports (s, block) ->
-      let block' = map block in
-      if block' == block then stmt else Supports (s, block')
-  | Moz_document (c, block) ->
-      let block' = map block in
-      if block' == block then stmt else Moz_document (c, block')
-  | When (c, block) ->
-      let block' = map block in
-      if block' == block then stmt else When (c, block')
-  | Else (c, block) ->
-      let block' = map block in
-      if block' == block then stmt else Else (c, block')
-  | Starting_style block ->
-      let block' = map block in
-      if block' == block then stmt else Starting_style block'
-  | Origin (o, block) ->
-      let block' = map block in
-      if block' == block then stmt else Origin (o, block')
-  | Scope (a, b, block) ->
-      let block' = map block in
-      if block' == block then stmt else Scope (a, b, block')
-  | _ -> stmt
-
-let iter_statement_block f stmt =
-  match stmt with
-  | Layer (_, block)
-  | Media (_, block)
-  | Container (_, _, block)
-  | Supports (_, block)
-  | Moz_document (_, block)
-  | When (_, block)
-  | Else (_, block)
-  | Starting_style block
-  | Origin (_, block)
-  | Scope (_, _, block) ->
-      List.iter f block
-  | _ -> ()
-
-(* The declaration counterpart of [map_statement_block_preserve]: rebuild [stmt]
-   with [f] applied to each declaration list it holds itself, leaving the
-   statements it wraps to that function. Every arm is listed rather than closed
-   with a wildcard, so an at-rule that grows a declaration list has to be
-   classified here before it compiles instead of quietly escaping the passes
-   built on this. Descriptor at-rules ([@font-face], [@counter-style], ...) hold
-   descriptor values rather than declarations, so they pass through.
-   {!Stylesheet.map_statement_declarations} classifies the same arms but
-   rebuilds every statement it is handed, which would cost this pass the
-   physical-equality short-circuit the rest of the optimizer runs on. *)
-let map_statement_declarations_preserve f stmt =
-  let frames =
-    list_map_preserve (fun (frame : keyframe) ->
-        let declarations = f frame.declarations in
-        if declarations == frame.declarations then frame
-        else { frame with declarations })
-  in
-  match stmt with
-  | Rule rule ->
-      let declarations = f rule.declarations in
-      if declarations == rule.declarations then stmt
-      else Rule { rule with declarations }
-  | Declarations decls ->
-      let decls' = f decls in
-      if decls' == decls then stmt else Declarations decls'
-  | Page (selector, decls) ->
-      let decls' = f decls in
-      if decls' == decls then stmt else Page (selector, decls')
-  | Position_try (name, decls) ->
-      let decls' = f decls in
-      if decls' == decls then stmt else Position_try (name, decls')
-  | Supports_condition (name, decls) ->
-      let decls' = f decls in
-      if decls' == decls then stmt else Supports_condition (name, decls')
-  | Page_with_margins (selector, descriptors, margins) ->
-      let descriptors' = f descriptors in
-      let margins' =
-        list_map_preserve
-          (fun (margin : page_margin_rule) ->
-            let descriptors = f margin.descriptors in
-            if descriptors == margin.descriptors then margin
-            else { margin with descriptors })
-          margins
-      in
-      if descriptors' == descriptors && margins' == margins then stmt
-      else Page_with_margins (selector, descriptors', margins')
-  | Keyframes (name, fs) ->
-      let fs' = frames fs in
-      if fs' == fs then stmt else Keyframes (name, fs')
-  | Webkit_keyframes (name, fs) ->
-      let fs' = frames fs in
-      if fs' == fs then stmt else Webkit_keyframes (name, fs')
-  | Moz_keyframes (name, fs) ->
-      let fs' = frames fs in
-      if fs' == fs then stmt else Moz_keyframes (name, fs')
-  | Property _ | Bang_comment _ | Charset _ | Import _ | Namespace _
-  | Layer_decl _ | Layer _ | Media _ | Container _ | Supports _ | Moz_document _
-  | When _ | Else _ | Starting_style _ | Origin _ | Scope _ | Font_face _
-  | Counter_style _ | Font_palette_values _ | Font_feature_values _
-  | View_transition _ | Viewport _ | Unknown_at_rule _ ->
-      stmt
-
 (** [drop_invalid] walks every declaration list in the stylesheet (rules, bare
     nesting blocks, [@keyframes] frames, [@page] and its margin boxes,
     [@position-try], [@supports-condition]) and removes declarations whose typed
@@ -641,13 +529,13 @@ let drop_invalid (stylesheet : t) : t =
     list_filter_preserve (fun d -> not (Declaration.is_invalid d))
   in
   let rec statement stmt =
-    let stmt = map_statement_declarations_preserve filter_decls stmt in
+    let stmt = map_statement_declarations filter_decls stmt in
     match stmt with
     | Rule rule ->
         let nested = list_map_preserve statement rule.nested in
         let rule' = rule_with_nested rule nested in
         if rule' == rule then stmt else Rule rule'
-    | stmt -> map_statement_block_preserve statement stmt
+    | stmt -> map_statement_children (list_map_preserve statement) stmt
   in
   list_map_preserve statement stylesheet
 
@@ -780,8 +668,7 @@ let promote_registered_custom_properties ~lossless (stmts : statement list) =
     match stmt with
     | Property pr ->
         Hashtbl.replace registry pr.name (Variables.Syntax pr.syntax)
-    | Rule r -> List.iter collect_stmt r.nested
-    | _ -> iter_statement_block collect_stmt stmt
+    | _ -> List.iter collect_stmt (statement_children stmt)
   in
   List.iter collect_stmt stmts;
   let promote_decls =
@@ -791,13 +678,13 @@ let promote_registered_custom_properties ~lossless (stmts : statement list) =
      typed wherever it is written: through the declaration walker rather than a
      list of the at-rules that came to mind. *)
   let rec walk_stmt (stmt : statement) : statement =
-    let stmt = map_statement_declarations_preserve promote_decls stmt in
+    let stmt = map_statement_declarations promote_decls stmt in
     match stmt with
     | Rule r ->
         let nested = list_map_preserve walk_stmt r.nested in
         let r' = rule_with_nested r nested in
         if r' == r then stmt else Rule r'
-    | stmt -> map_statement_block_preserve walk_stmt stmt
+    | stmt -> map_statement_children (list_map_preserve walk_stmt) stmt
   in
   list_map_preserve walk_stmt stmts
 
@@ -812,10 +699,7 @@ let canonicalize_declaration_order stmts =
         let nested = list_map_preserve walk_stmt r.nested in
         let r' = rule_with_declarations_and_nested r declarations nested in
         if r' == r then stmt else Rule r'
-    | Media _ | Container _ | Supports _ | Layer _ | Origin _ | Scope _
-    | Starting_style _ | Moz_document _ | When _ | Else _ ->
-        map_statement_block_preserve walk_stmt stmt
-    | _ -> stmt
+    | stmt -> map_statement_children (list_map_preserve walk_stmt) stmt
   in
   list_map_preserve walk_stmt stmts
 
@@ -903,7 +787,7 @@ let prune_position_try_fallbacks ~scope (stylesheet : t) : t =
             if decls' == decls then stmt else Declarations decls'
         | Layer _ | Media _ | Container _ | Supports _ | Moz_document _ | When _
         | Else _ | Starting_style _ | Origin _ | Scope _ ->
-            map_statement_block_preserve walk stmt
+            map_statement_children (list_map_preserve walk) stmt
         | Page (sel, decls) ->
             let decls' = prune_decls decls in
             if decls' == decls then stmt else Page (sel, decls')
@@ -981,8 +865,7 @@ let single_valued_calc_ctx (stmts : statement list) : Values.calc_ctx =
     | Property pr ->
         if syntax_is_single_valued pr.syntax then
           Hashtbl.replace tbl (bare pr.name) ()
-    | Rule r -> List.iter collect r.nested
-    | _ -> iter_statement_block collect stmt
+    | _ -> List.iter collect (statement_children stmt)
   in
   List.iter collect stmts;
   { Values.var_is_single_valued = (fun name -> Hashtbl.mem tbl name) }
@@ -1092,9 +975,9 @@ let rec statement_rule_count = function
   | Rule _ -> 1
   | stmt ->
       let count = ref 0 in
-      iter_statement_block
+      List.iter
         (fun stmt -> count := !count + statement_rule_count stmt)
-        stmt;
+        (statement_children stmt);
       !count
 
 let stylesheet_rule_count stmts =
@@ -1179,7 +1062,7 @@ let drop_unused_custom_props (stmts : statement list) : statement list =
     | Declarations decls ->
         let decls' = list_filter_preserve keep_decl decls in
         if decls' == decls then stmt else Declarations decls'
-    | _ -> map_statement_block_preserve prune stmt
+    | _ -> map_statement_children (list_map_preserve prune) stmt
   in
   list_map_preserve prune stmts
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -308,61 +308,109 @@ let statement_declarations = function
    written on [statement_children] and [statement_declarations] alone; one that
    rewrites the tree needs to put the result back, and hand-rolling that half is
    how a block at-rule ends up read but not written. Exhaustive for the same
-   reason as the readers. *)
-let map_statement_children f = function
-  | Rule rule -> Rule { rule with nested = f rule.nested }
-  | Layer (name, block) -> Layer (name, f block)
-  | Media (query, block) -> Media (query, f block)
-  | Container (name, query, block) -> Container (name, query, f block)
-  | Supports (condition, block) -> Supports (condition, f block)
-  | Moz_document (condition, block) -> Moz_document (condition, f block)
-  | When (condition, block) -> When (condition, f block)
-  | Else (condition, block) -> Else (condition, f block)
-  | Starting_style block -> Starting_style (f block)
-  | Origin (origin, block) -> Origin (origin, f block)
-  | Scope (start, end_, block) -> Scope (start, end_, f block)
-  | ( Property _ | Declarations _ | Bang_comment _ | Charset _ | Import _
-    | Namespace _ | Layer_decl _ | Supports_condition _ | Keyframes _
-    | Webkit_keyframes _ | Moz_keyframes _ | Font_face _ | Counter_style _
-    | Page _ | Page_with_margins _ | Font_palette_values _
-    | Font_feature_values _ | View_transition _ | Position_try _ | Viewport _
-    | Unknown_at_rule _ ) as stmt ->
+   reason as the readers.
+
+   Both preserve physical identity: a statement whose lists [f] returns
+   physically unchanged is returned itself rather than rebuilt, so a pass built
+   on them keeps the subtree sharing its fixed point converges on. That only
+   pays off when [f] preserves identity too. *)
+let map_statement_children f stmt =
+  match stmt with
+  | Rule rule ->
+      let nested = f rule.nested in
+      if nested == rule.nested then stmt else Rule { rule with nested }
+  | Layer (name, block) ->
+      let block' = f block in
+      if block' == block then stmt else Layer (name, block')
+  | Media (query, block) ->
+      let block' = f block in
+      if block' == block then stmt else Media (query, block')
+  | Container (name, query, block) ->
+      let block' = f block in
+      if block' == block then stmt else Container (name, query, block')
+  | Supports (condition, block) ->
+      let block' = f block in
+      if block' == block then stmt else Supports (condition, block')
+  | Moz_document (condition, block) ->
+      let block' = f block in
+      if block' == block then stmt else Moz_document (condition, block')
+  | When (condition, block) ->
+      let block' = f block in
+      if block' == block then stmt else When (condition, block')
+  | Else (condition, block) ->
+      let block' = f block in
+      if block' == block then stmt else Else (condition, block')
+  | Starting_style block ->
+      let block' = f block in
+      if block' == block then stmt else Starting_style block'
+  | Origin (origin, block) ->
+      let block' = f block in
+      if block' == block then stmt else Origin (origin, block')
+  | Scope (start, end_, block) ->
+      let block' = f block in
+      if block' == block then stmt else Scope (start, end_, block')
+  | Property _ | Declarations _ | Bang_comment _ | Charset _ | Import _
+  | Namespace _ | Layer_decl _ | Supports_condition _ | Keyframes _
+  | Webkit_keyframes _ | Moz_keyframes _ | Font_face _ | Counter_style _
+  | Page _ | Page_with_margins _ | Font_palette_values _ | Font_feature_values _
+  | View_transition _ | Position_try _ | Viewport _ | Unknown_at_rule _ ->
       stmt
 
 let map_frame_declarations f frames =
-  List.map
+  Common.List.map_preserve
     (fun (frame : keyframe) ->
-      { frame with declarations = f frame.declarations })
+      let declarations = f frame.declarations in
+      if declarations == frame.declarations then frame
+      else { frame with declarations })
     frames
 
 (* [f] sees each declaration list the statement holds as its own list, not the
    concatenation [statement_declarations] returns: the frames of [@keyframes]
    and the margin rules of [@page] each keep their own block. *)
-let map_statement_declarations f = function
-  | Rule rule -> Rule { rule with declarations = f rule.declarations }
-  | Declarations decls -> Declarations (f decls)
-  | Supports_condition (name, decls) -> Supports_condition (name, f decls)
-  | Page (selector, decls) -> Page (selector, f decls)
-  | Position_try (name, decls) -> Position_try (name, f decls)
-  | Keyframes (name, frames) -> Keyframes (name, map_frame_declarations f frames)
+let map_statement_declarations f stmt =
+  match stmt with
+  | Rule rule ->
+      let declarations = f rule.declarations in
+      if declarations == rule.declarations then stmt
+      else Rule { rule with declarations }
+  | Declarations decls ->
+      let decls' = f decls in
+      if decls' == decls then stmt else Declarations decls'
+  | Supports_condition (name, decls) ->
+      let decls' = f decls in
+      if decls' == decls then stmt else Supports_condition (name, decls')
+  | Page (selector, decls) ->
+      let decls' = f decls in
+      if decls' == decls then stmt else Page (selector, decls')
+  | Position_try (name, decls) ->
+      let decls' = f decls in
+      if decls' == decls then stmt else Position_try (name, decls')
+  | Keyframes (name, frames) ->
+      let frames' = map_frame_declarations f frames in
+      if frames' == frames then stmt else Keyframes (name, frames')
   | Webkit_keyframes (name, frames) ->
-      Webkit_keyframes (name, map_frame_declarations f frames)
+      let frames' = map_frame_declarations f frames in
+      if frames' == frames then stmt else Webkit_keyframes (name, frames')
   | Moz_keyframes (name, frames) ->
-      Moz_keyframes (name, map_frame_declarations f frames)
+      let frames' = map_frame_declarations f frames in
+      if frames' == frames then stmt else Moz_keyframes (name, frames')
   | Page_with_margins (selector, descriptors, margins) ->
-      Page_with_margins
-        ( selector,
-          f descriptors,
-          List.map
-            (fun (margin : page_margin_rule) ->
-              { margin with descriptors = f margin.descriptors })
-            margins )
-  | ( Property _ | Bang_comment _ | Charset _ | Import _ | Namespace _
-    | Layer_decl _ | Layer _ | Media _ | Container _ | Supports _
-    | Moz_document _ | When _ | Else _ | Starting_style _ | Origin _ | Scope _
-    | Font_face _ | Counter_style _ | Font_palette_values _
-    | Font_feature_values _ | View_transition _ | Viewport _ | Unknown_at_rule _
-      ) as stmt ->
+      let descriptors' = f descriptors in
+      let margins' =
+        Common.List.map_preserve
+          (fun (margin : page_margin_rule) ->
+            let descriptors = f margin.descriptors in
+            if descriptors == margin.descriptors then margin
+            else { margin with descriptors })
+          margins
+      in
+      if descriptors' == descriptors && margins' == margins then stmt
+      else Page_with_margins (selector, descriptors', margins')
+  | Property _ | Bang_comment _ | Charset _ | Import _ | Namespace _
+  | Layer_decl _ | Layer _ | Media _ | Container _ | Supports _ | Moz_document _
+  | When _ | Else _ | Starting_style _ | Origin _ | Scope _ | Font_face _
+  | Counter_style _ | Font_palette_values _ | Font_feature_values _
+  | View_transition _ | Viewport _ | Unknown_at_rule _ ->
       stmt
 
 (** {1 Pretty Printing} *)

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -245,7 +245,9 @@ val map_statement_children : (block -> block) -> statement -> statement
 (** [map_statement_children f stmt] rebuilds [stmt] with [f] applied to the
     block {!statement_children} reads, and returns a statement that holds no
     block unchanged. It is the rebuilding counterpart of {!statement_children},
-    for a walk that rewrites the tree rather than only reading it. *)
+    for a walk that rewrites the tree rather than only reading it. It preserves
+    physical identity: when [f] returns the block it was given, the result is
+    [stmt] itself. *)
 
 val map_statement_declarations :
   (declaration list -> declaration list) -> statement -> statement
@@ -254,7 +256,8 @@ val map_statement_declarations :
     unchanged. It is the rebuilding counterpart of {!statement_declarations},
     with one difference: [f] sees each declaration list as its own list rather
     than the concatenation, so every frame of [@keyframes] and every margin rule
-    of [@page] keeps its own block. *)
+    of [@page] keeps its own block. It preserves physical identity: when [f]
+    returns every list it was given, the result is [stmt] itself. *)
 
 (** {1 Reading/Parsing} *)
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -7834,4 +7834,63 @@ let additional_tests =
         | _ -> Alcotest.fail "expected one warning" );
   ]
 
-let suite = ("stylesheet", stylesheet_tests @ additional_tests)
+(* Every shape a statement can take, so the walkers are exercised on the block
+   at-rules and on the at-rules that hold declarations outside a block. *)
+let every_statement_shape =
+  "@charset \"utf-8\";\n\
+   @import url(a.css);\n\
+   @namespace svg url(http://www.w3.org/2000/svg);\n\
+   @property --p { syntax: \"<color>\"; inherits: false; initial-value: red }\n\
+   @layer base, theme;\n\
+   @layer base { .a { color: red; & .b { color: blue } } }\n\
+   @media print { .c { color: red } }\n\
+   @container card (width > 10px) { .d { color: red } }\n\
+   @supports (display: grid) { .e { color: red } }\n\
+   @-moz-document url-prefix(\"http://x\") { .f { color: red } }\n\
+   @starting-style { .g { color: red } }\n\
+   @scope (.h) to (.i) { .j { color: red } }\n\
+   @keyframes k { from { color: red } to { color: blue } }\n\
+   @-webkit-keyframes wk { from { color: red } }\n\
+   @font-face { font-family: F; src: url(f.woff2) }\n\
+   @counter-style cs { system: cyclic; symbols: a }\n\
+   @page { margin: 1cm }\n\
+   @page :first { margin: 1cm; @top-left { content: \"x\" } }\n\
+   @font-palette-values --fp { font-family: F }\n\
+   @view-transition { navigation: auto }\n\
+   @position-try --pt { top: 1px }\n\
+   @viewport { width: device-width }\n\
+   .k { color: red }\n"
+
+let parse_shapes () =
+  match Css.of_string every_statement_shape with
+  | Ok { Css.stylesheet; _ } -> stylesheet
+  | Error err ->
+      Alcotest.failf "shape corpus did not parse: %s"
+        (Cascade.Error.to_string err)
+
+let walker_tests =
+  [
+    ( "map_statement_children keeps an unchanged statement",
+      `Quick,
+      fun () ->
+        (* A rewriting walk short-circuits on physical equality, so a map that
+           reallocates a statement it did not change costs the caller the
+           sharing its fixed point converges on. *)
+        List.iter
+          (fun stmt ->
+            if not (map_statement_children Fun.id stmt == stmt) then
+              Alcotest.failf "children map rebuilt %s"
+                (Css.to_string ~minify:true [ stmt ]))
+          (parse_shapes ()) );
+    ( "map_statement_declarations keeps an unchanged statement",
+      `Quick,
+      fun () ->
+        List.iter
+          (fun stmt ->
+            if not (map_statement_declarations Fun.id stmt == stmt) then
+              Alcotest.failf "declaration map rebuilt %s"
+                (Css.to_string ~minify:true [ stmt ]))
+          (parse_shapes ()) );
+  ]
+
+let suite = ("stylesheet", stylesheet_tests @ additional_tests @ walker_tests)


### PR DESCRIPTION
`Css.Stylesheet.map_statement_children` and `map_statement_declarations` used to rebuild every statement they were handed; now they return the statement itself when the function they run leaves every list physically unchanged, which is what the optimizer needs to call them at all. It had grown a private copy of both walkers to keep that sharing, and this deletes it. Stacked on #349.