### PR TITLE
lib: keep a page-break property through variable inlining

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -429,6 +429,11 @@ answers.
 
 ### Custom properties
 
+- A `page-break-before`, `page-break-after` or `page-break-inside` declaration
+  survives `Css.inline_vars` as itself. Substituting a `var()` rebuilt the
+  declaration from its minified name, which for these three is the `break-*`
+  alias of a different property, so `page-break-inside` came back as
+  `break-inside` with a value that property does not accept (#506)
 - `Css.inline_vars` stays linear in at-rule nesting depth. Each of its four
   walks rebuilt the enclosing `@media`/`@layer`/`@supports` chain at every
   level, which cost 6.4% of the instructions on real stylesheets (#481)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -962,6 +962,12 @@ let prop_name (type a) (prop_type : a property) =
   pp_property ctx prop_type;
   Buffer.contents buf
 
+(* The spelling a property parses back from. [prop_name] renders under minify,
+   where [page-break-*] becomes the CSS Fragmentation 3 sec. 3.4 [break-*] alias
+   of a different property. *)
+let canonical_prop_name (type a) (prop : a property) =
+  Pp.to_string ~minify:false pp_property prop
+
 type value_reader = {
   read_value_opt : 'a. 'a property -> Cursor.t -> declaration option;
 }
@@ -1982,17 +1988,10 @@ let read_custom_value name ~raw_is_whitespace_only value_str =
     whitespace_only_custom_property_value
   else read_custom_property_payload name value_str
 
-let read_custom_property_declaration t : declaration =
-  let name = read_property_name t in
-  (* CSS Syntax 3 sec. 4.3.7 lets [\X] escapes carry any code point into an
-     ident, so the name may contain characters ([/], whitespace, etc.) that
-     don't tokenize as a bare ident on a string round-trip. We trust the
-     original lexer's tokenization: the only validation we still run is the
-     [<dashed-ident>] prefix check. *)
-  if String.length name <= 2 || name.[0] <> '-' || name.[1] <> '-' then
-    Cursor.err_invalid t ("expected <dashed-ident>, got: " ^ name);
-  Cursor.ws t;
-  if not (Cursor.colon t) then Cursor.err_expected t "':'";
+(* The [name] declaration formed over the value at [t]; split from
+   [read_custom_property_declaration] for a caller that already holds the
+   name. *)
+let read_custom_value_declaration t name : declaration =
   (* CSS Custom Properties 1 sec. 2.1: [<declaration-value>] matches "any
      sequence of one or more tokens", so the whitespace after [:] IS the value
      when nothing else follows ([--foo: ;]). Don't skip it before
@@ -2011,6 +2010,19 @@ let read_custom_property_declaration t : declaration =
     in
     if is_important then important decl else decl
   with Failure msg -> Cursor.err_invalid t msg
+
+let read_custom_property_declaration t : declaration =
+  let name = read_property_name t in
+  (* CSS Syntax 3 sec. 4.3.7 lets [\X] escapes carry any code point into an
+     ident, so the name may contain characters ([/], whitespace, etc.) that
+     don't tokenize as a bare ident on a string round-trip. We trust the
+     original lexer's tokenization: the only validation we still run is the
+     [<dashed-ident>] prefix check. *)
+  if String.length name <= 2 || name.[0] <> '-' || name.[1] <> '-' then
+    Cursor.err_invalid t ("expected <dashed-ident>, got: " ^ name);
+  Cursor.ws t;
+  if not (Cursor.colon t) then Cursor.err_expected t "':'";
+  read_custom_value_declaration t name
 
 (* Properties whose grammar allows multi-token values where a CSS-wide keyword
    can legitimately appear as a non-special ident. [animation-name] /
@@ -2157,12 +2169,14 @@ let read_unknown_property_declaration t name =
   | _ -> ());
   unknown_property ~important:is_important name raw_value
 
-let read_typed_property_declaration t start =
-  Cursor.restore t start;
-  let (Prop prop_type) = read_any_property t in
-  Cursor.ws t;
-  if not (Cursor.colon t) then Cursor.err_expected t "':'";
-  Cursor.ws t;
+(* The declaration [prop_type] forms over the value at [t]. Takes the property
+   rather than reading it, so a caller holding one does not have to spell it out
+   for the parser to read back: [pp_property] under minify writes [page-break-*]
+   as its CSS Fragmentation 3 sec. 3.4 [break-*] alias, which names a different
+   property. *)
+let read_typed_value_declaration : type a. a property -> Cursor.t -> declaration
+    =
+ fun prop_type t ->
   (* CSS Syntax 3 sec. 2.2 / sec. 4.3.5 auto-close unterminated functions,
      brackets and strings at EOF. Typed readers consume the spec-recovered
      tokens; the declaration survives with the auto-closed shape. *)
@@ -2188,6 +2202,14 @@ let read_typed_property_declaration t start =
       with Cursor.Parse_error e ->
         Error.fail (Error.with_property (prop_name prop_type) e))
 
+let read_typed_property_declaration t start =
+  Cursor.restore t start;
+  let (Prop prop_type) = read_any_property t in
+  Cursor.ws t;
+  if not (Cursor.colon t) then Cursor.err_expected t "':'";
+  Cursor.ws t;
+  read_typed_value_declaration prop_type t
+
 (** Parse a regular property (name: value) *)
 let read_regular_property_declaration t : declaration =
   let start = Cursor.save t in
@@ -2211,6 +2233,28 @@ let read_regular_property_declaration t : declaration =
       if not (Cursor.colon t) then Cursor.err_expected t "':'";
       Cursor.ws t;
       read_unknown_property_declaration t name
+
+(* [read_regular_property_declaration] with the name step replaced by the
+   property itself. [name] serves the validation and the opaque fallback; the
+   identity of what is read back comes from [prop]. *)
+let read_regular_value_declaration : type a.
+    a property -> Cursor.t -> declaration =
+ fun prop t ->
+  let name = canonical_prop_name prop in
+  let start = Cursor.save t in
+  let components = Cursor.lookahead Cursor.drain_to_decl_end t in
+  validate_regular_property_components t name components;
+  match prop with
+  | Source ->
+      read_font_src_declaration t
+        (String.trim (Parser.string_of_components components))
+  | _ -> (
+      try read_typed_value_declaration prop t
+      with Cursor.Parse_error _ as exn ->
+        let raw_value = String.trim (Parser.string_of_components components) in
+        if not (allows_unknown_fallback name raw_value) then raise exn;
+        Cursor.restore t start;
+        read_unknown_property_declaration t name)
 
 (* CSS Nesting 1: distinguish a declaration ([<ident> : <value>]) from a nested
    rule whose selector starts with an ident ([html &:hover { ... }]). The
@@ -2366,6 +2410,26 @@ let read t =
   match read_declaration t with
   | Some d -> d
   | None -> Cursor.err_expected t "declaration"
+
+let with_value decl value =
+  let important = if is_important decl then "!important" else "" in
+  let tail () = Cursor.of_string (String.concat "" [ value; important ]) in
+  match property_key decl with
+  | Key (Custom_property name) -> read_custom_value_declaration (tail ()) name
+  | Key (Unknown_property name) ->
+      (* An unknown property is its name, and a substituted value may now be one
+         a typed reader accepts, so read the pair back whole: that is the step
+         that types [--x: 1px] once [width: var(--x)] has folded. *)
+      read (Cursor.of_string (String.concat "" [ name; ":"; value; important ]))
+  | Key prop -> read_regular_value_declaration prop (tail ())
+
+let with_opaque_value decl value =
+  let (Key prop) = property_key decl in
+  let opaque =
+    let name = canonical_prop_name prop in
+    v (Unknown_property name) (Cursor.remaining (Cursor.of_string value))
+  in
+  if is_important decl then important opaque else opaque
 
 (* Pretty printer for declarations *)
 let rec pp_declaration : declaration Pp.t =

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -186,6 +186,19 @@ val same_property : declaration -> declaration -> bool
 (** [same_property d1 d2] is [property_key d1 = property_key d2]: the two
     declarations target the same property name. *)
 
+val with_value : declaration -> string -> declaration
+(** [with_value decl value] is [decl] carrying [value], read as a value of the
+    property [decl] already holds and re-typed where that property accepts it.
+    The property is taken from [decl] rather than from its name, so one whose
+    minified spelling belongs to another property ([page-break-*] renders as the
+    CSS Fragmentation 3 sec. 3.4 [break-*] alias) is rebuilt as itself. Raises
+    [Cursor.Parse_error] when the property accepts no such value. *)
+
+val with_opaque_value : declaration -> string -> declaration
+(** [with_opaque_value decl value] is [decl]'s property carrying [value] as an
+    unknown property's token stream, for a [value] {!with_value} rejects. The
+    property is named as it parses back, not as it minifies. *)
+
 val string_of_value : ?minify:bool -> ?inline:bool -> declaration -> string
 (** [string_of_value ?minify decl] returns the value as a string. *)
 

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -455,18 +455,18 @@ and keep_wrapper ~kept visible ~visited original fallback =
                 };
             ])
 
