### PR TITLE
values: never spend the precision budget on an integer digit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -185,6 +185,13 @@
   and cascade's own reader both drop. `abs()` and `hypot()` now carry their
   arguments' unit out, the inverse trig functions carry `deg`, and a call whose
   operands mix units keeps its spelling (#362)
+- A computed dimension past a million units keeps every digit under `--minify`.
+  Six significant figures stop reaching its fraction there, so the budget was
+  paid in integer digits the arithmetic got right: `calc(1in + 999999999px)`
+  came out as `1000000000px`, 95px from the `1000000095px` an inch is worth (CSS
+  Values 4 sec. 6.2), and `hypot(999999999px, 1px)` a pixel wider than its own
+  longest side. A narrower value still pays the budget: `calc(1cm + 1px)` is
+  `38.7953px` (#367)
 - An empty `@layer name` inside a style rule keeps its block form. The
   statement form is a layer-order declaration, which no style rule accepts, so
   `.a { @layer n {} }` minified to `.a{@layer n;}`, which neither a browser nor

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -989,8 +989,18 @@ let pp_calc_contents : type a. a Pp.t -> a calc Pp.t =
    out of [pi] or [sqrt()], a conversion between absolute units - which carries
    digits that will never be printed. An authored coefficient is the author's
    own digits and keeps every one of them: at a [14px] font [.4285714em] is
-   [6px] and [.428571em] is not. *)
-let round_computed (f : float) : float = Pp.round_sig 6 f
+   [6px] and [.428571em] is not.
+
+   The budget buys a fractional tail, and six significant figures reach one only
+   while the magnitude stays under [10^6]. Wider than that the only digits left
+   to drop are integer ones the arithmetic got right: [1in] is exactly [96px]
+   and [1pt] exactly [4/3px] (CSS Values 4 sec. 6.2), so an inch added to
+   [999999999px] is [1000000095px], and [1000000000px] is 95px away from it. *)
+let round_computed (f : float) : float =
+  if Float.abs f < 1e6 then Pp.round_sig 6 f else f
+
+(* Whether every digit of [f] already prints within the budget. *)
+let fits_precision (f : float) : bool = Pp.round_sig 6 f = f
 
 (* Fold [a / b] only when the float quotient round-trips through multiplication:
    exact divisions like [100/4 = 25] survive but [100/3 = 33.333...] does not,
@@ -1001,10 +1011,10 @@ let exact_div (a : float) (b : float) : float option =
   else
     let r = a /. b in
     (* Round-trip alone is too lax under IEEE 754 (33.333... * 3 = 100.0 due to
-       multiplication rounding). Also require the quotient to survive
-       [round_computed]. *)
-    if Float.is_finite r && r *. b = a && round_computed r = r then
-      Option.some r
+       multiplication rounding). Also require the quotient to fit the serialised
+       precision, whatever its magnitude: an unfolded [calc()] keeps the digits
+       the quotient would otherwise drop. *)
+    if Float.is_finite r && r *. b = a && fits_precision r then Option.some r
     else Option.none
 
 (* Scale the coefficient [v] of a typed leaf by [n], rebuilding the leaf in its

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -7045,6 +7045,62 @@ let authored_precision_preserved () =
         ".x{line-height:6.28318531}" );
     ]
 
+(* The six-significant-figure budget buys a fractional tail, and past 10^6 it
+   stops reaching one: the only digits left to spend are integer ones the
+   arithmetic got right. [1in] is exactly [96px] and [1pt] exactly [4/3px] (CSS
+   Values 4 sec. 6.2), so [calc(1in + 999999999px)] is [1000000095px] and
+   rounding it to [1000000000px] moves the box by 95px. A value small enough for
+   the budget to reach its fraction still pays it: [1cm] is [4800/127px], whose
+   tail is Cascade's own noise. *)
+let computed_precision_keeps_integer_digits () =
+  let normalize css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> minify parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  List.iter
+    (fun (name, input, expected) ->
+      Alcotest.(check string) name expected (normalize input);
+      Alcotest.(check string)
+        (name ^ " [idempotent]") expected (normalize expected))
+    [
+      (* An absolute-unit combine past 10^6 keeps every digit. *)
+      ( "in + px keeps the whole magnitude",
+        ".x { width: calc(1in + 999999999px) }",
+        ".x{width:1000000095px}" );
+      ( "in + px keeps a mid-range magnitude",
+        ".x { width: calc(1in + 12345678px) }",
+        ".x{width:12345774px}" );
+      ( "pc + px keeps the whole magnitude",
+        ".x { width: calc(1pc + 1000000px) }",
+        ".x{width:1000016px}" );
+      ( "pt + px keeps the third of a pixel",
+        ".x { width: calc(1pt + 1000000px) }",
+        ".x{width:1000001.33333333px}" );
+      ( "hypot() past 10^6 keeps the whole magnitude",
+        ".x { width: hypot(999999999px, 1px) }",
+        ".x{width:999999999px}" );
+      ( "a folded irrational past 10^6 keeps its integer digits",
+        ".x { width: calc(1000000px * pi) }",
+        ".x{width:3141592.65358979px}" );
+      (* Under 10^6 the budget still spends the tail. *)
+      ( "cm + px spends the tail",
+        ".x { width: calc(1cm + 1px) }",
+        ".x{width:38.7953px}" );
+      ( "mm + px spends the tail",
+        ".x { width: calc(1mm + 1px) }",
+        ".x{width:4.77953px}" );
+      ( "q + px spends the tail",
+        ".x { width: calc(1q + 1px) }",
+        ".x{width:1.94488px}" );
+      ( "a non-Pythagorean hypot() spends the tail",
+        ".x { width: hypot(1px, 2px) }",
+        ".x{width:2.23607px}" );
+      ( "a Pythagorean hypot() has no tail to spend",
+        ".x { width: hypot(3px, 4px) }",
+        ".x{width:5px}" );
+    ]
+
 let v4107_mod_rem () =
   let normalize css =
     match Css.of_string ~strict:false css with
@@ -8539,6 +8595,9 @@ let additional_tests =
     ( "authored numeric precision preserved",
       `Quick,
       authored_precision_preserved );
+    ( "computed numeric precision keeps integer digits",
+      `Quick,
+      computed_precision_keeps_integer_digits );
     ("spec values 4 10.7 mod/rem reduction", `Quick, v4107_mod_rem);
     ("spec values 4 10.7 round reduction", `Quick, v4_10_7_round_reduction);
     ( "spec values 4 10.7 division by zero preserved",


### PR DESCRIPTION
`calc(1in + 999999999px)` used to minify to `1000000000px`, 95px from the `1000000095px` an inch is worth: past a million units six significant figures no longer reach the fraction, so the budget came out of integer digits the arithmetic got right. A narrower value still pays it, so `calc(1cm + 1px)` stays `38.7953px`. Follow-up to #350.