### PR TITLE
optimize: read the crossed slots off the shorthand footprint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@
 
 ### Minification
 
+- A same-condition `@media` block is no longer hoisted over a crossed rule
+  whose shorthand writes a longhand the hoisted block also writes. The hoist
+  tied two declarations by property name, so
+  `@media (width>=1px){a{background-color:red}}a{background:blue}@media (width>=1px){a{background-color:green}}`
+  minified to a sheet Chrome computes blue for where the source computes green
+  (#415)
 - `@media not all and (X)` minifies to the Level 4 `@media not (X)`. `all` is
   the identity media type (Media Queries 4 sec. 2.3), so the two spell the same
   query, and default minify already spends Level 3 compatibility by lowering

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -163,27 +163,24 @@ let rec leaf_rules stmt =
       List.concat_map leaf_rules b
   | _ -> []
 
-(* Only reached once the two declarations are known to share a property, so the
-   property itself is not part of the key. *)
-let decl_value_key d =
-  (Declaration.string_of_value ~minify:true d, Declaration.is_important d)
+(* Two declarations an element computes differently once they swap order: they
+   write a common longhand slot, and they are not the same declaration. Reading
+   the slots off the shorthand footprint rather than the property name is what
+   ties [background] to the [background-color] it also writes. A pair that
+   differs in importance is decided by importance, not by order. *)
+let declarations_conflict a b =
+  Declaration.is_important a = Declaration.is_important b
+  && (not (Shorthand.same_minified_declaration a b))
+  && Shorthand.declarations_overlap a b
 
 (* Two rules whose declarations would reorder unsafely: overlapping selectors
-   and a shared property set to a different value. Equal values reorder
-   freely. *)
+   and a conflicting declaration pair. *)
 let rules_conflict (r1 : rule) (r2 : rule) =
   Selector_summary.may_overlap
     (Selector_summary.of_selector r1.selector)
     (Selector_summary.of_selector r2.selector)
   && List.exists
-       (fun a ->
-         List.exists
-           (fun b ->
-             (* [same_property] reads the property off the AST; comparing the
-                printed names would tie two constructors that print alike. *)
-             Declaration.same_property a b
-             && decl_value_key a <> decl_value_key b)
-           r2.declarations)
+       (fun a -> List.exists (declarations_conflict a) r2.declarations)
        r1.declarations
 
 let needs_distant_media_merge stmts =

--- a/test/inline/fixtures/distant_media_shorthand.html
+++ b/test/inline/fixtures/distant_media_shorthand.html
@@ -1,0 +1,11 @@
+<!doctype html><html><head><style>
+  @media (min-width: 1px) { .sh1 { background-color: red } }
+  .sh1 { background: blue }
+  @media (min-width: 1px) { .sh1 { background-color: green } }
+  @media (min-width: 1px) { .sh2 { background-color: red } }
+  .sh2 { color: blue }
+  @media (min-width: 1px) { .sh2 { background-color: green } }
+</style></head><body>
+<div class="sh1">a</div>
+<div class="sh2">b</div>
+</body></html>

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1586,7 +1586,16 @@ let test_distant_media_merge () =
      theme;@media(width>=1px){a{color:#00f}}"
     (minify_str
        "@media (width>=1px){a{color:red}}@layer theme;@media \
-        (width>=1px){a{color:blue}}")
+        (width>=1px){a{color:blue}}");
+  (* A crossed shorthand writes the longhand slot the hoisted block writes, so
+     the two do not commute even though no property name is shared: hoisting
+     computes blue where the source computes green. *)
+  Alcotest.(check string)
+    "keeps blocks apart when a crossed shorthand writes the same slot"
+    "@media(width>=1px){a{background-color:red}}a{background:#00f}@media(width>=1px){a{background-color:green}}"
+    (minify_str
+       "@media (width>=1px){a{background-color:red}}a{background:blue}@media \
+        (width>=1px){a{background-color:green}}")
 
 let test_keep_bang_comment_leading () =
   (* A bang comment (/*! ... */) is preserved by minify; it stays where it was


### PR DESCRIPTION
The distant `@media` merge tied two declarations by property name, so a crossed `background` and a hoisted `background-color` read as unrelated and the block moved past it: `@media (width>=1px){a{background-color:red}}a{background:blue}@media (width>=1px){a{background-color:green}}` minified to a sheet Chrome 146 computes blue for where the source computes green. The conflict test now reads the slots each declaration writes off `Shorthand`, the same footprint model the rule graph uses.

Independent of #414, which fixes the other blind spot in the same hoist.