### PR TITLE
properties: invalidate a border width comparison it cannot read whole

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,16 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- An argument a border width comparison cannot read invalidates the
+  declaration. The reader stopped at the first such argument and compared the
+  ones before it, so `border-width: max(1px, red)` became `1px` and
+  `border-width: min(3px, red, 1px)` became `3px`, a narrower comparison than
+  the one written and one an author never asked for; `margin` dropped both
+  already. CSS Values 4 sec. 10.2 gives `min()` and `max()` a list of
+  `<calc-sum>` and `clamp()` three arguments, and CSS Syntax 3 sec. 8.2 makes
+  an invalid value invalidate the declaration. The four physical longhands,
+  their logical counterparts, the 1-4 value shorthand and the width slot of
+  `border` all read through that reader (#617)
 - An at-rule or function name written in another case names what it spells.
   CSS Values 4 sec. 4.1 makes both of them keywords, so `@MEDIA`,
   `@Font-Face`, `RGB()`, `color-mix(IN srgb, ...)`, `background: URL("a.png")`,

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1128,24 +1128,30 @@ let length_to_border_width t (length : length) : border_width =
       | Some (unit, value) -> typed_dimension value unit
       | None -> err_invalid_value t "border-width" "unsupported length type")
 
+(* CSS Values 4 sec. 10.2: every argument of a comparison function is a
+   [<calc-sum>], and [clamp()] takes three. [Cursor.list] stops at the first
+   argument it cannot read, so the body has to be read to its end: comparing the
+   prefix answers a different question, and CSS Syntax 3 sec. 8.2 makes an
+   invalid value invalidate the declaration. *)
+let read_math_args ?at_most ~at_least read_arg t =
+  let args = Cursor.list ~sep:Cursor.comma ~at_least ?at_most read_arg t in
+  Cursor.expect_eof t;
+  args
+
 let rec read_border_width t : border_width =
   let read_var t : border_width = Var (read_var read_border_width t) in
   let read_calc t : border_width = Calc (read_calc read_border_width t) in
   let read_math_arg t = read_calc_expr read_border_width t in
   let read_min t : border_width =
-    Min
-      (Cursor.call "min" t
-         (Cursor.list ~sep:Cursor.comma ~at_least:1 read_math_arg))
+    Min (Cursor.call "min" t (read_math_args ~at_least:1 read_math_arg))
   in
   let read_max t : border_width =
-    Max
-      (Cursor.call "max" t
-         (Cursor.list ~sep:Cursor.comma ~at_least:1 read_math_arg))
+    Max (Cursor.call "max" t (read_math_args ~at_least:1 read_math_arg))
   in
   let read_clamp t : border_width =
     match
       Cursor.call "clamp" t
-        (Cursor.list ~sep:Cursor.comma ~at_least:3 ~at_most:3 read_math_arg)
+        (read_math_args ~at_least:3 ~at_most:3 read_math_arg)
     with
     | [ lower; value; upper ] -> Clamp (lower, value, upper)
     | _ -> Cursor.err_invalid t "invalid clamp"

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2969,6 +2969,58 @@ let shape_outside_sheet () =
       "a{shape-outside:url(shape.png)}";
     ]
 
