### PR TITLE
lib: fault a media query on the slice that failed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,11 +68,12 @@ answers.
 
 ### Parsing
 
-- An error inside an at-rule condition points at the slice of the query
-  that failed. `@container style()` faulted the whole rule at the end of
-  the file, so the caret sat past the last byte and the snippet opened
-  mid-word. `Css.Container.of_string` raises `Cursor.Parse_error`, which
-  carries that span, where it raised `Failure` (#496)
+- An error inside an at-rule condition points at the slice of the query that
+  failed, where it landed at the end of the file with the caret past the last
+  byte and the snippet opening mid-word. The readers take the cursor
+  (`Css.Container.read`, `Css.Media.read`, replacing `of_components`) and raise
+  `Cursor.Parse_error`, which carries the span, where they raised `Failure`
+  (#496, #497)
 - Everything the parser repaired or dropped is reported, so strict mode
   rejects it. `@media screen {` swallowed the rest of the file and still
   returned `Ok` with no warnings, hiding a truncated stylesheet (#484)

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -734,7 +734,7 @@ let atom_of_components t components =
           match single_feature_of_media media with
           | Some f -> Feature_query f
           | None -> err t components "not a container feature query")
-      | exception Failure _ -> specific_of_components t stripped)
+      | exception Error.Parse_error _ -> specific_of_components t stripped)
 
 let rec unnamed_of_components t components =
   let components = trim_components components in

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -229,10 +229,13 @@ let err_expected_but_eof t what =
 
 let err_unexpected t = err t "unexpected token"
 
