### PR TITLE
reader: scan forward for the error line and column

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -519,6 +519,12 @@ answers.
   was sliced on byte offsets, so a long multibyte class name opened the snippet
   inside a code point and the line came out starting with a replacement
   character (#472)
+- `Cascade.Reader.parse_error` reports the line and column of the failing byte
+  from a forward scan and counts its caret in characters. The walk ran
+  backwards from the error and reset the column at each newline, so it counted
+  the line before the error and stopped one column short at end of input, and
+  the caret was a byte count under a window that could open inside a code
+  point (#477)
 
 ### CLI tools
 

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -76,6 +76,32 @@ module String = struct
 
   let lowercase_ascii_preserve s =
     if is_ascii_lower_or_digit s then s else Stdlib.String.lowercase_ascii s
+
+  let utf8_length ?pos ?len s =
+    Uutf.String.fold_utf_8 ?pos ?len (fun n _ _ -> n + 1) 0 s
+
+  (* A UTF-8 continuation byte, [10xxxxxx]: an index sitting on one is inside a
+     sequence rather than at its start. *)
+  let continuation s i = Char.code s.[i] land 0xc0 = 0x80
+
+  (* Walk out of a sequence by no more than the three continuation bytes one can
+     hold, so bytes that are not UTF-8 to begin with leave the index where it
+     was rather than running off. *)
+  let utf8_lead_before s i =
+    let n = length s in
+    let rec go i room =
+      if room = 0 || i <= 0 || i >= n || not (continuation s i) then i
+      else go (i - 1) (room - 1)
+    in
+    go i 3
+
+  let utf8_lead_after s i =
+    let n = length s in
+    let rec go i room =
+      if room = 0 || i >= n || not (continuation s i) then i
+      else go (i + 1) (room - 1)
+    in
+    go i 3
 end
 
 let mix_int acc x = ((acc lsl 5) - acc) lxor x

--- a/lib/common.mli
+++ b/lib/common.mli
@@ -39,6 +39,20 @@ module String : sig
       lowercase ASCII letters, digits, [-] and [_]; otherwise it is
       [Stdlib.String.lowercase_ascii s]. CSS identifiers are overwhelmingly in
       that set, so this avoids the [Bytes.map] allocation for them. *)
+
+  val utf8_length : ?pos:int -> ?len:int -> string -> int
+  (** [utf8_length s] counts the Unicode scalar values of [s], or of its [len]
+      bytes from [pos], each malformed byte sequence counting as one. *)
+
+  val utf8_lead_before : string -> int -> int
+  (** [utf8_lead_before s i] moves [i] back to the lead byte of the UTF-8
+      sequence it falls inside, by at most the three continuation bytes a
+      sequence holds, so bytes that are not UTF-8 leave [i] where it was.
+      Slicing [s] at the result never splits a code point. *)
+
+  val utf8_lead_after : string -> int -> int
+  (** [utf8_lead_after s i] moves [i] forward out of the UTF-8 sequence it falls
+      inside, on the same terms as {!utf8_lead_before}. *)
 end
 
 val mix_int : int -> int -> int

--- a/lib/loc.ml
+++ b/lib/loc.ml
@@ -68,23 +68,7 @@ end
    wide CJK glyph takes one here and two there. Counting graphemes or east Asian
    widths instead needs segmentation and width tables cascade does not carry,
    and scalars are exact for the ASCII and Latin text CSS is written in. *)
-let scalars ?pos ?len text =
-  Uutf.String.fold_utf_8 ?pos ?len (fun n _ _ -> n + 1) 0 text
-
-(* A UTF-8 continuation byte, [10xxxxxx]. A window boundary sitting on one is
-   inside a code point. *)
-let continuation source i = Char.code source.[i] land 0xc0 = 0x80
-
-(* Walk a boundary out of a code point, no further than the three continuation
-   bytes a sequence can hold, so a source that is not UTF-8 to begin with leaves
-   the boundary where it was rather than running off. *)
-let rec lead_at_or_before source len i room =
-  if room = 0 || i <= 0 || i >= len || not (continuation source i) then i
-  else lead_at_or_before source len (i - 1) (room - 1)
-
-let rec lead_at_or_after source len i room =
-  if room = 0 || i >= len || not (continuation source i) then i
-  else lead_at_or_after source len (i + 1) (room - 1)
+let scalars = Common.String.utf8_length
 
 let snippet ?(window = 40) source loc =
   let len = String.length source in
@@ -94,8 +78,12 @@ let snippet ?(window = 40) source loc =
      point moves outward to the lead byte, widening the snippet by up to three
      bytes a side. A snippet is a diagnostic, so keeping the sequence whole
      outranks keeping the byte budget. *)
