### PR TITLE
optimize: order a same-selector merge by its nested blocks too

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -271,6 +271,11 @@
   conditional group that sets the same property. The safety check saw a nested
   style rule only, so `@media`, `@container` and friends let the merge hoist
   the declaration past them and hand the conditional the win (#352)
+- Merging same-selector rules orders the rules by what their nested blocks set
+  as well as by their declarations, and reads the source order to decide
+  whether a declaration crosses a nested block. The merge order could put the
+  rule carrying the nested block last, leaving that check nothing to look at,
+  so a nested `@media` won over a later declaration that overrode it (#364)
 - A `font-family` name that cannot be spelled as an identifier keeps its
   quotes. The unquoting guard checked which characters a name is made of but
   not how CSS Syntax 3 sec. 4.3.9 lets an ident sequence start, so `"2Brand"`,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -235,11 +235,12 @@
   `-webkit-backdrop-filter`, `-webkit-user-select`, `-webkit-text-size-adjust`
   and `-webkit-print-color-adjust` were dropped against an unprefixed twin no
   shipping Safari understands (#325)
-- A rule that carries nested content stays out of the same-selector merge, the
-  distant `@media` hoist and the shadowed-rule drop. A rule's declarations are
-  only the run written before its first nested statement (CSS Nesting 1
-  sec. 3.4), so a pass reading them as the whole body moves or drops content it
-  never looked at (#376)
+- A rule whose declarations a later rule all rewrites is dropped only when it
+  carries no nested content. A rule's declarations are only the run written
+  before its first nested statement (CSS Nesting 1 sec. 3.4), so covering them
+  says nothing about what the rest of the body sets, and
+  `.a { all: unset; @media (min-width: 1px) { width: 1px } } .a { all: initial }`
+  lost its nested block along with the rule (#376)
 - A declaration written after a nested statement rejoins the rule's own run
   when nothing it crosses writes the same property at the same importance, so
   `.a { & b { width: 1px } color: red }` minifies to
@@ -276,6 +277,11 @@
   whether a declaration crosses a nested block. The merge order could put the
   rule carrying the nested block last, leaving that check nothing to look at,
   so a nested `@media` won over a later declaration that overrode it (#364)
+- Merging same-selector rules weighs what a nested block sets against a later
+  declaration by cascade slot rather than by property name. A nested
+  `margin: 2rem` and a later `margin-top: 1rem` write one slot under two names,
+  so the merge read them as disjoint, hoisted the longhand ahead of the nested
+  block and handed the shorthand the win (#364)
 - A `font-family` name that cannot be spelled as an identifier keeps its
   quotes. The unquoting guard checked which characters a name is made of but
   not how CSS Syntax 3 sec. 4.3.9 lets an ident sequence start, so `"2Brand"`,

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -27,13 +27,16 @@ let decl_facts_conflict a b =
   && (not (same_decl a.decl b.decl))
   && Shorthand.declarations_overlap_with_keys a.decl a.keys b.decl b.keys
 
-let declaration_blocks_commute left right =
-  let left = decl_facts left in
-  let right = decl_facts right in
+(* Two footprints commute when no pair of them writes a common cascade slot: the
+   order they are replayed in cannot then be observed. *)
+let decl_facts_commute left right =
   not
     (List.exists
        (fun a -> List.exists (fun b -> decl_facts_conflict a b) right)
        left)
+
+let declaration_blocks_commute left right =
+  decl_facts_commute (decl_facts left) (decl_facts right)
 
 let declarations_equal (a : Declaration.declaration list)
     (b : Declaration.declaration list) =
@@ -86,45 +89,39 @@ let rule_eligible (r : rule) =
    rules too - unlike the factoring passes, which reorder declarations and would
    disturb a later [var()] resolution. [try_rewrite]'s acyclicity check still
    rejects a group whose merge would cross a conflicting (re)definition. *)
-(* Keyed on the property's AST identity rather than its printed name: two
-   constructors that print alike are different properties, and building the set
-   from names would merge them. [prop_key] is unboxed over the property
-   constructor, so ordering it is ordering the constructor. *)
-module Prop_set = Set.Make (struct
-  type t = Declaration.prop_key
-
-  let compare = Stdlib.compare
-end)
-
 (* Merging a run of same-selector rules into the first one moves each later
    rule's declarations ahead of any nested block an earlier one carries. That
-   only matters for a property the nested block also sets, so a rule with nested
-   children can still take part as long as those children and the declarations
-   that would move past them are disjoint.
+   only matters where the two write a common cascade slot, so a rule with
+   nested children can still take part as long as those children and the
+   declarations that would move past them commute.
+
+   A slot, not a property name: a nested [margin] and a later [margin-top] name
+   two properties and write one slot, so the nested children are carried as
+   footprints and put through the overlap relation two flat declarations use.
 
    Read through the exhaustive statement walks: every nested statement sets
    properties, a nested declarations run as much as a nested style rule, and one
    this walk cannot see is one the merge would happily hoist past. *)
-let rec nested_property_keys acc (stmts : statement list) =
+let rec nested_decl_facts acc (stmts : statement list) =
   List.fold_left
     (fun acc stmt ->
       let acc =
         List.fold_left
-          (fun acc d -> Prop_set.add (Declaration.property_key d) acc)
+          (fun acc d -> decl_fact d :: acc)
           acc
           (statement_declarations stmt)
       in
-      nested_property_keys acc (statement_children stmt))
+      nested_decl_facts acc (statement_children stmt))
     acc stmts
 
 (* CSS Nesting 1 sec. 3.4 puts a declaration written after a nested rule behind
    it, so a rule's body is not the run of declarations [declarations] holds:
    merging a later same-selector rule into it moves that rule's declarations
-   ahead of everything nested. [nested_merge_is_safe] below decides that per
-   property; until it reads the whole body, keep a rule carrying nested content
-   out of the merge entirely, as [rule_eligible] already does. *)
+   ahead of everything nested. [nested_merge_is_safe] below reads the whole body
+   and decides that per property, so a rule carrying nested content stands on
+   the same terms as any other. *)
 let same_selector_eligible (r : rule) =
-  r.nested = [] && r.merge_key = Option.None
+  r.merge_key = Option.None
   && (not (contains_vendor_pseudo_element r.selector))
   && not (List.exists Shorthand.is_all_declaration r.declarations)
 
@@ -134,17 +131,15 @@ let same_selector_eligible (r : rule) =
 let nested_merge_is_safe (rules : rule list) =
   let rec go = function
     | [] | [ _ ] -> true
-    | r :: rest ->
-        (r.nested = []
-        ||
-        let blocked = nested_property_keys Prop_set.empty r.nested in
-        List.for_all
-          (fun (later : rule) ->
+    | (r : rule) :: rest -> (
+        match nested_decl_facts [] r.nested with
+        | [] -> go rest
+        | nested ->
             List.for_all
-              (fun d -> not (Prop_set.mem (Declaration.property_key d) blocked))
-              later.declarations)
-          rest)
-        && go rest
+              (fun (later : rule) ->
+                decl_facts_commute nested (decl_facts later.declarations))
+              rest
+            && go rest)
   in
   go rules
 
@@ -315,10 +310,8 @@ let same_selector_merge_order
     (rules_with_ids : (Rule_graph.node_id * rule) list) =
   let rows = Array.of_list rules_with_ids in
   let n = Array.length rows in
-  let nested_keys =
-    Array.map
-      (fun (_, (r : rule)) -> nested_property_keys Prop_set.empty r.nested)
-      rows
+  let nested_facts =
+    Array.map (fun (_, (r : rule)) -> nested_decl_facts [] r.nested) rows
   in
   let succ = Array.make n [] in
   let pred = Array.make n 0 in
@@ -328,7 +321,7 @@ let same_selector_merge_order
       let _, right = rows.(j) in
       if
         (not (declaration_blocks_commute left.declarations right.declarations))
-        || not (Prop_set.disjoint nested_keys.(i) nested_keys.(j))
+        || not (decl_facts_commute nested_facts.(i) nested_facts.(j))
       then begin
         succ.(i) <- j :: succ.(i);
         pred.(j) <- pred.(j) + 1

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -128,6 +128,9 @@ let same_selector_eligible (r : rule) =
   && (not (contains_vendor_pseudo_element r.selector))
   && not (List.exists Shorthand.is_all_declaration r.declarations)
 
+(* [rules] in source order: whether a declaration ends up ahead of a nested
+   block it followed is a question about where the two were written, and the
+   merge order below answers a different one. *)
 let nested_merge_is_safe (rules : rule list) =
   let rec go = function
     | [] | [ _ ] -> true
@@ -304,17 +307,28 @@ let compare_rule_order_key (left_id, (left_rule : rule))
         (Rule_graph.Node_id.to_int right_id)
   | order -> order
 
+(* The precedence DAG holds every pair the merged rule replays in emission
+   order: its declarations, and its nested blocks, which follow all of them. A
+   pair that competes keeps the order it was written in; the rest is free for
+   [compare_rule_order_key] to canonicalise. *)
 let same_selector_merge_order
     (rules_with_ids : (Rule_graph.node_id * rule) list) =
   let rows = Array.of_list rules_with_ids in
   let n = Array.length rows in
+  let nested_keys =
+    Array.map
+      (fun (_, (r : rule)) -> nested_property_keys Prop_set.empty r.nested)
+      rows
+  in
   let succ = Array.make n [] in
   let pred = Array.make n 0 in
   for i = 0 to n - 1 do
     let _, left = rows.(i) in
     for j = i + 1 to n - 1 do
       let _, right = rows.(j) in
-      if not (declaration_blocks_commute left.declarations right.declarations)
+      if
+        (not (declaration_blocks_commute left.declarations right.declarations))
+        || not (Prop_set.disjoint nested_keys.(i) nested_keys.(j))
       then begin
         succ.(i) <- j :: succ.(i);
         pred.(j) <- pred.(j) + 1
@@ -672,14 +686,14 @@ let same_selector_groups g ids =
   |> List.map (fun (_, ids) -> List.rev ids)
 
 let add_same_selector_group ?size_cache ~finalize g ~candidates ids =
-  let rules_with_ids =
-    ordered_ids g ids |> rules_with_ids g |> same_selector_merge_order
-  in
+  let source_order = ordered_ids g ids |> rules_with_ids g in
+  let safe = nested_merge_is_safe (List.map snd source_order) in
+  let rules_with_ids = same_selector_merge_order source_order in
   let ordered = List.map fst rules_with_ids in
   let rules = List.map snd rules_with_ids in
   match rules with
   | [] | [ _ ] -> ()
-  | (first : rule) :: _ when nested_merge_is_safe rules -> (
+  | (first : rule) :: _ when safe -> (
       let merged =
         {
           first with

--- a/test/inline/fixtures/nested_merge.html
+++ b/test/inline/fixtures/nested_merge.html
@@ -3,4 +3,8 @@
   .n { color: green }
   .m { padding: 1rem; @media (min-width: 1px) { color: blue } }
   .m { margin: 1rem; @media (min-width: 2px) { color: green } }
-</style></head><body><div class="n">n</div><div class="m">m</div></body></html>
+  .s { color: red; @media (min-width: 1px) { margin: 2rem } }
+  .s { margin-top: 1rem }
+  .t { padding: 1rem; @media (min-width: 1px) { margin: 2rem } }
+  .t { color: red; @media (min-width: 2px) { margin-top: 3rem } }
+</style></head><body><div class="n">n</div><div class="m">m</div><div class="s">s</div><div class="t">t</div></body></html>

--- a/test/inline/fixtures/nested_merge.html
+++ b/test/inline/fixtures/nested_merge.html
@@ -1,0 +1,6 @@
+<!doctype html><html><head><style>
+  .n { padding: 1rem; @media (min-width: 1px) { color: blue } }
+  .n { color: green }
+  .m { padding: 1rem; @media (min-width: 1px) { color: blue } }
+  .m { margin: 1rem; @media (min-width: 2px) { color: green } }
+</style></head><body><div class="n">n</div><div class="m">m</div></body></html>

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2228,7 +2228,24 @@ let same_selector_merge_past_nested () =
     "a nested @container setting the same property blocks it"
     ".a{color:red;@container(width>=1px){padding:2rem}}.a{padding:1rem}"
     (canon
-       ".a{color:red;@container (min-width:1px){padding:2rem}}.a{padding:1rem}")
+       ".a{color:red;@container (min-width:1px){padding:2rem}}.a{padding:1rem}");
+  (* The merged rule replays every declaration ahead of every nested block, so
+     no order of the rules rescues a merge a later declaration would have to
+     cross: [color:green] wins over the [@media] wherever it applies, and
+     merging hands the win back to the [@media]. *)
+  Alcotest.(check string)
+    "a later declaration overriding a nested @media blocks the merge"
+    ".a{padding:1rem;@media(width>=1px){color:#00f}}.a{color:green}"
+    (canon ".a{padding:1rem;@media (min-width:1px){color:blue}}.a{color:green}");
+  (* Two nested blocks setting a common property race in the order the merged
+     rule replays them, which stays the order they were written in. *)
+  Alcotest.(check string)
+    "nested blocks setting a common property keep their order"
+    ".a{padding:1rem;margin:1rem;@media(width>=1px){color:#00f}@media(width>=2px){color:green}}"
+    (canon
+       ".a{padding:1rem;@media \
+        (min-width:1px){color:blue}}.a{margin:1rem;@media \
+        (min-width:2px){color:green}}")
 
 (* A run of declarations written after a nested statement (CSS Nesting 1 sec.
    3.4) is a declaration list like any other, with nothing between two writes

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2245,7 +2245,39 @@ let same_selector_merge_past_nested () =
     (canon
        ".a{padding:1rem;@media \
         (min-width:1px){color:blue}}.a{margin:1rem;@media \
-        (min-width:2px){color:green}}")
+        (min-width:2px){color:green}}");
+  (* A shorthand and a longhand of its family write a common cascade slot, so a
+     nested [margin] and a later [margin-top] compete: hoisting the longhand
+     ahead of the nested block hands [margin] the win, a different rendered
+     margin-top wherever the query applies. *)
+  Alcotest.(check string)
+    "a later longhand overriding a nested shorthand blocks the merge"
+    ".a{color:red;@media(width>=1px){margin:2rem}}.a{margin-top:1rem}"
+    (canon
+       ".a{color:red;@media (min-width:1px){margin:2rem}}.a{margin-top:1rem}");
+  (* The same slot written the other way round: a later shorthand resets the
+     longhand the nested block set. *)
+  Alcotest.(check string)
+    "a later shorthand overriding a nested longhand blocks the merge"
+    ".a{color:red;@media(width>=1px){margin-top:2rem}}.a{margin:1rem}"
+    (canon
+       ".a{color:red;@media (min-width:1px){margin-top:2rem}}.a{margin:1rem}");
+  (* Two properties of different families share no slot, so the merge stands:
+     the guard reads footprints, not the presence of a nested block. *)
+  Alcotest.(check string)
+    "a nested block of a disjoint family still merges"
+    ".a{color:red;padding:1rem;@media(width>=1px){margin:2rem}}"
+    (canon ".a{color:red;@media (min-width:1px){margin:2rem}}.a{padding:1rem}");
+  (* Nested blocks race in the order the merged rule replays them, and shorthand
+     against longhand is such a race: swapping these two blocks changes
+     margin-top wherever both queries apply. *)
+  Alcotest.(check string)
+    "nested blocks sharing a slot through a shorthand keep their order"
+    ".a{padding:1rem;color:red;@media(width>=1px){margin:2rem}@media(width>=2px){margin-top:3rem}}"
+    (canon
+       ".a{padding:1rem;@media \
+        (min-width:1px){margin:2rem}}.a{color:red;@media \
+        (min-width:2px){margin-top:3rem}}")
 
 (* A run of declarations written after a nested statement (CSS Nesting 1 sec.
    3.4) is a declaration list like any other, with nothing between two writes

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2197,7 +2197,9 @@ let c61_adjacent_later_dedup () =
 (* A rule's [declarations] is the run written before its first nested statement
    (CSS Nesting 1 sec. 3.4), not its whole body, so absorbing a later
    same-selector rule moves that rule's declarations ahead of body content the
-   merge never looked at. A rule carrying nested children stays out. *)
+   merge has to read for itself. It reads the whole body, so a rule carrying
+   nested children can still absorb a later one: the move is only observable for
+   a property that body also sets. *)
 let same_selector_merge_past_nested () =
   let of_string css =
     match Css.of_string css with
@@ -2210,8 +2212,8 @@ let same_selector_merge_past_nested () =
     |> String.trim
   in
   Alcotest.(check string)
-    "nested children keep the rule out of the merge"
-    ".a{color:red;&:hover{background:#00f}}.a{padding:1rem}"
+    "disjoint nested children do not block the merge"
+    ".a{color:red;padding:1rem;&:hover{background:#00f}}"
     (canon ".a{color:red;&:hover{background:blue}}.a{padding:1rem}");
   Alcotest.(check string)
     "a nested child setting the same property keeps its place"


### PR DESCRIPTION
The merge order is picked from declarations alone, so the rule carrying a nested `@media` could be sorted last, where the check that guards a hoisted declaration has nothing left to compare: `.a{padding:1rem;@media (min-width:1px){color:blue}}.a{color:green}` minified to one rule that renders blue where Chrome renders green.

That guard compared property names, so `.a{color:red;@media (min-width:1px){margin:2rem}}.a{margin-top:1rem}` read as disjoint and merged into a rule Chrome computes at 32px where the source computes 16px; commit 5ed39d9 puts both call sites on the cascade-slot footprints the flat declarations already use.

Stacked on #352, which closed the other half of the same merge.
