### PR TITLE
diff: a container query reads the whole diff tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -176,6 +176,10 @@
 
 ### Library
 
+- `Cascade_diff.Tree_diff.has_container_added_of_type` and
+  `has_container_removed_of_type` look inside a container reported as modified,
+  as `count_containers_by_type` already did. A `@supports` added inside an
+  existing `@media` was counted but not found (#395)
 - `Cascade.Resolve.Make.resolve` and `Cascade.Resolve.layer_order` document
   every block they leave out, not just conditional groups: `@starting-style`
   declares a before-change style, `@scope` brings a scoping root and the

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -614,16 +614,35 @@ let rec count_containers_in_list container_type containers =
 let count_containers_by_type container_type (diff : t) =
   count_containers_in_list container_type diff.containers
 
-let has_container_added_of_type container_type (diff : t) =
+(* [Modified] holds the containers that came and went inside a container that
+   survived, so an existence query reads the same tree
+   [count_containers_in_list] counts: a flat [List.exists] would answer no about
+   a container the count reports, which is an answer about the shape of the diff
+   rather than about the stylesheets. *)
+let rec exists_container here containers =
   List.exists
+    (fun cont ->
+      here cont
+      ||
+      match cont with
+      | Modified { container_changes; _ } ->
+          exists_container here container_changes
+      | Added _ | Removed _ | Reordered _ | Block_structure_changed _ -> false)
+    containers
+
+let has_container_added_of_type container_type (diff : t) =
+  exists_container
     (function
-      | Added { container_type = ct; _ } -> ct = container_type | _ -> false)
+      | Added { container_type = ct; _ } -> ct = container_type
+      | Removed _ | Modified _ | Reordered _ | Block_structure_changed _ ->
+          false)
     diff.containers
 
 let has_container_removed_of_type container_type (diff : t) =
-  List.exists
+  exists_container
     (function
-      | Removed { container_type = ct; _ } -> ct = container_type | _ -> false)
+      | Removed { container_type = ct; _ } -> ct = container_type
+      | Added _ | Modified _ | Reordered _ | Block_structure_changed _ -> false)
     diff.containers
 
 let container_prefix = function

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -166,19 +166,24 @@ val count_containers_by_type :
   [ `At_rule | `Container | `Layer | `Media | `Nesting | `Property | `Supports ] ->
   t ->
   int
-(** [count_containers_by_type container_type diff] counts containers of the
-    given type in [diff]. *)
+(** [count_containers_by_type container_type diff] counts the containers of the
+    given type in [diff], at its top level and inside every container it reports
+    as modified. *)
 
 val has_container_added_of_type :
   [ `At_rule | `Container | `Layer | `Media | `Nesting | `Property | `Supports ] ->
   t ->
   bool
-(** [has_container_added_of_type container_type diff] returns [true] if [diff]
-    contains added containers of the given type. *)
+(** [has_container_added_of_type container_type diff] is whether [diff] reports
+    a container of the given type as added, at its top level or inside a
+    container it reports as modified. It answers about the same containers
+    {!count_containers_by_type} counts. *)
 
 val has_container_removed_of_type :
   [ `At_rule | `Container | `Layer | `Media | `Nesting | `Property | `Supports ] ->
   t ->
   bool
-(** [has_container_removed_of_type container_type diff] returns [true] if [diff]
-    contains removed containers of the given type. *)
+(** [has_container_removed_of_type container_type diff] is whether [diff]
+    reports a container of the given type as removed, at its top level or inside
+    a container it reports as modified. It answers about the same containers
+    {!count_containers_by_type} counts. *)

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -480,6 +480,57 @@ let count_containers_media () =
   let count = Cascade_diff.Tree_diff.count_containers_by_type `Media d in
   Alcotest.(check bool) "at least one media container" true (count >= 1)
 
+(* A container that survived is reported as [Modified] and carries the
+   containers that came and went inside it, so a container added one level down
+   is in the diff but not at its top level. [count_containers_by_type] descends
+   into [Modified], and the two existence queries name the same containers, so
+   they answer for the same set: a query that says no about a container the
+   count reports is answering about the shape of the diff rather than about the
+   stylesheets. *)
+let nested_container_added_is_found () =
+  let expected = parse "@media print { .a { color: red } }" in
+  let actual =
+    parse
+      "@media print { .a { color: red } @supports (color: red) { .b { color: \
+       blue } } }"
+  in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check int)
+    "the nested @supports is counted" 1
+    (Cascade_diff.Tree_diff.count_containers_by_type `Supports d);
+  Alcotest.(check bool)
+    "and the same @supports is found as added" true
+    (Cascade_diff.Tree_diff.has_container_added_of_type `Supports d)
+
+let nested_container_removed_is_found () =
+  let expected =
+    parse
+      "@media print { .a { color: red } @supports (color: red) { .b { color: \
+       blue } } }"
+  in
+  let actual = parse "@media print { .a { color: red } }" in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check int)
+    "the nested @supports is counted" 1
+    (Cascade_diff.Tree_diff.count_containers_by_type `Supports d);
+  Alcotest.(check bool)
+    "and the same @supports is found as removed" true
+    (Cascade_diff.Tree_diff.has_container_removed_of_type `Supports d)
+
+(* An added container is not a removed one and the reverse, however deep it
+   sits. *)
+let nested_container_added_is_not_removed () =
+  let expected = parse "@media print { .a { color: red } }" in
+  let actual =
+    parse
+      "@media print { .a { color: red } @supports (color: red) { .b { color: \
+       blue } } }"
+  in
+  let d = Cascade_diff.Tree_diff.diff ~expected ~actual in
+  Alcotest.(check bool)
+    "the nested addition is not reported as a removal" false
+    (Cascade_diff.Tree_diff.has_container_removed_of_type `Supports d)
+
 let count_containers_zero () =
   let css = parse ".a { color: red }" in
   let d = Cascade_diff.Tree_diff.diff ~expected:css ~actual:css in
@@ -1241,6 +1292,12 @@ let suite =
         single_rule_diff_multiple_changes;
       Alcotest.test_case "count containers media" `Quick count_containers_media;
       Alcotest.test_case "count containers zero" `Quick count_containers_zero;
+      Alcotest.test_case "nested container added is found" `Quick
+        nested_container_added_is_found;
+      Alcotest.test_case "nested container removed is found" `Quick
+        nested_container_removed_is_found;
+      Alcotest.test_case "nested container added is not removed" `Quick
+        nested_container_added_is_not_removed;
       Alcotest.test_case "nesting modified" `Quick diff_nesting_modified;
       Alcotest.test_case "nesting identical" `Quick diff_nesting_identical;
       Alcotest.test_case "nesting child added" `Quick diff_nesting_child_added;


### PR DESCRIPTION
`Tree_diff.has_container_added_of_type` and `has_container_removed_of_type` used to test the top level of a diff only, so a `@supports` added inside an existing `@media` was reported by `count_containers_by_type` but not by either query. They now descend into a modified container the way the count already did.

Stacked on #394.