### PR TITLE
display: fold the keyword spellings in the AST, not the printer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -469,12 +469,15 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
-- `--minify` drops an explicit initial value from a slot of the `border`,
-  `column-rule` and `outline` shorthands: the `medium` width and the `none`
-  style an omitted slot already resolves to. A shorthand with no slot left
-  declares what `none` declares, so `border: medium none` and `border: none`
-  now factor into one rule, as do `border: none red` and `border: red`
-  (#635, #636)
+- `--minify` folds a value's spelling before two rules are compared, so rules
+  that wrote one declaration two ways factor into one: an explicit initial
+  `medium` width or `none` style in the `border`, `column-rule` and `outline`
+  shorthands, `font-weight: bold` beside `700`, a two-value `display` beside
+  its legacy keyword, and `overflow: auto auto` beside `auto`
+  (#635, #636, #637)
+- `--minify` keeps `display: block ruby`. It printed `ruby`, which CSS Display
+  3 reads as `inline ruby`, so a block-level ruby container came back
+  inline-level (#637)
 - `--minify` folds the width slot of the `border` shorthands and of
   `column-rule`, so `border: 0px solid red` prints as `border:0 solid red`
   and `border: calc(1px + 1px) solid red` as `border:2px solid red`. That

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -110,6 +110,37 @@ let factor_rules_incremental ?cache ~ctx rules =
    selector so a list bound is de-duplicated and ordered consistently. *)
 let canonicalize_scope_selector sel = Selector.canonicalize sel
 
+(* CSS Fonts 4 (ED) sec. 4.4 gives the [font-weight] descriptor the values of
+   the property of the same name, so the descriptor takes the property's fold. A
+   descriptor is not a declaration and never reaches factoring, but the fold is
+   still a node question, so it belongs here and not in the serializer. *)
+let normalize_font_face_descriptor (desc : font_face_descriptor) :
+    font_face_descriptor =
+  let weight w = Properties.normalize_property_value Properties.Font_weight w in
+  match desc with
+  | Font_weight value ->
+      let value' = weight value in
+      if value' == value then desc else Font_weight value'
+  | Font_weight_range (low, high) ->
+      let low' = weight low in
+      let high' = weight high in
+      if low' == low && high' == high then desc
+      else Font_weight_range (low', high')
+  | Font_family _ | Src _ | Font_style _ | Font_style_range _ | Font_stretch _
+  | Font_stretch_range _ | Font_display _ | Unicode_range _ | Font_variant _
+  | Font_feature_settings _ | Font_variation_settings _ | Font_tech _
+  | Size_adjust _ | Ascent_override _ | Descent_override _ | Line_gap_override _
+    ->
+      desc
+
+(* [stmt] is returned unchanged when no descriptor moved: the factoring fixpoint
+   reads a no-op off physical identity. *)
+let normalize_font_face stmt descriptors =
+  let descriptors' =
+    list_map_preserve normalize_font_face_descriptor descriptors
+  in
+  if descriptors' == descriptors then stmt else Font_face descriptors'
+
 (* Nested rule selectors are implicitly relative to the parent [&], so drop a
    redundant leading [& <combinator>] (CSS Nesting 1 sec. 3). *)
 let drop_nesting_prefix (stmt : statement) : statement =
@@ -249,14 +280,18 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
   | (Declarations decls as stmt) :: rest ->
       process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~owner
         ~supports acc stmt decls rest
+  | (Font_face descriptors as stmt) :: rest ->
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        (normalize_font_face stmt descriptors :: acc)
+        rest
   (* Listed rather than closed with a wildcard: everything left holds no block,
      so a statement that grows one has to be classified above before it
      compiles. *)
   | (( Property _ | Bang_comment _ | Charset _ | Namespace _ | Layer_decl _
      | Supports_condition _ | Keyframes _ | Webkit_keyframes _ | Moz_keyframes _
-     | Font_face _ | Counter_style _ | Page _ | Page_with_margins _
-     | Font_palette_values _ | Font_feature_values _ | View_transition _
-     | Position_try _ | Viewport _ | Unknown_at_rule _ ) as hd)
+     | Counter_style _ | Page _ | Page_with_margins _ | Font_palette_values _
+     | Font_feature_values _ | View_transition _ | Position_try _ | Viewport _
+     | Unknown_at_rule _ ) as hd)
     :: rest ->
       process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
         (hd :: acc) rest

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -299,8 +299,8 @@ let rec pp_display : display Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_display ctx v
-  | Multi (Multi (Block, Block), List_item) when Pp.minified ctx ->
-      Pp.string ctx "list-item"
+  (* CSS Display 3 (ED) sec. 2.3: a [list-item] written with no inside display
+     type takes [flow], so leaving the [flow] out names the same value. *)
   | Multi (Multi (outside, Block), List_item) when Pp.minified ctx ->
       pp_display ctx outside;
       Pp.space ctx ();