+(* The property is carried through as the tag [decl] already holds, never as its
+   rendered name: [Declaration.property_name] minifies, and [page-break-*]
+   minifies to the CSS Fragmentation 3 sec. 3.4 [break-*] alias of a different
+   property. *)
 let declaration_with_components decl components : Declaration.declaration option
     =
-  let property = Declaration.property_name decl in
   let value =
     Parser.to_string_custom_minified ~fold_ident:Values.fold_custom_value_ident
       components
   in
   if String.trim value = "" then None
   else
-    let important =
-      if Declaration.is_important decl then "!important" else ""
-    in
     let has_string =
       components_contain (function
         | { kind = Token.String _; _ } -> true
@@ -477,20 +477,20 @@ let declaration_with_components decl components : Declaration.declaration option
         | { kind = Token.Comma; _ } -> true
         | _ -> false)
     in
-    let opaque () =
-      let fallback =
-        Declaration.v (Properties.Unknown_property property)
-          (Cursor.remaining (Cursor.of_string value))
-      in
-      Some
-        (if Declaration.is_important decl then Declaration.important fallback
-         else fallback)
+    (* [font-family] reaches here typed or, when its value never parsed as one,
+       as the unknown property of that name; both are the same property. *)
+    let is_font_family =
+      match Declaration.property_key decl with
+      | Declaration.Key Properties.Font_family -> true
+      | Declaration.Key (Properties.Unknown_property name) ->
+          String.equal name "font-family"
+      | _ -> false
     in
