### PR TITLE
selector: honour --enforce-spec in the :dir() fold

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -397,6 +397,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify --enforce-spec` keeps the author's `:not(:dir(ltr))` instead of
+  shortening it to `:dir(rtl)`. CSS Selectors 4 sec. 7.1 leaves directionality
+  to the document language, so only a host document like HTML makes `ltr` and
+  `rtl` a partition, and that is one of the facts `--enforce-spec` drops (#593)
 - `--minify` merges a run of adjacent `@starting-style` blocks. The rule takes
   no prelude (CSS Transitions 2 sec. 3.3), so the run holds the same starting
   styles, in the same order, as one block over their concatenation, and the

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cat style.css | cascade -                                          # read stdin
 | `-m, --minify` | Minify the output. Local linear rewrites always run; the expensive global factoring fixpoint runs only when its preflight predicts useful savings. The top-level pipeline re-runs until the AST stops changing (capped at 5 iterations), so the output is a fixed point: rule-order canonicalisation can expose a merge a single pass would miss. |
 | `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win and drives the factoring fixpoint to convergence, the right objective when the output ships uncompressed (inline style attributes, email HTML), at roughly 10-30x the wall clock. Has no effect without `--minify`. |
 | `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Also sorts each rule's declarations into a canonical cross-rule order (keeping cascade-significant pairs in place) so gzip back-references line up. Has no effect without `--minify`. |
-| `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest CSS form it knows, but it keeps every vendor-prefixed declaration and makes no assumption about the HTML direction model, unless the CSS text and spec alone prove the rewrite. Has no effect without `--minify`. |
+| `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest form the CSS text and the specs prove on their own, so it keeps every vendor-prefixed declaration, the `min-`/`max-` spelling of a media or container feature, the `&` prefix on a nested selector, and the author's `:not(:dir(ltr))`. Has no effect without `--minify`. |
 | `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
 | `--flatten-nesting` | Desugar nested rules into flat top-level rules for browsers that pre-date CSS Nesting. By default cascade preserves nesting since modern browsers parse it natively and it is usually shorter. |
 | `--inline-imports` | Resolve `@import` against files relative to the input. Closed-world: assumes you control file resolution. |
@@ -300,14 +300,20 @@ write the optimiser can't see.
 
 ### Target browsers
 
-The default minify targets maintained evergreen browsers. Cascade may use the
-HTML direction model to shorten `:not(:dir(ltr))` to `:dir(rtl)`, and may drop
-a vendor-prefixed declaration (`-moz-box-sizing`) whose unprefixed twin is
-present, since evergreen browsers understand the unprefixed form.
+The default minify targets maintained evergreen browsers rendering an HTML
+document, and takes four facts from that target. The HTML direction model,
+where every element is either `ltr` or `rtl`, shortens `:not(:dir(ltr))` to
+`:dir(rtl)`. A vendor-prefixed declaration (`-moz-box-sizing`) whose unprefixed
+twin is present is dropped, since evergreen browsers understand the unprefixed
+form. A `min-`/`max-` media or container feature becomes the Media Queries 4
+range grammar, `(min-width: 700px)` to `(width >= 700px)`. A nested selector
+loses its `&` prefix, `& div` to `div`, which the relaxed nesting syntax reads
+the same way.
 
 `--enforce-spec` drops those facts. Cascade still serialises to the shortest
-CSS form it knows, but the direction model is not assumed and every vendor
-prefix is kept.
+CSS form it knows, but the direction model is not assumed, every vendor prefix
+is kept, a media or container feature keeps the `min-`/`max-` spelling the
+author wrote, and a nested selector keeps its `&`.
 
 An `@supports` condition is not a target fact. CSS Conditional Rules 3 section
 6.1 defines support as the rendering browser accepting the declaration, down to

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2493,11 +2493,15 @@ and pp : t Pp.t =
   | Not [ Invalid ] when Pp.minified ctx -> pseudo ctx "valid"
   | Not [ Required ] when Pp.minified ctx -> pseudo ctx "optional"
   | Not [ Optional ] when Pp.minified ctx -> pseudo ctx "required"
-  | Not [ Dir "ltr" ] when Pp.minified ctx ->
-      (* CSS Selectors 4 sec. 7.1: directionality is binary, so
-         [:not(:dir(ltr))] is spec-equivalent to [:dir(rtl)] (and shorter). *)
+  | Not [ Dir "ltr" ] when Pp.minified ctx && not ctx.Pp.enforce_spec ->
+      (* CSS Selectors 4 sec. 7.1 leaves directionality to the document
+         language, so CSS alone does not make [ltr] and [rtl] a partition: an
+         element the language gives no directionality matches neither. [HTML]
+         makes it one for every element in an HTML document, which is the host
+         fact [enforce_spec] drops. *)
       func ctx "dir" Pp.string "rtl"
-  | Not [ Dir "rtl" ] when Pp.minified ctx -> func ctx "dir" Pp.string "ltr"
+  | Not [ Dir "rtl" ] when Pp.minified ctx && not ctx.Pp.enforce_spec ->
+      func ctx "dir" Pp.string "ltr"
   | Not selectors -> func ctx "not" sels selectors
   | Has selectors -> func ctx "has" sels_nested_function_lists selectors
   | Nth_child (Index 1, None) when Pp.minified ctx ->

