### PR TITLE
lib: remove duplicate parsing and printing paths

### DIFF
--- a/lib/css.ml
+++ b/lib/css.ml
@@ -350,68 +350,22 @@ let media_not_min_width_length l =
           (Media.Feature (Media.Plain (Media.Min Media.Width, Media.Length l)));
     }
 
-let parse_length s =
+let parse_option read s =
   match
     let c = Cursor.of_string s in
-    let l = Values.read_length c in
-    if Cursor.is_done c then Some l else None
+    let value = read c in
+    if Cursor.is_done c then Some value else None
   with
   | value -> value
   | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
 
-let parse_color s =
-  match
-    let c = Cursor.of_string s in
-    let col = Values.read_color c in
-    if Cursor.is_done c then Some col else None
-  with
-  | value -> value
-  | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
-
-let parse_shadow s =
-  match
-    let r = Cursor.of_string s in
-    let sh = Properties.read_shadow r in
-    if Cursor.is_done r then Some sh else None
-  with
-  | value -> value
-  | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
-
-let parse_background_image s =
-  match
-    let r = Cursor.of_string s in
-    let imgs = Properties.read_background_images r in
-    if Cursor.is_done r then Some imgs else None
-  with
-  | value -> value
-  | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
-
-let parse_font_family s =
-  match
-    let r = Cursor.of_string s in
-    let v = Properties.read_font_family r in
-    if Cursor.is_done r then Some v else None
-  with
-  | value -> value
-  | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
-
-let parse_list_style_type s =
-  match
-    let r = Cursor.of_string s in
-    let v = Properties.read_list_style_type r in
-    if Cursor.is_done r then Some v else None
-  with
-  | value -> value
-  | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
-
-let parse_list_style_image s =
-  match
-    let r = Cursor.of_string s in
-    let v = Properties.read_list_style_image r in
-    if Cursor.is_done r then Some v else None
-  with
-  | value -> value
-  | exception (Cursor.Parse_error _ | Invalid_argument _) -> None
+let parse_length s = parse_option Values.read_length s
+let parse_color s = parse_option Values.read_color s
+let parse_shadow s = parse_option Properties.read_shadow s
+let parse_background_image s = parse_option Properties.read_background_images s
+let parse_font_family s = parse_option Properties.read_font_family s
+let parse_list_style_type s = parse_option Properties.read_list_style_type s
+let parse_list_style_image s = parse_option Properties.read_list_style_image s
 
 let as_layer = function
   | Layer (name, content) -> Some (name, content)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2470,12 +2470,8 @@ let rec pp_declaration : declaration Pp.t =
       pp_property ctx (Custom_property name);
       Pp.string ctx ":";
       Pp.space_if_pretty ctx ();
-      (match (layer, value) with
-      | Some "theme", Typed { kind = Font_family; value } ->
-          pp_value ctx (Font_family, value)
-      | _ ->
-          pp_property_value ctx
-            (Custom_property name, Custom_value { value; layer; meta = None }));
+      pp_property_value ctx
+        (Custom_property name, Custom_value { value; layer; meta = None });
       if important then
         Pp.string ctx (if ctx.minify then "!important" else " !important")
   | Declaration { property; value; important; _ } ->

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1563,6 +1563,59 @@ let font_family_value_parser () =
   roundtrip "var(--font-source-sans-pro), system-ui";
   roundtrip "var(--font-ubuntu-mono)"
 
