### PR TITLE
properties: read the self- axis position-area keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -196,11 +196,11 @@ answers.
   `Css.of_string ~strict:true` rejects it. CSS Syntax 3 sec. 5.5.3 makes the
   shape invalid so that a `{}`-block inside a custom property value is never
   misread as a rule; the drop itself was silent (#473)
-- `position-area` takes the logical `start`, `end`, `self-start` and
-  `self-end`, along with their `span-` forms. css-anchor-position-1
-  sec. 3.1.2 gives them two `{1,2}` branches of the grammar and browsers lay
-  them out, but cascade had no keyword for any of them and dropped the
-  declaration (#478)
+- `position-area` takes the logical `start`/`end` keywords along with their
+  `self-`, `self-x-`, `self-y-`, `self-block-` and `self-inline-` forms and
+  every `span-` spelling. css-anchor-position-1 sec. 3.1.2 gives them a branch
+  of the grammar and browsers lay them out, but cascade had no keyword for any
+  of them and dropped the declaration (#478, #485)
 
 ### Printing
 

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -192,6 +192,22 @@ let pp_position_area_keyword : position_area_keyword Pp.t =
   | Self_end -> Pp.string ctx "self-end"
   | Span_self_start -> Pp.string ctx "span-self-start"
   | Span_self_end -> Pp.string ctx "span-self-end"
+  | Self_x_start -> Pp.string ctx "self-x-start"
+  | Self_x_end -> Pp.string ctx "self-x-end"
+  | Self_y_start -> Pp.string ctx "self-y-start"
+  | Self_y_end -> Pp.string ctx "self-y-end"
+  | Span_self_x_start -> Pp.string ctx "span-self-x-start"
+  | Span_self_x_end -> Pp.string ctx "span-self-x-end"
+  | Span_self_y_start -> Pp.string ctx "span-self-y-start"
+  | Span_self_y_end -> Pp.string ctx "span-self-y-end"
+  | Self_block_start -> Pp.string ctx "self-block-start"
+  | Self_block_end -> Pp.string ctx "self-block-end"
+  | Self_inline_start -> Pp.string ctx "self-inline-start"
+  | Self_inline_end -> Pp.string ctx "self-inline-end"
+  | Span_self_block_start -> Pp.string ctx "span-self-block-start"
+  | Span_self_block_end -> Pp.string ctx "span-self-block-end"
+  | Span_self_inline_start -> Pp.string ctx "span-self-inline-start"
+  | Span_self_inline_end -> Pp.string ctx "span-self-inline-end"
   | Span_all -> Pp.string ctx "span-all"
 
 let rec pp_position_area : position_area Pp.t =
@@ -811,45 +827,62 @@ let rec read_position_visibility t : position_visibility =
       (Conditions conditions : position_visibility))
     t
 
+let position_area_keywords : (string * position_area_keyword) list =
+  [
+    ("top", Top);
+    ("bottom", Bottom);
+    ("left", Left);
+    ("right", Right);
+    ("center", Center);
+    ("span-top", Span_top);
+    ("span-bottom", Span_bottom);
+    ("span-left", Span_left);
+    ("span-right", Span_right);
+    ("x-start", X_start);
+    ("x-end", X_end);
+    ("y-start", Y_start);
+    ("y-end", Y_end);
+    ("span-x-start", Span_x_start);
+    ("span-x-end", Span_x_end);
+    ("span-y-start", Span_y_start);
+    ("span-y-end", Span_y_end);
+    ("inline-start", Inline_start);
+    ("inline-end", Inline_end);
+    ("block-start", Block_start);
+    ("block-end", Block_end);
+    ("span-inline-start", Span_inline_start);
+    ("span-inline-end", Span_inline_end);
+    ("span-block-start", Span_block_start);
+    ("span-block-end", Span_block_end);
+    ("start", Start);
+    ("end", End);
+    ("span-start", Span_start);
+    ("span-end", Span_end);
+    ("self-start", Self_start);
+    ("self-end", Self_end);
+    ("span-self-start", Span_self_start);
+    ("span-self-end", Span_self_end);
+    ("self-x-start", Self_x_start);
+    ("self-x-end", Self_x_end);
+    ("self-y-start", Self_y_start);
+    ("self-y-end", Self_y_end);
+    ("span-self-x-start", Span_self_x_start);
+    ("span-self-x-end", Span_self_x_end);
+    ("span-self-y-start", Span_self_y_start);
+    ("span-self-y-end", Span_self_y_end);
+    ("self-block-start", Self_block_start);
+    ("self-block-end", Self_block_end);
+    ("self-inline-start", Self_inline_start);
+    ("self-inline-end", Self_inline_end);
+    ("span-self-block-start", Span_self_block_start);
+    ("span-self-block-end", Span_self_block_end);
+    ("span-self-inline-start", Span_self_inline_start);
+    ("span-self-inline-end", Span_self_inline_end);
+    ("span-all", Span_all);
+  ]
+
 let read_position_area_keyword t : position_area_keyword =
-  Cursor.enum "position-area keyword"
-    [
-      ("top", (Top : position_area_keyword));
-      ("bottom", Bottom);
-      ("left", Left);
-      ("right", Right);
-      ("center", Center);
-      ("span-top", Span_top);
-      ("span-bottom", Span_bottom);
-      ("span-left", Span_left);
-      ("span-right", Span_right);
-      ("x-start", X_start);
-      ("x-end", X_end);
-      ("y-start", Y_start);
-      ("y-end", Y_end);
-      ("span-x-start", Span_x_start);
-      ("span-x-end", Span_x_end);
-      ("span-y-start", Span_y_start);
-      ("span-y-end", Span_y_end);
-      ("inline-start", Inline_start);
-      ("inline-end", Inline_end);
-      ("block-start", Block_start);
-      ("block-end", Block_end);
-      ("span-inline-start", Span_inline_start);
-      ("span-inline-end", Span_inline_end);
-      ("span-block-start", Span_block_start);
-      ("span-block-end", Span_block_end);
-      ("start", Start);
-      ("end", End);
-      ("span-start", Span_start);
-      ("span-end", Span_end);
-      ("self-start", Self_start);
-      ("self-end", Self_end);
-      ("span-self-start", Span_self_start);
-      ("span-self-end", Span_self_end);
-      ("span-all", Span_all);
-    ]
-    t
+  Cursor.enum "position-area keyword" position_area_keywords t
 
 type position_area_axis = Horizontal | Vertical | Either
 
@@ -857,13 +890,19 @@ let position_area_axis (keyword : position_area_keyword) =
   match keyword with
   | Left | Right | Span_left | Span_right | X_start | X_end | Span_x_start
   | Span_x_end | Inline_start | Inline_end | Span_inline_start | Span_inline_end
-    ->
+  | Self_x_start | Self_x_end | Span_self_x_start | Span_self_x_end
+  | Self_inline_start | Self_inline_end | Span_self_inline_start
+  | Span_self_inline_end ->
       Horizontal
   | Top | Bottom | Span_top | Span_bottom | Y_start | Y_end | Span_y_start
-  | Span_y_end | Block_start | Block_end | Span_block_start | Span_block_end ->
+  | Span_y_end | Block_start | Block_end | Span_block_start | Span_block_end
+  | Self_y_start | Self_y_end | Span_self_y_start | Span_self_y_end
+  | Self_block_start | Self_block_end | Span_self_block_start
+  | Span_self_block_end ->
       Vertical
   (* css-anchor-position-1 sec. 3.1.2: [center], [span-all] and the start/end
-     keywords that name neither the block nor the inline axis are ambiguous. *)
+     keywords that name no axis explicitly are ambiguous. The [self-] forms that
+     do name one, physical or logical, are not. *)
   | Center | Span_all | Start | End | Span_start | Span_end | Self_start
   | Self_end | Span_self_start | Span_self_end ->
       Either

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3346,6 +3346,22 @@ type position_area_keyword =
   | Self_end
   | Span_self_start
   | Span_self_end
+  | Self_x_start
+  | Self_x_end
+  | Self_y_start
+  | Self_y_end
+  | Span_self_x_start
+  | Span_self_x_end
+  | Span_self_y_start
+  | Span_self_y_end
+  | Self_block_start
+  | Self_block_end
+  | Self_inline_start
+  | Self_inline_end
+  | Span_self_block_start
+  | Span_self_block_end
+  | Span_self_inline_start
+  | Span_self_inline_end
   | Span_all
 
 type position_area =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4069,6 +4069,48 @@ let spec_generated_position_interaction_edges () =
   check_position_area ~expected:"self-start" "self-start self-start";
   check_position_area "self-start span-self-end";
   check_position_area "span-self-start self-end";
+  (* Section 3.1.2 also spells out [self-x-start]/[self-x-end] and
+     [self-y-start]/[self-y-end] inside the two physical groups, and gives
+     [self-block-start]/[self-inline-start] a branch of their own, each with a
+     [span-] form. Unlike [self-start], every one of these names its axis, so
+     the ambiguity clause does not reach them: a lone one behaves as if the
+     second keyword were [span-all] instead of repeating itself, which leaves a
+     repeated one naming a single axis twice, a shape no branch admits. *)
+  check_position_area "self-x-start";
+  check_position_area "self-x-end";
+  check_position_area "self-y-start";
+  check_position_area "self-y-end";
+  check_position_area "span-self-x-start";
+  check_position_area "span-self-x-end";
+  check_position_area "span-self-y-start";
+  check_position_area "span-self-y-end";
+  check_position_area "self-block-start";
+  check_position_area "self-block-end";
+  check_position_area "self-inline-start";
+  check_position_area "self-inline-end";
+  check_position_area "span-self-block-start";
+  check_position_area "span-self-block-end";
+  check_position_area "span-self-inline-start";
+  check_position_area "span-self-inline-end";
+  (* Two keywords on opposite axes name one row and one column, so they are a
+     distinct area from either alone and stay as written. *)
+  check_position_area "self-x-start self-y-end";
+  check_position_area "span-self-x-end self-y-start";
+  check_position_area "self-block-start self-inline-end";
+  check_position_area "span-self-block-end self-inline-start";
+  (* [span-all] is the ambiguous partner, so it takes the free axis and the pair
+     is held exactly as [top span-all] is. *)
+  check_position_area "top span-all";
+  check_position_area "self-x-start span-all";
+  check_position_area "span-all self-block-end";
+  (* Naming one axis twice has no branch, in contrast with the ambiguous
+     [self-start self-start] above, which folds. *)
+  neg_cursor read_position_area "self-x-start self-x-end";
+  neg_cursor read_position_area "self-x-start self-x-start";
+  neg_cursor read_position_area "self-y-start span-self-y-end";
+  neg_cursor read_position_area "self-block-start self-block-end";
+  neg_cursor read_position_area "self-block-start self-block-start";
+  neg_cursor read_position_area "self-inline-start span-self-inline-end";
   check_position_area_keyword "span-inline-start";
   check_position_try_fallback "flip-block";
   check_position_try_fallbacks ~expected:"flip-block,--fallback"


### PR DESCRIPTION
`position-area: self-x-start` and its fifteen siblings were rejected outright, and a rejected value takes the whole stylesheet down rather than the one declaration. Follow-up to #478, which covered the axis-ambiguous branches only; these name an axis, so a repeated one stays invalid where `self-start self-start` folds.