### PR TITLE
lib: fault an @container query on the slice that failed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,11 @@ answers.
 
 ### Parsing
 
+- An error inside an at-rule condition points at the slice of the query
+  that failed. `@container style()` faulted the whole rule at the end of
+  the file, so the caret sat past the last byte and the snippet opened
+  mid-word. `Css.Container.of_string` raises `Cursor.Parse_error`, which
+  carries that span, where it raised `Failure` (#496)
 - Everything the parser repaired or dropped is reported, so strict mode
   rejects it. `@media screen {` swallowed the rest of the file and still
   returned `Ok` with no warnings, hiding a truncated stylesheet (#484)

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -412,17 +412,26 @@ let style_range_query cvs =
       | _ -> None)
   | _ -> None
 
-let style_leaf_declaration name_components value =
+(* Every failure below is an [@container] prelude failure, and the slice of the
+   query that failed carries the span the caret must point at. [t] anchors the
+   smallest enclosing construct, for a failure that has no components of its
+   own. *)
+let err t cvs reason =
+  let at = match cvs with [] -> t | _ :: _ -> Cursor.sub t cvs in
+  Cursor.err_condition at ~at_rule:"@container" reason
+
+let style_leaf_declaration t name_components value =
   match (style_strip_ws name_components, style_strip_ws value) with
   | [ name_component ], stripped_value when not (has_semicolon_component value)
     -> (
       match ident_component name_component with
       | Some name when stripped_value <> [] || is_custom_property name ->
           Declaration { name; value }
-      | Some _ | None -> failwith "invalid style() container query")
-  | _ -> failwith "invalid style() container query"
+      | Some _ | None -> err t name_components "invalid style() container query"
+      )
+  | _ -> err t name_components "invalid style() container query"
 
-let style_leaf_boolean components =
+let style_leaf_boolean t components =
   match style_strip_ws components with
   | [ name_component ] -> (
       match ident_component name_component with
@@ -431,56 +440,56 @@ let style_leaf_boolean components =
          [--]. A bare property name like [style(color)] is not a valid boolean
          form. *)
       | Some name when is_custom_property name -> Boolean name
-      | _ -> failwith "invalid style() container query")
-  | _ -> failwith "invalid style() container query"
+      | _ -> err t components "invalid style() container query")
+  | _ -> err t components "invalid style() container query"
 
-let style_leaf_components components =
+let style_leaf_components t components =
   match split_top_level_colon components with
   | Some (name_components, value) ->
-      style_leaf_declaration name_components value
+      style_leaf_declaration t name_components value
   | None -> (
       match style_range_query components with
       | Some query -> query
-      | None -> style_leaf_boolean components)
+      | None -> style_leaf_boolean t components)
 
-let rec style_query_components components =
+let rec style_query_components t components =
   let components = trim_components components in
-  if components_empty components then failwith "empty style() container query";
+  if components_empty components then
+    err t components "empty style() container query";
   match split_top_level_colon components with
-  | Some _ -> style_leaf_components components
-  | None -> style_query_operator components
+  | Some _ -> style_leaf_components t components
+  | None -> style_query_operator t components
 
-and style_query_operator components =
+and style_query_operator t components =
   let level, unwrapped =
     match single_paren_body components with
     | Some body -> (trim_components body, true)
     | None -> (components, false)
   in
   if has_keyword "and" level && has_keyword "or" level then
-    failwith "mixed style() operators require grouping"
+    err t level "mixed style() operators require grouping"
   else
     match split_keyword "or" level with
     | Some (lhs, rhs) ->
-        Any (style_query_components lhs, style_query_components rhs)
-    | None -> style_query_conjunction ~components ~level ~unwrapped
+        Any (style_query_components t lhs, style_query_components t rhs)
+    | None -> style_query_conjunction t ~components ~level ~unwrapped
 
-and style_query_conjunction ~components ~level ~unwrapped =
+and style_query_conjunction t ~components ~level ~unwrapped =
   match split_keyword "and" level with
   | Some (lhs, rhs) ->
-      All (style_query_components lhs, style_query_components rhs)
-  | None -> style_query_unary ~components ~level ~unwrapped
+      All (style_query_components t lhs, style_query_components t rhs)
+  | None -> style_query_unary t ~components ~level ~unwrapped
 
-and style_query_unary ~components ~level ~unwrapped =
+and style_query_unary t ~components ~level ~unwrapped =
   match level with
