### PR TITLE
selector: apply the pseudo-element rules to every :: form

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,13 @@
   CSS-wide keyword as a corner radius. CSS Backgrounds 3 sec. 5.1 allows only a
   non-negative `<length-percentage>` there, and Chrome and WebKit drop every
   such declaration (#417)
+- The reader and the optimizer's selector summary answer "is this a
+  pseudo-element?" from one list, so `::target-text`, `::spelling-error`,
+  `::grammar-error` and the framework-only `::deep` family obey the compound
+  and `:has()` rules the rest already did. Selectors 4 sec. 16 admits nothing
+  but pseudo-classes after a pseudo-element and sec. 4.5 keeps pseudo-elements
+  out of `:has()`, whatever the pseudo-element's name, and Chrome and WebKit
+  drop every selector that breaks either rule (#418)
 - A `<custom-ident>` or `<dashed-ident>` an at-rule prelude or a declaration
   value names is printed with the escapes CSS Syntax 3 sec. 4.3.7 needs to read
   it back as the same name. `@layer a\3b b` printed `@layer a;b`, two

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -1021,29 +1021,33 @@ let pseudo_vendor_idents =
     ("details-content", Details_content);
   ]
 
-let is_deep_piercing_pseudo name =
-  match String.lowercase_ascii name with
-  | "deep" | "v-deep" | "ng-deep" -> true
-  | _ -> false
-
-let is_pseudo_element_selector = function
+(* Every [::] form, and only those: a pseudo-element names a box other than the
+   originating element, where an element-tied pseudo-class ([:hover], [:focus])
+   only narrows which elements match. An unrecognised [::foo] belongs here too.
+   Selectors 4 sec. 16 builds a pseudo-compound out of
+   [<pseudo-element-selector> <pseudo-class-selector>*] whatever the
+   pseudo-element's name is, so the shape rules that read this predicate cannot
+   wait for cascade to learn the name; the framework-only [::deep] / [::v-deep]
+   / [::ng-deep] are unknown [::] names like any other, since Selectors 4 has no
+   piercing combinator. *)
+let is_pseudo_element = function
   | Before _ | After _ | First_letter _ | First_line _ | Backdrop | Marker
-  | Placeholder | Selection | File_selector_button | Moz_placeholder
-  | Webkit_input_placeholder | Ms_input_placeholder | Webkit_scrollbar
-  | Webkit_search_cancel_button | Webkit_search_decoration
-  | Webkit_datetime_edit_fields_wrapper | Webkit_date_and_time_value
-  | Webkit_datetime_edit | Webkit_datetime_edit_year_field
-  | Webkit_datetime_edit_month_field | Webkit_datetime_edit_day_field
-  | Webkit_datetime_edit_hour_field | Webkit_datetime_edit_minute_field
-  | Webkit_datetime_edit_second_field | Webkit_datetime_edit_millisecond_field
-  | Webkit_datetime_edit_meridiem_field | Webkit_inner_spin_button
-  | Webkit_outer_spin_button | Webkit_calendar_picker_indicator
-  | Webkit_details_marker | Details_content | Part _ | Slotted _ | Cue _
-  | Cue_region _ | Highlight _ | View_transition | View_transition_group _
-  | View_transition_image_pair _ | View_transition_old _ | View_transition_new _
+  | Placeholder | Selection | Target_text | Spelling_error | Grammar_error
+  | File_selector_button | Moz_placeholder | Webkit_input_placeholder
+  | Ms_input_placeholder | Webkit_scrollbar | Webkit_search_cancel_button
+  | Webkit_search_decoration | Webkit_datetime_edit_fields_wrapper
+  | Webkit_date_and_time_value | Webkit_datetime_edit
+  | Webkit_datetime_edit_year_field | Webkit_datetime_edit_month_field
+  | Webkit_datetime_edit_day_field | Webkit_datetime_edit_hour_field
+  | Webkit_datetime_edit_minute_field | Webkit_datetime_edit_second_field
+  | Webkit_datetime_edit_millisecond_field | Webkit_datetime_edit_meridiem_field
+  | Webkit_inner_spin_button | Webkit_outer_spin_button
+  | Webkit_calendar_picker_indicator | Webkit_details_marker | Details_content
+  | Part _ | Slotted _ | Cue _ | Cue_region _ | Highlight _ | View_transition
+  | View_transition_group _ | View_transition_image_pair _
+  | View_transition_old _ | View_transition_new _ | Unknown_pseudo_element _
   | Unknown_pseudo_element_call _ ->
       true
-  | Unknown_pseudo_element name -> not (is_deep_piercing_pseudo name)
   | _ -> false
 
 let rec any p = function
@@ -1072,7 +1076,7 @@ let rec any p = function
   | Part _ as sel -> p sel
   | s -> p s
 
-let has_pseudo_element sel = any is_pseudo_element_selector sel
+let has_pseudo_element sel = any is_pseudo_element sel
 
 let has_unknown_pseudo_class =
   any (function
@@ -1098,7 +1102,7 @@ let rec matches_nothing = function
    still make the compound invalid. *)
 let is_pe_action = function
   | Element _ | Class _ | Id _ | Universal _ | Attribute _ | Nesting -> false
-  | sel -> not (is_pseudo_element_selector sel)
+  | sel -> not (is_pseudo_element sel)
 
 (* The merged lists are static across the lifetime of the program (every
    constituent is a [let] binding above); memoise them so the [@] cons-chain
@@ -1551,7 +1555,7 @@ and read_compound t =
        [:not()]/[:has()] ([read_not_content]/[read_has_content]) and in the rule
        reader when a whole selector list is unknown. *)
     let s = read_simple ~allow_unknown_pseudo_class:true t in
-    if List.exists is_pseudo_element_selector acc && not (is_pe_action s) then
+    if List.exists is_pseudo_element acc && not (is_pe_action s) then
       Cursor.err t "pseudo-element must be last in compound selector"
     else s :: acc
   in

--- a/lib/selector.mli
+++ b/lib/selector.mli
@@ -267,6 +267,14 @@ val has_newer_pseudo_class : t -> bool
     forgiving parsing). Newer pseudo-classes should not be combined in selector
     lists with group/peer variants to preserve browser compatibility. *)
 
