### PR TITLE
cli: add cascade prune, which removes the rules a page cannot use

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -912,6 +912,17 @@ recorded cases carrying six minifiers' answers.
 
 ### CLI tools
 
+- `cascade prune PAGE.html... STYLE.css` removes the rules a set of HTML
+  documents cannot use, and `--dry-run` reports instead, ranking what survives
+  by how few elements matched it. A rule goes only when the matcher has a model
+  for its selector and every element answers that it does not match, so
+  `:hover`, a pseudo-element and any selector list holding one such branch are
+  kept and counted apart from the rules the documents used. A `@media`,
+  `@supports` or `@container` condition is never evaluated, since it asks about
+  a device rather than about a document, and a statement naming no element
+  (`@keyframes`, `@font-face`, `@property`, `@layer`) is kept. The documents are
+  all the analysis sees: a class a script adds at runtime is in none of them, so
+  a rule waiting for one is removed (#605)
 - `cascade diff --diff=tree` states a selector's move once. The entry names the
   selector, not the rule, so a selector whose several rules cross together
   printed the same line and counted the move once per rule (#581)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Cascade
 
-A command-line tool for **formatting**, **minifying**, **inlining**, and
-**structurally diffing** CSS. Ships one binary (`cascade`) and, for OCaml users,
-the library it is built on.
+A command-line tool for **formatting**, **minifying**, **inlining**,
+**structurally diffing**, and **pruning** CSS. Ships one binary (`cascade`)
+and, for OCaml users, the library it is built on.
 
 ```text
 $ cascade --minify style.css > style.min.css
@@ -148,6 +148,58 @@ cascade diff reference.css output.css
 cascade diff --diff=tree reference.css output.css
 cascade diff --diff=canonical reference.css output.css
 NO_COLOR=1 cascade diff reference.css output.css
+```
+
+## `cascade prune`: remove the rules a page cannot use
+
+```text
+cascade prune [--dry-run] PAGE.html... STYLE.css
+```
+
+Matches every rule of `STYLE.css` against every element of the given documents
+and writes the stylesheet back without the rules that matched nothing. The
+transform is the output, as it is under `--minify`; `--dry-run` reports instead.
+
+A rule is removed only when the matcher has a model for its selector *and*
+every element answers that it does not match. Keeping those two negatives apart
+is the whole of the analysis: reading "no model" as "does not match" is how a
+dead-rule check deletes a live rule.
+
+- A selector outside what the matcher models (`:hover`, a pseudo-element,
+  `:nth-child()`) is kept and never counted as unused, and so is a selector
+  list holding one such branch. Every branch of a fully modelled list is judged
+  on its own, so `.card, .gone` keeps `.card` and drops `.gone`.
+- A `@media`, `@supports` or `@container` condition is never evaluated. It asks
+  about a device, a user agent or a layout container, none of which a document
+  carries, so the rules inside are judged by their own selectors alone.
+- A statement that names no element (`@keyframes`, `@font-face`, `@property`,
+  `@import`, `@layer`, `@charset`) is kept: a document says nothing about
+  whether it is reached.
+- Nesting is flattened before anything is judged, since a nested selector is
+  written against its parent. Pipe the result through `cascade --minify` to
+  nest it again.
+
+**The documents are the whole of what the analysis sees.** A class a script
+adds at runtime is in none of them, so a rule waiting for one is removed. That
+is the limit of an AST-level dead-rule check: [CILLA](#references) runs the page
+and reads matching off the live DOM instead, which is what answering for a class
+that appears only after a click takes. Check what your scripts add before
+shipping a pruned stylesheet.
+
+`--dry-run` writes the ranking instead. Rules that matched nothing come first,
+then the survivors by ascending matched-element count. The rules kept for want
+of a model are listed and counted apart, since that number is the measure of
+what the analysis could not see.
+
+| Flag | Purpose |
+|---|---|
+| `--dry-run` | Write the ranked report instead of the pruned stylesheet. Rules that matched nothing come first, then the survivors by ascending matched-element count; the rules kept because the matcher has no model for their selector are counted apart. |
+
+<!-- $MDX skip -->
+```bash
+cascade prune src/*.html style.css > style.pruned.css
+cascade prune --dry-run src/*.html style.css
+cascade prune src/*.html style.css | cascade --minify - > style.min.css
 ```
 
 ## In a build, CI, or pre-commit hook
@@ -365,6 +417,9 @@ frameworks.
   context.
 - **Comments and source positions** are not preserved across the
   parser/printer round trip.
+- **`cascade prune` sees only the documents it is given.** A rule whose class
+  a script adds at runtime matches nothing in the parsed HTML, so it is
+  removed.
 - **Unregistered custom properties** stay opaque token streams to the
   optimiser, apart from substreams whose type their own syntax fixes
   unambiguously (complete colour functions, and constant math functions

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -8,26 +8,7 @@
 open Cmdliner
 module Sheet = Cascade.Stylesheet
 module Css = Cascade.Css
-
-(* ---------- the tree ---------- *)
-module Node = struct
-  type t = Html.element
-
-  let equal = ( == )
-  let name (n : t) = Some n.tag
-  let id n = Html.attribute n "id"
-  let classes = Html.classes
-  let attribute = Html.attribute
-  let parent (n : t) = n.parent
-
-  (* [children] is the element children the structural selectors count; text is
-     reported apart because [:empty] counts that too, and a comment counts for
-     neither. *)
-  let children = Html.element_children
-  let text_children = Html.text_children
-end
-
-module Apply = Cascade.Apply.Make (Node)
+module Apply = Cascade.Apply.Make (Html_node)
 
 let err_msg fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
 

--- a/bin/cmd_prune.ml
+++ b/bin/cmd_prune.ml
@@ -1,0 +1,169 @@
+(* [cascade prune <page.html>... <style.css>]: remove the rules no element of
+   the documents can match, or rank what survives by how little it is used. The
+   analysis is {!Cascade.Prune}; this command is the HTML glue and the
+   report. *)
+
+open Cmdliner
+module Css = Cascade.Css
+module Selector = Cascade.Selector
+module Prune = Cascade.Prune
+module P = Prune.Make (Html_node)
+
+let err_msg fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
+
+(* The stylesheet is the last positional so the documents can be a shell glob,
+   and so the order reads the way [cascade apply] takes its two. *)
+let split_inputs files =
+  match List.rev files with
+  | css :: (_ :: _ as rev_docs) -> Ok (List.rev rev_docs, css)
+  | _ -> err_msg "expected one or more HTML documents and then a stylesheet"
+
+(* Cmdliner's [file] conv only checks that the path exists, so a directory or a
+   file with no read permission reaches the command. Reading nothing where a
+   document was named would call its rules unused, so that is a usage error
+   rather than a document with no element in it. *)
+let read_document path =
+  try Ok (Html.roots (Html.parse (Cli_io.read_file path)))
+  with Sys_error msg -> err_msg "Error reading %s: %s" path msg
+
+let read_documents paths =
+  List.fold_left
+    (fun acc path ->
+      Result.bind acc (fun roots ->
+          Result.map (fun r -> roots @ r) (read_document path)))
+    (Ok []) paths
+
+(* The three reasons a rule is where it is, kept apart: what the documents ruled
+   out, what they used, and what they could not answer for. *)
+let split_entries entries =
+  let unused, used, unmodelled =
+    List.fold_left
+      (fun (unused, used, unmodelled) e ->
+        let name = Selector.to_string e.Prune.selector in
+        match e.Prune.verdict with
+        | Prune.Unused -> (name :: unused, used, unmodelled)
+        | Prune.Used n -> (unused, (n, name) :: used, unmodelled)
+        | Prune.Unmodelled -> (unused, used, name :: unmodelled))
+      ([], [], []) entries
+  in
+  ( List.rev unused,
+    List.rev used |> List.stable_sort (fun (a, _) (b, _) -> Int.compare a b),
+    List.rev unmodelled )
+
+let counts ppf ~unused ~used ~unmodelled =
+  Fmt.pf ppf
+    "rules: %d total, %d removed, %d kept as used, %d kept without a verdict@."
+    (unused + used + unmodelled)
+    unused used unmodelled
+
+(* A rule kept for want of a model is the measure of what the analysis cannot
+   see, so it is reported apart from the rules the documents used rather than
+   folded in with them. *)
+let report ~documents (analysis : Prune.analysis) =
+  let unused, used, unmodelled = split_entries analysis.Prune.entries in
+  Fmt.pr "documents: %d, elements: %d@." documents analysis.Prune.elements;
+  if unused <> [] then begin
+    Fmt.pr "@.unused, removed by a run without --dry-run:@.";
+    List.iter (fun name -> Fmt.pr "  %s@." name) unused
+  end;
+  if used <> [] then begin
+    Fmt.pr "@.used, fewest matched elements first:@.";
+    List.iter (fun (n, name) -> Fmt.pr "  %4d  %s@." n name) used
+  end;
+  if unmodelled <> [] then begin
+    Fmt.pr "@.no verdict, kept: the matcher has no model for the selector.@.";
+    List.iter (fun name -> Fmt.pr "  %s@." name) unmodelled
+  end;
+  Fmt.pr "@.";
+  counts Fmt.stdout ~unused:(List.length unused) ~used:(List.length used)
+    ~unmodelled:(List.length unmodelled);
+  Fmt.pr
+    "@.Unused means unused in these documents: a class a script adds at \
+     runtime is not in them.@."
+
+(* [Css.to_buffer] never ends with a newline; a stylesheet on stdout is a text
+   file, so it gets one. *)
+let emit sheet =
+  let buf = Buffer.create 4096 in
+  Css.to_buffer buf sheet;
+  if Buffer.length buf > 0 then Buffer.add_char buf '\n';
+  Buffer.output_buffer stdout buf
+
+let run dry_run files () =
+  match
+    Result.bind (split_inputs files) (fun (docs, css) ->
+        Result.map (fun roots -> (docs, css, roots)) (read_documents docs))
+  with
+  | Error e -> Error e
+  | Ok (docs, css, roots) ->
+      let input = Cli_io.read_input css in
+      Cli_io.check_not_all_dropped input;
+      let analysis = P.analyse ~sheet:input.Cli_io.stylesheet roots in
+      (* Nothing to match against makes every rule look unused, which is an
+         answer about the documents rather than about the stylesheet. *)
+      if analysis.Prune.elements = 0 then begin
+        Fmt.epr
+          "Error: the documents hold no element, so every rule would look \
+           unused@.";
+        Stdlib.exit 1
+      end;
+      if dry_run then report ~documents:(List.length docs) analysis
+      else begin
+        let unused, used, unmodelled = split_entries analysis.Prune.entries in
+        counts Fmt.stderr ~unused:(List.length unused) ~used:(List.length used)
+          ~unmodelled:(List.length unmodelled);
+        emit analysis.Prune.sheet
+      end;
+      Ok ()
+
+let dry_run_arg =
+  let doc =
+    "Write the ranked report instead of the pruned stylesheet: what would go, \
+     what stays and how few elements matched it, and what was kept for want of \
+     a model."
+  in
+  Arg.(value & flag & info [ "dry-run" ] ~doc)
+
+let files_arg =
+  let doc = "The HTML documents to match against, then the stylesheet." in
+  Arg.(value & pos_all file [] & info [] ~docv:"PAGE.html... STYLE.css" ~doc)
+
+let term = Term.(const run $ dry_run_arg $ files_arg $ const ())
+
+let cmd =
+  let doc = "Remove the CSS rules a set of documents cannot use" in
+  let man =
+    [
+      `S Manpage.s_description;
+      `P
+        "Match every rule of $(i,STYLE.css) against every element of the given \
+         documents and write the stylesheet back without the rules that \
+         matched nothing.";
+      `P
+        "A rule is removed only when the matcher has a model for its selector \
+         and every element answers that it does not match. A selector outside \
+         what the matcher models ($(b,:hover), a pseudo-element, \
+         $(b,:nth-child())) is kept and never counted as unused, and so is a \
+         selector list with one such branch. A $(b,@media), $(b,@supports) or \
+         $(b,@container) condition is never evaluated: it asks about a device, \
+         not about a document, so the rules inside are judged by their own \
+         selectors. A statement that names no element ($(b,@keyframes), \
+         $(b,@font-face), $(b,@property), $(b,@import), $(b,@layer)) is kept.";
+      `P
+        "The documents are the whole of what the analysis sees. A class a \
+         script adds at runtime is not in them, so a rule waiting for one is \
+         removed; check those before shipping the result.";
+      `P
+        "Nesting is flattened before anything is judged, since a nested \
+         selector is written against its parent. Pipe the result through \
+         $(b,cascade --minify) to nest it again.";
+      `S Manpage.s_exit_status;
+      `P "$(tname) exits with:";
+      `I ("0", "on success");
+      `I
+        ( "1",
+          "if the documents hold no element, or the stylesheet parsed to \
+           nothing" );
+    ]
+  in
+  Cmd.v (Cmd.info "prune" ~doc ~man) Term.(term_result term)

--- a/bin/cmd_prune.ml
+++ b/bin/cmd_prune.ml
@@ -118,9 +118,10 @@ let run dry_run files () =
 
 let dry_run_arg =
   let doc =
-    "Write the ranked report instead of the pruned stylesheet: what would go, \
-     what stays and how few elements matched it, and what was kept for want of \
-     a model."
+    "Write the ranked report instead of the pruned stylesheet. Rules that \
+     matched nothing come first, then the survivors by ascending \
+     matched-element count; the rules kept for want of a model are counted \
+     apart."
   in
   Arg.(value & flag & info [ "dry-run" ] ~doc)
 

--- a/bin/html_node.ml
+++ b/bin/html_node.ml
@@ -1,0 +1,17 @@
+(* The tree {!Cascade.Resolve} walks: an {!Html} element, read through the
+   parent and child links markup.ml left on it. *)
+
+type t = Html.element
+
+let equal = ( == )
+let name (n : t) = Some n.Html.tag
+let id n = Html.attribute n "id"
+let classes = Html.classes
+let attribute = Html.attribute
+let parent (n : t) = n.Html.parent
+
+(* [children] is the element children the structural selectors count; text is
+   reported apart because [:empty] counts that too, and a comment counts for
+   neither. *)
+let children = Html.element_children
+let text_children = Html.text_children

--- a/bin/html_node.mli
+++ b/bin/html_node.mli
@@ -1,0 +1,4 @@
+(** An {!Html} element as a {!Cascade.Resolve.NODE}, so the library can match
+    selectors and resolve the cascade against a parsed page. *)
+
+include Cascade.Resolve.NODE with type t = Html.element

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -8,9 +8,10 @@ let info =
     [
       `S Manpage.s_description;
       `P
-        "Cascade ships three subcommands: $(b,fmt) (format, minify, inline \
-         imports), $(b,diff) (structural CSS diff) and $(b,apply) (resolve a \
-         stylesheet into an HTML page's inline styles). When no subcommand is \
+        "Cascade ships four subcommands: $(b,fmt) (format, minify, inline \
+         imports), $(b,diff) (structural CSS diff), $(b,apply) (resolve a \
+         stylesheet into an HTML page's inline styles) and $(b,prune) (remove \
+         the rules a set of documents cannot use). When no subcommand is \
          given, $(b,fmt) is used.";
       `S Manpage.s_bugs;
       `P "Report bugs at https://github.com/samoht/cascade";
@@ -20,9 +21,11 @@ let info =
 
 let cmd =
   Cmd.group info ~default:Cmd_fmt.term
-    [ Cmd_fmt.cmd; Cmd_diff.cmd; Cmd_apply.cmd ]
+    [ Cmd_fmt.cmd; Cmd_diff.cmd; Cmd_apply.cmd; Cmd_prune.cmd ]
 
-let known_subcommand = function "fmt" | "diff" | "apply" -> true | _ -> false
+let known_subcommand = function
+  | "fmt" | "diff" | "apply" | "prune" -> true
+  | _ -> false
 
 let help_or_version = function
   | "--help" | "-h" | "--version" -> true

--- a/lib/dune
+++ b/lib/dune
@@ -97,6 +97,7 @@
   pool.mli
   preflight.mli
   pp.mli
+  prune.mli
   properties.mli
   reader.mli
   resolve.mli

--- a/lib/prune.ml
+++ b/lib/prune.ml
@@ -1,0 +1,128 @@
+(* Remove the rules a set of documents cannot use. The matching is {!Resolve};
+   this decides what a No_match may be read as, which is the whole of the
+   analysis: [Unsupported] is not a No_match, so a selector with no model is
+   kept and never counted against the stylesheet. *)
+
+type verdict = Unused | Used of int | Unmodelled
+type entry = { selector : Selector.t; verdict : verdict }
+type analysis = { sheet : Stylesheet.t; entries : entry list; elements : int }
+
+module Make (Node : Resolve.NODE) = struct
+  module R = Resolve.Make (Node)
+
+  let rec collect acc node =
+    List.fold_left collect (node :: acc) (Node.children node)
+
+  let matched elements sel =
+    List.fold_left
+      (fun n e ->
+        match R.match_selector sel e with
+        | Resolve.Matches -> n + 1
+        | Resolve.No_match | Resolve.Unsupported -> n)
+      0 elements
+
+  (* [supported] settles the question before any element is looked at, which is
+     what keeps [Unused] a statement about the documents: were the count taken
+     first, a selector the matcher cannot decide would come back at zero and
+     read as ruled out. *)
+  let judge elements (r : Stylesheet.rule) =
+    match r.nested with
+    | _ :: _ -> Unmodelled
+    | [] -> (
+        if not (Resolve.supported r.selector) then Unmodelled
+        else match matched elements r.selector with 0 -> Unused | n -> Used n)
+
+  (* Selectors 4 sec. 3.3: a selector list is a set of selectors, each matching
+     on its own and carrying its own specificity (sec. 17), so a branch nothing
+     matches goes while the rest of the rule stays. A list is supported only
+     when every branch is, so every branch reached here is modelled. *)
+  let live_branches elements sel =
+    match Selector.as_list sel with
+    | None -> None
+    | Some branches -> (
+        match List.filter (fun b -> matched elements b > 0) branches with
+        | kept when List.compare_lengths kept branches = 0 -> None
+        | [] -> None
+        | [ one ] -> Some one
+        | kept -> Some (Selector.list kept))
+
+  let rec block elements acc stmts =
+    let acc, out =
+      List.fold_left
+        (fun (acc, out) stmt ->
+          match statement elements acc stmt with
+          | acc, None -> (acc, out)
+          | acc, Some s -> (acc, s :: out))
+        (acc, []) stmts
+    in
+    (acc, List.rev out)
+
+  and statement elements acc stmt =
+    (* A group block left with nothing goes with its rules: the condition it
+       carries guards no declaration any more. [@layer] is the exception, since
+       an empty one still declares a layer the cascade orders by (css-cascade-5
+       sec. 6.4.4). *)
+    let group acc body rebuild =
+      let acc, pruned = block elements acc body in
+      match (body, pruned) with
+      | _ :: _, [] -> (acc, None)
+      | _ -> (acc, Some (rebuild pruned))
+    in
+    match stmt with
+    | Stylesheet.Rule r ->
+        let selector = r.selector in
+        let verdict = judge elements r in
+        let acc = { selector; verdict } :: acc in
+        let kept =
+          match verdict with
+          | Unused -> None
+          | Unmodelled -> Some stmt
+          | Used _ -> (
+              match live_branches elements selector with
+              | None -> Some stmt
+              | Some selector -> Some (Stylesheet.Rule { r with selector }))
+        in
+        (acc, kept)
+    | Stylesheet.Layer (name, body) ->
+        let acc, pruned = block elements acc body in
+        (acc, Some (Stylesheet.Layer (name, pruned)))
+    | Stylesheet.Media (query, body) ->
+        group acc body (fun b -> Stylesheet.Media (query, b))
+    | Stylesheet.Supports (cond, body) ->
+        group acc body (fun b -> Stylesheet.Supports (cond, b))
+    | Stylesheet.Container (name, cond, body) ->
+        group acc body (fun b -> Stylesheet.Container (name, cond, b))
+    | Stylesheet.Moz_document (conds, body) ->
+        group acc body (fun b -> Stylesheet.Moz_document (conds, b))
+    | Stylesheet.Starting_style body ->
+        group acc body (fun b -> Stylesheet.Starting_style b)
+    | Stylesheet.When (cond, body) ->
+        group acc body (fun b -> Stylesheet.When (cond, b))
+    | Stylesheet.Else (cond, body) ->
+        group acc body (fun b -> Stylesheet.Else (cond, b))
+    | Stylesheet.Scope (root, limit, body) ->
+        (* The scoping root is not judged: css-cascade-6 puts the elements in
+           scope behind a proximity criterion the matcher does not model, so a
+           root that matches nothing here says nothing about the rules
+           inside. *)
+        group acc body (fun b -> Stylesheet.Scope (root, limit, b))
+    | Stylesheet.Origin (origin, body) ->
+        group acc body (fun b -> Stylesheet.Origin (origin, b))
+    (* Nothing here names an element, so no document can rule it out. *)
+    | Stylesheet.Declarations _ | Stylesheet.Bang_comment _
+    | Stylesheet.Charset _ | Stylesheet.Import _ | Stylesheet.Namespace _
+    | Stylesheet.Property _ | Stylesheet.Layer_decl _
+    | Stylesheet.Supports_condition _ | Stylesheet.Keyframes _
+    | Stylesheet.Webkit_keyframes _ | Stylesheet.Moz_keyframes _
+    | Stylesheet.Font_face _ | Stylesheet.Counter_style _ | Stylesheet.Page _
+    | Stylesheet.Page_with_margins _ | Stylesheet.Font_palette_values _
+    | Stylesheet.Font_feature_values _ | Stylesheet.View_transition _
+    | Stylesheet.Position_try _ | Stylesheet.Viewport _
+    | Stylesheet.Unknown_at_rule _ ->
+        (acc, Some stmt)
+
+  let analyse ~sheet roots =
+    let elements = List.fold_left collect [] roots in
+    let entries, sheet = block elements [] (Flatten.block sheet) in
+    { sheet; entries = List.rev entries; elements = List.length elements }
+end

--- a/lib/prune.mli
+++ b/lib/prune.mli
@@ -1,0 +1,55 @@
+(** Remove the rules a set of documents cannot use.
+
+    A rule is removed only when {!Resolve.supported} holds for its selector and
+    every element of every document answers {!Resolve.constructor-No_match}. A
+    selector the matcher has no model for is kept and never counted as unused:
+    {!Resolve.constructor-Unsupported} is not "does not match", so reading it as
+    one deletes a rule nothing ruled out.
+
+    Only selectors are read. A [@media], [@supports] or [@container] condition
+    asks about a device, a user agent or a layout container, none of which a
+    document carries, so the rules inside a group block are judged by their own
+    selectors and the condition is left alone. A statement with no selector -
+    [@keyframes], [@font-face], [@property], [@import], [@layer], [@charset] -
+    names nothing a document can rule out and is kept.
+
+    Nesting is flattened as by {!Css.flatten_nesting} before anything is judged,
+    so the result is flat: a nested selector is written against its parent and
+    decides nothing on its own.
+
+    The documents are the whole of what this sees. A class a script adds at
+    runtime is not in them, so a rule waiting for one is removed. *)
+
+(** What the documents said about a rule. *)
+type verdict =
+  | Unused
+      (** Every element answered no, so nothing in the documents uses it. *)
+  | Used of int  (** This many elements matched. *)
+  | Unmodelled
+      (** Nothing ruled it out: {!Resolve.supported} does not hold for its
+          selector, or the rule still carries nesting, whose children are
+          written against it. *)
+
+type entry = { selector : Selector.t; verdict : verdict }
+(** One rule of the analysed sheet, with the selector as it was written. A rule
+    whose selector list lost an unused branch keeps the whole list here: the
+    entry reports on the source, the sheet carries the result. *)
+
+type analysis = {
+  sheet : Stylesheet.t;  (** The flattened sheet with every unused rule gone. *)
+  entries : entry list;  (** Every rule that was judged, in source order. *)
+  elements : int;  (** How many elements the documents hold. *)
+}
+(** What a set of documents says about a stylesheet. *)
+
+module Make (Node : Resolve.NODE) : sig
+  val analyse : sheet:Stylesheet.t -> Node.t list -> analysis
+  (** [analyse ~sheet roots] judges every rule of [sheet] against the elements
+      of the trees rooted at [roots], and is [sheet] with the unused ones
+      removed alongside the verdict for each.
+
+      [roots] holding no element between them makes every rule look unused. That
+      is an answer about the documents rather than about [sheet], and the caller
+      has to tell the two apart: {!field-elements} is [0] and every rule is
+      reported {!constructor-Unused}. *)
+end

--- a/test/cli/prune.t
+++ b/test/cli/prune.t
@@ -1,0 +1,258 @@
+CLI: [cascade prune] removes the rules the documents cannot match.
+
+A rule is removed only when the matcher has a model for its selector
+and every element of every document answers No_match. Selectors 4
+describes far more than a matcher with no browser behind it can decide,
+which is why resolve.mli splits the negative answer in two: Unsupported
+is not "does not match", so a selector with no model is kept and is
+never counted as unused.
+
+  $ cat > page.html <<EOF
+  > <html><head></head><body>
+  > <div class="card"><p>one</p></div>
+  > <p>two</p>
+  > </body></html>
+  > EOF
+
+
+# What goes and what stays
+
+
+[.unused] matches no element of the page, so it goes. [:root] matches
+the [<html>] element (Selectors 4 sec. 8.1), [p] matches two elements,
+and [.card:hover] is a stateful pseudo-class the matcher has no model
+for, so it is kept without a verdict rather than ruled out.
+
+  $ cat > basic.css <<EOF
+  > :root { --brand: red }
+  > .card { color: var(--brand) }
+  > .unused { color: blue }
+  > p { margin: 0 }
+  > .card:hover { color: green }
+  > EOF
+  $ cascade prune page.html basic.css
+  rules: 5 total, 1 removed, 3 kept as used, 1 kept without a verdict
+  :root {
+    --brand: red;
+  }
+  .card {
+    color: var(--brand);
+  }
+  p {
+    margin: 0;
+  }
+  .card:hover {
+    color: green;
+  }
+
+A rule live in any one of the documents survives. [.badge] is nowhere
+in the first page and [.card] is nowhere in the second.
+
+  $ cat > other.html <<EOF
+  > <html><head></head><body><span class="badge">b</span></body></html>
+  > EOF
+  $ cat > two.css <<EOF
+  > .badge { color: red }
+  > .card { color: blue }
+  > .neither { color: green }
+  > EOF
+  $ cascade prune page.html other.html two.css
+  rules: 3 total, 1 removed, 2 kept as used, 0 kept without a verdict
+  .badge {
+    color: red;
+  }
+  .card {
+    color: blue;
+  }
+
+
+# A condition is not a selector
+
+
+[@media], [@supports] and [@container] ask about the device, the user
+agent and a layout container, none of which a document carries. So the
+condition is never evaluated: the rules inside are judged by their own
+selectors, and [@media print] survives because [.card] matches. A group
+block left with nothing goes with its rules; a [@layer] block stays,
+emptied or not, because it declares a layer that orders the cascade.
+
+  $ cat > cond.css <<EOF
+  > @media print { .card { color: black } }
+  > @supports (display: grid) { .nowhere { display: grid } }
+  > @layer base { .card { margin: 0 } .nowhere { margin: 1px } }
+  > EOF
+  $ cascade prune page.html cond.css
+  rules: 4 total, 2 removed, 2 kept as used, 0 kept without a verdict
+  @media print {
+    .card {
+      color: black;
+    }
+  }
+  @layer base {
+    .card {
+      margin: 0;
+    }
+  }
+
+
+# A statement with no selector is never unused
+
+
+[@charset], [@import], [@layer], [@font-face], [@keyframes] and
+[@property] name nothing this analysis can rule out: they register a
+font, a name or a property, and a document says nothing about whether
+they are reached. Only [.gone] is decided here.
+
+  $ cat > atrules.css <<EOF
+  > @charset "UTF-8";
+  > @import url("theme.css");
+  > @layer base, theme;
+  > @font-face { font-family: Brand; src: url("brand.woff2") }
+  > @keyframes fade { from { opacity: 0 } }
+  > @property --gap { syntax: "<length>"; inherits: false; initial-value: 1rem }
+  > .gone { color: red }
+  > EOF
+  $ cascade prune page.html atrules.css
+  rules: 1 total, 1 removed, 0 kept as used, 0 kept without a verdict
+  @charset "UTF-8";
+  @import "theme.css";
+  @layer base, theme;
+  @font-face {
+    font-family: Brand;
+    src: url("brand.woff2");
+  }
+  @keyframes fade {
+    from {
+      opacity: 0;
+    }
+  }
+  @property --gap {
+    syntax: "<length>";
+    inherits: false;
+    initial-value: 1rem;
+  }
+
+
+# A selector list is only as modelled as its least modelled branch
+
+
+Each branch of a selector list matches on its own and carries its own
+specificity (Selectors 4 sec. 3.3, sec. 17), so a branch that matches
+nothing can go while the rest of the rule stays.
+
+  $ cat > list.css <<EOF
+  > .card, .nowhere { color: red }
+  > EOF
+  $ cascade prune page.html list.css
+  rules: 1 total, 0 removed, 1 kept as used, 0 kept without a verdict
+  .card {
+    color: red;
+  }
+
+One unmodelled branch leaves the whole list without a verdict, so the
+rule is kept as written. Dropping [.nowhere] here would rest on a
+No_match the matcher never gave for the list it belongs to.
+
+  $ cat > mixed.css <<EOF
+  > .nowhere, .card:hover { color: red }
+  > EOF
+  $ cascade prune page.html mixed.css
+  rules: 1 total, 0 removed, 0 kept as used, 1 kept without a verdict
+  .nowhere, .card:hover {
+    color: red;
+  }
+
+
+# A custom property a removed rule declares
+
+
+A custom property reaches an element through a rule that matched it, or
+by inheritance from an ancestor a rule matched. [.theme-dark] matched
+nothing, so nothing in this document ever carried [--bg] and
+[var(--bg)] already resolved to its guaranteed-invalid value: removing
+the declaration changes no computed value here. [:root] is the case
+that matters in practice, and it survives on [<html>].
+
+  $ cat > vars.css <<EOF
+  > :root { --brand: red }
+  > .theme-dark { --bg: black }
+  > body { background: var(--bg); color: var(--brand) }
+  > EOF
+  $ cascade prune page.html vars.css
+  rules: 3 total, 1 removed, 2 kept as used, 0 kept without a verdict
+  :root {
+    --brand: red;
+  }
+  body {
+    background: var(--bg);
+    color: var(--brand);
+  }
+
+
+# Only text nodes decide :empty
+
+
+Selectors 4 sec. 13.2 counts element nodes and non-empty text nodes; a
+comment is neither, so [#b] is empty and [#c] is not.
+
+  $ cat > empty-page.html <<EOF
+  > <html><head></head><body>
+  > <p id="a"></p>
+  > <p id="b"><!-- c --></p>
+  > <p id="c">x</p>
+  > </body></html>
+  > EOF
+  $ cat > empty.css <<EOF
+  > p:empty { color: red }
+  > EOF
+  $ cascade prune --dry-run empty-page.html empty.css
+  documents: 1, elements: 6
+  
+  used, fewest matched elements first:
+       2  p:empty
+  
+  rules: 1 total, 0 removed, 1 kept as used, 0 kept without a verdict
+  
+  Unused means unused in these documents: a class a script adds at runtime is not in them.
+
+
+# The ranked report
+
+
+[--dry-run] writes the ranking instead of the pruned stylesheet: what
+would go, then what stays ordered by how few elements it matched, then
+what was kept for want of a model. The last count is the measure of
+what the analysis cannot see.
+
+  $ cascade prune --dry-run page.html basic.css
+  documents: 1, elements: 6
+  
+  unused, removed by a run without --dry-run:
+    .unused
+  
+  used, fewest matched elements first:
+       1  :root
+       1  .card
+       2  p
+  
+  no verdict, kept: the matcher has no model for the selector.
+    .card:hover
+  
+  rules: 5 total, 1 removed, 3 kept as used, 1 kept without a verdict
+  
+  Unused means unused in these documents: a class a script adds at runtime is not in them.
+
+
+# Nothing to match against
+
+
+A document set with no element makes every rule look unused, which is
+an answer about the input rather than about the stylesheet.
+
+  $ printf '' > blank.html
+  $ cascade prune blank.html basic.css
+  Error: the documents hold no element, so every rule would look unused
+  [1]
+  $ cascade prune --dry-run blank.html basic.css
+  Error: the documents hold no element, so every rule would look unused
+  [1]

--- a/test/test.ml
+++ b/test/test.ml
@@ -47,6 +47,7 @@ let () =
       Test_rule.suite;
       Test_rule_index.suite;
       Test_apply.suite;
+      Test_prune.suite;
       Test_factor.suite;
       Test_block.suite;
       Test_cover.suite;

--- a/test/test_prune.ml
+++ b/test/test_prune.ml
@@ -1,0 +1,217 @@
+open Cascade
+
+type node = {
+  name : string;
+  id : string option;
+  classes : string list;
+  attrs : (string * string) list;
+  texts : string list;
+  mutable parent : node option;
+  children : node list;
+}
+
+module Node = struct
+  type t = node
+
+  let equal = ( == )
+  let name n = Some n.name
+  let id n = n.id
+  let classes n = n.classes
+  let attribute n key = List.assoc_opt key n.attrs
+  let parent n = n.parent
+  let children n = n.children
+
+  (* Only text counts, as {!Resolve.NODE} states: a comment is not a text node,
+     so an element holding one alone is still [:empty]. The fixtures below give
+     [texts] and children apart for exactly that reason. *)
+  let text_children n = n.texts
+end
+
+module P = Prune.Make (Node)
+
+let node ?id ?(classes = []) ?(attrs = []) ?(texts = []) ?(children = []) name =
+  let n = { name; id; classes; attrs; texts; parent = None; children } in
+  List.iter (fun c -> c.parent <- Some n) children;
+  n
+
+(* The fixtures are all meant to parse; one that does not is a broken test, not
+   a case under test. *)
+let parse css =
+  match Css.of_string css with
+  | Ok p -> p.Css.stylesheet
+  | Error e -> Alcotest.failf "fixture did not parse: %s" (Error.to_string e)
+
+let verdict =
+  let pp ppf = function
+    | Prune.Unused -> Fmt.string ppf "unused"
+    | Prune.Used n -> Fmt.pf ppf "used %d" n
+    | Prune.Unmodelled -> Fmt.string ppf "unmodelled"
+  in
+  let equal a b =
+    match (a, b) with
+    | Prune.Unused, Prune.Unused | Prune.Unmodelled, Prune.Unmodelled -> true
+    | Prune.Used a, Prune.Used b -> Int.equal a b
+    | (Prune.Unused | Prune.Used _ | Prune.Unmodelled), _ -> false
+  in
+  Alcotest.testable pp equal
+
+(* A page with one [.card] holding a paragraph, plus a bare paragraph. *)
+let page () =
+  node "html"
+    ~children:
+      [
+        node "body"
+          ~children:
+            [
+              node "div" ~classes:[ "card" ]
+                ~children:[ node "p" ~texts:[ "one" ] ];
+              node "p" ~texts:[ "two" ];
+            ];
+      ]
+
+let analyse css = P.analyse ~sheet:(parse css) [ page () ]
+let css result = Css.to_string ~minify:true result.Prune.sheet
+let verdicts result = List.map (fun e -> e.Prune.verdict) result.Prune.entries
+
+let check_verdicts msg expected result =
+  Alcotest.(check (list verdict)) msg expected (verdicts result)
+
+let removes_a_rule_no_element_matches () =
+  let r = analyse ".card{color:red}.gone{color:blue}" in
+  check_verdicts "verdicts" [ Prune.Used 1; Prune.Unused ] r;
+  Alcotest.(check string) "sheet" ".card{color:red}" (css r)
+
+let counts_every_matched_element () =
+  let r = analyse "p{margin:0}" in
+  check_verdicts "verdicts" [ Prune.Used 2 ] r;
+  Alcotest.(check int) "elements" 5 r.Prune.elements
+
+(* [Unsupported] is not a No_match: the matcher has no model for [:hover], so no
+   element ruled the rule out and it stays. *)
+let keeps_a_selector_the_matcher_cannot_decide () =
+  let r = analyse ".gone:hover{color:red}" in
+  check_verdicts "verdicts" [ Prune.Unmodelled ] r;
+  Alcotest.(check string) "sheet" ".gone:hover{color:red}" (css r)
+
+(* Selectors 4 sec. 8.1: [:root] is the document's root element. *)
+let root_matches_the_root_element () =
+  let r = analyse ":root{--brand:red}" in
+  check_verdicts "verdicts" [ Prune.Used 1 ] r;
+  Alcotest.(check string) "sheet" ":root{--brand:red}" (css r)
+
+(* Selectors 4 sec. 13.2 counts element nodes and non-empty text nodes, so the
+   paragraph holding text is not [:empty] and the two divs with neither are. *)
+let empty_reads_text_children_only () =
+  let tree =
+    node "html"
+      ~children:
+        [
+          node "div" ~children:[];
+          node "div" ~texts:[ "x" ];
+          node "div" ~children:[ node "span" ];
+        ]
+  in
+  let r = P.analyse ~sheet:(parse "div:empty{color:red}") [ tree ] in
+  check_verdicts "verdicts" [ Prune.Used 1 ] r
+
+(* A condition is a question about the device, not about the document, so the
+   rules inside a group block are judged by their own selectors. *)
+let a_condition_is_not_a_selector () =
+  let r = analyse "@media print{.card{color:red}}" in
+  check_verdicts "verdicts" [ Prune.Used 1 ] r;
+  Alcotest.(check string) "sheet" "@media print{.card{color:red}}" (css r)
+
+let drops_a_group_block_left_with_nothing () =
+  let r = analyse "@supports (display:grid){.gone{display:grid}}p{margin:0}" in
+  check_verdicts "verdicts" [ Prune.Unused; Prune.Used 2 ] r;
+  Alcotest.(check string) "sheet" "p{margin:0}" (css r)
+
+(* A layer left with no rule still declares the layer the cascade orders by
+   (css-cascade-5 sec. 6.4.4.2), so it survives its rules; minified, the
+   statement form is how that declaration is spelled. *)
+let keeps_a_layer_block_left_with_nothing () =
+  let r = analyse "@layer base{.gone{color:red}}" in
+  check_verdicts "verdicts" [ Prune.Unused ] r;
+  Alcotest.(check string) "sheet" "@layer base;" (css r)
+
+let keeps_a_statement_with_no_selector () =
+  let source =
+    "@font-face{font-family:Brand;src:url(b.woff2)}@keyframes \
+     fade{0%{opacity:0}}@property \
+     --gap{syntax:\"<length>\";inherits:false;initial-value:1rem}"
+  in
+  let r = analyse source in
+  check_verdicts "no rule was judged" [] r;
+  Alcotest.(check string) "sheet" source (css r)
+
+(* A list is only as modelled as its least modelled branch, so one unmodelled
+   branch leaves the whole rule without a verdict. Dropping [.gone] here would
+   rest on a No_match the matcher never gave for the list it belongs to. *)
+let keeps_a_list_holding_an_unmodelled_branch () =
+  let r = analyse ".gone,.card:hover{color:red}" in
+  check_verdicts "verdicts" [ Prune.Unmodelled ] r;
+  Alcotest.(check string) "sheet" ".gone,.card:hover{color:red}" (css r)
+
+(* Each branch of a modelled list matches on its own and carries its own
+   specificity (Selectors 4 sec. 3.3, sec. 17), so the unused one goes. *)
+let drops_the_unused_branch_of_a_modelled_list () =
+  let r = analyse ".card,.gone{color:red}" in
+  check_verdicts "verdicts" [ Prune.Used 1 ] r;
+  Alcotest.(check string) "sheet" ".card{color:red}" (css r)
+
+(* A custom property reaches an element through a rule that matched it, or by
+   inheritance from an ancestor a rule matched. [.gone] matched nothing, so
+   nothing here ever carried [--bg] and [var(--bg)] already resolved to its
+   guaranteed-invalid value. *)
+let removes_an_unused_rule_that_declares_a_custom_property () =
+  let r = analyse ".gone{--bg:black}p{background:var(--bg)}" in
+  check_verdicts "verdicts" [ Prune.Unused; Prune.Used 2 ] r;
+  Alcotest.(check string) "sheet" "p{background:var(--bg)}" (css r)
+
+(* Nesting is flattened first, so the nested rule is judged on the selector it
+   resolves to rather than on the [&] it was written with. *)
+let judges_a_nested_rule_on_its_flattened_selector () =
+  let r = analyse ".card{color:red;& span{color:blue}}" in
+  check_verdicts "verdicts" [ Prune.Used 1; Prune.Unused ] r;
+  Alcotest.(check string) "sheet" ".card{color:red}" (css r)
+
+(* Documents with no element between them make every rule look unused. The count
+   is what tells a caller that is an answer about the input. *)
+let no_element_leaves_every_rule_unused () =
+  let r = P.analyse ~sheet:(parse ".card{color:red}") [] in
+  check_verdicts "verdicts" [ Prune.Unused ] r;
+  Alcotest.(check int) "elements" 0 r.Prune.elements
+
+let suite =
+  ( "prune",
+    [
+      Alcotest.test_case "removes a rule no element matches" `Quick
+        removes_a_rule_no_element_matches;
+      Alcotest.test_case "counts every matched element" `Quick
+        counts_every_matched_element;
+      Alcotest.test_case "keeps a selector the matcher cannot decide" `Quick
+        keeps_a_selector_the_matcher_cannot_decide;
+      Alcotest.test_case "root matches the root element" `Quick
+        root_matches_the_root_element;
+      Alcotest.test_case "empty reads text children only" `Quick
+        empty_reads_text_children_only;
+      Alcotest.test_case "a condition is not a selector" `Quick
+        a_condition_is_not_a_selector;
+      Alcotest.test_case "drops a group block left with nothing" `Quick
+        drops_a_group_block_left_with_nothing;
+      Alcotest.test_case "keeps a layer block left with nothing" `Quick
+        keeps_a_layer_block_left_with_nothing;
+      Alcotest.test_case "keeps a statement with no selector" `Quick
+        keeps_a_statement_with_no_selector;
+      Alcotest.test_case "keeps a list holding an unmodelled branch" `Quick
+        keeps_a_list_holding_an_unmodelled_branch;
+      Alcotest.test_case "drops the unused branch of a modelled list" `Quick
+        drops_the_unused_branch_of_a_modelled_list;
+      Alcotest.test_case
+        "removes an unused rule that declares a custom property" `Quick
+        removes_an_unused_rule_that_declares_a_custom_property;
+      Alcotest.test_case "judges a nested rule on its flattened selector" `Quick
+        judges_a_nested_rule_on_its_flattened_selector;
+      Alcotest.test_case "no element leaves every rule unused" `Quick
+        no_element_leaves_every_rule_unused;
+    ] )

--- a/test/test_prune.mli
+++ b/test/test_prune.mli
@@ -1,0 +1,4 @@
+(** Unit tests for [Prune]. *)
+
+val suite : string * unit Alcotest.test_case list
+(** Alcotest suite for the [Prune] module. *)


### PR DESCRIPTION
`cascade prune PAGE.html... STYLE.css` removes the rules no element of the given documents can match; `--dry-run` ranks what survives by how few elements matched it instead. A rule goes only when the matcher has a model for its selector and every element answers `No_match`, so a selector `Resolve.supported` does not cover is kept and counted apart rather than ruled out.

The documents are all the analysis sees, so a class a script adds at runtime reads as unused and its rule is removed; the README says so and points at CILLA. Stacked on #604.
