### PR TITLE
selector: raise Parse_error for empty input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,9 @@ answers.
   `Cursor.Parse_error` where they raised `Failure`, so a `Failure` handler
   around any of them stops catching and the exception escapes; match
   `Cursor.Parse_error` instead (#496, #497, #499, #501)
+- `Css.Selector.of_string ""` raises `Error.Parse_error`, like every other
+  malformed selector, where it raised `Invalid_argument`. Its documentation
+  now describes the complete selector grammar the function already parses.
 - `Cascade.Component.pp` documents and renders itself as the located debug
   dump it always was. It was documented as source text, which sent a caller
   down a check that could never fire. Every node now shows its own location

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -1841,7 +1841,8 @@ let has_invalid_css_escape s =
 
 let can_fallback_shortcut s =
   let len = String.length s in
-  (not (has_invalid_css_escape s))
+  len > 0
+  && (not (has_invalid_css_escape s))
   &&
   match s.[0] with
   | '.' | '#' -> len > 1 && not (is_unescaped_selector_syntax s 1)
@@ -1857,11 +1858,9 @@ let of_string_fallback s =
   | _ -> Element (None, unescape_selector_name s)
 
 let of_string s =
-  if String.length s = 0 then invalid_arg "of_string: empty selector string"
-  else
-    try read (Cursor.of_string s)
-    with Cursor.Parse_error _ as exn ->
-      if not (can_fallback_shortcut s) then raise exn else of_string_fallback s
+  try read (Cursor.of_string s)
+  with Cursor.Parse_error _ as exn ->
+    if not (can_fallback_shortcut s) then raise exn else of_string_fallback s
 
 (** Pretty print a function-like pseudo-class or pseudo-element *)
 let pp_func : 'a. Pp.ctx -> prefix:string -> string -> 'a Pp.t -> 'a -> unit =

--- a/lib/selector.mli
+++ b/lib/selector.mli
@@ -26,14 +26,9 @@ val id : string -> t
     [Invalid_argument] on invalid. *)
 
 val of_string : string -> t
-(** [of_string s] parses a CSS-escaped selector string:
-    - [".classname"] -> class selector
-    - ["#idname"] -> id selector
-    - ["element"] -> element selector
-
-    Unescapes both simple escapes (e.g., ["\:"]) and hex escapes (e.g.,
-    ["\3A"]). Example: [of_string ".sm\\:p-4"] creates a class selector for
-    "sm:p-4". *)
+(** [of_string s] parses a complete CSS selector, including complex and
+    comma-separated selectors. CSS escapes are decoded. Raises
+    {!Error.Parse_error} when [s] is malformed. *)
 
 val universal : t
 (** [universal] universal selector "*" (no namespace). *)

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -68,6 +68,14 @@ let check_minified_equiv input =
     ("specificity preserved: " ^ input)
     (specificity original) (specificity reparsed)
 
+let of_string_empty_raises_parse_error () =
+  match of_string "" with
+  | _ -> Alcotest.fail "empty selector parsed"
+  | exception Error.Parse_error _ -> ()
+  | exception exn ->
+      Alcotest.failf "empty selector raised %s instead of Error.Parse_error"
+        (Printexc.to_string exn)
+
 (* Not a roundtrip test *)
 let element_cases () =
   (* Test element selectors *)
@@ -2246,6 +2254,8 @@ let suite =
         test_attr_case_sensitivity_flags;
       test_case "selector component failures" `Quick component_parsing_failures;
       (* Parser/API-policy error coverage. *)
+      test_case "of_string empty raises Parse_error" `Quick
+        of_string_empty_raises_parse_error;
       test_case "invalid" `Quick invalid;
       test_case "parse errors - attributes" `Quick parse_errors_attributes;
       test_case "parse errors - combinators" `Quick parse_errors_combinators;


### PR DESCRIPTION
Selector.of_string "" leaked Invalid_argument despite the parser contract promising Parse_error; route empty input through Parse_error and document the complete selector grammar. Stacked on #527.