### PR TITLE
css: @layer inside a style rule is a nesting context

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,15 @@
   discarded to the end of its block rather than to the next `;`, and a
   selector-shaped item in a margin box, such as `@page { @top-center { .a { b:
   c } } }`, no longer loops forever (#398)
+- A descriptor an `@property` body rejects is dropped on its own rather than
+  taking the registration and the stylesheet holding it. `@property --x { syntax:
+  "<length>"; inherits: false; initial-value: 0px; zzz: 1 }` parsed to nothing,
+  and so did a stray `;` between two valid descriptors. CSS Properties and Values
+  API 1 sec. 2 ignores an unknown descriptor, CSS Syntax 3 sec. 5.4.3 discards a
+  `;` with no declaration to validate, and Blink 146 reads the registration in
+  both. Tokens left after a descriptor's value, such as a trailing `!important`,
+  now invalidate the declaration they follow rather than the leftover alone
+  (#399)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,11 @@
   CSS-wide keyword as a corner radius. CSS Backgrounds 3 sec. 5.1 allows only a
   non-negative `<length-percentage>` there, and Chrome and WebKit drop every
   such declaration (#417)
+- An `@layer` block inside a style rule holds nesting content, so
+  `.a { @layer n { color: red } }` keeps its declaration instead of reading the
+  body as a selector list and dropping it. CSS Nesting 1 sec. 3.1 admits nested
+  at-rules, and `@layer` was the only one still read as a stylesheet block
+  (#374)
 
 ### Minification
 
@@ -55,6 +60,10 @@
   `@media (width>=1px){a{background-color:red}}a{background:blue}@media (width>=1px){a{background-color:green}}`
   minified to a sheet Chrome computes blue for where the source computes green
   (#415)
+- An empty `@layer name` inside a style rule keeps its block form. The
+  statement form is a layer-order declaration, which no style rule accepts, so
+  `.a { @layer n {} }` minified to `.a{@layer n;}`, which neither a browser nor
+  cascade's own reader takes back (#374)
 - A declaration whose value is spec-invalid is discarded inside a `@keyframes`
   frame, matching what a browser does with it there and what cascade already
   did in a style rule (#341)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,12 @@
   body as a selector list and dropping it. CSS Nesting 1 sec. 3.1 admits nested
   at-rules, and `@layer` was the only one still read as a stylesheet block
   (#374)
+- A declaration written after a nested rule keeps its place instead of being
+  hoisted to the top of the block. CSS Nesting 1 sec. 3.4 wraps such a run in a
+  nested declarations rule, and its worked example names the hoisted spelling as
+  not equivalent, so `.a { @supports (color: red) { color: blue } color: green }`
+  now computes green as Blink and WebKit do, where cascade printed a sheet that
+  computed blue (#380)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,11 @@
   `.a{color:red;b{width:1px}}` and `--diff=canonical` stops reporting it as
   different from `.a { color: red; & b { width: 1px } }`. A declaration that
   does clash keeps the place CSS Nesting 1 sec. 3.4 gives it (#383)
+- A run of declarations written after a nested statement is deduplicated like
+  any other declaration list, so `.a { & b { color: red } color: blue;
+  color: green }` minifies to `.a{b{color:red}color:green}` rather than keeping
+  a write nothing can read. Nothing sits between two writes inside one run, so
+  the later wins (CSS Cascade 5 sec. 6.4.4) (#386)
 - `--minify` is faster on a stylesheet the optimizer factors heavily, for the
   same output. The rule graph's cycle check, topological order and
   selector-branch index each probed a generic `Hashtbl` once per edge or per

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,19 @@
   stylesheet-level reader and lost its block too. CSS Nesting 1 sec. 3.3 nests
   any at-rule whose body carries style rules, and Blink 146 keeps every one of
   these shapes whole (#384)
+- An at-rule with no style rule in its body is rejected inside a style rule
+  instead of being kept. CSS Nesting 1 sec. 3.3 nests only an at-rule whose body
+  carries style rules, so `.a { @font-face { ... } }`, `@keyframes`, `@property`,
+  `@page`, `@counter-style`, `@position-try`, `@font-palette-values`,
+  `@font-feature-values`, `@viewport` and `@supports-condition` are invalid
+  there, as is an `@else` with no preceding `@when`; each is dropped with a
+  warning that `Css.of_string ~strict:true` turns into an error, and the
+  declarations written around it stay in the rule. `@view-transition` is kept,
+  since Blink 146 still reads it there (#388)
+- Discarding an at-rule that is invalid inside a style rule ends at the at-rule
+  rather than at the next semicolon. `.a { @import url(x) { } color: red }` lost
+  `color: red`, and an `@import` inside a nested group rule took the whole group
+  with it (#388)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -109,6 +109,16 @@
   `;` and sec. 5.4.3 ends a qualified rule at its block, so a `(` or a `[`
   written before that block is part of what is discarded, and Blink 146 keeps no
   such rule (#402)
+- A `@page` body and a page-margin box keep any property they are given, so
+  `@page { color: red }`, `@page { orphans: 3 }` and
+  `@page { @top-center { display: block } }` are read instead of erroring under
+  `~strict:true` and being dropped with a warning otherwise. CSS Paged Media 3
+  sec. 6 admits its Appendix A list of CSS 2.1 properties in both contexts and
+  leaves anything outside CSS 2.1 undefined rather than invalid, and Blink 146
+  keeps every property it knows there. The seven-name allowlist also rejected
+  `bleed`, the name sec. 7.3 defines, and `page-orientation`. A value the
+  property's grammar rejects, and an item that is no declaration, are still
+  rejected (#403)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -126,6 +126,14 @@
   declaration above a normal one whatever their order, and Blink 146 reads the
   important one back in a page body and in a margin box alike. Two declarations
   of the same importance still keep the last (#404)
+- A page-margin box with an empty block is read instead of erroring under
+  `~strict:true` and being dropped with a warning otherwise, so
+  `@page { @top-center { } }` no longer takes its `@page` with it. CSS Paged
+  Media 3 sec. 5 gives a margin at-rule a `<declaration-list>`, which CSS Syntax
+  3 sec. 5.4.4 consumes even when it holds nothing, and Blink 146 keeps the box.
+  Sec. 5 generates the box only where `content` computes away from `none`, so an
+  empty one is elided on output like an empty style rule and an empty `@page`
+  already are (#405)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,12 @@
   only the run written before its first nested statement (CSS Nesting 1
   sec. 3.4), so a pass reading them as the whole body moves or drops content it
   never looked at (#376)
+- A declaration written after a nested statement rejoins the rule's own run
+  when nothing it crosses writes the same property at the same importance, so
+  `.a { & b { width: 1px } color: red }` minifies to
+  `.a{color:red;b{width:1px}}` and `--diff=canonical` stops reporting it as
+  different from `.a { color: red; & b { width: 1px } }`. A declaration that
+  does clash keeps the place CSS Nesting 1 sec. 3.4 gives it (#383)
 - `--minify` is faster on a stylesheet the optimizer factors heavily, for the
   same output. The rule graph's cycle check, topological order and
   selector-branch index each probed a generic `Hashtbl` once per edge or per

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -147,6 +147,15 @@
   `@view-transition` or `@counter-style` descriptor value, such as a trailing
   `!important`, now invalidate the declaration they follow rather than the
   leftover alone (#419)
+- An at-rule inside a `@keyframes` body is dropped on its own rather than taking
+  the animation and the stylesheet holding it, so
+  `@keyframes k { from { color: red } @media print { to { color: pink } } 50%
+  { background: lime } }` keeps both keyframes where it parsed to nothing. The
+  rejection was raised around the loop rather than inside it, so it unwound past
+  the recovery the loop already ran for a keyframe selector it rejects. CSS
+  Syntax 3 sec. 5.4.2 ends the at-rule being discarded at its own block, past
+  any `(` or `[` in its prelude, and Blink 146 keeps the keyframes written
+  around it (#420)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,7 +85,7 @@
 - A descriptor a `@page` body rejects is dropped on its own rather than taking
   the rule and the stylesheet holding it. `@page { margin: 1cm; width: 10;
   margin-top: 2cm }` parsed to nothing, and a page margin box lost its whole
-  block the same way. CSS Paged Media 3 sec. 6 applies the parse-error rules
+  block the same way. CSS Paged Media 3 sec. 4.1 applies the parse-error rules
   inside a page or margin context, so the valid declarations around the bad one
   still apply, and Blink 146 keeps every neighbour. An invalid margin at-rule is
   discarded to the end of its block rather than to the next `;`, and a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -129,6 +129,12 @@
   conflict test walks the two key lists in step instead of scanning one per
   element of the other, and collecting them no longer rescans what it has
   already collected (#422)
+- A same-condition `@media` block is no longer hoisted over a declaration
+  written after a nested rule. CSS Nesting 1 sec. 3.4 keeps that run behind the
+  rule it follows, so it is one more rule the hoist reorders, and
+  `.a { @media (min-width: 1px) { color: red } color: blue; @media (min-width: 1px) { color: green } }`
+  minified to a sheet Chrome computes blue for where the source computes green
+  (#414)
 - An empty `@-moz-document`, `@when` or `@else` is dropped, as an empty
   `@media` already was: a conditional group rule with no contents applies
   nothing whatever its condition. An empty `@when` or `@else` stays while a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,11 @@
   `-webkit-backdrop-filter`, `-webkit-user-select`, `-webkit-text-size-adjust`
   and `-webkit-print-color-adjust` were dropped against an unprefixed twin no
   shipping Safari understands (#325)
+- A rule that carries nested content stays out of the same-selector merge, the
+  distant `@media` hoist and the shadowed-rule drop. A rule's declarations are
+  only the run written before its first nested statement (CSS Nesting 1
+  sec. 3.4), so a pass reading them as the whole body moves or drops content it
+  never looked at (#376)
 - `--minify` is faster on a stylesheet the optimizer factors heavily, for the
   same output. The rule graph's cycle check, topological order and
   selector-branch index each probed a generic `Hashtbl` once per edge or per

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,14 @@
   not equivalent, so `.a { @supports (color: red) { color: blue } color: green }`
   now computes green as Blink and WebKit do, where cascade printed a sheet that
   computed blue (#380)
+- Every at-rule that nests inside a style rule reads its body as nesting
+  content. `.a { @starting-style { color: blue } }` kept the wrapper and dropped
+  the declaration, `@-moz-document`, `@when` and `@else` lost theirs the same
+  way, and an at-rule written inside a nested group rule, as in
+  `.a { @layer n { @media screen { color: red } } }`, reached the
+  stylesheet-level reader and lost its block too. CSS Nesting 1 sec. 3.3 nests
+  any at-rule whose body carries style rules, and Blink 146 keeps every one of
+  these shapes whole (#384)
 
 ### Minification
 
@@ -246,6 +254,9 @@
 - `Css.Stylesheet.map_statement_children` and `map_statement_declarations`
   rebuild a statement with a function applied to the block or the declarations
   it holds, the rebuilding counterparts of the two readers (#337)
+- `Css.Flatten` carries the parent selector into an `@-moz-document` block, the
+  one group rule it did not descend into. A nested declaration run came out
+  bare at the top of the block, which no reader takes back (#384)
 - `Css.Stylesheet.map_statement_children` and `map_statement_declarations`
   return the very statement they were given when the function they run leaves
   every list physically unchanged. A pass that short-circuits on physical

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -134,6 +134,19 @@
   Sec. 5 generates the box only where `content` computes away from `none`, so an
   empty one is elided on output like an empty style rule and an empty `@page`
   already are (#405)
+- A descriptor a `@counter-style`, `@font-palette-values` or `@view-transition`
+  body rejects is dropped on its own, as is a feature block an
+  `@font-feature-values` body rejects, rather than taking the at-rule and the
+  stylesheet holding it. `@counter-style thumbs { system: cyclic; symbols: "x";
+  zzz: 1 }` parsed to nothing, and the other three lost their whole rule the
+  same way. CSS Syntax 3 sec. 5.4.3 keeps what a block's contents already
+  yielded when one item fails to parse, and Blink 146 keeps all four rules. An
+  `@font-feature-values` body is a list of rules, so an item discarded there
+  ends at its own block rather than at a `;` it has not got, and a `;` with
+  nothing before it costs nothing. Tokens left after a `@font-palette-values` or
+  `@view-transition` or `@counter-style` descriptor value, such as a trailing
+  `!important`, now invalidate the declaration they follow rather than the
+  leftover alone (#419)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -100,6 +100,15 @@
   both. Tokens left after a descriptor's value, such as a trailing `!important`,
   now invalidate the declaration they follow rather than the leftover alone
   (#399)
+- A rule a grouping at-rule's block rejects is discarded to the end of that rule
+  rather than to the first block of any kind in its prelude. In
+  `@media screen { @supports (display: grid) bogus { a { color: red } } }` the
+  discard stopped at `(display: grid)`, so `bogus { a { color: red } }` came back
+  as a rule of its own, and a `[]` in a bad selector cost a second warning for
+  one dropped rule. CSS Syntax 3 sec. 5.4.2 ends an at-rule at its block or its
+  `;` and sec. 5.4.3 ends a qualified rule at its block, so a `(` or a `[`
+  written before that block is part of what is discarded, and Blink 146 keeps no
+  such rule (#402)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,15 @@
   starts with an identifier, as in `.a { @media screen { h2:where(.b) { color:
   red } } }`, and a stray `;` between two declarations there, were lost the same
   way (#392)
+- A descriptor a `@page` body rejects is dropped on its own rather than taking
+  the rule and the stylesheet holding it. `@page { margin: 1cm; width: 10;
+  margin-top: 2cm }` parsed to nothing, and a page margin box lost its whole
+  block the same way. CSS Paged Media 3 sec. 6 applies the parse-error rules
+  inside a page or margin context, so the valid declarations around the bad one
+  still apply, and Blink 146 keeps every neighbour. An invalid margin at-rule is
+  discarded to the end of its block rather than to the next `;`, and a
+  selector-shaped item in a margin box, such as `@page { @top-center { .a { b:
+  c } } }`, no longer loops forever (#398)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,16 @@
   rather than at the next semicolon. `.a { @import url(x) { } color: red }` lost
   `color: red`, and an `@import` inside a nested group rule took the whole group
   with it (#388)
+- An invalid declaration inside a nested at-rule is dropped on its own rather
+  than taking the whole stylesheet. `.a { @media screen { color: red;
+  width: 10; background: blue } }` parsed to nothing, since the nested block had
+  no recovery and the error unwound past every enclosing block. CSS Syntax 3
+  sec. 5.4.4 ends a bad declaration at the next top-level `;`, counting a `{}`
+  met on the way as one component value of the value being skipped, and Blink
+  146 keeps both neighbours in one declaration run. A nested rule whose prelude
+  starts with an identifier, as in `.a { @media screen { h2:where(.b) { color:
+  red } } }`, and a stray `;` between two declarations there, were lost the same
+  way (#392)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,13 @@
   `bleed`, the name sec. 7.3 defines, and `page-orientation`. A value the
   property's grammar rejects, and an item that is no declaration, are still
   rejected (#403)
+- A duplicate descriptor in a `@page` body or a page-margin box keeps the
+  important declaration rather than the one written last, so
+  `@page { margin: 1cm !important; margin: 2cm }` keeps `margin: 1cm !important`
+  where it kept `margin: 2cm`. CSS Cascade 5 sec. 6.2 ranks an important author
+  declaration above a normal one whatever their order, and Blink 146 reads the
+  important one back in a page body and in a margin box alike. Two declarations
+  of the same importance still keep the last (#404)
 
 ### Minification
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,8 +43,8 @@
 - An `@layer` block inside a style rule holds nesting content, so
   `.a { @layer n { color: red } }` keeps its declaration instead of reading the
   body as a selector list and dropping it. CSS Nesting 1 sec. 3.1 admits nested
-  at-rules, and `@layer` was the only one still read as a stylesheet block
-  (#374)
+  at-rules, and `@layer` was the last of the at-rules cascade reads as a
+  nesting context still taking a stylesheet block (#374)
 - A declaration written after a nested rule keeps its place instead of being
   hoisted to the top of the block. CSS Nesting 1 sec. 3.4 wraps such a run in a
   nested declarations rule, and its worked example names the hoisted spelling as

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -333,6 +333,11 @@
   overlap keys and for its position in the other rule, both of which name a
   property through a fresh buffer, where each is a fact about one declaration.
   `--minify` canonicalises a rule's declaration order the same way (#424)
+- `cascade diff` names a rule's nested block after the rule it belongs to. The
+  container printed as `& .a`, which is a selector matching a `.a` inside the
+  parent rather than the parent's own block, and a run of declarations written
+  after a nested statement was named by its first declaration instead of the
+  `&` that CSS Nesting 1 sec. 3.4 makes it (#385)
 
 ## 1.1.0
 

--- a/fuzz/fuzz_css.ml
+++ b/fuzz/fuzz_css.ml
@@ -376,7 +376,7 @@ let test_css2_legacy_invalid_vectors buf =
         "h1::first-line::before { color: red }";
         "a + { color: red }";
         "table > > td { color: red }";
-        "@page { @top-center { display: block } }";
+        "@page { @top-center { display: 1px } }";
         "ol { list-style-position: center }";
         "p { vertical-align: left right }";
         "q { content: open-quote none }";

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -1046,7 +1046,7 @@ let test_invalid_atrule_descriptor buf =
         "@font-face { font-family: Brand; src: url(font.woff2); font-display: \
          block swap }";
         "@page :unknown { margin: 1cm }";
-        "@page { @top-center { display: block } }";
+        "@page { @top-center { display: 1px } }";
         "@font-palette-values brand { font-family: Brand; base-palette: 1 }";
         "@font-palette-values --brand { override-colors: -1 red }";
         "@counter-style thumbs { system: cyclic }";
@@ -1153,7 +1153,7 @@ let test_invalid_page_margin buf =
     pick
       [
         "@page :unknown { margin: 1cm }";
-        "@page { @top-center { display: block } }";
+        "@page { @top-center { display: 1px } }";
       ]
       buf 0
   in

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -162,6 +162,25 @@ let rec leaf_rules ?parent stmt =
   | stmt ->
       List.concat_map (fun s -> leaf_rules ?parent s) (statement_children stmt)
 
+(* A declarations run outside any style rule: [leaf_rules] reports nothing for
+   it, so an analysis that must see every declaration refuses rather than read
+   that silence as "no conflict". *)
+let rec holds_unattributed_run stmt =
+  match stmt with
+  | Declarations _ -> true
+  | Media (_, b)
+  | Supports (_, b)
+  | Layer (_, b)
+  | Container (_, _, b)
+  | Starting_style b
+  | Origin (_, b)
+  | Moz_document (_, b)
+  | Scope (_, _, b)
+  | When (_, b)
+  | Else (_, b) ->
+      List.exists holds_unattributed_run b
+  | _ -> false
+
 (* Two declarations an element computes differently once they swap order: they
    write a common longhand slot, and they are not the same declaration. Reading
    the slots off the shorthand footprint rather than the property name is what
@@ -194,12 +213,21 @@ let needs_distant_media_merge stmts =
 
 (* CSS Conditional 3: same-condition [@media] blocks are spec-equivalent to one
    block. Merge a later block into the first occurrence when hoisting it past
-   the intervening statements cannot reorder a conflicting rule. *)
-let merge_distant_media ~optimize_merged_block stmts =
+   the intervening statements cannot reorder a conflicting rule.
+
+   [owner] is the style rule whose body [stmts] is, when it is one. A
+   declarations run in that body sets properties on [owner] (CSS Nesting 1 sec.
+   3.4), so the analysis below only sees it once it can name the rule the run
+   belongs to. *)
+let merge_distant_media ?owner ~optimize_merged_block stmts =
   if not (needs_distant_media_merge stmts) then stmts
   else
+    let leaves stmts = List.concat_map (leaf_rules ?parent:owner) stmts in
+    let unattributed stmts =
+      Option.is_none owner && List.exists holds_unattributed_run stmts
+    in
     let try_merge out cond block : statement list option =
-      let hoisted = List.concat_map leaf_rules block in
+      let hoisted = leaves block in
       let rec split before :
           statement list ->
           (statement list * statement list * statement list) option = function
@@ -218,11 +246,12 @@ let merge_distant_media ~optimize_merged_block stmts =
       match split [] out with
       | None -> None
       | Some (before, target, after) when List.for_all crossable after ->
-          let crossed = List.concat_map leaf_rules after in
+          let crossed = leaves after in
           if
-            List.exists
-              (fun h -> List.exists (rules_conflict h) crossed)
-              hoisted
+            unattributed block || unattributed after
+            || List.exists
+                 (fun h -> List.exists (rules_conflict h) crossed)
+                 hoisted
           then None
           else Some (before @ [ Media (cond, target @ block) ] @ after)
       | Some _ -> None

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -147,12 +147,20 @@ let merge_consecutive_media ~optimize_merged_block (stmts : statement list) :
   else stmts
 
 (* Leaf rules reachable from a statement, in source order, descending into
-   nested blocks. *)
-let leaf_rules stmt =
-  List.rev
-    (fold_statements
-       (fun acc stmt -> match stmt with Rule r -> r :: acc | _ -> acc)
-       [] [ stmt ])
+   nested blocks. A nested declarations run (CSS Nesting 1 sec. 3.4) sets
+   properties on the rule it sits in, so it reads as one more rule with that
+   selector; missed, it is a conflict the hoisting analysis below never sees.
+   Descent goes through [statement_children], so a statement that grows a block
+   is reached without listing it here. *)
+let rec leaf_rules ?parent stmt =
+  match stmt with
+  | Rule r -> r :: List.concat_map (fun s -> leaf_rules ~parent:r s) r.nested
+  | Declarations decls -> (
+      match parent with
+      | Some (p : rule) -> [ { p with declarations = decls; nested = [] } ]
+      | None -> [])
+  | stmt ->
+      List.concat_map (fun s -> leaf_rules ?parent s) (statement_children stmt)
 
 (* Two declarations an element computes differently once they swap order: they
    write a common longhand slot, and they are not the same declaration. Reading

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -517,6 +517,22 @@ let is_empty_statement ~chained = function
   | Position_try _ | Viewport _ | Unknown_at_rule _ ->
       false
 
+(* CSS Paged Media 3 sec. 5 generates a page-margin box only where its [content]
+   computes away from [none], so a box holding no descriptor generates nothing.
+   Stripping those first lets [is_empty_statement] drop the page they leave with
+   neither descriptor nor box. *)
+let drop_empty_margin_boxes stmt =
+  match stmt with
+  | Page_with_margins (selector, descriptors, margins) ->
+      let kept =
+        list_filter_preserve
+          (fun (m : page_margin_rule) -> m.descriptors <> [])
+          margins
+      in
+      if kept == margins then stmt
+      else Page_with_margins (selector, descriptors, kept)
+  | stmt -> stmt
+
 (* The tail is filtered first, so a branch is judged against the [@else] that
    survives rather than the one written: an empty [@when] whose only [@else] is
    itself empty goes with it in one pass. *)
@@ -525,12 +541,13 @@ let rec drop_empty_rules stmts =
   | [] -> []
   | stmt :: rest ->
       let rest' = drop_empty_rules rest in
+      let stmt' = drop_empty_margin_boxes stmt in
       let chained =
         match rest' with Else _ :: _ -> true | [] | _ :: _ -> false
       in
-      if is_empty_statement ~chained stmt then rest'
-      else if rest' == rest then stmts
-      else stmt :: rest'
+      if is_empty_statement ~chained stmt' then rest'
+      else if rest' == rest && stmt' == stmt then stmts
+      else stmt' :: rest'
 
 (* CSS Cascade 5 sec. 2: a [@layer <name>;] declaration form is prelude-friendly
    and may interleave with [@charset] / [@import] / [@namespace], so a

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -13,13 +13,17 @@ val merge_consecutive_media :
 (** Merge adjacent [@media] blocks with identical conditions. *)
 
 val merge_distant_media :
+  ?owner:Stylesheet.rule ->
   optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->
   Stylesheet.statement list ->
   Stylesheet.statement list
 (** Merge a later same-condition [@media] block into the first occurrence when
     hoisting it past the intervening statements cannot reorder a conflicting
     rule (overlapping selector with a shared property set to a different value).
-*)
+
+    [owner] is the style rule whose body the statements are, when they are one.
+    A declarations run in that body sets properties on [owner] (CSS Nesting 1
+    sec. 3.4), so without it the run is a conflict the hoist never sees. *)
 
 val merge_consecutive_supports :
   optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -163,7 +163,9 @@ val statement_selector : statement -> Selector.t option
 val as_rule :
   statement -> (Selector.t * declaration list * statement list) option
 (** [as_rule stmt] returns [Some (selector, declarations, nested)] if the
-    statement is a rule, {!constructor-None} otherwise. *)
+    statement is a rule, {!constructor-None} otherwise. The declarations are the
+    run written before the first nested statement; a run written after one is a
+    nested declarations rule inside [nested], at the position it was written. *)
 
 val as_layer : statement -> (string option * statement list) option
 (** [as_layer stmt] returns [Some (name, statements)] if the statement is a

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -455,6 +455,11 @@ let is_bang_cv = function
 let consume_until_semicolon ?(trim = false) t =
   string_of_components ~trim (drain_until_raw is_semicolon_cv t)
 
+let rec skip_past_semicolon t =
+  match next_raw t with
+  | None -> ()
+  | Some cv -> if not (is_semicolon_cv cv) then skip_past_semicolon t
+
 let consume_to_decl_end ?(trim = false) t =
   string_of_components ~trim
     (drain_until_raw (fun cv -> is_semicolon_cv cv || is_bang_cv cv) t)

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -327,6 +327,13 @@ val consume_until_semicolon : ?trim:bool -> t -> string
 (** [consume_until_semicolon t] consumes and serializes components up to, but
     not including, the next semicolon. *)
 
+val skip_past_semicolon : t -> unit
+(** [skip_past_semicolon t] consumes and discards components up to and including
+    the next top-level semicolon, or up to end of input if none is left. A [{}]
+    met on the way is one component value, not a stopping point, so this is the
+    recovery step CSS Syntax 3 sec. 5.4.4 prescribes for a declaration that
+    fails to parse. *)
+
 val consume_to_decl_end : ?trim:bool -> t -> string
 (** [consume_to_decl_end t] consumes and serializes components up to, but not
     including, the next semicolon or top-level [!] delimiter. *)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2256,20 +2256,6 @@ let read_declaration t : declaration option =
          next [;]) is a nested rule. *)
       if is_nested_rule t then None else Some (read_one ())
 
-(* Skip from the current cursor position to just past the next top-level [;], or
-   stop at EOF. Used to recover from a failed declaration inside a block: per
-   CSS Syntax section 5.5.5 ("consume a block's contents"), an invalid
-   declaration is dropped, parsing resumes at the next [;], and the surrounding
-   rule survives. *)
-let skip_to_next_declaration t =
-  let rec loop () =
-    match Cursor.next_raw t with
-    | None -> ()
-    | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
-    | Some _ -> loop ()
-  in
-  loop ()
-
 type parse_step =
   | Done of declaration list
   | Continue of declaration list
@@ -2305,9 +2291,12 @@ let read_declaration_step t acc =
   if Cursor.recover t then read_declaration_with_recovery t acc
   else read_declaration_no_recovery t acc
 
+(* CSS Syntax 3 sec. 5.5.5 ("consume a block's contents"): the invalid
+   declaration is dropped, reading resumes past the next [;], and the
+   surrounding rule survives. *)
 let recover_declaration_step t acc e =
   Cursor.push_warning t e;
-  skip_to_next_declaration t;
+  Cursor.skip_past_semicolon t;
   acc
 
 let rec read_declarations_loop t acc =

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -656,9 +656,13 @@ let container_prefix = function
   | `At_rule -> ""
 
 let container_label container_type condition =
-  match container_prefix container_type with
-  | "" -> condition
-  | prefix -> prefix ^ " " ^ condition
+  match container_type with
+  | `At_rule -> condition
+  (* A nesting container is a rule's own block, and the condition names the rule
+     it belongs to. Prefixing it as the others are prints [& .a], which is a
+     selector matching a [.a] inside the parent, the one thing it is not. *)
+  | `Nesting -> condition ^ " { & }"
+  | container_type -> container_prefix container_type ^ " " ^ condition
 
 (* The statements that carry neither a selector nor a block. Naming them apart
    also keeps them apart in the order keys, where one shared "(other statement)"
@@ -1144,12 +1148,19 @@ let statement_head stmt =
   else head
 
 (* Helper to extract rule information from statements *)
-let strings_of_rule stmt =
+let strings_of_rule (stmt : Css.statement) =
   match Css.as_rule stmt with
   | Some (selector, decls, _) ->
       let selector_str = Css.Selector.to_string selector in
       (selector_str, decls)
-  | None -> (statement_head stmt, Css.Stylesheet.statement_declarations stmt)
+  (* CSS Nesting 1 sec. 3.4: a run written after a nested statement is a nested
+     declarations rule, which acts as [&]. It has no head to cut at, so the text
+     up to the first brace is its first declaration, which reads in the selector
+     column as a selector it is not. *)
+  | None -> (
+      match stmt with
+      | Declarations decls -> ("&", decls)
+      | _ -> (statement_head stmt, Css.Stylesheet.statement_declarations stmt))
 
 let decl_to_prop_value decl =
   let name = Css.declaration_name decl in

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -56,6 +56,71 @@ let rec merge_lone (rule : rule) =
       merge_lone { child with selector = combine rule.selector child.selector }
   | _ -> rule
 
+(* What a run of nested statements would have to cross to move ahead of them:
+   every declaration they can write at any depth, read through
+   [statement_declarations] and [statement_children] so no block at-rule hides
+   one. An unknown at-rule is raw text whose body cannot be read at all, so it
+   is [Opaque]: a barrier nothing crosses. *)
+type barrier = Opaque | Crossed of Declaration.declaration list
+
+let rec crossing barrier (stmts : statement list) =
+  match (barrier, stmts) with
+  | Opaque, _ | _, [] -> barrier
+  | Crossed decls, stmt :: rest ->
+      let barrier =
+        match stmt with
+        | Unknown_at_rule _ -> Opaque
+        | _ ->
+            crossing
+              (Crossed (List.rev_append (statement_declarations stmt) decls))
+              (statement_children stmt)
+      in
+      crossing barrier rest
+
+let crosses_freely barrier decl =
+  match barrier with
+  | Opaque -> false
+  | Crossed decls -> Shorthand.declarations_commute [ decl ] decls
+
+(* CSS Nesting 1 sec. 3.4 keeps a declaration written after a nested statement
+   behind it. Moving one back into the rule's own run is cascade-neutral exactly
+   when it commutes with everything it would cross, so the body is walked once,
+   growing the barrier with each statement kept and with each declaration that
+   had to stay. Selectors are left out of the question: a nested rule matches
+   other elements than its parent, but assuming it matches the same one only
+   refuses a hoist the cascade would have allowed. *)
+let hoist_declaration_runs (rule : rule) =
+  let hoist_run barrier run =
+    List.fold_left
+      (fun (hoisted, barrier, kept) decl ->
+        if crosses_freely barrier decl then (decl :: hoisted, barrier, kept)
+        else
+          let barrier =
+            match barrier with
+            | Opaque -> Opaque
+            | Crossed decls -> Crossed (decl :: decls)
+          in
+          (hoisted, barrier, decl :: kept))
+      ([], barrier, []) run
+  in
+  let rec go hoisted barrier nested = function
+    | [] -> (List.rev hoisted, List.rev nested)
+    | Declarations run :: rest ->
+        let run_hoisted, barrier, kept = hoist_run barrier run in
+        let nested =
+          match List.rev kept with
+          | [] -> nested
+          | kept -> Declarations kept :: nested
+        in
+        go (run_hoisted @ hoisted) barrier nested rest
+    | stmt :: rest ->
+        go hoisted (crossing barrier [ stmt ]) (stmt :: nested) rest
+  in
+  match go [] (Crossed []) [] rule.nested with
+  | [], _ -> rule
+  | hoisted, nested ->
+      { rule with declarations = rule.declarations @ hoisted; nested }
+
 let rec strip_prefix (parent : Selector.t) (child : Selector.t) =
   match (parent, child) with
   | _, Selector.Combined (cp, comb, crest) when Selector.equal cp parent ->

--- a/lib/nest.mli
+++ b/lib/nest.mli
@@ -12,6 +12,14 @@ val combine : Selector.t -> Selector.t -> Selector.t
 val merge_lone : Stylesheet.rule -> Stylesheet.rule
 (** Merge a pure wrapper rule with its sole nested rule when safe. *)
 
+val hoist_declaration_runs : Stylesheet.rule -> Stylesheet.rule
+(** [hoist_declaration_runs rule] moves each declaration written after a nested
+    statement (CSS Nesting 1 sec. 3.4) back into the rule's own run, as far as
+    it commutes with everything nested above it. A declaration whose property a
+    crossed statement also writes stays where the author put it, so the rule
+    computes the same values while the rest rejoins the declaration passes.
+    Physically unchanged when nothing moves. *)
+
 val rules : Stylesheet.rule list -> Stylesheet.rule list
 (** Synthesize nested rules from adjacent flat selector chains. *)
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -152,13 +152,13 @@ let split_vendor_selector_lists (stmts : statement list) : statement list =
       | other -> [ other ])
     stmts
 
-let rec statements ?factor_cache ~ctx ~enforce_spec ~nesting
+let rec statements ?factor_cache ~ctx ~enforce_spec ~owner
     (stmts : statement list) : statement list =
   match stmts with
   | [] -> stmts
   | _ ->
       let optimize_merged_block =
-        statements ?factor_cache ~ctx ~enforce_spec ~nesting
+        statements ?factor_cache ~ctx ~enforce_spec ~owner
       in
       (* [drop_misplaced_imports] runs first: an [@import] after a style rule is
          invalid and ignored by browsers, so it must not act as a cascade
@@ -171,7 +171,7 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~nesting
           |> merge_named_layers_by_name |> split_vendor_selector_lists
         in
         let stmts =
-          process_statements ?factor_cache ~ctx ~enforce_spec ~nesting [] stmts
+          process_statements ?factor_cache ~ctx ~enforce_spec ~owner [] stmts
         in
         let stmts =
           if Ctx.regroup ctx then synthesize_nesting_statements stmts else stmts
@@ -179,7 +179,7 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~nesting
         let stmts =
           stmts
           |> merge_consecutive_media ~optimize_merged_block
-          |> merge_distant_media ~optimize_merged_block
+          |> merge_distant_media ?owner ~optimize_merged_block
           |> merge_consecutive_supports ~optimize_merged_block
           |> merge_consecutive_containers ~optimize_merged_block
         in
@@ -191,7 +191,7 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~nesting
    popping the next pending segment when the list is exhausted. This lets
    [process_supports_statement] splice three segments without materialising
    their concatenation. *)
-and process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
+and process_statements ?factor_cache ~ctx ~enforce_spec ~owner
     ?(pending : statement list list = []) (acc : statement list)
     (remaining : statement list) : statement list =
   match remaining with
@@ -199,35 +199,35 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
       match pending with
       | [] -> List.rev acc
       | next :: rest_pending ->
-          process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
+          process_statements ?factor_cache ~ctx ~enforce_spec ~owner
             ~pending:rest_pending acc next)
   | (Rule r as stmt) :: rest ->
-      process_rule_run ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc
-        stmt r rest
+      process_rule_run ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc stmt
+        r rest
   | (Media (cond, block) as stmt) :: rest ->
-      process_media_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_media_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         acc stmt cond block rest
   | (Container (name, cond, block) as stmt) :: rest ->
-      process_container_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+      process_container_statement ?factor_cache ~ctx ~enforce_spec ~owner
         ~pending acc stmt name cond block rest
   | Supports (cond, block) :: rest ->
-      process_supports_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+      process_supports_statement ?factor_cache ~ctx ~enforce_spec ~owner
         ~pending acc cond block rest
   | (Scope (start, end_, block) as stmt) :: rest ->
       let start' = option_map_preserve canonicalize_scope_selector start in
       let end_' = option_map_preserve canonicalize_scope_selector end_ in
       let optimized_block =
-        statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+        statements ?factor_cache ~ctx ~enforce_spec ~owner block
       in
       let optimized =
         if start' == start && end_' == end_ && optimized_block == block then
           stmt
         else Scope (start', end_', optimized_block)
       in
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         (optimized :: acc) rest
   | (Origin (origin, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         acc stmt block
         (fun block -> Origin (origin, block))
         rest
@@ -235,33 +235,33 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
      like [@media]'s: a group left out here keeps whatever the author wrote and
      [--minify] does nothing inside it. *)
   | (Moz_document (cond, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         acc stmt block
         (fun block -> Moz_document (cond, block))
         rest
   | (When (cond, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         acc stmt block
         (fun block -> When (cond, block))
         rest
   | (Else (cond, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         acc stmt block
         (fun block -> Else (cond, block))
         rest
   | (Starting_style block as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         acc stmt block
         (fun block -> Starting_style block)
         rest
   | (Layer (name, block) as stmt) :: rest ->
-      process_layer_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         acc stmt name block rest
   | (Import import as stmt) :: rest ->
-      process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting
-        ~pending acc stmt import rest
+      process_import_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
+        acc stmt import rest
   | (Declarations decls as stmt) :: rest ->
-      process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+      process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~owner
         ~pending acc stmt decls rest
   (* Listed rather than closed with a wildcard: everything left holds no block,
      so a statement that grows one has to be classified above before it
@@ -272,47 +272,47 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
      | Font_palette_values _ | Font_feature_values _ | View_transition _
      | Position_try _ | Viewport _ | Unknown_at_rule _ ) as hd)
     :: rest ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         (hd :: acc) rest
 
 (* A run of declarations is a declaration list wherever it sits, and nothing
    comes between two writes inside one, so the same deduplication a rule body
    gets applies (CSS Cascade 5 sec. 6.4.4: the later write wins). *)
-and process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+and process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~owner
     ~pending acc stmt decls rest =
   let decls' = declaration_run ~ctx decls in
   let stmt = if decls' == decls then stmt else Declarations decls' in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     (stmt :: acc) rest
 
-and process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
-    acc stmt block rebuild rest =
+and process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
+    stmt block rebuild rest =
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner block
   in
   let optimized =
     if optimized_block == block then stmt else rebuild optimized_block
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     (optimized :: acc) rest
 
-and process_rule_run ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc stmt
-    r rest =
+and process_rule_run ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc stmt r
+    rest =
   let plain_stmts, plain_rules, rest = collect_rules [ stmt ] [ r ] rest in
   let optimized = rules_aux ?factor_cache ~ctx ~enforce_spec plain_rules in
   let as_statements =
     if optimized == plain_rules then plain_stmts
     else List.map (fun r -> Rule r) optimized
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     (List.rev_append as_statements acc)
     rest
 
-and process_media_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
-    acc stmt cond block rest =
+and process_media_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
+    stmt cond block rest =
   let cond = if enforce_spec then cond else Media.lower_for_minify cond in
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner block
   in
   let optimized =
     if
@@ -321,17 +321,17 @@ and process_media_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
     then stmt
     else Media (cond, optimized_block)
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     (optimized :: acc) rest
 
-and process_container_statement ?factor_cache ~ctx ~enforce_spec ~nesting
-    ~pending acc stmt name cond block rest =
+and process_container_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
+    acc stmt name cond block rest =
   let cond =
     if enforce_spec then cond
     else option_map_preserve Container.lower_for_minify cond
   in
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner block
   in
   let optimized =
     if
@@ -340,20 +340,20 @@ and process_container_statement ?factor_cache ~ctx ~enforce_spec ~nesting
     then stmt
     else Container (name, cond, optimized_block)
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     (optimized :: acc) rest
 
-and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~nesting
-    ~pending acc cond block rest =
+and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
+    acc cond block rest =
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner block
   in
   let baseline =
     if enforce_spec then `Cond cond else Supports.simplify_baseline cond
   in
   match baseline with
   | `True when block_introduces_layer_order optimized_block ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         (Supports (cond, optimized_block) :: acc)
         rest
   | `True ->
@@ -363,48 +363,48 @@ and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~nesting
          adjacent rules across the segment boundary into one run - the whole
          point of unwrapping a baseline-true @supports. Tail-recursive
          [List.concat] so a long [optimized_block] cannot stack-overflow. *)
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
         (List.concat [ trailing; optimized_block; rest ])
   | `False ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
         rest
   | `Cond cond' ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         (Supports (cond', optimized_block) :: acc)
         rest
 
-and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
-    acc stmt name block rest =
+and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
+    stmt name block rest =
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner block
   in
   if is_layer_empty optimized_block then
     match name with
     (* A style rule holds no layer-order declaration, so inside one the empty
        block keeps its block form; folding it to [Layer_decl] emits CSS every
        engine drops. *)
-    | Some _ when nesting ->
-        process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+    | Some _ when Option.is_some owner ->
+        process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
           (Layer (name, optimized_block) :: acc)
           rest
     | Some layer_name ->
         let all_names, remaining =
           collect_empty_layer_names [ layer_name ] rest
         in
-        process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
           (Layer_decl all_names :: acc)
           remaining
     | None ->
-        process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
-          acc rest
+        process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
+          rest
   else
     let optimized =
       if optimized_block == block then stmt else Layer (name, optimized_block)
     in
-    process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+    process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
       (optimized :: acc) rest
 
-and process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+and process_import_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     acc stmt import rest =
   let stmt =
     match import.supports with
@@ -413,19 +413,20 @@ and process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
         Import { import with supports = None }
     | _ -> stmt
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     (stmt :: acc) rest
 
 (* Optimize one rule's nested statements recursively, then drop the redundant
    nesting prefix (see [drop_nesting_prefix]) and let a run written after them
-   rejoin the rule's own declarations wherever the cascade allows. *)
+   rejoin the rule's own declarations wherever the cascade allows. The body is
+   the rule's, so it optimizes with the rule as owner. *)
 and rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec rule =
   let nested =
     match rule.nested with
     | [] -> []
     | nested ->
         let nested =
-          statements ?factor_cache ~ctx ~enforce_spec ~nesting:true nested
+          statements ?factor_cache ~ctx ~enforce_spec ~owner:(Some rule) nested
         in
         if enforce_spec then nested
         else list_map_preserve drop_nesting_prefix nested
@@ -508,10 +509,10 @@ let drop_shadowed_keyframes (stmts : statement list) : statement list =
 let statements_top_level ?factor_cache ~ctx ~enforce_spec
     (stmts : statement list) : statement list =
   let optimize_merged_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting:false
+    statements ?factor_cache ~ctx ~enforce_spec ~owner:None
   in
   let stmts' =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting:false stmts
+    statements ?factor_cache ~ctx ~enforce_spec ~owner:None stmts
     |> merge_consecutive_layers ~optimize_merged_block
     |> drop_redundant_layer_decls |> drop_shadowed_keyframes
   in
@@ -523,7 +524,8 @@ let single_rule ?scope (rule : rule) : rule =
     hoist_declaration_runs
       {
         rule with
-        nested = statements ~ctx ~enforce_spec:false ~nesting:true rule.nested;
+        nested =
+          statements ~ctx ~enforce_spec:false ~owner:(Some rule) rule.nested;
       }
   in
   {

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -150,12 +150,14 @@ let split_vendor_selector_lists (stmts : statement list) : statement list =
       | other -> [ other ])
     stmts
 
-let rec statements ?factor_cache ~ctx ~enforce_spec (stmts : statement list) :
-    statement list =
+let rec statements ?factor_cache ~ctx ~enforce_spec ~nesting
+    (stmts : statement list) : statement list =
   match stmts with
   | [] -> stmts
   | _ ->
-      let optimize_merged_block = statements ?factor_cache ~ctx ~enforce_spec in
+      let optimize_merged_block =
+        statements ?factor_cache ~ctx ~enforce_spec ~nesting
+      in
       (* [drop_misplaced_imports] runs first: an [@import] after a style rule is
          invalid and ignored by browsers, so it must not act as a cascade
          boundary. Stripping it up front lets the rules it falsely separated
@@ -167,7 +169,7 @@ let rec statements ?factor_cache ~ctx ~enforce_spec (stmts : statement list) :
           |> merge_named_layers_by_name |> split_vendor_selector_lists
         in
         let stmts =
-          process_statements ?factor_cache ~ctx ~enforce_spec [] stmts
+          process_statements ?factor_cache ~ctx ~enforce_spec ~nesting [] stmts
         in
         let stmts =
           if Ctx.regroup ctx then synthesize_nesting_statements stmts else stmts
@@ -187,7 +189,7 @@ let rec statements ?factor_cache ~ctx ~enforce_spec (stmts : statement list) :
    popping the next pending segment when the list is exhausted. This lets
    [process_supports_statement] splice three segments without materialising
    their concatenation. *)
-and process_statements ?factor_cache ~ctx ~enforce_spec
+and process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
     ?(pending : statement list list = []) (acc : statement list)
     (remaining : statement list) : statement list =
   match remaining with
@@ -195,64 +197,67 @@ and process_statements ?factor_cache ~ctx ~enforce_spec
       match pending with
       | [] -> List.rev acc
       | next :: rest_pending ->
-          process_statements ?factor_cache ~ctx ~enforce_spec
+          process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
             ~pending:rest_pending acc next)
   | (Rule r as stmt) :: rest ->
-      process_rule_run ?factor_cache ~ctx ~enforce_spec ~pending acc stmt r rest
+      process_rule_run ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc
+        stmt r rest
   | (Media (cond, block) as stmt) :: rest ->
-      process_media_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-        cond block rest
+      process_media_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        acc stmt cond block rest
   | (Container (name, cond, block) as stmt) :: rest ->
-      process_container_statement ?factor_cache ~ctx ~enforce_spec ~pending acc
-        stmt name cond block rest
+      process_container_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+        ~pending acc stmt name cond block rest
   | Supports (cond, block) :: rest ->
-      process_supports_statement ?factor_cache ~ctx ~enforce_spec ~pending acc
-        cond block rest
+      process_supports_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+        ~pending acc cond block rest
   | (Scope (start, end_, block) as stmt) :: rest ->
       let start' = option_map_preserve canonicalize_scope_selector start in
       let end_' = option_map_preserve canonicalize_scope_selector end_ in
-      let optimized_block = statements ?factor_cache ~ctx ~enforce_spec block in
+      let optimized_block =
+        statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+      in
       let optimized =
         if start' == start && end_' == end_ && optimized_block == block then
           stmt
         else Scope (start', end_', optimized_block)
       in
-      process_statements ?factor_cache ~ctx ~enforce_spec ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
         (optimized :: acc) rest
   | (Origin (origin, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-        block
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        acc stmt block
         (fun block -> Origin (origin, block))
         rest
   (* The wrapper is opaque but its body is an ordinary block, so it optimises
      like [@media]'s: a group left out here keeps whatever the author wrote and
      [--minify] does nothing inside it. *)
   | (Moz_document (cond, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-        block
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        acc stmt block
         (fun block -> Moz_document (cond, block))
         rest
   | (When (cond, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-        block
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        acc stmt block
         (fun block -> When (cond, block))
         rest
   | (Else (cond, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-        block
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        acc stmt block
         (fun block -> Else (cond, block))
         rest
   | (Starting_style block as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-        block
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        acc stmt block
         (fun block -> Starting_style block)
         rest
   | (Layer (name, block) as stmt) :: rest ->
-      process_layer_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-        name block rest
+      process_layer_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        acc stmt name block rest
   | (Import import as stmt) :: rest ->
-      process_import_statement ?factor_cache ~ctx ~enforce_spec ~pending acc
-        stmt import rest
+      process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+        ~pending acc stmt import rest
   (* Listed rather than closed with a wildcard: everything left holds no block,
      so a statement that grows one has to be classified above before it
      compiles. *)
@@ -263,33 +268,38 @@ and process_statements ?factor_cache ~ctx ~enforce_spec
      | View_transition _ | Position_try _ | Viewport _ | Unknown_at_rule _ ) as
      hd)
     :: rest ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~pending (hd :: acc)
-        rest
+      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        (hd :: acc) rest
 
-and process_group_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-    block rebuild rest =
-  let optimized_block = statements ?factor_cache ~ctx ~enforce_spec block in
+and process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+    acc stmt block rebuild rest =
+  let optimized_block =
+    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+  in
   let optimized =
     if optimized_block == block then stmt else rebuild optimized_block
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
     (optimized :: acc) rest
 
-and process_rule_run ?factor_cache ~ctx ~enforce_spec ~pending acc stmt r rest =
+and process_rule_run ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc stmt
+    r rest =
   let plain_stmts, plain_rules, rest = collect_rules [ stmt ] [ r ] rest in
   let optimized = rules_aux ?factor_cache ~ctx ~enforce_spec plain_rules in
   let as_statements =
     if optimized == plain_rules then plain_stmts
     else List.map (fun r -> Rule r) optimized
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
     (List.rev_append as_statements acc)
     rest
 
-and process_media_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-    cond block rest =
+and process_media_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+    acc stmt cond block rest =
   let cond = if enforce_spec then cond else Media.lower_for_minify cond in
-  let optimized_block = statements ?factor_cache ~ctx ~enforce_spec block in
+  let optimized_block =
+    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+  in
   let optimized =
     if
       (cond == match stmt with Media (c, _) -> c | _ -> assert false)
@@ -297,16 +307,18 @@ and process_media_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
     then stmt
     else Media (cond, optimized_block)
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
     (optimized :: acc) rest
 
-and process_container_statement ?factor_cache ~ctx ~enforce_spec ~pending acc
-    stmt name cond block rest =
+and process_container_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+    ~pending acc stmt name cond block rest =
   let cond =
     if enforce_spec then cond
     else option_map_preserve Container.lower_for_minify cond
   in
-  let optimized_block = statements ?factor_cache ~ctx ~enforce_spec block in
+  let optimized_block =
+    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+  in
   let optimized =
     if
       (cond == match stmt with Container (_, c, _) -> c | _ -> assert false)
@@ -314,18 +326,20 @@ and process_container_statement ?factor_cache ~ctx ~enforce_spec ~pending acc
     then stmt
     else Container (name, cond, optimized_block)
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
     (optimized :: acc) rest
 
-and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~pending acc
-    cond block rest =
-  let optimized_block = statements ?factor_cache ~ctx ~enforce_spec block in
+and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+    ~pending acc cond block rest =
+  let optimized_block =
+    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+  in
   let baseline =
     if enforce_spec then `Cond cond else Supports.simplify_baseline cond
   in
   match baseline with
   | `True when block_introduces_layer_order optimized_block ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
         (Supports (cond, optimized_block) :: acc)
         rest
   | `True ->
@@ -335,38 +349,49 @@ and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~pending acc
          adjacent rules across the segment boundary into one run - the whole
          point of unwrapping a baseline-true @supports. Tail-recursive
          [List.concat] so a long [optimized_block] cannot stack-overflow. *)
-      process_statements ?factor_cache ~ctx ~enforce_spec ~pending acc
+      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc
         (List.concat [ trailing; optimized_block; rest ])
   | `False ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~pending acc rest
+      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc
+        rest
   | `Cond cond' ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
         (Supports (cond', optimized_block) :: acc)
         rest
 
-and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-    name block rest =
-  let optimized_block = statements ?factor_cache ~ctx ~enforce_spec block in
+and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+    acc stmt name block rest =
+  let optimized_block =
+    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+  in
   if is_layer_empty optimized_block then
     match name with
+    (* A style rule holds no layer-order declaration, so inside one the empty
+       block keeps its block form; folding it to [Layer_decl] emits CSS every
+       engine drops. *)
+    | Some _ when nesting ->
+        process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+          (Layer (name, optimized_block) :: acc)
+          rest
     | Some layer_name ->
         let all_names, remaining =
           collect_empty_layer_names [ layer_name ] rest
         in
-        process_statements ?factor_cache ~ctx ~enforce_spec ~pending
+        process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
           (Layer_decl all_names :: acc)
           remaining
     | None ->
-        process_statements ?factor_cache ~ctx ~enforce_spec ~pending acc rest
+        process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+          acc rest
   else
     let optimized =
       if optimized_block == block then stmt else Layer (name, optimized_block)
     in
-    process_statements ?factor_cache ~ctx ~enforce_spec ~pending
+    process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
       (optimized :: acc) rest
 
-and process_import_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
-    import rest =
+and process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+    acc stmt import rest =
   let stmt =
     match import.supports with
     | Some cond
@@ -374,8 +399,8 @@ and process_import_statement ?factor_cache ~ctx ~enforce_spec ~pending acc stmt
         Import { import with supports = None }
     | _ -> stmt
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~pending (stmt :: acc)
-    rest
+  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+    (stmt :: acc) rest
 
 and rules_aux ?factor_cache ~ctx ~enforce_spec (rules : rule list) : rule list =
   (* First optimize each rule's nested statements recursively, then drop the
@@ -387,7 +412,9 @@ and rules_aux ?factor_cache ~ctx ~enforce_spec (rules : rule list) : rule list =
           match rule.nested with
           | [] -> []
           | nested ->
-              let nested = statements ?factor_cache ~ctx ~enforce_spec nested in
+              let nested =
+                statements ?factor_cache ~ctx ~enforce_spec ~nesting:true nested
+              in
               if enforce_spec then nested
               else list_map_preserve drop_nesting_prefix nested
         in
@@ -463,9 +490,11 @@ let drop_shadowed_keyframes (stmts : statement list) : statement list =
    [empty-named-layer -> Layer_decl] normalisation in [process_statements]. *)
 let statements_top_level ?factor_cache ~ctx ~enforce_spec
     (stmts : statement list) : statement list =
-  let optimize_merged_block = statements ?factor_cache ~ctx ~enforce_spec in
+  let optimize_merged_block =
+    statements ?factor_cache ~ctx ~enforce_spec ~nesting:false
+  in
   let stmts' =
-    statements ?factor_cache ~ctx ~enforce_spec stmts
+    statements ?factor_cache ~ctx ~enforce_spec ~nesting:false stmts
     |> merge_consecutive_layers ~optimize_merged_block
     |> drop_redundant_layer_decls |> drop_shadowed_keyframes
   in
@@ -476,7 +505,7 @@ let single_rule ?scope (rule : rule) : rule =
   {
     rule with
     declarations = deduplicate_declarations_with ~ctx rule.declarations;
-    nested = statements ~ctx ~enforce_spec:false rule.nested;
+    nested = statements ~ctx ~enforce_spec:false ~nesting:true rule.nested;
   }
 
 let rules ?scope (rules : rule list) : rule list =

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -78,6 +78,7 @@ let drop_empty_rules = Block.drop_empty_rules
 let drop_misplaced_imports = Block.drop_misplaced_imports
 let merge_named_layers_by_name = Block.merge_named_layers_by_name
 let merge_lone_nested_rule = Nest.merge_lone
+let hoist_declaration_runs = Nest.hoist_declaration_runs
 let synthesize_nesting_statements = Nest.statements
 let stylesheet_key stmts = Pp.to_string ~minify:true pp_stylesheet stmts
 
@@ -402,28 +403,31 @@ and process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
   process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
     (stmt :: acc) rest
 
+(* Optimize one rule's nested statements recursively, then drop the redundant
+   nesting prefix (see [drop_nesting_prefix]) and let a run written after them
+   rejoin the rule's own declarations wherever the cascade allows. *)
+and rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec rule =
+  let nested =
+    match rule.nested with
+    | [] -> []
+    | nested ->
+        let nested =
+          statements ?factor_cache ~ctx ~enforce_spec ~nesting:true nested
+        in
+        if enforce_spec then nested
+        else list_map_preserve drop_nesting_prefix nested
+  in
+  let rule = hoist_declaration_runs (rule_with_nested rule nested) in
+  let rule =
+    let selector = Selector.canonicalize rule.selector in
+    if selector == rule.selector then rule else { rule with selector }
+  in
+  merge_lone_nested_rule rule
+
 and rules_aux ?factor_cache ~ctx ~enforce_spec (rules : rule list) : rule list =
-  (* First optimize each rule's nested statements recursively, then drop the
-     redundant nesting prefix (see [drop_nesting_prefix]). *)
   let with_optimized_nested =
     list_map_preserve
-      (fun rule ->
-        let nested =
-          match rule.nested with
-          | [] -> []
-          | nested ->
-              let nested =
-                statements ?factor_cache ~ctx ~enforce_spec ~nesting:true nested
-              in
-              if enforce_spec then nested
-              else list_map_preserve drop_nesting_prefix nested
-        in
-        let rule = rule_with_nested rule nested in
-        let rule =
-          let selector = Selector.canonicalize rule.selector in
-          if selector == rule.selector then rule else { rule with selector }
-        in
-        merge_lone_nested_rule rule)
+      (rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec)
       rules
   in
   (* Apply local rule normalization before the DAG factor scheduler decides
@@ -502,10 +506,16 @@ let statements_top_level ?factor_cache ~ctx ~enforce_spec
 
 let single_rule ?scope (rule : rule) : rule =
   let ctx = ctx_of_scope scope in
+  let rule =
+    hoist_declaration_runs
+      {
+        rule with
+        nested = statements ~ctx ~enforce_spec:false ~nesting:true rule.nested;
+      }
+  in
   {
     rule with
     declarations = deduplicate_declarations_with ~ctx rule.declarations;
-    nested = statements ~ctx ~enforce_spec:false ~nesting:true rule.nested;
   }
 
 let rules ?scope (rules : rule list) : rule list =

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -61,6 +61,7 @@ let compose_shorthands = Shorthand.compose_shorthands
 let deduplicate_declarations_with = Shorthand.deduplicate_declarations_with
 let deduplicate_declarations = Shorthand.deduplicate_declarations
 let single_rule_without_nested = Rule.single
+let declaration_run = Rule.declaration_run
 let finalize_rule_without_nested = Rule.finalize
 
 (** {1 Statement Optimization} *)
@@ -259,18 +260,30 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
   | (Import import as stmt) :: rest ->
       process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting
         ~pending acc stmt import rest
+  | (Declarations decls as stmt) :: rest ->
+      process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+        ~pending acc stmt decls rest
   (* Listed rather than closed with a wildcard: everything left holds no block,
      so a statement that grows one has to be classified above before it
      compiles. *)
-  | (( Declarations _ | Property _ | Bang_comment _ | Charset _ | Namespace _
-     | Layer_decl _ | Supports_condition _ | Keyframes _ | Webkit_keyframes _
-     | Moz_keyframes _ | Font_face _ | Counter_style _ | Page _
-     | Page_with_margins _ | Font_palette_values _ | Font_feature_values _
-     | View_transition _ | Position_try _ | Viewport _ | Unknown_at_rule _ ) as
-     hd)
+  | (( Property _ | Bang_comment _ | Charset _ | Namespace _ | Layer_decl _
+     | Supports_condition _ | Keyframes _ | Webkit_keyframes _ | Moz_keyframes _
+     | Font_face _ | Counter_style _ | Page _ | Page_with_margins _
+     | Font_palette_values _ | Font_feature_values _ | View_transition _
+     | Position_try _ | Viewport _ | Unknown_at_rule _ ) as hd)
     :: rest ->
       process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
         (hd :: acc) rest
+
+(* A run of declarations is a declaration list wherever it sits, and nothing
+   comes between two writes inside one, so the same deduplication a rule body
+   gets applies (CSS Cascade 5 sec. 6.4.4: the later write wins). *)
+and process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+    ~pending acc stmt decls rest =
+  let decls' = declaration_run ~ctx decls in
+  let stmt = if decls' == decls then stmt else Declarations decls' in
+  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+    (stmt :: acc) rest
 
 and process_group_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
     acc stmt block rebuild rest =

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -23,6 +23,9 @@ type ctx = {
           feature test. The value is a capability predicate for that exact
           syntax, so lossy rewrites (e.g. static colour folding) must be
           suppressed there. *)
+  in_style_rule : bool;
+      (** Set while serialising a style rule's contents, where CSS nesting
+          applies and a statement-form at-rule is not accepted. *)
   lossless : bool;
       (** Set under [--minify --lossless]: suppress colour-channel rounding and
           other colour approximations while keeping exact serialisation
@@ -80,6 +83,7 @@ let v ?(minify = false) ?indent ?(inline = false) ?(lossless = false)
     in_function = false;
     in_calc = false;
     in_feature_query = false;
+    in_style_rule = false;
     lossless;
     enforce_spec;
   }
@@ -453,6 +457,8 @@ let block_close ctx () = char ctx '}'
 let minified ctx = ctx.minify
 let in_feature_query ctx = ctx.in_feature_query
 let enter_feature_query ctx = { ctx with in_feature_query = true }
+let in_style_rule ctx = ctx.in_style_rule
+let enter_style_rule ctx = { ctx with in_style_rule = true }
 let cond p a b ctx x = if p ctx then a ctx x else b ctx x
 let space_if_pretty = sp
 

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -43,6 +43,9 @@ type ctx = {
           feature test. The value is a capability predicate for that exact
           syntax, so lossy rewrites (e.g. static colour folding) are suppressed
           there. *)
+  in_style_rule : bool;
+      (** Set while serialising a style rule's contents, where CSS nesting
+          applies and a statement-form at-rule is not accepted. *)
   lossless : bool;
       (** Set under [--minify --lossless]: suppress colour-channel rounding and
           other colour approximations while keeping exact serialisation
@@ -274,6 +277,13 @@ val in_feature_query : ctx -> bool
 val enter_feature_query : ctx -> ctx
 (** [enter_feature_query ctx] marks [ctx] as inside an [@supports] feature-test
     value. *)
+
+val in_style_rule : ctx -> bool
+(** [in_style_rule ctx] is true while serialising the contents of a style rule,
+    where CSS nesting applies and statement-form at-rules are not accepted. *)
+
+val enter_style_rule : ctx -> ctx
+(** [enter_style_rule ctx] marks [ctx] as inside a style rule's contents. *)
 
 val cond : (ctx -> bool) -> 'a t -> 'a t -> 'a t
 (** [cond predicate then_fmt else_fmt] conditionally chooses formatter based on

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -217,9 +217,12 @@ let drop_shadowed_rules (rules : rule list) : rule list =
   let changed = ref false in
   for i = len - 1 downto 0 do
     let rule = rules_arr.(i) in
+    (* [declarations] is only the run written before the first nested statement
+       (CSS Nesting 1 sec. 3.4), so covering it says nothing about what the rest
+       of the body sets: a rule with nested content stays. *)
     dropped.(i) <-
       (rule.declarations = [] && rule.nested = [])
-      || rule.declarations <> []
+      || rule.nested = [] && rule.declarations <> []
          && List.for_all
               (Cover.covered later_by_selector rule.Stylesheet_intf.selector)
               rule.declarations;

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -191,6 +191,16 @@ let synthesize_position_try decls =
       | _ -> decls)
   | _ -> decls
 
+(* The declaration passes a rule body gets, for a body that has no rule of its
+   own: a nested declarations run (CSS Nesting 1 sec. 3.4) or a bare
+   [Declarations] block. Nothing comes between two writes inside one run, so the
+   later wins exactly as it does in a rule. The selector-dependent steps are
+   left out, since neither form carries a selector. *)
+let declaration_run ~ctx decls =
+  list_map_preserve (Declaration.normalize ~lossless:(Ctx.lossless ctx)) decls
+  |> deduplicate_declarations_with ~ctx
+  |> synthesize_columns |> synthesize_position_try |> preserve_list decls
+
 let finalize ?(canonicalize_selector = true) ~ctx (rule : rule) : rule =
   let declarations =
     deduplicate_declarations_with ~ctx rule.declarations

--- a/lib/rule.mli
+++ b/lib/rule.mli
@@ -3,6 +3,11 @@
 val single : ctx:Ctx.t -> Stylesheet.rule -> Stylesheet.rule
 (** Optimize one rule without descending into nested statements. *)
 
+val declaration_run :
+  ctx:Ctx.t -> Declaration.declaration list -> Declaration.declaration list
+(** Declaration cleanup for a body that has no rule of its own: a nested
+    declarations run or a bare [Declarations] block. *)
+
 val finalize :
   ?canonicalize_selector:bool -> ctx:Ctx.t -> Stylesheet.rule -> Stylesheet.rule
 (** Final declaration cleanup before a rule leaves the fixpoint. *)

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -100,23 +100,31 @@ end)
    rule's declarations ahead of any nested block an earlier one carries. That
    only matters for a property the nested block also sets, so a rule with nested
    children can still take part as long as those children and the declarations
-   that would move past them are disjoint. *)
+   that would move past them are disjoint.
+
+   Read through the exhaustive statement walks: every nested statement sets
+   properties, a nested declarations run as much as a nested style rule, and one
+   this walk cannot see is one the merge would happily hoist past. *)
 let rec nested_property_keys acc (stmts : statement list) =
   List.fold_left
     (fun acc stmt ->
-      match stmt with
-      | Rule r ->
-          let acc =
-            List.fold_left
-              (fun acc d -> Prop_set.add (Declaration.property_key d) acc)
-              acc r.declarations
-          in
-          nested_property_keys acc r.nested
-      | _ -> acc)
+      let acc =
+        List.fold_left
+          (fun acc d -> Prop_set.add (Declaration.property_key d) acc)
+          acc
+          (statement_declarations stmt)
+      in
+      nested_property_keys acc (statement_children stmt))
     acc stmts
 
+(* CSS Nesting 1 sec. 3.4 puts a declaration written after a nested rule behind
+   it, so a rule's body is not the run of declarations [declarations] holds:
+   merging a later same-selector rule into it moves that rule's declarations
+   ahead of everything nested. [nested_merge_is_safe] below decides that per
+   property; until it reads the whole body, keep a rule carrying nested content
+   out of the merge entirely, as [rule_eligible] already does. *)
 let same_selector_eligible (r : rule) =
-  r.merge_key = Option.None
+  r.nested = [] && r.merge_key = Option.None
   && (not (contains_vendor_pseudo_element r.selector))
   && not (List.exists Shorthand.is_all_declaration r.declarations)
 

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3483,6 +3483,37 @@ let same_minified_declaration (a : declaration) (b : declaration) =
   || Declaration.hash a = Declaration.hash b
      && Declaration.equal_declaration a b
 
+(* Only a pair that writes a common cascade slot at the same importance with
+   different values constrains its own order: [!important] beats the plain
+   declaration wherever the two sit, and an identical pair is its own winner
+   either way. The footprint is computed once per declaration rather than once
+   per pair, since the test below is quadratic. *)
+type commute_fact = {
+  decl : declaration;
+  important : bool;
+  keys : overlap_key list;
+}
+
+let commute_fact decl =
+  {
+    decl;
+    important = Declaration.is_important decl;
+    keys = declaration_overlap_keys decl;
+  }
+
+let commute_facts_conflict a b =
+  a.important = b.important
+  && (not (same_minified_declaration a.decl b.decl))
+  && declarations_overlap_with_keys a.decl a.keys b.decl b.keys
+
+let declarations_commute left right =
+  let left = List.map commute_fact left in
+  let right = List.map commute_fact right in
+  not
+    (List.exists
+       (fun a -> List.exists (fun b -> commute_facts_conflict a b) right)
+       left)
+
 let legacy_vendor_fallback new_decl existing =
   (* Different-value duplicates are kept when one value is vendor-prefixed: the
      cascade may pick whichever the browser understands. *)

--- a/lib/shorthand.mli
+++ b/lib/shorthand.mli
@@ -69,6 +69,14 @@ val same_minified_declaration :
   Declaration.declaration -> Declaration.declaration -> bool
 (** Same canonical minified declaration. *)
 
+val declarations_commute :
+  Declaration.declaration list -> Declaration.declaration list -> bool
+(** [declarations_commute a b] is [true] when running [a] before [b] and [b]
+    before [a] compute the same value for every property on every element: no
+    pair across the two writes a common cascade slot at the same importance with
+    a different value. Selectors are not read, so two runs that could never meet
+    on one element still count as constrained when their properties clash. *)
+
 val is_all_declaration : Declaration.declaration -> bool
 (** Whether a declaration is the [all] shorthand. *)
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3755,7 +3755,8 @@ and read_nested_at_keyword r ~loc ~prev = function
       Some (read_else ~body:read_nesting_block r)
   | "else" -> drop_nested_at_rule r ~loc "@else without preceding @when"
   | ("charset" | "import" | "namespace") as name ->
-      Cursor.err_invalid r ("Unexpected nested at-rule: @" ^ name)
+      drop_nested_at_rule r ~loc
+        ("@" ^ name ^ " is only valid at the top of a stylesheet")
   | name when not (nests_in_style_rule name) ->
       drop_nested_at_rule r ~loc
         ("@" ^ name ^ " has no style rule in it, so it does not nest")

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2069,12 +2069,24 @@ let read_descriptor_item (r : Cursor.t) =
     | Some desc -> `Descriptor desc
     | None -> Cursor.err_expected r "descriptor"
 
+(* CSS Cascade 5 sec. 6.2 ranks an important author declaration above a normal
+   one whatever their order, and sec. 6.4 breaks a tie between two of the same
+   importance by order of appearance. A descriptor read later therefore takes
+   the slot one already read holds, unless the one held is important and it is
+   not: then the later declaration is the one that is dropped, and the survivor
+   keeps the place it was written in. *)
 let replace_descriptor desc acc =
-  desc
-  :: List.filter
-       (fun existing ->
-         Declaration.property_name existing <> Declaration.property_name desc)
-       acc
+  let same_slot held =
+    String.equal
+      (Declaration.property_name held)
+      (Declaration.property_name desc)
+  in
+  match List.find_opt same_slot acc with
+  | Some held
+    when Declaration.is_important held && not (Declaration.is_important desc) ->
+      acc
+  | Some _ -> desc :: List.filter (fun held -> not (same_slot held)) acc
+  | None -> desc :: acc
 
 let read_descriptor_step normalize inner acc =
   match read_descriptor_item inner with

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2034,11 +2034,12 @@ let skip_invalid_item r =
 
 (* Read a body one item at a time, [step] committing each item to the
    accumulator before the next is read, so an item dropped in recovery costs
-   only itself. CSS Paged Media 3 sec. 6: "If an error is encountered during the
-   processing of a declaration block within a page or a margin context, the
-   Rules for handling parsing errors apply; that is, valid declarations within
-   the block are applied." Strict mode ([not (Cursor.recover r)]) still raises,
-   so [~strict:true] rejects exactly what the lenient parse warns about. *)
+   only itself and the items around it are kept. CSS Syntax 3 sec. 5.4.3 keeps
+   what a block's contents already yielded when one item fails to parse, and CSS
+   Paged Media 3 sec. 6 says as much of a page or a margin context in so many
+   words: "valid declarations within the block are applied". Strict mode ([not
+   (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly what the
+   lenient parse warns about. *)
 let read_items_with_recovery step r init =
   let rec loop state =
     if Cursor.recover r then recovering state else continue (step r state)
@@ -3324,32 +3325,44 @@ let nests_in_style_rule = function
       false
   | _ -> true
 
-let read_property_descriptors (r : Cursor.t) : property_reader_state =
-  let state = ref { syntax = None; inherits = None; initial_value = None } in
-  let rec loop () =
-    Cursor.ws r;
-    if Cursor.is_done r then !state
-    else
-      let key = Cursor.ident ~keep_case:false r in
-      Cursor.ws r;
-      if not (Cursor.colon r) then Cursor.err_expected r "':'";
-      Cursor.ws r;
-      (match key with
-      | "syntax" ->
-          let syn = Variables.read_syntax r in
-          state := { !state with syntax = Some syn }
-      | "inherits" ->
-          let inherits_value = Cursor.bool r in
-          state := { !state with inherits = Some inherits_value }
-      | "initial-value" ->
-          let value_str = Cursor.consume_until_semicolon ~trim:true r in
-          state := { !state with initial_value = Some value_str }
-      | _ -> Cursor.err_invalid r "unknown property descriptor");
-      Cursor.ws r;
-      if Cursor.peek_semicolon r then Cursor.skip r;
-      loop ()
+(* One descriptor of an [@property] body. The state is returned rather than
+   assigned as the value is read, so a descriptor that fails leaves the ones
+   before it untouched. CSS Properties and Values API 1 sec. 2 gives each
+   descriptor a grammar of its own, and the declaration is the whole of it: a
+   trailing [!important] or a stray ident makes the declaration invalid rather
+   than the leftover alone, as it does in Blink 146. *)
+let read_property_descriptor (r : Cursor.t) state =
+  let key = Cursor.ident ~keep_case:false r in
+  Cursor.ws r;
+  if not (Cursor.colon r) then Cursor.err_expected r "':'";
+  Cursor.ws r;
+  let state =
+    match key with
+    | "syntax" -> { state with syntax = Some (Variables.read_syntax r) }
+    | "inherits" -> { state with inherits = Some (Cursor.bool r) }
+    | "initial-value" ->
+        {
+          state with
+          initial_value = Some (Cursor.consume_until_semicolon ~trim:true r);
+        }
+    | _ -> Cursor.err_invalid r "unknown property descriptor"
   in
-  loop ()
+  Cursor.ws r;
+  if not (Cursor.is_done r || Cursor.peek_semicolon r) then
+    Cursor.err_invalid r ("trailing tokens after @property " ^ key);
+  state
+
+let read_property_step r state =
+  Cursor.ws r;
+  if Cursor.is_done r then `Done state
+  else if Cursor.peek_semicolon r then (
+    Cursor.skip r;
+    `More state)
+  else `More (read_property_descriptor r state)
+
+let read_property_descriptors (r : Cursor.t) : property_reader_state =
+  read_items_with_recovery read_property_step r
+    { syntax = None; inherits = None; initial_value = None }
 
 let read_property_rule (r : Cursor.t) : statement =
   (* Read @property descriptors as a separate helper to keep the reader tidy. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3332,6 +3332,15 @@ let item_opens_block inner =
   Cursor.restore inner start;
   found
 
+(* CSS Nesting 1 sec. 3.4 wraps a run of declarations written after a nested
+   statement in a nested declarations rule, so it keeps its place among them.
+   The run a rule body is reading is the head of its [nested] accumulator and
+   holds its declarations reversed, like [decls]; sealing it puts them back in
+   source order. *)
+let seal_declaration_run = function
+  | Declarations run :: rest -> Declarations (List.rev run) :: rest
+  | nested -> nested
+
 let rec read_statement (r : Cursor.t) : statement =
   Cursor.ws r;
   let table : (string * (Cursor.t -> statement)) list =
@@ -3715,10 +3724,10 @@ and read_nested_at_within_rule (r : Cursor.t) (selector : Selector.t) :
 
 and read_rule_item selector inner decls nested =
   match Cursor.peek inner with
-  | None -> `Done (List.rev decls, List.rev nested)
+  | None -> `Done (List.rev decls, List.rev (seal_declaration_run nested))
   | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
       let stmt = read_nested_at_within_rule inner selector in
-      `Continue (decls, stmt :: nested)
+      `Continue (decls, stmt :: seal_declaration_run nested)
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       Cursor.skip inner;
       `Continue (decls, nested)
@@ -3727,10 +3736,16 @@ and read_rule_item selector inner decls nested =
 and read_rule_decl_or_nested selector inner decls nested =
   let start = Cursor.save inner in
   match Declaration.read_declaration inner with
-  | Some d ->
+  | Some d -> (
       Cursor.ws inner;
       if Cursor.peek_semicolon inner then Cursor.skip inner;
-      `Continue (d :: decls, nested)
+      (* Only the run written before the first nested statement is the rule's
+         own; a later one joins the block it follows. *)
+      match nested with
+      | [] -> `Continue (d :: decls, nested)
+      | Declarations run :: rest ->
+          `Continue (decls, Declarations (d :: run) :: rest)
+      | _ -> `Continue (decls, Declarations [ d ] :: nested))
   | None -> read_nested_rule_or_done selector inner decls nested
   (* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so
      [h2:where(...) { ... }] reads as a declaration up to the [{]. Rewind and
@@ -3742,11 +3757,12 @@ and read_rule_decl_or_nested selector inner decls nested =
       read_nested_rule_or_done selector inner decls nested
 
 and read_nested_rule_or_done selector inner decls nested =
-  if Cursor.is_done inner then `Done (List.rev decls, List.rev nested)
+  if Cursor.is_done inner then
+    `Done (List.rev decls, List.rev (seal_declaration_run nested))
   else
     let nr = read_rule ~nested:true inner in
     validate_nested_rule_selector inner selector nr.selector;
-    `Continue (decls, Rule nr :: nested)
+    `Continue (decls, Rule nr :: seal_declaration_run nested)
 
 and read_rule_body selector inner =
   let rec loop decls nested =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2001,16 +2001,20 @@ let read_descriptor_value read_fn constructor r =
     constructor value
   with Failure msg -> Cursor.err_invalid r msg
 
-(* CSS Syntax 3 sec. 5.4.2: an at-rule ends at its block or at its [;].
-   Discarding an invalid one consumes exactly that far, so the declarations
-   written after it stay in the rule. *)
-let rec skip_at_rule r =
+(* Discard the rule the cursor sits on, stopping at its [{}] block or at a
+   top-level [;]: CSS Syntax 3 sec. 5.4.2 ends an at-rule at whichever comes
+   first, and sec. 5.4.3 ends a qualified rule at its block. Consuming exactly
+   that far leaves what was written after the rule - the declarations around it,
+   or the next rule - to be read on its own. A [(] or a [[] met before the block
+   is a component value of the prelude being discarded, so stopping there would
+   offer the tail of that prelude as a rule of its own. *)
+let rec skip_past_rule r =
   match Cursor.next_raw r with
   | None -> ()
   | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       ()
-  | Some _ -> skip_at_rule r
+  | Some _ -> skip_past_rule r
 
 (* Discard the item the cursor sits on. A body that holds declarations and
    at-rules alike has to pick by what the item starts with: the two ends differ,
@@ -2020,7 +2024,7 @@ let rec skip_at_rule r =
 let skip_invalid_item r =
   match Cursor.peek r with
   | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      skip_at_rule r
+      skip_past_rule r
   | _ -> Cursor.skip_past_semicolon r
 
 (* Read a body one item at a time, [step] committing each item to the
@@ -3391,7 +3395,7 @@ let item_opens_block inner =
    item, the recovery CSS Syntax 3 sec. 5.4.4 describes. The warning is what
    [~strict:true] turns into an error. *)
 let drop_nested_at_rule r ~loc reason : statement option =
-  skip_at_rule r;
+  skip_past_rule r;
   Cursor.push_warning r (Error.bad_value loc ~property:"rule" ~reason);
   None
 
@@ -3510,16 +3514,6 @@ let rec read_statement (r : Cursor.t) : statement =
   | _ -> Rule (read_rule r)
 
 and read_block (r : Cursor.t) : block =
-  (* Skip a statement that failed to parse: consume to the end of its block
-     ([{...}]) or its terminating [;], leaving the cursor at the next rule. *)
-  let rec skip_bad_statement () =
-    match Cursor.next_raw r with
-    | None -> ()
-    | Some (Component.Block _)
-    | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-        ()
-    | Some _ -> skip_bad_statement ()
-  in
   let rec read_statements acc =
     Cursor.ws r;
     if Cursor.is_done r then List.rev acc
@@ -3534,7 +3528,7 @@ and read_block (r : Cursor.t) : block =
       | exception Error.Parse_error e when Cursor.recover r ->
           Cursor.restore r snap;
           Cursor.push_warning r e;
-          skip_bad_statement ();
+          skip_past_rule r;
           read_statements acc
       | Import _ ->
           (* CSS Cascade L6 sec. 2: @import is only valid at the top of the

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2001,14 +2001,77 @@ let read_descriptor_value read_fn constructor r =
     constructor value
   with Failure msg -> Cursor.err_invalid r msg
 
-let read_descriptor_declaration (r : Cursor.t) : Declaration.declaration option
-    =
+(* CSS Syntax 3 sec. 5.4.4: a declaration that fails to parse ends at the next
+   top-level [;]; a [{}] met on the way is one component value of the value
+   being skipped, not a stopping point. *)
+let rec skip_bad_rule_item inner =
+  match Cursor.next_raw inner with
+  | None -> ()
+  | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
+  | Some _ -> skip_bad_rule_item inner
+
+(* CSS Syntax 3 sec. 5.4.2: an at-rule ends at its block or at its [;].
+   Discarding an invalid one consumes exactly that far, so the declarations
+   written after it stay in the rule. *)
+let rec skip_at_rule r =
+  match Cursor.next_raw r with
+  | None -> ()
+  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
+  | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
+      ()
+  | Some _ -> skip_at_rule r
+
+(* Discard the item the cursor sits on. A body that holds declarations and
+   at-rules alike has to pick by what the item starts with: the two ends differ,
+   and taking an at-rule for a declaration would eat the item written after it.
+   The caller rewinds first, so a reader that already consumed part of the item
+   is skipped from its start. *)
+let skip_invalid_item r =
+  match Cursor.peek r with
+  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
+      skip_at_rule r
+  | _ -> skip_bad_rule_item r
+
+(* Read a body one item at a time, [step] committing each item to the
+   accumulator before the next is read, so an item dropped in recovery costs
+   only itself. CSS Paged Media 3 sec. 6: "If an error is encountered during the
+   processing of a declaration block within a page or a margin context, the
+   Rules for handling parsing errors apply; that is, valid declarations within
+   the block are applied." Strict mode ([not (Cursor.recover r)]) still raises,
+   so [~strict:true] rejects exactly what the lenient parse warns about. *)
+let read_items_with_recovery step r init =
+  let rec loop state =
+    if Cursor.recover r then recovering state else continue (step r state)
+  and recovering state =
+    let start = Cursor.save r in
+    match step r state with
+    | committed -> continue committed
+    | exception Error.Parse_error e ->
+        Cursor.push_warning r e;
+        Cursor.restore r start;
+        skip_invalid_item r;
+        loop state
+  and continue = function
+    | `Done result -> result
+    | `More state -> loop state
+  in
+  loop init
+
+(* One item of a descriptor body: a descriptor, a stray [;] that CSS Syntax 3
+   sec. 5.4.3 discards with no declaration to validate, or the end of the body.
+   [Declaration.read_declaration] answers [None] for an item that opens a block
+   instead; a descriptor body holds no rules, so that item is invalid and is
+   reported rather than left for the caller to loop on. *)
+let read_descriptor_item (r : Cursor.t) =
   Cursor.ws r;
-  if Cursor.is_done r then None
+  if Cursor.is_done r then `Done
   else if Cursor.peek_semicolon r then (
     Cursor.skip r;
-    None)
-  else Declaration.read_declaration r
+    `Skip)
+  else
+    match Declaration.read_declaration r with
+    | Some desc -> `Descriptor desc
+    | None -> Cursor.err_expected r "descriptor"
 
 let replace_descriptor desc acc =
   desc
@@ -2017,15 +2080,14 @@ let replace_descriptor desc acc =
          Declaration.property_name existing <> Declaration.property_name desc)
        acc
 
+let read_descriptor_step normalize inner acc =
+  match read_descriptor_item inner with
+  | `Done -> `Done (List.rev acc)
+  | `Skip -> `More acc
+  | `Descriptor desc -> `More (normalize desc acc)
+
 let read_descriptor_block normalize inner =
-  let rec loop acc =
-    match read_descriptor_declaration inner with
-    | Some desc -> loop (normalize desc acc)
-    | None ->
-        Cursor.ws inner;
-        if Cursor.is_done inner then List.rev acc else loop acc
-  in
-  loop []
+  read_items_with_recovery (read_descriptor_step normalize) inner []
 
 (* CSS Fonts 4 sec. 4.4: a descriptor range whose startpoint is larger than its
    endpoint is well defined, the user agent swapping the two endpoints for font
@@ -2614,15 +2676,12 @@ let allowed_page_margin_names =
     "left-top";
   ]
 
-let read_page_descriptor r =
-  match read_descriptor_declaration r with
-  | Some desc
-    when List.mem (Declaration.property_name desc) allowed_page_descriptors ->
-      desc
-  | Some desc ->
-      Cursor.err_invalid r
-        ("invalid @page descriptor: " ^ Declaration.property_name desc)
-  | None -> Cursor.err_expected r "@page descriptor"
+let replace_page_descriptor r desc acc =
+  if List.mem (Declaration.property_name desc) allowed_page_descriptors then
+    replace_descriptor desc acc
+  else
+    Cursor.err_invalid r
+      ("invalid @page descriptor: " ^ Declaration.property_name desc)
 
 let allowed_page_margin_descriptors = "content" :: allowed_page_descriptors
 
@@ -2654,22 +2713,20 @@ let read_page_margin_rule r =
       Cursor.err_invalid r ("unknown page margin rule: @" ^ name)
   | _ -> Cursor.err_expected r "page margin rule"
 
-let read_page_body inner =
-  let rec loop descriptors margins =
-    Cursor.ws inner;
-    match Cursor.peek inner with
-    | None -> (List.rev descriptors, List.rev margins)
-    | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-        Cursor.skip inner;
-        loop descriptors margins
-    | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-        let margin = read_page_margin_rule inner in
-        loop descriptors (margin :: margins)
-    | Some _ ->
-        let desc = read_page_descriptor inner in
-        loop (replace_descriptor desc descriptors) margins
-  in
-  loop [] []
+(* CSS Paged Media 3 sec. 2: a [@page] body holds page properties and margin
+   at-rules, so its items end two different ways and are read apart. *)
+let read_page_step inner (descriptors, margins) =
+  match Cursor.peek inner with
+  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
+      `More (descriptors, read_page_margin_rule inner :: margins)
+  | _ -> (
+      match read_descriptor_item inner with
+      | `Done -> `Done (List.rev descriptors, List.rev margins)
+      | `Skip -> `More (descriptors, margins)
+      | `Descriptor desc ->
+          `More (replace_page_descriptor inner desc descriptors, margins))
+
+let read_page_body inner = read_items_with_recovery read_page_step inner ([], [])
 
 let read_page (r : Cursor.t) : statement =
   Cursor.with_context r "@page" @@ fun () ->
@@ -3252,23 +3309,6 @@ let validate_nested_rule_selector inner selector nested_selector =
   then
     Cursor.err_invalid inner
       "bare nesting selector cannot directly nest another bare nesting selector"
-
-let rec skip_bad_rule_item inner =
-  match Cursor.next_raw inner with
-  | None -> ()
-  | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
-  | Some _ -> skip_bad_rule_item inner
-
-(* CSS Syntax 3 sec. 5.4.2: an at-rule ends at its block or at its [;].
-   Discarding an invalid one consumes exactly that far, so the declarations
-   written after it stay in the rule. *)
-let rec skip_at_rule r =
-  match Cursor.next_raw r with
-  | None -> ()
-  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
-  | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-      ()
-  | Some _ -> skip_at_rule r
 
 (* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be
    nested inside of a style rule as well, unless otherwise specified". A

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3374,6 +3374,12 @@ let seal_declaration_run = function
   | Declarations run :: rest -> Declarations (List.rev run) :: rest
   | nested -> nested
 
+(* Add one declaration to the run being read, which is the head of the
+   accumulator and holds its declarations reversed until it is sealed. *)
+let add_to_declaration_run decl = function
+  | Declarations run :: rest -> Declarations (decl :: run) :: rest
+  | nested -> Declarations [ decl ] :: nested
+
 let read_starting_style ~body (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "starting-style" r;
   Cursor.ws r;
@@ -3630,10 +3636,26 @@ and read_layer (r : Cursor.t) : statement =
 and read_nesting_block (r : Cursor.t) : block =
   let rec read_items acc =
     Cursor.ws r;
+    if Cursor.recover r then read_recovering_item acc
+    else add_item acc (read_nesting_item ~prev:acc r)
+  (* CSS Syntax 3 sec. 5.4.4: a declaration that fails to parse is dropped and
+     reading resumes past the next top-level [;], a [{}] met on the way counting
+     as one component value of the value being skipped. A nested at-rule's body
+     is <block-contents> like a style rule's, so it recovers the same way and
+     one bad declaration takes neither the group rule holding it nor the rest of
+     the sheet. Strict mode ([not (Cursor.recover r)]) still raises. *)
+  and read_recovering_item acc =
     match read_nesting_item ~prev:acc r with
-    | `Done -> List.rev acc
+    | item -> add_item acc item
+    | exception Error.Parse_error e ->
+        Cursor.push_warning r e;
+        skip_bad_rule_item r;
+        read_items acc
+  and add_item acc = function
+    | `Done -> List.rev (seal_declaration_run acc)
     | `Skip -> read_items acc
-    | `Stmt stmt -> read_items (stmt :: acc)
+    | `Decl decl -> read_items (add_to_declaration_run decl acc)
+    | `Stmt stmt -> read_items (stmt :: seal_declaration_run acc)
   in
   read_items []
 
@@ -3650,30 +3672,21 @@ and read_nesting_item ~prev r =
   | _ -> read_nesting_declaration_or_statement r
 
 and read_nesting_declaration_or_statement r =
+  let start = Cursor.save r in
   match Declaration.read_declaration r with
   | Some decl ->
       Cursor.ws r;
-      `Stmt (Declarations (read_more_nested_decls r [ decl ]))
+      if Cursor.peek_semicolon r then Cursor.skip r;
+      `Decl decl
   | None -> `Stmt (read_statement r)
-
-and read_more_nested_decls r acc =
-  match Cursor.peek r with
-  | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-      Cursor.skip r;
-      Cursor.ws r;
-      read_nested_decl_after_semicolon r acc
-  | _ -> List.rev acc
-
-and read_nested_decl_after_semicolon r acc =
-  match Cursor.peek r with
-  | None | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      List.rev acc
-  | _ -> (
-      match Declaration.read_declaration r with
-      | Some d ->
-          Cursor.ws r;
-          read_more_nested_decls r (d :: acc)
-      | None -> List.rev acc)
+  (* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so
+     [h2:where(...) { ... }] reads as a declaration up to the [{]. Rewind and
+     take it as a rule; a genuine bad declaration has no block and still reports
+     as one. *)
+  | exception Error.Parse_error _
+    when Cursor.restore r start;
+         item_opens_block r ->
+      `Stmt (read_statement r)
 
 (* Helper: Read nested at-rule with declarations content *)
 and read_nested_at_rule (r : Cursor.t) (at_rule : string) : statement =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1923,7 +1923,7 @@ let skip_invalid_item r =
    accumulator before the next is read, so an item dropped in recovery costs
    only itself and the items around it are kept. CSS Syntax 3 sec. 5.4.3 keeps
    what a block's contents already yielded when one item fails to parse, and CSS
-   Paged Media 3 sec. 6 says as much of a page or a margin context in so many
+   Paged Media 3 sec. 4.1 says as much of a page or a margin context in so many
    words: "valid declarations within the block are applied". Strict mode ([not
    (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly what the
    lenient parse warns about. [skip] discards the item that failed, and which

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2034,8 +2034,11 @@ let skip_invalid_item r =
    Paged Media 3 sec. 6 says as much of a page or a margin context in so many
    words: "valid declarations within the block are applied". Strict mode ([not
    (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly what the
-   lenient parse warns about. *)
-let read_items_with_recovery step r init =
+   lenient parse warns about. [skip] discards the item that failed, and which
+   one it is depends on the body: {!skip_invalid_item} for a body of
+   declarations, {!skip_past_rule} for a body of rules, where an item that opens
+   a block ends at that block rather than at a [;] it does not have. *)
+let read_items_with_recovery ~skip step r init =
   let rec loop state =
     if Cursor.recover r then recovering state else continue (step r state)
   and recovering state =
@@ -2045,7 +2048,7 @@ let read_items_with_recovery step r init =
     | exception Error.Parse_error e ->
         Cursor.push_warning r e;
         Cursor.restore r start;
-        skip_invalid_item r;
+        skip r;
         loop state
   and continue = function
     | `Done result -> result
@@ -2095,7 +2098,9 @@ let read_descriptor_step normalize inner acc =
   | `Descriptor desc -> `More (normalize desc acc)
 
 let read_descriptor_block normalize inner =
-  read_items_with_recovery (read_descriptor_step normalize) inner []
+  read_items_with_recovery ~skip:skip_invalid_item
+    (read_descriptor_step normalize)
+    inner []
 
 (* CSS Fonts 4 sec. 4.4: a descriptor range whose startpoint is larger than its
    endpoint is well defined, the user agent swapping the two endpoints for font
@@ -2467,33 +2472,34 @@ let read_counter_string_descriptor constructor r =
       value)
     constructor r
 
-let read_counter_style_descriptor (r : Cursor.t) :
-    counter_style_descriptor option =
+(* CSS Counter Styles 3 sec. 3: "unknown descriptors are invalid and ignored".
+   One descriptor of the body, the caller looping over the rest, so a descriptor
+   that fails leaves the ones already read untouched. The declaration is the
+   whole of the descriptor's value: an [!important] flag, which no descriptor
+   takes, invalidates the declaration it follows rather than being left over as
+   an item of its own, as it is in Blink 146. *)
+let read_counter_style_descriptor (r : Cursor.t) : counter_style_descriptor =
+  let name = Cursor.ident ~keep_case:false r |> String.lowercase_ascii in
+  let descriptor =
+    match name with
+    | "system" -> read_counter_style_system_descriptor r
+    | "symbols" -> read_counter_symbols_descriptor r
+    | "suffix" -> read_counter_symbol_descriptor (fun s -> Suffix s) r
+    | "prefix" -> read_counter_symbol_descriptor (fun s -> Prefix s) r
+    | "fallback" -> read_counter_string_descriptor (fun s -> Fallback s) r
+    | "range" -> read_counter_string_descriptor (fun s -> Range s) r
+    | "pad" -> read_counter_string_descriptor (fun s -> Pad s) r
+    | "negative" -> read_counter_string_descriptor (fun s -> Negative s) r
+    | "additive-symbols" ->
+        read_counter_string_descriptor (fun s -> Additive_symbols s) r
+    | "speak-as" -> read_counter_string_descriptor (fun s -> Speak_as s) r
+    | _ -> Cursor.err_invalid r ("unknown counter-style descriptor: " ^ name)
+  in
   Cursor.ws r;
-  if Cursor.is_done r then None
-  else if Cursor.peek_semicolon r then (
-    Cursor.skip r;
-    None)
-  else
-    let name = Cursor.ident ~keep_case:false r |> String.lowercase_ascii in
-    let descriptor =
-      match name with
-      | "system" -> read_counter_style_system_descriptor r
-      | "symbols" -> read_counter_symbols_descriptor r
-      | "suffix" -> read_counter_symbol_descriptor (fun s -> Suffix s) r
-      | "prefix" -> read_counter_symbol_descriptor (fun s -> Prefix s) r
-      | "fallback" -> read_counter_string_descriptor (fun s -> Fallback s) r
-      | "range" -> read_counter_string_descriptor (fun s -> Range s) r
-      | "pad" -> read_counter_string_descriptor (fun s -> Pad s) r
-      | "negative" -> read_counter_string_descriptor (fun s -> Negative s) r
-      | "additive-symbols" ->
-          read_counter_string_descriptor (fun s -> Additive_symbols s) r
-      | "speak-as" -> read_counter_string_descriptor (fun s -> Speak_as s) r
-      | _ -> Cursor.err_invalid r ("unknown counter-style descriptor: " ^ name)
-    in
-    Cursor.ws r;
-    if Cursor.peek_semicolon r then Cursor.skip r;
-    Some descriptor
+  if not (Cursor.is_done r || Cursor.peek_semicolon r) then
+    Cursor.err_invalid r ("trailing tokens after @counter-style " ^ name);
+  if Cursor.peek_semicolon r then Cursor.skip r;
+  descriptor
 
 let counter_style_descriptor_rank = function
   | System _ -> 0
@@ -2515,19 +2521,24 @@ let replace_counter_style_descriptor desc acc =
          <> counter_style_descriptor_rank desc)
        acc
 
-let continue_descriptor_loop inner acc loop =
+(* One item of a descriptor body: a descriptor, a stray [;] that CSS Syntax 3
+   sec. 5.4.3 discards with no declaration to validate, or the end of the
+   body. *)
+let read_descriptor_body_step read_one replace inner acc =
   Cursor.ws inner;
-  if Cursor.is_done inner then List.rev acc else loop acc
+  if Cursor.is_done inner then `Done (List.rev acc)
+  else if Cursor.peek_semicolon inner then (
+    Cursor.skip inner;
+    `More acc)
+  else `More (replace (read_one inner) acc)
 
 let read_counter_style_descriptors r =
   Cursor.braces
     (fun inner ->
-      let rec loop acc =
-        match read_counter_style_descriptor inner with
-        | Some desc -> loop (replace_counter_style_descriptor desc acc)
-        | None -> continue_descriptor_loop inner acc loop
-      in
-      loop [])
+      read_items_with_recovery ~skip:skip_invalid_item
+        (read_descriptor_body_step read_counter_style_descriptor
+           replace_counter_style_descriptor)
+        inner [])
     r
 
 let counter_style_system descriptors =
@@ -2703,7 +2714,8 @@ let read_page_step inner (descriptors, margins) =
       | `Descriptor desc -> `More (replace_descriptor desc descriptors, margins)
       )
 
-let read_page_body inner = read_items_with_recovery read_page_step inner ([], [])
+let read_page_body inner =
+  read_items_with_recovery ~skip:skip_invalid_item read_page_step inner ([], [])
 
 let read_page (r : Cursor.t) : statement =
   Cursor.with_context r "@page" @@ fun () ->
@@ -2755,44 +2767,45 @@ let read_override_color_entry c =
   Cursor.ws c;
   (Float.to_int index, color)
 
-let read_font_palette_descriptor outer inner : font_palette_descriptor option =
+(* CSS Fonts 4 sec. 12.1 gives each [@font-palette-values] descriptor a grammar
+   of its own, and the declaration is the whole of it: a trailing [!important]
+   or a stray ident makes the declaration invalid rather than the leftover
+   alone, as it does in Blink 146. *)
+let read_font_palette_descriptor outer inner : font_palette_descriptor =
+  let desc_name = Cursor.ident ~keep_case:false inner in
   Cursor.ws inner;
-  if Cursor.is_done inner then None
-  else if Cursor.peek_semicolon inner then (
-    Cursor.skip inner;
-    None)
-  else
-    let desc_name = Cursor.ident ~keep_case:false inner in
-    Cursor.ws inner;
-    if not (Cursor.colon inner) then Cursor.err_expected inner "':'";
-    Cursor.ws inner;
-    let desc =
-      match desc_name with
-      | "font-family" ->
-          Palette_font_family
-            (Cursor.list ~sep:Cursor.comma Properties.read_font_family inner)
-      | "base-palette" -> Base_palette (read_base_palette_value inner)
-      | "override-colors" ->
-          Override_colors
-            (Cursor.list ~sep:Cursor.comma ~at_least:1 read_override_color_entry
-               inner)
-      | name ->
-          Cursor.err_invalid outer
-            ("unknown font-palette-values descriptor: " ^ name)
-    in
-    Cursor.ws inner;
-    if Cursor.peek_semicolon inner then Cursor.skip inner;
-    Some desc
+  if not (Cursor.colon inner) then Cursor.err_expected inner "':'";
+  Cursor.ws inner;
+  let desc =
+    match desc_name with
+    | "font-family" ->
+        Palette_font_family
+          (Cursor.list ~sep:Cursor.comma Properties.read_font_family inner)
+    | "base-palette" -> Base_palette (read_base_palette_value inner)
+    | "override-colors" ->
+        Override_colors
+          (Cursor.list ~sep:Cursor.comma ~at_least:1 read_override_color_entry
+             inner)
+    | name ->
+        Cursor.err_invalid outer
+          ("unknown font-palette-values descriptor: " ^ name)
+  in
+  Cursor.ws inner;
+  if not (Cursor.is_done inner || Cursor.peek_semicolon inner) then
+    Cursor.err_invalid outer
+      ("trailing tokens after @font-palette-values " ^ desc_name);
+  if Cursor.peek_semicolon inner then Cursor.skip inner;
+  desc
 
 let read_font_palette_descriptors outer =
-  let rec loop inner acc =
-    match read_font_palette_descriptor outer inner with
-    | Some desc -> loop inner (replace_font_palette_descriptor desc acc)
-    | None ->
-        Cursor.ws inner;
-        if Cursor.is_done inner then List.rev acc else loop inner acc
-  in
-  Cursor.braces (fun inner -> loop inner []) outer
+  Cursor.braces
+    (fun inner ->
+      read_items_with_recovery ~skip:skip_invalid_item
+        (read_descriptor_body_step
+           (read_font_palette_descriptor outer)
+           replace_font_palette_descriptor)
+        inner [])
+    outer
 
 let font_palette_descriptor_rank = function
   | Palette_font_family _ -> 0
@@ -2863,7 +2876,6 @@ let read_font_feature_values_entries outer =
   Cursor.braces (fun inner -> loop inner []) outer
 
 let read_font_feature_values_block outer inner =
-  Cursor.ws inner;
   match Cursor.at_keyword_opt inner with
   | None -> Cursor.err_expected inner "@font-feature-values nested at-rule"
   | Some name ->
@@ -2872,13 +2884,26 @@ let read_font_feature_values_block outer inner =
         Cursor.err_invalid outer ("unknown @font-feature-values block: @" ^ name);
       (name, read_font_feature_values_entries inner)
 
+(* CSS Fonts 4 sec. 11.1 fills the body with feature value blocks, so it is a
+   list of rules rather than of declarations: a block the body rejects ends at
+   its own [{}] or at a [;] (CSS Syntax 3 sec. 5.4.2), which leaves the blocks
+   written around it in the rule. A [;] with nothing before it has no
+   declaration to validate and is discarded (sec. 5.4.3). *)
+let read_font_feature_values_step outer inner acc =
+  Cursor.ws inner;
+  if Cursor.is_done inner then `Done (List.rev acc)
+  else if Cursor.peek_semicolon inner then (
+    Cursor.skip inner;
+    `More acc)
+  else `More (read_font_feature_values_block outer inner :: acc)
+
 let read_font_feature_values_blocks outer =
-  let rec loop inner acc =
-    Cursor.ws inner;
-    if Cursor.is_done inner then List.rev acc
-    else loop inner (read_font_feature_values_block outer inner :: acc)
-  in
-  Cursor.braces (fun inner -> loop inner []) outer
+  Cursor.braces
+    (fun inner ->
+      read_items_with_recovery ~skip:skip_past_rule
+        (read_font_feature_values_step outer)
+        inner [])
+    outer
 
 let read_font_feature_values (r : Cursor.t) : statement =
   Cursor.with_context r "@font-feature-values" @@ fun () ->
@@ -2929,39 +2954,35 @@ let read_view_transition_types inner =
       in
       Types (Some (names [ first ]))
 
-let read_view_transition_descriptor outer inner :
-    view_transition_descriptor option =
+(* CSS View Transitions 2 sec. 2.4 gives each [@view-transition] descriptor a
+   grammar of its own, and the declaration is the whole of it. *)
+let read_view_transition_descriptor outer inner : view_transition_descriptor =
+  let desc_name = Cursor.ident ~keep_case:false inner in
   Cursor.ws inner;
-  if Cursor.is_done inner then None
-  else if Cursor.peek_semicolon inner then (
-    Cursor.skip inner;
-    None)
-  else
-    let desc_name = Cursor.ident ~keep_case:false inner in
-    Cursor.ws inner;
-    if not (Cursor.colon inner) then Cursor.err_expected inner "':'";
-    Cursor.ws inner;
-    let desc =
-      match desc_name with
-      | "navigation" -> read_view_transition_navigation inner
-      | "types" -> read_view_transition_types inner
-      | name ->
-          Cursor.err_invalid outer
-            ("unknown @view-transition descriptor: " ^ name)
-    in
-    Cursor.ws inner;
-    if Cursor.peek_semicolon inner then Cursor.skip inner;
-    Some desc
+  if not (Cursor.colon inner) then Cursor.err_expected inner "':'";
+  Cursor.ws inner;
+  let desc =
+    match desc_name with
+    | "navigation" -> read_view_transition_navigation inner
+    | "types" -> read_view_transition_types inner
+    | name ->
+        Cursor.err_invalid outer ("unknown @view-transition descriptor: " ^ name)
+  in
+  Cursor.ws inner;
+  if not (Cursor.is_done inner || Cursor.peek_semicolon inner) then
+    Cursor.err_invalid outer
+      ("trailing tokens after @view-transition " ^ desc_name);
+  if Cursor.peek_semicolon inner then Cursor.skip inner;
+  desc
 
 let read_view_transition_descriptors outer =
   Cursor.braces
     (fun inner ->
-      let rec loop acc =
-        match read_view_transition_descriptor outer inner with
-        | Some desc -> loop (replace_view_transition_descriptor desc acc)
-        | None -> continue_descriptor_loop inner acc loop
-      in
-      loop [])
+      read_items_with_recovery ~skip:skip_invalid_item
+        (read_descriptor_body_step
+           (read_view_transition_descriptor outer)
+           replace_view_transition_descriptor)
+        inner [])
     outer
 
 let read_view_transition (r : Cursor.t) : statement =
@@ -3329,7 +3350,7 @@ let read_property_step r state =
   else `More (read_property_descriptor r state)
 
 let read_property_descriptors (r : Cursor.t) : property_reader_state =
-  read_items_with_recovery read_property_step r
+  read_items_with_recovery ~skip:skip_invalid_item read_property_step r
     { syntax = None; inherits = None; initial_value = None }
 
 let read_property_rule (r : Cursor.t) : statement =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3259,6 +3259,31 @@ let rec skip_bad_rule_item inner =
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
   | Some _ -> skip_bad_rule_item inner
 
+(* CSS Syntax 3 sec. 5.4.2: an at-rule ends at its block or at its [;].
+   Discarding an invalid one consumes exactly that far, so the declarations
+   written after it stay in the rule. *)
+let rec skip_at_rule r =
+  match Cursor.next_raw r with
+  | None -> ()
+  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
+  | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
+      ()
+  | Some _ -> skip_at_rule r
+
+(* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be
+   nested inside of a style rule as well, unless otherwise specified". A
+   descriptor rule, a keyframe list and a declaration-list rule contain none, so
+   none of them nests, and Blink 146 drops each one. [\@view-transition] is a
+   descriptor rule too, yet Blink keeps it inside a style rule; dropping what a
+   shipping engine still reads is the one lossy direction, so it stays. *)
+let nests_in_style_rule = function
+  | "keyframes" | "-webkit-keyframes" | "-moz-keyframes" | "font-face"
+  | "counter-style" | "page" | "font-palette-values" | "font-feature-values"
+  | "position-try" | "viewport" | "-ms-viewport" | "property"
+  | "supports-condition" ->
+      false
+  | _ -> true
+
 let read_property_descriptors (r : Cursor.t) : property_reader_state =
   let state = ref { syntax = None; inherits = None; initial_value = None } in
   let rec loop () =
@@ -3331,6 +3356,14 @@ let item_opens_block inner =
   let found = scan () in
   Cursor.restore inner start;
   found
+
+(* Discard an at-rule that is invalid in a style rule and resume at the next
+   item, the recovery CSS Syntax 3 sec. 5.4.4 describes. The warning is what
+   [~strict:true] turns into an error. *)
+let drop_nested_at_rule r ~loc reason : statement option =
+  skip_at_rule r;
+  Cursor.push_warning r (Error.bad_value loc ~property:"rule" ~reason);
+  None
 
 (* CSS Nesting 1 sec. 3.4 wraps a run of declarations written after a nested
    statement in a nested declarations rule, so it keeps its place among them.
@@ -3597,18 +3630,20 @@ and read_layer (r : Cursor.t) : statement =
 and read_nesting_block (r : Cursor.t) : block =
   let rec read_items acc =
     Cursor.ws r;
-    match read_nesting_item r with
+    match read_nesting_item ~prev:acc r with
     | `Done -> List.rev acc
     | `Skip -> read_items acc
     | `Stmt stmt -> read_items (stmt :: acc)
   in
   read_items []
 
-and read_nesting_item r =
+and read_nesting_item ~prev r =
   match Cursor.peek r with
   | None -> `Done
-  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      `Stmt (read_nested_at_within_rule r)
+  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) -> (
+      match read_nested_at_within_rule ~prev r with
+      | Some stmt -> `Stmt stmt
+      | None -> `Skip)
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       Cursor.skip r;
       `Skip
@@ -3695,11 +3730,11 @@ and read_nested_layer_rule r =
       Cursor.ws r;
       Layer (Some name, Cursor.braces (fun inner -> read_nesting_block inner) r)
 
-and read_nested_at_within_rule (r : Cursor.t) : statement =
+and read_nested_at_within_rule ~prev (r : Cursor.t) : statement option =
   match Cursor.peek r with
-  | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
-      read_nested_at_keyword r name
-  | _ -> read_statement r
+  | Some (Component.Preserved { kind = Token.At_keyword name; loc; _ }) ->
+      read_nested_at_keyword r ~loc ~prev name
+  | _ -> Some (read_statement r)
 
 (* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be
    nested inside of a style rule as well", which is every group rule cascade
@@ -3707,27 +3742,34 @@ and read_nested_at_within_rule (r : Cursor.t) : statement =
    @else that generalise them (CSS Conditional 5 sec. 3, sec. 4),
    @-moz-document, @layer, @scope, and @starting-style (CSS Transitions 2 sec.
    3.3). Nested, the body is <block-contents>, so a bare declaration run in it
-   belongs to the parent selector. Everything else keeps its stylesheet-level
-   reading: a descriptor rule such as @font-face carries no style rule, and a
-   top-of-sheet rule is invalid here outright. *)
-and read_nested_at_keyword r = function
+   belongs to the parent selector. An at-rule with no style rule in its body is
+   invalid here and dropped; a top-of-sheet rule is invalid here outright. *)
+and read_nested_at_keyword r ~loc ~prev = function
   | ("supports" | "media" | "container" | "scope") as name ->
-      read_nested_at_rule r ("@" ^ name)
-  | "layer" -> read_nested_layer_rule r
-  | "starting-style" -> read_starting_style ~body:read_nesting_block r
-  | "-moz-document" -> read_moz_document ~body:read_nesting_block r
-  | "when" -> read_when ~body:read_nesting_block r
-  | "else" -> read_else ~body:read_nesting_block r
+      Some (read_nested_at_rule r ("@" ^ name))
+  | "layer" -> Some (read_nested_layer_rule r)
+  | "starting-style" -> Some (read_starting_style ~body:read_nesting_block r)
+  | "-moz-document" -> Some (read_moz_document ~body:read_nesting_block r)
+  | "when" -> Some (read_when ~body:read_nesting_block r)
+  | "else" when List.exists follows_conditional prev ->
+      Some (read_else ~body:read_nesting_block r)
+  | "else" -> drop_nested_at_rule r ~loc "@else without preceding @when"
   | ("charset" | "import" | "namespace") as name ->
       Cursor.err_invalid r ("Unexpected nested at-rule: @" ^ name)
-  | _ -> read_statement r
+  | name when not (nests_in_style_rule name) ->
+      drop_nested_at_rule r ~loc
+        ("@" ^ name ^ " has no style rule in it, so it does not nest")
+  | _ -> Some (read_statement r)
 
 and read_rule_item selector inner decls nested =
   match Cursor.peek inner with
   | None -> `Done (List.rev decls, List.rev (seal_declaration_run nested))
-  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      let stmt = read_nested_at_within_rule inner in
-      `Continue (decls, stmt :: seal_declaration_run nested)
+  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) -> (
+      match read_nested_at_within_rule ~prev:nested inner with
+      | Some stmt -> `Continue (decls, stmt :: seal_declaration_run nested)
+      (* A dropped at-rule leaves no gap: the declaration run written around it
+         is one run, as it is in Blink. *)
+      | None -> `Continue (decls, nested))
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       Cursor.skip inner;
       `Continue (decls, nested)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1893,48 +1893,89 @@ let read_namespace (r : Cursor.t) : statement =
   if Cursor.peek_semicolon r then Cursor.skip r;
   Namespace (prefix, uri)
 
-let rec skip_bad_keyframe inner =
-  match Cursor.peek_raw inner with
+(* Discard the rule the cursor sits on, stopping at its [{}] block or at a
+   top-level [;]: CSS Syntax 3 sec. 5.4.2 ends an at-rule at whichever comes
+   first, and sec. 5.4.3 ends a qualified rule at its block. Consuming exactly
+   that far leaves what was written after the rule - the declarations around it,
+   or the next rule - to be read on its own. A [(] or a [[] met before the block
+   is a component value of the prelude being discarded, so stopping there would
+   offer the tail of that prelude as a rule of its own. *)
+let rec skip_past_rule r =
+  match Cursor.next_raw r with
   | None -> ()
+  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-      ignore (Cursor.next_raw inner : Component.t option)
-  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ }) ->
-      ignore (Cursor.next_raw inner : Component.t option)
-  | Some _ ->
-      ignore (Cursor.next_raw inner : Component.t option);
-      skip_bad_keyframe inner
+      ()
+  | Some _ -> skip_past_rule r
 
+(* Discard the item the cursor sits on. A body that holds declarations and
+   at-rules alike has to pick by what the item starts with: the two ends differ,
+   and taking an at-rule for a declaration would eat the item written after it.
+   The caller rewinds first, so a reader that already consumed part of the item
+   is skipped from its start. *)
+let skip_invalid_item r =
+  match Cursor.peek r with
+  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
+      skip_past_rule r
+  | _ -> Cursor.skip_past_semicolon r
+
+(* Read a body one item at a time, [step] committing each item to the
+   accumulator before the next is read, so an item dropped in recovery costs
+   only itself and the items around it are kept. CSS Syntax 3 sec. 5.4.3 keeps
+   what a block's contents already yielded when one item fails to parse, and CSS
+   Paged Media 3 sec. 6 says as much of a page or a margin context in so many
+   words: "valid declarations within the block are applied". Strict mode ([not
+   (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly what the
+   lenient parse warns about. [skip] discards the item that failed, and which
+   one it is depends on the body: {!skip_invalid_item} for a body of
+   declarations, {!skip_past_rule} for a body of rules, where an item that opens
+   a block ends at that block rather than at a [;] it does not have. *)
+let read_items_with_recovery ~skip step r init =
+  let rec loop state =
+    if Cursor.recover r then recovering state else continue (step r state)
+  and recovering state =
+    let start = Cursor.save r in
+    match step r state with
+    | committed -> continue committed
+    | exception Error.Parse_error e ->
+        Cursor.push_warning r e;
+        Cursor.restore r start;
+        skip r;
+        loop state
+  and continue = function
+    | `Done result -> result
+    | `More state -> loop state
+  in
+  loop init
+
+(* A selector that is no keyframe selector - the [to] of [entry to], which is no
+   [<length-percentage>] - drops its rule and the block keeps parsing. *)
 let read_keyframe_or_skip inner acc =
   let snap = Cursor.save inner in
   match read_keyframe inner with
-  | frame -> `Frame frame
+  | frame -> frame :: acc
   | exception Cursor.Parse_error e ->
-      (* Invalid keyframe rules are ignored, but the surrounding block keeps
-         parsing. *)
       Cursor.restore inner snap;
       Cursor.push_warning inner e;
-      skip_bad_keyframe inner;
-      `Skip acc
+      skip_past_rule inner;
+      acc
 
+(* One item of the body: a keyframe rule, or the end of it. CSS Animations 1
+   sec. 3 fills a [@keyframes] body with keyframe rules, so an at-rule has no
+   place there; rejecting it here rather than around the loop leaves the
+   rejection inside the recovery the loop runs, which costs the at-rule alone
+   instead of the animation and the sheet holding it. *)
 let read_keyframes_step inner acc =
-  match Cursor.peek inner with
-  | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
-      Cursor.err_invalid inner ("@keyframes nested @" ^ name)
-  | _ -> (
-      match read_keyframe_or_skip inner acc with
-      | `Frame frame -> frame :: acc
-      | `Skip acc -> acc)
+  Cursor.ws inner;
+  if Cursor.is_done inner then `Done (List.rev acc)
+  else
+    match Cursor.peek inner with
+    | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
+        Cursor.err_invalid inner ("@keyframes nested @" ^ name)
+    | _ -> `More (read_keyframe_or_skip inner acc)
 
 let read_keyframes_block inner =
-  (* CSS Syntax 5.4.4: a [@keyframes] block lists keyframe rules; an invalid
-     selector (e.g. [entry to] - [to] is not a [<length-percentage>]) only drops
-     that rule, the surrounding block keeps parsing. *)
-  let rec read_frames acc =
-    Cursor.ws inner;
-    if Cursor.is_done inner then List.rev acc
-    else read_frames (read_keyframes_step inner acc)
-  in
-  read_frames []
+  read_items_with_recovery ~skip:skip_past_rule read_keyframes_step inner []
 
 (* CSS Animations 1 sec. 3: [@keyframes <keyframes-name>], [<keyframes-name> =
    <custom-ident> | <string>]. The reserved spellings ([none], CSS-wide
@@ -2000,61 +2041,6 @@ let read_descriptor_value read_fn constructor r =
     let value = read_fn r in
     constructor value
   with Failure msg -> Cursor.err_invalid r msg
-
-(* Discard the rule the cursor sits on, stopping at its [{}] block or at a
-   top-level [;]: CSS Syntax 3 sec. 5.4.2 ends an at-rule at whichever comes
-   first, and sec. 5.4.3 ends a qualified rule at its block. Consuming exactly
-   that far leaves what was written after the rule - the declarations around it,
-   or the next rule - to be read on its own. A [(] or a [[] met before the block
-   is a component value of the prelude being discarded, so stopping there would
-   offer the tail of that prelude as a rule of its own. *)
-let rec skip_past_rule r =
-  match Cursor.next_raw r with
-  | None -> ()
-  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
-  | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-      ()
-  | Some _ -> skip_past_rule r
-
-(* Discard the item the cursor sits on. A body that holds declarations and
-   at-rules alike has to pick by what the item starts with: the two ends differ,
-   and taking an at-rule for a declaration would eat the item written after it.
-   The caller rewinds first, so a reader that already consumed part of the item
-   is skipped from its start. *)
-let skip_invalid_item r =
-  match Cursor.peek r with
-  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      skip_past_rule r
-  | _ -> Cursor.skip_past_semicolon r
-
-(* Read a body one item at a time, [step] committing each item to the
-   accumulator before the next is read, so an item dropped in recovery costs
-   only itself and the items around it are kept. CSS Syntax 3 sec. 5.4.3 keeps
-   what a block's contents already yielded when one item fails to parse, and CSS
-   Paged Media 3 sec. 6 says as much of a page or a margin context in so many
-   words: "valid declarations within the block are applied". Strict mode ([not
-   (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly what the
-   lenient parse warns about. [skip] discards the item that failed, and which
-   one it is depends on the body: {!skip_invalid_item} for a body of
-   declarations, {!skip_past_rule} for a body of rules, where an item that opens
-   a block ends at that block rather than at a [;] it does not have. *)
-let read_items_with_recovery ~skip step r init =
-  let rec loop state =
-    if Cursor.recover r then recovering state else continue (step r state)
-  and recovering state =
-    let start = Cursor.save r in
-    match step r state with
-    | committed -> continue committed
-    | exception Error.Parse_error e ->
-        Cursor.push_warning r e;
-        Cursor.restore r start;
-        skip r;
-        loop state
-  and continue = function
-    | `Done result -> result
-    | `More state -> loop state
-  in
-  loop init
 
 (* One item of a descriptor body: a descriptor, a stray [;] that CSS Syntax 3
    sec. 5.4.3 discards with no declaration to validate, or the end of the body.

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2001,15 +2001,6 @@ let read_descriptor_value read_fn constructor r =
     constructor value
   with Failure msg -> Cursor.err_invalid r msg
 
-(* CSS Syntax 3 sec. 5.4.4: a declaration that fails to parse ends at the next
-   top-level [;]; a [{}] met on the way is one component value of the value
-   being skipped, not a stopping point. *)
-let rec skip_bad_rule_item inner =
-  match Cursor.next_raw inner with
-  | None -> ()
-  | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
-  | Some _ -> skip_bad_rule_item inner
-
 (* CSS Syntax 3 sec. 5.4.2: an at-rule ends at its block or at its [;].
    Discarding an invalid one consumes exactly that far, so the declarations
    written after it stay in the rule. *)
@@ -2030,7 +2021,7 @@ let skip_invalid_item r =
   match Cursor.peek r with
   | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
       skip_at_rule r
-  | _ -> skip_bad_rule_item r
+  | _ -> Cursor.skip_past_semicolon r
 
 (* Read a body one item at a time, [step] committing each item to the
    accumulator before the next is read, so an item dropped in recovery costs
@@ -2376,13 +2367,7 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
            or an invalid value of a known one ([font-display:maybe]) - is
            dropped and the rest of the @font-face is kept, matching browsers. *)
         Cursor.push_warning r e;
-        let rec skip_to_semicolon () =
-          match Cursor.next_raw r with
-          | None | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-              ()
-          | Some _ -> skip_to_semicolon ()
-        in
-        skip_to_semicolon ();
+        Cursor.skip_past_semicolon r;
         None
 
 let read_font_face_block inner =
@@ -2872,14 +2857,6 @@ let read_font_feature_value_entry outer inner : (string * int list) option =
 let replace_font_feature_value ((name, _) as entry) acc =
   entry :: List.filter (fun (existing, _) -> existing <> name) acc
 
-let skip_semicolon_tail inner =
-  let rec loop () =
-    match Cursor.next_raw inner with
-    | None | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
-    | Some _ -> loop ()
-  in
-  loop ()
-
 let read_font_feature_values_entries outer =
   let rec loop inner acc =
     match read_font_feature_value_entry outer inner with
@@ -2889,7 +2866,7 @@ let read_font_feature_values_entries outer =
         if Cursor.is_done inner then List.rev acc else loop inner acc
     | exception Error.Parse_error e ->
         Cursor.push_warning inner e;
-        skip_semicolon_tail inner;
+        Cursor.skip_past_semicolon inner;
         loop inner acc
   in
   Cursor.braces (fun inner -> loop inner []) outer
@@ -3702,7 +3679,7 @@ and read_nesting_block (r : Cursor.t) : block =
     | item -> add_item acc item
     | exception Error.Parse_error e ->
         Cursor.push_warning r e;
-        skip_bad_rule_item r;
+        Cursor.skip_past_semicolon r;
         read_items acc
   and add_item acc = function
     | `Done -> List.rev (seal_declaration_run acc)
@@ -3891,7 +3868,7 @@ and read_recovering_rule_item selector inner loop decls nested =
   | `Continue (decls, nested) -> loop decls nested
   | exception Error.Parse_error e ->
       Cursor.push_warning inner e;
-      skip_bad_rule_item inner;
+      Cursor.skip_past_semicolon inner;
       loop decls nested
 
 and read_rule ?(nested = false) (r : Cursor.t) : rule =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2636,20 +2636,6 @@ let parse_page_selectors r selector =
   in
   consume_selectors [] 0
 
-let page_descriptor_order =
-  [
-    "size";
-    "margin";
-    "margin-left";
-    "margin-right";
-    "margin-top";
-    "margin-bottom";
-    "bleeds";
-    "marks";
-  ]
-
-let allowed_page_descriptors = page_descriptor_order
-
 let allowed_page_margin_names =
   [
     "top-left";
@@ -2666,35 +2652,22 @@ let allowed_page_margin_names =
     "left-top";
   ]
 
-let replace_page_descriptor r desc acc =
-  if List.mem (Declaration.property_name desc) allowed_page_descriptors then
-    replace_descriptor desc acc
-  else
-    Cursor.err_invalid r
-      ("invalid @page descriptor: " ^ Declaration.property_name desc)
-
-let allowed_page_margin_descriptors = "content" :: allowed_page_descriptors
-
-let replace_page_margin_descriptor r desc acc =
-  if List.mem (Declaration.property_name desc) allowed_page_margin_descriptors
-  then replace_descriptor desc acc
-  else
-    Cursor.err_invalid r
-      ("invalid page margin descriptor: " ^ Declaration.property_name desc)
-
+(* CSS Paged Media 3 sec. 6: Appendix A lists the CSS 2.1 properties that apply
+   in a page and in a margin context, and behaviour for a property outside CSS
+   2.1 is left undefined "to allow the gradual addition of appropriate CSS3
+   properties as they emerge" - undefined, not invalid. Blink 146 duly keeps
+   every property it knows in both contexts. A name filter here would drop text
+   browsers keep, so the page contexts take the declarations a style rule takes:
+   a value its property's grammar rejects is still rejected, and so is an item
+   that is no declaration at all. *)
 let read_page_margin_rule r =
   match Cursor.peek r with
   | Some (Component.Preserved { kind = Token.At_keyword name; _ })
     when List.mem name allowed_page_margin_names ->
       Cursor.skip r;
       Cursor.ws r;
-      (* CSS Paged Media sec. 5: a page-margin box accepts every descriptor
-         valid in [@page] plus [content]. *)
       let descriptors =
-        Cursor.braces
-          (fun inner ->
-            read_descriptor_block (replace_page_margin_descriptor inner) inner)
-          r
+        Cursor.braces (read_descriptor_block replace_descriptor) r
       in
       if descriptors = [] then
         Cursor.err_invalid r "page margin rule requires descriptors";
@@ -2713,8 +2686,8 @@ let read_page_step inner (descriptors, margins) =
       match read_descriptor_item inner with
       | `Done -> `Done (List.rev descriptors, List.rev margins)
       | `Skip -> `More (descriptors, margins)
-      | `Descriptor desc ->
-          `More (replace_page_descriptor inner desc descriptors, margins))
+      | `Descriptor desc -> `More (replace_descriptor desc descriptors, margins)
+      )
 
 let read_page_body inner = read_items_with_recovery read_page_step inner ([], [])
 
@@ -4034,16 +4007,6 @@ let validate_partial_statement loc = function
            ~reason:"forbidden keyframes name")
   | _ -> None
 
-(* @page / @font-face descriptors flow through [Declaration.read_declaration]
-   like ordinary declarations and show up as [Unknown_property "marks"] / "src".
-   The reader already enforces each at-rule's allowed-descriptor list, so an
-   [Unknown_property] in a descriptor block is by construction a known
-   descriptor - skip the [is_invalid] check that would flag it. *)
-let descriptor_has_typed_invalid_value = function
-  | Declaration.Declaration { property = Properties.Unknown_property _; _ } ->
-      false
-  | decl -> Declaration.is_invalid decl
-
 let rec statement_has_invalid_declaration = function
   | Rule { declarations; nested; _ } ->
       List.exists Declaration.is_invalid declarations
@@ -4060,15 +4023,15 @@ let rec statement_has_invalid_declaration = function
   | Origin (_, block)
   | Scope (_, _, block) ->
       List.exists statement_has_invalid_declaration block
-  | Page (_, decls) -> List.exists descriptor_has_typed_invalid_value decls
+  | Page (_, decls) -> List.exists Declaration.is_invalid decls
   | Page_with_margins (_, descs, margins) ->
-      List.exists descriptor_has_typed_invalid_value descs
+      List.exists Declaration.is_invalid descs
       || List.exists
            (fun { descriptors; _ } ->
-             List.exists descriptor_has_typed_invalid_value descriptors)
+             List.exists Declaration.is_invalid descriptors)
            margins
   | Position_try (_, decls) | Supports_condition (_, decls) ->
-      List.exists descriptor_has_typed_invalid_value decls
+      List.exists Declaration.is_invalid decls
   | _ -> false
 
 let validate_partial_invalid_declarations loc stmt =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2678,11 +2678,13 @@ let read_page_margin_rule r =
     when List.mem name allowed_page_margin_names ->
       Cursor.skip r;
       Cursor.ws r;
+      (* Sec. 5 gives the margin at-rule a [<declaration-list>], which CSS
+         Syntax 3 sec. 5.4.4 consumes even when it holds nothing, so an empty
+         box is valid and Blink 146 keeps one. That it paints nothing is
+         [Block.drop_empty_rules]'s call to make, not the reader's. *)
       let descriptors =
         Cursor.braces (read_descriptor_block replace_descriptor) r
       in
-      if descriptors = [] then
-        Cursor.err_invalid r "page margin rule requires descriptors";
       { name; descriptors }
   | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
       Cursor.err_invalid r ("unknown page margin rule: @" ^ name)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3341,6 +3341,57 @@ let seal_declaration_run = function
   | Declarations run :: rest -> Declarations (List.rev run) :: rest
   | nested -> nested
 
+let read_starting_style ~body (r : Cursor.t) : statement =
+  Cursor.expect_at_keyword "starting-style" r;
+  Cursor.ws r;
+  Starting_style (Cursor.braces body r)
+
+let read_when ~body (r : Cursor.t) : statement =
+  Cursor.expect_at_keyword "when" r;
+  Cursor.ws r;
+  let prelude = Cursor.drain_until_block r in
+  if List.for_all (fun cv -> Component.to_string cv |> String.trim = "") prelude
+  then Cursor.err_invalid r "@when: missing condition";
+  let condition : conditional =
+    try conditional_components prelude
+    with Failure msg -> Cursor.err_invalid r ("@when: " ^ msg)
+  in
+  When (condition, Cursor.braces body r)
+
+let read_else ~body (r : Cursor.t) : statement =
+  Cursor.expect_at_keyword "else" r;
+  Cursor.ws r;
+  let prelude = Cursor.drain_until_block r in
+  let condition =
+    match
+      List.filter
+        (function
+          | Component.Preserved { kind = Token.Whitespace; _ } -> false
+          | _ -> true)
+        prelude
+    with
+    | [] -> Option.None
+    | _ -> (
+        match conditional_components prelude with
+        | condition -> Some condition
+        | exception Failure msg -> Cursor.err_invalid r ("@else: " ^ msg))
+  in
+  Else (condition, Cursor.braces body r)
+
+let read_moz_document ~body (r : Cursor.t) : statement =
+  Cursor.with_context r "@-moz-document" @@ fun () ->
+  Cursor.expect_at_keyword "-moz-document" r;
+  Cursor.ws r;
+  let prelude = Cursor.drain_until_block_as_string ~trim:true r in
+  let prelude_cursor = Cursor.of_string prelude in
+  let conditions =
+    Cursor.list ~sep:Cursor.comma ~at_least:1 read_moz_document_condition
+      prelude_cursor
+  in
+  Cursor.ws prelude_cursor;
+  Cursor.expect_eof prelude_cursor;
+  Moz_document (conditions, Cursor.braces body r)
+
 let rec read_statement (r : Cursor.t) : statement =
   Cursor.ws r;
   let table : (string * (Cursor.t -> statement)) list =
@@ -3352,11 +3403,11 @@ let rec read_statement (r : Cursor.t) : statement =
       ("media", read_media);
       ("container", read_container);
       ("supports", read_supports);
-      ("-moz-document", read_moz_document);
-      ("when", read_when);
-      ("else", read_else);
+      ("-moz-document", read_moz_document ~body:read_block);
+      ("when", read_when ~body:read_block);
+      ("else", read_else ~body:read_block);
       ("supports-condition", read_supports_condition);
-      ("starting-style", read_starting_style);
+      ("starting-style", read_starting_style ~body:read_block);
       ("scope", read_scope);
       ("keyframes", read_keyframes);
       ("-webkit-keyframes", read_webkit_keyframes);
@@ -3429,46 +3480,6 @@ and read_block (r : Cursor.t) : block =
   in
   read_statements []
 
-and read_starting_style (r : Cursor.t) : statement =
-  Cursor.expect_at_keyword "starting-style" r;
-  Cursor.ws r;
-  let content = Cursor.braces (fun inner -> read_block inner) r in
-  Starting_style content
-
-and read_when (r : Cursor.t) : statement =
-  Cursor.expect_at_keyword "when" r;
-  Cursor.ws r;
-  let prelude = Cursor.drain_until_block r in
-  if List.for_all (fun cv -> Component.to_string cv |> String.trim = "") prelude
-  then Cursor.err_invalid r "@when: missing condition";
-  let condition : conditional =
-    try conditional_components prelude
-    with Failure msg -> Cursor.err_invalid r ("@when: " ^ msg)
-  in
-  let content = Cursor.braces (fun inner -> read_block inner) r in
-  When (condition, content)
-
-and read_else (r : Cursor.t) : statement =
-  Cursor.expect_at_keyword "else" r;
-  Cursor.ws r;
-  let prelude = Cursor.drain_until_block r in
-  let condition =
-    match
-      List.filter
-        (function
-          | Component.Preserved { kind = Token.Whitespace; _ } -> false
-          | _ -> true)
-        prelude
-    with
-    | [] -> Option.None
-    | _ -> (
-        match conditional_components prelude with
-        | condition -> Some condition
-        | exception Failure msg -> Cursor.err_invalid r ("@else: " ^ msg))
-  in
-  let content = Cursor.braces (fun inner -> read_block inner) r in
-  Else (condition, content)
-
 and read_media (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "media" r;
   Cursor.ws r;
@@ -3493,21 +3504,6 @@ and read_supports (r : Cursor.t) : statement =
     Cursor.err r "@supports rule requires a condition";
   let content = Cursor.braces (fun inner -> read_block inner) r in
   Supports (supports_condition ~loc:cond_loc condition, content)
-
-and read_moz_document (r : Cursor.t) : statement =
-  Cursor.with_context r "@-moz-document" @@ fun () ->
-  Cursor.expect_at_keyword "-moz-document" r;
-  Cursor.ws r;
-  let prelude = Cursor.drain_until_block_as_string ~trim:true r in
-  let prelude_cursor = Cursor.of_string prelude in
-  let conditions =
-    Cursor.list ~sep:Cursor.comma ~at_least:1 read_moz_document_condition
-      prelude_cursor
-  in
-  Cursor.ws prelude_cursor;
-  Cursor.expect_eof prelude_cursor;
-  let content = Cursor.braces (fun inner -> read_block inner) r in
-  Moz_document (conditions, content)
 
 and read_scope (r : Cursor.t) : statement =
   (* CSS Cascade 6 sec. 3.5.2: [@scope <start> to <end> { ... }]. The two
@@ -3612,7 +3608,7 @@ and read_nesting_item r =
   match Cursor.peek r with
   | None -> `Done
   | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      `Stmt (read_statement r)
+      `Stmt (read_nested_at_within_rule r)
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       Cursor.skip r;
       `Skip
@@ -3645,8 +3641,7 @@ and read_nested_decl_after_semicolon r acc =
       | None -> List.rev acc)
 
 (* Helper: Read nested at-rule with declarations content *)
-and read_nested_at_rule (r : Cursor.t) (at_rule : string)
-    (_selector : Selector.t) : statement =
+and read_nested_at_rule (r : Cursor.t) (at_rule : string) : statement =
   Cursor.with_context r at_rule @@ fun () ->
   let name = String.sub at_rule 1 (String.length at_rule - 1) in
   Cursor.expect_at_keyword name r;
@@ -3689,36 +3684,41 @@ and read_nested_scope_rule r =
   let content = Cursor.braces (fun inner -> read_nesting_block inner) r in
   Scope (scope_start, scope_end, content)
 
-and read_nested_at_within_rule (r : Cursor.t) (selector : Selector.t) :
-    statement =
+and read_nested_layer_rule r =
+  Cursor.expect_at_keyword "layer" r;
+  Cursor.ws r;
   match Cursor.peek r with
-  | Some (Component.Preserved { kind = Token.At_keyword name; _ })
-    when name = "supports" || name = "media" || name = "container"
-         || name = "scope" ->
-      read_nested_at_rule r ("@" ^ name) selector
-  | Some (Component.Preserved { kind = Token.At_keyword "layer"; _ }) -> (
-      Cursor.expect_at_keyword "layer" r;
+  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ }) ->
+      Layer (None, Cursor.braces (fun inner -> read_nesting_block inner) r)
+  | _ ->
+      let name = Cursor.ident ~keep_case:true r in
       Cursor.ws r;
-      match Cursor.peek r with
-      | Some (Component.Block { node = { opening = Token.Curly; _ }; _ }) ->
-          let content =
-            Cursor.braces (fun inner -> read_nesting_block inner) r
-          in
-          Layer (None, content)
-      | _ ->
-          let name = Cursor.ident ~keep_case:true r in
-          Cursor.ws r;
-          let content =
-            Cursor.braces (fun inner -> read_nesting_block inner) r
-          in
-          Layer (Some name, content))
-  | Some
-      (Component.Preserved
-         {
-           kind =
-             Token.At_keyword (("charset" | "import" | "namespace") as name);
-           _;
-         }) ->
+      Layer (Some name, Cursor.braces (fun inner -> read_nesting_block inner) r)
+
+and read_nested_at_within_rule (r : Cursor.t) : statement =
+  match Cursor.peek r with
+  | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
+      read_nested_at_keyword r name
+  | _ -> read_statement r
+
+(* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be
+   nested inside of a style rule as well", which is every group rule cascade
+   models - the conditional group rules @media/@supports/@container, @when and
+   @else that generalise them (CSS Conditional 5 sec. 3, sec. 4),
+   @-moz-document, @layer, @scope, and @starting-style (CSS Transitions 2 sec.
+   3.3). Nested, the body is <block-contents>, so a bare declaration run in it
+   belongs to the parent selector. Everything else keeps its stylesheet-level
+   reading: a descriptor rule such as @font-face carries no style rule, and a
+   top-of-sheet rule is invalid here outright. *)
+and read_nested_at_keyword r = function
+  | ("supports" | "media" | "container" | "scope") as name ->
+      read_nested_at_rule r ("@" ^ name)
+  | "layer" -> read_nested_layer_rule r
+  | "starting-style" -> read_starting_style ~body:read_nesting_block r
+  | "-moz-document" -> read_moz_document ~body:read_nesting_block r
+  | "when" -> read_when ~body:read_nesting_block r
+  | "else" -> read_else ~body:read_nesting_block r
+  | ("charset" | "import" | "namespace") as name ->
       Cursor.err_invalid r ("Unexpected nested at-rule: @" ^ name)
   | _ -> read_statement r
 
@@ -3726,7 +3726,7 @@ and read_rule_item selector inner decls nested =
   match Cursor.peek inner with
   | None -> `Done (List.rev decls, List.rev (seal_declaration_run nested))
   | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      let stmt = read_nested_at_within_rule inner selector in
+      let stmt = read_nested_at_within_rule inner in
       `Continue (decls, stmt :: seal_declaration_run nested)
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       Cursor.skip inner;

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1252,7 +1252,7 @@ let rec pp_rule : rule Pp.t =
   (match (decls, rule.nested) with
   | [], [] -> ()
   | decls, nested ->
-      let ctx = { ctx with level = ctx.level + 1 } in
+      let ctx = Pp.enter_style_rule { ctx with level = ctx.level + 1 } in
       let pp_declarations ctx () =
         Pp.list ~sep:Pp.semicolon_cut
           (Pp.indent Declaration.pp_declaration)
@@ -1298,8 +1298,11 @@ and pp_layer_statement ctx name content =
       Pp.string ctx n
   | None -> ());
   (* For empty layers: use statement form when minifying (more concise), but
-     preserve block form otherwise for roundtrip fidelity *)
-  if content = [] && Pp.minified ctx then Pp.semicolon ctx ()
+     preserve block form otherwise for roundtrip fidelity. A style rule accepts
+     no layer-order declaration, so inside one the block form is the only
+     spelling that survives a re-read. *)
+  if content = [] && Pp.minified ctx && not (Pp.in_style_rule ctx) then
+    Pp.semicolon ctx ()
   else (
     Pp.sp ctx ();
     Pp.braces pp_block ctx content)
@@ -3689,12 +3692,16 @@ and read_nested_at_within_rule (r : Cursor.t) (selector : Selector.t) :
       Cursor.ws r;
       match Cursor.peek r with
       | Some (Component.Block { node = { opening = Token.Curly; _ }; _ }) ->
-          let content = Cursor.braces (fun inner -> read_block inner) r in
+          let content =
+            Cursor.braces (fun inner -> read_nesting_block inner) r
+          in
           Layer (None, content)
       | _ ->
           let name = Cursor.ident ~keep_case:true r in
           Cursor.ws r;
-          let content = Cursor.braces (fun inner -> read_block inner) r in
+          let content =
+            Cursor.braces (fun inner -> read_nesting_block inner) r
+          in
           Layer (Some name, content))
   | Some
       (Component.Preserved

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -212,7 +212,11 @@ val selector : rule -> Selector.t
 (** [selector rule] returns the selector of a rule. *)
 
 val declarations : rule -> declaration list
-(** [declarations rule] returns the declarations of a rule. *)
+(** [declarations rule] returns the run of declarations written before the
+    rule's first nested statement. CSS Nesting 1 sec. 3.4 wraps a run written
+    after one in a nested declarations rule, so it stays in {!nested} at the
+    position it was written; this is the whole body only for a rule that nests
+    nothing. *)
 
 val nested : rule -> statement list
 (** [nested rule] returns the nested statements of a rule. *)

--- a/test/cli/diff_nested_block.t
+++ b/test/cli/diff_nested_block.t
@@ -1,0 +1,48 @@
+CLI: cascade diff - a rule's nested block is named as a block.
+
+The container is the block of a rule, not a selector, so it is named after the
+rule it belongs to. Prefixing it the way an at-rule container is named prints
+"& .a", which is a valid selector matching a ".a" inside the parent.
+
+  $ cat > nest-a.css <<'EOF'
+  > .a{color:red;& b{color:blue}}
+  > EOF
+  $ cat > nest-b.css <<'EOF'
+  > .a{color:red;& b{color:green}}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=tree nest-a.css nest-b.css
+  CSS: 30 chars vs 31 chars (3.3% diff)
+  Changes: 1 modified rule, 1 changed container
+  
+  --- nest-a.css
+  +++ nest-b.css
+  └─ .a { & } (1 modified)
+     └─ & b
+           * color: blue -> green
+  
+  [1]
+
+A run of declarations written after a nested statement is the nested
+declarations rule of CSS Nesting 1 sec. 3.4, which acts as "&". It has no
+head, so naming it by the text up to its first brace puts its first
+declaration in the selector column.
+
+  $ cat > run-a.css <<'EOF'
+  > .a{color:red;& b{color:blue}}
+  > EOF
+  $ cat > run-b.css <<'EOF'
+  > .a{& b{color:blue}color:red}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=tree run-a.css run-b.css
+  CSS: 30 chars vs 29 chars (3.3% diff)
+  Changes: 1 modified rule, 1 changed container
+  
+  --- run-a.css
+  +++ run-b.css
+  ├─ .a
+  │     - color
+  └─ .a { & } (1 added)
+     └─ &
+           + color red
+  
+  [1]

--- a/test/inline/fixtures/nested_media_order.html
+++ b/test/inline/fixtures/nested_media_order.html
@@ -1,0 +1,9 @@
+<!doctype html><html><head><style>
+  .dm1 { @media (min-width: 1px) { color: red } color: blue; @media (min-width: 1px) { color: green } }
+  .dm2 { @media (min-width: 1px) { color: red } @media (min-width: 1px) { color: green } color: blue }
+  .dm3 { @media (min-width: 1px) { color: red } outline-color: blue; @media (min-width: 1px) { color: green } }
+</style></head><body>
+<div class="dm1">a</div>
+<div class="dm2">b</div>
+<div class="dm3">c</div>
+</body></html>

--- a/test/inline/fixtures/nested_order.html
+++ b/test/inline/fixtures/nested_order.html
@@ -1,0 +1,12 @@
+<!doctype html><html><head><style>
+  .n1 { color: red; & b { width: 9px } color: green }
+  .n2 { @media (min-width: 1px) { color: blue } color: green }
+  .n3 { @supports (color: red) { color: blue } color: green }
+  .n4 { color: red; & b { width: 9px } color: blue }
+  .n4 { color: green }
+</style></head><body>
+<div class="n1">a<b>x</b></div>
+<div class="n2">b</div>
+<div class="n3">c</div>
+<div class="n4">d<b>y</b></div>
+</body></html>

--- a/test/inline/fixtures/nested_order.html
+++ b/test/inline/fixtures/nested_order.html
@@ -8,6 +8,7 @@
   .n6 { --w: 40px; & b { --w: 50px } width: var(--w) }
   .n7 { @media (min-width: 1px) { color: blue } color: green !important }
   .n8 { color: red; @media (min-width: 1px) { padding: 3px } color: green; & i { width: 8px } font-size: 20px }
+  .n9 { @media (min-width: 1px) { color: blue } color: red; color: green }
 </style></head><body>
 <div class="n1">a<b>x</b></div>
 <div class="n2">b</div>
@@ -17,4 +18,5 @@
 <div class="n6">f<b>z</b></div>
 <div class="n7">g</div>
 <div class="n8">h<i>w</i></div>
+<div class="n9">i</div>
 </body></html>

--- a/test/inline/fixtures/nested_order.html
+++ b/test/inline/fixtures/nested_order.html
@@ -4,9 +4,17 @@
   .n3 { @supports (color: red) { color: blue } color: green }
   .n4 { color: red; & b { width: 9px } color: blue }
   .n4 { color: green }
+  .n5 { @media (min-width: 1px) { color: blue } color: green; width: 30px }
+  .n6 { --w: 40px; & b { --w: 50px } width: var(--w) }
+  .n7 { @media (min-width: 1px) { color: blue } color: green !important }
+  .n8 { color: red; @media (min-width: 1px) { padding: 3px } color: green; & i { width: 8px } font-size: 20px }
 </style></head><body>
 <div class="n1">a<b>x</b></div>
 <div class="n2">b</div>
 <div class="n3">c</div>
 <div class="n4">d<b>y</b></div>
+<div class="n5">e</div>
+<div class="n6">f<b>z</b></div>
+<div class="n7">g</div>
+<div class="n8">h<i>w</i></div>
 </body></html>

--- a/test/spec/inventory/at_rule_grammar.ml
+++ b/test/spec/inventory/at_rule_grammar.ml
@@ -140,8 +140,8 @@ let negative =
       "@font-face { font-family: Brand; src: url(brand.woff2); @media screen { \
        .x { color: red } } }";
     invalid "page" "invalid-pseudo" "@page :unknown { margin: 1cm }";
-    invalid "page" "invalid-margin-descriptor"
-      "@page { @top-center { display: block } }";
+    invalid "page" "bad-margin-descriptor-value"
+      "@page { @top-center { display: 1px } }";
     invalid "keyframes" "missing-block" "@keyframes missing-block";
     invalid "font-palette-values" "bad-name"
       "@font-palette-values brand { font-family: Brand; base-palette: 1 }";

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -134,6 +134,35 @@ let equal_canonical_lossless_exact_srgb () =
     "an off-grid channel keeps its function" false
     (equal ".a{color:color(srgb .501 0 0)}" ".a{color:maroon}")
 
+(* CSS Nesting 1 sec. 3.4 keeps a declaration written after a nested rule where
+   the author wrote it, which only matters for a property the nested rule also
+   sets. Where nothing clashes across the boundary the two spellings compute the
+   same values on every element, so the projection has to bring them
+   together. *)
+let canonical_declaration_after_nested_rule () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  Alcotest.(check bool)
+    "a disjoint declaration agrees either side of a nested rule" true
+    (equal ".a{color:red;& b{width:1px}}" ".a{& b{width:1px}color:red}");
+  Alcotest.(check bool)
+    "so does one either side of a nested @media" true
+    (equal ".a{width:2px;@media (hover){color:blue}}"
+       ".a{@media (hover){color:blue}width:2px}");
+  (* A [var()] reader writes its own property, never the one it reads, so it
+     crosses a nested definition of that custom property freely. *)
+  Alcotest.(check bool)
+    "a var() reader crosses a nested definition of what it reads" true
+    (equal ".a{width:var(--x);& b{--x:1px}}" ".a{& b{--x:1px}width:var(--x)}");
+  (* The clashing pair is a real difference: hoisting [color] over the nested
+     rule is the miscompile the position exists to prevent. *)
+  Alcotest.(check bool)
+    "a clashing declaration still differs" false
+    (equal ".a{color:red;& b{color:blue}}" ".a{& b{color:blue}color:red}");
+  Alcotest.(check bool)
+    "a longhand still clashes with a crossed shorthand" false
+    (equal ".a{margin-top:2px;& b{margin:1px}}"
+       ".a{& b{margin:1px}margin-top:2px}")
+
 (* Filter Effects 1 sec. 6.1 makes an omitted [hue-rotate()] argument 0, and
    [hue-rotate] names a filter function and nothing else, so the two spellings
    are one value wherever the stream is substituted. *)
@@ -1416,6 +1445,8 @@ let suite =
         equal_prune_unused_custom_props;
       Alcotest.test_case "canonical folds a zero hue-rotate in a custom value"
         `Quick canonical_custom_hue_rotate_zero;
+      Alcotest.test_case "canonical folds a disjoint trailing declaration"
+        `Quick canonical_declaration_after_nested_rule;
       Alcotest.test_case "canonical keeps custom-property importance" `Quick
         canonical_important_custom_property_distinct;
       Alcotest.test_case "canonical ignores @property order" `Quick

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -116,6 +116,22 @@ let test_flattens_inside_moz_document () =
   check ".a{@-moz-document url-prefix(){.b{color:red}}}"
     "@-moz-document url-prefix(){.a .b{color:red}}"
 
+(* CSS Nesting 1 sec. 3.3: any at-rule whose body carries style rules nests
+   inside a style rule, so flattening one has to carry the parent selector into
+   its declaration run. A group rule flatten does not know leaves the run bare
+   at the top of the block, which no reader takes back. *)
+let test_nested_group_rules_keep_parent () =
+  let check src expected =
+    Alcotest.(check string) src expected (render (Flatten.block (block src)))
+  in
+  check ".a{@starting-style{color:red}}" "@starting-style{.a{color:red}}";
+  check ".a{@-moz-document url-prefix(){color:red}}"
+    "@-moz-document url-prefix(){.a{color:red}}";
+  check ".a{@when media(width>0px){color:red}}"
+    "@when media(width>0px){.a{color:red}}";
+  check ".a{@layer n{@media screen{color:red}}}"
+    "@layer n{@media screen{.a{color:red}}}"
+
 let suite =
   ( "flatten",
     [
@@ -135,4 +151,6 @@ let suite =
         test_nested_selector_list_keeps_parent;
       Alcotest.test_case "flattens inside @-moz-document" `Quick
         test_flattens_inside_moz_document;
+      Alcotest.test_case "nested group rules keep the parent" `Quick
+        test_nested_group_rules_keep_parent;
     ] )

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -54,9 +54,10 @@ let test_nested_rule_starting_with_ident () =
   check ".a{p:hover{color:red}}" ".a{p:hover{color:red}}";
   (* minify canonicalises the legacy one-colon form, as it does at top level *)
   check ".a{li::before{color:red}}" ".a{li:before{color:red}}";
-  (* several in a row, after and between declarations *)
+  (* several in a row, after and between declarations: CSS Nesting 1 sec. 3.4
+     keeps [height] where it was written, behind both nested rules *)
   check ".a{color:red;h2:hover{width:1px}h3:hover{width:2px};height:2px}"
-    ".a{color:red;height:2px;h2:hover{width:1px}h3:hover{width:2px}}";
+    ".a{color:red;h2:hover{width:1px}h3:hover{width:2px}height:2px}";
   (* the shapes that already worked must keep working *)
   check ".a{&:hover{color:red}}" ".a{&:hover{color:red}}";
   check ".a{.b{color:red}}" ".a{.b{color:red}}";

--- a/test/test_nest.ml
+++ b/test/test_nest.ml
@@ -53,6 +53,39 @@ let test_merge_lone_wrapper () =
     "wrapper with declarations preserved" ".card{color:red;.title{width:1px}}"
     (Pp.to_string ~minify:true Stylesheet.pp_rule with_decl)
 
+(* CSS Nesting 1 sec. 3.4 holds a declaration written after a nested statement
+   behind it. Moving it back is cascade-neutral exactly when it commutes with
+   what it crosses, so the hoist is decided per declaration and per property. *)
+let test_hoist_declaration_runs () =
+  let hoisted css =
+    Pp.to_string ~minify:true Stylesheet.pp_rule
+      (Nest.hoist_declaration_runs (rule css))
+  in
+  Alcotest.(check string)
+    "a disjoint run rejoins the rule's own declarations"
+    ".a{color:red;& b{width:1px}}"
+    (hoisted ".a{& b{width:1px}color:red}");
+  Alcotest.(check string)
+    "a clashing run keeps its place" ".a{& b{color:blue}color:red}"
+    (hoisted ".a{& b{color:blue}color:red}");
+  Alcotest.(check string)
+    "a crossed shorthand blocks its longhand"
+    ".a{& b{margin:1px}margin-top:2px}"
+    (hoisted ".a{& b{margin:1px}margin-top:2px}");
+  Alcotest.(check string)
+    "only the clashing declaration stays"
+    ".a{width:2px;& b{color:blue}color:red}"
+    (hoisted ".a{& b{color:blue}color:red;width:2px}");
+  (* [!important] wins wherever it sits, so it never has to wait. *)
+  Alcotest.(check string)
+    "a differing importance is not a clash"
+    ".a{color:red!important;& b{color:blue}}"
+    (hoisted ".a{& b{color:blue}color:red!important}");
+  (* An unknown at-rule is raw text, so nothing may be assumed about it. *)
+  Alcotest.(check string)
+    "an unknown at-rule blocks everything" ".a{@wat foo{q:1}color:red}"
+    (hoisted ".a{@wat foo{q:1}color:red}")
+
 let test_rules_synthesizes_isolated_chain () =
   let nested = Nest.rules (rules ".card{color:red}.card .title{width:1px}") in
   Alcotest.(check (list string))
@@ -76,6 +109,8 @@ let suite =
       Alcotest.test_case "combine relative nested and descendant" `Quick
         test_combine_relative_nested_and_descendant;
       Alcotest.test_case "merge_lone wrapper" `Quick test_merge_lone_wrapper;
+      Alcotest.test_case "hoist declaration runs" `Quick
+        test_hoist_declaration_runs;
       Alcotest.test_case "rules synthesizes isolated chain" `Quick
         test_rules_synthesizes_isolated_chain;
       Alcotest.test_case "rules preserves competing outside selector" `Quick

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2191,6 +2191,35 @@ let same_selector_merge_past_nested () =
     ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}"
     (canon ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}")
 
+(* A run of declarations written after a nested statement (CSS Nesting 1 sec.
+   3.4) is a declaration list like any other, with nothing between two writes
+   inside it, so the deduplication a rule body gets applies to it. *)
+let nested_declaration_run_dedupes () =
+  let of_string css =
+    match Css.of_string css with
+    | Ok p -> p.Css.stylesheet
+    | Error _ -> Alcotest.failf "could not parse %s" css
+  in
+  let canon css =
+    Css.Optimize.stylesheet (Css.statements (of_string css))
+    |> Css.Stylesheet.to_string ~minify:true
+    |> String.trim
+  in
+  (* The run cannot move: [color] is what the nested rule sets too. *)
+  Alcotest.(check string)
+    "a repeated declaration inside a run collapses" ".a{b{color:red}color:#00f}"
+    (canon ".a{& b{color:red}color:blue;color:blue}");
+  Alcotest.(check string)
+    "a declaration the run itself overrides goes" ".a{b{color:red}color:green}"
+    (canon ".a{& b{color:red}color:blue;color:green}");
+  (* The crossed shorthand pins every one of the four longhands, so they compose
+     where they stand. *)
+  Alcotest.(check string)
+    "longhands inside a run compose" ".a{b{margin:9px}margin:1px}"
+    (canon
+       ".a{& \
+        b{margin:9px}margin-top:1px;margin-right:1px;margin-bottom:1px;margin-left:1px}")
+
 (* A selector list holding a vendor pseudo-element is invalidated as a whole by
    a browser that does not know it, so the other selectors silently lose the
    declarations. The grouping passes refuse to build such a list; one the author
@@ -5393,6 +5422,8 @@ module Fuzz = struct
         fuzz_cascade_equivalent;
       Alcotest.test_case "same-selector merge past nested children" `Quick
         same_selector_merge_past_nested;
+      Alcotest.test_case "a nested declarations run is deduplicated" `Quick
+        nested_declaration_run_dedupes;
       Alcotest.test_case "vendor pseudo-element list is split" `Quick
         vendor_pseudo_list_is_split;
       Alcotest.test_case "cascade-neutral permutations stay equivalent" `Slow

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1731,7 +1731,34 @@ let test_distant_media_merge () =
     "@media(width>=1px){a{background-color:red}}a{background:#00f}@media(width>=1px){a{background-color:green}}"
     (minify_str
        "@media (width>=1px){a{background-color:red}}a{background:blue}@media \
-        (width>=1px){a{background-color:green}}")
+        (width>=1px){a{background-color:green}}");
+  (* CSS Nesting 1 sec. 3.4: a declaration written after a nested rule stays
+     behind it, so the run between the two blocks is one more rule with the
+     enclosing selector. Hoisting the second block over it would compute blue
+     where the source computes green. *)
+  Alcotest.(check string)
+    "keeps blocks apart across a conflicting nested declarations run"
+    ".a{@media(width>=1px){color:red}color:#00f;@media(width>=1px){color:green}}"
+    (minify_str
+       ".a{@media (width>=1px){color:red}color:blue;@media \
+        (width>=1px){color:green}}");
+  (* The run sets another property, so nothing an element computes depends on
+     the order: the blocks still merge, and the disjoint run rejoins the rule's
+     own declarations. *)
+  Alcotest.(check string)
+    "merges across a nested declarations run that sets another property"
+    ".a{outline-color:#00f;@media(width>=1px){color:red;color:green}}"
+    (minify_str
+       ".a{@media (width>=1px){color:red}outline-color:blue;@media \
+        (width>=1px){color:green}}");
+  (* Adjacent blocks cross nothing, so the run after them keeps its place and
+     the merge stands. *)
+  Alcotest.(check string)
+    "merges adjacent blocks inside a rule"
+    ".a{@media(width>=1px){color:red;color:green}color:#00f}"
+    (minify_str
+       ".a{@media (width>=1px){color:red}@media \
+        (width>=1px){color:green}color:blue}")
 
 let test_keep_bang_comment_leading () =
   (* A bang comment (/*! ... */) is preserved by minify; it stays where it was

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2167,9 +2167,10 @@ let c61_adjacent_later_dedup () =
     "adjacent same-selector rules merge and dedupe by source order"
     ".box{display:flex;color:#00f}" output
 
-(* A rule that carries nested children can still absorb a later same-selector
-   rule: the merge moves the later declarations ahead of the nested block, which
-   is only observable for a property the nested block also sets. *)
+(* A rule's [declarations] is the run written before its first nested statement
+   (CSS Nesting 1 sec. 3.4), not its whole body, so absorbing a later
+   same-selector rule moves that rule's declarations ahead of body content the
+   merge never looked at. A rule carrying nested children stays out. *)
 let same_selector_merge_past_nested () =
   let of_string css =
     match Css.of_string css with
@@ -2182,11 +2183,11 @@ let same_selector_merge_past_nested () =
     |> String.trim
   in
   Alcotest.(check string)
-    "disjoint nested children do not block the merge"
-    ".a{color:red;padding:1rem;&:hover{background:#00f}}"
+    "nested children keep the rule out of the merge"
+    ".a{color:red;&:hover{background:#00f}}.a{padding:1rem}"
     (canon ".a{color:red;&:hover{background:blue}}.a{padding:1rem}");
   Alcotest.(check string)
-    "a nested child setting the same property does block it"
+    "a nested child setting the same property keeps its place"
     ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}"
     (canon ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}")
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1473,22 +1473,27 @@ let spec_lenient_recovery_nested_declaration_run () =
      blue } }"
     ".a{@media screen{color:red;& b{margin:0}background:#00f}}" 1
 
+(* [css] reports exactly [expected] warnings leniently, and [~strict:true]
+   rejects it exactly when the lenient parse warned. *)
+let warns_exactly css expected =
+  let warnings =
+    match Css.of_string ~strict:false css with
+    | Ok { Css.warnings; _ } -> warnings
+    | Error err ->
+        Alcotest.failf "lenient parse rejected %S: %s" css
+          (Cascade.Error.to_string err)
+  in
+  Alcotest.(check int) ("warnings for " ^ css) expected (List.length warnings);
+  match (Css.of_string ~strict:true css, expected) with
+  | Ok _, 0 -> ()
+  | Error _, 0 -> Alcotest.failf "strict parse rejected warning-free %S" css
+  | Ok _, _ -> Alcotest.failf "strict parse accepted warned-about %S" css
+  | Error _, _ -> ()
+
 (* Each recovered declaration reports once, and [~strict:true] rejects exactly
    the inputs the lenient parse warned about. *)
 let spec_recovery_warns_once_per_declaration () =
-  let check css expected =
-    let warnings =
-      match Css.of_string ~strict:false css with
-      | Ok { Css.warnings; _ } -> warnings
-      | Error err ->
-          Alcotest.failf "lenient parse rejected %S: %s" css
-            (Cascade.Error.to_string err)
-    in
-    Alcotest.(check int) ("warnings for " ^ css) expected (List.length warnings);
-    match (Css.of_string ~strict:true css, expected) with
-    | Ok _, 0 | Error _, _ -> ()
-    | Ok _, _ -> Alcotest.failf "strict parse accepted warned-about %S" css
-  in
+  let check = warns_exactly in
   check ".a { @media screen { color: red; width: 10; background: blue } }" 1;
   check ".a { @media screen { width: 10; height: 20; color: red } }" 2;
   check
@@ -1496,6 +1501,107 @@ let spec_recovery_warns_once_per_declaration () =
      }"
     1;
   check ".a { @media screen { color: red; background: blue } }" 0
+
+(* CSS Paged Media 3 sec. 6: "If an error is encountered during the processing
+   of a declaration block within a page or a margin context, the Rules for
+   handling parsing errors apply; that is, valid declarations within the block
+   are applied." One bad descriptor therefore costs that descriptor, not the
+   [@page] holding it and not the sheet holding that. The discard follows CSS
+   Syntax 3 sec. 5.4.4 for a declaration - up to the next top-level [;], a [{}]
+   met on the way counting as one component value of the value being skipped -
+   and sec. 5.4.2 for an at-rule, which ends at its block or its [;]. Blink 146
+   keeps both neighbours in every case below. *)
+let spec_lenient_recovery_page_descriptors () =
+  let recovered = "@page{margin:1cm;margin-top:2cm}" in
+  lenient_recover "bad descriptor first in @page"
+    "@page { width: 10; margin: 1cm; margin-top: 2cm }" recovered 1;
+  lenient_recover "bad descriptor mid-body in @page"
+    "@page { margin: 1cm; width: 10; margin-top: 2cm }" recovered 1;
+  lenient_recover "bad descriptor last in @page"
+    "@page { margin: 1cm; margin-top: 2cm; width: 10 }" recovered 1;
+  lenient_recover "sole descriptor of @page dropped" "@page { width: 10 }" "" 1;
+  lenient_recover "descriptor invalid in the page context is dropped alone"
+    "@page { margin: 1cm; zzz: 1; margin-top: 2cm }" recovered 1;
+  lenient_recover "curly block inside a dropped page value is skipped with it"
+    "@page { margin: 1cm; width: {1}; margin-top: 2cm }" recovered 1;
+  lenient_recover "two curly blocks in a dropped page value are one skip"
+    "@page { margin: 1cm; width: {1}{2}; margin-top: 2cm }" recovered 1;
+  lenient_recover "tokens after a curly block in a dropped page value"
+    "@page { margin: 1cm; width: {1} 2px; margin-top: 2cm }" recovered 1;
+  (* An unclosed function has no top-level [;] left to stop at - the tokenizer
+     closes it at the end of the block - so it takes the rest of the body, as it
+     does in Blink. *)
+  lenient_recover "unclosed function swallows the rest of the page body"
+    "@page { margin: 1cm; width: calc(1px; margin-top: 2cm }"
+    "@page{margin:1cm}" 1;
+  (* A selector-shaped item is not a declaration, so sec. 5.4.4 skips it as a
+     bad one: with no [;] after its block it takes the body's tail with it, and
+     with a [;] it costs only itself. Blink 146 splits the two the same way. *)
+  lenient_recover "selector-shaped item without a semicolon takes the tail"
+    "@page { margin: 1cm; .a { b: c } margin-top: 2cm }" "@page{margin:1cm}" 1;
+  lenient_recover "selector-shaped item with a semicolon costs only itself"
+    "@page { margin: 1cm; .a { b: c }; margin-top: 2cm }" recovered 1;
+  (* An at-rule ends at its block, so discarding an invalid one leaves the
+     descriptor written after it in the page. *)
+  lenient_recover "unknown page margin rule is dropped alone"
+    "@page { @bogus-box { content: \"x\" } margin: 1cm; margin-top: 2cm }"
+    recovered 1;
+  lenient_recover "at-rule that is no page margin rule is dropped alone"
+    "@page { margin: 1cm; @media screen { color: red } margin-top: 2cm }"
+    recovered 1;
+  lenient_recover "page margin rule with no block ends at its semicolon"
+    "@page { margin: 1cm; @top-center; margin-top: 2cm }" recovered 1
+
+(* A page-margin box holds a declaration block of its own (CSS Paged Media 3
+   sec. 5), so sec. 6 applies inside it too: the descriptors written around a
+   bad one stay in the box, and the box stays in the [@page]. *)
+let spec_lenient_recovery_page_margin_box () =
+  let recovered = "@page{@top-center{content:\"x\";margin:0}}" in
+  lenient_recover "bad descriptor in a page margin box"
+    "@page { @top-center { content: \"x\"; width: 10; margin: 0 } }" recovered 1;
+  lenient_recover "descriptor invalid in a margin box is dropped alone"
+    "@page { @top-center { content: \"x\"; zzz: 1; margin: 0 } }" recovered 1;
+  lenient_recover "at-rule in a page margin box ends at its block"
+    "@page { @top-center { @media screen { a: b } content: \"x\"; margin: 0 } }"
+    recovered 1;
+  lenient_recover "selector-shaped item in a margin box with a semicolon"
+    "@page { @top-center { content: \"x\"; .a { b: c }; margin: 0 } }" recovered
+    1;
+  (* [read_page_margin_rule] rejects a box left with no descriptor, so the box
+     goes with its only item; Blink 146 keeps an empty [@top-center { }]. *)
+  lenient_recover "selector-shaped item alone in a page margin box"
+    "@page { @top-center { .a { b: c } } }" "" 1
+
+(* A dropped descriptor leaves no gap: the page keeps the descriptors written
+   around it in source order, and its margin boxes keep theirs. *)
+let spec_lenient_recovery_page_body_order () =
+  lenient_recover "bad descriptor before a page margin box"
+    "@page { margin: 1cm; width: 10; @top-center { content: \"x\" } \
+     margin-top: 2cm }"
+    "@page{margin:1cm;margin-top:2cm;@top-center{content:\"x\"}}" 1;
+  lenient_recover "bad descriptor after a page margin box"
+    "@page { margin: 1cm; @top-center { content: \"x\" } width: 10; \
+     margin-top: 2cm }"
+    "@page{margin:1cm;margin-top:2cm;@top-center{content:\"x\"}}" 1;
+  lenient_recover "bad descriptor between two page margin boxes"
+    "@page { @top-center { content: \"x\" } width: 10; @bottom-center { \
+     content: \"y\" } margin: 1cm }"
+    "@page{margin:1cm;@top-center{content:\"x\"}@bottom-center{content:\"y\"}}"
+    1
+
+(* Each dropped page descriptor reports once, and [~strict:true] rejects exactly
+   the inputs the lenient parse warned about. A stray [;] is discarded without a
+   declaration to validate (CSS Syntax 3 sec. 5.4.3), so it costs nothing. *)
+let spec_page_recovery_warns_once_per_descriptor () =
+  warns_exactly "@page { margin: 1cm; width: 10; margin-top: 2cm }" 1;
+  warns_exactly "@page { margin: 1cm; width: {1}{2}; margin-top: 2cm }" 1;
+  warns_exactly "@page { width: 10; margin: 1cm; height: 20 }" 2;
+  warns_exactly "@page { @top-center { content: \"x\"; width: 10; margin: 0 } }"
+    1;
+  warns_exactly "@page { margin: 1cm; margin-top: 2cm }" 0;
+  warns_exactly "@page { margin: 1cm;; margin-top: 2cm }" 0;
+  warns_exactly "@page { ; margin: 1cm }" 0;
+  warns_exactly "@page { @top-center { content: \"x\" } margin: 1cm }" 0
 
 let stylesheet_tests =
   [
@@ -1581,6 +1687,18 @@ let stylesheet_tests =
     ( "spec recovery warns once per dropped declaration",
       `Quick,
       spec_recovery_warns_once_per_declaration );
+    ( "spec lenient recovery in a @page body",
+      `Quick,
+      spec_lenient_recovery_page_descriptors );
+    ( "spec lenient recovery in a page margin box",
+      `Quick,
+      spec_lenient_recovery_page_margin_box );
+    ( "spec lenient recovery keeps a @page body in order",
+      `Quick,
+      spec_lenient_recovery_page_body_order );
+    ( "spec page recovery warns once per dropped descriptor",
+      `Quick,
+      spec_page_recovery_warns_once_per_descriptor );
   ]
 
 (* Tests for newly added check functions *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -995,6 +995,53 @@ let spec_page_context_properties () =
       "@page { @top-center { @media screen { .x { color: red } } } }";
     ]
 
+(* CSS Cascade 5 sec. 6.2 puts an important author declaration above a normal
+   one whichever was written first, and sec. 6.4 breaks a tie between two of the
+   same importance by order of appearance. The page context cascades on those
+   rules like any other author context, so a duplicate name in a page body or a
+   margin box keeps the important declaration, and the last one when both carry
+   the same importance. Blink 146 reads exactly that back out of
+   [cssRules[0].cssText] in both contexts. Blink serializes the survivors with
+   the normal declarations before the important ones, a consequence of how it
+   builds its property set; cascade keeps the order the author wrote, which
+   names the same declarations. *)
+let spec_page_descriptor_importance () =
+  List.iter
+    (fun (expected, input) -> check_stylesheet ~expected input)
+    [
+      ( "@page{margin:1cm!important}",
+        "@page { margin: 1cm !important; margin: 2cm }" );
+      ( "@page{margin:2cm!important}",
+        "@page { margin: 1cm; margin: 2cm !important }" );
+      ("@page{margin:2cm}", "@page { margin: 1cm; margin: 2cm }");
+      ( "@page{margin:2cm!important}",
+        "@page { margin: 1cm !important; margin: 2cm !important }" );
+      ( "@page{color:red!important}",
+        "@page { color: red !important; color: blue; color: green }" );
+      (* The important declaration keeps the place it was written in. *)
+      ( "@page{margin:1cm!important;size:A4}",
+        "@page { margin: 1cm !important; size: a4; margin: 2cm }" );
+      (* Sec. 5: a margin box holds a declaration list of its own, and the same
+         cascade decides it. *)
+      ( "@page{@top-center{content:\"a\"!important}}",
+        "@page { @top-center { content: \"a\" !important; content: \"b\" } }" );
+      ( "@page{@top-center{content:\"b\"!important}}",
+        "@page { @top-center { content: \"a\"; content: \"b\" !important } }" );
+      ( "@page{@top-center{content:\"b\"}}",
+        "@page { @top-center { content: \"a\"; content: \"b\" } }" );
+      (* A longhand written after its shorthand is a different name, so neither
+         replaces the other and both stay. Blink expands the pair to longhands
+         and prints [margin: 2cm 1cm 1cm], the same four values. *)
+      ( "@page{margin:1cm;margin-top:2cm}",
+        "@page { margin: 1cm; margin-top: 2cm }" );
+      ( "@page{margin-top:2cm!important;margin:1cm}",
+        "@page { margin-top: 2cm !important; margin: 1cm }" );
+      (* Blink drops a custom property in a page context, so it gives no reading
+         here; the cascade rule that decides every other name decides this one
+         too. *)
+      ("@page{--x:1!important}", "@page { --x: 1 !important; --x: 2 }");
+    ]
+
 let spec_property_descriptor_matrix () =
   List.iter
     (fun (expected, input) -> check_stylesheet ~expected input)
@@ -1877,6 +1924,7 @@ let stylesheet_tests =
       `Quick,
       spec_page_margin_descriptor_matrix );
     ("spec page context properties", `Quick, spec_page_context_properties);
+    ("spec page descriptor importance", `Quick, spec_page_descriptor_importance);
     ("property rule edges", `Quick, property_rule_edges);
     ("spec property descriptor matrix", `Quick, spec_property_descriptor_matrix);
     ("sheet_item", `Quick, sheet_item_case);

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1042,6 +1042,38 @@ let spec_page_descriptor_importance () =
       ("@page{--x:1!important}", "@page { --x: 1 !important; --x: 2 }");
     ]
 
+(* CSS Paged Media 3 sec. 5 gives a margin at-rule a [<declaration-list>], which
+   CSS Syntax 3 sec. 5.4.4 consumes even when it holds nothing, so a margin box
+   with an empty block is valid and Blink 146 reads one back unchanged - a box
+   left empty by a stray [;] too, which sec. 5.4.3 discards with no declaration
+   to validate. Sec. 5 generates the box only where its [content] computes away
+   from [none], so an empty one paints nothing, and {!Css.to_string} elides what
+   paints nothing whether or not the sheet was optimized: an empty box goes the
+   way an empty style rule and an empty [@page] already go, and a page left with
+   neither descriptor nor box goes with it. *)
+let spec_page_margin_box_empty () =
+  List.iter
+    (fun (expected, input) -> check_stylesheet ~expected input)
+    [
+      ("@page{@top-center{}}", "@page { @top-center { } }");
+      ("@page{@top-center{}}", "@page { @top-center {} }");
+      ("@page{@top-center{}}", "@page { @top-center { ; } }");
+      ( "@page{margin:1cm;@top-center{}}",
+        "@page { margin: 1cm; @top-center { } }" );
+      ( "@page{@top-center{}@bottom-center{content:\"x\"}}",
+        "@page { @top-center { } @bottom-center { content: \"x\" } }" );
+    ];
+  (* An empty block is not a missing one: sec. 5 still asks for a block. *)
+  neg_cursor read_stylesheet "@page { @top-left; }";
+  assert_minify_and_optimize "@page { @top-center { } }" ~minified:""
+    ~optimized:"";
+  assert_minify_and_optimize "@page { margin: 1cm; @top-center { } }"
+    ~minified:"@page{margin:1cm}" ~optimized:"@page{margin:1cm}";
+  assert_minify_and_optimize
+    "@page { @top-center { } @bottom-center { content: \"x\" } }"
+    ~minified:"@page{@bottom-center{content:\"x\"}}"
+    ~optimized:"@page{@bottom-center{content:\"x\"}}"
+
 let spec_property_descriptor_matrix () =
   List.iter
     (fun (expected, input) -> check_stylesheet ~expected input)
@@ -1293,6 +1325,7 @@ let spec_strict_accepts_valid_stylesheets () =
         "@container sidebar (inline-size > 30em) { .x { display: grid } }" );
       (* Paged Media 3 SS 3.1 permits multiple page pseudo-classes; compound
          vectors are covered by the page descriptor matrix. *)
+      ("empty page margin box", "@page { @top-center { } }");
       ( "scope with end boundary",
         "@scope (.card) to (.footer) { .title { color: red } }" );
       ( "font-face wildcard unicode range",
@@ -1925,6 +1958,7 @@ let stylesheet_tests =
       spec_page_margin_descriptor_matrix );
     ("spec page context properties", `Quick, spec_page_context_properties);
     ("spec page descriptor importance", `Quick, spec_page_descriptor_importance);
+    ("spec page margin box empty", `Quick, spec_page_margin_box_empty);
     ("property rule edges", `Quick, property_rule_edges);
     ("spec property descriptor matrix", `Quick, spec_property_descriptor_matrix);
     ("sheet_item", `Quick, sheet_item_case);

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1224,6 +1224,41 @@ let spec_strict_rejects_invalid_stylesheets () =
         "@namespace svg url(http://www.w3.org/2000/svg); @import url(late.css);"
       );
       ("import inside style rule", ".x { @import url(inner.css); color: red }");
+      (* CSS Nesting 1 sec. 3.3: an at-rule whose body holds no style rule does
+         not nest, so writing one inside a style rule is invalid. *)
+      ( "font-face inside style rule",
+        ".x { color: red; @font-face { font-family: F; src: url(f.woff2) } }" );
+      ( "keyframes inside style rule",
+        ".x { color: red; @keyframes k { to { opacity: 1 } } }" );
+      ( "webkit keyframes inside style rule",
+        ".x { color: red; @-webkit-keyframes k { to { opacity: 1 } } }" );
+      ( "moz keyframes inside style rule",
+        ".x { color: red; @-moz-keyframes k { to { opacity: 1 } } }" );
+      ( "property inside style rule",
+        ".x { color: red; @property --p { syntax: \"*\"; inherits: false } }" );
+      ("page inside style rule", ".x { color: red; @page { margin: 1cm } }");
+      ( "counter-style inside style rule",
+        ".x { color: red; @counter-style c { system: cyclic; symbols: \"x\" } }"
+      );
+      ( "position-try inside style rule",
+        ".x { color: red; @position-try --t { top: 1px } }" );
+      ( "font-palette-values inside style rule",
+        ".x { color: red; @font-palette-values --v { font-family: F; \
+         base-palette: 0 } }" );
+      ( "font-feature-values inside style rule",
+        ".x { color: red; @font-feature-values F { @styleset { s: 1 } } }" );
+      ( "viewport inside style rule",
+        ".x { color: red; @viewport { width: 1px } }" );
+      ( "ms-viewport inside style rule",
+        ".x { color: red; @-ms-viewport { width: 1px } }" );
+      ( "supports-condition inside style rule",
+        ".x { color: red; @supports-condition (color: red) { color: green } }"
+      );
+      (* CSS Conditional 5 sec. 4: an @else needs a preceding @when here too. *)
+      ( "orphan else inside style rule",
+        ".x { color: red; @else { color: green } }" );
+      ( "orphan else inside a nested group rule",
+        ".x { @media screen { color: red; @else { color: green } } }" );
       ("import inside media rule", "@media screen { @import url(inner.css); }");
       ("import with block", "@import url(theme.css) { .x { color: red } }");
       ( "import layer after condition",
@@ -1361,7 +1396,14 @@ let spec_lenient_recovery_stylesheets () =
     ".ok { color: green } .bad:not() { color: red } .next { color: blue }"
     ".ok{color:green}.next{color:#00f}" 1;
   lenient_recover "unclosed block auto-closes" ".btn { color: red;"
-    ".btn{color:red}" 0
+    ".btn{color:red}" 0;
+  lenient_recover "descriptor at-rule in a style rule keeps its neighbours"
+    ".a { color: red; @font-face { font-family: F; src: url(f.woff2) } \
+     background: blue }"
+    ".a{color:red;background:#00f}" 1;
+  lenient_recover "orphan else in a style rule keeps its neighbours"
+    ".a { color: red; @else { color: green } background: blue }"
+    ".a{color:red;background:#00f}" 1
 
 let stylesheet_tests =
   [
@@ -2970,6 +3012,80 @@ let spec_nesting_at_rule_inside_nested_group () =
     ~expected:".a{@media screen{@starting-style{color:red}}}"
     ".a { @media screen { @starting-style { color: red } } }";
   test_nesting_idempotent ".a { @layer n { @media screen { color: red } } }"
+
+(* CSS Nesting 1 sec. 3.3 nests "any at-rule whose body contains style rules"; a
+   descriptor rule, a keyframe list and a declaration-list rule contain none, so
+   inside a style rule they are invalid. Blink 146 drops each one and keeps the
+   declarations written around it, which is the recovery CSS Syntax 3 sec. 5.4.4
+   describes: discard the invalid construct, resume at the next one. *)
+let spec_nesting_rejects_non_group_at_rules () =
+  let drops at_rule =
+    test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+      (".a { color: red; " ^ at_rule ^ " background: blue }")
+  in
+  drops "@font-face { font-family: F; src: url(f.woff2) }";
+  drops "@keyframes k { from { opacity: 0 } to { opacity: 1 } }";
+  drops "@-webkit-keyframes k { from { opacity: 0 } to { opacity: 1 } }";
+  drops "@-moz-keyframes k { from { opacity: 0 } to { opacity: 1 } }";
+  drops "@property --p { syntax: \"<color>\"; inherits: false }";
+  drops "@page { margin: 1cm }";
+  drops "@counter-style c { system: cyclic; symbols: \"x\" }";
+  drops "@position-try --t { top: 1px }";
+  drops "@font-palette-values --v { font-family: F; base-palette: 0 }";
+  drops "@font-feature-values F { @styleset { s: 1 } }";
+  drops "@viewport { width: 100px }";
+  drops "@-ms-viewport { width: 100px }";
+  drops "@supports-condition (color: red) { color: green }"
+
+(* The same rejection inside every nesting context that a style rule opens: a
+   nested group rule's body, a nested style rule, and a rule reached through a
+   stylesheet-level group rule. *)
+let spec_nesting_rejects_non_group_at_rules_deep () =
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{color:red;background:blue}}"
+    ".a { @media screen { color: red; @font-face { font-family: F; src: \
+     url(f.woff2) } background: blue } }";
+  test_nesting_roundtrip ~expected:".a{& b{color:red;background:blue}}"
+    ".a { & b { color: red; @keyframes k { to { opacity: 1 } } background: \
+     blue } }";
+  test_nesting_roundtrip
+    ~expected:"@media screen{.a{color:red;background:blue}}"
+    "@media screen { .a { color: red; @page { margin: 1cm } background: blue } \
+     }"
+
+(* Dropping the invalid at-rule must not take a nested style rule written after
+   it, and the surviving text has to read back unchanged. *)
+let spec_nesting_rejection_keeps_the_rest () =
+  test_nesting_roundtrip ~expected:".a{color:red;& span{color:lime}b:2}"
+    ".a { color: red; @font-face { font-family: F; src: url(f.woff2) } & span \
+     { color: lime } b: 2 }";
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @font-face; background: blue }";
+  test_nesting_idempotent
+    ".a { color: red; @page { margin: 1cm } background: blue }"
+
+(* CSS View Transitions 2 gives [\@view-transition] a descriptor body, so CSS
+   Nesting 1 sec. 3.3 does not nest it either - but Blink 146 keeps it inside a
+   style rule, down to [&:hover], where every rule above is dropped. Dropping
+   what a shipping engine still reads is the one lossy direction, so cascade
+   keeps it. *)
+let spec_nesting_keeps_view_transition () =
+  test_nesting_roundtrip
+    ~expected:".a{color:red;@view-transition{navigation:auto}background:blue}"
+    ".a { color: red; @view-transition { navigation: auto } background: blue }"
+
+(* CSS Conditional 5 sec. 4: [\@else] is only valid after a [\@when] or another
+   [\@else], wherever it is written. *)
+let spec_nesting_rejects_orphan_else () =
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @else { color: green } background: blue }";
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{color:red;background:blue}}"
+    ".a { @media screen { color: red; @else { color: green } background: blue \
+     } }";
+  test_nesting_roundtrip
+    ~expected:".a{@when media(width>0px){color:red}@else{color:green}}"
+    ".a { @when media(width > 0px) { color: red } @else { color: green } }"
 
 (* CSS Nesting 1 sec. 3.4: a run of declarations written after a nested rule is
    wrapped in a nested declarations rule, which keeps its place among the nested
@@ -7107,6 +7223,21 @@ let additional_tests =
     ( "spec nesting at-rule inside a nested group rule",
       `Quick,
       spec_nesting_at_rule_inside_nested_group );
+    ( "spec nesting rejects a non-group at-rule",
+      `Quick,
+      spec_nesting_rejects_non_group_at_rules );
+    ( "spec nesting rejects a non-group at-rule at every depth",
+      `Quick,
+      spec_nesting_rejects_non_group_at_rules_deep );
+    ( "spec nesting rejection keeps the rest of the rule",
+      `Quick,
+      spec_nesting_rejection_keeps_the_rest );
+    ( "spec nesting keeps @view-transition",
+      `Quick,
+      spec_nesting_keeps_view_transition );
+    ( "spec nesting rejects an orphan @else",
+      `Quick,
+      spec_nesting_rejects_orphan_else );
     ( "spec CSS Nesting L1 preserves nested structure",
       `Quick,
       nesting_module_l1_preserves_structure );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -777,7 +777,7 @@ let page_case () =
      counter(page) } }";
   neg_cursor read_stylesheet "@page : { margin: 1cm }";
   neg_cursor read_stylesheet "@page :unknown { margin: 1cm }";
-  neg_cursor read_stylesheet "@page { color: red }"
+  neg_cursor read_stylesheet "@page { color: notacolor }"
 
 let page_margin_edges () =
   check_stylesheet
@@ -798,7 +798,7 @@ let page_margin_edges () =
     "@page invoice:blank:first { margin: 1cm }";
   neg_cursor read_stylesheet "@page { @unknown { content: none } }";
   neg_cursor read_stylesheet "@page { @top-left; }";
-  neg_cursor read_stylesheet "@page { @top-left { color: red } }"
+  neg_cursor read_stylesheet "@page { @top-left { color: notacolor } }"
 
 let property_rule_edges () =
   check_stylesheet
@@ -926,11 +926,74 @@ let spec_page_margin_descriptor_matrix () =
      content: counter(page) } @bottom-center { content: \"Chapter\" } }";
   List.iter
     (neg_cursor read_stylesheet)
-    [ "@page { @top-center { display: block } }" ];
+    [ "@page { @top-center { display: 1px } }" ];
   check_stylesheet ~expected:"@page:first:left{margin:1cm}"
     "@page :first:left { margin: 1cm }";
   check_stylesheet ~expected:"@page:blank:first{margin:.5cm}"
     "@page :blank:first { margin: 0.5cm }"
+
+(* CSS Paged Media 3 sec. 6: Appendix A is the normative list of CSS 2.1
+   properties that apply in the page context and in the margin context, and
+   "behavior for properties not included in CSS 2.1 is undefined" - undefined,
+   not invalid, "to allow the gradual addition of appropriate CSS3 properties as
+   they emerge". Page-margin boxes inherit from the page context and the page
+   context inherits from the root element, so an inherited property set on the
+   page carries into every margin box. Blink 146 reads every declaration below
+   back out of [cssRules[0].cssText] unchanged, in the page body and in the
+   margin box alike. *)
+let spec_page_context_properties () =
+  List.iter
+    (fun (expected, input) -> check_stylesheet ~expected input)
+    [
+      (* Appendix A, page context. *)
+      ("@page{color:red}", "@page { color: red }");
+      ("@page{font-size:12pt}", "@page { font-size: 12pt }");
+      ("@page{direction:rtl}", "@page { direction: rtl }");
+      ("@page{text-align:center}", "@page { text-align: center }");
+      ("@page{padding:1cm}", "@page { padding: 1cm }");
+      ("@page{border:1px solid red}", "@page { border: 1px solid red }");
+      ("@page{visibility:hidden}", "@page { visibility: hidden }");
+      (* Sec. 6.1: page-based counters are defined in the page context. *)
+      ("@page{counter-increment:page 1}", "@page { counter-increment: page 1 }");
+      (* Sec. 7.1.2 and 7.3 descriptors of this same module. Blink 146 keeps
+         [page-orientation] and drops [bleed], which it does not implement;
+         [bleed] is the name the module defines. *)
+      ( "@page{page-orientation:rotate-left}",
+        "@page { page-orientation: rotate-left }" );
+      ("@page{bleed:6pt}", "@page { bleed: 6pt }");
+      (* Not in Appendix A, so undefined rather than invalid; Blink 146 keeps
+         both. Cascade formats CSS, so an undefined descriptor is carried
+         through rather than dropped. *)
+      ("@page{orphans:3;widows:3}", "@page { orphans: 3; widows: 3 }");
+      (* Blink 146 drops a custom property in a page context and no module
+         defines one there, so admissibility is open; carrying it costs nothing,
+         dropping it loses the author's text. *)
+      ("@page{--custom:1}", "@page { --custom: 1 }");
+      (* Appendix A, margin context: the page-context list plus [content]. *)
+      ( "@page{@top-center{color:red;font-size:9pt;content:\"x\"}}",
+        "@page { @top-center { color: red; font-size: 9pt; content: \"x\" } }"
+      );
+      ( "@page{@top-center{display:block}}",
+        "@page { @top-center { display: block } }" );
+      (* An inherited property on the page reaches the margin boxes. *)
+      ( "@page{color:red;@top-center{content:\"x\"}}",
+        "@page { color: red; @top-center { content: \"x\" } }" );
+    ];
+  (* What browsers still reject: a value the property's grammar does not admit,
+     and an item that is not a declaration at all. Blink 146 drops each of these
+     and keeps the rest of the block. *)
+  List.iter
+    (neg_cursor read_stylesheet)
+    [
+      "@page { margin: notalength }";
+      "@page { color: notacolor }";
+      "@page { width: 10 }";
+      "@page { .a { b: c } }";
+      "@page { @media print { margin: 1cm } }";
+      "@page { @unknown { content: none } }";
+      "@page { @top-center { display: 1px } }";
+      "@page { @top-center { @media screen { .x { color: red } } } }";
+    ]
 
 let spec_property_descriptor_matrix () =
   List.iter
@@ -1354,8 +1417,7 @@ let spec_strict_rejects_invalid_stylesheets () =
         "@counter-style thumbs { symbols: \"*\" }" );
       ( "counter-style cyclic missing symbols",
         "@counter-style thumbs { system: cyclic }" );
-      ( "page margin invalid declaration",
-        "@page { @top-left { display: block } }" );
+      ("page margin invalid declaration", "@page { @top-left { display: 1px } }");
       ("keyframes invalid selector", "@keyframes fade { 50px { opacity: 0 } }");
       ("keyframes forbidden name none", "@keyframes none { to { opacity: 1 } }");
       ( "keyframes forbidden css-wide name",
@@ -1520,8 +1582,6 @@ let spec_lenient_recovery_page_descriptors () =
   lenient_recover "bad descriptor last in @page"
     "@page { margin: 1cm; margin-top: 2cm; width: 10 }" recovered 1;
   lenient_recover "sole descriptor of @page dropped" "@page { width: 10 }" "" 1;
-  lenient_recover "descriptor invalid in the page context is dropped alone"
-    "@page { margin: 1cm; zzz: 1; margin-top: 2cm }" recovered 1;
   lenient_recover "curly block inside a dropped page value is skipped with it"
     "@page { margin: 1cm; width: {1}; margin-top: 2cm }" recovered 1;
   lenient_recover "two curly blocks in a dropped page value are one skip"
@@ -1559,8 +1619,6 @@ let spec_lenient_recovery_page_margin_box () =
   let recovered = "@page{@top-center{content:\"x\";margin:0}}" in
   lenient_recover "bad descriptor in a page margin box"
     "@page { @top-center { content: \"x\"; width: 10; margin: 0 } }" recovered 1;
-  lenient_recover "descriptor invalid in a margin box is dropped alone"
-    "@page { @top-center { content: \"x\"; zzz: 1; margin: 0 } }" recovered 1;
   lenient_recover "at-rule in a page margin box ends at its block"
     "@page { @top-center { @media screen { a: b } content: \"x\"; margin: 0 } }"
     recovered 1;
@@ -1601,7 +1659,12 @@ let spec_page_recovery_warns_once_per_descriptor () =
   warns_exactly "@page { margin: 1cm; margin-top: 2cm }" 0;
   warns_exactly "@page { margin: 1cm;; margin-top: 2cm }" 0;
   warns_exactly "@page { ; margin: 1cm }" 0;
-  warns_exactly "@page { @top-center { content: \"x\" } margin: 1cm }" 0
+  warns_exactly "@page { @top-center { content: \"x\" } margin: 1cm }" 0;
+  (* A name no module defines in a page context is undefined there, not invalid,
+     so it neither warns nor is dropped - the same treatment cascade gives an
+     unknown property name in a style rule. *)
+  warns_exactly "@page { margin: 1cm; zzz: 1; margin-top: 2cm }" 0;
+  warns_exactly "@page { @top-center { content: \"x\"; zzz: 1; margin: 0 } }" 0
 
 (* CSS Properties and Values API 1 sec. 2: [@property] holds the [syntax],
    [inherits] and [initial-value] descriptors, and "unknown descriptors are
@@ -1813,6 +1876,7 @@ let stylesheet_tests =
     ( "spec page margin descriptor matrix",
       `Quick,
       spec_page_margin_descriptor_matrix );
+    ("spec page context properties", `Quick, spec_page_context_properties);
     ("property rule edges", `Quick, property_rule_edges);
     ("spec property descriptor matrix", `Quick, spec_property_descriptor_matrix);
     ("sheet_item", `Quick, sheet_item_case);
@@ -3095,7 +3159,7 @@ let spec_at_rule_descriptor_matrix () =
       "@view-transition { @media screen { .x { color: red } } }";
       "@position-try --below { @supports (display: grid) { .x { color: red } } \
        }";
-      "@page { @top-center { display: block } }";
+      "@page { @top-center { @media screen { .x { color: red } } } }";
       "@keyframes fade { @media screen { opacity: 1 } }";
       "@media screen;";
       "@media screen and or (width) { .x { color: red } }";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1705,8 +1705,9 @@ let spec_lenient_recovery_page_margin_box () =
   lenient_recover "selector-shaped item in a margin box with a semicolon"
     "@page { @top-center { content: \"x\"; .a { b: c }; margin: 0 } }" recovered
     1;
-  (* [read_page_margin_rule] rejects a box left with no descriptor, so the box
-     goes with its only item; Blink 146 keeps an empty [@top-center { }]. *)
+  (* The box outlives its only item, as it does in Blink 146, and what is left
+     is an empty box: nothing to paint, so it is elided on output like any other
+     block that applies nothing, and the page it empties goes with it. *)
   lenient_recover "selector-shaped item alone in a page margin box"
     "@page { @top-center { .a { b: c } } }" "" 1
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2930,6 +2930,47 @@ let spec_nesting_empty_layer_keeps_block () =
   test_nesting_idempotent ".a { @layer n { } }";
   test_nesting_roundtrip ~expected:"@layer n;" "@layer n { }"
 
+(* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be
+   nested inside of a style rule as well", and its body is then read as nesting
+   content. [@starting-style] is a grouping rule over style rules (CSS
+   Transitions 2 sec. 3.3), and Blink 146 keeps the whole shape. *)
+let spec_nesting_starting_style () =
+  test_nesting_roundtrip ~expected:".a{@starting-style{color:red}}"
+    ".a { @starting-style { color: red } }";
+  test_nesting_roundtrip ~expected:".a{@starting-style{color:red}color:green}"
+    ".a { @starting-style { color: red } color: green }";
+  test_nesting_roundtrip ~expected:".a{@starting-style{& b{color:red}}}"
+    ".a { @starting-style { & b { color: red } } }";
+  test_nesting_idempotent ".a { @starting-style { color: red } color: green }"
+
+(* The same section covers every conditional group rule, not just the three
+   cascade already nested: [@-moz-document] carries style rules, and CSS
+   Conditional 5 sec. 3 and sec. 4 make [@when] and [@else] conditional group
+   rules over a rule list. *)
+let spec_nesting_other_group_rules () =
+  test_nesting_roundtrip ~expected:".a{@-moz-document url-prefix(){color:red}}"
+    ".a { @-moz-document url-prefix() { color: red } }";
+  test_nesting_roundtrip ~expected:".a{@when media(width>0px){color:red}}"
+    ".a { @when media(width > 0px) { color: red } }";
+  test_nesting_roundtrip
+    ~expected:".a{@when media(width>0px){color:red}@else{color:green}}"
+    ".a { @when media(width > 0px) { color: red } @else { color: green } }";
+  test_nesting_idempotent ".a { @-moz-document url-prefix() { color: red } }"
+
+(* A nested group rule's body is nesting content all the way down, so an at-rule
+   inside one is itself a nested group rule. Blink 146 keeps [.a{@layer n{@media
+   screen{color:red}}}] whole. *)
+let spec_nesting_at_rule_inside_nested_group () =
+  test_nesting_roundtrip ~expected:".a{@layer n{@media screen{color:red}}}"
+    ".a { @layer n { @media screen { color: red } } }";
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{@supports(foo:bar){color:red}}}"
+    ".a { @media screen { @supports (foo: bar) { color: red } } }";
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{@starting-style{color:red}}}"
+    ".a { @media screen { @starting-style { color: red } } }";
+  test_nesting_idempotent ".a { @layer n { @media screen { color: red } } }"
+
 (* CSS Nesting 1 sec. 3.4: a run of declarations written after a nested rule is
    wrapped in a nested declarations rule, which keeps its place among the nested
    rules. The spec's own worked example names the hoisted spelling as NOT
@@ -7057,6 +7098,15 @@ let additional_tests =
     ( "spec nesting empty @layer keeps block form",
       `Quick,
       spec_nesting_empty_layer_keeps_block );
+    ( "spec nesting @starting-style holds nesting content",
+      `Quick,
+      spec_nesting_starting_style );
+    ( "spec nesting other group rules hold nesting content",
+      `Quick,
+      spec_nesting_other_group_rules );
+    ( "spec nesting at-rule inside a nested group rule",
+      `Quick,
+      spec_nesting_at_rule_inside_nested_group );
     ( "spec CSS Nesting L1 preserves nested structure",
       `Quick,
       nesting_module_l1_preserves_structure );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1905,6 +1905,223 @@ let spec_block_recovery_warns_once_per_statement () =
      blue } }"
     0
 
+(* CSS Counter Styles 3 sec. 3 gives [@counter-style] a block of descriptor
+   declarations, so CSS Syntax 3 sec. 5.4.3 keeps what that block already
+   yielded when one item fails to parse: a descriptor cascade rejects costs that
+   descriptor, not the [@counter-style] holding it and not the sheet holding
+   that. The discard follows sec. 5.4.4 for a declaration - up to the next
+   top-level [;], a [{}] met on the way counting as one component value of the
+   value being skipped - and sec. 5.4.2 for an at-rule, which ends at its block
+   or its [;]. Blink 146 keeps the rule in every case below. *)
+let spec_lenient_recovery_counter_style_descriptors () =
+  let recovered =
+    "@counter-style c{system:cyclic;symbols:\"a\";suffix:\" \"}"
+  in
+  let shorter = "@counter-style c{system:cyclic;symbols:\"a\"}" in
+  let body rest = "@counter-style c { system: cyclic; " ^ rest ^ " }" in
+  lenient_recover "unknown descriptor first in @counter-style"
+    "@counter-style c { zzz: 1; system: cyclic; symbols: \"a\"; suffix: \" \" }"
+    recovered 1;
+  lenient_recover "unknown descriptor mid-body in @counter-style"
+    (body "zzz: 1; symbols: \"a\"; suffix: \" \"")
+    recovered 1;
+  lenient_recover "unknown descriptor last in @counter-style"
+    (body "symbols: \"a\"; suffix: \" \"; zzz: 1")
+    recovered 1;
+  lenient_recover "bad value for a known @counter-style descriptor"
+    (body "symbols: \"a\"; suffix: !!!")
+    shorter 1;
+  lenient_recover "two curly blocks in a dropped counter-style value"
+    (body "zzz: {1}{2}; symbols: \"a\"; suffix: \" \"")
+    recovered 1;
+  (* A descriptor's value is the whole of its declaration, and no descriptor
+     takes an [!important] flag, so the declaration it follows is invalid rather
+     than the flag alone. *)
+  lenient_recover "an important flag invalidates the counter-style descriptor"
+    (body "symbols: \"a\"; suffix: \" \" !important")
+    shorter 1;
+  lenient_recover "an important flag on an opaque counter-style descriptor"
+    (body "symbols: \"a\"; pad: 2 \"0\" !important; suffix: \" \"")
+    recovered 1;
+  lenient_recover "at-rule in @counter-style ends at its block"
+    (body "@media screen { color: red } symbols: \"a\"; suffix: \" \"")
+    recovered 1;
+  lenient_recover
+    "at-rule with no block in @counter-style ends at its semicolon"
+    (body "@media screen; symbols: \"a\"; suffix: \" \"")
+    recovered 1;
+  lenient_recover "selector-shaped item in @counter-style with a semicolon"
+    (body ".a { b: c }; symbols: \"a\"; suffix: \" \"")
+    recovered 1;
+  (* Sec. 5.4.4 skips a bad declaration to the next top-level [;], and a
+     selector-shaped item has none of its own, so it takes the tail of the body
+     with it. Blink 146 splits the two the same way. *)
+  lenient_recover "selector-shaped item in @counter-style takes the tail"
+    (body "symbols: \"a\"; .a { b: c } suffix: \" \"")
+    shorter 1;
+  lenient_recover "a dropped counter-style descriptor keeps the sheet whole"
+    (".a { color: red } "
+    ^ body "zzz: 1; symbols: \"a\"; suffix: \" \""
+    ^ " .z { color: lime }")
+    (".a{color:red}" ^ recovered ^ ".z{color:#0f0}")
+    1
+
+(* CSS Fonts 4 sec. 12.1 gives [@font-palette-values] a block of descriptor
+   declarations, so one descriptor cascade rejects costs that descriptor alone.
+   A descriptor's value is the whole of its declaration: a trailing [!important]
+   or a stray ident makes the declaration invalid rather than the leftover
+   alone, as it does in Blink 146. *)
+let spec_lenient_recovery_font_palette_descriptors () =
+  let recovered = "@font-palette-values --p{font-family:X;base-palette:1}" in
+  let body rest = "@font-palette-values --p { font-family: X; " ^ rest ^ " }" in
+  lenient_recover "unknown descriptor first in @font-palette-values"
+    "@font-palette-values --p { zzz: 1; font-family: X; base-palette: 1 }"
+    recovered 1;
+  lenient_recover "unknown descriptor mid-body in @font-palette-values"
+    (body "zzz: 1; base-palette: 1")
+    recovered 1;
+  lenient_recover "unknown descriptor last in @font-palette-values"
+    (body "base-palette: 1; zzz: 1")
+    recovered 1;
+  lenient_recover "bad value for a known @font-palette-values descriptor"
+    (body "base-palette: -1; base-palette: 1")
+    recovered 1;
+  lenient_recover "two curly blocks in a dropped font-palette value"
+    (body "zzz: {1}{2}; base-palette: 1")
+    recovered 1;
+  lenient_recover "trailing tokens invalidate the font-palette descriptor"
+    (body "base-palette: 2 bogus; base-palette: 1")
+    recovered 1;
+  lenient_recover "an important flag invalidates the font-palette descriptor"
+    (body "base-palette: 2 !important; base-palette: 1")
+    recovered 1;
+  lenient_recover "at-rule in @font-palette-values ends at its block"
+    (body "@media screen { color: red } base-palette: 1")
+    recovered 1;
+  lenient_recover
+    "at-rule with no block in @font-palette-values ends at its semicolon"
+    (body "@media screen; base-palette: 1")
+    recovered 1;
+  lenient_recover
+    "selector-shaped item in @font-palette-values with a semicolon"
+    (body ".a { b: c }; base-palette: 1")
+    recovered 1;
+  lenient_recover "a dropped font-palette descriptor keeps the sheet whole"
+    (".a { color: red } "
+    ^ body "zzz: 1; base-palette: 1"
+    ^ " .z { color: lime }")
+    (".a{color:red}" ^ recovered ^ ".z{color:#0f0}")
+    1
+
+(* CSS View Transitions 2 sec. 2.4 gives [@view-transition] a block of
+   descriptor declarations, so one descriptor cascade rejects costs that
+   descriptor alone. Blink 146 keeps the rule in every case below. *)
+let spec_lenient_recovery_view_transition_descriptors () =
+  let recovered = "@view-transition{navigation:auto}" in
+  let both = "@view-transition{navigation:auto;types:a}" in
+  lenient_recover "unknown descriptor first in @view-transition"
+    "@view-transition { zzz: 1; navigation: auto }" recovered 1;
+  lenient_recover "unknown descriptor mid-body in @view-transition"
+    "@view-transition { navigation: auto; zzz: 1; types: a }" both 1;
+  lenient_recover "unknown descriptor last in @view-transition"
+    "@view-transition { navigation: auto; zzz: 1 }" recovered 1;
+  lenient_recover "bad value for a known @view-transition descriptor"
+    "@view-transition { navigation: bogus; navigation: auto }" recovered 1;
+  lenient_recover "two curly blocks in a dropped view-transition value"
+    "@view-transition { zzz: {1}{2}; navigation: auto }" recovered 1;
+  lenient_recover "trailing tokens invalidate the view-transition descriptor"
+    "@view-transition { navigation: none bogus; navigation: auto }" recovered 1;
+  lenient_recover "an important flag invalidates the view-transition descriptor"
+    "@view-transition { navigation: none !important; navigation: auto }"
+    recovered 1;
+  lenient_recover "at-rule in @view-transition ends at its block"
+    "@view-transition { @media screen { color: red } navigation: auto }"
+    recovered 1;
+  lenient_recover
+    "at-rule with no block in @view-transition ends at its semicolon"
+    "@view-transition { @media screen; navigation: auto }" recovered 1;
+  lenient_recover "selector-shaped item in @view-transition with a semicolon"
+    "@view-transition { .a { b: c }; navigation: auto }" recovered 1;
+  lenient_recover "a dropped view-transition descriptor keeps the sheet whole"
+    ".a { color: red } @view-transition { zzz: 1; navigation: auto } .z { \
+     color: lime }"
+    (".a{color:red}" ^ recovered ^ ".z{color:#0f0}")
+    1
+
+(* CSS Fonts 4 sec. 11.1 fills an [@font-feature-values] body with feature value
+   blocks, so it is a rule list: CSS Syntax 3 sec. 5.4.2 ends the block cascade
+   rejects at its own [{}] or [;], leaving the blocks written around it in the
+   rule. A [;] with no rule before it is discarded with nothing to validate
+   (sec. 5.4.3), so it costs nothing. *)
+let spec_lenient_recovery_font_feature_values_blocks () =
+  let recovered = "@font-feature-values Xf{@swash{s:1}@ornaments{o:2}}" in
+  let body rest = "@font-feature-values Xf { @swash { s: 1 } " ^ rest ^ " }" in
+  lenient_recover "unknown block first in @font-feature-values"
+    "@font-feature-values Xf { @zzz { a: 1 } @swash { s: 1 } @ornaments { o: 2 \
+     } }"
+    recovered 1;
+  lenient_recover "unknown block mid-body in @font-feature-values"
+    (body "@zzz { a: 1 } @ornaments { o: 2 }")
+    recovered 1;
+  lenient_recover "unknown block last in @font-feature-values"
+    (body "@ornaments { o: 2 } @zzz { a: 1 }")
+    recovered 1;
+  lenient_recover
+    "at-rule with no block in @font-feature-values ends at its semicolon"
+    (body "@zzz; @ornaments { o: 2 }")
+    recovered 1;
+  lenient_recover
+    "selector-shaped item in @font-feature-values ends at its block"
+    (body ".a { b: c } @ornaments { o: 2 }")
+    recovered 1;
+  lenient_recover
+    "declaration in an @font-feature-values body ends at its semicolon"
+    (body "color: red; @ornaments { o: 2 }")
+    recovered 1;
+  lenient_recover "stray semicolon in @font-feature-values costs nothing"
+    (body "; @ornaments { o: 2 }")
+    recovered 0;
+  lenient_recover "leading semicolon in @font-feature-values costs nothing"
+    "@font-feature-values Xf { ; @swash { s: 1 } @ornaments { o: 2 } }"
+    recovered 0;
+  lenient_recover "a dropped feature block keeps the sheet whole"
+    (".a { color: red } "
+    ^ body "@zzz { a: 1 } @ornaments { o: 2 }"
+    ^ " .z { color: lime }")
+    (".a{color:red}" ^ recovered ^ ".z{color:#0f0}")
+    1
+
+(* Each dropped descriptor reports once, and [~strict:true] rejects exactly the
+   inputs the lenient parse warned about. *)
+let spec_descriptor_recovery_warns_once_per_descriptor () =
+  warns_exactly "@counter-style c { system: cyclic; zzz: 1; symbols: \"a\" }" 1;
+  warns_exactly
+    "@counter-style c { system: cyclic; zzz: {1}{2}; symbols: \"a\" }" 1;
+  warns_exactly
+    "@counter-style c { system: cyclic; zzz: 1; yyy: 2; symbols: \"a\" }" 2;
+  warns_exactly "@counter-style c { system: cyclic; symbols: \"a\" }" 0;
+  warns_exactly "@counter-style c { ;; system: cyclic; symbols: \"a\" }" 0;
+  warns_exactly
+    "@font-palette-values --p { font-family: X; zzz: 1; base-palette: 1 }" 1;
+  warns_exactly
+    "@font-palette-values --p { font-family: X; zzz: {1}{2}; base-palette: 1 }"
+    1;
+  warns_exactly
+    "@font-palette-values --p { font-family: X; zzz: 1; yyy: 2; base-palette: \
+     1 }"
+    2;
+  warns_exactly "@font-palette-values --p { font-family: X; base-palette: 1 }" 0;
+  warns_exactly "@view-transition { zzz: 1; navigation: auto }" 1;
+  warns_exactly "@view-transition { zzz: {1}{2}; navigation: auto }" 1;
+  warns_exactly "@view-transition { zzz: 1; yyy: 2; navigation: auto }" 2;
+  warns_exactly "@view-transition { navigation: auto }" 0;
+  warns_exactly "@view-transition { ;; navigation: auto }" 0;
+  warns_exactly "@font-feature-values Xf { @zzz { a: 1 } @swash { s: 1 } }" 1;
+  warns_exactly
+    "@font-feature-values Xf { @zzz { a: 1 } @yyy { b: 2 } @swash { s: 1 } }" 2;
+  warns_exactly "@font-feature-values Xf { @swash { s: 1 } }" 0;
+  warns_exactly "@font-feature-values Xf { ;; @swash { s: 1 } }" 0
+
 let stylesheet_tests =
   [
     (* Core type tests *)
@@ -2019,6 +2236,21 @@ let stylesheet_tests =
     ( "spec block recovery warns once per dropped statement",
       `Quick,
       spec_block_recovery_warns_once_per_statement );
+    ( "spec lenient recovery in a @counter-style body",
+      `Quick,
+      spec_lenient_recovery_counter_style_descriptors );
+    ( "spec lenient recovery in a @font-palette-values body",
+      `Quick,
+      spec_lenient_recovery_font_palette_descriptors );
+    ( "spec lenient recovery in a @view-transition body",
+      `Quick,
+      spec_lenient_recovery_view_transition_descriptors );
+    ( "spec lenient recovery in a @font-feature-values body",
+      `Quick,
+      spec_lenient_recovery_font_feature_values_blocks );
+    ( "spec descriptor recovery warns once per dropped descriptor",
+      `Quick,
+      spec_descriptor_recovery_warns_once_per_descriptor );
   ]
 
 (* Tests for newly added check functions *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2930,6 +2930,22 @@ let spec_nesting_empty_layer_keeps_block () =
   test_nesting_idempotent ".a { @layer n { } }";
   test_nesting_roundtrip ~expected:"@layer n;" "@layer n { }"
 
+(* CSS Nesting 1 sec. 3.4: a run of declarations written after a nested rule is
+   wrapped in a nested declarations rule, which keeps its place among the nested
+   rules. The spec's own worked example names the hoisted spelling as NOT
+   equivalent, and Blink and WebKit both compute the later declaration. *)
+let spec_nesting_declaration_after_nested_rule () =
+  test_nesting_roundtrip ~expected:".a{color:red;& b{color:blue}color:green}"
+    ".a { color: red; & b { color: blue } color: green }";
+  test_nesting_roundtrip
+    ~expected:".a{@supports(color:red){color:blue}color:green}"
+    ".a { @supports (color: red) { color: blue } color: green }";
+  test_nesting_roundtrip ~expected:".a{c:1;& b{d:2}e:3;f:4;& g{h:5}i:6}"
+    ".a { c: 1; & b { d: 2 } e: 3; f: 4; & g { h: 5 } i: 6 }";
+  test_nesting_idempotent ".a { color: red; & b { color: blue } color: green }";
+  test_nesting_idempotent
+    ".a { @media (min-width: 1px) { padding: 2rem } color: green }"
+
 let spec_nesting_selector_edges () =
   assert_minify_and_optimize
     ".card { color: red; &:is(:hover, :focus-visible) { color: blue } &:has(> \
@@ -7032,6 +7048,9 @@ let additional_tests =
     ( "spec nesting selector and conditional edges",
       `Quick,
       spec_nesting_selector_edges );
+    ( "spec nesting declaration after a nested rule keeps its place",
+      `Quick,
+      spec_nesting_declaration_after_nested_rule );
     ( "spec nesting @layer block holds nesting content",
       `Quick,
       spec_nesting_layer_block );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2122,6 +2122,79 @@ let spec_descriptor_recovery_warns_once_per_descriptor () =
   warns_exactly "@font-feature-values Xf { @swash { s: 1 } }" 0;
   warns_exactly "@font-feature-values Xf { ;; @swash { s: 1 } }" 0
 
+(* CSS Animations 1 sec. 3 fills a [@keyframes] body with keyframe rules, so it
+   is a list of rules: an at-rule has no place there, and CSS Syntax 3 sec.
+   5.4.2 ends the one being discarded at its own [{}] block or at its [;],
+   leaving the keyframes written around it in the animation. A [(] or a [[] met
+   in the prelude on the way is a component value of that prelude, not an end.
+   Blink 146 keeps both neighbours in every case below. *)
+let spec_lenient_recovery_keyframes_at_rule () =
+  let recovered = "@keyframes k{0%{color:red}50%{background:#0f0}}" in
+  let body rest = "@keyframes k { " ^ rest ^ " }" in
+  lenient_recover "at-rule first in @keyframes"
+    (body
+       "@media print { to { color: pink } } from { color: red } 50% { \
+        background: lime }")
+    recovered 1;
+  lenient_recover "at-rule mid-body in @keyframes"
+    (body
+       "from { color: red } @media print { to { color: pink } } 50% { \
+        background: lime }")
+    recovered 1;
+  lenient_recover "at-rule last in @keyframes"
+    (body
+       "from { color: red } 50% { background: lime } @media print { to { \
+        color: pink } }")
+    recovered 1;
+  lenient_recover "at-rule with no block in @keyframes ends at its semicolon"
+    (body "from { color: red } @zzz; 50% { background: lime }")
+    recovered 1;
+  lenient_recover "a paren in the prelude of a dropped @keyframes at-rule"
+    (body
+       "from { color: red } @media (min-width: 1px) { to { color: pink } } 50% \
+        { background: lime }")
+    recovered 1;
+  lenient_recover "a bracket in the prelude of a dropped @keyframes at-rule"
+    (body
+       "from { color: red } @zzz [a] { to { color: pink } } 50% { background: \
+        lime }")
+    recovered 1;
+  lenient_recover "two at-rules in @keyframes are dropped one at a time"
+    (body
+       "from { color: red } @media print { a: b } @supports (display: grid) { \
+        b: c } 50% { background: lime }")
+    recovered 2;
+  (* The animation outlives its only item, as it does in Blink 146: what is left
+     is a [@keyframes] that animates nothing. *)
+  lenient_recover "at-rule alone in @keyframes"
+    (body "@media print { to { color: pink } }")
+    "@keyframes k{}" 1;
+  lenient_recover "a dropped at-rule in @keyframes keeps the sheet whole"
+    (".a { color: red } "
+    ^ body
+        "from { color: red } @media print { to { color: pink } } 50% { \
+         background: lime }"
+    ^ " .z { color: lime }")
+    (".a{color:red}" ^ recovered ^ ".z{color:#0f0}")
+    1
+
+(* Each dropped keyframe rule reports once, and [~strict:true] rejects exactly
+   the inputs the lenient parse warned about. *)
+let spec_keyframes_recovery_warns_once_per_rule () =
+  let body rest = "@keyframes k { " ^ rest ^ " }" in
+  warns_exactly
+    (body
+       "from { color: red } @media print { to { color: pink } } 50% { \
+        background: lime }")
+    1;
+  warns_exactly
+    (body
+       "from { color: red } @media print { a: b } @supports (display: grid) { \
+        b: c } 50% { background: lime }")
+    2;
+  warns_exactly (body "from { color: red } @zzz; 50% { background: lime }") 1;
+  warns_exactly (body "from { color: red } 50% { background: lime }") 0
+
 let stylesheet_tests =
   [
     (* Core type tests *)
@@ -2251,6 +2324,12 @@ let stylesheet_tests =
     ( "spec descriptor recovery warns once per dropped descriptor",
       `Quick,
       spec_descriptor_recovery_warns_once_per_descriptor );
+    ( "spec lenient recovery in a @keyframes body",
+      `Quick,
+      spec_lenient_recovery_keyframes_at_rule );
+    ( "spec keyframes recovery warns once per dropped rule",
+      `Quick,
+      spec_keyframes_recovery_warns_once_per_rule );
   ]
 
 (* Tests for newly added check functions *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -3087,6 +3087,23 @@ let spec_nesting_rejects_orphan_else () =
     ~expected:".a{@when media(width>0px){color:red}@else{color:green}}"
     ".a { @when media(width > 0px) { color: red } @else { color: green } }"
 
+(* A top-of-sheet rule is invalid in a style rule too, and Blink 146 drops it
+   the same way. Discarding it ends at the at-rule: [\@import url(x){}] carries
+   a block, and a skip to the next [;] runs past the end of the group rule
+   holding it. *)
+let spec_nesting_rejects_top_of_sheet_at_rules () =
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @charset \"utf-8\"; background: blue }";
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @import url(x.css); background: blue }";
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @import url(x.css) { color: pink } background: blue }";
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @namespace n url(http://e.com); background: blue }";
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{color:red;background:blue}}"
+    ".a { @media screen { color: red; @import url(x.css); background: blue } }"
+
 (* CSS Nesting 1 sec. 3.4: a run of declarations written after a nested rule is
    wrapped in a nested declarations rule, which keeps its place among the nested
    rules. The spec's own worked example names the hoisted spelling as NOT
@@ -7238,6 +7255,9 @@ let additional_tests =
     ( "spec nesting rejects an orphan @else",
       `Quick,
       spec_nesting_rejects_orphan_else );
+    ( "spec nesting rejects a top-of-sheet at-rule",
+      `Quick,
+      spec_nesting_rejects_top_of_sheet_at_rules );
     ( "spec CSS Nesting L1 preserves nested structure",
       `Quick,
       nesting_module_l1_preserves_structure );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2908,6 +2908,28 @@ let test_nesting_check_stylesheet () =
   check_stylesheet ~expected:".a{& .b{& .c{color:red}}}"
     ".a { & .b { & .c { color: red; } } }"
 
+(* A nested @layer holds nesting content: bare declarations belong to the parent
+   selector, exactly as in @media/@supports. Blink and WebKit both read
+   [.a{@layer n{color:red}}] as a layer block wrapping nested declarations. *)
+let spec_nesting_layer_block () =
+  test_nesting_roundtrip ~expected:".a{@layer n{color:red}}"
+    ".a { @layer n { color: red; } }";
+  test_nesting_roundtrip ~expected:".a{@layer{color:red}}"
+    ".a { @layer { color: red; } }";
+  test_nesting_roundtrip ~expected:".a{color:red;@layer n{color:blue}}"
+    ".a { color: red; @layer n { color: blue; } }";
+  test_nesting_roundtrip ~expected:".a{@layer n{& b{color:red}}}"
+    ".a { @layer n { & b { color: red; } } }";
+  test_nesting_idempotent ".a { @layer n { color: red; } }"
+
+(* The statement form [@layer n;] is only a layer-order declaration, which no
+   style rule can contain: both Blink and WebKit drop it. An empty nested layer
+   therefore keeps its block form so the output re-reads. *)
+let spec_nesting_empty_layer_keeps_block () =
+  test_nesting_roundtrip ~expected:".a{@layer n{}}" ".a { @layer n { } }";
+  test_nesting_idempotent ".a { @layer n { } }";
+  test_nesting_roundtrip ~expected:"@layer n;" "@layer n { }"
+
 let spec_nesting_selector_edges () =
   assert_minify_and_optimize
     ".card { color: red; &:is(:hover, :focus-visible) { color: blue } &:has(> \
@@ -7010,6 +7032,12 @@ let additional_tests =
     ( "spec nesting selector and conditional edges",
       `Quick,
       spec_nesting_selector_edges );
+    ( "spec nesting @layer block holds nesting content",
+      `Quick,
+      spec_nesting_layer_block );
+    ( "spec nesting empty @layer keeps block form",
+      `Quick,
+      spec_nesting_empty_layer_keeps_block );
     ( "spec CSS Nesting L1 preserves nested structure",
       `Quick,
       nesting_module_l1_preserves_structure );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1691,6 +1691,76 @@ let spec_property_recovery_warns_once_per_descriptor () =
   warns_exactly (body "inherits: false; initial-value: 0px") 0;
   warns_exactly (body ";; inherits: false; initial-value: 0px") 0
 
+(* A rule that fails to parse inside a grouping at-rule's block ends where CSS
+   Syntax 3 says its kind ends: an at-rule at its block or its [;] (sec. 5.4.2),
+   a qualified rule at its block (sec. 5.4.3). A [(] or a [[] met before that
+   block is a component value of the prelude, so the rule being discarded runs
+   on past it. Stopping there instead would leave the tail of the prelude to be
+   read as a rule of its own, and Blink 146 keeps no such rule: for each input
+   below it reads back only the rule named in the expectation. *)
+let spec_lenient_recovery_block_statements () =
+  lenient_recover "bad @supports prelude in @media ends at its block"
+    "@media screen { @supports (display: grid) bogus { a { color: red } } b { \
+     color: blue } }"
+    "@media screen{b{color:#00f}}" 1;
+  lenient_recover "bad @supports prelude in @layer ends at its block"
+    "@layer base { @supports (display: grid) bogus { a { color: red } } b { \
+     color: blue } }"
+    "@layer base{b{color:#00f}}" 1;
+  lenient_recover "bad @supports prelude in @supports ends at its block"
+    "@supports (color: red) { @supports (display: grid) bogus { a { color: red \
+     } } b { color: blue } }"
+    "b{color:#00f}" 1;
+  lenient_recover "bad @media prelude in @media ends at its block"
+    "@media screen { @media (min-width: 1px) and { a { color: red } } b { \
+     color: blue } }"
+    "@media screen{b{color:#00f}}" 1;
+  lenient_recover "bad @container prelude in @media ends at its block"
+    "@media screen { @container (min-width: 1px) !! { a { color: red } } b { \
+     color: blue } }"
+    "@media screen{b{color:#00f}}" 1;
+  lenient_recover "at-rule with no block in @media ends at its semicolon"
+    "@media screen { @supports (display: grid) bogus; b { color: blue } }"
+    "@media screen{b{color:#00f}}" 1;
+  lenient_recover "bad selector holding a [] in @media ends at its block"
+    "@media screen { a[href=] { color: red } p { color: blue } }"
+    "@media screen{p{color:#00f}}" 1;
+  lenient_recover "bad selector holding a [] in @layer ends at its block"
+    "@layer base { a[href=] { color: red } p { color: blue } }"
+    "@layer base{p{color:#00f}}" 1;
+  lenient_recover "bad selector opening on a () in @media ends at its block"
+    "@media screen { (foo) bar { a { color: red } } b { color: blue } }"
+    "@media screen{b{color:#00f}}" 1;
+  lenient_recover "two bad statements in one block cost only themselves"
+    "@media screen { @supports (display: grid) bogus { a { color: red } } \
+     @container (min-width: 1px) !! { c { color: lime } } b { color: blue } }"
+    "@media screen{b{color:#00f}}" 2
+
+(* Each statement dropped from a grouping at-rule's block reports once: the tail
+   of its prelude is part of what is discarded, not a second rule to be read and
+   rejected on its own. *)
+let spec_block_recovery_warns_once_per_statement () =
+  warns_exactly
+    "@media screen { @supports (display: grid) bogus { a { color: red } } b { \
+     color: blue } }"
+    1;
+  warns_exactly
+    "@media screen { @container (min-width: 1px) !! { a { color: red } } b { \
+     color: blue } }"
+    1;
+  warns_exactly
+    "@media screen { @supports (display: grid) bogus; b { color: blue } }" 1;
+  warns_exactly "@media screen { a[href=] { color: red } p { color: blue } }" 1;
+  warns_exactly "@layer base { a[href=] { color: red } p { color: blue } }" 1;
+  warns_exactly
+    "@media screen { @supports (display: grid) bogus { a { color: red } } \
+     @container (min-width: 1px) !! { c { color: lime } } b { color: blue } }"
+    2;
+  warns_exactly
+    "@media screen { @supports (display: grid) { a { color: red } } b { color: \
+     blue } }"
+    0
+
 let stylesheet_tests =
   [
     (* Core type tests *)
@@ -1796,6 +1866,12 @@ let stylesheet_tests =
     ( "spec property recovery warns once per dropped descriptor",
       `Quick,
       spec_property_recovery_warns_once_per_descriptor );
+    ( "spec lenient recovery in a grouping at-rule block",
+      `Quick,
+      spec_lenient_recovery_block_statements );
+    ( "spec block recovery warns once per dropped statement",
+      `Quick,
+      spec_block_recovery_warns_once_per_statement );
   ]
 
 (* Tests for newly added check functions *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1644,7 +1644,7 @@ let spec_recovery_warns_once_per_declaration () =
     1;
   check ".a { @media screen { color: red; background: blue } }" 0
 
-(* CSS Paged Media 3 sec. 6: "If an error is encountered during the processing
+(* CSS Paged Media 3 sec. 4.1: "If an error is encountered during the processing
    of a declaration block within a page or a margin context, the Rules for
    handling parsing errors apply; that is, valid declarations within the block
    are applied." One bad descriptor therefore costs that descriptor, not the
@@ -1693,7 +1693,7 @@ let spec_lenient_recovery_page_descriptors () =
     "@page { margin: 1cm; @top-center; margin-top: 2cm }" recovered 1
 
 (* A page-margin box holds a declaration block of its own (CSS Paged Media 3
-   sec. 5), so sec. 6 applies inside it too: the descriptors written around a
+   sec. 5), so sec. 4.1 applies inside it too: the descriptors written around a
    bad one stay in the box, and the box stays in the [@page]. *)
 let spec_lenient_recovery_page_margin_box () =
   let recovered = "@page{@top-center{content:\"x\";margin:0}}" in

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1603,6 +1603,94 @@ let spec_page_recovery_warns_once_per_descriptor () =
   warns_exactly "@page { ; margin: 1cm }" 0;
   warns_exactly "@page { @top-center { content: \"x\" } margin: 1cm }" 0
 
+(* CSS Properties and Values API 1 sec. 2: [@property] holds the [syntax],
+   [inherits] and [initial-value] descriptors, and "unknown descriptors are
+   invalid and ignored". Dropping one costs that descriptor, not the
+   registration and not the sheet holding it. The discard follows CSS Syntax 3
+   sec. 5.4.4 for a declaration - up to the next top-level [;], a [{}] met on
+   the way counting as one component value of the value being skipped - and sec.
+   5.4.2 for an at-rule, which ends at its block or its [;]. Blink 146 keeps the
+   registration in every case below. *)
+let spec_lenient_recovery_property_descriptors () =
+  let registered =
+    "@property --x{syntax:\"<length>\";inherits:false;initial-value:0px}"
+  in
+  let body rest = "@property --x { syntax: \"<length>\"; " ^ rest ^ " }" in
+  lenient_recover "unknown descriptor first in @property"
+    "@property --x { zzz: 1; syntax: \"<length>\"; inherits: false; \
+     initial-value: 0px }"
+    registered 1;
+  lenient_recover "unknown descriptor mid-body in @property"
+    (body "zzz: 1; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "unknown descriptor last in @property"
+    (body "inherits: false; initial-value: 0px; zzz: 1")
+    registered 1;
+  lenient_recover "curly block inside a dropped descriptor value"
+    (body "zzz: {1}; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "two curly blocks in a dropped descriptor value are one skip"
+    (body "zzz: {1}{2}; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "tokens after a curly block in a dropped descriptor value"
+    (body "zzz: {1} 2px; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "a run of stray tokens is dropped like a bad descriptor"
+    (body "!!!; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "selector-shaped item in @property is dropped alone"
+    (body ".a { b: c }; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "at-rule in @property ends at its block"
+    (body "@media screen { color: red } inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "at-rule with no block in @property ends at its semicolon"
+    (body "@media screen; inherits: false; initial-value: 0px")
+    registered 1;
+  (* A descriptor's value is its whole declaration, so anything left over makes
+     the declaration invalid rather than the leftover alone. Losing [inherits]
+     that way leaves the registration incomplete, which drops it - as it does in
+     Blink. *)
+  lenient_recover "trailing tokens invalidate the descriptor they follow"
+    (body "inherits: false bogus; initial-value: 0px")
+    "" 1;
+  lenient_recover "an important flag invalidates the descriptor it follows"
+    (body "inherits: false !important; initial-value: 0px")
+    "" 1;
+  lenient_recover "a later descriptor still overrides the one dropped"
+    (body "inherits: false !important; initial-value: 0px; inherits: true")
+    "@property --x{syntax:\"<length>\";inherits:true;initial-value:0px}" 1
+
+(* CSS Syntax 3 sec. 5.4.3 "consume a block's contents" discards a [;] that no
+   declaration precedes rather than validating one, so a stray semicolon in an
+   [@property] body costs nothing. Blink 146 reads all three of these. *)
+let spec_property_skips_stray_semicolons () =
+  let registered =
+    "@property --x{syntax:\"<length>\";inherits:false;initial-value:0px}"
+  in
+  lenient_recover "leading semicolon in @property"
+    "@property --x { ; syntax: \"<length>\"; inherits: false; initial-value: \
+     0px }"
+    registered 0;
+  lenient_recover "doubled semicolon in @property"
+    "@property --x { syntax: \"<length>\";; inherits: false; initial-value: \
+     0px }"
+    registered 0;
+  lenient_recover "trailing semicolon in @property"
+    "@property --x { syntax: \"<length>\"; inherits: false; initial-value: \
+     0px; }"
+    registered 0
+
+(* Each dropped [@property] descriptor reports once, and [~strict:true] rejects
+   exactly the inputs the lenient parse warned about. *)
+let spec_property_recovery_warns_once_per_descriptor () =
+  let body rest = "@property --x { syntax: \"<length>\"; " ^ rest ^ " }" in
+  warns_exactly (body "zzz: 1; inherits: false; initial-value: 0px") 1;
+  warns_exactly (body "zzz: {1}{2}; inherits: false; initial-value: 0px") 1;
+  warns_exactly (body "zzz: 1; yyy: 2; inherits: false; initial-value: 0px") 2;
+  warns_exactly (body "inherits: false; initial-value: 0px") 0;
+  warns_exactly (body ";; inherits: false; initial-value: 0px") 0
+
 let stylesheet_tests =
   [
     (* Core type tests *)
@@ -1699,6 +1787,15 @@ let stylesheet_tests =
     ( "spec page recovery warns once per dropped descriptor",
       `Quick,
       spec_page_recovery_warns_once_per_descriptor );
+    ( "spec lenient recovery in an @property body",
+      `Quick,
+      spec_lenient_recovery_property_descriptors );
+    ( "spec @property skips stray semicolons",
+      `Quick,
+      spec_property_skips_stray_semicolons );
+    ( "spec property recovery warns once per dropped descriptor",
+      `Quick,
+      spec_property_recovery_warns_once_per_descriptor );
   ]
 
 (* Tests for newly added check functions *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1405,6 +1405,98 @@ let spec_lenient_recovery_stylesheets () =
     ".a { color: red; @else { color: green } background: blue }"
     ".a{color:red;background:#00f}" 1
 
+(* CSS Syntax 3 sec. 5.4.4 "consume a declaration" ends an invalid declaration
+   at the next top-level [;], and a [{}] met on the way is one component value
+   of the value being skipped, not a stopping point. A nested at-rule's body is
+   <block-contents> just like a style rule's (CSS Nesting 1 sec. 3.3), so the
+   same recovery applies inside it: Blink 146 drops the one declaration and
+   keeps every neighbour, the enclosing group rule and the rest of the sheet. *)
+let spec_lenient_recovery_nested_at_rule_declarations () =
+  let recovered = ".a{@media screen{color:red;background:#00f}}" in
+  lenient_recover "bad declaration first in a nested at-rule"
+    ".a { @media screen { width: 10; color: red; background: blue } }" recovered
+    1;
+  lenient_recover "bad declaration mid-run in a nested at-rule"
+    ".a { @media screen { color: red; width: 10; background: blue } }" recovered
+    1;
+  lenient_recover "bad declaration last in a nested at-rule"
+    ".a { @media screen { color: red; background: blue; width: 10 } }" recovered
+    1;
+  lenient_recover "sole declaration of a nested at-rule dropped"
+    ".a { @media screen { width: 10 } }" "" 1;
+  lenient_recover "bad declaration in a nested style rule"
+    ".a { & b { color: red; width: 10; margin: 0 } }" ".a b{color:red;margin:0}"
+    1;
+  lenient_recover "bad declaration in a style rule under a nested at-rule"
+    ".a { @media screen { & b { color: red; width: 10; margin: 0 } } }"
+    ".a{@media screen{& b{color:red;margin:0}}}" 1;
+  lenient_recover "bad declaration in a doubly nested at-rule"
+    ".a { @media screen { @container (width > 0px) { color: red; width: 10; \
+     background: blue } } }"
+    ".a{@media screen{@container(width>0px){color:red;background:#00f}}}" 1;
+  lenient_recover "nested at-rule keeps recovery in @layer"
+    ".a { @layer x { color: red; width: 10; background: blue } }"
+    ".a{@layer x{color:red;background:#00f}}" 1;
+  lenient_recover "nested at-rule keeps recovery in @scope"
+    ".a { @scope (.b) { color: red; width: 10; background: blue } }"
+    ".a{@scope(.b){color:red;background:#00f}}" 1;
+  lenient_recover "nested at-rule keeps recovery in @starting-style"
+    ".a { @starting-style { color: red; width: 10; background: blue } }"
+    ".a{@starting-style{color:red;background:#00f}}" 1;
+  (* A [{}] in the dropped value is consumed with it; the run resumes at the [;]
+     after it. An unclosed function has no such [;] - the tokenizer closes it at
+     the end of the block, so it swallows the rest, as Blink does. *)
+  lenient_recover "curly block inside a dropped value is skipped with it"
+    ".a { @media screen { color: red; width: {1}; background: blue } }"
+    recovered 1;
+  lenient_recover "unclosed function swallows the rest of the block"
+    ".a { @media screen { color: red; width: calc(1px; background: blue } }"
+    ".a{@media screen{color:red}}" 1;
+  lenient_recover "a run of stray tokens is dropped like a bad declaration"
+    ".a { @media screen { color: red; !!!; background: blue } }" recovered 1
+
+(* A dropped declaration leaves no gap: the run written around it is one run, as
+   it is in Blink 146, the same way a dropped at-rule leaves one. *)
+let spec_lenient_recovery_nested_declaration_run () =
+  lenient_recover "bad declaration immediately before a nested rule"
+    ".a { @media screen { width: 10; & b { color: red } } }"
+    ".a{@media screen{& b{color:red}}}" 1;
+  lenient_recover "bad declaration immediately after a nested rule"
+    ".a { @media screen { & b { color: red } width: 10; background: blue } }"
+    ".a{@media screen{& b{color:red}background:#00f}}" 1;
+  lenient_recover "dropped declaration does not seal the run before a rule"
+    ".a { @media screen { color: red; width: 10; background: blue; & b { \
+     margin: 0 } } }"
+    ".a{@media screen{color:red;background:#00f;& b{margin:0}}}" 1;
+  lenient_recover "dropped declaration does not seal the run it opened"
+    ".a { @media screen { width: 10; color: red; & b { margin: 0 } background: \
+     blue } }"
+    ".a{@media screen{color:red;& b{margin:0}background:#00f}}" 1
+
+(* Each recovered declaration reports once, and [~strict:true] rejects exactly
+   the inputs the lenient parse warned about. *)
+let spec_recovery_warns_once_per_declaration () =
+  let check css expected =
+    let warnings =
+      match Css.of_string ~strict:false css with
+      | Ok { Css.warnings; _ } -> warnings
+      | Error err ->
+          Alcotest.failf "lenient parse rejected %S: %s" css
+            (Cascade.Error.to_string err)
+    in
+    Alcotest.(check int) ("warnings for " ^ css) expected (List.length warnings);
+    match (Css.of_string ~strict:true css, expected) with
+    | Ok _, 0 | Error _, _ -> ()
+    | Ok _, _ -> Alcotest.failf "strict parse accepted warned-about %S" css
+  in
+  check ".a { @media screen { color: red; width: 10; background: blue } }" 1;
+  check ".a { @media screen { width: 10; height: 20; color: red } }" 2;
+  check
+    ".a { @media screen { @container (width > 0px) { width: 10; color: red } } \
+     }"
+    1;
+  check ".a { @media screen { color: red; background: blue } }" 0
+
 let stylesheet_tests =
   [
     (* Core type tests *)
@@ -1480,6 +1572,15 @@ let stylesheet_tests =
     ( "spec lenient recovery stylesheets",
       `Quick,
       spec_lenient_recovery_stylesheets );
+    ( "spec lenient recovery in a nested at-rule",
+      `Quick,
+      spec_lenient_recovery_nested_at_rule_declarations );
+    ( "spec lenient recovery keeps a nested declaration run whole",
+      `Quick,
+      spec_lenient_recovery_nested_declaration_run );
+    ( "spec recovery warns once per dropped declaration",
+      `Quick,
+      spec_recovery_warns_once_per_declaration );
   ]
 
 (* Tests for newly added check functions *)
@@ -3103,6 +3204,31 @@ let spec_nesting_rejects_top_of_sheet_at_rules () =
   test_nesting_roundtrip
     ~expected:".a{@media screen{color:red;background:blue}}"
     ".a { @media screen { color: red; @import url(x.css); background: blue } }"
+
+(* CSS Nesting 1 sec. 3: a nested rule's prelude may start with an ident, so
+   [h2:where(.b) { ... }] is a rule and not a [h2] declaration, however much its
+   head looks like one. That holds in a nested at-rule's body as much as in a
+   style rule's, and Blink 146 reads both as rules. *)
+let spec_nesting_ident_prelude_in_nested_at_rule () =
+  test_nesting_roundtrip ~expected:".a{@media screen{h2:where(.b){color:red}}}"
+    ".a { @media screen { h2:where(.b) { color: red } } }";
+  test_nesting_idempotent ".a { @media screen { h2:where(.b) { color: red } } }";
+  test_nesting_roundtrip
+    ~expected:
+      ".a{@media screen{color:red;h2:where(.b){margin:0}background:blue}}"
+    ".a { @media screen { color: red; h2:where(.b) { margin: 0 } background: \
+     blue } }"
+
+(* CSS Syntax 3 sec. 5.4.3 "consume a block's contents" drops a [;] that no
+   declaration precedes rather than validating one, so a stray semicolon in a
+   nested at-rule's body costs nothing. Blink 146 keeps both neighbours. *)
+let spec_nesting_skips_stray_semicolons () =
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{color:red;background:blue}}"
+    ".a { @media screen { color: red;; background: blue } }";
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{color:red;background:blue}}"
+    ".a { @media screen { ; color: red; background: blue } }"
 
 (* CSS Nesting 1 sec. 3.4: a run of declarations written after a nested rule is
    wrapped in a nested declarations rule, which keeps its place among the nested
@@ -7258,6 +7384,12 @@ let additional_tests =
     ( "spec nesting rejects a top-of-sheet at-rule",
       `Quick,
       spec_nesting_rejects_top_of_sheet_at_rules );
+    ( "spec nesting reads an ident prelude in a nested at-rule",
+      `Quick,
+      spec_nesting_ident_prelude_in_nested_at_rule );
+    ( "spec nesting skips stray semicolons in a nested at-rule",
+      `Quick,
+      spec_nesting_skips_stray_semicolons );
     ( "spec CSS Nesting L1 preserves nested structure",
       `Quick,
       nesting_module_l1_preserves_structure );


### PR DESCRIPTION
`.a { @layer n { color: red } }` lost its declaration: the layer body was read as a stylesheet block, so the bare declaration parsed as a selector list and was dropped. `@layer` was the last of the at-rules cascade reads as a nesting context still taking a stylesheet block, and both Blink and WebKit expose this one as a layer block wrapping nested declarations.

An empty nested layer also minified to `.a{@layer n;}`, a layer-order declaration that no style rule accepts, so neither a browser nor cascade's own reader took the output back.

An at-rule the reader does not take as a nesting context, `@starting-style` among them, still reads its body as a stylesheet block and loses it; #384 covers those.
