### PR TITLE
lib: hash a whole selector so shadow-dropping stays linear

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -398,6 +398,12 @@ answers.
 - `--minify` no longer allocates quadratically on a long run of rules sharing
   one selector or one body. The benchmark corpora hold no such run, so this
   bounds a worst case rather than speeding real input up (#480, #486, #487)
+- `--minify` no longer scans quadratically when many rules share a deep
+  selector prefix. The structural hash reads a fixed count of nodes, so
+  `.a .b .c .d .e .f .g` and every sibling differing only past that prefix took
+  one hash and the two tables that drop shadowed rules and declarations
+  compared selector subtrees on every probe; the heaviest stylesheet in the
+  corpus spends a third of what it did on that pass (#493)
 
 ### Custom properties
 

--- a/lib/cover.ml
+++ b/lib/cover.ml
@@ -4,11 +4,14 @@ module Props = Set.Make (struct
   let compare = Stdlib.compare
 end)
 
+(* Keyed on the selector itself, so it carries the same requirement as the
+   shadowing table next door: the stdlib hash reads a fixed count of nodes, and
+   rules written under one deep prefix would all land in one bucket. *)
 module Selector_tbl = Hashtbl.Make (struct
   type t = Selector.t
 
-  let equal = ( = )
-  let hash = Hashtbl.hash
+  let equal = Selector.equal
+  let hash = Selector.hash
 end)
 
 type entry = Props.t * Props.t

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -261,20 +261,34 @@ let selector_keys (r : rule) =
   | Some xs -> List.map canonical_selector_key xs
   | None -> [ canonical_selector_key r.Stylesheet_intf.selector ]
 
+(* [canonical_selector_key] sorts, so a key names the SET of selectors a rule
+   targets and two rules that target the same set share one. List equality under
+   [Selector.equal] over that sorted key keeps exactly that relation.
+
+   Typed rather than polymorphic because the stdlib hash reads a fixed count of
+   nodes: selectors sharing a deep prefix all land in one bucket, and every
+   probe then walks it comparing selector subtrees down the chain they share.
+   [Selector.hash] reads the whole selector, so the probe lands on the one entry
+   that matches. *)
+module Key_table = Common.Table.Make (struct
+  type t = Selector.t list
+
+  let equal = List.equal Selector.equal
+
+  let rec fold acc = function
+    | [] -> acc
+    | sel :: rest -> fold (Common.mix_int acc (Selector.hash sel)) rest
+
+  let hash keys = fold 0x9e3779b9 keys land max_int
+end)
+
 let later_by_selector_key (indexed : (int * rule) list) =
-  let later_by_key :
-      (Selector.t list, (int * Declaration.t list) list) Hashtbl.t =
-    Hashtbl.create 16
-  in
+  let later_by_key = Key_table.create 16 in
   List.iter
     (fun ((i, r) : int * rule) ->
       List.iter
         (fun key ->
-          let prev =
-            Hashtbl.find_opt later_by_key key |> Option.value ~default:[]
-          in
-          Hashtbl.replace later_by_key key
-            ((i, r.Stylesheet_intf.declarations) :: prev))
+          Key_table.push later_by_key key (i, r.Stylesheet_intf.declarations))
         (selector_keys r))
     indexed;
   later_by_key
@@ -282,7 +296,7 @@ let later_by_selector_key (indexed : (int * rule) list) =
 let shadowed_by_later ~later_by_key ~rule_index ~keys decl =
   let property_shadowed_for_key key =
     let writes =
-      Hashtbl.find_opt later_by_key key |> Option.value ~default:[]
+      Key_table.find_opt later_by_key key |> Option.value ~default:[]
     in
     List.exists
       (fun (j, decls) ->

--- a/lib/selector_intf.ml
+++ b/lib/selector_intf.ml
@@ -257,6 +257,13 @@ type t =
   | Nesting (* & - CSS nesting selector *)
 
 let equal (a : t) b = a = b
-let hash (selector : t) = Hashtbl.hash selector
+
+(* [Hashtbl.hash] reads ten meaningful nodes, and [Combined] nests to the right,
+   so what tells [.a .b .c .d .e .f .g] from [.a .b .c .d .e .f .h] sits past
+   where it stops: every selector behind a six-deep prefix takes one hash, and a
+   table keyed by one degenerates into a scan comparing selector subtrees down
+   the chain they share. 256 is the largest budget the runtime honours, and it
+   reaches the tail of any selector CSS is written with. *)
+let hash (selector : t) = Hashtbl.hash_param 256 256 selector
 let equal_specificity (a : specificity) b = a = b
 let equal_combinator (a : combinator) b = a = b

--- a/test/test_merge.ml
+++ b/test/test_merge.ml
@@ -140,6 +140,66 @@ let test_all_compatible_matches_the_pair_loop () =
            pool.(Random.State.int state (Array.length pool))))
   done
 
