### PR TITLE
inline: decide liveness through indexes and a worklist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -699,6 +699,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- `Css.inline_vars` decides which variables are live through indexes and a
+  worklist rather than scanning its accumulator, so the pass no longer costs a
+  square in the variable count. On a 12,800-variable sheet the liveness phase
+  drops from 1.2s to 0.007s (#568)
 - `Resolve.prepare` and `Resolve.Make.resolve_prepared` split the sheet-only
   work out of `resolve`, so a caller walking a document flattens the nesting
   and buckets the rules by layer once rather than per node. Ten queries against

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -918,55 +918,91 @@ let visible_refs ~path_visible consumers path =
       if path_visible ~scope_path:path ~consumer_path:cp then refs else [])
     consumers
 
-let marked_live live (path, sel, name) =
-  List.exists (fun (p, s, n) -> p = path && s = sel && n = name) !live
+(* Each question the liveness fixpoint asks used to scan a whole list, which
+   made the walk cost a square in the variable count. Index them once: the
+   reference names a path can see, the customs answering to a name, and the
+   customs sharing a scope. *)
+let index_customs key_of customs =
+  let table = Hashtbl.create 64 in
+  List.iter
+    (fun custom ->
+      let key = key_of custom in
+      let prev = Option.value ~default:[] (Hashtbl.find_opt table key) in
+      Hashtbl.replace table key (custom :: prev))
+    customs;
+  fun key -> Option.value ~default:[] (Hashtbl.find_opt table key)
 
-let mark_live live entry =
-  if not (marked_live live entry) then live := entry :: !live
+let visible_ref_sets ~path_visible ~consumers =
+  let cache = Hashtbl.create 16 in
+  fun path ->
+    match Hashtbl.find_opt cache path with
+    | Some set -> set
+    | None ->
+        let set =
+          List.fold_left
+            (fun acc name -> Pp.String_set.add name acc)
+            Pp.String_set.empty
+            (visible_refs ~path_visible consumers path)
+        in
+        Hashtbl.replace cache path set;
+        set
 
-let live_at_scope live ~path ~sel =
-  List.exists (fun (p, s, _) -> p = path && s = sel) !live
-
-let mark_referenced_custom ~path_visible ~live ~consumer_path ref_name
-    (b_path, b_sel, b_name, _) =
-  if
-    b_name = ref_name
-    && path_visible ~scope_path:b_path ~consumer_path
-    && not (marked_live live (b_path, b_sel, b_name))
-  then mark_live live (b_path, b_sel, b_name)
+(* A scope enters the queue the first time anything in it goes live, and every
+   custom in a live scope propagates - which is what the scan-to-fixpoint did,
+   since it gated on the scope rather than on the entry. *)
+let live_marker () =
+  let live = Hashtbl.create 64 in
+  let live_scopes = Hashtbl.create 64 in
+  let pending = Queue.create () in
+  let mark (path, sel, name) =
+    if not (Hashtbl.mem live (path, sel, name)) then begin
+      Hashtbl.replace live (path, sel, name) ();
+      if not (Hashtbl.mem live_scopes (path, sel)) then begin
+        Hashtbl.replace live_scopes (path, sel) ();
+        Queue.add (path, sel) pending
+      end
+    end
+  in
+  (live, pending, mark)
 
 let live_customs ~consumers ~customs =
   let path_visible ~scope_path ~consumer_path =
     at_path_prefix ~outer:scope_path ~inner:consumer_path
   in
-  let live = ref [] in
+  let visible_ref_set = visible_ref_sets ~path_visible ~consumers in
+  let by_name = index_customs (fun (_, _, name, _) -> name) customs in
+  let by_scope = index_customs (fun (path, sel, _, _) -> (path, sel)) customs in
+  let live, pending, mark = live_marker () in
   (* Seed: every custom whose scope has a path-compatible consumer referencing
      its name is directly live. *)
   List.iter
     (fun (path, sel, name, _) ->
-      if List.mem name (visible_refs ~path_visible consumers path) then
-        mark_live live (path, sel, name))
+      if Pp.String_set.mem name (visible_ref_set path) then
+        mark (path, sel, name))
     customs;
   (* Propagate: if a live custom [A] references a name [N], any custom [B] named
-     [N] at a path that contains [A]'s path is also live. Iterate to
-     fixpoint. *)
-  let propagate_from (a_path, a_sel, _, a_refs) =
-    if live_at_scope live ~path:a_path ~sel:a_sel then
-      List.iter
-        (fun ref_name ->
-          List.iter
-            (mark_referenced_custom ~path_visible ~live ~consumer_path:a_path
-               ref_name)
-            customs)
-        a_refs
-  in
-  let changed = ref true in
-  while !changed do
-    let before = List.length !live in
-    List.iter propagate_from customs;
-    changed := List.length !live > before
+     [N] at a path that contains [A]'s path is also live. *)
+  while not (Queue.is_empty pending) do
+    let a_path, a_sel = Queue.pop pending in
+    List.iter
+      (fun (_, _, _, a_refs) ->
+        List.iter
+          (fun ref_name ->
+            List.iter
+              (fun (b_path, b_sel, b_name, _) ->
+                if path_visible ~scope_path:b_path ~consumer_path:a_path then
+                  mark (b_path, b_sel, b_name))
+              (by_name ref_name))
+          a_refs)
+      (by_scope (a_path, a_sel))
   done;
