### PR TITLE
diff: spell a compared property's name the way it is written

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -414,6 +414,11 @@
 
 ### Canonical diff
 
+- `Css_compare.equivalent_value ~property` spells the property name the way the
+  printer spells it before giving the two values that declaration context. A
+  name carrying a `}` (CSS Syntax 3 sec. 4.3.7 puts one there through an escape)
+  closed the rule and took both values with it, so any two values under such a
+  name compared equal (#440)
 - A fully transparent missing-axis `oklab()` colour, such as
   `oklab(0% none none / 0)`, canonicalises to transparent black while
   non-transparent forms remain distinct (#312)

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -231,10 +231,16 @@ let build_reorder_diff expected_css actual_css =
   if !diffs = [] then None
   else Some D.{ rules = List.rev !diffs; containers = []; layer_order = None }
 
+(* [css] is value text neither side has parsed yet, so the declaration context
+   [property] names is given as text too. CSS Syntax 3 sec. 4.3.7 lets an escape
+   carry a [;] or a [}] into a custom property's name: written raw here such a
+   name ends the declaration or closes the rule, and both values go with it, so
+   the name is spelled the way the printer spells it. *)
 let css_for_semantic_comparison ?property css =
   match property with
   | None -> css
-  | Some property -> ":root{" ^ property ^ ":" ^ css ^ "}"
+  | Some property ->
+      String.concat "" [ ":root{"; Parser.escape_ident property; ":"; css; "}" ]
 
 let canonical_of_stylesheet ~lossless ~prune_unused_custom_props stylesheet =
   try

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -840,6 +840,25 @@ let semantically_equivalent_rejects_different_colors () =
     "different color values are not semantically equivalent" false
     (Cascade_diff.Css_compare.equivalent_value ~property:"color" "red" "blue")
 
+(* [equivalent_value] gives its two values the declaration context [property]
+   names. CSS Syntax 3 sec. 4.3.7 lets an escape carry a [;] or a [}] into a
+   custom property's name, and written raw into that context such a name closes
+   the rule and takes both values with it, so any two of them read back the
+   same. *)
+let semantically_equivalent_escaping_property () =
+  List.iter
+    (fun property ->
+      Alcotest.(check bool)
+        (String.concat "" [ property; ": red and blue stay different" ])
+        false
+        (Cascade_diff.Css_compare.equivalent_value ~property "red" "blue");
+      Alcotest.(check bool)
+        (String.concat ""
+           [ property; ": the same colour spelled twice agrees" ])
+        true
+        (Cascade_diff.Css_compare.equivalent_value ~property "#ffffff" "#fff"))
+    [ "--x"; "--x;y"; "--x}y"; "--x y" ]
+
 (* ===== diff returning No_diff ===== *)
 
 let diff_no_diff () =
@@ -1396,6 +1415,8 @@ let suite =
         semantic_transparent_ident_boundary;
       Alcotest.test_case "semantically equivalent rejects different colors"
         `Quick semantically_equivalent_rejects_different_colors;
+      Alcotest.test_case "semantically equivalent under an escaping property"
+        `Quick semantically_equivalent_escaping_property;
       Alcotest.test_case "diff No_diff" `Quick diff_no_diff;
       Alcotest.test_case "diff No_diff empty" `Quick diff_no_diff_empty;
       Alcotest.test_case "diff Tree_diff" `Quick diff_tree_diff;


### PR DESCRIPTION
`Css_compare.equivalent_value ~property` put the caller's name into a `:root{...}` rule as raw text, so a name carrying a `}` closed the rule and took both values with it: any two values under such a name compared equal. Stacked on #439.