### PR TITLE
flatten: drop nesting that would follow a pseudo-element

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A rule nested under a pseudo-element parent, such as `.b` in
+  `.a::before{.b{color:red}}`, is dropped instead of flattened to
+  `.a::before .b`. CSS Selectors 4 sec. 3.6.5 makes that selector invalid and
+  every engine matches nothing with it (#559)
 - An unknown at-rule whose raw body ends on a backslash is written with a
   closer that closes it. The backslash used to escape the `}` the printer wrote
   after it, so the next statement in the stylesheet was swallowed into the body

--- a/lib/flatten.ml
+++ b/lib/flatten.ml
@@ -24,12 +24,32 @@ let scope_selector_in_context (parent : Selector.t) selector =
   if contains_nesting selector then substitute_nesting ~parent selector
   else selector
 
+(* CSS Selectors 4 sec. 3.6.5: a combinator after a pseudo-element is invalid,
+   and nesting composes exactly that selector out of a valid parent and a valid
+   child. Such a rule matches nothing in any engine, so drop the branches that
+   follow the pseudo-element and keep the ones that extend its compound. *)
+let keep_readable_branches (selector : Selector.t) =
+  let keeps sel = not (Selector.has_combinator_after_pseudo_element sel) in
+  match selector with
+  | Selector.List branches -> (
+      match List.filter keeps branches with
+      | [] -> Option.None
+      | [ branch ] -> Option.Some branch
+      | branches -> Option.Some (Selector.List branches))
+  | sel when keeps sel -> Option.Some sel
+  | _ -> Option.None
+
 let rec flat_rule ?(parent : Selector.t option) (rule : rule) : statement list =
   let selector =
     match parent with
-    | None -> rule.selector
-    | Some p -> combine_with_parent p rule.selector
+    | None -> Option.Some rule.selector
+    | Some p -> keep_readable_branches (combine_with_parent p rule.selector)
   in
+  match selector with
+  | Option.None -> []
+  | Option.Some selector -> flat_rule_with ~selector rule
+
+and flat_rule_with ~selector (rule : rule) : statement list =
   let direct =
     if rule.declarations = [] then []
     else

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -1347,6 +1347,22 @@ let bars_following_combinator = function
   | Compound components -> List.exists is_modelled_pseudo_element components
   | sel -> is_modelled_pseudo_element sel
 
+(* The same sec. 3.6.5 rule read off a built selector rather than applied while
+   reading one. Nesting reaches a selector the reader would refuse, because it
+   joins a valid parent to a valid child without either passing the check. The
+   two tooling combinators are exempt for the reason [check_combinator] exempts
+   them: no engine parses them, so the rule never reaches them. *)
+let rec has_combinator_after_pseudo_element = function
+  | List branches -> List.exists has_combinator_after_pseudo_element branches
+  | Combined (left, comb, right) ->
+      (match comb with
+        | Shadow_piercing | Shadow_deep -> false
+        | Descendant | Child | Next_sibling | Subsequent_sibling | Column ->
+            bars_following_combinator left)
+      || has_combinator_after_pseudo_element left
+      || has_combinator_after_pseudo_element right
+  | _ -> false
+
 (* The merged lists are static across the lifetime of the program (every
    constituent is a [let] binding above); memoise them so the [@] cons-chain
    only happens once instead of per [:foo] / [::foo] pseudo read. *)

--- a/lib/selector.mli
+++ b/lib/selector.mli
@@ -262,6 +262,14 @@ val has_newer_pseudo_class : t -> bool
     forgiving parsing). Newer pseudo-classes should not be combined in selector
     lists with group/peer variants to preserve browser compatibility. *)
 
