### PR TITLE
cursor: require a function reader to consume its whole argument list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A function reader that could not read all of its arguments answered with
+  the ones it had, so `transform: translateX(10px red)` read as
+  `translateX(10px)`; the cause behind #617, #627 and #629 (#631)
 - `skew()`, `matrix()`, `matrix3d()` and `repeat()` read only up to the first
   argument they could not parse, so `skew(10deg,red)` became `skew(10deg)`
   instead of an invalid declaration; same gap #617 closed elsewhere (#627)

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -143,10 +143,13 @@ let string_of_components ?(trim = false) cvs =
 let string_of_remaining ?(trim = false) t =
   string_of_components ~trim (remaining t)
 
-let consume_remaining_as_string ?(trim = false) t =
-  let cvs = remaining t in
+let consume_remaining t =
+  let cvs = t.cvs in
   t.cvs <- [];
-  string_of_components ~trim cvs
+  cvs
+
+let consume_remaining_as_string ?(trim = false) t =
+  string_of_components ~trim (consume_remaining t)
 
 let peek_raw t = match t.cvs with [] -> None | hd :: _ -> Some hd
 
@@ -784,7 +787,12 @@ let call name t f =
       let arg = sub ~eof_loc:(closer_loc fn.loc) t fn.node.arguments in
       let arg = { arg with depth = t.depth + 1 } in
       if arg.depth > max_nesting_depth then err arg "nesting too deep";
-      f arg
+      (* A function's grammar ends at its closing paren, so whatever [f] left
+         behind is an invalid value, not a shorter one it may answer with (CSS
+         Syntax 3 sec. 8.2). [expect_eof] skips leading whitespace itself. *)
+      let v = f arg in
+      expect_eof arg;
+      v
   | _ -> err_expected t (name ^ "(")
 
 (** {1 Enums} *)

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -98,6 +98,9 @@ val string_of_remaining : ?trim:bool -> t -> string
 (** [string_of_remaining t] serializes the unconsumed tail without advancing
     [t]. *)
 
+val consume_remaining : t -> Component.t list
+(** [consume_remaining t] is {!val-remaining}, and also consumes the tail. *)
+
 val consume_remaining_as_string : ?trim:bool -> t -> string
 (** [consume_remaining_as_string t] serializes and consumes the unconsumed tail.
 *)
