### PR TITLE
rule_graph: skip identical declarations in source-order indexing

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -47,6 +47,17 @@ current plugin through `postcss-cli` instead.
 RUNS=5 CASCADE=_build/default/bin/main.exe bench/minifier_comparison.sh
 ```
 
+## `source-order/bench_source_order.ml` -- rule-graph allocation scaling
+
+```bash
+dune exec bench/source-order/bench_source_order.exe
+```
+
+Reports allocated words per graph build while doubling same-specificity rule
+sets. Its four shapes separate distinct declarations from identical ones and
+class selectors from ID and type selectors, making regressions in source-order
+candidate indexing visible without including parse or startup allocation.
+
 ## Corpus
 
 The SatCSS corpus (Hague, Lin, Hong; TOPLAS 2019) is regenerated locally rather

--- a/bench/source-order/bench_source_order.ml
+++ b/bench/source-order/bench_source_order.ml
@@ -1,0 +1,49 @@
+open Cascade
+
+let rules_of s =
+  match Css.of_string ~strict:false s with
+  | Ok p ->
+      List.filter_map
+        (function Stylesheet.Rule r -> Some r | _ -> None)
+        p.Css.stylesheet
+  | Error _ -> failwith "parse"
+
+let shape name n =
+  let b = Buffer.create (n * 32) in
+  for i = 0 to n - 1 do
+    (match name with
+      | "A" -> Fmt.str ".c%d{color:rgb(%d,%d,0)}" i (i mod 256) (i / 256)
+      | "B" -> Fmt.str ".c%d{color:red}" i
+      | "C" -> Fmt.str "#i%d{color:rgb(%d,%d,0)}" i (i mod 256) (i / 256)
+      | "D" -> Fmt.str "e%d{color:rgb(%d,%d,0)}" i (i mod 256) (i / 256)
+      | _ -> assert false)
+    |> Buffer.add_string b
+  done;
+  rules_of (Buffer.contents b)
+
+(* Differenced across two iteration counts, so the parse and the one-off startup
+   cancel out. Three builds are enough here: allocation is deterministic, while
+   the distinct-declaration controls are intentionally quadratic. *)
+let words rules =
+  let run k =
+    Gc.full_major ();
+    let w0 = Gc.minor_words () in
+    for _ = 1 to k do
+      ignore (Sys.opaque_identity (Rule_graph.of_rules rules))
+    done;
+    Gc.minor_words () -. w0
+  in
+  let w1 = run 1 in
+  let w3 = run 3 in
+  (w3 -. w1) /. 2.
+
+let () =
+  print_endline "shape n words_per_build";
+  List.iter
+    (fun s ->
+      List.iter
+        (fun n ->
+          let rules = shape s n in
+          Fmt.pr "%s %d %.0f@." s n (words rules))
+        [ 500; 1000; 2000; 4000 ])
+    [ "A"; "B"; "C"; "D" ]

--- a/bench/source-order/dune
+++ b/bench/source-order/dune
@@ -1,0 +1,3 @@
+(executable
+ (name bench_source_order)
+ (libraries cascade fmt))

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -403,6 +403,107 @@ let collect_string_bucket bucket key stamp seen acc =
   |> Option.value ~default:[]
   |> add_candidates stamp seen acc
 
+(* The declaration that writes a key is the third level of the source-order
+   index, under the overlap key and the specificity. Two rules writing the same
+   declaration for a key never constrain each other's order there - an identical
+   pair is its own winner wherever the two sit - so that (often large) group is
+   skipped whole instead of being walked and rejected pair by pair. The rewrite
+   path already reads its externals this way through [key_index]; specificity
+   stays the outer level so #468's partition still narrows first. *)
+type decl_groups = node_id list Decl_tbl.t
+
+let decl_spec_bucket bucket key =
+  match Overlap_key_table.find_opt bucket key with
+  | Option.Some inner -> inner
+  | Option.None ->
+      let inner = Spec_table.create 4 in
+      Overlap_key_table.replace bucket key inner;
+      inner
+
+let decl_groups inner spec : decl_groups =
+  match Spec_table.find_opt inner spec with
+  | Option.Some groups -> groups
+  | Option.None ->
+      let groups = Decl_tbl.create 4 in
+      Spec_table.replace inner spec groups;
+      groups
+
+let rec add_decl_specs inner decl value = function
+  | [] -> ()
+  | spec :: rest ->
+      let groups = decl_groups inner spec in
+      Decl_tbl.replace groups decl
+        (value :: Option.value ~default:[] (Decl_tbl.find_opt groups decl));
+      add_decl_specs inner decl value rest
+
+let add_decl_bucket bucket key specs decl value =
+  add_decl_specs (decl_spec_bucket bucket key) decl value specs
+
+(* Every group under [key] at one of [specs], minus the one writing [decl]. *)
+let rec collect_decl_specs inner decl specs stamp seen acc =
+  match specs with
+  | [] -> acc
+  | spec :: rest ->
+      let acc =
+        match Spec_table.find_opt inner spec with
+        | Option.None -> acc
+        | Option.Some groups ->
+            Decl_tbl.fold
+              (fun decl' ids acc ->
+                if Shorthand.same_minified_declaration decl decl' then acc
+                else add_candidates stamp seen acc ids)
+              groups acc
+      in
+      collect_decl_specs inner decl rest stamp seen acc
+
+let collect_decl_bucket bucket key decl specs stamp seen acc =
+  match Overlap_key_table.find_opt bucket key with
+  | Option.None -> acc
+  | Option.Some inner -> collect_decl_specs inner decl specs stamp seen acc
+
+(* A prior node whose own declaration is broad meets every key, so no single
+   declaration of the querying node can rule its group out. *)
+let rec collect_broad_specs inner specs stamp seen acc =
+  match specs with
+  | [] -> acc
+  | spec :: rest ->
+      let acc =
+        match Spec_table.find_opt inner spec with
+        | Option.None -> acc
+        | Option.Some groups ->
+            Decl_tbl.fold
+              (fun _ ids acc -> add_candidates stamp seen acc ids)
+              groups acc
+      in
+      collect_broad_specs inner rest stamp seen acc
+
+let collect_broad_bucket bucket specs stamp seen acc =
+  match Overlap_key_table.find_opt bucket Shorthand.broad_overlap_key with
+  | Option.None -> acc
+  | Option.Some inner -> collect_broad_specs inner specs stamp seen acc
+
+let rec collect_decl_keys bucket decl specs stamp seen acc = function
+  | [] -> acc
+  | key :: rest ->
+      collect_decl_keys bucket decl specs stamp seen
+        (collect_decl_bucket bucket key decl specs stamp seen acc)
+        rest
+
+let rec collect_decl_overlaps bucket specs stamp seen acc = function
+  | [] -> acc
+  | (ov : decl_overlap) :: rest ->
+      collect_decl_overlaps bucket specs stamp seen
+        (collect_decl_keys bucket ov.decl specs stamp seen acc ov.footprint)
+        rest
+
+let rec add_decl_overlaps bucket specs value = function
+  | [] -> ()
+  | (ov : decl_overlap) :: rest ->
+      List.iter
+        (fun key -> add_decl_bucket bucket key specs ov.decl value)
+        ov.footprint;
+      add_decl_overlaps bucket specs value rest
+
 let source_order_edges t =
   let n = t.count in
   let succ = Array.make n [] in
@@ -417,15 +518,17 @@ let source_order_edges t =
     let keys = t.overlap_keys.(j) in
     let specs = distinct_spec_keys [] t.specificities.(j) in
     let candidates =
+      (* A node carrying the broad key meets every prior declaration, so its own
+         keys index nothing: only specificity narrows it. *)
       if overlap_key_in Shorthand.broad_overlap_key keys then
         collect_specs by_spec specs j seen []
       else
-        collect_bucket by_decl_key Shorthand.broad_overlap_key specs j seen []
-    in
-    let candidates =
-      List.fold_left
-        (fun acc key -> collect_bucket by_decl_key key specs j seen acc)
-        candidates keys
+        (* probed per declaration rather than per distinct key: the key alone
+           does not say which declaration of [j] faces the bucket, and that is
+           what decides which group can never conflict *)
+        collect_decl_overlaps by_decl_key specs j seen
+          (collect_broad_bucket by_decl_key specs j seen [])
+          t.decl_overlaps.(j)
     in
     let candidates =
       List.fold_left
@@ -438,7 +541,7 @@ let source_order_edges t =
         | Option.None -> ()
         | Option.Some reason -> succ.(i) <- (j, reason) :: succ.(i))
       candidates;
-    List.iter (fun key -> add_bucket by_decl_key key specs j) keys;
+    add_decl_overlaps by_decl_key specs j t.decl_overlaps.(j);
     List.iter
       (fun branch -> String_table.push by_branch branch j)
       t.branches.(j);

--- a/test/test_rule_graph.ml
+++ b/test/test_rule_graph.ml
@@ -359,6 +359,26 @@ let second_specificity_costs_no_pair () =
     true
     (a1 = 0. || a2 < a1 *. 2.5)
 
+(* Rules that all write the same declaration have no order to discover: an
+   identical pair is its own winner wherever the two sit. The run sits at one
+   specificity, where partitioning candidates by specificity separates nothing,
+   so the pairs are only ruled out by what each rule writes. Doubling N doubles
+   the rules to index and adds no dependency to find, so it may cost about twice
+   as much, not four times. *)
+let identical_declaration_costs_no_pair () =
+  let sheet n =
+    rules_of (String.concat "" (List.init n (Fmt.str ".c%d{color:red}")))
+  in
+  let small = sheet 400 in
+  let large = sheet 800 in
+  let a1 = measure (fun () -> Rule_graph.of_rules small) in
+  let a2 = measure (fun () -> Rule_graph.of_rules large) in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.1fx for 2x N at one specificity)" a1 a2
+       (a2 /. a1))
+    true
+    (a1 = 0. || a2 < a1 *. 2.5)
+
 (* A single transaction rebuilds graph state once: its allocation grows at most
    linearly with the live node count, never with the number of edges. *)
 let try_rewrite_is_subquadratic () =
@@ -542,6 +562,8 @@ let suite =
         try_rewrite_is_subquadratic;
       Alcotest.test_case "a second specificity costs no pair" `Quick
         second_specificity_costs_no_pair;
+      Alcotest.test_case "an identical declaration costs no pair" `Quick
+        identical_declaration_costs_no_pair;
       Alcotest.test_case "same-selector commute is sub-quadratic" `Quick
         same_selector_commute_is_subquadratic;
       Alcotest.test_case "grouping respects non-transitive compatibility" `Quick


### PR DESCRIPTION
Skip equal declarations by bucket instead of rejecting them pair by pair.

Add an allocation-scaling regression test and a reusable source-order benchmark harness.