### PR TITLE
css: keep an at-rule cascade cannot interpret

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -180,6 +180,12 @@ answers.
   (#404)
 - `@page { @top-center { } }` no longer takes its `@page` with it. An empty
   margin box is elided on output, as an empty style rule already was (#405)
+- An at-rule cascade has no handler for reaches the output with its block
+  intact, where `cascade fmt` deleted it and every rule inside it without
+  saying so. CSS Syntax 3 sec. 5.4.2 consumes an at-rule whatever its
+  at-keyword; discarding one is the user agent's step, and
+  `Optimize.drop_unknown_at_rules` serves a caller writing for a browser
+  (#469)
 
 ### Printing
 

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -1450,11 +1450,37 @@ let test_no_comments_in_output buf =
       check "lenient-minified" (Css.to_string ~minify:true parsed.stylesheet);
       check "lenient-pretty" (Css.to_string ~minify:false parsed.stylesheet)
 
+(* Every warning kind but one names something lenient mode repairs: a rejected
+   value or selector is dropped, an unterminated node is closed, so the repair
+   is done once and the reparse is silent. [Unknown_at_rule] names no defect.
+   CSS Syntax 3 sec. 5.4.2 consumes an at-rule whatever its at-keyword, and sec.
+   5.5.2 keeps the block it consumes, so an at-keyword cascade has no handler
+   for is well-formed CSS carrying no grammar cascade knows - discarding it is
+   the user agent's step (CSS 2.1 sec. 4.2), and a transform that took it would
+   delete every construct newer than its own vocabulary. There is no repair that
+   both keeps the at-rule and clears the notice, because the notice is about the
+   name and the name is the data. So it recurs on every reparse by design, and
+   the two properties below, which measure repair, read it apart from the kinds
+   that do report one. *)
+let is_unknown_at_keyword (err : Error.t) =
+  match err.Error.kind with Error.Unknown_at_rule _ -> true | _ -> false
+
+(* Count them rather than name them: an at-keyword's spelling is not stable
+   across a roundtrip, since a source byte outside ASCII comes back as the hex
+   escape for the code point it denotes, exactly as a selector's does ([.\xb5x]
+   serialises to [.\b5 x]). Serialisation splitting one at-rule in two, or
+   minting one the input never held, still moves the count. *)
+let unknown_at_rule_count warnings =
+  List.length (List.filter is_unknown_at_keyword warnings)
+
 (* Lenient output is strict-parseable: after lenient recovery, the serialized
    stylesheet must be acceptable to strict mode. This is the "best-minifier"
-   guarantee: feed lenient any garbage, get clean spec-compliant CSS out.
-   Equivalent to [recovery is total] above via the dual-mode invariant, but
-   stated directly in terms of strict acceptance. *)
+   guarantee: feed lenient any garbage, get clean spec-compliant CSS out. The
+   one thing strict may still reject is an at-keyword it had no handler for on
+   the way in, which lenient carried through rather than deleting. Strict stops
+   at the first warning, so an unrecognised at-rule sitting ahead of a real
+   defect hides it here; [recovery is total] below reads the whole warning list
+   and fails on that case. *)
 let test_lenient_output_strict_parseable buf =
   match Css.of_string ~strict:false buf with
   | Error _ -> ()
@@ -1462,6 +1488,10 @@ let test_lenient_output_strict_parseable buf =
       let serialized = Css.to_string ~minify:true parsed.stylesheet in
       match Css.of_string ~strict:true serialized with
       | Ok _ -> ()
+      | Error err
+        when is_unknown_at_keyword err
+             && unknown_at_rule_count parsed.warnings > 0 ->
+          ()
       | Error err ->
           failf
             "lenient output is not strict-parseable: lenient cleaned %S to %S \
@@ -1469,9 +1499,13 @@ let test_lenient_output_strict_parseable buf =
             buf serialized
             (Cascade.Error.to_string err))
 
