### PR TITLE
pp: spell a NaN value as the calc(NaN) form CSS defines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,12 @@
 
 ### Minification
 
+- A NaN-valued number prints as `calc(NaN)`, and a NaN-valued dimension as
+  `calc(NaN * 1unit)`, the forms CSS Values 4 sec. 10.13 defines. A bare `NaN`
+  is not a CSS token, so `width: calc(sqrt(-1) * 1px)` minifying to
+  `width: NaNpx` and `rotate: asin(-20)` to `rotate: NaNdeg` produced output
+  Chrome drops and cascade's own reader rejects. A math function whose value is
+  NaN keeps its function form instead of folding to a leaf (#425)
 - A same-condition `@media` block is no longer hoisted over a crossed rule
   whose shorthand writes a longhand the hoisted block also writes. The hoist
   tied two declarations by property name, so

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -340,6 +340,9 @@ let string_of_float ?(drop_leading_zero = false) ?(max_decimals = 8) f =
   (* Handle special cases first *)
   match classify_float f with
   | FP_zero -> "0"
+  (* Raw float formatting, not a CSS value sink: [Context] round-trips a float
+     through this and back with [float_of_string]. The CSS spelling of a NaN is
+     [nan_value]'s. *)
   | FP_nan -> "NaN"
   | FP_infinite when f > 0.0 -> "3.40282e38"
   | FP_infinite -> "-3.40282e38"
@@ -374,15 +377,29 @@ let int ctx i =
 (* An integer-valued float prints as that integer (see [format_integer]); take
    the allocation-free [int] path instead of building a string via
    [string_of_float]. The bound mirrors [format_integer]'s own guard. *)
+(* CSS Values 4 sec. 10.7.2: [NaN] is a keyword of the math-function grammar and
+   exists nowhere else, so a NaN-valued number has no literal spelling. Sec.
+   10.13 serialises it as [calc(NaN)], with [* 1<unit>] appended once the value
+   carries a unit. A bare [NaN] token is not CSS: browsers drop [width: NaNpx]
+   and [opacity: NaN], and so does cascade's own reader. *)
+let nan_value ctx suffix =
+  string ctx "calc(NaN";
+  if suffix <> "" then (
+    string ctx (if ctx.minify then "*1" else " * 1");
+    string ctx suffix);
+  char ctx ')'
+
 let float ctx f =
-  if Float.is_integer f && Float.abs f <= float_of_int max_int then
+  if Float.is_nan f then nan_value ctx ""
+  else if Float.is_integer f && Float.abs f <= float_of_int max_int then
     int ctx (int_of_float f)
   else string ctx (string_of_float ~drop_leading_zero:true f)
 
 let float_compact = float
 
 let float_n n ctx f =
-  if Float.is_integer f && Float.abs f <= float_of_int max_int then
+  if Float.is_nan f then nan_value ctx ""
+  else if Float.is_integer f && Float.abs f <= float_of_int max_int then
     int ctx (int_of_float f)
   else string ctx (string_of_float ~drop_leading_zero:true ~max_decimals:n f)
 
@@ -405,8 +422,10 @@ let hex ctx i =
   string ctx (to_hex i)
 
 let unit ctx f suffix =
-  float ctx f;
-  string ctx suffix
+  if Float.is_nan f then nan_value ctx suffix
+  else (
+    float ctx f;
+    string ctx suffix)
 
 let pct ctx f =
   (* CSS Values 4 sec. 6 only allows the unit to drop on a zero [<length>]; a
@@ -416,8 +435,10 @@ let pct ctx f =
      changes the value (a repeating fraction such as [33.333333%] from [w-1/3]
      would lose digits), so any precision reduction belongs in the optimizer,
      not here. *)
-  float ctx f;
-  string ctx "%"
+  if Float.is_nan f then nan_value ctx "%"
+  else (
+    float ctx f;
+    string ctx "%")
 
 let sep ctx s =
   string ctx s;

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -205,6 +205,11 @@ val string_of_float :
       instead of 0.5)
     - [max_decimals]: maximum decimal precision (default 8) *)
 
+val nan_value : ctx -> string -> unit
+(** [nan_value ctx suffix] writes the CSS spelling of a NaN-valued number:
+    [calc(NaN)], or [calc(NaN * 1suffix)] when [suffix] is a unit. CSS Values 4
+    sec. 10.13. *)
+
 val float : float t
 (** [float] formats floating point numbers with CSS rules:
     - Always drops leading zero for 0 < |n| < 1 (outputs .5 not 0.5)

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -365,7 +365,8 @@ let rec pp_timeline_inset : timeline_inset Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
 
 let pp_timing_float ctx f =
-  Pp.string ctx (Pp.string_of_float ~drop_leading_zero:(Pp.minified ctx) f)
+  if Float.is_nan f then Pp.nan_value ctx ""
+  else Pp.string ctx (Pp.string_of_float ~drop_leading_zero:(Pp.minified ctx) f)
 
 let pp_cubic_bezier_args : (float * float * float * float) Pp.t =
  fun ctx (a, b, c, d) ->

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -162,9 +162,7 @@ let rec pp_grid_template : grid_template Pp.t =
   (* CSS Grid 2 sec. 7.2.4: [<flex>] is [<number>fr]; the unit-drop rule is for
      [<length>] only. [0fr] is a zero flex factor, distinct from a [0]
      [<length>] in [grid-template]'s union grammar. *)
-  | Fr f ->
-      Pp.float ctx f;
-      Pp.string ctx "fr"
+  | Fr f -> Pp.unit ctx f "fr"
   | Auto -> Pp.string ctx "auto"
   | Min_content -> Pp.string ctx "min-content"
   | Max_content -> Pp.string ctx "max-content"

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -984,18 +984,10 @@ let rec pp_image_rendering : image_rendering Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
 
 let pp_resolution ctx = function
-  | Dpi f ->
-      Pp.float ctx f;
-      Pp.string ctx "dpi"
-  | Dpcm f ->
-      Pp.float ctx f;
-      Pp.string ctx "dpcm"
-  | Dppx f ->
-      Pp.float ctx f;
-      Pp.string ctx "dppx"
-  | X f ->
-      Pp.float ctx f;
-      Pp.char ctx 'x'
+  | Dpi f -> Pp.unit ctx f "dpi"
+  | Dpcm f -> Pp.unit ctx f "dpcm"
+  | Dppx f -> Pp.unit ctx f "dppx"
+  | X f -> Pp.unit ctx f "x"
 
 let rec pp_image_resolution : image_resolution Pp.t =
  fun ctx -> function

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -609,6 +609,12 @@ let pp_math_const ctx = function
   | Neg_infinity -> Pp.string ctx "-infinity"
   | Nan -> Pp.string ctx "NaN"
 
+(* Inside a math function [NaN] is a keyword of the grammar (CSS Values 4 sec.
+   10.7.2), so an operand spells a NaN with it; the [calc()] wrapper
+   {!Pp.nan_value} adds is for the positions outside one. *)
+let pp_calc_number ctx f =
+  if Float.is_nan f then pp_math_const ctx Nan else Pp.float ctx f
+
 let read_math_const t =
   match Cursor.ident_opt t with
   | Some name -> (
@@ -657,10 +663,8 @@ let rec minify_angle_arg : angle_arg -> angle_arg = function
   | arg -> arg
 
 let rec pp_math_arg ctx = function
-  | Lit f -> Pp.float ctx f
-  | Dim (f, unit_) ->
-      Pp.float ctx f;
-      Pp.string ctx unit_
+  | Lit f -> pp_calc_number ctx f
+  | Dim (f, unit_) -> Pp.unit ctx f unit_
   | Const c -> pp_math_const ctx c
   | Var_arg v -> pp_var pp_math_arg ctx v
   | Op (l, op, r) ->
@@ -708,18 +712,10 @@ and pp_math_fn ctx fn =
 
 and pp_angle_arg ctx arg =
   match if Pp.minified ctx then minify_angle_arg arg else arg with
-  | Deg f ->
-      Pp.float ctx f;
-      Pp.string ctx "deg"
-  | Rad f ->
-      Pp.float ctx f;
-      Pp.string ctx "rad"
-  | Turn f ->
-      Pp.float ctx f;
-      Pp.string ctx "turn"
-  | Grad f ->
-      Pp.float ctx f;
-      Pp.string ctx "grad"
+  | Deg f -> Pp.unit ctx f "deg"
+  | Rad f -> Pp.unit ctx f "rad"
+  | Turn f -> Pp.unit ctx f "turn"
+  | Grad f -> Pp.unit ctx f "grad"
   | Numeric_arg arg -> pp_math_arg ctx arg
   | Operation (l, op, r) ->
       pp_angle_arg ctx l;
@@ -806,6 +802,14 @@ and eval_math_fn fn =
         a
   | Abs_n a -> unary Float.abs a
 
+(* CSS Values 4 sec. 10.9.2: NaN belongs to a calculation tree and has no leaf
+   spelling outside one, so folding a math function down to a NaN would lose the
+   only form the value can take. Leave the function in place. *)
+let fold_math_fn fn =
+  match eval_math_fn fn with
+  | Some v when Float.is_nan v -> Option.None
+  | result -> result
+
 let rec math_arg_contains_var = function
   | Lit _ | Dim _ | Const _ -> false
   | Var_arg _ -> true
@@ -844,7 +848,7 @@ let pp_calc_contents : type a. a Pp.t -> a calc Pp.t =
   let rec pp_calc_inner ~parent_prec ~right_of_noncommut ctx = function
     | Val v -> pp_value ctx v
     | Var v -> pp_var pp_value ctx v
-    | Num n -> Pp.float ctx n
+    | Num n -> pp_calc_number ctx n
     | Math_const c -> pp_math_const ctx c
     | Math_fn fn -> pp_math_fn ctx fn
     | Sibling_index -> Pp.string ctx "sibling-index()"
@@ -1006,7 +1010,7 @@ let rec eval_calc : type a. ?ctx:calc_ctx -> a calc -> a calc =
   | Math_const _ as leaf -> leaf
   | Math_fn fn when math_fn_contains_var fn -> Math_fn fn
   | Math_fn fn -> (
-      match eval_math_fn fn with Some v -> Num v | None -> Math_fn fn)
+      match fold_math_fn fn with Some v -> Num v | None -> Math_fn fn)
   | Nested inner ->
       unwrap_grouping ~ctx ~rewrap:(fun r -> Nested r) (eval_calc ~ctx inner)
   | Parens inner ->
@@ -1129,13 +1133,15 @@ let pp_unit ?always:_ ctx f suffix =
      values ([.25rem], not [0.25rem]) in both modes; under minify round to 6
      significant digits so a [calc()]-folded result emits [70.7107px] rather
      than an 8-decimal float. *)
-  let rendered =
-    if Pp.minified ctx then
-      Pp.string_of_float ~drop_leading_zero:true (Pp.round_sig 6 f)
-    else Pp.string_of_float ~drop_leading_zero:true f
-  in
-  Pp.string ctx rendered;
-  Pp.string ctx suffix
+  if Float.is_nan f then Pp.nan_value ctx suffix
+  else
+    let rendered =
+      if Pp.minified ctx then
+        Pp.string_of_float ~drop_leading_zero:true (Pp.round_sig 6 f)
+      else Pp.string_of_float ~drop_leading_zero:true f
+    in
+    Pp.string ctx rendered;
+    Pp.string ctx suffix
 
 (** Try to evaluate a calc expression containing only numbers to a float.
     Returns None if the expression contains variables or non-numeric values. *)
@@ -3359,6 +3365,9 @@ let rec pp_angle : angle Pp.t =
           Pp.comma ctx ();
           pp_angle ctx b)
         ctx (a, b)
+  (* A math function is itself an [<angle>] production, so the [calc()] around
+     one is redundant (CSS Values 4 sec. 10.8). *)
+  | Calc (Math_fn fn) -> pp_math_fn ctx fn
   | Calc c -> pp_calc_presolved pp_angle ctx c
   | Var v -> pp_var pp_angle ctx v
   | Invalid tokens ->
@@ -3408,10 +3417,8 @@ let rec pp_alpha : alpha Pp.t =
       let max_decimals =
         if Pp.minified ctx && not ctx.Pp.lossless then 3 else 8
       in
-      Pp.string ctx (Pp.string_of_float ~drop_leading_zero:true ~max_decimals f)
-  | Pct f ->
-      Pp.float ctx f;
-      Pp.char ctx '%'
+      Pp.float_n max_decimals ctx f
+  | Pct f -> Pp.pct ctx f
   | Var v -> pp_var pp_alpha ctx v
   | Calc c -> pp_calc pp_alpha ctx c
 
@@ -3602,7 +3609,7 @@ let eval_pct_calc ?(ctx = default_calc_ctx) (c : percentage calc) :
     percentage calc =
   eval_typed_calc
     ~math_fn:(fun fn ->
-      match eval_math_fn fn with Some v -> Num v | None -> Math_fn fn)
+      match fold_math_fn fn with Some v -> Num v | None -> Math_fn fn)
     ~scale:(fun ~exact op v n -> pct_scale ~exact op v n)
     ~combine:pct_combine ~is_zero:pct_is_zero
     ~zero:(Val (Pct 0.) : percentage calc)
@@ -3645,7 +3652,7 @@ let eval_time_calc ?(ctx = default_calc_ctx) (c : duration calc) : duration calc
     =
   eval_typed_calc
     ~math_fn:(fun fn ->
-      match eval_math_fn fn with Some v -> Num v | None -> Math_fn fn)
+      match fold_math_fn fn with Some v -> Num v | None -> Math_fn fn)
     ~scale:(fun ~exact op v n -> time_scale ~exact op v n)
     ~combine:time_combine ~is_zero:time_is_zero
     ~zero:(Val (S 0.) : duration calc)
