### PR TITLE
selector: model the pseudo-elements read as raw idents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- Bare `::cue`, `::cue-region` and the scrollbar parts past
+  `::-webkit-scrollbar` are read as the pseudo-elements they are, so
+  `::cue::before` and `.a::-webkit-scrollbar-thumb .b` are dropped the way
+  Chrome, WebKit and Lightning CSS drop them (#556)
 - A rule whose selector chains one pseudo-element onto another, such as
   `::before::marker`, `::part(label)::before` or `::slotted(a)::before`, is
   read and written back instead of dropped. CSS Selectors 4 sec. 3.6.4

--- a/lib/merge.ml
+++ b/lib/merge.ml
@@ -1,6 +1,6 @@
 let rec vendor : Selector.t -> bool = function
   | File_selector_button -> true
-  | Webkit_scrollbar | Webkit_search_cancel_button | Webkit_search_decoration
+  | Webkit_scrollbar _ | Webkit_search_cancel_button | Webkit_search_decoration
   | Webkit_datetime_edit_fields_wrapper | Webkit_date_and_time_value
   | Webkit_datetime_edit | Webkit_datetime_edit_year_field
   | Webkit_datetime_edit_month_field | Webkit_datetime_edit_day_field

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -975,6 +975,15 @@ let scrollbar_state_ident = function
   | Corner_present -> "corner-present"
   | Window_inactive -> "window-inactive"
 
+let scrollbar_part_ident = function
+  | Scrollbar -> "-webkit-scrollbar"
+  | Button -> "-webkit-scrollbar-button"
+  | Track -> "-webkit-scrollbar-track"
+  | Track_piece -> "-webkit-scrollbar-track-piece"
+  | Thumb -> "-webkit-scrollbar-thumb"
+  | Corner -> "-webkit-scrollbar-corner"
+  | Resizer -> "-webkit-resizer"
+
 (* WebKit, "Styling Scrollbars". Both engines read these on any element, so they
    are ordinary pseudo-classes here; which pseudo-elements take them is
    [pseudo_element_allows]'s business. *)
@@ -1031,7 +1040,7 @@ let pseudo_vendor_idents =
     ("-ms-input-placeholder", Ms_input_placeholder);
     ("-moz-ui-invalid", Moz_ui_invalid);
     ("-moz-ui-valid", Moz_ui_valid);
-    ("-webkit-scrollbar", Webkit_scrollbar);
+    ("-webkit-scrollbar", Webkit_scrollbar Scrollbar);
     ("-webkit-search-cancel-button", Webkit_search_cancel_button);
     ("-webkit-search-decoration", Webkit_search_decoration);
     (* Webkit datetime pseudo-elements *)
@@ -1054,6 +1063,24 @@ let pseudo_vendor_idents =
     ("details-content", Details_content);
   ]
 
+(* Names the [::] reader takes and the [:] reader does not. Chrome 151 and
+   WebKit 26.5 drop [:cue] and [:-webkit-scrollbar-thumb] while keeping the [::]
+   spelling of both, so these stay out of [pseudo_class_all_idents];
+   [::-webkit-scrollbar] itself keeps the single-colon spelling cascade has
+   always read for it and stays in [pseudo_vendor_idents].
+
+   WebVTT 1 sec. 8.2 requires "the ::cue, ::cue(selector), ::cue-region and
+   ::cue-region(selector) pseudo-elements", and sec. 8.2.1 and sec. 8.2.3 define
+   the argument-less pair the [calls] table above cannot reach. Chrome, WebKit
+   and Lightning CSS all take [::cue]; only Lightning CSS takes [::cue-region],
+   the other two implement neither of its forms. *)
+let pseudo_element_double_colon_idents =
+  ("cue", Cue None)
+  :: ("cue-region", Cue_region None)
+  :: List.map
+       (fun part -> (scrollbar_part_ident part, Webkit_scrollbar part))
+       [ Button; Track; Track_piece; Thumb; Corner; Resizer ]
+
 (* Every [::] form, and only those: a pseudo-element names a box other than the
    originating element, where an element-tied pseudo-class ([:hover], [:focus])
    only narrows which elements match. An unrecognised [::foo] belongs here too.
@@ -1067,7 +1094,7 @@ let is_pseudo_element = function
   | Before _ | After _ | First_letter _ | First_line _ | Backdrop | Marker
   | Placeholder | Selection | Target_text | Spelling_error | Grammar_error
   | File_selector_button | Moz_placeholder | Webkit_input_placeholder
-  | Ms_input_placeholder | Webkit_scrollbar | Webkit_search_cancel_button
+  | Ms_input_placeholder | Webkit_scrollbar _ | Webkit_search_cancel_button
   | Webkit_search_decoration | Webkit_datetime_edit_fields_wrapper
   | Webkit_date_and_time_value | Webkit_datetime_edit
   | Webkit_datetime_edit_year_field | Webkit_datetime_edit_month_field
@@ -1095,8 +1122,6 @@ let rec any p = function
     | Moz_any_call xs
     | Webkit_any_call xs
     | Slotted xs
-    | Cue xs
-    | Cue_region xs
     | Current_of xs ) as sel ->
       List.exists (any p) xs || p sel
   | ( Nth_child (_, Some xs)
@@ -1104,6 +1129,8 @@ let rec any p = function
     | Nth_of_type (_, Some xs)
     | Nth_last_of_type (_, Some xs)
     | Host (Some xs)
+    | Cue (Some xs)
+    | Cue_region (Some xs)
     | Host_context xs ) as sel ->
       List.exists (any p) xs || p sel
   | Part _ as sel -> p sel
@@ -1163,9 +1190,11 @@ let rec pseudo_element_allows pe pc =
   match pe with
   (* A name no engine recognises: cascade keeps it so a pseudo-element newer
      than this list survives a format pass, and knows nothing about its rules,
-     so it keeps taking any pseudo-class after it. *)
+     so it keeps taking any pseudo-class after it. [::cue-region()] keeps the
+     same bargain: Chrome 151 and WebKit 26.5 implement neither of its forms. *)
   | Unknown_pseudo_element _ | Unknown_pseudo_element_call _ | Moz_placeholder
