### PR TITLE
inline: unwrap an @layer only where the cascade agrees

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -314,6 +314,13 @@
   holds. A layer first named inside a conditional group is introduced there only
   when the condition holds, so the order is not decidable and the layers are
   left standing rather than folded to a winner (#357)
+- `Css.inline_vars` unwraps an `@layer` only where the layer stack and document
+  order already pick the same winner for every slot two layers write. Unwrapping
+  replays the stack as document order and hands the decision back to
+  specificity, so a sheet whose layers order competing declarations came out
+  rendering a different value, with no custom property involved. It narrows the
+  unwrapping #373 added: a sheet holding a nested rule is one the check cannot
+  answer for, so an `@layer` written inside a rule stays standing (#371)
 
 - `Css.resolve_theme` accounts for the declarations `@keyframes`, `@page`,
   `@position-try` and `@supports-condition` carry. A `var()` referenced only

--- a/fuzz/fuzz_inline.ml
+++ b/fuzz/fuzz_inline.ml
@@ -22,7 +22,13 @@ let layer name body = String.concat "" [ "@layer "; name; "{"; body; "}" ]
    which layer - or none - holds its definition or its consumers. Build a set of
    single-def [:root] variables and one consumer each, place them across layers
    several ways, and assert every placement inlines identically to the fully
-   unlayered stylesheet (which never mishandled layers). *)
+   unlayered stylesheet (which never mishandled layers).
+
+   Every placement keeps the consumers in one layer, which is what lets the
+   whole sheet compare equal to the unlayered one. Spread them over two layers
+   and the layers order them against each other, so dropping the wrappers is a
+   different render rather than a different spelling, and the equality would be
+   asserting a bug. *)
 let test_layer_placement_invariant buf =
   let n = 1 + (byte_at buf 0 mod 4) in
   let root_block =
@@ -56,12 +62,9 @@ let test_layer_placement_invariant buf =
         String.concat ""
           [ root_block; layer "utilities" (String.concat "" consumers) ]
     | _ ->
-        (* definition layered, each consumer in an alternating layer *)
+        (* definition layered, consumers in one layer a block at a time *)
         String.concat ""
-          (layer "theme" root_block
-          :: List.mapi
-               (fun i c -> layer (if i land 1 = 0 then "a" else "b") c)
-               consumers)
+          (layer "theme" root_block :: List.map (layer "utilities") consumers)
   in
   match (inlined_min reference, inlined_min layered) with
   | Some r, Some l ->

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -634,9 +634,10 @@ let of_string_exn ?strict ?filename ?meta ?enforce_spec css =
 
    [keep_layers] leaves the [@layer] wrappers and declarations standing.
    Dropping them replays the layer stack as document order, which only preserves
-   the cascade once every layered competition has been resolved; when
-   {!Inline.layer_order} cannot say what that order is, none of them has
-   been. *)
+   the cascade once every layered competition has been resolved: the layered
+   custom properties by the fold {!Inline.vars} runs, and the rest by the stack
+   and document order already agreeing, which is what
+   {!Inline.flattening_layers_is_safe} answers. *)
 let rec statements_for_inline ~live ~keep_layers block =
   List.concat_map (statement_for_inline ~live ~keep_layers) block
 
@@ -706,7 +707,7 @@ let inline_vars ?keep_vars ?warn stylesheet =
     | Some keep_vars -> Inline.vars ?warn ~keep_vars stylesheet
   in
   let live = Inline.mentioned_custom_names substituted in