@@ -311,25 +311,6 @@ let rec pp_display : display Pp.t =
       pp_display_inside ctx inside;
       Pp.space ctx ();
       Pp.string ctx "list-item"
-  (* CSS Display 3 sec. 2: [<display-outside> <display-inside>] with
-     [<display-inside>] = [flow] (encoded as the inner [Block] arm here)
-     collapses to just the outside keyword - [block flow] -> [block], [inline
-     flow] -> [inline]. *)
-  | Multi (Block, Block) when Pp.minified ctx -> Pp.string ctx "block"
-  | Multi (Inline, Block) when Pp.minified ctx -> Pp.string ctx "inline"
-  | Multi (Run_in, Block) when Pp.minified ctx -> Pp.string ctx "run-in"
-  | Multi (Block, Flow_root) when Pp.minified ctx -> Pp.string ctx "flow-root"
-  | Multi (Inline, Flow_root) when Pp.minified ctx ->
-      (* CSS Display 3 sec. 2.6: [inline flow-root] is the two-value equivalent
-         of the legacy [inline-block] keyword. *)
-      Pp.string ctx "inline-block"
-  | Multi (Block, Flex) when Pp.minified ctx -> Pp.string ctx "flex"
-  | Multi (Inline, Flex) when Pp.minified ctx -> Pp.string ctx "inline-flex"
-  | Multi (Block, Grid) when Pp.minified ctx -> Pp.string ctx "grid"
-  | Multi (Inline, Grid) when Pp.minified ctx -> Pp.string ctx "inline-grid"
-  | Multi (Block, Table) when Pp.minified ctx -> Pp.string ctx "table"
-  | Multi (Inline, Table) when Pp.minified ctx -> Pp.string ctx "inline-table"
-  | Multi (Block, Ruby) when Pp.minified ctx -> Pp.string ctx "ruby"
   | Multi (outside, inside) ->
       pp_display ctx outside;
       Pp.space ctx ();
@@ -339,6 +320,30 @@ and pp_display_inside ctx = function
   | Block -> Pp.string ctx "flow"
   | Flow_root -> Pp.string ctx "flow-root"
   | display -> pp_display ctx display
+
+(* CSS Display 3 (ED) sec. 2.1: a [<display-outside>] written without an inside
+   defaults the inner type to [flow]; sec. 2.2: an inside written alone defaults
+   the outer type to [block], "except for ruby, which defaults to inline"; sec.
+   2.3: a [list-item] with neither slot filled is [block flow list-item]; sec.
+   2.6 names the four precomposed inline-level keywords. Each pair below is one
+   value under two spellings, and the single keyword is the shorter one. That
+   ruby exception is why [block ruby] has no entry: the bare [ruby] keyword
+   names [inline ruby], so the two are different values. *)
+let normalize_display : display -> display = function
+  | Multi (Multi (Block, Block), List_item) -> List_item
+  | Multi (Block, Block) -> Block
+  | Multi (Inline, Block) -> Inline
+  | Multi (Run_in, Block) -> Run_in
+  | Multi (Block, Flow_root) -> Flow_root
+  | Multi (Inline, Flow_root) -> Inline_block
+  | Multi (Block, Flex) -> Flex
+  | Multi (Inline, Flex) -> Inline_flex
+  | Multi (Block, Grid) -> Grid
+  | Multi (Inline, Grid) -> Inline_grid
+  | Multi (Block, Table) -> Table
+  | Multi (Inline, Table) -> Inline_table
+  | Multi (Inline, Ruby) -> Ruby
+  | value -> value
 
 let rec pp_position : position Pp.t =
  fun ctx -> function
