### PR TITLE
diff: merge a selector's changes when one entry names the move

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -798,6 +798,9 @@ recorded cases carrying six minifiers' answers.
 
 ### CLI tools
 
+- `cascade diff` names a selector whose rules a feature query splits once,
+  where two entries under it claimed a declaration gained and another lost
+  that the selector never stopped writing (#580)
 - `cascade apply` reads a `style` attribute as a declaration list in source
   order. The declarations came out reversed, so a longhand beat the shorthand
   it was written after, and a `}` inside the attribute closed the list early

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2149,12 +2149,17 @@ let change_sides : rule_diff -> Css.declaration list * Css.declaration list =
       (old_declarations, new_declarations)
   | _ -> ([], [])
 
+(* A property arriving and a property leaving, judged on what the entry names
+   rather than on which constructor it is: a [Content_changed] that only
+   restates a value, or that names nothing at all, moves no declaration. *)
 let change_gains : rule_diff -> bool = function
-  | Added _ | Content_changed _ -> true
+  | Added _ -> true
+  | Content_changed { added_properties; _ } -> added_properties <> []
   | _ -> false
 
 let change_loses : rule_diff -> bool = function
-  | Removed _ | Content_changed _ -> true
+  | Removed _ -> true
+  | Content_changed { removed_properties; _ } -> removed_properties <> []
   | _ -> false
 
 (* Every declaration [sel] writes on one side, across all of its rules. *)
@@ -2190,7 +2195,12 @@ let merge_selector_group ~rules1 ~rules2 sel peers =
 
    Only a group that both gains and loses collapses: several rules added under
    one selector really are several additions, and merging those would hide the
-   count. *)
+   count. A single entry carries both sides of that on its own, and does when a
+   container sits between two rules of one selector: the two sheets then no
+   longer line up rule for rule, and the positional walk pairs one rule of the
+   selector against another, reading as a swap of declarations that never left
+   the selector. What the selector writes across all of its rules is what
+   settles it. *)
 let merge_same_selector_changes ~rules1 ~rules2 (changes : rule_diff list) :
     rule_diff list =
   let done_ = Hashtbl.create 8 in
@@ -2204,7 +2214,7 @@ let merge_same_selector_changes ~rules1 ~rules2 (changes : rule_diff list) :
             List.filter (fun d -> changed_selector d = Some sel) changes
           in
           match peers with
-          | _ :: _ :: _
+          | _ :: _
             when List.exists change_gains peers
                  && List.exists change_loses peers ->
               Hashtbl.replace done_ sel ();

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -111,3 +111,35 @@ an added !important changes what the selector writes.
   [1]
 
 
+
+
+
+The guard does not have to be one the optimizer can drop. Under a feature
+query no browser satisfies, each utility keeps all three of its rules and
+the two sides still differ only in which group comes first. Neither selector
+gains or loses a declaration, so neither may be reported as modified.
+
+  $ cat > guarded_ref.css <<'EOF'
+  > @layer utilities{.x{--c:1}@supports (zoo:bar){.x{--c:2}}.x{--d:3}.y{--c:4}@supports (zoo:bar){.y{--c:5}}.y{--d:6}}
+  > EOF
+  $ cat > guarded_tw.css <<'EOF'
+  > @layer utilities{.y{--c:4}@supports (zoo:bar){.y{--c:5}}.y{--d:6}.x{--c:1}@supports (zoo:bar){.x{--c:2}}.x{--d:3}}
+  > EOF
+  $ cascade diff --diff=canonical --depth=max guarded_ref.css guarded_tw.css
+  CSS: 115 chars vs 115 chars (0.0% diff)
+  Changes: 1 changed container
+  
+  --- guarded_ref.css
+  +++ guarded_tw.css
+  └─ @layer utilities (1 reordered, 2 rearranged)
+     ├─ .x (position 2) ↔  .y (position 0)
+     ├─ .x (moved between rules)
+     │       --c 1
+     │       --d 3
+     ├─ .y (moved between rules)
+     │       --c 4
+     │       --d 6
+     └─ @supports (zoo: bar) (1 reordered)
+        └─ .x ↔  .y
+  
+  [1]


### PR DESCRIPTION
When one selector's rules are split across a non-baseline `@supports` guard, the canonical report claimed `.x` loses `--d` and gains `--c` while `.y` does the reverse, though both write both properties on both sides. The report was false, not merely noisy; it now reads `moved between rules` for each.

`merge_same_selector_changes` required two peer entries. The positional walk pairs one of the selector's entries as `Content_changed` and leaves the other a `Reordered`, which `changed_selector` maps away, so the merge never saw its second peer. Relaxing that to a single peer also meant reading what an entry actually names, through `added_properties` and `removed_properties`, rather than treating every `Content_changed` as both a gain and a loss: without that a nested-block-only change grew a spurious move.

The item that prompted this said the tree renderer was at fault and canonical was unaffected. It is the other way round for this shape. The canonical verdict is untouched either way, since `diff_canonical` decides identical or different by byte equality of the two canonical forms and never consults the tree.
