### PR TITLE
css: check the pair custom_property is handed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,15 @@
   take every other theme default down with it.
   `Css.Declaration.parse_custom_property` is the checked constructor the
   resolver builds each binding with (#421)
+- `Css.Declaration.custom_property` refuses a name and value it cannot write
+  back as the one declaration they name, instead of storing the token stream
+  unchecked: `custom_property "--a" "red;--b:blue"` wrote a second declaration,
+  `"red} .evil{color:lime"` closed the rule and opened another, `"rgb(1,2,3"`
+  gained a closing parenthesis it was never given, `"\"abc"` left a string open
+  across the rest of the sheet, and a name carrying a `}` destroyed the rule
+  around it. The pair it takes is a `<dashed-ident>` name and the
+  `<declaration-value>?` CSS Variables 1 sec. 2 gives a custom property, the
+  check `parse_custom_property` already made (#428)
 - `Css.inline_vars` preserves runtime-marked `var()` references, including
   typed fallbacks simplified through scalar values or shorthands, instead of
   replacing browser-time override points with compile-time defaults (#315)

--- a/fuzz/fuzz_declaration.ml
+++ b/fuzz/fuzz_declaration.ml
@@ -117,15 +117,19 @@ let test_custom_property_serialization_shape buf =
     ^ string_of_int (if String.length buf = 0 then 0 else Char.code buf.[0])
   in
   let value = cssish buf in
-  let decl = Css.Declaration.custom_property name value in
-  let serialized = serialize decl in
-  if not (starts_with ~prefix:(name ^ ":") serialized) then
-    failf "custom property lost its name: %S" serialized;
-  match parse_declaration serialized with
-  | None -> ()
-  | Some reparsed ->
-      if Css.Declaration.property_name reparsed <> name then
-        fail "custom property name changed after reparse"
+  (* [custom_property] refuses a value it cannot write back as one declaration,
+     so the shape holds over the pairs it accepts. *)
+  match Css.Declaration.custom_property name value with
+  | exception Failure _ -> ()
+  | decl -> (
+      let serialized = serialize decl in
+      if not (starts_with ~prefix:(name ^ ":") serialized) then
+        failf "custom property lost its name: %S" serialized;
+      match parse_declaration serialized with
+      | None -> ()
+      | Some reparsed ->
+          if Css.Declaration.property_name reparsed <> name then
+            fail "custom property name changed after reparse")
 
 let test_block_declarations_serialize_individually buf =
   let middle =

--- a/fuzz/fuzz_variables.ml
+++ b/fuzz/fuzz_variables.ml
@@ -74,11 +74,15 @@ let test_nested_fallback_stays_balanced buf =
 
 let test_custom_declaration_name_invariant buf =
   let name = "--" ^ var_name buf in
-  let decl = Css.Declaration.custom_property name (cssish buf) in
-  match Css.Variables.custom_declaration_name decl with
-  | Some parsed when parsed = name -> ()
-  | Some parsed -> failf "custom declaration name changed: %S" parsed
-  | None -> fail "custom property declaration was not recognized"
+  (* [custom_property] refuses a value it cannot write back as one declaration,
+     so the invariant holds over the pairs it accepts. *)
+  match Css.Declaration.custom_property name (cssish buf) with
+  | exception Failure _ -> ()
+  | decl -> (
+      match Css.Variables.custom_declaration_name decl with
+      | Some parsed when parsed = name -> ()
+      | Some parsed -> failf "custom declaration name changed: %S" parsed
+      | None -> fail "custom property declaration was not recognized")
 
 let test_var_compare_antisym buf =
   let _, a =

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7568,8 +7568,16 @@ val custom_property : ?layer:string -> string -> string -> declaration
     API which provides compile-time checking and automatic variable management.
 
     @param layer Optional CSS layer name for the custom property
-    @param name CSS custom property name (must start with --)
-    @param value CSS value as string
+    @param name
+      CSS custom property name: a [<dashed-ident>] that tokenizes to itself
+    @param value
+      the [<declaration-value>?] CSS Variables 1 sec. 2 gives a custom property,
+      as CSS text
+
+    It raises [Failure] on a pair that does not write back as the one
+    declaration it names, such as a value carrying a top-level [;] or [}] or an
+    unterminated function, block or string. {!Declaration.parse_custom_property}
+    is the same check as an option.
 
     Example: [custom_property "--primary-color" "#3b82f6"]
 

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -62,20 +62,77 @@ let rec normalize ?(lossless = false) ?(exact_srgb = false)
       let decl = normalize ~lossless ~exact_srgb ~ctx g.decl in
       if decl == g.decl then themed else theme_guarded ~var_name:g.var_name decl
 
+let is_custom_property_name name =
+  String.length name > 2 && name.[0] = '-' && name.[1] = '-'
+
+(* CSS Syntax 3 sec. 8.2: a [<declaration-value>] is one or more component
+   values with no [<bad-string-token>], no [<bad-url-token>] and no unmatched
+   closing bracket. A component breaking one of those does not stay inside the
+   declaration it is written into: it closes the enclosing block, or turns the
+   rest of the stylesheet into a string. *)
+let rec component_stays_in_declaration = function
+  | Component.Preserved
+      {
+        kind =
+          ( Token.Close _ | Token.Bad_string | Token.Bad_url
+          | Token.String { terminated = false; _ } );
+        _;
+      } ->
+      false
+  | Component.Preserved _ -> true
+  | Component.Block { node = { closed; value; _ }; _ } ->
+      closed && List.for_all component_stays_in_declaration value
+  | Component.Func { node = { terminated; arguments; _ }; _ } ->
+      terminated && List.for_all component_stays_in_declaration arguments
+
+(* A top-level [;] ends the declaration, so the tail becomes a second one. It is
+   only a stop at top level: [(a;b)] keeps it inside the block. *)
+let is_top_level_stop = function
+  | Component.Preserved { kind = Token.Semicolon; _ } -> true
+  | _ -> false
+
+let components_stay_in_declaration components =
+  List.for_all
+    (fun c -> (not (is_top_level_stop c)) && component_stays_in_declaration c)
+    components
+
+(* CSS Variables 1 sec. 2 gives a custom property the value grammar
+   [<declaration-value>?], so the empty value is one of its values. *)
+let is_optional_declaration_value value =
+  components_stay_in_declaration (Cursor.remaining (Cursor.of_string value))
+
+let is_declaration_value value =
+  match Cursor.remaining (Cursor.of_string value) with
+  | [] -> false
+  | components -> components_stay_in_declaration components
+
+(* A name is written back verbatim, so it binds only when it tokenizes as the
+   single ident it claims to be. An escape (CSS Syntax 3 sec. 4.3.7) can carry a
+   [;] or a [}] into a name read from a [var()] reference. *)
+let is_writable_custom_property_name name =
+  is_custom_property_name name
+  &&
+  match Cursor.remaining (Cursor.of_string name) with
+  | [ Component.Preserved { kind = Token.Ident ident; _ } ] ->
+      String.equal ident name
+  | _ -> false
+
+let refuse name detail =
+  failwith (String.concat "" [ "custom_property: "; name; ": "; detail ])
+
 (* Helper for raw custom properties - primarily for internal use *)
 
 let custom_property ?layer name value =
-  (* Validate that this is a proper CSS variable name. Custom-property names are
-     dashed idents starting with [--] and a non-empty name body. *)
-  if not (String.length name > 2 && String.sub name 0 2 = "--") then
-    failwith
-      (String.concat ""
-         [
-           "custom_property: ";
-           name;
-           " is not a valid CSS variable name (must start with -- and include \
-            a name)";
-         ]);
+  (* The pair is written back verbatim, so it binds only when the text reads
+     back as the one declaration it names: a [<dashed-ident>] name that
+     tokenizes to itself, and the [<declaration-value>?] CSS Variables 1 sec. 2
+     gives a custom property. A name or value outside that - a top-level [;] or
+     [}], an unmatched closing bracket, an unterminated function, block or
+     string - leaves the declaration as soon as the text is read back. *)
+  if not (is_writable_custom_property_name name) then
+    refuse name "not a custom-property name";
+  if not (is_optional_declaration_value value) then
+    refuse name (String.concat "" [ value; " is not a declaration value" ]);
   (* Parse the value into a CSS Syntax 3 component stream so the declaration
      never carries a raw author string; the printer can then re-serialise with
      the active [Pp] context (handles minification). *)