@@ -445,7 +448,9 @@ val braces : (t -> 'a) -> t -> 'a
 
 val call : string -> t -> (t -> 'a) -> 'a
 (** [call name t f] consumes a [name(...)] function call and applies [f] to a
-    cursor over its arguments. Raises if no such function is next. *)
+    cursor over its arguments. Raises if no such function is next, or if [f]
+    leaves any of the arguments unconsumed: trailing content makes the value
+    invalid, not truncated (CSS Syntax 3 sec. 8.2). *)
 
 val function_call : string -> (t -> 'a) -> t -> 'a option
 (** [function_call name f t] consumes a [name(...)] call and calls [f] over its

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -233,9 +233,17 @@ let invalid_var_arguments arguments =
   match
     List.filter (fun component -> not (is_ws_component component)) arguments
   with
-  | Component.Preserved { kind = Token.Ident name; _ } :: _
-    when Custom_property_name.is_valid name ->
-      false
+  | Component.Preserved { kind = Token.Ident name; _ } :: rest
+    when Custom_property_name.is_valid name -> (
+      (* CSS Custom Properties 1 sec. 3: nothing follows the name but a comma
+         opening the fallback. This raw-component check gates the opaque
+         keep-verbatim path, so it has to agree with the typed reader; without
+         the comma case [var(--x 10px)] took that path and was preserved instead
+         of invalidating the declaration. *)
+      match rest with
+      | [] -> false
+      | Component.Preserved { kind = Token.Comma; _ } :: _ -> false
+      | _ -> true)
   | _ -> true
 
 let rec components_have_invalid_var components =

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1227,30 +1227,24 @@ let length_to_border_width t (length : length) : border_width =
       | Some (unit, value) -> typed_dimension value unit
       | None -> err_invalid_value t "border-width" "unsupported length type")
 
-(* CSS Values 4 sec. 10.2: every argument of a comparison function is a
-   [<calc-sum>], and [clamp()] takes three. [Cursor.list] stops at the first
-   argument it cannot read, so the body has to be read to its end: comparing the
-   prefix answers a different question, and CSS Syntax 3 sec. 8.2 makes an
-   invalid value invalidate the declaration. *)
-let read_math_args ?at_most ~at_least read_arg t =
-  let args = Cursor.list ~sep:Cursor.comma ~at_least ?at_most read_arg t in
-  Cursor.expect_eof t;
-  args
-
 let rec read_border_width t : border_width =
   let read_var t : border_width = Var (read_var read_border_width t) in
   let read_calc t : border_width = Calc (read_calc read_border_width t) in
   let read_math_arg t = read_calc_expr read_border_width t in
   let read_min t : border_width =
-    Min (Cursor.call "min" t (read_math_args ~at_least:1 read_math_arg))
+    Min
+      (Cursor.call "min" t
+         (Cursor.list ~sep:Cursor.comma ~at_least:1 read_math_arg))
   in
   let read_max t : border_width =
-    Max (Cursor.call "max" t (read_math_args ~at_least:1 read_math_arg))
+    Max
+      (Cursor.call "max" t
+         (Cursor.list ~sep:Cursor.comma ~at_least:1 read_math_arg))
   in
   let read_clamp t : border_width =
     match
       Cursor.call "clamp" t
-        (read_math_args ~at_least:3 ~at_most:3 read_math_arg)
+        (Cursor.list ~sep:Cursor.comma ~at_least:3 ~at_most:3 read_math_arg)
     with
     | [ lower; value; upper ] -> Clamp (lower, value, upper)
     | _ -> Cursor.err_invalid t "invalid clamp"

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -843,8 +843,6 @@ module Grid_template = struct
                     ~sep:(fun i -> Cursor.ws i)
                     read_single_track inner
                 in
-                Cursor.ws inner;
-                Cursor.expect_eof inner;
                 (Repeat (count, tracks) : grid_template) );
           ]
         ~default:(fun t -> Cursor.one_of [ read_length_as_grid; read_fr ] t)

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -132,23 +132,17 @@ module Transform = struct
               read_angle t)
             t
         in
-        Cursor.ws t;
-        Cursor.expect_eof t;
         Skew (x, y))
 
   let read_matrix t =
     Cursor.call "matrix" t (fun t ->
-        let args = Cursor.list ~sep:Cursor.comma Cursor.number t in
-        Cursor.expect_eof t;
-        match args with
+        match Cursor.list ~sep:Cursor.comma Cursor.number t with
         | [ a; b; c; d; e; f ] -> Matrix (a, b, c, d, e, f)
         | _ -> err_invalid_value t "matrix" "expected 6 arguments")
 
   let read_matrix3d t =
     Cursor.call "matrix3d" t (fun t ->
-        let args = Cursor.list ~sep:Cursor.comma Cursor.number t in
-        Cursor.expect_eof t;
-        match args with
+        match Cursor.list ~sep:Cursor.comma Cursor.number t with
         | [
          m11;
          m12;

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5063,8 +5063,11 @@ let read_var_body : type a. (Cursor.t -> a) -> Cursor.t -> a var =
       if Cursor.is_done t then Empty
       else
         match Cursor.try_parse_full_err read_value t with
+        (* The fallback is a [<declaration-value>]: it swallows the rest of the
+           argument list whether or not it parses as the target syntax, so it is
+           consumed either way. *)
         | Ok fb -> Fallback fb
-        | Error _ -> Syntax_fallback (Cursor.remaining t))
+        | Error _ -> Syntax_fallback (Cursor.consume_remaining t))
   in
   var_ref ~fallback var_name
 

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2602,10 +2602,10 @@ let read_any_syntax (r : Cursor.t) : any_syntax =
    instead of re-serialising tokens. Falls back to component-based serialisation
    when the source is not retained on the cursor. *)
 let string_of_fallback inner =
