### PR TITLE
css: build a declaration from its name and its value, not from their text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -358,6 +358,15 @@
   around it. The pair it takes is a `<dashed-ident>` name and the
   `<declaration-value>?` CSS Variables 1 sec. 2 gives a custom property, the
   check `parse_custom_property` already made (#428)
+- A custom-property name that needs escaping binds instead of being refused.
+  `Css.Declaration.parse_declaration` read `property ":" value` back as one
+  text, so a name carrying a `;` or a `}` (CSS Syntax 3 sec. 4.3.7 puts either
+  there through an escape) ended its own declaration, and the guard on
+  `custom_property` and `parse_custom_property` was there only to keep such a
+  name out of that text. The name and the value are read as the tokens they
+  are, so a `theme_defaults` answer for `x;y` emits `:root{--x\;y:red}` and a
+  name carrying a `:` names no declaration at all. `@supports (--x\3b y: red)`
+  builds its declaration the same way (#439)
 - `Css.inline_vars` preserves runtime-marked `var()` references, including
   typed fallbacks simplified through scalar values or shorthands, instead of
   replacing browser-time override points with compile-time defaults (#315)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7599,24 +7599,26 @@ val custom_property : ?layer:string -> string -> string -> declaration
     API which provides compile-time checking and automatic variable management.
 
     @param layer Optional CSS layer name for the custom property
-    @param name
-      CSS custom property name: a [<dashed-ident>] that tokenizes to itself
+    @param name CSS custom property name: a [<dashed-ident>]
     @param value
       the [<declaration-value>?] CSS Variables 1 sec. 2 gives a custom property,
       as CSS text
 
-    It raises [Failure] on a pair that does not write back as the one
-    declaration it names, such as a value carrying a top-level [;] or [}] or an
-    unterminated function, block or string. {!Declaration.parse_custom_property}
-    is the same check as an option.
+    It raises [Failure] on a pair that does not make the one declaration it
+    names, such as a value carrying a top-level [;] or [}] or an unterminated
+    function, block or string. A name holding a code point no bare ident carries
+    is written back with the escapes that read it.
+    {!Declaration.parse_custom_property} is the same check as an option.
 
     Example: [custom_property "--primary-color" "#3b82f6"]
 
     See also {!val:var} (type-safe CSS variable API). *)
 
 val parse_declaration : ?layer:string -> string -> string -> declaration option
-(** [parse_declaration ?layer property value] parses ["property: value"] with
-    the full declaration parser:
+(** [parse_declaration ?layer property value] reads [property] and [value] with
+    the full declaration parser. The two are read as the tokens they are rather
+    than as one ["property: value"] text, so a [property] carrying a [;], a [}]
+    or a [:] names this declaration or names none:
     - a known property (e.g. [mask-type], {!val-display}) becomes a typed
       declaration;
     - a custom property ([--x]) or an unknown property keeps its parsed

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -106,30 +106,20 @@ let is_declaration_value value =
   | [] -> false
   | components -> components_stay_in_declaration components
 
-(* A name is written back verbatim, so it binds only when it tokenizes as the
-   single ident it claims to be. An escape (CSS Syntax 3 sec. 4.3.7) can carry a
-   [;] or a [}] into a name read from a [var()] reference. *)
-let is_writable_custom_property_name name =
-  is_custom_property_name name
-  &&
-  match Cursor.remaining (Cursor.of_string name) with
-  | [ Component.Preserved { kind = Token.Ident ident; _ } ] ->
-      String.equal ident name
-  | _ -> false
-
 let refuse name detail =
   failwith (String.concat "" [ "custom_property: "; name; ": "; detail ])
 
 (* Helper for raw custom properties - primarily for internal use *)
 
 let custom_property ?layer name value =
