### PR TITLE
diff: keep target-gated content in the canonical projection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -722,6 +722,12 @@ recorded cases carrying six minifiers' answers.
   alone, so `@layer a;@layer a{...}` and `@layer a{...}` compare equal. A pin
   that fixes the order, or one over a position the projection cannot read, is
   kept (#475)
+- The canonical projection no longer deletes content that only a
+  browser-support assumption makes dead, which had it report no difference
+  between sheets that render differently: a progressive-enhancement fallback
+  under a baseline-true `@supports`, a vendor-prefixed declaration, an
+  `@import supports()` guard. The respellings gated with those, `min-width`
+  into the range form and the Level 3 `not all and (...)`, still compare equal
 
 ### Library
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7723,13 +7723,15 @@ val canonicalize_rule_order : t -> t
     relative order, and named [@layer] blocks pin the layer order where they
     stand. A run of [@property] rules sorts by name, keeping the last
     registration of each, since CSS Properties and Values API 1 sec. 2 makes
-    registrations for different names order-independent. A
-    [@media not all and (X)] block is keyed as the [@media not (X)] that Media
-    Queries 4 makes it equal to, which emission cannot do because a Level 3
-    parser rejects the shorter form. A [color(srgb ...)] whose channels all land
-    on a whole byte is keyed as the [rgb()] spelling of the same colour, which
-    emission cannot do either because [color()] needs a browser that parses it.
-    This is a comparison-side normalisation; {!val-optimize} stays
+    registrations for different names order-independent. A [@media] prelude is
+    keyed as the Level 4 query Media Queries 4 makes it equal to -
+    [not all and (X)] as [not (X)], [min-X]/[max-X] as the range form, and a
+    lower bound met by an upper bound as the two-sided interval - and an
+    [@container] prelude the same way, which emission cannot do because a Level
+    3 parser rejects the shorter forms. A [color(srgb ...)] whose channels all
+    land on a whole byte is keyed as the [rgb()] spelling of the same colour,
+    which emission cannot do either because [color()] needs a browser that
+    parses it. This is a comparison-side normalisation; {!val-optimize} stays
     source-stable. *)
 
 val optimize :

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -252,8 +252,22 @@ let canonical_of_stylesheet ~lossless ~prune_unused_custom_props stylesheet =
          synthesising nesting from adjacent rules - depends on how the input
          happened to order its rules, so it is not confluent: the same sheet
          written either way would canonicalise differently. The projection skips
-         it. *)
-      |> Css.optimize ~lossless ~regroup:false ~prune_unused_custom_props
+         it.
+
+         [~enforce_spec:true] holds off the rewrites the optimizer justifies
+         with what maintained browsers support, because they delete content:
+         unwrapping a baseline-true [@supports] leaves the declaration written
+         before the guard dead, dropping a vendor-prefixed declaration leaves
+         the engine that needs the prefix nothing, and clearing an [@import
+         supports()] guard decides the sheet always loads. An engine without the
+         feature reads exactly what each of those deletes, so two sheets that
+         disagree there paint differently and the projection has to keep them
+         apart. The respellings gated with them - [min-X] into the range form,
+         the Level 3 [not all and (X)] - delete nothing, and
+         {!Css.canonicalize_rule_order} applies those on the comparison side
+         instead. *)
+      |> Css.optimize ~lossless ~regroup:false ~enforce_spec:true
+           ~prune_unused_custom_props
       |> Css.canonicalize_rule_order
       |> Css.to_string ~minify:true ~lossless)
   with Invalid_argument _ -> None

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -13,6 +13,18 @@
     {b not} reason about browser computed values or cascade-affecting rule
     reorderings.
 
