### PR TITLE
cursor: reject a trailing separator in a comma list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -184,6 +184,9 @@ recorded cases carrying six minifiers' answers.
 - `skew()`, `matrix()`, `matrix3d()` and `repeat()` read only up to the first
   argument they could not parse, so `skew(10deg,red)` became `skew(10deg)`
   instead of an invalid declaration; same gap #617 closed elsewhere (#627)
+- A trailing comma in a comma-separated list read as `matrix(1,2,3,4,5,6,)`
+  or `border-width: min(1px,)` instead of invalidating the declaration (CSS
+  Values 4 sec. 5.7.3); same family of gaps as #617, #627 (#629)
 - A `var()`, a `-webkit-gradient()` `color-stop()`/`from()`/`to()`, an
   `animation-timeline` `scroll()`/`view()`, or `box-shadow`'s `inset` written
   in another case is read as that keyword. CSS Values 4 sec. 4.1 makes a

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -920,31 +920,37 @@ let at_least_shortfall ~at_least ~got =
       ")";
     ]
 
-let list_consume_separator sep t =
-  match sep with
-  | None -> true
-  | Some s -> (
-      let snap = save t in
-      match s t with
-      | () -> true
-      | exception Parse_error _ ->
-          restore t snap;
-          false)
-
 type 'a collect_step = Done of 'a list | Continue of 'a list * int
 
