### PR TITLE
api: remove redundant public entry points

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,26 @@ answers.
   `Css.Stylesheet.Keep`, `Replace` or `Drop` through the new
   `Css.Stylesheet.edit` type. They previously leaked the otherwise-internal
   `Common.List.edit` type.
+- Redundant public aliases are gone. Use `Declaration.pp` and
+  `Declaration.to_string` instead of `pp_declaration` and
+  `string_of_declaration`; `Stylesheet.empty`, `Stylesheet.read` and
+  `Stylesheet.to_string` instead of `empty_stylesheet`, `read_stylesheet` and
+  the old string-valued `Stylesheet.pp`; and `Keyframe.to_string` instead of
+  `string_of_selector`. `Stylesheet.pp`, `Css.pp`, and `Container.pp` are now
+  composable `Pp.t` printers rather than string-returning aliases; use their
+  `to_string` functions when a string is required. `Pp.float` replaces the
+  identical `Pp.float_compact`. Use `Css.inline_style_of_declarations`, which
+  retains the useful `optimize` option, instead of the removed duplicate
+  `Stylesheet.inline_style_of_declarations`.
+- The unused one-off `Css.Transform`, `Css.Transform_origin`,
+  `Css.Perspective_origin` and `Css.Animation` string parser modules are gone;
+  use the corresponding `Properties.read_*` parser with a `Cursor`.
+  `Css.Gradient_direction.of_string`, which has an external caller, remains.
+  The unused Tailwind-specific `inset_ring_shadow` helper is also gone; use
+  `shadow ~inset:true` or construct the typed shadow value when its distinct
+  defaults matter.
+- `Box_shadow` is no longer a duplicate constructor of the typed `kind` GADT;
+  use `Shadow`. The `Box_shadow` CSS property constructor is unchanged.
 - `Declaration.declaration` is a private variant. Its constructors remain
   available for pattern matching, but construct values with `Declaration.v` or
   `Declaration.theme_guarded`. The public records exposed their cached hash, so

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -39,7 +39,7 @@ let style_node node = function
          them. The [Inline] mode would substitute a var() with its fallback,
          dropping the reference and changing the render. *)
       Html.set_attribute node "style"
-        (Sheet.inline_style_of_declarations ~minify:true ~mode:Variables decls)
+        (Css.inline_style_of_declarations ~minify:true ~mode:Variables decls)
 
 (* Prefix every line of a multi-line diagnostic so a downstream [grep -v
    "warning"] filters the whole entry, not just the first line. *)
@@ -122,7 +122,7 @@ let read_file path =
    that reads but does not parse is reported and the page is still written,
    without it. *)
 let read_extra = function
-  | None -> Ok (Some Sheet.empty_stylesheet)
+  | None -> Ok (Some Sheet.empty)
   | Some f -> Result.map (parse_source ~filename:f ~note:"") (read_file f)
 
 let run minimal html_file css_file () =
@@ -134,7 +134,7 @@ let run minimal html_file css_file () =
   | Ok (html, extra) ->
       let out, kept, lost =
         inline_html ~minimal ~filename:html_file ~html
-          ~extra:(Option.value extra ~default:Sheet.empty_stylesheet)
+          ~extra:(Option.value extra ~default:Sheet.empty)
       in
       if kept > 0 then
         Fmt.epr "Kept %d rule(s) with no inline form in a <style> block.@." kept;

--- a/fuzz/fuzz_apply.ml
+++ b/fuzz/fuzz_apply.ml
@@ -28,7 +28,7 @@ let pick xs buf i = List.nth xs (byte_at buf i mod List.length xs)
 let color buf i = pick [ "#abc"; "#123"; "#f00"; "#00f"; "red"; "blue" ] buf i
 
 let inline_style ds =
-  Stylesheet.inline_style_of_declarations ~minify:true ~mode:Variables ds
+  Css.inline_style_of_declarations ~minify:true ~mode:Variables ds
 
 (* [A.compute] takes a parsed sheet. The generator only assembles well-formed
    rules, so a fatal parse error is a bug in the generator, not a finding. *)

--- a/fuzz/fuzz_context.ml
+++ b/fuzz/fuzz_context.ml
@@ -18,12 +18,11 @@ let contains_literal haystack needle =
   let re = Re.compile (Re.str needle) in
   Re.execp re haystack
 
-let pp_decl decl = Css.Declaration.string_of_declaration ~minify:true decl
+let pp_decl decl = Css.Declaration.to_string ~minify:true decl
 let pp_stylesheet sheet = Css.Stylesheet.to_string ~minify:true sheet
 
 let normalize_decl decl =
-  Css.Declaration.of_string
-    (Css.Declaration.string_of_declaration ~minify:true decl)
+  Css.Declaration.of_string (Css.Declaration.to_string ~minify:true decl)
 
 let check_same_decl label expected actual =
   let expected = normalize_decl expected in
@@ -270,7 +269,7 @@ let eval_ctx ?viewport_height buf =
     ~container_width:(Px container_width) ()
 
 let stylesheet_of_string css =
-  try Css.Stylesheet.read_stylesheet (Cursor.of_string css)
+  try Css.Stylesheet.read (Cursor.of_string css)
   with Cursor.Parse_error err ->
     failf "stylesheet did not parse: %s" (Error.to_string err)
 

--- a/fuzz/fuzz_declaration.ml
+++ b/fuzz/fuzz_declaration.ml
@@ -53,7 +53,7 @@ let parse_declaration input =
   let r = Cursor.of_string input in
   try Css.Declaration.read_declaration r with Cursor.Parse_error _ -> None
 
-let serialize decl = Css.Declaration.string_of_declaration ~minify:true decl
+let serialize decl = Css.Declaration.to_string ~minify:true decl
 
 let assert_invalid_declaration_contract =
   Fuzz_helpers.assert_invalid_declaration_contract

--- a/fuzz/fuzz_keyframe.ml
+++ b/fuzz/fuzz_keyframe.ml
@@ -32,7 +32,7 @@ let test_selector_roundtrip buf =
   match Css.Keyframe.selector_of_string buf with
   | exception Invalid_argument _ -> ()
   | sel ->
-      let s = Css.Keyframe.string_of_selector sel in
+      let s = Css.Keyframe.to_string sel in
       let sel2 = Css.Keyframe.selector_of_string s in
       if not (Css.Keyframe.selector_equal sel sel2) then
         fail "selector roundtrip mismatch"

--- a/fuzz/fuzz_optimize.ml
+++ b/fuzz/fuzz_optimize.ml
@@ -188,8 +188,7 @@ let minified ss = Css.Stylesheet.to_string ~minify:true ss |> String.trim
 
 let parse_stylesheet input =
   let r = Cursor.of_string input in
-  try Some (Css.Stylesheet.read_stylesheet r)
-  with Cursor.Parse_error _ -> None
+  try Some (Css.Stylesheet.read r) with Cursor.Parse_error _ -> None
 
 let class_name prefix buf i = prefix ^ string_of_int (byte_at buf i mod 10)
 

