### PR TITLE
media: preserve escaped identifiers on emission

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -265,6 +265,11 @@ answers.
 
 ### Printing
 
+- An unknown media type, media feature name or media identifier value keeps the
+  escapes needed to read it back as one identifier. `@media (width\ \>\=\
+  10px)` printed `@media (width >= 10px)`, turning an unknown boolean feature
+  into a real size range, so a second `--minify` pass could merge two conditions
+  the first kept apart.
 - A compound operand of `not`, `and` or `or` in a `@media` condition keeps its
   parentheses: `not ((min-width:1px) or (max-width:2px))` printed as
   `not (min-width:1px)or (max-width:2px)`, which browsers and cascade's own

--- a/fuzz/fuzz_container.ml
+++ b/fuzz/fuzz_container.ml
@@ -272,20 +272,13 @@ let test_spelling_pairs_sound buf =
     | Some q -> report_disagreement "Container.equal" a b q
     | None -> ()
 
-(* Control: the sweep above only means something if it can see a wrong merge.
-   Equality on serialised text is one such wrong rule, and these two queries are
-   the reason: an unknown container feature selects no query container
-   (Conditional Rules 5 sec. 5.4), so they serialise the same and match
-   different containers. If the sweep cannot separate them it cannot separate
-   anything. *)
+(* Control: the sweep above only means something if it can see a wrong merge. An
+   unknown container feature selects no query container (Conditional Rules 5
+   sec. 5.4), so these two queries match different containers. If the sweep
+   cannot separate them it cannot separate anything. *)
 let test_sweep_catches_wrong_equality _buf =
   let escaped = Css.Container.of_string {|(inline-size\ \>\=\ 10px)|} in
   let real = Css.Container.of_string "(inline-size >= 10px)" in
-  let text_equal a b =
-    String.equal (Css.Container.to_string a) (Css.Container.to_string b)
-  in
-  if not (text_equal escaped real) then
-    fail "the control pair no longer collides on serialised text";
   match disagreement escaped real with
   | Some _ -> ()
   | None ->

--- a/fuzz/fuzz_media.ml
+++ b/fuzz/fuzz_media.ml
@@ -337,19 +337,12 @@ let test_bound_spellings_sound buf =
     | Some q -> report_disagreement "Media.equal" a b q
     | None -> ()
 
-(* Control: the sweep above only means something if it can see a wrong merge.
-   Equality on serialised text is one such wrong rule, and these two queries are
-   the reason: an unknown media type never matches, so they serialise the same
-   and select different media. If the sweep cannot separate them it cannot
-   separate anything. *)
+(* Control: the sweep above only means something if it can see a wrong merge. An
+   unknown media type never matches, so these two queries select different
+   media. If the sweep cannot separate them it cannot separate anything. *)
 let test_sweep_catches_wrong_equality _buf =
   let escaped = Css.Media.of_string {|screen\ and\ \(min-width\:\ 10px\)|} in
   let real = Css.Media.of_string "screen and (min-width: 10px)" in
-  let text_equal a b =
-    String.equal (Css.Media.to_string a) (Css.Media.to_string b)
-  in
-  if not (text_equal escaped real) then
-    fail "the control pair no longer collides on serialised text";
   match disagreement escaped real with
   | Some _ -> ()
   | None ->

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -700,7 +700,7 @@ let unresolved_media_feature components =
                           (Media.Feature
                              (Media.Plain
                                 ( Media.name_of_string name,
-                                  Media.Ident (Media.ident_of_string value) )))))
+                                  Media.value_of_string value )))))
               | Some _ | None -> None)
           | _ -> None)
       | None -> None)

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -164,7 +164,7 @@ let string_of_medium : medium -> string = function
   | All -> "all"
   | Screen -> "screen"
   | Print -> "print"
-  | Other s -> s
+  | Other s -> Parser.escape_ident s
 
 let rec string_of_name : name -> string = function
   | Width -> "width"
@@ -205,7 +205,7 @@ let rec string_of_name : name -> string = function
   | Scripting -> "scripting"
   | Min name -> "min-" ^ string_of_name name
   | Max name -> "max-" ^ string_of_name name
-  | Other s -> s
+  | Other s -> Parser.escape_ident s
 
 let rec name_of_string s : name =
   let s = String.lowercase_ascii s in
@@ -297,7 +297,7 @@ let string_of_ident : ident -> string = function
   | Back -> "back"
   | Initial_only -> "initial-only"
   | Enabled -> "enabled"
