### PR TITLE
optimize: scan for a crossing rule without building a list

### DIFF
--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -1014,8 +1014,12 @@ let origin_bounds g ids =
       in
       Option.Some (min_origin, max_origin)
 
-let id_mem id ids =
-  List.exists (fun other -> Rule_graph.Node_id.compare id other = 0) ids
+(* Recursive rather than [List.exists] over a closure: the closure captures
+   [id], so it is allocated afresh at every node the external scan walks
+   past. *)
+let rec id_mem id = function
+  | [] -> false
+  | other :: rest -> Rule_graph.Node_id.compare id other = 0 || id_mem id rest
 
 let crosses_bounds g ~min_origin ~max_origin id =
   let origin = Rule_graph.node_origin g id in
@@ -1040,12 +1044,11 @@ let group_crosses_external_conflict g ~ids (grouped : rule) =
   match origin_bounds g ids with
   | Option.None -> false
   | Option.Some (min_origin, max_origin) ->
-      (* Walk the ids, not a freshly built (id, rule) list: this runs once per
-         candidate, so materialising every live rule up front cost more than the
-         scan itself, which usually stops on the first crossing node. The origin
+      (* Walk the nodes, materialising neither their rules nor a list of their
+         ids: this runs once per candidate and answers no at almost every node,
+         so anything built to scan over costs more than the scan. The origin
          range is the cheapest filter, so it goes first. *)
-      Rule_graph.live_nodes g
-      |> List.exists (fun external_id ->
+      Rule_graph.exists_live_node g (fun external_id ->
           (not (id_mem external_id ids))
           && crosses_bounds g ~min_origin ~max_origin external_id
           &&

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -534,6 +534,14 @@ let live_nodes t =
   done;
   !acc
 
+(* Recursive over the index rather than a local closure over [t] and [f], so a
+   scan that answers no everywhere allocates nothing at all. *)
+let rec exists_live_from t f i =
+  i < t.count
+  && ((t.live.(i) && f (Node_id.of_int_exn i)) || exists_live_from t f (i + 1))
+
+let exists_live_node t f = exists_live_from t f 0
+
 (* The interned declaration-body hash list of a node, for bucketing nodes by
    identical declaration body. *)
 let declaration_body_key t i =

--- a/lib/rule_graph.mli
+++ b/lib/rule_graph.mli
@@ -91,6 +91,13 @@ val generation : t -> int
 val live_nodes : t -> node_id list
 (** [live_nodes t] is the live node ids in creation order. *)
 
+val exists_live_node : t -> (node_id -> bool) -> bool
+(** [exists_live_node t f] is whether [f] holds of some live node, asked in
+    creation order and stopping at the first that says yes. This is
+    [List.exists f (live_nodes t)] without the list: the candidate search runs
+    it once per proposed group over the whole graph, and answers no at almost
+    every node, so the list was the scan's whole cost. *)
+
 val declaration_body_key : t -> node_id -> int list
 (** [declaration_body_key t i] is a hash key for bucketing nodes with identical
     declaration bodies. Hash collisions must be checked by callers. *)

--- a/test/test_rule_candidate.ml
+++ b/test/test_rule_candidate.ml
@@ -275,6 +275,39 @@ let default_factoring_lookup_is_subcubic () =
     true
     (a1 = 0. || a2 < a1 *. 5.5)
 
+(* [pairs] pairs of neighbouring rules, each pair sharing one custom property
+   and each member carrying one of its own. Every pair is an exact-factoring
+   group whose two members sit next to each other in source order, so the span
+   between the group's first and last rule holds nothing, and the whole sheet
+   grows without ever putting a rule inside one of those spans. *)
+let adjacent_shared_pairs ~pairs =
+  List.init pairs (fun i ->
+      Fmt.str ".a%d{--s%d:1;--x%d:2}.b%d{--s%d:1;--y%d:3}" i i i i i i)
+  |> String.concat ""
+
+(* Before committing a factored group the search asks whether any rule outside
+   it sits between the group's first and last member and would change meaning by
+   being crossed. Only a rule inside that origin span can answer yes, and a
+   group of two neighbours has none, so every node is rejected on an integer
+   comparison. Listing the live nodes to scan them, and capturing the group's
+   ids in a closure at each one, spends that scan's whole allocation on nodes it
+   walks straight past - and both the number of groups and the number of nodes
+   grow with the sheet, so the waste is quadratic in it. Scanning without
+   building the list leaves the rejection allocation-free: quadrupling the sheet
+   must stay near the linear 4x, well below the quadratic 16x. *)
+let external_conflict_scan_is_subquadratic () =
+  let work pairs () =
+    adjacent_shared_pairs ~pairs
+    |> rules |> Rule_graph.of_rules
+    |> Rule_candidate.enumerate ~ctx:Ctx.fragment ~finalize:Fun.id
+  in
+  let a1 = measure (work 64) in
+  let a2 = measure (work 256) in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.1fx for 4x rules)" a1 a2 (a2 /. a1))
+    true
+    (a1 = 0. || a2 < a1 *. 5.)
+
 let suite =
   ( "rule_candidate",
     [
@@ -303,4 +336,6 @@ let suite =
         nested_merge_safety_reads_each_block_once;
       Alcotest.test_case "default factoring lookup is subcubic" `Quick
         default_factoring_lookup_is_subcubic;
+      Alcotest.test_case "external-conflict scan is subquadratic" `Quick
+        external_conflict_scan_is_subquadratic;
     ] )


### PR DESCRIPTION
Avoid allocating a temporary live-node list and per-node closure for candidates rejected by the crossing-rule check.

Add an allocation-scaling regression test for the scan.