### PR TITLE
lib: give Reader.parse_error real line and col fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,9 @@ answers.
   pattern naming either takes the extra field (#313)
 - `Css.Pp.ctx` gains `in_style_rule`; record expressions must set it and record
   patterns must bind it or use `; _` (#374)
+- `Cascade.Reader.parse_error` gains `line` and `col`, and `filename` holds a
+  source name where it packed `"<CSS input>:L:C"`: read the location from the
+  two new fields, and `with_filename` keeps it instead of overwriting (#491)
 
 ### Parsing
 

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -18,6 +18,8 @@ type parse_error = {
   got : string option;
   position : int;
   filename : string;
+  line : int;
+  col : int;
   context_window : string;
   marker_pos : int;
   callstack : string list;
@@ -56,8 +58,18 @@ let pp_parse_error (err : parse_error) =
       in
       "\n" ^ context_display ^ "\n" ^ marker
   in
-  err.message ^ " at " ^ err.filename ^ ":" ^ string_of_int err.position
-  ^ callstack_str ^ context_str
+  String.concat ""
+    [
+      err.message;
+      " at ";
+      err.filename;
+      ":";
+      string_of_int err.line;
+      ":";
+      string_of_int err.col;
+      callstack_str;
+      context_str;
+    ]
 
 (* Pretty-printer for the parser state *)
 let pp (ctx : Pp.ctx) (t : t) =
@@ -228,16 +240,17 @@ let err ?got t expected =
         | `Uchar _ | `Malformed _ -> (line, col + 1))
       (1, 1) t.input
   in
-  let better_filename =
-    "<CSS input>:" ^ string_of_int line ^ ":" ^ string_of_int col
-  in
   raise
     (Parse_error
        {
          message = expected;
          got;
          position = t.pos;
-         filename = better_filename;
+         (* A reader is built from a string, so it has no name of its own; a
+            caller that has one stamps it with [with_filename]. *)
+         filename = "<CSS input>";
+         line;
+         col;
          context_window = context;
          marker_pos;
          callstack = callstack t;

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -17,12 +17,16 @@ type parse_error = {
   got : string option;
   position : int;
   filename : string;
+  line : int;
+  col : int;
   context_window : string;
   marker_pos : int;
   callstack : string list;
 }
-(** Parse error information with structured details. {!field-position} is a byte
-    offset, {!field-filename} carries the 1-based line and column of that
+(** Parse error information with structured details. {!field-filename} names the
+    source: a reader built by {!val-of_string} carries ["<CSS input>"] until
+    {!with_filename} replaces it. {!field-position} is a byte offset,
+    {!field-line} and {!field-col} are the 1-based line and column of that
     offset, and {!field-marker_pos} counts the characters of
     {!field-context_window} before it. A column is one Unicode scalar value, as
     for {!context_window}. *)
@@ -32,8 +36,8 @@ exception Parse_error of parse_error
     information. *)
 
 val pp_parse_error : parse_error -> string
-(** [pp_parse_error error] formats a parse error as a string, including call
-    stack if available. *)
+(** [pp_parse_error error] formats a parse error as a string, locating it as
+    [filename:line:column] and including call stack if available. *)
 
 (** {1 Core} *)
 
@@ -116,7 +120,8 @@ val err_invalid : t -> string -> 'a
 (** {1 Error Utilities} *)
 
 val with_filename : parse_error -> string -> parse_error
-(** [with_filename error filename] returns error with updated filename. *)
+(** [with_filename error filename] is [error] with [filename] as its source
+    name. The location is unchanged. *)
 
 (** {1 Characters & Strings} *)
 

--- a/test/test_reader.ml
+++ b/test/test_reader.ml
@@ -5,8 +5,12 @@ open Cascade
 open Reader
 open Css_test_helpers
 
-(* Helper to create parse_error for test expectations *)
-let parse_error_expected ?(got = None) ?(filename = "<string>") message reader =
+(* Expected-error skeleton for [check_raises], which compares [message] and
+   [got] and nothing else. [filename] is the source name, so the default is the
+   placeholder name a reader built by [of_string] carries; [line] and [col] hold
+   the location, and are inert here. *)
+let parse_error_expected ?(got = None) ?(filename = "<CSS input>") message
+    reader =
   let context_window, marker_pos = context_window reader in
   Parse_error
     {
@@ -14,6 +18,8 @@ let parse_error_expected ?(got = None) ?(filename = "<string>") message reader =
       got;
       position = position reader;
       filename;
+      line = 1;
+      col = 1;
       context_window;
       marker_pos;
       callstack = callstack reader;
@@ -1369,10 +1375,13 @@ let error_formatting_multiline () =
     Alcotest.(check bool)
       "context reasonable length" true
       (String.length error.context_window < 120);
-    (* Check that filename includes line:col info *)
+    (* The location lives in [line] and [col]; [filename] names the source and
+       carries no location, so it holds no separator. *)
     Alcotest.(check bool)
-      "filename has line info" true
-      (String.contains error.filename ':')
+      "filename holds no location" false
+      (String.contains error.filename ':');
+    Alcotest.(check (pair int int))
+      "location of the failing byte" (5, 3) (error.line, error.col)
 
 let error_formatting_long_line () =
   (* Test error on very long single line (minified CSS) *)
@@ -1507,26 +1516,27 @@ let error_at input pos =
    past the last byte of a line is one column beyond it. *)
 let error_line_and_column () =
   let check name input pos expected =
-    Alcotest.(check string) name expected (error_at input pos).filename
+    let error = error_at input pos in
+    Alcotest.(check (pair int int)) name expected (error.line, error.col)
   in
-  check "start of the second line" "abc\n" 4 "<CSS input>:2:1";
-  check "start of the second line, longer first" "aaaaa\n" 6 "<CSS input>:2:1";
-  check "start of the third line" "ab\ncd\n" 6 "<CSS input>:3:1";
-  check "past the last character" "abc" 3 "<CSS input>:1:4"
+  check "start of the second line" "abc\n" 4 (2, 1);
+  check "start of the second line, longer first" "aaaaa\n" 6 (2, 1);
+  check "start of the third line" "ab\ncd\n" 6 (3, 1);
+  check "past the last character" "abc" 3 (1, 4)
 
 (* A column is one Unicode scalar value, for the reported column and for the
    caret alike, so three euro signs put the error in column 4 with three
    characters before the caret rather than nine bytes. *)
 let error_column_counts_characters () =
   let error = error_at (euros 3) 9 in
-  Alcotest.(check string)
-    "column counts characters" "<CSS input>:1:4" error.filename;
+  Alcotest.(check (pair int int))
+    "column counts characters" (1, 4) (error.line, error.col);
   Alcotest.(check int) "caret counts characters" 3 error.marker_pos
 
 (* The caret of pure ASCII stays where it was, one column per byte. *)
 let error_ascii_caret_holds () =
   let error = error_at (String.make 50 'a') 50 in
-  Alcotest.(check string) "ascii column" "<CSS input>:1:51" error.filename;
+  Alcotest.(check (pair int int)) "ascii column" (1, 51) (error.line, error.col);
   Alcotest.(check int) "ascii caret" 40 error.marker_pos
 
 (* A window boundary landing inside a UTF-8 sequence moves out to the lead byte,
@@ -1540,6 +1550,38 @@ let error_context_window_keeps_code_points () =
   Alcotest.(check bool)
     "trailing boundary keeps code points" true
     (is_utf8 after.context_window)
+
+(* [filename] names the source and holds nothing else. A reader built by
+   [of_string] has no name of its own, so it carries the placeholder, and
+   [with_filename] swaps in the caller's name without disturbing the location in
+   [line], [col] and [position]. *)
+let error_filename_names_the_source () =
+  let error = error_at "abc\ndef" 5 in
+  Alcotest.(check string) "default source name" "<CSS input>" error.filename;
+  Alcotest.(check (pair int int))
+    "location of the failing byte" (2, 2) (error.line, error.col);
+  let stamped = with_filename error "theme.css" in
+  Alcotest.(check string) "stamped source name" "theme.css" stamped.filename;
+  Alcotest.(check (pair int int))
+    "stamping a name keeps the location" (2, 2)
+    (stamped.line, stamped.col);
+  Alcotest.(check int) "stamping a name keeps the offset" 5 stamped.position
+
+(* The rendered location is the three-part [source:line:column] an editor can
+   jump to. The byte offset stays in [position] for a caller that wants it, and
+   is not a fourth part of the rendered location. *)
+let error_renders_three_part_location () =
+  let first_line error =
+    List.hd (String.split_on_char '\n' (pp_parse_error error))
+  in
+  let error = error_at "abc\ndef" 5 in
+  Alcotest.(check bool)
+    "renders source:line:column" true
+    (String.ends_with ~suffix:" at <CSS input>:2:2" (first_line error));
+  Alcotest.(check bool)
+    "renders the stamped source name" true
+    (String.ends_with ~suffix:" at theme.css:2:2"
+       (first_line (with_filename error "theme.css")))
 
 (* Grouped test runners by feature for simpler suite entries *)
 
@@ -1593,7 +1635,9 @@ let tests_error_position () =
   error_line_and_column ();
   error_column_counts_characters ();
   error_ascii_caret_holds ();
-  error_context_window_keeps_code_points ()
+  error_context_window_keeps_code_points ();
+  error_filename_names_the_source ();
+  error_renders_three_part_location ()
 
 let tests_error_formatting () =
   error_formatting_multiline ();


### PR DESCRIPTION
`Reader.parse_error.filename` held `"<CSS input>:L:C"` rather than a filename, so the location had no fields of its own, `with_filename` destroyed it, and `pp_parse_error` rendered a four-part `<CSS input>:1:43:122`. The location now lives in `line` and `col`, `filename` holds only a source name, and the render is the three-part `filename:line:column`.

Follow-up to #477, which fixed the line and column walk in this record but stopped short of the type change.