### PR TITLE
preflight: record why the gain stays a raw-byte proxy

### DIFF
--- a/lib/preflight.ml
+++ b/lib/preflight.ml
@@ -81,6 +81,16 @@ let source_units t = t.source_units
    selector list is paid for, so discount it. *)
 let estimated_gain t = t.identical_body_gain + (t.shared_declaration_gain / 4)
 
+(* The gain is a raw-byte proxy, and the transfer gate in [Factor] later judges
+   the same factoring on compressed size, so a segment admitted here can still
+   be thrown away. Measured over the 30-file satcss corpus: 44 fixpoints run, 4
+   reverted, and those 4 account for 0.20s of the 1.01s spent factoring.
+
+   Scoring compressed size here instead is not available: the gate compares the
+   factored rendering against the unfactored one, and producing the factored
+   rendering is the work this gate exists to avoid. What the reverts cost is
+   bounded another way, by [Factor.near_reverted], which remembers a large
+   reverted segment's shape and suppresses the ones that resemble it. *)
 let useful t =
   t.declaration_count <= small_declaration_threshold
   ||

--- a/lib/preflight.mli
+++ b/lib/preflight.mli
@@ -20,4 +20,9 @@ val estimated_gain : t -> int
 
 val useful : t -> bool
 (** [useful t] is [true] when the estimated gain justifies running the full
-    factoring fixpoint. Small inputs always return [true]. *)
+    factoring fixpoint. Small inputs always return [true].
+
+    The gain is a raw-byte proxy. A segment it admits can still be reverted by
+    the compressed-size gate that judges the finished factoring, and the
+    estimate cannot anticipate that: deciding it needs the factored rendering,
+    which is the work this gate exists to avoid. *)


### PR DESCRIPTION
The backlog asked for a compression-aware `Preflight.useful`, with a benchmark first. The benchmark says leave it alone. Over the 30-file satcss corpus the preflight skips nothing; 4 of 44 fixpoints are reverted by the transfer gate, costing 0.20s of the 1.01s spent factoring. Making the estimate compression-aware is not available at that point anyway, since deciding it needs the factored rendering that the gate exists to avoid producing. `Factor.near_reverted` already bounds the repeat cost by remembering a large reverted segment and suppressing ones that resemble it. This PR records that in the code so the question is settled rather than re-opened; no behaviour changes.
