### PR TITLE
test/inline: reject a page an older freeze_page.js froze

### DIFF
--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -46,6 +46,15 @@ Freezing happens at fetch time, before `cascade apply` ever sees the page, so
 the document cascade resolves is the document the browser lays out. Pages live
 in the gitignored `pages/`; re-run `fetch.sh` to rebuild them.
 
+Freezing and pinning are what make a page reproducible; neither shows that it
+is. So `run.sh` renders each fetched page twice with nothing transforming it in
+between (`xtest.js --self`) before it measures anything, and unless the two
+renders agree it reports the page as unusable and skips its transform legs. A
+page that differs from itself yields a difference list about nothing, and the
+run would otherwise hand that list to whichever transform it was measuring.
+Fixtures are exempt: they are committed and change only under review, where a
+page arrives off the network and goes stale on its own.
+
 ## What a count is comparable to
 
 Repeating on one machine is half of it. A count also has to say what produced

--- a/test/inline/README.md
+++ b/test/inline/README.md
@@ -55,6 +55,15 @@ run would otherwise hand that list to whichever transform it was measuring.
 Fixtures are exempt: they are committed and change only under review, where a
 page arrives off the network and goes stale on its own.
 
+Two renders catch a page that is unstable on those two, which is not the same
+as catching an unstable page: a `tailwind.html` frozen before the freezer
+learned to strip `@font-face` differed from itself on three self-checks in
+eight. So the run also re-freezes each page and requires that to be a no-op.
+`freeze_page.js` is idempotent, so a page it still changes was frozen by an
+older one and is stale whatever it renders today. That question is
+deterministic and costs milliseconds, so it is asked first, and `fetch.sh` is
+the answer to it.
+
 ## What a count is comparable to
 
 Repeating on one machine is half of it. A count also has to say what produced

--- a/test/inline/dune
+++ b/test/inline/dune
@@ -6,10 +6,10 @@
  (name canon_filter)
  (libraries cascade cascade_diff))
 
