### PR TITLE
lib: close the eval_kind and rule-merge dispatch wildcards

### DIFF
--- a/lib/context.ml
+++ b/lib/context.ml
@@ -3428,6 +3428,96 @@ let simplify_lengths_value ~layer_order ?layer ctx length_ctx value =
           | _ -> [ simplify_one (Values.Var var) ]))
   | _ -> List.map simplify_one value
 
+(* Every kind resolves the same way - simplify the value in context, then let a
+   css-wide keyword in the result take over - so the simplifier and the css-wide
+   reader are all that vary. Keeping them in one total table is what makes a new
+   kind a compile error rather than a value that falls through unsimplified. *)
+let kind_simplifier : type a.
+    layer_order:string list ->
+    ?layer:string ->
+    t ->
+    a Properties.property_value_kind ->
+    (a -> a) * (a -> css_wide_keyword option) =
+ fun ~layer_order ?layer ctx kind ->
+  let length_ctx = Length.of_t ctx in
+  match kind with
+  | Properties.Length ->
+      (Length.simplify ~layer_order ?layer ctx length_ctx, css_wide_of_length)
+  | Properties.Lengths ->
+      ( simplify_lengths_value ~layer_order ?layer ctx length_ctx,
+        css_wide_of_length_list )
+  | Properties.Length_percentage ->
+      ( simplify_length_percentage ~layer_order ?layer ctx length_ctx,
+        css_wide_of_length_percentage )
+  | Properties.Border_width ->
+      ( simplify_border_width ~layer_order ?layer ctx length_ctx,
+        css_wide_of_border_width )
+  | Properties.Border_widths ->
+      ( List.map (simplify_border_width ~layer_order ?layer ctx length_ctx),
+        css_wide_of_border_widths )
+  | Properties.Font_size ->
+      ( simplify_font_size ~layer_order ?layer ctx length_ctx,
+        css_wide_of_font_size )
+  | Properties.Translate ->
+      ( simplify_translate_value ~layer_order ?layer ctx length_ctx,
+        css_wide_of_translate_value )
+  | Properties.Transform ->
+      ( List.map (simplify_transform ~layer_order ?layer ctx length_ctx),
+        css_wide_of_transforms )
+  | Properties.Filter ->
+      (simplify_filter ~layer_order ?layer ctx length_ctx, css_wide_of_filter)
+  | Properties.Shadow ->
+      (simplify_shadow ~layer_order ?layer ctx length_ctx, css_wide_of_shadow)
+  | Properties.Border_radius ->
+      ( simplify_border_radius ~layer_order ?layer ctx length_ctx,
+        css_wide_of_border_radius )
+  | Properties.Opacity ->
+      (simplify_opacity ~layer_order ?layer ctx, css_wide_of_opacity)
+  | Properties.Rotate ->
+      (simplify_rotate_value ~layer_order ?layer ctx, css_wide_of_rotate_value)
+  | Properties.Duration ->
+      (simplify_duration ~layer_order ?layer ctx, css_wide_of_duration)
+  | Properties.Display ->
+      (simplify_display ~layer_order ?layer ctx, css_wide_of_display)
+  | Properties.Position ->
+      (simplify_position ~layer_order ?layer ctx, css_wide_of_position)
+  | Properties.Visibility ->
+      (simplify_visibility ~layer_order ?layer ctx, css_wide_of_visibility)
+  | Properties.Clear ->
+      (simplify_clear ~layer_order ?layer ctx, css_wide_of_clear)
+  | Properties.Float ->
+      (simplify_float_side ~layer_order ?layer ctx, css_wide_of_float_side)
+  | Properties.Number_percentage ->
+      (simplify_number_percentage ~layer_order ?layer ctx, fun _ -> None)
+  | Properties.Scale ->
+      (simplify_scale ~layer_order ?layer ctx, css_wide_of_scale)
+  | Properties.Animation ->
+      let duration = simplify_duration ~layer_order ?layer ctx in
+      ( List.map (simplify_animation_item ~layer_order ?layer ctx duration),
+        css_wide_of_animations )
+  | Properties.Transition ->
+      let duration = simplify_duration ~layer_order ?layer ctx in
+      ( List.map (simplify_transition_item ~layer_order ?layer ctx duration),
+        css_wide_of_transitions )
+  | Properties.Color ->
+      (simplify_color ~layer_order ?layer ctx, css_wide_of_color)
+  | Properties.Colors ->
+      (List.map (simplify_color ~layer_order ?layer ctx), css_wide_of_colors)
+  | Properties.Animation_name ->
+      (simplify_animation_name ~layer_order ?layer ctx, fun _ -> None)
+  | Properties.Background ->
+      (List.map (simplify_background ~layer_order ?layer ctx), fun _ -> None)
+  | Properties.Background_image ->
+      ( simplify_background_image ~layer_order ?layer ctx,
+        css_wide_of_background_image )
+  | Properties.Background_images ->
+      ( List.map (simplify_background_image ~layer_order ?layer ctx),
+        css_wide_of_background_images )
+  | Properties.Font_src ->
+      (simplify_font_src ~layer_order ?layer ctx, fun _ -> None)
+  | Properties.Font_family ->
+      (simplify_font_family ~layer_order ?layer ctx, css_wide_of_font_family)
+
 let rec eval_typed ?layer_order ?layer ctx decl =
   let ctx = scope ?layer_order ?layer ctx in
   let layer_order = ctx.layer_order in
