### PR TITLE
stylesheet: a walk that can drop a statement, not just rewrite it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -175,6 +175,10 @@
   declaration walks take `?sites` to name the places a narrow walk wants, so a
   place added to `declaration_sites` stops every walk that made a choice from
   compiling (#356)
+- `Css.Stylesheet.edit_statements` rewrites a whole block: the walk hands each
+  statement to a function that keeps, replaces or drops it, and descends into
+  what survives, so a pass that drops a statement no longer carries its own
+  list of the at-rules that nest (#363)
 
 ### CLI tools
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -507,52 +507,9 @@ let drop_invalid (stylesheet : t) : t =
     emitted at parse time materialise as a dropped rule, matching CSS Syntax 3
     sec. 5.4.1 (unknown at-rules are discarded). *)
 let drop_unknown_at_rules (stylesheet : t) : t =
-  let rec statement stmt =
-    match stmt with
-    | Rule rule ->
-        let nested = list_edit_preserve statement rule.nested in
-        let rule' = rule_with_nested rule nested in
-        if rule' == rule then List.Keep else List.Replace (Rule rule')
-    | Layer (name, block) ->
-        let block' = list_edit_preserve statement block in
-        if block' == block then List.Keep
-        else List.Replace (Layer (name, block'))
-    | Media (m, block) ->
-        let block' = list_edit_preserve statement block in
-        if block' == block then List.Keep else List.Replace (Media (m, block'))
-    | Container (n, c, block) ->
-        let block' = list_edit_preserve statement block in
-        if block' == block then List.Keep
-        else List.Replace (Container (n, c, block'))
-    | Supports (s, block) ->
-        let block' = list_edit_preserve statement block in
-        if block' == block then List.Keep
-        else List.Replace (Supports (s, block'))
-    | Moz_document (c, block) ->
-        let block' = list_edit_preserve statement block in
-        if block' == block then List.Keep
-        else List.Replace (Moz_document (c, block'))
-    | When (c, block) ->
-        let block' = list_edit_preserve statement block in
-        if block' == block then List.Keep else List.Replace (When (c, block'))
-    | Else (c, block) ->
-        let block' = list_edit_preserve statement block in
-        if block' == block then List.Keep else List.Replace (Else (c, block'))
-    | Starting_style block ->
-        let block' = list_edit_preserve statement block in
-        if block' == block then List.Keep
-        else List.Replace (Starting_style block')
-    | Origin (o, block) ->
-        let block' = list_edit_preserve statement block in
-        if block' == block then List.Keep else List.Replace (Origin (o, block'))
-    | Scope (a, b, block) ->
-        let block' = list_edit_preserve statement block in
-        if block' == block then List.Keep
-        else List.Replace (Scope (a, b, block'))
-    | Unknown_at_rule _ -> List.Drop
-    | _ -> List.Keep
-  in
-  list_edit_preserve statement stylesheet
+  edit_statements
+    (function Unknown_at_rule _ -> List.Drop | _ -> List.Keep)
+    stylesheet
 
 (* CSS Properties and Values API 1 sec. 2: an [@property --name] registers a
    typed syntax, lifting later [--name: ...] uses out of the opaque-token-stream
@@ -810,85 +767,14 @@ let normalize_live_declarations ~ctx ~lossless decls =
       else List.Replace decl')
     decls
 
-let sanitize_keyframe ~ctx ~lossless (k : keyframe) : keyframe =
-  let declarations =
-    normalize_live_declarations ~ctx ~lossless k.declarations
-  in
-  if declarations == k.declarations then k else { k with declarations }
-
-let rec sanitize_block ~ctx ~lossless (b : statement list) : statement list =
-  list_edit_preserve (sanitize_statement ~ctx ~lossless) b
-
-and sanitize_statement ~ctx ~lossless (s : statement) : statement List.edit =
-  let nd = normalize_live_declarations ~ctx ~lossless in
+(* An [@property] registration holds a typed initial value rather than a
+   declaration, so it is the one statement whose value
+   [map_statement_declarations] does not reach; every other statement either is
+   an unknown at-rule, dropped per CSS Syntax 3 sec. 5.4.1, or has its
+   declarations normalised wherever that walk finds them. *)
+let sanitize_statement ~ctx ~lossless (s : statement) : statement List.edit =
   match s with
-  | Rule r ->
-      let declarations = nd r.declarations in
-      let nested = sanitize_block ~ctx ~lossless r.nested in
-      let r' = rule_with_declarations_and_nested r declarations nested in
-      if r' == r then List.Keep else List.Replace (Rule r')
-  | Declarations d ->
-      let d' = nd d in
-      if d' == d then List.Keep else List.Replace (Declarations d')
-  | Page (n, d) ->
-      let d' = nd d in
-      if d' == d then List.Keep else List.Replace (Page (n, d'))
-  | Page_with_margins (n, descs, margins) ->
-      let descs' = nd descs in
-      let margins' =
-        list_map_preserve
-          (fun m ->
-            let descriptors = nd m.descriptors in
-            if descriptors == m.descriptors then m else { m with descriptors })
-          margins
-      in
-      if descs' == descs && margins' == margins then List.Keep
-      else List.Replace (Page_with_margins (n, descs', margins'))
-  | Position_try (n, d) ->
-      let d' = nd d in
-      if d' == d then List.Keep else List.Replace (Position_try (n, d'))
-  | Supports_condition (n, d) ->
-      let d' = nd d in
-      if d' == d then List.Keep else List.Replace (Supports_condition (n, d'))
-  | Keyframes (n, ks) ->
-      let ks' = list_map_preserve (sanitize_keyframe ~ctx ~lossless) ks in
-      if ks' == ks then List.Keep else List.Replace (Keyframes (n, ks'))
-  | Webkit_keyframes (n, ks) ->
-      let ks' = list_map_preserve (sanitize_keyframe ~ctx ~lossless) ks in
-      if ks' == ks then List.Keep else List.Replace (Webkit_keyframes (n, ks'))
-  | Moz_keyframes (n, ks) ->
-      let ks' = list_map_preserve (sanitize_keyframe ~ctx ~lossless) ks in
-      if ks' == ks then List.Keep else List.Replace (Moz_keyframes (n, ks'))
-  | Layer (n, b) ->
-      let b' = sanitize_block ~ctx ~lossless b in
-      if b' == b then List.Keep else List.Replace (Layer (n, b'))
-  | Media (c, b) ->
-      let b' = sanitize_block ~ctx ~lossless b in
-      if b' == b then List.Keep else List.Replace (Media (c, b'))
-  | Container (n, c, b) ->
-      let b' = sanitize_block ~ctx ~lossless b in
-      if b' == b then List.Keep else List.Replace (Container (n, c, b'))
-  | Supports (c, b) ->
-      let b' = sanitize_block ~ctx ~lossless b in
-      if b' == b then List.Keep else List.Replace (Supports (c, b'))
-  | Moz_document (c, b) ->
-      let b' = sanitize_block ~ctx ~lossless b in
-      if b' == b then List.Keep else List.Replace (Moz_document (c, b'))
-  | Starting_style b ->
-      let b' = sanitize_block ~ctx ~lossless b in
-      if b' == b then List.Keep else List.Replace (Starting_style b')
-  | When (c, b) ->
-      let b' = sanitize_block ~ctx ~lossless b in
-      if b' == b then List.Keep else List.Replace (When (c, b'))
-  | Else (c, b) ->
-      let b' = sanitize_block ~ctx ~lossless b in
-      if b' == b then List.Keep else List.Replace (Else (c, b'))
-  | Origin (o, b) ->
-      let b' = sanitize_block ~ctx ~lossless b in
-      if b' == b then List.Keep else List.Replace (Origin (o, b'))
-  | Scope (s1, s2, b) ->
-      let b' = sanitize_block ~ctx ~lossless b in
-      if b' == b then List.Keep else List.Replace (Scope (s1, s2, b'))
+  | Unknown_at_rule _ -> List.Drop
   | Property r ->
       let initial_value =
         match r.initial_value with
