### PR TITLE
error: count and slice a snippet in characters, not bytes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -503,6 +503,12 @@ answers.
   proximity criterion, and an origin wrapper carries an origin that outranks
   the layer. `Css.layers` remains the exhaustive count of what a sheet declares
   (#394)
+- `Cascade.Error.to_string` puts the caret under the character that failed and
+  prints back a snippet that is valid UTF-8. The caret column was a byte count,
+  so a multibyte selector pushed the marker well past the error, and the window
+  was sliced on byte offsets, so a long multibyte class name opened the snippet
+  inside a code point and the line came out starting with a replacement
+  character (#472)
 
 ### CLI tools
 

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -91,6 +91,8 @@ let pp : t Pp.t =
       Pp.cut ctx ();
       Pp.string ctx text;
       Pp.cut ctx ();
+      (* Both counts are columns rather than bytes, so a space and a caret
+         apiece line the marker up under a multibyte snippet. *)
       Pp.string ctx (String.make marker_pos ' ');
       Pp.string ctx (String.make (max 1 marker_len) '^')
 

--- a/lib/loc.ml
+++ b/lib/loc.ml
@@ -63,14 +63,48 @@ module Context = struct
   let push step t = { t with path = Path.push step t.path }
 end
 
+(* A caret column is one Unicode scalar value. That is not what a terminal
+   draws: a combining mark takes a column of its own here and none there, and a
+   wide CJK glyph takes one here and two there. Counting graphemes or east Asian
+   widths instead needs segmentation and width tables cascade does not carry,
+   and scalars are exact for the ASCII and Latin text CSS is written in. *)
+let scalars ?pos ?len text =
+  Uutf.String.fold_utf_8 ?pos ?len (fun n _ _ -> n + 1) 0 text
+
+(* A UTF-8 continuation byte, [10xxxxxx]. A window boundary sitting on one is
+   inside a code point. *)
+let continuation source i = Char.code source.[i] land 0xc0 = 0x80
+
+(* Walk a boundary out of a code point, no further than the three continuation
+   bytes a sequence can hold, so a source that is not UTF-8 to begin with leaves
+   the boundary where it was rather than running off. *)
+let rec lead_at_or_before source len i room =
+  if room = 0 || i <= 0 || i >= len || not (continuation source i) then i
+  else lead_at_or_before source len (i - 1) (room - 1)
+
+let rec lead_at_or_after source len i room =
+  if room = 0 || i >= len || not (continuation source i) then i
+  else lead_at_or_after source len (i + 1) (room - 1)
+
 let snippet ?(window = 40) source loc =
   let len = String.length source in
   let pos = max 0 (min len loc.start_pos) in
   let end_pos = max pos (min len loc.end_pos) in
-  let start_pos = max 0 (pos - window) in
-  let stop_pos = min len (end_pos + window) in
+  (* [window] is a target radius, not a cap: a boundary that falls inside a code
+     point moves outward to the lead byte, widening the snippet by up to three
+     bytes a side. A snippet is a diagnostic, so keeping the sequence whole
+     outranks keeping the byte budget. *)
+  let start_pos = lead_at_or_before source len (max 0 (pos - window)) 3 in
+  let stop_pos = lead_at_or_after source len (min len (end_pos + window)) 3 in
   let text = String.sub source start_pos (stop_pos - start_pos) in
-  let marker_pos = pos - start_pos in
-  let marker_len = max 1 (end_pos - pos) in
-  let marker_len = min marker_len (String.length text - marker_pos) in
-  { Context.text; marker_pos; marker_len }
+  let before = pos - start_pos and marked = end_pos - pos in
+  let marker_pos = scalars ~pos:0 ~len:before text in
+  let marked_chars = scalars ~pos:before ~len:marked text in
+  let after_chars =
+    scalars ~pos:(before + marked) ~len:(stop_pos - end_pos) text
+  in
+  {
+    Context.text;
+    marker_pos;
+    marker_len = min (max 1 marked_chars) (marked_chars + after_chars);
+  }

--- a/lib/loc.mli
+++ b/lib/loc.mli
@@ -82,7 +82,12 @@ end
 
 val snippet : ?window:int -> string -> t -> Context.snippet
 (** [snippet source loc] extracts a snippet of [source] around [loc]:
-    {!Context.field-text} is the byte window (default: 40 bytes on each side of
-    the location), {!Context.field-marker_pos} points at [loc.start_pos] within
-    {!Context.field-text}, and {!Context.field-marker_len} spans the located
-    range. *)
+    {!Context.field-text} is the window (default: 40 bytes on each side of the
+    location), {!Context.field-marker_pos} counts the characters of
+    {!Context.field-text} before [loc.start_pos], and
+    {!Context.field-marker_len} counts the characters the located range spans.
+
+    A column is one Unicode scalar value, which a combining mark and a wide
+    glyph each make approximate on a terminal. [window] is a target rather than
+    a cap: a boundary falling inside a UTF-8 sequence moves outward to the lead
+    byte, so {!Context.field-text} is never a truncated code point. *)

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -7,6 +7,16 @@ let loc = Loc.v ~start_pos:12 ~end_pos:13
 let check name e expected =
   Alcotest.(check string) name expected (Error.to_string e)
 
+(* U+20AC EURO SIGN: three bytes, one caret column. Source stays 7-bit, so the
+   multibyte inputs below are byte escapes. *)
+let eur = "\xe2\x82\xac"
+let repeat n s = String.concat "" (List.init n (fun _ -> s))
+
+let located ~source ~start_pos ~end_pos =
+  Error.v ~source
+    ~loc:(Loc.v ~start_pos ~end_pos)
+    ~sort:Sort.Selector (Error.Bad_selector "boom")
+
 let sort_mismatch () =
   check "sort mismatch"
     (Error.sort_mismatch loc ~sort:Sort.Selector ~expected:Sort.Component
@@ -60,6 +70,69 @@ let unterminated () =
     (Error.unterminated loc Sort.Function)
     "unterminated function at [12-13] (in function)"
 
+let caret_counts_characters () =
+  (* Four EURO SIGNs are twelve bytes but four columns, so the caret belongs
+     under the fifth character. *)
+  let source = String.concat "" [ repeat 4 eur; "!" ] in
+  check "caret counts characters"
+    (located ~source ~start_pos:12 ~end_pos:13)
+    (String.concat ""
+       [
+         "bad selector: boom at [12-13] (in selector)\n";
+         repeat 4 eur;
+         "!\n";
+         "    ^";
+       ])
+
+let marker_spans_characters () =
+  (* The marked range covers three EURO SIGNs: three carets, not nine. *)
+  let source = String.concat "" [ "."; repeat 3 eur; "!" ] in
+  check "marker spans characters"
+    (located ~source ~start_pos:1 ~end_pos:10)
+    (String.concat ""
+       [
+         "bad selector: boom at [1-10] (in selector)\n.";
+         repeat 3 eur;
+         "!\n";
+         " ^^^";
+       ])
+
+let window_never_splits_a_code_point () =
+  (* A 30-character class name puts the window boundary 50 bytes in, the last
+     byte of a EURO SIGN. The snippet has to open on the lead byte at 48
+     instead: a diagnostic must not be a truncated code point. *)
+  let source = String.concat "" [ repeat 30 eur; "!" ] in
+  let e = located ~source ~start_pos:90 ~end_pos:91 in
+  Alcotest.(check bool)
+    "renders valid utf-8" true
+    (String.is_valid_utf_8 (Error.to_string e));
+  check "window opens on a lead byte" e
+    (String.concat ""
+       [
+         "bad selector: boom at [90-91] (in selector)\n";
+         repeat 14 eur;
+         "!\n";
+         "              ^";
+       ])
+
+let ascii_caret_unmoved () =
+  (* The counting change must leave every byte of a 7-bit snippet where it
+     was. *)
+  let source = "a { color: bogus; }" in
+  let e =
+    Error.v ~source
+      ~loc:(Loc.v ~start_pos:11 ~end_pos:16)
+      ~sort:Sort.Property_value
+      (Error.Bad_value { property = "color"; reason = "not a color" })
+  in
+  Alcotest.(check bool)
+    "renders valid utf-8" true
+    (String.is_valid_utf_8 (Error.to_string e));
+  check "ascii caret unmoved" e
+    "bad value for color: not a color at [11-16] (in property-value)\n\
+     a { color: bogus; }\n\
+    \           ^^^^^"
+
 let source_context () =
   let t = Cursor.of_string "color red;" in
   match Cursor.colon t with
@@ -84,4 +157,11 @@ let suite =
       Alcotest.test_case "unknown at-rule" `Quick unknown_at_rule;
       Alcotest.test_case "unterminated" `Quick unterminated;
       Alcotest.test_case "source context" `Quick source_context;
+      Alcotest.test_case "caret counts characters" `Quick
+        caret_counts_characters;
+      Alcotest.test_case "marker spans characters" `Quick
+        marker_spans_characters;
+      Alcotest.test_case "window never splits a code point" `Quick
+        window_never_splits_a_code_point;
+      Alcotest.test_case "ascii caret unmoved" `Quick ascii_caret_unmoved;
     ] )


### PR DESCRIPTION
The caret column was a byte count, so a parse error over a multibyte selector pointed well past the character that failed. The window also sliced on byte offsets, so a long multibyte class name opened the snippet inside a code point and cascade printed a truncated UTF-8 sequence back at the user.