+(* Selectors whose distinguishing part sits behind a prefix they share, which is
+   where a table keyed by [key] has to work hardest. *)
+let key_pool =
+  Array.map Selector.of_string
+    [|
+      ".a";
+      ".p0 .p1 .p2 .p3 .p4 .p5 .p6 .p7 .t1";
+      ".p0 .p1 .p2 .p3 .p4 .p5 .p6 .p7 .t2";
+      ".p0>.p1>.p2>.p3>.p4>.p5>.p6>.t1";
+      ":is(.p0 .p1 .p2 .p3 .p4 .p5 .t1)";
+      ".p0 .p1 .p2 .p3 .p4 .p5 .p6[data-x=one]";
+      ".p0 .p1 .p2 .p3 .p4 .p5 .p6::before";
+      "div.p0 .p1 .p2 .p3 .p4 .p5 .p6 span.t1";
+    |]
+
+let key_of sels = Merge.key (Merge.selector_list sels)
+let keys_equal a b = List.equal Selector.equal (key_of a) (key_of b)
+let render sels = String.concat "," (List.map Selector.to_string sels)
+
+(* [key] answers for a selector list which SET of targets it writes, so any two
+   orderings of one list share a key and two different sets never do. A table
+   keyed by [key] inherits exactly that, which is what makes it sound to merge
+   the rules it groups. *)
+let check_key_is_the_set sels =
+  let shuffled = List.rev sels in
+  if not (keys_equal sels shuffled) then
+    Alcotest.failf "key is not order-insensitive on [%s]" (render sels);
+  let sorted = List.sort Selector.compare sels in
+  if not (keys_equal sels sorted) then
+    Alcotest.failf "key disagrees with its own sort on [%s]" (render sels)
+
+let test_key_is_the_selector_set () =
+  let pool = key_pool in
+  let n = Array.length pool in
+  (* Every list up to four selectors drawn from the pool, then longer random
+     ones. *)
+  let rec exhaustive depth acc =
+    if acc <> [] then check_key_is_the_set (List.rev acc);
+    if depth > 0 then
+      Array.iter (fun sel -> exhaustive (depth - 1) (sel :: acc)) pool
+  in
+  exhaustive 4 [];
+  let state = Random.State.make [| 0x5E1EC |] in
+  for _ = 1 to 5000 do
+    let len = 1 + Random.State.int state 12 in
+    check_key_is_the_set
+      (List.init len (fun _ -> pool.(Random.State.int state n)))
+  done;
+  (* Distinctness: two singleton lists share a key only when the selector is the
+     same one. *)
+  Array.iter
+    (fun a ->
+      Array.iter
+        (fun b ->
+          if keys_equal [ a ] [ b ] <> Selector.equal a b then
+            Alcotest.failf "key conflates %s with %s" (Selector.to_string a)
+              (Selector.to_string b))
+        pool)
+    pool
+
 let suite =
   ( "merge",
     [
@@ -153,4 +213,6 @@ let suite =
         test_all_compatible_matches_the_pair_loop;
       Alcotest.test_case "declarations_equal fast and structural paths" `Quick
         test_declarations_equal_fast_and_structural_paths;
+      Alcotest.test_case "key is the selector set" `Quick
+        test_key_is_the_selector_set;
     ] )

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -1613,6 +1613,64 @@ let test_attr_name () =
   check_attr_name "data-testid";
   check_attr_name "href"
 
