### PR TITLE
resolve: name every block the cascade walk leaves out

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -176,6 +176,12 @@
 
 ### Library
 
+- `Cascade.Resolve.Make.resolve` and `Cascade.Resolve.layer_order` document
+  every block they leave out, not just conditional groups: `@starting-style`
+  declares a before-change style, `@scope` brings a scoping root and the
+  proximity criterion, and an origin wrapper carries an origin that outranks
+  the layer. `Css.layers` remains the exhaustive count of what a sheet declares
+  (#394)
 - `Css.Media.kind` classifies a negated width bound by the side it bounds, so
   `not (min-width: 640px)` groups and sorts with the upper bounds it matches
   instead of with the lower bound it negates, and a doubled `not` cancels. The

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -520,8 +520,9 @@ val layers : t -> string list
     sublayer of an anonymous [@layer { ... }] has no name to report.
 
     This is what a sheet declares, not the order a cascade resolves in.
-    {!Resolve.layer_order} answers that, and leaves out a layer named inside a
-    conditional group because the resolver does not enter one. *)
+    {!Resolve.layer_order} answers that, and leaves out a layer named inside any
+    block the resolver does not enter: a conditional group rule,
+    [@starting-style], [@scope] or an origin wrapper. *)
 
 (** {3 AST Introspection Helpers} *)
 

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -110,8 +110,8 @@ type layer_order_diff = {
     whose conflicts the two sheets resolve differently. It is never empty.
 
     The order compared is the sheet's own, so a layer declared inside a
-    conditional group is not part of it, as in {!Cascade.Resolve.layer_order}.
-*)
+    conditional group rule, [@starting-style], [@scope] or an origin wrapper is
+    not part of it, as in {!Cascade.Resolve.layer_order}. *)
 
 type t = {
   rules : rule_diff list;

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -112,7 +112,22 @@ let declare_layer order name =
 (* [layered_rules stmts] is the sheet's layer order together with every rule
    paired with the layer it sits in ([None] for the unlayered ones), both in
    source order. An [@layer a, b;] statement declares its names without
-   contributing a rule. *)
+   contributing a rule.
+
+   The statements it does not walk into are listed one by one rather than closed
+   with a wildcard, since which ones those are is the contract of {!resolve} and
+   {!layer_order} both. A conditional group rule ([@media], [@supports],
+   [@container], [@-moz-document], [@when], [@else]) gates its contents on an
+   environment nothing here models: there is no viewport, no UA feature table,
+   no container layout and no document URL. [@starting-style] declares a
+   before-change style (css-transitions-2 sec. 5) rather than an ordinary one.
+   [@scope] adds a scoping root, a scoping limit and the proximity criterion
+   (css-cascade-6), none of which the matcher models. [Origin] carries the
+   origin that outranks the layer in the cascade sorting order (css-cascade-5
+   sec. 6.1), which the ranking below does not weigh. Each is left to the
+   browser instead: {!Apply.Make} keeps these blocks whole in the stylesheet it
+   emits and inlines only what [resolve] returns, so a rule counted in both
+   places would apply twice. *)
 let layered_rules stmts =
   let anon = ref 0 in
   let rec go parent acc stmts =
@@ -134,7 +149,20 @@ let layered_rules stmts =
                   qualify parent (anonymous_layer !anon)
             in
             go (Some name) (declare_layer order name, rules) body
