### PR TITLE
css: escape a custom-property name that needs it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,6 +83,13 @@
 - A registered `<color>` custom property is promoted and fills the colour slot
   of a `box-shadow` inside `@keyframes`, so the same declaration minifies the
   same way wherever it sits (#337)
+- A custom-property name written with an escape is printed with the escapes
+  CSS Syntax 3 sec. 4.3.7 needs to read it back as the same name.
+  `:root{--x\3b y:red}` printed `:root{--x;y:red}`, which cascade's own reader
+  splits into two declarations, and a reference to it printed `var(--x}y)`,
+  which closes the rule around it. The declaration name, the `var()` reference
+  and every shape of its fallback, the `@property` prelude and a `style()`
+  container query all take the escaping (#429)
 
 ### Canonical diff
 

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -53,11 +53,15 @@ let string_of_range_operator = function
   | Gt -> ">"
   | Gte -> ">="
 
+(* CSS Syntax 3 sec. 4.3.7: a [style()] query names a custom property, and an
+   escape can carry a [;] or a [}] into that name, so it is written back with
+   the escapes that read the same name (see [Properties.pp_property]). *)
 let rec string_of_style_query ~minify = function
-  | Boolean name -> name
+  | Boolean name -> Parser.escape_ident name
   | Declaration { name; value } ->
       let sep = if minify then ":" else ": " in
-      String.concat "" [ name; sep; string_of_components value ]
+      String.concat ""
+        [ Parser.escape_ident name; sep; string_of_components value ]
   | Range { lower; lower_op; name; upper_op; upper } ->
       let sep = if minify then "" else " " in
       String.concat ""
@@ -66,7 +70,7 @@ let rec string_of_style_query ~minify = function
           sep;
           string_of_range_operator lower_op;
           sep;
-          name;
+          Parser.escape_ident name;
           sep;
           string_of_range_operator upper_op;
           sep;

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2361,7 +2361,7 @@ let rec pp_declaration : declaration Pp.t =
         important;
         _;
       } ->
-      Pp.string ctx name;
+      pp_property ctx (Custom_property name);
       Pp.string ctx ":";
       Pp.space_if_pretty ctx ();
       (match (layer, value) with

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -171,15 +171,27 @@ let escape_ident s =
     Uutf.String.fold_utf_8 (escape_ident_emit_item buf starts) () s;
     Buffer.contents buf
 
+(* Every code point of an all-ASCII name serialises to itself, so the buffer +
+   Uutf walk below would allocate nothing useful. *)
+let escape_name_needs_no_escape s n =
+  let rec loop i =
+    if i >= n then true
+    else if Syntax.is_ascii_ident_continue s.[i] then loop (i + 1)
+    else false
+  in
+  loop 0
+
 let escape_name s =
   let n = String.length s in
-  let buf = Buffer.create n in
-  let folder () _ = function
-    | `Uchar u -> escape_ident_emit_cp buf ~needs_leading_escape:false u
-    | `Malformed bs -> Buffer.add_string buf bs
-  in
-  Uutf.String.fold_utf_8 folder () s;
-  Buffer.contents buf
+  if escape_name_needs_no_escape s n then s
+  else
+    let buf = Buffer.create n in
+    let folder () _ = function
+      | `Uchar u -> escape_ident_emit_cp buf ~needs_leading_escape:false u
+      | `Malformed bs -> Buffer.add_string buf bs
+    in
+    Uutf.String.fold_utf_8 folder () s;
+    Buffer.contents buf
 
 let escape_string ~quote ~terminated s =
   let buf = Buffer.create (String.length s + 2) in

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -69,6 +69,13 @@ val escape_ident : string -> string
     or hex-escaped per CSS Syntax 3 section 9.1, so that
     [Cursor.of_string (escape_ident s) |> Cursor.ident] yields [s] again. *)
 
