### PR TITLE
lib: fault an @font-face descriptor on its value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,12 +68,11 @@ answers.
 
 ### Parsing
 
-- An error inside an at-rule condition points at the slice of the query that
-  failed, where it landed at the end of the file with the caret past the last
-  byte and the snippet opening mid-word. The readers take the cursor
-  (`Css.Container.read`, `Css.Media.read`, replacing `of_components`) and raise
-  `Cursor.Parse_error`, which carries the span, where they raised `Failure`
-  (#496, #497)
+- An error inside an at-rule condition or an `@font-face` descriptor points at
+  the slice that failed, not at the end of the file with the caret past the
+  last byte. The readers take a cursor and raise `Cursor.Parse_error` where
+  they raised `Failure`; `Css.Container.of_components` and
+  `Css.Media.of_components` are replaced by `read` (#496, #497, #499)
 - Everything the parser repaired or dropped is reported, so strict mode
   rejects it. `@media screen {` swallowed the rest of the file and still
   returned `Ok` with no warnings, hiding a truncated stylesheet (#484)

--- a/fuzz/fuzz_font_face.ml
+++ b/fuzz/fuzz_font_face.ml
@@ -13,30 +13,48 @@ let pick values buf salt =
 
 let parse_metric input =
   try Some (Css.Font_face.metric_override_of_string input)
-  with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> None
+  with
+  | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _ | Failure _
+  ->
+    None
 
 let parse_size_adjust input =
   try Some (Css.Font_face.size_adjust_of_string input)
-  with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> None
+  with
+  | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _ | Failure _
+  ->
+    None
 
 let parse_src input =
   try Some (Css.Font_face.src_of_string input)
-  with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> None
+  with
+  | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _ | Failure _
+  ->
+    None
 
 (** metric_override_of_string -- must not crash. *)
 let test_metric_override buf =
   try ignore (Css.Font_face.metric_override_of_string buf)
-  with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> ()
+  with
+  | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _ | Failure _
+  ->
+    ()
 
 (** size_adjust_of_string -- must not crash. *)
 let test_size_adjust buf =
   try ignore (Css.Font_face.size_adjust_of_string buf)
-  with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> ()
+  with
+  | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _ | Failure _
+  ->
+    ()
 
 (** src_of_string -- must not crash. *)
 let test_src buf =
   try ignore (Css.Font_face.src_of_string buf)
-  with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> ()
+  with
+  | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _ | Failure _
+  ->
+    ()
 
 (** metric_override roundtrip: parse -> to_string -> parse. *)
 let test_metric_override_roundtrip buf =
@@ -45,7 +63,10 @@ let test_metric_override_roundtrip buf =
   | Some m -> (
       let s = Css.Font_face.string_of_metric_override m in
       try ignore (Css.Font_face.metric_override_of_string s)
-      with Reader.Parse_error _ | Invalid_argument _ | Failure _ ->
+      with
+      | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _
+      | Failure _
+      ->
         fail "metric_override roundtrip failed")
 
 (** src roundtrip: parse -> to_string -> parse. *)
@@ -55,7 +76,10 @@ let test_src_roundtrip buf =
   | Some src -> (
       let s = Css.Font_face.string_of_src src in
       try ignore (Css.Font_face.src_of_string s)
-      with Reader.Parse_error _ | Invalid_argument _ | Failure _ ->
+      with
+      | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _
+      | Failure _
+      ->
         fail "src roundtrip failed")
 
 let test_metric_override_non_negative buf =

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -155,24 +155,38 @@ let to_string = string_of_src
 
 let valid_percentage p = Float.is_finite p && p >= 0.
 
-(** Parse a metric override string like "normal" or "90%". *)
-let metric_override_of_string s =
-  let s = String.trim s in
-  if String.equal s "normal" then Normal
-  else if String.length s > 0 && s.[String.length s - 1] = '%' then (
-    let p = float_of_string (String.sub s 0 (String.length s - 1)) in
-    if not (valid_percentage p) then failwith "invalid metric override";
-    Percent p)
-  else failwith "invalid metric override"
+(* CSS Fonts 4 sec. 4.10: [normal | <percentage [0,inf]>]. The token is left in
+   place on a mismatch, so the error carries the offending value's span rather
+   than whatever follows it. *)
+let read_metric_override t =
+  match Cursor.peek t with
+  | Some (Component.Preserved { kind = Token.Ident "normal"; _ }) ->
+      Cursor.skip t;
+      Normal
+  | Some (Component.Preserved { kind = Token.Percentage number; _ })
+    when valid_percentage number.Token.value ->
+      Cursor.skip t;
+      Percent number.Token.value
+  | Some _ | None -> Cursor.err_invalid t "metric override"
 
-(** Parse a size-adjust percentage like "90%". *)
-let size_adjust_of_string s =
-  let s = String.trim s in
-  if String.length s > 0 && s.[String.length s - 1] = '%' then (
-    let p = float_of_string (String.sub s 0 (String.length s - 1)) in
-    if not (valid_percentage p) then failwith "invalid size-adjust";
-    p)
-  else failwith "invalid size-adjust"
+(* CSS Fonts 4 sec. 4.11: [<percentage [0,inf]>]. *)
+let read_size_adjust t =
+  match Cursor.peek t with
+  | Some (Component.Preserved { kind = Token.Percentage number; _ })
+    when valid_percentage number.Token.value ->
+      Cursor.skip t;
+      number.Token.value
+  | Some _ | None -> Cursor.err_invalid t "size-adjust"
+
+let read_whole read s =
+  let t = Cursor.of_string s in
+  let value = read t in
+  Cursor.ws t;
+  Cursor.expect_eof t;
+  value
+
+let metric_override_of_string = read_whole read_metric_override
+let size_adjust_of_string = read_whole read_size_adjust
 
 let read_function_arg name t =
   Cursor.call name t @@ fun inner ->
@@ -284,9 +298,7 @@ let src_of_string s =
     | Quoted_url { url; format; tech; _ } -> Url { url; format; tech }
     | entry -> entry
   in
-  try
-    let t = Cursor.of_string s in
-    let entries = read_src t in
-    Cursor.expect_eof t;
-    List.map normalize_entry entries
-  with Cursor.Parse_error _ -> failwith "invalid font src"
+  let t = Cursor.of_string s in
+  let entries = read_src t in
+  Cursor.expect_eof t;
+  List.map normalize_entry entries

--- a/lib/font_face.mli
+++ b/lib/font_face.mli
@@ -65,6 +65,15 @@ val to_string : ?minify:bool -> t -> string
 
 (** {1 Parsing} *)
 
+val read_metric_override : Cursor.t -> metric_override
+(** [read_metric_override t] reads one [ascent-override] / [descent-override] /
+    [line-gap-override] value. A mismatch raises {!Cursor.exception-Parse_error}
+    without consuming, so the error carries the offending value's span. *)
+
+val read_size_adjust : Cursor.t -> size_adjust
+(** [read_size_adjust t] reads one [size-adjust] value, like
+    {!read_metric_override}. *)
+
 val metric_override_of_string : string -> metric_override
 (** [metric_override_of_string s] parses a metric override value. *)
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2073,10 +2073,7 @@ let read_descriptor_value read_fn constructor r =
   Cursor.ws r;
   if not (Cursor.colon r) then Cursor.err_expected r "':'";
   Cursor.ws r;
-  try
-    let value = read_fn r in
-    constructor value
-  with Failure msg -> Cursor.err_invalid r msg
+  constructor (read_fn r)
 
 (* One item of a descriptor body: a descriptor, a stray [;] that CSS Syntax 3
    sec. 5.4.3 discards with no declaration to validate, or the end of the body.
@@ -2339,20 +2336,20 @@ let read_font_face_desc name r =
         r
   | "font-tech" -> read_string_descriptor "font-tech" (fun v -> Font_tech v) r
   | "size-adjust" ->
-      read_descriptor_value Declaration.read_property_value
-        (fun v -> Size_adjust (Font_face.size_adjust_of_string v))
+      read_descriptor_value Font_face.read_size_adjust
+        (fun v -> Size_adjust v)
         r
   | "ascent-override" ->
-      read_descriptor_value Declaration.read_property_value
-        (fun v -> Ascent_override (Font_face.metric_override_of_string v))
+      read_descriptor_value Font_face.read_metric_override
+        (fun v -> Ascent_override v)
         r
   | "descent-override" ->
-      read_descriptor_value Declaration.read_property_value
-        (fun v -> Descent_override (Font_face.metric_override_of_string v))
+      read_descriptor_value Font_face.read_metric_override
+        (fun v -> Descent_override v)
         r
   | "line-gap-override" ->
-      read_descriptor_value Declaration.read_property_value
-        (fun v -> Line_gap_override (Font_face.metric_override_of_string v))
+      read_descriptor_value Font_face.read_metric_override
+        (fun v -> Line_gap_override v)
         r
   | _ -> Cursor.err_invalid r ("unknown font-face descriptor: " ^ name)
 

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -42,20 +42,29 @@ let expect_src_rejected input =
     let src = src_of_string input in
     Alcotest.failf "invalid font-face src parsed: %S -> %S" input
       (string_of_src src)
-  with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> ()
+  with
+  | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _ | Failure _
+  ->
+    ()
 
 let expect_metric_rejected input =
   try
     let metric = metric_override_of_string input in
     Alcotest.failf "invalid font metric parsed: %S -> %S" input
       (string_of_metric_override metric)
-  with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> ()
+  with
+  | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _ | Failure _
+  ->
+    ()
 
 let expect_size_adjust_rejected input =
   try
     let size_adjust = size_adjust_of_string input in
     Alcotest.failf "invalid font size-adjust parsed: %S -> %g" input size_adjust
-  with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> ()
+  with
+  | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _ | Failure _
+  ->
+    ()
 
 let accepted_invalid_cases label parse render inputs =
   List.filter_map
@@ -65,7 +74,11 @@ let accepted_invalid_cases label parse render inputs =
           (fun s -> Some s)
           "%s: %S -> %S" label input
           (parse input |> render)
-      with Reader.Parse_error _ | Invalid_argument _ | Failure _ -> None)
+      with
+      | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _
+      | Failure _
+      ->
+        None)
     inputs
 
 let expect_rejected_cases label parse render inputs =

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -8816,6 +8816,49 @@ let media_condition_error_spans () =
     ~at_rule:"@media"
     ("expected media-in-parens", 22, 27)
 
+(* An @font-face descriptor whose value does not parse is faulted against the
+   value, not against the enclosing block. The descriptor is dropped and the
+   rest of the at-rule is kept, so the [src] below keeps the @font-face valid
+   and the warning list holds only the descriptor failure. Spans are counted off
+   the source text: the leading rule is 18 bytes plus a newline, so line 2 opens
+   at offset 19. *)
+let descriptor_value_error_spans () =
+  let check name descriptor (reason, start_pos, end_pos) =
+    let input =
+      ".ok { color: red }\n@font-face { font-family: x; src: url(a.woff2); "
+      ^ descriptor ^ " }\n"
+    in
+    match Css.of_string ~strict:false input with
+    | Error err ->
+        Alcotest.failf "%s: lenient parse failed: %s" name
+          (Cascade.Error.to_string err)
+    | Ok { Css.stylesheet; warnings } -> (
+        Alcotest.(check int)
+          (name ^ ": sibling rule survives")
+          1
+          (List.length (Css.rule_statements stylesheet));
+        match warnings with
+        | [ e ] ->
+            (match e.Error.kind with
+            | Error.Bad_value { reason = got; _ } ->
+                Alcotest.(check string) (name ^ ": reason") reason got
+            | _ ->
+                Alcotest.failf "%s: expected Bad_value, got %s" name
+                  (Error.to_string e));
+            Alcotest.(check (pair int int))
+              (name ^ ": span") (start_pos, end_pos)
+              (e.Error.loc.Loc.start_pos, e.Error.loc.Loc.end_pos)
+        | ws ->
+            Alcotest.failf "%s: expected one warning, got %d" name
+              (List.length ws))
+  in
+  (* [ascent-override] opens at offset 67, so its value spans 84-86. *)
+  check "negative metric override" "ascent-override: -5%"
+    ("invalid: metric override", 84, 87);
+  (* [size-adjust] opens at offset 67, so its value spans 80-84. *)
+  check "size-adjust that is not a percentage" "size-adjust: bogus"
+    ("invalid: size-adjust", 80, 85)
+
 let additional_tests =
   [
     ("check function", `Quick, test_check);
@@ -9750,6 +9793,9 @@ let additional_tests =
     ( "a media query error points at the failing slice",
       `Quick,
       media_condition_error_spans );
+    ( "an @font-face descriptor error points at the value",
+      `Quick,
+      descriptor_value_error_spans );
   ]
 
 (* Every shape a statement can take, so the walkers are exercised on the block


### PR DESCRIPTION
`ascent-override: -5%` reported its parse error at the end of the file, because the value was validated from its text after the descriptor cursor had run past it. `Css.Font_face.read_metric_override` and `Css.Font_face.read_size_adjust` read from the cursor and leave the token in place on a mismatch, so the warning underlines the value.

The three `of_string` entry points raise `Cursor.Parse_error` where they raised `Failure`; `src_of_string` no longer flattens a located error into one.

Emitted CSS is byte-identical over 4554 comparisons (797 `test/interop` files under `--minify` and pretty, plus the 2960 `minify.pairs` records), with one intended stderr change carried over from #496. That corpus is a weak oracle for this change, though: across all 3757 inputs the base binary emits no `@font-face` descriptor value warning at all, so the coverage that matters is the spec test in `test/test_stylesheet.ml`. Follow-up to #497.