### PR TITLE
properties: read every length unit as a border width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -95,6 +95,13 @@ recorded cases carrying six minifiers' answers.
   statement holds; call that one instead (#348)
 - `Css.Stylesheet.moz_document_condition` gains `Url_exact`, `Domain`,
   `Media_document` and `Regexp`, so a match on it is no longer exhaustive (#461)
+- `Css.border_width` gains `Dimension`, so a match on it is no longer
+  exhaustive. `border-width` takes a `<length>`, but the reader named its own
+  units and refused every other one, so `border-width: 3dvh` was dropped as
+  invalid while `margin: 3dvh` was read. The physical and logical longhands and
+  the `border` shorthand refused them too. Every dimension `Css.length` carries
+  now reads, keeping its authored spelling, and a `min()` or `max()` over units
+  with no fixed ratio between them keeps both bounds (#612)
 - An author's `@supports` guard survives `--minify`. Cascade decided the
   condition against a generated support table, which is property-granular, so
   `@supports (height: stretch)` was read as a question about `height` and every

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1724,6 +1724,9 @@ type border_width = Properties.border_width =
   | Vmin of float
   | Vmax of float
   | Pct of float
+  | Dimension of { value : float; unit : string; repr : string }
+      (** A length in a unit [border_width] does not name, carrying the authored
+          spelling in [repr] the way {!length} does. *)
   | Zero
   | Auto
   | Max_content

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -351,6 +351,7 @@ let length_of_border_width : border_width -> length option = function
   | Vmin n -> Some (Vmin n)
   | Vmax n -> Some (Vmax n)
   | Pct n -> Some (Pct n)
+  | Dimension { value; unit; repr } -> Some (Dimension { value; unit; repr })
   | Zero -> Some Zero
   | _ -> None
 
@@ -495,54 +496,38 @@ let pp_length_calc_contents ctx calc =
   in
   pp_inner ~parent_prec:0 ~right_of_noncommut:false ctx calc
 
-let border_width_length_measure : length -> [ `Abs | `Unit of string ] * float =
-  function
-  | Px n -> (`Abs, n)
-  | In n -> (`Abs, n *. 96.)
-  | Cm n -> (`Abs, n *. 96. /. 2.54)
-  | Mm n -> (`Abs, n *. 96. /. 25.4)
-  | Q n -> (`Abs, n *. 96. /. 101.6)
-  | Pt n -> (`Abs, n *. 96. /. 72.)
-  | Pc n -> (`Abs, n *. 16.)
-  | Rem n -> (`Unit "rem", n)
-  | Em n -> (`Unit "em", n)
-  | Ex n -> (`Unit "ex", n)
-  | Cap n -> (`Unit "cap", n)
-  | Ic n -> (`Unit "ic", n)
-  | Ric n -> (`Unit "ric", n)
-  | Rlh n -> (`Unit "rlh", n)
-  | Ch n -> (`Unit "ch", n)
-  | Lh n -> (`Unit "lh", n)
-  | Vw n -> (`Unit "vw", n)
-  | Vh n -> (`Unit "vh", n)
-  | Vmin n -> (`Unit "vmin", n)
-  | Vmax n -> (`Unit "vmax", n)
-  | Pct n -> (`Unit "%", n)
-  | Zero -> (`Abs, 0.)
-  | _ -> (`Unit "", nan)
-
-let comparable_border_width_length length :
-    ([ `Abs | `Unit of string ] * float) option =
-  match border_width_length_measure length with
-  | `Unit "", _ -> None
-  | key, n -> Some (key, n)
+(* Two arguments of a [min()] / [max()] compare only when they share a unit. CSS
+   Values 4 sec. 6.2 puts the absolute units on one scale, so they share the
+   [px] key; every other unit compares only with itself. *)
+let border_width_length_measure length : (string * float) option =
+  match Values.calc_length_unit length with
+  | None -> None
+  | Some (unit, n) -> (
+      match Values.absolute_unit_px_ratio unit with
+      | Some ratio -> Some ("px", n *. ratio)
+      | None -> Some (unit, n))
 
 let border_width_calc_length = function Val length -> Some length | _ -> None
 
-let record_border_width_group kind groups pos length =
-  match comparable_border_width_length length with
-  | None -> ()
-  | Some (key, n) ->
-      let keep =
-        match Hashtbl.find_opt groups key with
-        | None -> (pos, length, n)
-        | Some (old_pos, old_length, old_n) ->
-            let better =
-              match kind with `Min -> n < old_n | `Max -> n > old_n
-            in
-            if better then (old_pos, length, n) else (old_pos, old_length, old_n)
-      in
-      Hashtbl.replace groups key keep
+let record_border_width_group kind groups pos (length, key, n) =
+  let keep =
+    match Hashtbl.find_opt groups key with
+    | None -> (pos, length, n)
+    | Some (old_pos, old_length, old_n) ->
+        let better = match kind with `Min -> n < old_n | `Max -> n > old_n in
+        if better then (old_pos, length, n) else (old_pos, old_length, old_n)
+  in
+  Hashtbl.replace groups key keep
+
+(* Grouping keeps one argument per unit, so an argument no unit measures has to
+   stop the reduction: dropping it would delete a bound from the function. *)
+let measured_border_width_lengths lengths =
+  List.fold_right
+    (fun length acc ->
+      match (border_width_length_measure length, acc) with
+      | Some (key, n), Some acc -> Some ((length, key, n) :: acc)
+      | _ -> None)
+    lengths (Some [])
 
 let reduce_border_width_minmax kind args : length calc list option =
   let simplified = List.map simplified_border_width_length args in
@@ -552,16 +537,18 @@ let reduce_border_width_minmax kind args : length calc list option =
     match List.map border_width_calc_length vals with
     | lengths when List.exists Option.is_none lengths -> None
     | lengths -> (
-        let lengths = List.map Option.get lengths in
-        let groups = Hashtbl.create 4 in
-        List.iteri (record_border_width_group kind groups) lengths;
-        let reduced =
-          Hashtbl.to_seq_values groups
-          |> List.of_seq
-          |> List.sort (fun (a, _, _) (b, _, _) -> compare a b)
-          |> List.map (fun (_, length, _) -> Val length)
-        in
-        match reduced with [] -> None | _ -> Some reduced)
+        match measured_border_width_lengths (List.map Option.get lengths) with
+        | None -> None
+        | Some measured -> (
+            let groups = Hashtbl.create 4 in
+            List.iteri (record_border_width_group kind groups) measured;
+            let reduced =
+              Hashtbl.to_seq_values groups
+              |> List.of_seq
+              |> List.sort (fun (a, _, _) (b, _, _) -> compare a b)
+              |> List.map (fun (_, length, _) -> Val length)
+            in
+            match reduced with [] -> None | _ -> Some reduced))
 
 let reduce_border_width_clamp lower value upper =
   match
@@ -571,21 +558,22 @@ let reduce_border_width_clamp lower value upper =
   with
   | Some (Val lower), Some (Val value), Some (Val upper) -> (
       match
-        ( comparable_border_width_length lower,
-          comparable_border_width_length value,
-          comparable_border_width_length upper )
+        ( border_width_length_measure lower,
+          border_width_length_measure value,
+          border_width_length_measure upper )
       with
       | ( Some (lower_key, lower_n),
           Some (value_key, value_n),
           Some (upper_key, upper_n) )
-        when lower_key = value_key && value_key = upper_key ->
+        when String.equal lower_key value_key
+             && String.equal value_key upper_key ->
           Some
             (`Length
                (if value_n < lower_n then lower
                 else if value_n > upper_n then upper
                 else value))
       | Some _, Some (value_key, value_n), Some (upper_key, upper_n)
-        when value_key = upper_key && value_n <= upper_n ->
+        when String.equal value_key upper_key && value_n <= upper_n ->
           Some (`Max [ Val lower; Val value ])
       | _ -> None)
   | _ -> None
@@ -616,6 +604,11 @@ let rec pp_border_width : border_width Pp.t =
   | Vmin f -> Pp.unit ctx f "vmin"
   | Vmax f -> Pp.unit ctx f "vmax"
   | Pct f -> Pp.pct ctx f
+  | Dimension { value; unit; repr } ->
+      if Pp.minified ctx then Pp.unit ctx value unit
+      else (
+        Pp.string ctx repr;
+        Pp.string ctx unit)
   | Zero -> Pp.char ctx '0'
   | Auto -> Pp.string ctx "auto"
   | Max_content -> Pp.string ctx "max-content"
@@ -1091,10 +1084,13 @@ let ensure_non_negative_border_width t value =
     err_invalid_value t "border-width" "negative values not allowed"
   else value
 
-(* Helper: convert length to border_width, ensuring non-negative values *)
+(* [border-width] takes a [<length>], so every dimension [length] carries is
+   one. The units [border_width] names get their own arm; the rest keep their
+   value and spelling in [Dimension], the way [length] itself does, so a unit
+   [length] learns needs no second table here. *)
 let length_to_border_width t (length : length) : border_width =
   let non_neg = ensure_non_negative_border_width t in
-  let typed_dimension value unit : border_width =
+  let typed_dimension ?repr value unit : border_width =
     let value = non_neg value in
     match String.lowercase_ascii unit with
     | "%" -> Pct value
@@ -1118,33 +1114,19 @@ let length_to_border_width t (length : length) : border_width =
     | "vw" -> Vw value
     | "vmin" -> Vmin value
     | "vmax" -> Vmax value
-    | _ -> err_invalid_value t "border-width" "unsupported length type"
+    | _ ->
+        let repr =
+          match repr with Some repr -> repr | None -> Pp.string_of_float value
+        in
+        Dimension { value; unit; repr }
   in
   match length with
   | Zero -> Zero
-  | Px n -> Px (non_neg n)
-  | Cm n -> Cm (non_neg n)
-  | Mm n -> Mm (non_neg n)
-  | Q n -> Q (non_neg n)
-  | In n -> In (non_neg n)
-  | Pt n -> Pt (non_neg n)
-  | Pc n -> Pc (non_neg n)
-  | Rem n -> Rem (non_neg n)
-  | Em n -> Em (non_neg n)
-  | Ex n -> Ex (non_neg n)
-  | Cap n -> Cap (non_neg n)
-  | Ic n -> Ic (non_neg n)
-  | Ric n -> Ric (non_neg n)
-  | Rlh n -> Rlh (non_neg n)
-  | Ch n -> Ch (non_neg n)
-  | Lh n -> Lh (non_neg n)
-  | Vh n -> Vh (non_neg n)
-  | Vw n -> Vw (non_neg n)
-  | Vmin n -> Vmin (non_neg n)
-  | Vmax n -> Vmax (non_neg n)
-  | Pct n -> Pct (non_neg n)
-  | Dimension { value; unit; _ } -> typed_dimension value unit
-  | _ -> err_invalid_value t "border-width" "unsupported length type"
+  | Dimension { value; unit; repr } -> typed_dimension ~repr value unit
+  | length -> (
+      match calc_length_unit length with
+      | Some (unit, value) -> typed_dimension value unit
+      | None -> err_invalid_value t "border-width" "unsupported length type")
 
 let rec read_border_width t : border_width =
   let read_var t : border_width = Var (read_var read_border_width t) in

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -641,6 +641,7 @@ type border_width =
   | Vmin of float
   | Vmax of float
   | Pct of float
+  | Dimension of { value : float; unit : string; repr : string }
   | Zero
   | Auto
   | Max_content

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -192,6 +192,15 @@ val length_has_runtime_subst : length -> bool
 (** [length_has_runtime_subst l] is [true] when [l] is [var()] / [env()] /
     [attr()] / an anchor query, or a [calc()] containing one. *)
 
+val calc_length_unit : length -> (string * float) option
+(** [calc_length_unit l] is [Some (unit, value)] when [l] is a dimension, with
+    the unit lower-cased. A keyword, a [var()] or a math function is [None]. *)
+
+val absolute_unit_px_ratio : string -> float option
+(** [absolute_unit_px_ratio unit] is [Some ratio] when [unit] is one of the
+    absolute units CSS Values 4 sec. 6.2 puts on the [px] scale, with [ratio]
+    the number of [px] in one [unit]. A relative unit is [None]. *)
+
 val length_is_zero : length -> bool
 (** [length_is_zero l] is [true] when [l] is a literal zero in any length unit
     ([0], [0px], [0%], etc.). *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1823,6 +1823,44 @@ let test_border_width () =
   check_border_width "thick";
   check_border_width "2px";
   check_border_width ".0625rem";
+  (* border-width takes a <length>, and CSS Values 4 sec. 6.1 and 6.2 give the
+     viewport-percentage and container-query units the same standing there as
+     [vh]. Every unit [length] names is a border width. *)
+  check_border_width "3vi";
+  check_border_width "3vb";
+  check_border_width "3dvh";
+  check_border_width "3svw";
+  check_border_width "3lvmin";
+  check_border_width "2cqw";
+  check_border_width "2cqi";
+  check_border_width "2cqmax";
+  (* Every property whose width component is a border width reads those units:
+     the four physical longhands, their logical counterparts, and the 1-4 value
+     shorthand. *)
+  decl_optimizes ~prop:"border-top-width" ~held:"3dvh" ~into:"3dvh" "3dvh";
+  decl_optimizes ~prop:"border-right-width" ~held:"2cqi" ~into:"2cqi" "2cqi";
+  decl_optimizes ~prop:"border-bottom-width" ~held:"3svw" ~into:"3svw" "3svw";
+  decl_optimizes ~prop:"border-left-width" ~held:"3lvmin" ~into:"3lvmin"
+    "3lvmin";
+  decl_optimizes ~prop:"border-block-start-width" ~held:"3dvh" ~into:"3dvh"
+    "3dvh";
+  decl_optimizes ~prop:"border-inline-end-width" ~held:"2cqw" ~into:"2cqw"
+    "2cqw";
+  decl_optimizes ~prop:"border-width" ~held:"3dvh 2cqi" ~into:"3dvh 2cqi"
+    "3dvh 2cqi";
+  (* Two units with no fixed ratio leave both bounds standing: [dvh] is a
+     fraction of the viewport and [px] is absolute (CSS Values 4 sec. 6.1 and
+     6.2), so neither argument of the comparison is redundant. *)
+  check_border_width "min(3dvh,4px)";
+  check_border_width "max(3dvh,4px)";
+  check_border_width "clamp(1dvh,3dvh,4px)";
+  (* One unit does compare with itself, and a container-query length grows with
+     its multiplier, so the smaller multiple is the minimum. *)
+  check_border_width ~expected:"2cqi" "min(2cqi,3cqi)";
+  check_border_width ~expected:"4dvh" "max(3dvh,4dvh)";
+  (* A bound nothing else measures stops only its own group: [1px] and [2px]
+     stay on one scale (CSS Values 4 sec. 6.2), so they collapse. *)
+  check_border_width ~expected:"max(2px,3dvh)" "max(1px,3dvh,2px)";
   (* A zero-valued border-width collapses the unit like any other zero length
      (border-width: 0px -> 0), matching width/outline-width. Holds for the
      longhand, the logical longhand, and the 1-4 value shorthand; non-zero


### PR DESCRIPTION
`border-width: 3dvh` was dropped as invalid while `margin: 3dvh` in the same rule was read, because the border-width reader named its own units instead of taking the `<length>` the grammar gives it. `2cqi`, `3svw` and `1vi` went the same way, on the shorthand and on every longhand, physical and logical.

`min(3dvh, 4px)` would then have folded to `4px`, since the `min()` / `max()` reduction dropped a bound no unit measures; it now stops at such a bound instead.