@@ -521,12 +526,18 @@ let rec pp_overflow : overflow Pp.t =
   | Unset -> Pp.string ctx "unset"
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
-  | Overflow_pair (x, y) when Pp.minified ctx && equal_overflow x y ->
-      pp_overflow ctx x
   | Overflow_pair (x, y) ->
       pp_overflow ctx x;
       Pp.space ctx ();
       pp_overflow ctx y
+
+(* CSS Overflow 3 (ED) sec. 3.1: [overflow] is [<'overflow-block'>{1,2}] and
+   "sets the specified values of overflow-x and overflow-y in that order. If the
+   second value is omitted, it is copied from the first." Repeating an axis
+   therefore says what the single value says. *)
+let normalize_overflow : overflow -> overflow = function
+  | Overflow_pair (x, y) when equal_overflow x y -> x
+  | value -> value
 
 let pp_overflow_clip_box : overflow_clip_box Pp.t =
  fun ctx -> function

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1204,13 +1204,7 @@ let rec pp_line_height : line_height Pp.t =
 let rec pp_font_weight : font_weight Pp.t =
  fun ctx -> function
   | Weight n -> Pp.int ctx n
-  | Normal when Pp.minified ctx ->
-      (* CSS Fonts 4 5.1.2: [normal] is spec-equivalent to [400]. *)
-      Pp.string ctx "400"
   | Normal -> Pp.string ctx "normal"
-  | Bold when Pp.minified ctx ->
-      (* CSS Fonts 4 5.1.2: [bold] is spec-equivalent to [700]. *)
-      Pp.string ctx "700"
   | Bold -> Pp.string ctx "bold"
   | Bolder -> Pp.string ctx "bolder"
   | Lighter -> Pp.string ctx "lighter"
@@ -1990,6 +1984,24 @@ let normalize_line_height (lh : line_height) : line_height =
       | Values.Val v -> v
       | folded -> Calc folded)
   | _ -> lh
