### PR TITLE
prop: fold var() and color-stop() function names to lower case

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,15 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A `var()` or `-webkit-gradient()` `color-stop()` written in another case is
+  read as that function. CSS Values 4 sec. 4.1 makes a function name ASCII
+  case-insensitive, but `transition`'s shorthand read a capitalised `VAR(--x)`
+  as a duration instead of the property, turning
+  `transition: VAR(--x) 1s ease` into `transition: all var(--x) ease 1s`, and
+  a capitalised `COLOR-STOP()` inside `-webkit-gradient()` dropped the whole
+  `background` declaration. `display`, `animation-timeline`, `container`,
+  `box-shadow`'s `inset` and `@font-face`'s `unicode-range` had the same gap
+  (#620)
 - An argument a border width comparison cannot read invalidates the
   declaration. The reader stopped at the first such argument and compared the
   ones before it, so `border-width: max(1px, red)` became `1px` and

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -699,11 +699,11 @@ let read_shape_outside t =
   (match Cursor.peek t with
   | Some
       (Component.Func
-         { node = { name = "var"; terminated = true; arguments = []; _ }; _ })
-    ->
+         { node = { name; terminated = true; arguments = []; _ }; _ })
+    when String.lowercase_ascii_preserve name = "var" ->
       Cursor.err_invalid t "empty var()"
-  | Some (Component.Func { node = { name = "var"; terminated = true; _ }; _ })
-    ->
+  | Some (Component.Func { node = { name; terminated = true; _ }; _ })
+    when String.lowercase_ascii_preserve name = "var" ->
       let _ : string var =
         Values.read_var
           (fun inner -> Cursor.consume_remaining_as_string ~trim:true inner)

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -510,7 +510,8 @@ let rec pp_transition : transition Pp.t =
 let rec read_animation_timeline (t : Cursor.t) : animation_timeline =
   Cursor.ws t;
   match Cursor.peek t with
-  | Some (Component.Func { node = { name = "var"; _ }; _ }) ->
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii_preserve name = "var" ->
       (Var (Values.read_var read_animation_timeline t) : animation_timeline)
   | Some (Component.Func fn) when not fn.node.terminated ->
       Cursor.err_invalid t
@@ -862,9 +863,9 @@ let read_transition_part t read set =
 
 let transition_property_start t =
   match Cursor.peek t with
-  | Some (Component.Preserved { kind = Token.Ident _; _ })
-  | Some (Component.Func { node = { name = "var"; _ }; _ }) ->
-      true
+  | Some (Component.Preserved { kind = Token.Ident _; _ }) -> true
+  | Some (Component.Func { node = { name; _ }; _ }) ->
+      String.lowercase_ascii_preserve name = "var"
   | _ -> false
 
 let read_transition_property_part parts t =

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -102,7 +102,8 @@ let rec read_shadow_single t : shadow =
     | Some "inset" -> (
         Cursor.ws t;
         match Cursor.peek t with
-        | Some (Component.Func { node = { name = "var"; _ }; _ }) ->
+        | Some (Component.Func { node = { name; _ }; _ })
+          when String.lowercase_ascii_preserve name = "var" ->
             Some (Inset (Var (read_var read_shadow_single t)))
         | _ -> Option.None)
     | _ -> Option.None

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -138,7 +138,9 @@ let rec read_display t : display =
   let read_var t : display = Var (read_var read_display t) in
   Cursor.ws t;
   match Cursor.peek t with
-  | Some (Component.Func { node = { name = "var"; _ }; _ }) -> read_var t
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii_preserve name = "var" ->
+      read_var t
   | _ -> (
       match Cursor.option read_display_list_item t with
       | Some d -> d

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1813,7 +1813,8 @@ let rec read_unicode_range t : unicode_range =
      Syntax section 4.3.14); we just translate it to the [unicode_range] ADT. *)
   Cursor.with_context t "unicode-range" @@ fun () ->
   match Cursor.peek t with
