### PR TITLE
docs: split the agent file from the contributor docs

### DIFF
--- a/.claude/rules/diff.md
+++ b/.claude/rules/diff.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "lib/diff/**"
+---
+
+# Structural diff
+
+The canonical projection decides what two sheets have to agree on. It may fold
+a difference in spelling, and it may not delete content a browser still
+paints. A progressive-enhancement fallback and a vendor-prefixed declaration
+are both live, and so is an `@import supports()` guard. Deleting from both
+sides makes sheets that render differently compare equal, which is the failure
+mode this projection has.
+
+The comparator may equate spellings the optimizer has to keep verbatim, since
+a comparison emits nothing. That asymmetry is deliberate. It is not a licence
+for a diff-only shim: canonical comparison inherits the optimizer's passes.
+
+Rule order is judged on a longest order-preserving matching of the statements
+both sides share, with containers among the order keys. Absolute rule indexes
+are a different coordinate and the two disagree, so an index cannot always
+express a move that the matching found. A renderer meeting a shape it cannot
+spell reports less. It never asserts: the report is buffered, so raising there
+costs the whole report rather than the one entry.

--- a/.claude/rules/optimize.md
+++ b/.claude/rules/optimize.md
@@ -1,0 +1,36 @@
+---
+paths:
+  - "lib/optimize.ml"
+  - "lib/factor.ml"
+  - "lib/factor_safe.ml"
+  - "lib/merge.ml"
+  - "lib/cover.ml"
+  - "lib/shorthand.ml"
+  - "lib/rule_graph.ml"
+  - "lib/rule_scheduler.ml"
+  - "lib/rule_order.ml"
+---
+
+# The optimizer matches the typed AST
+
+Never compare or `String.starts_with` a property name here. Pattern-match the
+property constructors. A longhand with no constructor is untyped: give it a
+type first, then match it. A string test silently covers the wrong set the
+moment a property is renamed or a vendor twin appears.
+
+`scope` picks the world the pass may assume. `` `Fragment `` is the default and
+assumes the sheet may be one part of a page. `` `Stylesheet `` is closed over
+the CSS text only, never over runtime layout: it may not assume a writing mode
+or a direction, and it knows nothing about the DOM. Shorthand synthesis from partial
+coverage needs `` `Stylesheet ``.
+
+The default objective is transfer size, gated on a compressed-size estimate. A
+rewrite that shrinks the raw bytes and grows the compressed output is not a
+win. `` `Raw `` is the opt-out.
+
+Fold only when the result is exactly value-preserving. An approximate `calc`
+fold that is right for the sampled inputs is still wrong.
+
+Factoring a value into a shared block needs selector-overlap reasoning: taking
+the first rule's value is unsafe when a later rule repeats it and an
+intermediate rule with an overlapping selector writes a different one.

--- a/.claude/rules/printer.md
+++ b/.claude/rules/printer.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - "lib/pp.ml"
+  - "lib/pp.mli"
+---
+
+# The printer is a pure serializer
+
+`Pp` serializes the AST it is given. It may only pick a different spelling of
+the same node: float and whitespace formatting, separators, the shortest
+equivalent lexical form. It may not change the node.
+
+The litmus test is `parse a = parse b`. If the two spellings parse to different
+ASTs, the rewrite is not a printing choice and belongs in `Optimize`, which
+maps AST to AST. Colour cross-folds, `calc` folding, unit and keyword folds,
+and `scale(x,x)` to `scale(x)` are all node-changing and all live there.
+
+Keeping this line is what makes factoring deterministic and idempotent: two
+declarations that minify to the same text have to hash the same, and a fold
+smuggled into the printer breaks that without failing any printer test.
+
+Test both forms per scenario, minify alone and minify with `--optimize`, and derive
+the held form from the spec rather than from what the code currently prints.

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ _opam
 _homebrew_build/
 *~
 .DS_Store