-let err_condition t ~at_rule reason =
-  raise_sort t Sort.At_rule
+let condition_error t ~at_rule reason =
+  let source = match (t.meta, t.source) with `Full, s -> s | _ -> None in
+  Error.v ?source ~loc:(position t) ~sort:Sort.At_rule
     (Error.Bad_condition { at_rule; reason })
-    (position t)
+
+let err_condition t ~at_rule reason =
+  Error.fail (condition_error t ~at_rule reason)
 
 let with_context _t label f = Error.with_context label f
 

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -197,11 +197,17 @@ val err_expected_but_eof : t -> string -> 'a
 val err_unexpected : t -> 'a
 (** [err_unexpected t] raises "unexpected token" at the current position. *)
 
+val condition_error : t -> at_rule:string -> string -> Error.t
+(** [condition_error t ~at_rule reason] is the {!Error.Bad_condition} for
+    [at_rule] anchored at the current position, with [t]'s source attached. A
+    reader that buffers a failure before deciding whether to recover from it
+    builds the error here and raises it later. *)
+
 val err_condition : t -> at_rule:string -> string -> 'a
 (** [err_condition t ~at_rule reason] raises {!Parse_error} carrying
-    {!Error.Bad_condition} for [at_rule], anchored at the current position. An
-    at-rule prelude reader raises through this so the caret lands on the slice
-    of the condition that failed rather than on the enclosing rule. *)
+    {!val-condition_error}. An at-rule prelude reader raises through this so the
+    caret lands on the slice of the condition that failed rather than on the
+    enclosing rule. *)
 
 val with_context : t -> string -> (unit -> 'a) -> 'a
 (** [with_context t label f] annotates any {!Parse_error} raised by [f] with

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -522,9 +522,19 @@ let to_string ?(minify = false) t = Pp.to_string ~minify pp t
 
 type recovery_scope = Branch | Query_list
 
-exception Parse_error of recovery_scope * string
+(* A branch failure is buffered rather than raised straight out: [of_components]
+   decides from [recover] whether to swallow it into [not all] or re-raise it,
+   so the error travels as a value with the span already attached. *)
+exception Parse_error of recovery_scope * Error.t
 
-let fail_parse ?(scope = Branch) reason = raise (Parse_error (scope, reason))
+let fail_parse ?(scope = Branch) e = raise (Parse_error (scope, e))
+
+(* Anchoring a failure on the components that failed puts the caret on that
+   slice of the query. [t] anchors the smallest enclosing construct, for a
+   failure that has no components of its own. *)
+let err ?scope t cvs reason =
+  let at = match cvs with [] -> t | _ :: _ -> Cursor.sub t cvs in
+  fail_parse ?scope (Cursor.condition_error at ~at_rule:"@media" reason)
 
 let is_whitespace_component = function
   | Component.Preserved { kind = Token.Whitespace; _ } -> true
@@ -650,10 +660,10 @@ let value_of_components_opt components =
   | _ -> Option.None
 
 let value_of_string s =
-  let components = Cursor.of_string s |> Cursor.remaining in
-  match value_of_components_opt components with
+  let cursor = Cursor.of_string s in
+  match value_of_components_opt (Cursor.remaining cursor) with
   | Some value -> value
-  | Option.None -> failwith ("invalid media value: " ^ s)
+  | Option.None -> Cursor.err_invalid cursor "media value"
 
 let boolean_feature name : feature = Boolean name
 
@@ -910,53 +920,52 @@ let feature_in_components components =
   | Valid_feature feature -> Some feature
   | Invalid_feature | Not_feature -> Option.None
 
-let rec condition_of_components components : condition =
+let rec condition_of_components t components : condition =
   let components = non_whitespace_components components in
   match components with
   | first :: rest when ident_is "not" first -> (
       match rest with
-      | [ operand ] -> Not (condition_in_parens operand)
-      | _ -> failwith "trailing content after 'not <media-in-parens>'")
+      | [ operand ] -> Not (condition_in_parens t operand)
+      | _ -> err t rest "trailing content after 'not <media-in-parens>'")
   | first :: rest ->
-      let left = condition_in_parens first in
-      condition_chain Option.None left rest
-  | [] -> failwith "empty media condition"
+      let left = condition_in_parens t first in
+      condition_chain t Option.None left rest
+  | [] -> err t components "empty media condition"
 
-and condition_in_parens component : condition =
+and condition_in_parens t component : condition =
   match component with
   | Component.Block
       { node = { opening = Token.Paren; value; closed = true }; _ } -> (
       match parse_feature_components value with
       | Valid_feature feature -> Feature feature
-      | Invalid_feature ->
-          failwith ("invalid media feature: " ^ string_of_components value)
-      | Not_feature -> condition_of_components value)
+      | Invalid_feature -> err t value "invalid media feature"
+      | Not_feature -> condition_of_components t value)
   | Component.Block { node = { opening = Token.Paren; closed = false; _ }; _ }
     ->
-      failwith "unmatched parenthesis in @media condition"
+      err t [ component ] "unmatched parenthesis in @media condition"
   | Component.Func { node = { terminated = true; _ }; _ } ->
       Feature (General_enclosed (string_of_components [ component ]))
   | Component.Func { node = { terminated = false; _ }; _ } ->
-      failwith "unmatched function in @media condition"
+      err t [ component ] "unmatched function in @media condition"
   | Component.Block _ | Component.Preserved _ ->
-      failwith "expected media-in-parens"
+      err t [ component ] "expected media-in-parens"
 
-and condition_chain operator acc components : condition =
+and condition_chain t operator acc components : condition =
   match components with
   | [] -> acc
   | keyword :: operand :: rest when ident_is "and" keyword ->
       (match operator with
-      | Some `Or -> failwith "mixed 'and'/'or' media condition"
+      | Some `Or -> err t [ keyword ] "mixed 'and'/'or' media condition"
       | Some `And | Option.None -> ());
