### PR TITLE
container: escape API-constructed names

### DIFF
--- a/lib/container.ml
+++ b/lib/container.ml
@@ -136,7 +136,8 @@ and to_string_with ~pretty ~minify t =
   | Min_width_px px ->
       let sep = if pretty && not minify then ": " else ":" in
       "(min-width" ^ sep ^ Int.to_string px ^ "px)"
-  | Named (name, cond) -> name ^ " " ^ to_string_with ~pretty ~minify cond
+  | Named (name, cond) ->
+      Parser.escape_ident name ^ " " ^ to_string_with ~pretty ~minify cond
   | Style { query; uppercase } ->
       let head = if uppercase then "STYLE(" else "style(" in
       head ^ string_of_style_query ~minify query ^ ")"

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -49,6 +49,18 @@ let test_string_output () =
     "aspect ratio query raw" "(aspect-ratio > 1/1)"
     (to_string (of_string "(aspect-ratio > 1/1)"))
 
+(* CSS Containment 3 sec. 4 makes a container name a [<custom-ident>], so an
+   API-constructed name must take CSS Syntax 3 sec. 9.1 identifier escaping. *)
+let named_container_name_round_trips () =
+  let open Css.Container in
+  let query = Named ("a b", Min_width_rem 24.) in
+  let serialized = to_string query in
+  Alcotest.(check string)
+    "the container name is escaped" {|a\ b (min-width:24rem)|} serialized;
+  Alcotest.(check bool)
+    "the escaped container name reparses" true
+    (equal query (of_string serialized))
+
 let component_parser_edges () =
   let open Css.Container in
   Alcotest.(check string)
@@ -381,6 +393,8 @@ let tests =
   Alcotest.
     [
       test_case "to_string" `Quick test_string_output;
+      test_case "named container name round-trips" `Quick
+        named_container_name_round_trips;
       test_case "component parser edges" `Quick component_parser_edges;
       test_case "stylesheet component parser edges" `Quick
         stylesheet_component_parser_edges;


### PR DESCRIPTION
API-constructed named containers emitted names raw and failed to round-trip; escape them during serialization. Stacked on #529.