### PR TITLE
font-family: quote a family name holding a reserved word

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -272,6 +272,13 @@
   not how CSS Syntax 3 sec. 4.3.9 lets an ident sequence start, so `"2Brand"`,
   `"-2x"` and `"-"` came out bare in every mode and a browser dropped the whole
   declaration, taking the rest of the font stack with it (#390)
+- A multi-word `font-family` name holding a reserved word keeps its quotes.
+  `"inherit test"`, `"revert serif"` and `"default x"` came out bare under
+  `--minify`, and cascade's own reader then rejected the declaration it had
+  just written. CSS Fonts 4 sec. 2.1.1 excludes a pre-defined `font-family`
+  keyword and a CSS-wide keyword per identifier, and CSS Values 4 sec. 4.2 adds
+  the reserved `default`, so the exclusion reaches every word of a
+  `<custom-ident>+` sequence and the quoted form is the only valid one (#401)
 - A same-condition `@media` block is no longer hoisted over a declaration
   written after a nested rule. CSS Nesting 1 sec. 3.4 keeps that run behind the
   rule it follows, so it is one more rule the hoist reorders, and

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -543,15 +543,61 @@ let is_font_family_ident_word s =
   in
   starts_ident && String.for_all is_name_char s
 
+(* CSS Fonts 4 sec. 2.1.1: in an unquoted [<font-family-name>] "any identifier
+   which could be misinterpreted as a pre-defined keyword in the font-family
+   value definition, or the CSS-wide keywords, is not allowed", and a user agent
+   "must not consider these keywords as matching the [<font-family-name>] type".
+   Sec. 2.1.2 spells the pre-defined keywords out: the bare
+   [<generic-font-family>] names listed below, the script-specific generics
+   being functional instead ([generic(fangsong)]). CSS Values 4 sec. 4.2 adds
+   the CSS-wide keywords and the reserved [default], and excludes every entry in
+   all ASCII case permutations. *)
+let font_family_reserved_words =
+  [
+    "serif";
+    "sans-serif";
+    "monospace";
+    "cursive";
+    "fantasy";
+    "system-ui";
+    "math";
+    "ui-serif";
+    "ui-sans-serif";
+    "ui-monospace";
+    "ui-rounded";
+    "inherit";
+    "initial";
+    "unset";
+    "revert";
+    "revert-layer";
+    "default";
+  ]
+
+let is_font_family_reserved_word w =
+  let w = String.lowercase_ascii w in
+  List.exists (String.equal w) font_family_reserved_words
+
+(* A lone word has to clear more than the excluded idents: [read_font_family]
+   below also maps a bare [emoji], [fangsong] or [none] to a keyword rather than
+   a name, so unquoting one changes the value. Inside a sequence they are
+   ordinary [<custom-ident>]s, which is what keeps [Noto Color Emoji]
+   unquoted. *)
+let is_font_family_keyword_name s =
+  let s = String.lowercase_ascii s in
+  is_font_family_reserved_word s
+  || List.exists (String.equal s) [ "emoji"; "fangsong"; "none" ]
+
 let can_unquote_font_family_name s =
   match String.split_on_char ' ' s with
   | _ :: _ :: _ as words ->
-      (* CSS Fonts 4 sec. 2.1.1: a [<family-name>] formed of two or more
-         [<custom-ident>]s is unambiguous - none of its words can be picked up
-         as a property-level CSS-wide keyword once the parser has committed to a
-         multi-token value. So [inherit test] / [revert serif] etc. round-trip
-         unquoted, just like [Times New Roman]. *)
-      List.for_all is_font_family_ident_word words
+      (* The exclusion is stated per identifier, so it holds at every word of a
+         [<custom-ident>+] sequence and not only at a lone one: [inherit test]
+         and [Foo serif] are no more valid family names than [inherit] and
+         [serif] are, and quoting is their only spelling. *)
+      List.for_all
+        (fun w ->
+          is_font_family_ident_word w && not (is_font_family_reserved_word w))
+        words
   | _ -> false
 
 (* Walk a component stream and rewrite each [<string>] token whose content is a
@@ -560,8 +606,8 @@ let can_unquote_font_family_name s =
    property promotion path when the registered syntax accepts [<custom-ident>+]
    - the two forms ([custom-ident>+] vs [<string>]) are spec-equivalent there
    (CSS Fonts 4 sec. 2.1.1), so the rewrite produces a single canonical AST. The
-   guard's "two or more words" rule avoids the CSS-wide-keyword trap (a quoted
-   ["inherit"] never collapses to the bare keyword). *)
+   guard keeps a name holding a reserved word quoted, so no rewrite turns a word
+   of the sequence into a keyword. *)
 let unquote_font_family_strings components =
   let changed = ref false in
   let words_of s =
