### PR TITLE
font-face: resolve a var() in every typed descriptor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -596,6 +596,12 @@ recorded cases carrying six minifiers' answers.
 
 ### Custom properties
 
+- A `var()` in the `font-style`, `font-weight`, `font-stretch`,
+  `font-display`, `font-feature-settings` or `font-variation-settings`
+  descriptor of an `@font-face` is resolved by `Css.inline_vars` instead of
+  being dropped at parse time, joining `src` and `unicode-range`. A descriptor
+  whose typed value has no `Var` arm to hold the reference is still dropped
+  with a warning, as a browser does (#571)
 - `Css.inline_vars` resolves every `@page` descriptor under one unit policy.
   `margin-top` alone kept the authored unit, so one `@page` block answered
   `1cm` for it and `37.79527559px` for the `margin-left` beside it (#555)

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -586,25 +586,64 @@ let simplify_font_src_descriptor visible entries =
   in
   simplify ~visited:[] entries
 
-let unicode_range_var_fallback ~simplify ~visited
-    (var : Properties.unicode_range Values.var) : Properties.unicode_range =
-  match var.Values.fallback with
-  | Values.Fallback value -> simplify ~visited value
-  | _ -> (Properties.Var var : Properties.unicode_range)
-
-let simplify_unicode_range_descriptor visible (value : Properties.unicode_range)
-    =
-  let rec simplify ~visited : Properties.unicode_range -> _ = function
-    | Properties.Var var when not (List.mem var.Values.name visited) -> (
-        match
-          lookup_visible_custom visible var.Values.name
-            Properties.read_unicode_range
-        with
-        | Some value -> simplify ~visited:(var.Values.name :: visited) value
-        | None -> unicode_range_var_fallback ~simplify ~visited var)
-    | value -> value
+(* Every descriptor whose value type carries a [Var] arm resolves the same way:
+   follow the reference to the custom it names, then the references that value
+   holds in turn, and stop on a name already seen so a cycle terminates. What
+   differs per descriptor is only how to read the value and how to see a [Var],
+   so take those three and share the walk. *)
+let simplify_typed_var visible ~read ~(as_var : 'a -> 'a Values.var option)
+    ~(of_var : 'a Values.var -> 'a) (value : 'a) : 'a =
+  let rec simplify ~visited (value : 'a) : 'a =
+    match as_var value with
+    | Some var when not (List.mem var.Values.name visited) -> (
+        match lookup_visible_custom visible var.Values.name read with
+        | Some found -> simplify ~visited:(var.Values.name :: visited) found
+        | None -> (
+            (* Nothing defines the name: CSS Variables 1 sec. 3 falls back to
+               the second argument, and with none the reference stands. *)
+            match (var.Values.fallback : 'a Values.fallback) with
+            | Values.Fallback fallback -> simplify ~visited fallback
+            | Values.Empty | Values.Empty2 | Values.None
+            | Values.Syntax_fallback _ | Values.Var_fallback _ ->
+                of_var var))
+    | Some _ | None -> value
   in
   simplify ~visited:[] value
+
+let simplify_unicode_range_descriptor visible =
+  simplify_typed_var visible ~read:Properties.read_unicode_range
+    ~as_var:(function Properties.Var v -> Some v | _ -> None)
+    ~of_var:(fun v -> (Properties.Var v : Properties.unicode_range))
+
+let simplify_font_style_descriptor visible =
+  simplify_typed_var visible ~read:Properties.read_font_style
+    ~as_var:(function Properties.Var v -> Some v | _ -> None)
+    ~of_var:(fun v -> (Properties.Var v : Properties.font_style))
+
+let simplify_font_weight_descriptor visible =
+  simplify_typed_var visible ~read:Properties.read_font_weight
+    ~as_var:(function Properties.Var v -> Some v | _ -> None)
+    ~of_var:(fun v -> (Properties.Var v : Properties.font_weight))
+
+let simplify_font_stretch_descriptor visible =
+  simplify_typed_var visible ~read:Properties.read_font_stretch
+    ~as_var:(function Properties.Var v -> Some v | _ -> None)
+    ~of_var:(fun v -> (Properties.Var v : Properties.font_stretch))
+
+let simplify_font_display_descriptor visible =
+  simplify_typed_var visible ~read:Properties.read_font_display
+    ~as_var:(function Properties.Var v -> Some v | _ -> None)
+    ~of_var:(fun v -> (Properties.Var v : Properties.font_display))
+
+let simplify_font_feature_settings_descriptor visible =
+  simplify_typed_var visible ~read:Properties.read_font_feature_settings
+    ~as_var:(function Properties.Var v -> Some v | _ -> None)
+    ~of_var:(fun v -> (Properties.Var v : Properties.font_feature_settings))
+
+let simplify_font_variation_settings_descriptor visible =
+  simplify_typed_var visible ~read:Properties.read_font_variation_settings
+    ~as_var:(function Properties.Var v -> Some v | _ -> None)
+    ~of_var:(fun v -> (Properties.Var v : Properties.font_variation_settings))
 
 (* [resolve_font_face_var] names the descriptors whose var() survives the parse
    and asks for one resolver each, so this pass and the parser cannot grow
@@ -615,6 +654,13 @@ let simplify_font_face_descriptor visible descriptor =
     resolve_font_face_var
       ~src:(simplify_font_src_descriptor visible)
       ~unicode_range:(List.map (simplify_unicode_range_descriptor visible))
+      ~font_style:(simplify_font_style_descriptor visible)
+      ~font_weight:(simplify_font_weight_descriptor visible)
+      ~font_stretch:(simplify_font_stretch_descriptor visible)
+      ~font_display:(simplify_font_display_descriptor visible)
+      ~font_feature_settings:(simplify_font_feature_settings_descriptor visible)
+      ~font_variation_settings:
+        (simplify_font_variation_settings_descriptor visible)
       descriptor
   with
   | Some resolved -> resolved

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1763,8 +1763,8 @@ let rec read_font_stretch t : font_stretch =
     ~var:(fun t -> Var (read_var read_font_stretch t))
     ~default:read_percentage t
 
-let read_font_display t : font_display =
-  Cursor.enum "font-display"
+let rec read_font_display t : font_display =
+  Cursor.enum_or_var "font-display"
     [
       ("auto", (Auto : font_display));
       ("block", Block);
@@ -1772,6 +1772,7 @@ let read_font_display t : font_display =
       ("fallback", Fallback);
       ("optional", Optional);
     ]
+    ~var:(fun t -> Var (read_var read_font_display t))
     t
 
 let read_unicode_single start_value width =

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2374,7 +2374,10 @@ let descriptor_resolves_var name =
   match read_font_face_desc name probe with
   | descriptor ->
       Option.is_some
-        (resolve_font_face_var ~src:Fun.id ~unicode_range:Fun.id descriptor)
+        (resolve_font_face_var ~src:Fun.id ~unicode_range:Fun.id
+           ~font_style:Fun.id ~font_weight:Fun.id ~font_stretch:Fun.id
+           ~font_display:Fun.id ~font_feature_settings:Fun.id
+           ~font_variation_settings:Fun.id descriptor)
   | exception Error.Parse_error _ -> false
 
 let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -342,9 +342,9 @@ type mode = Variables | Inline  (** Rendering mode for CSS output *)
 let equal_cascade_origin (a : cascade_origin) b = a = b
 let equal (a : stylesheet) b = a = b
 
-(** [resolve_font_face_var ~src ~unicode_range descriptor] is [descriptor] with
-    its value rewritten by the matching resolver, or [None] when it holds no
-    value a [var()] can be resolved in.
+(** [resolve_font_face_var ~src ~unicode_range ... descriptor] is [descriptor]
+    with its value rewritten by the matching resolver, or [None] when it holds
+    no value a [var()] can be resolved in.
 
     CSS Variables 1 sec. 3 substitutes [var()] in a property value; an
     [\@font-face] descriptor is not a property, so no descriptor grammar accepts
@@ -353,12 +353,27 @@ let equal (a : stylesheet) b = a = b
     keeps a [var()] only for a descriptor named here, and {!Inline} supplies the
     resolvers. A descriptor added to the table takes another resolver argument,
     so both sides have to answer for it. *)
-let resolve_font_face_var ~src ~unicode_range = function
+let resolve_font_face_var ~src ~unicode_range ~font_style ~font_weight
+    ~font_stretch ~font_display ~font_feature_settings ~font_variation_settings
+    = function
   | Src value -> Some (Src (src value))
   | Unicode_range values -> Some (Unicode_range (unicode_range values))
-  | Font_family _ | Font_style _ | Font_style_range _ | Font_weight _
-  | Font_weight_range _ | Font_stretch _ | Font_stretch_range _ | Font_display _
-  | Font_variant _ | Font_feature_settings _ | Font_variation_settings _
-  | Font_tech _ | Size_adjust _ | Ascent_override _ | Descent_override _
-  | Line_gap_override _ ->
+  | Font_style value -> Some (Font_style (font_style value))
+  | Font_style_range (low, high) ->
+      Some (Font_style_range (font_style low, font_style high))
+  | Font_weight value -> Some (Font_weight (font_weight value))
+  | Font_weight_range (low, high) ->
+      Some (Font_weight_range (font_weight low, font_weight high))
+  | Font_stretch value -> Some (Font_stretch (font_stretch value))
+  | Font_display value -> Some (Font_display (font_display value))
+  | Font_feature_settings value ->
+      Some (Font_feature_settings (font_feature_settings value))
+  | Font_variation_settings value ->
+      Some (Font_variation_settings (font_variation_settings value))
+  (* The rest hold a value type with no [Var] arm to park an unresolved
+     reference in, so the parser has nowhere to keep one and drops the
+     declaration as a browser does. *)
+  | Font_family _ | Font_stretch_range _ | Font_variant _ | Font_tech _
+  | Size_adjust _ | Ascent_override _ | Descent_override _ | Line_gap_override _
+    ->
       Option.None

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -310,10 +310,14 @@ let spec_fontface_metric_numeric_edges () =
         (String.concat "\n" accepted)
 
 (* CSS Custom Properties 1 sec. 3 substitutes var() in properties only, and
-   @font-face descriptors are not properties: no descriptor grammar accepts it.
-   Every one of them is therefore dropped with a warning while the rest of the
-   block is kept (CSS Fonts 4 sec. 4.1, CSS Syntax 3 sec. 5.5.5), and
-   ~strict:true turns that warning into an error. *)
+   @font-face descriptors are not properties: no descriptor grammar accepts it,
+   so a browser drops the declaration. cascade substitutes at build time
+   instead, and can only do so for a descriptor whose typed value has somewhere
+   to park an unresolved reference. The ones below have no [Var] arm, so there
+   is nothing to keep and the declaration is dropped with a warning while the
+   rest of the block survives (CSS Fonts 4 sec. 4.1, CSS Syntax 3 sec. 5.5.5);
+   ~strict:true turns that warning into an error. The descriptors that do carry
+   one are covered by [spec_fontface_var_descriptor_kept]. *)
 let spec_fontface_var_descriptor_edges () =
   let kept = "@font-face{font-family:Brand;src:url(font.woff2)}" in
   let source descriptor =
@@ -346,8 +350,6 @@ let spec_fontface_var_descriptor_edges () =
     in
     lenient @ strict
   in
-  (* [unicode-range] is exempt for the same reason as [src]: [--inline-vars]
-     resolves its var() at build time, so cascade keeps it. *)
   match
     List.concat_map mismatches
       [
@@ -355,15 +357,61 @@ let spec_fontface_var_descriptor_edges () =
         "ascent-override";
         "descent-override";
         "line-gap-override";
-        "font-display";
-        "font-weight";
-        "font-style";
-        "font-stretch";
+        "font-family";
+        "font-tech";
       ]
   with
   | [] -> ()
   | mismatches ->
       Alcotest.failf "@font-face descriptors keeping var():\n%s"
+        (String.concat "\n" mismatches)
+
+(* The other side of the same decision: a descriptor whose typed value carries a
+   [Var] arm keeps the reference through the parse, with no warning and no
+   strict error, so [Css.inline_vars] can substitute it at build time. Keeping
+   it is only useful because the value is typed; an unresolved one still prints
+   as the [var()] it was. *)
+let spec_fontface_var_descriptor_kept () =
+  let source descriptor =
+    Fmt.str "@font-face{font-family:Brand;src:url(font.woff2);%s:var(--b)}"
+      descriptor
+  in
+  let mismatches descriptor =
+    let input = source descriptor in
+    match Css.of_string input with
+    | Error _ -> [ Fmt.str "%s: lenient parse rejected %S" descriptor input ]
+    | Ok { Css.stylesheet; warnings } -> (
+        let printed = Css.to_string ~minify:true stylesheet |> String.trim in
+        (if String.equal printed input then []
+         else [ Fmt.str "%s: printed %S, expected %S" descriptor printed input ])
+        @ (if warnings = [] then []
+           else
+             [
+               Fmt.str "%s: %d parse warnings, expected none" descriptor
+                 (List.length warnings);
+             ])
+        @
+        match Css.of_string ~strict:true input with
+        | Ok _ -> []
+        | Error _ -> [ Fmt.str "%s: strict parse rejected %S" descriptor input ]
+        )
+  in
+  match
+    List.concat_map mismatches
+      [
+        "src";
+        "unicode-range";
+        "font-style";
+        "font-weight";
+        "font-stretch";
+        "font-display";
+        "font-feature-settings";
+        "font-variation-settings";
+      ]
+  with
+  | [] -> ()
+  | mismatches ->
+      Alcotest.failf "@font-face descriptors dropping var():\n%s"
         (String.concat "\n" mismatches)
 
 (* CSS Fonts 4 sec. 4.2: the [font-family] descriptor *defines* the name used in
@@ -689,6 +737,8 @@ let suite =
         spec_fontface_src_invalid_edges;
       test_case "spec font-face metric numeric edges" `Quick
         spec_fontface_metric_numeric_edges;
+      test_case "spec font-face var() descriptor kept" `Quick
+        spec_fontface_var_descriptor_kept;
       test_case "spec font-face var() descriptor edges" `Quick
         spec_fontface_var_descriptor_edges;
       test_case "spec font-face family descriptor verbatim" `Quick

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -87,7 +87,50 @@ let test_inline_font_face_var_descriptors () =
   in
   let kept = List.map fst (List.filter survives font_face_descriptors) in
   Alcotest.(check (list string))
-    "descriptors the parser keeps a var() for" [ "src"; "unicode-range" ] kept
+    "descriptors the parser keeps a var() for"
+    [
+      "src";
+      "font-style";
+      "font-weight";
+      "font-stretch";
+      "font-display";
+      "unicode-range";
+      "font-feature-settings";
+      "font-variation-settings";
+    ]
+    kept
+
+(* Surviving the parse is only half of it: the value a [var()] stands for has to
+   reach the output. Each row reads a variable whose value the descriptor's own
+   grammar accepts. *)
+let test_inline_font_face_var_resolves () =
+  let resolves (name, value) =
+    let css =
+      String.concat ""
+        [
+          ":root{--v:";
+          value;
+          "}@font-face{font-family:a;src:local(anchor);";
+          name;
+          ":var(--v)}";
+        ]
+    in
+    let inlined = minified (Css.inline_vars (parse css)) in
+    Alcotest.(check bool)
+      (Fmt.str "%s: resolves to %s (%s)" name value inlined)
+      true
+      (holds_substring (name ^ ":" ^ value) inlined)
+  in
+  List.iter resolves
+    [
+      ("font-style", "italic");
+      ("font-weight", "700");
+      ("font-stretch", "50%");
+      ("font-display", "swap");
+      ("unicode-range", "U+0-7f");
+      ("font-feature-settings", "normal");
+      ("font-variation-settings", "normal");
+    ]
 
 let test_inline_substitutes_vars () =
   check_inline ~optimized:".button{color:#00f}"
@@ -802,6 +845,8 @@ let test_inline_keeps_a_page_break_property_from_css () =
 let suite =
   ( "inline",
     [
+      Alcotest.test_case "inline vars resolve a typed @font-face descriptor"
+        `Quick test_inline_font_face_var_resolves;
       Alcotest.test_case "inline vars propagate liveness across scopes" `Quick
         test_inline_vars_liveness_propagates_through_scopes;
       Alcotest.test_case "inline vars contain a definition to its at-rule path"

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -127,7 +127,9 @@ let test_inline_font_face_var_resolves () =
       ("font-weight", "700");
       ("font-stretch", "50%");
       ("font-display", "swap");
-      ("unicode-range", "U+0-7f");
+      (* CSS Syntax 3 sec. 4.3.10 reads the range case-insensitively and the
+         printer writes the hex digits upper-case. *)
+      ("unicode-range", "U+0-7F");
       ("font-feature-settings", "normal");
       ("font-variation-settings", "normal");
     ]


### PR DESCRIPTION
Six `@font-face` descriptors already carried a `Var` arm on their value type, so the parser had somewhere to keep an unresolved reference, but `resolve_font_face_var` named only `src` and `unicode-range` and the parse-time guard dropped the rest. They now resolve through `Css.inline_vars` like the other two: `font-style`, `font-weight`, `font-stretch`, `font-display`, `font-feature-settings` and `font-variation-settings`. `read_font_display` also had to accept a `var()`, which it did not.

This keeps the browser-matching outcome of #322 and #417 rather than reversing it. A descriptor whose typed value has no `Var` arm - `font-family`, `size-adjust`, the three metric overrides, `font-tech`, `font-variant`, `font-stretch-range` - has nowhere to hold the reference and is still dropped with a warning, and strict parsing still rejects it. Giving those a `Var` arm is a wider change to shared property types and is not attempted here.
