### PR TITLE
expose the ident check, function tables, and a typed custom property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -457,6 +457,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` folds `sin()` through `atan2()` inside a custom-property stream,
+  matching `calc()`'s family; the table gating the fold and the one exported as
+  `Properties.is_math_function`/`is_color_function` had drifted apart (#626)
 - `--minify` merges two rules whose `border-width` differ only in an
   unreduced `min()`/`max()`/`clamp()`, such as `min(2cqi,3cqi)` and `2cqi`; a
   second `--minify` pass used to be needed before they merged (#624)
@@ -729,6 +732,12 @@ recorded cases carrying six minifiers' answers.
 
 ### Custom properties
 
+- `Css.Variables.typed_custom_property` writes a custom-property declaration
+  from a value already typed by a `@property` registration's syntax;
+  `Declaration.custom_property` takes a plain string (#626)
+- `--minify` keeps the space between the repetitions of a `@property`
+  `<type>+` initial value. CSS Values 4 sec. 2.3 makes it the separator, not
+  layout whitespace: dropped, `10px 20px` read back as one `px20px` dimension (#626)
 - A `var()` in the `ascent-override`, `descent-override`, `line-gap-override`
   or `font-variant` descriptor of an `@font-face` is resolved by
   `Css.inline_vars` instead of being dropped at parse time. Their value types
@@ -860,6 +869,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- `Syntax.is_ident` answers whether a whole string is one CSS ident (CSS
+  Syntax 3 sec. 4.3.11), the check `Parser.escape_ident` already made for
+  emission; a per-character scan reads a leading `-` as ident-start and misses `-4` (#626)
 - `Declaration.value_of` reads a declaration's value at a property witness, the
   counterpart of `Declaration.property_key` on the property side. The value was
   reachable only as text through `Declaration.string_of_value`, so a caller

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -156,14 +156,10 @@ let rec ascii_ident_continue_from s n i =
   || Syntax.is_ascii_ident_continue s.[i]
      && ascii_ident_continue_from s n (i + 1)
 
-(* An all-ASCII ident (start byte in ident-start, rest in ident-continue)
-   serialises to itself byte-for-byte, so [escape_ident]'s buffer + Uutf walk
-   would allocate nothing useful. A leading [-] is ident-start, so the
-   dash-digit shape passes that scan and has to be ruled out on its own. *)
-let escape_ident_needs_no_escape s n =
-  (not (escape_ident_starts_dash_digit s n))
-  && (n = 0
-     || (Syntax.is_ascii_ident_start s.[0] && ascii_ident_continue_from s n 1))
+(* An ident serialises to itself byte-for-byte, so the buffer + Uutf walk below
+   would allocate nothing useful. The empty name is not an ident and has nothing
+   to escape either. *)
+let escape_ident_needs_no_escape s n = n = 0 || Syntax.is_ident s
 
 let escape_ident s =
   let n = String.length s in

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2968,21 +2968,25 @@ let fold_custom_color ~lossless (c : Component.t) ~fallback =
       | Typed _ -> [ c ])
   | _ -> fallback ()
 
-(* A math function ([calc()], [min()], [clamp()], ...) is unconditionally a math
-   expression whose type is fixed by its operands' units, so when it reduces to
-   a single constant it has that value in every [var()] substitution site - fold
-   it inside an opaque custom-property stream like a complete colour. [<number>]
-   and the unit-unambiguous dimensions ([<angle>] / [<time>]) qualify;
-   [<percentage>] is ambiguous (length vs number percentage) so it stays
-   verbatim, as does a function that still references a [var()] (it does not
-   reduce to a leaf). *)
+(* CSS Values 4 sec. 10 names the whole set: [calc()], the comparison functions,
+   the stepped-value, trigonometric, exponential and sign-related families. One
+   table serves every caller - a second copy drifts, and the two passes over a
+   custom-property stream then disagree about the same token. *)
 let is_math_function name =
   match String.lowercase_ascii name with
-  | "calc" | "min" | "max" | "clamp" | "round" | "mod" | "rem" | "abs" | "sign"
-  | "hypot" | "pow" | "sqrt" | "exp" | "log" ->
+  | "calc" | "min" | "max" | "clamp" | "round" | "mod" | "rem" | "sin" | "cos"
+  | "tan" | "asin" | "acos" | "atan" | "atan2" | "pow" | "sqrt" | "hypot"
+  | "log" | "exp" | "abs" | "sign" ->
       true
   | _ -> false
 
+(* A math function is unconditionally a math expression whose type is fixed by
+   its operands' units, so when it reduces to a single constant it has that
+   value in every [var()] substitution site - fold it inside an opaque
+   custom-property stream like a complete colour. [<number>] and the
+   unit-unambiguous dimensions ([<angle>] / [<time>]) qualify; [<percentage>] is
+   ambiguous (length vs number percentage) so it stays verbatim, as does a
+   function that still references a [var()] (it does not reduce to a leaf). *)
 let fold_custom_calc (c : Component.t) ~fallback =
   let text = Parser.to_string_custom [ c ] in
   (* Parse the whole token as one typed value and fold only when it reduces to a
@@ -3355,34 +3359,6 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
    values where cascade preserves the author's whitespace verbatim by design.
    Nested non-math functions ([var()] etc.) get a recursive component walk but
    no whitespace stripping; nested math functions get their own. *)
-let math_function_names =
-  [
-    "calc";
-    "min";
-    "max";
-    "clamp";
-    "round";
-    "mod";
-    "rem";
-    "sin";
-    "cos";
-    "tan";
-    "asin";
-    "acos";
-    "atan";
-    "atan2";
-    "pow";
-    "sqrt";
-    "hypot";
-    "log";
-    "exp";
-    "abs";
-    "sign";
-  ]
-
-let is_math_function_name name =
-  List.mem (String.lowercase_ascii name) math_function_names
-
 let is_plus_or_minus_delim = function
   | Component.Preserved { kind = Token.Delim "+"; _ }
   | Component.Preserved { kind = Token.Delim "-"; _ } ->
@@ -3471,7 +3447,7 @@ let rec canonicalize_math_whitespace_components ?(in_math = false) comps =
         match c with
         | Component.Func wrapped ->
             let func = wrapped.Component.node in
-            let nested_in_math = is_math_function_name func.name in
+            let nested_in_math = is_math_function func.name in
             let args =
               canonicalize_math_whitespace_components ~in_math:nested_in_math
                 func.arguments

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2563,3 +2563,19 @@ val read_any_property : Cursor.t -> any_property
 val property_value_kind : 'a property -> 'a property_value_kind option
 (** [property_value_kind property] classifies property value shapes that have a
     shared typed evaluator. *)
+
+(** {2 Function names} *)
+
+val is_math_function : string -> bool
+(** [is_math_function name] is true for a CSS Values 4 sec. 10 math function:
+    [calc()], the comparison functions ([min()], [max()], [clamp()]), the
+    stepped-value ([round()], [mod()], [rem()]), trigonometric ([sin()] through
+    [atan2()]), exponential ([pow()], [sqrt()], [hypot()], [log()], [exp()]) and
+    sign-related ([abs()], [sign()]) families. [name] is matched case
+    insensitively, as CSS function names are. *)
+
+val is_color_function : string -> bool
+(** [is_color_function name] is true for a function whose own syntax fixes it as
+    a colour: the CSS Color 4 numeric notations, [color()] and [color-mix()],
+    and [light-dark()]. A gradient is not one: its type is fixed by the property
+    it lands in, not by the function. *)

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -10,6 +10,40 @@ let is_hex = function
   | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
   | _ -> false
 
+(* Sec. 4.3.9 opens no ident on [-] then a digit, and a bare [-] is a delim, so
+   both shapes slip past a per-character scan that reads [-] as ident-start. *)
+let starts_dash_digit s =
+  String.length s >= 2 && s.[0] = '-' && s.[1] >= '0' && s.[1] <= '9'
+
+let rec ascii_ident_continue_from s n i =
+  i >= n
+  || (is_ascii_ident_continue s.[i] && ascii_ident_continue_from s n (i + 1))
+
+(* Sec. 4.2 shares one range list between ident-start and ident code points, so
+   [-] and the digits are the only positional difference. *)
+let is_ident_start_cp cp =
+  if cp < 0x80 then is_ascii_ident_start (Char.unsafe_chr cp)
+  else Lexer.spec_non_ascii_ident_cp cp
+
+let is_ident_cp cp =
+  if cp < 0x80 then is_ascii_ident_continue (Char.unsafe_chr cp)
+  else Lexer.spec_non_ascii_ident_cp cp
+
+(* [i] is a byte offset, so [i = 0] is the first code point. Malformed UTF-8
+   names no code point and so names no ident. *)
+let ident_code_point ok i = function
+  | `Uchar u ->
+      let cp = Uchar.to_int u in
+      ok && if i = 0 then is_ident_start_cp cp else is_ident_cp cp
+  | `Malformed _ -> false
+
+let is_ident s =
+  let n = String.length s in
+  if n = 0 || starts_dash_digit s || (n = 1 && s.[0] = '-') then false
+  else if is_ascii_ident_start s.[0] && ascii_ident_continue_from s n 1 then
+    true
+  else Uutf.String.fold_utf_8 ident_code_point true s
+
 let url_needs_quotes =
   String.exists (function
     | ' ' | ')' | '"' | '\'' | '(' | '\\' -> true

--- a/lib/syntax.mli
+++ b/lib/syntax.mli
@@ -15,6 +15,16 @@ val is_hex : char -> bool
 (** [is_hex c] returns true if [c] is a hexadecimal digit ([0-9], [a-f], [A-F]).
 *)
 
+val is_ident : string -> bool
+(** [is_ident s] is true when the whole of [s] is one ident, per CSS Syntax 3
+    sec. 4.3.11 for its opening and sec. 4.2 for the rest: a bare [-] and a [-]
+    before a digit open no ident, a leading digit opens none, and every code
+    point is an ident code point. The non-ASCII half is
+    {!Lexer.spec_non_ascii_ident_cp}, the range list serialisers emit verbatim,
+    so [is_ident s] holds exactly when {!Parser.escape_ident} returns [s]
+    unchanged. An escape is not an ident code point: [s] is the decoded name,
+    not its CSS spelling. *)
+
 val url_needs_quotes : string -> bool
 (** [url_needs_quotes s] returns true when serializing [s] as a bare [url(...)]
     argument would change tokenization; the caller must wrap [s] in quotes. *)

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -140,9 +140,11 @@ let rec pp_value : type a. a syntax -> a Pp.t =
       | Left v -> pp_value syn1 ctx v
       | Right v -> pp_value syn2 ctx v)
   | Plus syn ->
+      (* The [+] separator is the whole of it: drop the space and [10px 20px] is
+         one dimension whose unit is [px20px]. *)
       List.iteri
         (fun i v ->
-          if i > 0 then Pp.sp ctx ();
+          if i > 0 then Pp.space ctx ();
           pp_value syn ctx v)
         value
   | Hash syn ->

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -155,6 +155,13 @@ let rec pp_value : type a. a syntax -> a Pp.t =
         value
   | Ident_keyword name -> Pp.string ctx name
 
+(* A value already typed by [syntax] is already spelled for the substitution
+   site (CSS Variables 1 sec. 2); [custom_property] still checks the name and
+   parses the printed text into the token stream a declaration holds. *)
+let typed_custom_property ?layer name syntax value =
+  custom_property ?layer name
+    (Pp.to_string ~minify:true (pp_value syntax) value)
+
 (* CSS Properties and Values API 1 section 2 lists the named [<...>] type
    references. Bare ident keywords match the [<custom-ident>] shape so a leading
    letter followed by ident-continue characters counts; this rejects stray

--- a/lib/variables.mli
+++ b/lib/variables.mli
@@ -31,6 +31,14 @@ val pp_syntax : 'a syntax Pp.t
 val pp_value : 'a syntax -> 'a Pp.t
 (** [pp_value syntax] pretty-prints a value according to its syntax type. *)
 
+val typed_custom_property :
+  ?layer:string -> string -> 'a syntax -> 'a -> declaration
+(** [typed_custom_property ?layer name syntax value] is the custom-property
+    declaration binding [name] to [value], spelled at [syntax] the way CSS
+    Variables 1 sec. 2 substitutes it (a unitless [0] is a [<number>] there, so
+    a [Length] keeps its unit). [name] and the printed value carry the same
+    checks as {!Declaration.custom_property}, which this calls. *)
+
 val read_syntax : Cursor.t -> any_syntax
 (** [read_syntax r] reads a CSS syntax descriptor from input. *)
 

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -92,3 +92,8 @@ let _ : 'a Properties.property -> 'b Properties.property -> int =
 let _ :
     'a Properties.property -> 'b Properties.property -> ('a, 'b) Type.eq option =
   Properties.eq_property
+
+(* A name is checked whole. Rebuilding CSS Syntax 3 sec. 4.3.11 out of the
+   per-character predicates drops the two cases they cannot see: a lone [-] and
+   a [-] followed by a digit open no ident. *)
+let _ : string -> bool = Syntax.is_ident

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -103,3 +103,22 @@ let _ : string -> bool = Syntax.is_ident
    optimizer folds by. *)
 let _ : string -> bool = Properties.is_math_function
 let _ : string -> bool = Properties.is_color_function
+
+(* A registration read back at its syntax carries a value typed by it, so
+   assigning that value is one call and not a match over every syntax arm with
+   a printer per arm. The existential is the point: the name pins nothing
+   unless it takes the syntax and the value the same pack hands out. *)
+let _ : Css.statement -> Css.declaration option =
+ fun stmt ->
+  match Css.as_property stmt with
+  | Some (Css.Property_info { name; syntax; initial_value = Some v; _ }) ->
+      Some (Css.Variables.typed_custom_property name syntax v)
+  | Some (Css.Property_info { initial_value = None; _ }) | None -> None
+
+let _ :
+    ?layer:string ->
+    string ->
+    Values.length Css.Variables.syntax ->
+    Values.length ->
+    Css.declaration =
+  Css.Variables.typed_custom_property

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -97,3 +97,9 @@ let _ :
    per-character predicates drops the two cases they cannot see: a lone [-] and
    a [-] followed by a digit open no ident. *)
 let _ : string -> bool = Syntax.is_ident
+
+(* The math and colour function names are one table each, not one per caller: a
+   generator that has to tell calc() from a colour asks the same list the
+   optimizer folds by. *)
+let _ : string -> bool = Properties.is_math_function
+let _ : string -> bool = Properties.is_color_function

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -8150,6 +8150,21 @@ let customprops13_registered_angle_time_calc () =
     ".x{--a:calc(50%*2)}"
     (normalize_minified ".x { --a: calc(50% * 2) }")
 
+let customprops13_trigonometric_calc () =
+  (* CSS Values 4 sec. 10.4 puts the trigonometric family among the math
+     functions, so a complete one reduces in a custom-property stream the way
+     the exponential family already does. The inverse functions resolve to an
+     <angle>, which is unambiguous in every var() site. *)
+  Alcotest.(check string)
+    "unregistered arc tangent custom property folds to an angle" ".x{--v:45deg}"
+    (normalize_minified ".x { --v: atan2(1, 1) }");
+  Alcotest.(check string)
+    "unregistered arc cosine custom property folds to an angle" ".x{--v:90deg}"
+    (normalize_minified ".x { --v: acos(0) }");
+  Alcotest.(check string)
+    "unregistered arc sine custom property folds to an angle" ".x{--v:90deg}"
+    (normalize_minified ".x { --v: asin(1) }")
+
 let customprops13_shortest_unresolved_calc_spacing () =
   Alcotest.(check string)
     "unregistered unresolved calc custom property keeps token stream"
@@ -9521,6 +9536,9 @@ let additional_tests =
     ( "spec custom-properties 1 3 registered angle and time calc",
       `Quick,
       customprops13_registered_angle_time_calc );