@@ -899,8 +785,16 @@ and sanitize_statement ~ctx ~lossless (s : statement) : statement List.edit =
       in
       if initial_value == r.initial_value then List.Keep
       else List.Replace (Property { r with initial_value })
-  | Unknown_at_rule _ -> List.Drop
-  | _ -> List.Keep
+  | _ ->
+      let s' =
+        map_statement_declarations
+          (normalize_live_declarations ~ctx ~lossless)
+          s
+      in
+      if s' == s then List.Keep else List.Replace s'
+
+let sanitize_block ~ctx ~lossless (b : statement list) : statement list =
+  edit_statements (sanitize_statement ~ctx ~lossless) b
 
 let rec statement_rule_count = function
   | Rule _ -> 1

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -470,6 +470,26 @@ let rec fold_statements f acc block =
 
 let iter_statements f block = fold_statements (fun () stmt -> f stmt) () block
 
+(* The rewriting counterpart of [iter_statements]. [f] decides each statement's
+   fate; the descent into what it holds is [map_statement_children]'s, so a
+   caller that only cares about one statement kind does not enumerate the ones
+   it nests inside. Applied to a statement before the statements it holds, and
+   to the replacement rather than the original, so a rewrite and the walk below
+   it compose. *)
+let edit_statements f block =
+  let rec statement stmt =
+    match f stmt with
+    | Common.List.Drop -> Common.List.Drop
+    | Keep -> descend stmt stmt
+    | Replace stmt' -> descend stmt stmt'
+  and descend stmt stmt' =
+    let stmt' =
+      map_statement_children (Common.List.edit_preserve statement) stmt'
+    in
+    if stmt' == stmt then Common.List.Keep else Common.List.Replace stmt'
+  in
+  Common.List.edit_preserve statement block
+
 let fold_declarations ?(sites = every_site) f acc block =
   fold_statements
     (fun acc stmt ->

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -291,6 +291,17 @@ val iter_statements : (statement -> unit) -> block -> unit
 (** [iter_statements f block] applies [f] to every statement {!fold_statements}
     reaches. *)
 
+val edit_statements :
+  (statement -> statement Common.List.edit) -> block -> block
+(** [edit_statements f block] rewrites the statements {!fold_statements}
+    reaches: [f] keeps, replaces or drops each one, and the walk descends
+    through {!map_statement_children} into what survives, so a caller names only
+    the statements it acts on rather than the at-rules they nest inside.
+    Dropping a statement drops what it holds. [f] sees a statement before the
+    statements it holds, and the walk continues into a replacement rather than
+    into the statement it replaced. It preserves physical identity: when [f]
+    keeps every statement, the result is [block] itself. *)
+
 val fold_declarations :
   ?sites:declaration_sites ->
   ('a -> declaration list -> 'a) ->

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -8026,6 +8026,48 @@ let deep_walker_tests =
                ".o";
              ])
           (List.sort compare !seen) );
