### PR TITLE
css: recover from a bad descriptor in a @page body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -75,6 +75,15 @@
   starts with an identifier, as in `.a { @media screen { h2:where(.b) { color:
   red } } }`, and a stray `;` between two declarations there, were lost the same
   way (#392)
+- A descriptor a `@page` body rejects is dropped on its own rather than taking
+  the rule and the stylesheet holding it. `@page { margin: 1cm; width: 10;
+  margin-top: 2cm }` parsed to nothing, and a page margin box lost its whole
+  block the same way. CSS Paged Media 3 sec. 6 applies the parse-error rules
+  inside a page or margin context, so the valid declarations around the bad one
+  still apply, and Blink 146 keeps every neighbour. An invalid margin at-rule is
+  discarded to the end of its block rather than to the next `;`, and a
+  selector-shaped item in a margin box, such as `@page { @top-center { .a { b:
+  c } } }`, no longer loops forever (#398)
 
 ### Minification
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1783,14 +1783,77 @@ let read_descriptor_value read_fn constructor r =
     constructor value
   with Failure msg -> Cursor.err_invalid r msg
 
-let read_descriptor_declaration (r : Cursor.t) : Declaration.declaration option
-    =
+(* CSS Syntax 3 sec. 5.4.4: a declaration that fails to parse ends at the next
+   top-level [;]; a [{}] met on the way is one component value of the value
+   being skipped, not a stopping point. *)
+let rec skip_bad_rule_item inner =
+  match Cursor.next_raw inner with
+  | None -> ()
+  | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
+  | Some _ -> skip_bad_rule_item inner
+
+(* CSS Syntax 3 sec. 5.4.2: an at-rule ends at its block or at its [;].
+   Discarding an invalid one consumes exactly that far, so the declarations
+   written after it stay in the rule. *)
+let rec skip_at_rule r =
+  match Cursor.next_raw r with
+  | None -> ()
+  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
+  | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
+      ()
+  | Some _ -> skip_at_rule r
+
+(* Discard the item the cursor sits on. A body that holds declarations and
+   at-rules alike has to pick by what the item starts with: the two ends differ,
+   and taking an at-rule for a declaration would eat the item written after it.
+   The caller rewinds first, so a reader that already consumed part of the item
+   is skipped from its start. *)
+let skip_invalid_item r =
+  match Cursor.peek r with
+  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
+      skip_at_rule r
+  | _ -> skip_bad_rule_item r
+
+(* Read a body one item at a time, [step] committing each item to the
+   accumulator before the next is read, so an item dropped in recovery costs
+   only itself. CSS Paged Media 3 sec. 6: "If an error is encountered during the
+   processing of a declaration block within a page or a margin context, the
+   Rules for handling parsing errors apply; that is, valid declarations within
+   the block are applied." Strict mode ([not (Cursor.recover r)]) still raises,
+   so [~strict:true] rejects exactly what the lenient parse warns about. *)
+let read_items_with_recovery step r init =
+  let rec loop state =
+    if Cursor.recover r then recovering state else continue (step r state)
+  and recovering state =
+    let start = Cursor.save r in
+    match step r state with
+    | committed -> continue committed
+    | exception Error.Parse_error e ->
+        Cursor.push_warning r e;
+        Cursor.restore r start;
+        skip_invalid_item r;
+        loop state
+  and continue = function
+    | `Done result -> result
+    | `More state -> loop state
+  in
+  loop init
+
+(* One item of a descriptor body: a descriptor, a stray [;] that CSS Syntax 3
+   sec. 5.4.3 discards with no declaration to validate, or the end of the body.
+   [Declaration.read_declaration] answers [None] for an item that opens a block
+   instead; a descriptor body holds no rules, so that item is invalid and is
+   reported rather than left for the caller to loop on. *)
+let read_descriptor_item (r : Cursor.t) =
   Cursor.ws r;
-  if Cursor.is_done r then None
+  if Cursor.is_done r then `Done
   else if Cursor.peek_semicolon r then (
     Cursor.skip r;
-    None)
-  else Declaration.read_declaration r
+    `Skip)
+  else
+    match Declaration.read_declaration r with
+    | Some desc -> `Descriptor desc
+    | None -> Cursor.err_expected r "descriptor"
 
 let replace_descriptor desc acc =
   desc
@@ -1799,15 +1862,14 @@ let replace_descriptor desc acc =
          Declaration.property_name existing <> Declaration.property_name desc)
        acc
 
+let read_descriptor_step normalize inner acc =
+  match read_descriptor_item inner with
+  | `Done -> `Done (List.rev acc)
+  | `Skip -> `More acc
+  | `Descriptor desc -> `More (normalize desc acc)
+
 let read_descriptor_block normalize inner =
-  let rec loop acc =
-    match read_descriptor_declaration inner with
-    | Some desc -> loop (normalize desc acc)
-    | None ->
-        Cursor.ws inner;
-        if Cursor.is_done inner then List.rev acc else loop acc
-  in
-  loop []
+  read_items_with_recovery (read_descriptor_step normalize) inner []
 
 (* CSS Fonts 4 sec. 4.4: a descriptor range whose startpoint is larger than its
    endpoint is well defined, the user agent swapping the two endpoints for font
@@ -2396,15 +2458,12 @@ let allowed_page_margin_names =
     "left-top";
   ]
 
-let read_page_descriptor r =
-  match read_descriptor_declaration r with
-  | Some desc
-    when List.mem (Declaration.property_name desc) allowed_page_descriptors ->
-      desc
-  | Some desc ->
-      Cursor.err_invalid r
-        ("invalid @page descriptor: " ^ Declaration.property_name desc)
-  | None -> Cursor.err_expected r "@page descriptor"
+let replace_page_descriptor r desc acc =
+  if List.mem (Declaration.property_name desc) allowed_page_descriptors then
+    replace_descriptor desc acc
+  else
+    Cursor.err_invalid r
+      ("invalid @page descriptor: " ^ Declaration.property_name desc)
 
 let allowed_page_margin_descriptors = "content" :: allowed_page_descriptors
 
@@ -2436,22 +2495,20 @@ let read_page_margin_rule r =
       Cursor.err_invalid r ("unknown page margin rule: @" ^ name)
   | _ -> Cursor.err_expected r "page margin rule"
 
-let read_page_body inner =
-  let rec loop descriptors margins =
-    Cursor.ws inner;
-    match Cursor.peek inner with
-    | None -> (List.rev descriptors, List.rev margins)
-    | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-        Cursor.skip inner;
-        loop descriptors margins
-    | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-        let margin = read_page_margin_rule inner in
-        loop descriptors (margin :: margins)
-    | Some _ ->
-        let desc = read_page_descriptor inner in
-        loop (replace_descriptor desc descriptors) margins
-  in
-  loop [] []
+(* CSS Paged Media 3 sec. 2: a [@page] body holds page properties and margin
+   at-rules, so its items end two different ways and are read apart. *)
+let read_page_step inner (descriptors, margins) =
+  match Cursor.peek inner with
+  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
+      `More (descriptors, read_page_margin_rule inner :: margins)
+  | _ -> (
+      match read_descriptor_item inner with
+      | `Done -> `Done (List.rev descriptors, List.rev margins)
+      | `Skip -> `More (descriptors, margins)
+      | `Descriptor desc ->
+          `More (replace_page_descriptor inner desc descriptors, margins))
+
+let read_page_body inner = read_items_with_recovery read_page_step inner ([], [])
 
 let read_page (r : Cursor.t) : statement =
   Cursor.with_context r "@page" @@ fun () ->
@@ -3034,23 +3091,6 @@ let validate_nested_rule_selector inner selector nested_selector =
   then
     Cursor.err_invalid inner
       "bare nesting selector cannot directly nest another bare nesting selector"
-
-let rec skip_bad_rule_item inner =
-  match Cursor.next_raw inner with
-  | None -> ()
-  | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
-  | Some _ -> skip_bad_rule_item inner
-
-(* CSS Syntax 3 sec. 5.4.2: an at-rule ends at its block or at its [;].
-   Discarding an invalid one consumes exactly that far, so the declarations
-   written after it stay in the rule. *)
-let rec skip_at_rule r =
-  match Cursor.next_raw r with
-  | None -> ()
-  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
-  | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-      ()
-  | Some _ -> skip_at_rule r
 
 (* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be
    nested inside of a style rule as well, unless otherwise specified". A

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1473,22 +1473,27 @@ let spec_lenient_recovery_nested_declaration_run () =
      blue } }"
     ".a{@media screen{color:red;& b{margin:0}background:#00f}}" 1
 
