### PR TITLE
selector: read the state pseudo-classes a scrollbar part reports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,13 @@
   parses and matches nothing, while the unforgiving `:not()` goes down with the
   argument, so `::before:not(.b)` and `::part(p):not(.b)` stop parsing and
   `::part(p):not(:hover)` keeps parsing (#430)
+- The eleven pseudo-classes WebKit's scrollbar parts report their state through
+  are read as pseudo-classes, so `::-webkit-scrollbar:vertical`,
+  `::-webkit-scrollbar-thumb:window-inactive` and the rest of that family keep
+  their rule instead of losing it at an unforgiving selector list. Chrome and
+  WebKit both read all eleven wherever a pseudo-class goes; after a
+  pseudo-element only a scrollbar part takes them, bar `:window-inactive`,
+  which reaches a `::selection` and a `::part()` as well (#441)
 - A `<custom-ident>` or `<dashed-ident>` an at-rule prelude or a declaration
   value names is printed with the escapes CSS Syntax 3 sec. 4.3.7 needs to read
   it back as the same name. `@layer a\3b b` printed `@layer a;b`, two

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -962,6 +962,39 @@ let pseudo_class_base_idents =
     ("active-view-transition", Active_view_transition);
   ]
 
+let scrollbar_state_ident = function
+  | Horizontal -> "horizontal"
+  | Vertical -> "vertical"
+  | Decrement -> "decrement"
+  | Increment -> "increment"
+  | Start -> "start"
+  | End -> "end"
+  | Double_button -> "double-button"
+  | Single_button -> "single-button"
+  | No_button -> "no-button"
+  | Corner_present -> "corner-present"
+  | Window_inactive -> "window-inactive"
+
+(* WebKit, "Styling Scrollbars". Both engines read these on any element, so they
+   are ordinary pseudo-classes here; which pseudo-elements take them is
+   [pseudo_element_allows]'s business. *)
+let pseudo_class_scrollbar_idents =
+  List.map
+    (fun state -> (scrollbar_state_ident state, Scrollbar_state state))
+    [
+      Horizontal;
+      Vertical;
+      Decrement;
+      Increment;
+      Start;
+      End;
+      Double_button;
+      Single_button;
+      No_button;
+      Corner_present;
+      Window_inactive;
+    ]
+
 let pseudo_element_legacy_idents form =
   [
     (* Legacy pseudo-elements: parser records [Single] or [Double] colon for
@@ -1146,6 +1179,17 @@ let rec pseudo_element_allows pe pc =
          compound down with it: both engines drop [::before:not(:hover)] and
          keep [::part(p):not(:hover)]. *)
       | Not args -> List.for_all (pseudo_element_allows_argument pe) args
+      (* WebKit, "Styling Scrollbars": a scrollbar part reports its own state,
+         and [:window-inactive] reaches past the scrollbar to a selection and to
+         a shadow part, where both engines take it. Past that they disagree one
+         cell each way (only WebKit takes the other ten after [::part()], only
+         Chrome takes [:window-inactive] after [::details-content]), so the list
+         stops where they agree. *)
+      | Scrollbar_state state -> (
+          match (pe, state) with
+          | Webkit_scrollbar, _ -> true
+          | (Selection | Part _), Window_inactive -> true
+          | _ -> false)
       (* Same forward-compatibility bargain as an unknown pseudo-element. *)
       | Unknown_pseudo_class _ | Unknown_pseudo_class_call _ -> true
       | pc -> (
@@ -1157,8 +1201,8 @@ let rec pseudo_element_allows pe pc =
               match pc with
               | Has _ -> false
               | pc -> not (is_structural_pseudo_class pc))
-          (* A scrollbar takes no focus, and reports its own state through the
-             vendor pseudo-classes, which reach here as unknown names. *)
+          (* A scrollbar takes no focus, and reports which part of which
+             scrollbar it is through the state pseudo-classes below. *)
           | Webkit_scrollbar -> (
               match pc with
               | Hover | Active | Enabled | Disabled -> true
@@ -1199,7 +1243,7 @@ and pseudo_element_allows_argument pe = function
    only happens once instead of per [:foo] / [::foo] pseudo read. *)
 let pseudo_class_all_idents_lazy =
   lazy
-    (pseudo_class_base_idents
+    (pseudo_class_base_idents @ pseudo_class_scrollbar_idents
     @ pseudo_element_legacy_idents Single
     @ pseudo_element_modern_idents @ pseudo_vendor_idents)
 
@@ -2226,6 +2270,7 @@ and pp : t Pp.t =
   | Webkit_autofill -> vendor ctx "webkit-autofill"
   | Moz_ui_invalid -> vendor ctx "moz-ui-invalid"
   | Moz_ui_valid -> vendor ctx "moz-ui-valid"
+  | Scrollbar_state state -> pseudo ctx (scrollbar_state_ident state)
   (* Vendor-specific pseudo-elements *)
   | Moz_placeholder -> vendor_elem ctx "moz-placeholder"
   | Webkit_input_placeholder -> vendor_elem ctx "webkit-input-placeholder"
@@ -2545,18 +2590,18 @@ let rec specificity = function
   | Current | Popover_open | Open | Moz_focusring | Webkit_any | Webkit_autofill
   | Unknown_pseudo_class _ | Unknown_pseudo_class_call _ | Moz_placeholder
   | Webkit_input_placeholder | Ms_input_placeholder | Moz_ui_invalid
-  | Moz_ui_valid | Webkit_scrollbar | Webkit_search_cancel_button
-  | Webkit_search_decoration | Webkit_datetime_edit_fields_wrapper
-  | Webkit_date_and_time_value | Webkit_datetime_edit
-  | Webkit_datetime_edit_year_field | Webkit_datetime_edit_month_field
-  | Webkit_datetime_edit_day_field | Webkit_datetime_edit_hour_field
-  | Webkit_datetime_edit_minute_field | Webkit_datetime_edit_second_field
-  | Webkit_datetime_edit_millisecond_field | Webkit_datetime_edit_meridiem_field
-  | Webkit_inner_spin_button | Webkit_outer_spin_button
-  | Webkit_calendar_picker_indicator | Webkit_details_marker | Details_content
-  | Nth_col _ | Nth_last_col _ | Dir _ | Lang _ | State _
-  | Active_view_transition | Active_view_transition_type _ | Heading
-  | Local_scope | Global_scope ->
+  | Moz_ui_valid | Scrollbar_state _ | Webkit_scrollbar
+  | Webkit_search_cancel_button | Webkit_search_decoration
+  | Webkit_datetime_edit_fields_wrapper | Webkit_date_and_time_value
+  | Webkit_datetime_edit | Webkit_datetime_edit_year_field
+  | Webkit_datetime_edit_month_field | Webkit_datetime_edit_day_field
+  | Webkit_datetime_edit_hour_field | Webkit_datetime_edit_minute_field
+  | Webkit_datetime_edit_second_field | Webkit_datetime_edit_millisecond_field
+  | Webkit_datetime_edit_meridiem_field | Webkit_inner_spin_button
+  | Webkit_outer_spin_button | Webkit_calendar_picker_indicator
+  | Webkit_details_marker | Details_content | Nth_col _ | Nth_last_col _ | Dir _
+  | Lang _ | State _ | Active_view_transition | Active_view_transition_type _
+  | Heading | Local_scope | Global_scope ->
       { ids = 0; classes = 1; elements = 0 }
   | Element _ -> { ids = 0; classes = 0; elements = 1 }
   | Universal _ | Nesting -> zero_specificity

--- a/lib/selector_intf.ml
+++ b/lib/selector_intf.ml
@@ -40,6 +40,22 @@ type specificity = { ids : int; classes : int; elements : int }
     canonical spelling. *)
 type colon_form = Single | Double
 
+(** WebKit's scrollbar pseudo-classes (WebKit, "Styling Scrollbars"): the state
+    a scrollbar part reports about itself, and the one the whole window reports.
+    Non-standard, and both Chrome and WebKit take them. *)
+type scrollbar_state =
+  | Horizontal
+  | Vertical
+  | Decrement
+  | Increment
+  | Start
+  | End
+  | Double_button
+  | Single_button
+  | No_button
+  | Corner_present
+  | Window_inactive
+
 type aria_attr = Aria.t
 (** ARIA attribute names for type-safe handling *)
 
@@ -168,6 +184,7 @@ type t =
   | Ms_input_placeholder
   | Moz_ui_invalid
   | Moz_ui_valid
+  | Scrollbar_state of scrollbar_state
   | Webkit_scrollbar
   | Webkit_search_cancel_button
   | Webkit_search_decoration

--- a/scripts/check_api_consistency.ml
+++ b/scripts/check_api_consistency.ml
@@ -33,6 +33,7 @@ let ignored_types =
     "repeat_count";
     "stop";
     "point";
+    "scrollbar_state";
     (* Helper fragments parsed only inside their owning structured values. *)
     "colon_form";
     "vt_class_selector";

--- a/test/render/dom_of_css.ml
+++ b/test/render/dom_of_css.ml
@@ -392,6 +392,7 @@ let rec add sp part =
       raise (Skip "view-transition pseudo-class")
   | Selector.Nth_col _ | Selector.Nth_last_col _ ->
       raise (Skip "column pseudo-class")
+  | Selector.Scrollbar_state _ -> raise (Skip "scrollbar pseudo-class")
   | Selector.Unknown_pseudo_class _ | Selector.Unknown_pseudo_class_call _
   | Selector.Webkit_any ->
       raise (Skip "unknown pseudo-class")

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -753,6 +753,12 @@ let pseudo_element_spellings =
     "::deep";
     "::v-deep";
     "::ng-deep";
+    "::-webkit-scrollbar-thumb";
+    "::-webkit-scrollbar-track";
+    "::-webkit-scrollbar-track-piece";
+    "::-webkit-scrollbar-button";
+    "::-webkit-scrollbar-corner";
+    "::-webkit-resizer";
   ]
 
 (* Selectors 4 sec. 16: a complex selector unit is [<compound-selector>?
@@ -844,11 +850,29 @@ let element_backed_pseudo_classes =
       ":lang(en)";
     ]
 
+(* WebKit, "Styling Scrollbars": the state a scrollbar part reports about
+   itself. [:window-inactive] is the one that is about the window rather than
+   the scrollbar, and the one that reaches past the scrollbar. *)
+let scrollbar_state_pseudo_classes =
+  [
+    ":horizontal";
+    ":vertical";
+    ":decrement";
+    ":increment";
+    ":start";
+    ":end";
+    ":double-button";
+    ":single-button";
+    ":no-button";
+    ":corner-present";
+    ":window-inactive";
+  ]
+
 (* Each probe names a pseudo-class cascade recognises: an unrecognised one is
    already a parse error at an unforgiving site, whatever precedes it, so it
    would not tell us anything about the pseudo-element's own rules. *)
 let probe_pseudo_classes =
-  element_backed_pseudo_classes
+  element_backed_pseudo_classes @ scrollbar_state_pseudo_classes
   @ [
       ":root";
       ":empty";
@@ -878,7 +902,6 @@ let pseudo_element_pseudo_class_rows =
         "::first-letter";
         "::backdrop";
         "::marker";
-        "::selection";
         "::target-text";
         "::spelling-error";
         "::grammar-error";
@@ -913,7 +936,11 @@ let pseudo_element_pseudo_class_rows =
       ],
       user_action_pseudo_classes );
     (* The scrollbar takes no focus, and reports its own state instead. *)
-    ([ "::-webkit-scrollbar" ], [ ":hover"; ":active"; ":enabled"; ":disabled" ]);
+    ( [ "::-webkit-scrollbar" ],
+      [ ":hover"; ":active"; ":enabled"; ":disabled" ]
+      @ scrollbar_state_pseudo_classes );
+    (* WebKit's [::selection:window-inactive], and nothing else. *)
+    ([ "::selection" ], [ ":window-inactive" ]);
     (* CSS View Transitions 1 sec. 3.1: [:only-child] matches a view transition
        pseudo with no sibling in the pseudo-element tree. *)
     ( [
@@ -923,7 +950,12 @@ let pseudo_element_pseudo_class_rows =
         "::view-transition-new(*)";
       ],
       [ ":only-child" ] );
-    ([ "::part(tab)"; "::details-content" ], element_backed_pseudo_classes);
+    (* [:window-inactive] is about the window, so both engines take it after a
+       shadow part. The rows stop where the engines agree: only WebKit takes the
+       other ten after [::part()], and only Chrome takes [:window-inactive]
+       after [::details-content]. *)
+    ([ "::part(tab)" ], element_backed_pseudo_classes @ [ ":window-inactive" ]);
+    ([ "::details-content" ], element_backed_pseudo_classes);
     (* Names no shipping engine knows, plus the two WebVTT names cascade only
        has a constructor for in their functional form, so that a bare [::cue] or
        [::cue-region] reaches the reader as an unrecognised name: cascade keeps
@@ -939,6 +971,12 @@ let pseudo_element_pseudo_class_rows =
         "::deep";
         "::v-deep";
         "::ng-deep";
+        "::-webkit-scrollbar-thumb";
+        "::-webkit-scrollbar-track";
+        "::-webkit-scrollbar-track-piece";
+        "::-webkit-scrollbar-button";
+        "::-webkit-scrollbar-corner";
+        "::-webkit-resizer";
       ],
       probe_pseudo_classes );
   ]
@@ -1050,6 +1088,39 @@ let canonicalize_pseudo_compound_is () =
   canon ".x .a" ".x :is(:is(.a))";
   (* [:where()] never unwraps: it contributes zero specificity. *)
   canon ".a:before:where(.b)" ".a::before:where(.b)"
+
+(* WebKit, "Styling Scrollbars" defines eleven pseudo-classes for the state a
+   scrollbar part is in. They are not in any spec, and Chrome 151 and WebKit
+   26.5 both read them wherever a pseudo-class goes, so an unforgiving selector
+   list holding one keeps its rule. *)
+let scrollbar_state_pseudo_classes_read () =
+  let concat = String.concat "" in
+  let round_trips input =
+    match Cursor.option read (Cursor.of_string input) with
+    | None -> Alcotest.failf "selector should parse: %s" input
+    | Some sel ->
+        Alcotest.(check string)
+          ("round trip " ^ input) input
+          (to_string ~minify:true sel)
+  in
+  List.iter
+    (fun pc ->
+      (* On a plain element, where both engines read them. *)
+      round_trips (concat [ ".a"; pc ]);
+      (* And in the argument lists, forgiving and unforgiving alike. *)
+      round_trips (concat [ ".a:not("; pc; ")" ]);
+      round_trips (concat [ ".a:is("; pc; ")" ]);
+      round_trips (concat [ ".a:has("; pc; ")" ]);
+      (* Selectors 4 sec. 17: a pseudo-class weighs a class. *)
+      Alcotest.(check int)
+        ("specificity " ^ pc) 1 (specificity (of_string pc)).classes;
+      (* None of them is functional. *)
+      neg_cursor read (concat [ ".a"; pc; "(1)" ]))
+    scrollbar_state_pseudo_classes;
+  (* A scrollbar part reads any combination of them. *)
+  round_trips "::-webkit-scrollbar:vertical:hover";
+  round_trips "::-webkit-scrollbar:corner-present:window-inactive";
+  round_trips "::-webkit-scrollbar-button:start:decrement"
 
 let parse_errors_nesting_depth () =
   (* A pathologically deep functional-pseudo-class nest is capped rather than
@@ -2128,6 +2199,8 @@ let suite =
         logical_combinator_pseudo_element;
       test_case "pseudo-element pseudo-classes" `Quick
         pseudo_element_pseudo_classes;
+      test_case "scrollbar state pseudo-classes" `Quick
+        scrollbar_state_pseudo_classes_read;
       test_case "canonicalize pseudo-compound :is()" `Quick
         canonicalize_pseudo_compound_is;
       test_case "parse errors - nesting depth" `Quick parse_errors_nesting_depth;


### PR DESCRIPTION
`::-webkit-scrollbar:vertical`, `::-webkit-scrollbar-thumb:window-inactive` and the rest of WebKit's scrollbar state family were unknown pseudo-class names, so an unforgiving selector list holding one lost its rule, while Chrome 151 and WebKit 26.5 read all eleven wherever a pseudo-class goes. After a pseudo-element only a scrollbar part takes them, bar `:window-inactive`, which both engines also take after `::selection` and `::part()`.

Stacked on #431.