-      let right = condition_in_parens operand in
-      condition_chain (Some `And) (And (acc, right)) rest
+      let right = condition_in_parens t operand in
+      condition_chain t (Some `And) (And (acc, right)) rest
   | keyword :: operand :: rest when ident_is "or" keyword ->
       (match operator with
-      | Some `And -> failwith "mixed 'and'/'or' media condition"
+      | Some `And -> err t [ keyword ] "mixed 'and'/'or' media condition"
       | Some `Or | Option.None -> ());
-      let right = condition_in_parens operand in
-      condition_chain (Some `Or) (Or (acc, right)) rest
-  | _ -> failwith "trailing content in media condition"
+      let right = condition_in_parens t operand in
+      condition_chain t (Some `Or) (Or (acc, right)) rest
+  | _ -> err t components "trailing content in media condition"
 
 let medium_of_ident s : medium =
   match String.lowercase_ascii s with
@@ -985,19 +994,22 @@ let read_query_prefix = function
   | first :: rest when ident_is "only" first -> (Some Only, rest)
   | components -> (Option.None, components)
 
-let read_media_type_query components =
+let read_media_type_query t components =
   let components = non_whitespace_components components in
   let prefix, components = read_query_prefix components in
   (match (prefix, components) with
-  | Some _, first :: _ when ident_is "not" first || ident_is "only" first ->
-      fail_parse ~scope:Query_list "duplicate media query prefix"
+  | Some _, (first :: _ as rest)
+    when ident_is "not" first || ident_is "only" first ->
+      err ~scope:Query_list t rest "duplicate media query prefix"
   | _ -> ());
   match components with
   | name_component :: rest -> (
       match ident_component name_component with
-      | Option.None -> failwith "expected media type or condition"
+      | Option.None ->
+          err t [ name_component ] "expected media type or condition"
       | Some name when is_reserved_media_type_keyword name ->
-          failwith "reserved media condition keyword cannot be a media type"
+          err t [ name_component ]
+            "reserved media condition keyword cannot be a media type"
       | Some name -> (
           let type_ = medium_of_ident name in
           match rest with
@@ -1007,16 +1019,16 @@ let read_media_type_query components =
                 {
                   prefix;
                   type_;
-                  trailing = Some (condition_of_components condition);
+                  trailing = Some (condition_of_components t condition);
                 }
-          | _ -> failwith "expected 'and' or end of query after media type"))
-  | [] -> failwith "expected media type or condition"
+          | _ -> err t rest "expected 'and' or end of query after media type"))
+  | [] -> err t components "expected media type or condition"
 
-let single_query components =
-  if components_empty components then failwith "empty media query"
+let single_query t components =
+  if components_empty components then err t components "empty media query"
   else if starts_with_condition components then
-    Cond (condition_of_components components)
-  else read_media_type_query components
+    Cond (condition_of_components t components)
+  else read_media_type_query t components
 
 let not_all_query : t =
   Type { prefix = Some Not; type_ = All; trailing = Option.None }
@@ -1034,12 +1046,15 @@ let split_query_list components =
   in
   loop [] [] false components
 
-let parse_query_branch components =
-  try Ok (single_query components) with
-  | Parse_error (scope, reason) -> Error (scope, reason)
-  | Failure reason -> Error (Branch, reason)
+let parse_query_branch t components =
+  (* Anchor the branch, not the whole query list, so a fallback with no
+     components of its own still lands inside the branch that failed. *)
+  let t = Cursor.sub t components in
+  try Ok (single_query t components)
+  with Parse_error (scope, e) -> Error (scope, e)
 
-let of_components ?(recover = true) components =
+let read ?(recover = true) t =
+  let components = Cursor.remaining t in
   let branches, saw_comma = split_query_list components in
   if (not saw_comma) && List.for_all components_empty branches then
     (List [] : t)
@@ -1047,18 +1062,17 @@ let of_components ?(recover = true) components =
     let rec parse acc = function
       | [] -> List.rev acc
       | [ branch ] -> (
-          match parse_query_branch branch with
+          match parse_query_branch t branch with
           | Ok query -> List.rev (query :: acc)
-          | Error (_, reason) ->
-              if recover then [ not_all_query ] else raise (Failure reason))
+          | Error (_, e) -> if recover then [ not_all_query ] else Error.fail e)
       | branch :: rest -> (
-          match parse_query_branch branch with
+          match parse_query_branch t branch with
           | Ok query -> parse (query :: acc) rest
-          | Error (Query_list, reason) ->
-              if recover then [ not_all_query ] else raise (Failure reason)
-          | Error (Branch, reason) ->
+          | Error (Query_list, e) ->
+              if recover then [ not_all_query ] else Error.fail e
+          | Error (Branch, e) ->
               if recover then parse (not_all_query :: acc) rest
-              else raise (Failure reason))
+              else Error.fail e)
     in
     match (saw_comma, parse [] branches) with
     | false, [ query ] -> query
@@ -1069,18 +1083,16 @@ let of_components ?(recover = true) components =
         not_all_query
     | true, queries -> List queries
 
-let of_string s = Cursor.of_string s |> Cursor.remaining |> of_components
-
-let of_string_strict s =
-  Cursor.of_string s |> Cursor.remaining |> of_components ~recover:false
+let of_string s = read (Cursor.of_string s)
+let of_string_strict s = read ~recover:false (Cursor.of_string s)
 
 let of_function_components components =
   match feature_in_components components with
   | Some feature -> Cond (Feature feature)
-  | Option.None -> of_components components
+  | Option.None -> read (Cursor.of_components components)
 
 let of_function_body s =
-  Cursor.of_string s |> Cursor.remaining |> of_function_components
+  of_function_components (Cursor.remaining (Cursor.of_string s))
 
 let feature name value : t =
   Cond (Feature (plain_feature (name_of_string name) value))

--- a/lib/media.mli
+++ b/lib/media.mli
@@ -136,11 +136,15 @@ val of_string : string -> t
 (** [of_string s] parses [s] as a media query. *)
 
 val of_string_strict : string -> t
-(** [of_string_strict s] parses [s] as a media query without branch recovery. *)
+(** [of_string_strict s] parses [s] as a media query without branch recovery.
+    Raises {!Cursor.exception-Parse_error} for a malformed query. *)
 
-val of_components : ?recover:bool -> Component.t list -> t
-(** [of_components components] parses an already-tokenized media query. Invalid
-    branches recover to [not all] unless [recover] is [false]. *)
+val read : ?recover:bool -> Cursor.t -> t
+(** [read t] parses the media query [t] holds, consuming nothing. Invalid
+    branches recover to [not all] unless [recover] is [false], in which case the
+    branch's {!Cursor.exception-Parse_error} propagates anchored on the slice of
+    the query that failed. Pass a cursor built over the components the prelude
+    was lexed into ({!Cursor.val-sub}) rather than a re-lex of their text. *)
 
 val of_function_body : string -> t
 (** [of_function_body s] parses the body of a conditional [media(...)] function.

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1846,11 +1846,7 @@ let read_import_media (r : Cursor.t) : Media.t option =
     if starts_with_import_keyword components then
       Error.fail_bad_condition loc ~at_rule:"@media"
         ~reason:"layer()/supports() must precede the media query, and once only"
-    else
-      match Media.of_components ~recover:false components with
-      | media -> Some media
-      | exception Failure reason ->
-          Error.fail_bad_condition loc ~at_rule:"@media" ~reason
+    else Some (Media.read ~recover:false (Cursor.sub r components))
 
 let read_import_prelude ~keep_url_repr (r : Cursor.t) : import_rule =
   Cursor.expect_at_keyword "import" r;
@@ -3363,11 +3359,11 @@ let read_supports_condition (r : Cursor.t) : statement =
 
 let read_layer_name (r : Cursor.t) : layer_name = read_layer_name_component r
 
-let read_nested_media_condition components =
-  if Cursor.of_components components |> Cursor.is_done then Media.List []
+let read_nested_media_condition t =
+  if Cursor.is_done t then Media.List []
   else
-    try Media.of_components ~recover:false components
-    with Failure _ -> Media.of_string "not all"
+    try Media.read ~recover:false t
+    with Error.Parse_error _ -> Media.of_string "not all"
 
 let read_rule_selector ?(nested = false) r =
   let prelude = Cursor.drain_until_block r in
@@ -3657,14 +3653,11 @@ and read_media (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "media" r;
   Cursor.ws r;
   let condition_components = Cursor.drain_until_block r in
+  let query = Cursor.sub r condition_components in
   let content = Cursor.braces (fun inner -> read_block inner) r in
   let condition =
-    if Cursor.of_components condition_components |> Cursor.is_done then
-      Media.List []
-    else
-      try Media.of_components ~recover:false condition_components
-      with Failure reason ->
-        Cursor.err_invalid r ("invalid @media condition: " ^ reason)
+    if Cursor.is_done query then Media.List []
+    else Media.read ~recover:false query
   in
   Media (condition, content)
 
@@ -3847,9 +3840,9 @@ and read_nested_supports_rule r =
   Supports (supports_condition ~loc:cond_loc condition, content)
 
 and read_nested_media_rule r =
-  let condition_components = Cursor.drain_until_block r in
+  let query = Cursor.sub r (Cursor.drain_until_block r) in
   let content = Cursor.braces (fun inner -> read_nesting_block inner) r in
-  Media (read_nested_media_condition condition_components, content)
+  Media (read_nested_media_condition query, content)
 
 and read_nested_scope_rule r =
   let prelude_components = Cursor.drain_until_block r in

--- a/test/cli/parse_error_locations.t
+++ b/test/cli/parse_error_locations.t
@@ -43,5 +43,9 @@ import URL's span.
   > .ok { color: red }
   > EOF
   $ cascade --minify bad-media.css 2>&1 | grep -E "warning|color" | head
-  warning: bad-media.css: bad condition for @media: expected media-in-parens at [21-32] (in at-rule)
+  warning: bad-media.css: bad condition for @media: expected media-in-parens at [22-27] (in at-rule)
+  warning: @import url("a.css") (bogus !!!);
+  warning: .ok { color: red }
+  warning: 
+  warning:                       ^^^^^
   .ok{color:red}

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -8763,6 +8763,59 @@ let container_condition_error_spans () =
   check "bad style() name" "style(1px: red)"
     ("invalid style() container query", 36, 39)
 
+(* One warning off a lenient parse, checked against the at-rule it names, the
+   reason it gives and the span it points at. *)
+let one_condition_warning name input ~at_rule (reason, start_pos, end_pos) =
+  match Css.of_string ~strict:false input with
+  | Error err ->
+      Alcotest.failf "%s: lenient parse failed: %s" name
+        (Cascade.Error.to_string err)
+  | Ok { Css.stylesheet; warnings } -> (
+      Alcotest.(check int)
+        (name ^ ": sibling rule survives")
+        1
+        (List.length (Css.rule_statements stylesheet));
+      match warnings with
+      | [ e ] ->
+          (match e.Error.kind with
+          | Error.Bad_condition { at_rule = got_rule; reason = got } ->
+              Alcotest.(check string) (name ^ ": at-rule") at_rule got_rule;
+              Alcotest.(check string) (name ^ ": reason") reason got
+          | _ ->
+              Alcotest.failf "%s: expected Bad_condition, got %s" name
+                (Error.to_string e));
+          Alcotest.(check (pair int int))
+            (name ^ ": span") (start_pos, end_pos)
+            (e.Error.loc.Loc.start_pos, e.Error.loc.Loc.end_pos)
+      | ws ->
+          Alcotest.failf "%s: expected one warning, got %d" name
+            (List.length ws))
+
+(* A media query that does not parse is faulted against the slice of the query
+   that failed. Spans are counted off the source text: the leading rule is 18
+   bytes plus a newline, so line 2 opens at offset 19 and [@media ] runs to
+   offset 25. *)
+let media_condition_error_spans () =
+  let check name query expected =
+    let input =
+      ".ok { color: red }\n@media " ^ query ^ " { .a { color: blue } }\n"
+    in
+    one_condition_warning name input ~at_rule:"@media" expected
+  in
+  (* A lone [not] prefixes nothing; the query itself spans offsets 26-28. *)
+  check "prefix with no type" "not" ("expected media type or condition", 26, 29);
+  (* [bogus] inside the parentheses spans offsets 27-31. *)
+  check "junk in parens" "(bogus !!!)" ("expected media-in-parens", 27, 32);
+  (* The [or] that follows an [and] spans offsets 46-47. *)
+  check "mixed operators" "(color) and (hover) or (a)"
+    ("mixed 'and'/'or' media condition", 46, 48);
+  (* The media query list of an [@import] prelude is read the same way: [bogus]
+     spans offsets 22-26. *)
+  one_condition_warning "import prelude"
+    "@import url(\"a.css\") (bogus !!!);\n.ok { color: red }\n"
+    ~at_rule:"@media"
+    ("expected media-in-parens", 22, 27)
+
 let additional_tests =
   [
     ("check function", `Quick, test_check);
