### PR TITLE
font: fold the font value spellings in the AST, not the printer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -472,9 +472,13 @@ recorded cases carrying six minifiers' answers.
 - `--minify` folds a value's spelling before two rules are compared, so rules
   that wrote one declaration two ways factor into one: an explicit initial
   `medium` width or `none` style in the `border`, `column-rule` and `outline`
-  shorthands, `font-weight: bold` beside `700`, a two-value `display` beside
-  its legacy keyword, and `overflow: auto auto` beside `auto`
-  (#635, #636, #637)
+  shorthands, `font-weight: bold` beside `700`, `font-stretch: condensed`
+  beside `75%`, a family repeated in `font-family`, a `font` slot left at its
+  longhand's initial, a two-value `display` beside its legacy keyword, and
+  `overflow: auto auto` beside `auto` (#635, #636, #637, #639)
+- `--minify` folds a same-unit `calc()` in `font-size`, so `calc(1px + 1px)`
+  prints as `2px` and merges with a rule that wrote `2px`; the property ran the
+  untyped calc simplifier, which cannot add two typed lengths (#639)
 - `--minify` keeps `display: block ruby`. It printed `ruby`, which CSS Display
   3 reads as `inline ruby`, so a block-level ruby container came back
   inline-level (#637)

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -110,13 +110,17 @@ let factor_rules_incremental ?cache ~ctx rules =
    selector so a list bound is de-duplicated and ordered consistently. *)
 let canonicalize_scope_selector sel = Selector.canonicalize sel
 
-(* CSS Fonts 4 (ED) sec. 4.4 gives the [font-weight] descriptor the values of
-   the property of the same name, so the descriptor takes the property's fold. A
-   descriptor is not a declaration and never reaches factoring, but the fold is
-   still a node question, so it belongs here and not in the serializer. *)
+(* CSS Fonts 4 (ED) sec. 4.4 gives the [font-weight] and [font-width]
+   descriptors the values of the properties of the same name, so a descriptor
+   takes its property's fold. A descriptor is not a declaration and never
+   reaches factoring, but the fold is still a node question, so it belongs here
+   and not in the serializer. *)
 let normalize_font_face_descriptor (desc : font_face_descriptor) :
     font_face_descriptor =
   let weight w = Properties.normalize_property_value Properties.Font_weight w in
+  let stretch w =
+    Properties.normalize_property_value Properties.Font_stretch w
+  in
   match desc with
   | Font_weight value ->
       let value' = weight value in
@@ -126,11 +130,18 @@ let normalize_font_face_descriptor (desc : font_face_descriptor) :
       let high' = weight high in
       if low' == low && high' == high then desc
       else Font_weight_range (low', high')
-  | Font_family _ | Src _ | Font_style _ | Font_style_range _ | Font_stretch _
-  | Font_stretch_range _ | Font_display _ | Unicode_range _ | Font_variant _
-  | Font_feature_settings _ | Font_variation_settings _ | Font_tech _
-  | Size_adjust _ | Ascent_override _ | Descent_override _ | Line_gap_override _
-    ->
+  | Font_stretch value ->
+      let value' = stretch value in
+      if value' == value then desc else Font_stretch value'
+  | Font_stretch_range (low, high) ->
+      let low' = stretch low in
+      let high' = stretch high in
+      if low' == low && high' == high then desc
+      else Font_stretch_range (low', high')
+  | Font_family _ | Src _ | Font_style _ | Font_style_range _ | Font_display _
+  | Unicode_range _ | Font_variant _ | Font_feature_settings _
+  | Font_variation_settings _ | Font_tech _ | Size_adjust _ | Ascent_override _
+  | Descent_override _ | Line_gap_override _ ->
       desc
 
 (* [stmt] is returned unchanged when no descriptor moved: the factoring fixpoint

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -757,32 +757,6 @@ let rec pp_font_family : font_family Pp.t =
       let level_chars =
         match ctx.Pp.indent with Some w -> w * ctx.Pp.level | None -> 0
       in
-      (* CSS Fonts 4 sec. 2.1: [font-family] is a fallback list, so a duplicate
-         entry never wins under cascade resolution - drop it under minify (the
-         first occurrence keeps the source position). A bare generic keyword
-         (notably [monospace]) takes the UA generic-font size, so the
-         [monospace, monospace] idiom opts back into the normal size; a dedup
-         must not collapse a list to a single generic, which would shrink the
-         text. *)
-      let fonts =
-        if Pp.minified ctx then
-          let seen = Hashtbl.create 8 in
-          let deduped =
-            List.filter
-              (fun f ->
-                let key = Pp.to_string ~minify:true pp_font_family f in
-                if Hashtbl.mem seen key then false
-                else (
-                  Hashtbl.add seen key ();
-                  true))
-              fonts
-          in
-          match deduped with
-          | [ single ] when is_generic_family single && List.length fonts > 1 ->
-              fonts
-          | _ -> deduped
-        else fonts
-      in
       Pp.list_wrap ~threshold:90 ~sep:Pp.comma ~wrap_indent:(level_chars + 2)
         pp_font_family ctx fonts
   | Invalid tokens ->
@@ -1993,14 +1967,47 @@ let normalize_font_weight : font_weight -> font_weight = function
   | Bold -> Weight 700
   | value -> value
 
-(* sec. 2.7 gives the [font] shorthand a [<'font-weight'>] slot, so the slot
-   takes the longhand's fold. *)
+(* sec. 2.1 has the user agent walk the family list until one matches, so an
+   entry repeating an earlier one is never reached and names nothing: drop it,
+   keeping the first occurrence's position. The key is the minified spelling,
+   which is what makes [Arial] and ["Arial"] one entry. A one-entry list is that
+   entry, so the fold lands on the node the same text parses to. A bare generic
+   keyword (notably [monospace]) takes the UA generic-font size, so the
+   [monospace, monospace] idiom opts back into the normal size: a list that
+   would collapse to a lone generic keeps its duplicate. *)
+let normalize_font_family (value : font_family) : font_family =
+  match value with
+  | List fonts -> (
+      let seen = Hashtbl.create 8 in
+      let deduped =
+        List.filter
+          (fun f ->
+            let key = Pp.to_string ~minify:true pp_font_family f in
+            if Hashtbl.mem seen key then false
+            else (
+              Hashtbl.add seen key ();
+              true))
+          fonts
+      in
+      if List.compare_lengths deduped fonts = 0 then
+        match fonts with [ single ] -> single | _ -> value
+      else
+        match deduped with
+        | [ single ] when is_generic_family single -> value
+        | [ single ] -> single
+        | deduped -> List deduped)
+  | other -> other
+
+(* sec. 2.7 gives the [font] shorthand [<'font-weight'>] and [<'font-family'>#]
+   slots, so each slot takes its longhand's fold. *)
 let normalize_font : font -> font =
  fun value ->
   match value with
   | Shorthand s ->
       let weight = option_map_preserve normalize_font_weight s.weight in
-      if weight == s.weight then value else Shorthand { s with weight }
+      let family = normalize_font_family s.family in
+      if weight == s.weight && family == s.family then value
+      else Shorthand { s with weight; family }
   | other -> other
 
 let rec read_font_variant_emoji t : font_variant_emoji =

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1093,27 +1093,53 @@ let rec pp_webkit_font_smoothing : webkit_font_smoothing Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+(* [<length-percentage>] is the whole of [font-size]'s numeric grammar, so a
+   calc built from those leaves is a [<length>] calc and can be handed to the
+   length simplifier. The trip back lands under [Length], percentage included: a
+   [<percentage>] is one token, so the reader takes [font-size: 50%] through
+   [read_non_negative_length] and the [Pct] leaf it produces sits there. A
+   [var()] leaf carries a [font_size]-typed fallback, which does not survive the
+   trip either way. *)
+let rec length_of_font_size_calc : font_size calc -> length calc option =
+  function
+  | Val (Length l) -> Some (Val l)
+  | Val (Pct n) -> Some (Val (Pct n : length))
+  | Num n -> Some (Num n)
+  | Math_const c -> Some (Math_const c)
+  | Math_fn fn -> Some (Math_fn fn)
+  | Var _ | Sibling_index | Sibling_count | Val _ -> None
+  | Nested inner ->
+      Option.map (fun c -> Nested c) (length_of_font_size_calc inner)
+  | Parens inner ->
+      Option.map (fun c -> Parens c) (length_of_font_size_calc inner)
+  | Expr (left, op, right) -> (
+      match (length_of_font_size_calc left, length_of_font_size_calc right) with
+      | Some left, Some right -> Some (Expr (left, op, right))
+      | _ -> None)
+
+let rec font_size_of_length_calc : length calc -> font_size calc option =
+  function
+  | Val l -> Some (Val (Length l))
+  | Num n -> Some (Num n)
+  | Math_const c -> Some (Math_const c)
+  | Math_fn fn -> Some (Math_fn fn)
+  | Var _ | Sibling_index | Sibling_count -> None
+  | Nested inner ->
+      Option.map (fun c -> Nested c) (font_size_of_length_calc inner)
+  | Parens inner ->
+      Option.map (fun c -> Parens c) (font_size_of_length_calc inner)
+  | Expr (left, op, right) -> (
+      match (font_size_of_length_calc left, font_size_of_length_calc right) with
+      | Some left, Some right -> Some (Expr (left, op, right))
+      | _ -> None)
+
 let rec pp_font_size : font_size Pp.t =
  fun ctx -> function
   | Length l -> pp_length ctx l
   | Pct f -> Pp.pct ctx f
   | Var v -> pp_var pp_font_size ctx v
   | Calc c -> (
-      let rec to_length_calc : font_size calc -> length calc option = function
-        | Val (Length l) -> Some (Val l)
-        | Val (Pct n) -> Some (Val (Pct n : length))
-        | Num n -> Some (Num n)
-        | Math_const c -> Some (Math_const c)
-        | Math_fn fn -> Some (Math_fn fn)
-        | Var _ | Sibling_index | Sibling_count | Val _ -> None
-        | Nested inner -> Option.map (fun c -> Nested c) (to_length_calc inner)
-        | Parens inner -> Option.map (fun c -> Parens c) (to_length_calc inner)
-        | Expr (left, op, right) -> (
-            match (to_length_calc left, to_length_calc right) with
-            | Some left, Some right -> Some (Expr (left, op, right))
-            | _ -> None)
-      in
-      match (Pp.minified ctx, to_length_calc c) with
+      match (Pp.minified ctx, length_of_font_size_calc c) with
       | true, Some c -> pp_length ctx (Calc c)
       | _ -> pp_calc pp_font_size ctx c)
   | Xx_small -> Pp.string ctx "xx-small"
@@ -1935,11 +1961,28 @@ let rec read_font_variation_settings t : font_variation_settings =
 let pp_font_src : Font_face.src Pp.t = Font_face.pp
 let read_font_src = Font_face.read_src
 
+(* CSS Values 4 (ED) sec. 10.10.1 sums a calc's same-unit children and returns
+   the lone remaining child, which needs the typed length simplifier: the
+   untyped one cannot add two [Val] leaves. [em] and [%] resolve against the
+   parent font size rather than the element's own, but every term of one
+   declaration shares that reference, so their sum is the same value whatever
+   the reference turns out to be. *)
 let normalize_font_size (fs : font_size) : font_size =
   match fs with
   | Length l -> preserve_if_equal fs (Length (Values.normalize_length l))
   | Calc c -> (
-      match Values.eval_calc c with Values.Val v -> v | folded -> Calc folded)
+      match length_of_font_size_calc c with
+      | None -> (
+          match Values.eval_calc c with
+          | Values.Val v -> v
+          | folded -> Calc folded)
+      | Some lc -> (
+          match Values.normalize_length (Calc lc) with
+          | Calc folded -> (
+              match font_size_of_length_calc folded with
+              | Some folded -> Calc folded
+              | None -> fs)
+          | length -> Length length))
   | _ -> fs
 
 let normalize_line_height (lh : line_height) : line_height =
@@ -1997,18 +2040,19 @@ let normalize_font_family (value : font_family) : font_family =
         | deduped -> List deduped)
   | other -> other
 
-(* sec. 2.7 gives the [font] shorthand [<'font-weight'>] and [<'font-family'>#]
-   slots, so each slot takes its longhand's fold. Its width slot is
-   [<font-width-css3>], the keywords alone, so the percentage the longhand folds
-   to is not a value the slot can hold. *)
+(* sec. 2.7 gives the [font] shorthand [<'font-weight'>], [<'font-size'>] and
+   [<'font-family'>#] slots, so each slot takes its longhand's fold. Its width
+   slot is [<font-width-css3>], the keywords alone, so the percentage the
+   longhand folds to is not a value the slot can hold. *)
 let normalize_font : font -> font =
  fun value ->
   match value with
   | Shorthand s ->
       let weight = option_map_preserve normalize_font_weight s.weight in
       let family = normalize_font_family s.family in
-      if weight == s.weight && family == s.family then value
-      else Shorthand { s with weight; family }
+      let size = normalize_font_size s.size in
+      if weight == s.weight && family == s.family && size == s.size then value
+      else Shorthand { s with weight; family; size }
   | other -> other
 
 let rec read_font_variant_emoji t : font_variant_emoji =

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1209,10 +1209,9 @@ let rec pp_font_weight : font_weight Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_font_weight ctx v
 
-(* CSS Fonts 4 sec. 2.7: under minify, drop [<style>? <weight>? <stretch>?]
-   components that equal their longhand initial value, and drop [line-height]
-   when it's [normal]. The shorthand body itself is always [<size>
-   [/<line-height>]? <family>+]; size and family are required. *)
+(* CSS Fonts 4 sec. 2.7: the shorthand body is [<size> [/<line-height>]?
+   <family>+], so size and family are always emitted and the four prefix slots
+   only when the value carries them. *)
 let pp_font_variant_css21 ctx = function
   | (Normal : font_variant_css21) -> Pp.string ctx "normal"
   | Small_caps -> Pp.string ctx "small-caps"
@@ -1221,40 +1220,6 @@ let read_font_variant_css21 t : font_variant_css21 =
   Cursor.enum "font-variant-css21"
     [ ("normal", (Normal : font_variant_css21)); ("small-caps", Small_caps) ]
     t
-
-let drop_font_default ctx (type a) ~(is_default : a -> bool) (opt : a option) :
-    a option =
-  if Pp.minified ctx then
-    match opt with Some v when is_default v -> None | _ -> opt
-  else opt
-
-let drop_font_shorthand_defaults ctx style variant weight stretch line_height =
-  let style =
-    drop_font_default ctx style ~is_default:(function
-      | (Normal : font_style) -> true
-      | _ -> false)
-  in
-  let variant =
-    drop_font_default ctx variant ~is_default:(function
-      | (Normal : font_variant_css21) -> true
-      | _ -> false)
-  in
-  let weight =
-    drop_font_default ctx weight ~is_default:(function
-      | (Normal : font_weight) | Weight 400 -> true
-      | _ -> false)
-  in
-  let stretch =
-    drop_font_default ctx stretch ~is_default:(function
-      | (Normal : font_stretch) -> true
-      | _ -> false)
-  in
-  let line_height =
-    drop_font_default ctx line_height ~is_default:(function
-      | (Normal : line_height) -> true
-      | _ -> false)
-  in
-  (style, variant, weight, stretch, line_height)
 
 let pp_font_prefix ctx style variant weight stretch =
   let first = ref true in
@@ -1274,9 +1239,6 @@ let pp_font_prefix ctx style variant weight stretch =
 
 let pp_font_shorthand : font_shorthand Pp.t =
  fun ctx { style; variant; weight; stretch; size; line_height; family } ->
-  let style, variant, weight, stretch, line_height =
-    drop_font_shorthand_defaults ctx style variant weight stretch line_height
-  in
   if not (pp_font_prefix ctx style variant weight stretch) then Pp.space ctx ();
   pp_font_size ctx size;
   Option.iter
@@ -2040,19 +2002,60 @@ let normalize_font_family (value : font_family) : font_family =
         | deduped -> List deduped)
   | other -> other
 
+let drop_font_initial_slot (type a) ~(is_initial : a -> bool) (opt : a option) :
+    a option =
+  match opt with Some v when is_initial v -> None | _ -> opt
+
 (* sec. 2.7 gives the [font] shorthand [<'font-weight'>], [<'font-size'>] and
    [<'font-family'>#] slots, so each slot takes its longhand's fold. Its width
    slot is [<font-width-css3>], the keywords alone, so the percentage the
-   longhand folds to is not a value the slot can hold. *)
+   longhand folds to is not a value the slot can hold.
+
+   sec. 2.7 also resets every subproperty to its initial value before applying
+   the slots given explicitly, so a slot holding its longhand's initial says
+   what leaving it out says: drop it. The initials are [normal] for style,
+   variant and width, [normal] (that is 400) for weight and [normal] for
+   line-height; size and family are required and stay. *)
 let normalize_font : font -> font =
  fun value ->
   match value with
   | Shorthand s ->
-      let weight = option_map_preserve normalize_font_weight s.weight in
+      let style =
+        drop_font_initial_slot s.style ~is_initial:(function
+          | (Normal : font_style) -> true
+          | _ -> false)
+      in
+      let variant =
+        drop_font_initial_slot s.variant ~is_initial:(function
+          | (Normal : font_variant_css21) -> true
+          | _ -> false)
+      in
+      let weight =
+        option_map_preserve normalize_font_weight s.weight
+        |> drop_font_initial_slot ~is_initial:(function
+          | (Normal : font_weight) | Weight 400 -> true
+          | _ -> false)
+      in
+      let stretch =
+        drop_font_initial_slot s.stretch ~is_initial:(function
+          | (Normal : font_stretch) -> true
+          | _ -> false)
+      in
+      let line_height =
+        drop_font_initial_slot s.line_height ~is_initial:(function
+          | (Normal : line_height) -> true
+          | _ -> false)
+      in
       let family = normalize_font_family s.family in
       let size = normalize_font_size s.size in
-      if weight == s.weight && family == s.family && size == s.size then value
-      else Shorthand { s with weight; family; size }
+      if
+        style == s.style && variant == s.variant && weight == s.weight
+        && stretch == s.stretch
+        && line_height == s.line_height
+        && family == s.family && size == s.size
+      then value
+      else
+        Shorthand { style; variant; weight; stretch; size; line_height; family }
   | other -> other
 
 let rec read_font_variant_emoji t : font_variant_emoji =

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -901,12 +901,6 @@ let font_stretch_pct = function
   | _ -> None
 
 let rec pp_font_stretch : font_stretch Pp.t =
- fun ctx v ->
-  match if Pp.minified ctx then font_stretch_pct v else None with
-  | Some pct -> Pp.pct ctx pct
-  | None -> pp_font_stretch_keyword ctx v
-
-and pp_font_stretch_keyword : font_stretch Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_font_stretch ctx v
   | Pct f -> Pp.pct ctx f
@@ -1249,9 +1243,7 @@ let pp_font_prefix ctx style variant weight stretch =
   emit pp_font_style style;
   emit pp_font_variant_css21 variant;
   emit pp_font_weight weight;
-  (* The [font] shorthand's stretch component takes only the keywords, so the
-     percentage the standalone property minifies to would be invalid here. *)
-  emit pp_font_stretch_keyword stretch;
+  emit pp_font_stretch stretch;
   !first
 
 let pp_font_shorthand : font_shorthand Pp.t =
@@ -1967,6 +1959,13 @@ let normalize_font_weight : font_weight -> font_weight = function
   | Bold -> Weight 700
   | value -> value
 
+(* sec. 2.3 maps each width keyword onto a percentage, and getComputedStyle()
+   serializes the property as a percentage however the value was written, so the
+   keyword and its percentage name one width and the percentage is never
+   longer. *)
+let normalize_font_stretch (value : font_stretch) : font_stretch =
+  match font_stretch_pct value with Some pct -> Pct pct | None -> value
+
 (* sec. 2.1 has the user agent walk the family list until one matches, so an
    entry repeating an earlier one is never reached and names nothing: drop it,
    keeping the first occurrence's position. The key is the minified spelling,
@@ -1999,7 +1998,9 @@ let normalize_font_family (value : font_family) : font_family =
   | other -> other
 
 (* sec. 2.7 gives the [font] shorthand [<'font-weight'>] and [<'font-family'>#]
-   slots, so each slot takes its longhand's fold. *)
+   slots, so each slot takes its longhand's fold. Its width slot is
+   [<font-width-css3>], the keywords alone, so the percentage the longhand folds
+   to is not a value the slot can hold. *)
 let normalize_font : font -> font =
  fun value ->
   match value with

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3602,6 +3602,7 @@ let normalize_property_value : type a.
   | Gap -> normalize_gap value
   | Font_size -> normalize_font_size value
   | Font_weight -> normalize_font_weight value
+  | Font_family -> normalize_font_family value
   | Font -> normalize_font value
   | Display -> normalize_display value
   | Overflow -> normalize_overflow value

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3603,6 +3603,7 @@ let normalize_property_value : type a.
   | Font_size -> normalize_font_size value
   | Font_weight -> normalize_font_weight value
   | Font_family -> normalize_font_family value
+  | Font_stretch -> normalize_font_stretch value
   | Font -> normalize_font value
   | Display -> normalize_display value
   | Overflow -> normalize_overflow value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -690,6 +690,29 @@ let font_properties () =
   check_declaration ~expected:"font:condensed 12px serif"
     ~optimized:"font:condensed 12px serif" "font: condensed 12px serif";
 
+  (* CSS Values 4 (ED) sec. 10.10.1 simplifies a Sum by replacing each set of
+     children with identical units by their sum, and returns the lone remaining
+     child, so a same-unit [font-size] calc folds the way a [width] one does.
+     [em] and [%] resolve against the parent font size here rather than the
+     element's own, but both terms of one declaration share that reference, so
+     the sum is the same value whatever it turns out to be. *)
+  check_declaration ~expected:"font-size:calc(1px + 1px)"
+    ~optimized:"font-size:2px" "font-size: calc(1px + 1px)";
+  check_declaration ~expected:"font-size:calc(1em + 1em)"
+    ~optimized:"font-size:2em" "font-size: calc(1em + 1em)";
+  check_declaration ~expected:"font-size:calc(50% + 50%)"
+    ~optimized:"font-size:100%" "font-size: calc(50% + 50%)";
+  check_declaration ~expected:"font-size:calc(2*3px)" ~optimized:"font-size:6px"
+    "font-size: calc(2 * 3px)";
+  (* Terms of different units carry no conversion factor until layout, so the
+     Sum keeps both children and both layers hold the call. *)
+  check_declaration ~expected:"font-size:calc(1em + 1px)"
+    ~optimized:"font-size:calc(1em + 1px)" "font-size: calc(1em + 1px)";
+  (* sec. 2.7 of CSS Fonts 4 gives the [font] shorthand a [<'font-size'>] slot,
+     so the slot takes the longhand's fold. *)
+  check_declaration ~expected:"font:calc(1px + 1px) serif"
+    ~optimized:"font:2px serif" "font: calc(1px + 1px) serif";
+
   (* Font style *)
   check_declaration ~expected:"font-style:normal" "font-style: normal";
   check_declaration ~expected:"font-style:italic" "font-style: italic";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -667,6 +667,29 @@ let font_properties () =
   check_declaration ~expected:"font-weight:700" "font-weight: 700";
   check_declaration ~expected:"font-weight:900" "font-weight: 900";
 
+  (* CSS Fonts 4 (ED) sec. 2.3 maps every [font-width] keyword onto a percentage
+     ([condensed] is 75%, [normal] is 100%) and has getComputedStyle() serialize
+     the property as a percentage whichever spelling was authored, so keyword
+     and percentage are one value and the percentage is the shorter one.
+     Swapping them is a node change, so pp holds what it parsed and the
+     optimizer folds. *)
+  check_declaration ~expected:"font-stretch:condensed"
+    ~optimized:"font-stretch:75%" "font-stretch: condensed";
+  check_declaration ~expected:"font-stretch:normal"
+    ~optimized:"font-stretch:100%" "font-stretch: normal";
+  check_declaration ~expected:"font-stretch:semi-expanded"
+    ~optimized:"font-stretch:112.5%" "font-stretch: semi-expanded";
+  check_declaration ~expected:"font-stretch:ultra-expanded"
+    ~optimized:"font-stretch:200%" "font-stretch: ultra-expanded";
+  check_declaration ~expected:"font-stretch:75%" ~optimized:"font-stretch:75%"
+    "font-stretch: 75%";
+  (* sec. 2.7 gives the [font] shorthand's width slot the grammar
+     [<font-width-css3>], which is the keywords alone: the percentage the
+     longhand folds to is not a value the slot accepts, so neither layer folds
+     it here. *)
+  check_declaration ~expected:"font:condensed 12px serif"
+    ~optimized:"font:condensed 12px serif" "font: condensed 12px serif";
+
   (* Font style *)
   check_declaration ~expected:"font-style:normal" "font-style: normal";
   check_declaration ~expected:"font-style:italic" "font-style: italic";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -679,15 +679,28 @@ let font_properties () =
     "font-family: \"Helvetica Neue\", Helvetica, Arial, sans-serif";
   check_declaration ~expected:"font-family:Georgia,serif"
     "font-family: Georgia, serif";
-  (* minify dedups a repeated family, but must not collapse the list to a lone
-     generic keyword - [monospace, monospace] opts a bare generic back into the
-     normal UA size, so dropping the duplicate would shrink the text. *)
-  check_declaration ~expected:"font-family:Arial,Helvetica"
+  (* CSS Fonts 4 (ED) sec. 2.1 has the user agent iterate the list until a
+     family matches, so a repeat of an earlier entry is unreachable and names
+     the same value as the list without it. Dropping it is a node change, so pp
+     holds the list it parsed and the optimizer folds. A one-entry list is the
+     entry, so the fold has to land on the node [font-family: Arial] parses to.
+     The exception is a list that would collapse to a lone generic keyword:
+     [monospace, monospace] opts a bare generic back into the normal UA size, so
+     dropping the duplicate would shrink the text. *)
+  check_declaration ~expected:"font-family:Arial,Helvetica,Arial"
+    ~optimized:"font-family:Arial,Helvetica"
     "font-family: Arial, Helvetica, Arial";
+  check_declaration ~expected:"font-family:Arial,Arial"
+    ~optimized:"font-family:Arial" "font-family: Arial, Arial";
   check_declaration ~expected:"font-family:monospace,monospace"
+    ~optimized:"font-family:monospace,monospace"
     "font-family: monospace, monospace";
   check_declaration ~expected:"font-family:serif,serif"
-    "font-family: serif, serif";
+    ~optimized:"font-family:serif,serif" "font-family: serif, serif";
+  (* sec. 2.7 gives the [font] shorthand a [<'font-family'>#] slot, so the slot
+     takes the longhand's fold. *)
+  check_declaration ~expected:"font:12px Arial,Arial"
+    ~optimized:"font:12px Arial" "font: 12px Arial, Arial";
   (* CSS Fonts 4 defines font-family names as <custom-ident> sequences. Quoted
      reserved words are family names; unquoted CSS-wide keywords remain CSS-wide
      keywords and must not be reinterpreted as family names. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -713,6 +713,30 @@ let font_properties () =
   check_declaration ~expected:"font:calc(1px + 1px) serif"
     ~optimized:"font:2px serif" "font: calc(1px + 1px) serif";
 
+  (* sec. 2.7 first resets every subproperty of [font] to its initial value and
+     then applies the slots given explicitly, so a slot carrying its longhand's
+     initial says exactly what leaving it out says. The initials are [normal]
+     for style, variant and width, [normal] (that is 400) for weight, and
+     [normal] for line-height. Dropping a slot is a node change, so pp holds
+     every slot it parsed and the optimizer drops. *)
+  check_declaration ~expected:"font:400 12px serif" ~optimized:"font:12px serif"
+    "font: 400 12px serif";
+  check_declaration ~expected:"font:12px/normal serif"
+    ~optimized:"font:12px serif" "font: 12px/normal serif";
+  check_declaration ~expected:"font:small-caps 400 12px/normal serif"
+    ~optimized:"font:small-caps 12px serif"
+    "font: normal small-caps 400 normal 12px/normal serif";
+  (* A bare [normal] in the prefix names the initial of whichever of the four
+     slots is still open, so the reader binds no slot for it and the two layers
+     agree from the start. *)
+  check_declaration ~expected:"font:12px serif" ~optimized:"font:12px serif"
+    "font: normal 12px serif";
+  (* A slot that is not its longhand's initial stays in both layers. *)
+  check_declaration ~expected:"font:italic 12px serif"
+    ~optimized:"font:italic 12px serif" "font: italic 12px serif";
+  check_declaration ~expected:"font:12px/1.5 serif"
+    ~optimized:"font:12px/1.5 serif" "font: 12px/1.5 serif";
+
   (* Font style *)
   check_declaration ~expected:"font-style:normal" "font-style: normal";
   check_declaration ~expected:"font-style:italic" "font-style: italic";

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -192,6 +192,16 @@ let test_overflow_pair_spellings_factor () =
     "auto auto factors with auto" ".a,.b{overflow:auto}"
     (optimize_str ".a{overflow:auto auto}.b{overflow:auto}")
 
+(* CSS Fonts 4 (ED) sec. 2.1 makes [font-family] a prioritized list the user
+   agent walks until a family matches, so a repeated entry is unreachable and
+   [Arial, Arial] names the value [Arial] names. Factoring compares nodes, so
+   the two rules only meet as one declaration if the fold happened before they
+   were compared. *)
+let test_font_family_duplicate_factors () =
+  Alcotest.(check string)
+    "a repeated family factors with the single one" ".a,.b{font-family:Arial}"
+    (optimize_str ".a{font-family:Arial,Arial}.b{font-family:Arial}")
+
 let suite =
   ( "factor",
     [
@@ -209,6 +219,8 @@ let suite =
         test_initial_line_style_spellings_factor;
       Alcotest.test_case "font-weight keyword and number factor together" `Quick
         test_font_weight_spellings_factor;
+      Alcotest.test_case "font-family duplicate factors with the single family"
+        `Quick test_font_family_duplicate_factors;
       Alcotest.test_case "display two-value and legacy spellings factor" `Quick
         test_display_spellings_factor;
       Alcotest.test_case "equal overflow axes factor with the single value"

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -202,6 +202,16 @@ let test_font_family_duplicate_factors () =
     "a repeated family factors with the single one" ".a,.b{font-family:Arial}"
     (optimize_str ".a{font-family:Arial,Arial}.b{font-family:Arial}")
 
+(* CSS Fonts 4 (ED) sec. 2.3 maps [condensed] onto 75%, and getComputedStyle()
+   serializes the property as a percentage whichever spelling was authored, so
+   the keyword and the percentage name one width. Factoring compares nodes, so
+   the two rules only meet as one declaration if the fold happened before they
+   were compared. *)
+let test_font_stretch_spellings_factor () =
+  Alcotest.(check string)
+    "condensed factors with 75%" ".a,.b{font-stretch:75%}"
+    (optimize_str ".a{font-stretch:condensed}.b{font-stretch:75%}")
+
 let suite =
   ( "factor",
     [
@@ -221,6 +231,8 @@ let suite =
         test_font_weight_spellings_factor;
       Alcotest.test_case "font-family duplicate factors with the single family"
         `Quick test_font_family_duplicate_factors;
+      Alcotest.test_case "font-stretch keyword and percentage factor together"
+        `Quick test_font_stretch_spellings_factor;
       Alcotest.test_case "display two-value and legacy spellings factor" `Quick
         test_display_spellings_factor;
       Alcotest.test_case "equal overflow axes factor with the single value"

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -224,6 +224,17 @@ let test_font_size_calc_factors () =
     "a folded calc factors with the percentage" ".a,.b{font-size:100%}"
     (optimize_str ".a{font-size:calc(50% + 50%)}.b{font-size:100%}")
 
+(* CSS Fonts 4 (ED) sec. 2.7 resets every subproperty of [font] to its initial
+   value before applying the slots given explicitly, so a slot holding its
+   longhand's initial and no slot at all name one value. Factoring compares
+   nodes, so the three rules only meet as one declaration if the drop happened
+   before they were compared. *)
+let test_font_shorthand_default_slots_factor () =
+  Alcotest.(check string)
+    "an initial slot factors with the slot left out" ".a,.b,.c{font:12px serif}"
+    (optimize_str
+       ".a{font:400 12px serif}.b{font:12px/normal serif}.c{font:12px serif}")
+
 let suite =
   ( "factor",
     [
@@ -247,6 +258,8 @@ let suite =
         `Quick test_font_stretch_spellings_factor;
       Alcotest.test_case "font-size calc factors with the folded length" `Quick
         test_font_size_calc_factors;
+      Alcotest.test_case "font shorthand initial slots factor together" `Quick
+        test_font_shorthand_default_slots_factor;
       Alcotest.test_case "display two-value and legacy spellings factor" `Quick
         test_display_spellings_factor;
       Alcotest.test_case "equal overflow axes factor with the single value"

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -212,6 +212,18 @@ let test_font_stretch_spellings_factor () =
     "condensed factors with 75%" ".a,.b{font-stretch:75%}"
     (optimize_str ".a{font-stretch:condensed}.b{font-stretch:75%}")
 
+(* CSS Values 4 (ED) sec. 10.10.1 sums a calc's same-unit children and returns
+   the lone remaining child, so [calc(1px + 1px)] and [2px] name one size.
+   Factoring compares nodes, so the two rules only meet as one declaration if
+   the fold happened before they were compared. *)
+let test_font_size_calc_factors () =
+  Alcotest.(check string)
+    "a folded calc factors with the length" ".a,.b{font-size:2px}"
+    (optimize_str ".a{font-size:calc(1px + 1px)}.b{font-size:2px}");
+  Alcotest.(check string)
+    "a folded calc factors with the percentage" ".a,.b{font-size:100%}"
+    (optimize_str ".a{font-size:calc(50% + 50%)}.b{font-size:100%}")
+
 let suite =
   ( "factor",
     [
@@ -233,6 +245,8 @@ let suite =
         `Quick test_font_family_duplicate_factors;
       Alcotest.test_case "font-stretch keyword and percentage factor together"
         `Quick test_font_stretch_spellings_factor;
+      Alcotest.test_case "font-size calc factors with the folded length" `Quick
+        test_font_size_calc_factors;
       Alcotest.test_case "display two-value and legacy spellings factor" `Quick
         test_display_spellings_factor;
       Alcotest.test_case "equal overflow axes factor with the single value"

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2418,12 +2418,12 @@ let test_font_stretch () =
   check_font_stretch "50%";
   check_font_stretch "inherit";
   neg_cursor read_font_stretch "invalid-stretch";
-  (* CSS Fonts 4 sec. 2.3 defines each keyword as a percentage, never longer, so
-     minified output uses it, but only for the standalone property: the [font]
-     shorthand's stretch component takes the keyword alone. *)
-  check_font_stretch ~expected:"100%" "normal";
-  check_font_stretch ~expected:"50%" "ultra-condensed";
-  check_font_stretch ~expected:"200%" "ultra-expanded"
+  (* CSS Fonts 4 (ED) sec. 2.3 makes each keyword a percentage, but swapping one
+     for the other is a node change, so pp prints the keyword it was handed and
+     the optimizer folds (test_declaration pins the fold). *)
+  check_font_stretch "normal";
+  check_font_stretch "ultra-condensed";
+  check_font_stretch "ultra-expanded"
 
 let test_font_variant_numeric () =
   check_font_variant_numeric "normal";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -739,6 +739,25 @@ let spec_fontface_descriptors () =
   check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
     "@font-face { font-family: Brand; src: url(font.woff2); font-variant: \
      common-ligatures no-common-ligatures; }";
+  (* sec. 4.4 gives the font-width descriptor the values of the property of the
+     same name, so a keyword endpoint takes the property's percentage fold. A
+     descriptor never reaches factoring, but the fold is still a node change and
+     so waits for the optimizer. *)
+  assert_minify_and_optimize
+    "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: \
+     condensed; }"
+    ~minified:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-stretch:condensed}"
+    ~optimized:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-stretch:75%}";
+  assert_minify_and_optimize
+    "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: \
+     condensed expanded; }"
+    ~minified:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-stretch:condensed \
+       expanded}"
+    ~optimized:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-stretch:75% 125%}";
   (* A descending font-stretch range is kept like the font-weight / oblique
      ranges below: CSS Fonts 4 sec. 4.4 swaps the endpoints for font matching
      and leaves the descriptor as it was written. *)


### PR DESCRIPTION
Four folds on the font properties ran at print time, so two rules that wrote one declaration two different ways emitted the same bytes but reached factoring as different nodes and never merged. `font-size` separately ran the untyped calc simplifier, which cannot add two typed lengths, so a same-unit sum never folded at all.