### PR TITLE
css: every nestable at-rule inside a style rule is a nesting context

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,14 @@
   not equivalent, so `.a { @supports (color: red) { color: blue } color: green }`
   now computes green as Blink and WebKit do, where cascade printed a sheet that
   computed blue (#380)
+- Every at-rule that nests inside a style rule reads its body as nesting
+  content. `.a { @starting-style { color: blue } }` kept the wrapper and dropped
+  the declaration, `@-moz-document`, `@when` and `@else` lost theirs the same
+  way, and an at-rule written inside a nested group rule, as in
+  `.a { @layer n { @media screen { color: red } } }`, reached the
+  stylesheet-level reader and lost its block too. CSS Nesting 1 sec. 3.3 nests
+  any at-rule whose body carries style rules, and Blink 146 keeps every one of
+  these shapes whole (#384)
 
 ### Minification
 
@@ -174,6 +182,9 @@
 - `Css.Stylesheet.map_statement_children` and `map_statement_declarations`
   rebuild a statement with a function applied to the block or the declarations
   it holds, the rebuilding counterparts of the two readers (#337)
+- `Css.Flatten` carries the parent selector into an `@-moz-document` block, the
+  one group rule it did not descend into. A nested declaration run came out
+  bare at the top of the block, which no reader takes back (#384)
 
 ### CLI tools
 

--- a/lib/flatten.ml
+++ b/lib/flatten.ml
@@ -65,6 +65,8 @@ and in_rule_context (parent : Selector.t) : statement -> statement list =
       [ Container (name, cond, List.concat_map (in_rule_context parent) block) ]
   | Supports (cond, block) ->
       [ Supports (cond, List.concat_map (in_rule_context parent) block) ]
+  | Moz_document (conds, block) ->
+      [ Moz_document (conds, List.concat_map (in_rule_context parent) block) ]
   | Layer (name, block) ->
       [ Layer (name, List.concat_map (in_rule_context parent) block) ]
   | Origin (origin, block) ->
@@ -99,6 +101,7 @@ let rec top_statement (stmt : statement) : statement list =
   | Container (name, cond, block) ->
       wrap block (fun b -> Container (name, cond, b))
   | Supports (cond, block) -> wrap block (fun b -> Supports (cond, b))
+  | Moz_document (conds, block) -> wrap block (fun b -> Moz_document (conds, b))
   | Layer (name, block) -> wrap block (fun b -> Layer (name, b))
   | Origin (origin, block) -> wrap block (fun b -> Origin (origin, b))
   | Starting_style block -> wrap block (fun b -> Starting_style b)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3123,6 +3123,57 @@ let seal_declaration_run = function
   | Declarations run :: rest -> Declarations (List.rev run) :: rest
   | nested -> nested
 
+let read_starting_style ~body (r : Cursor.t) : statement =
+  Cursor.expect_at_keyword "starting-style" r;
+  Cursor.ws r;
+  Starting_style (Cursor.braces body r)
+
+let read_when ~body (r : Cursor.t) : statement =
+  Cursor.expect_at_keyword "when" r;
+  Cursor.ws r;
+  let prelude = Cursor.drain_until_block r in
+  if List.for_all (fun cv -> Component.to_string cv |> String.trim = "") prelude
+  then Cursor.err_invalid r "@when: missing condition";
+  let condition : conditional =
+    try conditional_components prelude
+    with Failure msg -> Cursor.err_invalid r ("@when: " ^ msg)
+  in
+  When (condition, Cursor.braces body r)
+
+let read_else ~body (r : Cursor.t) : statement =
+  Cursor.expect_at_keyword "else" r;
+  Cursor.ws r;
+  let prelude = Cursor.drain_until_block r in
+  let condition =
+    match
+      List.filter
+        (function
+          | Component.Preserved { kind = Token.Whitespace; _ } -> false
+          | _ -> true)
+        prelude
+    with
+    | [] -> Option.None
+    | _ -> (
+        match conditional_components prelude with
+        | condition -> Some condition
+        | exception Failure msg -> Cursor.err_invalid r ("@else: " ^ msg))
+  in
+  Else (condition, Cursor.braces body r)
+
+let read_moz_document ~body (r : Cursor.t) : statement =
+  Cursor.with_context r "@-moz-document" @@ fun () ->
+  Cursor.expect_at_keyword "-moz-document" r;
+  Cursor.ws r;
+  let prelude = Cursor.drain_until_block_as_string ~trim:true r in
+  let prelude_cursor = Cursor.of_string prelude in
+  let conditions =
+    Cursor.list ~sep:Cursor.comma ~at_least:1 read_moz_document_condition
+      prelude_cursor
+  in
+  Cursor.ws prelude_cursor;
+  Cursor.expect_eof prelude_cursor;
+  Moz_document (conditions, Cursor.braces body r)
+
 let rec read_statement (r : Cursor.t) : statement =
   Cursor.ws r;
   let table : (string * (Cursor.t -> statement)) list =
@@ -3134,11 +3185,11 @@ let rec read_statement (r : Cursor.t) : statement =
       ("media", read_media);
       ("container", read_container);
       ("supports", read_supports);
-      ("-moz-document", read_moz_document);
-      ("when", read_when);
-      ("else", read_else);
+      ("-moz-document", read_moz_document ~body:read_block);
+      ("when", read_when ~body:read_block);
+      ("else", read_else ~body:read_block);
       ("supports-condition", read_supports_condition);
-      ("starting-style", read_starting_style);
+      ("starting-style", read_starting_style ~body:read_block);
       ("scope", read_scope);
       ("keyframes", read_keyframes);
       ("-webkit-keyframes", read_webkit_keyframes);
@@ -3211,46 +3262,6 @@ and read_block (r : Cursor.t) : block =
   in
   read_statements []
 
-and read_starting_style (r : Cursor.t) : statement =
-  Cursor.expect_at_keyword "starting-style" r;
-  Cursor.ws r;
-  let content = Cursor.braces (fun inner -> read_block inner) r in
-  Starting_style content
-
-and read_when (r : Cursor.t) : statement =
-  Cursor.expect_at_keyword "when" r;
-  Cursor.ws r;
-  let prelude = Cursor.drain_until_block r in
-  if List.for_all (fun cv -> Component.to_string cv |> String.trim = "") prelude
-  then Cursor.err_invalid r "@when: missing condition";
-  let condition : conditional =
-    try conditional_components prelude
-    with Failure msg -> Cursor.err_invalid r ("@when: " ^ msg)
-  in
-  let content = Cursor.braces (fun inner -> read_block inner) r in
-  When (condition, content)
-
-and read_else (r : Cursor.t) : statement =
-  Cursor.expect_at_keyword "else" r;
-  Cursor.ws r;
-  let prelude = Cursor.drain_until_block r in
-  let condition =
-    match
-      List.filter
-        (function
-          | Component.Preserved { kind = Token.Whitespace; _ } -> false
-          | _ -> true)
-        prelude
-    with
-    | [] -> Option.None
-    | _ -> (
-        match conditional_components prelude with
-        | condition -> Some condition
-        | exception Failure msg -> Cursor.err_invalid r ("@else: " ^ msg))
-  in
-  let content = Cursor.braces (fun inner -> read_block inner) r in
-  Else (condition, content)
-
 and read_media (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "media" r;
   Cursor.ws r;
@@ -3275,21 +3286,6 @@ and read_supports (r : Cursor.t) : statement =
     Cursor.err r "@supports rule requires a condition";
   let content = Cursor.braces (fun inner -> read_block inner) r in
   Supports (supports_condition ~loc:cond_loc condition, content)
-
-and read_moz_document (r : Cursor.t) : statement =
-  Cursor.with_context r "@-moz-document" @@ fun () ->
-  Cursor.expect_at_keyword "-moz-document" r;
-  Cursor.ws r;
-  let prelude = Cursor.drain_until_block_as_string ~trim:true r in
-  let prelude_cursor = Cursor.of_string prelude in
-  let conditions =
-    Cursor.list ~sep:Cursor.comma ~at_least:1 read_moz_document_condition
-      prelude_cursor
-  in
-  Cursor.ws prelude_cursor;
-  Cursor.expect_eof prelude_cursor;
-  let content = Cursor.braces (fun inner -> read_block inner) r in
-  Moz_document (conditions, content)
 
 and read_scope (r : Cursor.t) : statement =
   (* CSS Cascade 6 sec. 3.5.2: [@scope <start> to <end> { ... }]. The two
@@ -3394,7 +3390,7 @@ and read_nesting_item r =
   match Cursor.peek r with
   | None -> `Done
   | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      `Stmt (read_statement r)
+      `Stmt (read_nested_at_within_rule r)
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       Cursor.skip r;
       `Skip
@@ -3427,8 +3423,7 @@ and read_nested_decl_after_semicolon r acc =
       | None -> List.rev acc)
 
 (* Helper: Read nested at-rule with declarations content *)
-and read_nested_at_rule (r : Cursor.t) (at_rule : string)
-    (_selector : Selector.t) : statement =
+and read_nested_at_rule (r : Cursor.t) (at_rule : string) : statement =
   Cursor.with_context r at_rule @@ fun () ->
   let name = String.sub at_rule 1 (String.length at_rule - 1) in
   Cursor.expect_at_keyword name r;
@@ -3471,36 +3466,41 @@ and read_nested_scope_rule r =
   let content = Cursor.braces (fun inner -> read_nesting_block inner) r in
   Scope (scope_start, scope_end, content)
 
-and read_nested_at_within_rule (r : Cursor.t) (selector : Selector.t) :
-    statement =
+and read_nested_layer_rule r =
+  Cursor.expect_at_keyword "layer" r;
+  Cursor.ws r;
   match Cursor.peek r with
-  | Some (Component.Preserved { kind = Token.At_keyword name; _ })
-    when name = "supports" || name = "media" || name = "container"
-         || name = "scope" ->
-      read_nested_at_rule r ("@" ^ name) selector
-  | Some (Component.Preserved { kind = Token.At_keyword "layer"; _ }) -> (
-      Cursor.expect_at_keyword "layer" r;
+  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ }) ->
+      Layer (None, Cursor.braces (fun inner -> read_nesting_block inner) r)
+  | _ ->
+      let name = Cursor.ident ~keep_case:true r in
       Cursor.ws r;
-      match Cursor.peek r with
-      | Some (Component.Block { node = { opening = Token.Curly; _ }; _ }) ->
-          let content =
-            Cursor.braces (fun inner -> read_nesting_block inner) r
-          in
-          Layer (None, content)
-      | _ ->
-          let name = Cursor.ident ~keep_case:true r in
-          Cursor.ws r;
-          let content =
-            Cursor.braces (fun inner -> read_nesting_block inner) r
-          in
-          Layer (Some name, content))
-  | Some
-      (Component.Preserved
-         {
-           kind =
-             Token.At_keyword (("charset" | "import" | "namespace") as name);
-           _;
-         }) ->
+      Layer (Some name, Cursor.braces (fun inner -> read_nesting_block inner) r)
+
+and read_nested_at_within_rule (r : Cursor.t) : statement =
+  match Cursor.peek r with
+  | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
+      read_nested_at_keyword r name
+  | _ -> read_statement r
+
+(* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be
+   nested inside of a style rule as well", which is every group rule cascade
+   models - the conditional group rules @media/@supports/@container, @when and
+   @else that generalise them (CSS Conditional 5 sec. 3, sec. 4),
+   @-moz-document, @layer, @scope, and @starting-style (CSS Transitions 2 sec.
+   3.3). Nested, the body is <block-contents>, so a bare declaration run in it
+   belongs to the parent selector. Everything else keeps its stylesheet-level
+   reading: a descriptor rule such as @font-face carries no style rule, and a
+   top-of-sheet rule is invalid here outright. *)
+and read_nested_at_keyword r = function
+  | ("supports" | "media" | "container" | "scope") as name ->
+      read_nested_at_rule r ("@" ^ name)
+  | "layer" -> read_nested_layer_rule r
+  | "starting-style" -> read_starting_style ~body:read_nesting_block r
+  | "-moz-document" -> read_moz_document ~body:read_nesting_block r
+  | "when" -> read_when ~body:read_nesting_block r
+  | "else" -> read_else ~body:read_nesting_block r
+  | ("charset" | "import" | "namespace") as name ->
       Cursor.err_invalid r ("Unexpected nested at-rule: @" ^ name)
   | _ -> read_statement r
 
@@ -3508,7 +3508,7 @@ and read_rule_item selector inner decls nested =
   match Cursor.peek inner with
   | None -> `Done (List.rev decls, List.rev (seal_declaration_run nested))
   | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      let stmt = read_nested_at_within_rule inner selector in
+      let stmt = read_nested_at_within_rule inner in
       `Continue (decls, stmt :: seal_declaration_run nested)
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       Cursor.skip inner;

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -104,6 +104,22 @@ let test_nested_selector_list_keeps_parent () =
   check ".p{a::before,a::after{color:red}}" ".p a:before,.p a:after{color:red}";
   check ".p{& a,& b{color:red}}" ".p a,.p b{color:red}"
 
+(* CSS Nesting 1 sec. 3.3: any at-rule whose body carries style rules nests
+   inside a style rule, so flattening one has to carry the parent selector into
+   its declaration run. A group rule flatten does not know leaves the run bare
+   at the top of the block, which no reader takes back. *)
+let test_nested_group_rules_keep_parent () =
+  let check src expected =
+    Alcotest.(check string) src expected (render (Flatten.block (block src)))
+  in
+  check ".a{@starting-style{color:red}}" "@starting-style{.a{color:red}}";
+  check ".a{@-moz-document url-prefix(){color:red}}"
+    "@-moz-document url-prefix(){.a{color:red}}";
+  check ".a{@when media(width>0px){color:red}}"
+    "@when media(width>0px){.a{color:red}}";
+  check ".a{@layer n{@media screen{color:red}}}"
+    "@layer n{@media screen{.a{color:red}}}"
+
 let suite =
   ( "flatten",
     [
@@ -121,4 +137,6 @@ let suite =
         test_nesting_wraps_complex_parent;
       Alcotest.test_case "nested selector list keeps the parent" `Quick
         test_nested_selector_list_keeps_parent;
+      Alcotest.test_case "nested group rules keep the parent" `Quick
+        test_nested_group_rules_keep_parent;
     ] )

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2930,6 +2930,47 @@ let spec_nesting_empty_layer_keeps_block () =
   test_nesting_idempotent ".a { @layer n { } }";
   test_nesting_roundtrip ~expected:"@layer n;" "@layer n { }"
 
+(* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be
+   nested inside of a style rule as well", and its body is then read as nesting
+   content. [@starting-style] is a grouping rule over style rules (CSS
+   Transitions 2 sec. 3.3), and Blink 146 keeps the whole shape. *)
+let spec_nesting_starting_style () =
+  test_nesting_roundtrip ~expected:".a{@starting-style{color:red}}"
+    ".a { @starting-style { color: red } }";
+  test_nesting_roundtrip ~expected:".a{@starting-style{color:red}color:green}"
+    ".a { @starting-style { color: red } color: green }";
+  test_nesting_roundtrip ~expected:".a{@starting-style{& b{color:red}}}"
+    ".a { @starting-style { & b { color: red } } }";
+  test_nesting_idempotent ".a { @starting-style { color: red } color: green }"
+
+(* The same section covers every conditional group rule, not just the three
+   cascade already nested: [@-moz-document] carries style rules, and CSS
+   Conditional 5 sec. 3 and sec. 4 make [@when] and [@else] conditional group
+   rules over a rule list. *)
+let spec_nesting_other_group_rules () =
+  test_nesting_roundtrip ~expected:".a{@-moz-document url-prefix(){color:red}}"
+    ".a { @-moz-document url-prefix() { color: red } }";
+  test_nesting_roundtrip ~expected:".a{@when media(width>0px){color:red}}"
+    ".a { @when media(width > 0px) { color: red } }";
+  test_nesting_roundtrip
+    ~expected:".a{@when media(width>0px){color:red}@else{color:green}}"
+    ".a { @when media(width > 0px) { color: red } @else { color: green } }";
+  test_nesting_idempotent ".a { @-moz-document url-prefix() { color: red } }"
+
+(* A nested group rule's body is nesting content all the way down, so an at-rule
+   inside one is itself a nested group rule. Blink 146 keeps [.a{@layer n{@media
+   screen{color:red}}}] whole. *)
+let spec_nesting_at_rule_inside_nested_group () =
+  test_nesting_roundtrip ~expected:".a{@layer n{@media screen{color:red}}}"
+    ".a { @layer n { @media screen { color: red } } }";
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{@supports(foo:bar){color:red}}}"
+    ".a { @media screen { @supports (foo: bar) { color: red } } }";
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{@starting-style{color:red}}}"
+    ".a { @media screen { @starting-style { color: red } } }";
+  test_nesting_idempotent ".a { @layer n { @media screen { color: red } } }"
+
 (* CSS Nesting 1 sec. 3.4: a run of declarations written after a nested rule is
    wrapped in a nested declarations rule, which keeps its place among the nested
    rules. The spec's own worked example names the hoisted spelling as NOT
@@ -7057,6 +7098,15 @@ let additional_tests =
     ( "spec nesting empty @layer keeps block form",
       `Quick,
       spec_nesting_empty_layer_keeps_block );
+    ( "spec nesting @starting-style holds nesting content",
+      `Quick,
+      spec_nesting_starting_style );
+    ( "spec nesting other group rules hold nesting content",
+      `Quick,
+      spec_nesting_other_group_rules );
+    ( "spec nesting at-rule inside a nested group rule",
+      `Quick,
+      spec_nesting_at_rule_inside_nested_group );
     ( "spec CSS Nesting L1 preserves nested structure",
       `Quick,
       nesting_module_l1_preserves_structure );


### PR DESCRIPTION
`.a { @starting-style { color: blue } }` kept the wrapper and dropped the declaration, and `@-moz-document`, `@when`, `@else` and any at-rule written inside a nested group rule lost their bodies the same way: each read its body as a stylesheet block, so the bare declaration parsed as a selector list. CSS Nesting 1 sec. 3.3 nests any at-rule whose body carries style rules, and Blink 146 keeps every one of these shapes whole. Stacked on #380.