### PR TITLE
declaration: compare a value the way its hash does

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -210,6 +210,9 @@ answers.
 
 ### Minification
 
+- `--minify` merges two rules that declare the same NaN, such as
+  `opacity: calc(infinity - infinity)`. Structural equality read a NaN as
+  different from itself, which the declaration hash never did (#471)
 - `--minify` merges adjacent `@container` blocks whose `style()` conditions
   are written the same way. The comparison reached the source byte offsets
   every token carries, so two byte-identical `style(--x: 1)` queries never

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -32,8 +32,8 @@ let theme_guarded ~var_name decl =
 
 (* Read the cached structural hash. Two declarations that minify to the same
    text always produce the same value here; the converse may fail on hash
-   collisions, so callers still confirm equality with [=] before treating two
-   declarations as equal. *)
+   collisions, so callers still confirm with [equal_declaration] before treating
+   two declarations as equal. *)
 let hash = function
   | Declaration { hash; _ } -> hash
   | Theme_guarded { hash; _ } -> hash
@@ -522,7 +522,14 @@ let rec property_name decl =
    property name" directly - no [Pp], no [Obj.repr]. *)
 type prop_key = Key : 'a Properties.property -> prop_key [@@unboxed]
 
-let equal_declaration (a : declaration) b = a = b
+(* The pack hides the value's type, so nothing witnesses a per-property
+   comparison and the value is compared by walking its representation - the same
+   walk [v] hashes. That walk has to be [compare], not [(=)]: IEEE leaves a NaN
+   equal to nothing, itself included, so [(=)] read [opacity:calc(NaN)] as
+   different from itself while [hash], which normalises NaN, read it as the
+   same. CSS has one NaN, a parse-time keyword of the <number> grammar (Values 4
+   sec. 10.7.2) serialised as calc(NaN) (sec. 10.13). *)
+let equal_declaration (a : declaration) b = Stdlib.compare a b = 0
 let equal_prop_key (a : prop_key) b = a = b
 let hash_prop_key (key : prop_key) = Hashtbl.hash key
 

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -167,7 +167,10 @@ val property_name : declaration -> string
 type prop_key = Key : 'a Properties.property -> prop_key [@@unboxed]
 
 val equal_declaration : declaration -> declaration -> bool
-(** [equal_declaration a b] tests declarations for structural equality. *)
+(** [equal_declaration a b] tests declarations for structural equality. A NaN
+    equals itself here, as it does under {!hash}: CSS has one NaN, a keyword of
+    the [<number>] grammar (Values 4 sec. 10.7.2) serialised as [calc(NaN)]
+    (sec. 10.13). *)
 
 val equal_prop_key : prop_key -> prop_key -> bool
 (** [equal_prop_key a b] tests property identities for equality. *)

--- a/test/cli/minify_nan_merge.t
+++ b/test/cli/minify_nan_merge.t
@@ -1,0 +1,15 @@
+CLI: --minify merges two rules that declare the same NaN.
+
+CSS Values 4 sec. 10.7.2 defines NaN as a keyword of the <number> grammar,
+resolved at parse time, and sec. 10.13 serialises every NaN-valued calculation
+as calc(NaN). One value, one spelling: two rules that declare it hold the same
+declaration and merge, exactly as the ordinary-float pair below does.
+
+  $ cat > nan.css <<CSS
+  > .a { opacity: calc(infinity - infinity) }
+  > .b { opacity: calc(infinity - infinity) }
+  > .c { opacity: .5 }
+  > .d { opacity: .5 }
+  > CSS
+  $ cascade --minify nan.css
+  .a,.b{opacity:calc(NaN)}.c,.d{opacity:.5}

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2982,10 +2982,71 @@ let vendor_prefixed_shorthands () =
     (fun css -> check_sheet_roundtrip "vendor prefix" ("a{" ^ css ^ "}"))
     cases
 
+(* CSS Values 4 sec. 10.7.2 makes NaN a keyword of the <number> grammar that
+   resolves at parse time, and sec. 10.13 serialises every NaN-valued
+   calculation as calc(NaN): CSS has one NaN and one spelling for it, so two
+   declarations that spell it are one declaration. The cached [Declaration.hash]
+   already answers that way, and [Shorthand.same_minified_declaration] merges
+   rules on [hash a = hash b && equal_declaration a b], so the two have to agree
+   or a merge is lost. *)
+let optimized_declarations css =
+  Css.of_string_exn css |> Css.optimize |> Css.statements
+  |> List.concat_map (function
+    | Css.Stylesheet.Rule r -> r.Css.Stylesheet.declarations
+    | _ -> [])
+
+let sole_declaration css =
+  match optimized_declarations css with
+  | [ d ] -> d
+  | l ->
+      Alcotest.failf "%s: expected one declaration, got %d" css (List.length l)
+
+let minified css =
+  Css.to_string ~minify:true (Css.optimize (Css.of_string_exn css))
+
+let nan_declaration_is_one_value () =
+  (* Parsed apart so the two are distinct heap blocks: a physical-equality
+     short-circuit must not stand in for the answer. *)
+  let a = sole_declaration ".a{opacity:calc(infinity - infinity)}" in
+  let b = sole_declaration ".b{opacity:calc(infinity - infinity)}" in
+  Alcotest.(check string)
+    "the fold spells calc(NaN)" "opacity:calc(NaN)"
+    (Css.Declaration.to_string ~minify:true a);
+  Alcotest.(check int)
+    "hash reads the two as one value" (Css.Declaration.hash a)
+    (Css.Declaration.hash b);
+  Alcotest.(check bool)
+    "a NaN declaration equals itself" true
+    (Css.Declaration.equal_declaration a a);
+  Alcotest.(check bool)
+    "two NaN declarations are equal" true
+    (Css.Declaration.equal_declaration a b);
+  (* An ordinary float still answers both ways. *)
+  let half = sole_declaration ".c{opacity:.5}" in
+  let half' = sole_declaration ".d{opacity:.5}" in
+  let other = sole_declaration ".e{opacity:.6}" in
+  Alcotest.(check bool)
+    "equal floats are equal" true
+    (Css.Declaration.equal_declaration half half');
+  Alcotest.(check bool)
+    "different floats are not" false
+    (Css.Declaration.equal_declaration half other);
+  (* What the disagreement costs: the NaN pair is left unmerged while the
+     ordinary-float control merges. *)
+  Alcotest.(check string)
+    "the NaN pair merges" ".a,.b{opacity:calc(NaN)}"
+    (minified
+       ".a{opacity:calc(infinity - infinity)}.b{opacity:calc(infinity - \
+        infinity)}");
+  Alcotest.(check string)
+    "the float control merges" ".c,.d{opacity:.5}"
+    (minified ".c{opacity:.5}.d{opacity:.5}")
+
 let declaration_tests =
   [
     (* Core declaration type testing *)
     test_case "declaration" `Quick test_declaration;
+    test_case "NaN is one declared value" `Quick nan_declaration_is_one_value;
     test_case "parse_declaration" `Quick parse_declaration_case;
     (* Parsing basics *)
     test_case "simple" `Quick simple;


### PR DESCRIPTION
`--minify` left two rules declaring the same NaN apart, such as a pair of `opacity: calc(infinity - infinity)`: `(=)` reads a NaN as different from itself while the cached declaration hash reads it as the same, and the merge test consults both.

`calc(NaN)` and `calc(infinity - infinity)` still hash differently and so still do not merge with each other; that is a separate canonicalisation gap, not addressed here.