-  (* The pair is written back verbatim, so it binds only when the text reads
-     back as the one declaration it names: a [<dashed-ident>] name that
-     tokenizes to itself, and the [<declaration-value>?] CSS Variables 1 sec. 2
-     gives a custom property. A name or value outside that - a top-level [;] or
-     [}], an unmatched closing bracket, an unterminated function, block or
-     string - leaves the declaration as soon as the text is read back. *)
-  if not (is_writable_custom_property_name name) then
+  (* The pair binds only when it makes the one declaration it names: a
+     [<dashed-ident>] name, and the [<declaration-value>?] CSS Variables 1 sec.
+     2 gives a custom property. A value outside that - a top-level [;] or [}],
+     an unmatched closing bracket, an unterminated function, block or string -
+     leaves the declaration as soon as the text is read back. A name carrying
+     one of those is written back with the escapes that read it (CSS Syntax 3
+     sec. 4.3.7), so it stays the name of this declaration. *)
+  if not (is_custom_property_name name) then
     refuse name "not a custom-property name";
   if not (is_optional_declaration_value value) then
     refuse name (String.concat "" [ value; " is not a declaration value" ]);
@@ -2322,24 +2312,36 @@ let of_string s =
   | Some d -> d
   | None -> failwith ("Declaration.of_string: invalid declaration: " ^ s)
 
+(* The declaration [property] and [value] name, as the tokens they are. The name
+   is one [<ident-token>] by construction and the value is parsed on its own, so
+   neither reaches the other's position: written into one text, a name carrying
+   a [;] or a [}] (CSS Syntax 3 sec. 4.3.7 puts either there through an escape)
+   would end its own declaration, and one carrying a [:] would name the property
+   in front of it. *)
+let name_value_components property value =
+  Component.Preserved (Token.synthetic (Token.Ident property))
+  :: Component.Preserved (Token.synthetic Token.Colon)
+  :: Cursor.remaining (Cursor.of_string value)
+
 let parse_declaration ?layer property value =
-  (* Parse [property:value] with the full declaration parser: a known property
-     (e.g. [mask-type], [display]) becomes a typed declaration, a custom
-     property ([--x]) or an unknown property keeps its parsed component stream
-     (so [vars_of_declarations] still finds its [var()] references), unlike
-     [custom_property] which forces an opaque [Tokens] value. A [layer] only
-     applies to a custom property; [custom_property] attaches it and yields the
-     same parsed token stream the declaration parser would. *)
+  (* Read [property] and [value] with the full declaration parser: a known
+     property (e.g. [mask-type], [display]) becomes a typed declaration, a
+     custom property ([--x]) or an unknown property keeps its parsed component
+     stream (so [vars_of_declarations] still finds its [var()] references),
+     unlike [custom_property] which forces an opaque [Tokens] value. A [layer]
+     only applies to a custom property; [custom_property] attaches it and yields
+     the same parsed token stream the declaration parser would. *)
   match layer with
   | Some _ when is_custom_property_name property -> (
       try Some (custom_property ?layer property value) with Failure _ -> None)
   | _ -> (
-      let s = String.concat "" [ property; ":"; value ] in
-      try read_declaration (Cursor.of_string s)
+      try
+        read_declaration
+          (Cursor.of_components (name_value_components property value))
       with Cursor.Parse_error _ -> None)
 
 let parse_custom_property name value =
-  if is_writable_custom_property_name name && is_declaration_value value then
+  if is_custom_property_name name && is_declaration_value value then
     parse_declaration name value
   else None
 

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -45,16 +45,19 @@ val custom_property : ?layer:string -> string -> string -> declaration
     authored CSS text.
 
     @raise Failure
-      if the pair does not write back as the one declaration it names. [name]
-      has to be a [<dashed-ident>] that tokenizes to itself, and [value] the
-      [<declaration-value>?] CSS Variables 1 sec. 2 gives a custom property: no
-      top-level [;], no unmatched closing bracket, no unterminated function,
-      block or string. {!parse_custom_property} is the same check as an option.
-*)
+      if the pair does not make the one declaration it names. [name] has to be a
+      [<dashed-ident>], and [value] the [<declaration-value>?] CSS Variables 1
+      sec. 2 gives a custom property: no top-level [;], no unmatched closing
+      bracket, no unterminated function, block or string. A [name] holding a
+      code point no bare ident carries is written back with the escapes that
+      read it. {!parse_custom_property} is the same check as an option. *)
 
 val parse_declaration : ?layer:string -> string -> string -> declaration option
