### PR TITLE
optimize: deduplicate a nested declarations run

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,6 +78,11 @@
   `.a{color:red;b{width:1px}}` and `--diff=canonical` stops reporting it as
   different from `.a { color: red; & b { width: 1px } }`. A declaration that
   does clash keeps the place CSS Nesting 1 sec. 3.4 gives it (#383)
+- A run of declarations written after a nested statement is deduplicated like
+  any other declaration list, so `.a { & b { color: red } color: blue;
+  color: green }` minifies to `.a{b{color:red}color:green}` rather than keeping
+  a write nothing can read. Nothing sits between two writes inside one run, so
+  the later wins (CSS Cascade 5 sec. 6.4.4) (#386)
 - `--minify` is faster on a stylesheet the optimizer factors heavily, for the
   same output. The rule graph's cycle check, topological order and
   selector-branch index each probed a generic `Hashtbl` once per edge or per

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -61,6 +61,7 @@ let compose_shorthands = Shorthand.compose_shorthands
 let deduplicate_declarations_with = Shorthand.deduplicate_declarations_with
 let deduplicate_declarations = Shorthand.deduplicate_declarations
 let single_rule_without_nested = Rule.single
+let declaration_run = Rule.declaration_run
 let finalize_rule_without_nested = Rule.finalize
 
 (** {1 Statement Optimization} *)
@@ -241,6 +242,15 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
   | (Import import as stmt) :: rest ->
       process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting
         ~pending acc stmt import rest
+  | (Declarations decls as stmt) :: rest ->
+      (* A run of declarations is a declaration list wherever it sits, and
+         nothing comes between two writes inside one, so the same deduplication
+         a rule body gets applies (CSS Cascade 5 sec. 6.4.4: the later write
+         wins). *)
+      let decls' = declaration_run ~ctx decls in
+      let stmt = if decls' == decls then stmt else Declarations decls' in
+      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        (stmt :: acc) rest
   | hd :: rest ->
       (* Other statement types - keep as-is *)
       process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -191,6 +191,16 @@ let synthesize_position_try decls =
       | _ -> decls)
   | _ -> decls
 
+(* The declaration passes a rule body gets, for a body that has no rule of its
+   own: a nested declarations run (CSS Nesting 1 sec. 3.4) or a bare
+   [Declarations] block. Nothing comes between two writes inside one run, so the
+   later wins exactly as it does in a rule. The selector-dependent steps are
+   left out, since neither form carries a selector. *)
+let declaration_run ~ctx decls =
+  list_map_preserve (Declaration.normalize ~lossless:(Ctx.lossless ctx)) decls
+  |> deduplicate_declarations_with ~ctx
+  |> synthesize_columns |> synthesize_position_try |> preserve_list decls
+
 let finalize ?(canonicalize_selector = true) ~ctx (rule : rule) : rule =
   let declarations =
     deduplicate_declarations_with ~ctx rule.declarations

--- a/lib/rule.mli
+++ b/lib/rule.mli
@@ -3,6 +3,11 @@
 val single : ctx:Ctx.t -> Stylesheet.rule -> Stylesheet.rule
 (** Optimize one rule without descending into nested statements. *)
 
+val declaration_run :
+  ctx:Ctx.t -> Declaration.declaration list -> Declaration.declaration list
+(** Declaration cleanup for a body that has no rule of its own: a nested
+    declarations run or a bare [Declarations] block. *)
+
 val finalize :
   ?canonicalize_selector:bool -> ctx:Ctx.t -> Stylesheet.rule -> Stylesheet.rule
 (** Final declaration cleanup before a rule leaves the fixpoint. *)

--- a/test/inline/fixtures/nested_order.html
+++ b/test/inline/fixtures/nested_order.html
@@ -8,6 +8,7 @@
   .n6 { --w: 40px; & b { --w: 50px } width: var(--w) }
   .n7 { @media (min-width: 1px) { color: blue } color: green !important }
   .n8 { color: red; @media (min-width: 1px) { padding: 3px } color: green; & i { width: 8px } font-size: 20px }
+  .n9 { @media (min-width: 1px) { color: blue } color: red; color: green }
 </style></head><body>
 <div class="n1">a<b>x</b></div>
 <div class="n2">b</div>
@@ -17,4 +18,5 @@
 <div class="n6">f<b>z</b></div>
 <div class="n7">g</div>
 <div class="n8">h<i>w</i></div>
+<div class="n9">i</div>
 </body></html>

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2055,6 +2055,35 @@ let same_selector_merge_past_nested () =
     ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}"
     (canon ".a{color:red;&:hover{padding:2rem}}.a{padding:1rem}")
 
+(* A run of declarations written after a nested statement (CSS Nesting 1 sec.
+   3.4) is a declaration list like any other, with nothing between two writes
+   inside it, so the deduplication a rule body gets applies to it. *)
+let nested_declaration_run_dedupes () =
+  let of_string css =
+    match Css.of_string css with
+    | Ok p -> p.Css.stylesheet
+    | Error _ -> Alcotest.failf "could not parse %s" css
+  in
+  let canon css =
+    Css.Optimize.stylesheet (Css.statements (of_string css))
+    |> Css.Stylesheet.to_string ~minify:true
+    |> String.trim
+  in
+  (* The run cannot move: [color] is what the nested rule sets too. *)
+  Alcotest.(check string)
+    "a repeated declaration inside a run collapses" ".a{b{color:red}color:#00f}"
+    (canon ".a{& b{color:red}color:blue;color:blue}");
+  Alcotest.(check string)
+    "a declaration the run itself overrides goes" ".a{b{color:red}color:green}"
+    (canon ".a{& b{color:red}color:blue;color:green}");
+  (* The crossed shorthand pins every one of the four longhands, so they compose
+     where they stand. *)
+  Alcotest.(check string)
+    "longhands inside a run compose" ".a{b{margin:9px}margin:1px}"
+    (canon
+       ".a{& \
+        b{margin:9px}margin-top:1px;margin-right:1px;margin-bottom:1px;margin-left:1px}")
+
 (* A selector list holding a vendor pseudo-element is invalidated as a whole by
    a browser that does not know it, so the other selectors silently lose the
    declarations. The grouping passes refuse to build such a list; one the author
@@ -5257,6 +5286,8 @@ module Fuzz = struct
         fuzz_cascade_equivalent;
       Alcotest.test_case "same-selector merge past nested children" `Quick
         same_selector_merge_past_nested;
+      Alcotest.test_case "a nested declarations run is deduplicated" `Quick
+        nested_declaration_run_dedupes;
       Alcotest.test_case "vendor pseudo-element list is split" `Quick
         vendor_pseudo_list_is_split;
       Alcotest.test_case "cascade-neutral permutations stay equivalent" `Slow


### PR DESCRIPTION
The declaration passes only ever ran on a rule's leading run, so `.a { & b { color: red } color: blue; color: green }` kept the `color:blue` nothing can read. Stacked on #385.