### PR TITLE
css: a page-margin box may hold nothing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -119,6 +119,14 @@
   declaration above a normal one whatever their order, and Blink 146 reads the
   important one back in a page body and in a margin box alike. Two declarations
   of the same importance still keep the last (#404)
+- A page-margin box with an empty block is read instead of erroring under
+  `~strict:true` and being dropped with a warning otherwise, so
+  `@page { @top-center { } }` no longer takes its `@page` with it. CSS Paged
+  Media 3 sec. 5 gives a margin at-rule a `<declaration-list>`, which CSS Syntax
+  3 sec. 5.4.4 consumes even when it holds nothing, and Blink 146 keeps the box.
+  Sec. 5 generates the box only where `content` computes away from `none`, so an
+  empty one is elided on output like an empty style rule and an empty `@page`
+  already are (#405)
 
 ### Minification
 

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -4,6 +4,7 @@ open Stylesheet
 open Common
 
 let list_filter_preserve = List.filter_preserve
+let list_edit_preserve = List.edit_preserve
 
 let media_feature_is name (f : Media.feature) =
   match f with
@@ -496,20 +497,32 @@ let drop_redundant_layer_decls stmts =
    nothing, so drop it under [~optimize:true]; an empty [@media]/[@supports]/
    [@container]/[@scope]/[@starting-style] body is likewise removed. An empty
    named [@layer] survives as a [Layer_decl] since the name still orders the
-   layer (CSS Cascade L6 6.4). *)
+   layer (CSS Cascade L6 6.4). CSS Paged Media 3 sec. 5 generates a page-margin
+   box only where its [content] computes away from [none], so a box with no
+   descriptor generates nothing and goes the same way, and the page it leaves
+   with neither descriptor nor box goes after it. *)
 let drop_empty_rules stmts =
-  list_filter_preserve
+  list_edit_preserve
     (function
-      | Rule { declarations = []; nested = []; _ } -> false
-      | Rule { selector; _ } when Selector.matches_nothing selector -> false
-      | Media (_, []) -> false
-      | Supports (_, []) -> false
-      | Container (_, _, []) -> false
-      | Scope (_, _, []) -> false
-      | Starting_style [] -> false
-      | Page (_, []) -> false
-      | Page_with_margins (_, [], []) -> false
-      | _ -> true)
+      | Rule { declarations = []; nested = []; _ } -> List.Drop
+      | Rule { selector; _ } when Selector.matches_nothing selector -> List.Drop
+      | Media (_, []) -> List.Drop
+      | Supports (_, []) -> List.Drop
+      | Container (_, _, []) -> List.Drop
+      | Scope (_, _, []) -> List.Drop
+      | Starting_style [] -> List.Drop
+      | Page (_, []) -> List.Drop
+      | Page_with_margins (selector, descriptors, margins) -> (
+          let kept =
+            list_filter_preserve
+              (fun (m : page_margin_rule) -> m.descriptors <> [])
+              margins
+          in
+          match (descriptors, kept) with
+          | [], [] -> List.Drop
+          | _ when kept == margins -> List.Keep
+          | _ -> List.Replace (Page_with_margins (selector, descriptors, kept)))
+      | _ -> List.Keep)
     stmts
 
 (* CSS Cascade 5 sec. 2: a [@layer <name>;] declaration form is prelude-friendly

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2460,11 +2460,13 @@ let read_page_margin_rule r =
     when List.mem name allowed_page_margin_names ->
       Cursor.skip r;
       Cursor.ws r;
+      (* Sec. 5 gives the margin at-rule a [<declaration-list>], which CSS
+         Syntax 3 sec. 5.4.4 consumes even when it holds nothing, so an empty
+         box is valid and Blink 146 keeps one. That it paints nothing is
+         [Block.drop_empty_rules]'s call to make, not the reader's. *)
       let descriptors =
         Cursor.braces (read_descriptor_block replace_descriptor) r
       in
-      if descriptors = [] then
-        Cursor.err_invalid r "page margin rule requires descriptors";
       { name; descriptors }
   | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
       Cursor.err_invalid r ("unknown page margin rule: @" ^ name)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1042,6 +1042,38 @@ let spec_page_descriptor_importance () =
       ("@page{--x:1!important}", "@page { --x: 1 !important; --x: 2 }");
     ]
 
