### PR TITLE
stylesheet: render the sheet once in to_string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -217,6 +217,11 @@ answers.
   which closes the rule around it. The declaration name, the `var()` reference
   and its fallback, the `@property` prelude and a `style()` container query all
   take the escaping (#435)
+- Serialising a stylesheet walks it once. `Css.to_string` sized its buffer
+  exactly by first rendering the whole sheet through a counter, so every
+  printer below it ran twice to save a buffer growth that is amortised
+  anyway; one walk cuts a 5000-rule sheet to 55% of the allocations and 69%
+  of the instructions, for byte-identical output (#479)
 
 ### Minification
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1565,14 +1565,14 @@ let pp_stylesheet : stylesheet Pp.t =
 
 (** {1 Rendering} *)
 
-(* Measure the output size with [Pp.size] and presize the buffer exactly. *)
+(* One walk of the tree. Presizing the buffer from a [Pp.size] prepass would
+   cost a second full walk - the counter sink skips the output bytes, not
+   [normalise], [printable_statements] or any printer below them - to save a
+   [Buffer] growth that is amortised anyway. *)
 let to_string ?(minify = false) ?indent ?lossless ?enforce_spec (statements : t)
     =
   let pp ctx () = pp_stylesheet ctx statements in
-  let size = Pp.size ~minify ?indent ?lossless ?enforce_spec pp () in
-  let buf = Buffer.create size in
-  Pp.to_buffer ~minify ?indent ?lossless ?enforce_spec buf pp ();
-  Buffer.contents buf
+  Pp.to_string ~minify ?indent ?lossless ?enforce_spec pp ()
 
 let pp = to_string
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -9832,6 +9832,76 @@ let deep_walker_tests =
           Alcotest.fail "statement edit rebuilt an unchanged stylesheet" );
   ]
 
+(* --- rendering --- *)
+
+(* [to_string] and the bare formatter run the same printer, so they agree byte
+   for byte; the only difference either may have is how the output bytes are
+   collected. *)
+let one_pass ~minify sheet =
+  let pp ctx () = pp_stylesheet ctx sheet in
+  Css.Pp.to_string ~minify pp ()
+
+let render_sheet n =
+  let b = Buffer.create (n * 96) in
+  let out = Fmt.with_buffer b in
+  for i = 0 to n - 1 do
+    Fmt.pf out
+      ".c%d .d%d > span:hover{color:rgb(%d,%d,%d);margin:%dpx \
+       %dpx;padding:%dpx;display:flex}@media (min-width:%dpx){.m%d{outline:1px \
+       solid #abc}}"
+      i i (i mod 256)
+      (i * 7 mod 256)
+      (i * 13 mod 256)
+      (i mod 40)
+      (i * 3 mod 40)
+      (i mod 20)
+      (300 + (i mod 900))
+      i
+  done;
+  Fmt.flush out ();
+  Css.of_string_exn (Buffer.contents b)
+
+let measure f =
+  Gc.full_major ();
+  let w0 = Gc.minor_words () in
+  let r = f () in
+  ignore (Sys.opaque_identity r);
+  Gc.minor_words () -. w0
+
+(* A serialiser walks the tree once. Presizing the buffer from a [Pp.size]
+   prepass walks it a second time, and the counter sink skips only the output
+   bytes: [normalise], [printable_statements] and every printer below them run
+   twice. Buffer growth is amortised, so the second walk buys nothing, and its
+   cost is the whole formatter rather than a rounding error - pin it well below
+   the 1.8x the prepass measured. *)
+let to_string_renders_once minify () =
+  let sheet = render_sheet 400 in
+  let a_one = measure (fun () -> one_pass ~minify sheet) in
+  let a_full = measure (fun () -> to_string ~minify sheet) in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.2fx the one-pass walk)" a_one a_full
+       (a_full /. a_one))
+    true
+    (a_one = 0. || a_full < a_one *. 1.25)
+
+let to_string_matches_one_pass minify () =
+  let sheet = render_sheet 400 in
+  Alcotest.(check string)
+    "same bytes" (one_pass ~minify sheet) (to_string ~minify sheet)
+
+let render_tests =
+  [
+    ( "to_string minified matches the bare formatter",
+      `Quick,
+      to_string_matches_one_pass true );
+    ( "to_string pretty matches the bare formatter",
+      `Quick,
+      to_string_matches_one_pass false );
+    ("to_string renders minified once", `Quick, to_string_renders_once true);
+    ("to_string renders pretty once", `Quick, to_string_renders_once false);
+  ]
+
 let suite =
   ( "stylesheet",
-    stylesheet_tests @ additional_tests @ walker_tests @ deep_walker_tests )
+    stylesheet_tests @ additional_tests @ walker_tests @ deep_walker_tests
+    @ render_tests )


### PR DESCRIPTION
`Css.to_string` rendered the whole sheet twice: once through `Pp.size`'s counter sink to presize the buffer, then again for real. The counter skips the output bytes but not `normalise`, `printable_statements` or any printer below them, so a 5000-rule sheet cost 4.92M words per render against 2.72M for a single walk, and 6.15G instructions against 4.25G over 20 renders; the buffer growth the prepass saved is amortised anyway.

Output is byte-identical across the 797 `test/interop` CSS files (minified and pretty) and all 2960 `minify.pairs` records.