### PR TITLE
diff: read a declaration's overlap keys once, not once per pair

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -116,6 +116,11 @@
   `#p{font:16px serif}#mid{font-weight:bold}#c{font:16px serif}` left `#c`
   bold. `all` and a property cascade does not type reset everything, so neither
   is dropped either (#332)
+- `cascade diff` spends less time on a rule holding many declarations. Deciding
+  whether a reorder is significant asked each pair of declarations for its
+  overlap keys and for its position in the other rule, both of which name a
+  property through a fresh buffer, where each is a fact about one declaration.
+  `--minify` canonicalises a rule's declaration order the same way (#424)
 
 ## 1.1.0
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -338,15 +338,24 @@ let reorder_is_significant decls1 decls2 =
   ||
   let pos2 = Hashtbl.create 16 in
   List.iteri (fun i d -> Hashtbl.replace pos2 (name d) i) decls2;
-  let pos d = Option.value ~default:(-1) (Hashtbl.find_opt pos2 (name d)) in
   let arr = Array.of_list decls1 in
   let n = Array.length arr in
+  (* Both hoisted out of the pair loop: naming a declaration and reading its
+     overlap keys each serialize the property through a fresh buffer. *)
+  let pos =
+    Array.of_list
+      (List.map
+         (fun prop -> Option.value ~default:(-1) (Hashtbl.find_opt pos2 prop))
+         names1)
+  in
+  let footprints = Array.map Shorthand.declaration_overlap_keys arr in
   let flipped = ref false in
   for i = 0 to n - 1 do
     for j = i + 1 to n - 1 do
       if
-        Shorthand.declarations_overlap arr.(i) arr.(j)
-        && pos arr.(i) >= pos arr.(j)
+        Shorthand.declarations_overlap_with_keys arr.(i) footprints.(i) arr.(j)
+          footprints.(j)
+        && pos.(i) >= pos.(j)
       then flipped := true
     done
   done;

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -65,14 +65,19 @@ let is_identity order =
 
 (* Source-order-preserving edge count: [indeg.(j)] is the number of
    source-earlier declarations that overlap [j], which must all be emitted
-   before [j]. *)
-let overlap_indegrees (arr : Declaration.declaration array) : int array =
+   before [j]. [footprints] is the overlap key list of each declaration, hoisted
+   out of the pair loop: computing it names the property, which serializes the
+   declaration's property through a fresh buffer. *)
+let overlap_indegrees (arr : Declaration.declaration array) footprints :
+    int array =
   let n = Array.length arr in
   let indeg = Array.make n 0 in
   for j = 0 to n - 1 do
     for i = 0 to j - 1 do
-      if Shorthand.declarations_overlap arr.(i) arr.(j) then
-        indeg.(j) <- indeg.(j) + 1
+      if
+        Shorthand.declarations_overlap_with_keys arr.(i) footprints.(i) arr.(j)
+          footprints.(j)
+      then indeg.(j) <- indeg.(j) + 1
     done
   done;
   indeg
@@ -112,7 +117,8 @@ let canonical_declarations (decls : Declaration.declaration list) :
           (fun d -> Pp.to_string ~minify:true Declaration.pp_declaration d)
           arr
       in
-      let indeg = overlap_indegrees arr in
+      let footprints = Array.map Shorthand.declaration_overlap_keys arr in
+      let indeg = overlap_indegrees arr footprints in
       let emitted = Array.make n false in
       let order = Array.make n 0 in
       let changed = ref false in
@@ -122,7 +128,10 @@ let canonical_declarations (decls : Declaration.declaration list) :
         emitted.(b) <- true;
         order.(pos) <- b;
         for j = b + 1 to n - 1 do
-          if (not emitted.(j)) && Shorthand.declarations_overlap arr.(b) arr.(j)
+          if
+            (not emitted.(j))
+            && Shorthand.declarations_overlap_with_keys arr.(b) footprints.(b)
+                 arr.(j) footprints.(j)
           then indeg.(j) <- indeg.(j) - 1
         done
       done;


### PR DESCRIPTION
`allocated_words` for `diff --diff=tree` on one rule of 2000 distinct custom properties falls from 51.2M to 3.5M, and for `fmt --minify --lossless` on the same rule from 79.1M to 7.2M. Output is byte-identical on all 504 SatCSS fixtures, with and without `--lossless`, and on the 432 diff pairs drawn from them.