### PR TITLE
selector: keep the :is() wrapper a pseudo-compound needs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -310,6 +310,11 @@
   conflict test walks the two key lists in step instead of scanning one per
   element of the other, and collecting them no longer rescans what it has
   already collected (#422)
+- A single-argument `:is()` keeps its wrapper after a pseudo-element that
+  cannot take its argument, so `.a::before:is(.b)` minifies to
+  `.a:before:is(.b)` rather than the `.a:before.b` that cascade's own reader,
+  Chrome and WebKit all drop. It still unwraps everywhere the compound can hold
+  the argument, `.a::part(p):is(:hover)` included (#431)
 - Merging same-selector rules keeps a later declaration behind a nested
   conditional group that sets the same property. The safety check saw a nested
   style rule only, so `@media`, `@container` and friends let the merge hoist

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2414,6 +2414,29 @@ let canonicalize_unordered_list selectors =
   in
   List.sort (fun (k1, _) (k2, _) -> String.compare k1 k2) uniq |> List.map snd
 
+(* [map] rewrites a compound's components before the compound itself, so the
+   [Is] branch below has already spliced a single-argument [:is()] into this
+   list. A component the reader refuses after the pseudo-element can only have
+   arrived that way, so the compound puts the wrapper back: Selectors 4 sec. 16
+   builds a pseudo-compound out of [<pseudo-element-selector>
+   <pseudo-class-selector>*] and sec. 3.6.3 makes the pseudo-class list per
+   pseudo-element. *)
+let rewrap_pseudo_compound components =
+  let rec loop seen = function
+    | [] -> []
+    | c :: rest when is_pseudo_element c -> c :: loop (Some c) rest
+    | c :: rest ->
+        let c =
+          match seen with
+          | Some pe when not (is_pe_action c && pseudo_element_allows pe c) ->
+              Is [ c ]
+          | _ -> c
+        in
+        c :: loop seen rest
+  in
+  if List.exists is_pseudo_element components then loop None components
+  else components
+
 (* Canonicalise so selectors denoting the same thing are structurally equal:
    drop the implied [*] from a multi-part compound ([*.foo] -> [.foo]), collapse
    a one-part compound, and dedup/sort selector-list alternatives by printed
@@ -2429,7 +2452,9 @@ let canonicalize sel =
       in
       match node with
       | Compound components -> (
-          match drop_redundant_universal components with
+          match
+            rewrap_pseudo_compound (drop_redundant_universal components)
+          with
           | [ single ] -> single
           | components' ->
               if list_same components' components then node

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -1017,6 +1017,40 @@ let pseudo_element_pseudo_classes () =
         true (covered pe))
     pseudo_element_spellings
 
+(* [canonicalize] splices a single-argument [:is(s)] into the compound around
+   it, since [:is(s)] matches [s] with the same specificity (Selectors 4 sec.
+   4.2). A pseudo-compound is [<pseudo-element-selector>
+   <pseudo-class-selector>*] (sec. 16) and which pseudo-classes it takes is per
+   pseudo-element (sec. 3.6.3), so the splice would build a compound cascade's
+   own reader rejects. Chrome 151 and WebKit 26.5 keep every input below and
+   drop [.a::before.b] and [.a::before:hover]. *)
+let canonicalize_pseudo_compound_is () =
+  let canon expected input =
+    let actual = to_string ~minify:true (canonicalize (of_string input)) in
+    Alcotest.(check string) ("canonicalize " ^ input) expected actual;
+    match Cursor.option read (Cursor.of_string actual) with
+    | Some _ -> ()
+    | None -> Alcotest.failf "canonicalized selector does not parse: %s" actual
+  in
+  (* The wrapper stays in a pseudo-compound. *)
+  canon ".a:before:is(.b)" ".a::before:is(.b)";
+  canon ".a:before:is(#c)" ".a::before:is(#c)";
+  canon ".a:before:is([d])" ".a::before:is([d])";
+  canon ".a:before:is(div)" ".a::before:is(div)";
+  canon ".a:before:is(.b.c)" ".a::before:is(.b.c)";
+  canon ".a:before:is(:hover)" ".a::before:is(:hover)";
+  canon ".a:before:is(.b)" ".a:before:is(.b)";
+  canon "div .a:before:is(.b)" "div .a::before:is(.b)";
+  (* [::part()] takes the user action pseudo-classes, so that one splices. *)
+  canon ".a::part(p):hover" ".a::part(p):is(:hover)";
+  (* Outside a pseudo-compound the splice stands. *)
+  canon ".a.b" ".a:is(.b)";
+  canon "div>.b" "div>:is(.b)";
+  canon ".b" ":is(.b)";
+  canon ".x .a" ".x :is(:is(.a))";
+  (* [:where()] never unwraps: it contributes zero specificity. *)
+  canon ".a:before:where(.b)" ".a::before:where(.b)"
+
 let parse_errors_nesting_depth () =
   (* A pathologically deep functional-pseudo-class nest is capped rather than
      driving the per-level selector validation into super-linear time (a
@@ -2094,6 +2128,8 @@ let suite =
         logical_combinator_pseudo_element;
       test_case "pseudo-element pseudo-classes" `Quick
         pseudo_element_pseudo_classes;
+      test_case "canonicalize pseudo-compound :is()" `Quick
+        canonicalize_pseudo_compound_is;
       test_case "parse errors - nesting depth" `Quick parse_errors_nesting_depth;
       test_case "parse errors - empty list" `Quick parse_errors_empty_list;
       test_case "parse errors - complex" `Quick parse_errors_complex;


### PR DESCRIPTION
`--minify` used to carry `.a::before:is(.b)` to `.a:before.b`, a selector cascade's own reader drops and Chrome 151 and WebKit 26.5 drop too, while both keep the input; the single-argument `:is()` now keeps its wrapper wherever the compound around it cannot hold the argument, and still unwraps everywhere else, `.a::part(p):is(:hover)` included.

Stacked on #430, which supplies the per-pseudo-element pseudo-class list this reads, and without which `.a::before:is(:hover)` stays folded to `.a:before:hover`.