### PR TITLE
api: drop the no-op Selector_summary.clear_memo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -151,6 +151,9 @@ recorded cases carrying six minifiers' answers.
   names over a component-value stream, so read CSS from a `Cursor.of_string` or
   `Cursor.of_reader` instead. The cursor itself, the `parse_error` record and
   the call stack are unchanged (#509, #514)
+- `Css.Selector_summary.clear_memo` is gone. It did nothing, so a caller that
+  called it can drop the call and see no change: summaries are computed per
+  call and there is no cache to reset (#548)
 
 ### Parsing
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -906,7 +906,6 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
     ?(enforce_spec = false) ?(aggressive = false) ?(regroup = true)
     ?(closed_world = false) ?(objective = `Transfer)
     ?(prune_unused_custom_props = false) ?stats (stylesheet : t) : t =
-  Selector_summary.clear_memo ();
   let scope = Option.value scope ~default:`Fragment in
   let ctx = single_valued_calc_ctx stylesheet in
   let stylesheet = sanitize_block ~ctx ~lossless stylesheet in

--- a/lib/selector_summary.ml
+++ b/lib/selector_summary.ml
@@ -125,8 +125,6 @@ let rec fold_simple s (sel : Selector.t) =
       | Some nth -> add_nth nth s
       | None -> mark_complex s)
 
-let clear_memo () = ()
-
 let rec of_selector (sel : Selector.t) : t =
   match sel with
   | Combined (left, Child, right) ->

--- a/lib/selector_summary.mli
+++ b/lib/selector_summary.mli
@@ -19,12 +19,6 @@ val of_selector : Selector.t -> t
     keyed on the rightmost compound (the subject element) so that, e.g., [.a .b]
     and [.c .b] summarize the same way - both target a [.b] element. *)
 
-val clear_memo : unit -> unit
-(** [clear_memo ()] is a no-op kept for callers that previously reset a
-    per-selector memo. Summaries are now computed afresh per call; structural
-    Hashtbl caching cost more time on real-world stylesheets than the recompute
-    work it saved. *)
-
 val may_overlap : t -> t -> bool
 (** [may_overlap a b] is [true] when some DOM element might match both
     selectors. [false] is a hard guarantee that no element matches both, modulo


### PR DESCRIPTION
`Selector_summary.clear_memo` is an empty function, and keeping it public implies a per-selector cache that callers might think they have to reset. There is none, so the only caller drops its call.
