### PR TITLE
stylesheet: close an unknown at-rule whose body ends on a backslash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- An unknown at-rule whose raw body ends on a backslash is written with a
+  closer that closes it. The backslash used to escape the `}` the printer wrote
+  after it, so the next statement in the stylesheet was swallowed into the body
+  (#558)
 - Bare `::cue`, `::cue-region` and the scrollbar parts past
   `::-webkit-scrollbar` are read as the pseudo-elements they are, so
   `::cue::before` and `.a::-webkit-scrollbar-thumb .b` are dropped the way

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -700,6 +700,16 @@ let trim_unknown_at_prelude prelude =
   let n = String.length prelude in
   String.sub prelude 0 (trim_end (n - 1))
 
+(* CSS Syntax 3 sec. 4.3.1: a backslash starts an escape unless a newline
+   follows it. A raw body ending on an odd run of backslashes therefore escapes
+   the closer written straight after it, and the at-rule swallows whatever comes
+   next instead of ending. *)
+let body_escapes_its_closer body =
+  let rec backslashes i n =
+    if i < 0 || body.[i] <> '\\' then n else backslashes (i - 1) (n + 1)
+  in
+  backslashes (String.length body - 1) 0 land 1 = 1
+
 let pp_unknown_at_rule_statement ctx name prelude (block : string option) =
   (* CSS Syntax 3 section 5.5.2: an at-rule terminates on [;], [}], or EOF. When
      the Parser captures an unterminated nested block ([(...], [[...], [{...])
@@ -726,6 +736,10 @@ let pp_unknown_at_rule_statement ctx name prelude (block : string option) =
       Pp.sp ctx ();
       Pp.char ctx '{';
       Pp.string ctx body;
+      (* Sec. 4.3.7 reads a space or a hex digit as part of the escape, so a
+         newline is the only separator that leaves the last backslash the delim
+         token it was. *)
+      if body_escapes_its_closer body then Pp.char ctx '\n';
       Pp.char ctx '}'
 
 let font_face_participates descriptors =

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2680,6 +2680,45 @@ let s3431_unknown_at_rule_prelude_separator () =
     "statement form without a prelude stays unspaced" "@foo;"
     (roundtrips "@foo;")
 
+(* CSS Syntax 3 sec. 4.3.1: a backslash is the start of an escape unless a
+   newline follows it, so a raw body ending on an odd run of backslashes eats
+   the [}] written straight after it and the at-rule never closes. Parsing can
+   only produce such a body at EOF, where recovery closes the block again and
+   hides the damage; the reachable case is a stylesheet that holds a statement
+   after the at-rule, where the escape swallows that statement instead.
+
+   A newline is the only separator that repairs it. Sec. 4.3.7 reads a space or
+   a hex digit as part of the escape, so either one changes the last backslash
+   from the delim token it was; a newline cannot be escaped, so the delim stays
+   a delim and the closer stays a closer. *)
+let s3431_unknown_at_rule_trailing_backslash () =
+  let parse input = read (Cursor.of_string input) in
+  let printed sheet =
+    String.trim (Css.Stylesheet.to_string ~minify:true sheet)
+  in
+  let at_rule body =
+    Unknown_at_rule { name = "o"; prelude = "x"; block = Some body }
+  in
+  let survives name body =
+    let sheet = [ at_rule body; List.hd (parse ".b{color:red}") ] in
+    Alcotest.(check int)
+      (name ^ ": the statement after the at-rule survives a round-trip")
+      2
+      (List.length (parse (printed sheet)))
+  in
+  survives "one backslash" " a \\";
+  survives "three backslashes" " a \\\\\\";
+  (* Control: an even run is a complete escape, and the closer after it already
+     closes the block. *)
+  survives "two backslashes" " a \\\\";
+  Alcotest.(check string)
+    "a body ending on a delim backslash is closed after a newline"
+    "@o x{ a \\\n}"
+    (printed [ at_rule " a \\" ]);
+  Alcotest.(check string)
+    "an escaped backslash needs no separator" "@o x{ a \\\\}"
+    (printed [ at_rule " a \\\\" ])
+
 (* CSS Syntax 3 sec. 5.4.2: an unrecognised at-rule has no grammar to
    re-serialise its body from, so the body travels as the source text between
    its braces. That text is what sits between the at-rule's own braces. Taking
@@ -8955,6 +8994,9 @@ let additional_tests =
     ( "spec CSS Syntax 4.3.1 unknown at-rule prelude separator",
       `Quick,
       s3431_unknown_at_rule_prelude_separator );
+    ( "spec CSS Syntax 4.3.1 unknown at-rule trailing backslash",
+      `Quick,
+      s3431_unknown_at_rule_trailing_backslash );
     ("spec @-moz-document prelude forms", `Quick, moz_document_prelude_forms);
     (* CSS nesting round-trip tests *)
     ("nesting basic", `Quick, test_nesting_basic);


### PR DESCRIPTION
A raw unknown-at-rule body ending on a backslash escaped the `}` the printer wrote after it, so the at-rule never closed and the next statement in the stylesheet was parsed as part of its body. Parsing alone can only build such a body at EOF, where recovery hides it; the reachable case is a stylesheet assembled through the public API.