-(* Recovery is total: after lenient parse, the recovered AST is clean - so
-   re-parsing its serialization in lenient mode must yield zero warnings.
-   Otherwise the parser kept invalid material inside the AST. *)
+(* Recovery is total: after lenient parse, everything the recovered AST still
+   holds is material cascade can read back, so re-parsing its serialization in
+   lenient mode reports no repairable defect. A warning of any other kind means
+   the parser kept invalid material inside the AST and laundered the error
+   through the serializer instead of fixing it. The unrecognised at-rules that
+   do recur must be ones the input already carried: minting one is the same bug
+   wearing the exempt kind. *)
 let test_lenient_recovery_is_total buf =
   match Css.of_string ~strict:false buf with
   | Error _ -> ()
@@ -1485,11 +1519,24 @@ let test_lenient_recovery_is_total buf =
             serialized
             (Cascade.Error.to_string err)
       | Ok reparsed ->
-          if reparsed.Css.warnings <> [] then
+          let defects =
+            List.filter
+              (fun w -> not (is_unknown_at_keyword w))
+              reparsed.Css.warnings
+          in
+          if defects <> [] then
             failf
               "lenient recovery is not total: recovered AST re-serialized to \
-               CSS that still emits warnings: %S -> %S"
-              buf serialized)
+               CSS that still emits warnings: %S -> %S (%s)"
+              buf serialized
+              (String.concat "; " (List.map Cascade.Error.to_string defects));
+          let carried = unknown_at_rule_count parsed.warnings in
+          let reported = unknown_at_rule_count reparsed.Css.warnings in
+          if reported > carried then
+            failf
+              "lenient recovery is not total: serialization turned %d \
+               unrecognised at-rule(s) into %d: %S -> %S"
+              carried reported buf serialized)
 
 (* Strict output reparses strictly: if [Css.of_string ~strict:true] accepted the
    input, the serialized output must also be strict-accepted (no new warnings
@@ -1781,7 +1828,7 @@ let recovery_cases =
       test_strict_output_reparses_strictly;
     test_case "optimize preserves strict-validity" [ bytes ]
       test_optimize_preserves_strict_validity;
-    test_case "lenient recovery is total: re-serialize yields no warnings"
+    test_case "lenient recovery is total: re-serialize repairs nothing further"
       [ bytes ] test_lenient_recovery_is_total;
     test_case "lenient output is strict-parseable" [ bytes ]
       test_lenient_output_strict_parseable;

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -663,14 +663,15 @@ and statement_for_inline ~live ~keep_layers statement =
   | statement -> [ map_statement_children inline_block statement ]
 
 (* Pure serialiser: walk the AST and emit CSS, no optimise/theme/inline-vars
-   rewriting. Spec recovery (drop invalid declarations, unknown at-rules, empty
-   rules) still applies - browsers discard those at parse, so it keeps the
-   output observationally equal to a fresh parse, not an optimisation. Compose
-   {!optimize}, {!resolve_theme}, {!inline_vars} upstream when needed. *)
+   rewriting. Spec recovery (drop invalid declarations, empty rules) still
+   applies - browsers discard those at parse, so it keeps the output
+   observationally equal to a fresh parse, not an optimisation. An at-rule with
+   no handler is not in that set: the browser ignoring it is a cascade step, and
+   a serialiser has no agent to be. Compose {!optimize}, {!resolve_theme},
+   {!inline_vars} upstream when needed. *)
 let to_string ?(minify = false) ?indent ?lossless ?enforce_spec stylesheet =
   let stylesheet =
-    stylesheet |> Optimize.drop_invalid |> Optimize.drop_unknown_at_rules
-    |> Optimize.drop_empty_rules
+    stylesheet |> Optimize.drop_invalid |> Optimize.drop_empty_rules
   in
   Stylesheet.to_string ~minify ?indent ?lossless ?enforce_spec stylesheet
 
@@ -679,8 +680,7 @@ let pp = to_string
 (* Append the serialised stylesheet to [buf]. *)
 let to_buffer buf ?(minify = false) ?indent ?lossless ?enforce_spec stylesheet =
   let stylesheet =
-    stylesheet |> Optimize.drop_invalid |> Optimize.drop_unknown_at_rules
-    |> Optimize.drop_empty_rules
+    stylesheet |> Optimize.drop_invalid |> Optimize.drop_empty_rules
   in
   let pp ctx () = Stylesheet.pp_stylesheet ctx stylesheet in
   Pp.to_buffer ~minify ?indent ?lossless ?enforce_spec buf pp ()

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -557,9 +557,9 @@ let drop_invalid (stylesheet : t) : t =
     stylesheet
 
 (** [drop_unknown_at_rules] removes [Unknown_at_rule] statements at every block
-    depth. Used in [--minify] alongside [drop_invalid] so the typed warnings
-    emitted at parse time materialise as a dropped rule, matching CSS Syntax 3
-    sec. 5.4.1 (unknown at-rules are discarded). *)
+    depth, matching what a user agent applies of a stylesheet (CSS 2.1 sec. 4.2)
+    rather than what a transform may hand the next reader of one. Opt in when
+    the output has exactly one consumer and it is a browser. *)
 let drop_unknown_at_rules (stylesheet : t) : t =
   edit_statements
     (function Unknown_at_rule _ -> List.Drop | _ -> List.Keep)