-  | Ms_input_placeholder | Cue_region _ ->
+  | Ms_input_placeholder
+  | Cue_region (Some _) ->
       true
   | pe -> (
       match pc with
@@ -1189,7 +1218,7 @@ let rec pseudo_element_allows pe pc =
          stops where they agree. *)
       | Scrollbar_state state -> (
           match (pe, state) with
-          | Webkit_scrollbar, _ -> true
+          | Webkit_scrollbar _, _ -> true
           | (Selection | Part _), Window_inactive -> true
           | _ -> false)
       (* Same forward-compatibility bargain as an unknown pseudo-element. *)
@@ -1203,9 +1232,9 @@ let rec pseudo_element_allows pe pc =
               match pc with
               | Has _ -> false
               | pc -> not (is_structural_pseudo_class pc))
-          (* A scrollbar takes no focus, and reports which part of which
+          (* A scrollbar part takes no focus, and reports which part of which
              scrollbar it is through the state pseudo-classes below. *)
-          | Webkit_scrollbar -> (
+          | Webkit_scrollbar _ -> (
               match pc with
               | Hover | Active | Enabled | Disabled -> true
               | _ -> false)
@@ -1214,8 +1243,12 @@ let rec pseudo_element_allows pe pc =
           | View_transition_group _ | View_transition_image_pair _
           | View_transition_old _ | View_transition_new _ -> (
               match pc with Only_child -> true | _ -> false)
-          (* The UA widgets that stand in for a real control. [::cue(...)]
-             selects inside the cue and takes none of them. *)
+          (* The UA widgets that stand in for a real control, and the cue and
+             region boxes WebVTT 1 sec. 8.2.1 and sec. 8.2.3 define: all three
+             engines keep [::cue:focus-within] and drop [::cue:enabled].
+             [::cue(...)] selects inside the cue and takes none of them. *)
+          | Cue None
+          | Cue_region None
           | Placeholder | File_selector_button | Webkit_input_placeholder
           | Webkit_search_cancel_button | Webkit_search_decoration
           | Webkit_datetime_edit_fields_wrapper | Webkit_date_and_time_value
@@ -1328,6 +1361,7 @@ let pseudo_class_all_idents () = Lazy.force pseudo_class_all_idents_lazy
 let pseudo_element_unknown_idents =
   lazy
     (pseudo_element_modern_idents @ pseudo_vendor_idents
+   @ pseudo_element_double_colon_idents
     @ pseudo_element_legacy_idents Double)
 
 let read_unknown_pseudo_class_call ~all_idents t =
@@ -1620,11 +1654,11 @@ and read_slotted_content t =
 
 and read_cue_content t =
   let sels = read_complex_list t in
-  Cue sels
+  Cue (Some sels)
 
 and read_cue_region_content t =
   let sels = read_complex_list t in
-  Cue_region sels
+  Cue_region (Some sels)
 
 and read_slotted t = Cursor.call "slotted" t read_slotted_content
 and read_cue t = Cursor.call "cue" t read_cue_content
@@ -2372,7 +2406,7 @@ and pp : t Pp.t =
   | Moz_placeholder -> vendor_elem ctx "moz-placeholder"
   | Webkit_input_placeholder -> vendor_elem ctx "webkit-input-placeholder"
   | Ms_input_placeholder -> vendor_elem ctx "ms-input-placeholder"
-  | Webkit_scrollbar -> vendor_elem ctx "webkit-scrollbar"
+  | Webkit_scrollbar part -> elem ctx (scrollbar_part_ident part)
   | Webkit_search_cancel_button -> vendor_elem ctx "webkit-search-cancel-button"
   | Webkit_search_decoration -> vendor_elem ctx "webkit-search-decoration"
   (* Webkit datetime pseudo-elements *)
@@ -2405,8 +2439,10 @@ and pp : t Pp.t =
   (* Functional pseudo-elements *)
   | Part idents -> elem_func ctx "part" (Pp.list ~sep:Pp.space Pp.string) idents
   | Slotted selectors -> elem_func ctx "slotted" sels selectors
-  | Cue selectors -> elem_func ctx "cue" sels selectors
-  | Cue_region selectors -> elem_func ctx "cue-region" sels selectors
+  | Cue None -> elem ctx "cue"
+  | Cue (Some selectors) -> elem_func ctx "cue" sels selectors
+  | Cue_region None -> elem ctx "cue-region"
+  | Cue_region (Some selectors) -> elem_func ctx "cue-region" sels selectors
   (* Functional pseudo-classes *)
   | Is selectors
     when Pp.minified ctx && List.sort compare selectors = [ Link; Visited ] ->
@@ -2537,8 +2573,8 @@ let rec map f node =
     | Current_of xs -> lst (fun xs -> Current_of xs) xs
     | Host_context xs -> lst (fun xs -> Host_context xs) xs
     | Slotted xs -> lst (fun xs -> Slotted xs) xs
-    | Cue xs -> lst (fun xs -> Cue xs) xs
-    | Cue_region xs -> lst (fun xs -> Cue_region xs) xs
+    | Cue (Some xs) -> lst (fun xs -> Cue (Some xs)) xs
+    | Cue_region (Some xs) -> lst (fun xs -> Cue_region (Some xs)) xs
     | other -> other
   in
   f node'
@@ -2695,7 +2731,8 @@ let rec specificity = function
   | Current | Popover_open | Open | Moz_focusring | Webkit_any | Webkit_autofill
   | Unknown_pseudo_class _ | Unknown_pseudo_class_call _ | Moz_placeholder
   | Webkit_input_placeholder | Ms_input_placeholder | Moz_ui_invalid
-  | Moz_ui_valid | Scrollbar_state _ | Webkit_scrollbar
+  | Moz_ui_valid | Scrollbar_state _
+  | Webkit_scrollbar Scrollbar
   | Webkit_search_cancel_button | Webkit_search_decoration
   | Webkit_datetime_edit_fields_wrapper | Webkit_date_and_time_value
   | Webkit_datetime_edit | Webkit_datetime_edit_year_field
@@ -2714,7 +2751,13 @@ let rec specificity = function
   | Placeholder | Selection | Target_text | Spelling_error | Grammar_error
   | File_selector_button | Part _ | View_transition | View_transition_group _
   | View_transition_image_pair _ | View_transition_old _ | View_transition_new _
-  | Unknown_pseudo_element _ | Unknown_pseudo_element_call _ ->
+  | Unknown_pseudo_element _ | Unknown_pseudo_element_call _
+  (* Sec. 17 counts a pseudo-element in C. [::-webkit-scrollbar] is read with
+     one colon too and weighs a class above, as every [pseudo_vendor_idents]
+     name does; the parts are [::]-only. *)
+  | Webkit_scrollbar (Button | Track | Track_piece | Thumb | Corner | Resizer)
+  | Cue None
+  | Cue_region None ->
       { ids = 0; classes = 0; elements = 1 }
   | Where _ -> zero_specificity
   | Is xs
@@ -2738,7 +2781,7 @@ let rec specificity = function
       add_specificity
         { ids = 0; classes = 1; elements = 0 }
         (xs |> List.map specificity |> max_specificity)
-  | Slotted xs | Cue xs | Cue_region xs ->
+  | Slotted xs | Cue (Some xs) | Cue_region (Some xs) ->
       add_specificity
         { ids = 0; classes = 0; elements = 1 }
         (xs |> List.map specificity |> max_specificity)
@@ -2811,10 +2854,9 @@ let rec first_class = function
   | Moz_any_call xs
   | Webkit_any_call xs
   | Slotted xs
-  | Cue xs
-  | Cue_region xs
   | Current_of xs -> (
       match xs with [] -> None | h :: _ -> first_class h)
+  | Cue (Some (h :: _)) | Cue_region (Some (h :: _)) -> first_class h
   | Part _ -> None
   | _ -> None
 
@@ -2841,16 +2883,15 @@ let rec has_group_marker = function
   | Combined (a, _, b) -> has_group_marker a || has_group_marker b
   | Relative (_, b) -> has_group_marker b
   | List xs -> List.exists has_group_marker xs
+  | Cue (Some xs) | Cue_region (Some xs) -> List.exists has_group_marker xs
   | Is xs
   | Not xs
   | Has xs
   | Moz_any_call xs
   | Webkit_any_call xs
   | Slotted xs
-  | Cue xs
-  | Cue_region xs ->
+  | Current_of xs ->
       List.exists has_group_marker xs
-  | Current_of xs -> List.exists has_group_marker xs
   | _ -> false
 
 (** Check if selector contains :where(.peer) - used for peer-* modifiers *)
@@ -2870,16 +2911,15 @@ let rec has_peer_marker = function
   | Combined (a, _, b) -> has_peer_marker a || has_peer_marker b
   | Relative (_, b) -> has_peer_marker b
   | List xs -> List.exists has_peer_marker xs
+  | Cue (Some xs) | Cue_region (Some xs) -> List.exists has_peer_marker xs
   | Is xs
   | Not xs
   | Has xs
   | Moz_any_call xs
   | Webkit_any_call xs
   | Slotted xs
-  | Cue xs
-  | Cue_region xs ->
+  | Current_of xs ->
       List.exists has_peer_marker xs
-  | Current_of xs -> List.exists has_peer_marker xs
   | _ -> false
 
 (** Check if selector uses the :is(:where(...)) pattern used by group-* and

--- a/lib/selector_intf.ml
+++ b/lib/selector_intf.ml
@@ -56,6 +56,19 @@ type scrollbar_state =
   | Corner_present
   | Window_inactive
 
+(** Which part of a scrollbar a [::-webkit-] pseudo-element names. No
+    specification defines any of them: WebKit's "Styling Scrollbars" introduces
+    the seven together and is the only description there is. Chrome, WebKit and
+    Lightning CSS take all seven, and give all seven the same rules. *)
+type scrollbar_part =
+  | Scrollbar  (** [::-webkit-scrollbar] *)
+  | Button  (** [::-webkit-scrollbar-button] *)
+  | Track  (** [::-webkit-scrollbar-track] *)
+  | Track_piece  (** [::-webkit-scrollbar-track-piece] *)
+  | Thumb  (** [::-webkit-scrollbar-thumb] *)
+  | Corner  (** [::-webkit-scrollbar-corner] *)
+  | Resizer  (** [::-webkit-resizer] *)
+
 type aria_attr = Aria.t
 (** ARIA attribute names for type-safe handling *)
 
@@ -185,7 +198,7 @@ type t =
   | Moz_ui_invalid
   | Moz_ui_valid
   | Scrollbar_state of scrollbar_state
-  | Webkit_scrollbar
+  | Webkit_scrollbar of scrollbar_part
   | Webkit_search_cancel_button
   | Webkit_search_decoration
   (* Webkit datetime pseudo-elements *)
@@ -229,8 +242,12 @@ type t =
   (* Pseudo-elements *)
   | Part of string list (* ::part(...) - takes list of part names *)
   | Slotted of t list (* ::slotted(...) - takes selectors *)
-  | Cue of t list (* ::cue(...) - takes selectors *)
-  | Cue_region of t list (* ::cue-region(...) - takes selectors *)
+  | Cue of t list option
+      (** WebVTT 1 sec. 8.2.1 [::cue] ([None]) and [::cue(<selector>)] ([Some]).
+      *)
+  | Cue_region of t list option
+      (** WebVTT 1 sec. 8.2.3 [::cue-region] ([None]) and
+          [::cue-region(<selector>)] ([Some]). *)
   | Highlight of
       string list (* ::highlight(...) - takes custom highlight names *)
   | View_transition (* ::view-transition (CSS View Transitions 1 sec. 3.2) *)

--- a/scripts/check_api_consistency.ml
+++ b/scripts/check_api_consistency.ml
@@ -34,6 +34,7 @@ let ignored_types =
     "stop";
     "point";
     "scrollbar_state";
+    "scrollbar_part";
     (* Helper fragments parsed only inside their owning structured values. *)
     "colon_form";
     "vt_class_selector";

--- a/test/render/dom_of_css.ml
+++ b/test/render/dom_of_css.ml
@@ -81,7 +81,7 @@ let is_pseudo_element = function
   | Selector.View_transition_old _ | Selector.View_transition_new _
   | Selector.Unknown_pseudo_element _ | Selector.Unknown_pseudo_element_call _
   | Selector.Moz_placeholder | Selector.Webkit_input_placeholder
-  | Selector.Ms_input_placeholder | Selector.Webkit_scrollbar
+  | Selector.Ms_input_placeholder | Selector.Webkit_scrollbar _
   | Selector.Webkit_search_cancel_button | Selector.Webkit_search_decoration
   | Selector.Webkit_details_marker | Selector.Details_content
   | Selector.Webkit_datetime_edit_fields_wrapper
@@ -350,7 +350,7 @@ let rec add sp part =
   | Selector.View_transition_old _ | Selector.View_transition_new _
   | Selector.Unknown_pseudo_element _ | Selector.Unknown_pseudo_element_call _
   | Selector.Moz_placeholder | Selector.Webkit_input_placeholder
-  | Selector.Ms_input_placeholder | Selector.Webkit_scrollbar
+  | Selector.Ms_input_placeholder | Selector.Webkit_scrollbar _
   | Selector.Webkit_search_cancel_button | Selector.Webkit_search_decoration
   | Selector.Webkit_details_marker | Selector.Details_content
   | Selector.Webkit_datetime_edit_fields_wrapper

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -773,27 +773,14 @@ let pseudo_element_spellings =
    constructor of its own. Every other entry of [pseudo_element_spellings] names
    a pseudo-element cascade models.
 
-   Some of these are real pseudo-elements that engines do implement: bare
-   [::cue] and [::cue-region] reach cascade's reader only in their functional
-   form, and the scrollbar parts past [::-webkit-scrollbar] have no constructor
-   at all. Until each name is modelled, cascade cannot tell it from [::deep] and
-   so keeps the rule. Modelling the name is what moves it to the list above. *)
+   No engine implements any of these, so cascade has nothing to judge them
+   against and keeps the rule: the name may be one a browser ships next.
+   [::deep], [::v-deep] and [::ng-deep] are Vue and Angular tooling spellings
+   that no engine has ever parsed. Chrome 151 and WebKit 26.5 drop every one,
+   and Lightning CSS reads every one back verbatim, which is what
+   test/interop/lightning records. *)
 let unmodelled_pseudo_element_spellings =
-  [
-    "::future-pseudo-element";
-    "::foo(bar)";
-    "::deep";
-    "::v-deep";
-    "::ng-deep";
-    "::cue";
-    "::cue-region";
-    "::-webkit-scrollbar-thumb";
-    "::-webkit-scrollbar-track";
-    "::-webkit-scrollbar-track-piece";
-    "::-webkit-scrollbar-button";
-    "::-webkit-scrollbar-corner";
-    "::-webkit-resizer";
-  ]
+  [ "::future-pseudo-element"; "::foo(bar)"; "::deep"; "::v-deep"; "::ng-deep" ]
 
 let modelled_pseudo_element_spellings =
   List.filter
@@ -1204,10 +1191,28 @@ let pseudo_element_pseudo_class_rows =
         "::-webkit-details-marker";
       ],
       user_action_pseudo_classes );
