### PR TITLE
declaration: report a parse error against the property written

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,6 +108,12 @@ answers.
 
 ### Parsing
 
+- A parse error in a `page-break-before`, `page-break-after` or
+  `page-break-inside` declaration is reported against the property the
+  declaration wrote. The diagnostic named the CSS Fragmentation 3 sec. 3.4
+  `break-*` property those minify to, which is a different property with
+  different values, so the message pointed at a property the author never used
+  (#518)
 - A `var()` in a `page-break-before`, `page-break-after` or
   `page-break-inside` declaration is read as the property it names. These
   three were the only fragmentation properties whose reader had no `var()`

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -961,15 +961,10 @@ let read_place_self_value t =
 let read_background_blend_mode_value t =
   v Background_blend_mode (Cursor.list ~sep:Cursor.comma read_blend_mode t)
 
-let prop_name (type a) (prop_type : a property) =
-  let buf = Buffer.create 32 in
-  let ctx = Pp.ctx ~minify:true buf in
-  pp_property ctx prop_type;
-  Buffer.contents buf
-
-(* The spelling a property parses back from. [prop_name] renders under minify,
-   where [page-break-*] becomes the CSS Fragmentation 3 sec. 3.4 [break-*] alias
-   of a different property. *)
+(* The spelling a property parses back from, and the one a diagnostic names: a
+   minified [page-break-*] is the CSS Fragmentation 3 sec. 3.4 [break-*] alias
+   of a different property, which reports the failure against a property the
+   declaration never wrote. *)
 let canonical_prop_name (type a) (prop : a property) =
   Pp.to_string ~minify:false pp_property prop
 
@@ -1916,14 +1911,16 @@ let rec read_value_from : type a.
     value_reader list -> a property -> Cursor.t -> declaration =
  fun readers prop t ->
   match readers with
-  | [] -> Cursor.err_invalid t ("unsupported property reader: " ^ prop_name prop)
+  | [] ->
+      Cursor.err_invalid t
+        ("unsupported property reader: " ^ canonical_prop_name prop)
   | reader :: rest -> (
       match reader.read_value_opt prop t with
       | Some decl -> decl
       | None -> read_value_from rest prop t)
 
 let read_value (type a) (prop : a property) t : declaration =
-  Cursor.with_context t (prop_name prop) @@ fun () ->
+  Cursor.with_context t (canonical_prop_name prop) @@ fun () ->
   match prop with
   | Custom_property name ->
       Cursor.err_invalid t
@@ -2205,7 +2202,7 @@ let read_typed_value_declaration : type a. a property -> Cursor.t -> declaration
       in
       try read ()
       with Cursor.Parse_error e ->
-        Error.fail (Error.with_property (prop_name prop_type) e))
+        Error.fail (Error.with_property (canonical_prop_name prop_type) e))
 
 let read_typed_property_declaration t start =
   Cursor.restore t start;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1477,6 +1477,35 @@ let spec_cascade3_shorthands () =
   neg_cursor read_declaration "border: 1px solid revert";
   neg_cursor read_declaration "font: bold inherit 12pt Helvetica"
 
+(* A parse error names the property the declaration wrote. [page-break-*]
+   minifies to the CSS Fragmentation 3 sec. 3.4 [break-*] property it aliases,
+   which is a different property with its own values, so a diagnostic rendered
+   under minify reports the failure against a property the author never wrote
+   and cannot tell the two apart. *)
+let error_names_the_property_written () =
+  let message input =
+    let r = Cursor.of_string input in
+    match read_declaration r with
+    | _ -> Alcotest.failf "%s: expected Parse_error but none was raised" input
+    | exception Cursor.Parse_error e -> Error.to_string e
+  in
+  List.iter
+    (fun (input, written, alias) ->
+      let msg = message input in
+      Alcotest.(check bool)
+        (input ^ " is reported against " ^ written)
+        true
+        (Astring.String.is_infix ~affix:("bad value for " ^ written ^ ":") msg);
+      Alcotest.(check bool)
+        (input ^ " is not reported against " ^ alias)
+        false
+        (Astring.String.is_infix ~affix:("bad value for " ^ alias ^ ":") msg))
+    [
+      ("page-break-before: bogus", "page-break-before", "break-before");
+      ("page-break-after: bogus", "page-break-after", "break-after");
+      ("page-break-inside: bogus", "page-break-inside", "break-inside");
+    ]
+
 let spec_cascade3_aliasing () =
   (* CSS Cascade section 3.1: legacy shorthands behave as shorthands at parse
      time but are not selected for serialization. The spec example maps
@@ -3282,6 +3311,8 @@ let declaration_tests =
     test_case "spec cascade 3.1 property aliasing" `Quick spec_cascade3_aliasing;
     test_case "spec break 3.4 page-break alias with a var" `Quick
       spec_break3_page_break_var;
+    test_case "a parse error names the property written" `Quick
+      error_names_the_property_written;
     test_case "spec cascade 3.2 all property" `Quick spec_cascade3_all;
     test_case "spec cascade 7 defaulting keywords" `Quick
       spec_cascade7_defaulting;


### PR DESCRIPTION
`Declaration.prop_name` rendered the property under minify, where `page-break-before`, `page-break-after` and `page-break-inside` become the CSS Fragmentation 3 sec. 3.4 `break-*` property they alias. A bad value in one of the three was reported as `bad value for break-after`, naming a different property with different values and reading identically to a real `break-after` failure. `canonical_prop_name`, added by #506 as "the spelling a property parses back from", is exactly what the diagnostic wants, so the three error sites take it and `prop_name` goes.

Both corpora are blind to this: `test/interop` holds no `page-break` declaration in any of its 797 stylesheets and the 2960 recorded minifier cases hold none either, so stdout, stderr and exit codes are byte-identical across all 4554 units against base 8ea2adb5. The evidence is a purpose-made corpus instead: eight declarations covering the three `page-break-*` properties, the three `break-*` they alias and a control, where exactly the three `page-break-*` headlines change and the other four are untouched. Byte-identity is necessary here, not sufficient.