### PR TITLE
diff: name a rule's nested block after that rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -211,6 +211,11 @@
   overlap keys and for its position in the other rule, both of which name a
   property through a fresh buffer, where each is a fact about one declaration.
   `--minify` canonicalises a rule's declaration order the same way (#424)
+- `cascade diff` names a rule's nested block after the rule it belongs to. The
+  container printed as `& .a`, which is a selector matching a `.a` inside the
+  parent rather than the parent's own block, and a run of declarations written
+  after a nested statement was named by its first declaration instead of the
+  `&` that CSS Nesting 1 sec. 3.4 makes it (#385)
 
 ## 1.1.0
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -637,9 +637,13 @@ let container_prefix = function
   | `At_rule -> ""
 
 let container_label container_type condition =
-  match container_prefix container_type with
-  | "" -> condition
-  | prefix -> prefix ^ " " ^ condition
+  match container_type with
+  | `At_rule -> condition
+  (* A nesting container is a rule's own block, and the condition names the rule
+     it belongs to. Prefixing it as the others are prints [& .a], which is a
+     selector matching a [.a] inside the parent, the one thing it is not. *)
+  | `Nesting -> condition ^ " { & }"
+  | container_type -> container_prefix container_type ^ " " ^ condition
 
 let describe_statement stmt =
   let try_desc f = f stmt in
@@ -1110,14 +1114,21 @@ let statement_head stmt =
   else head
 
 (* Helper to extract rule information from statements *)
-let strings_of_rule stmt =
+let strings_of_rule (stmt : Css.statement) =
   match Css.as_rule stmt with
   | Some (selector, decls, _) ->
       let selector_str = Css.Selector.to_string selector in
       (selector_str, decls)
-  | None ->
-      ( statement_head stmt,
-        Option.value ~default:[] (Css.statement_declarations stmt) )
+  (* CSS Nesting 1 sec. 3.4: a run written after a nested statement is a nested
+     declarations rule, which acts as [&]. It has no head to cut at, so the text
+     up to the first brace is its first declaration, which reads in the selector
+     column as a selector it is not. *)
+  | None -> (
+      match stmt with
+      | Declarations decls -> ("&", decls)
+      | _ ->
+          ( statement_head stmt,
+            Option.value ~default:[] (Css.statement_declarations stmt) ))
 
 let decl_to_prop_value decl =
   let name = Css.declaration_name decl in

--- a/test/cli/diff_nested_block.t
+++ b/test/cli/diff_nested_block.t
@@ -1,0 +1,48 @@
+CLI: cascade diff - a rule's nested block is named as a block.
+
+The container is the block of a rule, not a selector, so it is named after the
+rule it belongs to. Prefixing it the way an at-rule container is named prints
+"& .a", which is a valid selector matching a ".a" inside the parent.
+
+  $ cat > nest-a.css <<'EOF'
+  > .a{color:red;& b{color:blue}}
+  > EOF
+  $ cat > nest-b.css <<'EOF'
+  > .a{color:red;& b{color:green}}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=tree nest-a.css nest-b.css
+  CSS: 30 chars vs 31 chars (3.3% diff)
+  Changes: 1 modified rule, 1 changed container
+  
+  --- nest-a.css
+  +++ nest-b.css
+  └─ .a { & } (1 modified)
+     └─ & b
+           * color: blue -> green
+  
+  [1]
+
+A run of declarations written after a nested statement is the nested
+declarations rule of CSS Nesting 1 sec. 3.4, which acts as "&". It has no
+head, so naming it by the text up to its first brace puts its first
+declaration in the selector column.
+
+  $ cat > run-a.css <<'EOF'
+  > .a{color:red;& b{color:blue}}
+  > EOF
+  $ cat > run-b.css <<'EOF'
+  > .a{& b{color:blue}color:red}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=tree run-a.css run-b.css
+  CSS: 30 chars vs 29 chars (3.3% diff)
+  Changes: 1 modified rule, 1 changed container
+  
+  --- run-a.css
+  +++ run-b.css
+  ├─ .a
+  │     - color
+  └─ .a { & } (1 added)
+     └─ &
+           + color red
+  
+  [1]


### PR DESCRIPTION
The tree report printed a rule's nested block as `& .a`, which reads as a selector matching a `.a` inside the parent, and named a declaration run written after a nested statement by its first declaration. Stacked on #383.