### PR TITLE
inline: keep a custom declaration’s layer and metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -483,6 +483,11 @@ answers.
 
 ### Custom properties
 
+- A cascade layer and caller metadata on a custom property survive
+  `Css.inline_vars`. Both belong to the declaration rather than to its value,
+  and the two rewrites that read a custom value back - canonicalising a value
+  that is one colour, and folding a `var()` that value references - rebuilt the
+  declaration from the value alone (#520)
 - A `page-break-before`, `page-break-after` or `page-break-inside` declaration
   survives `Css.inline_vars` as itself. Substituting a `var()` rebuilt the
   declaration from its minified name, which for these three is the `break-*`

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2413,11 +2413,31 @@ let read t =
   | Some d -> d
   | None -> Cursor.err_expected t "declaration"
 
+(* A cascade layer and caller metadata belong to the declaration, not to its
+   value, so a value read back from text starts without them. A value-only
+   rewrite copies over what [from] holds, the way [map_custom_value] keeps them
+   when it rewrites in place. *)
+let keep_custom_fields ~from decl =
+  match decl with
+  | Declaration
+      {
+        property = Custom_property _ as property;
+        value = Custom_value cv;
+        important;
+        _;
+      } ->
+      let layer = custom_declaration_layer from in
+      let meta = meta_of_declaration from in
+      v ~important property (Custom_value { cv with layer; meta })
+  | Declaration _ | Theme_guarded _ -> decl
+
 let with_value decl value =
   let important = if is_important decl then "!important" else "" in
   let tail () = Cursor.of_string (String.concat "" [ value; important ]) in
   match property_key decl with
-  | Key (Custom_property name) -> read_custom_value_declaration (tail ()) name
+  | Key (Custom_property name) ->
+      keep_custom_fields ~from:decl
+        (read_custom_value_declaration (tail ()) name)
   | Key (Unknown_property name) ->
       (* An unknown property is its name, and a substituted value may now be one
          a typed reader accepts, so read the pair back whole: that is the step

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1036,23 +1036,22 @@ let cyclic_live_customs ~consumers ~customs =
         customs)
     initially_live
 
+(* Write a value that is one colour back in its canonical spelling.
+   [map_custom_value] rewrites the value in place, so the declaration keeps its
+   importance, its cascade layer, its metadata and any theme guard; rebuilding
+   from the name and the new text drops all four. *)
 let normalize_custom_value decl =
   match custom_name decl with
   | None -> decl
-  | Some name -> (
+  | Some _ -> (
       let value = Declaration.string_of_value ~minify:true decl in
-      let important = Declaration.is_important decl in
       try
         let cursor = Cursor.of_string value in
         let color = Values.read_color cursor in
         Cursor.ws cursor;
         Cursor.expect_eof cursor;
-        match
-          rebuild_custom name (Pp.to_string ~minify:true Values.pp_color color)
-        with
-        | None -> decl
-        | Some normalized ->
-            if important then Declaration.important normalized else normalized
+        let canonical = Pp.to_string ~minify:true Values.pp_color color in
+        Declaration.map_custom_value (fun _ -> canonical) decl
       with Cursor.Parse_error _ -> decl)
 
 let custom_is_live ~keep ~live_set ~at_path ~selector name =

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -351,6 +351,70 @@ let test_inline_layer_winner () =
     ":root{--c:red}.dark{--c:blue}.x{color:var(--c)}"
     ":root{--c:red}.dark{--c:blue}.x{color:var(--c)}"
 
+(* A custom declaration carries a cascade layer and caller metadata beside its
+   value, and both are cascade- and caller-significant. [inline_vars] rewrites
+   the value of a custom property it keeps - it canonicalises a value that is
+   one colour, and folds the variables that value references - so every rewrite
+   has to hand the layer, the metadata and [!important] on. *)
+let test_inline_keeps_what_a_custom_declaration_carries () =
+  let inject, project = Css.meta () in
+  let kept ?(extra = []) name decl =
+    let stylesheet =
+      Css.v [ Css.rule ~selector:(Css.Selector.class_ "a") (extra @ [ decl ]) ]
+    in
+    match
+      List.concat_map Css.Stylesheet.statement_declarations
+        (Css.inline_vars ~keep_vars:[ "--x" ] stylesheet)
+    with
+    | [ d ] -> d
+    | ds ->
+        Alcotest.failf "%s: expected one declaration, got %d" name
+          (List.length ds)
+  in
+  let layer d = Css.custom_declaration_layer d in
+  let meta d = Option.bind (Css.meta_of_declaration d) project in
+  (* A value that is one colour is the value [inline_vars] canonicalises. *)
+  let red : Css.color = Css.Named Css.Values.Red in
+  let layered, _ = Css.var ~layer:"theme" "x" Css.Color red in
+  let d = kept "layer" layered in
+  Alcotest.(check (option string)) "layer survives" (Some "theme") (layer d);
+  let tagged, _ = Css.var ~meta:(inject "tag") "x" Css.Color red in
+  let d = kept "meta" tagged in
+  Alcotest.(check (option string)) "meta survives" (Some "tag") (meta d);
+  let both, _ = Css.var ~layer:"theme" ~meta:(inject "tag") "x" Css.Color red in
+  let d = kept "layer and meta" both in
+  Alcotest.(check (option string))
+    "layer survives beside meta" (Some "theme") (layer d);
+  Alcotest.(check (option string))
+    "meta survives beside layer" (Some "tag") (meta d);
+  (* Importance already travels; it must keep travelling. *)
+  let d = kept "important" (Css.important (Css.custom_property "--x" "red")) in
+  Alcotest.(check bool)
+    "important survives" true
+    (Css.Declaration.is_important d);
+  Alcotest.(check string)
+    "important is written back" "--x:red!important"
+    (Css.Declaration.to_string ~minify:true d);
+  (* A declaration carrying none of the three is left exactly as it was. *)
+  let d = kept "plain" (Css.custom_property "--x" "red") in
+  Alcotest.(check (option string)) "no layer appears" None (layer d);
+  Alcotest.(check (option string)) "no meta appears" None (meta d);
+  Alcotest.(check bool) "not important" false (Css.Declaration.is_important d);
+  Alcotest.(check string)
+    "plain value is unchanged" "--x:red"
+    (Css.Declaration.to_string ~minify:true d);
+  (* Folding a variable the kept value references is the other rewrite. *)
+  let d =
+    kept "folds a reference"
+      ~extra:[ Css.custom_property "--y" "1px solid" ]
+      (Css.custom_property ~layer:"theme" "--x" "var(--y)")
+  in
+  Alcotest.(check string)
+    "the reference folded" "--x:1px solid"
+    (Css.Declaration.to_string ~minify:true d);
+  Alcotest.(check (option string))
+    "layer survives the fold" (Some "theme") (layer d)
+
 (* The closed-world cleanup that follows substitution reaches inside a rule: CSS
    nesting puts an [@layer] and a [@property] registration there, and a cleanup
    that stops at the top level leaves the same sheet half cleaned. The [var()]
@@ -687,6 +751,8 @@ let suite =
       Alcotest.test_case
         "inline vars fold a layer-decided override to its winner" `Quick
         test_inline_layer_winner;
+      Alcotest.test_case "inline vars keep what a custom declaration carries"
+        `Quick test_inline_keeps_what_a_custom_declaration_carries;
       Alcotest.test_case "inline vars clean up inside a rule too" `Quick
         test_inline_cleanup_inside_a_rule;
       Alcotest.test_case


### PR DESCRIPTION
Preserve a custom declaration’s original cascade layer and source metadata when its value is inlined.

Add a regression test covering both properties.