### PR TITLE
prop: invalidate a transform or repeat() it cannot read whole

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `skew()`, `matrix()`, `matrix3d()` and `repeat()` read only up to the first
+  argument they could not parse, so `skew(10deg,red)` became `skew(10deg)`
+  instead of an invalid declaration; same gap #617 closed elsewhere (#627)
 - A `var()`, a `-webkit-gradient()` `color-stop()`/`from()`/`to()`, an
   `animation-timeline` `scroll()`/`view()`, or `box-shadow`'s `inset` written
   in another case is read as that keyword. CSS Values 4 sec. 4.1 makes a

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -843,6 +843,8 @@ module Grid_template = struct
                     ~sep:(fun i -> Cursor.ws i)
                     read_single_track inner
                 in
+                Cursor.ws inner;
+                Cursor.expect_eof inner;
                 (Repeat (count, tracks) : grid_template) );
           ]
         ~default:(fun t -> Cursor.one_of [ read_length_as_grid; read_fr ] t)

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -132,17 +132,23 @@ module Transform = struct
               read_angle t)
             t
         in
+        Cursor.ws t;
+        Cursor.expect_eof t;
         Skew (x, y))
 
   let read_matrix t =
     Cursor.call "matrix" t (fun t ->
-        match Cursor.list ~sep:Cursor.comma Cursor.number t with
+        let args = Cursor.list ~sep:Cursor.comma Cursor.number t in
+        Cursor.expect_eof t;
+        match args with
         | [ a; b; c; d; e; f ] -> Matrix (a, b, c, d, e, f)
         | _ -> err_invalid_value t "matrix" "expected 6 arguments")
 
   let read_matrix3d t =
     Cursor.call "matrix3d" t (fun t ->
-        match Cursor.list ~sep:Cursor.comma Cursor.number t with
+        let args = Cursor.list ~sep:Cursor.comma Cursor.number t in
+        Cursor.expect_eof t;
+        match args with
         | [
          m11;
          m12;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3054,6 +3054,38 @@ let line_width_invalid_math_argument () =
     (line_width_sites "max(3dvh,4px)" @ length_math_sites "max(3dvh,4px)");
   check_declaration ~roundtrip:true "border-width:1px max(3dvh,4px)"
 
+(* [skew()] (CSS Transforms 1 sec. 13.2) takes one or two [<angle>], [matrix()]
+   (sec. 12.1) exactly six [<number>], [matrix3d()] (CSS Transforms 2 sec. 12.2)
+   exactly sixteen, and [repeat()] (CSS Grid 1 sec. 7.2.3) a count and a track
+   list; a trailing argument outside that grammar is invalid (CSS Syntax 3 sec.
+   8.2), which invalidates the declaration. The same [Cursor.call] gap #617
+   closed for the [<line-width>] readers left these four reading only up to the
+   first argument they could not read and answering with a truncated function,
+   e.g. [transform: skew(10deg, red)] as [skew(10deg)]. *)
+let function_argument_validity () =
+  List.iter
+    (neg_cursor read_declaration)
+    [
+      "transform:skew(10deg,red)";
+      "transform:matrix(1,2,3,4,5,6,red)";
+      "transform:matrix3d(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,red)";
+      "grid-template-columns:repeat(2,1fr red)";
+      "grid-template-columns:repeat(2,1fr,red)";
+    ];
+  (* Controls: a valid call at every site still stands, including interior
+     whitespace around commas and parens. *)
+  List.iter
+    (fun css -> check_declaration ~roundtrip:true css)
+    [
+      "transform:skew(10deg)";
+      "transform:skew(10deg,20deg)";
+      "transform:matrix(1,2,3,4,5,6)";
+      "transform:matrix3d(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)";
+      "grid-template-columns:repeat(2,1fr)";
+    ];
+  check_declaration ~expected:"transform:skew(10deg,20deg)"
+    "transform:skew( 10deg , 20deg )"
+
 (* CSS Backgrounds 3 sec. 5.1: [border-radius] is [<length-percentage
    [0,inf]>{1,4} [ / <length-percentage [0,inf]>{1,4} ]?], so an
    intrinsic-sizing keyword ([auto], [max-content], [stretch], ...) is no part
@@ -3488,6 +3520,7 @@ let declaration_tests =
     test_case "shape-outside grammar (sheet)" `Quick shape_outside_sheet;
     test_case "line-width invalid math argument" `Quick
       line_width_invalid_math_argument;
+    test_case "function argument validity" `Quick function_argument_validity;
     test_case "border-radius keyword radii" `Quick border_radius_keyword_radii;
     test_case "border-radius CSS-wide keywords" `Quick
       border_radius_css_wide_keywords;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1625,6 +1625,7 @@ let test_transform () =
   check_transform "scale3d(2, 3, 4)" ~expected:"scale3d(2,3,4)";
   check_transform "skew(30deg)";
   check_transform "skew(30deg, 45deg)" ~expected:"skew(30deg,45deg)";
+  check_transform "skew( 10deg , 20deg )" ~expected:"skew(10deg,20deg)";
   check_transform "skewX(45deg)";
   check_transform "skewY(30deg)";
   check_transform "matrix(1, 0, 0, 1, 0, 0)" ~expected:"matrix(1,0,0,1,0,0)";
@@ -1641,7 +1642,21 @@ let test_transform () =
   neg_cursor read_transform "translate3d(10px,20px)";
   neg_cursor read_transform "scale3d(1,2)";
   neg_cursor read_transform "matrix(1,2,3,4,5)";
-  neg_cursor read_transform "matrix3d(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0)"
+  neg_cursor read_transform "matrix3d(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0)";
+  (* CSS Transforms 1 sec. 13.2 gives [skew()] one or two [<angle>], and
+     [matrix()]/[matrix3d()] take exactly six/sixteen [<number>] (sec. 12.1, CSS
+     Transforms 2 sec. 12.2); a trailing argument outside that grammar is
+     invalid (CSS Syntax 3 sec. 8.2). [Cursor.call] did not require these
+     readers to consume their whole sub-cursor, so each read only its prefix and
+     answered with a truncated function, e.g. [skew(10deg,red)] as
+     [skew(10deg)]. *)
+  neg_cursor read_transform "skew(10deg,red)";
+  neg_cursor read_transform "matrix(1,2,3,4,5,6,red)";
+  neg_cursor read_transform "matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1,red)";
+  (* A seventeenth, well-formed number is the same over-count as [red] above,
+     not a different bug: the exact-arity match already rejects it, with or
+     without the [expect_eof] fix. *)
+  neg_cursor read_transform "matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1,2)"
 
 let test_transforms () =
   (* Adjacent [var()] references in a transform list keep a single separating
@@ -3542,7 +3557,16 @@ let test_grid_template () =
   check_grid_template "10cm";
   check_grid_template ~expected:"minmax(calc(var(--x)*2),1fr)"
     "minmax(calc(var(--x) * 2), 1fr)";
-  neg_cursor read_grid_template "invalid-template"
+  check_grid_template "repeat(2,1fr)";
+  check_grid_template "repeat( 2 , 1fr )" ~expected:"repeat(2,1fr)";
+  neg_cursor read_grid_template "invalid-template";
+  (* CSS Grid 1 sec. 7.2.3 gives [repeat()] a count and a track list; trailing
+     junk after the last track is invalid (CSS Syntax 3 sec. 8.2). [Cursor.call]
+     did not require the reader to consume its whole sub-cursor, so it read up
+     to the first unreadable track and answered with a truncated [repeat()]
+     instead. *)
+  neg_cursor read_grid_template "repeat(2,1fr red)";
+  neg_cursor read_grid_template "repeat(2,1fr,red)"
 
 let test_grid_template_areas () =
   check_grid_template_areas ~expected:"\"nav main\"\". foot\""


### PR DESCRIPTION
`Cursor.call` does not require the reader to consume its whole sub-cursor, so `skew()`, `matrix()`, `matrix3d()` and `grid-template-columns`'s `repeat()` read up to the first argument they could not parse and answered with a truncated function: `transform:skew(10deg,red)` became `skew(10deg)`. Close the sub-cursor with `expect_eof`, as #617 did for the border-width comparison functions.
