### PR TITLE
font-family: quote a name that cannot start an ident sequence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -267,6 +267,11 @@
   conflict test walks the two key lists in step instead of scanning one per
   element of the other, and collecting them no longer rescans what it has
   already collected (#422)
+- A `font-family` name that cannot be spelled as an identifier keeps its
+  quotes. The unquoting guard checked which characters a name is made of but
+  not how CSS Syntax 3 sec. 4.3.9 lets an ident sequence start, so `"2Brand"`,
+  `"-2x"` and `"-"` came out bare in every mode and a browser dropped the whole
+  declaration, taking the rest of the font stack with it (#390)
 - A same-condition `@media` block is no longer hoisted over a declaration
   written after a nested rule. CSS Nesting 1 sec. 3.4 keeps that run behind the
   rule it follows, so it is one more rule the hoist reorders, and

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -517,18 +517,31 @@ let rec read_font_variant_east_asian t : font_variant_east_asian =
       | features, _ -> (Features features : font_variant_east_asian))
     t
 
+(* CSS Syntax 3 sec. 4.3.9: an ident sequence starts with a name-start code
+   point, or with a [-] followed by a name-start code point or by a second [-].
+   Sec. 4.2 counts a letter, [_] and a non-ASCII code point as name-start, and
+   adds the digits and [-] to the name code points that may follow. A name
+   needing an escape has no plain ident spelling, so [\] and every other
+   non-name byte fails here and the name is written as a [<string>] instead.
+   Non-ASCII is held to the ASCII rule and stays quoted too. *)
 let is_font_family_ident_word s =
   let len = String.length s in
-  let is_alpha = function 'a' .. 'z' | 'A' .. 'Z' -> true | _ -> false in
-  let is_digit = function '0' .. '9' -> true | _ -> false in
-  let is_ident_char = function
+  let is_name_start = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '_' -> true
+    | _ -> false
+  in
+  let is_name_char = function
     | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> true
     | _ -> false
   in
-  len > 0
-  && (is_alpha s.[0] || s.[0] = '_' || s.[0] = '-')
-  && (not (len >= 2 && s.[0] = '-' && is_digit s.[1]))
-  && String.for_all is_ident_char s
+  let starts_ident =
+    len > 0
+    && (is_name_start s.[0]
+       || Char.equal s.[0] '-'
+          && len >= 2
+          && (is_name_start s.[1] || Char.equal s.[1] '-'))
+  in
+  starts_ident && String.for_all is_name_char s
 
 let can_unquote_font_family_name s =
   match String.split_on_char ' ' s with
@@ -577,16 +590,13 @@ let unquote_font_family_strings components =
 
 (* CSS Fonts 4 sec. 2.1: a [<family-name>] is a [<string>] or a
    [<custom-ident>+], and the two spell the same name. Emit the bare ident
-   sequence when it reads back as that same name and quote otherwise; a single
-   word colliding with a generic family or a CSS-wide keyword must stay quoted,
-   since dropping the quotes turns the name into the keyword. The unquoted
-   multi-word form is shorter but is not the CSSOM-canonical serialization, so
-   [enforce_spec] keeps the quotes. *)
+   sequence when it reads back as that same name and quote otherwise: a name
+   that is no ident sequence at all keeps its quotes, and so does a single word
+   colliding with a generic family or a CSS-wide keyword, since dropping the
+   quotes there turns the name into the keyword. The unquoted multi-word form is
+   shorter but is not the CSSOM-canonical serialization, so [enforce_spec] keeps
+   the quotes. *)
 let pp_family_name ctx s =
