### PR TITLE
font-face: resolve a var() in the metric and variant descriptors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -599,6 +599,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Custom properties
 
+- A `var()` in the `ascent-override`, `descent-override`, `line-gap-override`
+  or `font-variant` descriptor of an `@font-face` is resolved by
+  `Css.inline_vars` instead of being dropped at parse time. Their value types
+  carry the `Var` arm the other typed descriptors already had (#573)
 - A `var()` in the `font-style`, `font-weight`, `font-stretch`,
   `font-display`, `font-feature-settings` or `font-variation-settings`
   descriptor of an `@font-face` is resolved by `Css.inline_vars` instead of

--- a/fuzz/fuzz_font_face.ml
+++ b/fuzz/fuzz_font_face.ml
@@ -84,7 +84,9 @@ let test_src_roundtrip buf =
 
 let test_metric_override_non_negative buf =
   match parse_metric buf with
-  | None | Some Css.Font_face.Normal -> ()
+  (* A [var()] stands for a value the inline pass has yet to substitute, so
+     there is no percentage to bound here. *)
+  | None | Some Css.Font_face.Normal | Some (Css.Font_face.Var _) -> ()
   | Some (Css.Font_face.Percent p) ->
       if Float.compare p 0. < 0 then
         fail "metric override parsed a negative percentage"

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -4,13 +4,21 @@ open Syntax
 
 (** {1 Metric Override Types} *)
 
-(** Metric override value - either "normal" or a percentage. Used for
-    ascent-override, descent-override, line-gap-override. *)
-type metric_override = Normal | Percent of float
+(** Metric override value - either "normal", a percentage, or an unresolved
+    [var()]. Used for ascent-override, descent-override, line-gap-override. *)
+type metric_override =
+  | Normal
+  | Percent of float
+  | Var of metric_override Values.var
 
-let string_of_metric_override = function
-  | Normal -> "normal"
-  | Percent p -> Pp.string_of_float p ^ "%"
+let rec pp_metric_override ctx = function
+  | Normal -> Pp.string ctx "normal"
+  | Percent p ->
+      Pp.string ctx (Pp.string_of_float p);
+      Pp.char ctx '%'
+  | Var var -> Values.pp_var pp_metric_override ctx var
+
+let string_of_metric_override = Pp.to_string ~minify:false pp_metric_override
 
 (** {1 Size Adjust} *)
 
@@ -158,7 +166,7 @@ let valid_percentage p = Float.is_finite p && p >= 0.
 (* CSS Fonts 4 sec. 4.10: [normal | <percentage [0,inf]>]. The token is left in
    place on a mismatch, so the error carries the offending value's span rather
    than whatever follows it. *)
-let read_metric_override t =
+let rec read_metric_override t : metric_override =
   match Cursor.peek t with
   | Some (Component.Preserved { kind = Token.Ident "normal"; _ }) ->
       Cursor.skip t;
@@ -167,6 +175,9 @@ let read_metric_override t =
     when valid_percentage number.Token.value ->
       Cursor.skip t;
       Percent number.Token.value
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii name = "var" ->
+      Var (Values.read_var read_metric_override t)
   | Some _ | None -> Cursor.err_invalid t "metric override"
 
 (* CSS Fonts 4 sec. 4.11: [<percentage [0,inf]>]. *)

--- a/lib/font_face.mli
+++ b/lib/font_face.mli
@@ -2,9 +2,15 @@
 
 (** {1 Metric Override Types} *)
 
-(** Metric override value - either "normal" or a percentage. Used for
-    ascent-override, descent-override, line-gap-override. *)
-type metric_override = Normal | Percent of float
+(** Metric override value - either "normal", a percentage, or an unresolved
+    [var()]. Used for ascent-override, descent-override, line-gap-override. *)
+type metric_override =
+  | Normal
+  | Percent of float
+  | Var of metric_override Values.var
+
+val pp_metric_override : metric_override Pp.t
+(** [pp_metric_override] renders a metric override. *)
 
 val string_of_metric_override : metric_override -> string
 (** [string_of_metric_override m] converts a metric override to its CSS string
@@ -67,8 +73,9 @@ val to_string : ?minify:bool -> t -> string
 
 val read_metric_override : Cursor.t -> metric_override
 (** [read_metric_override t] reads one [ascent-override] / [descent-override] /
-    [line-gap-override] value. A mismatch raises {!Cursor.exception-Parse_error}
-    without consuming, so the error carries the offending value's span. *)
+    [line-gap-override] value, or a [var()] standing for one. A mismatch raises
+    {!Cursor.exception-Parse_error} without consuming, so the error carries the
+    offending value's span. *)
 
 val read_size_adjust : Cursor.t -> size_adjust
 (** [read_size_adjust t] reads one [size-adjust] value, like

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -645,6 +645,19 @@ let simplify_font_variation_settings_descriptor visible =
     ~as_var:(function Properties.Var v -> Some v | _ -> None)
     ~of_var:(fun v -> (Properties.Var v : Properties.font_variation_settings))
 
+let simplify_font_variant_descriptor visible =
+  simplify_typed_var visible ~read:read_font_variant_descriptor
+    ~as_var:(function Var v -> Some v | _ -> Option.None)
+    ~of_var:(fun v -> (Var v : font_variant_descriptor))
+
+(* One resolver covers [ascent-override], [descent-override] and
+   [line-gap-override]: CSS Fonts 4 sec. 4.10 gives the three the same
+   grammar. *)
+let simplify_metric_override_descriptor visible =
+  simplify_typed_var visible ~read:Font_face.read_metric_override
+    ~as_var:(function Font_face.Var v -> Some v | _ -> Option.None)
+    ~of_var:(fun v -> (Font_face.Var v : Font_face.metric_override))
+
 (* [resolve_font_face_var] names the descriptors whose var() survives the parse
    and asks for one resolver each, so this pass and the parser cannot grow
    apart: a descriptor added to that table takes a resolver argument the call
@@ -658,9 +671,11 @@ let simplify_font_face_descriptor visible descriptor =
       ~font_weight:(simplify_font_weight_descriptor visible)
       ~font_stretch:(simplify_font_stretch_descriptor visible)
       ~font_display:(simplify_font_display_descriptor visible)
+      ~font_variant:(simplify_font_variant_descriptor visible)
       ~font_feature_settings:(simplify_font_feature_settings_descriptor visible)
       ~font_variation_settings:
         (simplify_font_variation_settings_descriptor visible)
+      ~metric_override:(simplify_metric_override_descriptor visible)
       descriptor
   with
   | Some resolved -> resolved

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1090,11 +1090,12 @@ let pp_font_variant_descriptor_value ctx = function
   | Numeric value -> Properties.pp_font_variant_numeric_token ctx value
   | East_asian value -> Properties.pp_east_asian_feature ctx value
 
-let pp_font_variant_descriptor ctx = function
+let rec pp_font_variant_descriptor ctx = function
   | Normal -> Pp.string ctx "normal"
   | None -> Pp.string ctx "none"
   | Values values ->
       Pp.list ~sep:Pp.space pp_font_variant_descriptor_value ctx values
+  | Var var -> Values.pp_var pp_font_variant_descriptor ctx var
 
 let pp_font_face_descriptor : font_face_descriptor Pp.t =
  fun ctx desc ->
@@ -1152,17 +1153,11 @@ let pp_font_face_descriptor : font_face_descriptor Pp.t =
         (fun ctx v -> Pp.string ctx (Font_face.string_of_size_adjust v))
         value
   | Ascent_override value ->
-      pp_descriptor "ascent-override"
-        (fun ctx v -> Pp.string ctx (Font_face.string_of_metric_override v))
-        value
+      pp_descriptor "ascent-override" Font_face.pp_metric_override value
   | Descent_override value ->
-      pp_descriptor "descent-override"
-        (fun ctx v -> Pp.string ctx (Font_face.string_of_metric_override v))
-        value
+      pp_descriptor "descent-override" Font_face.pp_metric_override value
   | Line_gap_override value ->
-      pp_descriptor "line-gap-override"
-        (fun ctx v -> Pp.string ctx (Font_face.string_of_metric_override v))
-        value
+      pp_descriptor "line-gap-override" Font_face.pp_metric_override value
 
 let pp_counter_style_system ctx = function
   | Cyclic -> Pp.string ctx "cyclic"
@@ -2277,7 +2272,7 @@ let read_font_variant_descriptor_value r =
   | Some value -> value
   | None -> Cursor.err_invalid r ("font-variant descriptor value: " ^ ident)
 
-let read_font_variant_descriptor r =
+let read_font_variant_keywords r : font_variant_descriptor =
   let at_value_end () = Cursor.is_done r || Cursor.peek_semicolon r in
   let snap = Cursor.save r in
   let first = Cursor.ident ~keep_case:false r in
@@ -2296,6 +2291,14 @@ let read_font_variant_descriptor r =
       if values = [] then Cursor.err_invalid r "font-variant descriptor";
       validate_font_variant_descriptor_values r values;
       Values values
+
+let rec read_font_variant_descriptor r : font_variant_descriptor =
+  Cursor.ws r;
+  match Cursor.peek r with
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii name = "var" ->
+      Var (Values.read_var read_font_variant_descriptor r)
+  | Some _ | None -> read_font_variant_keywords r
 
 let read_font_face_desc name r =
   match name with
@@ -2376,8 +2379,9 @@ let descriptor_resolves_var name =
       Option.is_some
         (resolve_font_face_var ~src:Fun.id ~unicode_range:Fun.id
            ~font_style:Fun.id ~font_weight:Fun.id ~font_stretch:Fun.id
-           ~font_display:Fun.id ~font_feature_settings:Fun.id
-           ~font_variation_settings:Fun.id descriptor)
+           ~font_display:Fun.id ~font_variant:Fun.id
+           ~font_feature_settings:Fun.id ~font_variation_settings:Fun.id
+           ~metric_override:Fun.id descriptor)
   | exception Error.Parse_error _ -> false
 
 let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -357,6 +357,11 @@ val read_rule : ?nested:bool -> Cursor.t -> rule
 val read_block : Cursor.t -> block
 (** [read_block r] reads a CSS block from the reader. *)
 
+val read_font_variant_descriptor : Cursor.t -> font_variant_descriptor
+(** [read_font_variant_descriptor r] reads the [font-variant] descriptor of an
+    [\@font-face] rule, or a [var()] standing for one. {!Inline} reads a custom
+    property back through it when resolving such a reference. *)
+
 val read : Cursor.t -> t
 (** [read r] reads a complete CSS stylesheet from the cursor. Raises
     {!Cursor.Parse_error} on the first validator failure; use

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -280,6 +280,7 @@ and font_variant_descriptor =
   | Normal
   | None
   | Values of font_variant_descriptor_value list
+  | Var of font_variant_descriptor Values.var
 
 and font_variant_descriptor_value =
   | Ligature of Properties.font_variant_ligature
@@ -354,8 +355,8 @@ let equal (a : stylesheet) b = a = b
     resolvers. A descriptor added to the table takes another resolver argument,
     so both sides have to answer for it. *)
 let resolve_font_face_var ~src ~unicode_range ~font_style ~font_weight
-    ~font_stretch ~font_display ~font_feature_settings ~font_variation_settings
-    = function
+    ~font_stretch ~font_display ~font_variant ~font_feature_settings
+    ~font_variation_settings ~metric_override = function
   | Src value -> Some (Src (src value))
   | Unicode_range values -> Some (Unicode_range (unicode_range values))
   | Font_style value -> Some (Font_style (font_style value))
@@ -366,14 +367,16 @@ let resolve_font_face_var ~src ~unicode_range ~font_style ~font_weight
       Some (Font_weight_range (font_weight low, font_weight high))
   | Font_stretch value -> Some (Font_stretch (font_stretch value))
   | Font_display value -> Some (Font_display (font_display value))
+  | Font_variant value -> Some (Font_variant (font_variant value))
   | Font_feature_settings value ->
       Some (Font_feature_settings (font_feature_settings value))
   | Font_variation_settings value ->
       Some (Font_variation_settings (font_variation_settings value))
+  | Ascent_override value -> Some (Ascent_override (metric_override value))
+  | Descent_override value -> Some (Descent_override (metric_override value))
+  | Line_gap_override value -> Some (Line_gap_override (metric_override value))
   (* The rest hold a value type with no [Var] arm to park an unresolved
      reference in, so the parser has nowhere to keep one and drops the
      declaration as a browser does. *)
-  | Font_family _ | Font_stretch_range _ | Font_variant _ | Font_tech _
-  | Size_adjust _ | Ascent_override _ | Descent_override _ | Line_gap_override _
-    ->
+  | Font_family _ | Font_stretch_range _ | Font_tech _ | Size_adjust _ ->
       Option.None

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -351,15 +351,7 @@ let spec_fontface_var_descriptor_edges () =
     lenient @ strict
   in
   match
-    List.concat_map mismatches
-      [
-        "size-adjust";
-        "ascent-override";
-        "descent-override";
-        "line-gap-override";
-        "font-family";
-        "font-tech";
-      ]
+    List.concat_map mismatches [ "size-adjust"; "font-family"; "font-tech" ]
   with
   | [] -> ()
   | mismatches ->
@@ -405,8 +397,12 @@ let spec_fontface_var_descriptor_kept () =
         "font-weight";
         "font-stretch";
         "font-display";
+        "font-variant";
         "font-feature-settings";
         "font-variation-settings";
+        "ascent-override";
+        "descent-override";
+        "line-gap-override";
       ]
   with
   | [] -> ()

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -95,8 +95,12 @@ let test_inline_font_face_var_descriptors () =
       "font-stretch";
       "font-display";
       "unicode-range";
+      "font-variant";
       "font-feature-settings";
       "font-variation-settings";
+      "ascent-override";
+      "descent-override";
+      "line-gap-override";
     ]
     kept
 
@@ -130,8 +134,13 @@ let test_inline_font_face_var_resolves () =
       (* CSS Syntax 3 sec. 4.3.10 reads the range case-insensitively and the
          printer writes the hex digits upper-case. *)
       ("unicode-range", "U+0-7F");
+      ("font-variant", "normal");
+      ("font-variant", "small-caps");
       ("font-feature-settings", "normal");
       ("font-variation-settings", "normal");
+      ("ascent-override", "normal");
+      ("descent-override", "90%");
+      ("line-gap-override", "10%");
     ]
 
 let test_inline_substitutes_vars () =


### PR DESCRIPTION
`ascent-override`, `descent-override`, `line-gap-override` and `font-variant` now keep a `var()` through the parse and resolve it in `Css.inline_vars`, joining the eight descriptors #571 covered. `Font_face.metric_override` and `font_variant_descriptor` were already plain variants, so each just needed the `Var` arm, a reader that accepts a `var(` head, and an entry in the resolver table.

`font-variant` could not use `Cursor.enum_or_var`: its grammar is a keyword sequence with duplicate-slot validation, so the `var(` head is dispatched ahead of the keyword reader. Its reader is now exported from `Stylesheet`, which `Inline` needs to read the substituted value back.