-    (* The scrollbar takes no focus, and reports its own state instead. *)
-    ( [ "::-webkit-scrollbar" ],
+    (* The scrollbar takes no focus, and reports its own state instead. Every
+       part reads the same row: Chrome 151, WebKit 26.5 and Lightning CSS keep
+       [::-webkit-resizer:vertical] and [::-webkit-scrollbar-thumb:enabled] and
+       drop [::-webkit-scrollbar-thumb:focus]. *)
+    ( [
+        "::-webkit-scrollbar";
+        "::-webkit-scrollbar-button";
+        "::-webkit-scrollbar-track";
+        "::-webkit-scrollbar-track-piece";
+        "::-webkit-scrollbar-thumb";
+        "::-webkit-scrollbar-corner";
+        "::-webkit-resizer";
+      ],
       [ ":hover"; ":active"; ":enabled"; ":disabled" ]
       @ scrollbar_state_pseudo_classes );
+    (* WebVTT 1 sec. 8.2.1 and sec. 8.2.3 define a cue and a region as boxes the
+       page styles, not as controls it drives, and the engines give the pair the
+       user-action row and nothing more: all three keep [::cue:focus-within] and
+       drop [::cue:enabled] and [::cue:lang(en)]. Chrome and WebKit implement
+       neither form of [::cue-region], so Lightning CSS answers that row alone
+       and answers it the same way. *)
+    ([ "::cue"; "::cue-region" ], user_action_pseudo_classes);
     (* WebKit's [::selection:window-inactive], and nothing else. *)
     ([ "::selection" ], [ ":window-inactive" ]);
     (* CSS View Transitions 1 sec. 3.1: [:only-child] matches a view transition
@@ -1225,27 +1230,17 @@ let pseudo_element_pseudo_class_rows =
        after [::details-content]. *)
     ([ "::part(tab)" ], element_backed_pseudo_classes @ [ ":window-inactive" ]);
     ([ "::details-content" ], element_backed_pseudo_classes);
-    (* Names no shipping engine knows, plus the two WebVTT names cascade only
-       has a constructor for in their functional form, so that a bare [::cue] or
-       [::cue-region] reaches the reader as an unrecognised name: cascade keeps
-       all of these for forward compatibility and cannot know their rules, so it
-       keeps taking any pseudo-class after them. *)
+    (* Names no shipping engine knows: cascade keeps all of these for forward
+       compatibility and cannot know their rules, so it keeps taking any
+       pseudo-class after them. *)
     ( [
         "::-moz-placeholder";
         "::-ms-input-placeholder";
-        "::cue";
-        "::cue-region";
         "::future-pseudo-element";
         "::foo(bar)";
         "::deep";
         "::v-deep";
         "::ng-deep";
-        "::-webkit-scrollbar-thumb";
-        "::-webkit-scrollbar-track";
-        "::-webkit-scrollbar-track-piece";
-        "::-webkit-scrollbar-button";
-        "::-webkit-scrollbar-corner";
-        "::-webkit-resizer";
       ],
       probe_pseudo_classes );
   ]
@@ -1323,6 +1318,110 @@ let pseudo_element_pseudo_classes () =
         (String.concat "" [ "pseudo-class row for "; pe ])
         true (covered pe))
     pseudo_element_spellings
