### PR TITLE
css: accept an escaped custom-property name in @supports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,10 @@
   `@position-try`, `@font-palette-values`, `@container`, `@import layer()`, a
   `@font-feature-values` feature name and every name a declaration value
   carries, from `anchor-name` to `will-change`, all take the escaping (#436)
+- `@supports (--x\3b y: red)` is read instead of the whole rule being dropped.
+  The reader demanded a property name that re-tokenizes from its own bytes,
+  which holds only while the printer writes that name raw; Chrome and
+  lightningcss both accept the escaped name (#437)
 - An `@layer` block inside a style rule holds nesting content, so
   `.a { @layer n { color: red } }` keeps its declaration instead of reading the
   body as a selector list and dropping it. CSS Nesting 1 sec. 3.1 admits nested

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -124,8 +124,13 @@ let starts_with ~prefix s =
   let prefix_len = String.length prefix in
   String.length s >= prefix_len && String.sub s 0 prefix_len = prefix
 
+(* CSS Syntax 3 sec. 4.3.7 lets an escape carry a [;] or a [}] into a custom
+   property's name, so the name is checked against the spelling it serializes to
+   (CSS Syntax 3 sec. 2.1) rather than against its own bytes: read raw, such a
+   name ends the declaration early and never looks like the single ident it
+   is. *)
 let property_name name =
-  let reader = Cursor.of_string name in
+  let reader = Cursor.of_string (Parser.escape_ident name) in
   let parsed =
     try Cursor.ident ~keep_case:true reader
     with Cursor.Parse_error _ ->
@@ -147,7 +152,10 @@ let declaration_feature prop value =
   | "-vendor-flag", "enabled" -> Vendor_flag_enabled
   | _ -> (
       let name = property_name prop in
-      try Declaration (Declaration.of_string (prop ^ ":" ^ value))
+      try
+        Declaration
+          (Declaration.of_string
+             (String.concat "" [ Parser.escape_ident prop; ":"; value ]))
       with Cursor.Parse_error _ | Failure _ ->
         Unsupported (name, String.trim value))
 
@@ -197,10 +205,13 @@ let func name args =
 
 (* ===== Pretty printing ===== *)
 
+let escaped_property_name name =
+  Parser.escape_ident (string_of_property_name name)
+
 let render_declaration_feature = function
   | Declaration decl -> Declaration.string_of_declaration ~minify:false decl
-  | Empty name -> string_of_property_name name ^ ":"
-  | Unsupported (name, value) -> string_of_property_name name ^ ": " ^ value
+  | Empty name -> escaped_property_name name ^ ":"
+  | Unsupported (name, value) -> escaped_property_name name ^ ": " ^ value
   | Vendor_flag_enabled -> "-vendor-flag: enabled"
 
 let render_function_feature = function
@@ -239,10 +250,10 @@ let pp_declaration_feature ctx = function
          suppress lossy value rewrites (e.g. static colour folding). *)
       Declaration.pp_declaration (Pp.enter_feature_query ctx) decl
   | Empty name ->
-      Pp.string ctx (string_of_property_name name);
+      Pp.string ctx (escaped_property_name name);
       Pp.char ctx ':'
   | Unsupported (name, value) ->
