### PR TITLE
stylesheet: raise @when and @else prelude errors in place

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -134,7 +134,8 @@ answers.
   a later one of its own name (#511)
 - An error inside an at-rule condition or an `@font-face` descriptor points at
   the slice that failed, not at the end of the file with the caret past the
-  last byte (#496, #497, #499, #501)
+  last byte. `@when` and `@else` name the at-rule with it (#496, #497, #499,
+  #501, #538)
 - Everything the parser repaired or dropped is reported, so strict mode
   rejects it. `@media screen {` swallowed the rest of the file and still
   returned `Ok` with no warnings, hiding a truncated stylesheet (#484)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3235,25 +3235,25 @@ let read_property_initial_value r syntax str =
   Cursor.expect_eof value_reader;
   value
 
-let conditional_args (fn : Component.func Component.node) =
-  if not fn.node.terminated then failwith "unterminated conditional function";
-  Cursor.string_of_components ~trim:true fn.node.arguments
+(* Every failure below is a failure of the [\@when] / [\@else] prelude, so it is
+   raised on the cursor the prelude's own components sit in and the caret lands
+   on the one that failed rather than on the block that follows it. *)
+let conditional_terminated r ~at_rule (fn : Component.func Component.node) =
+  if not fn.node.terminated then
+    Cursor.err_condition r ~at_rule "unterminated condition function"
 
-let conditional_arguments (fn : Component.func Component.node) =
-  if not fn.node.terminated then failwith "unterminated conditional function";
-  fn.node.arguments
-
-let conditional_atom (fn : Component.func Component.node) =
+let conditional_atom r ~at_rule (fn : Component.func Component.node) =
+  conditional_terminated r ~at_rule fn;
   match String.lowercase_ascii fn.Component.node.name with
-  | "media" ->
-      Media_condition (Media.of_function_components (conditional_arguments fn))
+  | "media" -> Media_condition (Media.of_function_components fn.node.arguments)
   | "supports" ->
       Supports_condition_test
-        (Supports.of_string ~allow_unwrapped_decl:true (conditional_args fn))
-  | name -> failwith ("unknown conditional function: " ^ name)
+        (Supports.of_string ~allow_unwrapped_decl:true
+           (Cursor.string_of_components ~trim:true fn.node.arguments))
+  | name ->
+      Cursor.err_condition r ~at_rule ("unknown condition function: " ^ name)
 
-let conditional_components components =
-  let cursor = Cursor.of_components components in
+let conditional_components ~at_rule cursor =
   let peek_ident () =
     match Cursor.peek cursor with
     | Some (Component.Preserved { kind = Token.Ident name; _ }) ->
@@ -3264,30 +3264,29 @@ let conditional_components components =
     Cursor.ws cursor;
     match Cursor.peek cursor with
     | Some (Component.Func fn) ->
+        let atom = conditional_atom cursor ~at_rule fn in
         Cursor.skip cursor;
-        conditional_atom fn
-    | _ -> failwith "expected conditional function"
+        atom
+    | _ -> Cursor.err_condition cursor ~at_rule "expected a condition function"
   in
+  let mixed op = Cursor.err_condition cursor ~at_rule ("cannot mix " ^ op) in
   let rec chain op acc =
     Cursor.ws cursor;
     match peek_ident () with
     | Some "and" ->
-        (match op with
-        | Some `Or -> failwith "mixed @when condition operators"
-        | _ -> ());
+        (match op with Some `Or -> mixed "or and and" | _ -> ());
         Cursor.skip cursor;
         chain (Some `And) (And (acc, read_atom ()))
     | Some "or" ->
-        (match op with
-        | Some `And -> failwith "mixed @when condition operators"
-        | _ -> ());
+        (match op with Some `And -> mixed "and and or" | _ -> ());
         Cursor.skip cursor;
         chain (Some `Or) (Or (acc, read_atom ()))
     | _ -> acc
   in
   let condition = chain None (read_atom ()) in
   Cursor.ws cursor;
-  if not (Cursor.is_done cursor) then failwith "trailing @when condition";
+  if not (Cursor.is_done cursor) then
+    Cursor.err_condition cursor ~at_rule "trailing content";
   condition
 
 let follows_conditional = function When _ | Else _ -> true | _ -> false
@@ -3514,10 +3513,9 @@ let read_when ~body (r : Cursor.t) : statement =
   Cursor.ws r;
   let prelude = Cursor.drain_until_block r in
   if Cursor.string_of_components ~trim:true prelude = "" then
-    Cursor.err_invalid r "@when: missing condition";
+    Cursor.err_condition r ~at_rule:"@when" "missing condition";
   let condition : conditional =
-    try conditional_components prelude
-    with Failure msg -> Cursor.err_invalid r ("@when: " ^ msg)
+    conditional_components ~at_rule:"@when" (Cursor.sub r prelude)
   in
   When (condition, Cursor.braces body r)
 
@@ -3534,10 +3532,7 @@ let read_else ~body (r : Cursor.t) : statement =
         prelude
     with
     | [] -> Option.None
-    | _ -> (
-        match conditional_components prelude with
-        | condition -> Some condition
-        | exception Failure msg -> Cursor.err_invalid r ("@else: " ^ msg))
+    | _ -> Some (conditional_components ~at_rule:"@else" (Cursor.sub r prelude))
   in
   Else (condition, Cursor.braces body r)
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4009,6 +4009,58 @@ let spec_nesting_starting_style () =
     ".a { @starting-style { & b { color: red } } }";
   test_nesting_idempotent ".a { @starting-style { color: red } color: green }"
 
+(* CSS Conditional 5 sec. 3 and sec. 4: a prelude the [@when] / [@else]
+   condition grammar rejects is a condition failure of that at-rule, and the
+   caret belongs on the slice of the condition that failed. The reader holds
+   those components, so it can point at them rather than at the block that
+   follows; the same rule the [@container] and [@supports] preludes read by. *)
+let conditional_prelude_errors () =
+  let case (input, at_rule, offending) =
+    let warnings =
+      match Css.of_string ~strict:false input with
+      | Error e -> [ e ]
+      | Ok { Css.warnings; _ } -> warnings
+    in
+    match warnings with
+    | [ ({ Error.kind = Error.Bad_condition { at_rule = named; _ }; _ } as e) ]
+      ->
+        Alcotest.(check string) (input ^ ": at-rule named") at_rule named;
+        Alcotest.(check string)
+          (input ^ ": caret on the offending slice")
+          offending
+          (String.sub input e.Error.loc.Loc.start_pos
+             (e.Error.loc.Loc.end_pos - e.Error.loc.Loc.start_pos))
+    | [ e ] ->
+        Alcotest.failf "%s: expected a condition error, got %s" input
+          (Error.to_string e)
+    | warnings ->
+        Alcotest.failf "%s: expected one warning, got %d" input
+          (List.length warnings)
+  in
+  List.iter case
+    [
+      ("@when foo(x){.a{color:red}}", "@when", "foo(x)");
+      ( "@when media(screen) and supports(top:0) or media(print){.a{c:red}}",
+        "@when",
+        "or" );
+      ( "@when media(screen) or supports(top:0) and media(print){.a{c:red}}",
+        "@when",
+        "and" );
+      ("@when .a{color:red}", "@when", ".");
+      ( "@when media(screen) media(print){.a{color:red}}",
+        "@when",
+        "media(print)" );
+      ( "@when media(screen{.a{color:red}}",
+        "@when",
+        "media(screen{.a{color:red}}" );
+      ( "@when media(width>0px){.a{color:red}}@else foo(x){.b{color:red}}",
+        "@else",
+        "foo(x)" );
+      ( "@when media(width>0px){.a{c:red}}@else media(print) x{.b{c:red}}",
+        "@else",
+        "x" );
+    ]
+
 (* The same section covers every conditional group rule, not just the three
    cascade already nested: [@-moz-document] carries style rules, and CSS
    Conditional 5 sec. 3 and sec. 4 make [@when] and [@else] conditional group
@@ -8933,6 +8985,9 @@ let additional_tests =
     ( "spec nesting @starting-style holds nesting content",
       `Quick,
       spec_nesting_starting_style );
+    ( "conditional prelude errors name the at-rule and the slice",
+      `Quick,
+      conditional_prelude_errors );
     ( "spec nesting other group rules hold nesting content",
       `Quick,
       spec_nesting_other_group_rules );


### PR DESCRIPTION
`conditional_components` threw `Failure` and `read_when` / `read_else` re-wrapped it against the cursor, which `drain_until_block` had already left on the block, so every condition failure pointed at `{` instead of the part of the prelude that caused it. All seven sites now raise `Cursor.err_condition` on the prelude's own components, the way the `@container` and `@supports` preludes already do since #496 through #501, and the error names `@when` or `@else` as a typed `Bad_condition` rather than a `Bad_value` with the at-rule spliced into the reason.

`lib/supports.ml` keeps its `failwith`s: `Css.Supports.property` raising `Failure` is a contract in the shipped 1.2.0 block (#459).