+(* The legacy option-returning value parsers all accept one complete value and
+   turn malformed or trailing input into [None], without leaking parser
+   exceptions. Keep that shared public contract while their cursor plumbing is
+   consolidated. *)
+let option_value_parser_contracts () =
+  let parsers =
+    [
+      ( "length",
+        (fun s -> Option.is_some (Css.parse_length s)),
+        "1px",
+        "red",
+        "1px red" );
+      ( "color",
+        (fun s -> Option.is_some (Css.parse_color s)),
+        "red",
+        "not-a-color",
+        "red junk" );
+      ( "shadow",
+        (fun s -> Option.is_some (Css.parse_shadow s)),
+        "0 1px 2px #000",
+        "not-a-shadow",
+        "0 1px 2px #000 junk" );
+      ( "background-image",
+        (fun s -> Option.is_some (Css.parse_background_image s)),
+        "url(a.png)",
+        "red",
+        "url(a.png) junk" );
+      ( "font-family",
+        (fun s -> Option.is_some (Css.parse_font_family s)),
+        "Inter, sans-serif",
+        ",",
+        "Inter, sans-serif !" );
+      ( "list-style-type",
+        (fun s -> Option.is_some (Css.parse_list_style_type s)),
+        "square",
+        "nonsense-style",
+        "square junk" );
+      ( "list-style-image",
+        (fun s -> Option.is_some (Css.parse_list_style_image s)),
+        "none",
+        "red",
+        "none junk" );
+    ]
+  in
+  List.iter
+    (fun (name, accepts, valid, malformed, trailing) ->
+      Alcotest.(check bool) (name ^ " complete value") true (accepts valid);
+      Alcotest.(check bool)
+        (name ^ " malformed value")
+        false (accepts malformed);
+      Alcotest.(check bool) (name ^ " trailing input") false (accepts trailing))
+    parsers
+
 (* CSS Syntax 3 sec. 5.4.2 "consume an at-rule" builds an at-rule node for any
    at-keyword, recognised or not; the block it consumes keeps its contents.
    Discarding an unrecognised at-rule is a user-agent cascade step (CSS 2.1 sec.
@@ -1634,6 +1687,8 @@ let suite =
         list_style_value_parsers;
       Alcotest.test_case "font-family value parser" `Quick
         font_family_value_parser;
+      Alcotest.test_case "option value parser contracts" `Quick
+        option_value_parser_contracts;
       (* AST introspection helpers *)
       Alcotest.test_case "layer_block extraction" `Quick test_layer_block;
       Alcotest.test_case "rules_of_statements" `Quick test_rules_of_statements;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1694,6 +1694,24 @@ let custom_property_values () =
   check_declaration ~expected:"z-index:var(--spec-value,{color:red;})"
     "z-index: var(--spec-value, { color: red; })"
 
+(* A typed custom property carries its layer as metadata; the layer does not
+   select a different CSS value serialization. In particular, the historical
+   [theme] layer and any caller-defined layer print the same font-family
+   value. *)
+let typed_custom_font_family_layer_printing () =
+  let render layer =
+    let declaration, _ =
+      Css.var ~layer "font-body" Css.Font_family
+        (Css.font_stack [ Css.Name "Inter"; Css.Sans_serif ])
+    in
+    Css.Declaration.to_string ~minify:true declaration
+  in
+  let theme = render "theme" in
+  Alcotest.(check string)
+    "typed font family" "--font-body:Inter,sans-serif" theme;
+  Alcotest.(check string)
+    "layer-independent serialization" theme (render "utilities")
+
 (* [parse_custom_property] builds a declaration from a name and value that came
    from outside the parser, so it takes only a pair that writes back as the one
    declaration it claims to be: a [<dashed-ident>] name, written back with the
@@ -3271,6 +3289,8 @@ let declaration_tests =
     test_case "custom properties basic" `Quick custom_properties_basic;
     test_case "custom properties" `Quick custom_properties;
     test_case "custom property values" `Quick custom_property_values;
+    test_case "typed custom font family layers print alike" `Quick
+      typed_custom_font_family_layer_printing;
     test_case "parse_custom_property rejects an escaping pair" `Quick
       parse_custom_property_guard;
     test_case "custom_property refuses an escaping pair" `Quick


### PR DESCRIPTION
Factors the seven option-returning value parsers through one private helper and removes the vestigial theme-layer declaration printer branch. Focused tests pin full-consumption, exception, and byte-identical printing behavior.