### PR TITLE
inline: resolve @page descriptors through one path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -576,6 +576,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Custom properties
 
+- `Css.inline_vars` resolves every `@page` descriptor under one unit policy.
+  `margin-top` alone kept the authored unit, so one `@page` block answered
+  `1cm` for it and `37.79527559px` for the `margin-left` beside it (#555)
 - A cascade layer and caller metadata on a custom property survive
   `Css.inline_vars`. Both belong to the declaration rather than to its value,
   and the two rewrites that read a custom value back - canonicalising a value

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -592,26 +592,6 @@ let simplify_font_face_descriptor visible descriptor =
   | Some resolved -> resolved
   | Option.None -> descriptor
 
-let eval_page_declaration visible ctx decl =
-  let resolve_length_var (var : Values.length Values.var) =
-    match lookup_visible_custom visible var.Values.name Values.read_length with
-    | Some value -> value
-    | None -> (
-        match var.Values.fallback with
-        | Values.Fallback value -> value
-        | _ -> Values.Var var)
-  in
-  match decl with
-  | Declaration.Declaration
-      {
-        property = Properties.Margin_top as property;
-        value = (Values.Var var : Values.length);
-        important;
-        _;
-      } ->
-      Declaration.v ~important property (resolve_length_var var)
-  | _ -> Context.eval ctx decl
-
 let map_keyframe_decls f frames =
   List.map
     (fun frame -> { frame with declarations = List.map f frame.declarations })
@@ -645,7 +625,7 @@ let substitute_font_face ~scopes ~at_path descriptors =
 
 let substitute_page_with_margins ~scopes ~at_path sel descriptors margins =
   let visible = universal_visible_customs ~scopes ~at_path in
-  let eval_page = eval_page_declaration visible (context_for visible) in
+  let eval_page = Context.eval (context_for visible) in
   let update_margin (m : page_margin_rule) =
     { m with descriptors = List.map eval_page m.descriptors }
   in
@@ -681,7 +661,7 @@ and substitute_stmt ~kept ~scopes ~parents ~at_path stmt =
       | Page (sel, decls) ->
           let visible = universal_visible_customs ~scopes ~at_path in
           let ctx = context_for visible in
-          Page (sel, List.map (eval_page_declaration visible ctx) decls)
+          Page (sel, List.map (Context.eval ctx) decls)
       | Position_try (n, decls) ->
           Position_try (n, eval_universal_decls ~scopes ~at_path decls)
       | Keyframes (n, frames) ->

--- a/test/cli/inline_vars_at_rules.t
+++ b/test/cli/inline_vars_at_rules.t
@@ -22,14 +22,15 @@ A variable used in an @font-face descriptor inlines.
   $ cascade --minify --inline-vars font-face.css
   @font-face{font-family:Brand;src:url(font.woff2);unicode-range:U+25-FF}
 
-A variable used in an @page margin descriptor inlines.
+A variable used in an @page margin descriptor follows the same canonical unit
+policy for a longhand or shorthand.
 
-  $ cat > page.css <<EOF
-  > :root { --margin-top: 1cm }
-  > @page { margin-top: var(--margin-top) }
-  > EOF
+  $ printf '%s\n' ':root { --page-margin: 1cm }' \
+  >   '@page:first { margin-top: var(--page-margin) }' \
+  >   '@page:left { margin-left: var(--page-margin) }' \
+  >   '@page:right { margin: var(--page-margin) }' > page.css
   $ cascade --minify --inline-vars page.css
-  @page{margin-top:1cm}
+  @page:first{margin-top:37.79527559px}@page:left{margin-left:37.79527559px}@page:right{margin:37.79527559px}
 
 A registered custom property declared via @property with an
 [initial-value] provides the inlining source when no explicit


### PR DESCRIPTION
A `var()` in an `@page` margin resolved through a path of its own when the property was `margin-top`, so a single block answered `1cm` for it and `37.79527559px` for the `margin-left` beside it. Both now go through `Context.eval`, like every other declaration.
