### PR TITLE
optimize: a distant @media hoist sees the run it crosses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,6 +99,12 @@
   conflict test walks the two key lists in step instead of scanning one per
   element of the other, and collecting them no longer rescans what it has
   already collected (#422)
+- A same-condition `@media` block is no longer hoisted over a declaration
+  written after a nested rule. CSS Nesting 1 sec. 3.4 keeps that run behind the
+  rule it follows, so it is one more rule the hoist reorders, and
+  `.a { @media (min-width: 1px) { color: red } color: blue; @media (min-width: 1px) { color: green } }`
+  minified to a sheet Chrome computes blue for where the source computes green
+  (#414)
 
 ### Custom properties
 

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -170,6 +170,25 @@ let rec leaf_rules ?parent stmt =
       List.concat_map (fun s -> leaf_rules ?parent s) b
   | _ -> []
 
+(* A declarations run outside any style rule: [leaf_rules] reports nothing for
+   it, so an analysis that must see every declaration refuses rather than read
+   that silence as "no conflict". *)
+let rec holds_unattributed_run stmt =
+  match stmt with
+  | Declarations _ -> true
+  | Media (_, b)
+  | Supports (_, b)
+  | Layer (_, b)
+  | Container (_, _, b)
+  | Starting_style b
+  | Origin (_, b)
+  | Moz_document (_, b)
+  | Scope (_, _, b)
+  | When (_, b)
+  | Else (_, b) ->
+      List.exists holds_unattributed_run b
+  | _ -> false
+
 (* Two declarations an element computes differently once they swap order: they
    write a common longhand slot, and they are not the same declaration. Reading
    the slots off the shorthand footprint rather than the property name is what
@@ -202,12 +221,21 @@ let needs_distant_media_merge stmts =
 
 (* CSS Conditional 3: same-condition [@media] blocks are spec-equivalent to one
    block. Merge a later block into the first occurrence when hoisting it past
-   the intervening statements cannot reorder a conflicting rule. *)
-let merge_distant_media ~optimize_merged_block stmts =
+   the intervening statements cannot reorder a conflicting rule.
+
+   [owner] is the style rule whose body [stmts] is, when it is one. A
+   declarations run in that body sets properties on [owner] (CSS Nesting 1 sec.
+   3.4), so the analysis below only sees it once it can name the rule the run
+   belongs to. *)
+let merge_distant_media ?owner ~optimize_merged_block stmts =
   if not (needs_distant_media_merge stmts) then stmts
   else
+    let leaves stmts = List.concat_map (leaf_rules ?parent:owner) stmts in
+    let unattributed stmts =
+      Option.is_none owner && List.exists holds_unattributed_run stmts
+    in
     let try_merge out cond block : statement list option =
-      let hoisted = List.concat_map leaf_rules block in
+      let hoisted = leaves block in
       let rec split before :
           statement list ->
           (statement list * statement list * statement list) option = function
@@ -226,11 +254,12 @@ let merge_distant_media ~optimize_merged_block stmts =
       match split [] out with
       | None -> None
       | Some (before, target, after) when List.for_all crossable after ->
-          let crossed = List.concat_map leaf_rules after in
+          let crossed = leaves after in
           if
-            List.exists
-              (fun h -> List.exists (rules_conflict h) crossed)
-              hoisted
+            unattributed block || unattributed after
+            || List.exists
+                 (fun h -> List.exists (rules_conflict h) crossed)
+                 hoisted
           then None
           else Some (before @ [ Media (cond, target @ block) ] @ after)
       | Some _ -> None

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -13,13 +13,17 @@ val merge_consecutive_media :
 (** Merge adjacent [@media] blocks with identical conditions. *)
 
 val merge_distant_media :
+  ?owner:Stylesheet.rule ->
   optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->
   Stylesheet.statement list ->
   Stylesheet.statement list
 (** Merge a later same-condition [@media] block into the first occurrence when
     hoisting it past the intervening statements cannot reorder a conflicting
     rule (overlapping selector with a shared property set to a different value).
-*)
+
+    [owner] is the style rule whose body the statements are, when they are one.
+    A declarations run in that body sets properties on [owner] (CSS Nesting 1
+    sec. 3.4), so without it the run is a conflict the hoist never sees. *)
 
 val merge_consecutive_supports :
   optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -152,13 +152,13 @@ let split_vendor_selector_lists (stmts : statement list) : statement list =
       | other -> [ other ])
     stmts
 