@@ -591,43 +637,17 @@ let unquote_font_family_strings components =
 (* CSS Fonts 4 sec. 2.1: a [<family-name>] is a [<string>] or a
    [<custom-ident>+], and the two spell the same name. Emit the bare ident
    sequence when it reads back as that same name and quote otherwise: a name
-   that is no ident sequence at all keeps its quotes, and so does a single word
-   colliding with a generic family or a CSS-wide keyword, since dropping the
-   quotes there turns the name into the keyword. The unquoted multi-word form is
-   shorter but is not the CSSOM-canonical serialization, so [enforce_spec] keeps
-   the quotes. *)
+   that is no ident sequence at all keeps its quotes, and so does one whose
+   words include a reserved word, since dropping the quotes there turns the word
+   into the keyword. The unquoted multi-word form is shorter but is not the
+   CSSOM-canonical serialization, so [enforce_spec] keeps the quotes. *)
 let pp_family_name ctx s =
-  let collides_with_keyword =
-    List.mem (String.lowercase_ascii s)
-      [
-        "serif";
-        "sans-serif";
-        "monospace";
-        "cursive";
-        "fantasy";
-        "system-ui";
-        "ui-serif";
-        "ui-sans-serif";
-        "ui-monospace";
-        "ui-rounded";
-        "emoji";
-        "math";
-        "fangsong";
-        "inherit";
-        "initial";
-        "unset";
-        "revert";
-        "revert-layer";
-        "none";
-        "default";
-      ]
-  in
   if
     Pp.minified ctx && (not ctx.Pp.enforce_spec)
     && can_unquote_font_family_name s
   then Pp.string ctx s
-  else if collides_with_keyword || not (is_font_family_ident_word s) then
-    Pp.quoted_string ctx s
+  else if is_font_family_keyword_name s || not (is_font_family_ident_word s)
+  then Pp.quoted_string ctx s
   else Pp.string ctx s
 
 let is_generic_family : font_family -> bool = function

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -61,8 +61,9 @@ val unquote_font_family_strings : custom_value -> custom_value
     [<ident> <whitespace> <ident> ...] component sequence. Used by the
     [@property]-registered custom-property promotion when the registered syntax
     accepts [<custom-ident>+] (CSS Fonts 4 sec. 2.1.1 makes the two forms
-    equivalent in font-family-typed positions). Single-word strings and any
-    token that isn't a [<string>] pass through unchanged. *)
+    equivalent in font-family-typed positions). A single-word string, a string
+    holding a word that sec. 2.1.1 excludes from [<custom-ident>], and any token
+    that isn't a [<string>] pass through unchanged. *)
 
 val components_have_generic_family : custom_value -> bool
 (** [components_have_generic_family components] is [true] when a bare ident in

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -403,32 +403,30 @@ let spec_fontface_family_descriptor_verbatim () =
    does not start an ident sequence, so it has no [<custom-ident>] spelling and
    CSS Fonts 4 sec. 2.1.1 leaves only the [<string>] one. Each output is re-read
    in strict mode: what the printer emits names the same family. *)