@@ -3693,7 +3700,7 @@ let angle_combine op (a : angle) (b : angle) : angle option =
 let eval_angle_calc ?(ctx = default_calc_ctx) (c : angle calc) : angle calc =
   eval_typed_calc
     ~math_fn:(fun fn ->
-      match eval_math_fn fn with Some v -> Num v | None -> Math_fn fn)
+      match fold_math_fn fn with Some v -> Num v | None -> Math_fn fn)
     ~scale:(fun ~exact op v n -> angle_scale ~exact op v n)
     ~combine:angle_combine ~is_zero:angle_is_zero ~zero:(Val (Deg 0.)) ~ctx c
 
@@ -3839,7 +3846,7 @@ let eval_np_calc ?(ctx = default_calc_ctx) (c : number_percentage calc) :
     number_percentage calc =
   eval_typed_calc
     ~math_fn:(fun fn ->
-      match eval_math_fn fn with Some v -> Num v | None -> Math_fn fn)
+      match fold_math_fn fn with Some v -> Num v | None -> Math_fn fn)
     ~scale:(fun ~exact op v n -> np_scale ~exact op v n)
     ~combine:np_combine ~is_zero:np_is_zero
     ~zero:(Val (Num 0.) : number_percentage calc)
@@ -4146,7 +4153,7 @@ let pp_hwb = Pp.call "hwb" pp_hue_pct_pct_alpha
     ~ 0.004 so 3 decimals is more than display-accurate. *)
 let pp_float_drop_zero ctx f =
   let max_decimals = if Pp.minified ctx && not ctx.Pp.lossless then 3 else 8 in
