### PR TITLE
selector: keep a type selector inside the wrapper that carries it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -327,6 +327,11 @@
   footprint, so the optimizer read the pair as commutative: two rules writing
   the colour merged across `column-rule: 1px solid red`, and an element
   matching both painted the rule red (#447)
+- A single-argument `:is()` and a double `:not()` keep their wrapper around a
+  type or universal selector. Selectors 4 sec. 3.5 puts such a selector first
+  in its compound, and both rewrites are node-local, so splicing fused the two
+  names: `.a:is(code)` printed `.acode` and `:is(.a *):is(code)` printed
+  `:is(.a *)code`, which browsers drop (#377)
 - A single-argument `:is()` keeps its wrapper after a pseudo-element that
   cannot take its argument, so `.a::before:is(.b)` minifies to
   `.a:before:is(.b)` rather than the `.a:before.b` that cascade's own reader,

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2117,6 +2117,16 @@ let drop_redundant_universal = function
       in
       if kept = [] then components else kept
 
+(* CSS Selectors 4 3.5: a compound selector that "contains a type selector or
+   universal selector [...] must come first in the sequence". So a rewrite that
+   splices a wrapped selector into the surrounding compound has to leave a
+   type-bearing argument wrapped: spliced, the two names fuse and [.a:is(code)]
+   reads as [.acode], a class nobody wrote. *)
+let rec carries_type_selector = function
+  | Element _ | Universal _ -> true
+  | Compound parts -> List.exists carries_type_selector parts
+  | _ -> false
+
 let rec pp_nth_func ctx name expr of_sel =
   Pp.char ctx ':';
   Pp.string ctx name;
@@ -2318,9 +2328,12 @@ and pp : t Pp.t =
       pp ctx Any_link
   | Is selectors -> func ctx "is" sels selectors
   | Where selectors -> func ctx "where" sels selectors
-  | Not [ Not [ inner ] ] when Pp.minified ctx ->
+  | Not [ Not [ inner ] ]
+    when Pp.minified ctx && not (carries_type_selector inner) ->
       (* CSS Selectors 4 sec. 4.3: double negation [:not(:not(X))] is
-         spec-equivalent to [X] (and shorter under minify). *)
+         spec-equivalent to [X] (and shorter under minify). [X] is spliced into
+         whatever compound holds the [:not()], so a type-bearing one stays
+         wrapped (Selectors 4 3.5, [carries_type_selector]). *)
       pp ctx inner
   | Not [ Enabled ] when Pp.minified ctx -> pseudo ctx "disabled"
   | Not [ Disabled ] when Pp.minified ctx -> pseudo ctx "enabled"
@@ -2482,6 +2495,24 @@ let rewrap_pseudo_compound components =
   if List.exists is_pseudo_element components then loop None components
   else components
 
+(* CSS Selectors 4 sec. 4.2: a single-argument [:is(s)] matches the same
+   elements as [s] with the same specificity, so it reduces to [s]. Sound only
+   when [s] is a single compound: a combinator ([Combined] / [Relative]) or a
+   [List] makes [:is()] a grouping boundary that cannot be spliced into the
+   surrounding compound. A type or universal selector cannot be spliced either:
+   this rewrite is node-local and cannot see whether the [:is()] heads its
+   compound, and only there may such a selector stand
+   ([carries_type_selector]). *)
+let canonicalize_is node selectors =
+  let sorted = canonicalize_unordered_list selectors in
+  match sorted with
+  | [ single ]
+    when match single with
+         | Combined _ | Relative _ | List _ -> false
+         | _ -> not (carries_type_selector single) ->
+      single
+  | _ -> if list_same sorted selectors then node else Is sorted
+
 (* Canonicalise so selectors denoting the same thing are structurally equal:
    drop the implied [*] from a multi-part compound ([*.foo] -> [.foo]), collapse
    a one-part compound, and dedup/sort selector-list alternatives by printed
@@ -2506,20 +2537,7 @@ let canonicalize sel =
               else Compound components')
       | List selectors -> canon (fun xs -> List xs) selectors
       | Where selectors -> canon (fun xs -> Where xs) selectors
-      | Is selectors -> (
-          (* CSS Selectors 4 sec. 4.2: a single-argument [:is(s)] matches the
-             same elements as [s] with the same specificity, so it reduces to
-             [s]. Sound only when [s] is a single compound: a combinator
-             ([Combined] / [Relative]) or a [List] makes [:is()] a grouping
-             boundary that cannot be spliced into the surrounding compound. *)
-          let sorted = canonicalize_unordered_list selectors in
-          match sorted with
-          | [ single ]
-            when match single with
-                 | Combined _ | Relative _ | List _ -> false
-                 | _ -> true ->
-              single
-          | _ -> if list_same sorted selectors then node else Is sorted)
+      | Is selectors -> canonicalize_is node selectors
       | Not selectors -> canon (fun xs -> Not xs) selectors
       | Has selectors -> canon (fun xs -> Has xs) selectors
       | Moz_any_call selectors -> canon (fun xs -> Moz_any_call xs) selectors

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5999,6 +5999,55 @@ let s417_is_unwrap () =
     (normalize ".x .a.b { color: red }")
     (normalize ".x :is(.a):is(.b) { color: red }")
 
+(* CSS Selectors L4 section 4.2 (compound selector): "if it contains a type
+   selector or universal selector, that selector must come first". So a
+   single-argument [:is(<type>)] unwraps only into a compound it leads: spliced
+   anywhere else the two names fuse, and [.a:is(code)] turns into [.acode],
+   which matches a class nobody wrote. Same for [:not(:not(<type>))]. *)
+let s442_compound_type_first () =
+  let normalize css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> minify parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  Alcotest.(check string)
+    ".a:is(code) keeps its wrapper" ".x .a:is(code){color:red}"
+    (normalize ".x .a:is(code) { color: red }");
+  Alcotest.(check string)
+    "div:is(code) keeps its wrapper" ".x div:is(code){color:red}"
+    (normalize ".x div:is(code) { color: red }");
+  Alcotest.(check string)
+    ":is(<ancestor> *):is(code) keeps its wrapper"
+    ":is(.a *):is(code){color:red}"
+    (normalize ":is(.a *):is(code) { color: red }");
+  Alcotest.(check string)
+    ":is(code.b) keeps its wrapper" ".a:is(code.b){color:red}"
+    (normalize ".a:is(code.b) { color: red }");
+  Alcotest.(check string)
+    "a namespaced universal keeps its wrapper" ".a:is(svg|*){color:red}"
+    (normalize ".a:is(svg|*) { color: red }");
+  Alcotest.(check string)
+    ":not(:not(code)) keeps its wrappers" ".a:not(:not(code)){color:red}"
+    (normalize ".a:not(:not(code)) { color: red }");
+  (* Leading its compound the type selector would be where it belongs, and
+     unwrapping there is sound - but the rewrite is node-local, so it declines
+     rather than guess at a position it cannot see. *)
+  Alcotest.(check string)
+    ":is(code) leading a compound keeps its wrapper too"
+    ".x :is(code).a{color:red}"
+    (normalize ".x :is(code).a { color: red }");
+  Alcotest.(check string)
+    ":is(*) keeps its wrapper" ".a:is(*){color:red}"
+    (normalize ".a:is(*) { color: red }");
+  (* An argument with no type selector is spliceable wherever the [:is()]
+     stands, so those keep unwrapping. *)
+  Alcotest.(check string)
+    ":is(.b) still unwraps" ".a.b{color:red}"
+    (normalize ".a:is(.b) { color: red }");
+  Alcotest.(check string)
+    ":not(:not(.b)) still folds" ".a.b{color:red}"
+    (normalize ".a:not(:not(.b)) { color: red }")
+
 (* CSS Selectors L4 section 6.1: attribute compound selectors drop quotes per
    attribute when the value is a valid identifier. *)
 let s462_compound_attr () =
@@ -8661,6 +8710,9 @@ let additional_tests =
       `Quick,
       v4107_minmax_reduction );
     ("spec selectors 4 17 :is single-argument unwrap", `Quick, s417_is_unwrap);
+    ( "spec selectors 4 4.2 compound type selector first",
+      `Quick,
+      s442_compound_type_first );
     ( "spec selectors 4 6.2 compound attribute canonicalization",
       `Quick,
       s462_compound_attr );


### PR DESCRIPTION
Selectors 4 sec. 3.5 puts a type or universal selector first in its compound, but the single-argument `:is()` unwrap and the double-negation fold both splice their argument into whatever compound holds them, so `.a:is(code)` printed `.acode` and `:is(.a *):is(code)` printed `:is(.a *)code`, which browsers reject, dropping the rule. tailwindcss.com carries the second shape throughout its arbitrary-variant utilities, and minify silently lost `white-space`, `padding` and `width` on every code block.

The unwrap now declines a type-bearing argument outright rather than guess at a position it cannot see, which gives up the sound `:is(code)` -> `code` case; no file in `test/interop` and none of the four fetched pages exercises it.