### PR TITLE
css: read a layer name as the idents it is made of

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,6 +51,11 @@
   The reader demanded a property name that re-tokenizes from its own bytes,
   which holds only while the printer writes that name raw; Chrome and
   lightningcss both accept the escaped name (#437)
+- A `@layer` name is read as the idents CSS Cascade 5 sec. 6.4.1 makes it, so
+  `@layer a\2e b`, the layer named `a.b`, is no longer the same value as
+  `@layer a.b`, the sublayer `b` of `a`. Both printed `@layer a.b` and the
+  minifier merged the two blocks into one layer, moving declarations into a
+  layer the input never wrote them in (#442)
 - An `@layer` block inside a style rule holds nesting content, so
   `.a { @layer n { color: red } }` keeps its declaration instead of reading the
   body as a selector list and dropping it. CSS Nesting 1 sec. 3.1 admits nested

--- a/fuzz/fuzz_css.ml
+++ b/fuzz/fuzz_css.ml
@@ -104,7 +104,7 @@ let generated_stylesheet buf =
             ];
         ];
       Css.layer
-        ~name:(pick [ "base"; "theme"; "components" ] buf 8)
+        ~name:(pick [ [ "base" ]; [ "theme" ]; [ "components" ] ] buf 8)
         [ Css.rule ~selector:(selector "layered") [ color 12 ] ];
     ]
 
