### PR TITLE
lib: document Component.pp as the debug dump it is

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,13 @@ answers.
   `Cursor.Parse_error` where they raised `Failure`, so a `Failure` handler
   around any of them stops catching and the exception escapes; match
   `Cursor.Parse_error` instead (#496, #497, #499, #501)
+- `Cascade.Component.pp` documents and renders itself as the located debug
+  dump it always was. It was documented as source text, which sent a caller
+  down a check that could never fire. Every node now shows its own location
+  and an unclosed block or unterminated function is tagged, so two components
+  `Component.equal` separates no longer print alike, and the children stay
+  apart under minify. Source text comes from
+  `Cascade.Parser.string_of_components` (#504)
 - `Css.statement_declarations` is gone. It answered for a rule and a bare
   nesting block only, sharing its name with the exhaustive
   `Css.Stylesheet.statement_declarations`, which reaches every declaration a

--- a/lib/component.ml
+++ b/lib/component.ml
@@ -82,18 +82,28 @@ let closing_char : Token.bracket -> char = function
   | Paren -> ')'
   | Square -> ']'
 
+(* A debug dump, not source text: every node shows its own location and the CSS
+   Syntax section 5.4.6 flags [compare] separates values on. [Pp.space] rather
+   than [Pp.sp] because a dump has no minified form, and layout whitespace would
+   drop out and run the children together. *)
 let rec pp : t Pp.t =
  fun ctx cv ->
   match cv with
   | Preserved tok -> Token.pp ctx tok
-  | Block { node = { opening; value; _ }; _ } ->
+  | Block { node = { opening; value; closed }; loc } ->
       Pp.char ctx (opening_char opening);
-      Pp.list ~sep:Pp.sp pp ctx value;
-      Pp.char ctx (closing_char opening)
-  | Func { node = { name; arguments; _ }; _ } ->
+      Pp.list ~sep:Pp.space pp ctx value;
+      Pp.char ctx (closing_char opening);
+      if not closed then Pp.string ctx "<unclosed>";
+      Pp.char ctx '@';
+      Loc.pp ctx loc
+  | Func { node = { name; arguments; terminated }; loc } ->
       Pp.string ctx name;
       Pp.char ctx '(';
-      Pp.list ~sep:Pp.sp pp ctx arguments;
-      Pp.char ctx ')'
+      Pp.list ~sep:Pp.space pp ctx arguments;
+      Pp.char ctx ')';
+      if not terminated then Pp.string ctx "<unterminated>";
+      Pp.char ctx '@';
+      Loc.pp ctx loc
 
 let to_string t = Pp.to_string pp t

--- a/lib/component.mli
+++ b/lib/component.mli
@@ -62,7 +62,11 @@ val rule_loc : rule -> Loc.t
 (** [rule_loc r] is the source range spanned by rule [r]. *)
 
 val pp : t Pp.t
-(** [pp] renders a component value back to source-like text. *)
+(** [pp] renders a component value as a located debug dump, the {!Token.pp} of a
+    whole tree, e.g. [rgb(<number 1>@[4-5])@[0-6]]. Every node shows its own
+    {!Loc.t}, and one the lexer closed synthetically at EOF is tagged
+    [<unclosed>] or [<unterminated>]. Source text comes from
+    {!Parser.string_of_components} and its whitespace-policy variants. *)
 
 val to_string : t -> string
 (** [to_string t] is the string rendering of {!pp}. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3512,8 +3512,8 @@ let read_when ~body (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "when" r;
   Cursor.ws r;
   let prelude = Cursor.drain_until_block r in
-  if List.for_all (fun cv -> Component.to_string cv |> String.trim = "") prelude
-  then Cursor.err_invalid r "@when: missing condition";
+  if Cursor.string_of_components ~trim:true prelude = "" then
+    Cursor.err_invalid r "@when: missing condition";
   let condition : conditional =
     try conditional_components prelude
     with Failure msg -> Cursor.err_invalid r ("@when: " ^ msg)

--- a/test/test_component.ml
+++ b/test/test_component.ml
@@ -1,6 +1,13 @@
 (** Component IR tests. Component is pure data; these tests exercise [pp] /
     [to_string] on representative values. Round-trip via Parser is covered in
-    test_parser.ml. *)
+    test_parser.ml.
+
+    [pp] is the located debug rendering of the stage-3 IR, the {!Token.pp} of a
+    whole component tree - not source text. Source text comes from
+    {!Parser.string_of_components} and its whitespace-policy variants. A debug
+    rendering has to show what {!Component.equal} distinguishes, so every node
+    carries its own {!Loc.t} and the [closed] / [terminated] flags are visible,
+    and it has to read the same however the printer context was configured. *)
 
 open Cascade
 
@@ -14,6 +21,13 @@ let wrap_func (node : Component.func) : Component.func Component.node =
 
 let check name cv expected =
   Alcotest.(check string) name expected (Component.to_string cv)
+
+(* The first component of [src], as the parser produced it: real locations, real
+   [closed] / [terminated] flags. *)
+let first src =
+  match Cursor.remaining (Cursor.of_string src) with
+  | cv :: _ -> cv
+  | [] -> Alcotest.fail ("no component in " ^ src)
 
 let preserved_ident () =
   check "preserved ident"
@@ -34,7 +48,7 @@ let block_curly () =
             value = [ Component.Preserved (tok (Token.Ident "red")) ];
             closed = true;
           }))