@@ -9694,6 +9747,9 @@ let additional_tests =
     ( "an @container query error points at the failing slice",
       `Quick,
       container_condition_error_spans );
+    ( "a media query error points at the failing slice",
+      `Quick,
+      media_condition_error_spans );
   ]
 
 (* Every shape a statement can take, so the walkers are exercised on the block


### PR DESCRIPTION
`@media not { ... }` reported its parse error at the end of the file, because a branch failure carried only a reason string and the stylesheet rebuilt a position from a cursor that had already run past the whole rule. A branch failure now carries the typed `Error.t` with the span already attached, so the warning underlines the offending slice of the query; the same reader serves the `@import` prelude's media query list.

`Css.Media.of_components` is replaced by `Css.Media.read`, which takes the cursor, and `Css.Media.of_string_strict` raises `Cursor.Parse_error` where it raised `Failure`.

Emitted CSS is byte-identical over 4554 comparisons (797 `test/interop` files under `--minify` and pretty, plus the 2960 `minify.pairs` records), with one intended stderr change carried over from #496. That corpus is a weak oracle for this change, though: across all 3757 inputs the base binary emits no `@media` condition warning at all, so the coverage that matters is `test/cli/parse_error_locations.t` and the spec test in `test/test_stylesheet.ml`. Follow-up to #496.