+(* [css] reports exactly [expected] warnings leniently, and [~strict:true]
+   rejects it exactly when the lenient parse warned. *)
+let warns_exactly css expected =
+  let warnings =
+    match Css.of_string ~strict:false css with
+    | Ok { Css.warnings; _ } -> warnings
+    | Error err ->
+        Alcotest.failf "lenient parse rejected %S: %s" css
+          (Cascade.Error.to_string err)
+  in
+  Alcotest.(check int) ("warnings for " ^ css) expected (List.length warnings);
+  match (Css.of_string ~strict:true css, expected) with
+  | Ok _, 0 -> ()
+  | Error _, 0 -> Alcotest.failf "strict parse rejected warning-free %S" css
+  | Ok _, _ -> Alcotest.failf "strict parse accepted warned-about %S" css
+  | Error _, _ -> ()
+
 (* Each recovered declaration reports once, and [~strict:true] rejects exactly
    the inputs the lenient parse warned about. *)
 let spec_recovery_warns_once_per_declaration () =
-  let check css expected =
-    let warnings =
-      match Css.of_string ~strict:false css with
-      | Ok { Css.warnings; _ } -> warnings
-      | Error err ->
-          Alcotest.failf "lenient parse rejected %S: %s" css
-            (Cascade.Error.to_string err)
-    in
-    Alcotest.(check int) ("warnings for " ^ css) expected (List.length warnings);
-    match (Css.of_string ~strict:true css, expected) with
-    | Ok _, 0 | Error _, _ -> ()
-    | Ok _, _ -> Alcotest.failf "strict parse accepted warned-about %S" css
-  in
+  let check = warns_exactly in
   check ".a { @media screen { color: red; width: 10; background: blue } }" 1;
   check ".a { @media screen { width: 10; height: 20; color: red } }" 2;
   check