-.claude/
+.claude/*
+!.claude/rules/
 
 /mono
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,50 +1,30 @@
-# Cascade -- CSS Library for OCaml
+# Cascade
 
-## What is this?
+A CSS generation and manipulation library and CLI: a typed CSS AST, parser,
+pretty-printer, structural diff and optimizer, with no Tailwind-specific code.
+`README.md` covers what the tool does, how it is built and tested, and the
+oracle corpora the suite replays.
 
-A standalone CSS generation and manipulation library extracted from the `tw`
-(Tailwind CSS v4 in OCaml) project. It provides a typed CSS AST, parser,
-pretty-printer, structural transformation helpers, structural diff tools, and
-optimizer with no Tailwind-specific code.
+## Scope
 
-Cascade is a CSS library scoped to CSS text and CSS ASTs. It should parse,
-print, minify, diff, fold/map/sort, and apply safe AST transforms.
-Context-supplied evaluations are in scope when the caller provides the needed
-data through an explicit closed context record; theme/default based `var()`
-output is an existing example, and `Css.Context.t` is the context
-type for property-value transforms.
+Cascade is scoped to CSS text and CSS ASTs: parse, print, minify, diff,
+fold/map/sort, and safe AST transforms. A context-supplied evaluation is in
+scope when the caller passes the data in through an explicit closed context
+record; `Css.Context.t` is that type for property-value transforms, and
+theme-based `var()` output is the worked example. Tailwind-specific code, and
+Cascade APIs that exist only to serve Tailwind, belong in the `tw` project.
 
-## Build & Test
+`lib/` is flat and large. Read the interface next to a module rather than
+guessing from its name, and prefer extending an existing pass to adding one.
 
-```bash
-dune build
-dune test
-```
+## Working on it
 
-## Project Structure
-
-```
-lib/           CSS library (public_name: cascade)
-  css.ml       Main entry point: of_string, to_string, rule, etc.
-  values.ml    CSS values: lengths, colors, angles, durations
-  properties.ml CSS properties: typed property/value pairs
-  selector.ml  CSS selectors: class, id, pseudo, combinators
-  declaration.ml Declarations and custom properties
-  stylesheet.ml Statements: rules, @media, @layer, @supports, etc.
-  reader.ml    CSS parser
-  pp.ml        CSS pretty-printer (minification support)
-  optimize.ml  CSS optimizer (dedup, merge, combine)
-  variables.ml CSS custom properties and @property
-  media.ml     Media queries
-  supports.ml  @supports conditions
-  container.ml @container queries
-  font_face.ml @font-face
-  keyframe.ml  @keyframes
-  diff/        CSS diff sub-library (public_name cascade.diff)
-    css_compare.ml  Structural CSS diff
-    tree_diff.ml    Tree-based diff algorithm
-    string_diff.ml  String-level diff
-test/          CSS parser and printer tests
-bin/           cascade binary (fmt + diff subcommands)
-```
-
+- Start a behavioural change with a test that fails on current `main`. A test
+  that passes before the fix is pinning something else.
+- When a test oracle contradicts the code, surface the contradiction and ask
+  which side is right. Never rewrite an expected output to match what the code
+  prints, and never set an expectation by calling the function under test.
+- Sealed ADTs over open extension: nothing outside this repo adds a variant, so
+  a new case should stop every site that decides about it from compiling.
+- Build a string with `Buffer`, the internal `Pp`, or `String.concat ""`, not
+  with `^`, `Printf.sprintf` or `Fmt.str`.

--- a/README.md
+++ b/README.md
@@ -429,6 +429,28 @@ parses and minifies one stylesheet compresses to under 200 KiB
 
 ## Development and testing
 
+<!-- $MDX skip -->
+```bash
+dune build          # the library and the cascade binary
+dune test           # the whole suite: unit, cram, fuzz, interop, render
+dune fmt            # ocamlformat
+merlint             # lint the OCaml sources
+```
+
+`merlint` comes from the
+[samoht opam overlay](https://tangled.org/gazagnaire.org/opam-overlay.git);
+add the repository before `opam install merlint`.
+
+CI runs four jobs, and a change passing `dune build` and `dune test` can still
+fail two of them: `Build and test` on Linux and macOS, `Lower bounds` against
+the oldest dependency versions that solve, `ASCII source`
+([scripts/check_ascii.sh](scripts/check_ascii.sh) over the `.ml`, `.mli`,
+`.mll`, `.mly` and `dune` files), and `Lint` (ocamlformat plus merlint).
+Prose files carry their non-ASCII content.
+
+Every user-visible change gets an entry in the top version block of
+[CHANGES.md](CHANGES.md), naming the impact rather than the diff.
+
 Three oracle corpora cover parser conformance and minified-output behaviour:
 
 - **WPT parser conformance.** The `css/css-syntax/` subset of the [Web


### PR DESCRIPTION
The build and test commands lived only in `CLAUDE.md`, so a contributor cloning cascade could not find out how to build it, and nothing named the three CI gates that a green `dune build` and `dune test` still leave open.

`.claude/rules/` is un-ignored so the per-file conventions ship with the repo rather than sitting in one machine's local state.
