### PR TITLE
stylesheet: reach every statement and declaration from one walk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -169,6 +169,12 @@
   return the very statement they were given when the function they run leaves
   every list physically unchanged. A pass that short-circuits on physical
   equality can now call them instead of hand-rolling its own walk (#355)
+- `Css.Stylesheet.fold_statements`, `iter_statements`, `fold_declarations`,
+  `iter_declarations` and `map_declarations` walk a whole block: every statement
+  a rule nests, and every declaration an at-rule holds outside a block. The
+  declaration walks take `?sites` to name the places a narrow walk wants, so a
+  place added to `declaration_sites` stops every walk that made a choice from
+  compiling (#356)
 
 ### CLI tools
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -413,6 +413,82 @@ let map_statement_declarations f stmt =
   | View_transition _ | Viewport _ | Unknown_at_rule _ ->
       stmt
 
+(* Where in a stylesheet a declaration sits. This is the one classification of
+   the declaration-carrying statements: [statement_declarations] extracts the
+   lists, this says what they are, and the walks below filter on it. Exhaustive
+   for the same reason as the extractors. *)
+type declaration_site =
+  | No_declarations
+  | Element_rule
+  | Animation_frame
+  | Page_box
+  | Position_fallback
+  | Condition_test
+
+let declaration_site = function
+  | Rule _ | Declarations _ -> Element_rule
+  | Keyframes _ | Webkit_keyframes _ | Moz_keyframes _ -> Animation_frame
+  | Page _ | Page_with_margins _ -> Page_box
+  | Position_try _ -> Position_fallback
+  | Supports_condition _ -> Condition_test
+  | Property _ | Bang_comment _ | Charset _ | Import _ | Namespace _
+  | Layer_decl _ | Layer _ | Media _ | Container _ | Supports _ | Moz_document _
+  | When _ | Else _ | Starting_style _ | Origin _ | Scope _ | Font_face _
+  | Counter_style _ | Font_palette_values _ | Font_feature_values _
+  | View_transition _ | Viewport _ | Unknown_at_rule _ ->
+      No_declarations
+
+type declaration_sites = {
+  element_rule : bool;
+  animation_frame : bool;
+  page_box : bool;
+  position_fallback : bool;
+  condition_test : bool;
+}
+
+let every_site =
+  {
+    element_rule = true;
+    animation_frame = true;
+    page_box = true;
+    position_fallback = true;
+    condition_test = true;
+  }
+
+let site_selected sites = function
+  | No_declarations -> false
+  | Element_rule -> sites.element_rule
+  | Animation_frame -> sites.animation_frame
+  | Page_box -> sites.page_box
+  | Position_fallback -> sites.position_fallback
+  | Condition_test -> sites.condition_test
+
+let rec fold_statements f acc block =
+  List.fold_left
+    (fun acc stmt -> fold_statements f (f acc stmt) (statement_children stmt))
+    acc block
+
+let iter_statements f block = fold_statements (fun () stmt -> f stmt) () block
+
+let fold_declarations ?(sites = every_site) f acc block =
+  fold_statements
+    (fun acc stmt ->
+      if site_selected sites (declaration_site stmt) then
+        f acc (statement_declarations stmt)
+      else acc)
+    acc block
+
+let iter_declarations ?sites f block =
+  fold_declarations ?sites (fun () decls -> f decls) () block
+
+let map_declarations f block =
+  let rec statement stmt =
+    map_statement_children
+      (Common.List.map_preserve statement)
+      (map_statement_declarations f stmt)
+  in
+  Common.List.map_preserve statement block
+
 (** {1 Pretty Printing} *)
 
 let pp_property_rule : 'a property_rule Pp.t =

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -259,6 +259,65 @@ val map_statement_declarations :
     of [@page] keeps its own block. It preserves physical identity: when [f]
     returns every list it was given, the result is [stmt] itself. *)
 
+type declaration_sites = {
+  element_rule : bool;
+      (** A style rule or a bare nesting block: declarations that apply to an
+          element. *)
+  animation_frame : bool;
+      (** A frame of [@keyframes] (and of its [-webkit-] / [-moz-] spellings):
+          declarations in the animation origin. *)
+  page_box : bool;
+      (** [@page] and its margin boxes: declarations that apply to a page box
+          rather than to an element. *)
+  position_fallback : bool;
+      (** [@position-try]: declarations in the position fallback origin. *)
+  condition_test : bool;
+      (** [@supports-condition]: declarations that are tested rather than
+          applied. *)
+}
+(** The places a stylesheet holds declarations, grouped by what the declarations
+    there mean rather than by which at-rule spells them. A walk that wants only
+    some of them says so with this record instead of matching on the statements
+    it expects to meet, which separates a narrow walk from one that forgot an
+    at-rule, and makes a place added here a compile error in every walk that
+    made a choice. *)
+
+val fold_statements : ('a -> statement -> 'a) -> 'a -> block -> 'a
+(** [fold_statements f acc block] folds [f] over [block] and over every
+    statement reachable from it through {!statement_children}, in source order,
+    a statement before the statements it holds. *)
+
+val iter_statements : (statement -> unit) -> block -> unit
+(** [iter_statements f block] applies [f] to every statement {!fold_statements}
+    reaches. *)
+
+val fold_declarations :
+  ?sites:declaration_sites ->
+  ('a -> declaration list -> 'a) ->
+  'a ->
+  block ->
+  'a
+(** [fold_declarations f acc block] folds [f] over the declarations of every
+    statement {!fold_statements} reaches, so a rule nested in a rule and an
+    at-rule that holds declarations outside a block are both covered. [f] sees
+    one statement's declarations at a time, as {!statement_declarations} returns
+    them. [sites] defaults to every place a declaration sits; pass it to fold
+    over some of them, and write the record out in full so that a place added to
+    it does not compile until this walk has been read again. *)
+
+val iter_declarations :
+  ?sites:declaration_sites -> (declaration list -> unit) -> block -> unit
+(** [iter_declarations f block] applies [f] to the declaration lists
+    {!fold_declarations} folds over. *)
+
+val map_declarations : (declaration list -> declaration list) -> block -> block
+(** [map_declarations f block] rewrites the declarations of every statement
+    {!fold_statements} reaches. [f] sees each declaration list as its own list,
+    as {!map_statement_declarations} hands them over, so every frame of
+    [@keyframes] and every margin rule of [@page] keeps its own block. It
+    preserves physical identity: when [f] returns every list it was given, the
+    result is [block] itself. *)
+
 (** {1 Reading/Parsing} *)
 
 val read_rule : ?nested:bool -> Cursor.t -> rule

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -7893,4 +7893,141 @@ let walker_tests =
           (parse_shapes ()) );
   ]
 
