### PR TITLE
css: a bad descriptor costs itself, not the at-rule holding it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -127,6 +127,19 @@
   Sec. 5 generates the box only where `content` computes away from `none`, so an
   empty one is elided on output like an empty style rule and an empty `@page`
   already are (#405)
+- A descriptor a `@counter-style`, `@font-palette-values` or `@view-transition`
+  body rejects is dropped on its own, as is a feature block an
+  `@font-feature-values` body rejects, rather than taking the at-rule and the
+  stylesheet holding it. `@counter-style thumbs { system: cyclic; symbols: "x";
+  zzz: 1 }` parsed to nothing, and the other three lost their whole rule the
+  same way. CSS Syntax 3 sec. 5.4.3 keeps what a block's contents already
+  yielded when one item fails to parse, and Blink 146 keeps all four rules. An
+  `@font-feature-values` body is a list of rules, so an item discarded there
+  ends at its own block rather than at a `;` it has not got, and a `;` with
+  nothing before it costs nothing. Tokens left after a `@font-palette-values` or
+  `@view-transition` or `@counter-style` descriptor value, such as a trailing
+  `!important`, now invalidate the declaration they follow rather than the
+  leftover alone (#419)
 
 ### Minification
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1816,8 +1816,11 @@ let skip_invalid_item r =
    Paged Media 3 sec. 6 says as much of a page or a margin context in so many
    words: "valid declarations within the block are applied". Strict mode ([not
    (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly what the
-   lenient parse warns about. *)
-let read_items_with_recovery step r init =
+   lenient parse warns about. [skip] discards the item that failed, and which
+   one it is depends on the body: {!skip_invalid_item} for a body of
+   declarations, {!skip_past_rule} for a body of rules, where an item that opens
+   a block ends at that block rather than at a [;] it does not have. *)
+let read_items_with_recovery ~skip step r init =
   let rec loop state =
     if Cursor.recover r then recovering state else continue (step r state)
   and recovering state =
@@ -1827,7 +1830,7 @@ let read_items_with_recovery step r init =
     | exception Error.Parse_error e ->
         Cursor.push_warning r e;
         Cursor.restore r start;
-        skip_invalid_item r;
+        skip r;
         loop state
   and continue = function
     | `Done result -> result
@@ -1877,7 +1880,9 @@ let read_descriptor_step normalize inner acc =
   | `Descriptor desc -> `More (normalize desc acc)
 
 let read_descriptor_block normalize inner =
-  read_items_with_recovery (read_descriptor_step normalize) inner []
+  read_items_with_recovery ~skip:skip_invalid_item
+    (read_descriptor_step normalize)
+    inner []
 
 (* CSS Fonts 4 sec. 4.4: a descriptor range whose startpoint is larger than its
    endpoint is well defined, the user agent swapping the two endpoints for font
@@ -2249,33 +2254,34 @@ let read_counter_string_descriptor constructor r =
       value)
     constructor r
 
-let read_counter_style_descriptor (r : Cursor.t) :
-    counter_style_descriptor option =
+(* CSS Counter Styles 3 sec. 3: "unknown descriptors are invalid and ignored".
+   One descriptor of the body, the caller looping over the rest, so a descriptor
+   that fails leaves the ones already read untouched. The declaration is the
+   whole of the descriptor's value: an [!important] flag, which no descriptor
+   takes, invalidates the declaration it follows rather than being left over as
+   an item of its own, as it is in Blink 146. *)
+let read_counter_style_descriptor (r : Cursor.t) : counter_style_descriptor =
+  let name = Cursor.ident ~keep_case:false r |> String.lowercase_ascii in
+  let descriptor =
+    match name with
+    | "system" -> read_counter_style_system_descriptor r
+    | "symbols" -> read_counter_symbols_descriptor r
+    | "suffix" -> read_counter_symbol_descriptor (fun s -> Suffix s) r
+    | "prefix" -> read_counter_symbol_descriptor (fun s -> Prefix s) r
+    | "fallback" -> read_counter_string_descriptor (fun s -> Fallback s) r
+    | "range" -> read_counter_string_descriptor (fun s -> Range s) r
+    | "pad" -> read_counter_string_descriptor (fun s -> Pad s) r
+    | "negative" -> read_counter_string_descriptor (fun s -> Negative s) r
+    | "additive-symbols" ->
+        read_counter_string_descriptor (fun s -> Additive_symbols s) r
+    | "speak-as" -> read_counter_string_descriptor (fun s -> Speak_as s) r
+    | _ -> Cursor.err_invalid r ("unknown counter-style descriptor: " ^ name)
+  in
   Cursor.ws r;
-  if Cursor.is_done r then None
-  else if Cursor.peek_semicolon r then (
-    Cursor.skip r;
-    None)
-  else
-    let name = Cursor.ident ~keep_case:false r |> String.lowercase_ascii in
-    let descriptor =
-      match name with
-      | "system" -> read_counter_style_system_descriptor r
-      | "symbols" -> read_counter_symbols_descriptor r
-      | "suffix" -> read_counter_symbol_descriptor (fun s -> Suffix s) r
-      | "prefix" -> read_counter_symbol_descriptor (fun s -> Prefix s) r
-      | "fallback" -> read_counter_string_descriptor (fun s -> Fallback s) r
-      | "range" -> read_counter_string_descriptor (fun s -> Range s) r
-      | "pad" -> read_counter_string_descriptor (fun s -> Pad s) r
-      | "negative" -> read_counter_string_descriptor (fun s -> Negative s) r
-      | "additive-symbols" ->
-          read_counter_string_descriptor (fun s -> Additive_symbols s) r
-      | "speak-as" -> read_counter_string_descriptor (fun s -> Speak_as s) r
-      | _ -> Cursor.err_invalid r ("unknown counter-style descriptor: " ^ name)
-    in
-    Cursor.ws r;
-    if Cursor.peek_semicolon r then Cursor.skip r;
-    Some descriptor
+  if not (Cursor.is_done r || Cursor.peek_semicolon r) then
+    Cursor.err_invalid r ("trailing tokens after @counter-style " ^ name);
+  if Cursor.peek_semicolon r then Cursor.skip r;
+  descriptor
 
 let counter_style_descriptor_rank = function
   | System _ -> 0
@@ -2297,19 +2303,24 @@ let replace_counter_style_descriptor desc acc =
          <> counter_style_descriptor_rank desc)
        acc
 
-let continue_descriptor_loop inner acc loop =
+(* One item of a descriptor body: a descriptor, a stray [;] that CSS Syntax 3
+   sec. 5.4.3 discards with no declaration to validate, or the end of the
+   body. *)
+let read_descriptor_body_step read_one replace inner acc =
   Cursor.ws inner;
-  if Cursor.is_done inner then List.rev acc else loop acc
+  if Cursor.is_done inner then `Done (List.rev acc)
+  else if Cursor.peek_semicolon inner then (
+    Cursor.skip inner;
+    `More acc)
+  else `More (replace (read_one inner) acc)
 
 let read_counter_style_descriptors r =
   Cursor.braces
     (fun inner ->
-      let rec loop acc =
-        match read_counter_style_descriptor inner with
-        | Some desc -> loop (replace_counter_style_descriptor desc acc)
-        | None -> continue_descriptor_loop inner acc loop
-      in
-      loop [])
+      read_items_with_recovery ~skip:skip_invalid_item
+        (read_descriptor_body_step read_counter_style_descriptor
+           replace_counter_style_descriptor)
+        inner [])
     r
 
 let counter_style_system descriptors =
@@ -2485,7 +2496,8 @@ let read_page_step inner (descriptors, margins) =
       | `Descriptor desc -> `More (replace_descriptor desc descriptors, margins)
       )
 
-let read_page_body inner = read_items_with_recovery read_page_step inner ([], [])
+let read_page_body inner =
+  read_items_with_recovery ~skip:skip_invalid_item read_page_step inner ([], [])
 
 let read_page (r : Cursor.t) : statement =
   Cursor.with_context r "@page" @@ fun () ->
@@ -2537,44 +2549,45 @@ let read_override_color_entry c =
   Cursor.ws c;
   (Float.to_int index, color)
 
-let read_font_palette_descriptor outer inner : font_palette_descriptor option =
+(* CSS Fonts 4 sec. 12.1 gives each [@font-palette-values] descriptor a grammar
+   of its own, and the declaration is the whole of it: a trailing [!important]
+   or a stray ident makes the declaration invalid rather than the leftover
+   alone, as it does in Blink 146. *)
+let read_font_palette_descriptor outer inner : font_palette_descriptor =
+  let desc_name = Cursor.ident ~keep_case:false inner in
   Cursor.ws inner;
-  if Cursor.is_done inner then None
-  else if Cursor.peek_semicolon inner then (
-    Cursor.skip inner;
-    None)
-  else
-    let desc_name = Cursor.ident ~keep_case:false inner in
-    Cursor.ws inner;
-    if not (Cursor.colon inner) then Cursor.err_expected inner "':'";
-    Cursor.ws inner;
-    let desc =
-      match desc_name with
-      | "font-family" ->
-          Palette_font_family
-            (Cursor.list ~sep:Cursor.comma Properties.read_font_family inner)
-      | "base-palette" -> Base_palette (read_base_palette_value inner)
-      | "override-colors" ->
-          Override_colors
-            (Cursor.list ~sep:Cursor.comma ~at_least:1 read_override_color_entry
-               inner)
-      | name ->
-          Cursor.err_invalid outer
-            ("unknown font-palette-values descriptor: " ^ name)
-    in
-    Cursor.ws inner;
-    if Cursor.peek_semicolon inner then Cursor.skip inner;
-    Some desc
+  if not (Cursor.colon inner) then Cursor.err_expected inner "':'";
+  Cursor.ws inner;
+  let desc =
+    match desc_name with
+    | "font-family" ->
+        Palette_font_family
+          (Cursor.list ~sep:Cursor.comma Properties.read_font_family inner)
+    | "base-palette" -> Base_palette (read_base_palette_value inner)
+    | "override-colors" ->
+        Override_colors
+          (Cursor.list ~sep:Cursor.comma ~at_least:1 read_override_color_entry
+             inner)
+    | name ->
+        Cursor.err_invalid outer
+          ("unknown font-palette-values descriptor: " ^ name)
+  in
+  Cursor.ws inner;
+  if not (Cursor.is_done inner || Cursor.peek_semicolon inner) then
+    Cursor.err_invalid outer
+      ("trailing tokens after @font-palette-values " ^ desc_name);
+  if Cursor.peek_semicolon inner then Cursor.skip inner;
+  desc
 
 let read_font_palette_descriptors outer =
-  let rec loop inner acc =
-    match read_font_palette_descriptor outer inner with
-    | Some desc -> loop inner (replace_font_palette_descriptor desc acc)
-    | None ->
-        Cursor.ws inner;
-        if Cursor.is_done inner then List.rev acc else loop inner acc
-  in
-  Cursor.braces (fun inner -> loop inner []) outer
+  Cursor.braces
+    (fun inner ->
+      read_items_with_recovery ~skip:skip_invalid_item
+        (read_descriptor_body_step
+           (read_font_palette_descriptor outer)
+           replace_font_palette_descriptor)
+        inner [])
+    outer
 
 let font_palette_descriptor_rank = function
   | Palette_font_family _ -> 0
@@ -2645,7 +2658,6 @@ let read_font_feature_values_entries outer =
   Cursor.braces (fun inner -> loop inner []) outer
 
 let read_font_feature_values_block outer inner =
-  Cursor.ws inner;
   match Cursor.at_keyword_opt inner with
   | None -> Cursor.err_expected inner "@font-feature-values nested at-rule"
   | Some name ->
@@ -2654,13 +2666,26 @@ let read_font_feature_values_block outer inner =
         Cursor.err_invalid outer ("unknown @font-feature-values block: @" ^ name);
       (name, read_font_feature_values_entries inner)
 
+(* CSS Fonts 4 sec. 11.1 fills the body with feature value blocks, so it is a
+   list of rules rather than of declarations: a block the body rejects ends at
+   its own [{}] or at a [;] (CSS Syntax 3 sec. 5.4.2), which leaves the blocks
+   written around it in the rule. A [;] with nothing before it has no
+   declaration to validate and is discarded (sec. 5.4.3). *)
+let read_font_feature_values_step outer inner acc =
+  Cursor.ws inner;
+  if Cursor.is_done inner then `Done (List.rev acc)
+  else if Cursor.peek_semicolon inner then (
+    Cursor.skip inner;
+    `More acc)
+  else `More (read_font_feature_values_block outer inner :: acc)
+
 let read_font_feature_values_blocks outer =
-  let rec loop inner acc =
-    Cursor.ws inner;
-    if Cursor.is_done inner then List.rev acc
-    else loop inner (read_font_feature_values_block outer inner :: acc)
-  in
-  Cursor.braces (fun inner -> loop inner []) outer
+  Cursor.braces
+    (fun inner ->
+      read_items_with_recovery ~skip:skip_past_rule
+        (read_font_feature_values_step outer)
+        inner [])
+    outer
 
 let read_font_feature_values (r : Cursor.t) : statement =
   Cursor.with_context r "@font-feature-values" @@ fun () ->
@@ -2711,39 +2736,35 @@ let read_view_transition_types inner =
       in
       Types (Some (names [ first ]))
 
-let read_view_transition_descriptor outer inner :
-    view_transition_descriptor option =
+(* CSS View Transitions 2 sec. 2.4 gives each [@view-transition] descriptor a
+   grammar of its own, and the declaration is the whole of it. *)
+let read_view_transition_descriptor outer inner : view_transition_descriptor =
+  let desc_name = Cursor.ident ~keep_case:false inner in
   Cursor.ws inner;
-  if Cursor.is_done inner then None
-  else if Cursor.peek_semicolon inner then (
-    Cursor.skip inner;
-    None)
-  else
-    let desc_name = Cursor.ident ~keep_case:false inner in
-    Cursor.ws inner;
-    if not (Cursor.colon inner) then Cursor.err_expected inner "':'";
-    Cursor.ws inner;
-    let desc =
-      match desc_name with
-      | "navigation" -> read_view_transition_navigation inner
-      | "types" -> read_view_transition_types inner
-      | name ->
-          Cursor.err_invalid outer
-            ("unknown @view-transition descriptor: " ^ name)
-    in
-    Cursor.ws inner;
-    if Cursor.peek_semicolon inner then Cursor.skip inner;
-    Some desc
+  if not (Cursor.colon inner) then Cursor.err_expected inner "':'";
+  Cursor.ws inner;
+  let desc =
+    match desc_name with
+    | "navigation" -> read_view_transition_navigation inner
+    | "types" -> read_view_transition_types inner
+    | name ->
+        Cursor.err_invalid outer ("unknown @view-transition descriptor: " ^ name)
+  in
+  Cursor.ws inner;
+  if not (Cursor.is_done inner || Cursor.peek_semicolon inner) then
+    Cursor.err_invalid outer
+      ("trailing tokens after @view-transition " ^ desc_name);
+  if Cursor.peek_semicolon inner then Cursor.skip inner;
+  desc
 
 let read_view_transition_descriptors outer =
   Cursor.braces
     (fun inner ->
-      let rec loop acc =
-        match read_view_transition_descriptor outer inner with
-        | Some desc -> loop (replace_view_transition_descriptor desc acc)
-        | None -> continue_descriptor_loop inner acc loop
-      in
-      loop [])
+      read_items_with_recovery ~skip:skip_invalid_item
+        (read_descriptor_body_step
+           (read_view_transition_descriptor outer)
+           replace_view_transition_descriptor)
+        inner [])
     outer
 
 let read_view_transition (r : Cursor.t) : statement =
@@ -3111,7 +3132,7 @@ let read_property_step r state =
   else `More (read_property_descriptor r state)
 
 let read_property_descriptors (r : Cursor.t) : property_reader_state =
-  read_items_with_recovery read_property_step r
+  read_items_with_recovery ~skip:skip_invalid_item read_property_step r
     { syntax = None; inherits = None; initial_value = None }
 
 let read_property_rule (r : Cursor.t) : statement =

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1905,6 +1905,223 @@ let spec_block_recovery_warns_once_per_statement () =
      blue } }"
     0
 