+val is_pseudo_element : t -> bool
+(** [is_pseudo_element sel] is [true] when [sel] is one simple selector naming a
+    pseudo-element: a box other than the originating element, where an
+    element-tied pseudo-class such as [:hover] only narrows which elements
+    match. Every [::] form counts, including a name cascade does not recognise,
+    since Selectors 4 sec. 16 shapes a pseudo-compound around a pseudo-element
+    whatever its name. *)
+
 val has_pseudo_element : t -> bool
 (** [has_pseudo_element sel] returns [true] if selector contains a
     pseudo-element like ::before, ::after, ::marker, etc. *)

--- a/lib/selector_summary.ml
+++ b/lib/selector_summary.ml
@@ -44,31 +44,6 @@ let empty =
   }
 
 let mark_complex s = if s.complex then s else { s with complex = true }
-
-(* Pseudo-elements as far as overlap analysis is concerned: anything that
-   identifies a generated box distinct from its originating element.
-   Element-tied pseudo-classes (Hover, Focus, ...) do not appear here - they
-   tighten which elements match but do not change the subject identity. *)
-let is_pseudo_element = function
-  | Selector_intf.Before _ | After _ | First_letter _ | First_line _ | Backdrop
-  | Marker | Placeholder | Selection | Target_text | Spelling_error
-  | Grammar_error | File_selector_button | Details_content | Moz_placeholder
-  | Webkit_input_placeholder | Ms_input_placeholder | Webkit_scrollbar
-  | Webkit_search_cancel_button | Webkit_search_decoration
-  | Webkit_datetime_edit_fields_wrapper | Webkit_date_and_time_value
-  | Webkit_datetime_edit | Webkit_datetime_edit_year_field
-  | Webkit_datetime_edit_month_field | Webkit_datetime_edit_day_field
-  | Webkit_datetime_edit_hour_field | Webkit_datetime_edit_minute_field
-  | Webkit_datetime_edit_second_field | Webkit_datetime_edit_millisecond_field
-  | Webkit_datetime_edit_meridiem_field | Webkit_inner_spin_button
-  | Webkit_outer_spin_button | Webkit_calendar_picker_indicator
-  | Webkit_details_marker | View_transition | View_transition_group _
-  | View_transition_image_pair _ | View_transition_old _ | View_transition_new _
-  | Unknown_pseudo_element _ | Unknown_pseudo_element_call _ | Part _
-  | Slotted _ | Cue _ | Cue_region _ | Highlight _ ->
-      true
-  | _ -> false
-
 let add_nth nth s = { s with nth = nth :: s.nth; complex = true }
 
 let nth_of_selector = function