-let suite = ("stylesheet", stylesheet_tests @ additional_tests @ walker_tests)
+(* One declaration per place a statement can hold one, each under a property
+   name that names only that place, so a walk that misses a place is a missing
+   name rather than a smaller count. *)
+let every_declaration_place =
+  ".el { color: red }\n\
+   @media print { .m { display: none } }\n\
+   @layer l { .l { float: left } }\n\
+   @container (width > 1px) { .c { clear: both } }\n\
+   @supports (display: grid) { .s { z-index: 1 } }\n\
+   @-moz-document url-prefix(\"x\") { .d { direction: rtl } }\n\
+   @starting-style { .ss { opacity: 0 } }\n\
+   @scope (.a) to (.b) { .sc { visibility: hidden } }\n\
+   @when media(print) { .w { order: 1 } }\n\
+   @else { .e { order: 2 } }\n\
+   .parent { & .nested { overflow: hidden } }\n\
+   @keyframes k { from { rotate: 0deg } }\n\
+   @page { size: a4 }\n\
+   @page :first { @top-left { content: \"tl\" } }\n\
+   @position-try --pt { inset: 1px }\n\
+   @supports-condition --sc { padding: 1px }\n"
+
+let parsed source =
+  match Css.of_string source with
+  | Ok { Css.stylesheet; _ } -> stylesheet
+  | Error err ->
+      Alcotest.failf "declaration-place corpus did not parse: %s"
+        (Cascade.Error.to_string err)
+
+let places () =
+  (* [Origin] has no CSS syntax, so it can only be built. *)
+  parsed every_declaration_place
+  @ [ with_origin Author (parsed ".o { top: 1px }") ]
+
+let properties_folded ?sites () =
+  List.sort compare
+    (fold_declarations ?sites
+       (fun acc decls ->
+         List.rev_append (List.map Css.Declaration.property_name decls) acc)
+       [] (places ()))
+
+let element_places =
+  [
+    "clear";
+    "color";
+    "direction";
+    "display";
+    "float";
+    "opacity";
+    "order";
+    "order";
+    "overflow";
+    "top";
+    "visibility";
+    "z-index";
+  ]
+
+let other_places = [ "content"; "inset"; "padding"; "rotate"; "size" ]
+
+let deep_walker_tests =
+  [
+    ( "fold_declarations reaches every place a declaration sits",
+      `Quick,
+      fun () ->
+        Alcotest.(check (list string))
+          "every property"
+          (List.sort compare (element_places @ other_places))
+          (properties_folded ()) );
+    ( "fold_declarations keeps to the sites it is given",
+      `Quick,
+      fun () ->
+        (* The narrow walk names the places it wants rather than the statements
+           it expects to meet, so leaving one out is a stated choice. *)
+        let sites =
+          {
+            element_rule = true;
+            animation_frame = false;
+            page_box = false;
+            position_fallback = false;
+            condition_test = false;
+          }
+        in
+        Alcotest.(check (list string))
+          "element declarations only"
+          (List.sort compare element_places)
+          (properties_folded ~sites ()) );
+    ( "map_declarations rewrites every place a declaration sits",
+      `Quick,
+      fun () ->
+        let emptied = map_declarations (fun _ -> []) (places ()) in
+        Alcotest.(check (list string))
+          "nothing left" []
+          (fold_declarations
+             (fun acc decls ->
+               List.rev_append
+                 (List.map Css.Declaration.property_name decls)
+                 acc)
+             [] emptied) );
+    ( "map_declarations keeps an unchanged tree",
+      `Quick,
+      fun () ->
+        let block = places () in
+        if not (map_declarations Fun.id block == block) then
+          Alcotest.fail "declaration map rebuilt an unchanged stylesheet" );
+    ( "iter_statements reaches a statement inside every at-rule",
+      `Quick,
+      fun () ->
+        let seen = ref [] in
+        iter_statements
+          (fun stmt ->
+            match stmt with
+            | Rule r ->
+                seen := Selector.to_string ~minify:true r.selector :: !seen
+            | _ -> ())
+          (places ());
+        Alcotest.(check (list string))
+          "every rule"
+          (List.sort compare
+             [
+               ".el";
+               ".m";
+               ".l";
+               ".c";
+               ".s";
+               ".d";
+               ".ss";
+               ".sc";
+               ".w";
+               ".e";
+               ".parent";
+               "& .nested";
+               ".o";
+             ])
+          (List.sort compare !seen) );
+  ]
+
+let suite =
+  ( "stylesheet",
+    stylesheet_tests @ additional_tests @ walker_tests @ deep_walker_tests )


### PR DESCRIPTION
Passes across `lib/` hand-enumerate the statement constructors they descend into, and no two of those lists agree; #341 to #349 each fixed one instance. This PR adds `Css.Stylesheet.fold_statements`, `iter_statements`, `fold_declarations`, `iter_declarations` and `map_declarations`, which reach every statement a rule nests and every declaration an at-rule holds outside a block, and a `declaration_sites` record so a deliberately narrow walk names the places it wants instead of matching on the statements it expects. Stacked on #355.