-  let keep_layers = Option.is_none (Inline.layer_order stylesheet) in
+  let keep_layers = not (Inline.flattening_layers_is_safe substituted) in
   statements_for_inline ~live ~keep_layers substituted
 
 (* Collect every [var(--name)] reference's name (with leading [--]) from a

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1228,6 +1228,162 @@ let layer_order stylesheet : string list option =
   walk ~placed:true "" stylesheet;
   if !undecided then None else Some (List.rev !order)
 
+module Slot_table = Hashtbl.Make (struct
+  type t = Shorthand.overlap_key
+
+  let equal = Shorthand.overlap_key_equal
+  let hash = Shorthand.overlap_key_hash
+end)
+
+(* One declaration's stake in one cascade slot: where the layer stack ranks it,
+   and where specificity and document order leave it once the wrappers are gone.
+   [index] keeps both orders total, so two claims a single rule writes never
+   compare equal. *)
+type layer_claim = {
+  rank : int;
+  position : int;
+  specificity : Selector.specificity;
+  important : bool;
+  index : int;
+}
+
+(* Where specificity and document order leave two claims once the wrappers are
+   gone. Ascending, so the last claim standing is the one that wins. *)
+let compare_flattened a b =
+  match Bool.compare a.important b.important with
+  | 0 -> (
+      match Selector.compare_specificity a.specificity b.specificity with
+      | 0 -> (
+          match Int.compare a.position b.position with
+          | 0 -> Int.compare a.index b.index
+          | order -> order)
+      | order -> order)
+  | order -> order
+
+(* And where the layer stack leaves them. Importance outranks the stack and
+   comes through flattening untouched, so it settles a pair either way; between
+   two layers the stack decides, reversed for important declarations (CSS
+   Cascade 5 sec. 6.4.2); inside one layer the same things decide as after. *)
+let compare_layered a b =
+  match Bool.compare a.important b.important with
+  | 0 ->
+      let rank =
+        if a.important then Int.compare b.rank a.rank
+        else Int.compare a.rank b.rank
+      in
+      if rank <> 0 then rank else compare_flattened a b
+  | order -> order
+
+(* Two total orders over the same claims are the same order exactly when one's
+   sequence is sorted under the other, so whatever subset of them an element
+   matches, it keeps the winner it had. *)
+let slot_survives_flattening claims =
+  let rec ascending = function
+    | a :: (b :: _ as rest) -> compare_flattened a b < 0 && ascending rest
+    | _ -> true
+  in
+  ascending (List.stable_sort compare_layered claims)
+
+(* A selector list matches an element through one branch at a time, and it is
+   that branch's specificity the cascade weighs. *)
+let selector_specificities selector =
+  match Selector.as_list selector with
+  | Some branches -> List.map Selector.specificity branches
+  | None -> [ Selector.specificity selector ]
+
+(* Record what one declaration stakes in every slot it writes. [false] when it
+   is broad enough that no footprint tells it apart from anything. *)
+let add_claim ~slots ~index ~rank ~position ~specificities decl =
+  if Shorthand.declaration_is_broad decl then false
+  else begin
+    let important = Declaration.is_important decl in
+    List.iter
+      (fun specificity ->
+        incr index;
+        let claim =
+          { rank; position; specificity; important; index = !index }
+        in
+        List.iter
+          (fun slot ->
+            let prev =
+              Option.value ~default:[] (Slot_table.find_opt slots slot)
+            in
+            Slot_table.replace slots slot (claim :: prev))
+          (Shorthand.declaration_overlap_keys decl))
+      specificities;
+    true
+  end
+
+(* Every declaration's stake in the slots it writes, indexed by slot, or [None]
+   for a sheet holding what this does not reach: an anonymous layer, another
+   origin's stack or a [@scope] block's proximity rule, a nested rule whose
+   subject it does not resolve, a declaration broad enough to write any slot at
+   all, or anything but a style rule inside a layer, [@keyframes] and friends
+   included, whose name resolution the stack also orders. *)
+let layer_claims ~ranks ~unlayered stylesheet =
+  let slots = Slot_table.create 64 in
+  let reaches = ref true in
+  let position = ref 0 in
+  let index = ref 0 in
+  let dotted prefix name =
+    if prefix = "" then name else String.concat "." [ prefix; name ]
+  in
+  let rec walk ~layer ~rank stmts = List.iter (statement ~layer ~rank) stmts
+  and statement ~layer ~rank stmt =
+    match stmt with
+    | Stylesheet.Layer (None, _) | Stylesheet.Origin _ | Stylesheet.Scope _ ->
+        reaches := false
+    | Stylesheet.Layer (Some name, body) ->
+        let layer = dotted layer name in
+        let rank =
+          Option.value ~default:unlayered (Hashtbl.find_opt ranks layer)
+        in
+        walk ~layer ~rank body
+    | Stylesheet.Layer_decl _ -> ()
+    | Stylesheet.Rule r ->
+        incr position;
+        if r.nested <> [] then reaches := false
+        else
+          let specificities = selector_specificities r.selector in
+          let position = !position in
+          List.iter
+            (fun decl ->
+              if
+                not
+                  (add_claim ~slots ~index ~rank ~position ~specificities decl)
+              then reaches := false)
+            r.declarations
+    | Stylesheet.Media (_, body)
+    | Stylesheet.Supports (_, body)
+    | Stylesheet.Container (_, _, body)
+    | Stylesheet.Moz_document (_, body)
+    | Stylesheet.When (_, body)
+    | Stylesheet.Else (_, body)
+    | Stylesheet.Starting_style body ->
+        walk ~layer ~rank body
+    | _ -> if rank <> unlayered then reaches := false
+  in
+  walk ~layer:"" ~rank:unlayered stylesheet;
+  if !reaches then Some slots else None
+
+(* Whether dropping every [@layer] wrapper leaves the same declaration winning
+   each cascade slot. Unwrapping replays the layer stack as document order and
+   hands the decision back to specificity, so it holds only where the two orders
+   already agree on every slot two layers write, and [layer_order] is what ranks
+   them: a sheet it cannot rank is one this cannot answer for. *)
+let flattening_layers_is_safe stylesheet =
+  match layer_order stylesheet with
+  | None -> false
+  | Some order -> (
+      let ranks = Hashtbl.create 16 in
+      List.iteri (fun rank name -> Hashtbl.replace ranks name rank) order;
+      match layer_claims ~ranks ~unlayered:(List.length order) stylesheet with
+      | None -> false
+      | Some slots ->
+          Slot_table.fold
+            (fun _ claims ok -> ok && slot_survives_flattening claims)
+            slots true)
+
 (* [Some layer] for a purely-layered path ([layer = None] unlayered, [Some name]
    the dotted layer), [None] when the path is conditional or holds an anonymous
    layer - those are not statically foldable. *)

--- a/lib/inline.mli
+++ b/lib/inline.mli
@@ -36,6 +36,16 @@ val layer_order : Stylesheet.t -> string list option
     defined across several layers against, and [None] is the answer that stops
     it. *)
 
+val flattening_layers_is_safe : Stylesheet.t -> bool
+(** [flattening_layers_is_safe stylesheet] is [true] when dropping every
+    [@layer] wrapper in [stylesheet] leaves the same declaration winning each
+    cascade slot. Unwrapping a layer replays the stack as document order and
+    lets specificity speak again, which only holds where the two already agree
+    on every slot two layers write. [false] also answers for a sheet where that
+    is out of reach: an order {!layer_order} cannot rank, an anonymous layer,
+    another origin's stack, a [@scope] block, a nested rule, or a declaration
+    broad enough to write any slot. *)
+
 val decode_import_url : string -> string
 (** [decode_import_url s] strips the [url(...)] wrapper and any surrounding
     quotes from an [@import] URL string as held in

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -1127,6 +1127,15 @@ let declarations_overlap a b =
     b
     (declaration_overlap_keys b)
 
+(* A declaration no footprint comparison separates from another: [all] resets
+   every non-exempt slot, and a property outside the model expands to slots its
+   name does not spell out. *)
+let declaration_is_broad decl =
+  match unwrap_theme_guard decl with
+  | Declaration { property = All; _ } -> true
+  | Declaration { property = Unknown_property _; _ } -> true
+  | _ -> false
+
 let display_value_is_vendor : Properties.display -> bool = function
   | Webkit_flex | Webkit_inline_flex | Ms_flexbox | Webkit_box | Moz_box
   | Moz_inline_box ->

--- a/lib/shorthand.mli
+++ b/lib/shorthand.mli
@@ -59,6 +59,12 @@ val declarations_overlap_with_keys :
 (** [declarations_overlap_with_keys a a_keys b b_keys] is
     {!val-declarations_overlap} using precomputed declaration footprints. *)
 
+val declaration_is_broad : Declaration.declaration -> bool
+(** [declaration_is_broad d] is [true] when [d] may write a cascade slot any
+    other declaration writes, so comparing footprints cannot tell the two apart:
+    the [all] shorthand, and a property outside the model, whose name does not
+    spell out what it expands to. *)
+
 val same_property : Declaration.declaration -> Declaration.declaration -> bool
 (** Same CSS property. *)
 

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -351,14 +351,17 @@ let test_inline_layer_winner () =
     ":root{--c:red}.dark{--c:blue}.x{color:var(--c)}"
     ":root{--c:red}.dark{--c:blue}.x{color:var(--c)}"
 
-(* The closed-world cleanup that follows substitution unwraps every [@layer] and
-   drops every [@property] registration. CSS nesting puts both inside a rule, so
-   the cleanup has to reach there as well or the same sheet comes out half
-   cleaned. *)
+(* The closed-world cleanup that follows substitution reaches inside a rule: CSS
+   nesting puts an [@layer] and a [@property] registration there, and a cleanup
+   that stops at the top level leaves the same sheet half cleaned. The [var()]
+   inside the nested [@media] is substituted either way; the wrapper itself
+   stays, since [Inline.flattening_layers_is_safe] cannot rank a sheet whose
+   rule carries nested content and unwrapping is only sound where the layer
+   stack and document order already agree. *)
 let test_inline_cleanup_inside_a_rule () =
-  check_inline_case "a nested @layer wrapper is unwrapped"
+  check_inline_case "a nested @layer wrapper keeps an order it cannot decide"
     ":root{--c:red}.a{@layer m{@media print{.n{color:var(--c)}}}}"
-    ".a{@media print{.n{color:red}}}";
+    ".a{@layer m{@media print{.n{color:red}}}}";
   check_inline_case "a nested @property registration is dropped"
     ".b{color:red;@property --y{syntax:\"*\";inherits:false}}" ".b{color:red}"
 

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -496,6 +496,27 @@ let test_inline_layer_order_sites () =
      a{:root{--c:red}}@layer b{:root{--c:blue}}.x{color:var(--c)}"
     "@container(min-width:1px){.z{outline-color:red}}.x{color:red}"
 
+(* Unwrapping a [@layer] replays the layer stack as document order and hands the
+   decision back to specificity, so it holds only where no cascade slot is
+   written from two layers at once (CSS Cascade 5 sec. 6.4.3). No custom
+   property has to be involved for the unwrapping to change the render. *)
+let test_inline_layer_flattening () =
+  check_inline_case "a declared layer order outranks document order"
+    "@layer a,b;@layer b{.x{color:blue}}@layer a{.x{color:red}}"
+    "@layer a,b;@layer b{.x{color:blue}}@layer a{.x{color:red}}";
+  check_inline_case "an unlayered declaration keeps its win over a layer"
+    ".x{color:red}@layer a{.x{color:blue}}"
+    ".x{color:red}@layer a{.x{color:blue}}";
+  check_inline_case "a layer outranks a more specific selector below it"
+    "@layer a,b;@layer a{#x{color:red}}@layer b{.x{color:blue}}"
+    "@layer a,b;@layer a{#x{color:red}}@layer b{.x{color:blue}}";
+  check_inline_case "a longhand in a weaker layer loses to a shorthand"
+    "@layer a,b;@layer b{.x{margin:0}}@layer a{.x{margin-left:5px}}"
+    "@layer a,b;@layer b{.x{margin:0}}@layer a{.x{margin-left:5px}}";
+  check_inline_case "layers writing disjoint slots still flatten"
+    "@layer b{.x{color:blue}}@layer a{.y{padding:1px}}"
+    ".x{color:blue}.y{padding:1px}"
+
 let suite =
   ( "inline",
     [
@@ -558,4 +579,6 @@ let suite =
         `Quick test_inline_style_query_keeps_no_more;
       Alcotest.test_case "inline vars order layers by where they are named"
         `Quick test_inline_layer_order_sites;
+      Alcotest.test_case "inline vars keep a layer that still decides a slot"
+        `Quick test_inline_layer_flattening;
     ] )


### PR DESCRIPTION
`Css.inline_vars` unwrapped every `@layer`, which replays the layer stack as document order and hands the decision back to specificity: `@layer a, b;@layer b{.x{color:blue}}@layer a{.x{color:red}}` came out as `.x{color:red}` where Chrome renders blue, with no custom property involved. It now unwraps only where the stack and document order already pick the same winner for every slot two layers write, ranking them through the `Inline.layer_order` #357 added.

Commit 11ed0140 corrects a fuzz oracle that pinned the old behaviour: its alternating-layer placement asserted that unwrapping is byte-neutral, and Chrome computes `rgb(170,187,204)` layered against `rgb(255,0,0)` flattened for it.