### PR TITLE
diff: fold a projection value through every block at-rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -166,6 +166,13 @@
 - A complete shadow value in an unregistered custom property types its colour
   slot, so named and hex colours and typed `var()` fallbacks compare
   canonically while non-colour identifiers remain opaque (#314)
+- The projection's value folds reach inside every block at-rule. A quoted
+  multi-word family name in a custom property, a whole-byte `color(srgb ...)`
+  and the Level 3 `not all and (...)` media spelling folded inside `@layer` and
+  `@media` but not inside `@scope`, `@starting-style`, `@-moz-document`,
+  `@when`, `@else` or an origin wrapper, so the diff's verdict depended on
+  which at-rule enclosed the rule. A custom property in a `@keyframes` frame or
+  a `@page` box folds too (#393)
 
 ### Library
 

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -522,22 +522,16 @@ let normalize_custom_declaration d =
   Declaration.unquote_custom_font_strings
     (Declaration.map_custom_value normalize_custom_value d)
 
-let rec normalize_custom_values (stmts : statement list) : statement list =
-  List.map
-    (fun stmt ->
-      match stmt with
-      | Rule r ->
-          Rule
-            {
-              r with
-              declarations =
-                List.map normalize_custom_declaration r.declarations;
-              nested = normalize_custom_values r.nested;
-            }
-      | Layer (n, inner) -> Layer (n, normalize_custom_values inner)
-      | Media (c, inner) -> Media (c, normalize_custom_values inner)
-      | Supports (c, inner) -> Supports (c, normalize_custom_values inner)
-      | other -> other)
+(* The fold reads one declaration, so it holds wherever the declaration sits: a
+   [@keyframes] frame and a [@page] box spell a custom property exactly as a
+   style rule does, and no block at-rule changes what the token stream means.
+   {!Stylesheet.map_declarations} reaches every one of those sites, so the pass
+   does not carry a list of the statements it descends through - the list is
+   what left [@scope] and [@starting-style] answering differently from
+   [@layer]. *)
+let normalize_custom_values (stmts : statement list) : statement list =
+  Stylesheet.map_declarations
+    (Common.List.map_preserve normalize_custom_declaration)
     stmts
 
 (* CSS Color 4 sec. 10.2: [color(srgb r g b)] scales each channel by 255, so
@@ -560,23 +554,9 @@ let canonical_color_spelling decl =
   then decl
   else folded
 
-let rec canonical_color_spellings (stmts : statement list) : statement list =
-  List.map
-    (fun stmt ->
-      match stmt with
-      | Rule r ->
-          Rule
-            {
-              r with
-              declarations = List.map canonical_color_spelling r.declarations;
-              nested = canonical_color_spellings r.nested;
-            }
-      | Layer (n, inner) -> Layer (n, canonical_color_spellings inner)
-      | Media (c, inner) -> Media (c, canonical_color_spellings inner)
-      | Supports (c, inner) -> Supports (c, canonical_color_spellings inner)
-      | Container (n, c, inner) ->
-          Container (n, c, canonical_color_spellings inner)
-      | other -> other)
+let canonical_color_spellings (stmts : statement list) : statement list =
+  Stylesheet.map_declarations
+    (Common.List.map_preserve canonical_color_spelling)
     stmts
 
 (* CSS Properties and Values API 1 sec. 2: registrations for different custom
@@ -648,21 +628,26 @@ let rec canonical_media (query : Media.t) : Media.t =
   | Media.Type { prefix = Some Media.Not; type_ = Media.All; trailing = Some c }
     ->
       Media.Cond (Media.Not c)
-  | Media.List qs -> Media.List (List.map canonical_media qs)
+  | Media.List qs ->
+      let qs' = Common.List.map_preserve canonical_media qs in
+      if qs' == qs then query else Media.List qs'
   | query -> query
 
+(* [@media] is the only statement whose prelude this rewrites, so it is the only
+   one named; the descent below it is {!Stylesheet.map_statement_children}'s and
+   reaches every block at-rule, including the ones a [@media] can be written
+   inside. *)
 let rec canonical_media_queries (stmts : statement list) : statement list =
-  List.map
+  Common.List.map_preserve
     (fun stmt ->
-      match stmt with
-      | Rule r -> Rule { r with nested = canonical_media_queries r.nested }
-      | Media (q, inner) ->
-          Media (canonical_media q, canonical_media_queries inner)
-      | Layer (n, inner) -> Layer (n, canonical_media_queries inner)
-      | Supports (c, inner) -> Supports (c, canonical_media_queries inner)
-      | Container (n, c, inner) ->
-          Container (n, c, canonical_media_queries inner)
-      | other -> other)
+      let stmt =
+        match stmt with
+        | Media (q, inner) ->
+            let q' = canonical_media q in
+            if q' == q then stmt else Media (q', inner)
+        | stmt -> stmt
+      in
+      Stylesheet.map_statement_children canonical_media_queries stmt)
     stmts
 
 let canonicalize (stmts : statement list) : statement list =

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -93,6 +93,64 @@ let custom_property_font_name_quoting_converges () =
     "a single-word string stays opaque" true
     (canonical {|.a{--x:"foo"}|} <> canonical ".a{--x:foo}")
 
+(* Every block at-rule that holds a statement list, each as the CSS text that
+   opens and closes it. [@else] has no standalone form (css-conditional-5 sec. 3
+   binds it to the [@when] before it), so its opener carries the antecedent.
+   [Origin] has no CSS syntax at all and is exercised separately. *)
+let block_at_rules =
+  [
+    ("@layer", "@layer L{", "}");
+    ("@media", "@media (width>0px){", "}");
+    ("@container", "@container (width>0px){", "}");
+    ("@supports", "@supports (color:red){", "}");
+    ("@-moz-document", "@-moz-document url-prefix(){", "}");
+    ("@starting-style", "@starting-style{", "}");
+    ("@when", "@when media(width>0px){", "}");
+    ("@else", "@when media(width<0px){.z{color:red}}@else{", "}");
+    ("@scope", "@scope (.card){", "}");
+  ]
+
+(* A projection fold reads a declaration or a media prelude; neither depends on
+   the block at-rule the statement was written in, since a wrapper decides when
+   its contents apply and never what they mean. So a pair that converges at the
+   top level converges inside every wrapper - otherwise the canonical diff
+   answers differently for the same rule depending on what encloses it, which is
+   the phantom difference the projection exists to remove. *)
+let converges_everywhere name a b =
+  Alcotest.(check string)
+    (String.concat " " [ name; "at the top level" ])
+    (canonical b) (canonical a);
+  List.iter
+    (fun (label, before, after) ->
+      let wrap body = String.concat "" [ before; body; after ] in
+      Alcotest.(check string)
+        (String.concat " " [ name; "inside"; label ])
+        (canonical (wrap b))
+        (canonical (wrap a)))
+    block_at_rules;
+  let origin css =
+    render
+      (Rule_order.canonicalize [ Stylesheet.Origin (Author, statements css) ])
+  in
+  Alcotest.(check string)
+    (String.concat " " [ name; "inside an origin wrapper" ])
+    (origin b) (origin a)
+
+let custom_font_quoting_converges_under_every_wrapper () =
+  converges_everywhere "a quoted family name" {|.a{--f:"Fira Code",monospace}|}
+    ".a{--f:Fira Code,monospace}"
+
+let color_spelling_converges_under_every_wrapper () =
+  (* CSS Color 4 sec. 10.2 scales each [color(srgb ...)] channel by 255, so
+     [color(srgb 1 0 0)] is the sRGB red the keyword names. *)
+  converges_everywhere "a whole-byte color(srgb)" ".a{color:color(srgb 1 0 0)}"
+    ".a{color:red}"
+
+let media_level_spelling_converges_under_every_wrapper () =
+  converges_everywhere "the Level 3 negation"
+    "@media not all and (width>100px){.a{color:red}}"
+    "@media not (width>100px){.a{color:red}}"
+
 let media_and_independent_rule_converge () =
   (* A conditional block whose rules cannot conflict with a neighbouring rule
      reorders with it, so both source orderings reach one canonical form. *)
@@ -277,6 +335,13 @@ let suite =
         custom_property_layer_and_meta_survive;
       Alcotest.test_case "custom-property font-name quoting converges" `Quick
         custom_property_font_name_quoting_converges;
+      Alcotest.test_case
+        "custom-property font-name quoting converges under every wrapper" `Quick
+        custom_font_quoting_converges_under_every_wrapper;
+      Alcotest.test_case "color spelling converges under every wrapper" `Quick
+        color_spelling_converges_under_every_wrapper;
+      Alcotest.test_case "media level spelling converges under every wrapper"
+        `Quick media_level_spelling_converges_under_every_wrapper;
       Alcotest.test_case "media and independent rule converge" `Quick
         media_and_independent_rule_converge;
       Alcotest.test_case "media conflict keeps source order" `Quick


### PR DESCRIPTION
The canonical projection's three value folds each walked their own subset of the block at-rules, so `cascade diff --diff=canonical` reported a difference for a rule written in `@scope` that it folded away for the same rule in `@layer`. They now descend through the exhaustive statement walks, which also reaches a custom property in a `@keyframes` frame or a `@page` box.

Stacked on #389.