### PR TITLE
api: close public contract gaps

### DIFF
--- a/lib/container.ml
+++ b/lib/container.ml
@@ -368,8 +368,7 @@ let split_named_components components =
       if starts_query query then Some (name, query) else None
   | _ -> None
 
-let is_custom_property name =
-  String.length name >= 2 && name.[0] = '-' && name.[1] = '-'
+let is_custom_property name = Custom_property_name.is_valid name
 
 let has_semicolon_component =
   List.exists (function

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -169,8 +169,8 @@ let animation ?timeline_time ?progress ?(animated_properties = []) () =
 let empty_property_registry = { property_registrations = [] }
 
 let property_registration ?initial_value ~inherits name syntax =
-  if not (String.length name >= 2 && String.sub name 0 2 = "--") then
-    invalid_arg "property_registration: name must start with --";
+  if not (Custom_property_name.is_valid name) then
+    invalid_arg "property_registration: invalid custom-property name";
   { name; syntax; inherits; initial_value }
 
 let property_registry ?(property_registrations = []) () =
@@ -433,7 +433,7 @@ let validate_value_against_syntax (Variables.Syntax syntax) value =
 
 let validate_registered_custom_property registry decl =
   let name = Declaration.property_name decl in
-  if not (String.length name >= 2 && String.sub name 0 2 = "--") then
+  if not (Custom_property_name.is_valid name) then
     Error ("not a custom property: " ^ name)
   else
     match registered_property name registry with

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -720,10 +720,7 @@ let resolve_theme_guards_in_decls ~(theme : Pp.String_set.t option) decls =
 let resolve_theme_guards_in_stmts ~theme stmts =
   Stylesheet.map_declarations (resolve_theme_guards_in_decls ~theme) stmts
 
-let bare_theme_name raw_name =
-  if String.length raw_name >= 2 && String.sub raw_name 0 2 = "--" then
-    String.sub raw_name 2 (String.length raw_name - 2)
-  else raw_name
+let bare_theme_name raw_name = Custom_property_name.strip_prefix raw_name
 
 (* [var()] references nested anywhere inside a value, so resolving one theme
    default pulls its targets into the inject set and [Inline.vars]' recursive
@@ -785,10 +782,7 @@ let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
    declaration, an unterminated string - is not a binding this library can
    write, so the name stays unresolved and its [var()] reference stays live. *)
 let theme_default_declaration (name, value) =
-  let name =
-    if String.length name >= 2 && String.sub name 0 2 = "--" then name
-    else "--" ^ name
-  in
+  let name = Custom_property_name.add_prefix name in
   Declaration.parse_custom_property name value
 
 (* [lookup] restricted to the answers that bind: anything else reads as [None],

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3971,7 +3971,7 @@ val grid_template_rows : grid_template -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows}
      grid-template-rows} property. *)
 
-val grid_template_areas : string -> declaration
+val grid_template_areas : grid_template_areas -> declaration
 (** [grid_template_areas areas] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-areas}
      grid-template-areas} property. *)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -4433,7 +4433,8 @@ val font_family : font_family -> declaration
 val font_families : font_family list -> declaration
 (** [font_families fonts] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/font-family}
-     font-family} property from a comma-separated list. *)
+     font-family} property from a comma-separated list. Raises
+    [Invalid_argument] when [fonts] is empty. *)
 
 val font_size : length -> declaration
 (** [font_size size] is the
@@ -6060,7 +6061,7 @@ val box_shadow : shadow -> declaration
 val box_shadows : shadow list -> declaration
 (** [box_shadows values] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow} box-shadow}
-    property. *)
+    property. Raises [Invalid_argument] when [values] is empty. *)
 
 (** CSS scale property values *)
 type scale = Properties.scale =

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7669,17 +7669,19 @@ val to_string :
   ?enforce_spec:bool ->
   t ->
   string
