### PR TITLE
css: keep the @property registration of a live custom property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -331,6 +331,12 @@
   which closes the rule around it. The declaration name, the `var()` reference
   and every shape of its fallback, the `@property` prelude and a `style()`
   container query all take the escaping (#429)
+- `Css.inline_vars` keeps the `@property` registration of a custom property it
+  keeps live. Every registration was dropped, so a property the pass could not
+  inline safely lost the `initial-value` its references fall back on and the
+  `inherits: false` that stops it inheriting, repainting the page; and the pass
+  missed its own fixpoint, the second run pruning the declaration the first had
+  kept (#416)
 - Pruning unreferenced custom properties counts a `var()` in a `@keyframes`
   frame, `@page` and its margin boxes, `@position-try` or
   `@supports-condition` as a reference, instead of deleting a binding those

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -621,14 +621,28 @@ let of_string_exn ?strict ?filename ?meta ?enforce_spec css =
    which [edit_statements] cannot express and which does not need it: the splice
    is the [concat_map] over a block, and the descent below it is still
    [map_statement_children]'s, so an at-rule added later is walked without a
-   word here. *)
-let rec statements_for_inline block = List.concat_map statement_for_inline block
+   word here.
 
-and statement_for_inline statement =
+   [live] holds every custom-property name the substituted stylesheet still
+   mentions, with the leading [--]. A [@property] registration is not
+   scaffolding for the [var()] it feeds: CSS Properties and Values API 1 sec. 2
+   makes its [initial-value] the computed value wherever no declaration wins,
+   and its [inherits] descriptor decides whether the property inherits at all.
+   Both change computed values, so the registration dies only with the property
+   itself - once substitution has left neither a declaration of it nor a [var()]
+   reading it. *)
+let rec statements_for_inline ~live block =
+  List.concat_map (statement_for_inline ~live) block
+
+and statement_for_inline ~live statement =
   match statement with
-  | Layer (_, block) -> statements_for_inline block
-  | Layer_decl _ | Property _ -> []
-  | statement -> [ map_statement_children statements_for_inline statement ]
+  | Layer (_, block) -> statements_for_inline ~live block
+  | Property rule -> if List.mem rule.name live then [ statement ] else []
+  (* Every [@layer] wrapper is spliced into its parent above, so the layers an
+     [@layer] statement orders no longer exist to be ordered. *)
+  | Layer_decl _ -> []
+  | statement ->
+      [ map_statement_children (statements_for_inline ~live) statement ]
 
 (* Pure serialiser: walk the AST and emit CSS, no optimise/theme/inline-vars
    rewriting. Spec recovery (drop invalid declarations, unknown at-rules, empty
@@ -675,15 +689,16 @@ let canonicalize_rule_order = Rule_order.canonicalize
 
 (* Explicit AST step matching what [to_string ~mode:Inline] does internally:
    substitute every resolvable [var()] reference, then strip the now-empty
-   [@layer] wrappers and the [@property] / [@layer-decl] rules that only existed
-   to register the substituted variables. *)
+   [@layer] wrappers, the [@layer-decl] rules ordering them, and the [@property]
+   registrations whose property the substitution removed. *)
 let inline_vars ?keep_vars ?warn stylesheet =
   let substituted =
     match keep_vars with
     | None -> Inline.vars ?warn stylesheet
     | Some keep_vars -> Inline.vars ?warn ~keep_vars stylesheet
   in
-  statements_for_inline substituted
+  let live = Inline.mentioned_custom_names substituted in
+  statements_for_inline ~live substituted
 
 (* Collect every [var(--name)] reference's name (with leading [--]) from a
    stylesheet. Used by [resolve_theme] to know which names to ask the

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7841,7 +7841,13 @@ val inline_vars : ?keep_vars:string list -> ?warn:(string -> unit) -> t -> t
     [var()] reference; [warn] is called with each such name. The transform
     assumes no runtime mutation of the variables it inlines: a reference marked
     [~runtime] on {!var_ref} also stays live, fallback included, so a
-    browser-time override point survives. *)
+    browser-time override point survives.
+
+    Every [@layer] wrapper is spliced into its parent and the [@layer-decl]
+    rules ordering them go with it. A [@property] registration goes only when
+    the substitution left neither a declaration of its property nor a [var()]
+    reading it: its [initial-value] and [inherits] descriptors decide computed
+    values, so a property that stays live keeps its registration. *)
 
 val resolve_theme :
   ?theme:Pp.String_set.t -> ?theme_defaults:(string -> string option) -> t -> t

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1091,6 +1091,22 @@ let normalise_var_name name =
   if String.length name >= 2 && String.sub name 0 2 = "--" then name
   else String.concat "" [ "--"; name ]
 
