### PR TITLE
test: drop google-2 from the satcss known-larger list

### DIFF
--- a/test/interop/satcss/test.ml
+++ b/test/interop/satcss/test.ml
@@ -49,18 +49,14 @@ let cases () =
    closed-world (where it already makes the same DOM-dependent merges). The
    remainder is a structural-shape difference in the merged form, not a refused
    merge. Each entry asserts cascade is STILL larger, so a fix that closes the
-   gap fails the test and prompts removing the entry. *)
+   gap fails the test and prompts removing the entry. Only the sign is asserted:
+   the byte figures below move with the optimizer. *)
 let known_larger =
   [
     ( "vk-3",
-      "Residual +17 bytes under closed-world: SatCSS's grouping of \
+      "Residual +13 bytes under closed-world: SatCSS's grouping of \
        `.blocked_about_login`/`.blocked_no_code` (tied on `padding-top`) lands \
        a marginally tighter structure than cascade's equivalent merge." );
-    ( "google-2",
-      "Residual +39 bytes under closed-world: with the DOM-disjointness \
-       assumption cascade groups the `position` rules \
-       (`#viewport,.goog-inline-block,...` and `#footer,.jfk-bubble,...`) but \
-       reaches all but ~39 bytes of SatCSS's exact shape." );
   ]
 
 let check_case name () =


### PR DESCRIPTION
The `google-2` case asserted `cascade > satcss` and no longer holds. Cascade is 4886 bytes against SatCSS's 4972, so 86 bytes smaller, where the entry claimed 39 bytes larger. The assertion message already prescribes the remedy, so the entry goes and the case falls back to the ordinary `cascade <= satcss` check, which it passes.

`vk-3` was re-measured rather than assumed and still holds at +13, so it stays, with its stale "+17" corrected. The header now says only the sign is asserted, since both figures had drifted silently and one had crossed zero.

This is what made `dune build @runtest` exit non-zero in any workspace that symlinks cascade, which is how it surfaced. No changelog entry: the assertion is internal bookkeeping with no user-visible change.
