### PR TITLE
css: reach every conditional group from map and sort

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -196,6 +196,11 @@
   that carries a cascade layer or an `@supports` depth down the tree cannot be
   a fold, and can now name the sites it reads instead of matching on the
   statements it expects to meet (#368)
+- `Css.map` and `Css.sort` reach a rule inside `@scope`, `@starting-style`,
+  `@-moz-document`, `@when` or `@else`, as they already did for `@media` and
+  `@supports`. Those at-rules group style rules like any other conditional
+  group, and a caller rewriting or reordering "all rules at all nesting levels"
+  got a sheet with five of them silently untouched (#381)
 
 ### CLI tools
 

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -431,28 +431,9 @@ let as_origin = function
   | Origin (origin, content) -> Some (origin, content)
   | _ -> None
 
-(* The block at-rules [map] and [sort] rebuild. Listed one by one rather than
-   closed with a wildcard, so a statement that grows a block later has to be
-   classified here before it compiles. [Scope], [Starting_style],
-   [Moz_document], [When] and [Else] wrap rules too; whether the public
-   [map]/[sort] reach them is a contract question rather than a traversal one,
-   so they stay out until it is answered. *)
-let map_container_block f = function
-  | Media (condition, content) -> media ~condition (f content)
-  | Supports (condition, content) -> supports ~condition (f content)
-  | Layer (name, content) -> layer ?name (f content)
-  | Container (name, condition, content) ->
-      container ?name ?condition (f content)
-  | Origin (origin, content) -> Origin (origin, f content)
-  | ( Rule _ | Property _ | Declarations _ | Bang_comment _ | Charset _
-    | Import _ | Namespace _ | Layer_decl _ | Supports_condition _ | Scope _
-    | Starting_style _ | Moz_document _ | When _ | Else _ | Keyframes _
-    | Webkit_keyframes _ | Moz_keyframes _ | Font_face _ | Counter_style _
-    | Page _ | Page_with_margins _ | Font_palette_values _
-    | Font_feature_values _ | View_transition _ | Position_try _ | Viewport _
-    | Unknown_at_rule _ ) as stmt ->
-      stmt
-
+(* [f] decides a rule's fate; the descent into what holds it is
+   [map_statement_children]'s, so every block at-rule is walked and one added
+   later is walked without a word here. *)
 let rec map f stmts =
   List.map
     (fun stmt ->
@@ -468,22 +449,20 @@ let rec map f stmts =
               (* Callback supplied its own nested (or returned a non-Rule);
                  trust it and replace the original. *)
               other)
-      | None -> map_container_block (map f) stmt)
+      | None -> map_statement_children (map f) stmt)
     stmts
 
 let rec sort cmp stmts =
-  (* First, recursively sort within containers and inside rule.nested. *)
+  (* Sort each block first, so the pass reaches a rule at any depth. The descent
+     is [map_statement_children]'s: an at-rule that grows a block later is
+     sorted inside without a word here, and a nesting block inside a rule is one
+     of them. *)
   let stmts_with_sorted_contents =
-    List.map
-      (fun stmt ->
-        match stmt with
-        | Rule rule -> Rule { rule with nested = sort cmp rule.nested }
-        | stmt -> map_container_block (sort cmp) stmt)
-      stmts
+    List.map (map_statement_children (sort cmp)) stmts
   in
