### PR TITLE
font-face: one table decides which descriptors resolve var()

### DIFF
--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -596,12 +596,19 @@ let simplify_unicode_range_descriptor visible (value : Properties.unicode_range)
   in
   simplify ~visited:[] value
 
-let simplify_font_face_descriptor visible = function
-  | Src value -> Src (simplify_font_src_descriptor visible value)
-  | Unicode_range values ->
-      Unicode_range
-        (List.map (simplify_unicode_range_descriptor visible) values)
-  | descriptor -> descriptor
+(* [resolve_font_face_var] names the descriptors whose var() survives the parse
+   and asks for one resolver each, so this pass and the parser cannot grow
+   apart: a descriptor added to that table takes a resolver argument the call
+   below has to supply. *)
+let simplify_font_face_descriptor visible descriptor =
+  match
+    resolve_font_face_var
+      ~src:(simplify_font_src_descriptor visible)
+      ~unicode_range:(List.map (simplify_unicode_range_descriptor visible))
+      descriptor
+  with
+  | Some resolved -> resolved
+  | Option.None -> descriptor
 
 let eval_page_declaration visible ctx decl =
   let resolve_length_var (var : Values.length Values.var) =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2353,17 +2353,23 @@ let rec components_upto_semicolon = function
   | [] | Component.Preserved { kind = Token.Semicolon; _ } :: _ -> []
   | component :: rest -> component :: components_upto_semicolon rest
 
-(* cascade generates CSS, so a var() it substitutes at build time never reaches
-   a browser. [Inline.simplify_font_face_descriptor] resolves exactly these two
-   under [--inline-vars], so their readers keep the var(); every other
-   descriptor has no resolution path, leaving the var() unresolvable. *)
-let descriptor_resolves_var = function
-  | "src" | "unicode-range" -> true
-  | _ -> false
+let descriptor_value_has_var r =
+  components_have_var (components_upto_semicolon (Cursor.remaining r))
 
-let descriptor_value_has_var name r =
-  (not (descriptor_resolves_var name))
-  && components_have_var (components_upto_semicolon (Cursor.remaining r))
+(* Whether the descriptor called [name] keeps a var() for the inline pass, asked
+   of the typed AST rather than of a second list of names: read a value only
+   such a descriptor accepts, then put the descriptor to
+   {!resolve_font_face_var}, the one table [Inline] fills in. A descriptor with
+   no resolution path either refuses the probe or lands on an arm that table
+   answers [None] for. Only a value carrying a var() asks, so an ordinary
+   descriptor never pays for the probe. *)
+let descriptor_resolves_var name =
+  let probe = Cursor.of_string ":var(--x)" in
+  match read_font_face_desc name probe with
+  | descriptor ->
+      Option.is_some
+        (resolve_font_face_var ~src:Fun.id ~unicode_range:Fun.id descriptor)
+  | exception Error.Parse_error _ -> false
 
 let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
   Cursor.ws r;
@@ -2374,7 +2380,7 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
   else
     let name = Cursor.ident ~keep_case:false r in
     match
-      if descriptor_value_has_var name r then
+      if descriptor_value_has_var r && not (descriptor_resolves_var name) then
         Cursor.err_invalid r ("var() in @font-face descriptor: " ^ name)
       else read_font_face_desc name r
     with

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -337,3 +337,24 @@ type mode = Variables | Inline  (** Rendering mode for CSS output *)
 
 let equal_cascade_origin (a : cascade_origin) b = a = b
 let equal (a : stylesheet) b = a = b
