### PR TITLE
font-face: route every src through one printer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -215,6 +215,14 @@ answers.
   every token carries, so two byte-identical `style(--x: 1)` queries never
   compared equal and their blocks stayed separate, while size queries and the
   bare `style(--x)` form already merged (#465)
+- `--minify` shortens an `src:` declaration outside `@font-face` the way it
+  already shortened the `@font-face` descriptor: `url("a.woff2")` drops its
+  quotes, `local("Arial")` becomes `local(Arial)` and a known `format()`
+  keyword loses its quotes. The two routes into the `src` printer had
+  drifted, and the declaration route spelled a multi-word `format("...")`
+  string unquoted, which no browser reads back as that format. A family name
+  of `default` keeps its quotes on both routes, the reserved word being no
+  `<custom-ident>` (#470)
 - `--minify` keeps the `center` in `position-area: top center`. A lone keyword
   stands for `X span-all`, not `X center`, so dropping it moved the box to a
   different area (#457)

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -93,14 +93,18 @@ let pp_url_arg ctx s =
     Pp.char ctx '"')
   else Pp.string ctx s
 
-let css_wide_keyword s =
+(* CSS Values 4 sec. 3.3: the CSS-wide keywords are not valid [<custom-ident>]s,
+   and neither is the reserved [default]. Both exclusions hold in every ASCII
+   case permutation, so such a name has only its [<string>] spelling. *)
+let excluded_from_custom_ident s =
   match String.lowercase_ascii s with
-  | "initial" | "inherit" | "unset" | "revert" | "revert-layer" -> true
+  | "initial" | "inherit" | "unset" | "revert" | "revert-layer" | "default" ->
+      true
   | _ -> false
 
 let local_name_can_unquote name =
   String.length name > 0
-  && (not (css_wide_keyword name))
+  && (not (excluded_from_custom_ident name))
   && String.for_all
        (function
          | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> true | _ -> false)

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -9,7 +9,6 @@
 
 open Common
 open Values
-open Syntax
 open Properties_intf
 open Prop_common
 
@@ -1968,64 +1967,10 @@ let rec read_font_variation_settings t : font_variation_settings =
     ~calls:[ ("var", read_var) ]
     ~default:read_axis_list t
 
-let pp_font_url ctx s =
-  Pp.string ctx "url(";
-  if url_needs_quotes s then (
-    Pp.char ctx '"';
-    Pp.string ctx s;
-    Pp.char ctx '"')
-  else Pp.string ctx s;
-  Pp.char ctx ')'
-
-let pp_quoted_font_url ctx quote s =
-  Pp.string ctx "url(";
-  Pp.char ctx quote;
-  Pp.string ctx s;
-  Pp.char ctx quote;
-  Pp.char ctx ')'
-
-let pp_font_src_modifiers ctx (format : string option) (tech : string option) =
-  (match format with
-  | None -> ()
-  | Some value ->
-      Pp.space ctx ();
-      Pp.string ctx "format(";
-      Pp.string ctx value;
-      Pp.char ctx ')');
-  match tech with
-  | None -> ()
-  | Some value ->
-      Pp.space ctx ();
-      Pp.string ctx "tech(";
-      Pp.string ctx value;
-      Pp.char ctx ')'
-
-let rec pp_font_src_entry ctx : Font_face.src_entry -> unit = function
-  | Local name ->
-      Pp.string ctx "local(";
-      Pp.char ctx '"';
-      Pp.string ctx name;
-      Pp.char ctx '"';
-      Pp.char ctx ')'
-  | Url { url; format; tech } ->
-      pp_font_url ctx url;
-      pp_font_src_modifiers ctx format tech
-  | Quoted_url { url; quote; format; tech } ->
-      pp_quoted_font_url ctx quote url;
-      pp_font_src_modifiers ctx format tech
-  | Var var -> pp_var pp_font_src ctx var
-
-and pp_font_src ctx entries =
-  let first = ref true in
-  List.iter
-    (fun entry ->
-      if !first then first := false
-      else (
-        Pp.char ctx ',';
-        Pp.space_if_pretty ctx ());
-      pp_font_src_entry ctx entry)
-    entries
-
+(* [src] has one value type, one reader and one printer. The [@font-face]
+   descriptor and every [src:] declaration route through [Font_face.pp], so the
+   two spellings cannot drift apart. *)
+let pp_font_src : Font_face.src Pp.t = Font_face.pp
 let read_font_src = Font_face.read_src
 
 let normalize_font_size (fs : font_size) : font_size =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1106,11 +1106,7 @@ let pp_font_face_descriptor : font_face_descriptor Pp.t =
         (fun ctx fams ->
           Pp.list ~sep:Pp.comma Properties.pp_font_family ctx fams)
         families
-  | Src value ->
-      pp_descriptor "src"
-        (fun ctx v ->
-          Pp.string ctx (Font_face.string_of_src ~minify:(Pp.minified ctx) v))
-        value
+  | Src value -> pp_descriptor "src" Properties.pp_font_src value
   | Font_style style ->
       pp_descriptor "font-style" Properties.pp_font_style style
   | Font_style_range (min_style, max_style) ->

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -521,6 +521,137 @@ let spec_family_name_reserved_words () =
       Alcotest.failf "family names spelled with a reserved word:\n%s"
         (String.concat "\n" mismatches)
 
+(* [src] has one value type and one reader, so the [@font-face] descriptor and
+   an [src:] declaration are two routes into one printer and must spell the same
+   value the same way. CSS Fonts 4 sec. 4.3: [<font-src> = <url>
+   [format(<font-format>)]? [tech(<font-tech>#)]? | local(<font-family-name>)],
+   with [<font-family-name> = <string> | <custom-ident>+] (CSS Fonts 4 sec.
+   2.1.1) and [<font-format>] a [<string>] or one of the seven format keywords.
+   Each of the two notations a [<url>], a family name and a format spells is
+   valid, so minify picks the shorter one and pretty keeps the authored one.
+   Every route is checked minified and pretty, and each output is re-read in
+   strict mode: what one route emits, the other reads back. *)
+let check_src_printer_routes (name, value, minified, pretty) =
+  let fail fmt = Fmt.kstr (fun s -> Some s) fmt in
+  let route label ~minify input expected =
+    match Css.of_string ~strict:false input with
+    | Error e ->
+        fail "%s / %s: parse rejected %S\n  %s" name label input
+          (Error.to_string e)
+    | Ok { Css.stylesheet; _ } -> (
+        let actual = Css.to_string ~minify stylesheet |> String.trim in
+        if not (String.equal actual expected) then
+          fail "%s / %s\n  input:    %S\n  expected: %S\n  actual:   %S" name
+            label input expected actual
+        else
+          match Css.of_string ~strict:true actual with
+          | Error e ->
+              fail "%s / %s: output does not read back: %S\n  %s" name label
+                actual (Error.to_string e)
+          | Ok _ -> None)
+  in
+  let descriptor v =
+    String.concat "" [ "@font-face{font-family:F;src:"; v; "}" ]
+  in
+  let declaration v = String.concat "" [ ".a{src:"; v; "}" ] in
+  List.filter_map Fun.id
+    [
+      route "@font-face descriptor, minified" ~minify:true (descriptor value)
+        (descriptor minified);
+      route "src declaration, minified" ~minify:true (declaration value)
+        (declaration minified);
+      route "@font-face descriptor, pretty" ~minify:false (descriptor value)
+        (String.concat ""
+           [ "@font-face {\n  font-family: F;\n  src: "; pretty; ";\n}" ]);
+      route "src declaration, pretty" ~minify:false (declaration value)
+        (String.concat "" [ ".a {\n  src: "; pretty; ";\n}" ]);
+    ]
+
+let spec_src_printer_routes () =
+  match
+    List.concat_map check_src_printer_routes
+      [
+        (* CSS Values 4 sec. 3.4: [url(<string>)] and the bare [<url-token>]
+           spell the same URL, so the quotes go under minify unless the body
+           holds a character the bare form cannot carry. *)
+        ( "a quoted url drops its quotes under minify",
+          "url(\"a.woff2\")",
+          "url(a.woff2)",
+          "url(\"a.woff2\")" );
+        ( "a single-quoted url drops its quotes under minify",
+          "url('a.woff2')",
+          "url(a.woff2)",
+          "url('a.woff2')" );
+        ("a bare url stays bare", "url(a.woff2)", "url(a.woff2)", "url(a.woff2)");
+        ( "a url holding a space keeps its quotes",
+          "url(\"a b.woff2\")",
+          "url(\"a b.woff2\")",
+          "url(\"a b.woff2\")" );
+        (* CSS Fonts 4 sec. 2.1.1: a [<font-family-name>] is a [<string>] or a
+           [<custom-ident>+], so an ident name drops its quotes under minify. *)
+        ( "a local ident name drops its quotes under minify",
+          "local(\"Arial\")",
+          "local(Arial)",
+          "local(\"Arial\")" );
+        ( "a bare local ident name reads as the same name",
+          "local(Arial)",
+          "local(Arial)",
+          "local(\"Arial\")" );
+        ( "a local name with an underscore drops its quotes",
+          "local(\"Brand_2\")",
+          "local(Brand_2)",
+          "local(\"Brand_2\")" );
+        ( "a local name holding a space keeps its quotes",
+          "local(\"Noto Sans\")",
+          "local(\"Noto Sans\")",
+          "local(\"Noto Sans\")" );
+        (* CSS Values 4 sec. 3.3: the CSS-wide keywords and the reserved
+           [default] are not valid [<custom-ident>]s, in every ASCII case
+           permutation, so those names have only the [<string>] spelling. *)
+        ( "a local CSS-wide keyword name keeps its quotes",
+          "local(\"inherit\")",
+          "local(\"inherit\")",
+          "local(\"inherit\")" );
+        ( "the reserved default keeps its quotes in local()",
+          "local(\"default\")",
+          "local(\"default\")",
+          "local(\"default\")" );
+        ( "the reserved default is excluded in every ASCII case permutation",
+          "local(\"DEFAULT\")",
+          "local(\"DEFAULT\")",
+          "local(\"DEFAULT\")" );
+        (* CSS Syntax 3 sec. 4.3.9: a name starting with a digit does not start
+           an ident sequence, so it has no unquoted spelling. *)
+        ( "a local name starting with a digit keeps its quotes",
+          "local(\"2Cool\")",
+          "local(\"2Cool\")",
+          "local(\"2Cool\")" );
+        (* CSS Fonts 4 sec. 4.3: [<font-format>] is a [<string>] or one of
+           [collection], [embedded-opentype], [opentype], [svg], [truetype],
+           [woff] and [woff2]; only those seven have a bare spelling. *)
+        ( "a known format keyword drops its quotes under minify",
+          "url(\"a.woff2\") format(\"woff2\")",
+          "url(a.woff2)format(woff2)",
+          "url(\"a.woff2\") format(\"woff2\")" );
+        ( "a format string that is no keyword keeps its quotes",
+          "url(a.woff2) format(\"weird thing\")",
+          "url(a.woff2)format(\"weird thing\")",
+          "url(a.woff2) format(\"weird thing\")" );
+        ( "format and tech both follow the url",
+          "url(a.woff2) format(\"truetype\") tech(variations)",
+          "url(a.woff2)format(truetype)tech(variations)",
+          "url(a.woff2) format(\"truetype\") tech(variations)" );
+        ( "a source list keeps its order and separator",
+          "local(\"Brand\"),url(\"b.woff2\") format(\"woff2\")",
+          "local(Brand),url(b.woff2)format(woff2)",
+          "local(\"Brand\"), url(\"b.woff2\") format(\"woff2\")" );
+      ]
+  with
+  | [] -> ()
+  | mismatches ->
+      Alcotest.failf "src printer routes disagree with the spec oracle:\n%s"
+        (String.concat "\n" mismatches)
+
 let suite =
   let open Alcotest in
   ( "font_face",
@@ -553,4 +684,5 @@ let suite =
         spec_family_name_ident_start;
       test_case "spec family name reserved words" `Quick
         spec_family_name_reserved_words;
+      test_case "spec src printer routes" `Quick spec_src_printer_routes;
     ] )

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -3354,7 +3354,9 @@ let fetch_url_boundary () =
     "background-image: url(../img/logo.svg);";
   check_declaration ~expected:"cursor:url(cursor.cur),auto"
     "cursor: url(cursor.cur), auto";
-  check_declaration ~expected:"src:url(brand.woff2) format(woff2)"
+  (* A [<url-token>] ends at its [)], so [format(] needs no separator after it
+     and minify drops the space, as it does after [@import] just below. *)
+  check_declaration ~expected:"src:url(brand.woff2)format(woff2)"
     "src: url(brand.woff2) format(woff2)";
   check_import_rule ~expected:"@import\"theme.css\"supports(display:);"
     "@import url(theme.css) supports(display:);";


### PR DESCRIPTION
`src` had one value type and one reader but two printers, so a `src:` declaration outside `@font-face` kept the quotes the descriptor dropped under `--minify`, and spelled a multi-word `format("...")` string unquoted, which no browser reads back as that format. The surviving printer also stops unquoting the reserved `default`, which is no `<custom-ident>`.

Needs arbitration: `test_stylesheet.ml` expected `src:url(brand.woff2) format(woff2)` where `test_font_face.ml` expected `url(brand.woff2)format(woff2)` for the same value. Both pre-date this branch and only both passed because there were two printers; this keeps the spec-cited one.