+
+(* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as
+   "Same as 700", so each keyword and its number name one weight and the number
+   is the shorter spelling. *)
+let normalize_font_weight : font_weight -> font_weight = function
+  | Normal -> Weight 400
+  | Bold -> Weight 700
+  | value -> value
+
+(* sec. 2.7 gives the [font] shorthand a [<'font-weight'>] slot, so the slot
+   takes the longhand's fold. *)
+let normalize_font : font -> font =
+ fun value ->
+  match value with
+  | Shorthand s ->
+      let weight = option_map_preserve normalize_font_weight s.weight in
+      if weight == s.weight then value else Shorthand { s with weight }
+  | other -> other
 
 let rec read_font_variant_emoji t : font_variant_emoji =
   Cursor.enum_or_var "font-variant-emoji"

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3603,6 +3603,8 @@ let normalize_property_value : type a.
   | Font_size -> normalize_font_size value
   | Font_weight -> normalize_font_weight value
   | Font -> normalize_font value
+  | Display -> normalize_display value
+  | Overflow -> normalize_overflow value
   | Padding_left -> Values.normalize_length ~ctx value
   | Padding_right -> Values.normalize_length ~ctx value
   | Padding_bottom -> Values.normalize_length ~ctx value

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3601,6 +3601,8 @@ let normalize_property_value : type a.
   | Aspect_ratio -> normalize_aspect_ratio value
   | Gap -> normalize_gap value
   | Font_size -> normalize_font_size value
+  | Font_weight -> normalize_font_weight value
+  | Font -> normalize_font value
   | Padding_left -> Values.normalize_length ~ctx value
   | Padding_right -> Values.normalize_length ~ctx value
   | Padding_bottom -> Values.normalize_length ~ctx value

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -4263,8 +4263,13 @@ let drop_longhands_after_covering_shorthand props =
     &&
     match implied_longhand arr.(j) li with
     | Some implied ->
+        (* [implied] is built here from the shorthand's slots and the initials
+           it resets the rest to, so it has not been through the normalisation
+           every declaration in [props] already carries. Canonicalise it before
+           comparing, or a slot filled by an initial reads as different from the
+           same value written out. *)
         String.equal
-          (string_of_value ~minify:true implied)
+          (string_of_value ~minify:true (Declaration.normalize implied))
           (string_of_value ~minify:true li)
     | None -> false
   in

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -593,7 +593,51 @@ let display () =
   c ~expected:"display:table-cell" "display: table-cell";
   c ~expected:"display:list-item" "display: list-item";
   c ~expected:"display:contents" "display: contents";
-  c ~expected:"display:flow-root" "display: flow-root"
+  c ~expected:"display:flow-root" "display: flow-root";
+  (* CSS Display 3 (ED) sec. 2.1: a [<display-outside>] written without an
+     inside defaults the inner type to [flow]. sec. 2.2: an inside written alone
+     defaults the outer type to [block], except [ruby], which defaults to
+     [inline]. sec. 2.6 names the four precomposed inline-level keywords. Each
+     two-value form below therefore has a single-keyword spelling of the same
+     value, and the keyword is the shorter one; swapping them is a node change,
+     so pp prints what it parsed and the optimizer folds. *)
+  c ~expected:"display:block flow" ~optimized:"display:block"
+    "display: block flow";
+  c ~expected:"display:inline flow" ~optimized:"display:inline"
+    "display: inline flow";
+  c ~expected:"display:run-in flow" ~optimized:"display:run-in"
+    "display: run-in flow";
+  c ~expected:"display:block flow-root" ~optimized:"display:flow-root"
+    "display: block flow-root";
+  c ~expected:"display:inline flow-root" ~optimized:"display:inline-block"
+    "display: inline flow-root";
+  c ~expected:"display:block flex" ~optimized:"display:flex"
+    "display: block flex";
+  c ~expected:"display:inline flex" ~optimized:"display:inline-flex"
+    "display: inline flex";
+  c ~expected:"display:block grid" ~optimized:"display:grid"
+    "display: block grid";
+  c ~expected:"display:inline grid" ~optimized:"display:inline-grid"
+    "display: inline grid";
+  c ~expected:"display:block table" ~optimized:"display:table"
+    "display: block table";
+  c ~expected:"display:inline table" ~optimized:"display:inline-table"
+    "display: inline table";
+  c ~expected:"display:inline ruby" ~optimized:"display:ruby"
+    "display: inline ruby";
+  (* sec. 2.2's ruby exception cuts the other way too: the bare [ruby] keyword
+     means [inline ruby], so [block ruby] is the one two-value form with no
+     shorter spelling and both layers hold it. *)
+  c ~expected:"display:block ruby" ~optimized:"display:block ruby"
+    "display: block ruby";
+  (* sec. 2.3: a [list-item] with no inside takes [flow] and with no outside
+     takes [block], so [block flow list-item] is what [list-item] alone says.
+     Dropping the [flow] alone names the same value either way, which is why pp
+     may do it and the outer keyword has to wait for the optimizer. *)
+  c ~expected:"display:block list-item" ~optimized:"display:list-item"
+    "display: block flow list-item";
+  c ~expected:"display:inline list-item" ~optimized:"display:inline list-item"
+    "display: inline flow list-item"
 
 let position () =
   let c = check_declaration in
@@ -1054,6 +1098,18 @@ let overflow () =
   check_declaration ~expected:"overflow:scroll" "overflow: scroll";
   check_declaration ~expected:"overflow:auto" "overflow: auto";
   check_declaration ~expected:"overflow:clip" "overflow: clip";
+  (* CSS Overflow 3 (ED) sec. 3.1: [overflow] is [<'overflow-block'>{1,2}] and
+     "sets the specified values of overflow-x and overflow-y in that order. If
+     the second value is omitted, it is copied from the first." A pair of equal
+     values therefore says what the single value says, and dropping the second
+     is a node change, so pp holds the pair and the optimizer folds. *)
+  check_declaration ~expected:"overflow:auto auto" ~optimized:"overflow:auto"
+    "overflow: auto auto";
+  check_declaration ~expected:"overflow:hidden hidden"
+    ~optimized:"overflow:hidden" "overflow: hidden hidden";
+  (* Two different values name two axes, so the pair stands. *)
+  check_declaration ~expected:"overflow:visible hidden"
+    ~optimized:"overflow:visible hidden" "overflow: visible hidden";
 
   check_declaration ~expected:"overflow-x:visible" "overflow-x: visible";
   check_declaration ~expected:"overflow-x:hidden" "overflow-x: hidden";
@@ -1605,7 +1661,8 @@ let spec_property_grammar_table_expansion () =
             (Some "animation:fade 1s linear 2 alternate both", None)
         | "animation-range", "entry 10% exit 90%" ->
             (Some "animation-range:entry 10%exit 90%", None)
-        | "display", "inline flow-root" -> (Some "display:inline-block", None)
+        | "display", "inline flow-root" ->
+            (Some "display:inline flow-root", Some "display:inline-block")
         | "position-try-fallbacks", "--below, flip-block" ->
             (Some "position-try-fallbacks:--below,flip-block", None)
         | "cursor", "url(cursor.cur), pointer" ->
@@ -2344,7 +2401,7 @@ let spec_platform_property_vectors () =
         "content:attr(data-label string,var(--label,\"x y\"))" );
       ( "font: italic small-caps 650 condensed 16px/1.5 \"Brand\", serif",
         "font:italic small-caps 650 condensed 16px/1.5 Brand,serif" );
