### PR TITLE
css: keep the custom property a style() container query reads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -337,6 +337,11 @@
   `inherits: false` that stops it inheriting, repainting the page; and the pass
   missed its own fixpoint, the second run pruning the declaration the first had
   kept (#416)
+- `Css.inline_vars` reads a `style()` container query as a reference to the
+  custom property it queries. CSS Conditional 5 sec. 6.2 evaluates the query
+  against that property's computed value, so deleting the declaration behind it,
+  or the `@property` registration standing in for one, leaves a block that no
+  longer matches (#423)
 - Pruning unreferenced custom properties counts a `var()` in a `@keyframes`
   frame, `@page` and its margin boxes, `@position-try` or
   `@supports-condition` as a reference, instead of deleting a binding those

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7841,7 +7841,9 @@ val inline_vars : ?keep_vars:string list -> ?warn:(string -> unit) -> t -> t
     [var()] reference; [warn] is called with each such name. The transform
     assumes no runtime mutation of the variables it inlines: a reference marked
     [~runtime] on {!var_ref} also stays live, fallback included, so a
-    browser-time override point survives.
+    browser-time override point survives. A [style()] container query reads the
+    computed value of the custom property it names, so that property stays live
+    as well.
 
     Every [@layer] wrapper is spliced into its parent and the [@layer-decl]
     rules ordering them go with it. A [@property] registration goes only when

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -801,14 +801,29 @@ let rec refs_of_supports : Supports.t -> string list = function
   | Not condition -> refs_of_supports condition
   | And (a, b) | Or (a, b) -> refs_of_supports a @ refs_of_supports b
 
+(* A style() query names a property; only a custom one is at risk here, and a
+   real property like [style(color: red)] keeps its value through substitution.
+   The name is dashed as written, so it needs no normalisation. *)
+let refs_of_queried_name name =
+  if String.length name >= 2 && String.sub name 0 2 = "--" then [ name ] else []
+
+(* CSS Conditional 5 sec. 6.2: a [style()] query is evaluated against the
+   computed value the queried property has on the query container, its boolean
+   form against that property's initial value. The queried name is therefore a
+   reference to whatever supplies that value, exactly like a [var()]: drop the
+   declaration and the block stops matching. *)
 let rec refs_of_style_query : Container.style_query -> string list = function
-  | Boolean _ -> []
-  | Declaration { value; _ } -> refs_of_components value
-  | Range { lower; upper; _ } ->
-      refs_of_components lower @ refs_of_components upper
+  | Boolean name -> refs_of_queried_name name
+  | Declaration { name; value } ->
+      refs_of_queried_name name @ refs_of_components value
+  | Range { lower; name; upper; _ } ->
+      refs_of_queried_name name @ refs_of_components lower
+      @ refs_of_components upper
   | All (a, b) | Any (a, b) -> refs_of_style_query a @ refs_of_style_query b
   | Neg query -> refs_of_style_query query
 
+(* CSS Conditional 5 sec. 6.3: scroll-state features are a fixed keyword set, so
+   a scroll-state query reads no custom property. *)
 let rec refs_of_scroll_state : Container.scroll_state_query -> string list =
   function
   | State _ -> []
@@ -818,6 +833,8 @@ let rec refs_of_scroll_state : Container.scroll_state_query -> string list =
 
 let rec refs_of_container : Container.t -> string list = function
   | Min_width_rem _ | Min_width_px _ -> []
+  (* A container name is a [<custom-ident>], so one spelled [--name] selects a
+     container and reads no custom property. *)
   | Named (_, query) | Not query -> refs_of_container query
   | Style { query; _ } -> refs_of_style_query query
   | Scroll_state { query; _ } -> refs_of_scroll_state query

--- a/lib/inline.mli
+++ b/lib/inline.mli
@@ -21,10 +21,10 @@ val vars :
 
 val mentioned_custom_names : Stylesheet.t -> string list
 (** [mentioned_custom_names stylesheet] is every custom-property name (leading
-    [--]) the stylesheet still mentions: declared by a declaration, or
-    referenced by a [var()] in a declaration or in an at-rule condition,
-    fallbacks included. A [@property] body is not a mention, so a registration
-    never keeps itself. *)
+    [--]) the stylesheet still mentions: declared by a declaration, referenced
+    by a [var()] in a declaration or in an at-rule condition (fallbacks
+    included), or queried by a [style()] container query. A [@property] body is
+    not a mention, so a registration never keeps itself. *)
 
 val decode_import_url : string -> string
 (** [decode_import_url s] strips the [url(...)] wrapper and any surrounding

--- a/test/inline/fixtures/style_query.html
+++ b/test/inline/fixtures/style_query.html
@@ -1,0 +1,11 @@
+<!doctype html><html><head><style>
+  :root { --theme: dark; --flag: on }
+  @property --tone { syntax: "<color>"; inherits: true; initial-value: teal }
+  .card { color: black; background: white; border: 2px solid black; outline: 2px solid black }
+  @container style(--theme: dark) { .card { color: lime; background: navy } }
+  @container style(--flag) { .card { border-color: orange } }
+  @container not style(--theme: dark) { .card { outline-color: fuchsia } }
+  @container style(--tone: teal) { .card { text-decoration-color: teal } }
+</style></head><body>
+<div class="wrap"><p class="card">card</p></div>
+</body></html>

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -419,6 +419,67 @@ let test_inline_property_idempotent () =
   check "an unused registration is a fixpoint"
     "@property --y{syntax:\"*\";inherits:false}.b{color:red}"
 
+(* CSS Conditional 5 sec. 6.2 (style container features): a [style()] query is
+   evaluated against the computed value the queried custom property has on the
+   query container, and its boolean form against that property's initial value.
+   The queried name is a reference like any [var()]: whatever supplies that
+   computed value decides whether the block applies at all. Chrome 146 paints
+   [.z] green for [:root{--c:red}@container style(--c:red){.z{color:green}}] and
+   black once [:root] loses the declaration. *)
+let test_inline_style_query_keeps_queried_property () =
+  check_inline_case "a declaration style() query keeps the property it reads"
+    ":root{--c:red}@container style(--c: red){.z{color:green}}"
+    ":root{--c:red}@container style(--c:red){.z{color:green}}";
+  check_inline_case "a boolean style() query keeps the property it tests"
+    ":root{--c:red}@container style(--c){.z{color:green}}"
+    ":root{--c:red}@container style(--c){.z{color:green}}";
+  check_inline_case "a queried property and the var() in its value both stay"
+    ":root{--c:red;--d:red}@container style(--c: var(--d)){.z{color:green}}"
+    ":root{--c:red;--d:red}@container style(--c:var(--d)){.z{color:green}}";
+  check_inline_case "a range style() query keeps the property it bounds"
+    ":root{--n:5}@container style(3 < --n < 10){.z{color:green}}"
+    ":root{--n:5}@container style(3<--n<10){.z{color:green}}";
+  check_inline_case "both sides of a combined style() query stay live"
+    ":root{--a:red;--b:blue}@container style(--a: red) and style(--b: \
+     blue){.z{color:green}}"
+    ":root{--a:red;--b:blue}@container style(--a:red) and \
+     style(--b:blue){.z{color:green}}";
+  (* Negation reverses which elements a lost declaration paints: with [--c] red
+     the block does not apply, without it the query is true and it does. *)
+  check_inline_case "a negated style() query keeps the property it tests"
+    ":root{--c:red}@container not style(--c: red){.z{color:green}}"
+    ":root{--c:red}@container not style(--c:red){.z{color:green}}";
+  check_inline_case "a named container's style() query keeps its property"
+    ":root{--c:red}@container tall style(--c: red){.z{color:green}}"
+    ":root{--c:red}@container tall style(--c:red){.z{color:green}}";
+  check_inline_case "a style() query nested under @media keeps its property"
+    ":root{--c:red}@media screen{@container style(--c: red){.z{color:green}}}"
+    ":root{--c:red}@media screen{@container style(--c:red){.z{color:green}}}"
+
+(* A style() query reads a computed value, so the [@property] registration that
+   supplies the initial value when nothing declares the property keeps the query
+   answerable. Chrome 146 paints [.z] green for the registration below and black
+   without it. *)
+let test_inline_style_query_keeps_registration () =
+  check_inline_case "a style() query keeps the registration it reads"
+    "@property \
+     --c{syntax:\"<color>\";inherits:false;initial-value:red}@container \
+     style(--c: red){.z{color:green}}"
+    "@property \
+     --c{syntax:\"<color>\";inherits:false;initial-value:red}@container \
+     style(--c:red){.z{color:green}}"
+
+(* The other half of the guard: a style() query keeps the property it names, not
+   every property in sight, and a container name is a custom-ident that happens
+   to be spelled with two dashes, not a custom property. *)
+let test_inline_style_query_keeps_no_more () =
+  check_inline_case "a style() query keeps only the property it names"
+    ":root{--c:red;--other:blue}@container style(--c: red){.z{color:green}}"
+    ":root{--c:red}@container style(--c:red){.z{color:green}}";
+  check_inline_case "a container name is not a reference to a custom property"
+    ":root{--c:red}@container --c (min-width:1px){.z{color:green}}"
+    "@container --c (min-width:1px){.z{color:green}}"
+
 let suite =
   ( "inline",
     [
@@ -472,4 +533,11 @@ let suite =
         test_inline_property_registration_dropped;
       Alcotest.test_case "inline vars reach a fixpoint on registrations" `Quick
         test_inline_property_idempotent;
+      Alcotest.test_case "inline vars keep the property a style() query reads"
+        `Quick test_inline_style_query_keeps_queried_property;
+      Alcotest.test_case
+        "inline vars keep the registration a style() query reads" `Quick
+        test_inline_style_query_keeps_registration;
+      Alcotest.test_case "inline vars keep no more than a style() query reads"
+        `Quick test_inline_style_query_keeps_no_more;
     ] )


### PR DESCRIPTION
`Css.inline_vars` deleted the declaration a `style()` container query is answered from, and the `@property` registration standing in for one, so the queried block silently stopped matching; the queried name now counts as a reference like any `var()`.

Stacked on #416, which the `@property` half depends on.