-  let safe_ident_char = function
-    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> true
-    | _ -> false
-  in
   let collides_with_keyword =
     List.mem (String.lowercase_ascii s)
       [
@@ -616,9 +626,8 @@ let pp_family_name ctx s =
     Pp.minified ctx && (not ctx.Pp.enforce_spec)
     && can_unquote_font_family_name s
   then Pp.string ctx s
-  else if
-    s = "" || (not (String.for_all safe_ident_char s)) || collides_with_keyword
-  then Pp.quoted_string ctx s
+  else if collides_with_keyword || not (is_font_family_ident_word s) then
+    Pp.quoted_string ctx s
   else Pp.string ctx s
 
 let is_generic_family : font_family -> bool = function

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -396,6 +396,71 @@ let spec_fontface_family_descriptor_verbatim () =
       Alcotest.failf "@font-face family name rewrites:\n%s"
         (String.concat "\n" mismatches)
 
+(* The [font-family] descriptor, every reference to it, and
+   [@font-feature-values] share one family-name printer, so one bad ident
+   spelling breaks all three at once. CSS Syntax 3 sec. 4.3.9: a name starting
+   with a digit, or with [-] followed by a digit, or consisting of a lone [-],
+   does not start an ident sequence, so it has no [<custom-ident>] spelling and
+   CSS Fonts 4 sec. 2.1.1 leaves only the [<string>] one. Each output is re-read
+   in strict mode: what the printer emits names the same family. *)
+let spec_family_name_ident_start () =
+  let check (name, input, expected) =
+    let fail fmt = Fmt.kstr (fun s -> Some s) fmt in
+    match Css.of_string ~strict:false input with
+    | Error _ -> fail "%s: parse rejected %S" name input
+    | Ok { Css.stylesheet; _ } -> (
+        let actual = Css.to_string ~minify:true stylesheet |> String.trim in
+        if not (String.equal actual expected) then
+          fail "%s\n  input:    %S\n  expected: %S\n  actual:   %S" name input
+            expected actual
+        else
+          match Css.of_string ~strict:true actual with
+          | Error e ->
+              fail "%s: output does not read back: %S\n  %s" name actual
+                (Error.to_string e)
+          | Ok { Css.stylesheet; _ } ->
+              let again =
+                Css.to_string ~minify:true stylesheet |> String.trim
+              in
+              if String.equal again actual then None
+              else
+                fail "%s: not a fixpoint\n  once:  %S\n  twice: %S" name actual
+                  again)
+  in
+  match
+    List.filter_map check
+      [
+        ( "a name starting with a digit stays quoted in the descriptor",
+          "@font-face{font-family:\"2Brand\";src:url(a.woff2)}",
+          "@font-face{font-family:\"2Brand\";src:url(a.woff2)}" );
+        ( "a name starting with a digit stays quoted in a reference",
+          ".a{font-family:\"2Brand\",sans-serif}",
+          ".a{font-family:\"2Brand\",sans-serif}" );
+        ( "a name starting with a digit stays quoted in the font shorthand",
+          ".a{font:12px/1.5 \"2Brand\"}",
+          ".a{font:12px/1.5 \"2Brand\"}" );
+        ( "a name starting with a digit stays quoted in @font-feature-values",
+          "@font-feature-values \"2Brand\"{@styleset{x:1}}",
+          "@font-feature-values \"2Brand\"{@styleset{x:1}}" );
+        ( "hyphen then digit stays quoted",
+          ".a{font-family:\"-2x\"}",
+          ".a{font-family:\"-2x\"}" );
+        ( "a lone hyphen stays quoted",
+          ".a{font-family:\"-\"}",
+          ".a{font-family:\"-\"}" );
+        ( "a lone hyphen keeps a multi-word name quoted",
+          ".a{font-family:\"Brand -\"}",
+          ".a{font-family:\"Brand -\"}" );
+        ( "a double hyphen starts an ident sequence and unquotes",
+          ".a{font-family:\"--brand\"}",
+          ".a{font-family:--brand}" );
+      ]
+  with
+  | [] -> ()
+  | mismatches ->
+      Alcotest.failf "family names spelled as invalid idents:\n%s"
+        (String.concat "\n" mismatches)
+
 let suite =
   let open Alcotest in
   ( "font_face",
@@ -424,4 +489,6 @@ let suite =
         spec_fontface_var_descriptor_edges;
       test_case "spec font-face family descriptor verbatim" `Quick
         spec_fontface_family_descriptor_verbatim;
+      test_case "spec family name ident start" `Quick
+        spec_family_name_ident_start;
     ] )

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2149,6 +2149,45 @@ let test_font_family () =
   check_font_family ~roundtrip:true ~expected:"inter" "\"inter\"";
   check_font_family ~roundtrip:true ~expected:"OPEN SANS" "\"OPEN SANS\"";
   check_font_family ~roundtrip:true ~expected:"Open Sans" "\"Open Sans\"";
