### PR TITLE
lib: decide a nested merge from one running index

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -410,8 +410,9 @@ answers.
 - `--minify` and `cascade diff` spend less time and memory on a large
   stylesheet, for the same output (#413, #422, #424, #468)
 - `--minify` no longer allocates quadratically on a long run of rules sharing
-  one selector or one body. The benchmark corpora hold no such run, so this
-  bounds a worst case rather than speeding real input up (#480, #486, #487)
+  one selector or one body, nor probes every pair of them to decide whether it
+  may merge. The benchmark corpora hold no such run, so this bounds a worst
+  case rather than speeding real input up (#480, #486, #487, #502)
 - `--minify` no longer scans quadratically when many rules share a deep
   selector prefix. The structural hash reads a fixed count of nodes, so
   `.a .b .c .d .e .f .g` and every sibling differing only past that prefix took

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -97,9 +97,9 @@ type commute_slot = { witness : decl_fact; mutable uniform : bool }
    pairwise test; they are rare enough that keeping it costs nothing. [indexed]
    is the side itself, for a [Broad] declaration facing it. *)
 type facts_index = {
-  indexed : decl_fact list;
+  mutable indexed : decl_fact list;
   written : commute_slot list Overlap_table.t;
-  broad : decl_fact list;
+  mutable broad : decl_fact list;
 }
 
 (* Whether two declarations share a slot: one weight, and, for a custom
@@ -149,6 +149,23 @@ let index_facts facts =
       [] facts
   in
   { indexed = facts; written; broad }
+
+let empty_index () =
+  { indexed = []; written = Overlap_table.create 16; broad = [] }
+
+(* Filing further facts into a built index. A slot answers for the whole
+   multiset filed into it - it conflicts with whatever reaches it once two of
+   them disagree, and otherwise compares the one witness they all match - so an
+   index over a union of footprints answers exactly what asking each of them
+   separately would. *)
+let rec add_facts index = function
+  | [] -> ()
+  | (fact : decl_fact) :: rest ->
+      index.indexed <- fact :: index.indexed;
+      (match fact.shape with
+      | Broad -> index.broad <- fact :: index.broad
+      | Slots | Custom _ -> file_keys index.written fact fact.keys);
+      add_facts index rest
 
 let rec slots_conflict (fact : decl_fact) = function
   | [] -> false
@@ -235,28 +252,38 @@ let same_selector_eligible (r : rule) =
 
    [decl_facts_conflict] is symmetric - every arm of the overlap relation under
    it is spelled both ways round - so either side of a commute test can be the
-   indexed one. The nested body is the side worth indexing: it is read once per
-   rule rather than once per rule facing it, and each declaration block is read
-   once for the whole run rather than once per nested block ahead of it. The
-   scan first is what keeps a run carrying no nested block, the common one, from
-   reading a body at all. *)
+   indexed one. The nested bodies are the side worth indexing, and one index
+   over all of them read so far is what a block moving past them faces: "every
+   nested body before it commutes with this block" is one question about their
+   union, not one per body. So the run is walked once, each block probed once
+   and each nested body read once, rather than every (body, later block) pair
+   being put to the index separately.
+
+   The scan first is what keeps a run carrying no nested block, the common one,
+   from reading a body at all, and the empty index short-circuits the blocks
+   ahead of the first nested body. *)
 let nested_merge_is_safe (rules : rule list) =
   let rec nested_ahead = function
     | [] | [ _ ] -> false
     | (r : rule) :: rest -> r.nested <> [] || nested_ahead rest
   in
-  let rec go = function
-    | [] | [ _ ] -> true
-    | ((r : rule), _) :: rest -> (
-        match nested_decl_facts [] r.nested with
-        | [] -> go rest
-        | nested ->
-            let index = index_facts nested in
-            List.for_all (fun (_, facts) -> facts_commute_with index facts) rest
-            && go rest)
+  let rec go ahead = function
+    | [] -> true
+    | (r : rule) :: rest -> (
+        let block_commutes =
+          match ahead.indexed with
+          | [] -> true
+          | _ -> facts_commute_with ahead (decl_facts r.declarations)
+        in
+        block_commutes
+        &&
+        match rest with
+        | [] -> true
+        | _ ->
+            add_facts ahead (nested_decl_facts [] r.nested);
+            go ahead rest)
   in
-  (not (nested_ahead rules))
-  || go (List.map (fun (r : rule) -> (r, decl_facts r.declarations)) rules)
+  (not (nested_ahead rules)) || go (empty_index ()) rules
 
 let identical_body_eligible ~ctx (r : rule) =
   r.nested = [] && r.merge_key = Option.None

--- a/lib/rule_candidate.mli
+++ b/lib/rule_candidate.mli
@@ -12,3 +12,13 @@ val enumerate :
     scheduler's neighborhood refresh after a commit. The list is intentionally
     local and heuristic; every candidate still commits through
     {!Rule_graph.rewrite}. *)