+    ( "spec custom-properties 1 3 trigonometric calc",
+      `Quick,
+      customprops13_trigonometric_calc );
     ( "spec custom-properties 1 3 unregistered unresolved calc spacing",
       `Quick,
       customprops13_shortest_unresolved_calc_spacing );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -817,6 +817,28 @@ let property_rule_edges () =
   check_stylesheet
     ~expected:"@property --any-tokens{syntax:\"*\";inherits:true}"
     "@property --any-tokens { syntax: \"*\"; inherits: true; }";
+  (* The [+] multiplier repeats a component space-separated (CSS Values 4 sec.
+     2.3), and that space is the only thing separating the two: CSS Syntax 3
+     sec. 4.3.1 consumes [10px20px] as one dimension whose unit is [px20px]. The
+     [#] multiplier carries a comma of its own, so it is the control. *)
+  check_stylesheet
+    ~expected:
+      "@property \
+       --edges{syntax:\"<length>+\";inherits:false;initial-value:10px 20px}"
+    "@property --edges { syntax: \"<length>+\"; inherits: false; \
+     initial-value: 10px 20px; }";
+  check_stylesheet
+    ~expected:
+      "@property \
+       --stops{syntax:\"<color>+\";inherits:false;initial-value:yellow blue}"
+    "@property --stops { syntax: \"<color>+\"; inherits: false; initial-value: \
+     yellow blue; }";
+  check_stylesheet
+    ~expected:
+      "@property \
+       --palette{syntax:\"<color>#\";inherits:false;initial-value:yellow,blue}"
+    "@property --palette { syntax: \"<color>#\"; inherits: false; \
+     initial-value: yellow, blue; }";
   neg_cursor read
     "@property --bad { syntax: \"<length>+\"; inherits: false; initial-value: \
      red }";

--- a/test/test_syntax.ml
+++ b/test/test_syntax.ml
@@ -18,6 +18,41 @@ let is_ascii_ident_continue () =
   check_true "underscore" (Syntax.is_ascii_ident_continue '_');
   check_false "punctuation" (Syntax.is_ascii_ident_continue '!')
 
+let is_ident () =
+  (* CSS Syntax 3 sec. 4.3.11 for the opening code points, sec. 4.2 for the
+     rest. *)
+  check_true "letters" (Syntax.is_ident "foo");
+  check_true "underscore start" (Syntax.is_ident "_x");
+  check_true "digit and hyphen inside" (Syntax.is_ident "a-1");
+  check_true "dash then ident-start" (Syntax.is_ident "-foo");
+  check_true "dashed-ident" (Syntax.is_ident "--foo");
+  (* A second [-] opens an ident, so the reserved custom-property name is one
+     lexically even though it names no property. *)
+  check_true "two dashes" (Syntax.is_ident "--");
+  check_false "empty" (Syntax.is_ident "");
+  (* A lone [-] is a delim, and [-] before a digit opens no ident, so both slip
+     past a scan that reads [-] as ident-start. *)
+  check_false "bare hyphen" (Syntax.is_ident "-");
+  check_false "dash then digit" (Syntax.is_ident "-5px");
+  check_false "leading digit" (Syntax.is_ident "5px");
+  check_false "space" (Syntax.is_ident "a b");
+  check_false "backslash is no ident code point" (Syntax.is_ident "a\\b")
+
+let is_ident_non_ascii () =
+  (* Sec. 4.2 lists the non-ASCII ident code points as ranges rather than
+     admitting every code point [>= U+0080]. U+00B7, U+00F6 and U+200C are in
+     the list. *)
+  check_true "U+00B7" (Syntax.is_ident "\xc2\xb7mid");
+  check_true "U+00F6" (Syntax.is_ident "f\xc3\xb6o");
+  check_true "U+200C" (Syntax.is_ident "\xe2\x80\x8cz");
+  (* U+00D7 falls in the gap between U+00C0..U+00D6 and U+00D8..U+00F6, and
+     U+2197 between U+2070..U+218F and U+2C00..U+2FEF. *)
+  check_false "U+00D7" (Syntax.is_ident "a\xc3\x97b");
+  check_false "U+2197" (Syntax.is_ident "text-\xe2\x86\x97");
+  (* A byte [>= 0x80] is not a code point: a lone continuation byte decodes to
+     nothing an ident can hold. *)
+  check_false "lone continuation byte" (Syntax.is_ident "a\x80b")
+
 let is_hex () =
   check_true "digit" (Syntax.is_hex '0');
   check_true "lower a-f" (Syntax.is_hex 'a');
@@ -71,6 +106,8 @@ let suite =
       Alcotest.test_case "is_ascii_ident_start" `Quick is_ascii_ident_start;
       Alcotest.test_case "is_ascii_ident_continue" `Quick
         is_ascii_ident_continue;
+      Alcotest.test_case "is_ident" `Quick is_ident;
+      Alcotest.test_case "is_ident_non_ascii" `Quick is_ident_non_ascii;
       Alcotest.test_case "is_hex" `Quick is_hex;
       Alcotest.test_case "url_needs_quotes" `Quick url_needs_quotes;
       Alcotest.test_case "strip_url_suffix" `Quick strip_url_suffix;

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -421,6 +421,57 @@ let test_custom_property_roundtrip () =
       Alcotest.(check string) "correct name" "--primary" name
   | None -> Alcotest.fail "Expected custom declaration"
 
+let check_typed_custom name expected syntax value =
+  Alcotest.(check string)
+    name expected
+    (Css.Declaration.to_string ~minify:true
+       (typed_custom_property name syntax value))
+
+let spec_typed_custom_property () =
+  (* CSS Variables 1 sec. 2 substitutes the declared token stream verbatim, so
+     the value has to spell its own type. A unitless 0 is a <number> token
+     there, and CSS Values 4 sec. 10.1 rejects a <number> added to a <length>,
+     so the zero keeps its unit. *)
+  check_typed_custom "--w" "--w:0px" Length (Px 0.);
+  (* The multipliers of CSS Values 4 sec. 2.3: [+] repeats space-separated, [#]
+     comma-separated. *)
+  check_typed_custom "--edges" "--edges:10px 20px" (Plus Length)
+    [ Px 10.; Px 20. ];
+  check_typed_custom "--stops" "--stops:1px,2px" (Hash Length) [ Px 1.; Px 2. ];
+  (* Unquoted, CSS Syntax 3 sec. 4.3.1 reads [a b] as two idents, which is not
+     the one <string> the syntax names. *)
+  check_typed_custom "--label" "--label:\"a b\"" String "a b";
+  (* A disjunction writes the arm it holds, not both. *)
+  check_typed_custom "--edge" "--edge:auto"
+    (Or (Length, Ident_keyword "auto"))
+    (Either.Right ());
+  Alcotest.(check (option string))
+    "layer travels with the declaration" (Some "theme")
+    (Css.Declaration.custom_declaration_layer
+       (typed_custom_property ~layer:"theme" "--w" Length (Px 1.)));
+  (* CSS Variables 1 sec. 2 names a custom property with a <dashed-ident>, the
+     same check Declaration.custom_property makes. *)
+  Alcotest.check_raises "undashed name is no custom property"
+    (Failure "custom_property: w: not a custom-property name") (fun () ->
+      ignore (typed_custom_property "w" Length (Px 1.)))
+
+let spec_typed_custom_property_registration () =
+  (* A registration read back at its syntax assigns without a printer per arm,
+     and writes the value the registration registers. *)
+  let registration =
+    Css.property ~name:"--w" Length ~initial_value:(Px 0.) ~inherits:false ()
+  in
+  let declared =
+    match List.map Css.as_property registration with
+    | [ Some (Css.Property_info { name; syntax; initial_value = Some v; _ }) ]
+      ->
+        Css.Declaration.to_string ~minify:true
+          (typed_custom_property name syntax v)
+    | _ -> Alcotest.fail "expected one @property registration"
+  in
+  Alcotest.(check string)
+    "declares the registered initial value" "--w:0px" declared
+
 let test_any_syntax () =
   (* Test syntax parsing according to CSS @property spec
      https://developer.mozilla.org/en-US/docs/Web/CSS/@property/syntax *)
@@ -608,6 +659,10 @@ let tests =
     ("custom declaration name", `Quick, test_custom_declaration_name);
     ("compare vars by name", `Quick, test_compare_vars_by_name);
     ("custom property roundtrip", `Quick, test_custom_property_roundtrip);
+    ("spec typed custom property", `Quick, spec_typed_custom_property);
+    ( "spec typed custom property registration",
+      `Quick,
+      spec_typed_custom_property_registration );
     ("syntax", `Quick, test_syntax);
     ("read_reference", `Quick, test_read_var_reference);
     ("spec custom property fallback edges", `Quick, spec_custom_fallback_edges);


### PR DESCRIPTION
Ships three of four requested public helpers: `Syntax.is_ident` (whole-string CSS Syntax 3 ident check), `Properties.is_math_function`/`is_color_function` (the internal function-name tables, exported), and `Variables.typed_custom_property` (writes a custom-property declaration from a value already typed by a `@property` registration's syntax). The fourth, a compact printer mode, is declined: minify already drops leading zeros and keeps calc() spacing verbatim, and a third serialisation policy would make every consumer of `minify` decide what "compact" means.

Also fixes a lost separator space between repeated `+`-multiplier `@property` initial values, found while building the fourth helper.