### PR TITLE
properties: read the logical position-area keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -191,6 +191,11 @@ answers.
   `Css.of_string ~strict:true` rejects it. CSS Syntax 3 sec. 5.5.3 makes the
   shape invalid so that a `{}`-block inside a custom property value is never
   misread as a rule; the drop itself was silent (#473)
+- `position-area` takes the logical `start`, `end`, `self-start` and
+  `self-end`, along with their `span-` forms. css-anchor-position-1
+  sec. 3.1.2 gives them two `{1,2}` branches of the grammar and browsers lay
+  them out, but cascade had no keyword for any of them and dropped the
+  declaration (#478)
 
 ### Printing
 

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -184,6 +184,14 @@ let pp_position_area_keyword : position_area_keyword Pp.t =
   | Span_inline_end -> Pp.string ctx "span-inline-end"
   | Span_block_start -> Pp.string ctx "span-block-start"
   | Span_block_end -> Pp.string ctx "span-block-end"
+  | Start -> Pp.string ctx "start"
+  | End -> Pp.string ctx "end"
+  | Span_start -> Pp.string ctx "span-start"
+  | Span_end -> Pp.string ctx "span-end"
+  | Self_start -> Pp.string ctx "self-start"
+  | Self_end -> Pp.string ctx "self-end"
+  | Span_self_start -> Pp.string ctx "span-self-start"
+  | Span_self_end -> Pp.string ctx "span-self-end"
   | Span_all -> Pp.string ctx "span-all"
 
 let rec pp_position_area : position_area Pp.t =
@@ -831,6 +839,14 @@ let read_position_area_keyword t : position_area_keyword =
       ("span-inline-end", Span_inline_end);
       ("span-block-start", Span_block_start);
       ("span-block-end", Span_block_end);
+      ("start", Start);
+      ("end", End);
+      ("span-start", Span_start);
+      ("span-end", Span_end);
+      ("self-start", Self_start);
+      ("self-end", Self_end);
+      ("span-self-start", Span_self_start);
+      ("span-self-end", Span_self_end);
       ("span-all", Span_all);
     ]
     t
@@ -846,7 +862,11 @@ let position_area_axis (keyword : position_area_keyword) =
   | Top | Bottom | Span_top | Span_bottom | Y_start | Y_end | Span_y_start
   | Span_y_end | Block_start | Block_end | Span_block_start | Span_block_end ->
       Vertical
-  | Center | Span_all -> Either
+  (* css-anchor-position-1 sec. 3.1.2: [center], [span-all] and the start/end
+     keywords that name neither the block nor the inline axis are ambiguous. *)
+  | Center | Span_all | Start | End | Span_start | Span_end | Self_start
+  | Self_end | Span_self_start | Span_self_end ->
+      Either
 
 let compatible_position_area_keywords first second =
   match (position_area_axis first, position_area_axis second) with

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3338,6 +3338,14 @@ type position_area_keyword =
   | Span_inline_end
   | Span_block_start
   | Span_block_end
+  | Start
+  | End
+  | Span_start
+  | Span_end
+  | Self_start
+  | Self_end
+  | Span_self_start
+  | Span_self_end
   | Span_all
 
 type position_area =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4053,6 +4053,22 @@ let spec_generated_position_interaction_edges () =
   check_position_area "center top";
   check_position_area ~expected:"center" "center center";
   check_position_area ~expected:"span-all" "span-all span-all";
+  (* css-anchor-position-1 sec. 3.1.2 has two {1,2} branches over the plain
+     logical keywords, [start] [end] [span-start] [span-end] [span-all], and
+     over their [self-] equivalents. The spec calls every start/end keyword that
+     names neither the block nor the inline axis ambiguous, so a lone one
+     repeats itself instead of standing for [X span-all]: [start start] folds to
+     [start], while [start end] and [end start] name distinct areas and survive
+     minification unchanged. *)
+  check_position_area "start";
+  check_position_area ~expected:"start" "start start";
+  check_position_area "start end";
+  check_position_area "end start";
+  check_position_area "start span-end";
+  check_position_area "span-start end";
+  check_position_area ~expected:"self-start" "self-start self-start";
+  check_position_area "self-start span-self-end";
+  check_position_area "span-self-start self-end";
   check_position_area_keyword "span-inline-start";
   check_position_try_fallback "flip-block";
   check_position_try_fallbacks ~expected:"flip-block,--fallback"


### PR DESCRIPTION
`position-area: start`, `start end` and their `self-` forms were dropped with a warning, taking down any file that held nothing else. css-anchor-position-1 sec. 3.1.2 gives those keywords two `{1,2}` branches of the grammar, and every one of them is axis-ambiguous, so `start start` folds to `start` while `start end` does not.