### PR TITLE
lib: share one byte hash and one list-bucket push

### DIFF
--- a/lib/common.ml
+++ b/lib/common.ml
@@ -77,3 +77,25 @@ module String = struct
   let lowercase_ascii_preserve s =
     if is_ascii_lower_or_digit s then s else Stdlib.String.lowercase_ascii s
 end
+
+let mix_int acc x = ((acc lsl 5) - acc) lxor x
+
+(* [String.iter] would allocate a closure over the accumulator ref on every
+   call; the loop carries it in a parameter instead. *)
+let hash_string s =
+  let n = String.length s in
+  let rec go acc i =
+    if i >= n then acc
+    else go (mix_int acc (Char.code (String.unsafe_get s i))) (i + 1)
+  in
+  go 0x811c9dc5 0
+
+module Table = struct
+  module Make (H : Hashtbl.HashedType) = struct
+    include Hashtbl.Make (H)
+
+    let push tbl key value =
+      let prev = find_opt tbl key |> Option.value ~default:[] in
+      replace tbl key (value :: prev)
+  end
+end

--- a/lib/common.mli
+++ b/lib/common.mli
@@ -40,3 +40,22 @@ module String : sig
       [Stdlib.String.lowercase_ascii s]. CSS identifiers are overwhelmingly in
       that set, so this avoids the [Bytes.map] allocation for them. *)
 end
+
+val mix_int : int -> int -> int
+(** [mix_int acc x] folds the integer [x] into the running hash [acc]. *)
+
+val hash_string : string -> int
+(** [hash_string s] hashes the bytes of [s] with {!mix_int}. Callers combine the
+    result with other hashes through {!mix_int}, so both sides of a bucket key
+    must come from the same pair of functions. *)
+
+(** Hash tables whose bindings are lists used as buckets. *)
+module Table : sig
+  module Make (H : Hashtbl.HashedType) : sig
+    include Hashtbl.S with type key = H.t
+
+    val push : 'a list t -> key -> 'a -> unit
+    (** [push tbl key value] prepends [value] to the list bound to [key], or
+        binds the singleton [[value]] when [key] is absent. *)
+  end
+end

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -46,29 +46,19 @@ let merge_selector_list = Merge.selector_list
 let contains_vendor_pseudo_element = Merge.vendor
 let selectors_compatible = Merge.compatible
 let decls_size = Size.decls
-let mix_int acc x = ((acc lsl 5) - acc) lxor x
+let mix_int = Common.mix_int
+let hash_string = Common.hash_string
 let hash_bool = function false -> 0 | true -> 1
-
-(* [String.iter] would allocate a closure over the accumulator ref on every
-   call; the loop carries it in a parameter instead. *)
-let hash_string s =
-  let n = String.length s in
-  let rec go acc i =
-    if i >= n then acc
-    else go (mix_int acc (Char.code (String.unsafe_get s i))) (i + 1)
-  in
-  go 0x811c9dc5 0
-
 let hash_ints xs = List.fold_left mix_int 0x345678 xs
 
