### PR TITLE
selector: read the pseudo-class list per pseudo-element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,19 @@
   by sec. 16 out of compound selectors with no pseudo-element among them, and
   the list is unforgiving, so Chrome and WebKit drop the whole rule where
   `:is()` and `:where()` drop only the offending item (#426)
+- Which pseudo-classes may follow a pseudo-element is read per pseudo-element,
+  so `::before:hover`, `::marker:hover`, `::selection:hover` and
+  `::spelling-error:hover` stop parsing while `::file-selector-button:hover`,
+  `::part(p):hover`, `::cue:hover` and `::-webkit-scrollbar:hover` keep
+  parsing. Selectors 4 sec. 3.6.3 makes the list per pseudo-element and calls
+  every other combination invalid, CSS Pseudo-Elements 4 sec. 5 gives the
+  element-backed pseudo-elements theirs, and Chrome and WebKit agree on the
+  rest. A pseudo-element cascade does not recognise still takes any
+  pseudo-class. A logical combination carries that list into its own argument:
+  `:is()` and `:where()` take a forgiving list, so `::before:is(.b)` still
+  parses and matches nothing, while the unforgiving `:not()` goes down with the
+  argument, so `::before:not(.b)` and `::part(p):not(.b)` stop parsing and
+  `::part(p):not(:hover)` keeps parsing (#430)
 - A `<custom-ident>` or `<dashed-ident>` an at-rule prelude or a declaration
   value names is printed with the escapes CSS Syntax 3 sec. 4.3.7 needs to read
   it back as the same name. `@layer a\3b b` printed `@layer a;b`, two

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -1104,6 +1104,96 @@ let is_pe_action = function
   | Element _ | Class _ | Id _ | Universal _ | Attribute _ | Nesting -> false
   | sel -> not (is_pseudo_element sel)
 
+(* CSS Selectors 4 sec. 9. *)
+let is_user_action_pseudo_class = function
+  | Hover | Active | Focus | Focus_visible | Focus_within -> true
+  | _ -> false
+
+(* CSS Selectors 4 sec. 13: the tree-structural pseudo-classes, the ones that
+   answer a question about the element's place among its siblings. *)
+let is_structural_pseudo_class = function
+  | Root | Empty | First_child | Last_child | Only_child | First_of_type
+  | Last_of_type | Only_of_type | Nth_child _ | Nth_last_child _ | Nth_of_type _
+  | Nth_last_of_type _ ->
+      true
+  | _ -> false
+
+(* Which pseudo-classes each pseudo-element takes after it. CSS Selectors 4 sec.
+   3.6.3 allows the logical combinations and hands the rest of the list to
+   "other specifications", so the rows below come from CSS Pseudo-Elements 4
+   sec. 5 for the element-backed pseudo-elements and, for the UA widgets whose
+   list only exists in the engines, from Chrome and WebKit, taking a
+   pseudo-class as allowed when either engine keeps the rule. *)
+let rec pseudo_element_allows pe pc =
+  match pe with
+  (* A name no engine recognises: cascade keeps it so a pseudo-element newer
+     than this list survives a format pass, and knows nothing about its rules,
+     so it keeps taking any pseudo-class after it. *)
+  | Unknown_pseudo_element _ | Unknown_pseudo_element_call _ | Moz_placeholder
+  | Ms_input_placeholder | Cue_region _ ->
+      true
+  | pe -> (
+      match pc with
+      (* Sec. 3.6.3 allows the logical combinations after every pseudo-element
+         and passes the row below on to their arguments; what an argument the
+         row refuses costs is the argument list's own business. [:is()] and
+         [:where()] take a [<forgiving-selector-list>] (sec. 4.1), which drops
+         it and leaves a selector that still parses and matches nothing, so both
+         engines keep the rule; the [:-moz-any()] / [:-webkit-any()] aliases
+         read back the same way. *)
+      | Is _ | Where _ | Moz_any_call _ | Webkit_any_call _ -> true
+      (* [:not()] takes an unforgiving list, so the refused argument takes the
+         compound down with it: both engines drop [::before:not(:hover)] and
+         keep [::part(p):not(:hover)]. *)
+      | Not args -> List.for_all (pseudo_element_allows_argument pe) args
+      (* Same forward-compatibility bargain as an unknown pseudo-element. *)
+      | Unknown_pseudo_class _ | Unknown_pseudo_class_call _ -> true
+      | pc -> (
+          match pe with
+          (* CSS Pseudo-Elements 4 sec. 5: an element-backed pseudo-element
+             takes what a real element takes, bar the pseudo-classes that would
+             report on the tree it sits in. *)
+          | Part _ | Details_content -> (
+              match pc with
+              | Has _ -> false
+              | pc -> not (is_structural_pseudo_class pc))
+          (* A scrollbar takes no focus, and reports its own state through the
+             vendor pseudo-classes, which reach here as unknown names. *)
+          | Webkit_scrollbar -> (
+              match pc with
+              | Hover | Active | Enabled | Disabled -> true
+              | _ -> false)
+          (* CSS View Transitions 1 sec. 3.1: [:only-child] matches a view
+             transition pseudo with no sibling in the pseudo-element tree. *)
+          | View_transition_group _ | View_transition_image_pair _
+          | View_transition_old _ | View_transition_new _ -> (
+              match pc with Only_child -> true | _ -> false)
+          (* The UA widgets that stand in for a real control. [::cue(...)]
+             selects inside the cue and takes none of them. *)
+          | Placeholder | File_selector_button | Webkit_input_placeholder
+          | Webkit_search_cancel_button | Webkit_search_decoration
+          | Webkit_datetime_edit_fields_wrapper | Webkit_date_and_time_value
+          | Webkit_datetime_edit | Webkit_datetime_edit_year_field
+          | Webkit_datetime_edit_month_field | Webkit_datetime_edit_day_field
+          | Webkit_datetime_edit_hour_field | Webkit_datetime_edit_minute_field
+          | Webkit_datetime_edit_second_field
+          | Webkit_datetime_edit_millisecond_field
+          | Webkit_datetime_edit_meridiem_field | Webkit_inner_spin_button
+          | Webkit_outer_spin_button | Webkit_calendar_picker_indicator
+          | Webkit_details_marker ->
+              is_user_action_pseudo_class pc
+          | _ -> false))
+
+(* An argument of a logical combination sits where the pseudo-element's own
+   pseudo-classes sit, so it reads as a pseudo-compound tail: pseudo-classes the
+   pseudo-element takes, and nothing else. A combinator or a selector list makes
+   the argument a whole complex selector, which no pseudo-element takes. *)
+and pseudo_element_allows_argument pe = function
+  | Compound components ->
+      List.for_all (pseudo_element_allows_argument pe) components
+  | Combined _ | Relative _ | List _ -> false
+  | c -> is_pe_action c && pseudo_element_allows pe c
+
 (* The merged lists are static across the lifetime of the program (every
    constituent is a [let] binding above); memoise them so the [@] cons-chain
    only happens once instead of per [:foo] / [::foo] pseudo read. *)
@@ -1560,9 +1650,12 @@ and read_compound t =
        [:not()]/[:has()] ([read_not_content]/[read_has_content]) and in the rule
        reader when a whole selector list is unknown. *)
     let s = read_simple ~allow_unknown_pseudo_class:true t in
-    if List.exists is_pseudo_element acc && not (is_pe_action s) then
-      Cursor.err t "pseudo-element must be last in compound selector"
-    else s :: acc
+    match List.find_opt is_pseudo_element acc with
+    | Some _ when not (is_pe_action s) ->
+        Cursor.err t "pseudo-element must be last in compound selector"
+    | Some pe when not (pseudo_element_allows pe s) ->
+        Cursor.err t "pseudo-class not allowed after this pseudo-element"
+    | _ -> s :: acc
   in
   let rec loop acc = if can_start () then loop (prepend_simple acc) else acc in
   match loop [] with

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -892,7 +892,6 @@ let pseudo_element_pseudo_class_rows =
     ( [
         "::placeholder";
         "::file-selector-button";
-        "::cue";
         "::-webkit-input-placeholder";
         "::-webkit-search-cancel-button";
         "::-webkit-search-decoration";
@@ -915,7 +914,8 @@ let pseudo_element_pseudo_class_rows =
       user_action_pseudo_classes );
     (* The scrollbar takes no focus, and reports its own state instead. *)
     ([ "::-webkit-scrollbar" ], [ ":hover"; ":active"; ":enabled"; ":disabled" ]);
-    (* CSS View Transitions 1 sec. 3.4: the group tree is one deep. *)
+    (* CSS View Transitions 1 sec. 3.1: [:only-child] matches a view transition
+       pseudo with no sibling in the pseudo-element tree. *)
     ( [
         "::view-transition-group(*)";
         "::view-transition-image-pair(*)";
@@ -924,12 +924,15 @@ let pseudo_element_pseudo_class_rows =
       ],
       [ ":only-child" ] );
     ([ "::part(tab)"; "::details-content" ], element_backed_pseudo_classes);
-    (* Names no shipping engine knows: cascade keeps them for forward
-       compatibility and cannot know their rules, so it keeps taking any
-       pseudo-class after them. *)
+    (* Names no shipping engine knows, plus the two WebVTT names cascade only
+       has a constructor for in their functional form, so that a bare [::cue] or
+       [::cue-region] reaches the reader as an unrecognised name: cascade keeps
+       all of these for forward compatibility and cannot know their rules, so it
+       keeps taking any pseudo-class after them. *)
     ( [
         "::-moz-placeholder";
         "::-ms-input-placeholder";
+        "::cue";
         "::cue-region";
         "::future-pseudo-element";
         "::foo(bar)";
@@ -1702,7 +1705,9 @@ let spec_selector_scope_pseudo_edges () =
   check_minified_to "input:not([type],[type=hidden])"
     "input:not([type], [type=hidden])";
   check_minified_to "a:before" "a::before";
-  check_minified_to ".a:before:hover" ".a::before:hover";
+  (* Chrome 151 and WebKit 26.5 drop [.a::before:hover], so the legacy fold is
+     pinned with the pseudo-class in the position both keep. *)
+  check_minified_to ".a:hover:before" ".a:hover::before";
   (* CSS Selectors 4 section 5.2: [*] in a non-solitary compound is redundant,
      but dropping it is a node change reserved for the optimizer's
      [Selector.canonicalize]; pp is lexical-only and holds it. *)

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -820,6 +820,200 @@ let logical_combinator_pseudo_element () =
         (concat [ ".a:not(:where("; pe; "))" ]))
     pseudo_element_spellings
 
+(* CSS Selectors 4 sec. 9. Sec. 3.6.3 allows these after every pseudo-element;
+   the engines are narrower, and disagree with the spec on the four Level 2
+   pseudo-elements ([::first-line:hover] is the spec's own example and both
+   engines drop it), so the rows below follow the engines. *)
+let user_action_pseudo_classes =
+  [ ":hover"; ":active"; ":focus"; ":focus-visible"; ":focus-within" ]
+
+(* CSS Pseudo-Elements 4 sec. 5: an element-backed pseudo-element takes the
+   pseudo-classes a real element takes, bar the ones that would report on the
+   tree it sits in - the tree-structural pseudo-classes (Selectors 4 sec. 13)
+   and [:has()]. *)
+let element_backed_pseudo_classes =
+  user_action_pseudo_classes
+  @ [
+      ":enabled";
+      ":disabled";
+      ":checked";
+      ":defined";
+      ":link";
+      ":target";
+      ":dir(ltr)";
+      ":lang(en)";
+    ]
+
+(* Each probe names a pseudo-class cascade recognises: an unrecognised one is
+   already a parse error at an unforgiving site, whatever precedes it, so it
+   would not tell us anything about the pseudo-element's own rules. *)
+let probe_pseudo_classes =
+  element_backed_pseudo_classes
+  @ [
+      ":root";
+      ":empty";
+      ":first-child";
+      ":only-child";
+      ":nth-child(1)";
+      ":has(.b)";
+    ]
+
+(* What each pseudo-element accepts after it. Rows come from CSS Pseudo-Elements
+   4 sec. 5 for the element-backed ones and from Chrome 151 and WebKit 26.5
+   everywhere else, taking a pseudo-class as accepted when either engine keeps
+   the rule: Selectors 4 sec. 3.6.3 hands the per-pseudo-element list to "other
+   specifications", and for the UA widgets that list is only written down in the
+   engines. *)
+let pseudo_element_pseudo_class_rows =
+  [
+    (* Nothing beyond the logical combinations. *)
+    ( [
+        ":before";
+        ":after";
+        ":first-line";
+        ":first-letter";
+        "::before";
+        "::after";
+        "::first-line";
+        "::first-letter";
+        "::backdrop";
+        "::marker";
+        "::selection";
+        "::target-text";
+        "::spelling-error";
+        "::grammar-error";
+        "::highlight(find)";
+        "::view-transition";
+        "::slotted(p)";
+        "::cue(v)";
+      ],
+      [] );
+    (* The UA widgets that stand in for a real control. *)
+    ( [
+        "::placeholder";
+        "::file-selector-button";
+        "::cue";
+        "::-webkit-input-placeholder";
+        "::-webkit-search-cancel-button";
+        "::-webkit-search-decoration";
+        "::-webkit-datetime-edit";
+        "::-webkit-datetime-edit-fields-wrapper";
+        "::-webkit-datetime-edit-year-field";
+        "::-webkit-datetime-edit-month-field";
+        "::-webkit-datetime-edit-day-field";
+        "::-webkit-datetime-edit-hour-field";
+        "::-webkit-datetime-edit-minute-field";
+        "::-webkit-datetime-edit-second-field";
+        "::-webkit-datetime-edit-millisecond-field";
+        "::-webkit-datetime-edit-meridiem-field";
+        "::-webkit-date-and-time-value";
+        "::-webkit-inner-spin-button";
+        "::-webkit-outer-spin-button";
+        "::-webkit-calendar-picker-indicator";
+        "::-webkit-details-marker";
+      ],
+      user_action_pseudo_classes );
+    (* The scrollbar takes no focus, and reports its own state instead. *)
+    ([ "::-webkit-scrollbar" ], [ ":hover"; ":active"; ":enabled"; ":disabled" ]);
+    (* CSS View Transitions 1 sec. 3.4: the group tree is one deep. *)
+    ( [
+        "::view-transition-group(*)";
+        "::view-transition-image-pair(*)";
+        "::view-transition-old(*)";
+        "::view-transition-new(*)";
+      ],
+      [ ":only-child" ] );
+    ([ "::part(tab)"; "::details-content" ], element_backed_pseudo_classes);
+    (* Names no shipping engine knows: cascade keeps them for forward
+       compatibility and cannot know their rules, so it keeps taking any
+       pseudo-class after them. *)
+    ( [
+        "::-moz-placeholder";
+        "::-ms-input-placeholder";
+        "::cue-region";
+        "::future-pseudo-element";
+        "::foo(bar)";
+        "::deep";
+        "::v-deep";
+        "::ng-deep";
+      ],
+      probe_pseudo_classes );
+  ]
+
+(* CSS Selectors 4 sec. 3.6.3: "Certain pseudo-elements may be immediately
+   followed by any combination of certain pseudo-classes [...] Combinations that
+   are not explicitly allowed are invalid selectors." Which combinations those
+   are is per pseudo-element, so one predicate over all of them cannot answer
+   it: Chrome 151 and WebKit 26.5 keep [::file-selector-button:hover] and drop
+   [::before:hover], and agree on every row below. *)
+let pseudo_element_pseudo_classes () =
+  let concat = String.concat "" in
+  let parses input =
+    match Cursor.option read (Cursor.of_string input) with
+    | Some _ -> ()
+    | None -> Alcotest.failf "selector should parse: %s" input
+  in
+  List.iter
+    (fun (spellings, allowed) ->
+      List.iter
+        (fun pe ->
+          List.iter
+            (fun pc ->
+              let sel = concat [ ".a"; pe; pc ] in
+              if List.mem pc allowed then parses sel else neg_cursor read sel)
+            probe_pseudo_classes;
+          (* Sec. 3.6.3 allows the logical combinations after any pseudo-element
+             and passes the row on to their arguments; what an argument the row
+             rules out costs is then the argument list's own business. [:is()]
+             and [:where()] take a [<forgiving-selector-list>] (sec. 4.1), which
+             drops it and leaves a selector that still parses and matches
+             nothing, so both engines keep the rule whatever the row says. *)
+          List.iter
+            (fun pc -> parses (concat [ ".a"; pe; pc ]))
+            [ ":is(.b)"; ":where(.b)"; ":is(:hover)"; ":not(:is(.b))" ];
+          (* [:not()] takes an unforgiving list, so it goes down with an
+             argument the row rules out. *)
+          List.iter
+            (fun pc ->
+              let sel = concat [ ".a"; pe; ":not("; pc; ")" ] in
+              if List.mem pc allowed then parses sel else neg_cursor read sel)
+            probe_pseudo_classes;
+          (* Only a pseudo-class may follow a pseudo-element at all, so a
+             [:not()] holding anything else goes down with it too - except after
+             a name cascade does not recognise, whose row takes every probe
+             because cascade knows none of its rules. *)
+          let knows_nothing =
+            List.for_all (fun pc -> List.mem pc allowed) probe_pseudo_classes
+          in
+          let sel = concat [ ".a"; pe; ":not(.b)" ] in
+          if knows_nothing then parses sel else neg_cursor read sel)
+        spellings)
+    pseudo_element_pseudo_class_rows;
+  (* The row reaches all the way down a nest of unforgiving lists, and stops at
+     the first forgiving one. *)
+  parses ".a::part(tab):not(:not(:hover))";
+  parses ".a::-webkit-scrollbar:not(:not(:hover))";
+  parses ".a::part(tab):not(:where(.b))";
+  neg_cursor read ".a::part(tab):not(:not(.b))";
+  neg_cursor read ".a::-webkit-scrollbar:not(:not(:focus))";
+  neg_cursor read ".a::before:not(:not(:hover))";
+  neg_cursor read ".a::marker:not(:not(:hover))";
+  (* A whole complex selector never fits where a pseudo-class goes. *)
+  neg_cursor read ".a::part(tab):not(div>.b)";
+  (* No pseudo-element is left to a default: every spelling the compound guard
+     covers names its own row. *)
+  let covered pe =
+    List.exists
+      (fun (spellings, _) -> List.mem pe spellings)
+      pseudo_element_pseudo_class_rows
+  in
+  List.iter
+    (fun pe ->
+      Alcotest.(check bool)
+        (String.concat "" [ "pseudo-class row for "; pe ])
+        true (covered pe))
+    pseudo_element_spellings
+
 let parse_errors_nesting_depth () =
   (* A pathologically deep functional-pseudo-class nest is capped rather than
      driving the per-level selector validation into super-linear time (a
@@ -1893,6 +2087,8 @@ let suite =
         pseudo_element_compound_guard;
       test_case "logical combinator pseudo-element" `Quick
         logical_combinator_pseudo_element;
+      test_case "pseudo-element pseudo-classes" `Quick
+        pseudo_element_pseudo_classes;
       test_case "parse errors - nesting depth" `Quick parse_errors_nesting_depth;
       test_case "parse errors - empty list" `Quick parse_errors_empty_list;
       test_case "parse errors - complex" `Quick parse_errors_complex;


### PR DESCRIPTION
`.a::before:hover`, `::marker:hover`, `::selection:hover` and `::spelling-error:hover` used to parse; which pseudo-classes may follow a pseudo-element is now read per pseudo-element, so those stop while `::file-selector-button:hover`, `::part(p):hover`, `::cue:hover` and `::-webkit-scrollbar:hover` keep parsing. The table is derived from Chrome 151 and WebKit 26.5, not from Selectors 4 sec. 3.6.3, which allows the user-action pseudo-classes after any pseudo-element and whose own example `::first-line:hover` both engines drop; where the engines disagree it takes the permissive union, so `::placeholder:hover` stays even though only WebKit keeps it. The row carries into a logical combination's argument, along the split Selectors 4 sec. 4.1 draws: `:is()` and `:where()` take a forgiving list, so both engines keep `::before:is(.b)` as a rule that matches nothing, while the unforgiving `:not()` goes down with an argument the row refuses, so `::before:not(.b)` and `::part(p):not(.b)` are rejected and `::part(p):not(:hover)` is not. The minifier oracle that pinned `.a::before:hover` now pins the legacy single-colon fold as `.a:hover::before`, the position both engines keep.

Stacked on #426.