-  | first :: rest when ident_is "not" first -> Neg (style_query_components rest)
-  | _ when unwrapped -> style_query_components level
-  | _ -> style_leaf_components components
+  | first :: rest when ident_is "not" first ->
+      Neg (style_query_components t rest)
+  | _ when unwrapped -> style_query_components t level
+  | _ -> style_leaf_components t components
 
-let style_body ~uppercase components =
-  let body = string_of_components components in
-  try Style { query = style_query_components components; uppercase }
-  with Failure msg ->
-    failwith (if String.equal body "" then msg else msg ^ ": " ^ body)
+let style_body t ~uppercase (fn : Component.func Component.node) =
+  let t = Cursor.sub t [ Component.Func fn ] in
+  Style { query = style_query_components t fn.node.arguments; uppercase }
 
 let scroll_state_value_allowed name value =
   match name with
@@ -508,7 +517,7 @@ let scroll_state_value_allowed name value =
       | _ -> false)
   | _ -> false
 
-let scroll_state_query_leaf components =
+let scroll_state_query_leaf t components =
   match split_top_level_colon components with
   | Some (name_components, value_components) -> (
       match
@@ -523,58 +532,63 @@ let scroll_state_query_leaf components =
               let value = String.lowercase_ascii value in
               if scroll_state_value_allowed name value then
                 State { name; value }
-              else failwith "invalid scroll-state() container query"
+              else
+                err t value_components "invalid scroll-state() container query"
           | Some _, None | None, Some _ | None, None ->
-              failwith "invalid scroll-state() container query")
-      | _ -> failwith "invalid scroll-state() container query")
-  | None -> failwith "invalid scroll-state() container query"
+              err t components "invalid scroll-state() container query")
+      | _ -> err t components "invalid scroll-state() container query")
+  | None -> err t components "invalid scroll-state() container query"
 
-let rec scroll_state_query_components components =
+let rec scroll_state_query_components t components =
   let components = trim_components components in
   if components_empty components then
-    failwith "empty scroll-state() container query";
+    err t components "empty scroll-state() container query";
   match split_top_level_colon components with
-  | Some _ -> scroll_state_query_leaf components
-  | None -> scroll_state_query_operator components
+  | Some _ -> scroll_state_query_leaf t components
+  | None -> scroll_state_query_operator t components
 
-and scroll_state_query_operator components =
+and scroll_state_query_operator t components =
   let level, unwrapped =
     match single_paren_body components with
     | Some body -> (trim_components body, true)
     | None -> (components, false)
   in
   if has_keyword "and" level && has_keyword "or" level then
-    failwith "mixed scroll-state() operators require grouping"
+    err t level "mixed scroll-state() operators require grouping"
   else
     match split_keyword "or" level with
     | Some (lhs, rhs) ->
         Either
-          (scroll_state_query_components lhs, scroll_state_query_components rhs)
-    | None -> scroll_state_query_conjunction ~components ~level ~unwrapped
+          ( scroll_state_query_components t lhs,
+            scroll_state_query_components t rhs )
+    | None -> scroll_state_query_conjunction t ~components ~level ~unwrapped
 
-and scroll_state_query_conjunction ~components ~level ~unwrapped =
+and scroll_state_query_conjunction t ~components ~level ~unwrapped =
   match split_keyword "and" level with
   | Some (lhs, rhs) ->
-      Both (scroll_state_query_components lhs, scroll_state_query_components rhs)
-  | None -> scroll_state_query_unary ~components ~level ~unwrapped
+      Both
+        ( scroll_state_query_components t lhs,
+          scroll_state_query_components t rhs )
+  | None -> scroll_state_query_unary t ~components ~level ~unwrapped
 
-and scroll_state_query_unary ~components ~level ~unwrapped =
+and scroll_state_query_unary t ~components ~level ~unwrapped =
   match level with
   | first :: rest when ident_is "not" first ->
-      Negated (scroll_state_query_components rest)
-  | _ when unwrapped -> scroll_state_query_components level
-  | _ -> scroll_state_query_leaf components
+      Negated (scroll_state_query_components t rest)
+  | _ when unwrapped -> scroll_state_query_components t level
+  | _ -> scroll_state_query_leaf t components
 
-let scroll_state_body ~uppercase components =
-  let body = string_of_components components in
-  try
-    Scroll_state { query = scroll_state_query_components components; uppercase }
-  with Failure msg ->
-    failwith (if String.equal body "" then msg else msg ^ ": " ^ body)
+let scroll_state_body t ~uppercase (fn : Component.func Component.node) =
+  let t = Cursor.sub t [ Component.Func fn ] in
+  Scroll_state
+    { query = scroll_state_query_components t fn.node.arguments; uppercase }
 
 type query_surface =