-module Int_table = Hashtbl.Make (struct
+module Int_table = Common.Table.Make (struct
   type t = int
 
   let equal = Int.equal
   let hash x = x land max_int
 end)
 
-module String_table = Hashtbl.Make (struct
+module String_table = Common.Table.Make (struct
   type t = string
 
   let equal = String.equal
@@ -193,14 +183,6 @@ let pairwise_compatible rules =
 let can_group_selectors rules = pairwise_compatible rules
 let body_equal_key g id = Rule_graph.declaration_body_key g id
 let body_bucket_key g id = body_equal_key g id |> hash_ints
-
-let add_int_bucket tbl key value =
-  let prev = Int_table.find_opt tbl key |> Option.value ~default:[] in
-  Int_table.replace tbl key (value :: prev)
-
-let add_string_bucket tbl key value =
-  let prev = String_table.find_opt tbl key |> Option.value ~default:[] in
-  String_table.replace tbl key (value :: prev)
 
 let touching_set = function
   | Option.None -> Option.None
@@ -645,7 +627,7 @@ let identical_body_candidates ?size_cache ?touching ~ctx ~finalize g =
   List.iter
     (fun (id, rule) ->
       if identical_body_eligible ~ctx rule && rule.declarations <> [] then
-        add_int_bucket buckets (body_bucket_key g id) id)
+        Int_table.push buckets (body_bucket_key g id) id)
     (live_rules g);
   let candidates = ref [] in
   Int_table.iter
@@ -710,7 +692,7 @@ let same_selector_candidates ?size_cache ?touching ~finalize g =
   List.iter
     (fun (id, rule) ->
       if same_selector_eligible rule then
-        add_int_bucket buckets (selector_key_hash rule) id)
+        Int_table.push buckets (selector_key_hash rule) id)
     (live_rules g);
   let candidates = ref [] in
   Int_table.iter
@@ -1425,7 +1407,7 @@ let selector_rank = Rule_graph.Node_id.to_int
 let add_single_selector_receivers receivers id rule =
   match single_selector_branch_key rule with
   | Option.None -> ()
-  | Option.Some key -> add_string_bucket receivers key id
+  | Option.Some key -> String_table.push receivers key id
 
 let remaining_selector_branches ~removed_key selectors =
   List.filter

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -21,7 +21,7 @@ module Key_tbl = Hashtbl.Make (struct
   let hash = Shorthand.overlap_key_hash
 end)
 
-module String_table = Hashtbl.Make (String)
+module String_table = Common.Table.Make (String)
 
 module Node_id = struct
   type t = int
@@ -264,7 +264,7 @@ end)
 
 (* Packed specificities, so the bucket index is keyed by an immediate rather
    than by a record a generic table would hash and compare field by field. *)
-module Spec_table = Hashtbl.Make (struct
+module Spec_table = Common.Table.Make (struct
   type t = int
 
   let equal = Int.equal
@@ -357,22 +357,14 @@ let spec_bucket bucket key =
       Overlap_key_table.replace bucket key inner;
       inner
 
-let add_spec_bucket bucket spec value =
-  let prev = Spec_table.find_opt bucket spec |> Option.value ~default:[] in
-  Spec_table.replace bucket spec (value :: prev)
-
 let rec add_spec_buckets bucket value = function
   | [] -> ()
   | spec :: rest ->
-      add_spec_bucket bucket spec value;
+      Spec_table.push bucket spec value;
       add_spec_buckets bucket value rest
 
 let add_bucket bucket key specs value =
   add_spec_buckets (spec_bucket bucket key) value specs
-
-let add_string_bucket bucket key value =
-  let prev = String_table.find_opt bucket key |> Option.value ~default:[] in
-  String_table.replace bucket key (value :: prev)
 
 (* [seen] is a per-target stamp array indexed by node id: [seen.(i) = stamp]
    means node [i] is already a candidate for the current target. The target's
@@ -448,7 +440,7 @@ let source_order_edges t =
       candidates;
     List.iter (fun key -> add_bucket by_decl_key key specs j) keys;
     List.iter
-      (fun branch -> add_string_bucket by_branch branch j)
+      (fun branch -> String_table.push by_branch branch j)
       t.branches.(j);
     add_spec_buckets by_spec j specs
   done;
@@ -1076,7 +1068,7 @@ let add_produced_edges t ~consume ~total ~produced_count graph succ =
         | [] ->
             List.iter (fun key -> add_bucket by_decl_key key specs right) keys;
             List.iter
-              (fun branch -> add_string_bucket by_branch branch right)
+              (fun branch -> String_table.push by_branch branch right)
               graph.branches.(right);
             add_spec_buckets by_spec right specs;
             loop (pi + 1)

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -231,12 +231,6 @@ type overlap_key = int
 let overlap_key_equal = Int.equal
 let overlap_key_compare = Int.compare
 let overlap_key_hash key = key land max_int
-let mix_int acc x = ((acc lsl 5) - acc) lxor x
-
-let hash_string s =
-  let hash = ref 0x811c9dc5 in
-  String.iter (fun c -> hash := mix_int !hash (Char.code c)) s;
-  !hash
 
 let overlap_key_of_name name =
   (* Hash collisions only add conservative ordering edges. They cannot make two


### PR DESCRIPTION
The seeded byte hash was spelled two ways and the list-bucket push four times over four table modules. Output is byte-identical on the interop corpora, so this carries no changelog entry.