### PR TITLE
selector: scope the :not() state folds to a proved carrier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -402,6 +402,16 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` keeps `.c:not(:enabled)` instead of rewriting it to
+  `.c:disabled`. An element outside a state pseudo-class pair's own set matches
+  neither half of it (CSS Selectors 4 sec. 12.1.1, 12.3.1, 12.3.3), so
+  `<p class=c>` matched the rule before the rewrite and not after. The rewrite
+  now needs a compound that proves its subject carries the state, and the three
+  pairs reach three different sets: an `input` proves `:enabled`/`:disabled`
+  alone, since a disabled or `type=hidden` one is barred from constraint
+  validation and the `required` attribute does not apply to every input type.
+  Which elements carry a state is a host-document fact, so `--enforce-spec`
+  keeps `input:not(:enabled)` as well (#596)
 - `--minify --enforce-spec` keeps the author's `:not(:dir(ltr))` instead of
   shortening it to `:dir(rtl)`. CSS Selectors 4 sec. 7.1 leaves directionality
   to the document language, so only a host document like HTML makes `ltr` and

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cat style.css | cascade -                                          # read stdin
 | `-m, --minify` | Minify the output. Local linear rewrites always run; the expensive global factoring fixpoint runs only when its preflight predicts useful savings. The top-level pipeline re-runs until the AST stops changing (capped at 5 iterations), so the output is a fixed point: rule-order canonicalisation can expose a merge a single pass would miss. |
 | `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win and drives the factoring fixpoint to convergence, the right objective when the output ships uncompressed (inline style attributes, email HTML), at roughly 10-30x the wall clock. Has no effect without `--minify`. |
 | `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Also sorts each rule's declarations into a canonical cross-rule order (keeping cascade-significant pairs in place) so gzip back-references line up. Has no effect without `--minify`. |
-| `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest form the CSS text and the specs prove on their own, so it keeps every vendor-prefixed declaration, the `min-`/`max-` spelling of a media or container feature, the `&` prefix on a nested selector, and the author's `:not(:dir(ltr))`. Has no effect without `--minify`. |
+| `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest form the CSS text and the specs prove on their own, so it keeps every vendor-prefixed declaration, the `min-`/`max-` spelling of a media or container feature, the `&` prefix on a nested selector, and the author's `:not(:dir(ltr))` and `input:not(:enabled)`. Has no effect without `--minify`. |
 | `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
 | `--flatten-nesting` | Desugar nested rules into flat top-level rules for browsers that pre-date CSS Nesting. By default cascade preserves nesting since modern browsers parse it natively and it is usually shorter. |
 | `--inline-imports` | Resolve `@import` against files relative to the input. Closed-world: assumes you control file resolution. |
@@ -301,19 +301,26 @@ write the optimiser can't see.
 ### Target browsers
 
 The default minify targets maintained evergreen browsers rendering an HTML
-document, and takes four facts from that target. The HTML direction model,
+document, and takes five facts from that target. The HTML direction model,
 where every element is either `ltr` or `rtl`, shortens `:not(:dir(ltr))` to
-`:dir(rtl)`. A vendor-prefixed declaration (`-moz-box-sizing`) whose unprefixed
-twin is present is dropped, since evergreen browsers understand the unprefixed
-form. A `min-`/`max-` media or container feature becomes the Media Queries 4
-range grammar, `(min-width: 700px)` to `(width >= 700px)`. A nested selector
-loses its `&` prefix, `& div` to `div`, which the relaxed nesting syntax reads
-the same way.
+`:dir(rtl)`. The HTML form-control model, which says an `input` is either
+`:enabled` or `:disabled`, shortens `input:not(:enabled)` to `input:disabled`.
+A vendor-prefixed declaration (`-moz-box-sizing`) whose unprefixed twin is
+present is dropped, since evergreen browsers understand the unprefixed form. A
+`min-`/`max-` media or container feature becomes the Media Queries 4 range
+grammar, `(min-width: 700px)` to `(width >= 700px)`. A nested selector loses
+its `&` prefix, `& div` to `div`, which the relaxed nesting syntax reads the
+same way.
+
+Each of those state pseudo-class pairs partitions a different set of elements,
+and outside its own set an element matches neither half, so the rewrite runs
+only where the compound proves its subject is in the set. `.c:not(:enabled)`
+and `input:not(:required)` both stay as the author wrote them.
 
 `--enforce-spec` drops those facts. Cascade still serialises to the shortest
