### PR TITLE
media: compare normalised structure, not serialised text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,11 @@ answers.
 
 ### Breaking
 
+- `Css.Media.equal` reads normalised query structure where it read serialised
+  text, so it is no longer `Css.Media.compare a b = 0` and answers differently
+  both ways: `(min-width: 10px)` and `(width >= 10px)` are now equal, and two
+  queries that print alike but parse apart are not. `Css.Media.normalize`
+  exposes the normal form it compares (#516)
 - **IMPORTANT** Many of the fixes below change the CSS cascade emits for input
   1.1.0 already accepted, and a dozen of them change how the page renders. If
   you shipped minified output built with 1.1.0, re-run it and compare:
@@ -278,6 +283,11 @@ answers.
 
 ### Minification
 
+- `--minify` merges `@media` blocks by query structure rather than serialised
+  text: `(min-width: 10px)` and `(width >= 10px)` are one bound and now merge
+  (Media Queries 4 sec. 2.4.4), while `@media screen\ and\ \(min-width\:\
+  10px\)` names an unknown media type that never matches and no longer merges
+  into `@media screen and (min-width: 10px)` (#516)
 - `--minify` merges two rules that declare the same NaN, whichever way each
   spelled it: `opacity: calc(NaN)` and `opacity: calc(infinity - infinity)`
   are one declaration (#471, #482)

--- a/fuzz/fuzz_media.ml
+++ b/fuzz/fuzz_media.ml
@@ -211,6 +211,152 @@ let test_media_feature_recovery buf =
   if actual <> "not all" then
     failf "invalid media feature family did not recover: %S -> %S" input actual
 
+(* ===== Soundness of the equivalence [Media.equal] decides ===== *)
+
+(* [Media.equal] gates block merging: two [@media] blocks it calls equal have
+   their declarations concatenated under one condition. So whatever it calls
+   equal must select the same media, and that is a property, not a table:
+
+   Media.equal a b => a and b match every sampled media state alike
+
+   Only this direction. Two equivalent queries are free to compare unequal; that
+   costs a merge and never correctness, and demanding the converse would mean
+   deciding media-query equivalence.
+
+   The oracle is [Context.matches_media], which evaluates a query against a
+   described environment the way a UA does. It knows nothing about how [equal]
+   is derived, so it is free to disagree with it. *)
+
+let px f : Css.Media.value = Length (Css.Values.Px f)
+let em f : Css.Media.value = Length (Css.Values.Em f)
+
+let state ?media_type features : Css.Context.query =
+  { Css.Context.empty_query with media_type; media_features = features }
+
+(* Widths land on, just below and just above every bound the generator can emit,
+   because an inclusive bound read as a strict one only shows at the bound
+   itself. Both length units appear, since a normaliser that rewrites a bound
+   must carry its unit across. *)
+let sampled_states =
+  let widths = [ 0.; 1.; 9.; 10.; 11.; 39.; 40.; 41.; 255.; 256. ] in
+  let sizes =
+    List.concat_map
+      (fun w ->
+        [
+          [
+            Css.Media.feature "width" (px w); Css.Media.feature "height" (px w);
+          ];
+          [
+            Css.Media.feature "width" (em w); Css.Media.feature "height" (em w);
+          ];
+        ])
+      widths
+  in
+  let discrete =
+    [
+      [];
+      [ Css.Media.feature "orientation" (Ident Landscape) ];
+      [ Css.Media.feature "orientation" (Ident Portrait) ];
+      [ Css.Media.feature "hover" (Ident Hover) ];
+      [ Css.Media.feature "pointer" (Ident Coarse) ];
+      [ Css.Media.feature "prefers-color-scheme" (Ident Dark) ];
+      [ Css.Media.feature "prefers-reduced-motion" (Ident Reduce) ];
+      [ Css.Media.feature "prefers-contrast" (Ident More) ];
+      [ Css.Media.feature "forced-colors" (Ident Active) ];
+      [ Css.Media.feature "scripting" (Ident Enabled) ];
+      [ Css.Media.feature "dynamic-range" (Ident High) ];
+      [ Css.Media.feature "prefers-reduced-data" (Ident Reduce) ];
+    ]
+  in
+  let types = [ None; Some "screen"; Some "print"; Some "tv" ] in
+  List.concat_map
+    (fun media_type ->
+      List.concat_map
+        (fun size -> List.map (fun d -> state ?media_type (size @ d)) discrete)
+        sizes)
+    types
+
+(* The first sampled state the two queries disagree on, if any. *)
+let disagreement a b =
+  List.find_opt
+    (fun q ->
+      Bool.compare
+        (Css.Context.matches_media q a)
+        (Css.Context.matches_media q b)
+      <> 0)
+    sampled_states
+
+let report_disagreement label a b q =
+  failf "%s called %S and %S equal, but they disagree on media state %s" label
+    (Css.Media.to_string a) (Css.Media.to_string b)
+    (String.concat " "
+       (Option.value ~default:"(no type)" q.Css.Context.media_type
+       :: List.map Css.Media.to_string q.Css.Context.media_features))
+
+let test_equal_is_sound buf =
+  let a = media buf 0 in
+  let b = media buf 7 in
+  if Css.Media.equal a b then
+    match disagreement a b with
+    | Some q -> report_disagreement "Media.equal" a b q
+    | None -> ()
+
+(* Bound spellings the generator above never pairs, drawn so that a normaliser
+   which flips a comparison, drops a unit or loses the media type is caught. *)
+let bound_pair buf i =
+  let open Css.Media in
+  pick
+    [
+      ("(min-width: 10px)", "(width >= 10px)");
+      ("(min-width: 10px)", "(width > 10px)");
+      ("(max-width: 40em)", "(width <= 40em)");
+      ("(max-width: 40em)", "(40em >= width)");
+      ("(10px <= width)", "(width >= 10px)");
+      ("(10px < width)", "(width > 10px)");
+      ("(10em <= width <= 40em)", "(40em >= width >= 10em)");
+      ("(10em <= width < 40em)", "(40em > width >= 10em)");
+      ("(min-height: 10px)", "(height >= 10px)");
+      ("(min-width: 10px)", "(min-height: 10px)");
+      ("all and (min-width: 10px)", "(width >= 10px)");
+      ("screen and (min-width: 10px)", "screen and (width >= 10px)");
+      ("screen and (min-width: 10px)", "print and (width >= 10px)");
+      ("not all and (min-width: 10px)", "not (width >= 10px)");
+      ({|screen\ and\ \(min-width\:\ 10px\)|}, "screen and (min-width: 10px)");
+      ({|print\,screen|}, "print, screen");
+      ("theme(static)", "theme(dynamic)");
+      ("(unknown-feature: 1)", "theme(static)");
+      ("(min-width: 10px), print", "(width >= 10px), print");
+    ]
+    buf i
+  |> fun (a, b) -> (of_string a, of_string b)
+
+let test_bound_spellings_sound buf =
+  let a, b = bound_pair buf 0 in
+  if Css.Media.equal a b then
+    match disagreement a b with
+    | Some q -> report_disagreement "Media.equal" a b q
+    | None -> ()
+
+(* Control: the sweep above only means something if it can see a wrong merge.
+   Equality on serialised text is one such wrong rule, and these two queries are
+   the reason: an unknown media type never matches, so they serialise the same
+   and select different media. If the sweep cannot separate them it cannot
+   separate anything. *)
+let test_sweep_catches_wrong_equality _buf =
+  let escaped = Css.Media.of_string {|screen\ and\ \(min-width\:\ 10px\)|} in
+  let real = Css.Media.of_string "screen and (min-width: 10px)" in
+  let text_equal a b =
+    String.equal (Css.Media.to_string a) (Css.Media.to_string b)
+  in
+  if not (text_equal escaped real) then
+    fail "the control pair no longer collides on serialised text";
+  match disagreement escaped real with
+  | Some _ -> ()
+  | None ->
+      fail
+        "the sampled media states cannot tell an unknown media type from a \
+         media type plus a condition"
+
 let suite =
   ( "media",
     [
@@ -233,4 +379,9 @@ let suite =
         test_media_feature_family;
       test_case "spec media feature family recovery vectors" [ bytes ]
         test_media_feature_recovery;
+      test_case "equal is sound" [ bytes ] test_equal_is_sound;
+      test_case "equal is sound on bound spellings" [ bytes ]
+        test_bound_spellings_sound;
+      test_case "state sweep catches a wrong equality" [ bytes ]
+        test_sweep_catches_wrong_equality;
     ] )

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -91,7 +91,7 @@ let rec drop_deeper n (path : at_node list) =
   else match path with [] -> [] | _ :: rest -> drop_deeper (n - 1) rest
 
 (* Nodes compare structurally, as the prefix form compared them. [Media.equal]
-   and its neighbours answer on the serialised query, which would make
+   and its neighbours fold the spec's spelling equivalences, which would make
    [(min-width:10px)] and [(width>=10px)] one barrier rather than two. *)
 let rec same_path (a : at_node list) (b : at_node list) =
   match (a, b) with

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -1156,6 +1156,156 @@ let rec lower_for_minify : t -> t = function
       in
       loop false [] qs
 
+(* ===== Canonical form ===== *)
+
+(* [normalize] is the one place that decides which spellings name one query, and
+   its invariant runs one way only:
+
+   normalize a = normalize b => a and b select the same media
+
+   Nothing promises the converse, and nothing should: two equivalent queries may
+   normalise apart, which costs a merge and never correctness. So every rewrite
+   below is one of the spec's own equivalences, never a heuristic. *)
+
+(* Media Queries 4 sec. 2.4.4: a [min-] prefix on a range feature is the [>=]
+   comparison and [max-] is [<=]; sec. 2.4.3 adds the value-first spelling. One
+   bound, four spellings. [feature_bound] already projects all four onto a
+   common view for the interval fold, so reading that view back as [name op
+   value] is the whole rewrite. The prefix leg is gated on a range feature
+   because that is the feature class sec. 2.4.4 speaks about, and the parser
+   rejects the prefix anywhere else. *)
+let canonical_bound (f : feature) : feature =
+  let is_bound =
+    match f with
+    | Plain (Min base, _) | Plain (Max base, _) -> range_feature_name base
+    | Range _ | Range_rev _ -> true
+    | Plain _ | Boolean _ | Interval _ | General_enclosed _ -> false
+  in
+  if not is_bound then f
+  else
+    match feature_bound f with
+    | Some (name, Lower, Le, v) -> Range (name, Ge, v)
+    | Some (name, Lower, Lt, v) -> Range (name, Gt, v)
+    | Some (name, Upper, Le, v) -> Range (name, Le, v)
+    | Some (name, Upper, Lt, v) -> Range (name, Lt, v)
+    (* [feature_bound] reports every bound it recognises as [Lt] or [Le]. *)
+    | Some _ | None -> f
+
+(* Media Queries 4 sec. 2.4.3: an interval is written in either direction, so
+   [(20em >= width >= 10em)] and [(10em <= width <= 20em)] are one query. Keep
+   the ascending direction. *)
+let canonical_interval a op1 name op2 b : feature =
+  match (op1, op2) with
+  | (Gt | Ge), (Gt | Ge) ->
+      let flip = function Gt -> Lt | Ge -> Le | (Lt | Le | Eq) as op -> op in
+      Interval (b, flip op2, name, flip op1, a)
+  | _ -> Interval (a, op1, name, op2, b)
+
+let normalize_feature (f : feature) : feature =
+  match f with
+  | Interval (a, op1, name, op2, b) -> canonical_interval a op1 name op2 b
+  | Plain _ | Boolean _ | Range _ | Range_rev _ -> canonical_bound f
+  (* A [<general-enclosed>] carries no structure to read, so its text is the
+     whole of what it means and none of it is rewritten. *)
+  | General_enclosed _ -> f
+
+(* Rebuild only what changed, as [lower_condition] does: [equal] runs this on
+   both sides of every merge test, and the queries it is asked about are usually
+   already normal. *)
+let rec normalize_condition (c : condition) : condition =
+  match c with
+  | Feature f as cond ->
+      let f' = normalize_feature f in
+      if f' == f then cond else Feature f'
+  | Not c as cond ->
+      let c' = normalize_condition c in
+      if c' == c then cond else Not c'
+  | And (a, b) as cond ->
+      let a' = normalize_condition a and b' = normalize_condition b in
+      if a' == a && b' == b then cond else And (a', b')
+  | Or (a, b) as cond ->
+      let a' = normalize_condition a and b' = normalize_condition b in
+      if a' == a && b' == b then cond else Or (a', b')
+
+let rec normalize (query : t) : t =
+  match query with
+  | Cond c ->
+      let c' = normalize_condition c in
+      if c' == c then query else Cond c'
+  (* Media Queries 4 sec. 2.3: [all] matches every media type, so it drops out
+     of an unprefixed [all and X], and [not all and X] is the Level 3 spelling
+     of [not (X)]. Bare [all] has no condition form and stays. *)
+  | Type { prefix = None; type_ = All; trailing = Some c } ->
+      Cond (normalize_condition c)
+  | Type { prefix = Some Not; type_ = All; trailing = Some c } ->
+      Cond (Not (normalize_condition c))
+  | Type { trailing = None; _ } -> query
+  | Type ({ trailing = Some c; _ } as r) ->
+      let c' = normalize_condition c in
+      if c' == c then query else Type { r with trailing = Some c' }
+  (* A query list matches when any member does, so a one-member list is that
+     member and a nested list flattens. *)
+  | List [ q ] -> normalize q
+  | List qs ->
+      List
+        (List.concat_map
+           (fun q -> match normalize q with List qs -> qs | q -> [ q ])
+           qs)
+
+(* Written out rather than left to the structural operators: [equal] is the gate
+   on block merging, and a comparison that walks a runtime representation is how
+   a spelling difference becomes a merge. *)
+let equal_cmp (a : cmp) b =
+  match (a, b) with
+  | Lt, Lt | Le, Le | Eq, Eq | Gt, Gt | Ge, Ge -> true
+  | (Lt | Le | Eq | Gt | Ge), _ -> false
+
+let equal_medium (a : medium) b =
+  match (a, b) with
+  | All, All | Screen, Screen | Print, Print -> true
+  | Other a, Other b -> String.equal a b
+  | (All | Screen | Print | Other _), _ -> false
+
+let equal_prefix (a : prefix) b =
+  match (a, b) with Not, Not | Only, Only -> true | (Not | Only), _ -> false
+
+let equal_feature (a : feature) b =
+  match (a, b) with
+  | Plain (n1, v1), Plain (n2, v2) -> equal_name n1 n2 && equal_value v1 v2
+  | Boolean n1, Boolean n2 -> equal_name n1 n2
+  | Range (n1, o1, v1), Range (n2, o2, v2) ->
+      equal_name n1 n2 && equal_cmp o1 o2 && equal_value v1 v2
+  | Range_rev (v1, o1, n1), Range_rev (v2, o2, n2) ->
+      equal_value v1 v2 && equal_cmp o1 o2 && equal_name n1 n2
+  | Interval (a1, o1, n1, p1, b1), Interval (a2, o2, n2, p2, b2) ->
+      equal_value a1 a2 && equal_cmp o1 o2 && equal_name n1 n2
+      && equal_cmp p1 p2 && equal_value b1 b2
+  | General_enclosed a, General_enclosed b -> String.equal a b
+  | ( ( Plain _ | Boolean _ | Range _ | Range_rev _ | Interval _
+      | General_enclosed _ ),
+      _ ) ->
+      false
+
+let rec equal_condition (a : condition) b =
+  match (a, b) with
+  | Feature a, Feature b -> equal_feature a b
+  | Not a, Not b -> equal_condition a b
+  | And (a1, b1), And (a2, b2) | Or (a1, b1), Or (a2, b2) ->
+      equal_condition a1 a2 && equal_condition b1 b2
+  | (Feature _ | Not _ | And _ | Or _), _ -> false
+
+let rec equal_normalized (a : t) b =
+  match (a, b) with
+  | Cond a, Cond b -> equal_condition a b
+  | Type a, Type b ->
+      Option.equal equal_prefix a.prefix b.prefix
+      && equal_medium a.type_ b.type_
+      && Option.equal equal_condition a.trailing b.trailing
+  | List a, List b -> List.equal equal_normalized a b
+  | (Cond _ | Type _ | List _), _ -> false
+
+let equal a b = equal_normalized (normalize a) (normalize b)
+
 (* ===== Sorting / classification ===== *)
 
 type kind =
@@ -1419,5 +1569,3 @@ let compare a b =
       else
         let c = Int.compare (preference_order a) (preference_order b) in
         if c <> 0 then c else String.compare (to_string a) (to_string b)
-
-let equal a b = compare a b = 0

--- a/lib/media.mli
+++ b/lib/media.mli
@@ -197,11 +197,41 @@ val pp_condition : condition Pp.t
 val pp_feature : feature Pp.t
 (** Pretty-printer for media features. *)
 
+val normalize : t -> t
+(** [normalize t] rewrites [t] into the spelling its equivalence class is
+    compared by. The invariant runs one way: when [normalize a] and
+    [normalize b] are equal, [a] and [b] select the same media.
+
+    The converse is neither promised nor intended: two equivalent queries may
+    normalise apart, which costs a merge and never correctness. So every rewrite
+    is one of the spec's own equivalences. A [min-] or [max-] prefix on a range
+    feature becomes the [>=] or [<=] comparison and a value-first bound becomes
+    name-first (Media Queries 4 sec. 2.4.4 and sec. 2.4.3); a descending
+    interval becomes ascending; [all] drops out of [all and X] and
+    [not all and X] (sec. 2.3); a nested query list flattens and a one-member
+    list becomes its member.
+
+    Completeness is a separate property, and it stops there. Equivalences
+    [normalize] leaves apart: two bounds on one feature against the written
+    interval, [(width >= 10px) and (width <= 20px)] against
+    [(10px <= width <= 20px)]; De Morgan pairs; reassociating or reordering
+    [and] and [or]; a plain feature against its [=] comparison; reordering a
+    query list; and anything inside a [<general-enclosed>], whose text is
+    compared verbatim. Each of those costs a merge, never correctness. *)
+
 val compare : t -> t -> int
-(** Total order on media queries. *)
+(** Total order on media queries. Ordering only needs to be deterministic, so a
+    full tie on every ordinal key breaks on the serialised query. That makes
+    [compare a b = 0] a different question from {!equal}, which reads structure:
+    each says yes where the other says no. Sort with [compare], decide sameness
+    with {!equal}. *)
 
 val equal : t -> t -> bool
-(** Structural equality on media queries. *)
+(** [equal a b] is structural equality on {!normalize}d queries, so it is true
+    only when [a] and [b] select the same media. It gates block merging and
+    therefore never answers on serialised text: an unknown media type spelled as
+    one escaped ident is not the media type and condition whose characters it
+    repeats, and a [<general-enclosed>] equals only the same text. *)
 
 type key
 (** A precomputed sort key for {!val-compare}. Deriving the order serializes the

--- a/test/cli/media_unitless_zero.t
+++ b/test/cli/media_unitless_zero.t
@@ -40,4 +40,4 @@ The range and container spellings take the zero too.
   > @container (min-width: 0) { .c { color: red } }
   > EOF
   $ cascade fmt --minify range.css
-  @media(width>=0px){.a{color:red}}@media(0px<=width){.b{color:red}}@container(width>=0px){.c{color:red}}
+  @media(0px<=width){.a,.b{color:red}}@container(width>=0px){.c{color:red}}

--- a/test/test_block.ml
+++ b/test/test_block.ml
@@ -199,6 +199,38 @@ let test_is_layer_not_empty_with_nested () =
       | _ -> Alcotest.fail "expected one layer statement")
     cases
 
+(* Media Queries 4 sec. 3.2: an unknown media type never matches. [@media
+   screen\ and\ \(min-width\:\ 10px\)] names one escaped ident as its media
+   type, so it selects nothing, while [@media screen and (min-width: 10px)]
+   selects a screen at 10px or wider. The two spell the same characters, and
+   merging them would apply declarations the input never let match. Same shape
+   as the escaped [@layer] dot above. *)
+let test_merge_media_keeps_an_escaped_media_type_apart () =
+  let css =
+    "@media screen\\ and\\ \\(min-width\\:\\ 10px\\){.x{color:red}}@media \
+     screen and (min-width:10px){.y{color:blue}}"
+  in
+  let stmts = block css in
+  let merged = Block.merge_consecutive_media ~optimize_merged_block:id stmts in
+  Alcotest.(check int)
+    "an unknown media type is not merged into a real one" 2 (List.length merged);
+  let distant = Block.merge_distant_media ~optimize_merged_block:id stmts in
+  Alcotest.(check int)
+    "the distant merge keeps them apart too" 2 (List.length distant)
+
+(* Media Queries 4 sec. 2.4.4: a [min-] prefix on a range feature is the [>=]
+   comparison, so these two blocks carry one condition in two spellings and the
+   cascade evaluates them identically. *)
+let test_merge_media_joins_two_spellings_of_one_bound () =
+  let stmts =
+    block
+      "@media (min-width:10px){.x{color:red}}@media \
+       (width>=10px){.y{color:blue}}"
+  in
+  let merged = Block.merge_consecutive_media ~optimize_merged_block:id stmts in
+  Alcotest.(check int)
+    "two spellings of one bound merge into one block" 1 (List.length merged)
+
 let suite =
   ( "block",
     [
@@ -212,6 +244,10 @@ let suite =
         test_merge_layers_combines_escaped_dot;
       Alcotest.test_case "merge same-condition @media" `Quick
         test_merge_media_combines_same_condition;
+      Alcotest.test_case "keep an escaped media type out of a merge" `Quick
+        test_merge_media_keeps_an_escaped_media_type_apart;
+      Alcotest.test_case "merge two spellings of one bound" `Quick
+        test_merge_media_joins_two_spellings_of_one_bound;
       Alcotest.test_case "merge same-condition @container" `Quick
         test_merge_containers_by_condition;
       Alcotest.test_case "keep distinct-condition @container" `Quick

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -482,6 +482,72 @@ let spec_media_unitless_zero_length () =
   check_recovers "non-zero number is not a length" "(min-width: 1)";
   check_recovers "non-zero number in a range" "(width >= 1)"
 
+(* Media Queries 4 sec. 2.4.4 "Using 'min-' and 'max-' Prefixes On Range
+   Features": "Using a 'min-' prefix on a feature name is equivalent to using
+   the '>=' operator", and 'max-' is the '<=' operator. Two spellings of one
+   query, so [equal] must not read them as two. Sec. 2.4.3 adds the value-first
+   spelling and the two interval directions to the same class. *)
+let equal_ignores_bound_spelling () =
+  let same name a b =
+    Alcotest.(check bool) name true (equal (of_string a) (of_string b))
+  in
+  same "min- prefix is the >= comparison" "(min-width: 10px)" "(width >= 10px)";
+  same "max- prefix is the <= comparison" "(max-width: 10px)" "(width <= 10px)";
+  same "value-first range" "(10px <= width)" "(width >= 10px)";
+  same "value-first strict range" "(10px < width)" "(width > 10px)";
+  same "min- prefix against the value-first spelling" "(min-width: 10px)"
+    "(10px <= width)";
+  same "descending interval" "(20em >= width >= 10em)" "(10em <= width <= 20em)";
+  same "all is the identity media type" "all and (min-width: 10px)"
+    "(width >= 10px)";
+  (* An inclusive bound is not the strict one: normalising the spelling must not
+     normalise away the comparison. *)
+  let differ name a b =
+    Alcotest.(check bool) name false (equal (of_string a) (of_string b))
+  in
+  differ "inclusive is not strict" "(min-width: 10px)" "(width > 10px)";
+  differ "a lower bound is not an upper bound" "(min-width: 10px)"
+    "(max-width: 10px)";
+  differ "the bound value still counts" "(min-width: 10px)" "(min-width: 11px)"
+
+(* An unknown media type never matches (Media Queries 4 sec. 3.2 error
+   handling), so a query whose type is one escaped ident is not the query that
+   spells the same characters as a type plus a condition. They share a
+   serialisation, which is why [equal] cannot be an equality on serialised
+   text. *)
+let equal_separates_an_escaped_media_type () =
+  let escaped = of_string {|screen\ and\ \(min-width\:\ 10px\)|} in
+  let real = of_string "screen and (min-width: 10px)" in
+  Alcotest.(check string)
+    "the witness is a serialisation collision" (to_string real)
+    (to_string escaped);
+  Alcotest.(check bool)
+    "an unknown media type is not a media type plus a condition" false
+    (equal escaped real)
+
+(* An opaque condition carries no structure to reason over, so it equals an
+   identical spelling and nothing else. Reflexivity is not optional: [equal] is
+   an equality, and the duplicate scan in [Block] reads a query against
+   itself. *)
+let equal_on_opaque_conditions () =
+  let opaque = of_string "theme(static)" in
+  Alcotest.(check bool)
+    "an opaque condition equals itself" true
+    (equal opaque (of_string "theme(static)"));
+  Alcotest.(check bool)
+    "an opaque condition does not equal a different spelling" false
+    (equal opaque (of_string "theme( static )"));
+  Alcotest.(check bool)
+    "an opaque condition does not equal a different one" false
+    (equal opaque (of_string "theme(dynamic)"));
+  (* Nothing in an opaque condition is read, so it does not equal the feature
+     whose serialisation it happens to share. *)
+  Alcotest.(check bool)
+    "an opaque condition is not the feature it spells" false
+    (equal
+       (of_string "(unknown-feature: 1)")
+       (feat (General_enclosed "(unknown-feature: 1)")))
+
 let suite =
   let open Alcotest in
   ( "media",
@@ -515,4 +581,9 @@ let suite =
       test_case "media-not takes a media-in-parens" `Quick
         media_not_takes_media_in_parens;
       test_case "negated all is level 4 not" `Quick negated_all_is_level4_not;
+      test_case "equal ignores bound spelling" `Quick
+        equal_ignores_bound_spelling;
+      test_case "equal separates an escaped media type" `Quick
+        equal_separates_an_escaped_media_type;
+      test_case "equal on opaque conditions" `Quick equal_on_opaque_conditions;
     ] )

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -548,6 +548,34 @@ let equal_on_opaque_conditions () =
        (of_string "(unknown-feature: 1)")
        (feat (General_enclosed "(unknown-feature: 1)")))
 
+(* A normal form is already normal, and it is still the query it came from:
+   reparsing what [normalize] printed lands back on the same normal form. *)
+let normalize_is_idempotent () =
+  List.iter
+    (fun input ->
+      let once = normalize (of_string input) in
+      Alcotest.(check string)
+        ("normalize is idempotent: " ^ input)
+        (to_string once)
+        (to_string (normalize once));
+      Alcotest.(check bool)
+        ("a normal form reparses to itself: " ^ input)
+        true
+        (equal once (of_string (to_string once))))
+    [
+      "(min-width: 10px)";
+      "(width >= 10px)";
+      "(10px <= width)";
+      "(20em >= width >= 10em)";
+      "all and (min-width: 10px)";
+      "not all and (min-width: 10px)";
+      "screen and (max-width: 40em)";
+      "(min-width: 10px) and (orientation: landscape)";
+      "not (min-width: 10px)";
+      "print, screen and (min-width: 10px)";
+      "theme(static)";
+    ]
+
 let suite =
   let open Alcotest in
   ( "media",
@@ -586,4 +614,5 @@ let suite =
       test_case "equal separates an escaped media type" `Quick
         equal_separates_an_escaped_media_type;
       test_case "equal on opaque conditions" `Quick equal_on_opaque_conditions;
+      test_case "normalize is idempotent" `Quick normalize_is_idempotent;
     ] )


### PR DESCRIPTION
`Media.equal` is documented as structural equality but was `compare a b = 0`, whose final tiebreak serialises both sides, so it decided block merging on printed text. That diverges from structural equality in both directions, and only one of them is benign.

Non-equivalent queries compared equal, which merges blocks that must stay apart. `@media screen\ and\ \(min-width\:\ 10px\)` names one escaped ident as its media type, and an unknown media type never matches (Media Queries 4 sec. 3.2), yet it prints as `screen and (min-width: 10px)` and so tied with the real `@media screen and (min-width: 10px)`. `Block.merge_consecutive_media` concatenated the two, applying declarations under a condition the input never let match. Building the AST directly reaches a second pair: `General_enclosed "(unknown-feature: 1)"` evaluates to false always, while `Plain (Other "unknown-feature", Integer 1)` matches a UA that exposes the feature, and the two print alike.

Equivalent queries compared unequal, which only costs a merge. `(min-width: 10px)` and `(width >= 10px)` are one bound (sec. 2.4.4) but print differently, so they stayed two blocks and two scope barriers.

`Media.normalize` now folds the spelling equivalences the spec states and `equal` compares the result structurally, so queries are equal only when they normalise identically. `compare` is unchanged and keeps its serialising tiebreak, since ordering only needs to be deterministic; nothing paired it with `equal`.