+(* CSS Paged Media 3 sec. 5 gives a margin at-rule a [<declaration-list>], which
+   CSS Syntax 3 sec. 5.4.4 consumes even when it holds nothing, so a margin box
+   with an empty block is valid and Blink 146 reads one back unchanged - a box
+   left empty by a stray [;] too, which sec. 5.4.3 discards with no declaration
+   to validate. Sec. 5 generates the box only where its [content] computes away
+   from [none], so an empty one paints nothing, and {!Css.to_string} elides what
+   paints nothing whether or not the sheet was optimized: an empty box goes the
+   way an empty style rule and an empty [@page] already go, and a page left with
+   neither descriptor nor box goes with it. *)
+let spec_page_margin_box_empty () =
+  List.iter
+    (fun (expected, input) -> check_stylesheet ~expected input)
+    [
+      ("@page{@top-center{}}", "@page { @top-center { } }");
+      ("@page{@top-center{}}", "@page { @top-center {} }");
+      ("@page{@top-center{}}", "@page { @top-center { ; } }");
+      ( "@page{margin:1cm;@top-center{}}",
+        "@page { margin: 1cm; @top-center { } }" );
+      ( "@page{@top-center{}@bottom-center{content:\"x\"}}",
+        "@page { @top-center { } @bottom-center { content: \"x\" } }" );
+    ];
+  (* An empty block is not a missing one: sec. 5 still asks for a block. *)
+  neg_cursor read_stylesheet "@page { @top-left; }";
+  assert_minify_and_optimize "@page { @top-center { } }" ~minified:""
+    ~optimized:"";
+  assert_minify_and_optimize "@page { margin: 1cm; @top-center { } }"
+    ~minified:"@page{margin:1cm}" ~optimized:"@page{margin:1cm}";
+  assert_minify_and_optimize
+    "@page { @top-center { } @bottom-center { content: \"x\" } }"
+    ~minified:"@page{@bottom-center{content:\"x\"}}"
+    ~optimized:"@page{@bottom-center{content:\"x\"}}"
+
 let spec_property_descriptor_matrix () =
   List.iter
     (fun (expected, input) -> check_stylesheet ~expected input)
@@ -1293,6 +1325,7 @@ let spec_strict_accepts_valid_stylesheets () =
         "@container sidebar (inline-size > 30em) { .x { display: grid } }" );
       (* Paged Media 3 SS 3.1 permits multiple page pseudo-classes; compound
          vectors are covered by the page descriptor matrix. *)
+      ("empty page margin box", "@page { @top-center { } }");
       ( "scope with end boundary",
         "@scope (.card) to (.footer) { .title { color: red } }" );
       ( "font-face wildcard unicode range",
@@ -1925,6 +1958,7 @@ let stylesheet_tests =
       spec_page_margin_descriptor_matrix );
     ("spec page context properties", `Quick, spec_page_context_properties);
     ("spec page descriptor importance", `Quick, spec_page_descriptor_importance);
+    ("spec page margin box empty", `Quick, spec_page_margin_box_empty);
     ("property rule edges", `Quick, property_rule_edges);
     ("spec property descriptor matrix", `Quick, spec_property_descriptor_matrix);
     ("sheet_item", `Quick, sheet_item_case);

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1705,8 +1705,9 @@ let spec_lenient_recovery_page_margin_box () =
   lenient_recover "selector-shaped item in a margin box with a semicolon"
     "@page { @top-center { content: \"x\"; .a { b: c }; margin: 0 } }" recovered
     1;
-  (* [read_page_margin_rule] rejects a box left with no descriptor, so the box
-     goes with its only item; Blink 146 keeps an empty [@top-center { }]. *)
+  (* The box outlives its only item, as it does in Blink 146, and what is left
+     is an empty box: nothing to paint, so it is elided on output like any other
+     block that applies nothing, and the page it empties goes with it. *)
   lenient_recover "selector-shaped item alone in a page margin box"
     "@page { @top-center { .a { b: c } } }" "" 1
 


### PR DESCRIPTION
`@page { @top-center { } }` used to be rejected as a rule requiring descriptors, taking the whole `@page` with it, where CSS Paged Media 3 sec. 5 gives a margin at-rule a `<declaration-list>` that may be empty and Blink 146 keeps the box. The reader accepts it; an empty box paints nothing, so the empty-block pass elides it the way it already elides `@page { }`. Stacked on #404.