### PR TITLE
properties: type the colour of every colour-valued property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,10 @@
   `-webkit-backdrop-filter`, `-webkit-user-select`, `-webkit-text-size-adjust`
   and `-webkit-print-color-adjust` were dropped against an unprefixed twin no
   shipping Safari understands (#325)
+- `column-rule-color` and `-webkit-text-stroke-color` are typed as colours and
+  `-webkit-text-fill-color` joins the colour fold, so a colour-valued property
+  minifies to the same spelling whatever its name: `lab(1.90334 0.278696
+  -5.48866)` and `rgb(3, 7, 18)` both print `#030712` (#365)
 
 ### Custom properties
 

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -400,6 +400,9 @@ let property_value_uses_color (type a) (p : Values.color -> bool)
   | Lighting_color -> p value
   | Webkit_tap_highlight_color -> p value
   | Webkit_text_decoration_color -> p value
+  | Webkit_text_fill_color -> p value
+  | Webkit_text_stroke_color -> p value
+  | Column_rule_color -> p value
   | Border_inline_color -> logical_color_uses p value
   | Border_block_color -> logical_color_uses p value
   | Box_shadow -> shadow_uses_color p value
@@ -1636,6 +1639,7 @@ let read_object_transition_value : type a.
   | Column_width -> Some (v Column_width (read_column_width t))
   | Column_count -> Some (v Column_count (read_column_count t))
   | Column_rule -> Some (v Column_rule (read_border t))
+  | Column_rule_color -> Some (v Column_rule_color (read_color t))
   | Column_span -> Some (v Column_span (read_column_span t))
   | _ -> None
 
@@ -1756,6 +1760,7 @@ let read_interaction_value : type a.
   | Webkit_user_select -> Some (v Webkit_user_select (read_user_select t))
   | Ms_user_select -> Some (v Ms_user_select (read_user_select t))
   | Webkit_text_fill_color -> Some (v Webkit_text_fill_color (read_color t))
+  | Webkit_text_stroke_color -> Some (v Webkit_text_stroke_color (read_color t))
   | Moz_user_select -> Some (v Moz_user_select (read_user_select t))
   | Pointer_events -> Some (v Pointer_events (read_pointer_events t))
   | Resize -> Some (v Resize (read_resize t))

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -426,6 +426,7 @@ let pp_property : type a. a property Pp.t =
   | Font_variation_settings -> Pp.string ctx "font-variation-settings"
   | Webkit_tap_highlight_color -> Pp.string ctx "-webkit-tap-highlight-color"
   | Webkit_text_fill_color -> Pp.string ctx "-webkit-text-fill-color"
+  | Webkit_text_stroke_color -> Pp.string ctx "-webkit-text-stroke-color"
   | Webkit_user_select -> Pp.string ctx "-webkit-user-select"
   | Ms_user_select -> Pp.string ctx "-ms-user-select"
   | Moz_user_select -> Pp.string ctx "-moz-user-select"
@@ -541,6 +542,7 @@ let pp_property : type a. a property Pp.t =
   | Column_width -> Pp.string ctx "column-width"
   | Column_count -> Pp.string ctx "column-count"
   | Column_rule -> Pp.string ctx "column-rule"
+  | Column_rule_color -> Pp.string ctx "column-rule-color"
   | Column_span -> Pp.string ctx "column-span"
   | Word_spacing -> Pp.string ctx "word-spacing"
   | Background_attachment -> Pp.string ctx "background-attachment"
@@ -1485,6 +1487,7 @@ let read_any_property t =
   | "column-width" -> Prop Column_width
   | "column-count" -> Prop Column_count
   | "column-rule" -> Prop Column_rule
+  | "column-rule-color" -> Prop Column_rule_color
   | "column-span" -> Prop Column_span
   | "clear" -> Prop Clear
   | "clip" -> Prop Clip
@@ -1745,6 +1748,7 @@ let read_any_property t =
   | "-webkit-text-size-adjust" -> Prop Webkit_text_size_adjust
   | "-webkit-tap-highlight-color" -> Prop Webkit_tap_highlight_color
   | "-webkit-text-fill-color" -> Prop Webkit_text_fill_color
+  | "-webkit-text-stroke-color" -> Prop Webkit_text_stroke_color
   | "-webkit-user-select" -> Prop Webkit_user_select
   | "-ms-user-select" -> Prop Ms_user_select
   | "-moz-user-select" -> Prop Moz_user_select
@@ -2434,6 +2438,9 @@ let normalize_property_value : type a.
   | Border_block_color -> normalize_logical_border_color ~lossless value
   | Text_decoration_color -> normalize_color value
   | Webkit_text_decoration_color -> normalize_color value
+  | Webkit_text_fill_color -> normalize_color value
+  | Webkit_text_stroke_color -> normalize_color value
+  | Column_rule_color -> normalize_color value
   | Webkit_tap_highlight_color -> normalize_color value
   | Text_emphasis_color -> normalize_color value
   | Outline_color -> normalize_color value
@@ -2781,6 +2788,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Webkit_text_decoration_color -> pp pp_color
   | Webkit_tap_highlight_color -> pp pp_color
   | Webkit_text_fill_color -> pp pp_color
+  | Webkit_text_stroke_color -> pp pp_color
+  | Column_rule_color -> pp pp_color
   | Text_indent -> pp pp_text_indent_value
   | Border_spacing -> pp pp_border_spacing
   | Outline_offset -> pp pp_length
@@ -3432,6 +3441,9 @@ let property_value_kind : type a. a property -> a property_value_kind option =
   | Outline_color -> Some Color
   | Webkit_tap_highlight_color -> Some Color
   | Webkit_text_decoration_color -> Some Color
+  | Webkit_text_fill_color -> Some Color
+  | Webkit_text_stroke_color -> Some Color
+  | Column_rule_color -> Some Color
   | Accent_color -> Some Color
   | Caret_color -> Some Color
   | Stop_color -> Some Color

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4689,6 +4689,7 @@ type 'a property =
   | Webkit_text_decoration : text_decoration property
   | Webkit_text_decoration_color : color property
   | Webkit_text_fill_color : color property
+  | Webkit_text_stroke_color : color property
   | Text_indent : text_indent_value property
   | List_style : list_style property
   | Font : font property
@@ -4841,6 +4842,7 @@ type 'a property =
   | Column_width : column_width property
   | Column_count : column_count property
   | Column_rule : border property
+  | Column_rule_color : color property
   | Column_span : column_span property
   | Word_spacing : length property
   | Background_attachment : background_attachment property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2125,6 +2125,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Column_width, value -> vars_of_column_width value
   | Column_count, value -> vars_of_column_count value
   | Column_rule, value -> vars_of_border value
+  | Column_rule_color, value -> vars_of_color value
   | Column_span, value -> vars_of_column_span value
   (* Contain *)
   | Contain, value -> vars_of_contain value
@@ -2406,6 +2407,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Webkit_user_select, value -> vars_of_user_select value
   | Ms_user_select, value -> vars_of_user_select value
   | Webkit_text_fill_color, value -> vars_of_color value
+  | Webkit_text_stroke_color, value -> vars_of_color value
   | Moz_user_select, value -> vars_of_user_select value
   | White_space, value -> vars_of_white_space value
   | Word_break, value -> vars_of_word_break value

--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -37,3 +37,11 @@ over one unchanged pair of pages reported 14, 410, 14 and 14 differences.
 Freezing happens at fetch time, before `cascade apply` ever sees the page, so
 the document cascade resolves is the document the browser lays out. Pages live
 in the gitignored `pages/`; re-run `fetch.sh` to rebuild them.
+
+## Coverage
+
+`fixtures/` is committed and always runs. `pages/` holds real sites downloaded
+by `fetch.sh`, and they gate the run in the same way: a surviving difference is
+a defect in a transform, whichever page found it. A failure that starts the day
+a site is redesigned is still a defect, but re-run `fetch.sh` before reading it
+as a regression in the working tree.

--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -17,9 +17,10 @@ CASCADE=_build/default/bin/main.exe sh test/inline/run.sh
 ```
 
 It looks for a headless Chrome on `PATH`, in `$CHROME`, or under the puppeteer
-cache, and skips cleanly if none is found (so it is a no-op in CI). `xtest.js`
-appends an extractor script, runs the browser with `--dump-dom`, and diffs the
-computed styles element by element.
+cache (highest version, ordered numerically), and skips cleanly if none is
+found (so it is a no-op in CI). `xtest.js` appends an extractor script, runs
+the browser with `--dump-dom`, and diffs the computed styles element by
+element.
 
 ## Reproducibility
 
@@ -37,6 +38,36 @@ over one unchanged pair of pages reported 14, 410, 14 and 14 differences.
 Freezing happens at fetch time, before `cascade apply` ever sees the page, so
 the document cascade resolves is the document the browser lays out. Pages live
 in the gitignored `pages/`; re-run `fetch.sh` to rebuild them.
+
+## What a count is comparable to
+
+Repeating on one machine is half of it. A count also has to say what produced
+it, and two of its three inputs sit outside the repository.
+
+The **browser** is one: Chrome versions disagree about computed styles, so a
+count is comparable only against another from the same engine. `run.sh` heads
+its output with the version it used. Set `CHROME_VERSION` to a substring of the
+expected version and the run stops unless the browser matches, which is how a
+comparison crosses machines; leaving it unset reports the version without
+demanding one, so a machine with a different build still runs.
+
+The **pages** are the other: `fetch.sh` downloads them live, and a CDN serves
+whatever it serves that day. Committing them would pin the bytes at the cost of
+about a megabyte of third-party CSS in every clone, kept fresh by hand, so the
+harness records them instead of pinning them. `fetch.sh` writes `pages/MANIFEST`
+with a sha256 per stage (the page off the wire, the CSS the CDN served, the
+frozen page), and `run.sh` prints the frozen page's hash in each real-page
+label. A count that moved because the site moved shows up as a changed hash
+next to it.
+
+The **canonical filter** is the third input, and it lives here. `canon_filter.exe`
+compares values the way cascade does, so `0%` against `0px`, or `red` against
+`rgb(255, 0, 0)`, is not reported. Comparing raw strings instead counts every
+such pair, which inflates the total into a number that reads like a result and
+is not one. `run.sh` therefore builds the filter through the checkout's own
+opam switch and proves it filters, on a pair that must be dropped and a pair
+that must survive, before measuring anything; a filter that is missing or wrong
+stops the run rather than downgrading it.
 
 ## Coverage
 

--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -18,5 +18,22 @@ CASCADE=_build/default/bin/main.exe sh test/inline/run.sh
 
 It looks for a headless Chrome on `PATH`, in `$CHROME`, or under the puppeteer
 cache, and skips cleanly if none is found (so it is a no-op in CI). `xtest.js`
-injects an extractor script, runs the browser with `--dump-dom`, and diffs the
+appends an extractor script, runs the browser with `--dump-dom`, and diffs the
 computed styles element by element.
+
+## Reproducibility
+
+A difference list is a measurement, so it has to repeat: run the same
+comparison twice and diff the two outputs, and they match byte for byte.
+
+That takes both halves of the harness. `fetch.sh` freezes each downloaded page
+through `freeze_page.js`, which removes everything that resolves at a moment
+nobody controls: scripts, `@font-face` rules whose relative `.woff2` cannot be
+read under `file://`, and images with an unreachable `src`. `xtest.js` then
+pins the browser, which otherwise brings its own variables (window size,
+device scale factor, scrollbars, name resolution). Without them, four runs
+over one unchanged pair of pages reported 14, 410, 14 and 14 differences.
+
+Freezing happens at fetch time, before `cascade apply` ever sees the page, so
+the document cascade resolves is the document the browser lays out. Pages live
+in the gitignored `pages/`; re-run `fetch.sh` to rebuild them.

--- a/test/inline/fetch.sh
+++ b/test/inline/fetch.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 # Download a few real pages into test/inline/pages/ so run.sh can run the
 # differential test against them. Each page is made self-contained (its external
-# stylesheets are fetched and inlined into a <style> block) so the inliner has
-# CSS to project and the page renders without network access. The downloaded
-# files are large and change upstream, so they are gitignored, never committed.
+# stylesheets are fetched and inlined into a <style> block) and then frozen
+# (scripts, web fonts and remote images removed, see freeze_page.js), so it
+# renders offline and its computed styles are reproducible run to run. The
+# downloaded files are large and change upstream, so they are gitignored, never
+# committed; re-run this script to reproduce them.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 out="$dir/pages"
 mkdir -p "$out"
@@ -13,12 +15,17 @@ fetch() { # name url
   url="$2"
   echo "$name <- $url"
   if curl -sL --max-time 60 -A "Mozilla/5.0" "$url" -o "$out/$name.raw.html"; then
-    node "$dir/inline_css.js" "$url" "$out/$name.raw.html" "$out/$name.html" ||
+    if node "$dir/inline_css.js" "$url" "$out/$name.raw.html" "$out/$name.in.html"
+    then
+      node "$dir/freeze_page.js" "$out/$name.in.html" "$out/$name.html" ||
+        echo "  freeze failed"
+    else
       echo "  inline-css failed"
+    fi
   else
     echo "  download failed"
   fi
-  rm -f "$out/$name.raw.html"
+  rm -f "$out/$name.raw.html" "$out/$name.in.html"
 }
 
 fetch wikipedia https://en.wikipedia.org/wiki/Cascading_Style_Sheets

--- a/test/inline/fetch.sh
+++ b/test/inline/fetch.sh
@@ -6,19 +6,49 @@
 # renders offline and its computed styles are reproducible run to run. The
 # downloaded files are large and change upstream, so they are gitignored, never
 # committed; re-run this script to reproduce them.
+#
+# Committing them instead would pin the inputs outright, at the price of about
+# a megabyte of third-party CSS in every clone forever, kept fresh by hand. The
+# need is to notice a changed input, not to prevent one, so MANIFEST records a
+# sha256 per stage instead: the page off the wire, the CSS the CDN served, and
+# the frozen page run.sh measures. A count that moved because the site moved is
+# then a diff in MANIFEST rather than a mystery.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 out="$dir/pages"
+manifest="$out/MANIFEST"
 mkdir -p "$out"
+
+sha() { # file -> sha256, or "-" if nothing on this machine can hash
+  if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1"
+  elif command -v sha256sum >/dev/null 2>&1; then sha256sum "$1"
+  elif command -v openssl >/dev/null 2>&1; then openssl dgst -sha256 "$1" | sed 's/.*= //'
+  else echo -
+  fi | cut -d' ' -f1
+}
+
+{
+  echo "# fetched $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "# name url raw-sha256 css-sha256 frozen-sha256"
+} > "$manifest"
 
 fetch() { # name url
   name="$1"
   url="$2"
   echo "$name <- $url"
   if curl -sL --max-time 60 -A "Mozilla/5.0" "$url" -o "$out/$name.raw.html"; then
-    if node "$dir/inline_css.js" "$url" "$out/$name.raw.html" "$out/$name.in.html"
+    if info=$(node "$dir/inline_css.js" "$url" "$out/$name.raw.html" "$out/$name.in.html")
     then
-      node "$dir/freeze_page.js" "$out/$name.in.html" "$out/$name.html" ||
+      printf '%s\n' "$info"
+      if node "$dir/freeze_page.js" "$out/$name.in.html" "$out/$name.html"; then
+        # The CSS digest covers the stylesheet bytes alone, so a CDN that
+        # changed its CSS under an unchanged page is visible on its own line.
+        printf '%s %s %s %s %s\n' "$name" "$url" \
+          "$(sha "$out/$name.raw.html")" \
+          "$(printf '%s\n' "$info" | sed -n 's/^  css-sha256 //p')" \
+          "$(sha "$out/$name.html")" >> "$manifest"
+      else
         echo "  freeze failed"
+      fi
     else
       echo "  inline-css failed"
     fi

--- a/test/inline/freeze_page.js
+++ b/test/inline/freeze_page.js
@@ -1,0 +1,46 @@
+// Freeze a fetched page so its layout is a pure function of its CSS.
+//
+// A page straight off the wire has three resolvers that finish at a moment
+// nobody controls, and each of them moves computed styles: <script> mutates the
+// DOM, an @font-face whose relative .woff2 src cannot be read under file://
+// swaps text metrics from the fallback to the webfont mid-render, and an <img>
+// with an unreachable src settles on its broken-image box whenever the load
+// finally fails. Measured unfrozen, one unchanged pair of pages returned 14,
+// 410, 14 and 14 differences on four consecutive runs.
+//
+// Everything asynchronous is therefore removed, or replaced by something that
+// resolves before layout. <noscript> goes too: the browser leaves its content
+// as inert text while scripting is on, so an HTML parser that reads it as
+// markup styles elements the browser never lays out.
+//
+// Usage: node freeze_page.js <in.html> <out.html>
+const fs = require('fs');
+
+// A 1x1 transparent GIF: an intrinsic size that is known before layout.
+const PIXEL =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+const paired = (tag) =>
+  new RegExp('<' + tag + '\\b[^>]*>[\\s\\S]*?<\\/' + tag + '\\s*>', 'gi');
+
+function freeze(html) {
+  // Self-closing scripts first: to the paired pattern they read as an opener,
+  // and it would swallow the document down to the next </script>.
+  html = html.replace(/<script\b[^>]*\/>/gi, '');
+  for (const tag of ['script', 'noscript', 'iframe', 'video', 'audio'])
+    html = html.replace(paired(tag), '');
+  html = html.replace(/<source\b[^>]*>/gi, '');
+  html = html.replace(/@font-face\s*\{[^}]*\}/gi, '');
+  html = html.replace(/<img\b[^>]*>/gi, (tag) => {
+    // Leading \s keeps data-src and friends, which are inert without scripts.
+    const bare = tag.replace(
+      /\s(?:src|srcset|sizes)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]*)/gi,
+      ''
+    );
+    return bare.replace(/^<img/i, '<img src="' + PIXEL + '"');
+  });
+  return html;
+}
+
+const [, , inPath, outPath] = process.argv;
+fs.writeFileSync(outPath, freeze(fs.readFileSync(inPath, 'utf8')));

