### PR TITLE
color: name the sRGB colour an out-of-gamut oklch renders as

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -753,6 +753,12 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- `Css.Color_space.gamut_mapped_srgb_of_oklch` and `Css.Values.gamut_map_color`
+  name the sRGB colour to write for an OKLCh colour sRGB cannot hold, reducing
+  its chroma at constant lightness and hue per CSS Color 4 sec. 14.2. The
+  library could report that a colour was out of gamut, not what to render in
+  its place. Minify is untouched and still keeps the colour the author wrote
+  (#591)
 - `Css.inline_vars` no longer costs a square in the variable count: liveness is
   decided through indexes and a worklist, and the customs a rule can see are
   indexed by name instead of scanned per declaration. A 12,800-variable sheet

--- a/lib/color_space.ml
+++ b/lib/color_space.ml
@@ -274,6 +274,58 @@ let srgb_bytes_of_linear ?(budget = 0.002) (linear : rgb) :
     then Some (rb, gb, bb)
     else None
 
+(* CSS Color 4 sec. 14.2.2 "Binary Search Gamut Mapping with Local MINDE": halve
+   the OKLCh chroma at constant lightness and hue until the sRGB clip of the
+   searched colour lies within one just noticeable difference of it. *)
+
+let gamut_jnd = 0.02
+let gamut_epsilon = 0.0001
+
+let gamut_mapped_srgb_of_oklch ((l, chroma, h) : lch) : rgb =
+  if l >= 1.0 then (1.0, 1.0, 1.0)
+  else if l <= 0.0 then (0.0, 0.0, 0.0)
+  else
+    let srgb c =
+      rgb_of_linear_rgb (linear_srgb_of_oklab (oklab_of_oklch (l, c, h)))
+    in
+    let in_gamut (r, g, b) =
+      let inside v = v >= 0.0 && v <= 1.0 in
+      inside r && inside g && inside b
+    in
+    let clip (r, g, b) =
+      let clamp v = Float.max 0.0 (Float.min 1.0 v) in
+      (clamp r, clamp g, clamp b)
+    in
+    let delta clipped c =
+      oklab_distance
+        (oklab_of_linear_srgb (linear_rgb_of_rgb clipped))
+        (oklab_of_oklch (l, c, h))
+    in
+    let origin = srgb chroma in
+    if in_gamut origin then origin
+    else
+      let clipped = clip origin in
+      if delta clipped chroma < gamut_jnd then clipped
+      else
+        (* [lo_in_gamut] drops the first time the difference, rather than the
+           gamut, admits a chroma; past that the surface no longer bounds the
+           search, so testing it again would raise the lower end wrongly. *)
+        let rec search ~lo ~hi ~lo_in_gamut clipped =
+          if hi -. lo <= gamut_epsilon then clipped
+          else
+            let c = (lo +. hi) /. 2.0 in
+            let current = srgb c in
+            if lo_in_gamut && in_gamut current then
+              search ~lo:c ~hi ~lo_in_gamut clipped
+            else
+              let clipped = clip current in
+              let e = delta clipped c in
+              if e >= gamut_jnd then search ~lo ~hi:c ~lo_in_gamut clipped
+              else if gamut_jnd -. e < gamut_epsilon then clipped
+              else search ~lo:c ~hi ~lo_in_gamut:false clipped
+        in
+        search ~lo:0.0 ~hi:chroma ~lo_in_gamut:true clipped
+
 (* Hue interpolation. CSS Color 4 sec. 13.4. *)
 
 type hue_interpolation = Shorter | Longer | Increasing | Decreasing

--- a/lib/color_space.mli
+++ b/lib/color_space.mli
@@ -132,6 +132,19 @@ val srgb_bytes_of_linear : ?budget:float -> rgb -> (int * int * int) option
     its 8-bit quantisation lies more than [budget] (default [0.002]) in OKLab
     distance from the source. Alpha is not considered. *)
 
