### PR TITLE
test/inline: gate a real page on minify, not just apply

### DIFF
--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -85,3 +85,14 @@ by `fetch.sh`, and they gate the run in the same way: a surviving difference is
 a defect in a transform, whichever page found it. A failure that starts the day
 a site is redesigned is still a defect, but re-run `fetch.sh` before reading it
 as a regression in the working tree.
+
+Every page runs both transforms. `apply` and `--minify` fail differently, and a
+real page carries selectors, feature queries and at-rules no fixture does, so a
+minify defect only a real page reaches stays unmeasured until the leg exists.
+The four pages cost about 25 seconds between them.
+
+Positions are how the two element lists line up, so the comparison runs only as
+far as the first index whose tags disagree. Past a dropped or added element
+every later index compares two different elements, and one structural change
+would report as thousands: `xtest.js` names the index instead and says how many
+elements it did not compare.

--- a/test/inline/minify_page.js
+++ b/test/inline/minify_page.js
@@ -14,7 +14,10 @@ if (!CASCADE) {
 const src = fs.readFileSync(process.argv[2], 'utf8');
 const flags = process.argv.slice(3).join(' ');
 const out = src.replace(/<style([^>]*)>([\s\S]*?)<\/style>/gi, (_m, attrs, css) => {
-  const min = execSync(`"${CASCADE}" fmt --minify ${flags} -`, { input: css, encoding: 'utf8' });
+  // maxBuffer: a real page's <style> runs to megabytes, and the default 1MB
+  // makes execSync throw rather than return the minified sheet.
+  const min = execSync(`"${CASCADE}" fmt --minify ${flags} -`,
+    { input: css, encoding: 'utf8', maxBuffer: 1e9 });
   return `<style${attrs}>${min.trim()}</style>`;
 });
 process.stdout.write(out);

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -166,12 +166,20 @@ done
 # transform, whichever page happened to find it. One that appears the day a
 # site is redesigned is still a defect, but re-run fetch.sh before reading it
 # as a regression in the working tree, and check the hash in the label first.
+#
+# Both transforms run: `apply` and `--minify` fail differently, and a real page
+# carries selectors and feature queries no fixture does, so a minify defect
+# that only a real page reaches goes unmeasured until the leg exists.
 for f in "$dir"/pages/*.html; do
   [ -e "$f" ] || continue
   page="$(basename "$f")@$(sha "$f")"
   tmp=$(mktemp)
   label="real $page minimal"
   if transform "$label" "$tmp" "$CASCADE" apply --minimal "$f"; then
+    check "$label" "$f" "$tmp"
+  fi
+  label="real $page minify"
+  if transform "$label" "$tmp" node "$dir/minify_page.js" "$f"; then
     check "$label" "$f" "$tmp"
   fi
   rm -f "$tmp"

--- a/test/inline/xtest.js
+++ b/test/inline/xtest.js
@@ -36,7 +36,19 @@ function computed(path){
   return JSON.parse(Buffer.from(m[1],'base64').toString('utf8'));
 }
 const a = computed(process.argv[2]), b = computed(process.argv[3]);
-const n = Math.min(a.length,b.length);
+// The two lists line up by position, so the comparison is only meaningful up to
+// the first place the trees disagree. Past a dropped or added element every
+// later index compares two different elements, and one structural change
+// reports as thousands, which makes the total say nothing about the transform.
+// Stop there and name the position instead.
+let n = Math.min(a.length,b.length), split = null;
+for (let i=0;i<n;i++) if (a[i]._tag !== b[i]._tag) {
+  split = 'element trees diverge at index '+i+': '+a[i]._tag+' vs '+b[i]._tag+
+    ' ('+(Math.max(a.length,b.length)-i)+' element(s) past it not compared)';
+  n = i; break;
+}
+if (split === null && a.length !== b.length)
+  split = 'element count '+a.length+' vs '+b.length;
 // Candidate differences: any property whose getComputedStyle string differs.
 const cand = [];
 for (let i=0;i<n;i++) for (const p in a[i]) if (a[i][p]!==b[i][p])
@@ -52,7 +64,7 @@ if (CANON && cand.length) {
   lines = execSync(`"${CANON}" < "${tmp}"`,{encoding:'utf8',maxBuffer:1e8}).split('\n').filter(Boolean);
 }
 const diffs = lines.map(l=>{const f=l.split('\t');return '['+f[0]+' '+f[1]+'] '+f[2]+': "'+f[3]+'" vs "'+f[4]+'"';});
-if (a.length !== b.length) diffs.unshift('element count '+a.length+' vs '+b.length);
+if (split !== null) diffs.unshift(split);
 // Say which comparison produced the count. Without the filter every
 // equivalent spelling counts, so the total is inflated and is not the number
 // run.sh reports: label it loudly rather than let it pass for the real one.


### PR DESCRIPTION
The real-page leg only ran `apply --minimal`, so `cascade --minify` on a real page was measured by hand and gated by nothing while `apply` took five fixes in a day; the two `:is()` and `@supports` defects underneath this stack were both found that way and neither fixture reaches them. The four pages cost about 25 seconds.

It also stops one structural change reporting as thousands: the element lists line up by position, so the comparison now runs to the first index whose tags disagree and names that index instead of comparing two different elements at every later one. Stacked on #378, and it fails today on `ocaml.html` and `tailwind.html`.