+(* Every property that reads a [<line-width>]: the four physical longhands and
+   their logical counterparts, the 1-4 value shorthand, the two-value logical
+   shorthands, and the width slot of [border]. *)
+let line_width_sites value =
+  List.map
+    (fun property -> String.concat "" [ property; ":"; value ])
+    [
+      "border-width";
+      "border-top-width";
+      "border-right-width";
+      "border-bottom-width";
+      "border-left-width";
+      "border-block-start-width";
+      "border-block-end-width";
+      "border-inline-start-width";
+      "border-inline-end-width";
+      "border-block-width";
+      "border-inline-width";
+      "border";
+    ]
+
+(* A [<length>] site reading the same comparison, for contrast. *)
+let length_math_sites value =
+  List.map
+    (fun property -> String.concat "" [ property; ":"; value ])
+    [ "margin"; "margin-top"; "outline-width"; "width" ]
+
+(* CSS Values 4 sec. 10.2 gives [min()] / [max()] a comma-separated list of
+   [<calc-sum>] and [clamp()] exactly three arguments, and CSS Syntax 3 sec. 8.2
+   drops a declaration whose value is invalid. The [<length>] sites answer that
+   way already. The [<line-width>] sites read arguments up to the first one they
+   could not read and compared those, so [max(1px,red)] answered [1px]: a
+   narrower comparison than the one written, and one the author never asked
+   for. *)
+let line_width_invalid_math_argument () =
+  List.iter
+    (fun value ->
+      List.iter (neg_cursor read_declaration) (line_width_sites value);
+      List.iter (neg_cursor read_declaration) (length_math_sites value))
+    [
+      "max(1px,red)";
+      "min(3px,red,1px)";
+      "max(1px 2px)";
+      "clamp(1px,2px,3px,4px)";
+    ];
+  (* Controls: two bounds no unit relates stand as written at every site, and
+     the 1-4 value shorthand still takes one per side. *)
+  List.iter
+    (fun css -> check_declaration ~roundtrip:true css)
+    (line_width_sites "max(3dvh,4px)" @ length_math_sites "max(3dvh,4px)");
+  check_declaration ~roundtrip:true "border-width:1px max(3dvh,4px)"
+
 (* CSS Backgrounds 3 sec. 5.1: [border-radius] is [<length-percentage
    [0,inf]>{1,4} [ / <length-percentage [0,inf]>{1,4} ]?], so an
    intrinsic-sizing keyword ([auto], [max-content], [stretch], ...) is no part
@@ -3401,6 +3453,8 @@ let declaration_tests =
       scroll_margin_negative_sheet;
     test_case "shape-outside grammar" `Quick shape_outside_grammar;
     test_case "shape-outside grammar (sheet)" `Quick shape_outside_sheet;
+    test_case "line-width invalid math argument" `Quick
+      line_width_invalid_math_argument;
     test_case "border-radius keyword radii" `Quick border_radius_keyword_radii;
     test_case "border-radius CSS-wide keywords" `Quick
       border_radius_css_wide_keywords;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1871,6 +1871,21 @@ let test_border_width () =
   decl_optimizes ~prop:"border-width" ~held:"0px 1px 0 2rem"
     ~into:"0 1px 0 2rem" "0px 1px 0 2rem";
   decl_optimizes ~prop:"border-width" ~held:"2px" ~into:"2px" "2px";
+  (* Whitespace around an argument is not an argument, so the comparison still
+     reads as two bounds. *)
+  check_border_width ~expected:"max(3dvh,4px)" "max( 3dvh , 4px )";
+  (* CSS Values 4 sec. 10.2 gives [min()] / [max()] a comma-separated list of
+     [<calc-sum>] and [clamp()] exactly three arguments. An argument that is no
+     [<calc-sum>], a second bound with no comma before it, and a fourth
+     [clamp()] argument each make the function invalid, and CSS Syntax 3 sec.
+     8.2 makes an invalid value invalidate the declaration. Reading arguments up
+     to the first unreadable one and comparing those is a different function:
+     [min(3px,red,1px)] answers [3px] where the bound that decides the minimum
+     is [1px]. *)
+  neg_cursor read_border_width "max(1px,red)";
+  neg_cursor read_border_width "min(3px,red,1px)";
+  neg_cursor read_border_width "max(1px 2px)";
+  neg_cursor read_border_width "clamp(1px,2px,3px,4px)";
   neg_cursor read_border_width "invalid-width";
   neg_cursor read_border_width "-2px";
   (* negative width *)


### PR DESCRIPTION
`border-width: max(1px, red)` used to print `1px`, while `margin: max(1px, red)` was dropped. Both readers build the argument list with `Cursor.list`, which stops at the first argument it cannot read; the `<length>` readers then close the function body with `expect_eof` and the border-width ones did not, so the comparison silently shrank to the arguments that happened to parse. `min(3px, red, 1px)` answered `3px`, dropping the bound that decides the minimum.

The same reader serves the four physical longhands, their logical counterparts, the 1-4 value shorthand and the width slot of `border`; `outline-width` and `width` read through `<length>` and were already correct.
