### PR TITLE
optimize: publish the merging passes and merge @starting-style

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -397,6 +397,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` merges a run of adjacent `@starting-style` blocks. The rule takes
+  no prelude (CSS Transitions 2 sec. 3.3), so the run holds the same starting
+  styles, in the same order, as one block over their concatenation, and the
+  four conditional groups beside it already collapsed such a run (#592)
 - `--minify` simplifies a nested `@supports` condition against the conditions
   enclosing it, by propositional logic over its feature tests and against no
   support table: under `@supports (A)`, an inner `@supports (A)` loses its
@@ -759,6 +763,15 @@ recorded cases carrying six minifiers' answers.
   library could report that a colour was out of gamut, not what to render in
   its place. Minify is untouched and still keeps the colour the author wrote
   (#591)
+- The statement-merging passes are callable on their own:
+  `Css.Optimize.merge_consecutive_layers`, `merge_named_layers_by_name`,
+  `merge_consecutive_media`, `merge_distant_media`,
+  `merge_consecutive_supports`, `merge_consecutive_containers` and
+  `merge_consecutive_starting_style`. A caller that runs `Css.optimize` behind
+  a flag of its own can now collapse the block structure of a sheet it only
+  serialises. `Css.Optimize.drop_empty_rules` is spelled over the statement
+  list it walks, which states the scope it always had: the block it is given,
+  not the tree below it (#592)
 - `Css.inline_vars` no longer costs a square in the variable count: liveness is
   decided through indexes and a worklist, and the customs a rule can see are
   indexed by name instead of scanned per declaration. A 12,800-variable sheet

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -94,8 +94,8 @@ let merge_layer_blocks ~optimize_merged_block stmts =
   in
   merge [] None stmts
 
-let merge_consecutive_layers ~optimize_merged_block (stmts : statement list) :
-    statement list =
+let merge_consecutive_layers ?(optimize_merged_block = Fun.id)
+    (stmts : statement list) : statement list =
   if needs_layer_merge stmts then
     merge_layer_blocks ~optimize_merged_block stmts
   else stmts
@@ -141,8 +141,8 @@ let merge_media_blocks ~optimize_merged_block stmts =
   in
   merge [] None stmts
 
-let merge_consecutive_media ~optimize_merged_block (stmts : statement list) :
-    statement list =
+let merge_consecutive_media ?(optimize_merged_block = Fun.id)
+    (stmts : statement list) : statement list =
   if needs_media_merge stmts then
     merge_media_blocks ~optimize_merged_block stmts
   else stmts
@@ -256,7 +256,7 @@ let try_distant_media_merge ~leaves ~unattributed out cond block :
       else Some (before @ [ Media (cond, target @ block) ] @ after)
   | Some _ -> None
 
-let merge_distant_media ?owner ~optimize_merged_block stmts =
+let merge_distant_media ?owner ?(optimize_merged_block = Fun.id) stmts =
   if not (needs_distant_media_merge stmts) then stmts
   else
     let leaves stmts = List.concat_map (leaf_rules ?parent:owner) stmts in
@@ -287,8 +287,8 @@ let merge_distant_media ?owner ~optimize_merged_block stmts =
 (* CSS Conditional Rules 5: adjacent same-condition [@supports] / [@container]
    blocks may be merged because the cascade evaluates them identically. Mirror
    the [@media] approach. *)
-let merge_consecutive_supports ~optimize_merged_block (stmts : statement list) :
-    statement list =
+let merge_consecutive_supports ?(optimize_merged_block = Fun.id)
+    (stmts : statement list) : statement list =
   let rec needs_merge = function
     | Supports (prev_cond, _) :: Supports (cond, _) :: _
       when Supports.equal prev_cond cond ->
@@ -335,8 +335,8 @@ let same_container (prev_name, prev_cond) (name, cond) =
   Option.equal String.equal prev_name name
   && Option.equal Container.equal prev_cond cond
 
-let merge_consecutive_containers ~optimize_merged_block (stmts : statement list)
-    : statement list =
+let merge_consecutive_containers ?(optimize_merged_block = Fun.id)
+    (stmts : statement list) : statement list =
   let rec needs_merge = function
     | Container (prev_name, prev_cond, _) :: Container (name, cond, _) :: _
       when same_container (prev_name, prev_cond) (name, cond) ->
@@ -374,6 +374,40 @@ let merge_consecutive_containers ~optimize_merged_block (stmts : statement list)
                 (stmt
                 :: Container (name, cond, optimize_merged_block block)
                 :: acc)
+                None rest
+          | None -> merge (stmt :: acc) None rest)
+    in
+    merge [] None stmts
+
+(* CSS Transitions 2 sec. 3.3: [@starting-style] takes no prelude, so two
+   adjacent blocks hold the same starting styles, in the same order, as one
+   block over their concatenation. Adjacency is the whole gate; the conditional
+   passes above compare a condition this rule does not have. *)
+let merge_consecutive_starting_style ?(optimize_merged_block = Fun.id)
+    (stmts : statement list) : statement list =
+  let rec needs_merge = function
+    | Starting_style _ :: Starting_style _ :: _ -> true
+    | _ :: rest -> needs_merge rest
+    | [] -> false
+  in
+  if not (needs_merge stmts) then stmts
+  else
+    (* [acc] holds output in REVERSE order; reverse once at the end. *)
+    let rec merge acc prev = function
+      | [] -> (
+          match prev with
+          | Some block ->
+              List.rev (Starting_style (optimize_merged_block block) :: acc)
+          | None -> List.rev acc)
+      | Starting_style block :: rest -> (
+          match prev with
+          | Some prev_block -> merge acc (Some (prev_block @ block)) rest
+          | None -> merge acc (Some block) rest)
+      | stmt :: rest -> (
+          match prev with
+          | Some block ->
+              merge
+                (stmt :: Starting_style (optimize_merged_block block) :: acc)
                 None rest
           | None -> merge (stmt :: acc) None rest)
     in

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -1,41 +1,48 @@
 (** Statement-block cleanup passes. *)
 
 val merge_consecutive_layers :
-  optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->
+  ?optimize_merged_block:
+    (Stylesheet.statement list -> Stylesheet.statement list) ->
   Stylesheet.statement list ->
   Stylesheet.statement list
 (** Merge adjacent named [@layer] blocks with the same layer name. *)
 
 val merge_consecutive_media :
-  optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->
+  ?optimize_merged_block:
+    (Stylesheet.statement list -> Stylesheet.statement list) ->
   Stylesheet.statement list ->
   Stylesheet.statement list
 (** Merge adjacent [@media] blocks with identical conditions. *)
 
 val merge_distant_media :
   ?owner:Stylesheet.rule ->
-  optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->
+  ?optimize_merged_block:
+    (Stylesheet.statement list -> Stylesheet.statement list) ->
   Stylesheet.statement list ->
   Stylesheet.statement list
 (** Merge a later same-condition [@media] block into the first occurrence when
-    hoisting it past the intervening statements cannot reorder a conflicting
-    rule (overlapping selector with a shared property set to a different value).
-
-    [owner] is the style rule whose body the statements are, when they are one.
-    A declarations run in that body sets properties on [owner] (CSS Nesting 1
-    sec. 3.4), so without it the run is a conflict the hoist never sees. *)
+    the hoist reorders no conflicting rule. *)
 
 val merge_consecutive_supports :
-  optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->
+  ?optimize_merged_block:
+    (Stylesheet.statement list -> Stylesheet.statement list) ->
   Stylesheet.statement list ->
   Stylesheet.statement list
 (** Merge adjacent [@supports] blocks with identical conditions. *)
 
 val merge_consecutive_containers :
-  optimize_merged_block:(Stylesheet.statement list -> Stylesheet.statement list) ->
+  ?optimize_merged_block:
+    (Stylesheet.statement list -> Stylesheet.statement list) ->
   Stylesheet.statement list ->
   Stylesheet.statement list
 (** Merge adjacent [@container] blocks with identical names and conditions. *)
+
+val merge_consecutive_starting_style :
+  ?optimize_merged_block:
+    (Stylesheet.statement list -> Stylesheet.statement list) ->
+  Stylesheet.statement list ->
+  Stylesheet.statement list
+(** Merge adjacent [@starting-style] blocks. *)
 
 val is_layer_empty : Stylesheet.statement list -> bool
 (** Whether a layer block has no cascade-contributing statements. *)
@@ -55,14 +62,7 @@ val drop_redundant_layer_decls :
 (** Drop layer declarations whose ordering is already established. *)
 
 val drop_empty_rules : Stylesheet.statement list -> Stylesheet.statement list
-(** Drop the statements of a block that contribute nothing: a rule with no
-    declarations and no nested rules, a rule whose selector
-    {!Selector.matches_nothing}, a conditional group rule with an empty body,
-    and an empty [@scope], [@starting-style] or [@page] box. An empty [@when] or
-    [@else] goes only when no [@else] chains onto it, since css-conditional-5
-    sec. 3 binds an [@else] to the branch before it. An empty [@layer] stays,
-    the name still ordering the layer, and so does an empty origin wrapper,
-    which gates nothing. *)
+(** Drop the statements of a block that contribute nothing. *)
 
 val drop_misplaced_imports :
   Stylesheet.statement list -> Stylesheet.statement list

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -72,6 +72,7 @@ let merge_consecutive_media = Block.merge_consecutive_media
 let merge_distant_media = Block.merge_distant_media
 let merge_consecutive_supports = Block.merge_consecutive_supports
 let merge_consecutive_containers = Block.merge_consecutive_containers
+let merge_consecutive_starting_style = Block.merge_consecutive_starting_style
 let is_layer_empty = Block.is_layer_empty
 let collect_empty_layer_names = Block.collect_empty_layer_names
 let merge_layer_declarations = Block.merge_layer_declarations
@@ -175,6 +176,7 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
           |> merge_distant_media ?owner ~optimize_merged_block
           |> merge_consecutive_supports ~optimize_merged_block
           |> merge_consecutive_containers ~optimize_merged_block
+          |> merge_consecutive_starting_style ~optimize_merged_block
         in
         stmts |> merge_layer_declarations |> drop_empty_rules
       in

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -106,13 +106,6 @@ val drop_unknown_at_rules : t -> t
     this: the reader of a transform's output is not always a browser, and an
     agent that later implements the name would render the two differently. *)
 
-val drop_empty_rules : t -> t
-(** [drop_empty_rules ss] removes top-level rules and at-rule frames whose body
-    is empty (no declarations and no nested rules), and rules whose selector
-    {!Selector.matches_nothing}, which no element can ever be styled by. An
-    empty [@when] or [@else] stays while a later [@else] binds to it, and an
-    empty [@layer] or origin wrapper always stays. *)
-
 (** {1 Edge Model} *)
 
 (** Existential wrapper that hides the value type of a typed property tag, so
@@ -144,6 +137,91 @@ val single_rule : ?scope:scope -> rule -> rule
 
 val rules : ?scope:scope -> rule list -> rule list
 (** [rules ?scope rs] optimizes a list of flat rules. *)
+
+(** {1 Statement Optimization}
+
+    Passes over the statements of one block: a whole stylesheet, or the body of
+    a single [@media] / [@layer] / style rule. Each one is a self-contained
+    rewrite, so a caller that runs {!stylesheet} behind a flag of its own can
+    still collapse the structure of a sheet it only serialises.
+
+    [optimize_merged_block] runs over the statements of a block a merge
+    produced. It defaults to the identity, which leaves the joined body exactly
+    as the two written bodies were; {!stylesheet} passes its own recursion, so a
+    merge there re-optimizes what it joins. *)
+
+val merge_consecutive_layers :
+  ?optimize_merged_block:(statement list -> statement list) ->
+  statement list ->
+  statement list
+(** [merge_consecutive_layers stmts] merges adjacent named [@layer] blocks that
+    name the same layer: CSS Cascade 5 sec. 6.4.2 accumulates a named layer over
+    all of its occurrences. An anonymous [@layer] block is left alone, each one
+    without a name creating a layer of its own. *)
+
+val merge_named_layers_by_name : statement list -> statement list
+(** [merge_named_layers_by_name stmts] merges every same-name [@layer] block in
+    one enclosing block into its first non-empty occurrence. The accumulation
+    {!merge_consecutive_layers} exploits is not conditional on adjacency, so
+    this reaches the occurrences another statement is written between. The
+    hoisted content keeps the source order it had within its layer, and against
+    a statement outside that layer precedence follows layer order rather than
+    position (CSS Cascade 5 sec. 6.4.3). *)
+
+val merge_consecutive_media :
+  ?optimize_merged_block:(statement list -> statement list) ->
+  statement list ->
+  statement list
+(** [merge_consecutive_media stmts] merges adjacent [@media] blocks with
+    identical conditions. *)
+
+val merge_distant_media :
+  ?owner:rule ->
+  ?optimize_merged_block:(statement list -> statement list) ->
+  statement list ->
+  statement list
+(** [merge_distant_media ?owner stmts] merges a later same-condition [@media]
+    block into the first occurrence when hoisting it past the intervening
+    statements cannot reorder a conflicting rule (overlapping selector with a
+    shared property set to a different value).
+
+    [owner] is the style rule whose body [stmts] is, when it is one. A
+    declarations run in that body sets properties on [owner] (CSS Nesting 1 sec.
+    3.4), so without it the run is a conflict the hoist never sees; the pass
+    then refuses the merge rather than read that silence as safety. *)
+
+val merge_consecutive_supports :
+  ?optimize_merged_block:(statement list -> statement list) ->
+  statement list ->
+  statement list
+(** [merge_consecutive_supports stmts] merges adjacent [@supports] blocks with
+    identical conditions. *)
+
+val merge_consecutive_containers :
+  ?optimize_merged_block:(statement list -> statement list) ->
+  statement list ->
+  statement list
+(** [merge_consecutive_containers stmts] merges adjacent [@container] blocks
+    with identical names and conditions. *)
+
+val merge_consecutive_starting_style :
+  ?optimize_merged_block:(statement list -> statement list) ->
+  statement list ->
+  statement list
+(** [merge_consecutive_starting_style stmts] merges adjacent [@starting-style]
+    blocks. The rule takes no prelude (CSS Transitions 2 sec. 3.3), so unlike
+    the conditional groups above it has nothing to compare: adjacency is the
+    whole gate. *)
+
+val drop_empty_rules : statement list -> statement list
+(** [drop_empty_rules stmts] drops the statements of a block that contribute
+    nothing: a rule with no declarations and no nested rules, a rule whose
+    selector {!Selector.matches_nothing}, a conditional group rule with an empty
+    body, and an empty [@scope], [@starting-style] or [@page] box. An empty
+    [@when] or [@else] goes only when no [@else] chains onto it, since
+    css-conditional-5 sec. 3 binds an [@else] to the branch before it. An empty
+    [@layer] stays, the name still ordering the layer, and so does an empty
+    origin wrapper, which gates nothing. *)
 
 (** {1 Nested Structure Optimization} *)
 

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -25,3 +25,24 @@ let _ = Pp.float
 let _ = Css.Gradient_direction.of_string
 let _ = Css.shadow
 let _ : Css.shadow Css.kind = Css.Shadow
+
+(* The statement-merging passes are callable on their own, so a caller that
+   does not run the whole optimizer can still collapse a run of blocks. *)
+type merge_block =
+  ?optimize_merged_block:
+    (Stylesheet.statement list -> Stylesheet.statement list) ->
+  Stylesheet.statement list ->
+  Stylesheet.statement list
+
+let _ : merge_block = Optimize.merge_consecutive_layers
+let _ : merge_block = Optimize.merge_consecutive_media
+let _ : merge_block = Optimize.merge_consecutive_supports
+let _ : merge_block = Optimize.merge_consecutive_containers
+let _ : merge_block = Optimize.merge_consecutive_starting_style
+let _ : ?owner:Stylesheet.rule -> merge_block = Optimize.merge_distant_media
+
+let _ : Stylesheet.statement list -> Stylesheet.statement list =
+  Optimize.merge_named_layers_by_name
+
+let _ : Stylesheet.statement list -> Stylesheet.statement list =
+  Optimize.drop_empty_rules

--- a/test/cram/statement_merging.t/consumer.ml
+++ b/test/cram/statement_merging.t/consumer.ml
@@ -1,0 +1,22 @@
+(* A caller that does not run the whole optimizer still collapses a run of
+   adjacent blocks, through the installed public API alone. *)
+open Cascade
+
+let statements css =
+  match Css.of_string css with
+  | Ok { stylesheet; _ } -> stylesheet
+  | Error e -> failwith (Error.to_string e)
+
+let show label merge css =
+  print_string label;
+  print_string ": ";
+  print_endline (Css.to_string ~minify:true (merge (statements css)))
+
+let () =
+  show "media" Optimize.merge_consecutive_media
+    "@media print{.a{opacity:0}}@media print{.b{opacity:1}}";
+  show "supports" Optimize.merge_consecutive_supports
+    "@supports (display:grid){.a{opacity:0}}\n\
+     @supports (display:grid){.b{opacity:1}}";
+  show "starting-style" Optimize.merge_consecutive_starting_style
+    "@starting-style{.a{opacity:0}}@starting-style{.b{opacity:1}}"

--- a/test/cram/statement_merging.t/run.t
+++ b/test/cram/statement_merging.t/run.t
@@ -1,0 +1,9 @@
+The statement-merging passes are reachable on their own: a caller that runs the
+optimizer under its own flag can still collapse a run of adjacent blocks in a
+sheet it only minifies.
+
+  $ ocamlfind ocamlc -package cascade -linkpkg consumer.ml -o consumer
+  $ ./consumer
+  media: @media print{.a{opacity:0}.b{opacity:1}}
+  supports: @supports(display:grid){.a{opacity:0}.b{opacity:1}}
+  starting-style: @starting-style{.a{opacity:0}.b{opacity:1}}

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -906,6 +906,34 @@ let test_optimize_descends_into_every_conditional_group () =
      media(print){a{color:#f00}a{color:#f00}}@else{b{color:#f00}b{color:#f00}}"
     "@when media(print){a{color:red}}@else{b{color:red}}"
 
+(* CSS Transitions 2 sec. 3.3: a [@starting-style] rule carries no condition, so
+   a run of adjacent blocks holds the same starting styles, in the same order,
+   as one block over their concatenation - the argument the conditional groups
+   beside it make once their conditions are known equal. *)
+let test_merge_consecutive_starting_style () =
+  let check name css expected =
+    Alcotest.(check string) name expected (minify (Css.of_string_exn css))
+  in
+  check "@media merges an adjacent run"
+    "@media print{.a{opacity:0}}@media print{.b{opacity:1}}"
+    "@media print{.a{opacity:0}.b{opacity:1}}";
+  check "@supports merges an adjacent run"
+    "@supports (display:grid){.a{opacity:0}}@supports \
+     (display:grid){.b{opacity:1}}"
+    "@supports(display:grid){.a{opacity:0}.b{opacity:1}}";
+  check "@starting-style merges an adjacent run"
+    "@starting-style{.a{opacity:0}}@starting-style{.b{opacity:1}}"
+    "@starting-style{.a{opacity:0}.b{opacity:1}}";
+  check "three in a row collapse to one"
+    "@starting-style{.a{opacity:0}}@starting-style{.b{opacity:1}}@starting-style{.c{opacity:.5}}"
+    "@starting-style{.a{opacity:0}.b{opacity:1}.c{opacity:.5}}";
+  (* Adjacency-only, like the four passes beside it: reaching a block further
+     down means hoisting it over the statements between, which is the analysis
+     [merge_distant_media] carries and this pass does not. *)
+  check "a rule between two blocks keeps them apart"
+    "@starting-style{.a{opacity:0}}.c{opacity:1}@starting-style{.b{opacity:1}}"
+    "@starting-style{.a{opacity:0}}.c{opacity:1}@starting-style{.b{opacity:1}}"
+
 (* An [@property] registration is document-global (CSS Properties and Values API
    1 sec. 2), so a declaration of that name is typed wherever it is written.
    Promotion has to reach the at-rules that hold declarations outside a nested
@@ -1626,6 +1654,9 @@ let optimize_tests =
     ( "optimize descends into every conditional group",
       `Quick,
       test_optimize_descends_into_every_conditional_group );
+    ( "merge consecutive starting-style",
+      `Quick,
+      test_merge_consecutive_starting_style );
     ( "promote registered reaches at-rule declarations",
       `Quick,
       test_promote_registered_reaches_at_rule_declarations );


### PR DESCRIPTION
A caller that runs `Css.optimize` behind a flag of its own gets no structural merging out of a plain minify, because the passes live in a private module. This PR re-exports them on `Css.Optimize` rather than publishing `Block`, whose interface carries loop state only the optimizer can supply.

`merge_consecutive_starting_style` is new, and wired into the optimizer: `@starting-style` takes no prelude, so adjacency is the whole gate, and `--minify` now collapses a run of those blocks.
