### PR TITLE
lib: hash a string without allocating a closure

### DIFF
--- a/lib/common.ml
+++ b/lib/common.ml
@@ -107,14 +107,13 @@ end
 let mix_int acc x = ((acc lsl 5) - acc) lxor x
 
 (* [String.iter] would allocate a closure over the accumulator ref on every
-   call; the loop carries it in a parameter instead. *)
-let hash_string s =
-  let n = String.length s in
-  let rec go acc i =
-    if i >= n then acc
-    else go (mix_int acc (Char.code (String.unsafe_get s i))) (i + 1)
-  in
-  go 0x811c9dc5 0
+   call, and an inner loop reading [s] and [n] out of the enclosing scope
+   allocates one just the same; the loop carries all four in parameters. *)
+let rec hash_from s n acc i =
+  if i >= n then acc
+  else hash_from s n (mix_int acc (Char.code (String.unsafe_get s i))) (i + 1)
+
+let hash_string s = hash_from s (String.length s) 0x811c9dc5 0
 
 module Table = struct
   module Make (H : Hashtbl.HashedType) = struct

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -73,6 +73,53 @@ let test_filter_map_preserve_keeps_noop_identity () =
   Alcotest.(check bool) "replacement allocates" false (replaced == xs);
   Alcotest.(check int) "replacement length" 3 (L.length replaced)
 
+(* --- allocation guard --- *)
+
+let measure f =
+  Gc.full_major ();
+  let w0 = Gc.minor_words () in
+  let r = f () in
+  ignore (Sys.opaque_identity r);
+  Gc.minor_words () -. w0
+
+(* The string shapes a stylesheet hashes: an empty name, a short ident, a
+   hyphenated property, a long custom property, a value with punctuation, and a
+   name far longer than any of them. *)
+let hash_corpus =
+  [|
+    "";
+    "a";
+    "color";
+    "background-color";
+    "--tw-ring-offset-shadow";
+    "rgb(12 34 56/.5)";
+    String.make 64 'x';
+  |]
+
+let hash_corpus_times iters =
+  let acc = ref 0 in
+  for _ = 1 to iters do
+    for j = 0 to Array.length hash_corpus - 1 do
+      acc := Common.mix_int !acc (Common.hash_string hash_corpus.(j))
+    done
+  done;
+  !acc
+
+(* Hashing folds the bytes of a string into an accumulator, so nothing about it
+   needs the heap. A loop that reads the string and its length out of the
+   enclosing scope instead of carrying them in parameters costs a closure per
+   call, which a hot pair loop pays once per declaration it hashes. Two
+   iteration counts differenced cancel whatever the harness itself allocates. *)
+let test_hash_string_allocates_nothing () =
+  let iters = 20_000 in
+  let calls = iters * Array.length hash_corpus in
+  let a1 = measure (fun () -> hash_corpus_times iters) in
+  let a2 = measure (fun () -> hash_corpus_times (2 * iters)) in
+  let per_call = (a2 -. a1) /. float_of_int calls in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.2f words per call)" a1 a2 per_call)
+    true (per_call < 0.5)
+
 let suite =
   ( "common",
     [
@@ -86,4 +133,6 @@ let suite =
         test_filter_preserve_keeps_noop_identity;
       Alcotest.test_case "filter_map_preserve keeps no-op identity" `Quick
         test_filter_map_preserve_keeps_noop_identity;
+      Alcotest.test_case "hash_string allocates nothing" `Quick
+        test_hash_string_allocates_nothing;
     ] )


### PR DESCRIPTION
`Common.hash_string` allocated a 6-word closure on every call, because its inner loop read the string and its length out of the enclosing scope rather than carrying them in parameters; it now allocates nothing.

Hash values are unchanged, checked against the previous implementation over the empty string, all 256 one-byte and all 65,536 two-byte strings, 200,000 random strings up to 64 bytes, embedded NUL and 64 KiB inputs. A full parse, optimize and minify pass over the interop corpora allocates 0.3% fewer minor words and moves neither wall-clock nor instructions retired out of noise, which is too small to earn a changelog entry.