+    The projection optimizes spec-literally: it takes none of the rewrites
+    {!Cascade.Css.optimize} justifies with what maintained browsers support,
+    because those delete content rather than respell it. Taking them leaves the
+    declaration written before a baseline-true [@supports] dead, drops a
+    vendor-prefixed declaration whose unprefixed twin is widely available, and
+    clears an [@import supports()] guard, and an engine without the feature
+    reads exactly what each of those deletes - so two sheets that disagree there
+    render differently and the projection keeps them apart. The respellings
+    gated with them, [min-X] into the range form and the Level 3
+    [not all and (X)], delete nothing and are applied by
+    {!Cascade.Css.canonicalize_rule_order} instead.
+
     Those bytes are the verdict in mode [`Canonical]. Canonical means equivalent
     inputs project to one form, so two canonical forms that differ are either
     two different stylesheets or one projection missing a normalisation key -

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -795,31 +795,27 @@ let fold_layer_pins (stmts : statement list) : statement list =
       in
       List.filter_map Fun.id (List.mapi rebuild stmts)
 
-(* Media Queries 4 sec. 2.3: [all] matches every media type, so it is the
-   identity in [<media-type> and <condition>] and the Level 3 spelling [not all
-   and (X)] is the same query as the Level 4 [not (X)]. Bare [not all] has no
-   condition form - it matches nothing - so it stays, and the unnegated [all and
-   (X)] never reaches here because {!Optimize} already drops it.
+(* Media Queries 4 sec. 2.3 makes [all] the identity media type, so the Level 3
+   [not all and (X)] is the Level 4 [not (X)]; sec. 4.2 gives [min-X]/[max-X]
+   and the range form one meaning, and a lower bound met by an upper bound one
+   two-sided interval. Every one of those is a respelling - nothing is dropped
+   and no query changes what it matches - so the projection takes them all.
+   {!Media.lower_for_minify} is the rewrite, and it fires here on the input the
+   optimizer leaves alone: statements a caller projects without optimizing, and
+   spec-literal optimized output, which keeps the longer spellings because a
+   Level 3 parser rejects the shorter ones. *)
+let canonical_media : Media.t -> Media.t = Media.lower_for_minify
 
-   Default minify emits the Level 4 form itself ({!Media.lower_for_minify}), so
-   this fires on the input that pass leaves alone: statements a caller projects
-   without optimizing, and [--enforce-spec] output, which keeps the Level 3
-   spelling. *)
-let rec canonical_media (query : Media.t) : Media.t =
-  match query with
-  | Media.Type { prefix = Some Media.Not; type_ = Media.All; trailing = Some c }
-    ->
-      Media.Cond (Media.Not c)
-  | Media.List qs ->
-      let qs' = Common.List.map_preserve canonical_media qs in
-      if qs' == qs then query else Media.List qs'
-  | query -> query
+(* An [@container] prelude carries a media condition of its own, and the same
+   respellings hold inside it. *)
+let canonical_container : Container.t -> Container.t =
+  Container.lower_for_minify
 
-(* [@media] is the only statement whose prelude this rewrites, so it is the only
-   one named; the descent below it is {!Stylesheet.map_statement_children}'s and
-   reaches every block at-rule, including the ones a [@media] can be written
-   inside. *)
-let rec canonical_media_queries (stmts : statement list) : statement list =
+(* [@media] and [@container] are the only statements whose prelude this
+   rewrites, so they are the only ones named; the descent below them is
+   {!Stylesheet.map_statement_children}'s and reaches every block at-rule,
+   including the ones they can be written inside. *)
+let rec canonical_query_preludes (stmts : statement list) : statement list =
   Common.List.map_preserve
     (fun stmt ->
       let stmt =
@@ -827,16 +823,19 @@ let rec canonical_media_queries (stmts : statement list) : statement list =
         | Media (q, inner) ->
             let q' = canonical_media q in
             if q' == q then stmt else Media (q', inner)
+        | Container (name, Some cond, inner) ->
+            let cond' = canonical_container cond in
+            if cond' == cond then stmt else Container (name, Some cond', inner)
         | stmt -> stmt
       in
-      Stylesheet.map_statement_children canonical_media_queries stmt)
+      Stylesheet.map_statement_children canonical_query_preludes stmt)
     stmts
 
 let canonicalize (stmts : statement list) : statement list =
   let changed = ref false in
   let normalized =
     fold_layer_pins
-      (canonical_media_queries
+      (canonical_query_preludes
          (sort_property_runs
             (canonical_color_spellings (normalize_custom_values stmts))))
   in

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -11,6 +11,12 @@ blue group and the indigo group in the opposite order. That order is
 cascade-significant for an element carrying both classes, so the difference
 is real and must still be reported.
 
+The projection keeps the feature query, since the declaration before it is
+what an engine without color-mix(in lab) paints, so each selector stays
+split over three rules with another selector's rules between them. Both
+groups keep every declaration they write, so each reports as one move
+rather than as a loss and a gain.
+
   $ cat > ref.css <<'EOF'
   > @layer utilities{.drop-shadow-sm{--tw-drop-shadow-size:drop-shadow(0 1px 2px var(--tw-drop-shadow-color,#00000026));--tw-drop-shadow:drop-shadow(var(--drop-shadow-sm));filter:var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,)}.drop-shadow-blue-500\/50{--tw-drop-shadow-color:#3080ff80}@supports (color:color-mix(in lab, red, red)){.drop-shadow-blue-500\/50{--tw-drop-shadow-color:color-mix(in oklab, color-mix(in oklab, var(--color-blue-500) 50%, transparent) var(--tw-drop-shadow-alpha), transparent)}}.drop-shadow-blue-500\/50{--tw-drop-shadow:var(--tw-drop-shadow-size)}.drop-shadow-indigo-500{--tw-drop-shadow-color:oklch(58.5% .233 277.117)}@supports (color:color-mix(in lab, red, red)){.drop-shadow-indigo-500{--tw-drop-shadow-color:color-mix(in oklab, var(--color-indigo-500) var(--tw-drop-shadow-alpha), transparent)}}.drop-shadow-indigo-500{--tw-drop-shadow:var(--tw-drop-shadow-size)}}
   > EOF
@@ -23,10 +29,17 @@ is real and must still be reported.
   
   --- ref.css
   +++ tw.css
-  └─ @layer utilities (1 rearranged)
-     └─ .drop-shadow-indigo-500 (moved between rules)
-             --tw-drop-shadow-color color-mix(in oklab,var(--col...tw-drop-shadow-alpha),#0000)
-             --tw-drop-shadow var(--tw-drop-shadow-size)
+  └─ @layer utilities (2 reordered, 2 rearranged)
+     ├─ .drop-shadow-blue-500\/50 (position 3) ↔  .drop-shadow-indigo-500 (position 0)
+     ├─ .drop-shadow-blue-500\/50 (moved between rules)
+     │       --tw-drop-shadow-color #3080ff80
+     │       --tw-drop-shadow var(--tw-drop-shadow-size)
+     ├─ .drop-shadow-indigo-500 (moved between rules)
+     │       --tw-drop-shadow-color oklch(.585 .233 277.117)
+     │       --tw-drop-shadow var(--tw-drop-shadow-size)
+     ├─ .drop-shadow-indigo-500 (position 0) ↔  .drop-shadow-indigo-500 (position 4)
+     └─ @supports (color: color-mix(in lab, red, red)) (1 reordered)
+        └─ .drop-shadow-blue-500\/50 ↔  .drop-shadow-indigo-500
   
   [1]
 

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -99,6 +99,66 @@ let equal_canonical_media_not_all () =
     (Cascade_diff.Css_compare.equal ~mode:`Canonical
        "@media not all{.a{color:red}}" "@media not (hover){.a{color:red}}")
 
