### PR TITLE
css: an important @page descriptor outranks the one written after it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,13 @@
   `bleed`, the name sec. 7.3 defines, and `page-orientation`. A value the
   property's grammar rejects, and an item that is no declaration, are still
   rejected (#403)
+- A duplicate descriptor in a `@page` body or a page-margin box keeps the
+  important declaration rather than the one written last, so
+  `@page { margin: 1cm !important; margin: 2cm }` keeps `margin: 1cm !important`
+  where it kept `margin: 2cm`. CSS Cascade 5 sec. 6.2 ranks an important author
+  declaration above a normal one whatever their order, and Blink 146 reads the
+  important one back in a page body and in a margin box alike. Two declarations
+  of the same importance still keep the last (#404)
 
 ### Minification
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1851,12 +1851,24 @@ let read_descriptor_item (r : Cursor.t) =
     | Some desc -> `Descriptor desc
     | None -> Cursor.err_expected r "descriptor"
 
+(* CSS Cascade 5 sec. 6.2 ranks an important author declaration above a normal
+   one whatever their order, and sec. 6.4 breaks a tie between two of the same
+   importance by order of appearance. A descriptor read later therefore takes
+   the slot one already read holds, unless the one held is important and it is
+   not: then the later declaration is the one that is dropped, and the survivor
+   keeps the place it was written in. *)
 let replace_descriptor desc acc =
-  desc
-  :: List.filter
-       (fun existing ->
-         Declaration.property_name existing <> Declaration.property_name desc)
-       acc
+  let same_slot held =
+    String.equal
+      (Declaration.property_name held)
+      (Declaration.property_name desc)
+  in
+  match List.find_opt same_slot acc with
+  | Some held
+    when Declaration.is_important held && not (Declaration.is_important desc) ->
+      acc
+  | Some _ -> desc :: List.filter (fun held -> not (same_slot held)) acc
+  | None -> desc :: acc
 
 let read_descriptor_step normalize inner acc =
   match read_descriptor_item inner with

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -995,6 +995,53 @@ let spec_page_context_properties () =
       "@page { @top-center { @media screen { .x { color: red } } } }";
     ]
 
+(* CSS Cascade 5 sec. 6.2 puts an important author declaration above a normal
+   one whichever was written first, and sec. 6.4 breaks a tie between two of the
+   same importance by order of appearance. The page context cascades on those
+   rules like any other author context, so a duplicate name in a page body or a
+   margin box keeps the important declaration, and the last one when both carry
+   the same importance. Blink 146 reads exactly that back out of
+   [cssRules[0].cssText] in both contexts. Blink serializes the survivors with
+   the normal declarations before the important ones, a consequence of how it
+   builds its property set; cascade keeps the order the author wrote, which
+   names the same declarations. *)
+let spec_page_descriptor_importance () =
+  List.iter
+    (fun (expected, input) -> check_stylesheet ~expected input)
+    [
+      ( "@page{margin:1cm!important}",
+        "@page { margin: 1cm !important; margin: 2cm }" );
+      ( "@page{margin:2cm!important}",
+        "@page { margin: 1cm; margin: 2cm !important }" );
+      ("@page{margin:2cm}", "@page { margin: 1cm; margin: 2cm }");
+      ( "@page{margin:2cm!important}",
+        "@page { margin: 1cm !important; margin: 2cm !important }" );
+      ( "@page{color:red!important}",
+        "@page { color: red !important; color: blue; color: green }" );
+      (* The important declaration keeps the place it was written in. *)
+      ( "@page{margin:1cm!important;size:A4}",
+        "@page { margin: 1cm !important; size: a4; margin: 2cm }" );
+      (* Sec. 5: a margin box holds a declaration list of its own, and the same
+         cascade decides it. *)
+      ( "@page{@top-center{content:\"a\"!important}}",
+        "@page { @top-center { content: \"a\" !important; content: \"b\" } }" );
+      ( "@page{@top-center{content:\"b\"!important}}",
+        "@page { @top-center { content: \"a\"; content: \"b\" !important } }" );
+      ( "@page{@top-center{content:\"b\"}}",
+        "@page { @top-center { content: \"a\"; content: \"b\" } }" );
+      (* A longhand written after its shorthand is a different name, so neither
+         replaces the other and both stay. Blink expands the pair to longhands
+         and prints [margin: 2cm 1cm 1cm], the same four values. *)
+      ( "@page{margin:1cm;margin-top:2cm}",
+        "@page { margin: 1cm; margin-top: 2cm }" );
+      ( "@page{margin-top:2cm!important;margin:1cm}",
+        "@page { margin-top: 2cm !important; margin: 1cm }" );
+      (* Blink drops a custom property in a page context, so it gives no reading
+         here; the cascade rule that decides every other name decides this one
+         too. *)
+      ("@page{--x:1!important}", "@page { --x: 1 !important; --x: 2 }");
+    ]
+
 let spec_property_descriptor_matrix () =
   List.iter
     (fun (expected, input) -> check_stylesheet ~expected input)
@@ -1877,6 +1924,7 @@ let stylesheet_tests =
       `Quick,
       spec_page_margin_descriptor_matrix );
     ("spec page context properties", `Quick, spec_page_context_properties);
+    ("spec page descriptor importance", `Quick, spec_page_descriptor_importance);
     ("property rule edges", `Quick, property_rule_edges);
     ("spec property descriptor matrix", `Quick, spec_property_descriptor_matrix);
     ("sheet_item", `Quick, sheet_item_case);


### PR DESCRIPTION
`@page { margin: 1cm !important; margin: 2cm }` used to keep `margin: 2cm`: descriptor dedup keyed on the property name alone, so a later normal declaration replaced an important one, where CSS Cascade 5 sec. 6.2 and Blink 146 both keep the important one. Stacked on #403.