### PR TITLE
bin: ask the AST whether `apply` lost every rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -575,6 +575,10 @@ answers.
   measures each text run on its own, so merging them moved the element's width;
   licence headers went missing outright. The page is parsed and printed with
   markup.ml in place of lambdasoup (#346)
+- `cascade apply` exits 0 for a `<style>` block whose parse kept a statement,
+  so a build gating on the exit status passes on valid CSS. The check rendered
+  the sheet, and an empty rule, a redundant `@charset "UTF-8"` or an `src`-less
+  `@font-face` prints nothing while losing nothing (#489)
 - `cascade diff` names an at-rule that carries no condition of its own by the
   head it prints to, rather than describing every one identically. That
   description keys the ordering comparison, so a `@media` that moved between a

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -48,23 +48,27 @@ let report_warning w =
   |> List.iter (fun line -> Fmt.epr "warning: %s@." line)
 
 (* [Some sheet] is CSS the projection can use. [None] is a source the parser
-   could not turn into any: a fatal syntax error, or - keyed as in [cascade fmt]
-   - a recovery that left nothing to serialise from an input that had something
-   to drop. Neither is a source that was legitimately empty, which parses
-   without a word and contributes nothing. [note] says what the caller does
-   about the loss. *)
+   could not turn into any: a fatal syntax error, or a recovery that left no
+   statement at all from an input that had something to drop. Neither is a
+   source that was legitimately empty, which parses without a word and
+   contributes nothing. [note] says what the caller does about the loss. *)
 let parse_source ~filename ~note css =
   match Css.of_string ~filename css with
   | Error e ->
       Fmt.epr "Error: %s@." (Cascade.Error.to_string e);
       None
-  | Ok { Css.stylesheet; warnings } ->
+  | Ok { Css.stylesheet; warnings } -> (
       List.iter report_warning warnings;
-      if warnings <> [] && Css.to_string ~minify:true stylesheet = "" then begin
-        Fmt.epr "Error: %s: parse dropped every rule%s@." filename note;
-        None
-      end
-      else Some stylesheet
+      (* Whether the parse produced anything is a question about the statement
+         list. Serialising the sheet to answer it asks a different one, and gets
+         it wrong: [@charset "UTF-8"] and an [src]-less [@font-face] parse, are
+         kept, and still print nothing. What [Apply.compute] consumes is the
+         list, not the text. *)
+      match (stylesheet, warnings) with
+      | [], _ :: _ ->
+          Fmt.epr "Error: %s: parse dropped every rule%s@." filename note;
+          None
+      | _ -> Some stylesheet)
 
 let inline_html ~minimal ~filename ~html ~extra =
   let doc = Html.parse html in

--- a/test/cli/apply_errors.t
+++ b/test/cli/apply_errors.t
@@ -71,3 +71,84 @@ The control: a supplementary stylesheet that reads and parses still applies.
   $ cascade apply page.html good.css 2> /dev/null
   <html><head></head><body><p style="margin:0">hi</p>
   </body></html>
+
+The gate asks a question about the parse: did it produce any statement? It
+is not the question "does this sheet serialise to anything", which a parse
+that kept everything can still answer with nothing. A statement can be
+parsed, held, and still print as the empty string: CSS Syntax 3 §8.3 makes
+`@charset` a decoder hint rather than a rule, and UTF-8 is what the
+serialiser emits anyway, so a redundant one prints nothing.
+
+  $ cat > charset.html <<EOF
+  > <html><head><style>@charset "UTF-8";@charset "UTF-8";</style></head><body><p>hi</p></body></html>
+  > EOF
+  $ cascade apply charset.html > out4.html 2> err4.txt
+  $ grep '^Error' err4.txt
+  [1]
+  $ cat out4.html
+  <html><head><style></style></head><body><p>hi</p>
+  </body></html>
+
+The second `@charset` is out of place, which is reported, and both are
+kept: nothing about that parse dropped every rule.
+
+  $ grep -c '^warning' err4.txt
+  1
+
+A `@font-face` with no `src` is the same shape. CSS Fonts 4 §4.3 gives it
+no font to load, so it prints nothing, but the rule itself parsed and the
+statement is there for the projection to read.
+
+  $ cat > face.html <<EOF
+  > <html><head><style>@font-face{font-family:x}</style></head><body><p>hi</p></body></html>
+  > EOF
+  $ cascade apply face.html > out5.html 2> err5.txt
+  $ grep '^Error' err5.txt
+  [1]
+  $ cat out5.html
+  <html><head><style></style></head><body><p>hi</p>
+  </body></html>
+
+Recovery inside that block is a different matter: a descriptor the parser
+cannot read takes the whole at-rule with it, which leaves no statement, so
+this one is a loss and says so.
+
+  $ cat > face2.html <<EOF
+  > <html><head><style>@font-face{font-family:x;@bogus w;}</style></head><body><p>hi</p></body></html>
+  > EOF
+  $ cascade apply face2.html > out8.html 2> err8.txt
+  [1]
+  $ grep '^Error' err8.txt
+  Error: face2.html:<style>#1: parse dropped every rule; keeping the block verbatim
+  $ cat out8.html
+  <html><head><style>@font-face{font-family:x;@bogus w;}</style></head><body><p>hi</p>
+  </body></html>
+
+An at-rule this library does not know parses to a statement of its own and
+is kept, so a block holding nothing else is not a loss either.
+
+  $ cat > unknown.html <<EOF
+  > <html><head><style>@foo bar;</style></head><body><p>hi</p></body></html>
+  > EOF
+  $ cascade apply unknown.html > out6.html 2> err6.txt
+  $ grep '^Error' err6.txt
+  [1]
+  $ cat out6.html
+  <html><head><style></style><style>@foo bar;</style></head><body><p>hi</p>
+  </body></html>
+
+The true positive keeps its exit status. `@charset` is recognised only in
+the exact form CSS Syntax 3 §8.2 reserves, so a lowercase label is not a
+statement this parser produces: the block holds one construct, it is
+dropped, and nothing is left to project.
+
+  $ cat > lower.html <<EOF
+  > <html><head><style>@charset "utf-8";</style></head><body><p>hi</p></body></html>
+  > EOF
+  $ cascade apply lower.html > out7.html 2> err7.txt
+  [1]
+  $ grep '^Error' err7.txt
+  Error: lower.html:<style>#1: parse dropped every rule; keeping the block verbatim
+  $ cat out7.html
+  <html><head><style>@charset "utf-8";</style></head><body><p>hi</p>
+  </body></html>


### PR DESCRIPTION
`cascade apply` decided a `<style>` block had lost everything by rendering the parsed sheet and testing the text for emptiness. A sheet that kept every statement it was given can still print nothing, so a block holding an empty rule, a redundant `@charset "UTF-8"` or an `src`-less `@font-face` was reported as a total loss and exited 1, failing any build gating on the status. The gate now asks the statement list, which is also what `Apply.compute` consumes.

The two WPT traces in `test/interop/wpt/traces/css-syntax` that hold only empty rules were hitting this; every other HTML fixture in the tree is byte-identical before and after.