### PR TITLE
optimize: let a disjoint trailing declaration rejoin its rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -72,6 +72,12 @@
   only the run written before its first nested statement (CSS Nesting 1
   sec. 3.4), so a pass reading them as the whole body moves or drops content it
   never looked at (#376)
+- A declaration written after a nested statement rejoins the rule's own run
+  when nothing it crosses writes the same property at the same importance, so
+  `.a { & b { width: 1px } color: red }` minifies to
+  `.a{color:red;b{width:1px}}` and `--diff=canonical` stops reporting it as
+  different from `.a { color: red; & b { width: 1px } }`. A declaration that
+  does clash keeps the place CSS Nesting 1 sec. 3.4 gives it (#383)
 - `--minify` is faster on a stylesheet the optimizer factors heavily, for the
   same output. The rule graph's cycle check, topological order and
   selector-branch index each probed a generic `Hashtbl` once per edge or per

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -56,6 +56,71 @@ let rec merge_lone (rule : rule) =
       merge_lone { child with selector = combine rule.selector child.selector }
   | _ -> rule
 
+(* What a run of nested statements would have to cross to move ahead of them:
+   every declaration they can write at any depth, read through
+   [statement_declarations] and [statement_children] so no block at-rule hides
+   one. An unknown at-rule is raw text whose body cannot be read at all, so it
+   is [Opaque]: a barrier nothing crosses. *)
+type barrier = Opaque | Crossed of Declaration.declaration list
+
+let rec crossing barrier (stmts : statement list) =
+  match (barrier, stmts) with
+  | Opaque, _ | _, [] -> barrier
+  | Crossed decls, stmt :: rest ->
+      let barrier =
+        match stmt with
+        | Unknown_at_rule _ -> Opaque
+        | _ ->
+            crossing
+              (Crossed (List.rev_append (statement_declarations stmt) decls))
+              (statement_children stmt)
+      in
+      crossing barrier rest
+
+let crosses_freely barrier decl =
+  match barrier with
+  | Opaque -> false
+  | Crossed decls -> Shorthand.declarations_commute [ decl ] decls
+
+(* CSS Nesting 1 sec. 3.4 keeps a declaration written after a nested statement
+   behind it. Moving one back into the rule's own run is cascade-neutral exactly
+   when it commutes with everything it would cross, so the body is walked once,
+   growing the barrier with each statement kept and with each declaration that
+   had to stay. Selectors are left out of the question: a nested rule matches
+   other elements than its parent, but assuming it matches the same one only
+   refuses a hoist the cascade would have allowed. *)
+let hoist_declaration_runs (rule : rule) =
+  let hoist_run barrier run =
+    List.fold_left
+      (fun (hoisted, barrier, kept) decl ->
+        if crosses_freely barrier decl then (decl :: hoisted, barrier, kept)
+        else
+          let barrier =
+            match barrier with
+            | Opaque -> Opaque
+            | Crossed decls -> Crossed (decl :: decls)
+          in
+          (hoisted, barrier, decl :: kept))
+      ([], barrier, []) run
+  in
+  let rec go hoisted barrier nested = function
+    | [] -> (List.rev hoisted, List.rev nested)
+    | Declarations run :: rest ->
+        let run_hoisted, barrier, kept = hoist_run barrier run in
+        let nested =
+          match List.rev kept with
+          | [] -> nested
+          | kept -> Declarations kept :: nested
+        in
+        go (run_hoisted @ hoisted) barrier nested rest
+    | stmt :: rest ->
+        go hoisted (crossing barrier [ stmt ]) (stmt :: nested) rest
+  in
+  match go [] (Crossed []) [] rule.nested with
+  | [], _ -> rule
+  | hoisted, nested ->
+      { rule with declarations = rule.declarations @ hoisted; nested }
+
 let rec strip_prefix (parent : Selector.t) (child : Selector.t) =
   match (parent, child) with
   | _, Selector.Combined (cp, comb, crest) when Selector.equal cp parent ->

--- a/lib/nest.mli
+++ b/lib/nest.mli
@@ -12,6 +12,14 @@ val combine : Selector.t -> Selector.t -> Selector.t
 val merge_lone : Stylesheet.rule -> Stylesheet.rule
 (** Merge a pure wrapper rule with its sole nested rule when safe. *)
 
+val hoist_declaration_runs : Stylesheet.rule -> Stylesheet.rule
+(** [hoist_declaration_runs rule] moves each declaration written after a nested
+    statement (CSS Nesting 1 sec. 3.4) back into the rule's own run, as far as
+    it commutes with everything nested above it. A declaration whose property a
+    crossed statement also writes stays where the author put it, so the rule
+    computes the same values while the rest rejoins the declaration passes.
+    Physically unchanged when nothing moves. *)
+
 val rules : Stylesheet.rule list -> Stylesheet.rule list
 (** Synthesize nested rules from adjacent flat selector chains. *)
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -78,6 +78,7 @@ let drop_empty_rules = Block.drop_empty_rules
 let drop_misplaced_imports = Block.drop_misplaced_imports
 let merge_named_layers_by_name = Block.merge_named_layers_by_name
 let merge_lone_nested_rule = Nest.merge_lone
+let hoist_declaration_runs = Nest.hoist_declaration_runs
 let synthesize_nesting_statements = Nest.statements
 let stylesheet_key stmts = Pp.to_string ~minify:true pp_stylesheet stmts
 
@@ -365,28 +366,31 @@ and process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
   process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
     (stmt :: acc) rest
 
+(* Optimize one rule's nested statements recursively, then drop the redundant
+   nesting prefix (see [drop_nesting_prefix]) and let a run written after them
+   rejoin the rule's own declarations wherever the cascade allows. *)
+and rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec rule =
+  let nested =
+    match rule.nested with
+    | [] -> []
+    | nested ->
+        let nested =
+          statements ?factor_cache ~ctx ~enforce_spec ~nesting:true nested
+        in
+        if enforce_spec then nested
+        else list_map_preserve drop_nesting_prefix nested
+  in
+  let rule = hoist_declaration_runs (rule_with_nested rule nested) in
+  let rule =
+    let selector = Selector.canonicalize rule.selector in
+    if selector == rule.selector then rule else { rule with selector }
+  in
+  merge_lone_nested_rule rule
+
 and rules_aux ?factor_cache ~ctx ~enforce_spec (rules : rule list) : rule list =
-  (* First optimize each rule's nested statements recursively, then drop the
-     redundant nesting prefix (see [drop_nesting_prefix]). *)
   let with_optimized_nested =
     list_map_preserve
-      (fun rule ->
-        let nested =
-          match rule.nested with
-          | [] -> []
-          | nested ->
-              let nested =
-                statements ?factor_cache ~ctx ~enforce_spec ~nesting:true nested
-              in
-              if enforce_spec then nested
-              else list_map_preserve drop_nesting_prefix nested
-        in
-        let rule = rule_with_nested rule nested in
-        let rule =
-          let selector = Selector.canonicalize rule.selector in
-          if selector == rule.selector then rule else { rule with selector }
-        in
-        merge_lone_nested_rule rule)
+      (rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec)
       rules
   in
   (* Apply local rule normalization before the DAG factor scheduler decides
@@ -465,10 +469,16 @@ let statements_top_level ?factor_cache ~ctx ~enforce_spec
 
 let single_rule ?scope (rule : rule) : rule =
   let ctx = ctx_of_scope scope in
+  let rule =
+    hoist_declaration_runs
+      {
+        rule with
+        nested = statements ~ctx ~enforce_spec:false ~nesting:true rule.nested;
+      }
+  in
   {
     rule with
     declarations = deduplicate_declarations_with ~ctx rule.declarations;
-    nested = statements ~ctx ~enforce_spec:false ~nesting:true rule.nested;
   }
 
 let rules ?scope (rules : rule list) : rule list =

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3483,6 +3483,37 @@ let same_minified_declaration (a : declaration) (b : declaration) =
   || Declaration.hash a = Declaration.hash b
      && Declaration.equal_declaration a b
 
+(* Only a pair that writes a common cascade slot at the same importance with
+   different values constrains its own order: [!important] beats the plain
+   declaration wherever the two sit, and an identical pair is its own winner
+   either way. The footprint is computed once per declaration rather than once
+   per pair, since the test below is quadratic. *)
+type commute_fact = {
+  decl : declaration;
+  important : bool;
+  keys : overlap_key list;
+}
+
+let commute_fact decl =
+  {
+    decl;
+    important = Declaration.is_important decl;
+    keys = declaration_overlap_keys decl;
+  }
+
+let commute_facts_conflict a b =
+  a.important = b.important
+  && (not (same_minified_declaration a.decl b.decl))
+  && declarations_overlap_with_keys a.decl a.keys b.decl b.keys
+
+let declarations_commute left right =
+  let left = List.map commute_fact left in
+  let right = List.map commute_fact right in
+  not
+    (List.exists
+       (fun a -> List.exists (fun b -> commute_facts_conflict a b) right)
+       left)
+
 let legacy_vendor_fallback new_decl existing =
   (* Different-value duplicates are kept when one value is vendor-prefixed: the
      cascade may pick whichever the browser understands. *)

--- a/lib/shorthand.mli
+++ b/lib/shorthand.mli
@@ -69,6 +69,14 @@ val same_minified_declaration :
   Declaration.declaration -> Declaration.declaration -> bool
 (** Same canonical minified declaration. *)
 
+val declarations_commute :
+  Declaration.declaration list -> Declaration.declaration list -> bool
+(** [declarations_commute a b] is [true] when running [a] before [b] and [b]
+    before [a] compute the same value for every property on every element: no
+    pair across the two writes a common cascade slot at the same importance with
+    a different value. Selectors are not read, so two runs that could never meet
+    on one element still count as constrained when their properties clash. *)
+
 val is_all_declaration : Declaration.declaration -> bool
 (** Whether a declaration is the [all] shorthand. *)
 

--- a/test/inline/fixtures/nested_order.html
+++ b/test/inline/fixtures/nested_order.html
@@ -4,9 +4,17 @@
   .n3 { @supports (color: red) { color: blue } color: green }
   .n4 { color: red; & b { width: 9px } color: blue }
   .n4 { color: green }
+  .n5 { @media (min-width: 1px) { color: blue } color: green; width: 30px }
+  .n6 { --w: 40px; & b { --w: 50px } width: var(--w) }
+  .n7 { @media (min-width: 1px) { color: blue } color: green !important }
+  .n8 { color: red; @media (min-width: 1px) { padding: 3px } color: green; & i { width: 8px } font-size: 20px }
 </style></head><body>
 <div class="n1">a<b>x</b></div>
 <div class="n2">b</div>
 <div class="n3">c</div>
 <div class="n4">d<b>y</b></div>
+<div class="n5">e</div>
+<div class="n6">f<b>z</b></div>
+<div class="n7">g</div>
+<div class="n8">h<i>w</i></div>
 </body></html>

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -134,6 +134,35 @@ let equal_canonical_lossless_exact_srgb () =
     "an off-grid channel keeps its function" false
     (equal ".a{color:color(srgb .501 0 0)}" ".a{color:maroon}")
 
+(* CSS Nesting 1 sec. 3.4 keeps a declaration written after a nested rule where
+   the author wrote it, which only matters for a property the nested rule also
+   sets. Where nothing clashes across the boundary the two spellings compute the
+   same values on every element, so the projection has to bring them
+   together. *)
+let canonical_declaration_after_nested_rule () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  Alcotest.(check bool)
+    "a disjoint declaration agrees either side of a nested rule" true
+    (equal ".a{color:red;& b{width:1px}}" ".a{& b{width:1px}color:red}");
+  Alcotest.(check bool)
+    "so does one either side of a nested @media" true
+    (equal ".a{width:2px;@media (hover){color:blue}}"
+       ".a{@media (hover){color:blue}width:2px}");
+  (* A [var()] reader writes its own property, never the one it reads, so it
+     crosses a nested definition of that custom property freely. *)
+  Alcotest.(check bool)
+    "a var() reader crosses a nested definition of what it reads" true
+    (equal ".a{width:var(--x);& b{--x:1px}}" ".a{& b{--x:1px}width:var(--x)}");
+  (* The clashing pair is a real difference: hoisting [color] over the nested
+     rule is the miscompile the position exists to prevent. *)
+  Alcotest.(check bool)
+    "a clashing declaration still differs" false
+    (equal ".a{color:red;& b{color:blue}}" ".a{& b{color:blue}color:red}");
+  Alcotest.(check bool)
+    "a longhand still clashes with a crossed shorthand" false
+    (equal ".a{margin-top:2px;& b{margin:1px}}"
+       ".a{& b{margin:1px}margin-top:2px}")
+
 (* Filter Effects 1 sec. 6.1 makes an omitted [hue-rotate()] argument 0, and
    [hue-rotate] names a filter function and nothing else, so the two spellings
    are one value wherever the stream is substituted. *)
@@ -1416,6 +1445,8 @@ let suite =
         equal_prune_unused_custom_props;
       Alcotest.test_case "canonical folds a zero hue-rotate in a custom value"
         `Quick canonical_custom_hue_rotate_zero;
+      Alcotest.test_case "canonical folds a disjoint trailing declaration"
+        `Quick canonical_declaration_after_nested_rule;
       Alcotest.test_case "canonical keeps custom-property importance" `Quick
         canonical_important_custom_property_distinct;
       Alcotest.test_case "canonical ignores @property order" `Quick

--- a/test/test_nest.ml
+++ b/test/test_nest.ml
@@ -53,6 +53,39 @@ let test_merge_lone_wrapper () =
     "wrapper with declarations preserved" ".card{color:red;.title{width:1px}}"
     (Pp.to_string ~minify:true Stylesheet.pp_rule with_decl)
 
+(* CSS Nesting 1 sec. 3.4 holds a declaration written after a nested statement
+   behind it. Moving it back is cascade-neutral exactly when it commutes with
+   what it crosses, so the hoist is decided per declaration and per property. *)
+let test_hoist_declaration_runs () =
+  let hoisted css =
+    Pp.to_string ~minify:true Stylesheet.pp_rule
+      (Nest.hoist_declaration_runs (rule css))
+  in
+  Alcotest.(check string)
+    "a disjoint run rejoins the rule's own declarations"
+    ".a{color:red;& b{width:1px}}"
+    (hoisted ".a{& b{width:1px}color:red}");
+  Alcotest.(check string)
+    "a clashing run keeps its place" ".a{& b{color:blue}color:red}"
+    (hoisted ".a{& b{color:blue}color:red}");
+  Alcotest.(check string)
+    "a crossed shorthand blocks its longhand"
+    ".a{& b{margin:1px}margin-top:2px}"
+    (hoisted ".a{& b{margin:1px}margin-top:2px}");
+  Alcotest.(check string)
+    "only the clashing declaration stays"
+    ".a{width:2px;& b{color:blue}color:red}"
+    (hoisted ".a{& b{color:blue}color:red;width:2px}");
+  (* [!important] wins wherever it sits, so it never has to wait. *)
+  Alcotest.(check string)
+    "a differing importance is not a clash"
+    ".a{color:red!important;& b{color:blue}}"
+    (hoisted ".a{& b{color:blue}color:red!important}");
+  (* An unknown at-rule is raw text, so nothing may be assumed about it. *)
+  Alcotest.(check string)
+    "an unknown at-rule blocks everything" ".a{@wat foo{q:1}color:red}"
+    (hoisted ".a{@wat foo{q:1}color:red}")
+
 let test_rules_synthesizes_isolated_chain () =
   let nested = Nest.rules (rules ".card{color:red}.card .title{width:1px}") in
   Alcotest.(check (list string))
@@ -76,6 +109,8 @@ let suite =
       Alcotest.test_case "combine relative nested and descendant" `Quick
         test_combine_relative_nested_and_descendant;
       Alcotest.test_case "merge_lone wrapper" `Quick test_merge_lone_wrapper;
+      Alcotest.test_case "hoist declaration runs" `Quick
+        test_hoist_declaration_runs;
       Alcotest.test_case "rules synthesizes isolated chain" `Quick
         test_rules_synthesizes_isolated_chain;
       Alcotest.test_case "rules preserves competing outside selector" `Quick


### PR DESCRIPTION
`.a { & b { width: 1px } color: red }` and `.a { color: red; & b { width: 1px } }` render identically, but since #380 pinned the trailing run in place `--diff=canonical` reported them as different and the declaration passes stopped at the boundary; the run now moves back as far as it commutes with what it crosses. Stacked on #380.