### PR TITLE
properties: give ray() only the sizes it can spell

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -154,6 +154,9 @@ recorded cases carrying six minifiers' answers.
 - `Css.Selector_summary.clear_memo` is gone. It did nothing, so a caller that
   called it can drop the call and see no change: summaries are computed per
   call and there is no cache to reset (#548)
+- `Css.Properties.ray_size` names the five sizes `ray()` accepts directly, so
+  write `Closest_side` for `Radial Closest_side`. The dropped `Radial` wrapper
+  also admitted lengths and radii that `pp_ray_size` raised on (#549)
 
 ### Parsing
 

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -301,12 +301,6 @@ let normalize_transform_origin : transform_origin -> transform_origin =
         preserve_if_equal value (Position_z (normalize_position_value p, z c))
     | other -> other
 
-let normalize_ray_size : ray_size -> ray_size =
- fun value ->
-  match value with
-  | Radial size -> preserve_if_equal value (Radial (normalize_radial_size size))
-  | Sides -> Sides
-
 let normalize_offset_path : offset_path -> offset_path =
  fun value ->
   match value with
@@ -316,7 +310,6 @@ let normalize_offset_path : offset_path -> offset_path =
            {
              ray with
              angle = Values.normalize_angle ray.angle;
-             size = option_map_preserve normalize_ray_size ray.size;
              position =
                option_map_preserve
                  (normalize_position_value ~strip:false)
@@ -654,11 +647,10 @@ let rec pp_backface_visibility : backface_visibility Pp.t =
 
 let pp_ray_size : ray_size Pp.t =
  fun ctx -> function
-  | Radial Closest_side -> Pp.string ctx "closest-side"
-  | Radial Closest_corner -> Pp.string ctx "closest-corner"
-  | Radial Farthest_side -> Pp.string ctx "farthest-side"
-  | Radial Farthest_corner -> Pp.string ctx "farthest-corner"
-  | Radial _ -> invalid_arg "pp_ray_size: invalid radial size for ray()"
+  | Closest_side -> Pp.string ctx "closest-side"
+  | Closest_corner -> Pp.string ctx "closest-corner"
+  | Farthest_side -> Pp.string ctx "farthest-side"
+  | Farthest_corner -> Pp.string ctx "farthest-corner"
   | Sides -> Pp.string ctx "sides"
 
 let pp_ray : ray Pp.t =
@@ -1201,10 +1193,10 @@ let read_perspective_origin : Cursor.t -> perspective_origin =
 let read_ray_size t : ray_size =
   Cursor.enum "ray size"
     [
-      ("closest-side", (Radial Closest_side : ray_size));
-      ("closest-corner", Radial Closest_corner);
-      ("farthest-side", Radial Farthest_side);
-      ("farthest-corner", Radial Farthest_corner);
+      ("closest-side", (Closest_side : ray_size));
+      ("closest-corner", Closest_corner);
+      ("farthest-side", Farthest_side);
+      ("farthest-corner", Farthest_corner);
       ("sides", Sides);
     ]
     t

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3581,7 +3581,14 @@ type margin_trim =
   | Revert_layer
   | Var of margin_trim var
 
-type ray_size = Radial of radial_size | Sides
+(** [ray()] size: the [<radial-extent>] keywords plus [sides]. The [<length>]
+    and two-radii branches of [<radial-size>] have no [ray()] syntax. *)
+type ray_size =
+  | Closest_side
+  | Closest_corner
+  | Farthest_side
+  | Farthest_corner
+  | Sides
 
 type ray = {
   angle : angle;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4490,6 +4490,30 @@ let test_outline_shorthand () =
   check_outline_shorthand "2px solid red";
   neg_cursor read_outline_shorthand "invalid-outline-value"
 
+(* CSS Motion Path 1 (ED) sec. 2.1.1 gives [<ray-size> = <radial-extent> |
+   sides], and [<radial-extent>] (css-images-3 sec. 3.2.1) is the four extent
+   keywords: a length or a pair of radii is a [<radial-size>] branch that
+   [ray()] has no syntax for. Every value the type admits prints, and the
+   printed text parses back to it. *)
+let test_ray_size () =
+  let sizes : ray_size list =
+    [
+      Radial Closest_side;
+      Radial Closest_corner;
+      Radial Farthest_side;
+      Radial Farthest_corner;
+      Radial (Circle_radius (Px 1.));
+      Radial (Ellipse_radii (Length (Px 1.), Pct 50.));
+      Radial (Var (Values.var_ref "x"));
+      Sides;
+    ]
+  in
+  List.iter
+    (fun size ->
+      check_ray_size (Css.Pp.to_string ~minify:true pp_ray_size size))
+    sizes;
+  neg_cursor read_ray_size "10px"
+
 let additional_tests =
   [
     test_case "will_change" `Quick test_will_change;
@@ -4499,6 +4523,7 @@ let additional_tests =
     test_case "quotes" `Quick test_quotes;
     test_case "outline" `Quick test_outline;
     test_case "outline_shorthand" `Quick test_outline_shorthand;
+    test_case "ray_size" `Quick test_ray_size;
     test_case "background" `Quick test_background;
     test_case "font_family" `Quick test_font_family;
     test_case "text_shadow" `Quick test_text_shadow;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4497,16 +4497,7 @@ let test_outline_shorthand () =
    printed text parses back to it. *)
 let test_ray_size () =
   let sizes : ray_size list =
-    [
-      Radial Closest_side;
-      Radial Closest_corner;
-      Radial Farthest_side;
-      Radial Farthest_corner;
-      Radial (Circle_radius (Px 1.));
-      Radial (Ellipse_radii (Length (Px 1.), Pct 50.));
-      Radial (Var (Values.var_ref "x"));
-      Sides;
-    ]
+    [ Closest_side; Closest_corner; Farthest_side; Farthest_corner; Sides ]
   in
   List.iter
     (fun size ->


### PR DESCRIPTION
`Properties.pp_ray_size` used to raise `Invalid_argument` on a value the public constructors could build: `ray_size` wrapped a whole `radial_size`, so it admitted the length, radii-pair and `var()` branches that `ray()` has no syntax for and the reader never produces. It now names the five sizes CSS Motion Path 1 sec. 2.1.1 allows, and the printer covers every one of them.
