### PR TITLE
CHANGES: merge the unreleased entries that are one change

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,659 +2,478 @@
 
 ### Breaking
 
+- **IMPORTANT** Many of the fixes below change the CSS cascade emits for input
+  1.1.0 already accepted, and a dozen of them change how the page renders. If
+  you shipped minified output built with 1.1.0, re-run it and compare:
+  `cascade diff --diff=canonical old.css new.css` exits 1 and prints the
+  difference wherever the two are not equivalent.
 - `Css.statement_declarations` is gone. It answered for a rule and a bare
   nesting block only, sharing its name with the exhaustive
   `Css.Stylesheet.statement_declarations`, which reaches every declaration a
   statement holds; call that one instead (#348)
+- `Css.Declaration.custom_property` raises `Failure` on a name and value that
+  do not write back as the one declaration they name, where it stored the token
+  stream unchecked: `custom_property "--a" "red;--b:blue"` wrote a second
+  declaration and `"red} .evil{color:lime"` closed the rule and opened another.
+  For strings from outside the parser use `parse_custom_property`, which is the
+  same check as an option (#421, #428)
+- `Css.Media.kind` classifies a negated width bound by the side it bounds, so
+  `not (min-width: 640px)` sorts with the upper bounds it matches rather than
+  with the lower bound it negates, and a doubled `not` cancels. The negation of
+  a range such as `not (640px <= width <= 1024px)` is `Other`. `sort_key`,
+  `group_order` and `compare` follow, so a caller sorting media queries gets a
+  different order (#328)
+- `Css.vars_of_rules` is `Css.vars_of_stylesheet`. It reported only what a
+  top-level rule holds; it now also reports a `var()` inside a nested rule, an
+  animation frame or a page margin box (#382)
 
 ### Parsing
 
-- A compound operand of `not`, `and` or `or` in a `@media` condition keeps the
-  parentheses Media Queries 4 sec. 3 requires around a `<media-in-parens>`:
-  `not ((min-width:1px) or (max-width:2px))` printed as
-  `not (min-width:1px)or (max-width:2px)`, which browsers and cascade's own
-  reader reject, losing the whole block (#319)
+- `stroke-miterlimit` takes a value between 0 and 1. SVG 2 makes only a
+  negative value illegal, having dropped SVG 1.1's "at least 1" rule because
+  CSS parsers never enforced it (#334)
+- A descending `@font-face` range such as `font-weight: 700 400` parses without
+  a warning, the user agent swapping the endpoints for font matching. Only
+  `unicode-range` keeps an ordering rule (#335)
+- A media or container size feature takes a unitless zero. `@media (min-width: 0)`,
+  `(width >= 0)` and `@container (min-width: 0)` were rejected and the at-rule
+  went down with the condition, taking every rule inside it. The allowance is
+  for a zero `<length>`, so `(min-resolution: 0)` stays invalid (#427)
 - An `@font-face` descriptor whose value holds a `var()` is dropped with a
-  warning, and `Css.of_string ~strict:true` rejects it. `var()` substitutes in
-  property values only (CSS Variables 1), so no descriptor grammar accepts one
-  and browsers drop the declaration. `src` and `unicode-range` keep theirs,
-  since `Css.inline_vars` resolves those references at build time (#322)
-- `stroke-miterlimit` accepts a value between 0 and 1. SVG 2 sec. 13.5.5 makes
-  only a negative value illegal, having dropped SVG 1.1's "at least 1" rule
-  because CSS parsers never enforced it, and `stroke-miterlimit: 0.5` was
-  rejected outright (#334)
-- A media or container size feature takes the unitless zero CSS Values 4 sec. 5
-  allows for a zero `<length>`, which Media Queries 4 sec. 1.3 inherits.
-  `@media (min-width: 0)`, `(width >= 0)` and `@container (min-width: 0)` were
-  rejected, and the at-rule went down with the condition, taking every rule
-  inside it at exit 0. The allowance is `<length>`-only, so
-  `(min-resolution: 0)` stays invalid (#427)
-- A descending `@font-face` descriptor range such as `font-weight: 700 400`
-  parses without a warning and `Css.of_string ~strict:true` accepts it. CSS
-  Fonts 4 sec. 4.4 has the user agent swap the endpoints for font matching, so
-  the range is well defined rather than an error, and only `unicode-range`
-  keeps an ordering rule (#335)
-- The `round <'border-radius'>` suffix of a basic shape reads its radii through
-  the same reader as the `border-radius` property, so `clip-path`,
-  `shape-outside` and `object-view-box` stop accepting an intrinsic-sizing or
-  CSS-wide keyword as a corner radius. CSS Backgrounds 3 sec. 5.1 allows only a
-  non-negative `<length-percentage>` there, and Chrome and WebKit drop every
-  such declaration (#417)
-- The reader and the optimizer's selector summary answer "is this a
-  pseudo-element?" from one list, so `::target-text`, `::spelling-error`,
-  `::grammar-error` and the framework-only `::deep` family obey the compound
-  and `:has()` rules the rest already did. Selectors 4 sec. 16 admits nothing
-  but pseudo-classes after a pseudo-element and sec. 4.5 keeps pseudo-elements
-  out of `:has()`, whatever the pseudo-element's name, and Chrome and WebKit
-  drop every selector that breaks either rule (#418)
+  warning, and `Css.of_string ~strict:true` rejects it: `var()` substitutes in
+  property values only, so no descriptor grammar accepts one. `src` and
+  `unicode-range` keep theirs, since `Css.inline_vars` resolves those at build
+  time (#322)
+- `clip-path`, `shape-outside` and `object-view-box` stop taking an
+  intrinsic-sizing or CSS-wide keyword as a corner radius in the
+  `round <'border-radius'>` suffix of a basic shape, which browsers drop anyway
+  (#417)
+- Which pseudo-classes may follow a pseudo-element is read per pseudo-element,
+  so `::before:hover`, `::marker:hover` and `::selection:hover` stop parsing
+  while `::file-selector-button:hover`, `::part(p):hover`, `::cue:hover` and
+  `::-webkit-scrollbar:hover` keep parsing. One cascade does not recognise
+  still takes any pseudo-class. A logical combination carries the list into its
+  argument, so `::before:is(.b)` parses and matches nothing while
+  `::before:not(.b)` stops parsing (#430)
+- `::target-text`, `::spelling-error`, `::grammar-error` and the framework-only
+  `::deep` family obey the compound and `:has()` rules the other
+  pseudo-elements already did (#418)
 - `:not()` rejects a pseudo-element in its argument, as `:has()` already did,
   so `.a:not(::before)` no longer parses and prints back as `.a:not(:before)`.
-  Selectors 4 sec. 4.3 gives `:not()` a `<complex-real-selector-list>`, built
-  by sec. 16 out of compound selectors with no pseudo-element among them, and
-  the list is unforgiving, so Chrome and WebKit drop the whole rule where
-  `:is()` and `:where()` drop only the offending item (#426)
-- Which pseudo-classes may follow a pseudo-element is read per pseudo-element,
-  so `::before:hover`, `::marker:hover`, `::selection:hover` and
-  `::spelling-error:hover` stop parsing while `::file-selector-button:hover`,
-  `::part(p):hover`, `::cue:hover` and `::-webkit-scrollbar:hover` keep
-  parsing. Selectors 4 sec. 3.6.3 makes the list per pseudo-element and calls
-  every other combination invalid, CSS Pseudo-Elements 4 sec. 5 gives the
-  element-backed pseudo-elements theirs, and Chrome and WebKit agree on the
-  rest. A pseudo-element cascade does not recognise still takes any
-  pseudo-class. A logical combination carries that list into its own argument:
-  `:is()` and `:where()` take a forgiving list, so `::before:is(.b)` still
-  parses and matches nothing, while the unforgiving `:not()` goes down with the
-  argument, so `::before:not(.b)` and `::part(p):not(.b)` stop parsing and
-  `::part(p):not(:hover)` keeps parsing (#430)
+  Its argument is an unforgiving selector list, so browsers drop the whole rule
+  where `:is()` and `:where()` drop only the offending item (#426)
 - The eleven pseudo-classes WebKit's scrollbar parts report their state through
-  are read as pseudo-classes, so `::-webkit-scrollbar:vertical`,
-  `::-webkit-scrollbar-thumb:window-inactive` and the rest of that family keep
-  their rule instead of losing it at an unforgiving selector list. Chrome and
-  WebKit both read all eleven wherever a pseudo-class goes; after a
-  pseudo-element only a scrollbar part takes them, bar `:window-inactive`,
-  which reaches a `::selection` and a `::part()` as well (#441)
+  are read as pseudo-classes, so `::-webkit-scrollbar:vertical` and
+  `::-webkit-scrollbar-thumb:window-inactive` keep their rule instead of losing
+  it at an unforgiving selector list. After a pseudo-element only a scrollbar
+  part takes them, bar `:window-inactive`, which also reaches `::selection` and
+  `::part()` (#441)
 - A `<custom-ident>` or `<dashed-ident>` an at-rule prelude or a declaration
-  value names is printed with the escapes CSS Syntax 3 sec. 4.3.7 needs to read
-  it back as the same name. `@layer a\3b b` printed `@layer a;b`, two
-  statements naming a layer the input never had. `@counter-style`,
-  `@position-try`, `@font-palette-values`, `@container`, `@import layer()`, a
-  `@font-feature-values` feature name and every name a declaration value
-  carries, from `anchor-name` to `will-change`, all take the escaping (#436)
+  value names is printed with the escapes needed to read it back as the same
+  name: `@layer a\3b b` printed `@layer a;b`, two statements naming a layer the
+  input never had. `@counter-style`, `@position-try`, `@font-palette-values`,
+  `@container`, `@import layer()`, `@font-feature-values` feature names and
+  every name a declaration value carries all take the escaping (#436)
 - `@supports (--x\3b y: red)` is read instead of the whole rule being dropped.
   The reader demanded a property name that re-tokenizes from its own bytes,
-  which holds only while the printer writes that name raw; Chrome and
-  lightningcss both accept the escaped name (#437)
-- A `@layer` name is read as the idents CSS Cascade 5 sec. 6.4.1 makes it, so
-  `@layer a\2e b`, the layer named `a.b`, is no longer the same value as
-  `@layer a.b`, the sublayer `b` of `a`. Both printed `@layer a.b` and the
-  minifier merged the two blocks into one layer, moving declarations into a
-  layer the input never wrote them in (#442)
-- An `@layer` block inside a style rule holds nesting content, so
-  `.a { @layer n { color: red } }` keeps its declaration instead of reading the
-  body as a selector list and dropping it. CSS Nesting 1 sec. 3.1 admits nested
-  at-rules, and `@layer` was the last of the at-rules cascade reads as a
-  nesting context still taking a stylesheet block (#374)
-- A declaration written after a nested rule keeps its place instead of being
-  hoisted to the top of the block. CSS Nesting 1 sec. 3.4 wraps such a run in a
-  nested declarations rule, and its worked example names the hoisted spelling as
-  not equivalent, so `.a { @supports (color: red) { color: blue } color: green }`
-  now computes green as Blink and WebKit do, where cascade printed a sheet that
-  computed blue (#380)
-- Every at-rule that nests inside a style rule reads its body as nesting
-  content. `.a { @starting-style { color: blue } }` kept the wrapper and dropped
-  the declaration, `@-moz-document`, `@when` and `@else` lost theirs the same
-  way, and an at-rule written inside a nested group rule, as in
-  `.a { @layer n { @media screen { color: red } } }`, reached the
-  stylesheet-level reader and lost its block too. CSS Nesting 1 sec. 3.3 nests
-  any at-rule whose body carries style rules, and Blink 146 keeps every one of
-  these shapes whole (#384)
-- An at-rule with no style rule in its body is rejected inside a style rule
-  instead of being kept. CSS Nesting 1 sec. 3.3 nests only an at-rule whose body
-  carries style rules, so `.a { @font-face { ... } }`, `@keyframes`, `@property`,
-  `@page`, `@counter-style`, `@position-try`, `@font-palette-values`,
-  `@font-feature-values`, `@viewport` and `@supports-condition` are invalid
-  there, as is an `@else` with no preceding `@when`; each is dropped with a
-  warning that `Css.of_string ~strict:true` turns into an error, and the
-  declarations written around it stay in the rule. `@view-transition` is kept,
-  since Blink 146 still reads it there (#388)
-- Discarding an at-rule that is invalid inside a style rule ends at the at-rule
-  rather than at the next semicolon. `.a { @import url(x) { } color: red }` lost
-  `color: red`, and an `@import` inside a nested group rule took the whole group
-  with it (#388)
-- An invalid declaration inside a nested at-rule is dropped on its own rather
-  than taking the whole stylesheet. `.a { @media screen { color: red;
-  width: 10; background: blue } }` parsed to nothing, since the nested block had
-  no recovery and the error unwound past every enclosing block. CSS Syntax 3
-  sec. 5.4.4 ends a bad declaration at the next top-level `;`, counting a `{}`
-  met on the way as one component value of the value being skipped, and Blink
-  146 keeps both neighbours in one declaration run. A nested rule whose prelude
-  starts with an identifier, as in `.a { @media screen { h2:where(.b) { color:
-  red } } }`, and a stray `;` between two declarations there, were lost the same
-  way (#392)
-- A descriptor a `@page` body rejects is dropped on its own rather than taking
-  the rule and the stylesheet holding it. `@page { margin: 1cm; width: 10;
-  margin-top: 2cm }` parsed to nothing, and a page margin box lost its whole
-  block the same way. CSS Paged Media 3 sec. 4.1 applies the parse-error rules
-  inside a page or margin context, so the valid declarations around the bad one
-  still apply, and Blink 146 keeps every neighbour. An invalid margin at-rule is
-  discarded to the end of its block rather than to the next `;`, and a
-  selector-shaped item in a margin box, such as `@page { @top-center { .a { b:
-  c } } }`, no longer loops forever (#398)
-- A descriptor an `@property` body rejects is dropped on its own rather than
-  taking the registration and the stylesheet holding it. `@property --x { syntax:
-  "<length>"; inherits: false; initial-value: 0px; zzz: 1 }` parsed to nothing,
-  and so did a stray `;` between two valid descriptors. CSS Properties and Values
-  API 1 sec. 2 ignores an unknown descriptor, CSS Syntax 3 sec. 5.4.3 discards a
-  `;` with no declaration to validate, and Blink 146 reads the registration in
-  both. Tokens left after a descriptor's value, such as a trailing `!important`,
-  now invalidate the declaration they follow rather than the leftover alone
-  (#399)
-- A rule a grouping at-rule's block rejects is discarded to the end of that rule
-  rather than to the first block of any kind in its prelude. In
-  `@media screen { @supports (display: grid) bogus { a { color: red } } }` the
-  discard stopped at `(display: grid)`, so `bogus { a { color: red } }` came back
-  as a rule of its own, and a `[]` in a bad selector cost a second warning for
-  one dropped rule. CSS Syntax 3 sec. 5.4.2 ends an at-rule at its block or its
-  `;` and sec. 5.4.3 ends a qualified rule at its block, so a `(` or a `[`
-  written before that block is part of what is discarded, and Blink 146 keeps no
-  such rule (#402)
-- A `@page` body and a page-margin box keep any property they are given, so
+  which holds only while the printer writes that name raw (#437)
+- A `@layer` name is read as the identifiers it is made of, so `@layer a\2e b`,
+  the layer named `a.b`, is no longer the same value as `@layer a.b`, the
+  sublayer `b` of `a`. Both printed `@layer a.b`, and minification merged the
+  two blocks into one layer, moving declarations into a layer the input never
+  wrote them in (#442)
+- Every at-rule that nests inside a style rule reads its body as nested rules.
+  `.a { @starting-style { color: blue } }` kept the wrapper and dropped the
+  declaration; `@-moz-document`, `@when` and `@else` lost theirs the same way,
+  and `.a { @layer n { @media screen { color: red } } }` reached the
+  stylesheet-level reader and lost its block too (#384)
+- `.a { @layer n { color: red } }` keeps its declaration instead of reading the
+  body as a selector list and dropping it. `@layer` was the last at-rule
+  cascade nests that still took a stylesheet block (#374)
+- An at-rule with no style rule in its body is invalid inside a style rule and
+  dropped with a warning `Css.of_string ~strict:true` turns into an error:
+  `@font-face`, `@keyframes`, `@property`, `@page`, `@counter-style`,
+  `@position-try`, `@font-palette-values`, `@font-feature-values`, `@viewport`,
+  `@supports-condition`, and an `@else` with no preceding `@when`. The discard
+  ends at the at-rule rather than at the next `;`, where
+  `.a { @import url(x) { } color: red }` lost `color: red`. `@view-transition`
+  is kept, since browsers still read it there (#388)
+- A declaration written after a nested rule keeps its place instead of moving
+  to the top of the block, so
+  `.a { @supports (color: red) { color: blue } color: green }` now computes
+  green as browsers do, where cascade printed a sheet that computed blue (#380)
+- A bad item inside a block is dropped on its own rather than taking the block
+  and the stylesheet holding it. Each of these parsed to nothing:
+    - an invalid declaration, a stray `;`, or a nested rule whose prelude
+      starts with an identifier, inside a nested at-rule (#392)
+    - a descriptor a `@page` body or a page margin box rejects. An invalid
+      margin at-rule is discarded to the end of its block rather than to the
+      next `;`, and `@page { @top-center { .a { b: c } } }` no longer loops
+      forever (#398)
+    - a descriptor an `@property` body rejects, and a stray `;` between two
+      valid ones (#399)
+    - a rule a grouping at-rule's block rejects, now discarded to the end of
+      that rule rather than to the first block of any kind in its prelude, so
+      a bad selector no longer costs a second warning (#402)
+    - a descriptor a `@counter-style`, `@font-palette-values` or
+      `@view-transition` body rejects, and a feature block an
+      `@font-feature-values` body rejects (#419)
+    - an at-rule inside a `@keyframes` body (#420)
+- Tokens left after a descriptor's value, such as a trailing `!important`,
+  invalidate the declaration they follow rather than the leftover alone
+  (#399, #419)
+- A `@page` body and a page margin box keep any property they are given, so
   `@page { color: red }`, `@page { orphans: 3 }` and
-  `@page { @top-center { display: block } }` are read instead of erroring under
-  `~strict:true` and being dropped with a warning otherwise. CSS Paged Media 3
-  sec. 6 admits its Appendix A list of CSS 2.1 properties in both contexts and
-  leaves anything outside CSS 2.1 undefined rather than invalid, and Blink 146
-  keeps every property it knows there. The seven-name allowlist also rejected
-  `bleed`, the name sec. 7.3 defines, and `page-orientation`. A value the
-  property's grammar rejects, and an item that is no declaration, are still
-  rejected (#403)
-- A duplicate descriptor in a `@page` body or a page-margin box keeps the
+  `@page { @top-center { display: block } }` are read where a seven-name
+  allowlist rejected them, `bleed` and `page-orientation` included. A value the
+  property's grammar rejects is still rejected (#403)
+- A duplicate descriptor in a `@page` body or a page margin box keeps the
   important declaration rather than the one written last, so
   `@page { margin: 1cm !important; margin: 2cm }` keeps `margin: 1cm !important`
-  where it kept `margin: 2cm`. CSS Cascade 5 sec. 6.2 ranks an important author
-  declaration above a normal one whatever their order, and Blink 146 reads the
-  important one back in a page body and in a margin box alike. Two declarations
-  of the same importance still keep the last (#404)
-- A page-margin box with an empty block is read instead of erroring under
-  `~strict:true` and being dropped with a warning otherwise, so
-  `@page { @top-center { } }` no longer takes its `@page` with it. CSS Paged
-  Media 3 sec. 5 gives a margin at-rule a `<declaration-list>`, which CSS Syntax
-  3 sec. 5.4.4 consumes even when it holds nothing, and Blink 146 keeps the box.
-  Sec. 5 generates the box only where `content` computes away from `none`, so an
-  empty one is elided on output like an empty style rule and an empty `@page`
-  already are (#405)
-- A descriptor a `@counter-style`, `@font-palette-values` or `@view-transition`
-  body rejects is dropped on its own, as is a feature block an
-  `@font-feature-values` body rejects, rather than taking the at-rule and the
-  stylesheet holding it. `@counter-style thumbs { system: cyclic; symbols: "x";
-  zzz: 1 }` parsed to nothing, and the other three lost their whole rule the
-  same way. CSS Syntax 3 sec. 5.4.3 keeps what a block's contents already
-  yielded when one item fails to parse, and Blink 146 keeps all four rules. An
-  `@font-feature-values` body is a list of rules, so an item discarded there
-  ends at its own block rather than at a `;` it has not got, and a `;` with
-  nothing before it costs nothing. Tokens left after a `@font-palette-values` or
-  `@view-transition` or `@counter-style` descriptor value, such as a trailing
-  `!important`, now invalidate the declaration they follow rather than the
-  leftover alone (#419)
-- An at-rule inside a `@keyframes` body is dropped on its own rather than taking
-  the animation and the stylesheet holding it, so
-  `@keyframes k { from { color: red } @media print { to { color: pink } } 50%
-  { background: lime } }` keeps both keyframes where it parsed to nothing. The
-  rejection was raised around the loop rather than inside it, so it unwound past
-  the recovery the loop already ran for a keyframe selector it rejects. CSS
-  Syntax 3 sec. 5.4.2 ends the at-rule being discarded at its own block, past
-  any `(` or `[` in its prelude, and Blink 146 keeps the keyframes written
-  around it (#420)
+  (#404)
+- `@page { @top-center { } }` no longer takes its `@page` with it. An empty
+  margin box is elided on output, as an empty style rule already was (#405)
 
-### Minification
+### Printing
 
-- A NaN-valued number prints as `calc(NaN)`, and a NaN-valued dimension as
-  `calc(NaN * 1unit)`, the forms CSS Values 4 sec. 10.13 defines. A bare `NaN`
-  is not a CSS token, so `width: calc(sqrt(-1) * 1px)` minifying to
-  `width: NaNpx` and `rotate: asin(-20)` to `rotate: NaNdeg` produced output
-  Chrome drops and cascade's own reader rejects. A math function whose value is
-  NaN keeps its function form instead of folding to a leaf (#425)
-- A same-condition `@media` block is no longer hoisted over a crossed rule
-  whose shorthand writes a longhand the hoisted block also writes. The hoist
-  tied two declarations by property name, so
-  `@media (width>=1px){a{background-color:red}}a{background:blue}@media (width>=1px){a{background-color:green}}`
-  minified to a sheet Chrome computes blue for where the source computes green
-  (#415)
-- A `font-family` name keeps the spelling the author wrote. A table of known
-  font names matched an authored name case-insensitively with hyphens folded
-  to spaces and re-emitted the table's spelling, so `font-family: open-sans`
-  became `font-family: "Open Sans"` and `font-family: ny` became
-  `font-family: "New York"`. CSS Fonts 4 sec. 5.1 matches a `<family-name>`
-  with Default Caseless Matching, a caseless string comparison that folds
-  neither a hyphen to a space nor one name to another, so those rewrites named
-  a different family, in the `@font-face` descriptor that *defines* the name as
-  well as in the properties that reference it (#387)
-- A multi-word `<family-name>` unquotes under minify wherever it appears:
-  `"Source Code Pro"` and `"Fira Sans"` stayed quoted next to the `SF Mono` and
-  `Roboto Mono` in the same stack (#387)
-- An authored coefficient keeps every digit under `--minify`. Any dimension was
-  rounded to six significant figures at print time, so `.4285714em` came out as
-  `.428571em`, which is `5.99999px` rather than `6px` at a `14px` font size, and
-  `999999999px` came out a pixel wider. The six-figure budget now belongs to the
-  fold that computes a value, so `calc(2px * pi)` is still `6.28319px` (#350)
-- A `--name` registered by `@property` as a `<number>` keeps the digits it was
-  written with: `--n: 1.4285714` came out as `1.42857`. The six-figure budget
-  stays on the `calc()` the printer folds itself, so `calc(1 / 3)` is still
-  `.333333` (#354)
-- A math function inside `calc()` keeps the unit CSS Values 4 sec. 10.7 gives
-  it: `calc(hypot(1px, 1px))` came out as `1.41421356`, a declaration browsers
-  and cascade's own reader both drop. `abs()` and `hypot()` now carry their
-  arguments' unit out, the inverse trig functions carry `deg`, and a call whose
-  operands mix units keeps its spelling (#362)
-- A computed dimension past a million units keeps every digit under `--minify`.
-  Six significant figures stop reaching its fraction there, so the budget was
-  paid in integer digits the arithmetic got right: `calc(1in + 999999999px)`
-  came out as `1000000000px`, 95px from the `1000000095px` an inch is worth (CSS
-  Values 4 sec. 6.2), and `hypot(999999999px, 1px)` a pixel wider than its own
-  longest side. A narrower value still pays the budget: `calc(1cm + 1px)` is
-  `38.7953px` (#367)
-- An empty `@layer name` inside a style rule keeps its block form. The
-  statement form is a layer-order declaration, which no style rule accepts, so
-  `.a { @layer n {} }` minified to `.a{@layer n;}`, which neither a browser nor
-  cascade's own reader takes back (#374)
-- A declaration whose value is spec-invalid is discarded inside a `@keyframes`
-  frame, matching what a browser does with it there and what cascade already
-  did in a style rule (#341)
-- Under `--scope=stylesheet` a `position-try-fallbacks` name with no
-  `@position-try` rule is dropped inside a `@keyframes` frame, as it already
-  was in a style rule. The name cannot match at runtime wherever the
-  declaration is written (#372)
-- `--minify` optimises the body of `@-moz-document`, `@starting-style`,
-  `@when` and `@else`, which it walked past: rules inside one of them kept
-  whatever the author wrote (#343)
-- `--minify` keeps a `@layer` whose rules write no declarations of their own
-  but nest rules that do. The emptiness test read only the declarations, so
-  `@layer a { .x { .y { color: red } } }` collapsed to `@layer a;` and every
-  declaration below the brace was deleted (#389)
-- `--flatten-nesting` treats `@-moz-document` as the grouping at-rule it is:
-  nesting inside one flattens, and a rule wrapping one keeps its selector
-  instead of emitting the at-rule at top level under no parent (#344)
-- `@media not all and (X)` minifies to the Level 4 `@media not (X)`. `all` is
-  the identity media type (Media Queries 4 sec. 2.3), so the two spell the same
-  query, and default minify already spends Level 3 compatibility by lowering
-  `min-width` to range syntax inside that very query. `--enforce-spec` keeps
-  both Level 3 spellings (#323)
-- A vendor prefix is dropped only when its unprefixed twin is Baseline "widely
-  available", so `--minify` keeps the prefix a maintained browser still reads:
-  `-webkit-backdrop-filter`, `-webkit-user-select`, `-webkit-text-size-adjust`
-  and `-webkit-print-color-adjust` were dropped against an unprefixed twin no
-  shipping Safari understands (#325)
-- A rule whose declarations a later rule all rewrites is dropped only when it
-  carries no nested content. A rule's declarations are only the run written
-  before its first nested statement (CSS Nesting 1 sec. 3.4), so covering them
-  says nothing about what the rest of the body sets, and
-  `.a { all: unset; @media (min-width: 1px) { width: 1px } } .a { all: initial }`
-  lost its nested block along with the rule (#376)
-- A declaration written after a nested statement rejoins the rule's own run
-  when nothing it crosses writes the same property at the same importance, so
-  `.a { & b { width: 1px } color: red }` minifies to
-  `.a{color:red;b{width:1px}}` and `--diff=canonical` stops reporting it as
-  different from `.a { color: red; & b { width: 1px } }`. A declaration that
-  does clash keeps the place CSS Nesting 1 sec. 3.4 gives it (#383)
-- A run of declarations written after a nested statement is deduplicated like
-  any other declaration list, so `.a { & b { color: red } color: blue;
-  color: green }` minifies to `.a{b{color:red}color:green}` rather than keeping
-  a write nothing can read. Nothing sits between two writes inside one run, so
-  the later wins (CSS Cascade 5 sec. 6.4.4) (#386)
-- `--minify` is faster on a stylesheet the optimizer factors heavily, for the
-  same output. The rule graph's cycle check, topological order and
-  selector-branch index each probed a generic `Hashtbl` once per edge or per
-  branch, paying a hash and a structural comparison on a key that is a dense
-  node id or a branch string (#413)
-- Unwrapping a baseline-true `@supports` nested in a style rule keeps the `;`
-  separating its declarations from the sibling that follows. CSS Syntax 3 sec.
-  5.4.4 runs a declaration to the next `;` or to the block's `}`, so
+- A compound operand of `not`, `and` or `or` in a `@media` condition keeps its
+  parentheses: `not ((min-width:1px) or (max-width:2px))` printed as
+  `not (min-width:1px)or (max-width:2px)`, which browsers and cascade's own
+  reader reject, losing the whole block (#319)
+- Unwrapping a `@supports` nested in a style rule keeps the `;` before the
+  sibling that follows, where
   `.a{@supports (color:red){color:blue}@supports (color:red){color:green}}`
-  minified to `.a{color:#00fcolor:green}`, which browsers and cascade's own
-  reader reject, losing the declaration (#370)
-- `--minify` spends less time deciding whether two rules conflict, for the same
-  output. A rule's overlap keys are sorted and deduplicated once, so the
-  conflict test walks the two key lists in step instead of scanning one per
-  element of the other, and collecting them no longer rescans what it has
-  already collected (#422)
-- `--minify` keeps two rules apart across a rule whose property name the
-  footprint model cannot place. Such a name may be a shorthand, a legacy alias
-  or a longhand of a family the model does not carry, and the conflict test
-  says so, but the rule graph ruled the pair out first on an overlap key naming
-  the property itself, so
-  `.a{word-wrap:break-word}.b{overflow-wrap:normal}.c{word-wrap:break-word}`
-  minified to a sheet Chrome 146 computes `overflow-wrap: normal` for where the
-  source computes `break-word` (#452)
-- `column-rule-color` and `-webkit-text-stroke-color` are typed as colours and
-  `-webkit-text-fill-color` joins the colour fold, so a colour-valued property
-  minifies to the same spelling whatever its name: `lab(1.90334 0.278696
-  -5.48866)` and `rgb(3, 7, 18)` both print `#030712` (#447)
-- A declaration writing `column-rule-color` keeps its place against one writing
-  `column-rule`. The shorthand resets the rule width, style and colour (CSS
-  Multicol 1 sec. 4.4), but the colour longhand sat outside its overlap
-  footprint, so the optimizer read the pair as commutative: two rules writing
-  the colour merged across `column-rule: 1px solid red`, and an element
-  matching both painted the rule red (#447)
-- A single-argument `:is()` and a double `:not()` keep their wrapper around a
-  type or universal selector. Selectors 4 sec. 3.5 puts such a selector first
-  in its compound, and both rewrites are node-local, so splicing fused the two
-  names: `.a:is(code)` printed `.acode` and `:is(.a *):is(code)` printed
-  `:is(.a *)code`, which browsers drop (#377)
-- A feature query on a vendor-prefixed property keeps its guard. The
-  web-features dataset behind the Baseline facts tracks unprefixed features
-  only, so a prefix is evidence of nothing and folding it to true flipped
-  Tailwind's legacy-browser reset on in Chrome, where
-  `@supports (-webkit-hyphens: none)` is false (#378)
-- A single-argument `:is()` keeps its wrapper after a pseudo-element that
-  cannot take its argument, so `.a::before:is(.b)` minifies to
-  `.a:before:is(.b)` rather than the `.a:before.b` that cascade's own reader,
-  Chrome and WebKit all drop. It still unwraps everywhere the compound can hold
-  the argument, `.a::part(p):is(:hover)` included (#431)
-- Merging same-selector rules keeps a later declaration behind a nested
-  conditional group that sets the same property. The safety check saw a nested
-  style rule only, so `@media`, `@container` and friends let the merge hoist
-  the declaration past them and hand the conditional the win (#352)
-- Merging same-selector rules orders the rules by what their nested blocks set
-  as well as by their declarations, and reads the source order to decide
-  whether a declaration crosses a nested block. The merge order could put the
-  rule carrying the nested block last, leaving that check nothing to look at,
-  so a nested `@media` won over a later declaration that overrode it (#364)
-- Merging same-selector rules weighs what a nested block sets against a later
-  declaration by cascade slot rather than by property name. A nested
-  `margin: 2rem` and a later `margin-top: 1rem` write one slot under two names,
-  so the merge read them as disjoint, hoisted the longhand ahead of the nested
-  block and handed the shorthand the win (#364)
-- A `font-family` name that cannot be spelled as an identifier keeps its
-  quotes. The unquoting guard checked which characters a name is made of but
-  not how CSS Syntax 3 sec. 4.3.9 lets an ident sequence start, so `"2Brand"`,
-  `"-2x"` and `"-"` came out bare in every mode and a browser dropped the whole
-  declaration, taking the rest of the font stack with it (#390)
-- A multi-word `font-family` name holding a reserved word keeps its quotes.
-  `"inherit test"`, `"revert serif"` and `"default x"` came out bare under
-  `--minify`, and cascade's own reader then rejected the declaration it had
-  just written. CSS Fonts 4 sec. 2.1.1 excludes a pre-defined `font-family`
-  keyword and a CSS-wide keyword per identifier, and CSS Values 4 sec. 4.2 adds
-  the reserved `default`, so the exclusion reaches every word of a
-  `<custom-ident>+` sequence and the quoted form is the only valid one (#401)
-- A same-condition `@media` block is no longer hoisted over a declaration
-  written after a nested rule. CSS Nesting 1 sec. 3.4 keeps that run behind the
-  rule it follows, so it is one more rule the hoist reorders, and
-  `.a { @media (min-width: 1px) { color: red } color: blue; @media (min-width: 1px) { color: green } }`
-  minified to a sheet Chrome computes blue for where the source computes green
-  (#414)
-- An empty `@-moz-document`, `@when` or `@else` is dropped, as an empty
-  `@media` already was: a conditional group rule with no contents applies
-  nothing whatever its condition. An empty `@when` or `@else` stays while a
-  later `@else` binds to it, since dropping the antecedent would leave a bare
-  `@else` that no parser accepts (#396)
-- A declaration writing `border-block-end-style` keeps its place against one
-  writing `border` or `border-style`. CSS Logical 1 sec. 4 resolves the four
-  flow-relative border style longhands to whichever physical side the writing
-  mode picks, but each named a slot no footprint mentions, so the optimizer
-  read the pair as commutative:
-  `.a{border:1px solid red;border-block-end-style:dashed}`
-  reordered under `--minify --lossless` into a rule Chrome 146 computes
-  `border-bottom-style: solid` for where the source computes `dashed`, and two
-  rules writing the longhand merged across an intervening `border` (#453)
-- A vendor-prefixed declaration keeps its place against the property it
-  aliases. `-webkit-transform` and the rest of the prefixed spellings cascade
-  types write the slot their unprefixed twin writes, but each named a slot of
-  its own, so the optimizer read the pair as commutative:
-  `.a{-webkit-transform:none}.b{transform:rotate(45deg)}.c{-webkit-transform:none}`
-  minified to a sheet Chrome 146 computes `transform: matrix(...)` for where
-  the source computes `none`. Whether a dead prefix is then dropped outright is
-  a Baseline question `drop_vendor_aliases` still answers on its own (#454)
-
-### Custom properties
-
-- `Css.inline_vars` resolves a custom property defined across cascade layers
-  against the order every `@layer` in the sheet gives it, counting the ones a
-  rule nests and the ones a `@container`, `@scope` or `@starting-style` block
-  holds. A layer first named inside a conditional group is introduced there only
-  when the condition holds, so the order is not decidable and the layers are
-  left standing rather than folded to a winner (#357)
-- `Css.inline_vars` unwraps an `@layer` only where the layer stack and document
-  order already pick the same winner for every slot two layers write. Unwrapping
-  replays the stack as document order and hands the decision back to
-  specificity, so a sheet whose layers order competing declarations came out
-  rendering a different value, with no custom property involved. It narrows the
-  unwrapping #373 added: a sheet holding a nested rule is one the check cannot
-  answer for, so an `@layer` written inside a rule stays standing (#371)
-
-- `Css.resolve_theme` accounts for the declarations `@keyframes`, `@page`,
-  `@position-try` and `@supports-condition` carry. A `var()` referenced only
-  from inside one of them keeps its theme binding instead of leaving the name
-  undefined in the emitted sheet; a name whose only declaration sits in
-  `@keyframes` or `@position-try` keeps the root binding, since the animation
-  and position fallback origins never defined it for the element referencing
-  it; and a theme guard the keep-set rejects is dropped instead of printed as
-  a declaration the theme never selected (#317, #324, #327)
-- `Css.resolve_theme` binds a `theme_defaults` answer only when the name and
-  the value make one custom-property declaration. The resolver used to write
-  every answer into synthesised `:root { ... }` text and reparse it, so a value
-  carrying a `}`, a top-level `;` or an unterminated string could close the
-  block and add a rule, an at-rule or a second declaration to the output, or
-  take every other theme default down with it.
-  `Css.Declaration.parse_custom_property` is the checked constructor the
-  resolver builds each binding with (#421)
-- `Css.Declaration.custom_property` refuses a name and value it cannot write
-  back as the one declaration they name, instead of storing the token stream
-  unchecked: `custom_property "--a" "red;--b:blue"` wrote a second declaration,
-  `"red} .evil{color:lime"` closed the rule and opened another, `"rgb(1,2,3"`
-  gained a closing parenthesis it was never given, `"\"abc"` left a string open
-  across the rest of the sheet, and a name carrying a `}` destroyed the rule
-  around it. The pair it takes is a `<dashed-ident>` name and the
-  `<declaration-value>?` CSS Variables 1 sec. 2 gives a custom property, the
-  check `parse_custom_property` already made (#428)
-- A custom-property name that needs escaping binds instead of being refused.
-  `Css.Declaration.parse_declaration` read `property ":" value` back as one
-  text, so a name carrying a `;` or a `}` (CSS Syntax 3 sec. 4.3.7 puts either
-  there through an escape) ended its own declaration, and the guard on
-  `custom_property` and `parse_custom_property` was there only to keep such a
-  name out of that text. The name and the value are read as the tokens they
-  are, so a `theme_defaults` answer for `x;y` emits `:root{--x\;y:red}` and a
-  name carrying a `:` names no declaration at all. `@supports (--x\3b y: red)`
-  builds its declaration the same way (#439)
-- `Css.inline_vars` preserves runtime-marked `var()` references, including
-  typed fallbacks simplified through scalar values or shorthands, instead of
-  replacing browser-time override points with compile-time defaults (#315)
-- A registered `<color>` custom property is promoted and fills the colour slot
-  of a `box-shadow` inside `@keyframes`, so the same declaration minifies the
-  same way wherever it sits (#337)
-- A custom-property name written with an escape is printed with the escapes
-  CSS Syntax 3 sec. 4.3.7 needs to read it back as the same name.
+  printed `.a{color:#00fcolor:green}` (#370)
+- A NaN-valued number prints as `calc(NaN)` and a NaN-valued dimension as
+  `calc(NaN * 1unit)`. A bare `NaN` is not a CSS token, so
+  `width: calc(sqrt(-1) * 1px)` printed `width: NaNpx` and `rotate: asin(-20)`
+  printed `rotate: NaNdeg`, which browsers drop (#425)
+- A custom-property name written with an escape is printed with its escapes.
   `:root{--x\3b y:red}` printed `:root{--x;y:red}`, which cascade's own reader
   splits into two declarations, and a reference to it printed `var(--x}y)`,
   which closes the rule around it. The declaration name, the `var()` reference
-  and every shape of its fallback, the `@property` prelude and a `style()`
-  container query all take the escaping (#429)
-- `Css.inline_vars` keeps the `@property` registration of a custom property it
-  keeps live. Every registration was dropped, so a property the pass could not
-  inline safely lost the `initial-value` its references fall back on and the
-  `inherits: false` that stops it inheriting, repainting the page; and the pass
-  missed its own fixpoint, the second run pruning the declaration the first had
-  kept (#416)
-- `Css.inline_vars` reads a `style()` container query as a reference to the
-  custom property it queries. CSS Conditional 5 sec. 6.2 evaluates the query
-  against that property's computed value, so deleting the declaration behind it,
-  or the `@property` registration standing in for one, leaves a block that no
-  longer matches (#423)
+  and its fallback, the `@property` prelude and a `style()` container query all
+  take the escaping (#435)
+
+### Minification
+
+- `--minify` keeps a `@layer` whose own rules write no declarations but nest
+  rules that do. The emptiness test read only the declarations, so
+  `@layer a { .x { .y { color: red } } }` collapsed to `@layer a;` and every
+  declaration below the brace was deleted (#389)
+- `--minify` optimises the body of `@-moz-document`, `@starting-style`, `@when`
+  and `@else`, which it walked past: rules inside one kept whatever the author
+  wrote (#343)
+- An empty `@-moz-document`, `@when` or `@else` is dropped, as an empty
+  `@media` already was. An empty `@when` or `@else` stays while a later `@else`
+  binds to it, since dropping it leaves a bare `@else` no parser accepts (#396)
+- `.a { @layer n {} }` keeps its block form. The statement form is a
+  layer-order declaration, which no style rule accepts, so minifying it to
+  `.a{@layer n;}` produced CSS neither a browser nor cascade's own reader takes
+  back (#374)
+- A declaration whose value is spec-invalid is discarded inside a `@keyframes`
+  frame, as it already was in a style rule (#341)
+- Under `--scope=stylesheet` a `position-try-fallbacks` name with no
+  `@position-try` rule is dropped inside a `@keyframes` frame, as it already
+  was in a style rule (#372)
+- A custom property registered by `@property` as a `<color>` is typed as one
+  inside `@keyframes`, where `box-shadow: 0 0 var(--ring)` kept the reference
+  in the blur radius (#337)
+- A custom property registered by `@property` is typed wherever it is declared,
+  so the same value minifies the same way inside `@keyframes`,
+  `@position-try` and `@supports-condition` (#349)
+- `--flatten-nesting` treats `@-moz-document` as the grouping at-rule it is:
+  nesting inside one flattens, and a rule wrapping one keeps its selector
+  instead of the at-rule being emitted at top level under no parent (#344)
+- A rule whose declarations a later rule all rewrites is dropped only when it
+  nests nothing. Only the declarations written before a rule's first nested
+  rule belong to the rule itself, which says nothing about the rest of the
+  body, and
+  `.a { all: unset; @media (min-width: 1px) { width: 1px } } .a { all: initial }`
+  lost its nested block along with the rule (#376)
+- A declaration written after a nested rule rejoins the declarations before it
+  when nothing it crosses writes the same property at the same importance, so
+  `.a { & b { width: 1px } color: red }` minifies to
+  `.a{color:red;b{width:1px}}` and `--diff=canonical` stops calling it
+  different from the same rule written the other way round. One that clashes
+  keeps its place (#383)
+- Declarations written after a nested rule are deduplicated like any other
+  declaration list, so `.a { & b { color: red } color: blue; color: green }`
+  minifies to `.a{b{color:red}color:green}` (#386)
+- Merging same-selector rules keeps a later declaration behind a nested
+  conditional group that writes the same property. The safety check saw a
+  nested style rule only, so `@media`, `@container` and friends let the merge
+  move the declaration past them and hand the conditional the win (#352)
+- That merge reads the source order rather than the merged order, and compares
+  a nested block with a later declaration by the longhands each writes rather
+  than by property name. A nested `@media` won over a later declaration that
+  overrode it, and a nested `margin: 2rem` and a later `margin-top: 1rem` were
+  read as disjoint (#364)
+- Merging two same-condition `@media` blocks no longer moves the first past a
+  rule whose shorthand writes a longhand the block also writes:
+  `@media (width>=1px){a{background-color:red}}a{background:blue}@media (width>=1px){a{background-color:green}}`
+  minified to a sheet browsers compute blue for where the source computes green
+  (#415)
+- That merge no longer moves a block past a declaration written after a nested
+  rule, which stays behind the rule it follows and is therefore one more rule
+  in the way (#414)
+- A declaration writing `column-rule-color` keeps its place against one writing
+  `column-rule`. The shorthand resets the rule width, style and colour, but the
+  colour longhand was not counted among them, so two rules writing the colour
+  merged across `column-rule: 1px solid red` and an element matching both
+  painted the rule red (#447)
+- A declaration writing one of the four flow-relative border style longhands
+  keeps its place against one writing `border` or `border-style`, neither
+  shorthand having counted them:
+  `.a{border:1px solid red;border-block-end-style:dashed}` reordered under
+  `--minify --lossless` into a rule computing `border-bottom-style: solid`
+  where the source computes `dashed` (#453)
+- Two rules stay apart across a rule whose property name cascade cannot resolve
+  to a set of longhands, where it was ruled out first on the property name
+  itself: `.a{word-wrap:break-word}.b{overflow-wrap:normal}.c{word-wrap:break-word}`
+  minified to a sheet computing `overflow-wrap: normal` where the source
+  computes `break-word` (#452)
+- A vendor-prefixed declaration keeps its place against the property it
+  aliases, each having counted as a property of its own:
+  `.a{-webkit-transform:none}.b{transform:rotate(45deg)}.c{-webkit-transform:none}`
+  minified to a sheet computing `transform: matrix(...)` where the source
+  computes `none`. Whether a dead prefix is then dropped outright stays the
+  Baseline question `drop_vendor_aliases` answers on its own (#454)
+- An authored value keeps every digit. Any dimension was rounded to six
+  significant figures on the way out, so `.4285714em` came out as `.428571em`,
+  which is `5.99999px` rather than `6px` at a `14px` font size, and
+  `999999999px` came out a pixel wider. Six figures still bound a value
+  cascade computes itself, so `calc(2px * pi)` is still `6.28319px` (#350)
+- A `--name` registered by `@property` as a `<number>` keeps the digits it was
+  written with, `--n: 1.4285714` having come out as `1.42857`. `calc(1 / 3)` is
+  still `.333333` (#354)
+- A math function inside `calc()` keeps its unit, where `calc(hypot(1px, 1px))`
+  came out as `1.41421356`, a declaration browsers and cascade's own reader
+  both drop. `abs()` and `hypot()` carry their arguments' unit out, the inverse
+  trigonometric functions carry `deg`, and a call whose operands mix units
+  keeps its spelling (#362)
+- A computed dimension past a million units keeps every digit, where six
+  significant figures stopped reaching its fraction and the budget was paid in
+  integer digits the arithmetic got right: `calc(1in + 999999999px)` came out
+  as `1000000000px`, 95px short. A narrower value still pays the budget:
+  `calc(1cm + 1px)` is `38.7953px` (#367)
+- A `font-family` name keeps the spelling the author wrote. A table of known
+  names matched case-insensitively with hyphens folded to spaces and re-emitted
+  its own spelling, so `font-family: open-sans` became `"Open Sans"` and
+  `font-family: ny` became `"New York"`, naming a different family, in the
+  `@font-face` descriptor that *defines* the name as much as in the properties
+  that reference it. A multi-word name unquotes wherever it appears, where
+  `"Source Code Pro"` stayed quoted next to a bare `SF Mono` in the same stack
+  (#387)
+- A `font-family` name that cannot be spelled as an identifier keeps its
+  quotes. The guard checked which characters a name is made of but not how an
+  identifier may start, so `"2Brand"`, `"-2x"` and `"-"` came out bare and a
+  browser dropped the whole declaration, taking the rest of the stack (#390)
+- A multi-word `font-family` name holding a reserved word keeps its quotes.
+  `"inherit test"`, `"revert serif"` and `"default x"` came out bare and
+  cascade's own reader then rejected the declaration it had just written (#401)
+- `column-rule-color` and `-webkit-text-stroke-color` are typed as colours and
+  `-webkit-text-fill-color` is minified as one, so a colour-valued property
+  minifies to the same spelling whatever its name:
+  `lab(1.90334 0.278696 -5.48866)` and `rgb(3, 7, 18)` both print `#030712`
+  (#447)
+- A single-argument `:is()` and a double `:not()` keep their wrapper around a
+  type or universal selector, where removing it fused the two names:
+  `.a:is(code)` printed `.acode` and `:is(.a *):is(code)` printed
+  `:is(.a *)code`, which browsers drop (#377)
+- A single-argument `:is()` keeps its wrapper after a pseudo-element that
+  cannot take its argument, so `.a::before:is(.b)` minifies to
+  `.a:before:is(.b)` rather than the `.a:before.b` that cascade's own reader
+  and browsers all drop. It still unwraps where the compound can hold the
+  argument, `.a::part(p):is(:hover)` included (#431)
+- A vendor prefix is dropped only when its unprefixed twin is Baseline "widely
+  available": `-webkit-backdrop-filter`, `-webkit-user-select`,
+  `-webkit-text-size-adjust` and `-webkit-print-color-adjust` were dropped
+  against a twin no shipping Safari understands (#325)
+- A feature query on a vendor-prefixed property keeps its guard. The
+  web-features dataset behind the Baseline facts tracks unprefixed features
+  only, so a prefix is evidence of nothing, and treating the query as true
+  turned Tailwind's legacy-browser reset on in Chrome, where
+  `@supports (-webkit-hyphens: none)` is false (#378)
+- `@media not all and (X)` minifies to the Level 4 `@media not (X)`. `all`
+  matches every device, so the two spell the same query, and default minify
+  already gives up Level 3 compatibility inside that very query by lowering
+  `min-width` to range syntax. `--enforce-spec` keeps both Level 3 spellings
+  (#323)
+- `--minify` and `cascade diff` spend less time on a large stylesheet, for the
+  same output (#413, #422, #424)
+
+### Custom properties
+
+- `Css.resolve_theme` accounts for the declarations `@keyframes`, `@page`,
+  `@position-try` and `@supports-condition` carry: a name referenced only from
+  inside one of them keeps its theme binding, a name whose only declaration
+  sits in `@keyframes` or `@position-try` keeps the root binding, and a theme
+  guard the theme did not select is dropped rather than printed as a
+  declaration (#317, #324, #327)
+- `Css.resolve_theme` builds each `theme_defaults` binding with
+  `parse_custom_property` instead of writing every answer into synthesised
+  `:root { ... }` text and reparsing it, where one value could add a rule, an
+  at-rule or a second declaration to the output, or take every other theme
+  default down with it (#421)
+- A custom-property name that needs escaping binds instead of being refused.
+  The name and the value are read as the tokens they are rather than as one
+  `property ":" value` text, so a `theme_defaults` answer for `x;y` emits
+  `:root{--x\;y:red}`, a name carrying a `:` names no declaration at all, and
+  `@supports (--x\3b y: red)` builds its declaration the same way (#439)
 - Pruning unreferenced custom properties counts a `var()` in a `@keyframes`
   frame, `@page` and its margin boxes, `@position-try` or
   `@supports-condition` as a reference, instead of deleting a binding those
   at-rules still use (#341)
 - `Css.inline_vars` counts a `var()` in a page margin box or a
   `@supports-condition` body as a reference, so it no longer emits a name whose
-  definition it deleted, and reports an overridden variable referenced from any
-  of those at-rules through `~warn` (#342)
+  definition it deleted, and reports an overridden variable through `~warn`
+  (#342)
+- `Css.inline_vars` preserves runtime-marked `var()` references, typed
+  fallbacks simplified through scalar values or shorthands included, instead of
+  replacing browser-time override points with compile-time defaults (#315)
+- `Css.inline_vars` resolves a custom property defined across cascade layers
+  against the order every `@layer` in the sheet gives it, counting the ones a
+  rule nests and the ones a `@container`, `@scope` or `@starting-style` block
+  holds. A layer first named inside a conditional group has no decidable order,
+  so those layers are left standing (#357)
 - `Css.inline_vars` unwraps an `@layer` and drops an `@property` registration
-  written inside a rule, as it already did at top level. CSS nesting puts both
-  there, and a sheet using it came back half cleaned (#373)
+  written inside a rule, as it already did at top level, so a sheet using CSS
+  nesting no longer comes back half cleaned (#373)
+- `Css.inline_vars` unwraps an `@layer` only where the layer order and document
+  order already pick the same winner for every property two layers write.
+  Unwrapping replays the layer order as document order and hands the decision
+  back to specificity, so a sheet whose layers order competing declarations
+  came out rendering a different value with no custom property involved. An
+  `@layer` written inside a rule stays standing (#371)
+- `Css.inline_vars` keeps the `@property` registration of a custom property it
+  leaves live. Every registration was dropped, so a property it could not
+  inline safely lost the `initial-value` its references fall back on and the
+  `inherits: false` that stops it inheriting, repainting the page. A second run
+  also pruned a declaration the first had kept (#416)
+- `Css.inline_vars` reads a `style()` container query as a reference to the
+  custom property it queries, so deleting the declaration behind it, or the
+  registration standing in for one, no longer leaves a block that never matches
+  (#423)
 - `Css.custom_props` reports a name declared inside `@scope`,
   `@starting-style`, `@-moz-document`, `@when`, `@else` or a bare nesting
-  block, as it already did for `@media` and `@supports`. Those declarations
-  reach the matching element just as an `@media` one does, and the names were
-  missing from an answer callers use to decide what a sheet defines (#375)
-- A custom property registered by `@property` is typed wherever it is
-  declared, including inside `@keyframes`, `@position-try` and
-  `@supports-condition`, so the same registered value canonicalises the same
-  way in every one of them (#349)
+  block, as it already did for `@media` and `@supports` (#375)
 
 ### Canonical diff
 
+- A fully transparent `oklab()` with a missing axis, such as
+  `oklab(0% none none / 0)`, compares equal to transparent black.
+  Non-transparent forms stay distinct (#312)
+- A relative-colour function keeps its origin as a typed colour, so `red` and
+  `#f00` compare equal in `rgb()`, `oklab()` and the rest, including inside
+  custom properties (#313)
+- A complete shadow value in an unregistered custom property has its colour
+  compared as a colour. Non-colour identifiers stay opaque (#314)
+- The canonical form is taken inside every at-rule with a block, so the verdict
+  no longer depends on which at-rule encloses the rule. A quoted multi-word
+  family name in a custom property, a `color(srgb ...)` naming an exact 8-bit
+  colour and the Level 3 `not all and (...)` spelling were canonicalised inside
+  `@layer` and `@media` but not inside `@scope`, `@starting-style`,
+  `@-moz-document`, `@when` or `@else` (#393)
 - `Css_compare.equivalent_value ~property` spells the property name the way the
-  printer spells it before giving the two values that declaration context. A
-  name carrying a `}` (CSS Syntax 3 sec. 4.3.7 puts one there through an escape)
-  closed the rule and took both values with it, so any two values under such a
-  name compared equal (#440)
-- A fully transparent missing-axis `oklab()` colour, such as
-  `oklab(0% none none / 0)`, canonicalises to transparent black while
-  non-transparent forms remain distinct (#312)
-- Relative-colour functions retain their origin as a typed colour, so
-  equivalent spellings such as `red` and `#f00` compare equal in `rgb()`,
-  `oklab()` and the other relative functions, including inside custom
-  properties (#313)
-- A complete shadow value in an unregistered custom property types its colour
-  slot, so named and hex colours and typed `var()` fallbacks compare
-  canonically while non-colour identifiers remain opaque (#314)
-- The projection's value folds reach inside every block at-rule. A quoted
-  multi-word family name in a custom property, a whole-byte `color(srgb ...)`
-  and the Level 3 `not all and (...)` media spelling folded inside `@layer` and
-  `@media` but not inside `@scope`, `@starting-style`, `@-moz-document`,
-  `@when`, `@else` or an origin wrapper, so the diff's verdict depended on
-  which at-rule enclosed the rule. A custom property in a `@keyframes` frame or
-  a `@page` box folds too (#393)
+  printer spells it before comparing two values under it. A name carrying an
+  escaped `}` closed the rule and took both values with it, so any two values
+  under such a name compared equal (#440)
 
 ### Library
 
+- `Css.Stylesheet.statement_declarations` is the declarations a statement holds
+  directly; with `statement_children` it reaches every declaration in a
+  stylesheet (#317)
+- `Css.Stylesheet.map_statement_children` and `map_statement_declarations`
+  rebuild a statement with a function applied to the block or the declarations
+  it holds (#337). They return the statement they were given when that function
+  leaves every list physically unchanged, so a pass that short-circuits on
+  physical equality can call them (#355)
+- `Css.Stylesheet.fold_statements`, `iter_statements`, `fold_declarations`,
+  `iter_declarations` and `map_declarations` traverse a whole block. The
+  declaration functions take `?sites`, so a place added to `declaration_sites`
+  stops every caller that made a choice from compiling (#356)
+- `Css.Stylesheet.edit_statements` hands each statement to a function that
+  keeps, replaces or drops it, and descends into what survives (#363)
+- `Css.Stylesheet.at_declaration_site` answers whether a statement holds its
+  declarations in one of the places a `declaration_sites` record names, for a
+  traversal carrying state down the tree that cannot be a fold (#368)
+- `Css.map` and `Css.sort` reach a rule inside `@scope`, `@starting-style`,
+  `@-moz-document`, `@when` or `@else`, where a caller rewriting or reordering
+  "all rules at all nesting levels" got a sheet with five of them silently
+  untouched (#381)
+- `Css.layers` and `Css.layer_block` find a layer declared inside a grouping
+  at-rule, so a caller asking which layers a sheet declares was given a wrong
+  answer rather than a partial one (#382)
+- `Css.Stylesheet.layers` is what `Css.layers` calls, so the two no longer give
+  different answers to the same question, and `Css.Stylesheet.layer_block` is
+  exposed alongside it. `Css.Stylesheet.media_queries`, `container_queries` and
+  `Css.media_queries` report a query written inside a grouping at-rule, and
+  pair each query with every rule below its brace rather than the ones sitting
+  directly under it (#389)
+- `Css.Flatten` carries the parent selector into an `@-moz-document` block, the
+  one grouping at-rule it did not descend into, where the declarations came out
+  bare at the top of the block and no reader takes that back (#384)
 - `Cascade_diff.Tree_diff.has_container_added_of_type` and
   `has_container_removed_of_type` look inside a container reported as modified,
-  as `count_containers_by_type` already did. A `@supports` added inside an
-  existing `@media` was counted but not found (#395)
+  as `count_containers_by_type` already did, where a `@supports` added inside
+  an existing `@media` was counted but not found (#395)
 - `Cascade.Resolve.Make.resolve` and `Cascade.Resolve.layer_order` document
   every block they leave out, not just conditional groups: `@starting-style`
   declares a before-change style, `@scope` brings a scoping root and the
   proximity criterion, and an origin wrapper carries an origin that outranks
   the layer. `Css.layers` remains the exhaustive count of what a sheet declares
   (#394)
-- `Css.Media.kind` classifies a negated width bound by the side it bounds, so
-  `not (min-width: 640px)` groups and sorts with the upper bounds it matches
-  instead of with the lower bound it negates, and a doubled `not` cancels. The
-  negation of a range, such as `not (640px <= width <= 1024px)`, is `Other`:
-  it matches the viewports on either side of the range, which no single bound
-  describes. `Css.Media.sort_key`, `group_order` and `compare` follow (#328)
-- `Css.Stylesheet.statement_declarations` returns the declarations a statement
-  holds directly; paired with `statement_children` it reaches every declaration
-  in a stylesheet (#317)
-- `Css.Stylesheet.map_statement_children` and `map_statement_declarations`
-  rebuild a statement with a function applied to the block or the declarations
-  it holds, the rebuilding counterparts of the two readers (#337)
-- `Css.Flatten` carries the parent selector into an `@-moz-document` block, the
-  one group rule it did not descend into. A nested declaration run came out
-  bare at the top of the block, which no reader takes back (#384)
-- `Css.Stylesheet.map_statement_children` and `map_statement_declarations`
-  return the very statement they were given when the function they run leaves
-  every list physically unchanged. A pass that short-circuits on physical
-  equality can now call them instead of hand-rolling its own walk (#355)
-- `Css.Stylesheet.fold_statements`, `iter_statements`, `fold_declarations`,
-  `iter_declarations` and `map_declarations` walk a whole block: every statement
-  a rule nests, and every declaration an at-rule holds outside a block. The
-  declaration walks take `?sites` to name the places a narrow walk wants, so a
-  place added to `declaration_sites` stops every walk that made a choice from
-  compiling (#356)
-- `Css.Stylesheet.edit_statements` rewrites a whole block: the walk hands each
-  statement to a function that keeps, replaces or drops it, and descends into
-  what survives, so a pass that drops a statement no longer carries its own
-  list of the at-rules that nest (#363)
-- `Css.Stylesheet.at_declaration_site` answers whether a statement holds its
-  declarations in one of the places a `declaration_sites` record names. A walk
-  that carries a cascade layer or an `@supports` depth down the tree cannot be
-  a fold, and can now name the sites it reads instead of matching on the
-  statements it expects to meet (#368)
-- `Css.map` and `Css.sort` reach a rule inside `@scope`, `@starting-style`,
-  `@-moz-document`, `@when` or `@else`, as they already did for `@media` and
-  `@supports`. Those at-rules group style rules like any other conditional
-  group, and a caller rewriting or reordering "all rules at all nesting levels"
-  got a sheet with five of them silently untouched (#381)
-- `Css.layers` and `Css.layer_block` find a layer declared inside `@media`,
-  `@supports`, `@container`, `@scope` or any other grouping at-rule. Such a
-  block declares a real layer, so a caller asking which layers a sheet declares
-  was given a wrong answer rather than a partial one; `layers` reports every
-  name it finds in source order (#382)
-- `Css.vars_of_rules` is `Css.vars_of_stylesheet`, so a `var()` inside a nested
-  rule or inside any at-rule is reported instead of only one a top-level rule
-  holds. Both fold over every declaration site, which also adds the references
-  an animation frame and a page margin box hold (#382)
-- `Css.Stylesheet.layers` is what `Css.layers` calls, so the two no longer give
-  different answers to the same question: the lower one reported neither a
-  layer declared inside a grouping at-rule nor the sublayer a dotted name
-  declares. `Css.Stylesheet.layer_block` is exposed alongside it (#389)
-- `Css.Stylesheet.media_queries`, `container_queries` and `Css.media_queries`
-  report a query written inside a grouping at-rule, and pair each query with
-  every rule below its brace rather than the ones sitting directly under it, so
-  a rule nested in another rule or held by an inner group is no longer missing
-  from the query it is written in (#389)
 
 ### CLI tools
 
-- `cascade apply` keeps the comments a page holds. React writes an empty
-  comment between two adjacent text nodes to keep them apart, and a browser
-  measures and rounds each text run on its own, so merging them moved the
-  element's width; licence headers and conditional comments went missing
-  outright. The page is parsed and printed with markup.ml, which carries
-  comments, in place of lambdasoup, which discards them (#346)
-- `cascade diff` names an at-rule that carries no condition of its own by the
-  head it prints to, rather than describing every one of them identically. That
-  description keys the ordering comparison, so a `@media` that moved between a
-  `@page` and a `@starting-style` was reported as no change (#345)
-- `cascade diff --diff=tree` shows the contents of a block added or removed
-  wholesale whatever the block holds. The report read the body through its own
-  list of at-rules, so a `@scope`, a `@starting-style` or a rule nested in
-  another rule printed a header with nothing beneath it and read as empty (#389)
-- `cascade apply` keeps a declaration in the sheet when a kept rule can write
-  the same cascade slot under another property name. `p{margin:0}` was
-  projected into a style attribute while the `.my-7{margin-top:1.75rem}` it
-  loses to stayed behind, and a style attribute outranks every selector, so the
-  paragraph rendered with no margin (#340)
-- `cascade apply` empties the `<style>` blocks it projects instead of removing
-  them. A `<style>` element is a sibling like any other, so unlinking it stops
-  a kept rule such as `.navbox + style + .portal-bar` from matching what it
-  matches in the browser (#339)
 - `cascade apply` reads a `style` attribute as a declaration list in source
   order. The declarations came out reversed, so a longhand beat the shorthand
-  it was written after, and an empty attribute was enough to trigger it. A `}`
-  inside the attribute closed the list early instead of staying a preserved
-  token (CSS Syntax 3 sec. 5.4), so `style="color:red}p{color:lime"` applied
-  `color:red`, where the whole attribute is one invalid declaration a browser
-  drops. Both made the projected page render differently from its input (#326)
+  it was written after, and a `}` inside the attribute closed the list early
+  instead of staying a preserved token, so `style="color:red}p{color:lime"`
+  applied `color:red` where the whole attribute is one invalid declaration a
+  browser drops (#326)
 - `cascade apply --minimal` drops an inherited declaration only when it truly
-  restates the value the element would inherit. Two kinds of declaration it
-  dropped are not restatements: one whose property a user-agent rule declares
-  for the element or for one of its ancestors, which css-cascade-5 sec. 6.1
-  sorts by origin before inheritance, so the drop uncovered the UA value for
-  link colour, heading size, `b` weight, `em` style, `pre` family and `ol`
-  marker; and one whose value resolves against the element it lands on, where
-  a font-relative unit, a percentage, `larger`/`bolder`, a container unit,
+  restates the value the element would inherit. It dropped one whose property a
+  user-agent rule declares for the element or an ancestor, uncovering the
+  user-agent value for link colour, heading size and `pre` family (#326); and
+  one whose value resolves against the element it lands on, where a
+  font-relative unit, a percentage, `larger`/`bolder`, a container unit,
   `var()`, `light-dark()` or `currentColor` inside `color-mix()` names two
   values across two elements, so `div{font-size:2em}div p{font-size:2em}`
-  halved the paragraph (#326, #329)
+  halved the paragraph (#329)
 - `cascade apply --minimal` keeps a restated inherited shorthand when an
-  element in between sets one of the longhands it resets. A shorthand resets
-  every longhand it does not mention (css-fonts-4 sec. 2.7 for `font`), so the
-  restatement is what puts that longhand back, and
+  element in between sets one of the longhands it resets, where
   `#p{font:16px serif}#mid{font-weight:bold}#c{font:16px serif}` left `#c`
   bold. `all` and a property cascade does not type reset everything, so neither
   is dropped either (#332)
-- `cascade diff` spends less time on a rule holding many declarations. Deciding
-  whether a reorder is significant asked each pair of declarations for its
-  overlap keys and for its position in the other rule, both of which name a
-  property through a fresh buffer, where each is a fact about one declaration.
-  `--minify` canonicalises a rule's declaration order the same way (#424)
-- `cascade diff` names a rule's nested block after the rule it belongs to. The
-  container printed as `& .a`, which is a selector matching a `.a` inside the
-  parent rather than the parent's own block, and a run of declarations written
-  after a nested statement was named by its first declaration instead of the
-  `&` that CSS Nesting 1 sec. 3.4 makes it (#385)
+- `cascade apply` empties the `<style>` blocks it projects instead of removing
+  them: a `<style>` element is a sibling like any other, so unlinking it
+  stopped a kept rule such as `.navbox + style + .portal-bar` from matching
+  (#339)
+- `cascade apply` keeps a declaration in the sheet when a kept rule writes the
+  same longhand under another property name. `p{margin:0}` went into a style
+  attribute while the `.my-7{margin-top:1.75rem}` it loses to stayed behind,
+  and a style attribute outranks every selector, so the paragraph rendered with
+  no margin (#340)
+- `cascade apply` keeps the comments a page holds. React writes an empty
+  comment between two adjacent text nodes to keep them apart, and a browser
+  measures each text run on its own, so merging them moved the element's width;
+  licence headers went missing outright. The page is parsed and printed with
+  markup.ml in place of lambdasoup (#346)
+- `cascade diff` names an at-rule that carries no condition of its own by the
+  head it prints to, rather than describing every one identically. That
+  description keys the ordering comparison, so a `@media` that moved between a
+  `@page` and a `@starting-style` was reported as no change (#345)
+- `cascade diff` names a rule's nested block after the rule it belongs to,
+  where the block printed as `& .a`, a selector matching a `.a` inside the
+  parent rather than the parent's own block, and the declarations written after
+  a nested rule were named by the first of them (#385)
+- `cascade diff --diff=tree` shows the contents of a block added or removed
+  wholesale whatever the block holds, where a `@scope`, a `@starting-style` or
+  a rule nested in another rule printed a header with nothing beneath it and
+  read as empty (#389)
 
 ## 1.1.0
 


### PR DESCRIPTION
The unreleased block had grown one entry per pull request, so a single defect fixed at eight sites read as eight changes and the mechanism crowded out the effect a reader upgrading would act on. Every reference is kept, except that the custom-property escaping entry cited #429, which was closed without merging; the same change merged as #435, so the entry now cites that.

Top of the stack, so it consolidates the block as #454 and #452 leave it.