+    ( "edit_statements drops a statement inside every at-rule",
+      `Quick,
+      fun () ->
+        let dropped =
+          edit_statements
+            (function Rule _ -> Common.List.Drop | _ -> Common.List.Keep)
+            (places ())
+        in
+        Alcotest.(check (list string))
+          "no rule left" []
+          (fold_statements
+             (fun acc stmt ->
+               match stmt with
+               | Rule r -> Selector.to_string ~minify:true r.selector :: acc
+               | _ -> acc)
+             [] dropped) );
+    ( "edit_statements walks into a replacement",
+      `Quick,
+      fun () ->
+        (* The nested rule is reachable only through the rule that was replaced,
+           so it is marked when the walk continues into the replacement rather
+           than into the statement it replaced. *)
+        let mark = function
+          | Rule r -> Common.List.Replace (Rule { r with merge_key = Some "k" })
+          | _ -> Common.List.Keep
+        in
+        Alcotest.(check (list string))
+          "every rule marked" []
+          (fold_statements
+             (fun acc stmt ->
+               match stmt with
+               | Rule r when r.merge_key = None ->
+                   Selector.to_string ~minify:true r.selector :: acc
+               | _ -> acc)
+             []
+             (edit_statements mark (places ()))) );
+    ( "edit_statements keeps an unchanged tree",
+      `Quick,
+      fun () ->
+        let block = places () in
+        if not (edit_statements (fun _ -> Common.List.Keep) block == block) then
+          Alcotest.fail "statement edit rebuilt an unchanged stylesheet" );
   ]
 
 let suite =


### PR DESCRIPTION
The two walkers in `optimize.ml` that drop a statement had no shared walk to drop it in, so each kept its own list of the at-rules that nest and would have walked past a new one. This PR adds `Css.Stylesheet.edit_statements`, which keeps, replaces or drops each statement and descends through `map_statement_children` into what survives, and moves both onto it.