-  | Style_func of { canonical_name : bool; arguments : Component.t list }
-  | Scroll_state_func of { canonical_name : bool; arguments : Component.t list }
+  | Style_func of { canonical_name : bool; fn : Component.func Component.node }
+  | Scroll_state_func of {
+      canonical_name : bool;
+      fn : Component.func Component.node;
+    }
   | Parenthesized_feature
   | Other_query
 
@@ -620,25 +634,27 @@ let has_dangling_range_operator cvs =
   | Component.Preserved { kind = Token.Delim ("<" | ">"); _ } :: _ -> true
   | _ -> false
 
-let classify_query_surface components =
+let classify_query_surface t components =
   match trim_components components with
-  | [ Component.Func { node = { name; arguments; terminated }; _ } ] -> (
-      if not terminated then failwith "unmatched container query function";
+  | [ (Component.Func ({ node = { name; terminated; _ }; _ } as fn) as cv) ]
+    -> (
+      if not terminated then err t [ cv ] "unmatched container query function";
       let lower = String.lowercase_ascii name in
       let canonical_name = name = lower in
       match lower with
-      | "style" -> Style_func { canonical_name; arguments }
-      | "scroll-state" -> Scroll_state_func { canonical_name; arguments }
+      | "style" -> Style_func { canonical_name; fn }
+      | "scroll-state" -> Scroll_state_func { canonical_name; fn }
       | _ -> Other_query)
-  | [ Component.Block { node = { opening = Token.Paren; value; closed }; _ } ]
-    ->
-      if not closed then failwith "unmatched container query parentheses";
+  | [
+   (Component.Block { node = { opening = Token.Paren; value; closed }; _ } as cv);
+  ] ->
+      if not closed then err t [ cv ] "unmatched container query parentheses";
       let value = strip_ws value in
       if components_empty value then Other_query
       else if has_dangling_range_operator value then
-        failwith "dangling range operator in container query"
+        err t value "dangling range operator in container query"
       else if has_opposing_interval_components value then
-        failwith "opposing interval operators in container query"
+        err t value "opposing interval operators in container query"
       else Parenthesized_feature
   | _ -> Other_query
 
@@ -651,16 +667,17 @@ let single_feature_of_media (media : Media.t) =
   | Media.Cond (Media.Feature _) -> Some media
   | Media.Cond _ | Media.List _ | Media.Type _ -> None
 
-let specific_of_components components =
+let specific_of_components t components =
   if trim_components components |> components_empty then
-    failwith "empty container query";
-  match classify_query_surface components with
-  | Style_func { canonical_name; arguments } ->
-      style_body ~uppercase:(not canonical_name) arguments
-  | Scroll_state_func { canonical_name; arguments } ->
-      scroll_state_body ~uppercase:(not canonical_name) arguments
-  | Parenthesized_feature -> failwith "unrecognised container feature query"
-  | Other_query -> failwith "not a container-specific query"
+    err t components "empty container query";
+  match classify_query_surface t components with
+  | Style_func { canonical_name; fn } ->
+      style_body t ~uppercase:(not canonical_name) fn
+  | Scroll_state_func { canonical_name; fn } ->
+      scroll_state_body t ~uppercase:(not canonical_name) fn
+  | Parenthesized_feature ->
+      err t components "unrecognised container feature query"
+  | Other_query -> err t components "not a container-specific query"
 
 let unresolved_media_feature components =
   match trim_components components with
@@ -694,15 +711,15 @@ let rec strip_outer_components components =
   | Some body -> strip_outer_components body
   | None -> trim_components components
 
-let atom_of_components components =
+let atom_of_components t components =
   let components = trim_components components in
   let stripped = strip_outer_components components in
-  match classify_query_surface stripped with
+  match classify_query_surface t stripped with
   | _ when components_have_var components -> (
       match unresolved_media_feature components with
       | Some query -> query
-      | None -> specific_of_components stripped)
-  | Style_func _ | Scroll_state_func _ -> specific_of_components stripped
+      | None -> specific_of_components t stripped)
+  | Style_func _ | Scroll_state_func _ -> specific_of_components t stripped
   | Parenthesized_feature | Other_query -> (
       let source = string_of_components components in
       match Media.of_string_strict source with
@@ -716,12 +733,12 @@ let atom_of_components components =
       | media -> (
           match single_feature_of_media media with
           | Some f -> Feature_query f
-          | None -> failwith "not a container feature query")
-      | exception Failure _ -> specific_of_components stripped)
+          | None -> err t components "not a container feature query")
+      | exception Failure _ -> specific_of_components t stripped)
 
