### PR TITLE
optimize: compare a declaration's property key without building it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -456,6 +456,10 @@ answers.
   one selector or one body, nor probes every pair of them to decide whether it
   may merge. The benchmark corpora hold no such run, so this bounds a worst
   case rather than speeding real input up (#480, #486, #487, #502, #505)
+- `--minify` decides which rules share a default value without rebuilding a
+  property key for every declaration it reads, a scan it repeats once per
+  member per property under consideration. It allocates a twentieth less over
+  the 504-file corpus, for byte-identical output (#517)
 - `--minify` no longer scans quadratically when many rules share a deep
   selector prefix. The structural hash reads a fixed count of nodes, so
   `.a .b .c .d .e .f .g` and every sibling differing only past that prefix took

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -1144,11 +1144,23 @@ let property_key_equal left right =
 
 let property_key_hash key = key.hash
 
+(* [property_key_equal (declaration_property_key decl) key] reads only the two
+   compared fields, so building the record first buys nothing and costs one
+   allocation per declaration examined. The scans below run once per entry per
+   member per candidate group, which made this the single largest allocation
+   site in the whole candidate search. *)
+let declaration_has_key key decl =
+  Bool.equal (Declaration.is_important decl) key.important
+  && Declaration.equal_prop_key (Declaration.property_key decl) key.prop
+
+let declaration_has_any_key keys decl =
+  List.exists (fun key -> declaration_has_key key decl) keys
+
 let single_declaration_in_list key decls =
   let rec loop found = function
     | [] -> found
     | decl :: rest ->
-        if property_key_equal (declaration_property_key decl) key then
+        if declaration_has_key key decl then
           match found with
           | Option.None -> loop (Option.Some decl) rest
           | Option.Some _ -> Option.None
@@ -1168,9 +1180,7 @@ let property_keys (r : rule) =
 
 let rec has_property_key key = function
   | [] -> false
-  | decl :: rest ->
-      property_key_equal (declaration_property_key decl) key
-      || has_property_key key rest
+  | decl :: rest -> declaration_has_key key decl || has_property_key key rest
 
 (* Each entry carries the order in which its key was first seen. The buckets
    live in a hash table, so folding them yields the hash's order, and the sort
@@ -1205,12 +1215,8 @@ let add_property_buckets ~seq ~origin buckets id (rule : rule) =
   in
   loop [] rule.declarations
 
-let key_mem key keys = List.exists (property_key_equal key) keys
-
 let remove_property_declarations keys decls =
-  List.filter
-    (fun decl -> not (key_mem (declaration_property_key decl) keys))
-    decls
+  List.filter (fun decl -> not (declaration_has_any_key keys decl)) decls
 
 type default_member = { id : Rule_graph.node_id; rule : rule }
 
@@ -1332,8 +1338,7 @@ let removed_default_declarations entries member =
 
 let exact_common_without keys members =
   common_exact_decls (default_member_rules members)
-  |> List.filter (fun decl ->
-      not (key_mem (declaration_property_key decl) keys))
+  |> List.filter (fun decl -> not (declaration_has_any_key keys decl))
 
 let default_group_decls ~exact_common entries =
   append_unique_decls exact_common

--- a/test/test_rule_candidate.ml
+++ b/test/test_rule_candidate.ml
@@ -230,6 +230,51 @@ let nested_merge_safety_reads_each_block_once () =
     true
     (b = 0. || a < b *. 3.)
 
+(* --- allocation / complexity guards --- *)
+
+let measure f =
+  Gc.full_major ();
+  let w0 = Gc.minor_words () in
+  let r = f () in
+  ignore (Sys.opaque_identity r);
+  Gc.minor_words () -. w0
+
+(* [members] rules that write the same [props] custom properties, each differing
+   on one of them, is the densest shape the default-value search sees: every
+   property is common to every member, so each is a candidate default and each
+   member is a candidate override. *)
+let dense_default_sheet ~members ~props =
+  List.init members (fun m ->
+      let decls =
+        List.init props (fun p ->
+            if p = m mod props then Fmt.str "--p%d:%dpx" p (p + 1)
+            else Fmt.str "--p%d:0px" p)
+        |> String.concat ";"
+      in
+      Fmt.str ".s%d{%s}" m decls)
+  |> String.concat ""
+
+(* Deciding a default group reads each member's body once per entry to find the
+   declaration that carries that entry's property. The number of entries and the
+   length of a body both grow with the shared property count, and so does the
+   number of groups examined, so a per-declaration allocation inside that lookup
+   makes the whole search cubic in [props]. Building only the lists the search
+   keeps leaves it quadratic: doubling [props] must stay well below the cubic
+   8x. *)
+let default_factoring_lookup_is_subcubic () =
+  let work props () =
+    dense_default_sheet ~members:8 ~props
+    |> rules |> Rule_graph.of_rules
+    |> Rule_candidate.enumerate ~ctx:Ctx.fragment ~finalize:Fun.id
+  in
+  let a1 = measure (work 16) in
+  let a2 = measure (work 32) in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.1fx for 2x shared properties)" a1 a2
+       (a2 /. a1))
+    true
+    (a1 = 0. || a2 < a1 *. 5.5)
+
 let suite =
   ( "rule_candidate",
     [
@@ -256,4 +301,6 @@ let suite =
         nested_merge_reads_a_slot_as_a_multiset;
       Alcotest.test_case "nested-merge safety reads each block once" `Quick
         nested_merge_safety_reads_each_block_once;
+      Alcotest.test_case "default factoring lookup is subcubic" `Quick
+        default_factoring_lookup_is_subcubic;
     ] )


### PR DESCRIPTION
Deciding which rules share a default value rereads each member's body once per property under consideration, and every one of those reads built a `property_key` record in order to compare two of its fields. This PR compares those fields straight off the declaration, so the scan allocates nothing.

Over the 504 SatCSS fixtures the candidate search falls from 6,082,983,029 to 5,381,909,223 minor words, an eleventh of what `Rule_candidate.enumerate` allocated, and it enumerates the same 137,277 candidates as before. On a sheet whose rules all write the same properties the scan was cubic in that property count and is now quadratic: over four sizes, doubling it grew allocation 7.0x, 7.5x and 7.8x before and grows it 3.8x, 4.1x and 4.2x now. Output is byte-identical over the 504 SatCSS fixtures, the 797 corpus stylesheets and the 2960 recorded minifier cases, under `--minify` and pretty alike.