@@ -1496,6 +1501,107 @@ let spec_recovery_warns_once_per_declaration () =
      }"
     1;
   check ".a { @media screen { color: red; background: blue } }" 0
+
+(* CSS Paged Media 3 sec. 6: "If an error is encountered during the processing
+   of a declaration block within a page or a margin context, the Rules for
+   handling parsing errors apply; that is, valid declarations within the block
+   are applied." One bad descriptor therefore costs that descriptor, not the
+   [@page] holding it and not the sheet holding that. The discard follows CSS
+   Syntax 3 sec. 5.4.4 for a declaration - up to the next top-level [;], a [{}]
+   met on the way counting as one component value of the value being skipped -
+   and sec. 5.4.2 for an at-rule, which ends at its block or its [;]. Blink 146
+   keeps both neighbours in every case below. *)
+let spec_lenient_recovery_page_descriptors () =
+  let recovered = "@page{margin:1cm;margin-top:2cm}" in
+  lenient_recover "bad descriptor first in @page"
+    "@page { width: 10; margin: 1cm; margin-top: 2cm }" recovered 1;
+  lenient_recover "bad descriptor mid-body in @page"
+    "@page { margin: 1cm; width: 10; margin-top: 2cm }" recovered 1;
+  lenient_recover "bad descriptor last in @page"
+    "@page { margin: 1cm; margin-top: 2cm; width: 10 }" recovered 1;
+  lenient_recover "sole descriptor of @page dropped" "@page { width: 10 }" "" 1;
+  lenient_recover "descriptor invalid in the page context is dropped alone"
+    "@page { margin: 1cm; zzz: 1; margin-top: 2cm }" recovered 1;
+  lenient_recover "curly block inside a dropped page value is skipped with it"
+    "@page { margin: 1cm; width: {1}; margin-top: 2cm }" recovered 1;
+  lenient_recover "two curly blocks in a dropped page value are one skip"
+    "@page { margin: 1cm; width: {1}{2}; margin-top: 2cm }" recovered 1;
+  lenient_recover "tokens after a curly block in a dropped page value"
+    "@page { margin: 1cm; width: {1} 2px; margin-top: 2cm }" recovered 1;
+  (* An unclosed function has no top-level [;] left to stop at - the tokenizer
+     closes it at the end of the block - so it takes the rest of the body, as it
+     does in Blink. *)
+  lenient_recover "unclosed function swallows the rest of the page body"
+    "@page { margin: 1cm; width: calc(1px; margin-top: 2cm }"
+    "@page{margin:1cm}" 1;
+  (* A selector-shaped item is not a declaration, so sec. 5.4.4 skips it as a
+     bad one: with no [;] after its block it takes the body's tail with it, and
+     with a [;] it costs only itself. Blink 146 splits the two the same way. *)
+  lenient_recover "selector-shaped item without a semicolon takes the tail"
+    "@page { margin: 1cm; .a { b: c } margin-top: 2cm }" "@page{margin:1cm}" 1;
+  lenient_recover "selector-shaped item with a semicolon costs only itself"
+    "@page { margin: 1cm; .a { b: c }; margin-top: 2cm }" recovered 1;
+  (* An at-rule ends at its block, so discarding an invalid one leaves the
+     descriptor written after it in the page. *)
+  lenient_recover "unknown page margin rule is dropped alone"
+    "@page { @bogus-box { content: \"x\" } margin: 1cm; margin-top: 2cm }"
+    recovered 1;
+  lenient_recover "at-rule that is no page margin rule is dropped alone"
+    "@page { margin: 1cm; @media screen { color: red } margin-top: 2cm }"
+    recovered 1;
+  lenient_recover "page margin rule with no block ends at its semicolon"
+    "@page { margin: 1cm; @top-center; margin-top: 2cm }" recovered 1
+
+(* A page-margin box holds a declaration block of its own (CSS Paged Media 3
+   sec. 5), so sec. 6 applies inside it too: the descriptors written around a
+   bad one stay in the box, and the box stays in the [@page]. *)
+let spec_lenient_recovery_page_margin_box () =
+  let recovered = "@page{@top-center{content:\"x\";margin:0}}" in
+  lenient_recover "bad descriptor in a page margin box"
+    "@page { @top-center { content: \"x\"; width: 10; margin: 0 } }" recovered 1;
+  lenient_recover "descriptor invalid in a margin box is dropped alone"
+    "@page { @top-center { content: \"x\"; zzz: 1; margin: 0 } }" recovered 1;
+  lenient_recover "at-rule in a page margin box ends at its block"
+    "@page { @top-center { @media screen { a: b } content: \"x\"; margin: 0 } }"
+    recovered 1;
+  lenient_recover "selector-shaped item in a margin box with a semicolon"
+    "@page { @top-center { content: \"x\"; .a { b: c }; margin: 0 } }" recovered
+    1;
+  (* [read_page_margin_rule] rejects a box left with no descriptor, so the box
+     goes with its only item; Blink 146 keeps an empty [@top-center { }]. *)
+  lenient_recover "selector-shaped item alone in a page margin box"
+    "@page { @top-center { .a { b: c } } }" "" 1
+
+(* A dropped descriptor leaves no gap: the page keeps the descriptors written
+   around it in source order, and its margin boxes keep theirs. *)
+let spec_lenient_recovery_page_body_order () =
+  lenient_recover "bad descriptor before a page margin box"
+    "@page { margin: 1cm; width: 10; @top-center { content: \"x\" } \
+     margin-top: 2cm }"
+    "@page{margin:1cm;margin-top:2cm;@top-center{content:\"x\"}}" 1;
+  lenient_recover "bad descriptor after a page margin box"
+    "@page { margin: 1cm; @top-center { content: \"x\" } width: 10; \
+     margin-top: 2cm }"
+    "@page{margin:1cm;margin-top:2cm;@top-center{content:\"x\"}}" 1;
+  lenient_recover "bad descriptor between two page margin boxes"
+    "@page { @top-center { content: \"x\" } width: 10; @bottom-center { \
+     content: \"y\" } margin: 1cm }"
+    "@page{margin:1cm;@top-center{content:\"x\"}@bottom-center{content:\"y\"}}"
+    1
+
+(* Each dropped page descriptor reports once, and [~strict:true] rejects exactly
+   the inputs the lenient parse warned about. A stray [;] is discarded without a
+   declaration to validate (CSS Syntax 3 sec. 5.4.3), so it costs nothing. *)
+let spec_page_recovery_warns_once_per_descriptor () =
+  warns_exactly "@page { margin: 1cm; width: 10; margin-top: 2cm }" 1;
+  warns_exactly "@page { margin: 1cm; width: {1}{2}; margin-top: 2cm }" 1;
+  warns_exactly "@page { width: 10; margin: 1cm; height: 20 }" 2;
+  warns_exactly "@page { @top-center { content: \"x\"; width: 10; margin: 0 } }"
+    1;
+  warns_exactly "@page { margin: 1cm; margin-top: 2cm }" 0;
+  warns_exactly "@page { margin: 1cm;; margin-top: 2cm }" 0;
+  warns_exactly "@page { ; margin: 1cm }" 0;
+  warns_exactly "@page { @top-center { content: \"x\" } margin: 1cm }" 0
 
 let stylesheet_tests =
   [
@@ -1581,6 +1687,18 @@ let stylesheet_tests =
     ( "spec recovery warns once per dropped declaration",
       `Quick,
       spec_recovery_warns_once_per_declaration );
+    ( "spec lenient recovery in a @page body",
+      `Quick,
+      spec_lenient_recovery_page_descriptors );
+    ( "spec lenient recovery in a page margin box",
+      `Quick,
+      spec_lenient_recovery_page_margin_box );
+    ( "spec lenient recovery keeps a @page body in order",
+      `Quick,
+      spec_lenient_recovery_page_body_order );
+    ( "spec page recovery warns once per dropped descriptor",
+      `Quick,
+      spec_page_recovery_warns_once_per_descriptor );
   ]
 
 (* Tests for newly added check functions *)


### PR DESCRIPTION
`@page { margin: 1cm; width: 10; margin-top: 2cm }` parsed to nothing: the page body and its margin boxes had no recovery, so a descriptor they reject unwound past the rule and past the stylesheet holding it. CSS Paged Media 3 sec. 4.1 applies the parse-error rules inside a page or margin context, and Blink 146 keeps every neighbour.

Stacked on #392. A selector-shaped item in a margin box, `@page { @top-center { .a { b: c } } }`, also used to loop forever.
