### PR TITLE
resolve: prepare the sheet once instead of per node

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -699,6 +699,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- `Resolve.prepare` and `Resolve.Make.resolve_prepared` split the sheet-only
+  work out of `resolve`, so a caller walking a document flattens the nesting
+  and buckets the rules by layer once rather than per node. Ten queries against
+  a 2,000-rule sheet allocate 4.6x less (#567)
 - `Css.Properties.compare_property` and `Css.Declaration.compare_prop_key` are
   a total order on a property identity, `0` exactly where equality holds. The
   table that drops shadowed rules orders its coverage set with it instead of

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -184,6 +184,19 @@ let layered_rules stmts =
 
 let layer_order stmts = List.map layer_key (fst (layered_rules stmts))
 
+(* Everything [resolve] can work out from the sheet alone: the flattened rule
+   list with each rule's layer, and the layer order the cascade ranks by.
+   Neither depends on the node, so a caller walking a document pays for them
+   once rather than per element. *)
+type prepared = {
+  layer_order : string list;
+  rules : (string list option * Stylesheet.rule) list;
+}
+
+let prepare sheet =
+  let paths, rules = layered_rules (Flatten.block sheet) in
+  { layer_order = List.map layer_key paths; rules }
+
 module Make (N : NODE) = struct
   let preceding_siblings n =
     match N.parent n with
@@ -348,13 +361,11 @@ module Make (N : NODE) = struct
               (Selector.specificity b) rest)
     | None -> Selector.specificity sel
 
-  let resolve sheet node =
+  let resolve_prepared { layer_order; rules } node =
     let upsert acc d =
       let k = Declaration.property_name d in
       (k, d) :: List.remove_assoc k acc
     in