-  | Other s -> s
+  | Other s -> Parser.escape_ident s
 
 let ident_of_string s : ident =
   match String.lowercase_ascii s with

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -287,16 +287,16 @@ let equal_ignores_bound_spelling () =
 (* Conditional Rules 5 sec. 5.4: a <container-query> naming an unknown container
    feature selects no query container, so it is never true. [(inline-size\ \>\=\
    10px)] is one escaped ident, a boolean feature with that name, and it spells
-   the same characters as the size range [(inline-size >= 10px)]. They share a
-   serialisation, which is why [equal] cannot be an equality on serialised
-   text. *)
+   the same characters as the size range [(inline-size >= 10px)]. [equal]
+   therefore cannot be an equality on serialised text, even though correct
+   serialisation also keeps their spellings apart. *)
 let equal_separates_an_escaped_feature_name () =
   let open Css.Container in
   let escaped = of_string {|(inline-size\ \>\=\ 10px)|} in
   let real = of_string "(inline-size >= 10px)" in
-  Alcotest.(check string)
-    "the witness is a serialisation collision" (to_string real)
-    (to_string escaped);
+  Alcotest.(check bool)
+    "the two queries keep distinct serialisations" false
+    (String.equal (to_string escaped) (to_string real));
   Alcotest.(check bool)
     "an unknown container feature is not the size range it spells" false
     (equal escaped real);

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -512,18 +512,46 @@ let equal_ignores_bound_spelling () =
 
 (* An unknown media type never matches (Media Queries 4 sec. 3.2 error
    handling), so a query whose type is one escaped ident is not the query that
-   spells the same characters as a type plus a condition. They share a
-   serialisation, which is why [equal] cannot be an equality on serialised
-   text. *)
+   spells the same characters as a type plus a condition. [equal] therefore
+   cannot be an equality on serialised text, even though correct serialisation
+   also keeps their spellings apart. *)
 let equal_separates_an_escaped_media_type () =
   let escaped = of_string {|screen\ and\ \(min-width\:\ 10px\)|} in
   let real = of_string "screen and (min-width: 10px)" in
-  Alcotest.(check string)
-    "the witness is a serialisation collision" (to_string real)
-    (to_string escaped);
+  Alcotest.(check bool)
+    "the two queries keep distinct serialisations" false
+    (String.equal (to_string escaped) (to_string real));
   Alcotest.(check bool)
     "an unknown media type is not a media type plus a condition" false
     (equal escaped real)
+
+(* CSS Syntax 3 sec. 4.3.11 consumes escapes before Media sees an ident, while
+   sec. 4.2 requires serialisation to produce a token stream that re-parses to
+   the same tokens. This applies to unknown media types, feature names and
+   feature values alike. Losing those token boundaries can turn an unknown
+   condition into a real one, after which a second minify pass merges blocks
+   that the first pass correctly kept apart. *)
+let escaped_identifiers_survive_emission () =
+  let check_roundtrip name source =
+    let parsed = of_string source in
+    let reparsed = parsed |> to_string ~minify:true |> of_string in
+    Alcotest.(check bool) name true (equal parsed reparsed)
+  in
+  check_roundtrip "escaped media type" {|screen\ and\ \(min-width\:\ 10px\)|};
+  check_roundtrip "escaped feature name" {|(width\ \>\=\ 10px)|};
+  check_roundtrip "escaped feature value" {|(future: light\ or\ dark)|};
+  let minify source =
+    source
+    |> Css.of_string_exn ~strict:false
+    |> Css.optimize |> Css.to_string ~minify:true
+  in
+  let source =
+    "@media(width\\ \\>\\=\\ \
+     10px){.a{color:red}}@media(width>=10px){.b{color:blue}}"
+  in
+  let once = minify source in
+  Alcotest.(check string)
+    "a second minify pass preserves the two conditions" once (minify once)
 
 (* An opaque condition carries no structure to reason over, so it equals an
    identical spelling and nothing else. Reflexivity is not optional: [equal] is
@@ -613,6 +641,8 @@ let suite =
         equal_ignores_bound_spelling;
       test_case "equal separates an escaped media type" `Quick
         equal_separates_an_escaped_media_type;
+      test_case "escaped identifiers survive emission" `Quick
+        escaped_identifiers_survive_emission;
       test_case "equal on opaque conditions" `Quick equal_on_opaque_conditions;
       test_case "normalize is idempotent" `Quick normalize_is_idempotent;
     ] )


### PR DESCRIPTION
Escaped media identifiers lost their escapes on emission, so a second minify pass could merge distinct conditions; preserve those identifiers and unresolved container var() values. Stacked on #525.