+val gamut_mapped_srgb_of_oklch : lch -> rgb
+(** [gamut_mapped_srgb_of_oklch (l, c, h)] is the sRGB colour, channels in
+    [[0, 1]], that CSS Color 4 sec. 14.2.2 renders for the OKLCh colour
+    [(l, c, h)]: a binary search that halves the chroma at constant lightness
+    and hue until the clipped result is within one just noticeable difference,
+    [0.02] in {!val-oklab_distance}, of the colour it searched. A colour already
+    inside the sRGB gamut converts unchanged; [l >= 1.] is white and [l <= 0.]
+    is black. Alpha is not considered.
+
+    This is the rendering answer {!val-srgb_bytes_of_linear} declines to give:
+    that one reports whether a colour is representable, this one names the
+    colour to write when it is not. *)
+
 (** {1 Hue interpolation} *)
 
 type hue_interpolation =

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3251,6 +3251,23 @@ let resolve_static_srgb (c : color) : color =
           | None -> c)
       | None -> c)
 
+(* CSS Color 4 sec. 14.2: the sRGB colour a display renders for a static colour,
+   gamut mapping the ones sRGB cannot hold. Unlike [resolve_static_srgb] this
+   always answers, so it serves a caller that has to write an sRGB colour; the
+   optimizer must not use it, as the mapped colour is not the authored one. A
+   colour that is not static is returned unchanged. *)
+let gamut_map_color (c : color) : color =
+  match static_color_to_linear_srgb c with
+  | None -> c
+  | Some (linear, alpha_f) ->
+      let lch =
+        Color_space.oklch_of_oklab (Color_space.oklab_of_linear_srgb linear)
+      in
+      let r, g, b = Color_space.gamut_mapped_srgb_of_oklch lch in
+      let byte v = Float.to_int (Float.round (v *. 255.)) in
+      let clamp01 v = Float.max 0. (Float.min 1. v) in
+      Hex { r = byte r; g = byte g; b = byte b; a = byte (clamp01 alpha_f) }
+
 (* CSS Color 4 sec. 13.4 [hue interpolation method] mapping into the simpler
    [Color_space.hue_interpolation] enum. [Default] and [Specified] both collapse
    to [Shorter] for the static fold; sec. 13.4 makes [shorter hue] the default

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -94,6 +94,17 @@ val nonkeyword_color : color -> color
     must not be introduced when folding a colour inside an opaque
     custom-property token stream. *)
 
+val gamut_map_color : color -> color
+(** [gamut_map_color c] is the sRGB colour a display renders for the static
+    colour [c], as a hex colour: CSS Color 4 sec. 14.2 reduces the chroma of a
+    colour sRGB cannot hold until it fits, holding lightness and hue. A colour
+    already inside the sRGB gamut keeps its bytes, and one that is not static (a
+    [var()], [currentcolor], a [color-mix()] over either) is returned unchanged.
+
+    Emission does not use this: the mapped colour is not the authored one, and a
+    display shows the wider colour on hardware that has it. It is for a caller
+    that has to commit to sRGB bytes. *)
+
 val current_color : color
 (** [current_color] is the CSS currentcolor value. *)
 

--- a/test/test_color_space.ml
+++ b/test/test_color_space.ml
@@ -213,6 +213,101 @@ let test_srgb_bytes_of_linear () =
     "out-of-sRGB-gamut colour is preserved" true
     (fold (2.0, 0.0, 0.0) = None)
 