+val escape_name : string -> string
+(** [escape_name s] escapes [s] as CSS Syntax 3 section 4.3.7 name code points,
+    with no ident-start rule applied to the first one. It is what serialises a
+    name written after a prefix the caller emits itself, such as the [#] of a
+    hash or the [--] of a dashed ident; {!escape_ident} serialises a whole
+    ident. *)
+
 (** {1 Entry points (section 5.4)} *)
 
 type 'a output = { value : 'a; warnings : Error.t list }

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -152,7 +152,9 @@ let pp_shadow_body ctx { h_offset; v_offset; blur; spread; color } =
    separator after it is load-bearing. *)
 let pp_inset_toggle ctx ~name ~no_fallback =
   Pp.string ctx "var(--";
-  Pp.string ctx name;
+  (* [name] is the custom property's name without its [--] prefix; CSS Syntax 3
+     sec. 4.3.7 lets an escape carry a [;] or a [}] into it. *)
+  Pp.string ctx (Parser.escape_name name);
   if no_fallback then Pp.string ctx ")"
   else (
     (* Empty fallback: var(--name, ) in pretty, var(--name,) in minified. *)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -201,7 +201,11 @@ let rec pp_list_style : list_style Pp.t =
 
 let pp_property : type a. a property Pp.t =
  fun ctx -> function
-  | Custom_property name -> Pp.string ctx name
+  (* CSS Syntax 3 sec. 4.3.7 lets an escape carry a [;], a [}] or any other
+     non-name code point into a custom-property name, so the name is written
+     back with the escapes that read it as the same name. Printed raw it ends
+     its own declaration or closes the rule around it. *)
+  | Custom_property name -> Pp.string ctx (Parser.escape_ident name)
   | Unknown_property name -> Pp.string ctx name
   | All -> Pp.string ctx "all"
   | Background_color -> Pp.string ctx "background-color"

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -393,7 +393,10 @@ let pp_property_rule : 'a property_rule Pp.t =
       match initial_value with None -> () | Some v -> pp_initial_value ctx v
   in
   Pp.string ctx "@property ";
-  Pp.string ctx name;
+  (* CSS Syntax 3 sec. 4.3.7: the prelude names the custom property this rule
+     registers, so it is written with the escapes that read the same name back
+     (see [Properties.pp_property]). *)
+  Pp.string ctx (Parser.escape_ident name);
   Pp.sp ctx ();
   Pp.braces
     (fun ctx () ->

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -394,12 +394,19 @@ let color_mix_var_pct_fallback ?in_space ?(hue = Default) ~var_name ~fallback
 
 (** Pretty-printing functions *)
 
+(* Opens [var(] and writes the referenced name. [name] is the custom property's
+   name without its [--] prefix, and CSS Syntax 3 sec. 4.3.7 lets an escape
+   carry a [;] or a [}] into it, so the tail is written with the escapes that
+   read the same name back. *)
+let pp_var_open ctx name =
+  Pp.string ctx "var(--";
+  Pp.string ctx (Parser.escape_name name)
+
 (* Prints the [var(--fallback_name)] used as another var's fallback, then the
    outer var's closing paren. Theme resolution is a transform, not a print
    concern, so the reference is emitted structurally. *)
 let pp_var_fallback ctx fallback_name =
-  Pp.string ctx "var(--";
-  Pp.string ctx fallback_name;
+  pp_var_open ctx fallback_name;
   Pp.string ctx "))"
 
 let pp_syntax_fallback ctx value =
@@ -410,31 +417,26 @@ let pp_syntax_fallback ctx value =
      else Parser.to_string_custom value)
 
 let pp_var_ref ctx name =
-  Pp.string ctx "var(--";
-  Pp.string ctx name;
+  pp_var_open ctx name;
   Pp.char ctx ')'
 
 let pp_empty_var ctx name =
-  Pp.string ctx "var(--";
-  Pp.string ctx name;
+  pp_var_open ctx name;
   Pp.char ctx ',';
   Pp.char ctx ')'
 
 let pp_empty2_var ctx name =
-  Pp.string ctx "var(--";
-  Pp.string ctx name;
+  pp_var_open ctx name;
   Pp.string ctx ",  )"
 
 let pp_typed_var_fallback pp_value ctx name value =
