### PR TITLE
font-face: type the three bare-valued descriptors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -607,6 +607,11 @@ recorded cases carrying six minifiers' answers.
   `Css.inline_vars` instead of being dropped at parse time. The descriptor is a
   comma-separated list, so the reference may stand for one family or for the
   whole stack (#575)
+- `Css.inline_vars` resolves a `var()` in the `size-adjust` and `font-tech`
+  descriptors of an `@font-face`, and in either endpoint of a `font-stretch`
+  range. The first two were dropped at parse time; the range carried the
+  reference through to the output, where a browser drops the whole
+  declaration (#577)
 - A `var()` in the `font-style`, `font-weight`, `font-stretch`,
   `font-display`, `font-feature-settings` or `font-variation-settings`
   descriptor of an `@font-face` is resolved by `Css.inline_vars` instead of

--- a/fuzz/fuzz_font_face.ml
+++ b/fuzz/fuzz_font_face.ml
@@ -93,8 +93,8 @@ let test_metric_override_non_negative buf =
 
 let test_size_adjust_non_negative buf =
   match parse_size_adjust buf with
-  | None -> ()
-  | Some p ->
+  | None | Some (Css.Font_face.Var _) -> ()
+  | Some (Css.Font_face.Pct p) ->
       if Float.compare p 0. < 0 then
         fail "size-adjust parsed a negative percentage"
 
@@ -203,12 +203,19 @@ let test_invalid_metric_vectors buf =
 
 let test_spec_size_adjust_vectors buf =
   let input, expected =
-    pick [ ("0%", 0.); ("100%", 100.); ("125.5%", 125.5) ] buf 5
+    pick
+      [
+        ("0%", Css.Font_face.Pct 0.);
+        ("100%", Css.Font_face.Pct 100.);
+        ("125.5%", Css.Font_face.Pct 125.5);
+      ]
+      buf 5
   in
   match parse_size_adjust input with
   | Some actual when Css.Font_face.equal_size_adjust actual expected -> ()
   | Some actual ->
-      failf "font size-adjust structure changed: %S -> %g" input actual
+      failf "font size-adjust structure changed: %S -> %s" input
+        (Css.Font_face.string_of_size_adjust actual)
   | None -> failf "valid font size-adjust vector rejected: %S" input
 
 let test_invalid_size_adjust_vectors buf =
@@ -216,7 +223,8 @@ let test_invalid_size_adjust_vectors buf =
   match parse_size_adjust input with
   | None -> ()
   | Some size_adjust ->
-      failf "invalid font size-adjust vector parsed: %S -> %g" input size_adjust
+      failf "invalid font size-adjust vector parsed: %S -> %s" input
+        (Css.Font_face.string_of_size_adjust size_adjust)
 
 let suite =
   ( "font_face",

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -22,10 +22,18 @@ let string_of_metric_override = Pp.to_string ~minify:false pp_metric_override
 
 (** {1 Size Adjust} *)
 
-type size_adjust = float
-(** Size adjustment percentage. *)
+(** CSS Fonts 5 sec. 4.4: a [<percentage [0,inf]>] glyph size multiplier. No
+    descriptor grammar takes a [var()] (CSS Fonts 4 sec. 4.1), so [Var] parks a
+    reference until the inline pass substitutes it. *)
+type size_adjust = Pct of float | Var of size_adjust Values.var
 
-let string_of_size_adjust p = Pp.string_of_float p ^ "%"
+let rec pp_size_adjust ctx : size_adjust -> unit = function
+  | Pct p ->
+      Pp.string ctx (Pp.string_of_float p);
+      Pp.char ctx '%'
+  | Var var -> Values.pp_var pp_size_adjust ctx var
+
+let string_of_size_adjust = Pp.to_string ~minify:false pp_size_adjust
 
 (** {1 Font Source} *)
 
@@ -47,8 +55,8 @@ and src = src_entry list
 type t = src
 
 let equal_metric_override (a : metric_override) b = a = b
-let equal_size_adjust (a : size_adjust) b = Float.equal a b
-let compare_size_adjust (a : size_adjust) b = Float.compare a b
+let equal_size_adjust (a : size_adjust) b = a = b
+let compare_size_adjust (a : size_adjust) b = compare a b
 let equal_src (a : src) b = a = b
 
 (* Emit the optional [format(...)] / [tech(...)] modifiers after a [url()] base.
@@ -180,13 +188,16 @@ let rec read_metric_override t : metric_override =
       Var (Values.read_var read_metric_override t)
   | Some _ | None -> Cursor.err_invalid t "metric override"
 
-(* CSS Fonts 4 sec. 4.11: [<percentage [0,inf]>]. *)
-let read_size_adjust t =
+(* CSS Fonts 5 sec. 4.4: [<percentage [0,inf]>]. *)
+let rec read_size_adjust t : size_adjust =
   match Cursor.peek t with
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii name = "var" ->
+      Var (Values.read_var read_size_adjust t)
   | Some (Component.Preserved { kind = Token.Percentage number; _ })
     when valid_percentage number.Token.value ->
       Cursor.skip t;
-      number.Token.value
+      Pct number.Token.value
   | Some _ | None -> Cursor.err_invalid t "size-adjust"
 
 let read_whole read s =

--- a/lib/font_face.mli
+++ b/lib/font_face.mli
@@ -18,8 +18,13 @@ val string_of_metric_override : metric_override -> string
 
 (** {1 Size Adjust} *)
 
-type size_adjust = float
-(** Size adjustment percentage. *)
+(** CSS Fonts 5 sec. 4.4: a [<percentage [0,inf]>] glyph size multiplier. No
+    descriptor grammar takes a [var()] (CSS Fonts 4 sec. 4.1), so [Var] parks a
+    reference until the inline pass substitutes it. *)
+type size_adjust = Pct of float | Var of size_adjust Values.var
+
+val pp_size_adjust : size_adjust Pp.t
+(** [pp_size_adjust] renders one [size-adjust] value. *)
 
 val string_of_size_adjust : size_adjust -> string
 (** [string_of_size_adjust s] converts size adjust to string. *)

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -686,6 +686,17 @@ let simplify_metric_override_descriptor visible =
     ~as_var:(function Font_face.Var v -> Some v | _ -> Option.None)
     ~of_var:(fun v -> (Font_face.Var v : Font_face.metric_override))
 
+let simplify_font_tech_descriptor visible =
+  simplify_typed_var visible ~read:read_font_tech_descriptor
+    ~as_var:(function Var v -> Some v | Tech _ -> Option.None)
+    ~of_var:(fun v -> (Var v : font_tech_descriptor))
+
+let simplify_size_adjust_descriptor visible =
+  simplify_typed_var visible ~read:Font_face.read_size_adjust
+    ~as_var:(function
+      | Font_face.Var v -> Some v | Font_face.Pct _ -> Option.None)
+    ~of_var:(fun v -> (Font_face.Var v : Font_face.size_adjust))
+
 (* [resolve_font_face_var] names the descriptors whose var() survives the parse
    and asks for one resolver each, so this pass and the parser cannot grow
    apart: a descriptor added to that table takes a resolver argument the call
@@ -705,6 +716,8 @@ let simplify_font_face_descriptor visible descriptor =
       ~font_variation_settings:
         (simplify_font_variation_settings_descriptor visible)
       ~metric_override:(simplify_metric_override_descriptor visible)
+      ~font_tech:(simplify_font_tech_descriptor visible)
+      ~size_adjust:(simplify_size_adjust_descriptor visible)
       descriptor
   with
   | Some resolved -> resolved

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1090,6 +1090,10 @@ let pp_font_variant_descriptor_value ctx = function
   | Numeric value -> Properties.pp_font_variant_numeric_token ctx value
   | East_asian value -> Properties.pp_east_asian_feature ctx value
 
+let rec pp_font_tech_descriptor ctx : font_tech_descriptor -> unit = function
+  | Tech tech -> Pp.string ctx (Supports.string_of_font_tech tech)
+  | Var var -> Values.pp_var pp_font_tech_descriptor ctx var
+
 let rec pp_font_variant_descriptor ctx = function
   | Normal -> Pp.string ctx "normal"
   | None -> Pp.string ctx "none"
@@ -1132,7 +1136,13 @@ let pp_font_face_descriptor : font_face_descriptor Pp.t =
         (min_weight, max_weight)
   | Font_stretch stretch ->
       pp_descriptor "font-stretch" Properties.pp_font_stretch stretch
-  | Font_stretch_range value -> pp_descriptor "font-stretch" Pp.string value
+  | Font_stretch_range (min_stretch, max_stretch) ->
+      pp_descriptor "font-stretch"
+        (fun ctx (min_stretch, max_stretch) ->
+          Properties.pp_font_stretch ctx min_stretch;
+          Pp.space ctx ();
+          Properties.pp_font_stretch ctx max_stretch)
+        (min_stretch, max_stretch)
   | Font_display value ->
       pp_descriptor "font-display" Properties.pp_font_display value
   | Unicode_range values ->
@@ -1147,11 +1157,9 @@ let pp_font_face_descriptor : font_face_descriptor Pp.t =
   | Font_variation_settings value ->
       pp_descriptor "font-variation-settings"
         Properties.pp_font_variation_settings value
-  | Font_tech value -> pp_descriptor "font-tech" Pp.string value
+  | Font_tech value -> pp_descriptor "font-tech" pp_font_tech_descriptor value
   | Size_adjust value ->
-      pp_descriptor "size-adjust"
-        (fun ctx v -> Pp.string ctx (Font_face.string_of_size_adjust v))
-        value
+      pp_descriptor "size-adjust" Font_face.pp_size_adjust value
   | Ascent_override value ->
       pp_descriptor "ascent-override" Font_face.pp_metric_override value
   | Descent_override value ->
@@ -2139,13 +2147,6 @@ let validate_nonempty_descriptor r name value =
   if String.trim value = "" then
     Cursor.err_invalid r ("empty " ^ name ^ " descriptor")
 
-let read_string_descriptor name constructor r =
-  read_descriptor_value Declaration.read_property_value
-    (fun value ->
-      validate_nonempty_descriptor r name value;
-      constructor value)
-    r
-
 let read_font_family_descriptor r =
   read_descriptor_value
     (fun r -> Cursor.list ~sep:Cursor.comma Properties.read_font_family r)
@@ -2159,14 +2160,11 @@ let read_font_stretch_descriptor r =
       let first = Properties.read_font_stretch c in
       Cursor.ws c;
       if Cursor.is_done c then Font_stretch first
-      else begin
-        (* The endpoint is parsed for validation only: the range keeps the raw
-           [value], which already carries both bounds. *)
-        ignore (Properties.read_font_stretch c : Properties.font_stretch);
+      else
+        let second = Properties.read_font_stretch c in
         Cursor.ws c;
         Cursor.expect_eof c;
-        Font_stretch_range value
-      end)
+        Font_stretch_range (first, second))
     r
 
 let read_unicode_range_descriptor r =
@@ -2272,6 +2270,19 @@ let read_font_variant_descriptor_value r =
   | Some value -> value
   | None -> Cursor.err_invalid r ("font-variant descriptor value: " ^ ident)
 
+(* CSS Fonts 4 sec. 11.1 spells [<font-tech>] as a keyword, so an unknown ident
+   is a parse error rather than text to carry through. *)
+let rec read_font_tech_descriptor r : font_tech_descriptor =
+  match Cursor.peek r with
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii name = "var" ->
+      Var (Values.read_var read_font_tech_descriptor r)
+  | Some _ | Option.None -> (
+      let ident = Cursor.ident r in
+      match Supports.font_tech_of_string (String.lowercase_ascii ident) with
+      | Some tech -> Tech tech
+      | Option.None -> Cursor.err_invalid r ("font-tech descriptor: " ^ ident))
+
 let read_font_variant_keywords r : font_variant_descriptor =
   let at_value_end () = Cursor.is_done r || Cursor.peek_semicolon r in
   let snap = Cursor.save r in
@@ -2324,7 +2335,8 @@ let read_font_face_desc name r =
       read_descriptor_value Properties.read_font_variation_settings
         (fun v -> Font_variation_settings v)
         r
-  | "font-tech" -> read_string_descriptor "font-tech" (fun v -> Font_tech v) r
+  | "font-tech" ->
+      read_descriptor_value read_font_tech_descriptor (fun v -> Font_tech v) r
   | "size-adjust" ->
       read_descriptor_value Font_face.read_size_adjust
         (fun v -> Size_adjust v)
@@ -2381,7 +2393,8 @@ let descriptor_resolves_var name =
            ~font_family:Fun.id ~font_style:Fun.id ~font_weight:Fun.id
            ~font_stretch:Fun.id ~font_display:Fun.id ~font_variant:Fun.id
            ~font_feature_settings:Fun.id ~font_variation_settings:Fun.id
-           ~metric_override:Fun.id descriptor)
+           ~metric_override:Fun.id ~font_tech:Fun.id ~size_adjust:Fun.id
+           descriptor)
   | exception Error.Parse_error _ -> false
 
 let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -460,6 +460,11 @@ val pp_import_rule : import_rule Pp.t
 val read_import_rule : Cursor.t -> import_rule
 (** [read_import_rule r] parses an import rule. *)
 
+val read_font_tech_descriptor : Cursor.t -> font_tech_descriptor
+(** [read_font_tech_descriptor r] parses the [font-tech] descriptor of an
+    [\@font-face] rule: one [<font-tech>] keyword (CSS Fonts 4 sec. 11.1), or a
+    [var()] reference the inline pass resolves. *)
+
 val pp_layer_name : layer_name Pp.t
 (** [pp_layer_name] prints a [<layer-name>]: each ident with the escapes that
     read it back (CSS Syntax 3 sec. 2.1), joined by the [.] separators of CSS

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -282,6 +282,13 @@ and font_variant_descriptor =
   | Values of font_variant_descriptor_value list
   | Var of font_variant_descriptor Values.var
 
+(** CSS Fonts 4 sec. 11.1 [<font-tech>], shared with [font-tech()] in
+    [\@supports]. No descriptor grammar takes a [var()] (sec. 4.1), so [Var]
+    parks a reference until the inline pass substitutes it. *)
+and font_tech_descriptor =
+  | Tech of Supports.font_tech
+  | Var of font_tech_descriptor Values.var
+
 and font_variant_descriptor_value =
   | Ligature of Properties.font_variant_ligature
   | Caps of Properties.font_variant_caps
@@ -306,7 +313,8 @@ and font_face_descriptor =
       (** variable font weight range, e.g. [100 900] *)
   | Font_stretch of Properties.font_stretch
       (** normal, condensed, expanded, etc. *)
-  | Font_stretch_range of string  (** variable font stretch range *)
+  | Font_stretch_range of Properties.font_stretch * Properties.font_stretch
+      (** variable font stretch range, e.g. [50% 200%] *)
   | Font_display of Properties.font_display
       (** auto, block, swap, fallback, optional *)
   | Unicode_range of Properties.unicode_range list
@@ -316,7 +324,7 @@ and font_face_descriptor =
       (** OpenType feature settings *)
   | Font_variation_settings of Properties.font_variation_settings
       (** Variable font settings *)
-  | Font_tech of string  (** [font-tech] descriptor *)
+  | Font_tech of font_tech_descriptor  (** [font-tech] descriptor *)
   | Size_adjust of Font_face.size_adjust  (** Size adjustment percentage *)
   | Ascent_override of Font_face.metric_override  (** Ascent metric override *)
   | Descent_override of Font_face.metric_override
@@ -356,7 +364,8 @@ let equal (a : stylesheet) b = a = b
     so both sides have to answer for it. *)
 let resolve_font_face_var ~src ~unicode_range ~font_family ~font_style
     ~font_weight ~font_stretch ~font_display ~font_variant
-    ~font_feature_settings ~font_variation_settings ~metric_override = function
+    ~font_feature_settings ~font_variation_settings ~metric_override ~font_tech
+    ~size_adjust = function
   | Src value -> Some (Src (src value))
   | Unicode_range values -> Some (Unicode_range (unicode_range values))
   | Font_family values -> Some (Font_family (font_family values))
@@ -367,6 +376,8 @@ let resolve_font_face_var ~src ~unicode_range ~font_family ~font_style
   | Font_weight_range (low, high) ->
       Some (Font_weight_range (font_weight low, font_weight high))
   | Font_stretch value -> Some (Font_stretch (font_stretch value))
+  | Font_stretch_range (low, high) ->
+      Some (Font_stretch_range (font_stretch low, font_stretch high))
   | Font_display value -> Some (Font_display (font_display value))
   | Font_variant value -> Some (Font_variant (font_variant value))
   | Font_feature_settings value ->
@@ -376,7 +387,5 @@ let resolve_font_face_var ~src ~unicode_range ~font_family ~font_style
   | Ascent_override value -> Some (Ascent_override (metric_override value))
   | Descent_override value -> Some (Descent_override (metric_override value))
   | Line_gap_override value -> Some (Line_gap_override (metric_override value))
-  (* The rest hold a value type with no [Var] arm to park an unresolved
-     reference in, so the parser has nowhere to keep one and drops the
-     declaration as a browser does. *)
-  | Font_stretch_range _ | Font_tech _ | Size_adjust _ -> Option.None
+  | Font_tech value -> Some (Font_tech (font_tech value))
+  | Size_adjust value -> Some (Size_adjust (size_adjust value))

--- a/lib/supports.mli
+++ b/lib/supports.mli
@@ -33,6 +33,13 @@ type font_tech =
   | Palettes
   | Incremental
 
+val font_tech_of_string : string -> font_tech option
+(** [font_tech_of_string s] is the [<font-tech>] keyword [s] spells (CSS Fonts 4
+    sec. 11.1), or [None] for anything else. [s] is matched lower-cased. *)
+
+val string_of_font_tech : font_tech -> string
+(** [string_of_font_tech tech] is the canonical spelling of [tech]. *)
+
 type function_feature =
   | Selector of Selector.t
   | Font_format of font_format

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -8,7 +8,7 @@ let test_string_of_metric_override () =
     (string_of_metric_override (Percent 110.))
 
 let test_size_adjust () =
-  let s = string_of_size_adjust 90. in
+  let s = string_of_size_adjust (Pct 90.) in
   Alcotest.(check string) "size-adjust 90%" "90%" s
 
 let test_src () =
@@ -60,7 +60,8 @@ let expect_metric_rejected input =
 let expect_size_adjust_rejected input =
   try
     let size_adjust = size_adjust_of_string input in
-    Alcotest.failf "invalid font size-adjust parsed: %S -> %g" input size_adjust
+    Alcotest.failf "invalid font size-adjust parsed: %S -> %s" input
+      (string_of_size_adjust size_adjust)
   with
   | Error.Parse_error _ | Reader.Parse_error _ | Invalid_argument _ | Failure _
   ->
@@ -139,9 +140,9 @@ let test_spec_metric_parsing_edges () =
   Alcotest.(check string)
     "percentage parses" "92.5%"
     (metric_override_of_string "92.5%" |> string_of_metric_override);
-  Alcotest.(check (float 0.0001))
-    "size adjust percentage" 87.5
-    (size_adjust_of_string "87.5%")
+  Alcotest.(check string)
+    "size adjust percentage" "87.5%"
+    (size_adjust_of_string "87.5%" |> string_of_size_adjust)
 
 let test_spec_metric_negative_vectors () =
   List.iter expect_metric_rejected [ "-1%"; "auto"; "100"; "calc(1%)" ];
@@ -150,9 +151,9 @@ let test_spec_metric_negative_vectors () =
     (metric_override_of_string "120%" |> string_of_metric_override);
   List.iter expect_size_adjust_rejected
     [ "-10%"; "normal"; "auto"; "100"; "calc(100%)" ];
-  Alcotest.(check (float 0.0001))
-    "zero size adjust parses" 0.
-    (size_adjust_of_string "0%")
+  Alcotest.(check string)
+    "zero size adjust parses" "0%"
+    (size_adjust_of_string "0%" |> string_of_size_adjust)
 
 let spec_fontface_source_edges () =
   let check_normalized name input expected =
@@ -191,10 +192,15 @@ let spec_fontface_metric_edges () =
     ];
   List.iter
     (fun (input, expected) ->
-      Alcotest.(check (float 0.0001))
+      Alcotest.(check string)
         input expected
-        (size_adjust_of_string input))
-    [ ("0%", 0.); ("100%", 100.); ("125.5%", 125.5); (" 87.25% ", 87.25) ]
+        (size_adjust_of_string input |> string_of_size_adjust))
+    [
+      ("0%", "0%");
+      ("100%", "100%");
+      ("125.5%", "125.5%");
+      (" 87.25% ", "87.25%");
+    ]
 
 let spec_fontface_src_minify_edges () =
   let check_all cases =