-CSS form it knows, but the direction model is not assumed, every vendor prefix
-is kept, a media or container feature keeps the `min-`/`max-` spelling the
-author wrote, and a nested selector keeps its `&`.
+CSS form it knows, but neither the direction nor the form-control model is
+assumed, every vendor prefix is kept, a media or container feature keeps the
+`min-`/`max-` spelling the author wrote, and a nested selector keeps its `&`.
 
 An `@supports` condition is not a target fact. CSS Conditional Rules 3 section
 6.1 defines support as the rendering browser accepting the declaration, down to

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2278,6 +2278,63 @@ let rec carries_type_selector = function
   | Compound parts -> List.exists carries_type_selector parts
   | _ -> false
 
+(* Which elements [HTML] gives each state pseudo-class pair to. The three sets
+   differ. [:enabled] and [:disabled] split every form control plus [optgroup],
+   [option] and [fieldset] (HTML sec. 4.15, sec. 4.16.3). [:valid] and
+   [:invalid] split a [form] and a [fieldset] whole, but reach a form control
+   only while it is a candidate for constraint validation, which a disabled,
+   readonly or [type=hidden] one is not. [:required] and [:optional] split
+   [select] and [textarea]; [:optional] wants an [input] "to which the required
+   attribute applies", and it does not apply in e.g. the Hidden state. *)
+let enabled_carriers =
+  [ "button"; "fieldset"; "input"; "optgroup"; "option"; "select"; "textarea" ]
+
+let validity_carriers = [ "fieldset"; "form" ]
+let optionality_carriers = [ "select"; "textarea" ]
+
+let state_pair = function
+  | Enabled -> Some (Disabled, enabled_carriers)
+  | Disabled -> Some (Enabled, enabled_carriers)
+  | Valid -> Some (Invalid, validity_carriers)
+  | Invalid -> Some (Valid, validity_carriers)
+  | Required -> Some (Optional, optionality_carriers)
+  | Optional -> Some (Required, optionality_carriers)
+  | _ -> None
+
+(* Whether every element [sel] can select is one of [carriers]. A type selector
+   proves it, and [:is()]/[:where()] prove it when every branch does; a class,
+   an attribute, a negation or [:has()] constrains something other than the
+   subject's element type, so it proves nothing. Selectors 4 sec. 3.5: the
+   subject of a complex selector is its rightmost compound. A namespaced type
+   selector is left out: the prefix binds to a namespace declared elsewhere in
+   the stylesheet, and these names are the HTML ones. *)
+let rec selects_only carriers = function
+  | Element (None, name) -> List.mem (String.lowercase_ascii name) carriers
+  | Compound parts -> List.exists (selects_only carriers) parts
+  | Is branches | Where branches ->
+      branches <> [] && List.for_all (selects_only carriers) branches
+  | Combined (_, _, right) -> selects_only carriers right
+  | _ -> false
+
+(* CSS Selectors 4 sec. 12.1.1, 12.3.1 and 12.3.3: an element outside a pair's
+   set matches neither half, so [X:not(:enabled)] is [X:disabled] only inside a
+   compound that proves its subject carries the state. Which elements those are
+   is a [HTML] fact rather than one the CSS text proves, hence the
+   [enforce_spec] gate. *)
+let fold_state_negations ctx components =
+  if (not (Pp.minified ctx)) || ctx.Pp.enforce_spec then components
+  else
+    List.map
+      (function
+        | Not [ state ] as component -> (
+            match state_pair state with
+            | Some (complement, carriers)
+              when List.exists (selects_only carriers) components ->
+                complement
+            | _ -> component)
+        | component -> component)
+      components
+
 let rec pp_nth_func ctx name expr of_sel =
   Pp.char ctx ':';
   Pp.string ctx name;
@@ -2305,7 +2362,10 @@ and pp_nested_function_lists ctx = function
   | Is selectors -> func ctx "is" spaced_sels_nested_function_lists selectors
   | Where selectors ->
       func ctx "where" spaced_sels_nested_function_lists selectors
-  | Compound selectors -> List.iter (pp_nested_function_lists ctx) selectors
+  | Compound selectors ->
+      List.iter
+        (pp_nested_function_lists ctx)
+        (fold_state_negations ctx selectors)
   | Combined (left, comb, right) ->
       pp_nested_function_lists ctx left;
       pp_combinator ctx comb;
@@ -2488,12 +2548,6 @@ and pp : t Pp.t =
          whatever compound holds the [:not()], so a type-bearing one stays
          wrapped (Selectors 4 3.5, [carries_type_selector]). *)
       pp ctx inner