--- a/test/cli/enforce_spec_dir.t
+++ b/test/cli/enforce_spec_dir.t
@@ -1,0 +1,35 @@
+CLI: --enforce-spec keeps the author's :not(:dir()).
+
+CSS Selectors 4 sec. 7.1 defers directionality to the document language, and
+an element the language gives no directionality matches neither `:dir(ltr)`
+nor `:dir(rtl)`. What makes the two a partition is the host document: HTML
+gives every element, not just an HTML one, a directionality of either 'ltr' or
+'rtl'. That is the fact `--minify` takes and `--enforce-spec` drops.
+
+  $ cat > ltr.css <<EOF
+  > .a:not(:dir(ltr)) { color: red }
+  > EOF
+  $ cascade fmt --minify ltr.css
+  .a:dir(rtl){color:red}
+  $ cascade fmt --minify --enforce-spec ltr.css
+  .a:not(:dir(ltr)){color:red}
+
+The other direction is the same fact.
+
+  $ cat > rtl.css <<EOF
+  > .a:not(:dir(rtl)) { color: red }
+  > EOF
+  $ cascade fmt --minify rtl.css
+  .a:dir(ltr){color:red}
+  $ cascade fmt --minify --enforce-spec rtl.css
+  .a:not(:dir(rtl)){color:red}
+
+The author's own `:dir()` is not a rewrite either way.
+
+  $ cat > plain.css <<EOF
+  > .a:dir(rtl) { color: red }
+  > EOF
+  $ cascade fmt --minify plain.css
+  .a:dir(rtl){color:red}
+  $ cascade fmt --minify --enforce-spec plain.css
+  .a:dir(rtl){color:red}

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -50,6 +50,15 @@ let check_minified_to expected input =
     ("specificity preserved: " ^ input)
     (specificity original) (specificity reparsed)
 
+(* Minified serialisation under [--enforce-spec], where no fact about the
+   rendering browser or the host document language is available: a rewrite runs
+   only when the CSS text and the CSS specs prove it on their own. *)
+let check_enforce_spec_to expected input =
+  let actual =
+    Css.Pp.to_string ~minify:true ~enforce_spec:true pp (of_string input)
+  in
+  Alcotest.(check string) ("enforce-spec " ^ input) expected actual
+
 (* Extra minifier invariant: minify is idempotent (a second pass produces no
    further change), and specificity is preserved. Strict AST equality between
    [original] and [reparsed] does not hold for inputs the minifier rewrites
@@ -2163,6 +2172,28 @@ let spec_minifier_semantics () =
   neg_cursor read ".a::before.class";
   neg_cursor read ".a::before::before"
 
+(* CSS Selectors 4 sec. 7.1 defers directionality to the document language, and
+   an element the language gives no directionality matches neither [:dir(ltr)]
+   nor [:dir(rtl)], so the CSS text alone never proves the two are a partition.
+   [HTML] proves it for a host HTML document: the directionality of an element,
+   any element and not just an HTML one, is either 'ltr' or 'rtl'. Default
+   minify takes that host fact; [--enforce-spec] drops it and keeps the author's
+   [:not()]. *)
+let spec_selector_dir_fold_is_a_host_fact () =
+  check_minified_to ".a:dir(rtl)" ".a:not(:dir(ltr))";
+  check_minified_to ".a:dir(ltr)" ".a:not(:dir(rtl))";
+  check_enforce_spec_to ".a:not(:dir(ltr))" ".a:not(:dir(ltr))";
+  check_enforce_spec_to ".a:not(:dir(rtl))" ".a:not(:dir(rtl))";
+  (* The author's own [:dir()] is a plain serialisation in either mode. *)
+  check_minified_to ".a:dir(rtl)" ".a:dir(rtl)";
+  check_enforce_spec_to ".a:dir(ltr)" ".a:dir(ltr)";
+  (* The gate is on the host fact alone: rewrites the CSS specs prove on their
+     own still run. Selectors 4 sec. 8.1 defines [:any-link] as equivalent to
+     [:is(:link, :visited)], and sec. 4.3 makes [:not(:not(X))] equivalent to
+     [X]. *)
+  check_enforce_spec_to ".a:any-link" ".a:is(:link,:visited)";
+  check_enforce_spec_to ".a:hover" ".a:not(:not(:hover))"
+
 (* ignore-test *)
 let test_spec_forgiving_selector_lists () =
   (* Selectors Level 4: :is() and :where() use forgiving selector-list parsing.
@@ -2667,6 +2698,8 @@ let suite =
         test_spec_selector_specificity;
       test_case "spec selector minifier semantics" `Quick
         spec_minifier_semantics;
+      test_case "spec selector :dir() fold is a host fact" `Quick
+        spec_selector_dir_fold_is_a_host_fact;
       test_case "spec forgiving selector lists" `Quick
         test_spec_forgiving_selector_lists;
       test_case "spec selector current pseudo vectors" `Quick


### PR DESCRIPTION
`--minify --enforce-spec` folded `:not(:dir(ltr))` to `:dir(rtl)` even though the README documents the flag as making no assumption about the HTML direction model; CSS Selectors 4 sec. 7.1 leaves directionality to the document language, so only a host document like HTML makes the two a partition.

The README also names the target gates it omitted: the `min-`/`max-` spelling of a media or container feature, and the nested `&` prefix.