+  (* CSS Syntax 3 sec. 4.3.9 gates when a name may be spelled as an ident at
+     all: the first code point must be a name-start code point, or a [-]
+     followed by a name-start code point or by a second [-]. A name that fails
+     that test has no unquoted spelling - CSS Fonts 4 sec. 2.1.1 leaves only the
+     [<string>] arm of [<family-name>] - and emitting it bare makes the browser
+     drop the whole declaration. *)
+  check_font_family ~roundtrip:true ~expected:"\"2Brand\"" "\"2Brand\"";
+  check_font_family ~roundtrip:true ~expected:"\"9\"" "\"9\"";
+  check_font_family ~roundtrip:true ~expected:"\"-2x\"" "\"-2x\"";
+  check_font_family ~roundtrip:true ~expected:"\"-\"" "\"-\"";
+  (* The guard is not a minify choice: the unminified printer picks the same
+     spelling. *)
+  check_font_family ~minify:false ~roundtrip:true ~expected:"\"2Brand\""
+    "\"2Brand\"";
+  check_font_family ~minify:false ~roundtrip:true ~expected:"\"-2x\"" "\"-2x\"";
+  (* The other side of sec. 4.3.9: a second [-] starts an ident sequence, and
+     sec. 4.2 counts [_] as a name-start code point, so these do unquote. *)
+  check_font_family ~roundtrip:true ~expected:"--brand" "\"--brand\"";
+  check_font_family ~roundtrip:true ~expected:"--" "\"--\"";
+  check_font_family ~roundtrip:true ~expected:"-x" "\"-x\"";
+  check_font_family ~roundtrip:true ~expected:"_brand" "\"_brand\"";
+  check_font_family ~roundtrip:true ~expected:"_" "\"_\"";
+  (* Sec. 4.2: [.] is not a name code point, and sec. 4.3.7 reads [\] as the
+     start of an escape, so [a\b] would name the family [ab]. Both stay
+     quoted. *)
+  check_font_family ~roundtrip:true ~expected:"\"Foo.Bar\"" "\"Foo.Bar\"";
+  check_font_family ~roundtrip:true ~expected:"\"a\\\\b\"" "\"a\\\\b\"";
+  (* Every word of a [<custom-ident>+] sequence is an ident in its own right, so
+     the same start rule gates each of them. *)
+  check_font_family ~roundtrip:true ~expected:"\"Brand -\"" "\"Brand -\"";
+  check_font_family ~roundtrip:true ~expected:"\"3 Rounded\"" "\"3 Rounded\"";
+  (* CSS Fonts 4 sec. 2.1 spells [font-family] as [[ <family-name> |
+     <generic-family> ]#], so the bare keyword is the generic and only the
+     quoted form names a family; CSS Values 4 sec. 4.2 excludes the CSS-wide
+     keywords and the reserved [default] from [<custom-ident>]. Unquoting any of
+     these changes the meaning rather than the spelling. *)
+  check_font_family ~roundtrip:true ~expected:"\"serif\"" "\"serif\"";
+  check_font_family ~roundtrip:true ~expected:"\"inherit\"" "\"inherit\"";
+  check_font_family ~roundtrip:true ~expected:"\"default\"" "\"default\"";
   (* Test actual invalid cases *)
   neg_cursor read_font_family "123invalid";
   (* identifier can't start with number *)


### PR DESCRIPTION
`font-family: "2Brand"` came out as `font-family: 2Brand`, in every mode: the unquoting guard checked which characters a name is made of but not the CSS Syntax 3 sec. 4.3.9 rule for how an ident sequence may start, so a browser dropped the declaration and the rest of the font stack with it.

Stacked on #387.