-let rec statements ?factor_cache ~ctx ~enforce_spec ~nesting
+let rec statements ?factor_cache ~ctx ~enforce_spec ~owner
     (stmts : statement list) : statement list =
   match stmts with
   | [] -> stmts
   | _ ->
       let optimize_merged_block =
-        statements ?factor_cache ~ctx ~enforce_spec ~nesting
+        statements ?factor_cache ~ctx ~enforce_spec ~owner
       in
       (* [drop_misplaced_imports] runs first: an [@import] after a style rule is
          invalid and ignored by browsers, so it must not act as a cascade
@@ -171,7 +171,7 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~nesting
           |> merge_named_layers_by_name |> split_vendor_selector_lists
         in
         let stmts =
-          process_statements ?factor_cache ~ctx ~enforce_spec ~nesting [] stmts
+          process_statements ?factor_cache ~ctx ~enforce_spec ~owner [] stmts
         in
         let stmts =
           if Ctx.regroup ctx then synthesize_nesting_statements stmts else stmts
@@ -179,7 +179,7 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~nesting
         let stmts =
           stmts
           |> merge_consecutive_media ~optimize_merged_block
-          |> merge_distant_media ~optimize_merged_block
+          |> merge_distant_media ?owner ~optimize_merged_block
           |> merge_consecutive_supports ~optimize_merged_block
           |> merge_consecutive_containers ~optimize_merged_block
         in
@@ -191,7 +191,7 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~nesting
    popping the next pending segment when the list is exhausted. This lets
    [process_supports_statement] splice three segments without materialising
    their concatenation. *)
-and process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
+and process_statements ?factor_cache ~ctx ~enforce_spec ~owner
     ?(pending : statement list list = []) (acc : statement list)
     (remaining : statement list) : statement list =
   match remaining with
@@ -199,49 +199,49 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
       match pending with
       | [] -> List.rev acc
       | next :: rest_pending ->
-          process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
+          process_statements ?factor_cache ~ctx ~enforce_spec ~owner
             ~pending:rest_pending acc next)
   | (Rule r as stmt) :: rest ->
-      process_rule_run ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc
-        stmt r rest
+      process_rule_run ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc stmt
+        r rest
   | (Media (cond, block) as stmt) :: rest ->
-      process_media_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_media_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         acc stmt cond block rest
   | (Container (name, cond, block) as stmt) :: rest ->
-      process_container_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+      process_container_statement ?factor_cache ~ctx ~enforce_spec ~owner
         ~pending acc stmt name cond block rest
   | Supports (cond, block) :: rest ->
-      process_supports_statement ?factor_cache ~ctx ~enforce_spec ~nesting
+      process_supports_statement ?factor_cache ~ctx ~enforce_spec ~owner
         ~pending acc cond block rest
   | (Scope (start, end_, block) as stmt) :: rest ->
       let start' = option_map_preserve canonicalize_scope_selector start in
       let end_' = option_map_preserve canonicalize_scope_selector end_ in
       let optimized_block =
-        statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+        statements ?factor_cache ~ctx ~enforce_spec ~owner block
       in
       let optimized =
         if start' == start && end_' == end_ && optimized_block == block then
           stmt
         else Scope (start', end_', optimized_block)
       in
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         (optimized :: acc) rest
   | (Origin (origin, block) as stmt) :: rest ->
       let optimized_block =
-        statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+        statements ?factor_cache ~ctx ~enforce_spec ~owner block
       in
       let optimized =
         if optimized_block == block then stmt
         else Origin (origin, optimized_block)
       in
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         (optimized :: acc) rest
   | (Layer (name, block) as stmt) :: rest ->
-      process_layer_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         acc stmt name block rest
   | (Import import as stmt) :: rest ->
-      process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting
-        ~pending acc stmt import rest
+      process_import_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
+        acc stmt import rest
   | (Declarations decls as stmt) :: rest ->
       (* A run of declarations is a declaration list wherever it sits, and
          nothing comes between two writes inside one, so the same deduplication
@@ -249,30 +249,30 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~nesting
          wins). *)
       let decls' = declaration_run ~ctx decls in
       let stmt = if decls' == decls then stmt else Declarations decls' in
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         (stmt :: acc) rest
   | hd :: rest ->
       (* Other statement types - keep as-is *)
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         (hd :: acc) rest
 
