### PR TITLE
shorthand: give a vendor-prefixed property its twin's slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -388,6 +388,14 @@
   reordered under `--minify --lossless` into a rule Chrome 146 computes
   `border-bottom-style: solid` for where the source computes `dashed`, and two
   rules writing the longhand merged across an intervening `border` (#453)
+- A vendor-prefixed declaration keeps its place against the property it
+  aliases. `-webkit-transform` and the rest of the prefixed spellings cascade
+  types write the slot their unprefixed twin writes, but each named a slot of
+  its own, so the optimizer read the pair as commutative:
+  `.a{-webkit-transform:none}.b{transform:rotate(45deg)}.c{-webkit-transform:none}`
+  minified to a sheet Chrome 146 computes `transform: matrix(...)` for where
+  the source computes `none`. Whether a dead prefix is then dropped outright is
+  a Baseline question `drop_vendor_aliases` still answers on its own (#454)
 
 ### Custom properties
 

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -438,13 +438,13 @@ let property_slots : type a. a Properties.property -> overlap_key list =
       ]
   | Background_attachment -> [ key "background-attachment" ]
   | Background_blend_mode -> [ key "background-blend-mode" ]
-  | Background_clip -> [ key "background-clip" ]
+  | Background_clip | Webkit_background_clip -> [ key "background-clip" ]
   | Background_color -> [ key "background-color" ]
   | Background_image -> [ key "background-image" ]
   | Background_origin -> [ key "background-origin" ]
   | Background_position -> [ key "background-position" ]
   | Background_repeat -> [ key "background-repeat" ]
-  | Background_size -> [ key "background-size" ]
+  | Background_size | Webkit_background_size -> [ key "background-size" ]
   | Flex -> [ key "flex-grow"; key "flex-shrink"; key "flex-basis" ]
   | Flex_grow -> [ key "flex-grow" ]
   | Flex_shrink -> [ key "flex-shrink" ]
@@ -455,7 +455,25 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   (* A vendor-prefixed spelling is an alias of the unprefixed property in every
      engine that supports it - [deduplicate_declarations] already drops the
      prefixed copy of an identical twin - so it writes the same cascade slots
-     and carries the same footprint. *)
+     and carries the same footprint. The prefixed vocabulary need not match the
+     unprefixed one - [-webkit-mask-composite] spells [xor] where
+     [mask-composite] spells [exclude] - since the slot is named by the property
+     and not by the value. *)
+  | Transform | Webkit_transform | Moz_transform | Ms_transform | O_transform ->
+      [ key "transform" ]
+  | Appearance | Webkit_appearance | Moz_appearance -> [ key "appearance" ]
+  | Box_shadow | Webkit_box_shadow | Moz_box_shadow -> [ key "box-shadow" ]
+  | Box_sizing | Webkit_box_sizing | Moz_box_sizing -> [ key "box-sizing" ]
+  | User_select | Webkit_user_select | Moz_user_select | Ms_user_select ->
+      [ key "user-select" ]
+  | Filter | Webkit_filter | Ms_filter -> [ key "filter" ]
+  | Backdrop_filter | Webkit_backdrop_filter -> [ key "backdrop-filter" ]
+  | Box_decoration_break | Webkit_box_decoration_break ->
+      [ key "box-decoration-break" ]
+  | Hyphens | Webkit_hyphens -> [ key "hyphens" ]
+  | Print_color_adjust | Webkit_print_color_adjust ->
+      [ key "print-color-adjust" ]
+  | Text_size_adjust | Webkit_text_size_adjust -> [ key "text-size-adjust" ]
   | Transition | Webkit_transition | Moz_transition | O_transition ->
       transition_keys
   | Transition_property | Webkit_transition_property | Moz_transition_property
@@ -622,14 +640,14 @@ let property_slots : type a. a Properties.property -> overlap_key list =
         key "mask-composite";
         key "mask-border";
       ]
