### PR TITLE
css: a bad rule in a block ends at its block, not at a paren

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,6 +93,15 @@
   both. Tokens left after a descriptor's value, such as a trailing `!important`,
   now invalidate the declaration they follow rather than the leftover alone
   (#399)
+- A rule a grouping at-rule's block rejects is discarded to the end of that rule
+  rather than to the first block of any kind in its prelude. In
+  `@media screen { @supports (display: grid) bogus { a { color: red } } }` the
+  discard stopped at `(display: grid)`, so `bogus { a { color: red } }` came back
+  as a rule of its own, and a `[]` in a bad selector cost a second warning for
+  one dropped rule. CSS Syntax 3 sec. 5.4.2 ends an at-rule at its block or its
+  `;` and sec. 5.4.3 ends a qualified rule at its block, so a `(` or a `[`
+  written before that block is part of what is discarded, and Blink 146 keeps no
+  such rule (#402)
 
 ### Minification
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1783,16 +1783,20 @@ let read_descriptor_value read_fn constructor r =
     constructor value
   with Failure msg -> Cursor.err_invalid r msg
 
-(* CSS Syntax 3 sec. 5.4.2: an at-rule ends at its block or at its [;].
-   Discarding an invalid one consumes exactly that far, so the declarations
-   written after it stay in the rule. *)
-let rec skip_at_rule r =
+(* Discard the rule the cursor sits on, stopping at its [{}] block or at a
+   top-level [;]: CSS Syntax 3 sec. 5.4.2 ends an at-rule at whichever comes
+   first, and sec. 5.4.3 ends a qualified rule at its block. Consuming exactly
+   that far leaves what was written after the rule - the declarations around it,
+   or the next rule - to be read on its own. A [(] or a [[] met before the block
+   is a component value of the prelude being discarded, so stopping there would
+   offer the tail of that prelude as a rule of its own. *)
+let rec skip_past_rule r =
   match Cursor.next_raw r with
   | None -> ()
   | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
       ()
-  | Some _ -> skip_at_rule r
+  | Some _ -> skip_past_rule r
 
 (* Discard the item the cursor sits on. A body that holds declarations and
    at-rules alike has to pick by what the item starts with: the two ends differ,
@@ -1802,7 +1806,7 @@ let rec skip_at_rule r =
 let skip_invalid_item r =
   match Cursor.peek r with
   | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      skip_at_rule r
+      skip_past_rule r
   | _ -> Cursor.skip_past_semicolon r
 
 (* Read a body one item at a time, [step] committing each item to the
@@ -3173,7 +3177,7 @@ let item_opens_block inner =
    item, the recovery CSS Syntax 3 sec. 5.4.4 describes. The warning is what
    [~strict:true] turns into an error. *)
 let drop_nested_at_rule r ~loc reason : statement option =
-  skip_at_rule r;
+  skip_past_rule r;
   Cursor.push_warning r (Error.bad_value loc ~property:"rule" ~reason);
   None
 
@@ -3292,16 +3296,6 @@ let rec read_statement (r : Cursor.t) : statement =
   | _ -> Rule (read_rule r)
 
 and read_block (r : Cursor.t) : block =
-  (* Skip a statement that failed to parse: consume to the end of its block
-     ([{...}]) or its terminating [;], leaving the cursor at the next rule. *)
-  let rec skip_bad_statement () =
-    match Cursor.next_raw r with
-    | None -> ()
-    | Some (Component.Block _)
-    | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-        ()
-    | Some _ -> skip_bad_statement ()
-  in
   let rec read_statements acc =
     Cursor.ws r;
     if Cursor.is_done r then List.rev acc
@@ -3316,7 +3310,7 @@ and read_block (r : Cursor.t) : block =
       | exception Error.Parse_error e when Cursor.recover r ->
           Cursor.restore r snap;
           Cursor.push_warning r e;
-          skip_bad_statement ();
+          skip_past_rule r;
           read_statements acc
       | Import _ ->
           (* CSS Cascade L6 sec. 2: @import is only valid at the top of the

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1691,6 +1691,76 @@ let spec_property_recovery_warns_once_per_descriptor () =
   warns_exactly (body "inherits: false; initial-value: 0px") 0;
   warns_exactly (body ";; inherits: false; initial-value: 0px") 0
 
+(* A rule that fails to parse inside a grouping at-rule's block ends where CSS
+   Syntax 3 says its kind ends: an at-rule at its block or its [;] (sec. 5.4.2),
+   a qualified rule at its block (sec. 5.4.3). A [(] or a [[] met before that
+   block is a component value of the prelude, so the rule being discarded runs
+   on past it. Stopping there instead would leave the tail of the prelude to be
+   read as a rule of its own, and Blink 146 keeps no such rule: for each input
+   below it reads back only the rule named in the expectation. *)
+let spec_lenient_recovery_block_statements () =
+  lenient_recover "bad @supports prelude in @media ends at its block"
+    "@media screen { @supports (display: grid) bogus { a { color: red } } b { \
+     color: blue } }"
+    "@media screen{b{color:#00f}}" 1;
+  lenient_recover "bad @supports prelude in @layer ends at its block"
+    "@layer base { @supports (display: grid) bogus { a { color: red } } b { \
+     color: blue } }"
+    "@layer base{b{color:#00f}}" 1;
+  lenient_recover "bad @supports prelude in @supports ends at its block"
+    "@supports (color: red) { @supports (display: grid) bogus { a { color: red \
+     } } b { color: blue } }"
+    "b{color:#00f}" 1;
+  lenient_recover "bad @media prelude in @media ends at its block"
+    "@media screen { @media (min-width: 1px) and { a { color: red } } b { \
+     color: blue } }"
+    "@media screen{b{color:#00f}}" 1;
+  lenient_recover "bad @container prelude in @media ends at its block"
+    "@media screen { @container (min-width: 1px) !! { a { color: red } } b { \
+     color: blue } }"
+    "@media screen{b{color:#00f}}" 1;
+  lenient_recover "at-rule with no block in @media ends at its semicolon"
+    "@media screen { @supports (display: grid) bogus; b { color: blue } }"
+    "@media screen{b{color:#00f}}" 1;
+  lenient_recover "bad selector holding a [] in @media ends at its block"
+    "@media screen { a[href=] { color: red } p { color: blue } }"
+    "@media screen{p{color:#00f}}" 1;
+  lenient_recover "bad selector holding a [] in @layer ends at its block"
+    "@layer base { a[href=] { color: red } p { color: blue } }"
+    "@layer base{p{color:#00f}}" 1;
+  lenient_recover "bad selector opening on a () in @media ends at its block"
+    "@media screen { (foo) bar { a { color: red } } b { color: blue } }"
+    "@media screen{b{color:#00f}}" 1;
+  lenient_recover "two bad statements in one block cost only themselves"
+    "@media screen { @supports (display: grid) bogus { a { color: red } } \
+     @container (min-width: 1px) !! { c { color: lime } } b { color: blue } }"
+    "@media screen{b{color:#00f}}" 2
+
+(* Each statement dropped from a grouping at-rule's block reports once: the tail
+   of its prelude is part of what is discarded, not a second rule to be read and
+   rejected on its own. *)
+let spec_block_recovery_warns_once_per_statement () =
+  warns_exactly
+    "@media screen { @supports (display: grid) bogus { a { color: red } } b { \
+     color: blue } }"
+    1;
+  warns_exactly
+    "@media screen { @container (min-width: 1px) !! { a { color: red } } b { \
+     color: blue } }"
+    1;
+  warns_exactly
+    "@media screen { @supports (display: grid) bogus; b { color: blue } }" 1;
+  warns_exactly "@media screen { a[href=] { color: red } p { color: blue } }" 1;
+  warns_exactly "@layer base { a[href=] { color: red } p { color: blue } }" 1;
+  warns_exactly
+    "@media screen { @supports (display: grid) bogus { a { color: red } } \
+     @container (min-width: 1px) !! { c { color: lime } } b { color: blue } }"
+    2;
+  warns_exactly
+    "@media screen { @supports (display: grid) { a { color: red } } b { color: \
+     blue } }"
+    0
+
 let stylesheet_tests =
   [
     (* Core type tests *)
@@ -1796,6 +1866,12 @@ let stylesheet_tests =
     ( "spec property recovery warns once per dropped descriptor",
       `Quick,
       spec_property_recovery_warns_once_per_descriptor );
+    ( "spec lenient recovery in a grouping at-rule block",
+      `Quick,
+      spec_lenient_recovery_block_statements );
+    ( "spec block recovery warns once per dropped statement",
+      `Quick,
+      spec_block_recovery_warns_once_per_statement );
   ]
 
 (* Tests for newly added check functions *)


### PR DESCRIPTION
Statement recovery inside a grouping at-rule stopped at any block, so a `(` or a `[` in the prelude of the rule being discarded cut the discard short and the tail of that prelude came back as a rule Blink 146 rejects: `@media screen { @supports (display: grid) bogus { a { color: red } } b { color: blue } }` used to keep `bogus { a { color: red } }`, and a `[]` in a bad selector cost a second warning for one dropped rule. The at-rule skip this duplicated already stopped where CSS Syntax 3 ends a rule, at its `{}` block or at a `;`, and now serves every site that discards one.

Every file under `test/interop` formats and minifies byte-identically in `fmt`, `--minify` and `--minify --enforce-spec`, warnings and exit status included. Stacked on #400.