### PR TITLE
supports: a vendor prefix is not evidence that a browser supports it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -332,6 +332,11 @@
   in its compound, and both rewrites are node-local, so splicing fused the two
   names: `.a:is(code)` printed `.acode` and `:is(.a *):is(code)` printed
   `:is(.a *)code`, which browsers drop (#377)
+- A feature query on a vendor-prefixed property keeps its guard. The
+  web-features dataset behind the Baseline facts tracks unprefixed features
+  only, so a prefix is evidence of nothing and folding it to true flipped
+  Tailwind's legacy-browser reset on in Chrome, where
+  `@supports (-webkit-hyphens: none)` is false (#378)
 - A single-argument `:is()` keeps its wrapper after a pseudo-element that
   cannot take its argument, so `.a::before:is(.b)` minifies to
   `.a:before:is(.b)` rather than the `.a:before.b` that cascade's own reader,

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -558,16 +558,26 @@ let value_uses_greenfield value =
     (fun fn -> contains_sub ~needle:(fn ^ "(") v)
     Baseline.greenfield_value_functions
 
+(* A vendor prefix is the author saying support is not universal, and the
+   web-features dataset behind {!Baseline} tracks unprefixed features only, so
+   there is no fact either way and the guard stays. A custom property is not
+   that: CSS Conditional 4 sec. 2.5 makes every custom property declaration
+   supported, so [--x] is left to the Baseline path. *)
+let is_vendor_prefixed name =
+  String.length name > 1 && name.[0] = '-' && name.[1] <> '-'
+
 let is_greenfield_feature decl =
-  is_greenfield_property (Declaration.property_name decl)
+  let name = Declaration.property_name decl in
+  is_greenfield_property name
+  || is_vendor_prefixed name
   || value_uses_greenfield (Declaration.string_of_value ~minify:true decl)
 
 (* Baseline classification of one declaration feature. A [(prop: value)] test
    whose property and value Cascade recognizes as Baseline is treated as
-   Baseline-true; a not-yet-Baseline property or a greenfield value function
-   keeps its guard ([`Unknown]). Properties Cascade does not model parse as
-   [Unknown_property] and stay unknown, as do empty/unsupported/vendor-flag
-   features. *)
+   Baseline-true; a not-yet-Baseline property, a vendor-prefixed one or a
+   greenfield value function keeps its guard ([`Unknown]). Properties Cascade
+   does not model parse as [Unknown_property] and stay unknown, as do
+   empty/unsupported/vendor-flag features. *)
 let declaration_feature_truth = function
   | Declaration (Declaration.Declaration { property = Unknown_property _; _ })
     ->

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6661,6 +6661,48 @@ let fidelity_color_space_preserved () =
 
 (* {2 @supports (CSS Conditional L4 sec. 2)} *)
 
+(* CSS Conditional 4 sec. 2.5: a feature query asks the browser whether it
+   supports a declaration, and a vendor prefix is the author saying support is
+   not universal. The web-features dataset behind {!Baseline} tracks unprefixed
+   features only, so a prefixed property has no fact either way and its guard is
+   load-bearing: Chrome answers false to both [(-webkit-hyphens: none)] and
+   [(-moz-orient: inline)], which no unprefixed baseline predicts. A custom
+   property is a different case - sec. 2.5 makes every custom property
+   declaration supported - so [(--x: y)] still elides. *)
+let conditional4_2_vendor_prefixed_guard_kept () =
+  let normalize css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed ->
+        parsed.stylesheet |> Css.optimize |> Css.to_string ~minify:true
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  Alcotest.(check string)
+    "a prefixed feature query keeps its guard"
+    "@supports(-webkit-hyphens:none){.x{color:red}}"
+    (normalize "@supports (-webkit-hyphens: none) { .x { color: red } }");
+  Alcotest.(check string)
+    "a negated prefixed feature query keeps its rule"
+    "@supports not (-webkit-hyphens:none){.x{color:red}}"
+    (normalize "@supports not (-webkit-hyphens: none) { .x { color: red } }");
+  Alcotest.(check string)
+    "a prefixed property with a prefixed value keeps its guard"
+    "@supports(-webkit-appearance:-apple-pay-button){.x{color:red}}"
+    (normalize
+       "@supports (-webkit-appearance: -apple-pay-button) { .x { color: red } }");
+  Alcotest.(check bool)
+    "a prefixed conjunct survives a mixed condition" true
+    (Astring.String.is_infix ~affix:"-webkit-hyphens"
+       (normalize
+          "@supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) \
+           { .x { color: red } }"));
+  Alcotest.(check string)
+    "a custom property declaration is supported, so its guard goes"
+    ".x{color:red}"
+    (normalize "@supports (--x: y) { .x { color: red } }");
+  Alcotest.(check string)
+    "an unprefixed baseline guard still goes" ".x{display:grid}"
+    (normalize "@supports (display: grid) { .x { display: grid } }")
+
 (* CSS Conditional Rules Module Level 4, section 2 (The @supports rule): the
    rule body parses as a rule list (like a stylesheet) and round- trips
    preserved. The supports-condition grammar accepts declarations, [not], [and],
@@ -8779,6 +8821,9 @@ let additional_tests =
     ( "spec conditional 4 2 supports preserved",
       `Quick,
       conditional4_2_supports_preserved );
+    ( "spec conditional 4 2 vendor-prefixed guard kept",
+      `Quick,
+      conditional4_2_vendor_prefixed_guard_kept );
     ( "spec conditional 4 2 supports invalid (negative)",
       `Quick,
       conditional4_2_supports_invalid_rejected );


### PR DESCRIPTION
The web-features dataset behind the Baseline facts tracks unprefixed features only, so a prefixed property has no fact either way, but `@supports (-webkit-hyphens: none)` folded to true and Chrome answers false to it. On tailwindcss.com that turned on the legacy-browser custom-property reset the page gates to other engines; the values it sets are guaranteed-invalid in Chrome, so no computed style moves, which is why nothing caught it.

Stacked on #377.