### PR TITLE
lib: read an at-rule and a function name as the keyword each is

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -174,6 +174,16 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- An at-rule or function name written in another case names what it spells.
+  CSS Values 4 sec. 4.1 makes both of them keywords, so `@MEDIA`,
+  `@Font-Face`, `RGB()`, `color-mix(IN srgb, ...)`, `background: URL("a.png")`,
+  `@page :FIRST`, a `@page` margin box such as `@TOP-LEFT` and the legacy
+  `/DEEP/` combinator each read as the node their lower-case spelling reads as.
+  A miscased name cascade has a grammar for is no longer an unknown at-rule, so
+  it optimises and merges like that spelling and is rejected on the preludes
+  that spelling rejects. A name cascade has no grammar for still reaches the
+  output as written, and `@charset` stays the byte sequence CSS Syntax 3
+  sec. 8.2 matches (#604)
 - A keyword written in another case is read as that keyword. CSS Values 4
   sec. 4.1 makes a keyword ASCII case-insensitive, so `grid-column: SPAN 2` is
   a span of two tracks rather than the reordered `2 SPAN` it printed, and a

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -421,7 +421,7 @@ let at_keyword_opt t =
 
 let expect_at_keyword name t =
   match at_keyword_opt t with
-  | Some s when s = name -> ()
+  | Some s when String.lowercase_ascii_preserve s = name -> ()
   | _ -> err_expected t ("@" ^ name)
 
 let drain_until_block t =
@@ -662,6 +662,12 @@ let looking_at_ident name t =
   | Some (Component.Preserved { kind = Token.Ident s; _ }) ->
       String.lowercase_ascii_preserve s = name
   | _ -> false
+
+let try_ident name t =
+  if looking_at_ident name t then
+    let _ = next t in
+    true
+  else false
 
 let looking_at_func name t =
   drop_ws t;

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -327,7 +327,9 @@ val at_keyword_opt : t -> string option
     token, returning the keyword name without the leading [@]. *)
 
 val expect_at_keyword : string -> t -> unit
