### PR TITLE
css: a declaration after a nested rule keeps its place

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,12 @@
   body as a selector list and dropping it. CSS Nesting 1 sec. 3.1 admits nested
   at-rules, and `@layer` was the only one still read as a stylesheet block
   (#374)
+- A declaration written after a nested rule keeps its place instead of being
+  hoisted to the top of the block. CSS Nesting 1 sec. 3.4 wraps such a run in a
+  nested declarations rule, and its worked example names the hoisted spelling as
+  not equivalent, so `.a { @supports (color: red) { color: blue } color: green }`
+  now computes green as Blink and WebKit do, where cascade printed a sheet that
+  computed blue (#380)
 
 ### Minification
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -162,12 +162,17 @@ val statement_selector : statement -> Selector.t option
 
 val statement_declarations : statement -> declaration list option
 (** [statement_declarations stmt] returns [Some declarations] if the statement
-    is a rule, {!constructor-None} otherwise. *)
+    is a rule, {!constructor-None} otherwise. The declarations are the run
+    written before the rule's first nested statement, not its whole body: CSS
+    Nesting 1 sec. 3.4 keeps a later run in [nested], where it holds its place
+    among the nested rules. *)
 
 val as_rule :
   statement -> (Selector.t * declaration list * statement list) option
 (** [as_rule stmt] returns [Some (selector, declarations, nested)] if the
-    statement is a rule, {!constructor-None} otherwise. *)
+    statement is a rule, {!constructor-None} otherwise. The declarations are the
+    run written before the first nested statement; a run written after one is a
+    nested declarations rule inside [nested], at the position it was written. *)
 
 val as_layer : statement -> (string option * statement list) option
 (** [as_layer stmt] returns [Some (name, statements)] if the statement is a

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3114,6 +3114,15 @@ let item_opens_block inner =
   Cursor.restore inner start;
   found
 
+(* CSS Nesting 1 sec. 3.4 wraps a run of declarations written after a nested
+   statement in a nested declarations rule, so it keeps its place among them.
+   The run a rule body is reading is the head of its [nested] accumulator and
+   holds its declarations reversed, like [decls]; sealing it puts them back in
+   source order. *)
+let seal_declaration_run = function
+  | Declarations run :: rest -> Declarations (List.rev run) :: rest
+  | nested -> nested
+
 let rec read_statement (r : Cursor.t) : statement =
   Cursor.ws r;
   let table : (string * (Cursor.t -> statement)) list =
@@ -3497,10 +3506,10 @@ and read_nested_at_within_rule (r : Cursor.t) (selector : Selector.t) :
 
 and read_rule_item selector inner decls nested =
   match Cursor.peek inner with
-  | None -> `Done (List.rev decls, List.rev nested)
+  | None -> `Done (List.rev decls, List.rev (seal_declaration_run nested))
   | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
       let stmt = read_nested_at_within_rule inner selector in
-      `Continue (decls, stmt :: nested)
+      `Continue (decls, stmt :: seal_declaration_run nested)
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       Cursor.skip inner;
       `Continue (decls, nested)
@@ -3509,10 +3518,16 @@ and read_rule_item selector inner decls nested =
 and read_rule_decl_or_nested selector inner decls nested =
   let start = Cursor.save inner in
   match Declaration.read_declaration inner with
-  | Some d ->
+  | Some d -> (
       Cursor.ws inner;
       if Cursor.peek_semicolon inner then Cursor.skip inner;
-      `Continue (d :: decls, nested)
+      (* Only the run written before the first nested statement is the rule's
+         own; a later one joins the block it follows. *)
+      match nested with
+      | [] -> `Continue (d :: decls, nested)
+      | Declarations run :: rest ->
+          `Continue (decls, Declarations (d :: run) :: rest)
+      | _ -> `Continue (decls, Declarations [ d ] :: nested))
   | None -> read_nested_rule_or_done selector inner decls nested
   (* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so
      [h2:where(...) { ... }] reads as a declaration up to the [{]. Rewind and
@@ -3524,11 +3539,12 @@ and read_rule_decl_or_nested selector inner decls nested =
       read_nested_rule_or_done selector inner decls nested
 
 and read_nested_rule_or_done selector inner decls nested =
-  if Cursor.is_done inner then `Done (List.rev decls, List.rev nested)
+  if Cursor.is_done inner then
+    `Done (List.rev decls, List.rev (seal_declaration_run nested))
   else
     let nr = read_rule ~nested:true inner in
     validate_nested_rule_selector inner selector nr.selector;
-    `Continue (decls, Rule nr :: nested)
+    `Continue (decls, Rule nr :: seal_declaration_run nested)
 
 and read_rule_body selector inner =
   let rec loop decls nested =

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -212,7 +212,11 @@ val selector : rule -> Selector.t
 (** [selector rule] returns the selector of a rule. *)
 
 val declarations : rule -> declaration list
-(** [declarations rule] returns the declarations of a rule. *)
+(** [declarations rule] returns the run of declarations written before the
+    rule's first nested statement. CSS Nesting 1 sec. 3.4 wraps a run written
+    after one in a nested declarations rule, so it stays in {!nested} at the
+    position it was written; this is the whole body only for a rule that nests
+    nothing. *)
 
 val nested : rule -> statement list
 (** [nested rule] returns the nested statements of a rule. *)

--- a/test/inline/fixtures/nested_order.html
+++ b/test/inline/fixtures/nested_order.html
@@ -1,0 +1,12 @@
+<!doctype html><html><head><style>
+  .n1 { color: red; & b { width: 9px } color: green }
+  .n2 { @media (min-width: 1px) { color: blue } color: green }
+  .n3 { @supports (color: red) { color: blue } color: green }
+  .n4 { color: red; & b { width: 9px } color: blue }
+  .n4 { color: green }
+</style></head><body>
+<div class="n1">a<b>x</b></div>
+<div class="n2">b</div>
+<div class="n3">c</div>
+<div class="n4">d<b>y</b></div>
+</body></html>

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -54,9 +54,10 @@ let test_nested_rule_starting_with_ident () =
   check ".a{p:hover{color:red}}" ".a{p:hover{color:red}}";
   (* minify canonicalises the legacy one-colon form, as it does at top level *)
   check ".a{li::before{color:red}}" ".a{li:before{color:red}}";
-  (* several in a row, after and between declarations *)
+  (* several in a row, after and between declarations: CSS Nesting 1 sec. 3.4
+     keeps [height] where it was written, behind both nested rules *)
   check ".a{color:red;h2:hover{width:1px}h3:hover{width:2px};height:2px}"
-    ".a{color:red;height:2px;h2:hover{width:1px}h3:hover{width:2px}}";
+    ".a{color:red;h2:hover{width:1px}h3:hover{width:2px}height:2px}";
   (* the shapes that already worked must keep working *)
   check ".a{&:hover{color:red}}" ".a{&:hover{color:red}}";
   check ".a{.b{color:red}}" ".a{.b{color:red}}";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2930,6 +2930,22 @@ let spec_nesting_empty_layer_keeps_block () =
   test_nesting_idempotent ".a { @layer n { } }";
   test_nesting_roundtrip ~expected:"@layer n;" "@layer n { }"
 
+(* CSS Nesting 1 sec. 3.4: a run of declarations written after a nested rule is
+   wrapped in a nested declarations rule, which keeps its place among the nested
+   rules. The spec's own worked example names the hoisted spelling as NOT
+   equivalent, and Blink and WebKit both compute the later declaration. *)
+let spec_nesting_declaration_after_nested_rule () =
+  test_nesting_roundtrip ~expected:".a{color:red;& b{color:blue}color:green}"
+    ".a { color: red; & b { color: blue } color: green }";
+  test_nesting_roundtrip
+    ~expected:".a{@supports(color:red){color:blue}color:green}"
+    ".a { @supports (color: red) { color: blue } color: green }";
+  test_nesting_roundtrip ~expected:".a{c:1;& b{d:2}e:3;f:4;& g{h:5}i:6}"
+    ".a { c: 1; & b { d: 2 } e: 3; f: 4; & g { h: 5 } i: 6 }";
+  test_nesting_idempotent ".a { color: red; & b { color: blue } color: green }";
+  test_nesting_idempotent
+    ".a { @media (min-width: 1px) { padding: 2rem } color: green }"
+
 let spec_nesting_selector_edges () =
   assert_minify_and_optimize
     ".card { color: red; &:is(:hover, :focus-visible) { color: blue } &:has(> \
@@ -7032,6 +7048,9 @@ let additional_tests =
     ( "spec nesting selector and conditional edges",
       `Quick,
       spec_nesting_selector_edges );
+    ( "spec nesting declaration after a nested rule keeps its place",
+      `Quick,
+      spec_nesting_declaration_after_nested_rule );
     ( "spec nesting @layer block holds nesting content",
       `Quick,
       spec_nesting_layer_block );


### PR DESCRIPTION
The reader appended every declaration to the rule's own list, so `.a { @supports (color: red) { color: blue } color: green }` printed as `.a{color:green;@supports(color:red){color:blue}}`, which Blink 146 computes blue where the source computes green; CSS Nesting 1 sec. 3.4 wraps the later run in a nested declarations rule so it holds its place, and its worked example names the hoist as not equivalent.

`Flatten`, `cascade apply` and the optimizer all render correctly on the new position, but the optimizer no longer folds a declaration across a nested block (a dead declaration before one is kept) and the canonical comparator now separates two orderings that only differ where no property clashes; both are follow-ups. Stacked on #376.