### PR TITLE
properties: type the colour of every colour-valued property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -317,6 +317,16 @@
   conflict test walks the two key lists in step instead of scanning one per
   element of the other, and collecting them no longer rescans what it has
   already collected (#422)
+- `column-rule-color` and `-webkit-text-stroke-color` are typed as colours and
+  `-webkit-text-fill-color` joins the colour fold, so a colour-valued property
+  minifies to the same spelling whatever its name: `lab(1.90334 0.278696
+  -5.48866)` and `rgb(3, 7, 18)` both print `#030712` (#447)
+- A declaration writing `column-rule-color` keeps its place against one writing
+  `column-rule`. The shorthand resets the rule width, style and colour (CSS
+  Multicol 1 sec. 4.4), but the colour longhand sat outside its overlap
+  footprint, so the optimizer read the pair as commutative: two rules writing
+  the colour merged across `column-rule: 1px solid red`, and an element
+  matching both painted the rule red (#447)
 - A single-argument `:is()` keeps its wrapper after a pseudo-element that
   cannot take its argument, so `.a::before:is(.b)` minifies to
   `.a:before:is(.b)` rather than the `.a:before.b` that cascade's own reader,

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -447,6 +447,9 @@ let property_value_uses_color (type a) (p : Values.color -> bool)
   | Lighting_color -> p value
   | Webkit_tap_highlight_color -> p value
   | Webkit_text_decoration_color -> p value
+  | Webkit_text_fill_color -> p value
+  | Webkit_text_stroke_color -> p value
+  | Column_rule_color -> p value
   | Border_inline_color -> logical_color_uses p value
   | Border_block_color -> logical_color_uses p value
   | Box_shadow -> shadow_uses_color p value
@@ -1640,6 +1643,7 @@ let read_object_transition_value : type a.
   | Column_width -> Some (v Column_width (read_column_width t))
   | Column_count -> Some (v Column_count (read_column_count t))
   | Column_rule -> Some (v Column_rule (read_border t))
+  | Column_rule_color -> Some (v Column_rule_color (read_color t))
   | Column_span -> Some (v Column_span (read_column_span t))
   | _ -> None
 
@@ -1760,6 +1764,7 @@ let read_interaction_value : type a.
   | Webkit_user_select -> Some (v Webkit_user_select (read_user_select t))
   | Ms_user_select -> Some (v Ms_user_select (read_user_select t))
   | Webkit_text_fill_color -> Some (v Webkit_text_fill_color (read_color t))
+  | Webkit_text_stroke_color -> Some (v Webkit_text_stroke_color (read_color t))
   | Moz_user_select -> Some (v Moz_user_select (read_user_select t))
   | Pointer_events -> Some (v Pointer_events (read_pointer_events t))
   | Resize -> Some (v Resize (read_resize t))

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -430,6 +430,7 @@ let pp_property : type a. a property Pp.t =
   | Font_variation_settings -> Pp.string ctx "font-variation-settings"
   | Webkit_tap_highlight_color -> Pp.string ctx "-webkit-tap-highlight-color"
   | Webkit_text_fill_color -> Pp.string ctx "-webkit-text-fill-color"
+  | Webkit_text_stroke_color -> Pp.string ctx "-webkit-text-stroke-color"
   | Webkit_user_select -> Pp.string ctx "-webkit-user-select"
   | Ms_user_select -> Pp.string ctx "-ms-user-select"
   | Moz_user_select -> Pp.string ctx "-moz-user-select"
@@ -545,6 +546,7 @@ let pp_property : type a. a property Pp.t =
   | Column_width -> Pp.string ctx "column-width"
   | Column_count -> Pp.string ctx "column-count"
   | Column_rule -> Pp.string ctx "column-rule"
+  | Column_rule_color -> Pp.string ctx "column-rule-color"
   | Column_span -> Pp.string ctx "column-span"
   | Word_spacing -> Pp.string ctx "word-spacing"
   | Background_attachment -> Pp.string ctx "background-attachment"
@@ -1489,6 +1491,7 @@ let read_any_property t =
   | "column-width" -> Prop Column_width
   | "column-count" -> Prop Column_count
   | "column-rule" -> Prop Column_rule
+  | "column-rule-color" -> Prop Column_rule_color
   | "column-span" -> Prop Column_span
   | "clear" -> Prop Clear
   | "clip" -> Prop Clip
@@ -1749,6 +1752,7 @@ let read_any_property t =
   | "-webkit-text-size-adjust" -> Prop Webkit_text_size_adjust
   | "-webkit-tap-highlight-color" -> Prop Webkit_tap_highlight_color
   | "-webkit-text-fill-color" -> Prop Webkit_text_fill_color
+  | "-webkit-text-stroke-color" -> Prop Webkit_text_stroke_color
   | "-webkit-user-select" -> Prop Webkit_user_select
   | "-ms-user-select" -> Prop Ms_user_select
   | "-moz-user-select" -> Prop Moz_user_select
@@ -2440,6 +2444,9 @@ let normalize_property_value : type a.
   | Border_block_color -> normalize_logical_border_color ~lossless value
   | Text_decoration_color -> normalize_color value
   | Webkit_text_decoration_color -> normalize_color value
+  | Webkit_text_fill_color -> normalize_color value
+  | Webkit_text_stroke_color -> normalize_color value
+  | Column_rule_color -> normalize_color value
   | Webkit_tap_highlight_color -> normalize_color value
   | Text_emphasis_color -> normalize_color value
   | Outline_color -> normalize_color value
@@ -2787,6 +2794,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Webkit_text_decoration_color -> pp pp_color
   | Webkit_tap_highlight_color -> pp pp_color
   | Webkit_text_fill_color -> pp pp_color
+  | Webkit_text_stroke_color -> pp pp_color
+  | Column_rule_color -> pp pp_color
   | Text_indent -> pp pp_text_indent_value
   | Border_spacing -> pp pp_border_spacing
   | Outline_offset -> pp pp_length
@@ -3438,6 +3447,9 @@ let property_value_kind : type a. a property -> a property_value_kind option =
   | Outline_color -> Some Color
   | Webkit_tap_highlight_color -> Some Color
   | Webkit_text_decoration_color -> Some Color
+  | Webkit_text_fill_color -> Some Color
+  | Webkit_text_stroke_color -> Some Color
+  | Column_rule_color -> Some Color
   | Accent_color -> Some Color
   | Caret_color -> Some Color
   | Stop_color -> Some Color

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4694,6 +4694,7 @@ type 'a property =
   | Webkit_text_decoration : text_decoration property
   | Webkit_text_decoration_color : color property
   | Webkit_text_fill_color : color property
+  | Webkit_text_stroke_color : color property
   | Text_indent : text_indent_value property
   | List_style : list_style property
   | Font : font property
@@ -4846,6 +4847,7 @@ type 'a property =
   | Column_width : column_width property
   | Column_count : column_count property
   | Column_rule : border property
+  | Column_rule_color : color property
   | Column_span : column_span property
   | Word_spacing : length property
   | Background_attachment : background_attachment property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -730,6 +730,16 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Columns -> [ key "column-width"; key "column-count" ]
   | Column_width -> [ key "column-width" ]
   | Column_count -> [ key "column-count" ]
+  (* CSS Multicol 1 sec. 4.4: [column-rule] resets the rule width, style and
+     colour. Naming those three is what keeps [column-rule-color] from reading
+     as a slot of its own that [column-rule] never touches. *)
+  | Column_rule ->
+      [
+        key "column-rule-width";
+        key "column-rule-style";
+        key "column-rule-color";
+      ]
+  | Column_rule_color -> [ key "column-rule-color" ]
   (* CSS Lists 3 sec. 3.6. *)
   | List_style ->
       [
@@ -997,6 +1007,7 @@ let layout_footprint_family_heads =
       Prop Overflow;
       Prop Overscroll_behavior;
       Prop Columns;
+      Prop Column_rule;
       Prop Contain_intrinsic_size;
       Prop Container;
     ]

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2125,6 +2125,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Column_width, value -> vars_of_column_width value
   | Column_count, value -> vars_of_column_count value
   | Column_rule, value -> vars_of_border value
+  | Column_rule_color, value -> vars_of_color value
   | Column_span, value -> vars_of_column_span value
   (* Contain *)
   | Contain, value -> vars_of_contain value
@@ -2406,6 +2407,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Webkit_user_select, value -> vars_of_user_select value
   | Ms_user_select, value -> vars_of_user_select value
   | Webkit_text_fill_color, value -> vars_of_color value
+  | Webkit_text_stroke_color, value -> vars_of_color value
   | Moz_user_select, value -> vars_of_user_select value
   | White_space, value -> vars_of_white_space value
   | Word_break, value -> vars_of_word_break value

--- a/test/inline/fixtures/multicol.html
+++ b/test/inline/fixtures/multicol.html
@@ -1,0 +1,18 @@
+<!doctype html><html><head><style>
+  /* CSS Multicol 1 sec. 4.4: [column-rule] is a shorthand over the rule width,
+     style and colour, so a rule writing the colour and one writing the
+     shorthand are order-dependent for any element matching both. The two
+     colour rules say the same thing, which tempts the optimizer to merge them
+     into the first one's place - that moves the second one before the
+     shorthand and repaints the rule red. */
+  .a { column-rule-color: rgb(0, 0, 255) }
+  .b { column-rule: 3px solid rgb(255, 0, 0) }
+  .c { column-rule-color: rgb(0, 0, 255) }
+  /* The same pair inside one rule: the canonical declaration order has to keep
+     the colour after the shorthand that resets it. */
+  .d { column-rule: 3px solid rgb(255, 0, 0); column-rule-color: rgb(0, 128, 0) }
+</style></head><body>
+<div class="b c" style="columns: 2 auto">one two three four</div>
+<div class="d" style="columns: 2 auto">one two three four</div>
+<div class="a" style="columns: 2 auto">one two three four</div>
+</body></html>

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -397,6 +397,9 @@ let matrix =
         "text-decoration-color";
         "-webkit-text-decoration-color";
         "-webkit-tap-highlight-color";
+        "-webkit-text-fill-color";
+        "-webkit-text-stroke-color";
+        "column-rule-color";
         "outline-color";
         "fill";
         "stroke";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2597,7 +2597,7 @@ let spec_property_grammar_manifest () =
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
   Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 452
+    "property grammar manifest covers every tracked spec property name" 455
     (List.length unique_properties);
   List.iter check_property_row property_grammar_matrix
 

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1048,6 +1048,36 @@ let test_vendor_prefix_baseline_gate () =
     ".a{-moz-box-sizing:border-box!important;box-sizing:border-box}"
     (opt ".a{-moz-box-sizing:border-box!important;box-sizing:border-box}")
 
+(* A colour-valued property folds its colour whatever its name: CIE Lab
+   L=1.90334 a=0.278696 b=-5.48866 is sRGB 3,7,18, so both spellings print the
+   same hex. A property left out of the fold reports the two as different
+   values, which is what the browser-differential harness then counts as a
+   render change. *)
+let test_color_property_folds () =
+  let opt css =
+    match Css.of_string css with
+    | Ok p ->
+        Css.to_string ~minify:true (Css.optimize p.stylesheet) |> String.trim
+    | Error _ -> Alcotest.fail "parse"
+  in
+  List.iter
+    (fun property ->
+      let rule value = String.concat "" [ ".a{"; property; ":"; value; "}" ] in
+      Alcotest.(check string)
+        (String.concat "" [ property; " folds lab() to hex" ])
+        (rule "#030712")
+        (opt (rule "lab(1.90334 0.278696 -5.48866)"));
+      Alcotest.(check string)
+        (String.concat "" [ property; " folds rgb() to hex" ])
+        (rule "#030712")
+        (opt (rule "rgb(3, 7, 18)")))
+    [
+      "color";
+      "column-rule-color";
+      "-webkit-text-fill-color";
+      "-webkit-text-stroke-color";
+    ]
+
 let test_lossless_declaration_order () =
   let opt ?(lossless = false) css =
     match Css.of_string css with
@@ -1142,6 +1172,9 @@ let shorthand_longhand_order_cases =
     ( "columns",
       ".a{columns:2;column-width:10em}",
       ".a{columns:2;column-width:10em}" );
+    ( "column-rule",
+      ".a{column-rule:1px solid red;column-rule-color:green}",
+      ".a{column-rule:1px solid red;column-rule-color:green}" );
     ( "list-style",
       ".a{list-style:none;list-style-type:disc}",
       ".a{list-style:none;list-style-type:disc}" );
@@ -1214,6 +1247,25 @@ let test_lossless_keeps_shorthand_longhand_order () =
     (fun (name, input, expected) ->
       Alcotest.(check string) name expected (opt input))
     shorthand_longhand_order_cases
+
+(* The same relation across rules. Two rules writing one colour tempt the
+   optimizer to share a selector list, which puts the later one where the
+   earlier one sits; a rule writing the shorthand in between resets that colour,
+   so an element matching both would repaint. *)
+let test_shorthand_longhand_rule_order () =
+  let opt css =
+    match Css.of_string ~strict:false css with
+    | Ok p ->
+        Css.to_string ~minify:true (Css.optimize p.stylesheet) |> String.trim
+    | Error _ -> Alcotest.fail "parse"
+  in
+  Alcotest.(check string)
+    "a colour rule does not cross the shorthand that resets it"
+    ".a{column-rule-color:green}.b{column-rule:1px solid \
+     red}.c{column-rule-color:green}"
+    (opt
+       ".a{column-rule-color:green}.b{column-rule:1px solid \
+        red}.c{column-rule-color:green}")
 
 (* CSS Logical 1 sec. 2: a flow-relative longhand resolves to a physical side
    the writing mode picks, so a sheet on its own cannot say whether
@@ -1390,6 +1442,7 @@ let optimize_tests =
       nesting_synthesis_can_be_disabled );
     ("vendor prefix strip", `Quick, test_vendor_prefix_strip);
     ("vendor prefix baseline gate", `Quick, test_vendor_prefix_baseline_gate);
+    ("color property folds", `Quick, test_color_property_folds);
     ("lossless declaration order", `Quick, test_lossless_declaration_order);
     ( "lossless keeps unknown property order",
       `Quick,
@@ -1397,6 +1450,7 @@ let optimize_tests =
     ( "lossless keeps shorthand longhand order",
       `Quick,
       test_lossless_keeps_shorthand_longhand_order );
+    ("shorthand longhand rule order", `Quick, test_shorthand_longhand_rule_order);
     ( "lossless keeps logical physical order",
       `Quick,
       test_lossless_keeps_logical_physical_order );


### PR DESCRIPTION
`column-rule-color` and `-webkit-text-stroke-color` parsed as opaque token streams and `-webkit-text-fill-color` was left out of the colour fold, so `lab(1.90334 0.278696 -5.48866)` and `rgb(3, 7, 18)` compared equal under every other colour-valued property and unequal under those three. Typing `column-rule-color` also takes it off the conservative overlap path, so `column-rule` registers the three slots it resets: without that the optimizer merged two rules writing the colour across one writing the shorthand, and Chrome 146 painted the rule red where the source paints it blue.

Supersedes #365, which GitHub closed when #361 merged and its base branch went away.
