### PR TITLE
rule_order: fold a redundant @layer order pin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -462,6 +462,11 @@ answers.
   printer spells it before comparing two values under it. A name carrying an
   escaped `}` closed the rule and took both values with it, so any two values
   under such a name compared equal (#440)
+- A redundant `@layer` order pin no longer reads as a difference: the canonical
+  projection drops every name whose removal leaves the sheet's layer order
+  alone, so `@layer a;@layer a{...}` and `@layer a{...}` compare equal. A pin
+  that fixes the order, or one over a position the projection cannot read, is
+  kept (#475)
 
 ### Library
 

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -613,6 +613,147 @@ let rec sort_property_runs (stmts : statement list) : statement list =
   in
   go [] stmts
 
+(* CSS Cascade 5 sec. 6.4.3: cascade layers are sorted by the order in which
+   they first are declared, so all an [@layer a;] statement contributes is the
+   position it gives [a] in that order (sec. 6.4.4.2). A name whose removal
+   leaves the whole order untouched contributes nothing, and the projection
+   drops it, so [@layer a;@layer a{...}] and [@layer a{...}] read as one sheet.
+   Emission keeps the statement: it is visible through the CSSOM, and a sheet
+   concatenated after this one can bind the position it fixes. *)
+
+(* One position in the layer order. [Named] dedups by layer name, a
+   re-declaration naming no new layer. [Opaque] stands for a position whose
+   names cannot be read here: an anonymous layer (sec. 6.4.2.1), the layers an
+   [@import] carries in with it, or a layer declared inside a conditional group
+   rule, which sec. 6.4.3 has contribute to the order only when the condition
+   holds. Each carries the index of the statement that raised it, so the two
+   orders being weighed line their opaque positions up while no name ever dedups
+   into one: a pin whose name is refilled across an unreadable position is left
+   alone, which is what makes reading the sheet this coarsely safe. *)
+type slot = Named of layer_name | Opaque of int
+
+let equal_slot a b =
+  match (a, b) with
+  | Named a, Named b -> equal_layer_name a b
+  | Opaque a, Opaque b -> Int.equal a b
+  | (Named _ | Opaque _), _ -> false
+
+(* Sec. 6.4.2: [a.b] is shorthand for those layers nested in order, so naming a
+   sublayer declares each of its parents first. *)
+let layer_name_slots (name : layer_name) : slot list =
+  let rec loop acc rev_prefix = function
+    | [] -> List.rev acc
+    | ident :: rest ->
+        let rev_prefix = ident :: rev_prefix in
+        loop (Named (List.rev rev_prefix) :: acc) rev_prefix rest
+  in
+  loop [] [] name
+
+let rec declares_layer (stmts : statement list) : bool =
+  List.exists
+    (fun stmt ->
+      match stmt with
+      | Layer _ | Layer_decl _ | Import _ -> true
+      | stmt -> declares_layer (Stylesheet.statement_children stmt))
+    stmts
+
+(* The positions statement [i] adds to the layer order. A named [@layer] block
+   or an [@import ... layer(x)] declares its own name, and whatever either holds
+   inside is a sublayer sorting within it rather than a position out here. *)
+let statement_slots i (stmt : statement) : slot list =
+  match stmt with
+  | Layer_decl names -> List.concat_map layer_name_slots names
+  | Layer (Some name, _) -> layer_name_slots name
+  | Import { layer = Some (_ :: _ as name); _ } -> layer_name_slots name
+  | Layer (None, _) | Import _ -> [ Opaque i ]
+  | stmt ->
+      if declares_layer (Stylesheet.statement_children stmt) then [ Opaque i ]
+      else []
+
+(* [fixed.(i)] is what statement [i] contributes when it is not a pin, read
+   once; [pins.(i)] is the names a pin still carries, which the pruning below
+   shortens. A pin left with no name contributes nothing and keeps its index, so
+   the opaque positions stay keyed the way [target] saw them. *)
+let layer_order ~(fixed : slot list array)
+    ~(pins : layer_name list option array) =
+  let add (seen, rev) slot =
+    match slot with
+    | Named name when List.exists (equal_layer_name name) seen -> (seen, rev)
+    | Named name -> (name :: seen, slot :: rev)
+    | Opaque _ -> (seen, slot :: rev)
+  in
+  let rec loop i acc =
+    if i >= Array.length fixed then List.rev (snd acc)
+    else
+      let slots =
+        match pins.(i) with
+        | None -> fixed.(i)
+        | Some names -> List.concat_map layer_name_slots names
+      in
+      loop (i + 1) (List.fold_left add acc slots)
+  in
+  loop 0 ([], [])
+
+(* Weigh one pin's names left to right, each candidate against the order the
+   sheet came in with rather than against the last candidate, so every name kept
+   is one the sheet's own order needs. *)
+let rec prune_pin ~(fixed : slot list array)
+    ~(pins : layer_name list option array) ~target i kept_rev = function
+  | [] -> List.rev kept_rev
+  | name :: rest ->
+      pins.(i) <- Some (List.rev_append kept_rev rest);
+      if List.equal equal_slot (layer_order ~fixed ~pins) target then
+        prune_pin ~fixed ~pins ~target i kept_rev rest
+      else begin
+        pins.(i) <- Some (List.rev_append kept_rev (name :: rest));
+        prune_pin ~fixed ~pins ~target i (name :: kept_rev) rest
+      end
+
+(* Top level only. A pin written inside a [@layer] block names a sublayer of it,
+   and the sublayer order runs across every block of that layer rather than
+   within one, so a block on its own does not say whether such a pin binds. *)
+let fold_layer_pins (stmts : statement list) : statement list =
+  let is_pin = function Layer_decl (_ :: _) -> true | _ -> false in
+  if not (List.exists is_pin stmts) then stmts
+  else
+    let work = Array.of_list stmts in
+    let pins : layer_name list option array =
+      Array.map (function Layer_decl names -> Some names | _ -> None) work
+    in
+    let fixed =
+      Array.mapi
+        (fun i stmt ->
+          match stmt with Layer_decl _ -> [] | stmt -> statement_slots i stmt)
+        work
+    in
+    let target = layer_order ~fixed ~pins in
+    (* One sweep is not enough: a name only reads as needed while a later one it
+       is weighed against is still there, and drops out once that one goes. Each
+       sweep only removes, so repeating to a fixed point terminates, and every
+       candidate is still weighed against the order the sheet came in with. *)
+    let sweep () =
+      let dropped = ref false in
+      Array.iteri
+        (fun i names ->
+          match names with
+          | Some (_ :: _ as names) ->
+              let kept = prune_pin ~fixed ~pins ~target i [] names in
+              if List.compare_lengths kept names <> 0 then dropped := true
+          | Some [] | None -> ())
+        pins;
+      !dropped
+    in
+    let rec settle changed = if sweep () then settle true else changed in
+    if not (settle false) then stmts
+    else
+      let rebuild i (stmt : statement) : statement option =
+        match (stmt, pins.(i)) with
+        | Layer_decl _, Some [] -> None
+        | Layer_decl _, Some (_ :: _ as names) -> Some (Layer_decl names)
+        | stmt, (None | Some _) -> Some stmt
+      in
+      List.filter_map Fun.id (List.mapi rebuild stmts)
+
 (* Media Queries 4 sec. 2.3: [all] matches every media type, so it is the
    identity in [<media-type> and <condition>] and the Level 3 spelling [not all
    and (X)] is the same query as the Level 4 [not (X)]. Bare [not all] has no
@@ -653,9 +794,10 @@ let rec canonical_media_queries (stmts : statement list) : statement list =
 let canonicalize (stmts : statement list) : statement list =
   let changed = ref false in
   let normalized =
-    canonical_media_queries
-      (sort_property_runs
-         (canonical_color_spellings (normalize_custom_values stmts)))
+    fold_layer_pins
+      (canonical_media_queries
+         (sort_property_runs
+            (canonical_color_spellings (normalize_custom_values stmts))))
   in
   let result =
     canonicalize_block ~parent:(None : Selector.t option) changed normalized

--- a/lib/rule_order.mli
+++ b/lib/rule_order.mli
@@ -53,4 +53,15 @@ val canonicalize : Stylesheet.statement list -> Stylesheet.statement list
     [--lossless], which otherwise keeps whichever function was written. Only
     that fold applies: a declaration is kept exactly as it came in unless the
     colour moved. Emission cannot make the same rewrite, since [color()] needs a
-    browser that parses it. *)
+    browser that parses it.
+
+    A top-level [@layer] statement loses every name whose removal leaves the
+    sheet's layer order alone, and goes away once it has none left. CSS Cascade
+    5 sec. 6.4.3 sorts layers by the order in which they first are declared, so
+    a pin the following block repeats declares nothing the block does not, while
+    one that is the only or the earliest declaration of its layer stays. A
+    position the projection cannot read - an anonymous layer, the layers an
+    [@import] carries in, or a layer declared inside a conditional group rule,
+    which sec. 6.4.3 has contribute only when the condition holds - blocks the
+    fold across it. Emission keeps every pin, since the statement is visible
+    through the CSSOM. *)

--- a/test/cli/diff_canonical_residual.t
+++ b/test/cli/diff_canonical_residual.t
@@ -2,36 +2,51 @@ CLI: cascade diff - canonical mode's byte verdict.
 
 The canonical minified form is what canonical mode compares, so two sheets
 that reach different bytes differ even when the tree diff walked past the
-divergence. Here an empty layer-order pin the projection does not fold
-away: the report shows the two canonical forms and the exit code is 1.
+divergence. Here a layer-order pin that is the only declaration of its layer:
+it puts `a` before `b`, the tree diff sees a statement carrying no rules, and
+the report shows the two canonical forms with exit code 1.
 
   $ cat > pinned.css <<EOF
-  > @layer a;@layer a{x{top:0}}
+  > @layer a;@layer b{x{top:0}}
   > EOF
   $ cat > unpinned.css <<EOF
-  > @layer a{x{top:0}}
+  > @layer b{x{top:0}}
   > EOF
   $ NO_COLOR=1 cascade diff --diff=canonical pinned.css unpinned.css
   CSS: 28 chars vs 19 chars (32.1% diff)
   Changes: none classified structurally (see report below)
   Canonical forms differ:
   
-  Strings differ at position 8 (line 0, col 8)
+  Strings differ at position 7 (line 0, col 7)
   
   --- pinned.css
   +++ unpinned.css
-  @@ position 8 @@
-  -@layer a;@layer a{x{top:0}}
-  +@layer a{x{top:0}}
-           ^
+  @@ position 7 @@
+  -@layer a;@layer b{x{top:0}}
+  +@layer b{x{top:0}}
+          ^
   
   [1]
 
   $ cascade diff --diff=canonical pinned.css unpinned.css > /dev/null; echo $?
   1
 
+  $ NO_COLOR=1 cascade diff --diff=tree pinned.css unpinned.css
+  CSS files are identical
+
 Two sheets that reach the same canonical form are equal whatever they were
-spelled like.
+spelled like. A pin the very next block repeats gives its layer the position
+that block gives it anyway, so the projection folds it and the two spellings
+are one sheet.
+
+  $ cat > repeated.css <<EOF
+  > @layer a;@layer a{x{top:0}}
+  > EOF
+  $ cat > plain.css <<EOF
+  > @layer a{x{top:0}}
+  > EOF
+  $ cascade diff --diff=canonical repeated.css plain.css
+  CSS files are identical
 
   $ cat > same-a.css <<EOF
   > .x { color: red }

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -1083,12 +1083,12 @@ let zero_counters_unparsed_do_not_claim_equivalence () =
 
 (* The canonical minified form is the verdict in [`Canonical] mode: two sheets
    whose canonical bytes differ differ, whether or not the tree diff reached the
-   divergence. Here an empty layer-order pin the projection does not fold away -
-   either a normalisation key the projection is missing or a blind spot in the
-   tree diff, and both are findings. *)
+   divergence. Here a layer-order pin that is the only declaration of its layer,
+   so CSS Cascade 5 sec. 6.4.3 has it order [a] before [b] and the projection
+   keeps it; the tree diff walks past a statement that carries no rules. *)
 let canonical_byte_residual_is_a_difference () =
-  let pinned = "@layer a;@layer a{x{top:0}}" in
-  let unpinned = "@layer a{x{top:0}}" in
+  let pinned = "@layer a;@layer b{x{top:0}}" in
+  let unpinned = "@layer b{x{top:0}}" in
   let result = Cascade_diff.Css_compare.diff ~mode:`Canonical pinned unpinned in
   (match result.Cascade_diff.Css_compare.result with
   | Cascade_diff.Css_compare.String_diff _ -> ()

--- a/test/test_rule_order.ml
+++ b/test/test_rule_order.ml
@@ -206,6 +206,114 @@ let layer_blocks_stay_put () =
     (render (statements css))
     (canonical css)
 
+let redundant_layer_pin_folds () =
+  (* CSS Cascade 5 sec. 6.4.3: cascade layers are sorted by the order in which
+     they first are declared, so a pin gives its layer a position the very next
+     block would have given it anyway. Dropping it leaves the order alone, so
+     the two spellings are one sheet and the projection brings them together. *)
+  Alcotest.(check string)
+    "a pin the following block repeats folds away" "@layer a{x{color:red}}"
+    (canonical "@layer a;@layer a{x{color:red}}")
+
+let order_changing_layer_pin_is_kept () =
+  (* Sec. 6.4.3 read the other way: here the pins are the only thing putting [a]
+     before [b], since [b]'s block comes first. Dropping [@layer a;] reverses
+     the two layers and changes what the sheet renders, so it has to stay. The
+     [b] pin only repeats what [b]'s own block declares, so it goes. *)
+  let pinned =
+    "@layer a;@layer b;@layer b{x{color:red}}@layer a{y{color:blue}}"
+  in
+  let unpinned = "@layer b{x{color:red}}@layer a{y{color:blue}}" in
+  Alcotest.(check string)
+    "the pin that fixes the order stays"
+    "@layer a;@layer b{x{color:red}}@layer a{y{color:blue}}" (canonical pinned);
+  Alcotest.(check bool)
+    "pinned and unpinned sheets stay distinct" true
+    (canonical pinned <> canonical unpinned)
+
+let leading_layer_pins_matching_the_blocks_fold () =
+  (* The shape a generator writes: every layer named up front, then the blocks
+     in that same order. Sec. 6.4.3 has the blocks declare that order on their
+     own, so the whole pin goes. One name reads as needed only while a later one
+     is still there to be weighed against it, so the fold has to settle rather
+     than sweep once. *)
+  Alcotest.(check string)
+    "pins repeating the block order fold away"
+    "@layer a{x{color:red}}@layer b{y{color:blue}}"
+    (canonical "@layer a,b;@layer a{x{color:red}}@layer b{y{color:blue}}");
+  Alcotest.(check string)
+    "written as two statements they fold the same way"
+    "@layer a{x{color:red}}@layer b{y{color:blue}}"
+    (canonical "@layer a;@layer b;@layer a{x{color:red}}@layer b{y{color:blue}}");
+  Alcotest.(check bool)
+    "the reversed pin order is another sheet and stays" true
+    (canonical "@layer b,a;@layer a{x{color:red}}@layer b{y{color:blue}}"
+    <> canonical "@layer a{x{color:red}}@layer b{y{color:blue}}")
+
+let layer_pin_folds_one_name_not_the_statement () =
+  (* Sec. 6.4.4.2: [@layer a, b;] declares two layers in that order. Only [b]
+     repeats the order the blocks already give, so the statement survives with
+     [a] alone rather than going away whole, and the two spellings of the one
+     order project together. *)
+  Alcotest.(check string)
+    "only the redundant name leaves the pin"
+    "@layer a;@layer b{x{color:red}}@layer a{y{color:blue}}"
+    (canonical "@layer a,b;@layer b{x{color:red}}@layer a{y{color:blue}}")
+
+let layer_pin_names_are_ident_lists () =
+  (* Sec. 6.4.2: [a.b] is the sublayer [b] of [a] and declares [a] on the way,
+     so a pin naming [a] repeats what the sublayer block declares first. An
+     escaped dot makes one ident instead, a layer neither block declares, and
+     that pin is the whole of what puts that layer in the order. *)
+  Alcotest.(check string)
+    "a pin the sublayer block declares first folds away"
+    "@layer a.b{x{color:red}}"
+    (canonical "@layer a;@layer a.b{x{color:red}}");
+  Alcotest.(check bool)
+    "a pin naming an ident that holds a dot stays" true
+    (canonical "@layer a\\2e b;@layer a.b{x{color:red}}"
+    <> canonical "@layer a.b{x{color:red}}")
+
+let unblocked_layer_pin_is_kept () =
+  (* A pin whose layer never gets a block of its own is the only declaration of
+     that layer, and sec. 6.4.3 sorts it before every layer declared after it.
+     Dropping it would take a position out of the order. *)
+  Alcotest.(check string)
+    "a pin with no block of its own stays" "@layer a;@layer b{x{color:red}}"
+    (canonical "@layer a;@layer b{x{color:red}}")
+
+let layer_pin_over_conditional_declaration_is_kept () =
+  (* Sec. 6.4.3: a layer declared inside a conditional group rule contributes to
+     the order only when the condition holds, so what the [@media] puts between
+     the pin and the block cannot be read here. Without the pin the [@media] may
+     declare [a] first and push it before [b], so the pin stays. *)
+  let css =
+    "@layer a;@media print{@layer a{x{color:red}}}@layer \
+     b{y{color:blue}}@layer a{z{color:green}}"
+  in
+  Alcotest.(check string)
+    "a pin over an unreadable position stays"
+    (render (statements css))
+    (canonical css)
+
+let layer_pin_over_import_is_kept () =
+  (* Sec. 6.4.1: an [@import] with no layer keyword puts the imported sheet's
+     own layers into this order at that point, so the position between the pin
+     and the block is unknown here too. *)
+  let css = "@layer a;@import url(x.css);@layer a{y{color:red}}" in
+  Alcotest.(check string)
+    "a pin over an import stays"
+    (render (statements css))
+    (canonical css)
+
+let layer_pin_fold_is_idempotent () =
+  (* The projection is a projection: what it emits is already canonical. *)
+  let once =
+    canonical "@layer a,b;@layer b{x{color:red}}@layer a{y{color:blue}}"
+  in
+  Alcotest.(check string)
+    "projecting the projection changes nothing" once (canonical once)
+
 let block_with_layer_content_is_barrier () =
   (* A conditional block is only reorderable when its transitive content is
      plain rules; a nested [@layer] pins it in place. *)
@@ -398,6 +506,24 @@ let suite =
         overlapping_declarations_keep_order;
       Alcotest.test_case "logical border style keeps its place" `Quick
         logical_border_style_keeps_its_place;
+      Alcotest.test_case "redundant layer pin folds" `Quick
+        redundant_layer_pin_folds;
+      Alcotest.test_case "order-changing layer pin is kept" `Quick
+        order_changing_layer_pin_is_kept;
+      Alcotest.test_case "leading layer pins matching the blocks fold" `Quick
+        leading_layer_pins_matching_the_blocks_fold;
+      Alcotest.test_case "layer pin folds one name not the statement" `Quick
+        layer_pin_folds_one_name_not_the_statement;
+      Alcotest.test_case "layer pin names are ident lists" `Quick
+        layer_pin_names_are_ident_lists;
+      Alcotest.test_case "unblocked layer pin is kept" `Quick
+        unblocked_layer_pin_is_kept;
+      Alcotest.test_case "layer pin over conditional declaration is kept" `Quick
+        layer_pin_over_conditional_declaration_is_kept;
+      Alcotest.test_case "layer pin over import is kept" `Quick
+        layer_pin_over_import_is_kept;
+      Alcotest.test_case "layer pin fold is idempotent" `Quick
+        layer_pin_fold_is_idempotent;
       Alcotest.test_case "block with layer content is barrier" `Quick
         block_with_layer_content_is_barrier;
       Alcotest.test_case "nested conditionals participate" `Quick


### PR DESCRIPTION
`@layer a;@layer a{...}` and `@layer a{...}` declare the same layer order, but canonical diff reported them as different: the projection had no fold for the pin. It now drops every pin name whose removal leaves the sheet's layer order unchanged, and keeps the rest, including any pin reaching across a position it cannot read (an anonymous layer, an `@import`'s own layers, or a layer inside a conditional group rule, which CSS Cascade 5 sec. 6.4.3 has contribute only when the condition holds).

The pin in test/cli/diff_canonical_residual.t was recording that gap rather than desired behaviour, so it moves to a pin that really is a difference. `cascade fmt` output is byte-identical over test/interop's 797 files.