-  let start_pos = lead_at_or_before source len (max 0 (pos - window)) 3 in
-  let stop_pos = lead_at_or_after source len (min len (end_pos + window)) 3 in
+  let start_pos =
+    Common.String.utf8_lead_before source (max 0 (pos - window))
+  in
+  let stop_pos =
+    Common.String.utf8_lead_after source (min len (end_pos + window))
+  in
   let text = String.sub source start_pos (stop_pos - start_pos) in
   let before = pos - start_pos and marked = end_pos - pos in
   let marker_pos = scalars ~pos:0 ~len:before text in

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -48,7 +48,7 @@ let pp_parse_error (err : parse_error) =
       let marker =
         if
           err.marker_pos > 0
-          && err.marker_pos <= String.length err.context_window
+          && err.marker_pos <= Common.String.utf8_length err.context_window
         then String.make err.marker_pos ' ' ^ "^"
         else
           (* Fallback if marker position is out of bounds *)
@@ -198,26 +198,35 @@ let callstack t = List.rev t.call_stack
 
 let context_window ?(before = 40) ?(after = 40) t =
   let pos = t.pos in
-  let start_pos = max 0 (pos - before) in
-  let end_pos = min t.len (pos + after) in
-  let before_text = String.sub t.input start_pos (pos - start_pos) in
-  let after_text = String.sub t.input pos (end_pos - pos) in
-  let context = before_text ^ after_text in
-  let marker_pos = String.length before_text in
+  (* [before] and [after] are target radiuses, not caps: a boundary that falls
+     inside a code point moves outward to the lead byte, widening the window by
+     up to three bytes a side. A window is a diagnostic, so keeping the sequence
+     whole outranks keeping the byte budget. *)
+  let start_pos =
+    Common.String.utf8_lead_before t.input (max 0 (pos - before))
+  in
+  let end_pos =
+    Common.String.utf8_lead_after t.input (min t.len (pos + after))
+  in
+  let context = String.sub t.input start_pos (end_pos - start_pos) in
+  let marker_pos =
+    Common.String.utf8_length ~pos:start_pos ~len:(pos - start_pos) t.input
+  in
   (context, marker_pos)
 
 (** Error helpers *)
 let err ?got t expected =
   let context, marker_pos = context_window t in
-  (* Calculate line and column numbers for better error reporting *)
+  (* Scan forward from the start of the input, so a newline ends the line it
+     sits on and the byte after it opens the next one at column 1. A column
+     counts Unicode scalar values, like the caret. *)
   let line, col =
