### PR TITLE
css: reject a theme default that escapes its declaration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,14 @@
   and position fallback origins never defined it for the element referencing
   it; and a theme guard the keep-set rejects is dropped instead of printed as
   a declaration the theme never selected (#317, #324, #327)
+- `Css.resolve_theme` binds a `theme_defaults` answer only when the name and
+  the value make one custom-property declaration. The resolver used to write
+  every answer into synthesised `:root { ... }` text and reparse it, so a value
+  carrying a `}`, a top-level `;` or an unterminated string could close the
+  block and add a rule, an at-rule or a second declaration to the output, or
+  take every other theme default down with it.
+  `Css.Declaration.parse_custom_property` is the checked constructor the
+  resolver builds each binding with (#421)
 - `Css.inline_vars` preserves runtime-marked `var()` references, including
   typed fallbacks simplified through scalar values or shorthands, instead of
   replacing browser-time override points with compile-time defaults (#315)

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -1082,18 +1082,38 @@ let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
   | Option.None -> ());
   Hashtbl.fold (fun k v acc -> (bare_theme_name k, v) :: acc) resolved []
 
-let theme_defaults_source defaults =
-  let body =
-    defaults
-    |> List.map (fun (name, value) ->
-        let n =
-          if String.length name >= 2 && String.sub name 0 2 = "--" then name
-          else "--" ^ name
-        in
-        n ^ ":" ^ value)
-    |> String.concat ";"
+(* A theme default is CSS text the caller supplies, so a pair binds only when it
+   makes exactly one custom-property declaration. A name or value that would
+   escape it - a [}] closing the block, a top-level [;] starting a second
+   declaration, an unterminated string - is not a binding this library can
+   write, so the name stays unresolved and its [var()] reference stays live. *)
+let theme_default_declaration (name, value) =
+  let name =
+    if String.length name >= 2 && String.sub name 0 2 = "--" then name
+    else "--" ^ name
   in
-  ":root{" ^ body ^ "}"
+  Declaration.parse_custom_property name value
+
+(* [lookup] restricted to the answers that bind: anything else reads as [None],
+   the "no default for this name" answer the rest of the resolver
+   understands. *)
+let bindable_theme_defaults lookup name =
+  match lookup name with
+  | Option.Some value
+    when Option.is_some (theme_default_declaration (name, value)) ->
+      Option.Some value
+  | _ -> Option.None
+
+(* The fresh root-scope theme block, used when no [:root] / [:host] rule is
+   available to merge into. *)
+let root_theme_rule declarations =
+  Stylesheet.Rule
+    {
+      selector = Selector.of_string ":root";
+      declarations;
+      nested = [];
+      merge_key = None;
+    }
 
 (* The declarations a statement contributes to ordinary element matching. Unlike
    [Stylesheet.statement_declarations], which reaches every declaration in the
@@ -1227,20 +1247,11 @@ let emit_transitive_theme_refs ~theme_defaults stylesheet =
         resolve_theme_defaults ~declared ~lookup
           (referenced_var_names stylesheet)
       in
-      let injected =
-        if to_emit = [] then []
-        else
-          match of_string ~strict:false (theme_defaults_source to_emit) with
-          | Ok { stylesheet = root_stmts; _ } -> root_stmts
-          | Error _ -> []
-      in
-      let injected_decls =
-        match injected with [ Stylesheet.Rule r ] -> r.declarations | _ -> []
-      in
+      let injected_decls = List.filter_map theme_default_declaration to_emit in
       if injected_decls = [] then stylesheet
       else
         let result, merged = merge_into_root_scope injected_decls stylesheet in
-        if merged then result else injected @ stylesheet
+        if merged then result else root_theme_rule injected_decls :: stylesheet
 
 (* Inline only the theme defaults the resolver resolved, leaving every other
    [var()] live. [Inline.vars] alone would also collapse [var(--x, fallback)]
@@ -1276,17 +1287,15 @@ let inline_theme_defaults ?theme ?theme_defaults ~keep_set stylesheet =
     let inject =
       List.filter (fun (n, _) -> not (Hashtbl.mem declared n)) defaults
     in
-    if inject = [] then Inline.vars ~keep_vars stylesheet
-    else
-      match of_string ~strict:false (theme_defaults_source inject) with
-      | Ok { stylesheet = root_stmts; _ } ->
-          (* Do NOT run the closed-world [statements_for_inline] cleanup: this
-             is a partial inline, so it must preserve unrelated [@property]
-             registrations and [@layer] structure (the cleanup strips every
-             [@property] and flattens every [@layer], dropping author
-             registrations like an unrelated [@property --tw-foo]). *)
-          Inline.vars ~keep_vars (root_stmts @ stylesheet)
-      | Error _ -> stylesheet
+    match List.filter_map theme_default_declaration inject with
+    | [] -> Inline.vars ~keep_vars stylesheet
+    | decls ->
+        (* Do NOT run the closed-world [statements_for_inline] cleanup: this is
+           a partial inline, so it must preserve unrelated [@property]
+           registrations and [@layer] structure (the cleanup strips every
+           [@property] and flattens every [@layer], dropping author
+           registrations like an unrelated [@property --tw-foo]). *)
+        Inline.vars ~keep_vars (root_theme_rule decls :: stylesheet)
 
 (* Theme resolution as an explicit AST step. [theme] names the variables whose
    [var()] references should survive (handed to [Inline.vars]' keep-set) and
@@ -1296,6 +1305,7 @@ let inline_theme_defaults ?theme ?theme_defaults ~keep_set stylesheet =
    [emit_transitive_theme_refs] then injects root definitions for references the
    AST collector could not see. *)
 let resolve_theme ?theme ?theme_defaults stylesheet =
+  let theme_defaults = Option.map bindable_theme_defaults theme_defaults in
   let stylesheet = resolve_theme_guards_in_stmts ~theme stylesheet in
   let keep_set =
     match theme with None -> Pp.String_set.empty | Some set -> set

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7814,13 +7814,18 @@ val resolve_theme :
     [theme_defaults] resolves for it.
 
     [theme_defaults] maps a custom-property name to its value and is the source
-    of global theme-token definitions. Every [var()] reference that is undefined
-    in [stylesheet] and resolvable through [theme_defaults] - transitively, and
-    only when the whole chain closes without a cycle or dead end - is emitted as
-    a definition in the root-scope theme block: merged into an existing [:root]
-    / [:host] rule, or a fresh [:root]. A name with no [theme_defaults] value
-    (e.g. a runtime [--tw-*] variable) is left free, so non-theme variables are
-    gated out.
+    of global theme-token definitions. An answer binds only when the name and
+    the value make one custom-property declaration - a [<dashed-ident>] name and
+    a CSS Syntax 3 sec. 8.2 [<declaration-value>], as
+    {!Declaration.parse_custom_property} checks. Any other answer, such as one
+    carrying a [}] or a top-level [;], reads as no default at all and leaves the
+    reference live. Every [var()] reference that is undefined in [stylesheet]
+    and resolvable through [theme_defaults] - transitively, and only when the
+    whole chain closes without a cycle or dead end - is emitted as a definition
+    in the root-scope theme block: merged into an existing [:root] / [:host]
+    rule, or a fresh [:root]. A name with no [theme_defaults] value (e.g. a
+    runtime [--tw-*] variable) is left free, so non-theme variables are gated
+    out.
 
     Root scope is deliberate. Per CSS Custom Properties L1 a custom property is
     inherited and resolved per element at computed-value time, so [var(--x)]

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2295,6 +2295,57 @@ let parse_declaration ?layer property value =
       try read_declaration (Cursor.of_string s)
       with Cursor.Parse_error _ -> None)
 
+(* CSS Syntax 3 sec. 8.2: a [<declaration-value>] is one or more component
+   values with no [<bad-string-token>], no [<bad-url-token>] and no unmatched
+   closing bracket. A component breaking one of those does not stay inside the
+   declaration it is written into: it closes the enclosing block, or turns the
+   rest of the stylesheet into a string. *)
+let rec component_stays_in_declaration = function
+  | Component.Preserved
+      {
+        kind =
+          ( Token.Close _ | Token.Bad_string | Token.Bad_url
+          | Token.String { terminated = false; _ } );
+        _;
+      } ->
+      false
+  | Component.Preserved _ -> true
+  | Component.Block { node = { closed; value; _ }; _ } ->
+      closed && List.for_all component_stays_in_declaration value
+  | Component.Func { node = { terminated; arguments; _ }; _ } ->
+      terminated && List.for_all component_stays_in_declaration arguments
+
+(* A top-level [;] ends the declaration, so the tail becomes a second one. It is
+   only a stop at top level: [(a;b)] keeps it inside the block. *)
+let is_top_level_stop = function
+  | Component.Preserved { kind = Token.Semicolon; _ } -> true
+  | _ -> false
+
+let is_declaration_value value =
+  match Cursor.remaining (Cursor.of_string value) with
+  | [] -> false
+  | components ->
+      List.for_all
+        (fun c ->
+          (not (is_top_level_stop c)) && component_stays_in_declaration c)
+        components
+
+(* A name is written back verbatim, so it binds only when it tokenizes as the
+   single ident it claims to be. An escape (CSS Syntax 3 sec. 4.3.7) can carry a
+   [;] or a [}] into a name read from a [var()] reference. *)
+let is_writable_custom_property_name name =
+  is_custom_property_name name
+  &&
+  match Cursor.remaining (Cursor.of_string name) with
+  | [ Component.Preserved { kind = Token.Ident ident; _ } ] ->
+      String.equal ident name
+  | _ -> false
+
+let parse_custom_property name value =
+  if is_writable_custom_property_name name && is_declaration_value value then
+    parse_declaration name value
+  else None
+
 let read t =
   match read_declaration t with
   | Some d -> d

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -57,6 +57,18 @@ val parse_declaration : ?layer:string -> string -> string -> declaration option
     [layer] applies only to a custom property (a typed declaration has no
     layer). Unlike {!custom_property}, this parses the full property grammar. *)
 
