### PR TITLE
selector: keep pseudo-elements out of :not()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,12 @@
   but pseudo-classes after a pseudo-element and sec. 4.5 keeps pseudo-elements
   out of `:has()`, whatever the pseudo-element's name, and Chrome and WebKit
   drop every selector that breaks either rule (#418)
+- `:not()` rejects a pseudo-element in its argument, as `:has()` already did,
+  so `.a:not(::before)` no longer parses and prints back as `.a:not(:before)`.
+  Selectors 4 sec. 4.3 gives `:not()` a `<complex-real-selector-list>`, built
+  by sec. 16 out of compound selectors with no pseudo-element among them, and
+  the list is unforgiving, so Chrome and WebKit drop the whole rule where
+  `:is()` and `:where()` drop only the offending item (#426)
 - A `<custom-ident>` or `<dashed-ident>` an at-rule prelude or a declaration
   value names is printed with the escapes CSS Syntax 3 sec. 4.3.7 needs to read
   it back as the same name. `@layer a\3b b` printed `@layer a;b`, two

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -1336,11 +1336,16 @@ and read_has_content t =
 
 and read_not_content t =
   let selectors = read_complex_list t in
-  (* CSS Selectors 4 sec. 4.3: [:not()] is non-forgiving, so an unknown selector
-     inside it invalidates the whole rule. Top-level lists keep unknown
-     pseudo-classes for forward compatibility. *)
+  (* CSS Selectors 4 sec. 4.3: [:not()] takes a [<complex-real-selector-list>],
+     which sec. 16 builds out of [<compound-selector>]s alone, with no
+     [<pseudo-compound-selector>] and so no pseudo-element. It is also
+     non-forgiving, so a pseudo-element or an unknown selector anywhere in the
+     argument invalidates the whole rule instead of just its own item. Top-level
+     lists keep unknown pseudo-classes for forward compatibility. *)
   List.iter
     (fun sel ->
+      if has_pseudo_element sel then
+        Cursor.err t ":not() cannot contain pseudo-elements";
       if has_unknown_pseudo_class sel then
         Cursor.err t ":not() cannot contain an unknown pseudo-class")
     selectors;

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -780,6 +780,46 @@ let pseudo_element_compound_guard () =
       neg_cursor read (String.concat "" [ ".a:has("; pe; ")" ]))
     pseudo_element_spellings
 
+(* Selectors 4 sec. 16 builds both argument lists of the logical combinations
+   out of [<complex-real-selector>], which is [<compound-selector> [
+   <combinator>? <compound-selector> ]*] and so has no room for a
+   [<pseudo-compound-selector>]: sec. 4.3 spells that out for [:not()]
+   ("Pseudo-elements cannot be represented by the negation pseudo-class; they
+   are not valid within :not()"), sec. 4.2 for [:is()], sec. 4.4 gives
+   [:where()] the syntax of [:is()], and sec. 4.5 keeps them out of [:has()] as
+   well.
+
+   What a caller sees differs, because [:is()] and [:where()] take a
+   [<forgiving-selector-list>] (sec. 16.1: parse each item, drop the ones that
+   fail) while [:not()] and [:has()] do not: the pseudo-element takes the item
+   with it in the first pair and the whole selector in the second. Chrome 151
+   and WebKit 26.5 agree on both halves - they drop every rule the negatives
+   build, and keep every rule the positives build (Chrome prunes the dead item
+   from its [cssRules] readback, WebKit leaves it in place). *)
+let logical_combinator_pseudo_element () =
+  let concat = String.concat "" in
+  List.iter
+    (fun pe ->
+      (* Unforgiving: the pseudo-element invalidates the whole selector,
+         wherever in the argument it sits and however the two nest. *)
+      neg_cursor read (concat [ ".a:not("; pe; ")" ]);
+      neg_cursor read (concat [ ".a:not("; pe; ",.b)" ]);
+      neg_cursor read (concat [ ".a:not(.b "; pe; ")" ]);
+      neg_cursor read (concat [ ".a:not(:not("; pe; "))" ]);
+      neg_cursor read (concat [ ".a:has("; pe; ",.b)" ]);
+      neg_cursor read (concat [ ".a:has(:not("; pe; "))" ]);
+      neg_cursor read (concat [ ".a:not(:has("; pe; "))" ]);
+      (* Forgiving: only the item carrying the pseudo-element goes. *)
+      check_minified_to ".a:is()" (concat [ ".a:is("; pe; ")" ]);
+      check_minified_to ".a:where()" (concat [ ".a:where("; pe; ")" ]);
+      check_minified_to ".a:is(.b)" (concat [ ".a:is("; pe; ",.b)" ]);
+      check_minified_to ".a:is()" (concat [ ".a:is(:not("; pe; "))" ]);
+      check_minified_to ".a:where()" (concat [ ".a:where(:not("; pe; "))" ]);
+      check_minified_to ".a:not(:is())" (concat [ ".a:not(:is("; pe; "))" ]);
+      check_minified_to ".a:not(:where())"
+        (concat [ ".a:not(:where("; pe; "))" ]))
+    pseudo_element_spellings
+
 let parse_errors_nesting_depth () =
   (* A pathologically deep functional-pseudo-class nest is capped rather than
      driving the per-level selector validation into super-linear time (a
@@ -1851,6 +1891,8 @@ let suite =
       test_case "parse errors - pseudo" `Quick parse_errors_pseudo;
       test_case "pseudo-element compound guard" `Quick
         pseudo_element_compound_guard;
+      test_case "logical combinator pseudo-element" `Quick
+        logical_combinator_pseudo_element;
       test_case "parse errors - nesting depth" `Quick parse_errors_nesting_depth;
       test_case "parse errors - empty list" `Quick parse_errors_empty_list;
       test_case "parse errors - complex" `Quick parse_errors_complex;


### PR DESCRIPTION
`.a:not(::before)` used to parse and print back as `.a:not(:before)`: `:not()` guarded its argument against unknown pseudo-classes but never against pseudo-elements, where Selectors 4 sec. 4.3 gives it a `<complex-real-selector-list>` that sec. 16 builds without one. The list is unforgiving, so Chrome 151 and WebKit 26.5 drop the whole rule, unlike the forgiving `:is()` and `:where()` that drop only the offending item, and the new test pins both halves of that split across every `::` spelling.

Stacked on #418.