-  Pp.string ctx "var(--";
-  Pp.string ctx name;
+  pp_var_open ctx name;
   Pp.comma ctx ();
   pp_value { ctx with in_function = true } value;
   Pp.char ctx ')'
 
 let pp_syntax_var_fallback ctx name value =
-  Pp.string ctx "var(--";
-  Pp.string ctx name;
+  pp_var_open ctx name;
   Pp.comma ctx ();
   pp_syntax_fallback { ctx with in_function = true } value;
   Pp.char ctx ')'
@@ -483,8 +485,7 @@ let pp_stylesheet_var : type a. a Pp.t -> a var Pp.t =
   | Fallback value -> pp_typed_var_fallback pp_value ctx v.name value
   | Syntax_fallback value -> pp_syntax_var_fallback ctx v.name value
   | Var_fallback fallback_name ->
-      Pp.string ctx "var(--";
-      Pp.string ctx v.name;
+      pp_var_open ctx v.name;
       Pp.comma ctx ();
       pp_var_fallback ctx fallback_name
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6588,29 +6588,26 @@ let theme_defaults_reject_escaping_name () =
     | Ok parsed -> parsed.stylesheet
     | Error _ -> Alcotest.failf "failed to parse: %s" css
   in
-  let declarations sheet =
-    Css.statements sheet
-    |> List.concat_map (fun stmt ->
-        Option.value ~default:[] (Css.statement_declarations stmt))
-  in
   List.iter
