### PR TITLE
properties: a position-area pair comes from one grammar branch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -204,6 +204,10 @@ answers.
   every `span-` spelling. css-anchor-position-1 sec. 3.1.2 gives them a branch
   of the grammar and browsers lay them out, but cascade had no keyword for any
   of them and dropped the declaration (#478, #485)
+- `position-area` rejects two keywords taken from different branches of its
+  grammar, such as `left block-start` or `start top`. Cascade checked only that
+  they named different axes, so it accepted 1120 ordered keyword pairs that
+  css-anchor-position-1 sec. 3.1.2 and Chrome 151 both reject (#495)
 
 ### Printing
 

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -884,33 +884,65 @@ let position_area_keywords : (string * position_area_keyword) list =
 let read_position_area_keyword t : position_area_keyword =
   Cursor.enum "position-area keyword" position_area_keywords t
 
-type position_area_axis = Horizontal | Vertical | Either
+type position_area_axis = Horizontal | Vertical
 
-let position_area_axis (keyword : position_area_keyword) =
+(* css-anchor-position-1 sec. 3.1.2 spells <position-area> as five top-level
+   alternatives: three join two groups with [||], and two repeat a single group
+   with [{1,2}]. The axis below is only ever read against the other side of the
+   same [||], never across alternatives. [center] and [span-all] are the two
+   keywords listed in every group. *)
+type position_area_group =
+  | Physical of position_area_axis
+  | Logical of position_area_axis
+  | Self_logical of position_area_axis
+  | Plain
+  | Self_plain
+  | Every_group
+
+let position_area_group (keyword : position_area_keyword) =
   match keyword with
   | Left | Right | Span_left | Span_right | X_start | X_end | Span_x_start
-  | Span_x_end | Inline_start | Inline_end | Span_inline_start | Span_inline_end
-  | Self_x_start | Self_x_end | Span_self_x_start | Span_self_x_end
+  | Span_x_end | Self_x_start | Self_x_end | Span_self_x_start | Span_self_x_end
+    ->
+      Physical Horizontal
+  | Top | Bottom | Span_top | Span_bottom | Y_start | Y_end | Span_y_start
+  | Span_y_end | Self_y_start | Self_y_end | Span_self_y_start | Span_self_y_end
+    ->
+      Physical Vertical
+  | Inline_start | Inline_end | Span_inline_start | Span_inline_end ->
+      Logical Horizontal
+  | Block_start | Block_end | Span_block_start | Span_block_end ->
+      Logical Vertical
   | Self_inline_start | Self_inline_end | Span_self_inline_start
   | Span_self_inline_end ->
-      Horizontal
-  | Top | Bottom | Span_top | Span_bottom | Y_start | Y_end | Span_y_start
-  | Span_y_end | Block_start | Block_end | Span_block_start | Span_block_end
-  | Self_y_start | Self_y_end | Span_self_y_start | Span_self_y_end
+      Self_logical Horizontal
   | Self_block_start | Self_block_end | Span_self_block_start
   | Span_self_block_end ->
-      Vertical
-  (* css-anchor-position-1 sec. 3.1.2: [center], [span-all] and the start/end
-     keywords that name no axis explicitly are ambiguous. The [self-] forms that
-     do name one, physical or logical, are not. *)
-  | Center | Span_all | Start | End | Span_start | Span_end | Self_start
-  | Self_end | Span_self_start | Span_self_end ->
-      Either
+      Self_logical Vertical
+  | Start | End | Span_start | Span_end -> Plain
+  | Self_start | Self_end | Span_self_start | Span_self_end -> Self_plain
+  | Center | Span_all -> Every_group
 
 let compatible_position_area_keywords first second =
-  match (position_area_axis first, position_area_axis second) with
-  | Horizontal, Horizontal | Vertical, Vertical -> false
-  | _ -> true
+  match (position_area_group first, position_area_group second) with
+  (* Being in every group, these pair with anything and take whichever side is
+     left over. *)
+  | Every_group, _ | _, Every_group -> true
+  (* Each side of a [||] contributes at most one keyword, so a two-keyword value
+     has to take both sides of one alternative. *)
+  | Physical Horizontal, Physical Vertical
+  | Physical Vertical, Physical Horizontal
+  | Logical Horizontal, Logical Vertical
+  | Logical Vertical, Logical Horizontal
+  | Self_logical Horizontal, Self_logical Vertical
+  | Self_logical Vertical, Self_logical Horizontal ->
+      true
+  (* A [{1,2}] repeats one group, so any two of its keywords pair, a repeat
+     included. *)
+  | Plain, Plain | Self_plain, Self_plain -> true
+  (* Everything else crosses two alternatives, which the grammar never
+     produces. *)
+  | (Physical _ | Logical _ | Self_logical _ | Plain | Self_plain), _ -> false
 
 let rec read_position_area t : position_area =
   Cursor.enum_or_var "position-area"
@@ -929,7 +961,7 @@ let rec read_position_area t : position_area =
       | [ first; second ] ->
           if not (compatible_position_area_keywords first second) then
             Cursor.err_invalid t
-              "position-area keywords must cover different axes";
+              "position-area keywords must come from one branch of the grammar";
           (Area (first, Some second) : position_area)
       | _ -> Cursor.err_expected t "position-area")
     t

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4111,6 +4111,52 @@ let spec_generated_position_interaction_edges () =
   neg_cursor read_position_area "self-block-start self-block-end";
   neg_cursor read_position_area "self-block-start self-block-start";
   neg_cursor read_position_area "self-inline-start span-self-inline-end";
+  (* Sec. 3.1.2 spells <position-area> as five top-level alternatives: the
+     physical [ left | ... ] || [ top | ... ], the logical [ block-start | ... ]
+     || [ inline-start | ... ], its [self-] twin, and the two {1,2} groups over
+     [ start | ... ] and [ self-start | ... ]. Only [center] and [span-all]
+     appear in every group, so any other pair has to come from one alternative.
+     Naming two axes is not enough on its own: each pair below names one row and
+     one column yet crosses two alternatives, and Chrome 151 rejects every one
+     of them, leaving position-area at its [none] initial value. *)
+  neg_cursor read_position_area "left block-start";
+  neg_cursor read_position_area "block-start left";
+  neg_cursor read_position_area "inline-start y-end";
+  neg_cursor read_position_area "x-start self-block-start";
+  neg_cursor read_position_area "self-x-start self-block-start";
+  neg_cursor read_position_area "self-inline-end top";
+  neg_cursor read_position_area "block-start self-inline-end";
+  neg_cursor read_position_area "span-inline-start span-self-block-end";
+  (* The {1,2} groups are alternatives of their own, so a plain [start] pairs
+     with nothing outside its own group, not with a physical or logical keyword
+     and not with a [self-] one. *)
+  neg_cursor read_position_area "start top";
+  neg_cursor read_position_area "span-end left";
+  neg_cursor read_position_area "start block-end";
+  neg_cursor read_position_area "inline-end span-start";
+  neg_cursor read_position_area "start self-inline-start";
+  neg_cursor read_position_area "self-block-end span-start";
+  neg_cursor read_position_area "self-start right";
+  neg_cursor read_position_area "span-self-end y-start";
+  neg_cursor read_position_area "self-end block-start";
+  neg_cursor read_position_area "self-start self-x-end";
+  neg_cursor read_position_area "self-start self-block-end";
+  neg_cursor read_position_area "span-self-inline-start self-end";
+  neg_cursor read_position_area "start self-start";
+  neg_cursor read_position_area "span-self-start end";
+  (* Within one alternative the two sides of the [||] still combine in either
+     order, and [center] and [span-all] pair with anything. *)
+  check_position_area "left top";
+  check_position_area "x-start self-y-end";
+  check_position_area "block-start inline-end";
+  check_position_area "span-inline-start block-end";
+  check_position_area "self-inline-start self-block-end";
+  check_position_area "inline-start center";
+  check_position_area "span-all self-inline-end";
+  check_position_area "start span-all";
+  check_position_area "center self-end";
+  check_position_area "top span-right";
+  check_position_area "top span-left";
   check_position_area_keyword "span-inline-start";
   check_position_try_fallback "flip-block";
   check_position_try_fallbacks ~expected:"flip-block,--fallback"


### PR DESCRIPTION
`position-area: left block-start`, `start top` and `start self-start` used to parse; now they are rejected, because the reader checked only that the two keywords named different axes and not that they came from the same top-level alternative of the css-anchor-position-1 sec. 3.1.2 grammar. Chrome 151 rejects every pair this newly refuses, and the interop corpus is byte-identical.

Follow-up to #478 and #485, which both noted this looseness.