@@ -292,16 +298,15 @@ let spec_fontface_metric_numeric_edges () =
     [ ("+10%", "10%"); (".5%", "0.5%"); ("1e2%", "100%"); ("0e0%", "0%") ];
   List.iter
     (fun (input, expected) ->
-      Alcotest.(check (float 0.0001))
+      Alcotest.(check string)
         input expected
-        (size_adjust_of_string input))
-    [ ("+10%", 10.); (".5%", 0.5); ("1e2%", 100.); ("0e0%", 0.) ];
+        (size_adjust_of_string input |> string_of_size_adjust))
+    [ ("+10%", "10%"); (".5%", "0.5%"); ("1e2%", "100%"); ("0e0%", "0%") ];
   let accepted =
     accepted_invalid_cases "font metric override" metric_override_of_string
       string_of_metric_override [ ""; "%"; "+%"; "NaN%" ]
     @ accepted_invalid_cases "font size-adjust" size_adjust_of_string
-        (fun v -> string_of_size_adjust v)
-        [ ""; "%"; "+%"; "NaN%" ]
+        string_of_size_adjust [ ""; "%"; "+%"; "NaN%" ]
   in
   match accepted with
   | [] -> ()

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -350,7 +350,7 @@ let spec_fontface_var_descriptor_edges () =
     in
     lenient @ strict
   in
