### PR TITLE
css: clean up after inlining wherever a statement sits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -137,6 +137,9 @@
   `@supports-condition` body as a reference, so it no longer emits a name whose
   definition it deleted, and reports an overridden variable referenced from any
   of those at-rules through `~warn` (#342)
+- `Css.inline_vars` unwraps an `@layer` and drops an `@property` registration
+  written inside a rule, as it already did at top level. CSS nesting puts both
+  there, and a sheet using it came back half cleaned (#373)
 - A custom property registered by `@property` is typed wherever it is
   declared, including inside `@keyframes`, `@position-try` and
   `@supports-condition`, so the same registered value canonicalises the same

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -709,23 +709,18 @@ let of_string_exn ?strict ?filename ?meta ?enforce_spec css =
   | Ok { stylesheet; _ } -> stylesheet
   | Error error -> Error.fail error
 
-let rec statements_for_inline statement =
-  let inline_block block = List.concat_map statements_for_inline block in
+(* Splicing a [@layer] body into its parent replaces one statement with several,
+   which [edit_statements] cannot express and which does not need it: the splice
+   is the [concat_map] over a block, and the descent below it is still
+   [map_statement_children]'s, so an at-rule added later is walked without a
+   word here. *)
+let rec statements_for_inline block = List.concat_map statement_for_inline block
+
+and statement_for_inline statement =
   match statement with
-  | Layer (_, block) -> List.concat_map statements_for_inline block
+  | Layer (_, block) -> statements_for_inline block
   | Layer_decl _ | Property _ -> []
-  | Media (condition, block) -> [ Media (condition, inline_block block) ]
-  | Supports (condition, block) -> [ Supports (condition, inline_block block) ]
-  | Moz_document (conditions, block) ->
-      [ Moz_document (conditions, inline_block block) ]
-  | Container (name, condition, block) ->
-      [ Container (name, condition, inline_block block) ]
-  | Scope (start, end_, block) -> [ Scope (start, end_, inline_block block) ]
-  | Origin (origin, block) -> [ Origin (origin, inline_block block) ]
-  | When (condition, block) -> [ When (condition, inline_block block) ]
-  | Else (condition, block) -> [ Else (condition, inline_block block) ]
-  | Starting_style block -> [ Starting_style (inline_block block) ]
-  | statement -> [ statement ]
+  | statement -> [ map_statement_children statements_for_inline statement ]
 
 (* Pure serialiser: walk the AST and emit CSS, no optimise/theme/inline-vars
    rewriting. Spec recovery (drop invalid declarations, unknown at-rules, empty
@@ -780,7 +775,7 @@ let inline_vars ?keep_vars ?warn stylesheet =
     | None -> Inline.vars ?warn stylesheet
     | Some keep_vars -> Inline.vars ?warn ~keep_vars stylesheet
   in
-  List.concat_map statements_for_inline substituted
+  statements_for_inline substituted
 
 (* Collect every [var(--name)] reference's name (with leading [--]) from a
    stylesheet. Used by [resolve_theme] to know which names to ask the

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -351,6 +351,17 @@ let test_inline_layer_winner () =
     ":root{--c:red}.dark{--c:blue}.x{color:var(--c)}"
     ":root{--c:red}.dark{--c:blue}.x{color:var(--c)}"
 
+(* The closed-world cleanup that follows substitution unwraps every [@layer] and
+   drops every [@property] registration. CSS nesting puts both inside a rule, so
+   the cleanup has to reach there as well or the same sheet comes out half
+   cleaned. *)
+let test_inline_cleanup_inside_a_rule () =
+  check_inline_case "a nested @layer wrapper is unwrapped"
+    ":root{--c:red}.a{@layer m{@media print{.n{color:var(--c)}}}}"
+    ".a{@media print{.n{color:red}}}";
+  check_inline_case "a nested @property registration is dropped"
+    ".b{color:red;@property --y{syntax:\"*\";inherits:false}}" ".b{color:red}"
+
 let suite =
   ( "inline",
     [
@@ -394,4 +405,6 @@ let suite =
       Alcotest.test_case
         "inline vars fold a layer-decided override to its winner" `Quick
         test_inline_layer_winner;
+      Alcotest.test_case "inline vars clean up inside a rule too" `Quick
+        test_inline_cleanup_inside_a_rule;
     ] )


### PR DESCRIPTION
The closed-world cleanup `Css.inline_vars` runs after substitution listed the at-rules that nest itself and left out the one CSS nesting reaches through, a rule, so an `@layer` wrapper and an `@property` registration written inside a rule survived a step whose whole job is to remove them. Splicing a `@layer` body into its parent is the `concat_map` over a block rather than a form of `edit_statements`, and the descent below it is `map_statement_children`'s, so no new walk form is needed.

Stacked on #372.