-    let rec count_lines pos line col =
-      if pos <= 0 then (line, col)
-      else if pos >= String.length t.input then (line, col)
-      else if t.input.[pos] = '\n' then count_lines (pos - 1) (line + 1) 1
-      else count_lines (pos - 1) line (col + 1)
-    in
-    count_lines (t.pos - 1) 1 1
+    Uutf.String.fold_utf_8 ~len:t.pos
+      (fun (line, col) _ decoded ->
+        match decoded with
+        | `Uchar u when Uchar.to_int u = 0x0A -> (line + 1, 1)
+        | `Uchar _ | `Malformed _ -> (line, col + 1))
+      (1, 1) t.input
   in
   let better_filename =
     "<CSS input>:" ^ string_of_int line ^ ":" ^ string_of_int col

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -21,7 +21,11 @@ type parse_error = {
   marker_pos : int;
   callstack : string list;
 }
-(** Parse error information with structured details. *)
+(** Parse error information with structured details. {!field-position} is a byte
+    offset, {!field-filename} carries the 1-based line and column of that
+    offset, and {!field-marker_pos} counts the characters of
+    {!field-context_window} before it. A column is one Unicode scalar value, as
+    for {!context_window}. *)
 
 exception Parse_error of parse_error
 (** [Parse_error error] is raised on parse errors with structured debugging
@@ -67,9 +71,13 @@ val position : t -> int
 
 val context_window : ?before:int -> ?after:int -> t -> string * int
 (** [context_window ~before ~after t] returns [(context, marker_pos)] where
-    [context] is text around the current position and {!field-marker_pos}
-    indicates where in the context the current position is. Used for better
-    error messages. *)
+    [context] is text around the current position and {!field-marker_pos} counts
+    the characters of [context] before it. Used for better error messages.
+
+    A character is one Unicode scalar value, which a combining mark and a wide
+    glyph each make approximate on a terminal. [before] and [after] are target
+    radiuses rather than caps: a boundary falling inside a UTF-8 sequence moves
+    outward to the lead byte, so [context] is never a truncated code point. *)
 
 (** {1 Call Stack Management} *)
 

--- a/test/test_reader.ml
+++ b/test/test_reader.ml
@@ -1460,6 +1460,87 @@ let error_formatting_at_end () =
       "marker near end" true
       (error.marker_pos >= String.length error.context_window - 5)
 
+(* U+20AC EURO SIGN, three UTF-8 bytes, spelled as escapes because cascade
+   source stays 7-bit. *)
+let euro = "\xe2\x82\xac"
+let euros n = String.concat "" (List.init n (fun _ -> euro))
+
+(* A local UTF-8 validator, so the oracle does not run through the decoder under
+   test. *)
+let is_utf8 s =
+  let len = String.length s in
+  let rec go i =
+    if i >= len then true
+    else
+      let b = Char.code s.[i] in
+      let n =
+        if b < 0x80 then 1
+        else if b land 0xe0 = 0xc0 then 2
+        else if b land 0xf0 = 0xe0 then 3
+        else if b land 0xf8 = 0xf0 then 4
+        else 0
+      in
+      if n = 0 || i + n > len then false
+      else
+        let rec continuations k =
+          k = n
+          || (Char.code s.[i + k] land 0xc0 = 0x80 && continuations (k + 1))
+        in
+        continuations 1 && go (i + n)
+  in
+  go 0
+
+(* Fail at byte [pos] of [input] by demanding a character the input never holds,
+   and hand back the error record. *)
+let error_at input pos =
+  let r = of_string input in
+  for _ = 1 to pos do
+    skip r
+  done;
+  try
+    expect '\x01' r;
+    Alcotest.failf "expected a parse error at byte %d" pos
+  with Parse_error error -> error
+
+(* Lines and columns are 1-based and counted from the start of the input: the
+   byte just past a newline opens the next line at column 1, and the position
+   past the last byte of a line is one column beyond it. *)
+let error_line_and_column () =
+  let check name input pos expected =
+    Alcotest.(check string) name expected (error_at input pos).filename
+  in
+  check "start of the second line" "abc\n" 4 "<CSS input>:2:1";
+  check "start of the second line, longer first" "aaaaa\n" 6 "<CSS input>:2:1";
+  check "start of the third line" "ab\ncd\n" 6 "<CSS input>:3:1";
+  check "past the last character" "abc" 3 "<CSS input>:1:4"
+
+(* A column is one Unicode scalar value, for the reported column and for the
+   caret alike, so three euro signs put the error in column 4 with three
+   characters before the caret rather than nine bytes. *)
+let error_column_counts_characters () =
+  let error = error_at (euros 3) 9 in
+  Alcotest.(check string)
+    "column counts characters" "<CSS input>:1:4" error.filename;
+  Alcotest.(check int) "caret counts characters" 3 error.marker_pos
+
+(* The caret of pure ASCII stays where it was, one column per byte. *)
+let error_ascii_caret_holds () =
+  let error = error_at (String.make 50 'a') 50 in
+  Alcotest.(check string) "ascii column" "<CSS input>:1:51" error.filename;
+  Alcotest.(check int) "ascii caret" 40 error.marker_pos
+
+(* A window boundary landing inside a UTF-8 sequence moves out to the lead byte,
+   so the context a caret is drawn under is never a truncated code point. *)
+let error_context_window_keeps_code_points () =
+  let before = error_at (euros 40 ^ "xx") 122 in
+  Alcotest.(check bool)
+    "leading boundary keeps code points" true
+    (is_utf8 before.context_window);
+  let after = error_at ("x" ^ euros 40) 1 in
+  Alcotest.(check bool)
+    "trailing boundary keeps code points" true
+    (is_utf8 after.context_window)
+
 (* Grouped test runners by feature for simpler suite entries *)
 
 let tests_backtracking () =
@@ -1507,6 +1588,12 @@ let tests_call_stack () =
   fold_many_with_enum_context ();
   many_call_stack ();
   triple_call_stack ()
+
+let tests_error_position () =
+  error_line_and_column ();
+  error_column_counts_characters ();
+  error_ascii_caret_holds ();
+  error_context_window_keeps_code_points ()
 
 let tests_error_formatting () =
   error_formatting_multiline ();
@@ -1557,4 +1644,5 @@ let suite =
       test_case "call stack" `Quick tests_call_stack;
       (* Error formatting *)
       test_case "error formatting" `Quick tests_error_formatting;
+      test_case "error position" `Quick tests_error_position;
     ] )


### PR DESCRIPTION
`Reader.parse_error` reported the line and column of a failure from a walk that ran backwards from the error and reset the column at each newline, so it named the line before the error, and stopped at position zero, so it lost the last column at end of input. Its caret was also a byte count under a window sliced on byte offsets, the defect #472 fixed for `Loc.Context.snippet` on the other render path.

The UTF-8 scalar count and lead-byte snapping #472 added move to `Common.String` so both paths share them.