### PR TITLE
declaration: reject keyword radii in a basic shape's round suffix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,12 @@
   Fonts 4 sec. 4.4 has the user agent swap the endpoints for font matching, so
   the range is well defined rather than an error, and only `unicode-range`
   keeps an ordering rule (#335)
+- The `round <'border-radius'>` suffix of a basic shape reads its radii through
+  the same reader as the `border-radius` property, so `clip-path`,
+  `shape-outside` and `object-view-box` stop accepting an intrinsic-sizing or
+  CSS-wide keyword as a corner radius. CSS Backgrounds 3 sec. 5.1 allows only a
+  non-negative `<length-percentage>` there, and Chrome and WebKit drop every
+  such declaration (#417)
 
 ### Minification
 

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -826,49 +826,6 @@ let rec read_text_decoration_thickness t =
     ~default:(read_non_negative_length ~with_keywords:false)
     t
 
-let read_border_radius_radii t =
-  let rec loop acc count =
-    if count >= 4 then List.rev acc
-    else
-      match Cursor.option read_non_negative_length_percentage t with
-      | None -> List.rev acc
-      | Some lp -> loop (lp :: acc) (count + 1)
-  in
-  match loop [] 0 with
-  | [] -> Cursor.err_expected t "<length-percentage>"
-  | radii -> radii
-
-let read_border_radius_vertical t =
-  match Cursor.peek_delim t with
-  | Some '/' ->
-      Cursor.skip t;
-      Cursor.ws t;
-      Some (read_border_radius_radii t)
-  | _ -> None
-
-(* CSS Backgrounds and Borders 3 sec. 4.1: [border-radius =
-   <length-percentage>{1,4} [/ <length-percentage>{1,4}]?]. Reads 1-4 horizontal
-   radii then, after [/], 1-4 vertical radii. *)
-let rec read_border_radius (t : Cursor.t) : Properties.border_radius =
-  Cursor.ws t;
-  Cursor.enum_or_var "border-radius"
-    [
-      ("inherit", (Properties.Inherit : Properties.border_radius));
-      ("initial", Properties.Initial);
-      ("unset", Properties.Unset);
-      ("revert", Properties.Revert);
-      ("revert-layer", Properties.Revert_layer);
-    ]
-    ~var:(fun t ->
-      (Properties.Var (Values.read_var read_border_radius t)
-        : Properties.border_radius))
-    ~default:(fun t ->
-      let horizontal = read_border_radius_radii t in
-      Cursor.ws t;
-      let vertical = read_border_radius_vertical t in
-      Properties.Radius { horizontal; vertical })
-    t
-
 (* Delegate to the proper reader in Properties *)
 let read_translate_value t : Properties_intf.translate_value =
   Properties.read_translate_value t

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1688,15 +1688,24 @@ let rec read_background t : background =
 let read_backgrounds t : background list =
   Cursor.list ~sep:Cursor.comma ~at_least:1 read_background t
 
-(* Inline border-radius parser for the [round <border-radius>] suffix shared by
-   clip-path basic shapes. Cannot reuse [Declaration.read_border_radius] because
-   Declaration depends on Properties; the same grammar is small enough to inline
-   here. *)
+(* CSS Backgrounds 3 sec. 5.1: [border-radius = <length-percentage [0,inf]>{1,4}
+   [ / <length-percentage [0,inf]>{1,4} ]?]. Reads 1-4 horizontal radii then,
+   after [/], 1-4 vertical radii. No keyword is a radius: the intrinsic-sizing
+   keywords are no part of the grammar, and the CSS-wide keywords are only the
+   whole property value (CSS Cascade 5 sec. 6), which [read_border_radius] takes
+   before delegating here. Basic shapes spell their rounded-corner suffix [round
+   <'border-radius'>] (CSS Shapes 1 sec. 3.1), a reference to this same value
+   definition, so they read radii through [read_border_radius_inline] and get
+   the keyword exclusion with it. *)
 let read_border_radius_inline_radii t =
   let rec loop acc count =
     if count >= 4 then List.rev acc
     else
-      match Cursor.option (read_length_percentage ~allow_negative:false) t with
+      match
+        Cursor.option
+          (read_length_percentage ~allow_negative:false ~with_keywords:false)
+          t
+      with
       | None -> List.rev acc
       | Some lp -> loop (lp :: acc) (count + 1)
   in

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2587,6 +2587,82 @@ let shape_outside_sheet () =
       "a{shape-outside:url(shape.png)}";
     ]
 
+(* CSS Backgrounds 3 sec. 5.1: [border-radius] is [<length-percentage
+   [0,inf]>{1,4} [ / <length-percentage [0,inf]>{1,4} ]?], so an
+   intrinsic-sizing keyword ([auto], [max-content], [stretch], ...) is no part
+   of it. CSS Shapes 1 sec. 3.1 spells the rounded-corner suffix of a basic
+   shape [round <'border-radius'>], and [<'property'>] (CSS Values 4 sec. 2.2)
+   names that same value definition, so the keywords stay out there too. Chrome
+   151 and WebKit 26.5 drop every declaration below. *)
+let radius_keywords =
+  [
+    "auto";
+    "none";
+    "normal";
+    "size";
+    "max-content";
+    "min-content";
+    "fit-content";
+    "-webkit-max-content";
+    "-webkit-min-content";
+    "-webkit-fit-content";
+    "-moz-max-content";
+    "-moz-min-content";
+    "-moz-fit-content";
+    "contain";
+    "stretch";
+    "from-font";
+  ]
+
+let radius_shorthand_sites radius =
+  List.map
+    (fun property -> String.concat "" [ property; ":"; radius ])
+    [ "border-radius"; "-webkit-border-radius"; "-moz-border-radius" ]
+
+(* Every [round <'border-radius'>] site: the basic shapes behind [clip-path] and
+   [shape-outside], and the [rect()] / [xywh()] of [object-view-box]. *)
+let radius_nested_sites radius =
+  List.map
+    (fun (before, after) -> String.concat "" [ before; radius; after ])
+    [
+      ("clip-path:inset(0 round ", ")");
+      ("clip-path:rect(0 1px 1px 0 round ", ")");
+      ("clip-path:xywh(0 0 1px 1px round ", ")");
+      ("shape-outside:inset(0 round ", ")");
+      ("object-view-box:rect(0 1px 1px 0 round ", ")");
+      ("object-view-box:xywh(0 0 1px 1px round ", ")");
+    ]
+
+let border_radius_keyword_radii () =
+  List.iter
+    (fun radius ->
+      List.iter (neg_cursor read_declaration) (radius_shorthand_sites radius);
+      List.iter (neg_cursor read_declaration) (radius_nested_sites radius))
+    radius_keywords;
+  (* Controls: a length and a percentage are radii everywhere, a negative one is
+     a radius nowhere. *)
+  List.iter
+    (fun radius ->
+      List.iter
+        (fun css -> check_declaration ~roundtrip:true css)
+        (radius_shorthand_sites radius @ radius_nested_sites radius))
+    [ "10px"; "10%" ];
+  List.iter (neg_cursor read_declaration) (radius_shorthand_sites "-5px");
+  List.iter (neg_cursor read_declaration) (radius_nested_sites "-5px")
+
+(* CSS Cascade 5 sec. 6: a CSS-wide keyword is only valid "as the entire
+   property value", so it is a whole [border-radius] and never one radius inside
+   a basic shape. Chrome 151 and WebKit 26.5 keep the shorthand and drop the
+   nested form. *)
+let border_radius_css_wide_keywords () =
+  List.iter
+    (fun radius ->
+      List.iter
+        (fun css -> check_declaration ~roundtrip:true css)
+        (radius_shorthand_sites radius);
+      List.iter (neg_cursor read_declaration) (radius_nested_sites radius))
+    [ "inherit"; "initial"; "unset"; "revert"; "revert-layer" ]
+
 (* Vendor-prefixed properties with a typed constructor need a reader arm as
    well: without one the dispatch falls through to "unsupported property reader"
    and the declaration is dropped. Each takes the same value type as the
@@ -2748,6 +2824,9 @@ let declaration_tests =
       scroll_margin_negative_sheet;
     test_case "shape-outside grammar" `Quick shape_outside_grammar;
     test_case "shape-outside grammar (sheet)" `Quick shape_outside_sheet;
+    test_case "border-radius keyword radii" `Quick border_radius_keyword_radii;
+    test_case "border-radius CSS-wide keywords" `Quick
+      border_radius_css_wide_keywords;
     (* Spec details and edge cases *)
     test_case "CSS-wide keywords" `Quick css_wide_keywords;
     test_case "spec cascade 3 shorthand properties" `Quick


### PR DESCRIPTION
`clip-path: inset(0 round auto)` used to parse, along with the same `round` suffix on `shape-outside` and `object-view-box`: a second copy of the border-radius reader left `~with_keywords` at its default and took `auto`, `max-content`, `inherit` and every other keyword as a corner radius, where CSS Backgrounds 3 sec. 5.1 allows only a non-negative `<length-percentage>`. The copy is gone, so `border-radius` and the basic shapes read the same reader, and Chrome 151 and WebKit 26.5 agree the old output was dead CSS.