--- a/fuzz/fuzz_properties.ml
+++ b/fuzz/fuzz_properties.ml
@@ -656,14 +656,11 @@ let test_inventory_css_wide_generation buf =
   | None ->
       failf "deterministic manifest CSS-wide declaration rejected: %S" input
   | Some decl -> (
-      let serialized =
-        Css.Declaration.string_of_declaration ~minify:true decl
-      in
+      let serialized = Css.Declaration.to_string ~minify:true decl in
       let c2 = Cursor.of_string serialized in
       match Css.Declaration.read_declaration c2 with
       | Some reparsed
-        when Css.Declaration.string_of_declaration ~minify:true reparsed
-             = serialized ->
+        when Css.Declaration.to_string ~minify:true reparsed = serialized ->
           ()
       | _ ->
           failf
@@ -679,13 +676,10 @@ let assert_decl_roundtrip label input =
   match parse_declaration input with
   | None -> failf "%s declaration rejected: %S" label input
   | Some decl -> (
-      let serialized =
-        Css.Declaration.string_of_declaration ~minify:true decl
-      in
+      let serialized = Css.Declaration.to_string ~minify:true decl in
       match parse_declaration serialized with
       | Some reparsed
-        when Css.Declaration.string_of_declaration ~minify:true reparsed
-             = serialized ->
+        when Css.Declaration.to_string ~minify:true reparsed = serialized ->
           ()
       | _ ->
           failf "%s declaration did not structurally roundtrip: %S -> %S" label
@@ -727,13 +721,10 @@ let test_inventory_positive_values buf =
   | None ->
       failf "deterministic manifest positive declaration rejected: %S" input
   | Some decl -> (
-      let serialized =
-        Css.Declaration.string_of_declaration ~minify:true decl
-      in
+      let serialized = Css.Declaration.to_string ~minify:true decl in
       match parse_declaration serialized with
       | Some reparsed
-        when Css.Declaration.string_of_declaration ~minify:true reparsed
-             = serialized ->
+        when Css.Declaration.to_string ~minify:true reparsed = serialized ->
           ()
       | _ ->
           failf
@@ -764,13 +755,10 @@ let test_inventory_var_values buf =
   match parse_declaration input with
   | None -> failf "deterministic manifest var() declaration rejected: %S" input
   | Some decl -> (
-      let serialized =
-        Css.Declaration.string_of_declaration ~minify:true decl
-      in
+      let serialized = Css.Declaration.to_string ~minify:true decl in
       match parse_declaration serialized with
       | Some reparsed
-        when Css.Declaration.string_of_declaration ~minify:true reparsed
-             = serialized ->
+        when Css.Declaration.to_string ~minify:true reparsed = serialized ->
           ()
       | _ ->
           failf
@@ -929,13 +917,10 @@ let assert_branch_roundtrip input =
   | None ->
       failf "property branch-depth positive declaration rejected: %S" input
   | Some decl -> (
-      let serialized =
-        Css.Declaration.string_of_declaration ~minify:true decl
-      in
+      let serialized = Css.Declaration.to_string ~minify:true decl in
       match parse_declaration serialized with
       | Some reparsed
-        when Css.Declaration.string_of_declaration ~minify:true reparsed
-             = serialized ->
+        when Css.Declaration.to_string ~minify:true reparsed = serialized ->
           ()
       | _ ->
           failf

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -306,16 +306,14 @@ let generated_condition_stylesheet buf =
 
 let parse_stylesheet input =
   let r = Cursor.of_string input in
-  try Some (Css.Stylesheet.read_stylesheet r)
-  with Cursor.Parse_error _ -> None
+  try Some (Css.Stylesheet.read r) with Cursor.Parse_error _ -> None
 
 let parse_declaration input =
   let r = Cursor.of_string input in
   try
     match Css.Declaration.read_declaration r with
     | None -> None
-    | Some decl ->
-        Some (Css.Declaration.string_of_declaration ~minify:true decl)
+    | Some decl -> Some (Css.Declaration.to_string ~minify:true decl)
   with Cursor.Parse_error _ | Error.Parse_error _ -> None
 
 let minified_stylesheet ss =
@@ -603,11 +601,10 @@ let anonymous_layer_count ss =
   and block_count block = List.fold_left (fun n s -> n + statement s) 0 block in
   block_count ss
 
-(** read_stylesheet -- must not crash on arbitrary input. *)
+(** [Stylesheet.read] must not crash on arbitrary input. *)
 let test_read_stylesheet buf =
   let r = Cursor.of_string buf in
-  try ignore (Css.Stylesheet.read_stylesheet r)
-  with Cursor.Parse_error _ -> ()
+  try ignore (Css.Stylesheet.read r) with Cursor.Parse_error _ -> ()
 
 (** read_rule -- must not crash. *)
 let test_read_rule buf =
@@ -659,14 +656,13 @@ let test_read_property_value buf =
 let test_stylesheet_roundtrip buf =
   let r = Cursor.of_string buf in
   match
-    try Some (Css.Stylesheet.read_stylesheet r)
-    with Cursor.Parse_error _ -> None
+    try Some (Css.Stylesheet.read r) with Cursor.Parse_error _ -> None
   with
   | None -> ()
   | Some ss -> (
       let s = Css.Stylesheet.to_string ss in
       let r2 = Cursor.of_string s in
-      try ignore (Css.Stylesheet.read_stylesheet r2)
+      try ignore (Css.Stylesheet.read r2)
       with Cursor.Parse_error _ -> fail "stylesheet roundtrip re-parse failed")
 
 (* Allow one canonicalization pass (numeric trim, [1e3] -> [1000], escape
@@ -1598,7 +1594,7 @@ let test_comments_anywhere_robust buf =
         mutated
         (Cascade.Error.to_string err)
 
-(* Comments in raw bytes: the lower-level [read_stylesheet] (used through
+(* Comments in raw bytes: the lower-level [Stylesheet.read] (used through
    [Cursor.of_string]) must also not crash when the input contains comments at
    pathological positions, even alongside random garbage. *)
 let test_comments_random_no_crash buf =
@@ -1717,7 +1713,7 @@ let test_invalid_prelude_order buf =
 
 let parser_cases =
   [
-    test_case "read_stylesheet crash safety" [ bytes ] test_read_stylesheet;
+    test_case "stylesheet read crash safety" [ bytes ] test_read_stylesheet;
     test_case "read_rule crash safety" [ bytes ] test_read_rule;
     test_case "read_block crash safety" [ bytes ] test_read_block;
     test_case "read crash safety" [ bytes ] test_read;

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -150,9 +150,7 @@ let parse_inline s =
   | exception Error.Parse_error _ -> []
 
 let decl_value d =
-  let s =
-    Stylesheet.inline_style_of_declarations ~minify:true ~mode:Variables [ d ]
-  in
+  let s = Css.inline_style_of_declarations ~minify:true ~mode:Variables [ d ] in
   match String.index_opt s ':' with
   | Some i -> String.sub s (i + 1) (String.length s - i - 1)
   | None -> s

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -170,7 +170,7 @@ let to_string ?(minify = false) t = to_string_with ~pretty:false ~minify t
 let to_stylesheet_string ?(minify = false) t =
   to_string_with ~pretty:true ~minify t
 
-let pp t = to_string t
+let pp ctx t = Pp.string ctx (to_string ~minify:(Pp.minified ctx) t)
 
 (* A style query holds component values, which carry the source positions they
    were read from, so a structural walk would call two spellings of one query

--- a/lib/container.mli
+++ b/lib/container.mli
@@ -80,8 +80,8 @@ val to_stylesheet_string : ?minify:bool -> t -> string
     printing. Non-minified output keeps optional whitespace in typed shorthand
     feature queries. *)
 
-val pp : t -> string
-(** [pp t] returns a string representation of a container condition. *)
+val pp : t Pp.t
+(** [pp] is a composable printer for a container condition. *)
 
 val of_string : string -> t
 (** [of_string s] parses a container condition. Raises

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -486,7 +486,7 @@ let pp_field ctx ~first label print_value value =
   Pp.char ctx '=';
   print_value ctx value
 
-let pp_decl_list ctx items = pp_debug_list Declaration.pp_declaration ctx items
+let pp_decl_list ctx items = pp_debug_list Declaration.pp ctx items
 let pp_bool ctx value = Pp.string ctx (string_of_bool value)
 let pp_int ctx value = Pp.string ctx (string_of_int value)
 
@@ -497,7 +497,7 @@ let pp_cascade_rule ctx (rule : cascade_rule) =
   pp_field ctx ~first "important" pp_bool rule.important;
   pp_field ctx ~first "layer" pp_string_option rule.layer;
   pp_field ctx ~first "source_order" pp_int rule.source_order;
-  pp_field ctx ~first "declaration" Declaration.pp_declaration rule.declaration;
+  pp_field ctx ~first "declaration" Declaration.pp rule.declaration;
   Pp.char ctx '}'
 
 let pp_cascade_rules ctx = function
@@ -664,9 +664,6 @@ let kind_equal : type a b.
   | Properties.Font_size, Properties.Font_size -> Some Refl
   | Properties.Filter, Properties.Filter -> Some Refl
   | Properties.Shadow, Properties.Shadow -> Some Refl
-  | Properties.Shadow, Properties.Box_shadow -> Some Refl
-  | Properties.Box_shadow, Properties.Shadow -> Some Refl
-  | Properties.Box_shadow, Properties.Box_shadow -> Some Refl
   | Properties.Color, Properties.Color -> Some Refl
   | Properties.Gradient_stop, Properties.Gradient_stop -> Some Refl
   | Properties.Background_image, Properties.Background_image -> Some Refl
@@ -1791,7 +1788,7 @@ module Import = struct
   let parse_source rule source =
     try
       let cursor = Cursor.of_string source in
-      let sheet = Stylesheet.read_stylesheet cursor in
+      let sheet = Stylesheet.read cursor in
       Ok (wrap_in_layer rule sheet)
     with
     | Failure msg -> Error msg

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -40,28 +40,9 @@ let parse_full ~property read s =
       else Ok v
     with Cursor.Parse_error e -> Error e
 
-module Transform = struct
-  let of_string s = parse_full ~property:"transform" Properties.read_transform s
-end
-
 module Gradient_direction = struct
   let of_string s =
     parse_full ~property:"gradient-direction" Properties.read_gradient_prelude s
-end
-
-module Transform_origin = struct
-  let of_string s =
-    parse_full ~property:"transform-origin" Properties.read_transform_origin s
-end
-
-module Perspective_origin = struct
-  let of_string s =
-    parse_full ~property:"perspective-origin" Properties.read_perspective_origin
-      s
-end
-
-module Animation = struct
-  let of_string s = parse_full ~property:"animation" Properties.read_animation s
 end
 
 let eval_declaration ?layer_order ?layer ctx decl =
@@ -626,21 +607,47 @@ and statement_for_inline ~live ~keep_layers statement =
    no handler is not in that set: the browser ignoring it is a cascade step, and
    a serialiser has no agent to be. Compose {!optimize}, {!resolve_theme},
    {!inline_vars} upstream when needed. *)
-let to_string ?(minify = false) ?indent ?lossless ?enforce_spec stylesheet =
+let pp ctx stylesheet =
   let stylesheet =
     stylesheet |> Optimize.drop_invalid |> Optimize.drop_empty_rules
   in
-  Stylesheet.to_string ~minify ?indent ?lossless ?enforce_spec stylesheet
+  Stylesheet.pp ctx stylesheet
 
-let pp = to_string
+let to_string ?(minify = false) ?indent ?lossless ?enforce_spec stylesheet =
+  Pp.to_string ~minify ?indent ?lossless ?enforce_spec pp stylesheet
 
 (* Append the serialised stylesheet to [buf]. *)
 let to_buffer buf ?(minify = false) ?indent ?lossless ?enforce_spec stylesheet =
-  let stylesheet =
-    stylesheet |> Optimize.drop_invalid |> Optimize.drop_empty_rules
+  Pp.to_buffer ~minify ?indent ?lossless ?enforce_spec buf pp stylesheet
+
+let pp_inline_important ~minify ctx =
+  if minify then Pp.string ctx "!important"
+  else (
+    Pp.space ctx ();
+    Pp.string ctx "!important")
+
+let pp_inline_declaration ~minify ~mode ctx declaration =
+  let name = Declaration.property_name declaration in
+  let value =
+    Declaration.string_of_value ~minify ~inline:(mode = Inline) declaration
   in
-  let pp ctx () = Stylesheet.pp_stylesheet ctx stylesheet in
-  Pp.to_buffer ~minify ?indent ?lossless ?enforce_spec buf pp ()
+  Pp.string ctx name;
+  Pp.char ctx ':';
+  if not minify then Pp.space ctx ();
+  Pp.string ctx value;
+  if Declaration.is_important declaration then pp_inline_important ~minify ctx
+
+let render_inline_style ?(minify = false) ?(mode : mode = Inline) declarations =
+  let buffer = Buffer.create 128 in
+  let ctx = Pp.ctx ~minify ~inline:(mode = Inline) buffer in
+  List.iteri
+    (fun index declaration ->
+      if index > 0 then (
+        Pp.semicolon ctx ();
+        if not minify then Pp.space ctx ());
+      pp_inline_declaration ~minify ~mode ctx declaration)
+    declarations;
+  Buffer.contents buffer
 
 let inline_style_of_declarations ?(optimize = false) ?minify ?mode declarations
     =
@@ -648,7 +655,7 @@ let inline_style_of_declarations ?(optimize = false) ?minify ?mode declarations
     if optimize then Optimize.deduplicate_declarations declarations
     else declarations
   in
-  inline_style_of_declarations ?minify ?mode declarations
+  render_inline_style ?minify ?mode declarations
 
 let optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
     ?regroup ?closed_world ?objective ?prune_unused_custom_props ?stats

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -90,41 +90,12 @@ module Nest = Nest
 (** Parser building blocks live at the library root ([Cascade.Cursor],
     [Cascade.Parser], [Cascade.Token], ...), not under [Css]. *)
 
-(** {2:value_parsers Per-type value parsers}
-
-    [of_string] wrappers around the [Properties.read_*] cursor-driven parsers
-    used internally by {!Declaration.of_string}. The argument is the
-    right-hand-side of a declaration, with no [property:] prefix or trailing
-    [;]. They are intended for callers (e.g. Tailwind bracket values) that have
-    already extracted a typed value substring and need to lift it into the typed
-    AST without round-tripping through a full declaration. *)
-
-module Transform : sig
-  val of_string : string -> (Properties.transform, Error.t) result
-  (** [of_string s] parses [s] as a single {!val-transform} value. *)
-end
+(** {2:value_parsers Per-type value parsers} *)
 
 module Gradient_direction : sig
   val of_string : string -> (Properties.gradient_direction, Error.t) result
   (** [of_string s] parses [s] as a gradient [<direction>] (a side keyword, an
       [<angle>], or a [<direction> in <color-interpolation>] form). *)
-end
-
-module Transform_origin : sig
-  val of_string : string -> (Properties.transform_origin, Error.t) result
-  (** [of_string s] parses [s] as a [transform-origin] value. *)
-end
-
-module Perspective_origin : sig
-  val of_string : string -> (Properties.perspective_origin, Error.t) result
-  (** [of_string s] parses [s] as a [perspective-origin] value. *)
-end
-
-module Animation : sig
-  val of_string : string -> (Properties.animation, Error.t) result
-  (** [of_string s] parses [s] as a single {!val-animation} shorthand entry (one
-      comma-separated entry; for the full list use {!Properties.read_animations}
-      with a cursor). *)
 end
 
 (** {2:css_rules CSS Rules and Stylesheets}
@@ -1510,11 +1481,6 @@ val declaration_value_for_equivalence : declaration -> string
     the equivalent unquoted [<ident>] sequence. Used as a structural-diff key so
     [--font: "Noto Color Emoji"] and [--font: Noto Color Emoji] compare equal;
     not for emission, where both forms stay verbatim. *)
-
-val string_of_declaration : ?minify:bool -> declaration -> string
-(** [string_of_declaration ~minify decl] converts a declaration to its string
-    representation. If [minify] is [true] (default: [false]), the output is
-    minified. *)
 
 (** {1 Property Categories}
 
@@ -5041,18 +5007,6 @@ val shadow :
     inset_var=None, inset_var_no_fallback=false, h_offset=0px, v_offset=0px,
     blur=0px, spread=0px, color=Transparent. *)
 
-val inset_ring_shadow :
-  ?h_offset:length ->
-  ?v_offset:length ->
-  ?blur:length ->
-  ?spread:length ->
-  ?color:color ->
-  unit ->
-  shadow
-(** [inset_ring_shadow ?h_offset ?v_offset ?blur ?spread ?color ()] is an inset
-    shadow value suitable for ring utilities. Defaults: h_offset=0px,
-    v_offset=0px, blur=0px, spread=0px, color=Transparent. *)
-
 (** CSS text-shadow values *)
 type text_shadow = Properties.text_shadow =
   | None
@@ -7473,7 +7427,6 @@ type 'a kind = 'a Properties.kind =
   | Rotate : rotate_value kind
   | Scale : scale kind
   | Shadow : shadow kind
-  | Box_shadow : shadow kind
   | Content : content kind
   | Gradient_stop : gradient_stop kind
   | Gradient_direction : gradient_direction kind
@@ -7685,14 +7638,9 @@ val to_string :
 
     @see <https://developer.mozilla.org/en-US/docs/Web/CSS> "MDN: CSS". *)
 
-val pp :
-  ?minify:bool ->
-  ?indent:int ->
-  ?lossless:bool ->
-  ?enforce_spec:bool ->
-  t ->
-  string
-(** [pp] is {!to_string}. *)
+val pp : t Pp.t
+(** [pp] is the composable form of {!to_string}. It applies the same invalid
+    declaration and empty-rule filtering before printing. *)
 
 val to_buffer :
   Buffer.t ->

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2453,7 +2453,7 @@ let with_opaque_value decl value =
   if is_important decl then important opaque else opaque
 
 (* Pretty printer for declarations *)
-let rec pp_declaration : declaration Pp.t =
+let rec pp : declaration Pp.t =
  fun ctx -> function
   | Declaration
       {
@@ -2485,18 +2485,14 @@ let rec pp_declaration : declaration Pp.t =
   | Theme_guarded { decl; _ } ->
       (* Theme guards are resolved by the transform layer; if one survives to
          print time, emit the wrapped declaration. *)
-      pp_declaration ctx decl
-
-let pp = pp_declaration
+      pp ctx decl
 
 (* Convert a declaration to its string representation *)
-let string_of_declaration ?(minify = false) decl =
+let to_string ?(minify = false) (decl : t) =
   let buf = Buffer.create 32 in
   let ctx = Pp.ctx ~minify buf in
-  pp_declaration ctx decl;
+  pp ctx decl;
   Buffer.contents buf
-
-let to_string ?minify (decl : t) = string_of_declaration ?minify decl
 
 (* Single-to-list property helpers *)
 let background_image value = v Background_image [ value ]

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -25,9 +25,6 @@ type t = declaration
 val pp_property : 'a Properties.property Pp.t
 (** [pp_property] is the pretty-printer for CSS property names. *)
 
-val pp_declaration : declaration Pp.t
-(** [pp_declaration] is the pretty-printer for declarations. *)
-
 val pp : t Pp.t
 (** [pp] is the pretty-printer for declarations. *)
 
@@ -51,11 +48,6 @@ val normalize :
     pure serialiser. [lossless] disables colour approximation. [exact_srgb] is
     {!Properties.normalize_property_value}'s flag of the same name, for the
     canonical diff projection only. *)
-
-val string_of_declaration : ?minify:bool -> declaration -> string
-(** [string_of_declaration ~minify decl] converts a declaration to its string
-    representation. If [minify] is [true] (default: [false]), the output is
-    minified. *)
 
 val to_string : ?minify:bool -> t -> string
 (** [to_string ~minify d] converts a declaration to CSS source text. *)

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2612,7 +2612,7 @@ let keyframe_frames_diff frames1 frames2 =
     diffs ~key_of ~key_equal ~is_empty_diff frames1 frames2
   in
   let selector_str (frame : Css.keyframe) =
-    Css.Keyframe.string_of_selector frame.selector
+    Css.Keyframe.to_string frame.selector
   in
   let added_changes =
     List.map

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1617,7 +1617,7 @@ let strip_evaluated_guards ~(query : Context.query option) (rule : import_rule)
 
 let parse_import_content content =
   let cursor = Cursor.of_string content in
-  match read_stylesheet cursor with
+  match read cursor with
   | stylesheet -> Some stylesheet
   | exception Cursor.Parse_error _ -> (
       match

--- a/lib/keyframe.ml
+++ b/lib/keyframe.ml
@@ -26,12 +26,11 @@ type selector = Positions of position list
 
 type t = selector
 
-let string_of_selector = function
+let to_string = function
   | Positions positions ->
       String.concat ", " (List.map string_of_position positions)
 
-let to_string = string_of_selector
-let pp ctx selector = Pp.string ctx (string_of_selector selector)
+let pp ctx selector = Pp.string ctx (to_string selector)
 
 let percent_of_position = function
   | From -> 0.
@@ -96,4 +95,4 @@ let selector_of_string s =
     Positions positions
   else invalid_arg ("invalid keyframe selector: " ^ s)
 
-let selector_equal a b = string_of_selector a = string_of_selector b
+let selector_equal a b = to_string a = to_string b

--- a/lib/keyframe.mli
+++ b/lib/keyframe.mli
@@ -21,9 +21,6 @@ type t = selector
 val pp : t Pp.t
 (** [pp] renders a keyframe selector. *)
 
-val string_of_selector : selector -> string
-(** [string_of_selector sel] renders a selector as CSS string. *)
-
 val to_string : t -> string
 (** [to_string sel] renders a selector as CSS source text. *)
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -867,7 +867,7 @@ let referenced_custom_props (stmts : statement list) : (string, unit) Hashtbl.t
         List.iter
           (fun n -> Hashtbl.replace tbl (bare n) ())
           (Variables.var_refs_in_value_string
-             (Declaration.string_of_declaration ~minify:true d)))
+             (Declaration.to_string ~minify:true d)))
   in
   (* Through the exhaustive walk rather than a local match: a reference it
      cannot reach reads as no reference at all, and [@keyframes], [@page] and

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -420,8 +420,6 @@ let float ctx f =
     int ctx (int_of_float f)
   else string ctx (string_of_float ~drop_leading_zero:true f)
 
-let float_compact = float
-
 let float_n n ctx f =
   if Float.is_nan f then nan_value ctx ""
   else if Float.is_integer f && Float.abs f <= float_of_int max_int then

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -219,11 +219,6 @@ val float : float t
     - No scientific notation (uses bounded precision)
     - Trims trailing zeros. *)
 
-val float_compact : float t
-(** [float_compact] like {!val-float} but always drops leading zeros regardless
-    of minification mode. Used for oklch chroma values where Tailwind always
-    uses compact format (e.g. [.034] not [0.034]). *)
-
 val float_n : int -> float t
 (** [float_n n] formats float to exactly n decimal places using round-half-up.
     Used for CSS color channels and opacity where precision matters. *)

--- a/lib/preflight.ml
+++ b/lib/preflight.ml
@@ -4,7 +4,7 @@ let useful_gain_ratio_ppm = 140_000
 
 (* Source size and both gains are tracked in approximate minified bytes so a few
    repeated long declarations register their real weight, not just a count. *)
-let decl_size = Pp.size ~minify:true Declaration.pp_declaration
+let decl_size = Pp.size ~minify:true Declaration.pp
 
 type t = {
   mutable source_units : int;

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1499,13 +1499,6 @@ let shadow ?(inset = false) ?(inset_var : string option)
       Inset (Toggle { name; no_fallback = inset_var_no_fallback; body })
   | None -> if inset then Inset (Body body) else Shadow body
 
-let inset_ring_shadow ?(h_offset : length option) ?(v_offset : length option)
-    ?(blur : length option) ?(spread : length option) ?(color : color option) ()
-    : shadow =
-  let h_offset = Option.value h_offset ~default:(Zero : length) in
-  let v_offset = Option.value v_offset ~default:(Zero : length) in
-  (Inset (Body { h_offset; v_offset; blur; spread; color }) : shadow)
-
 let border_shorthand ?width ?style ?color () : border =
   Shorthand { width; style; color }
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2680,7 +2680,6 @@ let pp_value : type a. (a kind * a) Pp.t =
   | Angle -> pp pp_angle
   | Rotate -> pp pp_rotate_value
   | Scale -> pp pp_scale
-  | Box_shadow -> pp pp_shadow
   | Content -> pp pp_content
   | Gradient_stop -> pp pp_gradient_stop
   | Gradient_direction -> pp pp_gradient_direction

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2538,17 +2538,6 @@ val shadow :
     [inset_var_no_fallback] is true). Defaults: inset=false, h_offset=0px,
     v_offset=0px, blur=0px, spread=0px, color=Rgb(0,0,0). *)
 
-val inset_ring_shadow :
-  ?h_offset:length ->
-  ?v_offset:length ->
-  ?blur:length ->
-  ?spread:length ->
-  ?color:color ->
-  unit ->
-  shadow
-(** [inset_ring_shadow ~h_offset ~v_offset ~blur ~spread ~color] is an inset
-    shadow with the given parameters. *)
-
 (** {2 Generic property handling} *)
 
 val pp_any_property : any_property Pp.t

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4468,7 +4468,6 @@ type _ kind =
   | Rotate : rotate_value kind
   | Scale : scale kind
   | Shadow : shadow kind
-  | Box_shadow : shadow kind
   | Content : content kind
   | Gradient_stop : gradient_stop kind
   | Gradient_direction : gradient_direction kind

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -213,7 +213,7 @@ let rec share_branch a b =
       else if c < 0 then share_branch xs b
       else share_branch a ys
 
-let declaration_size decl = Pp.size ~minify:true Declaration.pp_declaration decl
+let declaration_size decl = Pp.size ~minify:true Declaration.pp decl
 
 let rule_summary rule =
   Summary.v ~rule_size:Size.rule ~decl_size:declaration_size

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -113,9 +113,7 @@ let canonical_declarations (decls : Declaration.declaration list) :
       let arr = Array.of_list decls in
       let n = Array.length arr in
       let keys =
-        Array.map
-          (fun d -> Pp.to_string ~minify:true Declaration.pp_declaration d)
-          arr
+        Array.map (fun d -> Pp.to_string ~minify:true Declaration.pp d) arr
       in
       let footprints = Array.map Shorthand.declaration_overlap_keys arr in
       let indeg = overlap_indegrees arr footprints in

--- a/lib/size.ml
+++ b/lib/size.ml
@@ -1,5 +1,5 @@
 let decls ds =
-  let pp ctx ds = List.iter (Declaration.pp_declaration ctx) ds in
+  let pp ctx ds = List.iter (Declaration.pp ctx) ds in
   Pp.size ~minify:true pp ds
 
 let rule (r : Stylesheet.rule) =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -246,7 +246,7 @@ let starting_style_nested declarations =
 
 let keyframes name frames = Keyframes (name, frames)
 let v statements : stylesheet = statements
-let empty_stylesheet : stylesheet = []
+let empty : stylesheet = []
 
 (** {1 Accessors} *)
 
@@ -612,7 +612,7 @@ let pp_keyframe : keyframe Pp.t =
  fun ctx kf ->
   pp_keyframe_selector ctx kf.selector;
   Pp.sp ctx ();
-  Pp.braced_semicolon_list Declaration.pp_declaration ctx kf.declarations
+  Pp.braced_semicolon_list Declaration.pp ctx kf.declarations
 
 let pp_keyframes_block_statement ctx header name frames =
   Pp.string ctx header;
@@ -651,15 +651,14 @@ let pp_page_margin_rule : page_margin_rule Pp.t =
   Pp.string ctx "@";
   Pp.string ctx rule.name;
   Pp.sp ctx ();
-  Pp.braced_semicolon_list Declaration.pp_declaration ctx rule.descriptors
+  Pp.braced_semicolon_list Declaration.pp ctx rule.descriptors
 
 let pp_page_with_margins_body ctx descriptors margins =
   Pp.braces
     (fun ctx () ->
       Pp.list ~sep:Pp.semicolon_cut
         (fun ctx (i, d) ->
-          if i = 0 then Declaration.pp_declaration ctx d
-          else Pp.indent Declaration.pp_declaration ctx d)
+          if i = 0 then Declaration.pp ctx d else Pp.indent Declaration.pp ctx d)
         ctx
         (List.mapi (fun i d -> (i, d)) descriptors);
       if descriptors <> [] && margins <> [] then (
@@ -1035,7 +1034,7 @@ let pp_declarations_statement ctx raw_decls =
   (* Bare declarations for CSS nesting - no selector/braces, just declarations.
      No extra indent since the containing block handles it *)
   let decls = raw_decls in
-  Pp.list ~sep:Pp.semicolon_cut Declaration.pp_declaration ctx decls;
+  Pp.list ~sep:Pp.semicolon_cut Declaration.pp ctx decls;
   if decls <> [] && not ctx.Pp.minify then Pp.semicolon ctx ()
 
 let pp_namespace_uri ctx = function
@@ -1266,9 +1265,7 @@ let rec pp_rule : rule Pp.t =
   | decls, nested ->
       let ctx = Pp.enter_style_rule { ctx with level = ctx.level + 1 } in
       let pp_declarations ctx () =
-        Pp.list ~sep:Pp.semicolon_cut
-          (Pp.indent Declaration.pp_declaration)
-          ctx decls
+        Pp.list ~sep:Pp.semicolon_cut (Pp.indent Declaration.pp) ctx decls
       in
       let pp_nested ctx () =
         let rec loop = function
@@ -1451,7 +1448,7 @@ and pp_statement : statement Pp.t =
       Pp.string ctx "@supports-condition ";
       Pp.string ctx name;
       Pp.sp ctx ();
-      Pp.braced_semicolon_list Declaration.pp_declaration ctx declarations
+      Pp.braced_semicolon_list Declaration.pp ctx declarations
   | Origin (_, content) -> pp_block ctx content
   | Scope (start, end_, content) -> pp_scope_statement ctx start end_ content
   | Keyframes (name, frames) ->
@@ -1473,7 +1470,7 @@ and pp_statement : statement Pp.t =
       Pp.string ctx "@page";
       pp_page_selector ctx selector;
       Pp.sp ctx ();
-      Pp.braced_semicolon_list Declaration.pp_declaration ctx raw_declarations
+      Pp.braced_semicolon_list Declaration.pp ctx raw_declarations
   | Page_with_margins (selector, descriptors, margins) ->
       Pp.string ctx "@page";
       pp_page_selector ctx selector;
@@ -1499,7 +1496,7 @@ and pp_statement : statement Pp.t =
       Pp.string ctx "@position-try ";
       Pp.string ctx (Parser.escape_ident name);
       Pp.sp ctx ();
-      Pp.braced_semicolon_list Declaration.pp_declaration ctx declarations
+      Pp.braced_semicolon_list Declaration.pp ctx declarations
   | Viewport (prefix, descriptors) ->
       pp_viewport_statement ctx prefix descriptors
   | Unknown_at_rule { name; prelude; block } ->
@@ -1554,6 +1551,8 @@ let pp_stylesheet : stylesheet Pp.t =
   in
   loop statements
 
+let pp = pp_stylesheet
+
 (** {1 Rendering} *)
 
 (* One walk of the tree. Presizing the buffer from a [Pp.size] prepass would
@@ -1564,8 +1563,6 @@ let to_string ?(minify = false) ?indent ?lossless ?enforce_spec (statements : t)
     =
   let pp ctx () = pp_stylesheet ctx statements in
   Pp.to_string ~minify ?indent ?lossless ?enforce_spec pp ()
-
-let pp = to_string
 
 (** {1 Legacy Compatibility} *)
 
@@ -1652,7 +1649,6 @@ let queries_of pick block =
        [] block)
 
 (* Legacy compatibility functions *)
-let empty = empty_stylesheet
 let rules t = extract_rules t
 
 let media_queries t =
@@ -3988,7 +3984,7 @@ let rec read_stylesheet_statements r state acc =
     validate_stylesheet_prelude r state stmt;
     read_stylesheet_statements r state (stmt :: acc)
 
-let read_stylesheet (r : Cursor.t) : stylesheet =
+let read (r : Cursor.t) : stylesheet =
   Cursor.with_context r "stylesheet" (fun () ->
       read_stylesheet_statements r (new_prelude_seen ()) [])
 
@@ -4304,41 +4300,6 @@ let parse_stylesheet_partial ?(meta = Loc.default_meta_level)
   let sheet = interleave bangs rule_ends sheet in
   (sheet, out.warnings @ typed_warnings)
 
-(** {1 Inline Styles} *)
-
-let pp_important ~minify pp_ctx =
-  if minify then Pp.string pp_ctx "!important"
-  else (
-    Pp.space pp_ctx ();
-    Pp.string pp_ctx "!important")
-
-let pp_decl_inline ~minify ~mode pp_ctx decl =
-  let name = Declaration.property_name decl in
-  let value =
-    Declaration.string_of_value ~minify ~inline:(mode = Inline) decl
-  in
-  let is_important = Declaration.is_important decl in
-  Pp.string pp_ctx name;
-  Pp.char pp_ctx ':';
-  if not minify then Pp.space pp_ctx ();
-  Pp.string pp_ctx value;
-  if is_important then pp_important ~minify pp_ctx
-
-let inline_style_of_declarations ?(minify = false) ?(mode : mode = Inline) props
-    =
-  let buf = Buffer.create 128 in
-  let pp_ctx = Pp.ctx ~minify ~inline:(mode = Inline) buf in
-  let first = ref true in
-  List.iter
-    (fun decl ->
-      if !first then first := false
-      else (
-        Pp.semicolon pp_ctx ();
-        if not minify then Pp.space pp_ctx ());
-      pp_decl_inline ~minify ~mode pp_ctx decl)
-    props;
-  Buffer.contents buf
-
 (** {1 Variable extraction from stylesheets} *)
 
 (* A [var()] is a reference wherever the declaration holding it sits, so this is
@@ -4349,9 +4310,6 @@ let inline_style_of_declarations ?(minify = false) ?(mode : mode = Inline) props
 let vars_of_stylesheet (ss : stylesheet) : Variables.any_var list =
   fold_declarations (fun acc decls -> List.rev_append decls acc) [] ss
   |> List.rev |> Variables.vars_of_declarations
-
-(* Alias for API consistency *)
-let read = read_stylesheet
 
 (* Pretty-printer for import_rule *)
 let pp_import_rule : import_rule Pp.t =

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -209,8 +209,8 @@ val keyframes : string -> keyframe list -> statement
 val v : statement list -> stylesheet
 (** [v statements] creates a stylesheet from a list of statements. *)
 
-val empty_stylesheet : stylesheet
-(** [empty_stylesheet] is an empty stylesheet. *)
+val empty : t
+(** [empty] is an empty stylesheet. *)
 
 (** {1 Accessors} *)
 
@@ -357,8 +357,8 @@ val read_rule : ?nested:bool -> Cursor.t -> rule
 val read_block : Cursor.t -> block
 (** [read_block r] reads a CSS block from the reader. *)
 
-val read_stylesheet : Cursor.t -> stylesheet
-(** [read_stylesheet r] reads a complete CSS stylesheet from the reader. Raises
+val read : Cursor.t -> t
+(** [read r] reads a complete CSS stylesheet from the cursor. Raises
     {!Cursor.Parse_error} on the first validator failure; use
     {!parse_stylesheet_partial} to get the recovered sheet with warnings
     instead. *)
@@ -393,6 +393,9 @@ val pp_rule : rule Pp.t
 val pp_stylesheet : stylesheet Pp.t
 (** [pp_stylesheet] pretty-prints CSS stylesheets. *)
 
+val pp : t Pp.t
+(** [pp] is {!pp_stylesheet}. *)
+
 (** {1 Variable Extraction} *)
 
 val vars_of_stylesheet : stylesheet -> Variables.any_var list
@@ -413,24 +416,7 @@ val to_string :
 (** [to_string ?minify ?indent stylesheet] serialises a stylesheet to CSS. Pure
     formatter - no optimisation, no theme resolution. *)
 
-val pp :
-  ?minify:bool ->
-  ?indent:int ->
-  ?lossless:bool ->
-  ?enforce_spec:bool ->
-  t ->
-  string
-(** [pp] is {!to_string}. *)
-
-val inline_style_of_declarations :
-  ?minify:bool -> ?mode:mode -> declaration list -> string
-(** [inline_style_of_declarations declarations] converts declarations to inline
-    style string. *)
-
 (** {1 Legacy Compatibility} *)
-
-val empty : t
-(** [empty] is an empty stylesheet. *)
 
 val rules : t -> rule list
 (** [rules t] returns the top-level rules from the stylesheet. *)
@@ -462,9 +448,6 @@ val container_queries :
     below its brace, on the same terms as {!media_queries}. *)
 
 (** {1 Parsing and Pretty-printing} *)
-
-val read : Cursor.t -> t
-(** [read r] parses a stylesheet from the reader. *)
 
 val pp_import_rule : import_rule Pp.t
 (** [pp_import_rule] pretty-prints an import rule. *)

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -229,7 +229,7 @@ let escaped_property_name name =
   Parser.escape_ident (string_of_property_name name)
 
 let render_declaration_feature = function
-  | Declaration decl -> Declaration.string_of_declaration ~minify:false decl
+  | Declaration decl -> Declaration.to_string ~minify:false decl
   | Empty name -> escaped_property_name name ^ ":"
   | Unsupported (name, value) -> escaped_property_name name ^ ": " ^ value
   | Vendor_flag_enabled -> "-vendor-flag: enabled"
@@ -268,7 +268,7 @@ let pp_declaration_feature ctx = function
   | Declaration decl ->
       (* The declaration is a capability predicate for this exact value, so
          suppress lossy value rewrites (e.g. static colour folding). *)
-      Declaration.pp_declaration (Pp.enter_feature_query ctx) decl
+      Declaration.pp (Pp.enter_feature_query ctx) decl
   | Empty name ->
       Pp.string ctx (escaped_property_name name);
       Pp.char ctx ':'

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1870,7 +1870,6 @@ let vars_of_kind : type a. a kind -> a -> any_var list =
   | Rotate -> vars_of_rotate_value value
   | Scale -> vars_of_scale value
   | Shadow -> vars_of_shadow value
-  | Box_shadow -> vars_of_shadow value
   | Content -> vars_of_content value
   | Gradient_stop -> vars_of_gradient_stop value
   | Gradient_direction -> vars_of_gradient_direction value

--- a/scripts/check_api_consistency.ml
+++ b/scripts/check_api_consistency.ml
@@ -367,7 +367,10 @@ let check_test_patterns ~lib_dir ~mod_name ~valid_types ~expected_test_name
   match List.find_opt (fun t -> expected_test_name t = tname) valid_types with
   | Some typename ->
       let mli_path = lib_dir // (mod_name ^ ".mli") in
-      let read_name = if typename = "t" then "read" else "read_" ^ typename in
+      let read_name =
+        if typename = "t" || typename = mod_name then "read"
+        else "read_" ^ typename
+      in
       if
         (not has_neg) && Sys.file_exists mli_path
         && file_has_val mli_path read_name
@@ -540,10 +543,16 @@ let () =
         List.iter
           (fun tname ->
             stats.total_types <- stats.total_types + 1;
-            (* Special case: type t uses 'read' and 'pp' instead of 'read_t' and
-               'pp_t' *)
-            let read_name = if tname = "t" then "read" else "read_" ^ tname in
-            let pp_name = if tname = "t" then "pp" else "pp_" ^ tname in
+            (* A module's principal reader uses [read]. A [t] printer uses [pp];
+               Declaration's historical [declaration] type is also its [t].
+               Other named types keep the explicit [pp_<type>] form. *)
+            let principal = tname = "t" || tname = mod_base in
+            let read_name = if principal then "read" else "read_" ^ tname in
+            let pp_name =
+              if tname = "t" || (mod_base = "declaration" && principal) then
+                "pp"
+              else "pp_" ^ tname
+            in
             let check_name =
               if tname = "t" then "check" else "check_" ^ tname
             in

--- a/test/cram/public_surface.t/old_container_pp.ml
+++ b/test/cram/public_surface.t/old_container_pp.ml
@@ -1,0 +1,3 @@
+open Cascade
+
+let _ : Container.t -> string = Container.pp

--- a/test/cram/public_surface.t/old_css_pp.ml
+++ b/test/cram/public_surface.t/old_css_pp.ml
@@ -1,0 +1,10 @@
+open Cascade
+
+let _ :
+    ?minify:bool ->
+    ?indent:int ->
+    ?lossless:bool ->
+    ?enforce_spec:bool ->
+    Css.t ->
+    string =
+  Css.pp

--- a/test/cram/public_surface.t/old_stylesheet_pp.ml
+++ b/test/cram/public_surface.t/old_stylesheet_pp.ml
@@ -1,0 +1,10 @@
+open Cascade
+
+let _ :
+    ?minify:bool ->
+    ?indent:int ->
+    ?lossless:bool ->
+    ?enforce_spec:bool ->
+    Stylesheet.t ->
+    string =
+  Stylesheet.pp

--- a/test/cram/public_surface.t/removed_box_shadow_kind.ml
+++ b/test/cram/public_surface.t/removed_box_shadow_kind.ml
@@ -1,0 +1,3 @@
+open Cascade
+
+let kind : Css.shadow Css.kind = Css.Box_shadow

--- a/test/cram/public_surface.t/removed_values
+++ b/test/cram/public_surface.t/removed_values
@@ -1,0 +1,13 @@
+Declaration.pp_declaration
+Declaration.string_of_declaration
+Stylesheet.empty_stylesheet
+Stylesheet.read_stylesheet
+Stylesheet.inline_style_of_declarations
+Keyframe.string_of_selector
+Pp.float_compact
+Css.Transform.of_string
+Css.Transform_origin.of_string
+Css.Perspective_origin.of_string
+Css.Animation.of_string
+Css.inset_ring_shadow
+Properties.inset_ring_shadow

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -1,0 +1,25 @@
+open Cascade
+
+let _ = Declaration.pp
+let _ = Declaration.to_string
+let _ = Stylesheet.empty
+let _ = Stylesheet.read
+let _ = Stylesheet.to_string
+let _ = Stylesheet.pp_stylesheet
+let _ = Keyframe.to_string
+let _ = Css.to_string
+let _ = Container.to_string
+let _ : Container.t Pp.t = Container.pp
+let _ : Stylesheet.t Pp.t = Stylesheet.pp
+let _ : Css.t Pp.t = Css.pp
+let _ :
+    ?optimize:bool ->
+    ?minify:bool ->
+    ?mode:Css.mode ->
+    Css.declaration list ->
+    string =
+  Css.inline_style_of_declarations
+let _ = Pp.float
+let _ = Css.Gradient_direction.of_string
+let _ = Css.shadow
+let _ : Css.shadow Css.kind = Css.Shadow

--- a/test/cram/public_surface.t/run.t
+++ b/test/cram/public_surface.t/run.t
@@ -1,0 +1,28 @@
+The compact public surface keeps the conventional names callers need:
+
+  $ ocamlfind ocamlc -package cascade -c retained.ml
+
+Compatibility aliases and one-off helpers are not part of the public API. Each
+name is compiled separately so that one missing name cannot hide another that
+was accidentally retained:
+
+  $ status=0
+  > while IFS= read -r value; do
+  >   printf 'open Cascade\nlet _ = %s\n' "$value" > probe.ml
+  >   if ocamlfind ocamlc -package cascade -c probe.ml >/dev/null 2>&1; then
+  >     echo "still public: $value"
+  >     status=1
+  >   fi
+  > done < removed_values
+  > for probe in old_container_pp.ml old_stylesheet_pp.ml old_css_pp.ml; do
+  >   if ocamlfind ocamlc -package cascade -c "$probe" >/dev/null 2>&1; then
+  >     echo "old string printer still public: $probe"
+  >     status=1
+  >   fi
+  > done
+  > if ocamlfind ocamlc -package cascade -c removed_box_shadow_kind.ml \
+  >      >/dev/null 2>&1; then
+  >   echo "still public: Css.Box_shadow as a shadow kind"
+  >   status=1
+  > fi
+  > test $status -eq 0

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -30,7 +30,7 @@ let node ?id ?(classes = []) ?(attrs = []) ?(children = []) name =
   n
 
 let inline_style decls =
-  Stylesheet.inline_style_of_declarations ~minify:true ~mode:Variables decls
+  Css.inline_style_of_declarations ~minify:true ~mode:Variables decls
 
 (* [A.compute] takes a parsed sheet, so the fixtures parse here. They are all
    meant to parse; one that does not is a broken test, not a case under test. *)

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -4,8 +4,7 @@ open Cascade
 
 let decl_t : Css.Declaration.declaration Alcotest.testable =
   Alcotest.testable
-    (fun fmt d ->
-      Format.pp_print_string fmt (Css.Declaration.string_of_declaration d))
+    (fun fmt d -> Format.pp_print_string fmt (Css.Declaration.to_string d))
     ( = )
 
 let stylesheet_t : Css.Stylesheet.t Alcotest.testable =
@@ -446,7 +445,7 @@ let check_layered_eval_preserves name ~ctx ~layer_order ?layer input =
 
 let stylesheet_of_string input =
   let cursor = Cursor.of_string input in
-  try Css.Stylesheet.read_stylesheet cursor
+  try Css.Stylesheet.read cursor
   with Cursor.Parse_error err ->
     Alcotest.failf "expected stylesheet to parse: %s" (Error.to_string err)
 
@@ -523,7 +522,7 @@ let rec statement_shape stmt =
       ("container:"
       ^ Option.value ~default:"" name
       ^ ":"
-      ^ Option.fold ~none:"" ~some:Css.Container.pp condition)
+      ^ Option.fold ~none:"" ~some:Css.Container.to_string condition)
       :: block_lines block
   | Supports (condition, block) ->
       ("supports:" ^ Css.Pp.to_string ~minify:true Css.Supports.pp condition)
@@ -552,21 +551,21 @@ let rec statement_shape stmt =
       ("keyframes:" ^ name)
       :: (keyframes
          |> List.map (fun (keyframe : Css.Stylesheet.keyframe) ->
-             ("  keyframe:" ^ Css.Keyframe.string_of_selector keyframe.selector)
+             ("  keyframe:" ^ Css.Keyframe.to_string keyframe.selector)
              :: prefixed "    " (declaration_lines keyframe.declarations))
          |> List.concat)
   | Webkit_keyframes (name, keyframes) ->
       ("webkit-keyframes:" ^ name)
       :: (keyframes
          |> List.map (fun (keyframe : Css.Stylesheet.keyframe) ->
-             ("  keyframe:" ^ Css.Keyframe.string_of_selector keyframe.selector)
+             ("  keyframe:" ^ Css.Keyframe.to_string keyframe.selector)
              :: prefixed "    " (declaration_lines keyframe.declarations))
          |> List.concat)
   | Moz_keyframes (name, keyframes) ->
       ("moz-keyframes:" ^ name)
       :: (keyframes
          |> List.map (fun (keyframe : Css.Stylesheet.keyframe) ->
-             ("  keyframe:" ^ Css.Keyframe.string_of_selector keyframe.selector)
+             ("  keyframe:" ^ Css.Keyframe.to_string keyframe.selector)
              :: prefixed "    " (declaration_lines keyframe.declarations))
          |> List.concat)
   | Font_face descriptors ->
@@ -633,8 +632,7 @@ let specificity_score selector =
   + (specificity.classes * 1_000)
   + specificity.elements
 
-let declaration_source decl =
-  Css.Declaration.string_of_declaration ~minify:true decl
+let declaration_source decl = Css.Declaration.to_string ~minify:true decl
 
 let declaration_value_source decl =
   let source = declaration_source decl in
@@ -2519,14 +2517,14 @@ let runtime_var_not_folded_contract () =
   Alcotest.(check bool)
     "non-runtime var folds" false
     (String.equal
-       (Css.Declaration.string_of_declaration folding)
-       (Css.Declaration.string_of_declaration
+       (Css.Declaration.to_string folding)
+       (Css.Declaration.to_string
           (Css.eval_declaration Css.Context.empty folding)));
   (* Multiplicative identities never read the variable's value, so they still
      simplify a runtime var; only value resolution ([* n], n >= 2) is
      skipped. *)
   let eval c =
-    Css.Declaration.string_of_declaration ~minify:true
+    Css.Declaration.to_string ~minify:true
       (Css.eval_declaration Css.Context.empty (Css.width (Calc c)))
   in
   Alcotest.(check string)
@@ -2544,7 +2542,7 @@ let runtime_var_not_folded_contract () =
   Alcotest.(check string)
     "runtime var * 1 in the padding shorthand folds to the operand"
     "padding:var(--spacing)"
-    (Css.Declaration.string_of_declaration ~minify:true
+    (Css.Declaration.to_string ~minify:true
        (Css.eval_declaration Css.Context.empty
           (Css.padding [ Calc (Expr (Var spacing, Mul, Num 1.)) ])))
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -7,9 +7,8 @@ open Css_test_helpers
 
 (* One-liner check functions for each type *)
 let check_declaration ?minify ?roundtrip ?expected ?optimized input =
-  check_value_cursor "declaration" read_declaration
-    (Css.Pp.option pp_declaration)
-    ?minify ?roundtrip ?expected input;
+  check_value_cursor "declaration" read_declaration (Css.Pp.option pp) ?minify
+    ?roundtrip ?expected input;
   match optimized with
   | None -> ()
   | Some into ->
@@ -1670,8 +1669,7 @@ let unterminated () =
   in
   Alcotest.(check string)
     "unterminated rgb declaration normalize" "color:#000"
-    (decl |> Css.Declaration.normalize
-    |> Css.Declaration.string_of_declaration ~minify:true);
+    (decl |> Css.Declaration.normalize |> Css.Declaration.to_string ~minify:true);
   (* A missing semicolon between two declarations in a block remains a parse
      error. *)
   Css_test_helpers.neg_cursor Css.Declaration.read_block
@@ -2572,17 +2570,15 @@ let parse_property_decl property value =
     match read_declaration c with
     | None -> None
     | Some decl ->
-        let serialized =
-          Css.Declaration.string_of_declaration ~minify:true decl
-        in
+        let serialized = Css.Declaration.to_string ~minify:true decl in
         let c2 = Cursor.of_string serialized in
         Some (input, serialized, decl, read_declaration c2)
   with Cursor.Parse_error _ | Reader.Parse_error _ -> None
 
 let same_property_reparse (row : property_grammar_row) decl reparsed =
   Css.Declaration.property_name reparsed = row.property
-  && Css.Declaration.string_of_declaration ~minify:true decl
-     = Css.Declaration.string_of_declaration ~minify:true reparsed
+  && Css.Declaration.to_string ~minify:true decl
+     = Css.Declaration.to_string ~minify:true reparsed
 
 let check_property_positive (row : property_grammar_row) value =
   match parse_property_decl row.property value with

--- a/test/test_keyframe.ml
+++ b/test/test_keyframe.ml
@@ -88,7 +88,7 @@ let test_spec_keyframe_selector_vectors () =
 
 let test_selector_roundtrip () =
   let sel = Positions [ From; To ] in
-  let s = string_of_selector sel in
+  let s = to_string sel in
   Alcotest.(check string) "from, to" "from, to" s
 
 let spec_keyframe_duplicate_offsets () =
@@ -98,7 +98,7 @@ let spec_keyframe_duplicate_offsets () =
   let check input expected =
     Alcotest.(check string)
       input expected
-      (selector_of_string input |> string_of_selector)
+      (selector_of_string input |> to_string)
   in
   check "50%, 50%" "50%, 50%";
   check "from, 0%, 100%, to" "from, 0%, 100%, to";

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -35,7 +35,7 @@ let is_important = Css.Declaration.is_important
 
 (* Helper to extract color hex value from declaration string like "color:red" *)
 let color_value_of_decl decl =
-  let s = Css.Declaration.string_of_declaration ~minify:true decl in
+  let s = Css.Declaration.to_string ~minify:true decl in
   (* Extract just the hex value after the colon and before any !important *)
   let after_colon =
     String.split_on_char ':' s |> List.tl |> String.concat ":"
@@ -146,13 +146,13 @@ let test_duplicate_buggy_properties () =
   let duplicated = duplicate_buggy_properties decls in
   check (list string) "keeps one webkit-text-decoration inherit fallback"
     [ "-webkit-text-decoration:inherit" ]
-    (List.map (Css.Declaration.string_of_declaration ~minify:true) duplicated);
+    (List.map (Css.Declaration.to_string ~minify:true) duplicated);
 
   (* -webkit-text-decoration-color is a compatibility property, not a generated
      fallback for the standard property. External minifiers preserve authored
      prefixed/unprefixed pairs and do not synthesize either spelling. *)
   let pp_decls decls =
-    List.map (Css.Declaration.string_of_declaration ~minify:true) decls
+    List.map (Css.Declaration.to_string ~minify:true) decls
   in
   let standard_color =
     duplicate_buggy_properties [ v Text_decoration_color (hex_color "0000ff") ]
@@ -5295,7 +5295,7 @@ module Fuzz = struct
   let canon_memo : (string, string) Hashtbl.t = Hashtbl.create 256
 
   let canon_decl d =
-    let s = Pp.to_string ~minify:true Declaration.pp_declaration d in
+    let s = Pp.to_string ~minify:true Declaration.pp d in
     match Hashtbl.find_opt canon_memo s with
     | Some c -> c
     | None ->
@@ -5477,7 +5477,7 @@ module Fuzz = struct
     ]
 
   let sh_decls = Array.of_list (List.map fst sh_alphabet)
-  let sh_decl_string d = Pp.to_string ~minify:true Declaration.pp_declaration d
+  let sh_decl_string d = Pp.to_string ~minify:true Declaration.pp d
 
   (* Four-side box shorthands: physical longhand names, in top/right/bottom/left
      order. optimize composes longhand runs back into these, so the oracle must

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -153,7 +153,7 @@ let test_resolve_cascade () =
     List.find_map
       (fun d ->
         if Declaration.property_name d = p then
-          Some (Declaration.string_of_declaration ~minify:true d)
+          Some (Declaration.to_string ~minify:true d)
         else None)
       decls
   in
@@ -169,7 +169,7 @@ let resolved_color css =
   List.find_map
     (fun d ->
       if Declaration.property_name d = "color" then
-        Some (Declaration.string_of_declaration ~minify:true d)
+        Some (Declaration.to_string ~minify:true d)
       else None)
     (R.resolve (sheet_of css) s2)
 
@@ -241,7 +241,7 @@ let test_resolve_skips_conditional_and_scoped_blocks () =
     (List.find_map
        (fun d ->
          if Declaration.property_name d = "color" then
-           Some (Declaration.string_of_declaration ~minify:true d)
+           Some (Declaration.to_string ~minify:true d)
          else None)
        (R.resolve [ Stylesheet.Origin (Author, sheet_of "span{color:red}") ] s2))
 

--- a/test/test_rule_scheduler.ml
+++ b/test/test_rule_scheduler.ml
@@ -49,7 +49,7 @@ let rec subsets = function
       let rest = subsets xs in
       rest @ List.map (fun tail -> x :: tail) rest
 
-let canon d = Pp.to_string ~minify:true Declaration.pp_declaration d
+let canon d = Pp.to_string ~minify:true Declaration.pp d
 
 let computed sheet classes =
   R.resolve sheet { classes } |> List.map canon |> List.sort String.compare

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -12,7 +12,7 @@ let decls css =
   | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
 
 let decl_strings decls =
-  List.map (Pp.to_string ~minify:true Declaration.pp_declaration) decls
+  List.map (Pp.to_string ~minify:true Declaration.pp) decls
 
 let indexed decls = List.mapi (fun i d -> (i, d)) decls
 let unindexed decls = List.map snd decls

--- a/test/test_size.ml
+++ b/test/test_size.ml
@@ -14,7 +14,7 @@ let rule css =
   | rs -> Alcotest.failf "expected one rule, got %d" (List.length rs)
 
 let min_rule r = Pp.to_string ~minify:true Stylesheet.pp_rule r
-let min_decl d = Pp.to_string ~minify:true Declaration.pp_declaration d
+let min_decl d = Pp.to_string ~minify:true Declaration.pp d
 
 let test_decl_list_separator_math () =
   Alcotest.(check int) "empty list" 0 (Size.decl_list 0 0);

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -17,8 +17,7 @@ let check_rule = check_value_cursor "rule" read_rule pp_rule
 
 let decl_t : Css.Declaration.declaration Alcotest.testable =
   Alcotest.testable
-    (fun fmt d ->
-      Format.pp_print_string fmt (Css.Declaration.string_of_declaration d))
+    (fun fmt d -> Format.pp_print_string fmt (Css.Declaration.to_string d))
     ( = )
 
 let check_import_rule =
@@ -29,10 +28,9 @@ let check_layer_name =
 
 let check_declaration =
   check_value_cursor "declaration" Css.Declaration.read_declaration
-    (Css.Pp.option Css.Declaration.pp_declaration)
+    (Css.Pp.option Css.Declaration.pp)
 
-let check_stylesheet =
-  check_value_cursor "stylesheet" read_stylesheet pp_stylesheet
+let check_stylesheet = check_value_cursor "stylesheet" read pp_stylesheet
 
 (* Assert both serialization paths for one input. [minified] is pure pp: the
    held value in its shortest same-node spelling. [optimized] is pp+optimize:
@@ -72,12 +70,12 @@ let test_rule () =
   check_rule ~expected:"*{box-sizing:border-box}" "* { box-sizing: border-box }";
 
   (* Test invalid rule syntax *)
-  neg_cursor read_stylesheet "{color:red}";
+  neg_cursor read "{color:red}";
   (* Missing selector *)
-  neg_cursor read_stylesheet ".btn";
+  neg_cursor read ".btn";
   (* Missing declarations. CSS Syntax sec. 2.2 auto-closes [.btn{] so it is
      spec-valid and not asserted here. *)
-  neg_cursor read_stylesheet ".btn{color}";
+  neg_cursor read ".btn{color}";
   (* Missing value *)
   neg_cursor read_rule "" (* Empty rule *)
 
@@ -138,9 +136,9 @@ let test_stylesheet () =
   check_stylesheet ~expected:"@media{.test{color:red}}"
     "@media { .test { color: red } }";
   check_stylesheet ~expected:"@media{}" "@media { }";
-  neg_cursor read_stylesheet "@charset 'UTF-8'" (* Wrong charset quotes *)
+  neg_cursor read "@charset 'UTF-8'" (* Wrong charset quotes *)
 
-let string_of_stylesheet s = Css.Stylesheet.pp ~minify:true s
+let string_of_stylesheet s = Css.Stylesheet.to_string ~minify:true s
 
 (* Helper for testing rule construction *)
 let check_construct_rule name expected rule =
@@ -173,7 +171,7 @@ let test_media_rule_creation () =
       [ statement_of_rule r ]
   in
   let sheet = Css.Stylesheet.v [ media_stmt ] in
-  let output = Css.Stylesheet.pp ~minify:true sheet in
+  let output = Css.Stylesheet.to_string ~minify:true sheet in
   check_stylesheet output
 
 (* Not a roundtrip test *)
@@ -186,7 +184,7 @@ let test_container_rule_creation () =
       [ statement_of_rule r ]
   in
   let sheet = Css.Stylesheet.v [ container_stmt ] in
-  let output = Css.Stylesheet.pp ~minify:true sheet in
+  let output = Css.Stylesheet.to_string ~minify:true sheet in
   check_stylesheet output
 
 (* ignore-test: error-recovery contract, not a per-statement constructor. *)
@@ -241,7 +239,7 @@ let test_supports_rule_creation () =
       [ statement_of_rule r ]
   in
   let sheet = Css.Stylesheet.v [ supports_stmt ] in
-  let output = Css.Stylesheet.pp ~minify:true sheet in
+  let output = Css.Stylesheet.to_string ~minify:true sheet in
   check_stylesheet output
 
 (* Not a roundtrip test *)
@@ -259,7 +257,7 @@ let test_supports_nested_creation () =
       [ statement_of_rule r; nested_supports ]
   in
   let sheet = Css.Stylesheet.v [ supports_stmt ] in
-  let output = Css.Stylesheet.pp ~minify:true sheet in
+  let output = Css.Stylesheet.to_string ~minify:true sheet in
   check_stylesheet output
 
 (* Not a roundtrip test *)
@@ -288,7 +286,7 @@ let test_layer_rule_creation () =
   Alcotest.(check string)
     "layer rule creation (minify)"
     "@layer utilities{.red{background-color:#f00}}"
-    (Css.Stylesheet.pp ~minify:true sheet);
+    (Css.Stylesheet.to_string ~minify:true sheet);
   Alcotest.(check string)
     "layer rule creation (minify+optimize)"
     "@layer utilities{.red{background-color:red}}" (minify sheet)
@@ -327,13 +325,13 @@ let helper () =
 
 (* Not a roundtrip test *)
 let test_empty_stylesheet () =
-  let empty = empty_stylesheet in
-  Alcotest.(check int) "empty layers" 0 (List.length (layers empty));
-  Alcotest.(check int) "empty rules" 0 (List.length (rules empty));
-  Alcotest.(check int) "empty media" 0 (List.length (media_queries empty));
+  let sheet = empty in
+  Alcotest.(check int) "empty layers" 0 (List.length (layers sheet));
+  Alcotest.(check int) "empty rules" 0 (List.length (rules sheet));
+  Alcotest.(check int) "empty media" 0 (List.length (media_queries sheet));
   Alcotest.(check int)
     "empty container" 0
-    (List.length (container_queries empty))
+    (List.length (container_queries sheet))
 
 (* Not a roundtrip test *)
 let construction () =
@@ -407,7 +405,7 @@ let test_default_property_rule () =
 
   (* Test these generate valid statements *)
   let sheet = Css.Stylesheet.v [ prop_with_initial; prop_no_initial ] in
-  let output = Css.Stylesheet.pp ~minify:true sheet in
+  let output = Css.Stylesheet.to_string ~minify:true sheet in
 
   check_stylesheet output
 
@@ -420,7 +418,7 @@ let test_property_composite_syntax () =
       "--size"
   in
   let sheet = Css.Stylesheet.v [ prop ] in
-  let output = Css.Stylesheet.pp ~minify:true sheet in
+  let output = Css.Stylesheet.to_string ~minify:true sheet in
   check_stylesheet output
 
 (** Test [@property] descriptor permutations and minified canonical order *)
@@ -473,7 +471,7 @@ let test_property_permutations () =
 let expect_property_error name input =
   let r = Cursor.of_string input in
   try
-    let _ = read_stylesheet r in
+    let _ = read r in
     Alcotest.failf "%s: expected parse error" name
   with Cursor.Parse_error _ -> ()
 
@@ -561,7 +559,7 @@ let test_layer_pp () =
   let layer_stmt = layer ~name:[ "utilities" ] [ statement_of_rule rule_obj ] in
 
   let sheet = Css.Stylesheet.v [ layer_stmt ] in
-  let output = Css.Stylesheet.pp ~minify:true sheet in
+  let output = Css.Stylesheet.to_string ~minify:true sheet in
   Alcotest.(check string)
     "layer pp" "@layer utilities{.blue{color:#00f}}" output;
 
@@ -569,7 +567,7 @@ let test_layer_pp () =
      semicolon *)
   let empty_layer = layer ~name:[ "base" ] [] in
   let empty_sheet = Css.Stylesheet.v [ empty_layer ] in
-  let empty_output = Css.Stylesheet.pp ~minify:true empty_sheet in
+  let empty_output = Css.Stylesheet.to_string ~minify:true empty_sheet in
   Alcotest.(check string) "empty layer" "@layer base;" empty_output
 
 (** Test complete stylesheet pp *)
@@ -586,7 +584,7 @@ let pp_case () =
 
   let sheet = Css.Stylesheet.v [ statement_of_rule r; media_stmt; prop ] in
 
-  let output = Css.Stylesheet.pp ~minify:true sheet in
+  let output = Css.Stylesheet.to_string ~minify:true sheet in
   Alcotest.(check string)
     "stylesheet pp"
     (* pp emits each node's shortest same-node spelling: Hex ff0000 -> #f00,
@@ -638,8 +636,8 @@ let namespace_case () =
   check_stylesheet
     ~expected:"@namespace math\"http://www.w3.org/1998/Math/MathML\";"
     "@namespace math \"http://www.w3.org/1998/Math/MathML\";";
-  neg_cursor read_stylesheet "@namespace { url(http://example.test); }";
-  neg_cursor read_stylesheet "@namespace svg;"
+  neg_cursor read "@namespace { url(http://example.test); }";
+  neg_cursor read "@namespace svg;"
 
 (** Test [@keyframes] rules *)
 let keyframes_case () =
@@ -674,7 +672,7 @@ let test_keyframes_spec_edge_vectors () =
     "@keyframes bad { 50px { opacity: 1 } }";
   check_stylesheet ~expected:"@keyframes bad{}"
     "@keyframes bad { from, { opacity: 1 } }";
-  neg_cursor read_stylesheet "@keyframes missing-block"
+  neg_cursor read "@keyframes missing-block"
 
 (** Test [@font-face] rules *)
 let font_face_case () =
@@ -778,9 +776,9 @@ let page_case () =
       "@page{@top-left{content:\"title\"}@bottom-center{content:counter(page)}}"
     "@page { @top-left { content: \"title\" } @bottom-center { content: \
      counter(page) } }";
-  neg_cursor read_stylesheet "@page : { margin: 1cm }";
-  neg_cursor read_stylesheet "@page :unknown { margin: 1cm }";
-  neg_cursor read_stylesheet "@page { color: notacolor }"
+  neg_cursor read "@page : { margin: 1cm }";
+  neg_cursor read "@page :unknown { margin: 1cm }";
+  neg_cursor read "@page { color: notacolor }"
 
 let page_margin_edges () =
   check_stylesheet
@@ -799,9 +797,9 @@ let page_margin_edges () =
     "@page { bleeds: 6pt; marks: crop cross; @top-center { content: none } }";
   check_stylesheet ~expected:"@page invoice:blank:first{margin:1cm}"
     "@page invoice:blank:first { margin: 1cm }";
-  neg_cursor read_stylesheet "@page { @unknown { content: none } }";
-  neg_cursor read_stylesheet "@page { @top-left; }";
-  neg_cursor read_stylesheet "@page { @top-left { color: notacolor } }"
+  neg_cursor read "@page { @unknown { content: none } }";
+  neg_cursor read "@page { @top-left; }";
+  neg_cursor read "@page { @top-left { color: notacolor } }"
 
 let property_rule_edges () =
   check_stylesheet
@@ -819,16 +817,15 @@ let property_rule_edges () =
   check_stylesheet
     ~expected:"@property --any-tokens{syntax:\"*\";inherits:true}"
     "@property --any-tokens { syntax: \"*\"; inherits: true; }";
-  neg_cursor read_stylesheet
+  neg_cursor read
     "@property --bad { syntax: \"<length>+\"; inherits: false; initial-value: \
      red }";
-  neg_cursor read_stylesheet
+  neg_cursor read
     "@property --bad { syntax: \"<color>\"; inherits: yes; initial-value: red }";
-  neg_cursor read_stylesheet
+  neg_cursor read
     "@property --bad { syntax: \"<length> |\"; inherits: false; initial-value: \
      1px }";
-  neg_cursor read_stylesheet
-    "@property color { syntax: \"*\"; inherits: false }"
+  neg_cursor read "@property color { syntax: \"*\"; inherits: false }"
 
 let spec_font_face_descriptor_matrix () =
   (* Descriptor syntax is a spec oracle; these are not snapshots of the current
@@ -927,9 +924,7 @@ let spec_page_margin_descriptor_matrix () =
        landscape;margin:1in;@right-top{content:counter(page)}@bottom-center{content:\"Chapter\"}}"
     "@page chapter:right { size: letter landscape; margin: 1in; @right-top { \
      content: counter(page) } @bottom-center { content: \"Chapter\" } }";
-  List.iter
-    (neg_cursor read_stylesheet)
-    [ "@page { @top-center { display: 1px } }" ];
+  List.iter (neg_cursor read) [ "@page { @top-center { display: 1px } }" ];
   check_stylesheet ~expected:"@page:first:left{margin:1cm}"
     "@page :first:left { margin: 1cm }";
   check_stylesheet ~expected:"@page:blank:first{margin:.5cm}"
@@ -985,8 +980,7 @@ let spec_page_context_properties () =
   (* What browsers still reject: a value the property's grammar does not admit,
      and an item that is not a declaration at all. Blink 146 drops each of these
      and keeps the rest of the block. *)
-  List.iter
-    (neg_cursor read_stylesheet)
+  List.iter (neg_cursor read)
     [
       "@page { margin: notalength }";
       "@page { color: notacolor }";
@@ -1067,7 +1061,7 @@ let spec_page_margin_box_empty () =
         "@page { @top-center { } @bottom-center { content: \"x\" } }" );
     ];
   (* An empty block is not a missing one: sec. 5 still asks for a block. *)
-  neg_cursor read_stylesheet "@page { @top-left; }";
+  neg_cursor read "@page { @top-left; }";
   assert_minify_and_optimize "@page { @top-center { } }" ~minified:""
     ~optimized:"";
   assert_minify_and_optimize "@page { margin: 1cm; @top-center { } }"
@@ -1094,8 +1088,7 @@ let spec_property_descriptor_matrix () =
         "@property --ident-or-color { syntax: \"<custom-ident> | <color>\"; \
          inherits: true; initial-value: currentColor }" );
     ];
-  List.iter
-    (neg_cursor read_stylesheet)
+  List.iter (neg_cursor read)
     [
       "@property --bad { syntax: \"<angle>#\"; inherits: false; initial-value: \
        red }";
@@ -1140,7 +1133,7 @@ let ordering () =
 let test_read_stylesheet_basic () =
   let css = ".btn { color: red; padding: 10px; }" in
   let reader = Cursor.of_string css in
-  let sheet = read_stylesheet reader in
+  let sheet = read reader in
   let rules = rules sheet in
   Alcotest.(check int) "has one rule" 1 (List.length rules);
   let rule = List.hd rules in
@@ -1151,7 +1144,7 @@ let test_read_stylesheet_basic () =
 let test_read_stylesheet_multiple_rules () =
   let css = ".btn { color: red; } .card { margin: 5px; }" in
   let reader = Cursor.of_string css in
-  let sheet = read_stylesheet reader in
+  let sheet = read reader in
   let rules = rules sheet in
   Alcotest.(check int) "has two rules" 2 (List.length rules)
 
@@ -1159,7 +1152,7 @@ let test_read_stylesheet_multiple_rules () =
 let test_read_stylesheet_empty () =
   let css = "" in
   let reader = Cursor.of_string css in
-  let sheet = read_stylesheet reader in
+  let sheet = read reader in
   let rules = rules sheet in
   Alcotest.(check int) "empty stylesheet has no rules" 0 (List.length rules)
 
@@ -1167,7 +1160,7 @@ let test_read_stylesheet_empty () =
 let test_read_stylesheet_whitespace_only () =
   let css = "   \n\t  " in
   let reader = Cursor.of_string css in
-  let sheet = read_stylesheet reader in
+  let sheet = read reader in
   let rules = rules sheet in
   Alcotest.(check int)
     "whitespace-only stylesheet has no rules" 0 (List.length rules)
@@ -1176,7 +1169,7 @@ let test_read_stylesheet_whitespace_only () =
 let test_read_stylesheet_with_comments () =
   let css = "/* comment */ .btn { color: red; } /* another comment */" in
   let reader = Cursor.of_string css in
-  let sheet = read_stylesheet reader in
+  let sheet = read reader in
   let rules = rules sheet in
   Alcotest.(check int) "has one rule despite comments" 1 (List.length rules)
 
@@ -2260,15 +2253,11 @@ let stylesheet_tests =
     ("sheet_item", `Quick, sheet_item_case);
     ("ordering", `Quick, ordering);
     (* CSS parsing tests *)
-    ("read_stylesheet basic", `Quick, test_read_stylesheet_basic);
-    ( "read_stylesheet multiple rules",
-      `Quick,
-      test_read_stylesheet_multiple_rules );
-    ("read_stylesheet empty", `Quick, test_read_stylesheet_empty);
-    ( "read_stylesheet whitespace only",
-      `Quick,
-      test_read_stylesheet_whitespace_only );
-    ("read_stylesheet with comments", `Quick, test_read_stylesheet_with_comments);
+    ("read basic", `Quick, test_read_stylesheet_basic);
+    ("read multiple rules", `Quick, test_read_stylesheet_multiple_rules);
+    ("read empty", `Quick, test_read_stylesheet_empty);
+    ("read whitespace only", `Quick, test_read_stylesheet_whitespace_only);
+    ("read with comments", `Quick, test_read_stylesheet_with_comments);
     ( "spec strict accepts valid stylesheets",
       `Quick,
       spec_strict_accepts_valid_stylesheets );
@@ -2454,7 +2443,7 @@ let test_nested_rules () =
 let expect_parse_error input =
   let r = Cursor.of_string input in
   try
-    let _ = read_stylesheet r in
+    let _ = read r in
     Alcotest.failf "Expected parse error for: %s" input
   with Cursor.Parse_error _ | Error.Parse_error _ -> ()
 
@@ -2641,7 +2630,7 @@ let css_syntax_recovery_structural () =
    all keep the space. An at-rule with no prelude has no boundary to preserve
    and stays unspaced. *)
 let s3431_unknown_at_rule_prelude_separator () =
-  let parse input = read_stylesheet (Cursor.of_string input) in
+  let parse input = read (Cursor.of_string input) in
   let unknown input =
     match parse input with
     | [ Unknown_at_rule { name; prelude; block } ] -> (name, prelude, block)
@@ -2684,8 +2673,7 @@ let s3431_unknown_at_rule_prelude_separator () =
 let s542_unknown_at_rule_block_body () =
   let printed input =
     String.trim
-      (Css.Stylesheet.to_string ~minify:true
-         (read_stylesheet (Cursor.of_string input)))
+      (Css.Stylesheet.to_string ~minify:true (read (Cursor.of_string input)))
   in
   let roundtrips name input expected =
     Alcotest.(check string) name expected (printed input);
@@ -2716,8 +2704,7 @@ let s542_unknown_at_rule_block_body () =
 let s552_unknown_at_rule_eof_closers () =
   let printed input =
     String.trim
-      (Css.Stylesheet.to_string ~minify:true
-         (read_stylesheet (Cursor.of_string input)))
+      (Css.Stylesheet.to_string ~minify:true (read (Cursor.of_string input)))
   in
   (* The at-rule has to end on its own: append a rule to what was printed and
      both must come back, and re-reading must report nothing left
@@ -2789,8 +2776,7 @@ let s552_unknown_at_rule_eof_closers () =
 let moz_document_prelude_forms () =
   let roundtrips input =
     String.trim
-      (Css.Stylesheet.to_string ~minify:true
-         (read_stylesheet (Cursor.of_string input)))
+      (Css.Stylesheet.to_string ~minify:true (read (Cursor.of_string input)))
   in
   List.iter
     (fun (prelude, expected) ->
@@ -2866,10 +2852,9 @@ let c64_layer_name_syntax () =
        reset{[hidden]{display:none}}"
     "@layer reset.type { strong { font-weight: bold } } @layer reset { \
      [hidden] { display: none } }";
-  neg_cursor read_stylesheet
-    "@layer framework . theme { blockquote { display: block } }";
-  neg_cursor read_stylesheet "@layer initial { blockquote { display: block } }";
-  neg_cursor read_stylesheet
+  neg_cursor read "@layer framework . theme { blockquote { display: block } }";
+  neg_cursor read "@layer initial { blockquote { display: block } }";
+  neg_cursor read
     "@layer framework.revert-layer { blockquote { display: block } }"
 
 (* Not a roundtrip test *)
@@ -2923,11 +2908,10 @@ let c64_layer_statement_edges () =
      @layer default { audio[controls] { display: block } }";
   check_stylesheet ~expected:"@layer framework.base,framework.theme;"
     "@layer framework.base, framework.theme;";
-  neg_cursor read_stylesheet "@layer;";
-  neg_cursor read_stylesheet "@layer , theme;";
-  neg_cursor read_stylesheet "@layer default, { audio { display: block } }";
-  neg_cursor read_stylesheet
-    "@layer default, theme { audio { display: block } }"
+  neg_cursor read "@layer;";
+  neg_cursor read "@layer , theme;";
+  neg_cursor read "@layer default, { audio { display: block } }";
+  neg_cursor read "@layer default, theme { audio { display: block } }"
 
 (* Not a roundtrip test *)
 let c64_anonymous_layer_edges () =
@@ -3011,13 +2995,13 @@ let c64_import_namespace_order () =
        \"http://www.w3.org/1999/xhtml\";"
     "@charset \"UTF-8\"; @layer reset, theme; @import url(theme.css) \
      layer(theme); @namespace url(http://www.w3.org/1999/xhtml);";
-  neg_cursor read_stylesheet
+  neg_cursor read
     "@import url(default.css) layer(default); @layer theme; @import \
      url(components.css) layer(components);";
-  neg_cursor read_stylesheet
+  neg_cursor read
     "@import url(default.css) layer(default); @layer theme { .x { color: red } \
      } @import url(components.css) layer(components);";
-  neg_cursor read_stylesheet
+  neg_cursor read
     "@import url(default.css) layer(default); @layer theme; @namespace \
      url(http://www.w3.org/1999/xhtml);"
 
@@ -3027,15 +3011,14 @@ let c64_invalid_layer_names () =
      segment, and the <layer-name> grammar has no empty segments. *)
   List.iter
     (fun keyword ->
-      neg_cursor read_stylesheet ("@layer " ^ keyword ^ " { .x { color: red } }");
-      neg_cursor read_stylesheet
-        ("@layer framework." ^ keyword ^ " { .x { color: red } }"))
+      neg_cursor read ("@layer " ^ keyword ^ " { .x { color: red } }");
+      neg_cursor read ("@layer framework." ^ keyword ^ " { .x { color: red } }"))
     [ "initial"; "inherit"; "unset"; "revert"; "revert-layer" ];
-  neg_cursor read_stylesheet "@layer framework..theme { .x { color: red } }";
-  neg_cursor read_stylesheet "@layer .framework { .x { color: red } }";
-  neg_cursor read_stylesheet "@layer framework. { .x { color: red } }";
-  neg_cursor read_stylesheet "@layer framework.theme. { .x { color: red } }";
-  neg_cursor read_stylesheet "@layer InHeRiT { .x { color: red } }"
+  neg_cursor read "@layer framework..theme { .x { color: red } }";
+  neg_cursor read "@layer .framework { .x { color: red } }";
+  neg_cursor read "@layer framework. { .x { color: red } }";
+  neg_cursor read "@layer framework.theme. { .x { color: red } }";
+  neg_cursor read "@layer InHeRiT { .x { color: red } }"
 
 (* Not a roundtrip test *)
 let c8_layer_api () =
@@ -3398,9 +3381,9 @@ let dom_selector_boundary () =
         expected
         (Css.Selector.to_string ~minify:true (Css.Selector.of_string input)))
     selector_cases;
-  neg_cursor read_stylesheet ".card:has(> ) { color: red }";
-  neg_cursor read_stylesheet "::before::after { color: red }";
-  neg_cursor read_stylesheet ":host-context() { color: red }"
+  neg_cursor read ".card:has(> ) { color: red }";
+  neg_cursor read "::before::after { color: red }";
+  neg_cursor read ":host-context() { color: red }"
 
 let fetch_url_boundary () =
   (* @import and url(...) syntax is in scope; loading/resolution is not. *)
@@ -3451,9 +3434,9 @@ let environment_query_boundary () =
      style(--theme: dark) { .card { display: grid } } } }";
   check_stylesheet ~expected:"@supports(display:){.x{color:red}}"
     "@supports (display:) { .x { color: red } }";
-  neg_cursor read_stylesheet "@media (width >= ) { .x { color: red } }";
-  neg_cursor read_stylesheet "@container card style() { .x { color: red } }";
-  neg_cursor read_stylesheet "@container card (width >) { .x { color: red } }"
+  neg_cursor read "@media (width >= ) { .x { color: red } }";
+  neg_cursor read "@container card style() { .x { color: red } }";
+  neg_cursor read "@container card (width >) { .x { color: red } }"
 
 let value_resolution_boundary () =
   let open Css.Values in
@@ -3540,7 +3523,7 @@ let custom_property_boundary () =
     "--empty: var(--missing,);";
   check_specified_value "nested var fallback"
     "--nested: var(--a, var(--b, red));" "var(--a, var(--b, red))";
-  neg_cursor read_stylesheet
+  neg_cursor read
     "@property --registered { syntax: \"<color>\"; inherits: false; \
      initial-value: 10px }"
 
@@ -3595,9 +3578,8 @@ let spec_current_at_rules () =
   check_stylesheet
     ~expected:"@container scroll-state(stuck:top){.card{color:red}}"
     "@container scroll-state(stuck: top) { .card { color: red } }";
-  neg_cursor read_stylesheet "@container style() { .card { color: red } }";
-  neg_cursor read_stylesheet
-    "@container scroll-state() { .card { color: red } }";
+  neg_cursor read "@container style() { .card { color: red } }";
+  neg_cursor read "@container scroll-state() { .card { color: red } }";
   check_stylesheet
     ~expected:
       "@container(30em<=inline-size<60em){@supports(display:grid){.grid{display:grid}}}"
@@ -3608,13 +3590,13 @@ let spec_current_at_rules () =
     "@starting-style { .dialog { opacity: 0; translate: 0 1rem } }";
   check_stylesheet ~expected:"@page chapter:left{margin:2cm}"
     "@page chapter:left { margin: 2cm }";
-  neg_cursor read_stylesheet "@media (width >) { .x { color: red } }";
-  neg_cursor read_stylesheet "@supports selector() { .x { color: red } }";
-  neg_cursor read_stylesheet "@scope (.card) .title { color: red }";
-  neg_cursor read_stylesheet "@font-palette-values { base-palette: 1; }";
-  neg_cursor read_stylesheet "@position-try default { top: 0; }";
-  neg_cursor read_stylesheet "@container () { .x { color: red } }";
-  neg_cursor read_stylesheet "@page : { margin: 1cm }"
+  neg_cursor read "@media (width >) { .x { color: red } }";
+  neg_cursor read "@supports selector() { .x { color: red } }";
+  neg_cursor read "@scope (.card) .title { color: red }";
+  neg_cursor read "@font-palette-values { base-palette: 1; }";
+  neg_cursor read "@position-try default { top: 0; }";
+  neg_cursor read "@container () { .x { color: red } }";
+  neg_cursor read "@page : { margin: 1cm }"
 
 let font_palette_values_descriptor_matrix () =
   List.iter
@@ -3630,8 +3612,7 @@ let font_palette_values_descriptor_matrix () =
         "@font-palette-values --dark { font-family: \"Color Font\", Brand; \
          base-palette: dark; }" );
     ];
-  List.iter
-    (neg_cursor read_stylesheet)
+  List.iter (neg_cursor read)
     [
       "@font-palette-values brand { font-family: Brand; base-palette: 1 }";
       "@font-palette-values --brand;";
@@ -3648,8 +3629,7 @@ let spec_view_transition_descriptor_matrix () =
       ( "@view-transition{navigation:none}",
         "@view-transition { navigation: none; }" );
     ];
-  List.iter
-    (neg_cursor read_stylesheet)
+  List.iter (neg_cursor read)
     [
       "@view-transition page { navigation: auto; }";
       "@view-transition;";
@@ -3669,8 +3649,7 @@ let spec_position_try_descriptor_matrix () =
         "@position-try --inline-start { inset-inline-end: anchor(start); \
          margin-inline: 1rem; }" );
     ];
-  List.iter
-    (neg_cursor read_stylesheet)
+  List.iter (neg_cursor read)
     [
       "@position-try default { top: 0; }";
       "@position-try --fallback;";
@@ -3714,8 +3693,7 @@ let spec_at_rule_descriptor_matrix () =
       ( "@starting-style{.dialog{opacity:0}}",
         "@starting-style { .dialog { opacity: 0 } }" );
     ];
-  List.iter
-    (neg_cursor read_stylesheet)
+  List.iter (neg_cursor read)
     [
       "@property --bad { syntax: \"<length>\"; inherits: false }";
       "@property --bad { syntax: \"<length>\"; inherits: false; initial-value: \
@@ -3744,9 +3722,7 @@ let spec_at_rule_inventory_matrix () =
   List.iter
     (fun (row : A.row) -> check_stylesheet ~expected:row.expected row.input)
     A.positive;
-  List.iter
-    (fun (row : A.invalid_row) -> neg_cursor read_stylesheet row.input)
-    A.negative;
+  List.iter (fun (row : A.invalid_row) -> neg_cursor read row.input) A.negative;
   let positive_features = A.features A.positive in
   let negative_features =
     A.negative
@@ -3811,9 +3787,9 @@ let test_spec_snapshot_tracking_vectors () =
       ".card{color:var(--fg);@media(prefers-color-scheme:dark){&{color:white}}}"
     ~optimized:
       ".card{color:var(--fg);@media(prefers-color-scheme:dark){&{color:#fff}}}";
-  neg_cursor read_stylesheet "@layer reset,,base;";
-  neg_cursor read_stylesheet "@container card () { .card { color: red } }";
-  neg_cursor read_stylesheet "@supports () { .accent { color: red } }"
+  neg_cursor read "@layer reset,,base;";
+  neg_cursor read "@container card () { .card { color: red } }";
+  neg_cursor read "@supports () { .accent { color: red } }"
 
 (* ignore-test *)
 let test_snapshot_membership_matrix () =
@@ -4256,10 +4232,10 @@ let spec_nesting_selector_edges () =
   check_stylesheet
     ~expected:"@starting-style{.dialog[open]{opacity:0;transform:scale(.95)}}"
     "@starting-style { .dialog[open] { opacity: 0; transform: scale(0.95) } }";
-  neg_cursor read_stylesheet ".card { & { & { color: red } } }";
-  neg_cursor read_stylesheet "@scope () { .x { color: red } }";
-  neg_cursor read_stylesheet "@scope (.x) to () { .x { color: red } }";
-  neg_cursor read_stylesheet "@starting-style;"
+  neg_cursor read ".card { & { & { color: red } } }";
+  neg_cursor read "@scope () { .x { color: red } }";
+  neg_cursor read "@scope (.x) to () { .x { color: red } }";
+  neg_cursor read "@starting-style;"
 
 (* CSS Nesting Module Level 1, sections 1 and 2: a nested style rule is a
    qualified rule appearing inside another qualified rule's block. The grammar
@@ -9622,9 +9598,9 @@ let additional_tests =
     ( "partial recovery: bad declaration does not poison sibling rule",
       `Quick,
       fun () ->
-        (* Strict [read_stylesheet] would raise on the bad [rgb()]. The partial
-           entry point drops just the bad declaration; both rules survive (the
-           empty [.a\{\}] and the good [.b]). Per 5.4.4. *)
+        (* Strict [read] would raise on the bad [rgb()]. The partial entry point
+           drops just the bad declaration; both rules survive (the empty
+           [.a\{\}] and the good [.b]). Per 5.4.4. *)
         let sheet, warnings =
           parse_stylesheet_partial ".a { color: rgb(300); } .b { color: red; }"
         in

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -11,8 +11,7 @@ let check_any_syntax =
 
 let decl_t : Css.Declaration.declaration Alcotest.testable =
   Alcotest.testable
-    (fun fmt d ->
-      Format.pp_print_string fmt (Css.Declaration.string_of_declaration d))
+    (fun fmt d -> Format.pp_print_string fmt (Css.Declaration.to_string d))
     ( = )
 
 (* These tests are for CSS Variables module *)
@@ -338,7 +337,7 @@ let spec_radial_and_position_kinds () =
     Alcotest.(check string)
       ("--" ^ name ^ " binding")
       expected
-      (Css.Declaration.string_of_declaration ~minify:true decl)
+      (Css.Declaration.to_string ~minify:true decl)
   in
   bind "radial-shape" Radial_shape Circle "--radial-shape:circle";
   bind "radial-size" Radial_size Farthest_corner "--radial-size:farthest-corner";


### PR DESCRIPTION
Removes redundant aliases, one-off parsers, the duplicate Box_shadow kind, and the unused inset-ring helper; pp functions now expose composable printers and Css owns the sole inline-style renderer. Adjacent tw only needs its Box_shadow kind match migrated to Shadow.