### PR TITLE
prop: elide box-shorthand values at a percent boundary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -446,6 +446,12 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` drops the space between the values of `margin`, `padding`,
+  `inset` and `border-radius` (and `border-color`, which shares the same
+  printer) at a `%` or `)` boundary, the token-boundary rule already applied
+  to `background-position` (#614): `margin:10% 0` prints as `margin:10%0`. A
+  value ending in a unit still keeps its space, since `10px 0` would
+  re-tokenise as `10px0` (#619)
 - `--minify` drops the space between the components of a position value, so
   `background-position:100% 0` prints as `background-position:100%0`. CSS
   Syntax 3 sec. 4.3.3 consumes the `%` into the percentage token, so whatever

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -153,7 +153,7 @@ let collapse_box_shorthand vs =
 
 let pp_box_shorthand pp ctx vs =
   let vs = if Pp.minified ctx then collapse_box_shorthand vs else vs in
-  Pp.list ~sep:Pp.space pp ctx vs
+  Pp.list ~sep:Pp.token_sp pp ctx vs
 
 (* Canonicalise a colour to its shortest spelling. *)
 let normalize_color ?(lossless = false) = Values.normalize_color ~lossless

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -421,6 +421,26 @@ let normalize_expected ~category ~id expected =
       fixture ~category ~id
         ~upstream:"a{mask:linear-gradient(#000,transparent)}"
         ~cascade:"a{mask:linear-gradient(#000,#0000)}" upstream
+  | "shorthands", "0061" ->
+      (* Four longhands with a matching [@property] each merge into one
+         [padding] shorthand. A [var()] reference ends at [)], the same
+         self-delimiting token boundary as [url(...)], so the space before the
+         next [var()] is not part of the value. *)
+      fixture ~category ~id
+        ~upstream:
+          "@property \
+           --pt{syntax:\"<length>\";inherits:false;initial-value:0px}@property \
+           --pr{syntax:\"<length>\";inherits:false;initial-value:0px}@property \
+           --pb{syntax:\"<length>\";inherits:false;initial-value:0px}@property \
+           --pl{syntax:\"<length>\";inherits:false;initial-value:0px}a{padding:var(--pt) \
+           var(--pr) var(--pb) var(--pl)}"
+        ~cascade:
+          "@property \
+           --pt{syntax:\"<length>\";inherits:false;initial-value:0px}@property \
+           --pr{syntax:\"<length>\";inherits:false;initial-value:0px}@property \
+           --pb{syntax:\"<length>\";inherits:false;initial-value:0px}@property \
+           --pl{syntax:\"<length>\";inherits:false;initial-value:0px}a{padding:var(--pt)var(--pr)var(--pb)var(--pl)}"
+        upstream
   | "shorthands", "0065" ->
       (* The fixture runs under stylesheet scope: [--custom] has no matching
          @position-try rule anywhere in the fixture, so the fallback list can

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -456,7 +456,25 @@ let special_cases () =
     ~optimized:"background-position:30%,70%"
     "background-position: 30% 50%, 70% 50%;";
   check_declaration ~expected:"mask-position:0 0,10px 10px"
-    "mask-position: 0 0, 10px 10px;"
+    "mask-position: 0 0, 10px 10px;";
+
+  (* CSS Box 4 sec. 7.1 box shorthands elide the same percentage token boundary
+     as background-position (CSS Syntax 3 sec. 4.3.3): a % closes the
+     percentage-token, so a following length starts a fresh token with no
+     re-tokenisation risk. A unit keeps its space: [10px0] would re-tokenise as
+     the single dimension 10px0. *)
+  check_declaration ~expected:"margin:10%0" "margin: 10% 0;";
+  check_declaration ~expected:"margin:10px 0" "margin: 10px 0;";
+  check_declaration ~expected:"padding:10%0" "padding: 10% 0;";
+  check_declaration ~expected:"inset:10%0" "inset: 10% 0;";
+  check_declaration ~expected:"border-radius:10%0" "border-radius: 10% 0;";
+  check_declaration ~expected:"border-radius:10%20%/30%0"
+    "border-radius: 10% 20% / 30% 0;";
+
+  (* border-color shares the same box-shorthand printer, so a colour function's
+     closing paren gets the same elision. *)
+  check_declaration ~expected:"border-color:var(--c)red"
+    "border-color: var(--c) red;"
 
 let colors () =
   (* Same-node spellings the printer keeps (case-fold, hex shorten). The

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -8237,8 +8237,7 @@ let customprops12_shorthand_calc () =
     "var() inside calc() preserved" ".x{width:calc(var(--x) + 10px)}"
     (normalize ".x { width: calc(var(--x) + 10px) }");
   Alcotest.(check string)
-    "multiple var() in one value preserved"
-    ".x{padding:var(--top) var(--right)}"
+    "multiple var() in one value preserved" ".x{padding:var(--top)var(--right)}"
     (normalize ".x { padding: var(--top) var(--right) }")
 
 let fidelity_var_fallback_preserved () =


### PR DESCRIPTION
`margin`, `padding`, `inset` and `border-radius` (and `border-color`, which shares the printer) kept a plain space between values where `background-position` already elides one at the same token boundary (#614).