+(* CSS Color 4 sec. 14.2.2 "Binary Search Gamut Mapping with Local MINDE". The
+   algorithm halves the OKLCh chroma at constant lightness and hue and returns a
+   clipped sRGB colour whose deltaEOK from the searched colour is under one just
+   noticeable difference, 0.02 in OKLab. Every bound below is that JND read back
+   through the OKLCh geometry, so the assertions follow from the algorithm
+   rather than from a captured result. *)
+let jnd = 0.02
+
+let oklch_of_srgb rgb =
+  Color_space.oklch_of_oklab
+    (Color_space.oklab_of_linear_srgb (Color_space.linear_rgb_of_rgb rgb))
+
+let srgb_of_oklch (l, c, h) =
+  Color_space.rgb_of_linear_rgb
+    (Color_space.linear_srgb_of_oklab (Color_space.oklab_of_oklch (l, c, h)))
+
+let check_in_srgb name (r, g, b) =
+  let inside v = v >= 0.0 && v <= 1.0 in
+  Alcotest.(check bool) name true (inside r && inside g && inside b)
+
+(* The mapped colour sits within one JND of the constant-lightness, constant-hue
+   ray through the origin: the lightness error is one component of that
+   distance, and the hue error is the angle a chord of at most one JND subtends
+   at the mapped chroma. *)
+let check_on_origin_ray ~l ~c ~h mapped =
+  let lm, cm, hm = oklch_of_srgb mapped in
+  Alcotest.(check bool)
+    "lightness stays within one JND" true
+    (Float.abs (lm -. l) <= jnd);
+  Alcotest.(check bool) "chroma is reduced, never raised" true (cm < c);
+  let max_hue_error =
+    if cm <= jnd then 180.0 else Float.asin (jnd /. cm) *. 180.0 /. Float.pi
+  in
+  let dh = Float.abs (hm -. h) in
+  let dh = Float.min dh (360.0 -. dh) in
+  Alcotest.(check bool)
+    "hue stays inside the JND cone" true (dh <= max_hue_error)
+
+let test_gamut_map_out_of_srgb () =
+  let l, c, h = (0.7, 0.35, 150.0) in
+  Alcotest.(check bool)
+    "premise: oklch(.7 .35 150) is out of the sRGB gamut" true
+    (Color_space.srgb_bytes_of_linear
+       (Color_space.linear_srgb_of_oklab (Color_space.oklab_of_oklch (l, c, h)))
+    = None);
+  let mapped = Color_space.gamut_mapped_srgb_of_oklch (l, c, h) in
+  check_in_srgb "mapped colour is writable in sRGB" mapped;
+  check_on_origin_ray ~l ~c ~h mapped
+
+let test_gamut_map_far_out_of_srgb () =
+  (* Chroma 1.0 is several times the widest sRGB chroma at any lightness. *)
+  let l, c, h = (0.5, 1.0, 300.0) in
+  let mapped = Color_space.gamut_mapped_srgb_of_oklch (l, c, h) in
+  check_in_srgb "far out-of-gamut colour is writable in sRGB" mapped;
+  check_on_origin_ray ~l ~c ~h mapped;
+  let _, cm, _ = oklch_of_srgb mapped in
+  Alcotest.(check bool) "chroma falls by more than half" true (cm < c /. 2.0)
+
+(* Relative colorimetric intent: sec. 14.2 leaves colours inside the destination
+   gamut alone. *)
+let test_gamut_map_in_srgb () =
+  let l, c, h = (0.7, 0.1, 150.0) in
+  let direct = srgb_of_oklch (l, c, h) in
+  check_in_srgb "premise: oklch(.7 .1 150) is already in sRGB" direct;
+  Alcotest.(check triplet)
+    "in-gamut colour is converted, not mapped" direct
+    (Color_space.gamut_mapped_srgb_of_oklch (l, c, h))
+
+let test_gamut_map_achromatic () =
+  let mapped = Color_space.gamut_mapped_srgb_of_oklch (0.5, 0.0, 0.0) in
+  check_in_srgb "achromatic colour is writable in sRGB" mapped;
+  Alcotest.(check triplet)
+    "achromatic colour is the grey of its lightness"
+    (srgb_of_oklch (0.5, 0.0, 0.0))
+    mapped;
+  let r, g, b = mapped in
+  Alcotest.(check approx_float_tight) "grey: r = g" r g;
+  Alcotest.(check approx_float_tight) "grey: g = b" g b
+
+(* Sec. 14.2: lightness at or above 1.0 returns white, at or below 0.0 black,
+   whatever the chroma. *)
+let test_gamut_map_lightness_extremes () =
+  Alcotest.(check triplet)
+    "L = 1 is white" (1.0, 1.0, 1.0)
+    (Color_space.gamut_mapped_srgb_of_oklch (1.0, 0.2, 150.0));
+  Alcotest.(check triplet)
+    "L above 1 is white" (1.0, 1.0, 1.0)
+    (Color_space.gamut_mapped_srgb_of_oklch (1.5, 0.2, 150.0));
+  Alcotest.(check triplet)
+    "L = 0 is black" (0.0, 0.0, 0.0)
+    (Color_space.gamut_mapped_srgb_of_oklch (0.0, 0.2, 150.0));
+  Alcotest.(check triplet)
+    "L below 0 is black" (0.0, 0.0, 0.0)
+    (Color_space.gamut_mapped_srgb_of_oklch (-0.5, 0.2, 150.0))
+
 let test_hue_interpolation () =
   let hue m h1 h2 t = Color_space.interpolate_hue m h1 h2 t in
   Alcotest.(check approx_float)