-(** [parse_declaration ?layer property value] parses ["property: value"] with
-    the declaration parser into a fully-typed declaration:
+(** [parse_declaration ?layer property value] reads [property] and [value] with
+    the declaration parser into a fully-typed declaration. The two are read as
+    the tokens they are rather than as one ["property: value"] text, so a
+    [property] carrying a [;], a [}] or a [:] names this declaration or names
+    none:
     - a known property (e.g. [mask-type], {!val-display}) becomes a typed
       declaration;
     - a custom property ([--x]) or an unknown property keeps its parsed
@@ -67,9 +70,8 @@ val parse_declaration : ?layer:string -> string -> string -> declaration option
 
 val parse_custom_property : string -> string -> declaration option
 (** [parse_custom_property name value] is {!parse_declaration} restricted to a
-    custom property whose [name] and [value] are safe to write into a rule
-    verbatim. It is [None] unless [name] is a [<dashed-ident>] that tokenizes
-    back to itself and [value] is one [<declaration-value>] (CSS Syntax 3 sec.
+    custom property that a rule can hold. It is [None] unless [name] is a
+    [<dashed-ident>] and [value] is one [<declaration-value>] (CSS Syntax 3 sec.
     8.2): no [<bad-string-token>], no [<bad-url-token>], no unmatched closing
     bracket, no unterminated function or block, and no top-level [;].
 

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -149,10 +149,10 @@ type scope = {
 
 let custom_name = Variables.custom_declaration_name
 
-(* [Declaration.custom_property] refuses a name and value it cannot write back
-   as the one declaration they name. A parsed stylesheet can hold such a pair -
-   a name written with an escape, a value CSS Syntax 3 would drop - so a rewrite
-   that reaches one keeps what it started from instead of raising. *)
+(* [Declaration.custom_property] refuses a value it cannot write back as part of
+   the declaration it belongs to. A parsed stylesheet can hold such a value -
+   one CSS Syntax 3 would drop - so a rewrite that reaches one keeps what it
+   started from instead of raising. *)
 let rebuild_custom ?layer name value =
   try Some (Declaration.custom_property ?layer name value)
   with Failure _ -> None

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -151,13 +151,13 @@ let declaration_feature prop value =
   | _, "" -> Empty (property_name prop)
   | "-vendor-flag", "enabled" -> Vendor_flag_enabled
   | _ -> (
+      (* The name and the value stay apart: read as one text, a name carrying a
+         [;] or a [}] (CSS Syntax 3 sec. 4.3.7 puts either there through an
+         escape) would end its own declaration. *)
       let name = property_name prop in
-      try
-        Declaration
-          (Declaration.of_string
-             (String.concat "" [ Parser.escape_ident prop; ":"; value ]))
-      with Cursor.Parse_error _ | Failure _ ->
-        Unsupported (name, String.trim value))
+      match Declaration.parse_declaration prop value with
+      | Some decl -> Declaration decl
+      | None -> Unsupported (name, String.trim value))
 
 let property prop value = Property (declaration_feature prop value)
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1540,8 +1540,9 @@ let custom_property_values () =
 
 (* [parse_custom_property] builds a declaration from a name and value that came
    from outside the parser, so it takes only a pair that writes back as the one
-   declaration it claims to be: a [<dashed-ident>] name that tokenizes to
-   itself, and a CSS Syntax 3 sec. 8.2 [<declaration-value>]. *)
+   declaration it claims to be: a [<dashed-ident>] name, written back with the
+   escapes that read it (CSS Syntax 3 sec. 4.3.7), and a CSS Syntax 3 sec. 8.2
+   [<declaration-value>]. *)
 let parse_custom_property_guard () =
   let bind name value =
     match parse_custom_property name value with
@@ -1579,9 +1580,9 @@ let parse_custom_property_guard () =
     [
       ("--x", "--x:red");
       ("--color-red-500", "--color-red-500:red");
-      ("--x;y", "<rejected>");
-      ("--x}y", "<rejected>");
-      ("--x y", "<rejected>");
+      ("--x;y", "--x\\;y:red");
+      ("--x}y", "--x\\}y:red");
+      ("--x y", "--x\\ y:red");
       ("--", "<rejected>");
       ("-x", "<rejected>");
       ("color", "<rejected>");
@@ -1590,9 +1591,12 @@ let parse_custom_property_guard () =
 (* [custom_property] takes authored CSS text, so a pair it accepts has to write
    back as the one declaration it names. CSS Variables 1 sec. 2 gives a custom
    property the value grammar [<declaration-value>?] and a [<dashed-ident>]
-   name; a top-level [;] or [}], an unterminated function, block or string, or
-   an unmatched closing bracket all stop being part of the declaration as soon
-   as the text is read back, so they are not a pair this library can write. *)
+   name; a value carrying a top-level [;] or [}], an unterminated function,
+   block or string, or an unmatched closing bracket stops being part of the
+   declaration as soon as the text is read back, so it is not a pair this
+   library can write. A name carrying one of those is written back with the
+   escapes that read it (CSS Syntax 3 sec. 4.3.7), so it names the declaration
+   it made. *)
 let custom_property_guard () =
   (* Build the declaration, print it into a rule and read the rule back. The
      answer is derived from the round-trip, not from a pinned spelling. *)