-
-  (* Now sort the rules at this level *)
-  List.sort
+  (* [stable_sort], not [sort]: the comparison answers 0 for two non-rules, so
+     stability is what keeps an [@else] with the [@when] it answers. *)
+  List.stable_sort
     (fun stmt1 stmt2 ->
       match (as_rule stmt1, as_rule stmt2) with
       | Some (sel1, decls1, _), Some (sel2, decls2, _) ->

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -372,27 +372,32 @@ val map :
   (Selector.t -> declaration list -> statement) ->
   statement list ->
   statement list
-(** [map f stmts] applies [f] to all rules in [stmts], recursively descending
-    into nested containers (media, supports, layers, etc.).
+(** [map f stmts] applies [f] to every rule in [stmts]: the ones at the top
+    level, the ones inside a conditional group at-rule such as [@media],
+    [@supports], [@layer], [@container], [@scope] or [@starting-style], however
+    deeply nested, and the ones nested inside a rule.
 
-    - Rules are transformed while non-rule statements are preserved
-    - Traversal is depth-first, processing nested containers recursively
-    - Transformation is applied to all rules at all nesting levels
-    - Non-rule statements (at-rules without rule content) maintain their
-      relative order. *)
+    - Traversal is depth-first, and a statement that is not a rule is kept with
+      its block rewritten.
+    - Non-rule statements maintain their relative order.
+    - When [f] returns a rule holding no nested statements, the original nested
+      tree is kept with [map] applied to it; one holding its own replaces it. *)
 
 val sort :
   (Selector.t * declaration list -> Selector.t * declaration list -> int) ->
   statement list ->
   statement list
-(** [sort cmp stmts] sorts rules within [stmts] using the comparison function
-    [cmp], recursively descending into nested containers.
+(** [sort cmp stmts] reorders the rules of [stmts] with [cmp], and the rules of
+    every block below them: inside a conditional group at-rule such as [@media],
+    [@supports], [@layer], [@container], [@scope] or [@starting-style], however
+    deeply nested, and inside the nested statements of a rule.
 
-    - Sort is stable: equal elements maintain their relative order
-    - Non-rule statements are preserved in their original positions
-    - Sorting occurs independently within each container level
-    - Nested containers (media, supports, layers) have their rules sorted
-      recursively. *)
+    - Each block is sorted on its own, so a rule never leaves the block it sits
+      in.
+    - Sort is stable: rules [cmp] calls equal maintain their relative order.
+    - Non-rule statements sort after the rules of their block and maintain their
+      relative order among themselves, so an [@else] still follows the [@when]
+      it answers. *)
 
 (** Existential type for property information that preserves type safety *)
 type property_info =

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -388,6 +388,28 @@ let test_map_nested () =
     "map descends into media" true
     (Astring.String.is_infix ~affix:"color:#00f" css)
 
+(* Every conditional group at-rule holding [body]. [map] and [sort] speak of
+   "all rules at all nesting levels", so each of these has to give the same
+   answer as [@media]: they all wrap style rules, and which one wraps them is
+   not something a caller rewriting or reordering rules asked about. *)
+let conditional_groups body =
+  [
+    ("@media", Stylesheet.Media (Media.of_string "screen", body));
+    ("@supports", Stylesheet.Supports (Supports.of_string "(top: 0)", body));
+    ("@container", Stylesheet.Container (None, None, body));
+    ("@layer", Stylesheet.Layer (Some "a", body));
+    ("@origin", Stylesheet.Origin (Stylesheet.Author, body));
+    ("@scope", Stylesheet.Scope (Some (Selector.class_ "card"), None, body));
+    ("@starting-style", Stylesheet.Starting_style body);
+    ( "@-moz-document",
+      Stylesheet.Moz_document
+        ([ Stylesheet.Url_prefix (Some "https://example.com/") ], body) );
+    ( "@when",
+      Stylesheet.When
+        (Stylesheet.Media_condition (Media.of_string "screen"), body) );
+    ("@else", Stylesheet.Else (None, body));
+  ]
+
 let test_spec_map_conditional_boundaries () =
   let recolor sel _decls =
     rule ~selector:sel [ color (Css.Values.hex "0000ff") ]
@@ -419,7 +441,20 @@ let test_spec_map_conditional_boundaries () =
     "map preserves condition boundaries" true
     (Astring.String.is_infix ~affix:"@supports" css
     && Astring.String.is_infix ~affix:"@container" css
-    && Astring.String.is_infix ~affix:"@layer" css)
+    && Astring.String.is_infix ~affix:"@layer" css);
+  let missed =
+    List.filter_map
+      (fun (label, stmt) ->
+        let mapped = Css.map recolor [ stmt ] in
+        let css = Css.to_string ~minify:true (v mapped) in
+        if Astring.String.is_infix ~affix:"color:#00f" css then None
+        else Some label)
+      (conditional_groups
+         [ rule ~selector:(Selector.class_ "a") [ color (hex "#ff0000") ] ])
+  in
+  if missed <> [] then
+    Alcotest.failf "map did not reach the rules of: %s"
+      (String.concat ", " missed)
 
 (* Test Css.sort - sorts rules by custom comparison *)
 let test_sort () =
