### PR TITLE
changelog: record the external-conflict scan's allocation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -487,6 +487,12 @@ answers.
   property key for every declaration it reads, a scan it repeats once per
   member per property under consideration. It allocates a twentieth less over
   the 504-file corpus, for byte-identical output (#517)
+- `--minify` decides whether a factored group would cross a rule outside it
+  without listing the graph's nodes to scan them, and without allocating at
+  each node it walks past. The check runs once per proposed group and answers
+  no at almost every node, so those two were the scan's whole cost. It
+  allocates a thirtieth less over the 504-file corpus, for byte-identical
+  output (#519)
 - `--minify` no longer scans quadratically when many rules share a deep
   selector prefix. The structural hash reads a fixed count of nodes, so
   `.a .b .c .d .e .f .g` and every sibling differing only past that prefix took


### PR DESCRIPTION
The scan's allocation change landed in #519 without an entry, and a reader of the 1.2.0 performance list meets it as a change separate from the default-value one above it.

Allocation over the 504-file SatCSS corpus falls by roughly 3%, and the output is byte-identical.
