### PR TITLE
lib: read a monotonic clock instead of linking unix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -808,6 +808,13 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- The library no longer links `unix`. Timing a factoring iteration for
+  `--profile` was its only use of it, and `Unix.gettimeofday` reads a wall
+  clock that NTP can step backwards, so an iteration could be reported as
+  having taken negative time. `mtime` reads the monotonic clock the
+  measurement wants and ships a js_of_ocaml implementation of it, which `unix`
+  does not, so embedding cascade in a browser no longer means linking an
+  operating system to time a loop. A cram test pins the closure (#609)
 - `Css.Resolve` answers the selectors Selectors 4 settles from the element tree
   a `NODE` supplies: `:nth-child()` and `:nth-last-child()` with or without
   their `of S` argument, the typed `:nth-of-type()`, `:nth-last-of-type()`,

--- a/README.md
+++ b/README.md
@@ -504,9 +504,11 @@ minified outputs are identical.
 ### Small runtime footprint
 
 The core `cascade` library links
-[uutf](https://erratique.ch/software/uutf), `uri`, `psq`, `logs` and `unix`;
-it does not pull `fmt`, so js_of_ocaml embedders stay lean. A local jsoo
-build that parses and minifies one stylesheet compresses to under 200 KiB
+[uutf](https://erratique.ch/software/uutf), `uri`, `psq`, `logs` and
+[mtime](https://erratique.ch/software/mtime), which supplies the monotonic
+clock `--profile` measures factoring iterations against; it does not pull
+`fmt` or `unix`, so js_of_ocaml embedders stay lean. A local jsoo build that
+parses and minifies one stylesheet compresses to under 200 KiB
 (`--opt 3 --no-source-map`, size-oriented runtime flags).
 
 ## Development and testing

--- a/cascade.opam
+++ b/cascade.opam
@@ -24,6 +24,7 @@ depends: [
   "re" {with-test}
   "fmt" {>= "0.10.0"}
   "base-unix"
+  "mtime" {>= "2.1.0"}
   "uutf"
   "uri"
   "psq"

--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,7 @@
   (re :with-test)
   (fmt (>= 0.10.0))
   base-unix
+  (mtime (>= 2.1.0))
   uutf
   uri
   psq

--- a/lib/dune
+++ b/lib/dune
@@ -59,7 +59,7 @@
   prop_font
   prop_text
   prop_animation)
- (libraries uutf uri psq logs unix))
+ (libraries uutf uri psq logs mtime.clock))
 
 (mdx
  (files

--- a/lib/factor.ml
+++ b/lib/factor.ml
@@ -113,12 +113,12 @@ let optimize_graph ~ctx ~finalize ~fixpoint ~local_iteration rules graph =
   let before_rules = List.length rules in
   let profile = Stats.profile stats in
   let before_bytes = if profile then rules_pp_size rules else 0 in
-  let started_at = Unix.gettimeofday () in
+  let timer = Mtime_clock.counter () in
   let graph = Rule_scheduler.run ~ctx ~finalize graph in
   let ordered = ordered_rules rules graph in
   let rules' = list_map_preserve finalize ordered in
   let after_bytes = if profile then rules_pp_size rules' else 0 in
-  let elapsed = Unix.gettimeofday () -. started_at in
+  let elapsed = Mtime.Span.to_float_ns (Mtime_clock.count timer) /. 1e9 in
   let bytes_saved = Stats.saving stats in
   (* Both return the input unchanged by physical identity on a no-op, so a
      pointer compare detects change without rendering to CSS. *)

--- a/test/cram/runtime_deps.t/run.t
+++ b/test/cram/runtime_deps.t/run.t
@@ -1,0 +1,14 @@
+Cascade links a fixed set of runtime dependencies.  The list is part of what
+the library promises: an embedder targeting js_of_ocaml pays for every entry.
+Alphabetical, and mtime comes along because mtime.clock exports it.
+
+  $ ocamlfind query -format '%(requires)' cascade
+  logs mtime mtime.clock psq uri uutf
+
+Measuring how long a factoring iteration takes needs a monotonic clock, so the
+library reads one from mtime rather than the wall clock in unix.  Nothing else
+in the library wants an operating system, and unix has no js_of_ocaml
+implementation, so it must stay out of the closure.
+
+  $ ocamlfind query -recursive -p-format cascade | grep -Fx unix || echo "unix: not linked"
+  unix: not linked


### PR DESCRIPTION
`Unix.gettimeofday` reads a wall clock that NTP can step backwards, so `--profile` could report a factoring iteration as having taken negative time. `mtime` is monotonic, ships a js_of_ocaml implementation, and that call was the library's only use of `unix`.

The package still depends on `base-unix`: the installed CLI links `fmt.tty`, which requires it. What changes is the library's own findlib requires, which is what a js_of_ocaml embedder pays for, and a cram test now pins it.
