### PR TITLE
css: recover from an invalid declaration in a nested at-rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,16 @@
   rather than at the next semicolon. `.a { @import url(x) { } color: red }` lost
   `color: red`, and an `@import` inside a nested group rule took the whole group
   with it (#388)
+- An invalid declaration inside a nested at-rule is dropped on its own rather
+  than taking the whole stylesheet. `.a { @media screen { color: red;
+  width: 10; background: blue } }` parsed to nothing, since the nested block had
+  no recovery and the error unwound past every enclosing block. CSS Syntax 3
+  sec. 5.4.4 ends a bad declaration at the next top-level `;`, counting a `{}`
+  met on the way as one component value of the value being skipped, and Blink
+  146 keeps both neighbours in one declaration run. A nested rule whose prelude
+  starts with an identifier, as in `.a { @media screen { h2:where(.b) { color:
+  red } } }`, and a stray `;` between two declarations there, were lost the same
+  way (#392)
 
 ### Minification
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3156,6 +3156,12 @@ let seal_declaration_run = function
   | Declarations run :: rest -> Declarations (List.rev run) :: rest
   | nested -> nested
 
+(* Add one declaration to the run being read, which is the head of the
+   accumulator and holds its declarations reversed until it is sealed. *)
+let add_to_declaration_run decl = function
+  | Declarations run :: rest -> Declarations (decl :: run) :: rest
+  | nested -> Declarations [ decl ] :: nested
+
 let read_starting_style ~body (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "starting-style" r;
   Cursor.ws r;
@@ -3412,10 +3418,26 @@ and read_layer (r : Cursor.t) : statement =
 and read_nesting_block (r : Cursor.t) : block =
   let rec read_items acc =
     Cursor.ws r;
+    if Cursor.recover r then read_recovering_item acc
+    else add_item acc (read_nesting_item ~prev:acc r)
+  (* CSS Syntax 3 sec. 5.4.4: a declaration that fails to parse is dropped and
+     reading resumes past the next top-level [;], a [{}] met on the way counting
+     as one component value of the value being skipped. A nested at-rule's body
+     is <block-contents> like a style rule's, so it recovers the same way and
+     one bad declaration takes neither the group rule holding it nor the rest of
+     the sheet. Strict mode ([not (Cursor.recover r)]) still raises. *)
+  and read_recovering_item acc =
     match read_nesting_item ~prev:acc r with
-    | `Done -> List.rev acc
+    | item -> add_item acc item
+    | exception Error.Parse_error e ->
+        Cursor.push_warning r e;
+        skip_bad_rule_item r;
+        read_items acc
+  and add_item acc = function
+    | `Done -> List.rev (seal_declaration_run acc)
     | `Skip -> read_items acc
-    | `Stmt stmt -> read_items (stmt :: acc)
+    | `Decl decl -> read_items (add_to_declaration_run decl acc)
+    | `Stmt stmt -> read_items (stmt :: seal_declaration_run acc)
   in
   read_items []
 
@@ -3432,30 +3454,21 @@ and read_nesting_item ~prev r =
   | _ -> read_nesting_declaration_or_statement r
 
 and read_nesting_declaration_or_statement r =
+  let start = Cursor.save r in
   match Declaration.read_declaration r with
   | Some decl ->
       Cursor.ws r;
-      `Stmt (Declarations (read_more_nested_decls r [ decl ]))
+      if Cursor.peek_semicolon r then Cursor.skip r;
+      `Decl decl
   | None -> `Stmt (read_statement r)
-
-and read_more_nested_decls r acc =
-  match Cursor.peek r with
-  | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-      Cursor.skip r;
-      Cursor.ws r;
-      read_nested_decl_after_semicolon r acc
-  | _ -> List.rev acc
-
-and read_nested_decl_after_semicolon r acc =
-  match Cursor.peek r with
-  | None | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      List.rev acc
-  | _ -> (
-      match Declaration.read_declaration r with
-      | Some d ->
-          Cursor.ws r;
-          read_more_nested_decls r (d :: acc)
-      | None -> List.rev acc)
+  (* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so
+     [h2:where(...) { ... }] reads as a declaration up to the [{]. Rewind and
+     take it as a rule; a genuine bad declaration has no block and still reports
+     as one. *)
+  | exception Error.Parse_error _
+    when Cursor.restore r start;
+         item_opens_block r ->
+      `Stmt (read_statement r)
 
 (* Helper: Read nested at-rule with declarations content *)
 and read_nested_at_rule (r : Cursor.t) (at_rule : string) : statement =

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1405,6 +1405,98 @@ let spec_lenient_recovery_stylesheets () =
     ".a { color: red; @else { color: green } background: blue }"
     ".a{color:red;background:#00f}" 1
 
+(* CSS Syntax 3 sec. 5.4.4 "consume a declaration" ends an invalid declaration
+   at the next top-level [;], and a [{}] met on the way is one component value
+   of the value being skipped, not a stopping point. A nested at-rule's body is
+   <block-contents> just like a style rule's (CSS Nesting 1 sec. 3.3), so the
+   same recovery applies inside it: Blink 146 drops the one declaration and
+   keeps every neighbour, the enclosing group rule and the rest of the sheet. *)
+let spec_lenient_recovery_nested_at_rule_declarations () =
+  let recovered = ".a{@media screen{color:red;background:#00f}}" in
+  lenient_recover "bad declaration first in a nested at-rule"
+    ".a { @media screen { width: 10; color: red; background: blue } }" recovered
+    1;
+  lenient_recover "bad declaration mid-run in a nested at-rule"
+    ".a { @media screen { color: red; width: 10; background: blue } }" recovered
+    1;
+  lenient_recover "bad declaration last in a nested at-rule"
+    ".a { @media screen { color: red; background: blue; width: 10 } }" recovered
+    1;
+  lenient_recover "sole declaration of a nested at-rule dropped"
+    ".a { @media screen { width: 10 } }" "" 1;
+  lenient_recover "bad declaration in a nested style rule"
+    ".a { & b { color: red; width: 10; margin: 0 } }" ".a b{color:red;margin:0}"
+    1;
+  lenient_recover "bad declaration in a style rule under a nested at-rule"
+    ".a { @media screen { & b { color: red; width: 10; margin: 0 } } }"
+    ".a{@media screen{& b{color:red;margin:0}}}" 1;
+  lenient_recover "bad declaration in a doubly nested at-rule"
+    ".a { @media screen { @container (width > 0px) { color: red; width: 10; \
+     background: blue } } }"
+    ".a{@media screen{@container(width>0px){color:red;background:#00f}}}" 1;
+  lenient_recover "nested at-rule keeps recovery in @layer"
+    ".a { @layer x { color: red; width: 10; background: blue } }"
+    ".a{@layer x{color:red;background:#00f}}" 1;
+  lenient_recover "nested at-rule keeps recovery in @scope"
+    ".a { @scope (.b) { color: red; width: 10; background: blue } }"
+    ".a{@scope(.b){color:red;background:#00f}}" 1;
+  lenient_recover "nested at-rule keeps recovery in @starting-style"
+    ".a { @starting-style { color: red; width: 10; background: blue } }"
+    ".a{@starting-style{color:red;background:#00f}}" 1;
+  (* A [{}] in the dropped value is consumed with it; the run resumes at the [;]
+     after it. An unclosed function has no such [;] - the tokenizer closes it at
+     the end of the block, so it swallows the rest, as Blink does. *)
+  lenient_recover "curly block inside a dropped value is skipped with it"
+    ".a { @media screen { color: red; width: {1}; background: blue } }"
+    recovered 1;
+  lenient_recover "unclosed function swallows the rest of the block"
+    ".a { @media screen { color: red; width: calc(1px; background: blue } }"
+    ".a{@media screen{color:red}}" 1;
+  lenient_recover "a run of stray tokens is dropped like a bad declaration"
+    ".a { @media screen { color: red; !!!; background: blue } }" recovered 1
+
+(* A dropped declaration leaves no gap: the run written around it is one run, as
+   it is in Blink 146, the same way a dropped at-rule leaves one. *)
+let spec_lenient_recovery_nested_declaration_run () =
+  lenient_recover "bad declaration immediately before a nested rule"
+    ".a { @media screen { width: 10; & b { color: red } } }"
+    ".a{@media screen{& b{color:red}}}" 1;
+  lenient_recover "bad declaration immediately after a nested rule"
+    ".a { @media screen { & b { color: red } width: 10; background: blue } }"
+    ".a{@media screen{& b{color:red}background:#00f}}" 1;
+  lenient_recover "dropped declaration does not seal the run before a rule"
+    ".a { @media screen { color: red; width: 10; background: blue; & b { \
+     margin: 0 } } }"
+    ".a{@media screen{color:red;background:#00f;& b{margin:0}}}" 1;
+  lenient_recover "dropped declaration does not seal the run it opened"
+    ".a { @media screen { width: 10; color: red; & b { margin: 0 } background: \
+     blue } }"
+    ".a{@media screen{color:red;& b{margin:0}background:#00f}}" 1
+
+(* Each recovered declaration reports once, and [~strict:true] rejects exactly
+   the inputs the lenient parse warned about. *)
+let spec_recovery_warns_once_per_declaration () =
+  let check css expected =
+    let warnings =
+      match Css.of_string ~strict:false css with
+      | Ok { Css.warnings; _ } -> warnings
+      | Error err ->
+          Alcotest.failf "lenient parse rejected %S: %s" css
+            (Cascade.Error.to_string err)
+    in
+    Alcotest.(check int) ("warnings for " ^ css) expected (List.length warnings);
+    match (Css.of_string ~strict:true css, expected) with
+    | Ok _, 0 | Error _, _ -> ()
+    | Ok _, _ -> Alcotest.failf "strict parse accepted warned-about %S" css
+  in
+  check ".a { @media screen { color: red; width: 10; background: blue } }" 1;
+  check ".a { @media screen { width: 10; height: 20; color: red } }" 2;
+  check
+    ".a { @media screen { @container (width > 0px) { width: 10; color: red } } \
+     }"
+    1;
+  check ".a { @media screen { color: red; background: blue } }" 0
+
 let stylesheet_tests =
   [
     (* Core type tests *)
@@ -1480,6 +1572,15 @@ let stylesheet_tests =
     ( "spec lenient recovery stylesheets",
       `Quick,
       spec_lenient_recovery_stylesheets );
+    ( "spec lenient recovery in a nested at-rule",
+      `Quick,
+      spec_lenient_recovery_nested_at_rule_declarations );
+    ( "spec lenient recovery keeps a nested declaration run whole",
+      `Quick,
+      spec_lenient_recovery_nested_declaration_run );
+    ( "spec recovery warns once per dropped declaration",
+      `Quick,
+      spec_recovery_warns_once_per_declaration );
   ]
 
 (* Tests for newly added check functions *)
@@ -3103,6 +3204,31 @@ let spec_nesting_rejects_top_of_sheet_at_rules () =
   test_nesting_roundtrip
     ~expected:".a{@media screen{color:red;background:blue}}"
     ".a { @media screen { color: red; @import url(x.css); background: blue } }"
+
+(* CSS Nesting 1 sec. 3: a nested rule's prelude may start with an ident, so
+   [h2:where(.b) { ... }] is a rule and not a [h2] declaration, however much its
+   head looks like one. That holds in a nested at-rule's body as much as in a
+   style rule's, and Blink 146 reads both as rules. *)
+let spec_nesting_ident_prelude_in_nested_at_rule () =
+  test_nesting_roundtrip ~expected:".a{@media screen{h2:where(.b){color:red}}}"
+    ".a { @media screen { h2:where(.b) { color: red } } }";
+  test_nesting_idempotent ".a { @media screen { h2:where(.b) { color: red } } }";
+  test_nesting_roundtrip
+    ~expected:
+      ".a{@media screen{color:red;h2:where(.b){margin:0}background:blue}}"
+    ".a { @media screen { color: red; h2:where(.b) { margin: 0 } background: \
+     blue } }"
+
+(* CSS Syntax 3 sec. 5.4.3 "consume a block's contents" drops a [;] that no
+   declaration precedes rather than validating one, so a stray semicolon in a
+   nested at-rule's body costs nothing. Blink 146 keeps both neighbours. *)
+let spec_nesting_skips_stray_semicolons () =
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{color:red;background:blue}}"
+    ".a { @media screen { color: red;; background: blue } }";
+  test_nesting_roundtrip
+    ~expected:".a{@media screen{color:red;background:blue}}"
+    ".a { @media screen { ; color: red; background: blue } }"
 
 (* CSS Nesting 1 sec. 3.4: a run of declarations written after a nested rule is
    wrapped in a nested declarations rule, which keeps its place among the nested
@@ -7258,6 +7384,12 @@ let additional_tests =
     ( "spec nesting rejects a top-of-sheet at-rule",
       `Quick,
       spec_nesting_rejects_top_of_sheet_at_rules );
+    ( "spec nesting reads an ident prelude in a nested at-rule",
+      `Quick,
+      spec_nesting_ident_prelude_in_nested_at_rule );
+    ( "spec nesting skips stray semicolons in a nested at-rule",
+      `Quick,
+      spec_nesting_skips_stray_semicolons );
     ( "spec CSS Nesting L1 preserves nested structure",
       `Quick,
       nesting_module_l1_preserves_structure );


### PR DESCRIPTION
`.a { @media screen { color: red; width: 10; background: blue } }` parsed to an empty stylesheet, because a nested at-rule's body had no error recovery and the invalid `width: 10` unwound past every enclosing block; cascade now drops that one declaration and keeps its neighbours in one run, as Blink 146 does.

Stacked on #388.