-    let paths, rules = layered_rules (Flatten.block sheet) in
-    let layer_order = List.map layer_key paths in
     let matched =
       rules
       |> List.mapi (fun i (layer, r) ->
@@ -398,6 +409,8 @@ module Make (N : NODE) = struct
     (* normal first, then !important, last wins per property *)
     List.fold_left upsert [] (bucket ~important:false @ bucket ~important:true)
     |> List.rev_map snd
+
+  let resolve sheet node = resolve_prepared (prepare sheet) node
 end
 
 (* The capability side of the matcher, read off the matcher rather than restated

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -86,6 +86,17 @@ val layer_order : Stylesheet.t -> string list
     This is the [~layer_order] that {!Stylesheet.cascade_layer_precedence_rank}
     expects. *)
 
+type prepared
+(** A stylesheet with everything {!Make.resolve} can settle without a node
+    worked out: the flattened rules with their layers, and the layer order the
+    cascade ranks by. *)
+
+val prepare : Stylesheet.t -> prepared
+(** [prepare sheet] is [sheet] with its nesting flattened and its rules bucketed
+    by layer. A caller resolving many nodes against one sheet prepares it once
+    and passes the result to {!Make.resolve_prepared}, rather than paying for
+    the flattening per node. *)
+
 module Make (N : NODE) : sig
   val match_selector : Selector.t -> N.t -> match_result
   (** [match_selector sel node] is what the matcher can say about [sel] and
@@ -98,14 +109,19 @@ module Make (N : NODE) : sig
       [No_match], so a caller that has to tell the two apart wants
       {!match_selector}. *)
 
+  val resolve_prepared : prepared -> N.t -> Declaration.declaration list
+  (** [resolve_prepared prepared node] is {!resolve} against an already
+      {!prepare}d sheet. Same result, without redoing the sheet-only work per
+      node. *)
+
   val resolve : Stylesheet.t -> N.t -> Declaration.declaration list
-  (** [resolve sheet node] is the declarations that win for [node] after
-      flattening nesting and applying the cascade: selector matching,
-      [!important] over normal, then cascade layer, specificity and source
-      order. [@layer] blocks and [@layer a, b;] statements order the layers by
-      first appearance, sublayers included; among normal declarations the last
-      layer wins and an unlayered declaration beats them all, and for
-      [!important] declarations that order reverses.
+  (** [resolve sheet node] is [resolve_prepared (prepare sheet) node]: the
+      declarations that win for [node] after flattening nesting and applying the
+      cascade: selector matching, [!important] over normal, then cascade layer,
+      specificity and source order. [@layer] blocks and [@layer a, b;]
+      statements order the layers by first appearance, sublayers included; among
+      normal declarations the last layer wins and an unlayered declaration beats
+      them all, and for [!important] declarations that order reverses.
 
       Style rules and [@layer] are the only blocks walked. A rule inside a
       conditional group rule ([@media], [@supports], [@container],

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -345,10 +345,78 @@ let test_apply_compute () =
   Alcotest.(check int) "the :hover rule is kept in a <style>" 1 result.kept;
   Alcotest.(check bool) "kept css is non-empty" true (result.keep_css <> "")
 
+(* --- allocation / complexity guard --- *)
+
+let measure f =
+  Gc.full_major ();
+  let w0 = Gc.minor_words () in
+  let r = f () in
+  ignore (Sys.opaque_identity r);
+  Gc.minor_words () -. w0
+
+let sheet_of_size n =
+  let b = Buffer.create ((n * 20) + 32) in
+  let out = Fmt.with_buffer b in
+  for i = 1 to n do
+    Fmt.pf out ".c%d{--p%d:%d}" i i i
+  done;
+  Buffer.add_string b "#s1{color:red}";
+  match Css.of_string (Buffer.contents b) with
+  | Ok { stylesheet; _ } -> stylesheet
+  | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
+
+(* Flattening the sheet and bucketing its rules by layer depend on the sheet
+   alone, so a caller walking a document should pay for them once. Ten queries
+   against one prepared sheet cost close to one preparation; ten calls of
+   [resolve] pay ten times. *)
+let test_resolve_prepared_shares_the_sheet () =
+  let sheet = sheet_of_size 2_000 in
+  let queries = 10 in
+  let repeated =
+    measure (fun () ->
+        let last = ref [] in
+        for _ = 1 to queries do
+          last := R.resolve sheet s1
+        done;
+        !last)
+  in
+  let shared =
+    measure (fun () ->
+        let prepared = Resolve.prepare sheet in
+        let last = ref [] in
+        for _ = 1 to queries do
+          last := R.resolve_prepared prepared s1
+        done;
+        !last)
+  in
+  let ratio = repeated /. shared in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f repeated vs %.0f shared (%.2fx for %d queries)"
+       repeated shared ratio queries)
+    true (ratio > 3.)
+
+(* [resolve] is [prepare] followed by [resolve_prepared], so the two answer
+   alike on every node. *)
+let test_resolve_prepared_agrees () =
+  let sheet = sheet_of_size 32 in
+  let prepared = Resolve.prepare sheet in
+  List.iter
+    (fun node ->
+      let direct = List.map Declaration.to_string (R.resolve sheet node) in
+      let via =
+        List.map Declaration.to_string (R.resolve_prepared prepared node)
+      in
+      Alcotest.(check (list string)) "prepared resolve agrees" direct via)
+    [ s1; s2; a; b; section ]
+
 let suite =
   ( "resolve",
     [
       Alcotest.test_case "simple selectors" `Quick test_simple;
+      Alcotest.test_case "prepared resolve shares the sheet" `Quick
+        test_resolve_prepared_shares_the_sheet;
+      Alcotest.test_case "prepared resolve agrees with resolve" `Quick
+        test_resolve_prepared_agrees;
       Alcotest.test_case "single combinator" `Quick test_single_combinator;
       Alcotest.test_case "sibling then descendant/child" `Quick
         test_sibling_then_descendant;


### PR DESCRIPTION
`Resolve.Make.resolve` called `Flatten.block` and rebuilt its layer buckets on every query, though both depend on the sheet alone. `Resolve.prepare` does that work once and `resolve_prepared` takes the result; `resolve` is now the two composed, so no caller changes. Ten queries against a 2,000-rule sheet allocate 482K words through `resolve` and 104K through a shared `prepare`.