+
+(** [resolve_font_face_var ~src ~unicode_range descriptor] is [descriptor] with
+    its value rewritten by the matching resolver, or [None] when it holds no
+    value a [var()] can be resolved in.
+
+    CSS Variables 1 sec. 3 substitutes [var()] in a property value; an
+    [\@font-face] descriptor is not a property, so no descriptor grammar accepts
+    one and browsers drop the declaration that holds it. cascade substitutes at
+    build time instead, and this table is the whole set it can reach: the parser
+    keeps a [var()] only for a descriptor named here, and {!Inline} supplies the
+    resolvers. A descriptor added to the table takes another resolver argument,
+    so both sides have to answer for it. *)
+let resolve_font_face_var ~src ~unicode_range = function
+  | Src value -> Some (Src (src value))
+  | Unicode_range values -> Some (Unicode_range (unicode_range values))
+  | Font_family _ | Font_style _ | Font_style_range _ | Font_weight _
+  | Font_weight_range _ | Font_stretch _ | Font_stretch_range _ | Font_display _
+  | Font_variant _ | Font_feature_settings _ | Font_variation_settings _
+  | Font_tech _ | Size_adjust _ | Ascent_override _ | Descent_override _
+  | Line_gap_override _ ->
+      Option.None

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -25,6 +25,70 @@ let check_inline_case ?optimized name input expected =
         expected
         (optimized_minified inlined)
 
+(* Every [\@font-face] descriptor, with a value it takes. *)
+let font_face_descriptors =
+  [
+    ("font-family", "b");
+    ("src", "local(y)");
+    ("font-style", "italic");
+    ("font-weight", "400");
+    ("font-stretch", "50%");
+    ("font-display", "swap");
+    ("unicode-range", "U+0-7f");
+    ("font-variant", "normal");
+    ("font-feature-settings", "normal");
+    ("font-variation-settings", "normal");
+    ("font-tech", "\"variations\"");
+    ("size-adjust", "100%");
+    ("ascent-override", "normal");
+    ("descent-override", "normal");
+    ("line-gap-override", "normal");
+  ]
+
+let holds_substring sub s =
+  let n = String.length s and m = String.length sub in
+  let rec from i = i + m <= n && (String.sub s i m = sub || from (i + 1)) in
+  from 0
+
+let font_face_descriptor_count sheet =
+  List.length
+    (List.concat_map
+       (fun statement ->
+         match Css.as_font_face statement with
+         | Some descriptors -> descriptors
+         | None -> [])
+       sheet)
+
+(* CSS Fonts 4 sec. 4.1: no descriptor grammar accepts a [var()], so a browser
+   drops the declaration holding one. cascade substitutes at build time instead,
+   but only where the inline pass has a resolution path, and the parser keeps a
+   [var()] exactly there. The two are one decision, so read them together: a
+   descriptor that survives the parse leaves [inline_vars] with no [var()]
+   behind, and no other descriptor survives. *)
+let test_inline_font_face_var_descriptors () =
+  let survives (name, value) =
+    let css =
+      String.concat ""
+        [
+          ":root{--v:";
+          value;
+          "}@font-face{font-family:a;src:local(anchor);";
+          name;
+          ":var(--v)}";
+        ]
+    in
+    let sheet = parse css in
+    let inlined = minified (Css.inline_vars sheet) in
+    Alcotest.(check bool)
+      (name ^ ": no var() reaches the output")
+      false
+      (holds_substring "var(" inlined);
+    font_face_descriptor_count sheet = 3
+  in
+  let kept = List.map fst (List.filter survives font_face_descriptors) in
+  Alcotest.(check (list string))
+    "descriptors the parser keeps a var() for" [ "src"; "unicode-range" ] kept
+
 let test_inline_substitutes_vars () =
   check_inline ~optimized:".button{color:#00f}"
     ":root{--brand:blue}.button{color:var(--brand)}" ".button{color:blue}"
@@ -778,4 +842,7 @@ let suite =
         test_inline_keeps_a_page_break_property;
       Alcotest.test_case "inline vars keep a page-break property read from CSS"
         `Quick test_inline_keeps_a_page_break_property_from_css;
+      Alcotest.test_case
+        "inline vars resolve the @font-face descriptors the parser keeps" `Quick
+        test_inline_font_face_var_descriptors;
     ] )


### PR DESCRIPTION
The parser matched the descriptor names `src` and `unicode-range` while `Inline.simplify_font_face_descriptor` matched the constructors `Src` and `Unicode_range`, in another file and another representation, so adding a descriptor to one side left the other's code dead or let an unresolvable `var()` reach the output. Both sides now go through `resolve_font_face_var`, which takes one resolver per descriptor: adding a descriptor to that table makes both call sites fail to compile until they answer for it.

Emitted CSS and parse warnings are unchanged.