--- a/test/inline/inline_css.js
+++ b/test/inline/inline_css.js
@@ -4,6 +4,7 @@
 // in the headless browser without network access, so the differential test is
 // reproducible. Usage: node inline_css.js <page-url> <raw.html> <out.html>
 const { execSync } = require('child_process');
+const crypto = require('crypto');
 const fs = require('fs');
 const [, , pageUrl, rawPath, outPath] = process.argv;
 
@@ -36,3 +37,7 @@ const style = '<style>' + css + '</style>';
 html = html.includes('</head>') ? html.replace('</head>', style + '</head>') : style + html;
 fs.writeFileSync(outPath, html);
 console.log('  wrote ' + outPath + ' (' + html.length + ' bytes, ' + hrefs.length + ' stylesheet(s))');
+// The stylesheet bytes are whatever the CDN served at this moment, and they
+// move independently of the page. Digest them on their own so fetch.sh can
+// record which CSS a later measurement was taken against.
+console.log('  css-sha256 ' + crypto.createHash('sha256').update(css).digest('hex'));

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -3,6 +3,10 @@
 # complete computed style must be identical before and after a transform.
 # Covers `cascade apply` (both modes) and `cascade --minify` (each <style>
 # block minified in place). Skips cleanly with no browser or node (e.g. in CI).