-(** [expect_at_keyword name t] consumes the [@name] token or raises. *)
+(** [expect_at_keyword name t] consumes the [@name] token or raises. The name is
+    a keyword, matched ASCII case-insensitively (CSS Values 4 sec. 4.1), so
+    [name] is given lowercase. *)
 
 val drain_until_block : t -> Component.t list
 (** [drain_until_block t] consumes components up to (but not including) the next
@@ -386,6 +388,11 @@ val consume_if : char -> t -> bool
 val try_kind : Token.kind -> t -> bool
 (** [try_kind kind t] consumes [kind] if it is next and returns whether it
     matched. *)
+
+val try_ident : string -> t -> bool
+(** [try_ident name t] consumes the next component if it is the identifier
+    [name] and returns whether it matched. The ident is a keyword, matched ASCII
+    case-insensitively (CSS Values 4 sec. 4.1), so [name] is given lowercase. *)
 
 val try_kind_pair : Token.kind -> Token.kind -> t -> bool
 (** [try_kind_pair k1 k2 t] consumes [k1] followed by [k2] if both are next and

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -1732,7 +1732,8 @@ let read_bg_url_call t terminated =
 let read_bg_url t : background_image =
   match Cursor.peek t with
   | Some (Component.Preserved { kind = Token.Url _; _ }) -> Url (Cursor.url t)
-  | Some (Component.Func { node = { name = "url"; terminated; _ }; _ }) ->
+  | Some (Component.Func { node = { name; terminated; _ }; _ })
+    when String.lowercase_ascii_preserve name = "url" ->
       read_bg_url_call t terminated
   | _ -> Cursor.err_expected t "url"
 

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -567,7 +567,7 @@ let try_shadow_deep t =
   let snap = Cursor.save t in
   if
     Cursor.try_kind (Token.Delim "/") t
-    && Cursor.try_kind (Token.Ident "deep") t
+    && Cursor.try_ident "deep" t
     && Cursor.try_kind (Token.Delim "/") t
   then true
   else (

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2840,7 +2840,9 @@ let parse_page_selectors r selector =
   let consume_ident = page_selector_consume_ident s len in
   let skip_ws = page_selector_skip_ws s len in
   let pseudo_of_name name =
-    match name with
+    (* CSS Paged Media 3 sec. 4.3 closes [<pseudo-page>] over four names, so
+       each is a keyword and not the page name beside it. *)
+    match Common.String.lowercase_ascii_preserve name with
     | "first" -> First
     | "left" -> Left
     | "right" -> Right
@@ -2905,8 +2907,11 @@ let allowed_page_margin_names =
    that is no declaration at all. *)
 let read_page_margin_rule r =
   match Cursor.peek r with
-  | Some (Component.Preserved { kind = Token.At_keyword name; _ })
-    when List.mem name allowed_page_margin_names ->
+  | Some (Component.Preserved { kind = Token.At_keyword raw; _ }) ->
+      (* Sec. 5.2 names the margin boxes, so each name is a keyword. *)
+      let name = Common.String.lowercase_ascii_preserve raw in
+      if not (List.mem name allowed_page_margin_names) then
+        Cursor.err_invalid r ("unknown page margin rule: @" ^ raw);
       Cursor.skip r;
       Cursor.ws r;
       (* Sec. 5 gives the margin at-rule a [<declaration-list>], which CSS
@@ -2917,8 +2922,6 @@ let read_page_margin_rule r =
         Cursor.braces (read_descriptor_block replace_descriptor) r
       in
       { name; descriptors }
-  | Some (Component.Preserved { kind = Token.At_keyword name; _ }) ->
-      Cursor.err_invalid r ("unknown page margin rule: @" ^ name)
   | _ -> Cursor.err_expected r "page margin rule"
 
 (* CSS Paged Media 3 sec. 2: a [@page] body holds page properties and margin
@@ -3767,6 +3770,15 @@ let read_moz_document ~body (r : Cursor.t) : statement =
   Cursor.expect_eof prelude_cursor;
   Moz_document (conditions, Cursor.braces body r)
 
+(* CSS Values 4 sec. 4.1 reads an at-rule name as a keyword, so its case does
+   not pick between two grammars. Sec. 8.2 of CSS Syntax 3 is the one exception:
+   it matches [@charset] and the quote after it as an exact byte sequence, so
+   any other spelling of that name is a name with no grammar behind it. *)
+let at_rule_keyword name =
+  match Common.String.lowercase_ascii_preserve name with
+  | "charset" when name <> "charset" -> name
+  | folded -> folded
+
 let rec read_statement (r : Cursor.t) : statement =
   Cursor.ws r;
   let table : (string * (Cursor.t -> statement)) list =
@@ -3801,7 +3813,7 @@ let rec read_statement (r : Cursor.t) : statement =
   in
   match Cursor.peek r with
   | Some (Component.Preserved { kind = Token.At_keyword name; loc; _ }) -> (
-      match List.assoc_opt name table with
+      match List.assoc_opt (at_rule_keyword name) table with
       | Some p -> p r
       | None ->
           (* CSS Syntax 3 sec. 5.4.2 consumes an at-rule whatever its name, so
@@ -4058,7 +4070,7 @@ and read_nested_layer_rule r =
 and read_nested_at_within_rule ~prev (r : Cursor.t) : statement option =
   match Cursor.peek r with
   | Some (Component.Preserved { kind = Token.At_keyword name; loc; _ }) ->
-      read_nested_at_keyword r ~loc ~prev name
+      read_nested_at_keyword r ~loc ~prev (at_rule_keyword name)
   | _ -> Some (read_statement r)
 
 (* CSS Nesting 1 sec. 3.3: "any at-rule whose body contains style rules can be

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6645,7 +6645,7 @@ let rec read_color_mix t : color =
   (* CSS Color 5 sec. 3: an omitted [<color-interpolation-method>] defaults to
      [in oklab], so the [in <space> [<hue> hue]?] prefix (and its trailing
      comma) is optional. *)
-  let has_method = Cursor.peek_ident t = Some "in" in
+  let has_method = Cursor.looking_at_ident "in" t in
   let in_space, hue =
     if has_method then (
       Cursor.expect_string "in" t;
@@ -6856,11 +6856,14 @@ and read_color t : color =
           | Some (r, g, b, a) -> Authored_hex { value; r; g; b; a }
           | None -> Cursor.err_invalid t ("hex color digits: " ^ value))
     | Some (Component.Func ({ node = { name; _ }; _ } as fn)) -> (
-        match List.assoc_opt name color_parsers with
+        (* CSS Values 4 sec. 4.1: a function name is a keyword, so it names the
+           same function in whatever case it was written. *)
+        let fn_name = Common.String.lowercase_ascii_preserve name in
+        match List.assoc_opt fn_name color_parsers with
         | Some parser ->
             Cursor.skip t;
             parser (Cursor.func_sub fn t)
-        | None when name = "var" -> Var (read_var read_color t)
+        | None when fn_name = "var" -> Var (read_var read_color t)
         | None -> Cursor.err t ("unknown color function: " ^ name))
     | Some (Component.Preserved { kind = Token.Ident ident; _ }) -> (
         Cursor.skip t;

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1708,7 +1708,50 @@ let spec_keyword_case_insensitive () =
     ~lower:".a{background:linear-gradient(to right,red,blue)}";
   agrees "@counter-style system"
     ~upper:"@counter-style c{system:FIXED;symbols:\"a\"}"
-    ~lower:"@counter-style c{system:fixed;symbols:\"a\"}"
+    ~lower:"@counter-style c{system:fixed;symbols:\"a\"}";
+  (* CSS Color 4 sec. 5 names each colour function; the name is a keyword, so
+     the capitalised spelling is the same function. *)
+  agrees "rgb() function name" ~upper:".a{color:RGB(1,2,3)}"
+    ~lower:".a{color:rgb(1,2,3)}";
+  agrees "oklch() function name" ~upper:".a{color:OKLCH(50% .1 30)}"
+    ~lower:".a{color:oklch(50% .1 30)}";
+  agrees "light-dark() function name" ~upper:".a{color:LIGHT-DARK(red,blue)}"
+    ~lower:".a{color:light-dark(red,blue)}";
+  (* CSS Color 5 sec. 3: [in] introduces the optional
+     [<color-interpolation-method>], so it is a keyword of the grammar. *)
+  agrees "color-mix() interpolation method"
+    ~upper:".a{color:color-mix(IN srgb,red,blue)}"
+    ~lower:".a{color:color-mix(in srgb,red,blue)}";
+  (* CSS Values 4 sec. 4.5.1 writes a [<url>] as the [url()] name over a
+     [<string>], or as the url-token a URL with nothing to quote spells
+     shorter. *)
+  pins "background url()" ~upper:".a{background:URL(\"a.png\")}"
+    ~lower:".a{background:url(\"a.png\")}" ~expect:".a{background:url(a.png)}";
+  (* CSS Paged Media 3 sec. 4.3: a [<pseudo-page>] comes from the closed set
+     [first | left | right | blank], so it is a keyword and not a page name. *)
+  pins "@page pseudo-page" ~upper:"@page :FIRST{margin:1in}"
+    ~lower:"@page :first{margin:1in}" ~expect:"@page:first{margin:1in}";
+  (* The legacy shadow-piercing combinator spells one fixed ident between its
+     two slashes, so that ident belongs to the combinator's syntax. *)
+  pins "/deep/ combinator" ~upper:".a /DEEP/ .b{color:red}"
+    ~lower:".a /deep/ .b{color:red}" ~expect:".a/deep/.b{color:red}";
+  (* CSS Paged Media 3 sec. 5.2 names the sixteen margin boxes, so each name is
+     a keyword of the [@page] body. *)
+  pins "@page margin box" ~upper:"@page{@TOP-LEFT{content:\"x\"}}"
+    ~lower:"@page{@top-left{content:\"x\"}}"
+    ~expect:"@page{@top-left{content:\"x\"}}";
+  (* An at-rule name is an identifier of the grammar, so sec. 4.1 reaches it
+     too. The name beside it is the author's and sec. 4.2 keeps it. *)
+  pins "@keyframes at-rule name" ~upper:"@KEYFRAMES Slide{FROM{opacity:0}}"
+    ~lower:"@keyframes Slide{from{opacity:0}}"
+    ~expect:"@keyframes Slide{0%{opacity:0}}";
+  pins "@media at-rule name" ~upper:"@MEDIA screen{a{color:red}}"
+    ~lower:"@media screen{a{color:red}}" ~expect:"@media screen{a{color:red}}";
+  pins "@media nested in a style rule" ~upper:".a{@MEDIA screen{color:red}}"
+    ~lower:".a{@media screen{color:red}}" ~expect:".a{@media screen{color:red}}";
+  agrees "@font-face at-rule name"
+    ~upper:"@Font-Face{font-family:F;src:url(a.woff)}"
+    ~lower:"@font-face{font-family:F;src:url(a.woff)}"
 
 (* CSS Values 4 sec. 4.2: an author-defined identifier is "fully case-sensitive
    [...] even in the ASCII range (e.g. example and EXAMPLE are two different,
@@ -1757,6 +1800,19 @@ let spec_author_ident_case_sensitive () =
      [base-palette], so any other ident there is the author's own. *)
   keeps "base-palette ident"
     "@font-palette-values --P{font-family:F;base-palette:MyPalette}" "MyPalette";
+  (* CSS Paged Media 3 sec. 4.3 puts an optional [<ident-token>] before the
+     pseudo-pages; that one is the page's own name. *)
+  keeps "@page name" "@page Invoice:FIRST{margin:1in}" "Invoice";
+  (* A class beside the folded [/deep/] ident is still a name the author
+     chose. *)
+  keeps "class next to /deep/" ".a /DEEP/ .DEEP{color:red}" ".DEEP";
+  (* CSS Values 4 sec. 4.5.1 carries the [<url>] as a string, not an identifier,
+     so nothing in it folds. *)
+  keeps "url path" ".a{background:URL(\"A.PNG\")}" "A.PNG";
+  (* A [var()] reference inside a folded colour function still names a custom
+     property. *)
+  keeps "custom property inside color-mix()"
+    ".a{--Foo:red;color:color-mix(IN srgb,var(--Foo),blue)}" "var(--Foo)";
   (* CSS Syntax 3 sec. 8.2 recognises [@charset] only as the exact byte
      sequence, so the encoding name is not a keyword to fold. *)
   (match of_string ~strict:true "@charset \"utf-8\";.a{color:red}" with
@@ -1808,6 +1864,57 @@ let unknown_at_rule_reaches_output () =
     "pretty output re-parses to the minified output"
     "@future x{a{color:red}}b{color:red}"
     (to_string ~minify:true (parse (to_string (parse input))))
+
+(* Reading an at-rule name as a keyword decides what a miscased name reaches: a
+   name cascade has a grammar for is that grammar, and only a name it has none
+   for stays the [Unknown_at_rule] above. *)
+let spec_at_rule_name_case_insensitive () =
+  let parse input =
+    match of_string ~strict:false input with
+    | Ok parsed -> parsed.stylesheet
+    | Error err ->
+        Alcotest.failf "lenient parse rejected %S: %s" input
+          (Cascade.Error.to_string err)
+  in
+  let render input = to_string ~minify:true (parse input) in
+  let optimized input = to_string ~minify:true (optimize (parse input)) in
+  let rejects name input =
+    match of_string ~strict:true input with
+    | Ok _ -> Alcotest.failf "%s: strict parse accepted %S" name input
+    | Error _ -> ()
+  in
+  (* A name cascade has no grammar for is the keyword of nothing, so CSS Syntax
+     3 sec. 5.4.2 consumes it and it reaches the output as it was written. *)
+  Alcotest.(check string)
+    "an unknown at-rule keeps the case it was written in"
+    "@Foo bar;a{color:red}"
+    (render "@Foo bar;\na{color:red}");
+  Alcotest.(check string)
+    "an unknown at-rule nested in a block keeps its case"
+    "@layer x{@Bar baz;a{color:red}}"
+    (render "@layer x{@Bar baz;a{color:red}}");
+  (* CSS Syntax 3 sec. 8.2 matches [@charset] and the quote after it as an exact
+     byte sequence, so no other spelling of it is the charset rule. *)
+  Alcotest.(check string)
+    "@CHARSET is a name, not the charset rule" "@CHARSET \"UTF-8\";a{color:red}"
+    (render "@CHARSET \"UTF-8\";a{color:red}");
+  (* Read as [@media], the block is the node its lower-case spelling is, so the
+     optimizer treats the two as one. *)
+  let merged =
+    optimized "@media screen{a{color:red}}@media screen{b{color:blue}}"
+  in
+  Alcotest.(check bool)
+    (String.concat ""
+       [ "the lower-case control merges into one block, got "; merged ])
+    true
+    (not (Astring.String.is_infix ~affix:"}@media" merged));
+  Alcotest.(check string)
+    "@MEDIA merges with the @media beside it" merged
+    (optimized "@media screen{a{color:red}}@MEDIA screen{b{color:blue}}");
+  (* The grammar comes with its rejections: a prelude [@media] has no reading
+     for is rejected under every spelling of the name. *)
+  rejects "@media with a malformed prelude" "@media (bad{a{color:red}}";
+  rejects "@MEDIA with a malformed prelude" "@MEDIA (bad{a{color:red}}"
 
 let suite =
   ( "css",
@@ -1883,4 +1990,6 @@ let suite =
         spec_keyword_case_insensitive;
       Alcotest.test_case "spec section 4.2 author ident case is sensitive"
         `Quick spec_author_ident_case_sensitive;
+      Alcotest.test_case "spec section 4.1 at-rule name case is insensitive"
+        `Quick spec_at_rule_name_case_insensitive;
     ] )


### PR DESCRIPTION
An at-rule or function name written in another case, such as `@MEDIA`, `RGB()`, `color-mix(IN srgb, ...)`, `background: URL("a.png")`, `@page :FIRST` or `/DEEP/`, is read as the keyword CSS Values 4 sec. 4.1 says it is. Follow-up to #603, which fixed the cursor helpers; these sites match a name against its own literal outside any helper, so no reader fix reached them.

Folding the at-rule name reaches further than the other five. Where cascade has a grammar for the name, a miscased spelling is no longer an `Unknown_at_rule`: it optimises and merges like the lower-case one, and it is rejected on the preludes that one rejects. Names with no grammar behind them still round-trip as written, `@charset` included, which CSS Syntax 3 sec. 8.2 matches byte-exactly rather than as a keyword.