@@ -511,7 +546,65 @@ let test_spec_sort_conditional_boundaries () =
   let bbb = Astring.String.find_sub ~sub:".bbb" css |> Option.get in
   let yyy = Astring.String.find_sub ~sub:".yyy" css |> Option.get in
   Alcotest.(check bool) "sort descends into container" true (aaa < zzz);
-  Alcotest.(check bool) "sort descends into layer" true (bbb < yyy)
+  Alcotest.(check bool) "sort descends into layer" true (bbb < yyy);
+  let unsorted =
+    List.filter_map
+      (fun (label, stmt) ->
+        let css = Css.to_string ~minify:true (v (Css.sort cmp [ stmt ])) in
+        let at sub = Astring.String.find_sub ~sub css in
+        match (at ".aaa", at ".zzz") with
+        | Some a, Some z when a < z -> None
+        | _ -> Some label)
+      (conditional_groups
+         [
+           rule ~selector:(Selector.class_ "zzz") [ color (hex "#ff0000") ];
+           rule ~selector:(Selector.class_ "aaa") [ color (hex "#00ff00") ];
+         ])
+  in
+  if unsorted <> [] then
+    Alcotest.failf "sort did not reach the rules of: %s"
+      (String.concat ", " unsorted)
+
+(* An [@else] answers the [@when] before it, so a chain is one unit: sorting may
+   not put a rule between its links nor swap them. [sort] moves rules ahead of
+   the at-rules they sit among and leaves the at-rules in source order, which
+   holds the chain together wherever it sits, including in a block [sort] only
+   reaches by descending. *)
+let test_spec_sort_when_else_chain () =
+  let cmp (sel1, _) (sel2, _) =
+    String.compare (Selector.to_string sel1) (Selector.to_string sel2)
+  in
+  let when_link =
+    Stylesheet.When
+      ( Stylesheet.Media_condition (Media.of_string "screen"),
+        [ rule ~selector:(Selector.class_ "w") [ color (hex "#ff0000") ] ] )
+  in
+  let else_link =
+    Stylesheet.Else
+      (None, [ rule ~selector:(Selector.class_ "e") [ color (hex "#00ff00") ] ])
+  in
+  let chain = [ when_link; else_link ] in
+  let zzz = rule ~selector:(Selector.class_ "zzz") [ color (hex "#ff0000") ] in
+  let aaa = rule ~selector:(Selector.class_ "aaa") [ color (hex "#00ff00") ] in
+  let check label stmts =
+    let css = Css.to_string ~minify:true (v (Css.sort cmp stmts)) in
+    Alcotest.(check bool)
+      (label ^ ": @else still answers its @when")
+      true
+      (Astring.String.is_infix
+         ~affix:"@when media(screen){.w{color:#f00}}@else{.e{color:#0f0}}" css)
+  in
+  check "top level" chain;
+  check "rules around the chain" ((zzz :: chain) @ [ aaa ]);
+  check "rule between the links" [ when_link; aaa; else_link ];
+  check "inside @media" [ Stylesheet.Media (Media.of_string "print", chain) ];
+  check "inside @scope"
+    [ Stylesheet.Scope (Some (Selector.class_ "card"), None, chain) ];
+  check "inside @when"
+    [
+      Stylesheet.When
+        (Stylesheet.Media_condition (Media.of_string "print"), chain);
+    ]
 
 let public_fold_edges () =
   let title = Selector.class_ "title" in
@@ -1223,6 +1316,8 @@ let suite =
       Alcotest.test_case "sort nested in media" `Quick test_sort_nested;
       Alcotest.test_case "spec sort conditional boundaries" `Quick
         test_spec_sort_conditional_boundaries;
+      Alcotest.test_case "spec sort keeps a when/else chain" `Quick
+        test_spec_sort_when_else_chain;
       Alcotest.test_case "public fold edge traversal" `Quick public_fold_edges;
       Alcotest.test_case "public custom property scoping" `Quick
         public_custom_props_edges;


### PR DESCRIPTION
`Css.map` and `Css.sort` used to skip a rule inside `@scope`, `@starting-style`, `@-moz-document`, `@when` or `@else` while their docs promised all rules at all nesting levels; now they walk through `Stylesheet.map_statement_children`, so a block at-rule added later is reached without a line here.
Stacked on #375.