+(* CSS Counter Styles 3 sec. 3 gives [@counter-style] a block of descriptor
+   declarations, so CSS Syntax 3 sec. 5.4.3 keeps what that block already
+   yielded when one item fails to parse: a descriptor cascade rejects costs that
+   descriptor, not the [@counter-style] holding it and not the sheet holding
+   that. The discard follows sec. 5.4.4 for a declaration - up to the next
+   top-level [;], a [{}] met on the way counting as one component value of the
+   value being skipped - and sec. 5.4.2 for an at-rule, which ends at its block
+   or its [;]. Blink 146 keeps the rule in every case below. *)
+let spec_lenient_recovery_counter_style_descriptors () =
+  let recovered =
+    "@counter-style c{system:cyclic;symbols:\"a\";suffix:\" \"}"
+  in
+  let shorter = "@counter-style c{system:cyclic;symbols:\"a\"}" in
+  let body rest = "@counter-style c { system: cyclic; " ^ rest ^ " }" in
+  lenient_recover "unknown descriptor first in @counter-style"
+    "@counter-style c { zzz: 1; system: cyclic; symbols: \"a\"; suffix: \" \" }"
+    recovered 1;
+  lenient_recover "unknown descriptor mid-body in @counter-style"
+    (body "zzz: 1; symbols: \"a\"; suffix: \" \"")
+    recovered 1;
+  lenient_recover "unknown descriptor last in @counter-style"
+    (body "symbols: \"a\"; suffix: \" \"; zzz: 1")
+    recovered 1;
+  lenient_recover "bad value for a known @counter-style descriptor"
+    (body "symbols: \"a\"; suffix: !!!")
+    shorter 1;
+  lenient_recover "two curly blocks in a dropped counter-style value"
+    (body "zzz: {1}{2}; symbols: \"a\"; suffix: \" \"")
+    recovered 1;
+  (* A descriptor's value is the whole of its declaration, and no descriptor
+     takes an [!important] flag, so the declaration it follows is invalid rather
+     than the flag alone. *)
+  lenient_recover "an important flag invalidates the counter-style descriptor"
+    (body "symbols: \"a\"; suffix: \" \" !important")
+    shorter 1;
+  lenient_recover "an important flag on an opaque counter-style descriptor"
+    (body "symbols: \"a\"; pad: 2 \"0\" !important; suffix: \" \"")
+    recovered 1;
+  lenient_recover "at-rule in @counter-style ends at its block"
+    (body "@media screen { color: red } symbols: \"a\"; suffix: \" \"")
+    recovered 1;
+  lenient_recover
+    "at-rule with no block in @counter-style ends at its semicolon"
+    (body "@media screen; symbols: \"a\"; suffix: \" \"")
+    recovered 1;
+  lenient_recover "selector-shaped item in @counter-style with a semicolon"
+    (body ".a { b: c }; symbols: \"a\"; suffix: \" \"")
+    recovered 1;
+  (* Sec. 5.4.4 skips a bad declaration to the next top-level [;], and a
+     selector-shaped item has none of its own, so it takes the tail of the body
+     with it. Blink 146 splits the two the same way. *)
+  lenient_recover "selector-shaped item in @counter-style takes the tail"
+    (body "symbols: \"a\"; .a { b: c } suffix: \" \"")
+    shorter 1;
+  lenient_recover "a dropped counter-style descriptor keeps the sheet whole"
+    (".a { color: red } "
+    ^ body "zzz: 1; symbols: \"a\"; suffix: \" \""
+    ^ " .z { color: lime }")
+    (".a{color:red}" ^ recovered ^ ".z{color:#0f0}")
+    1
+
+(* CSS Fonts 4 sec. 12.1 gives [@font-palette-values] a block of descriptor
+   declarations, so one descriptor cascade rejects costs that descriptor alone.
+   A descriptor's value is the whole of its declaration: a trailing [!important]
+   or a stray ident makes the declaration invalid rather than the leftover
+   alone, as it does in Blink 146. *)
+let spec_lenient_recovery_font_palette_descriptors () =
+  let recovered = "@font-palette-values --p{font-family:X;base-palette:1}" in
+  let body rest = "@font-palette-values --p { font-family: X; " ^ rest ^ " }" in
+  lenient_recover "unknown descriptor first in @font-palette-values"
+    "@font-palette-values --p { zzz: 1; font-family: X; base-palette: 1 }"
+    recovered 1;
+  lenient_recover "unknown descriptor mid-body in @font-palette-values"
+    (body "zzz: 1; base-palette: 1")
+    recovered 1;
+  lenient_recover "unknown descriptor last in @font-palette-values"
+    (body "base-palette: 1; zzz: 1")
+    recovered 1;
+  lenient_recover "bad value for a known @font-palette-values descriptor"
+    (body "base-palette: -1; base-palette: 1")
+    recovered 1;
+  lenient_recover "two curly blocks in a dropped font-palette value"
+    (body "zzz: {1}{2}; base-palette: 1")
+    recovered 1;
+  lenient_recover "trailing tokens invalidate the font-palette descriptor"
+    (body "base-palette: 2 bogus; base-palette: 1")
+    recovered 1;
+  lenient_recover "an important flag invalidates the font-palette descriptor"
+    (body "base-palette: 2 !important; base-palette: 1")
+    recovered 1;
+  lenient_recover "at-rule in @font-palette-values ends at its block"
+    (body "@media screen { color: red } base-palette: 1")
+    recovered 1;
+  lenient_recover
+    "at-rule with no block in @font-palette-values ends at its semicolon"
+    (body "@media screen; base-palette: 1")
+    recovered 1;
+  lenient_recover
+    "selector-shaped item in @font-palette-values with a semicolon"
+    (body ".a { b: c }; base-palette: 1")
+    recovered 1;
+  lenient_recover "a dropped font-palette descriptor keeps the sheet whole"
+    (".a { color: red } "
+    ^ body "zzz: 1; base-palette: 1"
+    ^ " .z { color: lime }")
+    (".a{color:red}" ^ recovered ^ ".z{color:#0f0}")
+    1
+
+(* CSS View Transitions 2 sec. 2.4 gives [@view-transition] a block of
+   descriptor declarations, so one descriptor cascade rejects costs that
+   descriptor alone. Blink 146 keeps the rule in every case below. *)
+let spec_lenient_recovery_view_transition_descriptors () =
+  let recovered = "@view-transition{navigation:auto}" in
+  let both = "@view-transition{navigation:auto;types:a}" in
+  lenient_recover "unknown descriptor first in @view-transition"
+    "@view-transition { zzz: 1; navigation: auto }" recovered 1;
+  lenient_recover "unknown descriptor mid-body in @view-transition"
+    "@view-transition { navigation: auto; zzz: 1; types: a }" both 1;
+  lenient_recover "unknown descriptor last in @view-transition"
+    "@view-transition { navigation: auto; zzz: 1 }" recovered 1;
+  lenient_recover "bad value for a known @view-transition descriptor"
+    "@view-transition { navigation: bogus; navigation: auto }" recovered 1;
+  lenient_recover "two curly blocks in a dropped view-transition value"
+    "@view-transition { zzz: {1}{2}; navigation: auto }" recovered 1;
+  lenient_recover "trailing tokens invalidate the view-transition descriptor"
+    "@view-transition { navigation: none bogus; navigation: auto }" recovered 1;
+  lenient_recover "an important flag invalidates the view-transition descriptor"
+    "@view-transition { navigation: none !important; navigation: auto }"
+    recovered 1;
+  lenient_recover "at-rule in @view-transition ends at its block"
+    "@view-transition { @media screen { color: red } navigation: auto }"
+    recovered 1;
+  lenient_recover
+    "at-rule with no block in @view-transition ends at its semicolon"
+    "@view-transition { @media screen; navigation: auto }" recovered 1;
+  lenient_recover "selector-shaped item in @view-transition with a semicolon"
+    "@view-transition { .a { b: c }; navigation: auto }" recovered 1;
+  lenient_recover "a dropped view-transition descriptor keeps the sheet whole"
+    ".a { color: red } @view-transition { zzz: 1; navigation: auto } .z { \
+     color: lime }"
+    (".a{color:red}" ^ recovered ^ ".z{color:#0f0}")
+    1
+
+(* CSS Fonts 4 sec. 11.1 fills an [@font-feature-values] body with feature value
+   blocks, so it is a rule list: CSS Syntax 3 sec. 5.4.2 ends the block cascade
+   rejects at its own [{}] or [;], leaving the blocks written around it in the
+   rule. A [;] with no rule before it is discarded with nothing to validate
+   (sec. 5.4.3), so it costs nothing. *)
+let spec_lenient_recovery_font_feature_values_blocks () =
+  let recovered = "@font-feature-values Xf{@swash{s:1}@ornaments{o:2}}" in
+  let body rest = "@font-feature-values Xf { @swash { s: 1 } " ^ rest ^ " }" in
+  lenient_recover "unknown block first in @font-feature-values"
+    "@font-feature-values Xf { @zzz { a: 1 } @swash { s: 1 } @ornaments { o: 2 \
+     } }"
+    recovered 1;
+  lenient_recover "unknown block mid-body in @font-feature-values"
+    (body "@zzz { a: 1 } @ornaments { o: 2 }")
+    recovered 1;
+  lenient_recover "unknown block last in @font-feature-values"
+    (body "@ornaments { o: 2 } @zzz { a: 1 }")
+    recovered 1;
+  lenient_recover
+    "at-rule with no block in @font-feature-values ends at its semicolon"
+    (body "@zzz; @ornaments { o: 2 }")
+    recovered 1;
+  lenient_recover
+    "selector-shaped item in @font-feature-values ends at its block"
+    (body ".a { b: c } @ornaments { o: 2 }")
+    recovered 1;
+  lenient_recover
+    "declaration in an @font-feature-values body ends at its semicolon"
+    (body "color: red; @ornaments { o: 2 }")
+    recovered 1;
+  lenient_recover "stray semicolon in @font-feature-values costs nothing"
+    (body "; @ornaments { o: 2 }")
+    recovered 0;
+  lenient_recover "leading semicolon in @font-feature-values costs nothing"
+    "@font-feature-values Xf { ; @swash { s: 1 } @ornaments { o: 2 } }"
+    recovered 0;
+  lenient_recover "a dropped feature block keeps the sheet whole"
+    (".a { color: red } "
+    ^ body "@zzz { a: 1 } @ornaments { o: 2 }"
+    ^ " .z { color: lime }")
+    (".a{color:red}" ^ recovered ^ ".z{color:#0f0}")
+    1
+
+(* Each dropped descriptor reports once, and [~strict:true] rejects exactly the
+   inputs the lenient parse warned about. *)
+let spec_descriptor_recovery_warns_once_per_descriptor () =
+  warns_exactly "@counter-style c { system: cyclic; zzz: 1; symbols: \"a\" }" 1;
+  warns_exactly
+    "@counter-style c { system: cyclic; zzz: {1}{2}; symbols: \"a\" }" 1;
+  warns_exactly
+    "@counter-style c { system: cyclic; zzz: 1; yyy: 2; symbols: \"a\" }" 2;
+  warns_exactly "@counter-style c { system: cyclic; symbols: \"a\" }" 0;
+  warns_exactly "@counter-style c { ;; system: cyclic; symbols: \"a\" }" 0;
+  warns_exactly
+    "@font-palette-values --p { font-family: X; zzz: 1; base-palette: 1 }" 1;
+  warns_exactly
+    "@font-palette-values --p { font-family: X; zzz: {1}{2}; base-palette: 1 }"
+    1;
+  warns_exactly
+    "@font-palette-values --p { font-family: X; zzz: 1; yyy: 2; base-palette: \
+     1 }"
+    2;
+  warns_exactly "@font-palette-values --p { font-family: X; base-palette: 1 }" 0;
+  warns_exactly "@view-transition { zzz: 1; navigation: auto }" 1;
+  warns_exactly "@view-transition { zzz: {1}{2}; navigation: auto }" 1;
+  warns_exactly "@view-transition { zzz: 1; yyy: 2; navigation: auto }" 2;
+  warns_exactly "@view-transition { navigation: auto }" 0;
+  warns_exactly "@view-transition { ;; navigation: auto }" 0;
+  warns_exactly "@font-feature-values Xf { @zzz { a: 1 } @swash { s: 1 } }" 1;
+  warns_exactly
+    "@font-feature-values Xf { @zzz { a: 1 } @yyy { b: 2 } @swash { s: 1 } }" 2;
+  warns_exactly "@font-feature-values Xf { @swash { s: 1 } }" 0;
+  warns_exactly "@font-feature-values Xf { ;; @swash { s: 1 } }" 0
+
 let stylesheet_tests =
   [
     (* Core type tests *)
@@ -2019,6 +2236,21 @@ let stylesheet_tests =
     ( "spec block recovery warns once per dropped statement",
       `Quick,
       spec_block_recovery_warns_once_per_statement );
+    ( "spec lenient recovery in a @counter-style body",
+      `Quick,
+      spec_lenient_recovery_counter_style_descriptors );
+    ( "spec lenient recovery in a @font-palette-values body",
+      `Quick,
+      spec_lenient_recovery_font_palette_descriptors );
+    ( "spec lenient recovery in a @view-transition body",
+      `Quick,
+      spec_lenient_recovery_view_transition_descriptors );
+    ( "spec lenient recovery in a @font-feature-values body",
+      `Quick,
+      spec_lenient_recovery_font_feature_values_blocks );
+    ( "spec descriptor recovery warns once per dropped descriptor",
+      `Quick,
+      spec_descriptor_recovery_warns_once_per_descriptor );
   ]
 
 (* Tests for newly added check functions *)


### PR DESCRIPTION
`@counter-style thumbs { system: cyclic; symbols: "x"; zzz: 1 }` parsed to nothing: four descriptor bodies had no item-level recovery, so a descriptor or feature block they reject unwound past the at-rule and past the stylesheet holding it, and `@font-palette-values`, `@view-transition` and `@font-feature-values` lost their whole rule the same way. CSS Syntax 3 sec. 5.4.3 keeps what a block's contents already yielded when one item fails, and Blink 146 keeps all four rules.

Stacked on #405. A `@counter-style`, `@font-palette-values` or `@view-transition` descriptor value now has to be the whole of its declaration, or recovery would commit a trailing `!important` Blink drops. Every file under `test/interop` formats and minifies byte-identically in `fmt`, `--minify` and `--minify --enforce-spec`, warnings and exit status included.