### PR TITLE
border: fold the initial none style in the AST, not the printer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -469,10 +469,12 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
-- `--minify` drops an explicit `medium` width from the `border`, `column-rule`
-  and `outline` shorthands, the value an omitted width slot already resolves
-  to, and two rules that differ only in that spelling now factor into one
-  (#635)
+- `--minify` drops an explicit initial value from a slot of the `border`,
+  `column-rule` and `outline` shorthands: the `medium` width and the `none`
+  style an omitted slot already resolves to. A shorthand with no slot left
+  declares what `none` declares, so `border: medium none` and `border: none`
+  now factor into one rule, as do `border: none red` and `border: red`
+  (#635, #636)
 - `--minify` folds the width slot of the `border` shorthands and of
   `column-rule`, so `border: 0px solid red` prints as `border:0 solid red`
   and `border: calc(1px + 1px) solid red` as `border:2px solid red`. That

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -760,12 +760,6 @@ let pp_border_shorthand : border_shorthand Pp.t =
     | Some Current when Pp.minified ctx -> (None : color option)
     | color -> color
   in
-  let style =
-    match (style, width, color) with
-    | Some (None : border_style), None, Some _ when Pp.minified ctx ->
-        (None : border_style option)
-    | style, _, _ -> style
-  in
   Option.iter
     (fun w ->
       add_space ();
@@ -1848,29 +1842,38 @@ let normalize_logical_border_width :
   | other -> other
 
 (* CSS Backgrounds 3 (ED) sec. 3.4: a shorthand sets every longhand it covers,
-   so an omitted slot takes its initial value, and sec. 3.3 makes that [medium]
-   for the width. An explicit [medium] therefore declares what leaving the slot
-   out declares, and the shorter spelling wins - as long as some other slot
-   carries the declaration. The sole filled slot stays: emptied, the shorthand
-   has no value left to print. *)
-let drop_initial_line_width ~others_filled (width : border_width option) :
-    border_width option =
-  match width with
-  | Some Medium when others_filled -> Option.None
-  | width -> width
+   so an omitted slot takes its initial value - sec. 3.3 makes that [medium] for
+   the width, sec. 3.2 [none] for the style. An explicit initial value therefore
+   declares what leaving the slot out declares, and the shorter spelling
+   wins. *)
+let drop_initial_line_width (width : border_width option) : border_width option
+    =
+  match width with Some Medium -> Option.None | width -> width
+
+let drop_initial_line_style (style : border_style option) : border_style option
+    =
+  match style with Some (None : border_style) -> Option.None | style -> style
 
 (* The width slot of the border shorthands is a [<'border-width'>], so it takes
-   the same fold as the longhand; the colour slot is a [<color>]. *)
+   the same fold as the longhand; the style slot is a [<line-style>] and the
+   colour slot a [<color>]. Drained of every slot the shorthand declares nothing
+   but initial values, which is what [none] declares, and [none] is the node the
+   keyword parses to - so the two spellings meet there. *)
 let normalize_border ?(lossless = false) : border -> border =
  fun value ->
   match value with
   | Shorthand s ->
-      let width = option_map_preserve normalize_border_width s.width in
+      let width =
+        drop_initial_line_width
+          (option_map_preserve normalize_border_width s.width)
+      in
+      let style = drop_initial_line_style s.style in
       let color = option_map_preserve (normalize_color ~lossless) s.color in
-      let others_filled = Option.is_some s.style || Option.is_some color in
-      let width = drop_initial_line_width ~others_filled width in
-      if width == s.width && color == s.color then value
-      else Shorthand { s with width; color }
+      if width == s.width && style == s.style && color == s.color then value
+      else if
+        Option.is_none width && Option.is_none style && Option.is_none color
+      then (None : border)
+      else Shorthand { width; style; color }
   | other -> other
 
 let read_border_image_repeat_keyword t : border_image_repeat_keyword =

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -279,28 +279,35 @@ let rec read_nav t : nav =
           Target (target, scope))
     t
 
+(* CSS UI 4 (ED) sec. 3.3 gives outline-style the initial value [none]. *)
+let drop_initial_outline_style (style : outline_style option) :
+    outline_style option =
+  match style with Some (None : outline_style) -> Option.None | style -> style
+
 (* CSS UI 4 (ED) sec. 3.2 gives outline-width the values and meaning of
-   border-width, so the width slot takes the longhand's fold, and its initial
-   value is [medium]. sec. 3.1 makes the outline shorthand set all three
-   longhands, and CSS Cascade 5 (ED) sec. 3 assigns an omitted sub-property its
-   initial value, so an explicit [medium] beside another slot is the longer
-   spelling of the same declaration - the [auto] case included, since a lone
-   [auto] and an [auto] beside a width both set outline-style and outline-color
-   to [auto]. *)
+   border-width, so the width slot takes the longhand's fold and its initial
+   [medium] drops the same way. sec. 3.1 makes the outline shorthand set all
+   three longhands, and CSS Cascade 5 (ED) sec. 3 assigns an omitted
+   sub-property its initial value, so a shorthand left with no slot at all
+   declares what [outline: none] declares - the node the keyword parses to, so
+   the two spellings meet there. [auto] is not the initial style and stays: a
+   lone [auto] and an [auto] beside a width both set outline-style and
+   outline-color to [auto]. *)
 let normalize_outline ?(lossless = false) : outline -> outline =
  fun value ->
   match value with
   | Shorthand s ->
       let width =
