### PR TITLE
css: reject an at-rule that does not nest inside a style rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -52,6 +52,19 @@
   stylesheet-level reader and lost its block too. CSS Nesting 1 sec. 3.3 nests
   any at-rule whose body carries style rules, and Blink 146 keeps every one of
   these shapes whole (#384)
+- An at-rule with no style rule in its body is rejected inside a style rule
+  instead of being kept. CSS Nesting 1 sec. 3.3 nests only an at-rule whose body
+  carries style rules, so `.a { @font-face { ... } }`, `@keyframes`, `@property`,
+  `@page`, `@counter-style`, `@position-try`, `@font-palette-values`,
+  `@font-feature-values`, `@viewport` and `@supports-condition` are invalid
+  there, as is an `@else` with no preceding `@when`; each is dropped with a
+  warning that `Css.of_string ~strict:true` turns into an error, and the
+  declarations written around it stay in the rule. `@view-transition` is kept,
+  since Blink 146 still reads it there (#388)
+- Discarding an at-rule that is invalid inside a style rule ends at the at-rule
+  rather than at the next semicolon. `.a { @import url(x) { } color: red }` lost
+  `color: red`, and an `@import` inside a nested group rule took the whole group
+  with it (#388)
 
 ### Minification
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3041,6 +3041,31 @@ let rec skip_bad_rule_item inner =
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
   | Some _ -> skip_bad_rule_item inner
 
+(* CSS Syntax 3 sec. 5.4.2: an at-rule ends at its block or at its [;].
+   Discarding an invalid one consumes exactly that far, so the declarations
+   written after it stay in the rule. *)
+let rec skip_at_rule r =
+  match Cursor.next_raw r with
+  | None -> ()
+  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
+  | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
+      ()
+  | Some _ -> skip_at_rule r
+
+(* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be
+   nested inside of a style rule as well, unless otherwise specified". A
+   descriptor rule, a keyframe list and a declaration-list rule contain none, so
+   none of them nests, and Blink 146 drops each one. [\@view-transition] is a
+   descriptor rule too, yet Blink keeps it inside a style rule; dropping what a
+   shipping engine still reads is the one lossy direction, so it stays. *)
+let nests_in_style_rule = function
+  | "keyframes" | "-webkit-keyframes" | "-moz-keyframes" | "font-face"
+  | "counter-style" | "page" | "font-palette-values" | "font-feature-values"
+  | "position-try" | "viewport" | "-ms-viewport" | "property"
+  | "supports-condition" ->
+      false
+  | _ -> true
+
 let read_property_descriptors (r : Cursor.t) : property_reader_state =
   let state = ref { syntax = None; inherits = None; initial_value = None } in
   let rec loop () =
@@ -3113,6 +3138,14 @@ let item_opens_block inner =
   let found = scan () in
   Cursor.restore inner start;
   found
+
+(* Discard an at-rule that is invalid in a style rule and resume at the next
+   item, the recovery CSS Syntax 3 sec. 5.4.4 describes. The warning is what
+   [~strict:true] turns into an error. *)
+let drop_nested_at_rule r ~loc reason : statement option =
+  skip_at_rule r;
+  Cursor.push_warning r (Error.bad_value loc ~property:"rule" ~reason);
+  None
 
 (* CSS Nesting 1 sec. 3.4 wraps a run of declarations written after a nested
    statement in a nested declarations rule, so it keeps its place among them.
@@ -3379,18 +3412,20 @@ and read_layer (r : Cursor.t) : statement =
 and read_nesting_block (r : Cursor.t) : block =
   let rec read_items acc =
     Cursor.ws r;
-    match read_nesting_item r with
+    match read_nesting_item ~prev:acc r with
     | `Done -> List.rev acc
     | `Skip -> read_items acc
     | `Stmt stmt -> read_items (stmt :: acc)
   in
   read_items []
 
-and read_nesting_item r =
+and read_nesting_item ~prev r =
   match Cursor.peek r with
   | None -> `Done
-  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      `Stmt (read_nested_at_within_rule r)
+  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) -> (
+      match read_nested_at_within_rule ~prev r with
+      | Some stmt -> `Stmt stmt
+      | None -> `Skip)
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       Cursor.skip r;
       `Skip
@@ -3477,11 +3512,11 @@ and read_nested_layer_rule r =
       Cursor.ws r;
       Layer (Some name, Cursor.braces (fun inner -> read_nesting_block inner) r)
 
-and read_nested_at_within_rule (r : Cursor.t) : statement =
+and read_nested_at_within_rule ~prev (r : Cursor.t) : statement option =
   match Cursor.peek r with
-  | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
-      read_nested_at_keyword r name
-  | _ -> read_statement r
+  | Some (Component.Preserved { kind = Token.At_keyword name; loc; _ }) ->
+      read_nested_at_keyword r ~loc ~prev name
+  | _ -> Some (read_statement r)
 
 (* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be
    nested inside of a style rule as well", which is every group rule cascade
@@ -3489,27 +3524,34 @@ and read_nested_at_within_rule (r : Cursor.t) : statement =
    @else that generalise them (CSS Conditional 5 sec. 3, sec. 4),
    @-moz-document, @layer, @scope, and @starting-style (CSS Transitions 2 sec.
    3.3). Nested, the body is <block-contents>, so a bare declaration run in it
-   belongs to the parent selector. Everything else keeps its stylesheet-level
-   reading: a descriptor rule such as @font-face carries no style rule, and a
-   top-of-sheet rule is invalid here outright. *)
-and read_nested_at_keyword r = function
+   belongs to the parent selector. An at-rule with no style rule in its body is
+   invalid here and dropped; a top-of-sheet rule is invalid here outright. *)
+and read_nested_at_keyword r ~loc ~prev = function
   | ("supports" | "media" | "container" | "scope") as name ->
-      read_nested_at_rule r ("@" ^ name)
-  | "layer" -> read_nested_layer_rule r
-  | "starting-style" -> read_starting_style ~body:read_nesting_block r
-  | "-moz-document" -> read_moz_document ~body:read_nesting_block r
-  | "when" -> read_when ~body:read_nesting_block r
-  | "else" -> read_else ~body:read_nesting_block r
+      Some (read_nested_at_rule r ("@" ^ name))
+  | "layer" -> Some (read_nested_layer_rule r)
+  | "starting-style" -> Some (read_starting_style ~body:read_nesting_block r)
+  | "-moz-document" -> Some (read_moz_document ~body:read_nesting_block r)
+  | "when" -> Some (read_when ~body:read_nesting_block r)
+  | "else" when List.exists follows_conditional prev ->
+      Some (read_else ~body:read_nesting_block r)
+  | "else" -> drop_nested_at_rule r ~loc "@else without preceding @when"
   | ("charset" | "import" | "namespace") as name ->
       Cursor.err_invalid r ("Unexpected nested at-rule: @" ^ name)
-  | _ -> read_statement r
+  | name when not (nests_in_style_rule name) ->
+      drop_nested_at_rule r ~loc
+        ("@" ^ name ^ " has no style rule in it, so it does not nest")
+  | _ -> Some (read_statement r)
 
 and read_rule_item selector inner decls nested =
   match Cursor.peek inner with
   | None -> `Done (List.rev decls, List.rev (seal_declaration_run nested))
-  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      let stmt = read_nested_at_within_rule inner in
-      `Continue (decls, stmt :: seal_declaration_run nested)
+  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) -> (
+      match read_nested_at_within_rule ~prev:nested inner with
+      | Some stmt -> `Continue (decls, stmt :: seal_declaration_run nested)
+      (* A dropped at-rule leaves no gap: the declaration run written around it
+         is one run, as it is in Blink. *)
+      | None -> `Continue (decls, nested))
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       Cursor.skip inner;
       `Continue (decls, nested)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3537,7 +3537,8 @@ and read_nested_at_keyword r ~loc ~prev = function
       Some (read_else ~body:read_nesting_block r)
   | "else" -> drop_nested_at_rule r ~loc "@else without preceding @when"
   | ("charset" | "import" | "namespace") as name ->
-      Cursor.err_invalid r ("Unexpected nested at-rule: @" ^ name)
+      drop_nested_at_rule r ~loc
+        ("@" ^ name ^ " is only valid at the top of a stylesheet")
   | name when not (nests_in_style_rule name) ->
       drop_nested_at_rule r ~loc
         ("@" ^ name ^ " has no style rule in it, so it does not nest")

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1224,6 +1224,41 @@ let spec_strict_rejects_invalid_stylesheets () =
         "@namespace svg url(http://www.w3.org/2000/svg); @import url(late.css);"
       );
       ("import inside style rule", ".x { @import url(inner.css); color: red }");
+      (* CSS Nesting 1 sec. 3.3: an at-rule whose body holds no style rule does
+         not nest, so writing one inside a style rule is invalid. *)
+      ( "font-face inside style rule",
+        ".x { color: red; @font-face { font-family: F; src: url(f.woff2) } }" );
+      ( "keyframes inside style rule",
+        ".x { color: red; @keyframes k { to { opacity: 1 } } }" );
+      ( "webkit keyframes inside style rule",
+        ".x { color: red; @-webkit-keyframes k { to { opacity: 1 } } }" );
+      ( "moz keyframes inside style rule",
+        ".x { color: red; @-moz-keyframes k { to { opacity: 1 } } }" );
+      ( "property inside style rule",
+        ".x { color: red; @property --p { syntax: \"*\"; inherits: false } }" );
+      ("page inside style rule", ".x { color: red; @page { margin: 1cm } }");
+      ( "counter-style inside style rule",
+        ".x { color: red; @counter-style c { system: cyclic; symbols: \"x\" } }"
+      );
+      ( "position-try inside style rule",
+        ".x { color: red; @position-try --t { top: 1px } }" );
+      ( "font-palette-values inside style rule",
+        ".x { color: red; @font-palette-values --v { font-family: F; \
+         base-palette: 0 } }" );
+      ( "font-feature-values inside style rule",
+        ".x { color: red; @font-feature-values F { @styleset { s: 1 } } }" );
+      ( "viewport inside style rule",
+        ".x { color: red; @viewport { width: 1px } }" );
+      ( "ms-viewport inside style rule",
+        ".x { color: red; @-ms-viewport { width: 1px } }" );
+      ( "supports-condition inside style rule",
+        ".x { color: red; @supports-condition (color: red) { color: green } }"
+      );
+      (* CSS Conditional 5 sec. 4: an @else needs a preceding @when here too. *)
+      ( "orphan else inside style rule",
+        ".x { color: red; @else { color: green } }" );
+      ( "orphan else inside a nested group rule",
+        ".x { @media screen { color: red; @else { color: green } } }" );
       ("import inside media rule", "@media screen { @import url(inner.css); }");
       ("import with block", "@import url(theme.css) { .x { color: red } }");
       ( "import layer after condition",
@@ -1361,7 +1396,14 @@ let spec_lenient_recovery_stylesheets () =
     ".ok { color: green } .bad:not() { color: red } .next { color: blue }"
     ".ok{color:green}.next{color:#00f}" 1;
   lenient_recover "unclosed block auto-closes" ".btn { color: red;"
-    ".btn{color:red}" 0
+    ".btn{color:red}" 0;
+  lenient_recover "descriptor at-rule in a style rule keeps its neighbours"
+    ".a { color: red; @font-face { font-family: F; src: url(f.woff2) } \
+     background: blue }"
+    ".a{color:red;background:#00f}" 1;
+  lenient_recover "orphan else in a style rule keeps its neighbours"
+    ".a { color: red; @else { color: green } background: blue }"
+    ".a{color:red;background:#00f}" 1
 
 let stylesheet_tests =
   [
@@ -2970,6 +3012,80 @@ let spec_nesting_at_rule_inside_nested_group () =
     ~expected:".a{@media screen{@starting-style{color:red}}}"
     ".a { @media screen { @starting-style { color: red } } }";
   test_nesting_idempotent ".a { @layer n { @media screen { color: red } } }"
+
+(* CSS Nesting 1 sec. 3.3 nests "any at-rule whose body contains style rules"; a
+   descriptor rule, a keyframe list and a declaration-list rule contain none, so
+   inside a style rule they are invalid. Blink 146 drops each one and keeps the
+   declarations written around it, which is the recovery CSS Syntax 3 sec. 5.4.4
+   describes: discard the invalid construct, resume at the next one. *)
+let spec_nesting_rejects_non_group_at_rules () =
+  let drops at_rule =
+    test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+      (".a { color: red; " ^ at_rule ^ " background: blue }")
+  in
+  drops "@font-face { font-family: F; src: url(f.woff2) }";
+  drops "@keyframes k { from { opacity: 0 } to { opacity: 1 } }";
+  drops "@-webkit-keyframes k { from { opacity: 0 } to { opacity: 1 } }";
+  drops "@-moz-keyframes k { from { opacity: 0 } to { opacity: 1 } }";
+  drops "@property --p { syntax: \"<color>\"; inherits: false }";
+  drops "@page { margin: 1cm }";
+  drops "@counter-style c { system: cyclic; symbols: \"x\" }";
+  drops "@position-try --t { top: 1px }";
+  drops "@font-palette-values --v { font-family: F; base-palette: 0 }";
+  drops "@font-feature-values F { @styleset { s: 1 } }";
+  drops "@viewport { width: 100px }";
+  drops "@-ms-viewport { width: 100px }";
+  drops "@supports-condition (color: red) { color: green }"
+
+(* The same rejection inside every nesting context that a style rule opens: a
+   nested group rule's body, a nested style rule, and a rule reached through a
+   stylesheet-level group rule. *)
+let spec_nesting_rejects_non_group_at_rules_deep () =
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{color:red;background:blue}}"
+    ".a { @media screen { color: red; @font-face { font-family: F; src: \
+     url(f.woff2) } background: blue } }";
+  test_nesting_roundtrip ~expected:".a{& b{color:red;background:blue}}"
+    ".a { & b { color: red; @keyframes k { to { opacity: 1 } } background: \
+     blue } }";
+  test_nesting_roundtrip
+    ~expected:"@media screen{.a{color:red;background:blue}}"
+    "@media screen { .a { color: red; @page { margin: 1cm } background: blue } \
+     }"
+
+(* Dropping the invalid at-rule must not take a nested style rule written after
+   it, and the surviving text has to read back unchanged. *)
+let spec_nesting_rejection_keeps_the_rest () =
+  test_nesting_roundtrip ~expected:".a{color:red;& span{color:lime}b:2}"
+    ".a { color: red; @font-face { font-family: F; src: url(f.woff2) } & span \
+     { color: lime } b: 2 }";
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @font-face; background: blue }";
+  test_nesting_idempotent
+    ".a { color: red; @page { margin: 1cm } background: blue }"
+
+(* CSS View Transitions 2 gives [\@view-transition] a descriptor body, so CSS
+   Nesting 1 sec. 3.3 does not nest it either - but Blink 146 keeps it inside a
+   style rule, down to [&:hover], where every rule above is dropped. Dropping
+   what a shipping engine still reads is the one lossy direction, so cascade
+   keeps it. *)
+let spec_nesting_keeps_view_transition () =
+  test_nesting_roundtrip
+    ~expected:".a{color:red;@view-transition{navigation:auto}background:blue}"
+    ".a { color: red; @view-transition { navigation: auto } background: blue }"
+
+(* CSS Conditional 5 sec. 4: [\@else] is only valid after a [\@when] or another
+   [\@else], wherever it is written. *)
+let spec_nesting_rejects_orphan_else () =
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @else { color: green } background: blue }";
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{color:red;background:blue}}"
+    ".a { @media screen { color: red; @else { color: green } background: blue \
+     } }";
+  test_nesting_roundtrip
+    ~expected:".a{@when media(width>0px){color:red}@else{color:green}}"
+    ".a { @when media(width > 0px) { color: red } @else { color: green } }"
 
 (* CSS Nesting 1 sec. 3.4: a run of declarations written after a nested rule is
    wrapped in a nested declarations rule, which keeps its place among the nested
@@ -7107,6 +7223,21 @@ let additional_tests =
     ( "spec nesting at-rule inside a nested group rule",
       `Quick,
       spec_nesting_at_rule_inside_nested_group );
+    ( "spec nesting rejects a non-group at-rule",
+      `Quick,
+      spec_nesting_rejects_non_group_at_rules );
+    ( "spec nesting rejects a non-group at-rule at every depth",
+      `Quick,
+      spec_nesting_rejects_non_group_at_rules_deep );
+    ( "spec nesting rejection keeps the rest of the rule",
+      `Quick,
+      spec_nesting_rejection_keeps_the_rest );
+    ( "spec nesting keeps @view-transition",
+      `Quick,
+      spec_nesting_keeps_view_transition );
+    ( "spec nesting rejects an orphan @else",
+      `Quick,
+      spec_nesting_rejects_orphan_else );
     ( "spec CSS Nesting L1 preserves nested structure",
       `Quick,
       nesting_module_l1_preserves_structure );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -3087,6 +3087,23 @@ let spec_nesting_rejects_orphan_else () =
     ~expected:".a{@when media(width>0px){color:red}@else{color:green}}"
     ".a { @when media(width > 0px) { color: red } @else { color: green } }"
 
+(* A top-of-sheet rule is invalid in a style rule too, and Blink 146 drops it
+   the same way. Discarding it ends at the at-rule: [\@import url(x){}] carries
+   a block, and a skip to the next [;] runs past the end of the group rule
+   holding it. *)
+let spec_nesting_rejects_top_of_sheet_at_rules () =
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @charset \"utf-8\"; background: blue }";
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @import url(x.css); background: blue }";
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @import url(x.css) { color: pink } background: blue }";
+  test_nesting_roundtrip ~expected:".a{color:red;background:blue}"
+    ".a { color: red; @namespace n url(http://e.com); background: blue }";
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{color:red;background:blue}}"
+    ".a { @media screen { color: red; @import url(x.css); background: blue } }"
+
 (* CSS Nesting 1 sec. 3.4: a run of declarations written after a nested rule is
    wrapped in a nested declarations rule, which keeps its place among the nested
    rules. The spec's own worked example names the hoisted spelling as NOT
@@ -7238,6 +7255,9 @@ let additional_tests =
     ( "spec nesting rejects an orphan @else",
       `Quick,
       spec_nesting_rejects_orphan_else );
+    ( "spec nesting rejects a top-of-sheet at-rule",
+      `Quick,
+      spec_nesting_rejects_top_of_sheet_at_rules );
     ( "spec CSS Nesting L1 preserves nested structure",
       `Quick,
       nesting_module_l1_preserves_structure );


### PR DESCRIPTION
`.a { @font-face { ... } }` and an orphan `.a { @else { ... } }` survived a parse; CSS Nesting 1 sec. 3.3 nests only an at-rule whose body carries style rules, and Blink 146 drops every one of these while keeping the declarations around it. Discarding one now ends at the at-rule rather than running on to the next semicolon, which also stops a nested `@import` from taking its whole group rule with it.

`@view-transition` stays accepted: its body is descriptors too, but Blink 146 keeps it inside a style rule, and dropping what a shipping engine still reads is the one lossy direction. Stacked on #384.