-let rec unnamed_of_components components =
+let rec unnamed_of_components t components =
   let components = trim_components components in
-  if components_empty components then failwith "empty container query";
+  if components_empty components then err t components "empty container query";
   let level =
     match single_paren_body components with
     | Some body when Option.is_none (split_top_level_colon body) ->
@@ -729,32 +746,35 @@ let rec unnamed_of_components components =
     | Some _ | None -> components
   in
   if has_keyword "and" level && has_keyword "or" level then
-    failwith "mixed container query operators require grouping"
-  else unnamed_or_components ~components level
+    err t level "mixed container query operators require grouping"
+  else unnamed_or_components t ~components level
 
-and unnamed_or_components ~components level =
+and unnamed_or_components t ~components level =
   match split_keyword "or" level with
-  | Some (lhs, rhs) -> Or (unnamed_of_components lhs, unnamed_of_components rhs)
-  | None -> unnamed_and_components ~components level
+  | Some (lhs, rhs) ->
+      Or (unnamed_of_components t lhs, unnamed_of_components t rhs)
+  | None -> unnamed_and_components t ~components level
 
-and unnamed_and_components ~components level =
+and unnamed_and_components t ~components level =
   match split_keyword "and" level with
-  | Some (lhs, rhs) -> And (unnamed_of_components lhs, unnamed_of_components rhs)
-  | None -> unnamed_unary_components ~components level
+  | Some (lhs, rhs) ->
+      And (unnamed_of_components t lhs, unnamed_of_components t rhs)
+  | None -> unnamed_unary_components t ~components level
 
-and unnamed_unary_components ~components = function
+and unnamed_unary_components t ~components = function
   | first :: rest when ident_is "not" first ->
       if not (is_query_operand rest) then
-        failwith "container query: 'not' requires a query-in-parens operand";
-      Not (unnamed_of_components rest)
-  | _ -> atom_of_components components
+        err t rest "container query: 'not' requires a query-in-parens operand";
+      Not (unnamed_of_components t rest)
+  | _ -> atom_of_components t components
 
-let of_components components =
+let read t =
+  let components = Cursor.remaining t in
   match split_named_components components with
-  | Some (name, query) -> Named (name, unnamed_of_components query)
-  | None -> unnamed_of_components components
+  | Some (name, query) -> Named (name, unnamed_of_components t query)
+  | None -> unnamed_of_components t components
 
-let of_string s = Cursor.of_string s |> Cursor.remaining |> of_components
+let of_string s = read (Cursor.of_string s)
 let feature name value = Feature_query (Media.feature name value)
 
 let style ?value prop =

--- a/lib/container.mli
+++ b/lib/container.mli
@@ -84,12 +84,15 @@ val pp : t -> string
 (** [pp t] returns a string representation of a container condition. *)
 
 val of_string : string -> t
-(** [of_string s] parses a container condition. Raises [Failure] for malformed
-    conditions. *)
+(** [of_string s] parses a container condition. Raises
+    {!Cursor.exception-Parse_error} for a malformed condition. *)
 