@@ -120,7 +95,10 @@ let rec fold_simple s (sel : Selector.t) =
       | Some _ -> mark_complex s)
   | Universal _ -> s
   | Compound xs -> List.fold_left fold_simple s xs
-  | sel when is_pseudo_element sel -> (
+  (* A pseudo-element is a subject of its own, so it replaces the originating
+     element rather than narrowing it. Same predicate as the reader's, so the
+     summary calls a compound a pseudo-element exactly when the reader does. *)
+  | sel when Selector.is_pseudo_element sel -> (
       (* Normalize legacy single-colon spellings ([:before] vs [::before]) so
          the two parses of the same pseudo-element compare equal. *)
       let canonical : Selector.t =

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -701,6 +701,85 @@ let parse_errors_pseudo () =
   check_parse_error ".test:not()" "expected at least one selector";
   check_parse_error ".test:has()" "expected at least one selector"
 
+(* Every [::] spelling cascade parses, in the shortest form that reaches its own
+   constructor. The list is the pseudo-element inventory of CSS Pseudo-Elements
+   4, Selectors 4, CSS Highlight API 1, CSS Shadow Parts 1, WebVTT and CSS View
+   Transitions 1, plus the vendor names shipping engines expose, plus the two
+   kinds cascade cannot name: an unrecognised [::foo] and the framework-only
+   [::deep] / [::v-deep] / [::ng-deep]. *)
+let pseudo_element_spellings =
+  [
+    ":before";
+    ":after";
+    ":first-line";
+    ":first-letter";
+    "::before";
+    "::after";
+    "::first-line";
+    "::first-letter";
+    "::backdrop";
+    "::marker";
+    "::placeholder";
+    "::selection";
+    "::target-text";
+    "::spelling-error";
+    "::grammar-error";
+    "::file-selector-button";
+    "::details-content";
+    "::view-transition";
+    "::view-transition-group(*)";
+    "::view-transition-image-pair(*)";
+    "::view-transition-old(*)";
+    "::view-transition-new(*)";
+    "::part(tab)";
+    "::slotted(p)";
+    "::cue";
+    "::cue-region";
+    "::highlight(find)";
+    "::-moz-placeholder";
+    "::-webkit-input-placeholder";
+    "::-ms-input-placeholder";
+    "::-webkit-scrollbar";
+    "::-webkit-search-cancel-button";
+    "::-webkit-search-decoration";
+    "::-webkit-datetime-edit";
+    "::-webkit-date-and-time-value";
+    "::-webkit-inner-spin-button";
+    "::-webkit-outer-spin-button";
+    "::-webkit-calendar-picker-indicator";
+    "::-webkit-details-marker";
+    "::future-pseudo-element";
+    "::foo(bar)";
+    "::deep";
+    "::v-deep";
+    "::ng-deep";
+  ]
+
+(* Selectors 4 sec. 16: a complex selector unit is [<compound-selector>?
+   <pseudo-compound-selector>*] and a pseudo-compound is
+   [<pseudo-element-selector> <pseudo-class-selector>*], so a class, id or
+   attribute selector may never follow a pseudo-element; sec. 4.5 keeps
+   pseudo-elements out of [:has()] as well. Both rules key off the [::] form,
+   not off whether the name is one cascade knows, so an unrecognised [::foo] and
+   the framework-only [::deep] family are bound by them too. Cascade keeps a
+   bare pseudo-element it does not recognise, since the name may be one a
+   browser already ships, but the shape rules apply all the same. Chrome 151 and
+   WebKit 26.5 drop every rule the negatives below build. *)
+let pseudo_element_compound_guard () =
+  let parses input =
+    match Cursor.option read (Cursor.of_string input) with
+    | Some _ -> ()
+    | None -> Alcotest.failf "pseudo-element selector should parse: %s" input
+  in
+  List.iter
+    (fun pe ->
+      parses (String.concat "" [ ".a"; pe ]);
+      neg_cursor read (String.concat "" [ ".a"; pe; ".b" ]);
+      neg_cursor read (String.concat "" [ ".a"; pe; "#c" ]);
+      neg_cursor read (String.concat "" [ ".a"; pe; "[d]" ]);
+      neg_cursor read (String.concat "" [ ".a:has("; pe; ")" ]))
+    pseudo_element_spellings
+
 let parse_errors_nesting_depth () =
   (* A pathologically deep functional-pseudo-class nest is capped rather than
      driving the per-level selector validation into super-linear time (a
@@ -1770,6 +1849,8 @@ let suite =
       test_case "parse errors - combinators" `Quick parse_errors_combinators;
       test_case "parse errors - starts" `Quick parse_errors_starts;
       test_case "parse errors - pseudo" `Quick parse_errors_pseudo;
+      test_case "pseudo-element compound guard" `Quick
+        pseudo_element_compound_guard;
       test_case "parse errors - nesting depth" `Quick parse_errors_nesting_depth;
       test_case "parse errors - empty list" `Quick parse_errors_empty_list;
       test_case "parse errors - complex" `Quick parse_errors_complex;

--- a/test/test_selector_summary.ml
+++ b/test/test_selector_summary.ml
@@ -73,6 +73,17 @@ let pseudo_elements () =
     ".x::after";
   check_overlap "pseudo-element and originating element are disjoint" false
     ".x::before" ".x";
+  (* The reader and the summary read one pseudo-element list, so the highlight
+     pseudo-elements, an unrecognised [::foo] and the framework-only [::deep]
+     name boxes of their own here as well. *)
+  check_overlap "target-text is a box of its own" false ".x::target-text" ".x";
+  check_overlap "spelling-error is a box of its own" false ".x::spelling-error"
+    ".x";
+  check_overlap "grammar-error is a box of its own" false ".x::grammar-error"
+    ".x";
+  check_overlap "unknown pseudo-element is a box of its own" false
+    ".x::future-pseudo-element" ".x";
+  check_overlap "::v-deep is a box of its own" false ".x::v-deep" ".x";
   check_overlap "legacy and modern before spelling may overlap" true ".x:before"
     ".x::before";
   check_overlap "legacy and modern after spelling may overlap" true ".x:after"


### PR DESCRIPTION
`.a::spelling-error.b` and `.a:has(::spelling-error)` used to parse, as did the `::deep` / `::v-deep` / `::ng-deep` compounds, because the reader's pseudo-element list had drifted from the one `Selector_summary` uses; both now read `Selector.is_pseudo_element`, so Selectors 4 sec. 16 and sec. 4.5 apply to every `::` form whether or not cascade recognises the name. Chrome 151 and WebKit 26.5 drop every selector that stops parsing here, including the one corpus record affected, `.foo ::deep.bar`.