### PR TITLE
inline: keep var() inlining linear in at-rule nesting depth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -404,6 +404,10 @@ answers.
 
 ### Custom properties
 
+- `Css.inline_vars` stays linear in at-rule nesting depth. Each of its four
+  walks rebuilt the enclosing `@media`/`@layer`/`@supports` chain at every
+  level, so the cost grew with the square of the depth: one variable inside 800
+  nested blocks allocated 8.9M words, now 221K (#481)
 - `Css.resolve_theme` accounts for the declarations `@keyframes`, `@page`,
   `@position-try` and `@supports-condition` carry: a name referenced only from
   inside one of them keeps its theme binding, a name whose only declaration

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -61,6 +61,9 @@ let selector_covers ~ancestor ~consumer =
 
 (** {1 At-rule path} *)
 
+(* One at-rule wrapper a statement sits inside. A path is the whole chain, held
+   innermost-first so that descending conses onto the parent's chain rather than
+   copying it. *)
 type at_node =
   | Media of Media.t
   | Layer of Stylesheet.layer_name option
@@ -83,16 +86,27 @@ let rec drop_layers = function
   | Layer _ :: rest -> drop_layers rest
   | node :: rest -> node :: drop_layers rest
 
+let rec drop_deeper n (path : at_node list) =
+  if n <= 0 then path
+  else match path with [] -> [] | _ :: rest -> drop_deeper (n - 1) rest
+
+(* Nodes compare structurally, as the prefix form compared them. [Media.equal]
+   and its neighbours answer on the serialised query, which would make
+   [(min-width:10px)] and [(width>=10px)] one barrier rather than two. *)
+let rec same_path (a : at_node list) (b : at_node list) =
+  match (a, b) with
+  | [], [] -> true
+  | x :: a, y :: b -> x = y && same_path a b
+  | _ -> false
+
 (* Visibility through at-rule wrappers: a custom property defined outside
-   (shorter path) is visible to consumers further inside (longer path). *)
+   (shorter path) is visible to consumers further inside (longer path). A path
+   is held innermost-first, so "outside" is the tail: [outer] reaches [inner]
+   when it is a suffix of it. *)
 let at_path_prefix ~outer ~inner =
-  let rec prefix outer inner =
-    match (outer, inner) with
-    | [], _ -> true
-    | _, [] -> false
-    | a :: outer, b :: inner -> a = b && prefix outer inner
-  in
-  prefix (drop_layers outer) (drop_layers inner)
+  let outer = drop_layers outer and inner = drop_layers inner in
+  let deeper = List.length inner - List.length outer in
+  deeper >= 0 && same_path outer (drop_deeper deeper inner)
 
 let at_wrapper : statement -> (at_node * t * (t -> statement)) option = function
   | Stylesheet.Layer (n, b) ->
@@ -188,7 +202,7 @@ let collect_scopes ~kept stylesheet =
   let rec walk_stmt ~parents ~at_path stmt =
     match at_wrapper stmt with
     | Some (node, body, _) ->
-        List.iter (walk_stmt ~parents ~at_path:(at_path @ [ node ])) body
+        List.iter (walk_stmt ~parents ~at_path:(node :: at_path)) body
     | None -> walk_non_at ~parents ~at_path stmt
   and walk_non_at ~parents ~at_path = function
     | Rule rule ->
@@ -656,7 +670,7 @@ and substitute_stmt ~kept ~scopes ~parents ~at_path stmt =
   match at_wrapper stmt with
   | Some (node, body, rebuild) ->
       rebuild
-        (substitute ~kept ~scopes ~parents ~at_path:(at_path @ [ node ]) body)
+        (substitute ~kept ~scopes ~parents ~at_path:(node :: at_path) body)
   | None -> (
       match stmt with
       | Rule rule ->
@@ -892,7 +906,7 @@ let collect_scoped_refs stylesheet =
     match at_wrapper stmt with
     | Some (node, body, _) ->
         record_at_node_refs consumers ~parents ~at_path node;
-        List.iter (walk_stmt ~parents ~at_path:(at_path @ [ node ])) body
+        List.iter (walk_stmt ~parents ~at_path:(node :: at_path)) body
     | None -> walk_non_at ~parents ~at_path stmt
   and walk_non_at ~parents ~at_path stmt =
     match stmt with
@@ -1080,7 +1094,7 @@ let strip_dead ~keep ~live_set stmts =
   and map_stmt ~parents ~at_path stmt =
     match at_wrapper stmt with
     | Some (node, body, rebuild) -> (
-        match map_stmts ~parents ~at_path:(at_path @ [ node ]) body with
+        match map_stmts ~parents ~at_path:(node :: at_path) body with
         | [] -> None
         | b -> Some (rebuild b))
     | None -> map_non_at ~parents ~at_path stmt
@@ -1385,9 +1399,11 @@ let flattening_layers_is_safe stylesheet =
    the dotted layer), [None] when the path is conditional or holds an anonymous
    layer - those are not statically foldable. *)
 let foldable_layer_of_at_path at_path : string option option =
