### PR TITLE
declaration: make cached hashes private

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,11 @@ answers.
 
 ### Breaking
 
+- `Declaration.declaration` is a private variant. Its constructors remain
+  available for pattern matching, but construct values with `Declaration.v` or
+  `Declaration.theme_guarded`. The public records exposed their cached hash, so
+  a caller could give equal declarations different caches and make the
+  optimizer treat them as unequal.
 - `Css.Media.equal` reads normalised query structure where it read serialised
   text, so it is no longer `Css.Media.compare a b = 0` and answers differently
   both ways: `(min-width: 10px)` and `(width >= 10px)` are now equal, and two

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -1,6 +1,26 @@
 (** CSS declarations and parser. *)
 
-include module type of Declaration_intf
+type 'a kind = 'a Properties_intf.kind
+
+(** A typed declaration. Constructors remain available for pattern matching, but
+    values must be built with {!v} or {!theme_guarded} so the cached hash
+    matches the payload. *)
+type declaration = private
+  | Declaration : {
+      property : 'a Properties_intf.property;
+      value : 'a;
+      important : bool;
+      hash : int;
+    }
+      -> declaration
+  | Theme_guarded : {
+      var_name : string;
+      decl : declaration;
+      hash : int;
+    }
+      -> declaration
+
+type t = declaration
 
 val pp_property : 'a Properties.property Pp.t
 (** [pp_property] is the pretty-printer for CSS property names. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -836,38 +836,33 @@ let rec rewrite_shadow_value color_vars (value : Properties.shadow) :
 
 let rewrite_shadow_decl color_vars = function
   | Declaration.Declaration
-      ({ property = Properties.Box_shadow; value; _ } as decl) ->
-      Declaration.Declaration
-        { decl with value = rewrite_shadow_value color_vars value }
+      { property = Properties.Box_shadow as property; value; important; _ } as
+    decl ->
+      let value' = rewrite_shadow_value color_vars value in
+      if value' == value then decl else Declaration.v ~important property value'
   | Declaration.Declaration
-      ({
-         property = Properties.Custom_property _;
-         value =
-           Properties.Custom_value
-             {
+      {
+        property = Properties.Custom_property _ as property;
+        value =
+          Properties.Custom_value
+            ({
                value =
                  Properties.Typed { kind = Properties.Shadow; value = shadow };
-               layer;
-               meta;
-             };
-         _;
-       } as decl) ->
-      Declaration.Declaration
-        {
-          decl with
-          value =
-            Properties.Custom_value
-              {
-                value =
-                  Properties.Typed
-                    {
-                      kind = Properties.Shadow;
-                      value = rewrite_shadow_value color_vars shadow;
-                    };
-                layer;
-                meta;
-              };
-        }
+               _;
+             } as custom_value);
+        important;
+        _;
+      } as decl ->
+      let shadow' = rewrite_shadow_value color_vars shadow in
+      if shadow' == shadow then decl
+      else
+        Declaration.v ~important property
+          (Properties.Custom_value
+             {
+               custom_value with
+               value =
+                 Properties.Typed { kind = Properties.Shadow; value = shadow' };
+             })
   | decl -> decl
 
 let normalise_shadows stylesheet =

--- a/merlint.toml
+++ b/merlint.toml
@@ -5,3 +5,9 @@
 [[rules]]
 files = "lib/prop_*.ml"
 exclude = ["E505"]
+
+# Declaration.declaration is an existing public API name. Its constructors are
+# repeated in the interface to make them private without renaming the type.
+[[rules]]
+files = "lib/declaration.mli"
+exclude = ["E330"]

--- a/test/api/declaration_hash.t
+++ b/test/api/declaration_hash.t
@@ -1,0 +1,14 @@
+A declaration's cached structural hash is an implementation detail.  Public
+clients can inspect declarations, but cannot construct one with an arbitrary
+cache value instead of using the smart constructors.
+
+  $ cat > forge_hash.ml <<'EOF'
+  > open Cascade
+  > let forged =
+  >   match Declaration.of_string "color:currentColor" with
+  >   | Declaration.Declaration { property; value; important; _ } ->
+  >       Declaration.Declaration { property; value; important; hash = 0 }
+  >   | Declaration.Theme_guarded _ -> assert false
+  > EOF
+  $ ocamlfind ocamlc -package cascade -c forge_hash.ml >/dev/null 2>&1
+  [2]

--- a/test/api/dune
+++ b/test/api/dune
@@ -1,0 +1,3 @@
+(cram
+ (deps
+  (package cascade)))


### PR DESCRIPTION
Public declaration constructors allowed callers to forge cached hashes and break equality shortcuts; make the constructors private and rebuild internal shadow declarations through Declaration.v. Stacked on #526.