### PR TITLE
test/inline: stop the render diff degrading without saying so

### DIFF
--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -17,9 +17,10 @@ CASCADE=_build/default/bin/main.exe sh test/inline/run.sh
 ```
 
 It looks for a headless Chrome on `PATH`, in `$CHROME`, or under the puppeteer
-cache, and skips cleanly if none is found (so it is a no-op in CI). `xtest.js`
-appends an extractor script, runs the browser with `--dump-dom`, and diffs the
-computed styles element by element.
+cache (highest version, ordered numerically), and skips cleanly if none is
+found (so it is a no-op in CI). `xtest.js` appends an extractor script, runs
+the browser with `--dump-dom`, and diffs the computed styles element by
+element.
 
 ## Reproducibility
 
@@ -37,6 +38,36 @@ over one unchanged pair of pages reported 14, 410, 14 and 14 differences.
 Freezing happens at fetch time, before `cascade apply` ever sees the page, so
 the document cascade resolves is the document the browser lays out. Pages live
 in the gitignored `pages/`; re-run `fetch.sh` to rebuild them.
+
+## What a count is comparable to
+
+Repeating on one machine is half of it. A count also has to say what produced
+it, and two of its three inputs sit outside the repository.
+
+The **browser** is one: Chrome versions disagree about computed styles, so a
+count is comparable only against another from the same engine. `run.sh` heads
+its output with the version it used. Set `CHROME_VERSION` to a substring of the
+expected version and the run stops unless the browser matches, which is how a
+comparison crosses machines; leaving it unset reports the version without
+demanding one, so a machine with a different build still runs.
+
+The **pages** are the other: `fetch.sh` downloads them live, and a CDN serves
+whatever it serves that day. Committing them would pin the bytes at the cost of
+about a megabyte of third-party CSS in every clone, kept fresh by hand, so the
+harness records them instead of pinning them. `fetch.sh` writes `pages/MANIFEST`
+with a sha256 per stage (the page off the wire, the CSS the CDN served, the
+frozen page), and `run.sh` prints the frozen page's hash in each real-page
+label. A count that moved because the site moved shows up as a changed hash
+next to it.
+
+The **canonical filter** is the third input, and it lives here. `canon_filter.exe`
+compares values the way cascade does, so `0%` against `0px`, or `red` against
+`rgb(255, 0, 0)`, is not reported. Comparing raw strings instead counts every
+such pair, which inflates the total into a number that reads like a result and
+is not one. `run.sh` therefore builds the filter through the checkout's own
+opam switch and proves it filters, on a pair that must be dropped and a pair
+that must survive, before measuring anything; a filter that is missing or wrong
+stops the run rather than downgrading it.
 
 ## Coverage
 

--- a/test/inline/fetch.sh
+++ b/test/inline/fetch.sh
@@ -6,19 +6,49 @@
 # renders offline and its computed styles are reproducible run to run. The
 # downloaded files are large and change upstream, so they are gitignored, never
 # committed; re-run this script to reproduce them.
+#
+# Committing them instead would pin the inputs outright, at the price of about
+# a megabyte of third-party CSS in every clone forever, kept fresh by hand. The
+# need is to notice a changed input, not to prevent one, so MANIFEST records a
+# sha256 per stage instead: the page off the wire, the CSS the CDN served, and
+# the frozen page run.sh measures. A count that moved because the site moved is
+# then a diff in MANIFEST rather than a mystery.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 out="$dir/pages"
+manifest="$out/MANIFEST"
 mkdir -p "$out"
+
+sha() { # file -> sha256, or "-" if nothing on this machine can hash
+  if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1"
+  elif command -v sha256sum >/dev/null 2>&1; then sha256sum "$1"
+  elif command -v openssl >/dev/null 2>&1; then openssl dgst -sha256 "$1" | sed 's/.*= //'
+  else echo -
+  fi | cut -d' ' -f1
+}
+
+{
+  echo "# fetched $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "# name url raw-sha256 css-sha256 frozen-sha256"
+} > "$manifest"
 
 fetch() { # name url
   name="$1"
   url="$2"
   echo "$name <- $url"
   if curl -sL --max-time 60 -A "Mozilla/5.0" "$url" -o "$out/$name.raw.html"; then
-    if node "$dir/inline_css.js" "$url" "$out/$name.raw.html" "$out/$name.in.html"
+    if info=$(node "$dir/inline_css.js" "$url" "$out/$name.raw.html" "$out/$name.in.html")
     then
-      node "$dir/freeze_page.js" "$out/$name.in.html" "$out/$name.html" ||
+      printf '%s\n' "$info"
+      if node "$dir/freeze_page.js" "$out/$name.in.html" "$out/$name.html"; then
+        # The CSS digest covers the stylesheet bytes alone, so a CDN that
+        # changed its CSS under an unchanged page is visible on its own line.
+        printf '%s %s %s %s %s\n' "$name" "$url" \
+          "$(sha "$out/$name.raw.html")" \
+          "$(printf '%s\n' "$info" | sed -n 's/^  css-sha256 //p')" \
+          "$(sha "$out/$name.html")" >> "$manifest"
+      else
         echo "  freeze failed"
+      fi
     else
       echo "  inline-css failed"
     fi

--- a/test/inline/inline_css.js
+++ b/test/inline/inline_css.js
@@ -4,6 +4,7 @@
 // in the headless browser without network access, so the differential test is
 // reproducible. Usage: node inline_css.js <page-url> <raw.html> <out.html>
 const { execSync } = require('child_process');
+const crypto = require('crypto');
 const fs = require('fs');
 const [, , pageUrl, rawPath, outPath] = process.argv;
 
@@ -36,3 +37,7 @@ const style = '<style>' + css + '</style>';
 html = html.includes('</head>') ? html.replace('</head>', style + '</head>') : style + html;
 fs.writeFileSync(outPath, html);
 console.log('  wrote ' + outPath + ' (' + html.length + ' bytes, ' + hrefs.length + ' stylesheet(s))');
+// The stylesheet bytes are whatever the CDN served at this moment, and they
+// move independently of the page. Digest them on their own so fetch.sh can
+// record which CSS a later measurement was taken against.
+console.log('  css-sha256 ' + crypto.createHash('sha256').update(css).digest('hex'));

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -4,20 +4,36 @@
 # Covers `cascade apply` (both modes) and `cascade --minify` (each <style>
 # block minified in place). Skips cleanly with no browser or node (e.g. in CI).
 #
-# A difference list is reproducible, so two runs can be diffed against each
-# other: fetch.sh freezes every downloaded page (freeze_page.js) and xtest.js
-# pins the browser, leaving computed style a function of the CSS alone.
+# A difference list is a measurement, so the run says what produced it: the
+# browser version heads the output, and each fetched page carries the hash of
+# the bytes actually measured. fetch.sh freezes every downloaded page
+# (freeze_page.js) and xtest.js pins the browser, leaving computed style a
+# function of the CSS alone.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 root=$(CDPATH= cd "$dir/../.." && pwd)
 export CASCADE=${CASCADE:-cascade}
 if [ -z "$CHROME" ]; then
   CHROME=$(command -v chromium 2>/dev/null || command -v google-chrome 2>/dev/null || true)
 fi
-[ -z "$CHROME" ] && CHROME=$(find "$HOME/.cache/puppeteer" -type f -name chrome-headless-shell 2>/dev/null | sort | tail -1)
+# sort -V, not sort: the cache holds mac_arm-<version> directories, and in
+# lexical order a 99.x outranks a 146.x.
+[ -z "$CHROME" ] && CHROME=$(find "$HOME/.cache/puppeteer" -type f -name chrome-headless-shell 2>/dev/null | sort -V | tail -1)
 if [ -z "$CHROME" ] || ! command -v node >/dev/null 2>&1; then
   echo "SKIP: no headless browser or node available"; exit 0
 fi
 export CHROME
+
+# Chrome versions do not agree on computed styles, so a count is comparable
+# only against another from the same engine. Reporting the version keeps a
+# number from being quoted without it; CHROME_VERSION demands a given build for
+# a comparison that has to cross machines, and is unset by default because
+# requiring one build outright would strand anyone who lacks it.
+browser=$("$CHROME" --version 2>/dev/null | tr -d '\r')
+[ -z "$browser" ] && browser="unknown ($CHROME)"
+if [ -n "$CHROME_VERSION" ] && ! printf '%s\n' "$browser" | grep -qF "$CHROME_VERSION"; then
+  echo "ERROR: CHROME_VERSION=$CHROME_VERSION, but the browser is $browser" >&2
+  exit 1
+fi
 
 # Canonical-difference filter: compares values the way cascade does, so
 # render-equivalent spellings (0% vs 0px, red vs rgb(...)) are not reported.
@@ -43,6 +59,18 @@ if [ "$canon_probe" != "$(printf '0\tX\tcolor\tred\tblue')" ]; then
 fi
 export CANON_FILTER
 
+# Fetched pages are downloaded rather than committed, so record which bytes
+# produced a result: the hash moves when the site or its CDN does, and a count
+# that moved with it is explained instead of mysterious.
+sha() { # file -> first 12 hex of sha256
+  if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1"
+  elif command -v sha256sum >/dev/null 2>&1; then sha256sum "$1"
+  elif command -v openssl >/dev/null 2>&1; then openssl dgst -sha256 "$1" | sed 's/.*= //'
+  else echo nohash
+  fi | cut -c1-12
+}
+
+echo "browser: $browser"
 echo "compare: canonical"
 fail=0
 # xtest.js renders two pages, which is the whole cost of the run: keep its
@@ -77,12 +105,13 @@ done
 # They gate like the fixtures do: a surviving difference is a defect in the
 # transform, whichever page happened to find it. One that appears the day a
 # site is redesigned is still a defect, but re-run fetch.sh before reading it
-# as a regression in the working tree.
+# as a regression in the working tree, and check the hash in the label first.
 for f in "$dir"/pages/*.html; do
   [ -e "$f" ] || continue
+  page="$(basename "$f")@$(sha "$f")"
   tmp=$(mktemp)
   "$CASCADE" apply --minimal "$f" > "$tmp" 2>/dev/null
-  check "real $(basename "$f") minimal" "$f" "$tmp"
+  check "real $page minimal" "$f" "$tmp"
   rm -f "$tmp"
 done
 exit $fail

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -8,6 +8,7 @@
 # other: fetch.sh freezes every downloaded page (freeze_page.js) and xtest.js
 # pins the browser, leaving computed style a function of the CSS alone.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+root=$(CDPATH= cd "$dir/../.." && pwd)
 export CASCADE=${CASCADE:-cascade}
 if [ -z "$CHROME" ]; then
   CHROME=$(command -v chromium 2>/dev/null || command -v google-chrome 2>/dev/null || true)
@@ -17,15 +18,32 @@ if [ -z "$CHROME" ] || ! command -v node >/dev/null 2>&1; then
   echo "SKIP: no headless browser or node available"; exit 0
 fi
 export CHROME
+
 # Canonical-difference filter: compares values the way cascade does, so
 # render-equivalent spellings (0% vs 0px, red vs rgb(...)) are not reported.
-# The filter is optional, so a build that cannot run leaves it unset rather
-# than stopping the sweep -- but it says why instead of discarding the reason.
-root=$(CDPATH= cd "$dir/../.." && pwd)
-if "$root/scripts/with_switch.sh" dune build test/inline/canon_filter.exe; then
-  CANON_FILTER=$(cd "$root" && find _build -name canon_filter.exe | head -1)
-  [ -n "$CANON_FILTER" ] && export CANON_FILTER="$root/$CANON_FILTER"
+# Without it every such pair counts, and the run prints a number that looks
+# like a result but is an inflated one, which is worse than no number at all.
+# So a filter that is missing or does not work is fatal, not skipped.
+if [ -z "$CANON_FILTER" ]; then
+  (cd "$root" && "$root/scripts/with_switch.sh" dune build test/inline/canon_filter.exe)
+  CANON_FILTER="$root/_build/default/test/inline/canon_filter.exe"
 fi
+# Prove it filters, rather than that a file exists: a stale or broken binary
+# passes an existence check and silently restores raw comparison. The first
+# line is one spelling of one value and must be dropped; the second is a real
+# change and must survive.
+canon_probe=$(printf '0\tX\tbackground-position\t0%% 0%%\t0px 0px\n0\tX\tcolor\tred\tblue\n' |
+  "$CANON_FILTER" 2>/dev/null)
+if [ "$canon_probe" != "$(printf '0\tX\tcolor\tred\tblue')" ]; then
+  echo "ERROR: canonical filter missing or not filtering: $CANON_FILTER" >&2
+  echo "  build it with: dune build test/inline/canon_filter.exe" >&2
+  echo "  (or point CANON_FILTER at one). Without it, equivalent spellings" >&2
+  echo "  count as differences and the reported total is not a result." >&2
+  exit 1
+fi
+export CANON_FILTER
+
+echo "compare: canonical"
 fail=0
 # xtest.js renders two pages, which is the whole cost of the run: keep its
 # report rather than paying for it a second time to print the failure.

--- a/test/inline/xtest.js
+++ b/test/inline/xtest.js
@@ -53,7 +53,12 @@ if (CANON && cand.length) {
 }
 const diffs = lines.map(l=>{const f=l.split('\t');return '['+f[0]+' '+f[1]+'] '+f[2]+': "'+f[3]+'" vs "'+f[4]+'"';});
 if (a.length !== b.length) diffs.unshift('element count '+a.length+' vs '+b.length);
-console.log('visual elements: '+n+', computed props/elem: ~'+Object.keys(a[0]||{}).length+(CANON?' (canonical compare)':''));
+// Say which comparison produced the count. Without the filter every
+// equivalent spelling counts, so the total is inflated and is not the number
+// run.sh reports: label it loudly rather than let it pass for the real one.
+const how = CANON ? ' (canonical compare)'
+  : ' (RAW COMPARE, no CANON_FILTER: equivalent spellings counted, total inflated)';
+console.log('visual elements: '+n+', computed props/elem: ~'+Object.keys(a[0]||{}).length+how);
 if (!diffs.length) console.log('RESULT: IDENTICAL computed styles (inlining preserves the render)');
 // The whole list, not a sample: it is the artifact you diff between runs.
-else { console.log('RESULT: '+diffs.length+' difference(s):'); diffs.forEach(d=>console.log('  '+d)); }
+else { console.log('RESULT: '+diffs.length+' difference(s)'+(CANON?'':' [RAW, INFLATED]')+':'); diffs.forEach(d=>console.log('  '+d)); }


### PR DESCRIPTION
The canonical filter was best-effort, so a missing `dune` left the run comparing raw strings and reporting an inflated count that read like a result; it is now fatal, and is proved to filter before anything is measured. The run also records the browser version and a hash of each fetched page, since neither is pinned and a count taken on a different engine or a changed page is not comparable to an earlier one.

Stacked on #353.