-    "{<ident red>@[0-0]}"
+    "{<ident red>@[0-0]}@[0-0]"
 
 let block_paren () =
   check "paren block"
@@ -45,7 +59,7 @@ let block_paren () =
             value = [ Component.Preserved (tok (Token.Ident "ok")) ];
             closed = true;
           }))
-    "(<ident ok>@[0-0])"
+    "(<ident ok>@[0-0])@[0-0]"
 
 let block_square () =
   check "square block"
@@ -56,7 +70,7 @@ let block_square () =
             value = [ Component.Preserved (tok (Token.Ident "attr")) ];
             closed = true;
           }))
-    "[<ident attr>@[0-0]]"
+    "[<ident attr>@[0-0]]@[0-0]"
 
 let func_call () =
   check "function call"
@@ -67,7 +81,43 @@ let func_call () =
             arguments = [ Component.Preserved (tok (Token.Ident "x")) ];
             terminated = true;
           }))
-    "rgb(<ident x>@[0-0])"
+    "rgb(<ident x>@[0-0])@[0-0]"
+
+(* A component knows where it was read from, so the dump says so for every node,
+   not only for the preserved tokens at the leaves. *)
+let located_nodes () =
+  check "located function" (first "rgb(1)") "rgb(<number 1>@[4-5])@[0-6]";
+  check "located block" (first "[a]") "[<ident a>@[1-2]]@[0-3]"
+
+(* CSS Syntax 3 sec. 5.4.6 forgives a value that runs to EOF, and the flag that
+   records it is what typed validators reject on. Two components that
+   {!Component.equal} separates must not dump alike. *)
+let unterminated_function () =
+  check "unterminated function" (first "rgb(1")
+    "rgb(<number 1>@[4-5])<unterminated>@[0-5]"
+
+let unclosed_block () =
+  check "unclosed block" (first "[a") "[<ident a>@[1-2]]<unclosed>@[0-2]"
+
+let distinct_values_dump_distinctly () =
+  let terminated = first "rgb(1)" and unterminated = first "rgb(1" in
+  Alcotest.(check bool)
+    "equal separates them" false
+    (Component.equal terminated unterminated);
+  Alcotest.(check bool)
+    "so does the dump" false
+    (String.equal
+       (Component.to_string terminated)
+       (Component.to_string unterminated))
+
+(* [Pp.sp] is layout whitespace and vanishes under minify. A dump has no
+   minified form: the children stay apart however the context is configured, or
+   [<ident a><ident b>] and a single ident become the same text. *)
+let dump_ignores_minify () =
+  let cv = first "(a b)" in
+  Alcotest.(check string)
+    "minified dump" (Component.to_string cv)
+    (Pp.to_string ~minify:true Component.pp cv)
 
 let suite =
   ( "component",
@@ -78,4 +128,10 @@ let suite =
       Alcotest.test_case "paren block" `Quick block_paren;
       Alcotest.test_case "square block" `Quick block_square;
       Alcotest.test_case "function call" `Quick func_call;
+      Alcotest.test_case "located nodes" `Quick located_nodes;
+      Alcotest.test_case "unterminated function" `Quick unterminated_function;
+      Alcotest.test_case "unclosed block" `Quick unclosed_block;
+      Alcotest.test_case "distinct values dump distinctly" `Quick
+        distinct_values_dump_distinctly;
+      Alcotest.test_case "dump ignores minify" `Quick dump_ignores_minify;
     ] )


### PR DESCRIPTION
`Component.pp` was documented as rendering source text and has always rendered a located debug dump, and `read_when` was written against the documented contract: its per-component blank test could never fire, leaving a fold that only means `prelude = []`. Component sits below `Syntax` and `Lexer`, which own the escaping the source form needs, so the dump is the half that can stay; the guard now asks `Cursor.string_of_components`, which is what actually renders source.