### PR TITLE
lib: read selector compatibility off each selector once

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -406,6 +406,11 @@ answers.
   run rebuilt every block it compared; indexing each block once by the slots it
   writes cuts 400 same-selector rules of 20 declarations to 4% of the
   allocations and 12% of the instructions (#480)
+- `--minify` groups a long run of same-body rules in less memory, for
+  byte-identical output. Whether the run can share one selector list was asked
+  of every pair of it, though the answer is read off each selector alone;
+  reading each once cuts 400 such rules to 17% of the allocations and 12% of
+  the instructions (#486)
 
 ### Custom properties
 

--- a/lib/merge.ml
+++ b/lib/merge.ml
@@ -46,13 +46,40 @@ let selector_list = function
       let flatten = function Selector.List xs -> xs | s -> [ s ] in
       Selector.List (List.concat_map flatten sels)
 
+(* Everything [compatible] reads off a selector. [Guarded] is an
+   [:is(:where(...))] group- or peer- variant; [Newer] carries, outside any
+   forgiving [:is()]/[:where()], a pseudo-class an older browser drops the whole
+   rule for; [Plain] is neither. *)
+type compatibility = Plain | Newer | Guarded
+
+let compatibility sel =
+  if Selector.has_is_where_pattern sel then Guarded
+  else if Selector.has_newer_pseudo_class sel then Newer
+  else Plain
+
 let compatible sel1 sel2 =
-  let sel1_complex = Selector.has_is_where_pattern sel1 in
-  let sel2_complex = Selector.has_is_where_pattern sel2 in
-  if sel1_complex <> sel2_complex then
-    let plain_sel = if sel1_complex then sel2 else sel1 in
-    not (Selector.has_newer_pseudo_class plain_sel)
-  else true
+  match (compatibility sel1, compatibility sel2) with
+  | Newer, Guarded | Guarded, Newer -> false
+  | _ -> true
+
+(* [compatible] rejects one pair and no other, so a list holds only compatible
+   pairs exactly when it does not hold both ends of it: one pass that reads each
+   selector once stands in for the N(N-1)/2 pair loop.
+
+   Sorting the list and checking neighbours would not, because [compatible] is
+   reflexive and symmetric but NOT transitive - [Newer] sits with [Plain] and
+   [Plain] sits with [Guarded], while [Newer] and [Guarded] never sit
+   together. *)
+let all_compatible sels =
+  let rec loop newer guarded = function
+    | [] -> true
+    | sel :: rest -> (
+        match compatibility sel with
+        | Plain -> loop newer guarded rest
+        | Newer -> (not guarded) && loop true guarded rest
+        | Guarded -> (not newer) && loop newer true rest)
+  in
+  loop false false sels
 
 let rec declaration_lists_equal ~same d1 d2 =
   match (d1, d2) with

--- a/lib/merge.mli
+++ b/lib/merge.mli
@@ -20,4 +20,9 @@ val declarations_equal :
 (** Compare declaration lists with physical-identity fast path. *)
 
 val compatible : Selector.t -> Selector.t -> bool
-(** Whether two selector-list branches can safely share one selector list. *)
+(** Whether two selector-list branches can safely share one selector list. The
+    relation is reflexive and symmetric but not transitive. *)
+
+val all_compatible : Selector.t list -> bool
+(** [all_compatible sels] is whether every pair in [sels] is {!compatible}, read
+    off each selector once rather than once per pair. *)

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -48,7 +48,6 @@ let declarations_equal (a : Declaration.declaration list)
 
 let merge_selector_list = Merge.selector_list
 let contains_vendor_pseudo_element = Merge.vendor
-let selectors_compatible = Merge.compatible
 let decls_size = Size.decls
 let mix_int = Common.mix_int
 let hash_string = Common.hash_string
@@ -285,22 +284,11 @@ let selector_keys_equal left right =
   in
   loop left right
 
-let pairwise_compatible rules =
-  let rec loop = function
-    | [] | [ _ ] -> true
-    | (r : rule) :: rest ->
-        List.for_all
-          (fun (other : rule) -> selectors_compatible r.selector other.selector)
-          rest
-        && loop rest
-  in
-  loop rules
-
 (* Any identical-body rules can group into a selector list: a list of disjoint
    selectors, including distinct pseudo-elements ([::before] and [::after] never
    match a common box), is exactly equivalent to the separate rules, and the DAG
    enforces cascade-order safety. *)
-let can_group_selectors rules = pairwise_compatible rules
+let can_group_selectors = Merge.all_compatible
 let body_equal_key g id = Rule_graph.declaration_body_key g id
 let body_bucket_key g id = body_equal_key g id |> hash_ints
 
@@ -352,14 +340,13 @@ let grouped_rule (rules : rule list) : rule option =
   match rules with
   | [] -> Option.None
   | first :: _ ->
-      if not (can_group_selectors rules) then Option.None
+      let selectors = List.map (fun (r : rule) -> r.selector) rules in
+      if not (can_group_selectors selectors) then Option.None
       else
         Option.Some
           {
             first with
-            selector =
-              merge_selector_list
-                (List.map (fun (r : rule) -> r.selector) rules);
+            selector = merge_selector_list selectors;
             nested = [];
             merge_key = Option.None;
           }

--- a/test/test_merge.ml
+++ b/test/test_merge.ml
@@ -41,11 +41,38 @@ let test_declarations_equal_fast_and_structural_paths () =
     "different length" false
     (Merge.declarations_equal ~same:same_decl r.declarations r3.declarations)
 
+(* [compatible] is reflexive and symmetric but NOT transitive. A plain selector
+   sits beside one carrying a newer pseudo-class, and beside an
+   [:is(:where(...))] variant, while those two never sit together: a browser
+   that does not know [:user-valid] drops the whole rule, where the forgiving
+   variant would have survived. Grouping by sorting a run and checking only
+   neighbours is unsound for exactly this reason. *)
+let test_compatible_is_not_transitive () =
+  let newer = Selector.of_string ".x:user-valid" in
+  let plain = Selector.of_string ".y" in
+  let guarded = Selector.of_string ":is(:where(.group):hover .z)" in
+  Alcotest.(check bool) "newer with plain" true (Merge.compatible newer plain);
+  Alcotest.(check bool)
+    "plain with guarded" true
+    (Merge.compatible plain guarded);
+  Alcotest.(check bool)
+    "newer with guarded" false
+    (Merge.compatible newer guarded);
+  Alcotest.(check bool)
+    "and the other way round" false
+    (Merge.compatible guarded newer);
+  Alcotest.(check bool) "reflexive on newer" true (Merge.compatible newer newer);
+  Alcotest.(check bool)
+    "reflexive on guarded" true
+    (Merge.compatible guarded guarded)
+
 let suite =
   ( "merge",
     [
       Alcotest.test_case "pseudo and vendor detection" `Quick
         test_pseudo_and_vendor_detection;
+      Alcotest.test_case "compatible is not transitive" `Quick
+        test_compatible_is_not_transitive;
       Alcotest.test_case "declarations_equal fast and structural paths" `Quick
         test_declarations_equal_fast_and_structural_paths;
     ] )

--- a/test/test_merge.ml
+++ b/test/test_merge.ml
@@ -66,6 +66,80 @@ let test_compatible_is_not_transitive () =
     "reflexive on guarded" true
     (Merge.compatible guarded guarded)
 
+(* Every shape [compatible] distinguishes: a selector with neither marker, one
+   carrying a newer pseudo-class where a browser can see it, one carrying it
+   inside a forgiving [:is()], an [:is(:where(.group))] and an
+   [:is(:where(.peer))] variant, one that is both, and a [:where()] holding
+   neither marker. *)
+let compat_pool =
+  List.map Selector.of_string
+    [
+      ".a";
+      ".b:hover";
+      ".c:user-valid";
+      ".d:user-invalid .e";
+      ":is(:where(.group):hover .f)";
+      ":is(:where(.peer):checked~.g)";
+      ":is(:where(.group):hover .h):user-valid";
+      ":where(.i,.j) .k";
+      ":is(.l:user-valid) .m";
+      ".n::before";
+    ]
+
+(* The relation as it was written before [all_compatible]: read
+   [has_is_where_pattern] off both, and where they disagree read
+   [has_newer_pseudo_class] off the one that lacks it. *)
+let compatible_by_hand sel1 sel2 =
+  let sel1_complex = Selector.has_is_where_pattern sel1 in
+  let sel2_complex = Selector.has_is_where_pattern sel2 in
+  if sel1_complex <> sel2_complex then
+    let plain_sel = if sel1_complex then sel2 else sel1 in
+    not (Selector.has_newer_pseudo_class plain_sel)
+  else true
+
+let test_compatible_matches_the_predicates () =
+  List.iter
+    (fun a ->
+      List.iter
+        (fun b ->
+          if Merge.compatible a b <> compatible_by_hand a b then
+            Alcotest.failf "compatible %s %s" (Selector.to_string a)
+              (Selector.to_string b))
+        compat_pool)
+    compat_pool
+
+(* [all_compatible] answers for the whole list what [compatible] answers per
+   pair, so the two must agree on every list: all of them up to five selectors
+   drawn from the pool, then longer random ones. *)
+let all_compatible_by_hand sels =
+  let rec loop = function
+    | [] | [ _ ] -> true
+    | sel :: rest ->
+        List.for_all (fun other -> Merge.compatible sel other) rest && loop rest
+  in
+  loop sels
+
+let check_agrees sels =
+  if Merge.all_compatible sels <> all_compatible_by_hand sels then
+    Alcotest.failf "all_compatible [%s]"
+      (String.concat "; " (List.map Selector.to_string sels))
+
+let test_all_compatible_matches_the_pair_loop () =
+  let pool = Array.of_list compat_pool in
+  let rec exhaustive depth acc =
+    check_agrees (List.rev acc);
+    if depth > 0 then
+      Array.iter (fun sel -> exhaustive (depth - 1) (sel :: acc)) pool
+  in
+  exhaustive 5 [];
+  let state = Random.State.make [| 0x5EED |] in
+  for _ = 1 to 5000 do
+    let len = Random.State.int state 30 in
+    check_agrees
+      (List.init len (fun _ ->
+           pool.(Random.State.int state (Array.length pool))))
+  done
+
 let suite =
   ( "merge",
     [
@@ -73,6 +147,10 @@ let suite =
         test_pseudo_and_vendor_detection;
       Alcotest.test_case "compatible is not transitive" `Quick
         test_compatible_is_not_transitive;
+      Alcotest.test_case "compatible matches the two predicates" `Quick
+        test_compatible_matches_the_predicates;
+      Alcotest.test_case "all_compatible matches the pair loop" `Quick
+        test_all_compatible_matches_the_pair_loop;
       Alcotest.test_case "declarations_equal fast and structural paths" `Quick
         test_declarations_equal_fast_and_structural_paths;
     ] )

--- a/test/test_rule_graph.ml
+++ b/test/test_rule_graph.ml
@@ -410,6 +410,56 @@ let same_selector_commute_is_subquadratic () =
     true
     (a1 = 0. || a2 < a1 *. 3.)
 
+(* Selector compatibility is not transitive, so a run of same-body rules groups
+   only when EVERY pair in it agrees. [.y] pairs with both of the others and
+   they do not pair with each other, so the three never share a selector list
+   and the enumerator settles for the compatible subset. *)
+let grouping_respects_non_transitive_compatibility () =
+  let newer = ".x:user-valid{color:red}" in
+  let plain = ".y{color:red}" in
+  let guarded = ":is(:where(.group):hover .z){color:red}" in
+  Alcotest.(check string)
+    "newer groups with plain" ".x:user-valid,.y{color:red}"
+    (optimize_str (newer ^ plain));
+  Alcotest.(check string)
+    "plain groups with guarded" ".y,:is(:where(.group):hover .z){color:red}"
+    (optimize_str (plain ^ guarded));
+  Alcotest.(check string)
+    "newer never groups with guarded"
+    ".x:user-valid{color:red}:is(:where(.group):hover .z){color:red}"
+    (optimize_str (newer ^ guarded));
+  Alcotest.(check string)
+    "all three settle for the compatible subset"
+    ".x:user-valid{color:red}.y,:is(:where(.group):hover .z){color:red}"
+    (optimize_str (newer ^ plain ^ guarded))
+
+(* Every rule here carries the same body and a selector no other rule shares, so
+   the whole run lands in one identical-body bucket and grouping it asks about
+   all N(N-1)/2 pairs. Whether two selectors can share a selector list is
+   settled by two predicates read off each of them alone, so reading each
+   selector once is enough and the pair loop costs no allocation of its own:
+   doubling N may cost about twice as much, never the quadratic four times.
+
+   The [:where()] nodes hold no group or peer marker, so neither predicate stops
+   early and each pair pays a full walk of both selectors. Both runs stay above
+   the 128 nodes at which the enumerator drops its wider candidate kinds, so
+   what separates them is the pair loop alone. *)
+let identical_body_grouping_is_subquadratic () =
+  let sheet n =
+    List.init n
+      (Fmt.str ":where(.a,.b):where(.c,.d):where(.e,.f) .w%d{color:red}")
+    |> String.concat "" |> rules_of
+  in
+  let candidates graph () =
+    Rule_candidate.enumerate ~ctx:Ctx.fragment ~finalize:Fun.id graph
+  in
+  let a1 = measure (candidates (Rule_graph.of_rules (sheet 200))) in
+  let a2 = measure (candidates (Rule_graph.of_rules (sheet 400))) in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.1fx for 2x N)" a1 a2 (a2 /. a1))
+    true
+    (a1 = 0. || a2 < a1 *. 2.6)
+
 let suite =
   ( "rule_graph",
     [
@@ -463,4 +513,8 @@ let suite =
         second_specificity_costs_no_pair;
       Alcotest.test_case "same-selector commute is sub-quadratic" `Quick
         same_selector_commute_is_subquadratic;
+      Alcotest.test_case "grouping respects non-transitive compatibility" `Quick
+        grouping_respects_non_transitive_compatibility;
+      Alcotest.test_case "identical-body grouping is sub-quadratic" `Quick
+        identical_body_grouping_is_subquadratic;
     ] )


### PR DESCRIPTION
Grouping a run of same-body rules asked `Merge.compatible` about every pair of it, which is quadratic in the run length. The relation is not transitive, so the run cannot be sorted and checked pairwise-adjacent, but it turns on two facts read off each selector alone: a run is groupable exactly when it does not hold both a plain selector carrying a newer pseudo-class and an `:is(:where(...))` variant.

400 same-body rules: 4,600,033 words to 777,637, and 23.4G instructions to 2.7G, for byte-identical output on both interop corpora and the 504-file SatCSS corpus.