### PR TITLE
shorthand: shadow page-break-* against its break-* twin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -546,6 +546,10 @@ recorded cases carrying six minifiers' answers.
   one hash and the two tables that drop shadowed rules and declarations
   compared selector subtrees on every probe; the heaviest stylesheet in the
   corpus spends a third of what it did on that pass (#493)
+- `--minify` keeps one declaration where a rule writes both a `page-break-*`
+  property and its `break-*` twin. CSS Fragmentation 3 sec. 3.4 makes the pair
+  one property, so `page-break-before: always; break-before: page` no longer
+  emits `break-before: page` twice (#547)
 
 ### Custom properties
 

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -176,6 +176,24 @@ let covers_longhand : type a b.
   | Font, Font_optical_sizing -> true
   | _ -> false
 
+(* CSS Fragmentation 3 sec. 3.4 aliases [page-break-before/after/inside] to
+   [break-before/after/inside] through a value mapping ([always] maps to [page],
+   every other value to itself), so a pair is one property writing one slot:
+   either spelling shadows the other whatever value it carries. Symmetric,
+   unlike the shorthand table above, since the alias has exactly one
+   longhand. *)
+let aliases_page_break : type a b.
+    a Properties.property -> b Properties.property -> bool =
+ fun p q ->
+  match (p, q) with
+  | Page_break_before, Break_before -> true
+  | Break_before, Page_break_before -> true
+  | Page_break_after, Break_after -> true
+  | Break_after, Page_break_after -> true
+  | Page_break_inside, Break_inside -> true
+  | Break_inside, Page_break_inside -> true
+  | _ -> false
+
 (* CSS Cascade 5 sec. 3.2: [all] resets every property except [direction],
    [unicode-bidi], and custom properties. [Unknown_property _] is reset by [all]
    (an unrecognised non-custom property is still a CSS property). *)
@@ -224,6 +242,7 @@ let declaration_covers covering covered =
       Declaration { property = covered_p; _ } ) ->
       Declaration.same_property covering covered
       || covers_longhand covering_p covered_p
+      || aliases_page_break covering_p covered_p
   | _ -> false
 
 type overlap_key = int
@@ -756,6 +775,14 @@ let property_slots : type a. a Properties.property -> overlap_key list =
         key "column-rule-color";
       ]
   | Column_rule_color -> [ key "column-rule-color" ]
+  (* CSS Fragmentation 3 sec. 3.4: a [page-break-*] alias writes the slot of the
+     [break-*] property it aliases. *)
+  | Break_before -> [ key "break-before" ]
+  | Page_break_before -> [ key "break-before" ]
+  | Break_after -> [ key "break-after" ]
+  | Page_break_after -> [ key "break-after" ]
+  | Break_inside -> [ key "break-inside" ]
+  | Page_break_inside -> [ key "break-inside" ]
   (* CSS Lists 3 sec. 3.6. *)
   | List_style ->
       [

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -612,6 +612,45 @@ let test_same_value_ignores_importance () =
     [ "display:-webkit-box!important" ]
     (decl_strings result)
 
+(* CSS Fragmentation 3 sec. 3.4 aliases [page-break-before/after/inside] to
+   [break-before/after/inside] through a value mapping: [always] maps to [page]
+   and every other value to itself. The pair is one property writing one cascade
+   slot, so either spelling shadows the other and only the last one written
+   survives. *)
+let test_page_break_alias_shadowing () =
+  Alcotest.(check bool)
+    "the legacy spelling covers the modern one" true
+    (Shorthand.declaration_covers
+       (decl "page-break-before:always")
+       (decl "break-before:page"));
+  Alcotest.(check bool)
+    "the modern spelling covers the legacy one" true
+    (Shorthand.declaration_covers (decl "break-before:page")
+       (decl "page-break-before:always"));
+  Alcotest.(check bool)
+    "the pair writes one slot" true
+    (Shorthand.declarations_overlap
+       (decl "page-break-inside:avoid")
+       (decl "break-inside:avoid"));
+  let dedup css =
+    decl_strings (Shorthand.deduplicate_declarations (decls css))
+  in
+  Alcotest.(check (list string))
+    "[always] maps to [page], so the pair is one declaration"
+    [ "break-before:page" ]
+    (dedup ".a{page-break-before:always;break-before:page}");
+  Alcotest.(check (list string))
+    "[avoid] maps to itself, so the pair is one declaration"
+    [ "break-inside:avoid" ]
+    (dedup ".a{page-break-inside:avoid;break-inside:avoid}");
+  Alcotest.(check (list string))
+    "[always] and [avoid] are two values of one property, and the last wins"
+    [ "break-before:avoid" ]
+    (dedup ".a{page-break-before:always;break-before:avoid}");
+  Alcotest.(check (list string))
+    "the legacy spelling wins when it comes last" [ "break-after:page" ]
+    (dedup ".a{break-after:avoid;page-break-after:always}")
+
 let suite =
   ( "shorthand",
     [
@@ -649,4 +688,6 @@ let suite =
         test_deduplicate_keeps_legacy_fallbacks;
       Alcotest.test_case "same value ignores importance" `Quick
         test_same_value_ignores_importance;
+      Alcotest.test_case "page-break alias shadowing" `Quick
+        test_page_break_alias_shadowing;
     ] )


### PR DESCRIPTION
CSS Fragmentation 3 sec. 3.4 makes `page-break-*` and `break-*` one property, but the shadowing comparison read them as two, so a rule writing both spellings kept both and minified output repeated the same declaration. The printer stays as #511 left it: its minified `break-*` spelling is the cascade key `Resolve`, `Apply` and `Optimize` read through `Declaration.property_name`.
