### PR TITLE
values: fold a color-mix that lands outside the sRGB gamut

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -454,6 +454,10 @@ recorded cases carrying six minifiers' answers.
   and a position value did not. The rule now also covers a component that
   ends in `)`, such as a `var()` inside `polygon()`. A unit keeps its space,
   since `10px 0` would re-tokenise as the single dimension `10px0` (#614)
+- `--minify` folds a `color-mix()` in a wide-gamut rectangular space, and one in
+  `srgb` whose result leaves that gamut; both used to reach the browser
+  unfolded. The result keeps the space that was named rather than being gamut
+  mapped (#618)
 - `--minify` merges rules whose colours differ only in how a hex was
   spelled. The digits are case-insensitive and `#RGB` expands by duplicating
   each of them (CSS Color 4 sec. 5.2), but the authored spelling survived

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3408,6 +3408,78 @@ let mix_in_lch_space c1 c2 ~p1 ~p2 hue : color option =
                }))
   | _ -> None
 
+let map3 f (x, y, z) = (f x, f y, f z)
+
+(* Inverse of the [Color] arm of [static_color_to_linear_srgb]: linear sRGB back
+   into the coordinates of a predefined [color()] space, by the CSS Color 4 sec.
+   19 reference conversions. [None] for the spaces [color()] cannot spell (the
+   lab and polar families), which have their own mixers. *)
+let coords_of_linear_srgb (space : color_space) lrgb :
+    (float * float * float) option =
+  match space with
+  | Srgb -> Some (Color_space.rgb_of_linear_rgb lrgb)
+  | Srgb_linear -> Some lrgb
+  | Display_p3 ->
+      Some
+        (map3 Color_space.display_p3_of_linear
+           (Color_space.linear_p3_of_xyz65
+              (Color_space.xyz65_of_linear_srgb lrgb)))
+  | A98_rgb ->
+      Some
+        (map3 Color_space.a98_rgb_of_linear
+           (Color_space.linear_a98_of_xyz65
+              (Color_space.xyz65_of_linear_srgb lrgb)))
+  | Prophoto_rgb ->
+      Some
+        (map3 Color_space.prophoto_rgb_of_linear
+           (Color_space.linear_prophoto_of_xyz50
+              (Color_space.d50_of_xyz65 (Color_space.xyz65_of_linear_srgb lrgb))))
+  | Rec2020 ->
+      Some
+        (map3 Color_space.rec2020_of_linear
+           (Color_space.linear_rec2020_of_xyz65
+              (Color_space.xyz65_of_linear_srgb lrgb)))
+  | Xyz | Xyz_d65 -> Some (Color_space.xyz65_of_linear_srgb lrgb)
+  | Xyz_d50 ->
+      Some (Color_space.d50_of_xyz65 (Color_space.xyz65_of_linear_srgb lrgb))
+  | Lab | Oklab | Lch | Oklch | Hsl | Hwb -> None
+
+(* CSS Color 5 sec. 3: mixing in one of the rectangular [color()] spaces. The
+   operands are carried into that space's own coordinates, mixed premultiplied
+   there (CSS Color 4 sec. 13.3), and the result named in the same space. CSS
+   Color 4 sec. 10.1 leaves [color()] coordinates unclamped, so a mix that ends
+   outside the space's gamut is still a value: gamut mapping it (sec. 14.2) is
+   what a display does, not what the colour is.
+
+   The coordinates come back through a conversion round trip, which leaves float
+   noise many orders of magnitude below a channel step. Rounding to six decimals
+   clears it; [color_channel_decimals] never prints more than six for a colour
+   channel, so no digit that would have been shown is lost. *)
+let mix_in_rectangular_space (space : color_space) c1 c2 ~p1 ~p2 : color option
+    =
+  let round6 v = Float.round (v *. 1e6) /. 1e6 in
+  match (static_color_to_linear_srgb c1, static_color_to_linear_srgb c2) with
+  | Some (lrgb1, alpha1), Some (lrgb2, alpha2) -> (
+      match
+        ( coords_of_linear_srgb space lrgb1,
+          coords_of_linear_srgb space lrgb2,
+          mix_weights p1 p2 )
+      with
+      | Some x1, Some x2, Some (w1, w2, alpha_mult) ->
+          let (c1, c2, c3), interp_alpha =
+            premult_mix3 ~w1 ~w2 ~a1:alpha1 ~a2:alpha2 x1 x2
+          in
+          Some
+            (Color
+               {
+                 space;
+                 components =
+                   [ Num (round6 c1); Num (round6 c2); Num (round6 c3) ];
+                 alpha = alpha_of_unit_float (interp_alpha *. alpha_mult);
+               })
+      | _ -> None)
+  | _ -> None
+
 (* CSS Color 5 sec. 3 percentage normalisation: an omitted [percentN] takes the
    complement of the other side ([100% - percentM], clamped to 0); both omitted
    defaults to [50% / 50%]. *)
