### PR TITLE
declaration: one failure mode for of_string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,11 @@ answers.
   `Cursor.Parse_error` where they raised `Failure`, so a `Failure` handler
   around any of them stops catching and the exception escapes; match
   `Cursor.Parse_error` instead (#496, #497, #499, #501)
+- `Declaration.of_string` raises `Cursor.Parse_error` for every input it
+  refuses, anchored on the text that failed. Empty, blank and selector-shaped
+  input raised `Failure` while everything the reader reached already raised
+  `Cursor.Parse_error`, so one handler now covers the function; replace a
+  `Failure` handler around it with `Cursor.Parse_error` (#535)
 - `Css.Selector.of_string ""` raises `Error.Parse_error`, like every other
   malformed selector, where it raised `Invalid_argument`. Its documentation
   now describes the complete selector grammar the function already parses.

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2371,9 +2371,13 @@ let read_block t =
   Cursor.braces (fun inner -> read_declarations inner) t
 
 let of_string s =
-  match read_declaration (Cursor.of_string s) with
+  let r = Cursor.of_string s in
+  match read_declaration r with
   | Some d -> d
-  | None -> failwith ("Declaration.of_string: invalid declaration: " ^ s)
+  (* [read_declaration] answers [None] for text a declaration cannot start with,
+     which here is the whole input: report it where the reader stopped rather
+     than as a second, position-free exception. *)
+  | None -> Cursor.err_expected r "a declaration"
 
 (* The declaration [property] and [value] name, as the tokens they are. The name
    is one [<ident-token>] by construction and the value is parsed on its own, so

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -138,7 +138,8 @@ val read : Cursor.t -> t
 
 val of_string : string -> declaration
 (** [of_string s] parses a single declaration from [s] (e.g. ["color: red"]).
-    Raises [Failure] if [s] is not a valid declaration. *)
+    Raises {!Cursor.exception-Parse_error}, anchored on the offending text, when
+    [s] is not a valid declaration. *)
 
 val read_declarations : Cursor.t -> declaration list
 (** [read_declarations t] is all typed declarations in an unbraced block. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -385,6 +385,32 @@ let error_missing_colon () =
   let r = Cursor.of_string "color red;" in
   expect_parse_error "missing colon" (fun () -> ignore (read_declaration r))
 
+(* [Declaration.of_string] documents one failure mode, so a caller writes one
+   handler. Text that is not a declaration reaches it two ways - the reader
+   raises, or it answers [None] for a component a declaration cannot start with
+   - and both must leave through the same exception. *)
+let of_string_one_failure_mode () =
+  let refused input =
+    match of_string input with
+    | d ->
+        Alcotest.failf "%S: expected a parse error, parsed %S" input
+          (to_string d)
+    | exception Cursor.Parse_error _ -> ()
+  in
+  (* The reader reaches the value and rejects it. *)
+  refused "color";
+  refused "color red";
+  refused "color:";
+  refused "1px";
+  (* [read_declaration] answers [None]: no declaration starts here. *)
+  refused "";
+  refused "   ";
+  refused ".foo";
+  refused "#id";
+  refused "&:hover";
+  refused "[data-x]";
+  refused ": red"
+
 let error_stray_semicolon () =
   let r = Cursor.of_string "; color: red;" in
   expect_parse_error "stray semicolon" (fun () -> ignore (read_declaration r))
@@ -3292,6 +3318,7 @@ let declaration_tests =
       spec_property_grammar_manifest;
     (* Error handling *)
     test_case "error missing colon" `Quick error_missing_colon;
+    test_case "of_string has one failure mode" `Quick of_string_one_failure_mode;
     test_case "error stray semicolon" `Quick error_stray_semicolon;
     test_case "error unclosed block" `Quick error_unclosed_block;
     test_case "unterminated parsing" `Quick unterminated;


### PR DESCRIPTION
`Declaration.of_string` documents one exception, but only text the reader reached raised it: empty, blank and selector-shaped input left through `Failure` instead, so no single handler covered the function. It now raises `Cursor.Parse_error` throughout, anchored on the text that failed.