### PR TITLE
font-face: resolve a var() in the font-family descriptor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -603,6 +603,10 @@ recorded cases carrying six minifiers' answers.
   or `font-variant` descriptor of an `@font-face` is resolved by
   `Css.inline_vars` instead of being dropped at parse time. Their value types
   carry the `Var` arm the other typed descriptors already had (#573)
+- A `var()` in the `font-family` descriptor of an `@font-face` is resolved by
+  `Css.inline_vars` instead of being dropped at parse time. The descriptor is a
+  comma-separated list, so the reference may stand for one family or for the
+  whole stack (#575)
 - A `var()` in the `font-style`, `font-weight`, `font-stretch`,
   `font-display`, `font-feature-settings` or `font-variation-settings`
   descriptor of an `@font-face` is resolved by `Css.inline_vars` instead of

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -589,10 +589,16 @@ let simplify_font_src_descriptor visible entries =
 (* Every descriptor whose value type carries a [Var] arm resolves the same way:
    follow the reference to the custom it names, then the references that value
    holds in turn, and stop on a name already seen so a cycle terminates. What
-   differs per descriptor is only how to read the value and how to see a [Var],
-   so take those three and share the walk. *)
-let simplify_typed_var visible ~read ~(as_var : 'a -> 'a Values.var option)
-    ~(of_var : 'a Values.var -> 'a) (value : 'a) : 'a =
+   differs per descriptor is only how to read the value, how to see a [Var], and
+   what a value that is no [Var] still holds, so take those and share the walk.
+   [leaf] receives the walk so a value nesting its own type carries the same
+   [visited] set inwards; without that a reference reachable both directly and
+   through the nesting would not terminate. *)
+let simplify_nested_var visible ~read ~(as_var : 'a -> 'a Values.var option)
+    ~(of_var : 'a Values.var -> 'a)
+    ~(leaf :
+       (visited:string list -> 'a -> 'a) -> visited:string list -> 'a -> 'a)
+    (value : 'a) : 'a =
   let rec simplify ~visited (value : 'a) : 'a =
     match as_var value with
     | Some var when not (List.mem var.Values.name visited) -> (
@@ -606,14 +612,36 @@ let simplify_typed_var visible ~read ~(as_var : 'a -> 'a Values.var option)
             | Values.Empty | Values.Empty2 | Values.None
             | Values.Syntax_fallback _ | Values.Var_fallback _ ->
                 of_var var))
-    | Some _ | None -> value
+    | Some _ | None -> leaf simplify ~visited value
   in
   simplify ~visited:[] value
+
+(* The common case: the value is flat, so a non-[Var] holds no reference. *)
+let simplify_typed_var visible ~read ~as_var ~of_var value =
+  simplify_nested_var visible ~read ~as_var ~of_var
+    ~leaf:(fun _simplify ~visited:_ value -> value)
+    value
 
 let simplify_unicode_range_descriptor visible =
   simplify_typed_var visible ~read:Properties.read_unicode_range
     ~as_var:(function Properties.Var v -> Some v | _ -> None)
     ~of_var:(fun v -> (Properties.Var v : Properties.unicode_range))
+
+(* CSS Fonts 4 sec. 2.1 makes [font-family] a [<family-name>#] list, so a
+   [var()] stands for a whole stack as readily as for one entry and the type
+   nests through [List]. That is the model the property already uses
+   ({!Context.simplify_font_family}), so read the descriptor the same way rather
+   than a second one. *)
+let simplify_font_family_descriptor visible =
+  simplify_nested_var visible ~read:Properties.read_font_family
+    ~as_var:(function Properties.Var v -> Some v | _ -> None)
+    ~of_var:(fun v -> (Properties.Var v : Properties.font_family))
+    ~leaf:(fun simplify ~visited value ->
+      match (value : Properties.font_family) with
+      | Properties.List items ->
+          (Properties.List (List.map (simplify ~visited) items)
+            : Properties.font_family)
+      | value -> value)
 
 let simplify_font_style_descriptor visible =
   simplify_typed_var visible ~read:Properties.read_font_style
@@ -667,6 +695,7 @@ let simplify_font_face_descriptor visible descriptor =
     resolve_font_face_var
       ~src:(simplify_font_src_descriptor visible)
       ~unicode_range:(List.map (simplify_unicode_range_descriptor visible))
+      ~font_family:(List.map (simplify_font_family_descriptor visible))
       ~font_style:(simplify_font_style_descriptor visible)
       ~font_weight:(simplify_font_weight_descriptor visible)
       ~font_stretch:(simplify_font_stretch_descriptor visible)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2378,8 +2378,8 @@ let descriptor_resolves_var name =
   | descriptor ->
       Option.is_some
         (resolve_font_face_var ~src:Fun.id ~unicode_range:Fun.id
-           ~font_style:Fun.id ~font_weight:Fun.id ~font_stretch:Fun.id
-           ~font_display:Fun.id ~font_variant:Fun.id
+           ~font_family:Fun.id ~font_style:Fun.id ~font_weight:Fun.id
+           ~font_stretch:Fun.id ~font_display:Fun.id ~font_variant:Fun.id
            ~font_feature_settings:Fun.id ~font_variation_settings:Fun.id
            ~metric_override:Fun.id descriptor)
   | exception Error.Parse_error _ -> false

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -354,11 +354,12 @@ let equal (a : stylesheet) b = a = b
     keeps a [var()] only for a descriptor named here, and {!Inline} supplies the
     resolvers. A descriptor added to the table takes another resolver argument,
     so both sides have to answer for it. *)
-let resolve_font_face_var ~src ~unicode_range ~font_style ~font_weight
-    ~font_stretch ~font_display ~font_variant ~font_feature_settings
-    ~font_variation_settings ~metric_override = function
+let resolve_font_face_var ~src ~unicode_range ~font_family ~font_style
+    ~font_weight ~font_stretch ~font_display ~font_variant
+    ~font_feature_settings ~font_variation_settings ~metric_override = function
   | Src value -> Some (Src (src value))
   | Unicode_range values -> Some (Unicode_range (unicode_range values))
+  | Font_family values -> Some (Font_family (font_family values))
   | Font_style value -> Some (Font_style (font_style value))
   | Font_style_range (low, high) ->
       Some (Font_style_range (font_style low, font_style high))
@@ -378,5 +379,4 @@ let resolve_font_face_var ~src ~unicode_range ~font_style ~font_weight
   (* The rest hold a value type with no [Var] arm to park an unresolved
      reference in, so the parser has nowhere to keep one and drops the
      declaration as a browser does. *)
-  | Font_family _ | Font_stretch_range _ | Font_tech _ | Size_adjust _ ->
-      Option.None
+  | Font_stretch_range _ | Font_tech _ | Size_adjust _ -> Option.None

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -350,9 +350,7 @@ let spec_fontface_var_descriptor_edges () =
     in
     lenient @ strict
   in
-  match
-    List.concat_map mismatches [ "size-adjust"; "font-tech" ]
-  with
+  match List.concat_map mismatches [ "size-adjust"; "font-tech" ] with
   | [] -> ()
   | mismatches ->
       Alcotest.failf "@font-face descriptors keeping var():\n%s"

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -351,7 +351,7 @@ let spec_fontface_var_descriptor_edges () =
     lenient @ strict
   in
   match
-    List.concat_map mismatches [ "size-adjust"; "font-family"; "font-tech" ]
+    List.concat_map mismatches [ "size-adjust"; "font-tech" ]
   with
   | [] -> ()
   | mismatches ->
@@ -391,6 +391,7 @@ let spec_fontface_var_descriptor_kept () =
   match
     List.concat_map mismatches
       [
+        "font-family";
         "src";
         "unicode-range";
         "font-style";

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -89,6 +89,7 @@ let test_inline_font_face_var_descriptors () =
   Alcotest.(check (list string))
     "descriptors the parser keeps a var() for"
     [
+      "font-family";
       "src";
       "font-style";
       "font-weight";
@@ -127,6 +128,7 @@ let test_inline_font_face_var_resolves () =
   in
   List.iter resolves
     [
+      ("font-family", "b");
       ("font-style", "italic");
       ("font-weight", "700");
       ("font-stretch", "50%");
@@ -141,6 +143,30 @@ let test_inline_font_face_var_resolves () =
       ("ascent-override", "normal");
       ("descent-override", "90%");
       ("line-gap-override", "10%");
+    ]
+
+(* CSS Fonts 4 sec. 2.1 makes the [font-family] descriptor a [<family-name>#]
+   list, so a [var()] stands for a whole stack as readily as for one entry, and
+   a reference nested in the list has to be followed too. The property already
+   reads both shapes into the same type; the descriptor answers the same way. A
+   reference back onto its own name resolves once and then stands, as CSS
+   Variables 1 sec. 3 leaves an unresolvable reference in place. *)
+let test_inline_font_face_family_list () =
+  let check (name, css, expected) =
+    let inlined = minified (Css.inline_vars (parse css)) in
+    Alcotest.(check string) name expected inlined
+  in
+  List.iter check
+    [
+      ( "a var() standing for the whole stack",
+        ":root{--f:Arial,sans-serif}@font-face{font-family:var(--f);src:local(a)}",
+        "@font-face{font-family:Arial,sans-serif;src:local(a)}" );
+      ( "a var() standing for one entry",
+        ":root{--f:sans-serif}@font-face{font-family:Arial,var(--f);src:local(a)}",
+        "@font-face{font-family:Arial,sans-serif;src:local(a)}" );
+      ( "a var() naming itself inside a stack",
+        ":root{--f:Arial,var(--f)}@font-face{font-family:b,var(--f);src:local(a)}",
+        "@font-face{font-family:b,Arial,var(--f);src:local(a)}" );
     ]
 
 let test_inline_substitutes_vars () =
@@ -936,4 +962,6 @@ let suite =
       Alcotest.test_case
         "inline vars resolve the @font-face descriptors the parser keeps" `Quick
         test_inline_font_face_var_descriptors;
+      Alcotest.test_case "inline vars resolve a @font-face family list" `Quick
+        test_inline_font_face_family_list;
     ] )


### PR DESCRIPTION
The `font-family` descriptor of an `@font-face` now keeps a `var()` and resolves it in `Css.inline_vars`, the last of the descriptors #571 left dropping one.

`Properties.font_family` already carried both a `Var` arm and a `List` arm, and the real `font-family` property already resolved a reference through them, so nothing about the type or its readers changed. The descriptor was simply sitting in the fall-through of `resolve_font_face_var`, which is what the parse guard probes. The descriptor now answers what the property answers on the same input.

The type nests through `List`, so `--f: Arial, var(--f)` needs the visited set to thread into the list or the walk does not terminate. `simplify_typed_var` gained a `simplify_nested_var` underneath it for that; its own signature is unchanged.
