### PR TITLE
prop_layout: keep the second axis of a position-area

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -161,6 +161,9 @@
 
 ### Minification
 
+- `--minify` keeps the `center` in `position-area: top center`. A lone keyword
+  stands for `X span-all`, not `X center`, so dropping it moved the box to a
+  different area (#457)
 - `--minify` keeps a `@layer` whose own rules write no declarations but nest
   rules that do. The emptiness test read only the declarations, so
   `@layer a { .x { .y { color: red } } }` collapsed to `@layer a;` and every

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -190,12 +190,12 @@ let rec pp_position_area : position_area Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_position_area ctx v
   | None -> Pp.string ctx "none"
-  (* CSS Anchor Positioning 1 sec. 3.1: the second axis defaults to [center], so
-     [X center] minifies to [X]; both axes equal also collapse. *)
+  (* css-anchor-position-1 sec. 3.1.2: a lone keyword stands for [X span-all]
+     when it names an axis and repeats itself only when it names neither, so
+     only an axis-ambiguous pair collapses. [top center] is a different area
+     from [top]. *)
   | Area (first, Some second)
-    when Pp.minified ctx
-         && (equal_position_area_keyword first second
-            || equal_position_area_keyword second Center) ->
+    when Pp.minified ctx && equal_position_area_keyword first second ->
       pp_position_area_keyword ctx first
   | Area (first, second) ->
       pp_position_area_keyword ctx first;

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -475,6 +475,14 @@ let normalize_expected ~category ~id expected =
          rounding. *)
       fixture ~category ~id ~upstream:"a{width:calc(100%*2)}"
         ~cascade:"a{width:200%}" upstream
+  | "anchor", "0002" ->
+      (* The upstream folds [position-area: top center] to [top].
+         css-anchor-position-1 sec. 3.1.2 defaults the omitted axis to
+         [span-all], not to [center], so the two name different areas: Chrome
+         151 computes them as "center top" and "top" and lays a percentage-width
+         box out 50px wide at x=200 against 600px wide at x=0. *)
+      fixture ~category ~id ~upstream:"a{position-area:top}"
+        ~cascade:"a{position-area:top center}" upstream
   | "anchor", "0003" ->
       (* The upstream rewrites [position-try-fallbacks: --flip] to the built-in
          [flip-block] tactic by inlining the [@position-try --flip {

--- a/test/render/render_diff.ml
+++ b/test/render/render_diff.ml
@@ -162,12 +162,7 @@ type input = {
 (* Inputs the sweep is known to fail. Each is a render change the optimizer
    makes today; fixing one is its own piece of work, so the sweep pins them here
    and stays green on everything else. *)
-let known =
-  [
-    ( "corpus-anchor-0002",
-      "position-area: top center folds to top, which Chromium computes as a \
-       different area" );
-  ]
+let known = []
 
 let sheet id source =
   let expect =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4039,6 +4039,20 @@ let spec_generated_position_interaction_edges () =
   check_overlay "auto";
   check_position_anchor "--menu";
   check_position_area "center span-all";
+  (* css-anchor-position-1 sec. 3.1.2: a lone keyword behaves as if the second
+     were [span-all] when it names one axis, and repeats itself only when it
+     names neither. So [top center] is a different area from [top], and Chrome
+     151 agrees: it computes them as "center top" and "top", and lays a
+     percentage-width box out at 200px wide 50px against 0px wide 600px. Only
+     the axis-ambiguous keywords fold. *)
+  check_position_area "top center";
+  check_position_area "left center";
+  check_position_area "block-start center";
+  check_position_area "x-start center";
+  check_position_area "span-left center";
+  check_position_area "center top";
+  check_position_area ~expected:"center" "center center";
+  check_position_area ~expected:"span-all" "span-all span-all";
   check_position_area_keyword "span-inline-start";
   check_position_try_fallback "flip-block";
   check_position_try_fallbacks ~expected:"flip-block,--fallback"


### PR DESCRIPTION
Minification folded `position-area: top center` to `top`. css-anchor-position-1 sec. 3.1.2 defaults the omitted axis to `span-all`, not `center`, so the two name different areas: Chrome computes them as `center top` and `top`, and lays a percentage-width box out 50px wide at x=200 against 600px wide at x=0. The render differential drops its `corpus-anchor-0002` pin.

Stacked on #456.