### PR TITLE
supports: check the value Supports.property is handed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
   nesting block only, sharing its name with the exhaustive
   `Css.Stylesheet.statement_declarations`, which reaches every declaration a
   statement holds; call that one instead (#348)
+- `Css.Supports.property` raises `Failure` on a value that is not a
+  `<declaration-value>`, where it wrote the text unchecked:
+  `property "color" "red) or (color:blue"` emitted a condition a browser answers
+  true for, so the rules the caller meant to guard applied (#459)
 - `Css.Declaration.custom_property` raises `Failure` on a name and value that
   do not write back as the one declaration they name, where it stored the token
   stream unchecked: `custom_property "--a" "red;--b:blue"` wrote a second

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -40,6 +40,13 @@ val string_of_declaration : ?minify:bool -> declaration -> string
 val to_string : ?minify:bool -> t -> string
 (** [to_string ~minify d] converts a declaration to CSS source text. *)
 
+val is_declaration_value : string -> bool
+(** [is_declaration_value s] is whether [s] is a [<declaration-value>]: one or
+    more component values with no unmatched closing bracket, no top-level [;],
+    no [<bad-string-token>] or [<bad-url-token>] and no unterminated function,
+    block or string (CSS Syntax 3 sec. 8.2). Text outside it stops being part of
+    the declaration it is written into. *)
+
 val custom_property : ?layer:string -> string -> string -> declaration
 (** [custom_property ?layer name value] is a custom property declaration from
     authored CSS text.

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -159,7 +159,31 @@ let declaration_feature prop value =
       | Some decl -> Declaration decl
       | None -> Unsupported (name, String.trim value))
 
-let property prop value = Property (declaration_feature prop value)
+(* [property] takes authored CSS text and writes it between the feature's own
+   parentheses, so the value has to be a [<declaration-value>] (CSS Syntax 3
+   sec. 8.2): an unmatched closing bracket closes those parentheses and the tail
+   becomes a second branch of the condition. The reader below hands
+   [declaration_feature] a value rendered from balanced components, so it needs
+   no check. Rendering through the component stream closes a [<url-token>] the
+   caller left open, the way the reader's own path already does. *)
+let property prop value =
+  if not (String.equal value "" || Declaration.is_declaration_value value) then
+    failwith
+      (String.concat ""
+         [
+           "supports property: ";
+           prop;
+           ": ";
+           value;
+           " is not a declaration value";
+         ]);
+  let value =
+    if String.equal value "" then value
+    else
+      Cursor.string_of_components ~trim:true
+        (Cursor.remaining (Cursor.of_string value))
+  in
+  Property (declaration_feature prop value)
 
 let single_ident name args =
   let cursor = Cursor.of_string args in
@@ -374,7 +398,7 @@ let declaration_of_components prop value =
   match property_ident (strip_components prop) with
   | Some prop ->
       let value = Cursor.string_of_components ~trim:true value in
-      property prop value
+      Property (declaration_feature prop value)
   | None -> failwith "Invalid declaration in @supports"
 
 let function_call (fn : Component.func Component.node) =

--- a/lib/supports.mli
+++ b/lib/supports.mli
@@ -54,7 +54,13 @@ type t =
 
 val property : string -> string -> t
 (** [property name value] parses [name: value] as a structured supports
-    declaration feature. *)
+    declaration feature.
+
+    @raise Failure
+      if [value] is not a [<declaration-value>] (CSS Syntax 3 sec. 8.2). The
+      feature writes the value between its own parentheses, so an unmatched
+      closing bracket closes them and the tail becomes a second branch of the
+      condition. *)
 
 val func : string -> string -> t
 (** [func name args] parses [args] as CSS component values for a supports

--- a/test/test_supports.ml
+++ b/test/test_supports.ml
@@ -187,6 +187,77 @@ let test_roundtrip () =
       Alcotest.(check string) ("roundtrip: " ^ s) s (to_string parsed))
     cases
 
+(* [property] takes authored CSS text, so a pair it accepts has to write back as
+   the one feature test it names. css-conditional-3 sec. 2.2 gives
+   [<supports-decl>] the grammar [( <declaration> )], and CSS Syntax 3 sec. 8.2
+   keeps out of a [<declaration-value>] any unmatched closing bracket, any
+   top-level [;], and any [<bad-string-token>] or [<bad-url-token>]. Written
+   between the feature's own parentheses such a value closes them, and the tail
+   becomes a second branch of the condition: Chrome answers
+   [CSS.supports("color", "red) or (color:blue")] false while the emitted
+   [(color:red) or (color:blue)] is true, so the rules it guards apply. CSS
+   Syntax 3 sec. 4.3.6 returns the [<url-token>] at end of input, so [url(foo]
+   is the value [url(foo)] is. *)
+let property_guard () =
+  (* Print the condition into a stylesheet and read the stylesheet back. The
+     answer comes from the round-trip, not from a pinned spelling. *)
+  let body =
+    [ Css.rule ~selector:(Css.Selector.class_ "a") [ Css.color (Named Red) ] ]
+  in
+  let build name value =
+    match property name value with
+    | exception Failure _ -> "<refused>"
+    | cond -> (
+        let text =
+          Css.to_string ~minify:true
+            (Css.v [ Css.Stylesheet.Supports (cond, body) ])
+        in
+        match Css.of_string ~strict:false text with
+        | Error _ -> String.concat "" [ text; " reads back as <unparsable>" ]
+        | Ok { Css.stylesheet = [ Css.Stylesheet.Supports (back, [ _ ]) ]; _ }
+          when equal cond back ->
+            "<round-trips>"
+        | Ok { Css.stylesheet; _ } ->
+            String.concat ""
+              [
+                text;
+                " reads back as ";
+                Css.to_string ~minify:true (Css.v stylesheet);
+              ])
+  in
+  List.iter
+    (fun (value, expected) ->
+      Alcotest.(check string)
+        (String.concat "" [ "color:"; value ])
+        expected (build "color" value))
+    [
+      (* A [<declaration-value>]. *)
+      ("red", "<round-trips>");
+      ("rgb(1,2,3)", "<round-trips>");
+      ("\"a;b\"", "<round-trips>");
+      ("url(foo", "<round-trips>");
+      (* Not one: an unmatched closing bracket, a top-level [;], an unterminated
+         function, block or string, a [<bad-url-token>]. *)
+      ("red) or (color:blue", "<refused>");
+      ("red)", "<refused>");
+      ("red]", "<refused>");
+      ("red}", "<refused>");
+      ("red;--b:blue", "<refused>");
+      ("rgb(1,2,3", "<refused>");
+      ("{a:b", "<refused>");
+      ("\"abc", "<refused>");
+      ("url(foo bar)", "<refused>");
+    ];
+  (* The same holds for a property whose value cascade does not model, which is
+     the arm that keeps the caller's text. *)
+  List.iter
+    (fun (value, expected) ->
+      Alcotest.(check string)
+        (String.concat "" [ "wibble-prop:"; value ])
+        expected
+        (build "wibble-prop" value))
+    [ ("1", "<round-trips>"); ("1) or (color:blue", "<refused>") ]
+
 let suite =
   let open Alcotest in
   ( "supports",
@@ -205,4 +276,5 @@ let suite =
       test_case "spec conditional supports context syntax vectors" `Quick
         spec_supports_context_vectors;
       test_case "roundtrip" `Quick test_roundtrip;
+      test_case "property guard" `Quick property_guard;
     ] )


### PR DESCRIPTION
`Supports.property "color" "red) or (color:blue"` rendered `(color:red) or (color:blue)`, a condition Chrome answers true for while `CSS.supports("color", "red) or (color:blue")` is false, so the rules the caller meant to guard applied. The constructor now takes the `<declaration-value>` that `Css.custom_property` takes and raises on the rest; the `@supports` reader is unaffected, since it renders its value from balanced components.

Stacked on #457.