+val parse_custom_property : string -> string -> declaration option
+(** [parse_custom_property name value] is {!parse_declaration} restricted to a
+    custom property whose [name] and [value] are safe to write into a rule
+    verbatim. It is [None] unless [name] is a [<dashed-ident>] that tokenizes
+    back to itself and [value] is one [<declaration-value>] (CSS Syntax 3 sec.
+    8.2): no [<bad-string-token>], no [<bad-url-token>], no unmatched closing
+    bracket, no unterminated function or block, and no top-level [;].
+
+    Use it for a name or value that comes from outside the parser, where the
+    string may close the block it is placed in or start a second declaration.
+    {!custom_property} keeps such a string verbatim. *)
+
 val custom_declaration_layer : declaration -> string option
 (** [custom_declaration_layer d] is the layer of [d], if any. *)
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1538,6 +1538,55 @@ let custom_property_values () =
   check_declaration ~expected:"z-index:var(--spec-value,{color:red;})"
     "z-index: var(--spec-value, { color: red; })"
 
+(* [parse_custom_property] builds a declaration from a name and value that came
+   from outside the parser, so it takes only a pair that writes back as the one
+   declaration it claims to be: a [<dashed-ident>] name that tokenizes to
+   itself, and a CSS Syntax 3 sec. 8.2 [<declaration-value>]. *)
+let parse_custom_property_guard () =
+  let bind name value =
+    match parse_custom_property name value with
+    | Some d -> to_string ~minify:true d
+    | None -> "<rejected>"
+  in
+  List.iter
+    (fun (value, expected) ->
+      Alcotest.(check string) ("--x:" ^ value) expected (bind "--x" value))
+    [
+      (* One declaration value: a matched block, a [;] inside a string and a
+         comment all stay inside the declaration. *)
+      ("red", "--x:red");
+      ("0 0 var(--spacing) black", "--x:0 0 var(--spacing) black");
+      ("\"a;b\"", "--x:\"a;b\"");
+      ("{a:b;}", "--x:{a:b;}");
+      ("red/*", "--x:red");
+      (" ", "--x: ");
+      (* Not one declaration value: each of these closes the enclosing block,
+         starts a second declaration, or runs to end of input. *)
+      ("red}", "<rejected>");
+      ("red}.evil{color:lime", "<rejected>");
+      ("red}@media print{.x{color:red}", "<rejected>");
+      ("red;--y:lime", "<rejected>");
+      ("red)", "<rejected>");
+      ("red]", "<rejected>");
+      ("rgb(1,2,3", "<rejected>");
+      ("{a:b", "<rejected>");
+      ("\"abc", "<rejected>");
+      ("", "<rejected>");
+    ];
+  List.iter
+    (fun (name, expected) ->
+      Alcotest.(check string) (name ^ ":red") expected (bind name "red"))
+    [
+      ("--x", "--x:red");
+      ("--color-red-500", "--color-red-500:red");
+      ("--x;y", "<rejected>");
+      ("--x}y", "<rejected>");
+      ("--x y", "<rejected>");
+      ("--", "<rejected>");
+      ("-x", "<rejected>");
+      ("color", "<rejected>");
+    ]
+
 let spec_custom_tokens () =
   check_specified_value "custom property token stream specified"
     "--tokens: [a, b] (c) { d: e; }" "[a, b] (c) { d: e; }";