@@ -2276,9 +2333,6 @@ let of_string s =
   | Some d -> d
   | None -> failwith ("Declaration.of_string: invalid declaration: " ^ s)
 
-let is_custom_property_name name =
-  String.length name > 2 && name.[0] = '-' && name.[1] = '-'
-
 let parse_declaration ?layer property value =
   (* Parse [property:value] with the full declaration parser: a known property
      (e.g. [mask-type], [display]) becomes a typed declaration, a custom
@@ -2294,52 +2348,6 @@ let parse_declaration ?layer property value =
       let s = String.concat "" [ property; ":"; value ] in
       try read_declaration (Cursor.of_string s)
       with Cursor.Parse_error _ -> None)
-
-(* CSS Syntax 3 sec. 8.2: a [<declaration-value>] is one or more component
-   values with no [<bad-string-token>], no [<bad-url-token>] and no unmatched
-   closing bracket. A component breaking one of those does not stay inside the
-   declaration it is written into: it closes the enclosing block, or turns the
-   rest of the stylesheet into a string. *)
-let rec component_stays_in_declaration = function
-  | Component.Preserved
-      {
-        kind =
-          ( Token.Close _ | Token.Bad_string | Token.Bad_url
-          | Token.String { terminated = false; _ } );
-        _;
-      } ->
-      false
-  | Component.Preserved _ -> true
-  | Component.Block { node = { closed; value; _ }; _ } ->
-      closed && List.for_all component_stays_in_declaration value
-  | Component.Func { node = { terminated; arguments; _ }; _ } ->
-      terminated && List.for_all component_stays_in_declaration arguments
-
-(* A top-level [;] ends the declaration, so the tail becomes a second one. It is
-   only a stop at top level: [(a;b)] keeps it inside the block. *)
-let is_top_level_stop = function
-  | Component.Preserved { kind = Token.Semicolon; _ } -> true
-  | _ -> false
-
-let is_declaration_value value =
-  match Cursor.remaining (Cursor.of_string value) with
-  | [] -> false
-  | components ->
-      List.for_all
-        (fun c ->
-          (not (is_top_level_stop c)) && component_stays_in_declaration c)
-        components
-
-(* A name is written back verbatim, so it binds only when it tokenizes as the
-   single ident it claims to be. An escape (CSS Syntax 3 sec. 4.3.7) can carry a
-   [;] or a [}] into a name read from a [var()] reference. *)
-let is_writable_custom_property_name name =
-  is_custom_property_name name
-  &&
-  match Cursor.remaining (Cursor.of_string name) with
-  | [ Component.Preserved { kind = Token.Ident ident; _ } ] ->
-      String.equal ident name
-  | _ -> false
 
 let parse_custom_property name value =
   if is_writable_custom_property_name name && is_declaration_value value then

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -42,7 +42,15 @@ val to_string : ?minify:bool -> t -> string
 
 val custom_property : ?layer:string -> string -> string -> declaration
 (** [custom_property ?layer name value] is a custom property declaration from
-    authored CSS text. *)
+    authored CSS text.
+
+    @raise Failure
+      if the pair does not write back as the one declaration it names. [name]
+      has to be a [<dashed-ident>] that tokenizes to itself, and [value] the
+      [<declaration-value>?] CSS Variables 1 sec. 2 gives a custom property: no
+      top-level [;], no unmatched closing bracket, no unterminated function,
+      block or string. {!parse_custom_property} is the same check as an option.
+*)
 
 val parse_declaration : ?layer:string -> string -> string -> declaration option
 (** [parse_declaration ?layer property value] parses ["property: value"] with
@@ -67,7 +75,8 @@ val parse_custom_property : string -> string -> declaration option
 
     Use it for a name or value that comes from outside the parser, where the
     string may close the block it is placed in or start a second declaration.
-    {!custom_property} keeps such a string verbatim. *)
+    {!custom_property} takes the same pairs and raises on the rest, and also
+    takes the empty value CSS Variables 1 sec. 2 allows. *)
 
 val custom_declaration_layer : declaration -> string option
 (** [custom_declaration_layer d] is the layer of [d], if any. *)

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -149,6 +149,14 @@ type scope = {
 
 let custom_name = Variables.custom_declaration_name
 
+(* [Declaration.custom_property] refuses a name and value it cannot write back
+   as the one declaration they name. A parsed stylesheet can hold such a pair -
+   a name written with an escape, a value CSS Syntax 3 would drop - so a rewrite
+   that reaches one keeps what it started from instead of raising. *)
+let rebuild_custom ?layer name value =
+  try Some (Declaration.custom_property ?layer name value)
+  with Failure _ -> None
+
 let local_customs ~kept decls =
   List.filter
     (fun d ->
@@ -160,11 +168,9 @@ let property_initial_custom_decl : type a.
  fun ~kept rule ->
   if List.mem rule.name kept then None
   else
-    Option.map
-      (fun value ->
-        Declaration.custom_property rule.name
+    Option.bind rule.initial_value (fun value ->
+        rebuild_custom rule.name
           (Pp.to_string ~minify:true (Variables.pp_value rule.syntax) value))
-      rule.initial_value
 
 (** {1 Pass 1 - collect every rule's scope} *)
 
@@ -1010,11 +1016,12 @@ let normalize_custom_value decl =
         let color = Values.read_color cursor in
         Cursor.ws cursor;
         Cursor.expect_eof cursor;
-        let decl =
-          Declaration.custom_property name
-            (Pp.to_string ~minify:true Values.pp_color color)
-        in
-        if important then Declaration.important decl else decl
+        match
+          rebuild_custom name (Pp.to_string ~minify:true Values.pp_color color)
+        with
+        | None -> decl
+        | Some normalized ->
+            if important then Declaration.important normalized else normalized
       with Cursor.Parse_error _ -> decl)
 
 let custom_is_live ~keep ~live_set ~at_path ~selector name =
@@ -1190,16 +1197,25 @@ let foldable_layer_of_at_path at_path : string option option =
   go [] at_path
 
 (* A copy of [d] tagged with [layer] and its own importance, for the cascade
-   resolver. *)
+   resolver, or [None] when [d] is not a pair this library writes back. *)
 let annotate_layer (layer : string option) d =
   let name = Declaration.property_name d in
   let value = Declaration.string_of_value ~minify:true d in
-  let base =
-    match layer with
-    | None -> Declaration.custom_property name value
-    | Some l -> Declaration.custom_property ~layer:l name value
-  in
-  if Declaration.is_important d then Declaration.important base else base
+  Option.map
+    (fun base ->
+      if Declaration.is_important d then Declaration.important base else base)
+    (rebuild_custom ?layer name value)
+
+(* Every definition of one name tagged with its layer, or [None] as soon as one
+   of them is not a pair this library writes back: resolving a subset would
+   resolve a different cascade. *)
+let annotate_every_layer entries =
+  List.fold_left
+    (fun acc (_, fl, d) ->
+      Option.bind acc (fun acc ->
+          Option.bind fl (fun l ->
+              Option.map (fun a -> a :: acc) (annotate_layer l d))))
+    (Option.Some []) entries
 
 (* Names whose every definition is unconditional, on one selector, and spread
    over two or more layers, mapped to the resolved cascade winner ([`Unset] when
@@ -1242,16 +1258,14 @@ let layer_decided_customs ~keep stylesheet =
         |> List.sort_uniq compare |> List.length
       in
       if unconditional && one_selector && distinct_layers >= 2 then
-        let annotated =
-          List.filter_map
-            (fun (_, fl, d) -> Option.map (fun l -> annotate_layer l d) fl)
-            entries
-        in
-        match Context.winning_custom_declaration ~layer_order annotated with
-        | Some w ->
-            Hashtbl.replace fold name
-              (`Value (Declaration.string_of_value ~minify:true w))
-        | None -> Hashtbl.replace fold name `Unset)
+        match annotate_every_layer entries with
+        | Option.None -> ()
+        | Option.Some annotated -> (
+            match Context.winning_custom_declaration ~layer_order annotated with
+            | Some w ->
+                Hashtbl.replace fold name
+                  (`Value (Declaration.string_of_value ~minify:true w))
+            | None -> Hashtbl.replace fold name `Unset))
     by_name;
   fold
 
@@ -1273,7 +1287,7 @@ let collapse_layer_decided ~keep stylesheet =
               | `Value _ when Hashtbl.mem emitted n -> None
               | `Value v ->
                   Hashtbl.add emitted n ();
-                  Some (Declaration.custom_property n v))
+                  Some (Option.value ~default:d (rebuild_custom n v)))
           | _ -> Some d)
         decls
     in

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1587,6 +1587,87 @@ let parse_custom_property_guard () =
       ("color", "<rejected>");
     ]
 
+(* [custom_property] takes authored CSS text, so a pair it accepts has to write
+   back as the one declaration it names. CSS Variables 1 sec. 2 gives a custom
+   property the value grammar [<declaration-value>?] and a [<dashed-ident>]
+   name; a top-level [;] or [}], an unterminated function, block or string, or
+   an unmatched closing bracket all stop being part of the declaration as soon
+   as the text is read back, so they are not a pair this library can write. *)
+let custom_property_guard () =
+  (* Build the declaration, print it into a rule and read the rule back. The
+     answer is derived from the round-trip, not from a pinned spelling. *)
+  let build name value =
+    match custom_property name value with
+    | exception Failure _ -> "<refused>"
+    | d -> (
+        let text = to_string ~minify:true d in
+        let back =
+          match
+            Css.of_string ~strict:false
+              (String.concat "" [ ":root{"; text; "}" ])
+          with
+          | Ok { Css.stylesheet = [ Css.Stylesheet.Rule r ]; _ } ->
+              List.map (to_string ~minify:true) r.declarations
+          | Ok { Css.stylesheet; _ } ->
+              [
+                String.concat ""
+                  [
+                    "<"; string_of_int (List.length stylesheet); " statements>";
+                  ];
+              ]
+          | Error _ -> [ "<unparsable>" ]
+        in
+        match back with
+        | [ text' ] when String.equal text text' -> "<round-trips>"
+        | back ->
+            String.concat ""
+              [ text; " reads back as "; String.concat " + " back ])
+  in
+  List.iter
+    (fun (value, expected) ->
+      Alcotest.(check string)
+        (String.concat "" [ "--x:"; value ])
+        expected (build "--x" value))
+    [
+      (* A [<declaration-value>], and the empty value CSS Variables 1 allows. *)
+      ("red", "<round-trips>");
+      ("", "<round-trips>");
+      (" ", "<round-trips>");
+      ("0 0 var(--spacing) black", "<round-trips>");
+      ("\"a;b\"", "<round-trips>");
+      ("{a:b;}", "<round-trips>");
+      ("red/*", "<round-trips>");
+      (* CSS Syntax 3 sec. 4.3.6 returns the [<url-token>] at end of input, so
+         [url(foo] is the same token [url(foo)] is. *)
+      ("url(foo", "<round-trips>");
+      (* Not a [<declaration-value>]: a second declaration, a closed rule, an
+         unterminated function, block or string, an unmatched bracket. *)
+      ("red;--b:blue", "<refused>");
+      ("red} .evil{color:lime", "<refused>");
+      ("red}", "<refused>");
+      ("rgb(1,2,3", "<refused>");
+      ("url(foo bar)", "<refused>");
+      ("{a:b", "<refused>");
+      ("\"abc", "<refused>");
+      ("red)", "<refused>");
+      ("red]", "<refused>");
+    ];
+  List.iter
+    (fun (name, expected) ->
+      Alcotest.(check string)
+        (String.concat "" [ name; ":red" ])
+        expected (build name "red"))
+    [
+      ("--x", "<round-trips>");
+      ("--color-red-500", "<round-trips>");
+      ("--x}y", "<refused>");
+      ("--x;y", "<refused>");
+      ("--x y", "<refused>");
+      ("--", "<refused>");
+      ("-x", "<refused>");
+      ("color", "<refused>");
+    ]
+
 let spec_custom_tokens () =
   check_specified_value "custom property token stream specified"
     "--tokens: [a, b] (c) { d: e; }" "[a, b] (c) { d: e; }";
@@ -2826,6 +2907,8 @@ let declaration_tests =
     test_case "custom property values" `Quick custom_property_values;
     test_case "parse_custom_property rejects an escaping pair" `Quick
       parse_custom_property_guard;
+    test_case "custom_property refuses an escaping pair" `Quick
+      custom_property_guard;
     test_case "spec custom property token stream values" `Quick
       spec_custom_tokens;
     test_case "vendor prefixes" `Quick vendor_prefixes;


### PR DESCRIPTION
`Css.Declaration.custom_property` documents authored CSS text and stored it unchecked, so `custom_property "--a" "red;--b:blue"` wrote a second declaration and `"red} .evil{color:lime"` closed the rule and opened another. It takes the pair `parse_custom_property` takes plus the empty value CSS Variables 1 sec. 2 allows, and raises on the rest, which makes the two fuzz properties that fed it an arbitrary value conditional on it accepting the pair.

Stacked on #421.