### PR TITLE
stylesheet: make a declaration-site choice outside the folds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -179,6 +179,11 @@
   statement to a function that keeps, replaces or drops it, and descends into
   what survives, so a pass that drops a statement no longer carries its own
   list of the at-rules that nest (#363)
+- `Css.Stylesheet.at_declaration_site` answers whether a statement holds its
+  declarations in one of the places a `declaration_sites` record names. A walk
+  that carries a cascade layer or an `@supports` depth down the tree cannot be
+  a fold, and can now name the sites it reads instead of matching on the
+  statements it expects to meet (#368)
 
 ### CLI tools
 

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -80,6 +80,27 @@ let layer_known ~layer_order = function
   | None -> true
   | Some name -> List.exists (String.equal name) layer_order
 
+(* The places a declaration contributes to ordinary element matching. The other
+   declaration sites belong to another cascade origin or to no element at all
+   (CSS Cascading 5 sec. 6.1): [@keyframes] is the animation origin,
+   [@position-try] the position fallback origin, [@page] and its margin boxes
+   are not elements, and [@supports-condition] is never applied to a box.
+   Written out in full so that a site added to the record has to be classified
+   here. *)
+let element_matching_sites =
+  {
+    Stylesheet.element_rule = true;
+    animation_frame = false;
+    page_box = false;
+    position_fallback = false;
+    condition_test = false;
+  }
+
+(* The layer a declaration sits in is carried down the tree and differs per
+   branch, which no accumulator can do, so this spells its own recursion rather
+   than calling [fold_declarations]. The descent is still [statement_children]'s
+   and the sites are still named, so a grouping at-rule or a declaration site
+   added later reaches this walk. *)
 let collect_cascade_rules ~layer_order stylesheet =
   let source_order = ref 0 in
   let add layer decl acc =
@@ -95,36 +116,20 @@ let collect_cascade_rules ~layer_order stylesheet =
     incr source_order;
     rule :: acc
   in
-  let rec statement current_layer acc =
+  let rec statement current_layer acc stmt =
     let open Stylesheet in
-    function
-    | Rule rule ->
-        let acc =
-          List.fold_left
-            (fun acc decl -> add current_layer decl acc)
-            acc rule.declarations
-        in
-        List.fold_left (statement current_layer) acc rule.nested
-    | Declarations declarations ->
+    let current_layer =
+      match stmt with Layer ((Some _ as name), _) -> name | _ -> current_layer
+    in
+    let acc =
+      if at_declaration_site element_matching_sites stmt then
         List.fold_left
           (fun acc decl -> add current_layer decl acc)
-          acc declarations
-    | Layer (name, block) ->
-        let current_layer =
-          match name with Some _ -> name | None -> current_layer
-        in
-        List.fold_left (statement current_layer) acc block
-    | Media (_, block)
-    | Supports (_, block)
-    | Moz_document (_, block)
-    | When (_, block)
-    | Else (_, block)
-    | Starting_style block
-    | Origin (_, block) ->
-        List.fold_left (statement current_layer) acc block
-    | Container (_, _, block) | Scope (_, _, block) ->
-        List.fold_left (statement current_layer) acc block
-    | _ -> acc
+          acc
+          (statement_declarations stmt)
+      else acc
+    in
+    List.fold_left (statement current_layer) acc (statement_children stmt)
   in
   List.fold_left (statement None) [] stylesheet
   |> List.filter (fun (rule : Context.cascade_rule) ->
@@ -1022,23 +1027,9 @@ let root_theme_rule declarations =
       merge_key = None;
     }
 
-(* The places a declaration contributes to ordinary element matching. The other
-   declaration sites belong to another cascade origin or to no element at all
-   (CSS Cascading 5 sec. 6.1): [@keyframes] is the animation origin,
-   [@position-try] the position fallback origin, [@page] and its margin boxes
-   are not elements, and [@supports-condition] is never applied to a box. None
-   of them declares a name for an element that merely references it. Written out
-   in full so that a site added to the record has to be classified here. *)
-let element_matching_sites =
-  {
-    Stylesheet.element_rule = true;
-    animation_frame = false;
-    page_box = false;
-    position_fallback = false;
-    condition_test = false;
-  }
-
-(* Names a style rule declares as a custom property (bare, no [--]). *)
+(* Names a style rule declares as a custom property (bare, no [--]). Only the
+   element-matching sites count: a name written in another cascade origin is not
+   declared for the element that merely references it. *)
 let declared_custom_prop_names (stmts : Stylesheet.statement list) :
     (string, unit) Hashtbl.t =
   let tbl = Hashtbl.create 16 in

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -463,6 +463,8 @@ let site_selected sites = function
   | Position_fallback -> sites.position_fallback
   | Condition_test -> sites.condition_test
 
+let at_declaration_site sites stmt = site_selected sites (declaration_site stmt)
+
 let rec fold_statements f acc block =
   List.fold_left
     (fun acc stmt -> fold_statements f (f acc stmt) (statement_children stmt))
@@ -493,8 +495,7 @@ let edit_statements f block =
 let fold_declarations ?(sites = every_site) f acc block =
   fold_statements
     (fun acc stmt ->
-      if site_selected sites (declaration_site stmt) then
-        f acc (statement_declarations stmt)
+      if at_declaration_site sites stmt then f acc (statement_declarations stmt)
       else acc)
     acc block
 

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -282,6 +282,15 @@ type declaration_sites = {
     at-rule, and makes a place added here a compile error in every walk that
     made a choice. *)
 
+val at_declaration_site : declaration_sites -> statement -> bool
+(** [at_declaration_site sites stmt] holds when the declarations [stmt] carries
+    sit in one of the places [sites] names. It is the test {!fold_declarations}
+    makes, exposed for a walk that carries something down the tree, such as the
+    cascade layer a declaration sits in or an [@supports] nesting depth. An
+    accumulator travels sideways rather than down, so such a walk cannot be a
+    fold and recurses on {!statement_children} instead; this keeps the sites it
+    reads as compile-checked as the fold's. *)
+
 val fold_statements : ('a -> statement -> 'a) -> 'a -> block -> 'a
 (** [fold_statements f acc block] folds [f] over [block] and over every
     statement reachable from it through {!statement_children}, in source order,

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -7978,6 +7978,36 @@ let deep_walker_tests =
           "element declarations only"
           (List.sort compare element_places)
           (properties_folded ~sites ()) );
+    ( "at_declaration_site makes the fold's choice outside the fold",
+      `Quick,
+      fun () ->
+        (* A walk that carries something down the tree recurses itself, so it
+           reads the sites rather than passing them; it must land on the same
+           declarations the fold does. *)
+        let sites =
+          {
+            element_rule = true;
+            animation_frame = false;
+            page_box = false;
+            position_fallback = false;
+            condition_test = false;
+          }
+        in
+        let rec walk acc stmt =
+          let acc =
+            if at_declaration_site sites stmt then
+              List.rev_append
+                (List.map Css.Declaration.property_name
+                   (statement_declarations stmt))
+                acc
+            else acc
+          in
+          List.fold_left walk acc (statement_children stmt)
+        in
+        Alcotest.(check (list string))
+          "the sites the fold folds over"
+          (properties_folded ~sites ())
+          (List.sort compare (List.fold_left walk [] (places ()))) );
     ( "map_declarations rewrites every place a declaration sits",
       `Quick,
       fun () ->


### PR DESCRIPTION
The collector behind `Css.eval_stylesheet` carries the cascade layer down the tree, which an accumulator cannot do, so it could not call `fold_declarations` and listed the at-rules that nest itself; a new one would have kept its declarations out of the cascade in silence. This PR adds `Css.Stylesheet.at_declaration_site` so a walk that spells its own recursion still names the declaration sites it reads, and moves the collector onto it and onto `statement_children`.

Stacked on #363.