-(** [to_string ?minify ?indent stylesheet] serialises a stylesheet to CSS. Pure
-    formatter - no optimisation, no theme resolution, no [var()] substitution.
-    Run {!optimize}, {!resolve_theme}, and {!inline_vars} explicitly when those
-    passes are needed. Spec recovery (drop invalid declarations, unknown
-    at-rules, empty rules) still applies because the parser preserved those
-    shapes for round-trip and browsers discard them during parse. Output never
-    ends with a newline.
+(** [to_string ?minify ?indent ?lossless ?enforce_spec stylesheet] serialises a
+    stylesheet to CSS. Pure formatter - no optimisation, no theme resolution, no
+    [var()] substitution. Run {!optimize}, {!resolve_theme}, and {!inline_vars}
+    explicitly when those passes are needed. Spec recovery (drop invalid
+    declarations and empty rules) still applies because the parser preserved
+    those shapes for round-trip and browsers discard them during parse. Unknown
+    at-rules are preserved. Output never ends with a newline.
 
     - [minify] toggles compact serialisation (no insignificant whitespace).
     - [indent] sets the per-level indent width.
     - [lossless] suppresses colour-channel rounding in minified output.
+    - [enforce_spec] suppresses target-dependent minified shortenings and keeps
+      their spec-canonical serialisations.
 
     @see <https://developer.mozilla.org/en-US/docs/Web/CSS> "MDN: CSS". *)
 
@@ -7864,8 +7866,9 @@ val inline_vars : ?keep_vars:string list -> ?warn:(string -> unit) -> t -> t
 
 val resolve_theme :
   ?theme:Pp.String_set.t -> ?theme_defaults:(string -> string option) -> t -> t
-(** [resolve_theme ?theme ?theme_defaults stylesheet] is the explicit AST step
-    matching the print-time [~theme] / [~theme_defaults] knobs on {!to_string}.
+(** [resolve_theme ?theme ?theme_defaults stylesheet] resolves theme guards and
+    external theme defaults as an explicit AST transformation. {!to_string} is a
+    pure formatter and does not perform this step.
 
     [theme] names the variables whose [var()] references stay live. When [theme]
     is given, references to any other name are inlined to the value

--- a/lib/custom_property_name.ml
+++ b/lib/custom_property_name.ml
@@ -1,0 +1,8 @@
+let has_prefix name =
+  String.length name >= 2 && name.[0] = '-' && name.[1] = '-'
+
+let is_valid name = String.length name > 2 && has_prefix name
+let add_prefix name = if has_prefix name then name else "--" ^ name
+
+let strip_prefix name =
+  if has_prefix name then String.sub name 2 (String.length name - 2) else name

--- a/lib/custom_property_name.mli
+++ b/lib/custom_property_name.mli
@@ -1,0 +1,16 @@
+(** Internal custom-property name classification and validation. *)
+
+val has_prefix : string -> bool
+(** [has_prefix name] reports whether [name] starts with [--]. This is a lexical
+    classification only: the bare reserved keyword [--] has the prefix but is
+    not a valid custom-property name. *)
+
+val is_valid : string -> bool
+(** [is_valid name] reports whether [name] is a custom-property name: a
+    [<dashed-ident>] other than the bare reserved keyword [--]. *)
+
+val add_prefix : string -> string
+(** [add_prefix name] adds [--] unless it is already present. *)
+
+val strip_prefix : string -> string
+(** [strip_prefix name] removes [--] when present. *)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -62,8 +62,7 @@ let rec normalize ?(lossless = false) ?(exact_srgb = false)
       let decl = normalize ~lossless ~exact_srgb ~ctx g.decl in
       if decl == g.decl then themed else theme_guarded ~var_name:g.var_name decl
 
-let is_custom_property_name name =
-  String.length name > 2 && name.[0] = '-' && name.[1] = '-'
+let is_custom_property_name = Custom_property_name.is_valid
 
 (* CSS Syntax 3 sec. 8.2: a [<declaration-value>] is one or more component
    values with no [<bad-string-token>], no [<bad-url-token>] and no unmatched
@@ -235,7 +234,7 @@ let invalid_var_arguments arguments =
     List.filter (fun component -> not (is_ws_component component)) arguments
   with
   | Component.Preserved { kind = Token.Ident name; _ } :: _
-    when String.length name >= 2 && name.[0] = '-' && name.[1] = '-' ->
+    when Custom_property_name.is_valid name ->
       false
   | _ -> true
 
@@ -1934,11 +1933,7 @@ let read_value (type a) (prop : a property) t : declaration =
 
 (** Parse a custom property (--name: value) *)
 let is_font_family_var name =
-  let bare =
-    if String.length name > 2 && String.sub name 0 2 = "--" then
-      String.sub name 2 (String.length name - 2)
-    else name
-  in
+  let bare = Custom_property_name.strip_prefix name in
   let starts_with prefix s =
     String.length s >= String.length prefix
     && String.sub s 0 (String.length prefix) = prefix
@@ -2287,7 +2282,7 @@ let read_declaration t : declaration option =
     let is_custom =
       match Cursor.peek t with
       | Some (Component.Preserved { kind = Token.Ident s; _ }) ->
-          String.length s >= 2 && s.[0] = '-' && s.[1] = '-'
+          Custom_property_name.has_prefix s
       | _ -> false
     in
     if is_custom then read_custom_property_declaration t

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2508,7 +2508,7 @@ let animation value = v Animation [ value ]
 let box_shadow value = v Box_shadow value
 
 let box_shadows = function
-  | [] -> failwith "empty box_shadows"
+  | [] -> invalid_arg "box_shadows: empty list"
   | values -> v Box_shadow (List values)
 
 (* Special helpers *)
@@ -2800,7 +2800,7 @@ let background_clip value = v Background_clip value
 let webkit_background_clip value = v Webkit_background_clip value
 
 let font_families = function
-  | [] -> failwith "empty font_families"
+  | [] -> invalid_arg "font_families: empty list"
   | fonts -> v Font_family (List fonts)
 
 let background_attachment value = v Background_attachment value

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2554,7 +2554,7 @@ let column_gap len = v Column_gap len
 let row_gap len = v Row_gap len
 
 (* Grid functions *)
-let grid_template_areas template = v Grid_template_areas (Areas template)
+let grid_template_areas value = v Grid_template_areas value
 let grid_template template = v Grid_template template
 let grid_auto_columns size = v Grid_auto_columns size
 let grid_auto_rows size = v Grid_auto_rows size

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -488,7 +488,7 @@ val row_gap : length -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap} row-gap}
     property. *)
 
-val grid_template_areas : string -> declaration
+val grid_template_areas : grid_template_areas -> declaration
 (** [grid_template_areas v] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-areas}
      grid-template-areas} property. *)

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -279,7 +279,8 @@ val box_shadow : shadow -> declaration
 val box_shadows : shadow list -> declaration
 (** [box_shadows values] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow} box-shadow}
