### PR TITLE
css: recover from an unknown descriptor in @property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,15 @@
   discarded to the end of its block rather than to the next `;`, and a
   selector-shaped item in a margin box, such as `@page { @top-center { .a { b:
   c } } }`, no longer loops forever (#398)
+- A descriptor an `@property` body rejects is dropped on its own rather than
+  taking the registration and the stylesheet holding it. `@property --x { syntax:
+  "<length>"; inherits: false; initial-value: 0px; zzz: 1 }` parsed to nothing,
+  and so did a stray `;` between two valid descriptors. CSS Properties and Values
+  API 1 sec. 2 ignores an unknown descriptor, CSS Syntax 3 sec. 5.4.3 discards a
+  `;` with no declaration to validate, and Blink 146 reads the registration in
+  both. Tokens left after a descriptor's value, such as a trailing `!important`,
+  now invalidate the declaration they follow rather than the leftover alone
+  (#399)
 
 ### Minification
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1816,11 +1816,12 @@ let skip_invalid_item r =
 
 (* Read a body one item at a time, [step] committing each item to the
    accumulator before the next is read, so an item dropped in recovery costs
-   only itself. CSS Paged Media 3 sec. 6: "If an error is encountered during the
-   processing of a declaration block within a page or a margin context, the
-   Rules for handling parsing errors apply; that is, valid declarations within
-   the block are applied." Strict mode ([not (Cursor.recover r)]) still raises,
-   so [~strict:true] rejects exactly what the lenient parse warns about. *)
+   only itself and the items around it are kept. CSS Syntax 3 sec. 5.4.3 keeps
+   what a block's contents already yielded when one item fails to parse, and CSS
+   Paged Media 3 sec. 6 says as much of a page or a margin context in so many
+   words: "valid declarations within the block are applied". Strict mode ([not
+   (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly what the
+   lenient parse warns about. *)
 let read_items_with_recovery step r init =
   let rec loop state =
     if Cursor.recover r then recovering state else continue (step r state)
@@ -3106,32 +3107,44 @@ let nests_in_style_rule = function
       false
   | _ -> true
 
-let read_property_descriptors (r : Cursor.t) : property_reader_state =
-  let state = ref { syntax = None; inherits = None; initial_value = None } in
-  let rec loop () =
-    Cursor.ws r;
-    if Cursor.is_done r then !state
-    else
-      let key = Cursor.ident ~keep_case:false r in
-      Cursor.ws r;
-      if not (Cursor.colon r) then Cursor.err_expected r "':'";
-      Cursor.ws r;
-      (match key with
-      | "syntax" ->
-          let syn = Variables.read_syntax r in
-          state := { !state with syntax = Some syn }
-      | "inherits" ->
-          let inherits_value = Cursor.bool r in
-          state := { !state with inherits = Some inherits_value }
-      | "initial-value" ->
-          let value_str = Cursor.consume_until_semicolon ~trim:true r in
-          state := { !state with initial_value = Some value_str }
-      | _ -> Cursor.err_invalid r "unknown property descriptor");
-      Cursor.ws r;
-      if Cursor.peek_semicolon r then Cursor.skip r;
-      loop ()
+(* One descriptor of an [@property] body. The state is returned rather than
+   assigned as the value is read, so a descriptor that fails leaves the ones
+   before it untouched. CSS Properties and Values API 1 sec. 2 gives each
+   descriptor a grammar of its own, and the declaration is the whole of it: a
+   trailing [!important] or a stray ident makes the declaration invalid rather
+   than the leftover alone, as it does in Blink 146. *)
+let read_property_descriptor (r : Cursor.t) state =
+  let key = Cursor.ident ~keep_case:false r in
+  Cursor.ws r;
+  if not (Cursor.colon r) then Cursor.err_expected r "':'";
+  Cursor.ws r;
+  let state =
+    match key with
+    | "syntax" -> { state with syntax = Some (Variables.read_syntax r) }
+    | "inherits" -> { state with inherits = Some (Cursor.bool r) }
+    | "initial-value" ->
+        {
+          state with
+          initial_value = Some (Cursor.consume_until_semicolon ~trim:true r);
+        }
+    | _ -> Cursor.err_invalid r "unknown property descriptor"
   in
-  loop ()
+  Cursor.ws r;
+  if not (Cursor.is_done r || Cursor.peek_semicolon r) then
+    Cursor.err_invalid r ("trailing tokens after @property " ^ key);
+  state
+
+let read_property_step r state =
+  Cursor.ws r;
+  if Cursor.is_done r then `Done state
+  else if Cursor.peek_semicolon r then (
+    Cursor.skip r;
+    `More state)
+  else `More (read_property_descriptor r state)
+
+let read_property_descriptors (r : Cursor.t) : property_reader_state =
+  read_items_with_recovery read_property_step r
+    { syntax = None; inherits = None; initial_value = None }
 
 let read_property_rule (r : Cursor.t) : statement =
   (* Read @property descriptors as a separate helper to keep the reader tidy. *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1603,6 +1603,94 @@ let spec_page_recovery_warns_once_per_descriptor () =
   warns_exactly "@page { ; margin: 1cm }" 0;
   warns_exactly "@page { @top-center { content: \"x\" } margin: 1cm }" 0
 
+(* CSS Properties and Values API 1 sec. 2: [@property] holds the [syntax],
+   [inherits] and [initial-value] descriptors, and "unknown descriptors are
+   invalid and ignored". Dropping one costs that descriptor, not the
+   registration and not the sheet holding it. The discard follows CSS Syntax 3
+   sec. 5.4.4 for a declaration - up to the next top-level [;], a [{}] met on
+   the way counting as one component value of the value being skipped - and sec.
+   5.4.2 for an at-rule, which ends at its block or its [;]. Blink 146 keeps the
+   registration in every case below. *)
+let spec_lenient_recovery_property_descriptors () =
+  let registered =
+    "@property --x{syntax:\"<length>\";inherits:false;initial-value:0px}"
+  in
+  let body rest = "@property --x { syntax: \"<length>\"; " ^ rest ^ " }" in
+  lenient_recover "unknown descriptor first in @property"
+    "@property --x { zzz: 1; syntax: \"<length>\"; inherits: false; \
+     initial-value: 0px }"
+    registered 1;
+  lenient_recover "unknown descriptor mid-body in @property"
+    (body "zzz: 1; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "unknown descriptor last in @property"
+    (body "inherits: false; initial-value: 0px; zzz: 1")
+    registered 1;
+  lenient_recover "curly block inside a dropped descriptor value"
+    (body "zzz: {1}; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "two curly blocks in a dropped descriptor value are one skip"
+    (body "zzz: {1}{2}; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "tokens after a curly block in a dropped descriptor value"
+    (body "zzz: {1} 2px; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "a run of stray tokens is dropped like a bad descriptor"
+    (body "!!!; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "selector-shaped item in @property is dropped alone"
+    (body ".a { b: c }; inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "at-rule in @property ends at its block"
+    (body "@media screen { color: red } inherits: false; initial-value: 0px")
+    registered 1;
+  lenient_recover "at-rule with no block in @property ends at its semicolon"
+    (body "@media screen; inherits: false; initial-value: 0px")
+    registered 1;
+  (* A descriptor's value is its whole declaration, so anything left over makes
+     the declaration invalid rather than the leftover alone. Losing [inherits]
+     that way leaves the registration incomplete, which drops it - as it does in
+     Blink. *)
+  lenient_recover "trailing tokens invalidate the descriptor they follow"
+    (body "inherits: false bogus; initial-value: 0px")
+    "" 1;
+  lenient_recover "an important flag invalidates the descriptor it follows"
+    (body "inherits: false !important; initial-value: 0px")
+    "" 1;
+  lenient_recover "a later descriptor still overrides the one dropped"
+    (body "inherits: false !important; initial-value: 0px; inherits: true")
+    "@property --x{syntax:\"<length>\";inherits:true;initial-value:0px}" 1
+
+(* CSS Syntax 3 sec. 5.4.3 "consume a block's contents" discards a [;] that no
+   declaration precedes rather than validating one, so a stray semicolon in an
+   [@property] body costs nothing. Blink 146 reads all three of these. *)
+let spec_property_skips_stray_semicolons () =
+  let registered =
+    "@property --x{syntax:\"<length>\";inherits:false;initial-value:0px}"
+  in
+  lenient_recover "leading semicolon in @property"
+    "@property --x { ; syntax: \"<length>\"; inherits: false; initial-value: \
+     0px }"
+    registered 0;
+  lenient_recover "doubled semicolon in @property"
+    "@property --x { syntax: \"<length>\";; inherits: false; initial-value: \
+     0px }"
+    registered 0;
+  lenient_recover "trailing semicolon in @property"
+    "@property --x { syntax: \"<length>\"; inherits: false; initial-value: \
+     0px; }"
+    registered 0
+
+(* Each dropped [@property] descriptor reports once, and [~strict:true] rejects
+   exactly the inputs the lenient parse warned about. *)
+let spec_property_recovery_warns_once_per_descriptor () =
+  let body rest = "@property --x { syntax: \"<length>\"; " ^ rest ^ " }" in
+  warns_exactly (body "zzz: 1; inherits: false; initial-value: 0px") 1;
+  warns_exactly (body "zzz: {1}{2}; inherits: false; initial-value: 0px") 1;
+  warns_exactly (body "zzz: 1; yyy: 2; inherits: false; initial-value: 0px") 2;
+  warns_exactly (body "inherits: false; initial-value: 0px") 0;
+  warns_exactly (body ";; inherits: false; initial-value: 0px") 0
+
 let stylesheet_tests =
   [
     (* Core type tests *)
@@ -1699,6 +1787,15 @@ let stylesheet_tests =
     ( "spec page recovery warns once per dropped descriptor",
       `Quick,
       spec_page_recovery_warns_once_per_descriptor );
+    ( "spec lenient recovery in an @property body",
+      `Quick,
+      spec_lenient_recovery_property_descriptors );
+    ( "spec @property skips stray semicolons",
+      `Quick,
+      spec_property_skips_stray_semicolons );
+    ( "spec property recovery warns once per dropped descriptor",
+      `Quick,
+      spec_property_recovery_warns_once_per_descriptor );
   ]
 
 (* Tests for newly added check functions *)


### PR DESCRIPTION
`@property --x { syntax: "<length>"; inherits: false; initial-value: 0px; zzz: 1 }` parsed to nothing: the descriptor loop had no recovery, so a descriptor it rejects unwound past the registration and past the stylesheet holding it, and a stray `;` between two valid descriptors did the same. Blink 146 reads the registration in both.

Stacked on #398. Tokens left after a descriptor's value, such as a trailing `!important`, now invalidate the declaration they follow rather than the leftover alone.