### PR TITLE
fmt: drop the false --enforce-spec minify-only warning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1001,6 +1001,9 @@ recorded cases carrying six minifiers' answers.
   multi-word font family, and the ident code points the reader accepts. It
   described an `@supports` elision that no longer exists, so the one place a
   user reads about the flag contradicted every other (#611)
+- `cascade fmt --enforce-spec` can drop a rule with a raw non-ASCII selector
+  without `--minify`: the flag also gates the parser's ident range, so the
+  "has no effect without --minify" warning was false (#625)
 - `cascade prune PAGE.html... STYLE.css` removes the rules a set of HTML
   documents cannot use, and `--dry-run` reports instead, ranking what survives
   by how few elements matched it. A rule goes only when the matcher has a model

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -257,11 +257,12 @@ let term =
         end;
         if keep_vars <> [] && not inline_vars_flag then
           Fmt.epr "Warning: --keep-vars has no effect without --inline-vars@.";
+        (* --enforce-spec is excluded: it also gates the parser's non-ASCII
+           ident range, which acts with or without --minify. *)
         warn_minify_only ~minify
           [
             (scope = `Stylesheet, "--scope=stylesheet");
             (lossless, "--lossless");
-            (enforce_spec, "--enforce-spec");
             (closed_world, "--closed-world");
             (objective = `Raw, "--objective");
             (profile, "--profile");

--- a/test/cli/enforce_spec_parse_warning.t
+++ b/test/cli/enforce_spec_parse_warning.t
@@ -1,0 +1,38 @@
+CLI: --enforce-spec's parse effect does not need --minify.
+
+lib/lexer.ml gates non-ASCII identifiers on `~enforce_spec` at parse time
+(CSS Syntax 3 sec. 4.2's ident code points), independent of `--minify`. A
+raw non-ASCII identifier this parser reads by default then fails that
+narrower check under `--enforce-spec`, taking its rule with it - a real
+effect the CLI's "has no effect without --minify" warning must not deny.
+
+  $ cat > arrow.css <<EOF
+  > .text-↗ { color: red }
+  > EOF
+  $ cascade fmt arrow.css
+  .text-\2197  {
+    color: red;
+  }
+
+`--enforce-spec` alone drops the rule, so the flag did something: no
+warning may say it did not.
+
+  $ cascade fmt --enforce-spec arrow.css 2>&1 | grep -v "warning"
+  Error: arrow.css: parse dropped every rule; refusing to write an empty stylesheet
+
+Adding `--minify` changes nothing about that outcome - the drop already
+happened at parse time.
+
+  $ cascade fmt --enforce-spec --minify arrow.css 2>&1 | grep -v "warning"
+  Error: arrow.css: parse dropped every rule; refusing to write an empty stylesheet
+
+An input `--enforce-spec` leaves alone stays silent too: no warning fires
+just because `--minify` is absent.
+
+  $ cat > plain.css <<EOF
+  > .a { color: red }
+  > EOF
+  $ cascade fmt --enforce-spec plain.css 2>&1 | grep -v "warning"
+  .a {
+    color: red;
+  }


### PR DESCRIPTION
`--enforce-spec` also restricts the parser's non-ASCII identifier range to CSS Syntax 3's ident code points, and that gate acts whether or not `--minify` is given. `cascade fmt` still warned that the flag "has no effect without --minify", which is false: it can drop a rule with a raw non-ASCII selector on its own.