-val of_components : Component.t list -> t
-(** [of_components components] parses an already-tokenized container condition.
-    Raises [Failure] for malformed conditions. *)
+val read : Cursor.t -> t
+(** [read t] parses the container condition [t] holds, consuming nothing. A
+    malformed condition raises {!Cursor.exception-Parse_error} anchored on the
+    slice of the query that failed, so pass a cursor built over the components
+    the prelude was lexed into ({!Cursor.val-sub}) rather than a re-lex of their
+    text. *)
 
 val feature : string -> Media.value -> t
 (** [feature name value] is the typed container feature query constructed via

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -205,9 +205,11 @@ exception Parse_error = Error.Parse_error
 
 let sort = Sort.Component
 
-let raise_ t kind loc =
+let raise_sort t sort kind loc =
   let source = match (t.meta, t.source) with `Full, s -> s | _ -> None in
   Error.fail (Error.v ?source ~loc ~sort kind)
+
+let raise_ t kind loc = raise_sort t sort kind loc
 
 let err ?got t msg =
   let loc = position t in
@@ -226,6 +228,12 @@ let err_expected_but_eof t what =
   raise_ t (Error.Missing_token what) (position t)
 
 let err_unexpected t = err t "unexpected token"
+
+let err_condition t ~at_rule reason =
+  raise_sort t Sort.At_rule
+    (Error.Bad_condition { at_rule; reason })
+    (position t)
+
 let with_context _t label f = Error.with_context label f
 
 let atomic t f =

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -197,6 +197,12 @@ val err_expected_but_eof : t -> string -> 'a
 val err_unexpected : t -> 'a
 (** [err_unexpected t] raises "unexpected token" at the current position. *)
 
+val err_condition : t -> at_rule:string -> string -> 'a
+(** [err_condition t ~at_rule reason] raises {!Parse_error} carrying
+    {!Error.Bad_condition} for [at_rule], anchored at the current position. An
+    at-rule prelude reader raises through this so the caret lands on the slice
+    of the condition that failed rather than on the enclosing rule. *)
+
 val with_context : t -> string -> (unit -> 'a) -> 'a
 (** [with_context t label f] annotates any {!Parse_error} raised by [f] with
     [label] in the error path. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3706,15 +3706,10 @@ and read_container (r : Cursor.t) : statement =
     | other -> other
   in
   Cursor.ws r;
-  let condition_components = Cursor.drain_until_block r in
+  let query = Cursor.sub r (Cursor.drain_until_block r) in
   let content = Cursor.braces (fun inner -> read_block inner) r in
   let condition : Container.t option =
-    if Cursor.of_components condition_components |> Cursor.is_done then
-      Option.None
-    else
-      match Container.of_components condition_components with
-      | condition -> Some condition
-      | exception Failure msg -> Cursor.err_invalid r msg
+    if Cursor.is_done query then Option.None else Some (Container.read query)
   in
   (* CSS Containment 3 section 4: [@container] requires a query (with an
      optional [<container-name>] in front). Bare [@container { ... }] is a parse
@@ -3838,14 +3833,10 @@ and read_nested_at_rule (r : Cursor.t) (at_rule : string) : statement =
 and read_nested_container_rule r =
   let container_name : string option = Cursor.option Cursor.ident r in
   Cursor.ws r;
-  let condition_str = Cursor.drain_until_block_as_string ~trim:true r in
+  let query = Cursor.sub r (Cursor.drain_until_block r) in
   let content = Cursor.braces (fun inner -> read_nesting_block inner) r in
   let condition : Container.t option =
-    if condition_str = "" then Option.None
-    else
-      match Container.of_string condition_str with
-      | condition -> Some condition
-      | exception Failure msg -> Cursor.err_invalid r msg
+    if Cursor.is_done query then Option.None else Some (Container.read query)
   in
   Container (container_name, condition, content)
 

--- a/test/cli/parse_error_locations.t
+++ b/test/cli/parse_error_locations.t
@@ -1,10 +1,12 @@
 CLI: parse-error warnings carry a precise location, not Loc.dummy.
 
-The `of_string` parsers in lib/{supports,container,media,...}.ml raise
-typed `Cursor.Parse_error` anchored at the failing cursor position.
-The stylesheet readers re-anchor those errors at the surrounding rule's
-condition span so the `[start-end]` locator in the warning points at
-the offending region of the source file, never `[0-0]`.
+The `read` and `of_string` parsers in lib/{supports,container,media,...}.ml
+raise typed `Cursor.Parse_error` anchored at the failing cursor position.
+A reader handed the components the prelude was lexed into faults the slice
+of the condition that failed; one handed a re-lex of the prelude text is
+re-anchored by the stylesheet reader at the surrounding condition span. The
+`[start-end]` locator in the warning points at the offending region of the
+source file, never `[0-0]`.
 
 Invalid `@supports` condition: trailing junk after a valid feature
 query lands the warning at the at-rule's prelude span.
@@ -26,10 +28,11 @@ slice, not at the start of the file.
   > @container style() { .a { color: blue } }
   > EOF
   $ cascade --minify bad-container.css 2>&1
-  warning: bad-container.css: bad value for : invalid: empty style() container query at [61-61] (in component)
-  warning: ontainer style() { .a { color: blue } }
+  warning: bad-container.css: bad condition for @container: empty style() container query at [30-37] (in at-rule)
+  warning: .ok { color: red }
+  warning: @container style() { .a { color: blue } }
   warning: 
-  warning:                                         ^
+  warning:                               ^^^^^^^
   .ok{color:red}
 
 Invalid `@media` query inside `@import`: the warning points at the

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -3,7 +3,7 @@ open Cascade
 let rejects_invalid input =
   let open Css.Container in
   match of_string input with
-  | exception Failure _ -> ()
+  | exception Error.Parse_error _ -> ()
   | query ->
       Alcotest.failf "invalid container query parsed: %s -> %s" input
         (to_string query)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -8716,6 +8716,53 @@ let cssom67_no_trailing_semicolon () =
     "minified output has no trailing semicolon before }" false
     (Astring.String.is_infix ~affix:";}" with_trailing)
 
+(* An [@container] prelude that does not parse is faulted against the slice of
+   the query that failed, so the caret lands inside the query. Every span below
+   is counted off the source text: the leading rule is 18 bytes plus a newline,
+   so line 2 opens at offset 19 and [@container ] runs to offset 29. *)
+let container_condition_error_spans () =
+  let check name query (reason, start_pos, end_pos) =
+    let input =
+      ".ok { color: red }\n@container " ^ query ^ " { .a { color: blue } }\n"
+    in
+    match Css.of_string ~strict:false input with
+    | Error err ->
+        Alcotest.failf "%s: lenient parse failed: %s" name
+          (Cascade.Error.to_string err)
+    | Ok { Css.stylesheet; warnings } -> (
+        Alcotest.(check int)
+          (name ^ ": sibling rule survives")
+          1
+          (List.length (Css.rule_statements stylesheet));
+        match warnings with
+        | [ e ] ->
+            (match e.Error.kind with
+            | Error.Bad_condition { at_rule; reason = got } ->
+                Alcotest.(check string)
+                  (name ^ ": at-rule") "@container" at_rule;
+                Alcotest.(check string) (name ^ ": reason") reason got
+            | _ ->
+                Alcotest.failf "%s: expected Bad_condition, got %s" name
+                  (Error.to_string e));
+            Alcotest.(check (pair int int))
+              (name ^ ": span") (start_pos, end_pos)
+              (e.Error.loc.Loc.start_pos, e.Error.loc.Loc.end_pos)
+        | ws ->
+            Alcotest.failf "%s: expected one warning, got %d" name
+              (List.length ws))
+  in
+  (* [style()] spans offsets 30-36; an empty argument list has no components of
+     its own, so the call itself carries the span. *)
+  check "empty style()" "style()" ("empty style() container query", 30, 37);
+  (* The parenthesised query spans offsets 30-33. *)
+  check "empty query" "(  )" ("empty container query", 30, 34);
+  (* [scroll-state(] ends at offset 42, so [bogus] spans 43-47. *)
+  check "bad scroll-state()" "scroll-state(bogus)"
+    ("invalid scroll-state() container query", 43, 48);
+  (* [style(] ends at offset 35, so [1px] spans 36-38. *)
+  check "bad style() name" "style(1px: red)"
+    ("invalid style() container query", 36, 39)
+
 let additional_tests =
   [
     ("check function", `Quick, test_check);