+val has_combinator_after_pseudo_element : t -> bool
+(** [has_combinator_after_pseudo_element sel] is [true] when [sel] puts a
+    combinator after a pseudo-element, which CSS Selectors 4 sec. 3.6.5 makes
+    invalid and {!of_string} refuses. Reading it off a built selector catches
+    the selectors nesting composes, which join a valid parent to a valid child
+    without either one being refused. [>>>] and [/deep/] do not count: no engine
+    parses them, so the rule never reaches them. *)
+
 val is_pseudo_element : t -> bool
 (** [is_pseudo_element sel] is [true] when [sel] is one simple selector naming a
     pseudo-element: a box other than the originating element, where an

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -39,22 +39,29 @@ let test_empty_block_is_empty () =
     "empty input yields empty output" 0
     (List.length (Flatten.block stmts))
 
-(* A gap, pinned so it stays visible. CSS Selectors 4 sec. 3.6.5 makes a
-   combinator after a pseudo-element invalid, and the selector reader refuses
-   [.a::before .b] for it. Flattening builds the same selector from a valid
-   parent and a valid nested selector without going through the reader, so this
-   route still emits it. Chrome 151 and WebKit 26.5 keep the nested rule in
-   cssRules but it matches nothing, since the flattened form is the invalid one.
+(* CSS Selectors 4 sec. 3.6.5 makes a combinator after a pseudo-element invalid,
+   and the selector reader refuses [.a::before .b] when it is authored directly.
+   Flattening reaches the same selector from a valid parent and a valid nested
+   selector, so it has to apply the rule too: Chrome 151 and WebKit 26.5 keep
+   such a nested rule in cssRules but it matches nothing, so the rule carries no
+   style and emitting it only produces CSS cascade would refuse to read back.
 
-   Closing this needs the parent context at flatten time, which is a larger
-   change than the reader guard; when it lands, this expectation becomes an
-   empty statement list. *)
-let test_pseudo_element_parent_still_flattens () =
-  let stmts = block ".a::before{.b{color:red}}" in
-  Alcotest.(check string)
-    "nested rule under a pseudo-element parent flattens to an invalid selector"
-    ".a:before .b{color:red}"
-    (render (Flatten.block stmts))
+   The parent's own declarations are unaffected, and a nested selector that
+   extends the compound rather than following it is still valid. *)
+let test_pseudo_element_parent_drops_invalid_nesting () =
+  let dropped name css expected =
+    Alcotest.(check string) name expected (render (Flatten.block (block css)))
+  in
+  dropped "a descendant under a pseudo-element parent goes"
+    ".a::before{.b{color:red}}" "";
+  dropped "the parent keeps its own declarations"
+    ".a::before{color:red;.b{color:blue}}" ".a:before{color:red}";
+  dropped "a child combinator goes the same way" ".a::before{>.b{color:red}}" "";
+  (* Only the branches that follow the pseudo-element go. *)
+  dropped "an amperand branch extending the compound stays"
+    ".a::before{.b,&:hover{color:red}}" ".a:before:hover{color:red}";
+  (* Control: no pseudo-element, so nesting is valid and lifts as before. *)
+  dropped "a plain parent still flattens" ".a{.b{color:red}}" ".a .b{color:red}"
 
 (* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so its
    prelude is ambiguous with a declaration until the block appears:
@@ -158,8 +165,8 @@ let suite =
         test_flattens_descendant_nesting;
       Alcotest.test_case "empty block stays empty" `Quick
         test_empty_block_is_empty;
-      Alcotest.test_case "pseudo-element parent still flattens" `Quick
-        test_pseudo_element_parent_still_flattens;
+      Alcotest.test_case "pseudo-element parent drops invalid nesting" `Quick
+        test_pseudo_element_parent_drops_invalid_nesting;
       Alcotest.test_case "nested rule starting with an ident" `Quick
         test_nested_rule_starting_with_ident;
       Alcotest.test_case "bad declaration stays a declaration" `Quick


### PR DESCRIPTION
Nesting composed `.a::before .b` out of a valid parent and a valid child, so neither half met the selector reader's CSS Selectors 4 sec. 3.6.5 check and the rule was emitted even though `Css.of_string` refuses the same selector written directly. Branches that extend the compound rather than follow it, such as `&:hover`, are kept.
