### PR TITLE
selector: accept any single identifier in :dir()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -174,6 +174,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `:dir()` accepts any single identifier, so `:dir(auto)` is read and written
+  back instead of taking its whole rule down. CSS Selectors 4 sec. 7.1 says a
+  value other than `ltr` or `rtl` "is not invalid, but does not match
+  anything", which through `:not()` is the difference between a rule that
+  matches every element and no rule at all (#594)
 - `stroke-width` reads a bare number, so `stroke-width: 1.5` round-trips
   through cascade's own parser instead of being printed and then refused. SVG 2
   sec. 13.5.3 gives it `<length-percentage> | <number>`, where a number is a

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -331,10 +331,11 @@ let read_lang_content t =
   Lang langs
 
 let read_dir_content t =
-  (* :dir() accepts only [ltr] or [rtl] per Selectors 4 sec. 7.1. *)
+  (* Selectors 4 sec. 7.1: the argument is a single identifier, and one other
+     than [ltr] or [rtl] "is not invalid, but does not match anything". Keeping
+     it verbatim also leaves room for a directionality a later markup spec
+     defines. *)
   let dir = Cursor.ident t in
-  if dir <> "ltr" && dir <> "rtl" then
-    Cursor.err_invalid t (":dir() expects ltr or rtl, got: " ^ dir);
   ensure_call_done t "dir";
   Dir dir
 

--- a/lib/selector_intf.ml
+++ b/lib/selector_intf.ml
@@ -230,7 +230,7 @@ type t =
   | Nth_last_of_type of nth * t list option (* :nth-last-of-type(An+B [of S]) *)
   | Nth_col of nth (* :nth-col(An+B) *)
   | Nth_last_col of nth (* :nth-last-col(An+B) *)
-  | Dir of string (* :dir(ltr|rtl) *)
+  | Dir of string (* :dir(<ident>) *)
   | Lang of string list (* :lang(en|fr|...) - comma-separated language codes *)
   | Host of t list option (* :host or :host(selector) *)
   | Host_context of t list (* :host-context(selector) *)

--- a/test/cli/dir_ident.t
+++ b/test/cli/dir_ident.t
@@ -1,0 +1,13 @@
+CLI: :dir() takes any single identifier.
+
+CSS Selectors 4 sec. 7.1: "Values other than ltr and rtl are not invalid, but
+do not match anything." `:dir(auto)` matches no element, so `:not(:dir(auto))`
+matches every element, and its rule must survive. The colour is folded to its
+shortest spelling on the way out, which is a separate pass.
+
+  $ cat > dir.css <<CSS
+  > .i:not(:dir(auto)) { color: lime }
+  > .j { color: red }
+  > CSS
+  $ cascade fmt --minify dir.css
+  .i:not(:dir(auto)){color:#0f0}.j{color:red}

--- a/test/render/dom_of_css.ml
+++ b/test/render/dom_of_css.ml
@@ -316,7 +316,11 @@ let rec add sp part =
   | Selector.Open ->
       want_tag sp "details";
       set_attr sp "open" ""
-  | Selector.Dir d -> set_attr sp "dir" d
+  | Selector.Dir (("ltr" | "rtl") as d) -> set_attr sp "dir" d
+  | Selector.Dir _ ->
+      (* Selectors 4 sec. 7.1: no element matches any other directionality, so
+         there is nothing to build. *)
+      raise (Skip "unknown :dir() directionality")
   | Selector.Lang (code :: _) -> set_attr sp "lang" code
   | Selector.Lang [] -> raise (Skip "empty :lang()")
   | Selector.Heading -> want_tag sp "h1"
@@ -412,7 +416,10 @@ and negate sp = function
   | Selector.Enabled ->
       want_tag sp "input";
       set_attr sp "disabled" ""
-  | Selector.Dir d -> set_attr sp "dir" (if d = "rtl" then "ltr" else "rtl")
+  (* Sec. 7.1 again: the negation of an unknown directionality holds for every
+     element, so any [dir] serves. *)
+  | Selector.Dir "rtl" -> set_attr sp "dir" "ltr"
+  | Selector.Dir _ -> set_attr sp "dir" "rtl"
   | Selector.Not l -> List.iter (add sp) l
   | Selector.Compound parts -> List.iter (negate sp) parts
   | Selector.List l | Selector.Is l | Selector.Where l ->

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -2194,6 +2194,34 @@ let spec_selector_dir_fold_is_a_host_fact () =
   check_enforce_spec_to ".a:any-link" ".a:is(:link,:visited)";
   check_enforce_spec_to ".a:hover" ".a:not(:not(:hover))"
 
+(* CSS Selectors 4 sec. 7.1: "The argument to :dir() must be a single
+   identifier, otherwise the selector is invalid. [...] Values other than ltr
+   and rtl are not invalid, but do not match anything." An unrecognised
+   directionality is a valid selector that matches no element, so it parses and
+   round-trips; a non-identifier argument stays invalid. *)
+let spec_selector_dir_argument_is_an_ident () =
+  check ":dir(auto)";
+  check ":dir(sideways)";
+  check ":dir(--custom)";
+  check ~expected:":dir(auto)" ":dir( auto )";
+  check_minified_to ".a:dir(auto)" ".a:dir(auto)";
+  (* [:dir(auto)] matches nothing, so [:not(:dir(auto))] matches everything.
+     That is not [:dir(<the other one>)]: the sec. 7.1 fold speaks only for the
+     two directionalities the spec names, and must not fire here in either
+     mode. *)
+  check_minified_to ".a:not(:dir(auto))" ".a:not(:dir(auto))";
+  check_enforce_spec_to ".a:not(:dir(auto))" ".a:not(:dir(auto))";
+  (* The two directionalities sec. 7.1 does name still fold, which is what makes
+     the pair above a contrast rather than a blanket ban. *)
+  check_minified_to ".a:dir(rtl)" ".a:not(:dir(ltr))";
+  check_enforce_spec_to ".a:not(:dir(ltr))" ".a:not(:dir(ltr))";
+  (* "a single identifier, otherwise the selector is invalid": no argument, a
+     number, a string, and two idents are all outside the grammar. *)
+  neg_cursor read ":dir()";
+  neg_cursor read ":dir(1)";
+  neg_cursor read ":dir(\"ltr\")";
+  neg_cursor read ":dir(ltr, rtl)"
+
 (* ignore-test *)
 let test_spec_forgiving_selector_lists () =
   (* Selectors Level 4: :is() and :where() use forgiving selector-list parsing.
@@ -2700,6 +2728,8 @@ let suite =
         spec_minifier_semantics;
       test_case "spec selector :dir() fold is a host fact" `Quick
         spec_selector_dir_fold_is_a_host_fact;
+      test_case "spec selector :dir() argument is an ident" `Quick
+        spec_selector_dir_argument_is_an_ident;
       test_case "spec forgiving selector lists" `Quick
         test_spec_forgiving_selector_lists;
       test_case "spec selector current pseudo vectors" `Quick

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -2644,7 +2644,6 @@ let spec_selector_serialization_invariant_matrix () =
       ":nth-last-of-type(odd even)";
       ":has(+)";
       ":lang(, en)";
-      ":dir(sideways)";
       "::part(tab, panel)";
       "::slotted(.a, .b)";
       "::cue-region()";


### PR DESCRIPTION
`.i:not(:dir(auto)) { color: lime }` produced no rule at all: cascade refused the `:dir()` argument at parse and dropped the whole thing with a warning, where a browser paints every `.i` lime. CSS Selectors 4 sec. 7.1 says a value other than `ltr` or `rtl` "is not invalid, but does not match anything", so `:dir(auto)` matches nothing and its negation matches everything.

A non-identifier argument (`:dir()`, `:dir(1)`, `:dir("ltr")`, `:dir(ltr, rtl)`) stays invalid, and the `ltr`/`rtl` fold #593 gated on `--enforce-spec` still fires for those two and not for an argument sec. 7.1 does not name.