@@ -3469,154 +3559,8 @@ and eval_kind : type a.
     a ->
     Declaration.declaration =
  fun ~layer_order ?layer ctx kind property important value ->
-  let length_ctx = Length.of_t ctx in
-  let resolve s c =
-    resolve_typed ~layer_order ctx s c property important value
-  in
-  match kind with
-  | Properties.Length ->
-      resolve
-        (Length.simplify ~layer_order ?layer ctx length_ctx)
-        css_wide_of_length
-  | Properties.Lengths ->
-      resolve
-        (simplify_lengths_value ~layer_order ?layer ctx length_ctx)
-        css_wide_of_length_list
-  | Properties.Length_percentage ->
-      resolve
-        (simplify_length_percentage ~layer_order ?layer ctx length_ctx)
-        css_wide_of_length_percentage
-  | Properties.Border_width ->
-      resolve
-        (simplify_border_width ~layer_order ?layer ctx length_ctx)
-        css_wide_of_border_width
-  | Properties.Border_widths ->
-      resolve
-        (List.map (simplify_border_width ~layer_order ?layer ctx length_ctx))
-        css_wide_of_border_widths
-  | Properties.Font_size ->
-      resolve
-        (simplify_font_size ~layer_order ?layer ctx length_ctx)
-        css_wide_of_font_size
-  | Properties.Translate ->
-      resolve
-        (simplify_translate_value ~layer_order ?layer ctx length_ctx)
-        css_wide_of_translate_value
-  | Properties.Transform ->
-      resolve
-        (List.map (simplify_transform ~layer_order ?layer ctx length_ctx))
-        css_wide_of_transforms
-  | Properties.Filter ->
-      resolve
-        (simplify_filter ~layer_order ?layer ctx length_ctx)
-        css_wide_of_filter
-  | Properties.Shadow ->
-      resolve
-        (simplify_shadow ~layer_order ?layer ctx length_ctx)
-        css_wide_of_shadow
-  | Properties.Border_radius ->
-      resolve
-        (simplify_border_radius ~layer_order ?layer ctx length_ctx)
-        css_wide_of_border_radius
-  | kind ->
-      eval_kind_other ~layer_order ?layer ctx kind property important value
-
-and eval_kind_other : type a.
-    layer_order:string list ->
-    ?layer:string ->
-    t ->
-    a Properties.property_value_kind ->
-    a Properties.property ->
-    bool ->
-    a ->
-    Declaration.declaration =
- fun ~layer_order ?layer ctx kind property important value ->
-  let resolve s c =
-    resolve_typed ~layer_order ctx s c property important value
-  in
-  match kind with
-  | Properties.Opacity ->
-      resolve (simplify_opacity ~layer_order ?layer ctx) css_wide_of_opacity
-  | Properties.Rotate ->
-      resolve
-        (simplify_rotate_value ~layer_order ?layer ctx)
-        css_wide_of_rotate_value
-  | Properties.Duration ->
-      resolve (simplify_duration ~layer_order ?layer ctx) css_wide_of_duration
-  | Properties.Display ->
-      resolve (simplify_display ~layer_order ?layer ctx) css_wide_of_display
-  | Properties.Position ->
-      resolve (simplify_position ~layer_order ?layer ctx) css_wide_of_position
-  | Properties.Visibility ->
-      resolve
-        (simplify_visibility ~layer_order ?layer ctx)
-        css_wide_of_visibility
-  | Properties.Clear ->
-      resolve (simplify_clear ~layer_order ?layer ctx) css_wide_of_clear
-  | Properties.Float ->
-      resolve
-        (simplify_float_side ~layer_order ?layer ctx)
-        css_wide_of_float_side
-  | kind -> eval_kind_misc ~layer_order ?layer ctx kind property important value
-
-and eval_kind_misc : type a.
-    layer_order:string list ->
-    ?layer:string ->
-    t ->
-    a Properties.property_value_kind ->
-    a Properties.property ->
-    bool ->
-    a ->
-    Declaration.declaration =
- fun ~layer_order ?layer ctx kind property important value ->
-  let resolve s c =
-    resolve_typed ~layer_order ctx s c property important value
-  in
-  match kind with
-  | Properties.Number_percentage ->
-      let value = simplify_number_percentage ~layer_order ?layer ctx value in
-      Declaration.v ~important property value
-  | Properties.Scale ->
-      resolve (simplify_scale ~layer_order ?layer ctx) css_wide_of_scale
-  | Properties.Animation ->
-      let duration = simplify_duration ~layer_order ?layer ctx in
-      resolve
-        (List.map (simplify_animation_item ~layer_order ?layer ctx duration))
-        css_wide_of_animations
-  | Properties.Transition ->
-      let duration = simplify_duration ~layer_order ?layer ctx in
-      resolve
-        (List.map (simplify_transition_item ~layer_order ?layer ctx duration))
-        css_wide_of_transitions
-  | Properties.Color ->
-      resolve (simplify_color ~layer_order ?layer ctx) css_wide_of_color
-  | Properties.Colors ->
-      resolve
-        (List.map (simplify_color ~layer_order ?layer ctx))
-        css_wide_of_colors
-  | Properties.Animation_name ->
-      resolve (simplify_animation_name ~layer_order ?layer ctx) (fun _ -> None)
-  | Properties.Background ->
-      resolve
-        (List.map (simplify_background ~layer_order ?layer ctx))
-        (fun _ -> None)
-  | Properties.Background_image ->
-      resolve
-        (simplify_background_image ~layer_order ?layer ctx)
-        css_wide_of_background_image
-  | Properties.Background_images ->
-      resolve
-        (List.map (simplify_background_image ~layer_order ?layer ctx))
-        css_wide_of_background_images
-  | Properties.Font_src ->
-      resolve (simplify_font_src ~layer_order ?layer ctx) (fun _ -> None)
-  | Properties.Font_family ->
-      resolve
-        (simplify_font_family ~layer_order ?layer ctx)
-        css_wide_of_font_family
-  | _ ->
-      (* unreachable: handled by eval_kind / eval_kind_other *)
-      assert false
+  let simplify, css_wide_of = kind_simplifier ~layer_order ?layer ctx kind in
+  resolve_typed ~layer_order ctx simplify css_wide_of property important value
 
 and resolve_css_wide_keyword ~layer_order ctx ~important ~property_name keyword
     =

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -228,15 +228,48 @@ let interval_clear scan ~lo ~hi mems =
   done;
   !ok
 
