### PR TITLE
properties: read a bare number as a stroke width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -160,6 +160,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `stroke-width` reads a bare number, so `stroke-width: 1.5` round-trips
+  through cascade's own parser instead of being printed and then refused. SVG 2
+  sec. 13.5.3 gives it `<length-percentage> | <number>`, where a number is a
+  width in user units and a negative value is invalid (#579)
 - A selector using the column combinator, such as `svg||td` or `a||b`, is read
   and written back instead of dropped. The namespace read claimed the first
   bar of the `||` that CSS Selectors 4 sec. 15.2 defines (#572)

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -1980,6 +1980,18 @@ let simplify_font_size ?layer_order ?layer cascade (length_ctx : Length.ctx)
   in
   Calc_residual.simplify ?layer_order ?layer cascade ops value
 
+(* Only the <length-percentage> branch carries anything to simplify: a bare
+   number is already a user-unit width. *)
+let simplify_stroke_width ?layer_order ?layer cascade length_ctx
+    (value : Properties.stroke_width) : Properties.stroke_width =
+  match value with
+  | Length lp ->
+      let lp' =
+        simplify_length_percentage ?layer_order ?layer cascade length_ctx lp
+      in
+      if lp' == lp then value else Length lp'
+  | _ -> value
+
 let simplify_opacity ?layer_order ?layer cascade value =
   let to_number = function
     | Properties.Opacity_number n -> Some n
@@ -2422,6 +2434,15 @@ let css_wide_of_border_widths (value : Properties.border_width list) =
   match value with [ width ] -> css_wide_of_border_width width | _ -> None
 
 let css_wide_of_opacity (value : Properties.opacity) =
+  match value with
+  | Properties.Inherit -> Some Inherit
+  | Properties.Initial -> Some Initial
+  | Properties.Unset -> Some Unset
+  | Properties.Revert -> Some Revert
+  | Properties.Revert_layer -> Some Revert_layer
+  | _ -> None
+
+let css_wide_of_stroke_width (value : Properties.stroke_width) =
   match value with
   | Properties.Inherit -> Some Inherit
   | Properties.Initial -> Some Initial
@@ -3514,6 +3535,9 @@ let kind_simplifier : type a.
       (simplify_font_src ~layer_order ?layer ctx, fun _ -> None)
   | Properties.Font_family ->
       (simplify_font_family ~layer_order ?layer ctx, css_wide_of_font_family)
+  | Properties.Stroke_width ->
+      ( simplify_stroke_width ~layer_order ?layer ctx length_ctx,
+        css_wide_of_stroke_width )
 
 let rec eval_typed ?layer_order ?layer ctx decl =
   let ctx = scope ?layer_order ?layer ctx in

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -6969,7 +6969,19 @@ val fill : svg_paint -> declaration
 val stroke : svg_paint -> declaration
 (** [stroke paint] is the SVG stroke property. *)
 
-val stroke_width : length -> declaration
+(** SVG 2 sec. 13.5.3 [stroke-width]: [<length-percentage> | <number>], where a
+    bare number is a width in user units rather than a CSS [<length>]. *)
+type stroke_width = Properties.stroke_width =
+  | Number of float  (** A width in user units *)
+  | Length of length_percentage
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of stroke_width var
+
+val stroke_width : stroke_width -> declaration
 (** [stroke_width width] is the SVG stroke-width property. *)
 
 (** {2:scroll_touch Scroll & Touch}

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1028,7 +1028,6 @@ let read_sizing_value : type a. a property -> Cursor.t -> declaration option =
   | Offset_distance -> Some (v Offset_distance (read_nn_lp_or_global t))
   | Shape_margin -> Some (v Shape_margin (read_nn_lp_or_global t))
   | Line_height_step -> Some (v Line_height_step (read_nn_length_or_global t))
-  | Stroke_width -> Some (v Stroke_width (read_nn_length_or_global t))
   | _ -> None
 
 let read_radius_gap_value : type a. a property -> Cursor.t -> declaration option
@@ -1801,6 +1800,7 @@ let read_interaction_value : type a.
       Some (v Stroke_linejoin (Properties.read_stroke_linejoin t))
   | Stroke_miterlimit ->
       Some (v Stroke_miterlimit (Properties.read_stroke_miterlimit t))
+  | Stroke_width -> Some (v Stroke_width (Properties.read_stroke_width t))
   | Stroke_dashoffset ->
       Some (v Stroke_dashoffset (Properties.read_stroke_dashoffset t))
   | Stroke_dasharray ->

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -883,7 +883,7 @@ val stroke : svg_paint -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke}
      stroke} property. *)
 