-; The self-stability control is what licenses every count run.sh prints, so it
-; is checked on every machine rather than only where a browser is installed:
-; test_selfcheck.sh drives run.sh through a stub browser that is unstable on
-; demand. It skips, with status 0, when node is missing.
+; The controls that license every count run.sh prints are checked on every
+; machine rather than only where a browser is installed: test_selfcheck.sh
+; drives run.sh through a stub browser that is unstable on demand. It skips,
+; with status 0, when node is missing.
 
 (rule
  (alias runtest)

--- a/test/inline/dune
+++ b/test/inline/dune
@@ -13,7 +13,7 @@
 
 (rule
  (alias runtest)
- (deps run.sh xtest.js minify_page.js)
+ (deps run.sh xtest.js minify_page.js freeze_page.js)
  (action
   (run
    sh

--- a/test/inline/dune
+++ b/test/inline/dune
@@ -5,3 +5,18 @@
 (executable
  (name canon_filter)
  (libraries cascade cascade_diff))
+
+; The self-stability control is what licenses every count run.sh prints, so it
+; is checked on every machine rather than only where a browser is installed:
+; test_selfcheck.sh drives run.sh through a stub browser that is unstable on
+; demand. It skips, with status 0, when node is missing.
+
+(rule
+ (alias runtest)
+ (deps run.sh xtest.js minify_page.js)
+ (action
+  (run
+   sh
+   %{dep:test_selfcheck.sh}
+   %{exe:../../bin/main.exe}
+   %{dep:canon_filter.exe})))

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -119,6 +119,24 @@ check() { # label before after
        fail=1 ;;
   esac
 }
+# A count means something about a transform only if the page renders the same
+# twice without one, and a fetched page does not always: one frozen by an older
+# freeze_page.js keeps the @font-face rules that swap text metrics mid-render,
+# and it then differs from itself by a few hundred computed styles on about
+# half of its runs. Measured against a transform, that reads as a defect in the
+# transform. So prove the page first, and skip it rather than report a number
+# from an instrument that is not measuring the transform.
+selfstable() { # label file
+  report=$(node "$dir/xtest.js" --self "$2" 2>&1)
+  case $report in
+    *"RESULT: SELF-STABLE"*) return 0 ;;
+    *) echo "UNUSABLE $1"
+       printf '%s\n' "$report" | head -8 | sed 's/^/     /'
+       echo "     no count from this page means anything; re-run fetch.sh"
+       fail=1
+       return 1 ;;
+  esac
+}
 # A transform that dies leaves an empty file, and an empty page differs from
 # the original in every computed style, so the run blames the transform for a
 # render change that never happened. Report the status, and the error the tool
@@ -170,9 +188,14 @@ done
 # Both transforms run: `apply` and `--minify` fail differently, and a real page
 # carries selectors and feature queries no fixture does, so a minify defect
 # that only a real page reaches goes unmeasured until the leg exists.
+#
+# The self-stability check is on the pages alone. A fixture is committed and
+# changes only under review; a page arrives off the network and goes stale on
+# its own, which is the way this has failed.
 for f in "$dir"/pages/*.html; do
   [ -e "$f" ] || continue
   page="$(basename "$f")@$(sha "$f")"
+  selfstable "real $page" "$f" || continue
   tmp=$(mktemp)
   label="real $page minimal"
   if transform "$label" "$tmp" "$CASCADE" apply --minimal "$f"; then

--- a/test/inline/run.sh
+++ b/test/inline/run.sh
@@ -119,13 +119,40 @@ check() { # label before after
        fail=1 ;;
   esac
 }
-# A count means something about a transform only if the page renders the same
-# twice without one, and a fetched page does not always: one frozen by an older
-# freeze_page.js keeps the @font-face rules that swap text metrics mid-render,
-# and it then differs from itself by a few hundred computed styles on about
-# half of its runs. Measured against a transform, that reads as a defect in the
-# transform. So prove the page first, and skip it rather than report a number
-# from an instrument that is not measuring the transform.
+# A page is frozen once, at fetch time, and the freezer moves. One frozen
+# before freeze_page.js learned to strip @font-face keeps the rules that swap
+# text metrics mid-render, and it then differs from itself by a few hundred
+# computed styles on about half of its runs; measured against a transform, that
+# reads as a defect in the transform.
+#
+# Freezing is idempotent, so re-freezing a page that is current is a no-op: one
+# that changes under the freezer in the tree was frozen by a different one and
+# is stale, whatever it happens to render today. That is the deterministic half
+# of the question, and it costs milliseconds, so ask it first.
+frozen_now() { # label file
+  refrozen=$(mktemp)
+  # A freezer that will not run would mark every page stale, which reads as a
+  # fetch.sh away from a working harness and is not. Stop, as a broken
+  # canonical filter does.
+  if ! node "$dir/freeze_page.js" "$2" "$refrozen"; then
+    rm -f "$refrozen"
+    echo "ERROR: freeze_page.js failed on $2, so no page can be checked" >&2
+    exit 1
+  fi
+  if cmp -s "$2" "$refrozen"; then rm -f "$refrozen"; return 0; fi
+  rm -f "$refrozen"
+  echo "UNUSABLE $1"
+  echo "     frozen by an older freeze_page.js, so what it renders is not"
+  echo "     what it will render; re-run fetch.sh"
+  fail=1
+  return 1
+}
+# The other half: a count means something about a transform only if the page
+# renders the same twice without one. Two renders catch only a page that is
+# unstable on those two renders, which is why the check above is not enough on
+# its own, but they catch instability the freezer does not know about. Prove
+# the page before measuring it, and skip it rather than report a number from an
+# instrument that is measuring something else.
 selfstable() { # label file
   report=$(node "$dir/xtest.js" --self "$2" 2>&1)
   case $report in
@@ -189,12 +216,13 @@ done
 # carries selectors and feature queries no fixture does, so a minify defect
 # that only a real page reaches goes unmeasured until the leg exists.
 #
-# The self-stability check is on the pages alone. A fixture is committed and
-# changes only under review; a page arrives off the network and goes stale on
-# its own, which is the way this has failed.
+# Both checks are on the pages alone. A fixture is committed and changes only
+# under review; a page arrives off the network and goes stale on its own, which
+# is the way this has failed.
 for f in "$dir"/pages/*.html; do
   [ -e "$f" ] || continue
   page="$(basename "$f")@$(sha "$f")"
+  frozen_now "real $page" "$f" || continue
   selfstable "real $page" "$f" || continue
   tmp=$(mktemp)
   label="real $page minimal"

--- a/test/inline/test_selfcheck.sh
+++ b/test/inline/test_selfcheck.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# The harness must prove a page renders the same twice before it reports a
+# difference count for it.
+#
+# A page whose layout has not settled by the time the computed styles are read
+# differs from itself, and run.sh then attributes that difference to whichever
+# transform it happened to be measuring: a defect report about code that is
+# fine. It has happened twice. So a page that is not self-stable has to be
+# reported as unusable, and its transform legs skipped, rather than measured.
+#
+# Testing that needs a browser that is unstable on demand, which a real one is
+# not, so this drives run.sh through a stub: it answers `--version`, and for
+# each `--dump-dom` it prints one of two computed-style payloads, alternating
+# only for a page carrying the marker below. No browser is involved, so the
+# gate is checked on every machine rather than only where Chrome is installed.
+#
+# Usage: sh test_selfcheck.sh <cascade> <canon_filter>
+set -e
+dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+CASCADE=$1
+CANON_FILTER=$2
+case $CASCADE in /*) ;; *) CASCADE=$(CDPATH= cd "$(dirname "$CASCADE")" && pwd)/$(basename "$CASCADE") ;; esac
+case $CANON_FILTER in /*) ;; *) CANON_FILTER=$(CDPATH= cd "$(dirname "$CANON_FILTER")" && pwd)/$(basename "$CANON_FILTER") ;; esac
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "SKIP: no node available"; exit 0
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/fixtures" "$work/pages"
+cp "$dir/run.sh" "$dir/xtest.js" "$dir/minify_page.js" "$work/"
+
+# The stub keys off the page text, not the invocation count, so the original
+# page and each transform of it answer alike: only the marked page moves.
+cat > "$work/browser" <<'STUB'
+#!/bin/sh
+case $1 in --version) echo "Stub Browser 0.0"; exit 0 ;; esac
+for a in "$@"; do case $a in file://*) page=${a#file://} ;; esac; done
+n=0
+if grep -q xtest-stub-unstable "$page" 2>/dev/null; then
+  n=$(cat "$STUB_STATE" 2>/dev/null || echo 0)
+  n=$((n + 1))
+  echo "$n" > "$STUB_STATE"
+  n=$((n % 2))
+fi
+if [ "$n" = 0 ]
+then body='[{"_tag":"DIV","color":"rgb(0, 0, 0)"}]'
+else body='[{"_tag":"DIV","color":"rgb(1, 1, 1)"}]'
+fi
+printf '<html><body data-xtest="%s"></body></html>\n' \
+  "$(printf '%s' "$body" | base64 | tr -d '\n')"
+STUB
+chmod +x "$work/browser"
+
+page() { # path marker
+  cat > "$1" <<EOF
+<html><head><style>.a{color:#000}</style></head>
+<body><div class="a" data-note="$2">x</div></body></html>
+EOF
+}
+# One fixture, because run.sh always has fixtures to measure; the pages are
+# what the control is for.
+page "$work/fixtures/one.html" stable
+page "$work/pages/stable.html" stable
+page "$work/pages/moving.html" xtest-stub-unstable
+
+STUB_STATE=$work/state
+export STUB_STATE CASCADE CANON_FILTER
+CHROME=$work/browser
+export CHROME
+status=0
+sh "$work/run.sh" > "$work/out" 2>&1 || status=$?
+
+fail() {
+  echo "FAIL: $1"
+  echo "--- run.sh output (exit $status) ---"
+  cat "$work/out"
+  exit 1
+}
+
+# The self-stable page is measured as before: the control must not cost a
+# result on a page that passes it.
+grep -q '^ok   real stable\.html@.* minimal$' "$work/out" ||
+  fail "the self-stable page was not measured"
+grep -q '^ok   real stable\.html@.* minify$' "$work/out" ||
+  fail "the self-stable page was not measured under minify"
+
+# The page that renders differently twice is named unusable.
+grep -q '^UNUSABLE real moving\.html@' "$work/out" ||
+  fail "a page that renders differently twice was not reported as unusable"
+
+# And it produces no count: a difference between two renders of one page says
+# nothing about a transform, so blaming one is the failure this gate exists to
+# stop.
+if grep -q 'moving\.html@.* \(minimal\|minify\)$' "$work/out"; then
+  fail "an unusable page still reported a transform result"
+fi
+
+[ "$status" -ne 0 ] || fail "run.sh exited 0 with a page it could not measure"
+
+echo "PASS: an unstable page is reported as unusable, not measured"

--- a/test/inline/test_selfcheck.sh
+++ b/test/inline/test_selfcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# The harness must prove a page renders the same twice before it reports a
-# difference count for it.
+# The harness must prove a page is measurable before it reports a difference
+# count for it, on both of the counts it can fail.
 #
 # A page whose layout has not settled by the time the computed styles are read
 # differs from itself, and run.sh then attributes that difference to whichever
@@ -8,11 +8,19 @@
 # fine. It has happened twice. So a page that is not self-stable has to be
 # reported as unusable, and its transform legs skipped, rather than measured.
 #
-# Testing that needs a browser that is unstable on demand, which a real one is
-# not, so this drives run.sh through a stub: it answers `--version`, and for
-# each `--dump-dom` it prints one of two computed-style payloads, alternating
-# only for a page carrying the marker below. No browser is involved, so the
-# gate is checked on every machine rather than only where Chrome is installed.
+# Two renders only catch a page that is unstable on those two renders, and the
+# page that prompted this was unstable on three self-checks in eight. What is
+# deterministic about it is that it was frozen by an older freeze_page.js:
+# freezing is idempotent, so re-freezing a current page is a no-op, and a page
+# that changes under the current freezer is stale whatever it renders today.
+# That has to be caught too, and every time.
+#
+# Testing the first needs a browser that is unstable on demand, which a real
+# one is not, so this drives run.sh through a stub: it answers `--version`, and
+# for each `--dump-dom` it prints one of two computed-style payloads,
+# alternating only for a page carrying the marker below. No browser is
+# involved, so both gates are checked on every machine rather than only where
+# Chrome is installed.
 #
 # Usage: sh test_selfcheck.sh <cascade> <canon_filter>
 set -e
@@ -29,7 +37,7 @@ fi
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work/fixtures" "$work/pages"
-cp "$dir/run.sh" "$dir/xtest.js" "$dir/minify_page.js" "$work/"
+cp "$dir/run.sh" "$dir/xtest.js" "$dir/minify_page.js" "$dir/freeze_page.js" "$work/"
 
 # The stub keys off the page text, not the invocation count, so the original
 # page and each transform of it answer alike: only the marked page moves.
@@ -64,6 +72,12 @@ EOF
 page "$work/fixtures/one.html" stable
 page "$work/pages/stable.html" stable
 page "$work/pages/moving.html" xtest-stub-unstable
+# Frozen by a freezer that did not strip <script>, so the current one changes
+# it. The stub renders it as steadily as any other page: staleness is the only
+# thing wrong with it.
+page "$work/pages/unfrozen.html" stable
+sed -i.bak 's|</body>|<script>void 0</script></body>|' "$work/pages/unfrozen.html"
+rm -f "$work/pages/unfrozen.html.bak"
 
 STUB_STATE=$work/state
 export STUB_STATE CASCADE CANON_FILTER
@@ -97,6 +111,14 @@ if grep -q 'moving\.html@.* \(minimal\|minify\)$' "$work/out"; then
   fail "an unusable page still reported a transform result"
 fi
 
+# The page the current freezer would still change was frozen by an older one,
+# so what it renders today says nothing about what it renders tomorrow.
+grep -q '^UNUSABLE real unfrozen\.html@' "$work/out" ||
+  fail "a page the current freezer still changes was not reported as unusable"
+if grep -q 'unfrozen\.html@.* \(minimal\|minify\)$' "$work/out"; then
+  fail "a stale page still reported a transform result"
+fi
+
 [ "$status" -ne 0 ] || fail "run.sh exited 0 with a page it could not measure"
 
-echo "PASS: an unstable page is reported as unusable, not measured"
+echo "PASS: an unstable page and a stale one are reported as unusable"

--- a/test/inline/xtest.js
+++ b/test/inline/xtest.js
@@ -35,7 +35,15 @@ function computed(path){
   if(!m) throw new Error('no data-xtest for '+path);
   return JSON.parse(Buffer.from(m[1],'base64').toString('utf8'));
 }
-const a = computed(process.argv[2]), b = computed(process.argv[3]);
+// --self renders one page twice and compares it with itself. Nothing
+// transformed it in between, so a difference here is the page's own, and every
+// later count taken from it reads as a defect in whichever transform happened
+// to be measured. run.sh settles that before it believes any count.
+const self = process.argv[2] === '--self';
+const [pathA, pathB] = self
+  ? [process.argv[3], process.argv[3]]
+  : [process.argv[2], process.argv[3]];
+const a = computed(pathA), b = computed(pathB);
 // The two lists line up by position, so the comparison is only meaningful up to
 // the first place the trees disagree. Past a dropped or added element every
 // later index compares two different elements, and one structural change
@@ -71,6 +79,11 @@ if (split !== null) diffs.unshift(split);
 const how = CANON ? ' (canonical compare)'
   : ' (RAW COMPARE, no CANON_FILTER: equivalent spellings counted, total inflated)';
 console.log('visual elements: '+n+', computed props/elem: ~'+Object.keys(a[0]||{}).length+how);
-if (!diffs.length) console.log('RESULT: IDENTICAL computed styles (inlining preserves the render)');
+const verdict = self
+  ? { same: 'RESULT: SELF-STABLE (the page renders the same twice)',
+      differ: 'RESULT: NOT SELF-STABLE, '+diffs.length+' difference(s) between two renders of it' }
+  : { same: 'RESULT: IDENTICAL computed styles (inlining preserves the render)',
+      differ: 'RESULT: '+diffs.length+' difference(s)'+(CANON?'':' [RAW, INFLATED]') };
+if (!diffs.length) console.log(verdict.same);
 // The whole list, not a sample: it is the artifact you diff between runs.
-else { console.log('RESULT: '+diffs.length+' difference(s)'+(CANON?'':' [RAW, INFLATED]')+':'); diffs.forEach(d=>console.log('  '+d)); }
+else { console.log(verdict.differ+':'); diffs.forEach(d=>console.log('  '+d)); }


### PR DESCRIPTION
Two renders catch a page that is unstable on those two renders: the `tailwind.html` that prompted #463 was unstable on three self-checks in eight, so that gate alone is close to a coin flip on the case it was written for.

Freezing is idempotent, so a page the current `freeze_page.js` still changes was frozen by an older one and is stale whatever it renders today. `run.sh` asks that first, deterministically and in milliseconds, and `fetch.sh` is the fix.