+let check_family_name_minify (name, input, expected) =
+  let fail fmt = Fmt.kstr (fun s -> Some s) fmt in
+  match Css.of_string ~strict:false input with
+  | Error _ -> fail "%s: parse rejected %S" name input
+  | Ok { Css.stylesheet; _ } -> (
+      let actual = Css.to_string ~minify:true stylesheet |> String.trim in
+      if not (String.equal actual expected) then
+        fail "%s\n  input:    %S\n  expected: %S\n  actual:   %S" name input
+          expected actual
+      else
+        match Css.of_string ~strict:true actual with
+        | Error e ->
+            fail "%s: output does not read back: %S\n  %s" name actual
+              (Error.to_string e)
+        | Ok { Css.stylesheet; _ } ->
+            let again = Css.to_string ~minify:true stylesheet |> String.trim in
+            if String.equal again actual then None
+            else
+              fail "%s: not a fixpoint\n  once:  %S\n  twice: %S" name actual
+                again)
+
 let spec_family_name_ident_start () =
-  let check (name, input, expected) =
-    let fail fmt = Fmt.kstr (fun s -> Some s) fmt in
-    match Css.of_string ~strict:false input with
-    | Error _ -> fail "%s: parse rejected %S" name input
-    | Ok { Css.stylesheet; _ } -> (
-        let actual = Css.to_string ~minify:true stylesheet |> String.trim in
-        if not (String.equal actual expected) then
-          fail "%s\n  input:    %S\n  expected: %S\n  actual:   %S" name input
-            expected actual
-        else
-          match Css.of_string ~strict:true actual with
-          | Error e ->
-              fail "%s: output does not read back: %S\n  %s" name actual
-                (Error.to_string e)
-          | Ok { Css.stylesheet; _ } ->
-              let again =
-                Css.to_string ~minify:true stylesheet |> String.trim
-              in
-              if String.equal again actual then None
-              else
-                fail "%s: not a fixpoint\n  once:  %S\n  twice: %S" name actual
-                  again)
-  in
   match