-      ("display: block flex", "display:flex");
+      ("display: block flex", "display:block flex");
       ( "grid-template: \"head head\" auto \"nav main\" 1fr / 12rem 1fr",
         "grid-template:\"head head\" auto \"nav main\" 1fr/12rem 1fr" );
       ( "transition: opacity 1s ease-in .2s allow-discrete",

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1752,8 +1752,8 @@ let spec_cascade3_shorthands () =
   check_declaration ~expected:"padding:1em 2em" "padding: 1em 2em";
   check_declaration ~expected:"background:green" "background: green";
   check_declaration ~expected:"border:1px solid red" "border: 1px solid red";
-  check_declaration ~expected:"font:700 12pt/14pt Helvetica"
-    "font: bold 12pt/14pt Helvetica";
+  check_declaration ~expected:"font:bold 12pt/14pt Helvetica"
+    ~optimized:"font:700 12pt/14pt Helvetica" "font: bold 12pt/14pt Helvetica";
   check_declaration ~expected:"margin:inherit" "margin: inherit";
   check_declaration ~expected:"padding:initial" "padding: initial";
   check_declaration ~expected:"background:unset" "background: unset";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -604,11 +604,18 @@ let position () =
   c ~expected:"position:sticky" "position: sticky"
 
 let font_properties () =
-  (* Font weight. Per CSS Fonts 4 section 2.2 the keywords [normal] and [bold]
-     map to [400] / [700]; the printer canonicalizes to the numeric form under
-     minify. *)
-  check_declaration ~expected:"font-weight:400" "font-weight: normal";
-  check_declaration ~expected:"font-weight:700" "font-weight: bold";
+  (* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as
+     "Same as 700", so each keyword and its number are one value with two
+     spellings, and the number is the shorter one. Swapping them is a node
+     change, so pp holds what it was handed and the optimizer folds. *)
+  check_declaration ~expected:"font-weight:normal" ~optimized:"font-weight:400"
+    "font-weight: normal";
+  check_declaration ~expected:"font-weight:bold" ~optimized:"font-weight:700"
+    "font-weight: bold";
+  (* sec. 2.7 gives the [font] shorthand a [<'font-weight'>] slot, so the slot
+     takes the longhand's fold. *)
+  check_declaration ~expected:"font:bold 12px serif"
+    ~optimized:"font:700 12px serif" "font: bold 12px serif";
   check_declaration ~expected:"font-weight:lighter" "font-weight: lighter";
   check_declaration ~expected:"font-weight:bolder" "font-weight: bolder";
   check_declaration ~expected:"font-weight:100" "font-weight: 100";
@@ -1592,7 +1599,8 @@ let spec_property_grammar_table_expansion () =
             (Some "transform:translateX(10px)rotate(45deg)scale(1.2)", None)
         | "rotate", "1 0 0 45deg" -> (Some "rotate:x 45deg", None)
         | "font", "italic small-caps bold 16px/1.5 serif" ->
-            (Some "font:italic small-caps 700 16px/1.5 serif", None)
+            ( Some "font:italic small-caps bold 16px/1.5 serif",
+              Some "font:italic small-caps 700 16px/1.5 serif" )
         | "animation", "fade 1s linear 2 alternate both running" ->
             (Some "animation:fade 1s linear 2 alternate both", None)
         | "animation-range", "entry 10% exit 90%" ->

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -164,6 +164,34 @@ let test_font_weight_spellings_factor () =
     "normal factors with 400" ".a,.b{font-weight:400}"
     (optimize_str ".a{font-weight:normal}.b{font-weight:400}")
 
+(* CSS Display 3 (ED) sec. 2.1, 2.2 and 2.6 give most two-value [display] forms
+   a single-keyword spelling of the same value, and sec. 2.3 gives [block flow
+   list-item] one. Factoring compares nodes, so the two rules meet as one
+   declaration only if the fold happened first. *)
+let test_display_spellings_factor () =
+  Alcotest.(check string)
+    "block flow factors with block" ".a,.b{display:block}"
+    (optimize_str ".a{display:block flow}.b{display:block}");
+  Alcotest.(check string)
+    "inline flow-root factors with inline-block" ".a,.b{display:inline-block}"
+    (optimize_str ".a{display:inline flow-root}.b{display:inline-block}");
+  Alcotest.(check string)
+    "block flow list-item factors with list-item" ".a,.b{display:list-item}"
+    (optimize_str ".a{display:block flow list-item}.b{display:list-item}");
+  (* sec. 2.2 reads [ruby] as [inline ruby], so [block ruby] names a different
+     value and the two rules stay apart. *)
+  Alcotest.(check string)
+    "block ruby does not factor with ruby"
+    ".a{display:block ruby}.b{display:ruby}"
+    (optimize_str ".a{display:block ruby}.b{display:ruby}")
+
+(* CSS Overflow 3 (ED) sec. 3.1: the omitted second value is copied from the
+   first, so a repeated axis is the longer spelling of the single value. *)
+let test_overflow_pair_spellings_factor () =
+  Alcotest.(check string)
+    "auto auto factors with auto" ".a,.b{overflow:auto}"
+    (optimize_str ".a{overflow:auto auto}.b{overflow:auto}")
+
 let suite =
   ( "factor",
     [
@@ -181,4 +209,8 @@ let suite =
         test_initial_line_style_spellings_factor;
       Alcotest.test_case "font-weight keyword and number factor together" `Quick
         test_font_weight_spellings_factor;
+      Alcotest.test_case "display two-value and legacy spellings factor" `Quick
+        test_display_spellings_factor;
+      Alcotest.test_case "equal overflow axes factor with the single value"
+        `Quick test_overflow_pair_spellings_factor;
     ] )

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -152,6 +152,18 @@ let test_initial_line_style_spellings_factor () =
     ".a,.b{column-rule:none}"
     (optimize_str ".a{column-rule:medium none}.b{column-rule:none}")
 
+(* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as
+   "Same as 700", so the keyword and the number name one weight. Factoring
+   compares nodes, so the two rules only meet as one declaration if the fold
+   happened before they were compared. *)
+let test_font_weight_spellings_factor () =
+  Alcotest.(check string)
+    "bold factors with 700" ".a,.b{font-weight:700}"
+    (optimize_str ".a{font-weight:bold}.b{font-weight:700}");
+  Alcotest.(check string)
+    "normal factors with 400" ".a,.b{font-weight:400}"
+    (optimize_str ".a{font-weight:normal}.b{font-weight:400}")
+
 let suite =
   ( "factor",
     [
@@ -167,4 +179,6 @@ let suite =
         test_initial_line_width_spellings_factor;
       Alcotest.test_case "initial line-style spellings factor together" `Quick
         test_initial_line_style_spellings_factor;
+      Alcotest.test_case "font-weight keyword and number factor together" `Quick
+        test_font_weight_spellings_factor;
     ] )

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1804,10 +1804,12 @@ let test_background () =
   neg_cursor read_background "10px 20px 30px 40px 50px"
 
 let test_font_weight () =
-  (* CSS Fonts 4 section 2.2: [normal] and [bold] canonicalize to the numeric
-     forms [400] and [700] under minify. *)
-  check_font_weight ~expected:"400" "normal";
-  check_font_weight ~expected:"700" "bold";
+  (* CSS Fonts 4 (ED) sec. 2.2 makes [normal] and [bold] the numbers 400 and
+     700, but swapping one for the other is a node change, so pp prints the
+     keyword it was handed and the optimizer folds (test_declaration pins the
+     fold). *)
+  check_font_weight "normal";
+  check_font_weight "bold";
   check_font_weight "700";
   check_font_weight "1000";
   check_font_weight "lighter";
@@ -3628,7 +3630,7 @@ let test_grid_area () =
 let test_font () =
   check_font "16px serif";
   check_font "italic 700 16px/1.5 serif";
-  check_font ~expected:"italic 700 16px/1.5 serif" "italic bold 16px/1.5 serif";
+  check_font "italic bold 16px/1.5 serif";
   check_font "small-caps 12px monospace";
   check_font "inherit";
   check_font "caption";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -3052,7 +3052,7 @@ let c64_layer_name_syntax () =
     "@layer framework.base, framework.theme;";
   check_stylesheet
     ~expected:
-      "@layer reset.type{strong{font-weight:700}}@layer \
+      "@layer reset.type{strong{font-weight:bold}}@layer \
        reset{[hidden]{display:none}}"
     "@layer reset.type { strong { font-weight: bold } } @layer reset { \
      [hidden] { display: none } }";
@@ -3087,7 +3087,7 @@ let c64_layer_nesting_examples () =
        framework.theme{blockquote{color:#639}}";
   check_stylesheet
     ~expected:
-      "@layer reset.type{strong{font-weight:700}}@layer \
+      "@layer reset.type{strong{font-weight:bold}}@layer \
        framework{.title{font-weight:100}@layer \
        theme{h1,h2{color:maroon}}}@layer reset{[hidden]{display:none}}"
     "@layer reset.type { strong { font-weight: bold } } @layer framework { \


### PR DESCRIPTION
`font-weight: bold`, the two-value `display` forms and a repeated `overflow` axis were folded to their shorter spelling in the serializer, so two rules declaring the same thing reached factoring as different nodes and never merged. This moves each fold into `normalize`, the third property family to take the shape #635 established for the border width slot and #636 for the style slot.

The `display` audit turned up a miscompile: CSS Display 3 reads the bare `ruby` keyword as `inline ruby`, so folding `display: block ruby` onto it moved the box from block-level to inline-level. `inline ruby` now folds and `block ruby` stands.