+(* The shape a run element folds in: a style rule merges declaration lists under
+   one selector, a conditional block concatenates bodies under an unchanged
+   prelude. [element_shape] is the one place the statements that can pair are
+   enumerated - the key that decides two elements share a cascade slot and the
+   merge that folds them both read it, so a statement cannot become mergeable
+   for one and stay unknown to the other. *)
+type block_prelude =
+  | Media_query of Media.t
+  | Feature_query of Supports.t
+  | Container_query of string option * Container.t option
+
+type merge_shape = Style of rule | Block of block_prelude * statement list
+
+let element_shape (stmt : statement) =
+  match stmt with
+  | Rule r when r.merge_key = None -> Some (Style r)
+  | Media (m, body) -> Some (Block (Media_query m, body))
+  | Supports (c, body) -> Some (Block (Feature_query c, body))
+  | Container (name, cond, body) ->
+      Some (Block (Container_query (name, cond), body))
+  | _ -> None
+
+let block_statement prelude body =
+  match prelude with
+  | Media_query m -> Media (m, body)
+  | Feature_query c -> Supports (c, body)
+  | Container_query (name, cond) -> Container (name, cond, body)
+
 (* The element a merge produces. Two elements only ever pair on an equal
-   [element_key], which is derived from the constructor, so the two sides always
-   match here. A block merge concatenates the bodies in source order and
-   re-canonicalises the result: the two halves were each canonical alone, but
-   their concatenation need not be. *)
+   [element_key], and the key carries the slot's shape, so the two sides always
+   agree; a pair that did not agree declines to merge, which is always sound
+   since leaving a run alone is what the coalescing scan starts from. A block
+   merge concatenates the bodies in source order and re-canonicalises the
+   result: the two halves were each canonical alone, but their concatenation
+   need not be. *)
 let merged_element ~canon_body scan ~from ~into =
   let earlier, later = if from < into then (from, into) else (into, from) in
