### PR TITLE
selector: allow the sub-pseudo-elements the spec defines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,13 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A rule whose selector chains one pseudo-element onto another, such as
+  `::before::marker`, `::part(label)::before` or `::slotted(a)::before`, is
+  read and written back instead of dropped. CSS Selectors 4 sec. 3.6.4
+  (Editor's Draft, drafts.csswg.org/selectors-4/) makes such a chain valid
+  where another specification defines the sub-pseudo-element, and CSS
+  Pseudo-Elements 4 sec. 4.2 and sec. 5 and CSS Shadow 1 sec. 3.2.4 (both
+  Editor's Drafts) do. `::before::before` stays invalid (#553)
 - A rule whose selector puts a combinator after a pseudo-element, such as
   `.a::before .b`, is reported and dropped instead of written back. CSS
   Selectors 4 sec. 3.6.5 (Editor's Draft, drafts.csswg.org/selectors-4/) makes

--- a/fuzz/fuzz_selector.ml
+++ b/fuzz/fuzz_selector.ml
@@ -231,7 +231,7 @@ let test_noisy_unforgiving buf =
         ".card:has(:has(img))";
         ".card:has(::before)";
         ".a::before.class";
-        ".a::before::marker";
+        ".a::before::before";
       ]
       buf 0
   in

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -1130,9 +1130,11 @@ let rec matches_nothing = function
   | List xs -> List.for_all matches_nothing xs
   | _ -> false
 
-(* CSS Selectors 4 sec. 3.6.3: a pseudo-element compound may only be followed by
-   pseudo-classes. Class/id/type/attribute selectors after the pseudo-element
-   still make the compound invalid. *)
+(* CSS Selectors 4 sec. 3.6.3: what may follow a pseudo-element in its compound
+   is a pseudo-class, and sec. 3.6.4 adds a sub-pseudo-element
+   ([pseudo_element_allows_sub]). A class, id, type or attribute selector after
+   the pseudo-element makes the compound invalid whatever the pseudo-element
+   is. *)
 let is_pe_action = function
   | Element _ | Class _ | Id _ | Universal _ | Attribute _ | Nesting -> false
   | sel -> not (is_pseudo_element sel)
@@ -1237,6 +1239,53 @@ and pseudo_element_allows_argument pe = function
       List.for_all (pseudo_element_allows_argument pe) components
   | Combined _ | Relative _ | List _ -> false
   | c -> is_pe_action c && pseudo_element_allows pe c
+
+(* CSS Pseudo-Elements 4 sec. 4 names the tree-abiding pseudo-elements, sec. 7.1
+   lists [::backdrop] and [::view-transition] among them, and sec. 5 adds that
+   "element-backed pseudo-elements are always tree-abiding". [::part()] is
+   element-backed and so belongs here on that reading, and is left out because
+   sec. 5 also says it never matches after a pseudo-element. *)
+let is_tree_abiding_pseudo_element = function
+  | Before _ | After _ | Marker | Placeholder | Backdrop | View_transition
+  | Details_content | File_selector_button ->
+      true
+  | _ -> false
+
+(* Which pseudo-elements each pseudo-element takes after it, in the same
+   compound. CSS Selectors 4 sec. 3.6.4 refuses the shape "unless the
+   corresponding sub-pseudo-element is explicitly defined to exist in another
+   specification", so the rows below are those definitions and nothing else:
+   [::before::before] goes, [::before::marker] stays.
+
+   CSS Pseudo-Elements 4 sec. 4.2 defines the [::marker] of a [::before] or
+   [::after] that is a list item, and rules [::marker::marker] out. Sec. 5 lets
+   an element-backed pseudo-element take every pseudo-element "just as if the
+   pseudo-element were a type selector", bar [::part()], which "never matches"
+   there; cascade turns that never-matching row into a refusal, as it does one
+   row up for [:has()] and the structural pseudo-classes. Sec. 5.1 files
+   [::file-selector-button] as element-backed, but Chrome 151, WebKit 27 and
+   Lightning CSS all drop [::file-selector-button::before], so the originating
+   row keeps the [::part()] / [::details-content] pair [pseudo_element_allows]
+   carries.
+
+   CSS Shadow 1 sec. 3.2.4 gives [::slotted()] a narrower row of its own: "the
+   ::slotted() pseudo-element can be followed by a tree-abiding pseudo-element".
+   The engines show the difference, dropping [::slotted(a)::first-line] while
+   keeping [::part(x)::first-line].
+
+   One adjacent pair at a time, so a longer chain is as valid as each of its
+   links: Chrome keeps [::part(x)::before::marker] and drops
+   [::part(x)::marker::before].
+
+   An unmodelled [::] name keeps the bargain [pseudo_element_allows] makes for
+   it: cascade preserves the name rather than judging what may follow it. *)
+let pseudo_element_allows_sub pe sub =
+  match pe with
+  | Unknown_pseudo_element _ | Unknown_pseudo_element_call _ -> true
+  | Part _ | Details_content -> ( match sub with Part _ -> false | _ -> true)
+  | Slotted _ -> is_tree_abiding_pseudo_element sub
+  | Before _ | After _ -> ( match sub with Marker -> true | _ -> false)
+  | _ -> false
 
 (* CSS Selectors 4 sec. 3.6.5: a pseudo-element defined to have internal
    structure may be followed by a child or descendant combinator, and a selector
@@ -1722,6 +1771,9 @@ and read_compound t =
        reader when a whole selector list is unknown. *)
     let s = read_simple ~allow_unknown_pseudo_class:true t in
     match List.find_opt is_pseudo_element acc with
+    | Some pe when is_pseudo_element s ->
+        if pseudo_element_allows_sub pe s then s :: acc
+        else Cursor.err t "pseudo-element not allowed after this pseudo-element"
     | Some _ when not (is_pe_action s) ->
         Cursor.err t "pseudo-element must be last in compound selector"
     | Some pe when not (pseudo_element_allows pe s) ->

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -952,6 +952,144 @@ let pseudo_element_combinator_guard () =
   check_minified_to ".a:where(.d)" ".a:where(.b::before .c,.d)";
   neg_cursor read ".a:not(.b::before .c)"
 
+(* CSS Selectors 4 (Editor's Draft, drafts.csswg.org/selectors-4/) sec. 3.6.4
+   "Sub-pseudo-elements": "Unless the corresponding sub-pseudo-element is
+   explicitly defined to exist in another specification, pseudo-element
+   selectors are not valid when compounded to another pseudo-element selector.
+   So, for example, ::before::before is an invalid selector, but
+   ::before::marker is valid". The rule is a pointer, so the question is which
+   other specification defines what, and the answer is three rows.
+
+   CSS Pseudo-Elements 4 (Editor's Draft, drafts.csswg.org/css-pseudo-4/) sec.
+   4.2: "The ::before::marker or ::after::marker selectors are valid [...]
+   However ::marker::marker is invalid". Chrome 151 keeps [::before::marker] and
+   its legacy [:before::marker] spelling, and drops [::marker::marker].
+
+   Same draft, sec. 5 "Element-backed Pseudo-Elements": "All pseudo-classes and
+   pseudo-elements are syntactically allowed after an element-backed
+   pseudo-element (such as x-button::part(label):hover or
+   x-button::part(label)::before), just as if the pseudo-element were a type
+   selector; but some are disallowed from matching: [...] ::part() never
+   matches". cascade turns the never-matching rows into a refusal, the way
+   [pseudo_element_allows] already turns sec. 5's [:has()] and structural rows
+   into one, so [::part()] and [::slotted()] never follow another
+   pseudo-element: Chrome 151 and Lightning CSS both drop [::part(x)::part(y)],
+   [::details-content::part(y)], [::part(x)::slotted(b)] and
+   [::slotted(a)::slotted(b)]. The element-backed row is [::part()] and
+   [::details-content], the pair [pseudo_element_allows] already carries. Sec.
+   5.1 puts [::file-selector-button] in the same section, but Chrome 151 and
+   Lightning CSS both drop [::file-selector-button::before], so it stays out on
+   the same engines-over-spec-text bargain the sec. 3.6.3 rows take.
+
+   CSS Shadow 1 (Editor's Draft, drafts.csswg.org/css-shadow-1/, the document
+   css-scoping-1 now redirects to) sec. 3.2.4: "The ::slotted() pseudo-element
+   can be followed by a tree-abiding pseudo-element, like ::slotted()::before".
+   Tree-abiding is narrower than element-backed and the engines show the gap:
+   both keep [::slotted(a)::before] and [::slotted(a)::marker] and drop
+   [::slotted(a)::first-line], while both keep [::part(x)::first-line]. The
+   tree-abiding names are css-pseudo-4 sec. 4 ([::before], [::after],
+   [::marker], [::placeholder]), the [::backdrop] and [::view-transition] of its
+   sec. 7.1 list, and the element-backed ones its sec. 5 calls "always
+   tree-abiding".
+
+   The rule reads one adjacent pair at a time, so a chain longer than two is
+   exactly as valid as each of its links: Chrome 151 keeps
+   [::part(x)::before::marker] and [::slotted(a)::before::marker] and drops
+   [::part(x)::marker::before] and [::before::marker::before].
+
+   A [::] name cascade does not model keeps its exemption in this position too,
+   for the reason [pseudo_element_allows] exempts it from sec. 3.6.3: cascade
+   preserves such a name rather than judging it, and Lightning CSS reads
+   [::foo::bar] and [::foo::before] back unchanged. A name cascade does model is
+   judged, so [::before::foo] goes. *)
+let sub_pseudo_element_guard () =
+  let concat = String.concat "" in
+  let parses input =
+    let c = Cursor.of_string input in
+    match read c with
+    | exception Error.Parse_error _ ->
+        Alcotest.failf "selector should parse: %s" input
+    | _ ->
+        if Stdlib.not (Cursor.is_done c) then
+          Alcotest.failf "selector only partly read: %s" input
+  in
+  let mem s = List.exists (String.equal s) in
+  let element_backed = [ "::part(tab)"; "::details-content" ] in
+  let tree_abiding =
+    [
+      ":before";
+      "::before";
+      ":after";
+      "::after";
+      "::marker";
+      "::placeholder";
+      "::backdrop";
+      "::view-transition";
+      "::details-content";
+      "::file-selector-button";
+    ]
+  in
+  let never_a_sub = [ "::part(tab)"; "::slotted(p)" ] in
+  let generated_content = [ ":before"; "::before"; ":after"; "::after" ] in
+  let allowed origin sub =
+    if mem sub never_a_sub then false
+    else if mem origin element_backed then true
+    else if String.equal origin "::slotted(p)" then mem sub tree_abiding
+    else if mem origin generated_content then String.equal sub "::marker"
+    else false
+  in
+  List.iter
+    (fun origin ->
+      List.iter
+        (fun sub ->
+          let s = concat [ ".a"; origin; sub ] in
+          if allowed origin sub then parses s else neg_cursor read s)
+        modelled_pseudo_element_spellings;
+      List.iter
+        (fun sub ->
+          let s = concat [ ".a"; origin; sub ] in
+          if mem origin element_backed then parses s else neg_cursor read s)
+        unmodelled_pseudo_element_spellings)
+    modelled_pseudo_element_spellings;
+  List.iter
+    (fun origin ->
+      List.iter
+        (fun sub -> parses (concat [ ".a"; origin; sub ]))
+        pseudo_element_spellings)
+    unmodelled_pseudo_element_spellings;
+  (* The three shapes the guard used to delete, read back after a print. *)
+  check_minified_to ".a:before::marker" ".a::before::marker";
+  check_minified_to "x-b::part(label):before" "x-b::part(label)::before";
+  check_minified_to "::slotted(a):before" "::slotted(a)::before";
+  check_minified_to ".a:after::marker" ".a::after::marker";
+  check_minified_to ".a:before::marker" ".a:before::marker";
+  check_minified_to "::part(label):first-line" "::part(label)::first-line";
+  check_minified_to "::slotted(a)::marker" "::slotted(a)::marker";
+  check_minified_to "::details-content:before" "::details-content::before";
+  check_minified_to "::part(label):before::marker"
+    "::part(label)::before::marker";
+  check_minified_to "::slotted(a):before::marker" "::slotted(a)::before::marker";
+  neg_cursor read ".a::before::marker::before";
+  neg_cursor read ".a::part(label)::marker::before";
+  (* A pseudo-class between the two belongs to the pseudo-element on its left,
+     and the one after it to the pseudo-element on its own left. *)
+  check_minified_to "::part(label):hover:before" "::part(label):hover::before";
+  (* Sec. 3.6.5 is the other question and answers it as before: a combinator
+     after the chain is invalid whatever the chain is, and an unmodelled name
+     stays exempt. *)
+  neg_cursor read ".a::before::marker > .b";
+  neg_cursor read ".a::part(label)::before .b";
+  parses ".foo ::deep .bar";
+  (* Sec. 3.6.3 is untouched: [::before] still takes no [:hover], [::part()]
+     still does, and what may never follow a pseudo-element still may not. *)
+  neg_cursor read ".a::before:hover";
+  neg_cursor read ".a::before::marker:hover";
+  neg_cursor read ".a::part(label)::before:hover";
+  check_minified_to ".a::part(label):hover" ".a::part(label):hover";
+  neg_cursor read ".a::before::marker.class";
+  neg_cursor read ".a::before::marker#id";
+  neg_cursor read ".a::before::marker[x]"
+
 (* CSS Selectors 4 sec. 9. Sec. 3.6.3 allows these after every pseudo-element;
    the engines are narrower, and disagree with the spec on the four Level 2
    pseudo-elements ([::first-line:hover] is the spec's own example and both
@@ -2385,6 +2523,7 @@ let suite =
         logical_combinator_pseudo_element;
       test_case "pseudo-element combinator guard" `Quick
         pseudo_element_combinator_guard;
+      test_case "sub-pseudo-element guard" `Quick sub_pseudo_element_guard;
       test_case "pseudo-element pseudo-classes" `Quick
         pseudo_element_pseudo_classes;
       test_case "scrollbar state pseudo-classes" `Quick

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -973,20 +973,21 @@ let pseudo_element_combinator_guard () =
    matches". cascade turns the never-matching rows into a refusal, the way
    [pseudo_element_allows] already turns sec. 5's [:has()] and structural rows
    into one, so [::part()] and [::slotted()] never follow another
-   pseudo-element: Chrome 151 and Lightning CSS both drop [::part(x)::part(y)],
-   [::details-content::part(y)], [::part(x)::slotted(b)] and
-   [::slotted(a)::slotted(b)]. The element-backed row is [::part()] and
-   [::details-content], the pair [pseudo_element_allows] already carries. Sec.
-   5.1 puts [::file-selector-button] in the same section, but Chrome 151 and
-   Lightning CSS both drop [::file-selector-button::before], so it stays out on
-   the same engines-over-spec-text bargain the sec. 3.6.3 rows take.
+   pseudo-element: Chrome 151, WebKit 27 and Lightning CSS all drop
+   [::part(x)::part(y)] and [::slotted(a)::part(y)]. [::slotted()] is in no such
+   row, so it stays allowed there and WebKit 27 keeps [::part(x)::slotted(b)].
+   The element-backed row is [::part()] and [::details-content], the pair
+   [pseudo_element_allows] already carries. Sec. 5.1 puts
+   [::file-selector-button] in the same section, but all three drop
+   [::file-selector-button::before], so it stays out on the same
+   engines-over-spec-text bargain the sec. 3.6.3 rows take.
 
    CSS Shadow 1 (Editor's Draft, drafts.csswg.org/css-shadow-1/, the document
    css-scoping-1 now redirects to) sec. 3.2.4: "The ::slotted() pseudo-element
    can be followed by a tree-abiding pseudo-element, like ::slotted()::before".
    Tree-abiding is narrower than element-backed and the engines show the gap:
-   both keep [::slotted(a)::before] and [::slotted(a)::marker] and drop
-   [::slotted(a)::first-line], while both keep [::part(x)::first-line]. The
+   all three keep [::slotted(a)::before] and [::slotted(a)::marker] and drop
+   [::slotted(a)::first-line], while all three keep [::part(x)::first-line]. The
    tree-abiding names are css-pseudo-4 sec. 4 ([::before], [::after],
    [::marker], [::placeholder]), the [::backdrop] and [::view-transition] of its
    sec. 7.1 list, and the element-backed ones its sec. 5 calls "always
@@ -1029,7 +1030,7 @@ let sub_pseudo_element_guard () =
       "::file-selector-button";
     ]
   in
-  let never_a_sub = [ "::part(tab)"; "::slotted(p)" ] in
+  let never_a_sub = [ "::part(tab)" ] in
   let generated_content = [ ":before"; "::before"; ":after"; "::after" ] in
   let allowed origin sub =
     if mem sub never_a_sub then false
@@ -1066,6 +1067,10 @@ let sub_pseudo_element_guard () =
   check_minified_to "::part(label):first-line" "::part(label)::first-line";
   check_minified_to "::slotted(a)::marker" "::slotted(a)::marker";
   check_minified_to "::details-content:before" "::details-content::before";
+  check_minified_to "::part(label)::slotted(a)" "::part(label)::slotted(a)";
+  neg_cursor read "::slotted(a)::slotted(b)";
+  neg_cursor read "::part(label)::part(x)";
+  neg_cursor read "::details-content::part(x)";
   check_minified_to "::part(label):before::marker"
     "::part(label)::before::marker";
   check_minified_to "::slotted(a):before::marker" "::slotted(a)::before::marker";
@@ -2040,7 +2045,7 @@ let spec_minifier_semantics () =
   neg_cursor read ".card:has(:has(img))";
   neg_cursor read ".card:has(::before)";
   neg_cursor read ".a::before.class";
-  neg_cursor read ".a::before::marker"
+  neg_cursor read ".a::before::before"
 
 (* ignore-test *)
 let test_spec_forgiving_selector_lists () =
@@ -2145,7 +2150,7 @@ let spec_selector_scope_pseudo_edges () =
   neg_cursor read "+ .item";
   neg_cursor read "~ .item";
   neg_cursor read ".a::before.class";
-  neg_cursor read ".a::before::marker";
+  neg_cursor read ".a::before::before";
   neg_cursor read ".a:has(:has(img))";
   neg_cursor read ".a:has(::before)";
   neg_cursor read "div#";


### PR DESCRIPTION
Selectors 4 sec. 3.6.4 makes a pseudo-element compounded onto another valid wherever some other specification defines that sub-pseudo-element, and three do: css-pseudo-4 sec. 4.2 for the marker of a generated-content box, its sec. 5 for the element-backed pseudo-elements, and css-shadow-1 sec. 3.2.4 for `::slotted()`. cascade refused all of them, so rules Chrome and WebKit honour were deleted on the way through.