@@ -9644,6 +9691,9 @@ let additional_tests =
                 Alcotest.failf "expected Bad_condition, got %s"
                   (Error.to_string e))
         | _ -> Alcotest.fail "expected one warning" );
+    ( "an @container query error points at the failing slice",
+      `Quick,
+      container_condition_error_spans );
   ]
 
 (* Every shape a statement can take, so the walkers are exercised on the block


### PR DESCRIPTION
`@container style() { ... }` reported its parse error at the end of the file, with the caret past the last byte and the source snippet opening mid-word, because the query reader signalled with `failwith` and the stylesheet rebuilt a position from a cursor that had already run past the whole rule. The reader now raises through `Cursor.err_condition` on the components the prelude was lexed into, so the warning reads `bad condition for @container` and underlines the offending slice of the query.

`Css.Container.of_components` is replaced by `Css.Container.read`, which takes the cursor, and `Css.Container.of_string` raises `Cursor.Parse_error` where it raised `Failure`.

Emitted CSS is byte-identical over 4554 comparisons (797 `test/interop` files under `--minify` and pretty, plus the 2960 `minify.pairs` records), with one intended stderr change. That corpus is a weak oracle for this change, though: across all 3757 inputs the base binary reaches an at-rule condition error exactly once, so the coverage that matters is `test/cli/parse_error_locations.t` and the spec test in `test/test_stylesheet.ml`.