-  | Not [ Enabled ] when Pp.minified ctx -> pseudo ctx "disabled"
-  | Not [ Disabled ] when Pp.minified ctx -> pseudo ctx "enabled"
-  | Not [ Valid ] when Pp.minified ctx -> pseudo ctx "invalid"
-  | Not [ Invalid ] when Pp.minified ctx -> pseudo ctx "valid"
-  | Not [ Required ] when Pp.minified ctx -> pseudo ctx "optional"
-  | Not [ Optional ] when Pp.minified ctx -> pseudo ctx "required"
   | Not [ Dir "ltr" ] when Pp.minified ctx && not ctx.Pp.enforce_spec ->
       (* CSS Selectors 4 sec. 7.1 leaves directionality to the document
          language, so CSS alone does not make [ltr] and [rtl] a partition: an
@@ -2555,7 +2609,8 @@ and pp : t Pp.t =
             (if Pp.minified ctx then Parser.to_string_minified args
              else Parser.string_of_components args))
         args
-  | Compound selectors -> List.iter (pp ctx) selectors
+  | Compound selectors ->
+      List.iter (pp ctx) (fold_state_negations ctx selectors)
   | Combined (left, comb, right) ->
       pp ctx left;
       pp_combinator ctx comb;

--- a/test/cli/not_state_fold.t
+++ b/test/cli/not_state_fold.t
@@ -1,0 +1,39 @@
+CLI: --minify keeps :not() over a state pseudo-class it cannot scope.
+
+CSS Selectors 4 sec. 12.1.1 says "In a typical document most elements will be
+neither :enabled nor :disabled", so `<p class=c>` matches `.c:not(:enabled)`
+and does not match `.c:disabled`. Rewriting one to the other drops the rule on
+every element that carries no enabled state.
+
+  $ cat > class.css <<EOF
+  > .c:not(:enabled) { color: red }
+  > EOF
+  $ cascade fmt --minify class.css
+  .c:not(:enabled){color:red}
+
+A type selector that names an element HTML gives the state to does scope it.
+HTML sec. 4.16.3 makes every `input` either `:enabled` or `:disabled`.
+
+  $ cat > input.css <<EOF
+  > input:not(:enabled) { color: red }
+  > EOF
+  $ cascade fmt --minify input.css
+  input:disabled{color:red}
+
+Validity and optionality reach a narrower set. An `input` is `:valid` or
+`:invalid` only while it is a candidate for constraint validation, which a
+disabled one is not, and `:optional` wants an `input` "to which the required
+attribute applies", which `type=hidden` is not.
+
+  $ cat > narrow.css <<EOF
+  > input:not(:invalid) { color: red }
+  > input:not(:required) { padding: 0 }
+  > EOF
+  $ cascade fmt --minify narrow.css
+  input:not(:invalid){color:red}input:not(:required){padding:0}
+
+Selectors 4 sec. 12.1.1 leaves the enabled and disabled states to the host
+language, so it is HTML, not the CSS text, that puts `input` on the list.
+
+  $ cascade fmt --minify --enforce-spec input.css
+  input:not(:enabled){color:red}

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -319,11 +319,30 @@ let normalize_expected ~category ~id expected =
          pseudo-class changes selector specificity from (0,1,1) to (0,0,1). *)
       fixture ~category ~id ~upstream:"a{color:red}"
         ~cascade:"a:nth-child(n){color:red}" upstream
