### PR TITLE
prop: fold border-width min()/max()/clamp() before the merge pass

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -457,6 +457,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` merges two rules whose `border-width` differ only in an
+  unreduced `min()`/`max()`/`clamp()`, such as `min(2cqi,3cqi)` and `2cqi`; a
+  second `--minify` pass used to be needed before they merged (#624)
 - `--minify` drops the same `%`/`)` boundary space in `clip-path`'s and
   `object-view-box`'s `inset()`, and in `margin-inline`/`margin-block`,
   which share the box-shorthand shape (#619, #623)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -373,6 +373,53 @@ let length_of_border_width_calc calc =
   in
   aux calc
 
+(* The reverse of [length_of_border_width]: every dimension the two types share
+   round-trips, so a fold done in [length] space (the [min()]/[max()]/ [clamp()]
+   reduction, [Values.normalize_length]) can rebuild a [border_width]
+   afterwards. *)
+let border_width_of_length : length -> border_width option = function
+  | Px n -> Some (Px n)
+  | Cm n -> Some (Cm n)
+  | Mm n -> Some (Mm n)
+  | Q n -> Some (Q n)
+  | In n -> Some (In n)
+  | Pt n -> Some (Pt n)
+  | Pc n -> Some (Pc n)
+  | Rem n -> Some (Rem n)
+  | Em n -> Some (Em n)
+  | Ex n -> Some (Ex n)
+  | Cap n -> Some (Cap n)
+  | Ic n -> Some (Ic n)
+  | Ric n -> Some (Ric n)
+  | Rlh n -> Some (Rlh n)
+  | Ch n -> Some (Ch n)
+  | Lh n -> Some (Lh n)
+  | Vh n -> Some (Vh n)
+  | Vw n -> Some (Vw n)
+  | Vmin n -> Some (Vmin n)
+  | Vmax n -> Some (Vmax n)
+  | Pct n -> Some (Pct n)
+  | Dimension { value; unit; repr } -> Some (Dimension { value; unit; repr })
+  | Zero -> Some Zero
+  | _ -> None
+
+let border_width_of_length_calc calc =
+  let rec aux : length calc -> border_width calc option = function
+    | Val length ->
+        Option.map (fun width -> Val width) (border_width_of_length length)
+    | Num n -> Some (Num n)
+    | Math_const c -> Some (Math_const c)
+    | Math_fn fn -> Some (Math_fn fn)
+    | Var _ | Sibling_index | Sibling_count -> None
+    | Nested inner -> Option.map (fun inner -> Nested inner) (aux inner)
+    | Parens inner -> Option.map (fun inner -> Parens inner) (aux inner)
+    | Expr (left, op, right) -> (
+        match (aux left, aux right) with
+        | Some left, Some right -> Some (Expr (left, op, right))
+        | _ -> None)
+  in
+  aux calc
+
 let length_linear_term : length -> (string * float * (float -> length)) option =
   function
   | Zero -> Some ("px", 0., fun _ -> Zero)
@@ -579,6 +626,70 @@ let reduce_border_width_clamp lower value upper =
       | _ -> None)
   | _ -> None
 
+(* [pp] is a pure serialiser (see the module note); every node-changing fold
+   lives here instead, so it runs before [Declaration.hash] and two authored
+   spellings of the same value converge to one node.
+
+   A [min()]/[max()]/[clamp()] argument that survives grouping still gets its
+   own same-unit terms combined (mirrors what [pp] used to do per-argument via
+   [simplified_border_width_length]); the standalone [calc()] arm instead goes
+   through [Values.normalize_length], the stronger fold [pp] used only when
+   minifying. *)
+let normalize_border_width_calc_arg (c : border_width calc) : border_width calc
+    =
+  match simplified_border_width_length c with
+  | Some (Val length) -> (
+      match border_width_of_length length with Some bw -> Val bw | None -> c)
+  | Some simplified -> (
+      match border_width_of_length_calc simplified with
+      | Some c' -> c'
+      | None -> c)
+  | None -> c
+
+let normalize_border_width_calc (c : border_width calc) : border_width calc =
+  match length_of_border_width_calc c with
+  | None -> Values.eval_calc c
+  | Some lc -> (
+      match Values.normalize_length (Calc lc) with
+      | Calc lc' -> (
+          match border_width_of_length_calc lc' with Some c' -> c' | None -> c)
+      | length -> (
+          match border_width_of_length length with
+          | Some bw -> Val bw
+          | None -> c))
+
+let normalize_border_width_minmax kind (args : border_width calc list) :
+    border_width =
+  let rebuild args = match kind with `Min -> Min args | `Max -> Max args in
+  match reduce_border_width_minmax kind args with
+  | Some [ Val length ] -> (
+      match border_width_of_length length with
+      | Some bw -> bw
+      | None -> rebuild args)
+  | Some lengths -> (
+      match List.map border_width_of_length_calc lengths with
+      | terms when List.for_all Option.is_some terms ->
+          rebuild (List.map Option.get terms)
+      | _ -> rebuild args)
+  | None -> rebuild (List.map normalize_border_width_calc_arg args)
+
+let normalize_border_width_clamp lower value upper : border_width =
+  match reduce_border_width_clamp lower value upper with
+  | Some (`Length length) -> (
+      match border_width_of_length length with
+      | Some bw -> bw
+      | None -> Clamp (lower, value, upper))
+  | Some (`Max cargs) -> (
+      match List.map border_width_of_length_calc cargs with
+      | terms when List.for_all Option.is_some terms ->
+          Max (List.map Option.get terms)
+      | _ -> Clamp (lower, value, upper))
+  | None ->
+      Clamp
+        ( normalize_border_width_calc_arg lower,
+          normalize_border_width_calc_arg value,
+          normalize_border_width_calc_arg upper )
+
 let rec pp_border_width : border_width Pp.t =
  fun ctx -> function
   | Thin -> Pp.string ctx "thin"
@@ -616,12 +727,9 @@ let rec pp_border_width : border_width Pp.t =
   | Min_content -> Pp.string ctx "min-content"
   | Fit_content -> Pp.string ctx "fit-content"
   | From_font -> Pp.string ctx "from-font"
-  | Calc cv -> (
-      match (Pp.minified ctx, length_of_border_width_calc cv) with
-      | true, Some cv -> pp_length ctx (Values.normalize_length (Calc cv))
-      | _ -> pp_calc pp_border_width ctx cv)
-  | Min args -> pp_border_width_minmax "min" `Min ctx args
-  | Max args -> pp_border_width_minmax "max" `Max ctx args
+  | Calc cv -> pp_calc pp_border_width ctx cv
+  | Min args -> pp_border_width_minmax "min" ctx args
+  | Max args -> pp_border_width_minmax "max" ctx args
   | Clamp (lower, value, upper) -> pp_border_width_clamp ctx lower value upper
   | Var v -> pp_var pp_border_width ctx v
   | Inherit -> Pp.string ctx "inherit"
@@ -630,36 +738,26 @@ let rec pp_border_width : border_width Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+(* Structural only (no [simplified_border_width_length]/[reduce_border_width_*]
+   fold: those moved to [normalize_border_width]); [length_of_border_width_calc]
+   is a type-level reshape, not a value fold. *)
 and pp_border_width_calc_contents ctx calc =
-  match simplified_border_width_length calc with
-  | Some (Val length) -> pp_length ctx length
-  | Some calc -> pp_length_calc_contents ctx calc
+  match length_of_border_width_calc calc with
+  | Some lc -> pp_length_calc_contents ctx lc
   | None -> pp_calc pp_border_width ctx calc
 
-and pp_border_width_minmax name kind ctx args =
-  match reduce_border_width_minmax kind args with
-  | Some [ Val length ] -> pp_length ctx length
-  | Some args ->
-      Pp.call name (Pp.list ~sep:Pp.comma pp_length_calc_contents) ctx args
-  | None ->
-      Pp.call name
-        (Pp.list ~sep:Pp.comma pp_border_width_calc_contents)
-        ctx args
+and pp_border_width_minmax name ctx args =
+  Pp.call name (Pp.list ~sep:Pp.comma pp_border_width_calc_contents) ctx args
 
 and pp_border_width_clamp ctx lower value upper =
-  match reduce_border_width_clamp lower value upper with
-  | Some (`Length length) -> pp_length ctx length
-  | Some (`Max args) ->
-      Pp.call "max" (Pp.list ~sep:Pp.comma pp_length_calc_contents) ctx args
-  | None ->
-      Pp.call "clamp"
-        (fun ctx (lower, value, upper) ->
-          pp_border_width_calc_contents ctx lower;
-          Pp.comma ctx ();
-          pp_border_width_calc_contents ctx value;
-          Pp.comma ctx ();
-          pp_border_width_calc_contents ctx upper)
-        ctx (lower, value, upper)
+  Pp.call "clamp"
+    (fun ctx (lower, value, upper) ->
+      pp_border_width_calc_contents ctx lower;
+      Pp.comma ctx ();
+      pp_border_width_calc_contents ctx value;
+      Pp.comma ctx ();
+      pp_border_width_calc_contents ctx upper)
+    ctx (lower, value, upper)
 
 let pp_border_shorthand : border_shorthand Pp.t =
  fun ctx { width; style; color } ->
@@ -1737,7 +1835,13 @@ let border_width_is_zero (bw : border_width) =
 let normalize_border_width (bw : border_width) : border_width =
   match bw with
   | Calc c -> (
-      match Values.eval_calc c with Values.Val v -> v | folded -> Calc folded)
+      match normalize_border_width_calc c with
+      | Val v -> v
+      | folded -> Calc folded)
+  | Min args -> normalize_border_width_minmax `Min args
+  | Max args -> normalize_border_width_minmax `Max args
+  | Clamp (lower, value, upper) ->
+      normalize_border_width_clamp lower value upper
   | _ when border_width_is_zero bw -> Zero
   | _ -> bw
 

--- a/test/cli/minify_border_width_idempotent.t
+++ b/test/cli/minify_border_width_idempotent.t
@@ -1,0 +1,29 @@
+CLI: --minify is idempotent on a border-width min()/max()/clamp() fold.
+
+lib/declaration.ml requires that two declarations minifying to the same text
+always share one value, since rule merging keys on that hash. min(2cqi,3cqi)
+and 2cqi are the same <line-width> (CSS Values 4 sec. 10.2 keeps the smaller
+of two same-unit arguments), so a first --minify pass must fold the min()
+into one AST node before hashing, not just into matching text. A second pass
+over already-minified output must be a no-op.
+
+  $ cat > border_width.css <<CSS
+  > a { border-width: min(2cqi,3cqi) }
+  > b { border-width: 2cqi }
+  > CSS
+  $ cascade --minify border_width.css
+  a,b{border-width:2cqi}
+  $ cascade --minify border_width.css | cascade --minify -
+  a,b{border-width:2cqi}
+
+A plain fmt keeps the authored spelling: folding min()/max()/clamp() is a
+node-changing rewrite, so it belongs in the optimizer, not in fmt's pure
+serialiser.
+
+  $ cat > authored.css <<CSS
+  > a { border-width: max(2cqi, 3cqi) }
+  > CSS
+  $ cascade authored.css
+  a {
+    border-width: max(2cqi, 3cqi);
+  }

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1855,12 +1855,18 @@ let test_border_width () =
   check_border_width "max(3dvh,4px)";
   check_border_width "clamp(1dvh,3dvh,4px)";
   (* One unit does compare with itself, and a container-query length grows with
-     its multiplier, so the smaller multiple is the minimum. *)
-  check_border_width ~expected:"2cqi" "min(2cqi,3cqi)";
-  check_border_width ~expected:"4dvh" "max(3dvh,4dvh)";
+     its multiplier, so the smaller multiple is the minimum. The fold is a
+     node-changing rewrite (two different ASTs would otherwise print the same
+     text and hash differently), so it runs in optimize, not pp: fmt/minify
+     alone hold the authored min()/max(), only minify+optimize collapses it. *)
+  decl_optimizes ~prop:"border-width" ~held:"min(2cqi,3cqi)" ~into:"2cqi"
+    "min(2cqi,3cqi)";
+  decl_optimizes ~prop:"border-width" ~held:"max(3dvh,4dvh)" ~into:"4dvh"
+    "max(3dvh,4dvh)";
   (* A bound nothing else measures stops only its own group: [1px] and [2px]
      stay on one scale (CSS Values 4 sec. 6.2), so they collapse. *)
-  check_border_width ~expected:"max(2px,3dvh)" "max(1px,3dvh,2px)";
+  decl_optimizes ~prop:"border-width" ~held:"max(1px,3dvh,2px)"
+    ~into:"max(2px,3dvh)" "max(1px,3dvh,2px)";
   (* A zero-valued border-width collapses the unit like any other zero length
      (border-width: 0px -> 0), matching width/outline-width. Holds for the
      longhand, the logical longhand, and the 1-4 value shorthand; non-zero


### PR DESCRIPTION
The reduction ran in `pp`, so two rules whose `border-width` printed the same minified text after one `--minify` pass (`min(2cqi,3cqi)` and `2cqi`) still held different AST nodes and needed a second pass to merge. `normalize_border_width` now does the fold, so the merge happens in one pass and plain `fmt` keeps the authored `min()`/`max()`/`clamp()`.
