### PR TITLE
parser: report the custom-property-shaped rule it drops

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -186,6 +186,11 @@ answers.
   at-keyword; discarding one is the user agent's step, and
   `Optimize.drop_unknown_at_rules` serves a caller writing for a browser
   (#469)
+- A qualified rule whose prelude reads as a custom property, such as
+  `--x:hover { color: red }`, is reported when it is dropped, and
+  `Css.of_string ~strict:true` rejects it. CSS Syntax 3 sec. 5.5.3 makes the
+  shape invalid so that a `{}`-block inside a custom property value is never
+  misread as a rule; the drop itself was silent (#473)
 
 ### Printing
 

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -840,7 +840,8 @@ let consume_at_rule ?(nested = false) lexer ~name ~start_loc : Component.at_rule
 (* CSS Syntax Level 3 section 5.5.3. [nested = true] makes a stray ['}'] or a
    top-level ';' before any block end the rule attempt with [None]. The
    custom-property-shaped guard discards a rule whose first two non-whitespace
-   prelude items are an ident starting with [--] followed by ':'. *)
+   prelude items are an ident starting with [--] followed by ':', warning that
+   the prelude read as a declaration rather than a selector. *)
 let consume_qualified_rule ?(nested = false) ~meta lexer ~start_loc ~warnings :
     Component.qualified_rule option =
   let is_custom_property_shape prelude =
@@ -872,10 +873,15 @@ let consume_qualified_rule ?(nested = false) ~meta lexer ~start_loc ~warnings :
     | Token.Open Curly ->
         let _ = Lexer.next lexer in
         let block = consume_simple_block lexer Curly ~start_loc:tok.loc in
-        if is_custom_property_shape prelude then None
-        else
-          let loc = Loc.union start_loc block.loc in
-          Some { node = { prelude = List.rev prelude; block }; loc }
+        let loc = Loc.union start_loc block.loc in
+        if is_custom_property_shape prelude then (
+          (* Dropping the rule is what the spec asks for, but it still has to be
+             reported: [Css.of_string] warns for every rule it drops. *)
+          warn ~meta lexer warnings
+            (Error.sort_mismatch loc ~sort:Sort.Qualified_rule
+               ~expected:Sort.Selector ~found:Sort.Declaration);
+          None)
+        else Some { node = { prelude = List.rev prelude; block }; loc }
     | _ ->
         let _ = Lexer.next lexer in
         let cv = consume_component_value_from lexer tok in

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -1036,6 +1036,56 @@ let spec_qualified_custom_prop () =
       Alcotest.fail
         "expected custom-property-shaped qualified rule to be discarded"
 
+let spec_qualified_custom_prop_warns () =
+  (* CSS Syntax Level 3 section 5.5.3 makes the custom-property-shaped prelude
+     invalid on purpose, so the rule is dropped rather than reinterpreted.
+     {!Css.of_string} promises warnings for "rules that were dropped", so the
+     drop has to be reported like any other. *)
+  let input = "--x:hover { color: red }" in
+  let out = Parser.stylesheet (Reader.of_string input) in
+  Alcotest.(check int) "rule dropped" 0 (List.length out.value);
+  (match out.warnings with
+  | [
+   {
+     sort = Sort.Qualified_rule;
+     kind =
+       Error.Sort_mismatch
+         { expected = Sort.Selector; found = Sort.Declaration };
+     _;
+   };
+  ] ->
+      ()
+  | ws ->
+      Alcotest.failf "expected one custom-property drop warning, got %d"
+        (List.length ws));
+  (* Strict mode collapses that warning into an error. *)
+  (match Css.of_string ~strict:true input with
+  | Error _ -> ()
+  | Ok _ -> Alcotest.fail "strict mode accepted a silently dropped rule");
+  (match Css.of_string input with
+  | Ok { Css.stylesheet; warnings = [ _ ] } ->
+      Alcotest.(check string)
+        "nothing survives the drop" ""
+        (Css.to_string ~minify:true stylesheet)
+  | Ok { Css.warnings; _ } ->
+      Alcotest.failf "expected exactly one lenient warning, got %d"
+        (List.length warnings)
+  | Error _ -> Alcotest.fail "lenient parse must recover");
+  (* [--x; {...}] is a different shape: the ';' ends the prelude, so it keeps
+     its single existing warning instead of gaining a second one. *)
+  (match Css.of_string "--x; { color: red }" with
+  | Ok { Css.warnings = [ _ ]; _ } -> ()
+  | Ok { Css.warnings; _ } ->
+      Alcotest.failf "expected exactly one warning for the ';' shape, got %d"
+        (List.length warnings)
+  | Error _ -> Alcotest.fail "lenient parse must recover");
+  (* A valid rule stays warning-free in both modes. *)
+  match Css.of_string ~strict:true ".a { color: red }" with
+  | Ok { Css.warnings = []; _ } -> ()
+  | Ok { Css.warnings; _ } ->
+      Alcotest.failf "valid rule warned %d times" (List.length warnings)
+  | Error _ -> Alcotest.fail "valid rule rejected in strict mode"
+
 (* ----- Component values ----- *)
 
 let component_value_block () =
@@ -1453,6 +1503,8 @@ let suite =
         spec_qualified_rule_branches;
       Alcotest.test_case "spec section 5.5.3 custom property rule ambiguity"
         `Quick spec_qualified_custom_prop;
+      Alcotest.test_case "spec section 5.5.3 custom property rule warns" `Quick
+        spec_qualified_custom_prop_warns;
       Alcotest.test_case "component value: block" `Quick component_value_block;
       Alcotest.test_case "component value: function" `Quick
         component_value_function;


### PR DESCRIPTION
`Css.of_string` documents its warning list as covering "rules that were dropped", but `--x:hover { color: red }` came back `Ok` with an empty stylesheet and no warning at all, so `~strict:true` had nothing to reject. CSS Syntax 3 sec. 5.5.3 drops the rule on purpose, to keep a `{}`-block inside a custom property value from being misread as a rule, and that decision is now reported like every other drop.