### PR TITLE
optimize: prune a dead position-try name wherever it is written

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,10 @@
 - A declaration whose value is spec-invalid is discarded inside a `@keyframes`
   frame, matching what a browser does with it there and what cascade already
   did in a style rule (#341)
+- Under `--scope=stylesheet` a `position-try-fallbacks` name with no
+  `@position-try` rule is dropped inside a `@keyframes` frame, as it already
+  was in a style rule. The name cannot match at runtime wherever the
+  declaration is written (#372)
 - `--minify` optimises the body of `@-moz-document`, `@starting-style`,
   `@when` and `@else`, which it walked past: rules inside one of them kept
   whatever the author wrote (#343)

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -672,33 +672,10 @@ let prune_position_try_fallbacks ~scope (stylesheet : t) : t =
             | None -> List.Drop)
           decls
       in
-      let rec walk (stmt : statement) : statement =
-        match stmt with
-        | Rule rule ->
-            let declarations = prune_decls rule.declarations in
-            let nested = list_map_preserve walk rule.nested in
-            let rule' =
-              rule_with_declarations_and_nested rule declarations nested
-            in
-            if rule' == rule then stmt else Rule rule'
-        | Declarations decls ->
-            let decls' = prune_decls decls in
-            if decls' == decls then stmt else Declarations decls'
-        | Layer _ | Media _ | Container _ | Supports _ | Moz_document _ | When _
-        | Else _ | Starting_style _ | Origin _ | Scope _ ->
-            map_statement_children (list_map_preserve walk) stmt
-        | Page (sel, decls) ->
-            let decls' = prune_decls decls in
-            if decls' == decls then stmt else Page (sel, decls')
-        | Position_try (n, decls) ->
-            let decls' = prune_decls decls in
-            if decls' == decls then stmt else Position_try (n, decls')
-        | Supports_condition (n, decls) ->
-            let decls' = prune_decls decls in
-            if decls' == decls then stmt else Supports_condition (n, decls')
-        | other -> other
-      in
-      list_map_preserve walk stylesheet
+      (* A name with no [@position-try] rule cannot match wherever it is
+         written, so this goes through the declaration walker rather than a list
+         of the at-rules that came to mind. *)
+      map_declarations prune_decls stylesheet
 
 (* Collect the custom properties registered with an [@property] initial-value.
    Such a property is never invalid at computed-value time, so folding its

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -766,6 +766,27 @@ let test_drop_invalid_reaches_keyframe_frames () =
     "so does a vendor-prefixed one" "@-webkit-keyframes k{0%{opacity:0}}"
     (recovered "@-webkit-keyframes k{from{width:asin(sin(45deg));opacity:0}}")
 
+(* Under closed-stylesheet scope a [position-try-fallbacks] name with no
+   [@position-try] rule can never match, and where the declaration is written
+   does not change that, so the prune reaches a keyframe frame as it does a
+   style rule. *)
+let test_position_try_prune_reaches_keyframe_frames () =
+  let pruned css =
+    Css.of_string_exn css
+    |> Css.Optimize.stylesheet ~scope:`Stylesheet
+    |> Css.Stylesheet.to_string ~minify:true
+  in
+  Alcotest.(check string)
+    "a style rule loses the unknown fallback"
+    "@position-try --k{top:1px}a{position-try-fallbacks:--k}"
+    (pruned "@position-try --k{top:1px}a{position-try-fallbacks:--k,--gone}");
+  Alcotest.(check string)
+    "a keyframe frame loses it too"
+    "@position-try --k{top:1px}@keyframes f{0%{position-try-fallbacks:--k}}"
+    (pruned
+       "@position-try --k{top:1px}@keyframes \
+        f{from{position-try-fallbacks:--k,--gone}}")
+
 (* Every conditional group wraps ordinary rules, so the optimizer's main
    recursion has to descend into all of them: a body it walks past keeps
    whatever the author wrote, and [--minify] silently does nothing there. *)
@@ -1369,6 +1390,9 @@ let optimize_tests =
     ( "drop_invalid reaches keyframe frames",
       `Quick,
       test_drop_invalid_reaches_keyframe_frames );
+    ( "position-try prune reaches keyframe frames",
+      `Quick,
+      test_position_try_prune_reaches_keyframe_frames );
     ( "optimize descends into every conditional group",
       `Quick,
       test_optimize_descends_into_every_conditional_group );


### PR DESCRIPTION
The closed-stylesheet prune listed the places a declaration sits itself and stopped at the ones that came to mind, so a `position-try-fallbacks` naming a `@position-try` rule that does not exist survived inside a `@keyframes` frame; it goes through `map_declarations` now.

Stacked on #369.