+  | "selectors-advanced", "0005" ->
+      (* [input:not(:invalid)] is not [input:valid]: HTML sec. 4.16.3 gives
+         [:valid] and [:invalid] to a form control only while it is a candidate
+         for constraint validation, and a disabled, readonly or [type=hidden]
+         input is barred from that, so it matches neither. *)
+      fixture ~category ~id ~upstream:"input:valid{color:red}"
+        ~cascade:"input:not(:invalid){color:red}" upstream
+  | "selectors-advanced", "0009" ->
+      (* [input:not(:required)] is not [input:optional]: HTML sec. 4.16.3 gives
+         [:optional] to an input "to which the required attribute applies", and
+         it applies to neither [type=hidden] nor [type=submit], so such an input
+         is neither [:required] nor [:optional]. *)
+      fixture ~category ~id ~upstream:"input:optional{color:red}"
+        ~cascade:"input:not(:required){color:red}" upstream
   | "selectors-advanced", "0010" ->
       (* [a:not(:link)] is not equivalent to [a:visited]: anchors without [href]
          are neither [:link] nor [:visited]. *)
       fixture ~category ~id ~upstream:"a:visited{color:red}"
         ~cascade:"a:not(:link){color:red}" upstream
+  | "selectors-advanced", "0012" ->
+      (* [:is()] proves the optionality pair only when every branch does, and
+         the [input] branch does not, for the reason recorded on 0009. *)
+      fixture ~category ~id ~upstream:":is(input,textarea):optional{color:red}"
+        ~cascade:":is(input,textarea):not(:required){color:red}" upstream
   | "selectors-advanced", "0013" ->
       (* [:heading] is an experimental Selectors 5 pseudo-class with limited
          browser availability. It is also not a drop-in replacement here:

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -2222,6 +2222,85 @@ let spec_selector_dir_argument_is_an_ident () =
   neg_cursor read ":dir(\"ltr\")";
   neg_cursor read ":dir(ltr, rtl)"
 
+(* CSS Selectors 4 sec. 12 makes each of these pseudo-class pairs a partition of
+   one set of elements only, and an element outside that set matches neither
+   half: sec. 12.1.1 "In a typical document most elements will be neither
+   :enabled nor :disabled", sec. 12.3.1 "An element which lacks data validity
+   semantics is neither :valid nor :invalid [...] a p element has no validity
+   semantics at all", sec. 12.3.3 "Elements that are not form elements are
+   neither required nor optional". So [:not()] over one half of a pair is the
+   other half only inside a compound that proves its subject carries that state,
+   and [HTML] names a different set of elements for each pair. *)
+let spec_selector_state_folds_need_a_carrier () =
+  (* A class names no element type, so [<p class=c>] matches [.c:not(:enabled)]
+     and none of the six positive halves. *)
+  check_minified_to ".c:not(:enabled)" ".c:not(:enabled)";
+  check_minified_to ".c:not(:disabled)" ".c:not(:disabled)";
+  check_minified_to ".c:not(:valid)" ".c:not(:valid)";
+  check_minified_to ".c:not(:invalid)" ".c:not(:invalid)";
+  check_minified_to ".c:not(:required)" ".c:not(:required)";
+  check_minified_to ".c:not(:optional)" ".c:not(:optional)";
+  (* Nothing at all around the negation proves even less. *)
+  check_minified_to ":not(:enabled)" ":not(:enabled)";
+  (* An attribute selector names no element type either: [type] is a plain
+     attribute on any element. *)
+  check_minified_to "[type=text]:not(:required)" "[type=text]:not(:required)";
+  (* HTML sec. 4.16.3: [:enabled] matches a non-disabled [button], [input],
+     [select], [textarea], [optgroup], [option] or [fieldset], and [:disabled]
+     matches an actually disabled one (sec. 4.15). [a] is on neither list. *)
+  check_minified_to "a:not(:enabled)" "a:not(:enabled)";
+  check_minified_to "input:disabled" "input:not(:enabled)";
+  check_minified_to "input:enabled" "input:not(:disabled)";
+  check_minified_to "option:enabled" "option:not(:disabled)";
+  check_minified_to "fieldset:disabled" "fieldset:not(:enabled)";
+  (* HTML sec. 4.16.3: [:valid] and [:invalid] split a [form] and a [fieldset]
+     whole, but reach a form control only while it is a candidate for constraint
+     validation. A disabled, readonly or [type=hidden] [input] is barred from it
+     (HTML sec. 4.10.19.5, sec. 4.10.5.3.3, sec. 4.10.5.1.1), so it matches
+     neither half. *)
+  check_minified_to "input:not(:invalid)" "input:not(:invalid)";
+  check_minified_to "input:not(:valid)" "input:not(:valid)";
+  check_minified_to "button:not(:valid)" "button:not(:valid)";
+  check_minified_to "form:invalid" "form:not(:valid)";
+  check_minified_to "fieldset:valid" "fieldset:not(:invalid)";
+  (* HTML sec. 4.16.3: [:optional] wants an [input] "to which the required
+     attribute applies". It does not apply in the Hidden or Submit Button state
+     (HTML sec. 4.10.5.1.1), so [<input type=hidden>] matches neither
+     [:required] nor [:optional], while every [select] and [textarea] carries
+     one or the other. *)
+  check_minified_to "input:not(:required)" "input:not(:required)";
+  check_minified_to "input:not(:optional)" "input:not(:optional)";
+  check_minified_to "select:optional" "select:not(:required)";
+  check_minified_to "textarea:required" "textarea:not(:optional)";
+  (* The three sets are distinct: an [input] proves the enabled pair and neither
+     of the other two. *)
+  check_minified_to "input:enabled:not(:required)"
+    "input:not(:disabled):not(:required)";
+  (* Selectors 4 sec. 3.5: the subject of a complex selector is its rightmost
+     compound, so an ancestor part neither proves nor blocks the fold. *)
+  check_minified_to "form input:disabled" "form input:not(:enabled)";
+  check_minified_to "form .c:not(:enabled)" "form .c:not(:enabled)";
+  check_minified_to "input.c:disabled" "input.c:not(:enabled)";
+  (* Selectors 4 sec. 4.2: [:is()] matches any element one of its branches
+     matches, so it proves the state only when every branch does. [:where()]
+     matches the same elements. *)
+  check_minified_to ":is(select,textarea):optional"
+    ":is(select,textarea):not(:required)";
+  check_minified_to ":is(input,textarea):not(:required)"
+    ":is(input,textarea):not(:required)";
+  check_minified_to ":is(input,.c):not(:enabled)" ":is(input,.c):not(:enabled)";
+  check_minified_to ":where(input):disabled" ":where(input):not(:enabled)";
+  (* Selectors 4 sec. 5: [:has()] constrains the subject's descendants, not its
+     element type. *)
+  check_minified_to ":has(input):not(:enabled)" ":has(input):not(:enabled)";
+  (* Selectors 4 sec. 12.1.1 leaves what counts as an enabled state, a disabled
+     state and a user interface element to the host language, so it is [HTML],
+     not the CSS text, that puts [input] on the list. [--enforce-spec] drops
+     that host fact. *)
+  check_enforce_spec_to "input:not(:enabled)" "input:not(:enabled)";
+  check_enforce_spec_to "select:not(:required)" "select:not(:required)";
+  check_enforce_spec_to "form:not(:valid)" "form:not(:valid)"
+
 (* ignore-test *)
 let test_spec_forgiving_selector_lists () =
   (* Selectors Level 4: :is() and :where() use forgiving selector-list parsing.
@@ -2729,6 +2808,9 @@ let suite =
         spec_selector_dir_fold_is_a_host_fact;
       test_case "spec selector :dir() argument is an ident" `Quick
         spec_selector_dir_argument_is_an_ident;
+
+      test_case "spec selector state folds need a carrier" `Quick
+        spec_selector_state_folds_need_a_carrier;
       test_case "spec forgiving selector lists" `Quick
         test_spec_forgiving_selector_lists;
       test_case "spec selector current pseudo vectors" `Quick

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -2808,7 +2808,6 @@ let suite =
         spec_selector_dir_fold_is_a_host_fact;
       test_case "spec selector :dir() argument is an ident" `Quick
         spec_selector_dir_argument_is_an_ident;
-
       test_case "spec selector state folds need a carrier" `Quick
         spec_selector_state_folds_need_a_carrier;
       test_case "spec forgiving selector lists" `Quick


### PR DESCRIPTION
`.c:not(:enabled)` minified to `.c:disabled`, so a rule written for anything not enabled stopped applying to `<p class=c>`: CSS Selectors 4 sec. 12.1.1 says most elements are neither, and sec. 12.3.1 and 12.3.3 say the same of validity and optionality. The rewrite now needs a compound that proves its subject carries the state, and each pair has its own element list, since an `input` proves `:enabled`/`:disabled` alone: a disabled or `type=hidden` one is barred from constraint validation, and the `required` attribute does not apply to every input type.

Three `css-minify-tests` fixtures asserted the unscoped rewrite and now carry a Cascade override each. Keeping the author's selector costs 371 bytes over the 504-file SatCSS corpus.