-        | _ -> (order, rules))
+        | Stylesheet.Media _ | Stylesheet.Supports _ | Stylesheet.Container _
+        | Stylesheet.Moz_document _ | Stylesheet.When _ | Stylesheet.Else _
+        | Stylesheet.Starting_style _ | Stylesheet.Scope _ | Stylesheet.Origin _
+        | Stylesheet.Declarations _ | Stylesheet.Bang_comment _
+        | Stylesheet.Charset _ | Stylesheet.Import _ | Stylesheet.Namespace _
+        | Stylesheet.Property _ | Stylesheet.Supports_condition _
+        | Stylesheet.Keyframes _ | Stylesheet.Webkit_keyframes _
+        | Stylesheet.Moz_keyframes _ | Stylesheet.Font_face _
+        | Stylesheet.Counter_style _ | Stylesheet.Page _
+        | Stylesheet.Page_with_margins _ | Stylesheet.Font_palette_values _
+        | Stylesheet.Font_feature_values _ | Stylesheet.View_transition _
+        | Stylesheet.Position_try _ | Stylesheet.Viewport _
+        | Stylesheet.Unknown_at_rule _ ->
+            (order, rules))
       acc stmts
   in
   let order, rules = go None ([], []) stmts in

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -74,9 +74,12 @@ val layer_order : Stylesheet.t -> string list
     (css-cascade-5 sec. 6.4.2), and an [@layer a, b;] statement declares its
     names there just as a block does. Every anonymous [@layer { ... }] block is
     a layer of its own, keyed by a path holding a U+0000 that no author can
-    write - a caller that prints these paths has to spell those out itself.
-    Layers declared inside a conditional group are not counted, as
-    {!Make.resolve} does not consider such groups either.
+    write - a caller that prints these paths has to spell those out itself. The
+    layers counted are those {!Make.resolve} ranks against, so a layer declared
+    inside one of the blocks it does not walk - a conditional group rule
+    ([@media], [@supports], [@container], [@-moz-document], [@when], [@else]),
+    [@starting-style], [@scope], or an origin wrapper - is not part of this
+    order.
 
     This is the [~layer_order] that {!Stylesheet.cascade_layer_precedence_rank}
     expects. *)
@@ -100,6 +103,18 @@ module Make (N : NODE) : sig
       order. [@layer] blocks and [@layer a, b;] statements order the layers by
       first appearance, sublayers included; among normal declarations the last
       layer wins and an unlayered declaration beats them all, and for
-      [!important] declarations that order reverses. Conditional groups
-      ([@media], [@supports], [@container]) are not considered. *)
+      [!important] declarations that order reverses.
+
+      Style rules and [@layer] are the only blocks walked. A rule inside a
+      conditional group rule ([@media], [@supports], [@container],
+      [@-moz-document], [@when], [@else]) contributes nothing, since the
+      condition needs a viewport, a UA feature table, a container layout or a
+      document URL that a {!NODE} does not carry. Nor does one inside
+      [@starting-style], which declares a before-change style rather than an
+      ordinary one (css-transitions-2 sec. 5); inside [@scope], whose scoping
+      root, scoping limit and proximity criterion (css-cascade-6) the matcher
+      does not model; or inside an origin wrapper, whose origin outranks the
+      layer in the cascade sorting order (css-cascade-5 sec. 6.1) and is not
+      weighed here. {!Apply.Make} keeps each of those blocks whole in the
+      stylesheet it emits rather than projecting it onto an element. *)
 end

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -198,6 +198,84 @@ let test_resolve_anonymous_layers () =
     (resolved_color
        "@layer{span{color:red!important}}@layer{span{color:blue!important}}")
 