-        option_map_preserve Prop_background.normalize_border_width s.width
+        Prop_background.drop_initial_line_width
+          (option_map_preserve Prop_background.normalize_border_width s.width)
       in
+      let style = drop_initial_outline_style s.style in
       let color = option_map_preserve (normalize_color ~lossless) s.color in
-      let others_filled = Option.is_some s.style || Option.is_some color in
-      let width =
-        Prop_background.drop_initial_line_width ~others_filled width
-      in
-      if width == s.width && color == s.color then value
-      else Shorthand { s with width; color }
+      if width == s.width && style == s.style && color == s.color then value
+      else if
+        Option.is_none width && Option.is_none style && Option.is_none color
+      then (None : outline)
+      else Shorthand { width; style; color }
   | other -> other
 
 let normalize_caret ?(lossless = false) : caret -> caret =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -959,6 +959,52 @@ let border_line_width () =
     "border: solid red";
   check_declaration ~expected:"border:red" ~optimized:"border:red" "border: red"
 
+(* CSS Backgrounds 3 (ED) sec. 3.2 gives the border-style properties the initial
+   value [none], and sec. 3.4 sets an omitted shorthand slot to its initial
+   value, so an explicit [none] beside another slot says what leaving the slot
+   out already says: the optimizer drops it, pp holds the node it was handed.
+   Drained of every slot the shorthand declares nothing but initial values,
+   which is what the [none] keyword declares, so that is the node it folds to -
+   and the node [border: none] parses to directly, which is how the two
+   spellings reach factoring as one. CSS UI 4 (ED) sec. 3.3 gives outline-style
+   the same initial value and sec. 3.1 the same shorthand rule. *)
+let border_line_style () =
+  check_declaration ~expected:"border:medium none" ~optimized:"border:none"
+    "border: medium none";
+  check_declaration ~expected:"outline:medium none" ~optimized:"outline:none"
+    "outline: medium none";
+  check_declaration ~expected:"border:none red" ~optimized:"border:red"
+    "border: none red";
+  check_declaration ~expected:"outline:none red" ~optimized:"outline:red"
+    "outline: none red";
+  (* The keyword itself is already that node, and must keep printing, not empty
+     out. *)
+  check_declaration ~expected:"border:none" ~optimized:"border:none"
+    "border: none";
+  check_declaration ~expected:"outline:none" ~optimized:"outline:none"
+    "outline: none";
+  (* The other shorthands reading the same production. *)
+  check_declaration ~expected:"border-top:medium none"
+    ~optimized:"border-top:none" "border-top: medium none";
+  check_declaration ~expected:"border-inline:medium none"
+    ~optimized:"border-inline:none" "border-inline: medium none";
+  check_declaration ~expected:"border-block-start:medium none"
+    ~optimized:"border-block-start:none" "border-block-start: medium none";
+  check_declaration ~expected:"column-rule:medium none"
+    ~optimized:"column-rule:none" "column-rule: medium none";
+  (* Controls: a style that is not the initial one stands, a zero width is not
+     the initial width, and [auto] is outline-style's own value, not [none]. *)
+  check_declaration ~expected:"border:1px solid red"
+    ~optimized:"border:1px solid red" "border: 1px solid red";
+  check_declaration ~expected:"border:solid red" ~optimized:"border:solid red"
+    "border: solid red";
+  check_declaration ~expected:"border:0 none" ~optimized:"border:0"
+    "border: 0 none";
+  check_declaration ~expected:"border:0" ~optimized:"border:0" "border: 0";
+  check_declaration ~expected:"outline:0" ~optimized:"outline:0" "outline: 0";
+  check_declaration ~expected:"outline:auto" ~optimized:"outline:auto"
+    "outline: auto"
+
 let logical_border_shorthands () =
   (* css-logical-1 sec. 4.4.1: border-block-start, border-block-end,
      border-inline-start and border-inline-end take <'border-top-width'> ||
@@ -3683,6 +3729,7 @@ let declaration_tests =
     test_case "borders" `Quick borders;
     test_case "outline line-width" `Quick outline_line_width;
     test_case "border line-width" `Quick border_line_width;
+    test_case "border line-style" `Quick border_line_style;
     test_case "logical border shorthands" `Quick logical_border_shorthands;
     test_case "overflow" `Quick overflow;
     test_case "animations (timing)" `Quick animations_timing;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -833,8 +833,9 @@ let outline_line_width () =
      CSS Cascade 5 (ED) sec. 3 assigns an omitted sub-property its initial
      value, which sec. 3.2 gives as [medium]. Spelling [medium] beside another
      slot says what leaving the slot out already says, so the optimizer drops it
-     and pp prints the node it was handed. A lone [medium] fills the only slot
-     there is, and the shorthand needs one, so it stays. *)
+     and pp prints the node it was handed. A lone [medium] leaves the shorthand
+     declaring nothing but initial values, which is what [outline: none]
+     declares. *)
   check_declaration ~expected:"outline:medium solid red"
     ~optimized:"outline:solid red" "outline: medium solid red";
   check_declaration ~expected:"outline:medium dashed"
@@ -846,7 +847,7 @@ let outline_line_width () =
      spellings are the same declaration here too. *)
   check_declaration ~expected:"outline:medium auto" ~optimized:"outline:auto"
     "outline: medium auto";
-  check_declaration ~expected:"outline:medium" ~optimized:"outline:medium"
+  check_declaration ~expected:"outline:medium" ~optimized:"outline:none"
     "outline: medium";
   check_declaration ~expected:"outline:thick solid red"
     "outline: thick solid red";
@@ -936,8 +937,8 @@ let border_line_width () =
   (* [medium] is the initial [<line-width>], and sec. 3.4 sets an omitted
      shorthand slot to its initial value, so an explicit [medium] beside another
      slot is what omitting it already means: the optimizer drops it, pp holds
-     the node. A lone [medium] fills the only slot the shorthand has, so it
-     stays. *)
+     the node. A lone [medium] leaves the shorthand declaring nothing but
+     initial values, which is what [border: none] declares. *)
   check_declaration ~expected:"border:medium solid red"
     ~optimized:"border:solid red" "border: medium solid red";
   check_declaration ~expected:"border-top:medium dashed blue"
@@ -949,7 +950,7 @@ let border_line_width () =
     "border-inline-start: medium dotted red";
   check_declaration ~expected:"border:medium red" ~optimized:"border:red"
     "border: medium red";
-  check_declaration ~expected:"border:medium" ~optimized:"border:medium"
+  check_declaration ~expected:"border:medium" ~optimized:"border:none"
     "border: medium";
   (* Controls: a plain length stands, and a shorthand that fills no width slot
      is untouched. *)

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -114,6 +114,44 @@ let test_initial_line_width_spellings_factor () =
     "outline medium factors with the omitted width" ".a,.b{outline:solid red}"
     (optimize_str ".a{outline:medium solid red}.b{outline:solid red}")
 
+(* The same argument one slot over. CSS Backgrounds 3 (ED) sec. 3.2 gives the
+   border-style properties the initial value [none], and CSS UI 4 (ED) sec. 3.3
+   gives outline-style the same one, so an explicit [none] and an absent style
+   are one declaration. A shorthand left holding nothing but initial values is
+   the [none] keyword, which is the other spelling these pairs meet on. *)
+let test_initial_line_style_spellings_factor () =
+  Alcotest.(check string)
+    "border medium none factors with the none keyword" ".a,.b{border:none}"
+    (optimize_str ".a{border:medium none}.b{border:none}");
+  Alcotest.(check string)
+    "outline medium none factors with the none keyword" ".c,.d{outline:none}"
+    (optimize_str ".c{outline:medium none}.d{outline:none}");
+  Alcotest.(check string)
+    "border none red factors with the omitted style" ".a,.b{border:red}"
+    (optimize_str ".a{border:none red}.b{border:red}");
+  Alcotest.(check string)
+    "outline none red factors with the omitted style" ".c,.d{outline:red}"
+    (optimize_str ".c{outline:none red}.d{outline:red}");
+  (* css-logical-1 sec. 4.4 and CSS Multi-column 1 (ED) sec. 4.5 route the other
+     border-family shorthands through the same production. *)
+  Alcotest.(check string)
+    "border-top medium none factors with the none keyword"
+    ".a,.b{border-top:none}"
+    (optimize_str ".a{border-top:medium none}.b{border-top:none}");
+  Alcotest.(check string)
+    "border-inline medium none factors with the none keyword"
+    ".a,.b{border-inline:none}"
+    (optimize_str ".a{border-inline:medium none}.b{border-inline:none}");
+  Alcotest.(check string)
+    "border-block-start medium none factors with the none keyword"
+    ".a,.b{border-block-start:none}"
+    (optimize_str
+       ".a{border-block-start:medium none}.b{border-block-start:none}");
+  Alcotest.(check string)
+    "column-rule medium none factors with the none keyword"
+    ".a,.b{column-rule:none}"
+    (optimize_str ".a{column-rule:medium none}.b{column-rule:none}")
+
 let suite =
   ( "factor",
     [
@@ -127,4 +165,6 @@ let suite =
         test_factoring_stable_under_unrelated_grouping;
       Alcotest.test_case "initial line-width spellings factor together" `Quick
         test_initial_line_width_spellings_factor;
+      Alcotest.test_case "initial line-style spellings factor together" `Quick
+        test_initial_line_style_spellings_factor;
     ] )


### PR DESCRIPTION
Follow-up to #635, one slot over: the printer was dropping an explicit `none` style that the AST kept, so two rules declaring the same border still reached factoring as different nodes. A shorthand left with no slot now folds to the `none` keyword, which is what lets the width drop give up its lone-slot guard.
