### PR TITLE
parser: report the blocks and rules EOF recovery repairs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,9 @@ answers.
 
 ### Parsing
 
+- Everything the parser repaired or dropped is reported, so strict mode
+  rejects it. `@media screen {` swallowed the rest of the file and still
+  returned `Ok` with no warnings, hiding a truncated stylesheet (#484)
 - `Reader.int` raises `Parse_error` on a number with a fractional part or one
   outside the `int` range. It truncated `3.9` to `3` and answered `-1` for
   `1e30`, `1e999` and `9223372036854775808`, `int_of_float` being undefined

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -810,11 +810,22 @@ let warn ~meta lexer (warnings : Error.t list ref) (e : Error.t) =
   in
   warnings := e :: !warnings
 
+(* Sections 5.5.9 and 5.5.10 auto-close a simple block and a function at EOF,
+   which every rule-level caller relies on, and the CR snapshot marks both of
+   those EOF branches a parse error. Report the repair so [Css.of_string] keeps
+   its promise: an unclosed block otherwise swallows the rest of the input in
+   silence. A function left open at EOF always sits inside such a block, so the
+   enclosing block accounts for it and the rule is reported once. *)
+let warn_unclosed ~meta lexer warnings (block : Component.block Component.node)
+    =
+  if not block.node.closed then
+    warn ~meta lexer warnings (Error.unterminated block.loc Sort.Block)
+
 (* CSS Syntax Level 3 section 5.5.2. [nested = true] also terminates on a stray
    ['}'] (the spec's "outermost block ended") so block-contents callers can
    recover instead of swallowing the closing delimiter. *)
-let consume_at_rule ?(nested = false) lexer ~name ~start_loc : Component.at_rule
-    =
+let consume_at_rule ?(nested = false) ~meta lexer ~name ~start_loc ~warnings :
+    Component.at_rule =
   let close prelude end_loc block =
     let loc = Loc.union start_loc end_loc in
     { node = { name; prelude = List.rev prelude; block }; loc }
@@ -829,6 +840,7 @@ let consume_at_rule ?(nested = false) lexer ~name ~start_loc : Component.at_rule
     | Token.Open Curly ->
         let _ = Lexer.next lexer in
         let block = consume_simple_block lexer Curly ~start_loc:tok.loc in
+        warn_unclosed ~meta lexer warnings block;
         close prelude block.loc (Some block)
     | _ ->
         let _ = Lexer.next lexer in
@@ -838,10 +850,12 @@ let consume_at_rule ?(nested = false) lexer ~name ~start_loc : Component.at_rule
   loop []
 
 (* CSS Syntax Level 3 section 5.5.3. [nested = true] makes a stray ['}'] or a
-   top-level ';' before any block end the rule attempt with [None]. The
-   custom-property-shaped guard discards a rule whose first two non-whitespace
-   prelude items are an ident starting with [--] followed by ':', warning that
-   the prelude read as a declaration rather than a selector. *)
+   top-level ';' before any block end the rule attempt with [None]; the spec
+   groups those two with the EOF branch as parse errors, so they are reported
+   the same way. The custom-property-shaped guard discards a rule whose first
+   two non-whitespace prelude items are an ident starting with [--] followed by
+   ':', warning that the prelude read as a declaration rather than a
+   selector. *)
 let consume_qualified_rule ?(nested = false) ~meta lexer ~start_loc ~warnings :
     Component.qualified_rule option =
   let is_custom_property_shape prelude =
@@ -858,21 +872,25 @@ let consume_qualified_rule ?(nested = false) ~meta lexer ~start_loc ~warnings :
         | _ -> false)
     | _ -> false
   in
+  let drop end_loc =
+    let loc = Loc.union start_loc end_loc in
+    warn ~meta lexer warnings (Error.unterminated loc Sort.Qualified_rule);
+    None
+  in
   let rec loop prelude =
     let tok = Lexer.peek lexer in
     match tok.Token.kind with
     | Token.Eof ->
         let _ = Lexer.next lexer in
