### PR TITLE
pp: elide the position separator at a percentage boundary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -436,6 +436,14 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` drops the space between the components of a position value, so
+  `background-position:100% 0` prints as `background-position:100%0`. CSS
+  Syntax 3 sec. 4.3.3 consumes the `%` into the percentage token, so whatever
+  follows starts a fresh token and the space cannot change how the value
+  reads; `polygon()` and `animation-range` already elided at that boundary
+  and a position value did not. The rule now also covers a component that
+  ends in `)`, such as a `var()` inside `polygon()`. A unit keeps its space,
+  since `10px 0` would re-tokenise as the single dimension `10px0` (#614)
 - `--minify` merges rules whose colours differ only in how a hex was
   spelled. The digits are case-insensitive and `#RGB` expands by duplicating
   each of them (CSS Color 4 sec. 5.2), but the authored spelling survived

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -204,14 +204,14 @@ let rec pp_position_value : position_value Pp.t =
   | Bottom_right -> Pp.string ctx "bottom right"
   | XY (a, b) ->
       pp_length ctx a;
-      Pp.space ctx ();
+      Pp.token_sp ctx ();
       pp_length ctx b
   | Single l -> pp_length ctx l
   | Edge_offset_axis (edge, offset, axis) ->
       Pp.string ctx edge;
       Pp.space ctx ();
       pp_position_offset ctx offset;
-      Pp.space ctx ();
+      Pp.token_sp ctx ();
       Pp.string ctx axis
   | Axis_edge_offset (axis, edge, offset) ->
       Pp.string ctx axis;
@@ -223,7 +223,7 @@ let rec pp_position_value : position_value Pp.t =
       Pp.string ctx edge1;
       Pp.space ctx ();
       pp_position_offset ctx offset1;
-      Pp.space ctx ();
+      Pp.token_sp ctx ();
       Pp.string ctx edge2;
       Pp.space ctx ();
       pp_position_offset ctx offset2

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -296,8 +296,7 @@ let pp_clip_path_polygon_sep spaced ctx () =
 
 let pp_clip_path_axis_pair ctx (x, y) =
   pp_length ctx x;
-  if not (Pp.minified ctx && match x with Pct _ -> true | _ -> false) then
-    Pp.space ctx ();
+  Pp.token_sp ctx ();
   pp_length ctx y
 
 let pp_clip_path_polygon_body ctx fill_rule points spaced =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -452,7 +452,7 @@ let special_cases () =
 
   (* One position per background layer, comma-separated: joining the layers with
      spaces reads as a single four-value position. *)
-  check_declaration ~expected:"background-position:30% 50%,70% 50%"
+  check_declaration ~expected:"background-position:30%50%,70%50%"
     ~optimized:"background-position:30%,70%"
     "background-position: 30% 50%, 70% 50%;";
   check_declaration ~expected:"mask-position:0 0,10px 10px"

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2810,20 +2810,26 @@ let test_conic_gradient_config () =
   neg_cursor read_conic_gradient_config "center";
   neg_cursor read_conic_gradient_config "from"
 
+(* CSS Syntax 3 sec. 4.3.3 consumes the [%] into the percentage token, so
+   whatever follows starts a fresh token and the separating space carries no
+   meaning: it elides under minify, as it already does inside polygon() and
+   animation-range. A unit ends in an ident instead ([10px 0] would re-tokenise
+   as the single dimension [10px0]), so that space stays. *)
 let test_background_position () =
   check_background_position "center";
   check_background_position "left top";
-  check_background_position ~expected:"100% 0" "right 0";
-  check_background_position ~expected:"100% -15.625rem" "right -15.625rem";
+  check_background_position ~roundtrip:true ~expected:"100%0" "right 0";
+  check_background_position ~roundtrip:true ~expected:"100%-15.625rem"
+    "right -15.625rem";
   check_background_position "right .5rem center";
-  check_background_position "50% 25%";
+  check_background_position ~roundtrip:true ~expected:"50%25%" "50% 25%";
   check_background_position "inherit";
   neg_cursor ~allow_partial:true read_background_position "invalid-position"
 
 let test_position_value () =
   check_position_value "center";
   check_position_value "left top";
-  check_position_value "50% 25%";
+  check_position_value ~roundtrip:true ~expected:"50%25%" "50% 25%";
   check_position_value "inherit";
   neg_cursor ~allow_partial:true read_position_value "invalid-position"
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5815,7 +5815,7 @@ let bg336_position_keyword () =
     (normalize ".x { background-position: left top }");
   Alcotest.(check string)
     "background-position: bottom right -> 100% 100%"
-    ".x{background-position:100% 100%}"
+    ".x{background-position:100%100%}"
     (normalize ".x { background-position: bottom right }")
 
 (* CSS Cascade L5 section 6.1: when two rules with different selectors share the


### PR DESCRIPTION
`background-position:100% 0` used to keep a space that `polygon()` and `animation-range` already dropped at the same boundary, so cascade gave two answers for one token boundary. Both now go through `Pp.token_sp`, which decides from the character emitted: CSS Syntax 3 sec. 4.3.3 consumes the `%` into the percentage token, so whatever follows starts a fresh token, while a unit is left alone because `10px 0` would re-tokenise as the single dimension `10px0`.
