### PR TITLE
block: carry the distant-@media accumulator reversed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -376,6 +376,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- Merging a distant same-condition `@media` block carries its accumulator
+  reversed instead of appending to the end, so the pass costs a line in the
+  statement count rather than a square. A 4,000-statement sheet allocates
+  24.4M words before and 0.4M after (#566)
 - `Css.optimize` writes an unrecognised at-rule's opaque body back as the token
   stream it read, so `@foo{ .a { color: red } }` minifies to
   `@foo{.a{color:red}}`. `~lossless:true` leaves the body as authored, and the

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -220,6 +220,42 @@ let needs_distant_media_merge stmts =
    declarations run in that body sets properties on [owner] (CSS Nesting 1 sec.
    3.4), so the analysis below only sees it once it can name the rule the run
    belongs to. *)
+(* Only cross statements whose cascade is pure source order: plain rules and
+   conditional groups. Layers, origins, scopes, imports, etc. establish
+   ordering/context that hoisting past would change. *)
+let crossable_by_distant_media = function
+  | Rule _ | Declarations _ | Media _ | Supports _ | Container _ -> true
+  | _ -> false
+
+(* Split [out] at the first [@media] whose condition is [cond], into what comes
+   before it, its own block, and what sits between it and the caller. *)
+let split_at_media cond out :
+    (statement list * statement list * statement list) option =
+  let rec go before :
+      statement list ->
+      (statement list * statement list * statement list) option = function
+    | [] -> None
+    | Media (c, b) :: after when Media.equal c cond ->
+        Some (List.rev before, b, after)
+    | x :: rest -> go (x :: before) rest
+  in
+  go [] out
+
+let try_distant_media_merge ~leaves ~unattributed out cond block :
+    statement list option =
+  let hoisted = leaves block in
+  match split_at_media cond out with
+  | None -> None
+  | Some (before, target, after)
+    when List.for_all crossable_by_distant_media after ->
+      let crossed = leaves after in
+      if
+        unattributed block || unattributed after
+        || List.exists (fun h -> List.exists (rules_conflict h) crossed) hoisted
+      then None
+      else Some (before @ [ Media (cond, target @ block) ] @ after)
+  | Some _ -> None
+
 let merge_distant_media ?owner ~optimize_merged_block stmts =
   if not (needs_distant_media_merge stmts) then stmts
   else
@@ -227,46 +263,24 @@ let merge_distant_media ?owner ~optimize_merged_block stmts =
     let unattributed stmts =
       Option.is_none owner && List.exists holds_unattributed_run stmts
     in
-    let try_merge out cond block : statement list option =
-      let hoisted = leaves block in
-      let rec split before :
-          statement list ->
-          (statement list * statement list * statement list) option = function
-        | [] -> None
-        | Media (c, b) :: after when Media.equal c cond ->
-            Some (List.rev before, b, after)
-        | x :: rest -> split (x :: before) rest
-      in
-      (* Only cross statements whose cascade is pure source order: plain rules
-         and conditional groups. Layers, origins, scopes, imports, etc.
-         establish ordering/context that hoisting past would change. *)
-      let crossable = function
-        | Rule _ | Declarations _ | Media _ | Supports _ | Container _ -> true
-        | _ -> false
-      in
-      match split [] out with
-      | None -> None
-      | Some (before, target, after) when List.for_all crossable after ->
-          let crossed = leaves after in
-          if
-            unattributed block || unattributed after
-            || List.exists
-                 (fun h -> List.exists (rules_conflict h) crossed)
-                 hoisted
-          then None
-          else Some (before @ [ Media (cond, target @ block) ] @ after)
-      | Some _ -> None
+    (* The accumulator is carried reversed, as the consecutive-block passes
+       nearby carry theirs: appending to the end copies it once per statement,
+       which costs a square in the statement count. Only a [@media] statement
+       needs it in order, to find the partner it merges into, and [rev_map] puts
+       the result back in source order. *)
+    let step rout stmt =
+      match stmt with
+      | Media (cond, block) when not (has_nested_preference_media block) -> (
+          match
+            try_distant_media_merge ~leaves ~unattributed (List.rev rout) cond
+              block
+          with
+          | Some out' -> List.rev out'
+          | None -> stmt :: rout)
+      | _ -> stmt :: rout
     in
-    List.fold_left
-      (fun out stmt ->
-        match stmt with
-        | Media (cond, block) when not (has_nested_preference_media block) -> (
-            match try_merge out cond block with
-            | Some out' -> out'
-            | None -> out @ [ stmt ])
-        | _ -> out @ [ stmt ])
-      [] stmts
-    |> List.map (function
+    List.fold_left step [] stmts
+    |> List.rev_map (function
       | Media (c, b) -> Media (c, optimize_merged_block b)
       | s -> s)
 

--- a/test/test_block.ml
+++ b/test/test_block.ml
@@ -263,6 +263,43 @@ let test_merge_media_joins_two_spellings_of_one_bound () =
   Alcotest.(check int)
     "two spellings of one bound merge into one block" 1 (List.length merged)
 
+(* --- allocation / complexity guard --- *)
+
+let measure f =
+  Gc.full_major ();
+  let w0 = Gc.minor_words () in
+  let r = f () in
+  ignore (Sys.opaque_identity r);
+  Gc.minor_words () -. w0
+
+(* [n] plain rules with one [@media print] block at each end, so the pass has
+   exactly one merge to make and [n] statements to carry while it looks for the
+   partner. Every rule writes its own property on its own selector, so nothing
+   conflicts and the merge goes through. *)
+let distant_media_run n =
+  let b = Buffer.create ((n * 24) + 64) in
+  let out = Fmt.with_buffer b in
+  Buffer.add_string b "@media print{.m0{color:red}}";
+  for i = 1 to n do
+    Fmt.pf out ".r%d{--p%d:%d}" i i i
+  done;
+  Buffer.add_string b "@media print{.m1{color:blue}}";
+  block (Buffer.contents b)
+
+(* Carrying the accumulator by appending to its end copies it once per
+   statement, so the walk costs a square in the statement count rather than a
+   line. The partner search is one scan and does not depend on [n] twice. *)
+let test_merge_distant_media_is_subquadratic () =
+  let small = distant_media_run 2_000 in
+  let large = distant_media_run 4_000 in
+  let merge stmts = Block.merge_distant_media ~optimize_merged_block:id stmts in
+  let small_words = measure (fun () -> merge small) in
+  let large_words = measure (fun () -> merge large) in
+  let ratio = large_words /. small_words in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.2fx for 2x N)" small_words large_words ratio)
+    true (ratio < 3.)
+
 let suite =
   ( "block",
     [
@@ -300,4 +337,6 @@ let suite =
       Alcotest.test_case "is_layer_empty" `Quick test_is_layer_empty;
       Alcotest.test_case "is_layer_empty sees nested rules" `Quick
         test_is_layer_not_empty_with_nested;
+      Alcotest.test_case "merge distant @media is subquadratic" `Quick
+        test_merge_distant_media_is_subquadratic;
     ] )


### PR DESCRIPTION
The pass built its output with `out @ [stmt]`, copying the accumulator once per statement, so it cost a square in the statement count. Measured on a sheet of N plain rules between two mergeable `@media print` blocks: 6.2M words at N=2,000 and 24.4M at N=4,000 before, 0.2M and 0.4M after. The partner search still needs the accumulator in source order, so only a `@media` statement pays for a reversal.
