### PR TITLE
stylesheet: read every @-moz-document URL-matching function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
   nesting block only, sharing its name with the exhaustive
   `Css.Stylesheet.statement_declarations`, which reaches every declaration a
   statement holds; call that one instead (#348)
+- `Css.Stylesheet.moz_document_condition` gains `Url_exact`, `Domain`,
+  `Media_document` and `Regexp`, so a match on it is no longer exhaustive (#461)
 - `Css.Supports.property` raises `Failure` on a value that is not a
   `<declaration-value>`, where it wrote the text unchecked:
   `property "color" "red) or (color:blue"` emitted a condition a browser answers
@@ -37,6 +39,9 @@
   `border-block-start` and `border-block-end` keep their value. None of the five
   had a value reader, so the declaration was dropped with a warning and a file
   holding nothing else exited 1 (#456)
+- `@-moz-document` reads all five of its URL-matching functions. Only
+  `url-prefix()` had a grammar, so `url()`, `domain()`, `media-document()` and
+  `regexp()` took the at-rule down with every rule inside it (#461)
 - `stroke-miterlimit` takes a value between 0 and 1. SVG 2 makes only a
   negative value illegal, having dropped SVG 1.1's "at least 1" rule because
   CSS parsers never enforced it (#334)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1023,12 +1023,22 @@ let rec pp_conditional : conditional Pp.t =
       Pp.string ctx " or ";
       pp_conditional ctx b
 
-let pp_moz_document_condition ctx = function
+(* Every argument but the [<url>] one is a [<string>], so it stays quoted; the
+   [<url>] takes the shortest spelling [Pp.url] gives it. *)
+let pp_moz_document_condition ctx =
+  let call name arg =
+    Pp.string ctx name;
+    Pp.char ctx '(';
+    Pp.quoted_string ctx arg;
+    Pp.char ctx ')'
+  in
+  function
+  | Url_exact url -> Pp.url ctx url
   | Url_prefix None -> Pp.string ctx "url-prefix()"
-  | Url_prefix (Some prefix) ->
-      Pp.string ctx "url-prefix(";
-      Pp.quoted_string ctx prefix;
-      Pp.char ctx ')'
+  | Url_prefix (Some prefix) -> call "url-prefix" prefix
+  | Domain domain -> call "domain" domain
+  | Media_document media -> call "media-document" media
+  | Regexp regexp -> call "regexp" regexp
 
 let pp_declarations_statement ctx raw_decls =
   (* Bare declarations for CSS nesting - no selector/braces, just declarations.
@@ -2021,25 +2031,49 @@ let read_moz_keyframes r =
     (fun name frames -> Moz_keyframes (name, frames))
     r
 
+(* [url-prefix()] with no argument is the prelude that matches every document,
+   so an empty argument list and an empty string both read as [None]. *)
+let read_moz_url_prefix arg_cursor =
+  match Cursor.string_opt arg_cursor with
+  | Some "" -> Option.None
+  | Some prefix -> Some prefix
+  | None ->
+      Cursor.ws arg_cursor;
+      if Cursor.is_done arg_cursor then Option.None
+      else Cursor.err_expected arg_cursor "url-prefix string argument"
+
+let read_moz_document_function r name arguments : moz_document_condition =
+  let arg_cursor = Cursor.of_components arguments in
+  Cursor.ws arg_cursor;
+  let finish condition =
+    Cursor.ws arg_cursor;
+    Cursor.expect_eof arg_cursor;
+    condition
+  in
+  match name with
+  | "url" -> finish (Url_exact (Cursor.string arg_cursor))
+  | "url-prefix" -> finish (Url_prefix (read_moz_url_prefix arg_cursor))
+  | "domain" -> finish (Domain (Cursor.string arg_cursor))
+  | "media-document" -> finish (Media_document (Cursor.string arg_cursor))
+  | "regexp" -> finish (Regexp (Cursor.string arg_cursor))
+  | _ -> Cursor.err_expected r "a @-moz-document URL-matching function"
+
+(* Gecko's [@document] prelude takes [<url>], [url-prefix(<string>)],
+   [domain(<string>)], [media-document(<string>)] and [regexp(<string>)]. A
+   prelude function outside that list has no grammar, so the at-rule goes down
+   with it, which is what CSS Syntax 3 sec. 5.4.2 does with any prelude no
+   grammar accepts. *)
 let read_moz_document_condition r : moz_document_condition =
   Cursor.ws r;
-  match Cursor.next r with
-  | Some (Component.Func { node = { name = "url-prefix"; arguments; _ }; _ }) ->
-      let arg_cursor = Cursor.of_components arguments in
-      Cursor.ws arg_cursor;
-      let prefix =
-        match Cursor.string_opt arg_cursor with
-        | Some "" -> Option.None
-        | Some s -> Some s
-        | None ->
-            Cursor.ws arg_cursor;
-            if Cursor.is_done arg_cursor then Option.None
-            else Cursor.err_expected arg_cursor "url-prefix string argument"
-      in
-      Cursor.ws arg_cursor;
-      Cursor.expect_eof arg_cursor;
-      Url_prefix prefix
-  | _ -> Cursor.err_expected r "url-prefix()"
+  (* [url(x)] lexes as a [<url-token>] and [url("x")] as a function, so the
+     [<url>] form is read before the function arms. *)
+  match Cursor.url_opt r with
+  | Some url -> Url_exact url
+  | None -> (
+      match Cursor.next r with
+      | Some (Component.Func { node = { name; arguments; _ }; _ }) ->
+          read_moz_document_function r name arguments
+      | _ -> Cursor.err_expected r "a @-moz-document URL-matching function")
 
 (* Read a font-face descriptor *)
 (* Helper to read descriptor value after colon *)

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -212,7 +212,15 @@ and conditional =
   | And of conditional * conditional
   | Or of conditional * conditional
 
-and moz_document_condition = Url_prefix of string option
+(* Gecko's [@document] prelude: [<url> | url-prefix(<string>) | domain(<string>)
+   | media-document(<string>) | regexp(<string>)]#. *)
+and moz_document_condition =
+  | Url_exact of string
+  | Url_prefix of string option
+  | Domain of string
+  | Media_document of string
+  | Regexp of string
+
 and viewport_prefix = Standard | Ms_prefixed
 
 and viewport_descriptor = { name : string; value : string }

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2702,10 +2702,17 @@ let moz_document_prelude_forms () =
       ("url-prefix(\"a\"),domain(\"b\")", "url-prefix(\"a\"),domain(\"b\")");
     ];
   (* A form outside the grammar still takes the at-rule down, which is what CSS
-     Syntax 3 sec. 5.4.2 does with a prelude no grammar accepts. *)
-  Alcotest.(check string)
-    "an unknown prelude function drops the at-rule" ".a{color:red}"
-    (roundtrips ".a{color:red}@-moz-document wibble(\"x\"){.b{color:red}}")
+     Syntax 3 sec. 5.4.2 does with a prelude no grammar accepts. The recovering
+     reader is the one that drops it; the raw one raises. *)
+  match
+    Css.of_string ~strict:false
+      ".a{color:red}@-moz-document wibble(\"x\"){.b{color:red}}"
+  with
+  | Error e -> Alcotest.fail (Error.to_string e)
+  | Ok { Css.stylesheet; _ } ->
+      Alcotest.(check string)
+        "an unknown prelude function drops the at-rule" ".a{color:red}"
+        (String.trim (Css.Stylesheet.to_string ~minify:true stylesheet))
 
 (* Not a roundtrip test *)
 let test_invalid_functions () =

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2671,6 +2671,42 @@ let s3431_unknown_at_rule_prelude_separator () =
     "statement form without a prelude stays unspaced" "@foo;"
     (roundtrips "@foo;")
 
+(* Gecko's [@document]/[@-moz-document] takes a comma-separated list of [<url> |
+   url-prefix(<string>) | domain(<string>) | media-document(<string>) |
+   regexp(<string>)]. Cascade modelled only [url-prefix()], so every other form
+   failed the prelude read and the at-rule went down with every rule inside it.
+   The five minifiers in [test/interop/lightning] all keep the at-rule verbatim.
+   A [<string>] argument stays quoted; a [<url>] takes the shortest spelling. *)
+let moz_document_prelude_forms () =
+  let roundtrips input =
+    String.trim
+      (Css.Stylesheet.to_string ~minify:true
+         (read_stylesheet (Cursor.of_string input)))
+  in
+  List.iter
+    (fun (prelude, expected) ->
+      let wrap p =
+        String.concat "" [ "@-moz-document "; p; "{.b{color:red}}" ]
+      in
+      Alcotest.(check string)
+        prelude (wrap expected)
+        (roundtrips (wrap prelude)))
+    [
+      ("url-prefix(\"x\")", "url-prefix(\"x\")");
+      ("url-prefix()", "url-prefix()");
+      ("url(x)", "url(x)");
+      ("url(\"x\")", "url(x)");
+      ("domain(\"example.com\")", "domain(\"example.com\")");
+      ("regexp(\"x\")", "regexp(\"x\")");
+      ("media-document(\"video\")", "media-document(\"video\")");
+      ("url-prefix(\"a\"),domain(\"b\")", "url-prefix(\"a\"),domain(\"b\")");
+    ];
+  (* A form outside the grammar still takes the at-rule down, which is what CSS
+     Syntax 3 sec. 5.4.2 does with a prelude no grammar accepts. *)
+  Alcotest.(check string)
+    "an unknown prelude function drops the at-rule" ".a{color:red}"
+    (roundtrips ".a{color:red}@-moz-document wibble(\"x\"){.b{color:red}}")
+
 (* Not a roundtrip test *)
 let test_invalid_functions () =
   expect_parse_error ".btn { color: rgb(300); }";
@@ -8582,6 +8618,7 @@ let additional_tests =
     ( "spec CSS Syntax 4.3.1 unknown at-rule prelude separator",
       `Quick,
       s3431_unknown_at_rule_prelude_separator );
+    ("spec @-moz-document prelude forms", `Quick, moz_document_prelude_forms);
     (* CSS nesting round-trip tests *)
     ("nesting basic", `Quick, test_nesting_basic);
     ("nesting ampersand hover", `Quick, test_nesting_ampersand_hover);


### PR DESCRIPTION
Gecko takes `<url>`, `url-prefix()`, `domain()`, `media-document()` and `regexp()` in the `@document` prelude. Cascade modelled `url-prefix()` alone, so the other four failed the prelude read and `read_block` dropped the at-rule together with every rule inside it; the five minifiers cascade traces in `test/interop/lightning` all keep it verbatim.

Stacked on #459, with #460 above this one so the release changelog names what is below it.