### PR TITLE
outline: read the width slot as a <line-width>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `outline-width` and the width slot of the `outline` shorthand read a
+  `<length>` where CSS UI 4 sec. 3.2 gives them a `<line-width>`, so
+  `outline: thin solid red` was dropped as invalid (#633)
 - A function reader that could not read all of its arguments answered with
   the ones it had, so `transform: translateX(10px red)` read as
   `translateX(10px)`; the cause behind #617, #627 and #629 (#631)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -5264,7 +5264,7 @@ type outline_style = Properties.outline_style =
   | Var of outline_style var
 
 type outline_shorthand = Properties.outline_shorthand = {
-  width : length option;
+  width : border_width option;
   style : outline_style option;
   color : color option;
 }
@@ -5282,7 +5282,7 @@ type outline = Properties.outline =
   | Var of outline var
 
 val outline_shorthand :
-  ?width:length -> ?style:outline_style -> ?color:color -> unit -> outline
+  ?width:border_width -> ?style:outline_style -> ?color:color -> unit -> outline
 (** [outline_shorthand ?width ?style ?color ()] is the outline shorthand. *)
 
 val border_shorthand :
@@ -5398,7 +5398,7 @@ val outline : outline -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/outline} outline}
     property. *)
 
-val outline_width : length -> declaration
+val outline_width : border_width -> declaration
 (** [outline_width width] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/outline-width}
      outline-width} property. *)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -504,7 +504,7 @@ let property_value_uses_runtime_subst (type a)
   | Border_top_right_radius -> Values.length_has_runtime_subst value
   | Border_bottom_left_radius -> Values.length_has_runtime_subst value
   | Border_bottom_right_radius -> Values.length_has_runtime_subst value
-  | Outline_width -> Values.length_has_runtime_subst value
+  | Outline_width -> Properties.border_width_has_runtime_subst value
   | Margin -> length_list_has_runtime_subst value
   | Padding -> length_list_has_runtime_subst value
   | Inset -> length_list_has_runtime_subst value
@@ -1439,7 +1439,7 @@ let read_position_value_prop : type a.
   | Left -> Some (v Left (read_inset_longhand t))
   | Outline -> Some (v Outline (read_outline t))
   | Outline_style -> Some (v Outline_style (read_outline_style t))
-  | Outline_width -> Some (v Outline_width (read_nn_length_or_global t))
+  | Outline_width -> Some (v Outline_width (read_border_width t))
   | Outline_offset -> Some (v Outline_offset (read_length_or_css_wide t))
   | Forced_color_adjust ->
       Some (v Forced_color_adjust (read_forced_color_adjust t))

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -910,7 +910,7 @@ val outline_style : outline_style -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/outline-style}
      outline-style} property. *)
 
-val outline_width : length -> declaration
+val outline_width : border_width -> declaration
 (** [outline_width v] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/outline-width}
      outline-width} property. *)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1839,6 +1839,23 @@ let normalize_border_width (bw : border_width) : border_width =
   | _ when border_width_is_zero bw -> Zero
   | _ -> bw
 
+(* [<line-width>] and [<length>] share every shape but the three keywords, so
+   read the substitution question in length space; a node that does not map over
+   ([var()], a sibling index) answers as substituting, the safe side for a
+   caller deciding whether the value can be folded into a shorthand. *)
+let border_width_has_runtime_subst (bw : border_width) : bool =
+  let calc c =
+    match length_of_border_width_calc c with
+    | Some lc -> Values.length_has_runtime_subst (Calc lc)
+    | None -> true
+  in
+  match bw with
+  | Var _ -> true
+  | Calc c -> calc c
+  | Min args | Max args -> List.exists calc args
+  | Clamp (lower, value, upper) -> calc lower || calc value || calc upper
+  | _ -> false
+
 let normalize_logical_border_width :
     logical_border_width -> logical_border_width =
  fun value ->

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -283,7 +283,9 @@ let normalize_outline ?(lossless = false) : outline -> outline =
  fun value ->
   match value with
   | Shorthand s ->
-      let width = option_map_preserve Values.normalize_length s.width in
+      let width =
+        option_map_preserve Prop_background.normalize_border_width s.width
+      in
       let color = option_map_preserve (normalize_color ~lossless) s.color in
       if width == s.width && color == s.color then value
       else Shorthand { s with width; color }
@@ -609,7 +611,7 @@ let pp_outline_shorthand : outline_shorthand Pp.t =
   Option.iter
     (fun w ->
       add_space ();
-      pp_length ctx w)
+      Prop_background.pp_border_width ctx w)
     width;
   Option.iter
     (fun s ->
@@ -1187,13 +1189,6 @@ let outline_style_keywords =
     "auto";
   ]
 
