### PR TITLE
api: document optimizer and printer flags

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7728,12 +7728,13 @@ val optimize :
   ?aggressive:bool ->
   ?regroup:bool ->
   ?closed_world:bool ->
-  ?objective:[ `Raw | `Transfer ] ->
+  ?objective:Optimize.objective ->
   ?prune_unused_custom_props:bool ->
   ?stats:Stats.t ->
   t ->
   t
 (** [optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
+     ?regroup ?closed_world ?objective ?prune_unused_custom_props ?stats
      stylesheet] applies CSS optimizations to the stylesheet, including merging
     consecutive identical selectors and combining rules with identical
     properties. Preserves CSS cascade semantics for any DOM, unless
@@ -7757,6 +7758,11 @@ val optimize :
     runs even when the preflight predicts low gain, and the top-level
     statement-optimisation pipeline iterates until the AST reaches a structural
     fixpoint (capped at a small bound).
+
+    When [regroup] is [true] (the default), order-dependent adjacent rule runs
+    may be regrouped by factoring shared declarations and synthesising nesting.
+    Canonical diff projection disables it to remain confluent; see
+    {!Optimize.stylesheet}.
 
     When [closed_world] is [true] (default [false]) the optimizer assumes the
     caller knows the exact HTML and that no element ever matches two clashing

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -12,6 +12,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 (** {1 Edge Model} *)
 
 type scope = Ctx.scope
+type objective = [ `Raw | `Transfer ]
 
 (* Optimisation context threaded from the entry points to the shorthand
    composers. [scope] drives fragment-vs-stylesheet decisions; [registered]

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -23,6 +23,10 @@ type scope = [ `Fragment | `Stylesheet ]
     partial-coverage shorthand because the omitted longhand resets are
     guaranteed not to disturb any prior write. *)
 
+type objective = [ `Raw | `Transfer ]
+(** The size objective for global factoring. [`Raw] keeps raw-byte wins;
+    [`Transfer] rejects a result that grows the estimated DEFLATE size. *)
+
 (** {1 Declaration Optimization} *)
 
 val duplicate_buggy_properties : declaration list -> declaration list
@@ -50,19 +54,21 @@ val ctx_of_scope :
   ?regroup:bool ->
   ?extend_lists:bool ->
   ?closed_world:bool ->
-  ?objective:Ctx.objective ->
+  ?objective:objective ->
   ?enforce_spec:bool ->
   ?stats:Stats.t ->
   scope option ->
   ctx
-(** [ctx_of_scope ?lossless ?aggressive ?extend_lists ?closed_world scope]
-    builds the context the composers take; [None] is [`Fragment]. [aggressive]
-    forces the expensive global factoring fixpoint to run even when its
-    preflight predicts low gain. [extend_lists] is for direct DAG-scheduler
-    experiments; the main stylesheet optimizer enables guarded selector-list
-    extension internally. [closed_world] asserts the caller knows the exact HTML
-    and that no element matches two clashing selectors, so the optimizer may
-    merge rules it would otherwise keep apart; unsafe for an unknown DOM. *)
+(** [ctx_of_scope ?lossless ?aggressive ?regroup ?extend_lists ?closed_world
+     ?objective ?enforce_spec ?stats scope] builds the context the composers
+    take; [None] is [`Fragment]. [aggressive] forces the expensive global
+    factoring fixpoint to run even when its preflight predicts low or no gain.
+    [regroup] permits order-dependent regrouping of adjacent rules.
+    [extend_lists] is for direct DAG-scheduler experiments; the main stylesheet
+    optimizer enables guarded selector-list extension internally. [closed_world]
+    asserts the caller knows the exact HTML and that no element matches two
+    clashing selectors, so the optimizer may merge rules it would otherwise keep
+    apart; unsafe for an unknown DOM. [objective] defaults to [`Transfer]. *)
 
 val compose_shorthands :
   ctx:ctx -> (int * declaration) list -> (int * declaration) list
@@ -155,17 +161,18 @@ val stylesheet :
   ?aggressive:bool ->
   ?regroup:bool ->
   ?closed_world:bool ->
-  ?objective:Ctx.objective ->
+  ?objective:objective ->
   ?prune_unused_custom_props:bool ->
   ?stats:Stats.t ->
   t ->
   t
-(** [stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec ss] optimizes an
-    entire stylesheet while preserving cascade semantics for any DOM (with
-    [closed_world] off, the default). When [@supports] blocks are present
-    alongside top-level rules, optimization is limited because the stylesheet
-    structure separates rules from [@supports] blocks, losing their relative
-    ordering.
+(** [stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
+     ?regroup ?closed_world ?objective ?prune_unused_custom_props ?stats ss]
+    optimizes an entire stylesheet while preserving cascade semantics for any
+    DOM (with [closed_world] off, the default). When [@supports] blocks are
+    present alongside top-level rules, optimization is limited because the
+    stylesheet structure separates rules from [@supports] blocks, losing their
+    relative ordering.
 
     When [flatten_nesting] is [true] (default [false]) nested rules are
     desugared into flat rules: child selectors with [&] have the parent selector
@@ -176,21 +183,34 @@ val stylesheet :
     [scope] (default [`Fragment]) gates partial-coverage shorthand synthesis;
     see the {!scope} doc.
 
-    [lossless] disables colour approximation while keeping exact colour
-    canonicalisation.
+    When [lossless] is [true] (default [false]), colour-channel rounding and
+    other lossy approximations are suppressed while exact colour
+    canonicalisation still runs.
 
     When [enforce_spec] is [false] (default) the optimizer may treat baseline
     feature queries as known facts and elide [@supports] guards whose condition
     is satisfied in maintained evergreen browsers; [true] keeps every feature
     query and applies only CSS-text-and-spec-provable rewrites.
 
+    When [aggressive] is [true] (default [false]), global factoring runs even
+    when its preflight predicts low or no gain, candidate limits widen, and the
+    top-level statement pipeline uses a larger structural-fixpoint cap.
+
+    When [regroup] is [true] (the default), order-dependent adjacent rule runs
+    may be regrouped by factoring shared declarations and synthesising nesting.
+    Canonical diff projection disables it to remain confluent.
+
     When [closed_world] is [true] (default [false]) the optimizer assumes the
     caller knows the exact HTML and that no element ever matches two clashing
     selectors, so it may merge rules it would otherwise keep apart. Unsafe: the
     page can render wrong if such an element appears, including one a script
     adds at runtime. This is about the HTML, separate from [scope] (how much of
-    the CSS you control). The default is safe for any page; see
-    {!Ctx.closed_world}.
+    the CSS you control). The default is safe for any page.
+
+    [objective] (default [`Transfer]) chooses the size metric for global
+    factoring. [`Transfer] discards a result that grows estimated DEFLATE size
+    even when it shrinks raw bytes; [`Raw] keeps every raw-byte win and suits
+    output that ships uncompressed.
 
     When [prune_unused_custom_props] is [true] (default [false]) custom-property
     bindings referenced by no [var()] anywhere are dropped. This is opt-in

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -71,8 +71,19 @@ val ctx :
   ?enforce_spec:bool ->
   Buffer.t ->
   ctx
-(** [ctx buf] builds a formatter context writing to [buf], for the
-    serialise-to-string / measuring helpers. *)
+(** [ctx ?minify ?indent ?inline ?lossless ?enforce_spec buf] builds a formatter
+    context writing to [buf], for the serialise-to-string and measuring helpers.
+
+    - [minify] (default [false]) selects compact layout and value spelling.
+    - When [indent] is omitted it defaults to [None] under [minify] and [Some 2]
+      otherwise. An explicit width is honoured in either mode.
+    - [inline] (default [false]) prints a variable node's stored default or
+      typed fallback when it has one; otherwise the [var()] reference remains.
+      It does not resolve variables at print time.
+    - [lossless] (default [false]) suppresses lossy colour rounding and
+      approximations while retaining exact canonicalisation.
+    - [enforce_spec] (default [false]) disables evergreen-target-dependent
+      shortenings while retaining exact and spec-safe shortenings. *)
 
 val to_buffer :
   ?minify:bool ->
@@ -84,9 +95,9 @@ val to_buffer :
   'a t ->
   'a ->
   unit
-(** [to_buffer buf formatter value] runs the formatter writing into [buf]. The
-    optional {!val-indent} sets the per-level indent width (default: [None]
-    under {!field-minify}, [Some 2] otherwise). *)
+(** [to_buffer ?minify ?indent ?inline ?lossless ?enforce_spec buf formatter
+     value] runs [formatter] under the context {!val-ctx} builds from the same
+    five options and writes the result into [buf]. *)
 
 val size :
   ?minify:bool ->
@@ -97,7 +108,8 @@ val size :
   'a t ->
   'a ->
   int
-(** [size formatter value] is the byte length of [to_string formatter value]
+(** [size ?minify ?indent ?inline ?lossless ?enforce_spec formatter value] is
+    the byte length of [to_string formatter value] under the same options,
     without allocating the result string. Use it for size-based decisions
     instead of measuring [String.length (to_string ...)]. *)
 
@@ -110,10 +122,9 @@ val to_string :
   'a t ->
   'a ->
   string
-(** [to_string formatter value] runs the formatter and returns a string. The
-    optional {!val-indent} sets the per-level indent width (default: [None]
-    under {!field-minify}, [Some 2] otherwise). {!field-enforce_spec} suppresses
-    target-dependent shortenings. *)
+(** [to_string ?minify ?indent ?inline ?lossless ?enforce_spec formatter value]
+    runs [formatter] under the context {!val-ctx} builds from the same five
+    options and returns the result. *)
 
 (** {2 Primitive Formatters} *)
 

--- a/lib/stats.mli
+++ b/lib/stats.mli
@@ -1,9 +1,9 @@
 (** Optimizer profiling counters, scoped to one run.
 
-    A recorder belongs to the optimizer run that created it and is reachable
-    only through that run's {!Ctx.t}, so an optimization started while another
-    is in progress counts its own work. Readers take a {!snapshot}: a value, not
-    a view, so a later run cannot rewrite what an earlier one reported. *)
+    A recorder is threaded through only the optimizer run that receives it, so
+    an optimization started while another is in progress counts its own work.
+    Readers take a {!snapshot}: a value, not a view, so a later run cannot
+    rewrite what an earlier one reported. *)
 
 type t
 (** One run's recorder. *)

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -12,6 +12,8 @@ let _ = Container.to_string
 let _ : Container.t Pp.t = Container.pp
 let _ : Stylesheet.t Pp.t = Stylesheet.pp
 let _ : Css.t Pp.t = Css.pp
+let _ : Optimize.objective = `Transfer
+let _ : Css.Optimize.objective = `Raw
 let _ :
     ?optimize:bool ->
     ?minify:bool ->


### PR DESCRIPTION
Exposes Optimize.objective so public signatures no longer name private Ctx, removes the remaining private odoc links, and documents every optimizer and printer flag with its real default and limits. A compiled installed-API probe pins the new public type.