@@ -259,6 +354,16 @@ let suite =
         test_display_p3_grey_to_srgb;
       Alcotest.test_case "fold linear sRGB to bytes within budget" `Quick
         test_srgb_bytes_of_linear;
+      Alcotest.test_case "gamut map out-of-sRGB oklch" `Quick
+        test_gamut_map_out_of_srgb;
+      Alcotest.test_case "gamut map far out-of-sRGB oklch" `Quick
+        test_gamut_map_far_out_of_srgb;
+      Alcotest.test_case "gamut map leaves in-sRGB oklch alone" `Quick
+        test_gamut_map_in_srgb;
+      Alcotest.test_case "gamut map achromatic oklch" `Quick
+        test_gamut_map_achromatic;
+      Alcotest.test_case "gamut map lightness extremes" `Quick
+        test_gamut_map_lightness_extremes;
       Alcotest.test_case "Hue interpolation methods" `Quick
         test_hue_interpolation;
     ] )

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -747,6 +747,36 @@ let test_color_oklch_none_hue () =
   check_color ~expected:"oklch(55.6%0 none)" ~optimized:"oklch(.556 0 none)"
     "oklch(55.6% 0 none)"
 
+(* CSS Color 4 sec. 14.2: an out-of-sRGB-gamut colour still has a writable sRGB
+   answer, reached by the sec. 14.2.2 binary search on chroma at constant
+   lightness and hue. For oklch(.7 .35 150) the search stops at chroma .224,
+   where the clipped colour is one just noticeable difference away, and clipping
+   there gives #00c248. *)
+(* Not a roundtrip test *)
+let test_gamut_map_color () =
+  let open Css.Values in
+  let parse s =
+    match Css.parse_color s with
+    | Some c -> c
+    | None -> Alcotest.failf "failed to parse: %s" s
+  in
+  let map s = Css.Pp.to_string pp_color (gamut_map_color (parse s)) in
+  Alcotest.(check string)
+    "out-of-gamut oklch maps into sRGB" "#00c248"
+    (map "oklch(0.7 0.35 150)");
+  Alcotest.(check string)
+    "alpha rides through the mapping" "#00c24880"
+    (map "oklch(0.7 0.35 150 / 0.5)");
+  Alcotest.(check string)
+    "an in-gamut colour keeps its bytes" "#0088cc" (map "#0088cc");
+  let dynamic = parse "var(--brand)" in
+  Alcotest.(check bool)
+    "a colour that is not static is left alone" true
+    (equal_color (gamut_map_color dynamic) dynamic);
+  (* Mapping is a rendering answer, not a shorter spelling: minify keeps the
+     authored colour. *)
+  check_color ~expected:"oklch(.7 .35 150)" "oklch(0.7 0.35 150)"
+
 (* Not a roundtrip test *)
 let test_color_mix_printing () =
   let open Css.Values in
@@ -1486,6 +1516,7 @@ let value_tests =
     test_case "regular value formatting" `Quick test_regular_value_formatting;
     test_case "oklch printing" `Quick test_color_oklch_printing;
     test_case "oklch none hue" `Quick test_color_oklch_none_hue;
+    test_case "gamut map colour into sRGB" `Quick test_gamut_map_color;
     test_case "color-mix printing" `Quick test_color_mix_printing;
     test_case "var in calc other types" `Quick test_var_in_calc_types;
     test_case "number var printing" `Quick test_number_var_printing;


### PR DESCRIPTION
`Css.Color_space.srgb_bytes_of_linear` reports whether a colour is representable in sRGB and returns nothing when it is not, so a caller that has to write sRGB bytes for `oklch(.7 .35 150)` had no answer anywhere in the API. This PR adds `Css.Color_space.gamut_mapped_srgb_of_oklch` and `Css.Values.gamut_map_color`, which name the colour to write, by the CSS Color 4 sec. 14.2.2 chroma reduction at constant lightness and hue.

Minify is untouched and still keeps the authored colour; a test pins that.