@@ -800,12 +800,13 @@ let normalize_live_declarations ~ctx ~lossless decls =
 
 (* An [@property] registration holds a typed initial value rather than a
    declaration, so it is the one statement whose value
-   [map_statement_declarations] does not reach; every other statement either is
-   an unknown at-rule, dropped per CSS Syntax 3 sec. 5.4.1, or has its
-   declarations normalised wherever that walk finds them. *)
+   [map_statement_declarations] does not reach; every other statement either
+   carries an unknown at-rule's body as opaque source text, which has no grammar
+   to normalise against, or has its declarations normalised wherever that walk
+   finds them. *)
 let sanitize_statement ~ctx ~lossless (s : statement) : statement List.edit =
   match s with
-  | Unknown_at_rule _ -> List.Drop
+  | Unknown_at_rule _ -> List.Keep
   | Property r ->
       let initial_value =
         match r.initial_value with

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -94,9 +94,11 @@ val drop_invalid : t -> t
 
 val drop_unknown_at_rules : t -> t
 (** [drop_unknown_at_rules ss] removes every [Unknown_at_rule] statement at any
-    block depth. CSS Syntax 3 sec. 5.4.1 says an unknown at-rule is discarded;
-    the parser preserves them in the AST for fidelity, and minify-time
-    canonicalization then drops them. *)
+    block depth, along with whatever it contains. A user agent ignores an
+    at-rule it has no handler for (CSS 2.1 sec. 4.2), so this projects a
+    stylesheet onto what one browser applies of it. Serialisation does not do
+    this: the reader of a transform's output is not always a browser, and an
+    agent that later implements the name would render the two differently. *)
 
 val drop_empty_rules : t -> t
 (** [drop_empty_rules ss] removes top-level rules and at-rule frames whose body

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3101,6 +3101,10 @@ let read_viewport_with_prefix prefix at_keyword (r : Cursor.t) : statement =
 let read_viewport = read_viewport_with_prefix Standard "viewport"
 let read_ms_viewport = read_viewport_with_prefix Ms_prefixed "-ms-viewport"
 
+(* CSS Syntax 3 sec. 5.4.6: an unclosed block runs to EOF, so its slice has no
+   closer to exclude and instead carries whatever [}] an unterminated nested
+   construct swallowed on the way. The serializer supplies its own closer, so
+   drop those or each round-trip stacks another one. *)
 let trim_unknown_block_body body =
   let rec trim_end i =
     if i < 0 then 0
@@ -3109,18 +3113,16 @@ let trim_unknown_block_body body =
       | '}' | ' ' | '\t' | '\n' | '\r' -> trim_end (i - 1)
       | _ -> i + 1
   in
-  let n = String.length body in
-  String.sub body 0 (trim_end (n - 1))
+  String.sub body 0 (trim_end (String.length body - 1))
 
