### PR TITLE
optimize: reject doomed default groups before pruning

### DIFF
--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -1452,9 +1452,39 @@ let default_produce g ~keys ~entries ~exact_common ~group_decls members =
         in
         Option.Some (grouped :: leftovers)
 
+(* Pruning keeps a member only two ways: everything it writes disappears into
+   the group body, or the body hands it back at least as many bytes as naming
+   its selector costs. Both are bounded by the provider's own declarations. The
+   body is drawn from them - [exact_common] filters the provider's list and
+   every default is the provider's declaration for that key - and every
+   declaration the body hands a member is one the member already writes, since
+   [exact_common] holds only declarations common to all members and a removed
+   default is the member's own value. So a member that writes something the
+   provider does not, and whose selector costs more than the provider
+   declarations it shares, is pruned whichever entries survive the safety
+   filters. When no member past the provider clears that bound the group cannot
+   keep two, and it is dropped before the four cross-member scans that would
+   otherwise reach the same answer. The bound is one-sided: it lets through
+   groups that pruning still rejects, never the reverse, so the candidates are
+   the same either way. *)
+let member_may_survive_pruning provider_decls (member : default_member) =
+  List.for_all
+    (fun decl -> decl_mem decl provider_decls)
+    member.rule.declarations
+  || selector_size member.rule + 1
+     <= decls_inline_cost
+          (List.filter
+             (fun decl -> decl_mem decl member.rule.declarations)
+             provider_decls)
+
+let default_group_can_keep_two provider members =
+  List.exists (member_may_survive_pruning provider.rule.declarations) members
+
 let default_candidate_from_members ?size_cache ~finalize g ~seen members =
   match members with
   | [] | [ _ ] -> Option.None
+  | first :: rest when not (default_group_can_keep_two first rest) ->
+      Option.None
   | first :: _ -> (
       let entries =
         common_property_keys members

--- a/test/test_rule_candidate.ml
+++ b/test/test_rule_candidate.ml
@@ -308,6 +308,38 @@ let external_conflict_scan_is_subquadratic () =
     true
     (a1 = 0. || a2 < a1 *. 5.)
 
+(* The first member provides the only default. Every later member writes an
+   extra declaration that the provider does not, and its selector costs more
+   than the provider declaration it shares, so pruning must discard it. The
+   group can therefore never keep two members. A same-sized group whose members
+   all repeat the provider's declaration is the control: those members can
+   survive and the full candidate checks still have to run. Rejecting the doomed
+   group before constructing entries and leftovers keeps its allocation well
+   below the control. *)
+let default_factoring_rejects_a_doomed_group_early () =
+  let doomed =
+    List.init 8 (fun i ->
+        if i = 0 then ".p{color:red}"
+        else
+          Fmt.str
+            ".selector-that-cannot-pay-for-the-group-%d{color:blue;--own-%d:1}"
+            i i)
+    |> String.concat "" |> rules |> Rule_graph.of_rules
+  in
+  let survivable =
+    List.init 8 (fun i -> Fmt.str ".s%d{color:red}" i)
+    |> String.concat "" |> rules |> Rule_graph.of_rules
+  in
+  let work graph () =
+    Rule_candidate.enumerate ~ctx:Ctx.fragment ~finalize:Fun.id graph
+  in
+  let rejected = measure (work doomed) in
+  let control = measure (work survivable) in
+  Alcotest.(check bool)
+    (Fmt.str "doomed group %.0f words, survivable control %.0f" rejected control)
+    true
+    (control = 0. || rejected < control *. 0.4)
+
 let suite =
   ( "rule_candidate",
     [
@@ -338,4 +370,6 @@ let suite =
         default_factoring_lookup_is_subcubic;
       Alcotest.test_case "external-conflict scan is subquadratic" `Quick
         external_conflict_scan_is_subquadratic;
+      Alcotest.test_case "default factoring rejects a doomed group early" `Quick
+        default_factoring_rejects_a_doomed_group_early;
     ] )


### PR DESCRIPTION
Reject groups that cannot retain a second member before constructing entries and leftovers that pruning would immediately discard.

Add a regression test that pins the reduced allocation cost.