-  match List.concat_map mismatches [ "size-adjust"; "font-tech" ] with
+  match List.concat_map mismatches [] with
   | [] -> ()
   | mismatches ->
       Alcotest.failf "@font-face descriptors keeping var():\n%s"
@@ -402,6 +402,8 @@ let spec_fontface_var_descriptor_kept () =
         "ascent-override";
         "descent-override";
         "line-gap-override";
+        "font-tech";
+        "size-adjust";
       ]
   with
   | [] -> ()

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -38,7 +38,7 @@ let font_face_descriptors =
     ("font-variant", "normal");
     ("font-feature-settings", "normal");
     ("font-variation-settings", "normal");
-    ("font-tech", "\"variations\"");
+    ("font-tech", "variations");
     ("size-adjust", "100%");
     ("ascent-override", "normal");
     ("descent-override", "normal");
@@ -102,6 +102,8 @@ let test_inline_font_face_var_descriptors () =
       "ascent-override";
       "descent-override";
       "line-gap-override";
+      "font-tech";
+      "size-adjust";
     ]
     kept
 
@@ -143,6 +145,8 @@ let test_inline_font_face_var_resolves () =
       ("ascent-override", "normal");
       ("descent-override", "90%");
       ("line-gap-override", "10%");
+      ("font-tech", "variations");
+      ("size-adjust", "100%");
     ]
 
 (* CSS Fonts 4 sec. 2.1 makes the [font-family] descriptor a [<family-name>#]
@@ -168,6 +172,16 @@ let test_inline_font_face_family_list () =
         ":root{--f:Arial,var(--f)}@font-face{font-family:b,var(--f);src:local(a)}",
         "@font-face{font-family:b,Arial,var(--f);src:local(a)}" );
     ]
