### PR TITLE
values: give a folded NaN the same node the NaN keyword parses to

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -225,9 +225,9 @@ answers.
 
 ### Minification
 
-- `--minify` merges two rules that declare the same NaN, such as
-  `opacity: calc(infinity - infinity)`. Structural equality read a NaN as
-  different from itself, which the declaration hash never did (#471)
+- `--minify` merges two rules that declare the same NaN, whichever way each
+  spelled it: `opacity: calc(NaN)` and `opacity: calc(infinity - infinity)`
+  are one declaration (#471, #482)
 - `--minify` merges adjacent `@container` blocks whose `style()` conditions
   are written the same way. The comparison reached the source byte offsets
   every token carries, so two byte-identical `style(--x: 1)` queries never

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -642,6 +642,15 @@ let calc_operand_value : type a. a calc -> a calc = function
   | Math_const c -> Num (math_const_value c)
   | other -> other
 
+(* The other direction, for a fold that lands on a NaN. Sec. 10.7.2 resolves
+   [NaN] at parse time into a keyword of the [<number>] grammar and sec. 10.13
+   serialises every NaN-valued calculation through that keyword, so CSS has one
+   NaN and one node for it: a [Num] carrying the float would print [calc(NaN)]
+   too and hash apart from the keyword the same text parses to. [infinity] /
+   [-infinity] are constants of their own in that list and keep their values. *)
+let calc_num : type a. float -> a calc =
+ fun f -> if Float.is_nan f then Math_const Nan else Num f
+
 let rec minify_angle_arg : angle_arg -> angle_arg = function
   | Operation (l, op, r) -> (
       let l = minify_angle_arg l in
@@ -1116,7 +1125,7 @@ let unwrap_grouping : type a.
     ctx:calc_ctx -> rewrap:(a calc -> a calc) -> a calc -> a calc =
  fun ~ctx ~rewrap reduced ->
   match reduced with
-  | (Val _ | Num _) as leaf -> leaf
+  | (Val _ | Num _ | Math_const _) as leaf -> leaf
   | Var v as leaf when ctx.var_is_single_valued v.name -> leaf
   | reduced -> rewrap reduced
 
@@ -1146,11 +1155,13 @@ let rec eval_calc : type a. ?ctx:calc_ctx -> a calc -> a calc =
       let lc = calc_operand_value l in
       let rc = calc_operand_value r in
       match (lc, op, rc) with
-      | Num a, Add, Num b -> Num (a +. b)
-      | Num a, Sub, Num b -> Num (a -. b)
-      | Num a, Mul, Num b -> Num (a *. b)
+      | Num a, Add, Num b -> calc_num (a +. b)
+      | Num a, Sub, Num b -> calc_num (a -. b)
+      | Num a, Mul, Num b -> calc_num (a *. b)
       | Num a, Div, Num b -> (
-          match exact_div a b with Some q -> Num q | None -> Expr (l, op, r))
+          match exact_div a b with
+          | Some q -> calc_num q
+          | None -> Expr (l, op, r))
       | _ -> (
           match
             calc_identity ~zero:(Num 0.) ~is_zero:(fun _ -> false) l op r
@@ -1201,11 +1212,11 @@ let fold_typed_expr : type a.
   in
   let value v = (Val v, computed) in
   match (lc, op, rc) with
-  | Num a, Add, Num b -> (Num (a +. b), false)
-  | Num a, Sub, Num b -> (Num (a -. b), false)
-  | Num a, Mul, Num b -> (Num (a *. b), false)
+  | Num a, Add, Num b -> (calc_num (a +. b), false)
+  | Num a, Sub, Num b -> (calc_num (a -. b), false)
+  | Num a, Mul, Num b -> (calc_num (a *. b), false)
   | Num a, Div, Num b -> (
-      match exact_div a b with Some q -> (Num q, false) | None -> keep ())
+      match exact_div a b with Some q -> (calc_num q, false) | None -> keep ())
   | _ when Option.is_some (fold_zero_numeric_expr lc op rc) ->
       (Option.get (fold_zero_numeric_expr lc op rc), false)
   | Val a, op, Val b -> (

--- a/test/cli/minify_nan_merge.t
+++ b/test/cli/minify_nan_merge.t
@@ -13,3 +13,26 @@ declaration and merge, exactly as the ordinary-float pair below does.
   > CSS
   $ cascade --minify nan.css
   .a,.b{opacity:calc(NaN)}.c,.d{opacity:.5}
+
+The keyword and a calculation that lands on NaN are the same value, so they
+merge too. Sec. 10.7.2 resolves NaN at parse time and sec. 10.13 gives it one
+serialisation, which leaves the source spelling nothing to carry.
+
+  $ cat > spellings.css <<CSS
+  > .a { opacity: calc(NaN) }
+  > .b { opacity: calc(infinity - infinity) }
+  > CSS
+  $ cascade --minify spellings.css
+  .a,.b{opacity:calc(NaN)}
+
+infinity and -infinity are constants of their own in that same list, each with
+its own serialisation, so the three stay three values.
+
+  $ cat > constants.css <<CSS
+  > .a { opacity: calc(NaN) }
+  > .b { opacity: calc(infinity) }
+  > .c { opacity: calc(infinity) }
+  > .d { opacity: calc(-infinity) }
+  > CSS
+  $ cascade --minify constants.css
+  .a{opacity:calc(NaN)}.b,.c{opacity:calc(infinity)}.d{opacity:calc(-infinity)}

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3042,11 +3042,94 @@ let nan_declaration_is_one_value () =
     "the float control merges" ".c,.d{opacity:.5}"
     (minified ".c{opacity:.5}.d{opacity:.5}")
 
+(* CSS Values 4 sec. 10.7.2 gives NaN one spelling and one resolution: it is a
+   keyword of the <number> grammar that resolves at parse time, so a NaN reaches
+   the AST as that keyword rather than as a float a calculation happened to land
+   on. Sec. 10.13 serialises every NaN-valued calculation the same way,
+   calc(NaN) for a <number> and calc(NaN * 1px) once the value carries a unit.
+   One value, one node: however the source spelled the NaN, the declaration that
+   holds it is the same declaration, so it merges and it hashes the same.
+
+   infinity and -infinity are separate constants of the same sec. 10.7.2 list,
+   each with its own serialisation, so they stay three distinct values. *)
+let same_text_same_hash label a b =
+  let text = Css.Declaration.to_string ~minify:true a in
+  Alcotest.(check string)
+    (label ^ ": one minified text")
+    text
+    (Css.Declaration.to_string ~minify:true b);
+  Alcotest.(check int)
+    (label ^ ": one hash") (Css.Declaration.hash a) (Css.Declaration.hash b);
+  Alcotest.(check bool)
+    (label ^ ": one declaration")
+    true
+    (Css.Declaration.equal_declaration a b)
+
+let distinct_value label a b =
+  Alcotest.(check bool)
+    (label ^ ": two texts") false
+    (String.equal
+       (Css.Declaration.to_string ~minify:true a)
+       (Css.Declaration.to_string ~minify:true b));
+  Alcotest.(check bool)
+    (label ^ ": two declarations")
+    false
+    (Css.Declaration.equal_declaration a b)
+
+let nan_has_one_node () =
+  (* The keyword and the calculation that lands on NaN are the same value. *)
+  let keyword = sole_declaration ".a{opacity:calc(NaN)}" in
+  let computed = sole_declaration ".b{opacity:calc(infinity - infinity)}" in
+  Alcotest.(check string)
+    "the keyword spells calc(NaN)" "opacity:calc(NaN)"
+    (Css.Declaration.to_string ~minify:true keyword);
+  same_text_same_hash "keyword vs computed" keyword computed;
+  Alcotest.(check string)
+    "the two spellings merge" ".a,.b{opacity:calc(NaN)}"
+    (minified ".a{opacity:calc(NaN)}.b{opacity:calc(infinity - infinity)}");
+  (* Spellings a calculation keeps rather than folds stay one value each. *)
+  Alcotest.(check string)
+    "calc(0/0) merges" ".a,.b{opacity:calc(0/0)}"
+    (minified ".a{opacity:calc(0/0)}.b{opacity:calc(0/0)}");
+  Alcotest.(check string)
+    "calc(asin(2)) merges" ".a,.b{opacity:calc(asin(2))}"
+    (minified ".a{opacity:calc(asin(2))}.b{opacity:calc(asin(2))}");
+  Alcotest.(check string)
+    "a NaN length merges" ".a,.b{width:calc(NaN*1px)}"
+    (minified ".a{width:calc(NaN*1px)}.b{width:calc(NaN*1px)}");
+  Alcotest.(check string)
+    "a NaN duration merges" ".a,.b{transition-duration:calc(NaN*1s)}"
+    (minified
+       ".a{transition-duration:calc(NaN*1s)}.b{transition-duration:calc(NaN*1s)}");
+  Alcotest.(check string)
+    "a NaN length expression merges"
+    ".a,.b{width:calc(infinity*1px - infinity*1px)}"
+    (minified
+       ".a{width:calc(infinity*1px - infinity*1px)}.b{width:calc(infinity*1px \
+        - infinity*1px)}");
+  (* The other two degenerate constants keep their own values. *)
+  let inf = sole_declaration ".c{opacity:calc(infinity)}" in
+  let inf' = sole_declaration ".d{opacity:calc(infinity)}" in
+  let neg_inf = sole_declaration ".e{opacity:calc(-infinity)}" in
+  same_text_same_hash "infinity vs infinity" inf inf';
+  distinct_value "infinity vs -infinity" inf neg_inf;
+  distinct_value "infinity vs NaN" inf keyword;
+  distinct_value "-infinity vs NaN" neg_inf keyword;
+  Alcotest.(check string)
+    "infinity merges with itself" ".c,.d{opacity:calc(infinity)}"
+    (minified ".c{opacity:calc(infinity)}.d{opacity:calc(infinity)}");
+  Alcotest.(check string)
+    "the three constants stay apart"
+    ".a{opacity:calc(NaN)}.c{opacity:calc(infinity)}.e{opacity:calc(-infinity)}"
+    (minified
+       ".a{opacity:calc(NaN)}.c{opacity:calc(infinity)}.e{opacity:calc(-infinity)}")
+
 let declaration_tests =
   [
     (* Core declaration type testing *)
     test_case "declaration" `Quick test_declaration;
     test_case "NaN is one declared value" `Quick nan_declaration_is_one_value;
+    test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "parse_declaration" `Quick parse_declaration_case;
     (* Parsing basics *)
     test_case "simple" `Quick simple;


### PR DESCRIPTION
`opacity: calc(NaN)` and `opacity: calc(infinity - infinity)` both minified to `opacity:calc(NaN)` but hashed apart, so two rules declaring the one value stayed two rules. A fold that landed on NaN now rebuilds the `NaN` keyword the same text parses to, leaving `infinity` and `-infinity` their own values; minified output over the 797 `test/interop` files and the 2960 `minify.pairs` inputs is byte-identical. Follow-up to #471.