### PR TITLE
stylesheet: require font-family in @font-palette-values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A valid `@font-palette-values` rule no longer warns, so `cascade apply`
+  accepts it. CSS Fonts 4 sec. 9.2.2 (Working Draft, 25 August 2026) defaults
+  a missing `base-palette` to 0, and sec. 9.2 makes `font-family` the mandatory
+  descriptor, whose absence warns in its place (#551)
 - A parse error in a `page-break-before`, `page-break-after` or
   `page-break-inside` declaration is reported against the property the
   declaration wrote. The diagnostic named the CSS Fragmentation 3 sec. 3.4

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -4079,14 +4079,16 @@ let validate_partial_statement loc = function
       Some
         (Error.bad_value loc ~property:"@font-face"
            ~reason:"missing font-family or src descriptor")
+  (* CSS Fonts 4 sec. 9.2 makes font-family the one mandatory descriptor; sec.
+     9.2.2 defaults a missing base-palette to 0. *)
   | Font_palette_values (_, descriptors)
     when not
            (List.exists
-              (function Base_palette _ -> true | _ -> false)
+              (function Palette_font_family _ -> true | _ -> false)
               descriptors) ->
       Some
         (Error.bad_value loc ~property:"@font-palette-values"
-           ~reason:"missing base-palette descriptor")
+           ~reason:"missing font-family descriptor")
   | (Keyframes (name, _) | Webkit_keyframes (name, _) | Moz_keyframes (name, _))
     when List.mem
            (String.lowercase_ascii name)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1487,7 +1487,7 @@ let spec_strict_rejects_invalid_stylesheets () =
       ( "font-face invalid font-display list",
         "@font-face { font-family: Brand; src: url(font.woff2); font-display: \
          block swap }" );
-      ( "font-palette missing base-palette",
+      ( "font-palette missing font-family",
         "@font-palette-values --brand { override-colors: 0 red }" );
       ( "counter-style missing system",
         "@counter-style thumbs { symbols: \"*\" }" );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2120,6 +2120,21 @@ let spec_descriptor_recovery_warns_once_per_descriptor () =
   warns_exactly "@font-feature-values Xf { @swash { s: 1 } }" 0;
   warns_exactly "@font-feature-values Xf { ;; @swash { s: 1 } }" 0
 
+(* CSS Fonts 4 sec. 9.2 names the one mandatory descriptor:
+   "@font-palette-values rules require a font-family descriptor; if it is
+   missing, the @font-palette-values rule is invalid and must be ignored
+   entirely." base-palette is optional, and sec. 9.2.2 gives it a default: "If
+   this descriptor is not present in the @font-palette-values, [...] it behaves
+   as if 0 were specified." Both sections read the same in the Editor's Draft
+   and in the TR Working Draft of 25 August 2026. *)
+let spec_font_palette_values_requires_font_family () =
+  warns_exactly
+    "@font-palette-values --p { font-family: A; override-colors: 0 red }" 0;
+  warns_exactly "@font-palette-values --p { font-family: A }" 0;
+  warns_exactly
+    "@font-palette-values --p { base-palette: 1; override-colors: 0 red }" 1;
+  warns_exactly "@font-palette-values --p { override-colors: 0 red }" 1
+
 (* CSS Animations 1 sec. 3 fills a [@keyframes] body with keyframe rules, so it
    is a list of rules: an at-rule has no place there, and CSS Syntax 3 sec.
    5.4.2 ends the one being discarded at its own [{}] block or at its [;],
@@ -2318,6 +2333,9 @@ let stylesheet_tests =
     ( "spec descriptor recovery warns once per dropped descriptor",
       `Quick,
       spec_descriptor_recovery_warns_once_per_descriptor );
+    ( "spec font-palette-values requires font-family",
+      `Quick,
+      spec_font_palette_values_requires_font_family );
     ( "spec lenient recovery in a @keyframes body",
       `Quick,
       spec_lenient_recovery_keyframes_at_rule );


### PR DESCRIPTION
`@font-palette-values` demanded a `base-palette` descriptor, which CSS Fonts 4 sec. 9.2.2 makes optional with a default of 0, so cascade warned on valid CSS and `cascade apply` rejected it over the `warnings <> []` gate. sec. 9.2 makes `font-family` the mandatory one, and its absence went unreported until now.
