### PR TITLE
hooks: run dune and merlint in the project's opam switch

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,9 +13,17 @@
 #   git config core.hooksPath .githooks
 #
 # Every check here has a CI counterpart, so a clone without the hook is still
-# gated; the hook only moves the failure earlier.
+# gated; the hook only moves the failure earlier. Both build steps go through
+# scripts/with_switch.sh, which is what CI's [opam exec] does: a dune taken
+# from PATH may carry a different compiler, and the artifacts it leaves in
+# _build make merlint report the whole project as unchecked.
 
 set -eu
+
+# Resolve everything from the top of the worktree rather than $PWD, so the
+# hook behaves the same run by hand as run by git.
+root=$(git rev-parse --show-toplevel)
+cd "$root"
 
 CHANGED=$(git diff --cached --name-only --diff-filter=ACM)
 [ -n "$CHANGED" ] || exit 0
@@ -23,44 +31,59 @@ CHANGED=$(git diff --cached --name-only --diff-filter=ACM)
 # 0. ASCII only, on the staged content rather than the worktree. The script
 #    owns the filter, so what CI covers and what the commit is held to are the
 #    same set by construction.
-printf '%s\n' "$CHANGED" | "$(dirname "$0")/../scripts/check_ascii.sh" --staged
+printf '%s\n' "$CHANGED" | "$root/scripts/check_ascii.sh" --staged
 
 # The fast path below only decides whether dune fmt and merlint are worth
 # running; the ASCII rule above has already seen every staged file.
 STAGED=$(printf '%s\n' "$CHANGED" | grep -E '(\.(ml|mli|mll|mly)|(^|/)dune(-project)?)$' || true)
 [ -n "$STAGED" ] || exit 0
 
-# 1. dune fmt
-if ! dune fmt 2>/dev/null; then
-    echo "error: dune fmt failed" >&2
-    exit 1
-fi
+run=$root/scripts/with_switch.sh
 
-REFORMATTED=$(git diff --name-only -- $STAGED 2>/dev/null || true)
+# 1. dune fmt. It exits non-zero whenever it rewrites a file, so the status on
+#    its own does not say whether formatting failed; digest the worktree diff
+#    either side of the run and let the two cases report separately. Nothing is
+#    redirected: the reason a format fails is the error ocamlformat prints.
+worktree_digest() { git diff | git hash-object --stdin; }
+
+before=$(worktree_digest)
+fmt=0
+"$run" dune fmt || fmt=$?
+after=$(worktree_digest)
+
+REFORMATTED=$(git diff --name-only -- $STAGED)
 if [ -n "$REFORMATTED" ]; then
     echo "error: dune fmt rewrote staged files:" >&2
-    echo "$REFORMATTED" >&2
-    echo "re-stage them and commit again." >&2
+    git diff --stat -- $STAGED >&2
+    echo "re-stage them and commit again -- after reading that diff. A rewrite" >&2
+    echo "far larger than a reformat is a stale _build promoting an old" >&2
+    echo ".corrected copy over the file, and [rm -rf _build] is the fix there," >&2
+    echo "not [git add]." >&2
+    exit 1
+elif [ "$after" != "$before" ]; then
+    # Formatting an unstaged file also makes dune fmt exit non-zero. The commit
+    # is unaffected, but the worktree just changed, so say so.
+    echo "note: dune fmt rewrote unstaged files; review with [git diff --stat]." >&2
+elif [ "$fmt" -ne 0 ]; then
+    echo "error: dune fmt could not run cleanly; the reason is above." >&2
     exit 1
 fi
 
-# 2. merlint -- prefer a project-local build if present, otherwise PATH.
-MERLINT=""
-if [ -x _build/default/merlint/bin/main.exe ]; then
-    MERLINT=_build/default/merlint/bin/main.exe
-elif command -v merlint >/dev/null 2>&1; then
-    MERLINT=merlint
+# 2. merlint, over the whole project. [--build] refreshes the .cmt files first:
+#    stale ones make merlint skip every typedtree rule and then fail on its own
+#    coverage gate, which is the same non-zero exit for a very different
+#    reason. It also picks up a format that failed on one file while others
+#    were promoted, which the step above lets past. CI runs the same command.
+if ! "$run" sh -c 'command -v merlint >/dev/null 2>&1'; then
+    echo "error: merlint is not installed in the switch, so the lint cannot run." >&2
+    echo "  opam repo add samoht https://tangled.org/gazagnaire.org/opam-overlay.git" >&2
+    echo "  opam install merlint" >&2
+    echo "CI runs the same lint, so skipping it here would only move the failure." >&2
+    exit 1
 fi
 
-if [ -n "$MERLINT" ]; then
-    # Scan the whole project. [--no-build] skips the [dune build @check] step
-    # so the commit stays fast; the typedtree-backed rules are silently
-    # skipped on any module whose .cmt is stale.
-    if ! "$MERLINT" --no-build; then
-        echo "" >&2
-        echo "merlint reported issues; fix them and commit again." >&2
-        exit 1
-    fi
-else
-    echo "warning: merlint not found on PATH; skipping lint" >&2
+if ! "$run" merlint --build; then
+    echo "" >&2
+    echo "merlint reported issues; fix them and commit again." >&2
+    exit 1
 fi

