### PR TITLE
cover: read a rule's shadowing coverage once for the whole rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -415,7 +415,7 @@ answers.
   `min-width` to range syntax. `--enforce-spec` keeps both Level 3 spellings
   (#323)
 - `--minify` and `cascade diff` spend less time and memory on a large
-  stylesheet, for the same output (#413, #422, #424, #468)
+  stylesheet, for the same output (#413, #422, #424, #468, #507)
 - `--minify` no longer allocates quadratically on a long run of rules sharing
   one selector or one body, nor probes every pair of them to decide whether it
   may merge. The benchmark corpora hold no such run, so this bounds a worst

--- a/lib/cover.ml
+++ b/lib/cover.ml
@@ -14,26 +14,32 @@ module Selector_tbl = Hashtbl.Make (struct
   let hash = Selector.hash
 end)
 
-type entry = Props.t * Props.t
-type t = entry Selector_tbl.t
+(* The normal and the important half of what a selector writes later. A rule
+   asks about one selector and every declaration it carries, so the entry is
+   fetched once and stored once rather than probed per declaration. *)
+type written = Props.t * Props.t
+type t = written Selector_tbl.t
 
 let v () = Selector_tbl.create 256
 let empty = (Props.empty, Props.empty)
 
-let get t selector =
+let written t selector =
   Option.value ~default:empty (Selector_tbl.find_opt t selector)
 
-let covered t selector decl =
-  let normal, important = get t selector in
+let covered (normal, important) decl =
   let prop = Declaration.property_key decl in
   if Declaration.is_important decl then Props.mem prop important
   else Props.mem prop normal || Props.mem prop important
 
-let add t selector decl =
-  let normal, important = get t selector in
-  let prop = Declaration.property_key decl in
-  let cover =
-    if Declaration.is_important decl then (normal, Props.add prop important)
-    else (Props.add prop normal, important)
+let record t selector (normal, important) decls =
+  (* The two halves stay apart until the store, so a rule builds one entry
+     rather than one per declaration. *)
+  let rec fold normal important = function
+    | [] -> Selector_tbl.replace t selector (normal, important)
+    | decl :: rest ->
+        let prop = Declaration.property_key decl in
+        if Declaration.is_important decl then
+          fold normal (Props.add prop important) rest
+        else fold (Props.add prop normal) important rest
   in
-  Selector_tbl.replace t selector cover
+  fold normal important decls

--- a/lib/cover.mli
+++ b/lib/cover.mli
@@ -3,14 +3,20 @@
 type t
 (** Properties written later, keyed by selector. *)
 
+type written
+(** What one selector has written later for it. *)
+
 val v : unit -> t
 (** [v ()] creates an empty coverage table. *)
 
-val covered : t -> Selector.t -> Declaration.t -> bool
-(** [covered t selector decl] is [true] when [decl]'s property is definitely
-    shadowed by a later declaration for [selector] at the same or stronger
-    importance. *)
+val written : t -> Selector.t -> written
+(** [written t selector] is what [t] holds for [selector], read in one lookup
+    and answering for every declaration a rule at that selector carries. *)
 
-val add : t -> Selector.t -> Declaration.t -> unit
-(** [add t selector decl] records that [decl]'s property is written later for
-    [selector]. *)
+val covered : written -> Declaration.t -> bool
+(** [covered written decl] is [true] when [decl]'s property is definitely
+    shadowed by a later declaration at the same or stronger importance. *)
+
+val record : t -> Selector.t -> written -> Declaration.t list -> unit
+(** [record t selector written decls] stores [written] extended with [decls] as
+    what is written later for [selector], in one store. *)

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -230,16 +230,17 @@ let drop_shadowed_rules (rules : rule list) : rule list =
     (* [declarations] is only the run written before the first nested statement
        (CSS Nesting 1 sec. 3.4), so covering it says nothing about what the rest
        of the body sets: a rule with nested content stays. *)
-    dropped.(i) <-
-      (rule.declarations = [] && rule.nested = [])
-      || rule.nested = [] && rule.declarations <> []
-         && List.for_all
-              (Cover.covered later_by_selector rule.Stylesheet_intf.selector)
-              rule.declarations;
-    if dropped.(i) then changed := true;
-    List.iter
-      (Cover.add later_by_selector rule.Stylesheet_intf.selector)
-      rule.declarations
+    (match rule.declarations with
+    | [] -> dropped.(i) <- rule.nested = []
+    | decls ->
+        (* One selector for the whole rule, so the coverage its declarations are
+           tested against is read once and stored back once. *)
+        let selector = rule.Stylesheet_intf.selector in
+        let written = Cover.written later_by_selector selector in
+        dropped.(i) <-
+          rule.nested = [] && List.for_all (Cover.covered written) decls;
+        Cover.record later_by_selector selector written decls);
+    if dropped.(i) then changed := true
   done;
   let rec filter i = function
     | [] -> []

--- a/test/test_cover.ml
+++ b/test/test_cover.ml
@@ -21,39 +21,83 @@ let test_empty_table_covers_nothing () =
   let s = sel ".a" in
   Alcotest.(check bool)
     "empty table reports no coverage" false
-    (Cover.covered t s (decl "color:red"))
+    (Cover.covered (Cover.written t s) (decl "color:red"))
 
 let test_add_then_covered () =
   let t = Cover.v () in
   let s = sel ".a" in
-  Cover.add t s (decl "color:red");
+  Cover.record t s (Cover.written t s) [ decl "color:red" ];
   Alcotest.(check bool)
     "same property reported covered" true
-    (Cover.covered t s (decl "color:blue"));
+    (Cover.covered (Cover.written t s) (decl "color:blue"));
   Alcotest.(check bool)
     "different property not covered" false
-    (Cover.covered t s (decl "width:1px"))
+    (Cover.covered (Cover.written t s) (decl "width:1px"))
 
 let test_per_selector_isolation () =
   let t = Cover.v () in
   let a = sel ".a" in
   let b = sel ".b" in
-  Cover.add t a (decl "color:red");
+  Cover.record t a (Cover.written t a) [ decl "color:red" ];
   Alcotest.(check bool)
     "coverage is selector-scoped" false
-    (Cover.covered t b (decl "color:blue"))
+    (Cover.covered (Cover.written t b) (decl "color:blue"))
 
 let test_importance_partitioning () =
   let t = Cover.v () in
   let s = sel ".a" in
-  Cover.add t s (decl "color:red");
+  Cover.record t s (Cover.written t s) [ decl "color:red" ];
   Alcotest.(check bool)
     "normal does not cover important" false
-    (Cover.covered t s (decl "color:blue!important"));
-  Cover.add t s (decl "color:red!important");
+    (Cover.covered (Cover.written t s) (decl "color:blue!important"));
+  Cover.record t s (Cover.written t s) [ decl "color:red!important" ];
   Alcotest.(check bool)
     "important covers important" true
-    (Cover.covered t s (decl "color:blue!important"))
+    (Cover.covered (Cover.written t s) (decl "color:blue!important"))
+
+(* A rule asks about one selector and every declaration it carries, so the
+   coverage those declarations are tested against is read once and answers for
+   all of them. That is what makes the read a value rather than a view onto the
+   table: what the rule records afterwards does not reach back into it. *)
+let test_read_answers_for_the_whole_rule () =
+  let t = Cover.v () in
+  let s = sel ".a" in
+  let before = Cover.written t s in
+  Cover.record t s before [ decl "color:red" ];
+  Alcotest.(check bool)
+    "the read answers as of the rule, not as of the table" false
+    (Cover.covered before (decl "color:blue"));
+  Alcotest.(check bool)
+    "and the next read sees the store" true
+    (Cover.covered (Cover.written t s) (decl "color:blue"))
+
+(* [record] extends the read it was given, so a rule's declarations reach the
+   table in one store exactly as they would one store at a time. *)
+let test_one_store_agrees_with_one_per_declaration () =
+  let together = Cover.v () and apart = Cover.v () in
+  let s = sel ".a" in
+  let decls = [ decl "color:red"; decl "width:1px!important"; decl "top:0" ] in
+  Cover.record together s (Cover.written together s) decls;
+  List.iter (fun d -> Cover.record apart s (Cover.written apart s) [ d ]) decls;
+  List.iter
+    (fun (probe, expected) ->
+      let d = decl probe in
+      Alcotest.(check bool)
+        (Fmt.str "one store on %s" probe)
+        expected
+        (Cover.covered (Cover.written together s) d);
+      Alcotest.(check bool)
+        (Fmt.str "one store per declaration on %s" probe)
+        expected
+        (Cover.covered (Cover.written apart s) d))
+    [
+      ("color:blue", true);
+      ("width:2px", true);
+      ("width:2px!important", true);
+      ("top:1px", true);
+      ("left:0", false);
+      ("color:blue!important", false);
+    ]
 
 let suite =
   ( "cover",
@@ -64,4 +108,8 @@ let suite =
       Alcotest.test_case "selector isolation" `Quick test_per_selector_isolation;
       Alcotest.test_case "importance partitioning" `Quick
         test_importance_partitioning;
+      Alcotest.test_case "read answers for the whole rule" `Quick
+        test_read_answers_for_the_whole_rule;
+      Alcotest.test_case "one store agrees with one per declaration" `Quick
+        test_one_store_agrees_with_one_per_declaration;
     ] )


### PR DESCRIPTION
`Rule.drop_shadowed` asked the coverage table about a rule's selector once per declaration and stored back once per declaration, where the selector is the same for the whole rule. `Cover.covered` now answers from a value read once, and `Cover.record` stores it back once.

200 rules of 16 declarations behind a seven-deep selector: 38.0M instructions per pass to 19.8M. On the covered worst case the pass spends 708 instructions per declaration where it spent 1604. Byte-identical over 2960 recorded minifier cases and 797 corpus stylesheets.