-  match (fst scan.arr.(earlier), fst scan.arr.(later)) with
-  | Rule a, Rule b ->
+  match
+    ( element_shape (fst scan.arr.(earlier)),
+      element_shape (fst scan.arr.(later)) )
+  with
+  | Some (Style a), Some (Style b) ->
       let merged =
         {
           a with
@@ -245,24 +278,21 @@ let merged_element ~canon_body scan ~from ~into =
               (coalesced_declarations (a.declarations @ b.declarations));
         }
       in
-      (Rule merged, [ merged ])
-  | Media (m, ba), Media (_, bb) ->
-      let stmt = Media (m, canon_body (ba @ bb)) in
-      (stmt, Option.value ~default:[] (element_rules stmt))
-  | Supports (c, ba), Supports (_, bb) ->
-      let stmt = Supports (c, canon_body (ba @ bb)) in
-      (stmt, Option.value ~default:[] (element_rules stmt))
-  | Container (n, c, ba), Container (_, _, bb) ->
-      let stmt = Container (n, c, canon_body (ba @ bb)) in
-      (stmt, Option.value ~default:[] (element_rules stmt))
-  | _ -> assert false
+      Some (Rule merged, [ merged ])
+  | Some (Block (prelude, ba)), Some (Block (_, bb)) ->
+      let stmt = block_statement prelude (canon_body (ba @ bb)) in
+      Some (stmt, Option.value ~default:[] (element_rules stmt))
+  | (Some (Style _ | Block _) | None), _ -> None
 
 let merge ~canon_body scan changed ~from ~into =
-  scan.arr.(into) <- merged_element ~canon_body scan ~from ~into;
-  scan.members.(into) <- scan.members.(from) @ scan.members.(into);
-  scan.alive.(from) <- false;
-  scan.merged_any <- true;
-  changed := true
+  match merged_element ~canon_body scan ~from ~into with
+  | None -> ()
+  | Some element ->
+      scan.arr.(into) <- element;
+      scan.members.(into) <- scan.members.(from) @ scan.members.(into);
+      scan.alive.(from) <- false;
+      scan.merged_any <- true;
+      changed := true
 
 (* Fold the earlier occurrence [i] down into [j] when nothing in between
    observes its writes moving; otherwise fold [j]'s writes up into [i] when
@@ -281,25 +311,24 @@ let try_merge ~canon_body scan changed ~last ~key i j =
    kind and condition; the [@]-prefix keeps the two namespaces apart. A block
    whose interior is not summarisable never became a run element, so it cannot
    reach here. *)
-let element_key (stmt : statement) =
-  match stmt with
-  | Rule r when r.merge_key = None ->
-      Some (Pp.to_string ~minify:true Selector.pp r.selector)
-  | Media (m, _) -> Some (String.concat "" [ "@media "; Media.to_string m ])
-  | Supports (c, _) ->
-      Some (String.concat "" [ "@supports "; Supports.to_string c ])
-  | Container (name, cond, _) ->
-      Some
-        (String.concat ""
-           [
-             "@container ";
-             Option.value ~default:"" name;
-             " ";
-             (match cond with
-             | Some c -> Container.to_string ~minify:true c
-             | None -> "");
-           ])
-  | _ -> None
+let shape_key = function
+  | Style r -> Pp.to_string ~minify:true Selector.pp r.selector
+  | Block (Media_query m, _) ->
+      String.concat "" [ "@media "; Media.to_string m ]
+  | Block (Feature_query c, _) ->
+      String.concat "" [ "@supports "; Supports.to_string c ]
+  | Block (Container_query (name, cond), _) ->
+      String.concat ""
+        [
+          "@container ";
+          Option.value ~default:"" name;
+          " ";
+          (match cond with
+          | Some c -> Container.to_string ~minify:true c
+          | None -> "");
+        ]
+
+let element_key (stmt : statement) = Option.map shape_key (element_shape stmt)
 
 (* Coalesce same-slot elements within one run. Folding an occurrence into
    another moves its writes past every element in between, which is observable


### PR DESCRIPTION
`eval_kind` and `merged_element` both ended in `assert false`, so the compiler had stopped checking them: a new `property_value_kind`, or a statement that becomes mergeable for `element_key` but not for the merge, would have compiled and then raised `Assert_failure` out of the library, in the second case out of `cascade diff`. Both dispatches now read one total enumeration, so the next constructor is a build error; neither site was reachable today, and output is byte-identical over the interop corpora and the lightning minify traces.