+
+val nested_merge_is_safe : Stylesheet.rule list -> bool
+(** [nested_merge_is_safe rules] is whether a run of rules on one selector,
+    given in source order, can merge into the first without changing what any
+    element computes. CSS Nesting 1 sec. 3.4 puts a declaration written after a
+    nested rule behind it, so merging moves each later rule's declarations ahead
+    of every nested block an earlier rule carries; the answer is [false] as soon
+    as one of those pairs writes a common cascade slot at the same weight with a
+    different value. Selectors are not read, so a pair that could never meet on
+    one element still counts. *)

--- a/test/test_rule_candidate.ml
+++ b/test/test_rule_candidate.ml
@@ -144,6 +144,92 @@ let default_factoring_keeps_prior_member_leftover_overlap () =
          ".a,.a.b.c,.b{border-color:green}.b{border-top-color:red}.a{margin-top:7px}"
        candidates)
 
+(* Whether a run of same-selector rules can merge is a question about the pairs
+   a merge reorders: each later rule's declarations move ahead of every nested
+   block an earlier rule carries. A pair counts when it writes a common cascade
+   slot at the same weight with a different value, so two nested blocks that
+   write one slot from two different rules must be read as a multiset - the
+   answer for a later block is not settled by whichever of them was seen first.
+   Each case below puts two nested writers on one slot and a third rule behind
+   them. *)
+let nested_merge_reads_a_slot_as_a_multiset () =
+  let case name expected css =
+    Alcotest.(check bool)
+      name expected
+      (Rule_candidate.nested_merge_is_safe (rules css))
+  in
+  case "a later nested writer still blocks a matching earlier one" false
+    ".q{top:0;&:hover{color:red}}.q{left:0;&:hover{color:blue}}.q{color:red}";
+  case "two nested writers that agree with the later block merge" true
+    ".q{top:0;&:hover{color:red}}.q{left:0;&:hover{color:red}}.q{color:red}";
+  case "an earlier nested writer still blocks a matching later one" false
+    ".q{top:0;&:hover{--x:1}}.q{left:0;&:hover{--y:1}}.q{--x:2}";
+  case "a weight of its own keeps a nested writer out of the slot" true
+    ".q{top:0;&:hover{color:red!important}}.q{left:0;&:hover{color:red}}.q{color:red}";
+  case "and does not excuse the writer at the block's weight" false
+    ".q{top:0;&:hover{color:red!important}}.q{left:0;&:hover{color:blue}}.q{color:red}";
+  case "a shorthand behind a longhand on one slot blocks the merge" false
+    ".q{top:0;&:hover{margin-top:1px}}.q{left:0;&:hover{margin:0}}.q{margin-top:1px}";
+  case "a slot neither of them writes is free" true
+    ".q{top:0;&:hover{margin-top:1px}}.q{left:0;&:hover{margin:0}}.q{padding:1rem}";
+  case "two values of one custom property block the merge" false
+    ".q{top:0;&:hover{--x:1}}.q{left:0;&:hover{--x:2}}.q{--x:1}";
+  case "one value of it does not" true
+    ".q{top:0;&:hover{--x:1}}.q{left:0;&:hover{--x:1}}.q{--x:1}";
+  case "nor does a custom property of another name" true
+    ".q{top:0;&:hover{--x:1}}.q{left:0;&:hover{--x:2}}.q{--y:1}";
+  case "a custom property at another weight writes another slot" true
+    ".q{top:0;&:hover{--x:1!important}}.q{left:0;&:hover{--x:2}}.q{--x:1!important}"
+
+(* Two runs of the same length carrying the same declarations and the same
+   nested declarations, differing only in where the nested blocks sit: [spread]
+   hangs one off every rule, [front] hangs all of them off the first. Deciding
+   the run asks, of each rule's declarations, whether they commute with every
+   nested block written before them - one question about the union of those
+   blocks, not one question per block - so each block is read once whichever run
+   it belongs to and the two cost the same. Asking it per (block, later block)
+   pair leaves [front] alone, since it has one block, and makes [spread] cost a
+   probe per pair.
+
+   The comparison is between the two runs, never against a wall-clock budget:
+   [Sys.time] is this process's own CPU, alcotest runs its cases one after
+   another, and the two measurements therefore sit under the same load. *)
+let nested_merge_safety_reads_each_block_once () =
+  let n = 2000 and reps = 100 in
+  let spread =
+    List.init n (fun i -> Fmt.str ".q{--a%d:%d;&:hover{--n%d:%d}}" i i i i)
+    |> String.concat "" |> rules
+  in
+  let front =
+    let nested =
+      List.init n (fun i -> Fmt.str "--n%d:%d" i i) |> String.concat ";"
+    in
+    Fmt.str ".q{--a0:0;&:hover{%s}}" nested
+    ^ (List.init (n - 1) (fun i -> Fmt.str ".q{--a%d:%d}" (i + 1) (i + 1))
+      |> String.concat "")
+    |> rules
+  in
+  Alcotest.(check bool)
+    "neither run writes a slot twice, so both merge" true
+    (Rule_candidate.nested_merge_is_safe spread
+    && Rule_candidate.nested_merge_is_safe front);
+  let cost rules =
+    Gc.full_major ();
+    let t0 = Sys.time () in
+    for _ = 1 to reps do
+      ignore (Sys.opaque_identity (Rule_candidate.nested_merge_is_safe rules))
+    done;
+    Sys.time () -. t0
+  in
+  let a = cost spread in
+  let b = cost front in
+  Alcotest.(check bool)
+    (Fmt.str
+       "%d nested blocks over %d rules costs %.3fs, all on one %.3fs (%.1fx)" n
+       n a b (a /. b))
+    true
+    (b = 0. || a < b *. 3.)
+
 let suite =
   ( "rule_candidate",
     [
@@ -166,4 +252,8 @@ let suite =
         `Quick exact_factoring_keeps_prior_member_leftover_overlap;
       Alcotest.test_case "default factoring keeps prior member leftover overlap"
         `Quick default_factoring_keeps_prior_member_leftover_overlap;
+      Alcotest.test_case "nested merge reads a slot as a multiset" `Quick
+        nested_merge_reads_a_slot_as_a_multiset;
+      Alcotest.test_case "nested-merge safety reads each block once" `Quick
+        nested_merge_safety_reads_each_block_once;
     ] )


### PR DESCRIPTION
Deciding whether a run of same-selector rules can merge probed every (nested block, later block) pair; one index over the blocks already read answers for all of them at once. On 400 rules carrying 20 declarations and a nested block of 20, `Rule_candidate.nested_merge_is_safe` goes from 488M to 44M instructions, and from 3.9x to 2.0x per doubling of the run.

The predicate is exported so the guard can put a run with its nested blocks spread over every rule beside one carrying them all on the first: nothing else observes the probe count, since neither allocation nor output moves. `Rule_candidate.enumerate` over the same run stays quadratic, because `same_selector_merge_order` still builds the full pair matrix.