-  let cvs = Cursor.remaining inner in
+  let cvs = Cursor.consume_remaining inner in
   match (cvs, Cursor.source inner) with
   | [], _ -> ""
-  | _, None -> Cursor.string_of_remaining ~trim:true inner
+  | _, None -> Cursor.string_of_components ~trim:true cvs
   | first :: _, Some src ->
       let start_pos = (Component.source_loc first).start_pos in
       let last = List.nth cvs (List.length cvs - 1) in

--- a/test/test_cursor.ml
+++ b/test/test_cursor.ml
@@ -153,6 +153,37 @@ let test_list_single_item_no_separator () =
   Alcotest.(check (list string)) "items" [ "a" ] items;
   Alcotest.(check bool) "fully consumed" true (Cursor.is_done c)
 
+(* [call] hands [f] a sub-cursor over the function's argument list, but a reader
+   that only recognises a prefix of it (e.g. one built from [option] or
+   [one_of]) can return without raising. CSS Syntax 3 sec. 8.2 makes anything
+   left over after that an invalid value, not a truncated one, so [call] must
+   check the sub-cursor is exhausted itself once [f] returns. *)
+let test_call_requires_eof () =
+  let c = cursor_of_string "foo(1,2)" in
+  match Cursor.call "foo" c (fun inner -> Cursor.number inner) with
+  | (_ : float) -> Alcotest.fail "expected Parse_error"
+  | exception Cursor.Parse_error _ -> ()
+
+let test_call_full_consumption_succeeds () =
+  let c = cursor_of_string "foo(1)" in
+  let v = Cursor.call "foo" c (fun inner -> Cursor.number inner) in
+  Alcotest.(check (float 0.)) "value" 1. v;
+  Alcotest.(check bool)
+    "outer cursor advanced past the call" true (Cursor.is_done c)
+
+let test_call_interior_whitespace () =
+  let c = cursor_of_string "foo( 1 )" in
+  let v =
+    Cursor.call "foo" c (fun inner ->
+        Cursor.ws inner;
+        let n = Cursor.number inner in
+        Cursor.ws inner;
+        n)
+  in
+  Alcotest.(check (float 0.)) "value" 1. v;
+  Alcotest.(check bool)
+    "outer cursor advanced past the call" true (Cursor.is_done c)
+
 let suite =
   ( "cursor",
     [
@@ -180,4 +211,9 @@ let suite =
         test_list_interior_whitespace;
       Alcotest.test_case "list single item, no separator" `Quick
         test_list_single_item_no_separator;
+      Alcotest.test_case "call requires eof" `Quick test_call_requires_eof;
+      Alcotest.test_case "call full consumption succeeds" `Quick
+        test_call_full_consumption_succeeds;
+      Alcotest.test_case "call interior whitespace" `Quick
+        test_call_interior_whitespace;
     ] )

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -224,7 +224,17 @@ let complex_values () =
 
   (* pp holds triple-nested calc; optimize reduces it fully. *)
   check_declaration ~expected:"width:calc(100% - calc(10px - calc(5px + 2px)))"