+
+(* The names sec. 3.6.5 and sec. 3.6.4 used to miss, because cascade carried
+   them as raw idents and both rules exempt a name cascade does not model.
+
+   WebVTT 1 (Editor's Draft, w3c.github.io/webvtt/, 20 May 2026) sec. 8.2: "A
+   CSS user agent that implements the text tracks model must implement the
+   ::cue, ::cue(selector), ::cue-region and ::cue-region(selector)
+   pseudo-elements". Sec. 8.2.1 and sec. 8.2.3 define the argument-less forms
+   ("The ::cue pseudo-element (with no argument) matches any list of WebVTT Node
+   Objects", "The ::cue-region pseudo-element (with no argument) matches any
+   list of WebVTT region objects"); the W3C Candidate Recommendation Draft of
+   the same date carries the same three section numbers. Chrome 151, WebKit 26.5
+   and Lightning CSS all take [::cue]; Chrome and WebKit implement neither form
+   of [::cue-region], so Lightning CSS is the oracle for that one.
+
+   No specification defines the scrollbar parts. WebKit's "Styling Scrollbars"
+   introduces the seven names together and nothing else covers them, so the
+   oracle is browsers and independent parsers alone: all three take every part
+   bare, and all three drop a combinator or a pseudo-element after it.
+
+   Reading a name gives it a constructor, and a constructor prints its own
+   spelling, so an uppercase source folds to lower case where a raw ident kept
+   it. *)
+let modelled_raw_ident_pseudo_elements () =
+  let parses input =
+    let c = Cursor.of_string input in
+    match read c with
+    | exception Error.Parse_error _ ->
+        Alcotest.failf "selector should parse: %s" input
+    | _ ->
+        if Stdlib.not (Cursor.is_done c) then
+          Alcotest.failf "selector only partly read: %s" input
+  in
+  (* Sec. 3.6.5: no combinator after any of the eight. *)
+  neg_cursor read ".a::cue .b";
+  neg_cursor read ".a::cue > .b";
+  neg_cursor read ".a::cue-region .b";
+  neg_cursor read ".a::cue-region + .b";
+  neg_cursor read ".a::-webkit-scrollbar-button .b";
+  neg_cursor read ".a::-webkit-scrollbar-track > .b";
+  neg_cursor read ".a::-webkit-scrollbar-track-piece ~ .b";
+  neg_cursor read ".a::-webkit-scrollbar-thumb .b";
+  neg_cursor read ".a::-webkit-scrollbar-corner .b";
+  neg_cursor read ".a::-webkit-resizer .b";
+  (* Sec. 3.6.4: none of the eight is defined to take a sub-pseudo-element. The
+     first two rows are where cascade differed from all three engines. *)
+  neg_cursor read "::cue::before";
+  neg_cursor read "::cue::marker";
+  neg_cursor read "::cue::after";
+  neg_cursor read "::cue::cue";
+  neg_cursor read "::cue-region::before";
+  neg_cursor read "::-webkit-scrollbar-thumb::before";
+  neg_cursor read "::-webkit-resizer::before";
+  (* Sec. 3.6.3, per the rows above: a cue takes the user-action pseudo-classes,
+     a scrollbar part its own states. *)
+  parses ".a::cue:hover";
+  parses ".a::cue:focus-within";
+  parses ".a::cue-region:active";
+  neg_cursor read ".a::cue:enabled";
+  neg_cursor read ".a::cue:lang(en)";
+  neg_cursor read ".a::cue-region:first-child";
+  parses ".a::-webkit-scrollbar-thumb:enabled";
+  parses ".a::-webkit-scrollbar-thumb:window-inactive";
+  parses ".a::-webkit-resizer:vertical";
+  neg_cursor read ".a::-webkit-scrollbar-thumb:focus";
+  (* The functional forms are the ones cascade already modelled, and their rows
+     are untouched: [::cue()] takes no pseudo-class and [::cue-region()] takes
+     any, both as before. *)
+  check_minified_to "::cue(v)" "::cue(v)";
+  check_minified_to "::cue-region(v)" "::cue-region(v)";
+  check_minified_to "::cue(v[voice=active])" "::cue(v[voice='active'])";
+  parses ".a::cue-region(v):hover";
+  neg_cursor read ".a::cue(v):hover";
+  neg_cursor read ".a::cue(v) .b";
+  neg_cursor read ".a::cue-region(v) > .b";
+  neg_cursor read "::cue()";
+  neg_cursor read "::cue-region()";
+  (* Chrome and WebKit take none of the eight with one colon, so cascade reads
+     them off the [::] table alone and a single colon stays a parse error. *)
+  neg_cursor read ".a:cue";
+  neg_cursor read ".a:cue-region";
+  neg_cursor read ".a:-webkit-scrollbar-thumb";
+  neg_cursor read ".a:-webkit-resizer";
+  (* CSS Values 4 sec. 4.1: the name is case-insensitive, and a constructor
+     prints the canonical lower-case spelling. *)
+  check_minified_to "::cue" "::CUE";
+  check_minified_to "::cue-region" "::Cue-Region";
+  check_minified_to "::-webkit-scrollbar-thumb" "::-WEBKIT-SCROLLBAR-THUMB";
+  check_minified_to "::-webkit-resizer" "::-WebKit-Resizer";
+  check_minified_to "::cue(v)" "::CUE(v)";
+  (* The exemption the interop corpus rests on is untouched: a name cascade does
+     not model still takes a combinator, a sub-pseudo-element and any
+     pseudo-class after it, and still keeps the source's case. *)
+  parses ".foo ::deep .bar";
+  parses ".foo ::unknown(.foo) .bar";
+  parses ".foo ::v-deep .bar";
+  parses ".foo ::ng-deep .bar";
+  parses ".a::deep > .b";
+  parses ".a::deep::before";
+  parses ".a::foo::before::marker";
+  parses ".a::deep:first-child";
+  parses ".a::unknown(.foo):lang(en)";
+  check_minified_to "::DEEP" "::DEEP";
+  check_minified_to "::Foo(bar)" "::Foo(bar)"
 
 (* [canonicalize] splices a single-argument [:is(s)] into the compound around
    it, since [:is(s)] matches [s] with the same specificity (Selectors 4 sec.
@@ -2531,6 +2630,8 @@ let suite =
       test_case "sub-pseudo-element guard" `Quick sub_pseudo_element_guard;
       test_case "pseudo-element pseudo-classes" `Quick
         pseudo_element_pseudo_classes;
+      test_case "modelled raw-ident pseudo-elements" `Quick
+        modelled_raw_ident_pseudo_elements;
       test_case "scrollbar state pseudo-classes" `Quick
         scrollbar_state_pseudo_classes_read;
       test_case "canonicalize pseudo-compound :is()" `Quick


### PR DESCRIPTION
Bare `::cue`, `::cue-region` and the scrollbar parts past `::-webkit-scrollbar` reached the reader as unmodelled names, which handed each of them the exemption CSS Selectors 4 keeps for a name cascade cannot judge, so selectors every engine drops were written back instead.