+(* Every block at-rule {!Flatten.block} leaves standing around a rule, as the
+   CSS text that opens and closes it. [@else] binds to the [@when] before it
+   (css-conditional-5 sec. 3), so its opener carries an antecedent that cannot
+   match [s2]. *)
+let wrappers_resolve_skips =
+  [
+    ("@media", "@media (width>0px){", "}");
+    ("@supports", "@supports (color:red){", "}");
+    ("@container", "@container (width>0px){", "}");
+    ("@-moz-document", "@-moz-document url-prefix(){", "}");
+    ("@starting-style", "@starting-style{", "}");
+    ("@when", "@when media(width>0px){", "}");
+    ("@else", "@when media(width<0px){p{color:blue}}@else{", "}");
+    ("@scope", "@scope (.card){", "}");
+  ]
+
+(* [resolve] answers for the ordinary cascade of an element in a document it
+   cannot see: it has no viewport, no UA feature table, no container layout, no
+   document URL, and no scoping root, and [@starting-style] declares a
+   before-change style rather than an ordinary one. So a rule inside any of
+   these contributes nothing, and only [@layer], which gates nothing, does. This
+   is what {!Apply.Make} relies on: it keeps each of these blocks in the
+   stylesheet and inlines only what [resolve] returns, so a declaration counted
+   in both places would be applied twice. *)
+let test_resolve_skips_conditional_and_scoped_blocks () =
+  Alcotest.(check (option string))
+    "a bare rule resolves" (Some "color:red")
+    (resolved_color "span{color:red}");
+  Alcotest.(check (option string))
+    "a rule in @layer resolves" (Some "color:red")
+    (resolved_color "@layer L{span{color:red}}");
+  List.iter
+    (fun (label, before, after) ->
+      Alcotest.(check (option string))
+        (String.concat " " [ "a rule in"; label; "does not resolve" ])
+        None
+        (resolved_color (String.concat "" [ before; "span{color:red}"; after ])))
+    wrappers_resolve_skips;
+  Alcotest.(check (option string))
+    "a rule in an origin wrapper does not resolve" None
+    (List.find_map
+       (fun d ->
+         if Declaration.property_name d = "color" then
+           Some (Declaration.string_of_declaration ~minify:true d)
+         else None)
+       (R.resolve [ Stylesheet.Origin (Author, sheet_of "span{color:red}") ] s2))
+
+(* [layer_order] is the order [resolve] ranks against, so it counts a layer in
+   exactly the blocks [resolve] walks. A layer named inside one of the others is
+   not part of that order. *)
+let test_layer_order_counts_the_blocks_resolve_walks () =
+  Alcotest.(check (list string))
+    "a nested @layer block is counted" [ "a"; "a.b" ]
+    (Resolve.layer_order (sheet_of "@layer a{@layer b{span{color:red}}}"));
+  List.iter
+    (fun (label, before, after) ->
+      Alcotest.(check (list string))
+        (String.concat " " [ "a layer named inside"; label; "is not counted" ])
+        []
+        (Resolve.layer_order
+           (sheet_of
+              (String.concat "" [ before; "@layer a{span{color:red}}"; after ]))))
+    wrappers_resolve_skips
+
+(* The declarations [resolve] leaves out are not lost: {!Apply.Make} keeps the
+   block whole in the stylesheet it emits, so the browser applies it there. *)
+let test_apply_keeps_the_blocks_resolve_skips () =
+  let module A = Apply.Make (Node) in
+  let result : tree Apply.result =
+    A.compute ~sheet:(sheet_of "@scope (.card){span{color:red}}") [ section ]
+  in
+  Alcotest.(check bool)
+    "nothing is projected onto an element" true
+    (List.for_all (fun (_, decls) -> decls = []) result.styles);
+  Alcotest.(check bool)
+    "the @scope block is kept in the stylesheet" true
+    (String.length result.keep_css > 0)
+
 (* {!Apply.Make} reuses the same {!Node} adapter: a static rule projects onto
    the element, a rule with no inline form ([:hover]) stays in a <style>
    block. *)
@@ -245,6 +323,12 @@ let suite =
         test_resolve_nested_layers;
       Alcotest.test_case "anonymous layers are distinct" `Quick
         test_resolve_anonymous_layers;
+      Alcotest.test_case "resolve skips conditional and scoped blocks" `Quick
+        test_resolve_skips_conditional_and_scoped_blocks;
+      Alcotest.test_case "layer order counts the blocks resolve walks" `Quick
+        test_layer_order_counts_the_blocks_resolve_walks;
+      Alcotest.test_case "apply keeps the blocks resolve skips" `Quick
+        test_apply_keeps_the_blocks_resolve_skips;
       Alcotest.test_case "apply projects a static rule, keeps a dynamic one"
         `Quick test_apply_compute;
     ] )


### PR DESCRIPTION
`Resolve.Make.resolve` and `Resolve.layer_order` documented conditional groups as their one exclusion, but a rule or `@layer` inside `@scope`, `@starting-style`, `@-moz-document`, `@when`, `@else` or an origin wrapper was skipped too. The skip is right, since `Apply.Make` keeps each of those blocks whole in the stylesheet it emits rather than inlining it, so the docstrings now name them with the reason and the walk lists them instead of closing with a wildcard.

Behaviour is unchanged; stacked on #393.