### PR TITLE
diff: name a move the rule index cannot express

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -728,6 +728,9 @@ recorded cases carrying six minifiers' answers.
   under a baseline-true `@supports`, a vendor-prefixed declaration, an
   `@import supports()` guard. The respellings gated with those, `min-width`
   into the range form and the Level 3 `not all and (...)`, still compare equal
+- `cascade diff` no longer aborts on a reordered selector holding the same rule
+  index on both sides. The report is buffered, so the assertion that met such a
+  move cost the whole report; the move is now named without a coordinate (#582)
 
 ### Library
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -440,23 +440,32 @@ let pp_content_changed ~style ~prefix ~child_prefix buf ~selector
           ~new_declarations ~property_changes ~added_properties
           ~removed_properties ~has_any_changes))
 
+(* The index counts the rules of a container, while whether the selector moved
+   is judged against the selectors both sides share, so the two disagree: the
+   middle selector of a reversal keeps its index, and a rule dropped ahead of a
+   selector shifts it back onto the one it had. Pairing that index with itself
+   states nothing, so the move is named without a coordinate. *)
 let pp_position_reorder ~prefix buf ~selector ~expected_pos ~actual_pos
     ~swapped_with =
-  assert (expected_pos <> actual_pos);
   let truncate s = String_diff.truncate_middle 40 s in
-  match swapped_with with
-  | Some other when abs (expected_pos - actual_pos) = 1 ->
-      Buffer.add_string buf
-        (prefix ^ truncate selector ^ " \xe2\x86\x94  " ^ truncate other ^ "\n")
-  | Some other ->
-      Buffer.add_string buf
-        (prefix ^ truncate selector ^ " (position " ^ string_of_int actual_pos
-       ^ ") \xe2\x86\x94  " ^ truncate other ^ " (position "
-       ^ string_of_int expected_pos ^ ")\n")
-  | None ->
-      Buffer.add_string buf
-        (prefix ^ truncate selector ^ " (position " ^ string_of_int expected_pos
-       ^ " \xe2\x86\x92 " ^ string_of_int actual_pos ^ ")\n")
+  if expected_pos = actual_pos then
+    Buffer.add_string buf (prefix ^ truncate selector ^ " (moved)\n")
+  else
+    match swapped_with with
+    | Some other when abs (expected_pos - actual_pos) = 1 ->
+        Buffer.add_string buf
+          (prefix ^ truncate selector ^ " \xe2\x86\x94  " ^ truncate other
+         ^ "\n")
+    | Some other ->
+        Buffer.add_string buf
+          (prefix ^ truncate selector ^ " (position " ^ string_of_int actual_pos
+         ^ ") \xe2\x86\x94  " ^ truncate other ^ " (position "
+         ^ string_of_int expected_pos ^ ")\n")
+    | None ->
+        Buffer.add_string buf
+          (prefix ^ truncate selector ^ " (position "
+         ^ string_of_int expected_pos ^ " \xe2\x86\x92 "
+         ^ string_of_int actual_pos ^ ")\n")
 
 let pp_regrouped ~style ~prefix ~child_prefix buf ~from_selectors ~to_selectors
     =

--- a/test/cli/diff_reorder_same_position.t
+++ b/test/cli/diff_reorder_same_position.t
@@ -1,0 +1,76 @@
+CLI: cascade diff - a move the rule index cannot express.
+
+A rule's position in these entries is its index among the rules of its
+container, but whether the selector moved is judged against the selectors
+both sides share. The two disagree: a selector can hold the same index on
+both sides and still have moved, so an entry pairing that index with itself
+carries no information and the report has to say so and keep printing.
+
+Every pair of these three inverts, so each selector moved, and the middle
+one keeps its index while doing it. The report names the move without a
+coordinate rather than pairing position 1 with position 1.
+
+  $ cat > reversed_ref.css <<'CSS'
+  > .b{--c:1}.a{--c:2}.c{--c:3}.z{--e:9}
+  > CSS
+  $ cat > reversed_tw.css <<'CSS'
+  > .c{--c:3}.a{--c:2}.b{--c:1}
+  > CSS
+  $ cascade diff --diff=tree --depth=max reversed_ref.css reversed_tw.css
+  CSS: 37 chars vs 28 chars (24.3% diff)
+  Changes: 1 removed rule, 2 reordered rules
+  
+  --- reversed_ref.css
+  +++ reversed_tw.css
+  └─ .z
+        - --e 9
+  Rules reordered (2 rules):
+  ├─ .b (position 2) ↔  .c (position 0)
+  └─ .a (moved)
+  
+  [1]
+
+The same pair inside a container reports through the container renderer.
+
+  $ cat > layer_ref.css <<'CSS'
+  > @layer u{.b{--c:1}.a{--c:2}.c{--c:3}.z{--e:9}}
+  > CSS
+  $ cat > layer_tw.css <<'CSS'
+  > @layer u{.c{--c:3}.a{--c:2}.b{--c:1}}
+  > CSS
+  $ cascade diff --diff=tree --depth=max layer_ref.css layer_tw.css
+  CSS: 47 chars vs 38 chars (19.1% diff)
+  Changes: 1 changed container
+  
+  --- layer_ref.css
+  +++ layer_tw.css
+  └─ @layer u (1 removed, 2 reordered)
+     ├─ .z
+     │     - --e 9
+     ├─ .b (position 2) ↔  .c (position 0)
+     └─ .a (moved)
+  
+  [1]
+
+A dropped rule ahead of the selector lands the move on the same index too.
+Here `.a` really does cross `.b`, and the index is 1 on both sides only
+because `.z` left.
+
+  $ cat > shifted_ref.css <<'CSS'
+  > .z{--e:9}.a{--c:2}.b{--c:1}
+  > CSS
+  $ cat > shifted_tw.css <<'CSS'
+  > .b{--c:1}.a{--c:2}
+  > CSS
+  $ cascade diff --diff=tree --depth=max shifted_ref.css shifted_tw.css
+  CSS: 28 chars vs 19 chars (32.1% diff)
+  Changes: 1 removed rule, 1 reordered rule
+  
+  --- shifted_ref.css
+  +++ shifted_tw.css
+  └─ .z
+        - --e 9
+  Rules reordered (1 rules):
+  └─ .a (moved)
+  
+  [1]


### PR DESCRIPTION
`cascade diff` used to abort with an assertion failure when a reordered selector held the same rule index on both sides. The report is buffered, so nothing printed at all, not even the summary line.
