### PR TITLE
bin: gate cascade fmt's exit status on the parse, not on the bytes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -588,6 +588,12 @@ answers.
   so a build gating on the exit status passes on valid CSS. The check rendered
   the sheet, and an empty rule, a redundant `@charset "UTF-8"` or an `src`-less
   `@font-face` prints nothing while losing nothing (#489)
+- `cascade fmt` exits 1 when parse recovery left no statement at all, where it
+  exited 1 when the printed output was empty and the parse had warned. A rule
+  survives a declaration the parser could not read, and `--minify` removes a
+  redundant `@charset "UTF-8"` or an `src`-less `@font-face` that nothing
+  lost, so both failed a build over CSS the parser used in full. The status
+  now answers the question `cascade apply` asks of each source (#494)
 - `cascade diff` names an at-rule that carries no condition of its own by the
   head it prints to, rather than describing every one identically. That
   description keys the ordering comparison, so a `@media` that moved between a

--- a/bin/cli_io.ml
+++ b/bin/cli_io.ml
@@ -46,15 +46,25 @@ let read_input ?enforce_spec path =
 (* Recovery that drops every rule leaves nothing to serialise, so [cascade fmt
    src.css > dist.css] writes a 0-byte file. Warnings on stderr are not
    something a build can gate on; the exit status is. An input that had nothing
-   to drop (comments only, an empty rule) stays a plain empty result. *)
-let check_not_all_dropped input ~written =
-  if written = 0 && input.recovered then begin
-    Fmt.epr
-      "Error: %s: parse dropped every rule; refusing to write an empty \
-       stylesheet@."
-      input.filename;
-    Stdlib.exit 1
-  end
+   to drop (comments only, an empty rule) stays a plain empty result.
+
+   Whether the parse produced anything is a question about the statement list,
+   the same one [cascade apply] asks of each [<style>] block. Counting the bytes
+   printed answers a different one and gets it wrong both ways: a rule survives
+   a declaration it could not read and prints nothing, and a sheet that lost
+   nothing still prints nothing once [--minify] drops a redundant [@charset] or
+   an [src]-less [@font-face]. Neither is a parse that dropped every rule. *)
+let check_not_all_dropped input =
+  match input.stylesheet with
+  | _ :: _ -> ()
+  | [] ->
+      if input.recovered then begin
+        Fmt.epr
+          "Error: %s: parse dropped every rule; refusing to write an empty \
+           stylesheet@."
+          input.filename;
+        Stdlib.exit 1
+      end
 
 let split_comma s =
   String.split_on_char ',' s |> List.map String.trim

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -43,21 +43,19 @@ let resolve_inline_imports ~input_path stylesheet =
   end
   else Cli_inline_imports.run ~base_url:input_path stylesheet
 
-(* Returns the number of bytes written, so the caller can tell a stylesheet that
-   serialised to nothing from one that had nothing to serialise. *)
 let emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet =
   let buf = Buffer.create 4096 in
   Css.to_buffer buf ~minify ~lossless ~enforce_spec stylesheet;
   let len = Buffer.length buf in
   if len > 0 && Buffer.nth buf (len - 1) <> '\n' then Buffer.add_char buf '\n';
-  Buffer.output_buffer stdout buf;
-  len
+  Buffer.output_buffer stdout buf
 
 let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
     ~enforce_spec ~closed_world ~objective ~inline_imports_flag
     ~inline_vars_flag ~keep_vars ~profile =
   try
     let input = Cli_io.read_input ~enforce_spec input_path in
+    Cli_io.check_not_all_dropped input;
     let stylesheet = input.Cli_io.stylesheet in
     let stylesheet =
       if inline_imports_flag then resolve_inline_imports ~input_path stylesheet
@@ -78,8 +76,7 @@ let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
           ~closed_world ~objective ~stats stylesheet
       else stylesheet
     in
-    let written = emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet in
-    Cli_io.check_not_all_dropped input ~written;
+    emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet;
     if profile then report_profile (Stats.snapshot stats)
   with
   | Sys_error msg ->
@@ -292,8 +289,9 @@ let man =
     `I ("0", "on success, including a parse that recovered some of the input");
     `I
       ( "1",
-        "if the input cannot be read, or if parse recovery dropped everything \
-         and the output would be an empty stylesheet" );
+        "if the input cannot be read, or if parse recovery left no statement \
+         at all. An output that is empty because the stylesheet held nothing a \
+         browser acts on is a success" );
     `S Manpage.s_examples;
     `P "Pretty-print a CSS file:";
     `Pre "  cascade fmt style.css";

--- a/test/cli/fmt_parse_failure.t
+++ b/test/cli/fmt_parse_failure.t
@@ -1,9 +1,11 @@
-CLI: `fmt` refuses to report success when it produced nothing.
+CLI: what `fmt` reports through its exit status.
 
-`cascade fmt src.css > dist.css` is a build step. When the input parses
-to an empty stylesheet the redirect writes a 0-byte file, and exiting 0
-there hands CI a green build and a site with no CSS. The warnings on
-stderr are easy to miss and impossible to gate on.
+`cascade fmt src.css > dist.css` is a build step, and the warnings on
+stderr are easy to miss and impossible to gate on, so the exit status
+carries the one thing the redirect cannot show: whether the parser could
+use the input at all. It is non-zero when a source that had something to
+drop left no statement behind, which is the question `cascade apply` asks
+of each `<style>` block. Everything else is a run that did its job.
 
 An entirely unparseable stylesheet: every rule is dropped, so the run is
 an error, stdout stays empty and the exit status is non-zero.
@@ -23,23 +25,31 @@ The warnings that explain the drop are still reported.
   $ grep -c '^warning' err.txt
   8
 
-A single rule whose value does not validate is the same case: the one
-rule is dropped and nothing is left to write.
-
-  $ cat > one-bad-rule.css <<EOF
-  > .b { color: notacolor }
-  > EOF
-  $ cascade fmt one-bad-rule.css > out2.css 2> err2.txt
-  [1]
-  $ wc -c < out2.css | tr -d ' '
-  0
-
 Reading from stdin reports the same way.
 
   $ cascade fmt - < broken.css > out3.css 2> err3.txt
   [1]
   $ grep '^Error' err3.txt
   Error: <stdin>: parse dropped every rule; refusing to write an empty stylesheet
+
+A rule whose only declaration does not validate is a partial loss, not a
+total one. CSS Syntax 3 sec. 5.4.4 discards the declaration and returns
+the rule that held it, so the parse leaves a statement; that statement
+has nothing to print, so the output is empty all the same.
+
+  $ cat > one-bad-rule.css <<EOF
+  > .b { color: notacolor }
+  > EOF
+  $ cascade fmt one-bad-rule.css > out2.css 2> err2.txt
+  $ wc -c < out2.css | tr -d ' '
+  0
+  $ grep '^Error' err2.txt
+  [1]
+
+The declaration that went is still reported.
+
+  $ grep -c 'notacolor' err2.txt
+  2
 
 Partial recovery is not an error: the rules that survive are written and
 the exit status stays 0.
@@ -51,6 +61,28 @@ the exit status stays 0.
   $ cascade fmt --minify partial.css 2> /dev/null
   .ok{color:#00f}
 
+Whatever the parser lost. A selector it cannot read takes the whole rule
+that carried it, and the rules either side are written.
+
+  $ cat > bad-selector.css <<EOF
+  > .ok { color: red }
+  > :: { color: blue }
+  > .ok2 { color: green }
+  > EOF
+  $ cascade fmt --minify bad-selector.css 2> /dev/null
+  .ok{color:red}.ok2{color:green}
+
+An at-rule prelude it cannot read is the same shape: the block goes, its
+neighbours stay.
+
+  $ cat > bad-prelude.css <<EOF
+  > .ok { color: red }
+  > @media (bogus^^^) { .x { color: blue } }
+  > .ok2 { color: green }
+  > EOF
+  $ cascade fmt --minify bad-prelude.css 2> /dev/null
+  .ok{color:red}.ok2{color:green}
+
 An input with no rules to begin with is legitimately empty: nothing was
 dropped, so there is nothing to report.
 
@@ -58,3 +90,50 @@ dropped, so there is nothing to report.
   > /* nothing but a comment */
   > EOF
   $ cascade fmt comment-only.css
+
+An empty output is not the question the status answers, and cannot be:
+`--minify` deletes CSS no browser would act on, and deleting it is the
+tool working rather than the parser losing. CSS Syntax 3 sec. 8.3 makes
+`@charset` a decoder hint rather than a rule, and UTF-8 is what the
+serialiser writes anyway, so a redundant one goes and the output is
+empty. Both were parsed and both were kept.
+
+  $ cat > charset.css <<EOF
+  > @charset "UTF-8";@charset "UTF-8";
+  > EOF
+  $ cascade fmt --minify charset.css > out4.css 2> err4.txt
+  $ wc -c < out4.css | tr -d ' '
+  0
+  $ grep '^Error' err4.txt
+  [1]
+
+The second one is out of place, which is reported, and neither that nor
+the deletion is a rule the parse dropped.
+
+  $ grep -c '^warning' err4.txt
+  1
+
+A `@font-face` with no `src` is the same shape. CSS Fonts 4 sec. 4.3
+gives it no font to load, so `--minify` removes it, but the rule parsed
+and the statement was there.
+
+  $ cat > face.css <<EOF
+  > @font-face{font-family:x}
+  > EOF
+  $ cascade fmt --minify face.css > out5.css 2> err5.txt
+  $ wc -c < out5.css | tr -d ' '
+  0
+  $ grep '^Error' err5.txt
+  [1]
+
+A warning is not a loss either way round: an at-rule this library does
+not recognise is reported and kept whole, so a stylesheet that is nothing
+but one formats to itself.
+
+  $ cat > kept.css <<EOF
+  > @foo bar;
+  > EOF
+  $ cascade fmt --minify kept.css 2> err6.txt
+  @foo bar;
+  $ grep -c '^warning' err6.txt
+  1


### PR DESCRIPTION
`cascade fmt` exited 1 whenever the printed output was empty and the parse had warned, which is not the question of whether the parse produced anything: a rule outlives a declaration the parser could not read, and `--minify` removes a redundant `@charset "UTF-8"` or an `src`-less `@font-face` that nothing lost, so a build gating on the status failed over CSS cascade used in full. It now exits 1 only when recovery left no statement at all, which is the question `cascade apply` has asked of each source since #489.

`test/cli/fmt_parse_failure.t` promotes the `one-bad-rule.css` transcript: that block recorded exit 1 on the grounds that the rule was dropped, and the parse in fact keeps `.b` and drops only its declaration.