### PR TITLE
variables: expose a reader for a var() argument list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -738,6 +738,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Custom properties
 
+- `Css.Variables.read_reference_body` reads a `var()` argument list - a name
+  and optional fallback - into a typed variable handle from a cursor
+  already positioned at the arguments, without the `var(`/`)` wrapper (#630)
 - `Css.Variables.typed_custom_property` writes a custom-property declaration
   from a value already typed by a `@property` registration's syntax;
   `Declaration.custom_property` takes a plain string (#626)

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -363,6 +363,11 @@ val read_var : (Cursor.t -> 'a) -> Cursor.t -> 'a var
     for the payload. Expects to be positioned at [var(] and parses the full
     expression. *)
 
+val read_var_body : (Cursor.t -> 'a) -> Cursor.t -> 'a var
+(** [read_var_body read t] parses a [var()] reference body -- the contents of a
+    [var(...)] form without the surrounding [var(] and [)] -- using [read] for
+    the fallback's payload. *)
+
 (** {1 Calc Module} *)
 module Calc : sig
   val add : 'a calc -> 'a calc -> 'a calc

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2654,3 +2654,5 @@ let read_reference (r : Cursor.t) : string * string option =
   if not (Cursor.is_done r) then
     Cursor.err_invalid r "trailing tokens after var()";
   result
+
+let read_reference_body = read_var_body

--- a/lib/variables.mli
+++ b/lib/variables.mli
@@ -120,3 +120,10 @@ val read_reference : Cursor.t -> string * string option
 (** [read_reference t] parses a CSS var() function and returns the variable name
     (without -- prefix) and optional fallback string. This is a lower-level
     function that doesn't create a variable handle. *)
+
+val read_reference_body : (Cursor.t -> 'a) -> Cursor.t -> 'a var
+(** [read_reference_body read t] parses a [var()] reference body -- the name and
+    optional fallback -- from a cursor already positioned at the arguments,
+    without the surrounding [var(] and [)]. Unlike {!read_reference}, which
+    returns strings, this reads the fallback with [read] and returns a typed
+    variable handle. *)

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -122,3 +122,10 @@ let _ :
     Values.length ->
     Css.declaration =
   Css.Variables.typed_custom_property
+
+(* The contents of a [var()] - a name and optional fallback - are readable
+   from a cursor already positioned at them, without assembling the [var(]
+   and [)] wrapper around a string first: the same relationship
+   [Values.read_calc_expr] has to a [calc()] body. *)
+let _ : (Cursor.t -> Values.length) -> Cursor.t -> Values.length Css.var =
+  Css.Variables.read_reference_body

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -606,6 +606,30 @@ let spec_custom_fallback_edges () =
   check_var_ref "var(---)" "-" None;
   neg "var(--, red)"
 
+(* CSS Custom Properties 1 sec. 3: [var()] = [var( <custom-property-name> ,
+   <declaration-value>? )]. [read_reference_body] reads that argument list from
+   a cursor already positioned at it, without the surrounding [var(] and [)] a
+   caller would otherwise have to assemble and hand back to a parser - the same
+   relationship [Values.read_calc_expr] has to a [calc()] body. *)
+let spec_read_reference_body_edges () =
+  let check ?(expected = "") input =
+    check_value_cursor "var body"
+      (read_reference_body read_length)
+      (pp_var pp_length) ~minify:false ~expected input
+  in
+  (* No fallback: just the [<custom-property-name>]. *)
+  check "--x" ~expected:"var(--x)";
+  (* A fallback that itself parses as the target syntax is kept typed. *)
+  check "--x, 10px" ~expected:"var(--x, 10px)";
+  (* A trailing comma with nothing after it is an explicit empty fallback,
+     distinct from no fallback at all. *)
+  check "--x," ~expected:"var(--x,)";
+  (* A fallback that is not itself a <length> is preserved as the
+     declaration-value tokens it is, not rejected. *)
+  check "--x, red" ~expected:"var(--x, red)";
+  neg_cursor (read_reference_body read_length) "not-a-var";
+  neg_cursor (read_reference_body read_length) "--"
+
 let spec_custom_computed_edges () =
   let check_context name specified =
     let decl = Css.Declaration.of_string (name ^ ": " ^ specified) in
@@ -666,6 +690,7 @@ let tests =
     ("syntax", `Quick, test_syntax);
     ("read_reference", `Quick, test_read_var_reference);
     ("spec custom property fallback edges", `Quick, spec_custom_fallback_edges);
+    ("spec read_reference_body edges", `Quick, spec_read_reference_body_edges);
     ( "spec custom property computed-time edges",
       `Quick,
       spec_custom_computed_edges );


### PR DESCRIPTION
A caller that already has a var() argument list, not the surrounding var(...) text, has to rebuild it as a string to reuse read_reference. Css.Variables.read_reference_body reads the name and optional fallback straight off a cursor positioned at the arguments and returns a typed variable handle, mirroring the existing read_calc/read_calc_expr split for calc() bodies. The underlying reader already existed as Values.read_var_body; this gives it its first public entry point.

Two of the three asks behind this change are not here: a bare parenthesised calc body is already readable through the existing public Values.read_calc_expr plus Values.read_length, verified to reproduce a negate-length round trip byte for byte without a calc() string wrapper, so no new export was needed there. And Css.parse_length already tolerates leading and trailing whitespace, since Cursor.is_done drops it before checking, so the described String.trim requirement does not hold today.