@@ -2775,6 +2824,8 @@ let declaration_tests =
     test_case "custom properties basic" `Quick custom_properties_basic;
     test_case "custom properties" `Quick custom_properties;
     test_case "custom property values" `Quick custom_property_values;
+    test_case "parse_custom_property rejects an escaping pair" `Quick
+      parse_custom_property_guard;
     test_case "spec custom property token stream values" `Quick
       spec_custom_tokens;
     test_case "vendor prefixes" `Quick vendor_prefixes;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6450,6 +6450,101 @@ let customprops1_transitive_merge () =
        ~theme_defaults:(fun _ -> None)
        ":root,:host{--shadow:0 0 var(--spacing) black}")
 
+(* CSS Custom Properties L1 sec. 2.1: a custom property's value is a
+   [<declaration-value>], and CSS Syntax 3 sec. 8.2 bars an unmatched [}] / [)],
+   a top-level [;], a [<bad-string-token>] and an unterminated function from
+   one. [theme_defaults] is caller-supplied CSS text, so an answer that breaks
+   those rules is not a value the name resolves to: the reference stays live,
+   the sibling default still binds, and no rule, at-rule or second declaration
+   reaches the output. *)
+let theme_defaults_reject_escaping_value () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let src = ".a{color:var(--brand);background-color:var(--ok)}" in
+  let defaults brand = function
+    | "brand" -> Some brand
+    | "ok" -> Some "blue"
+    | _ -> None
+  in
+  let emit brand =
+    parse src
+    |> Css.resolve_theme ~theme_defaults:(defaults brand)
+    |> Css.to_string ~minify:true
+  in
+  let inline brand =
+    parse src
+    |> Css.resolve_theme ~theme:Css.Pp.String_set.empty
+         ~theme_defaults:(defaults brand)
+    |> Css.to_string ~minify:true
+  in
+  let bound =
+    ":root{--ok:blue}.a{color:var(--brand);background-color:var(--ok)}"
+  in
+  let inlined = ".a{color:var(--brand);background-color:blue}" in
+  List.iter
+    (fun (what, brand) ->
+      Alcotest.(check string)
+        (what ^ " binds nothing and leaves the sibling default")
+        bound (emit brand);
+      Alcotest.(check string)
+        (what ^ " stays a live reference while the rest inlines")
+        inlined (inline brand))
+    [
+      ("a value closing the block", "red}");
+      ("a value starting a sibling rule", "red}.evil{color:red");
+      ("a value starting a rule after a [;]", "red};.evil{color:red");
+      ("a value starting an at-rule", "red}@media print{.x{color:red}");
+      ("a value carrying a second declaration", "red;--evil:lime");
+      ("a value with an unmatched [)]", "red)");
+      ("an unterminated function", "rgb(1,2,3");
+      ("an unterminated string", "\"abc");
+      ("an empty value", "");
+    ];
+  (* A comment is consumed by tokenization (CSS Syntax 3 sec. 4.3.2), so
+     ["red/*"] is the one-token value ["red"] and does bind. *)
+  Alcotest.(check string)
+    "an unterminated comment leaves a value that binds"
+    ":root{--ok:blue;--brand:red}.a{color:var(--brand);background-color:var(--ok)}"
+    (emit "red/*")
+
+(* CSS Syntax 3 sec. 4.3.7: a [\X] escape carries any code point into an ident,
+   so [var(--x\3b y)] references the theme name ["x;y"]. A name that cannot be
+   written back as a single ident cannot be bound - and must not turn into some
+   other declaration ([y:red]) at root scope. *)
+let theme_defaults_reject_escaping_name () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let declarations sheet =
+    Css.statements sheet
+    |> List.concat_map (fun stmt ->
+        Option.value ~default:[] (Css.statement_declarations stmt))
+  in
+  List.iter
+    (fun (what, src, name) ->
+      let resolved =
+        parse src
+        |> Css.resolve_theme ~theme_defaults:(fun n ->
+            if n = name then Some "red" else None)
+      in
+      Alcotest.(check int)
+        (what ^ ": no statement is added")
+        1
+        (List.length (Css.statements resolved));
+      Alcotest.(check int)
+        (what ^ ": no declaration is added")
+        1
+        (List.length (declarations resolved)))
+    [
+      ("a name carrying a [;]", ".a{color:var(--x\\3b y)}", "x;y");
+      ("a name carrying a [}]", ".a{color:var(--x\\7d y)}", "x}y");
+    ]
+
 (* CSS Custom Properties L1 section 2: a [var()] used inside a fallback list
    ([var(--font, "Helvetica", sans-serif)]) inlines if the variable resolves,
    otherwise the fallback list is kept intact. *)
@@ -7196,6 +7291,12 @@ let additional_tests =
     ( "spec custom-properties 1 transitive theme var merges in place",
       `Quick,
       customprops1_transitive_merge );
+    ( "theme defaults reject a value that escapes its declaration",
+      `Quick,
+      theme_defaults_reject_escaping_value );
+    ( "theme defaults reject a name that escapes its declaration",
+      `Quick,
+      theme_defaults_reject_escaping_name );
     ( "spec custom-properties 1 fallback list with inlining",
       `Quick,
       customprops1_fallback_list );


### PR DESCRIPTION
`Css.resolve_theme` built its `:root` block by concatenating caller-supplied names and values into CSS text and reparsing it, so a `theme_defaults` value carrying a `}` or a top-level `;` could add a rule, an at-rule or a second declaration to the output, and a value that produced more than one statement silently dropped every theme default instead of just its own.

Each binding is now constructed as a declaration through `Css.Declaration.parse_custom_property`, which this PR adds: an answer that is not one custom-property declaration reads as no default at all, leaving that `var()` reference live and the other defaults untouched. `Css.Declaration.custom_property` still keeps a value verbatim and is unchanged here.