-val stroke_width : length -> declaration
+val stroke_width : stroke_width -> declaration
 (** [stroke_width v] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-width}
      stroke-width} property. *)

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -57,6 +57,13 @@ let normalize_paint_order (value : paint_order) : paint_order =
       shortest 0
   | _ -> value
 
+let normalize_stroke_width ~ctx (value : stroke_width) : stroke_width =
+  match value with
+  | Length lp ->
+      let lp' = Values.normalize_length_percentage ~ctx lp in
+      if lp' == lp then value else Length lp'
+  | _ -> value
+
 let normalize_dash_length ~ctx (value : dash_length) : dash_length =
   match value with
   | Number _ -> value
@@ -139,6 +146,17 @@ let rec pp_paint_order : paint_order Pp.t =
   | Var v -> pp_var pp_paint_order ctx v
   | Normal -> Pp.string ctx "normal"
   | Order ks -> Pp.list ~sep:Pp.space pp_paint_order_keyword ctx ks
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+
+let rec pp_stroke_width : stroke_width Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_stroke_width ctx v
+  | Number n -> Pp.float ctx n
+  | Length lp -> Values.pp_length_percentage ctx lp
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -438,6 +456,34 @@ let rec read_stroke_dasharray t : stroke_dasharray =
       in
       (Dashes (go []) : stroke_dasharray))
     t