-  | Mask_image -> [ key "mask-image" ]
-  | Mask_repeat -> [ key "mask-repeat" ]
-  | Mask_size -> [ key "mask-size" ]
-  | Mask_position -> [ key "mask-position" ]
-  | Mask_origin -> [ key "mask-origin" ]
-  | Mask_clip -> [ key "mask-clip" ]
+  | Mask_image | Webkit_mask_image -> [ key "mask-image" ]
+  | Mask_repeat | Webkit_mask_repeat -> [ key "mask-repeat" ]
+  | Mask_size | Webkit_mask_size -> [ key "mask-size" ]
+  | Mask_position | Webkit_mask_position -> [ key "mask-position" ]
+  | Mask_origin | Webkit_mask_origin -> [ key "mask-origin" ]
+  | Mask_clip | Webkit_mask_clip -> [ key "mask-clip" ]
   | Mask_mode -> [ key "mask-mode" ]
-  | Mask_composite -> [ key "mask-composite" ]
+  | Mask_composite | Webkit_mask_composite -> [ key "mask-composite" ]
   | Mask_border -> [ key "mask-border" ]
   | Font ->
       [

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2450,6 +2450,37 @@ let aba_forbidden_intersection_dependency () =
     ".a.x{color:red}.b.x{color:#00f}.a.y{color:red}"
     (optimized_string ".a.x{color:red}.b.x{color:blue}.a.y{color:red}")
 
+let vendor_alias_pins_intervening_rule () =
+  (* A?B?A across a vendor alias: the prefixed spelling writes the slot its
+     unprefixed twin writes, so for an element matching [.b] and [.c] source
+     order decides the winner. Grouping [.a] with [.c] moves the prefixed
+     declaration in front of [.b] and flips it. Chrome 146 computes [transform:
+     none] for the first sheet below and [matrix(...)] once the pair is grouped;
+     Safari 26.5 agrees, and answers the same for [-webkit-hyphens], which
+     Chrome does not implement. *)
+  Alcotest.(check string)
+    "a prefixed transform is not grouped across its unprefixed twin"
+    ".a{-webkit-transform:none}.b{transform:rotate(45deg)}.c{-webkit-transform:none}"
+    (optimized_string
+       ".a{-webkit-transform:none}.b{transform:rotate(45deg)}.c{-webkit-transform:none}");
+  Alcotest.(check string)
+    "a prefixed hyphens is not grouped across its unprefixed twin"
+    ".a{-webkit-hyphens:none}.b{hyphens:auto}.c{-webkit-hyphens:none}"
+    (optimized_string
+       ".a{-webkit-hyphens:none}.b{hyphens:auto}.c{-webkit-hyphens:none}");
+  Alcotest.(check string)
+    "a prefixed mask longhand is not grouped across its unprefixed twin"
+    ".a{-webkit-mask-size:auto}.b{mask-size:cover}.c{-webkit-mask-size:auto}"
+    (optimized_string
+       ".a{-webkit-mask-size:auto}.b{mask-size:cover}.c{-webkit-mask-size:auto}");
+  (* A prefix names one slot, not its whole family, so an unrelated intervening
+     declaration still leaves the pair free to group. *)
+  Alcotest.(check string)
+    "a prefixed transform still groups across an unrelated declaration"
+    ".a,.c{-webkit-transform:none}.b{color:red}"
+    (optimized_string
+       ".a{-webkit-transform:none}.b{color:red}.c{-webkit-transform:none}")
+
 let c63_group_across_higher_specificity () =
   (* CSS Cascade 5 sec. 6.3: among the same origin, layer, and importance higher
      specificity wins regardless of source order; only a specificity tie defers
@@ -4829,6 +4860,9 @@ let selector_merging_tests =
     ( "A?B?A forbidden selector-intersection dependency",
       `Quick,
       aba_forbidden_intersection_dependency );
+    ( "vendor alias pins an intervening rule",
+      `Quick,
+      vendor_alias_pins_intervening_rule );
     ( "group equal rules across higher-specificity intervening rule",
       `Quick,
       c63_group_across_higher_specificity );

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -95,7 +95,61 @@ let test_vendor_alias_overlap () =
     "a prefixed text-decoration overlaps its unprefixed longhand" true
     (Shorthand.declarations_overlap
        (decl "-webkit-text-decoration:underline")
-       (decl "text-decoration-color:red"))
+       (decl "text-decoration-color:red"));
+  (* The whole alias family, one row per unprefixed twin the model types. A
+     prefix an engine does not implement makes the declaration invalid there,
+     which no ordering can be wrong about, so the relation follows the engine
+     that does implement it: Blink and WebKit for [-webkit-], Gecko for [-moz-],
+     Trident for [-ms-] and Presto for [-o-]. *)
+  List.iter
+    (fun (vendor, twin) ->
+      Alcotest.(check bool)
+        (String.concat " " [ vendor; "overlaps"; twin ])
+        true
+        (Shorthand.declarations_overlap (decl vendor) (decl twin)))
+    [
+      ("-webkit-transform:none", "transform:rotate(45deg)");
+      ("-moz-transform:none", "transform:rotate(45deg)");
+      ("-ms-transform:none", "transform:rotate(45deg)");
+      ("-o-transform:none", "transform:rotate(45deg)");
+      ("-webkit-appearance:none", "appearance:auto");
+      ("-moz-appearance:none", "appearance:auto");
+      ("-webkit-box-shadow:none", "box-shadow:0 0 1px red");
+      ("-moz-box-shadow:none", "box-shadow:0 0 1px red");
+      ("-webkit-box-sizing:content-box", "box-sizing:border-box");
+      ("-moz-box-sizing:content-box", "box-sizing:border-box");
+      ("-webkit-user-select:none", "user-select:text");
+      ("-moz-user-select:none", "user-select:text");
+      ("-ms-user-select:none", "user-select:text");
+      ("-webkit-filter:none", "filter:blur(1px)");
+      ("-ms-filter:none", "filter:blur(1px)");
+      ("-webkit-backdrop-filter:none", "backdrop-filter:blur(1px)");
+      ("-webkit-background-clip:border-box", "background-clip:content-box");
+      ("-webkit-background-size:auto", "background-size:cover");
+      ("-webkit-box-decoration-break:slice", "box-decoration-break:clone");
+      ("-webkit-hyphens:none", "hyphens:auto");
+      ("-webkit-mask-clip:border-box", "mask-clip:content-box");
+      ("-webkit-mask-composite:xor", "mask-composite:subtract");
+      ("-webkit-mask-image:none", "mask-image:linear-gradient(red,blue)");
+      ("-webkit-mask-origin:border-box", "mask-origin:content-box");
+      ("-webkit-mask-position:0 0", "mask-position:10px 20px");
+      ("-webkit-mask-repeat:repeat", "mask-repeat:no-repeat");
+      ("-webkit-mask-size:auto", "mask-size:cover");
+      ("-webkit-print-color-adjust:economy", "print-color-adjust:exact");
+      ("-webkit-text-size-adjust:none", "text-size-adjust:200%");
+    ];
+  (* Aliasing a prefix to its twin joins those two slots and no others: a
+     prefixed longhand still misses the rest of its own family. *)
+  Alcotest.(check bool)
+    "a prefixed mask image and an unprefixed mask size are disjoint" false
+    (Shorthand.declarations_overlap
+       (decl "-webkit-mask-image:none")
+       (decl "mask-size:cover"));
+  Alcotest.(check bool)
+    "a prefixed transform and an unrelated property are disjoint" false
+    (Shorthand.declarations_overlap
+       (decl "-webkit-transform:none")
+       (decl "color:red"))
 
 let test_shorthand_reset_boundaries () =
   (* CSS UI 4 sec. 3.1: [outline] resets width, style and colour, and leaves


### PR DESCRIPTION
`--minify` grouped two rules across a rule writing the property a vendor prefix aliases, because the prefixed spellings the model types fell through to a per-constructor hash key instead of naming the slot their unprefixed twin names. `.a{-webkit-transform:none}.b{transform:rotate(45deg)}.c{-webkit-transform:none}` minified to a sheet Chrome 146 computes `transform: matrix(...)` for where the source computes `none`; the same holds for `appearance`, `filter`, `box-shadow`, `box-sizing`, `user-select`, `background-clip`, `background-size`, `box-decoration-break`, `hyphens`, `print-color-adjust`, `text-size-adjust` and the seven `mask-*` longhands, with Safari 26.5 also witnessing `backdrop-filter` and `hyphens`.

Same class of miscompile as the merged #453, third cause. Whether a dead prefix is then dropped stays a separate Baseline question that `drop_vendor_aliases` answers on its own, unchanged here.
