### PR TITLE
properties: add radial shape, size and position kind witnesses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -79,6 +79,11 @@ answers.
 - `Cascade.Reader.parse_error` gains `line` and `col`, and `filename` holds a
   source name where it packed `"<CSS input>:L:C"`: read the location from the
   two new fields, and `with_filename` keeps it instead of overwriting (#491)
+- `Css.kind` gains `Radial_shape`, `Radial_size` and `Position_value`, so a
+  match on it is no longer exhaustive and needs the three arms. They let
+  `Css.Variables.var` bind a radial gradient's shape, size or centre
+  `<position>` as a typed custom property, where it could only take those as an
+  opaque token stream (#508)
 
 ### Parsing
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7474,6 +7474,9 @@ type 'a kind = 'a Properties.kind =
   | Gradient_stop : gradient_stop kind
   | Gradient_direction : gradient_direction kind
   | Gradient_position : gradient_position kind
+  | Radial_shape : radial_shape kind
+  | Radial_size : radial_size kind
+  | Position_value : position_value kind
   | Animation : animation kind
   | Timing_function : timing_function kind
   | Transform : transform kind

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2111,6 +2111,9 @@ let pp_value : type a. (a kind * a) Pp.t =
   | Gradient_stop -> pp pp_gradient_stop
   | Gradient_direction -> pp pp_gradient_direction
   | Gradient_position -> pp pp_gradient_position
+  | Radial_shape -> pp pp_radial_shape
+  | Radial_size -> pp pp_radial_size
+  | Position_value -> pp pp_position_value
   | Animation -> pp pp_animation
   | Timing_function -> pp pp_timing_function
   | Transform -> pp pp_transform

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4473,6 +4473,9 @@ type _ kind =
   | Gradient_stop : gradient_stop kind
   | Gradient_direction : gradient_direction kind
   | Gradient_position : gradient_position kind
+  | Radial_shape : radial_shape kind
+  | Radial_size : radial_size kind
+  | Position_value : position_value kind
   | Animation : animation kind
   | Timing_function : timing_function kind
   | Transform : transform kind

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1875,6 +1875,9 @@ let vars_of_kind : type a. a kind -> a -> any_var list =
   | Gradient_stop -> vars_of_gradient_stop value
   | Gradient_direction -> vars_of_gradient_direction value
   | Gradient_position -> vars_of_gradient_position value
+  | Radial_shape -> vars_of_radial_shape value
+  | Radial_size -> vars_of_radial_size value
+  | Position_value -> vars_of_position_value value
   | Animation -> vars_of_animation value
   | Timing_function -> []
   | Transform -> vars_of_transform value

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -318,6 +318,42 @@ let test_vars_of_declarations () =
   Alcotest.(check bool)
     "custom Tokens value exposes the ref" true (has_black tokens_ref)
 
+(* CSS Images 3 sec. 3.2 gives a radial gradient three independently animatable
+   parts - shape, size and centre <position> - and CSS Variables L1 sec. 3 lets
+   a custom property hold any one of them. Each type carries [Var], so a caller
+   binds one to a custom property, prints the binding, and reads it back through
+   a [var()] channel exactly as [Color] or [Length] does. *)
+let spec_radial_and_position_kinds () =
+  let bind name kind value expected =
+    let decl, _ = var name kind value in
+    Alcotest.(check string)
+      ("--" ^ name ^ " binding")
+      expected
+      (Css.Declaration.string_of_declaration ~minify:true decl)
+  in
+  bind "radial-shape" Radial_shape Circle "--radial-shape:circle";
+  bind "radial-size" Radial_size Farthest_corner "--radial-size:farthest-corner";
+  bind "radial-position" Position_value Center "--radial-position:center";
+  (* A typed binding whose value is itself a [var()] exposes the reference, so
+     the three channels compose the way tw's mask-radial stops need. *)
+  let _, shape_src = var "src-shape" Radial_shape Ellipse in
+  let _, size_src = var "src-size" Radial_size Closest_side in
+  let _, position_src = var "src-position" Position_value Top in
+  let reads name decl expected =
+    Alcotest.(check (list string))
+      name [ expected ]
+      (List.map any_var_name (vars_of_declarations [ decl ]))
+  in
+  reads "radial shape channel"
+    (fst (var "radial-shape" Radial_shape (Var shape_src)))
+    "--src-shape";
+  reads "radial size channel"
+    (fst (var "radial-size" Radial_size (Var size_src)))
+    "--src-size";
+  reads "radial position channel"
+    (fst (var "radial-position" Position_value (Var position_src)))
+    "--src-position"
+
 (* Not a roundtrip test *)
 let test_any_var_name () =
   let _spacing_decl, var_handle = var "spacing" Length (Px 0.) in
@@ -557,6 +593,7 @@ let tests =
       `Quick,
       spec_theme_binding_past_non_cascading_declaration );
     ("vars of declarations", `Quick, test_vars_of_declarations);
+    ("spec radial and position kinds", `Quick, spec_radial_and_position_kinds);
     ("any_var_name", `Quick, test_any_var_name);
     ("extract custom declarations", `Quick, test_extract_custom_declarations);
     ("custom declaration name", `Quick, test_custom_declaration_name);


### PR DESCRIPTION
`Css.kind` had no witness for `radial_shape`, `radial_size` or `position_value`, so a caller binding a radial gradient's shape, size or centre to a custom property had to pass it as an opaque token stream even though all three value types already carry `Var`.

This is breaking: an exhaustive match on `Css.kind` now needs the three new arms.