### PR TITLE
cursor: rewind pair and triple on failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,10 @@ answers.
   `Css.Variables.var` bind a radial gradient's shape, size or centre
   `<position>` as a typed custom property, where it could only take those as an
   opaque token stream (#508)
+- `Cascade.Cursor.pair` and `triple` rewind the cursor when the separator or a
+  later parser fails, as `option`, `one_of`, `try_parse_err` and `list` already
+  do. Code that caught `Parse_error` from either and read on from the advanced
+  position now re-reads what the first parser consumed (#509)
 
 ### Parsing
 
@@ -579,6 +583,9 @@ answers.
   the line before the error and stopped one column short at end of input, and
   the caret was a byte count under a window that could open inside a code
   point (#477)
+- `Cascade.Reader.list` reports too few items as
+  `expected at least N items (got M)`, the wording `Cascade.Cursor.list` uses,
+  where it said `expected at least N item(s)` (#509)
 
 ### CLI tools
 

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -870,24 +870,37 @@ let rec many p t =
       (v :: rest, err)
 
 let pair ?sep p1 p2 t =
-  let a = p1 t in
-  (match sep with None -> () | Some s -> s t);
-  let b = p2 t in
-  (a, b)
+  atomic t (fun () ->
+      let a = p1 t in
+      (match sep with None -> () | Some s -> s t);
+      let b = p2 t in
+      (a, b))
 
 let triple ?sep p1 p2 p3 t =
-  let a = p1 t in
-  (match sep with None -> () | Some s -> s t);
-  let b = p2 t in
-  (match sep with None -> () | Some s -> s t);
-  let c = p3 t in
-  (a, b, c)
+  atomic t (fun () ->
+      let a = p1 t in
+      (match sep with None -> () | Some s -> s t);
+      let b = p2 t in
+      (match sep with None -> () | Some s -> s t);
+      let c = p3 t in
+      (a, b, c))
 
 let fold_many p ~init ~f t =
   let rec loop acc =
     match option p t with None -> (acc, None) | Some v -> loop (f acc v)
   in
   loop init
+
+(* One wording for an [~at_least] shortfall, shared with [Reader.list]. *)
+let at_least_shortfall ~at_least ~got =
+  String.concat ""
+    [
+      "at least ";
+      string_of_int at_least;
+      " items (got ";
+      string_of_int got;
+      ")";
+    ]
 
 let list_consume_separator sep t =
   match sep with
@@ -924,16 +937,7 @@ let list ?sep ?(at_least = 0) ?at_most item t =
   let max = Option.value at_most ~default:max_int in
   let items = list_collect sep item t [] 0 max in
   let len = List.length items in
-  if len < at_least then
-    err_expected t
-      (String.concat ""
-         [
-           "at least ";
-           string_of_int at_least;
-           " items (got ";
-           string_of_int len;
-           ")";
-         ])
+  if len < at_least then err_expected t (at_least_shortfall ~at_least ~got:len)
   else items
 
 let try_parse_err p t =

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -488,7 +488,8 @@ val one_of : (t -> 'a) list -> t -> 'a
 val list :
   ?sep:(t -> unit) -> ?at_least:int -> ?at_most:int -> (t -> 'a) -> t -> 'a list
 (** [list ?sep ?at_least ?at_most item t] parses items separated by [sep]
-    (default: no separator). Enforces cardinality bounds. *)
+    (default: no separator). Enforces cardinality bounds. Too few items raise
+    ["expected at least N items (got M)"], the wording {!Reader.list} uses. *)
 
 val fold_many :
   (t -> 'a) -> init:'s -> f:('s -> 'a -> 's) -> t -> 's * string option
@@ -502,12 +503,13 @@ val many : (t -> 'a) -> t -> 'a list * string option
 
 val pair : ?sep:(t -> unit) -> (t -> 'a) -> (t -> 'b) -> t -> 'a * 'b
 (** [pair ?sep a b t] parses [a] followed by [b], optionally separated by [sep].
-*)
+    Atomic: a failure in [sep] or [b] rewinds the cursor to where [a] started,
+    so the caller can try another alternative. *)
 
 val triple :
   ?sep:(t -> unit) -> (t -> 'a) -> (t -> 'b) -> (t -> 'c) -> t -> 'a * 'b * 'c
 (** [triple ?sep a b c t] parses [a], [b], and [c], optionally separated by
-    [sep]. *)
+    [sep]. Atomic like {!val-pair}. *)
 
 val try_parse_err : (t -> 'a) -> t -> ('a, string) result
 (** [try_parse_err p t] returns [Ok v] on success or [Error msg] on parse

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -995,15 +995,26 @@ let triple ?(sep = fun (_ : t) -> ()) p1 p2 p3 t =
       let c = p3 t in
       (a, b, c))
 
+(* One wording for an [~at_least] shortfall, shared with [Cursor.list]. *)
+let at_least_shortfall ~at_least ~got =
+  String.concat ""
+    [
+      "at least ";
+      string_of_int at_least;
+      " items (got ";
+      string_of_int got;
+      ")";
+    ]
+
 let list_impl_check_at_least t item at_least items =
-  if List.length items >= at_least then ()
-  else if List.length items = 0 && at_least > 0 then
-    (* If we got no items and at_least:1 was specified, try to parse one more
-       time to get a better error message that includes the nested context. This
-       will fail and propagate the error with full context. *)
+  let got = List.length items in
+  if got >= at_least then ()
+  else if got = 0 && at_least > 0 then
+    (* No items at all: run the item parser once more so the error carries the
+       nested context. It failed already, so this raises. *)
     let _ = item t in
-    err t ("expected at least " ^ string_of_int at_least ^ " item(s)")
-  else err t ("expected at least " ^ string_of_int at_least ^ " item(s)")
+    err_expected t (at_least_shortfall ~at_least ~got)
+  else err_expected t (at_least_shortfall ~at_least ~got)
 
 let list_impl_check_at_most t at_most items =
   match at_most with

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -275,14 +275,19 @@ val enum : ?default:(t -> 'a) -> string -> (string * 'a) list -> t -> 'a
 val list :
   ?sep:(t -> unit) -> ?at_least:int -> ?at_most:int -> (t -> 'a) -> t -> 'a list
 (** [list ~sep ~at_least ~at_most item t] parses items separated by [sep]
-    (default: no separator). Enforces optional cardinality constraints. *)
+    (default: no separator). Enforces optional cardinality constraints. Too few
+    items raise ["expected at least N items (got M)"], the wording
+    {!Cursor.list} uses. *)
 
 val pair : ?sep:(t -> unit) -> (t -> 'a) -> (t -> 'b) -> t -> 'a * 'b
-(** [pair ~sep p1 p2 t] parses two items with optional separator. *)
+(** [pair ~sep p1 p2 t] parses two items with optional separator. Atomic: a
+    failure in [sep] or [p2] restores the position to where [p1] started, so the
+    caller can try another alternative. *)
 
 val triple :
   ?sep:(t -> unit) -> (t -> 'a) -> (t -> 'b) -> (t -> 'c) -> t -> 'a * 'b * 'c
-(** [triple ~sep p1 p2 p3 t] parses three items with optional separator. *)
+(** [triple ~sep p1 p2 p3 t] parses three items with optional separator. Atomic
+    like {!val-pair}. *)
 
 val url : t -> string
 (** [url t] parses [url(...)] content. *)

--- a/test/test_cursor.ml
+++ b/test/test_cursor.ml
@@ -89,6 +89,42 @@ let test_err_unexpected () =
   | exception Cursor.Parse_error _ -> ()
   | _ -> Alcotest.fail "expected Parse_error"
 
+(* [pair] and [triple] are backtracking combinators: a failure anywhere inside
+   them must leave the cursor exactly where it started, the same contract every
+   other failable [Cursor] combinator ([option], [one_of], [try_parse_err],
+   [list]) already honours through [atomic]. *)
+let boom t = Cursor.err_expected t "a later item"
+
+let test_pair_rewinds_on_failure () =
+  let c = cursor_of_string "foo" in
+  (match Cursor.pair Cursor.ident boom c with
+  | exception Cursor.Parse_error _ -> ()
+  | _ -> Alcotest.fail "expected Parse_error");
+  Alcotest.(check (option string))
+    "cursor rewound past the first item" (Some "foo") (Cursor.ident_opt c)
+
+let test_triple_rewinds_on_failure () =
+  let c = cursor_of_string "foo bar" in
+  (match Cursor.triple Cursor.ident Cursor.ident boom c with
+  | exception Cursor.Parse_error _ -> ()
+  | _ -> Alcotest.fail "expected Parse_error");
+  Alcotest.(check (option string))
+    "cursor rewound past both items" (Some "foo") (Cursor.ident_opt c);
+  Alcotest.(check (option string))
+    "second still there" (Some "bar") (Cursor.ident_opt c)
+
+(* The one wording for an [~at_least] shortfall, shared with [Reader.list]. *)
+let test_list_at_least_message () =
+  let c = cursor_of_string "foo" in
+  match Cursor.list ~at_least:2 Cursor.ident c with
+  | exception Cursor.Parse_error e -> (
+      match e.kind with
+      | Error.Bad_value { reason; _ } ->
+          Alcotest.(check string)
+            "at_least message" "expected at least 2 items (got 1)" reason
+      | _ -> Alcotest.fail "expected Bad_value")
+  | _ -> Alcotest.fail "expected Parse_error"
+
 let suite =
   ( "cursor",
     [
@@ -102,4 +138,10 @@ let suite =
       Alcotest.test_case "enum" `Quick test_enum;
       Alcotest.test_case "enum miss" `Quick test_enum_miss;
       Alcotest.test_case "err unexpected" `Quick test_err_unexpected;
+      Alcotest.test_case "pair rewinds on failure" `Quick
+        test_pair_rewinds_on_failure;
+      Alcotest.test_case "triple rewinds on failure" `Quick
+        test_triple_rewinds_on_failure;
+      Alcotest.test_case "list ~at_least message" `Quick
+        test_list_at_least_message;
     ] )

--- a/test/test_reader.ml
+++ b/test/test_reader.ml
@@ -782,6 +782,14 @@ let var_via_enum_or_calls () =
   Alcotest.(check string) "concat-var-2" "var:b:empty" v2;
   Alcotest.(check bool) "concat-done" true (is_done r)
 
+(* [Reader.list] and [Cursor.list] report an [~at_least] shortfall with one
+   wording, and it names how many items were actually read. *)
+let list_at_least_message () =
+  let r = of_string "a" in
+  check_raises "list-at-least"
+    (parse_error_expected "expected at least 2 items (got 1)" r) (fun () ->
+      ignore (list ~sep:comma ~at_least:2 ident r))
+
 (* list_impl edge cases *)
 let list_edges () =
   (* Trailing comma: current behavior returns parsed items so far *)
@@ -1613,6 +1621,7 @@ let tests_enum_or_calls () =
 let tests_lists () =
   backtrack_list ();
   list_edges ();
+  list_at_least_message ();
   list_call_stack ()
 
 let tests_one_of () =


### PR DESCRIPTION
`Cursor.pair` and `triple` left the cursor advanced when the separator or a later parser failed, so a caller that caught `Parse_error` and tried an alternative read from the wrong place; every other failable `Cursor` combinator already restores through `atomic`. `Reader`'s twins of the same names did rewind, which is why this settles `Cursor`'s behaviour rather than `Reader`'s: `Cursor` is the kit the whole library reads CSS through, and it had the wrong semantics of the two.

#514 then removes `Reader`'s combinator layer, which has no caller. This lands first so that removal is a no-op on behaviour rather than a silent choice between two answers, and so the surviving kit is tested for the answer it keeps.