### PR TITLE
selector: refuse a combinator after a pseudo-element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,12 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A rule whose selector puts a combinator after a pseudo-element, such as
+  `.a::before .b`, is reported and dropped instead of written back. CSS
+  Selectors 4 sec. 3.6.5 (Editor's Draft, drafts.csswg.org/selectors-4/) makes
+  it invalid unless the pseudo-element has internal structure, and none that
+  ships has; Chrome 151 and WebKit 26.5 drop every such rule. A `::` name
+  cascade does not model, such as `::deep`, keeps its combinator (#552)
 - A valid `@font-palette-values` rule no longer warns, so `cascade apply`
   accepts it. CSS Fonts 4 sec. 9.2.2 (Working Draft, 25 August 2026) defaults
   a missing `base-palette` to 0, and sec. 9.2 makes `font-family` the mandatory

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -1238,6 +1238,33 @@ and pseudo_element_allows_argument pe = function
   | Combined _ | Relative _ | List _ -> false
   | c -> is_pe_action c && pseudo_element_allows pe c
 
+(* CSS Selectors 4 sec. 3.6.5: a pseudo-element defined to have internal
+   structure may be followed by a child or descendant combinator, and a selector
+   with a combinator after the pseudo-element is invalid otherwise. Nothing
+   shipping claims that structure, so the exception stays empty: Chrome 151 and
+   WebKit 26.5 drop [::part(x) > .b], [::details-content > div] and
+   [::first-letter em] alike, and the Servo selectors crate raises
+   UnexpectedSelectorAfterPseudoElement for the same shapes.
+
+   A [::] name cascade does not model is exempt, for the reason
+   [pseudo_element_allows] already exempts it from sec. 3.6.3: cascade preserves
+   such a name rather than judging it. test/interop/lightning carries seven
+   rules of that kind ([.foo ::deep .bar], [.foo ::unknown(.foo) .bar] and their
+   kin) and all six reference minifiers keep every one verbatim, while Lightning
+   CSS rejects the identical shape as soon as the name is one it knows
+   ([::-moz-placeholder .b]). Dropping the exemption would delete those
+   rules. *)
+let is_modelled_pseudo_element = function
+  | Unknown_pseudo_element _ | Unknown_pseudo_element_call _ -> false
+  | sel -> is_pseudo_element sel
+
+(* Only the compound's own components. A pseudo-element inside a functional
+   pseudo-class argument belongs to that argument's own rules, so
+   [.a:has(.b::before) .c] is not this one's to judge. *)
+let bars_following_combinator = function
+  | Compound components -> List.exists is_modelled_pseudo_element components
+  | sel -> is_modelled_pseudo_element sel
+
 (* The merged lists are static across the lifetime of the program (every
    constituent is a [let] binding above); memoise them so the [@] cons-chain
    only happens once instead of per [:foo] / [::foo] pseudo read. *)
@@ -1720,26 +1747,35 @@ and read_complex t =
     || Cursor.peek_block t = Some Token.Square
     || Cursor.peek_ident t <> None
   in
+  (* CSS Selectors 4 sec. 3.6.5, via [bars_following_combinator]. [>>>] and
+     [/deep/] are Vue / Angular tooling spellings rather than CSS combinators,
+     and no engine parses either, so the rule never reaches them and cascade
+     passes them through as it does an unmodelled pseudo-element name. *)
+  let check_combinator = function
+    | Shadow_piercing | Shadow_deep -> ()
+    | Descendant | Child | Next_sibling | Subsequent_sibling | Column ->
+        if bars_following_combinator left then
+          Cursor.err t "combinator not allowed after a pseudo-element"
+  in
+  let read_combined () =
+    let comb = read_combinator t in
+    check_combinator comb;
+    Cursor.ws t;
+    combine left comb (read_complex t)
+  in
   match Cursor.peek_delim t with
   | Some '|'
     when Cursor.lookahead
            (fun t -> Cursor.try_kind_pair (Token.Delim "|") (Token.Delim "|") t)
            t ->
-      let comb = read_combinator t in
-      Cursor.ws t;
-      combine left comb (read_complex t)
-  | Some ('>' | '+' | '~') ->
-      let comb = read_combinator t in
-      Cursor.ws t;
-      combine left comb (read_complex t)
-  | Some '/' when Cursor.lookahead try_shadow_deep t ->
-      let comb = read_combinator t in
-      Cursor.ws t;
-      combine left comb (read_complex t)
+      read_combined ()
+  | Some ('>' | '+' | '~') -> read_combined ()
+  | Some '/' when Cursor.lookahead try_shadow_deep t -> read_combined ()
   | _ ->
       if Cursor.peek_comma t || Cursor.is_done t then left
-      else if can_start_selector () then
-        combine left Descendant (read_complex t)
+      else if can_start_selector () then (
+        check_combinator Descendant;
+        combine left Descendant (read_complex t))
       else left
 
 (* CSS Selectors 4 section 3.9: the top-level rule selector list is an

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -39,6 +39,23 @@ let test_empty_block_is_empty () =
     "empty input yields empty output" 0
     (List.length (Flatten.block stmts))
 
+(* A gap, pinned so it stays visible. CSS Selectors 4 sec. 3.6.5 makes a
+   combinator after a pseudo-element invalid, and the selector reader refuses
+   [.a::before .b] for it. Flattening builds the same selector from a valid
+   parent and a valid nested selector without going through the reader, so this
+   route still emits it. Chrome 151 and WebKit 26.5 keep the nested rule in
+   cssRules but it matches nothing, since the flattened form is the invalid one.
+
+   Closing this needs the parent context at flatten time, which is a larger
+   change than the reader guard; when it lands, this expectation becomes an
+   empty statement list. *)
+let test_pseudo_element_parent_still_flattens () =
+  let stmts = block ".a::before{.b{color:red}}" in
+  Alcotest.(check string)
+    "nested rule under a pseudo-element parent flattens to an invalid selector"
+    ".a:before .b{color:red}"
+    (render (Flatten.block stmts))
+
 (* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so its
    prelude is ambiguous with a declaration until the block appears:
    [h2:where(...)] reads as the property [h2] with value [where(...)]. Parsing
@@ -141,6 +158,8 @@ let suite =
         test_flattens_descendant_nesting;
       Alcotest.test_case "empty block stays empty" `Quick
         test_empty_block_is_empty;
+      Alcotest.test_case "pseudo-element parent still flattens" `Quick
+        test_pseudo_element_parent_still_flattens;
       Alcotest.test_case "nested rule starting with an ident" `Quick
         test_nested_rule_starting_with_ident;
       Alcotest.test_case "bad declaration stays a declaration" `Quick

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -771,7 +771,13 @@ let pseudo_element_spellings =
 
 (* The [::] names above that cascade carries as a raw ident rather than a
    constructor of its own. Every other entry of [pseudo_element_spellings] names
-   a pseudo-element cascade models. *)
+   a pseudo-element cascade models.
+
+   Some of these are real pseudo-elements that engines do implement: bare
+   [::cue] and [::cue-region] reach cascade's reader only in their functional
+   form, and the scrollbar parts past [::-webkit-scrollbar] have no constructor
+   at all. Until each name is modelled, cascade cannot tell it from [::deep] and
+   so keeps the rule. Modelling the name is what moves it to the list above. *)
 let unmodelled_pseudo_element_spellings =
   [
     "::future-pseudo-element";
@@ -779,6 +785,8 @@ let unmodelled_pseudo_element_spellings =
     "::deep";
     "::v-deep";
     "::ng-deep";
+    "::cue";
+    "::cue-region";
     "::-webkit-scrollbar-thumb";
     "::-webkit-scrollbar-track";
     "::-webkit-scrollbar-track-piece";
@@ -920,6 +928,10 @@ let pseudo_element_combinator_guard () =
   (* The corpus case, spelled as test/interop/lightning carries it. *)
   parses ".foo ::deep .bar";
   parses ".foo ::unknown(.foo) .bar";
+  (* [::cue] and [::cue-region] are modelled in their functional form. *)
+  neg_cursor read ".a::cue(v) .b";
+  neg_cursor read ".a::cue-region(v) > .b";
+  parses ".a::cue(v)";
   (* A pseudo-class between the pseudo-element and the combinator does not
      reopen the compound: [::part()] takes [:focus] (CSS Pseudo-Elements 4 sec.
      5) and the combinator after it is still invalid. *)

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -769,6 +769,29 @@ let pseudo_element_spellings =
     "::-webkit-resizer";
   ]
 
+(* The [::] names above that cascade carries as a raw ident rather than a
+   constructor of its own. Every other entry of [pseudo_element_spellings] names
+   a pseudo-element cascade models. *)
+let unmodelled_pseudo_element_spellings =
+  [
+    "::future-pseudo-element";
+    "::foo(bar)";
+    "::deep";
+    "::v-deep";
+    "::ng-deep";
+    "::-webkit-scrollbar-thumb";
+    "::-webkit-scrollbar-track";
+    "::-webkit-scrollbar-track-piece";
+    "::-webkit-scrollbar-button";
+    "::-webkit-scrollbar-corner";
+    "::-webkit-resizer";
+  ]
+
+let modelled_pseudo_element_spellings =
+  List.filter
+    (fun pe -> Stdlib.not (List.mem pe unmodelled_pseudo_element_spellings))
+    pseudo_element_spellings
+
 (* Selectors 4 sec. 16: a complex selector unit is [<compound-selector>?
    <pseudo-compound-selector>*] and a pseudo-compound is
    [<pseudo-element-selector> <pseudo-class-selector>*], so a class, id or
@@ -833,6 +856,89 @@ let logical_combinator_pseudo_element () =
       check_minified_to ".a:not(:where())"
         (concat [ ".a:not(:where("; pe; "))" ]))
     pseudo_element_spellings
+
+(* CSS Selectors 4 (Editor's Draft, drafts.csswg.org/selectors-4/) sec. 3.6.5
+   "Internal Structure": "Some pseudo-elements are defined to have internal
+   structure. These pseudo-elements may be followed by child/descendant
+   combinators to express those relationships. Selectors containing combinators
+   after the pseudo-element are otherwise invalid", with "::first-letter + span
+   and ::first-letter em are invalid selectors" as the section's own examples.
+   Sec. 3.6.2 says the same thing from the other side: a pseudo-element follows
+   the compound selector matching its originating element, and what comes after
+   applies to the pseudo-element itself.
+
+   Nothing shipping claims that internal structure, so the exception stays
+   theoretical and every name cascade models takes the rule. Chrome 151 and
+   WebKit 26.5 both drop [::part(x) > .b], [::details-content > div],
+   [::file-selector-button > div] and [::view-transition-group(...) > div]
+   alongside the plain [.a::before .b], and the Servo selectors crate - the
+   parser Firefox's Stylo shares, reached here through Lightning CSS - rejects
+   the same shapes with UnexpectedSelectorAfterPseudoElement.
+
+   A [::] name cascade does not model is exempt, for the reason
+   [pseudo_element_allows] already exempts it from sec. 3.6.3: cascade preserves
+   such a name rather than judging it. test/interop/lightning carries seven of
+   these ([.foo ::deep .bar], [.foo ::unknown(.foo) .bar] and their kin) and all
+   six reference minifiers keep every one verbatim, while Lightning CSS rejects
+   the identical shape as soon as the name is one it knows ([::-moz-placeholder
+   .b]).
+
+   [>>>] and [/deep/] are outside all of this: they are Vue and Angular tooling
+   spellings, no engine parses them, and cascade passes them through under the
+   same bargain as an unmodelled [::] name. *)
+let pseudo_element_combinator_guard () =
+  let concat = String.concat "" in
+  let parses input =
+    match Cursor.option read (Cursor.of_string input) with
+    | Some _ -> ()
+    | None -> Alcotest.failf "selector should parse: %s" input
+  in
+  (* Selectors 4 sec. 15: every combinator the specification defines. *)
+  let combinators = [ " "; ">"; "+"; "~"; " || " ] in
+  (* Tooling spellings cascade passes through; sec. 3.6.5 never reaches them. *)
+  let passthrough_combinators = [ ">>>"; "/deep/" ] in
+  List.iter
+    (fun pe ->
+      (* The pseudo-compound itself, and a pseudo-element ending the selector,
+         are what sec. 3.6.5 leaves alone. *)
+      parses (concat [ ".a"; pe ]);
+      parses (concat [ ".z .a"; pe ]);
+      parses (concat [ ".z > .a"; pe ]);
+      List.iter
+        (fun c -> neg_cursor read (concat [ ".a"; pe; c; ".b" ]))
+        combinators;
+      List.iter
+        (fun c -> parses (concat [ ".a"; pe; c; ".b" ]))
+        passthrough_combinators)
+    modelled_pseudo_element_spellings;
+  List.iter
+    (fun pe ->
+      List.iter
+        (fun c -> parses (concat [ ".a"; pe; c; ".b" ]))
+        (combinators @ passthrough_combinators))
+    unmodelled_pseudo_element_spellings;
+  (* The corpus case, spelled as test/interop/lightning carries it. *)
+  parses ".foo ::deep .bar";
+  parses ".foo ::unknown(.foo) .bar";
+  (* A pseudo-class between the pseudo-element and the combinator does not
+     reopen the compound: [::part()] takes [:focus] (CSS Pseudo-Elements 4 sec.
+     5) and the combinator after it is still invalid. *)
+  neg_cursor read ".a::part(x):focus > .b";
+  parses ".a::part(x):focus";
+  (* Sec. 3.6.5 governs the top level of the selector. A combinator inside a
+     functional pseudo-class argument is a different question and stays
+     untouched. *)
+  parses ".a:is(.b > .c) .d";
+  parses ".a:has(.b > .c) .d";
+  parses ".a:not(.b > .c) .d";
+  parses ".a:has(> .b) .c";
+  (* Sec. 3.9 and sec. 16.1: [:is()] and [:where()] take a forgiving list, so
+     the refused argument goes and the selector stands; [:not()] does not, so
+     the whole selector goes. Chrome 151 agrees on both, reading the first back
+     as [.a:is(.d)] and dropping the rule for the third. *)
+  check_minified_to ".a:is(.d)" ".a:is(.b::before .c,.d)";
+  check_minified_to ".a:where(.d)" ".a:where(.b::before .c,.d)";
+  neg_cursor read ".a:not(.b::before .c)"
 
 (* CSS Selectors 4 sec. 9. Sec. 3.6.3 allows these after every pseudo-element;
    the engines are narrower, and disagree with the spec on the four Level 2
@@ -2265,6 +2371,8 @@ let suite =
         pseudo_element_compound_guard;
       test_case "logical combinator pseudo-element" `Quick
         logical_combinator_pseudo_element;
+      test_case "pseudo-element combinator guard" `Quick
+        pseudo_element_combinator_guard;
       test_case "pseudo-element pseudo-classes" `Quick
         pseudo_element_pseudo_classes;
       test_case "scrollbar state pseudo-classes" `Quick


### PR DESCRIPTION
`.a::before .b` used to be written back unchanged, though every engine drops the rule: Selectors 4 sec. 3.6.5 ends the selector at the pseudo-element unless that pseudo-element has internal structure, and none that ships has. A `::` name cascade does not model keeps its combinator, since cascade cannot tell `::deep` from a pseudo-element it has yet to learn, and the lightning interop corpus carries seven such rules that all six reference minifiers preserve.

Nesting still reaches the same invalid output through `.a::before{.b{color:red}}`, which is built after the reader has run; a test pins that so the gap stays visible.
