### PR TITLE
stylesheet: close what an unrecognised at-rule left open

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -184,8 +184,10 @@ answers.
   intact, where `cascade fmt` deleted it and every rule inside it without
   saying so. CSS Syntax 3 sec. 5.4.2 consumes an at-rule whatever its
   at-keyword; discarding one is the user agent's step, and
-  `Optimize.drop_unknown_at_rules` serves a caller writing for a browser
-  (#469)
+  `Optimize.drop_unknown_at_rules` serves a caller writing for a browser. A
+  string, url, function, bracket or comment the source stopped inside is closed
+  on the way in, so what is written back ends the at-rule instead of swallowing
+  its `;` or `}` (#469, #483)
 - A qualified rule whose prelude reads as a custom property, such as
   `--x:hover { color: red }`, is reported when it is dropped, and
   `Css.of_string ~strict:true` rejects it. CSS Syntax 3 sec. 5.5.3 makes the

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3097,6 +3097,74 @@ let read_viewport_with_prefix prefix at_keyword (r : Cursor.t) : statement =
 let read_viewport = read_viewport_with_prefix Standard "viewport"
 let read_ms_viewport = read_viewport_with_prefix Ms_prefixed "-ms-viewport"
 
+(* CSS Syntax 3 (ED) sec. 4.3.5 closes a string at end of input, 4.3.6 a url,
+   4.3.2 a comment, and 5.5.9 and 5.5.10 a simple block and a function. Raw text
+   that stops mid-construct therefore means the closed form, but written back as
+   it stands it hands the next reader an opener that eats the [;] or [}] the
+   at-rule ends with. These close it, once, so the AST holds text that reads
+   back as itself. *)
+let bracket_closer = function
+  | Token.Curly -> "}"
+  | Token.Paren -> ")"
+  | Token.Square -> "]"
+
+(* One pass: the closers the open blocks and functions still want, innermost
+   first, with the last token and the token count for [tail_closer]. *)
+let scan_raw text =
+  let lexer = Lexer.of_string text in
+  let rec loop stack last n =
+    let tok = Lexer.next lexer in
+    match tok.Token.kind with
+    | Token.Eof -> (stack, last, n)
+    | Token.Function _ -> loop (")" :: stack) (Some tok) (n + 1)
+    | Token.Open b -> loop (bracket_closer b :: stack) (Some tok) (n + 1)
+    | Token.Close b ->
+        let stack =
+          match stack with
+          | c :: rest when String.equal c (bracket_closer b) -> rest
+          | _ -> stack
+        in
+        loop stack (Some tok) (n + 1)
+    | _ -> loop stack (Some tok) (n + 1)
+  in
+  loop [] None 0
+
+(* A string, a url and a comment run to end of input and close there without
+   leaving an opener on the stack, so ask the tokenizer rather than re-deriving
+   its state: text that swallows the probe gives back no token for it. Two probe
+   code points, since a [\] at end of input eats one and returns it as an
+   ident. *)
+let tail_closer text last n =
+  let lexer = Lexer.of_string (String.concat "" [ text; ";;" ]) in
+  let rec count n =
+    match (Lexer.next lexer).Token.kind with
+    | Token.Eof -> n
+    | _ -> count (n + 1)
+  in
+  if count 0 <> n then []
+  else
+    match last with
+    | Some { Token.kind = Token.String { quote; terminated = false; _ }; _ } ->
+        [ String.make 1 quote ]
+    | Some { Token.kind = Token.Url _ | Token.Bad_url; loc }
+      when loc.Loc.end_pos = String.length text ->
+        [ ")" ]
+    | _ -> [ "*/" ]
+
+(* Closing one construct can uncover another: a [\] before the closing quote
+   escapes it and leaves the string open, so re-read until the text settles. *)
+let rec close_raw fuel text =
+  let stack, last, n = scan_raw text in
+  match List.append (tail_closer text last n) stack with
+  | [] -> text
+  | closers ->
+      let closed = String.concat "" (text :: closers) in
+      if fuel <= 1 then closed else close_raw (fuel - 1) closed
+
+(* One pass closes what the stack holds; the other two are for a closer that a
+   [\] at end of input escapes before it lands. *)
+let close_open_constructs = close_raw 3
+
 (* CSS Syntax 3 sec. 5.4.6: an unclosed block runs to EOF, so its slice has no
    closer to exclude and instead carries whatever [}] an unterminated nested
    construct swallowed on the way. The serializer supplies its own closer, so
@@ -3118,7 +3186,9 @@ let trim_unknown_block_body body =
 let unknown_block_body slice (block : Component.block Component.node) =
   let start = block.loc.Loc.start_pos + 1 in
   if block.node.Component.closed then slice start (block.loc.Loc.end_pos - 1)
-  else slice start block.loc.Loc.end_pos |> trim_unknown_block_body
+  else
+    slice start block.loc.Loc.end_pos
+    |> trim_unknown_block_body |> close_open_constructs
 
 (* CSS Syntax 3 sec. 5.5.2 "consume an at-rule": after the at-keyword has been
    consumed, walk components until we hit [;] (no block) or [{...}] (block). Raw
@@ -3151,8 +3221,17 @@ let read_unknown_at_rule name (r : Cursor.t) : statement =
         gather ()
   in
   gather ();
+  (* The block form knows it ran to EOF from [closed] and pays for the scan only
+     then; a statement one cannot, because [cursor_of_rule] gives the at-rule a
+     [;] whether the source ended in one or in EOF. A prelude that is already
+     closed comes back unchanged, so close it either way - after the trim the
+     printer applies, so the closer lands where the trim would have ended the
+     text rather than after the run of whitespace it takes off. *)
   let prelude =
-    if !prelude_start < 0 then "" else slice !prelude_start !prelude_end
+    if !prelude_start < 0 then ""
+    else
+      slice !prelude_start !prelude_end
+      |> trim_unknown_at_prelude |> close_open_constructs
   in
   Unknown_at_rule { name; prelude; block = !block }
 

--- a/test/cli/fmt_unknown_at_rule.t
+++ b/test/cli/fmt_unknown_at_rule.t
@@ -66,3 +66,33 @@ minifying it lands back on the minified form.
   identical
   $ cascade fmt --minify pretty.css 2> /dev/null
   @future x{a{color:red}}b{color:#00f}
+
+A body cut short mid-construct still ends where the AST says it ends.
+CSS Syntax 3 (ED) sec. 4.3.5 returns the string token at end of input,
+4.3.6 the url token, and sec. 5.5.9 and 5.5.10 close a simple block and a
+function there, so the text carried means the closed form. Left open it
+eats the `}` and the at-rule runs on into whatever follows.
+
+  $ printf '@o x{ a "i' | cascade fmt --minify - 2> /dev/null
+  @o x{ a "i"}
+  $ printf '@o x{ a url(i' | cascade fmt --minify - 2> /dev/null
+  @o x{ a url(i)}
+  $ printf '@o x{ a f(i' | cascade fmt --minify - 2> /dev/null
+  @o x{ a f(i)}
+  $ printf '@o x{ a [i' | cascade fmt --minify - 2> /dev/null
+  @o x{ a [i]}
+  $ printf '@o x{ a (i' | cascade fmt --minify - 2> /dev/null
+  @o x{ a (i)}
+
+A well-formed body is untouched.
+
+  $ printf '@o x{ a b }' | cascade fmt --minify - 2> /dev/null
+  @o x{ a b }
+
+Written back, the at-rule ends where it ended: a rule appended to the
+output is a second statement, not more of the at-rule.
+
+  $ printf '@o x{ a "i' | cascade fmt --minify - 2> /dev/null > cut.css
+  $ printf '.z{color:red}' >> cut.css
+  $ cascade fmt --minify cut.css 2> /dev/null
+  @o x{ a "i"}.z{color:red}

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2699,9 +2699,86 @@ let s542_unknown_at_rule_block_body () =
     "@foo{a{b{c:d}}}";
   roundtrips "an empty body stays empty" "@foo{}" "@foo{}";
   roundtrips "an unterminated function does not stack closers" "@foo{a:(b}"
-    "@foo{a:(b}";
+    "@foo{a:(b)}";
   roundtrips "an unterminated nested block gets one closer" "@foo{a{b:c"
-    "@foo{a{b:c}"
+    "@foo{a{b:c}}"
+
+(* CSS Syntax 3 (ED) sec. 5.5.2 "consume an at-rule" reads a prelude and a block
+   whatever the at-keyword spells, and cascade keeps both as the source text it
+   cannot re-serialise from a grammar. Sec. 4.3.5 returns the string token at
+   end of input and 4.3.6 the url token, both calling it a parse error, 4.3.2
+   ends the comment there and calls that one too, and sec. 5.5.9 and 5.5.10
+   close a simple block and a function on the EOF token. Each defines what end
+   of input leaves, so text that stopped mid-construct means the closed form.
+   Written back open, that construct swallows the [;] or [}] the at-rule ends
+   with, and the next reader sees one at-rule where cascade held an at-rule and
+   the rule after it. *)
+let s552_unknown_at_rule_eof_closers () =
+  let printed input =
+    String.trim
+      (Css.Stylesheet.to_string ~minify:true
+         (read_stylesheet (Cursor.of_string input)))
+  in
+  (* The at-rule has to end on its own: append a rule to what was printed and
+     both must come back, and re-reading must report nothing left
+     unterminated. *)
+  let self_delimiting name printed =
+    let input = String.concat "" [ printed; ".z{color:red}" ] in
+    let { Css.stylesheet; warnings } =
+      match Css.of_string ~strict:false input with
+      | Ok parsed -> parsed
+      | Error err ->
+          Alcotest.failf "%s: %S failed to reparse: %s" name input
+            (Cascade.Error.to_string err)
+    in
+    Alcotest.(check int)
+      (String.concat "" [ name; ": the rule after it survives" ])
+      2
+      (List.length (Css.statements stylesheet));
+    let unterminated =
+      List.filter
+        (fun (e : Error.t) ->
+          match e.Error.kind with Error.Unterminated _ -> true | _ -> false)
+        warnings
+    in
+    Alcotest.(check int)
+      (String.concat "" [ name; ": nothing left unterminated" ])
+      0 (List.length unterminated)
+  in
+  let closes name input expected =
+    Alcotest.(check string) name expected (printed input);
+    Alcotest.(check string)
+      (String.concat "" [ name; " is a fixed point" ])
+      expected (printed expected);
+    self_delimiting name expected
+  in
+  closes "a string closes at end of input" "@o x{ a \"i" "@o x{ a \"i\"}";
+  closes "a single-quoted string closes too" "@o x{ a 'i" "@o x{ a 'i'}";
+  closes "a url closes at end of input" "@o x{ a url(i" "@o x{ a url(i)}";
+  closes "a bad url closes too" "@o x{ a url(i j" "@o x{ a url(i j)}";
+  closes "a function closes at end of input" "@o x{ a f(i" "@o x{ a f(i)}";
+  closes "a square block closes at end of input" "@o x{ a [i" "@o x{ a [i]}";
+  closes "a paren block closes at end of input" "@o x{ a (i" "@o x{ a (i)}";
+  closes "a curly block closes at end of input" "@o x{ a { b" "@o x{ a { b}}";
+  closes "a comment ends at end of input" "@o x{ a /* b" "@o x{ a /* b*/}";
+  (* The prelude runs to the [;] the at-rule ends with, and swallows it the same
+     way. *)
+  closes "a prelude string closes at end of input" "@o \"i" "@o \"i\";";
+  closes "a prelude url closes at end of input" "@o url(i" "@o url(i);";
+  (* Sec. 4.3.6 reads the whitespace before the missing [)] and keeps none of it
+     in the url, so the closer takes its place rather than following it: a
+     minified stylesheet carries no newline of its own. *)
+  closes "whitespace before a missing closer is not carried" "@o url(i\n"
+    "@o url(i);";
+  closes "a prelude function closes at end of input" "@o f(i" "@o f(i);";
+  (* Controls: nothing is open, so nothing is added. *)
+  closes "a closed body is untouched" "@o x{ a b }" "@o x{ a b }";
+  closes "a quote inside a comment is not an opener" "@o x{ a /* \" */ b"
+    "@o x{ a /* \" */ b}";
+  closes "an escaped quote is not an opener" "@o x{ a \"i\\\"j\""
+    "@o x{ a \"i\\\"j\"}";
+  closes "a closed url is not reopened" "@o x{url(a)}" "@o x{url(a)}";
+  closes "a closed prelude is untouched" "@o bar" "@o bar;"
 
 (* Gecko's [@document]/[@-moz-document] takes a comma-separated list of [<url> |
    url-prefix(<string>) | domain(<string>) | media-document(<string>) |
@@ -8659,6 +8736,9 @@ let additional_tests =
     ( "spec CSS Syntax 5.4.2 unknown at-rule block body",
       `Quick,
       s542_unknown_at_rule_block_body );
+    ( "spec CSS Syntax 5.5.2 unknown at-rule raw text closes at EOF",
+      `Quick,
+      s552_unknown_at_rule_eof_closers );
     ( "spec CSS Syntax 4.3.1 unknown at-rule prelude separator",
       `Quick,
       s3431_unknown_at_rule_prelude_separator );


### PR DESCRIPTION
`@o x{ a "i` printed as `@o x{ a "i}`, where the unterminated string swallows the closing brace, so the at-rule never ends and the next rule is read as more of its body. CSS Syntax 3 closes a string, url, function, bracket and comment at end of input, so the preserved text now carries those closers.

Builds on #469, which is what makes an at-rule cascade cannot interpret reach the output at all; both are one changelog entry.