### PR TITLE
optimize: an empty conditional group rule applies nothing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,11 @@
   conflict test walks the two key lists in step instead of scanning one per
   element of the other, and collecting them no longer rescans what it has
   already collected (#422)
+- An empty `@-moz-document`, `@when` or `@else` is dropped, as an empty
+  `@media` already was: a conditional group rule with no contents applies
+  nothing whatever its condition. An empty `@when` or `@else` stays while a
+  later `@else` binds to it, since dropping the antecedent would leave a bare
+  `@else` that no parser accepts (#396)
 
 ### Custom properties
 

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -447,26 +447,53 @@ let drop_redundant_layer_decls stmts =
   in
   loop [] [] stmts
 
-(* Main statement processing function with layer optimization *)
 (* CSS Cascade 6.1: an empty rule (no declarations, no nested rules) contributes
-   nothing, so drop it under [~optimize:true]; an empty [@media]/[@supports]/
-   [@container]/[@scope]/[@starting-style] body is likewise removed. An empty
-   named [@layer] survives as a [Layer_decl] since the name still orders the
-   layer (CSS Cascade L6 6.4). *)
-let drop_empty_rules stmts =
-  list_filter_preserve
-    (function
-      | Rule { declarations = []; nested = []; _ } -> false
-      | Rule { selector; _ } when Selector.matches_nothing selector -> false
-      | Media (_, []) -> false
-      | Supports (_, []) -> false
-      | Container (_, _, []) -> false
-      | Scope (_, _, []) -> false
-      | Starting_style [] -> false
-      | Page (_, []) -> false
-      | Page_with_margins (_, [], []) -> false
-      | _ -> true)
-    stmts
+   nothing, so drop it under [~optimize:true]. A conditional group rule applies
+   its contents when its condition holds (CSS Conditional 3 sec. 3), so an empty
+   one applies nothing whatever the condition and goes the same way, as does an
+   empty [@scope], [@starting-style] or [@page] box. An empty named [@layer]
+   survives as a [Layer_decl] since the name still orders the layer (CSS Cascade
+   L6 6.4), and an empty [Origin] survives because it gates nothing and records
+   where a block came from. *)
+let is_empty_statement ~chained = function
+  | Rule { declarations = []; nested = []; _ } -> true
+  | Rule { selector; _ } -> Selector.matches_nothing selector
+  | Media (_, []) -> true
+  | Supports (_, []) -> true
+  | Container (_, _, []) -> true
+  | Moz_document (_, []) -> true
+  | Scope (_, _, []) -> true
+  | Starting_style [] -> true
+  | Page (_, []) -> true
+  | Page_with_margins (_, [], []) -> true
+  (* css-conditional-5 sec. 3 binds an [@else] to the [@when] or [@else] before
+     it, so an empty branch is only inert when nothing chains onto it: dropping
+     an antecedent leaves a bare [@else] that no parser accepts, and the branch
+     that followed stops applying. *)
+  | (When (_, []) | Else (_, [])) when not chained -> true
+  | Declarations _ | Bang_comment _ | Charset _ | Import _ | Namespace _
+  | Property _ | Layer_decl _ | Layer _ | Media _ | Container _ | Supports _
+  | Moz_document _ | When _ | Else _ | Starting_style _ | Supports_condition _
+  | Origin _ | Scope _ | Keyframes _ | Webkit_keyframes _ | Moz_keyframes _
+  | Font_face _ | Counter_style _ | Page _ | Page_with_margins _
+  | Font_palette_values _ | Font_feature_values _ | View_transition _
+  | Position_try _ | Viewport _ | Unknown_at_rule _ ->
+      false
+
+(* The tail is filtered first, so a branch is judged against the [@else] that
+   survives rather than the one written: an empty [@when] whose only [@else] is
+   itself empty goes with it in one pass. *)
+let rec drop_empty_rules stmts =
+  match stmts with
+  | [] -> []
+  | stmt :: rest ->
+      let rest' = drop_empty_rules rest in
+      let chained =
+        match rest' with Else _ :: _ -> true | [] | _ :: _ -> false
+      in
+      if is_empty_statement ~chained stmt then rest'
+      else if rest' == rest then stmts
+      else stmt :: rest'
 
 (* CSS Cascade 5 sec. 2: a [@layer <name>;] declaration form is prelude-friendly
    and may interleave with [@charset] / [@import] / [@namespace], so a

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -51,7 +51,14 @@ val drop_redundant_layer_decls :
 (** Drop layer declarations whose ordering is already established. *)
 
 val drop_empty_rules : Stylesheet.statement list -> Stylesheet.statement list
-(** Drop empty rules and empty conditional wrappers. *)
+(** Drop the statements of a block that contribute nothing: a rule with no
+    declarations and no nested rules, a rule whose selector
+    {!Selector.matches_nothing}, a conditional group rule with an empty body,
+    and an empty [@scope], [@starting-style] or [@page] box. An empty [@when] or
+    [@else] goes only when no [@else] chains onto it, since css-conditional-5
+    sec. 3 binds an [@else] to the branch before it. An empty [@layer] stays,
+    the name still ordering the layer, and so does an empty origin wrapper,
+    which gates nothing. *)
 
 val drop_misplaced_imports :
   Stylesheet.statement list -> Stylesheet.statement list

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -101,7 +101,9 @@ val drop_unknown_at_rules : t -> t
 val drop_empty_rules : t -> t
 (** [drop_empty_rules ss] removes top-level rules and at-rule frames whose body
     is empty (no declarations and no nested rules), and rules whose selector
-    {!Selector.matches_nothing}, which no element can ever be styled by. *)
+    {!Selector.matches_nothing}, which no element can ever be styled by. An
+    empty [@when] or [@else] stays while a later [@else] binds to it, and an
+    empty [@layer] or origin wrapper always stays. *)
 
 (** {1 Edge Model} *)
 

--- a/test/test_block.ml
+++ b/test/test_block.ml
@@ -53,6 +53,57 @@ let test_drop_empty_rules () =
   let out = render (Block.drop_empty_rules stmts) in
   Alcotest.(check string) "empty rules removed" ".b{color:red}" out
 
+(* CSS Conditional 3 sec. 3: a conditional group rule applies its contents when
+   its condition holds, so one with no contents applies nothing whatever the
+   condition, and dropping it changes no cascade. That covers [@-moz-document]
+   alongside the conditional groups already dropped. *)
+let test_drop_empty_moz_document () =
+  let stmts = block "@-moz-document url-prefix(){}.b{color:red}" in
+  Alcotest.(check string)
+    "an empty @-moz-document is dropped" ".b{color:red}"
+    (render (Block.drop_empty_rules stmts))
+
+(* css-conditional-5 sec. 3 binds an [@else] to the [@when] or [@else] before
+   it, so an empty one of those is only inert when nothing chains onto it.
+   Dropping an antecedent leaves a bare [@else], which cascade's own reader and
+   a browser both reject, and the branch that followed stops applying. *)
+let test_drop_empty_when_and_else () =
+  Alcotest.(check string)
+    "an empty @when with nothing after it is dropped" ".b{color:red}"
+    (render
+       (Block.drop_empty_rules (block "@when media(width>0px){}.b{color:red}")));
+  Alcotest.(check string)
+    "an empty @else closing a chain is dropped"
+    "@when media(width>0px){.x{color:red}}"
+    (render
+       (Block.drop_empty_rules
+          (block "@when media(width>0px){.x{color:red}}@else{}")))
+
+let test_keep_empty_branch_with_a_chained_else () =
+  let chained = "@when media(width>0px){}@else{.z{color:green}}" in
+  Alcotest.(check string)
+    "an empty @when keeps the @else that binds to it" chained
+    (render (Block.drop_empty_rules (block chained)));
+  let middle =
+    String.concat ""
+      [
+        "@when media(width>0px){.x{color:red}}";
+        "@else supports(color:red){}";
+        "@else{.z{color:green}}";
+      ]
+  in
+  Alcotest.(check string)
+    "an empty @else in the middle of a chain stays" middle
+    (render (Block.drop_empty_rules (block middle)))
+
+(* An origin wrapper has no CSS syntax and gates nothing: it records where a
+   block came from, which an empty one still does. *)
+let test_keep_empty_origin () =
+  let stmts = [ Stylesheet.Origin (Author, []) ] in
+  Alcotest.(check int)
+    "an empty origin wrapper survives" 1
+    (List.length (Block.drop_empty_rules stmts))
+
 let test_is_layer_empty () =
   let stmts = block "@layer a{}" in
   match stmts with
@@ -92,6 +143,14 @@ let suite =
       Alcotest.test_case "merge same-condition @media" `Quick
         test_merge_media_combines_same_condition;
       Alcotest.test_case "drop empty rules" `Quick test_drop_empty_rules;
+      Alcotest.test_case "drop empty @-moz-document" `Quick
+        test_drop_empty_moz_document;
+      Alcotest.test_case "drop empty @when and @else" `Quick
+        test_drop_empty_when_and_else;
+      Alcotest.test_case "keep an empty branch a later @else binds to" `Quick
+        test_keep_empty_branch_with_a_chained_else;
+      Alcotest.test_case "keep an empty origin wrapper" `Quick
+        test_keep_empty_origin;
       Alcotest.test_case "is_layer_empty" `Quick test_is_layer_empty;
       Alcotest.test_case "is_layer_empty sees nested rules" `Quick
         test_is_layer_not_empty_with_nested;


### PR DESCRIPTION
`drop_empty_rules` dropped an empty `@media`, `@supports` and `@container` but left an empty `@-moz-document`, `@when` or `@else` standing, even though its docstring claimed every empty conditional wrapper. A branch keeps its place while a later `@else` binds to it, since css-conditional-5 sec. 3 would leave that `@else` bare and unparseable.

Stacked on #395.