### PR TITLE
fuzz: reach the non-ascii and U+ paths

### DIFF
--- a/fuzz/fuzz_css.ml
+++ b/fuzz/fuzz_css.ml
@@ -182,6 +182,27 @@ let test_parse_crash_safety buf =
   ignore (Css.of_string ~strict:false css);
   ignore (Css.of_string_exn ~strict:false css)
 
+(* Parsing and printing over the byte shapes [cssish] cannot reach. Sec. 3.3
+   replaces every malformed sequence with U+FFFD before the tokenizer sees it,
+   so the output has to re-parse like any other stylesheet. *)
+let test_roundtrip_unicode_bytes buf =
+  let css = Fuzz_helpers.unicodish buf in
+  match Css.of_string ~strict:false css with
+  | Error _ -> ()
+  | Ok parsed ->
+      let printed = minified parsed.stylesheet in
+      let again =
+        match Css.of_string ~strict:false printed with
+        | Ok again -> minified again.stylesheet
+        | Error e ->
+            failf "printed non-ascii stylesheet did not re-parse: %s (%S)"
+              (Cascade.Error.to_string e)
+              printed
+      in
+      if not (String.equal printed again) then
+        failf "non-ascii stylesheet is not a printing fixed point: %S -> %S"
+          printed again
+
 let test_parse_always_recovers_bytes buf =
   let parsed = recovered_css "parse always recovers bytes" buf in
   ignore (minified parsed.stylesheet : string)
