### PR TITLE
prop: fold scroll()/view(), from()/to() and inset case to lower

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,15 +181,17 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
-- A `var()` or `-webkit-gradient()` `color-stop()` written in another case is
-  read as that function. CSS Values 4 sec. 4.1 makes a function name ASCII
-  case-insensitive, but `transition`'s shorthand read a capitalised `VAR(--x)`
-  as a duration instead of the property, turning
-  `transition: VAR(--x) 1s ease` into `transition: all var(--x) ease 1s`, and
-  a capitalised `COLOR-STOP()` inside `-webkit-gradient()` dropped the whole
-  `background` declaration. `display`, `animation-timeline`, `container`,
-  `box-shadow`'s `inset` and `@font-face`'s `unicode-range` had the same gap
-  (#620)
+- A `var()`, a `-webkit-gradient()` `color-stop()`/`from()`/`to()`, an
+  `animation-timeline` `scroll()`/`view()`, or `box-shadow`'s `inset` written
+  in another case is read as that keyword. CSS Values 4 sec. 4.1 makes a
+  keyword ASCII case-insensitive, but `transition`'s shorthand read a
+  capitalised `VAR(--x)` as a duration instead of the property, turning
+  `transition: VAR(--x) 1s ease` into `transition: all var(--x) ease 1s`; a
+  capitalised `COLOR-STOP()`, `FROM()`/`TO()` or `SCROLL()`/`VIEW()` dropped
+  the whole `background` or `animation-timeline` declaration; and
+  `box-shadow: INSET var(--x)` fell back to an unfolded raw value. `display`,
+  `container` and `@font-face`'s `unicode-range` had the var()-name gap too
+  (#620, #622)
 - An argument a border width comparison cannot read invalidates the
   declaration. The reader stopped at the first such argument and compared the
   ones before it, so `border-width: max(1px, red)` became `1px` and

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -517,10 +517,13 @@ let rec read_animation_timeline (t : Cursor.t) : animation_timeline =
       Cursor.err_invalid t
         (String.concat "" [ "unterminated function "; fn.node.name; "(...)" ])
   | Some (Component.Func fn)
-    when fn.node.name = "scroll" || fn.node.name = "view" ->
+    when String.lowercase_ascii_preserve fn.node.name = "scroll" ->
       let _ = Cursor.next t in
-      let args = Parser.string_of_components fn.node.arguments in
-      if fn.node.name = "scroll" then Scroll args else View args
+      Scroll (Parser.string_of_components fn.node.arguments)
+  | Some (Component.Func fn)
+    when String.lowercase_ascii_preserve fn.node.name = "view" ->
+      let _ = Cursor.next t in
+      View (Parser.string_of_components fn.node.arguments)
   | _ ->
       let keywords : (string * animation_timeline) list =
         [

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -99,7 +99,7 @@ let rec read_shadow_single t : shadow =
   let snap = Cursor.save t in
   let inset_var : shadow option =
     match Cursor.ident_opt t with
-    | Some "inset" -> (
+    | Some s when String.lowercase_ascii_preserve s = "inset" -> (
         Cursor.ws t;
         match Cursor.peek t with
         | Some (Component.Func { node = { name; _ }; _ })

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -1757,8 +1757,12 @@ let read_webkit_gradient_stop t =
     | _ -> assert false
   in
   match Cursor.peek t with
-  | Some (Component.Func { node = { name = ("from" | "to") as name; _ }; _ }) ->
-      Cursor.call name t (color_arg name)
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii_preserve name = "from" ->
+      Cursor.call "from" t (color_arg "from")
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii_preserve name = "to" ->
+      Cursor.call "to" t (color_arg "to")
   | Some (Component.Func { node = { name; _ }; _ })
     when String.lowercase_ascii_preserve name = "color-stop" ->
       Cursor.call "color-stop" t (fun inner ->

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1759,10 +1759,21 @@ let spec_keyword_case_insensitive () =
     ~lower:".a{display:var(--x)}";
   agrees "animation-timeline var()" ~upper:".a{animation-timeline:VAR(--x)}"
     ~lower:".a{animation-timeline:var(--x)}";
+  (* scroll-animations-1 sec. 3/4 name [scroll()] and [view()] as the timeline
+     functions; sec. 4.1 folds a function name too. *)
+  agrees "animation-timeline scroll()"
+    ~upper:".a{animation-timeline:SCROLL(root block)}"
+    ~lower:".a{animation-timeline:scroll(root block)}";
+  agrees "animation-timeline view()" ~upper:".a{animation-timeline:VIEW(block)}"
+    ~lower:".a{animation-timeline:view(block)}";
   agrees "transition shorthand var() property"
     ~upper:".a{transition:VAR(--x) 1s ease}"
     ~lower:".a{transition:var(--x) 1s ease}";
   agrees "box-shadow inset var()" ~upper:".a{box-shadow:inset VAR(--x)}"
+    ~lower:".a{box-shadow:inset var(--x)}";
+  (* Sibling gap: #620 folded [var()]'s name here but left [inset] itself, so a
+     capitalised inset before [var()] still misses the typed reader. *)
+  agrees "box-shadow INSET var()" ~upper:".a{box-shadow:INSET VAR(--x)}"
     ~lower:".a{box-shadow:inset var(--x)}";
   agrees "container shorthand var()" ~upper:".a{container:VAR(--x)}"
     ~lower:".a{container:var(--x)}";
@@ -1776,6 +1787,15 @@ let spec_keyword_case_insensitive () =
      the raw source text, uppercase var() included, so there is no folded
      form to agree on here. Only the empty-var() rejection below is a shared
      path. *)
+  (* [from()]/[to()] name the two required stops of [-webkit-gradient()]; the
+     sibling [color-stop()] fold below (#620) left these two untouched. *)
+  agrees "-webkit-gradient from()/to()"
+    ~upper:
+      ".a{background:-webkit-gradient(linear,left top,left \
+       bottom,FROM(red),TO(blue))}"
+    ~lower:
+      ".a{background:-webkit-gradient(linear,left top,left \
+       bottom,from(red),to(blue))}";
   (* WebKit's legacy gradient names [color-stop()] as a helper function of
      [-webkit-gradient()], so sec. 4.1 folds it exactly as any other function
      name. *)
@@ -1871,9 +1891,15 @@ let spec_author_ident_case_sensitive () =
   keeps "display var() argument name" ".a{display:VAR(--Foo)}" "var(--Foo)";
   keeps "animation-timeline var() argument name"
     ".a{animation-timeline:VAR(--Foo)}" "var(--Foo)";
+  (* scroll-animations-1 sec. 3: a bare [<dashed-ident>] here names a
+     scroll-timeline/view-timeline, not the [scroll()]/[view()] function;
+     folding the function name (above) must not reach this. *)
+  keeps "animation-timeline name" ".a{animation-timeline:--Foo}" "--Foo";
   keeps "transition shorthand var() argument name"
     ".a{transition:VAR(--Foo) 1s ease}" "var(--Foo)";
   keeps "box-shadow inset var() argument name" ".a{box-shadow:inset VAR(--Foo)}"
+    "var(--Foo)";
+  keeps "box-shadow INSET var() argument name" ".a{box-shadow:INSET VAR(--Foo)}"
     "var(--Foo)";
   keeps "container shorthand var() argument name" ".a{container:VAR(--Foo)}"
     "var(--Foo)";


### PR DESCRIPTION
The three sites #620 left beside its fixes: `animation-timeline`'s `scroll()`/`view()`, `-webkit-gradient()`'s `from()`/`to()`, and `box-shadow`'s `inset` ident itself. Same pattern, same fix.
