### PR TITLE
optimize: keep a rule carrying nested content out of the merges

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,6 +61,11 @@
   `-webkit-backdrop-filter`, `-webkit-user-select`, `-webkit-text-size-adjust`
   and `-webkit-print-color-adjust` were dropped against an unprefixed twin no
   shipping Safari understands (#325)
+- A rule that carries nested content stays out of the same-selector merge, the
+  distant `@media` hoist and the shadowed-rule drop. A rule's declarations are
+  only the run written before its first nested statement (CSS Nesting 1
+  sec. 3.4), so a pass reading them as the whole body moves or drops content it
+  never looked at (#376)
 - `--minify` is faster on a stylesheet the optimizer factors heavily, for the
   same output. The rule graph's cycle check, topological order and
   selector-branch index each probed a generic `Hashtbl` once per edge or per

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -146,10 +146,17 @@ let merge_consecutive_media ~optimize_merged_block (stmts : statement list) :
     merge_media_blocks ~optimize_merged_block stmts
   else stmts
 
-(* Leaf rules reachable from a statement, descending into nested blocks. *)
-let rec leaf_rules stmt =
+(* Leaf rules reachable from a statement, descending into nested blocks. A
+   nested declarations run (CSS Nesting 1 sec. 3.4) sets properties on the rule
+   it sits in, so it reads as one more rule with that selector; missed, it is a
+   conflict the hoisting analysis below never sees. *)
+let rec leaf_rules ?parent stmt =
   match stmt with
-  | Rule r -> r :: List.concat_map leaf_rules r.nested
+  | Rule r -> r :: List.concat_map (leaf_rules ~parent:r) r.nested
+  | Declarations decls -> (
+      match parent with
+      | Some (p : rule) -> [ { p with declarations = decls; nested = [] } ]
+      | None -> [])
   | Media (_, b)
   | Supports (_, b)
   | Layer (_, b)
@@ -160,7 +167,7 @@ let rec leaf_rules stmt =
   | Scope (_, _, b)
   | When (_, b)
   | Else (_, b) ->
-      List.concat_map leaf_rules b
+      List.concat_map (fun s -> leaf_rules ?parent s) b
   | _ -> []
 
 (* Two declarations an element computes differently once they swap order: they

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -217,9 +217,12 @@ let drop_shadowed_rules (rules : rule list) : rule list =
   let changed = ref false in
   for i = len - 1 downto 0 do
     let rule = rules_arr.(i) in
+    (* [declarations] is only the run written before the first nested statement
+       (CSS Nesting 1 sec. 3.4), so covering it says nothing about what the rest
+       of the body sets: a rule with nested content stays. *)
     dropped.(i) <-
       (rule.declarations = [] && rule.nested = [])
-      || rule.declarations <> []
+      || rule.nested = [] && rule.declarations <> []
          && List.for_all
               (Cover.covered later_by_selector rule.Stylesheet_intf.selector)
               rule.declarations;

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -100,23 +100,31 @@ end)
    rule's declarations ahead of any nested block an earlier one carries. That
    only matters for a property the nested block also sets, so a rule with nested
    children can still take part as long as those children and the declarations
-   that would move past them are disjoint. *)
+   that would move past them are disjoint.
+
+   Read through the exhaustive statement walks: every nested statement sets
+   properties, a nested declarations run as much as a nested style rule, and one
+   this walk cannot see is one the merge would happily hoist past. *)
 let rec nested_property_keys acc (stmts : statement list) =
   List.fold_left
     (fun acc stmt ->
-      match stmt with
-      | Rule r ->
-          let acc =
-            List.fold_left
-              (fun acc d -> Prop_set.add (Declaration.property_key d) acc)
-              acc r.declarations
-          in
-          nested_property_keys acc r.nested
-      | _ -> acc)
+      let acc =
+        List.fold_left
+          (fun acc d -> Prop_set.add (Declaration.property_key d) acc)
+          acc
+          (statement_declarations stmt)
+      in
+      nested_property_keys acc (statement_children stmt))
     acc stmts
 
+(* CSS Nesting 1 sec. 3.4 puts a declaration written after a nested rule behind
+   it, so a rule's body is not the run of declarations [declarations] holds:
+   merging a later same-selector rule into it moves that rule's declarations
+   ahead of everything nested. [nested_merge_is_safe] below decides that per
+   property; until it reads the whole body, keep a rule carrying nested content
+   out of the merge entirely, as [rule_eligible] already does. *)
 let same_selector_eligible (r : rule) =
-  r.merge_key = Option.None
+  r.nested = [] && r.merge_key = Option.None
   && (not (contains_vendor_pseudo_element r.selector))
   && not (List.exists Shorthand.is_all_declaration r.declarations)
 

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2031,9 +2031,10 @@ let c61_adjacent_later_dedup () =
     "adjacent same-selector rules merge and dedupe by source order"
     ".box{display:flex;color:#00f}" output
 
-(* A rule that carries nested children can still absorb a later same-selector
-   rule: the merge moves the later declarations ahead of the nested block, which
-   is only observable for a property the nested block also sets. *)
+(* A rule's [declarations] is the run written before its first nested statement
+   (CSS Nesting 1 sec. 3.4), not its whole body, so absorbing a later
+   same-selector rule moves that rule's declarations ahead of body content the
+   merge never looked at. A rule carrying nested children stays out. *)
 let same_selector_merge_past_nested () =
   let of_string css =
     match Css.of_string css with
@@ -2046,11 +2047,11 @@ let same_selector_merge_past_nested () =
     |> String.trim
   in
   Alcotest.(check string)
-    "disjoint nested children do not block the merge"
-    ".a{color:red;padding:1rem;&:hover{background:#00f}}"
+    "nested children keep the rule out of the merge"
+    ".a{color:red;&:hover{background:#00f}}.a{padding:1rem}"
     (canon ".a{color:red;&:hover{background:blue}}.a{padding:1rem}");
   Alcotest.(check string)
-    "a nested child setting the same property does block it"
+    "a nested child setting the same property keeps its place"
     ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}"
     (canon ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}")
 


### PR DESCRIPTION
A rule's `declarations` is only the run written before its first nested statement (CSS Nesting 1 sec. 3.4), so the same-selector merge, the distant `@media` hoist and the shadowed-rule drop each reasoned about a rule they had only half read; none of them can miscompile on the AST the reader builds today, but all three would once a declaration written after a nested rule stays where it was written.

This is a deliberate temporary conservative loss: a rule carrying nested content no longer merges at all, which `same_selector_merge_past_nested` used to pin, and a later PR re-enables the merge once the passes know where a nested declarations run sits. Stacked on #374.