### PR TITLE
fmt: skip the --profile report without --minify

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1009,6 +1009,9 @@ recorded cases carrying six minifiers' answers.
 
 ### CLI tools
 
+- `cascade fmt --profile` without `--minify` still printed an empty
+  factoring-fixpoint report, contradicting its own "has no effect without
+  --minify" warning; the report is now skipped when nothing ran (#628)
 - `cascade fmt --help` says what `--enforce-spec` gates: the vendor-prefix
   drop, the Media Queries 4 range grammar for a media or container feature,
   the `&` prefix on a nested selector, the `:dir()` and form-control state

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -77,7 +77,9 @@ let process_css ~input_path ~minify ~scope ~flatten_nesting ~lossless
       else stylesheet
     in
     emit_stylesheet ~minify ~lossless ~enforce_spec stylesheet;
-    if profile then report_profile (Stats.snapshot stats)
+    (* Without --minify, Css.optimize never runs and the recorder stays empty:
+       report only when the fixpoint had a chance to run. *)
+    if profile && minify then report_profile (Stats.snapshot stats)
   with
   | Sys_error msg ->
       Fmt.epr "Error: %s@." msg;

--- a/test/cli/profile_without_minify.t
+++ b/test/cli/profile_without_minify.t
@@ -1,0 +1,39 @@
+CLI: --profile without --minify prints only its warning.
+
+`--profile` reports the optimizer's factoring-fixpoint recorder, but that
+recorder is created unconditionally, before the code even checks `--minify`.
+Without `--minify`, `Css.optimize` (the only thing that ever touches the
+recorder) never runs, so the recorder still holds zero counters and an empty
+iteration list - and used to be printed anyway, as an empty report sitting
+right under a warning that says the flag has no effect. Only one of those two
+can be right; the warning is correct, so the empty report must not print.
+
+  $ cat > small.css <<EOF
+  > .a { color: red }
+  > EOF
+  $ cascade --profile small.css > /dev/null 2>profile.txt
+  $ cat profile.txt
+  Warning: --profile has no effect without --minify
+
+The formatted output on stdout is unaffected: only the stderr report goes
+away.
+
+  $ cascade --profile small.css 2>/dev/null
+  .a {
+    color: red;
+  }
+
+`--profile --minify` together must still print the full report: this is the
+positive control that must keep working. Two rules sharing a declaration
+give the global factoring fixpoint real work, so the report is non-empty and
+names its iterations (the header line's counts, and the per-iteration table).
+
+  $ cat > dup.css <<EOF
+  > .a { color: red }
+  > .b { color: red }
+  > EOF
+  $ cascade --minify --profile dup.css > /dev/null 2>profile2.txt
+  $ grep -o "factor fixpoint ([0-9]* runs, [0-9]* iterations" profile2.txt
+  factor fixpoint (2 runs, 2 iterations
+  $ grep -c "rules_in" profile2.txt
+  1


### PR DESCRIPTION
`--profile` printed an empty factoring-fixpoint report even without `--minify`, right under a warning saying the flag has no effect. `Css.optimize`, the only thing that populates the report, never runs without `--minify`, so the report is now skipped in that case.
