### PR TITLE
css: report a custom property from every conditional group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -140,6 +140,11 @@
 - `Css.inline_vars` unwraps an `@layer` and drops an `@property` registration
   written inside a rule, as it already did at top level. CSS nesting puts both
   there, and a sheet using it came back half cleaned (#373)
+- `Css.custom_props` reports a name declared inside `@scope`,
+  `@starting-style`, `@-moz-document`, `@when`, `@else` or a bare nesting
+  block, as it already did for `@media` and `@supports`. Those declarations
+  reach the matching element just as an `@media` one does, and the names were
+  missing from an answer callers use to decide what a sheet defines (#375)
 - A custom property registered by `@property` is typed wherever it is
   declared, including inside `@keyframes`, `@position-try` and
   `@supports-condition`, so the same registered value canonicalises the same

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -607,50 +607,30 @@ let custom_prop_names decls = List.filter_map custom_declaration_name decls
 let custom_props_of_rules rules =
   List.concat_map (fun (_, decls) -> custom_prop_names decls) rules
 
-let custom_props_nested_block stmt =
-  (* Block-container statements whose children continue the [in_layer] context
-     unchanged: walk into [@media], [@supports], [@container], [@origin] blocks;
-     [@layer] is handled by the caller because it adjusts [in_layer]. *)
-  let extractors =
-    [
-      (fun s -> Option.map snd (as_media s));
-      (fun s -> Option.map snd (as_supports s));
-      (fun s -> Option.map (fun (_, _, c) -> c) (as_container s));
-      (fun s -> Option.map snd (as_origin s));
-    ]
-  in
-  List.find_map (fun f -> f stmt) extractors
-
 let custom_props ?layer sheet =
-  (* Walk the statement tree directly so [in_layer] follows the structure: it is
-     set on entry to a [Layer] node and reset on exit, never persists into
-     sibling statements. *)
+  (* [in_layer] is set on entry to a named [@layer] and differs per branch,
+     never persisting into a sibling, which no accumulator can carry, so this
+     spells its own recursion rather than calling [fold_declarations]. The
+     descent is still [statement_children]'s and the sites are still
+     [element_matching_sites], so this reports a name wherever it is declared
+     for an element and a grouping at-rule added later reaches the walk. *)
   let rec walk in_layer acc stmt =
-    let acc =
-      match as_rule stmt with
-      | Some (_, decls, nested) when in_layer ->
-          let acc = custom_prop_names decls @ acc in
-          List.fold_left (walk in_layer) acc nested
-      | Some (_, _, nested) -> List.fold_left (walk in_layer) acc nested
-      | None -> acc
-    in
-    let descend block in_layer' = List.fold_left (walk in_layer') acc block in
-    match as_layer stmt with
-    | Some (Some name, content) ->
-        let in_layer' =
+    let in_layer =
+      match stmt with
+      | Layer (Some name, _) -> (
           match layer with
           | None -> true
-          | Some target -> in_layer || name = target
-        in
-        descend content in_layer'
-    | Some (None, content) -> descend content in_layer
-    | None -> (
-        match custom_props_nested_block stmt with
-        | Some content -> descend content in_layer
-        | None -> acc)
+          | Some target -> in_layer || name = target)
+      | _ -> in_layer
+    in
+    let acc =
+      if in_layer && at_declaration_site element_matching_sites stmt then
+        custom_prop_names (statement_declarations stmt) @ acc
+      else acc
+    in
+    List.fold_left (walk in_layer) acc (statement_children stmt)
   in
-  let initial = layer = None in
-  List.rev (List.fold_left (walk initial) [] sheet)
+  List.rev (List.fold_left (walk (layer = None)) [] sheet)
 
 let media ~condition statements = Media (condition, statements)
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -533,10 +533,14 @@ val custom_props_of_rules : (Selector.t * declaration list) list -> string list
     declarations in the rules. *)
 
 val custom_props : ?layer:string -> t -> string list