@@ -389,6 +410,8 @@ let suite =
   ( "css",
     [
       test_case "parse crash safety" [ bytes ] test_parse_crash_safety;
+      test_case "parse roundtrip over non-ascii bytes" [ bytes ]
+        test_roundtrip_unicode_bytes;
       test_case "parse always recovers bytes" [ bytes ]
         test_parse_always_recovers_bytes;
       test_case "strict/lenient cssish contract" [ bytes ]

--- a/fuzz/fuzz_cursor.ml
+++ b/fuzz/fuzz_cursor.ml
@@ -33,6 +33,14 @@ let safe_component_input buf =
     ]
     buf 2
 
+(* The same property over the byte shapes [cssish] cannot reach. *)
+let test_cursor_unicode_bytes buf =
+  let c = Cursor.of_string (Fuzz_helpers.unicodish buf) in
+  ignore (Cursor.peek c);
+  ignore (Cursor.string_of_remaining c);
+  ignore (Cursor.consume_remaining_as_string c);
+  ignore (Cursor.is_done c)
+
 let test_cursor_crash_safety buf =
   let c = cursor buf in
   ignore (Cursor.peek c);
@@ -105,6 +113,8 @@ let suite =
   ( "cursor",
     [
       test_case "cursor crash safety" [ bytes ] test_cursor_crash_safety;
+      test_case "cursor crash safety over non-ascii bytes" [ bytes ]
+        test_cursor_unicode_bytes;
       test_case "save/restore remaining stable" [ bytes ]
         test_save_restore_remaining_stable;
       test_case "lookahead does not advance" [ bytes ]

--- a/fuzz/fuzz_declaration.ml
+++ b/fuzz/fuzz_declaration.ml
@@ -65,6 +65,10 @@ let starts_with ~prefix s =
 let test_read_declaration_crash_safety buf =
   ignore (parse_declaration (cssish buf))
 
+(* The same property over the byte shapes [cssish] cannot reach. *)
+let test_declaration_unicode_bytes buf =
+  ignore (parse_declaration (Fuzz_helpers.unicodish buf))
+
 (* Allow one canonicalization pass (numeric trim, escape canonical form, ...)
    that only fires on re-parse, then require fixed point. *)
 let test_serialization_idempotent buf =
@@ -388,6 +392,8 @@ let suite =
     [
       test_case "read_declaration crash safety" [ bytes ]
         test_read_declaration_crash_safety;
+      test_case "read_declaration crash safety over non-ascii bytes" [ bytes ]
+        test_declaration_unicode_bytes;
       test_case "serialization idempotent" [ bytes ]
         test_serialization_idempotent;
       test_case "property name preserved after serialization" [ bytes ]

--- a/fuzz/fuzz_lexer.ml
+++ b/fuzz/fuzz_lexer.ml
@@ -32,6 +32,10 @@ let kind_strings_no_eof input =
 
 let test_tokenization_crash_safety buf = ignore (kinds (cssish buf))
 
+(* The same property over the byte shapes [cssish] cannot reach. *)
+let test_tokenization_unicode_bytes buf =
+  ignore (kinds (Fuzz_helpers.unicodish buf))
+
 let test_tokenization_deterministic buf =
   let input = cssish buf in
   let a = kind_strings input in
@@ -120,6 +124,8 @@ let suite =
     [
       test_case "tokenization crash safety" [ bytes ]
         test_tokenization_crash_safety;
+      test_case "tokenization crash safety over non-ascii bytes" [ bytes ]
+        test_tokenization_unicode_bytes;
       test_case "tokenization deterministic" [ bytes ]
         test_tokenization_deterministic;
       test_case "peek/next consistency" [ bytes ] test_peek_next_consistency;

--- a/fuzz/fuzz_parser.ml
+++ b/fuzz/fuzz_parser.ml
@@ -109,11 +109,17 @@ let string_rev s =
   String.init len (fun i -> s.[len - 1 - i])
 
 (** Component-value parsing must not crash on decoded CSS-shaped input. *)
-let test_component_value_crash_safety buf =
-  let buf = cssish buf in
+let component_value_crash_safety buf =
   ignore (Parser.component_value (Reader.of_string buf));
   ignore (Parser.list_of_component_values (Reader.of_string buf));
   ignore (Parser.csv_component_values (Reader.of_string buf))
+
+let test_component_value_crash_safety buf =
+  component_value_crash_safety (cssish buf)
+
+(* The same property over the byte shapes [cssish] cannot reach. *)
+let test_component_unicode_bytes buf =
+  component_value_crash_safety (Fuzz_helpers.unicodish buf)
 
 (** Minified serialization should be idempotent after reparsing. *)
 let test_component_value_minified_idempotent buf =
@@ -232,6 +238,8 @@ let suite =
     [
       test_case "component-value crash safety" [ bytes ]
         test_component_value_crash_safety;
+      test_case "component-value crash safety over non-ascii bytes" [ bytes ]
+        test_component_unicode_bytes;
       test_case "component-value minified serialization idempotent" [ bytes ]
         test_component_value_minified_idempotent;
       test_case "component-value serialization idempotent" [ bytes ]

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -606,6 +606,11 @@ let test_read_stylesheet buf =
   let r = Cursor.of_string buf in
   try ignore (Css.Stylesheet.read r) with Cursor.Parse_error _ -> ()
 
+(* The same property over byte shapes an ASCII alphabet cannot reach. *)
+let test_stylesheet_unicode_bytes buf =
+  let r = Cursor.of_string (Fuzz_helpers.unicodish buf) in
+  try ignore (Css.Stylesheet.read r) with Cursor.Parse_error _ -> ()
+
 (** read_rule -- must not crash. *)
 let test_read_rule buf =
   let r = Cursor.of_string buf in
@@ -1714,6 +1719,8 @@ let test_invalid_prelude_order buf =
 let parser_cases =
   [
     test_case "stylesheet read crash safety" [ bytes ] test_read_stylesheet;
+    test_case "stylesheet read crash safety over non-ascii bytes" [ bytes ]
+      test_stylesheet_unicode_bytes;
     test_case "read_rule crash safety" [ bytes ] test_read_rule;
     test_case "read_block crash safety" [ bytes ] test_read_block;
     test_case "read crash safety" [ bytes ] test_read;

--- a/fuzz/helpers/fuzz_helpers.ml
+++ b/fuzz/helpers/fuzz_helpers.ml
@@ -30,3 +30,54 @@ let shapes_with_rule_runs ~boundary_shape ss =
         loop (List.rev_append (boundary_shape other) acc) false rest
   in
   loop [] false ss
+
+(* Byte shapes an ASCII alphabet cannot produce. Kept as literals rather than
+   generated, so each one names a decoder path: well-formed multi-byte, the
+   three ways a sequence is malformed, and the bytes no UTF-8 uses at all. *)
+let byte_shapes =
+  [
+    "\xef\xbb\xbf" (* BOM *);
+    "\xc3\xa9" (* U+00E9, two bytes *);
+    "\xe2\x86\x97" (* U+2197, three bytes *);
+    "\xf0\x9d\x84\x9e" (* U+1D11E, four bytes *);
+    "\x80" (* continuation byte with nothing to continue *);
+    "\xe2\x86" (* three-byte sequence cut short *);
+    "\xc0\xaf" (* overlong encoding of [/] *);
+    "\xed\xa0\x80" (* surrogate, which UTF-8 does not encode *);
+    "\xff\xfe" (* never valid UTF-8 *);
+    "\x00" (* NUL, which sec. 3.3 also replaces *);
+  ]
+
+(* [U+] ranges, including the spellings that end where a token boundary has to
+   be decided. *)
+let unicode_ranges =
+  [
+    "U+0-7f"; "u+41"; "U+1234-"; "U+??"; "U+"; "U+a?b"; "U+0-10FFFF"; "U+FF,U+0";
+  ]
+
+let unicodish buf =
+  let at i = if buf = "" then 0 else Char.code buf.[i mod String.length buf] in
+  let pick xs i = List.nth xs (at i mod List.length xs) in
+  let shape = pick byte_shapes in
+  let range = pick unicode_ranges in
+  let b = Buffer.create 128 in
+  if at 0 land 1 = 0 then Buffer.add_string b (List.hd byte_shapes);
+  Buffer.add_string b ".";
+  Buffer.add_string b (shape 1);
+  Buffer.add_string b "x{";
+  Buffer.add_string b (shape 2);
+  Buffer.add_string b "-color:";
+  Buffer.add_string b (shape 3);
+  Buffer.add_string b ";content:\"";
+  Buffer.add_string b (shape 4);
+  Buffer.add_string b "\"}@font-face{unicode-range:";
+  Buffer.add_string b (range 5);
+  Buffer.add_string b ";src:local(";
+  Buffer.add_string b (shape 6);
+  Buffer.add_string b ")}@media (min-width:1px){#";
+  Buffer.add_string b (shape 7);
+  Buffer.add_string b "{--v:";
+  Buffer.add_string b (range 8);
+  Buffer.add_string b (shape 9);
+  Buffer.add_string b "}}";
+  Buffer.contents b

--- a/fuzz/helpers/fuzz_helpers.mli
+++ b/fuzz/helpers/fuzz_helpers.mli
@@ -16,3 +16,15 @@ val shapes_with_rule_runs :
     without forcing the optimizer to keep every individual rule. Each fuzz entry
     point supplies its own [boundary_shape] (they differ in baseline-[@supports]
     handling). *)
+
+val unicodish : string -> string
+(** [unicodish buf] builds CSS text out of the byte shapes an ASCII-only
+    generator never reaches: a BOM, well-formed multi-byte UTF-8, malformed
+    UTF-8 (a lone continuation byte, a truncated sequence, an overlong form, a
+    surrogate encoding), a NUL, and [U+] ranges written next to an ident. CSS
+    Syntax 3 sec. 3.3 decodes the input as UTF-8 and turns every malformed
+    sequence into U+FFFD, and sec. 4.3.1 admits any code point at or above
+    U+0080 into an ident, so these are live paths that an alphabet of ASCII
+    never exercises. The fragments are placed in real syntactic positions -
+    selector, property name, value, at-rule prelude - rather than concatenated,
+    so the parser reaches them the way a stylesheet would. *)


### PR DESCRIPTION
Every `cssish` generator maps its input bytes onto an ASCII alphabet, so no fuzz case reached the UTF-8 decoding of CSS Syntax 3 sec. 3.3, the ident range of sec. 4.3.1, or a `U+` range written next to an ident. `Fuzz_helpers.unicodish` draws from a BOM, well-formed multi-byte sequences, the three ways a sequence is malformed, a NUL, and eight `U+` spellings, placing them in selector, property, value and at-rule-prelude positions. Six crash-safety and round-trip properties now run over it. Nothing failed, so this adds coverage rather than fixing a bug. Test-only, so no changelog entry.