+#
+# A difference list is reproducible, so two runs can be diffed against each
+# other: fetch.sh freezes every downloaded page (freeze_page.js) and xtest.js
+# pins the browser, leaving computed style a function of the CSS alone.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 export CASCADE=${CASCADE:-cascade}
 if [ -z "$CHROME" ]; then
@@ -21,41 +25,44 @@ if command -v dune >/dev/null 2>&1; then
   [ -n "$CANON_FILTER" ] && export CANON_FILTER="$(cd "$dir/../.." && pwd)/$CANON_FILTER"
 fi
 fail=0
+# xtest.js renders two pages, which is the whole cost of the run: keep its
+# report rather than paying for it a second time to print the failure.
+check() { # label before after
+  report=$(node "$dir/xtest.js" "$2" "$3" 2>&1)
+  case $report in
+    *IDENTICAL*) echo "ok   $1" ;;
+    *) echo "FAIL $1"
+       printf '%s\n' "$report" | head -8 | sed 's/^/     /'
+       fail=1 ;;
+  esac
+}
 for f in "$dir"/fixtures/*.html; do
   for mode in "" "--minimal"; do
-    out=$(mktemp)
-    "$CASCADE" apply $mode "$f" > "$out" 2>/dev/null
-    if node "$dir/xtest.js" "$f" "$out" 2>&1 | grep -q "IDENTICAL"; then
-      echo "ok   $(basename "$f") ${mode:-full}"
-    else
-      echo "FAIL $(basename "$f") ${mode:-full}"; node "$dir/xtest.js" "$f" "$out" 2>&1 | tail -6; fail=1
-    fi
-    rm -f "$out"
+    tmp=$(mktemp)
+    # shellcheck disable=SC2086 # an empty $mode must vanish, not pass ""
+    "$CASCADE" apply $mode "$f" > "$tmp" 2>/dev/null
+    check "$(basename "$f") ${mode:-full}" "$f" "$tmp"
+    rm -f "$tmp"
   done
 done
 # cascade --minify preserves the render too: minify each <style> block in place
 # and compare computed styles against the original page.
 for f in "$dir"/fixtures/*.html; do
-  out=$(mktemp)
-  node "$dir/minify_page.js" "$f" > "$out" 2>/dev/null
-  if node "$dir/xtest.js" "$f" "$out" 2>&1 | grep -q "IDENTICAL"; then
-    echo "ok   $(basename "$f") minify"
-  else
-    echo "FAIL $(basename "$f") minify"; node "$dir/xtest.js" "$f" "$out" 2>&1 | tail -6; fail=1
-  fi
-  rm -f "$out"
+  tmp=$(mktemp)
+  node "$dir/minify_page.js" "$f" > "$tmp" 2>/dev/null
+  check "$(basename "$f") minify" "$f" "$tmp"
+  rm -f "$tmp"
 done
-# Real pages downloaded by fetch.sh (gitignored): reported for coverage, but
-# they do not gate the run - they change upstream and exercise features still
-# being grown, so only the committed fixtures decide pass/fail.
-if [ -d "$dir/pages" ]; then
-  for f in "$dir"/pages/*.html; do
-    [ -e "$f" ] || continue
-    out=$(mktemp)
-    "$CASCADE" apply --minimal "$f" > "$out" 2>/dev/null
-    res=$(node "$dir/xtest.js" "$f" "$out" 2>/dev/null | grep RESULT)
-    echo "real $(basename "$f"): ${res:-no result}"
-    rm -f "$out"
-  done
-fi
+# Real pages downloaded by fetch.sh (gitignored, so absent until it is run).
+# They gate like the fixtures do: a surviving difference is a defect in the
+# transform, whichever page happened to find it. One that appears the day a
+# site is redesigned is still a defect, but re-run fetch.sh before reading it
+# as a regression in the working tree.
+for f in "$dir"/pages/*.html; do
+  [ -e "$f" ] || continue
+  tmp=$(mktemp)
+  "$CASCADE" apply --minimal "$f" > "$tmp" 2>/dev/null
+  check "real $(basename "$f") minimal" "$f" "$tmp"
+  rm -f "$tmp"
+done
 exit $fail

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -4,20 +4,36 @@
 # Covers `cascade apply` (both modes) and `cascade --minify` (each <style>
 # block minified in place). Skips cleanly with no browser or node (e.g. in CI).
 #
-# A difference list is reproducible, so two runs can be diffed against each
-# other: fetch.sh freezes every downloaded page (freeze_page.js) and xtest.js
-# pins the browser, leaving computed style a function of the CSS alone.
+# A difference list is a measurement, so the run says what produced it: the
+# browser version heads the output, and each fetched page carries the hash of
+# the bytes actually measured. fetch.sh freezes every downloaded page
+# (freeze_page.js) and xtest.js pins the browser, leaving computed style a
+# function of the CSS alone.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 root=$(dirname "$(dirname "$dir")")
 export CASCADE=${CASCADE:-cascade}
 if [ -z "$CHROME" ]; then
   CHROME=$(command -v chromium 2>/dev/null || command -v google-chrome 2>/dev/null || true)
 fi
-[ -z "$CHROME" ] && CHROME=$(find "$HOME/.cache/puppeteer" -type f -name chrome-headless-shell 2>/dev/null | sort | tail -1)
+# sort -V, not sort: the cache holds mac_arm-<version> directories, and in
+# lexical order a 99.x outranks a 146.x.
+[ -z "$CHROME" ] && CHROME=$(find "$HOME/.cache/puppeteer" -type f -name chrome-headless-shell 2>/dev/null | sort -V | tail -1)
 if [ -z "$CHROME" ] || ! command -v node >/dev/null 2>&1; then
   echo "SKIP: no headless browser or node available"; exit 0
 fi
 export CHROME
+
+# Chrome versions do not agree on computed styles, so a count is comparable
+# only against another from the same engine. Reporting the version keeps a
+# number from being quoted without it; CHROME_VERSION demands a given build for
+# a comparison that has to cross machines, and is unset by default because
+# requiring one build outright would strand anyone who lacks it.
+browser=$("$CHROME" --version 2>/dev/null | tr -d '\r')
+[ -z "$browser" ] && browser="unknown ($CHROME)"
+if [ -n "$CHROME_VERSION" ] && ! printf '%s\n' "$browser" | grep -qF "$CHROME_VERSION"; then
+  echo "ERROR: CHROME_VERSION=$CHROME_VERSION, but the browser is $browser" >&2
+  exit 1
+fi
 
 # Build through the checkout's own opam switch. A bare `dune` off $PATH can
 # belong to a different switch, and building with it fills _build with
@@ -59,6 +75,18 @@ if [ "$canon_probe" != "$(printf '0\tX\tcolor\tred\tblue')" ]; then
 fi
 export CANON_FILTER
 
+# Fetched pages are downloaded rather than committed, so record which bytes
+# produced a result: the hash moves when the site or its CDN does, and a count
+# that moved with it is explained instead of mysterious.
+sha() { # file -> first 12 hex of sha256
+  if command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1"
+  elif command -v sha256sum >/dev/null 2>&1; then sha256sum "$1"
+  elif command -v openssl >/dev/null 2>&1; then openssl dgst -sha256 "$1" | sed 's/.*= //'
+  else echo nohash
+  fi | cut -c1-12
+}
+
+echo "browser: $browser"
 echo "compare: canonical"
 fail=0
 # xtest.js renders two pages, which is the whole cost of the run: keep its
@@ -93,12 +121,13 @@ done
 # They gate like the fixtures do: a surviving difference is a defect in the
 # transform, whichever page happened to find it. One that appears the day a
 # site is redesigned is still a defect, but re-run fetch.sh before reading it
-# as a regression in the working tree.
+# as a regression in the working tree, and check the hash in the label first.
 for f in "$dir"/pages/*.html; do
   [ -e "$f" ] || continue
+  page="$(basename "$f")@$(sha "$f")"
   tmp=$(mktemp)
   "$CASCADE" apply --minimal "$f" > "$tmp" 2>/dev/null
-  check "real $(basename "$f") minimal" "$f" "$tmp"
+  check "real $page minimal" "$f" "$tmp"
   rm -f "$tmp"
 done
 exit $fail

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -8,6 +8,7 @@
 # other: fetch.sh freezes every downloaded page (freeze_page.js) and xtest.js
 # pins the browser, leaving computed style a function of the CSS alone.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+root=$(dirname "$(dirname "$dir")")
 export CASCADE=${CASCADE:-cascade}
 if [ -z "$CHROME" ]; then
   CHROME=$(command -v chromium 2>/dev/null || command -v google-chrome 2>/dev/null || true)
@@ -17,13 +18,48 @@ if [ -z "$CHROME" ] || ! command -v node >/dev/null 2>&1; then
   echo "SKIP: no headless browser or node available"; exit 0
 fi
 export CHROME
+
+# Build through the checkout's own opam switch. A bare `dune` off $PATH can
+# belong to a different switch, and building with it fills _build with
+# artefacts this project's compiler cannot read. The switch is located from the
+# script's own position, or from the main worktree whose _opam a linked
+# worktree shares, so nothing here is a hardcoded path.
+switch=
+if command -v opam >/dev/null 2>&1; then
+  common=$(git -C "$dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+  for cand in "$root" "${common:+$(dirname "$common")}"; do
+    if [ -n "$cand" ] && [ -d "$cand/_opam" ]; then switch=$cand; break; fi
+  done
+fi
+dune_() {
+  if [ -n "$switch" ]; then opam exec --switch="$switch" -- dune "$@"; else dune "$@"; fi
+}
+
 # Canonical-difference filter: compares values the way cascade does, so
 # render-equivalent spellings (0% vs 0px, red vs rgb(...)) are not reported.
-if command -v dune >/dev/null 2>&1; then
-  dune build test/inline/canon_filter.exe 2>/dev/null
-  CANON_FILTER=$(cd "$dir/../.." && find _build -name canon_filter.exe 2>/dev/null | head -1)
-  [ -n "$CANON_FILTER" ] && export CANON_FILTER="$(cd "$dir/../.." && pwd)/$CANON_FILTER"
+# Without it every such pair counts, and the run prints a number that looks
+# like a result but is an inflated one, which is worse than no number at all.
+# So a filter that is missing or does not work is fatal, not skipped.
+if [ -z "$CANON_FILTER" ]; then
+  (cd "$root" && dune_ build test/inline/canon_filter.exe) 2>/dev/null
+  CANON_FILTER="$root/_build/default/test/inline/canon_filter.exe"
 fi
+# Prove it filters, rather than that a file exists: a stale or broken binary
+# passes an existence check and silently restores raw comparison. The first
+# line is one spelling of one value and must be dropped; the second is a real
+# change and must survive.
+canon_probe=$(printf '0\tX\tbackground-position\t0%% 0%%\t0px 0px\n0\tX\tcolor\tred\tblue\n' |
+  "$CANON_FILTER" 2>/dev/null)
+if [ "$canon_probe" != "$(printf '0\tX\tcolor\tred\tblue')" ]; then
+  echo "ERROR: canonical filter missing or not filtering: $CANON_FILTER" >&2
+  echo "  build it with: dune build test/inline/canon_filter.exe" >&2
+  echo "  (or point CANON_FILTER at one). Without it, equivalent spellings" >&2
+  echo "  count as differences and the reported total is not a result." >&2
+  exit 1
+fi
+export CANON_FILTER
+
+echo "compare: canonical"
 fail=0
 # xtest.js renders two pages, which is the whole cost of the run: keep its
 # report rather than paying for it a second time to print the failure.

--- a/test/inline/xtest.js
+++ b/test/inline/xtest.js
@@ -8,12 +8,29 @@ const EXTRACTOR = '<script>(function(){var s=' + JSON.stringify(SKIP) +
   // real properties, which are already resolved and compared below.
   'var c=getComputedStyle(x),r={_tag:x.tagName};for(var j=0;j<c.length;j++){var p=c[j];if(p.indexOf("--")===0)continue;r[p]=c.getPropertyValue(p);}o.push(r);}' +
   'document.body.setAttribute("data-xtest",btoa(unescape(encodeURIComponent(JSON.stringify(o)))));})();</script>';
+// Rendering has to be a pure function of the page: a computed style that
+// depends on when the network gave up, how wide the window is or what the
+// display scale is makes the difference list change run to run. The pages
+// themselves are frozen by freeze_page.js at fetch time; these pin the browser.
+//   host-resolver-rules   nothing resolves, so a stray remote URL fails at once
+//   window-size, scale    viewport units and device pixels are fixed
+//   hide-scrollbars       a scrollbar does not eat viewport width
+const FLAGS = '--headless --disable-gpu --no-sandbox' +
+  ' --host-resolver-rules="MAP * ~NOTFOUND" --window-size=1280,900' +
+  ' --force-device-scale-factor=1 --hide-scrollbars --virtual-time-budget=4000';
 function computed(path){
-  let h = fs.readFileSync(path,'utf8');
-  h = h.includes('</body>') ? h.replace('</body>', EXTRACTOR+'</body>') : h+EXTRACTOR;
-  const tmp = '/tmp/xt_'+path.replace(/\W/g,'_')+'.html';
+  // Appended, not spliced in at </body>: a page can carry that text inside an
+  // attribute value (wikipedia's CSS article quotes a whole HTML document in
+  // one), and splicing there puts the extractor somewhere it never runs. The
+  // parser reparents trailing content into the body, so the end of the file
+  // reaches the same place.
+  const h = fs.readFileSync(path,'utf8') + EXTRACTOR;
+  const tmp = '/tmp/xt_'+process.pid+'_'+path.replace(/\W/g,'_')+'.html';
   fs.writeFileSync(tmp,h);
-  const dom = execSync(`"${CHROME}" --headless --disable-gpu --no-sandbox --virtual-time-budget=2000 --dump-dom "file://${tmp}"`,{encoding:'utf8',maxBuffer:1e8});
+  // Chrome's stderr is console chatter from the page (a blocked preload, a
+  // CORS notice); dropping it keeps a caller's failure report readable. A
+  // browser that fails outright still shows up: there is no data-xtest.
+  const dom = execSync(`"${CHROME}" ${FLAGS} --dump-dom "file://${tmp}"`,{encoding:'utf8',maxBuffer:1e8,stdio:['ignore','pipe','ignore']});
   const m = dom.match(/data-xtest="([^"]*)"/);
   if(!m) throw new Error('no data-xtest for '+path);
   return JSON.parse(Buffer.from(m[1],'base64').toString('utf8'));
@@ -38,4 +55,5 @@ const diffs = lines.map(l=>{const f=l.split('\t');return '['+f[0]+' '+f[1]+'] '+
 if (a.length !== b.length) diffs.unshift('element count '+a.length+' vs '+b.length);
 console.log('visual elements: '+n+', computed props/elem: ~'+Object.keys(a[0]||{}).length+(CANON?' (canonical compare)':''));
 if (!diffs.length) console.log('RESULT: IDENTICAL computed styles (inlining preserves the render)');
-else { console.log('RESULT: '+diffs.length+' difference(s):'); diffs.slice(0,40).forEach(d=>console.log('  '+d)); }
+// The whole list, not a sample: it is the artifact you diff between runs.
+else { console.log('RESULT: '+diffs.length+' difference(s):'); diffs.forEach(d=>console.log('  '+d)); }

--- a/test/inline/xtest.js
+++ b/test/inline/xtest.js
@@ -53,7 +53,12 @@ if (CANON && cand.length) {
 }
 const diffs = lines.map(l=>{const f=l.split('\t');return '['+f[0]+' '+f[1]+'] '+f[2]+': "'+f[3]+'" vs "'+f[4]+'"';});
 if (a.length !== b.length) diffs.unshift('element count '+a.length+' vs '+b.length);
-console.log('visual elements: '+n+', computed props/elem: ~'+Object.keys(a[0]||{}).length+(CANON?' (canonical compare)':''));
+// Say which comparison produced the count. Without the filter every
+// equivalent spelling counts, so the total is inflated and is not the number
+// run.sh reports: label it loudly rather than let it pass for the real one.
+const how = CANON ? ' (canonical compare)'
+  : ' (RAW COMPARE, no CANON_FILTER: equivalent spellings counted, total inflated)';
+console.log('visual elements: '+n+', computed props/elem: ~'+Object.keys(a[0]||{}).length+how);
 if (!diffs.length) console.log('RESULT: IDENTICAL computed styles (inlining preserves the render)');
 // The whole list, not a sample: it is the artifact you diff between runs.
-else { console.log('RESULT: '+diffs.length+' difference(s):'); diffs.forEach(d=>console.log('  '+d)); }
+else { console.log('RESULT: '+diffs.length+' difference(s)'+(CANON?'':' [RAW, INFLATED]')+':'); diffs.forEach(d=>console.log('  '+d)); }

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -397,6 +397,9 @@ let matrix =
         "text-decoration-color";
         "-webkit-text-decoration-color";
         "-webkit-tap-highlight-color";
+        "-webkit-text-fill-color";
+        "-webkit-text-stroke-color";
+        "column-rule-color";
         "outline-color";
         "fill";
         "stroke";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2401,7 +2401,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 452
+    "property grammar manifest covers every tracked spec property name" 455
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -925,6 +925,36 @@ let test_vendor_prefix_baseline_gate () =
     ".a{-moz-box-sizing:border-box!important;box-sizing:border-box}"
     (opt ".a{-moz-box-sizing:border-box!important;box-sizing:border-box}")
 
+(* A colour-valued property folds its colour whatever its name: CIE Lab
+   L=1.90334 a=0.278696 b=-5.48866 is sRGB 3,7,18, so both spellings print the
+   same hex. A property left out of the fold reports the two as different
+   values, which is what the browser-differential harness then counts as a
+   render change. *)
+let test_color_property_folds () =
+  let opt css =
+    match Css.of_string css with
+    | Ok p ->
+        Css.to_string ~minify:true (Css.optimize p.stylesheet) |> String.trim
+    | Error _ -> Alcotest.fail "parse"
+  in
+  List.iter
+    (fun property ->
+      let rule value = String.concat "" [ ".a{"; property; ":"; value; "}" ] in
+      Alcotest.(check string)
+        (String.concat "" [ property; " folds lab() to hex" ])
+        (rule "#030712")
+        (opt (rule "lab(1.90334 0.278696 -5.48866)"));
+      Alcotest.(check string)
+        (String.concat "" [ property; " folds rgb() to hex" ])
+        (rule "#030712")
+        (opt (rule "rgb(3, 7, 18)")))
+    [
+      "color";
+      "column-rule-color";
+      "-webkit-text-fill-color";
+      "-webkit-text-stroke-color";
+    ]
+
 let test_lossless_declaration_order () =
   let opt ?(lossless = false) css =
     match Css.of_string css with
@@ -1267,6 +1297,7 @@ let optimize_tests =
       nesting_synthesis_can_be_disabled );
     ("vendor prefix strip", `Quick, test_vendor_prefix_strip);
     ("vendor prefix baseline gate", `Quick, test_vendor_prefix_baseline_gate);
+    ("color property folds", `Quick, test_color_property_folds);
     ("lossless declaration order", `Quick, test_lossless_declaration_order);
     ( "lossless keeps unknown property order",
       `Quick,


### PR DESCRIPTION
`column-rule-color` and `-webkit-text-stroke-color` parsed as opaque token streams and `-webkit-text-fill-color` was left out of the colour fold, so `lab(1.90334 0.278696 -5.48866)` and `rgb(3, 7, 18)` compared equal under every other colour-valued property and unequal under those three. Stacked on #361.