### PR TITLE
css: an at-rule in a @keyframes body costs itself

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -140,6 +140,15 @@
   `@view-transition` or `@counter-style` descriptor value, such as a trailing
   `!important`, now invalidate the declaration they follow rather than the
   leftover alone (#419)
+- An at-rule inside a `@keyframes` body is dropped on its own rather than taking
+  the animation and the stylesheet holding it, so
+  `@keyframes k { from { color: red } @media print { to { color: pink } } 50%
+  { background: lime } }` keeps both keyframes where it parsed to nothing. The
+  rejection was raised around the loop rather than inside it, so it unwound past
+  the recovery the loop already ran for a keyframe selector it rejects. CSS
+  Syntax 3 sec. 5.4.2 ends the at-rule being discarded at its own block, past
+  any `(` or `[` in its prelude, and Blink 146 keeps the keyframes written
+  around it (#420)
 
 ### Minification
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1675,48 +1675,89 @@ let read_namespace (r : Cursor.t) : statement =
   if Cursor.peek_semicolon r then Cursor.skip r;
   Namespace (prefix, uri)
 
-let rec skip_bad_keyframe inner =
-  match Cursor.peek_raw inner with
+(* Discard the rule the cursor sits on, stopping at its [{}] block or at a
+   top-level [;]: CSS Syntax 3 sec. 5.4.2 ends an at-rule at whichever comes
+   first, and sec. 5.4.3 ends a qualified rule at its block. Consuming exactly
+   that far leaves what was written after the rule - the declarations around it,
+   or the next rule - to be read on its own. A [(] or a [[] met before the block
+   is a component value of the prelude being discarded, so stopping there would
+   offer the tail of that prelude as a rule of its own. *)
+let rec skip_past_rule r =
+  match Cursor.next_raw r with
   | None -> ()
+  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
   | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-      ignore (Cursor.next_raw inner : Component.t option)
-  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ }) ->
-      ignore (Cursor.next_raw inner : Component.t option)
-  | Some _ ->
-      ignore (Cursor.next_raw inner : Component.t option);
-      skip_bad_keyframe inner
+      ()
+  | Some _ -> skip_past_rule r
 
+(* Discard the item the cursor sits on. A body that holds declarations and
+   at-rules alike has to pick by what the item starts with: the two ends differ,
+   and taking an at-rule for a declaration would eat the item written after it.
+   The caller rewinds first, so a reader that already consumed part of the item
+   is skipped from its start. *)
+let skip_invalid_item r =
+  match Cursor.peek r with
+  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
+      skip_past_rule r
+  | _ -> Cursor.skip_past_semicolon r
+
+(* Read a body one item at a time, [step] committing each item to the
+   accumulator before the next is read, so an item dropped in recovery costs
+   only itself and the items around it are kept. CSS Syntax 3 sec. 5.4.3 keeps
+   what a block's contents already yielded when one item fails to parse, and CSS
+   Paged Media 3 sec. 6 says as much of a page or a margin context in so many
+   words: "valid declarations within the block are applied". Strict mode ([not
+   (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly what the
+   lenient parse warns about. [skip] discards the item that failed, and which
+   one it is depends on the body: {!skip_invalid_item} for a body of
+   declarations, {!skip_past_rule} for a body of rules, where an item that opens
+   a block ends at that block rather than at a [;] it does not have. *)
+let read_items_with_recovery ~skip step r init =
+  let rec loop state =
+    if Cursor.recover r then recovering state else continue (step r state)
+  and recovering state =
+    let start = Cursor.save r in
+    match step r state with
+    | committed -> continue committed
+    | exception Error.Parse_error e ->
+        Cursor.push_warning r e;
+        Cursor.restore r start;
+        skip r;
+        loop state
+  and continue = function
+    | `Done result -> result
+    | `More state -> loop state
+  in
+  loop init
+
+(* A selector that is no keyframe selector - the [to] of [entry to], which is no
+   [<length-percentage>] - drops its rule and the block keeps parsing. *)
 let read_keyframe_or_skip inner acc =
   let snap = Cursor.save inner in
   match read_keyframe inner with
-  | frame -> `Frame frame
+  | frame -> frame :: acc
   | exception Cursor.Parse_error e ->
-      (* Invalid keyframe rules are ignored, but the surrounding block keeps
-         parsing. *)
       Cursor.restore inner snap;
       Cursor.push_warning inner e;
-      skip_bad_keyframe inner;
-      `Skip acc
+      skip_past_rule inner;
+      acc
 
+(* One item of the body: a keyframe rule, or the end of it. CSS Animations 1
+   sec. 3 fills a [@keyframes] body with keyframe rules, so an at-rule has no
+   place there; rejecting it here rather than around the loop leaves the
+   rejection inside the recovery the loop runs, which costs the at-rule alone
+   instead of the animation and the sheet holding it. *)
 let read_keyframes_step inner acc =
-  match Cursor.peek inner with
-  | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
-      Cursor.err_invalid inner ("@keyframes nested @" ^ name)
-  | _ -> (
-      match read_keyframe_or_skip inner acc with
-      | `Frame frame -> frame :: acc
-      | `Skip acc -> acc)
+  Cursor.ws inner;
+  if Cursor.is_done inner then `Done (List.rev acc)
+  else
+    match Cursor.peek inner with
+    | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
+        Cursor.err_invalid inner ("@keyframes nested @" ^ name)
+    | _ -> `More (read_keyframe_or_skip inner acc)
 
 let read_keyframes_block inner =
-  (* CSS Syntax 5.4.4: a [@keyframes] block lists keyframe rules; an invalid
-     selector (e.g. [entry to] - [to] is not a [<length-percentage>]) only drops
-     that rule, the surrounding block keeps parsing. *)
-  let rec read_frames acc =
-    Cursor.ws inner;
-    if Cursor.is_done inner then List.rev acc
-    else read_frames (read_keyframes_step inner acc)
-  in
-  read_frames []
+  read_items_with_recovery ~skip:skip_past_rule read_keyframes_step inner []
 
 (* CSS Animations 1 sec. 3: [@keyframes <keyframes-name>], [<keyframes-name> =
    <custom-ident> | <string>]. The reserved spellings ([none], CSS-wide
@@ -1782,61 +1823,6 @@ let read_descriptor_value read_fn constructor r =
     let value = read_fn r in
     constructor value
   with Failure msg -> Cursor.err_invalid r msg
-
-(* Discard the rule the cursor sits on, stopping at its [{}] block or at a
-   top-level [;]: CSS Syntax 3 sec. 5.4.2 ends an at-rule at whichever comes
-   first, and sec. 5.4.3 ends a qualified rule at its block. Consuming exactly
-   that far leaves what was written after the rule - the declarations around it,
-   or the next rule - to be read on its own. A [(] or a [[] met before the block
-   is a component value of the prelude being discarded, so stopping there would
-   offer the tail of that prelude as a rule of its own. *)
-let rec skip_past_rule r =
-  match Cursor.next_raw r with
-  | None -> ()
-  | Some (Component.Block { node = { opening = Token.Curly; _ }; _ })
-  | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
-      ()
-  | Some _ -> skip_past_rule r
-
-(* Discard the item the cursor sits on. A body that holds declarations and
-   at-rules alike has to pick by what the item starts with: the two ends differ,
-   and taking an at-rule for a declaration would eat the item written after it.
-   The caller rewinds first, so a reader that already consumed part of the item
-   is skipped from its start. *)
-let skip_invalid_item r =
-  match Cursor.peek r with
-  | Some (Component.Preserved { kind = Token.At_keyword _; _ }) ->
-      skip_past_rule r
-  | _ -> Cursor.skip_past_semicolon r
-
-(* Read a body one item at a time, [step] committing each item to the
-   accumulator before the next is read, so an item dropped in recovery costs
-   only itself and the items around it are kept. CSS Syntax 3 sec. 5.4.3 keeps
-   what a block's contents already yielded when one item fails to parse, and CSS
-   Paged Media 3 sec. 6 says as much of a page or a margin context in so many
-   words: "valid declarations within the block are applied". Strict mode ([not
-   (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly what the
-   lenient parse warns about. [skip] discards the item that failed, and which
-   one it is depends on the body: {!skip_invalid_item} for a body of
-   declarations, {!skip_past_rule} for a body of rules, where an item that opens
-   a block ends at that block rather than at a [;] it does not have. *)
-let read_items_with_recovery ~skip step r init =
-  let rec loop state =
-    if Cursor.recover r then recovering state else continue (step r state)
-  and recovering state =
-    let start = Cursor.save r in
-    match step r state with
-    | committed -> continue committed
-    | exception Error.Parse_error e ->
-        Cursor.push_warning r e;
-        Cursor.restore r start;
-        skip r;
-        loop state
-  and continue = function
-    | `Done result -> result
-    | `More state -> loop state
-  in
-  loop init
 
 (* One item of a descriptor body: a descriptor, a stray [;] that CSS Syntax 3
    sec. 5.4.3 discards with no declaration to validate, or the end of the body.

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2122,6 +2122,79 @@ let spec_descriptor_recovery_warns_once_per_descriptor () =
   warns_exactly "@font-feature-values Xf { @swash { s: 1 } }" 0;
   warns_exactly "@font-feature-values Xf { ;; @swash { s: 1 } }" 0
 
+(* CSS Animations 1 sec. 3 fills a [@keyframes] body with keyframe rules, so it
+   is a list of rules: an at-rule has no place there, and CSS Syntax 3 sec.
+   5.4.2 ends the one being discarded at its own [{}] block or at its [;],
+   leaving the keyframes written around it in the animation. A [(] or a [[] met
+   in the prelude on the way is a component value of that prelude, not an end.
+   Blink 146 keeps both neighbours in every case below. *)
+let spec_lenient_recovery_keyframes_at_rule () =
+  let recovered = "@keyframes k{0%{color:red}50%{background:#0f0}}" in
+  let body rest = "@keyframes k { " ^ rest ^ " }" in
+  lenient_recover "at-rule first in @keyframes"
+    (body
+       "@media print { to { color: pink } } from { color: red } 50% { \
+        background: lime }")
+    recovered 1;
+  lenient_recover "at-rule mid-body in @keyframes"
+    (body
+       "from { color: red } @media print { to { color: pink } } 50% { \
+        background: lime }")
+    recovered 1;
+  lenient_recover "at-rule last in @keyframes"
+    (body
+       "from { color: red } 50% { background: lime } @media print { to { \
+        color: pink } }")
+    recovered 1;
+  lenient_recover "at-rule with no block in @keyframes ends at its semicolon"
+    (body "from { color: red } @zzz; 50% { background: lime }")
+    recovered 1;
+  lenient_recover "a paren in the prelude of a dropped @keyframes at-rule"
+    (body
+       "from { color: red } @media (min-width: 1px) { to { color: pink } } 50% \
+        { background: lime }")
+    recovered 1;
+  lenient_recover "a bracket in the prelude of a dropped @keyframes at-rule"
+    (body
+       "from { color: red } @zzz [a] { to { color: pink } } 50% { background: \
+        lime }")
+    recovered 1;
+  lenient_recover "two at-rules in @keyframes are dropped one at a time"
+    (body
+       "from { color: red } @media print { a: b } @supports (display: grid) { \
+        b: c } 50% { background: lime }")
+    recovered 2;
+  (* The animation outlives its only item, as it does in Blink 146: what is left
+     is a [@keyframes] that animates nothing. *)
+  lenient_recover "at-rule alone in @keyframes"
+    (body "@media print { to { color: pink } }")
+    "@keyframes k{}" 1;
+  lenient_recover "a dropped at-rule in @keyframes keeps the sheet whole"
+    (".a { color: red } "
+    ^ body
+        "from { color: red } @media print { to { color: pink } } 50% { \
+         background: lime }"
+    ^ " .z { color: lime }")
+    (".a{color:red}" ^ recovered ^ ".z{color:#0f0}")
+    1
+
+(* Each dropped keyframe rule reports once, and [~strict:true] rejects exactly
+   the inputs the lenient parse warned about. *)
+let spec_keyframes_recovery_warns_once_per_rule () =
+  let body rest = "@keyframes k { " ^ rest ^ " }" in
+  warns_exactly
+    (body
+       "from { color: red } @media print { to { color: pink } } 50% { \
+        background: lime }")
+    1;
+  warns_exactly
+    (body
+       "from { color: red } @media print { a: b } @supports (display: grid) { \
+        b: c } 50% { background: lime }")
+    2;
+  warns_exactly (body "from { color: red } @zzz; 50% { background: lime }") 1;
+  warns_exactly (body "from { color: red } 50% { background: lime }") 0
+
 let stylesheet_tests =
   [
     (* Core type tests *)
@@ -2251,6 +2324,12 @@ let stylesheet_tests =
     ( "spec descriptor recovery warns once per dropped descriptor",
       `Quick,
       spec_descriptor_recovery_warns_once_per_descriptor );
+    ( "spec lenient recovery in a @keyframes body",
+      `Quick,
+      spec_lenient_recovery_keyframes_at_rule );
+    ( "spec keyframes recovery warns once per dropped rule",
+      `Quick,
+      spec_keyframes_recovery_warns_once_per_rule );
   ]
 
 (* Tests for newly added check functions *)


### PR DESCRIPTION
`@keyframes k { from { color: red } @media print { to { color: pink } } 50% { background: lime } }` parsed to nothing: the rejection sat around the loop rather than inside it, so it unwound past the recovery the loop already ran for a keyframe selector it rejects, and past the sheet holding the animation. CSS Syntax 3 sec. 5.4.2 ends the at-rule being discarded at its own block, past any `(` or `[` in its prelude, and Blink 146 keeps both keyframes.

Stacked on #419. The body now runs the shared item loop, which drops the fourth copy of the walk that discards one rule.