### PR TITLE
cursor: match a keyword whatever case the author wrote it in

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -174,6 +174,13 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A keyword written in another case is read as that keyword. CSS Values 4
+  sec. 4.1 makes a keyword ASCII case-insensitive, so `grid-column: SPAN 2` is
+  a span of two tracks rather than the reordered `2 SPAN` it printed, and a
+  `FROM` keyframe, an `@import URL()` and an `INSET` shadow reach the output
+  instead of being dropped. Sec. 4.2 still reads a custom property, a
+  `@keyframes`, `@layer`, container or grid line name, a class, an id and an
+  attribute value in the case the author wrote (#603)
 - A `:dir()` argument written in another case, such as `:dir(LTR)`, names the
   directionality it spells. CSS Values 4 sec. 4.1 makes a keyword ASCII
   case-insensitive, so the two spellings reach one node, `:not(:dir(LTR))`

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -488,8 +488,13 @@ let consume_to_slash_or_semicolon ?(trim = false) t =
 
 (** {1 Token-shape helpers - raising variants} *)
 
-let ident ?keep_case:_ t =
-  match ident_opt t with Some s -> s | None -> err_expected t "identifier"
+(* CSS Values 4 sec. 4.1 reads a keyword ASCII case-insensitively; sec. 4.2
+   keeps an author-defined identifier case-sensitive. [keep_case] is which of
+   the two the caller is reading. *)
+let ident ?(keep_case = true) t =
+  match ident_opt t with
+  | Some s -> if keep_case then s else String.lowercase_ascii_preserve s
+  | None -> err_expected t "identifier"
 
 let number ?(allow_negative = true) t =
   match number_opt t with
@@ -556,7 +561,8 @@ let url t =
   | Some (Component.Preserved { kind = Token.Url s; _ }) ->
       skip t;
       s
-  | Some (Component.Func ({ node = { name = "url"; _ }; _ } as fn)) ->
+  | Some (Component.Func ({ node = { name; _ }; _ } as fn))
+    when String.lowercase_ascii_preserve name = "url" ->
       url_from_func t fn
   | _ -> err_expected t "url"
 
@@ -653,13 +659,15 @@ let try_kind k t =
 
 let looking_at_ident name t =
   match peek t with
-  | Some (Component.Preserved { kind = Token.Ident s; _ }) -> s = name
+  | Some (Component.Preserved { kind = Token.Ident s; _ }) ->
+      String.lowercase_ascii_preserve s = name
   | _ -> false
 
 let looking_at_func name t =
   drop_ws t;
   match t.cvs with
-  | Component.Func { node = { name = n; _ }; _ } :: _ -> n = name
+  | Component.Func { node = { name = n; _ }; _ } :: _ ->
+      String.lowercase_ascii_preserve n = name
   | _ -> false
 
 let looking_at_calc t =
@@ -675,9 +683,10 @@ let looking_at t s =
   else
     match peek t with
     | Some (Component.Preserved { kind = Token.Ident ident; _ }) ->
-        String.starts_with ~prefix:s ident
+        String.starts_with ~prefix:s (String.lowercase_ascii_preserve ident)
     | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
-        String.starts_with ~prefix:s ("@" ^ name)
+        String.starts_with ~prefix:s
+          (String.concat "" [ "@"; String.lowercase_ascii_preserve name ])
     | Some (Component.Preserved { kind = Token.Hash { value; _ }; _ }) ->
         String.starts_with ~prefix:s ("#" ^ value)
     | Some (Component.Preserved { kind = Token.Url _; _ }) ->
@@ -714,7 +723,9 @@ let expect c t =
     err_expected t (String.concat "" [ "'"; String.make 1 c; "'" ])
 
 let expect_string name t =
-  match ident_opt t with Some s when s = name -> () | _ -> err_expected t name
+  match ident_opt t with
+  | Some s when String.lowercase_ascii_preserve s = name -> ()
+  | _ -> err_expected t name
 
 let expect_eof t = if not (is_done t) then err t "unexpected token"
 
@@ -744,7 +755,8 @@ let braces f t =
 
 let function_call name f t =
   match peek t with
-  | Some (Component.Func fn) when fn.node.name = name ->
+  | Some (Component.Func fn)
+    when String.lowercase_ascii_preserve fn.node.name = name ->
       let _ = next t in
       Some (f (sub ~eof_loc:(closer_loc fn.loc) t fn.node.arguments))
   | _ -> None
@@ -774,7 +786,7 @@ let call name t f =
 let try_enum table t =
   match peek t with
   | Some (Component.Preserved { kind = Token.Ident s; _ }) -> (
-      match List.assoc_opt s table with
+      match List.assoc_opt (String.lowercase_ascii_preserve s) table with
       | Some v ->
           let _ = next t in
           Some v

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -218,8 +218,10 @@ val with_context : t -> string -> (unit -> 'a) -> 'a
     These parse and advance the cursor, or raise {!Parse_error} on mismatch. *)
 
 val ident : ?keep_case:bool -> t -> string
-(** [ident t] consumes the next ident. The [keep_case] flag is accepted for
-    source compatibility; component idents are already case-preserved. *)
+(** [ident t] consumes the next ident. [keep_case] defaults to [true], the
+    author's spelling, which is what an author-defined identifier is (CSS Values
+    4 sec. 4.2). [~keep_case:false] lowercases it, which is what a keyword is
+    (sec. 4.1). *)
 
 val number : ?allow_negative:bool -> t -> float
 (** [number t] consumes the next numeric token. *)
@@ -392,15 +394,18 @@ val try_kind_pair : Token.kind -> Token.kind -> t -> bool
 val looking_at : t -> string -> bool
 (** [looking_at t s] is [true] iff the next component (after leading whitespace)
     starts with [s] - matches an ident, a function name followed by [(], or a
-    delim-based prefix. *)
+    delim-based prefix. Idents and at-keywords match ASCII case-insensitively
+    (CSS Values 4 sec. 4.1), so [s] is given lowercase. *)
 
 val looking_at_ident : string -> t -> bool
 (** [looking_at_ident name t] is [true] if the next component is identifier
-    [name]. *)
+    [name], compared ASCII case-insensitively (CSS Values 4 sec. 4.1), so [name]
+    is given lowercase. *)
 
 val looking_at_func : string -> t -> bool