-    let source = String.concat "" [ property; ":"; value; important ] in
-    match Declaration.read (Cursor.of_string source) with
+    let opaque () = Some (Declaration.with_opaque_value decl value) in
+    match Declaration.with_value decl value with
     | decl -> Some decl
     | exception Cursor.Parse_error _ ->
-        if property = "font-family" && has_string components then opaque ()
+        if is_font_family && has_string components then opaque ()
         else if has_comma components then None
         else opaque ()
 

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -578,6 +578,42 @@ let test_inline_at_path_cost_is_linear () =
     true
     (a1 = 0. || a2 < a1 *. 2.5)
 
+(* A [page-break-*] declaration holding a [var()] is inlined like any other, and
+   the property it names has to survive the substitution. [page-break-*]
+   serialises under minify as its CSS Fragmentation 3 sec. 3.4 [break-*] alias,
+   so a pass that rebuilds the declaration from that spelling rebuilds a
+   different property: [break-inside] does not even accept [always]. Built
+   through the typed API because the reader has no [var()] arm for these
+   three. *)
+let test_inline_keeps_a_page_break_property () =
+  let inline_one property value decl =
+    Css.inline_vars
+      [
+        Stylesheet.Rule
+          (Stylesheet.rule
+             ~selector:(Selector.of_string ":root")
+             [ Declaration.custom_property property value ]);
+        Stylesheet.Rule
+          (Stylesheet.rule ~selector:(Selector.of_string ".a") [ decl ]);
+      ]
+    |> Css.to_string
+  in
+  let check name expected decl value =
+    Alcotest.(check string) name expected (inline_one "--pb" value decl)
+  in
+  check "page-break-after keeps its own property"
+    ".a {\n  page-break-after: always;\n}"
+    (Declaration.v Properties.Page_break_after (Var (Values.var_ref "pb")))
+    "always";
+  check "page-break-before keeps its own property"
+    ".a {\n  page-break-before: always;\n}"
+    (Declaration.v Properties.Page_break_before (Var (Values.var_ref "pb")))
+    "always";
+  check "page-break-inside keeps its own property"
+    ".a {\n  page-break-inside: avoid;\n}"
+    (Declaration.v Properties.Page_break_inside (Var (Values.var_ref "pb")))
+    "avoid"
+
 let suite =
   ( "inline",
     [
@@ -646,4 +682,6 @@ let suite =
         `Quick test_inline_layer_order_sites;
       Alcotest.test_case "inline vars keep a layer that still decides a slot"
         `Quick test_inline_layer_flattening;
+      Alcotest.test_case "inline vars keep a page-break property" `Quick
+        test_inline_keeps_a_page_break_property;
     ] )


### PR DESCRIPTION
`Css.inline_vars` rebuilt a substituted declaration from its minified property name, and `page-break-*` minifies to the `break-*` alias of a different property, so `page-break-inside` came back as `break-inside` carrying a value that property does not accept.

Only reachable through the typed API today, since the reader has no `var()` arm for those three, so output over `test/interop/**/*.css` and the lightning minify traces is byte-identical.