+(* A table keyed by a selector separates its keys only if the hash reads far
+   enough into one to reach what distinguishes it. [Combined] nests to the
+   right, so the class that tells [.p0 ... .p7 .t1] from [.p0 ... .p7 .t2] is
+   the deepest node in both, behind a prefix they share: a hash that stops after
+   a fixed count of nodes returns one value for the whole family, and every
+   probe of such a table then walks the whole bucket comparing selector subtrees
+   down the shared chain. *)
+let hash_separates_deep_tails () =
+  let depth = 8 and n = 500 in
+  let prefix = String.concat " " (List.init depth (Fmt.str ".p%d")) in
+  let seen = Hashtbl.create 1024 in
+  for i = 1 to n do
+    Hashtbl.replace seen
+      (Fmt.kstr (fun src -> hash (of_string src)) "%s .t%d" prefix i)
+      ()
+  done;
+  Alcotest.(check int)
+    (Fmt.str "%d selectors sharing a %d-deep prefix take distinct hashes" n
+       depth)
+    n (Hashtbl.length seen)
+
+(* [hash] is consistent with [equal], and [equal] is the structural order's
+   zero: both hold across shapes that put what distinguishes them at every depth
+   a selector can. Each source is read twice, so the two sides are separate
+   trees and the hash is read off the structure, not off a shared pointer. *)
+let hash_agrees_with_equal () =
+  let sources =
+    [
+      ".a";
+      ".p0 .p1 .p2 .p3 .p4 .p5 .p6 .p7 .t1";
+      ".p0 .p1 .p2 .p3 .p4 .p5 .p6 .p7 .t2";
+      ".p0>.p1>.p2>.p3>.p4>.p5>.p6>.t1";
+      ".p0 .p1 .p2 .p3 .p4 .p5 .p6 .p7 .t1:hover";
+      "div.p0 .p1 .p2 .p3 .p4 .p5 .p6 span.t1";
+      ":is(.p0 .p1 .p2 .p3 .p4 .p5 .t1)";
+      ":is(.p0 .p1 .p2 .p3 .p4 .p5 .t2)";
+      ":where(.p0 .p1 .p2 .p3 .p4 .p5 .t1)";
+      ".p0 .p1 .p2 .p3 .p4 .p5 .p6[data-x=one]";
+      ".p0 .p1 .p2 .p3 .p4 .p5 .p6[data-x=two]";
+      ".p0 .p1 .p2 .p3 .p4 .p5 .p6::before";
+    ]
+  in
+  List.iter
+    (fun src_a ->
+      List.iter
+        (fun src_b ->
+          let a = of_string src_a and b = of_string src_b in
+          let eq = equal a b in
+          if eq <> (compare a b = 0) then
+            Alcotest.failf "equal disagrees with compare on %s / %s" src_a src_b;
+          if eq <> String.equal src_a src_b then
+            Alcotest.failf "equal conflates %s with %s" src_a src_b;
+          if eq then
+            if hash a <> hash b then
+              Alcotest.failf "equal selectors hash apart: %s" src_a)
+        sources)
+    sources
+
 (** {2 CSS Nesting Selector Tests} *)
 
 (* ignore-test *)
@@ -2235,5 +2293,7 @@ let suite =
         spec_selector_serialization_invariant_matrix;
       test_case "spec selector attribute namespace edges" `Quick
         spec_selector_attr_ns_edges;
+      test_case "hash separates deep tails" `Quick hash_separates_deep_tails;
+      test_case "hash agrees with equal" `Quick hash_agrees_with_equal;
       test_case "nesting selector" `Quick test_nesting_selector;
     ] )


### PR DESCRIPTION
`Css.optimize` drops shadowed rules and declarations through two tables keyed by a selector, and both hashed it with the structural hash, which reads a fixed count of nodes. `Combined` nests to the right, so every selector behind a six-deep prefix took the same hash and each probe walked the whole bucket comparing selector subtrees down the chain they share: 2000 such rules cost 25.6G instructions in that pass against 91M here, and the heaviest stylesheet in the SatCSS corpus spends a third of what it did.