### PR TITLE
prop: elide the percent boundary in inset() and margin shorthands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -457,6 +457,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` drops the same `%`/`)` boundary space in `clip-path`'s and
+  `object-view-box`'s `inset()`, and in `margin-inline`/`margin-block`,
+  which share the box-shorthand shape (#619, #623)
 - `--minify` drops the space between the values of `margin`, `padding`,
   `inset` and `border-radius` (and `border-color`, which shares the same
   printer) at a `%` or `)` boundary, the token-boundary rule already applied

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -310,15 +310,15 @@ let pp_optional_inset_sides : type a.
  fun pp ctx right bottom left ->
   Option.iter
     (fun r ->
-      Pp.space ctx ();
+      Pp.token_sp ctx ();
       pp ctx r;
       Option.iter
         (fun b ->
-          Pp.space ctx ();
+          Pp.token_sp ctx ();
           pp ctx b;
           Option.iter
             (fun l ->
-              Pp.space ctx ();
+              Pp.token_sp ctx ();
               pp ctx l)
             left)
         bottom)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3820,8 +3820,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Margin_right -> pp pp_length
   | Margin_top -> pp pp_length
   | Margin_bottom -> pp pp_length
-  | Margin_inline -> pp (Pp.list ~sep:Pp.space pp_length)
-  | Margin_block -> pp (Pp.list ~sep:Pp.space pp_length)
+  | Margin_inline -> pp (Pp.list ~sep:Pp.token_sp pp_length)
+  | Margin_block -> pp (Pp.list ~sep:Pp.token_sp pp_length)
   | Margin_block_start -> pp pp_length
   | Margin_block_end -> pp pp_length
   | Gap -> pp pp_gap

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2378,7 +2378,7 @@ let spec_remaining_prop_vectors () =
       ("font-variant-east-asian: ruby", "font-variant-east-asian:ruby");
       ( "font-variant-east-asian: traditional proportional-width ruby",
         "font-variant-east-asian:traditional proportional-width ruby" );
-      ("object-view-box: inset(0 0 10% 0)", "object-view-box:inset(0 0 10% 0)");
+      ("object-view-box: inset(0 0 10% 0)", "object-view-box:inset(0 0 10%0)");
       ("image-rendering: pixelated", "image-rendering:pixelated");
       ("image-resolution: from-image 2dppx", "image-resolution:from-image 2dppx");
       ("mask-border: url(mask.svg) 30 fill", "mask-border:url(mask.svg)30 fill");

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -474,7 +474,22 @@ let special_cases () =
   (* border-color shares the same box-shorthand printer, so a colour function's
      closing paren gets the same elision. *)
   check_declaration ~expected:"border-color:var(--c)red"
-    "border-color: var(--c) red;"
+    "border-color: var(--c) red;";
+
+  (* clip-path/object-view-box inset() and margin-inline/margin-block hit the
+     same CSS Syntax 3 sec. 4.3.3 percentage-token boundary as margin/padding
+     above, but print through their own list combinator rather than the shared
+     pp_box_shorthand. A unit boundary still keeps its space. *)
+  check_declaration ~expected:"clip-path:inset(0 0 10%0)"
+    "clip-path: inset(0 0 10% 0);";
+  check_declaration ~expected:"clip-path:inset(0 0 10px 0)"
+    "clip-path: inset(0 0 10px 0);";
+  check_declaration ~expected:"object-view-box:inset(0 0 10%0)"
+    "object-view-box: inset(0 0 10% 0);";
+  check_declaration ~expected:"margin-inline:10%20%" "margin-inline: 10% 20%;";
+  check_declaration ~expected:"margin-inline:10px 20px"
+    "margin-inline: 10px 20px;";
+  check_declaration ~expected:"margin-block:10%20%" "margin-block: 10% 20%;"
 
 let colors () =
   (* Same-node spellings the printer keeps (case-fold, hex shorten). The

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4520,9 +4520,9 @@ let test_clip_path () =
   check_clip_path "inset(50%)";
   (* 1 value: all sides *)
   check_clip_path "inset(10px)";
-  check_clip_path "inset(10% 20%)";
+  check_clip_path ~expected:"inset(10%20%)" "inset(10% 20%)";
   (* 2 values: top/bottom, left/right *)
-  check_clip_path "inset(10% 20% 30%)";
+  check_clip_path ~expected:"inset(10%20%30%)" "inset(10% 20% 30%)";
   (* 3 values: top, left/right, bottom *)
   check_clip_path "inset(0px 10px 20px 30px)";
   (* CSS Values L4 sec. 6: a zero in <length>/<length-percentage> position drops


### PR DESCRIPTION
Extends #619's box-shorthand token-boundary rule to two sites it left: `clip-path`/`object-view-box`'s own `inset()` printer, and `margin-inline`/`margin-block`, which print through their own list rather than the shared `pp_box_shorthand`.
