### PR TITLE
inline: keep a cascade layer order inline_vars cannot decide

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -308,6 +308,13 @@
 
 ### Custom properties
 
+- `Css.inline_vars` resolves a custom property defined across cascade layers
+  against the order every `@layer` in the sheet gives it, counting the ones a
+  rule nests and the ones a `@container`, `@scope` or `@starting-style` block
+  holds. A layer first named inside a conditional group is introduced there only
+  when the condition holds, so the order is not decidable and the layers are
+  left standing rather than folded to a winner (#357)
+
 - `Css.resolve_theme` accounts for the declarations `@keyframes`, `@page`,
   `@position-try` and `@supports-condition` carry. A `var()` referenced only
   from inside one of them keeps its theme binding instead of leaving the name

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -630,19 +630,27 @@ let of_string_exn ?strict ?filename ?meta ?enforce_spec css =
    and its [inherits] descriptor decides whether the property inherits at all.
    Both change computed values, so the registration dies only with the property
    itself - once substitution has left neither a declaration of it nor a [var()]
-   reading it. *)
-let rec statements_for_inline ~live block =
-  List.concat_map (statement_for_inline ~live) block
+   reading it.
 
-and statement_for_inline ~live statement =
+   [keep_layers] leaves the [@layer] wrappers and declarations standing.
+   Dropping them replays the layer stack as document order, which only preserves
+   the cascade once every layered competition has been resolved; when
+   {!Inline.layer_order} cannot say what that order is, none of them has
+   been. *)
+let rec statements_for_inline ~live ~keep_layers block =
+  List.concat_map (statement_for_inline ~live ~keep_layers) block
+
+and statement_for_inline ~live ~keep_layers statement =
+  let inline_block = statements_for_inline ~live ~keep_layers in
   match statement with
-  | Layer (_, block) -> statements_for_inline ~live block
+  | Layer (name, block) when keep_layers -> [ Layer (name, inline_block block) ]
+  | Layer (_, block) -> inline_block block
   | Property rule -> if List.mem rule.name live then [ statement ] else []
+  | Layer_decl _ when keep_layers -> [ statement ]
   (* Every [@layer] wrapper is spliced into its parent above, so the layers an
      [@layer] statement orders no longer exist to be ordered. *)
   | Layer_decl _ -> []
-  | statement ->
-      [ map_statement_children (statements_for_inline ~live) statement ]
+  | statement -> [ map_statement_children inline_block statement ]
 
 (* Pure serialiser: walk the AST and emit CSS, no optimise/theme/inline-vars
    rewriting. Spec recovery (drop invalid declarations, unknown at-rules, empty
@@ -698,7 +706,8 @@ let inline_vars ?keep_vars ?warn stylesheet =
     | Some keep_vars -> Inline.vars ?warn ~keep_vars stylesheet
   in
   let live = Inline.mentioned_custom_names substituted in
-  statements_for_inline ~live substituted
+  let keep_layers = Option.is_none (Inline.layer_order stylesheet) in
+  statements_for_inline ~live ~keep_layers substituted
 
 (* Collect every [var(--name)] reference's name (with leading [--]) from a
    stylesheet. Used by [resolve_theme] to know which names to ask the

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1175,15 +1175,21 @@ let var_census stylesheet =
 (* A variable redefined across cascade layers on the same element is a real
    override, but - unlike an @media or dark-mode override - its winner is
    statically decidable, so it can be folded to that winner instead of kept
-   live. [statements_for_inline] later drops the [@layer] wrappers, which would
-   otherwise leave the losing definitions competing by document order and pick
-   the wrong value. Resolving the winner here keeps the folded value correct. *)
+   live. Resolving the winner here is what lets [statements_for_inline] drop the
+   [@layer] wrappers: flattened, the losing definitions would compete by
+   document order and pick the wrong value. *)
 
 (* Document-order cascade layer names (dotted for nesting), low precedence
-   first: the order in which layers are first introduced. *)
-let stylesheet_layer_order stylesheet =
+   first: the order in which layers are first introduced (css-cascade-5 sec.
+   6.4.2). [None] when a layer sits where cascade cannot place it: a conditional
+   group introduces its layers only when its condition holds, and an [Origin]
+   block carries its own layer stack. What a [@container], [@scope] or
+   [@starting-style] block holds, and what a rule nests, always exists, so a
+   layer named there counts where it is written. *)
+let layer_order stylesheet : string list option =
   let seen = Hashtbl.create 16 in
   let order = ref [] in
+  let undecided = ref false in
   let add name =
     if not (Hashtbl.mem seen name) then begin
       Hashtbl.add seen name ();
@@ -1193,22 +1199,34 @@ let stylesheet_layer_order stylesheet =
   let dotted prefix name =
     if prefix = "" then name else String.concat "." [ prefix; name ]
   in
-  let rec walk prefix = function
-    | [] -> ()
-    | stmt :: rest ->
-        (match stmt with
-        | Stylesheet.Layer_decl names ->
-            List.iter (fun n -> add (dotted prefix n)) names
-        | Stylesheet.Layer (Some n, body) ->
-            let full = dotted prefix n in
-            add full;
-            walk full body
-        | Stylesheet.Layer (None, body) -> walk prefix body
-        | _ -> ());
-        walk prefix rest
+  let rec walk ~placed prefix stmts = List.iter (statement ~placed prefix) stmts
+  and statement ~placed prefix stmt =
+    match stmt with
+    | Stylesheet.Layer_decl names ->
+        if not placed then undecided := true;
+        List.iter (fun n -> add (dotted prefix n)) names
+    | Stylesheet.Layer (name, body) ->
+        if not placed then undecided := true;
+        let prefix =
+          match name with
+          | None -> prefix
+          | Some n ->
+              let full = dotted prefix n in
+              add full;
+              full
+        in
+        walk ~placed prefix body
+    | Stylesheet.Media (_, body)
+    | Stylesheet.Supports (_, body)
+    | Stylesheet.Moz_document (_, body)
+    | Stylesheet.When (_, body)
+    | Stylesheet.Else (_, body)
+    | Stylesheet.Origin (_, body) ->
+        walk ~placed:false prefix body
+    | stmt -> walk ~placed prefix (Stylesheet.statement_children stmt)
   in
-  walk "" stylesheet;
-  List.rev !order
+  walk ~placed:true "" stylesheet;
+  if !undecided then None else Some (List.rev !order)
 
 (* [Some layer] for a purely-layered path ([layer = None] unlayered, [Some name]
    the dotted layer), [None] when the path is conditional or holds an anonymous
@@ -1251,52 +1269,57 @@ let annotate_every_layer entries =
    it resolves to no value). A single scope with repeated declarations is left
    alone: the census already treats it as one inlinable definition. *)
 let layer_decided_customs ~keep stylesheet =
