### PR TITLE
test/inline: test the binary in the tree, not the one on PATH

### DIFF
--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -13,8 +13,15 @@ before and after.
   computed style.
 
 ```sh
-CASCADE=_build/default/bin/main.exe sh test/inline/run.sh
+sh test/inline/run.sh
 ```
+
+The binary under test is the working tree's: `run.sh` builds `bin/main.exe`
+through the checkout's own opam switch and heads its output with the path and
+version it resolved. `CASCADE` overrides it with a path, to measure an
+installed release on purpose. There is no fallback to a `cascade` on `PATH`,
+which would report on whichever release is installed while reading as a result
+about the branch.
 
 It looks for a headless Chrome on `PATH`, in `$CHROME`, or under the puppeteer
 cache (highest version, ordered numerically), and skips cleanly if none is

--- a/test/inline/minify_page.js
+++ b/test/inline/minify_page.js
@@ -2,7 +2,13 @@
 // differential test can check that minification preserves the render.
 const { execSync } = require('child_process');
 const fs = require('fs');
-const CASCADE = process.env.CASCADE || 'cascade';
+// No fallback to a `cascade` off $PATH: which build minified the page is the
+// one thing the measurement is about. run.sh resolves it.
+const CASCADE = process.env.CASCADE;
+if (!CASCADE) {
+  console.error('ERROR: CASCADE is unset; run this through test/inline/run.sh');
+  process.exit(1);
+}
 const src = fs.readFileSync(process.argv[2], 'utf8');
 const out = src.replace(/<style([^>]*)>([\s\S]*?)<\/style>/gi, (_m, attrs, css) => {
   const min = execSync(`"${CASCADE}" fmt --minify -`, { input: css, encoding: 'utf8' });

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -5,13 +5,12 @@
 # block minified in place). Skips cleanly with no browser or node (e.g. in CI).
 #
 # A difference list is a measurement, so the run says what produced it: the
-# browser version heads the output, and each fetched page carries the hash of
-# the bytes actually measured. fetch.sh freezes every downloaded page
-# (freeze_page.js) and xtest.js pins the browser, leaving computed style a
-# function of the CSS alone.
+# binary under test and the browser version head the output, and each fetched
+# page carries the hash of the bytes actually measured. fetch.sh freezes every
+# downloaded page (freeze_page.js) and xtest.js pins the browser, leaving
+# computed style a function of the CSS alone.
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 root=$(CDPATH= cd "$dir/../.." && pwd)
-export CASCADE=${CASCADE:-cascade}
 if [ -z "$CHROME" ]; then
   CHROME=$(command -v chromium 2>/dev/null || command -v google-chrome 2>/dev/null || true)
 fi
@@ -34,6 +33,34 @@ if [ -n "$CHROME_VERSION" ] && ! printf '%s\n' "$browser" | grep -qF "$CHROME_VE
   echo "ERROR: CHROME_VERSION=$CHROME_VERSION, but the browser is $browser" >&2
   exit 1
 fi
+
+# The binary under test is this working tree's, built here. Falling back to a
+# `cascade` off $PATH tests whichever release happens to be installed while
+# still printing a confident result, so the run says nothing about the code it
+# was pointed at. CASCADE still wins, for measuring a release on purpose.
+if [ -z "$CASCADE" ]; then
+  if ! (cd "$root" && "$root/scripts/with_switch.sh" dune build bin/main.exe); then
+    echo "ERROR: cannot build bin/main.exe, so there is nothing to test." >&2
+    echo "  Fix the build, or set CASCADE to the binary you mean to measure." >&2
+    exit 1
+  fi
+  CASCADE="$root/_build/default/bin/main.exe"
+fi
+case $CASCADE in
+  */*) ;;
+  *) CASCADE=$(command -v "$CASCADE" 2>/dev/null || echo "$CASCADE") ;;
+esac
+if [ ! -x "$CASCADE" ]; then
+  echo "ERROR: CASCADE is not an executable: $CASCADE" >&2
+  exit 1
+fi
+# Absolute, so the header names one file however the run was started.
+case $CASCADE in
+  /*) ;;
+  *) CASCADE=$(CDPATH= cd "$(dirname "$CASCADE")" && pwd)/$(basename "$CASCADE") ;;
+esac
+export CASCADE
+cascade_version=$("$CASCADE" --version 2>/dev/null | head -1)
 
 # Canonical-difference filter: compares values the way cascade does, so
 # render-equivalent spellings (0% vs 0px, red vs rgb(...)) are not reported.
@@ -70,6 +97,7 @@ sha() { # file -> first 12 hex of sha256
   fi | cut -c1-12
 }
 
+echo "cascade: $CASCADE (${cascade_version:-unknown version})"
 echo "browser: $browser"
 echo "compare: canonical"
 fail=0

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -68,7 +68,12 @@ cascade_version=$("$CASCADE" --version 2>/dev/null | head -1)
 # like a result but is an inflated one, which is worse than no number at all.
 # So a filter that is missing or does not work is fatal, not skipped.
 if [ -z "$CANON_FILTER" ]; then
-  (cd "$root" && "$root/scripts/with_switch.sh" dune build test/inline/canon_filter.exe)
+  # Not discarded: a swallowed build failure leaves the last binary in place,
+  # and the probe below passes it.
+  if ! (cd "$root" && "$root/scripts/with_switch.sh" dune build test/inline/canon_filter.exe); then
+    echo "ERROR: cannot build test/inline/canon_filter.exe." >&2
+    exit 1
+  fi
   CANON_FILTER="$root/_build/default/test/inline/canon_filter.exe"
 fi
 # Prove it filters, rather than that a file exists: a stale or broken binary


### PR DESCRIPTION
An unset `CASCADE` resolved `cascade` off `PATH`, so a run with no environment measured whichever release happened to be installed while reporting the result as the branch's: on this machine a 1.0.0 from a month ago, which turned nine regression fixtures into nine failures of code that had already fixed them.

Stacked on #361.