### PR TITLE
container: decide block merging on query structure, not text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -294,6 +294,14 @@ answers.
   (Media Queries 4 sec. 2.4.4), while `@media screen\ and\ \(min-width\:\
   10px\)` names an unknown media type that never matches and no longer merges
   into `@media screen and (min-width: 10px)` (#516)
+- `--minify` merges `@container` blocks by query structure rather than
+  serialised text: `(min-width: 700px)` and `(width >= 700px)` are one bound
+  and now merge, because a `<size-feature>` is spelled like a media feature
+  (CSS Conditional Rules 5 sec. 6.1), while
+  `@container (inline-size\ \>\=\ 10px)` names an unknown container feature
+  that never matches and no longer merges into
+  `@container (inline-size >= 10px)`. `Css.Container.equal` decides that, and
+  `Css.Container.normalize` exposes the normal form it compares (#519)
 - `--minify` merges two rules that declare the same NaN, whichever way each
   spelled it: `opacity: calc(NaN)` and `opacity: calc(infinity - infinity)`
   are one declaration (#471, #482)

--- a/fuzz/fuzz_container.ml
+++ b/fuzz/fuzz_container.ml
@@ -125,6 +125,174 @@ let test_invalid_container_vectors buf =
   in
   assert_invalid_container_contract "invalid container query vector" input
 
+(* ===== Soundness of the equivalence [Container.equal] decides ===== *)
+
+(* [Container.equal] gates block merging: two [@container] blocks it calls equal
+   have their declarations concatenated under one condition. So whatever it
+   calls equal must select the same query containers, and that is a property,
+   not a table:
+
+   Container.equal a b => a and b match every sampled container state alike
+
+   Only this direction. Two equivalent queries are free to compare unequal; that
+   costs a merge and never correctness, and demanding the converse would mean
+   deciding container query equivalence.
+
+   The oracle is [Context.matches_container], which evaluates a query against a
+   described query container the way a UA does. It knows nothing about how
+   [equal] is derived, so it is free to disagree with it. *)
+
+let px f : Css.Media.value = Length (Css.Values.Px f)
+let em f : Css.Media.value = Length (Css.Values.Em f)
+let rem f : Css.Media.value = Length (Css.Values.Rem f)
+
+let sizes_in unit_ v =
+  List.map
+    (fun axis -> Css.Container.feature axis (unit_ v))
+    [ "width"; "height"; "inline-size"; "block-size" ]
+
+(* Sizes land exactly on every bound the generator and the spec inventory can
+   emit, and on either side of it: an inclusive bound read as a strict one shows
+   only at the bound itself. Each length unit appears on its own, since a
+   normaliser that rewrites a bound must carry its unit across. *)
+let sampled_sizes =
+  let bounds =
+    [ 0.; 9.; 10.; 11.; 20.; 24.; 30.; 45.; 60.; 100.; 400.; 700.; 1200. ]
+  in
+  List.concat_map
+    (fun v -> [ sizes_in px v; sizes_in em v; sizes_in rem v ])
+    bounds
+
+(* The rest of what a query container exposes: the discrete size features, the
+   computed values a [style()] query reads, the scroll state a [scroll-state()]
+   query reads, and the name a [<container-name>] filters on. *)
+let sampled_contexts =
+  [
+    (None, []);
+    (None, [ Css.Container.feature "orientation" (Ident Portrait) ]);
+    (None, [ Css.Container.feature "orientation" (Ident Landscape) ]);
+    (None, [ Css.Container.feature "aspect-ratio" (Ratio (16, 9)) ]);
+    (None, [ Css.Container.feature "aspect-ratio" (Ratio (4, 3)) ]);
+    (None, [ Css.Container.style ~value:"dark" "--theme" ]);
+    (None, [ Css.Container.style ~value:"featured" "--variant" ]);
+    (None, [ Css.Container.style ~value:"15px" "--gap" ]);
+    (None, [ Css.Container.style ~value:"red" "color" ]);
+    (None, [ Css.Container.scroll_state "stuck" "top" ]);
+    (None, [ Css.Container.scroll_state "stuck" "left" ]);
+    (None, [ Css.Container.scroll_state "snapped" "block" ]);
+    (None, [ Css.Container.scroll_state "scrollable" "inline" ]);
+    (None, [ Css.Container.scroll_state "scrolled" "y" ]);
+    (Some "card", []);
+    ( Some "card",
+      [
+        Css.Container.style ~value:"featured" "--variant";
+        Css.Container.scroll_state "stuck" "top";
+      ] );
+    (Some "sidebar", []);
+    (Some "sidebar", [ Css.Container.style ~value:"dark" "--theme" ]);
+  ]
+
+let sampled_states =
+  List.concat_map
+    (fun size ->
+      List.map
+        (fun (container_name, extra) ->
+          Css.Context.query ?container_name ~container_features:(size @ extra)
+            ())
+        sampled_contexts)
+    sampled_sizes
+
+(* The first sampled container state the two queries disagree on, if any. *)
+let disagreement a b =
+  List.find_opt
+    (fun q ->
+      Bool.compare
+        (Css.Context.matches_container q a)
+        (Css.Context.matches_container q b)
+      <> 0)
+    sampled_states
+
+let report_disagreement label a b q =
+  failf
+    "%s called %S and %S equal, but they disagree on container state %s (name \
+     %s)"
+    label
+    (Css.Container.to_string a)
+    (Css.Container.to_string b)
+    (String.concat " "
+       (List.map Css.Container.to_string q.Css.Context.container_features))
+    (Option.value ~default:"(none)" q.Css.Context.container_name)
+
+let test_equal_is_sound buf =
+  let a = condition buf 0 in
+  let b = condition buf 7 in
+  if Css.Container.equal a b then
+    match disagreement a b with
+    | Some q -> report_disagreement "Container.equal" a b q
+    | None -> ()
+
+(* Bound and function spellings the generator above never pairs, drawn so that a
+   normaliser which flips a comparison, drops a unit, loses the container name
+   or reads an escaped ident as the query it spells is caught. *)
+let spelling_pair buf i =
+  let open Css.Container in
+  pick
+    [
+      ("(min-width: 10px)", "(width >= 10px)");
+      ("(min-width: 10px)", "(width > 10px)");
+      ("(min-width: 24rem)", "(width >= 24rem)");
+      ("(max-inline-size: 30em)", "(inline-size <= 30em)");
+      ("(30em >= inline-size)", "(inline-size <= 30em)");
+      ("(30em < inline-size)", "(inline-size > 30em)");
+      ("(30em <= inline-size <= 60em)", "(60em >= inline-size >= 30em)");
+      ("(30em <= inline-size < 60em)", "(60em > inline-size >= 30em)");
+      ("(min-width: 10px)", "(min-height: 10px)");
+      ("(inline-size > 30em)", "(block-size > 30em)");
+      ({|(inline-size\ \>\=\ 10px)|}, "(inline-size >= 10px)");
+      ( {|(\31 0px\ \<\=\ inline-size\ \<\=\ 20px)|},
+        "(10px <= inline-size <= 20px)" );
+      ({|(orientation\:\ landscape)|}, "(orientation: landscape)");
+      ("STYLE(--theme: dark)", "style(--theme: dark)");
+      ("style(--theme: dark)", "style(--theme: light)");
+      ("style(--theme:dark)", "style(--theme: dark)");
+      ("SCROLL-STATE(stuck: top)", "scroll-state(stuck: top)");
+      ("scroll-state(stuck: top)", "scroll-state(stuck: left)");
+      ("card (inline-size > 30em)", "sidebar (inline-size > 30em)");
+      ("card (inline-size > 30em)", "card (30em < inline-size)");
+      ("not (inline-size > 30em)", "not (30em < inline-size)");
+      ("theme(static)", "theme(dynamic)");
+    ]
+    buf i
+  |> fun (a, b) -> (of_string a, of_string b)
+
+let test_spelling_pairs_sound buf =
+  let a, b = spelling_pair buf 0 in
+  if Css.Container.equal a b then
+    match disagreement a b with
+    | Some q -> report_disagreement "Container.equal" a b q
+    | None -> ()
+
+(* Control: the sweep above only means something if it can see a wrong merge.
+   Equality on serialised text is one such wrong rule, and these two queries are
+   the reason: an unknown container feature selects no query container
+   (Conditional Rules 5 sec. 5.4), so they serialise the same and match
+   different containers. If the sweep cannot separate them it cannot separate
+   anything. *)
+let test_sweep_catches_wrong_equality _buf =
+  let escaped = Css.Container.of_string {|(inline-size\ \>\=\ 10px)|} in
+  let real = Css.Container.of_string "(inline-size >= 10px)" in
+  let text_equal a b =
+    String.equal (Css.Container.to_string a) (Css.Container.to_string b)
+  in
+  if not (text_equal escaped real) then
+    fail "the control pair no longer collides on serialised text";
+  match disagreement escaped real with
+  | Some _ -> ()
+  | None ->
+      fail
+        "the sampled container states cannot tell an unknown container feature \
+         from the size range it spells"
+
 let suite =
   ( "container",
     [
@@ -143,4 +311,9 @@ let suite =
         test_spec_container_vectors;
       test_case "invalid container query vectors rejected" [ bytes ]
         test_invalid_container_vectors;
+      test_case "equal is sound" [ bytes ] test_equal_is_sound;
+      test_case "equal is sound on spelling pairs" [ bytes ]
+        test_spelling_pairs_sound;
+      test_case "state sweep catches a wrong equality" [ bytes ]
+        test_sweep_catches_wrong_equality;
     ] )

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -311,18 +311,21 @@ let merge_consecutive_supports ~optimize_merged_block (stmts : statement list) :
     in
     merge [] None stmts
 
+(* The whole [@container] merge gate: a name and a condition, read once to
+   decide the pass has work and once per adjacent pair. A [<container-name>] is
+   a [<custom-ident>] (Conditional Rules 5 sec. 5.4), so the name the parser
+   unescaped is its identity; [Container.equal] reads the condition's normalised
+   structure rather than its serialised text, which an unknown container feature
+   can repeat without meaning it. *)
+let same_container (prev_name, prev_cond) (name, cond) =
+  Option.equal String.equal prev_name name
+  && Option.equal Container.equal prev_cond cond
+
 let merge_consecutive_containers ~optimize_merged_block (stmts : statement list)
     : statement list =
-  let compare_condition a b =
-    match (a, b) with
-    | Some a, Some b -> Container.compare a b
-    | Some _, None -> 1
-    | None, Some _ -> -1
-    | None, None -> 0
-  in
   let rec needs_merge = function
     | Container (prev_name, prev_cond, _) :: Container (name, cond, _) :: _
-      when prev_name = name && compare_condition prev_cond cond = 0 ->
+      when same_container (prev_name, prev_cond) (name, cond) ->
         true
     | _ :: rest -> needs_merge rest
     | [] -> false
@@ -340,7 +343,7 @@ let merge_consecutive_containers ~optimize_merged_block (stmts : statement list)
       | Container (name, cond, block) :: rest -> (
           match prev with
           | Some (prev_name, prev_cond, prev_block)
-            when prev_name = name && compare_condition prev_cond cond = 0 ->
+            when same_container (prev_name, prev_cond) (name, cond) ->
               merge acc (Some (name, cond, prev_block @ block)) rest
           | Some (prev_name, prev_cond, prev_block) ->
               merge

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -793,3 +793,137 @@ let style ?value prop =
 
 let scroll_state name value =
   Scroll_state { query = State { name; value }; uppercase = false }
+
+(* ===== Canonical form ===== *)
+
+(* [normalize] is the one place that decides which spellings name one container
+   query, and its invariant runs one way only:
+
+   normalize a = normalize b => a and b select the same containers
+
+   Nothing promises the converse, and nothing should: two equivalent queries may
+   normalise apart, which costs a merge and never correctness. So every rewrite
+   below is one of the spec's own equivalences, never a heuristic. *)
+
+(* CSS Conditional Rules 5 sec. 6.1: a [<size-feature>] is spelled like a media
+   feature, so the [min-] prefix, the value-first bound and the two interval
+   directions are the Media Queries 4 sec. 2.4.3 and sec. 2.4.4 equivalences
+   here too. [Media.normalize] owns that fold; the [Min_width_*] shorthands are
+   cascade's compact spelling of [(min-width: V)], so they enter it as that
+   feature rather than being folded a second way. *)
+let min_width l : Media.t =
+  Media.Cond
+    (Media.Feature (Media.Plain (Media.Min Media.Width, Media.Length l)))
+
+(* CSS Syntax 3 sec. 5.5.6 consumes a declaration by discarding the whitespace
+   after the colon and removing the trailing whitespace tokens, so a
+   [<style-feature-plain>] means the same however much space the source left
+   around its value. A [<style-range>] carries no whitespace at all: the parser
+   strips it before splitting on the comparison. *)
+let rec normalize_style_query (q : style_query) : style_query =
+  match q with
+  | Declaration { name; value } ->
+      let value' = trim_components value in
+      if value' == value then q else Declaration { name; value = value' }
+  | All (a, b) ->
+      let a' = normalize_style_query a and b' = normalize_style_query b in
+      if a' == a && b' == b then q else All (a', b')
+  | Any (a, b) ->
+      let a' = normalize_style_query a and b' = normalize_style_query b in
+      if a' == a && b' == b then q else Any (a', b')
+  | Neg a ->
+      let a' = normalize_style_query a in
+      if a' == a then q else Neg a'
+  | Boolean _ | Range _ -> q
+
+(* Rebuild only what changed, as [lower_for_minify] does: [equal] runs this on
+   both sides of every merge test, and the queries it is asked about are usually
+   already normal. *)
+let rec normalize (c : t) : t =
+  match c with
+  | Min_width_rem rem -> Feature_query (Media.normalize (min_width (Rem rem)))
+  | Min_width_px px ->
+      Feature_query (Media.normalize (min_width (Px (float_of_int px))))
+  | Feature_query q ->
+      let q' = Media.normalize q in
+      if q' == q then c else Feature_query q'
+  | Named (name, cond) ->
+      let cond' = normalize cond in
+      if cond' == cond then c else Named (name, cond')
+  (* CSS Values 4 sec. 9: function names are ASCII case-insensitive, so the
+     [STYLE(] / [SCROLL-STATE(] spelling the AST keeps for round-trip says
+     nothing about which query this is. *)
+  | Style { query; uppercase } ->
+      let query' = normalize_style_query query in
+      if query' == query && not uppercase then c
+      else Style { query = query'; uppercase = false }
+  | Scroll_state { query; uppercase } ->
+      if not uppercase then c else Scroll_state { query; uppercase = false }
+  | And (a, b) ->
+      let a' = normalize a and b' = normalize b in
+      if a' == a && b' == b then c else And (a', b')
+  | Or (a, b) ->
+      let a' = normalize a and b' = normalize b in
+      if a' == a && b' == b then c else Or (a', b')
+  | Not a ->
+      let a' = normalize a in
+      if a' == a then c else Not a'
+
+(* Written out rather than left to the structural operators: [equal] is the gate
+   on block merging, and a comparison that walks a runtime representation is how
+   a spelling difference becomes a merge. *)
+let equal_components (a : component_values) b = List.equal Component.equal a b
+
+let equal_range_operator (a : range_operator) b =
+  match (a, b) with
+  | Lt, Lt | Lte, Lte | Gt, Gt | Gte, Gte -> true
+  | (Lt | Lte | Gt | Gte), _ -> false
+
+let equal_style_range (a : style_range) b =
+  String.equal a.name b.name
+  && equal_range_operator a.lower_op b.lower_op
+  && equal_range_operator a.upper_op b.upper_op
+  && equal_components a.lower b.lower
+  && equal_components a.upper b.upper
+
+let rec equal_style_query (a : style_query) b =
+  match (a, b) with
+  | Boolean a, Boolean b -> String.equal a b
+  | Declaration a, Declaration b ->
+      String.equal a.name b.name && equal_components a.value b.value
+  | Range a, Range b -> equal_style_range a b
+  | All (a1, b1), All (a2, b2) | Any (a1, b1), Any (a2, b2) ->
+      equal_style_query a1 a2 && equal_style_query b1 b2
+  | Neg a, Neg b -> equal_style_query a b
+  | (Boolean _ | Declaration _ | Range _ | All _ | Any _ | Neg _), _ -> false
+
+let rec equal_scroll_state_query (a : scroll_state_query) b =
+  match (a, b) with
+  | State a, State b ->
+      String.equal a.name b.name && String.equal a.value b.value
+  | Both (a1, b1), Both (a2, b2) | Either (a1, b1), Either (a2, b2) ->
+      equal_scroll_state_query a1 a2 && equal_scroll_state_query b1 b2
+  | Negated a, Negated b -> equal_scroll_state_query a b
+  | (State _ | Both _ | Either _ | Negated _), _ -> false
+
+(* A [<container-name>] is a [<custom-ident>] (Conditional Rules 5 sec. 5.4), so
+   it is compared by the name the parser unescaped, not by how it was
+   spelled. *)
+let rec equal_normalized (a : t) b =
+  match (a, b) with
+  | Min_width_rem a, Min_width_rem b -> Float.equal a b
+  | Min_width_px a, Min_width_px b -> Int.equal a b
+  | Named (n1, c1), Named (n2, c2) ->
+      String.equal n1 n2 && equal_normalized c1 c2
+  | Style a, Style b -> equal_style_query a.query b.query
+  | Scroll_state a, Scroll_state b -> equal_scroll_state_query a.query b.query
+  | And (a1, b1), And (a2, b2) | Or (a1, b1), Or (a2, b2) ->
+      equal_normalized a1 a2 && equal_normalized b1 b2
+  | Not a, Not b -> equal_normalized a b
+  | Feature_query a, Feature_query b -> Media.equal a b
+  | ( ( Min_width_rem _ | Min_width_px _ | Named _ | Style _ | Scroll_state _
+      | And _ | Or _ | Not _ | Feature_query _ ),
+      _ ) ->
+      false
+
+let equal a b = equal_normalized (normalize a) (normalize b)

--- a/lib/container.mli
+++ b/lib/container.mli
@@ -108,8 +108,48 @@ val scroll_state : string -> string -> t
 (** [scroll_state prop value] is the canonical lowercase
     {!constructor-Scroll_state} query, matching [scroll-state(prop: value)]. *)
 
+val normalize : t -> t
+(** [normalize t] rewrites [t] into the spelling its equivalence class is
+    compared by. The invariant runs one way: when [normalize a] and
+    [normalize b] are equal, [a] and [b] select the same query containers.
+
+    The converse is neither promised nor intended: two equivalent queries may
+    normalise apart, which costs a merge and never correctness. So every rewrite
+    is one of the spec's own equivalences. A [<size-feature>] is spelled like a
+    media feature (CSS Conditional Rules 5 sec. 6.1), so it takes
+    {!Media.normalize}: a [min-] or [max-] prefix on a range feature becomes the
+    [>=] or [<=] comparison, a value-first bound becomes name-first (Media
+    Queries 4 sec. 2.4.4 and sec. 2.4.3), and a descending interval becomes
+    ascending. {!constructor-Min_width_rem} and {!constructor-Min_width_px} are
+    cascade's compact spelling of [(min-width: V)] and enter that fold as the
+    feature they spell. A [style()] or [scroll-state()] function name loses the
+    case the source wrote it in (CSS Values 4 sec. 9), and a
+    [<style-feature-plain>] loses the whitespace around its value (CSS Syntax 3
+    sec. 5.5.6).
+
+    Completeness is a separate property, and it stops there. Equivalences
+    [normalize] leaves apart: a [style()] property name spelled in another case;
+    two [style()] values that compute alike but tokenise apart, such as [red]
+    against [#f00]; reassociating or reordering [and] and [or]; De Morgan pairs;
+    two bounds on one feature against the written interval; a plain feature
+    against its [=] comparison; and anything inside a [<general-enclosed>],
+    whose text is compared verbatim. Each of those costs a merge, never
+    correctness. *)
+
 val compare : t -> t -> int
-(** [compare t1 t2] compares two container conditions. *)
+(** [compare t1 t2] compares two container conditions. Ordering only needs to be
+    deterministic, so a size feature that ties on every ordinal key reaches
+    {!Media.compare}'s serialised tiebreak. That makes [compare a b = 0] a
+    different question from {!equal}, which reads structure: each says yes where
+    the other says no. Sort with [compare], decide sameness with {!equal}. *)
+
+val equal : t -> t -> bool
+(** [equal a b] is structural equality on {!normalize}d conditions, so it is
+    true only when [a] and [b] select the same query containers. It gates block
+    merging and therefore never answers on serialised text: an unknown container
+    feature spelled as one escaped ident is not the size feature whose
+    characters it repeats, and a [<general-enclosed>] equals only the same text.
+*)
 
 val compare_scroll_state_query : scroll_state_query -> scroll_state_query -> int
 (** [compare_scroll_state_query a b] totally orders scroll-state queries. *)

--- a/test/test_block.ml
+++ b/test/test_block.ml
@@ -114,6 +114,38 @@ let test_merge_containers_keeps_distinct_conditions () =
     (List.length
        (Block.merge_consecutive_containers ~optimize_merged_block:id stmts))
 
+(* Conditional Rules 5 sec. 5.4: a [<container-query>] that names an unknown
+   container feature selects no query container, so it is never true.
+   [@container (inline-size\ \>\=\ 10px)] is one escaped ident, a boolean
+   feature named [inline-size >= 10px], while [@container (inline-size >= 10px)]
+   is the size range that inline-size containers are made for. The two spell the
+   same characters, and merging them applies declarations the input never let
+   match. Same shape as the escaped [@layer] dot and the escaped [@media] type
+   above. *)
+let test_merge_containers_keeps_an_escaped_feature_name_apart () =
+  let css =
+    {|@container (inline-size\ \>\=\ 10px){.x{color:red}}@container (inline-size>=10px){.y{color:blue}}|}
+  in
+  Alcotest.(check int)
+    "an unknown container feature is not merged into a real one" 2
+    (List.length
+       (Block.merge_consecutive_containers ~optimize_merged_block:id (block css)))
+
+(* Conditional Rules 5 sec. 6.1 gives a [<size-feature>] the media feature
+   syntax, so Media Queries 4 sec. 2.4.4 applies: a [min-] prefix on a range
+   feature is the [>=] comparison. These two blocks carry one bound in two
+   spellings and the cascade evaluates them identically. *)
+let test_merge_containers_joins_two_spellings_of_one_bound () =
+  let stmts =
+    block
+      "@container (min-width:10px){.x{color:red}}@container \
+       (width>=10px){.y{color:blue}}"
+  in
+  Alcotest.(check int)
+    "two spellings of one bound merge into one block" 1
+    (List.length
+       (Block.merge_consecutive_containers ~optimize_merged_block:id stmts))
+
 let test_drop_empty_rules () =
   let stmts = block ".a{}.b{color:red}.c{}" in
   let out = render (Block.drop_empty_rules stmts) in
@@ -252,6 +284,10 @@ let suite =
         test_merge_containers_by_condition;
       Alcotest.test_case "keep distinct-condition @container" `Quick
         test_merge_containers_keeps_distinct_conditions;
+      Alcotest.test_case "keep an escaped container feature out of a merge"
+        `Quick test_merge_containers_keeps_an_escaped_feature_name_apart;
+      Alcotest.test_case "merge two spellings of one container bound" `Quick
+        test_merge_containers_joins_two_spellings_of_one_bound;
       Alcotest.test_case "drop empty rules" `Quick test_drop_empty_rules;
       Alcotest.test_case "drop empty @-moz-document" `Quick
         test_drop_empty_moz_document;

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -252,6 +252,131 @@ let spec_container_unitless_zero_length () =
   check "range" "(width >= 0)" "(width >= 0px)";
   rejects_invalid "(min-width: 1)"
 
+(* CSS Conditional Rules 5 sec. 6.1 "Size Container Features": "The syntax of a
+   <size-feature> is the same as for a media feature", so Media Queries 4 sec.
+   2.4.4 "Using 'min-' and 'max-' Prefixes On Range Features" reaches @container
+   too: a [min-] prefix on a range feature is the [>=] comparison and [max-] is
+   [<=]. Sec. 2.4.3 adds the value-first spelling and the two interval
+   directions to the same class. *)
+let equal_ignores_bound_spelling () =
+  let open Css.Container in
+  let same name a b =
+    Alcotest.(check bool) name true (equal (of_string a) (of_string b))
+  in
+  same "min- prefix is the >= comparison" "(min-width: 10px)" "(width >= 10px)";
+  same "min- prefix against the value-first spelling" "(min-width: 10px)"
+    "(10px <= width)";
+  same "the rem shorthand is the same bound" "(min-width: 24rem)"
+    "(width >= 24rem)";
+  same "max- prefix is the <= comparison" "(max-inline-size: 10px)"
+    "(inline-size <= 10px)";
+  same "value-first strict range" "(10px < inline-size)" "(inline-size > 10px)";
+  same "descending interval" "(20em >= inline-size >= 10em)"
+    "(10em <= inline-size <= 20em)";
+  (* An inclusive bound is not the strict one: normalising the spelling must not
+     normalise away the comparison. *)
+  let differ name a b =
+    Alcotest.(check bool) name false (equal (of_string a) (of_string b))
+  in
+  differ "inclusive is not strict" "(min-width: 10px)" "(width > 10px)";
+  differ "a lower bound is not an upper bound" "(min-width: 10px)"
+    "(max-width: 10px)";
+  differ "the bound value still counts" "(min-width: 10px)" "(min-width: 11px)";
+  differ "the axis still counts" "(min-width: 10px)" "(min-height: 10px)"
+
+(* Conditional Rules 5 sec. 5.4: a <container-query> naming an unknown container
+   feature selects no query container, so it is never true. [(inline-size\ \>\=\
+   10px)] is one escaped ident, a boolean feature with that name, and it spells
+   the same characters as the size range [(inline-size >= 10px)]. They share a
+   serialisation, which is why [equal] cannot be an equality on serialised
+   text. *)
+let equal_separates_an_escaped_feature_name () =
+  let open Css.Container in
+  let escaped = of_string {|(inline-size\ \>\=\ 10px)|} in
+  let real = of_string "(inline-size >= 10px)" in
+  Alcotest.(check string)
+    "the witness is a serialisation collision" (to_string real)
+    (to_string escaped);
+  Alcotest.(check bool)
+    "an unknown container feature is not the size range it spells" false
+    (equal escaped real);
+  Alcotest.(check bool)
+    "and it still equals itself" true
+    (equal escaped (of_string {|(inline-size\ \>\=\ 10px)|}))
+
+(* CSS Values 4 sec. 9: function names are ASCII case-insensitive, so the case
+   the AST keeps for round-trip is spelling. CSS Syntax 3 sec. 5.5.6 consumes a
+   declaration without the whitespace around its value, so that is spelling
+   too. *)
+let equal_ignores_function_spelling () =
+  let open Css.Container in
+  let same name a b =
+    Alcotest.(check bool) name true (equal (of_string a) (of_string b))
+  in
+  same "an uppercase style() is the same query" "STYLE(--x)" "style(--x)";
+  same "an uppercase scroll-state() is the same query"
+    "SCROLL-STATE(stuck: top)" "scroll-state(stuck: top)";
+  same "the space after the colon is not the value" "style(--x: 1)"
+    "style(--x:1)";
+  let differ name a b =
+    Alcotest.(check bool) name false (equal (of_string a) (of_string b))
+  in
+  differ "a different style() value is a different query" "style(--x: 1)"
+    "style(--x: 2)";
+  differ "a different custom property is a different query" "style(--x: 1)"
+    "style(--y: 1)";
+  differ "a different scroll-state is a different query"
+    "scroll-state(stuck: top)" "scroll-state(stuck: bottom)"
+
+(* Conditional Rules 5 sec. 5.4: "As with media queries, <general-enclosed>
+   evaluates to unknown". An opaque condition carries no structure to reason
+   over, so it equals an identical spelling and nothing else. Reflexivity is not
+   optional: [equal] is an equality, and the merge scan reads a query against
+   itself. *)
+let equal_on_opaque_conditions () =
+  let open Css.Container in
+  let opaque = of_string "theme(static)" in
+  Alcotest.(check bool)
+    "an opaque condition equals itself" true
+    (equal opaque (of_string "theme(static)"));
+  Alcotest.(check bool)
+    "the parentheses around it are not part of it" true
+    (equal opaque (of_string "(theme(static))"));
+  Alcotest.(check bool)
+    "an opaque condition does not equal a different one" false
+    (equal opaque (of_string "theme(dynamic)"))
+
+(* A normal form is already normal, and it is still the query it came from:
+   reparsing what [normalize] printed lands back on the same normal form. *)
+let normalize_is_idempotent () =
+  let open Css.Container in
+  List.iter
+    (fun input ->
+      let once = normalize (of_string input) in
+      Alcotest.(check string)
+        ("normalize is idempotent: " ^ input)
+        (to_string once)
+        (to_string (normalize once));
+      Alcotest.(check bool)
+        ("a normal form reparses to itself: " ^ input)
+        true
+        (equal once (of_string (to_string once))))
+    [
+      "(min-width: 10px)";
+      "(min-width: 24rem)";
+      "(width >= 10px)";
+      "(10px <= inline-size)";
+      "(20em >= inline-size >= 10em)";
+      "(orientation: landscape)";
+      "not (inline-size > 30em)";
+      "(inline-size > 30em) and (block-size > 10em)";
+      "card (inline-size > 30em)";
+      "style(--x)";
+      "STYLE(--x: 1)";
+      "scroll-state(stuck: top)";
+      "theme(static)";
+    ]
+
 let tests =
   Alcotest.
     [
@@ -275,6 +400,14 @@ let tests =
         spec_container_invalid_vectors;
       test_case "spec container unitless zero length" `Quick
         spec_container_unitless_zero_length;
+      test_case "equal ignores bound spelling" `Quick
+        equal_ignores_bound_spelling;
+      test_case "equal separates an escaped feature name" `Quick
+        equal_separates_an_escaped_feature_name;
+      test_case "equal ignores function spelling" `Quick
+        equal_ignores_function_spelling;
+      test_case "equal on opaque conditions" `Quick equal_on_opaque_conditions;
+      test_case "normalize is idempotent" `Quick normalize_is_idempotent;
     ]
 
 let suite = ("container", tests)


### PR DESCRIPTION
`@container (inline-size\ \>\=\ 10px)` is one escaped ident naming an unknown container feature, which never matches, but it serialises exactly like `@container (inline-size >= 10px)`, and `--minify` merged the two blocks so the first one's declarations started applying to every container 10px or wider. This PR adds `Css.Container.equal` and `Css.Container.normalize` and moves the `@container` merge gate onto them.

`compare` keeps its serialising tiebreak, so sort order does not move; the size-feature arm now reaches the structural `Media.equal` from #516, which is what makes `(min-width: 700px)` and `(width >= 700px)` merge as one bound.