+  (* Walking an innermost-first path and consing leaves [path] outermost-first,
+     which is the order the dotted layer name reads in. *)
   let rec go path : at_node list -> string option option = function
     | [] -> (
-        match List.rev path with
+        match path with
         | [] -> Some None
         | ns -> Some (Some (Stylesheet.string_of_layer_name (List.concat ns))))
     | Layer (Some n) :: rest -> go (n :: path) rest

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -520,9 +520,71 @@ let test_inline_layer_flattening () =
     "@layer b{.x{color:blue}}@layer a{.y{padding:1px}}"
     ".x{color:blue}.y{padding:1px}"
 
+(* An at-rule path is a containment test, not an equality: a custom property is
+   visible to a consumer wrapped in every block it sits in and then some, and to
+   nobody outside its own. A [@layer] is transparent to that test, so a path
+   crossing one still has to line the conditional blocks up. Both directions pin
+   the orientation the paths are compared in. *)
+let test_inline_at_path_containment () =
+  check_inline_case "an outer definition reaches a deeper consumer"
+    "@media print{@media (min-width:10px){:root{--x:red}@layer l{@media \
+     (min-width:20px){.a{color:var(--x)}}}}}"
+    "@media print{@media(min-width:10px){@layer \
+     l{@media(min-width:20px){.a{color:red}}}}}";
+  check_inline_case "an inner definition does not reach an outer consumer"
+    "@media print{:root{--x:red}}.a{color:var(--x)}" ".a{color:var(--x)}";
+  check_inline_case "a sibling block at the same depth is not an enclosing one"
+    "@media print{:root{--x:red}}@media screen{.a{color:var(--x)}}"
+    "@media screen{.a{color:var(--x)}}"
+
+(* --- allocation / complexity guard --- *)
+
+let measure f =
+  Gc.full_major ();
+  let w0 = Gc.minor_words () in
+  let r = f () in
+  ignore (Sys.opaque_identity r);
+  Gc.minor_words () -. w0
+
+(* [depth] nested [@media print] blocks around one rule that declares and reads
+   a single custom property. The variable count, the scope count and the
+   declaration count are all held at one, so the at-rule path depth is the only
+   thing that varies. *)
+let nested_media depth =
+  let b = Buffer.create ((depth * 14) + 32) in
+  for _ = 1 to depth do
+    Buffer.add_string b "@media print{"
+  done;
+  Buffer.add_string b ".a{--x:red;color:var(--x)}";
+  for _ = 1 to depth do
+    Buffer.add_char b '}'
+  done;
+  parse (Buffer.contents b)
+
+(* Each of the passes below descends carrying the chain of enclosing at-rules.
+   Extending that chain by copying it costs one cell per enclosing block, so a
+   depth-[d] chain pays 1 + 2 + ... + d per pass before a single liveness
+   question is asked; sharing the tail costs one cell per level. That is the
+   difference between quadrupling and doubling on twice the depth, so pin the
+   ratio below the halfway point. Minor words rather than total allocation: the
+   chain is short-lived scratch, and counting the major heap would fold in an
+   output string that grows with the depth. *)
+let test_inline_at_path_cost_is_linear () =
+  let shallow = nested_media 100 and deep = nested_media 200 in
+  let a1 = measure (fun () -> Css.inline_vars shallow) in
+  let a2 = measure (fun () -> Css.inline_vars deep) in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.2fx for 2x depth)" a1 a2 (a2 /. a1))
+    true
+    (a1 = 0. || a2 < a1 *. 2.5)
+
 let suite =
   ( "inline",
     [
+      Alcotest.test_case "inline vars contain a definition to its at-rule path"
+        `Quick test_inline_at_path_containment;
+      Alcotest.test_case "inline vars cost stays linear in at-rule depth" `Quick
+        test_inline_at_path_cost_is_linear;
       Alcotest.test_case "inline vars substitute visible custom properties"
         `Quick test_inline_substitutes_vars;
       Alcotest.test_case "inline vars keep requested references" `Quick


### PR DESCRIPTION
`Css.inline_vars` carried the enclosing at-rule chain by appending to it at every level, in each of its four walks, so inlining one variable inside deeply nested `@media`/`@layer`/`@supports` blocks cost time and memory quadratic in the depth. Carrying the chain as a shared tail makes it linear: one variable inside 800 nested blocks goes from 8.9M allocated words to 221K, and the whole `fmt --minify --inline-vars` run from 980M instructions to 84M.