### PR TITLE
css: escape a prelude or value name that needs it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,13 @@
   CSS-wide keyword as a corner radius. CSS Backgrounds 3 sec. 5.1 allows only a
   non-negative `<length-percentage>` there, and Chrome and WebKit drop every
   such declaration (#417)
+- A `<custom-ident>` or `<dashed-ident>` an at-rule prelude or a declaration
+  value names is printed with the escapes CSS Syntax 3 sec. 4.3.7 needs to read
+  it back as the same name. `@layer a\3b b` printed `@layer a;b`, two
+  statements naming a layer the input never had. `@counter-style`,
+  `@position-try`, `@font-palette-values`, `@container`, `@import layer()`, a
+  `@font-feature-values` feature name and every name a declaration value
+  carries, from `anchor-name` to `will-change`, all take the escaping (#436)
 - An `@layer` block inside a style rule holds nesting content, so
   `.a { @layer n { color: red } }` keeps its declaration instead of reading the
   body as a selector list and dropping it. CSS Nesting 1 sec. 3.1 admits nested

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -95,8 +95,8 @@ let rec pp_animation_iteration_count : animation_iteration_count Pp.t =
 let rec pp_animation_name : animation_name Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"
-  | Name name -> Pp.string ctx name
-  | Ambiguous name -> Pp.string ctx name
+  | Name name -> pp_ident ctx name
+  | Ambiguous name -> pp_ident ctx name
   | Quoted name ->
       (* CSS Animations 1 sec. 3: [<keyframes-name>] excludes [none], the
          CSS-wide keywords, and [default]. A source [animation-name: "none"]
@@ -203,7 +203,7 @@ let rec pp_animation_timeline : animation_timeline Pp.t =
   | Var v -> pp_var pp_animation_timeline ctx v
   | None -> Pp.string ctx "none"
   | Auto -> Pp.string ctx "auto"
-  | Name name -> Pp.string ctx name
+  | Name name -> pp_ident ctx name
   | Scroll args ->
       Pp.string ctx "scroll(";
       Pp.string ctx (canonical_scroll_timeline_args args);
@@ -283,7 +283,7 @@ let rec pp_view_transition_name : view_transition_name Pp.t =
   | Var v -> pp_var pp_view_transition_name ctx v
   | None -> Pp.string ctx "none"
   | Match_element -> Pp.string ctx "match-element"
-  | Name name -> Pp.string ctx name
+  | Name name -> pp_ident ctx name
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -294,7 +294,7 @@ let rec pp_view_transition_class : view_transition_class Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_view_transition_class ctx v
   | None -> Pp.string ctx "none"
-  | Classes classes -> Pp.list ~sep:Pp.space Pp.string ctx classes
+  | Classes classes -> Pp.list ~sep:Pp.space pp_ident ctx classes
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -318,7 +318,7 @@ let rec pp_timeline_name : timeline_name Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_timeline_name ctx v
   | None -> Pp.string ctx "none"
-  | Names names -> Pp.list ~sep:Pp.comma Pp.string ctx names
+  | Names names -> Pp.list ~sep:Pp.comma pp_ident ctx names
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -327,7 +327,7 @@ let rec pp_timeline_name : timeline_name Pp.t =
 
 let pp_timeline_shorthand_item : timeline_shorthand_item Pp.t =
  fun ctx { name; axis } ->
-  Pp.string ctx name;
+  pp_ident ctx name;
   Pp.space ctx ();
   pp_timeline_axis ctx axis
 
@@ -432,7 +432,7 @@ let rec pp_transition_property_value : transition_property_value Pp.t =
  fun ctx -> function
   | All -> Pp.string ctx "all"
   | None -> Pp.string ctx "none"
-  | Property s -> Pp.string ctx s
+  | Property s -> pp_ident ctx s
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -86,6 +86,13 @@ let pp_opt_space pp ctx = function
 
 let pp_keyword s ctx = Pp.string ctx s
 
+(* CSS Syntax 3 sec. 4.3.7 lets an escape carry a [;], a [}] or any other code
+   point CSS Syntax 3 sec. 4.2 keeps out of an ident into a name, so a
+   [<custom-ident>] or [<dashed-ident>] is written back with the escapes that
+   read it as the same name (see [Properties.pp_property]). Printed raw it ends
+   its own declaration. *)
+let pp_ident : string Pp.t = fun ctx s -> Pp.string ctx (Parser.escape_ident s)
+
 let is_zero_length : length -> bool = function
   | Zero
   | Px 0.

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -887,7 +887,7 @@ let rec pp_font_palette : font_palette Pp.t =
   | Normal -> Pp.string ctx "normal"
   | Light -> Pp.string ctx "light"
   | Dark -> Pp.string ctx "dark"
-  | Palette name -> Pp.string ctx name
+  | Palette name -> pp_ident ctx name
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -39,11 +39,11 @@ let rec pp_grid_line : grid_line Pp.t =
  fun ctx -> function
   | Auto -> Pp.string ctx "auto"
   | Num n -> Pp.int ctx n
-  | Name s -> Pp.string ctx s
+  | Name s -> pp_ident ctx s
   | Num_name (n, name) ->
       Pp.int ctx n;
       Pp.char ctx ' ';
-      Pp.string ctx name
+      pp_ident ctx name
   | Span n ->
       Pp.string ctx "span";
       Pp.char ctx ' ';
@@ -51,17 +51,17 @@ let rec pp_grid_line : grid_line Pp.t =
   | Span_name name ->
       Pp.string ctx "span";
       Pp.char ctx ' ';
-      Pp.string ctx name
+      pp_ident ctx name
   | Span_num_name (1, name) when Pp.minified ctx ->
       Pp.string ctx "span";
       Pp.char ctx ' ';
-      Pp.string ctx name
+      pp_ident ctx name
   | Span_num_name (n, name) ->
       Pp.string ctx "span";
       Pp.char ctx ' ';
       Pp.int ctx n;
       Pp.char ctx ' ';
-      Pp.string ctx name
+      pp_ident ctx name
   | Calc c -> pp_calc pp_grid_line ctx c
   | Var v -> pp_var pp_grid_line ctx v
 
@@ -221,7 +221,7 @@ let rec pp_grid_template : grid_template Pp.t =
       Pp.list ~sep:Pp.space pp_named_track ctx tracks
   | Line_names names ->
       Pp.char ctx '[';
-      Pp.list ~sep:Pp.space Pp.string ctx names;
+      Pp.list ~sep:Pp.space pp_ident ctx names;
       Pp.char ctx ']'
   | Template raw ->
       (* The complex grid-template syntax (with [<grid-template-areas>] string

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -20,7 +20,7 @@ let rec pp_will_change : will_change Pp.t =
   | Contents -> Pp.string ctx "contents"
   | Transform -> Pp.string ctx "transform"
   | Opacity -> Pp.string ctx "opacity"
-  | Properties props -> Pp.list ~sep:Pp.comma Pp.string ctx props
+  | Properties props -> Pp.list ~sep:Pp.comma pp_ident ctx props
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -63,7 +63,7 @@ let rec pp_container_name : container_name Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_container_name ctx v
   | None -> Pp.string ctx "none"
-  | Names names -> Pp.list ~sep:Pp.space Pp.string ctx names
+  | Names names -> Pp.list ~sep:Pp.space pp_ident ctx names
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -74,7 +74,7 @@ let rec pp_anchor_name : anchor_name Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_anchor_name ctx v
   | None -> Pp.string ctx "none"
-  | Names names -> Pp.list ~sep:Pp.comma Pp.string ctx names
+  | Names names -> Pp.list ~sep:Pp.comma pp_ident ctx names
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -85,7 +85,7 @@ let rec pp_position_anchor : position_anchor Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_position_anchor ctx v
   | Auto -> Pp.string ctx "auto"
-  | Anchor name -> Pp.string ctx name
+  | Anchor name -> pp_ident ctx name
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -97,7 +97,7 @@ let pp_position_try_fallback : position_try_fallback Pp.t =
   | Flip_block -> Pp.string ctx "flip-block"
   | Flip_inline -> Pp.string ctx "flip-inline"
   | Flip_start -> Pp.string ctx "flip-start"
-  | Name name -> Pp.string ctx name
+  | Name name -> pp_ident ctx name
 
 let rec pp_position_try_fallbacks : position_try_fallbacks Pp.t =
  fun ctx -> function

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -349,7 +349,7 @@ let rec pp_color_scheme : color_scheme Pp.t =
       Pp.string ctx "dark";
       Pp.space ctx ();
       Pp.string ctx "only"
-  | Custom names -> Pp.list ~sep:Pp.space Pp.string ctx names
+  | Custom names -> Pp.list ~sep:Pp.space pp_ident ctx names
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -769,11 +769,11 @@ let rec pp_content : content Pp.t =
   | Open_quote -> Pp.string ctx "open-quote"
   | Close_quote -> Pp.string ctx "close-quote"
   | Attr attr -> Pp.call "attr" (Values.pp_attr_call pp_content) ctx attr
-  | Counter name -> Pp.call "counter" Pp.string ctx name
-  | String_ref name -> Pp.call "string" Pp.string ctx name
+  | Counter name -> Pp.call "counter" pp_ident ctx name
+  | String_ref name -> Pp.call "string" pp_ident ctx name
   | Counters (name, separator) ->
       Pp.string ctx "counters(";
-      Pp.string ctx name;
+      pp_ident ctx name;
       Pp.char ctx ',';
       Pp.space ctx ();
       Pp.quoted_string ctx separator;
@@ -787,7 +787,7 @@ let rec pp_content : content Pp.t =
   | Var v -> pp_var pp_content ctx v
 
 let pp_counter_item ctx { name; value } =
-  Pp.string ctx name;
+  pp_ident ctx name;
   match value with
   | None -> ()
   | Some n ->

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -932,12 +932,25 @@ let pp_import_url ctx url =
   then Pp.string ctx url
   else Pp.quoted_string ctx url
 
+(* CSS Cascade 5 sec. 6.4.1: a [<layer-name>] is [<ident> ['.' <ident>]*], so
+   the escapes CSS Syntax 3 sec. 4.3.7 needs go on each dot-separated part while
+   the [.] separators stay bare (see [Properties.pp_property]). *)
+let escape_layer_name name =
+  if String.contains name '.' then
+    String.split_on_char '.' name
+    |> List.map Parser.escape_ident
+    |> String.concat "."
+  else Parser.escape_ident name
+
+let pp_layer_name : string Pp.t =
+ fun ctx name -> Pp.string ctx (escape_layer_name name)
+
 let pp_import_layer ctx layer =
   Pp.sp ctx ();
   if layer = "" then Pp.string ctx "layer"
   else (
     Pp.string ctx "layer(";
-    Pp.string ctx layer;
+    pp_layer_name ctx layer;
     Pp.char ctx ')')
 
 let pp_import_supports ctx supports =
@@ -1153,7 +1166,7 @@ let pp_counter_style_system ctx = function
   | Extends name ->
       Pp.string ctx "extends";
       Pp.space ctx ();
-      Pp.string ctx name
+      Pp.string ctx (Parser.escape_ident name)
 
 let pp_counter_symbol ctx symbol = Pp.quoted_string ctx symbol
 
@@ -1213,7 +1226,7 @@ let pp_font_palette_descriptor : font_palette_descriptor Pp.t =
         ctx entries
 
 let pp_font_feature_value ctx (name, indexes) =
-  Pp.string ctx name;
+  Pp.string ctx (Parser.escape_ident name);
   Pp.char ctx ':';
   Pp.space_if_pretty ctx ();
   Pp.list ~sep:Pp.space Pp.int ctx indexes
@@ -1295,7 +1308,7 @@ and pp_layer_statement ctx name content =
   (match name with
   | Some n ->
       Pp.string ctx " ";
-      Pp.string ctx n
+      pp_layer_name ctx n
   | None -> ());
   (* For empty layers: use statement form when minifying (more concise), but
      preserve block form otherwise for roundtrip fidelity. A style rule accepts
@@ -1331,7 +1344,7 @@ and pp_container_statement ctx name condition content =
   (match name with
   | Some n ->
       Pp.char ctx ' ';
-      Pp.string ctx n
+      Pp.string ctx (Parser.escape_ident n)
   | None -> ());
   (match condition with
   | Some condition ->
@@ -1414,7 +1427,7 @@ and pp_statement : statement Pp.t =
   | Property r -> pp_property_rule ctx r
   | Layer_decl names ->
       Pp.string ctx "@layer ";
-      Pp.list ~sep:Pp.comma Pp.string ctx names;
+      Pp.list ~sep:Pp.comma pp_layer_name ctx names;
       Pp.semicolon ctx ()
   | Layer (name, content) -> pp_layer_statement ctx name content
   | Media (condition, content) -> pp_media_statement ctx condition content
@@ -1454,7 +1467,7 @@ and pp_statement : statement Pp.t =
       Pp.braced_semicolon_list pp_font_face_descriptor ctx descriptors
   | Counter_style (name, descriptors) ->
       Pp.string ctx "@counter-style ";
-      Pp.string ctx name;
+      Pp.string ctx (Parser.escape_ident name);
       Pp.sp ctx ();
       Pp.braced_semicolon_list pp_counter_style_descriptor ctx descriptors
   | Page (selector, raw_declarations) ->
@@ -1469,7 +1482,7 @@ and pp_statement : statement Pp.t =
       pp_page_with_margins_body ctx descriptors margins
   | Font_palette_values (name, descriptors) ->
       Pp.string ctx "@font-palette-values ";
-      Pp.string ctx name;
+      Pp.string ctx (Parser.escape_ident name);
       Pp.sp ctx ();
       Pp.braced_semicolon_list pp_font_palette_descriptor ctx descriptors
   | Font_feature_values (families, blocks) ->
@@ -1485,7 +1498,7 @@ and pp_statement : statement Pp.t =
       Pp.braced_semicolon_list pp_view_transition_descriptor ctx descriptors
   | Position_try (name, declarations) ->
       Pp.string ctx "@position-try ";
-      Pp.string ctx name;
+      Pp.string ctx (Parser.escape_ident name);
       Pp.sp ctx ();
       Pp.braced_semicolon_list Declaration.pp_declaration ctx declarations
   | Viewport (prefix, descriptors) ->

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6301,40 +6301,45 @@ let s3437_string_escape () =
    those back escaped (CSS Syntax 3 sec. 2.1): printed raw, the name ends its
    own declaration or closes the rule around it, and cascade's reader stops
    reading what the input meant. *)
-let s4370_custom_property_name_escapes () =
-  (* Print [css] and hold the printer to its own reader: the output parses in
-     strict mode, says what the input said, and printing it again is a byte
-     fixpoint. The tree comparison stands in for AST equality, which a token
-     carrying its source position makes sensitive to how long the escape was.
-     The minified output is what the spellings below are checked against. *)
-  let roundtrip css =
-    match Css.of_string ~strict:false css with
-    | Error e ->
-        Alcotest.failf "parse failed: %s (%s)" css (Cascade.Error.to_string e)
-    | Ok parsed ->
-        let check ~minify label out =
-          match Css.of_string ~strict:true out with
-          | Error e ->
-              Alcotest.failf "%s output is not readable: %s (%s)" label out
-                (Cascade.Error.to_string e)
-          | Ok again ->
-              Alcotest.(check bool)
-                (String.concat "" [ label; " says what "; css; " said" ])
-                true
-                (Cascade_diff.Css_compare.equal ~mode:`Tree css out);
-              Alcotest.(check string)
-                (String.concat "" [ label; " is a byte fixpoint: "; out ])
-                out
-                (Css.to_string ~minify again.Css.stylesheet)
-        in
-        let minified = Css.to_string ~minify:true parsed.Css.stylesheet in
-        check ~minify:true "minified" minified;
-        check ~minify:false "pretty" (Css.to_string parsed.Css.stylesheet);
-        minified
-  in
+(* Print [css] and hold the printer to its own reader: the output parses in
+   strict mode, says what the input said, and printing it again is a byte
+   fixpoint. The tree comparison stands in for AST equality, which a token
+   carrying its source position makes sensitive to how long the escape was.
+   Returns the minified output, which is what a caller's spellings are checked
+   against. *)
+let escape_roundtrip css =
+  match Css.of_string ~strict:false css with
+  | Error e ->
+      Alcotest.failf "parse failed: %s (%s)" css (Cascade.Error.to_string e)
+  | Ok parsed ->
+      let check ~minify label out =
+        match Css.of_string ~strict:true out with
+        | Error e ->
+            Alcotest.failf "%s output is not readable: %s (%s)" label out
+              (Cascade.Error.to_string e)
+        | Ok again ->
+            Alcotest.(check bool)
+              (String.concat "" [ label; " says what "; css; " said" ])
+              true
+              (Cascade_diff.Css_compare.equal ~mode:`Tree css out);
+            Alcotest.(check string)
+              (String.concat "" [ label; " is a byte fixpoint: "; out ])
+              out
+              (Css.to_string ~minify again.Css.stylesheet)
+      in
+      let minified = Css.to_string ~minify:true parsed.Css.stylesheet in
+      check ~minify:true "minified" minified;
+      check ~minify:false "pretty" (Css.to_string parsed.Css.stylesheet);
+      minified
+
+let check_escape_roundtrips cases =
   List.iter
     (fun (css, expected) ->
-      Alcotest.(check string) css expected (roundtrip css))
+      Alcotest.(check string) css expected (escape_roundtrip css))
+    cases
+
+let s4370_custom_property_name_escapes () =
+  check_escape_roundtrips
     [
       (* The declaration name. *)
       (":root{--x\\3b y:red}", ":root{--x\\;y:red}");
@@ -6362,6 +6367,100 @@ let s4370_custom_property_name_escapes () =
       (":root{--0:red}.a{color:var(--0)}", ":root{--0:red}.a{color:var(--0)}");
       ( ":root{--\\e9 x:red}.a{color:var(--\\e9 x)}",
         ":root{--\xc3\xa9x:red}.a{color:var(--\xc3\xa9x)}" );
+    ]
+
+(* CSS Syntax 3 sec. 4.3.7 reads an escape as the code point it names, so any
+   ident cascade stores can hold a [;], a [}] or another code point CSS Syntax 3
+   sec. 4.2 keeps out of an ident. Serializing an ident writes those back
+   escaped (CSS Syntax 3 sec. 2.1), and every prelude below names something with
+   a [<custom-ident>] or a [<dashed-ident>]: printed raw the name ends the
+   at-rule or closes the block around it. *)
+let s4370_at_rule_prelude_name_escapes () =
+  check_escape_roundtrips
+    [
+      (* CSS Cascade 5 sec. 6.4.1: a [<layer-name>] is [<ident> ['.' <ident>]*],
+         so each dot-separated part takes the escapes and the [.] separators
+         stay bare. *)
+      ("@layer a\\3b b;", "@layer a\\;b;");
+      ("@layer a\\3b b{.x{color:red}}", "@layer a\\;b{.x{color:red}}");
+      ("@layer a\\3b b,c\\3b d;", "@layer a\\;b,c\\;d;");
+      ("@layer a.b\\3b c;", "@layer a.b\\;c;");
+      ("@import\"a.css\"layer(l\\3b x);", "@import\"a.css\"layer(l\\;x);");
+      (* CSS Counter Styles 3 sec. 2 [@counter-style <counter-style-name>], and
+         sec. 3.1.4 [system: extends <counter-style-name>]. *)
+      ( "@counter-style a\\3b b{system:cyclic;symbols:\"x\";suffix:\" \"}",
+        "@counter-style a\\;b{system:cyclic;symbols:\"x\";suffix:\" \"}" );
+      ( "@counter-style c{system:extends d\\3b y}",
+        "@counter-style c{system:extends d\\;y}" );
+      (* CSS Anchor Positioning 1 sec. 4.2 [@position-try <dashed-ident>] and
+         CSS Fonts 4 sec. 11.1 [@font-palette-values <dashed-ident>]. *)
+      ("@position-try --x\\3b y{top:0}", "@position-try --x\\;y{top:0}");
+      ( "@font-palette-values --x\\3b y{font-family:Foo;base-palette:1}",
+        "@font-palette-values --x\\;y{font-family:Foo;base-palette:1}" );
+      (* CSS Containment 3 sec. 5.2: [@container] names a [<custom-ident>], and
+         CSS Fonts 4 sec. 6.5 names a feature value the same way. *)
+      ( "@container n\\3b m (width>10px){.a{color:red}}",
+        "@container n\\;m (width>10px){.a{color:red}}" );
+      ( "@font-feature-values Foo{@styleset{s\\3b x:1}}",
+        "@font-feature-values Foo{@styleset{s\\;x:1}}" );
+      (* A name needing no escape keeps its spelling, and the leading-digit rule
+         of CSS Syntax 3 sec. 4.3.11 still applies. *)
+      ("@layer a.b{.x{color:red}}", "@layer a.b{.x{color:red}}");
+      ( "@counter-style \\31 a{system:cyclic;symbols:\"x\";suffix:\" \"}",
+        "@counter-style \\31 a{system:cyclic;symbols:\"x\";suffix:\" \"}" );
+      ( "@counter-style \\e9 x{system:cyclic;symbols:\"x\";suffix:\" \"}",
+        "@counter-style \xc3\xa9x{system:cyclic;symbols:\"x\";suffix:\" \"}" );
+    ]
+
+(* The same rule for a name a declaration's value carries: printed raw it ends
+   its own declaration, so it is written with the escapes CSS Syntax 3 sec.
+   4.3.7 reads back as the same name. *)
+let s4370_property_value_name_escapes () =
+  check_escape_roundtrips
+    [
+      (* CSS Anchor Positioning 1 sec. 2.1 / 3.1 / 4.1 name
+         [<dashed-ident>]s. *)
+      (".a{anchor-name:--a\\3b b}", ".a{anchor-name:--a\\;b}");
+      (".a{position-anchor:--p\\3b q}", ".a{position-anchor:--p\\;q}");
+      ( ".a{position-try-fallbacks:--f\\3b g}",
+        ".a{position-try-fallbacks:--f\\;g}" );
+      (* CSS Scroll Animations 1 sec. 2.1 / 3.1 / 4 name [<dashed-ident>]s, and
+         CSS Fonts 4 sec. 2.7 [font-palette] takes one. *)
+      (".a{animation-timeline:--t\\3b u}", ".a{animation-timeline:--t\\;u}");
+      (".a{scroll-timeline-name:--s\\3b t}", ".a{scroll-timeline-name:--s\\;t}");
+      (".a{view-timeline-name:--v\\3b w}", ".a{view-timeline-name:--v\\;w}");
+      ( ".a{scroll-timeline:--s\\3b t block}",
+        ".a{scroll-timeline:--s\\;t block}" );
+      (".a{timeline-scope:--z\\3b y}", ".a{timeline-scope:--z\\;y}");
+      (".a{font-palette:--f\\3b g}", ".a{font-palette:--f\\;g}");
+      (* CSS Transitions 1 sec. 2.1: [transition-property] names a property, and
+         a custom property is a [<dashed-ident>]. *)
+      (".a{transition-property:--t\\3b x}", ".a{transition-property:--t\\;x}");
+      (* [<custom-ident>] names: CSS Containment 3 sec. 3.1, CSS Animations 1
+         sec. 4.1, CSS View Transitions 1 sec. 3.1 and 2 sec. 3.2, and CSS Will
+         Change 1 sec. 2. *)
+      (".a{container-name:c\\3b d}", ".a{container-name:c\\;d}");
+      (".a{animation-name:n\\3b m}", ".a{animation-name:n\\;m}");
+      (".a{view-transition-name:v\\3b w}", ".a{view-transition-name:v\\;w}");
+      (".a{view-transition-class:c\\3b d}", ".a{view-transition-class:c\\;d}");
+      (".a{will-change:w\\3b x}", ".a{will-change:w\\;x}");
+      (* CSS Lists 3 sec. 3 names a counter with a [<custom-ident>], both where
+         it is set and where [counter()] reads it, and sec. 4 names a string the
+         same way. *)
+      (".a{counter-reset:c\\3b d 1}", ".a{counter-reset:c\\;d 1}");
+      (".a{counter-increment:c\\3b d 1}", ".a{counter-increment:c\\;d 1}");
+      (".a{content:counter(c\\3b d)}", ".a{content:counter(c\\;d)}");
+      (".a{content:string(s\\3b t)}", ".a{content:string(s\\;t)}");
+      (* CSS Grid 2 sec. 8.1: a grid line is named by a [<custom-ident>], in a
+         placement property and in a track list. *)
+      (".a{grid-area:g\\3b h}", ".a{grid-area:g\\;h}");
+      (".a{grid-row-start:g\\3b h}", ".a{grid-row-start:g\\;h}");
+      (".a{grid-row-start:span g\\3b h}", ".a{grid-row-start:span g\\;h}");
+      ( ".a{grid-template-columns:[l\\3b m]1fr}",
+        ".a{grid-template-columns:[l\\;m]1fr}" );
+      (* A name needing no escape keeps its spelling. *)
+      (".a{grid-area:g}", ".a{grid-area:g}");
+      (".a{anchor-name:--a}", ".a{anchor-name:--a}");
     ]
 
 let fidelity_string_escape_preserved () =
@@ -8523,6 +8622,12 @@ let additional_tests =
     ( "spec syntax 3 4.3.7 custom-property name escapes",
       `Quick,
       s4370_custom_property_name_escapes );
+    ( "spec syntax 3 4.3.7 at-rule prelude name escapes",
+      `Quick,
+      s4370_at_rule_prelude_name_escapes );
+    ( "spec syntax 3 4.3.7 property value name escapes",
+      `Quick,
+      s4370_property_value_name_escapes );
     ( "fidelity string escape preserved",
       `Quick,
       fidelity_string_escape_preserved );


### PR DESCRIPTION
cascade read `@layer a\3b b` as the layer it names and printed the raw `;`, so its own output named a different layer and no longer parsed as one statement. Follow-up to #435, which fixed the same defect for custom-property names.