### PR TITLE
cli, docs: match the help and README to what the binary does

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -932,6 +932,13 @@ recorded cases carrying six minifiers' answers.
 
 ### CLI tools
 
+- `cascade fmt --help` says what `--enforce-spec` gates: the vendor-prefix
+  drop, the Media Queries 4 range grammar for a media or container feature,
+  the `&` prefix on a nested selector, the `:dir()` and form-control state
+  negations, the percentage spelling of an `oklab`/`oklch` axis, the unquoted
+  multi-word font family, and the ident code points the reader accepts. It
+  described an `@supports` elision that no longer exists, so the one place a
+  user reads about the flag contradicted every other (#611)
 - `cascade prune PAGE.html... STYLE.css` removes the rules a set of HTML
   documents cannot use, and `--dry-run` reports instead, ranking what survives
   by how few elements matched it. A rule goes only when the matcher has a model

--- a/README.md
+++ b/README.md
@@ -160,6 +160,65 @@ cascade diff --diff=canonical reference.css output.css
 NO_COLOR=1 cascade diff reference.css output.css
 ```
 
+## `cascade apply`: resolve a stylesheet into inline styles
+
+```text
+cascade apply [--minimal] PAGE.html [EXTRA.css]
+```
+
+Resolves the cascade against every element of `PAGE.html` and writes each
+element's winning declarations into its `style` attribute, printing the page to
+stdout. Selector matching, specificity, `!important` and inline-style priority
+decide which declaration wins, the way a browser decides it. The page's own
+`<style>` blocks supply the CSS, and `EXTRA.css` is applied on top of them.
+
+A declaration moves onto an element only when nothing left in CSS can overwrite
+it. A rule with no inline form (`:hover`, a `@media` block, a pseudo-element,
+`@keyframes`) cannot be projected onto an element at all, so it is kept in a
+single `<style>` block, and every declaration a kept rule competes for is kept
+beside it. A style attribute outranks every selector, so inlining a `.btn`
+colour past a `.btn:hover` colour would win a fight the browser gives to the
+hover rule:
+
+```html
+<html><body><p class="btn">Send</p></body></html>
+```
+
+```css
+.btn { color: #fff; padding: .5rem 1rem }
+.btn:hover { color: #eee }
+```
+
+`cascade apply page.html theme.css` writes the padding onto the element and
+leaves both colours in CSS, since `:hover` still has to be able to win:
+
+```html
+<html><head><style>.btn{color:#fff}.btn:hover{color:#eee}</style></head><body><p style="padding:.5rem 1rem" class="btn">Send</p></body></html>
+```
+
+A projected `<style>` block is emptied rather than removed. A `<style>` element
+is a sibling like any other, so unlinking it would stop a kept rule such as
+`.navbox + style + .portal-bar` from matching what it matches in the browser. A
+block the parser could not use keeps its text instead of being emptied with the
+rest: emptying it would ship a page with neither the inline styles it should
+have had nor the CSS a browser might still make something of.
+
+| Flag | Purpose |
+|---|---|
+| `--minimal` | Drop an inherited declaration that only restates the value the element already inherits from its ancestors, for the smallest styled page. |
+
+The exit code is 0 on success, including a parse that recovered part of its
+input, and 1 when a `<style>` block or `EXTRA.css` parsed to nothing. The page
+is still written in that case, without those styles, so a build can gate on the
+status rather than on the output.
+
+<!-- $MDX skip -->
+```bash
+cascade apply page.html > inlined.html
+cascade apply page.html theme.css > inlined.html
+cascade apply --minimal page.html theme.css > inlined.html
+```
+
 ## `cascade prune`: remove the rules a page cannot use
 
 ```text

--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ cat style.css | cascade -                                          # read stdin
 | `-m, --minify` | Minify the output. Local linear rewrites always run; the expensive global factoring fixpoint runs only when its preflight predicts useful savings. The top-level pipeline re-runs until the AST stops changing, since rule-order canonicalisation can expose a merge a single pass would miss: up to five times for a sheet of at most 128 rules, once above that. |
 | `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win and drives the factoring fixpoint to convergence, the right objective when the output ships uncompressed (inline style attributes, email HTML), at a large multiple of the default's wall clock. Has no effect without `--minify`. |
 | `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Also sorts each rule's declarations into a canonical cross-rule order (keeping cascade-significant pairs in place) so gzip back-references line up. Has no effect without `--minify`. |
-| `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest form the CSS text and the specs prove on their own, so it keeps every vendor-prefixed declaration, the `min-`/`max-` spelling of a media or container feature, the `&` prefix on a nested selector, and the author's `:not(:dir(ltr))` and `input:not(:enabled)`. Has no effect without `--minify`. |
+| `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest form the CSS text and the specs prove on their own, so it keeps every vendor-prefixed declaration, the `min-`/`max-` spelling of a media or container feature, the `&` prefix on a nested selector, the author's `:not(:dir(ltr))` and `input:not(:enabled)`, the number form of an `oklab`/`oklch` axis, and the quotes around a multi-word font family. It also holds the parser to the ident code points CSS Syntax 3 lists, which is the one part that acts without `--minify`. |
 | `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
+| `--closed-world` | Assume you know the exact HTML and that no element ever matches two clashing selectors, so the optimiser may merge rules it would otherwise keep apart. Unsafe: the page can render wrong if such an element appears, including one a script adds at runtime. This is about the HTML, where `--scope` is about how much of the CSS you control; see [Scope](#scope). Has no effect without `--minify`. |
 | `--flatten-nesting` | Desugar nested rules into flat top-level rules for browsers that pre-date CSS Nesting. By default cascade preserves nesting since modern browsers parse it natively and it is usually shorter. |
 | `--inline-imports` | Resolve `@import` against files relative to the input. Closed-world: assumes you control file resolution. |
 | `--inline-vars` | Substitute `var(--name)` references with their declared values, then drop unused custom properties. Closed-world: assumes no runtime mutation of the variables it inlines. |
@@ -112,7 +113,7 @@ other minifiers on the SatCSS corpus are in [BENCHMARKS.md](BENCHMARKS.md).
 ## `cascade diff`: structural CSS diff
 
 ```text
-cascade diff [--color=WHEN] [--diff=MODE] FILE1 FILE2
+cascade diff [OPTIONS] FILE1 FILE2
 ```
 
 Compares two CSS files through the parsed CSS structure rather than
@@ -141,6 +142,15 @@ usable as a CI check.
   Cascade-significant order is kept distinct (two writes of the same
   property, a shorthand and its longhand, a vendor-prefixed alias, `@layer`
   blocks). Equivalent shorthand decompositions are still not modelled.
+
+| Flag | Purpose |
+|---|---|
+| `--diff=MODE` | What counts as "no difference": `auto` (default), `tree`, `string` or `canonical`, as above. |
+| `--depth=auto\|max\|N` | How many levels of the difference tree to print. `auto` (default) prints it whole while it stays short, then falls back to the deepest level that fits; `max` always prints it whole; an integer pins a level. A cut subtree carries the number of lines hidden. |
+| `--lossless` | Disable colour approximation in the `--diff=canonical` canonicalisation, so two sheets that differ only by a fold within the approximation budget report as different rather than equal. Has no effect outside `--diff=canonical`. |
+| `--prune-unused-custom-props` | Drop the custom-property bindings nothing references, on both sides, before comparing under `--diff=canonical`, so two sheets that differ only by a dead binding compare equal. The comparison is then blind to dead-custom-property divergences. Has no effect outside `--diff=canonical`. |
+| `--color=WHEN` | `auto` (default), `always` or `never`. `CASCADE_COLOR` sets the same thing; `NO_COLOR` overrides both. |
+| `-q, --quiet` / `-v, --verbose` | Standard verbosity controls. |
 
 <!-- $MDX skip -->
 ```bash
@@ -350,10 +360,18 @@ stylesheet is embedded in a larger page.
 shorthand whose omitted longhand resets are proved not to disturb a prior
 write the optimiser can't see.
 
+`--closed-world` is the other axis, and it is about the HTML rather than the
+CSS: it asserts you know the exact document and that no element ever matches
+two clashing selectors, so the optimiser may group rules the open world keeps
+apart. `.a{color:red}.c{color:blue}.b{color:red}` stays three rules by default,
+since a `.b.c` element would take the wrong colour, and becomes
+`.a,.b{color:red}.c{color:#00f}` under the flag. It is unsafe for any page such
+an element can appear on, including one a script builds at runtime.
+
 ### Target browsers
 
 The default minify targets maintained evergreen browsers rendering an HTML
-document, and takes five facts from that target. The HTML direction model,
+document, and takes six facts from that target. The HTML direction model,
 where every element is either `ltr` or `rtl`, shortens `:not(:dir(ltr))` to
 `:dir(rtl)`. The HTML form-control model, which says an `input` is either
 `:enabled` or `:disabled`, shortens `input:not(:enabled)` to `input:disabled`.
@@ -362,7 +380,8 @@ present is dropped, since evergreen browsers understand the unprefixed form. A
 `min-`/`max-` media or container feature becomes the Media Queries 4 range
 grammar, `(min-width: 700px)` to `(width >= 700px)`. A nested selector loses
 its `&` prefix, `& div` to `div`, which the relaxed nesting syntax reads the
-same way.
+same way. An `oklab` or `oklch` axis takes the percentage spelling wherever it
+is shorter, `oklch(.7 .304 20)` to `oklch(.7 76% 20)`.
 
 Each of those state pseudo-class pairs partitions a different set of elements,
 and outside its own set an element matches neither half, so the rewrite runs
@@ -372,7 +391,12 @@ and `input:not(:required)` both stay as the author wrote them.
 `--enforce-spec` drops those facts. Cascade still serialises to the shortest
 CSS form it knows, but neither the direction nor the form-control model is
 assumed, every vendor prefix is kept, a media or container feature keeps the
-`min-`/`max-` spelling the author wrote, and a nested selector keeps its `&`.
+`min-`/`max-` spelling the author wrote, a nested selector keeps its `&`, and a
+colour axis keeps its number form. It also keeps the quotes around a multi-word
+font-family name, whose unquoted form is shorter but is not the CSSOM-canonical
+serialisation, and holds the parser to the ident code points CSS Syntax 3 lists
+rather than reading anything above U+007F. That last one is the only part of the
+flag that acts without `--minify`.
 
 An `@supports` condition is not a target fact. CSS Conditional Rules 3 section
 6.1 defines support as the rendering browser accepting the declaration, down to

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -128,11 +128,15 @@ let scope_arg =
 
 let enforce_spec_arg =
   let doc =
-    "Keep feature queries that default $(b,--minify) would elide using \
-     evergreen-browser support facts. With $(b,--enforce-spec), $(tname) still \
-     serializes to the shortest CSS form but preserves $(b,@supports) and \
-     $(b,supports()) guards unless the CSS text and specification alone prove \
-     the rewrite. Has no effect without $(b,--minify)."
+    "Drop the evergreen-browser baseline that default $(b,--minify) targets. \
+     $(tname) still serializes to the shortest form the CSS text and the specs \
+     prove on their own, so it keeps a vendor-prefixed declaration written \
+     beside its unprefixed twin, the $(b,min-)/$(b,max-) spelling of a media \
+     or container feature, the $(b,&) prefix on a nested selector, the \
+     author's :not(:dir(ltr)) and input:not(:enabled), the number form of an \
+     oklab/oklch axis, and the quotes around a multi-word font family. It also \
+     holds the reader to the CSS Syntax 3 sec. 4.2 ident code points, which \
+     applies with or without $(b,--minify)."
   in
   Arg.(value & flag & info [ "enforce-spec" ] ~doc)
 


### PR DESCRIPTION
`cascade fmt --help` described an `@supports` elision that #584 removed, so the flag's own documentation contradicted the README that #608 corrected. It now names what `--enforce-spec` holds back, and the README gains the `--closed-world` row, the `cascade diff` flags that were only in `--help`, and a section for `cascade apply`.

#610 is the one thing this turned up that is a behaviour question rather than a wording one.