@@ -1660,13 +1664,75 @@ let custom_property_guard () =
     [
       ("--x", "<round-trips>");
       ("--color-red-500", "<round-trips>");
-      ("--x}y", "<refused>");
-      ("--x;y", "<refused>");
-      ("--x y", "<refused>");
+      ("--x}y", "<round-trips>");
+      ("--x;y", "<round-trips>");
+      ("--x y", "<round-trips>");
       ("--", "<refused>");
       ("-x", "<refused>");
       ("color", "<refused>");
     ]
+
+(* [parse_declaration] is handed the name and the value as two strings, and CSS
+   Syntax 3 sec. 4.3.7 lets an escape carry a [;], a [}] or a space into a
+   custom property's name. Written into the text in front of the [:], such a
+   name ends its own declaration, closes the rule around it, or names a
+   different property, so the two never meet as text: the name reaches the
+   reader as the one ident it is. *)
+let parse_declaration_name_case () =
+  let bound name value =
+    match parse_declaration name value with
+    | None -> "<none>"
+    | Some d -> (
+        let text = to_string ~minify:true d in
+        let names decl =
+          Option.equal String.equal
+            (Css.custom_declaration_name decl)
+            (Some name)
+        in
+        let read_back =
+          Css.of_string ~strict:true (String.concat "" [ ":root{"; text; "}" ])
+        in
+        match read_back with
+        | Ok { Css.stylesheet = [ Css.Stylesheet.Rule r ]; _ } -> (
+            match r.declarations with
+            | [ d' ] when String.equal text (to_string ~minify:true d') ->
+                if names d && names d' then text
+                else String.concat "" [ text; " names another property" ]
+            | back ->
+                String.concat ""
+                  [
+                    text;
+                    " reads back as ";
+                    String.concat " + " (List.map (to_string ~minify:true) back);
+                  ])
+        | Ok { Css.stylesheet; _ } ->
+            String.concat ""
+              [
+                text;
+                " reads back as ";
+                string_of_int (List.length stylesheet);
+                " statements";
+              ]
+        | Error _ -> String.concat "" [ text; " does not read back" ])
+  in
+  List.iter
+    (fun (name, expected) ->
+      Alcotest.(check string) name expected (bound name "red"))
+    [
+      ("--x", "--x:red");
+      ("--x;y", "--x\\;y:red");
+      ("--x}y", "--x\\}y:red");
+      ("--x y", "--x\\ y:red");
+    ];
+  (* A name is one ident or it names nothing: a [:] or a [;] inside it belongs
+     to no property cascade can write. *)
+  List.iter
+    (fun name ->
+      Alcotest.(check bool)
+        (String.concat "" [ name; " names no declaration" ])
+        true
+        (parse_declaration name "red" = None))
+    [ "a:b"; "color;background"; "color:red"; "" ]
 
 let spec_custom_tokens () =
   check_specified_value "custom property token stream specified"