-  Pp.string ctx (Pp.string_of_float ~drop_leading_zero:true ~max_decimals f)
+  Pp.float_n max_decimals ctx f
 
 let pp_alpha_drop_zero : alpha Pp.t =
  fun ctx -> function
@@ -4596,6 +4603,7 @@ and pp_duration_in_calc : duration Pp.t =
 
 let rec pp_number : number Pp.t =
  fun ctx -> function
+  | Num f when Float.is_nan f -> Pp.nan_value ctx ""
   | Num f ->
       Pp.string ctx (Pp.string_of_float ~drop_leading_zero:(Pp.minified ctx) f)
   | Var v -> pp_var pp_number ctx v
@@ -5888,17 +5896,34 @@ let angle_trig_function t =
 
 let read_angle_trig kind name t =
   let typed t =
-    Cursor.call name t (fun inner ->
-        let v = read_num_expr inner in
-        Cursor.ws inner;
-        Cursor.expect_eof inner;
-        let radians =
-          match kind with
-          | `Asin -> Float.asin v
-          | `Acos -> Float.acos v
-          | `Atan -> Float.atan v
-        in
-        (Deg (radians *. 180. /. Float.pi) : angle))
+    let snapshot = Cursor.save t in
+    let degrees =
+      Cursor.call name t (fun inner ->
+          let v = read_num_expr inner in
+          Cursor.ws inner;
+          Cursor.expect_eof inner;
+          let radians =
+            match kind with
+            | `Asin -> Float.asin v
+            | `Acos -> Float.acos v
+            | `Atan -> Float.atan v
+          in
+          radians *. 180. /. Float.pi)
+    in
+    if Float.is_nan degrees then (
+      (* CSS Values 4 sec. 10.9.2: NaN lives inside a calculation tree and
+         nowhere else, so it has no leaf spelling. Re-read the call and keep the
+         function the author wrote. *)
+      Cursor.restore t snapshot;
+      let arg = read_math_call_arg name t in
+      let fn : math_fn =
+        match kind with
+        | `Asin -> Asin arg
+        | `Acos -> Acos arg
+        | `Atan -> Atan arg
+      in
+      (Calc (Math_fn fn) : angle))
+    else Deg degrees
   in
   match Cursor.try_typed_call typed t with
   | Ok value -> value
@@ -7034,7 +7059,7 @@ let alpha_is_zero : alpha -> bool = function
 let eval_alpha_calc ?(ctx = default_calc_ctx) (c : alpha calc) : alpha calc =
   eval_typed_calc
     ~math_fn:(fun fn ->
-      match eval_math_fn fn with Some v -> Num v | None -> Math_fn fn)
+      match fold_math_fn fn with Some v -> Num v | None -> Math_fn fn)
     ~scale:(fun ~exact op v n -> alpha_scale ~exact op v n)
     ~combine:alpha_combine ~is_zero:alpha_is_zero
     ~zero:(Val (Num 0.) : alpha calc)

--- a/test/test_pp.ml
+++ b/test/test_pp.ml
@@ -92,8 +92,11 @@ let float_zero_and_nan_inf () =
   check_float infinity ~expected:"3.40282e38";
   check_float neg_infinity ~expected:"-3.40282e38";
 
-  (* NaN stays as NaN per CSS spec *)
-  check_float nan ~expected:"NaN"
+  (* A bare [NaN] is not a CSS token. CSS Values 4 sec. 10.7.2 puts the [NaN]
+     keyword in the math-function grammar and nowhere else, and sec. 10.13
+     serialises a NaN-valued number as [calc(NaN)]; Chrome drops [opacity: NaN]
+     and keeps [opacity: calc(NaN)]. *)
+  check_float nan ~expected:"calc(NaN)"
 
 let float_rounding_and_trim () =
   (* Rounding with float_n *)
@@ -146,6 +149,82 @@ let float_large_decimal_in_stylesheet () =
   check_sheet "scale" "a{transform:scale(123456789012.25)}"
     "a{transform:scale(123456789012)}";
   check_sheet "opacity" "b{opacity:calc(999999999999.75)}" "b{opacity:1e12}"
+
+(* CSS Values 4 sec. 10.7.2 puts the [NaN] keyword in the math-function grammar
+   and nowhere else, and sec. 10.9.2 keeps NaN inside a calculation tree, so a
+   value that is NaN has no bare spelling. Chrome drops [width: NaNpx],
+   [opacity: NaN] and [rotate: NaNdeg] as invalid, and computes each expected
+   form below to the same value as its input. Whatever cascade prints has to
+   survive its own reader unchanged. *)
+let nan_never_prints_as_a_bare_token () =
+  let check_sheet name input expected =
+    match of_string ~strict:true input with
+    | Error e -> failf "%s: %s" name (Pp.to_string Error.pp e)
+    | Ok { stylesheet; _ } -> (
+        let printed = to_string ~minify:true (optimize stylesheet) in
+        check string name expected printed;
+        match of_string ~strict:true printed with
+        | Error e ->
+            failf "%s: %S does not re-read: %s" name printed
+              (Pp.to_string Error.pp e)
+        | Ok { stylesheet = again; _ } ->
+            check string
+              (Fmt.str "%s is a fixpoint" name)
+              printed
+              (to_string ~minify:true (optimize again)))
+  in
+  check_sheet "length" ".a{width:calc(sqrt(-1) * 1px)}"
+    ".a{width:calc(NaN*1px)}";
+  check_sheet "relative length" ".a{width:calc(log(-1) * 1em)}"
+    ".a{width:calc(NaN*1em)}";
+  check_sheet "percentage" ".a{width:calc(sqrt(-1) * 1%)}"
+    ".a{width:calc(NaN*1%)}";
+  check_sheet "comparison function" ".a{opacity:min(sqrt(-1),1)}"
+    ".a{opacity:calc(NaN)}";
+  check_sheet "stepped value function" ".a{opacity:calc(rem(1,0))}"
+    ".a{opacity:calc(NaN)}";
+  (* A function the fold leaves alone keeps the form the author wrote, which is
+     the same calculation tree and the same value. *)
+  check_sheet "number" ".a{opacity:calc(sqrt(-1))}" ".a{opacity:calc(sqrt(-1))}";
+  check_sheet "time" ".a{transition-duration:calc(sqrt(-1) * 1s)}"
+    ".a{transition-duration:calc(sqrt(-1)*1s)}";
+  check_sheet "number in a function" ".a{transform:scale(calc(sqrt(-1)))}"
+    ".a{transform:scale(calc(sqrt(-1)))}";
+  check_sheet "inverse trigonometry" ".a{rotate:asin(-20)}"
+    ".a{rotate:asin(-20)}";
+  check_sheet "custom property" ".a{--x:calc(sqrt(-1))}"
+    ".a{--x:calc(sqrt(-1))}"
+
+(* A NaN reaching the printer from the typed API still has to come out as CSS.
+   Sec. 10.13 serialises it as [calc(NaN)], with [* 1<unit>] appended once the
+   value carries a unit. *)
+let nan_leaf_serializes_as_a_math_function () =
+  let check_decl name declaration expected =
+    let printed =
+      to_string ~minify:true
+        (v [ rule ~selector:(Selector.class_ "a") [ declaration ] ])
+    in
+    check string name expected printed;
+    match of_string ~strict:true printed with
+    | Error e ->
+        failf "%s: %S does not re-read: %s" name printed
+          (Pp.to_string Error.pp e)
+    | Ok { stylesheet; _ } ->
+        check string
+          (Fmt.str "%s is a fixpoint" name)
+          printed
+          (to_string ~minify:true stylesheet)
+  in
+  check_decl "length" (width (Px Float.nan)) ".a{width:calc(NaN*1px)}";
+  check_decl "relative length" (width (Em Float.nan)) ".a{width:calc(NaN*1em)}";
+  check_decl "percentage" (width (Pct Float.nan)) ".a{width:calc(NaN*1%)}";
+  check_decl "number"
+    (opacity (Opacity_number Float.nan))
+    ".a{opacity:calc(NaN)}";
+  check string "bare number" "calc(NaN)"
+    (Pp.to_string ~minify:true Pp.float Float.nan);
+  check string "angle" "calc(NaN*1deg)"
+    (Pp.to_string ~minify:true Css.pp_angle (Deg Float.nan))
 
 let cond_case () =
   let pp = Pp.cond (fun ctx -> not (Pp.minified ctx)) Pp.string Pp.nop in
@@ -202,6 +281,10 @@ let suite =
         float_large_decimal_reparses;
       Alcotest.test_case "float large decimal in stylesheet" `Quick
         float_large_decimal_in_stylesheet;
+      Alcotest.test_case "nan never prints as a bare token" `Quick
+        nan_never_prints_as_a_bare_token;
+      Alcotest.test_case "nan leaf serializes as a math function" `Quick
+        nan_leaf_serializes_as_a_math_function;
       Alcotest.test_case "cond" `Quick cond_case;
       Alcotest.test_case "space if pretty" `Quick space_if_pretty_case;
       Alcotest.test_case "combinations" `Quick combinations;


### PR DESCRIPTION
`width: calc(sqrt(-1) * 1px)` minified to `width: NaNpx` and `rotate: asin(-20)` to `rotate: NaNdeg`, which Chrome drops and cascade's own reader rejects, so a second `fmt --minify` pass exits 1 on the first pass's output. CSS Values 4 sec. 10.13 spells such a value `calc(NaN)`, or `calc(NaN * 1unit)` once it carries a unit, and a fold that would produce one keeps the math function instead.

This flips an existing oracle: `test/test_pp.ml` asserted `Pp.float nan` prints a bare `NaN` "per CSS spec", but the `NaN` keyword lives only inside a math function and Chrome drops `opacity: NaN`.