-and process_rule_run ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc stmt
-    r rest =
+and process_rule_run ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc stmt r
+    rest =
   let plain_stmts, plain_rules, rest = collect_rules [ stmt ] [ r ] rest in
   let optimized = rules_aux ?factor_cache ~ctx ~enforce_spec plain_rules in
   let as_statements =
     if optimized == plain_rules then plain_stmts
     else List.map (fun r -> Rule r) optimized
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     (List.rev_append as_statements acc)
     rest
 
-and process_media_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
-    acc stmt cond block rest =
+and process_media_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
+    stmt cond block rest =
   let cond = if enforce_spec then cond else Media.lower_for_minify cond in
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner block
   in
   let optimized =
     if
@@ -281,17 +281,17 @@ and process_media_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
     then stmt
     else Media (cond, optimized_block)
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     (optimized :: acc) rest
 
-and process_container_statement ?factor_cache ~ctx ~enforce_spec ~nesting
-    ~pending acc stmt name cond block rest =
+and process_container_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
+    acc stmt name cond block rest =
   let cond =
     if enforce_spec then cond
     else option_map_preserve Container.lower_for_minify cond
   in
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner block
   in
   let optimized =
     if
@@ -300,20 +300,20 @@ and process_container_statement ?factor_cache ~ctx ~enforce_spec ~nesting
     then stmt
     else Container (name, cond, optimized_block)
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     (optimized :: acc) rest
 