@@ -2909,6 +2975,8 @@ let declaration_tests =
       parse_custom_property_guard;
     test_case "custom_property refuses an escaping pair" `Quick
       custom_property_guard;
+    test_case "parse_declaration keeps the name out of the value" `Quick
+      parse_declaration_name_case;
     test_case "spec custom property token stream values" `Quick
       spec_custom_tokens;
     test_case "vendor prefixes" `Quick vendor_prefixes;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -8015,35 +8015,46 @@ let theme_defaults_reject_escaping_value () =
     (emit "red/*")
 
 (* CSS Syntax 3 sec. 4.3.7: a [\X] escape carries any code point into an ident,
-   so [var(--x\3b y)] references the theme name ["x;y"]. A name that cannot be
-   written back as a single ident cannot be bound - and must not turn into some
-   other declaration ([y:red]) at root scope. *)
-let theme_defaults_reject_escaping_name () =
+   so [var(--x\3b y)] references the theme name ["x;y"]. The default binds under
+   that name, written back with the escapes that read it - the one spelling that
+   makes the declaration the name it references rather than some other
+   declaration ([y:red]) at root scope. *)
+let theme_defaults_escaping_name () =
   let parse css =
     match Css.of_string ~strict:false css with
     | Ok parsed -> parsed.stylesheet
     | Error _ -> Alcotest.failf "failed to parse: %s" css
   in
   List.iter
-    (fun (what, src, name, expected) ->
-      let resolved =
+    (fun (what, src, name, bound, inlined) ->
+      let resolve ?theme () =
         parse src
-        |> Css.resolve_theme ~theme_defaults:(fun n ->
+        |> Css.resolve_theme ?theme ~theme_defaults:(fun n ->
             if n = name then Some "red" else None)
+        |> Css.to_string ~minify:true
       in
       Alcotest.(check string)
-        (what ^ ": nothing binds and the reference stays live")
-        expected
-        (Css.to_string ~minify:true resolved))
+        (what ^ ": binds under the name the reference spells")
+        bound (resolve ());
+      Alcotest.(check string)
+        (what ^ ": resolves the reference it binds")
+        inlined
+        (resolve ~theme:Css.Pp.String_set.empty ());
+      Alcotest.(check string)
+        (what ^ ": the binding reads back as itself")
+        bound
+        (Css.to_string ~minify:true (parse bound)))
     [
       ( "a name carrying a [;]",
         ".a{color:var(--x\\3b y)}",
         "x;y",
-        ".a{color:var(--x\\;y)}" );
+        ":root{--x\\;y:red}.a{color:var(--x\\;y)}",
+        ".a{color:red}" );
       ( "a name carrying a [}]",
         ".a{color:var(--x\\7d y)}",
         "x}y",
-        ".a{color:var(--x\\}y)}" );
+        ":root{--x\\}y:red}.a{color:var(--x\\}y)}",
+        ".a{color:red}" );
     ]
 
 (* CSS Custom Properties L1 section 2: a [var()] used inside a fallback list
@@ -8858,9 +8869,9 @@ let additional_tests =
     ( "theme defaults reject a value that escapes its declaration",
       `Quick,
       theme_defaults_reject_escaping_value );
-    ( "theme defaults reject a name that escapes its declaration",
+    ( "theme defaults bind a name that needs escaping",
       `Quick,
-      theme_defaults_reject_escaping_name );
+      theme_defaults_escaping_name );
     ( "spec custom-properties 1 fallback list with inlining",
       `Quick,
       customprops1_fallback_list );


### PR DESCRIPTION
`Css.Declaration.parse_declaration` wrote `property ":" value` into one string and read it back, so a custom-property name carrying a `;` or a `}` ended its own declaration and one carrying a `:` named the property in front of it. The guard refusing such a name was there only to keep it out of that text, so with the name now reaching the reader as the ident it is, the name binds: Chrome 146 resolves `var(--x\;y)` from the `:root{--x\;y:red}` this emits.

Stacked on #437.