-let outline_starts_length t =
-  Option.is_some
-    (Cursor.lookahead
-       (Cursor.option (fun t ->
-            ignore (Cursor.number_with_unit t : float * string option)))
-       t)
-
 let outline_starts_style t =
   List.exists (fun kw -> Cursor.looking_at t kw) outline_style_keywords
 
@@ -1205,17 +1200,27 @@ let read_outline_part ~width ~style ~color t =
     (* A var() is type-ambiguous; assign it to the next unfilled
        width/style/color slot, reading its fallback with that slot's reader. *)
     if Option.is_none !width then
-      width := Some (Var (read_var read_length t) : length)
+      width :=
+        Some (Var (read_var Prop_background.read_border_width t) : border_width)
     else if Option.is_none !style then
       style := Some (Var (read_var read_outline_style t) : outline_style)
     else if Option.is_none !color then color := Some (read_color t)
     else Cursor.err_expected t "outline"
   else if Option.is_none !style && outline_starts_style t then
     style := Some (read_outline_style t)
-  else if Option.is_none !width && outline_starts_length t then
-    width := Some (read_length t)
-  else if Option.is_none !color then color := Some (read_color t)
-  else Cursor.err_expected t "outline"
+  else
+    (* The width slot is a [<line-width>], so it takes the thin/medium/thick
+       keywords and the math functions as well as a length; bind it by trying
+       that reader rather than by guessing from the first token. *)
+    match
+      if Option.is_none !width then
+        Cursor.option Prop_background.read_border_width t
+      else Option.None
+    with
+    | Some w -> width := Some w
+    | Option.None ->
+        if Option.is_none !color then color := Some (read_color t)
+        else Cursor.err_expected t "outline"
 
 let read_outline_parts ~width ~style ~color t =
   let rec loop () =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3629,7 +3629,7 @@ let normalize_property_value : type a.
   | Border_start_end_radius -> Values.normalize_length ~ctx value
   | Border_end_start_radius -> Values.normalize_length ~ctx value
   | Border_end_end_radius -> Values.normalize_length ~ctx value
-  | Outline_width -> Values.normalize_length ~ctx value
+  | Outline_width -> normalize_border_width value
   | Outline_offset -> Values.normalize_length ~ctx value
   | Line_height_step -> Values.normalize_length ~ctx value
   | Perspective -> Values.normalize_length ~ctx value
@@ -4196,7 +4196,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Scale -> pp pp_scale
   | Outline -> pp pp_outline
   | Outline_style -> pp pp_outline_style
-  | Outline_width -> pp pp_length
+  | Outline_width -> pp pp_border_width
   | Outline_color -> pp pp_color
   | Forced_color_adjust -> pp pp_forced_color_adjust
   | Clip -> pp pp_clip
@@ -4420,7 +4420,7 @@ let property_value_kind : type a. a property -> a property_value_kind option =
   | Border_start_end_radius -> Some Length
   | Border_end_start_radius -> Some Length
   | Border_end_end_radius -> Some Length
-  | Outline_width -> Some Length
+  | Outline_width -> Some Border_width
   | Border_top_width -> Some Border_width
   | Border_right_width -> Some Border_width
   | Border_bottom_width -> Some Border_width

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -609,6 +609,10 @@ val pp_border_width : border_width Pp.t
 val read_border_width : Cursor.t -> border_width
 (** [read_border_width t] is the [border_width] parsed from [t]. *)
 
+val border_width_has_runtime_subst : border_width -> bool
+(** [border_width_has_runtime_subst w] is [true] when [w] is a [var()] or
+    reaches one through a math function. *)
+
 val pp_border : border Pp.t
 (** [pp_border] is the pretty-printer for [border]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1789,7 +1789,7 @@ type outline_style =
 
 (* Outline shorthand type *)
 type outline_shorthand = {
-  width : length option;
+  width : border_width option;
   style : outline_style option;
   color : color option;
 }
@@ -4730,7 +4730,7 @@ type 'a property =
   | Z_index : z_index property
   | Outline : outline property
   | Outline_style : outline_style property
-  | Outline_width : length property
+  | Outline_width : border_width property
   | Outline_color : color property
   | Outline_offset : length property
   | Forced_color_adjust : forced_color_adjust property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -1936,7 +1936,8 @@ let outline_part_of : declaration -> outline_part option = function
   | Declaration { property = Outline_color; _ } -> Some Color
   | _ -> None
 
-let outline_width_value : declaration -> Values.length option = function
+let outline_width_value : declaration -> Properties.border_width option =
+  function
   | Declaration { property = Outline_width; value; _ } -> Some value
   | _ -> None
 
@@ -1975,7 +1976,7 @@ let try_compose_outline_at idx i =
         let color = List.find_map outline_color_value triple in
         let no_runtime =
           match width with
-          | Some w -> not (Values.length_has_runtime_subst w)
+          | Some w -> not (Properties.border_width_has_runtime_subst w)
           | None -> true
         in
         if no_runtime then

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1352,7 +1352,7 @@ let vars_of_outline (value : Properties.outline) =
   match value with
   | Var v -> [ V v ]
   | Shorthand { width; style; color } ->
-      Option.value ~default:[] (Option.map vars_of_length width)
+      Option.value ~default:[] (Option.map vars_of_border_width width)
       @ Option.value ~default:[] (Option.map vars_of_outline_style style)
       @ Option.value ~default:[] (Option.map vars_of_color color)
   | _ -> []
@@ -1975,7 +1975,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Border_inline_end_width, value -> vars_of_border_width value
   | Border_block_start_width, value -> vars_of_border_width value
   | Border_block_end_width, value -> vars_of_border_width value
-  | Outline_width, value -> vars_of_length value
+  | Outline_width, value -> vars_of_border_width value
   | Column_gap, value -> vars_of_length value
   | Row_gap, value -> vars_of_length value
   | Gap, Lengths { row_gap; column_gap } ->

--- a/test/cli/outline_line_width.t
+++ b/test/cli/outline_line_width.t
@@ -1,0 +1,26 @@
+CLI: outline keeps a <line-width> keyword or comparison.
+
+CSS Basic User Interface 4 (ED) sec. 3.2 gives outline-width the value
+<line-width> and says it accepts the same values as border-width with the
+same meaning, and sec. 3.1 makes the outline shorthand's width slot
+<'outline-width'>. Reading that slot as a bare <length> made thin/medium/thick
+and min()/max()/clamp() fall through to the colour reader, and CSS Syntax 3
+sec. 8.2 then dropped the whole declaration: valid outlines disappeared from
+the output.
+
+  $ cat > outline.css <<CSS
+  > a { outline: thin solid red; color: blue }
+  > b { outline-width: thick }
+  > c { outline: min(3px) dashed red }
+  > CSS
+  $ cascade --minify outline.css
+  a{outline:thin solid red;color:#00f}b{outline-width:thick}c{outline:3px dashed red}
+
+border and column-rule read the same <line-width> and always kept it.
+
+  $ cat > border.css <<CSS
+  > a { border: thin solid red }
+  > b { column-rule: thin solid red }
+  > CSS
+  $ cascade --minify border.css
+  a{border:thin solid red}b{column-rule:thin solid red}

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3069,7 +3069,7 @@ let shape_outside_sheet () =
 
 (* Every property that reads a [<line-width>]: the four physical longhands and
    their logical counterparts, the 1-4 value shorthand, the two-value logical
-   shorthands, and the width slot of [border]. *)
+   shorthands, and the width slot of [border] and of [outline]. *)
 let line_width_sites value =
   List.map
     (fun property -> String.concat "" [ property; ":"; value ])
@@ -3086,13 +3086,15 @@ let line_width_sites value =
       "border-block-width";
       "border-inline-width";
       "border";
+      "outline-width";
+      "outline";
     ]
 
 (* A [<length>] site reading the same comparison, for contrast. *)
 let length_math_sites value =
   List.map
     (fun property -> String.concat "" [ property; ":"; value ])
-    [ "margin"; "margin-top"; "outline-width"; "width" ]
+    [ "margin"; "margin-top"; "width" ]
 
 (* CSS Values 4 sec. 10.2 gives [min()] / [max()] a comma-separated list of
    [<calc-sum>] and [clamp()] exactly three arguments, and CSS Syntax 3 sec. 8.2

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -818,6 +818,53 @@ let borders () =
   check_declaration ~expected:"border-left-color:yellow"
     ~optimized:"border-left-color:#ff0" "border-left-color: yellow"
 
+(* CSS Basic User Interface 4 (ED) sec. 3.2 gives outline-width the value
+   [<line-width>] and says it "accepts the same values as border-width [...]
+   with the same meaning"; CSS Backgrounds 3 (ED) sec. 3.3 defines
+   [<line-width>] as [thin | medium | thick | <length>]. The width slot of the
+   outline shorthand (sec. 3.1) is [<'outline-width'>], so the keywords and the
+   math functions read there too. *)
+let outline_line_width () =
+  check_declaration ~expected:"outline-width:thin" "outline-width: thin";
+  check_declaration ~expected:"outline-width:medium" "outline-width: medium";
+  check_declaration ~expected:"outline-width:thick" "outline-width: thick";
+  check_declaration ~expected:"outline:thin solid red" "outline: thin solid red";
+  check_declaration ~expected:"outline:medium solid red"
+    "outline: medium solid red";
+  check_declaration ~expected:"outline:thick solid red"
+    "outline: thick solid red";
+  (* CSS Values 4 sec. 10.2: a comparison over same-unit constants denotes one
+     length, so the optimizer reduces it to that length, as at every other
+     [<line-width>]; pp holds the call it was written as. *)
+  check_declaration ~expected:"outline-width:calc(1px + 1px)"
+    ~optimized:"outline-width:2px" "outline-width: calc(1px + 1px)";
+  check_declaration ~expected:"outline-width:min(3px)"
+    ~optimized:"outline-width:3px" "outline-width: min(3px)";
+  check_declaration ~expected:"outline-width:clamp(1px,2px,3px)"
+    ~optimized:"outline-width:2px" "outline-width: clamp(1px,2px,3px)";
+  check_declaration ~expected:"outline:calc(1px + 1px) solid red"
+    ~optimized:"outline:2px solid red" "outline: calc(1px + 1px) solid red";
+  check_declaration ~expected:"outline:min(3px) solid red"
+    ~optimized:"outline:3px solid red" "outline: min(3px) solid red";
+  check_declaration ~expected:"outline:clamp(1px,2px,3px) solid red"
+    ~optimized:"outline:2px solid red" "outline: clamp(1px,2px,3px) solid red";
+  (* No unit relates dvh to px, so the comparison stands as written. *)
+  check_declaration ~roundtrip:true "outline-width:max(3dvh,4px)";
+  (* A [<line-width>] is non-negative. *)
+  neg_cursor read_declaration "outline-width:-1px";
+  (* Controls: a plain length still reads, and the other shorthand slots are
+     untouched. *)
+  check_declaration ~expected:"outline-width:0px" ~optimized:"outline-width:0"
+    "outline-width: 0px";
+  check_declaration ~expected:"outline-width:2px" "outline-width: 2px";
+  check_declaration ~expected:"outline:0px solid red"
+    ~optimized:"outline:0 solid red" "outline: 0px solid red";
+  check_declaration ~expected:"outline:2px solid red" "outline: 2px solid red";
+  check_declaration ~expected:"outline:none" "outline: none";
+  check_declaration ~expected:"outline:auto" "outline: auto";
+  check_declaration ~expected:"outline:red" "outline: red";
+  check_declaration ~expected:"outline:solid red" "outline: solid red"
+
 let logical_border_shorthands () =
   (* css-logical-1 sec. 4.4.1: border-block-start, border-block-end,
      border-inline-start and border-inline-end take <'border-top-width'> ||
@@ -3538,6 +3585,7 @@ let declaration_tests =
     test_case "flexbox flex+basis" `Quick flexbox_flex_and_basis;
     test_case "flexbox alignment" `Quick flexbox_alignment;
     test_case "borders" `Quick borders;
+    test_case "outline line-width" `Quick outline_line_width;
     test_case "logical border shorthands" `Quick logical_border_shorthands;
     test_case "overflow" `Quick overflow;
     test_case "animations (timing)" `Quick animations_timing;

--- a/test/test_rule_index.ml
+++ b/test/test_rule_index.ml
@@ -4,7 +4,7 @@ let red = Declaration.v Properties.Color (Current : Values.color)
 let blue = Declaration.v Properties.Color (Transparent : Values.color)
 
 let solid_outline_width =
-  Declaration.v Properties.Outline_width (Px 1.0 : Values.length)
+  Declaration.v Properties.Outline_width (Px 1.0 : Properties.border_width)
 
 let solid_outline_style =
   Declaration.v Properties.Outline_style (Solid : Properties.outline_style)


### PR DESCRIPTION
`outline-width` and the width slot of the `outline` shorthand read a `<length>` where CSS UI 4 sec. 3.2 gives them a `<line-width>`, so a `thin`, `medium` or `thick` keyword fell through to the colour reader and the whole declaration was dropped: `outline: thin solid red` disappeared from the output. The slot now carries the same `border_width` type `border-width` and `column-rule` already use.