-    (fun (what, src, name) ->
+    (fun (what, src, name, expected) ->
       let resolved =
         parse src
         |> Css.resolve_theme ~theme_defaults:(fun n ->
             if n = name then Some "red" else None)
       in
-      Alcotest.(check int)
-        (what ^ ": no statement is added")
-        1
-        (List.length (Css.statements resolved));
-      Alcotest.(check int)
-        (what ^ ": no declaration is added")
-        1
-        (List.length (declarations resolved)))
+      Alcotest.(check string)
+        (what ^ ": nothing binds and the reference stays live")
+        expected
+        (Css.to_string ~minify:true resolved))
     [
-      ("a name carrying a [;]", ".a{color:var(--x\\3b y)}", "x;y");
-      ("a name carrying a [}]", ".a{color:var(--x\\7d y)}", "x}y");
+      ( "a name carrying a [;]",
+        ".a{color:var(--x\\3b y)}",
+        "x;y",
+        ".a{color:var(--x\\;y)}" );
+      ( "a name carrying a [}]",
+        ".a{color:var(--x\\7d y)}",
+        "x}y",
+        ".a{color:var(--x\\}y)}" );
     ]
 
 (* CSS Custom Properties L1 section 2: a [var()] used inside a fallback list

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5209,6 +5209,74 @@ let s3437_string_escape () =
     "\\\\ preserved" ".x{content:\"\\\\\"}"
     (normalize ".x { content: \"\\\\\" }")
 
+(* CSS Syntax 3 sec. 4.3.7 reads an escape as the code point it names, so a
+   custom-property name can hold a [;] or a [}]. Serializing an ident writes
+   those back escaped (CSS Syntax 3 sec. 2.1): printed raw, the name ends its
+   own declaration or closes the rule around it, and cascade's reader stops
+   reading what the input meant. *)
+let s4370_custom_property_name_escapes () =
+  (* Print [css] and hold the printer to its own reader: the output parses in
+     strict mode, says what the input said, and printing it again is a byte
+     fixpoint. The tree comparison stands in for AST equality, which a token
+     carrying its source position makes sensitive to how long the escape was.
+     The minified output is what the spellings below are checked against. *)
+  let roundtrip css =
+    match Css.of_string ~strict:false css with
+    | Error e ->
+        Alcotest.failf "parse failed: %s (%s)" css (Cascade.Error.to_string e)
+    | Ok parsed ->
+        let check ~minify label out =
+          match Css.of_string ~strict:true out with
+          | Error e ->
+              Alcotest.failf "%s output is not readable: %s (%s)" label out
+                (Cascade.Error.to_string e)
+          | Ok again ->
+              Alcotest.(check bool)
+                (String.concat "" [ label; " says what "; css; " said" ])
+                true
+                (Cascade_diff.Css_compare.equal ~mode:`Tree css out);
+              Alcotest.(check string)
+                (String.concat "" [ label; " is a byte fixpoint: "; out ])
+                out
+                (Css.to_string ~minify again.Css.stylesheet)
+        in
+        let minified = Css.to_string ~minify:true parsed.Css.stylesheet in
+        check ~minify:true "minified" minified;
+        check ~minify:false "pretty" (Css.to_string parsed.Css.stylesheet);
+        minified
+  in
+  List.iter
+    (fun (css, expected) ->
+      Alcotest.(check string) css expected (roundtrip css))
+    [
+      (* The declaration name. *)
+      (":root{--x\\3b y:red}", ":root{--x\\;y:red}");
+      (":root{--x\\7d y:red}", ":root{--x\\}y:red}");
+      (":root{--x\\7b y:red}", ":root{--x\\{y:red}");
+      (":root{--x\\3a y:red}", ":root{--x\\:y:red}");
+      (":root{--x\\ y:red}", ":root{--x\\ y:red}");
+      (":root{--x\\22 y:red}", ":root{--x\\\"y:red}");
+      (":root{--x\\\\y:red}", ":root{--x\\\\y:red}");
+      (* The [var()] reference name, with each shape of fallback. *)
+      (".a{color:var(--x\\7d y)}", ".a{color:var(--x\\}y)}");
+      (".a{color:var(--a\\3b b,red)}", ".a{color:var(--a\\;b,red)}");
+      ( ".a{color:var(--a\\3b b,var(--c\\3b d))}",
+        ".a{color:var(--a\\;b,var(--c\\;d))}" );
+      (".a{color:var(--a\\3b b,)}", ".a{color:var(--a\\;b,)}");
+      (* The [@property] prelude and the [style()] container query. *)
+      ( "@property --x\\3b y{syntax:\"*\";inherits:false}",
+        "@property --x\\;y{syntax:\"*\";inherits:false}" );
+      ( "@container style(--x\\3b y:red){.a{color:red}}",
+        "@container style(--x\\;y:red){.a{color:red}}" );
+      (* A name needing no escape keeps its spelling: [--] takes a digit
+         straight after it, and a code point CSS Syntax 3 sec. 4.2 admits in an
+         ident is written as itself. *)
+      (":root{--x:red}.a{color:var(--x)}", ":root{--x:red}.a{color:var(--x)}");
+      (":root{--0:red}.a{color:var(--0)}", ":root{--0:red}.a{color:var(--0)}");
+      ( ":root{--\\e9 x:red}.a{color:var(--\\e9 x)}",
+        ":root{--\xc3\xa9x:red}.a{color:var(--\xc3\xa9x)}" );
+    ]
+
 let fidelity_string_escape_preserved () =
   pretty_preserves ".x { content: \"\\41\" }" [ "\\41" ];
   pretty_preserves ".x { content: \"hello\" }" [ "hello" ];
@@ -7102,6 +7170,9 @@ let additional_tests =
     ("spec bg 3 2.1 multi-layer preserved", `Quick, bg321_multi_layer_kept);
     ("fidelity background preserved", `Quick, fidelity_background_preserved);
     ("spec syntax 3 4.3.7 string escape decoding", `Quick, s3437_string_escape);
+    ( "spec syntax 3 4.3.7 custom-property name escapes",
+      `Quick,
+      s4370_custom_property_name_escapes );
     ( "fidelity string escape preserved",
       `Quick,
       fidelity_string_escape_preserved );


### PR DESCRIPTION
cascade reads `--x\3b y` as the name that escape spells and then printed the raw code point back, so `:root{--x\3b y:red}` came out as `:root{--x;y:red}`, which its own reader splits into two declarations, and a reference to the same name came out as `var(--x}y)`, which closes the rule around it. The declaration name, the `var()` reference and its fallbacks, the `@property` prelude and a `style()` container query now go through the escaper the token printer already uses.

Stacked on #421.