-    List.filter_map check
+    List.filter_map check_family_name_minify
       [
         ( "a name starting with a digit stays quoted in the descriptor",
           "@font-face{font-family:\"2Brand\";src:url(a.woff2)}",
@@ -461,6 +459,68 @@ let spec_family_name_ident_start () =
       Alcotest.failf "family names spelled as invalid idents:\n%s"
         (String.concat "\n" mismatches)
 
+(* CSS Fonts 4 sec. 2.1.1: in an unquoted [<font-family-name>], "any identifier
+   which could be misinterpreted as a pre-defined keyword in the font-family
+   value definition, or the CSS-wide keywords, is not allowed", and CSS Values 4
+   sec. 4.2 reserves [default] on top. The exclusion is stated per identifier,
+   so it reaches every word of a [<custom-ident>+] sequence and such a name has
+   no unquoted spelling at all. All four routes into the family-name printer -
+   the property, the [font] shorthand, the [@font-face] descriptor and
+   [@font-feature-values] - are checked, and each output is re-read in strict
+   mode and re-printed. *)
+let spec_family_name_reserved_words () =
+  match
+    List.filter_map check_family_name_minify
+      [
+        ( "a CSS-wide keyword as the first word keeps the quotes",
+          ".a{font-family:\"inherit test\"}",
+          ".a{font-family:\"inherit test\"}" );
+        ( "a CSS-wide keyword as the last word keeps the quotes",
+          ".a{font-family:\"test inherit\"}",
+          ".a{font-family:\"test inherit\"}" );
+        ( "a CSS-wide keyword in the middle keeps the quotes",
+          ".a{font-family:\"a unset b\"}",
+          ".a{font-family:\"a unset b\"}" );
+        ( "revert-layer keeps the quotes",
+          ".a{font-family:\"revert-layer x\",sans-serif}",
+          ".a{font-family:\"revert-layer x\",sans-serif}" );
+        ( "the reserved default keeps the quotes",
+          ".a{font-family:\"default x\"}",
+          ".a{font-family:\"default x\"}" );
+        ( "a keyword word is excluded in every ASCII case permutation",
+          ".a{font-family:\"Foo INITIAL\"}",
+          ".a{font-family:\"Foo INITIAL\"}" );
+        ( "a generic family name as a sequence word keeps the quotes",
+          ".a{font-family:\"Foo serif\",serif}",
+          ".a{font-family:\"Foo serif\",serif}" );
+        ( "a generic family name as the first word keeps the quotes",
+          ".a{font-family:\"monospace Foo\"}",
+          ".a{font-family:\"monospace Foo\"}" );
+        ( "a reserved word keeps the quotes in the font shorthand",
+          ".a{font:12px/1.5 \"inherit test\"}",
+          ".a{font:12px/1.5 \"inherit test\"}" );
+        ( "a reserved word keeps the quotes in the @font-face descriptor",
+          "@font-face{font-family:\"revert serif\";src:url(a.woff2)}",
+          "@font-face{font-family:\"revert serif\";src:url(a.woff2)}" );
+        ( "a reserved word keeps the quotes in @font-feature-values",
+          "@font-feature-values \"default x\"{@styleset{x:1}}",
+          "@font-feature-values \"default x\"{@styleset{x:1}}" );
+        ( "a bare emoji is no generic in the grammar and still unquotes",
+          ".a{font-family:\"Noto Color Emoji\"}",
+          ".a{font-family:Noto Color Emoji}" );
+        ( "a word that merely contains a keyword still unquotes",
+          ".a{font-family:\"inherited serifs\"}",
+          ".a{font-family:inherited serifs}" );
+        ( "an ordinary multi-word name still unquotes",
+          ".a{font-family:\"Times New Roman\",serif}",
+          ".a{font-family:Times New Roman,serif}" );
+      ]
+  with
+  | [] -> ()
+  | mismatches ->
+      Alcotest.failf "family names spelled with a reserved word:\n%s"
+        (String.concat "\n" mismatches)
+
 let suite =
   let open Alcotest in
   ( "font_face",
@@ -491,4 +551,6 @@ let suite =
         spec_fontface_family_descriptor_verbatim;
       test_case "spec family name ident start" `Quick
         spec_family_name_ident_start;
+      test_case "spec family name reserved words" `Quick
+        spec_family_name_reserved_words;
     ] )

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2188,6 +2188,79 @@ let test_font_family () =
   check_font_family ~roundtrip:true ~expected:"\"serif\"" "\"serif\"";
   check_font_family ~roundtrip:true ~expected:"\"inherit\"" "\"inherit\"";
   check_font_family ~roundtrip:true ~expected:"\"default\"" "\"default\"";
+  (* CSS Fonts 4 sec. 2.1.1 states the exclusion per identifier, not per name:
+     "any identifier which could be misinterpreted as a pre-defined keyword in
+     the font-family value definition, or the CSS-wide keywords, is not
+     allowed". A word of a [<custom-ident>+] sequence is such an identifier, so
+     the rule reaches the first, a middle and the last word alike, and a name
+     carrying one has no unquoted spelling at all. *)
+  check_font_family ~roundtrip:true ~expected:"\"inherit test\""
+    "\"inherit test\"";
+  check_font_family ~roundtrip:true ~expected:"\"test inherit\""
+    "\"test inherit\"";
+  check_font_family ~roundtrip:true ~expected:"\"a initial b\""
+    "\"a initial b\"";
+  check_font_family ~roundtrip:true ~expected:"\"unset Sans\"" "\"unset Sans\"";
+  check_font_family ~roundtrip:true ~expected:"\"Brand revert\""
+    "\"Brand revert\"";
+  check_font_family ~roundtrip:true ~expected:"\"revert-layer x\""
+    "\"revert-layer x\"";
+  check_font_family ~roundtrip:true ~expected:"\"a revert-layer b\""
+    "\"a revert-layer b\"";
+  (* CSS Values 4 sec. 4.2 reserves [default] alongside the CSS-wide keywords
+     and excludes it from [<custom-ident>] in every position. *)
+  check_font_family ~roundtrip:true ~expected:"\"default x\"" "\"default x\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo default Bar\""
+    "\"Foo default Bar\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo default\""
+    "\"Foo default\"";
+  (* Sec. 4.2 excludes the keywords "in all ASCII case permutations". *)
+  check_font_family ~roundtrip:true ~expected:"\"INHERIT test\""
+    "\"INHERIT test\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo Default\""
+    "\"Foo Default\"";
+  (* The pre-defined keywords of the [font-family] value definition are the
+     [<generic-font-family>] names, and sec. 2.1.1 adds that a UA "must not
+     consider these keywords as matching the <font-family-name> type", so a
+     sequence word may not be one either. *)
+  check_font_family ~roundtrip:true ~expected:"\"Foo serif\"" "\"Foo serif\"";
+  check_font_family ~roundtrip:true ~expected:"\"serif Foo\"" "\"serif Foo\"";
+  check_font_family ~roundtrip:true ~expected:"\"a sans-serif b\""
+    "\"a sans-serif b\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo monospace\""
+    "\"Foo monospace\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo cursive\""
+    "\"Foo cursive\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo fantasy\""
+    "\"Foo fantasy\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo system-ui\""
+    "\"Foo system-ui\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo math\"" "\"Foo math\"";
+  check_font_family ~roundtrip:true ~expected:"\"Cambria Math\""
+    "\"Cambria Math\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo ui-serif\""
+    "\"Foo ui-serif\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo ui-sans-serif\""
+    "\"Foo ui-sans-serif\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo ui-monospace\""
+    "\"Foo ui-monospace\"";
+  check_font_family ~roundtrip:true ~expected:"\"Foo ui-rounded\""
+    "\"Foo ui-rounded\"";
+  (* Sec. 2.1.2 keeps the script-specific generics functional, so bare
+     [fangsong] and [emoji] are not pre-defined keywords of the value definition
+     and are ordinary [<custom-ident>]s inside a sequence. *)
+  check_font_family ~roundtrip:true ~expected:"Foo emoji" "\"Foo emoji\"";
+  check_font_family ~roundtrip:true ~expected:"Foo fangsong" "\"Foo fangsong\"";
+  check_font_family ~roundtrip:true ~expected:"Noto Color Emoji"
+    "\"Noto Color Emoji\"";
+  (* The exclusion is on the whole identifier, so a word that merely contains a
+     keyword is an ordinary [<custom-ident>] and still unquotes. *)
+  check_font_family ~roundtrip:true ~expected:"inherited test"
+    "\"inherited test\"";
+  check_font_family ~roundtrip:true ~expected:"Foo serifs" "\"Foo serifs\"";
+  check_font_family ~roundtrip:true ~expected:"Foo sans" "\"Foo sans\"";
+  check_font_family ~roundtrip:true ~expected:"Times New Roman"
+    "\"Times New Roman\"";
   (* Test actual invalid cases *)
   neg_cursor read_font_family "123invalid";
   (* identifier can't start with number *)


### PR DESCRIPTION
`font-family: "inherit test"` minified to the bare `inherit test`, which cascade's own reader rejects, so `cascade fmt` on its own output exited 1. CSS Fonts 4 sec. 2.1.1 states the keyword exclusion per identifier, so it reaches every word of a `<custom-ident>+` sequence and the quoted form is the only valid one; the guard now applies it per word, across the property, the `font` shorthand, the `@font-face` descriptor and `@font-feature-values`.

Stacked on #390.