### PR TITLE
optimize: keep rules apart across an unplaceable property name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -317,6 +317,14 @@
   conflict test walks the two key lists in step instead of scanning one per
   element of the other, and collecting them no longer rescans what it has
   already collected (#422)
+- `--minify` keeps two rules apart across a rule whose property name the
+  footprint model cannot place. Such a name may be a shorthand, a legacy alias
+  or a longhand of a family the model does not carry, and the conflict test
+  says so, but the rule graph ruled the pair out first on an overlap key naming
+  the property itself, so
+  `.a{word-wrap:break-word}.b{overflow-wrap:normal}.c{word-wrap:break-word}`
+  minified to a sheet Chrome 146 computes `overflow-wrap: normal` for where the
+  source computes `break-word` (#452)
 - `column-rule-color` and `-webkit-text-stroke-color` are typed as colours and
   `-webkit-text-fill-color` joins the colour fold, so a colour-valued property
   minifies to the same spelling whatever its name: `lab(1.90334 0.278696

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -987,11 +987,6 @@ let rec overlap_keys_intersect a b =
   | footprint :: rest ->
       footprint_mem footprint b || overlap_keys_intersect rest b
 
-let declaration_overlap_keys decl =
-  match unwrap_theme_guard decl with
-  | Declaration { property; _ } -> property_footprint property
-  | _ -> [ key (Declaration.property_name decl) ]
-
 (* The families whose footprints spell out every longhand name the model knows.
    Every arm of [property_footprint] not listed here has a footprint that is a
    subset of one of these. Grouped only to keep each list short. *)
@@ -1129,6 +1124,18 @@ let name_extends other name =
   String.length name > n
   && String.starts_with ~prefix:other name
   && Char.equal name.[n] '-'
+
+(* A name the model cannot place takes the broad key, not a key naming itself:
+   [declarations_overlap_with_keys] treats it as touching whatever it meets, and
+   a footprint naming only itself let a caller's key prefilter judge the pair
+   disjoint and rule the real test out. *)
+let declaration_overlap_keys decl =
+  match unwrap_theme_guard decl with
+  | Declaration { property = Unknown_property name; _ }
+    when not (unknown_name_is_placeable name) ->
+      [ broad_overlap_key ]
+  | Declaration { property; _ } -> property_footprint property
+  | _ -> [ key (Declaration.property_name decl) ]
 
 let declarations_overlap_with_keys a a_keys b b_keys =
   match (unwrap_theme_guard a, unwrap_theme_guard b) with

--- a/lib/shorthand.mli
+++ b/lib/shorthand.mli
@@ -37,8 +37,8 @@ val overlap_key_compare : overlap_key -> overlap_key -> int
     two footprints instead of scanning one per element of the other. *)
 
 val broad_overlap_key : overlap_key
-(** Key for broad reset-like declarations, such as [all], that may overlap any
-    other non-exempt declaration. *)
+(** Key for a declaration that may overlap any other non-exempt declaration: a
+    reset such as [all], or a property name the footprint model cannot place. *)
 
 val overlap_keys_intersect : overlap_key list -> overlap_key list -> bool
 (** [overlap_keys_intersect a b] is [true] when two precomputed declaration

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2481,6 +2481,33 @@ let vendor_alias_pins_intervening_rule () =
     (optimized_string
        ".a{-webkit-transform:none}.b{color:red}.c{-webkit-transform:none}")
 
+let unplaceable_name_pins_intervening_rule () =
+  (* A property name the footprint model cannot place may be a shorthand, a
+     legacy alias, or a longhand of a family the model does not carry, so it
+     writes whatever slot the declaration it meets writes. Grouping [.a] with
+     [.c] past [.b] changes which of the two wins for an element matching [.b]
+     and [.c]: Chrome 146 computes [background-position: 10px 0%] for the first
+     sheet below and [0% 0%] once the pair is grouped, and [overflow-wrap:
+     break-word] against [normal] for the second. *)
+  Alcotest.(check string)
+    "an unplaceable longhand is not grouped across the shorthand resetting it"
+    ".a{background-position-x:10px}.b{background:red}.c{background-position-x:10px}"
+    (optimized_string
+       ".a{background-position-x:10px}.b{background:red}.c{background-position-x:10px}");
+  Alcotest.(check string)
+    "an unplaceable legacy alias is not grouped across the property it aliases"
+    ".a{word-wrap:break-word}.b{overflow-wrap:normal}.c{word-wrap:break-word}"
+    (optimized_string
+       ".a{word-wrap:break-word}.b{overflow-wrap:normal}.c{word-wrap:break-word}");
+  (* A name the model does place keeps naming its own slot, so a rule holding
+     one still groups across an unrelated declaration. *)
+  Alcotest.(check string)
+    "a placeable name still groups across an unrelated declaration"
+    ".a,.c{margin-top:var(--a) var(--b)}.b{color:red}"
+    (optimized_string
+       ".a{margin-top:var(--a) var(--b)}.b{color:red}.c{margin-top:var(--a) \
+        var(--b)}")
+
 let c63_group_across_higher_specificity () =
   (* CSS Cascade 5 sec. 6.3: among the same origin, layer, and importance higher
      specificity wins regardless of source order; only a specificity tie defers
@@ -4863,6 +4890,9 @@ let selector_merging_tests =
     ( "vendor alias pins an intervening rule",
       `Quick,
       vendor_alias_pins_intervening_rule );
+    ( "unplaceable property name pins an intervening rule",
+      `Quick,
+      unplaceable_name_pins_intervening_rule );
     ( "group equal rules across higher-specificity intervening rule",
       `Quick,
       c63_group_across_higher_specificity );


### PR DESCRIPTION
`--minify` grouped two rules across a rule whose property name the footprint model cannot place, because the rule graph's overlap-key prefilter judged the pair disjoint before the conflict test that treats such a name as touching whatever it meets ever ran. `.a{word-wrap:break-word}.b{overflow-wrap:normal}.c{word-wrap:break-word}` minified to a sheet Chrome 146 computes `overflow-wrap: normal` for where the source computes `break-word`.

Stacked on #454 for the shared file only. That one gives a typed prefixed constructor its twin's slot; this one gives an untyped `Unknown_property` name the broad key, so the two arms never see the same declaration and neither covers the other.
