### PR TITLE
minify: fold the shorthand initial slots in the AST, not the printer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,12 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `display: flow-root list-item` and `display: flow list-item` are read as the
+  values they are. CSS Display 3 sec. 2 orders none of the three `list-item`
+  components, and the reader stopped at a leading inside keyword (#641)
+- `display: list-item table` and a repeated `list-item` are rejected.
+  `list-item` is not a `<display-outside>`, so it no longer stands in for one
+  (#641)
 - `outline-width` and the width slot of the `outline` shorthand read a
   `<length>` where CSS UI 4 sec. 3.2 gives them a `<line-width>`, so
   `outline: thin solid red` was dropped as invalid (#633)
@@ -470,18 +476,27 @@ recorded cases carrying six minifiers' answers.
 ### Minification
 
 - `--minify` folds a value's spelling before two rules are compared, so rules
-  that wrote one declaration two ways factor into one: an explicit initial
-  `medium` width or `none` style in the `border`, `column-rule` and `outline`
-  shorthands, `font-weight: bold` beside `700`, `font-stretch: condensed`
-  beside `75%`, a family repeated in `font-family`, a `font` slot left at its
-  longhand's initial, a two-value `display` beside its legacy keyword, and
-  `overflow: auto auto` beside `auto` (#635, #636, #637, #639)
+  that wrote one declaration two ways factor into one: a component left at its
+  longhand's initial in the `border`, `column-rule`, `outline`, `list-style`,
+  `text-decoration`, `text-shadow`, `transition` and `font` shorthands, a
+  keyword beside the number or curve naming the same value, a repeated
+  `font-family` entry, a two-value `display` beside its legacy keyword, and a
+  box shorthand whose sides repeat (#635, #636, #637, #639, #641)
 - `--minify` folds a same-unit `calc()` in `font-size`, so `calc(1px + 1px)`
   prints as `2px` and merges with a rule that wrote `2px`; the property ran the
   untyped calc simplifier, which cannot add two typed lengths (#639)
+- `--minify` collapses `margin-inline` and `margin-block` to one value when the
+  two edges match, which the four-sided box shorthands already did (#641)
+- `--minify` folds `steps(1)` to `step-end`. CSS Easing 1 sec. 2.3 assumes
+  `end` when the step position is left out, so it names the easing
+  `steps(1, end)` already folded to (#641)
 - `--minify` keeps `display: block ruby`. It printed `ruby`, which CSS Display
   3 reads as `inline ruby`, so a block-level ruby container came back
   inline-level (#637)
+- `--minify` keeps the zero duration a `transition` delay stands behind.
+  `transition: opacity 0s 2s` printed `transition:opacity 2s`; CSS Transitions
+  1 sec. 2.5 gives the first time to the duration, so the delayed instant
+  change came back as a two-second one starting straight away (#641)
 - `--minify` folds the width slot of the `border` shorthands and of
   `column-rule`, so `border: 0px solid red` prints as `border:0 solid red`
   and `border: calc(1px + 1px) solid red` as `border:2px solid red`. That

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -383,13 +383,6 @@ let rec pp_timing_function : timing_function Pp.t =
   | Ease_in_out -> Pp.string ctx "ease-in-out"
   | Step_start -> Pp.string ctx "step-start"
   | Step_end -> Pp.string ctx "step-end"
-  | Steps (1, Some (Jump_start | Start)) when Pp.minified ctx ->
-      (* CSS Easing 1 sec. 2: [steps(1, jump-start)] = [steps(1, start)] = the
-         [step-start] alias; the [end] / [jump-end] equivalents fold to
-         [step-end]. *)
-      Pp.string ctx "step-start"
-  | Steps (1, Some (Jump_end | End)) when Pp.minified ctx ->
-      Pp.string ctx "step-end"
   | Steps (n, jump_term_opt) ->
       Pp.string ctx "steps(";
       Pp.int ctx n;
@@ -400,20 +393,6 @@ let rec pp_timing_function : timing_function Pp.t =
           pp_steps_direction ctx d
       | None -> ());
       Pp.char ctx ')'
-  | Cubic_bezier (0.25, 0.1, 0.25, 1.0) when Pp.minified ctx ->
-      (* CSS Easing 1 2: the named cubic-bezier aliases canonicalise to the
-         keyword form, which is shorter than the four-argument call. *)
-      Pp.string ctx "ease"
-  | Cubic_bezier (0.42, 0.0, 1.0, 1.0) when Pp.minified ctx ->
-      Pp.string ctx "ease-in"
-  | Cubic_bezier (0.0, 0.0, 0.58, 1.0) when Pp.minified ctx ->
-      Pp.string ctx "ease-out"
-  | Cubic_bezier (0.42, 0.0, 0.58, 1.0) when Pp.minified ctx ->
-      Pp.string ctx "ease-in-out"
-  | Cubic_bezier (0.0, 0.0, 1.0, 1.0) when Pp.minified ctx ->
-      (* CSS Easing 1 sec. 2.2: [cubic-bezier(0, 0, 1, 1)] is the identity
-         curve, equivalent to the [linear] keyword. *)
-      Pp.string ctx "linear"
   | Cubic_bezier (x1, y1, x2, y2) -> pp_cubic_bezier ctx (x1, y1, x2, y2)
   | Timing_functions timings ->
       Pp.list ~sep:Pp.comma pp_timing_function ctx timings
@@ -427,6 +406,29 @@ let rec pp_timing_function : timing_function Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_timing_function ctx v
+
+(* CSS Easing 1 (ED) sec. 2.2 defines [ease] as [cubic-bezier(0.25, 0.1, 0.25,
+   1)], [ease-in] as [cubic-bezier(0.42, 0, 1, 1)], [ease-out] as
+   [cubic-bezier(0, 0, 0.58, 1)] and [ease-in-out] as [cubic-bezier(0.42, 0,
+   0.58, 1)]; [cubic-bezier(0, 0, 1, 1)] is the identity curve the [linear]
+   keyword names. sec. 2.3 computes [step-start] to [steps(1, start)] and
+   [step-end] to [steps(1, end)], reads [start] as [jump-start] and [end] as
+   [jump-end], and assumes [end] when the step position is left out. Each pair
+   is one easing under two spellings, and the keyword is the shorter one. *)
+let rec normalize_timing_function : timing_function -> timing_function =
+ fun value ->
+  match value with
+  | Cubic_bezier (0.25, 0.1, 0.25, 1.0) -> Ease
+  | Cubic_bezier (0.42, 0.0, 1.0, 1.0) -> Ease_in
+  | Cubic_bezier (0.0, 0.0, 0.58, 1.0) -> Ease_out
+  | Cubic_bezier (0.42, 0.0, 0.58, 1.0) -> Ease_in_out
+  | Cubic_bezier (0.0, 0.0, 1.0, 1.0) -> Linear
+  | Steps (1, (Option.None | Some (Jump_end | End))) -> Step_end
+  | Steps (1, Some (Jump_start | Start)) -> Step_start
+  | Timing_functions timings ->
+      let normalized = map_preserve normalize_timing_function timings in
+      if normalized == timings then value else Timing_functions normalized
+  | _ -> value
 
 let rec pp_transition_property_value : transition_property_value Pp.t =
  fun ctx -> function
@@ -454,11 +456,6 @@ let rec pp_transition_behavior : transition_behavior Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
-let transition_timing_is_default ctx = function
-  | Ease when Pp.minified ctx -> true
-  | Cubic_bezier (0.25, 0.1, 0.25, 1.0) when Pp.minified ctx -> true
-  | _ -> false
-
 let rec pp_overlay : overlay Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_overlay ctx v
@@ -470,31 +467,67 @@ let rec pp_overlay : overlay Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+let transition_duration_is_zero : duration -> bool = function
+  | S 0. | Ms 0. -> true
+  | _ -> false
+
 let pp_transition_shorthand : transition_shorthand Pp.t =
  fun ctx { property; duration; timing_function; delay; behavior } ->
+  let slot pp v =
+    Pp.space ctx ();
+    pp ctx v
+  in
   pp_transition_property_value ctx property;
-  (* Only output non-default values: defaults are 0s, ease, 0s *)
-  (match duration with
-  | Some (S 0.) | Some (Ms 0.) | None -> ()
-  | Some d ->
-      Pp.space ctx ();
-      pp_duration ctx d);
-  (match timing_function with
-  | None -> ()
-  | Some tf when transition_timing_is_default ctx tf -> ()
-  | Some tf ->
-      Pp.space ctx ();
-      pp_timing_function ctx tf);
-  (match delay with
-  | Some (S 0.) | Some (Ms 0.) | None -> ()
-  | Some d ->
-      Pp.space ctx ();
-      pp_duration ctx d);
-  match behavior with
-  | None | Some Normal -> ()
-  | Some b ->
-      Pp.space ctx ();
-      pp_transition_behavior ctx b
+  (* CSS Transitions 1 (ED) sec. 2.5: "the first value that can be parsed as a
+     time is assigned to the transition-duration, and the second value that can
+     be parsed as a time is assigned to transition-delay". The delay is only
+     reachable behind a duration, so a value carrying a delay and no duration
+     writes the duration initial [0s] out to hold the slot. *)
+  (match (duration, delay) with
+  | Option.Some d, _ -> slot pp_duration d
+  | Option.None, Option.Some _ -> slot Pp.string "0s"
+  | Option.None, Option.None -> ());
+  Option.iter (slot pp_timing_function) timing_function;
+  Option.iter (slot pp_duration) delay;
+  Option.iter (slot pp_transition_behavior) behavior
+
+(* CSS Transitions 1 (ED) sec. 2.5 assembles a [<single-transition>] out of
+   components that each fall back to their longhand initial when left out: [0s]
+   for the duration (sec. 2.2), [ease] for the easing (sec. 2.3), [0s] for the
+   delay (sec. 2.4), and [normal] for the Transitions 2 behaviour. Writing an
+   initial out says what leaving it out says, and the shorter spelling is the
+   canonical node. A zero duration goes with the rest: where the grammar still
+   needs the slot to reach a delay, the printer writes it back. *)
+let normalize_transition_shorthand (s : transition_shorthand) :
+    transition_shorthand =
+  let drop_zero d =
+    match d with
+    | Option.Some d when transition_duration_is_zero d -> Option.None
+    | d -> d
+  in
+  let duration = drop_zero s.duration in
+  let delay = drop_zero s.delay in
+  let timing_function =
+    match option_map_preserve normalize_timing_function s.timing_function with
+    | Option.Some Ease -> Option.None
+    | tf -> tf
+  in
+  let behavior =
+    match s.behavior with Option.Some Normal -> Option.None | b -> b
+  in
+  if
+    option_is_phys_same duration s.duration
+    && option_is_phys_same delay s.delay
+    && option_is_phys_same timing_function s.timing_function
+    && option_is_phys_same behavior s.behavior
+  then s
+  else { s with duration; timing_function; delay; behavior }
+
+let normalize_transition : transition -> transition = function
+  | Shorthand s as value ->
+      let s' = normalize_transition_shorthand s in
+      if s' == s then value else Shorthand s'
+  | value -> value
 
 let rec pp_transition : transition Pp.t =
  fun ctx -> function
@@ -1421,24 +1454,11 @@ module Animation = struct
   let is_zero_duration = function S 0. | Ms 0. -> true | _ -> false
   let pp_iter_count = pp_animation_iteration_count
 
-  (* Check if a timing function prints with a trailing ')'. Some function values
-     canonicalise to keyword aliases in minified output. *)
-  let rec ends_with_paren ctx = function
-    | Cubic_bezier (0.25, 0.1, 0.25, 1.0)
-    | Cubic_bezier (0.42, 0.0, 1.0, 1.0)
-    | Cubic_bezier (0.0, 0.0, 0.58, 1.0)
-    | Cubic_bezier (0.42, 0.0, 0.58, 1.0)
-      when Pp.minified ctx ->
-        false
-    | (Steps (1, Some (Jump_start | Start)) | Steps (1, Some (Jump_end | End)))
-      when Pp.minified ctx ->
-        (* These fold to the [step-start] / [step-end] keywords in
-           [pp_timing_function], so the rendered output is keyword-shaped, no
-           closing paren. *)
-        false
+  (* Check if a timing function prints with a trailing ')'. *)
+  let rec ends_with_paren = function
     | Cubic_bezier _ | Steps _ | Linear_function _ | Var _ -> true
     | Timing_functions [] -> false
-    | Timing_functions values -> ends_with_paren ctx (List.hd (List.rev values))
+    | Timing_functions values -> ends_with_paren (List.hd (List.rev values))
     | Inherit | Initial | Unset | Revert | Revert_layer -> false
     | Linear | Ease | Ease_in | Ease_out | Ease_in_out | Step_start | Step_end
       ->
@@ -1450,14 +1470,11 @@ module Animation = struct
     | Some d when not (is_zero_duration d) -> true
     | _ -> false
 
-  let is_default_timing ctx = function
-    | Ease -> true
-    | Cubic_bezier (0.25, 0.1, 0.25, 1.0) when Pp.minified ctx -> true
-    | _ -> false
+  let is_default_timing = function Ease -> true | _ -> false
 
-  let is_timing ctx : timing_function option -> bool = function
+  let is_timing : timing_function option -> bool = function
     | Some Ease | None -> false
-    | Some tf -> not (is_default_timing ctx tf)
+    | Some tf -> not (is_default_timing tf)
 
   let is_iteration : animation_iteration_count option -> bool = function
     | Some (Num 1.) | None -> false
@@ -1479,9 +1496,9 @@ module Animation = struct
     | Some Auto | None -> false
     | Some _ -> true
 
-  let has_non_defaults ctx (anim : animation_shorthand) =
+  let has_non_defaults (anim : animation_shorthand) =
     is_duration anim.duration
-    || is_timing ctx anim.timing_function
+    || is_timing anim.timing_function
     || is_duration anim.delay
     || is_iteration anim.iteration_count
     || is_direction anim.direction
@@ -1505,12 +1522,12 @@ module Animation = struct
      re-parse: the slot fills first, and the second occurrence falls through to
      the keyframes-name. In that case the printer can skip the quoting trick
      entirely. *)
-  let bare_ambiguous_safe ctx (anim : animation_shorthand) =
+  let bare_ambiguous_safe (anim : animation_shorthand) =
     match ambiguous_name_kind anim with
     | None -> false
     | Some Timing -> (
         match anim.timing_function with
-        | Some tf -> not (is_default_timing ctx tf)
+        | Some tf -> not (is_default_timing tf)
         | None -> false)
     | Some Iteration -> is_iteration anim.iteration_count
     | Some Direction -> is_direction anim.direction
@@ -1527,11 +1544,11 @@ module Animation = struct
         | Some d when not (is_zero_duration d) -> Some d
         | _ -> None)
 
-  let timing ?(quote_name = false) ctx (anim : animation_shorthand) :
+  let timing ?(quote_name = false) (anim : animation_shorthand) :
       timing_function option =
     match (anim.timing_function, effective_ambiguous_kind ~quote_name anim) with
     | (Some Ease | None), Some Timing -> Some Ease
-    | Some tf, _ when is_default_timing ctx tf -> None
+    | Some tf, _ when is_default_timing tf -> None
     | None, _ -> None
     | Some t, _ -> Some t
 
@@ -1619,7 +1636,7 @@ let animation_name_is_default_none ctx = function
 let animation_quote_ambiguous_name ctx anim =
   Pp.minified ctx
   && Animation.ambiguous_name_kind anim <> None
-  && not (Animation.bare_ambiguous_safe ctx anim)
+  && not (Animation.bare_ambiguous_safe anim)
 
 let pp_animation_initial_none ctx (anim : animation_shorthand)
     ~name_is_default_none ~has_any_non_default =
@@ -1645,9 +1662,9 @@ let pp_animation_name_slot ctx state ~quote_ambiguous_name
       anim.name
 
 let pp_animation_timing_slot ctx state ~quote_ambiguous_name anim =
-  match Animation.timing ~quote_name:quote_ambiguous_name ctx anim with
+  match Animation.timing ~quote_name:quote_ambiguous_name anim with
   | Some tf ->
-      let ends = Animation.ends_with_paren ctx tf in
+      let ends = Animation.ends_with_paren tf in
       pp_animation_space_before state ~ends_with_paren:ends Animation.pp_timing
         ctx tf
   | None -> ()
@@ -1655,7 +1672,7 @@ let pp_animation_timing_slot ctx state ~quote_ambiguous_name anim =
 let pp_animation_shorthand : animation_shorthand Pp.t =
  fun ctx anim ->
   let state = animation_pp_state () in
-  let has_any_non_default = Animation.has_non_defaults ctx anim in
+  let has_any_non_default = Animation.has_non_defaults anim in
   let name_is_default_none = animation_name_is_default_none ctx anim.name in
   let quote_ambiguous_name = animation_quote_ambiguous_name ctx anim in
   pp_animation_initial_none ctx anim ~name_is_default_none ~has_any_non_default;
@@ -1691,6 +1708,23 @@ let pp_animation_shorthand : animation_shorthand Pp.t =
     (pp_animation_space_before state pp_animation_timeline)
     ctx
     (Animation.timeline ~quote_name:quote_ambiguous_name anim)
+
+(* The animation reader fills every slot with its longhand initial, so only the
+   easing needs canonicalising here: its keyword and curve spellings are the
+   same node question [normalize_timing_function] answers. *)
+let normalize_animation_shorthand (a : animation_shorthand) :
+    animation_shorthand =
+  let timing_function =
+    option_map_preserve normalize_timing_function a.timing_function
+  in
+  if option_is_phys_same timing_function a.timing_function then a
+  else { a with timing_function }
+
+let normalize_animation : animation -> animation = function
+  | Shorthand a as value ->
+      let a' = normalize_animation_shorthand a in
+      if a' == a then value else Shorthand a'
+  | value -> value
 
 let rec pp_animation : animation Pp.t =
  fun ctx -> function

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -19,13 +19,11 @@ open Prop_mask
 (* CSS Display 3 sec. 2.1 [display-outside]: pre-existing aliases inside the
    single-value vocabulary that compose with a [display-inside] in the two-value
    form. The composite [<outside> <inside>] is a [Multi]. *)
+(* CSS Display 3 (ED) sec. 2: [<display-outside> = block | inline | run-in].
+   [list-item] belongs to [<display-listitem>], which spells it out separately,
+   so it is not one of these. *)
 let display_outside_idents : (string * display) list =
-  [
-    ("block", Block);
-    ("inline", Inline);
-    ("run-in", Run_in);
-    ("list-item", List_item);
-  ]
+  [ ("block", Block); ("inline", Inline); ("run-in", Run_in) ]
 
 let display_inside_idents : (string * display) list =
   [
@@ -108,21 +106,21 @@ let read_display_list_item t : display =
         ignore (Cursor.ident t : string);
         list_item := true;
         true
-    | Some s when Option.is_none !outside -> (
-        match List.assoc_opt s display_outside_idents with
-        | Some value ->
-            ignore (Cursor.ident t : string);
-            outside := Option.Some value;
-            true
-        | Option.None -> false)
-    | Some s when Option.is_none !inside -> (
-        match List.assoc_opt s list_item_inside_idents with
-        | Some value ->
-            ignore (Cursor.ident t : string);
-            inside := Option.Some value;
-            true
-        | Option.None -> false)
-    | _ -> false
+    | Some s ->
+        (* The three components are combined with [&&], so each keyword fills
+           whichever slot it belongs to wherever it appears; testing the outside
+           slot alone would stop the loop at a leading inside keyword. *)
+        let fill slot idents =
+          match (!slot, List.assoc_opt s idents) with
+          | Option.None, Some value ->
+              ignore (Cursor.ident t : string);
+              slot := Option.Some value;
+              true
+          | _ -> false
+        in
+        fill outside display_outside_idents
+        || fill inside list_item_inside_idents
+    | Option.None -> false
   in
   while consume_slot () do
     ()
@@ -303,6 +301,14 @@ let rec pp_display : display Pp.t =
      type takes [flow], so leaving the [flow] out names the same value. *)
   | Multi (Multi (outside, Block), List_item) when Pp.minified ctx ->
       pp_display ctx outside;
+      Pp.space ctx ();
+      Pp.string ctx "list-item"
+  (* sec. 2.3 defaults the unwritten outside to [block] the same way, so with an
+     inside written the [block] can go. One of the two has to stay: with both
+     left out the value is the bare [list-item] keyword, which is a different
+     node for the optimizer to fold to. *)
+  | Multi (Multi (Block, inside), List_item) when Pp.minified ctx ->
+      pp_display_inside ctx inside;
       Pp.space ctx ();
       Pp.string ctx "list-item"
   | Multi (Multi (outside, inside), List_item) ->

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -187,13 +187,11 @@ let option_is_phys_same a b =
   | Option.Some a, Option.Some b -> a == b
   | _ -> false
 
-(* CSS Lists 3 sec. 3.6: under minify, drop components equal to their longhand
-   initial ([type_: Disc], [position: Outside], [image: None]). When both
-   [type_] and [image] are [None] and [position] is omitted, emit the single
-   [none] keyword. If every component is defaulted, leave [outside] so the value
-   isn't empty. *)
-let drop_default_if ~drop ~is_default v =
-  match v with Some x when drop && is_default x -> Option.None | _ -> v
+(* Drop a shorthand component that equals its longhand initial: a shorthand
+   resets every component it leaves out to that initial, so the two spellings
+   name one value. *)
+let drop_default ~is_default v =
+  match v with Some x when is_default x -> Option.None | _ -> v
 
 let rec eval_number_value : number -> float option = function
   | Num f -> Some f

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -138,9 +138,11 @@ let is_zero_length : length -> bool = function
       true
   | _ -> false
 
-(* CSS Box 4 7.1: a 1-to-4 value box shorthand ([margin], [padding],
-   [border-radius] sides, [background-position]) collapses when sides repeat. [a
-   a a a] -> [a]; [a b a b] -> [a b]; [a b c b] -> [a b c]. *)
+(* CSS Box 4 (ED) sec. 3.2 and sec. 4.2: one value applies to all four sides,
+   two set the top/bottom and the right/left pairs, three set the top, then the
+   left and right, then the bottom. A shorthand whose sides repeat therefore has
+   a shorter spelling naming the same sides: [a a a a] -> [a]; [a b a b] -> [a
+   b]; [a b c b] -> [a b c]. *)
 let collapse_box_shorthand vs =
   match vs with
   | [ a; b; c; d ] when a = b && b = c && c = d -> [ a ]
@@ -167,6 +169,10 @@ let map_preserve f xs =
         loop (changed || not (y == x)) (y :: acc) rest
   in
   loop false [] xs
+
+(* Canonicalise a box shorthand: normalise each side with [f], then pick the
+   shortest of the spellings that name those sides. *)
+let normalize_box_shorthand f vs = collapse_box_shorthand (map_preserve f vs)
 
 let option_map_preserve f opt =
   match opt with

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -755,13 +755,29 @@ let normalize_text_indent : text_indent_value -> text_indent_value =
       if length == r.length then value else Indent { r with length }
   | other -> other
 
+(* CSS Text Decoration 4 (ED) sec. 2.6: the [text-decoration] shorthand sets the
+   line, thickness, style and colour longhands, and "Omitted values are set to
+   their initial values" - [solid] (sec. 2.2) and [currentcolor] (sec. 2.3).
+   Writing an initial out names what leaving it out names, and leaving it out is
+   the shorter spelling. *)
 let normalize_text_decoration ?(lossless = false) :
     text_decoration -> text_decoration =
  fun value ->
   match value with
   | Shorthand s ->
-      let color = option_map_preserve (normalize_color ~lossless) s.color in
-      if color == s.color then value else Shorthand { s with color }
+      let style =
+        drop_default
+          ~is_default:(fun (d : text_decoration_style) -> d = Solid)
+          s.style
+      in
+      let color =
+        drop_default
+          ~is_default:(fun (c : Values.color) -> c = Values.Current)
+          (option_map_preserve (normalize_color ~lossless) s.color)
+      in
+      if option_is_phys_same style s.style && option_is_phys_same color s.color
+      then value
+      else Shorthand { s with style; color }
   | other -> other
 
 let normalize_text_emphasis ?(lossless = false) : text_emphasis -> text_emphasis
@@ -773,6 +789,10 @@ let normalize_text_emphasis ?(lossless = false) : text_emphasis -> text_emphasis
         (Emphasis (style, option_map_preserve (normalize_color ~lossless) color))
   | other -> other
 
+(* CSS Text Decoration 4 (ED) sec. 4 reads a text shadow as a [<shadow>] "as for
+   box-shadow", and CSS Backgrounds 3 (ED) sec. 6.1 says "Omitted lengths are
+   0". The blur is the last length a text shadow carries, so a zero blur is the
+   spelled-out form of leaving it off. *)
 let normalize_text_shadow ?(lossless = false) : text_shadow -> text_shadow =
  fun value ->
   match value with
@@ -782,7 +802,9 @@ let normalize_text_shadow ?(lossless = false) : text_shadow -> text_shadow =
            {
              h_offset = Values.normalize_length s.h_offset;
              v_offset = Values.normalize_length s.v_offset;
-             blur = option_map_preserve Values.normalize_length s.blur;
+             blur =
+               drop_default ~is_default:is_zero_length
+                 (option_map_preserve Values.normalize_length s.blur);
              color = option_map_preserve (normalize_color ~lossless) s.color;
            })
   | other -> other
@@ -866,18 +888,6 @@ let pp_text_decoration_shorthand : text_decoration_shorthand Pp.t =
  fun ctx { lines; style; color; thickness } ->
   let first = ref true in
   let space_if_needed () = if !first then first := false else Pp.space ctx () in
-  (* CSS Text Decoration 4 sec. 2: under minify, drop components that equal the
-     longhand default ([style: solid], [color: currentcolor]); the shorthand is
-     interpreted with the dropped fields restored to default. *)
-  let drop_default = Pp.minified ctx in
-  let style : text_decoration_style option =
-    if drop_default then match style with Some Solid -> None | s -> s
-    else style
-  in
-  let color : Values.color option =
-    if drop_default then match color with Some Values.Current -> None | c -> c
-    else color
-  in
   (match lines with
   | [] -> ()
   | ls ->
@@ -1365,10 +1375,10 @@ let rec pp_text_shadow : text_shadow Pp.t =
       Pp.space ctx ();
       pp_length ctx v_offset;
       (match blur with
-      | Some b when not (Pp.minified ctx && is_zero_length b) ->
+      | Some b ->
           Pp.space ctx ();
           pp_length ctx b
-      | Some _ | None -> ());
+      | None -> ());
       match color with Some c -> pp_color_after_length ctx c | None -> ())
 
 let rec pp_text_size_adjust : text_size_adjust Pp.t =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3531,7 +3531,7 @@ let normalize_property_value : type a.
   | Baseline_shift -> normalize_baseline_shift value
   | Background_color -> normalize_color value
   | Color -> normalize_color value
-  | Border_color -> map_preserve normalize_color value
+  | Border_color -> normalize_box_shorthand normalize_color value
   | Border_top_color -> normalize_color value
   | Border_right_color -> normalize_color value
   | Border_bottom_color -> normalize_color value
@@ -3662,17 +3662,19 @@ let normalize_property_value : type a.
   | Scroll_padding_inline_end -> Values.normalize_length ~ctx value
   | Scroll_padding_block_start -> Values.normalize_length ~ctx value
   | Scroll_padding_block_end -> Values.normalize_length ~ctx value
-  | Padding -> map_preserve (Values.normalize_length ~ctx) value
-  | Padding_inline -> map_preserve (Values.normalize_length ~ctx) value
-  | Padding_block -> map_preserve (Values.normalize_length ~ctx) value
-  | Margin -> map_preserve (Values.normalize_length ~ctx) value
+  | Padding -> normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Padding_inline ->
+      normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Padding_block ->
+      normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Margin -> normalize_box_shorthand (Values.normalize_length ~ctx) value
   | Margin_inline -> map_preserve (Values.normalize_length ~ctx) value
   | Margin_block -> map_preserve (Values.normalize_length ~ctx) value
-  | Inset -> map_preserve (Values.normalize_length ~ctx) value
-  | Inset_inline -> map_preserve (Values.normalize_length ~ctx) value
+  | Inset -> normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Inset_inline -> normalize_box_shorthand (Values.normalize_length ~ctx) value
   | Inset_inline_start -> map_preserve (Values.normalize_length ~ctx) value
   | Inset_inline_end -> map_preserve (Values.normalize_length ~ctx) value
-  | Inset_block -> map_preserve (Values.normalize_length ~ctx) value
+  | Inset_block -> normalize_box_shorthand (Values.normalize_length ~ctx) value
   | Inset_block_start -> map_preserve (Values.normalize_length ~ctx) value
   | Inset_block_end -> map_preserve (Values.normalize_length ~ctx) value
   | Top -> map_preserve (Values.normalize_length ~ctx) value
@@ -3778,7 +3780,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | All -> pp pp_css_wide
   | Background_color -> pp pp_color
   | Color -> pp pp_color
-  | Border_color -> pp (pp_box_shorthand pp_color)
+  | Border_color -> pp (Pp.list ~sep:Pp.token_sp pp_color)
   | Border_style -> pp pp_border_style
   | Border_top_style -> pp pp_border_style
   | Border_right_style -> pp pp_border_style
@@ -3788,18 +3790,18 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Border_inline_end_style -> pp pp_border_style
   | Border_block_start_style -> pp pp_border_style
   | Border_block_end_style -> pp pp_border_style
-  | Padding -> pp (pp_box_shorthand pp_length)
+  | Padding -> pp (Pp.list ~sep:Pp.token_sp pp_length)
   | Padding_left -> pp pp_length
   | Padding_right -> pp pp_length
   | Padding_bottom -> pp pp_length
   | Padding_top -> pp pp_length
-  | Padding_inline -> pp (pp_box_shorthand pp_length)
+  | Padding_inline -> pp (Pp.list ~sep:Pp.token_sp pp_length)
   | Padding_inline_start -> pp pp_length
   | Padding_inline_end -> pp pp_length
-  | Padding_block -> pp (pp_box_shorthand pp_length)
+  | Padding_block -> pp (Pp.list ~sep:Pp.token_sp pp_length)
   | Padding_block_start -> pp pp_length
   | Padding_block_end -> pp pp_length
-  | Margin -> pp (pp_box_shorthand pp_length)
+  | Margin -> pp (Pp.list ~sep:Pp.token_sp pp_length)
   | Margin_inline_end -> pp pp_length
   | Margin_inline_start -> pp pp_length
   | Margin_left -> pp pp_length
@@ -3852,11 +3854,11 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Zoom -> pp pp_zoom
   | Webkit_line_clamp -> pp pp_webkit_line_clamp
   | Webkit_box_orient -> pp pp_webkit_box_orient
-  | Inset -> pp (pp_box_shorthand pp_length)
-  | Inset_inline -> pp (pp_box_shorthand pp_length)
+  | Inset -> pp (Pp.list ~sep:Pp.token_sp pp_length)
+  | Inset_inline -> pp (Pp.list ~sep:Pp.token_sp pp_length)
   | Inset_inline_start -> pp (Pp.list ~sep:Pp.space pp_length)
   | Inset_inline_end -> pp (Pp.list ~sep:Pp.space pp_length)
-  | Inset_block -> pp (pp_box_shorthand pp_length)
+  | Inset_block -> pp (Pp.list ~sep:Pp.token_sp pp_length)
   | Inset_block_start -> pp (Pp.list ~sep:Pp.space pp_length)
   | Inset_block_end -> pp (Pp.list ~sep:Pp.space pp_length)
   | Top -> pp (Pp.list ~sep:Pp.space pp_length)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3668,8 +3668,9 @@ let normalize_property_value : type a.
   | Padding_block ->
       normalize_box_shorthand (Values.normalize_length ~ctx) value
   | Margin -> normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Margin_inline -> map_preserve (Values.normalize_length ~ctx) value
-  | Margin_block -> map_preserve (Values.normalize_length ~ctx) value
+  | Margin_inline ->
+      normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Margin_block -> normalize_box_shorthand (Values.normalize_length ~ctx) value
   | Inset -> normalize_box_shorthand (Values.normalize_length ~ctx) value
   | Inset_inline -> normalize_box_shorthand (Values.normalize_length ~ctx) value
   | Inset_inline_start -> map_preserve (Values.normalize_length ~ctx) value

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -151,26 +151,14 @@ let rec pp_list_style_image : list_style_image Pp.t =
 
 let pp_list_style_shorthand : list_style_shorthand Pp.t =
  fun ctx { type_; position; image } ->
-  let drop = Pp.minified ctx in
-  let type_ =
-    drop_default_if ~drop
-      ~is_default:(fun (t : list_style_type) -> t = Disc)
-      type_
-  in
-  let position =
-    drop_default_if ~drop
-      ~is_default:(fun (p : list_style_position) -> p = Outside)
-      position
-  in
-  let image =
-    drop_default_if ~drop
-      ~is_default:(fun (i : list_style_image) -> i = None)
-      image
-  in
   let is_none_type = type_ = Some (None : list_style_type) in
   let is_none_image = image = Some (None : list_style_image) in
-  if is_none_type && is_none_image && position = Option.None && drop then
-    Pp.string ctx "none"
+  (* CSS Lists 3 (ED) sec. 3.6: "a value of none in the shorthand must be
+     applied to whichever of the two properties aren't otherwise set by the
+     shorthand", so a lone [none] with no position reads back as the same pair
+     of nones the two keywords spell out. *)
+  if is_none_type && is_none_image && position = Option.None && Pp.minified ctx
+  then Pp.string ctx "none"
   else
     let first = ref true in
     let emit pp = function
@@ -188,6 +176,37 @@ let pp_list_style_shorthand : list_style_shorthand Pp.t =
        [outside] would set the position, changing nothing, but [disc] is shorter
        and is the canonical single-value form. *)
     if !first then Pp.string ctx "disc"
+
+(* CSS Lists 3 (ED) sec. 3.6: [list-style] is [<'list-style-position'> ||
+   <'list-style-image'> || <'list-style-type'>], so a component left out of the
+   shorthand takes its longhand initial - [outside] (sec. 3.5), [none] (sec.
+   3.3) and [disc] (sec. 3.4). Writing an initial out names what leaving it out
+   names, and leaving it out is the shorter spelling. *)
+let normalize_list_style_shorthand (s : list_style_shorthand) :
+    list_style_shorthand =
+  let type_ =
+    drop_default ~is_default:(fun (t : list_style_type) -> t = Disc) s.type_
+  in
+  let position =
+    drop_default
+      ~is_default:(fun (p : list_style_position) -> p = Outside)
+      s.position
+  in
+  let image =
+    drop_default ~is_default:(fun (i : list_style_image) -> i = None) s.image
+  in
+  if
+    option_is_phys_same type_ s.type_
+    && option_is_phys_same position s.position
+    && option_is_phys_same image s.image
+  then s
+  else { type_; position; image }
+
+let normalize_list_style : list_style -> list_style = function
+  | Shorthand s as value ->
+      let s' = normalize_list_style_shorthand s in
+      if s' == s then value else Shorthand s'
+  | value -> value
 
 let rec pp_list_style : list_style Pp.t =
  fun ctx -> function
@@ -3608,6 +3627,7 @@ let normalize_property_value : type a.
   | Display -> normalize_display value
   | Overflow -> normalize_overflow value
   | Transition -> map_preserve normalize_transition value
+  | List_style -> normalize_list_style value
   | Transition_timing_function -> normalize_timing_function value
   | Animation -> map_preserve normalize_animation value
   | Animation_timing_function -> normalize_timing_function value

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3607,6 +3607,10 @@ let normalize_property_value : type a.
   | Font -> normalize_font value
   | Display -> normalize_display value
   | Overflow -> normalize_overflow value
+  | Transition -> map_preserve normalize_transition value
+  | Transition_timing_function -> normalize_timing_function value
+  | Animation -> map_preserve normalize_animation value
+  | Animation_timing_function -> normalize_timing_function value
   | Padding_left -> Values.normalize_length ~ctx value
   | Padding_right -> Values.normalize_length ~ctx value
   | Padding_bottom -> Values.normalize_length ~ctx value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1936,6 +1936,11 @@ let spec_property_grammar_table_expansion () =
             (Some "animation-range:entry 10%exit 90%", None)
         | "display", "inline flow-root" ->
             (Some "display:inline flow-root", Some "display:inline-block")
+        | "display", "list-item flow-root" ->
+            (* CSS Display 3 (ED) sec. 2 combines the list-item components with
+               [&&], so the two spellings are one value; sec. 2.3 leaves the
+               [block] outside unwritten. *)
+            (Some "display:flow-root list-item", None)
         | "position-try-fallbacks", "--below, flip-block" ->
             (Some "position-try-fallbacks:--below,flip-block", None)
         | "cursor", "url(cursor.cur), pointer" ->

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -486,6 +486,41 @@ let special_cases () =
   check_declaration ~expected:"border-color:var(--c)red"
     "border-color: var(--c) red;";
 
+  (* CSS Box 4 (ED) sec. 3.2 and sec. 4.2: "If there is only one component
+     value, it applies to all sides. If there are two values, the top and bottom
+     margins are set to the first value and the right and left margins are set
+     to the second. If there are three values, the top is set to the first
+     value, the left and right are set to the second, and the bottom is set to
+     the third." A repeated side therefore has a shorter spelling naming the
+     same four sides, and picking it is a node change, so pp prints what it
+     parsed and the optimizer folds. *)
+  check_declaration ~expected:"margin:2px 2px 2px 2px" ~optimized:"margin:2px"
+    "margin: 2px 2px 2px 2px";
+  check_declaration ~expected:"margin:1px 2px 1px 2px"
+    ~optimized:"margin:1px 2px" "margin: 1px 2px 1px 2px";
+  check_declaration ~expected:"margin:1px 2px 3px 2px"
+    ~optimized:"margin:1px 2px 3px" "margin: 1px 2px 3px 2px";
+  check_declaration ~expected:"margin:1px 1px 1px" ~optimized:"margin:1px"
+    "margin: 1px 1px 1px";
+  check_declaration ~expected:"margin:1px 2px 1px" ~optimized:"margin:1px 2px"
+    "margin: 1px 2px 1px";
+  (* Four distinct sides have no shorter spelling. *)
+  check_declaration ~expected:"margin:1px 2px 3px 4px"
+    ~optimized:"margin:1px 2px 3px 4px" "margin: 1px 2px 3px 4px";
+  check_declaration ~expected:"padding:0 0 0 0" ~optimized:"padding:0"
+    "padding: 0 0 0 0";
+  (* The logical shorthands take the same one-to-four assignment over their own
+     two sides. *)
+  check_declaration ~expected:"padding-inline:1px 1px"
+    ~optimized:"padding-inline:1px" "padding-inline: 1px 1px";
+  (* CSS Position 3 (ED) sec. 3.2 defines [inset] as [<'top'>{1,4}], and CSS
+     Backgrounds 3 (ED) sec. 3.1 defines [border-color] over the same
+     one-to-four side assignment. *)
+  check_declaration ~expected:"inset:1px 1px 1px 1px" ~optimized:"inset:1px"
+    "inset: 1px 1px 1px 1px";
+  check_declaration ~expected:"border-color:red red red red"
+    ~optimized:"border-color:red" "border-color: red red red red";
+
   (* clip-path/object-view-box inset() and margin-inline/margin-block hit the
      same CSS Syntax 3 sec. 4.3.3 percentage-token boundary as margin/padding
      above, but print through their own list combinator rather than the shared

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1229,6 +1229,51 @@ let animations_timing () =
   check_declaration
     ~expected:"animation-timing-function:cubic-bezier(.4,0,.2,1)"
     "animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1)";
+  (* CSS Easing 1 (ED) sec. 2.2 gives each cubic bezier keyword its equivalent
+     curve, and sec. 2.3 computes [step-start] to [steps(1, start)] and
+     [step-end] to [steps(1, end)], with [start] behaving as [jump-start], [end]
+     as [jump-end], and an omitted step position assumed to be [end]. Every pair
+     below is one easing under two spellings and the keyword is the shorter one,
+     so pp prints what it parsed and the optimizer folds. *)
+  check_declaration
+    ~expected:"animation-timing-function:cubic-bezier(.25,.1,.25,1)"
+    ~optimized:"animation-timing-function:ease"
+    "animation-timing-function: cubic-bezier(0.25, 0.1, 0.25, 1)";
+  check_declaration
+    ~expected:"animation-timing-function:cubic-bezier(.42,0,1,1)"
+    ~optimized:"animation-timing-function:ease-in"
+    "animation-timing-function: cubic-bezier(0.42, 0, 1, 1)";
+  check_declaration
+    ~expected:"animation-timing-function:cubic-bezier(0,0,.58,1)"
+    ~optimized:"animation-timing-function:ease-out"
+    "animation-timing-function: cubic-bezier(0, 0, 0.58, 1)";
+  check_declaration
+    ~expected:"animation-timing-function:cubic-bezier(.42,0,.58,1)"
+    ~optimized:"animation-timing-function:ease-in-out"
+    "animation-timing-function: cubic-bezier(0.42, 0, 0.58, 1)";
+  check_declaration ~expected:"animation-timing-function:cubic-bezier(0,0,1,1)"
+    ~optimized:"animation-timing-function:linear"
+    "animation-timing-function: cubic-bezier(0, 0, 1, 1)";
+  check_declaration ~expected:"transition-timing-function:steps(1,jump-start)"
+    ~optimized:"transition-timing-function:step-start"
+    "transition-timing-function: steps(1, jump-start)";
+  check_declaration ~expected:"transition-timing-function:steps(1,start)"
+    ~optimized:"transition-timing-function:step-start"
+    "transition-timing-function: steps(1, start)";
+  check_declaration ~expected:"transition-timing-function:steps(1,jump-end)"
+    ~optimized:"transition-timing-function:step-end"
+    "transition-timing-function: steps(1, jump-end)";
+  check_declaration ~expected:"transition-timing-function:steps(1)"
+    ~optimized:"transition-timing-function:step-end"
+    "transition-timing-function: steps(1)";
+  (* [jump-none] and [jump-both] have no keyword spelling, and neither does a
+     step count above one. *)
+  check_declaration ~expected:"transition-timing-function:steps(1,jump-both)"
+    ~optimized:"transition-timing-function:steps(1,jump-both)"
+    "transition-timing-function: steps(1, jump-both)";
+  check_declaration ~expected:"transition-timing-function:steps(2,jump-start)"
+    ~optimized:"transition-timing-function:steps(2,jump-start)"
+    "transition-timing-function: steps(2, jump-start)";
 
   (* Per CSS Values 4 section 7.2 the time unit ([s] or [ms]) is required for
      [<time>]. [0s] does not drop the unit. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -713,7 +713,23 @@ let display () =
   c ~expected:"display:block list-item" ~optimized:"display:list-item"
     "display: block flow list-item";
   c ~expected:"display:inline list-item" ~optimized:"display:inline list-item"
-    "display: inline flow list-item"
+    "display: inline flow list-item";
+  (* sec. 2 orders none of the three: [<display-outside>? && [ flow | flow-root
+     ]? && list-item] reads the inside keyword on either side of the
+     [list-item]. sec. 2.3 defaults the unwritten inside to [flow] and the
+     unwritten outside to [block], so [flow-root list-item] is what [block
+     flow-root list-item] says and pp writes the shorter one. *)
+  c ~expected:"display:flow-root list-item"
+    ~optimized:"display:flow-root list-item" "display: flow-root list-item";
+  c ~expected:"display:flow-root list-item"
+    ~optimized:"display:flow-root list-item" "display: list-item flow-root";
+  c ~expected:"display:flow-root list-item"
+    ~optimized:"display:flow-root list-item"
+    "display: block flow-root list-item";
+  c ~expected:"display:block list-item" ~optimized:"display:list-item"
+    "display: flow list-item";
+  c ~expected:"display:block list-item" ~optimized:"display:list-item"
+    "display: list-item flow"
 
 let position () =
   let c = check_declaration in

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1494,7 +1494,31 @@ let list_properties () =
 
   (* Transition *)
   check_declaration ~expected:"transition:none" "transition: none";
-  check_declaration ~expected:"transition:all .3s" "transition: all 0.3s ease";
+  (* CSS Transitions 1 (ED) sec. 2.5 builds a [<single-transition>] out of
+     components that each fall back to their longhand initial when left out:
+     [0s] for the duration (sec. 2.2), [ease] for the easing (sec. 2.3), [0s]
+     for the delay (sec. 2.4). Spelling an initial out therefore names the value
+     the shorter form already names, and swapping the two is a node change, so
+     pp prints what it parsed and the optimizer folds. *)
+  check_declaration ~expected:"transition:all .3s ease"
+    ~optimized:"transition:all .3s" "transition: all 0.3s ease";
+  check_declaration ~expected:"transition:all 1s ease 0s"
+    ~optimized:"transition:all 1s" "transition: all 1s ease 0s";
+  check_declaration ~expected:"transition:opacity 1s normal"
+    ~optimized:"transition:opacity 1s" "transition: opacity 1s normal";
+  check_declaration ~expected:"transition:opacity 0s 0s"
+    ~optimized:"transition:opacity" "transition: opacity 0s 0s";
+  (* sec. 2.5: "the first value that can be parsed as a time is assigned to the
+     transition-duration, and the second value that can be parsed as a time is
+     assigned to transition-delay". A delay is only reachable behind a duration,
+     so a zero duration that carries a non-zero delay has to stay written out:
+     dropping it hands the delay to the duration slot and starts the transition
+     immediately instead of two seconds late. *)
+  check_declaration ~expected:"transition:opacity 0s 2s"
+    ~optimized:"transition:opacity 0s 2s" "transition: opacity 0s 2s";
+  check_declaration ~expected:"transition:opacity 0s linear 2s"
+    ~optimized:"transition:opacity 0s linear 2s"
+    "transition: opacity 0s linear 2s";
   check_declaration ~expected:"transition:all .3s linear"
     "transition: all .3s linear";
   check_declaration ~expected:"transition:opacity 1s ease-in .5s"

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -534,7 +534,15 @@ let special_cases () =
   check_declaration ~expected:"margin-inline:10%20%" "margin-inline: 10% 20%;";
   check_declaration ~expected:"margin-inline:10px 20px"
     "margin-inline: 10px 20px;";
-  check_declaration ~expected:"margin-block:10%20%" "margin-block: 10% 20%;"
+  check_declaration ~expected:"margin-block:10%20%" "margin-block: 10% 20%;";
+  (* CSS Logical 1 (ED) sec. 4.2 defines [margin-inline] and [margin-block] as
+     [<'margin-top'>{1,2}]: "If only one value is given, it applies to both the
+     start and end edges." Two equal edges are therefore the longer spelling of
+     the single value, the way the physical shorthand's four sides are. *)
+  check_declaration ~expected:"margin-inline:1px 1px"
+    ~optimized:"margin-inline:1px" "margin-inline: 1px 1px";
+  check_declaration ~expected:"margin-block:1px 1px"
+    ~optimized:"margin-block:1px" "margin-block: 1px 1px"
 
 let colors () =
   (* Same-node spellings the printer keeps (case-fold, hex shorten). The

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -521,6 +521,39 @@ let special_cases () =
   check_declaration ~expected:"border-color:red red red red"
     ~optimized:"border-color:red" "border-color: red red red red";
 
+  (* CSS Lists 3 (ED) sec. 3.6: [list-style] is [<'list-style-position'> ||
+     <'list-style-image'> || <'list-style-type'>], so a component left out takes
+     its longhand initial - [outside] (sec. 3.5), [none] (sec. 3.3) and [disc]
+     (sec. 3.4). Writing an initial out names what leaving it out names, and
+     dropping it is a node change, so pp holds it and the optimizer folds. *)
+  check_declaration ~expected:"list-style:disc outside"
+    ~optimized:"list-style:disc" "list-style: disc outside";
+  check_declaration ~expected:"list-style:outside" ~optimized:"list-style:disc"
+    "list-style: outside";
+  check_declaration ~expected:"list-style:disc outside none"
+    ~optimized:"list-style:disc" "list-style: disc outside none";
+  check_declaration ~expected:"list-style:square outside"
+    ~optimized:"list-style:square" "list-style: square outside";
+  (* sec. 3.6 resolves a bare [none] onto whichever of the image and the type
+     the shorthand does not otherwise set, so [list-style: none] sets both. That
+     makes [none] the shortest spelling of that one node rather than a fold, and
+     it is what both layers print. *)
+  check_declaration ~expected:"list-style:none" ~optimized:"list-style:none"
+    "list-style: none";
+  check_declaration ~expected:"list-style:none" ~optimized:"list-style:none"
+    "list-style: none none";
+  (* With the image set, the [none] lands on the type and both stay. *)
+  check_declaration ~expected:"list-style:none url(bullet.png)"
+    ~optimized:"list-style:none url(bullet.png)"
+    "list-style: none url(bullet.png)";
+  (* With the type set, the [none] lands on the image, which is its initial, so
+     what is left is the all-initial value the single [disc] names. *)
+  check_declaration ~expected:"list-style:disc none"
+    ~optimized:"list-style:disc" "list-style: none disc";
+  (* A non-initial position stands. *)
+  check_declaration ~expected:"list-style:square inside"
+    ~optimized:"list-style:square inside" "list-style: square inside";
+
   (* clip-path/object-view-box inset() and margin-inline/margin-block hit the
      same CSS Syntax 3 sec. 4.3.3 percentage-token boundary as margin/padding
      above, but print through their own list combinator rather than the shared

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -880,6 +880,25 @@ let text_properties () =
     "text-decoration: overline";
   check_declaration ~expected:"text-decoration:line-through"
     "text-decoration: line-through";
+  (* CSS Text Decoration 4 (ED) sec. 2.6: the [text-decoration] shorthand sets
+     the line, thickness, style and colour longhands, and "Omitted values are
+     set to their initial values" - [solid] (sec. 2.2) and [currentcolor] (sec.
+     2.3). Writing one out names what leaving it out names, and dropping it is a
+     node change, so pp holds it and the optimizer folds. *)
+  check_declaration ~expected:"text-decoration:underline solid"
+    ~optimized:"text-decoration:underline" "text-decoration: underline solid";
+  check_declaration ~expected:"text-decoration:underline currentColor"
+    ~optimized:"text-decoration:underline"
+    "text-decoration: underline currentcolor";
+  check_declaration ~expected:"text-decoration:underline solid currentColor"
+    ~optimized:"text-decoration:underline"
+    "text-decoration: underline solid currentcolor";
+  (* A non-initial style or colour stands. *)
+  check_declaration ~expected:"text-decoration:underline dotted"
+    ~optimized:"text-decoration:underline dotted"
+    "text-decoration: underline dotted";
+  check_declaration ~expected:"text-decoration:underline red"
+    ~optimized:"text-decoration:underline red" "text-decoration: underline red";
 
   (* Text transform *)
   check_declaration ~expected:"text-transform:none" "text-transform: none";
@@ -1599,6 +1618,16 @@ let list_properties () =
   check_declaration ~expected:"text-shadow:0 0 10px blue,0 0 20px red"
     ~optimized:"text-shadow:0 0 10px #00f,0 0 20px red"
     "text-shadow: 0 0 10px blue, 0 0 20px red";
+  (* CSS Text Decoration 4 (ED) sec. 4 reads a text shadow as a [<shadow>] "as
+     for box-shadow", and CSS Backgrounds 3 (ED) sec. 6.1 says "Omitted lengths
+     are 0". The blur is the last length here, so a zero blur is the spelled-out
+     form of leaving it off, and dropping it is a node change. *)
+  check_declaration ~expected:"text-shadow:1px 1px 0"
+    ~optimized:"text-shadow:1px 1px" "text-shadow: 1px 1px 0";
+  check_declaration ~expected:"text-shadow:1px 1px 0 red"
+    ~optimized:"text-shadow:1px 1px red" "text-shadow: 1px 1px 0 red";
+  check_declaration ~expected:"text-shadow:1px 1px 2px"
+    ~optimized:"text-shadow:1px 1px 2px" "text-shadow: 1px 1px 2px";
 
   (* Background image *)
   check_declaration ~expected:"background-image:none" "background-image: none";

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -252,6 +252,21 @@ let test_transition_default_spellings_factor () =
     ".a{transition:opacity 0s 2s}.b{transition:opacity 2s}"
     (optimize_str ".a{transition:opacity 0s 2s}.b{transition:opacity 2s}")
 
+(* CSS Easing 1 (ED) sec. 2.2 and sec. 2.3 give the named curves and the
+   one-step easings a keyword spelling of the same function, so the two rules
+   set the same easing and have to reach factoring as one node. *)
+let test_timing_function_spellings_factor () =
+  Alcotest.(check string)
+    "the named curve factors with its keyword"
+    ".a,.b{transition-timing-function:ease-in}"
+    (optimize_str
+       ".a{transition-timing-function:cubic-bezier(.42,0,1,1)}.b{transition-timing-function:ease-in}");
+  Alcotest.(check string)
+    "the one-step easing factors with its keyword"
+    ".a,.b{transition-timing-function:step-end}"
+    (optimize_str
+       ".a{transition-timing-function:steps(1,end)}.b{transition-timing-function:step-end}")
+
 let suite =
   ( "factor",
     [
@@ -283,4 +298,6 @@ let suite =
         `Quick test_overflow_pair_spellings_factor;
       Alcotest.test_case "spelled-out transition initials factor away" `Quick
         test_transition_default_spellings_factor;
+      Alcotest.test_case "easing curves factor with their keywords" `Quick
+        test_timing_function_spellings_factor;
     ] )

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -279,6 +279,14 @@ let test_box_shorthand_spellings_factor () =
     "an axis pair factors with the two-value form" ".a,.b{padding:1px 2px}"
     (optimize_str ".a{padding:1px 2px 1px 2px}.b{padding:1px 2px}")
 
+(* CSS Lists 3 (ED) sec. 3.6 lets each component of [list-style] fall back to
+   its longhand initial, so the marker written with its initials spelled out is
+   the one the single keyword already names. *)
+let test_list_style_default_spellings_factor () =
+  Alcotest.(check string)
+    "spelled-out initials factor with the bare type" ".a,.b{list-style:disc}"
+    (optimize_str ".a{list-style:disc outside none}.b{list-style:disc}")
+
 let suite =
   ( "factor",
     [
@@ -314,4 +322,6 @@ let suite =
         test_timing_function_spellings_factor;
       Alcotest.test_case "repeated box sides factor with the short form" `Quick
         test_box_shorthand_spellings_factor;
+      Alcotest.test_case "spelled-out list-style initials factor away" `Quick
+        test_list_style_default_spellings_factor;
     ] )

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -267,6 +267,18 @@ let test_timing_function_spellings_factor () =
     (optimize_str
        ".a{transition-timing-function:steps(1,end)}.b{transition-timing-function:step-end}")
 
+(* CSS Box 4 (ED) sec. 3.2 and sec. 4.2 assign one to four values around the
+   box, so a shorthand whose sides repeat names what the shorter spelling names.
+   Factoring compares nodes, so the two rules meet as one declaration only if
+   the fold happened first. *)
+let test_box_shorthand_spellings_factor () =
+  Alcotest.(check string)
+    "four equal sides factor with the single value" ".a,.b{margin:2px}"
+    (optimize_str ".a{margin:2px 2px 2px 2px}.b{margin:2px}");
+  Alcotest.(check string)
+    "an axis pair factors with the two-value form" ".a,.b{padding:1px 2px}"
+    (optimize_str ".a{padding:1px 2px 1px 2px}.b{padding:1px 2px}")
+
 let suite =
   ( "factor",
     [
@@ -300,4 +312,6 @@ let suite =
         test_transition_default_spellings_factor;
       Alcotest.test_case "easing curves factor with their keywords" `Quick
         test_timing_function_spellings_factor;
+      Alcotest.test_case "repeated box sides factor with the short form" `Quick
+        test_box_shorthand_spellings_factor;
     ] )

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -235,6 +235,23 @@ let test_font_shorthand_default_slots_factor () =
     (optimize_str
        ".a{font:400 12px serif}.b{font:12px/normal serif}.c{font:12px serif}")
 
+(* CSS Transitions 1 (ED) sec. 2.5 lets every component of a
+   [<single-transition>] fall back to its longhand initial, so a transition that
+   writes [ease] and [0s] out is the one the bare duration already names.
+   Factoring compares nodes, so the two rules meet as one declaration only if
+   the fold happened first. *)
+let test_transition_default_spellings_factor () =
+  Alcotest.(check string)
+    "spelled-out initials factor with the omitted form"
+    ".a,.b{transition:all 1s}"
+    (optimize_str ".a{transition:all 1s ease 0s}.b{transition:1s}");
+  (* The second time is the delay, so a zero duration in front of one is not a
+     default that can go: the two rules name different transitions. *)
+  Alcotest.(check string)
+    "a delayed transition does not factor with a plain one"
+    ".a{transition:opacity 0s 2s}.b{transition:opacity 2s}"
+    (optimize_str ".a{transition:opacity 0s 2s}.b{transition:opacity 2s}")
+
 let suite =
   ( "factor",
     [
@@ -264,4 +281,6 @@ let suite =
         test_display_spellings_factor;
       Alcotest.test_case "equal overflow axes factor with the single value"
         `Quick test_overflow_pair_spellings_factor;
+      Alcotest.test_case "spelled-out transition initials factor away" `Quick
+        test_transition_default_spellings_factor;
     ] )

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -287,6 +287,20 @@ let test_list_style_default_spellings_factor () =
     "spelled-out initials factor with the bare type" ".a,.b{list-style:disc}"
     (optimize_str ".a{list-style:disc outside none}.b{list-style:disc}")
 
+(* CSS Text Decoration 4 (ED) sec. 2.6 sets an omitted shorthand component to
+   its initial, and sec. 4 with CSS Backgrounds 3 (ED) sec. 6.1 reads an omitted
+   shadow length as zero, so each pair below is one value under two
+   spellings. *)
+let test_text_decoration_default_spellings_factor () =
+  Alcotest.(check string)
+    "the initial style factors away" ".a,.b{text-decoration:underline}"
+    (optimize_str
+       ".a{text-decoration:underline solid}.b{text-decoration:underline}");
+  Alcotest.(check string)
+    "a zero blur factors with the two-length shadow"
+    ".a,.b{text-shadow:1px 1px}"
+    (optimize_str ".a{text-shadow:1px 1px 0}.b{text-shadow:1px 1px}")
+
 let suite =
   ( "factor",
     [
@@ -324,4 +338,6 @@ let suite =
         test_box_shorthand_spellings_factor;
       Alcotest.test_case "spelled-out list-style initials factor away" `Quick
         test_list_style_default_spellings_factor;
+      Alcotest.test_case "spelled-out text decoration defaults factor away"
+        `Quick test_text_decoration_default_spellings_factor;
     ] )

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -405,9 +405,12 @@ let test_inline_cycle_fallbacks () =
     ":root{--a:var(--b)}.x{color:var(--a,red)}" ".x{color:red}"
 
 let test_inline_shorthand_functions () =
+  (* CSS Transitions 1 (ED) sec. 2.5: [ease] is the easing initial, so pp holds
+     the spelled-out form and the optimizer folds it away. *)
   check_inline_case "transition variable resolves into property slot"
+    ~optimized:".a{transition:opacity .3s}"
     ":root{--prop:opacity}.a{transition:var(--prop) .3s ease}"
-    ".a{transition:opacity .3s}";
+    ".a{transition:opacity .3s ease}";
   check_inline_case "animation variable resolves into name slot"
     ":root{--anim:slide}.b{animation:var(--anim) 1s ease infinite}"
     ".b{animation:slide 1s infinite}";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1187,6 +1187,25 @@ let test_display () =
   check_display "table-row-group";
   check_display "inline-table";
   check_display "list-item";
+  (* CSS Display 3 (ED) sec. 2 defines [<display-listitem>] as
+     [<display-outside>? && [ flow | flow-root ]? && list-item], all three
+     order-free, so the inside keyword reads whether it comes before or after
+     the [list-item]. sec. 2.3: "If no inner display type value is specified,
+     the principal box's inner display type defaults to flow. If no outer
+     display type value is specified, the principal box's outer display type
+     defaults to block", so each default is left unwritten. *)
+  check_display "flow-root list-item";
+  check_display ~expected:"flow-root list-item" "list-item flow-root";
+  check_display ~expected:"block list-item" "flow list-item";
+  check_display ~expected:"block list-item" "list-item flow";
+  check_display "inline flow-root list-item";
+  check_display ~expected:"inline flow-root list-item"
+    "list-item inline flow-root";
+  (* [list-item] is not a [<display-outside>] and appears once in the
+     production, so neither a second [list-item] nor an inside outside the [flow
+     | flow-root] pair is a display value. *)
+  neg_cursor ~allow_partial:true read_display "list-item list-item";
+  neg_cursor ~allow_partial:true read_display "list-item table";
   check_display "contents";
   (* Intentional legacy: accepted for compatibility in some engines *)
   check_display "-webkit-box";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3598,23 +3598,28 @@ let test_border_image_outset () =
 let test_list_style () =
   (* All-initial values collapse to the canonical single token [disc], never the
      position initial [outside] (which would change which longhand is set). *)
+  (* The printer holds every component it parsed; dropping one that equals its
+     longhand initial is a node change the optimizer makes (pinned in
+     test_declaration). *)
   check_list_style "disc";
-  check_list_style ~expected:"disc" "outside";
-  check_list_style ~expected:"disc" "disc outside";
-  check_list_style ~expected:"disc" "disc outside none";
+  check_list_style "outside";
+  check_list_style "disc outside";
+  check_list_style "disc outside none";
   check_list_style "square inside";
-  check_list_style ~expected:"square" "square outside";
+  check_list_style "square outside";
   check_list_style "inside";
+  (* CSS Lists 3 (ED) sec. 3.6 sends a lone [none] to both the type and the
+     image, so the single keyword is the same node the pair spells out. *)
   check_list_style "none";
   check_list_style "url(a.png)";
-  check_list_style ~expected:"square url(a.png)" "square outside url(a.png)";
+  check_list_style "square outside url(a.png)";
   check_list_style "inherit";
   check_list_style "initial";
   neg_cursor read_list_style "12px"
 
 let test_list_style_shorthand () =
   check_list_style_shorthand "disc";
-  check_list_style_shorthand ~expected:"disc" "disc outside";
+  check_list_style_shorthand "disc outside";
   check_list_style_shorthand "square inside";
   check_list_style_shorthand "square";
   check_list_style_shorthand "none";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1983,12 +1983,14 @@ let test_text_decoration () =
   neg_cursor read_text_decoration "red"
 
 let test_text_decoration_shorthand () =
-  (* Test individual parts *)
+  (* Test individual parts. The printer holds every component it parsed;
+     dropping one that equals its longhand initial is a node change the
+     optimizer makes (pinned in test_declaration). *)
   check_text_decoration_shorthand "underline";
-  check_text_decoration_shorthand ~expected:"underline" "underline solid";
-  check_text_decoration_shorthand ~expected:"underline red"
+  check_text_decoration_shorthand "underline solid";
+  check_text_decoration_shorthand ~expected:"underline solid red"
     "underline solid red";
-  check_text_decoration_shorthand ~expected:"underline red 2px"
+  check_text_decoration_shorthand ~expected:"underline solid red 2px"
     "underline solid red 2px";
   (* Test multiple lines *)
   check_text_decoration_shorthand ~expected:"underline overline"
@@ -1996,7 +1998,7 @@ let test_text_decoration_shorthand () =
   check_text_decoration_shorthand ~expected:"underline overline dashed"
     "underline overline dashed";
   (* Test order independence *)
-  check_text_decoration_shorthand ~expected:"underline red"
+  check_text_decoration_shorthand ~expected:"underline solid red"
     "red solid underline";
   check_text_decoration_shorthand ~expected:"underline wavy blue 3px"
     "3px wavy blue underline";


### PR DESCRIPTION
The box, list-style, text-decoration, text-shadow, transition and easing printers each dropped a component that equalled its longhand initial, or collapsed repeated box sides, at print time, so two rules that named one value two ways reached factoring as different nodes and never merged. The folds move into the normalize pass and the printers hold what they parsed.

Two defects fell out of that. `transition: opacity 0s 2s` printed `transition:opacity 2s`, which CSS Transitions 1 sec. 2.5 reads as a two-second transition starting straight away rather than an instant one two seconds late; and `display: flow-root list-item` was rejected because the reader tested the outside slot before the inside one, while `list-item` stood in for a `<display-outside>` it is not.
