### PR TITLE
lib: fault an @supports condition on the slice that failed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,13 @@ answers.
   you shipped minified output built with 1.1.0, re-run it and compare:
   `cascade diff --diff=canonical old.css new.css` exits 1 and prints the
   difference wherever the two are not equivalent.
+- `Css.Container.of_components` and `Css.Media.of_components` are gone: call
+  `Container.read` / `Media.read` with a cursor over the prelude's components
+  (`Cursor.sub`). `Container.of_string`, `Media.of_string_strict`,
+  `Supports.of_string` and the three `Font_face.*_of_string` raise
+  `Cursor.Parse_error` where they raised `Failure`, so a `Failure` handler
+  around any of them stops catching and the exception escapes; match
+  `Cursor.Parse_error` instead (#496, #497, #499, #501)
 - `Css.statement_declarations` is gone. It answered for a rule and a bare
   nesting block only, sharing its name with the exhaustive
   `Css.Stylesheet.statement_declarations`, which reaches every declaration a
@@ -70,9 +77,7 @@ answers.
 
 - An error inside an at-rule condition or an `@font-face` descriptor points at
   the slice that failed, not at the end of the file with the caret past the
-  last byte. The readers take a cursor and raise `Cursor.Parse_error` where
-  they raised `Failure`; `Css.Container.of_components` and
-  `Css.Media.of_components` are replaced by `read` (#496, #497, #499)
+  last byte (#496, #497, #499, #501)
 - Everything the parser repaired or dropped is reported, so strict mode
   rejects it. `@media screen {` swallowed the rest of the file and still
   returned `Ok` with no warnings, hiding a truncated stylesheet (#484)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1720,14 +1720,6 @@ let read_charset (r : Cursor.t) : statement =
       ~reason:"@charset must end with ';'";
   Charset encoding
 
-(* Re-anchor [Supports.of_string]'s typed error at the caller's [loc] so the
-   partial-parse catch in [read_statement_of_rule] surfaces it as a warning at
-   the surrounding rule, not at [Loc.dummy]. *)
-let supports_condition ~loc condition =
-  try Supports.of_string condition
-  with Error.Parse_error { kind = Bad_condition { reason; _ }; _ } ->
-    Error.fail_bad_condition loc ~at_rule:"@supports" ~reason
-
 (* CSS Cascade section 6.4.2: a layer name is one or more idents joined by '.'
    with no whitespace around the dot. CSS-wide keywords are reserved. *)
 let read_layer_name_component (r : Cursor.t) : layer_name =
@@ -1803,13 +1795,7 @@ let read_import_layer (r : Cursor.t) =
 
 let read_import_supports (r : Cursor.t) =
   Cursor.function_call "supports"
-    (fun inner ->
-      let loc = Cursor.position inner in
-      try
-        Supports.of_string ~allow_unwrapped_decl:true
-          (Cursor.string_of_remaining ~trim:true inner)
-      with Failure reason ->
-        Error.fail_bad_condition loc ~at_rule:"@supports" ~reason)
+    (fun inner -> Supports.read ~allow_unwrapped_decl:true inner)
     r
 
 (* In the [@import] prelude [layer(...)] and [supports(...)] are structural, and
@@ -3661,12 +3647,11 @@ and read_media (r : Cursor.t) : statement =
 and read_supports (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "supports" r;
   Cursor.ws r;
-  let cond_loc = Cursor.position r in
-  let condition = Cursor.drain_until_block_as_string ~trim:true r in
-  if String.length condition = 0 then
+  let query = Cursor.sub r (Cursor.drain_until_block r) in
+  if Cursor.is_done query then
     Cursor.err r "@supports rule requires a condition";
   let content = Cursor.braces (fun inner -> read_block inner) r in
-  Supports (supports_condition ~loc:cond_loc condition, content)
+  Supports (Supports.read query, content)
 
 and read_scope (r : Cursor.t) : statement =
   (* CSS Cascade 6 sec. 3.5.2: [@scope <start> to <end> { ... }]. The two
@@ -3831,10 +3816,9 @@ and read_nested_container_rule r =
   Container (container_name, condition, content)
 
 and read_nested_supports_rule r =
-  let cond_loc = Cursor.position r in
-  let condition = Cursor.drain_until_block_as_string ~trim:true r in
+  let query = Cursor.sub r (Cursor.drain_until_block r) in
   let content = Cursor.braces (fun inner -> read_nesting_block inner) r in
-  Supports (supports_condition ~loc:cond_loc condition, content)
+  Supports (Supports.read query, content)
 
 and read_nested_media_rule r =
   let query = Cursor.sub r (Cursor.drain_until_block r) in

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -392,21 +392,40 @@ let property_ident = function
   | [ Component.Preserved { kind = Token.Ident name; _ } ] -> Some name
   | _ -> None
 
-let declaration_of_components prop value =
-  if contains_top_level_semicolon value then
-    failwith "Invalid declaration in @supports";
-  match property_ident (strip_components prop) with
-  | Some prop ->
-      let value = Cursor.string_of_components ~trim:true value in
-      Property (declaration_feature prop value)
-  | None -> failwith "Invalid declaration in @supports"
+(* Anchoring a failure on the components that failed puts the caret on that
+   slice of the condition. [t] anchors the smallest enclosing construct, for a
+   failure that has no components of its own. *)
+let err t cvs reason =
+  let at = match cvs with [] -> t | _ :: _ -> Cursor.sub t cvs in
+  Cursor.err_condition at ~at_rule:"@supports" reason
 
-let function_call (fn : Component.func Component.node) =
+let declaration_of_components t prop value =
+  if contains_top_level_semicolon value then
+    err t value "Invalid declaration in @supports";
+  match property_ident (strip_components prop) with
+  | Some name -> (
+      let text = Cursor.string_of_components ~trim:true value in
+      (* [declaration_feature] is the shared constructor, so it reports through
+         [Failure]; re-raise it against the declaration's own components. *)
+      match declaration_feature name text with
+      | feature -> Property feature
+      | exception Failure msg -> err t (prop @ value) msg)
+  | None -> err t prop "Invalid declaration in @supports"
+
+let function_call t (fn : Component.func Component.node) =
   let name = fn.node.name in
   let args = fn.node.arguments in
+  let inner = Cursor.func_sub fn t in
   if not (fn.node.terminated && components_are_closed args) then
-    failwith ("Unterminated " ^ name ^ "() in @supports");
-  func name (Cursor.string_of_components ~trim:true args)
+    err t [ Component.Func fn ] ("Unterminated " ^ name ^ "() in @supports");
+  (* [func] and the readers under it work from the argument text, so both the
+     [Failure] the shared constructor raises and a reader's own [Parse_error]
+     carry a position relative to that text, not to the source. *)
+  match func name (Cursor.string_of_components ~trim:true args) with
+  | feature -> feature
+  | exception Failure msg -> err inner args msg
+  | exception Cursor.Parse_error e ->
+      err inner args (Pp.to_string Error.pp_kind e.Error.kind)
 
 let peek_ident t =
   match Cursor.peek t with
@@ -430,7 +449,7 @@ and chain t op acc =
   | Some "and" ->
       (match op with
       | Some `Or ->
-          failwith "Cannot mix and/or without parentheses in @supports"
+          err t [] "Cannot mix and/or without parentheses in @supports"
       | _ -> ());
       Cursor.skip t;
       let right = in_parens ~allow_unwrapped_decl:false t in
@@ -438,7 +457,7 @@ and chain t op acc =
   | Some "or" ->
       (match op with
       | Some `And ->
-          failwith "Cannot mix and/or without parentheses in @supports"
+          err t [] "Cannot mix and/or without parentheses in @supports"
       | _ -> ());
       Cursor.skip t;
       let right = in_parens ~allow_unwrapped_decl:false t in
@@ -450,10 +469,10 @@ and in_parens ~allow_unwrapped_decl t =
     let components = Cursor.remaining t in
     match split_top_level_colon components with
     | Some (prop, value) ->
-        let decl = declaration_of_components prop value in
+        let decl = declaration_of_components t prop value in
         ignore (Cursor.consume_remaining_as_string t : string);
         decl
-    | None -> failwith "Expected supports feature"
+    | None -> err t [] "Expected supports feature"
   in
   Cursor.ws t;
   match Cursor.peek t with
@@ -461,48 +480,50 @@ and in_parens ~allow_unwrapped_decl t =
       (Component.Block { node = { opening = Token.Paren; value; _ }; _ } as cv)
     ->
       if not (closed_block cv) then
-        failwith "Unmatched parenthesis in @supports condition";
+        err t [ cv ] "Unmatched parenthesis in @supports condition";
       Cursor.skip t;
-      paren_components value
+      paren_components (Cursor.sub t [ cv ]) value
   | Some (Component.Func fn) ->
+      let group = Cursor.sub t [ Component.Func fn ] in
       Cursor.skip t;
-      function_call fn
+      function_call group fn
   | _ when allow_unwrapped_decl -> unwrapped_declaration t
-  | _ -> failwith "Expected supports feature"
+  | _ -> err t [] "Expected supports feature"
 
-and paren_components value =
-  if strip_components value = [] then failwith "Empty parentheses in @supports";
+and paren_components t value =
+  if strip_components value = [] then
+    err t value "Empty parentheses in @supports";
   if not (components_are_closed value) then
-    failwith "Unmatched parenthesis in @supports condition";
+    err t value "Unmatched parenthesis in @supports condition";
   match split_top_level_colon value with
-  | Some (prop, value) -> declaration_of_components prop value
+  | Some (prop, value) -> declaration_of_components t prop value
   | None ->
-      let inner = Cursor.of_components value in
+      let inner = Cursor.sub t value in
       let condition = condition inner in
       Cursor.ws inner;
       if not (Cursor.is_done inner) then
-        failwith "trailing content in @supports group";
+        err inner [] "trailing content in @supports group";
       condition
 
-let of_string ?(allow_unwrapped_decl = false) s =
-  let cursor = ref (Cursor.of_string s) in
-  let raise_bad reason =
-    Error.fail_bad_condition (Cursor.position !cursor) ~at_rule:"@supports"
-      ~reason
+let read ?(allow_unwrapped_decl = false) t =
+  let cond =
+    if not allow_unwrapped_decl then condition t
+    else
+      (* A bare declaration is only reachable once the wrapped grammar has been
+         ruled out, so the cursor is rewound and read again. *)
+      let snapshot = Cursor.save t in
+      try condition t
+      with Cursor.Parse_error _ ->
+        Cursor.restore t snapshot;
+        in_parens ~allow_unwrapped_decl t
   in
-  try
-    let cond =
-      try condition !cursor
-      with Failure _ when allow_unwrapped_decl ->
-        cursor := Cursor.of_string s;
-        in_parens ~allow_unwrapped_decl !cursor
-    in
-    Cursor.ws !cursor;
-    if not (Cursor.is_done !cursor) then raise_bad "trailing content";
-    cond
-  with
-  | Cursor.Parse_error _ as exn -> raise exn
-  | Failure reason -> raise_bad reason
+  Cursor.ws t;
+  if not (Cursor.is_done t) then
+    Cursor.err_condition t ~at_rule:"@supports" "trailing content";
+  cond
+
+let of_string ?allow_unwrapped_decl s =
+  read ?allow_unwrapped_decl (Cursor.of_string s)
 
 (* ===== Comparison ===== *)
 

--- a/lib/supports.mli
+++ b/lib/supports.mli
@@ -76,9 +76,16 @@ val pp_declaration_feature : declaration_feature Pp.t
 (** [pp_declaration_feature ctx feature] prints a supports declaration feature
     without the surrounding condition parentheses. *)
 
+val read : ?allow_unwrapped_decl:bool -> Cursor.t -> t
+(** [read t] parses the [\@supports] condition [t] holds. A malformed condition
+    raises {!Cursor.exception-Parse_error} anchored on the slice of the
+    condition that failed, so pass a cursor built over the components the
+    prelude was lexed into ({!Cursor.val-sub}) rather than a re-lex of their
+    text. *)
+
 val of_string : ?allow_unwrapped_decl:bool -> string -> t
 (** [of_string s] parses a [\@supports] condition string into a structured type.
-    Fails if the condition cannot be parsed. *)
+    Raises {!Cursor.exception-Parse_error} if the condition cannot be parsed. *)
 
 val compare : t -> t -> int
 (** [compare a b] compares conditions for sorting. *)

--- a/test/cli/parse_error_locations.t
+++ b/test/cli/parse_error_locations.t
@@ -1,15 +1,13 @@
 CLI: parse-error warnings carry a precise location, not Loc.dummy.
 
-The `read` and `of_string` parsers in lib/{supports,container,media,...}.ml
-raise typed `Cursor.Parse_error` anchored at the failing cursor position.
-A reader handed the components the prelude was lexed into faults the slice
-of the condition that failed; one handed a re-lex of the prelude text is
-re-anchored by the stylesheet reader at the surrounding condition span. The
-`[start-end]` locator in the warning points at the offending region of the
-source file, never `[0-0]`.
+The `read` parsers in lib/{supports,container,media,...}.ml take a cursor
+over the components the prelude was lexed into, so the typed
+`Cursor.Parse_error` they raise is anchored on the slice of the condition
+that failed. The `[start-end]` locator in the warning points at that slice
+of the source file, never `[0-0]`, and the caret underlines it.
 
 Invalid `@supports` condition: trailing junk after a valid feature
-query lands the warning at the at-rule's prelude span.
+query lands the warning on the junk.
 
   $ cat > bad-supports.css <<EOF
   > .ok { color: red }
@@ -17,7 +15,11 @@ query lands the warning at the at-rule's prelude span.
   > .also-ok { color: green }
   > EOF
   $ cascade --minify bad-supports.css 2>&1
-  warning: bad-supports.css: bad condition for @supports: trailing content at [29-44] (in at-rule)
+  warning: bad-supports.css: bad condition for @supports: trailing content at [45-55] (in at-rule)
+  warning:  color: red }
+  warning: @supports (display: grid) extra-junk { .a { color: blue } }
+  warning: .also-ok { color
+  warning:                                         ^^^^^^^^^^
   .ok{color:red}.also-ok{color:green}
 
 Invalid `@container` query: malformed `style()` reports at the query
@@ -35,8 +37,8 @@ slice, not at the start of the file.
   warning:                               ^^^^^^^
   .ok{color:red}
 
-Invalid `@media` query inside `@import`: the warning points at the
-import URL's span.
+Invalid `@media` query inside `@import`: the media query list of the
+prelude is read the same way as an `@media` rule's.
 
   $ cat > bad-media.css <<EOF
   > @import url("a.css") (bogus !!!);

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -8859,6 +8859,30 @@ let descriptor_value_error_spans () =
   check "size-adjust that is not a percentage" "size-adjust: bogus"
     ("invalid: size-adjust", 80, 85)
 
+(* An @supports condition that does not parse is faulted against the slice of
+   the condition that failed, where the reader used to hand back a bare reason
+   that the stylesheet re-anchored on the whole prelude. Spans are counted off
+   the source text: the leading rule is 18 bytes plus a newline, so line 2 opens
+   at offset 19 and [@supports ] runs to offset 28. *)
+let supports_condition_error_spans () =
+  let check name condition expected =
+    let input =
+      ".ok { color: red }\n@supports " ^ condition ^ " { .a { color: blue } }\n"
+    in
+    one_condition_warning name input ~at_rule:"@supports" expected
+  in
+  (* [extra-junk] follows a complete feature query and spans offsets 45-54. *)
+  check "trailing content" "(display: grid) extra-junk"
+    ("trailing content", 45, 55);
+  (* The [or] that follows an [and] spans offsets 45-46. *)
+  check "mixed operators" "(a:b) and (c:d) or (e:f)"
+    ("Cannot mix and/or without parentheses in @supports", 45, 47);
+  (* The empty parentheses span offsets 29-30. *)
+  check "empty parentheses" "()" ("Empty parentheses in @supports", 29, 31);
+  (* [font-format(] ends at offset 40, so [bogus] spans 41-45. *)
+  check "unknown font format" "font-format(bogus)"
+    ("invalid font-format() in @supports", 41, 46)
+
 let additional_tests =
   [
     ("check function", `Quick, test_check);
@@ -9796,6 +9820,9 @@ let additional_tests =
     ( "an @font-face descriptor error points at the value",
       `Quick,
       descriptor_value_error_spans );
+    ( "an @supports condition error points at the failing slice",
+      `Quick,
+      supports_condition_error_spans );
   ]
 
 (* Every shape a statement can take, so the walkers are exercised on the block


### PR DESCRIPTION
`@supports (display: grid) extra-junk` reported its parse error against the whole prelude, because the condition reader handed back a bare reason string that the stylesheet re-anchored on a position captured before the prelude was read. The reader raises through `Cursor.err_condition` on the components the prelude was lexed into, so the warning underlines the trailing junk and carries a source snippet it did not have.

Seven `failwith` calls survive in `lib/supports.ml` on purpose. They are in the public constructors `property`, `property_name`, `single_ident` and `func`, and `Css.Supports.property` raising `Failure` is a contract already documented under `### Breaking` for 1.2.0 by #459; converting them would contradict a note that has shipped. The parse path catches both that `Failure` and a reader's own relatively-positioned `Parse_error` and re-raises against the components that failed, so a caller still gets the right span.

`Css.Supports.of_string` raises `Cursor.Parse_error` where it raised `Failure`; this PR also moves that half of the changelog entry out of `### Parsing` and into `### Breaking`, where a caller with a `Failure` handler will find it.

Emitted CSS is byte-identical over 4554 comparisons (797 `test/interop` files under `--minify` and pretty, plus the 2960 `minify.pairs` records), with one intended stderr change. That corpus is a weak oracle for this change, though: across all 3757 inputs the base binary emits no `@media`, `@supports` or `@font-face` descriptor condition warning at all, so the coverage that matters is `test/cli/parse_error_locations.t` and the spec test in `test/test_stylesheet.ml`. Follow-up to #499.