### PR TITLE
resolve: answer the selectors Selectors 4 decides from the element tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -808,6 +808,19 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- `Css.Resolve` answers the selectors Selectors 4 settles from the element tree
+  a `NODE` supplies: `:nth-child()` and `:nth-last-child()` with or without
+  their `of S` argument, the typed `:nth-of-type()`, `:nth-last-of-type()`,
+  `:first-of-type`, `:last-of-type` and `:only-of-type`, the relational
+  `:has()`, the `i` and `s` attribute case flags, and `:scope`, which names the
+  root of the tree when no scoping root is given (sec. 8.4). Each read
+  `Unsupported` before, which says the matcher has no model rather than that
+  the selector missed, so a rule carrying one could neither be resolved against
+  an element nor pruned, and `Css.Apply` kept it in the sheet rather than
+  projecting it. `Unsupported` still carries through `:is()`, `:not()`,
+  `:has()`, an `of S` and a selector list, so a `No_match` is still a fact
+  about the element. A namespace and `:lang()` stay unsupported: a `NODE`
+  carries neither the namespace nor the document's content language (#607)
 - `Css.unknown_at_rule` builds an at-rule cascade has no grammar for, such as
   one a tool of the caller's own defines. Such a rule could be read from the AST
   but not constructed, so emitting one meant assembling a sheet as text and

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -63,6 +63,24 @@ let attr_key : Selector.attr_name -> string = function
   | Selector.Data s -> "data-" ^ s
   | Selector.Aria a -> Aria.to_string a
 
