### PR TITLE
variables: expose the var() body reader that returns strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -788,6 +788,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Custom properties
 
+- `Css.Variables.read_reference_body_as_string` reads the same `var()`
+  argument list as `read_reference_body` and returns the name and the fallback
+  as text, for a caller with no value type to pick a typed fallback reader
+  from. Such a caller had to assemble a `var(...)` wrapper for
+  `read_reference` (#XXX)
 - `Css.Variables.read_reference_body` reads a `var()` argument list - a name
   and optional fallback - into a typed variable handle from a cursor
   already positioned at the arguments, without the `var(`/`)` wrapper (#630)

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2616,6 +2616,25 @@ let string_of_fallback inner =
       in
       String.trim slice
 
+(* CSS Custom Properties 1 sec. 3: [var( <custom-property-name> ,
+   <declaration-value>? )], read from a cursor already positioned at the
+   argument list. The string-returning counterpart of [read_var_body], for a
+   caller with no value type to read the fallback at. *)
+let read_reference_body_as_string (r : Cursor.t) : string * string option =
+  Cursor.ws r;
+  let raw_name = Cursor.ident ~keep_case:true r in
+  (* css-variables-1: a <custom-property-name> is a <dashed-ident> other than
+     the bare reserved [--] keyword. A further leading dash is part of the
+     name. *)
+  if not (Custom_property_name.is_valid raw_name) then
+    Cursor.err_invalid r ("not a custom property: " ^ raw_name);
+  let name = Custom_property_name.strip_prefix raw_name in
+  Cursor.ws r;
+  let fallback =
+    if Cursor.comma_opt r then Some (string_of_fallback r) else None
+  in
+  (name, fallback)
+
 (** Parse a CSS variable reference with optional fallback value. This creates a
     variable handle for parsing purposes only - it doesn't have type or layer
     information which would need to be resolved from a variable registry or
@@ -2631,22 +2650,7 @@ let read_reference (r : Cursor.t) : string * string option =
     | Some (Component.Func fn) -> fn.node.terminated
     | _ -> true
   in
-  let result =
-    Cursor.call "var" r (fun inner ->
-        let raw_name = Cursor.ident ~keep_case:true inner in
-        (* css-variables-1: a <custom-property-name> is a <dashed-ident> other
-           than the bare reserved [--] keyword. A further leading dash is part
-           of the name. *)
-        if not (Custom_property_name.is_valid raw_name) then
-          Cursor.err_invalid inner ("not a custom property: " ^ raw_name);
-        let name = Custom_property_name.strip_prefix raw_name in
-        Cursor.ws inner;
-        let fallback =
-          if Cursor.comma_opt inner then Some (string_of_fallback inner)
-          else None
-        in
-        (name, fallback))
-  in
+  let result = Cursor.call "var" r read_reference_body_as_string in
   (match (terminated, snd result) with
   | false, None -> Cursor.err_invalid r "unterminated var()"
   | _ -> ());

--- a/lib/variables.mli
+++ b/lib/variables.mli
@@ -127,3 +127,11 @@ val read_reference_body : (Cursor.t -> 'a) -> Cursor.t -> 'a var
     without the surrounding [var(] and [)]. Unlike {!read_reference}, which
     returns strings, this reads the fallback with [read] and returns a typed
     variable handle. *)
+
+val read_reference_body_as_string : Cursor.t -> string * string option
+(** [read_reference_body_as_string t] parses a [var()] reference body from a
+    cursor already positioned at the arguments, as {!read_reference_body} does,
+    and returns the name without its [--] prefix and the fallback as the
+    [<declaration-value>] text, as {!read_reference} does. It is what a caller
+    with no value type to pick a fallback reader from needs, and the fallback it
+    hands back is what {!Values.syntax_fallback} consumes. *)

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -637,6 +637,40 @@ let spec_read_reference_body_edges () =
   neg_cursor (read_reference_body read_length) "not-a-var";
   neg_cursor (read_reference_body read_length) "--"
 
+(* The string-returning counterpart of {!read_reference_body}: same [var(
+   <custom-property-name> , <declaration-value>? )] argument list, read from a
+   cursor already positioned at it, but handing back the name and the fallback
+   text rather than a typed handle. A caller that has no value type to pick a
+   fallback reader from needs the [<declaration-value>] as the text
+   {!Values.syntax_fallback} consumes. *)
+let spec_read_reference_body_as_string_edges () =
+  let check input expected_name expected_fallback =
+    let r = Cursor.of_string input in
+    let name, fallback = read_reference_body_as_string r in
+    Alcotest.(check string) (input ^ " name") expected_name name;
+    Alcotest.(check (option string))
+      (input ^ " fallback") expected_fallback fallback
+  in
+  (* No fallback: just the [<custom-property-name>], [--] stripped as
+     {!read_reference} strips it. *)
+  check "--x" "x" None;
+  check "--x, 10px" "x" (Some "10px");
+  (* A trailing comma with nothing after it is an explicit empty fallback,
+     distinct from no fallback at all. *)
+  check "--x," "x" (Some "");
+  (* The fallback is a [<declaration-value>]: commas inside it belong to it. *)
+  check "--x, red, blue" "x" (Some "red, blue");
+  check "--shadow, 0 0 0 var(--f, black)" "shadow"
+    (Some "0 0 0 var(--f, black)");
+  (* CSS Custom Properties 1 sec. 3 round-trips author comments in a
+     fallback. *)
+  check "--commented, a /*x*/ b" "commented" (Some "a /*x*/ b");
+  (* A third dash starts the ident body; it is not forbidden. *)
+  check "---" "-" None;
+  neg_cursor read_reference_body_as_string "not-a-var";
+  neg_cursor read_reference_body_as_string "--";
+  neg_cursor read_reference_body_as_string "--, red"
+
 let spec_custom_computed_edges () =
   let check_context name specified =
     let decl = Css.Declaration.of_string (name ^ ": " ^ specified) in
@@ -698,6 +732,9 @@ let tests =
     ("read_reference", `Quick, test_read_var_reference);
     ("spec custom property fallback edges", `Quick, spec_custom_fallback_edges);
     ("spec read_reference_body edges", `Quick, spec_read_reference_body_edges);
+    ( "spec read_reference_body_as_string edges",
+      `Quick,
+      spec_read_reference_body_as_string_edges );
     ( "spec custom property computed-time edges",
       `Quick,
       spec_custom_computed_edges );


### PR DESCRIPTION
`read_reference` reads a whole `var(...)` and returns strings; `read_reference_body` reads the body but takes a typed fallback reader and returns an `'a var`. A caller that has a body-positioned cursor and wants the strings had neither, so tw assembles `"var(--" ^ name ^ ")"` just to feed `read_reference`.

This PR adds `read_reference_body_as_string`, lifted out of the closure `read_reference` already passed to `Cursor.call`, so `read_reference` now composes with it and its behaviour is unchanged.