@@ -7509,7 +7581,10 @@ let normalize_srgb_mix color1 color2 ~p1 ~p2 =
       ~p1 ~p2
   with
   | Some (r, g, b, a) -> Some (canonical_color_of_hex r g b a)
-  | Option.None -> None
+  (* The byte mixer only speaks sRGB bytes, so it declines a mix whose operands
+     or result leave the sRGB gamut. The result is a colour all the same, and
+     [color(srgb ...)] can hold it. *)
+  | Option.None -> mix_in_rectangular_space Srgb color1 color2 ~p1 ~p2
 
 let normalize_lab_family_mix effective color1 color2 ~p1 ~p2 =
   match mix_lab_family effective color1 color2 ~p1 ~p2 with
@@ -7647,6 +7722,12 @@ and normalize_mix_color ~lossless ~in_space ~hue ~color1 ~percent1 ~color2
       match (in_space, hue, color_mix_percentages percent1 percent2) with
       | Some Srgb, Default, Some (p1, p2) ->
           normalize_srgb_mix color1 color2 ~p1 ~p2
+      | ( Some
+            (( Srgb_linear | Display_p3 | A98_rgb | Prophoto_rgb | Rec2020 | Xyz
+             | Xyz_d50 | Xyz_d65 ) as space),
+          Default,
+          Some (p1, p2) ) ->
+          mix_in_rectangular_space space color1 color2 ~p1 ~p2
       | ((Some (Lab | Oklab | Lch | Oklch) | None) as sp), Default, Some (p1, p2)
         ->
           (* CSS Color 5 sec. 3: [in oklab] is the default interpolation space,

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1478,6 +1478,67 @@ let spec_color5_function_edges () =
   neg_cursor read_color "color-mix(in, red, blue)";
   neg_cursor read_color "color-mix(in srgb red blue)"
 
+(* CSS Color 5 sec. 3: the result of [color-mix()] is a colour in the named
+   interpolation space, and CSS Color 4 sec. 10.1 keeps [color()] coordinates
+   unclamped, so a mix that lands outside the sRGB gamut is still a value the
+   fold can name - [color(srgb ...)] - not a reason to leave the [color-mix()]
+   standing for the browser to recompute. The coefficients are the CSS Color 4
+   sec. 19 reference conversions of each operand into sRGB, mixed premultiplied
+   per sec. 13.3. Gamut mapping the result (sec. 14.2) is a rendering answer,
+   not this value, so the fold must not reach for it. *)
+let spec_color5_mix_out_of_srgb_gamut () =
+  (* Display-P3 red is outside sRGB on the red axis and below zero on the other
+     two. *)
+  check_color
+    ~expected:"color-mix(in srgb,color(display-p3 1 0 0) 50%,transparent)"
+    ~optimized:"color(srgb 1.093-.227-.15/.5)"
+    "color-mix(in srgb, color(display-p3 1 0 0) 50%, transparent)";
+  (* The same holds for the other predefined RGB spaces and for XYZ: nothing
+     here is specific to one [color()] space. *)
+  check_color
+    ~expected:"color-mix(in srgb,color(a98-rgb .2 .4 .6) 50%,transparent)"
+    ~optimized:"color(srgb -.115 .401 .613/.5)"
+    "color-mix(in srgb, color(a98-rgb 0.2 0.4 0.6) 50%, transparent)";
+  check_color ~expected:"color-mix(in srgb,color(xyz .2 .3 .4) 50%,transparent)"
+    ~optimized:"color(srgb -.115 .654 .644/.5)"
+    "color-mix(in srgb, color(xyz 0.2 0.3 0.4) 50%, transparent)";
+  (* Nor to [color()]: an [oklch()] operand whose mix leaves the gamut was held
+     back by the same rule. *)
+  check_color ~expected:"color-mix(in srgb,oklch(70%.15 200) 50%,transparent)"
+    ~optimized:"color(srgb -.317 .724 .764/.5)"
+    "color-mix(in srgb, oklch(70% 0.15 200) 50%, transparent)"
+
+(* CSS Color 5 sec. 3 <rectangular-color-space>: [srgb], [srgb-linear],
+   [display-p3], [a98-rgb], [prophoto-rgb], [rec2020], [lab], [oklab], [xyz],
+   [xyz-d50] and [xyz-d65] are all interpolation spaces. Mixing red and blue in
+   each folds to the colour the CSS Color 4 sec. 19 conversions give, collapsed
+   to hex when sRGB can hold it. XYZ is a linear-light transform of linear sRGB,
+   so [in xyz], [in xyz-d50], [in xyz-d65] and [in srgb-linear] all agree. *)
+let spec_color5_mix_rectangular_spaces () =
+  check_color ~expected:"color-mix(in srgb-linear,red,blue)"
+    ~optimized:"#bc00bc" "color-mix(in srgb-linear, red, blue)";
+  check_color ~expected:"color-mix(in xyz,red,blue)" ~optimized:"#bc00bc"
+    "color-mix(in xyz, red, blue)";
+  check_color ~expected:"color-mix(in xyz,red,blue)" ~optimized:"#bc00bc"
+    "color-mix(in xyz-d65, red, blue)";
+  check_color ~expected:"color-mix(in xyz-d50,red,blue)" ~optimized:"#bc00bc"
+    "color-mix(in xyz-d50, red, blue)";
+  check_color ~expected:"color-mix(in display-p3,red,blue)" ~optimized:"#800a91"
+    "color-mix(in display-p3, red, blue)";
+  check_color ~expected:"color-mix(in a98-rgb,red,blue)" ~optimized:"#810081"
+    "color-mix(in a98-rgb, red, blue)";
+  check_color ~expected:"color-mix(in prophoto-rgb,red,blue)"
+    ~optimized:"#ba039d" "color-mix(in prophoto-rgb, red, blue)";
+  check_color ~expected:"color-mix(in rec2020,red,blue)" ~optimized:"#a21393"
+    "color-mix(in rec2020, red, blue)";
+  (* Half-strength Display-P3 primaries stay outside sRGB, so the mix keeps the
+     interpolation space it was asked for. *)
+  check_color
+    ~expected:
+      "color-mix(in display-p3,color(display-p3 1 0 0),color(display-p3 0 0 1))"
+    ~optimized:"color(display-p3 .5 0 .5)"
+    "color-mix(in display-p3, color(display-p3 1 0 0), color(display-p3 0 0 1))"
+
 let spec_color_invalid_mutation_matrix () =
   List.iter
     (fun input -> neg_cursor read_color input)
@@ -1661,6 +1722,10 @@ let value_tests =
     test_case "spec values level 4/5 math and color edges" `Quick
       spec_values_l45_math_color;
     test_case "spec color 5 function edges" `Quick spec_color5_function_edges;
+    test_case "spec color 5 mix out of sRGB gamut" `Quick
+      spec_color5_mix_out_of_srgb_gamut;
+    test_case "spec color 5 mix in rectangular spaces" `Quick
+      spec_color5_mix_rectangular_spaces;
     test_case "spec color invalid mutation matrix" `Quick
       spec_color_invalid_mutation_matrix;
     test_case "spec math function edges" `Quick spec_math_function_edges;


### PR DESCRIPTION
`--minify` left a `color-mix()` unfolded whenever its mixer could not work in 8-bit sRGB, so a mix naming a wide-gamut space, or one in `srgb` whose result leaves that gamut, reached the browser as written.

The fold stops short of gamut mapping the result, which is what a display does with a colour rather than what the colour is.
