### PR TITLE
changelog: name 1.2.0 and record the API breaks it carries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,19 @@
 - `Css.vars_of_rules` is `Css.vars_of_stylesheet`. It reported only what a
   top-level rule holds; it now also reports a `var()` inside a nested rule, an
   animation frame or a page margin box (#382)
+- `Css.Stylesheet.layer_name` is the identifiers a `<layer-name>` is made of
+  rather than the text between them, so `Css.layers`, `layer_block`,
+  `layer_decl`, `layer`, `layer_of`, `as_layer`, `layer_block_name`,
+  `layer_statement_name_list`, `import_layer_name` and the `?layer` argument of
+  `custom_props` carry a `string list` where they carried a `string`.
+  `Css.Stylesheet.read_layer_name` and `string_of_layer_name` convert between
+  the two (#442)
+- `Css.color` keeps the origin of a relative colour as a colour rather than in
+  the opaque tail: `Relative_rgb` carries `color * string` and
+  `Relative_color` carries `string * color * string`, so an expression or a
+  pattern naming either takes the extra field (#313)
+- `Css.Pp.ctx` gains `in_style_rule`; record expressions must set it and record
+  patterns must bind it or use `; _` (#374)
 
 ### Parsing
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,21 @@
-## Unreleased
+## 1.2.0
+
+Most of the entries below are defect fixes, and the largest group of them has
+one cause. Readers, printers and optimizer passes each walked the statement
+tree by hand, matching the constructors they knew and closing with a wildcard,
+and no two of those lists agreed, so an at-rule added to the AST later fell
+through them unseen rather than failing to compile. They share one traversal
+now, written without that wildcard, so a statement kind added after this
+release stops every site that has to decide about it from compiling, and a test
+walks all twenty-three statement shapes and every place a declaration can sit
+to pin that the shared walk reaches them. Correctness was judged against a
+browser rather than against cascade: the test suite renders a sheet and its
+optimised form in headless Chrome and compares every property
+`getComputedStyle` reports on every element, and a manual sweep does the same
+to live pages, so several of the fixes below are miscompiles Chrome
+contradicted rather than readings of the spec. Behind those sit 504 CSS files
+drawn from 72 production sites and 2960 recorded cases carrying six minifiers'
+answers.
 
 ### Breaking
 


### PR DESCRIPTION
The layer-name widening (#442), the typed relative-colour origin (#313) and the new `Css.Pp.ctx` field (#374) each stop a caller compiling and were not in the breaking section. The preamble says where this many defects came from and what checked the fixes, so the list does not read as instability on its own.

Prepares the release only. The tag and the opam submission are not part of this.