@@ -117,14 +117,14 @@ let generated_api_stylesheet buf =
   in
   Css.v
     [
-      Css.layer ~name:"theme"
+      Css.layer ~name:[ "theme" ]
         [
           Css.rule ~selector:(selector "root") [ prop 0 ];
           Css.media
             ~condition:(Css.Media.of_string "(prefers-color-scheme: dark)")
             [ Css.rule ~selector:(selector "dark") [ prop 2 ] ];
         ];
-      Css.layer ~name:"utilities"
+      Css.layer ~name:[ "utilities" ]
         [ Css.rule ~selector:(selector "utility") [ prop 4 ] ];
       Css.rule ~selector:(selector "card")
         ~nested:
@@ -267,8 +267,8 @@ let test_public_fold_count buf =
 let test_custom_props_scope buf =
   let sheet = generated_api_stylesheet buf in
   let all_props = Css.custom_props sheet in
-  let theme_props = Css.custom_props ~layer:"theme" sheet in
-  let util_props = Css.custom_props ~layer:"utilities" sheet in
+  let theme_props = Css.custom_props ~layer:[ "theme" ] sheet in
+  let util_props = Css.custom_props ~layer:[ "utilities" ] sheet in
   if List.length all_props < 3 then
     failf "Css.custom_props lost properties: %S" (String.concat "," all_props);
   List.iter

--- a/fuzz/fuzz_optimize.ml
+++ b/fuzz/fuzz_optimize.ml
@@ -94,7 +94,7 @@ let generated_import =
   Css.Stylesheet.Import
     {
       url = "theme.css";
-      layer = Some "theme";
+      layer = Some [ "theme" ];
       supports = Some (Css.Supports.property "display" "grid");
       media = Some (Css.Media.of_string "(width >= 40em)");
     }
@@ -152,7 +152,7 @@ let generated_keyframes =
 let generated_sheet_prelude =
   [
     Css.Stylesheet.Charset "UTF-8";
-    Css.Stylesheet.Layer_decl [ "reset"; "theme"; "components" ];
+    Css.Stylesheet.Layer_decl [ [ "reset" ]; [ "theme" ]; [ "components" ] ];
     generated_import;
     generated_namespace;
     Css.Stylesheet.property ~syntax:Css.Variables.Universal "--fuzz";
@@ -169,7 +169,7 @@ let generated_stylesheet buf =
       Css.Stylesheet.Supports_condition
         ("--fuzz-condition", [ declaration buf 12 ]);
       Css.Stylesheet.Layer
-        ( Some (pick [ "base"; "theme"; "components" ] buf 12),
+        ( Some (pick [ [ "base" ]; [ "theme" ]; [ "components" ] ] buf 12),
           [ rule buf 16; Css.Stylesheet.Layer (None, [ rule buf 20 ]) ] );
       Css.Stylesheet.Scope
         ( Some (Css.Selector.of_string ".card"),
@@ -222,11 +222,23 @@ let baseline_true_supports condition =
 let rec boundary_shape = function
   | Css.Stylesheet.Rule _ -> [ "rule" ]
   | Declarations _ -> [ "declarations" ]
-  | Import { layer; _ } -> [ "import:" ^ Option.value ~default:"<none>" layer ]
+  | Import { layer; _ } ->
+      [
+        "import:"
+        ^ Option.fold ~none:"<none>" ~some:Css.Stylesheet.string_of_layer_name
+            layer;
+      ]
   | Namespace _ -> [ "namespace" ]
-  | Layer_decl names -> [ "layer-decl:" ^ String.concat "," names ]
+  | Layer_decl names ->
+      [
+        "layer-decl:"
+        ^ String.concat "," (List.map Css.Stylesheet.string_of_layer_name names);
+      ]
   | Layer (name, block) ->
-      let name = Option.value ~default:"<anonymous>" name in
+      let name =
+        Option.fold ~none:"<anonymous>"
+          ~some:Css.Stylesheet.string_of_layer_name name
+      in
       ("layer:" ^ name)
       :: Fuzz_helpers.shapes_with_rule_runs ~boundary_shape block
       @ [ "/layer" ]
@@ -463,14 +475,14 @@ let cascade_merge_vectors =
       Css.rule
         ~selector:(Css.Selector.class_ "box")
         [ Css.Declaration.color (Css.Values.hex "#ff0000") ];
-      Css.Stylesheet.Layer_decl [ "reset"; "components" ];
+      Css.Stylesheet.Layer_decl [ [ "reset" ]; [ "components" ] ];
       Css.rule
         ~selector:(Css.Selector.class_ "box")
         [ Css.Declaration.display Css.Properties.Flex ];
     ];
     [
       media_rule "a" "#ff0000";
-      Css.Stylesheet.Layer_decl [ "theme" ];
+      Css.Stylesheet.Layer_decl [ [ "theme" ] ];
       media_rule "b" "#0000ff";
     ];
   ]
@@ -643,8 +655,9 @@ let test_smt_property_order_vectors buf =
 let test_positive_layer_statement_vectors buf =
   let input =
     [
-      Css.Stylesheet.Layer (Some (pick [ "reset"; "base" ] buf 0), []);
-      Css.Stylesheet.Layer (Some (pick [ "theme"; "components" ] buf 1), []);
+      Css.Stylesheet.Layer (Some (pick [ [ "reset" ]; [ "base" ] ] buf 0), []);
+      Css.Stylesheet.Layer
+        (Some (pick [ [ "theme" ]; [ "components" ] ] buf 1), []);
       Css.rule
         ~selector:(Css.Selector.class_ "card")
         [ Css.Declaration.display Css.Properties.Flex ];

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -188,11 +188,10 @@ let segment buf i =
 
 let layer_name buf i =
   match byte_at buf i mod 4 with
-  | 0 -> segment buf (i + 1)
-  | 1 -> segment buf (i + 1) ^ "." ^ segment buf (i + 2)
-  | 2 ->
-      segment buf (i + 1) ^ "." ^ segment buf (i + 2) ^ "." ^ segment buf (i + 3)
-  | _ -> "framework.theme"
+  | 0 -> [ segment buf (i + 1) ]
+  | 1 -> [ segment buf (i + 1); segment buf (i + 2) ]
+  | 2 -> [ segment buf (i + 1); segment buf (i + 2); segment buf (i + 3) ]
+  | _ -> [ "framework"; "theme" ]
 
 let selector buf i =
   Css.Selector.class_ (pick [ "card"; "title"; "button"; "inside" ] buf i)
@@ -216,7 +215,7 @@ let generated_layer_stylesheet buf =
   [
     Css.Stylesheet.Layer_decl [ primary; secondary ];
     import_rule ~layer:secondary "theme.css";
-    import_rule ~layer:"" "anonymous-layer.css";
+    import_rule ~layer:[] "anonymous-layer.css";
     import_rule "plain.css";
     Css.Stylesheet.Layer
       ( Some primary,
@@ -229,11 +228,11 @@ let generated_layer_stylesheet buf =
     Css.Stylesheet.Layer
       ( None,
         [
-          Css.Stylesheet.Layer (Some "foo", [ rule buf 20 ]);
-          Css.Stylesheet.Layer (Some "foo", [ rule buf 24 ]);
+          Css.Stylesheet.Layer (Some [ "foo" ], [ rule buf 20 ]);
+          Css.Stylesheet.Layer (Some [ "foo" ], [ rule buf 24 ]);
         ] );
     Css.Stylesheet.Layer
-      (None, [ Css.Stylesheet.Layer (Some "foo", [ rule buf 28 ]) ]);
+      (None, [ Css.Stylesheet.Layer (Some [ "foo" ], [ rule buf 28 ]) ]);
     rule buf 32;
   ]
 
@@ -457,7 +456,12 @@ let supports_is_baseline_true condition =
 let rec boundary_shape = function
   | Css.Stylesheet.Rule _ -> [ "rule" ]
   | Declarations _ -> [ "declarations" ]
-  | Import { layer; _ } -> [ "import:" ^ Option.value ~default:"<none>" layer ]
+  | Import { layer; _ } ->
+      [
+        "import:"
+        ^ Option.fold ~none:"<none>" ~some:Css.Stylesheet.string_of_layer_name
+            layer;
+      ]
   | Namespace _ -> [ "namespace" ]
   | Layer_decl names ->
       (* Naming an already-declared layer adds nothing - layer order follows the
@@ -468,9 +472,16 @@ let rec boundary_shape = function
         | n :: rest when List.mem n seen -> dedup seen rest
         | n :: rest -> n :: dedup (n :: seen) rest
       in
-      [ "layer-decl:" ^ String.concat "," (dedup [] names) ]
+      [
+        "layer-decl:"
+        ^ String.concat ","
+            (List.map Css.Stylesheet.string_of_layer_name (dedup [] names));
+      ]
   | Layer (name, block) ->
-      let name = Option.value ~default:"<anonymous>" name in
+      let name =
+        Option.fold ~none:"<anonymous>"
+          ~some:Css.Stylesheet.string_of_layer_name name
+      in
       ("layer:" ^ name)
       :: Fuzz_helpers.shapes_with_rule_runs ~boundary_shape block
       @ [ "/layer" ]
@@ -546,7 +557,7 @@ let rec merge_adjacent_layers = function
   | Css.Stylesheet.Layer (Some a, ba)
     :: Css.Stylesheet.Layer (Some b, bb)
     :: rest
-    when a = b ->
+    when Css.Stylesheet.equal_layer_name a b ->
       merge_adjacent_layers (Css.Stylesheet.Layer (Some a, ba @ bb) :: rest)
   | stmt :: rest -> normalize_blocks stmt :: merge_adjacent_layers rest
   | [] -> []

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -44,7 +44,7 @@ let has_nested_preference_media block =
    [@layer { ... }] without a name creates a new layer. *)
 let rec needs_layer_merge = function
   | Layer (Some prev_name, _) :: Layer (Some name, _) :: _
-    when String.equal prev_name name ->
+    when equal_layer_name prev_name name ->
       true
   | _ :: rest -> needs_layer_merge rest
   | [] -> false
@@ -59,7 +59,8 @@ let merge_layer_blocks ~optimize_merged_block stmts =
         | None -> List.rev acc)
     | Layer (Some name, block) :: rest -> (
         match prev with
-        | Some (Some prev_name, prev_block) when String.equal prev_name name ->
+        | Some (Some prev_name, prev_block) when equal_layer_name prev_name name
+          ->
             merge acc (Some (Some name, prev_block @ block)) rest
         | Some (Some prev_name, prev_block) ->
             merge
@@ -413,7 +414,7 @@ let add_new_layer_names seen names =
   let seen, added_rev =
     List.fold_left
       (fun (seen, added_rev) name ->
-        if List.exists (String.equal name) seen then (seen, added_rev)
+        if List.exists (equal_layer_name name) seen then (seen, added_rev)
         else (name :: seen, name :: added_rev))
       (seen, []) names
   in
@@ -444,7 +445,7 @@ let list_has_prefix prefix list =
   let rec loop = function
     | [], _ -> true
     | _ :: _, [] -> false
-    | x :: xs, y :: ys -> String.equal x y && loop (xs, ys)
+    | x :: xs, y :: ys -> equal_layer_name x y && loop (xs, ys)
   in
   loop (prefix, list)
 
@@ -456,7 +457,7 @@ let layer_decl_forward_redundant seen names rest =
   added_by_layer_decl && list_has_prefix introduced_by_decl introduced_by_rest
 
 let layer_decl_backward_redundant seen names =
-  List.for_all (fun name -> List.exists (String.equal name) seen) names
+  List.for_all (fun name -> List.exists (equal_layer_name name) seen) names
 
 (* Top-level CSS Cascade 6.4 cleanup. A layer statement is removable when it
    only repeats layer order already introduced in the current import-separated
@@ -579,8 +580,8 @@ let drop_misplaced_imports stmts =
    downstream. *)
 let merge_named_layers_by_name (stmts : statement list) : statement list =
   let is_empty_block = function [] -> true | _ -> false in
-  let content : (string, statement list) Hashtbl.t = Hashtbl.create 8 in
-  let first_nonempty : (string, unit) Hashtbl.t = Hashtbl.create 8 in
+  let content : (layer_name, statement list) Hashtbl.t = Hashtbl.create 8 in
+  let first_nonempty : (layer_name, unit) Hashtbl.t = Hashtbl.create 8 in
   let has_merge = ref false in
   List.iter
     (fun stmt ->

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -41,9 +41,9 @@ val is_layer_empty : Stylesheet.statement list -> bool
 (** Whether a layer block has no cascade-contributing statements. *)
 
 val collect_empty_layer_names :
-  string list ->
+  Stylesheet.layer_name list ->
   Stylesheet.statement list ->
-  string list * Stylesheet.statement list
+  Stylesheet.layer_name list * Stylesheet.statement list
 (** Collect consecutive empty named layers into layer declaration names. *)
 
 val merge_layer_declarations :

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -1769,7 +1769,7 @@ end
 module Import = struct
   let layer_known ~layer_order = function
     | None -> true
-    | Some name -> List.mem name layer_order
+    | Some name -> List.mem (Stylesheet.string_of_layer_name name) layer_order
 
   let supports_ok ?query rule =
     match ((rule : Stylesheet.import_rule).supports, query) with
@@ -1805,7 +1805,10 @@ module Import = struct
   let guards_ok ?query ~layer_order rule =
     let layer_name = (rule : Stylesheet.import_rule).layer in
     if not (layer_known ~layer_order layer_name) then
-      Error ("unknown layer " ^ Option.value layer_name ~default:"")
+      Error
+        ("unknown layer "
+        ^ Option.fold ~none:"" ~some:Stylesheet.string_of_layer_name layer_name
+        )
     else if not (supports_ok ?query rule) then
       Error "supports() guard rejected the import"
     else if not (media_ok ?query rule) then

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -71,6 +71,15 @@ let layer_known ~layer_order = function
   | None -> true
   | Some name -> List.exists (String.equal name) layer_order
 
+(* The layer a [Context] keys a declaration by: the CSS text of the [@layer]
+   name entered here, or the layer already entered when the block is anonymous.
+   Two names never share their text (CSS Cascade 5 sec. 6.4.1), so the key tells
+   the layer named [a.b] from the sublayer [b] of [a]. *)
+let entered_layer name outer =
+  match name with
+  | Some name -> Some (Stylesheet.string_of_layer_name name)
+  | None -> outer
+
 (* The places a declaration contributes to ordinary element matching. The other
    declaration sites belong to another cascade origin or to no element at all
    (CSS Cascading 5 sec. 6.1): [@keyframes] is the animation origin,
@@ -110,7 +119,9 @@ let collect_cascade_rules ~layer_order stylesheet =
   let rec statement current_layer acc stmt =
     let open Stylesheet in
     let current_layer =
-      match stmt with Layer ((Some _ as name), _) -> name | _ -> current_layer
+      match stmt with
+      | Layer (name, _) -> entered_layer name current_layer
+      | _ -> current_layer
     in
     let acc =
       if at_declaration_site element_matching_sites stmt then
@@ -142,9 +153,7 @@ and eval_statement ?ctx_for_layer ~layer_order ?layer:context_layer ctx
   let open Stylesheet in
   match statement with
   | Layer (name, block) ->
-      let current_layer =
-        match name with Some _ -> name | None -> context_layer
-      in
+      let current_layer = entered_layer name context_layer in
       let ctx =
         match ctx_for_layer with Some f -> f current_layer | None -> ctx
       in
@@ -551,7 +560,7 @@ let custom_props ?layer sheet =
       | Layer (Some name, _) -> (
           match layer with
           | None -> true
-          | Some target -> in_layer || name = target)
+          | Some target -> in_layer || Stylesheet.equal_layer_name name target)
       | _ -> in_layer
     in
     let acc =

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -167,7 +167,8 @@ val as_rule :
     run written before the first nested statement; a run written after one is a
     nested declarations rule inside [nested], at the position it was written. *)
 
-val as_layer : statement -> (string option * statement list) option
+val as_layer :
+  statement -> (Stylesheet.layer_name option * statement list) option
 (** [as_layer stmt] returns [Some (name, statements)] if the statement is a
     layer, {!constructor-None} otherwise. *)
 
@@ -247,16 +248,16 @@ val eval_stylesheet :
 (** [eval_stylesheet ctx stylesheet] evaluates every declaration in
     [stylesheet]. *)
 
-val import_layer_name : Stylesheet.import_rule -> string option
+val import_layer_name : Stylesheet.import_rule -> Stylesheet.layer_name option
 (** [import_layer_name rule] returns the layer name declared by an [@import]
-    rule: {!constructor-None} means no layer, [Some ""] means an anonymous
+    rule: {!constructor-None} means no layer, [Some []] means an anonymous
     layer, and [Some name] is a named layer. *)
 
-val layer_block_name : statement -> string option
+val layer_block_name : statement -> Stylesheet.layer_name option
 (** [layer_block_name stmt] returns the declared name of an [@layer] block rule.
-    Anonymous layer blocks return [Some ""]. *)
+    Anonymous layer blocks return [Some []]. *)
 
-val layer_statement_name_list : statement -> string list option
+val layer_statement_name_list : statement -> Stylesheet.layer_name list option
 (** [layer_statement_name_list stmt] returns the declared name list for
     statement-form [@layer] rules. *)
 
@@ -514,12 +515,13 @@ val media_queries : t -> (Media.t * statement list) list
     query's rules; a nested rule keeps the relative selector it was written
     with. *)
 
-val layers : t -> string list
-(** [layers t] is every cascade layer [t] declares, one dotted path per layer
-    ([a.b] is the sublayer [b] of [a], however it was written), in the order the
-    sheet first names them. A layer named inside a conditional group counts: the
-    group decides whether its contents apply, not whether the layer exists. A
-    sublayer of an anonymous [@layer { ... }] has no name to report.
+val layers : t -> Stylesheet.layer_name list
+(** [layers t] is every cascade layer [t] declares, one path per layer ([a.b] is
+    the sublayer [b] of [a], however it was written), in the order the sheet
+    first names them. Each path is its idents, so a [.] one ident carries is not
+    the separator between two. A layer named inside a conditional group counts:
+    the group decides whether its contents apply, not whether the layer exists.
+    A sublayer of an anonymous [@layer { ... }] has no name to report.
 
     This is what a sheet declares, not the order a cascade resolves in.
     {!Resolve.layer_order} answers that, and leaves out a layer named inside any
@@ -528,7 +530,7 @@ val layers : t -> string list
 
 (** {3 AST Introspection Helpers} *)
 
-val layer_block : string -> t -> statement list option
+val layer_block : Stylesheet.layer_name -> t -> statement list option
 (** [layer_block name sheet] is the statements of the layer [name], wherever it
     is declared and whatever form declares it: a dotted name, a nested block, or
     a block inside a conditional group. It is {!constructor-None} when no
@@ -556,7 +558,7 @@ val custom_props_of_rules : (Selector.t * declaration list) list -> string list
 (** [custom_props_of_rules rules] extracts all custom property names from the
     declarations in the rules. *)
 
-val custom_props : ?layer:string -> t -> string list
+val custom_props : ?layer:Stylesheet.layer_name -> t -> string list
 (** [custom_props ?layer sheet] is the name of every custom property [sheet]
     declares for an element: the ones in a style rule or a bare nesting block,
     at the top level and inside a conditional group at-rule such as [@media],
@@ -579,16 +581,16 @@ val declarations : declaration list -> statement
 (** [declarations decls] creates a bare declarations block (used in CSS
     nesting). *)
 
-val layer : ?name:string -> statement list -> statement
+val layer : ?name:Stylesheet.layer_name -> statement list -> statement
 (** [layer ?name statements] creates a [@layer] statement with the given
     statements. *)
 
-val layer_decl : string list -> statement
+val layer_decl : Stylesheet.layer_name list -> statement
 (** [layer_decl names] creates a [@layer] declaration statement that declares
     layer names without any content (e.g.,
     [@layer theme, base, components, utilities;]). *)
 
-val layer_of : ?name:string -> t -> t
+val layer_of : ?name:Stylesheet.layer_name -> t -> t
 (** [layer_of ?name stylesheet] wraps an entire stylesheet in [@layer],
     preserving [@supports] and other at-rules within it. *)
 

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -47,7 +47,9 @@ let media_path_and_inner stmt =
 let layer_path_and_inner stmt =
   match Css.as_layer stmt with
   | Some (name_opt, inner) ->
-      let name = match name_opt with Some n -> n | None -> "" in
+      let name =
+        Option.fold ~none:"" ~some:Css.Stylesheet.string_of_layer_name name_opt
+      in
       Some ("@layer " ^ name, inner)
   | None -> None
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -664,6 +664,17 @@ let container_label container_type condition =
   | `Nesting -> condition ^ " { & }"
   | container_type -> container_prefix container_type ^ " " ^ condition
 
+(* The whole of the [@layer] statement form. The semicolon is what tells a
+   layer-order pin from the block of the same name: [@layer a;] ahead of [@layer
+   a { ... }] is a second statement, not the block again. *)
+let layer_decl_text names =
+  String.concat ""
+    [
+      "@layer ";
+      String.concat ", " (List.map Css.Stylesheet.string_of_layer_name names);
+      ";";
+    ]
+
 (* The statements that carry neither a selector nor a block. Naming them apart
    also keeps them apart in the order keys, where one shared "(other statement)"
    made a [@charset] and a [@namespace] the same statement. *)
@@ -675,10 +686,7 @@ let describe_prelude_statement (s : Css.statement) =
         ("@namespace"
         ^ (match prefix with Some p -> " " ^ p | None -> "")
         ^ ";")
-  (* The semicolon is what tells a layer-order pin from the block of the same
-     name: [@layer a;] ahead of [@layer a { ... }] is a second statement, not
-     the block again. *)
-  | Layer_decl names -> Some ("@layer " ^ String.concat ", " names ^ ";")
+  | Layer_decl names -> Some (layer_decl_text names)
   | _ -> None
 
 (* A statement's own text, split at its block: the head names it, the body is
@@ -697,6 +705,12 @@ let statement_text_split stmt =
       in
       (String.trim head, body)
 
+(* The head of an [@layer]. *)
+let layer_block_head name =
+  match name with
+  | Some name -> "@layer " ^ Css.Stylesheet.string_of_layer_name name
+  | None -> "@layer"
+
 let describe_statement stmt =
   let try_desc f = f stmt in
   let matchers =
@@ -707,11 +721,7 @@ let describe_statement stmt =
         Option.map
           (fun (c, _) -> "@media " ^ Css.Media.to_string c)
           (Css.as_media s));
-      (fun s ->
-        Option.map
-          (fun (n, _) ->
-            match n with Some name -> "@layer " ^ name | None -> "@layer")
-          (Css.as_layer s));
+      (fun s -> Option.map (fun (n, _) -> layer_block_head n) (Css.as_layer s));
       (fun s ->
         Option.map
           (fun (n, c, _) ->
@@ -1049,11 +1059,26 @@ let pp_containers_section ~style buf containers =
       pp_container_diff ~style ~is_last ~parent_prefix:"" buf cont_diff)
     containers
 
+(* [Resolve.layer_order] escapes each ident of a path (CSS Syntax 3 sec. 2.1),
+   so only a bare [.] separates two of them: one an ident carries is written
+   [\.] and stays inside its own segment. *)
+let split_layer_path path =
+  let len = String.length path in
+  let rec go start i acc =
+    if i >= len then List.rev (String.sub path start (len - start) :: acc)
+    else
+      match path.[i] with
+      | '\\' -> go start (i + 2) acc
+      | '.' -> go (i + 1) (i + 1) (String.sub path start (i - start) :: acc)
+      | _ -> go start (i + 1) acc
+  in
+  go 0 0 []
+
 (* A layer path is keyed for the cascade, not for reading: an anonymous [@layer
    { }] block is a segment starting with U+0000, which a report has to name some
    other way. *)
 let layer_path_name path =
-  String.split_on_char '.' path
+  split_layer_path path
   |> List.map (fun segment ->
       if String.length segment > 0 && segment.[0] = '\000' then
         "(anonymous " ^ String.sub segment 1 (String.length segment - 1) ^ ")"
@@ -2526,11 +2551,16 @@ let extract_supports_as_string stmt =
   | Some (cond, rules) -> Some (Css.Supports.to_string cond, rules)
   | None -> None
 
-(* The name [layer_diff] keys a layer on: an anonymous [@layer { ... }] has
-   none, so it keys on the empty string like every other anonymous one. *)
+(* The name [layer_diff] keys a layer on: the CSS text of the name, so a [.] one
+   ident carries is not the separator between two (CSS Cascade 5 sec. 6.4.1). An
+   anonymous [@layer { ... }] has no name, so it keys on the empty string like
+   every other anonymous one. *)
+let layer_key name_opt =
+  Option.fold ~none:"" ~some:Css.Stylesheet.string_of_layer_name name_opt
+
 let extract_layer_name stmt =
   match Css.as_layer stmt with
-  | Some (name_opt, rules) -> Some (Option.value ~default:"" name_opt, rules)
+  | Some (name_opt, rules) -> Some (layer_key name_opt, rules)
   | None -> None
 
 let keyframes_container_info name =
@@ -2824,7 +2854,7 @@ and process_nested_containers ~container_type ~extract_fn ~diff_fn stmts1 stmts2
 
 (* Layer diff function *)
 and layer_diff items1 items2 =
-  let key_of (name_opt, _) = Option.value ~default:"" name_opt in
+  let key_of (name_opt, _) = layer_key name_opt in
   let key_equal = String.equal in
   let is_empty_diff (_, rules1) (_, rules2) =
     let a_r, r_r, m_r, rg_r = rule_diffs rules1 rules2 in
@@ -2842,19 +2872,15 @@ and layer_diff items1 items2 =
   in
   (* Transform to consistent format with media_diff *)
   let added =
-    List.map
-      (fun (name_opt, rules) -> (Option.value ~default:"" name_opt, rules))
-      added
+    List.map (fun (name_opt, rules) -> (layer_key name_opt, rules)) added
   in
   let removed =
-    List.map
-      (fun (name_opt, rules) -> (Option.value ~default:"" name_opt, rules))
-      removed
+    List.map (fun (name_opt, rules) -> (layer_key name_opt, rules)) removed
   in
   let modified =
     List.map
       (fun ((name_opt, rules1), (_, rules2)) ->
-        (Option.value ~default:"" name_opt, rules1, rules2))
+        (layer_key name_opt, rules1, rules2))
       modified_pairs
   in
   (added, removed, modified)

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -63,7 +63,7 @@ let selector_covers ~ancestor ~consumer =
 
 type at_node =
   | Media of Media.t
-  | Layer of string option
+  | Layer of Stylesheet.layer_name option
   | Supports of Supports.t
   | Moz_document of moz_document_condition list
   | Container of string option * Container.t option
@@ -1181,37 +1181,36 @@ let var_census stylesheet =
 
 (* Document-order cascade layer names (dotted for nesting), low precedence
    first: the order in which layers are first introduced (css-cascade-5 sec.
-   6.4.2). [None] when a layer sits where cascade cannot place it: a conditional
-   group introduces its layers only when its condition holds, and an [Origin]
-   block carries its own layer stack. What a [@container], [@scope] or
-   [@starting-style] block holds, and what a rule nests, always exists, so a
-   layer named there counts where it is written. *)
+   6.4.2). Keyed by the CSS text of the whole path, so a [.] one ident carries
+   is not the separator between two (sec. 6.4.1). [None] when a layer sits where
+   cascade cannot place it: a conditional group introduces its layers only when
+   its condition holds, and an [Origin] block carries its own layer stack. What
+   a [@container], [@scope] or [@starting-style] block holds, and what a rule
+   nests, always exists, so a layer named there counts where it is written. *)
 let layer_order stylesheet : string list option =
   let seen = Hashtbl.create 16 in
   let order = ref [] in
   let undecided = ref false in
-  let add name =
+  let add path =
+    let name = Stylesheet.string_of_layer_name path in
     if not (Hashtbl.mem seen name) then begin
       Hashtbl.add seen name ();
       order := name :: !order
     end
-  in
-  let dotted prefix name =
-    if prefix = "" then name else String.concat "." [ prefix; name ]
   in
   let rec walk ~placed prefix stmts = List.iter (statement ~placed prefix) stmts
   and statement ~placed prefix stmt =
     match stmt with
     | Stylesheet.Layer_decl names ->
         if not placed then undecided := true;
-        List.iter (fun n -> add (dotted prefix n)) names
+        List.iter (fun n -> add (prefix @ n)) names
     | Stylesheet.Layer (name, body) ->
         if not placed then undecided := true;
         let prefix =
           match name with
           | None -> prefix
           | Some n ->
-              let full = dotted prefix n in
+              let full = prefix @ n in
               add full;
               full
         in
@@ -1225,7 +1224,7 @@ let layer_order stylesheet : string list option =
         walk ~placed:false prefix body
     | stmt -> walk ~placed prefix (Stylesheet.statement_children stmt)
   in
-  walk ~placed:true "" stylesheet;
+  walk ~placed:true [] stylesheet;
   if !undecided then None else Some (List.rev !order)
 
 module Slot_table = Hashtbl.Make (struct
@@ -1325,18 +1324,16 @@ let layer_claims ~ranks ~unlayered stylesheet =
   let reaches = ref true in
   let position = ref 0 in
   let index = ref 0 in
-  let dotted prefix name =
-    if prefix = "" then name else String.concat "." [ prefix; name ]
-  in
   let rec walk ~layer ~rank stmts = List.iter (statement ~layer ~rank) stmts
   and statement ~layer ~rank stmt =
     match stmt with
     | Stylesheet.Layer (None, _) | Stylesheet.Origin _ | Stylesheet.Scope _ ->
         reaches := false
     | Stylesheet.Layer (Some name, body) ->
-        let layer = dotted layer name in
+        let layer = layer @ name in
         let rank =
-          Option.value ~default:unlayered (Hashtbl.find_opt ranks layer)
+          Option.value ~default:unlayered
+            (Hashtbl.find_opt ranks (Stylesheet.string_of_layer_name layer))
         in
         walk ~layer ~rank body
     | Stylesheet.Layer_decl _ -> ()
@@ -1363,7 +1360,7 @@ let layer_claims ~ranks ~unlayered stylesheet =
         walk ~layer ~rank body
     | _ -> if rank <> unlayered then reaches := false
   in
-  walk ~layer:"" ~rank:unlayered stylesheet;
+  walk ~layer:[] ~rank:unlayered stylesheet;
   if !reaches then Some slots else None
 
 (* Whether dropping every [@layer] wrapper leaves the same declaration winning
@@ -1388,12 +1385,12 @@ let flattening_layers_is_safe stylesheet =
    the dotted layer), [None] when the path is conditional or holds an anonymous
    layer - those are not statically foldable. *)
 let foldable_layer_of_at_path at_path : string option option =
-  let rec go names : at_node list -> string option option = function
+  let rec go path : at_node list -> string option option = function
     | [] -> (
-        match List.rev names with
+        match List.rev path with
         | [] -> Some None
-        | ns -> Some (Some (String.concat "." ns)))
-    | Layer (Some n) :: rest -> go (n :: names) rest
+        | ns -> Some (Some (Stylesheet.string_of_layer_name (List.concat ns))))
+    | Layer (Some n) :: rest -> go (n :: path) rest
     | Layer None :: _ -> None
     | _ :: _ -> None
   in
@@ -1584,7 +1581,7 @@ let wrap_import_body (ir : import_rule) body =
   in
   match ir.layer with
   | None -> body
-  | Some "" -> [ Stylesheet.Layer (None, body) ]
+  | Some [] -> [ Stylesheet.Layer (None, body) ]
   | Some n -> [ Stylesheet.Layer (Some n, body) ]
 
 (* Layer/supports/media guard checks. When [layer_order] is empty, every layer
@@ -1593,9 +1590,9 @@ let wrap_import_body (ir : import_rule) body =
    through and survive as wrapping at-rules in the inlined body; when a query is
    supplied the guard is evaluated and the import is dropped on rejection. *)
 let layer_guard_passes ~(layer_order : string list) (rule : import_rule) =
-  match ((rule.layer : string option), layer_order) with
+  match ((rule.layer : Stylesheet.layer_name option), layer_order) with
   | None, _ | _, [] -> true
-  | Some name, order -> List.mem name order
+  | Some name, order -> List.mem (Stylesheet.string_of_layer_name name) order
 
 let supports_guard_passes ~(query : Context.query option) (rule : import_rule) =
   match ((rule.supports : Supports.t option), query) with

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -65,36 +65,50 @@ let attr_key : Selector.attr_name -> string = function
 
 (* Cascade layers. Layer names form a tree: [@layer a.b] names the sublayer [b]
    of [a], and so does [@layer a { @layer b { ... } }]. The cascade only needs
-   the flattened pre-order of that tree, so a layer is keyed by its dotted path
-   and the order is a list of paths, oldest first (css-cascade-5 sec. 6.4.2). *)
+   the flattened pre-order of that tree, so a layer is keyed by its path - the
+   idents from the root down - and the order is a list of paths, oldest first
+   (css-cascade-5 sec. 6.4.2). *)
 
-let parent_layer name =
-  match String.rindex_opt name '.' with
-  | None -> None
-  | Some i -> Some (String.sub name 0 i)
+let parent_layer path =
+  match List.rev path with [] | [ _ ] -> None | _ :: up -> Some (List.rev up)
 
 (* Each unnamed [@layer { }] block is a layer of its own, distinct from every
    other one, so key it by a counter behind a prefix no author can write: NUL
    never survives tokenisation, css-syntax-3 sec. 3.3 turns it into U+FFFD. *)
-let anonymous_layer n = "\000" ^ string_of_int n
+let anonymous_layer n = [ "\000" ^ string_of_int n ]
+let is_anonymous_ident p = p <> "" && p.[0] = '\000'
 
-let qualify parent name =
-  match parent with None -> name | Some p -> p ^ "." ^ name
+(* A layer is keyed by the CSS text of its path: each ident with the escapes
+   that read it back (css-syntax-3 sec. 2.1), joined by the [.] separators of
+   css-cascade-5 sec. 6.4.1. A [.] an ident carries is escaped, so it never
+   passes for a separator and the layer named [a.b] stays apart from the
+   sublayer [a.b]. An anonymous layer's ident is left as it is: escaping its NUL
+   would only hide the marker a caller looks for. *)
+let layer_key path =
+  let ident p = if is_anonymous_ident p then p else Parser.escape_ident p in
+  String.concat "." (List.map ident path)
+
+let qualify parent name = match parent with None -> name | Some p -> p @ name
+
+let rec is_ancestor p n =
+  match (p, n) with
+  | [], _ -> true
+  | _ :: _, [] -> false
+  | x :: xs, y :: ys -> String.equal x y && is_ancestor xs ys
 
 (* A sublayer is ordered inside its parent, not at the end of the sheet: in
    [@layer a.b {} @layer c {} @layer a.d {}] the layer [a.d] joins [a]'s subtree
    and so still precedes [c]. *)
 let insert_layer order name =
-  if List.mem name order then order
+  if List.exists (Stylesheet.equal_layer_name name) order then order
   else
     match parent_layer name with
     | None -> order @ [ name ]
     | Some p ->
-        let inside n = n = p || starts n (p ^ ".") in
         (* [p]'s subtree is contiguous, so the insertion point is just past its
            last member; [entered] says the scan has reached it. *)
         let rec insert entered = function
-          | x :: rest when inside x -> x :: insert true rest
+          | x :: rest when is_ancestor p x -> x :: insert true rest
           | rest when entered -> name :: rest
           | [] -> [ name ]
           | x :: rest -> x :: insert entered rest
@@ -168,7 +182,7 @@ let layered_rules stmts =
   let order, rules = go None ([], []) stmts in
   (order, List.rev rules)
 
-let layer_order stmts = fst (layered_rules stmts)
+let layer_order stmts = List.map layer_key (fst (layered_rules stmts))
 
 module Make (N : NODE) = struct
   let preceding_siblings n =
@@ -339,14 +353,18 @@ module Make (N : NODE) = struct
       let k = Declaration.property_name d in
       (k, d) :: List.remove_assoc k acc
     in
-    let layer_order, rules = layered_rules (Flatten.block sheet) in
+    let paths, rules = layered_rules (Flatten.block sheet) in
+    let layer_order = List.map layer_key paths in
     let matched =
       rules
       |> List.mapi (fun i (layer, r) ->
           let sel = Stylesheet.selector r in
           if matches sel node then
             Some
-              (layer, matched_specificity sel node, i, Stylesheet.declarations r)
+              ( Option.map layer_key layer,
+                matched_specificity sel node,
+                i,
+                Stylesheet.declarations r )
           else None)
       |> List.filter_map Fun.id
     in

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -69,17 +69,19 @@ val supported : Selector.t -> bool
 val layer_order : Stylesheet.t -> string list
 (** [layer_order sheet] is the cascade layer order [sheet] declares, weakest
     first, as one dotted path per layer: [a.b] is the sublayer [b] of [a],
-    however it was written ([@layer a.b] or [@layer a { @layer b }]). Layers
-    come in order of first appearance with each sublayer inside its parent's run
-    (css-cascade-5 sec. 6.4.2), and an [@layer a, b;] statement declares its
-    names there just as a block does. Every anonymous [@layer { ... }] block is
-    a layer of its own, keyed by a path holding a U+0000 that no author can
-    write - a caller that prints these paths has to spell those out itself. The
-    layers counted are those {!Make.resolve} ranks against, so a layer declared
-    inside one of the blocks it does not walk - a conditional group rule
-    ([@media], [@supports], [@container], [@-moz-document], [@when], [@else]),
-    [@starting-style], [@scope], or an origin wrapper - is not part of this
-    order.
+    however it was written ([@layer a.b] or [@layer a { @layer b }]). Each ident
+    of a path carries the escapes that read it back (css-syntax-3 sec. 2.1), so
+    the layer named [a.b] is the path [a\.b] and stays apart from the sublayer
+    [a.b]. Layers come in order of first appearance with each sublayer inside
+    its parent's run (css-cascade-5 sec. 6.4.2), and an [@layer a, b;] statement
+    declares its names there just as a block does. Every anonymous
+    [@layer { ... }] block is a layer of its own, keyed by a path holding a
+    U+0000 that no author can write - a caller that prints these paths has to
+    spell those out itself. The layers counted are those {!Make.resolve} ranks
+    against, so a layer declared inside one of the blocks it does not walk - a
+    conditional group rule ([@media], [@supports], [@container],
+    [@-moz-document], [@when], [@else]), [@starting-style], [@scope], or an
+    origin wrapper - is not part of this order.
 
     This is the [~layer_order] that {!Stylesheet.cascade_layer_precedence_rank}
     expects. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -12,6 +12,11 @@ let rule ~selector ?(nested = []) ?merge_key declarations : rule =
 let property ~syntax ?initial_value ?(inherits = false) name =
   Property { name; syntax; inherits; initial_value }
 
+(* Two layers are the same layer when they name the same idents: a [.] one of
+   them carries is not the separator between two (CSS Cascade 5 sec. 6.4.1). *)
+let equal_layer_name : layer_name -> layer_name -> bool =
+  List.equal String.equal
+
 let layer_decl names = Layer_decl names
 let layer ?name content = Layer (name, content)
 let media ~condition content = Media (condition, content)
@@ -39,7 +44,7 @@ let import_layer_name ({ layer; _ } : import_rule) = layer
 
 let layer_block_name = function
   | Layer (Some name, _) -> Some name
-  | Layer (None, _) -> Some ""
+  | Layer (None, _) -> Some []
   | _ -> None
 
 let layer_statement_name_list = function
@@ -933,21 +938,18 @@ let pp_import_url ctx url =
   else Pp.quoted_string ctx url
 
 (* CSS Cascade 5 sec. 6.4.1: a [<layer-name>] is [<ident> ['.' <ident>]*], so
-   the escapes CSS Syntax 3 sec. 4.3.7 needs go on each dot-separated part while
-   the [.] separators stay bare (see [Properties.pp_property]). *)
-let escape_layer_name name =
-  if String.contains name '.' then
-    String.split_on_char '.' name
-    |> List.map Parser.escape_ident
-    |> String.concat "."
-  else Parser.escape_ident name
+   each ident takes the escapes CSS Syntax 3 sec. 4.3.7 needs (see
+   [Properties.pp_property]) and the [.] separators stay bare. A [.] an ident
+   carries is escaped, and so never reads back as a separator. *)
+let string_of_layer_name name =
+  String.concat "." (List.map Parser.escape_ident name)
 
-let pp_layer_name : string Pp.t =
- fun ctx name -> Pp.string ctx (escape_layer_name name)
+let pp_layer_name : layer_name Pp.t =
+ fun ctx name -> Pp.string ctx (string_of_layer_name name)
 
 let pp_import_layer ctx layer =
   Pp.sp ctx ();
-  if layer = "" then Pp.string ctx "layer"
+  if layer = [] then Pp.string ctx "layer"
   else (
     Pp.string ctx "layer(";
     pp_layer_name ctx layer;
@@ -985,7 +987,7 @@ let pp_import_components ctx { url; layer; supports; media } =
       (match supports with
       | Some supports when import_supports_media_needs_space supports media ->
           Pp.space ctx ()
-      | None when layer = Some "" -> Pp.space ctx ()
+      | None when layer = Some [] -> Pp.space ctx ()
       | _ -> Pp.sp ctx ());
       Media.pp ctx media)
     media
@@ -1598,43 +1600,40 @@ let rules_below block =
    that fills the layer in. A sublayer of an anonymous layer has no name a
    caller could ask for, so the walk stops there. *)
 let layer_declarations sheet =
-  let prefix_with parent name =
-    if String.equal parent "" then name else parent ^ "." ^ name
-  in
-  let rec emit_dotted parent segments (inner : block option) acc =
+  (* A [<layer-name>] is already its idents (CSS Cascade 5 sec. 6.4.1), so a
+     path extends by appending them: a [.] one ident carries never splits it. *)
+  let rec emit_parts parent segments (inner : block option) acc =
     match segments with
     | [] -> acc
     | [ leaf ] -> (
-        let qualified = prefix_with parent leaf in
+        let qualified = parent @ [ leaf ] in
         let acc = (qualified, inner) :: acc in
         match inner with None -> acc | Some block -> walk qualified acc block)
     | head :: tail ->
         (* An intermediate segment names a layer that exists but opens no block
            of its own. *)
-        let qualified = prefix_with parent head in
+        let qualified = parent @ [ head ] in
         let stub = Option.map (fun _ -> []) inner in
-        emit_dotted qualified tail inner ((qualified, stub) :: acc)
+        emit_parts qualified tail inner ((qualified, stub) :: acc)
   and walk parent acc statements =
     List.fold_left
       (fun acc s ->
         match s with
-        | Layer (Some name, inner) ->
-            emit_dotted parent (String.split_on_char '.' name) (Some inner) acc
+        | Layer (Some name, inner) -> emit_parts parent name (Some inner) acc
         | Layer_decl names ->
             List.fold_left
-              (fun acc name ->
-                emit_dotted parent (String.split_on_char '.' name) None acc)
+              (fun acc name -> emit_parts parent name None acc)
               acc names
         | Layer (None, _) -> acc
         | s -> walk parent acc (statement_children s))
       acc statements
   in
-  List.rev (walk "" [] sheet)
+  List.rev (walk [] [] sheet)
 
 let layer_block name sheet =
   List.find_map
     (fun (declared, block) ->
-      if String.equal declared name then block else None)
+      if equal_layer_name declared name then block else None)
     (layer_declarations sheet)
 
 let layers sheet =
@@ -1725,19 +1724,20 @@ let supports_condition ~loc condition =
 
 (* CSS Cascade section 6.4.2: a layer name is one or more idents joined by '.'
    with no whitespace around the dot. CSS-wide keywords are reserved. *)
-let read_layer_name_component (r : Cursor.t) : string =
+let read_layer_name_component (r : Cursor.t) : layer_name =
   let reserved = function
     | "initial" | "inherit" | "unset" | "revert" | "revert-layer" -> true
     | _ -> false
   in
-  let buf = Buffer.create 16 in
-  let add_part part =
-    if reserved (String.lowercase_ascii part) then
-      Cursor.err_invalid r ("layer name reserves CSS-wide keyword: " ^ part);
-    Buffer.add_string buf part
+  let part p =
+    if reserved (String.lowercase_ascii p) then
+      Cursor.err_invalid r ("layer name reserves CSS-wide keyword: " ^ p);
+    p
   in
-  add_part (Cursor.ident ~keep_case:true r);
-  let rec extend () =
+  let first = part (Cursor.ident ~keep_case:true r) in
+  (* Only a [.] delimiter separates two idents. One an ident carries arrives as
+     part of that ident's own token, so it never reaches here. *)
+  let rec extend acc =
     match Cursor.peek_raw r with
     | Some (Component.Preserved { kind = Token.Delim "."; _ }) ->
         Cursor.skip r;
@@ -1748,13 +1748,10 @@ let read_layer_name_component (r : Cursor.t) : string =
               s
           | _ -> Cursor.err_expected r "ident after '.' in layer name"
         in
-        Buffer.add_char buf '.';
-        add_part next;
-        extend ()
-    | _ -> ()
+        extend (part next :: acc)
+    | _ -> List.rev acc
   in
-  extend ();
-  Buffer.contents buf
+  extend [ first ]
 
 (* CSS Cascade 5 sec. 2 [@import] prelude: [<url> [layer | layer(<layer-name>)]?
    [supports(<supports-condition>)]? <media-query-list>?]. The [~keep_url_repr]
@@ -1782,7 +1779,7 @@ let read_import_layer (r : Cursor.t) =
     Cursor.function_call "layer"
       (fun inner ->
         Cursor.ws inner;
-        if Cursor.is_done inner then ""
+        if Cursor.is_done inner then []
         else
           let name = read_layer_name_component inner in
           Cursor.ws inner;
@@ -1795,7 +1792,7 @@ let read_import_layer (r : Cursor.t) =
       match Cursor.peek_ident r with
       | Some s when String.lowercase_ascii s = "layer" ->
           let _ = Cursor.ident r in
-          Some ""
+          Some []
       | _ -> None)
 
 let read_import_supports (r : Cursor.t) =
@@ -3258,7 +3255,7 @@ let read_supports_condition (r : Cursor.t) : statement =
   let declarations = Cursor.braces Declaration.read_declarations r in
   Supports_condition (name, declarations)
 
-let read_layer_name (r : Cursor.t) : string = read_layer_name_component r
+let read_layer_name (r : Cursor.t) : layer_name = read_layer_name_component r
 
 let read_nested_media_condition components =
   if Cursor.of_components components |> Cursor.is_done then Media.List []
@@ -3770,7 +3767,7 @@ and read_nested_layer_rule r =
   | Some (Component.Block { node = { opening = Token.Curly; _ }; _ }) ->
       Layer (None, Cursor.braces (fun inner -> read_nesting_block inner) r)
   | _ ->
-      let name = Cursor.ident ~keep_case:true r in
+      let name = read_layer_name r in
       Cursor.ws r;
       Layer (Some name, Cursor.braces (fun inner -> read_nesting_block inner) r)
 

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -33,10 +33,10 @@ val property :
 (** [property ~syntax ?initial_value ?inherits name] creates a [@property] rule
     with typed syntax and initial value. *)
 
-val layer_decl : string list -> statement
+val layer_decl : layer_name list -> statement
 (** [layer_decl names] creates a layer declaration statement. *)
 
-val layer : ?name:string -> block -> statement
+val layer : ?name:layer_name -> block -> statement
 (** [layer ?name content] creates a [@layer] rule. *)
 
 val media : condition:Media.t -> block -> statement
@@ -66,19 +66,25 @@ val origin_importance_rank : important:bool -> cascade_origin -> int
     rank for the origin/importance criterion. Larger ranks have higher
     precedence. *)
 
-val import_layer_name : import_rule -> string option
+val import_layer_name : import_rule -> layer_name option
 (** [import_layer_name rule] returns the layer name declared by an [@import]
-    rule: [None] means the import does not declare a layer, [Some ""] means the
+    rule: [None] means the import does not declare a layer, [Some []] means the
     import declares an anonymous layer, and [Some name] is the declared layer
     name. *)
 
-val layer_block_name : statement -> string option
+val equal_layer_name : layer_name -> layer_name -> bool
+(** [equal_layer_name a b] is whether [a] and [b] are the same layer, that is
+    the same idents in the same order. Two layers whose CSS text differs only in
+    how an ident is escaped are the same layer; [@layer a\2e b] and [@layer a.b]
+    are not. *)
+
+val layer_block_name : statement -> layer_name option
 (** [layer_block_name stmt] returns the declared name for an [@layer] block
-    rule. It returns [Some ""] for anonymous layer blocks, [Some name] for named
+    rule. It returns [Some []] for anonymous layer blocks, [Some name] for named
     layer blocks, and [None] for non-layer-block statements. The returned name
     is the at-rule's own declared name, not a parent-prefixed name. *)
 
-val layer_statement_name_list : statement -> string list option
+val layer_statement_name_list : statement -> layer_name list option
 (** [layer_statement_name_list stmt] returns the declared name list for
     statement-form [@layer] rules. *)
 
@@ -430,14 +436,15 @@ val empty : t
 val rules : t -> rule list
 (** [rules t] returns the top-level rules from the stylesheet. *)
 
-val layers : t -> string list
-(** [layers t] is every cascade layer [t] declares, one dotted path per layer
-    ([a.b] is the sublayer [b] of [a], however it was written), in the order the
-    sheet first names them. A layer named inside a conditional group counts: the
-    group decides whether its contents apply, not whether the layer exists. A
-    sublayer of an anonymous [@layer { ... }] has no name to report. *)
+val layers : t -> layer_name list
+(** [layers t] is every cascade layer [t] declares, one path per layer ([a.b] is
+    the sublayer [b] of [a], however it was written), in the order the sheet
+    first names them. Each path is its idents, so a [.] one ident carries is not
+    the separator between two. A layer named inside a conditional group counts:
+    the group decides whether its contents apply, not whether the layer exists.
+    A sublayer of an anonymous [@layer { ... }] has no name to report. *)
 
-val layer_block : string -> t -> block option
+val layer_block : layer_name -> t -> block option
 (** [layer_block name t] is the statements of the layer [name], wherever it is
     declared and whatever form declares it: a dotted name, a nested block, or a
     block inside a conditional group. It is [None] when no [@layer] block opens
@@ -465,6 +472,20 @@ val pp_import_rule : import_rule Pp.t
 
 val read_import_rule : Cursor.t -> import_rule
 (** [read_import_rule r] parses an import rule. *)
+
+val pp_layer_name : layer_name Pp.t
+(** [pp_layer_name] prints a [<layer-name>]: each ident with the escapes that
+    read it back (CSS Syntax 3 sec. 2.1), joined by the [.] separators of CSS
+    Cascade 5 sec. 6.4.1. A [.] an ident carries is escaped, so it never reads
+    back as a separator. *)
+
+val read_layer_name : Cursor.t -> layer_name
+(** [read_layer_name r] parses a [<layer-name>]. It rejects a CSS-wide keyword,
+    which CSS Cascade 5 sec. 6.4.1 reserves. *)
+
+val string_of_layer_name : layer_name -> string
+(** [string_of_layer_name name] is what {!pp_layer_name} prints. Two names never
+    share their text, so it keys a layer. *)
 
 val rule_hash : rule -> int
 (** [rule_hash r] is a cheap hash that discriminates rules by their cached

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -2,11 +2,24 @@
 
 (** {1 Core Types} *)
 
+(** {2 Layer Name} *)
+
+type layer_name = string list
+(** A CSS [\@layer] name: the idents of [<ident> ['.' <ident>]*] (CSS Cascade 5
+    sec. 6.4.1), outermost first. The separators are not part of any ident, so
+    they are not stored: an escape can carry a [.] into an ident (CSS Syntax 3
+    sec. 4.3.7), and one string would make [\@layer a\2e b], the layer named
+    [a.b], the same value as [\@layer a.b], the sublayer [b] of [a]. The empty
+    list is not a name; where an anonymous layer is admissible it is spelled
+    that way. *)
+
 (** {2 Import Rule} *)
 
 type import_rule = {
   url : string;  (** URL or string to import *)
-  layer : string option;  (** Optional layer name *)
+  layer : layer_name option;
+      (** The layer this import declares: {!constructor-None} for none,
+          [Some []] for the anonymous [layer] keyword. *)
   supports : Supports.t option;  (** Optional supports condition *)
   media : Media.t option;  (** Optional media query *)
 }
@@ -137,8 +150,8 @@ and statement =
   | Import of import_rule  (** [@import url(...) layer(...) supports(...);] *)
   | Namespace of string option * namespace_url  (** [@namespace prefix? url;] *)
   | Property : 'a property_rule -> statement  (** [@property --name { ... }] *)
-  | Layer_decl of string list  (** [@layer theme, base, utilities;] *)
-  | Layer of string option * block  (** [@layer name? { ... }] *)
+  | Layer_decl of layer_name list  (** [@layer theme, base, utilities;] *)
+  | Layer of layer_name option * block  (** [@layer name? { ... }] *)
   | Media of Media.t * block  (** [@media (...) { ... }] *)
   | Container of string option * Container.t option * block
       (** [@container name? (...) { ... }] *)

--- a/test/test_block.ml
+++ b/test/test_block.ml
@@ -24,6 +24,26 @@ let test_merge_layers_keeps_distinct_names () =
     "different-name @layer blocks stay separate"
     "@layer a{.x{color:red}}@layer b{.y{color:blue}}" out
 
+(* CSS Cascade 5 sec. 6.4.1: [@layer a\2e b] names one layer whose single ident
+   holds a dot and [@layer a.b] names the sublayer [b] of [a], so merging the
+   two would move a declaration into a layer the input never wrote it in. Two
+   spellings of the one ident still name the one layer. *)
+let test_merge_layers_keeps_escaped_dot_apart () =
+  let stmts = block "@layer a\\2e b{.x{color:red}}@layer a.b{.y{color:blue}}" in
+  let merged = Block.merge_consecutive_layers ~optimize_merged_block:id stmts in
+  Alcotest.(check string)
+    "an ident holding a dot is not the sublayer of the same spelling"
+    "@layer a\\.b{.x{color:red}}@layer a.b{.y{color:blue}}" (render merged)
+
+let test_merge_layers_combines_escaped_dot () =
+  let stmts =
+    block "@layer a\\2e b{.x{color:red}}@layer a\\.b{.y{color:blue}}"
+  in
+  let merged = Block.merge_consecutive_layers ~optimize_merged_block:id stmts in
+  Alcotest.(check string)
+    "two spellings of one ident merge"
+    "@layer a\\.b{.x{color:red}.y{color:blue}}" (render merged)
+
 let test_merge_media_combines_same_condition () =
   let stmts =
     block
@@ -140,6 +160,10 @@ let suite =
         test_merge_layers_combines_same_name;
       Alcotest.test_case "keep distinct-name @layer" `Quick
         test_merge_layers_keeps_distinct_names;
+      Alcotest.test_case "keep an escaped dot out of a sublayer" `Quick
+        test_merge_layers_keeps_escaped_dot_apart;
+      Alcotest.test_case "merge one ident spelled two ways" `Quick
+        test_merge_layers_combines_escaped_dot;
       Alcotest.test_case "merge same-condition @media" `Quick
         test_merge_media_combines_same_condition;
       Alcotest.test_case "drop empty rules" `Quick test_drop_empty_rules;

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -507,9 +507,15 @@ let rec statement_shape stmt =
   | Import _ -> [ "import:" ^ sheet_source stmt ]
   | Namespace _ -> [ "namespace:" ^ sheet_source stmt ]
   | Property _ -> [ "property:" ^ sheet_source stmt ]
-  | Layer_decl names -> [ "layer-decl:" ^ String.concat "." names ]
+  | Layer_decl names ->
+      [
+        "layer-decl:"
+        ^ String.concat "." (List.map Css.Stylesheet.string_of_layer_name names);
+      ]
   | Layer (name, block) ->
-      ("layer:" ^ Option.value ~default:"" name) :: block_lines block
+      ("layer:"
+      ^ Option.fold ~none:"" ~some:Css.Stylesheet.string_of_layer_name name)
+      :: block_lines block
   | Media (condition, block) ->
       ("media:" ^ Css.Pp.to_string ~minify:true Css.Media.pp condition)
       :: block_lines block
@@ -741,8 +747,9 @@ and collect_rule_like_statement ~source_order ~property ~document ~query ~origin
          else (acc, None))
   | Layer (name, block) ->
       Some
-        ( collect_matching_block ~source_order ~property ~document ~query
-            ~origin ~layer:name ~current_specificity ~scope_hops acc block,
+        ( collect_matching_block ~source_order ~property ~document ~query ~origin
+            ~layer:(Option.map Css.Stylesheet.string_of_layer_name name)
+            ~current_specificity ~scope_hops acc block,
           None )
   | Starting_style block ->
       Some

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -65,7 +65,7 @@ let optimization_flag () =
 (* Test layers work end-to-end *)
 let layers_integration () =
   let utility_rule = rule ~selector:btn [ padding [ Px 10. ] ] in
-  let stylesheet = Css.v [ layer ~name:"utilities" [ utility_rule ] ] in
+  let stylesheet = Css.v [ layer ~name:[ "utilities" ] [ utility_rule ] ] in
 
   let css = Css.to_string ~minify:true stylesheet in
 
@@ -262,21 +262,22 @@ let test_layer_block () =
   let stylesheet =
     v
       [
-        layer ~name:"theme" [ rule ~selector:btn [ color (hex "#ff0000") ] ];
-        layer ~name:"utilities" [ rule ~selector:card [ padding [ Px 10. ] ] ];
+        layer ~name:[ "theme" ] [ rule ~selector:btn [ color (hex "#ff0000") ] ];
+        layer ~name:[ "utilities" ]
+          [ rule ~selector:card [ padding [ Px 10. ] ] ];
         rule ~selector:(Selector.class_ "base") [ margin [ Px 5. ] ];
       ]
   in
 
   (* Test extracting theme layer *)
-  let theme_stmts = layer_block "theme" stylesheet in
+  let theme_stmts = layer_block [ "theme" ] stylesheet in
   Alcotest.(check bool) "theme layer found" true (Option.is_some theme_stmts);
 
   let theme_rules = theme_stmts |> Option.get |> rules_of_statements in
   Alcotest.(check int) "theme has one rule" 1 (List.length theme_rules);
 
   (* Test extracting non-existent layer *)
-  let missing = layer_block "missing" stylesheet in
+  let missing = layer_block [ "missing" ] stylesheet in
   Alcotest.(check bool) "missing layer not found" true (Option.is_none missing)
 
 let test_rules_of_statements () =
@@ -397,7 +398,7 @@ let conditional_groups body =
     ("@media", Stylesheet.Media (Media.of_string "screen", body));
     ("@supports", Stylesheet.Supports (Supports.of_string "(top: 0)", body));
     ("@container", Stylesheet.Container (None, None, body));
-    ("@layer", Stylesheet.Layer (Some "a", body));
+    ("@layer", Stylesheet.Layer (Some [ "a" ], body));
     ("@origin", Stylesheet.Origin (Stylesheet.Author, body));
     ("@scope", Stylesheet.Scope (Some (Selector.class_ "card"), None, body));
     ("@starting-style", Stylesheet.Starting_style body);
@@ -425,7 +426,7 @@ let test_spec_map_conditional_boundaries () =
               rule ~selector:(Selector.class_ "title") [ color (hex "#ff0000") ];
             ];
         ];
-      layer ~name:"components"
+      layer ~name:[ "components" ]
         [ rule ~selector:(Selector.class_ "inside") [ color (hex "#ff0000") ] ];
     ]
   in
@@ -532,7 +533,7 @@ let test_spec_sort_conditional_boundaries () =
               rule ~selector:(Selector.class_ "aaa") [ color (hex "#00ff00") ];
             ];
         ];
-      layer ~name:"base"
+      layer ~name:[ "base" ]
         [
           rule ~selector:(Selector.class_ "yyy") [ color (hex "#ff0000") ];
           rule ~selector:(Selector.class_ "bbb") [ color (hex "#00ff00") ];
@@ -623,7 +624,7 @@ let public_fold_edges () =
       [
         with_origin Author
           [
-            layer ~name:"components"
+            layer ~name:[ "components" ]
               [
                 supports
                   ~condition:(Css.Supports.property "display" "grid")
@@ -688,7 +689,7 @@ let public_custom_props_edges () =
     media
       ~condition:(Css.Media.of_string "(prefers-color-scheme: dark)")
       [
-        layer ~name:"theme"
+        layer ~name:[ "theme" ]
           [
             rule ~selector:Selector.Root
               [ custom_property "--brand-dark" "#000" ];
@@ -696,17 +697,17 @@ let public_custom_props_edges () =
       ]
   in
   let utilities =
-    layer ~name:"utilities"
+    layer ~name:[ "utilities" ]
       [
         rule ~selector:(Selector.class_ "m")
           [ custom_property "--space" "1rem" ];
       ]
   in
   let sheet =
-    v [ root; layer ~name:"theme" [ theme_rule ]; nested_theme; utilities ]
+    v [ root; layer ~name:[ "theme" ] [ theme_rule ]; nested_theme; utilities ]
   in
   let all_props = custom_props sheet in
-  let theme_props = custom_props ~layer:"theme" sheet in
+  let theme_props = custom_props ~layer:[ "theme" ] sheet in
   let has name props = List.mem name props in
   Alcotest.(check bool)
     "all props include unlayered" true
@@ -744,7 +745,7 @@ let public_custom_props_declaration_sites () =
       ( "@supports",
         Stylesheet.Supports (Supports.of_string "(top: 0)", [ styled ]) );
       ("@container", Stylesheet.Container (None, None, [ styled ]));
-      ("@layer", Stylesheet.Layer (Some "a", [ styled ]));
+      ("@layer", Stylesheet.Layer (Some [ "a" ], [ styled ]));
       ("@origin", Stylesheet.Origin (Stylesheet.Author, [ styled ]));
       ( "@scope",
         Stylesheet.Scope (Some (Selector.class_ "card"), None, [ styled ]) );
@@ -796,13 +797,13 @@ let public_custom_props_declaration_sites () =
     v
       [
         Stylesheet.Layer
-          (Some "a", [ Stylesheet.Scope (None, None, [ styled ]) ]);
+          (Some [ "a" ], [ Stylesheet.Scope (None, None, [ styled ]) ]);
         rule ~selector:(Selector.class_ "b") [ custom_property "--out" "2" ];
       ]
   in
   Alcotest.(check (list string))
     "layer selects through @scope" [ "--x" ]
-    (custom_props ~layer:"a" layered);
+    (custom_props ~layer:[ "a" ] layered);
   Alcotest.(check (list string))
     "unlayered sibling still reported" [ "--x"; "--out" ] (custom_props layered)
 
@@ -813,15 +814,15 @@ let public_custom_props_declaration_sites () =
    conservative one, when such a block is skipped. *)
 let public_layers_conditional_groups () =
   let styled = rule ~selector:(Selector.class_ "a") [ color (hex "#111111") ] in
-  let block = Stylesheet.Layer (Some "inner", [ styled ]) in
-  let decl = Stylesheet.Layer_decl [ "declared" ] in
+  let block = Stylesheet.Layer (Some [ "inner" ], [ styled ]) in
+  let decl = Stylesheet.Layer_decl [ [ "declared" ] ] in
   let groups =
     [
       ("@media", fun b -> Stylesheet.Media (Media.of_string "screen", b));
       ( "@supports",
         fun b -> Stylesheet.Supports (Supports.of_string "(top: 0)", b) );
       ("@container", fun b -> Stylesheet.Container (None, None, b));
-      ("@layer", fun b -> Stylesheet.Layer (Some "outer", b));
+      ("@layer", fun b -> Stylesheet.Layer (Some [ "outer" ], b));
       ("@origin", fun b -> Stylesheet.Origin (Stylesheet.Author, b));
       ( "@scope",
         fun b -> Stylesheet.Scope (Some (Selector.class_ "card"), None, b) );
@@ -838,7 +839,9 @@ let public_layers_conditional_groups () =
       ("style rule", fun b -> rule ~selector:(Selector.class_ "b") ~nested:b []);
     ]
   in
-  let qualify label name = if label = "@layer" then "outer." ^ name else name in
+  let qualify label name =
+    if label = "@layer" then [ "outer"; name ] else [ name ]
+  in
   let missing =
     List.filter_map
       (fun (label, group) ->
@@ -857,7 +860,7 @@ let public_layers_conditional_groups () =
     Alcotest.failf "layer not reported inside: %s" (String.concat ", " missing);
   (* A sublayer of an anonymous [@layer { }] has no name any caller can ask for,
      so it is not one of the sheet's declared layers. *)
-  Alcotest.(check (list string))
+  Alcotest.(check (list (list string)))
     "anonymous layer hides its sublayers" []
     (layers (v [ Stylesheet.Layer (None, [ block ]) ]));
   (* A layer statement declares a name without opening a block, so it must not
@@ -865,12 +868,13 @@ let public_layers_conditional_groups () =
   let forward_declared =
     v
       [
-        Stylesheet.Layer_decl [ "one"; "two" ];
-        Stylesheet.Layer (Some "one", [ styled ]);
+        Stylesheet.Layer_decl [ [ "one" ]; [ "two" ] ];
+        Stylesheet.Layer (Some [ "one" ], [ styled ]);
       ]
   in
-  Alcotest.(check (list string))
-    "statement declares the order" [ "one"; "two" ] (layers forward_declared);
+  Alcotest.(check (list (list string)))
+    "statement declares the order" [ [ "one" ]; [ "two" ] ]
+    (layers forward_declared);
   let block_text name sheet =
     match layer_block name sheet with
     | None -> "<no block>"
@@ -878,23 +882,23 @@ let public_layers_conditional_groups () =
   in
   Alcotest.(check string)
     "statement does not shadow the block" ".a{color:#111}"
-    (block_text "one" forward_declared);
+    (block_text [ "one" ] forward_declared);
   Alcotest.(check string)
     "a name only declared opens no block" "<no block>"
-    (block_text "two" forward_declared);
+    (block_text [ "two" ] forward_declared);
   (* Names come in source order, so a caller reading them reads the order the
      sheet introduces its layers in. *)
-  Alcotest.(check (list string))
+  Alcotest.(check (list (list string)))
     "names in source order"
-    [ "first"; "second"; "third" ]
+    [ [ "first" ]; [ "second" ]; [ "third" ] ]
     (layers
        (v
           [
-            Stylesheet.Layer_decl [ "first" ];
+            Stylesheet.Layer_decl [ [ "first" ] ];
             Stylesheet.Media
               ( Media.of_string "screen",
-                [ Stylesheet.Layer (Some "second", [ styled ]) ] );
-            Stylesheet.Layer (Some "third", [ styled ]);
+                [ Stylesheet.Layer (Some [ "second" ], [ styled ]) ] );
+            Stylesheet.Layer (Some [ "third" ], [ styled ]);
           ]))
 
 (* [Stylesheet.layers] and [Css.layers] answer one question, so they answer it
@@ -905,27 +909,28 @@ let stylesheet_layers_agree_with_css () =
   let styled = rule ~selector:(Selector.class_ "a") [ color (hex "#111111") ] in
   let sheets =
     [
-      ("dotted name", v [ Stylesheet.Layer (Some "foo.bar", [ styled ]) ]);
+      ("dotted name", v [ Stylesheet.Layer (Some [ "foo"; "bar" ], [ styled ]) ]);
       ( "layer in a group",
         v
           [
             Stylesheet.Media
               ( Media.of_string "screen",
-                [ Stylesheet.Layer (Some "inner", [ styled ]) ] );
+                [ Stylesheet.Layer (Some [ "inner" ], [ styled ]) ] );
           ] );
       ( "layer in a rule",
         v
           [
             rule ~selector:(Selector.class_ "b")
-              ~nested:[ Stylesheet.Layer (Some "deep", [ styled ]) ]
+              ~nested:[ Stylesheet.Layer (Some [ "deep" ], [ styled ]) ]
               [];
           ] );
-      ("statement form", v [ Stylesheet.Layer_decl [ "one"; "two.three" ] ]);
+      ( "statement form",
+        v [ Stylesheet.Layer_decl [ [ "one" ]; [ "two"; "three" ] ] ] );
     ]
   in
   List.iter
     (fun (label, sheet) ->
-      Alcotest.(check (list string))
+      Alcotest.(check (list (list string)))
         (label ^ ": Stylesheet.layers matches Css.layers")
         (layers sheet)
         (Css.Stylesheet.layers sheet))
@@ -968,7 +973,7 @@ let stylesheet_queries_reach_nested () =
       rule ~selector:(Selector.class_ "outer")
         ~nested:[ styled "nested" ]
         [ color (hex "#111111") ];
-      Stylesheet.Layer (Some "l", [ styled "layered" ]);
+      Stylesheet.Layer (Some [ "l" ], [ styled "layered" ]);
     ]
   in
   Alcotest.(check (list string))
@@ -1023,7 +1028,7 @@ let public_vars_declaration_sites () =
       ( "@supports",
         Stylesheet.Supports (Supports.of_string "(top: 0)", [ styled ]) );
       ("@container", Stylesheet.Container (None, None, [ styled ]));
-      ("@layer", Stylesheet.Layer (Some "a", [ styled ]));
+      ("@layer", Stylesheet.Layer (Some [ "a" ], [ styled ]));
       ("@origin", Stylesheet.Origin (Stylesheet.Author, [ styled ]));
       ( "@scope",
         Stylesheet.Scope (Some (Selector.class_ "card"), None, [ styled ]) );

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -306,7 +306,7 @@ let layers () =
   in
 
   let layer_stmt =
-    Css.Stylesheet.Layer (Some "utilities", [ statement_of_rule rule ])
+    Css.Stylesheet.Layer (Some [ "utilities" ], [ statement_of_rule rule ])
   in
 
   let stylesheet = [ layer_stmt ] in
@@ -532,7 +532,9 @@ let test_media_merge_in_layers () =
     ]
   in
 
-  let stylesheet = [ Css.Stylesheet.Layer (Some "utilities", layer_content) ] in
+  let stylesheet =
+    [ Css.Stylesheet.Layer (Some [ "utilities" ], layer_content) ]
+  in
 
   let optimized = Css.Optimize.stylesheet stylesheet in
 
@@ -554,10 +556,10 @@ let test_empty_layers_statement () =
      represented by the statement form from CSS Cascade 5. *)
   let stylesheet =
     [
-      Css.Stylesheet.Layer (Some "reset", []);
-      Css.Stylesheet.Layer (Some "theme", []);
+      Css.Stylesheet.Layer (Some [ "reset" ], []);
+      Css.Stylesheet.Layer (Some [ "theme" ], []);
       Css.Stylesheet.Layer
-        ( Some "components",
+        ( Some [ "components" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "card")
@@ -577,8 +579,8 @@ let test_tw_empty_layers_statement () =
      the shortest faithful spelling combines adjacent declarations. *)
   let input =
     [
-      Css.Stylesheet.Layer (Some "components", []);
-      Css.Stylesheet.Layer (Some "utilities", []);
+      Css.Stylesheet.Layer (Some [ "components" ], []);
+      Css.Stylesheet.Layer (Some [ "utilities" ], []);
     ]
   in
   let optimized = Css.Optimize.stylesheet input in
@@ -2818,7 +2820,7 @@ let c61_no_layer_media_merge () =
   let input =
     [
       media_rule "a" "ff0000";
-      Css.Stylesheet.Layer_decl [ "theme" ];
+      Css.Stylesheet.Layer_decl [ [ "theme" ] ];
       media_rule "b" "0000ff";
     ]
   in
@@ -2883,14 +2885,14 @@ let c61_no_merge_layer () =
   let input =
     [
       Css.Stylesheet.Layer
-        ( Some "reset",
+        ( Some [ "reset" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "btn")
               [ Css.Declaration.display Block ];
           ] );
       Css.Stylesheet.Layer
-        ( Some "components",
+        ( Some [ "components" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "btn")
@@ -2914,7 +2916,7 @@ let c64_layer_order_boundary () =
       Css.rule
         ~selector:(Css.Selector.class_ "theme")
         [ Css.Declaration.color (hex_color "ff0000") ];
-      Css.Stylesheet.Layer_decl [ "reset"; "components" ];
+      Css.Stylesheet.Layer_decl [ [ "reset" ]; [ "components" ] ];
       Css.rule
         ~selector:(Css.Selector.class_ "theme")
         [ Css.Declaration.display Flex ];
@@ -2933,7 +2935,7 @@ let c61_unlayered_outside_layer () =
   let input =
     [
       Css.Stylesheet.Layer
-        ( Some "reset",
+        ( Some [ "reset" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "audio")
@@ -2957,7 +2959,7 @@ let c61_important_layer_order () =
   let input =
     [
       Css.Stylesheet.Layer
-        ( Some "base",
+        ( Some [ "base" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "btn")
@@ -2967,7 +2969,7 @@ let c61_important_layer_order () =
               ];
           ] );
       Css.Stylesheet.Layer
-        ( Some "theme",
+        ( Some [ "theme" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "btn")
@@ -3922,16 +3924,16 @@ let c64_statement_layer_order () =
      rules appear later. *)
   let input =
     [
-      Css.Stylesheet.Layer_decl [ "default"; "theme"; "components" ];
+      Css.Stylesheet.Layer_decl [ [ "default" ]; [ "theme" ]; [ "components" ] ];
       Css.Stylesheet.Layer
-        ( Some "theme",
+        ( Some [ "theme" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "widget")
               [ Css.Declaration.color (hex_color "0000ff") ];
           ] );
       Css.Stylesheet.Layer
-        ( Some "default",
+        ( Some [ "default" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "widget")
@@ -4035,7 +4037,7 @@ let c64_unlayered_final_layer () =
         ~selector:(Css.Selector.element "audio")
         [ Css.Declaration.display Flex ];
       Css.Stylesheet.Layer
-        ( Some "reset",
+        ( Some [ "reset" ],
           [
             Css.rule
               ~selector:
@@ -4059,9 +4061,9 @@ let c64_important_layers_reverse () =
      but earlier layers win for important declarations. *)
   let input =
     [
-      Css.Stylesheet.Layer_decl [ "defaults"; "overrides" ];
+      Css.Stylesheet.Layer_decl [ [ "defaults" ]; [ "overrides" ] ];
       Css.Stylesheet.Layer
-        ( Some "defaults",
+        ( Some [ "defaults" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "notice")
@@ -4071,7 +4073,7 @@ let c64_important_layers_reverse () =
               ];
           ] );
       Css.Stylesheet.Layer
-        ( Some "overrides",
+        ( Some [ "overrides" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "notice")
@@ -4137,16 +4139,16 @@ let c64_nested_layer_distinct () =
   let input =
     [
       Css.Stylesheet.Layer
-        ( Some "base",
+        ( Some [ "base" ],
           [
             Css.rule ~selector:(Css.Selector.element "p")
               [ Css.Declaration.max_width (Ch 70.) ];
           ] );
       Css.Stylesheet.Layer
-        ( Some "framework",
+        ( Some [ "framework" ],
           [
             Css.Stylesheet.Layer
-              ( Some "base",
+              ( Some [ "base" ],
                 [
                   Css.rule ~selector:(Css.Selector.element "p")
                     [ Css.Declaration.margin_block (Em 0.75) ];
@@ -4157,10 +4159,10 @@ let c64_nested_layer_distinct () =
   let optimized = Css.Optimize.stylesheet input in
   match optimized with
   | [
-   Css.Stylesheet.Layer (Some "base", [ base_stmt ]);
+   Css.Stylesheet.Layer (Some [ "base" ], [ base_stmt ]);
    Css.Stylesheet.Layer
-     ( Some "framework",
-       [ Css.Stylesheet.Layer (Some "base", [ framework_base_stmt ]) ] );
+     ( Some [ "framework" ],
+       [ Css.Stylesheet.Layer (Some [ "base" ], [ framework_base_stmt ]) ] );
   ] ->
       let base_rule = rule_of_statement base_stmt in
       let framework_base_rule = rule_of_statement framework_base_stmt in
@@ -4189,16 +4191,16 @@ let c64_keyframe_name_layers () =
   in
   let input =
     [
-      Css.Stylesheet.Layer_decl [ "framework"; "override" ];
+      Css.Stylesheet.Layer_decl [ [ "framework" ]; [ "override" ] ];
       Css.Stylesheet.Layer
-        ( Some "override",
+        ( Some [ "override" ],
           [
             Css.Stylesheet.Keyframes
               ( "slide-left",
                 [ frame (Css.Declaration.opacity (Opacity_number 0.)) ] );
           ] );
       Css.Stylesheet.Layer
-        ( Some "framework",
+        ( Some [ "framework" ],
           [
             Css.Stylesheet.Keyframes
               ("slide-left", [ frame (Css.Declaration.margin_left (Pct 0.)) ]);
@@ -4221,17 +4223,17 @@ let c64_layer_decls_import_cross () =
      declarations across an import. *)
   let input =
     [
-      Css.Stylesheet.Layer_decl [ "default" ];
+      Css.Stylesheet.Layer_decl [ [ "default" ] ];
       Css.Stylesheet.Import
         {
           url = "url(\"theme.css\")";
-          layer = Some "theme";
+          layer = Some [ "theme" ];
           supports = None;
           media = None;
         };
-      Css.Stylesheet.Layer_decl [ "components" ];
+      Css.Stylesheet.Layer_decl [ [ "components" ] ];
       Css.Stylesheet.Layer
-        ( Some "default",
+        ( Some [ "default" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "audio")
@@ -4254,21 +4256,21 @@ let c64_repeated_layer_blocks_ordered () =
   let input =
     [
       Css.Stylesheet.Layer
-        ( Some "base",
+        ( Some [ "base" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "button")
               [ Css.Declaration.color (hex_color "ff0000") ];
           ] );
       Css.Stylesheet.Layer
-        ( Some "theme",
+        ( Some [ "theme" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "button")
               [ Css.Declaration.color (hex_color "0000ff") ];
           ] );
       Css.Stylesheet.Layer
-        ( Some "base",
+        ( Some [ "base" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "button")
@@ -4294,14 +4296,14 @@ let c64_child_layer_one_anonymous () =
         ( None,
           [
             Css.Stylesheet.Layer
-              ( Some "foo",
+              ( Some [ "foo" ],
                 [
                   Css.rule
                     ~selector:(Css.Selector.class_ "inside")
                     [ Css.Declaration.color (hex_color "ff0000") ];
                 ] );
             Css.Stylesheet.Layer
-              ( Some "foo",
+              ( Some [ "foo" ],
                 [
                   Css.rule
                     ~selector:(Css.Selector.class_ "inside")
@@ -4339,7 +4341,7 @@ let c64_child_layer_distinct_anonymous () =
       ( None,
         [
           Css.Stylesheet.Layer
-            ( Some "foo",
+            ( Some [ "foo" ],
               [
                 Css.rule
                   ~selector:(Css.Selector.class_ "inside")
@@ -4357,9 +4359,9 @@ let c64_child_layer_distinct_anonymous () =
   match optimized with
   | [
    Css.Stylesheet.Layer
-     (None, [ Css.Stylesheet.Layer (Some "foo", [ first_stmt ]) ]);
+     (None, [ Css.Stylesheet.Layer (Some [ "foo" ], [ first_stmt ]) ]);
    Css.Stylesheet.Layer
-     (None, [ Css.Stylesheet.Layer (Some "foo", [ second_stmt ]) ]);
+     (None, [ Css.Stylesheet.Layer (Some [ "foo" ], [ second_stmt ]) ]);
   ] ->
       let first = rule_of_statement first_stmt in
       let second = rule_of_statement second_stmt in
@@ -4385,7 +4387,7 @@ let c64_conditional_layer_decls_nested () =
       Css.media
         ~condition:(Css.Media.of_string "(min-width:30em)")
         [
-          Css.layer ~name:"layout"
+          Css.layer ~name:[ "layout" ]
             [
               Css.rule
                 ~selector:(Css.Selector.class_ "title")
@@ -4395,15 +4397,15 @@ let c64_conditional_layer_decls_nested () =
       Css.supports
         ~condition:(Css.Supports.property "display" "grid")
         [
-          Css.Stylesheet.Layer_decl [ "grid" ];
-          Css.layer ~name:"grid"
+          Css.Stylesheet.Layer_decl [ [ "grid" ] ];
+          Css.layer ~name:[ "grid" ]
             [
               Css.rule
                 ~selector:(Css.Selector.class_ "title")
                 [ Css.Declaration.display Grid ];
             ];
         ];
-      Css.Stylesheet.Layer_decl [ "theme"; "layout" ];
+      Css.Stylesheet.Layer_decl [ [ "theme" ]; [ "layout" ] ];
     ]
   in
   let optimized = Css.Optimize.stylesheet input in
@@ -4420,16 +4422,16 @@ let c64_empty_layer_before_block () =
      before a later block assigns style rules to that layer. *)
   let input =
     [
-      Css.Stylesheet.Layer (Some "reset", []);
+      Css.Stylesheet.Layer (Some [ "reset" ], []);
       Css.Stylesheet.Layer
-        ( Some "components",
+        ( Some [ "components" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "card")
               [ Css.Declaration.display Flex ];
           ] );
       Css.Stylesheet.Layer
-        ( Some "reset",
+        ( Some [ "reset" ],
           [
             Css.rule
               ~selector:(Css.Selector.class_ "card")

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -276,6 +276,47 @@ let test_apply_keeps_the_blocks_resolve_skips () =
     "the @scope block is kept in the stylesheet" true
     (String.length result.keep_css > 0)
 
+(* CSS Cascade 5 sec. 6.4.1: a [<layer-name>] is [<ident> ['.' <ident>]*], so
+   [@layer a\2e b] names one layer whose single ident holds a dot, and [@layer
+   a.b] names the sublayer [b] of [a]. They are two layers, each ordered by its
+   own first declaration (sec. 6.4.2), and [a] is the parent of the second only.
+   Chrome answers each of these the same way. *)
+let test_resolve_escaped_dot_layers () =
+  Alcotest.(check (option string))
+    "the layer named a.b is declared after the sublayer" (Some "color:red")
+    (resolved_color
+       "@layer a.b,a\\2e b;@layer a\\2e b{span{color:red}}@layer \
+        a.b{span{color:blue}}");
+  Alcotest.(check (option string))
+    "the sublayer is declared after the layer named a.b" (Some "color:blue")
+    (resolved_color
+       "@layer a\\2e b,a.b;@layer a\\2e b{span{color:red}}@layer \
+        a.b{span{color:blue}}");
+  Alcotest.(check (option string))
+    "a.b joins a's subtree, which precedes z" (Some "color:green")
+    (resolved_color
+       "@layer a,z;@layer z{span{color:green}}@layer a.b{span{color:blue}}");
+  Alcotest.(check (option string))
+    "the layer named a.b joins no subtree, so it follows z" (Some "color:blue")
+    (resolved_color
+       "@layer a,z;@layer z{span{color:green}}@layer a\\2e b{span{color:blue}}");
+  Alcotest.(check (option string))
+    "two spellings of one ident are one layer" (Some "color:green")
+    (resolved_color
+       "@layer a\\2e b,w;@layer w{span{color:green}}@layer \
+        a\\.b{span{color:blue}}")
+
+(* The same two names in {!Resolve.layer_order}: each part of a path is written
+   with the escapes that read it back (CSS Syntax 3 sec. 2.1), so the dot inside
+   an ident cannot pass for the separator between two. *)
+let test_layer_order_escaped_dot () =
+  Alcotest.(check (list string))
+    "a dot inside an ident is not a path separator" [ "a"; "a.b"; "a\\.b" ]
+    (Resolve.layer_order (sheet_of "@layer a.b;@layer a\\2e b;"));
+  Alcotest.(check (list string))
+    "a sublayer of the layer named a.b" [ "a\\.b"; "a\\.b.c" ]
+    (Resolve.layer_order (sheet_of "@layer a\\2e b.c;"))
+
 (* {!Apply.Make} reuses the same {!Node} adapter: a static rule projects onto
    the element, a rule with no inline form ([:hover]) stays in a <style>
    block. *)
@@ -329,6 +370,10 @@ let suite =
         test_layer_order_counts_the_blocks_resolve_walks;
       Alcotest.test_case "apply keeps the blocks resolve skips" `Quick
         test_apply_keeps_the_blocks_resolve_skips;
+      Alcotest.test_case "an escaped dot is not a layer separator" `Quick
+        test_resolve_escaped_dot_layers;
+      Alcotest.test_case "layer_order keeps the two apart" `Quick
+        test_layer_order_escaped_dot;
       Alcotest.test_case "apply projects a static rule, keeps a dynamic one"
         `Quick test_apply_compute;
     ] )

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6463,6 +6463,30 @@ let s4370_property_value_name_escapes () =
       (".a{anchor-name:--a}", ".a{anchor-name:--a}");
     ]
 
+(* CSS Cascade 5 sec. 6.4.1: a [<layer-name>] is [<ident> ['.' <ident>]*], so a
+   dot inside an ident and a dot between two idents name different layers.
+   [@layer a\2e b] is one layer, [@layer a.b] is the sublayer [b] of [a], and
+   the printed name says which: a dot an ident carries is written back escaped
+   (CSS Syntax 3 sec. 2.1), the separators stay bare. *)
+let s641_layer_name_parts () =
+  check_escape_roundtrips
+    [
+      (* One ident holding a dot, against the two idents it would pass for. *)
+      ("@layer a\\2e b;", "@layer a\\.b;");
+      ("@layer a.b;", "@layer a.b;");
+      ("@layer a\\2e b{.x{color:red}}", "@layer a\\.b{.x{color:red}}");
+      ("@layer a.b{.x{color:red}}", "@layer a.b{.x{color:red}}");
+      ("@layer a\\2e b,a.b;", "@layer a\\.b,a.b;");
+      (* A sublayer of the layer named [a.b], and the layer named [a.b.c]. *)
+      ("@layer a\\2e b.c;", "@layer a\\.b.c;");
+      ("@layer a\\2e b\\2e c;", "@layer a\\.b\\.c;");
+      (* The [@import] prelude names a layer the same way. *)
+      ("@import\"a.css\"layer(a\\2e b);", "@import\"a.css\"layer(a\\.b);");
+      ("@import\"a.css\"layer(a.b);", "@import\"a.css\"layer(a.b);");
+      (* Each part still takes the escaping of every other code point. *)
+      ("@layer a\\3b b.c\\3b d;", "@layer a\\;b.c\\;d;");
+    ]
+
 (* CSS Conditional 3 sec. 2.2: a [<supports-decl>] holds a declaration, and a
    custom property's name can carry a [;] or a [}] through an escape (CSS Syntax
    3 sec. 4.3.7). The condition is a capability predicate for that exact name,
@@ -8668,6 +8692,7 @@ let additional_tests =
     ( "spec conditional 3 2.2 supports property name escapes",
       `Quick,
       s4370_supports_property_name_escapes );
+    ("spec cascade 5 6.4.1 layer name parts", `Quick, s641_layer_name_parts);
     ( "fidelity string escape preserved",
       `Quick,
       fidelity_string_escape_preserved );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -24,6 +24,9 @@ let decl_t : Css.Declaration.declaration Alcotest.testable =
 let check_import_rule =
   check_value_cursor "import_rule" read_import_rule pp_import_rule
 
+let check_layer_name =
+  check_value_cursor "layer_name" read_layer_name pp_layer_name
+
 let check_declaration =
   check_value_cursor "declaration" Css.Declaration.read_declaration
     (Css.Pp.option Css.Declaration.pp_declaration)
@@ -277,7 +280,7 @@ let test_property_rule_creation () =
 let test_layer_rule_creation () =
   let decl = Css.Declaration.background_color (Css.Values.hex "ff0000") in
   let rule = rule ~selector:(Selector.class_ "red") [ decl ] in
-  let layer_stmt = layer ~name:"utilities" [ statement_of_rule rule ] in
+  let layer_stmt = layer ~name:[ "utilities" ] [ statement_of_rule rule ] in
   let sheet = Css.Stylesheet.v [ layer_stmt ] in
   (* Both paths for the same node. minify (pp) does the shortest same-node
      spelling: Hex ff0000 -> #f00. minify+optimize cross-folds to the shortest
@@ -555,7 +558,7 @@ let test_property_spec_syntax_vectors () =
 let test_layer_pp () =
   let decl = Css.Declaration.color (Css.Values.hex "0000ff") in
   let rule_obj = rule ~selector:(Selector.class_ "blue") [ decl ] in
-  let layer_stmt = layer ~name:"utilities" [ statement_of_rule rule_obj ] in
+  let layer_stmt = layer ~name:[ "utilities" ] [ statement_of_rule rule_obj ] in
 
   let sheet = Css.Stylesheet.v [ layer_stmt ] in
   let output = Css.Stylesheet.pp ~minify:true sheet in
@@ -564,7 +567,7 @@ let test_layer_pp () =
 
   (* Test empty layer - per CSS spec, empty @layer statements end with
      semicolon *)
-  let empty_layer = layer ~name:"base" [] in
+  let empty_layer = layer ~name:[ "base" ] [] in
   let empty_sheet = Css.Stylesheet.v [ empty_layer ] in
   let empty_output = Css.Stylesheet.pp ~minify:true empty_sheet in
   Alcotest.(check string) "empty layer" "@layer base;" empty_output
@@ -2358,6 +2361,22 @@ let test_import_rule () =
      token-level failure), so [\@import 'test.css] parses as a valid import. *)
   check_import_rule ~expected:"@import\"test.css\";" "@import 'test.css"
 
+(* CSS Cascade 5 sec. 6.4.1: a [<layer-name>] is [<ident> ['.' <ident>]*]. The
+   idents are the name; a [.] one of them carries is written back escaped (CSS
+   Syntax 3 sec. 2.1) and only a bare [.] separates two. A CSS-wide keyword is
+   reserved, in any ident of the name. *)
+let test_layer_name () =
+  check_layer_name ~roundtrip:true "a";
+  check_layer_name ~roundtrip:true "a.b";
+  check_layer_name ~roundtrip:true ~expected:"a\\.b" "a\\2e b";
+  check_layer_name ~roundtrip:true ~expected:"a\\.b.c" "a\\2e b.c";
+  check_layer_name ~roundtrip:true ~expected:"a.b\\.c" "a.b\\2e c";
+  check_layer_name ~roundtrip:true ~expected:"a\\;b" "a\\3b b";
+  neg_cursor read_layer_name "initial";
+  neg_cursor read_layer_name "a.revert-layer";
+  neg_cursor read_layer_name ".a";
+  neg_cursor read_layer_name "a."
+
 (* Not a roundtrip test *)
 let test_advanced_selectors () =
   assert_minify_and_optimize ".btn:hover { color: blue; }"
@@ -2869,56 +2888,57 @@ let c64_invalid_layer_names () =
 (* Not a roundtrip test *)
 let c8_layer_api () =
   (* CSS Cascade section 8: CSSOM exposes the declared layer name on imports and
-     layer block rules, and the declared name list on layer statement rules.
-     Nested block rule names are the at-rule's own name, not parent-prefixed. *)
+     layer block rules, and the declared name list on layer statement rules. A
+     name is its idents, so [framework.theme] is two of them; nested block rule
+     names are the at-rule's own name, not parent-prefixed. *)
+  let name = Alcotest.(option (list string)) in
   let import_named =
     {
       url = "theme.css";
-      layer = Some "framework.theme";
+      layer = Some [ "framework"; "theme" ];
       supports = None;
       media = None;
     }
   in
   let import_anonymous =
-    { url = "private.css"; layer = Some ""; supports = None; media = None }
+    { url = "private.css"; layer = Some []; supports = None; media = None }
   in
   let import_plain =
     { url = "plain.css"; layer = None; supports = None; media = None }
   in
-  Alcotest.(check (option string))
-    "named import layerName" (Some "framework.theme")
+  Alcotest.check name "named import layerName"
+    (Some [ "framework"; "theme" ])
     (Css.Stylesheet.import_layer_name import_named);
-  Alcotest.(check (option string))
-    "anonymous import layerName is empty string" (Some "")
+  Alcotest.check name "anonymous import layerName is the empty name" (Some [])
     (Css.Stylesheet.import_layer_name import_anonymous);
-  Alcotest.(check (option string))
-    "unlayered import layerName is null" None
+  Alcotest.check name "unlayered import layerName is null" None
     (Css.Stylesheet.import_layer_name import_plain);
-  Alcotest.(check (option string))
-    "named layer block API name" (Some "framework.theme")
+  Alcotest.check name "named layer block API name"
+    (Some [ "framework"; "theme" ])
     (Css.Stylesheet.layer_block_name
-       (Css.Stylesheet.Layer (Some "framework.theme", [])));
-  Alcotest.(check (option string))
-    "anonymous layer block API name is empty string" (Some "")
+       (Css.Stylesheet.Layer (Some [ "framework"; "theme" ], [])));
+  Alcotest.check name "anonymous layer block API name is the empty name"
+    (Some [])
     (Css.Stylesheet.layer_block_name (Css.Stylesheet.Layer (None, [])));
   (match
      Css.Stylesheet.Layer
-       (Some "outer", [ Css.Stylesheet.Layer (Some "foo.bar", []) ])
+       (Some [ "outer" ], [ Css.Stylesheet.Layer (Some [ "foo"; "bar" ], []) ])
    with
   | Css.Stylesheet.Layer (_, [ inner ]) ->
-      Alcotest.(check (option string))
-        "inner layer block API name is not parent-prefixed" (Some "foo.bar")
+      Alcotest.check name "inner layer block API name is not parent-prefixed"
+        (Some [ "foo"; "bar" ])
         (Css.Stylesheet.layer_block_name inner)
   | _ -> Alcotest.fail "expected nested layer block");
-  Alcotest.(check (option (list string)))
+  Alcotest.(check (option (list (list string))))
     "layer statement API nameList"
-    (Some [ "reset"; "framework.theme"; "components" ])
+    (Some [ [ "reset" ]; [ "framework"; "theme" ]; [ "components" ] ])
     (Css.Stylesheet.layer_statement_name_list
-       (Css.Stylesheet.Layer_decl [ "reset"; "framework.theme"; "components" ]));
-  Alcotest.(check (option (list string)))
+       (Css.Stylesheet.Layer_decl
+          [ [ "reset" ]; [ "framework"; "theme" ]; [ "components" ] ]));
+  Alcotest.(check (option (list (list string))))
     "non-statement layer has no nameList" None
     (Css.Stylesheet.layer_statement_name_list
-       (Css.Stylesheet.Layer (Some "reset", [])))
+       (Css.Stylesheet.Layer (Some [ "reset" ], [])))
 
 (* Not a roundtrip test *)
 let c41_declared_values () =
@@ -3236,16 +3256,16 @@ let fetch_url_boundary () =
     [
       ( "@import url(base.css) layer(reset) supports(display: grid) screen;",
         "base.css",
-        Some "reset" );
+        Some [ "reset" ] );
       ("@import \"print.css\" print;", "print.css", None);
-      ("@import url(theme.css) layer();", "theme.css", Some "");
+      ("@import url(theme.css) layer();", "theme.css", Some []);
       ( "@import url(theme.css) layer(theme) supports(selector(:has(img))) \
          screen and (width >= 40em);",
         "theme.css",
-        Some "theme" );
+        Some [ "theme" ] );
       ( "@import url(\"../fonts/brand.woff2\") layer(fonts);",
         "../fonts/brand.woff2",
-        Some "fonts" );
+        Some [ "fonts" ] );
     ]
   in
   List.iter
@@ -3253,7 +3273,7 @@ let fetch_url_boundary () =
       let r = Cursor.of_string input in
       let rule = Css.Stylesheet.read_import_rule r in
       Alcotest.(check string) "import url" url rule.url;
-      Alcotest.(check (option string)) "import layer" layer rule.layer)
+      Alcotest.(check (option (list string))) "import layer" layer rule.layer)
     import_cases;
   check_declaration ~expected:"background-image:url(../img/logo.svg)"
     "background-image: url(../img/logo.svg);";
@@ -4187,9 +4207,9 @@ let c643_dotted_nested_layer () =
   in
   Alcotest.(check string)
     "the inner rule appears in the foo.bar layer regardless of input form"
-    (inner_rule_text (Css.layer_block "foo.bar" dotted))
-    (inner_rule_text (Css.layer_block "foo.bar" nested));
-  Alcotest.(check (list string))
+    (inner_rule_text (Css.layer_block [ "foo"; "bar" ] dotted))
+    (inner_rule_text (Css.layer_block [ "foo"; "bar" ] nested));
+  Alcotest.(check (list (list string)))
     "both forms expose the same set of declared layers" (Css.layers dotted)
     (Css.layers nested)
 
@@ -8455,6 +8475,7 @@ let additional_tests =
   [
     ("check function", `Quick, test_check);
     ("import_rule", `Quick, test_import_rule);
+    ("layer_name", `Quick, test_layer_name);
     (* Positive tests *)
     ("advanced selectors", `Quick, test_advanced_selectors);
     ("advanced properties", `Quick, test_advanced_properties);


### PR DESCRIPTION
A `<layer-name>` is `<ident> ['.' <ident>]*` (CSS Cascade 5 sec. 6.4.1), and cascade stored the whole name as one string, so `@layer a\2e b`, the layer named `a.b`, was the same value as `@layer a.b`, the sublayer `b` of `a`: both printed `@layer a.b`, and `Block.merge_consecutive_layers` merged the two blocks into one layer, moving declarations into a layer the input never wrote them in.

Stacked on #437, so review that first.