-  | Some (Component.Func { node = { name = "var"; _ }; _ }) ->
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii_preserve name = "var" ->
       (Var (Values.read_var read_unicode_range t) : unicode_range)
   | Some
       (Component.Preserved

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -1590,7 +1590,8 @@ let read_gradient_prelude t : gradient_direction =
 let rec read_gradient_position t : gradient_position =
   Cursor.ws t;
   match Cursor.peek t with
-  | Some (Component.Func { node = { name = "var"; _ }; _ }) ->
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii_preserve name = "var" ->
       (Var (Values.read_var read_gradient_position t) : gradient_position)
   | _ -> (
       match Cursor.peek_ident t with
@@ -1758,7 +1759,8 @@ let read_webkit_gradient_stop t =
   match Cursor.peek t with
   | Some (Component.Func { node = { name = ("from" | "to") as name; _ }; _ }) ->
       Cursor.call name t (color_arg name)
-  | Some (Component.Func { node = { name = "color-stop"; _ }; _ }) ->
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii_preserve name = "color-stop" ->
       Cursor.call "color-stop" t (fun inner ->
           Cursor.ws inner;
           let position = read_percentage inner in

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -586,7 +586,8 @@ let rec read_container_shorthand (t : Cursor.t) : container_shorthand =
   in
   Cursor.ws t;
   match Cursor.peek t with
-  | Some (Component.Func { node = { name = "var"; _ }; _ }) ->
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii_preserve name = "var" ->
       (Var (Values.read_var read_container_shorthand t) : container_shorthand)
   | _ -> (
       let first = Cursor.ident t in

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1751,7 +1751,60 @@ let spec_keyword_case_insensitive () =
     ~lower:".a{@media screen{color:red}}" ~expect:".a{@media screen{color:red}}";
   agrees "@font-face at-rule name"
     ~upper:"@Font-Face{font-family:F;src:url(a.woff)}"
-    ~lower:"@font-face{font-family:F;src:url(a.woff)}"
+    ~lower:"@font-face{font-family:F;src:url(a.woff)}";
+  (* CSS Custom Properties 1 sec. 3 names the substitution function [var()];
+     capitalising it names the same function, even where a typed reader still
+     matched the function name as a bare string. *)
+  agrees "display var()" ~upper:".a{display:VAR(--x)}"
+    ~lower:".a{display:var(--x)}";
+  agrees "animation-timeline var()" ~upper:".a{animation-timeline:VAR(--x)}"
+    ~lower:".a{animation-timeline:var(--x)}";
+  agrees "transition shorthand var() property"
+    ~upper:".a{transition:VAR(--x) 1s ease}"
+    ~lower:".a{transition:var(--x) 1s ease}";
+  agrees "box-shadow inset var()" ~upper:".a{box-shadow:inset VAR(--x)}"
+    ~lower:".a{box-shadow:inset var(--x)}";
+  agrees "container shorthand var()" ~upper:".a{container:VAR(--x)}"
+    ~lower:".a{container:var(--x)}";
+  agrees "@font-face unicode-range var()"
+    ~upper:"@font-face{font-family:F;src:url(a.woff);unicode-range:VAR(--x)}"
+    ~lower:"@font-face{font-family:F;src:url(a.woff);unicode-range:var(--x)}";
+  agrees "gradient position var()"
+    ~upper:".a{background:linear-gradient(VAR(--dir),red,blue)}"
+    ~lower:".a{background:linear-gradient(var(--dir),red,blue)}";
+  (* [shape-outside] is a [string property]: a valid value is handed back as
+     the raw source text, uppercase var() included, so there is no folded
+     form to agree on here. Only the empty-var() rejection below is a shared
+     path. *)
+  (* WebKit's legacy gradient names [color-stop()] as a helper function of
+     [-webkit-gradient()], so sec. 4.1 folds it exactly as any other function
+     name. *)
+  agrees "-webkit-gradient color-stop()"
+    ~upper:
+      ".a{background:-webkit-gradient(linear,left top,left \
+       bottom,from(red),COLOR-STOP(50%,green),to(blue))}"
+    ~lower:
+      ".a{background:-webkit-gradient(linear,left top,left \
+       bottom,from(red),color-stop(50%,green),to(blue))}";
+  (* An empty [var()] is invalid regardless of case (CSS Custom Properties 1
+     sec. 3); the diagnosis must agree, not just the rejection. *)
+  let empty_var_diagnostic input =
+    match of_string ~strict:true input with
+    | Ok _ -> Alcotest.failf "%s: strict parse accepted an empty var()" input
+    | Error err -> Cascade.Error.to_string err
+  in
+  let lower_diag = empty_var_diagnostic ".a{shape-outside:var()}" in
+  Alcotest.(check bool)
+    (String.concat ""
+       [ "lower-case empty var() names the reason, got "; lower_diag ])
+    true
+    (Astring.String.is_infix ~affix:"empty var()" lower_diag);
+  let upper_diag = empty_var_diagnostic ".a{shape-outside:VAR()}" in
+  Alcotest.(check bool)
+    (String.concat ""
+       [ "capitalised empty var() names the reason, got "; upper_diag ])
+    true
+    (Astring.String.is_infix ~affix:"empty var()" upper_diag)
 
 (* CSS Values 4 sec. 4.2: an author-defined identifier is "fully case-sensitive
    [...] even in the ASCII range (e.g. example and EXAMPLE are two different,
@@ -1813,6 +1866,22 @@ let spec_author_ident_case_sensitive () =
      property. *)
   keeps "custom property inside color-mix()"
     ".a{--Foo:red;color:color-mix(IN srgb,var(--Foo),blue)}" "var(--Foo)";
+  (* [var()]'s function name folds (sec. 4.1); the custom property name in its
+     argument does not (sec. 4.2). *)
+  keeps "display var() argument name" ".a{display:VAR(--Foo)}" "var(--Foo)";
+  keeps "animation-timeline var() argument name"
+    ".a{animation-timeline:VAR(--Foo)}" "var(--Foo)";
+  keeps "transition shorthand var() argument name"
+    ".a{transition:VAR(--Foo) 1s ease}" "var(--Foo)";
+  keeps "box-shadow inset var() argument name" ".a{box-shadow:inset VAR(--Foo)}"
+    "var(--Foo)";
+  keeps "container shorthand var() argument name" ".a{container:VAR(--Foo)}"
+    "var(--Foo)";
+  keeps "@font-face unicode-range var() argument name"
+    "@font-face{font-family:F;src:url(a.woff);unicode-range:VAR(--Foo)}"
+    "var(--Foo)";
+  keeps "gradient position var() argument name"
+    ".a{background:linear-gradient(VAR(--Foo),red,blue)}" "var(--Foo)";
   (* CSS Syntax 3 sec. 8.2 recognises [@charset] only as the exact byte
      sequence, so the encoding name is not a keyword to fold. *)
   (match of_string ~strict:true "@charset \"utf-8\";.a{color:red}" with


### PR DESCRIPTION
CSS Values 4 sec. 4.1 makes a function name ASCII case-insensitive, but a handful of readers still matched `var()` and `-webkit-gradient()`'s `color-stop()` as an exact lower-case string. `transition: VAR(--x) 1s ease` read `VAR(--x)` as a duration instead of the property, miscompiling to `transition: all var(--x) ease 1s`; a capitalised `COLOR-STOP()` dropped the whole `background` declaration. `display`, `animation-timeline`, `container`, `box-shadow`'s `inset` and `@font-face`'s `unicode-range` had the same gap.

Finishes the case-folding sweep #602, #603 and #604 started.