+
+(* CSS Fonts 4 sec. 4.4 takes the font-width descriptor as
+   [<'font-width'>{1,2}], so the range form has two endpoints and a [var()] can
+   stand for either. A range built from one raw endpoint and one reference has
+   to reach the output with neither reference left in it. *)
+let test_inline_font_face_var_stretch_range () =
+  check_inline_case "font-stretch range endpoint from a var()"
+    ":root{--wide:200%}@font-face{font-family:a;src:local(anchor);font-stretch:50% \
+     var(--wide)}"
+    "@font-face{font-family:a;src:local(anchor);font-stretch:50% 200%}"
 
 let test_inline_substitutes_vars () =
   check_inline ~optimized:".button{color:#00f}"
@@ -884,6 +898,8 @@ let suite =
     [
       Alcotest.test_case "inline vars resolve a typed @font-face descriptor"
         `Quick test_inline_font_face_var_resolves;
+      Alcotest.test_case "inline vars resolve a @font-face range endpoint"
+        `Quick test_inline_font_face_var_stretch_range;
       Alcotest.test_case "inline vars propagate liveness across scopes" `Quick
         test_inline_vars_liveness_propagates_through_scopes;
       Alcotest.test_case "inline vars contain a definition to its at-rule path"

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -99,11 +99,11 @@ let test_inline_font_face_var_descriptors () =
       "font-variant";
       "font-feature-settings";
       "font-variation-settings";
+      "font-tech";
+      "size-adjust";
       "ascent-override";
       "descent-override";
       "line-gap-override";
-      "font-tech";
-      "size-adjust";
     ]
     kept
 


### PR DESCRIPTION
The last three `@font-face` descriptors that could not hold a `var()`. `size-adjust` was an alias for `float`; `font-tech` and the `font-stretch` range travelled as a raw `string`. None of them had anywhere to park an unresolved reference, so each gets a real type and with it the `Var` arm, reader and resolver the other descriptors already had. Every descriptor now resolves a `var()`, so the resolver table has no fall-through left.

Two things beyond the mechanical change, both worth a look. `font-tech` is now typed against `Supports.font_tech`, so `font-tech: bogus` is a parse error where it used to be carried through verbatim; that is a real grammar tightening. And the `font-stretch` range previously leaked the reference into the output, where a browser drops the whole declaration, so it was wrong in a different way from the other two.