-      Pp.string ctx (string_of_property_name name);
+      Pp.string ctx (escaped_property_name name);
       Pp.char ctx ':';
       Pp.space_if_pretty ctx ();
       Pp.string ctx value

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6473,20 +6473,20 @@ let s4370_supports_property_name_escapes () =
       (* The name a [<supports-decl>] tests, in each shape the feature takes: a
          declaration, an empty value, and an operand of [and]. *)
       ( "@supports (--x\\3b y:red){.a{color:red}}",
-        "@supports (--x\\;y:red){.a{color:red}}" );
+        "@supports(--x\\;y:red){.a{color:red}}" );
       ( "@supports (--x\\7d y:red){.a{color:red}}",
-        "@supports (--x\\}y:red){.a{color:red}}" );
+        "@supports(--x\\}y:red){.a{color:red}}" );
       ( "@supports (--x\\3b y:){.a{color:red}}",
-        "@supports (--x\\;y:){.a{color:red}}" );
+        "@supports(--x\\;y:){.a{color:red}}" );
       ( "@supports (--x\\3b y:red) and (color:red){.a{color:red}}",
-        "@supports (--x\\;y:red) and (color:red){.a{color:red}}" );
+        "@supports(--x\\;y:red)and (color:red){.a{color:red}}" );
       ( "@supports not (--x\\3b y:red){.a{color:red}}",
         "@supports not (--x\\;y:red){.a{color:red}}" );
       (* A name needing no escape keeps its spelling. *)
       ( "@supports (--xy:red){.a{color:red}}",
-        "@supports (--xy:red){.a{color:red}}" );
+        "@supports(--xy:red){.a{color:red}}" );
       ( "@supports (color:red){.a{color:red}}",
-        "@supports (color:red){.a{color:red}}" );
+        "@supports(color:red){.a{color:red}}" );
     ]
 
 let fidelity_string_escape_preserved () =

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6463,6 +6463,32 @@ let s4370_property_value_name_escapes () =
       (".a{anchor-name:--a}", ".a{anchor-name:--a}");
     ]
 
+(* CSS Conditional 3 sec. 2.2: a [<supports-decl>] holds a declaration, and a
+   custom property's name can carry a [;] or a [}] through an escape (CSS Syntax
+   3 sec. 4.3.7). The condition is a capability predicate for that exact name,
+   so it survives the round trip with the escapes that read it back. *)
+let s4370_supports_property_name_escapes () =
+  check_escape_roundtrips
+    [
+      (* The name a [<supports-decl>] tests, in each shape the feature takes: a
+         declaration, an empty value, and an operand of [and]. *)
+      ( "@supports (--x\\3b y:red){.a{color:red}}",
+        "@supports (--x\\;y:red){.a{color:red}}" );
+      ( "@supports (--x\\7d y:red){.a{color:red}}",
+        "@supports (--x\\}y:red){.a{color:red}}" );
+      ( "@supports (--x\\3b y:){.a{color:red}}",
+        "@supports (--x\\;y:){.a{color:red}}" );
+      ( "@supports (--x\\3b y:red) and (color:red){.a{color:red}}",
+        "@supports (--x\\;y:red) and (color:red){.a{color:red}}" );
+      ( "@supports not (--x\\3b y:red){.a{color:red}}",
+        "@supports not (--x\\;y:red){.a{color:red}}" );
+      (* A name needing no escape keeps its spelling. *)
+      ( "@supports (--xy:red){.a{color:red}}",
+        "@supports (--xy:red){.a{color:red}}" );
+      ( "@supports (color:red){.a{color:red}}",
+        "@supports (color:red){.a{color:red}}" );
+    ]
+
 let fidelity_string_escape_preserved () =
   pretty_preserves ".x { content: \"\\41\" }" [ "\\41" ];
   pretty_preserves ".x { content: \"hello\" }" [ "hello" ];
@@ -8628,6 +8654,9 @@ let additional_tests =
     ( "spec syntax 3 4.3.7 property value name escapes",
       `Quick,
       s4370_property_value_name_escapes );
+    ( "spec conditional 3 2.2 supports property name escapes",
+      `Quick,
+      s4370_supports_property_name_escapes );
     ( "fidelity string escape preserved",
       `Quick,
       fidelity_string_escape_preserved );


### PR DESCRIPTION
cascade dropped `@supports (--x\3b y: red)` whole: the reader demanded a property name that re-tokenizes from its own bytes, which holds only while the printer writes such a name raw. Stacked on #436; Chrome and lightningcss both accept the escaped name.