+(* Every custom-property name the stylesheet still mentions: declared by a
+   declaration, or referenced by a [var()] in a declaration or in an at-rule
+   condition, fallbacks included. [collect_scoped_refs] never descends into a
+   [@property] body, so a registration is not a mention of the property it
+   registers and cannot keep itself. *)
+let mentioned_custom_names stylesheet =
+  let consumers, customs, _ = collect_scoped_refs stylesheet in
+  List.fold_left
+    (fun acc (_, _, refs) -> List.rev_append refs acc)
+    (List.fold_left
+       (fun acc (_, _, name, refs) ->
+         List.rev_append refs (normalise_var_name name :: acc))
+       [] customs)
+    consumers
+  |> List.sort_uniq compare
+
 (* Per custom-property name, how many definitions it has across the whole
    stylesheet, plus the set of names referenced anywhere. A variable is safe to
    inline and delete only when it has a single definition: its value is then

--- a/lib/inline.mli
+++ b/lib/inline.mli
@@ -19,6 +19,13 @@ val vars :
     name (leading [--]) that could not be inlined because it is redefined in a
     different scope. *)
 
+val mentioned_custom_names : Stylesheet.t -> string list
+(** [mentioned_custom_names stylesheet] is every custom-property name (leading
+    [--]) the stylesheet still mentions: declared by a declaration, or
+    referenced by a [var()] in a declaration or in an at-rule condition,
+    fallbacks included. A [@property] body is not a mention, so a registration
+    never keeps itself. *)
+
 val decode_import_url : string -> string
 (** [decode_import_url s] strips the [url(...)] wrapper and any surrounding
     quotes from an [@import] URL string as held in

--- a/test/cli/inline_vars_property.t
+++ b/test/cli/inline_vars_property.t
@@ -1,0 +1,77 @@
+CLI: --inline-vars and @property registrations.
+
+CSS Properties and Values API 1 sec. 2 gives a registered property an
+[initial-value], used as its computed value wherever no declaration wins,
+and an [inherits] descriptor deciding whether it inherits at all. A
+registration is therefore dead only once nothing is left for it to govern:
+no declaration of the property, and no live var() reading it.
+
+A property the inliner resolved away leaves neither, so its registration
+goes with it.
+
+  $ cat > resolved.css <<EOF
+  > @property --gap { syntax: "<length>"; inherits: false; initial-value: 16px }
+  > .a { padding: var(--gap) }
+  > EOF
+  $ cascade --minify --inline-vars resolved.css
+  .a{padding:16px}
+
+A property the inliner keeps live keeps its registration. Here b declares
+no --c: with the registration it computes --c as the initial-value red,
+without it var(--c) is invalid at computed-value time and color falls back
+to the inherited black, so dropping the registration repaints the page.
+
+  $ cat > kept.css <<EOF
+  > @property --c { syntax: "<color>"; inherits: false; initial-value: red }
+  > a { --c: #00f }
+  > b { color: var(--c) }
+  > EOF
+  $ cascade --minify --inline-vars kept.css
+  Warning: --c is redefined in a different scope; kept live (cannot inline safely)
+  @property --c{syntax:"<color>";inherits:false;initial-value:red}a{--c:#00f}b{color:var(--c)}
+
+An inheriting registration is kept on the same terms.
+
+  $ cat > inherit.css <<EOF
+  > @property --c { syntax: "<color>"; inherits: true; initial-value: red }
+  > a { --c: #00f }
+  > b { color: var(--c) }
+  > EOF
+  $ cascade --minify --inline-vars inherit.css 2> /dev/null
+  @property --c{syntax:"<color>";inherits:true;initial-value:red}a{--c:#00f}b{color:var(--c)}
+
+A declaration the inliner cannot prove reaches its consumer keeps the
+var() live, so the registration that types that declaration stays too.
+
+  $ cat > scoped.css <<EOF
+  > @property --c { syntax: "<color>"; inherits: false; initial-value: red }
+  > .theme { --c: #00f }
+  > .other { color: var(--c) }
+  > EOF
+  $ cascade --minify --inline-vars scoped.css 2> /dev/null
+  @property --c{syntax:"<color>";inherits:false;initial-value:red}.theme{--c:#00f}.other{color:var(--c)}
+
+A registration nothing declares and nothing reads has nothing to govern in
+a closed world, so it goes.
+
+  $ cat > unused.css <<EOF
+  > @property --y { syntax: "*"; inherits: false }
+  > .b { color: red }
+  > EOF
+  $ cascade --minify --inline-vars unused.css
+  .b{color:red}
+
+Inlining is a rewrite to a fixpoint: a second run over its own output has
+to change nothing. Keeping a declaration because a registration made its
+property look multi-defined and then deleting that registration breaks
+that, since the next run sees a single-definition variable and prunes it.
+
+  $ cat > fix.css <<EOF
+  > @property --c { syntax: "<color>"; inherits: false; initial-value: red }
+  > a { --c: #00f }
+  > EOF
+  $ cascade --minify --inline-vars fix.css 2> /dev/null > pass1.css
+  $ cat pass1.css
+  @property --c{syntax:"<color>";inherits:false;initial-value:red}a{--c:#00f}
+  $ cascade --minify --inline-vars pass1.css 2> /dev/null > pass2.css
+  $ diff pass1.css pass2.css

--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -8,9 +8,9 @@ before and after.
   attribute and empties the `<style>` blocks, in both the default (full) and
   `--minimal` modes.
 - **`cascade --minify`** rewrites each `<style>` block in place (via
-  `minify_page.js`). Idempotence, size and reparse checks all pass on output
-  that renders differently; only this catches a minification that changes the
-  computed style.
+  `minify_page.js`), on its own and again with `--inline-vars`. Idempotence,
+  size and reparse checks all pass on output that renders differently; only
+  this catches a rewrite that changes the computed style.
 
 ```sh
 sh test/inline/run.sh

--- a/test/inline/fixtures/registered.html
+++ b/test/inline/fixtures/registered.html
@@ -1,0 +1,10 @@
+<!doctype html><html><head><style>
+  @property --tint { syntax: "<color>"; inherits: false; initial-value: red }
+  @property --pad { syntax: "<length>"; inherits: true; initial-value: 7px }
+  .outer { --tint: blue; --pad: 3px; color: var(--tint); padding: var(--pad) }
+  .inner { color: var(--tint); padding: var(--pad) }
+  .away { color: var(--tint); padding: var(--pad) }
+</style></head><body>
+<div class="outer">outer<span class="inner">inner</span></div>
+<p class="away">away</p>
+</body></html>

--- a/test/inline/minify_page.js
+++ b/test/inline/minify_page.js
@@ -1,5 +1,7 @@
-// Copy an HTML page with every <style> block minified through cascade, so the
-// differential test can check that minification preserves the render.
+// Copy an HTML page with every <style> block rewritten through cascade, so the
+// differential test can check that the transform preserves the render. Any
+// argument after the page is passed on to cascade, so one driver covers
+// `fmt --minify` and the closed-world `--inline-vars` cleanup on top of it.
 const { execSync } = require('child_process');
 const fs = require('fs');
 // No fallback to a `cascade` off $PATH: which build minified the page is the
@@ -10,8 +12,9 @@ if (!CASCADE) {
   process.exit(1);
 }
 const src = fs.readFileSync(process.argv[2], 'utf8');
+const flags = process.argv.slice(3).join(' ');
 const out = src.replace(/<style([^>]*)>([\s\S]*?)<\/style>/gi, (_m, attrs, css) => {
-  const min = execSync(`"${CASCADE}" fmt --minify -`, { input: css, encoding: 'utf8' });
+  const min = execSync(`"${CASCADE}" fmt --minify ${flags} -`, { input: css, encoding: 'utf8' });
   return `<style${attrs}>${min.trim()}</style>`;
 });
 process.stdout.write(out);

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -126,13 +126,17 @@ for f in "$dir"/fixtures/*.html; do
     rm -f "$tmp"
   done
 done
-# cascade --minify preserves the render too: minify each <style> block in place
-# and compare computed styles against the original page.
-for f in "$dir"/fixtures/*.html; do
-  tmp=$(mktemp)
-  node "$dir/minify_page.js" "$f" > "$tmp" 2>/dev/null
-  check "$(basename "$f") minify" "$f" "$tmp"
-  rm -f "$tmp"
+# cascade --minify preserves the render too, and so does the closed-world
+# --inline-vars cleanup layered on it: rewrite each <style> block in place and
+# compare computed styles against the original page.
+for flags in "" "--inline-vars"; do
+  for f in "$dir"/fixtures/*.html; do
+    tmp=$(mktemp)
+    # shellcheck disable=SC2086 # an empty $flags must vanish, not pass ""
+    node "$dir/minify_page.js" "$f" $flags > "$tmp" 2>/dev/null
+    check "$(basename "$f") minify${flags:+ $flags}" "$f" "$tmp"
+    rm -f "$tmp"
+  done
 done
 # Real pages downloaded by fetch.sh (gitignored, so absent until it is run).
 # They gate like the fixtures do: a surviving difference is a defect in the

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -362,6 +362,63 @@ let test_inline_cleanup_inside_a_rule () =
   check_inline_case "a nested @property registration is dropped"
     ".b{color:red;@property --y{syntax:\"*\";inherits:false}}" ".b{color:red}"
 
+(* CSS Properties and Values API 1 sec. 2: a registration gives its property an
+   [initial-value], used as the computed value wherever no declaration wins, and
+   an [inherits] descriptor deciding whether it inherits at all. Both change
+   computed values, so a registration is dead only once nothing is left for it
+   to govern: no declaration of the property, and no live [var()] reading it. *)
+let test_inline_property_registration_kept () =
+  check_inline_case "a registration for a kept-live property survives with it"
+    "@property \
+     --c{syntax:\"<color>\";inherits:false;initial-value:red}a{--c:#00f}b{color:var(--c)}"
+    "@property \
+     --c{syntax:\"<color>\";inherits:false;initial-value:red}a{--c:#00f}b{color:var(--c)}";
+  check_inline_case "an inheriting registration is kept on the same terms"
+    "@property \
+     --c{syntax:\"<color>\";inherits:true;initial-value:red}a{--c:#00f}b{color:var(--c)}"
+    "@property \
+     --c{syntax:\"<color>\";inherits:true;initial-value:red}a{--c:#00f}b{color:var(--c)}";
+  check_inline_case
+    "a registration for a declaration the cascade cannot see is kept"
+    "@property \
+     --c{syntax:\"<color>\";inherits:false;initial-value:red}.theme{--c:#00f}.other{color:var(--c)}"
+    "@property \
+     --c{syntax:\"<color>\";inherits:false;initial-value:red}.theme{--c:#00f}.other{color:var(--c)}";
+  check_inline_case
+    "a registration whose declaration survives unreferenced is kept"
+    "@property \
+     --c{syntax:\"<color>\";inherits:false;initial-value:red}a{--c:#00f}"
+    "@property \
+     --c{syntax:\"<color>\";inherits:false;initial-value:red}a{--c:#00f}"
+
+let test_inline_property_registration_dropped () =
+  check_inline_case "a resolved-away property takes its registration with it"
+    "@property \
+     --gap{syntax:\"<length>\";inherits:false;initial-value:16px}.a{padding:var(--gap)}"
+    ".a{padding:16px}";
+  check_inline_case
+    "a registration nothing declares and nothing reads has nothing to govern"
+    "@property --y{syntax:\"*\";inherits:false}.b{color:red}" ".b{color:red}"
+
+(* Inlining is a rewrite to a fixpoint: running it on its own output must change
+   nothing. A pass that keeps a declaration because a registration made its
+   property look multi-defined, then deletes that registration, contradicts
+   itself - the next pass sees a single-definition variable and prunes it. *)
+let test_inline_property_idempotent () =
+  let check name input =
+    let once = minified (Css.inline_vars (parse input)) in
+    let twice = minified (Css.inline_vars (parse once)) in
+    Alcotest.(check string) name once twice
+  in
+  check "a kept-live registered property is a fixpoint"
+    "@property \
+     --c{syntax:\"<color>\";inherits:false;initial-value:red}a{--c:#00f}b{color:var(--c)}";
+  check "an unreferenced registered declaration is a fixpoint"
+    "@property \
+     --c{syntax:\"<color>\";inherits:false;initial-value:red}a{--c:#00f}";
+  check "an unused registration is a fixpoint"
+    "@property --y{syntax:\"*\";inherits:false}.b{color:red}"
+
 let suite =
   ( "inline",
     [
@@ -407,4 +464,12 @@ let suite =
         test_inline_layer_winner;
       Alcotest.test_case "inline vars clean up inside a rule too" `Quick
         test_inline_cleanup_inside_a_rule;
+      Alcotest.test_case
+        "inline vars keep the registration of a property they keep" `Quick
+        test_inline_property_registration_kept;
+      Alcotest.test_case
+        "inline vars drop the registration of a property they remove" `Quick
+        test_inline_property_registration_dropped;
+      Alcotest.test_case "inline vars reach a fixpoint on registrations" `Quick
+        test_inline_property_idempotent;
     ] )


### PR DESCRIPTION
`Css.inline_vars` dropped every `@property` registration, including the one for a property it had just kept live, so a page whose `var()` reads a non-inheriting registered property lost the `initial-value` behind it and repainted; the pass also missed its own fixpoint, the second run pruning the declaration the first had kept.

#373 restructures the same function and its `@property --y` assertion stays correct, since nothing declares or reads `--y` there; rebasing it onto this only needs the new `~live` argument threaded through.