-let unknown_block_body slice value =
-  match value with
-  | [] -> ""
-  | _ ->
-      let first = Component.source_loc (List.hd value) in
-      let last =
-        Component.source_loc (List.nth value (List.length value - 1))
-      in
-      slice first.Loc.start_pos last.Loc.end_pos |> trim_unknown_block_body
+(* An unrecognised at-rule has no grammar to re-serialise its body from, so the
+   body travels as the source text between its own braces. Slice the block's own
+   span, not its child components: the children stop short of the closer
+   whenever the body ends in a nested block ([@foo{a{b:c}}]). *)
+let unknown_block_body slice (block : Component.block Component.node) =
+  let start = block.loc.Loc.start_pos + 1 in
+  if block.node.Component.closed then slice start (block.loc.Loc.end_pos - 1)
+  else slice start block.loc.Loc.end_pos |> trim_unknown_block_body
 
 (* CSS Syntax 3 sec. 5.5.2 "consume an at-rule": after the at-keyword has been
    consumed, walk components until we hit [;] (no block) or [{...}] (block). Raw
@@ -3141,14 +3143,9 @@ let read_unknown_at_rule name (r : Cursor.t) : statement =
     | None -> ()
     | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
         ignore (Cursor.next_raw r)
-    | Some (Component.Block { node = { opening = Token.Curly; value; _ }; _ })
+    | Some (Component.Block ({ node = { opening = Token.Curly; _ }; _ } as b))
       ->
-        (* CSS Syntax 3 section 5.5.2: when an unterminated nested block
-           ([(...], [[...]) inside the at-rule's body extends to EOF, the
-           Parser's source slice carries the close [}] and any trailing
-           whitespace from outside the block - trim them so the serializer
-           re-adds its own [}] without stacking. *)
-        block := Option.Some (unknown_block_body slice value);
+        block := Option.Some (unknown_block_body slice b);
         ignore (Cursor.next_raw r)
     | Some comp ->
         let loc = Component.source_loc comp in
@@ -3540,11 +3537,11 @@ let rec read_statement (r : Cursor.t) : statement =
       match List.assoc_opt name table with
       | Some p -> p r
       | None ->
-          (* CSS Syntax 3 sec. 5.4.1: an at-rule with no registered handler is
-             reported via a typed warning so [Css.of_string] partial-recovery
-             can surface it to callers. The prelude/block stay in the AST as
-             [Unknown_at_rule], and [Optimize.drop_unknown] removes them under
-             minify when the user opted into spec-strict canonicalization. *)
+          (* CSS Syntax 3 sec. 5.4.2 consumes an at-rule whatever its name, so
+             the prelude and block stay in the AST as [Unknown_at_rule] and
+             reach the output. The typed warning tells the caller cascade could
+             not interpret it; [Optimize.drop_unknown_at_rules] is there for a
+             caller that wants it gone. *)
           ignore (Cursor.next_raw r);
           let stmt = read_unknown_at_rule name r in
           Cursor.push_warning r (Error.unknown_at_rule loc name);

--- a/test/cli/fmt_unknown_at_rule.t
+++ b/test/cli/fmt_unknown_at_rule.t
@@ -1,0 +1,68 @@
+CLI: an at-rule cascade does not recognise still reaches the output.
+
+CSS Syntax 3 sec. 5.4.2 consumes an at-rule whatever its name, block and
+all. Discarding an unrecognised one is a user-agent step (CSS 2.1 sec.
+4.2), and `cascade fmt` is not the user agent: it cannot know which agent
+reads what it writes. Lightning CSS, esbuild, csso, clean-css and cssnano
+all keep the at-rule and its block.
+
+The body of an unrecognised at-rule has no known grammar, so it is
+carried as source text; every input below is written tight so the text
+carried is the text shown.
+
+A statement-form at-rule keeps its prelude and its neighbour.
+
+  $ cat > stmt.css <<CSS
+  > @foo bar;
+  > a { color: red }
+  > CSS
+  $ cascade fmt --minify stmt.css 2> err.txt
+  @foo bar;a{color:red}
+  $ grep -c '^warning' err.txt
+  1
+
+A block-form at-rule keeps the rules it contains. Deleting the wrapper
+deletes them too, which is the same silent loss with more of the
+stylesheet in it.
+
+  $ cat > block.css <<CSS
+  > @future x{a{color:red}}
+  > b { color: blue }
+  > CSS
+  $ cascade fmt --minify block.css 2> /dev/null
+  @future x{a{color:red}}b{color:#00f}
+
+The same at any block depth.
+
+  $ cat > nested.css <<CSS
+  > @media screen { @foo bar; d { color: red } }
+  > CSS
+  $ cascade fmt --minify nested.css 2> /dev/null
+  @media screen{@foo bar;d{color:red}}
+
+tw hands cascade `--input-css` written in Tailwind's authoring
+vocabulary, none of which cascade recognises.
+
+  $ cat > tw.css <<CSS
+  > @theme{--color-a:red}
+  > @utility btn{color:red}
+  > .x { color: red }
+  > CSS
+  $ cascade fmt --minify tw.css 2> /dev/null
+  @theme{--color-a:red}@utility btn{color:red}.x{color:red}
+
+An at-rule that is the whole stylesheet is the whole output, so nothing
+was dropped to report and the exit status stays 0.
+
+  $ printf '@foo bar;' | cascade fmt --minify - 2> /dev/null
+  @foo bar;
+
+Pretty output round-trips: re-formatting it is a fixed point, and
+minifying it lands back on the minified form.
+
+  $ cascade fmt block.css > pretty.css 2> /dev/null
+  $ cascade fmt pretty.css 2> /dev/null > pretty2.css
+  $ diff pretty.css pretty2.css && echo identical
+  identical
+  $ cascade fmt --minify pretty.css 2> /dev/null
+  @future x{a{color:red}}b{color:#00f}

--- a/test/interop/lightning/test.ml
+++ b/test/interop/lightning/test.ml
@@ -294,6 +294,71 @@ let format_source_parse_diagnostics (pair : Trace_pairs.t) =
      %s"
     input !parseable (List.length candidates) reports
 
+(* Lowercased at-keyword names in [css], scanned rather than parsed: the point
+   of the check below is to measure Cascade against the cached text without
+   routing through Cascade. Strings and comments are skipped so a [content:
+   "@media"] is not read as a rule. *)
+let at_keywords css =
+  let len = String.length css in
+  let is_name c =
+    (c >= 'a' && c <= 'z')
+    || (c >= 'A' && c <= 'Z')
+    || (c >= '0' && c <= '9')
+    || c = '-' || c = '_'
+    || Char.code c >= 0x80
+  in
+  let rec skip_string quote i =
+    if i >= len then i
+    else if css.[i] = '\\' then skip_string quote (i + 2)
+    else if css.[i] = quote then i + 1
+    else skip_string quote (i + 1)
+  in
+  let rec skip_comment i =
+    if i + 1 >= len then len
+    else if css.[i] = '*' && css.[i + 1] = '/' then i + 2
+    else skip_comment (i + 1)
+  in
+  let rec name_end i =
+    if i < len && is_name css.[i] then name_end (i + 1) else i
+  in
+  let rec scan i acc =
+    if i >= len then acc
+    else
+      match css.[i] with
+      | ('"' | '\'') as q -> scan (skip_string q (i + 1)) acc
+      | '/' when i + 1 < len && css.[i + 1] = '*' ->
+          scan (skip_comment (i + 2)) acc
+      | '@' ->
+          let stop = name_end (i + 1) in
+          let name =
+            String.lowercase_ascii (String.sub css (i + 1) (stop - i - 1))
+          in
+          scan stop (if name = "" then acc else name :: acc)
+      | _ -> scan (i + 1) acc
+  in
+  List.sort_uniq String.compare (scan 0 [])
+
+(* At-keywords Cascade's own parser reported as having no handler. *)
+let unrecognised_at_keywords input =
+  match Css.of_string ~strict:false input with
+  | Error _ -> []
+  | Ok { Css.warnings; _ } ->
+      warnings
+      |> List.filter_map (fun e ->
+          match e.Error.kind with
+          | Error.Unknown_at_rule name -> Some (String.lowercase_ascii name)
+          | _ -> None)
+      |> List.sort_uniq String.compare
+
+(* At-keywords every cached answer kept. *)
+let unanimously_kept_at_keywords (pair : Trace_pairs.t) =
+  match List.map (fun (c : candidate) -> at_keywords c.css) pair.candidates with
+  | [] -> []
+  | first :: rest ->
+      List.fold_left
+        (fun acc kept -> List.filter (fun k -> List.mem k kept) acc)
+        first rest
+
 let classify (pair : Trace_pairs.t) =
   let input = pair.input in
   match cascade_minify input with
@@ -309,8 +374,33 @@ let classify (pair : Trace_pairs.t) =
         @ List.map (fun issue -> Failed_candidate issue) pair.failures
       in
       let best = shortest_length candidates in
+      (* Neither measure below can see a construct Cascade deletes. Length
+         scoring cannot: a deletion always reads as a shorter output.
+         [validate_candidate] cannot either, because it routes the source and
+         the candidate through the same Cascade serializer, so whatever that
+         serializer drops is missing from both sides and the two compare equal.
+         The cached text is the one measure outside that loop. Scope it to the
+         at-rules Cascade's parser says it has no handler for: those are the
+         ones it has no grounds to rewrite, so when every tool that answered
+         kept one, its name has to reach Cascade's output too. At-rules Cascade
+         does understand stay out of scope, since unwrapping a satisfied
+         [@supports] removes the name and keeps the contents. *)
+      let dropped =
+        let kept = at_keywords actual in
+        let unanimous = unanimously_kept_at_keywords pair in
+        unrecognised_at_keywords input
+        |> List.filter (fun k -> List.mem k unanimous && not (List.mem k kept))
+      in
       let outcome =
-        if candidates = [] then Pass
+        if dropped <> [] then
+          Fmt.kstr
+            (fun s -> Mismatch s)
+            "%s\n\
+            \    dropped an at-rule it could not interpret and every cached \
+             answer kept: %s"
+            (display_css actual)
+            (dropped |> List.map (fun k -> "@" ^ k) |> String.concat " ")
+        else if candidates = [] then Pass
         else if String.length actual <= best then Pass
         else
           let shortest =

--- a/test/spec/test.ml
+++ b/test/spec/test.ml
@@ -289,7 +289,14 @@ let syntax_recovery () =
      and warns; strict mode escalates (pinned by [cross_mode_pinning]). *)
   recover ".a,:future-pseudo { color: red } .b { color: blue }" ".b{color:#00f}"
     1;
-  recover "@unknown { .a { color: red } } .b { color: blue }" ".b{color:#00f}" 1;
+  (* CSS Syntax 3 sec. 5.4.2 consumes an at-rule whatever its at-keyword and
+     sec. 5.5.2 keeps the block it consumes, so what recovers here is the rule
+     after the at-rule, not the at-rule itself. Discarding an unrecognised one
+     is the user agent's step (CSS 2.1 sec. 4.2), served by
+     [Optimize.drop_unknown_at_rules]. Its body has no known grammar, so it
+     travels as source text and minify has nothing to shorten it against. *)
+  recover "@unknown { .a { color: red } } .b { color: blue }"
+    "@unknown{ .a { color: red } }.b{color:#00f}" 1;
   recover ".a { color: red" ".a{color:red}" 0
 
 (* {2 CSS Selectors Level 4} https://www.w3.org/TR/selectors-4/ *)

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1563,6 +1563,57 @@ let font_family_value_parser () =
   roundtrip "var(--font-source-sans-pro), system-ui";
   roundtrip "var(--font-ubuntu-mono)"
 
+(* CSS Syntax 3 sec. 5.4.2 "consume an at-rule" builds an at-rule node for any
+   at-keyword, recognised or not; the block it consumes keeps its contents.
+   Discarding an unrecognised at-rule is a user-agent cascade step (CSS 2.1 sec.
+   4.2 "Rules for handling parsing errors"), not a serialisation step, and a
+   transform cannot know which agent reads its output: an agent that later
+   implements the name renders the input and a stripped output differently.
+   Lightning CSS, esbuild, csso, clean-css and cssnano all keep the at-rule and
+   its block. So [to_string] keeps it too, at every block depth, with a body or
+   without one. [Optimize.drop_unknown_at_rules] stays available for a caller
+   that does want user-agent-equivalent output. *)
+let unknown_at_rule_reaches_output () =
+  let parse input =
+    match of_string ~strict:false input with
+    | Ok parsed -> parsed.stylesheet
+    | Error err ->
+        Alcotest.failf "lenient parse rejected %S: %s" input
+          (Cascade.Error.to_string err)
+  in
+  let keeps name input expected =
+    Alcotest.(check string)
+      (name ^ " (serialize)") expected
+      (to_string ~minify:true (parse input));
+    Alcotest.(check string)
+      (name ^ " (optimize)") expected
+      (parse input |> optimize |> to_string ~minify:true)
+  in
+  keeps "a statement-form at-rule reaches the output" "@foo bar;\na{color:red}"
+    "@foo bar;a{color:red}";
+  keeps "a block-form at-rule takes its contents with it"
+    "@future x{a{color:red}}\nb{color:red}"
+    "@future x{a{color:red}}b{color:red}";
+  keeps "an unknown at-rule nested in @media survives"
+    "@media screen{@foo bar;d{color:red}}"
+    "@media screen{@foo bar;d{color:red}}";
+  (* tw hands cascade [--input-css] written in this vocabulary. *)
+  keeps "the Tailwind v4 authoring vocabulary survives"
+    "@theme{--c:red}\n@utility btn{color:red}\n.x{color:red}"
+    "@theme{--c:red}@utility btn{color:red}.x{color:red}";
+  (* An at-rule alone in the stylesheet is the whole output, not nothing. *)
+  keeps "an at-rule that is the entire stylesheet is the entire output"
+    "@foo bar;" "@foo bar;";
+  (* Control: a recognised at-rule is unaffected. *)
+  keeps "a recognised at-rule is unaffected" "@media screen{a{color:red}}"
+    "@media screen{a{color:red}}";
+  (* Pretty output re-parses to the same statement list as the minified one. *)
+  let input = "@future x{a{color:red}}\nb{color:red}" in
+  Alcotest.(check string)
+    "pretty output re-parses to the minified output"
+    "@future x{a{color:red}}b{color:red}"
+    (to_string ~minify:true (parse (to_string (parse input))))
+
 let suite =
   ( "css",
     [
@@ -1625,4 +1676,6 @@ let suite =
       Alcotest.test_case "public parse recovery edges" `Quick public_parse_edges;
       Alcotest.test_case "public bad-string prelude edges" `Quick
         public_bad_string_prelude_edges;
+      Alcotest.test_case "spec unknown at-rule reaches the output" `Quick
+        unknown_at_rule_reaches_output;
     ] )

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1534,9 +1534,11 @@ let spec_lenient_recovery_stylesheets () =
     ".a { color: invalid-color; color: red }" ".a{color:red}" 1;
   lenient_recover "bad declaration keeps sibling rule"
     ".a { color: rgb(300); } .b { color: red }" ".b{color:red}" 1;
-  lenient_recover "unknown at-rule skipped"
+  (* CSS Syntax 3 sec. 5.4.2 consumes the at-rule and its block whatever the
+     name, so what recovers here is the rule after it, not the at-rule. *)
+  lenient_recover "unknown at-rule keeps its neighbour"
     "@unknown-rule { .bad { color: red } } .ok { color: blue }"
-    ".ok{color:#00f}" 1;
+    "@unknown-rule{ .bad { color: red } }.ok{color:#00f}" 1;
   lenient_recover "bad selector list drops rule only"
     ".ok { color: green } .bad:not() { color: red } .next { color: blue }"
     ".ok{color:green}.next{color:#00f}" 1;
@@ -2590,7 +2592,7 @@ let css_syntax_recovery () =
     ".ok { color: green } .bad:not() { color: red }" ".ok{color:green}" 1;
   check_recovery "unknown at-rule"
     "@unknown-rule { .bad { color: red } } .ok { color: blue }"
-    ".ok{color:#00f}" 1
+    "@unknown-rule{ .bad { color: red } }.ok{color:#00f}" 1
 
 let css_syntax_recovery_structural () =
   let declaration_counts stylesheet =
@@ -2670,6 +2672,36 @@ let s3431_unknown_at_rule_prelude_separator () =
   Alcotest.(check string)
     "statement form without a prelude stays unspaced" "@foo;"
     (roundtrips "@foo;")
+
+(* CSS Syntax 3 sec. 5.4.2: an unrecognised at-rule has no grammar to
+   re-serialise its body from, so the body travels as the source text between
+   its braces. That text is what sits between the at-rule's own braces. Taking
+   it from the at-rule's child components instead stops at the last one the
+   lexer produced, which is inside the closer whenever the body ends in a nested
+   block, and the printed at-rule then never closes. Sec. 5.4.6: an unterminated
+   nested construct swallows the closer the other way, leaving none in the
+   source to exclude and one for the serializer to supply. *)
+let s542_unknown_at_rule_block_body () =
+  let printed input =
+    String.trim
+      (Css.Stylesheet.to_string ~minify:true
+         (read_stylesheet (Cursor.of_string input)))
+  in
+  let roundtrips name input expected =
+    Alcotest.(check string) name expected (printed input);
+    Alcotest.(check string)
+      (name ^ " is a fixed point")
+      expected (printed expected)
+  in
+  roundtrips "a body ending in a nested block keeps both closers"
+    "@foo test{div{color:red}}" "@foo test{div{color:red}}";
+  roundtrips "nested blocks all the way down" "@foo{a{b{c:d}}}"
+    "@foo{a{b{c:d}}}";
+  roundtrips "an empty body stays empty" "@foo{}" "@foo{}";
+  roundtrips "an unterminated function does not stack closers" "@foo{a:(b}"
+    "@foo{a:(b}";
+  roundtrips "an unterminated nested block gets one closer" "@foo{a{b:c"
+    "@foo{a{b:c}"
 
 (* Gecko's [@document]/[@-moz-document] takes a comma-separated list of [<url> |
    url-prefix(<string>) | domain(<string>) | media-document(<string>) |
@@ -8622,6 +8654,9 @@ let additional_tests =
     ( "spec CSS Syntax structural recovery",
       `Quick,
       css_syntax_recovery_structural );
+    ( "spec CSS Syntax 5.4.2 unknown at-rule block body",
+      `Quick,
+      s542_unknown_at_rule_block_body );
     ( "spec CSS Syntax 4.3.1 unknown at-rule prelude separator",
       `Quick,
       s3431_unknown_at_rule_prelude_separator );
@@ -9363,7 +9398,8 @@ let additional_tests =
               "warning surfaced" true
               (parsed.Css.warnings <> []);
             Alcotest.(check string)
-              "recovered output" ".a{color:#00f}" (minify parsed.stylesheet)
+              "recovered output" "@unknown{ color: red }.a{color:#00f}"
+              (minify parsed.stylesheet)
         | Error e ->
             Alcotest.failf "non-strict mode should not promote warnings: %s"
               (Error.to_string e) );


### PR DESCRIPTION
`cascade fmt` deleted any at-rule it had no handler for, and every rule inside it, without saying so in the output; CSS Syntax 3 sec. 5.4.2 consumes an at-rule whatever its at-keyword, and discarding one is the user agent's step rather than a serialiser's. `Optimize.drop_unknown_at_rules` stays for a caller whose output goes straight to a browser.

The lightning interop trace held 6 such records and gated none of them: both of its measures ran through the same serialiser, so a construct the serialiser deleted was missing from every side of every comparison.