-(** [custom_props ?layer sheet] recursively extracts all custom property names
-    from the stylesheet. If [layer] is provided, only properties from that layer
-    are extracted. Traverses nested [@supports], [@media], and other conditional
-    blocks. *)
+(** [custom_props ?layer sheet] is the name of every custom property [sheet]
+    declares for an element: the ones in a style rule or a bare nesting block,
+    at the top level and inside a conditional group at-rule such as [@media],
+    [@supports], [@container], [@scope] or [@starting-style], however deeply
+    nested. A name declared in [@keyframes], [@page], [@position-try] or
+    [@supports-condition] belongs to another cascade origin or to no element at
+    all (CSS Cascading 5 sec. 6.1) and is not among them. When [layer] is given,
+    the names are those declared inside the [@layer] of that name. *)
 
 val media : condition:Media.t -> statement list -> statement
 (** [media ~condition statements] creates a [@media] statement with the given

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -630,6 +630,89 @@ let public_custom_props_edges () =
     "theme props exclude siblings" false
     (has "--outside" theme_props || has "--space" theme_props)
 
+(* [custom_props] reports a custom property wherever it is declared for an
+   element: every conditional group that holds style rules, and a bare nesting
+   block, whose declarations apply to the enclosing rule's subject. The other
+   declaration sites belong to another cascade origin or to no element at all
+   (CSS Cascading 5 sec. 6.1), so a name declared only there is not declared for
+   the element that reads it. *)
+let public_custom_props_declaration_sites () =
+  let decl = custom_property "--x" "1" in
+  let styled = rule ~selector:(Selector.class_ "a") [ decl ] in
+  let frame : Stylesheet.keyframe =
+    { selector = Keyframe.Positions [ Keyframe.From ]; declarations = [ decl ] }
+  in
+  let margin : Stylesheet.page_margin_rule =
+    { name = "top-left"; descriptors = [ decl ] }
+  in
+  let reported =
+    [
+      ("@media", Stylesheet.Media (Media.of_string "screen", [ styled ]));
+      ( "@supports",
+        Stylesheet.Supports (Supports.of_string "(top: 0)", [ styled ]) );
+      ("@container", Stylesheet.Container (None, None, [ styled ]));
+      ("@layer", Stylesheet.Layer (Some "a", [ styled ]));
+      ("@origin", Stylesheet.Origin (Stylesheet.Author, [ styled ]));
+      ( "@scope",
+        Stylesheet.Scope (Some (Selector.class_ "card"), None, [ styled ]) );
+      ("@starting-style", Stylesheet.Starting_style [ styled ]);
+      ( "@-moz-document",
+        Stylesheet.Moz_document
+          ([ Stylesheet.Url_prefix (Some "https://example.com/") ], [ styled ])
+      );
+      ( "@when",
+        Stylesheet.When
+          (Stylesheet.Media_condition (Media.of_string "screen"), [ styled ]) );
+      ("@else", Stylesheet.Else (None, [ styled ]));
+      ( "nesting block",
+        rule ~selector:(Selector.class_ "a")
+          ~nested:[ Stylesheet.Declarations [ decl ] ]
+          [] );
+    ]
+  in
+  let hidden =
+    [
+      ("@keyframes", Stylesheet.keyframes "k" [ frame ]);
+      ("@page", Stylesheet.Page ([], [ decl ]));
+      ("@page margin box", Stylesheet.Page_with_margins ([], [], [ margin ]));
+      ("@position-try", Stylesheet.Position_try ("--pt", [ decl ]));
+      ("@supports-condition", Stylesheet.Supports_condition ("--sc", [ decl ]));
+    ]
+  in
+  let missing =
+    List.filter_map
+      (fun (label, stmt) ->
+        if custom_props (v [ stmt ]) = [ "--x" ] then None else Some label)
+      reported
+  in
+  if missing <> [] then
+    Alcotest.failf "custom property not reported in: %s"
+      (String.concat ", " missing);
+  let leaked =
+    List.filter_map
+      (fun (label, stmt) ->
+        if custom_props (v [ stmt ]) = [] then None else Some label)
+      hidden
+  in
+  if leaked <> [] then
+    Alcotest.failf "custom property reported outside element matching: %s"
+      (String.concat ", " leaked);
+  (* A layer holds whatever the conditional groups below it hold, so [layer]
+     selects a name declared inside one of them and nothing beside it. *)
+  let layered =
+    v
+      [
+        Stylesheet.Layer
+          (Some "a", [ Stylesheet.Scope (None, None, [ styled ]) ]);
+        rule ~selector:(Selector.class_ "b") [ custom_property "--out" "2" ];
+      ]
+  in
+  Alcotest.(check (list string))
+    "layer selects through @scope" [ "--x" ]
+    (custom_props ~layer:"a" layered);
+  Alcotest.(check (list string))
+    "unlayered sibling still reported" [ "--x"; "--out" ] (custom_props layered)
+
 let public_property_edges () =
   let sheet =
     property ~name:"--gap" Length ~initial_value:(Px 1.) ~inherits:false ()
@@ -1143,6 +1226,8 @@ let suite =
       Alcotest.test_case "public fold edge traversal" `Quick public_fold_edges;
       Alcotest.test_case "public custom property scoping" `Quick
         public_custom_props_edges;
+      Alcotest.test_case "public custom property declaration sites" `Quick
+        public_custom_props_declaration_sites;
       Alcotest.test_case "public property introspection" `Quick
         public_property_edges;
       Alcotest.test_case "public theme guards" `Quick public_theme_edges;


### PR DESCRIPTION
`Css.custom_props` walked a fixed list of at-rules, so a custom property declared inside `@scope`, `@starting-style`, `@-moz-document`, `@when`, `@else` or a bare nesting block was absent from the result; it now reads the declaration sites `Css.eval_stylesheet` resolves the element cascade from, so the two agree on which declarations reach an element.

Stacked on #373.