### PR TITLE
stylesheet: construct an at-rule cascade has no grammar for

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -786,6 +786,12 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- `Css.unknown_at_rule` builds an at-rule cascade has no grammar for, such as
+  one a tool of the caller's own defines. Such a rule could be read from the AST
+  but not constructed, so emitting one meant assembling a sheet as text and
+  reading it back, where a single malformed body fails the whole buffer and
+  takes every other at-rule with it. The constructor reads the parts back and
+  refuses one that ends the at-rule early, naming that at-rule alone (#600)
 - `Css.Color_space.gamut_mapped_srgb_of_oklch` and `Css.Values.gamut_map_color`
   name the sRGB colour to write for an OKLCh colour sRGB cannot hold, reducing
   its chroma at constant lightness and hue per CSS Color 4 sec. 14.2. The

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -172,6 +172,28 @@ val as_declarations : statement -> declaration list option
 (** [as_declarations stmt] returns [Some decls] if the statement is a bare
     declarations block (used in CSS nesting), {!constructor-None} otherwise. *)
 
+val unknown_at_rule :
+  name:string ->
+  prelude:string ->
+  ?block:string ->
+  unit ->
+  (statement, Error.t) result
+(** [unknown_at_rule ~name ~prelude ?block ()] is the at-rule [\@name prelude]
+    with [block] as its body, or the reason its parts cannot make one. It is the
+    way to emit an at-rule cascade has no grammar for, such as one a tool of the
+    caller's own defines. Omitting [block] gives the statement form,
+    [\@name prelude;].
+
+    [name] is the at-keyword without its [@]. [block] is the text between the
+    at-rule's braces, since an unknown at-rule has no grammar to re-serialise a
+    body from; [to_string ~minify:true statements] is that text for a block
+    cascade does model, so placing one needs no re-read of a printed sheet.
+
+    A part that would not read back as that part is refused rather than printed,
+    and the refusal names one at-rule rather than the sheet it sits in: building
+    each at-rule on its own loses the malformed one, where re-reading an
+    assembled sheet loses every at-rule in it. *)
+
 val with_origin : cascade_origin -> statement list -> statement
 (** [with_origin cascade_origin statements] records the cascade origin for a
     stylesheet block. This is an API-level wrapper with no CSS syntax. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -4524,6 +4524,44 @@ let parse_stylesheet_partial ?(meta = Loc.default_meta_level)
   let sheet = interleave bangs rule_ends sheet in
   (sheet, out.warnings @ typed_warnings)
 
+(** {1 Unknown At-Rule Construction} *)
+
+(* An at-rule cascade has no grammar for carries its parts as raw text, so the
+   constructor has to answer for text that ends the at-rule before its parts do:
+   CSS Syntax 3 sec. 5.5.2 ends the prelude at the first top-level [;] or [{],
+   sec. 5.5.9 ends the block at the closer matching its opener, sec. 4.3.2 runs
+   an unclosed [/*] to EOF, and sec. 4.3.7 lets a trailing backslash escape the
+   closer written after it. Enumerating those boundaries re-derives the
+   tokenizer and misses whichever one is not on the list, so read the parts back
+   instead: this sits after the parser because that read is the check.
+
+   A statement is whole when the text it prints to reads back as one unknown
+   at-rule of the same name printing that same text. Nothing else is required of
+   it - the printer's own separator before an escaped closer moves a byte the
+   caller did not write, and that byte is what keeps the at-rule closing where
+   the caller meant it to. *)
+let unknown_at_rule ~name ~prelude ?block () =
+  let printed statement = to_string ~minify:true [ statement ] in
+  let text = printed (Unknown_at_rule { name; prelude; block }) in
+  let reject reason =
+    let at_rule = String.concat "" [ "@"; name ] in
+    Error (Error.bad_condition Loc.dummy ~at_rule ~reason)
+  in
+  let read_back =
+    (* A name cascade does have a grammar for reads back as that at-rule and not
+       as this one, so [~name:"media"] is refused here rather than printed as a
+       statement whose type disagrees with the sheet it prints to. *)
+    match fst (parse_stylesheet_partial text) with
+    | [ (Unknown_at_rule at as statement) ] when String.equal at.name name ->
+        Option.Some statement
+    | _ | (exception Error.Parse_error _) -> Option.None
+  in
+  match read_back with
+  | Option.None -> reject "the parts do not read back as one at-rule"
+  | Option.Some statement ->
+      if String.equal (printed statement) text then Ok statement
+      else reject "a part carries text that ends the at-rule early"
+
 (** {1 Variable extraction from stylesheets} *)
 
 (* A [var()] is a reference wherever the declaration holding it sits, so this is

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -57,6 +57,30 @@ val supports : condition:Supports.t -> block -> statement
 val starting_style : block -> statement
 (** [starting_style content] creates a [@starting-style] rule. *)
 
+val unknown_at_rule :
+  name:string ->
+  prelude:string ->
+  ?block:string ->
+  unit ->
+  (statement, Error.t) result
+(** [unknown_at_rule ~name ~prelude ?block ()] is the at-rule [\@name prelude]
+    with [block] as its body, or the reason its parts cannot make one. Omitting
+    [block] gives the statement form, [\@name prelude;].
+
+    [name] is the at-keyword without its [@]. An unknown at-rule has no grammar
+    to re-serialise a body from, so [block] is the text between its braces, the
+    same text {!read} slices out of the source. Pass
+    [to_string ~minify:true statements] to put a block cascade does model inside
+    one.
+
+    Text ends the at-rule wherever CSS Syntax 3 says it does: at a top-level [;]
+    or [{] in the prelude (sec. 5.5.2), at the closer matching an opener in the
+    block (sec. 5.5.9), at EOF once an unclosed [/*] has started (sec. 4.3.2). A
+    part reaching one of those first prints a sheet that re-consumes to
+    statements the caller never wrote, so the parts are read back and refused
+    when they do. The refusal names one at-rule, so a caller keeps the rest of
+    the sheet rather than losing it to one bad part. *)
+
 val with_origin : cascade_origin -> block -> statement
 (** [with_origin cascade_origin content] records the cascade origin for a
     stylesheet block. This is an API-level wrapper with no CSS syntax. *)

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -56,3 +56,13 @@ let _ : Css.Values.color -> int = Css.Values.hash_color
 
 let _ : Css.Values.color -> Css.Values.alpha -> Css.Values.color =
   Css.Values.with_alpha
+
+(* An at-rule cascade has no grammar for is constructible, so a caller emitting
+   one does not assemble a sheet as text and read it back to get a statement. *)
+let _ :
+    name:string ->
+    prelude:string ->
+    ?block:string ->
+    unit ->
+    (Css.statement, Error.t) result =
+  Css.unknown_at_rule

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2751,26 +2751,26 @@ let s552_unknown_at_rule_constructor () =
           (List.length other)
   in
   let at_rule = Alcotest.(triple string string (option string)) in
-  let body = List.hd (Css.of_string_exn ".a{color:red}") in
-  (* A body given as statements is serialized by the library, so the block it
-     prints is balanced whatever the caller holds. *)
+  let block = Css.of_string_exn ".a{color:red}" in
+  (* A block cascade does model reaches the body through its own printer, so a
+     caller places one without assembling or re-reading a sheet. *)
   let statements =
-    built "statement body"
+    built "printed block body"
       (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4"
-         ~block:(Statements [ body ]) ())
+         ~block:(Css.to_string ~minify:true block)
+         ())
   in
   Alcotest.(check string)
-    "a statement body prints inside the at-rule's block"
+    "a printed block sits inside the at-rule's block"
     "@utility tab-4{.a{color:red}}" (printed statements);
-  Alcotest.check at_rule "a statement body re-consumes to the same at-rule"
+  Alcotest.check at_rule "a printed block re-consumes to the same at-rule"
     ("utility", "tab-4", Some ".a{color:red}")
     (parts statements);
-  (* Text is the body of an at-rule cascade does not model, and travels
-     whole. *)
+  (* The body of an at-rule cascade does not model travels whole. *)
   let text =
     built "text body"
       (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4"
-         ~block:(Text ".a{color:red}") ())
+         ~block:".a{color:red}" ())
   in
   Alcotest.check at_rule "a text body re-consumes to the same at-rule"
     ("utility", "tab-4", Some ".a{color:red}")
@@ -2787,17 +2787,41 @@ let s552_unknown_at_rule_constructor () =
   (* Every part that carries a terminator of its own is refused, not printed. *)
   rejected "a prelude holding its own block opener"
     (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4{x:1}"
-       ~block:(Text "color:red") ());
+       ~block:"color:red" ());
   rejected "a prelude holding its own terminator"
     (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4;.evil{color:red}" ());
   rejected "a body closing the block early"
     (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4"
-       ~block:(Text "x} .evil{color:red") ());
+       ~block:"x} .evil{color:red" ());
   rejected "a body that never closes what it opens"
-    (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4"
-       ~block:(Text ".a{color:red") ());
+    (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4" ~block:".a{color:red"
+       ());
   rejected "an empty at-keyword"
-    (Css.unknown_at_rule ~name:"" ~prelude:"tab-4" ())
+    (Css.unknown_at_rule ~name:"" ~prelude:"tab-4" ());
+  (* Sec. 4.3.2 "consume comments" runs an unclosed [/*] to EOF, so a part that
+     opens one swallows the closer written after it and every statement that
+     follows. A closed comment is only text and travels like the rest of the
+     body. *)
+  let commented =
+    built "closed comment body"
+      (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4"
+         ~block:"/* keep */color:red" ())
+  in
+  Alcotest.check at_rule "a closed comment travels inside the body"
+    ("utility", "tab-4", Some "/* keep */color:red")
+    (parts commented);
+  rejected "a body opening a comment it never closes"
+    (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4" ~block:"/* color:red"
+       ());
+  rejected "a prelude opening a comment it never closes"
+    (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4 /*" ());
+  (* An at-keyword cascade does have a grammar for reads back as that at-rule,
+     so the statement would disagree with the sheet it prints to. Sec. 5.5.2
+     dispatches on the at-keyword, and [media] is one this AST already models
+     with a typed condition. *)
+  rejected "an at-keyword cascade already models"
+    (Css.unknown_at_rule ~name:"media" ~prelude:"screen" ~block:".a{color:red}"
+       ())
 
 (* The refusal is per at-rule. Assembling a sheet as text and re-parsing it
    gives the whole buffer one error path, so a single malformed body takes every
@@ -2807,7 +2831,7 @@ let s552_unknown_at_rule_error_is_local () =
   let declared =
     List.map
       (fun (prelude, body) ->
-        Css.unknown_at_rule ~name:"utility" ~prelude ~block:(Text body) ())
+        Css.unknown_at_rule ~name:"utility" ~prelude ~block:body ())
       [
         ("tab-4", "color:red");
         ("bad", "x} .evil{color:blue}");

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2720,6 +2720,106 @@ let s3431_unknown_at_rule_trailing_backslash () =
     "an escaped backslash needs no separator" "@o x{ a \\\\}"
     (printed [ at_rule " a \\\\" ])
 
+(* CSS Syntax 3 (editor's draft) sec. 5.5.2 "consume an at-rule": an at-rule is
+   an at-keyword, then a prelude ending at the first top-level [;] or [{], then
+   either that [;] or a block. Sec. 5.5.9 makes the block a balanced token
+   sequence ending at its matching [}], and sec. 4.3.3 reads [@] as an
+   at-keyword only when an ident follows it.
+
+   [unknown_at_rule] hands those parts to a caller as text, so it answers for
+   every boundary: a part carrying one of its own terminators prints a sheet
+   that re-consumes to statements nobody wrote, and an empty name prints an [@]
+   delim that re-consumes to nothing at all. *)
+let s552_unknown_at_rule_constructor () =
+  let printed stmt = String.trim (Css.to_string ~minify:true [ stmt ]) in
+  let built what = function
+    | Ok stmt -> stmt
+    | Error e ->
+        Alcotest.failf "%s: unexpected error %s" what
+          (Cascade.Error.to_string e)
+  in
+  let rejected what = function
+    | Error _ -> ()
+    | Ok stmt ->
+        Alcotest.failf "%s: expected an error, built %S" what (printed stmt)
+  in
+  let parts stmt =
+    match Css.of_string_exn (printed stmt) with
+    | [ Unknown_at_rule { name; prelude; block } ] -> (name, prelude, block)
+    | other ->
+        Alcotest.failf "expected one unknown at-rule, got %d statements"
+          (List.length other)
+  in
+  let at_rule = Alcotest.(triple string string (option string)) in
+  let body = List.hd (Css.of_string_exn ".a{color:red}") in
+  (* A body given as statements is serialized by the library, so the block it
+     prints is balanced whatever the caller holds. *)
+  let statements =
+    built "statement body"
+      (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4"
+         ~block:(Statements [ body ]) ())
+  in
+  Alcotest.(check string)
+    "a statement body prints inside the at-rule's block"
+    "@utility tab-4{.a{color:red}}" (printed statements);
+  Alcotest.check at_rule "a statement body re-consumes to the same at-rule"
+    ("utility", "tab-4", Some ".a{color:red}")
+    (parts statements);
+  (* Text is the body of an at-rule cascade does not model, and travels
+     whole. *)
+  let text =
+    built "text body"
+      (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4"
+         ~block:(Text ".a{color:red}") ())
+  in
+  Alcotest.check at_rule "a text body re-consumes to the same at-rule"
+    ("utility", "tab-4", Some ".a{color:red}")
+    (parts text);
+  (* Sec. 5.5.2: with no block the at-rule ends at its [;]. *)
+  let bodyless =
+    built "no body" (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4" ())
+  in
+  Alcotest.(check string)
+    "an at-rule with no body ends at its semicolon" "@utility tab-4;"
+    (printed bodyless);
+  Alcotest.check at_rule "an at-rule with no body re-consumes to the same one"
+    ("utility", "tab-4", None) (parts bodyless);
+  (* Every part that carries a terminator of its own is refused, not printed. *)
+  rejected "a prelude holding its own block opener"
+    (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4{x:1}"
+       ~block:(Text "color:red") ());
+  rejected "a prelude holding its own terminator"
+    (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4;.evil{color:red}" ());
+  rejected "a body closing the block early"
+    (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4"
+       ~block:(Text "x} .evil{color:red") ());
+  rejected "a body that never closes what it opens"
+    (Css.unknown_at_rule ~name:"utility" ~prelude:"tab-4"
+       ~block:(Text ".a{color:red") ());
+  rejected "an empty at-keyword"
+    (Css.unknown_at_rule ~name:"" ~prelude:"tab-4" ())
+
+(* The refusal is per at-rule. Assembling a sheet as text and re-parsing it
+   gives the whole buffer one error path, so a single malformed body takes every
+   other at-rule with it; building each statement on its own loses only the
+   malformed one. *)
+let s552_unknown_at_rule_error_is_local () =
+  let declared =
+    List.map
+      (fun (prelude, body) ->
+        Css.unknown_at_rule ~name:"utility" ~prelude ~block:(Text body) ())
+      [
+        ("tab-4", "color:red");
+        ("bad", "x} .evil{color:blue}");
+        ("tab-8", "color:lime");
+      ]
+  in
+  let kept = List.filter_map Result.to_option declared in
+  Alcotest.(check int) "only the malformed at-rule is lost" 2 (List.length kept);
+  Alcotest.(check int)
+    "the survivors print a sheet holding both of them" 2
+    (List.length (Css.of_string_exn (Css.to_string ~minify:true kept)))
+
 (* CSS Syntax 3 sec. 5.4.2: an unrecognised at-rule has no grammar to
    re-serialise its body from, so the body travels as the source text between
    its braces. That text is what sits between the at-rule's own braces. Taking
@@ -9009,6 +9109,12 @@ let additional_tests =
     ( "spec CSS Syntax 4.3.1 unknown at-rule trailing backslash",
       `Quick,
       s3431_unknown_at_rule_trailing_backslash );
+    ( "spec CSS Syntax 5.5.2 unknown at-rule constructor",
+      `Quick,
+      s552_unknown_at_rule_constructor );
+    ( "spec CSS Syntax 5.5.2 unknown at-rule constructor reports locally",
+      `Quick,
+      s552_unknown_at_rule_error_is_local );
     ("spec @-moz-document prelude forms", `Quick, moz_document_prelude_forms);
     (* CSS nesting round-trip tests *)
     ("nesting basic", `Quick, test_nesting_basic);


### PR DESCRIPTION
`Unknown_at_rule` can be read but not built, so a caller emitting an at-rule cascade has no grammar for assembles the sheet as text and reads it back through `Css.of_string`. One malformed body then fails the whole buffer, and a caller answering that with a single fallback loses every at-rule in the sheet rather than the one it got wrong. This PR adds `Css.unknown_at_rule`, which builds one statement at a time and refuses a part that would end the at-rule early, so the loss is that at-rule alone.
