### PR TITLE
diff: fold a value inside every grouping at-rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -307,6 +307,13 @@
 
 ### Custom properties
 
+- `Css.inline_vars` resolves a custom property defined across cascade layers
+  against the order every `@layer` in the sheet gives it, counting the ones a
+  rule nests and the ones a `@container`, `@scope` or `@starting-style` block
+  holds. A layer first named inside a conditional group is introduced there only
+  when the condition holds, so the order is not decidable and the layers are
+  left standing rather than folded to a winner (#357)
+
 - `Css.resolve_theme` accounts for the declarations `@keyframes`, `@page`,
   `@position-try` and `@supports-condition` carry. A `var()` referenced only
   from inside one of them keeps its theme binding instead of leaving the name

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -396,6 +396,11 @@
 - A complete shadow value in an unregistered custom property types its colour
   slot, so named and hex colours and typed `var()` fallbacks compare
   canonically while non-colour identifiers remain opaque (#314)
+- The projection's value folds reach a declaration inside any grouping at-rule,
+  so two sheets differing only by a custom-property font quoting, an exact
+  `color(srgb ...)` spelling or a `@media not all and (X)` query inside
+  `@-moz-document`, `@scope`, `@starting-style`, `@when`, `@else` or a
+  `@container` no longer compare as different (#360)
 - The projection's value folds reach inside every block at-rule. A quoted
   multi-word family name in a custom property, a whole-byte `color(srgb ...)`
   and the Level 3 `not all and (...)` media spelling folded inside `@layer` and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -276,6 +276,11 @@
   whether a declaration crosses a nested block. The merge order could put the
   rule carrying the nested block last, leaving that check nothing to look at,
   so a nested `@media` won over a later declaration that overrode it (#364)
+- Merging same-selector rules weighs what a nested block sets against a later
+  declaration by cascade slot rather than by property name. A nested
+  `margin: 2rem` and a later `margin-top: 1rem` write one slot under two names,
+  so the merge read them as disjoint, hoisted the longhand ahead of the nested
+  block and handed the shorthand the win (#364)
 - A `font-family` name that cannot be spelled as an identifier keeps its
   quotes. The unquoting guard checked which characters a name is made of but
   not how CSS Syntax 3 sec. 4.3.9 lets an ident sequence start, so `"2Brand"`,

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -630,19 +630,27 @@ let of_string_exn ?strict ?filename ?meta ?enforce_spec css =
    and its [inherits] descriptor decides whether the property inherits at all.
    Both change computed values, so the registration dies only with the property
    itself - once substitution has left neither a declaration of it nor a [var()]
-   reading it. *)
-let rec statements_for_inline ~live block =
-  List.concat_map (statement_for_inline ~live) block
+   reading it.
 
-and statement_for_inline ~live statement =
+   [keep_layers] leaves the [@layer] wrappers and declarations standing.
+   Dropping them replays the layer stack as document order, which only preserves
+   the cascade once every layered competition has been resolved; when
+   {!Inline.layer_order} cannot say what that order is, none of them has
+   been. *)
+let rec statements_for_inline ~live ~keep_layers block =
+  List.concat_map (statement_for_inline ~live ~keep_layers) block
+
+and statement_for_inline ~live ~keep_layers statement =
+  let inline_block = statements_for_inline ~live ~keep_layers in
   match statement with
-  | Layer (_, block) -> statements_for_inline ~live block
+  | Layer (name, block) when keep_layers -> [ Layer (name, inline_block block) ]
+  | Layer (_, block) -> inline_block block
   | Property rule -> if List.mem rule.name live then [ statement ] else []
+  | Layer_decl _ when keep_layers -> [ statement ]
   (* Every [@layer] wrapper is spliced into its parent above, so the layers an
      [@layer] statement orders no longer exist to be ordered. *)
   | Layer_decl _ -> []
-  | statement ->
-      [ map_statement_children (statements_for_inline ~live) statement ]
+  | statement -> [ map_statement_children inline_block statement ]
 
 (* Pure serialiser: walk the AST and emit CSS, no optimise/theme/inline-vars
    rewriting. Spec recovery (drop invalid declarations, unknown at-rules, empty
@@ -698,7 +706,8 @@ let inline_vars ?keep_vars ?warn stylesheet =
     | Some keep_vars -> Inline.vars ?warn ~keep_vars stylesheet
   in
   let live = Inline.mentioned_custom_names substituted in
-  statements_for_inline ~live substituted
+  let keep_layers = Option.is_none (Inline.layer_order stylesheet) in
+  statements_for_inline ~live ~keep_layers substituted
 
 (* Collect every [var(--name)] reference's name (with leading [--]) from a
    stylesheet. Used by [resolve_theme] to know which names to ask the

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1175,15 +1175,21 @@ let var_census stylesheet =
 (* A variable redefined across cascade layers on the same element is a real
    override, but - unlike an @media or dark-mode override - its winner is
    statically decidable, so it can be folded to that winner instead of kept
-   live. [statements_for_inline] later drops the [@layer] wrappers, which would
-   otherwise leave the losing definitions competing by document order and pick
-   the wrong value. Resolving the winner here keeps the folded value correct. *)
+   live. Resolving the winner here is what lets [statements_for_inline] drop the
+   [@layer] wrappers: flattened, the losing definitions would compete by
+   document order and pick the wrong value. *)
 
 (* Document-order cascade layer names (dotted for nesting), low precedence
-   first: the order in which layers are first introduced. *)
-let stylesheet_layer_order stylesheet =
+   first: the order in which layers are first introduced (css-cascade-5 sec.
+   6.4.2). [None] when a layer sits where cascade cannot place it: a conditional
+   group introduces its layers only when its condition holds, and an [Origin]
+   block carries its own layer stack. What a [@container], [@scope] or
+   [@starting-style] block holds, and what a rule nests, always exists, so a
+   layer named there counts where it is written. *)
+let layer_order stylesheet : string list option =
   let seen = Hashtbl.create 16 in
   let order = ref [] in
+  let undecided = ref false in
   let add name =
     if not (Hashtbl.mem seen name) then begin
       Hashtbl.add seen name ();
@@ -1193,22 +1199,34 @@ let stylesheet_layer_order stylesheet =
   let dotted prefix name =
     if prefix = "" then name else String.concat "." [ prefix; name ]
   in
-  let rec walk prefix = function
-    | [] -> ()
-    | stmt :: rest ->
-        (match stmt with
-        | Stylesheet.Layer_decl names ->
-            List.iter (fun n -> add (dotted prefix n)) names
-        | Stylesheet.Layer (Some n, body) ->
-            let full = dotted prefix n in
-            add full;
-            walk full body
-        | Stylesheet.Layer (None, body) -> walk prefix body
-        | _ -> ());
-        walk prefix rest
+  let rec walk ~placed prefix stmts = List.iter (statement ~placed prefix) stmts
+  and statement ~placed prefix stmt =
+    match stmt with
+    | Stylesheet.Layer_decl names ->
+        if not placed then undecided := true;
+        List.iter (fun n -> add (dotted prefix n)) names
+    | Stylesheet.Layer (name, body) ->
+        if not placed then undecided := true;
+        let prefix =
+          match name with
+          | None -> prefix
+          | Some n ->
+              let full = dotted prefix n in
+              add full;
+              full
+        in
+        walk ~placed prefix body
+    | Stylesheet.Media (_, body)
+    | Stylesheet.Supports (_, body)
+    | Stylesheet.Moz_document (_, body)
+    | Stylesheet.When (_, body)
+    | Stylesheet.Else (_, body)
+    | Stylesheet.Origin (_, body) ->
+        walk ~placed:false prefix body
+    | stmt -> walk ~placed prefix (Stylesheet.statement_children stmt)
   in
-  walk "" stylesheet;
-  List.rev !order
+  walk ~placed:true "" stylesheet;
+  if !undecided then None else Some (List.rev !order)
 
 (* [Some layer] for a purely-layered path ([layer = None] unlayered, [Some name]
    the dotted layer), [None] when the path is conditional or holds an anonymous
@@ -1251,52 +1269,57 @@ let annotate_every_layer entries =
    it resolves to no value). A single scope with repeated declarations is left
    alone: the census already treats it as one inlinable definition. *)
 let layer_decided_customs ~keep stylesheet =
-  let scopes = collect_scopes ~kept:keep stylesheet in
-  let by_name = Hashtbl.create 64 in
-  List.iter
-    (fun (s : scope) ->
-      let sel = Selector.to_string ~minify:true s.selector in
-      let fl = foldable_layer_of_at_path s.at_path in
-      List.iter
-        (fun d ->
-          match custom_name d with
-          | None -> ()
-          | Some name ->
-              let prev =
-                Option.value ~default:[] (Hashtbl.find_opt by_name name)
-              in
-              Hashtbl.replace by_name name ((sel, fl, d) :: prev))
-        s.customs)
-    scopes;
-  let layer_order = stylesheet_layer_order stylesheet in
   let fold = Hashtbl.create 16 in
-  Hashtbl.iter
-    (fun name entries ->
-      let entries = List.rev entries in
-      let unconditional =
-        List.for_all (fun (_, fl, _) -> Option.is_some fl) entries
-      in
-      let one_selector =
-        match entries with
-        | (sel0, _, _) :: rest -> List.for_all (fun (s, _, _) -> s = sel0) rest
-        | [] -> true
-      in
-      let distinct_layers =
-        entries
-        |> List.filter_map (fun (_, fl, _) -> fl)
-        |> List.sort_uniq compare |> List.length
-      in
-      if unconditional && one_selector && distinct_layers >= 2 then
-        match annotate_every_layer entries with
-        | Option.None -> ()
-        | Option.Some annotated -> (
-            match Context.winning_custom_declaration ~layer_order annotated with
-            | Some w ->
-                Hashtbl.replace fold name
-                  (`Value (Declaration.string_of_value ~minify:true w))
-            | None -> Hashtbl.replace fold name `Unset))
-    by_name;
-  fold
+  match layer_order stylesheet with
+  | None -> fold
+  | Some layer_order ->
+      let scopes = collect_scopes ~kept:keep stylesheet in
+      let by_name = Hashtbl.create 64 in
+      List.iter
+        (fun (s : scope) ->
+          let sel = Selector.to_string ~minify:true s.selector in
+          let fl = foldable_layer_of_at_path s.at_path in
+          List.iter
+            (fun d ->
+              match custom_name d with
+              | None -> ()
+              | Some name ->
+                  let prev =
+                    Option.value ~default:[] (Hashtbl.find_opt by_name name)
+                  in
+                  Hashtbl.replace by_name name ((sel, fl, d) :: prev))
+            s.customs)
+        scopes;
+      Hashtbl.iter
+        (fun name entries ->
+          let entries = List.rev entries in
+          let unconditional =
+            List.for_all (fun (_, fl, _) -> Option.is_some fl) entries
+          in
+          let one_selector =
+            match entries with
+            | (sel0, _, _) :: rest ->
+                List.for_all (fun (s, _, _) -> s = sel0) rest
+            | [] -> true
+          in
+          let distinct_layers =
+            entries
+            |> List.filter_map (fun (_, fl, _) -> fl)
+            |> List.sort_uniq compare |> List.length
+          in
+          if unconditional && one_selector && distinct_layers >= 2 then
+            match annotate_every_layer entries with
+            | Option.None -> ()
+            | Option.Some annotated -> (
+                match
+                  Context.winning_custom_declaration ~layer_order annotated
+                with
+                | Some w ->
+                    Hashtbl.replace fold name
+                      (`Value (Declaration.string_of_value ~minify:true w))
+                | None -> Hashtbl.replace fold name `Unset))
+        by_name;
+      fold
 
 (* Replace every layer-decided definition with a single unlayered definition of
    the winner (or drop it entirely when unset), so the census sees one inlinable

--- a/lib/inline.mli
+++ b/lib/inline.mli
@@ -26,6 +26,16 @@ val mentioned_custom_names : Stylesheet.t -> string list
     included), or queried by a [style()] container query. A [@property] body is
     not a mention, so a registration never keeps itself. *)
 
+val layer_order : Stylesheet.t -> string list option
+(** [layer_order stylesheet] is the cascade layer order [stylesheet] declares,
+    weakest first, as one dotted path per layer, or [None] when the order
+    depends on something static analysis cannot settle: a layer first named
+    inside a conditional group is introduced there only when the condition
+    holds, and one named inside an {!Stylesheet.Origin} block belongs to that
+    origin's own stack. This is the order {!vars} resolves a custom property
+    defined across several layers against, and [None] is the answer that stops
+    it. *)
+
 val decode_import_url : string -> string
 (** [decode_import_url s] strips the [url(...)] wrapper and any surrounding
     quotes from an [@import] URL string as held in

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -27,13 +27,16 @@ let decl_facts_conflict a b =
   && (not (same_decl a.decl b.decl))
   && Shorthand.declarations_overlap_with_keys a.decl a.keys b.decl b.keys
 
-let declaration_blocks_commute left right =
-  let left = decl_facts left in
-  let right = decl_facts right in
+(* Two footprints commute when no pair of them writes a common cascade slot: the
+   order they are replayed in cannot then be observed. *)
+let decl_facts_commute left right =
   not
     (List.exists
        (fun a -> List.exists (fun b -> decl_facts_conflict a b) right)
        left)
+
+let declaration_blocks_commute left right =
+  decl_facts_commute (decl_facts left) (decl_facts right)
 
 let declarations_equal (a : Declaration.declaration list)
     (b : Declaration.declaration list) =
@@ -86,45 +89,39 @@ let rule_eligible (r : rule) =
    rules too - unlike the factoring passes, which reorder declarations and would
    disturb a later [var()] resolution. [try_rewrite]'s acyclicity check still
    rejects a group whose merge would cross a conflicting (re)definition. *)
-(* Keyed on the property's AST identity rather than its printed name: two
-   constructors that print alike are different properties, and building the set
-   from names would merge them. [prop_key] is unboxed over the property
-   constructor, so ordering it is ordering the constructor. *)
-module Prop_set = Set.Make (struct
-  type t = Declaration.prop_key
-
-  let compare = Stdlib.compare
-end)
-
 (* Merging a run of same-selector rules into the first one moves each later
    rule's declarations ahead of any nested block an earlier one carries. That
-   only matters for a property the nested block also sets, so a rule with nested
-   children can still take part as long as those children and the declarations
-   that would move past them are disjoint.
+   only matters where the two write a common cascade slot, so a rule with
+   nested children can still take part as long as those children and the
+   declarations that would move past them commute.
+
+   A slot, not a property name: a nested [margin] and a later [margin-top] name
+   two properties and write one slot, so the nested children are carried as
+   footprints and put through the overlap relation two flat declarations use.
 
    Read through the exhaustive statement walks: every nested statement sets
    properties, a nested declarations run as much as a nested style rule, and one
    this walk cannot see is one the merge would happily hoist past. *)
-let rec nested_property_keys acc (stmts : statement list) =
+let rec nested_decl_facts acc (stmts : statement list) =
   List.fold_left
     (fun acc stmt ->
       let acc =
         List.fold_left
-          (fun acc d -> Prop_set.add (Declaration.property_key d) acc)
+          (fun acc d -> decl_fact d :: acc)
           acc
           (statement_declarations stmt)
       in
-      nested_property_keys acc (statement_children stmt))
+      nested_decl_facts acc (statement_children stmt))
     acc stmts
 
 (* CSS Nesting 1 sec. 3.4 puts a declaration written after a nested rule behind
    it, so a rule's body is not the run of declarations [declarations] holds:
    merging a later same-selector rule into it moves that rule's declarations
-   ahead of everything nested. [nested_merge_is_safe] below decides that per
-   property; until it reads the whole body, keep a rule carrying nested content
-   out of the merge entirely, as [rule_eligible] already does. *)
+   ahead of everything nested. [nested_merge_is_safe] below reads the whole body
+   and decides that per property, so a rule carrying nested content stands on
+   the same terms as any other. *)
 let same_selector_eligible (r : rule) =
-  r.nested = [] && r.merge_key = Option.None
+  r.merge_key = Option.None
   && (not (contains_vendor_pseudo_element r.selector))
   && not (List.exists Shorthand.is_all_declaration r.declarations)
 
@@ -134,17 +131,15 @@ let same_selector_eligible (r : rule) =
 let nested_merge_is_safe (rules : rule list) =
   let rec go = function
     | [] | [ _ ] -> true
-    | r :: rest ->
-        (r.nested = []
-        ||
-        let blocked = nested_property_keys Prop_set.empty r.nested in
-        List.for_all
-          (fun (later : rule) ->
+    | (r : rule) :: rest -> (
+        match nested_decl_facts [] r.nested with
+        | [] -> go rest
+        | nested ->
             List.for_all
-              (fun d -> not (Prop_set.mem (Declaration.property_key d) blocked))
-              later.declarations)
-          rest)
-        && go rest
+              (fun (later : rule) ->
+                decl_facts_commute nested (decl_facts later.declarations))
+              rest
+            && go rest)
   in
   go rules
 
@@ -315,10 +310,8 @@ let same_selector_merge_order
     (rules_with_ids : (Rule_graph.node_id * rule) list) =
   let rows = Array.of_list rules_with_ids in
   let n = Array.length rows in
-  let nested_keys =
-    Array.map
-      (fun (_, (r : rule)) -> nested_property_keys Prop_set.empty r.nested)
-      rows
+  let nested_facts =
+    Array.map (fun (_, (r : rule)) -> nested_decl_facts [] r.nested) rows
   in
   let succ = Array.make n [] in
   let pred = Array.make n 0 in
@@ -328,7 +321,7 @@ let same_selector_merge_order
       let _, right = rows.(j) in
       if
         (not (declaration_blocks_commute left.declarations right.declarations))
-        || not (Prop_set.disjoint nested_keys.(i) nested_keys.(j))
+        || not (decl_facts_commute nested_facts.(i) nested_facts.(j))
       then begin
         succ.(i) <- j :: succ.(i);
         pred.(j) <- pred.(j) + 1

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -121,6 +121,17 @@ let equal_canonical_lossless_exact_srgb () =
   Alcotest.(check bool)
     "the alpha scales exactly too" true
     (equal ".a{color:color(srgb 1 0 0/.5)}" ".a{color:rgba(255,0,0,.5)}");
+  (* The spelling folds wherever the declaration sits: an at-rule that groups
+     rules holds the same declarations a caller could have written at the top
+     level. *)
+  Alcotest.(check bool)
+    "the fold reaches inside @starting-style" true
+    (equal "@starting-style{.a{color:color(srgb 1 0 0)}}"
+       "@starting-style{.a{color:#f00}}");
+  Alcotest.(check bool)
+    "the fold reaches inside @scope" true
+    (equal "@scope (.p){.a{color:color(srgb 1 0 0)}}"
+       "@scope (.p){.a{color:#f00}}");
   (* display-p3 red is a different colour, not a different spelling. *)
   Alcotest.(check bool)
     "color(display-p3 1 0 0) still differs from rgb(255 0 0)" false

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -480,6 +480,22 @@ let test_inline_style_query_keeps_no_more () =
     ":root{--c:red}@container --c (min-width:1px){.z{color:green}}"
     "@container --c (min-width:1px){.z{color:green}}"
 
+(* Layers are ordered by first appearance (CSS Cascade 5 sec. 6.4.2), so where a
+   layer is first named decides which definition of a cross-layer custom
+   property wins. A conditional group only introduces its layers when its
+   condition holds, which cascade cannot decide, while a [@container] block
+   holds rules that always exist and is evaluated per element. *)
+let test_inline_layer_order_sites () =
+  check_inline_case "a layer first named inside @media leaves the order open"
+    "@media screen{@layer b{.z{outline-color:red}}}@layer \
+     a{:root{--c:red}}@layer b{:root{--c:blue}}.x{color:var(--c)}"
+    "@media screen{@layer b{.z{outline-color:red}}}@layer \
+     a{:root{--c:red}}@layer b{:root{--c:blue}}.x{color:var(--c)}";
+  check_inline_case "a layer first named inside @container orders the sheet"
+    "@container (min-width:1px){@layer b{.z{outline-color:red}}}@layer \
+     a{:root{--c:red}}@layer b{:root{--c:blue}}.x{color:var(--c)}"
+    "@container(min-width:1px){.z{outline-color:red}}.x{color:red}"
+
 let suite =
   ( "inline",
     [
@@ -540,4 +556,6 @@ let suite =
         test_inline_style_query_keeps_registration;
       Alcotest.test_case "inline vars keep no more than a style() query reads"
         `Quick test_inline_style_query_keeps_no_more;
+      Alcotest.test_case "inline vars order layers by where they are named"
+        `Quick test_inline_layer_order_sites;
     ] )

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2197,7 +2197,9 @@ let c61_adjacent_later_dedup () =
 (* A rule's [declarations] is the run written before its first nested statement
    (CSS Nesting 1 sec. 3.4), not its whole body, so absorbing a later
    same-selector rule moves that rule's declarations ahead of body content the
-   merge never looked at. A rule carrying nested children stays out. *)
+   merge has to read for itself. It reads the whole body, so a rule carrying
+   nested children can still absorb a later one: the move is only observable for
+   a property that body also sets. *)
 let same_selector_merge_past_nested () =
   let of_string css =
     match Css.of_string css with
@@ -2210,8 +2212,8 @@ let same_selector_merge_past_nested () =
     |> String.trim
   in
   Alcotest.(check string)
-    "nested children keep the rule out of the merge"
-    ".a{color:red;&:hover{background:#00f}}.a{padding:1rem}"
+    "disjoint nested children do not block the merge"
+    ".a{color:red;padding:1rem;&:hover{background:#00f}}"
     (canon ".a{color:red;&:hover{background:blue}}.a{padding:1rem}");
   Alcotest.(check string)
     "a nested child setting the same property keeps its place"

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -151,6 +151,26 @@ let media_level_spelling_converges_under_every_wrapper () =
     "@media not all and (width>100px){.a{color:red}}"
     "@media not (width>100px){.a{color:red}}"
 
+let at_rule_block_takes_the_projection_folds () =
+  (* The projection's value folds apply to a declaration wherever it sits: an
+     at-rule that groups rules holds the same rules a caller could have written
+     at the top level, so two sheets differing only by a folded spelling inside
+     one still project alike. *)
+  Alcotest.(check string)
+    "a media query folds inside @-moz-document"
+    (canonical
+       "@-moz-document url-prefix(){@media not (min-width:1px){.a{color:red}}}")
+    (canonical
+       "@-moz-document url-prefix(){@media not all and \
+        (min-width:1px){.a{color:red}}}");
+  Alcotest.(check string)
+    "a font stack unquotes inside @scope"
+    (canonical
+       "@scope (.p){:root{--font-sans:ui-sans-serif,system-ui,Noto Color \
+        Emoji}}")
+    (canonical
+       {|@scope (.p){:root{--font-sans:ui-sans-serif,system-ui,"Noto Color Emoji"}}|})
+
 let media_and_independent_rule_converge () =
   (* A conditional block whose rules cannot conflict with a neighbouring rule
      reorders with it, so both source orderings reach one canonical form. *)
@@ -342,6 +362,8 @@ let suite =
         color_spelling_converges_under_every_wrapper;
       Alcotest.test_case "media level spelling converges under every wrapper"
         `Quick media_level_spelling_converges_under_every_wrapper;
+      Alcotest.test_case "at-rule block takes the projection folds" `Quick
+        at_rule_block_takes_the_projection_folds;
       Alcotest.test_case "media and independent rule converge" `Quick
         media_and_independent_rule_converge;
       Alcotest.test_case "media conflict keeps source order" `Quick


### PR DESCRIPTION
The canonical projection's three value folds each read a hand-listed set of constructors, so two sheets differing only by a custom-property font quoting, an exact `color(srgb ...)` spelling or a `@media not all and (X)` query inside `@-moz-document`, `@scope`, `@starting-style` or a `@container` compared as different and `cascade diff` exited 1. Stacked on #357.