### PR TITLE
values: fold an authored hex to its canonical node

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -402,6 +402,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` merges rules whose colours differ only in how a hex was
+  spelled. The digits are case-insensitive and `#RGB` expands by duplicating
+  each of them (CSS Color 4 sec. 5.2), but the authored spelling survived
+  optimisation, so `#FFF`, `#fff` and `#ffffff` reached the merge pass as
+  three declarations and stayed three rules (#597)
 - `--minify` keeps `.c:not(:enabled)` instead of rewriting it to
   `.c:disabled`. An element outside a state pseudo-class pair's own set matches
   neither half of it (CSS Selectors 4 sec. 12.1.1, 12.3.1, 12.3.3), so

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7480,12 +7480,10 @@ let normalize_static_modern_color ~exact_srgb ~lossless c =
         | None -> drop_full_alpha c)
     | None -> drop_full_alpha c
 
+(* [canonical_color_of_hex] answers a name or the same bytes back, so a [Hex]
+   that reaches its own canonical form is shared rather than rebuilt. *)
 let normalize_hex_color c r g b a =
-  match canonical_color_of_hex r g b a with
-  | Hex { r = r'; g = g'; b = b'; a = a' }
-    when r' = r && g' = g && b' = b && a' = a ->
-      c
-  | color -> color
+  match canonical_color_of_hex r g b a with Hex _ -> c | color -> color
 
 let normalize_named_color c orig_name =
   (* Pick the shortest spelling: a named colour collapses to hex only when the
@@ -7566,8 +7564,11 @@ let rec normalize_color ?(lossless = false) ?(exact_srgb = false) (c : color) :
   | Lch { l = Some _; c = Some _; _ } -> static_fold ()
   | Lab { l = Some _; a = Some _; b = Some _; _ } -> static_fold ()
   | Color _ -> normalize_static_modern_color ~exact_srgb ~lossless c
-  | Hex { r; g; b; a } | Authored_hex { r; g; b; a; _ } ->
-      normalize_hex_color c r g b a
+  | Hex { r; g; b; a } -> normalize_hex_color c r g b a
+  (* The authored spelling is a pretty-printing detail the printer reads, not
+     part of the colour, so the fold drops it: two spellings of one colour have
+     to reach the same node or nothing downstream can see them as one value. *)
+  | Authored_hex { r; g; b; a; _ } -> canonical_color_of_hex r g b a
   | Named orig_name -> normalize_named_color c orig_name
   | Rgb _ | Rgba _ | Hsl _ | Hwb _ | Transparent -> (
       let bytes =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3277,12 +3277,53 @@ let nan_has_one_node () =
     (minified
        ".a{opacity:calc(NaN)}.c{opacity:calc(infinity)}.e{opacity:calc(-infinity)}")
 
+(* CSS Color 4 sec. 5.2 reads the hexadecimal digits ASCII case-insensitively
+   and expands [#RGB] to [#RRGGBB] by duplicating each digit, so [#FFF], [#fff]
+   and [#ffffff] name one colour. The source spelling is a pretty-printing
+   detail, not part of the value: once optimisation has canonicalised it away
+   the three are one declaration, they hash alike, and the rules holding them
+   merge. *)
+let hex_spellings_have_one_node () =
+  let short_upper = sole_declaration ".a{color:#FFF}" in
+  let short_lower = sole_declaration ".b{color:#fff}" in
+  let long = sole_declaration ".c{color:#ffffff}" in
+  Alcotest.(check string)
+    "the fold spells #fff" "color:#fff"
+    (Css.Declaration.to_string ~minify:true short_upper);
+  same_text_same_hash "#FFF vs #fff" short_upper short_lower;
+  same_text_same_hash "#fff vs #ffffff" short_lower long;
+  Alcotest.(check string)
+    "the three spellings merge" ".a,.b,.c{color:#fff}"
+    (minified ".a{color:#FFF}.b{color:#fff}.c{color:#ffffff}");
+  (* A colour with no shorter named form takes the same route. *)
+  let mixed = sole_declaration ".a{color:#AbC}" in
+  let expanded = sole_declaration ".b{color:#aabbcc}" in
+  same_text_same_hash "#AbC vs #aabbcc" mixed expanded;
+  Alcotest.(check string)
+    "a mixed-case spelling merges" ".a,.b{color:#abc}"
+    (minified ".a{color:#AbC}.b{color:#aabbcc}");
+  (* Sec. 5.2 also gives the fourth digit pair as alpha, and sec. 4.2 drops a
+     fully opaque one, so [#FFFF] is the same value again. *)
+  same_text_same_hash "#FFFF vs #fff"
+    (sole_declaration ".a{color:#FFFF}")
+    short_lower;
+  (* The control that already merged: a hex whose colour has a shorter name
+     folds across notations. *)
+  Alcotest.(check string)
+    "hex and name merge" ".a,.b,.c{color:red}"
+    (minified ".a{color:#FF0000}.b{color:#f00}.c{color:red}");
+  (* Different colours stay different values. *)
+  distinct_value "#fff vs #eee" short_lower (sole_declaration ".d{color:#EEE}");
+  distinct_value "#fff vs #fff8" short_lower
+    (sole_declaration ".e{color:#FFF8}")
+
 let declaration_tests =
   [
     (* Core declaration type testing *)
     test_case "declaration" `Quick test_declaration;
     test_case "NaN is one declared value" `Quick nan_declaration_is_one_value;
     test_case "NaN has one node" `Quick nan_has_one_node;
+    test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;
     test_case "parse_declaration" `Quick parse_declaration_case;
     (* Parsing basics *)
     test_case "simple" `Quick simple;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5208,7 +5208,15 @@ let fidelity_hex_form_preserved () =
   pretty_preserves ".x { color: #FF0000 }" [ "#FF0000" ];
   pretty_preserves ".x { color: #ABCDEF }" [ "#ABCDEF" ];
   assert_minify_and_optimize ".x { color: #ff0000 }" ~minified:".x{color:#f00}"
-    ~optimized:".x{color:red}"
+    ~optimized:".x{color:red}";
+  (* Optimisation is the node-changing pass, and CSS Color 4 sec. 5.2 makes the
+     digit case carry no meaning, so the authored spelling does not survive it:
+     pretty output taken after [Css.optimize] carries the canonical colour, the
+     same way [#ff0000] already arrives there as [red]. *)
+  Alcotest.(check string)
+    "optimize drops the authored hex spelling" ".x {\n  color: #abcdef;\n}"
+    (Css.of_string_exn ".x { color: #ABCDEF }"
+    |> Css.optimize |> Css.to_string |> String.trim)
 
 (* CSS Color 4 section 5.1 + cascade convention: under non-minified output, the
    named-color and rgb() forms are preserved as written - no cross-form


### PR DESCRIPTION
`.a{color:#FFF}.b{color:#fff}.c{color:#ffffff}` minified to three rules instead of one. The three spell one colour, but `normalize_color` returned an `Authored_hex` untouched whenever the canonical hex spelled the same bytes, so the source spelling reached the merge pass and `Declaration.hash` answered differently for each. lightningcss emits `.a,.b,.c{color:#fff}`, and cascade now does too.

Pretty output is unaffected: `Css.to_string` still prints the hex as written. Pretty output taken after `Css.optimize` now carries the canonical colour, the way `#ff0000` already arrived there as `red`.