### PR TITLE
media: accept the unitless zero a length feature allows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,12 @@
   only a negative value illegal, having dropped SVG 1.1's "at least 1" rule
   because CSS parsers never enforced it, and `stroke-miterlimit: 0.5` was
   rejected outright (#334)
+- A media or container size feature takes the unitless zero CSS Values 4 sec. 5
+  allows for a zero `<length>`, which Media Queries 4 sec. 1.3 inherits.
+  `@media (min-width: 0)`, `(width >= 0)` and `@container (min-width: 0)` were
+  rejected, and the at-rule went down with the condition, taking every rule
+  inside it at exit 0. The allowance is `<length>`-only, so
+  `(min-resolution: 0)` stays invalid (#427)
 - A descending `@font-face` descriptor range such as `font-weight: 700 400`
   parses without a warning and `Css.of_string ~strict:true` accepts it. CSS
   Fonts 4 sec. 4.4 has the user agent swap the endpoints for font matching, so

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -673,6 +673,27 @@ let range_feature_name (name : name) =
 let prefixed_range_feature_name name : name option =
   match name with Min base | Max base -> Some base | _ -> Option.None
 
+(* CSS Values 4 sec. 5 writes a zero [<length>] as the unitless number [0], and
+   Media Queries 4 sec. 1.3 takes its units from CSS Values, so a length-typed
+   feature accepts a bare zero. The allowance is [<length>]-only: a
+   [<resolution>] keeps its unit, which is why [(min-resolution: 0)] stays
+   invalid. *)
+let length_feature_name (name : name) =
+  match name with
+  | Width | Height | Inline_size | Block_size -> true
+  | _ -> false
+
+let unitless_zero_length (name : name) value =
+  let base =
+    match prefixed_range_feature_name name with
+    | Some base -> base
+    | None -> name
+  in
+  match value with
+  | (Integer 0 | Number 0.) when length_feature_name base ->
+      Length (Values_intf.Px 0.)
+  | _ -> value
+
 let validate_plain_feature (name : name) value =
   let plain_name =
     match prefixed_range_feature_name name with
@@ -805,6 +826,7 @@ let plain_feature_of_components name components =
   match value_of_components_opt components with
   | Some value ->
       let name = name_of_string name in
+      let value = unitless_zero_length name value in
       if validate_plain_feature name value then Some (plain_feature name value)
       else Option.None
   | Option.None -> Option.None
@@ -813,6 +835,7 @@ let name_first_range name op components =
   match (split_cmp components, value_of_components_opt components) with
   | Option.None, Some value ->
       let name = name_of_string name in
+      let value = unitless_zero_length name value in
       if validate_range_feature name value then Some (Range (name, op, value))
       else Option.None
   | Some _, _ | Option.None, Option.None -> Option.None
@@ -822,6 +845,7 @@ let range_rev_of_components lower op1 = function
       match ident_component name_component with
       | Some name ->
           let name = name_of_string name in
+          let lower = unitless_zero_length name lower in
           if validate_range_feature name lower then
             Some (Range_rev (lower, op1, name))
           else Option.None
@@ -834,6 +858,8 @@ let interval_of_components lower op1 name_components op2 upper_components =
       match ident_component name_component with
       | Some name ->
           let name = name_of_string name in
+          let lower = unitless_zero_length name lower in
+          let upper = unitless_zero_length name upper in
           if
             interval_ops_compatible op1 op2
             && validate_range_feature name lower

--- a/test/cli/media_unitless_zero.t
+++ b/test/cli/media_unitless_zero.t
@@ -1,0 +1,43 @@
+CLI: a unitless zero in a media feature keeps the at-rule.
+
+CSS Values 4 sec. 5 spells a zero `<length>` as the bare number `0`, and
+Media Queries 4 sec. 1.3 takes its units from CSS Values. Chrome matches
+`@media (min-width: 0)` against a live document, so the whole at-rule and
+every rule inside it have to survive the parse.
+
+  $ cat > zero.css <<EOF
+  > .keep { color: blue }
+  > @media (min-width: 0) { .a { color: red } }
+  > EOF
+  $ cascade fmt --minify zero.css
+  .keep{color:#00f}@media(width>=0px){.a{color:red}}
+
+The unit is the only difference: spelling the same query with `0px` has
+always worked.
+
+  $ cat > unit.css <<EOF
+  > .keep { color: blue }
+  > @media (min-width: 0px) { .a { color: red } }
+  > EOF
+  $ cascade fmt --minify unit.css
+  .keep{color:#00f}@media(width>=0px){.a{color:red}}
+
+A non-zero unitless number is still not a length, so that query is the
+one that recovers, and only that one.
+
+  $ cat > one.css <<EOF
+  > .keep { color: blue }
+  > @media (min-width: 1) { .a { color: red } }
+  > EOF
+  $ cascade fmt --minify one.css 2> /dev/null
+  .keep{color:#00f}
+
+The range and container spellings take the zero too.
+
+  $ cat > range.css <<EOF
+  > @media (width >= 0) { .a { color: red } }
+  > @media (0 <= width) { .b { color: red } }
+  > @container (min-width: 0) { .c { color: red } }
+  > EOF
+  $ cascade fmt --minify range.css
+  @media(width>=0px){.a{color:red}}@media(0px<=width){.b{color:red}}@container(width>=0px){.c{color:red}}

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -183,6 +183,20 @@ let spec_container_invalid_vectors () =
       rejects_invalid row.input)
     Cascade_spec_inventory.Query_grammar.container_negative
 
+(* A container size feature carries the same [<length>] as a media feature (CSS
+   Containment 3 sec. 4), so it takes the unitless zero CSS Values 4 sec. 5
+   allows. Chrome matches [@container (min-width: 0)] and [@container
+   (min-inline-size: 0)] against a live container. *)
+let spec_container_unitless_zero_length () =
+  let open Css.Container in
+  let check name input expected =
+    Alcotest.(check string) name expected (to_string (of_string input))
+  in
+  check "min-width" "(min-width: 0)" "(min-width:0px)";
+  check "min-inline-size" "(min-inline-size: 0)" "(min-inline-size: 0px)";
+  check "range" "(width >= 0)" "(width >= 0px)";
+  rejects_invalid "(min-width: 1)"
+
 let tests =
   Alcotest.
     [
@@ -202,6 +216,8 @@ let tests =
         spec_container_query_vectors;
       test_case "spec container invalid query vectors" `Quick
         spec_container_invalid_vectors;
+      test_case "spec container unitless zero length" `Quick
+        spec_container_unitless_zero_length;
     ]
 
 let suite = ("container", tests)

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -452,6 +452,36 @@ let negated_all_is_level4_not () =
   check_modes "bare not all" "@media not all{a{color:red}}"
     ~default:"@media not all{a{color:red}}" ~spec:"@media not all{a{color:red}}"
 
+(* CSS Values 4 sec. 5 writes a zero [<length>] as the unitless number [0], and
+   Media Queries 4 sec. 1.3 takes its units from CSS Values, so a length-typed
+   media feature accepts a bare zero. Chrome matches [@media (min-width: 0)],
+   [(min-height: 0)], [(width >= 0)], [(0 <= width)] and [@container (min-width:
+   0)] against a live document; it does not match [(min-resolution: 0)] or
+   [(min-width: 1)], where no unitless spelling exists. *)
+let spec_media_unitless_zero_length () =
+  let check_raw name input expected =
+    Alcotest.(check string) name expected (to_string (of_string input))
+  in
+  check_raw "plain prefixed feature" "(min-width: 0)" "(min-width: 0px)";
+  check_raw "plain height feature" "(min-height: 0)" "(min-height: 0px)";
+  check_raw "plain equality feature" "(width: 0)" "(width: 0px)";
+  check_raw "name-first range" "(width >= 0)" "(width >= 0px)";
+  check_raw "value-first range" "(0 <= width)" "(0px <= width)";
+  check_raw "interval range" "(0 <= width <= 60em)" "(0px <= width <= 60em)";
+  check_raw "fractional zero" "(min-width: 0.0)" "(min-width: 0px)";
+  check_raw "negative zero" "(min-width: -0)" "(min-width: 0px)";
+  Alcotest.(check bool)
+    "unitless zero is the zero length" true
+    (equal (of_string "(min-width: 0)") (min_width 0.));
+  (* The allowance is [<length>]-only: a [<resolution>] has no unitless zero,
+     and a non-zero number is not a length in any feature. *)
+  let check_recovers name input =
+    Alcotest.(check string) name "not all" (to_string (of_string input))
+  in
+  check_recovers "resolution has no unitless zero" "(min-resolution: 0)";
+  check_recovers "non-zero number is not a length" "(min-width: 1)";
+  check_recovers "non-zero number in a range" "(width >= 1)"
+
 let suite =
   let open Alcotest in
   ( "media",
@@ -463,6 +493,8 @@ let suite =
         spec_media_structural_vectors;
       test_case "spec media query error recovery vectors" `Quick
         spec_media_error_recovery_vectors;
+      test_case "spec media unitless zero length" `Quick
+        spec_media_unitless_zero_length;
       test_case "kind" `Quick test_kind;
       test_case "kind follows meaning not spelling" `Quick
         kind_follows_meaning_not_spelling;


### PR DESCRIPTION
`@media (min-width: 0)` used to lose the at-rule and every rule inside it at exit 0; it now parses like `(min-width: 0px)`. CSS Values 4 sec. 5 spells a zero `<length>` as the bare number `0` and Media Queries 4 sec. 1.3 takes its units from CSS Values, and Chrome matches the query against a live document.

The allowance is `<length>`-only, so `(min-resolution: 0)` stays invalid, which Chrome agrees with.