### PR TITLE
test/inline: tighten the filter probe and report a crash as a crash

### DIFF
--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -72,9 +72,11 @@ compares values the way cascade does, so `0%` against `0px`, or `red` against
 `rgb(255, 0, 0)`, is not reported. Comparing raw strings instead counts every
 such pair, which inflates the total into a number that reads like a result and
 is not one. `run.sh` therefore builds the filter through the checkout's own
-opam switch and proves it filters, on a pair that must be dropped and a pair
+opam switch and proves it filters, on two pairs that must be dropped and one
 that must survive, before measuring anything; a filter that is missing or wrong
-stops the run rather than downgrading it.
+stops the run rather than downgrading it. One dropped pair is vendor-prefixed,
+because cascade folds a colour only for a property it types, and a real page's
+prefixed colours outnumber all its other differences.
 
 ## Coverage
 

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -119,12 +119,31 @@ check() { # label before after
        fail=1 ;;
   esac
 }
+# A transform that dies leaves an empty file, and an empty page differs from
+# the original in every computed style, so the run blames the transform for a
+# render change that never happened. Report the status, and the error the tool
+# printed with it.
+transform() { # label out cmd...
+  label=$1; out=$2; shift 2
+  err=$(mktemp)
+  "$@" > "$out" 2> "$err"
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "CRASH $label (exit $status): $*"
+    head -8 "$err" | sed 's/^/     /'
+    fail=1
+  fi
+  rm -f "$err"
+  return "$status"
+}
 for f in "$dir"/fixtures/*.html; do
   for mode in "" "--minimal"; do
     tmp=$(mktemp)
+    label="$(basename "$f") ${mode:-full}"
     # shellcheck disable=SC2086 # an empty $mode must vanish, not pass ""
-    "$CASCADE" apply $mode "$f" > "$tmp" 2>/dev/null
-    check "$(basename "$f") ${mode:-full}" "$f" "$tmp"
+    if transform "$label" "$tmp" "$CASCADE" apply $mode "$f"; then
+      check "$label" "$f" "$tmp"
+    fi
     rm -f "$tmp"
   done
 done
@@ -134,9 +153,11 @@ done
 for flags in "" "--inline-vars"; do
   for f in "$dir"/fixtures/*.html; do
     tmp=$(mktemp)
+    label="$(basename "$f") minify${flags:+ $flags}"
     # shellcheck disable=SC2086 # an empty $flags must vanish, not pass ""
-    node "$dir/minify_page.js" "$f" $flags > "$tmp" 2>/dev/null
-    check "$(basename "$f") minify${flags:+ $flags}" "$f" "$tmp"
+    if transform "$label" "$tmp" node "$dir/minify_page.js" "$f" $flags; then
+      check "$label" "$f" "$tmp"
+    fi
     rm -f "$tmp"
   done
 done
@@ -149,8 +170,10 @@ for f in "$dir"/pages/*.html; do
   [ -e "$f" ] || continue
   page="$(basename "$f")@$(sha "$f")"
   tmp=$(mktemp)
-  "$CASCADE" apply --minimal "$f" > "$tmp" 2>/dev/null
-  check "real $page minimal" "$f" "$tmp"
+  label="real $page minimal"
+  if transform "$label" "$tmp" "$CASCADE" apply --minimal "$f"; then
+    check "$label" "$f" "$tmp"
+  fi
   rm -f "$tmp"
 done
 exit $fail

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -77,10 +77,12 @@ if [ -z "$CANON_FILTER" ]; then
   CANON_FILTER="$root/_build/default/test/inline/canon_filter.exe"
 fi
 # Prove it filters, rather than that a file exists: a stale or broken binary
-# passes an existence check and silently restores raw comparison. The first
-# line is one spelling of one value and must be dropped; the second is a real
-# change and must survive.
-canon_probe=$(printf '0\tX\tbackground-position\t0%% 0%%\t0px 0px\n0\tX\tcolor\tred\tblue\n' |
+# passes an existence check and silently restores raw comparison. The first two
+# lines each spell one value two ways and must be dropped; the third is a real
+# change and must survive. The prefixed line is there on purpose: cascade folds
+# a colour only for a property it types, and the prefixed colours are the ones
+# a real page carries by the thousand.
+canon_probe=$(printf '0\tX\tbackground-position\t0%% 0%%\t0px 0px\n0\tX\t-webkit-text-fill-color\tlab(1.90334 0.278696 -5.48866)\trgb(3, 7, 18)\n0\tX\tcolor\tred\tblue\n' |
   "$CANON_FILTER" 2>/dev/null)
 if [ "$canon_probe" != "$(printf '0\tX\tcolor\tred\tblue')" ]; then
   echo "ERROR: canonical filter missing or not filtering: $CANON_FILTER" >&2


### PR DESCRIPTION
The probe folded a colour under `color` alone, so it passed while the render diff counted a page's prefixed colours as render changes, and `cascade apply`'s discarded exit status made a crash read as a transform that emptied the page. Stacked on #365.