+(* The An+B microsyntax (css-syntax-3 sec. 6), where [odd] is [2n+1] and [even]
+   is [2n]. It "represents any index i = An + B for any non-negative integer n"
+   (selectors-4 sec. 13.3.1), so an index hits when [i - B] is [A] times a
+   non-negative integer: with [A] zero that leaves the single index [B], and
+   with [A] negative it counts back down towards the start of the list. Indices
+   run from 1 (sec. 13), so a B below it, as in [10n-1], simply drops the terms
+   the list has no room for. *)
+let an_plus_b : Selector.nth -> int * int = function
+  | Selector.Odd -> (2, 1)
+  | Selector.Even -> (2, 0)
+  | Selector.Index b -> (0, b)
+  | Selector.An_plus_b (a, b) -> (a, b)
+
+let nth_hits nth i =
+  let a, b = an_plus_b nth in
+  let d = i - b in
+  if a = 0 then d = 0 else d mod a = 0 && d / a >= 0
+
 (* Cascade layers. Layer names form a tree: [@layer a.b] names the sublayer [b]
    of [a], and so does [@layer a { @layer b { ... } }]. The cascade only needs
    the flattened pre-order of that tree, so a layer is keyed by its path - the
@@ -209,9 +227,22 @@ module Make (N : NODE) = struct
         in
         before [] (N.children p)
 
+  let following_siblings n =
+    match N.parent n with
+    | None -> []
+    | Some p ->
+        let rec after = function
+          | [] -> []
+          | x :: rest when N.equal x n -> rest
+          | _ :: rest -> after rest
+        in
+        after (N.children p)
+
   let imm_pred n =
     match List.rev (preceding_siblings n) with x :: _ -> Some x | [] -> None
 
+  let rec subtree n = n :: List.concat_map subtree (N.children n)
+  let descendants n = List.concat_map subtree (N.children n)
   let is_first n = preceding_siblings n = []
 
   let is_last n =
@@ -223,23 +254,97 @@ module Make (N : NODE) = struct
   let rec ancestors n =
     match N.parent n with None -> [] | Some p -> p :: ancestors p
 
-  let attr_matches n name (m : Selector.attribute_match) =
+  (* selectors-4 sec. 6.3: an [i] flag makes a UA "match the attribute's value
+     ASCII case-insensitively", an [s] flag makes it match "case-sensitively,
+     with 'identical to' semantics". With no flag the case-sensitivity "depends
+     on the document language", which a {!NODE} does not carry, so the value is
+     read as written - the answer [s] gives. Folding is ASCII-only, which is why
+     the spec has [green] match [GREEN] but not the umlauted [grun] match its
+     own upper case. *)
+  let attr_fold : Selector.attr_flag option -> string -> string = function
+    | Some Selector.Insensitive -> String.lowercase_ascii
+    | None | Some Selector.Sensitive -> Fun.id
+
+  let attr_matches ~fold n name (m : Selector.attribute_match) =
     match N.attribute n (attr_key name) with
     | None -> false
     | Some v -> (
+        let v = fold v in
         match m with
         | Selector.Presence -> true
-        | Selector.Exact s | Selector.Exact_quoted (s, _) -> v = s
+        | Selector.Exact s | Selector.Exact_quoted (s, _) -> v = fold s
         | Selector.Whitespace_list s | Selector.Whitespace_list_quoted (s, _) ->
-            List.mem s (words v)
+            List.mem (fold s) (words v)
         | Selector.Prefix s | Selector.Prefix_quoted (s, _) ->
-            s <> "" && starts v s
+            s <> "" && starts v (fold s)
         | Selector.Suffix s | Selector.Suffix_quoted (s, _) ->
-            s <> "" && ends v s
+            s <> "" && ends v (fold s)
         | Selector.Substring s | Selector.Substring_quoted (s, _) ->
-            s <> "" && contains v s
+            s <> "" && contains v (fold s)
         | Selector.Hyphen_list s | Selector.Hyphen_list_quoted (s, _) ->
-            v = s || starts v (s ^ "-"))
+            let s = fold s in
+            v = s || starts v (String.concat "" [ s; "-" ]))
+
+  (* selectors-4 sec. 13.3: the child-indexed pseudo-classes read an element's
+     "relative index amongst its siblings", counting the inclusive ones, since
+     there was "no reason to exclude them from matching elements without
+     parents". A parentless element is a list of one, not no list at all. *)
+  let inclusive_siblings n =
+    match N.parent n with None -> [ n ] | Some p -> N.children p
+
+  (* [nth_position ~from_end n keep] is [n]'s 1-based index among the inclusive
+     siblings [keep] admits, or [None] when [n] is not one of them and so is
+     among the An+Bth of nothing. Only elements are listed: a {!NODE} keeps text
+     out of [children], which is what sec. 13 asks for. *)
+  let nth_position ~from_end n keep =
+    let sibs = List.filter keep (inclusive_siblings n) in
+    let sibs = if from_end then List.rev sibs else sibs in
+    let rec index i = function
+      | [] -> None
+      | x :: _ when N.equal x n -> Some i
+      | _ :: rest -> index (i + 1) rest
+    in
+    index 1 sibs
+
+  let nth_matches ~from_end nth keep n =
+    match nth_position ~from_end n keep with
+    | None -> false
+    | Some i -> nth_hits nth i
+
+  (* selectors-4 sec. 13.4: the typed child-indexed pseudo-classes resolve on an
+     element's index "among elements of the same type (tag name) in their
+     sibling list", the type being the one a type selector matching the element
+     would name. So the comparison is the type selector's own, which is why
+     [:nth-of-type(2)] and [:nth-child(2 of <type>)] agree as sec. 13.4.1
+     requires. A node {!NODE} gives no name has no tag name to share with a
+     named one. *)
+  let same_type n x =
+    match (N.name n, N.name x) with
+    | Some a, Some b -> ci a b
+    | None, None -> true
+    | Some _, None | None, Some _ -> false
+
+  (* sec. 13.4.3 makes [:first-of-type] the same element as [:nth-of-type(1)]
+     and sec. 13.4.4 makes [:last-of-type] the same as [:nth-last-of-type(1)];
+     sec. 13.4.5 makes [:only-of-type] the two at once. *)
+  let first_of_type n =
+    nth_matches ~from_end:false (Selector.Index 1) (same_type n) n
+
+  let last_of_type n =
+    nth_matches ~from_end:true (Selector.Index 1) (same_type n) n
+
+  (* Every combinator reaches down the tree or to the right, so the subject of a
+     relative selector absolutised against [n] never lies before [n]: a [:has()]
+     over a descendant or child combinator looks no further than [n]'s subtree,
+     and one over a sibling combinator no further than the subtrees of [n]'s
+     following siblings. The three combinators {!relation} has no model for
+     never reach here, since it is asked first. *)
+  let has_subjects comb n =
+    match comb with
+    | Selector.Descendant | Selector.Child -> descendants n
+    | Selector.Next_sibling | Selector.Subsequent_sibling ->
+        List.concat_map subtree (following_siblings n)
+    | Selector.Column | Selector.Shadow_piercing | Selector.Shadow_deep -> []
 
   (* selectors-4 sec. 13.2: [:empty] represents "an element that has no children
      except, optionally, document white space characters", counting "only
@@ -271,8 +376,11 @@ module Make (N : NODE) = struct
         of_bool (match N.name n with Some nm -> ci nm name | None -> false)
     | Selector.Class c -> of_bool (List.mem c (N.classes n))
     | Selector.Id i -> of_bool (N.id n = Some i)
-    | Selector.Attribute (None, name, m, None) ->
-        of_bool (attr_matches n name m)
+    (* selectors-4 sec. 16: an [<attr-modifier>] follows a matcher and a value,
+       so a presence test carrying one is not an attribute selector. *)
+    | Selector.Attribute (None, _, Selector.Presence, Some _) -> Unsupported
+    | Selector.Attribute (None, name, m, flag) ->
+        of_bool (attr_matches ~fold:(attr_fold flag) n name m)
     | Selector.Compound ps ->
         List.fold_left (fun acc p -> conj acc (match_selector p n)) Matches ps
     | Selector.List ss | Selector.Is ss | Selector.Where ss -> any ss n
@@ -282,18 +390,84 @@ module Make (N : NODE) = struct
         | None -> Unsupported
         | Some [] -> No_match
         | Some (_ :: _) -> Matches)
-    | Selector.Root -> of_bool (N.parent n = None)
+    (* selectors-4 sec. 8.4: [:scope] is the scoping root, and "if there is no
+       scoping root then :scope represents the root of the tree the element is
+       in", which is [:root] outside a shadow tree. Nothing hands this matcher a
+       scoping root and a {!NODE} tree has no shadow boundary, so the two ask
+       the same question. *)
+    | Selector.Root | Selector.Scope -> of_bool (N.parent n = None)
     | Selector.First_child -> of_bool (is_first n)
     | Selector.Last_child -> of_bool (is_last n)
     | Selector.Only_child -> of_bool (is_first n && is_last n)
     | Selector.Empty -> of_bool (is_empty n)
-    (* A namespace, an attribute case flag, and every stateful, generated or
-       tree-external form. The values compared above are verbatim, so [i] and
-       [s] would both be ignored, and no node here carries a namespace. *)
+    | Selector.Nth_child (nth, of_) -> nth_child ~from_end:false nth of_ n
+    | Selector.Nth_last_child (nth, of_) -> nth_child ~from_end:true nth of_ n
+    | Selector.Nth_of_type (nth, None) ->
+        of_bool (nth_matches ~from_end:false nth (same_type n) n)
+    | Selector.Nth_last_of_type (nth, None) ->
+        of_bool (nth_matches ~from_end:true nth (same_type n) n)
+    | Selector.First_of_type -> of_bool (first_of_type n)
+    | Selector.Last_of_type -> of_bool (last_of_type n)
+    | Selector.Only_of_type -> of_bool (first_of_type n && last_of_type n)
+    | Selector.Has rs ->
+        List.fold_left (fun acc r -> disj acc (has_relative n r)) No_match rs
+    (* sec. 13.4.1 and sec. 13.4.2 give the typed forms an [An+B] and nothing
+       else, so an [of S] on one is not a selector any UA takes. *)
+    | Selector.Nth_of_type (_, Some _) | Selector.Nth_last_of_type (_, Some _)
+      ->
+        Unsupported
+    (* A namespace, which no node here carries; [:lang()], whose content
+       language the document language defines rather than the tree; and every
+       stateful, generated or tree-external form. *)
     | _ -> Unsupported
 
   and any ss n =
     List.fold_left (fun acc s -> disj acc (match_selector s n)) No_match ss
+
+  (* selectors-4 sec. 13.3.1: with [of S] the element must be among the An+Bth
+     of "their inclusive siblings that match the selector list S", so [S] both
+     filters the list and decides whether [n] is in it at all; without it, [S]
+     defaults to [*|*] and the list is every sibling. *)
+  and nth_child ~from_end nth of_ n =
+    match of_ with
+    | None -> of_bool (nth_matches ~from_end nth (fun _ -> true) n)
+    | Some s -> (
+        (* Whether [S] is modelled is a fact about [S] alone, so any node
+           settles it, and asking [n] keeps that answer clear of which siblings
+           happen to be there. *)
+        match any s n with
+        | Unsupported -> Unsupported
+        | Matches | No_match ->
+            of_bool (nth_matches ~from_end nth (fun x -> any s x = Matches) n))
+
+  (* selectors-4 sec. 4.5: [:has()] "represents an element if any of the
+     relative selectors would match at least one element when anchored against
+     this element". A relative selector is a combinator and a complex selector
+     with "a selector representing the anchor element implied at the start", the
+     descendant combinator standing in when none is written (sec. 3.4). So
+     absolutise it against [n] and ask whether anything in reach is its subject
+     with [n] as the anchor. [complex] is matched against [n] itself only for
+     the support it reports, which no node can change; stopping at an empty
+     subject list would let the tree decide whether the selector is modelled. *)
+  and has_relative n r =
+    let comb, complex =
+      match r with
+      | Selector.Relative (comb, complex) -> (comb, complex)
+      | complex -> (Selector.Descendant, complex)
+    in
+    match (relation comb, match_selector complex n) with
+    | Some _, complex_answer when complex_answer <> Unsupported ->
+        let absolute =
+          Selector.Combined (Selector.Universal None, comb, complex)
+        in
+        of_bool
+          (List.exists
+             (fun e ->
+               match anchors absolute e with
+               | None -> false
+               | Some found -> List.exists (N.equal n) found)
+             (has_subjects comb n))
+    | _ -> Unsupported
 
   (* [Selector] is right-leaning: [a b > c] is [Combined (a, Descendant,
      Combined (b, Child, c))], so the rightmost compound (the subject) sits at

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -13,7 +13,10 @@ module type NODE = sig
   (** Node identity, used to locate a node among its siblings. *)
 
   val name : t -> string option
-  (** The element name (e.g. ["div"]), or [None] for an anonymous node. *)
+  (** The element name (e.g. ["div"]), or [None] for an anonymous node. A name
+      is read ASCII case-insensitively, against a type selector and between two
+      siblings alike, so an anonymous node is of the same type as another
+      anonymous node and of no named one. *)
 
   val id : t -> string option
   (** The [id] attribute, or [None]. *)
@@ -59,12 +62,35 @@ val supported : Selector.t -> bool
     why it needs no node.
 
     Modelled: the universal, type, class, id and attribute selectors, each
-    without a namespace and, for an attribute, without a case flag; [:root],
-    [:empty], [:first-child], [:last-child], [:only-child]; the descendant,
-    child and sibling combinators; and [:is()], [:where()], [:not()] and
-    selector lists over those - a list is only as modelled as its least modelled
-    branch. Everything else, every stateful pseudo-class and every
-    pseudo-element among it, is not. *)
+    without a namespace, an attribute carrying either case flag ([i], [s]) or
+    none; [:root] and [:scope], which name the same element here (selectors-4
+    sec. 8.4) since no scoping root is ever handed to the matcher; [:empty]; the
+    child-indexed [:first-child], [:last-child], [:only-child], [:nth-child()]
+    and [:nth-last-child()], the last two with or without their [of S] argument;
+    the typed [:first-of-type], [:last-of-type], [:only-of-type],
+    [:nth-of-type()] and [:nth-last-of-type()]; [:has()]; the descendant, child
+    and sibling combinators; and [:is()], [:where()], [:not()] and selector
+    lists over those - a list is only as modelled as its least modelled branch,
+    and so is an [of S] or a [:has()] argument.
+
+    Not modelled, and for two different reasons. Some forms would need a {!NODE}
+    to carry more than a tree of named elements: anything with a namespace,
+    which no accessor here reports, and [:lang()], whose content language the
+    document language defines rather than the element tree - HTML derives it
+    from a [lang] attribute but also from a [meta] pragma and from the
+    transport, so reading the attribute alone would answer
+    {!constructor-No_match} for a document that tags its language elsewhere. The
+    rest are outside any tree: every stateful pseudo-class, whether it needs the
+    user ([:hover], [:focus], [:active], [:focus-visible], [:focus-within]), the
+    document's history ([:visited], [:link], [:target]), or a form or media
+    element's own state ([:checked], [:indeterminate], [:default], [:playing],
+    [:paused], [:muted], [:open], [:closed]); every pseudo-element, which names
+    no element at all; the shadow-tree and column forms ([:host], [::part()],
+    [::slotted()], [||], [>>>], [/deep/]); and the nesting selector [&], which
+    {!prepare} resolves away before the matcher sees it. Two forms are simply
+    not selectors and are refused as such: [:nth-of-type(An+B of S)], which sec.
+    13.4.1 does not define, and an attribute presence test carrying a case flag,
+    which sec. 16's grammar admits only after a matcher and a value. *)
 
 val layer_order : Stylesheet.t -> string list
 (** [layer_order sheet] is the cascade layer order [sheet] declares, weakest

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -420,13 +420,16 @@ let unrelated_kept_property_still_inlines () =
     ~keep:"@media(min-width:1px){.q{color:red}}" ~kept:1
     (node ~classes:[ "m" ] "ul")
 
-(* The matcher compares attribute values verbatim, so it cannot represent the
-   [i] case flag. A selector it cannot represent has to stay in the sheet:
-   inlining it drops it from the sheet, and it then matches nobody, so the
-   declaration is lost. *)
-let keeps_rule_with_attribute_case_flag () =
+(* selectors-4 sec. 6.3: an [i] flag matches the attribute's value ASCII
+   case-insensitively and an [s] flag matches it "identical to", so the matcher
+   represents both and the rule projects or drops on the value the element
+   actually carries. *)
+let projects_attribute_rule_with_case_flag () =
   check_split "case-insensitive attribute" ~css:"p[data-k=\"X\" i]{color:red}"
-    ~inline:"" ~keep:"p[data-k=X i]{color:red}" ~kept:1
+    ~inline:"color:red" ~keep:"" ~kept:0
+    (node ~attrs:[ ("data-k", "x") ] "p");
+  check_split "case-sensitive attribute" ~css:"p[data-k=\"X\" s]{color:red}"
+    ~inline:"" ~keep:"" ~kept:0
     (node ~attrs:[ ("data-k", "x") ] "p")
 
 (* The control: without the flag the selector is representable, so it projects
@@ -569,8 +572,8 @@ let suite =
         `Quick keeps_logical_a_kept_physical_writes;
       Alcotest.test_case "unrelated kept property still inlines" `Quick
         unrelated_kept_property_still_inlines;
-      Alcotest.test_case "keeps a rule with an attribute case flag" `Quick
-        keeps_rule_with_attribute_case_flag;
+      Alcotest.test_case "projects an attribute rule with a case flag" `Quick
+        projects_attribute_rule_with_case_flag;
       Alcotest.test_case "projects an attribute rule to inline style" `Quick
         projects_attribute_rule_to_inline_style;
       Alcotest.test_case "keeps a rule with a namespaced element" `Quick

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -6,17 +6,19 @@ type tree = {
   tname : string;
   tid : string option;
   tclasses : string list;
+  tattrs : (string * string) list;
   ttext : string list;
   mutable tparent : tree option;
   tchildren : tree list;
 }
 
-let elt ?id ?(classes = []) ?(text = []) name children =
+let elt ?id ?(classes = []) ?(attrs = []) ?(text = []) name children =
   let t =
     {
       tname = name;
       tid = id;
       tclasses = classes;
+      tattrs = attrs;
       ttext = text;
       tparent = None;
       tchildren = children;
@@ -32,7 +34,7 @@ module Node = struct
   let name t = Some t.tname
   let id t = t.tid
   let classes t = t.tclasses
-  let attribute _ _ = None
+  let attribute t k = List.assoc_opt k t.tattrs
   let parent t = t.tparent
   let children t = t.tchildren
   let text_children t = t.ttext
@@ -96,7 +98,7 @@ let test_unsupported_is_not_no_match () =
   answers "a modelled miss" Resolve.No_match "div" s2;
   answers "stateful" Resolve.Unsupported "span:hover" s2;
   answers "pseudo-element" Resolve.Unsupported "span::before" s2;
-  answers "attribute case flag" Resolve.Unsupported "[id=\"S2\" i]" s2;
+  answers "a case flag on a presence test" Resolve.Unsupported "[id i]" s2;
   answers "namespaced type" Resolve.Unsupported "*|span" s2;
   answers "shadow-piercing combinator" Resolve.Unsupported "div>>>span" s2;
   (* One unsupported part carries the whole selector, whichever side of the
@@ -119,7 +121,15 @@ let test_supported_needs_no_node () =
   check "attribute" true "[data-k=\"X\"]";
   check "structural" true "p:empty";
   check "descendant" true "div span";
-  check "attribute case flag" false "[data-k=\"X\" i]";
+  check "attribute case flag" true "[data-k=\"X\" i]";
+  check "child-indexed" true ":nth-child(2n+1)";
+  check "child-indexed over an of S" true ":nth-child(2 of .a)";
+  check "typed child-indexed" true ":nth-of-type(2)";
+  check "relational" true ":has(> .a)";
+  check "the reference element" true ":scope";
+  check "a case flag on a presence test" false "[data-k i]";
+  check "an of S on :nth-of-type" false ":nth-of-type(1 of p)";
+  check "the content language" false ":lang(en)";
   check "namespaced attribute" false "[svg|href]";
   check "shadow-piercing combinator" false "div>>>span";
   check "stateful" false ":hover";
@@ -138,6 +148,340 @@ let test_empty_counts_text_children () =
     (elt ~text:[ " "; "text" ] "p" []);
   no "a no-break space" ":empty" (elt ~text:[ "\u{00a0}" ] "p" []);
   no "an element child" ":empty" (elt "p" [ elt "span" [] ])
+
+(* A spec sentence about a child-indexed pseudo-class names a set of positions
+   ("the 2nd, 4th, 6th, etc elements"), so pin the whole set rather than probe
+   it: [indices s children] is the 1-based positions of [children] that [s]
+   matches. *)
+let indices s children =
+  List.mapi (fun i n -> (i + 1, n)) children
+  |> List.filter_map (fun (i, n) ->
+      if R.matches (sel s) n then Some i else None)
+
+let of_ten = List.init 10 (fun i -> i + 1)
+let items = List.map (fun _ -> elt "li" []) of_ten
+let _ : tree = elt "ol" items
+let item i = List.nth items (i - 1)
+
+(* selectors-4 sec. 13.3.1: [:nth-child(An+B)] represents the elements that are
+   among the An+Bth of their inclusive siblings, where An+B "represents any
+   index i = An + B for any non-negative integer n" and the list is 1-indexed
+   (sec. 13). The sets below are the spec's own: [2n+1] takes the first child
+   "because when n=0 the expression evaluates to 1", [even] "represents the 2nd,
+   4th, 6th, etc elements", [10n-1] "the 9th, 19th, 29th, etc elements", and
+   [10n+9] is the "Same". [odd] is [2n+1] and [even] is [2n] per the An+B
+   microsyntax (css-syntax-3 sec. 6). *)
+let test_nth_child_indices () =
+  let check name expected s =
+    Alcotest.(check (list int)) name expected (indices s items)
+  in
+  check "the index is 1-based" [ 1 ] ":nth-child(1)";
+  check "2n+1 takes the first child" [ 1; 3; 5; 7; 9 ] ":nth-child(2n+1)";
+  check "odd is 2n+1" [ 1; 3; 5; 7; 9 ] ":nth-child(odd)";
+  check "even is the 2nd, 4th, 6th" [ 2; 4; 6; 8; 10 ] ":nth-child(even)";
+  check "2n is even" [ 2; 4; 6; 8; 10 ] ":nth-child(2n)";
+  (* n=0 gives -1, which is no index at all, so 10n-1 starts at the 9th *)
+  check "a negative B skips the indices below 1" [ 9 ] ":nth-child(10n-1)";
+  check "10n+9 names the same set" [ 9 ] ":nth-child(10n+9)";
+  check "A=0 is the single index B" [ 3 ] ":nth-child(0n+3)";
+  check "B alone spells it" [ 3 ] ":nth-child(3)";
+  check "index 0 is no index" [] ":nth-child(0)";
+  check "a negative A counts down to 1" [ 1; 2; 3 ] ":nth-child(-n+3)";
+  check "n alone takes every index" of_ten ":nth-child(n)";
+  check "n+4 takes the rest" [ 4; 5; 6; 7; 8; 9; 10 ] ":nth-child(n+4)"
+
+(* selectors-4 sec. 13.3.2: the same list "counting backwards from the end". The
+   spec's [tr:nth-last-child(-n+2)] "represents the two last rows of an HTML
+   table". *)
+let test_nth_last_child_indices () =
+  let check name expected s =
+    Alcotest.(check (list int)) name expected (indices s items)
+  in
+  check "the last one" [ 10 ] ":nth-last-child(1)";
+  check "the two last ones" [ 9; 10 ] ":nth-last-child(-n+2)";
+  check "odd from the end" [ 2; 4; 6; 8; 10 ] ":nth-last-child(odd)";
+  check "10n-1 from the end" [ 2 ] ":nth-last-child(10n-1)"
+
+(* selectors-4 sec. 13.3: these pseudo-classes "have been rephrased to refer to
+   an element's relative index amongst its siblings", since there was "no reason
+   to exclude them from matching elements without parents". A parentless element
+   is the whole list, so it is both the first and the last of it. *)
+let test_child_index_without_a_parent () =
+  let orphan = elt "p" [] in
+  yes "the first of its inclusive siblings" ":nth-child(1)" orphan;
+  yes "and the last" ":nth-last-child(1)" orphan;
+  yes "so the only one" ":only-child" orphan;
+  no "not the second" ":nth-child(2)" orphan;
+  yes "a fixture root indexes the same way" ":nth-child(1)" section
+
+(* selectors-4 sec. 13: "Standalone text and other non-element nodes are not
+   counted when calculating the position of an element in the list of children
+   of its parent." A {!NODE} keeps text out of [children], so text around an
+   element leaves its index alone. *)
+let test_child_index_counts_elements_only () =
+  let bold = elt "b" [] and italic = elt "i" [] in
+  let _ : tree =
+    elt ~text:[ "lead "; " middle "; " tail" ] "p" [ bold; italic ]
+  in
+  yes "the first element child" ":nth-child(1)" bold;
+  yes "the second element child" ":nth-child(2)" italic
+
+(* selectors-4 sec. 13.3.1: with [of S] the list is "composed of their inclusive
+   siblings that match the selector list S", so [:nth-child(-n+3 of
+   li.important)] "matches the first three 'important' list items". The spec
+   contrasts it with moving the selector out of the function: [li.important:
+   nth-child(-n+3)] "instead just selects the first three children if they also
+   happen to be 'important' list items". *)
+let important = List.init 4 (fun _ -> elt ~classes:[ "important" ] "li" [])
+let plain = List.init 2 (fun _ -> elt "li" [])
+
+let important_items =
+  match (important, plain) with
+  | [ i2; i4; i5; i6 ], [ p1; p3 ] -> [ p1; i2; p3; i4; i5; i6 ]
+  | _ -> assert false
+
+let _ : tree = elt "ol" important_items
+
+(* The [hidden] rows of the zebra-striping example in the same section:
+   [tr:nth-child(even of :not([hidden]))] keeps "a proper alternating background
+   regardless of which rows are hidden". *)
+let rows =
+  List.mapi
+    (fun i _ ->
+      let attrs = if i = 2 then [ ("hidden", "") ] else [] in
+      elt ~attrs "tr" [])
+    [ 1; 2; 3; 4; 5; 6 ]
+
+let _ : tree = elt "tbody" rows
+
+let test_nth_child_of_selector () =
+  let check name expected s children =
+    Alcotest.(check (list int)) name expected (indices s children)
+  in
+  check "the first three important items" [ 2; 4; 5 ]
+    ":nth-child(-n+3 of li.important)" important_items;
+  check "the important ones among the first three" [ 2 ]
+    "li.important:nth-child(-n+3)" important_items;
+  check "even among the rows that are not hidden" [ 2; 5 ]
+    "tr:nth-child(even of :not([hidden]))" rows;
+  check "even among all the rows" [ 2; 4; 6 ] "tr:nth-child(even)" rows;
+  check "counted backwards over the same list" [ 5; 6 ]
+    ":nth-last-child(-n+2 of li.important)" important_items
+
+(* selectors-4 sec. 13.4: the typed child-indexed pseudo-classes "resolve based
+   on an element's index among elements of the same type (tag name) in their
+   sibling list". Sec. 13.4.3 makes [:first-of-type] the same element as
+   [:nth-of-type(1)], sec. 13.4.4 makes [:last-of-type] the same as
+   [:nth-last-of-type(1)], and sec. 13.4.5 makes [:only-of-type] the same as
+   [:first-of-type:last-of-type]. *)
+let typed_children =
+  [
+    elt "h2" []; elt "p" []; elt "h2" []; elt "span" []; elt "h2" []; elt "p" [];
+  ]
+
+let _ : tree = elt "div" typed_children
+
+let test_of_type_indices () =
+  let check name expected s =
+    Alcotest.(check (list int)) name expected (indices s typed_children)
+  in
+  check "the first h2" [ 1 ] "h2:first-of-type";
+  check "the last h2" [ 5 ] "h2:last-of-type";
+  check "the second h2" [ 3 ] "h2:nth-of-type(2)";
+  check "the second h2 from the end" [ 3 ] "h2:nth-last-of-type(2)";
+  check "the span is the only one of its type" [ 4 ] ":only-of-type";
+  check "no h2 is" [] "h2:only-of-type";
+  (* sec. 13.4.1: "img:nth-of-type(2) is equivalent to *:nth-child(2 of img)" *)
+  check "the same element as :nth-child(2 of h2)" [ 3 ] ":nth-child(2 of h2)";
+  (* sec. 13.4.2 gives both spellings of "all h2 children except the first and
+     last" *)
+  check "every h2 but the first and the last" [ 3 ]
+    "h2:nth-of-type(n+2):nth-last-of-type(n+2)";
+  check "the same set through :not" [ 3 ]
+    "h2:not(:first-of-type):not(:last-of-type)"
+
+(* An element with no parent is the whole list of its inclusive siblings here
+   too, so it is the only one of its type. *)
+let test_of_type_without_a_parent () =
+  let orphan = elt "p" [] in
+  yes "first of its type" ":first-of-type" orphan;
+  yes "last of its type" ":last-of-type" orphan;
+  yes "only of its type" ":only-of-type" orphan
+
+(* The type comparison is the type selector's own, which reads a name ASCII
+   case-insensitively, so sec. 13.4.1's equivalence between [:nth-of-type()] and
+   [:nth-child(An+B of <type>)] holds whichever case the tree spells the tag
+   in. *)
+let test_of_type_reads_the_name_case_insensitively () =
+  let upper = elt "DIV" [] and lower = elt "div" [] in
+  let _ : tree = elt "section" [ upper; lower ] in
+  yes "the first of the two" ":first-of-type" upper;
+  no "so the second is not" ":first-of-type" lower;
+  no "and neither is alone" ":only-of-type" upper;
+  yes "as :nth-child(2 of div) agrees" ":nth-child(2 of div)" lower
+
+(* selectors-4 sec. 4.5: [:has()] "represents an element if any of the relative
+   selectors would match at least one element when anchored against this
+   element". A relative selector "begins with a combinator, with a selector
+   representing the anchor element implied at the start"; with no combinator the
+   descendant combinator is implied (sec. 3.4). *)
+let nested_img = elt "img" []
+let link_direct = elt "a" [ elt "img" [] ]
+let link_nested = elt "a" [ elt "span" [ nested_img ] ]
+let link_none = elt "a" [ elt "span" [] ]
+let links = elt "nav" [ link_direct; link_nested; link_none ]
+
+let test_has_descendant_and_child () =
+  (* sec. 4.5: "a:has(> img)" "matches only <a> elements that contain an <img>
+     child" *)
+  yes "an img child" "a:has(> img)" link_direct;
+  no "a grandchild is not a child" "a:has(> img)" link_nested;
+  no "no img at all" "a:has(> img)" link_none;
+  (* with no combinator the descendant combinator is implied *)
+  yes "an img child is a descendant" "a:has(img)" link_direct;
+  yes "so is a grandchild" "a:has(img)" link_nested;
+  no "still no img" "a:has(img)" link_none;
+  (* the argument is a complex selector, anchored at the subject *)
+  yes "a child span holding an img" "a:has(> span img)" link_nested;
+  no "the img is not under a span" "a:has(> span img)" link_direct;
+  (* the anchor is the subject, not an ancestor of it *)
+  no "an ancestor of the match is not the anchor" "nav:has(> img)" links
+
+let dt_first = elt "dt" []
+let dt_second = elt "dt" []
+let dd_last = elt "dd" []
+let _ : tree = elt "dl" [ dt_first; dt_second; dd_last ]
+
+let test_has_sibling_combinators () =
+  (* sec. 4.5: "dt:has(+ dt)" "matches a <dt> element immediately followed by
+     another <dt> element" *)
+  yes "followed immediately by a dt" "dt:has(+ dt)" dt_first;
+  no "followed immediately by a dd" "dt:has(+ dt)" dt_second;
+  yes "a dd follows somewhere" "dt:has(~ dd)" dt_first;
+  yes "and follows this one too" "dt:has(~ dd)" dt_second;
+  yes "a dt follows this one" "dt:has(~ dt)" dt_first;
+  no "nothing follows the last dt" "dt:has(~ dt)" dt_second;
+  no "the dd has no dt after it" "dd:has(~ dt)" dd_last
+
+(* sec. 4.5 spells out that the order of [:not()] and [:has()] matters:
+   "section:not(:has(h1, h2, h3, h4, h5, h6))" "matches <section> elements that
+   don't contain any heading elements", while swapping the nesting "would result
+   in matching any <section> element which contains anything that's not a
+   heading element". *)
+let sec_bare = elt "section" []
+let sec_heading = elt "section" [ elt "h1" [] ]
+let sec_para = elt "section" [ elt "p" [] ]
+let _ : tree = elt "main" [ sec_bare; sec_heading; sec_para ]
+let headings = "h1, h2, h3, h4, h5, h6"
+
+let test_has_ordering_against_not () =
+  let holds_no_heading =
+    String.concat "" [ "section:not(:has("; headings; "))" ]
+  in
+  let holds_a_non_heading =
+    String.concat "" [ "section:has(:not("; headings; "))" ]
+  in
+  yes "an empty section holds no heading" holds_no_heading sec_bare;
+  no "this one holds one" holds_no_heading sec_heading;
+  yes "a paragraph is not a heading" holds_no_heading sec_para;
+  no "an empty section holds nothing at all" holds_a_non_heading sec_bare;
+  no "this one holds only a heading" holds_a_non_heading sec_heading;
+  yes "this one holds a paragraph" holds_a_non_heading sec_para
+
+(* selectors-4 sec. 6.3: the [i] identifier makes a UA "match the attribute's
+   value ASCII case-insensitively", and [s] makes it match "case-sensitively,
+   with 'identical to' semantics". With no flag the case-sensitivity "depends on
+   the document language", which a {!NODE} does not carry, so the value is read
+   as written. *)
+let framed =
+  elt
+    ~attrs:[ ("frame", "HSIDES"); ("data-k", "GR\u{00dc}N"); ("lang", "EN-GB") ]
+    "table" []
+
+let type_lower = elt ~attrs:[ ("type", "a") ] "ol" []
+let type_upper = elt ~attrs:[ ("type", "A") ] "ol" []
+
+let test_attribute_case_flags () =
+  (* sec. 6.3's own example: [frame=hsides i] styles the attribute "whether that
+     value is represented as hsides, HSIDES, hSides, etc." *)
+  yes "i folds the case" "[frame=hsides i]" framed;
+  no "without a flag the value is read as written" "[frame=hsides]" framed;
+  no "s is identical-to" "[frame=hsides s]" framed;
+  yes "and the written value is identical to itself" "[frame=HSIDES s]" framed;
+  (* "ASCII case insensitivity allows green to match GREEN. However, gruen [with
+     an umlaut] would not match GRUEN [with an umlaut]." *)
+  no "i folds ASCII only" "[data-k=\"gr\u{00fc}n\" i]" framed;
+  (* the flag applies to every matcher, not just [=] *)
+  yes "a prefix" "[frame^=hs i]" framed;
+  yes "a suffix" "[frame$=des i]" framed;
+  yes "a substring" "[frame*=sid i]" framed;
+  yes "a hyphen list" "[lang|=en i]" framed;
+  (* sec. 6.3's second example: [type="a" s] and [type="A" s] are two rules *)
+  yes "s keeps the two apart" "[type=\"a\" s]" type_lower;
+  no "the other way round" "[type=\"a\" s]" type_upper;
+  yes "and back" "[type=\"A\" s]" type_upper;
+  yes "i puts them together" "[type=\"a\" i]" type_lower;
+  yes "both ways" "[type=\"a\" i]" type_upper
+
+(* selectors-4 sec. 8.4: ":scope represents this scoping root", and "if there is
+   no scoping root then :scope represents the root of the tree the element is in
+   ... or :root otherwise". Nothing hands this matcher a scoping root and it has
+   no shadow tree, so [:scope] is [:root]. *)
+let test_scope_is_the_root () =
+  yes "the root of the tree" ":scope" section;
+  no "not an element inside it" ":scope" s1;
+  yes "and combines like :root" ":scope > div" a;
+  no "a child, not a descendant" ":scope > span" s1
+
+(* [Unsupported] beats every other answer in every combining form, so a caller
+   never reads a gap in the model as a rule that does not apply. Each selector
+   here is asked against a node the supported part of it misses, so a matcher
+   that settled on the first failing part would answer [No_match] instead. *)
+let test_unsupported_beats_the_structural_forms () =
+  let leaf = elt "p" [] in
+  answers "a stateful :has argument" Resolve.Unsupported ":has(:hover)"
+    link_direct;
+  answers "a stateful relative :has argument" Resolve.Unsupported
+    ":has(> :hover)" link_direct;
+  answers "no candidate to test it against" Resolve.Unsupported ":has(:hover)"
+    leaf;
+  answers "inside :not" Resolve.Unsupported ":not(:has(:hover))" link_direct;
+  answers "inside :is" Resolve.Unsupported ":is(:has(:hover))" link_direct;
+  answers "beside a type that already missed" Resolve.Unsupported
+    "p:has(:hover)" link_direct;
+  answers "a branch of a list" Resolve.Unsupported ".x, :has(:hover)"
+    link_direct;
+  answers "a stateful of S" Resolve.Unsupported ":nth-child(1 of :hover)"
+    (item 1);
+  answers "counting backwards" Resolve.Unsupported
+    ":nth-last-child(1 of :hover)" (item 1);
+  answers "one stateful branch of an of S" Resolve.Unsupported
+    ":nth-child(1 of .x, :hover)" (item 1);
+  answers "a namespace in an of S" Resolve.Unsupported ":nth-child(1 of *|li)"
+    (item 1);
+  answers "a namespace in a :has argument" Resolve.Unsupported ":has(*|img)"
+    link_direct;
+  (* sec. 13.4.1 gives :nth-of-type() an An+B and nothing else *)
+  answers "an of S on :nth-of-type" Resolve.Unsupported ":nth-of-type(1 of p)"
+    (item 1);
+  (* sec. 16: the modifier follows a matcher and a value *)
+  answers "a case flag on a presence test" Resolve.Unsupported "[frame i]"
+    framed;
+  (* the content language is the document's to define, not the tree's *)
+  answers ":lang" Resolve.Unsupported ":lang(en)" framed
+
+(* The other half of the same property: a form the matcher does model answers
+   [No_match] rather than hedging, even where it has nothing to look at. *)
+let test_the_new_forms_answer_no_match () =
+  let leaf = elt "p" [] in
+  answers "an empty subtree is a miss" Resolve.No_match ":has(> img)" leaf;
+  answers "so is one with no sibling after it" Resolve.No_match ":has(+ p)" leaf;
+  answers "an index nothing reaches" Resolve.No_match ":nth-child(0)" (item 1);
+  answers "an of S the node itself misses" Resolve.No_match
+    ":nth-child(1 of .absent)" (item 1);
+  answers "a type with no second of its kind" Resolve.No_match
+    "span:nth-of-type(2)"
+    (List.nth typed_children 3)
 
 let sheet_of css =
   match Css.of_string css with
@@ -426,6 +770,33 @@ let suite =
         test_supported_needs_no_node;
       Alcotest.test_case "empty counts text children" `Quick
         test_empty_counts_text_children;
+      Alcotest.test_case "nth-child indexes from one" `Quick
+        test_nth_child_indices;
+      Alcotest.test_case "nth-last-child counts from the end" `Quick
+        test_nth_last_child_indices;
+      Alcotest.test_case "a child index needs no parent" `Quick
+        test_child_index_without_a_parent;
+      Alcotest.test_case "a child index counts elements only" `Quick
+        test_child_index_counts_elements_only;
+      Alcotest.test_case "of S filters the sibling list" `Quick
+        test_nth_child_of_selector;
+      Alcotest.test_case "of-type indexes within the type" `Quick
+        test_of_type_indices;
+      Alcotest.test_case "an of-type index needs no parent" `Quick
+        test_of_type_without_a_parent;
+      Alcotest.test_case "of-type reads the name case-insensitively" `Quick
+        test_of_type_reads_the_name_case_insensitively;
+      Alcotest.test_case "has over descendants and children" `Quick
+        test_has_descendant_and_child;
+      Alcotest.test_case "has over siblings" `Quick test_has_sibling_combinators;
+      Alcotest.test_case "has and not do not commute" `Quick
+        test_has_ordering_against_not;
+      Alcotest.test_case "attribute case flags" `Quick test_attribute_case_flags;
+      Alcotest.test_case "scope is the root" `Quick test_scope_is_the_root;
+      Alcotest.test_case "unsupported beats the structural forms" `Quick
+        test_unsupported_beats_the_structural_forms;
+      Alcotest.test_case "the structural forms answer no-match" `Quick
+        test_the_new_forms_answer_no_match;
       Alcotest.test_case "resolve applies the cascade" `Quick
         test_resolve_cascade;
       Alcotest.test_case "nested layer names order as a tree" `Quick


### PR DESCRIPTION
`Resolve.match_selector` answered `Unsupported` for `:nth-child()`, `:nth-last-child()`, the of-type family, `:has()`, the `i` and `s` attribute case flags and `:scope`, all of which Selectors 4 settles from the elements, names, attributes and siblings a `NODE` already exposes. A caller may not read `Unsupported` as a miss, so a rule carrying one of those was neither resolvable against an element nor prunable; a `No_match` now covers them, and `Css.Apply` projects such a rule rather than keeping it in the sheet.

`Unsupported` still beats every other answer inside `:is()`, `:not()`, `:has()`, an `of S` and a selector list, which the tests pin directly. Namespaces and `:lang()` stay unsupported for a reason the matcher cannot fix: a `NODE` carries neither a namespace nor the document's content language, which HTML also derives from a `meta` pragma and from the transport.