+(* A separator only commits once the item after it parses: with [n > 0], [snap]
+   covers both, so a failing [sep] or a failing item after a successful [sep]
+   restores to before the separator instead of leaving it consumed. CSS Values 4
+   sec. 5.7.3 makes a [#] list's trailing comma invalid, and this is the one
+   place that comma is read. *)
 let list_collect_step sep item t acc n max =
   if n >= max then Done (List.rev acc)
   else
     let snap = save t in
-    match option item t with
-    | None -> Done (List.rev acc)
-    | Some v ->
-        if t.cvs == snap then err t "list item consumed no input";
-        let acc = v :: acc in
-        if n + 1 >= max then Done (List.rev acc)
-        else if list_consume_separator sep t then Continue (acc, n + 1)
-        else Done (List.rev acc)
+    let sep_ok =
+      n = 0
+      ||
+      match sep with
+      | None -> true
+      | Some s -> (
+          match s t with () -> true | exception Parse_error _ -> false)
+    in
+    if not sep_ok then (
+      restore t snap;
+      Done (List.rev acc))
+    else
+      let item_snap = save t in
+      match option item t with
+      | None ->
+          restore t snap;
+          Done (List.rev acc)
+      | Some v ->
+          if t.cvs == item_snap then err t "list item consumed no input";
+          Continue (v :: acc, n + 1)
 
 let rec list_collect sep item t acc n max =
   match list_collect_step sep item t acc n max with

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -504,8 +504,11 @@ val one_of : (t -> 'a) list -> t -> 'a
 val list :
   ?sep:(t -> unit) -> ?at_least:int -> ?at_most:int -> (t -> 'a) -> t -> 'a list
 (** [list ?sep ?at_least ?at_most item t] parses items separated by [sep]
-    (default: no separator). Enforces cardinality bounds. Too few items raise
-    ["expected at least N items (got M)"], the wording {!Reader.list} uses. *)
+    (default: no separator). A [sep] only commits once another [item] parses
+    after it, so a trailing separator with nothing following it is left
+    unconsumed for the caller rather than silently dropped. Enforces cardinality
+    bounds. Too few items raise ["expected at least N items (got M)"], the
+    wording {!Reader.list} uses. *)
 
 val fold_many :
   (t -> 'a) -> init:'s -> f:('s -> 'a -> 's) -> t -> 's * string option

--- a/test/test_cursor.ml
+++ b/test/test_cursor.ml
@@ -125,6 +125,34 @@ let test_list_at_least_message () =
       | _ -> Alcotest.fail "expected Bad_value")
   | _ -> Alcotest.fail "expected Parse_error"
 
+(* CSS Values 4 sec. 5.7.3: a [#] list's comma never trails the last item. [sep]
+   must only commit once another [item] parses after it, or a trailing separator
+   is silently dropped and the list looks complete when it is not. *)
+let test_list_trailing_separator () =
+  let c = cursor_of_string "a,b," in
+  let items = Cursor.list ~sep:Cursor.comma Cursor.ident c in
+  Alcotest.(check (list string)) "items" [ "a"; "b" ] items;
+  Alcotest.(check bool)
+    "trailing comma left for the caller, not consumed" false (Cursor.is_done c)
+
+let test_list_no_trailing_separator () =
+  let c = cursor_of_string "a,b" in
+  let items = Cursor.list ~sep:Cursor.comma Cursor.ident c in
+  Alcotest.(check (list string)) "items" [ "a"; "b" ] items;
+  Alcotest.(check bool) "fully consumed" true (Cursor.is_done c)
+
+let test_list_interior_whitespace () =
+  let c = cursor_of_string "a , b" in
+  let items = Cursor.list ~sep:Cursor.comma Cursor.ident c in
+  Alcotest.(check (list string)) "items" [ "a"; "b" ] items;
+  Alcotest.(check bool) "fully consumed" true (Cursor.is_done c)
+
+let test_list_single_item_no_separator () =
+  let c = cursor_of_string "a" in
+  let items = Cursor.list ~sep:Cursor.comma Cursor.ident c in
+  Alcotest.(check (list string)) "items" [ "a" ] items;
+  Alcotest.(check bool) "fully consumed" true (Cursor.is_done c)
+
 let suite =
   ( "cursor",
     [
@@ -144,4 +172,12 @@ let suite =
         test_triple_rewinds_on_failure;
       Alcotest.test_case "list ~at_least message" `Quick
         test_list_at_least_message;
+      Alcotest.test_case "list rejects a trailing separator" `Quick
+        test_list_trailing_separator;
+      Alcotest.test_case "list without a trailing separator" `Quick
+        test_list_no_trailing_separator;
+      Alcotest.test_case "list interior whitespace" `Quick
+        test_list_interior_whitespace;
+      Alcotest.test_case "list single item, no separator" `Quick
+        test_list_single_item_no_separator;
     ] )

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3086,6 +3086,41 @@ let function_argument_validity () =
   check_declaration ~expected:"transform:skew(10deg,20deg)"
     "transform:skew( 10deg , 20deg )"
 
+(* CSS Values 4 sec. 5.7.3: a [#] multiplier's comma never trails the last item.
+   [min()]/[max()] take a comma-separated [<calc-sum>] list (sec. 10.2), and
+   [matrix()]/[matrix3d()] (CSS Transforms 1 sec. 12.1, 2 sec. 12.2) a
+   fixed-arity comma list of [<number>]; [list] committed a separator before it
+   knew whether another item followed it, so [min(1px,)] read as [min(1px)] and
+   [matrix(1,2,3,4,5,6,)] as [matrix(1,2,3,4,5,6)] instead of invalidating the
+   declaration (CSS Syntax 3 sec. 8.2). *)
+let list_trailing_separator_invalid () =
+  List.iter
+    (fun value ->
+      List.iter (neg_cursor read_declaration) (line_width_sites value);
+      List.iter (neg_cursor read_declaration) (length_math_sites value))
+    [ "min(1px,)"; "min(1px,2px,)"; "max(1px,2px,)" ];
+  List.iter
+    (neg_cursor read_declaration)
+    [
+      "transform:matrix(1,2,3,4,5,6,)";
+      "transform:matrix3d(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,)";
+    ];
+  (* Controls: no trailing separator, with and without interior whitespace, and
+     a single-item list, all still parse. *)
+  List.iter
+    (fun css -> check_declaration ~roundtrip:true css)
+    (line_width_sites "min(1px)"
+    @ length_math_sites "min(1px)"
+    @ line_width_sites "min(1px,2px)"
+    @ length_math_sites "min(1px,2px)");
+  check_declaration ~expected:"border-width:min(1px,2px)"
+    "border-width:min( 1px , 2px )";
+  List.iter
+    (fun css -> check_declaration ~roundtrip:true css)
+    [ "transform:matrix(1,2,3,4,5,6)" ];
+  check_declaration ~expected:"transform:matrix(1,2,3,4,5,6)"
+    "transform:matrix( 1 , 2 , 3 , 4 , 5 , 6 )"
+
 (* CSS Backgrounds 3 sec. 5.1: [border-radius] is [<length-percentage
    [0,inf]>{1,4} [ / <length-percentage [0,inf]>{1,4} ]?], so an
    intrinsic-sizing keyword ([auto], [max-content], [stretch], ...) is no part
@@ -3521,6 +3556,8 @@ let declaration_tests =
     test_case "line-width invalid math argument" `Quick
       line_width_invalid_math_argument;
     test_case "function argument validity" `Quick function_argument_validity;
+    test_case "list rejects a trailing separator" `Quick
+      list_trailing_separator_invalid;
     test_case "border-radius keyword radii" `Quick border_radius_keyword_radii;
     test_case "border-radius CSS-wide keywords" `Quick
       border_radius_css_wide_keywords;

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -2504,9 +2504,17 @@ let spec_selector_tree_structural_pseudos () =
     ];
   check ~expected:":nth-last-child(odd of:not([hidden]))"
     ":nth-last-child(odd of :not([hidden]))";
+  check ~expected:":nth-child(odd of.a,.b)" ":nth-child(2n+1 of.a,.b)";
   List.iter
     (fun input -> neg_cursor read input)
-    [ ":nth-child(n+)"; ":nth-last-child(2n of)"; ":nth-of-type(odd even)" ]
+    [
+      ":nth-child(n+)";
+      ":nth-last-child(2n of)";
+      ":nth-of-type(odd even)";
+      (* CSS Values 4 sec. 5.7.3: the [of <complex-selector-list>] clause is a
+         [#] list, so a trailing comma is invalid. *)
+      ":nth-child(2n+1 of .a,.b,)";
+    ]
 
 let spec_selector_input_state_pseudos () =
   List.iter check


### PR DESCRIPTION
`border-width: min(1px,)` parsed as `1px`: `Cursor.list` committed the comma before checking whether another item followed, so an invalid trailing comma was dropped instead of invalidating the declaration. The same gap let `transform: matrix(1,2,3,4,5,6,)` and `:nth-child(2n+1 of .a,.b,)` through. CSS Values 4 sec. 5.7.3 forbids a trailing comma in a `#` list, and CSS Syntax 3 sec. 8.2 makes that invalidate the declaration.

The fix is local to `Cursor.list`: a separator now commits only once the item after it parses. All ~111 call sites were audited; every comma-list grammar in cascade forbids a trailing separator, and three callers (`font-family`, `@font-face src`, `cross-fade()`) already carried hand-rolled workarounds for exactly this gap, which stay unchanged.
