### PR TITLE
css: fold the bad-declaration skip into one cursor primitive

### DIFF
--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -455,6 +455,11 @@ let is_bang_cv = function
 let consume_until_semicolon ?(trim = false) t =
   string_of_components ~trim (drain_until_raw is_semicolon_cv t)
 
+let rec skip_past_semicolon t =
+  match next_raw t with
+  | None -> ()
+  | Some cv -> if not (is_semicolon_cv cv) then skip_past_semicolon t
+
 let consume_to_decl_end ?(trim = false) t =
   string_of_components ~trim
     (drain_until_raw (fun cv -> is_semicolon_cv cv || is_bang_cv cv) t)

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -327,6 +327,13 @@ val consume_until_semicolon : ?trim:bool -> t -> string
 (** [consume_until_semicolon t] consumes and serializes components up to, but
     not including, the next semicolon. *)
 
+val skip_past_semicolon : t -> unit
+(** [skip_past_semicolon t] consumes and discards components up to and including
+    the next top-level semicolon, or up to end of input if none is left. A [{}]
+    met on the way is one component value, not a stopping point, so this is the
+    recovery step CSS Syntax 3 sec. 5.4.4 prescribes for a declaration that
+    fails to parse. *)
+
 val consume_to_decl_end : ?trim:bool -> t -> string
 (** [consume_to_decl_end t] consumes and serializes components up to, but not
     including, the next semicolon or top-level [!] delimiter. *)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2256,20 +2256,6 @@ let read_declaration t : declaration option =
          next [;]) is a nested rule. *)
       if is_nested_rule t then None else Some (read_one ())
 
-(* Skip from the current cursor position to just past the next top-level [;], or
-   stop at EOF. Used to recover from a failed declaration inside a block: per
-   CSS Syntax section 5.5.5 ("consume a block's contents"), an invalid
-   declaration is dropped, parsing resumes at the next [;], and the surrounding
-   rule survives. *)
-let skip_to_next_declaration t =
-  let rec loop () =
-    match Cursor.next_raw t with
-    | None -> ()
-    | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
-    | Some _ -> loop ()
-  in
-  loop ()
-
 type parse_step =
   | Done of declaration list
   | Continue of declaration list
@@ -2305,9 +2291,12 @@ let read_declaration_step t acc =
   if Cursor.recover t then read_declaration_with_recovery t acc
   else read_declaration_no_recovery t acc
 
+(* CSS Syntax 3 sec. 5.5.5 ("consume a block's contents"): the invalid
+   declaration is dropped, reading resumes past the next [;], and the
+   surrounding rule survives. *)
 let recover_declaration_step t acc e =
   Cursor.push_warning t e;
-  skip_to_next_declaration t;
+  Cursor.skip_past_semicolon t;
   acc
 
 let rec read_declarations_loop t acc =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1783,15 +1783,6 @@ let read_descriptor_value read_fn constructor r =
     constructor value
   with Failure msg -> Cursor.err_invalid r msg
 
-(* CSS Syntax 3 sec. 5.4.4: a declaration that fails to parse ends at the next
-   top-level [;]; a [{}] met on the way is one component value of the value
-   being skipped, not a stopping point. *)
-let rec skip_bad_rule_item inner =
-  match Cursor.next_raw inner with
-  | None -> ()
-  | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
-  | Some _ -> skip_bad_rule_item inner
-
 (* CSS Syntax 3 sec. 5.4.2: an at-rule ends at its block or at its [;].
    Discarding an invalid one consumes exactly that far, so the declarations
    written after it stay in the rule. *)
@@ -1812,7 +1803,7 @@ let skip_invalid_item r =
   match Cursor.peek r with
   | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
       skip_at_rule r
-  | _ -> skip_bad_rule_item r
+  | _ -> Cursor.skip_past_semicolon r
 
 (* Read a body one item at a time, [step] committing each item to the
    accumulator before the next is read, so an item dropped in recovery costs
@@ -2158,13 +2149,7 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
            or an invalid value of a known one ([font-display:maybe]) - is
            dropped and the rest of the @font-face is kept, matching browsers. *)
         Cursor.push_warning r e;
-        let rec skip_to_semicolon () =
-          match Cursor.next_raw r with
-          | None | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-              ()
-          | Some _ -> skip_to_semicolon ()
-        in
-        skip_to_semicolon ();
+        Cursor.skip_past_semicolon r;
         None
 
 let read_font_face_block inner =
@@ -2654,14 +2639,6 @@ let read_font_feature_value_entry outer inner : (string * int list) option =
 let replace_font_feature_value ((name, _) as entry) acc =
   entry :: List.filter (fun (existing, _) -> existing <> name) acc
 
-let skip_semicolon_tail inner =
-  let rec loop () =
-    match Cursor.next_raw inner with
-    | None | Some (Component.Preserved { kind = Token.Semicolon; _ }) -> ()
-    | Some _ -> loop ()
-  in
-  loop ()
-
 let read_font_feature_values_entries outer =
   let rec loop inner acc =
     match read_font_feature_value_entry outer inner with
@@ -2671,7 +2648,7 @@ let read_font_feature_values_entries outer =
         if Cursor.is_done inner then List.rev acc else loop inner acc
     | exception Error.Parse_error e ->
         Cursor.push_warning inner e;
-        skip_semicolon_tail inner;
+        Cursor.skip_past_semicolon inner;
         loop inner acc
   in
   Cursor.braces (fun inner -> loop inner []) outer
@@ -3484,7 +3461,7 @@ and read_nesting_block (r : Cursor.t) : block =
     | item -> add_item acc item
     | exception Error.Parse_error e ->
         Cursor.push_warning r e;
-        skip_bad_rule_item r;
+        Cursor.skip_past_semicolon r;
         read_items acc
   and add_item acc = function
     | `Done -> List.rev (seal_declaration_run acc)
@@ -3673,7 +3650,7 @@ and read_recovering_rule_item selector inner loop decls nested =
   | `Continue (decls, nested) -> loop decls nested
   | exception Error.Parse_error e ->
       Cursor.push_warning inner e;
-      skip_bad_rule_item inner;
+      Cursor.skip_past_semicolon inner;
       loop decls nested
 
 and read_rule ?(nested = false) (r : Cursor.t) : rule =


### PR DESCRIPTION
`Stylesheet` and `Declaration` each wrote out the skip CSS Syntax 3 sec. 5.4.4 prescribes for a declaration that fails to parse; this PR moves it to `Cursor.skip_past_semicolon`, the module both readers already depend on. Pure refactor: every file under `test/interop` formats and minifies byte-identically, warnings and exit status included.

Stacked on #399.