### PR TITLE
lib: read a same-body run's compatibility off each selector once

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -419,7 +419,7 @@ answers.
 - `--minify` no longer allocates quadratically on a long run of rules sharing
   one selector or one body, nor probes every pair of them to decide whether it
   may merge. The benchmark corpora hold no such run, so this bounds a worst
-  case rather than speeding real input up (#480, #486, #487, #502)
+  case rather than speeding real input up (#480, #486, #487, #502, #505)
 - `--minify` no longer scans quadratically when many rules share a deep
   selector prefix. The structural hash reads a fixed count of nodes, so
   `.a .b .c .d .e .f .g` and every sibling differing only past that prefix took

--- a/lib/merge.ml
+++ b/lib/merge.ml
@@ -62,24 +62,36 @@ let compatible sel1 sel2 =
   | Newer, Guarded | Guarded, Newer -> false
   | _ -> true
 
-(* [compatible] rejects one pair and no other, so a list holds only compatible
-   pairs exactly when it does not hold both ends of it: one pass that reads each
-   selector once stands in for the N(N-1)/2 pair loop.
+(* [compatible] rejects one pair and no other, so a set of selectors holds only
+   compatible pairs exactly when it does not hold both ends of it. That is all a
+   group needs to remember about the members it already has, so a candidate
+   joins by reading its own two facts once rather than once per member.
 
-   Sorting the list and checking neighbours would not, because [compatible] is
+   Sorting a group and checking neighbours would not do, because [compatible] is
    reflexive and symmetric but NOT transitive - [Newer] sits with [Plain] and
    [Plain] sits with [Guarded], while [Newer] and [Guarded] never sit
    together. *)
+type run = Neither | Has_newer | Has_guarded | Mixed
+
+let empty_run = Neither
+
+let extend_run run sel =
+  match (run, compatibility sel) with
+  | Mixed, _ | _, Plain -> run
+  | (Neither | Has_newer), Newer -> Has_newer
+  | (Neither | Has_guarded), Guarded -> Has_guarded
+  | Has_newer, Guarded | Has_guarded, Newer -> Mixed
+
+let run_compatible = function Mixed -> false | _ -> true
+
 let all_compatible sels =
-  let rec loop newer guarded = function
+  let rec loop run = function
     | [] -> true
-    | sel :: rest -> (
-        match compatibility sel with
-        | Plain -> loop newer guarded rest
-        | Newer -> (not guarded) && loop true guarded rest
-        | Guarded -> (not newer) && loop newer true rest)
+    | sel :: rest ->
+        let run = extend_run run sel in
+        run_compatible run && loop run rest
   in
-  loop false false sels
+  loop empty_run sels
 
 let rec declaration_lists_equal ~same d1 d2 =
   match (d1, d2) with

--- a/lib/merge.mli
+++ b/lib/merge.mli
@@ -26,3 +26,16 @@ val compatible : Selector.t -> Selector.t -> bool
 val all_compatible : Selector.t list -> bool
 (** [all_compatible sels] is whether every pair in [sels] is {!compatible}, read
     off each selector once rather than once per pair. *)
+
+type run
+(** A group of selectors under consideration for one selector list. *)
+
+val empty_run : run
+(** The group holding no selector. *)
+
+val extend_run : run -> Selector.t -> run
+(** [extend_run run sel] is [run] with [sel] added, reading [sel] once whatever
+    the group already holds. *)
+
+val run_compatible : run -> bool
+(** Whether every pair in the group is {!compatible}. *)

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -361,17 +361,22 @@ let merge_adjacent_identical ~ctx (rules : rule list) : rule list =
   let rec go = function
     | [] -> []
     | r :: rest when adjacent_merge_eligible ~ctx r && r.declarations <> [] ->
-        let rec take group = function
+        (* Whether a group may share one selector list turns on two facts read
+           off each selector alone, so the group carries them and a candidate is
+           read once rather than once per member already in it. *)
+        let rec take run group rules =
+          match rules with
           | s :: tail
             when adjacent_merge_eligible ~ctx s
-                 && bodies_equal r.declarations s.declarations
-                 && List.for_all
-                      (fun (g : rule) -> Merge.compatible g.selector s.selector)
-                      group ->
-              take (s :: group) tail
-          | tail -> (group, tail)
+                 && bodies_equal r.declarations s.declarations ->
+              let run = Merge.extend_run run s.selector in
+              if Merge.run_compatible run then take run (s :: group) tail
+              else (group, rules)
+          | _ -> (group, rules)
         in
-        let group, rest = take [ r ] rest in
+        let group, rest =
+          take (Merge.extend_run Merge.empty_run r.selector) [ r ] rest
+        in
         let merged =
           match group with
           | [ _ ] -> r

--- a/test/test_merge.ml
+++ b/test/test_merge.ml
@@ -140,6 +140,50 @@ let test_all_compatible_matches_the_pair_loop () =
            pool.(Random.State.int state (Array.length pool))))
   done
 
+(* The group decision as [Rule.merge_adjacent_identical] used to make it: a
+   candidate joins the group when it is [compatible] with every member already
+   in it. It decides which rules end up sharing a selector list, so the run has
+   to accept exactly the same prefix of every sequence. *)
+let take_by_pairs sels =
+  let rec loop group = function
+    | sel :: rest when List.for_all (fun g -> Merge.compatible g sel) group ->
+        loop (sel :: group) rest
+    | _ -> List.rev group
+  in
+  loop [] sels
+
+let take_by_run sels =
+  let rec loop run group = function
+    | sel :: rest ->
+        let run = Merge.extend_run run sel in
+        if Merge.run_compatible run then loop run (sel :: group) rest
+        else List.rev group
+    | [] -> List.rev group
+  in
+  loop Merge.empty_run [] sels
+
+let check_take sels =
+  if not (List.equal Selector.equal (take_by_pairs sels) (take_by_run sels))
+  then
+    Alcotest.failf "run disagrees with the pair loop on [%s]"
+      (String.concat "; " (List.map Selector.to_string sels))
+
+let test_run_matches_the_pair_loop () =
+  let pool = Array.of_list compat_pool in
+  let rec exhaustive depth acc =
+    check_take (List.rev acc);
+    if depth > 0 then
+      Array.iter (fun sel -> exhaustive (depth - 1) (sel :: acc)) pool
+  in
+  exhaustive 5 [];
+  let state = Random.State.make [| 0x217A |] in
+  for _ = 1 to 5000 do
+    let len = Random.State.int state 30 in
+    check_take
+      (List.init len (fun _ ->
+           pool.(Random.State.int state (Array.length pool))))
+  done
+
 (* Selectors whose distinguishing part sits behind a prefix they share, which is
    where a table keyed by [key] has to work hardest. *)
 let key_pool =
@@ -211,6 +255,8 @@ let suite =
         test_compatible_matches_the_predicates;
       Alcotest.test_case "all_compatible matches the pair loop" `Quick
         test_all_compatible_matches_the_pair_loop;
+      Alcotest.test_case "run matches the pair loop" `Quick
+        test_run_matches_the_pair_loop;
       Alcotest.test_case "declarations_equal fast and structural paths" `Quick
         test_declarations_equal_fast_and_structural_paths;
       Alcotest.test_case "key is the selector set" `Quick

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -85,6 +85,52 @@ let test_merge_adjacent_skips_vendor_pseudo () =
   Alcotest.(check bool)
     "vendor pseudo-element selectors never share a list" true (merged == input)
 
+(* --- complexity guard --- *)
+
+let measure f =
+  Gc.full_major ();
+  let w0 = Gc.minor_words () in
+  let r = f () in
+  ignore (Sys.opaque_identity r);
+  Gc.minor_words () -. w0
+
+(* [n] adjacent rules sharing one body and no two selectors alike, so the whole
+   run is one group and [take] grows it to [n]. The [:where(.sidebar)] prefix is
+   what makes the cost readable: the group- and peer-marker probes each take a
+   [String.sub] of a class name longer than the marker they look for, so a walk
+   of one of these selectors allocates and minor words count walks. *)
+let same_body_run n =
+  let b = Buffer.create (n * 48) in
+  let out = Fmt.with_buffer b in
+  for i = 0 to n - 1 do
+    Fmt.pf out ":where(.sidebar) .s%d{color:red}" i
+  done;
+  rules (Buffer.contents b)
+
+(* Whether a run may share one selector list turns on two facts read off each
+   selector alone, so the group decision costs one walk per member. Asking it of
+   every PAIR costs [n(n-1)] walks, and a run of same-body rules is exactly what
+   a utility-class sheet emits. Doubling the run must about double the words. *)
+let test_merge_run_reads_each_selector_once () =
+  (* The ratio below is readable only while the marker probe allocates. Pin that
+     first, so a probe that stops allocating fails here rather than leaving the
+     guard passing on a flat line. *)
+  let sel = Selector.of_string ":where(.sidebar) .s0" in
+  Alcotest.(check bool)
+    "marker probe allocates, so words count walks" true
+    (measure (fun () -> Selector.has_is_where_pattern sel) > 0.);
+  let in1 = same_body_run 200 and in2 = same_body_run 400 in
+  let merge input () = Rule.merge_adjacent_identical ~ctx:extend_ctx input in
+  Alcotest.(check int)
+    "the whole run merges into one rule" 1
+    (List.length (merge in2 ()));
+  let a1 = measure (merge in1) in
+  let a2 = measure (merge in2) in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.1fx for 2x N)" a1 a2 (a2 /. a1))
+    true
+    (a2 < a1 *. 3.)
+
 let suite =
   ( "rule",
     [
@@ -102,4 +148,6 @@ let suite =
         test_merge_adjacent_skips_intervening_rule;
       Alcotest.test_case "merge adjacent skips vendor pseudo" `Quick
         test_merge_adjacent_skips_vendor_pseudo;
+      Alcotest.test_case "merge run reads each selector once" `Quick
+        test_merge_run_reads_each_selector_once;
     ] )


### PR DESCRIPTION
Grouping a run of adjacent same-body rules asked `Merge.compatible` about every pair of it, which is quadratic in the run length. #486 fixed the same loop in the factoring candidate enumeration; this is the local merge that runs whatever the factoring gate decides.

800 same-body rules: 89.0M instructions per pass to 3.4M, and 2.0M words to 173K on a run whose marker probe allocates. Byte-identical on both interop corpora, and neither holds a run long enough to notice, so this bounds a worst case rather than speeding real input up.