### PR TITLE
css: find a layer and a var() wherever it sits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -201,6 +201,15 @@
   `@supports`. Those at-rules group style rules like any other conditional
   group, and a caller rewriting or reordering "all rules at all nesting levels"
   got a sheet with five of them silently untouched (#381)
+- `Css.layers` and `Css.layer_block` find a layer declared inside `@media`,
+  `@supports`, `@container`, `@scope` or any other grouping at-rule. Such a
+  block declares a real layer, so a caller asking which layers a sheet declares
+  was given a wrong answer rather than a partial one; `layers` reports every
+  name it finds in source order (#382)
+- `Css.vars_of_rules` is `Css.vars_of_stylesheet`, so a `var()` inside a nested
+  rule or inside any at-rule is reported instead of only one a top-level rule
+  holds. Both fold over every declaration site, which also adds the references
+  an animation frame and a page margin box hold (#382)
 
 ### CLI tools
 

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -523,55 +523,63 @@ let media_queries t =
 (* AST Introspection Helpers *)
 
 (* CSS Cascade 5 sec. 6.4.2: a dotted layer name [foo.bar] is shorthand for the
-   nested [@layer foo { @layer bar { ... } }]. Walk the @layer tree once,
-   expanding dotted names and prefixing each block with its parent's path, so
-   [foo.bar] is reachable under one canonical name whatever the input shape. *)
-let qualified_layer_blocks sheet =
+   nested [@layer foo { @layer bar { ... } }]. Walk the sheet once through
+   [statement_children], expanding dotted names and prefixing each name with its
+   parent's path, so a layer is reachable under one canonical name whatever the
+   input shape and an [@layer] inside a conditional group counts like any other:
+   the group decides whether its contents apply, not whether the layer exists.
+   Each entry carries the block the name opens, or [None] for a name declared by
+   a layer statement that opens none, so a statement never shadows the block
+   that fills the layer in. A sublayer of an anonymous layer has no name a
+   caller could ask for, so the walk stops there. *)
+let layer_declarations sheet =
   let prefix_with parent name =
     if parent = "" then name else parent ^ "." ^ name
   in
-  let rec emit_dotted parent rest inner acc =
-    match rest with
+  let rec emit_dotted parent segments (inner : statement list option) acc =
+    match segments with
     | [] -> acc
-    | [ leaf ] ->
+    | [ leaf ] -> (
         let qualified = prefix_with parent leaf in
-        walk qualified ((qualified, inner) :: acc) inner
+        let acc = (qualified, inner) :: acc in
+        match inner with None -> acc | Some block -> walk qualified acc block)
     | head :: tail ->
+        (* An intermediate segment names a layer that exists but opens no block
+           of its own. *)
         let qualified = prefix_with parent head in
-        emit_dotted qualified tail inner ((qualified, []) :: acc)
+        let stub = Option.map (fun _ -> []) inner in
+        emit_dotted qualified tail inner ((qualified, stub) :: acc)
   and walk parent acc statements =
     List.fold_left
       (fun acc s ->
-        match as_layer s with
-        | Some (Some name, inner) ->
-            let segments = String.split_on_char '.' name in
-            emit_dotted parent segments inner acc
-        | _ -> acc)
+        match s with
+        | Layer (Some name, inner) ->
+            emit_dotted parent (String.split_on_char '.' name) (Some inner) acc
+        | Layer_decl names ->
+            List.fold_left
+              (fun acc name ->
+                emit_dotted parent (String.split_on_char '.' name) None acc)
+              acc names
+        | Layer (None, _) -> acc
+        | s -> walk parent acc (statement_children s))
       acc statements
   in
   List.rev (walk "" [] sheet)
 
-let layer_block name sheet = List.assoc_opt name (qualified_layer_blocks sheet)
+let layer_block name sheet =
+  List.find_map
+    (fun (declared, block) -> if declared = name then block else None)
+    (layer_declarations sheet)
 
 let layers t =
-  (* Derive the layer set from the canonical [@layer] block walk plus any
-     explicit [@layer a, b, c;] forward declarations. Going through
-     [qualified_layer_blocks] alone keeps dotted and nested input forms
-     producing the same result. *)
-  let from_blocks = List.map fst (qualified_layer_blocks t) in
-  let from_decls =
-    List.concat_map
-      (fun s -> match s with Stylesheet.Layer_decl names -> names | _ -> [])
-      t
-  in
   let seen = Hashtbl.create 16 in
-  let dedup name : string option =
-    if Hashtbl.mem seen name then None
-    else (
-      Hashtbl.add seen name ();
-      Some name)
-  in
-  List.filter_map dedup (from_blocks @ from_decls)
+  List.filter_map
+    (fun (name, _) ->
+      if Hashtbl.mem seen name then None
+      else (
+        Hashtbl.add seen name ();
+        Some name))
+    (layer_declarations t)
 
 let rules_of_statements stmts =
   List.filter_map
@@ -638,13 +646,10 @@ let property ~name syntax ?initial_value ?(inherits = false) () =
 
 let vars_of_declarations = Variables.vars_of_declarations
 
-let vars_of_rules statements =
-  let decls =
-    List.concat_map
-      (fun stmt -> match stmt with Rule r -> r.declarations | _ -> [])
-      statements
-  in
-  vars_of_declarations decls
+(* Same question as [vars_of_stylesheet], differing only in what it is handed: a
+   statement list is a stylesheet. Two walks would answer differently the moment
+   one of them met a construct the other knew. *)
+let vars_of_rules = vars_of_stylesheet
 
 type parse = { stylesheet : t; warnings : Error.t list }
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -507,14 +507,24 @@ val media_queries : t -> (Media.t * statement list) list
 (** [media_queries t] returns media queries and their rule statements. *)
 
 val layers : t -> string list
-(** [layers t] returns the layer names from the stylesheet. *)
+(** [layers t] is every cascade layer [t] declares, one dotted path per layer
+    ([a.b] is the sublayer [b] of [a], however it was written), in the order the
+    sheet first names them. A layer named inside a conditional group counts: the
+    group decides whether its contents apply, not whether the layer exists. A
+    sublayer of an anonymous [@layer { ... }] has no name to report.
+
+    This is what a sheet declares, not the order a cascade resolves in.
+    {!Resolve.layer_order} answers that, and leaves out a layer named inside a
+    conditional group because the resolver does not enter one. *)
 
 (** {3 AST Introspection Helpers} *)
 
 val layer_block : string -> t -> statement list option
-(** [layer_block name sheet] extracts the statements from the named layer
-    [@layer name] in the stylesheet. Returns {!constructor-None} if the layer is
-    not found. *)
+(** [layer_block name sheet] is the statements of the layer [name], wherever it
+    is declared and whatever form declares it: a dotted name, a nested block, or
+    a block inside a conditional group. It is {!constructor-None} when no
+    [@layer] block opens that layer, so a name only an [@layer a, b;] statement
+    declares is {!constructor-None} as well. *)
 
 val rules_of_statements : statement list -> (Selector.t * declaration list) list
 (** [rules_of_statements stmts] extracts all CSS rules (selector + declarations)
@@ -623,16 +633,18 @@ val with_fallback : 'a var -> 'a -> 'a var
 type any_var = Variables.any_var = V : 'a var -> any_var
 
 val vars_of_rules : statement list -> any_var list
-(** [vars_of_rules statements] extracts all CSS variables referenced in rule
-    statements' declarations, returning them sorted and deduplicated. *)
+(** [vars_of_rules statements] is {!vars_of_stylesheet} of [statements]: a
+    statement list is a stylesheet, and the two answer the same question. *)
 
 val vars_of_declarations : declaration list -> any_var list
 (** [vars_of_declarations decls] extracts all CSS variables referenced in the
     declarations list. *)
 
 val vars_of_stylesheet : t -> any_var list
-(** [vars_of_stylesheet stylesheet] extracts all CSS variables referenced in the
-    entire stylesheet, returning them sorted and deduplicated. *)
+(** [vars_of_stylesheet stylesheet] is every variable [stylesheet] references,
+    from the declarations of every statement it holds: a rule nested in a rule,
+    a rule inside any grouping at-rule, and an at-rule carrying declarations of
+    its own such as [@keyframes] or [@page]. Deduplicated, in source order. *)
 
 val any_var_name : any_var -> string
 (** [any_var_name v] is the name of a CSS variable (with [--] prefix). *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -4108,40 +4108,14 @@ let inline_style_of_declarations ?(minify = false) ?(mode : mode = Inline) props
 
 (** {1 Variable extraction from stylesheets} *)
 
-let rec vars_of_statement (stmt : statement) : Variables.any_var list =
-  match stmt with
-  | Rule rule ->
-      Variables.vars_of_declarations rule.declarations
-      @ vars_of_block rule.nested
-  | Declarations decls -> Variables.vars_of_declarations decls
-  | Media (_, block)
-  | Container (_, _, block)
-  | Supports (_, block)
-  | Moz_document (_, block)
-  | When (_, block)
-  | Else (_, block)
-  | Layer (_, block)
-  | Starting_style block
-  | Origin (_, block)
-  | Scope (_, _, block) ->
-      vars_of_block block
-  | Font_face _ | Counter_style _ ->
-      [] (* At-rule descriptors don't contribute CSS variables *)
-  | Page (_, decls) -> Variables.vars_of_declarations decls
-  | Page_with_margins (_, _, _) -> []
-  | Position_try (_, decls) | Supports_condition (_, decls) ->
-      Variables.vars_of_declarations decls
-  | Viewport _ | Font_palette_values _ | Font_feature_values _
-  | View_transition _ | Charset _ | Import _ | Namespace _ | Property _
-  | Layer_decl _ | Keyframes _ | Webkit_keyframes _ | Moz_keyframes _
-  | Unknown_at_rule _ | Bang_comment _ ->
-      []
-
-and vars_of_block (block : block) : Variables.any_var list =
-  List.concat_map vars_of_statement block
-
+(* A [var()] is a reference wherever the declaration holding it sits, so this is
+   [fold_declarations] over every site rather than a list of the at-rules that
+   came to mind: an animation frame and a page margin box read a variable like a
+   style rule does. Gathering the declarations first and extracting once dedupes
+   across statements, which per-statement extraction cannot. *)
 let vars_of_stylesheet (ss : stylesheet) : Variables.any_var list =
-  vars_of_block ss
+  fold_declarations (fun acc decls -> List.rev_append decls acc) [] ss
+  |> List.rev |> Variables.vars_of_declarations
 
 (* Alias for API consistency *)
 let read = read_stylesheet

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -387,8 +387,10 @@ val pp_stylesheet : stylesheet Pp.t
 (** {1 Variable Extraction} *)
 
 val vars_of_stylesheet : stylesheet -> Variables.any_var list
-(** [vars_of_stylesheet ss] extracts all variables referenced in a stylesheet.
-*)
+(** [vars_of_stylesheet ss] is every variable [ss] references, from the
+    declarations {!fold_declarations} reaches, so a rule nested in a rule and an
+    at-rule carrying declarations of its own are both covered. Deduplicated, in
+    source order. *)
 
 (** {1 Rendering} *)
 

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -860,6 +860,28 @@ let public_layers_conditional_groups () =
   Alcotest.(check (list string))
     "anonymous layer hides its sublayers" []
     (layers (v [ Stylesheet.Layer (None, [ block ]) ]));
+  (* A layer statement declares a name without opening a block, so it must not
+     stand in for the block that fills the layer in later. *)
+  let forward_declared =
+    v
+      [
+        Stylesheet.Layer_decl [ "one"; "two" ];
+        Stylesheet.Layer (Some "one", [ styled ]);
+      ]
+  in
+  Alcotest.(check (list string))
+    "statement declares the order" [ "one"; "two" ] (layers forward_declared);
+  let block_text name sheet =
+    match layer_block name sheet with
+    | None -> "<no block>"
+    | Some stmts -> to_string ~minify:true (v stmts)
+  in
+  Alcotest.(check string)
+    "statement does not shadow the block" ".a{color:#111}"
+    (block_text "one" forward_declared);
+  Alcotest.(check string)
+    "a name only declared opens no block" "<no block>"
+    (block_text "two" forward_declared);
   (* Names come in source order, so a caller reading them reads the order the
      sheet introduces its layers in. *)
   Alcotest.(check (list string))

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -806,6 +806,155 @@ let public_custom_props_declaration_sites () =
   Alcotest.(check (list string))
     "unlayered sibling still reported" [ "--x"; "--out" ] (custom_props layered)
 
+(* A [@layer] inside a conditional group is ordinary CSS: the group decides
+   whether its contents apply, not whether the layer exists, and a layer named
+   there is the same layer a sibling block names (css-cascade-5 sec. 6.4). A
+   caller asking which layers a sheet declares gets a wrong answer, not a
+   conservative one, when such a block is skipped. *)
+let public_layers_conditional_groups () =
+  let styled = rule ~selector:(Selector.class_ "a") [ color (hex "#111111") ] in
+  let block = Stylesheet.Layer (Some "inner", [ styled ]) in
+  let decl = Stylesheet.Layer_decl [ "declared" ] in
+  let groups =
+    [
+      ("@media", fun b -> Stylesheet.Media (Media.of_string "screen", b));
+      ( "@supports",
+        fun b -> Stylesheet.Supports (Supports.of_string "(top: 0)", b) );
+      ("@container", fun b -> Stylesheet.Container (None, None, b));
+      ("@layer", fun b -> Stylesheet.Layer (Some "outer", b));
+      ("@origin", fun b -> Stylesheet.Origin (Stylesheet.Author, b));
+      ( "@scope",
+        fun b -> Stylesheet.Scope (Some (Selector.class_ "card"), None, b) );
+      ("@starting-style", fun b -> Stylesheet.Starting_style b);
+      ( "@-moz-document",
+        fun b ->
+          Stylesheet.Moz_document
+            ([ Stylesheet.Url_prefix (Some "https://example.com/") ], b) );
+      ( "@when",
+        fun b ->
+          Stylesheet.When
+            (Stylesheet.Media_condition (Media.of_string "screen"), b) );
+      ("@else", fun b -> Stylesheet.Else (None, b));
+      ("style rule", fun b -> rule ~selector:(Selector.class_ "b") ~nested:b []);
+    ]
+  in
+  let qualify label name = if label = "@layer" then "outer." ^ name else name in
+  let missing =
+    List.filter_map
+      (fun (label, group) ->
+        let sheet = v [ group [ block; decl ] ] in
+        let want_block = qualify label "inner" in
+        let want_decl = qualify label "declared" in
+        let names = layers sheet in
+        if
+          List.mem want_block names && List.mem want_decl names
+          && layer_block want_block sheet <> None
+        then None
+        else Some label)
+      groups
+  in
+  if missing <> [] then
+    Alcotest.failf "layer not reported inside: %s" (String.concat ", " missing);
+  (* A sublayer of an anonymous [@layer { }] has no name any caller can ask for,
+     so it is not one of the sheet's declared layers. *)
+  Alcotest.(check (list string))
+    "anonymous layer hides its sublayers" []
+    (layers (v [ Stylesheet.Layer (None, [ block ]) ]));
+  (* Names come in source order, so a caller reading them reads the order the
+     sheet introduces its layers in. *)
+  Alcotest.(check (list string))
+    "names in source order"
+    [ "first"; "second"; "third" ]
+    (layers
+       (v
+          [
+            Stylesheet.Layer_decl [ "first" ];
+            Stylesheet.Media
+              ( Media.of_string "screen",
+                [ Stylesheet.Layer (Some "second", [ styled ]) ] );
+            Stylesheet.Layer (Some "third", [ styled ]);
+          ]))
+
+(* [vars_of_rules] answers the same question as [vars_of_stylesheet] over the
+   statements it is given, so it reports a reference wherever a declaration
+   sits: nested in a rule, inside any grouping at-rule, and in an at-rule that
+   holds declarations without a block. A [var()] no walk reaches is a variable a
+   caller thinks nothing needs. *)
+let public_vars_declaration_sites () =
+  let decl = Declaration.of_string "color:var(--x)" in
+  let styled = rule ~selector:(Selector.class_ "a") [ decl ] in
+  let frame : Stylesheet.keyframe =
+    { selector = Keyframe.Positions [ Keyframe.From ]; declarations = [ decl ] }
+  in
+  let margin : Stylesheet.page_margin_rule =
+    { name = "top-left"; descriptors = [ decl ] }
+  in
+  let sites =
+    [
+      ("@media", Stylesheet.Media (Media.of_string "screen", [ styled ]));
+      ( "@supports",
+        Stylesheet.Supports (Supports.of_string "(top: 0)", [ styled ]) );
+      ("@container", Stylesheet.Container (None, None, [ styled ]));
+      ("@layer", Stylesheet.Layer (Some "a", [ styled ]));
+      ("@origin", Stylesheet.Origin (Stylesheet.Author, [ styled ]));
+      ( "@scope",
+        Stylesheet.Scope (Some (Selector.class_ "card"), None, [ styled ]) );
+      ("@starting-style", Stylesheet.Starting_style [ styled ]);
+      ( "@-moz-document",
+        Stylesheet.Moz_document
+          ([ Stylesheet.Url_prefix (Some "https://example.com/") ], [ styled ])
+      );
+      ( "@when",
+        Stylesheet.When
+          (Stylesheet.Media_condition (Media.of_string "screen"), [ styled ]) );
+      ("@else", Stylesheet.Else (None, [ styled ]));
+      ("nested rule", rule ~selector:(Selector.class_ "a") ~nested:[ styled ] []);
+      ( "nesting block",
+        rule ~selector:(Selector.class_ "a")
+          ~nested:[ Stylesheet.Declarations [ decl ] ]
+          [] );
+      ("@keyframes", Stylesheet.keyframes "k" [ frame ]);
+      ("@page", Stylesheet.Page ([], [ decl ]));
+      ("@page margin box", Stylesheet.Page_with_margins ([], [], [ margin ]));
+      ("@position-try", Stylesheet.Position_try ("--pt", [ decl ]));
+      ("@supports-condition", Stylesheet.Supports_condition ("--sc", [ decl ]));
+    ]
+  in
+  let names stmts = List.map any_var_name (vars_of_rules stmts) in
+  let missing =
+    List.filter_map
+      (fun (label, stmt) ->
+        if names [ stmt ] = [ "--x" ] then None else Some label)
+      sites
+  in
+  if missing <> [] then
+    Alcotest.failf "var() not reported in: %s" (String.concat ", " missing);
+  (* One question, one answer: the two entry points differ only in what they are
+     handed. *)
+  let disagree =
+    List.filter_map
+      (fun (label, stmt) ->
+        if
+          names [ stmt ]
+          = List.map any_var_name (vars_of_stylesheet (v [ stmt ]))
+        then None
+        else Some label)
+      sites
+  in
+  if disagree <> [] then
+    Alcotest.failf "vars_of_rules and vars_of_stylesheet disagree on: %s"
+      (String.concat ", " disagree);
+  (* Deduplicated across statements, in source order. *)
+  let y = Declaration.of_string "color:var(--y)" in
+  Alcotest.(check (list string))
+    "deduplicated in source order" [ "--x"; "--y" ]
+    (names
+       [
+         rule ~selector:(Selector.class_ "a") [ decl ];
+         Stylesheet.Media (Media.of_string "screen", [ styled ]);
+         rule ~selector:(Selector.class_ "b") [ y ];
+       ])
+
 let public_property_edges () =
   let sheet =
     property ~name:"--gap" Length ~initial_value:(Px 1.) ~inherits:false ()
@@ -1323,6 +1472,10 @@ let suite =
         public_custom_props_edges;
       Alcotest.test_case "public custom property declaration sites" `Quick
         public_custom_props_declaration_sites;
+      Alcotest.test_case "public layers in conditional groups" `Quick
+        public_layers_conditional_groups;
+      Alcotest.test_case "public var declaration sites" `Quick
+        public_vars_declaration_sites;
       Alcotest.test_case "public property introspection" `Quick
         public_property_edges;
       Alcotest.test_case "public theme guards" `Quick public_theme_edges;


### PR DESCRIPTION
`Css.layers` and `Css.layer_block` used to see only a top-level `@layer`, and `Css.vars_of_rules` only a top-level rule's own declarations; both now walk the whole sheet, so a layer inside `@media` and a `var()` inside a nested rule are reported. `vars_of_rules` is now `vars_of_stylesheet`, which folds over every declaration site rather than the at-rules one walk happened to list.