-  !live
+  (* Read the answer off [customs], so it does not depend on the order the queue
+     happened to take. *)
+  List.filter_map
+    (fun (path, sel, name, _) ->
+      if Hashtbl.mem live (path, sel, name) then Some (path, sel, name)
+      else None)
+    customs
 
 let same_live_custom (a_path, a_sel, a_name) (b_path, b_sel, b_name, _) =
   a_path = b_path && a_sel = b_sel && a_name = b_name
@@ -1023,18 +1059,22 @@ let normalize_custom_value decl =
         Declaration.map_custom_value (fun _ -> canonical) decl
       with Cursor.Parse_error _ -> decl)
 
-let custom_is_live ~keep ~live_set ~at_path ~selector name =
-  List.mem name keep
-  || List.exists
-       (fun (p, s, n) -> p = at_path && s = selector && n = name)
-       live_set
+(* [keep] and [live_set] are fixed for the whole walk, and the walk asks about
+   them once per declaration, so scanning either one costs a square in the
+   declaration count. Read them into a set and a table first. *)
+let live_lookup ~keep ~live_set =
+  let kept = Pp.String_set.of_list keep in
+  let live = Hashtbl.create (List.length live_set) in
+  List.iter (fun entry -> Hashtbl.replace live entry ()) live_set;
+  fun ~at_path ~selector name ->
+    Pp.String_set.mem name kept || Hashtbl.mem live (at_path, selector, name)
 
-let filter_live_custom_decls ~keep ~live_set ~at_path ~selector =
+let filter_live_custom_decls ~is_live ~at_path ~selector =
   List.filter_map (fun d ->
       match custom_name d with
       | None -> Some d
       | Some name ->
-          if custom_is_live ~keep ~live_set ~at_path ~selector name then
+          if is_live ~at_path ~selector name then
             Some (normalize_custom_value d)
           else None)
 
@@ -1054,8 +1094,9 @@ let strip_dead_declarations ~filter_decls ~parents ~at_path decls :
   | decls -> Some (Declarations decls)
 
 let strip_dead ~keep ~live_set stmts =
+  let is_live = live_lookup ~keep ~live_set in
   let filter_decls ~at_path ~selector =
-    filter_live_custom_decls ~keep ~live_set ~at_path ~selector
+    filter_live_custom_decls ~is_live ~at_path ~selector
   in
   let rec map_stmts ~parents ~at_path stmts =
     List.filter_map (map_stmt ~parents ~at_path) stmts

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -671,6 +671,31 @@ let test_inline_at_path_containment () =
     "@media print{:root{--x:red}}@media screen{.a{color:var(--x)}}"
     "@media screen{.a{color:var(--x)}}"
 
+(* Liveness is decided by a fixpoint: a variable is live when a rule that can
+   see it reads it, and a variable read by a live one is live too. The chain
+   below is only reachable through several rounds of that propagation, and each
+   link sits in a different at-rule scope, so it also pins the visibility rule
+   the propagation carries. The tail is dead and must go. *)
+let test_inline_vars_liveness_propagates_through_scopes () =
+  let css =
+    String.concat ""
+      [
+        ":root{--a:red;--dead:blue}";
+        "@media print{:root{--b:var(--a)}}";
+        "@media print{@supports (display:grid){:root{--c:var(--b)}}}";
+        "@media print{@supports (display:grid){.x{color:var(--c)}}}";
+      ]
+  in
+  let out = minified (Css.inline_vars (parse css)) in
+  Alcotest.(check bool)
+    ("the chain resolves to its root: " ^ out)
+    true
+    (holds_substring "color:red" out);
+  Alcotest.(check bool)
+    ("the unread variable is dropped: " ^ out)
+    false
+    (holds_substring "--dead" out)
+
 (* --- allocation / complexity guard --- *)
 
 let measure f =
@@ -777,6 +802,8 @@ let test_inline_keeps_a_page_break_property_from_css () =
 let suite =
   ( "inline",
     [
+      Alcotest.test_case "inline vars propagate liveness across scopes" `Quick
+        test_inline_vars_liveness_propagates_through_scopes;
       Alcotest.test_case "inline vars contain a definition to its at-rule path"
         `Quick test_inline_at_path_containment;
       Alcotest.test_case "inline vars cost stays linear in at-rule depth" `Quick


### PR DESCRIPTION
The liveness fixpoint answered every question by scanning a list that grows with the variable count, and rescanned every custom each round, so it cost a square in the variable count. The three lookups are now indexed by path, by name and by scope, liveness is a table, and a scope enters the worklist once. Phase timings on a 12,800-variable sheet: liveness 1.2s before, 0.007s after.

Worth flagging for whoever takes the next step: with liveness fixed, `substitute` is what the item's headline number was actually measuring, at 1.06s of the remaining 1.20s. `lookup_visible_custom` scans the visible-custom list per declaration. I have added that to the backlog rather than widening this PR.
