### PR TITLE
optimize: compact the opaque body of an unrecognised at-rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -376,6 +376,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `Css.optimize` writes an unrecognised at-rule's opaque body back as the token
+  stream it read, so `@foo{ .a { color: red } }` minifies to
+  `@foo{.a{color:red}}`. `~lossless:true` leaves the body as authored, and the
+  printer never touches it (#560)
 - `--minify` indexes each selector's latest write by property instead of
   rescanning every later declaration when deciding whether a rule is shadowed.
   The 8,000-rule same-selector benchmark is about 108x faster.

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -557,6 +557,34 @@ let drop_invalid (stylesheet : t) : t =
     (list_filter_preserve (fun d -> not (Declaration.is_invalid d)))
     stylesheet
 
+(* CSS Syntax 3 sec. 5.4.2 keeps an unrecognised at-rule's body as raw source
+   text, so no typed node stands between the author's layout and the output and
+   the serializer may not touch it: rewriting the body is an AST change. Reading
+   it back as a component-value stream and writing it out with the separator
+   rules that already serve custom-property streams keeps every token boundary,
+   string, escape and nested block while the layout between them goes. A body
+   the lexer cannot re-serialise to the same stream is left alone. *)
+let compact_unknown_at_rule_body body =
+  let reader = Reader.of_string body in
+  let { Parser.value = components; warnings } =
+    Parser.list_of_component_values reader
+  in
+  match warnings with
+  | _ :: _ -> body
+  | [] ->
+      let compacted = Parser.to_string_minified components in
+      if String.length compacted < String.length body then compacted else body
+
+let compact_unknown_at_rule_bodies (stylesheet : t) : t =
+  edit_statements
+    (function
+      | Unknown_at_rule ({ block = Some body; _ } as at) ->
+          let compacted = compact_unknown_at_rule_body body in
+          if String.equal compacted body then Keep
+          else Replace (Unknown_at_rule { at with block = Some compacted })
+      | _ -> Keep)
+    stylesheet
+
 (** [drop_unknown_at_rules] removes [Unknown_at_rule] statements at every block
     depth, matching what a user agent applies of a stylesheet (CSS 2.1 sec. 4.2)
     rather than what a transform may hand the next reader of one. Opt in when
@@ -909,6 +937,11 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
   let scope = Option.value scope ~default:`Fragment in
   let ctx = single_valued_calc_ctx stylesheet in
   let stylesheet = sanitize_block ~ctx ~lossless stylesheet in
+  (* Under [lossless] the raw body stands as authored: nothing types it, so
+     nothing proves the layout inside it carries no meaning to its reader. *)
+  let stylesheet =
+    if lossless then stylesheet else compact_unknown_at_rule_bodies stylesheet
+  in
   let stylesheet =
     if flatten_nesting then Flatten.block stylesheet else stylesheet
   in

--- a/test/cli/fmt_unknown_at_rule.t
+++ b/test/cli/fmt_unknown_at_rule.t
@@ -71,23 +71,25 @@ A body cut short mid-construct still ends where the AST says it ends.
 CSS Syntax 3 (ED) sec. 4.3.5 returns the string token at end of input,
 4.3.6 the url token, and sec. 5.5.9 and 5.5.10 close a simple block and a
 function there, so the text carried means the closed form. Left open it
-eats the `}` and the at-rule runs on into whatever follows.
+eats the `}` and the at-rule runs on into whatever follows. The layout
+inside the body goes with it: the optimizer writes the body back as the
+token stream it read, keeping only the separators the tokens need.
 
   $ printf '@o x{ a "i' | cascade fmt --minify - 2> /dev/null
-  @o x{ a "i"}
+  @o x{a "i"}
   $ printf '@o x{ a url(i' | cascade fmt --minify - 2> /dev/null
-  @o x{ a url(i)}
+  @o x{a url(i)}
   $ printf '@o x{ a f(i' | cascade fmt --minify - 2> /dev/null
-  @o x{ a f(i)}
+  @o x{a f(i)}
   $ printf '@o x{ a [i' | cascade fmt --minify - 2> /dev/null
-  @o x{ a [i]}
+  @o x{a[i]}
   $ printf '@o x{ a (i' | cascade fmt --minify - 2> /dev/null
-  @o x{ a (i)}
+  @o x{a (i)}
 
 A well-formed body is untouched.
 
   $ printf '@o x{ a b }' | cascade fmt --minify - 2> /dev/null
-  @o x{ a b }
+  @o x{a b}
 
 Written back, the at-rule ends where it ended: a rule appended to the
 output is a second statement, not more of the at-rule.
@@ -95,4 +97,4 @@ output is a second statement, not more of the at-rule.
   $ printf '@o x{ a "i' | cascade fmt --minify - 2> /dev/null > cut.css
   $ printf '.z{color:red}' >> cut.css
   $ cascade fmt --minify cut.css 2> /dev/null
-  @o x{ a "i"}.z{color:red}
+  @o x{a "i"}.z{color:red}

--- a/test/spec/test.ml
+++ b/test/spec/test.ml
@@ -296,7 +296,7 @@ let syntax_recovery () =
      [Optimize.drop_unknown_at_rules]. Its body has no known grammar, so it
      travels as source text and minify has nothing to shorten it against. *)
   recover "@unknown { .a { color: red } } .b { color: blue }"
-    "@unknown{ .a { color: red } }.b{color:#00f}" 1;
+    "@unknown{.a{color:red}}.b{color:#00f}" 1;
   recover ".a { color: red" ".a{color:red}" 0
 
 (* {2 CSS Selectors Level 4} https://www.w3.org/TR/selectors-4/ *)

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1460,8 +1460,52 @@ let page_break_var_shadows_like_its_alias () =
         ".a{page-break-inside:var(--x)}" );
     ]
 
+(* CSS Syntax 3 sec. 5.4.2 keeps an unrecognised at-rule's body as raw source
+   text, so nothing in it is typed and the printer cannot touch it: rewriting
+   the body changes the AST, which is the optimizer's job and not the
+   serializer's. The optimizer reads the body as a component-value stream and
+   writes it back with the separator rules that already serve custom-property
+   streams, so token boundaries, strings, escapes and nested blocks survive
+   while the layout between them goes.
+
+   [--minify] on its own leaves the body alone, since it may not change what the
+   AST holds. *)
+let unknown_at_rule_body_is_compacted () =
+  let parse css =
+    match Css.of_string ~strict:false css with
+    | Ok p -> p.stylesheet
+    | Error _ -> Alcotest.failf "parse failed: %s" css
+  in
+  let optimized css = Css.to_string ~minify:true (Css.optimize (parse css)) in
+  let minified css = Css.to_string ~minify:true (parse css) in
+  let compacts name css expected =
+    Alcotest.(check string) name expected (optimized css);
+    Alcotest.(check string)
+      (name ^ ": optimizing again changes nothing")
+      expected (optimized expected)
+  in
+  compacts "a nested rule in an opaque body loses its layout"
+    "@foo{ .a { color: red } }" "@foo{.a{color:red}}";
+  compacts "a string keeps every byte between its quotes"
+    "@foo{ a: \"  b  c  \" }" "@foo{a:\"  b  c  \"}";
+  compacts "an escape spelling an ident is written as that ident"
+    "@foo{ \\41 b }" "@foo{Ab}";
+  compacts "an escape the ident needs is kept" "@foo{ a\\ b }" "@foo{a\\ b}";
+  compacts "two idents keep the boundary between them" "@foo{ a   b }"
+    "@foo{a b}";
+  compacts "an ident before a paren keeps the space that stops a function token"
+    "@foo{ a ( b  c ) [ d ] }" "@foo{a (b c)[d]}";
+  (* [--minify] alone may not rewrite the AST, so the body travels verbatim. *)
+  Alcotest.(check string)
+    "minify alone leaves the opaque body as authored"
+    "@foo{ .a { color: red } }"
+    (minified "@foo{ .a { color: red } }")
+
 let optimize_tests =
   [
+    ( "unknown at-rule body is compacted",
+      `Quick,
+      unknown_at_rule_body_is_compacted );
     ( "!important survives non-adjacent duplicate elimination",
       `Quick,
       important_survives_non_adjacent_duplicate );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1531,7 +1531,7 @@ let spec_lenient_recovery_stylesheets () =
      name, so what recovers here is the rule after it, not the at-rule. *)
   lenient_recover "unknown at-rule keeps its neighbour"
     "@unknown-rule { .bad { color: red } } .ok { color: blue }"
-    "@unknown-rule{ .bad { color: red } }.ok{color:#00f}" 1;
+    "@unknown-rule{.bad{color:red}}.ok{color:#00f}" 1;
   lenient_recover "bad selector list drops rule only"
     ".ok { color: green } .bad:not() { color: red } .next { color: blue }"
     ".ok{color:green}.next{color:#00f}" 1;
@@ -2599,7 +2599,7 @@ let css_syntax_recovery () =
     ".ok { color: green } .bad:not() { color: red }" ".ok{color:green}" 1;
   check_recovery "unknown at-rule"
     "@unknown-rule { .bad { color: red } } .ok { color: blue }"
-    "@unknown-rule{ .bad { color: red } }.ok{color:#00f}" 1
+    "@unknown-rule{.bad{color:red}}.ok{color:#00f}" 1
 
 let css_syntax_recovery_structural () =
   let declaration_counts stylesheet =
@@ -9738,7 +9738,7 @@ let additional_tests =
               "warning surfaced" true
               (parsed.Css.warnings <> []);
             Alcotest.(check string)
-              "recovered output" "@unknown{ color: red }.a{color:#00f}"
+              "recovered output" "@unknown{color:red}.a{color:#00f}"
               (minify parsed.stylesheet)
         | Error e ->
             Alcotest.failf "non-strict mode should not promote warnings: %s"


### PR DESCRIPTION
An unrecognised at-rule's body is source text with no grammar behind it, so the printer may not rewrite it and the authored layout survived minification. `Css.optimize` now reads the body as a component-value stream and writes it back with the separator rules that already serve custom-property streams, so token boundaries, strings, escapes and nested blocks survive while the layout between them goes. `~lossless:true` keeps the body as authored.
