### PR TITLE
supports: keep the value the author wrote in a condition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,14 @@ recorded cases carrying six minifiers' answers.
   browser lacking that value lost the guarded fallback and rendered with no
   height at all. `Css.Supports.simplify_baseline` is gone, and `--enforce-spec`
   no longer changes how a guard is treated (#584)
+- An `@supports` condition keeps the value the author wrote. Cascade re-spelled
+  it through the property's typed grammar, so `(color: rgba(0,0,0,.5))` asked
+  about CSS Color 4 instead, and `(width: calc(10px))` and `(width: 10.0px)`
+  became one question, merging the blocks two different guards protected.
+  `Css.Values.normalize_color` loses the `in_feature_query` argument nothing
+  ever set, along with the `Css.Pp` field and accessors behind it.
+  `Css.Declaration.parse_opaque_declaration` reads a declaration without its
+  typed grammar (#587)
 - `Css.Supports.property` raises `Failure` on a value that is not a
   `<declaration-value>`, where it wrote the text unchecked:
   `property "color" "red) or (color:blue"` emitted a condition a browser answers

--- a/README.md
+++ b/README.md
@@ -244,6 +244,15 @@ token boundary, so the space after it is dropped (`drop-shadow(a) drop-shadow(b)
 -> `drop-shadow(a)drop-shadow(b)`). The space after a `var()` / `env()` / `attr()`
 stays, since the substituted value could otherwise merge with its neighbour.
 
+The value inside an `@supports` condition is opaque too, for a different
+reason. CSS Conditional Rules 3 section 6.1 answers a declaration feature by
+running that exact declaration through the rendering browser's parser, so what
+stands there is the question and not a value to shorten:
+`@supports (color: rgba(0,0,0,.5))` and `@supports (width: 10.0px)` reach the
+output as written, where the same text in a rule body folds. The whitespace
+around the condition's own tokens is still elided, so
+`@supports (display: grid)` prints as `@supports(display:grid)`.
+
 ### How rule merging scales
 
 The rule-level rewrites run on a cascade-dependency DAG, not on repeated linear

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2402,6 +2402,21 @@ let parse_declaration ?layer property value =
           (Cursor.of_components (name_value_components property value))
       with Cursor.Parse_error _ -> None)
 
+(* [parse_declaration] with the typed grammar skipped: the value stays the
+   component stream it was written as, the way an unknown property's does. A
+   custom property already reads that way, so it takes the ordinary path. *)
+let parse_opaque_declaration property value =
+  if is_custom_property_name property then parse_declaration property value
+  else
+    let t = Cursor.of_components (name_value_components property value) in
+    try
+      let name = String.lowercase_ascii_preserve (read_property_name t) in
+      Cursor.ws t;
+      if not (Cursor.colon t) then Cursor.err_expected t "':'";
+      Cursor.ws t;
+      Some (read_unknown_property_declaration t name)
+    with Cursor.Parse_error _ -> None
+
 let parse_custom_property name value =
   if is_custom_property_name name && is_declaration_value value then
     parse_declaration name value

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -87,6 +87,15 @@ val parse_declaration : ?layer:string -> string -> string -> declaration option
     [layer] applies only to a custom property (a typed declaration has no
     layer). Unlike {!custom_property}, this parses the full property grammar. *)
 
+val parse_opaque_declaration : string -> string -> declaration option
+(** [parse_opaque_declaration property value] is {!parse_declaration} with the
+    typed grammar skipped: [value] keeps the component stream it was written as
+    even where [property] has a typed grammar, so nothing about its spelling is
+    canonicalised. A custom property already reads that way and is unaffected.
+    It serves an [\@supports] condition, where the declaration is handed to
+    another parser rather than rendered, so the spelling is the question being
+    asked. [None] on a [value] no declaration can hold. *)
+
 val parse_custom_property : string -> string -> declaration option
 (** [parse_custom_property name value] is {!parse_declaration} restricted to a
     custom property that a rule can hold. It is [None] unless [name] is a

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -18,11 +18,6 @@ type ctx = {
   inline : bool;
   in_function : bool;
   in_calc : bool;
-  in_feature_query : bool;
-      (** Set while serialising the value of an [@supports (property: value)]
-          feature test. The value is a capability predicate for that exact
-          syntax, so lossy rewrites (e.g. static colour folding) must be
-          suppressed there. *)
   in_style_rule : bool;
       (** Set while serialising a style rule's contents, where CSS nesting
           applies and a statement-form at-rule is not accepted. *)
@@ -82,7 +77,6 @@ let v ?(minify = false) ?indent ?(inline = false) ?(lossless = false)
     inline;
     in_function = false;
     in_calc = false;
-    in_feature_query = false;
     in_style_rule = false;
     lossless;
     enforce_spec;
@@ -474,8 +468,6 @@ let space ctx () = char ctx ' '
 let block_open ctx () = char ctx '{'
 let block_close ctx () = char ctx '}'
 let minified ctx = ctx.minify
-let in_feature_query ctx = ctx.in_feature_query
-let enter_feature_query ctx = { ctx with in_feature_query = true }
 let in_style_rule ctx = ctx.in_style_rule
 let enter_style_rule ctx = { ctx with in_style_rule = true }
 let cond p a b ctx x = if p ctx then a ctx x else b ctx x

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -38,11 +38,6 @@ type ctx = {
       (** Inside a [calc()]: suppress canonicalisations that cross a typed leaf
           boundary ([calc] is type-aware so [<percentage>] and [<number>] are
           not interchangeable). *)
-  in_feature_query : bool;
-      (** Set while serialising the value of an [@supports (property: value)]
-          feature test. The value is a capability predicate for that exact
-          syntax, so lossy rewrites (e.g. static colour folding) are suppressed
-          there. *)
   in_style_rule : bool;
       (** Set while serialising a style rule's contents, where CSS nesting
           applies and a statement-form at-rule is not accepted. *)
@@ -275,14 +270,6 @@ val block_close : unit t
 
 val minified : ctx -> bool
 (** [minified ctx] queries whether context is in minification mode. *)
-
-val in_feature_query : ctx -> bool
-(** [in_feature_query ctx] is true while serialising an [@supports] feature-test
-    value, where lossy rewrites must be suppressed. *)
-
-val enter_feature_query : ctx -> ctx
-(** [enter_feature_query ctx] marks [ctx] as inside an [@supports] feature-test
-    value. *)
 
 val in_style_rule : ctx -> bool
 (** [in_style_rule ctx] is true while serialising the contents of a style rule,

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -155,13 +155,8 @@ let pp_box_shorthand pp ctx vs =
   let vs = if Pp.minified ctx then collapse_box_shorthand vs else vs in
   Pp.list ~sep:Pp.space pp ctx vs
 
-(* Canonicalise a colour to its shortest spelling. The normalize pass only ever
-   visits real declarations, never an [@supports] feature-test condition (those
-   live in the unwalked [Supports] condition), so the static colour-space fold
-   is never suppressed here. *)
-let normalize_color ?(lossless = false) =
-  Values.normalize_color ~lossless ~in_feature_query:false
-
+(* Canonicalise a colour to its shortest spelling. *)
+let normalize_color ?(lossless = false) = Values.normalize_color ~lossless
 let preserve_if_equal before after = if after == before then before else after
 
 let map_preserve f xs =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2407,8 +2407,7 @@ let fold_custom_color ~lossless (c : Component.t) ~fallback =
   | Some col when Cursor.is_done cur -> (
       let canon =
         Pp.to_string ~minify:true Values.pp_color
-          (Values.nonkeyword_color
-             (Values.normalize_color ~lossless ~in_feature_query:false col))
+          (Values.nonkeyword_color (Values.normalize_color ~lossless col))
       in
       match read_custom_property_value (Cursor.of_string canon) with
       | Tokens cs -> cs
@@ -2502,10 +2501,7 @@ let rec normalize_shadow_colors ~lossless (shadow : shadow) =
   let normalize_body (body : shadow_body) : shadow_body =
     {
       body with
-      color =
-        option_map_preserve
-          (Values.normalize_color ~lossless ~in_feature_query:false)
-          body.color;
+      color = option_map_preserve (Values.normalize_color ~lossless) body.color;
     }
   in
   match shadow with
@@ -2952,9 +2948,7 @@ let normalize_property_value : type a.
     a =
  fun ?(lossless = false) ?(exact_srgb = false) ?(ctx = Values.default_calc_ctx)
      property value ->
-  let normalize_color =
-    Values.normalize_color ~lossless ~exact_srgb ~in_feature_query:false
-  in
+  let normalize_color = Values.normalize_color ~lossless ~exact_srgb in
   (* [initial] -> shortest spec-equivalent (e.g. min-width:initial -> auto) is a
      semantic rewrite, so it belongs here, not in pp. *)
   let value = canonical_initial_for_minify property value in
@@ -3201,11 +3195,7 @@ let normalize_custom_property_value ?(lossless = false)
   | Typed { kind = Length; value } ->
       Typed { kind = Length; value = Values.normalize_length ~ctx value }
   | Typed { kind = Color; value } ->
-      Typed
-        {
-          kind = Color;
-          value = Values.normalize_color ~lossless ~in_feature_query:false value;
-        }
+      Typed { kind = Color; value = Values.normalize_color ~lossless value }
   | Typed { kind = Number; value } ->
       Typed { kind = Number; value = Values.normalize_number ~ctx value }
   | Typed { kind = Percentage; value } ->

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -149,9 +149,16 @@ let declaration_feature prop value =
   | _ -> (
       (* The name and the value stay apart: read as one text, a name carrying a
          [;] or a [}] (CSS Syntax 3 sec. 4.3.7 puts either there through an
-         escape) would end its own declaration. *)
+         escape) would end its own declaration.
+
+         The value is read opaquely. CSS Conditional 3 sec. 6.1 answers a
+         declaration feature by running that exact declaration through the
+         browser's own parser, so the spelling is the question and a typed
+         reading would hand back a different one: [rgba(0,0,0,.5)] and
+         [#ff0000ff] name grammars a browser can accept one of and refuse the
+         other. *)
       let name = property_name prop in
-      match Declaration.parse_declaration prop value with
+      match Declaration.parse_opaque_declaration prop value with
       | Some decl -> Declaration decl
       | None -> Unsupported (name, String.trim value))
 
@@ -265,10 +272,7 @@ and render_branch operator = function
 let to_string condition = render `Root condition
 
 let pp_declaration_feature ctx = function
-  | Declaration decl ->
-      (* The declaration is a capability predicate for this exact value, so
-         suppress lossy value rewrites (e.g. static colour folding). *)
-      Declaration.pp (Pp.enter_feature_query ctx) decl
+  | Declaration decl -> Declaration.pp ctx decl
   | Empty name ->
       Pp.string ctx (escaped_property_name name);
       Pp.char ctx ':'

--- a/lib/supports.mli
+++ b/lib/supports.mli
@@ -7,6 +7,11 @@ type property_name
 
 type declaration_feature =
   | Declaration of Declaration.t
+      (** The declaration the feature tests. Its value is the component stream
+          the author wrote, read through
+          {!Declaration.parse_opaque_declaration}: a browser answers the feature
+          by parsing that exact declaration, so the property's typed grammar
+          never re-spells it. *)
   | Empty of property_name
   | Unsupported of property_name * string
   | Vendor_flag_enabled
@@ -61,7 +66,7 @@ type t =
 
 val property : string -> string -> t
 (** [property name value] parses [name: value] as a structured supports
-    declaration feature.
+    declaration feature. [value] keeps the spelling it is given.
 
     @raise Failure
       if [value] is not a [<declaration-value>] (CSS Syntax 3 sec. 8.2). The

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7390,16 +7390,13 @@ let canonical_color_lightness ~lossless ~pct_scale ~axis_max_decimals
       else Some (num f)
   | other -> other
 
-let normalize_static_modern_color ~in_feature_query ~exact_srgb ~lossless c =
+let normalize_static_modern_color ~exact_srgb ~lossless c =
   let hex_of_bytes r g b (a : alpha) =
     match alpha_value_byte a with
     | Some ab -> canonical_color_of_hex r g b ab
     | Option.None -> c
   in
-  (* A feature query asks whether the browser parses the function that was
-     written, so the spelling is the point there and no fold applies. *)
-  if in_feature_query then drop_full_alpha c
-  else if lossless then
+  if lossless then
     match
       if exact_srgb then exact_srgb_function_channels c else Option.None
     with
@@ -7499,20 +7496,18 @@ let round_lab_family_axes ~lossless (c : color) : color =
   | other -> other
 
 (* AST-level color canonicalisation: the value-changing colour folds live here,
-   producing a canonical [color] so [pp_color] stays a pure serialiser.
-   [in_feature_query] gates the static colour-space fold (suppressed inside
-   [@supports] tests). The sRGB fold runs on the authored coefficients first;
-   [round_lab_family_axes] then rounds only what survives in its own colour
-   space. *)
-let rec normalize_color ?(lossless = false) ?(exact_srgb = false)
-    ~in_feature_query (c : color) : color =
+   producing a canonical [color] so [pp_color] stays a pure serialiser. The sRGB
+   fold runs on the authored coefficients first; [round_lab_family_axes] then
+   rounds only what survives in its own colour space. *)
+let rec normalize_color ?(lossless = false) ?(exact_srgb = false) (c : color) :
+    color =
   let normalize_color ?(lossless = lossless) =
     normalize_color ~lossless ~exact_srgb
   in
   let hex_of_byte_quad r g b ab = canonical_color_of_hex r g b ab in
   let static_fold () =
     round_lab_family_axes ~lossless
-      (normalize_static_modern_color ~in_feature_query ~exact_srgb ~lossless c)
+      (normalize_static_modern_color ~exact_srgb ~lossless c)
   in
   match c with
   | Oklab { l = Some l; a = None; b = None; alpha }
@@ -7522,8 +7517,7 @@ let rec normalize_color ?(lossless = false) ?(exact_srgb = false)
   | Oklab { l = Some _; a = Some _; b = Some _; _ } -> static_fold ()
   | Lch { l = Some _; c = Some _; _ } -> static_fold ()
   | Lab { l = Some _; a = Some _; b = Some _; _ } -> static_fold ()
-  | Color _ ->
-      normalize_static_modern_color ~in_feature_query ~exact_srgb ~lossless c
+  | Color _ -> normalize_static_modern_color ~exact_srgb ~lossless c
   | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
       normalize_hex_color c r g b a
   | Named orig_name -> normalize_named_color c orig_name
@@ -7536,19 +7530,15 @@ let rec normalize_color ?(lossless = false) ?(exact_srgb = false)
       | Some (r, g, b, a) -> hex_of_byte_quad r g b a
       | Option.None -> drop_full_alpha c)
   | Mix { in_space; hue; color1; percent1; color2; percent2 } ->
-      normalize_mix_color ~lossless ~in_feature_query ~in_space ~hue ~color1
-        ~percent1 ~color2 ~percent2
+      normalize_mix_color ~lossless ~in_space ~hue ~color1 ~percent1 ~color2
+        ~percent2
   | Light_dark (l, d) ->
-      Light_dark
-        ( normalize_color ~lossless ~in_feature_query l,
-          normalize_color ~lossless ~in_feature_query d )
-  | Contrast_color inner ->
-      Contrast_color (normalize_color ~lossless ~in_feature_query inner)
+      Light_dark (normalize_color ~lossless l, normalize_color ~lossless d)
+  | Contrast_color inner -> Contrast_color (normalize_color ~lossless inner)
   | Relative_rgb (origin, tail) ->
-      Relative_rgb (normalize_color ~lossless ~in_feature_query origin, tail)
+      Relative_rgb (normalize_color ~lossless origin, tail)
   | Relative_color (name, origin, tail) ->
-      Relative_color
-        (name, normalize_color ~lossless ~in_feature_query origin, tail)
+      Relative_color (name, normalize_color ~lossless origin, tail)
   | Var v ->
       (* A typed [var()] fallback / default is a colour, so canonicalise it the
          same way it would be if it stood alone. The opaque [Syntax_fallback] /
@@ -7556,7 +7546,7 @@ let rec normalize_color ?(lossless = false) ?(exact_srgb = false)
          untouched. *)
       let fallback =
         match v.fallback with
-        | Fallback c -> Fallback (normalize_color ~lossless ~in_feature_query c)
+        | Fallback c -> Fallback (normalize_color ~lossless c)
         | (Empty | Empty2 | None | Syntax_fallback _ | Var_fallback _) as other
           ->
             other
@@ -7565,13 +7555,12 @@ let rec normalize_color ?(lossless = false) ?(exact_srgb = false)
         {
           v with
           fallback;
-          default =
-            Option.map (normalize_color ~lossless ~in_feature_query) v.default;
+          default = Option.map (normalize_color ~lossless) v.default;
         }
   | _ -> c
 
-and normalize_mix_color ~lossless ~in_feature_query ~in_space ~hue ~color1
-    ~percent1 ~color2 ~percent2 =
+and normalize_mix_color ~lossless ~in_space ~hue ~color1 ~percent1 ~color2
+    ~percent2 =
   let keep () =
     (* CSS Color 5 sec. 3 / CSS Color 4 sec. 13.4: [shorter] is the default hue
        and drops, and percentages that restate the [100% - other] default drop
@@ -7594,9 +7583,9 @@ and normalize_mix_color ~lossless ~in_feature_query ~in_space ~hue ~color1
       {
         in_space;
         hue;
-        color1 = normalize_color ~lossless ~in_feature_query color1;
+        color1 = normalize_color ~lossless color1;
         percent1;
-        color2 = normalize_color ~lossless ~in_feature_query color2;
+        color2 = normalize_color ~lossless color2;
         percent2;
       }
   in
@@ -7617,7 +7606,7 @@ and normalize_mix_color ~lossless ~in_feature_query ~in_space ~hue ~color1
       | _ -> None
   in
   match folded with
-  | Some color -> normalize_color ~lossless ~in_feature_query color
+  | Some color -> normalize_color ~lossless color
   | None -> keep ()
 
 (** Read hue_interpolation *)

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -251,15 +251,12 @@ val normalize_duration : ?ctx:calc_ctx -> duration -> duration
     [calc()] ([calc(var(--d) * 1)] becomes [calc(var(--d))]), keeping any
     [var()]. *)
 
-val normalize_color :
-  ?lossless:bool -> ?exact_srgb:bool -> in_feature_query:bool -> color -> color
-(** [normalize_color ?lossless ~in_feature_query c] canonicalises a color to its
-    shortest spelling: a static colour in any space folds through sRGB to
-    hex/named, hex shortens, and named<->hex picks the shorter.
-    [in_feature_query] keeps a colour untouched inside an [@supports] test,
-    where the exact spelling is the capability being probed. [lossless] disables
-    lossy static colour-space and color-mix folds while preserving exact
-    named/hex and byte-exact rgb folds.
+val normalize_color : ?lossless:bool -> ?exact_srgb:bool -> color -> color
+(** [normalize_color ?lossless c] canonicalises a color to its shortest
+    spelling: a static colour in any space folds through sRGB to hex/named, hex
+    shortens, and named<->hex picks the shorter. [lossless] disables lossy
+    static colour-space and color-mix folds while preserving exact named/hex and
+    byte-exact rgb folds.
 
     [exact_srgb] (default [false], and only consulted under [lossless])
     additionally folds a [color(srgb ...)] whose channels all land on a whole

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -300,7 +300,7 @@ let list_map_preserve = List.map_preserve
 let rec normalize_value : type a. ?lossless:bool -> a syntax -> a -> a =
  fun ?(lossless = false) syntax value ->
   match syntax with
-  | Color -> Values.normalize_color ~lossless ~in_feature_query:false value
+  | Color -> Values.normalize_color ~lossless value
   | Or (left, right) -> (
       match value with
       | Either.Left v ->

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -38,7 +38,7 @@ rather than as a loss and a gain.
      │       --tw-drop-shadow-color oklch(.585 .233 277.117)
      │       --tw-drop-shadow var(--tw-drop-shadow-size)
      ├─ .drop-shadow-indigo-500 (position 0) ↔  .drop-shadow-indigo-500 (position 4)
-     └─ @supports (color: color-mix(in lab, red, red)) (1 reordered)
+     └─ @supports (color: color-mix(in lab,red,red)) (1 reordered)
         └─ .drop-shadow-blue-500\/50 ↔  .drop-shadow-indigo-500
   
   [1]

--- a/test/cli/supports_condition_values.t
+++ b/test/cli/supports_condition_values.t
@@ -1,0 +1,195 @@
+CLI: --minify keeps the value the author wrote inside an @supports condition.
+
+CSS Conditional 3 sec. 6 gives a declaration feature the grammar
+[( <declaration> )], and the UA answers it by running that exact declaration
+through its own parser. The value there is not a value, it is the question. Two
+spellings the spec calls equal are still two questions, because a feature query
+exists to find the UAs whose parser does not match the spec: whether one of them
+accepts both spellings is precisely what the author is asking, and a build
+cannot know.
+
+That makes a condition the one place in a stylesheet where spec-equivalence does
+not license a rewrite. Everywhere else [--minify] picks the shortest equivalent
+spelling and that is the whole policy; here the author's spelling is the input to
+somebody else's parser, so it is handed back.
+
+The surrounding whitespace is not part of the question. Every guard below is
+written with the author's spacing and prints without it, the same elision
+[test/cli/supports_guards.t] pins.
+
+
+# Legacy colour syntax
+
+
+[rgba()] with comma-separated arguments and [rgb()] with a slash-separated alpha
+are two different grammars, shipped years apart. A guard written in the older one
+asks about a colour syntax every UA that has ever evaluated a feature query
+accepts; rewritten into the newer one it asks about CSS Color 4, which the older
+half of that population rejects. The answer flips in exactly the UAs a guard is
+written to catch.
+
+  $ cat > rgba.css <<EOF
+  > .a { opacity: 1 }
+  > @supports (color: rgba(0,0,0,.5)) { .b { color: red } }
+  > EOF
+  $ cascade --minify rgba.css
+  .a{opacity:1}@supports(color:rgba(0,0,0,.5)){.b{color:red}}
+
+The same holds with no alpha at all, where the two spellings differ only in the
+separator.
+
+  $ cat > rgb.css <<EOF
+  > .a { opacity: 1 }
+  > @supports (color: rgb(0,0,0)) { .b { color: red } }
+  > EOF
+  $ cascade --minify rgb.css
+  .a{opacity:1}@supports(color:rgb(0,0,0)){.b{color:red}}
+
+And with [hsl()], which has the same pair of grammars.
+
+  $ cat > hsl.css <<EOF
+  > .a { opacity: 1 }
+  > @supports (color: hsl(0,0%,0%)) { .b { color: red } }
+  > EOF
+  $ cascade --minify hsl.css
+  .a{opacity:1}@supports(color:hsl(0,0%,0%)){.b{color:red}}
+
+
+# Hex with an alpha channel
+
+
+An eight-digit hex colour is its own syntax, and a UA that reads six digits does
+not necessarily read eight. Dropping a fully opaque alpha channel turns a probe
+for the eight-digit form into a probe for the six-digit form it was written to
+tell apart.
+
+  $ cat > hexalpha.css <<EOF
+  > .a { opacity: 1 }
+  > @supports (color: #ff0000ff) { .b { color: red } }
+  > EOF
+  $ cascade --minify hexalpha.css
+  .a{opacity:1}@supports(color:#ff0000ff){.b{color:red}}
+
+
+# The same class, with no divergence to name
+
+
+These three change the question the same way. Unlike the colour rows there is no
+UA anyone can point at that answers the two spellings differently: [calc()] was
+already in every engine before that engine evaluated its first feature query, and
+the other two are token spellings of the same age. They are here because the rule
+belongs to the construct. A build does not get to decide which of its rewrites a
+foreign parser will overlook.
+
+A [calc()] wrapper around a single term is a probe for [calc()].
+
+  $ cat > calc.css <<EOF
+  > .a { opacity: 1 }
+  > @supports (width: calc(10px)) { .b { color: red } }
+  > EOF
+  $ cascade --minify calc.css
+  .a{opacity:1}@supports(width:calc(10px)){.b{color:red}}
+
+A trailing zero is the author's spelling of the number.
+
+  $ cat > zero.css <<EOF
+  > .a { opacity: 1 }
+  > @supports (width: 10.0px) { .b { color: red } }
+  > EOF
+  $ cascade --minify zero.css
+  .a{opacity:1}@supports(width:10.0px){.b{color:red}}
+
+A quoted [url()] argument is a function token over a string, and an unquoted one
+is a url token: different tokens, not different spacing.
+
+  $ cat > url.css <<EOF
+  > .a { opacity: 1 }
+  > @supports (background: url("a.png")) { .b { color: red } }
+  > EOF
+  $ cascade --minify url.css
+  .a{opacity:1}@supports(background:url("a.png")){.b{color:red}}
+
+
+# Two questions must not become one
+
+
+Rewriting the value is not only a change of spelling. Two guards that ask
+different questions can be rewritten into the same one, and then the blocks
+behind them merge: a UA answering yes to one and no to the other loses the
+distinction the author built.
+
+  $ cat > merge.css <<EOF
+  > .a { opacity: 1 }
+  > @supports (width: calc(10px)) { .b { color: red } }
+  > @supports (width: 10.0px) { .c { color: red } }
+  > EOF
+  $ cascade --minify merge.css
+  .a{opacity:1}@supports(width:calc(10px)){.b{color:red}}@supports(width:10.0px){.c{color:red}}
+
+
+# The same guard in prefix position
+
+
+The [supports()] clause of an [@import] carries the same declaration feature and
+decides whether the sheet is fetched, so its value is preserved on the same
+grounds.
+
+  $ cat > import.css <<EOF
+  > @import url("t.css") supports(color: rgba(0,0,0,.5));
+  > .a { opacity: 1 }
+  > EOF
+  $ cascade --minify import.css
+  @import"t.css"supports(color:rgba(0,0,0,.5));.a{opacity:1}
+
+
+# --enforce-spec is not the flag that buys this back
+
+
+[--enforce-spec] drops the shortenings that depend on an evergreen target. The
+condition is not a target question at all, so it is preserved under both.
+
+  $ for f in rgba.css rgb.css hsl.css hexalpha.css calc.css zero.css url.css import.css; do
+  >   cascade --minify --enforce-spec $f
+  > done
+  .a{opacity:1}@supports(color:rgba(0,0,0,.5)){.b{color:red}}
+  .a{opacity:1}@supports(color:rgb(0,0,0)){.b{color:red}}
+  .a{opacity:1}@supports(color:hsl(0,0%,0%)){.b{color:red}}
+  .a{opacity:1}@supports(color:#ff0000ff){.b{color:red}}
+  .a{opacity:1}@supports(width:calc(10px)){.b{color:red}}
+  .a{opacity:1}@supports(width:10.0px){.b{color:red}}
+  .a{opacity:1}@supports(background:url("a.png")){.b{color:red}}
+  @import"t.css"supports(color:rgba(0,0,0,.5));.a{opacity:1}
+
+
+# Controls
+
+
+These already hold and a fix must not move them.
+
+A [calc()] carrying real arithmetic is not folded, so the guard reaches the UA as
+written. A condition already in the modern colour syntax is not rewritten into
+the legacy one, a zero length keeps its unit, and a [scale()] with two equal
+arguments keeps both.
+
+  $ cat > kept.css <<EOF
+  > .a { opacity: 1 }
+  > @supports (width: calc(10px*2)) { .b { color: red } }
+  > @supports (color: rgb(0 0 0)) { .c { color: red } }
+  > @supports (margin: 0px) { .d { color: red } }
+  > @supports (transform: scale(1,1)) { .e { color: red } }
+  > EOF
+  $ cascade --minify kept.css
+  .a{opacity:1}@supports(width:calc(10px*2)){.b{color:red}}@supports(color:rgb(0 0 0)){.c{color:red}}@supports(margin:0px){.d{color:red}}@supports(transform:scale(1,1)){.e{color:red}}
+
+A condition naming a property cascade does not model keeps its value byte for
+byte, including the two spellings the rows above lose. It is the control the
+guarded rows are measured against: what cascade can take apart must not come out
+differently from what it cannot.
+
+  $ cat > unknown.css <<EOF
+  > .a { opacity: 1 }
+  > @supports (nonsense-prop: 10.0px) { .b { color: red } }
+  > @supports (nonsense-prop: rgba(0,0,0,.5)) { .c { color: red } }
+  > EOF
+  $ cascade --minify unknown.css
+  .a{opacity:1}@supports(nonsense-prop:10.0px){.b{color:red}}@supports(nonsense-prop:rgba(0,0,0,.5)){.c{color:red}}

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -3825,12 +3825,16 @@ let test_spec_snapshot_tracking_vectors () =
     "@supports (color: oklch(50% 0.1 20)) { .accent { color: oklch(50% 0.1 20) \
      } }"
   in
+  (* The condition keeps [0.1] as written: it is the declaration the browser is
+     asked to parse, not a value to re-spell. The guarded rule folds. *)
   check_stylesheet
-    ~expected:"@supports(color:oklch(50%.1 20)){.accent{color:oklch(50%.1 20)}}"
+    ~expected:
+      "@supports(color:oklch(50% 0.1 20)){.accent{color:oklch(50%.1 20)}}"
     oklch_support;
   assert_minify_and_optimize oklch_support
-    ~minified:"@supports(color:oklch(50%.1 20)){.accent{color:oklch(50%.1 20)}}"
-    ~optimized:"@supports(color:oklch(50%.1 20)){.accent{color:#944a4b}}";
+    ~minified:
+      "@supports(color:oklch(50% 0.1 20)){.accent{color:oklch(50%.1 20)}}"
+    ~optimized:"@supports(color:oklch(50% 0.1 20)){.accent{color:#944a4b}}";
   let nested_media =
     ".card { color: var(--fg); @media (prefers-color-scheme: dark) { & { \
      color: white } } }"

--- a/test/test_supports.ml
+++ b/test/test_supports.ml
@@ -258,6 +258,79 @@ let property_guard () =
         (build "wibble-prop" value))
     [ ("1", "<round-trips>"); ("1) or (color:blue", "<refused>") ]
 
+(* The pipeline [cascade --minify] runs: the optimiser over a parsed sheet, then
+   the minified printer. *)
+let minified ?(enforce_spec = false) css =
+  Css.to_string ~minify:true ~enforce_spec
+    (Css.optimize ~enforce_spec (Css.of_string_exn css))
+
+(* Every input below is already in the minified spelling, so the sheet the
+   author wrote is the whole expectation. Rows are collected rather than
+   asserted one at a time, so a run names every condition that moved. *)
+let check_preserved name sheets =
+  let moved =
+    List.concat_map
+      (fun css ->
+        let one label actual =
+          if String.equal actual css then []
+          else [ String.concat "" [ label; actual ] ]
+        in
+        one "--minify -> " (minified css)
+        @ one "--minify --enforce-spec -> " (minified ~enforce_spec:true css))
+      sheets
+  in
+  Alcotest.(check (list string)) name [] moved
+
+(* Everywhere else in a stylesheet two spellings the spec calls equal are
+   interchangeable, and [--minify] takes the shorter one. A feature query is the
+   exception. CSS Conditional 3 sec. 6 gives the declaration feature the grammar
+   [( <declaration> )] and the UA answers it by handing that exact declaration
+   to its own parser, so the value there is the question, not a value. The
+   construct exists to find the parsers that deviate from the spec, which is why
+   spec-equivalence says nothing about whether two spellings come back with the
+   same answer: the author's spelling is what has to survive. *)
+let condition_value_preserved () =
+  check_preserved "the author's condition survives --minify"
+    [
+      (* Legacy and modern colour syntax are two grammars shipped years apart,
+         so a guard written in one does not ask what the other asks. *)
+      "@supports(color:rgba(0,0,0,.5)){.b{color:red}}";
+      "@supports(color:rgb(0,0,0)){.b{color:red}}";
+      "@supports(color:hsl(0,0%,0%)){.b{color:red}}";
+      (* Eight-digit hex is its own syntax, and dropping an opaque alpha channel
+         probes the six-digit one instead. *)
+      "@supports(color:#ff0000ff){.b{color:red}}";
+      (* The same rule with no divergence to name: a [calc()] wrapper, a
+         trailing zero and a quoted [url()] argument are the author's tokens
+         either way. *)
+      "@supports(width:calc(10px)){.b{color:red}}";
+      "@supports(width:10.0px){.b{color:red}}";
+      "@supports(background:url(\"a.png\")){.b{color:red}}";
+      (* The [supports()] clause of an [@import] is the same declaration feature
+         in prefix position, and it decides whether the sheet is fetched at
+         all. *)
+      "@import\"t.css\"supports(color:rgba(0,0,0,.5));.a{opacity:1}";
+      (* Two guards asking different questions must not be rewritten into one:
+         the UA that answers them differently loses the distinction. *)
+      "@supports(width:calc(10px)){.b{color:red}}@supports(width:10.0px){.c{color:red}}";
+    ]
+
+(* Controls for the rows above: conditions the default minify already hands back
+   unchanged. A [calc()] carrying arithmetic, a condition already in the modern
+   colour syntax, a zero length with its unit, a [scale()] with two equal
+   arguments, and a property cascade does not model at all, which keeps its
+   value byte for byte and is what the modelled rows are measured against. *)
+let condition_value_controls () =
+  check_preserved "conditions the default minify already keeps"
+    [
+      "@supports(width:calc(10px*2)){.b{color:red}}";
+      "@supports(color:rgb(0 0 0)){.b{color:red}}";
+      "@supports(margin:0px){.b{color:red}}";
+      "@supports(transform:scale(1,1)){.b{color:red}}";
+      "@supports(nonsense-prop:10.0px){.b{color:red}}";
+      "@supports(nonsense-prop:rgba(0,0,0,.5)){.b{color:red}}";
+    ]
+
 let suite =
   let open Alcotest in
   ( "supports",
@@ -277,4 +350,6 @@ let suite =
         spec_supports_context_vectors;
       test_case "roundtrip" `Quick test_roundtrip;
       test_case "property guard" `Quick property_guard;
+      test_case "condition value preserved" `Quick condition_value_preserved;
+      test_case "condition value controls" `Quick condition_value_controls;
     ] )


### PR DESCRIPTION
Two guards asking different questions were rewritten into the same text and the blocks behind them merged: `@supports (width: calc(10px))` and `@supports (width: 10.0px)` both became `@supports(width:10px)` over one combined selector list, so a user agent answering yes to one and no to the other lost the distinction outright. A condition is handed to another parser rather than rendered, so the spelling is the question being asked.

Cascade already preserved the value for a property it does not model, so this makes the typed arm agree with the untyped one. `@supports (width: 10Q)` now prints `10Q` rather than `10q`, which is the same policy applied to a unit spelling.