### PR TITLE
lib: read a var() in a page-break declaration as that property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,6 +91,11 @@ answers.
 
 ### Parsing
 
+- A `var()` in a `page-break-before`, `page-break-after` or
+  `page-break-inside` declaration is read as the property it names. These
+  three were the only fragmentation properties whose reader had no `var()`
+  arm, so the declaration became an unknown property and no longer shadowed
+  a later one of its own name (#511)
 - An error inside an at-rule condition or an `@font-face` descriptor points at
   the slice that failed, not at the end of the file with the caret past the
   last byte (#496, #497, #499, #501)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2453,7 +2453,13 @@ let rec pp_declaration : declaration Pp.t =
       if important then
         Pp.string ctx (if ctx.minify then "!important" else " !important")
   | Declaration { property; value; important; _ } ->
-      pp_property ctx property;
+      (* Under minify [pp_property] gives a [page-break-*] property the
+         [break-*] property it aliases, which CSS Fragmentation 3 sec. 3.4
+         defines by a value mapping table. A value the table does not name has
+         no alias spelling, so the name follows the value back to the legacy
+         property rather than writing it under one that cannot express it. *)
+      if minified_name_carries property value then pp_property ctx property
+      else Pp.string ctx (canonical_prop_name property);
       Pp.string ctx ":";
       Pp.space_if_pretty ctx ();
       pp_property_value ctx (property, value);

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -76,23 +76,29 @@ let rec pp_page_break_inside_value : page_break_inside_value Pp.t =
   | Avoid -> Pp.string ctx "avoid"
   | Inherit -> Pp.string ctx "inherit"
 
-let break_of_page_break (value : page_break_value) : break_value =
+(* CSS Fragmentation 3 sec. 3.4 defines the page-break-* aliases by a value
+   mapping table: [auto | left | right | avoid] map to themselves and [always]
+   maps to [page]. The table is keyed on the value, so a value it does not name
+   has no break-* spelling and declines. A [var()] is one: substitution happens
+   at computed-value time, and [always], the one mapping that is not the
+   identity, is not a break-* value to fall back on. *)
+let break_of_page_break (value : page_break_value) : break_value option =
   match value with
-  | Auto -> Auto
-  | Always -> Page
-  | Avoid -> Avoid
-  | Left -> Left
-  | Right -> Right
-  | Inherit -> Inherit
-  | Var _ -> invalid_arg "page-break value var cannot be converted"
+  | Auto -> Some Auto
+  | Always -> Some Page
+  | Avoid -> Some Avoid
+  | Left -> Some Left
+  | Right -> Some Right
+  | Inherit -> Some Inherit
+  | Var _ -> None
 
 let break_inside_of_page_break (value : page_break_inside_value) :
-    break_inside_value =
+    break_inside_value option =
   match value with
-  | Auto -> Auto
-  | Avoid -> Avoid
-  | Inherit -> Inherit
-  | Var _ -> invalid_arg "page-break-inside value var cannot be converted"
+  | Auto -> Some Auto
+  | Avoid -> Some Avoid
+  | Inherit -> Some Inherit
+  | Var _ -> None
 
 let rec pp_columns_value : columns_value Pp.t =
  fun ctx -> function
@@ -230,8 +236,8 @@ let rec read_break_inside_value t : break_inside_value =
     ~var:(fun t -> Var (Values.read_var read_break_inside_value t))
     t
 
-let read_page_break_value t : page_break_value =
-  Cursor.enum "page-break"
+let rec read_page_break_value t : page_break_value =
+  Cursor.enum_or_var "page-break"
     [
       ("auto", (Auto : page_break_value));
       ("always", Always);
@@ -240,15 +246,17 @@ let read_page_break_value t : page_break_value =
       ("right", Right);
       ("inherit", Inherit);
     ]
+    ~var:(fun t -> Var (Values.read_var read_page_break_value t))
     t
 
-let read_page_break_inside_value t : page_break_inside_value =
-  Cursor.enum "page-break-inside"
+let rec read_page_break_inside_value t : page_break_inside_value =
+  Cursor.enum_or_var "page-break-inside"
     [
       ("auto", (Auto : page_break_inside_value));
       ("avoid", Avoid);
       ("inherit", Inherit);
     ]
+    ~var:(fun t -> Var (Values.read_var read_page_break_inside_value t))
     t
 
 let read_columns_count t =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -754,6 +754,21 @@ let pp_property : type a. a property Pp.t =
   | Ms_filter -> Pp.string ctx "-ms-filter"
   | O_transition -> Pp.string ctx "-o-transition"
 
+(* Whether the name [pp_property] gives [property] under minify can carry
+   [value]. CSS Fragmentation 3 sec. 3.4 defines the [page-break-*] alias of
+   [break-*] by a value mapping table, so the [break-*] name a [page-break-*]
+   property minifies to is a spelling the declaration can use only for a value
+   the table names: [always] maps to [page], the rest map to themselves, and a
+   [var()] maps to nothing here since substitution happens at computed-value
+   time. Every other property names itself the same whatever it carries. *)
+let minified_name_carries : type a. a property -> a -> bool =
+ fun property value ->
+  match property with
+  | Page_break_before -> Option.is_some (break_of_page_break value)
+  | Page_break_after -> Option.is_some (break_of_page_break value)
+  | Page_break_inside -> Option.is_some (break_inside_of_page_break value)
+  | _ -> true
+
 let rec pp_content : content Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"
@@ -2809,16 +2824,20 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Break_before -> pp pp_break_value
   | Break_after -> pp pp_break_value
   | Break_inside -> pp pp_break_inside_value
-  | Page_break_before ->
-      if Pp.minified ctx then pp_break_value ctx (break_of_page_break value)
-      else pp_page_break_value ctx value
-  | Page_break_after ->
-      if Pp.minified ctx then pp_break_value ctx (break_of_page_break value)
-      else pp_page_break_value ctx value
-  | Page_break_inside ->
-      if Pp.minified ctx then
-        pp_break_inside_value ctx (break_inside_of_page_break value)
-      else pp_page_break_inside_value ctx value
+  | Page_break_before -> (
+      match if Pp.minified ctx then break_of_page_break value else None with
+      | Some aliased -> pp_break_value ctx aliased
+      | None -> pp_page_break_value ctx value)
+  | Page_break_after -> (
+      match if Pp.minified ctx then break_of_page_break value else None with
+      | Some aliased -> pp_break_value ctx aliased
+      | None -> pp_page_break_value ctx value)
+  | Page_break_inside -> (
+      match
+        if Pp.minified ctx then break_inside_of_page_break value else None
+      with
+      | Some aliased -> pp_break_inside_value ctx aliased
+      | None -> pp_page_break_inside_value ctx value)
   | Page_size -> pp pp_page_size
   | Columns -> pp pp_columns_value
   | Column_width -> pp pp_column_width

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -6,6 +6,16 @@ include module type of Properties_intf
 val pp_property : 'a property Pp.t
 (** [pp_property] is the pretty-printer for property names. *)
 
+val minified_name_carries : 'a property -> 'a -> bool
+(** [minified_name_carries property value] is whether the name {!pp_property}
+    gives [property] under minify can carry [value]. A [page-break-*] property
+    minifies to the CSS Fragmentation 3 sec. 3.4 [break-*] property it aliases,
+    and that alias is defined by a value mapping table, so it is a spelling the
+    declaration can use only for a value the table names. A [var()] is not one:
+    substitution happens at computed-value time, and [always], the only mapping
+    that is not the identity, has no [break-*] spelling. Every other property
+    names itself the same whatever it carries. *)
+
 val pp_property_value : ('a property * 'a) Pp.t
 (** [pp_property_value] is the pretty-printer for a property and its typed
     value. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1490,6 +1490,74 @@ let spec_cascade3_aliasing () =
       neg_cursor read_declaration row.input)
     Cascade_spec_inventory.Declaration_grammar.alias_negative
 
+let spec_break3_page_break_var () =
+  (* CSS Fragmentation 3 sec. 3.4 aliases [page-break-*] to [break-*] through a
+     value mapping table: [auto | left | right | avoid] map to themselves and
+     [always] maps to [page]. The table is keyed on the value, so a [var()]
+     declaration has no alias to take: substitution happens at computed-value
+     time, and the one mapping that is not the identity has no [break-*]
+     spelling to fall back on. The declaration names [page-break-*] and stays
+     there, in both modes. *)
+  List.iter
+    (fun (input, pretty, minified) ->
+      check_declaration ~minify:false ~expected:pretty input;
+      check_declaration ~expected:minified input)
+    [
+      ( "page-break-before: var(--x)",
+        "page-break-before: var(--x)",
+        "page-break-before:var(--x)" );
+      ( "page-break-after: var(--x)",
+        "page-break-after: var(--x)",
+        "page-break-after:var(--x)" );
+      ( "page-break-inside: var(--x)",
+        "page-break-inside: var(--x)",
+        "page-break-inside:var(--x)" );
+      (* The fallback shows what the alias cannot carry: an unset [--x] leaves
+         [always], which no [break-*] property accepts. *)
+      ( "page-break-after: var(--x, always)",
+        "page-break-after: var(--x, always)",
+        "page-break-after:var(--x,always)" );
+      ( "page-break-inside: var(--x) !important",
+        "page-break-inside: var(--x) !important",
+        "page-break-inside:var(--x)!important" );
+    ];
+  (* A value the table does map still takes the alias, unmoved. *)
+  List.iter
+    (fun (input, pretty, minified) ->
+      check_declaration ~minify:false ~expected:pretty input;
+      check_declaration ~expected:minified input)
+    [
+      ( "page-break-before: always",
+        "page-break-before: always",
+        "break-before:page" );
+      ( "page-break-after: always",
+        "page-break-after: always",
+        "break-after:page" );
+      ("page-break-after: avoid", "page-break-after: avoid", "break-after:avoid");
+      ("page-break-before: left", "page-break-before: left", "break-before:left");
+      ( "page-break-inside: avoid",
+        "page-break-inside: avoid",
+        "break-inside:avoid" );
+      ("page-break-inside: auto", "page-break-inside: auto", "break-inside:auto");
+    ];
+  (* The [var()] declaration is the property it names, not an opaque one that
+     happens to spell the same: it answers [same_property] against a keyword
+     declaration of that property, the way every other property does. *)
+  List.iter
+    (fun (var_decl, keyword_decl) ->
+      Alcotest.(check bool)
+        (var_decl ^ " names the same property as " ^ keyword_decl)
+        true
+        (same_property
+           (Css.Declaration.of_string var_decl)
+           (Css.Declaration.of_string keyword_decl)))
+    [
+      ("page-break-before: var(--x)", "page-break-before: left");
+      ("page-break-after: var(--x)", "page-break-after: always");
+      ("page-break-inside: var(--x)", "page-break-inside: avoid");
+      ("break-after: var(--x)", "break-after: page");
+    ]
+
 let spec_cascade3_all () =
   (* CSS Cascade section 3.2: [all] is a shorthand that accepts only CSS-wide
      keywords and resets all CSS properties except direction, unicode-bidi, and
@@ -3212,6 +3280,8 @@ let declaration_tests =
     test_case "spec cascade 3 shorthand properties" `Quick
       spec_cascade3_shorthands;
     test_case "spec cascade 3.1 property aliasing" `Quick spec_cascade3_aliasing;
+    test_case "spec break 3.4 page-break alias with a var" `Quick
+      spec_break3_page_break_var;
     test_case "spec cascade 3.2 all property" `Quick spec_cascade3_all;
     test_case "spec cascade 7 defaulting keywords" `Quick
       spec_cascade7_defaulting;

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -614,6 +614,32 @@ let test_inline_keeps_a_page_break_property () =
     (Declaration.v Properties.Page_break_inside (Var (Values.var_ref "pb")))
     "avoid"
 
+(* The same substitution as [test_inline_keeps_a_page_break_property], reached
+   from CSS text rather than from a hand-built declaration. Reading a [var()]
+   into the property the author wrote is what puts a [Page_break_*] carrying a
+   [var()] in front of the inliner at all, so the property tag it rebuilds on
+   has to survive the whole round trip. [break-inside] accepts neither [always]
+   nor [avoid-page]. *)
+let test_inline_keeps_a_page_break_property_from_css () =
+  List.iter
+    (fun (input, expected) ->
+      Alcotest.(check string)
+        input expected
+        (input |> parse |> Css.inline_vars |> minified))
+    [
+      ( ":root{--pb:always}.a{page-break-after:var(--pb)}",
+        ".a{break-after:page}" );
+      ( ":root{--pb:always}.a{page-break-before:var(--pb)}",
+        ".a{break-before:page}" );
+      ( ":root{--pb:avoid}.a{page-break-inside:var(--pb)}",
+        ".a{break-inside:avoid}" );
+      (":root{--pb:left}.a{page-break-after:var(--pb)}", ".a{break-after:left}");
+      (* A substitution the legacy grammar rejects leaves the declaration in
+         place rather than retyping it as a property that would accept it. *)
+      ( ":root{--pb:avoid-page}.a{page-break-inside:var(--pb)}",
+        ".a{page-break-inside:avoid-page}" );
+    ]
+
 let suite =
   ( "inline",
     [
@@ -684,4 +710,6 @@ let suite =
         `Quick test_inline_layer_flattening;
       Alcotest.test_case "inline vars keep a page-break property" `Quick
         test_inline_keeps_a_page_break_property;
+      Alcotest.test_case "inline vars keep a page-break property read from CSS"
+        `Quick test_inline_keeps_a_page_break_property_from_css;
     ] )

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1431,6 +1431,35 @@ let nesting_synthesis_can_be_disabled () =
     (Astring.String.is_infix ~affix:"&:where(.dark,.dark *)"
        (out ~regroup:false ()))
 
+(* CSS Fragmentation 3 sec. 3.4 makes [page-break-*] the same property as its
+   [break-*] alias, so two [page-break-*] declarations in one rule are two
+   declarations of one property and the later one shadows the earlier, exactly
+   as [break-*] and every other property does. A [var()] on the left does not
+   change whose property it is. *)
+let page_break_var_shadows_like_its_alias () =
+  List.iter
+    (fun (input, expected) ->
+      Alcotest.(check string)
+        input expected
+        (Css.of_string_exn ~strict:false input |> minify))
+    [
+      (* The modern spelling sets the oracle. *)
+      (".a{break-after:var(--x);break-after:page}", ".a{break-after:page}");
+      (".a{break-after:page;break-after:var(--x)}", ".a{break-after:var(--x)}");
+      (".a{break-inside:var(--x);break-inside:avoid}", ".a{break-inside:avoid}");
+      (* The legacy spelling answers the same. *)
+      ( ".a{page-break-after:var(--x);page-break-after:always}",
+        ".a{break-after:page}" );
+      ( ".a{page-break-after:always;page-break-after:var(--x)}",
+        ".a{page-break-after:var(--x)}" );
+      ( ".a{page-break-before:var(--x);page-break-before:left}",
+        ".a{break-before:left}" );
+      ( ".a{page-break-inside:var(--x);page-break-inside:avoid}",
+        ".a{break-inside:avoid}" );
+      ( ".a{page-break-inside:avoid;page-break-inside:var(--x)}",
+        ".a{page-break-inside:var(--x)}" );
+    ]
+
 let optimize_tests =
   [
     ( "!important survives non-adjacent duplicate elimination",
@@ -1440,6 +1469,9 @@ let optimize_tests =
     ( "nesting synthesis can be disabled",
       `Quick,
       nesting_synthesis_can_be_disabled );
+    ( "a page-break var shadows like its alias",
+      `Quick,
+      page_break_var_shadows_like_its_alias );
     ("vendor prefix strip", `Quick, test_vendor_prefix_strip);
     ("vendor prefix baseline gate", `Quick, test_vendor_prefix_baseline_gate);
     ("color property folds", `Quick, test_color_property_folds);


### PR DESCRIPTION
`page-break-before`, `page-break-after` and `page-break-inside` fell back to an unknown property when their value was a `var()`, so the declaration no longer shadowed a later one of its own name. CSS Fragmentation 3 sec. 3.4 keys the `break-*` alias on the value, so the alias now declines for a `var()` instead of raising and minified output keeps the legacy name.

Follow-up to #506.