+(* Every rewrite the optimizer gates behind [~enforce_spec] is justified by what
+   maintained browsers support rather than by what the two sheets say, and the
+   ones that delete content leave the reader of that content - an engine without
+   the feature - with a different page. A comparison projection may re-spell,
+   but it cannot delete on a target assumption, so the projection takes none of
+   them. *)
+let canonical_keeps_target_gated_content () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  (* The declaration an engine without the guarded feature paints is the one
+     before the guard, so two sheets that disagree there paint differently. *)
+  Alcotest.(check bool)
+    "differing fallbacks under a baseline-true @supports differ" false
+    (equal ".a{color:red;@supports (display:grid){color:blue}}"
+       ".a{color:green;@supports (display:grid){color:blue}}");
+  Alcotest.(check bool)
+    "so do they with the guard written at the top level" false
+    (equal ".a{color:red}@supports (display:grid){.a{color:blue}}"
+       ".a{color:green}@supports (display:grid){.a{color:blue}}");
+  (* A vendor-prefixed declaration is the only one an engine that needs the
+     prefix reads, so dropping it is not dropping a spelling. *)
+  Alcotest.(check bool)
+    "a vendor-prefixed twin is not nothing" false
+    (equal ".a{-webkit-transition:all 1s;transition:all 1s}"
+       ".a{transition:all 1s}");
+  (* CSS Cascade 5 sec. 3.1: [supports()] on an [@import] decides whether the
+     sheet loads at all. *)
+  Alcotest.(check bool)
+    "an @import supports() guard is not nothing" false
+    (equal "@import url(\"a.css\") supports(display:grid);"
+       "@import url(\"a.css\");");
+  (* Guards that agree are still no difference, spelled either way. *)
+  Alcotest.(check bool)
+    "matching guards agree through a respelling" true
+    (equal ".a{color:red;@supports (display:grid){color:blue}}"
+       ".a { color: #f00; @supports (display: grid) { color: #00f } }")
+
+(* Media Queries 4 sec. 4.2 gives [min-X]/[max-X] and the range form one
+   meaning, and cascade's own minified output writes the range form, so the fold
+   has to hold on the comparison side once the projection stops taking the
+   optimizer's target facts. Deleting nothing, it is a respelling and stays. *)
+let canonical_folds_media_range_spellings () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  Alcotest.(check bool)
+    "min-width agrees with the range form" true
+    (equal "@media (min-width:48rem){.a{color:red}}"
+       "@media (width>=48rem){.a{color:red}}");
+  Alcotest.(check bool)
+    "a bound pair agrees with the two-sided interval" true
+    (equal "@media (min-width:1px) and (max-width:9px){.a{color:red}}"
+       "@media (1px<=width<=9px){.a{color:red}}");
+  Alcotest.(check bool)
+    "an @container prelude folds the same way" true
+    (equal "@container (min-width:48rem){.a{color:red}}"
+       "@container (width>=48rem){.a{color:red}}");
+  (* A different bound is still a different query. *)
+  Alcotest.(check bool)
+    "a different bound still differs" false
+    (equal "@media (min-width:48rem){.a{color:red}}"
+       "@media (width>=49rem){.a{color:red}}")
+
 (* CSS Color 4 sec. 10.2: [color(srgb r g b)] scales each channel by 255, so
    [color(srgb 1 0 0)] and [rgb(255 0 0)] are one colour in two spellings.
    [--lossless] keeps a modern colour function on output, which leaves the
@@ -1485,6 +1545,10 @@ let suite =
         equal_canonical_ignores_property_order;
       Alcotest.test_case "canonical equates not all and (X) with not (X)" `Quick
         equal_canonical_media_not_all;
+      Alcotest.test_case "canonical keeps target-gated content" `Quick
+        canonical_keeps_target_gated_content;
+      Alcotest.test_case "canonical folds media range spellings" `Quick
+        canonical_folds_media_range_spellings;
       Alcotest.test_case "canonical lossless equates exact srgb spellings"
         `Quick equal_canonical_lossless_exact_srgb;
     ] )


### PR DESCRIPTION
Canonical comparison optimized with `~enforce_spec:false`, so the optimizer unwrapped an `@supports` guard it knew evergreen browsers satisfy and the now-dead fallback declaration was deleted from both sides before they were compared. Two sheets differing only in a fallback value, a vendor-prefixed declaration or an `@import ... supports()` guard therefore compared equal. The projection may respell, but it may not delete: the media and container respellings that `enforce_spec` also gates now happen on the comparison side instead.