### PR TITLE
diff: state a selector's move once in the tree report

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -798,6 +798,9 @@ recorded cases carrying six minifiers' answers.
 
 ### CLI tools
 
+- `cascade diff --diff=tree` states a selector's move once. The entry names the
+  selector, not the rule, so a selector whose several rules cross together
+  printed the same line and counted the move once per rule (#581)
 - `cascade diff` names a selector whose rules a feature query splits once,
   where two entries under it claimed a declaration gained and another lost
   that the selector never stopped writing (#580)

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2222,6 +2222,60 @@ let merge_same_selector_changes ~rules1 ~rules2 (changes : rule_diff list) :
           | _ -> Some diff))
     changes
 
+(* Everything a [Reordered] entry puts in the report, as one string; [None] for
+   any other entry. Two entries sharing a key print the same line. *)
+let reorder_key : rule_diff -> string option = function
+  | Reordered r ->
+      let buf = Buffer.create 64 in
+      let add_decls = function
+        | None -> Buffer.add_char buf '-'
+        | Some decls ->
+            List.iter
+              (fun decl ->
+                let name, value = decl_to_prop_value decl in
+                add_strings buf [ name; ":"; value; ";" ])
+              decls
+      in
+      add_strings buf
+        [
+          r.selector;
+          "|";
+          string_of_int r.expected_pos;
+          "|";
+          string_of_int r.actual_pos;
+          "|";
+          Option.value r.swapped_with ~default:"-";
+          "|";
+        ];
+      add_decls r.old_declarations;
+      Buffer.add_char buf '|';
+      add_decls r.new_declarations;
+      Some (Buffer.contents buf)
+  | Added _ | Removed _ | Content_changed _ | Selector_changed _ | Rearranged _
+  | Regrouped _ ->
+      None
+
+(* One move, one entry. A reorder names the selector and the position that
+   selector holds on each side; which of its rules carried the declarations
+   across is no part of it. A selector written by several rules that travel
+   together therefore builds the same entry once per rule, and the node then
+   states the move as many times as it has rules and counts it as many times
+   over. Keyed on what the entry prints rather than on the selector alone, so a
+   declaration-level reorder inside another rule of that selector is a different
+   entry and stays. *)
+let dedup_reorders (changes : rule_diff list) : rule_diff list =
+  let seen = Hashtbl.create 8 in
+  List.filter
+    (fun diff ->
+      match reorder_key diff with
+      | None -> true
+      | Some key ->
+          if Hashtbl.mem seen key then false
+          else (
+            Hashtbl.replace seen key ();
+            true))
+    changes
+
 (* At-rules that carry neither a selector nor a condition the other processors
    key on: [@page], [@font-face], [@counter-style], [@scope], [@starting-style]
    and friends. [rule_diffs] gives every one of them the universal selector, so
@@ -2347,6 +2401,7 @@ let to_rule_changes rules1 rules2 : rule_diff list =
   @ List.filter_map (convert_modified_rule ~moved ~rules1 ~rules2) r_modified
   @ r_regrouped
   |> merge_same_selector_changes ~rules1 ~rules2
+  |> dedup_reorders
 
 (* Generic helpers for processing nested containers *)
 let extract_items_with_positions extract_fn stmts =

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -143,3 +143,48 @@ gains or loses a declaration, so neither may be reported as modified.
         └─ .x ↔  .y
   
   [1]
+
+
+
+The tree view of the same pair names the move once. A [Reordered] entry
+carries the selector and the position that selector holds on each side, not
+the rule that carried it, so the two rules of `.x` crossing `.y` together
+are one fact stated once, and the summary counts what the node reports.
+
+  $ cascade diff --diff=tree --depth=max guarded_ref.css guarded_tw.css
+  CSS: 115 chars vs 115 chars (0.0% diff)
+  Changes: 1 changed container
+  
+  --- guarded_ref.css
+  +++ guarded_tw.css
+  └─ @layer utilities (1 reordered)
+     ├─ .x (position 3) ↔  .y (position 0)
+     └─ @supports (zoo: bar) (1 reordered)
+        └─ .x ↔  .y
+  
+  [1]
+
+
+
+Nothing about the walk that pairs the two sides position by position: a
+structural change elsewhere in the container sends the same selector down
+the exact-match path, which names the move once as well.
+
+  $ cat > swap_ref.css <<'EOF'
+  > @layer u{.x{--c:1}.x{--d:3}.y{--c:4}.z{--e:9}}
+  > EOF
+  $ cat > swap_tw.css <<'EOF'
+  > @layer u{.y{--c:4}.x{--c:1}.x{--d:3}}
+  > EOF
+  $ cascade diff --diff=tree --depth=max swap_ref.css swap_tw.css
+  CSS: 47 chars vs 38 chars (19.1% diff)
+  Changes: 1 changed container
+  
+  --- swap_ref.css
+  +++ swap_tw.css
+  └─ @layer u (1 removed, 1 reordered)
+     ├─ .z
+     │     - --e 9
+     └─ .x ↔  .y
+  
+  [1]


### PR DESCRIPTION
The tree report printed the same moved pair twice and counted it as two reorders, where one selector moved. The duplicate was in the entry list, not the rendering: `reordered` derives both positions and the swapped-with selector from the selector key alone, so every rule carrying that selector builds an identical record.

A `Reordered` entry names a selector and the position it holds on each side, with no field for which rule carried the declarations across, so two rules of `.x` crossing `.y` together is one statable fact and the report has no vocabulary for a second. The count is derived from the list, so suppressing the duplicate line alone would have left the summary contradicting the body. Canonical mode already read it as one, since it coalesces the rules before the walk.

The fix sits at `to_rule_changes`, where rule pairs have already become selector-level entries, because the positional walk is not the only producer: a structural change elsewhere routes the pair down the exact-match path and duplicates identically. Both cases are pinned. The dedup keys on everything the entry prints, so a declaration-level reorder inside another rule of the same selector keeps its own entry.
