### PR TITLE
css: close the last narrow public walks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,10 @@
 - `--minify` optimises the body of `@-moz-document`, `@starting-style`,
   `@when` and `@else`, which it walked past: rules inside one of them kept
   whatever the author wrote (#343)
+- `--minify` keeps a `@layer` whose rules write no declarations of their own
+  but nest rules that do. The emptiness test read only the declarations, so
+  `@layer a { .x { .y { color: red } } }` collapsed to `@layer a;` and every
+  declaration below the brace was deleted (#389)
 - `--flatten-nesting` treats `@-moz-document` as the grouping at-rule it is:
   nesting inside one flattens, and a rule wrapping one keeps its selector
   instead of emitting the at-rule at top level under no parent (#344)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -210,6 +210,15 @@
   rule or inside any at-rule is reported instead of only one a top-level rule
   holds. Both fold over every declaration site, which also adds the references
   an animation frame and a page margin box hold (#382)
+- `Css.Stylesheet.layers` is what `Css.layers` calls, so the two no longer give
+  different answers to the same question: the lower one reported neither a
+  layer declared inside a grouping at-rule nor the sublayer a dotted name
+  declares. `Css.Stylesheet.layer_block` is exposed alongside it (#389)
+- `Css.Stylesheet.media_queries`, `container_queries` and `Css.media_queries`
+  report a query written inside a grouping at-rule, and pair each query with
+  every rule below its brace rather than the ones sitting directly under it, so
+  a rule nested in another rule or held by an inner group is no longer missing
+  from the query it is written in (#389)
 
 ### CLI tools
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -232,6 +232,10 @@
   head it prints to, rather than describing every one of them identically. That
   description keys the ordering comparison, so a `@media` that moved between a
   `@page` and a `@starting-style` was reported as no change (#345)
+- `cascade diff --diff=tree` shows the contents of a block added or removed
+  wholesale whatever the block holds. The report read the body through its own
+  list of at-rules, so a `@scope`, a `@starting-style` or a rule nested in
+  another rule printed a header with nothing beneath it and read as empty (#389)
 - `cascade apply` keeps a declaration in the sheet when a kept rule can write
   the same cascade slot under another property name. `p{margin:0}` was
   projected into a style attribute while the `.my-7{margin-top:1.75rem}` it

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -324,12 +324,13 @@ let merge_consecutive_containers ~optimize_merged_block (stmts : statement list)
     in
     merge [] None stmts
 
-(* Check if a layer block contains only empty rules or no statements *)
+(* Whether a layer block holds nothing the cascade can act on. A rule that
+   writes no declarations of its own still carries whatever it nests, so reading
+   only the declarations called a layer empty and deleted the CSS under it. *)
 let is_layer_empty (block : statement list) : bool =
   List.for_all
-    (function Rule { declarations = []; _ } -> true | _ -> false)
+    (function Rule { declarations = []; nested = []; _ } -> true | _ -> false)
     block
-  || block = []
 
 (* Collect consecutive empty named layers and merge them into a Layer_decl *)
 let rec collect_empty_layer_names names remaining =

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -522,64 +522,8 @@ let media_queries t =
 
 (* AST Introspection Helpers *)
 
-(* CSS Cascade 5 sec. 6.4.2: a dotted layer name [foo.bar] is shorthand for the
-   nested [@layer foo { @layer bar { ... } }]. Walk the sheet once through
-   [statement_children], expanding dotted names and prefixing each name with its
-   parent's path, so a layer is reachable under one canonical name whatever the
-   input shape and an [@layer] inside a conditional group counts like any other:
-   the group decides whether its contents apply, not whether the layer exists.
-   Each entry carries the block the name opens, or [None] for a name declared by
-   a layer statement that opens none, so a statement never shadows the block
-   that fills the layer in. A sublayer of an anonymous layer has no name a
-   caller could ask for, so the walk stops there. *)
-let layer_declarations sheet =
-  let prefix_with parent name =
-    if parent = "" then name else parent ^ "." ^ name
-  in
-  let rec emit_dotted parent segments (inner : statement list option) acc =
-    match segments with
-    | [] -> acc
-    | [ leaf ] -> (
-        let qualified = prefix_with parent leaf in
-        let acc = (qualified, inner) :: acc in
-        match inner with None -> acc | Some block -> walk qualified acc block)
-    | head :: tail ->
-        (* An intermediate segment names a layer that exists but opens no block
-           of its own. *)
-        let qualified = prefix_with parent head in
-        let stub = Option.map (fun _ -> []) inner in
-        emit_dotted qualified tail inner ((qualified, stub) :: acc)
-  and walk parent acc statements =
-    List.fold_left
-      (fun acc s ->
-        match s with
-        | Layer (Some name, inner) ->
-            emit_dotted parent (String.split_on_char '.' name) (Some inner) acc
-        | Layer_decl names ->
-            List.fold_left
-              (fun acc name ->
-                emit_dotted parent (String.split_on_char '.' name) None acc)
-              acc names
-        | Layer (None, _) -> acc
-        | s -> walk parent acc (statement_children s))
-      acc statements
-  in
-  List.rev (walk "" [] sheet)
-
-let layer_block name sheet =
-  List.find_map
-    (fun (declared, block) -> if declared = name then block else None)
-    (layer_declarations sheet)
-
-let layers t =
-  let seen = Hashtbl.create 16 in
-  List.filter_map
-    (fun (name, _) ->
-      if Hashtbl.mem seen name then None
-      else (
-        Hashtbl.add seen name ();
-        Some name))
-    (layer_declarations t)
+let layer_block = Stylesheet.layer_block
+let layers = Stylesheet.layers
 
 let rules_of_statements stmts =
   List.filter_map

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -486,9 +486,11 @@ val statements : t -> statement list
 (** [statements t] returns all top-level statements from the stylesheet. *)
 
 val fold : ('a -> statement -> 'a) -> 'a -> t -> 'a
-(** [fold f acc css] folds over all statements in [css], recursively descending
-    into nested structures (layers, media queries, containers, and supports
-    rules). The function [f] is called for each statement in depth-first order.
+(** [fold f acc css] folds [f] over every statement in [css] and over every
+    statement reachable from one, in source order: a rule nested in a rule, a
+    block at-rule inside a group, and whatever those hold in turn. The walk
+    descends through {!Stylesheet.statement_children}, so it reaches every
+    statement the AST can hold rather than a listed set of at-rules.
 
     Example: Collect all selectors from all rules (including nested ones):
     {[
@@ -504,7 +506,11 @@ val fold : ('a -> statement -> 'a) -> 'a -> t -> 'a
     ]} *)
 
 val media_queries : t -> (Media.t * statement list) list
-(** [media_queries t] returns media queries and their rule statements. *)
+(** [media_queries t] is every [@media] in [t], at any depth, paired with the
+    rule statements below its brace. A query inside a group at-rule counts, and
+    a rule nested in another rule or held by an inner group is one of the
+    query's rules; a nested rule keeps the relative selector it was written
+    with. *)
 
 val layers : t -> string list
 (** [layers t] is every cascade layer [t] declares, one dotted path per layer

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -723,20 +723,10 @@ let describe_statement stmt =
 (* The body of a container that was added or removed wholesale. Every statement
    gets a line, including the ones [Css.as_rule] cannot see: a statement the
    tree drops silently leaves the reader counting fewer entries than the header
-   claims, and shifts the last-child connector onto the wrong one. *)
-let statement_children stmt =
-  match Css.as_media stmt with
-  | Some (_, body) -> body
-  | None -> (
-      match Css.as_supports stmt with
-      | Some (_, body) -> body
-      | None -> (
-          match Css.as_layer stmt with
-          | Some (_, body) -> body
-          | None -> (
-              match Css.as_container stmt with
-              | Some (_, _, body) -> body
-              | None -> [])))
+   claims, and shifts the last-child connector onto the wrong one. The body
+   comes from the shared reader, so a header never stands over children the walk
+   could not name. *)
+let statement_children = Css.Stylesheet.statement_children
 
 let rec pp_container_rules ~style ~parent_prefix ~label buf rules =
   let count = List.length rules in

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -100,7 +100,8 @@ val drop_unknown_at_rules : t -> t
 
 val drop_empty_rules : t -> t
 (** [drop_empty_rules ss] removes top-level rules and at-rule frames whose body
-    is empty (no declarations and no nested rules). *)
+    is empty (no declarations and no nested rules), and rules whose selector
+    {!Selector.matches_nothing}, which no element can ever be styled by. *)
 
 (** {1 Edge Model} *)
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1560,30 +1560,103 @@ let rec extract_rules = function
   | Rule r :: rest -> r :: extract_rules rest
   | _ :: rest -> extract_rules rest
 
-let rec extract_layer_names = function
-  | [] -> []
-  | Layer (Some name, _) :: rest -> name :: extract_layer_names rest
-  | Layer_decl names :: rest -> names @ extract_layer_names rest
-  | _ :: rest -> extract_layer_names rest
+(* Every rule below a brace, not the ones that happen to sit directly under it:
+   a rule nested in another rule and a rule inside an inner group are both under
+   the query, and a walk that stopped at the direct children would report the
+   query with a body it does not have. A nested rule keeps the relative selector
+   it was written with. *)
+let rules_below block =
+  List.rev
+    (fold_statements
+       (fun acc stmt -> match stmt with Rule r -> r :: acc | _ -> acc)
+       [] block)
 
-let rec extract_media_queries = function
-  | [] -> []
-  | Media (condition, content) :: rest ->
-      (condition, extract_rules content) :: extract_media_queries rest
-  | _ :: rest -> extract_media_queries rest
+(* CSS Cascade 5 sec. 6.4.2: a dotted layer name [foo.bar] is shorthand for the
+   nested [@layer foo { @layer bar { ... } }]. Walk the sheet once through
+   [statement_children], expanding dotted names and prefixing each name with its
+   parent's path, so a layer is reachable under one canonical name whatever the
+   input shape and an [@layer] inside a conditional group counts like any other:
+   the group decides whether its contents apply, not whether the layer exists.
+   Each entry carries the block the name opens, or [None] for a name declared by
+   a layer statement that opens none, so a statement never shadows the block
+   that fills the layer in. A sublayer of an anonymous layer has no name a
+   caller could ask for, so the walk stops there. *)
+let layer_declarations sheet =
+  let prefix_with parent name =
+    if String.equal parent "" then name else parent ^ "." ^ name
+  in
+  let rec emit_dotted parent segments (inner : block option) acc =
+    match segments with
+    | [] -> acc
+    | [ leaf ] -> (
+        let qualified = prefix_with parent leaf in
+        let acc = (qualified, inner) :: acc in
+        match inner with None -> acc | Some block -> walk qualified acc block)
+    | head :: tail ->
+        (* An intermediate segment names a layer that exists but opens no block
+           of its own. *)
+        let qualified = prefix_with parent head in
+        let stub = Option.map (fun _ -> []) inner in
+        emit_dotted qualified tail inner ((qualified, stub) :: acc)
+  and walk parent acc statements =
+    List.fold_left
+      (fun acc s ->
+        match s with
+        | Layer (Some name, inner) ->
+            emit_dotted parent (String.split_on_char '.' name) (Some inner) acc
+        | Layer_decl names ->
+            List.fold_left
+              (fun acc name ->
+                emit_dotted parent (String.split_on_char '.' name) None acc)
+              acc names
+        | Layer (None, _) -> acc
+        | s -> walk parent acc (statement_children s))
+      acc statements
+  in
+  List.rev (walk "" [] sheet)
 
-let rec extract_container_queries = function
-  | [] -> []
-  | Container (name, condition, content) :: rest ->
-      (name, condition, extract_rules content) :: extract_container_queries rest
-  | _ :: rest -> extract_container_queries rest
+let layer_block name sheet =
+  List.find_map
+    (fun (declared, block) ->
+      if String.equal declared name then block else None)
+    (layer_declarations sheet)
+
+let layers sheet =
+  let seen = Hashtbl.create 16 in
+  List.filter_map
+    (fun (name, _) ->
+      if Hashtbl.mem seen name then None
+      else (
+        Hashtbl.add seen name ();
+        Some name))
+    (layer_declarations sheet)
+
+(* A group at-rule above the query is not a reason to report nothing: it decides
+   whether its contents apply, not whether the query exists. *)
+let queries_of pick block =
+  List.rev
+    (fold_statements
+       (fun acc stmt -> match pick stmt with Some q -> q :: acc | None -> acc)
+       [] block)
 
 (* Legacy compatibility functions *)
 let empty = empty_stylesheet
 let rules t = extract_rules t
-let layers t = extract_layer_names t
-let media_queries t = extract_media_queries t
-let container_queries t = extract_container_queries t
+
+let media_queries t =
+  queries_of
+    (function
+      | Media (condition, block) -> Some (condition, rules_below block)
+      | _ -> None)
+    t
+
+let container_queries t =
+  queries_of
+    (function
+      | Container (name, condition, block) ->
+          Some (name, condition, rules_below block)
+      | _ -> None)
+    t
 
 (** {1 Reading/Parsing} *)
 

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -427,14 +427,29 @@ val rules : t -> rule list
 (** [rules t] returns the top-level rules from the stylesheet. *)
 
 val layers : t -> string list
-(** [layers t] returns the layer names from the stylesheet. *)
+(** [layers t] is every cascade layer [t] declares, one dotted path per layer
+    ([a.b] is the sublayer [b] of [a], however it was written), in the order the
+    sheet first names them. A layer named inside a conditional group counts: the
+    group decides whether its contents apply, not whether the layer exists. A
+    sublayer of an anonymous [@layer { ... }] has no name to report. *)
+
+val layer_block : string -> t -> block option
+(** [layer_block name t] is the statements of the layer [name], wherever it is
+    declared and whatever form declares it: a dotted name, a nested block, or a
+    block inside a conditional group. It is [None] when no [@layer] block opens
+    that layer, so a name only an [@layer a, b;] statement declares is [None] as
+    well. *)
 
 val media_queries : t -> (Media.t * rule list) list
-(** [media_queries t] returns the media queries from the stylesheet. *)
+(** [media_queries t] is every [@media] in [t], at any depth, paired with every
+    rule below its brace. A query inside a group at-rule counts, and a rule
+    nested in another rule or held by an inner group is one of the query's
+    rules; a nested rule keeps the relative selector it was written with. *)
 
 val container_queries :
   t -> (string option * Container.t option * rule list) list
-(** [container_queries t] returns the container queries from the stylesheet. *)
+(** [container_queries t] is every [@container] in [t], paired with every rule
+    below its brace, on the same terms as {!media_queries}. *)
 
 (** {1 Parsing and Pretty-printing} *)
 

--- a/test/test_block.ml
+++ b/test/test_block.ml
@@ -60,6 +60,28 @@ let test_is_layer_empty () =
       Alcotest.(check bool) "empty layer body" true (Block.is_layer_empty body)
   | _ -> Alcotest.fail "expected one layer statement"
 
+(* A rule with no declarations of its own still carries whatever it nests, so a
+   layer holding one is a layer with contents. Reading only the declarations
+   turned the block into a bare [@layer a;] and deleted the CSS under it. *)
+let test_is_layer_not_empty_with_nested () =
+  let cases =
+    [
+      ("a rule nesting two rules", "@layer a{.x{.y{color:red}.z{color:blue}}}");
+      ("a selector list nesting a rule", "@layer a{.x,.w{.y{color:red}}}");
+      ("a rule nesting an at-rule", "@layer a{.x{@media print{color:red}}}");
+    ]
+  in
+  List.iter
+    (fun (name, css) ->
+      match block css with
+      | [ Stylesheet.Layer (_, body) ] ->
+          Alcotest.(check bool)
+            (name ^ ": the layer has contents")
+            false
+            (Block.is_layer_empty body)
+      | _ -> Alcotest.fail "expected one layer statement")
+    cases
+
 let suite =
   ( "block",
     [
@@ -71,4 +93,6 @@ let suite =
         test_merge_media_combines_same_condition;
       Alcotest.test_case "drop empty rules" `Quick test_drop_empty_rules;
       Alcotest.test_case "is_layer_empty" `Quick test_is_layer_empty;
+      Alcotest.test_case "is_layer_empty sees nested rules" `Quick
+        test_is_layer_not_empty_with_nested;
     ] )

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -897,6 +897,112 @@ let public_layers_conditional_groups () =
             Stylesheet.Layer (Some "third", [ styled ]);
           ]))
 
+(* [Stylesheet.layers] and [Css.layers] answer one question, so they answer it
+   the same way: two functions in one library disagreeing about what a sheet
+   declares makes the answer depend on which one a caller happened to reach
+   for. *)
+let stylesheet_layers_agree_with_css () =
+  let styled = rule ~selector:(Selector.class_ "a") [ color (hex "#111111") ] in
+  let sheets =
+    [
+      ("dotted name", v [ Stylesheet.Layer (Some "foo.bar", [ styled ]) ]);
+      ( "layer in a group",
+        v
+          [
+            Stylesheet.Media
+              ( Media.of_string "screen",
+                [ Stylesheet.Layer (Some "inner", [ styled ]) ] );
+          ] );
+      ( "layer in a rule",
+        v
+          [
+            rule ~selector:(Selector.class_ "b")
+              ~nested:[ Stylesheet.Layer (Some "deep", [ styled ]) ]
+              [];
+          ] );
+      ("statement form", v [ Stylesheet.Layer_decl [ "one"; "two.three" ] ]);
+    ]
+  in
+  List.iter
+    (fun (label, sheet) ->
+      Alcotest.(check (list string))
+        (label ^ ": Stylesheet.layers matches Css.layers")
+        (layers sheet)
+        (Css.Stylesheet.layers sheet))
+    sheets
+
+(* A [@media] or [@container] is the same at-rule whether or not a group sits
+   above it, and the rules it holds are the ones below its brace, not the ones
+   that happen to be direct children. A walk that stops at the top level reports
+   neither, so a caller gets a wrong answer rather than a partial one. *)
+let stylesheet_queries_reach_nested () =
+  let styled sel =
+    rule ~selector:(Selector.class_ sel) [ color (hex "#111111") ]
+  in
+  let screen = Media.of_string "screen" in
+  let wide = Container.of_string "(width > 10px)" in
+  let selectors_of rules =
+    List.map (fun (r : Stylesheet.rule) -> Selector.to_string r.selector) rules
+  in
+  (* The at-rule sits under a group. *)
+  let grouped wrap =
+    v [ Stylesheet.Supports (Supports.of_string "(top: 0)", [ wrap ]) ]
+  in
+  let media_in_group = grouped (Stylesheet.Media (screen, [ styled "a" ])) in
+  Alcotest.(check (list string))
+    "@media under @supports is still a media query" [ ".a" ]
+    (List.concat_map
+       (fun (_, rules) -> selectors_of rules)
+       (Css.Stylesheet.media_queries media_in_group));
+  let container_in_group =
+    grouped (Stylesheet.Container (Some "card", Some wide, [ styled "a" ]))
+  in
+  Alcotest.(check (list string))
+    "@container under @supports is still a container query" [ ".a" ]
+    (List.concat_map
+       (fun (_, _, rules) -> selectors_of rules)
+       (Css.Stylesheet.container_queries container_in_group));
+  (* The rules sit under something inside the at-rule. *)
+  let deep_body =
+    [
+      rule ~selector:(Selector.class_ "outer")
+        ~nested:[ styled "nested" ]
+        [ color (hex "#111111") ];
+      Stylesheet.Layer (Some "l", [ styled "layered" ]);
+    ]
+  in
+  Alcotest.(check (list string))
+    "a media query holds every rule below its brace"
+    [ ".outer"; ".nested"; ".layered" ]
+    (List.concat_map
+       (fun (_, rules) -> selectors_of rules)
+       (Css.Stylesheet.media_queries
+          (v [ Stylesheet.Media (screen, deep_body) ])));
+  Alcotest.(check (list string))
+    "a container query holds every rule below its brace"
+    [ ".outer"; ".nested"; ".layered" ]
+    (List.concat_map
+       (fun (_, _, rules) -> selectors_of rules)
+       (Css.Stylesheet.container_queries
+          (v [ Stylesheet.Container (None, Some wide, deep_body) ])));
+  (* [Css.media_queries] is the same walk with the rules wrapped back up as
+     statements, so it reaches what the one below it reaches. *)
+  let statement_selectors =
+    List.concat_map
+      (fun (_, stmts) ->
+        List.filter_map
+          (fun stmt ->
+            match as_rule stmt with
+            | Some (sel, _, _) -> Some (Selector.to_string sel)
+            | None -> None)
+          stmts)
+      (media_queries (grouped (Stylesheet.Media (screen, deep_body))))
+  in
+  Alcotest.(check (list string))
+    "Css.media_queries reaches the same rules"
+    [ ".outer"; ".nested"; ".layered" ]
+    statement_selectors
+
 (* [vars_of_rules] answers the same question as [vars_of_stylesheet] over the
    statements it is given, so it reports a reference wherever a declaration
    sits: nested in a rule, inside any grouping at-rule, and in an at-rule that
@@ -1496,6 +1602,10 @@ let suite =
         public_custom_props_declaration_sites;
       Alcotest.test_case "public layers in conditional groups" `Quick
         public_layers_conditional_groups;
+      Alcotest.test_case "stylesheet layers agree with css layers" `Quick
+        stylesheet_layers_agree_with_css;
+      Alcotest.test_case "stylesheet queries reach nested" `Quick
+        stylesheet_queries_reach_nested;
       Alcotest.test_case "public var declaration sites" `Quick
         public_vars_declaration_sites;
       Alcotest.test_case "public property introspection" `Quick

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -587,6 +587,33 @@ let test_tw_empty_layers_statement () =
     "empty components/utilities collapse to one layer statement"
     "@layer components,utilities;" output
 
+(* A rule that writes no declarations of its own but nests rules that do is a
+   rule with contents, so the layer holding it is not an empty layer. Collapsing
+   it to the statement form deleted every declaration below the brace. *)
+let test_layer_keeps_nested_only_rule () =
+  let cases =
+    [
+      ( "a rule nesting two rules",
+        "@layer a{.x{.y{color:red}.z{margin:0}}}",
+        "@layer a{.x{.y{color:red}.z{margin:0}}}" );
+      ( "a selector list nesting a rule",
+        "@layer a{.w,.x{.y{color:red}}}",
+        "@layer a{.w,.x{.y{color:red}}}" );
+      ( "a rule nesting an at-rule",
+        "@layer a{.x{@media print{color:red}}}",
+        "@layer a{.x{@media print{color:red}}}" );
+    ]
+  in
+  List.iter
+    (fun (name, input, expected) ->
+      let optimized =
+        Css.Optimize.stylesheet (Css.Stylesheet.read (Cursor.of_string input))
+      in
+      Alcotest.(check string)
+        name expected
+        (Css.Stylesheet.to_string ~minify:true optimized |> String.trim))
+    cases
+
 let test_tw_conditionals_layer () =
   (* Tailwind emits utility rules inside @layer utilities. Cascade owns the
      generic CSS optimization: adjacent identical conditions merge inside that
@@ -1424,6 +1451,9 @@ let optimize_tests =
     ( "tailwind empty components/utilities layers to statement",
       `Quick,
       test_tw_empty_layers_statement );
+    ( "layer keeps a rule that only nests",
+      `Quick,
+      test_layer_keeps_nested_only_rule );
     ( "tailwind conditionals merge inside layer",
       `Quick,
       test_tw_conditionals_layer );

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -1119,6 +1119,44 @@ let nested_layer_order_pin_is_reported () =
     "and the report names them by their dotted paths" true
     (string_contains ~needle:"a.c now precedes a.b" s)
 
+(* A block added or dropped wholesale is rendered from its own body, and the
+   header claims children the reader then has to find. Reading the body through
+   a private list of at-rules left a [@scope], a [@starting-style] and a nested
+   rule printing a header with nothing under it, which reads as an empty block
+   rather than one whose contents the report failed to walk. *)
+let wholesale_block_shows_every_child () =
+  let cases =
+    [
+      ( "@scope inside an added @media",
+        "@media print{@scope(.card){.x{color:blue}.y{color:green}}}",
+        [ "@scope(.card)"; ".x"; ".y" ] );
+      ( "@starting-style inside an added @layer",
+        "@layer l{@starting-style{.x{color:blue}}}",
+        [ "@starting-style"; ".x" ] );
+      ( "a nested rule inside an added @media",
+        "@media print{.x{color:blue;.y{color:green}}}",
+        [ ".x"; ".y" ] );
+      ( "@when inside an added @supports",
+        "@supports (top:0){@when media(screen){.x{color:blue}}}",
+        [ ".x" ] );
+    ]
+  in
+  List.iter
+    (fun (name, added, wanted) ->
+      let out =
+        render
+          (diff_of ~expected:".keep{color:red}"
+             ~actual:(".keep{color:red}" ^ added))
+      in
+      List.iter
+        (fun affix ->
+          Alcotest.(check bool)
+            (name ^ ": the tree names " ^ affix)
+            true
+            (Astring.String.is_infix ~affix out))
+        wanted)
+    cases
+
 let suite =
   ( "tree_diff",
     [
@@ -1265,6 +1303,8 @@ let suite =
         deeply_nested_leaf_change_named;
       Alcotest.test_case "deeply nested identical is empty" `Quick
         deeply_nested_identical_is_empty;
+      Alcotest.test_case "wholesale block shows every child" `Quick
+        wholesale_block_shows_every_child;
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "pp_rule_diff_simple does not crash" `Quick
         pp_rule_diff_simple_ok;


### PR DESCRIPTION
`Css.Stylesheet.layers` disagreed with `Css.layers`, `media_queries` and `container_queries` saw neither a query inside a grouping at-rule nor a rule nested below one, `cascade diff --diff=tree` printed an added `@scope` as a header with nothing beneath it, and a `@layer` whose rules only nested other rules was minified away to `@layer a;` with every declaration below the brace deleted.

Stacked on #382.