-and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~nesting
-    ~pending acc cond block rest =
+and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
+    acc cond block rest =
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner block
   in
   let baseline =
     if enforce_spec then `Cond cond else Supports.simplify_baseline cond
   in
   match baseline with
   | `True when block_introduces_layer_order optimized_block ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         (Supports (cond, optimized_block) :: acc)
         rest
   | `True ->
@@ -323,48 +323,48 @@ and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~nesting
          adjacent rules across the segment boundary into one run - the whole
          point of unwrapping a baseline-true @supports. Tail-recursive
          [List.concat] so a long [optimized_block] cannot stack-overflow. *)
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
         (List.concat [ trailing; optimized_block; rest ])
   | `False ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending acc
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
         rest
   | `Cond cond' ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
         (Supports (cond', optimized_block) :: acc)
         rest
 
-and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
-    acc stmt name block rest =
+and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
+    stmt name block rest =
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner block
   in
   if is_layer_empty optimized_block then
     match name with
     (* A style rule holds no layer-order declaration, so inside one the empty
        block keeps its block form; folding it to [Layer_decl] emits CSS every
        engine drops. *)
-    | Some _ when nesting ->
-        process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+    | Some _ when Option.is_some owner ->
+        process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
           (Layer (name, optimized_block) :: acc)
           rest
     | Some layer_name ->
         let all_names, remaining =
           collect_empty_layer_names [ layer_name ] rest
         in
-        process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+        process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
           (Layer_decl all_names :: acc)
           remaining
     | None ->
-        process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
-          acc rest
+        process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending acc
+          rest
   else
     let optimized =
       if optimized_block == block then stmt else Layer (name, optimized_block)
     in
-    process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+    process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
       (optimized :: acc) rest
 
-and process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+and process_import_statement ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     acc stmt import rest =
   let stmt =
     match import.supports with
@@ -373,19 +373,20 @@ and process_import_statement ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
         Import { import with supports = None }
     | _ -> stmt
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~nesting ~pending
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~pending
     (stmt :: acc) rest
 
 (* Optimize one rule's nested statements recursively, then drop the redundant
    nesting prefix (see [drop_nesting_prefix]) and let a run written after them
-   rejoin the rule's own declarations wherever the cascade allows. *)
+   rejoin the rule's own declarations wherever the cascade allows. The body is
+   the rule's, so it optimizes with the rule as owner. *)
 and rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec rule =
   let nested =
     match rule.nested with
     | [] -> []
     | nested ->
         let nested =
-          statements ?factor_cache ~ctx ~enforce_spec ~nesting:true nested
+          statements ?factor_cache ~ctx ~enforce_spec ~owner:(Some rule) nested
         in
         if enforce_spec then nested
         else list_map_preserve drop_nesting_prefix nested
@@ -468,10 +469,10 @@ let drop_shadowed_keyframes (stmts : statement list) : statement list =
 let statements_top_level ?factor_cache ~ctx ~enforce_spec
     (stmts : statement list) : statement list =
   let optimize_merged_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting:false
+    statements ?factor_cache ~ctx ~enforce_spec ~owner:None
   in
   let stmts' =
-    statements ?factor_cache ~ctx ~enforce_spec ~nesting:false stmts
+    statements ?factor_cache ~ctx ~enforce_spec ~owner:None stmts
     |> merge_consecutive_layers ~optimize_merged_block
     |> drop_redundant_layer_decls |> drop_shadowed_keyframes
   in
@@ -483,7 +484,8 @@ let single_rule ?scope (rule : rule) : rule =
     hoist_declaration_runs
       {
         rule with
-        nested = statements ~ctx ~enforce_spec:false ~nesting:true rule.nested;
+        nested =
+          statements ~ctx ~enforce_spec:false ~owner:(Some rule) rule.nested;
       }
   in
   {

--- a/test/inline/fixtures/nested_media_order.html
+++ b/test/inline/fixtures/nested_media_order.html
@@ -1,0 +1,9 @@
+<!doctype html><html><head><style>
+  .dm1 { @media (min-width: 1px) { color: red } color: blue; @media (min-width: 1px) { color: green } }
+  .dm2 { @media (min-width: 1px) { color: red } @media (min-width: 1px) { color: green } color: blue }
+  .dm3 { @media (min-width: 1px) { color: red } outline-color: blue; @media (min-width: 1px) { color: green } }
+</style></head><body>
+<div class="dm1">a</div>
+<div class="dm2">b</div>
+<div class="dm3">c</div>
+</body></html>

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1595,7 +1595,34 @@ let test_distant_media_merge () =
     "@media(width>=1px){a{background-color:red}}a{background:#00f}@media(width>=1px){a{background-color:green}}"
     (minify_str
        "@media (width>=1px){a{background-color:red}}a{background:blue}@media \
-        (width>=1px){a{background-color:green}}")
+        (width>=1px){a{background-color:green}}");
+  (* CSS Nesting 1 sec. 3.4: a declaration written after a nested rule stays
+     behind it, so the run between the two blocks is one more rule with the
+     enclosing selector. Hoisting the second block over it would compute blue
+     where the source computes green. *)
+  Alcotest.(check string)
+    "keeps blocks apart across a conflicting nested declarations run"
+    ".a{@media(width>=1px){color:red}color:#00f;@media(width>=1px){color:green}}"
+    (minify_str
+       ".a{@media (width>=1px){color:red}color:blue;@media \
+        (width>=1px){color:green}}");
+  (* The run sets another property, so nothing an element computes depends on
+     the order: the blocks still merge, and the disjoint run rejoins the rule's
+     own declarations. *)
+  Alcotest.(check string)
+    "merges across a nested declarations run that sets another property"
+    ".a{outline-color:#00f;@media(width>=1px){color:red;color:green}}"
+    (minify_str
+       ".a{@media (width>=1px){color:red}outline-color:blue;@media \
+        (width>=1px){color:green}}");
+  (* Adjacent blocks cross nothing, so the run after them keeps its place and
+     the merge stands. *)
+  Alcotest.(check string)
+    "merges adjacent blocks inside a rule"
+    ".a{@media(width>=1px){color:red;color:green}color:#00f}"
+    (minify_str
+       ".a{@media (width>=1px){color:red}@media \
+        (width>=1px){color:green}color:blue}")
 
 let test_keep_bang_comment_leading () =
   (* A bang comment (/*! ... */) is preserved by minify; it stays where it was


### PR DESCRIPTION
`cascade --minify` hoisted a same-condition `@media` block back onto an earlier one across a declaration written after a nested rule, so `.a { @media (min-width: 1px) { color: red } color: blue; @media (min-width: 1px) { color: green } }` minified to a sheet Chrome 146 computes blue for where the source computes green. The hoist now reads that run as one more rule with the enclosing selector, which is what the `?parent` argument added in #376 was for.

Stacked on #380, which is what makes the shape reachable from CSS text; the same hoist is reachable on main today through the `Css.Stylesheet.Declarations` constructor.