-        let loc = Loc.union start_loc tok.loc in
-        warn ~meta lexer warnings (Error.unterminated loc Sort.Qualified_rule);
-        None
+        drop tok.loc
     | Token.Semicolon when nested ->
         let _ = Lexer.next lexer in
-        None
-    | Token.Close Curly when nested -> None
+        drop tok.loc
+    | Token.Close Curly when nested -> drop tok.loc
     | Token.Open Curly ->
         let _ = Lexer.next lexer in
         let block = consume_simple_block lexer Curly ~start_loc:tok.loc in
+        warn_unclosed ~meta lexer warnings block;
         let loc = Loc.union start_loc block.loc in
         if is_custom_property_shape prelude then (
           (* Dropping the rule is what the spec asks for, but it still has to be
@@ -905,7 +923,9 @@ let consume_list_of_rules ~meta lexer ~top_level ~warnings : Component.rule list
         | Some qr -> loop (Qualified qr :: acc)
         | None -> loop acc)
     | Token.At_keyword name ->
-        let ar = consume_at_rule lexer ~name ~start_loc:tok.loc in
+        let ar =
+          consume_at_rule ~meta lexer ~name ~start_loc:tok.loc ~warnings
+        in
         loop (At ar :: acc)
     | _ -> (
         Lexer.reconsume lexer tok;
@@ -1034,7 +1054,7 @@ let consume_decl_list_item ~meta lexer ~warnings tok =
   | Token.Eof -> `Done
   | Token.Whitespace | Token.Semicolon | Token.Close Curly -> `Skip
   | Token.At_keyword name ->
-      let ar = consume_at_rule lexer ~name ~start_loc:tok.loc in
+      let ar = consume_at_rule ~meta lexer ~name ~start_loc:tok.loc ~warnings in
       `Item (`At ar)
   | Token.Ident name -> (
       match
@@ -1136,7 +1156,10 @@ let consume_block_contents ~meta lexer ~warnings : block_item list =
     | Token.Whitespace | Token.Semicolon -> loop ()
     | Token.At_keyword name ->
         flush ();
-        let ar = consume_at_rule ~nested:true lexer ~name ~start_loc:tok.loc in
+        let ar =
+          consume_at_rule ~nested:true ~meta lexer ~name ~start_loc:tok.loc
+            ~warnings
+        in
         result := `Rule (Component.At ar) :: !result;
         loop ()
     | Token.Ident name ->
@@ -1168,7 +1191,9 @@ let rule ?(meta = Loc.default_meta_level) r =
         | Token.Eof -> None
         | Token.At_keyword name ->
             let tok = Lexer.next lexer in
-            Some (Component.At (consume_at_rule lexer ~name ~start_loc:tok.loc))
+            Some
+              (Component.At
+                 (consume_at_rule ~meta lexer ~name ~start_loc:tok.loc ~warnings))
         | _ -> (
             let start_loc = (Lexer.peek lexer).Token.loc in
             match consume_qualified_rule ~meta lexer ~start_loc ~warnings with

--- a/test/cli/apply_errors.t
+++ b/test/cli/apply_errors.t
@@ -23,7 +23,7 @@ the CSS text a browser might still make something of.
 The warnings that explain the drop are still reported.
 
   $ grep -c '^warning' err.txt
-  3
+  6
 
 The control: a page whose CSS parses is projected exactly as before, and the
 exit status stays 0.

--- a/test/cli/fmt_parse_failure.t
+++ b/test/cli/fmt_parse_failure.t
@@ -21,7 +21,7 @@ an error, stdout stays empty and the exit status is non-zero.
 The warnings that explain the drop are still reported.
 
   $ grep -c '^warning' err.txt
-  4
+  8
 
 A single rule whose value does not validate is the same case: the one
 rule is dropped and nothing is left to write.

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -491,9 +491,11 @@ let kept_counts_a_rule_less_at_rule_once () =
    the same nothing, so the projection cannot be what tells them apart. Taking a
    parsed sheet leaves that to {!Css.of_string}, whose warnings the caller reads
    before any of this runs; parsing the CSS text here would swallow them and
-   report both as the same empty result. ["a{"] is neither case: CSS Syntax 3
-   sec. 5.4 closes the block at EOF, so it is a valid rule with no
-   declarations. *)
+   report both as the same empty result. ["a{"] projects onto the same nothing
+   for a third reason: CSS Syntax 3 closes the block at EOF, so the rule is
+   valid and holds no declarations, but the CR snapshot calls that EOF branch a
+   parse error and the repair is reported. A correct rule and a reportable
+   defect are not in conflict. *)
 let invalid_css_is_not_empty_css () =
   let warnings css =
     match Css.of_string css with
@@ -506,8 +508,8 @@ let invalid_css_is_not_empty_css () =
     (warnings "@@@@ }}} {{{ !!! ;;;" <> []);
   Alcotest.(check bool) "empty CSS carries none" true (warnings "" = []);
   Alcotest.(check bool)
-    "a block closed at EOF carries none either" true
-    (warnings "a{" = []);
+    "a block repaired at EOF carries a diagnostic" true
+    (warnings "a{" <> []);
   List.iter
     (fun css ->
       let result = A.compute ~sheet:(parse css) [ node "div" ] in

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -1086,6 +1086,70 @@ let spec_qualified_custom_prop_warns () =
       Alcotest.failf "valid rule warned %d times" (List.length warnings)
   | Error _ -> Alcotest.fail "valid rule rejected in strict mode"
 
+let spec_unterminated_repairs_warn () =
+  (* CSS Syntax Level 3 auto-closes at EOF in "consume an at-rule" (sec. 5.5.2),
+     "consume a qualified rule" (sec. 5.5.3), "consume a simple block" (sec.
+     5.5.9) and "consume a function" (sec. 5.5.10); the CR snapshot marks each
+     of those EOF branches a parse error. Auto-closing is the right repair, but
+     {!Css.of_string} promises a warning for everything it repairs, so strict
+     mode has to have something to reject. *)
+  let repaired input ~expect ~sort =
+    match Css.of_string input with
+    | Ok { Css.stylesheet; warnings = [ w ] } -> (
+        Alcotest.(check string)
+          "the repair does not move the output" expect
+          (Css.to_string ~minify:true stylesheet);
+        (match w with
+        | { Error.kind = Error.Unterminated s; _ } ->
+            Alcotest.(check string)
+              "unterminated sort" (Sort.to_string sort) (Sort.to_string s)
+        | _ -> Alcotest.failf "expected an unterminated warning for %S" input);
+        match Css.of_string ~strict:true input with
+        | Error _ -> ()
+        | Ok _ -> Alcotest.failf "strict mode accepted the repair of %S" input)
+    | Ok { Css.warnings; _ } ->
+        Alcotest.failf "expected exactly one warning for %S, got %d" input
+          (List.length warnings)
+    | Error _ -> Alcotest.failf "lenient parse of %S must recover" input
+  in
+  (* An unclosed at-rule block swallows everything up to EOF. *)
+  repaired "@media screen {" ~expect:"" ~sort:Sort.Block;
+  repaired "@media screen{.c{color:green}"
+    ~expect:"@media screen{.c{color:green}}" ~sort:Sort.Block;
+  (* An unclosed qualified-rule block, and one whose value also leaves a
+     function open: the rule is repaired once, not once per nested construct. *)
+  repaired ".a{color:red" ~expect:".a{color:red}" ~sort:Sort.Block;
+  repaired ".a{color:rgb(1,2,3" ~expect:".a{color:rgb(1 2 3)}" ~sort:Sort.Block;
+  (* Section 5.5.3 makes a stop token before the block a parse error too, and
+     the rule is dropped rather than repaired. *)
+  let dropped input =
+    let out = Parser.block_contents (Reader.of_string input) in
+    Alcotest.(check int) "rule dropped" 0 (List.length out.value);
+    match out.warnings with
+    | [ { Error.kind = Error.Unterminated Sort.Qualified_rule; _ } ] -> ()
+    | ws ->
+        Alcotest.failf "expected one dropped-rule warning for %S, got %d" input
+          (List.length ws)
+  in
+  dropped "& .b ;";
+  dropped "& .b }";
+  (* The sibling that already reported: EOF in the prelude, before any block. It
+     keeps exactly one warning of the same shape. *)
+  (match Css.of_string "h1" with
+  | Ok { Css.warnings = [ { Error.kind = Error.Unterminated s; _ } ]; _ } ->
+      Alcotest.(check string)
+        "prelude EOF still reports the rule" "qualified-rule" (Sort.to_string s)
+  | Ok { Css.warnings; _ } ->
+      Alcotest.failf "expected exactly one warning for \"h1\", got %d"
+        (List.length warnings)
+  | Error _ -> Alcotest.fail "lenient parse must recover");
+  (* A closed stylesheet stays warning-free in both modes. *)
+  match Css.of_string ~strict:true "@media screen{.a{color:red}}" with
+  | Ok { Css.warnings = []; _ } -> ()
+  | Ok { Css.warnings; _ } ->
+      Alcotest.failf "valid stylesheet warned %d times" (List.length warnings)
+  | Error _ -> Alcotest.fail "valid stylesheet rejected in strict mode"
+
 (* ----- Component values ----- *)
 
 let component_value_block () =
@@ -1505,6 +1569,8 @@ let suite =
         `Quick spec_qualified_custom_prop;
       Alcotest.test_case "spec section 5.5.3 custom property rule warns" `Quick
         spec_qualified_custom_prop_warns;
+      Alcotest.test_case "spec EOF repairs and drops are reported" `Quick
+        spec_unterminated_repairs_warn;
       Alcotest.test_case "component value: block" `Quick component_value_block;
       Alcotest.test_case "component value: function" `Quick
         component_value_function;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1266,7 +1266,6 @@ let spec_strict_accepts_valid_stylesheets () =
         ".x { --token-list: [a, b] (c) { d: e } }" );
       ("custom property digit dashed-ident", ".x { font-size: var(--1A202C) }");
       ("valid escape in string", ".x { content: '\\gggg' }");
-      ("unterminated block auto-closes at EOF", ".x { color: red");
       ("out-of-range rgb channels clamp", ".x { color: rgb(300, 300, 300) }");
       ("mixed numeric rgb channels", ".x { color: rgb(50%, 100, 50%) }");
       ( "transparent currentColor color-mix",
@@ -1358,6 +1357,7 @@ let spec_strict_rejects_invalid_stylesheets () =
       (* CSS Syntax and stylesheet grammar. *)
       ("top-level bare block", "{ color: red }");
       ("stray top-level right brace", ".x { color: red } }");
+      ("unterminated block repaired at EOF", ".x { color: red");
       ( "malformed charset missing semicolon",
         "@charset \"UTF-8\" .x { color: red }" );
       ("charset must use string token", "@charset url(UTF-8);");


### PR DESCRIPTION
`Css.of_string` promises a warning for everything it repaired or dropped, but an unterminated at-rule swallowed its whole body in silence: `@media screen {` returned `Ok` with no warnings and empty output, so strict mode could not tell a truncated stylesheet from a clean one. An unclosed qualified-rule block, and the two nested stop-token branches that drop a rule on a `;` or `}` before its block, were silent the same way. Emitted CSS does not move: stdout and stderr are byte-identical across all 797 files in `test/interop` under both `--minify` and pretty.

Reporting the repair exposed a latent round-trip defect in #469, where an unknown at-rule's verbatim body could swallow the closer the printer appends; that is fixed in #483, so the two land together. On #483's parent those fuzz vectors pass only because no `Unterminated` warning exists there yet.

Section numbers follow the Editor's Draft, which is what the rest of `parser.ml` cites: 5.5.2 an at-rule, 5.5.3 a qualified rule, 5.5.9 a simple block, 5.5.10 a function. The CR snapshot numbers those 5.4.2, 5.4.3, 5.4.8 and 5.4.9 and is the one that marks all four EOF branches a parse error, the ED keeping that note only on 5.5.3, so the comments attribute it accordingly. Two oracles that read "closes at EOF" as "nothing to report" are updated here, and the two cram transcripts count lines with `grep -c '^warning'` rather than warnings, so each move is one new warning.