-(** [looking_at_func name t] is [true] if the next component is function [name].
-*)
+(** [looking_at_func name t] is [true] if the next component is function [name],
+    compared ASCII case-insensitively (CSS Values 4 sec. 4.1), so [name] is
+    given lowercase. *)
 
 val looking_at_calc : t -> bool
 (** [looking_at_calc t] is [true] if the next component is [calc()] or the
@@ -412,7 +417,9 @@ val expect : char -> t -> unit
 (** [expect c t] consumes the delim [c] or raises. *)
 
 val expect_string : string -> t -> unit
-(** [expect_string s t] consumes the ident [s] or raises. *)
+(** [expect_string s t] consumes the ident [s] or raises. The ident is a
+    keyword, matched ASCII case-insensitively (CSS Values 4 sec. 4.1), so [s] is
+    given lowercase. *)
 
 val expect_eof : t -> unit
 (** [expect_eof t] raises if any non-whitespace component remains. *)
@@ -436,7 +443,8 @@ val call : string -> t -> (t -> 'a) -> 'a
 val function_call : string -> (t -> 'a) -> t -> 'a option
 (** [function_call name f t] consumes a [name(...)] call and calls [f] over its
     arguments. Returns [None] without advancing if the next component is not a
-    function with that name. *)
+    function with that name, compared ASCII case-insensitively (CSS Values 4
+    sec. 4.1), so [name] is given lowercase. *)
 
 val any_function_call : (string -> t -> 'a) -> t -> 'a option
 (** [any_function_call f t] consumes any function call and applies [f] to its
@@ -450,7 +458,8 @@ val enum : ?default:(t -> 'a) -> string -> (string * 'a) list -> t -> 'a
     raises. *)
 
 val try_enum : (string * 'a) list -> t -> 'a option
-(** [try_enum table t] is like {!enum} but returns [None] without raising. *)
+(** [try_enum table t] is like {!enum} but returns [None] without raising. Keys
+    are given lowercase. *)
 
 val enum_calls : ?default:(t -> 'a) -> (string * (t -> 'a)) list -> t -> 'a
 (** [enum_calls ?default table t] skips leading whitespace, then dispatches on

--- a/lib/keyframe.ml
+++ b/lib/keyframe.ml
@@ -67,25 +67,26 @@ let parse_timeline_range_position s =
   match String.index_opt s ' ' with
   | None -> None
   | Some i ->
-      let name = String.sub s 0 i in
+      let name = Common.String.lowercase_ascii_preserve (String.sub s 0 i) in
       let rest = String.sub s (i + 1) (String.length s - i - 1) in
       let rest = String.trim rest in
-      if not (List.mem (String.lowercase_ascii name) timeline_range_names) then
-        None
+      if not (List.mem name timeline_range_names) then None
       else
         Option.bind (parse_percent rest) (fun p ->
             Some (Timeline_range (name, p)))
 
-(** Parse a position string like "from", "to", "50%", or "entry 0%". *)
+(** Parse a position string like "from", "to", "50%", or "entry 0%". CSS Values
+    4 sec. 4.1 reads each of these keywords case-insensitively. *)
 let position_of_string s =
   let s = String.trim s in
-  if String.equal s "from" then Some From
-  else if String.equal s "to" then Some To
-  else
-    match parse_percent s with
-    | Some p when p >= 0. && p <= 100. -> Some (Percent p)
-    | Some _ -> None
-    | None -> parse_timeline_range_position s
+  match Common.String.lowercase_ascii_preserve s with
+  | "from" -> Some From
+  | "to" -> Some To
+  | _ -> (
+      match parse_percent s with
+      | Some p when p >= 0. && p <= 100. -> Some (Percent p)
+      | Some _ -> None
+      | None -> parse_timeline_range_position s)
 
 (** Parse a selector string like "from", "50%", or "from, 50%". *)
 let selector_of_string s =

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -606,13 +606,17 @@ let grid_line_at_end t =
   | Some (Component.Preserved { kind = Token.Delim "/"; _ }) -> true
   | _ -> false
 
+(* CSS Grid 2 sec. 8.3 excludes [span] from the [<custom-ident>] of a grid line
+   name. That exclusion is on the keyword, so it reads case-insensitively while
+   the name itself keeps the author's case (CSS Values 4 sec. 4.1 and 4.2). *)
 let read_grid_line_name t =
   let name = Cursor.ident t in
-  if name = "span" then Cursor.err_invalid t "duplicate span grid line"
+  if String.lowercase_ascii_preserve name = "span" then
+    Cursor.err_invalid t "duplicate span grid line"
   else name
 
 let read_grid_span t =
-  let span_word = Cursor.ident t in
+  let span_word = Cursor.ident ~keep_case:false t in
   if span_word <> "span" then
     Cursor.err t ("Expected 'span' but got " ^ span_word);
   Cursor.ws t;

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2454,7 +2454,7 @@ let validate_font_variant_descriptor_values r values =
 
 let read_font_variant_descriptor_value r =
   let ident = Cursor.ident ~keep_case:false r in
-  match font_variant_desc_value (String.lowercase_ascii ident) with
+  match font_variant_desc_value ident with
   | Some value -> value
   | None -> Cursor.err_invalid r ("font-variant descriptor value: " ^ ident)
 
@@ -2476,7 +2476,7 @@ let read_font_variant_keywords r : font_variant_descriptor =
   let snap = Cursor.save r in
   let first = Cursor.ident ~keep_case:false r in
   Cursor.ws r;
-  match (String.lowercase_ascii first, at_value_end ()) with
+  match (first, at_value_end ()) with
   | "normal", true -> Normal
   | "none", true -> None
   | _ ->
@@ -2633,7 +2633,7 @@ let read_font_face (r : Cursor.t) : statement =
 
 let read_counter_style_system_value r =
   let system = Cursor.ident ~keep_case:false r in
-  match String.lowercase_ascii system with
+  match system with
   | "cyclic" -> Cyclic
   | "numeric" -> Numeric
   | "alphabetic" -> Alphabetic
@@ -2699,7 +2699,7 @@ let read_counter_string_descriptor constructor r =
    takes, invalidates the declaration it follows rather than being left over as
    an item of its own, as it is in Blink 146. *)
 let read_counter_style_descriptor (r : Cursor.t) : counter_style_descriptor =
-  let name = Cursor.ident ~keep_case:false r |> String.lowercase_ascii in
+  let name = Cursor.ident ~keep_case:false r in
   let descriptor =
     match name with
     | "system" -> read_counter_style_system_descriptor r
@@ -2972,10 +2972,13 @@ let read_base_palette_value inner =
         Cursor.err_invalid inner "base-palette index must be non-negative";
       Index (Float.to_int n)
   | exception Cursor.Parse_error _ -> (
-      match Cursor.ident ~keep_case:false inner with
+      (* [light] and [dark] are keywords, so CSS Values 4 sec. 4.1 reads them
+         case-insensitively; any other ident is the author's own. *)
+      let ident = Cursor.ident inner in
+      match Common.String.lowercase_ascii_preserve ident with
       | "light" -> Light
       | "dark" -> Dark
-      | ident when ident <> "" -> Palette_ident ident
+      | _ when ident <> "" -> Palette_ident ident
       | _ -> Cursor.err_expected inner "base-palette value")
 
 let read_override_color_entry c =

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -190,7 +190,7 @@ let property prop value =
 
 let single_ident name args =
   let cursor = Cursor.of_string args in
-  let ident = Cursor.ident ~keep_case:false cursor |> String.lowercase_ascii in
+  let ident = Cursor.ident ~keep_case:false cursor in
   Cursor.ws cursor;
   Cursor.expect_eof cursor;
   if ident = "" then failwith ("empty " ^ name ^ "() in @supports");

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1644,6 +1644,130 @@ let option_value_parser_contracts () =
    its block. So [to_string] keeps it too, at every block depth, with a body or
    without one. [Optimize.drop_unknown_at_rules] stays available for a caller
    that does want user-agent-equivalent output. *)
+(* CSS Values 4 sec. 4.1: "Keywords are identifiers and are interpreted ASCII
+   case-insensitively (i.e., [a-z] and [A-Z] are equivalent)." A keyword the
+   author capitalised is the same keyword, so it reads to the same node and
+   prints as that node prints. *)
+let spec_keyword_case_insensitive () =
+  let render input =
+    match of_string ~strict:false input with
+    | Ok parsed -> to_string ~minify:true parsed.stylesheet
+    | Error err ->
+        Alcotest.failf "lenient parse rejected %S: %s" input
+          (Cascade.Error.to_string err)
+  in
+  (* [expect] is the shortest spelling of the one node both inputs name. *)
+  let pins name ~upper ~lower ~expect =
+    Alcotest.(check string)
+      (String.concat "" [ name; " (lower-case control)" ])
+      expect (render lower);
+    Alcotest.(check string)
+      (String.concat "" [ name; " (capitalised keyword)" ])
+      expect (render upper)
+  in
+  (* Where the printed spelling is a canonicalisation of cascade's own, the pin
+     is that both spellings reach it, not what it is. *)
+  let agrees name ~upper ~lower =
+    let out = render lower in
+    Alcotest.(check bool)
+      (String.concat "" [ name; " (lower-case control parses)" ])
+      true (out <> "");
+    Alcotest.(check string)
+      (String.concat "" [ name; " (capitalised keyword)" ])
+      out (render upper)
+  in
+  (* CSS Grid 2 sec. 8.3: [span] is a keyword of [<grid-line>], so [SPAN 2] is
+     the span of 2 tracks and not the line named [SPAN] on track 2. *)
+  pins "grid-column span" ~upper:".a{grid-column:SPAN 2}"
+    ~lower:".a{grid-column:span 2}" ~expect:".a{grid-column:span 2}";
+  (* CSS Animations 1 sec. 4.1 makes [from] equivalent to [0%] and [to] to
+     [100%]; the shorter of each pair is the printed form. *)
+  pins "keyframe selector" ~upper:"@keyframes f{FROM{opacity:0}TO{opacity:1}}"
+    ~lower:"@keyframes f{from{opacity:0}to{opacity:1}}"
+    ~expect:"@keyframes f{0%{opacity:0}to{opacity:1}}";
+  (* CSS Cascade 5 sec. 2.1 takes a [<url>] or a [<string>]; they name the same
+     resource and the string is shorter. *)
+  pins "@import url()" ~upper:"@import URL(\"reset.css\");"
+    ~lower:"@import url(\"reset.css\");" ~expect:"@import\"reset.css\";";
+  (* CSS Backgrounds 3 sec. 6.2: [inset] is a keyword of [<shadow>]. *)
+  pins "box-shadow inset" ~upper:".a{box-shadow:INSET 1px 1px red}"
+    ~lower:".a{box-shadow:inset 1px 1px red}"
+    ~expect:".a{box-shadow:inset 1px 1px red}";
+  agrees "nth-child of" ~upper:".a:nth-child(2n OF .item){color:red}"
+    ~lower:".a:nth-child(2n of .item){color:red}";
+  agrees "@import layer()" ~upper:"@import \"a.css\" LAYER(base);"
+    ~lower:"@import \"a.css\" layer(base);";
+  agrees "@property descriptors"
+    ~upper:"@property --x{SYNTAX:\"<length>\";INHERITS:false;INITIAL-VALUE:0px}"
+    ~lower:"@property --x{syntax:\"<length>\";inherits:false;initial-value:0px}";
+  agrees "@font-face descriptors"
+    ~upper:"@font-face{FONT-FAMILY:Foo;SRC:url(a.woff)}"
+    ~lower:"@font-face{font-family:Foo;src:url(a.woff)}";
+  agrees "gradient corner keywords"
+    ~upper:".a{background:linear-gradient(TO RIGHT,red,blue)}"
+    ~lower:".a{background:linear-gradient(to right,red,blue)}";
+  agrees "@counter-style system"
+    ~upper:"@counter-style c{system:FIXED;symbols:\"a\"}"
+    ~lower:"@counter-style c{system:fixed;symbols:\"a\"}"
+
+(* CSS Values 4 sec. 4.2: an author-defined identifier is "fully case-sensitive
+   [...] even in the ASCII range (e.g. example and EXAMPLE are two different,
+   unrelated user-defined identifiers)". Reading a keyword case-insensitively
+   must not reach any of these. *)
+let spec_author_ident_case_sensitive () =
+  let render input =
+    match of_string ~strict:false input with
+    | Ok parsed -> to_string ~minify:true parsed.stylesheet
+    | Error err ->
+        Alcotest.failf "lenient parse rejected %S: %s" input
+          (Cascade.Error.to_string err)
+  in
+  let keeps name input affix =
+    let out = render input in
+    Alcotest.(check bool)
+      (String.concat "" [ name; ": "; affix; " survives, got "; out ])
+      true
+      (Astring.String.is_infix ~affix out)
+  in
+  keeps "custom property name" ".a{--Foo:1px;color:var(--Foo)}" "--Foo:1px";
+  keeps "custom property name (var reference)" ".a{--Foo:1px;color:var(--Foo)}"
+    "var(--Foo)";
+  (* [--Foo] and [--foo] are two unrelated properties, so neither absorbs the
+     other. *)
+  keeps "custom property names stay distinct" ".a{--Foo:1px;--foo:2px}"
+    "--Foo:1px";
+  keeps "custom property names stay distinct" ".a{--Foo:1px;--foo:2px}"
+    "--foo:2px";
+  keeps "@keyframes name" "@keyframes Slide{from{opacity:0}}" "Slide";
+  keeps "@layer name" "@layer Base{a{color:red}}" "Base";
+  keeps "container name" "@container Card (width>0px){a{color:red}}" "Card";
+  keeps "view-transition type" "@view-transition{types:Foo}" "Foo";
+  keeps "counter name" ".a{counter-reset:Chapter}" "Chapter";
+  keeps "grid line name" ".a{grid-column:Foo}" "Foo";
+  (* [span] is excluded from the name, so [SPAN Foo] is a span of the line named
+     [Foo] and the name keeps its case. *)
+  keeps "grid line name after span" ".a{grid-column:SPAN Foo}" "span Foo";
+  keeps "class selector" ".Foo{color:red}" ".Foo";
+  keeps "id selector" "#Bar{color:red}" "#Bar";
+  keeps "class selectors stay distinct" ".Foo{color:red}.foo{color:red}" ".foo";
+  keeps "attribute value" "[data-x=\"Foo\"]{color:red}" "Foo";
+  keeps "font family name" ".a{font-family:MyFont,sans-serif}" "MyFont";
+  keeps "@property name" "@property --Foo{syntax:\"*\";inherits:false}" "--Foo";
+  (* CSS Fonts 4 sec. 12.1: [light] and [dark] are the keywords of
+     [base-palette], so any other ident there is the author's own. *)
+  keeps "base-palette ident"
+    "@font-palette-values --P{font-family:F;base-palette:MyPalette}" "MyPalette";
+  (* CSS Syntax 3 sec. 8.2 recognises [@charset] only as the exact byte
+     sequence, so the encoding name is not a keyword to fold. *)
+  (match of_string ~strict:true "@charset \"utf-8\";.a{color:red}" with
+  | Ok _ -> Alcotest.fail "@charset accepted a lower-case encoding name"
+  | Error _ -> ());
+  match of_string ~strict:true "@charset \"UTF-8\";.a{color:red}" with
+  | Ok _ -> ()
+  | Error err ->
+      Alcotest.failf "@charset rejected the exact encoding name: %s"
+        (Cascade.Error.to_string err)
+
 let unknown_at_rule_reaches_output () =
   let parse input =
     match of_string ~strict:false input with
@@ -1755,4 +1879,8 @@ let suite =
         public_bad_string_prelude_edges;
       Alcotest.test_case "spec unknown at-rule reaches the output" `Quick
         unknown_at_rule_reaches_output;
+      Alcotest.test_case "spec section 4.1 keyword case is insensitive" `Quick
+        spec_keyword_case_insensitive;
+      Alcotest.test_case "spec section 4.2 author ident case is sensitive"
+        `Quick spec_author_ident_case_sensitive;
     ] )


### PR DESCRIPTION
`grid-column: SPAN 2` used to print back as `grid-column: 2 SPAN`, reading the keyword as a grid line name and reordering the value; a `FROM` keyframe, `@import URL("reset.css")` and `box-shadow: INSET 1px 1px red` were dropped outright. CSS Values 4 sec. 4.1 interprets a keyword ASCII case-insensitively, but six `Cursor` helpers compared the authored ident against a lower-case literal and `Cursor.ident` bound its `keep_case` flag to `_`, so every call site asking for a folded keyword got the author's spelling instead.

Folding at the reader is what keeps sec. 4.2 intact, so `keep_case` now works and an author-defined identifier still reads in the case it was written. At-rule names, colour function names and the `@page` selector scanner match their own literals elsewhere and are left for a follow-up.