-  let scopes = collect_scopes ~kept:keep stylesheet in
-  let by_name = Hashtbl.create 64 in
-  List.iter
-    (fun (s : scope) ->
-      let sel = Selector.to_string ~minify:true s.selector in
-      let fl = foldable_layer_of_at_path s.at_path in
-      List.iter
-        (fun d ->
-          match custom_name d with
-          | None -> ()
-          | Some name ->
-              let prev =
-                Option.value ~default:[] (Hashtbl.find_opt by_name name)
-              in
-              Hashtbl.replace by_name name ((sel, fl, d) :: prev))
-        s.customs)
-    scopes;
-  let layer_order = stylesheet_layer_order stylesheet in
   let fold = Hashtbl.create 16 in
-  Hashtbl.iter
-    (fun name entries ->
-      let entries = List.rev entries in
-      let unconditional =
-        List.for_all (fun (_, fl, _) -> Option.is_some fl) entries
-      in
-      let one_selector =
-        match entries with
-        | (sel0, _, _) :: rest -> List.for_all (fun (s, _, _) -> s = sel0) rest
-        | [] -> true
-      in
-      let distinct_layers =
-        entries
-        |> List.filter_map (fun (_, fl, _) -> fl)
-        |> List.sort_uniq compare |> List.length
-      in
-      if unconditional && one_selector && distinct_layers >= 2 then
-        match annotate_every_layer entries with
-        | Option.None -> ()
-        | Option.Some annotated -> (
-            match Context.winning_custom_declaration ~layer_order annotated with
-            | Some w ->
-                Hashtbl.replace fold name
-                  (`Value (Declaration.string_of_value ~minify:true w))
-            | None -> Hashtbl.replace fold name `Unset))
-    by_name;
-  fold
+  match layer_order stylesheet with
+  | None -> fold
+  | Some layer_order ->
+      let scopes = collect_scopes ~kept:keep stylesheet in
+      let by_name = Hashtbl.create 64 in
+      List.iter
+        (fun (s : scope) ->
+          let sel = Selector.to_string ~minify:true s.selector in
+          let fl = foldable_layer_of_at_path s.at_path in
+          List.iter
+            (fun d ->
+              match custom_name d with
+              | None -> ()
+              | Some name ->
+                  let prev =
+                    Option.value ~default:[] (Hashtbl.find_opt by_name name)
+                  in
+                  Hashtbl.replace by_name name ((sel, fl, d) :: prev))
+            s.customs)
+        scopes;
+      Hashtbl.iter
+        (fun name entries ->
+          let entries = List.rev entries in
+          let unconditional =
+            List.for_all (fun (_, fl, _) -> Option.is_some fl) entries
+          in
+          let one_selector =
+            match entries with
+            | (sel0, _, _) :: rest ->
+                List.for_all (fun (s, _, _) -> s = sel0) rest
+            | [] -> true
+          in
+          let distinct_layers =
+            entries
+            |> List.filter_map (fun (_, fl, _) -> fl)
+            |> List.sort_uniq compare |> List.length
+          in
+          if unconditional && one_selector && distinct_layers >= 2 then
+            match annotate_every_layer entries with
+            | Option.None -> ()
+            | Option.Some annotated -> (
+                match
+                  Context.winning_custom_declaration ~layer_order annotated
+                with
+                | Some w ->
+                    Hashtbl.replace fold name
+                      (`Value (Declaration.string_of_value ~minify:true w))
+                | None -> Hashtbl.replace fold name `Unset))
+        by_name;
+      fold
 
 (* Replace every layer-decided definition with a single unlayered definition of
    the winner (or drop it entirely when unset), so the census sees one inlinable

--- a/lib/inline.mli
+++ b/lib/inline.mli
@@ -26,6 +26,16 @@ val mentioned_custom_names : Stylesheet.t -> string list
     included), or queried by a [style()] container query. A [@property] body is
     not a mention, so a registration never keeps itself. *)
 
+val layer_order : Stylesheet.t -> string list option
+(** [layer_order stylesheet] is the cascade layer order [stylesheet] declares,
+    weakest first, as one dotted path per layer, or [None] when the order
+    depends on something static analysis cannot settle: a layer first named
+    inside a conditional group is introduced there only when the condition
+    holds, and one named inside an {!Stylesheet.Origin} block belongs to that
+    origin's own stack. This is the order {!vars} resolves a custom property
+    defined across several layers against, and [None] is the answer that stops
+    it. *)
+
 val decode_import_url : string -> string
 (** [decode_import_url s] strips the [url(...)] wrapper and any surrounding
     quotes from an [@import] URL string as held in

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -480,6 +480,22 @@ let test_inline_style_query_keeps_no_more () =
     ":root{--c:red}@container --c (min-width:1px){.z{color:green}}"
     "@container --c (min-width:1px){.z{color:green}}"
 
+(* Layers are ordered by first appearance (CSS Cascade 5 sec. 6.4.2), so where a
+   layer is first named decides which definition of a cross-layer custom
+   property wins. A conditional group only introduces its layers when its
+   condition holds, which cascade cannot decide, while a [@container] block
+   holds rules that always exist and is evaluated per element. *)
+let test_inline_layer_order_sites () =
+  check_inline_case "a layer first named inside @media leaves the order open"
+    "@media screen{@layer b{.z{outline-color:red}}}@layer \
+     a{:root{--c:red}}@layer b{:root{--c:blue}}.x{color:var(--c)}"
+    "@media screen{@layer b{.z{outline-color:red}}}@layer \
+     a{:root{--c:red}}@layer b{:root{--c:blue}}.x{color:var(--c)}";
+  check_inline_case "a layer first named inside @container orders the sheet"
+    "@container (min-width:1px){@layer b{.z{outline-color:red}}}@layer \
+     a{:root{--c:red}}@layer b{:root{--c:blue}}.x{color:var(--c)}"
+    "@container(min-width:1px){.z{outline-color:red}}.x{color:red}"
+
 let suite =
   ( "inline",
     [
@@ -540,4 +556,6 @@ let suite =
         test_inline_style_query_keeps_registration;
       Alcotest.test_case "inline vars keep no more than a style() query reads"
         `Quick test_inline_style_query_keeps_no_more;
+      Alcotest.test_case "inline vars order layers by where they are named"
+        `Quick test_inline_layer_order_sites;
     ] )


### PR DESCRIPTION
`Css.inline_vars` picked the layer order from the top-level `@layer` rules alone, so a layer first named inside `@media`, inside a `@container` or in a rule's nested block was invisible: `@media screen{@layer b{...}}@layer a{:root{--c:red}}@layer b{:root{--c:blue}}` folded `--c` to blue where Chrome renders red. The order now counts every layer whose position is fixed, and a layer named inside a conditional group leaves it undecided, which keeps the `@layer` wrappers instead of flattening them into document order. Stacked on #352.