### PR TITLE
border: reject the empty value and fold the initial slots in the AST

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- An empty value is no longer a declaration. `border:`, its per-side and
+  logical variants and `column-rule:` read as `border: none`, and `outline:`
+  printed a value no parser reads back; an empty value matches none of these
+  shorthand grammars, so the declaration is now dropped with a warning like
+  any other invalid one (#640)
 - `display: flow-root list-item` and `display: flow list-item` are read as the
   values they are. CSS Display 3 sec. 2 orders none of the three `list-item`
   components, and the reader stopped at a leading inside keyword (#641)
@@ -481,7 +486,7 @@ recorded cases carrying six minifiers' answers.
   `text-decoration`, `text-shadow`, `transition` and `font` shorthands, a
   keyword beside the number or curve naming the same value, a repeated
   `font-family` entry, a two-value `display` beside its legacy keyword, and a
-  box shorthand whose sides repeat (#635, #636, #637, #639, #641)
+  box shorthand whose sides repeat (#635, #636, #637, #639, #640, #641)
 - `--minify` folds a same-unit `calc()` in `font-size`, so `calc(1px + 1px)`
   prints as `2px` and merges with a rule that wrote `2px`; the property ran the
   untyped calc simplifier, which cannot add two typed lengths (#639)
@@ -497,6 +502,12 @@ recorded cases carrying six minifiers' answers.
   `transition: opacity 0s 2s` printed `transition:opacity 2s`; CSS Transitions
   1 sec. 2.5 gives the first time to the duration, so the delayed instant
   change came back as a two-second one starting straight away (#641)
+- `--minify` keeps a lone `background` position value and both `<box>` values
+  of a layer that disagree. CSS Backgrounds 3 sec. 2.6 reads one position
+  value as `<x> center`, so `background: url(a.png) 0` came back top-aligned,
+  and sec. 2.10 reads a single `<box>` as setting `background-origin` and
+  `background-clip` together, so `background: red content-box border-box`
+  came back painted over the content box alone (#640)
 - `--minify` folds the width slot of the `border` shorthands and of
   `column-rule`, so `border: 0px solid red` prints as `border:0 solid red`
   and `border: calc(1px + 1px) solid red` as `border:2px solid red`. That

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -243,15 +243,103 @@ let normalize_border_radius ?(strip = true) : border_radius -> border_radius =
            })
   | other -> other
 
+(* CSS Backgrounds 3 (ED) sec. 2.10: the shorthand resets every longhand it
+   covers before setting the ones written, so a slot holding its own initial
+   value declares what leaving it out declares and the shorter spelling wins. *)
+let drop_initial_slot : 'a. 'a -> 'a option -> 'a option =
+ fun initial opt ->
+  match opt with Some x when x = initial -> (None : _ option) | _ -> opt
+
+(* sec. 2.6 gives background-position the initial value [0% 0%] and reads a lone
+   value as the horizontal offset with [center] vertically, so a [Single] names
+   [<x> 50%] and never the initial position however small [<x>] is. *)
+let position_is_layer_initial (p : position_value) =
+  match p with
+  | XY (x, y) -> is_zero_length x && is_zero_length y
+  | Left_top | Top_left -> true
+  | _ -> false
+
+(* sec. 2.10 reads a single [<box>] as setting both background-origin and
+   background-clip, and a pair as setting origin then clip, so an absent clip
+   means the origin's box wherever one is written, and only sec. 2.7's initial
+   [border-box] when none is. Read the pair back to those two boxes and write
+   the shortest spelling of them: both initial (sec. 2.8 [padding-box] for the
+   origin) and neither is written, equal and the origin alone says both,
+   otherwise both are written. Dropping just the one at its initial value would
+   leave a [<box>] that reassigns the other. *)
+let drop_initial_boxes (origin : background_box option)
+    (clip : background_box option) :
+    background_box option * background_box option =
+  let o = Option.value origin ~default:(Padding_box : background_box) in
+  let c =
+    match (clip, origin) with
+    | Option.Some c, _ -> c
+    | Option.None, Option.Some o -> o
+    | Option.None, Option.None -> (Border_box : background_box)
+  in
+  if o = Padding_box && c = Border_box then (Option.None, Option.None)
+  else if equal_background_box o c then (Option.Some o, Option.None)
+  else (Option.Some o, Option.Some c)
+
+(* A layer that fills no slot declares what [background: none] declares, and
+   sec. 2.6's initial position is the shortest spelling of it, so that is where
+   the two meet. *)
+let drained_background_layer : background_shorthand =
+  {
+    color = None;
+    image = None;
+    position = Some (XY (Zero, Zero) : position_value);
+    size = None;
+    repeat = None;
+    attachment = None;
+    clip = None;
+    origin = None;
+  }
+
+let background_layer_is_empty (b : background_shorthand) =
+  Option.is_none b.color && Option.is_none b.image && Option.is_none b.position
+  && Option.is_none b.size && Option.is_none b.repeat
+  && Option.is_none b.attachment
+  && Option.is_none b.clip && Option.is_none b.origin
+
+let background_layer_slots_shared (a : background_shorthand)
+    (b : background_shorthand) =
+  a.color == b.color && a.image == b.image && a.position == b.position
+  && a.size == b.size && a.repeat == b.repeat
+  && a.attachment == b.attachment
+  && a.clip == b.clip && a.origin == b.origin
+
 let normalize_background_shorthand ?(lossless = false)
     (b : background_shorthand) =
-  let color = option_map_preserve (normalize_color ~lossless) b.color in
-  let image =
-    option_map_preserve (normalize_background_image ~lossless) b.image
+  let color =
+    option_map_preserve
+      (normalize_color ~lossless)
+      (drop_initial_slot (Transparent : color) b.color)
   in
+  let image =
+    option_map_preserve
+      (normalize_background_image ~lossless)
+      (drop_initial_slot (None : background_image) b.image)
+  in
+  let repeat = drop_initial_slot (Repeat : background_repeat) b.repeat in
+  let attachment =
+    drop_initial_slot (Scroll : background_attachment) b.attachment
+  in
+  let size = drop_initial_slot (Auto : background_size) b.size in
+  (* The size is written after the position and a [/], so the position can only
+     go once the size has. *)
   let position = option_map_preserve normalize_position_value b.position in
-  if color == b.color && image == b.image && position == b.position then b
-  else { b with color; image; position }
+  let position =
+    match position with
+    | Some p when Option.is_none size && position_is_layer_initial p ->
+        (None : position_value option)
+    | _ -> position
+  in
+  let origin, clip = drop_initial_boxes b.origin b.clip in
+  let b' = { color; image; position; size; repeat; attachment; clip; origin } in
+  if background_layer_is_empty b' then drained_background_layer
+  else if background_layer_slots_shared b b' then b
+  else b'
 
 let normalize_background ?(lossless = false) : background -> background =
  fun value ->
@@ -259,6 +347,7 @@ let normalize_background ?(lossless = false) : background -> background =
   | Shorthand s ->
       let s' = normalize_background_shorthand ~lossless s in
       if s' == s then value else Shorthand s'
+  | None -> Shorthand drained_background_layer
   | other -> other
 
 let normalize_logical_border_color ?(lossless = false) :
@@ -1037,81 +1126,30 @@ let pp_border_image : border_image Pp.t =
   in
   pp_bg_prop maybe_space pp_mask_border_mode ctx mode
 
-(* CSS Backgrounds 3 2.1: the [background] shorthand's default position is [0%
-   0%]; when no [<bg-size>] is also set the position is redundant and elided
-   under minify. *)
-let position_is_default_origin (p : position_value) =
-  match p with
-  | XY (x, y) -> is_zero_length x && is_zero_length y
-  | Single x -> is_zero_length x
-  | Left_top | Top_left -> true
-  | _ -> false
-
-(* CSS Backgrounds 3 sec. 2.10: under minify, drop a longhand whose value equals
-   its [background] shorthand initial. The resolved cascade is unchanged because
-   the omitted slot inherits that same initial. *)
-let drop_initial_when_minified : 'a. Pp.ctx -> 'a -> 'a option -> 'a option =
- fun ctx initial opt ->
-  match opt with
-  | Some x when Pp.minified ctx && x = initial -> (None : _ option)
-  | _ -> opt
-
-let drop_default_position ctx (opt : position_value option) :
-    position_value option =
-  match opt with
-  | Some pos when Pp.minified ctx && position_is_default_origin pos ->
-      (None : _ option)
-  | _ -> opt
-
 let pp_background_shorthand : background_shorthand Pp.t =
  fun ctx bg ->
   let first = ref true in
   let maybe_space () = if !first then first := false else Pp.token_sp ctx () in
-
-  let size = drop_initial_when_minified ctx (Auto : background_size) bg.size in
-  let position =
-    if size = None then drop_default_position ctx bg.position else bg.position
-  in
-  let image =
-    drop_initial_when_minified ctx (None : background_image) bg.image
-  in
-  let color = drop_initial_when_minified ctx (Transparent : color) bg.color in
-  let repeat =
-    drop_initial_when_minified ctx (Repeat : background_repeat) bg.repeat
-  in
-  let attachment =
-    drop_initial_when_minified ctx
-      (Scroll : background_attachment)
-      bg.attachment
-  in
-  let origin =
-    drop_initial_when_minified ctx (Padding_box : background_box) bg.origin
-  in
-  let clip =
-    drop_initial_when_minified ctx (Border_box : background_box) bg.clip
-  in
-
-  pp_bg_prop maybe_space pp_background_image ctx image;
-  pp_bg_prop maybe_space pp_position_value ctx position;
-  pp_bg_size_with_position maybe_space { bg with position; size } ctx;
-  pp_bg_prop maybe_space pp_background_repeat ctx repeat;
-  pp_bg_prop maybe_space pp_background_attachment ctx attachment;
-  pp_bg_prop maybe_space pp_background_box ctx origin;
-  pp_bg_prop maybe_space pp_background_box ctx clip;
-  pp_bg_prop maybe_space pp_color ctx color;
-
-  if !first then Pp.string ctx (if Pp.minified ctx then "0 0" else "none")
+  pp_bg_prop maybe_space pp_background_image ctx bg.image;
+  pp_bg_prop maybe_space pp_position_value ctx bg.position;
+  pp_bg_size_with_position maybe_space bg ctx;
+  pp_bg_prop maybe_space pp_background_repeat ctx bg.repeat;
+  pp_bg_prop maybe_space pp_background_attachment ctx bg.attachment;
+  pp_bg_prop maybe_space pp_background_box ctx bg.origin;
+  pp_bg_prop maybe_space pp_background_box ctx bg.clip;
+  pp_bg_prop maybe_space pp_color ctx bg.color;
+  (* The record is public, so a caller can hand over a layer with no slot
+     filled. It declares nothing but the initial longhands, which is what
+     [background: none] declares (CSS Backgrounds 3 (ED) sec. 2.10); the empty
+     string is not a value any parser reads back. *)
+  if !first then Pp.string ctx "none"
 
 let rec pp_background : background Pp.t =
  fun ctx -> function
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
-  | None ->
-      (* CSS Backgrounds 3 sec. 2.10: [background: none] and [background: 0 0]
-         are computed-value-equivalent (both clear the image and set position to
-         [0 0]). Pick the shorter form under minify. *)
-      Pp.string ctx (if Pp.minified ctx then "0 0" else "none")
+  | None -> Pp.string ctx "none"
   | Var v -> pp_var pp_background ctx v
   | Vars vars -> Pp.list ~sep:Pp.space (pp_var pp_background) ctx vars
   | Shorthand s -> pp_background_shorthand ctx s

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -755,11 +755,6 @@ let pp_border_shorthand : border_shorthand Pp.t =
  fun ctx { width; style; color } ->
   let first = ref true in
   let add_space () = if !first then first := false else Pp.space ctx () in
-  let color =
-    match color with
-    | Some Current when Pp.minified ctx -> (None : color option)
-    | color -> color
-  in
   Option.iter
     (fun w ->
       add_space ();
@@ -1854,9 +1849,9 @@ let normalize_logical_border_width :
 
 (* CSS Backgrounds 3 (ED) sec. 3.4: a shorthand sets every longhand it covers,
    so an omitted slot takes its initial value - sec. 3.3 makes that [medium] for
-   the width, sec. 3.2 [none] for the style. An explicit initial value therefore
-   declares what leaving the slot out declares, and the shorter spelling
-   wins. *)
+   the width, sec. 3.2 [none] for the style and sec. 3.1 [currentColor] for the
+   colour. An explicit initial value therefore declares what leaving the slot
+   out declares, and the shorter spelling wins. *)
 let drop_initial_line_width (width : border_width option) : border_width option
     =
   match width with Some Medium -> Option.None | width -> width
@@ -1864,6 +1859,14 @@ let drop_initial_line_width (width : border_width option) : border_width option
 let drop_initial_line_style (style : border_style option) : border_style option
     =
   match style with Some (None : border_style) -> Option.None | style -> style
+
+(* CSS Multi-column 1 (ED) sec. 4.2 and css-logical-1 sec. 4.5.3 give
+   column-rule and the logical borders the same initial colour, and they read
+   this production. CSS UI 4 (ED) sec. 3.4 does not: outline-color starts at
+   [auto], which [currentColor] does not name, so [normalize_outline] has no
+   colour drop. *)
+let drop_initial_line_color (color : color option) : color option =
+  match color with Some (Current : color) -> Option.None | color -> color
 
 (* The width slot of the border shorthands is a [<'border-width'>], so it takes
    the same fold as the longhand; the style slot is a [<line-style>] and the
@@ -1879,7 +1882,10 @@ let normalize_border ?(lossless = false) : border -> border =
           (option_map_preserve normalize_border_width s.width)
       in
       let style = drop_initial_line_style s.style in
-      let color = option_map_preserve (normalize_color ~lossless) s.color in
+      let color =
+        drop_initial_line_color
+          (option_map_preserve (normalize_color ~lossless) s.color)
+      in
       if width == s.width && style == s.style && color == s.color then value
       else if
         Option.is_none width && Option.is_none style && Option.is_none color

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1135,14 +1135,16 @@ let pp_border_image : border_image Pp.t =
   pp_bg_prop maybe_space
     (Pp.list ~sep:Pp.space pp_border_image_repeat_keyword)
     ctx repeat;
-  (* CSS Masking 1 sec. 8.2: [alpha] is the default mode, so drop it under
-     minify; [luminance] always prints. *)
-  let mode =
-    match mode with
-    | Some Alpha when Pp.minified ctx -> (None : mask_border_mode option)
-    | _ -> mode
-  in
   pp_bg_prop maybe_space pp_mask_border_mode ctx mode
+
+(* CSS Masking 1 (ED) sec. 8.2 gives mask-border-mode the initial value [alpha],
+   and sec. 8.7 sets an omitted shorthand slot to its initial value, so an
+   explicit [alpha] declares what leaving the slot out declares. [luminance] is
+   the other mode and stays. *)
+let normalize_mask_border (value : border_image) : border_image =
+  match value.mode with
+  | Some (Alpha : mask_border_mode) -> { value with mode = Option.None }
+  | _ -> value
 
 let pp_background_shorthand : background_shorthand Pp.t =
  fun ctx bg ->

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1291,6 +1291,12 @@ module Border = struct
     }
 end
 
+(* CSS Backgrounds 3 (ED) sec. 3.4 writes the shorthand as [<line-width> ||
+   <line-style> || <color>], and CSS Values 4 (ED) sec. 2.2 has [||] require one
+   or more of its options to occur, so an empty value matches no border grammar.
+   CSS Syntax 3 (ED) sec. 5.5.6 keeps only a declaration valid in its context,
+   so the whole declaration goes; filling the slots in from nowhere would
+   declare something the author did not write. *)
 let read_border_shorthand t : border_shorthand =
   (* A [var()] in the border shorthand is type-ambiguous (it could substitute a
      width, style, or colour), so it cannot be assigned by matching a typed
@@ -1321,7 +1327,12 @@ let read_border_shorthand t : border_shorthand =
             true
         | Option.None -> false
   done;
-  Border.to_shorthand !acc
+  let acc = !acc in
+  if
+    Option.is_none acc.width && Option.is_none acc.style
+    && Option.is_none acc.color
+  then Cursor.err_expected t "border width, style or color";
+  Border.to_shorthand acc
 
 let border_keyword = function
   | "inherit" -> Some (Inherit : border)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -225,27 +225,28 @@ let rec pp_border_radius : border_radius Pp.t =
           Pp.sp ctx ();
           pp_box_shorthand (pp_length_percentage ~always:true) ctx vs)
 
+(* CSS Backgrounds 3 (ED) sec. 4.1 puts the vertical radii after a [/], so each
+   group collapses on its own and neither reaches across the slash. With no
+   slash the values set both axes equally, so a vertical group equal to the
+   horizontal one says what omitting it says. *)
 let normalize_border_radius ?(strip = true) : border_radius -> border_radius =
  fun value ->
+  let group vs =
+    collapse_box_shorthand
+      (map_preserve (Values.normalize_length_percentage ~strip) vs)
+  in
   match value with
   | Radius { horizontal; vertical } ->
-      preserve_if_equal value
-        (Radius
-           {
-             horizontal =
-               collapse_box_shorthand
-                 (map_preserve
-                    (Values.normalize_length_percentage ~strip)
-                    horizontal);
-             vertical =
-               option_map_preserve
-                 (fun vs ->
-                   collapse_box_shorthand
-                     (map_preserve
-                        (Values.normalize_length_percentage ~strip)
-                        vs))
-                 vertical;
-           })
+      let horizontal = group horizontal in
+      let vertical = option_map_preserve group vertical in
+      let vertical =
+        match vertical with
+        | Some vs when List.equal Values.equal_length_percentage horizontal vs
+          ->
+            Option.None
+        | _ -> vertical
+      in
+      preserve_if_equal value (Radius { horizontal; vertical })
   | other -> other
 
 (* CSS Backgrounds 3 (ED) sec. 2.10: the shorthand resets every longhand it
@@ -939,10 +940,24 @@ let rec pp_logical_border_width : logical_border_width Pp.t =
 
 let rec pp_border_spacing : border_spacing Pp.t =
  fun ctx -> function
-  | Lengths [ a; b ] when Values.equal_length a b -> pp_length ctx a
   | (Lengths lengths : border_spacing) ->
       Pp.list ~sep:Pp.space pp_length ctx lengths
   | Var v -> pp_var pp_border_spacing ctx v
+
+(* CSS Tables 3 (ED) writes [border-spacing] as one or two non-negative lengths
+   and reads a single one as "both the horizontal and vertical spacing", so a
+   pair of equal lengths is the longer spelling of that one value. The per-side
+   fold runs first, so a pair that only agrees once normalised collapses too. *)
+and normalize_border_spacing : border_spacing -> border_spacing =
+ fun value ->
+  match value with
+  | Lengths lengths -> (
+      let normalized = map_preserve Values.normalize_length lengths in
+      match normalized with
+      | [ a; b ] when Values.equal_length a b -> Lengths [ a ]
+      | _ when normalized == lengths -> value
+      | _ -> Lengths normalized)
+  | Var _ -> value
 
 let rec pp_background_attachment : background_attachment Pp.t =
  fun ctx -> function

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -296,6 +296,24 @@ let drained_background_layer : background_shorthand =
     origin = None;
   }
 
+(* CSS Backgrounds 3 (ED) sec. 2.4 lists the pair each single [<repeat-style>]
+   keyword computes to, so every pair that appears there has a one-keyword
+   spelling of the same value and the shorter one wins. The pairs with two
+   different axes and no alias stay as written. *)
+let rec normalize_background_repeat : background_repeat -> background_repeat =
+ fun value ->
+  match value with
+  | Layers layers ->
+      preserve_if_equal value
+        (Layers (map_preserve normalize_background_repeat layers))
+  | Repeat_repeat -> Repeat
+  | Space_space -> Space
+  | Round_round -> Round
+  | No_repeat_no_repeat -> No_repeat
+  | Repeat_no_repeat -> Repeat_x
+  | No_repeat_repeat -> Repeat_y
+  | other -> other
+
 let background_layer_is_empty (b : background_shorthand) =
   Option.is_none b.color && Option.is_none b.image && Option.is_none b.position
   && Option.is_none b.size && Option.is_none b.repeat
@@ -321,7 +339,11 @@ let normalize_background_shorthand ?(lossless = false)
       (normalize_background_image ~lossless)
       (drop_initial_slot (None : background_image) b.image)
   in
-  let repeat = drop_initial_slot (Repeat : background_repeat) b.repeat in
+  let repeat =
+    drop_initial_slot
+      (Repeat : background_repeat)
+      (option_map_preserve normalize_background_repeat b.repeat)
+  in
   let attachment =
     drop_initial_slot (Scroll : background_attachment) b.attachment
   in
@@ -940,15 +962,6 @@ let rec pp_background_repeat : background_repeat Pp.t =
   | No_repeat -> Pp.string ctx "no-repeat"
   | Repeat_x -> Pp.string ctx "repeat-x"
   | Repeat_y -> Pp.string ctx "repeat-y"
-  (* CSS Backgrounds 3 sec. 2.6.1: the two-value forms collapse when both axes
-     match ([X X] -> [X]) or when they alias a single-keyword shorthand ([repeat
-     no-repeat] -> [repeat-x], [no-repeat repeat] -> [repeat-y]). *)
-  | Repeat_repeat when Pp.minified ctx -> Pp.string ctx "repeat"
-  | Space_space when Pp.minified ctx -> Pp.string ctx "space"
-  | Round_round when Pp.minified ctx -> Pp.string ctx "round"
-  | No_repeat_no_repeat when Pp.minified ctx -> Pp.string ctx "no-repeat"
-  | Repeat_no_repeat when Pp.minified ctx -> Pp.string ctx "repeat-x"
-  | No_repeat_repeat when Pp.minified ctx -> Pp.string ctx "repeat-y"
   | Repeat_repeat -> Pp.string ctx "repeat repeat"
   | Repeat_space -> Pp.string ctx "repeat space"
   | Repeat_round -> Pp.string ctx "repeat round"

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -233,12 +233,17 @@ let normalize_border_radius ?(strip = true) : border_radius -> border_radius =
         (Radius
            {
              horizontal =
-               map_preserve
-                 (Values.normalize_length_percentage ~strip)
-                 horizontal;
+               collapse_box_shorthand
+                 (map_preserve
+                    (Values.normalize_length_percentage ~strip)
+                    horizontal);
              vertical =
                option_map_preserve
-                 (map_preserve (Values.normalize_length_percentage ~strip))
+                 (fun vs ->
+                   collapse_box_shorthand
+                     (map_preserve
+                        (Values.normalize_length_percentage ~strip)
+                        vs))
                  vertical;
            })
   | other -> other

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -138,11 +138,14 @@ let is_zero_length : length -> bool = function
       true
   | _ -> false
 
-(* CSS Box 4 (ED) sec. 3.2 and sec. 4.2: one value applies to all four sides,
-   two set the top/bottom and the right/left pairs, three set the top, then the
-   left and right, then the bottom. A shorthand whose sides repeat therefore has
-   a shorter spelling naming the same sides: [a a a a] -> [a]; [a b a b] -> [a
-   b]; [a b c b] -> [a b c]. *)
+(* CSS Box 4 (ED) sec. 3.2 fills the four sides from a one-to-four value box
+   shorthand: one value goes to all four, two to top-bottom then left-right,
+   three to top, left-right, bottom. A list that repeats what those rules
+   already supply is the longer spelling of the same declaration, so it
+   collapses: [a a a a] -> [a]; [a b a b] -> [a b]; [a b c b] -> [a b c]. sec.
+   4.2 says the same for padding, css-logical-1 sec. 4.3 and sec. 4.4 for the
+   inset and logical padding/margin shorthands, and CSS Backgrounds 3 (ED) sec.
+   3.1 and sec. 4.1 for border-color and border-radius. *)
 let collapse_box_shorthand vs =
   match vs with
   | [ a; b; c; d ] when a = b && b = c && c = d -> [ a ]
@@ -153,9 +156,7 @@ let collapse_box_shorthand vs =
   | [ a; b ] when a = b -> [ a ]
   | _ -> vs
 
-let pp_box_shorthand pp ctx vs =
-  let vs = if Pp.minified ctx then collapse_box_shorthand vs else vs in
-  Pp.list ~sep:Pp.token_sp pp ctx vs
+let pp_box_shorthand pp ctx vs = Pp.list ~sep:Pp.token_sp pp ctx vs
 
 (* Canonicalise a colour to its shortest spelling. *)
 let normalize_color ?(lossless = false) = Values.normalize_color ~lossless

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -641,7 +641,12 @@ let pp_outline_shorthand : outline_shorthand Pp.t =
     (fun c ->
       add_space ();
       pp_color ctx c)
-    color
+    color;
+  (* The record is public, so a caller can hand over a value with no slot
+     filled. It declares nothing but the initial longhands, which is what
+     [outline: none] declares (CSS UI 4 (ED) sec. 3.1); the empty string is not
+     a value any parser reads back. *)
+  if !first then Pp.string ctx "none"
 
 let rec pp_outline : outline Pp.t =
  fun ctx -> function
@@ -1250,6 +1255,10 @@ let read_outline_parts ~width ~style ~color t =
   in
   loop ()
 
+(* CSS UI 4 (ED) sec. 3.1 writes the shorthand as [<'outline-width'> ||
+   <'outline-style'> || <'outline-color'>], and CSS Values 4 (ED) sec. 2.2 has
+   [||] require one or more of its options to occur, so an empty value matches
+   no outline grammar and CSS Syntax 3 (ED) sec. 5.5.6 drops the declaration. *)
 let read_outline_shorthand_value t : outline =
   let width = ref Option.None in
   let style = ref Option.None in
@@ -1257,6 +1266,8 @@ let read_outline_shorthand_value t : outline =
   read_outline_parts ~width ~style ~color t;
   match (!width, !style, !color) with
   | Option.None, Some (None : outline_style), Option.None -> None
+  | Option.None, Option.None, Option.None ->
+      Cursor.err_expected t "outline width, style or color"
   | _ -> Shorthand { width = !width; style = !style; color = !color }
 
 let rec read_outline t : outline =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3536,6 +3536,7 @@ let normalize_property_value : type a.
   | Webkit_mask_image -> normalize_background_image ~lossless value
   | Border_image_source -> normalize_background_image ~lossless value
   | Background -> map_preserve (normalize_background ~lossless) value
+  | Background_repeat -> normalize_background_repeat value
   | Mask -> normalize_mask ~lossless value
   | Clip_path -> normalize_clip_path value
   | Object_view_box -> normalize_object_view_box value

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3538,6 +3538,7 @@ let normalize_property_value : type a.
   | Background -> map_preserve (normalize_background ~lossless) value
   | Background_repeat -> normalize_background_repeat value
   | Mask_border -> normalize_mask_border value
+  | Border_spacing -> normalize_border_spacing value
   | Mask -> normalize_mask ~lossless value
   | Clip_path -> normalize_clip_path value
   | Object_view_box -> normalize_object_view_box value

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3537,6 +3537,7 @@ let normalize_property_value : type a.
   | Border_image_source -> normalize_background_image ~lossless value
   | Background -> map_preserve (normalize_background ~lossless) value
   | Background_repeat -> normalize_background_repeat value
+  | Mask_border -> normalize_mask_border value
   | Mask -> normalize_mask ~lossless value
   | Clip_path -> normalize_clip_path value
   | Object_view_box -> normalize_object_view_box value

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -5119,6 +5119,7 @@ let equal_initial_letter_align_keyword (a : initial_letter_align_keyword) b =
 
 let equal_ruby_position_keyword (a : ruby_position_keyword) b = a = b
 let equal_background_shorthand (a : background_shorthand) b = a = b
+let equal_background_box (a : background_box) b = a = b
 let equal_mask_layer (a : mask_layer) b = a = b
 let equal_position_area_keyword (a : position_area_keyword) b = a = b
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1251,6 +1251,76 @@ let border_line_style () =
   check_declaration ~expected:"outline:auto" ~optimized:"outline:auto"
     "outline: auto"
 
+(* CSS Syntax 3 (ED) sec. 5.5.6 keeps a parsed declaration only if it "is valid
+   in the current context", which for a non-custom property means its value
+   matches the property's grammar. CSS Backgrounds 3 (ED) sec. 3.4 writes the
+   border shorthands as [<line-width> || <line-style> || <color>], css-logical-1
+   sec. 4.5.4 and CSS Multi-column 1 (ED) sec. 4.5 route the logical shorthands
+   and column-rule through the same production, and CSS UI 4 (ED) sec. 3.1
+   writes outline the same way. CSS Values 4 (ED) sec. 2.2 has [||] require one
+   or more of its options to occur, so nothing at all matches none of these
+   grammars: the declaration is dropped, not filled in with a value nobody
+   wrote. *)
+let empty_shorthand_value () =
+  List.iter
+    (fun prop -> neg_cursor read_declaration (prop ^ ": "))
+    [
+      "border";
+      "border-top";
+      "border-right";
+      "border-bottom";
+      "border-left";
+      "border-block";
+      "border-block-start";
+      "border-block-end";
+      "border-inline";
+      "border-inline-start";
+      "border-inline-end";
+      "column-rule";
+      "outline";
+    ];
+  (* Whitespace is discarded before the value is read, so a run of it is still
+     an empty value. *)
+  neg_cursor read_declaration "border:";
+  neg_cursor read_declaration "outline:   ";
+  (* Controls: every slot is optional, so any one of them is a whole value. *)
+  check_declaration ~expected:"border:none" ~optimized:"border:none"
+    "border: none";
+  check_declaration ~expected:"border:1px solid red"
+    ~optimized:"border:1px solid red" "border: 1px solid red";
+  check_declaration ~expected:"outline:none" ~optimized:"outline:none"
+    "outline: none";
+  check_declaration ~expected:"outline:auto" ~optimized:"outline:auto"
+    "outline: auto";
+  check_declaration ~expected:"column-rule:1px solid red"
+    ~optimized:"column-rule:1px solid red" "column-rule: 1px solid red"
+
+(* The record behind each shorthand is public, so a caller can hand the printer
+   a value with no slot filled. That value declares nothing but the initial
+   longhands, which is what the [none] keyword declares (CSS Backgrounds 3 (ED)
+   sec. 3.4, CSS UI 4 (ED) sec. 3.1), and [none] is the spelling that says so.
+   An empty string is not a spelling of anything: no parser accepts it. *)
+let all_initial_shorthand_prints_none () =
+  let pp v = Css.Pp.to_string ~minify:true Css.Declaration.pp v in
+  let border : Css.border =
+    Shorthand { width = None; style = None; color = None }
+  in
+  let outline : Css.outline =
+    Shorthand { width = None; style = None; color = None }
+  in
+  Alcotest.(check string)
+    "drained border shorthand" "border:none"
+    (pp (Css.Declaration.v Border border));
+  Alcotest.(check string)
+    "drained outline shorthand" "outline:none"
+    (pp (Css.Declaration.v Outline outline));
+  Alcotest.(check string)
+    "outline_shorthand with no slot" "outline:none"
+    (pp (Css.Declaration.outline (Css.outline_shorthand ())));
+  Alcotest.(check string)
+    "border_shorthand with no slot" "border:none"
+    (pp (Css.Declaration.v Border (Css.border_shorthand ())))
+
 let logical_border_shorthands () =
   (* css-logical-1 sec. 4.4.1: border-block-start, border-block-end,
      border-inline-start and border-inline-end take <'border-top-width'> ||
@@ -4074,6 +4144,9 @@ let declaration_tests =
     test_case "outline line-width" `Quick outline_line_width;
     test_case "border line-width" `Quick border_line_width;
     test_case "border line-style" `Quick border_line_style;
+    test_case "empty shorthand value" `Quick empty_shorthand_value;
+    test_case "all-initial shorthand prints none" `Quick
+      all_initial_shorthand_prints_none;
     test_case "logical border shorthands" `Quick logical_border_shorthands;
     test_case "overflow" `Quick overflow;
     test_case "animations (timing)" `Quick animations_timing;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1251,6 +1251,44 @@ let border_line_style () =
   check_declaration ~expected:"outline:auto" ~optimized:"outline:auto"
     "outline: auto"
 
+(* CSS Backgrounds 3 (ED) sec. 3.1 gives the border-color properties the initial
+   value [currentColor], and sec. 3.4 sets an omitted shorthand slot to its
+   initial value, so an explicit [currentColor] beside another slot says what
+   leaving the colour out already says. Drained of every slot the shorthand
+   declares nothing but initial values, which is what [none] declares. CSS
+   Multi-column 1 (ED) sec. 4.2 and css-logical-1 sec. 4.5.3 give column-rule
+   and the logical borders the same initial colour, so they take the same fold.
+
+   CSS UI 4 (ED) sec. 3.4 does not: outline-color's initial value is [auto], a
+   UA-chosen colour that [currentColor] does not name, so the outline colour
+   slot holds whatever it was written with. *)
+let border_line_color () =
+  check_declaration ~expected:"border:solid currentColor"
+    ~optimized:"border:solid" "border: solid currentcolor";
+  check_declaration ~expected:"border:1px solid currentColor"
+    ~optimized:"border:1px solid" "border: 1px solid currentColor";
+  check_declaration ~expected:"border:currentColor" ~optimized:"border:none"
+    "border: currentcolor";
+  check_declaration ~expected:"border-top:solid currentColor"
+    ~optimized:"border-top:solid" "border-top: solid currentcolor";
+  check_declaration ~expected:"border-inline:solid currentColor"
+    ~optimized:"border-inline:solid" "border-inline: solid currentcolor";
+  check_declaration ~expected:"border-block-start:solid currentColor"
+    ~optimized:"border-block-start:solid"
+    "border-block-start: solid currentcolor";
+  check_declaration ~expected:"column-rule:solid currentColor"
+    ~optimized:"column-rule:solid" "column-rule: solid currentcolor";
+  (* outline-color's initial value is [auto], so nothing drops here. *)
+  check_declaration ~expected:"outline:solid currentColor"
+    ~optimized:"outline:solid currentColor" "outline: solid currentcolor";
+  check_declaration ~expected:"outline:currentColor"
+    ~optimized:"outline:currentColor" "outline: currentcolor";
+  (* Controls: a colour that is not the initial one stands. *)
+  check_declaration ~expected:"border:solid red" ~optimized:"border:solid red"
+    "border: solid red";
+  check_declaration ~expected:"column-rule:solid red"
+    ~optimized:"column-rule:solid red" "column-rule: solid red"
+
 (* CSS Syntax 3 (ED) sec. 5.5.6 keeps a parsed declaration only if it "is valid
    in the current context", which for a non-custom property means its value
    matches the property's grammar. CSS Backgrounds 3 (ED) sec. 3.4 writes the
@@ -4144,6 +4182,7 @@ let declaration_tests =
     test_case "outline line-width" `Quick outline_line_width;
     test_case "border line-width" `Quick border_line_width;
     test_case "border line-style" `Quick border_line_style;
+    test_case "border line-color" `Quick border_line_color;
     test_case "empty shorthand value" `Quick empty_shorthand_value;
     test_case "all-initial shorthand prints none" `Quick
       all_initial_shorthand_prints_none;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1329,6 +1329,19 @@ let background_box_slots () =
     ~optimized:"background:content-box border-box red"
     "background: red content-box border-box"
 
+(* CSS Masking 1 (ED) sec. 8.2 gives mask-border-mode the initial value [alpha],
+   and sec. 8.7 sets an omitted shorthand slot to its initial value, so an
+   explicit [alpha] says what leaving the slot out says. [luminance] is the
+   other mode and stays. *)
+let mask_border_mode_slot () =
+  check_declaration ~expected:"mask-border:url(a.png)alpha"
+    ~optimized:"mask-border:url(a.png)" "mask-border: url(a.png) alpha";
+  check_declaration ~expected:"mask-border:url(a.png)luminance"
+    ~optimized:"mask-border:url(a.png)luminance"
+    "mask-border: url(a.png) luminance";
+  check_declaration ~expected:"border-image:url(a.png)"
+    ~optimized:"border-image:url(a.png)" "border-image: url(a.png)"
+
 (* CSS Box 4 (ED) sec. 3.2 assigns the values of a one-to-four value box
    shorthand to the four sides: one value goes to all four, two to top-bottom
    then left-right, three to top, left-right, bottom. A repeat that those rules
@@ -4362,6 +4375,7 @@ let declaration_tests =
     test_case "background initial slots" `Quick background_initial_slots;
     test_case "background position slot" `Quick background_position_slot;
     test_case "background box slots" `Quick background_box_slots;
+    test_case "mask-border mode slot" `Quick mask_border_mode_slot;
     test_case "box shorthand repeats" `Quick box_shorthand_repeats;
     test_case "background repeat axes" `Quick background_repeat_axes;
     test_case "background drained layer" `Quick background_drained_layer;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1251,6 +1251,96 @@ let border_line_style () =
   check_declaration ~expected:"outline:auto" ~optimized:"outline:auto"
     "outline: auto"
 
+(* CSS Backgrounds 3 (ED) sec. 2.10 has the [background] shorthand reset every
+   longhand it covers and then set the ones written, so a slot holding its own
+   initial value says what leaving it out says: sec. 2.3 makes that [none] for
+   the image, sec. 2.4 [repeat] for the repeat, sec. 2.5 [scroll] for the
+   attachment, sec. 2.9 [auto] for the size and sec. 2.2 [transparent] for the
+   colour. The fold is the optimizer's; pp holds the node it was handed. *)
+let background_initial_slots () =
+  check_declaration ~expected:"background:none red" ~optimized:"background:red"
+    "background: none red";
+  check_declaration ~expected:"background:repeat red"
+    ~optimized:"background:red" "background: red repeat";
+  check_declaration ~expected:"background:scroll red"
+    ~optimized:"background:red" "background: red scroll";
+  check_declaration ~expected:"background:url(a.png)transparent"
+    ~optimized:"background:url(a.png)" "background: url(a.png) transparent";
+  (* Controls: a slot that is not at its initial value stands. *)
+  check_declaration ~expected:"background:no-repeat red"
+    ~optimized:"background:no-repeat red" "background: red no-repeat";
+  check_declaration ~expected:"background:fixed red"
+    ~optimized:"background:fixed red" "background: red fixed";
+  check_declaration ~expected:"background:url(a.png)red"
+    ~optimized:"background:url(a.png)red" "background: url(a.png) red"
+
+(* CSS Backgrounds 3 (ED) sec. 2.6 gives background-position the initial value
+   [0% 0%], which [0 0] and [left top] both name, so the slot drops with the
+   rest. It also reads a lone value as "the second value is assumed to be
+   center", so [0] names [0 50%] and stays: no initial position is spelled that
+   way. sec. 2.10 writes the size after the position and a [/], so the position
+   can only leave once the size has. *)
+let background_position_slot () =
+  check_declaration ~expected:"background:0 0 red" ~optimized:"background:red"
+    "background: red 0 0";
+  check_declaration ~expected:"background:left top red"
+    ~optimized:"background:red" "background: red left top";
+  check_declaration ~expected:"background:0 0/auto red"
+    ~optimized:"background:red" "background: red 0 0 / auto";
+  (* A single value is horizontal, with [center] vertically: not the initial
+     position, so it stays whatever the layer carries. *)
+  check_declaration ~expected:"background:0 red" ~optimized:"background:0 red"
+    "background: red 0";
+  check_declaration ~expected:"background:left red"
+    ~optimized:"background:0 red" "background: red left";
+  check_declaration ~expected:"background:url(a.png)0"
+    ~optimized:"background:url(a.png)0" "background: url(a.png) 0";
+  check_declaration ~expected:"background:url(a.png)left"
+    ~optimized:"background:url(a.png)0" "background: url(a.png) left";
+  (* A size keeps its position, which has to be written for the [/] to attach
+     to. *)
+  check_declaration ~expected:"background:0 0/cover red"
+    ~optimized:"background:0 0/cover red" "background: red 0 0 / cover"
+
+(* CSS Backgrounds 3 (ED) sec. 2.10 reads one [<box>] as setting both
+   background-origin and background-clip and two as setting origin then clip, so
+   the pair drops together or not at all: sec. 2.8 makes [padding-box] the
+   initial origin and sec. 2.7 [border-box] the initial clip. Dropping just the
+   one at its initial value would leave a single [<box>] that reassigns the
+   other. *)
+let background_box_slots () =
+  check_declaration ~expected:"background:padding-box border-box red"
+    ~optimized:"background:red" "background: red padding-box border-box";
+  check_declaration ~expected:"background:border-box border-box red"
+    ~optimized:"background:border-box red"
+    "background: red border-box border-box";
+  check_declaration ~expected:"background:content-box content-box red"
+    ~optimized:"background:content-box red"
+    "background: red content-box content-box";
+  check_declaration ~expected:"background:border-box border-box red"
+    ~optimized:"background:border-box red" "background: red border-box";
+  (* Both are written out where a single [<box>] would name a different pair. *)
+  check_declaration ~expected:"background:padding-box content-box red"
+    ~optimized:"background:padding-box content-box red"
+    "background: red padding-box content-box";
+  check_declaration ~expected:"background:content-box border-box red"
+    ~optimized:"background:content-box border-box red"
+    "background: red content-box border-box"
+
+(* CSS Backgrounds 3 (ED) sec. 2.10 resets every longhand the shorthand covers,
+   so a layer that fills no slot declares what [background: none] declares. [0
+   0] is the shortest spelling of that layer, so it is the node the spellings
+   meet on. *)
+let background_drained_layer () =
+  check_declaration ~expected:"background:none" ~optimized:"background:0 0"
+    "background: none";
+  check_declaration ~expected:"background:0 0" ~optimized:"background:0 0"
+    "background: 0 0";
+  check_declaration ~expected:"background:left top" ~optimized:"background:0 0"
+    "background: left top";
+  check_declaration ~expected:"background:transparent"
+    ~optimized:"background:0 0" "background: transparent"
+
 (* CSS Backgrounds 3 (ED) sec. 3.1 gives the border-color properties the initial
    value [currentColor], and sec. 3.4 sets an omitted shorthand slot to its
    initial value, so an explicit [currentColor] beside another slot says what
@@ -4184,6 +4274,10 @@ let declaration_tests =
     test_case "outline line-width" `Quick outline_line_width;
     test_case "border line-width" `Quick border_line_width;
     test_case "border line-style" `Quick border_line_style;
+    test_case "background initial slots" `Quick background_initial_slots;
+    test_case "background position slot" `Quick background_position_slot;
+    test_case "background box slots" `Quick background_box_slots;
+    test_case "background drained layer" `Quick background_drained_layer;
     test_case "border line-color" `Quick border_line_color;
     test_case "empty shorthand value" `Quick empty_shorthand_value;
     test_case "all-initial shorthand prints none" `Quick

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1329,6 +1329,49 @@ let background_box_slots () =
     ~optimized:"background:content-box border-box red"
     "background: red content-box border-box"
 
+(* CSS Backgrounds 3 (ED) sec. 2.4 gives every single [<repeat-style>] keyword
+   the pair it computes to: [repeat] is [repeat repeat], [space] is [space
+   space], [round] is [round round], [no-repeat] is [no-repeat no-repeat],
+   [repeat-x] is [repeat no-repeat] and [repeat-y] is [no-repeat repeat]. Each
+   pair therefore has a one-keyword spelling of the same value, and the
+   optimizer picks it; pp prints the pair it was handed. *)
+let background_repeat_axes () =
+  check_declaration ~expected:"background-repeat:repeat repeat"
+    ~optimized:"background-repeat:repeat" "background-repeat: repeat repeat";
+  check_declaration ~expected:"background-repeat:space space"
+    ~optimized:"background-repeat:space" "background-repeat: space space";
+  check_declaration ~expected:"background-repeat:round round"
+    ~optimized:"background-repeat:round" "background-repeat: round round";
+  check_declaration ~expected:"background-repeat:no-repeat no-repeat"
+    ~optimized:"background-repeat:no-repeat"
+    "background-repeat: no-repeat no-repeat";
+  check_declaration ~expected:"background-repeat:repeat no-repeat"
+    ~optimized:"background-repeat:repeat-x"
+    "background-repeat: repeat no-repeat";
+  check_declaration ~expected:"background-repeat:no-repeat repeat"
+    ~optimized:"background-repeat:repeat-y"
+    "background-repeat: no-repeat repeat";
+  (* Each layer of the comma-separated list folds on its own. *)
+  check_declaration ~expected:"background-repeat:repeat repeat,space space"
+    ~optimized:"background-repeat:repeat,space"
+    "background-repeat: repeat repeat, space space";
+  (* The shorthand's repeat slot reads the same production, so the fold reaches
+     it and leaves the slot at its initial value (sec. 2.4). *)
+  check_declaration ~expected:"background:repeat repeat red"
+    ~optimized:"background:red" "background: red repeat repeat";
+  (* Controls: a pair with two different axes has no one-keyword spelling, and
+     the one-keyword forms are already the node they fold to. *)
+  check_declaration ~expected:"background-repeat:repeat space"
+    ~optimized:"background-repeat:repeat space"
+    "background-repeat: repeat space";
+  check_declaration ~expected:"background-repeat:space no-repeat"
+    ~optimized:"background-repeat:space no-repeat"
+    "background-repeat: space no-repeat";
+  check_declaration ~expected:"background-repeat:repeat-x"
+    ~optimized:"background-repeat:repeat-x" "background-repeat: repeat-x";
+  check_declaration ~expected:"background-repeat:repeat"
+    ~optimized:"background-repeat:repeat" "background-repeat: repeat"
+
 (* CSS Backgrounds 3 (ED) sec. 2.10 resets every longhand the shorthand covers,
    so a layer that fills no slot declares what [background: none] declares. [0
    0] is the shortest spelling of that layer, so it is the node the spellings
@@ -4279,6 +4322,7 @@ let declaration_tests =
     test_case "background initial slots" `Quick background_initial_slots;
     test_case "background position slot" `Quick background_position_slot;
     test_case "background box slots" `Quick background_box_slots;
+    test_case "background repeat axes" `Quick background_repeat_axes;
     test_case "background drained layer" `Quick background_drained_layer;
     test_case "border line-color" `Quick border_line_color;
     test_case "empty shorthand value" `Quick empty_shorthand_value;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1329,6 +1329,46 @@ let background_box_slots () =
     ~optimized:"background:content-box border-box red"
     "background: red content-box border-box"
 
+(* CSS Box 4 (ED) sec. 3.2 assigns the values of a one-to-four value box
+   shorthand to the four sides: one value goes to all four, two to top-bottom
+   then left-right, three to top, left-right, bottom. A repeat that those rules
+   already supply is the longer spelling of the same declaration, so the
+   optimizer drops it and pp prints the list it was handed. sec. 4.2 says the
+   same for padding, css-logical-1 sec. 4.3 assigns inset's values "as for
+   margin" and sec. 4.4 padding-block/padding-inline's, and CSS Backgrounds 3
+   (ED) sec. 3.1 and sec. 4.1 give border-color and border-radius the same
+   four-value form. *)
+let box_shorthand_repeats () =
+  check_declaration ~expected:"inset:0 0 0 0" ~optimized:"inset:0"
+    "inset: 0 0 0 0";
+  check_declaration ~expected:"margin:1px 1px 1px 1px" ~optimized:"margin:1px"
+    "margin: 1px 1px 1px 1px";
+  check_declaration ~expected:"padding:1px 2px 1px 2px"
+    ~optimized:"padding:1px 2px" "padding: 1px 2px 1px 2px";
+  check_declaration ~expected:"margin:1px 2px 3px 2px"
+    ~optimized:"margin:1px 2px 3px" "margin: 1px 2px 3px 2px";
+  check_declaration ~expected:"margin:1px 1px 2px"
+    ~optimized:"margin:1px 1px 2px" "margin: 1px 1px 2px";
+  check_declaration ~expected:"border-color:red red red red"
+    ~optimized:"border-color:red" "border-color: red red red red";
+  check_declaration ~expected:"inset-block:0 0" ~optimized:"inset-block:0"
+    "inset-block: 0 0";
+  check_declaration ~expected:"padding-inline:1px 1px"
+    ~optimized:"padding-inline:1px" "padding-inline: 1px 1px";
+  check_declaration ~expected:"border-radius:1px 1px 1px 1px"
+    ~optimized:"border-radius:1px" "border-radius: 1px 1px 1px 1px";
+  (* The per-side folds run first, so sides that only agree once normalised
+     still collapse. *)
+  check_declaration ~expected:"margin:0px 0 0px 0" ~optimized:"margin:0"
+    "margin: 0px 0 0px 0";
+  (* Controls: a list the rules cannot rebuild stays as written. *)
+  check_declaration ~expected:"margin:1px 2px" ~optimized:"margin:1px 2px"
+    "margin: 1px 2px";
+  check_declaration ~expected:"margin:1px 2px 3px 4px"
+    ~optimized:"margin:1px 2px 3px 4px" "margin: 1px 2px 3px 4px";
+  check_declaration ~expected:"padding:1px 2px 1px 3px"
+    ~optimized:"padding:1px 2px 1px 3px" "padding: 1px 2px 1px 3px"
+
 (* CSS Backgrounds 3 (ED) sec. 2.4 gives every single [<repeat-style>] keyword
    the pair it computes to: [repeat] is [repeat repeat], [space] is [space
    space], [round] is [round round], [no-repeat] is [no-repeat no-repeat],
@@ -4322,6 +4362,7 @@ let declaration_tests =
     test_case "background initial slots" `Quick background_initial_slots;
     test_case "background position slot" `Quick background_position_slot;
     test_case "background box slots" `Quick background_box_slots;
+    test_case "box shorthand repeats" `Quick box_shorthand_repeats;
     test_case "background repeat axes" `Quick background_repeat_axes;
     test_case "background drained layer" `Quick background_drained_layer;
     test_case "border line-color" `Quick border_line_color;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1370,6 +1370,24 @@ let box_shorthand_repeats () =
     ~optimized:"padding-inline:1px" "padding-inline: 1px 1px";
   check_declaration ~expected:"border-radius:1px 1px 1px 1px"
     ~optimized:"border-radius:1px" "border-radius: 1px 1px 1px 1px";
+  (* CSS Backgrounds 3 (ED) sec. 4.1 puts the vertical radii after a [/], so
+     each group collapses on its own and neither reaches across the slash. With
+     no slash the values set both axes equally, so a vertical group equal to the
+     horizontal one says what omitting it says. *)
+  check_declaration
+    ~expected:"border-radius:5px 5px 5px 5px/10px 10px 10px 10px"
+    ~optimized:"border-radius:5px/10px"
+    "border-radius: 5px 5px 5px 5px / 10px 10px 10px 10px";
+  check_declaration ~expected:"border-radius:5px 10px 5px 10px/1px 2px 1px 2px"
+    ~optimized:"border-radius:5px 10px/1px 2px"
+    "border-radius: 5px 10px 5px 10px / 1px 2px 1px 2px";
+  check_declaration ~expected:"border-radius:5px/5px"
+    ~optimized:"border-radius:5px" "border-radius: 5px / 5px";
+  check_declaration ~expected:"border-radius:5px 10px/5px 10px"
+    ~optimized:"border-radius:5px 10px" "border-radius: 5px 10px / 5px 10px";
+  (* Control: the two axes differ, so both groups are written. *)
+  check_declaration ~expected:"border-radius:5px/10px"
+    ~optimized:"border-radius:5px/10px" "border-radius: 5px / 10px";
   (* The per-side folds run first, so sides that only agree once normalised
      still collapse. *)
   check_declaration ~expected:"margin:0px 0 0px 0" ~optimized:"margin:0"
@@ -1381,6 +1399,23 @@ let box_shorthand_repeats () =
     ~optimized:"margin:1px 2px 3px 4px" "margin: 1px 2px 3px 4px";
   check_declaration ~expected:"padding:1px 2px 1px 3px"
     ~optimized:"padding:1px 2px 1px 3px" "padding: 1px 2px 1px 3px"
+
+(* CSS Tables 3 (ED) writes [border-spacing] as one or two non-negative lengths
+   and reads a single one as "both the horizontal and vertical spacing", so a
+   pair of equal lengths is the longer spelling of that one value. The per-side
+   fold runs first, so a pair that only agrees once normalised collapses too. *)
+let border_spacing_pair () =
+  check_declaration ~expected:"border-spacing:1px 1px"
+    ~optimized:"border-spacing:1px" "border-spacing: 1px 1px";
+  check_declaration ~expected:"border-spacing:0px 0"
+    ~optimized:"border-spacing:0" "border-spacing: 0px 0";
+  check_declaration ~expected:"border-spacing:0px" ~optimized:"border-spacing:0"
+    "border-spacing: 0px";
+  (* Controls: two different lengths name two different spacings. *)
+  check_declaration ~expected:"border-spacing:1px 2px"
+    ~optimized:"border-spacing:1px 2px" "border-spacing: 1px 2px";
+  check_declaration ~expected:"border-spacing:1px"
+    ~optimized:"border-spacing:1px" "border-spacing: 1px"
 
 (* CSS Backgrounds 3 (ED) sec. 2.4 gives every single [<repeat-style>] keyword
    the pair it computes to: [repeat] is [repeat repeat], [space] is [space
@@ -4377,6 +4412,7 @@ let declaration_tests =
     test_case "background box slots" `Quick background_box_slots;
     test_case "mask-border mode slot" `Quick mask_border_mode_slot;
     test_case "box shorthand repeats" `Quick box_shorthand_repeats;
+    test_case "border-spacing pair" `Quick border_spacing_pair;
     test_case "background repeat axes" `Quick background_repeat_axes;
     test_case "background drained layer" `Quick background_drained_layer;
     test_case "border line-color" `Quick border_line_color;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1317,7 +1317,9 @@ let background_box_slots () =
   check_declaration ~expected:"background:content-box content-box red"
     ~optimized:"background:content-box red"
     "background: red content-box content-box";
-  check_declaration ~expected:"background:border-box border-box red"
+  (* A single [<box>] is one slot in the node, and pp holds the node: it is the
+     re-reading of that single keyword that sets both longhands. *)
+  check_declaration ~expected:"background:border-box red"
     ~optimized:"background:border-box red" "background: red border-box";
   (* Both are written out where a single [<box>] would name a different pair. *)
   check_declaration ~expected:"background:padding-box content-box red"

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2018,7 +2018,8 @@ let spec_property_grammar_table_expansion () =
               Some "background:url(bg.png)50%/cover no-repeat border-box" )
         | "scrollbar-color", "red blue" ->
             (Some "scrollbar-color:red blue", Some "scrollbar-color:red #00f")
-        | "border", "1px solid currentColor" -> (Some "border:1px solid", None)
+        | "border", "1px solid currentColor" ->
+            (Some "border:1px solid currentColor", Some "border:1px solid")
         | "background-position", "left 10px top 20px" ->
             ( Some "background-position:left 10px top 20px",
               Some "background-position:10px 20px" )
@@ -2975,7 +2976,8 @@ let spec_remaining_prop_vectors () =
       ("scroll-margin: 1px 2px 3px 4px", "scroll-margin:1px 2px 3px 4px");
       ("scroll-padding: 1rem 2rem", "scroll-padding:1rem 2rem");
       ("columns: 12rem 3", "columns:12rem 3");
-      ("column-rule: 1px solid currentColor", "column-rule:1px solid");
+      ( "column-rule: 1px solid currentColor",
+        "column-rule:1px solid currentColor" );
       ("column-span: all", "column-span:all");
       ("break-before: page", "break-before:page");
       ("break-after: avoid-page", "break-after:avoid-page");

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -250,6 +250,21 @@ let test_box_shorthand_repeats_factor () =
     ".a{margin:1px 2px 3px 4px}.b{margin:1px 2px 3px}"
     (optimize_str ".a{margin:1px 2px 3px 4px}.b{margin:1px 2px 3px}")
 
+(* CSS Masking 1 (ED) sec. 8.2 gives mask-border-mode the initial value [alpha],
+   so an explicit [alpha] and an absent mode are one declaration. Factoring
+   compares nodes, so the drop has to have happened before the two rules
+   meet. *)
+let test_mask_border_mode_spellings_factor () =
+  Alcotest.(check string)
+    "an explicit alpha factors with the omitted mode"
+    ".a,.b{mask-border:url(a.png)}"
+    (optimize_str ".a{mask-border:url(a.png) alpha}.b{mask-border:url(a.png)}");
+  Alcotest.(check string)
+    "luminance does not factor with the omitted mode"
+    ".a{mask-border:url(a.png)luminance}.b{mask-border:url(a.png)}"
+    (optimize_str
+       ".a{mask-border:url(a.png) luminance}.b{mask-border:url(a.png)}")
+
 (* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as
    "Same as 700", so the keyword and the number name one weight. Factoring
    compares nodes, so the two rules only meet as one declaration if the fold
@@ -422,6 +437,8 @@ let suite =
         test_repeat_style_spellings_factor;
       Alcotest.test_case "box shorthand repeats factor together" `Quick
         test_box_shorthand_repeats_factor;
+      Alcotest.test_case "mask-border mode spellings factor together" `Quick
+        test_mask_border_mode_spellings_factor;
       Alcotest.test_case "font-weight keyword and number factor together" `Quick
         test_font_weight_spellings_factor;
       Alcotest.test_case "font-family duplicate factors with the single family"

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -180,6 +180,35 @@ let test_initial_line_color_spellings_factor () =
     ".a{outline:solid currentColor}.b{outline:solid}"
     (optimize_str ".a{outline:solid currentcolor}.b{outline:solid}")
 
+(* The [background] shorthand resets every longhand it covers (CSS Backgrounds 3
+   (ED) sec. 2.10), so a slot written at its own initial value is the longer
+   spelling of the same declaration, and a layer that fills no slot is what
+   [background: none] declares. Factoring compares nodes, so the fold has to
+   have happened before the two rules meet. *)
+let test_background_initial_slot_spellings_factor () =
+  Alcotest.(check string)
+    "an initial position factors with the omitted one" ".a,.b{background:red}"
+    (optimize_str ".a{background:red 0 0}.b{background:red}");
+  Alcotest.(check string)
+    "an initial repeat factors with the omitted one" ".a,.b{background:red}"
+    (optimize_str ".a{background:red repeat}.b{background:red}");
+  Alcotest.(check string)
+    "the none keyword factors with the drained layer" ".a,.b{background:0 0}"
+    (optimize_str ".a{background:none}.b{background:0 0}");
+  (* sec. 2.6 reads a lone position value as [<x> center], which is not the
+     initial [0% 0%], so these two layers put the image in different places. *)
+  Alcotest.(check string)
+    "a lone position does not factor with the omitted one"
+    ".a{background:url(a.png)0}.b{background:url(a.png)}"
+    (optimize_str ".a{background:url(a.png) 0}.b{background:url(a.png)}");
+  (* sec. 2.10 reads a single [<box>] as both origin and clip, so dropping the
+     clip alone would repaint the layer over a smaller area. *)
+  Alcotest.(check string)
+    "an initial clip beside a non-initial origin does not factor"
+    ".a{background:content-box border-box red}.b{background:content-box red}"
+    (optimize_str
+       ".a{background:red content-box border-box}.b{background:red content-box}")
+
 (* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as
    "Same as 700", so the keyword and the number name one weight. Factoring
    compares nodes, so the two rules only meet as one declaration if the fold
@@ -346,6 +375,8 @@ let suite =
         test_initial_line_style_spellings_factor;
       Alcotest.test_case "initial line-color spellings factor together" `Quick
         test_initial_line_color_spellings_factor;
+      Alcotest.test_case "initial background slot spellings factor together"
+        `Quick test_background_initial_slot_spellings_factor;
       Alcotest.test_case "font-weight keyword and number factor together" `Quick
         test_font_weight_spellings_factor;
       Alcotest.test_case "font-family duplicate factors with the single family"

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -152,6 +152,34 @@ let test_initial_line_style_spellings_factor () =
     ".a,.b{column-rule:none}"
     (optimize_str ".a{column-rule:medium none}.b{column-rule:none}")
 
+(* The same argument one slot further over. CSS Backgrounds 3 (ED) sec. 3.1
+   gives the border-color properties the initial value [currentColor], and CSS
+   Multi-column 1 (ED) sec. 4.2 and css-logical-1 sec. 4.5.3 repeat it for
+   column-rule and the logical borders, so an explicit [currentColor] and an
+   absent colour are one declaration. CSS UI 4 (ED) sec. 3.4 gives outline-color
+   the initial value [auto] instead, so those two rules name different colours
+   and must stay apart. *)
+let test_initial_line_color_spellings_factor () =
+  Alcotest.(check string)
+    "border currentColor factors with the omitted colour" ".a,.b{border:solid}"
+    (optimize_str ".a{border:solid currentcolor}.b{border:solid}");
+  Alcotest.(check string)
+    "border currentColor alone factors with the none keyword"
+    ".a,.b{border:none}"
+    (optimize_str ".a{border:currentcolor}.b{border:none}");
+  Alcotest.(check string)
+    "column-rule currentColor factors with the omitted colour"
+    ".a,.b{column-rule:solid}"
+    (optimize_str ".a{column-rule:solid currentcolor}.b{column-rule:solid}");
+  Alcotest.(check string)
+    "border-inline currentColor factors with the omitted colour"
+    ".a,.b{border-inline:solid}"
+    (optimize_str ".a{border-inline:solid currentcolor}.b{border-inline:solid}");
+  Alcotest.(check string)
+    "outline currentColor does not factor with the omitted colour"
+    ".a{outline:solid currentColor}.b{outline:solid}"
+    (optimize_str ".a{outline:solid currentcolor}.b{outline:solid}")
+
 (* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as
    "Same as 700", so the keyword and the number name one weight. Factoring
    compares nodes, so the two rules only meet as one declaration if the fold
@@ -316,6 +344,8 @@ let suite =
         test_initial_line_width_spellings_factor;
       Alcotest.test_case "initial line-style spellings factor together" `Quick
         test_initial_line_style_spellings_factor;
+      Alcotest.test_case "initial line-color spellings factor together" `Quick
+        test_initial_line_color_spellings_factor;
       Alcotest.test_case "font-weight keyword and number factor together" `Quick
         test_font_weight_spellings_factor;
       Alcotest.test_case "font-family duplicate factors with the single family"

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -243,6 +243,21 @@ let test_box_shorthand_repeats_factor () =
   Alcotest.(check string)
     "border-color takes the same collapse" ".a,.b{border-color:red}"
     (optimize_str ".a{border-color:red red red red}.b{border-color:red}");
+  (* CSS Backgrounds 3 (ED) sec. 4.1 collapses each radii group on its own, and
+     with no slash the values set both axes equally. *)
+  Alcotest.(check string)
+    "border-radius collapses each group" ".a,.b{border-radius:5px/10px}"
+    (optimize_str
+       ".a{border-radius:5px 5px 5px 5px/10px 10px 10px \
+        10px}.b{border-radius:5px/10px}");
+  Alcotest.(check string)
+    "equal radii axes factor with the omitted group" ".a,.b{border-radius:5px}"
+    (optimize_str ".a{border-radius:5px/5px}.b{border-radius:5px}");
+  (* CSS Tables 3 (ED) reads a single border-spacing length as both axes. *)
+  Alcotest.(check string)
+    "equal border-spacing axes factor with the single length"
+    ".a,.b{border-spacing:1px}"
+    (optimize_str ".a{border-spacing:1px 1px}.b{border-spacing:1px}");
   (* A list the rules cannot rebuild stays as written, and the two stay
      apart. *)
   Alcotest.(check string)

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -229,6 +229,27 @@ let test_repeat_style_spellings_factor () =
     (optimize_str
        ".a{background-repeat:repeat space}.b{background-repeat:repeat}")
 
+(* CSS Box 4 (ED) sec. 3.2 fills the four sides from one, two or three values,
+   so a list that repeats what those rules already supply is the longer spelling
+   of the same declaration. Factoring compares nodes, so the two rules meet only
+   if the collapse ran first. *)
+let test_box_shorthand_repeats_factor () =
+  Alcotest.(check string)
+    "four equal sides factor with the single value" ".a,.b{inset:0}"
+    (optimize_str ".a{inset:0 0 0 0}.b{inset:0}");
+  Alcotest.(check string)
+    "a repeated axis factors with the pair" ".a,.b{padding:1px 2px}"
+    (optimize_str ".a{padding:1px 2px 1px 2px}.b{padding:1px 2px}");
+  Alcotest.(check string)
+    "border-color takes the same collapse" ".a,.b{border-color:red}"
+    (optimize_str ".a{border-color:red red red red}.b{border-color:red}");
+  (* A list the rules cannot rebuild stays as written, and the two stay
+     apart. *)
+  Alcotest.(check string)
+    "four distinct sides do not factor with three"
+    ".a{margin:1px 2px 3px 4px}.b{margin:1px 2px 3px}"
+    (optimize_str ".a{margin:1px 2px 3px 4px}.b{margin:1px 2px 3px}")
+
 (* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as
    "Same as 700", so the keyword and the number name one weight. Factoring
    compares nodes, so the two rules only meet as one declaration if the fold
@@ -399,6 +420,8 @@ let suite =
         `Quick test_background_initial_slot_spellings_factor;
       Alcotest.test_case "repeat-style spellings factor together" `Quick
         test_repeat_style_spellings_factor;
+      Alcotest.test_case "box shorthand repeats factor together" `Quick
+        test_box_shorthand_repeats_factor;
       Alcotest.test_case "font-weight keyword and number factor together" `Quick
         test_font_weight_spellings_factor;
       Alcotest.test_case "font-family duplicate factors with the single family"

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -209,6 +209,26 @@ let test_background_initial_slot_spellings_factor () =
     (optimize_str
        ".a{background:red content-box border-box}.b{background:red content-box}")
 
+(* CSS Backgrounds 3 (ED) sec. 2.4 gives each single [<repeat-style>] keyword
+   the axis pair it computes to, so the pair and the keyword name one value.
+   Factoring compares nodes, so the two rules meet only if the fold ran
+   first. *)
+let test_repeat_style_spellings_factor () =
+  Alcotest.(check string)
+    "repeat repeat factors with repeat" ".a,.b{background-repeat:repeat}"
+    (optimize_str
+       ".a{background-repeat:repeat repeat}.b{background-repeat:repeat}");
+  Alcotest.(check string)
+    "repeat no-repeat factors with repeat-x" ".a,.b{background-repeat:repeat-x}"
+    (optimize_str
+       ".a{background-repeat:repeat no-repeat}.b{background-repeat:repeat-x}");
+  (* Two different axes have no one-keyword spelling, so these stay apart. *)
+  Alcotest.(check string)
+    "repeat space does not factor with repeat"
+    ".a{background-repeat:repeat space}.b{background-repeat:repeat}"
+    (optimize_str
+       ".a{background-repeat:repeat space}.b{background-repeat:repeat}")
+
 (* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as
    "Same as 700", so the keyword and the number name one weight. Factoring
    compares nodes, so the two rules only meet as one declaration if the fold
@@ -377,6 +397,8 @@ let suite =
         test_initial_line_color_spellings_factor;
       Alcotest.test_case "initial background slot spellings factor together"
         `Quick test_background_initial_slot_spellings_factor;
+      Alcotest.test_case "repeat-style spellings factor together" `Quick
+        test_repeat_style_spellings_factor;
       Alcotest.test_case "font-weight keyword and number factor together" `Quick
         test_font_weight_spellings_factor;
       Alcotest.test_case "font-family duplicate factors with the single family"

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2152,7 +2152,9 @@ let test_background_shorthand () =
   check_background_shorthand "url(image.png)";
   check_background_shorthand "center";
   check_background_shorthand "no-repeat";
-  check_background_shorthand ~expected:"repeat" "repeat repeat";
+  (* pp prints the axis pair it was handed; the fold to the one-keyword spelling
+     is an optimize step (test_declaration pins it). *)
+  check_background_shorthand "repeat repeat";
   check_background_shorthand ~expected:"url(image.png)red" "red url(image.png)";
   check_background_shorthand ~expected:"url(image.png)center"
     "url(image.png) center";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1812,7 +1812,9 @@ let test_background () =
      is the default and folds away; the second layer's [space] stays. *)
   decl_optimizes ~prop:"background" ~into:"url(a.png),url(b.png)space"
     "url(a.png) repeat,url(b.png) space";
-  check_background ~expected:"0 0" "none";
+  (* pp holds the [none] keyword; the fold to the equivalent, and shorter, [0 0]
+     layer is an optimize transform (test_declaration pins it). *)
+  check_background "none";
   neg_cursor read_background "invalid-background";
   neg_cursor ~allow_partial:true read_background "red blue";
   (* multiple colors without gradient *)


### PR DESCRIPTION
An empty value matches none of these shorthand grammars, so `border:` no longer becomes `border: none` and `outline:` no longer prints a value no parser reads back.

The remaining printer-side initial-value drops move to the AST so two rules that declare the same thing meet at factoring. Some of them were unsound. A lone `background` position value leaves the vertical offset at `center` and a single `<box>` keyword sets both `background-origin` and `background-clip`, so either drop changed where the layer painted; `border-spacing` collapsed an equal pair with no minify gate at all.
