### PR TITLE
values: settle on one minified spelling of currentcolor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -402,6 +402,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` gives the colour keyword `currentcolor` one spelling. CSS Values 4
+  sec. 4.1 reads it case-insensitively, so no authored spelling survives the
+  parse, and a declaration printed `currentColor` where a custom-property
+  stream and a `var()` fallback in the same stylesheet printed `currentcolor`
+  (#599)
 - `--minify` merges rules whose colours differ only in how a hex was
   spelled. The digits are case-insensitive and `#RGB` expands by duplicating
   each of them (CSS Color 4 sec. 5.2), but the authored spelling survived

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -32,8 +32,10 @@ type ctx = {
   out : out;  (** Output sink *)
   inline : bool;  (** Whether to inline variables or not *)
   in_function : bool;
-      (** Whether inside a CSS function (var fallback, color-mix). Affects
-          keyword casing: [currentColor] becomes [currentcolor]. *)
+      (** Whether inside a CSS function (var fallback, color-mix). Unminified
+          output spells the colour keyword [currentcolor] here and
+          [currentColor] elsewhere; minified output spells it [currentcolor]
+          either way. *)
   in_calc : bool;
       (** Inside a [calc()]: suppress canonicalisations that cross a typed leaf
           boundary ([calc] is type-aware so [<percentage>] and [<number>] are

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4691,7 +4691,13 @@ and pp_color_default : color Pp.t =
   | System sc -> pp_system_color ctx sc
   | Var v -> pp_color_var ctx v
   | Current ->
-      Pp.string ctx (if ctx.in_function then "currentcolor" else "currentColor")
+      (* CSS Values 4 sec. 4.1 reads the keyword case-insensitively, so no
+         authored spelling survives the parse and minified output picks the CSS
+         Color 4 sec. 6.4 spelling everywhere: a typed [var()] fallback and a
+         custom-property stream already fold to it. *)
+      Pp.string ctx
+        (if Pp.minified ctx || ctx.in_function then "currentcolor"
+         else "currentColor")
   | Transparent -> pp_transparent_color ctx
   | Auto -> Pp.string ctx "auto"
   | Inherit -> Pp.string ctx "inherit"

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -190,6 +190,15 @@ let normalize_expected ~category ~id expected =
   let upstream = expected in
   let expected = normalize_expected_tokens expected in
   match (category, id) with
+  | "colors", "0025" ->
+      (* CSS Values 4 sec. 4.1 reads a keyword ASCII case-insensitively, so
+         [currentColor] and [currentcolor] are one value and the imported oracle
+         simply records the authored spelling. Cascade parses the keyword to one
+         node with no spelling attached, and minified output emits the CSS Color
+         4 sec. 6.4 spelling on every path, so a declaration and a
+         custom-property stream cannot carry two spellings of it. *)
+      fixture ~category ~id ~upstream:"a{color:currentColor}"
+        ~cascade:"a{color:currentcolor}" upstream
   | "colors", "0029" ->
       (* color-mix(in oklch, red, blue) folds to a static oklch(). cascade keeps
          3 hue decimals (326.643) where the keithamus oracle rounds to 1

--- a/test/spec/test.ml
+++ b/test/spec/test.ml
@@ -502,8 +502,10 @@ let color_keywords () =
   (* Per CSS Color 4 section 6.3 the printer canonicalizes the fully-transparent
      color to the shortest equivalent spelling [#0000]. *)
   roundtrip ".x { color: transparent }" ".x{color:#0000}";
-  (* currentColor preserves its camelCase form *)
-  roundtrip ".x { color: currentColor }" ".x{color:currentColor}"
+  (* CSS Color 4 section 6.4 spells the keyword [currentcolor]; CSS Values 4
+     section 4.1 reads it case-insensitively, so minified output emits that
+     spelling whatever was authored. *)
+  roundtrip ".x { color: currentColor }" ".x{color:currentcolor}"
 
 (* {2 CSS Conditional Rules Level 3} https://www.w3.org/TR/css-conditional-3/ *)
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -75,9 +75,9 @@ let complex_values () =
      <p1>, <color> <p2>], so adjacent stops of one colour fold into a
      double-position stop. pp holds the pair; the fold is an optimize step. *)
   check_declaration
-    ~expected:"background:linear-gradient(currentColor 0,currentColor 1px)"
+    ~expected:"background:linear-gradient(currentcolor 0,currentcolor 1px)"
     "background: linear-gradient(currentColor 0, currentColor 1px);";
-  decl_optimizes ~prop:"background" ~into:"linear-gradient(currentColor 0 1px)"
+  decl_optimizes ~prop:"background" ~into:"linear-gradient(currentcolor 0 1px)"
     "linear-gradient(currentColor 0, currentColor 1px)";
   (* The colours fold first, so two spellings of one colour still pair up. *)
   decl_optimizes ~prop:"background" ~into:"linear-gradient(red 0 10px)"
@@ -125,7 +125,7 @@ let complex_values () =
      these a plain <color>, so they shorten like any other colour-valued
      property instead of surviving as opaque unknown-property text. *)
   check_declaration ~expected:"stop-color:#fff" "stop-color: #ffffff;";
-  check_declaration ~expected:"lighting-color:currentColor"
+  check_declaration ~expected:"lighting-color:currentcolor"
     "lighting-color: currentColor;";
   (* Cross-notation folds are node changes, so they belong to the optimizer
      rather than the printer. *)
@@ -2311,7 +2311,7 @@ let spec_remaining_prop_vectors () =
         "text-decoration-skip-spaces:start end" );
       ("text-emphasis: filled dot red", "text-emphasis:filled dot red");
       ("text-emphasis-style: open sesame", "text-emphasis-style:open sesame");
-      ("text-emphasis-color: currentColor", "text-emphasis-color:currentColor");
+      ("text-emphasis-color: currentColor", "text-emphasis-color:currentcolor");
       ("text-emphasis-position: over right", "text-emphasis-position:over right");
       ( "text-emphasis-skip: punctuation symbols",
         "text-emphasis-skip:punctuation symbols" );

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -353,9 +353,13 @@ let test_color () =
   check_color ~optimized:"#0ff" "aqua";
 
   (* Special keywords. Per CSS Color 4 section 6.3 [transparent] canonicalizes
-     to the shortest spec-equivalent spelling [#0000] under minify. *)
+     to the shortest spec-equivalent spelling [#0000] under minify. CSS Values 4
+     section 4.1 reads [currentcolor] case-insensitively, so no authored
+     spelling survives the parse and minified output takes the CSS Color 4
+     section 6.4 one. *)
   check_color ~optimized:"#0000" "transparent";
-  check_color ~expected:"currentColor" "currentcolor";
+  check_color "currentcolor";
+  check_color ~expected:"currentcolor" "currentColor";
   check_color "inherit";
 
   (* Test var() parsing in color context *)
@@ -1213,6 +1217,27 @@ let spec_values_color_current () =
   neg_cursor read_color "contrast-color()";
   neg_cursor read_color "light-dark(black)"
 
+(* CSS Values 4 sec. 4.1 reads a keyword ASCII case-insensitively, so no
+   authored spelling of [currentcolor] survives the parse and the printer picks
+   one. Under minify that is the CSS Color 4 sec. 6.4 spelling on every path: a
+   custom-property stream and a typed [var()] fallback already fold to it, and a
+   declaration spelling it [currentColor] would leave one value under two
+   spellings in one stylesheet. *)
+let spec_currentcolor_one_minified_spelling () =
+  let check name source expected =
+    let minified =
+      Css.of_string_exn ~strict:false source |> Css.to_string ~minify:true
+    in
+    Alcotest.(check string) name expected minified
+  in
+  check "custom-property stream" ".x { --c: currentColor }"
+    ".x{--c:currentcolor}";
+  check "typed var() fallback" ".x { color: var(--c, currentColor) }"
+    ".x{color:var(--c,currentcolor)}";
+  check "declaration" ".x { color: currentColor }" ".x{color:currentcolor}";
+  check "upper-case spelling" ".x { color: CURRENTCOLOR }"
+    ".x{color:currentcolor}"
+
 let spec_values_l45_math_color () =
   check_length "1cqw";
   check_length "1cqh";
@@ -1545,6 +1570,8 @@ let value_tests =
     test_case "rgb" `Quick test_rgb;
     test_case "spec values and color current-work" `Quick
       spec_values_color_current;
+    test_case "spec color 4 currentcolor one minified spelling" `Quick
+      spec_currentcolor_one_minified_spelling;
     test_case "spec values level 4/5 math and color edges" `Quick
       spec_values_l45_math_color;
     test_case "spec color 5 function edges" `Quick spec_color5_function_edges;


### PR DESCRIPTION
`--minify` printed `currentColor` in a declaration and `currentcolor` in a `var()` fallback and in a custom-property stream, so one value reached the same stylesheet under two spellings. CSS Values 4 sec. 4.1 reads the keyword case-insensitively, so nothing in the parse records which spelling was authored; the imported css-minify-tests oracle keeps the author's bytes and now carries an override.
