### PR TITLE
lib: index a nested body once for the whole run

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -401,11 +401,11 @@ answers.
   4000-rule sheet to 51% of the allocations and 37% of the instructions
   (#468)
 - `--minify` merges a long run of rules on one selector in less time and
-  memory, for byte-identical output. Deciding whether two declaration blocks
-  can be reordered walked one block once per declaration of the other, and the
-  run rebuilt every block it compared; indexing each block once by the slots it
-  writes cuts 400 same-selector rules of 20 declarations to 4% of the
-  allocations and 12% of the instructions (#480)
+  memory, for byte-identical output. Deciding whether two blocks can be
+  reordered rebuilt and re-walked a body once per pair, both between two
+  declaration runs and between a nested block and the declarations that would
+  move past it; indexing each body once by the slots it writes leaves 4% of
+  the allocations either way (#480, #487)
 - `--minify` groups a long run of same-body rules in less memory, for
   byte-identical output. Whether the run can share one selector list was asked
   of every pair of it, though the answer is read off each selector alone;

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -183,11 +183,6 @@ let rec facts_conflict index = function
    order they are replayed in cannot then be observed. *)
 let facts_commute_with index left = not (facts_conflict index left)
 
-let decl_facts_commute left right =
-  match (left, right) with
-  | [], _ | _, [] -> true
-  | _ -> facts_commute_with (index_facts right) left
-
 let rule_eligible (r : rule) =
   r.nested = [] && r.merge_key = Option.None
   && (not (contains_vendor_pseudo_element r.selector))
@@ -236,21 +231,32 @@ let same_selector_eligible (r : rule) =
 
 (* [rules] in source order: whether a declaration ends up ahead of a nested
    block it followed is a question about where the two were written, and the
-   merge order below answers a different one. *)
+   merge order below answers a different one.
+
+   [decl_facts_conflict] is symmetric - every arm of the overlap relation under
+   it is spelled both ways round - so either side of a commute test can be the
+   indexed one. The nested body is the side worth indexing: it is read once per
+   rule rather than once per rule facing it, and each declaration block is read
+   once for the whole run rather than once per nested block ahead of it. The
+   scan first is what keeps a run carrying no nested block, the common one, from
+   reading a body at all. *)
 let nested_merge_is_safe (rules : rule list) =
+  let rec nested_ahead = function
+    | [] | [ _ ] -> false
+    | (r : rule) :: rest -> r.nested <> [] || nested_ahead rest
+  in
   let rec go = function
     | [] | [ _ ] -> true
-    | (r : rule) :: rest -> (
+    | ((r : rule), _) :: rest -> (
         match nested_decl_facts [] r.nested with
         | [] -> go rest
         | nested ->
-            List.for_all
-              (fun (later : rule) ->
-                decl_facts_commute nested (decl_facts later.declarations))
-              rest
+            let index = index_facts nested in
+            List.for_all (fun (_, facts) -> facts_commute_with index facts) rest
             && go rest)
   in
-  go rules
+  (not (nested_ahead rules))
+  || go (List.map (fun (r : rule) -> (r, decl_facts r.declarations)) rules)
 
 let identical_body_eligible ~ctx (r : rule) =
   r.nested = [] && r.merge_key = Option.None

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2337,6 +2337,51 @@ let same_selector_merge_past_nested () =
         (min-width:1px){margin:2rem}}.a{color:red;@media \
         (min-width:2px){margin-top:3rem}}")
 
+(* Whether a nested body and a later declaration block share a slot reads the
+   same whichever of the two is asked about: a custom property overlaps the same
+   name and nothing else, [all] reaches every non-exempt slot, and a property
+   the footprint model cannot place reaches whatever it meets. Each of those is
+   stated over an ordered pair, so each is checked here from both ends. The
+   shorthand-against-longhand pair is above. *)
+let nested_merge_reads_the_slot_from_either_side () =
+  let of_string css =
+    match Css.of_string css with
+    | Ok p -> p.Css.stylesheet
+    | Error _ -> Alcotest.failf "could not parse %s" css
+  in
+  let canon css =
+    Css.Optimize.stylesheet (Css.statements (of_string css))
+    |> Css.Stylesheet.to_string ~minify:true
+    |> String.trim
+  in
+  Alcotest.(check string)
+    "a later write of the nested custom property blocks the merge"
+    ".a{color:red;&:hover{--x:2}}.a{--x:1}"
+    (canon ".a{color:red;&:hover{--x:2}}.a{--x:1}");
+  Alcotest.(check string)
+    "another custom property still merges" ".a{--y:1;color:red;&:hover{--x:2}}"
+    (canon ".a{color:red;&:hover{--x:2}}.a{--y:1}");
+  Alcotest.(check string)
+    "a custom property and a longhand share no slot"
+    ".a{color:red;padding:1rem;&:hover{--x:2}}"
+    (canon ".a{color:red;&:hover{--x:2}}.a{padding:1rem}");
+  Alcotest.(check string)
+    "nor do they the other way round"
+    ".a{--x:1;color:red;&:hover{padding:2rem}}"
+    (canon ".a{color:red;&:hover{padding:2rem}}.a{--x:1}");
+  Alcotest.(check string)
+    "a nested all reset blocks the merge"
+    ".a{color:red;&:hover{all:unset}}.a{padding:1rem}"
+    (canon ".a{color:red;&:hover{all:unset}}.a{padding:1rem}");
+  Alcotest.(check string)
+    "a nested unplaceable name blocks the merge"
+    ".a{color:red;&:hover{unknown-thing:2}}.a{padding:1rem}"
+    (canon ".a{color:red;&:hover{unknown-thing:2}}.a{padding:1rem}");
+  Alcotest.(check string)
+    "and so does a later one"
+    ".a{color:red;&:hover{padding:2rem}}.a{unknown-thing:1}"
+    (canon ".a{color:red;&:hover{padding:2rem}}.a{unknown-thing:1}")
+
 (* A run of declarations written after a nested statement (CSS Nesting 1 sec.
    3.4) is a declaration list like any other, with nothing between two writes
    inside it, so the deduplication a rule body gets applies to it. *)
@@ -5632,6 +5677,8 @@ module Fuzz = struct
         fuzz_cascade_equivalent;
       Alcotest.test_case "same-selector merge past nested children" `Quick
         same_selector_merge_past_nested;
+      Alcotest.test_case "nested merge reads the slot from either side" `Quick
+        nested_merge_reads_the_slot_from_either_side;
       Alcotest.test_case "a nested declarations run is deduplicated" `Quick
         nested_declaration_run_dedupes;
       Alcotest.test_case "vendor pseudo-element list is split" `Quick

--- a/test/test_rule_graph.ml
+++ b/test/test_rule_graph.ml
@@ -460,6 +460,37 @@ let identical_body_grouping_is_subquadratic () =
     true
     (a1 = 0. || a2 < a1 *. 2.6)
 
+(* Every rule here sits on one selector and carries a block of custom properties
+   no other rule names, half of them in a nested block, so deciding whether the
+   run can merge asks about all N(N-1)/2 pairs and not one short-circuits.
+   Whether a nested body commutes with a later declaration block is a question
+   about the slots each writes, and the relation reads the same from either
+   side: indexing the nested body once per rule and reading each block once for
+   the whole run leaves the pair loop no allocation of its own, so doubling N
+   may cost about twice as much, never the quadratic four times.
+
+   Both runs stay above the 128 nodes at which the enumerator drops its wider
+   candidate kinds, so what separates them is the pair loop alone. *)
+let nested_merge_safety_is_subquadratic () =
+  let block prefix i =
+    List.init 20 (fun k -> Fmt.str "--%s%d-%d:%d" prefix i k ((i * 20) + k))
+    |> String.concat ";"
+  in
+  let sheet n =
+    List.init n (fun i ->
+        Fmt.str ".q{%s;&:hover{%s}}" (block "o" i) (block "n" i))
+    |> String.concat "" |> rules_of
+  in
+  let candidates graph () =
+    Rule_candidate.enumerate ~ctx:Ctx.fragment ~finalize:Fun.id graph
+  in
+  let a1 = measure (candidates (Rule_graph.of_rules (sheet 200))) in
+  let a2 = measure (candidates (Rule_graph.of_rules (sheet 400))) in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.1fx for 2x N)" a1 a2 (a2 /. a1))
+    true
+    (a1 = 0. || a2 < a1 *. 2.6)
+
 let suite =
   ( "rule_graph",
     [
@@ -517,4 +548,6 @@ let suite =
         grouping_respects_non_transitive_compatibility;
       Alcotest.test_case "identical-body grouping is sub-quadratic" `Quick
         identical_body_grouping_is_subquadratic;
+      Alcotest.test_case "nested-merge safety is sub-quadratic" `Quick
+        nested_merge_safety_is_subquadratic;
     ] )


### PR DESCRIPTION
Deciding whether a run of same-selector rules can merge asked, for each rule carrying a nested block, whether that block commutes with every later rule's declarations, and rebuilt and re-indexed the later block on every one of those pairs. The slot relation under it reads the same from either side, so the nested body can be the indexed one instead: it is read once per rule, and each declaration block once for the whole run.

400 rules on one selector with 20 declarations and a nested block of 20: 58,595,092 words to 2,144,260, allocation linear in the rule count rather than quadratic. The pair loop itself is still quadratic, so instructions fall 2.4x rather than asymptotically. Byte-identical output on both interop corpora, the 504-file SatCSS corpus and 200,000 generated same-selector sheets.