### PR TITLE
stylesheet: minify emitted a nested block cascade cannot read back

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,12 @@
   `-webkit-backdrop-filter`, `-webkit-user-select`, `-webkit-text-size-adjust`
   and `-webkit-print-color-adjust` were dropped against an unprefixed twin no
   shipping Safari understands (#325)
+- Unwrapping a baseline-true `@supports` nested in a style rule keeps the `;`
+  separating its declarations from the sibling that follows. CSS Syntax 3 sec.
+  5.4.4 runs a declaration to the next `;` or to the block's `}`, so
+  `.a{@supports (color:red){color:blue}@supports (color:red){color:green}}`
+  minified to `.a{color:#00fcolor:green}`, which browsers and cascade's own
+  reader reject, losing the declaration (#370)
 
 ### Custom properties
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1086,6 +1086,15 @@ let pp_view_transition_descriptor : view_transition_descriptor Pp.t =
       Pp.space_if_pretty ctx ();
       Pp.list ~sep:Pp.space Pp.string ctx types
 
+(* Under minify a [Declarations] statement carries no trailing [;] of its own,
+   so whoever sequences the statements owes it a separator: CSS Syntax 3 sec.
+   5.4.4 runs a declaration to the next [;] or to the block's [}], and a sibling
+   that follows would otherwise be read as part of its value. *)
+let pp_declarations_sep ctx = function
+  | Declarations decls when decls <> [] && Pp.minified ctx ->
+      Pp.semicolon ctx ()
+  | _ -> ()
+
 let rec pp_rule : rule Pp.t =
  fun ctx rule ->
   Selector.pp ctx rule.selector;
@@ -1102,7 +1111,16 @@ let rec pp_rule : rule Pp.t =
           ctx decls
       in
       let pp_nested ctx () =
-        Pp.list ~sep:Pp.cut (Pp.indent pp_statement) ctx nested
+        let rec loop = function
+          | [] -> ()
+          | [ stmt ] -> Pp.indent pp_statement ctx stmt
+          | stmt :: rest ->
+              Pp.indent pp_statement ctx stmt;
+              pp_declarations_sep ctx stmt;
+              Pp.cut ctx ();
+              loop rest
+        in
+        loop nested
       in
       Pp.cut ctx ();
       (match (decls, nested) with
@@ -1327,11 +1345,6 @@ and pp_statement : statement Pp.t =
 and pp_block : block Pp.t =
  fun ctx statements ->
   let statements = printable_statements ctx statements in
-  let pp_statement_sep ctx = function
-    | Declarations decls when decls <> [] && Pp.minified ctx ->
-        Pp.semicolon ctx ()
-    | _ -> ()
-  in
   (* Block printing for at-rules (@media, @supports, etc.) The braces helper
      adds nest 1 and indent for the first item only. Subsequent items need
      explicit indentation and blank line separation to match Tailwind format. *)
@@ -1340,7 +1353,7 @@ and pp_block : block Pp.t =
   | [ s ] -> pp_statement ctx s
   | s :: rest ->
       pp_statement ctx s;
-      pp_statement_sep ctx s;
+      pp_declarations_sep ctx s;
       let rec pp_rest = function
         | [] -> ()
         | [ stmt ] ->
@@ -1351,7 +1364,7 @@ and pp_block : block Pp.t =
             Pp.cut ctx ();
             if not ctx.Pp.minify then Pp.cut ctx ();
             Pp.indent pp_statement ctx stmt;
-            pp_statement_sep ctx stmt;
+            pp_declarations_sep ctx stmt;
             pp_rest rest
       in
       pp_rest rest
@@ -1364,17 +1377,12 @@ let pp_stylesheet : stylesheet Pp.t =
     if Pp.minified ctx then normalise statements else statements
   in
   let statements = printable_statements ctx statements in
-  let pp_statement_sep ctx = function
-    | Declarations decls when decls <> [] && Pp.minified ctx ->
-        Pp.semicolon ctx ()
-    | _ -> ()
-  in
   let rec loop = function
     | [] -> ()
     | [ s ] -> pp_statement ctx s
     | s :: (next :: _ as rest) ->
         pp_statement ctx s;
-        pp_statement_sep ctx s;
+        pp_declarations_sep ctx s;
         Pp.cut ctx ();
         (* Add blank line between consecutive @layer { } blocks *)
         if (not (Pp.minified ctx)) && is_layer_block s && is_layer_block next

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2395,6 +2395,39 @@ let c61_conditional_competitor_order () =
        "@media not all and (min-width:640px){.u{display:grid}}@media not all \
         and (min-width:1024px){.u{display:flex}}")
 
+(* CSS Syntax 3 sec. 5.4.4/5.4.5: a declaration inside a nested block runs to
+   the next [;] or to the block's [}]. Unwrapping a baseline-true [@supports]
+   inside a style rule leaves its declarations as siblings of whatever followed
+   the wrapper, so the serializer owes them a separator; without one the last
+   declaration runs on into the next sibling and the reader drops the rule.
+   [Css.of_string ~strict:true] is the gate: it turns any recovery warning into
+   an error. *)
+let nested_folded_block_separator () =
+  let check name input expected =
+    let output = optimized_string input in
+    Alcotest.(check string) name expected output;
+    match Css.of_string ~strict:true output with
+    | Ok _ -> ()
+    | Error e ->
+        Alcotest.failf "%s: emitted CSS %S is rejected by the reader: %s" name
+          output (Error.to_string e)
+  in
+  check "folded block before another folded block"
+    ".a{@supports (color:red){color:red}@supports (color:red){top:0}}"
+    ".a{color:red;top:0}";
+  check "three folded blocks in a row"
+    ".a{@supports (color:red){color:red}@supports (color:red){top:0}@supports \
+     (color:red){left:0}}"
+    ".a{color:red;top:0;left:0}";
+  check "folded block before a nested rule"
+    ".a{@supports (color:red){color:red}.b{top:0}}" ".a{color:red;.b{top:0}}";
+  check "folded block before a kept at-rule"
+    ".a{@supports (color:red){color:red}@media print{top:0}}"
+    ".a{color:red;@media print{top:0}}";
+  check "declarations then folded block then nested rule"
+    ".a{top:0;@supports (color:red){color:red}.b{left:0}}"
+    ".a{top:0;color:red;.b{left:0}}"
+
 let target_minify_enforce_spec_split () =
   let check_modes name input ~default ~spec =
     Alcotest.(check string) (name ^ " default") default (optimized_string input);
@@ -4518,6 +4551,9 @@ let selector_merging_tests =
     ( "target minify and enforce-spec split",
       `Quick,
       target_minify_enforce_spec_split );
+    ( "folded nested block keeps its declaration separator",
+      `Quick,
+      nested_folded_block_separator );
     ( "spec cascade 6.1 no media merge across layer statement",
       `Quick,
       c61_no_layer_media_merge );


### PR DESCRIPTION
`.a{@supports (color:red){color:blue}@supports (color:red){color:green}}` minified to `.a{color:#00fcolor:green}`: unwrapping a baseline-true `@supports` inside a style rule dropped the `;` between the declarations it folded in, and browsers and cascade's own reader then drop the whole rule.