### PR TITLE
optimize: decide a nested @supports against the conditions around it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -389,6 +389,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` simplifies a nested `@supports` condition against the conditions
+  enclosing it, by propositional logic over its feature tests and against no
+  support table: under `@supports (A)`, an inner `@supports (A)` loses its
+  guard, an inner `@supports (A) and (B)` narrows to `(B)`, and an inner
+  `@supports (not (A))` is dead code
 - Merging a distant same-condition `@media` block carries its accumulator
   reversed instead of appending to the end, so the pass costs a line in the
   statement count rather than a square. A 4,000-statement sheet allocates

--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ Rule-level rewrites:
   (`animation:1s slide` -> `animation:slide 1s`).
 - Dead-rule elimination, `@layer` consolidation, and `@media`/`@container`
   flattening when the condition is satisfied for the evergreen target.
+- A nested `@supports` condition is decided against the conditions enclosing it:
+  a guard they already answer yes loses its wrapper, a guard they contradict
+  takes its block with it, and anything else narrows to what they leave to ask.
 - MQ4 range syntax when shorter (`(min-width:48px)` -> `(width>=48px)`).
 
 These rules compose wherever cascade has a typed CSS value. An unregistered

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -84,6 +84,18 @@ let hoist_declaration_runs = Nest.hoist_declaration_runs
 let synthesize_nesting_statements = Nest.statements
 let stylesheet_key stmts = Pp.to_string ~minify:true pp_stylesheet stmts
 
+(* Pop the run of [Rule]s most recently pushed onto a reversed accumulator, in
+   forward order, with the remaining accumulator. Unwrapping an [@supports] its
+   context already answers exposes its inner rules, and the preceding rules
+   rejoin the merge pass so an adjacency the wrapper hid can collapse. *)
+let pop_trailing_rules acc =
+  let rec loop acc rules =
+    match acc with
+    | (Rule _ as r) :: rest -> loop rest (r :: rules)
+    | _ -> (rules, acc)
+  in
+  loop acc []
+
 let rec collect_rules (stmt_acc : statement list) (rules_acc : rule list) :
     statement list -> statement list * rule list * statement list = function
   | (Rule r as stmt) :: rest ->
@@ -132,13 +144,13 @@ let split_vendor_selector_lists (stmts : statement list) : statement list =
       | other -> [ other ])
     stmts
 
-let rec statements ?factor_cache ~ctx ~enforce_spec ~owner
+let rec statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
     (stmts : statement list) : statement list =
   match stmts with
   | [] -> stmts
   | _ ->
       let optimize_merged_block =
-        statements ?factor_cache ~ctx ~enforce_spec ~owner
+        statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
       in
       (* [drop_misplaced_imports] runs first: an [@import] after a style rule is
          invalid and ignored by browsers, so it must not act as a cascade
@@ -151,7 +163,8 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~owner
           |> merge_named_layers_by_name |> split_vendor_selector_lists
         in
         let stmts =
-          process_statements ?factor_cache ~ctx ~enforce_spec ~owner [] stmts
+          process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+            [] stmts
         in
         let stmts =
           if Ctx.regroup ctx then synthesize_nesting_statements stmts else stmts
@@ -168,73 +181,72 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~owner
       preserve_list stmts stmts'
 
 (* Walk the statement list left to right over a reversed accumulator. *)
-and process_statements ?factor_cache ~ctx ~enforce_spec ~owner
+and process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
     (acc : statement list) (remaining : statement list) : statement list =
   match remaining with
   | [] -> List.rev acc
   | (Rule r as stmt) :: rest ->
-      process_rule_run ?factor_cache ~ctx ~enforce_spec ~owner acc stmt r rest
+      process_rule_run ?factor_cache ~ctx ~enforce_spec ~owner ~supports acc
+        stmt r rest
   | (Media (cond, block) as stmt) :: rest ->
-      process_media_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-        cond block rest
+      process_media_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        acc stmt cond block rest
   | (Container (name, cond, block) as stmt) :: rest ->
-      process_container_statement ?factor_cache ~ctx ~enforce_spec ~owner acc
-        stmt name cond block rest
+      process_container_statement ?factor_cache ~ctx ~enforce_spec ~owner
+        ~supports acc stmt name cond block rest
   | (Supports (cond, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-        block
-        (fun block -> Supports (cond, block))
-        rest
+      process_supports_statement ?factor_cache ~ctx ~enforce_spec ~owner
+        ~supports acc stmt cond block rest
   | (Scope (start, end_, block) as stmt) :: rest ->
       let start' = option_map_preserve canonicalize_scope_selector start in
       let end_' = option_map_preserve canonicalize_scope_selector end_ in
       let optimized_block =
-        statements ?factor_cache ~ctx ~enforce_spec ~owner block
+        statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
       in
       let optimized =
         if start' == start && end_' == end_ && optimized_block == block then
           stmt
         else Scope (start', end_', optimized_block)
       in
-      process_statements ?factor_cache ~ctx ~enforce_spec ~owner
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
         (optimized :: acc) rest
   | (Origin (origin, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-        block
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        acc stmt block
         (fun block -> Origin (origin, block))
         rest
   (* The wrapper is opaque but its body is an ordinary block, so it optimises
      like [@media]'s: a group left out here keeps whatever the author wrote and
      [--minify] does nothing inside it. *)
   | (Moz_document (cond, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-        block
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        acc stmt block
         (fun block -> Moz_document (cond, block))
         rest
   | (When (cond, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-        block
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        acc stmt block
         (fun block -> When (cond, block))
         rest
   | (Else (cond, block) as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-        block
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        acc stmt block
         (fun block -> Else (cond, block))
         rest
   | (Starting_style block as stmt) :: rest ->
-      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-        block
+      process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        acc stmt block
         (fun block -> Starting_style block)
         rest
   | (Layer (name, block) as stmt) :: rest ->
-      process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-        name block rest
+      process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        acc stmt name block rest
   | (Import _ as stmt) :: rest ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~owner (stmt :: acc)
-        rest
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        (stmt :: acc) rest
   | (Declarations decls as stmt) :: rest ->
-      process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~owner acc
-        stmt decls rest
+      process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~owner
+        ~supports acc stmt decls rest
   (* Listed rather than closed with a wildcard: everything left holds no block,
      so a statement that grows one has to be classified above before it
      compiles. *)
@@ -244,45 +256,49 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~owner
      | Font_palette_values _ | Font_feature_values _ | View_transition _
      | Position_try _ | Viewport _ | Unknown_at_rule _ ) as hd)
     :: rest ->
-      process_statements ?factor_cache ~ctx ~enforce_spec ~owner (hd :: acc)
-        rest
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        (hd :: acc) rest
 
 (* A run of declarations is a declaration list wherever it sits, and nothing
    comes between two writes inside one, so the same deduplication a rule body
    gets applies (CSS Cascade 5 sec. 6.4.4: the later write wins). *)
-and process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~owner acc
-    stmt decls rest =
+and process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~owner
+    ~supports acc stmt decls rest =
   let decls' = declaration_run ~ctx decls in
   let stmt = if decls' == decls then stmt else Declarations decls' in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~owner (stmt :: acc) rest
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+    (stmt :: acc) rest
 
-and process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-    block rebuild rest =
+and process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+    acc stmt block rebuild rest =
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
   in
   let optimized =
     if optimized_block == block then stmt else rebuild optimized_block
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~owner (optimized :: acc)
-    rest
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+    (optimized :: acc) rest
 
-and process_rule_run ?factor_cache ~ctx ~enforce_spec ~owner acc stmt r rest =
+and process_rule_run ?factor_cache ~ctx ~enforce_spec ~owner ~supports acc stmt
+    r rest =
   let plain_stmts, plain_rules, rest = collect_rules [ stmt ] [ r ] rest in
-  let optimized = rules_aux ?factor_cache ~ctx ~enforce_spec plain_rules in
+  let optimized =
+    rules_aux ?factor_cache ~ctx ~enforce_spec ~supports plain_rules
+  in
   let as_statements =
     if optimized == plain_rules then plain_stmts
     else List.map (fun r -> Rule r) optimized
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~owner
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
     (List.rev_append as_statements acc)
     rest
 
-and process_media_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-    cond block rest =
+and process_media_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+    acc stmt cond block rest =
   let cond = if enforce_spec then cond else Media.lower_for_minify cond in
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
   in
   let optimized =
     if
@@ -291,17 +307,17 @@ and process_media_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
     then stmt
     else Media (cond, optimized_block)
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~owner (optimized :: acc)
-    rest
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+    (optimized :: acc) rest
 
-and process_container_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-    name cond block rest =
+and process_container_statement ?factor_cache ~ctx ~enforce_spec ~owner
+    ~supports acc stmt name cond block rest =
   let cond =
     if enforce_spec then cond
     else option_map_preserve Container.lower_for_minify cond
   in
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
   in
   let optimized =
     if
@@ -310,13 +326,47 @@ and process_container_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
     then stmt
     else Container (name, cond, optimized_block)
   in
-  process_statements ?factor_cache ~ctx ~enforce_spec ~owner (optimized :: acc)
-    rest
+  process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+    (optimized :: acc) rest
 
-and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
-    name block rest =
+and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+    acc stmt cond block rest =
+  match Supports.simplify_under ~context:supports cond with
+  (* The guard selects no user agent, so nothing in its block is ever applied
+     (CSS Conditional 3 sec. 2). Its cascade layers go with it: CSS Cascade 5
+     sec. 6.4.1 keeps a layer defined inside a conditional group rule out of the
+     layer order unless the condition is true, and a feature query is answered
+     once for the whole document rather than per element. *)
+  | `False ->
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports acc
+        rest
+  (* The guard holds wherever the block enclosing it does, so its contents apply
+     exactly where they already sit. Splicing them into the enclosing stream -
+     with the run of rules already accumulated - lets an adjacency the wrapper
+     hid collapse. *)
+  | `True ->
+      let block' =
+        statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
+      in
+      let trailing, acc = pop_trailing_rules acc in
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports acc
+        (List.concat [ trailing; block'; rest ])
+  | `Cond cond' ->
+      let block' =
+        statements ?factor_cache ~ctx ~enforce_spec ~owner
+          ~supports:(cond' :: supports) block
+      in
+      let optimized =
+        if cond' == cond && block' == block then stmt
+        else Supports (cond', block')
+      in
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        (optimized :: acc) rest
+
+and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+    acc stmt name block rest =
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner block
+    statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
   in
   if is_layer_empty optimized_block then
     match name with
@@ -324,36 +374,38 @@ and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner acc stmt
        block keeps its block form; folding it to [Layer_decl] emits CSS every
        engine drops. *)
     | Some _ when Option.is_some owner ->