+
+(* SVG 2 sec. 13.5.3: "A <number> value represents a value in user units", and
+   "A negative value is invalid", so both branches of the production refuse one.
+   Only a literal can be checked here; calc() and var() resolve later. *)
+let read_stroke_width_value t : stroke_width =
+  match Cursor.peek t with
+  | Some (Component.Preserved { kind = Token.Number_tok _; _ }) ->
+      let n = Cursor.number t in
+      if n < 0. then Cursor.err_invalid t "negative stroke-width";
+      Number n
+  (* The grammar has no keyword branch, so the intrinsic-sizing keywords a bare
+     length would accept are out. *)
+  | _ ->
+      Length
+        (Values.read_length_percentage ~allow_negative:false
+           ~with_keywords:false t)
+
+let rec read_stroke_width t : stroke_width =
+  Cursor.enum_or_calls "stroke-width"
+    [
+      ("inherit", (Inherit : stroke_width));
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~calls:[ ("var", fun t -> Var (Values.read_var read_stroke_width t)) ]
+    ~default:read_stroke_width_value t
 
 (* SVG 2 sec. 13.5.5: "A negative value for stroke-miterlimit must be treated as
    an illegal value". SVG 1.1 sec. 11.4 also required at least 1, but SVG 2

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3111,7 +3111,7 @@ let normalize_property_value : type a.
   | Perspective -> Values.normalize_length ~ctx value
   | Word_spacing -> Values.normalize_length ~ctx value
   | Text_decoration_thickness -> Values.normalize_length ~ctx value
-  | Stroke_width -> Values.normalize_length ~ctx value
+  | Stroke_width -> normalize_stroke_width ~ctx value
   | Scroll_margin_top -> Values.normalize_length ~ctx value
   | Scroll_margin_right -> Values.normalize_length ~ctx value
   | Scroll_margin_bottom -> Values.normalize_length ~ctx value
@@ -3671,7 +3671,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Box_shadow -> pp pp_shadow
   | Fill -> pp pp_svg_paint
   | Stroke -> pp pp_svg_paint
-  | Stroke_width -> pp pp_length
+  | Stroke_width -> pp pp_stroke_width
   | Transition -> pp (Pp.list ~sep:Pp.comma pp_transition)
   | Scale -> pp pp_scale
   | Outline -> pp pp_outline
@@ -3914,7 +3914,7 @@ let property_value_kind : type a. a property -> a property_value_kind option =
   | Line_height_step -> Some Length
   | Perspective -> Some Length
   | Text_decoration_thickness -> Some Length
-  | Stroke_width -> Some Length
+  | Stroke_width -> Some Stroke_width
   | Scroll_margin_top -> Some Length
   | Scroll_margin_right -> Some Length
   | Scroll_margin_bottom -> Some Length
@@ -4080,6 +4080,7 @@ let pp_property_value_kind : type a. a property_value_kind Pp.t =
   | Background_images -> Pp.string ctx "background-images"
   | Font_src -> Pp.string ctx "font-src"
   | Font_family -> Pp.string ctx "font-family"
+  | Stroke_width -> Pp.string ctx "stroke-width"
 
 let read_property_value_kind (type a) (_ : Cursor.t) : a property_value_kind =
   invalid_arg

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2335,6 +2335,14 @@ val pp_paint_order : paint_order Pp.t
 val read_paint_order : Cursor.t -> paint_order
 (** [read_paint_order t] is the [paint_order] parsed from [t]. *)
 
+val pp_stroke_width : stroke_width Pp.t
+(** [pp_stroke_width] pretty-prints a [stroke-width]. *)
+
+val read_stroke_width : Cursor.t -> stroke_width
+(** [read_stroke_width t] is the [stroke_width] parsed from [t]. A bare number
+    is in user units; anything carrying a unit or a percent sign is a
+    [<length-percentage>]. A negative width is rejected. *)
+
 val pp_dash_length : dash_length Pp.t
 (** [pp_dash_length] pretty-prints one SVG dash length. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3942,6 +3942,20 @@ type fill_rule =
   | Revert_layer
   | Var of fill_rule var
 
+(** SVG 2 sec. 13.5.3 [stroke-width]: [<length-percentage> | <number>], where a
+    bare [<number>] is a width in user units. That number is not a CSS
+    [<length>], which is why this is not plain [length_percentage]; sec. 13.5.6
+    gives the dash lengths the same shape. A negative width is invalid. *)
+type stroke_width =
+  | Number of float
+  | Length of length_percentage
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of stroke_width var
+
 (** SVG 2 sec. 13.5.4 [stroke-linecap]: the shape drawn at the ends of an open
     subpath and at the ends of each dash. *)
 type stroke_linecap =
@@ -4999,7 +5013,7 @@ type 'a property =
   | Box_shadow : shadow property
   | Fill : svg_paint property
   | Stroke : svg_paint property
-  | Stroke_width : length property
+  | Stroke_width : stroke_width property
   | Fill_rule : fill_rule property
   | Clip_rule : fill_rule property
   | Stroke_linecap : stroke_linecap property
@@ -5090,6 +5104,7 @@ type _ property_value_kind =
   | Background_images : background_image list property_value_kind
   | Font_src : Font_face.src property_value_kind
   | Font_family : font_family property_value_kind
+  | Stroke_width : stroke_width property_value_kind
 
 let equal_overflow (a : overflow) b = a = b
 let equal_grid_line (a : grid_line) b = a = b

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1734,6 +1734,12 @@ let vars_of_stroke_linejoin (value : Properties.stroke_linejoin) =
 let vars_of_stroke_miterlimit (value : Properties.stroke_miterlimit) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_stroke_width (value : Properties.stroke_width) =
+  match value with
+  | Var v -> [ V v ]
+  | Length lp -> vars_of_length_percentage lp
+  | _ -> []
+
 let vars_of_stroke_dashoffset (value : Properties.stroke_dashoffset) =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2010,7 +2016,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   (* Other length properties *)
   | Border_spacing, value -> vars_of_border_spacing value
   | Perspective, value -> vars_of_length value
-  | Stroke_width, value -> vars_of_length value
+  | Stroke_width, value -> vars_of_stroke_width value
   | Scroll_margin, value -> List.concat_map vars_of_length value
   | Scroll_margin_top, value -> vars_of_length value
   | Scroll_margin_right, value -> vars_of_length value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -140,6 +140,22 @@ let complex_values () =
   check_declaration ~expected:"fill-rule:evenodd" "fill-rule: evenodd;";
   check_declaration ~expected:"clip-rule:nonzero" "clip-rule: nonzero;";
   check_declaration ~expected:"fill-rule:var(--r)" "fill-rule: var(--r);";
+  (* SVG 2 Editor's Draft sec. 13.5.3 gives [stroke-width] the value
+     [<length-percentage> | <number>] and says "A <number> value represents a
+     value in user units", the production sec. 13.5.6 already gives the dash
+     lengths. The bare number is not a CSS <length>, so accepting it here is
+     what keeps a printed [stroke-width] readable again. *)
+  check_declaration ~roundtrip:true ~expected:"stroke-width:1.5"
+    "stroke-width: 1.5;";
+  check_declaration ~roundtrip:true ~expected:"stroke-width:1.5px"
+    "stroke-width: 1.5px;";
+  check_declaration ~roundtrip:true ~expected:"stroke-width:50%"
+    "stroke-width: 50%;";
+  check_declaration ~roundtrip:true ~expected:"stroke-width:var(--w)"
+    "stroke-width: var(--w);";
+  (* Same section: "A negative value is invalid." *)
+  none_cursor read_declaration "stroke-width: -1";
+  none_cursor read_declaration "stroke-width: -1px";
   (* SVG 2 sec. 13.5.4 and 13.5.5. [miter-clip] and [arcs] are the Level 2
      additions to [stroke-linejoin]; a reader that takes the grammar takes all
      five. *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -192,6 +192,9 @@ let check_svg_paint = check_value_cursor "svg-paint" read_svg_paint pp_svg_paint
 let check_direction = check_value_cursor "direction" read_direction pp_direction
 let check_fill_rule = check_value_cursor "fill-rule" read_fill_rule pp_fill_rule
 
+let check_stroke_width =
+  check_value_cursor "stroke-width" read_stroke_width pp_stroke_width
+
 let check_stroke_linecap =
   check_value_cursor "stroke-linecap" read_stroke_linecap pp_stroke_linecap
 
@@ -2993,6 +2996,19 @@ let test_fill_rule () =
   neg_cursor read_fill_rule "even-odd";
   neg_cursor ~allow_partial:true read_fill_rule "nonzero evenodd"
 
+(* SVG 2 sec. 13.5.3 gives [stroke-width] [<length-percentage> | <number>]: a
+   bare number is a width in user units, not a CSS [<length>], and a negative
+   value is invalid. *)
+let test_stroke_width () =
+  check_stroke_width "1.5";
+  check_stroke_width "0";
+  check_stroke_width "1.5px";
+  check_stroke_width "50%";
+  check_stroke_width "var(--w)";
+  neg_cursor read_stroke_width "-1";
+  neg_cursor read_stroke_width "-1px";
+  neg_cursor read_stroke_width "thick"
+
 let test_stroke_linecap () =
   check_stroke_linecap "butt";
   check_stroke_linecap "round";
@@ -4611,6 +4627,7 @@ let additional_tests =
     test_case "svg_paint" `Quick test_svg_paint;
     test_case "direction" `Quick test_direction;
     test_case "fill_rule" `Quick test_fill_rule;
+    test_case "stroke_width" `Quick test_stroke_width;
     test_case "stroke_linecap" `Quick test_stroke_linecap;
     test_case "stroke_linejoin" `Quick test_stroke_linejoin;
     test_case "stroke_miterlimit" `Quick test_stroke_miterlimit;


### PR DESCRIPTION
Cascade printed `stroke-width: 1.5` and then refused that same declaration when reading it back, so its output did not round-trip through its own parser. `Values` builds a `Dimension` with an empty unit and the `length`-typed property printed it as a bare number.

SVG 2 sec. 13.5.3 settles which side is wrong: `stroke-width` is `<length-percentage> | <number>`, and a number there is a width in user units rather than a CSS `<length>`. So the reader was wrong to refuse it. Rather than let an empty-unit dimension stand for a length everywhere, which would weaken length validation across the library, `stroke-width` gets its own type carrying the number as its own arm. A negative width is still refused, per the same section.
