### PR TITLE
reader: read an integer only from a whole, in-range number

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,10 @@ answers.
 
 ### Parsing
 
+- `Reader.int` raises `Parse_error` on a number with a fractional part or one
+  outside the `int` range. It truncated `3.9` to `3` and answered `-1` for
+  `1e30`, `1e999` and `9223372036854775808`, `int_of_float` being undefined
+  past that range (#466)
 - `border-inline`, `border-inline-start`, `border-inline-end`,
   `border-block-start` and `border-block-end` keep their value. None of the five
   had a value reader, so the declaration was dropped with a warning and a file

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -618,7 +618,14 @@ let number ?(allow_negative = true) t =
     err_invalid t "negative values not allowed"
   else result
 
-let int t = int_of_float (number t)
+let int t =
+  let v = number t in
+  (* [float_of_int max_int] rounds up to 2^62, so bound on [float_of_int
+     min_int], which is exact, and its negation. *)
+  let low = float_of_int min_int in
+  if v < low || v >= -.low then err_invalid t "integer (out of range)"
+  else if Float.is_integer v then int_of_float v
+  else err_invalid t "integer (not a whole number)"
 
 let hex t =
   let buf = Buffer.create 6 in

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -192,7 +192,8 @@ val number : ?allow_negative:bool -> t -> float
     rejects negative numbers. Default: true. *)
 
 val int : t -> int
-(** [int t] reads an integer. *)
+(** [int t] reads an integer. Raises Parse_error on a value with a fractional
+    part, such as [3.9], and on one outside the [int] range, such as [1e30]. *)
 
 val hex : t -> int
 (** [hex t] reads a hexadecimal number (without 0x prefix). *)

--- a/test/test_reader.ml
+++ b/test/test_reader.ml
@@ -465,6 +465,43 @@ let numbers () =
   let n = number r in
   Alcotest.(check (float 0.001)) "leading dot with exponent" 500.0 n
 
+(* Test integer parsing *)
+let integers () =
+  (* Whole numbers round-trip, sign included *)
+  let r = of_string "42" in
+  let n = int r in
+  Alcotest.(check int) "plain integer" 42 n;
+
+  let r = of_string "-17" in
+  let n = int r in
+  Alcotest.(check int) "negative integer" (-17) n;
+
+  let r = of_string "0" in
+  let n = int r in
+  Alcotest.(check int) "zero" 0 n;
+
+  (* A fractional value is not an integer *)
+  let r = of_string "3.9" in
+  check_raises "fractional"
+    (parse_error_expected "invalid integer (not a whole number)" r) (fun () ->
+      ignore (int r));
+
+  (* Values outside the OCaml int range *)
+  let r = of_string "1e999" in
+  check_raises "infinite"
+    (parse_error_expected "invalid integer (out of range)" r) (fun () ->
+      ignore (int r));
+
+  let r = of_string "1e30" in
+  check_raises "past max_int"
+    (parse_error_expected "invalid integer (out of range)" r) (fun () ->
+      ignore (int r));
+
+  let r = of_string "9223372036854775808" in
+  check_raises "past 2^63"
+    (parse_error_expected "invalid integer (out of range)" r) (fun () ->
+      ignore (int r))
+
 (* Test unit parsing *)
 let units () =
   (* Units are parsed as identifiers *)
@@ -1498,6 +1535,7 @@ let suite =
       test_case "commit" `Quick commit_case;
       (* Value parsing *)
       test_case "numbers" `Quick numbers;
+      test_case "integers" `Quick integers;
       test_case "units" `Quick units;
       test_case "idents" `Quick tests_idents;
       test_case "string literals" `Quick string_literals;


### PR DESCRIPTION
`Reader.int` used to answer with a number the input never named: `3.9` read as `3`, and `1e30`, `1e999` and `9223372036854775808` all read as `-1`. It now raises `Parse_error` the way the neighbouring readers do; nothing in the library or the CLI calls it, so only an API caller sees the new failure.
