### PR TITLE
border: fold the initial medium width in the AST, not the printer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -469,11 +469,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
-- `--minify` merges two rules that spell the initial `border` width
-  differently, so `border: medium solid red` and `border: solid red` factor
-  into one rule. `medium` is the value an omitted width slot takes, so the
-  keyword never reached the output; dropping it in the printer rather than in
-  the AST left the two declarations distinct and the rules apart (#NNN)
+- `--minify` drops an explicit `medium` width from the `border`, `column-rule`
+  and `outline` shorthands, the value an omitted width slot already resolves
+  to, and two rules that differ only in that spelling now factor into one
+  (#635)
 - `--minify` folds the width slot of the `border` shorthands and of
   `column-rule`, so `border: 0px solid red` prints as `border:0 solid red`
   and `border: calc(1px + 1px) solid red` as `border:2px solid red`. That

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -469,6 +469,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` merges two rules that spell the initial `border` width
+  differently, so `border: medium solid red` and `border: solid red` factor
+  into one rule. `medium` is the value an omitted width slot takes, so the
+  keyword never reached the output; dropping it in the printer rather than in
+  the AST left the two declarations distinct and the rules apart (#NNN)
 - `--minify` folds the width slot of the `border` shorthands and of
   `column-rule`, so `border: 0px solid red` prints as `border:0 solid red`
   and `border: calc(1px + 1px) solid red` as `border:2px solid red`. That

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -766,15 +766,6 @@ let pp_border_shorthand : border_shorthand Pp.t =
         (None : border_style option)
     | style, _, _ -> style
   in
-  (* CSS Backgrounds 3 sec. 3.3: [<border-width>] defaults to [medium]. When the
-     user spelled it explicitly and another slot is non-default, the keyword is
-     redundant - drop it. *)
-  let width : border_width option =
-    match (width, style, color) with
-    | (Some Medium, Some _, _ | Some Medium, _, Some _) when Pp.minified ctx ->
-        None
-    | width, _, _ -> width
-  in
   Option.iter
     (fun w ->
       add_space ();
@@ -1856,6 +1847,18 @@ let normalize_logical_border_width :
   | Pair (a, b) -> Pair (normalize_border_width a, normalize_border_width b)
   | other -> other
 
+(* CSS Backgrounds 3 (ED) sec. 3.4: a shorthand sets every longhand it covers,
+   so an omitted slot takes its initial value, and sec. 3.3 makes that [medium]
+   for the width. An explicit [medium] therefore declares what leaving the slot
+   out declares, and the shorter spelling wins - as long as some other slot
+   carries the declaration. The sole filled slot stays: emptied, the shorthand
+   has no value left to print. *)
+let drop_initial_line_width ~others_filled (width : border_width option) :
+    border_width option =
+  match width with
+  | Some Medium when others_filled -> Option.None
+  | width -> width
+
 (* The width slot of the border shorthands is a [<'border-width'>], so it takes
    the same fold as the longhand; the colour slot is a [<color>]. *)
 let normalize_border ?(lossless = false) : border -> border =
@@ -1864,6 +1867,8 @@ let normalize_border ?(lossless = false) : border -> border =
   | Shorthand s ->
       let width = option_map_preserve normalize_border_width s.width in
       let color = option_map_preserve (normalize_color ~lossless) s.color in
+      let others_filled = Option.is_some s.style || Option.is_some color in
+      let width = drop_initial_line_width ~others_filled width in
       if width == s.width && color == s.color then value
       else Shorthand { s with width; color }
   | other -> other

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -279,6 +279,14 @@ let rec read_nav t : nav =
           Target (target, scope))
     t
 
+(* CSS UI 4 (ED) sec. 3.2 gives outline-width the values and meaning of
+   border-width, so the width slot takes the longhand's fold, and its initial
+   value is [medium]. sec. 3.1 makes the outline shorthand set all three
+   longhands, and CSS Cascade 5 (ED) sec. 3 assigns an omitted sub-property its
+   initial value, so an explicit [medium] beside another slot is the longer
+   spelling of the same declaration - the [auto] case included, since a lone
+   [auto] and an [auto] beside a width both set outline-style and outline-color
+   to [auto]. *)
 let normalize_outline ?(lossless = false) : outline -> outline =
  fun value ->
   match value with
@@ -287,6 +295,10 @@ let normalize_outline ?(lossless = false) : outline -> outline =
         option_map_preserve Prop_background.normalize_border_width s.width
       in
       let color = option_map_preserve (normalize_color ~lossless) s.color in
+      let others_filled = Option.is_some s.style || Option.is_some color in
+      let width =
+        Prop_background.drop_initial_line_width ~others_filled width
+      in
       if width == s.width && color == s.color then value
       else Shorthand { s with width; color }
   | other -> other

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -916,6 +916,24 @@ let border_line_width () =
     ~optimized:"border:thin solid red" "border: thin solid red";
   check_declaration ~expected:"border:thick solid red"
     ~optimized:"border:thick solid red" "border: thick solid red";
+  (* [medium] is the initial [<line-width>], and sec. 3.4 sets an omitted
+     shorthand slot to its initial value, so an explicit [medium] beside another
+     slot is what omitting it already means: the optimizer drops it, pp holds
+     the node. A lone [medium] fills the only slot the shorthand has, so it
+     stays. *)
+  check_declaration ~expected:"border:medium solid red"
+    ~optimized:"border:solid red" "border: medium solid red";
+  check_declaration ~expected:"border-top:medium dashed blue"
+    ~optimized:"border-top:dashed#00f" "border-top: medium dashed blue";
+  check_declaration ~expected:"column-rule:medium solid red"
+    ~optimized:"column-rule:solid red" "column-rule: medium solid red";
+  check_declaration ~expected:"border-inline-start:medium dotted red"
+    ~optimized:"border-inline-start:dotted red"
+    "border-inline-start: medium dotted red";
+  check_declaration ~expected:"border:medium red" ~optimized:"border:red"
+    "border: medium red";
+  check_declaration ~expected:"border:medium" ~optimized:"border:medium"
+    "border: medium";
   (* Controls: a plain length stands, and a shorthand that fills no width slot
      is untouched. *)
   check_declaration ~expected:"border:1px solid red"

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -829,8 +829,25 @@ let outline_line_width () =
   check_declaration ~expected:"outline-width:medium" "outline-width: medium";
   check_declaration ~expected:"outline-width:thick" "outline-width: thick";
   check_declaration ~expected:"outline:thin solid red" "outline: thin solid red";
+  (* CSS UI 4 (ED) sec. 3.1: the outline shorthand sets all three longhands, and
+     CSS Cascade 5 (ED) sec. 3 assigns an omitted sub-property its initial
+     value, which sec. 3.2 gives as [medium]. Spelling [medium] beside another
+     slot says what leaving the slot out already says, so the optimizer drops it
+     and pp prints the node it was handed. A lone [medium] fills the only slot
+     there is, and the shorthand needs one, so it stays. *)
   check_declaration ~expected:"outline:medium solid red"
-    "outline: medium solid red";
+    ~optimized:"outline:solid red" "outline: medium solid red";
+  check_declaration ~expected:"outline:medium dashed"
+    ~optimized:"outline:dashed" "outline: medium dashed";
+  check_declaration ~expected:"outline:medium red" ~optimized:"outline:red"
+    "outline: medium red";
+  (* sec. 3.1: a lone [auto], and an [auto] beside a width but no explicit style
+     or colour, both set outline-style and outline-color to [auto], so the two
+     spellings are the same declaration here too. *)
+  check_declaration ~expected:"outline:medium auto" ~optimized:"outline:auto"
+    "outline: medium auto";
+  check_declaration ~expected:"outline:medium" ~optimized:"outline:medium"
+    "outline: medium";
   check_declaration ~expected:"outline:thick solid red"
     "outline: thick solid red";
   (* CSS Values 4 sec. 10.2: a comparison over same-unit constants denotes one

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -99,15 +99,20 @@ let test_factoring_stable_under_unrelated_grouping () =
     (optimize_str grouped)
 
 (* Two rules that declare the same thing must factor together, whatever spelling
-   the author used. CSS Backgrounds 3 (ED) sec. 3.4 makes every slot of the
-   border shorthands optional and sets an omitted one to its initial value,
-   which for the width slot is [medium] (sec. 3.3). An explicit [medium] and an
-   absent width are therefore the same declaration, and factoring compares
-   nodes, so the drop has to have happened before the two rules meet. *)
+   the author used. CSS Backgrounds 3 (ED) sec. 3.4 and CSS UI 4 (ED) sec. 3.1
+   make every slot of these shorthands optional, and an omitted one takes its
+   initial value (CSS Cascade 5 (ED) sec. 3), which for the width slot is
+   [medium] (CSS Backgrounds 3 sec. 3.3, CSS UI 4 sec. 3.2). An explicit
+   [medium] and an absent width are therefore the same declaration, and
+   factoring compares nodes, so the drop has to have happened before the two
+   rules meet. *)
 let test_initial_line_width_spellings_factor () =
   Alcotest.(check string)
     "border medium factors with the omitted width" ".a,.b{border:solid red}"
-    (optimize_str ".a{border:medium solid red}.b{border:solid red}")
+    (optimize_str ".a{border:medium solid red}.b{border:solid red}");
+  Alcotest.(check string)
+    "outline medium factors with the omitted width" ".a,.b{outline:solid red}"
+    (optimize_str ".a{outline:medium solid red}.b{outline:solid red}")
 
 let suite =
   ( "factor",

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -98,6 +98,17 @@ let test_factoring_stable_under_unrelated_grouping () =
     "unrelated grouping does not change factoring" (optimize_str separate)
     (optimize_str grouped)
 
+(* Two rules that declare the same thing must factor together, whatever spelling
+   the author used. CSS Backgrounds 3 (ED) sec. 3.4 makes every slot of the
+   border shorthands optional and sets an omitted one to its initial value,
+   which for the width slot is [medium] (sec. 3.3). An explicit [medium] and an
+   absent width are therefore the same declaration, and factoring compares
+   nodes, so the drop has to have happened before the two rules meet. *)
+let test_initial_line_width_spellings_factor () =
+  Alcotest.(check string)
+    "border medium factors with the omitted width" ".a,.b{border:solid red}"
+    (optimize_str ".a{border:medium solid red}.b{border:solid red}")
+
 let suite =
   ( "factor",
     [
@@ -109,4 +120,6 @@ let suite =
         test_split_shorthand_confluence;
       Alcotest.test_case "factoring stable under unrelated grouping" `Quick
         test_factoring_stable_under_unrelated_grouping;
+      Alcotest.test_case "initial line-width spellings factor together" `Quick
+        test_initial_line_width_spellings_factor;
     ] )


### PR DESCRIPTION
`border: medium solid red` and `border: solid red` are the same declaration, since an omitted width slot resolves to `medium`, but the keyword was dropped in the printer rather than in the AST, so the two spellings reached factoring as different nodes and the rules stayed apart. `outline` did not drop the keyword at all; README's `--minify` policy asks for the shortest valid spelling, and the width slot there is the same production with the same initial value.

Sibling of #634, which gave the same slot its length and comparison folds.
