### PR TITLE
css: statement equality and fingerprint, and a colour's alpha

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -781,6 +781,16 @@ recorded cases carrying six minifiers' answers.
   serialises. `Css.Optimize.drop_empty_rules` is spelled over the statement
   list it walks, which states the scope it always had: the block it is given,
   not the tree below it (#592)
+- `Css.equal_statement` and `Css.hash_statement` answer whether two statements
+  are the same, and key one in a hash table, without rendering either to CSS
+  text. Each part is read through the equality its own module states, so two
+  `@media` blocks that select the same media are one statement however their
+  queries are spelled, and the fingerprint reuses the hash a declaration
+  already caches rather than walking its value tree. `Css.Values.hash_color`
+  is that pair for a colour, beside the `equal_color` it already had, and
+  `Css.Values.with_alpha` sets a colour's alpha: a hex or a named colour is
+  re-spelled as the `rgb()` carrying the alpha slot CSS Color 4 sec. 4.1 gives
+  only the functional notations (#595)
 - `Css.inline_vars` no longer costs a square in the variable count: liveness is
   decided through indexes and a worklist, and the customs a rule can see are
   indexed by name instead of scanned per declaration. A 12,800-variable sheet

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -459,6 +459,8 @@ let rule_statements t =
 
 (* Function to extract all statements, not just rules *)
 let statements t = t
+let equal_statement = Stylesheet.equal_statement
+let hash_statement = Stylesheet.hash_statement
 let fold f acc t = Stylesheet.fold_statements f acc t
 
 let media_queries t =

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -462,6 +462,16 @@ val rule_statements : t -> statement list
 val statements : t -> statement list
 (** [statements t] returns all top-level statements from the stylesheet. *)
 
+val equal_statement : statement -> statement -> bool
+(** [equal_statement a b] is {!Stylesheet.equal_statement}: whether [a] and [b]
+    are the same statement, each part read through the equality its own module
+    states. *)
+
+val hash_statement : statement -> int
+(** [hash_statement stmt] is {!Stylesheet.hash_statement}: a fingerprint
+    consistent with {!equal_statement}, for keying a statement in a hash table
+    without rendering it to CSS text. *)
+
 val fold : ('a -> statement -> 'a) -> 'a -> t -> 'a
 (** [fold f acc css] folds [f] over every statement in [css] and over every
     statement reachable from one, in source order: a rule nested in a rule, a

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -515,6 +515,194 @@ let map_declarations f block =
   in
   Common.List.map_preserve statement block
 
+(** {1 Statement Identity} *)
+
+(* Every part is read through the equality its own module states, which is not
+   the answer a structural walk gives: {!Media.equal} and {!Container.equal}
+   normalise the query first, so two spellings that select the same media are
+   one statement here and two under [Stdlib.compare]. The statements holding no
+   condition, no selector and no block are the structural walk, the answer
+   {!Declaration.equal_declaration} gives as well. *)
+
+let equal_moz_document_condition (a : moz_document_condition) b =
+  match (a, b) with
+  | Url_exact a, Url_exact b
+  | Domain a, Domain b
+  | Media_document a, Media_document b
+  | Regexp a, Regexp b ->
+      String.equal a b
+  | Url_prefix a, Url_prefix b -> Option.equal String.equal a b
+  | (Url_exact _ | Url_prefix _ | Domain _ | Media_document _ | Regexp _), _ ->
+      false
+
+let rec equal_conditional (a : conditional) b =
+  match (a, b) with
+  | Media_condition a, Media_condition b -> Media.equal a b
+  | Supports_condition_test a, Supports_condition_test b -> Supports.equal a b
+  | And (a1, b1), And (a2, b2) | Or (a1, b1), Or (a2, b2) ->
+      equal_conditional a1 a2 && equal_conditional b1 b2
+  | (Media_condition _ | Supports_condition_test _ | And _ | Or _), _ -> false
+
+let equal_import_rule (a : import_rule) b =
+  String.equal a.url b.url
+  && Option.equal equal_layer_name a.layer b.layer
+  && Option.equal Supports.equal a.supports b.supports
+  && Option.equal Media.equal a.media b.media
+
+let rec equal_statement (a : statement) b =
+  match (a, b) with
+  | Rule r1, Rule r2 -> equal_rule r1 r2
+  | Layer (n1, b1), Layer (n2, b2) ->
+      Option.equal equal_layer_name n1 n2 && equal_block b1 b2
+  | Media (m1, b1), Media (m2, b2) -> Media.equal m1 m2 && equal_block b1 b2
+  | Container (n1, c1, b1), Container (n2, c2, b2) ->
+      Option.equal String.equal n1 n2
+      && Option.equal Container.equal c1 c2
+      && equal_block b1 b2
+  | Supports (c1, b1), Supports (c2, b2) ->
+      Supports.equal c1 c2 && equal_block b1 b2
+  | Moz_document (c1, b1), Moz_document (c2, b2) ->
+      List.equal equal_moz_document_condition c1 c2 && equal_block b1 b2
+  | Starting_style b1, Starting_style b2 -> equal_block b1 b2
+  | When (c1, b1), When (c2, b2) -> equal_conditional c1 c2 && equal_block b1 b2
+  | Else (c1, b1), Else (c2, b2) ->
+      Option.equal equal_conditional c1 c2 && equal_block b1 b2
+  | Origin (o1, b1), Origin (o2, b2) ->
+      equal_cascade_origin o1 o2 && equal_block b1 b2
+  | Scope (s1, e1, b1), Scope (s2, e2, b2) ->
+      Option.equal Selector.equal s1 s2
+      && Option.equal Selector.equal e1 e2
+      && equal_block b1 b2
+  | Import i1, Import i2 -> equal_import_rule i1 i2
+  (* What is left holds no block, no at-rule condition and no selector: names,
+     declarations and descriptor values, each of which the structural walk reads
+     the way its own module does. It also answers every mismatched pair whose
+     left side is one of these. *)
+  | ( ( Declarations _ | Bang_comment _ | Charset _ | Namespace _ | Property _
+      | Layer_decl _ | Supports_condition _ | Keyframes _ | Webkit_keyframes _
+      | Moz_keyframes _ | Font_face _ | Counter_style _ | Page _
+      | Page_with_margins _ | Font_palette_values _ | Font_feature_values _
+      | View_transition _ | Position_try _ | Viewport _ | Unknown_at_rule _ ),
+      _ ) ->
+      Stdlib.compare a b = 0
+  | ( ( Rule _ | Layer _ | Media _ | Container _ | Supports _ | Moz_document _
+      | Starting_style _ | When _ | Else _ | Origin _ | Scope _ | Import _ ),
+      _ ) ->
+      false
+
+and equal_block b1 b2 = List.equal equal_statement b1 b2
+
+and equal_rule (a : rule) b =
+  Option.equal String.equal a.merge_key b.merge_key
+  && Selector.equal a.selector b.selector
+  && List.equal Declaration.equal_declaration a.declarations b.declarations
+  && equal_block a.nested b.nested
+
+(* The fingerprint reads the statement's shape, {!Declaration.hash} of every
+   declaration it holds, {!Selector.hash} of every selector, the names and
+   descriptors it carries, and, recursively, the statements of its block.
+
+   The conditions of the conditional at-rules are the exception. {!Media.equal}
+   and {!Container.equal} answer on normalised queries, so no structural hash of
+   one agrees with them, and neither they nor {!Supports} state a hash of their
+   own. A fingerprint that disagreed with the equality it serves would file one
+   statement under two keys, so a condition is left unread: two statements
+   differing only there share a bucket, and [equal_statement] separates them. *)
+let mix = Common.mix_int
+let mix_string acc s = mix acc (Common.hash_string s)
+
+(* Bounded like [Declaration.hash]: a descriptor list is one leaf here, and the
+   cap keeps a long one out of the caller's inner loop. *)
+let mix_leaf acc x = mix acc (Hashtbl.hash_param 30 100 x)
+
+(* [None]/[Some] are shadowed here by the descriptor constructors of the same
+   name, so the option is matched through its own path. *)
+let mix_opt f acc = function
+  | Option.None -> mix acc 0
+  | Option.Some v -> f (mix acc 1) v
+
+let mix_decls acc =
+  List.fold_left (fun acc d -> mix acc (Declaration.hash d)) acc
+
+let mix_layer_name acc = List.fold_left mix_string acc
+let mix_selector acc s = mix acc (Selector.hash s)
+
+let mix_frames acc frames =
+  List.fold_left
+    (fun acc (f : keyframe) ->
+      mix_decls (mix_leaf acc f.selector) f.declarations)
+    acc frames
+
+let mix_namespace_url acc = function
+  | (Url (url, _) : namespace_url) | Quoted url -> mix_string acc url
+
+let rec mix_statement acc (stmt : statement) =
+  match stmt with
+  | Rule { selector; declarations; nested; merge_key } ->
+      mix_block
+        (mix_opt mix_string
+           (mix_decls (mix_selector (mix acc 1) selector) declarations)
+           merge_key)
+        nested
+  | Declarations decls -> mix_decls (mix acc 2) decls
+  | Bang_comment body -> mix_string (mix acc 3) body
+  | Charset name -> mix_string (mix acc 4) name
+  | Import { url; layer; supports = _; media = _ } ->
+      mix_opt mix_layer_name (mix_string (mix acc 5) url) layer
+  | Namespace (prefix, url) ->
+      mix_namespace_url (mix_opt mix_string (mix acc 6) prefix) url
+  | Property { name; syntax; inherits; initial_value } ->
+      mix_leaf (mix_string (mix acc 7) name) (syntax, inherits, initial_value)
+  | Layer_decl names -> List.fold_left mix_layer_name (mix acc 8) names
+  | Layer (name, block) ->
+      mix_block (mix_opt mix_layer_name (mix acc 9) name) block
+  | Media (_, block) -> mix_block (mix acc 10) block
+  | Container (name, _, block) ->
+      mix_block (mix_opt mix_string (mix acc 11) name) block
+  | Supports (_, block) -> mix_block (mix acc 12) block
+  | Moz_document (conditions, block) ->
+      mix_block (mix_leaf (mix acc 13) conditions) block
+  | Starting_style block -> mix_block (mix acc 14) block
+  | When (_, block) -> mix_block (mix acc 15) block
+  | Else (_, block) -> mix_block (mix acc 16) block
+  | Supports_condition (name, decls) ->
+      mix_decls (mix_string (mix acc 17) name) decls
+  | Origin (origin, block) -> mix_block (mix_leaf (mix acc 18) origin) block
+  | Scope (start_, end_, block) ->
+      mix_block
+        (mix_opt mix_selector (mix_opt mix_selector (mix acc 19) start_) end_)
+        block
+  | Keyframes (name, frames) -> mix_frames (mix_string (mix acc 20) name) frames
+  | Webkit_keyframes (name, frames) ->
+      mix_frames (mix_string (mix acc 21) name) frames
+  | Moz_keyframes (name, frames) ->
+      mix_frames (mix_string (mix acc 22) name) frames
+  | Font_face descriptors -> mix_leaf (mix acc 23) descriptors
+  | Counter_style (name, descriptors) ->
+      mix_leaf (mix_string (mix acc 24) name) descriptors
+  | Page (selectors, decls) -> mix_decls (mix_leaf (mix acc 25) selectors) decls
+  | Page_with_margins (selectors, descriptors, margins) ->
+      List.fold_left
+        (fun acc (m : page_margin_rule) ->
+          mix_decls (mix_string acc m.name) m.descriptors)
+        (mix_decls (mix_leaf (mix acc 26) selectors) descriptors)
+        margins
+  | Font_palette_values (name, descriptors) ->
+      mix_leaf (mix_string (mix acc 27) name) descriptors
+  | Font_feature_values (families, blocks) ->
+      mix_leaf (mix acc 28) (families, blocks)
+  | View_transition descriptors -> mix_leaf (mix acc 29) descriptors
+  | Position_try (name, decls) -> mix_decls (mix_string (mix acc 30) name) decls
+  | Viewport (prefix, descriptors) -> mix_leaf (mix acc 31) (prefix, descriptors)
+  | Unknown_at_rule { name; prelude; block } ->
+      mix_opt mix_string
+        (mix_string (mix_string (mix acc 32) name) prelude)
+        block
+
+and mix_block acc block = List.fold_left mix_statement acc block
+
+let hash_statement stmt = mix_statement 0x811c9dc5 stmt
+
 (** {1 Pretty Printing} *)
 
 let pp_property_rule : 'a property_rule Pp.t =

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -78,6 +78,26 @@ val equal_layer_name : layer_name -> layer_name -> bool
     how an ident is escaped are the same layer; [@layer a\2e b] and [@layer a.b]
     are not. *)
 
+val equal_statement : statement -> statement -> bool
+(** [equal_statement a b] is whether [a] and [b] are the same statement. Every
+    part is read through the equality its own module states, so two [\@media]
+    blocks whose queries select the same media are one statement even where the
+    two queries are spelled apart, while an [\@supports] guard naming a
+    different value stays a second statement. *)
+
+val hash_statement : statement -> int
+(** [hash_statement stmt] is a fingerprint of [stmt] consistent with
+    {!equal_statement}: two statements that are equal always return the same
+    value, and the converse may fail on a collision, so use it as a cheap
+    pre-filter before falling back to {!equal_statement}.
+
+    It reads the statement's shape, {!Declaration.hash} of every declaration it
+    holds, {!Selector.hash} of every selector, the names and descriptors it
+    carries, and, recursively, the statements of its block. It does not read the
+    condition of an [\@media], [\@container] or [\@supports] rule, since none of
+    the three states a hash agreeing with its equality; two statements differing
+    only in a condition share a bucket. *)
+
 val layer_block_name : statement -> layer_name option
 (** [layer_block_name stmt] returns the declared name for an [@layer] block
     rule. It returns [Some []] for anonymous layer blocks, [Some name] for named

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3483,6 +3483,37 @@ let hex_string_of_bytes r g b a =
   if a = 255 then shorten_hex rgb
   else shorten_hex (String.concat "" [ rgb; hex_of_byte a ])
 
+(* Only the functional notations carry CSS Color 4 sec. 4.1's [<alpha-value>]
+   slot, so a hex, a named colour and [transparent] are re-spelled as the
+   [rgb()] over the sRGB bytes sec. 6.1 and sec. 6.3 give them. A colour whose
+   channels are known only at used-value time has nothing to write into. *)
+let rec with_alpha (c : color) (a : alpha) : color =
+  let srgb r g b =
+    Rgba { rgb = Channels { r = Int r; g = Int g; b = Int b }; a }
+  in
+  match c with
+  | Hex { r; g; b; _ } | Authored_hex { r; g; b; _ } -> srgb r g b
+  | Transparent -> srgb 0 0 0
+  | Named n -> (
+      match rgba_of_hex (snd (color_name_hex n)) with
+      | Some (r, g, b, _) -> srgb r g b
+      | Option.None -> c)
+  | Rgb rgb | Rgba { rgb; _ } -> Rgba { rgb; a }
+  | Hsl { h; s; l; _ } -> Hsl { h; s; l; a }
+  | Hwb { h; w; b; _ } -> Hwb { h; w; b; a }
+  | Color { space; components; _ } -> Color { space; components; alpha = a }
+  | Lab { l; a = axis_a; b; _ } -> Lab { l; a = axis_a; b; alpha = a }
+  | Oklab { l; a = axis_a; b; _ } -> Oklab { l; a = axis_a; b; alpha = a }
+  | Lch { l; c = chroma; h; _ } -> Lch { l; c = chroma; h; alpha = a }
+  | Oklch { l; c = chroma; h; _ } -> Oklch { l; c = chroma; h; alpha = a }
+  (* [light-dark()] resolves to one of its two arguments, so both take it. *)
+  | Light_dark (light, dark) ->
+      Light_dark (with_alpha light a, with_alpha dark a)
+  | Relative_rgb _ | Relative_color _ | Contrast_color _ | Attribute _
+  | System _ | Var _ | Current | Mix _ | Auto | Inherit | Initial | Unset
+  | Revert | Revert_layer ->
+      c
+
 let minify_color : color -> color = function
   | Named n -> (
       let name, hex = color_name_hex n in

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -83,6 +83,37 @@ val lcha : float -> float -> float -> float -> color
 val color_name : color_name -> color
 (** [color_name n] creates a named color. *)
 
+val with_alpha : color -> alpha -> color
+(** [with_alpha c a] is [c] carrying the alpha [a], replacing whatever alpha [c]
+    already spelled.
+
+    CSS Color 4 sec. 4.1 gives an [<alpha-value>] slot to the functional colour
+    notations and to no other. A hex spells its alpha as a fourth pair of
+    digits, which holds a byte rather than a percentage or a [calc()], and a
+    named colour has no channel at all, so a hex, a named colour and
+    {!val-transparent} are re-spelled as the [rgb()] over the same sRGB
+    channels: [red] becomes [rgb(255 0 0 / a)], and {!val-transparent} the
+    [rgb(0 0 0 / a)] of sec. 6.3. A notation that already has the slot keeps
+    both its notation and its channels. [light-dark()] resolves to exactly one
+    of its two arguments, so the alpha goes onto both.
+
+    A colour whose channels are known only at used-value time ([currentcolor], a
+    [var()], a system colour, [color-mix()], [contrast-color()], [attr()], a
+    relative colour) has nothing to write into and comes back unchanged, the
+    answer {!gamut_map_color} gives one too. So do the CSS-wide keywords and
+    [auto], which are not colours. *)
+
+val equal_color : color -> color -> bool
+(** [equal_color a b] tests colours for structural equality. Two spellings of
+    one colour are two colours: [#fff] and [white] name the same sRGB, and each
+    is its own node until {!normalize_color} folds it. *)
+
+val hash_color : color -> int
+(** [hash_color c] returns a hash consistent with {!equal_color}: two colours
+    that are equal always return the same value, and the converse may fail on a
+    collision, so use it as a cheap pre-filter before falling back to
+    {!equal_color}. *)
+
 val minify_color : color -> color
 (** [minify_color c] converts named colors to hex when the hex form is shorter
     or equal length, matching Lightning CSS behavior. *)

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -591,3 +591,8 @@ let equal_length (a : length) b = a = b
 let equal_length_percentage (a : length_percentage) b = a = b
 let equal_number_percentage (a : number_percentage) b = a = b
 let equal_color (a : color) b = a = b
+
+(* Bounded like [Declaration.hash], for the same reason: the depth cap keeps the
+   cost of fingerprinting a deep [color-mix()] tree off the caller's inner
+   loop. *)
+let hash_color (c : color) = Hashtbl.hash_param 30 100 c

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -46,3 +46,13 @@ let _ : Stylesheet.statement list -> Stylesheet.statement list =
 
 let _ : Stylesheet.statement list -> Stylesheet.statement list =
   Optimize.drop_empty_rules
+
+(* Two statements can be compared and keyed on without rendering either to CSS
+   text, and a colour can be given an alpha without re-spelling it by hand. *)
+let _ : Css.statement -> Css.statement -> bool = Css.equal_statement
+let _ : Css.statement -> int = Css.hash_statement
+let _ : Css.Values.color -> Css.Values.color -> bool = Css.Values.equal_color
+let _ : Css.Values.color -> int = Css.Values.hash_color
+
+let _ : Css.Values.color -> Css.Values.alpha -> Css.Values.color =
+  Css.Values.with_alpha

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -10253,7 +10253,302 @@ let render_tests =
     ("to_string renders pretty once", `Quick, to_string_renders_once false);
   ]
 
+(* {2 Statement equality and fingerprint} *)
+
+(* One statement per shape, spelled in the CSS that produces it. Every shape is
+   parsed rather than assembled so the test reads what a stylesheet holds, not
+   what a constructor was handed. *)
+let parsed_shapes =
+  [
+    ("rule", ".a{color:red}");
+    ("bang comment", "/*! keep */");
+    ("charset", "@charset \"UTF-8\";");
+    ("import", "@import url(a.css) layer(x) supports(display:grid) screen;");
+    ("namespace", "@namespace svg url(http://www.w3.org/2000/svg);");
+    ( "property",
+      "@property --x{syntax:\"<length>\";inherits:false;initial-value:0px}" );
+    ("layer statement", "@layer a,b;");
+    ("layer block", "@layer a{.x{color:red}}");
+    ("media", "@media screen{.x{color:red}}");
+    ("container", "@container card (min-width:10px){.x{color:red}}");
+    ("supports", "@supports (display:grid){.x{color:red}}");
+    ("moz-document", "@-moz-document url-prefix(){.x{color:red}}");
+    ("starting-style", "@starting-style{.x{color:red}}");
+    ("when", "@when media(width>0px){.x{color:red}}");
+    ("supports-condition", "@supports-condition --n{color:red}");
+    ("scope", "@scope (.a) to (.b){.x{color:red}}");
+    ("keyframes", "@keyframes k{from{opacity:0}to{opacity:1}}");
+    ("webkit keyframes", "@-webkit-keyframes k{from{opacity:0}}");
+    ("moz keyframes", "@-moz-keyframes k{from{opacity:0}}");
+    ("font-face", "@font-face{font-family:A;src:url(a.woff2)}");
+    ("counter-style", "@counter-style c{system:cyclic;symbols:\"a\"}");
+    ("page with margins", "@page{margin:1cm;@top-left{content:\"x\"}}");
+    ( "font-palette-values",
+      "@font-palette-values --p{font-family:A;override-colors:0 red}" );
+    ("font-feature-values", "@font-feature-values A{@styleset{nice:1}}");
+    ("view-transition", "@view-transition{navigation:auto}");
+    ("position-try", "@position-try --p{top:0}");
+    ("viewport", "@viewport{width:100px}");
+    ("unknown at-rule", "@wibble foo{bar:1}");
+  ]
+
+let sole_statement css =
+  match Css.statements (Css.of_string_exn css) with
+  | [ s ] -> s
+  | l -> Alcotest.failf "%s: expected one statement, got %d" css (List.length l)
+
+(* The four shapes with no source text of their own. [Declarations] holds the
+   bare declarations of a nested block, [Else] needs the [@when] it answers,
+   [Origin] is an API-level wrapper the CSS grammar has no spelling for, and the
+   parser folds every [@page] into [Page_with_margins]. *)
+let bare_declarations () =
+  match
+    Css.statements (Css.of_string_exn ".a{color:red;@media screen{color:blue}}")
+  with
+  | [ Rule { nested = [ Media (_, [ (Declarations _ as d) ]) ]; _ } ] -> d
+  | _ -> Alcotest.fail "expected bare declarations inside a nested @media"
+
+let else_branch () =
+  match
+    Css.statements
+      (Css.of_string_exn
+         "@when media(width>0px){.x{color:red}}@else{.y{color:red}}")
+  with
+  | [ _; (Else _ as e) ] -> e
+  | _ -> Alcotest.fail "expected an @else branch"
+
+let statement_shapes () =
+  List.map (fun (label, css) -> (label, sole_statement css)) parsed_shapes
+  @ [
+      ("bare declarations", bare_declarations ());
+      ("else", else_branch ());
+      ("origin", with_origin User [ sole_statement ".x{color:red}" ]);
+      ("page", Page ([], [ Css.Declaration.of_string "margin:1cm" ]));
+    ]
+
+(* Two independent builds of the list, so no answer below can come from physical
+   equality of a shared node. *)
+let shape_matrix f =
+  let left = statement_shapes () and right = statement_shapes () in
+  List.concat_map
+    (fun (la, sa) -> List.filter_map (fun (lb, sb) -> f la sa lb sb) right)
+    left
+
+let statement_equality_separates_every_shape () =
+  let wrong =
+    shape_matrix (fun la sa lb sb ->
+        let same_shape = String.equal la lb in
+        if Bool.equal (Css.equal_statement sa sb) same_shape then None
+        else Some (String.concat "" [ la; " vs "; lb ]))
+  in
+  Alcotest.(check (list string))
+    "each shape equals its own copy and no other" [] wrong
+
+(* A hash that disagreed with the equality it serves would put one statement in
+   two buckets. The converse is not required: a collision is allowed. *)
+let statement_hash_agrees_with_equality () =
+  let wrong =
+    shape_matrix (fun la sa lb sb ->
+        if
+          Css.equal_statement sa sb
+          && Css.hash_statement sa <> Css.hash_statement sb
+        then Some (String.concat "" [ la; " vs "; lb ])
+        else None)
+  in
+  Alcotest.(check (list string)) "equal statements hash alike" [] wrong;
+  (* A constant hash would satisfy the rule above and be useless. *)
+  Alcotest.(check bool)
+    "two shapes are not one bucket" false
+    (Css.hash_statement (sole_statement ".a{color:red}")
+    = Css.hash_statement (sole_statement "@media screen{.x{color:red}}"))
+
+(* What a statement holds is read, not just its shape. *)
+let statement_equality_reads_the_payload () =
+  let differs label a b =
+    if Css.equal_statement (sole_statement a) (sole_statement b) then Some label
+    else None
+  in
+  let folded =
+    List.filter_map
+      (fun (label, a, b) -> differs label a b)
+      [
+        ("a selector", ".a{color:red}", ".b{color:red}");
+        ("a declaration", ".a{color:red}", ".a{color:blue}");
+        ( "a media query",
+          "@media screen{.x{color:red}}",
+          "@media print{.x{color:red}}" );
+        ( "a media block",
+          "@media screen{.x{color:red}}",
+          "@media screen{.x{color:blue}}" );
+        ( "a supports condition",
+          "@supports (display:grid){.x{color:red}}",
+          "@supports (display:flex){.x{color:red}}" );
+        ( "a container name",
+          "@container a (min-width:10px){.x{color:red}}",
+          "@container b (min-width:10px){.x{color:red}}" );
+        ( "a container condition",
+          "@container a (min-width:10px){.x{color:red}}",
+          "@container a (min-width:20px){.x{color:red}}" );
+        ("a layer name", "@layer a{.x{color:red}}", "@layer b{.x{color:red}}");
+        ( "a nested rule",
+          ".a{color:red;&:hover{color:blue}}",
+          ".a{color:red;&:focus{color:blue}}" );
+        ( "an import condition",
+          "@import url(a.css) supports(display:grid);",
+          "@import url(a.css) supports(display:flex);" );
+        ( "a @property name",
+          "@property --x{syntax:\"*\";inherits:false}",
+          "@property --y{syntax:\"*\";inherits:false}" );
+        (* A registration whose syntax is not [*] has to declare an initial
+           value, so the pair below holds one fixed and moves the syntax. *)
+        ( "a @property syntax",
+          "@property --x{syntax:\"<length>\";inherits:false;initial-value:0px}",
+          "@property \
+           --x{syntax:\"<length-percentage>\";inherits:false;initial-value:0px}"
+        );
+        ( "a @property initial value",
+          "@property --x{syntax:\"<length>\";inherits:false;initial-value:0px}",
+          "@property --x{syntax:\"<length>\";inherits:false;initial-value:1px}"
+        );
+        ( "a scope end selector",
+          "@scope (.a) to (.b){.x{color:red}}",
+          "@scope (.a) to (.c){.x{color:red}}" );
+      ]
+  in
+  Alcotest.(check (list string)) "each pair stays two statements" [] folded
+
+(* The pipeline [cascade --minify] runs: the optimiser over a parsed sheet, then
+   the minified printer. *)
+let optimized_statement css =
+  match Css.statements (Css.optimize (Css.of_string_exn css)) with
+  | [ s ] -> s
+  | l -> Alcotest.failf "%s: expected one statement, got %d" css (List.length l)
+
+let minified_statement s = Css.to_string ~minify:true (Css.v [ s ])
+
+(* The rule [Declaration.hash] already holds, one level up: a statement that
+   minifies to the text another statement minifies to has to hash the same, or a
+   table keyed on the fingerprint files one CSS statement under two keys. As
+   there, the rule is stated over the canonicalised sheet, and equality is the
+   finer relation, true for every pair below as well. *)
+let same_text_same_hash label a b =
+  let text = minified_statement a in
+  Alcotest.(check string)
+    (label ^ ": one minified text")
+    text (minified_statement b);
+  Alcotest.(check int)
+    (label ^ ": one hash") (Css.hash_statement a) (Css.hash_statement b);
+  Alcotest.(check bool)
+    (label ^ ": one statement")
+    true (Css.equal_statement a b)
+
+let statement_hash_follows_the_minified_text () =
+  let pair label a b =
+    same_text_same_hash label (optimized_statement a) (optimized_statement b)
+  in
+  (* Optional whitespace the printer drops. *)
+  pair "declaration spacing" ".a{color : red}" ".a{color:red}";
+  pair "selector spacing" ".a > .b{color:red}" ".a>.b{color:red}";
+  pair "media spacing" "@media screen and (min-width: 10px){.a{color:red}}"
+    "@media screen and (min-width:10px){.a{color:red}}";
+  pair "layer spacing" "@layer a {.x{color:red}}" "@layer a{.x{color:red}}";
+  pair "keyframe spacing" "@keyframes k{from{opacity: 0}}"
+    "@keyframes k{from{opacity:0}}";
+  (* A zero length keeps no unit under minify. *)
+  pair "zero length" ".a{margin:0px}" ".a{margin:0}";
+  (* CSS Color 4 sec. 6.1 gives [red] the sRGB bytes 255, 0, 0, so the three
+     spellings below are one colour and canonicalise to one node. *)
+  pair "a named colour" ".a{color:red}" ".a{color:#f00}";
+  pair "the sRGB function" ".a{color:red}" ".a{color:rgb(255 0 0)}";
+  (* An [\@supports] condition keeps the token stream the author wrote, and the
+     optimiser canonicalises the whitespace in it, so this pair reaches one
+     node. *)
+  pair "supports condition spacing"
+    "@supports(color:rgba(0, 0, 0, .5)){.b{color:red}}"
+    "@supports(color:rgba(0,0,0,.5)){.b{color:red}}"
+
+(* A fingerprint that stopped at the statement's shape would satisfy the rule
+   above and file every rule of a kind under one key. *)
+let statement_hash_reads_the_descriptors () =
+  let differs label a b =
+    if
+      Css.hash_statement (sole_statement a)
+      = Css.hash_statement (sole_statement b)
+    then Some label
+    else None
+  in
+  let colliding =
+    List.filter_map
+      (fun (label, a, b) -> differs label a b)
+      [
+        ( "@font-face descriptors",
+          "@font-face{font-family:A;src:url(a.woff2)}",
+          "@font-face{font-family:B;src:url(b.woff2)}" );
+        ( "@counter-style descriptors",
+          "@counter-style c{system:cyclic;symbols:\"a\"}",
+          "@counter-style c{system:cyclic;symbols:\"b\"}" );
+        ( "@view-transition descriptors",
+          "@view-transition{navigation:auto}",
+          "@view-transition{navigation:none}" );
+        ( "a keyframe selector",
+          "@keyframes k{from{opacity:0}}",
+          "@keyframes k{to{opacity:0}}" );
+        ( "a @property syntax",
+          "@property --x{syntax:\"<length>\";inherits:false;initial-value:0px}",
+          "@property \
+           --x{syntax:\"<length-percentage>\";inherits:false;initial-value:0px}"
+        );
+        ( "a @-moz-document condition",
+          "@-moz-document domain(\"a.test\"){.x{color:red}}",
+          "@-moz-document domain(\"b.test\"){.x{color:red}}" );
+      ]
+  in
+  Alcotest.(check (list string)) "each pair keys apart" [] colliding
+
+(* CSS Conditional 3 sec. 6 answers a declaration feature by handing that exact
+   declaration to the browser's own parser, so the value spelled in the
+   condition is the question. [calc(10px)] and [10.0px] name grammars a browser
+   can accept one of and refuse the other: two guards, not one, and the
+   optimiser keeps both spellings. *)
+let supports_spelling_stays_two_statements () =
+  let calc = optimized_statement "@supports(width:calc(10px)){.b{color:red}}" in
+  let plain = optimized_statement "@supports(width:10.0px){.b{color:red}}" in
+  Alcotest.(check bool)
+    "two texts" false
+    (String.equal (minified_statement calc) (minified_statement plain));
+  Alcotest.(check bool) "two statements" false (Css.equal_statement calc plain);
+  (* The control: the same guard over the same block is one statement, so the
+     verdict above is about the value and not about the parse. *)
+  let calc' =
+    optimized_statement "@supports(width:calc(10px)){.b{color:red}}"
+  in
+  Alcotest.(check bool)
+    "the same guard is one statement" true
+    (Css.equal_statement calc calc')
+
+let equality_tests =
+  [
+    ( "equal_statement separates every shape",
+      `Quick,
+      statement_equality_separates_every_shape );
+    ( "hash_statement agrees with equal_statement",
+      `Quick,
+      statement_hash_agrees_with_equality );
+    ( "equal_statement reads the payload",
+      `Quick,
+      statement_equality_reads_the_payload );
+    ( "hash_statement follows the minified text",
+      `Quick,
+      statement_hash_follows_the_minified_text );
+    ( "hash_statement reads the descriptors",
+      `Quick,
+      statement_hash_reads_the_descriptors );
+    ( "an @supports spelling stays two statements",
+      `Quick,
+      supports_spelling_stays_two_statements );
+  ]
+
 let suite =
   ( "stylesheet",
     stylesheet_tests @ additional_tests @ walker_tests @ deep_walker_tests
-    @ render_tests )
+    @ render_tests @ equality_tests )

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -777,6 +777,117 @@ let test_gamut_map_color () =
      authored colour. *)
   check_color ~expected:"oklch(.7 .35 150)" "oklch(0.7 0.35 150)"
 
+(* CSS Color 4 sec. 4.1 gives [<alpha-value>] a slot in every functional colour
+   notation and in none of the others: a hex spells its alpha as a fourth pair
+   of digits, so it cannot hold [calc()] or a percentage, and a named colour has
+   no channel at all. Setting an alpha on one of those therefore has to re-spell
+   the colour in the sRGB notation that does carry the slot, keeping the
+   channels the author wrote. The sRGB bytes are the ones the spec's named
+   colour table gives, so [red] is [rgb(255 0 0 / .5)]. *)
+(* Not a roundtrip test *)
+let test_with_alpha () =
+  let open Css.Values in
+  let parse s =
+    match Css.parse_color s with
+    | Some c -> c
+    | None -> Alcotest.failf "failed to parse: %s" s
+  in
+  let check name a b = Alcotest.(check bool) name true (equal_color a b) in
+  check "a hex keeps its channels and gains the slot"
+    (with_alpha (hex "#3b82f6") (Num 0.5))
+    (rgb ~alpha:0.5 59 130 246);
+  check "an authored hex spelling reads the same channels"
+    (with_alpha (parse "#3B82F6") (Num 0.5))
+    (rgb ~alpha:0.5 59 130 246);
+  check "a named colour resolves to its sRGB channels"
+    (with_alpha (color_name Red) (Num 0.5))
+    (rgb ~alpha:0.5 255 0 0);
+  check "transparent is rgb(0 0 0) with an alpha of its own"
+    (with_alpha transparent (Num 0.5))
+    (rgb ~alpha:0.5 0 0 0);
+  check "an rgb() without an alpha gains one"
+    (with_alpha (rgb 59 130 246) (Num 0.5))
+    (rgb ~alpha:0.5 59 130 246);
+  (* A notation that already carries the slot keeps its own channels and
+     notation: only the alpha moves. *)
+  check "an alpha already written is replaced"
+    (with_alpha (rgb ~alpha:0.2 59 130 246) (Num 0.5))
+    (rgb ~alpha:0.5 59 130 246);
+  check "an oklch() alpha is replaced in place"
+    (with_alpha (parse "oklch(.5 .1 200/.2)") (Num 0.5))
+    (parse "oklch(.5 .1 200/.5)");
+  check "an oklch() without an alpha gains one"
+    (with_alpha (parse "oklch(.5 .1 200)") (Num 0.5))
+    (parse "oklch(.5 .1 200/.5)");
+  (* [light-dark()] resolves to exactly one of its two arguments, so the colour
+     with an alpha is the one whose arguments both carry it. *)
+  check "light-dark() carries the alpha into both arguments"
+    (with_alpha (Light_dark (hex "#3b82f6", hex "#000000")) (Num 0.5))
+    (Light_dark (rgb ~alpha:0.5 59 130 246, rgb ~alpha:0.5 0 0 0));
+  (* A colour whose channels are only known at used-value time has no channel to
+     write, the same answer {!gamut_map_color} gives for one. *)
+  check "a var() colour is left alone"
+    (with_alpha (parse "var(--brand)") (Num 0.5))
+    (parse "var(--brand)");
+  check "currentcolor is left alone"
+    (with_alpha current_color (Num 0.5))
+    current_color
+
+(* The rule [Declaration.hash] holds, one type down: a value that minifies to the
+   text another value minifies to has to hash the same, or a table keyed on the
+   fingerprint files one colour under two keys. As there, the rule is stated over
+   the canonicalised node - [normalize_color] is the pass that gets a colour
+   there - and equality is the finer relation, true for every pair below too.
+
+   CSS Color 4 sec. 6.1 gives [red] the sRGB bytes 255, 0, 0, and sec. 4.1 says
+   the functional notations name a colour by those same channels: [red],
+   [#f00], [#ff0000] and [rgb(255 0 0)] are four spellings of one colour, so
+   they are one node once canonicalised. *)
+(* Not a roundtrip test *)
+let test_hash_color () =
+  let open Css.Values in
+  let parse s =
+    match Css.parse_color s with
+    | Some c -> normalize_color c
+    | None -> Alcotest.failf "failed to parse: %s" s
+  in
+  let text c = Css.Pp.to_string ~minify:true pp_color c in
+  let same_text_same_hash label a b =
+    Alcotest.(check string) (label ^ ": one minified text") (text a) (text b);
+    Alcotest.(check int) (label ^ ": one hash") (hash_color a) (hash_color b);
+    Alcotest.(check bool) (label ^ ": one colour") true (equal_color a b)
+  in
+  let red = parse "red" in
+  same_text_same_hash "the three-digit hex" red (parse "#f00");
+  same_text_same_hash "the six-digit hex" red (parse "#ff0000");
+  same_text_same_hash "the sRGB function" red (parse "rgb(255 0 0)");
+  same_text_same_hash "the legacy comma form" red (parse "rgba(255, 0, 0, 1)");
+  (* Equal colours hash alike, whatever else they hold. *)
+  let equal_pairs =
+    [
+      (hex "#3b82f6", hex "#3b82f6");
+      (rgb ~alpha:0.5 1 2 3, rgb ~alpha:0.5 1 2 3);
+      (parse "oklch(.5 .1 200/.2)", parse "oklch(.5 .1 200/.2)");
+      (color_name Red, color_name Red);
+      ( parse "color-mix(in oklab, red, blue)",
+        parse "color-mix(in oklab, red, blue)" );
+      (current_color, current_color);
+    ]
+  in
+  let disagreeing =
+    List.filter_map
+      (fun (a, b) ->
+        if equal_color a b && hash_color a <> hash_color b then Some (text a)
+        else None)
+      equal_pairs
+  in
+  Alcotest.(check (list string)) "equal colours hash alike" [] disagreeing;
+  (* A hash that answered the same for every colour would satisfy the rules
+     above and be useless, so pin that it separates the colours it can. *)
+  Alcotest.(check bool)
+    "two colours are not one bucket" false
+    (hash_color (hex "#3b82f6") = hash_color (hex "#f63b82"))
+
 (* Not a roundtrip test *)
 let test_color_mix_printing () =
   let open Css.Values in
@@ -1518,6 +1629,8 @@ let value_tests =
     test_case "oklch none hue" `Quick test_color_oklch_none_hue;
     test_case "gamut map colour into sRGB" `Quick test_gamut_map_color;
     test_case "color-mix printing" `Quick test_color_mix_printing;
+    test_case "with_alpha" `Quick test_with_alpha;
+    test_case "hash_color" `Quick test_hash_color;
     test_case "var in calc other types" `Quick test_var_in_calc_types;
     test_case "number var printing" `Quick test_number_var_printing;
     test_case "var() with empty fallback" `Quick test_var_empty_fallback;


### PR DESCRIPTION
A caller holding two statements can now ask whether they are the same and key one in a hash table, instead of comparing rendered CSS text. `Css.Values.with_alpha` sets a colour's alpha in one step, where re-spelling the printed colour by hand loses the alpha a hex already carried.
