### PR TITLE
container: compare a style query by what it says

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -200,6 +200,11 @@ answers.
 
 ### Minification
 
+- `--minify` merges adjacent `@container` blocks whose `style()` conditions
+  are written the same way. The comparison reached the source byte offsets
+  every token carries, so two byte-identical `style(--x: 1)` queries never
+  compared equal and their blocks stayed separate, while size queries and the
+  bare `style(--x)` form already merged (#465)
 - `--minify` keeps the `center` in `position-area: top center`. A lone keyword
   stands for `X span-all`, not `X center`, so dropping it moved the box to a
   different area (#457)

--- a/lib/component.ml
+++ b/lib/component.ml
@@ -37,7 +37,33 @@ type rule = Qualified of qualified_rule | At of at_rule
 type declaration_body = { name : string; value : t list; important : bool }
 type declaration = declaration_body node
 
-let equal (a : t) b = a = b
+(* A {!Loc.t} records where a node was read, not what it holds, so two nodes
+   that spell the same component value are the same value however far apart the
+   source wrote them. *)
+let rank = function Preserved _ -> 0 | Block _ -> 1 | Func _ -> 2
+
+let rec compare (a : t) (b : t) =
+  match (a, b) with
+  | Preserved t1, Preserved t2 -> Token.compare_kind t1.kind t2.kind
+  | Block b1, Block b2 -> compare_block b1.node b2.node
+  | Func f1, Func f2 -> compare_func f1.node f2.node
+  | (Preserved _ | Block _ | Func _), _ -> Int.compare (rank a) (rank b)
+
+and compare_block (b1 : block) (b2 : block) =
+  let c = Token.compare_bracket b1.opening b2.opening in
+  if c <> 0 then c
+  else
+    let c = Bool.compare b1.closed b2.closed in
+    if c <> 0 then c else List.compare compare b1.value b2.value
+
+and compare_func (f1 : func) (f2 : func) =
+  let c = String.compare f1.name f2.name in
+  if c <> 0 then c
+  else
+    let c = Bool.compare f1.terminated f2.terminated in
+    if c <> 0 then c else List.compare compare f1.arguments f2.arguments
+
+let equal a b = compare a b = 0
 
 let source_loc : t -> Loc.t = function
   | Preserved tok -> tok.Token.loc

--- a/lib/component.mli
+++ b/lib/component.mli
@@ -48,7 +48,12 @@ type declaration_body = { name : string; value : t list; important : bool }
 type declaration = declaration_body node
 
 val equal : t -> t -> bool
-(** [equal a b] tests component values for structural equality. *)
+(** [equal a b] tests component values for structural equality. Source locations
+    are provenance rather than value, so they are not compared. *)
+
+val compare : t -> t -> int
+(** [compare a b] totally orders component values, ignoring source locations
+    just as {!equal} does. *)
 
 val source_loc : t -> Loc.t
 (** [source_loc cv] is the source range spanned by [cv]. *)

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -171,6 +171,46 @@ let to_stylesheet_string ?(minify = false) t =
 
 let pp t = to_string t
 
+(* A style query holds component values, which carry the source positions they
+   were read from, so a structural walk would call two spellings of one query
+   different. Compare what the query asks, not where it was written. *)
+let style_query_rank = function
+  | Boolean _ -> 0
+  | Declaration _ -> 1
+  | Range _ -> 2
+  | All _ -> 3
+  | Any _ -> 4
+  | Neg _ -> 5
+
+let compare_values (a : component_values) b = List.compare Component.compare a b
+let compare_range_operator (a : range_operator) b = Stdlib.compare a b
+
+let compare_style_range (r1 : style_range) (r2 : style_range) =
+  let c = String.compare r1.name r2.name in
+  if c <> 0 then c
+  else
+    let c = compare_range_operator r1.lower_op r2.lower_op in
+    if c <> 0 then c
+    else
+      let c = compare_range_operator r1.upper_op r2.upper_op in
+      if c <> 0 then c
+      else
+        let c = compare_values r1.lower r2.lower in
+        if c <> 0 then c else compare_values r1.upper r2.upper
+
+let rec compare_style_query q1 q2 =
+  match (q1, q2) with
+  | Boolean n1, Boolean n2 -> String.compare n1 n2
+  | Declaration d1, Declaration d2 ->
+      let c = String.compare d1.name d2.name in
+      if c <> 0 then c else compare_values d1.value d2.value
+  | Range r1, Range r2 -> compare_style_range r1 r2
+  | All (a1, b1), All (a2, b2) | Any (a1, b1), Any (a2, b2) ->
+      let c = compare_style_query a1 a2 in
+      if c <> 0 then c else compare_style_query b1 b2
+  | Neg a, Neg b -> compare_style_query a b
+  | _ -> Int.compare (style_query_rank q1) (style_query_rank q2)
+
 let rec compare t1 t2 =
   match (t1, t2) with
   | Min_width_rem r1, Min_width_rem r2 -> Float.compare r1 r2
@@ -178,7 +218,8 @@ let rec compare t1 t2 =
   | Named (n1, c1), Named (n2, c2) ->
       let name_cmp = String.compare n1 n2 in
       if name_cmp <> 0 then name_cmp else compare c1 c2
-  | Style { query = q1; _ }, Style { query = q2; _ } -> Stdlib.compare q1 q2
+  | Style { query = q1; _ }, Style { query = q2; _ } ->
+      compare_style_query q1 q2
   | Scroll_state { query = q1; _ }, Scroll_state { query = q2; _ } ->
       Stdlib.compare q1 q2
   | And (a1, b1), And (a2, b2) ->

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -45,7 +45,10 @@ type t = { kind : kind; loc : Loc.t }
 let equal_hash_flag (a : hash_flag) b = a = b
 let equal_number_flag (a : number_flag) b = a = b
 let equal_bracket (a : bracket) b = a = b
+let bracket_rank = function Curly -> 0 | Paren -> 1 | Square -> 2
+let compare_bracket a b = Int.compare (bracket_rank a) (bracket_rank b)
 let equal_kind (a : kind) b = a = b
+let compare_kind (a : kind) b = Stdlib.compare a b
 let v ~kind ~loc = { kind; loc }
 let synthetic kind = { kind; loc = Loc.dummy }
 

--- a/lib/token.mli
+++ b/lib/token.mli
@@ -82,8 +82,16 @@ val equal_number_flag : number_flag -> number_flag -> bool
 val equal_bracket : bracket -> bracket -> bool
 (** [equal_bracket a b] tests bracket kinds for equality. *)
 
+val compare_bracket : bracket -> bracket -> int
+(** [compare_bracket a b] totally orders the bracket characters. *)
+
 val equal_kind : kind -> kind -> bool
 (** [equal_kind a b] tests token payloads for structural equality. *)
+
+val compare_kind : kind -> kind -> int
+(** [compare_kind a b] totally orders token payloads. A payload carries no
+    {!Loc.t}, so the order is over what the token spells, not where it was read.
+*)
 
 val v : kind:kind -> loc:Loc.t -> t
 (** [v ~kind ~loc] is a token with the given payload and location. *)

--- a/test/test_block.ml
+++ b/test/test_block.ml
@@ -68,6 +68,52 @@ let test_merge_media_combines_same_condition () =
      String.iter (fun c -> if c = '@' then incr media_count) out;
      !media_count = 1)
 
+(* CSS Conditional Rules 5 sec. 5: a [@container] rule applies when its
+   container name and query both match, so two adjacent rules sharing both
+   evaluate identically and merge. A [style()] query is one query whatever it
+   spells, values and ranges included. *)
+let test_merge_containers_by_condition () =
+  let merged condition =
+    let css =
+      String.concat ""
+        [
+          "@container ";
+          condition;
+          "{.a{color:red}}@container ";
+          condition;
+          "{.b{color:blue}}";
+        ]
+    in
+    Block.merge_consecutive_containers ~optimize_merged_block:id (block css)
+  in
+  List.iter
+    (fun (name, condition) ->
+      Alcotest.(check int)
+        (name ^ ": adjacent same-condition @container blocks merge into one")
+        1
+        (List.length (merged condition)))
+    [
+      ("size query", "(min-width: 100px)");
+      ("boolean style query", "style(--x)");
+      ("style declaration query", "style(--x: 1)");
+      ("style range query", "style(1px < --w < 5px)");
+      ("compound style query", "style((--x: 1) and (--y: 2))");
+      ("named style query", "card style(--x: 1)");
+    ]
+
+(* Two style queries that ask different things gate different content, so they
+   stay two rules. *)
+let test_merge_containers_keeps_distinct_conditions () =
+  let stmts =
+    block
+      "@container style(--x: 1){.a{color:red}}@container style(--x: \
+       2){.b{color:blue}}"
+  in
+  Alcotest.(check int)
+    "@container blocks with different style queries stay separate" 2
+    (List.length
+       (Block.merge_consecutive_containers ~optimize_merged_block:id stmts))
+
 let test_drop_empty_rules () =
   let stmts = block ".a{}.b{color:red}.c{}" in
   let out = render (Block.drop_empty_rules stmts) in
@@ -166,6 +212,10 @@ let suite =
         test_merge_layers_combines_escaped_dot;
       Alcotest.test_case "merge same-condition @media" `Quick
         test_merge_media_combines_same_condition;
+      Alcotest.test_case "merge same-condition @container" `Quick
+        test_merge_containers_by_condition;
+      Alcotest.test_case "keep distinct-condition @container" `Quick
+        test_merge_containers_keeps_distinct_conditions;
       Alcotest.test_case "drop empty rules" `Quick test_drop_empty_rules;
       Alcotest.test_case "drop empty @-moz-document" `Quick
         test_drop_empty_moz_document;

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -116,6 +116,61 @@ let test_compare () =
     "px < named" true
     (compare (Min_width_px 640) (Named ("x", Min_width_rem 24.)) < 0)
 
+(* A container condition means what it spells, not where it was written, so one
+   condition written twice compares equal wherever the source put it. *)
+let test_compare_ignores_source_position () =
+  let conditions css =
+    match Css.of_string css with
+    | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
+    | Ok { stylesheet; _ } ->
+        List.filter_map
+          (function
+            | Stylesheet.Container (_, condition, _) -> condition | _ -> None)
+          stylesheet
+  in
+  let pair condition =
+    conditions
+      (String.concat ""
+         [
+           "@container ";
+           condition;
+           "{.a{color:red}}@container ";
+           condition;
+           "{.b{color:blue}}";
+         ])
+  in
+  List.iter
+    (fun (name, condition) ->
+      match pair condition with
+      | [ first; second ] ->
+          Alcotest.(check int)
+            (name ^ ": one condition written twice compares equal")
+            0
+            (Css.Container.compare first second)
+      | got ->
+          Alcotest.failf "%s: expected two container conditions, got %d" name
+            (List.length got))
+    [
+      ("size query", "(min-width: 100px)");
+      ("boolean style query", "style(--x)");
+      ("style declaration query", "style(--x: 1)");
+      ("style range query", "style(1px < --w < 5px)");
+      ("compound style query", "style((--x: 1) and (--y: 2))");
+    ];
+  (* Ignoring source positions must not flatten the values themselves. *)
+  match
+    conditions
+      "@container style(--x: 1){.a{color:red}}@container style(--x: \
+       2){.b{color:blue}}"
+  with
+  | [ first; second ] ->
+      Alcotest.(check bool)
+        "style queries with different values stay distinct" true
+        (Css.Container.compare first second <> 0)
+  | got ->
+      Alcotest.failf "expected two container conditions, got %d"
+        (List.length got)
+
 let test_kind () =
   let open Css.Container in
   Alcotest.(check bool)
@@ -207,6 +262,8 @@ let tests =
       test_case "spec container query level 3 vectors" `Quick
         spec_container_l3_vectors;
       test_case "compare" `Quick test_compare;
+      test_case "compare ignores source position" `Quick
+        test_compare_ignores_source_position;
       test_case "kind" `Quick test_kind;
       test_case "spec container compare edges" `Quick
         test_spec_container_compare_edges;


### PR DESCRIPTION
`@container style(--x: 1)` blocks were never merged with an identical neighbour, because the condition comparison reached the source byte offsets every token carries and two byte-identical queries written at different offsets compared unequal. Size queries and the bare `style(--x)` form were unaffected, so the output stayed correct and only grew larger.