### PR TITLE
selector: read a :dir() keyword in the case the author wrote

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -174,6 +174,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A `:dir()` argument written in another case, such as `:dir(LTR)`, names the
+  directionality it spells. CSS Values 4 sec. 4.1 makes a keyword ASCII
+  case-insensitive, so the two spellings reach one node, `:not(:dir(LTR))`
+  shortens to `:dir(rtl)` like its lower-case twin, and rules that differ only
+  in that case merge (#602)
 - `:dir()` accepts any single identifier, so `:dir(auto)` is read and written
   back instead of taking its whole rule down. CSS Selectors 4 sec. 7.1 says a
   value other than `ltr` or `rtl` "is not invalid, but does not match

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -330,12 +330,20 @@ let read_lang_content t =
   ensure_call_done t "lang";
   Lang langs
 
+(* CSS Values 4 sec. 4.1 interprets a keyword ASCII case-insensitively, so the
+   two directionalities Selectors 4 sec. 7.1 names reach one node however they
+   are spelled. Any other identifier is no keyword, so it keeps its case. *)
+let dir_keyword ident =
+  match String.lowercase_ascii ident with
+  | ("ltr" | "rtl") as keyword -> keyword
+  | _ -> ident
+
 let read_dir_content t =
   (* Selectors 4 sec. 7.1: the argument is a single identifier, and one other
      than [ltr] or [rtl] "is not invalid, but does not match anything". Keeping
      it verbatim also leaves room for a directionality a later markup spec
      defines. *)
-  let dir = Cursor.ident t in
+  let dir = dir_keyword (Cursor.ident t) in
   ensure_call_done t "dir";
   Dir dir
 

--- a/test/cli/dir_keyword_case.t
+++ b/test/cli/dir_keyword_case.t
@@ -1,0 +1,69 @@
+CLI: `:dir()` takes a keyword, so its argument is ASCII case-insensitive.
+
+CSS Values 4 sec. 4.1: "Keywords are identifiers and are interpreted ASCII
+case-insensitively (i.e., [a-z] and [A-Z] are equivalent)." CSS Selectors 4
+sec. 7.1 names `ltr` and `rtl` as the two directionalities `:dir()` matches, so
+`:dir(LTR)` is that keyword written in another case and means `:dir(ltr)`.
+
+The oracle for every case below is the all-lower-case spelling: case cannot
+change what cascade emits.
+
+  $ cat > lower.css <<EOF
+  > .a:not(:dir(ltr)) { color: red }
+  > EOF
+  $ cascade fmt --minify lower.css
+  .a:dir(rtl){color:red}
+
+  $ cat > upper.css <<EOF
+  > .a:not(:dir(LTR)) { color: red }
+  > EOF
+  $ cascade fmt --minify upper.css
+  .a:dir(rtl){color:red}
+
+  $ cat > mixed.css <<EOF
+  > .a:not(:dir(Rtl)) { color: red }
+  > EOF
+  $ cascade fmt --minify mixed.css
+  .a:dir(ltr){color:red}
+
+A positive `:dir()` carries the same keyword.
+
+  $ cat > plain.css <<EOF
+  > .a:dir(RTL) { color: red }
+  > EOF
+  $ cascade fmt --minify plain.css
+  .a:dir(rtl){color:red}
+
+One keyword is one node, so two rules that differ only in its case are the same
+rule and merge.
+
+  $ cat > merge.css <<EOF
+  > .a:dir(LTR) { color: red }
+  > .b:dir(ltr) { color: red }
+  > EOF
+  $ cascade fmt --minify merge.css
+  .a:dir(ltr),.b:dir(ltr){color:red}
+
+  $ cat > same.css <<EOF
+  > .a:dir(ltr) { color: red }
+  > .a:dir(LTR) { color: red }
+  > EOF
+  $ cascade fmt --minify same.css
+  .a:dir(ltr){color:red}
+
+Sec. 7.1 leaves an identifier that is neither keyword valid but non-matching.
+That is no keyword, so it keeps the case the author wrote and pairs with no
+directionality.
+
+  $ cat > other.css <<EOF
+  > .a:not(:dir(Auto)) { color: red }
+  > EOF
+  $ cascade fmt --minify other.css
+  .a:not(:dir(Auto)){color:red}
+
+Case is a fact of the CSS text, so `--enforce-spec` reads the keyword the same
+way. What it drops is the host document's partition of sec. 7.1, which is what
+keeps the `:not()` here.
+
+  $ cascade fmt --minify --enforce-spec upper.css
+  .a:not(:dir(ltr)){color:red}

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -2222,6 +2222,34 @@ let spec_selector_dir_argument_is_an_ident () =
   neg_cursor read ":dir(\"ltr\")";
   neg_cursor read ":dir(ltr, rtl)"
 
+(* CSS Values 4 sec. 4.1: "Keywords are identifiers and are interpreted ASCII
+   case-insensitively (i.e., [a-z] and [A-Z] are equivalent)." CSS Selectors 4
+   sec. 7.1 names [ltr] and [rtl] as the two directionalities [:dir()] matches,
+   so [LTR] is that keyword and reaches the same node. The identifier sec. 7.1
+   leaves valid but non-matching is no keyword, so its case is the author's. *)
+let spec_selector_dir_keyword_is_case_insensitive () =
+  (* The keyword reaches its canonical node, so the sec. 7.1 fold applies. *)
+  check_minified_to ".a:dir(rtl)" ".a:not(:dir(LTR))";
+  check_minified_to ".a:dir(ltr)" ".a:not(:dir(RTL))";
+  check_minified_to ".a:dir(rtl)" ".a:not(:dir(Ltr))";
+  (* A positive [:dir()] carries the same keyword, in either mode. *)
+  check_minified_to ".a:dir(ltr)" ".a:dir(LTR)";
+  check_pretty_to ".a:dir(rtl)" ".a:dir(RTL)";
+  (* Case is a fact of the CSS text, so it holds under [--enforce-spec] too.
+     What that flag drops is the host partition of sec. 7.1, which is what keeps
+     the [:not()] here. *)
+  check_enforce_spec_to ".a:not(:dir(ltr))" ".a:not(:dir(LTR))";
+  check_enforce_spec_to ".a:dir(ltr)" ".a:dir(LTR)";
+  (* An identifier that is neither keyword keeps its case and pairs with no
+     directionality, in either mode. *)
+  check_minified_to ".a:dir(Auto)" ".a:dir(Auto)";
+  check_minified_to ".a:not(:dir(AUTO))" ".a:not(:dir(AUTO))";
+  check_enforce_spec_to ".a:not(:dir(Auto))" ".a:not(:dir(Auto))";
+  (* The same holds for a node built rather than read. *)
+  Alcotest.(check string)
+    "an identifier that is neither keyword does not fold" ":not(:dir(auto))"
+    (to_string ~minify:true (Not [ Dir "auto" ]))
+
 (* CSS Selectors 4 sec. 12 makes each of these pseudo-class pairs a partition of
    one set of elements only, and an element outside that set matches neither
    half: sec. 12.1.1 "In a typical document most elements will be neither
@@ -2808,6 +2836,8 @@ let suite =
         spec_selector_dir_fold_is_a_host_fact;
       test_case "spec selector :dir() argument is an ident" `Quick
         spec_selector_dir_argument_is_an_ident;
+      test_case "spec selector :dir() keyword is case-insensitive" `Quick
+        spec_selector_dir_keyword_is_case_insensitive;
       test_case "spec selector state folds need a carrier" `Quick
         spec_selector_state_folds_need_a_carrier;
       test_case "spec forgiving selector lists" `Quick


### PR DESCRIPTION
`:dir(LTR)` used to fail the selector and take its rule out of the stylesheet. CSS Values 4 sec. 4.1 interprets a keyword ASCII case-insensitively, so it now reaches the same node as `:dir(ltr)`, and the `:not()` fold and rule merging apply to it.

The same shape recurs across the readers, where `Cursor.expect_string`, `looking_at_ident`, `looking_at_func` and `function_call` compare an authored identifier against a lower-case literal. That is much larger than this fix and left for its own PR.