-    property from a comma-separated list. *)
+    property from a comma-separated list. Raises [Invalid_argument] when
+    [values] is empty. *)
 
 (** Declaration constructors *)
 
@@ -1316,7 +1317,8 @@ val webkit_background_clip : background_box -> declaration
 val font_families : font_family list -> declaration
 (** [font_families fonts] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/font-family}
-     font-family} property from a comma-separated list. *)
+     font-family} property from a comma-separated list. Raises
+    [Invalid_argument] when [fonts] is empty. *)
 
 val word_spacing : length -> declaration
 (** [word_spacing v] is the

--- a/lib/dune
+++ b/lib/dune
@@ -10,6 +10,7 @@
   baseline
   block
   common
+  custom_property_name
   declaration_intf
   factor
   flatten

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -234,13 +234,7 @@ let visible_customs ~scopes ~at_path ~selector =
 
 (* [kept] names carry the [--] prefix; [Context.runtime_vars] expects the bare
    custom-property name. *)
-let runtime_var_names kept =
-  List.map
-    (fun name ->
-      if String.length name >= 2 && String.sub name 0 2 = "--" then
-        String.sub name 2 (String.length name - 2)
-      else name)
-    kept
+let runtime_var_names kept = List.map Custom_property_name.strip_prefix kept
 
 let context_for ?(kept = []) visible =
   Context.v ~custom_properties:(List.rev visible)
@@ -266,10 +260,7 @@ let read_custom_components read = function
   | _ -> None
 
 let lookup_visible_custom visible name read =
-  let dashed =
-    if String.length name >= 2 && String.sub name 0 2 = "--" then name
-    else "--" ^ name
-  in
+  let dashed = Custom_property_name.add_prefix name in
   List.find_map
     (function
       | Declaration.Declaration
@@ -303,10 +294,7 @@ let consider_custom_candidate idx best decl value =
   if better_custom_candidate ~important ~idx best then Some candidate else best
 
 let lookup_visible_custom_components visible name =
-  let dashed =
-    if String.length name >= 2 && String.sub name 0 2 = "--" then name
-    else "--" ^ name
-  in
+  let dashed = Custom_property_name.add_prefix name in
   let choose idx best decl =
     match decl with
     | Declaration.Declaration { property = Properties.Custom_property n; _ }
@@ -346,15 +334,9 @@ let parse_var_components args : (string * Component.t list option) option =
   try
     let cursor = Cursor.of_components args in
     let raw_name = Cursor.ident ~keep_case:true cursor in
-    if
-      not
-        (String.length raw_name >= 3
-        && raw_name.[0] = '-'
-        && raw_name.[1] = '-'
-        && raw_name.[2] <> '-')
-    then None
+    if not (Custom_property_name.is_valid raw_name) then None
     else
-      let name = String.sub raw_name 2 (String.length raw_name - 2) in
+      let name = Custom_property_name.strip_prefix raw_name in
       let fallback =
         Cursor.ws cursor;
         if Cursor.comma_opt cursor then Some (Cursor.remaining cursor) else None
@@ -763,7 +745,7 @@ and refs_of_var_args args =
   with Cursor.Parse_error _ -> (
     match strip_component_ws args with
     | Component.Preserved { kind = Token.Ident name; _ } :: rest
-      when String.length name >= 2 && String.sub name 0 2 = "--" ->
+      when Custom_property_name.is_valid name ->
         name :: refs_of_components (split_var_fallback [] rest)
     | Component.Preserved { kind = Token.Delim "--"; _ }
       :: Component.Preserved { kind = Token.Ident name; _ }
@@ -826,7 +808,7 @@ let rec refs_of_supports : Supports.t -> string list = function
    real property like [style(color: red)] keeps its value through substitution.
    The name is dashed as written, so it needs no normalisation. *)
 let refs_of_queried_name name =
-  if String.length name >= 2 && String.sub name 0 2 = "--" then [ name ] else []
+  if Custom_property_name.is_valid name then [ name ] else []
 
 (* CSS Conditional 5 sec. 6.2: a [style()] query is evaluated against the
    computed value the queried property has on the query container, its boolean
@@ -1124,9 +1106,7 @@ let strip_dead ~keep ~live_set stmts =
   in
   map_stmts ~parents:[] ~at_path:[] stmts
 
-let normalise_var_name name =
-  if String.length name >= 2 && String.sub name 0 2 = "--" then name
-  else String.concat "" [ "--"; name ]
+let normalise_var_name = Custom_property_name.add_prefix
 
 (* Every custom-property name the stylesheet still mentions: declared by a
    declaration, or referenced by a [var()] in a declaration or in an at-rule

--- a/lib/loc.ml
+++ b/lib/loc.ml
@@ -1,4 +1,7 @@
-(** Source locations: byte-offset ranges in the original input.
+(** Source locations: byte-offset ranges in the CSS Syntax-preprocessed input.
+
+    {!Reader.of_string} strips a leading UTF-8 BOM, replaces NUL with U+FFFD,
+    and maps CR, FF and CRLF to LF before the lexer records these offsets.
 
     Every {!Token.t} and {!Component.t} carries one, letting downstream
     validators report errors with precise positions and recover ranges for

--- a/lib/loc.mli
+++ b/lib/loc.mli
@@ -1,4 +1,7 @@
-(** Source locations: byte-offset ranges in the original input.
+(** Source locations: byte-offset ranges in the CSS Syntax-preprocessed input.
+
+    {!Reader.of_string} strips a leading UTF-8 BOM, replaces NUL with U+FFFD,
+    and maps CR, FF and CRLF to LF before the lexer records these offsets.
 
     Every {!Token.t} and {!Component.t} carries one. *)
 
@@ -20,7 +23,8 @@ val default_meta_level : meta_level
 type t = { start_pos : int; end_pos : int }
 
 val v : start_pos:int -> end_pos:int -> t
-(** [v ~start_pos ~end_pos] is a location spanning [\[start_pos, end_pos)]. *)
+(** [v ~start_pos ~end_pos] is a location spanning [\[start_pos, end_pos)] in
+    the preprocessed source buffer. *)
 
 val dummy : t
 (** [dummy] is a location of zero width at position 0. For test data and
@@ -81,7 +85,11 @@ module Context : sig
 end
 
 val snippet : ?window:int -> string -> t -> Context.snippet
-(** [snippet source loc] extracts a snippet of [source] around [loc]:
+(** [snippet source loc] extracts a snippet of [source] around [loc]: [source]
+    must be the same preprocessed buffer the lexer indexed, such as
+    {!Reader.source}; a caller's original BOM/CRLF/NUL/FF-containing string is
+    in a different coordinate space.
+
     {!Context.field-text} is the window (default: 40 bytes on each side of the
     location), {!Context.field-marker_pos} counts the characters of
     {!Context.field-text} before [loc.start_pos], and

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -744,11 +744,7 @@ let registered_foldable (stylesheet : t) : string -> bool =
               (* [@property] names carry the [--] prefix; [var()] references
                  store the bare name, so normalise to the bare form for
                  lookup. *)
-              let key =
-                if String.length pr.name >= 2 && String.sub pr.name 0 2 = "--"
-                then String.sub pr.name 2 (String.length pr.name - 2)
-                else pr.name
-              in
+              let key = Custom_property_name.strip_prefix pr.name in
               Hashtbl.replace tbl key ()
           | None -> ())
       | _ -> ())
@@ -772,11 +768,7 @@ let single_valued_calc_ctx (stmts : statement list) : Values.calc_ctx =
   let tbl : (string, unit) Hashtbl.t = Hashtbl.create 8 in
   (* [@property] names carry the [--] prefix; calc [Var] leaves store the bare
      name (the reader strips it), so key the table on the bare name. *)
-  let bare name =
-    if String.length name >= 2 && name.[0] = '-' && name.[1] = '-' then
-      String.sub name 2 (String.length name - 2)
-    else name
-  in
+  let bare = Custom_property_name.strip_prefix in
   iter_statements
     (fun (stmt : statement) ->
       match stmt with
@@ -869,11 +861,7 @@ let run_pipeline ~ctx ~enforce_spec ~aggressive stylesheet =
 let referenced_custom_props (stmts : statement list) : (string, unit) Hashtbl.t
     =
   let tbl = Hashtbl.create 64 in
-  let bare n =
-    if String.length n >= 2 && n.[0] = '-' && n.[1] = '-' then
-      String.sub n 2 (String.length n - 2)
-    else n
-  in
+  let bare = Custom_property_name.strip_prefix in
   let note_decls =
     List.iter (fun d ->
         List.iter
@@ -893,11 +881,7 @@ let referenced_custom_props (stmts : statement list) : (string, unit) Hashtbl.t
    like [Inline.vars]. *)
 let drop_unused_custom_props (stmts : statement list) : statement list =
   let referenced = referenced_custom_props stmts in
-  let bare name =
-    if String.length name >= 2 && name.[0] = '-' && name.[1] = '-' then
-      String.sub name 2 (String.length name - 2)
-    else name
-  in
+  let bare = Custom_property_name.strip_prefix in
   let keep_decl d =
     match Variables.custom_declaration_name d with
     | Some name -> Hashtbl.mem referenced (bare name)

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -869,7 +869,7 @@ let consume_qualified_rule ?(nested = false) ~meta lexer ~start_loc ~warnings :
     in
     match drop_ws (List.rev prelude) with
     | Component.Preserved { kind = Token.Ident name; _ } :: rest
-      when String.length name >= 2 && name.[0] = '-' && name.[1] = '-' -> (
+      when Custom_property_name.has_prefix name -> (
         match drop_ws rest with
         | Component.Preserved { kind = Token.Colon; _ } :: _ -> true
         | _ -> false)
@@ -982,7 +982,7 @@ let value_has_invalid_block ~is_custom value =
 (* 5.3.7 Parse a declaration from a buffered component-value list. *)
 let declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings cvs :
     Component.declaration option =
-  let is_custom = String.length name >= 2 && name.[0] = '-' && name.[1] = '-' in
+  let is_custom = Custom_property_name.has_prefix name in
   match drop_leading_ws cvs with
   | Preserved { kind = Token.Colon; _ } :: rest ->
       let value1 = trim_ws rest in

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -228,12 +228,33 @@ let column ctx =
   in
   find_newline (len - 1)
 
-let list_wrap_append ~threshold ~wrap_sep ctx s =
-  char ctx ',';
-  if column ctx + 1 + String.length s > threshold then (
+let truncate_out out len =
+  match out with
+  | Buffer b -> Buffer.truncate b len
+  | Counter c -> c.count <- len
+
+let is_layout_whitespace = function
+  | ' ' | '\t' | '\n' | '\r' | '\012' -> true
+  | _ -> false
+
+let trim_separator_layout ctx start =
+  let rec find i =
+    if i >= start && is_layout_whitespace (out_nth ctx.out i) then find (i - 1)
+    else i + 1
+  in
+  truncate_out ctx.out (find (out_length ctx.out - 1))
+
+let list_wrap_append ~threshold ~sep ~wrap_sep ctx s =
+  let separator_start = out_length ctx.out in
+  sep ctx ();
+  if column ctx + String.length s > threshold then (
+    (* A pretty separator may end in layout space (for example [, ]). Replace
+       that layout with the wrapped layout while preserving the separator
+       itself. *)
+    trim_separator_layout ctx separator_start;
     char ctx '\n';
     string ctx wrap_sep)
-  else char ctx ' ';
+  else ();
   string ctx s
 
 let list_wrap ?(threshold = 80) ~sep ~wrap_indent pp ctx l =
@@ -251,9 +272,9 @@ let list_wrap ?(threshold = 80) ~sep ~wrap_indent pp ctx l =
     | [ x ] -> pp ctx x
     | h :: t ->
         pp ctx h;
-        ignore sep;
         List.iter
-          (fun x -> list_wrap_append ~threshold ~wrap_sep ctx (measure_item x))
+          (fun x ->
+            list_wrap_append ~threshold ~sep ~wrap_sep ctx (measure_item x))
           t
 
 let option ?(none = nop) pp ctx = function

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -629,7 +629,7 @@ let rec read_timeline_name t : timeline_name =
 let read_timeline_shorthand_item t : timeline_shorthand_item =
   Cursor.ws t;
   let name = Cursor.ident ~keep_case:true t in
-  if not (String.starts_with ~prefix:"--" name) then
+  if not (Custom_property_name.is_valid name) then
     Cursor.err_invalid t "timeline name";
   Cursor.ws t;
   let axis = read_timeline_axis t in

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -294,5 +294,5 @@ let pp_length_min_max ctx (v : length_percentage) =
    fallbacks, font-palette and the animation timeline names. *)
 let read_dashed_ident t =
   let ident = Cursor.ident ~keep_case:true t in
-  if String.length ident >= 2 && ident.[0] = '-' && ident.[1] = '-' then ident
+  if Custom_property_name.is_valid ident then ident
   else Cursor.err_invalid t ("expected dashed ident, got: " ^ ident)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2347,7 +2347,7 @@ let read_any_property t =
      value is opaque); other unrecognized names fail here. The lenient
      declaration recovery in [Declaration.read_regular_property_declaration]
      catches and falls back to [read_unknown_property_declaration]. *)
-  | _ when String.length prop_name >= 2 && String.sub prop_name 0 2 = "--" ->
+  | _ when Custom_property_name.has_prefix prop_name ->
       Prop (Unknown_property prop_name)
   | _ -> Cursor.err_invalid t ("unknown property: " ^ prop_name)
 

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -147,7 +147,7 @@ let validate_identifier_start name =
   if first_char >= '0' && first_char <= '9' then
     err_invalid_identifier name "cannot start with digit";
   if String.length name >= 2 then (
-    if name.[0] = '-' && name.[1] = '-' then
+    if Custom_property_name.has_prefix name then
       err_invalid_identifier name
         "cannot start with '--' (reserved for custom properties)";
     if name.[0] = '-' && name.[1] >= '0' && name.[1] <= '9' then
@@ -188,7 +188,7 @@ let element ?ns name =
    prefix. *)
 let validate_serializable_class name =
   if String.length name = 0 then err_invalid_identifier name "cannot be empty";
-  if String.length name >= 2 && name.[0] = '-' && name.[1] = '-' then
+  if Custom_property_name.has_prefix name then
     err_invalid_identifier name
       "cannot start with '--' (reserved for custom properties)";
   String.iter

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -766,11 +766,7 @@ let normalise_charset statements =
     statements
 
 let color_custom_property_names stylesheet =
-  let var_name_of_custom_property name =
-    if String.length name >= 2 && name.[0] = '-' && name.[1] = '-' then
-      String.sub name 2 (String.length name - 2)
-    else name
-  in
+  let var_name_of_custom_property = Custom_property_name.strip_prefix in
   let declaration names = function
     | Declaration.Declaration
         {
@@ -2735,7 +2731,7 @@ let read_page (r : Cursor.t) : statement =
   Page_with_margins (selector, descriptors, margins)
 
 let validate_dashed_ident r name context =
-  if not (String.starts_with ~prefix:"--" name) then
+  if not (Custom_property_name.is_valid name) then
     Cursor.err_invalid r (context ^ " name must be a dashed ident")
 
 let font_palette_descriptor_kind = function
@@ -3334,8 +3330,8 @@ let read_supports_condition (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "supports-condition" r;
   Cursor.ws r;
   let name = Cursor.ident ~keep_case:true r in
-  if not (String.length name >= 2 && String.sub name 0 2 = "--") then
-    Cursor.err_invalid r "@supports-condition: name must start with '--'";
+  if not (Custom_property_name.is_valid name) then
+    Cursor.err_invalid r "@supports-condition: invalid custom-property name";
   Cursor.ws r;
   let declarations = Cursor.braces Declaration.read_declarations r in
   Supports_condition (name, declarations)
@@ -3439,8 +3435,8 @@ let read_property_rule (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "property" r;
   Cursor.ws r;
   let name = Cursor.ident ~keep_case:true r in
-  if not (String.length name >= 2 && String.sub name 0 2 = "--") then
-    Cursor.err_invalid r ("@property: name must start with '--', got: " ^ name);
+  if not (Custom_property_name.is_valid name) then
+    Cursor.err_invalid r ("@property: invalid custom-property name: " ^ name);
   Cursor.ws r;
   let state = Cursor.braces (fun inner -> read_property_descriptors inner) r in
   match (state.syntax, state.inherits) with

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -120,10 +120,6 @@ let string_of_font_tech = function
   | Palettes -> "palettes"
   | Incremental -> "incremental"
 
-let starts_with ~prefix s =
-  let prefix_len = String.length prefix in
-  String.length s >= prefix_len && String.sub s 0 prefix_len = prefix
-
 (* CSS Syntax 3 sec. 4.3.7 lets an escape carry a [;] or a [}] into a custom
    property's name, so the name is checked against the spelling it serializes to
    (CSS Syntax 3 sec. 2.1) rather than against its own bytes: read raw, such a
@@ -139,7 +135,7 @@ let property_name name =
   if not (Cursor.is_done reader) then
     failwith ("invalid supports declaration property name: " ^ name);
   let name =
-    if starts_with ~prefix:"--" parsed then parsed
+    if Custom_property_name.has_prefix parsed then parsed
     else String.lowercase_ascii parsed
   in
   Property_name name

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4931,10 +4931,10 @@ let read_var_body : type a. (Cursor.t -> a) -> Cursor.t -> a var =
   Cursor.ws t;
   let name = Cursor.ident ~keep_case:true t in
   (* CSS Custom Properties 1: a [var()] reference must name a [<dashed-ident>]
-     (a token starting with [--]). Reject non-dashed names. *)
-  if not (String.length name >= 2 && name.[0] = '-' && name.[1] = '-') then
-    Cursor.err_invalid t ("var() name must start with '--': " ^ name);
-  let var_name = String.sub name 2 (String.length name - 2) in
+     other than the bare reserved [--] keyword. *)
+  if not (Custom_property_name.is_valid name) then
+    Cursor.err_invalid t ("var() requires a custom-property name: " ^ name);
+  let var_name = Custom_property_name.strip_prefix name in
   Cursor.ws t;
   let fallback : _ fallback =
     if not (Cursor.comma_opt t) then None
@@ -5558,7 +5558,7 @@ let read_anchor_size_length inner =
   Anchor_size size
 
 let read_anchor_name_side inner first =
-  if String.starts_with ~prefix:"--" first then
+  if Custom_property_name.is_valid first then
     let side = Cursor.ident inner in
     (Some first, side)
   else (None, first)

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -32,7 +32,7 @@ let string_of_custom_value = Parser.to_string_custom
 let rec first_var_ref_ident = function
   | [] -> Option.None
   | Component.Preserved { Token.kind = Token.Ident n; _ } :: _
-    when String.length n >= 2 && n.[0] = '-' && n.[1] = '-' ->
+    when Custom_property_name.is_valid n ->
       Option.Some n
   | _ :: rest -> first_var_ref_ident rest
 
@@ -1893,11 +1893,7 @@ let vars_of_kind : type a. a kind -> a -> any_var list =
 let vars_of_ref_names names : any_var list =
   List.rev_map
     (fun name ->
-      let bare =
-        if String.length name >= 2 && name.[0] = '-' && name.[1] = '-' then
-          String.sub name 2 (String.length name - 2)
-        else name
-      in
+      let bare = Custom_property_name.strip_prefix name in
       V (Values.var_ref bare))
     names
 
@@ -2625,17 +2621,11 @@ let read_reference (r : Cursor.t) : string * string option =
     Cursor.call "var" r (fun inner ->
         let raw_name = Cursor.ident ~keep_case:true inner in
         (* css-variables-1: a <custom-property-name> is a <dashed-ident> other
-           than [--]. The [--] prefix must be followed by an ident-continue code
-           point that is not itself [-], otherwise the trailing dashes are
-           ambiguous with the reserved [--] keyword. *)
-        if
-          not
-            (String.length raw_name >= 3
-            && raw_name.[0] = '-'
-            && raw_name.[1] = '-'
-            && raw_name.[2] <> '-')
-        then Cursor.err_invalid inner ("not a custom property: " ^ raw_name);
-        let name = String.sub raw_name 2 (String.length raw_name - 2) in
+           than the bare reserved [--] keyword. A further leading dash is part
+           of the name. *)
+        if not (Custom_property_name.is_valid raw_name) then
+          Cursor.err_invalid inner ("not a custom property: " ^ raw_name);
+        let name = Custom_property_name.strip_prefix raw_name in
         Cursor.ws inner;
         let fallback =
           if Cursor.comma_opt inner then Some (string_of_fallback inner)

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -62,6 +62,14 @@ let optimization_flag () =
   let css_optimized = minify stylesheet in
   Alcotest.(check string) "optimized exact" ".btn{color:#00f}" css_optimized
 
+let nonempty_declaration_lists () =
+  Alcotest.check_raises "box-shadow list"
+    (Invalid_argument "box_shadows: empty list") (fun () ->
+      ignore (box_shadows []));
+  Alcotest.check_raises "font-family list"
+    (Invalid_argument "font_families: empty list") (fun () ->
+      ignore (font_families []))
+
 (* Test layers work end-to-end *)
 let layers_integration () =
   let utility_rule = rule ~selector:btn [ padding [ Px 10. ] ] in
@@ -1673,6 +1681,8 @@ let suite =
       (* Integration tests using public Css interface only *)
       Alcotest.test_case "CSS generation end-to-end" `Quick generation;
       Alcotest.test_case "optimization flag works" `Quick optimization_flag;
+      Alcotest.test_case "non-empty declaration lists" `Quick
+        nonempty_declaration_lists;
       Alcotest.test_case "layers integration" `Quick layers_integration;
       Alcotest.test_case "media queries integration" `Quick media_integration;
       Alcotest.test_case "minify flag" `Quick minify_flag;

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -70,6 +70,16 @@ let nonempty_declaration_lists () =
     (Invalid_argument "font_families: empty list") (fun () ->
       ignore (font_families []))
 
+let grid_template_areas_values () =
+  let render value =
+    Css.Declaration.to_string ~minify:true (grid_template_areas value)
+  in
+  Alcotest.(check string) "none" "grid-template-areas:none" (render No_areas);
+  Alcotest.(check string)
+    "areas" "grid-template-areas:\"a\"" (render (Areas "\"a\""));
+  Alcotest.(check string)
+    "global keyword" "grid-template-areas:initial" (render Initial)
+
 (* Test layers work end-to-end *)
 let layers_integration () =
   let utility_rule = rule ~selector:btn [ padding [ Px 10. ] ] in
@@ -1683,6 +1693,8 @@ let suite =
       Alcotest.test_case "optimization flag works" `Quick optimization_flag;
       Alcotest.test_case "non-empty declaration lists" `Quick
         nonempty_declaration_lists;
+      Alcotest.test_case "grid-template-areas values" `Quick
+        grid_template_areas_values;
       Alcotest.test_case "layers integration" `Quick layers_integration;
       Alcotest.test_case "media queries integration" `Quick media_integration;
       Alcotest.test_case "minify flag" `Quick minify_flag;

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -107,6 +107,12 @@ let test_inline_keep_vars () =
     ":root{--brand:blue}.button{color:var(--brand);border-color:#00f}"
     (optimized_minified inlined)
 
+let test_inline_triple_dash_custom_property () =
+  Alcotest.(check string)
+    "a third dash starts the custom-property name" ".x{color:red}"
+    (parse ":root{---foo:red}.x{color:var(---foo)}"
+    |> Css.inline_vars |> minified)
+
 (* Inlining deletes a non-kept variable's definition only when it has a single
    definition scope; a variable overridden in another scope is kept as a live
    var() chain and reported through [warn]. *)
@@ -779,6 +785,8 @@ let suite =
         `Quick test_inline_substitutes_vars;
       Alcotest.test_case "inline vars keep requested references" `Quick
         test_inline_keep_vars;
+      Alcotest.test_case "inline vars accept a third name dash" `Quick
+        test_inline_triple_dash_custom_property;
       Alcotest.test_case "inline vars fold and delete non-kept definitions"
         `Quick test_inline_fold_deletes_defs;
       Alcotest.test_case "inline vars keep an at-rule reference's binding"

--- a/test/test_pp.ml
+++ b/test/test_pp.ml
@@ -57,6 +57,17 @@ let list_case () =
   let result = Pp.to_string ~minify:true pp_list [ "single" ] in
   check string "single item" "single" result
 
+let list_wrap_separator_case () =
+  let pp_list threshold =
+    Pp.list_wrap ~threshold ~sep:Pp.semicolon ~wrap_indent:2 Pp.string
+  in
+  check string "pretty separator" "a;b;c"
+    (Pp.to_string ~minify:false (pp_list 80) [ "a"; "b"; "c" ]);
+  check string "wrapped separator" "a;\n  bb"
+    (Pp.to_string ~minify:false (pp_list 3) [ "a"; "bb" ]);
+  check string "minified separator" "a;b;c"
+    (Pp.to_string ~minify:true (pp_list 3) [ "a"; "b"; "c" ])
+
 let float_case () =
   (* Basic floats *)
   check_float 3.14159 ~expected:"3.14159";
@@ -269,6 +280,7 @@ let suite =
       Alcotest.test_case "indent" `Quick indent_case;
       Alcotest.test_case "block" `Quick block_case;
       Alcotest.test_case "list" `Quick list_case;
+      Alcotest.test_case "list wrap separator" `Quick list_wrap_separator_case;
       Alcotest.test_case "float" `Quick float_case;
       Alcotest.test_case "float leading zero" `Quick float_leading_zero;
       Alcotest.test_case "float negative leading zero" `Quick

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -40,6 +40,15 @@ let test_any_var () =
   (* Test negative cases *)
   neg_cursor read_reference "not-a-var()"
 
+(* CSS Variables 1 sec. 2: a custom-property name is any dashed-ident other than
+   bare [--]. A third dash starts the ident body; it is not forbidden. *)
+let custom_property_name_edges () =
+  let cursor = Cursor.of_string "var(---foo)" in
+  let name, fallback = read_reference cursor in
+  Alcotest.(check string) "third dash belongs to the name" "-foo" name;
+  Alcotest.(check (option string)) "no fallback" None fallback;
+  neg_cursor read_reference "var(--)"
+
 (* Not a roundtrip test *)
 let test_vars_of_calc () =
   (* Test calc without variables *)
@@ -544,7 +553,7 @@ let spec_custom_fallback_edges () =
           (Printexc.to_string exn)
   in
   neg "var(--color";
-  neg "var(---)";
+  check_var_ref "var(---)" "-" None;
   neg "var(--, red)"
 
 let spec_custom_computed_edges () =
@@ -575,6 +584,7 @@ let spec_custom_computed_edges () =
 let tests =
   [
     ("any_var", `Quick, test_any_var);
+    ("custom property name edges", `Quick, custom_property_name_edges);
     ("any_syntax", `Quick, test_any_syntax);
     ("spec property syntax descriptor edges", `Quick, spec_property_syntax_edges);
     ("vars of calc", `Quick, test_vars_of_calc);


### PR DESCRIPTION
Shares custom-property name validation, honors pretty list separators, gives empty declaration helpers a documented Invalid_argument contract, and accepts every typed grid-template-areas value. The same branch corrects the rendering and preprocessed-location documentation.