-        process_statements ?factor_cache ~ctx ~enforce_spec ~owner
+        process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
           (Layer (name, optimized_block) :: acc)
           rest
     | Some layer_name ->
         let all_names, remaining =
           collect_empty_layer_names [ layer_name ] rest
         in
-        process_statements ?factor_cache ~ctx ~enforce_spec ~owner
+        process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
           (Layer_decl all_names :: acc)
           remaining
     | None ->
-        process_statements ?factor_cache ~ctx ~enforce_spec ~owner acc rest
+        process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports acc
+          rest
   else
     let optimized =
       if optimized_block == block then stmt else Layer (name, optimized_block)
     in
-    process_statements ?factor_cache ~ctx ~enforce_spec ~owner
+    process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
       (optimized :: acc) rest
 
 (* Optimize one rule's nested statements recursively, then drop the redundant
    nesting prefix (see [drop_nesting_prefix]) and let a run written after them
    rejoin the rule's own declarations wherever the cascade allows. The body is
    the rule's, so it optimizes with the rule as owner. *)
-and rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec rule =
+and rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec ~supports rule =
   let nested =
     match rule.nested with
     | [] -> []
     | nested ->
         let nested =
-          statements ?factor_cache ~ctx ~enforce_spec ~owner:(Some rule) nested
+          statements ?factor_cache ~ctx ~enforce_spec ~owner:(Some rule)
+            ~supports nested
         in
         if enforce_spec then nested
         else list_map_preserve drop_nesting_prefix nested
@@ -365,10 +417,11 @@ and rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec rule =
   in
   merge_lone_nested_rule rule
 
-and rules_aux ?factor_cache ~ctx ~enforce_spec (rules : rule list) : rule list =
+and rules_aux ?factor_cache ~ctx ~enforce_spec ~supports (rules : rule list) :
+    rule list =
   let with_optimized_nested =
     list_map_preserve
-      (rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec)
+      (rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec ~supports)
       rules
   in
   (* Apply local rule normalization before the DAG factor scheduler decides
@@ -436,10 +489,10 @@ let drop_shadowed_keyframes (stmts : statement list) : statement list =
 let statements_top_level ?factor_cache ~ctx ~enforce_spec
     (stmts : statement list) : statement list =
   let optimize_merged_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner:None
+    statements ?factor_cache ~ctx ~enforce_spec ~owner:None ~supports:[]
   in
   let stmts' =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner:None stmts
+    statements ?factor_cache ~ctx ~enforce_spec ~owner:None ~supports:[] stmts
     |> merge_consecutive_layers ~optimize_merged_block
     |> drop_redundant_layer_decls |> drop_shadowed_keyframes
   in
@@ -452,7 +505,8 @@ let single_rule ?scope (rule : rule) : rule =
       {
         rule with
         nested =
-          statements ~ctx ~enforce_spec:false ~owner:(Some rule) rule.nested;
+          statements ~ctx ~enforce_spec:false ~owner:(Some rule) ~supports:[]
+            rule.nested;
       }
   in
   {
@@ -461,7 +515,7 @@ let single_rule ?scope (rule : rule) : rule =
   }
 
 let rules ?scope (rules : rule list) : rule list =
-  rules_aux ~ctx:(ctx_of_scope scope) ~enforce_spec:false rules
+  rules_aux ~ctx:(ctx_of_scope scope) ~enforce_spec:false ~supports:[] rules
 
 (** {1 Nesting Flattening} *)
 

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -577,3 +577,151 @@ let rec compare t1 t2 =
   | _, And _ -> 1
 
 let equal a b = compare a b = 0
+
+(* ===== Entailment against the enclosing conditions ===== *)
+
+(* CSS Conditional 3 sec. 6 gives every term of a [<supports-condition>] a
+   two-valued result - of [<general-enclosed>] it says "The result is false",
+   not unknown - so a condition is a propositional formula over its feature
+   tests and classical entailment holds over it. A user agent answers one
+   feature test the same way everywhere in a sheet, so the conditions enclosing
+   a nested [@supports] are facts about whichever user agent reaches it. Nothing
+   below reads a support table.
+
+   Atom identity is syntactic: two feature tests are one variable exactly when
+   {!compare} calls them equal. Two spellings a user agent in fact answers alike
+   stay two variables, which enumerates worlds that do not exist; entailment
+   over that superset holds over the real world set too, so the approximation
+   only ever concludes less. *)
+
+(* A containment chain carries few distinct feature tests, so the truth table is
+   decided outright rather than searched. Past the cap the condition is left as
+   the author wrote it. *)
+let max_atoms = 16
+
+let rec collect_atoms acc = function
+  | (Property _ | Function _) as atom ->
+      if List.exists (fun a -> equal a atom) acc then acc
+      else if List.length acc >= max_atoms then raise Exit
+      else atom :: acc
+  | Not a -> collect_atoms acc a
+  | And (a, b) | Or (a, b) -> collect_atoms (collect_atoms acc a) b
+
+(* A truth vector holds one bit per assignment: bit [j] is the formula's value
+   under the assignment that reads bit [i] of [j] as the value of atom [i]. So
+   [and], [or] and [not] are bitwise, and one pass over [2^n / 8] bytes settles
+   a whole truth table. *)
+let vector_len n = if n <= 3 then 1 else 1 lsl (n - 3)
+
+let all_true n =
+  if n >= 3 then Bytes.make (vector_len n) '\xff'
+  else
+    (* Under three atoms the whole table fits in one byte's low bits. *)
+    Bytes.make 1 (Char.unsafe_chr [| 0b1; 0b11; 0b1111 |].(n))
+
+let map2 f a b =
+  Bytes.init (Bytes.length a) (fun i ->
+      Char.unsafe_chr
+        (f (Char.code (Bytes.get a i)) (Char.code (Bytes.get b i)) land 0xff))
+
+let v_and = map2 ( land )
+let v_or = map2 ( lor )
+let v_not ~all v = map2 ( lxor ) all v
+
+(* Atom [i] is true under assignment [j] when bit [i] of [j] is set. Below three
+   atoms that bit varies inside a byte, giving a fixed pattern; above it, whole
+   bytes alternate. *)
+let atom_vector n i =
+  let len = vector_len n in
+  if i < 3 then
+    v_and (all_true n)
+      (Bytes.make len (Char.unsafe_chr [| 0xaa; 0xcc; 0xf0 |].(i)))
+  else
+    Bytes.init len (fun b ->
+        if (b lsr (i - 3)) land 1 = 1 then '\xff' else '\000')
+
+let for_all_bytes f a b =
+  let rec loop i =
+    i >= Bytes.length a
+    || f (Char.code (Bytes.get a i)) (Char.code (Bytes.get b i))
+       && loop (i + 1)
+  in
+  loop 0
+
+let implies a b = for_all_bytes (fun x y -> x land lnot y land 0xff = 0) a b
+let disjoint a b = for_all_bytes (fun x y -> x land y = 0) a b
+let never v = Bytes.for_all (fun c -> c = '\000') v
+
+let rec eval ~atom ~all = function
+  | (Property _ | Function _) as leaf -> atom leaf
+  | Not a -> v_not ~all (eval ~atom ~all a)
+  | And (a, b) -> v_and (eval ~atom ~all a) (eval ~atom ~all b)
+  | Or (a, b) -> v_or (eval ~atom ~all a) (eval ~atom ~all b)
+
+(* Rewriting stays conservative where deciding is complete: a subformula the
+   context settles is replaced by its value and absorbed, and the author's shape
+   survives everywhere else. A minimised sum of products is usually longer as
+   CSS text and is not what the author wrote. *)
+let rec reduce ~atom ~world ~all cond =
+  let decide v residual =
+    if implies world v then (v, `True)
+    else if disjoint world v then (v, `False)
+    else (v, residual)
+  in
+  match cond with
+  | Property _ | Function _ -> decide (atom cond) (`Cond cond)
+  | Not a ->
+      let va, ra = reduce ~atom ~world ~all a in
+      let residual =
+        match ra with
+        | `True -> `False
+        | `False -> `True
+        | `Cond a' -> `Cond (if a' == a then cond else Not a')
+      in
+      decide (v_not ~all va) residual
+  | And (a, b) ->
+      let va, ra = reduce ~atom ~world ~all a in
+      let vb, rb = reduce ~atom ~world ~all b in
+      let residual =
+        match (ra, rb) with
+        | `False, _ | _, `False -> `False
+        | `True, r | r, `True -> r
+        | `Cond a', `Cond b' ->
+            `Cond (if a' == a && b' == b then cond else And (a', b'))
+      in
+      decide (v_and va vb) residual
+  | Or (a, b) ->
+      let va, ra = reduce ~atom ~world ~all a in
+      let vb, rb = reduce ~atom ~world ~all b in
+      let residual =
+        match (ra, rb) with
+        | `True, _ | _, `True -> `True
+        | `False, r | r, `False -> r
+        | `Cond a', `Cond b' ->
+            `Cond (if a' == a && b' == b then cond else Or (a', b'))
+      in
+      decide (v_or va vb) residual
+
+let simplify_under ~context cond =
+  match List.fold_left collect_atoms [] (cond :: context) with
+  | exception Exit -> `Cond cond
+  | atoms -> (
+      let atoms = Array.of_list atoms in
+      let n = Array.length atoms in
+      let all = all_true n in
+      let vectors = Array.init n (atom_vector n) in
+      let atom leaf =
+        let rec find i =
+          if equal atoms.(i) leaf then vectors.(i) else find (i + 1)
+        in
+        find 0
+      in
+      let world =
+        List.fold_left (fun w c -> v_and w (eval ~atom ~all c)) all context
+      in
+      if never world then `False
+      else
+        let size c = Pp.size ~minify:true pp c in
+        match snd (reduce ~atom ~world ~all cond) with
+        | `Cond c when (not (c == cond)) && size c >= size cond -> `Cond cond
+        | decision -> decision)

--- a/lib/supports.mli
+++ b/lib/supports.mli
@@ -99,3 +99,18 @@ val compare : t -> t -> int
 
 val equal : t -> t -> bool
 (** [equal a b] tests structural equality. *)
+
+val simplify_under : context:t list -> t -> [ `True | `False | `Cond of t ]
+(** [simplify_under ~context cond] decides [cond] against the conjunction [K] of
+    the conditions enclosing it. [`True] means [K and not cond] is
+    unsatisfiable, so [cond] holds wherever [K] does and its guard asks a
+    question already answered; [`False] means [K and cond] is unsatisfiable, so
+    the guard selects no user agent; [`Cond c] keeps the guard, narrowed to what
+    [K] leaves of it when that is shorter and left as written otherwise.
+
+    Every feature test is one propositional variable, keyed by {!compare}, and
+    the decision is the truth table over them: CSS Conditional 3 sec. 6 gives
+    every term a two-valued result, [<general-enclosed>] included. No support
+    table is consulted, so the answer holds whatever the user agent answers. A
+    chain carrying more than sixteen distinct feature tests is returned
+    unchanged. *)

--- a/test/cli/supports_entailment.t
+++ b/test/cli/supports_entailment.t
@@ -1,0 +1,285 @@
+CLI: --minify simplifies a nested @supports condition against its context.
+
+CSS Conditional Rules 3 sec. 6 evaluates a condition as a two-valued boolean
+over feature tests: [not] negates, [and] is true when every term is true, [or]
+is false when every term is false, and a [<general-enclosed>] term the UA does
+not understand is false rather than unknown. A condition is therefore a
+propositional formula over its feature tests, and classical entailment holds
+over it.
+
+Inside [@supports (A)] the UA has already answered [A], and one sheet gets the
+same answer to the same question everywhere in it. An inner condition can be
+simplified against the conjunction [K] of the conditions enclosing it, by
+propositional logic alone and against no support table. Writing [C] for the
+inner condition: [K and not C] unsatisfiable means [C] is entailed, so the
+inner guard goes; [K and C] unsatisfiable means [C] is refuted, so the inner
+block is dead; otherwise the guard stays, narrowed to what [K] leaves.
+
+This is the simplification the removal of the baseline fold leaves room for. It
+asks the support table nothing, so it holds whatever the UA answers.
+
+Atom identity is syntactic: two feature tests are the same variable when they
+are structurally equal after parsing. Nothing below asks cascade to decide that
+two different spellings probe the same thing.
+
+Most rows probe properties cascade models nothing about, so that entailment is
+the only thing that can decide them. The [display] and [text-wrap] rows repeat
+the same shapes with properties cascade knows in full: what it can decide must
+not differ from what it cannot.
+
+
+# The inner condition is entailed
+
+
+An inner guard repeating its enclosing guard asks a question already answered
+yes. Its block applies exactly where the enclosing block applies, so the guard
+goes and its contents stay.
+
+  $ cat > same.css <<EOF
+  > @supports (nonsense-a: 1px) {
+  >   @supports (nonsense-a: 1px) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify same.css
+  @supports(nonsense-a:1px){.r{top:0}}
+
+A conjunction entails each of its conjuncts, so under [(A) and (B)] the inner
+[(A)] is already answered yes.
+
+  $ cat > conjunct.css <<EOF
+  > @supports (nonsense-a: 1px) and (nonsense-b: 2px) {
+  >   @supports (nonsense-a: 1px) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify conjunct.css
+  @supports(nonsense-a:1px)and (nonsense-b:2px){.r{top:0}}
+
+A disjunct entails its disjunction, so under [(A)] the inner [(A) or (B)] is
+true whatever the UA answers about [B]. [B] does not survive into the output:
+nothing left in the sheet depends on it.
+
+  $ cat > weaker.css <<EOF
+  > @supports (nonsense-a: 1px) {
+  >   @supports (nonsense-a: 1px) or (nonsense-b: 2px) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify weaker.css
+  @supports(nonsense-a:1px){.r{top:0}}
+
+Operand order is not part of the question. [(A) and (B)] and [(B) and (A)] have
+the same truth table, so the inner guard is entailed and the enclosing one
+keeps the author's order.
+
+  $ cat > commuted.css <<EOF
+  > @supports (nonsense-a: 1px) and (nonsense-b: 2px) {
+  >   @supports (nonsense-b: 2px) and (nonsense-a: 1px) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify commuted.css
+  @supports(nonsense-a:1px)and (nonsense-b:2px){.r{top:0}}
+
+De Morgan is the same truth table too: [not ((A) and (B))] and
+[(not (A)) or (not (B))] are false on exactly the same UAs.
+
+  $ cat > demorgan.css <<EOF
+  > @supports (not ((nonsense-a: 1px) and (nonsense-b: 2px))) {
+  >   @supports ((not (nonsense-a: 1px)) or (not (nonsense-b: 2px))) {
+  >     .r { top: 0 }
+  >   }
+  > }
+  > EOF
+  $ cascade --minify demorgan.css
+  @supports not ((nonsense-a:1px)and (nonsense-b:2px)){.r{top:0}}
+
+A property cascade knows in full behaves the same way. The transform reads the
+condition's shape, not a support table, so knowing what [display: grid] means
+changes nothing.
+
+  $ cat > same-real.css <<EOF
+  > @supports (display: grid) {
+  >   @supports (display: grid) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify same-real.css
+  @supports(display:grid){.r{top:0}}
+
+
+# The inner condition is refuted
+
+
+An inner guard negating its enclosing guard applies on no UA at all: [A and not
+A] is false everywhere. Its block is dead, and the enclosing block is then
+empty.
+
+  $ cat > negated.css <<EOF
+  > @supports (nonsense-a: 1px) {
+  >   @supports (not (nonsense-a: 1px)) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify negated.css
+
+Again with a property cascade knows in full.
+
+  $ cat > negated-real.css <<EOF
+  > @supports (display: grid) {
+  >   @supports (not (display: grid)) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify negated-real.css
+
+
+# A condition that decides itself
+
+
+With nothing enclosing it, [K] is the empty conjunction and the same two tests
+still apply. [(A) or (not (A))] is true on every UA, so its guard selects the
+whole population and carries no information.
+
+  $ cat > tautology.css <<EOF
+  > @supports (nonsense-a: 1px) or (not (nonsense-a: 1px)) { .r { top: 0 } }
+  > EOF
+  $ cascade --minify tautology.css
+  .r{top:0}
+
+[(A) and (not (A))] is false on every UA, so its block never applies.
+
+  $ cat > contradiction.css <<EOF
+  > @supports (nonsense-a: 1px) and (not (nonsense-a: 1px)) { .r { top: 0 } }
+  > EOF
+  $ cascade --minify contradiction.css
+
+
+# What the context leaves of the inner condition
+
+
+Under [(A)], the inner [(A) and (B)] is neither entailed (a UA can answer yes
+to [A] and no to [B]) nor refuted (one can answer yes to both). What is left to
+ask is [(B)], so that is what the inner guard becomes. The shape of the result
+is the one the unrelated-conditions control below pins: two nested guards.
+
+  $ cat > residual.css <<EOF
+  > @supports (nonsense-a: 1px) {
+  >   @supports (nonsense-a: 1px) and (nonsense-b: 2px) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify residual.css
+  @supports(nonsense-a:1px){@supports(nonsense-b:2px){.r{top:0}}}
+
+The residual again with properties cascade knows in full.
+
+  $ cat > residual-real.css <<EOF
+  > @supports (display: grid) {
+  >   @supports (display: grid) and (text-wrap: balance) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify residual-real.css
+  @supports(display:grid){@supports(text-wrap:balance){.r{top:0}}}
+
+
+# The context travels down
+
+
+Whether the UA supports a declaration does not depend on the medium, so an
+[@media] between the two guards does not reopen the question.
+
+  $ cat > through-media.css <<EOF
+  > @supports (nonsense-a: 1px) {
+  >   @media print {
+  >     @supports (nonsense-a: 1px) { .r { top: 0 } }
+  >   }
+  > }
+  > EOF
+  $ cascade --minify through-media.css
+  @supports(nonsense-a:1px){@media print{.r{top:0}}}
+
+Nor does it depend on which cascade layer the rule lands in, so an [@layer]
+between the two guards does not reopen it either.
+
+  $ cat > through-layer.css <<EOF
+  > @supports (nonsense-a: 1px) {
+  >   @layer x {
+  >     @supports (nonsense-a: 1px) { .r { top: 0 } }
+  >   }
+  > }
+  > EOF
+  $ cascade --minify through-layer.css
+  @supports(nonsense-a:1px){@layer x{.r{top:0}}}
+
+A style rule between the two guards does not reopen it either: it selects
+elements, and the UA's answer is the same for all of them. Dropping the inner
+guard leaves its declaration in the rule that held it, after the declaration
+already there.
+
+  $ cat > through-rule.css <<EOF
+  > @supports (nonsense-a: 1px) {
+  >   .r {
+  >     top: 0;
+  >     @supports (nonsense-a: 1px) { left: 0 }
+  >   }
+  > }
+  > EOF
+  $ cascade --minify through-rule.css
+  @supports(nonsense-a:1px){.r{top:0;left:0}}
+
+
+# Controls: conditions that must not move
+
+
+These rows pass before the transform exists. They are the boundary it must not
+cross.
+
+Two unrelated conditions say nothing about each other, so both guards stay.
+This is also the shape the residual row above is expected to reach.
+
+  $ cat > unrelated.css <<EOF
+  > @supports (nonsense-a: 1px) {
+  >   @supports (nonsense-b: 2px) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify unrelated.css
+  @supports(nonsense-a:1px){@supports(nonsense-b:2px){.r{top:0}}}
+
+A disjunction does not entail its disjuncts: [(A) or (B)] is true on a UA that
+answers yes to [B] and no to [A], and there the inner [(A)] still has to be
+asked.
+
+  $ cat > disjunction.css <<EOF
+  > @supports (nonsense-a: 1px) or (nonsense-b: 2px) {
+  >   @supports (nonsense-a: 1px) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify disjunction.css
+  @supports(nonsense-a:1px)or (nonsense-b:2px){@supports(nonsense-a:1px){.r{top:0}}}
+
+Context does not leak sideways. The second block is not inside the first, so a
+UA that answered no to the first still has to evaluate the second in full.
+
+  $ cat > siblings.css <<EOF
+  > @supports (nonsense-a: 1px) { .x { top: 0 } }
+  > @supports (nonsense-a: 1px) and (nonsense-b: 2px) { .y { left: 0 } }
+  > EOF
+  $ cascade --minify siblings.css
+  @supports(nonsense-a:1px){.x{top:0}}@supports(nonsense-a:1px)and (nonsense-b:2px){.y{left:0}}
+
+The same in its sharpest form: a guard and its negation as siblings are the
+fallback pattern, and both blocks apply, each on its own half of the
+population.
+
+  $ cat > siblings-negated.css <<EOF
+  > @supports (nonsense-a: 1px) { .x { top: 0 } }
+  > @supports (not (nonsense-a: 1px)) { .y { left: 0 } }
+  > EOF
+  $ cascade --minify siblings-negated.css
+  @supports(nonsense-a:1px){.x{top:0}}@supports not (nonsense-a:1px){.y{left:0}}
+
+Two feature tests on the same property are still two variables. A UA that
+accepts [display: grid] need not accept [display: inline-grid], so the inner
+guard is neither entailed nor refuted.
+
+  $ cat > same-property.css <<EOF
+  > @supports (display: grid) {
+  >   @supports (display: inline-grid) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify same-property.css
+  @supports(display:grid){@supports(display:inline-grid){.r{top:0}}}

--- a/test/cli/supports_entailment_reach.t
+++ b/test/cli/supports_entailment_reach.t
@@ -1,0 +1,61 @@
+CLI: what a refuted @supports block takes with it, and what entailment leaves
+alone.
+
+Simplifying a nested [@supports] against the conditions enclosing it deletes a
+block whose guard those conditions refute. CSS Conditional 3 sec. 2 says of a
+false condition that processors "must not apply any of rules inside the group
+rule", so the block has no effect left to preserve. Its cascade layers are the
+case worth pinning, because a layer declaration reaches past the block it sits
+in: CSS Cascade 5 sec. 6.4.1 answers it with "Layers that are defined inside of
+a conditional group rule do not contribute to the layer order unless the
+condition is true or unless the conditional group rule can evaluate differently
+for different elements in the document." A feature query is answered once for
+the whole document rather than per element, so a layer a refuted block declares
+never entered the order and deleting the block cannot move it.
+
+
+# A refuted block's layer order goes with it
+
+
+The dead block declares [b] before [a] is declared anywhere. Since it applies
+on no UA, the order the sheet establishes is [a] then [b], which is the order
+left standing.
+
+  $ cat > dead-layer.css <<EOF
+  > @supports (nonsense-a: 1px) {
+  >   @supports (not (nonsense-a: 1px)) { @layer b; }
+  >   @layer a { .x { top: 0 } }
+  >   @layer b { .x { top: 1px } }
+  > }
+  > EOF
+  $ cascade --minify dead-layer.css
+  @supports(nonsense-a:1px){@layer a{.x{top:0}}@layer b{.x{top:1px}}}
+
+The control: nothing refutes this guard, so its block applies on the UAs that
+answer yes and [@layer b;] keeps its place at the head of the order.
+
+  $ cat > live-layer.css <<EOF
+  > @supports (nonsense-b: 2px) { @layer b; }
+  > @layer a { .x { top: 0 } }
+  > @layer b { .x { top: 1px } }
+  > EOF
+  $ cascade --minify live-layer.css
+  @supports(nonsense-b:2px){@layer b;}@layer a{.x{top:0}}@layer b{.x{top:1px}}
+
+
+# The supports() clause of an @import is nested in nothing
+
+
+An [@import] sits in the sheet's prelude with no conditional group rule around
+it, so there is no context to decide its [supports()] clause against. It is
+left as the author wrote it even when the clause decides itself, while the
+[@supports] rule below it simplifies against its own context.
+
+  $ cat > import.css <<EOF
+  > @import url("x.css") supports((nonsense-a: 1px) or (not (nonsense-a: 1px)));
+  > @supports (nonsense-a: 1px) {
+  >   @supports (nonsense-a: 1px) { .r { top: 0 } }
+  > }
+  > EOF
+  $ cascade --minify import.css
+  @import"x.css"supports((nonsense-a:1px)or (not (nonsense-a:1px)));@supports(nonsense-a:1px){.r{top:0}}

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -696,6 +696,77 @@ let test_supports_author_guard_kept_by_default () =
     "@supports not (display:grid){.a{display:flex}}"
     (minify "@supports (not (display:grid)){.a{display:flex}}")
 
+let test_supports_entailed_by_its_context () =
+  (* CSS Conditional 3 sec. 6 evaluates a condition as a two-valued boolean over
+     its feature tests, so a condition is a propositional formula and classical
+     entailment holds over it. Inside @supports (A) the UA has already answered
+     A, and one sheet gets the same answer everywhere in it, so an inner
+     condition simplifies against the conjunction K of its enclosing conditions
+     by propositional logic alone. K and not C unsatisfiable means C is entailed
+     and its guard goes; K and C unsatisfiable means C is refuted and its block
+     is dead. No support table is consulted, so this holds whatever the UA
+     answers. Atom identity is syntactic: two feature tests are the same
+     variable when they are structurally equal after parsing. *)
+  let minify css =
+    Css.Optimize.stylesheet (Css.Stylesheet.read (Cursor.of_string css))
+    |> Css.Stylesheet.to_string ~minify:true
+    |> String.trim
+  in
+  (* The boundary first. A disjunction does not entail its disjuncts: a UA
+     answering yes to (B) and no to (A) satisfies the context and still has to
+     be asked about (A). *)
+  Alcotest.(check string)
+    "a disjunctive context entails neither disjunct"
+    "@supports(nonsense-a:1px)or \
+     (nonsense-b:2px){@supports(nonsense-a:1px){.a{top:0}}}"
+    (minify
+       "@supports (nonsense-a:1px) or (nonsense-b:2px){@supports \
+        (nonsense-a:1px){.a{top:0}}}");
+  (* Two feature tests on one property are still two variables: accepting
+     display:grid does not imply accepting display:inline-grid. *)
+  Alcotest.(check string)
+    "two tests on one property are two variables"
+    "@supports(display:grid){@supports(display:inline-grid){.a{top:0}}}"
+    (minify
+       "@supports (display:grid){@supports (display:inline-grid){.a{top:0}}}");
+  Alcotest.(check string)
+    "a repeated guard asks a question already answered"
+    "@supports(nonsense-a:1px){.a{top:0}}"
+    (minify "@supports (nonsense-a:1px){@supports (nonsense-a:1px){.a{top:0}}}");
+  (* A conjunction entails each conjunct, and operand order is not part of the
+     question: (A) and (B) has the truth table of (B) and (A). *)
+  Alcotest.(check string)
+    "a conjunction entails its conjuncts in either order"
+    "@supports(nonsense-a:1px)and (nonsense-b:2px){.a{top:0}}"
+    (minify
+       "@supports (nonsense-a:1px) and (nonsense-b:2px){@supports \
+        (nonsense-b:2px) and (nonsense-a:1px){.a{top:0}}}");
+  (* A disjunct entails its disjunction, so (B) is never asked. *)
+  Alcotest.(check string)
+    "a disjunct entails its disjunction" "@supports(nonsense-a:1px){.a{top:0}}"
+    (minify
+       "@supports (nonsense-a:1px){@supports (nonsense-a:1px) or \
+        (nonsense-b:2px){.a{top:0}}}");
+  (* A and not A is false on every UA, so the inner block never applies and the
+     enclosing block is left empty. *)
+  Alcotest.(check string)
+    "a guard negating its context is dead" ""
+    (minify
+       "@supports (nonsense-a:1px){@supports (not (nonsense-a:1px)){.a{top:0}}}");
+  (* Neither entailed nor refuted: what K leaves to ask is (B). *)
+  Alcotest.(check string)
+    "a narrowing guard keeps only its residual"
+    "@supports(nonsense-a:1px){@supports(nonsense-b:2px){.a{top:0}}}"
+    (minify
+       "@supports (nonsense-a:1px){@supports (nonsense-a:1px) and \
+        (nonsense-b:2px){.a{top:0}}}");
+  (* Knowing the property changes nothing: the transform reads the condition's
+     shape, not a support table. *)
+  Alcotest.(check string)
+    "a property cascade models behaves the same"
+    "@supports(display:grid){.a{top:0}}"
+    (minify "@supports (display:grid){@supports (display:grid){.a{top:0}}}")
+
 (* Optimize must preserve physical identity when there is nothing left to do.
    Optimizing once reaches a fixed point [canon]; a second pass changes nothing,
    so it must return the very same value ([==]) rather than a structurally-equal
@@ -1595,6 +1666,9 @@ let optimize_tests =
     ( "author supports guards survive the default minify",
       `Quick,
       test_supports_author_guard_kept_by_default );
+    ( "a supports condition simplifies against the conditions enclosing it",
+      `Quick,
+      test_supports_entailed_by_its_context );
   ]
 
 (** {1 Selector merging tests (cascade semantics)} *)


### PR DESCRIPTION
Inside `@supports (A)` a user agent has already answered `A`, and one sheet gets the same answer to the same question everywhere in it, so an inner condition follows from the conditions enclosing it by propositional logic alone.

That is what makes it sound where the baseline fold removed in #584 was not. It consults no support table at all, only the fact that one user agent answers one feature test the same way throughout a sheet.