-    "width: calc(100% - calc(10px - calc(5px + 2px)));"
+    "width: calc(100% - calc(10px - calc(5px + 2px)));";
+  (* CSS Values 4 sec. 10.1 gives a [calc()] body exactly one [<calc-sum>]; a
+     top-level [calc()] already checks this (the comment above [read_calc] in
+     values.ml names [calc(1px 2px)] directly), but a nested [calc()] read
+     through [read_nested_calc_factor] shares the same [Cursor.call] and had no
+     such check, so [calc(calc(1px 2px) + 3px)] read only [1px] for the inner
+     factor and answered [calc(1px + 3px)] instead of invalidating the
+     declaration. *)
+  neg_cursor read_declaration "width:calc(calc(1px 2px) + 3px)";
+  check_declaration ~expected:"width:calc(calc(1px + 2px) + 3px)"
+    "width: calc( calc( 1px + 2px ) + 3px );"
 
 let quoted_strings () =
   (* Simple quoted strings *)
@@ -1186,7 +1196,15 @@ let custom_properties () =
 
   (* var() with empty fallback - declaration level coverage *)
   check_declaration ~expected:"color:var(--x,)" "color: var(--x,)";
-  check_declaration ~expected:"background:var(--bg,)" "background: var(--bg,)"
+  check_declaration ~expected:"background:var(--bg,)" "background: var(--bg,)";
+  (* CSS Custom Properties for Cascading Variables 1 sec. 3: [var()] takes a
+     name and an optional [, <fallback>]; content after the name without a
+     leading comma is not part of the grammar (CSS Syntax 3 sec. 8.2 invalidates
+     the declaration). [Cursor.call] did not require [var()]'s reader to consume
+     its whole sub-cursor, so [var(--x 10px)] silently dropped [ 10px] and
+     answered [var(--x)]. *)
+  neg_cursor read_declaration "color:var(--x 10px)";
+  check_declaration ~expected:"color:var(--x)" "color: var( --x )"
 
 let important () =
   (* Standard properties with !important *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1656,7 +1656,39 @@ let test_transform () =
   (* A seventeenth, well-formed number is the same over-count as [red] above,
      not a different bug: the exact-arity match already rejects it, with or
      without the [expect_eof] fix. *)
-  neg_cursor read_transform "matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1,2)"
+  neg_cursor read_transform "matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1,2)";
+  (* The same gap in [Cursor.call] itself (not just the readers #617/#627
+     already patched): CSS Transforms 1 sec. 7.1 gives each one-argument
+     function exactly one [<length-percentage>] / [<angle>] / [<number>], CSS
+     Transforms 2 sec. 12.1-12.2 gives the 3d/axis forms a fixed comma count,
+     and none of these readers checked that its sub-cursor was exhausted, so
+     e.g. [translateX(10px red)] read only [10px] and answered
+     [translateX(10px)] instead of invalidating the declaration. *)
+  List.iter
+    (neg_cursor read_transform)
+    [
+      "translateX(10px red)";
+      "translateY(10px red)";
+      "translateZ(10px red)";
+      "translate3d(10px,20px,30px,red)";
+      "translate(10px red)";
+      "translate(10px,20px,red)";
+      "rotateX(45deg red)";
+      "rotateY(45deg red)";
+      "rotateZ(45deg red)";
+      "rotate(45deg red)";
+      "rotate3d(1,0,0,45deg,red)";
+      "scaleX(2 red)";
+      "scaleY(2 red)";
+      "scaleZ(2 red)";
+      "scale3d(2,3,4,red)";
+      "skewX(10deg red)";
+      "skewY(10deg red)";
+    ];
+  (* Controls: whitespace directly inside the parens still stands. *)
+  check_transform "translateX( 10px )" ~expected:"translateX(10px)";
+  check_transform "rotate( 45deg )" ~expected:"rotate(45deg)";
+  check_transform "scaleX( 2 )" ~expected:"scaleX(2)"
 
 let test_transforms () =
   (* Adjacent [var()] references in a transform list keep a single separating
@@ -1824,6 +1856,14 @@ let test_cursor () =
     "url(./cursor.cur) 4 12, pointer";
   check_cursor ~expected:"url(a.cur),url(b.cur) 1 2,move"
     "url(\"a.cur\"), url(b.cur) 1 2, move";
+  (* A quoted [url()] with the hotspot placed inside its own parens still
+     parses, and prints with the hotspot moved after the call like every other
+     form (CSS UI 4 sec. 5.4: [<url> [<x> <y>]?]). A third number past the
+     hotspot has nowhere to go in that grammar; [Cursor.call] did not require
+     the reader to consume its whole sub-cursor, so it was silently dropped
+     instead of invalidating the declaration. *)
+  check_cursor ~expected:"url(a.cur) 1 2,move" "url(\"a.cur\" 1 2), move";
+  neg_cursor read_cursor "url(\"a.cur\" 1 2 3), pointer";
   neg_cursor read_cursor "invalid-cursor";
   neg_cursor read_cursor "url(cursor.cur)";
   (* missing fallback *)
@@ -2166,7 +2206,17 @@ let test_list_style_type () =
   check_list_style_type "ethiopic-numeric";
   check_list_style_type "disclosure-open";
   (* An unknown bare identifier is still rejected (no @counter-style here). *)
-  neg_cursor read_list_style_type "invalid-style"
+  neg_cursor read_list_style_type "invalid-style";
+  (* CSS Lists 3 sec. 6.2: [symbols() = symbols( <symbols-type>? [ <string> |
+     <image> ]+ )]. [Cursor.call] did not require the reader to consume its
+     whole sub-cursor, so a trailing token the [<symbols-type>? [<string> |
+     <image>]+] grammar cannot place was silently dropped instead of
+     invalidating the declaration. *)
+  check_list_style_type "symbols(cyclic \"a\" \"b\")"
+    ~expected:"symbols(cyclic\"a\"\"b\")";
+  check_list_style_type "symbols( cyclic \"a\" \"b\" )"
+    ~expected:"symbols(cyclic\"a\"\"b\")";
+  neg_cursor read_list_style_type "symbols(\"a\" 5)"
 
 let test_list_style_position () =
   check_list_style_position "inside";
@@ -2444,7 +2494,20 @@ let test_timing_function () =
   check_timing_function "step-end";
   check_timing_function ~expected:"cubic-bezier(.1,.7,1,.1)"
     "cubic-bezier(0.1, 0.7, 1.0, 0.1)";
-  neg_cursor read_timing_function "cubic-bezier()"
+  neg_cursor read_timing_function "cubic-bezier()";
+  (* CSS Easing 1 sec. 4.2/4.3 give [cubic-bezier()] exactly four [<number>] and
+     [steps()] a count and an optional [<step-position>]; a trailing argument is
+     invalid (CSS Syntax 3 sec. 8.2). [Cursor.call] did not require either
+     reader to consume its whole sub-cursor, so e.g. [steps(4, red)] read only
+     the count and answered [steps(4)] instead of invalidating the
+     declaration. *)
+  check_timing_function "steps(4)";
+  check_timing_function "steps(4, jump-start)" ~expected:"steps(4,jump-start)";
+  check_timing_function "steps( 4 , jump-start )"
+    ~expected:"steps(4,jump-start)";
+  neg_cursor read_timing_function "steps(4, jump-start, red)";
+  neg_cursor read_timing_function "steps(4 red)";
+  neg_cursor read_timing_function "cubic-bezier(0.1,0.7,1,0.1,0.5)"
 
 let test_transition_property_value () =
   check_transition_property_value "all";
@@ -2805,6 +2868,30 @@ let test_background_image () =
   check_background_image ~minify:false
     ~expected:"conic-gradient(in hsl longer hue, red, blue)"
     "conic-gradient(in hsl longer hue, red, blue)";
+  (* CSS Images 4 sec. 3.5.6 gives the color-stop-list a comma-separated list of
+     stops and hints, so a trailing item outside that grammar is invalid (CSS
+     Syntax 3 sec. 8.2). [Cursor.call] did not require [linear-gradient()] /
+     [radial-gradient()]'s reader to consume its whole sub-cursor, so the list
+     was read up to the first unreadable stop and answered with a truncated
+     gradient instead. *)
+  check_background_image "linear-gradient(red,blue)";
+  check_background_image "radial-gradient(red,blue)";
+  neg_cursor read_background_image "linear-gradient(red, blue, bogus-token)";
+  neg_cursor read_background_image "radial-gradient(red, blue, bogus-token)";
+  (* CSS Images 4 sec. 6.2 gives [image-set()] a comma-separated
+     [<image-set-option>]#; same [Cursor.call] gap in the option list. *)
+  check_background_image ~expected:"image-set(\"a.png\"1x)"
+    "image-set(\"a.png\" 1x)";
+  neg_cursor read_background_image "image-set(\"a.png\" 1x, bogus-token)";
+  (* [conic-gradient()] (sec. 3.6) reads its stop list the same way. *)
+  neg_cursor read_background_image
+    "conic-gradient(from 45deg, red, bogus-token)";
+  (* Controls: whitespace around the commas and just inside the parens is not
+     trailing content, so each call still stands. *)
+  check_background_image ~expected:"linear-gradient(to right,red,blue)"
+    "linear-gradient( to right , red , blue )";
+  check_background_image ~expected:"image-set(\"a.png\"1x,\"b.png\"2x)"
+    "image-set( \"a.png\" 1x , \"b.png\" 2x )";
   neg_cursor read_background_image "invalid-image"
 
 let test_radial_shape () =
@@ -3322,7 +3409,32 @@ let test_filter () =
   check_filter "url(foo.svg#x)";
   check_filter ~expected:"url(#liquid)" "url(\"#liquid\")";
   check_filter ~expected:"url(#blur)blur(2px)" "url(#blur) blur(2px)";
-  neg_cursor read_filter "invalid-filter"
+  neg_cursor read_filter "invalid-filter";
+  (* CSS Filter Effects 1 sec. 6.1 gives each of these one operand ([<length>],
+     [<number>]/[<percentage>], or [<color> && <length>{2,3}] for
+     [drop-shadow]); [Cursor.call] did not require the reader to consume its
+     whole sub-cursor, so e.g. [blur(2px foo)] read only [2px] and answered
+     [blur(2px)] instead of invalidating the whole [filter] value ([filter]'s
+     top-level list is space-separated, so the truncated function was simply
+     followed by the next one). *)
+  List.iter (neg_cursor read_filter)
+    [
+      "blur(5px 5px)";
+      "brightness(1.2 1.2)";
+      "contrast(1.2 1.2)";
+      "grayscale(.5 .5)";
+      "hue-rotate(30deg 30deg)";
+      "invert(.5 .5)";
+      "opacity(.5 .5)";
+      "saturate(1.5 1.5)";
+      "sepia(.5 .5)";
+      "drop-shadow(2px 4px 6px red foo)";
+    ];
+  (* Controls: whitespace directly inside the parens still stands. *)
+  check_filter "blur( 5px )" ~expected:"blur(5px)";
+  check_filter "opacity( .5 )" ~expected:"opacity(.5)";
+  check_filter "drop-shadow( 2px 4px 6px red )"
+    ~expected:"drop-shadow(2px 4px 6px red)"
 
 let test_shadow () =
   check_shadow "none";
@@ -3566,7 +3678,15 @@ let test_grid_template () =
      to the first unreadable track and answered with a truncated [repeat()]
      instead. *)
   neg_cursor read_grid_template "repeat(2,1fr red)";
-  neg_cursor read_grid_template "repeat(2,1fr,red)"
+  neg_cursor read_grid_template "repeat(2,1fr,red)";
+  (* Same [Cursor.call] gap in the two comparison functions #627 did not reach:
+     CSS Grid 1 sec. 7.2.3 gives [minmax()] exactly two [<track-breadth>] and
+     [fit-content()] exactly one [<length-percentage>]; a trailing argument is
+     invalid (CSS Syntax 3 sec. 8.2). *)
+  check_grid_template "fit-content(10px)";
+  check_grid_template "fit-content( 10px )" ~expected:"fit-content(10px)";
+  neg_cursor read_grid_template "minmax(1px,2px,3px)";
+  neg_cursor read_grid_template "fit-content(10px 20px)"
 
 let test_grid_template_areas () =
   check_grid_template_areas ~expected:"\"nav main\"\". foot\""
@@ -3845,7 +3965,16 @@ let test_opacity () =
     "calc(50% + 25%)";
   decl_optimizes ~prop:"opacity" ~held:"calc(.5*var(--x))"
     ~into:"calc(.5*var(--x))" "calc(50% * var(--x))";
-  neg_cursor read_opacity "invalid-opacity"
+  neg_cursor read_opacity "invalid-opacity";
+  (* CSS Values 4 sec. 11.4 gives [abs()]/[sign()] exactly one [<calc-sum>]
+     argument; [Cursor.call] did not require the reader to consume its whole
+     sub-cursor, so e.g. [abs(.5 .5)] read only the first [.5] and answered
+     [abs(.5)] instead of invalidating the declaration. *)
+  check_opacity "abs(.5)";
+  check_opacity "sign(.5)";
+  check_opacity "abs( .5 )" ~expected:"abs(.5)";
+  neg_cursor read_opacity "abs(.5 .5)";
+  neg_cursor read_opacity "sign(.5 red)"
 
 let test_order () =
   check_order "1";
@@ -3917,6 +4046,7 @@ let spec_property_grammar_edges () =
   check_scroll_snap_type "block proximity";
   check_clip_path "path(\"M 0 0 L 10 10\")";
   check_clip_path "xywh(0 0 100% 100% round 10px)";
+  check_clip_path "rect(0px 0px 10px 10px)";
   check_content "counter(page)";
   check_content "counters(section, \".\")";
   neg_cursor read_font_feature_settings "\"kern\" 2";
@@ -3929,6 +4059,13 @@ let spec_property_grammar_edges () =
     "card / inline-size / size";
   neg_cursor read_scroll_snap_type "mandatory x";
   neg_cursor read_clip_path "xywh(0 0)";
+  (* CSS Shapes 1 sec. 3.1 gives [xywh()]/[rect()] a fixed quad plus an optional
+     [round <'border-radius'>] tail; when that tail is not present,
+     [Cursor.call] did not require the reader to consume its whole sub-cursor,
+     so a trailing token past the quad was silently dropped instead of
+     invalidating the declaration. *)
+  neg_cursor read_clip_path "xywh(0 0 1px 1px foo)";
+  neg_cursor read_clip_path "rect(0px 0px 10px 10px foo)";
   neg_cursor read_content "counter()"
 
 let spec_ui_property_edges () =
@@ -4143,6 +4280,7 @@ let spec_generated_position_interaction_edges () =
   check_nav "#next current";
   check_nav_scope "root";
   check_object_view_box "inset(10px 20px)";
+  check_object_view_box "rect(0px 0px 10px 10px)";
   check_offset_path "ray(45deg sides contain at center)";
   check_offset_rotate "auto 45deg";
   check_offset_rotate_mode "reverse";
@@ -4303,6 +4441,15 @@ let spec_generated_position_interaction_edges () =
   neg_cursor read_nav "next current";
   neg_cursor read_nav_scope "document";
   neg_cursor read_object_view_box "xywh(0 0 1px)";
+  (* CSS Images 5 sec. 4.1 gives [object-view-box]'s [inset()]/[xywh()]/[rect()]
+     a fixed quad (plus an optional [round] tail for the latter two);
+     [Cursor.call] did not require any of the three readers to consume their
+     whole sub-cursor, so trailing content past the quad (or, for [inset()],
+     even a fifth value) was silently dropped instead of invalidating the
+     declaration. *)
+  neg_cursor read_object_view_box "inset(10px 20px 30px 40px 50px)";
+  neg_cursor read_object_view_box "xywh(0 0 1px 1px foo)";
+  neg_cursor read_object_view_box "rect(0px 0px 10px 10px foo)";
   neg_cursor read_offset_path "ray()";
   neg_cursor ~allow_partial:true read_offset_rotate "auto reverse";
   neg_cursor read_offset_rotate_mode "left";
@@ -4539,9 +4686,16 @@ let test_will_change () =
 let test_clip () =
   check_clip "auto";
   check_clip "rect(0px,10px,20px,30px)";
+  check_clip "rect(0px 10px 20px 30px)" ~expected:"rect(0px,10px,20px,30px)";
   decl_optimizes ~prop:"clip" ~held:"rect(0px,10px,20px,30px)"
     ~into:"rect(0px,10px,20px,30px)" "rect(0px,10px,20px,30px)";
-  neg_cursor read_clip "invalid-clip"
+  neg_cursor read_clip "invalid-clip";
+  (* CSS Masking 1 Appendix A gives the deprecated [clip] property's [rect()]
+     exactly four [<top>, <right>, <bottom>, <left>]; a fifth value is invalid
+     (CSS Syntax 3 sec. 8.2). [Cursor.call] did not require the reader to
+     consume its whole sub-cursor, so it stopped after the fourth length and
+     answered with a truncated [rect()] instead. *)
+  neg_cursor read_clip "rect(0px,10px,20px,30px,40px)"
 
 let test_clip_path () =
   check_clip_path "none";

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -2677,6 +2677,13 @@ let spec_selector_pseudo_manifest () =
       ":dir()";
       ":has()";
       ":host-context()";
+      (* CSS Shadow Parts 1 sec. 3.2.3: [:host()] takes one
+         [<compound-selector>]. [Cursor.option] swallows a [Parse_error] from an
+         unparsable argument and restores the sub-cursor, so [Cursor.call] saw
+         it as untouched rather than left with trailing content; a bare digit is
+         not a compound selector, so [:host(1)] silently became [Host None]
+         (prints as bare [:host]) instead of invalidating the whole selector. *)
+      ":host(1)";
       ":lang()";
       ":not()";
       ":nth-child(2n of)";

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -567,7 +567,14 @@ let test_read_var_reference () =
   (* Empty variable name *)
   neg "variable(--color)";
   (* Wrong function name *)
-  neg "var(--)" (* No name after -- *)
+  neg "var(--)";
+  (* No name after -- *)
+  (* CSS Custom Properties for Cascading Variables 1 sec. 3: content after the
+     name without a leading comma is not part of [var()]'s grammar.
+     [Cursor.call] did not require [read_reference] to consume its whole
+     sub-cursor, so [var(--x 10px)] silently dropped [ 10px] instead of
+     invalidating the reference. *)
+  neg "var(--x 10px)"
 
 let spec_custom_fallback_edges () =
   let check_var_ref input expected_name expected_fallback =


### PR DESCRIPTION
`Cursor.call` handed a reader a sub-cursor over a function's arguments but never checked it came back empty, so a reader that stopped early answered with the prefix it understood and dropped the rest: `transform: translateX(10px red)` read as `translateX(10px)` rather than invalidating the declaration (CSS Syntax 3 sec. 8.2). #617 and #627 closed this one reader at a time; the check belongs in `call`, and the `expect_eof` calls they added are removed as redundant.

An audit of all 157 call sites found no reader that wants the tolerance, so no opt-out flag: the two that relied on it by construction (`var()`'s fallback capture in `Values.read_var_body` and `Variables.read_reference`) peeked at the tail instead of consuming it, and now consume it. Stacked on #630.