### PR TITLE
selector: back the namespace read off a || combinator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A selector using the column combinator, such as `svg||td` or `a||b`, is read
+  and written back instead of dropped. The namespace read claimed the first
+  bar of the `||` that CSS Selectors 4 sec. 15.2 defines (#572)
 - A rule nested under a pseudo-element parent, such as `.b` in
   `.a::before{.b{color:red}}`, is dropped instead of flattened to
   `.a::before .b`. CSS Selectors 4 sec. 3.6.5 makes that selector invalid and

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -491,6 +491,13 @@ let lookahead_bare_pipe_ns t =
       | _ -> false)
     t
 
+(* CSS Selectors 4 sec. 15.2: [||] is the column combinator, so a pipe opening
+   one never separates a namespace prefix from a name. *)
+let at_column_combinator t =
+  Cursor.lookahead
+    (fun t -> Cursor.try_kind_pair (Token.Delim "|") (Token.Delim "|") t)
+    t
+
 let read_prefixed_ns t =
   let p = Cursor.ident ~keep_case:true t in
   (* Avoid treating '|=' as a namespace separator: peek for the pair. *)
@@ -499,12 +506,15 @@ let read_prefixed_ns t =
       (fun t -> Cursor.try_kind_pair (Token.Delim "|") (Token.Delim "=") t)
       t
   in
-  if is_eq_pair then Cursor.err t "not a namespace";
+  if is_eq_pair || at_column_combinator t then Cursor.err t "not a namespace";
   Cursor.expect '|' t;
   Prefix p
 
 let read_ns_inner t =
-  if Cursor.try_kind_pair (Token.Delim "*") (Token.Delim "|") t then Any
+  if Cursor.try_kind_pair (Token.Delim "*") (Token.Delim "|") t then
+    (* Another pipe means [*||td]: the universal selector, then a column. *)
+    if Cursor.peek_delim t = Some '|' then Cursor.err t "not a namespace"
+    else Any
   else if lookahead_bare_pipe_ns t then (
     Cursor.expect '|' t;
     None)
@@ -1806,7 +1816,10 @@ and read_compound t =
     | Some (Component.Preserved { kind = Token.Whitespace; _ }) -> false
     | _ ->
         (match Cursor.peek_delim t with
-          | Some ('.' | '*' | '|' | '&') -> true
+          | Some ('.' | '*' | '&') -> true
+          (* A pipe extends the compound only as the [|name] prefix; a [||] ends
+             it so [read_complex] can take the column combinator. *)
+          | Some '|' -> lookahead_bare_pipe_ns t
           | _ -> false)
         || Cursor.peek_hash t <> None
         || Cursor.peek_colon t

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -1791,6 +1791,8 @@ let test_ns () =
   none_cursor read_ns "|";
   none_cursor read_ns "||";
   none_cursor read_ns "svg";
+  none_cursor read_ns "svg||";
+  none_cursor read_ns "*||";
 
   (* Test cases that should return None (no namespace found) *)
   none_cursor read_ns "notanamespace";
@@ -1830,6 +1832,24 @@ let test_ns () =
   check "|div";
   check "|*";
   ()
+
+(* CSS Selectors 4 sec. 15.2 makes [||] the column combinator and sec. 6.1 makes
+   [ns|name] a namespaced name, so a pipe that opens a [||] never separates a
+   prefix from a name. *)
+let column_combinator_vs_namespace () =
+  check ~roundtrip:true "svg||td";
+  check ~roundtrip:true "*||td";
+  check ~roundtrip:true "a||b";
+  check ~roundtrip:true "svg|table||svg|td";
+  check ~expected:"a||b" "a || b";
+  check_minified_to "svg||td" "svg || td";
+  check_minified_to "*||td" "* || td";
+
+  (* The namespace forms a column combinator must leave alone. *)
+  check "svg|td";
+  check "*|a";
+  check "|a";
+  check "svg|a[*|href]"
 
 let test_nth () =
   (* Test nth type -- odd/even are canonicalized to 2n+1/2n *)
@@ -2584,6 +2604,8 @@ let suite =
       (* Core type tests *)
       test_case "combinator" `Quick test_combinator;
       test_case "ns" `Quick test_ns;
+      test_case "column combinator vs namespace" `Quick
+        column_combinator_vs_namespace;
       test_case "nth" `Quick test_nth;
       test_case "selector" `Quick test_selector;
       test_case "aria_attr" `Quick test_aria_attr;


### PR DESCRIPTION
A selector using the column combinator was dropped: `read_prefixed_ns` took the first bar of `||` as a namespace separator and left `|td`, which the rest of the reader could not read. `read_complex` already models `Column` correctly, so the namespace read and the compound reader just had to back off when the bar opens a `||`. This turned out wider than a namespace defect: `a||b` and `*||td`, with no namespace anywhere, were dropped too.