--- a/scripts/with_switch.sh
+++ b/scripts/with_switch.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Run a command in this project's opam switch.
+#
+#   scripts/with_switch.sh dune fmt
+#
+# Bare [dune] takes whatever compiler comes first on PATH, which on a machine
+# with several switches is rarely this project's. The two then share _build and
+# it ends up holding .cmt files of two magics; merlint reads only the one its
+# own compiler emits, so it reports the rest as unchecked, fails on the
+# coverage gate, and the typedtree rules stop running without saying so. Every
+# entry point that builds goes through here, so none of them can drift.
+#
+# The switch lives in the checkout that owns the shared git directory: a linked
+# worktree has no _opam of its own but builds against the same one.
+
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    echo "usage: with_switch.sh COMMAND [ARG]..." >&2
+    exit 2
+fi
+
+here=$(CDPATH= cd "$(dirname "$0")" && pwd)
+root=$(dirname "$here")
+
+main=""
+if common=$(git -C "$root" rev-parse --git-common-dir 2>/dev/null); then
+    case $common in
+    /*) ;;
+    *) common=$root/$common ;;
+    esac
+    main=$(dirname "$(CDPATH= cd "$common" && pwd)")
+fi
+
+# ocamlc rather than the directory: an interrupted [opam switch create] leaves
+# _opam behind with no compiler in it, and that is as unusable as no switch.
+switch=""
+for d in "$root" "$main"; do
+    [ -n "$d" ] || continue
+    if [ -x "$d/_opam/bin/ocamlc" ]; then
+        switch=$d
+        break
+    fi
+done
+
+if [ -z "$switch" ]; then
+    echo "error: no opam switch for this project; cannot run: $*" >&2
+    echo "  no _opam/bin/ocamlc under $root" >&2
+    if [ -n "$main" ] && [ "$main" != "$root" ]; then
+        echo "  nor under $main" >&2
+    fi
+    echo "  create it with: opam switch create . --deps-only --with-test" >&2
+    echo "  (falling back to the dune on PATH is what this script exists to" >&2
+    echo "   prevent: another compiler writes artifacts merlint cannot read)" >&2
+    exit 1
+fi
+
+if ! command -v opam >/dev/null 2>&1; then
+    echo "error: opam is not on PATH; cannot enter $switch/_opam to run: $*" >&2
+    exit 1
+fi
+
+# [opam exec] replaces the entry of whatever switch the caller's environment
+# points at, rather than shadowing it, and sets OPAM_SWITCH_PREFIX and
+# CAML_LD_LIBRARY_PATH to match. Prepending to PATH would leave those three
+# disagreeing. It is also what CI runs.
+exec opam exec --switch="$switch" -- "$@"

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -15,10 +15,12 @@ fi
 export CHROME
 # Canonical-difference filter: compares values the way cascade does, so
 # render-equivalent spellings (0% vs 0px, red vs rgb(...)) are not reported.
-if command -v dune >/dev/null 2>&1; then
-  dune build test/inline/canon_filter.exe 2>/dev/null
-  CANON_FILTER=$(cd "$dir/../.." && find _build -name canon_filter.exe 2>/dev/null | head -1)
-  [ -n "$CANON_FILTER" ] && export CANON_FILTER="$(cd "$dir/../.." && pwd)/$CANON_FILTER"
+# The filter is optional, so a build that cannot run leaves it unset rather
+# than stopping the sweep -- but it says why instead of discarding the reason.
+root=$(CDPATH= cd "$dir/../.." && pwd)
+if "$root/scripts/with_switch.sh" dune build test/inline/canon_filter.exe; then
+  CANON_FILTER=$(cd "$root" && find _build -name canon_filter.exe | head -1)
+  [ -n "$CANON_FILTER" ] && export CANON_FILTER="$root/$CANON_FILTER"
 fi
 fail=0
 for f in "$dir"/fixtures/*.html; do

--- a/test/render/run.sh
+++ b/test/render/run.sh
@@ -16,5 +16,6 @@ set -eu
 dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 root=$(CDPATH= cd "$dir/../.." && pwd)
 cd "$root"
-dune build test/render/render_diff.exe test/render/driver.js test/render/dom.js
+"$root/scripts/with_switch.sh" dune build test/render/render_diff.exe \
+  test/render/driver.js test/render/dom.js
 exec _build/default/test/render/render_diff.exe "$@"


### PR DESCRIPTION
The pre-commit hook ran bare `dune`, which on a machine with more than one switch resolves a different compiler; the `.cmt` files that leaves make `merlint` report every module as unchecked, so its typedtree rules quietly stopped running and the hook failed for a reason `2>/dev/null` had already discarded. A `merlint` that is not installed now fails the hook rather than skipping the lint, and the two by-hand render harnesses go through the same `scripts/with_switch.sh`.