### PR TITLE
docs: correct the css.mli type docs and the CSS Syntax citations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -792,7 +792,7 @@ recorded cases carrying six minifiers' answers.
   argument list as `read_reference_body` and returns the name and the fallback
   as text, for a caller with no value type to pick a typed fallback reader
   from. Such a caller had to assemble a `var(...)` wrapper for
-  `read_reference` (#XXX)
+  `read_reference` (#642)
 - `Css.Variables.read_reference_body` reads a `var()` argument list - a name
   and optional fallback - into a typed variable handle from a cursor
   already positioned at the arguments, without the `var(`/`)` wrapper (#630)

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -133,9 +133,9 @@ let ua_declared =
         m names)
     SMap.empty ua_groups
 
-(* CSS Syntax 3 sec. 5.4: a style attribute is a declaration list, not a rule
-   body, so a declaration's value runs to the next top-level [;] or the end of
-   input, where only [{], [(] and [[] open a block. A [}] is then a preserved
+(* CSS Syntax 3 (ED) sec. 5.5: a style attribute is a declaration list, not a
+   rule body, so a declaration's value runs to the next top-level [;] or the end
+   of input, where only [{], [(] and [[] open a block. A [}] is then a preserved
    token inside the value rather than a terminator, and splicing the attribute
    into [a{...}] lets it close the rule instead, reviving a declaration no
    browser applies. Recovery drops the invalid declaration and keeps the rest,

--- a/lib/component.ml
+++ b/lib/component.ml
@@ -1,4 +1,4 @@
-(** Stage 3 IR: CSS Syntax section 5.1 component values and rules. *)
+(** Stage 3 IR: CSS Syntax 3 (ED) sec. 5.1 component values and rules. *)
 
 type 'a node = { node : 'a; loc : Loc.t }
 
@@ -9,8 +9,8 @@ and block = {
   value : t list;
   closed : bool;
       (** [false] when the lexer reached EOF before the matching closer (CSS
-          Syntax section 5.4.6 parse error). Typed validators inspect this to
-          reject values that the syntax level only forgives. *)
+          Syntax 3 (ED) sec. 5.5.9 parse error). Typed validators inspect this
+          to reject values that the syntax level only forgives. *)
 }
 
 and func = {
@@ -18,10 +18,10 @@ and func = {
   arguments : t list;
   terminated : bool;
       (** [false] when the lexer reached EOF before the matching [)] (CSS Syntax
-          section 5.4.6 parse error). The serializer still emits the synthetic
-          [)] so reserialised output round-trips through the lexer; typed
-          validators can inspect this flag to reject values that the syntax
-          level only forgives. *)
+          3 (ED) sec. 5.4.6 parse error). The serializer still emits the
+          synthetic [)] so reserialised output round-trips through the lexer;
+          typed validators can inspect this flag to reject values that the
+          syntax level only forgives. *)
 }
 
 type at_rule_body = {
@@ -83,9 +83,9 @@ let closing_char : Token.bracket -> char = function
   | Square -> ']'
 
 (* A debug dump, not source text: every node shows its own location and the CSS
-   Syntax section 5.4.6 flags [compare] separates values on. [Pp.space] rather
-   than [Pp.sp] because a dump has no minified form, and layout whitespace would
-   drop out and run the children together. *)
+   Syntax 3 (ED) sec. 5.5.9 and 5.5.10 flags [compare] separates values on.
+   [Pp.space] rather than [Pp.sp] because a dump has no minified form, and
+   layout whitespace would drop out and run the children together. *)
 let rec pp : t Pp.t =
  fun ctx cv ->
   match cv with

--- a/lib/component.mli
+++ b/lib/component.mli
@@ -1,4 +1,4 @@
-(** Stage 3 IR: CSS Syntax section 5.1 component values and rules.
+(** Stage 3 IR: CSS Syntax 3 (ED) sec. 5.1 component values and rules.
 
     Stage 3 of the pipeline (chars -> lexer stream -> token stream -> AST): the
     output of {!Parser}, consumed by the typed-AST validators.
@@ -19,7 +19,7 @@ and block = {
   value : t list;
   closed : bool;
       (** [false] when the lexer reached EOF before the matching closer (CSS
-          Syntax sec. 5.4.6 parse error). The serializer still emits the
+          Syntax 3 (ED) sec. 5.5.9 parse error). The serializer still emits the
           synthetic closer so reserialised output round-trips. *)
 }
 
@@ -28,10 +28,10 @@ and func = {
   arguments : t list;
   terminated : bool;
       (** [false] when the lexer reached EOF before the matching [)] (CSS Syntax
-          section 5.4.6 parse error). The serializer still emits the synthetic
-          [)] so reserialised output round-trips through the lexer; typed
-          validators can inspect this flag to reject values that the syntax
-          level only forgives. *)
+          3 (ED) sec. 5.5.10 parse error). The serializer still emits the
+          synthetic [)] so reserialised output round-trips through the lexer;
+          typed validators can inspect this flag to reject values that the
+          syntax level only forgives. *)
 }
 
 type at_rule_body = {

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -53,8 +53,8 @@ let string_of_range_operator = function
   | Gt -> ">"
   | Gte -> ">="
 
-(* CSS Syntax 3 sec. 4.3.7: a [style()] query names a custom property, and an
-   escape can carry a [;] or a [}] into that name, so it is written back with
+(* CSS Syntax 3 (ED) sec. 4.3.7: a [style()] query names a custom property, and
+   an escape can carry a [;] or a [}] into that name, so it is written back with
    the escapes that read the same name (see [Properties.pp_property]). *)
 let rec string_of_style_query ~minify = function
   | Boolean name -> Parser.escape_ident name
@@ -815,8 +815,8 @@ let min_width l : Media.t =
   Media.Cond
     (Media.Feature (Media.Plain (Media.Min Media.Width, Media.Length l)))
 
-(* CSS Syntax 3 sec. 5.5.6 consumes a declaration by discarding the whitespace
-   after the colon and removing the trailing whitespace tokens, so a
+(* CSS Syntax 3 (ED) sec. 5.5.6 consumes a declaration by discarding the
+   whitespace after the colon and removing the trailing whitespace tokens, so a
    [<style-feature-plain>] means the same however much space the source left
    around its value. A [<style-range>] carries no whitespace at all: the parser
    strips it before splitting on the comparison. *)

--- a/lib/container.mli
+++ b/lib/container.mli
@@ -125,7 +125,7 @@ val normalize : t -> t
     feature they spell. A [style()] or [scroll-state()] function name loses the
     case the source wrote it in (CSS Values 4 sec. 9), and a
     [<style-feature-plain>] loses the whitespace around its value (CSS Syntax 3
-    sec. 5.5.6).
+    (ED) sec. 5.5.6).
 
     Completeness is a separate property, and it stops there. Equivalences
     [normalize] leaves apart: a [style()] property name spelled in another case;

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -684,12 +684,12 @@ val custom_declarations : ?layer:string -> declaration list -> declaration list
 (** CSS calc operations. *)
 type calc_op = Values.calc_op = Add | Sub | Mul | Div
 
-(** CSS Values 4 sec. 10.7.1 math constants - emitted at the source byte
-    sequence so pretty pp preserves [calc(2 * pi)] instead of writing
+(** CSS Values 4 sec. 10.7 math constants - emitted at the source byte sequence
+    so pretty pp preserves [calc(2 * pi)] instead of writing
     [calc(6.28318530718)]. *)
 type math_const = Values.math_const = Pi | E | Infinity | Neg_infinity | Nan
 
-(** CSS Values 4 sec. 9.1 numeric math function arguments. *)
+(** CSS Values 4 (ED) sec. 9.1 numeric math function arguments. *)
 type math_arg = Values.math_arg =
   | Lit of float
   | Dim of float * string  (** A dimension argument (e.g. [1vw], [1%]). *)
@@ -699,7 +699,7 @@ type math_arg = Values.math_arg =
   | Parens_arg of math_arg
   | Math_call of math_fn
 
-(** CSS Values 4 sec. 9.1 numeric math functions. *)
+(** CSS Values 4 (ED) sec. 9.1 numeric math functions. *)
 and math_fn = Values.math_fn =
   | Sin of angle_arg
   | Cos of angle_arg
@@ -734,14 +734,15 @@ type 'a calc = 'a Values.calc =
   | Val of 'a
   | Num of float  (** Unitless number *)
   | Math_const of math_const
-      (** CSS Values 4 sec. 10.7.1 math constant ([pi], [e], [infinity],
+      (** CSS Values 4 sec. 10.7 math constant ([pi], [e], [infinity],
           [-infinity], [NaN]) preserved verbatim through pretty pp. *)
   | Sibling_index  (** CSS [sibling-index()] math function. *)
   | Sibling_count  (** CSS [sibling-count()] math function. *)
   | Expr of 'a calc * calc_op * 'a calc
   | Nested of 'a calc  (** Explicitly nested calc() *)
   | Parens of 'a calc  (** Parenthesized expression *)
-  | Math_fn of math_fn  (** CSS Values 4 sec. 9.1 numeric math function call. *)
+  | Math_fn of math_fn
+      (** CSS Values 4 (ED) sec. 9.1 numeric math function call. *)
 
 type component_values = Component.t list
 (** Parsed CSS component values preserved for fallback and invalid-value
@@ -6612,10 +6613,6 @@ val webkit_background_clip : background_box -> declaration
     @see <https://www.w3.org/TR/css-contain-2/> CSS Containment Module Level 2
 *)
 
-(** [aspect_ratio ratio] is the
-    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio}
-     aspect-ratio} property. *)
-
 (** CSS container-type values *)
 type container_type = Properties.container_type =
   | Size
@@ -7739,19 +7736,21 @@ val of_string :
   ?enforce_spec:bool ->
   string ->
   (parse, Error.t) result
-(** [of_string ?strict css] parses [css] with CSS Syntax 3 section 5.4 recovery.
-    Returns [Ok { stylesheet; warnings }] when no fatal syntax error escapes
-    recovery; {!field-warnings} carries every typed diagnostic the parser
-    collected (unknown at-rules, unknown properties, invalid values, ...). With
-    [~strict:true] a non-empty {!field-warnings} list collapses to [Error]
-    (first warning) - useful in linters and CI gates that want to fail on any
-    spec deviation. [?meta] controls diagnostic richness; see {!Loc.meta_level}.
+(** [of_string ?strict css] parses [css] with CSS Syntax 3 (ED) section 5.4
+    recovery. Returns [Ok { stylesheet; warnings }] when no fatal syntax error
+    escapes recovery; {!field-warnings} carries every typed diagnostic the
+    parser collected (unknown at-rules, unknown properties, invalid values,
+    ...). With [~strict:true] a non-empty {!field-warnings} list collapses to
+    [Error] (first warning) - useful in linters and CI gates that want to fail
+    on any spec deviation. [?meta] controls diagnostic richness; see
+    {!Loc.meta_level}.
 
     [enforce_spec] (default [false]) restricts non-ASCII identifiers to the CSS
-    Syntax 3 sec. 4.2 range list, which excludes most BMP symbols. The default
-    accepts any code point [>= U+0080], so a selector such as [.text-\u{2197}]
-    reads rather than being dropped with a warning. Output is unaffected either
-    way: a code point outside the range list is hex-escaped. *)
+    Syntax 3 (ED) sec. 4.2 range list, which excludes most BMP symbols. The
+    default accepts any code point [>= U+0080], so a selector such as
+    [.text-\u{2197}] reads rather than being dropped with a warning. Output is
+    unaffected either way: a code point outside the range list is hex-escaped.
+*)
 
 val of_string_exn :
   ?strict:bool ->
@@ -7908,7 +7907,7 @@ val resolve_theme :
     [theme_defaults] maps a custom-property name to its value and is the source
     of global theme-token definitions. An answer binds only when the name and
     the value make one custom-property declaration - a [<dashed-ident>] name and
-    a CSS Syntax 3 sec. 8.2 [<declaration-value>], as
+    a CSS Syntax 3 (ED) sec. 7.2 [<declaration-value>], as
     {!Declaration.parse_custom_property} checks. Any other answer, such as one
     carrying a [}] or a top-level [;], reads as no default at all and leaves the
     reference live. Every [var()] reference that is undefined in [stylesheet]

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1175,14 +1175,14 @@ type percentage = Values.percentage =
   | Var of percentage var
   | Calc of percentage calc (* calc(...) that resolves to a % *)
 
-(** Spec-invalid input preserved verbatim. *)
+(** CSS length or percentage values. *)
 type length_percentage = Values.length_percentage =
   | Length of length
   | Pct of float
   | Env of length_percentage env
   | Var of length_percentage var
   | Calc of length_percentage calc
-  | Invalid of invalid_value
+  | Invalid of invalid_value  (** Spec-invalid input preserved verbatim. *)
 
 (** CSS number or percentage values (for properties like scale, brightness) *)
 type number_percentage = Values.number_percentage =
@@ -1432,7 +1432,7 @@ type aspect_ratio = Properties.aspect_ratio =
   | Unset
   | Revert
   | Revert_layer
-  | Var of aspect_ratio var  (** CSS blend-mode values *)
+  | Var of aspect_ratio var
 
 val ratio : float -> float -> aspect_ratio
 (** [ratio width height] is an [aspect-ratio] value such as [16 / 9]. *)
@@ -1441,7 +1441,7 @@ val auto_ratio : float -> float -> aspect_ratio
 (** [auto_ratio width height] is an [aspect-ratio] value such as [auto 16 / 9].
 *)
 
-(** CSS font-feature-settings values *)
+(** CSS blend-mode values *)
 type blend_mode = Properties.blend_mode =
   | Normal
   | Multiply
@@ -1468,7 +1468,7 @@ type blend_mode = Properties.blend_mode =
   | Revert_layer
   | Var of blend_mode var
 
-(** CSS font-variation-settings values *)
+(** CSS font-feature-settings values *)
 type font_feature_settings = Properties.font_feature_settings =
   | Normal
   | Feature_list of string
@@ -1480,6 +1480,7 @@ type font_feature_settings = Properties.font_feature_settings =
   | String of string
   | Var of font_feature_settings var
 
+(** CSS font-variation-settings values *)
 type font_variation_settings = Properties.font_variation_settings =
   | Normal
   | Axis_list of string
@@ -1537,9 +1538,9 @@ type box_sizing = Properties.box_sizing =
   | Unset
   | Revert
   | Revert_layer
-  | Var of box_sizing var  (** CSS field sizing values. *)
+  | Var of box_sizing var
 
-(** CSS caption side values. *)
+(** CSS field sizing values. *)
 type field_sizing = Properties.field_sizing =
   | Content
   | Fixed
@@ -1550,6 +1551,7 @@ type field_sizing = Properties.field_sizing =
   | Revert_layer
   | Var of field_sizing var
 
+(** CSS caption side values. *)
 type caption_side = Properties.caption_side =
   | Top
   | Bottom
@@ -1897,9 +1899,9 @@ type display = Properties.display =
   | Multi of display * display
       (** Two-value [<display-outside> <display-inside>] syntax per CSS Display
           3 sec. 2.1, e.g. [inline flow-root] or [list-item flow-root]. *)
-  | Var of display var  (** CSS position values. *)
+  | Var of display var
 
-(** CSS visibility values. *)
+(** CSS position values. *)
 type position = Properties.position =
   | Static
   | Relative
@@ -1914,7 +1916,7 @@ type position = Properties.position =
   | Revert_layer
   | Var of position var
 
-(** CSS z-index values. *)
+(** CSS visibility values. *)
 type visibility = Properties.visibility =
   | Visible
   | Hidden
@@ -1926,7 +1928,7 @@ type visibility = Properties.visibility =
   | Revert_layer
   | Var of visibility var
 
-(** CSS opacity values. *)
+(** CSS z-index values. *)
 type z_index = Properties.z_index =
   | Auto
   | Index of int
@@ -1938,6 +1940,7 @@ type z_index = Properties.z_index =
   | Revert_layer
   | Var of z_index var
 
+(** CSS opacity values. *)
 type opacity = Properties.opacity =
   | Opacity_number of float
   | Calc of opacity calc
@@ -1948,9 +1951,9 @@ type opacity = Properties.opacity =
   | Unset
   | Revert
   | Revert_layer
-  | Var of opacity var  (** CSS order values (flexbox order). *)
+  | Var of opacity var
 
-(** CSS overflow values. *)
+(** CSS order values (flexbox order). *)
 type order = Properties.order =
   | Int of int
   | Calc of order calc
@@ -1961,6 +1964,7 @@ type order = Properties.order =
   | Revert_layer
   | Var of order var
 
+(** CSS overflow values. *)
 type overflow = Properties.overflow =
   | Visible
   | Hidden
@@ -2153,7 +2157,7 @@ type page_size_orientation = Properties.page_size_orientation =
   | Landscape
   | Var of page_size_orientation var
 
-(** CSS columns values for multi-column layout. *)
+(** CSS paged-media [size] descriptor values. *)
 type page_size = Properties.page_size =
   | Auto
   | Single of length
@@ -2164,6 +2168,7 @@ type page_size = Properties.page_size =
   | Inherit
   | Var of page_size var
 
+(** CSS columns values for multi-column layout. *)
 type columns_value = Properties.columns_value =
   | Auto
   | Count of int
@@ -2765,9 +2770,9 @@ type forced_color_adjust = Properties.forced_color_adjust =
   | Unset
   | Revert
   | Revert_layer
-  | Var of forced_color_adjust var  (** CSS background-repeat values. *)
+  | Var of forced_color_adjust var
 
-(** CSS background-size values. *)
+(** CSS background-repeat values. *)
 type background_repeat = Properties.background_repeat =
   | Repeat
   | Space
@@ -2799,7 +2804,7 @@ type background_repeat = Properties.background_repeat =
   | Revert_layer
   | Var of background_repeat var
 
-(** CSS background-attachment values. *)
+(** CSS background-size values. *)
 type background_size = Properties.background_size =
   | Auto
   | Cover
@@ -2817,7 +2822,7 @@ type background_size = Properties.background_size =
 val background_size_pair : length -> length -> background_size
 (** [background_size_pair width height] is a two-value [background-size]. *)
 
-(** Color interpolation for gradients *)
+(** CSS background-attachment values. *)
 type background_attachment = Properties.background_attachment =
   | Scroll
   | Fixed
@@ -2838,7 +2843,7 @@ type hue_interpolation_method = Properties.hue_interpolation_method =
   | Increasing
   | Decreasing
 
-(** Gradient direction values *)
+(** Color interpolation for gradients *)
 type color_interpolation = Properties.color_interpolation =
   | In_oklab
   | In_oklch of hue_interpolation_method option
@@ -2848,7 +2853,7 @@ type color_interpolation = Properties.color_interpolation =
   | In_lch of hue_interpolation_method option
   | Var of color_interpolation var
 
-(** Gradient stop values *)
+(** Gradient direction values *)
 type gradient_direction = Properties.gradient_direction =
   | Default_direction
   | To_top
@@ -2867,8 +2872,9 @@ type gradient_direction = Properties.gradient_direction =
 type radial_shape = Properties.radial_shape =
   | Circle
   | Ellipse
-  | Var of radial_shape var  (** Size of a radial gradient *)
+  | Var of radial_shape var
 
+(** Size of a radial gradient *)
 type radial_size = Properties.radial_size =
   | Closest_side
   | Farthest_side
@@ -2902,6 +2908,7 @@ type gradient_position = Properties.gradient_position =
   | Conic_position of conic_gradient_config
   | Var of gradient_position var
 
+(** Gradient stop values *)
 type gradient_stop = Properties.gradient_stop =
   | Color_percentage of
       color * length_percentage option * length_percentage option
@@ -3093,7 +3100,7 @@ and cross_fade_option = Properties.cross_fade_option = {
   percent : percentage option;
 }
 
-(** Mask-related types *)
+(** CSS background and mask box values. *)
 type background_box = Properties.background_box =
   | Border_box
   | Padding_box
@@ -3107,6 +3114,7 @@ type background_box = Properties.background_box =
   | Revert_layer
   | Var of background_box var
 
+(* Mask-related types *)
 type webkit_mask_composite = Properties.webkit_mask_composite =
   | Source_over
   | Xor
@@ -3349,9 +3357,9 @@ type flex_direction = Properties.flex_direction =
   | Unset
   | Revert
   | Revert_layer
-  | Var of flex_direction var  (** CSS flex wrap values. *)
+  | Var of flex_direction var
 
-(** CSS flex basis values. *)
+(** CSS flex wrap values. *)
 type flex_wrap = Properties.flex_wrap =
   | Nowrap
   | Wrap
@@ -3382,7 +3390,7 @@ type flex_factor = Properties.flex_factor =
   | Calc of flex_factor calc
   | Var of flex_factor var
 
-(** CSS flex shorthand values. *)
+(** CSS flex basis values. *)
 type flex_basis = Properties.flex_basis =
   | Auto
   | Content
@@ -3444,6 +3452,7 @@ type flex_basis = Properties.flex_basis =
   | Calc of flex_basis calc
   | Var of flex_basis var
 
+(** CSS flex shorthand values. *)
 type flex = Properties.flex =
   | Initial  (** 0 1 auto *)
   | Inherit
@@ -3458,9 +3467,9 @@ type flex = Properties.flex =
   | Full of flex_factor * flex_factor * flex_basis  (** grow shrink basis *)
   | Var of flex var
 
-(** CSS align-content values.
-    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/align-content} MDN:
-     align-content} *)
+(** CSS font-size values.
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/font-size} MDN:
+     font-size} *)
 type font_size = Properties.font_size =
   | Length of length
   | Pct of float
@@ -3483,9 +3492,13 @@ type font_size = Properties.font_size =
   | Revert_layer
   | Var of font_size var
 
-(** CSS align-items values.
-    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/align-items} MDN:
-     align-items} *)
+(** {2:alignment_properties Alignment Properties}
+
+    CSS Box Alignment properties for flexbox and grid layouts. *)
+
+(** CSS align-content values.
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/align-content} MDN:
+     align-content} *)
 type align_content = Properties.align_content =
   | Normal
   | Baseline
@@ -3525,9 +3538,9 @@ type align_content = Properties.align_content =
   | Revert_layer
   | Var of align_content var
 
-(** CSS justify-content values.
-    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content} MDN:
-     justify-content} *)
+(** CSS align-items values.
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/align-items} MDN:
+     align-items} *)
 type align_items = Properties.align_items =
   | Normal
   | Stretch
@@ -3561,9 +3574,9 @@ type align_items = Properties.align_items =
   | Revert_layer
   | Var of align_items var
 
-(** CSS align-self values.
-    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/align-self} MDN:
-     align-self} *)
+(** CSS justify-content values.
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/justify-content} MDN:
+     justify-content} *)
 type justify_content = Properties.justify_content =
   | Normal
   | Center
@@ -3596,9 +3609,9 @@ type justify_content = Properties.justify_content =
   | Revert_layer
   | Var of justify_content var
 
-(** CSS justify-items values.
-    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items} MDN:
-     justify-items} *)
+(** CSS align-self values.
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/align-self} MDN:
+     align-self} *)
 type align_self = Properties.align_self =
   | Auto
   | Normal
@@ -3632,9 +3645,9 @@ type align_self = Properties.align_self =
   | Revert_layer
   | Var of align_self var
 
-(** CSS justify-self values.
-    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self} MDN:
-     justify-self} *)
+(** CSS justify-items values.
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items} MDN:
+     justify-items} *)
 type justify_items = Properties.justify_items =
   | Normal
   | Stretch
@@ -3680,8 +3693,9 @@ type justify_items = Properties.justify_items =
   | Revert_layer
   | Var of justify_items var
 
-(** {2:alignment_properties Alignment Properties}
-    CSS Box Alignment properties for flexbox and grid layouts. *)
+(** CSS justify-self values.
+    {{:https://developer.mozilla.org/en-US/docs/Web/CSS/justify-self} MDN:
+     justify-self} *)
 type justify_self = Properties.justify_self =
   | Auto
   | Normal
@@ -3901,7 +3915,7 @@ type grid_template = Properties.grid_template =
   | Masonry
   | Var of grid_template var
 
-(** CSS grid line values *)
+(** CSS grid-template-areas values *)
 type grid_template_areas = Properties.grid_template_areas =
   | No_areas
   | Areas of string
@@ -3912,6 +3926,7 @@ type grid_template_areas = Properties.grid_template_areas =
   | Revert_layer
   | Var of grid_template_areas var
 
+(** CSS grid line values *)
 type grid_line = Properties.grid_line =
   | Auto  (** auto *)
   | Num of int  (** 1, 2, 3, ... or -1, -2, ... *)
@@ -4114,9 +4129,9 @@ type font_weight = Properties.font_weight =
   | Unset
   | Revert
   | Revert_layer
-  | Var of font_weight var  (** CSS text align values. *)
+  | Var of font_weight var
 
-(** CSS text decoration values. *)
+(** CSS text align values. *)
 type text_align = Properties.text_align =
   | Left
   | Right
@@ -4168,6 +4183,7 @@ type text_decoration_shorthand = Properties.text_decoration_shorthand = {
   thickness : length option;
 }
 
+(** CSS text decoration values. *)
 type text_decoration = Properties.text_decoration =
   | None
   | Shorthand of text_decoration_shorthand
@@ -4279,14 +4295,14 @@ type font_style = Properties.font_style =
   | Unset
   | Revert
   | Revert_layer
-  | Var of font_style var  (** CSS text transform values. *)
+  | Var of font_style var
 
 type text_transform_case = Properties.text_transform_case =
   | Capitalize
   | Uppercase
   | Lowercase
 
-(** CSS text-size-adjust values (including vendor prefixes). *)
+(** CSS text transform values. *)
 type text_transform = Properties.text_transform =
   | None
   | Case of text_transform_case
@@ -4302,7 +4318,7 @@ type text_transform = Properties.text_transform =
   | Revert_layer
   | Var of text_transform var
 
-(** CSS font-family values *)
+(** CSS text-size-adjust values (including vendor prefixes). *)
 type text_size_adjust = Properties.text_size_adjust =
   | None
   | Auto
@@ -4314,8 +4330,7 @@ type text_size_adjust = Properties.text_size_adjust =
   | Revert_layer
   | Var of text_size_adjust var
 
-(** CSS-wide keyword mixed in a [<custom-ident>#] list, preserved verbatim and
-    dropped by [Optimize.drop_invalid] under minify. *)
+(** CSS font-family values *)
 type font_family = Properties.font_family =
   (* Generic CSS font families *)
   | Sans_serif
@@ -4422,6 +4437,8 @@ type font_family = Properties.font_family =
   | List of font_family list
   | Var of font_family var
   | Invalid of invalid_value
+      (** CSS-wide keyword mixed in a [<custom-ident>#] list, preserved verbatim
+          and dropped by [Optimize.drop_invalid] under minify. *)
 
 val font_stack : font_family list -> font_family
 (** [font_stack fonts] is a comma-separated [font-family] stack. *)
@@ -5202,7 +5219,7 @@ type border_shorthand = Properties.border_shorthand = {
 }
 (** CSS border shorthand type. *)
 
-(** CSS outline style values. *)
+(** CSS border property values. *)
 type border = Properties.border =
   | Inherit
   | Initial
@@ -5245,6 +5262,7 @@ val logical_border_width : border_width -> logical_border_width
 val logical_border_widths : border_width -> border_width -> logical_border_width
 (** [logical_border_widths start end_] is a two-value logical border width. *)
 
+(** CSS outline style values. *)
 type outline_style = Properties.outline_style =
   | None
   | Solid
@@ -5734,9 +5752,9 @@ type steps_direction = Properties.steps_direction =
   | Jump_both
   | Start
   | End
-  | Var of steps_direction var  (** CSS animation timing function values. *)
+  | Var of steps_direction var
 
-(** CSS duration values. *)
+(** CSS animation timing function values. *)
 type timing_function = Properties.timing_function =
   | Ease
   | Linear
@@ -5756,6 +5774,7 @@ type timing_function = Properties.timing_function =
   | Revert_layer
   | Var of timing_function var
 
+(** CSS duration values. *)
 type duration = Values.duration =
   | Ms of float  (** milliseconds *)
   | S of float  (** seconds *)
@@ -5879,9 +5898,9 @@ type animation_fill_mode = Properties.animation_fill_mode =
   | Unset
   | Revert
   | Revert_layer
-  | Var of animation_fill_mode var  (** CSS animation direction values *)
+  | Var of animation_fill_mode var
 
-(** CSS animation play state values *)
+(** CSS animation direction values *)
 type animation_direction = Properties.animation_direction =
   | Normal
   | Reverse
@@ -5895,7 +5914,7 @@ type animation_direction = Properties.animation_direction =
   | Revert_layer
   | Var of animation_direction var
 
-(** CSS animation iteration count values *)
+(** CSS animation play state values *)
 type animation_play_state = Properties.animation_play_state =
   | Running
   | Paused
@@ -5907,6 +5926,7 @@ type animation_play_state = Properties.animation_play_state =
   | Revert_layer
   | Var of animation_play_state var
 
+(** CSS animation iteration count values *)
 type animation_iteration_count = Properties.animation_iteration_count =
   | Num of float
   | Infinite
@@ -6152,7 +6172,7 @@ type clip = Properties.clip =
   | Unset
   | Revert
   | Revert_layer
-  | Var of clip var  (** CSS clip-path property values for clipping regions. *)
+  | Var of clip var
 
 type clip_geometry_box = Properties.clip_geometry_box =
   | Margin_box
@@ -6170,6 +6190,7 @@ type clip_path_extent = Properties.clip_path_extent =
 
 type clip_path_fill_rule = Properties.clip_path_fill_rule = Nonzero | Evenodd
 
+(** CSS clip-path property values for clipping regions. *)
 type clip_path = Properties.clip_path =
   | Clip_path_none
   | Clip_path_url of string
@@ -6356,13 +6377,13 @@ type cursor = Properties.cursor =
   | Unset
   | Revert
   | Revert_layer
-  | Var of cursor var  (** CSS user-select values. *)
+  | Var of cursor var
 
 val cursor_url : ?hotspot:float * float -> fallback:cursor -> string -> cursor
 (** [cursor_url ?hotspot ~fallback url] is a URL cursor with its required
     fallback. *)
 
-(** CSS resize values. *)
+(** CSS user-select values. *)
 type user_select = Properties.user_select =
   | None
   | Auto
@@ -6376,7 +6397,7 @@ type user_select = Properties.user_select =
   | Revert_layer
   | Var of user_select var
 
-(** CSS print-color-adjust values. *)
+(** CSS resize values. *)
 type resize = Properties.resize =
   | None
   | Both
@@ -6391,6 +6412,7 @@ type resize = Properties.resize =
   | Revert_layer
   | Var of resize var
 
+(** CSS print-color-adjust values. *)
 type print_color_adjust = Properties.print_color_adjust =
   | Economy
   | Exact
@@ -6677,9 +6699,9 @@ type webkit_box_orient = Properties.webkit_box_orient =
   | Unset
   | Revert
   | Revert_layer
-  | Var of webkit_box_orient var  (** CSS -webkit-line-clamp values. *)
+  | Var of webkit_box_orient var
 
-(** CSS -webkit-appearance values. *)
+(** CSS -webkit-line-clamp values. *)
 type webkit_line_clamp = Properties.webkit_line_clamp =
   | None
   | Lines of int
@@ -6690,6 +6712,7 @@ type webkit_line_clamp = Properties.webkit_line_clamp =
   | Revert_layer
   | Var of webkit_line_clamp var
 
+(** CSS -webkit-appearance values. *)
 type webkit_appearance = Properties.webkit_appearance =
   | None  (** No appearance styling *)
   | Auto  (** Default browser styling *)
@@ -6707,9 +6730,9 @@ type webkit_appearance = Properties.webkit_appearance =
   | Unset
   | Revert
   | Revert_layer
-  | Var of webkit_appearance var  (** CSS -webkit-font-smoothing values. *)
+  | Var of webkit_appearance var
 
-(** CSS -moz-osx-font-smoothing values. *)
+(** CSS -webkit-font-smoothing values. *)
 type webkit_font_smoothing = Properties.webkit_font_smoothing =
   | Auto
   | None
@@ -6722,6 +6745,7 @@ type webkit_font_smoothing = Properties.webkit_font_smoothing =
   | Revert_layer
   | Var of webkit_font_smoothing var
 
+(** CSS -moz-osx-font-smoothing values. *)
 type moz_osx_font_smoothing = Properties.moz_osx_font_smoothing =
   | Auto
   | Grayscale
@@ -6790,7 +6814,7 @@ val webkit_text_size_adjust : text_size_adjust -> declaration
 
     Properties for styling HTML lists and tables. *)
 
-(** CSS list-style-type values *)
+(** CSS [symbols()] counter-system keywords *)
 type symbols_type = Properties.symbols_type =
   | Cyclic
   | Numeric
@@ -6808,7 +6832,7 @@ val list_style_symbol_string : string -> list_style_symbol
 val list_style_symbol_url : string -> list_style_symbol
 (** [list_style_symbol_url value] is a URL symbol for [symbols()]. *)
 
-(** CSS list-style-image values *)
+(** CSS list-style-type values *)
 type list_style_type = Properties.list_style_type =
   | None
   | Disc
@@ -6882,6 +6906,7 @@ val list_style_symbols :
   ?kind:symbols_type -> list_style_symbol list -> list_style_type
 (** [list_style_symbols ?kind symbols] is a [symbols(...)] list-style type. *)
 
+(** CSS list-style-image values *)
 type list_style_image = Properties.list_style_image =
   | None
   | Url of string
@@ -7042,15 +7067,15 @@ type touch_action = Properties.touch_action =
   | Revert
   | Revert_layer
   | Vars of touch_action var list
-  | Var of touch_action var  (** CSS scroll-snap-strictness values *)
+  | Var of touch_action var
 
-(** CSS scroll-snap axis values *)
+(** CSS scroll-snap-strictness values *)
 type scroll_snap_strictness = Properties.scroll_snap_strictness =
   | Mandatory
   | Proximity
   | Var of scroll_snap_strictness var
 
-(** CSS scroll-snap-type values *)
+(** CSS scroll-snap axis values *)
 type scroll_snap_axis = Properties.scroll_snap_axis =
   | None
   | X
@@ -7060,7 +7085,7 @@ type scroll_snap_axis = Properties.scroll_snap_axis =
   | Both
   | Var of scroll_snap_axis var
 
-(** CSS scroll-snap-align values *)
+(** CSS scroll-snap-type values *)
 type scroll_snap_type = Properties.scroll_snap_type =
   | Axis of scroll_snap_axis (* Just the axis, no strictness *)
   | Axis_with_strictness of
@@ -7073,6 +7098,7 @@ type scroll_snap_type = Properties.scroll_snap_type =
   | Revert_layer
   | Var of scroll_snap_type var
 
+(** CSS scroll-snap-align values *)
 type scroll_snap_align = Properties.scroll_snap_align =
   | None
   | Start

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1402,8 +1402,8 @@ type angle = Values.angle =
   | Calc of angle calc  (** Calculated angle expressions *)
   | Var of angle var
   | Invalid of invalid_value
-      (** Spec-invalid input preserved verbatim for round-trip; dropped by
-          [Optimize.drop_invalid] under [--minify]. *)
+      (** Spec-invalid input the parser keeps verbatim; [Optimize.drop_invalid]
+          drops the declaration on every serialisation. *)
 
 (** CSS number values (unitless numbers for filters, transforms, etc.) *)
 type number = Values.number =
@@ -4438,7 +4438,7 @@ type font_family = Properties.font_family =
   | Var of font_family var
   | Invalid of invalid_value
       (** CSS-wide keyword mixed in a [<custom-ident>#] list, preserved verbatim
-          and dropped by [Optimize.drop_invalid] under minify. *)
+          and dropped by [Optimize.drop_invalid] on every serialisation. *)
 
 val font_stack : font_family list -> font_family
 (** [font_stack fonts] is a comma-separated [font-family] stack. *)

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -57,7 +57,7 @@ let lex_to_cv_list parser =
   in
   loop []
 
-(* [source] must be the post-preprocessing buffer (CSS Syntax section 3.3),
+(* [source] must be the post-preprocessing buffer (CSS Syntax 3 (ED) sec. 3.3),
    which is what the lexer indexes against. Using the caller's raw string would
    desync [Loc.offset] from [Loc.snippet] when the input contains BOM, NUL, CR,
    FF, or CRLF. *)
@@ -789,7 +789,8 @@ let call name t f =
       if arg.depth > max_nesting_depth then err arg "nesting too deep";
       (* A function's grammar ends at its closing paren, so whatever [f] left
          behind is an invalid value, not a shorter one it may answer with (CSS
-         Syntax 3 sec. 8.2). [expect_eof] skips leading whitespace itself. *)
+         Syntax 3 (ED) sec. 7.2). [expect_eof] skips leading whitespace
+         itself. *)
       let v = f arg in
       expect_eof arg;
       v

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -350,7 +350,7 @@ val skip_past_semicolon : t -> unit
 (** [skip_past_semicolon t] consumes and discards components up to and including
     the next top-level semicolon, or up to end of input if none is left. A [{}]
     met on the way is one component value, not a stopping point, so this is the
-    recovery step CSS Syntax 3 sec. 5.4.4 prescribes for a declaration that
+    recovery step CSS Syntax 3 (ED) sec. 5.5.5 prescribes for a declaration that
     fails to parse. *)
 
 val consume_to_decl_end : ?trim:bool -> t -> string
@@ -450,7 +450,7 @@ val call : string -> t -> (t -> 'a) -> 'a
 (** [call name t f] consumes a [name(...)] function call and applies [f] to a
     cursor over its arguments. Raises if no such function is next, or if [f]
     leaves any of the arguments unconsumed: trailing content makes the value
-    invalid, not truncated (CSS Syntax 3 sec. 8.2). *)
+    invalid, not truncated (CSS Syntax 3 (ED) sec. 7.2). *)
 
 val function_call : string -> (t -> 'a) -> t -> 'a option
 (** [function_call name f t] consumes a [name(...)] call and calls [f] over its

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -361,9 +361,9 @@ let is_decl_unknown_property_name name =
 
 (** [is_invalid decl] is [true] when [decl]'s typed value is a known spec
     violation detected at parse time; [Optimize.drop_invalid] removes such
-    declarations under minify. An unknown property is not invalid: browsers keep
-    unrecognised declarations (CSS Syntax 3 sec. 5.4), and cascade emits them
-    (and vendor-prefix extensions) as raw component lists. *)
+    declarations on every serialisation. An unknown property is not invalid:
+    browsers keep unrecognised declarations (CSS Syntax 3 sec. 5.4), and cascade
+    emits them (and vendor-prefix extensions) as raw component lists. *)
 let rec is_invalid = function
   | Declaration { property = Unknown_property _; _ } -> false
   | Declaration { property; value; _ } ->

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -64,7 +64,7 @@ let rec normalize ?(lossless = false) ?(exact_srgb = false)
 
 let is_custom_property_name = Custom_property_name.is_valid
 
-(* CSS Syntax 3 sec. 8.2: a [<declaration-value>] is one or more component
+(* CSS Syntax 3 (ED) sec. 7.2: a [<declaration-value>] is one or more component
    values with no [<bad-string-token>], no [<bad-url-token>] and no unmatched
    closing bracket. A component breaking one of those does not stay inside the
    declaration it is written into: it closes the enclosing block, or turns the
@@ -117,7 +117,7 @@ let custom_property ?layer name value =
      an unmatched closing bracket, an unterminated function, block or string -
      leaves the declaration as soon as the text is read back. A name carrying
      one of those is written back with the escapes that read it (CSS Syntax 3
-     sec. 4.3.7), so it stays the name of this declaration. *)
+     (ED) sec. 4.3.7), so it stays the name of this declaration. *)
   if not (is_custom_property_name name) then
     refuse name "not a custom-property name";
   if not (is_optional_declaration_value value) then
@@ -362,8 +362,8 @@ let is_decl_unknown_property_name name =
 (** [is_invalid decl] is [true] when [decl]'s typed value is a known spec
     violation detected at parse time; [Optimize.drop_invalid] removes such
     declarations on every serialisation. An unknown property is not invalid:
-    browsers keep unrecognised declarations (CSS Syntax 3 sec. 5.4), and cascade
-    emits them (and vendor-prefix extensions) as raw component lists. *)
+    browsers keep unrecognised declarations (CSS Syntax 3 (ED) sec. 5.5), and
+    cascade emits them (and vendor-prefix extensions) as raw component lists. *)
 let rec is_invalid = function
   | Declaration { property = Unknown_property _; _ } -> false
   | Declaration { property; value; _ } ->
@@ -2027,7 +2027,7 @@ let read_custom_value_declaration t name : declaration =
 
 let read_custom_property_declaration t : declaration =
   let name = read_property_name t in
-  (* CSS Syntax 3 sec. 4.3.7 lets [\X] escapes carry any code point into an
+  (* CSS Syntax 3 (ED) sec. 4.3.7 lets [\X] escapes carry any code point into an
      ident, so the name may contain characters ([/], whitespace, etc.) that
      don't tokenize as a bare ident on a string round-trip. We trust the
      original lexer's tokenization: the only validation we still run is the
@@ -2191,7 +2191,7 @@ let read_unknown_property_declaration t name =
 let read_typed_value_declaration : type a. a property -> Cursor.t -> declaration
     =
  fun prop_type t ->
-  (* CSS Syntax 3 sec. 2.2 / sec. 4.3.5 auto-close unterminated functions,
+  (* CSS Syntax 3 (ED) sec. 2.2 / sec. 4.3.5 auto-close unterminated functions,
      brackets and strings at EOF. Typed readers consume the spec-recovered
      tokens; the declaration survives with the auto-closed shape. *)
   match prop_type with
@@ -2356,7 +2356,7 @@ let read_declaration_step t acc =
   if Cursor.recover t then read_declaration_with_recovery t acc
   else read_declaration_no_recovery t acc
 
-(* CSS Syntax 3 sec. 5.5.5 ("consume a block's contents"): the invalid
+(* CSS Syntax 3 (ED) sec. 5.5.5 ("consume a block's contents"): the invalid
    declaration is dropped, reading resumes past the next [;], and the
    surrounding rule survives. *)
 let recover_declaration_step t acc e =
@@ -2394,9 +2394,9 @@ let of_string s =
 (* The declaration [property] and [value] name, as the tokens they are. The name
    is one [<ident-token>] by construction and the value is parsed on its own, so
    neither reaches the other's position: written into one text, a name carrying
-   a [;] or a [}] (CSS Syntax 3 sec. 4.3.7 puts either there through an escape)
-   would end its own declaration, and one carrying a [:] would name the property
-   in front of it. *)
+   a [;] or a [}] (CSS Syntax 3 (ED) sec. 4.3.7 puts either there through an
+   escape) would end its own declaration, and one carrying a [:] would name the
+   property in front of it. *)
 let name_value_components property value =
   Component.Preserved (Token.synthetic (Token.Ident property))
   :: Component.Preserved (Token.synthetic Token.Colon)

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -56,8 +56,8 @@ val is_declaration_value : string -> bool
 (** [is_declaration_value s] is whether [s] is a [<declaration-value>]: one or
     more component values with no unmatched closing bracket, no top-level [;],
     no [<bad-string-token>] or [<bad-url-token>] and no unterminated function,
-    block or string (CSS Syntax 3 sec. 8.2). Text outside it stops being part of
-    the declaration it is written into. *)
+    block or string (CSS Syntax 3 (ED) sec. 7.2). Text outside it stops being
+    part of the declaration it is written into. *)
 
 val custom_property : ?layer:string -> string -> string -> declaration
 (** [custom_property ?layer name value] is a custom property declaration from
@@ -99,9 +99,9 @@ val parse_opaque_declaration : string -> string -> declaration option
 val parse_custom_property : string -> string -> declaration option
 (** [parse_custom_property name value] is {!parse_declaration} restricted to a
     custom property that a rule can hold. It is [None] unless [name] is a
-    [<dashed-ident>] and [value] is one [<declaration-value>] (CSS Syntax 3 sec.
-    8.2): no [<bad-string-token>], no [<bad-url-token>], no unmatched closing
-    bracket, no unterminated function or block, and no top-level [;].
+    [<dashed-ident>] and [value] is one [<declaration-value>] (CSS Syntax 3 (ED)
+    sec. 7.2): no [<bad-string-token>], no [<bad-url-token>], no unmatched
+    closing bracket, no unterminated function or block, and no top-level [;].
 
     Use it for a name or value that comes from outside the parser, where the
     string may close the block it is placed in or start a second declaration.

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -167,9 +167,9 @@ val is_important : declaration -> bool
 
 val is_invalid : declaration -> bool
 (** [is_invalid decl] is [true] when [decl]'s typed value is a CSS
-    spec-violation cascade detected at parse time. The minify-time
-    [Optimize.drop_invalid] pass uses this predicate to remove the declaration.
-*)
+    spec-violation cascade detected at parse time. [Optimize.drop_invalid],
+    which every serialisation runs, uses this predicate to remove the
+    declaration. *)
 
 val value_uses_color_4 : declaration -> bool
 (** [value_uses_color_4 decl] is [true] when [decl]'s typed value contains any

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -234,10 +234,10 @@ let build_reorder_diff expected_css actual_css =
   else Some D.{ rules = List.rev !diffs; containers = []; layer_order = None }
 
 (* [css] is value text neither side has parsed yet, so the declaration context
-   [property] names is given as text too. CSS Syntax 3 sec. 4.3.7 lets an escape
-   carry a [;] or a [}] into a custom property's name: written raw here such a
-   name ends the declaration or closes the rule, and both values go with it, so
-   the name is spelled the way the printer spells it. *)
+   [property] names is given as text too. CSS Syntax 3 (ED) sec. 4.3.7 lets an
+   escape carry a [;] or a [}] into a custom property's name: written raw here
+   such a name ends the declaration or closes the rule, and both values go with
+   it, so the name is spelled the way the printer spells it. *)
 let css_for_semantic_comparison ?property css =
   match property with
   | None -> css

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1068,9 +1068,9 @@ let pp_containers_section ~style buf containers =
       pp_container_diff ~style ~is_last ~parent_prefix:"" buf cont_diff)
     containers
 
-(* [Resolve.layer_order] escapes each ident of a path (CSS Syntax 3 sec. 2.1),
-   so only a bare [.] separates two of them: one an ident carries is written
-   [\.] and stays inside its own segment. *)
+(* [Resolve.layer_order] escapes each ident of a path (CSS Syntax 3 (ED) sec.
+   2.1), so only a bare [.] separates two of them: one an ident carries is
+   written [\.] and stays inside its own segment. *)
 let split_layer_path path =
   let len = String.length path in
   let rec go start i acc =

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -1,6 +1,6 @@
 (** Stage 2 stream: characters -> Token.t.
 
-    Wraps a {!Reader.t} char cursor and exposes the CSS Syntax section 4
+    Wraps a {!Reader.t} char cursor and exposes the CSS Syntax 3 (ED) sec. 4
     tokenizer through the uniform [next / peek / reconsume] triple. The token
     buffer doubles as a backtracking stack: {!save}/{!restore} mark and replay,
     mirroring {!Reader.save}/{!Reader.restore} for the Token layer. *)
@@ -33,8 +33,8 @@ let is_hex c = is_digit c || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
 let is_ws c = c = ' ' || c = '\n' || c = '\t' || c = '\r' || c = '\012'
 let is_newline c = c = '\n' || c = '\r' || c = '\012'
 
-(* CSS Syntax 3 section 4.2 "non-ASCII ident code point" ranges: a sealed list
-   that excludes most BMP symbols, among them the arrows.
+(* CSS Syntax 3 (ED) section 4.2 "non-ASCII ident code point" ranges: a sealed
+   list that excludes most BMP symbols, among them the arrows.
 
    Real stylesheets carry those anyway - Tailwind emits [.text-\u{2197}] - and
    dropping a rule is a worse failure for a minifier than accepting a code point
@@ -413,9 +413,9 @@ let consume_url_token r =
   skip_ws ();
   let rec loop () =
     match Reader.peek r with
-    (* CSS Syntax 3 section 4.3.6: EOF inside [url(] is a parse error but still
-       returns a [<url-token>], surfacing via recovery warnings rather than a
-       [<bad-url-token>]. *)
+    (* CSS Syntax 3 (ED) section 4.3.6: EOF inside [url(] is a parse error but
+       still returns a [<url-token>], surfacing via recovery warnings rather
+       than a [<bad-url-token>]. *)
     | None -> Url (Buffer.contents buf)
     | Some ')' ->
         Reader.skip r;
@@ -571,8 +571,8 @@ let rec skip_comment_body r =
     Reader.skip r;
     skip_comment_body r)
 
-(* Skip a run of comments without consuming surrounding whitespace: CSS Syntax
-   sec. 4.3.2 treats comments as "nothing", so a comment between two
+(* Skip a run of comments without consuming surrounding whitespace: CSS Syntax 3
+   (ED) sec. 4.3.2 treats comments as "nothing", so a comment between two
    non-whitespace points disappears rather than becoming a
    <whitespace-token>. *)
 let rec skip_comment_run r =
@@ -756,8 +756,9 @@ let record_consume t tok =
 
 (* True iff the previous token was [Url(...)] with no separator (whitespace or
    comment) after: the next [url(...)] would re-enter the url branch and merge,
-   so force a function-call to keep them distinct. Per CSS Syntax 4.3.2 comments
-   act like whitespace, so a [/* */] between the urls also disarms this. *)
+   so force a function-call to keep them distinct. Per CSS Syntax 3 (ED) sec.
+   4.3.2 comments act like whitespace, so a [/* */] between the urls also
+   disarms this. *)
 let force_url_function t =
   match t.history with
   | { kind = Url _; loc; _ } :: _ when loc.end_pos = Reader.position t.reader

--- a/lib/lexer.mli
+++ b/lib/lexer.mli
@@ -1,11 +1,11 @@
-(** Stage 2 stream: characters -> Token.t (CSS Syntax section 4).
+(** Stage 2 stream: characters -> Token.t (CSS Syntax 3 (ED) sec. 4).
 
     Wraps a {!Reader.t} and produces {!Token.t} values via the section 4.3
     tokenization algorithm. Exposes the uniform [next / peek / reconsume] triple
     used across parse stages.
 
-    The input is already-decoded UTF-8 text. CSS Syntax section 3.2 byte-stream
-    decoding is outside this layer. *)
+    The input is already-decoded UTF-8 text. CSS Syntax 3 (ED) sec. 3.2
+    byte-stream decoding is outside this layer. *)
 
 type t
 (** A lexer stream: a character cursor plus one-token pushback. *)
@@ -51,7 +51,7 @@ val is_done : t -> bool
 (** [is_done t] is [true] when no more tokens remain. *)
 
 val spec_non_ascii_ident_cp : int -> bool
-(** [spec_non_ascii_ident_cp cp] is the CSS Syntax section 4.2 predicate: is
+(** [spec_non_ascii_ident_cp cp] is the CSS Syntax 3 (ED) sec. 4.2 predicate: is
     [cp] in that section's range list of non-ASCII ident code points? Exposed
     for serialisers, which hex-escape anything outside it; an escape is read by
     every parser, so emission stays on this list even though reading accepts any

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -585,13 +585,14 @@ let drop_invalid (stylesheet : t) : t =
     (list_filter_preserve (fun d -> not (Declaration.is_invalid d)))
     stylesheet
 
-(* CSS Syntax 3 sec. 5.4.2 keeps an unrecognised at-rule's body as raw source
-   text, so no typed node stands between the author's layout and the output and
-   the serializer may not touch it: rewriting the body is an AST change. Reading
-   it back as a component-value stream and writing it out with the separator
-   rules that already serve custom-property streams keeps every token boundary,
-   string, escape and nested block while the layout between them goes. A body
-   the lexer cannot re-serialise to the same stream is left alone. *)
+(* CSS Syntax 3 (ED) sec. 5.5.2 keeps an unrecognised at-rule's body as raw
+   source text, so no typed node stands between the author's layout and the
+   output and the serializer may not touch it: rewriting the body is an AST
+   change. Reading it back as a component-value stream and writing it out with
+   the separator rules that already serve custom-property streams keeps every
+   token boundary, string, escape and nested block while the layout between them
+   goes. A body the lexer cannot re-serialise to the same stream is left
+   alone. *)
 let compact_unknown_at_rule_body body =
   let reader = Reader.of_string body in
   let { Parser.value = components; warnings } =

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -95,8 +95,9 @@ val merge_overflow_longhands :
 val drop_invalid : t -> t
 (** [drop_invalid ss] removes every declaration whose typed value contains an
     [Invalid] arm cascade detected at parse time (CSS spec violations that
-    cascade preserved verbatim for round-trip). Run as part of minify-time
-    spec-based optimization. *)
+    cascade preserved verbatim for round-trip). Serialisation runs this on every
+    stylesheet, minified or not: a browser discards such a declaration at parse,
+    so dropping it keeps the output observationally equal to a fresh parse. *)
 
 val drop_unknown_at_rules : t -> t
 (** [drop_unknown_at_rules ss] removes every [Unknown_at_rule] statement at any

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -90,7 +90,7 @@ let hex_digit n =
   if n < 10 then Char.chr (n + Char.code '0')
   else Char.chr (n - 10 + Char.code 'A')
 
-(* Hex-escape a control byte as "\HH " per CSS Syntax section 9.1. *)
+(* Hex-escape a control byte as "\HH " per CSS Syntax 3 (ED) sec. 9. *)
 let add_hex_escape buf c =
   let code = Char.code c in
   Buffer.add_char buf '\\';
@@ -217,7 +217,7 @@ let add_escaped_url buf s =
 let digit_at s i = i < String.length s && s.[i] >= '0' && s.[i] <= '9'
 let is_sign c = c = '+' || c = '-'
 
-(* CSS Syntax sec. 9.1 ambiguous-dimension rule: a unit of [e]/[E] then a
+(* CSS Syntax 3 (ED) sec. 9 ambiguous-dimension rule: a unit of [e]/[E] then a
    (signed) digit would re-read as scientific notation, so the leading letter is
    hex-escaped to keep it out of the number's exponent. [digit_at] and [is_sign]
    are top-level so this test costs no closure per dimension printed. *)
@@ -262,16 +262,16 @@ let add_token_kind buf : Token.kind -> unit = function
       Buffer.add_string buf (escape_name value)
   | Token.String { value; quote = _; terminated } ->
       (* Normalize quoting to double-quote (the original quote is kept on the
-         token only for quote-sensitive lookups like @charset). CSS Syntax sec.
-         4.3.5 recovers an unterminated string; the [terminated] flag is
-         preserved so one round-trips, emitting without its closing quote. *)
+         token only for quote-sensitive lookups like @charset). CSS Syntax 3
+         (ED) sec. 4.3.5 recovers an unterminated string; the [terminated] flag
+         is preserved so one round-trips, emitting without its closing quote. *)
       add_escaped_string buf ~quote:'"' ~terminated value
   | Token.Bad_string ->
       (* A bad string keeps no text, so serialize the shortest source that
          re-tokenizes as one, the way [Bad_url] serializes to [url(a b)]. CSS
-         Syntax sec. 4.3.5 makes one only from a newline inside a string and
-         reconsumes that newline, so the quote needs the newline after it and
-         the token is always followed by whitespace -- which is what the
+         Syntax 3 (ED) sec. 4.3.5 makes one only from a newline inside a string
+         and reconsumes that newline, so the quote needs the newline after it
+         and the token is always followed by whitespace -- which is what the
          reconsumed newline lexes as, keeping the component count stable. *)
       Buffer.add_string buf "\"\n"
   | Token.Url s -> add_escaped_url buf s
@@ -424,7 +424,7 @@ let string_of_components cvs =
   cvs_to_buffer buf cvs;
   Buffer.contents buf
 
-(* CSS Syntax 3 section 9.1: adjacent tokens must stay lexically separate.
+(* CSS Syntax 3 (ED) section 9.1: adjacent tokens must stay lexically separate.
    [word_like_end p]/[word_like_start n] test the byte [p] ends with / [n]
    starts with, since a merge depends on both. {!Func} is word-like at the start
    ([ident(]) but self-delimiting at the end ([)]); {!Block} is self-delimiting
@@ -473,9 +473,9 @@ let word_like_start : Component.t -> bool = function
   | Block { node = { opening = Paren; _ }; _ } -> true
   | Block _ -> false
 
-(* CSS Syntax section 9 fixed-pair separations: certain delim pairs would form a
-   multi-char token (comment, CDO) when emitted adjacently, even though neither
-   token is word-like. Force a separator for those. *)
+(* CSS Syntax 3 (ED) sec. 9 fixed-pair separations: certain delim pairs would
+   form a multi-char token (comment, CDO) when emitted adjacently, even though
+   neither token is word-like. Force a separator for those. *)
 let pair_forms_multichar_token prev next =
   match (prev, next) with
   | ( Component.Preserved { kind = Token.Delim "/"; _ },
@@ -825,7 +825,7 @@ let warn_unclosed ~meta lexer warnings (block : Component.block Component.node)
   if not block.node.closed then
     warn ~meta lexer warnings (Error.unterminated block.loc Sort.Block)
 
-(* CSS Syntax Level 3 section 5.5.2. [nested = true] also terminates on a stray
+(* CSS Syntax 3 (ED) sec. 5.5.2. [nested = true] also terminates on a stray
    ['}'] (the spec's "outermost block ended") so block-contents callers can
    recover instead of swallowing the closing delimiter. *)
 let consume_at_rule ?(nested = false) ~meta lexer ~name ~start_loc ~warnings :
@@ -853,7 +853,7 @@ let consume_at_rule ?(nested = false) ~meta lexer ~name ~start_loc ~warnings :
   in
   loop []
 
-(* CSS Syntax Level 3 section 5.5.3. [nested = true] makes a stray ['}'] or a
+(* CSS Syntax 3 (ED) sec. 5.5.3. [nested = true] makes a stray ['}'] or a
    top-level ';' before any block end the rule attempt with [None]; the spec
    groups those two with the EOF branch as parse errors, so they are reported
    the same way. The custom-property-shaped guard discards a rule whose first
@@ -1014,8 +1014,8 @@ let declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings cvs :
         (Error.missing_token name_loc ~sort:Sort.Declaration "':'");
       None
 
-(* Buffer component values until the terminating ';' or EOF (CSS Syntax section
-   5.4.6 declaration body). Shared by the list, single-declaration and
+(* Buffer component values until the terminating ';' or EOF (CSS Syntax 3 (ED)
+   sec. 5.5.6 declaration body). Shared by the list, single-declaration and
    block-contents entry points.
 
    Section 5.5.7 also stops on a '}' when [nested] is true, the flag section
@@ -1104,8 +1104,8 @@ let stylesheet ?(meta = Loc.default_meta_level) r =
 
 let stylesheet_contents = stylesheet
 
-(* CSS Syntax Level 3 section 5.4.5: a block's contents is a mix of declarations
-   and nested rules. Consecutive declarations are grouped into a single [`Decls]
+(* CSS Syntax 3 (ED) sec. 5.4.5: a block's contents is a mix of declarations and
+   nested rules. Consecutive declarations are grouped into a single [`Decls]
    item so callers can re-emit them as a contiguous run. *)
 
 (* Try to consume a nested qualified rule at the current [tok] position. On
@@ -1184,7 +1184,7 @@ let block_contents ?(meta = Loc.default_meta_level) r : block_item list output =
       let lexer = Lexer.of_reader r in
       consume_block_contents ~meta lexer ~warnings)
 
-(* CSS Syntax Level 3 section 5.4.6 "Parse a rule": skip surrounding whitespace,
+(* CSS Syntax 3 (ED) sec. 5.4.6 "Parse a rule": skip surrounding whitespace,
    consume one rule, require EOF, no extra rules or stray tokens afterwards. *)
 let rule ?(meta = Loc.default_meta_level) r =
   with_warnings (fun ~warnings ->
@@ -1210,10 +1210,10 @@ let rule ?(meta = Loc.default_meta_level) r =
           skip_whitespace_tokens lexer;
           if (Lexer.peek lexer).Token.kind = Token.Eof then r' else None)
 
-(* CSS Syntax Level 3 section 5.4.7 "Parse a declaration": skip leading
-   whitespace, require an ident, consume exactly one declaration, ignore
-   anything after the terminating ';' or EOF. The first non-whitespace token
-   must be the declaration name -- a stray ':' or [@x] is a syntax error. *)
+(* CSS Syntax 3 (ED) sec. 5.4.7 "Parse a declaration": skip leading whitespace,
+   require an ident, consume exactly one declaration, ignore anything after the
+   terminating ';' or EOF. The first non-whitespace token must be the
+   declaration name -- a stray ':' or [@x] is a syntax error. *)
 let declaration ?(meta = Loc.default_meta_level) r =
   with_warnings (fun ~warnings ->
       let lexer = Lexer.of_reader r in

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -1,4 +1,4 @@
-(** Stage 3 stream: Token.t -> Component.t (CSS Syntax section 5).
+(** Stage 3 stream: Token.t -> Component.t (CSS Syntax 3 (ED) sec. 5).
 
     Ports the "consume a ..." algorithms from
     https://www.w3.org/TR/css-syntax-3/#parser-algorithms onto a {!Lexer.t}
@@ -66,18 +66,18 @@ val to_string_custom_minified :
 
 val escape_ident : string -> string
 (** [escape_ident s] returns [s] with non-ident-continue code points backslash-
-    or hex-escaped per CSS Syntax 3 section 9.1, so that
+    or hex-escaped per CSS Syntax 3 (ED) section 9.1, so that
     [Cursor.of_string (escape_ident s) |> Cursor.ident] yields [s] again. CSS
-    Syntax 3 section 4.3.9 opens no ident sequence on a digit, nor on [-]
+    Syntax 3 (ED) section 4.3.9 opens no ident sequence on a digit, nor on [-]
     followed by a digit, so that digit is hex-escaped even where it is an
     ident-continue code point. *)
 
 val escape_name : string -> string
-(** [escape_name s] escapes [s] as CSS Syntax 3 section 4.3.7 name code points,
-    with no ident-start rule applied to the first one. It is what serialises a
-    name written after a prefix the caller emits itself, such as the [#] of a
-    hash or the [--] of a dashed ident; {!escape_ident} serialises a whole
-    ident. *)
+(** [escape_name s] escapes [s] as CSS Syntax 3 (ED) section 4.3.7 name code
+    points, with no ident-start rule applied to the first one. It is what
+    serialises a name written after a prefix the caller emits itself, such as
+    the [#] of a hash or the [--] of a dashed ident; {!escape_ident} serialises
+    a whole ident. *)
 
 (** {1 Entry points (section 5.4)} *)
 
@@ -152,8 +152,9 @@ val csv_component_values : Reader.t -> Component.t list list output
     comma tokens. *)
 
 val declaration_value : Reader.t -> Component.t list option output
-(** [declaration_value r] matches CSS Syntax section 7.2's [<declaration-value>]
-    production. *)
+(** [declaration_value r] matches CSS Syntax 3 (ED) sec. 7.2's
+    [<declaration-value>] production. *)
 
 val any_value : Reader.t -> Component.t list option output
-(** [any_value r] matches CSS Syntax section 7.2's [<any-value>] production. *)
+(** [any_value r] matches CSS Syntax 3 (ED) sec. 7.2's [<any-value>] production.
+*)

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -123,9 +123,9 @@ let is_hex_digit = function
   | '0' .. '9' | 'a' .. 'f' | 'A' .. 'F' -> true
   | _ -> false
 
-(* CSS Syntax 3 sec. 4.3.7: a hex escape consumes up to 6 hex digits and one
-   trailing whitespace. The space terminator is only needed when the following
-   character would otherwise be eaten by the escape - a hex digit or a
+(* CSS Syntax 3 (ED) sec. 4.3.7: a hex escape consumes up to 6 hex digits and
+   one trailing whitespace. The space terminator is only needed when the
+   following character would otherwise be eaten by the escape - a hex digit or a
    whitespace. Omit it everywhere else for the shortest spelling. *)
 let hex_escape_byte ctx ~next c =
   let code = Char.code c in
@@ -201,10 +201,10 @@ let list ?sep pp ctx l =
           pp ctx x)
         t
 
-(* CSS Syntax 3 sec. 4 token-boundary separator: under minify, drop the space
-   when the previous token ends with [)] or [%] - both close cleanly so the
-   following ident/number cannot be re-tokenised into a single token. Falls back
-   to a regular space in pretty mode. *)
+(* CSS Syntax 3 (ED) sec. 4 token-boundary separator: under minify, drop the
+   space when the previous token ends with [)] or [%] - both close cleanly so
+   the following ident/number cannot be re-tokenised into a single token. Falls
+   back to a regular space in pretty mode. *)
 let token_sp ctx () =
   if not ctx.minify then char ctx ' '
   else

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -157,7 +157,7 @@ val token_sp : unit t
 (** [token_sp] writes a token-boundary space: a regular space in pretty mode,
     and a space under minify only when the previous output character would
     otherwise re-tokenise with the next one. Drops the space after [)] or [%]
-    since both cleanly close their token (CSS Syntax 3 sec. 4). *)
+    since both cleanly close their token (CSS Syntax 3 (ED) sec. 4). *)
 
 val cut : unit t
 (** [cut] writes a newline when not minifying. *)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -154,7 +154,7 @@ let pp_shadow_body ctx { h_offset; v_offset; blur; spread; color } =
 let pp_inset_toggle ctx ~name ~no_fallback =
   Pp.string ctx "var(--";
   (* [name] is the custom property's name without its [--] prefix; CSS Syntax 3
-     sec. 4.3.7 lets an escape carry a [;] or a [}] into it. *)
+     (ED) sec. 4.3.7 lets an escape carry a [;] or a [}] into it. *)
   Pp.string ctx (Parser.escape_name name);
   if no_fallback then Pp.string ctx ")"
   else (
@@ -1124,8 +1124,8 @@ let pp_mask_border_mode ctx = function
 let pp_border_image : border_image Pp.t =
  fun ctx { source; slice; width; outset; repeat; mode } ->
   let first = ref true in
-  (* CSS Syntax 3 sec. 9: tokens ending with [)] are self-delimiting, so the
-     inter-slot space after [url(...)] / [<image>] can be elided under
+  (* CSS Syntax 3 (ED) sec. 9: tokens ending with [)] are self-delimiting, so
+     the inter-slot space after [url(...)] / [<image>] can be elided under
      minify. *)
   let last_is_self_delim () =
     match Pp.last_char ctx with Some (')' | ']' | '}') -> true | _ -> false

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -86,8 +86,8 @@ let pp_opt_space pp ctx = function
 
 let pp_keyword s ctx = Pp.string ctx s
 
-(* CSS Syntax 3 sec. 4.3.7 lets an escape carry a [;], a [}] or any other code
-   point CSS Syntax 3 sec. 4.2 keeps out of an ident into a name, so a
+(* CSS Syntax 3 (ED) sec. 4.3.7 lets an escape carry a [;], a [}] or any other
+   code point CSS Syntax 3 (ED) sec. 4.2 keeps out of an ident into a name, so a
    [<custom-ident>] or [<dashed-ident>] is written back with the escapes that
    read it as the same name (see [Properties.pp_property]). Printed raw it ends
    its own declaration. *)

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -516,7 +516,7 @@ let rec read_font_variant_east_asian t : font_variant_east_asian =
       | features, _ -> (Features features : font_variant_east_asian))
     t
 
-(* CSS Syntax 3 sec. 4.3.9: an ident sequence starts with a name-start code
+(* CSS Syntax 3 (ED) sec. 4.3.9: an ident sequence starts with a name-start code
    point, or with a [-] followed by a name-start code point or by a second [-].
    Sec. 4.2 counts a letter, [_] and a non-ASCII code point as name-start, and
    adds the digits and [-] to the name code points that may follow. A name
@@ -1758,7 +1758,8 @@ let read_unicode_token t start_value end_value form =
 
 let rec read_unicode_range t : unicode_range =
   (* The lexer emits a single [Unicode_range] token for [U+...] forms (CSS
-     Syntax section 4.3.14); we just translate it to the [unicode_range] ADT. *)
+     Syntax 3 (ED) sec. 4.3.14); we just translate it to the [unicode_range]
+     ADT. *)
   Cursor.with_context t "unicode-range" @@ fun () ->
   match Cursor.peek t with
   | Some (Component.Func { node = { name; _ }; _ })

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -331,7 +331,7 @@ let rec pp_gradient_stop : gradient_stop Pp.t =
       match pos1_opt with
       | None -> ()
       | Some pos1 -> (
-          (* CSS Syntax 3 sec. 4: ident- and hash-typed colours absorb the
+          (* CSS Syntax 3 (ED) sec. 4: ident- and hash-typed colours absorb the
              following digit/hex into the same token ([red0%] -> ident [red0] +
              [%]), so the separator is mandatory there; and when the stop lives
              in a custom-property token stream, the whitespace token between a

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -476,7 +476,7 @@ let rec pp_mask_box : mask_box Pp.t =
 let pp_mask_layer : mask_layer Pp.t =
  fun ctx layer ->
   let first = ref true in
-  (* CSS Syntax 3 sec. 9: a token ending with [)], [\]] or [}] is
+  (* CSS Syntax 3 (ED) sec. 9: a token ending with [)], [\]] or [}] is
      self-delimiting, so under minify we can drop the inter-slot space after
      [url(...)] / [<image>]. *)
   let last_is_self_delim () =

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -252,8 +252,8 @@ let rec pp_svg_paint : svg_paint Pp.t =
       match fallback with
       | None -> ()
       | Some fb ->
-          (* CSS Syntax 3 sec. 9: a [url(...)] token closes with [)], so the
-             whitespace before a fallback keyword/colour can be elided under
+          (* CSS Syntax 3 (ED) sec. 9: a [url(...)] token closes with [)], so
+             the whitespace before a fallback keyword/colour can be elided under
              minify. *)
           Pp.sp ctx ();
           pp_svg_paint ctx fb)

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -740,7 +740,7 @@ let rec read_offset_rotate t : offset_rotate =
     ~default:(fun t -> Cursor.one_of [ read_mode_first; read_angle_first ] t)
     t
 
-(* CSS Syntax 3 sec. 4: two adjacent [<number-percentage>] tokens need a
+(* CSS Syntax 3 (ED) sec. 4: two adjacent [<number-percentage>] tokens need a
    separator unless the boundary is unambiguous - the previous ends with [%]
    (the unit terminates the token), or the next starts with [-]/[+] (a sign
    starts a new number). Render values to strings first since

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4383,8 +4383,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Font_family -> pp pp_font_family
 
 (* Cascade detected the value is spec-invalid (an [Invalid] arm in one of the
-   typed value types). The minify-time [Optimize.drop_invalid] pass uses this to
-   discard the declaration. *)
+   typed value types). [Optimize.drop_invalid], which every serialisation runs,
+   uses this to discard the declaration. *)
 let invalid_angle : angle -> bool = function Invalid _ -> true | _ -> false
 
 let invalid_length_percentage : length_percentage -> bool = function

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -220,7 +220,7 @@ let rec pp_list_style : list_style Pp.t =
 
 let pp_property : type a. a property Pp.t =
  fun ctx -> function
-  (* CSS Syntax 3 sec. 4.3.7 lets an escape carry a [;], a [}] or any other
+  (* CSS Syntax 3 (ED) sec. 4.3.7 lets an escape carry a [;], a [}] or any other
      non-name code point into a custom-property name, so the name is written
      back with the escapes that read it as the same name. Printed raw it ends
      its own declaration or closes the rule around it. *)
@@ -2365,7 +2365,7 @@ let rec read_quotes t : quotes =
     ~default:read_pairs t
 
 let read_any_property t =
-  (* CSS property names are case-insensitive per Syntax sec. 8.1. *)
+  (* CSS property names are case-insensitive per CSS Syntax 3 (ED) sec. 8.1. *)
   let prop_name = String.lowercase_ascii_preserve (Cursor.ident t) in
   (* PROPERTY_MATCHING_START - Used by scripts/check_properties.ml *)
   match prop_name with

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -60,8 +60,8 @@ val normalize_custom_property_value :
 val is_invalid_value : 'a property -> 'a -> bool
 (** [is_invalid_value prop value] is [true] when [value] contains an [Invalid]
     arm cascade detected at parse time (CSS spec violations preserved verbatim
-    for round-trip). The minify-time [Optimize.drop_invalid] pass removes
-    declarations that satisfy this predicate. *)
+    for round-trip). [Optimize.drop_invalid], which every serialisation runs,
+    removes declarations that satisfy this predicate. *)
 
 val pp_value : ('a kind * 'a) Pp.t
 (** [pp_value] pretty-prints a typed custom property value. *)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1915,7 +1915,7 @@ type font_family =
           valid as a sole top-level value. [font-family: Arial, inherit] mixes
           it inside a [<custom-ident>#] list and is therefore invalid. Cascade
           preserves the source verbatim for round-trip; [Optimize.drop_invalid]
-          removes the declaration under [--minify]. *)
+          removes the declaration on every serialisation. *)
 
 type font_stretch =
   | Pct of float
@@ -4456,8 +4456,8 @@ type clip_path =
       (** Spec-invalid [<basic-shape>] preserved verbatim - e.g.
           [ellipse(50px 60px at 0 10% 20%)] with a 3-value [<position>] tail.
           The pretty-printer round-trips the captured tokens; the
-          [Optimize.drop_invalid] pass removes the declaration under [--minify].
-      *)
+          [Optimize.drop_invalid] pass removes the declaration on every
+          serialisation. *)
 
 type _ kind =
   | Length : length kind

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -3,7 +3,7 @@
 type t = {
   input : string;
   len : int;
-  (* Restrict non-ASCII identifiers to the CSS Syntax 3 sec. 4.2 range list
+  (* Restrict non-ASCII identifiers to the CSS Syntax 3 (ED) sec. 4.2 range list
      rather than accepting any code point >= U+0080. Rides on the reader so
      every [_at] predicate reaches it without threading a parameter through the
      tokenizer. *)
@@ -78,7 +78,7 @@ let pp (ctx : Pp.ctx) (t : t) =
 
 (** {1 Creation} *)
 
-(* CSS Syntax Level 3 section 3.3 "Preprocessing the input stream": - Strip a
+(* CSS Syntax 3 (ED) sec. 3.3 "Preprocessing the input stream": - Strip a
    leading U+FEFF BYTE ORDER MARK. - Replace any U+0000 NULL or surrogate code
    point with U+FFFD REPLACEMENT. (We operate post-UTF-8-decode; surrogates
    don't occur in valid UTF-8 so the NUL byte is the practical concern.) -

--- a/lib/reader.mli
+++ b/lib/reader.mli
@@ -6,7 +6,7 @@
     reports where it stopped, and nothing here reads a CSS construct.
 
     Cascade parses already-decoded UTF-8 text. It does not implement the CSS
-    Syntax section 3.2 byte-stream decoding layer: BOM handling, HTTP or
+    Syntax 3 (ED) sec. 3.2 byte-stream decoding layer: BOM handling, HTTP or
     environment charset fallback, and exact [@charset "...";] byte sniffing are
     caller responsibilities before constructing a {!Reader.t}. *)
 
@@ -49,7 +49,7 @@ val pp_parse_error : parse_error -> string
 val of_string : ?enforce_spec:bool -> string -> t
 (** [of_string s] creates a parser from an already-decoded UTF-8 string.
     [enforce_spec] (default [false]) restricts non-ASCII identifiers to the CSS
-    Syntax 3 sec. 4.2 range list. *)
+    Syntax 3 (ED) sec. 4.2 range list. *)
 
 val enforce_spec : t -> bool
 (** [enforce_spec t] is the identifier rule [t] was built with; see

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -286,8 +286,8 @@ let unescape_selector_name s =
       len
     else if is_hex s.[i + 1] then (
       let codepoint, final_idx = process_hex_escape s i len in
-      (* CSS Syntax 4.3.7: U+0000, surrogates, and out-of-range code points are
-         replaced with U+FFFD rather than passed through. *)
+      (* CSS Syntax 3 (ED) sec. 4.3.7: U+0000, surrogates, and out-of-range code
+         points are replaced with U+FFFD rather than passed through. *)
       let cp =
         if
           codepoint <= 0 || codepoint > 0x10FFFF
@@ -680,7 +680,7 @@ let read_attribute t =
       Attribute (ns, attr_name, matcher, flag))
     t
 
-(** Parse the An+B microsyntax (Selectors 4 section 13.3.1 / CSS Syntax 3
+(** Parse the An+B microsyntax (Selectors 4 section 13.3.1 / CSS Syntax 3 (ED)
     section 6) as shape patterns over the component stream: [odd]/[even], bare
     [<integer>], [<n-dimension>] with optional offset, the [5n-5]/[5n-] token
     variants, and the [n]/[-n]/[n-5]/... ident forms with an optional leading
@@ -784,7 +784,7 @@ let ensure_no_ws_after_plus t =
   | _ -> ()
 
 (* Dimension forms [<n-dimension>, <ndashdigit-dimension>, <ndash-dimension>]
-   from CSS Syntax 3 section 6.2. Assumes the cursor is positioned on a
+   from CSS Syntax 3 (ED) section 6.2. Assumes the cursor is positioned on a
    [Dimension] component. *)
 let read_nth_dimension t number unit_ =
   if is_n_unit unit_ then (

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -4082,7 +4082,7 @@ let greenfield_keys =
 let unprefixed_is_widely_available twin =
   let key =
     match Declaration.property_key twin with
-    (* CSS Syntax 3 sec. 8.1: property names are case-insensitive. *)
+    (* CSS Syntax 3 (ED) sec. 8.1: property names are case-insensitive. *)
     | Key (Unknown_property name) ->
         Key (Properties.Unknown_property (String.lowercase_ascii_preserve name))
     | key -> key

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -731,9 +731,9 @@ let pp_property_rule : 'a property_rule Pp.t =
       match initial_value with None -> () | Some v -> pp_initial_value ctx v
   in
   Pp.string ctx "@property ";
-  (* CSS Syntax 3 sec. 4.3.7: the prelude names the custom property this rule
-     registers, so it is written with the escapes that read the same name back
-     (see [Properties.pp_property]). *)
+  (* CSS Syntax 3 (ED) sec. 4.3.7: the prelude names the custom property this
+     rule registers, so it is written with the escapes that read the same name
+     back (see [Properties.pp_property]). *)
   Pp.string ctx (Parser.escape_ident name);
   Pp.sp ctx ();
   Pp.braces
@@ -888,7 +888,7 @@ let trim_unknown_at_prelude prelude =
   let n = String.length prelude in
   String.sub prelude 0 (trim_end (n - 1))
 
-(* CSS Syntax 3 sec. 4.3.1: a backslash starts an escape unless a newline
+(* CSS Syntax 3 (ED) sec. 4.3.1: a backslash starts an escape unless a newline
    follows it. A raw body ending on an odd run of backslashes therefore escapes
    the closer written straight after it, and the at-rule swallows whatever comes
    next instead of ending. *)
@@ -899,21 +899,21 @@ let body_escapes_its_closer body =
   backslashes (String.length body - 1) 0 land 1 = 1
 
 let pp_unknown_at_rule_statement ctx name prelude (block : string option) =
-  (* CSS Syntax 3 section 5.5.2: an at-rule terminates on [;], [}], or EOF. When
-     the Parser captures an unterminated nested block ([(...], [[...], [{...])
-     its source slice can include the at-rule terminator or the enclosing
-     block's close - don't echo them as part of the prelude or each round-trip
-     stacks another [;]/[}]. *)
+  (* CSS Syntax 3 (ED) section 5.5.2: an at-rule terminates on [;], [}], or EOF.
+     When the Parser captures an unterminated nested block ([(...], [[...],
+     [{...]) its source slice can include the at-rule terminator or the
+     enclosing block's close - don't echo them as part of the prelude or each
+     round-trip stacks another [;]/[}]. *)
   let prelude = trim_unknown_at_prelude prelude in
   Pp.char ctx '@';
-  (* CSS Syntax 3 section 9.1: an at-rule name with non-ident-continue code
+  (* CSS Syntax 3 (ED) section 9.1: an at-rule name with non-ident-continue code
      points (control chars, escapes, non-ASCII) must round-trip through
      [escape_ident] so the serialized [\6 T] re-tokenizes back to the same
      at-keyword token. *)
   Pp.string ctx (Parser.escape_ident name);
-  (* CSS Syntax 3 sec. 4.3.1: the at-keyword consumes an ident sequence, so the
-     whitespace before the prelude is the only thing keeping them apart. It is a
-     hard space, not layout - minifying [@foo bar] to [@foobar] names a
+  (* CSS Syntax 3 (ED) sec. 4.3.1: the at-keyword consumes an ident sequence, so
+     the whitespace before the prelude is the only thing keeping them apart. It
+     is a hard space, not layout - minifying [@foo bar] to [@foobar] names a
      different at-rule. *)
   if prelude <> "" then (
     Pp.space ctx ();
@@ -946,11 +946,11 @@ let printable_statements ctx statements =
 module String_set = Pp.String_set
 
 let normalise_charset statements =
-  (* CSS Syntax 3 sec. 8.3: [@charset] is an encoding-declaration byte pattern
-     recognised before tokenization, not a stylesheet at-rule after parsing. In
-     minified output the serializer emits UTF-8, so [@charset "UTF-8"] is
-     redundant; keep at most the first non-UTF-8 declaration for byte-level
-     compatibility. *)
+  (* CSS Syntax 3 (ED) sec. 8.3: [@charset] is an encoding-declaration byte
+     pattern recognised before tokenization, not a stylesheet at-rule after
+     parsing. In minified output the serializer emits UTF-8, so [@charset
+     "UTF-8"] is redundant; keep at most the first non-UTF-8 declaration for
+     byte-level compatibility. *)
   let is_utf8 encoding =
     String.equal (String.lowercase_ascii encoding) "utf-8"
   in
@@ -1107,9 +1107,10 @@ let import_url_inner_string url len : string option =
 
 let pp_import_url_minified ctx url len =
   (* Canonicalise to the shortest spec-equivalent form: a double-quoted string
-     (CSS Syntax 4.3.5 prefers double quotes). The [url()] wrapping is five
-     characters of overhead that the bare-string form omits per CSS Conditional
-     Rules 3, and a single-quoted source string re-emits with double quotes. *)
+     (CSS Syntax 3 (ED) sec. 4.3.5 prefers double quotes). The [url()] wrapping
+     is five characters of overhead that the bare-string form omits per CSS
+     Conditional Rules 3, and a single-quoted source string re-emits with double
+     quotes. *)
   match import_url_inner_string url len with
   | Some s -> Pp.quoted_string ctx s
   | None -> (
@@ -1130,7 +1131,7 @@ let pp_import_url ctx url =
   else Pp.quoted_string ctx url
 
 (* CSS Cascade 5 sec. 6.4.1: a [<layer-name>] is [<ident> ['.' <ident>]*], so
-   each ident takes the escapes CSS Syntax 3 sec. 4.3.7 needs (see
+   each ident takes the escapes CSS Syntax 3 (ED) sec. 4.3.7 needs (see
    [Properties.pp_property]) and the [.] separators stay bare. A [.] an ident
    carries is escaped, and so never reads back as a separator. *)
 let string_of_layer_name name =
@@ -1451,9 +1452,9 @@ let pp_view_transition_descriptor : view_transition_descriptor Pp.t =
       Pp.list ~sep:Pp.space Pp.string ctx types
 
 (* Under minify a [Declarations] statement carries no trailing [;] of its own,
-   so whoever sequences the statements owes it a separator: CSS Syntax 3 sec.
-   5.4.4 runs a declaration to the next [;] or to the block's [}], and a sibling
-   that follows would otherwise be read as part of its value. *)
+   so whoever sequences the statements owes it a separator: CSS Syntax 3 (ED)
+   sec. 5.5.5 runs a declaration to the next [;] or to the block's [}], and a
+   sibling that follows would otherwise be read as part of its value. *)
 let pp_declarations_sep ctx = function
   | Declarations decls when decls <> [] && Pp.minified ctx ->
       Pp.semicolon ctx ()
@@ -1891,10 +1892,10 @@ let read_keyframe (r : Cursor.t) : keyframe =
 
 (* Helper functions for reading specific at-rules *)
 
-(* CSS Syntax section 8.2 reserves [@charset "UTF-8";] as the byte-stream
+(* CSS Syntax 3 (ED) sec. 8.3 reserves [@charset "UTF-8";] as the byte-stream
    decoder hint. The exact form -- uppercase label, double quotes, semicolon --
    is recognised; any other [@charset] (lowercase, single quotes, different
-   label, no terminating ';') is a syntax error per section 8.3. *)
+   label, no terminating ';') is a syntax error. *)
 let read_charset (r : Cursor.t) : statement =
   Cursor.expect_at_keyword "charset" r;
   Cursor.ws r;
@@ -2084,12 +2085,12 @@ let read_namespace (r : Cursor.t) : statement =
   Namespace (prefix, uri)
 
 (* Discard the rule the cursor sits on, stopping at its [{}] block or at a
-   top-level [;]: CSS Syntax 3 sec. 5.4.2 ends an at-rule at whichever comes
-   first, and sec. 5.4.3 ends a qualified rule at its block. Consuming exactly
-   that far leaves what was written after the rule - the declarations around it,
-   or the next rule - to be read on its own. A [(] or a [[] met before the block
-   is a component value of the prelude being discarded, so stopping there would
-   offer the tail of that prelude as a rule of its own. *)
+   top-level [;]: CSS Syntax 3 (ED) sec. 5.5.2 ends an at-rule at whichever
+   comes first, and sec. 5.5.3 ends a qualified rule at its block. Consuming
+   exactly that far leaves what was written after the rule - the declarations
+   around it, or the next rule - to be read on its own. A [(] or a [[] met
+   before the block is a component value of the prelude being discarded, so
+   stopping there would offer the tail of that prelude as a rule of its own. *)
 let rec skip_past_rule r =
   match Cursor.next_raw r with
   | None -> ()
@@ -2111,13 +2112,13 @@ let skip_invalid_item r =
 
 (* Read a body one item at a time, [step] committing each item to the
    accumulator before the next is read, so an item dropped in recovery costs
-   only itself and the items around it are kept. CSS Syntax 3 sec. 5.4.3 keeps
-   what a block's contents already yielded when one item fails to parse, and CSS
-   Paged Media 3 sec. 4.1 says as much of a page or a margin context in so many
-   words: "valid declarations within the block are applied". Strict mode ([not
-   (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly what the
-   lenient parse warns about. [skip] discards the item that failed, and which
-   one it is depends on the body: {!skip_invalid_item} for a body of
+   only itself and the items around it are kept. CSS Syntax 3 (ED) sec. 5.5.5
+   keeps what a block's contents already yielded when one item fails to parse,
+   and CSS Paged Media 3 sec. 4.1 says as much of a page or a margin context in
+   so many words: "valid declarations within the block are applied". Strict mode
+   ([not (Cursor.recover r)]) still raises, so [~strict:true] rejects exactly
+   what the lenient parse warns about. [skip] discards the item that failed, and
+   which one it is depends on the body: {!skip_invalid_item} for a body of
    declarations, {!skip_past_rule} for a body of rules, where an item that opens
    a block ends at that block rather than at a [;] it does not have. *)
 let read_items_with_recovery ~skip step r init =
@@ -2231,7 +2232,7 @@ let read_moz_document_function r name arguments : moz_document_condition =
 (* Gecko's [@document] prelude takes [<url>], [url-prefix(<string>)],
    [domain(<string>)], [media-document(<string>)] and [regexp(<string>)]. A
    prelude function outside that list has no grammar, so the at-rule goes down
-   with it, which is what CSS Syntax 3 sec. 5.4.2 does with any prelude no
+   with it, which is what CSS Syntax 3 (ED) sec. 5.5.2 does with any prelude no
    grammar accepts. *)
 let read_moz_document_condition r : moz_document_condition =
   Cursor.ws r;
@@ -2254,10 +2255,10 @@ let read_descriptor_value read_fn constructor r =
   constructor (read_fn r)
 
 (* One item of a descriptor body: a descriptor, a stray [;] that CSS Syntax 3
-   sec. 5.4.3 discards with no declaration to validate, or the end of the body.
-   [Declaration.read_declaration] answers [None] for an item that opens a block
-   instead; a descriptor body holds no rules, so that item is invalid and is
-   reported rather than left for the caller to loop on. *)
+   (ED) sec. 5.5.5 discards with no declaration to validate, or the end of the
+   body. [Declaration.read_declaration] answers [None] for an item that opens a
+   block instead; a descriptor body holds no rules, so that item is invalid and
+   is reported rather than left for the caller to loop on. *)
 let read_descriptor_item (r : Cursor.t) =
   Cursor.ws r;
   if Cursor.is_done r then `Done
@@ -2603,10 +2604,11 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
         if Cursor.peek_semicolon r then Cursor.skip r;
         Some descriptor
     | exception Error.Parse_error e ->
-        (* CSS Fonts 4 sec. 4.1 / CSS Syntax 3 sec. 5.5.5: a descriptor that
-           does not parse - an unknown name (Fontsource's [font-named-instance])
-           or an invalid value of a known one ([font-display:maybe]) - is
-           dropped and the rest of the @font-face is kept, matching browsers. *)
+        (* CSS Fonts 4 sec. 4.1 / CSS Syntax 3 (ED) sec. 5.5.5: a descriptor
+           that does not parse - an unknown name (Fontsource's
+           [font-named-instance]) or an invalid value of a known one
+           ([font-display:maybe]) - is dropped and the rest of the @font-face is
+           kept, matching browsers. *)
         Cursor.push_warning r e;
         Cursor.skip_past_semicolon r;
         None
@@ -2742,7 +2744,7 @@ let replace_counter_style_descriptor desc acc =
        acc
 
 (* One item of a descriptor body: a descriptor, a stray [;] that CSS Syntax 3
-   sec. 5.4.3 discards with no declaration to validate, or the end of the
+   (ED) sec. 5.5.5 discards with no declaration to validate, or the end of the
    body. *)
 let read_descriptor_body_step read_one replace inner acc =
   Cursor.ws inner;
@@ -2915,8 +2917,8 @@ let read_page_margin_rule r =
       Cursor.skip r;
       Cursor.ws r;
       (* Sec. 5 gives the margin at-rule a [<declaration-list>], which CSS
-         Syntax 3 sec. 5.4.4 consumes even when it holds nothing, so an empty
-         box is valid and Blink 146 keeps one. That it paints nothing is
+         Syntax 3 (ED) sec. 5.5.5 consumes even when it holds nothing, so an
+         empty box is valid and Blink 146 keeps one. That it paints nothing is
          [Block.drop_empty_rules]'s call to make, not the reader's. *)
       let descriptors =
         Cursor.braces (read_descriptor_block replace_descriptor) r
@@ -3112,9 +3114,9 @@ let read_font_feature_values_block outer inner =
 
 (* CSS Fonts 4 sec. 11.1 fills the body with feature value blocks, so it is a
    list of rules rather than of declarations: a block the body rejects ends at
-   its own [{}] or at a [;] (CSS Syntax 3 sec. 5.4.2), which leaves the blocks
-   written around it in the rule. A [;] with nothing before it has no
-   declaration to validate and is discarded (sec. 5.4.3). *)
+   its own [{}] or at a [;] (CSS Syntax 3 (ED) sec. 5.5.2), which leaves the
+   blocks written around it in the rule. A [;] with nothing before it has no
+   declaration to validate and is discarded (sec. 5.5.5). *)
 let read_font_feature_values_step outer inner acc =
   Cursor.ws inner;
   if Cursor.is_done inner then `Done (List.rev acc)
@@ -3365,8 +3367,8 @@ let rec close_raw fuel text =
    [\] at end of input escapes before it lands. *)
 let close_open_constructs = close_raw 3
 
-(* CSS Syntax 3 sec. 5.4.6: an unclosed block runs to EOF, so its slice has no
-   closer to exclude and instead carries whatever [}] an unterminated nested
+(* CSS Syntax 3 (ED) sec. 5.5.9: an unclosed block runs to EOF, so its slice has
+   no closer to exclude and instead carries whatever [}] an unterminated nested
    construct swallowed on the way. The serializer supplies its own closer, so
    drop those or each round-trip stacks another one. *)
 let trim_unknown_block_body body =
@@ -3390,10 +3392,10 @@ let unknown_block_body slice (block : Component.block Component.node) =
     slice start block.loc.Loc.end_pos
     |> trim_unknown_block_body |> close_open_constructs
 
-(* CSS Syntax 3 sec. 5.5.2 "consume an at-rule": after the at-keyword has been
-   consumed, walk components until we hit [;] (no block) or [{...}] (block). Raw
-   prelude/block strings are sliced from the original source so the at-rule
-   round-trips byte-for-byte even when its grammar is unknown. *)
+(* CSS Syntax 3 (ED) sec. 5.5.2 "consume an at-rule": after the at-keyword has
+   been consumed, walk components until we hit [;] (no block) or [{...}]
+   (block). Raw prelude/block strings are sliced from the original source so the
+   at-rule round-trips byte-for-byte even when its grammar is unknown. *)
 let read_unknown_at_rule name (r : Cursor.t) : statement =
   let source = Option.value (Cursor.source r) ~default:"" in
   let source_len = String.length source in
@@ -3701,8 +3703,8 @@ let item_opens_block inner =
   found
 
 (* Discard an at-rule that is invalid in a style rule and resume at the next
-   item, the recovery CSS Syntax 3 sec. 5.4.4 describes. The warning is what
-   [~strict:true] turns into an error. *)
+   item, the recovery CSS Syntax 3 (ED) sec. 5.5.5 describes. The warning is
+   what [~strict:true] turns into an error. *)
 let drop_nested_at_rule r ~loc reason : statement option =
   skip_past_rule r;
   Cursor.push_warning r (Error.bad_value loc ~property:"rule" ~reason);
@@ -3771,9 +3773,10 @@ let read_moz_document ~body (r : Cursor.t) : statement =
   Moz_document (conditions, Cursor.braces body r)
 
 (* CSS Values 4 sec. 4.1 reads an at-rule name as a keyword, so its case does
-   not pick between two grammars. Sec. 8.2 of CSS Syntax 3 is the one exception:
-   it matches [@charset] and the quote after it as an exact byte sequence, so
-   any other spelling of that name is a name with no grammar behind it. *)
+   not pick between two grammars. CSS Syntax 3 (ED) sec. 8.3 is the one
+   exception: it matches [@charset] and the quote after it as an exact byte
+   sequence, so any other spelling of that name is a name with no grammar behind
+   it. *)
 let at_rule_keyword name =
   match Common.String.lowercase_ascii_preserve name with
   | "charset" when name <> "charset" -> name
@@ -3816,8 +3819,8 @@ let rec read_statement (r : Cursor.t) : statement =
       match List.assoc_opt (at_rule_keyword name) table with
       | Some p -> p r
       | None ->
-          (* CSS Syntax 3 sec. 5.4.2 consumes an at-rule whatever its name, so
-             the prelude and block stay in the AST as [Unknown_at_rule] and
+          (* CSS Syntax 3 (ED) sec. 5.5.2 consumes an at-rule whatever its name,
+             so the prelude and block stay in the AST as [Unknown_at_rule] and
              reach the output. The typed warning tells the caller cascade could
              not interpret it; [Optimize.drop_unknown_at_rules] is there for a
              caller that wants it gone. *)
@@ -3835,10 +3838,10 @@ and read_block (r : Cursor.t) : block =
       let loc = Cursor.position r in
       let snap = Cursor.save r in
       match read_statement r with
-      (* CSS Syntax 3 sec. 5.4.1: a rule that fails to parse (e.g. an invalid
-         selector) is dropped, and parsing resumes at the next rule - one bad
-         rule must not take the rest of the [@layer] / [@media] block with it.
-         Strict mode ([not (Cursor.recover r)]) still raises. *)
+      (* CSS Syntax 3 (ED) sec. 5.5.1: a rule that fails to parse (e.g. an
+         invalid selector) is dropped, and parsing resumes at the next rule -
+         one bad rule must not take the rest of the [@layer] / [@media] block
+         with it. Strict mode ([not (Cursor.recover r)]) still raises. *)
       | exception Error.Parse_error e when Cursor.recover r ->
           Cursor.restore r snap;
           Cursor.push_warning r e;
@@ -3967,12 +3970,13 @@ and read_nesting_block (r : Cursor.t) : block =
     Cursor.ws r;
     if Cursor.recover r then read_recovering_item acc
     else add_item acc (read_nesting_item ~prev:acc r)
-  (* CSS Syntax 3 sec. 5.4.4: a declaration that fails to parse is dropped and
-     reading resumes past the next top-level [;], a [{}] met on the way counting
-     as one component value of the value being skipped. A nested at-rule's body
-     is <block-contents> like a style rule's, so it recovers the same way and
-     one bad declaration takes neither the group rule holding it nor the rest of
-     the sheet. Strict mode ([not (Cursor.recover r)]) still raises. *)
+  (* CSS Syntax 3 (ED) sec. 5.5.5: a declaration that fails to parse is dropped
+     and reading resumes past the next top-level [;], a [{}] met on the way
+     counting as one component value of the value being skipped. A nested
+     at-rule's body is <block-contents> like a style rule's, so it recovers the
+     same way and one bad declaration takes neither the group rule holding it
+     nor the rest of the sheet. Strict mode ([not (Cursor.recover r)]) still
+     raises. *)
   and read_recovering_item acc =
     match read_nesting_item ~prev:acc r with
     | item -> add_item acc item
@@ -4468,8 +4472,8 @@ let read_stylesheet_of_rules ?source ?meta (rules : Component.rule list) :
   (statements, List.rev !warnings)
 
 (* Scan [source] for top-level [/*! ... */] bang comments. The lexer drops
-   ordinary comments per CSS Syntax 3 sec. 4.3.2; bang comments are the minifier
-   convention for license headers and need to round-trip. Returns pairs
+   ordinary comments per CSS Syntax 3 (ED) sec. 4.3.2; bang comments are the
+   minifier convention for license headers and need to round-trip. Returns pairs
    [(start_offset, body)] in source order; nested comments inside strings or
    other comments are not handled because CSS comments don't nest. *)
 let extract_bang_comments (source : string) : (int * string) list =
@@ -4543,10 +4547,10 @@ let parse_stylesheet_partial ?(meta = Loc.default_meta_level)
 
 (* An at-rule cascade has no grammar for carries its parts as raw text, so the
    constructor has to answer for text that ends the at-rule before its parts do:
-   CSS Syntax 3 sec. 5.5.2 ends the prelude at the first top-level [;] or [{],
-   sec. 5.5.9 ends the block at the closer matching its opener, sec. 4.3.2 runs
-   an unclosed [/*] to EOF, and sec. 4.3.7 lets a trailing backslash escape the
-   closer written after it. Enumerating those boundaries re-derives the
+   CSS Syntax 3 (ED) sec. 5.5.2 ends the prelude at the first top-level [;] or
+   [{], sec. 5.5.9 ends the block at the closer matching its opener, sec. 4.3.2
+   runs an unclosed [/*] to EOF, and sec. 4.3.7 lets a trailing backslash escape
+   the closer written after it. Enumerating those boundaries re-derives the
    tokenizer and misses whichever one is not on the list, so read the parts back
    instead: this sits after the parser because that read is the check.
 

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -511,9 +511,9 @@ val read_font_tech_descriptor : Cursor.t -> font_tech_descriptor
 
 val pp_layer_name : layer_name Pp.t
 (** [pp_layer_name] prints a [<layer-name>]: each ident with the escapes that
-    read it back (CSS Syntax 3 sec. 2.1), joined by the [.] separators of CSS
-    Cascade 5 sec. 6.4.1. A [.] an ident carries is escaped, so it never reads
-    back as a separator. *)
+    read it back (CSS Syntax 3 (ED) sec. 2.1), joined by the [.] separators of
+    CSS Cascade 5 sec. 6.4.1. A [.] an ident carries is escaped, so it never
+    reads back as a separator. *)
 
 val read_layer_name : Cursor.t -> layer_name
 (** [read_layer_name r] parses a [<layer-name>]. It rejects a CSS-wide keyword,

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -8,10 +8,10 @@ type layer_name = string list
 (** A CSS [\@layer] name: the idents of [<ident> ['.' <ident>]*] (CSS Cascade 5
     sec. 6.4.1), outermost first. The separators are not part of any ident, so
     they are not stored: an escape can carry a [.] into an ident (CSS Syntax 3
-    sec. 4.3.7), and one string would make [\@layer a\2e b], the layer named
-    [a.b], the same value as [\@layer a.b], the sublayer [b] of [a]. The empty
-    list is not a name; where an anonymous layer is admissible it is spelled
-    that way. *)
+    (ED) sec. 4.3.7), and one string would make [\@layer a\2e b], the layer
+    named [a.b], the same value as [\@layer a.b], the sublayer [b] of [a]. The
+    empty list is not a name; where an anonymous layer is admissible it is
+    spelled that way. *)
 
 (** {2 Import Rule} *)
 
@@ -199,7 +199,7 @@ and statement =
       prelude : string;
       block : string option;
     }
-      (** CSS Syntax 3 sec. 5.5.2 "consume an at-rule" preserves any
+      (** CSS Syntax 3 (ED) sec. 5.5.2 "consume an at-rule" preserves any
           unrecognised at-rule as raw text so authors can ship unknown vendor or
           future at-rules without dropping the whole stylesheet. *)
 

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -120,11 +120,11 @@ let string_of_font_tech = function
   | Palettes -> "palettes"
   | Incremental -> "incremental"
 
-(* CSS Syntax 3 sec. 4.3.7 lets an escape carry a [;] or a [}] into a custom
-   property's name, so the name is checked against the spelling it serializes to
-   (CSS Syntax 3 sec. 2.1) rather than against its own bytes: read raw, such a
-   name ends the declaration early and never looks like the single ident it
-   is. *)
+(* CSS Syntax 3 (ED) sec. 4.3.7 lets an escape carry a [;] or a [}] into a
+   custom property's name, so the name is checked against the spelling it
+   serializes to (CSS Syntax 3 (ED) sec. 9) rather than against its own bytes:
+   read raw, such a name ends the declaration early and never looks like the
+   single ident it is. *)
 let property_name name =
   let reader = Cursor.of_string (Parser.escape_ident name) in
   let parsed =
@@ -148,7 +148,7 @@ let declaration_feature prop value =
   | "-vendor-flag", "enabled" -> Vendor_flag_enabled
   | _ -> (
       (* The name and the value stay apart: read as one text, a name carrying a
-         [;] or a [}] (CSS Syntax 3 sec. 4.3.7 puts either there through an
+         [;] or a [}] (CSS Syntax 3 (ED) sec. 4.3.7 puts either there through an
          escape) would end its own declaration.
 
          The value is read opaquely. CSS Conditional 3 sec. 6.1 answers a
@@ -164,8 +164,8 @@ let declaration_feature prop value =
 
 (* [property] takes authored CSS text and writes it between the feature's own
    parentheses, so the value has to be a [<declaration-value>] (CSS Syntax 3
-   sec. 8.2): an unmatched closing bracket closes those parentheses and the tail
-   becomes a second branch of the condition. The reader below hands
+   (ED) sec. 7.2): an unmatched closing bracket closes those parentheses and the
+   tail becomes a second branch of the condition. The reader below hands
    [declaration_feature] a value rendered from balanced components, so it needs
    no check. Rendering through the component stream closes a [<url-token>] the
    caller left open, the way the reader's own path already does. *)

--- a/lib/supports.mli
+++ b/lib/supports.mli
@@ -69,8 +69,8 @@ val property : string -> string -> t
     declaration feature. [value] keeps the spelling it is given.
 
     @raise Failure
-      if [value] is not a [<declaration-value>] (CSS Syntax 3 sec. 8.2). The
-      feature writes the value between its own parentheses, so an unmatched
+      if [value] is not a [<declaration-value>] (CSS Syntax 3 (ED) sec. 7.2).
+      The feature writes the value between its own parentheses, so an unmatched
       closing bracket closes them and the tail becomes a second branch of the
       condition. *)
 

--- a/lib/syntax.mli
+++ b/lib/syntax.mli
@@ -17,8 +17,8 @@ val is_hex : char -> bool
 
 val is_ident : string -> bool
 (** [is_ident s] is true when the whole of [s] is one ident, per CSS Syntax 3
-    sec. 4.3.11 for its opening and sec. 4.2 for the rest: a bare [-] and a [-]
-    before a digit open no ident, a leading digit opens none, and every code
+    (ED) sec. 4.3.9 for its opening and sec. 4.2 for the rest: a bare [-] and a
+    [-] before a digit open no ident, a leading digit opens none, and every code
     point is an ident code point. The non-ASCII half is
     {!Lexer.spec_non_ascii_ident_cp}, the range list serialisers emit verbatim,
     so [is_ident s] holds exactly when {!Parser.escape_ident} returns [s]

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -1,4 +1,4 @@
-(** CSS Syntax Module Level 3 section 4.2: token taxonomy.
+(** CSS Syntax 3 (ED) sec. 4.2: token taxonomy.
 
     Types only; the sec. 4.3 tokenization algorithm lives in {!Lexer}. *)
 

--- a/lib/token.mli
+++ b/lib/token.mli
@@ -1,4 +1,4 @@
-(** CSS Syntax Module Level 3 section 4.2: token taxonomy.
+(** CSS Syntax 3 (ED) sec. 4.2: token taxonomy.
 
     Types only; the section 4.3 tokenization algorithm lives in {!Lexer}. Every
     token carries the source {!Loc.t} it was read from. *)
@@ -33,13 +33,13 @@ type kind =
   | Hash of { value : string; hash_flag : hash_flag }
   | String of { value : string; quote : char; terminated : bool }
       (** String literal. [quote] is the opening quote character (double or
-          single); the spec treats both as equivalent delimiters (CSS Syntax
-          section 4.3.5) but we record it for quote-sensitive rules (e.g.
-          [@charset] per CSS Syntax section 8.2) and to round-trip the input
+          single); the spec treats both as equivalent delimiters (CSS Syntax 3
+          (ED) sec. 4.3.5) but we record it for quote-sensitive rules (e.g.
+          [@charset] per CSS Syntax 3 (ED) sec. 8.3) and to round-trip the input
           style. [terminated] is [false] when the lexer reached EOF without
-          seeing the closing quote (CSS Syntax section 4.3.5 returns the string
-          token but flags a parse error); the serializer omits the closing quote
-          so the original byte sequence is preserved. *)
+          seeing the closing quote (CSS Syntax 3 (ED) sec. 4.3.5 returns the
+          string token but flags a parse error); the serializer omits the
+          closing quote so the original byte sequence is preserved. *)
   | Bad_string
       (** Unterminated string (newline or EOF before the closing quote). *)
   | Url of string
@@ -57,10 +57,11 @@ type kind =
       end_value : int;
       form : unicode_range_form;
     }
-      (** [U+XXXX] / [U+XXXX-YYYY] / [U+XX??] (CSS Syntax section 4.3.14). The
-          three syntactic forms are normalised to the [[start_value, end_value]]
-          inclusive range; [start_value = end_value] for the single-codepoint
-          form. [form] keeps the typed token shape for non-minified fidelity. *)
+      (** [U+XXXX] / [U+XXXX-YYYY] / [U+XX??] (CSS Syntax 3 (ED) sec. 4.3.14).
+          The three syntactic forms are normalised to the
+          [[start_value, end_value]] inclusive range; [start_value = end_value]
+          for the single-codepoint form. [form] keeps the typed token shape for
+          non-minified fidelity. *)
   | Cdo  (** [<!--] at top level. *)
   | Cdc  (** [-->] at top level. *)
   | Colon

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -395,7 +395,7 @@ let color_mix_var_pct_fallback ?in_space ?(hue = Default) ~var_name ~fallback
 (** Pretty-printing functions *)
 
 (* Opens [var(] and writes the referenced name. [name] is the custom property's
-   name without its [--] prefix, and CSS Syntax 3 sec. 4.3.7 lets an escape
+   name without its [--] prefix, and CSS Syntax 3 (ED) sec. 4.3.7 lets an escape
    carry a [;] or a [}] into it, so the tail is written with the escapes that
    read the same name back. *)
 let pp_var_open ctx name =
@@ -891,9 +891,9 @@ and math_fn_result (fn : math_fn) : math_result option =
      place. *)
   | _ -> Option.map (fun v -> Scalar v) (eval_math_fn fn)
 
-(* CSS Values 4 sec. 10.9.2: NaN belongs to a calculation tree and has no leaf
-   spelling outside one, so folding a math function down to a NaN would lose the
-   only form the value can take. Leave the function in place. *)
+(* CSS Values 4 (ED) sec. 10.9.2: NaN belongs to a calculation tree and has no
+   leaf spelling outside one, so folding a math function down to a NaN would
+   lose the only form the value can take. Leave the function in place. *)
 let fold_math_result = function
   | Some r when Float.is_nan (math_result_value r) -> Option.none
   | result -> result
@@ -5289,8 +5289,8 @@ let math_constant_factor_of_name : type a. Cursor.t -> _ -> string -> a calc =
 
 let read_math_constant_factor : type a. Cursor.t -> a calc =
  fun t ->
-  (* CSS Values 4 sec. 10.7.1 math constants ([pi], [e], [infinity],
-     [-infinity], [NaN]) appear as bare identifiers inside [calc()]. *)
+  (* CSS Values 4 sec. 10.7 math constants ([pi], [e], [infinity], [-infinity],
+     [NaN]) appear as bare identifiers inside [calc()]. *)
   let snap = Cursor.save t in
   match Cursor.ident_opt t with
   | Some name -> math_constant_factor_of_name t snap name
@@ -5376,9 +5376,9 @@ and read_calc_numeric_function : type a. Cursor.t -> a calc =
       | "min" -> read_numeric_list_call "min" Float.min Float.infinity t
       | "max" -> read_numeric_list_call "max" Float.max Float.neg_infinity t
       | "clamp" -> read_numeric_clamp t
-      (* CSS Values 4 sec. 9.1 numeric math functions: parsed into the typed
-         [Math_fn] AST so pretty pp re-emits [name(args)]; the optimizer (or
-         minify pp) folds via [eval_math_fn]. *)
+      (* CSS Values 4 (ED) sec. 9.1 numeric math functions: parsed into the
+         typed [Math_fn] AST so pretty pp re-emits [name(args)]; the optimizer
+         (or minify pp) folds via [eval_math_fn]. *)
       | "sqrt" -> Math_fn (Sqrt (read_math_call_arg "sqrt" t))
       | "abs" -> Math_fn (Abs_n (read_math_call_arg "abs" t))
       | "sign" -> Math_fn (Sign_n (read_math_call_arg "sign" t))
@@ -6265,7 +6265,7 @@ let read_angle_trig kind name t =
           radians *. 180. /. Float.pi)
     in
     if Float.is_nan degrees then (
-      (* CSS Values 4 sec. 10.9.2: NaN lives inside a calculation tree and
+      (* CSS Values 4 (ED) sec. 10.9.2: NaN lives inside a calculation tree and
          nowhere else, so it has no leaf spelling. Re-read the call and keep the
          function the author wrote. *)
       Cursor.restore t snapshot;

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -595,9 +595,9 @@ val eval_numeric_calc : 'a calc -> float option
     non-numeric values. *)
 
 val eval_math_fn : math_fn -> float option
-(** [eval_math_fn fn] evaluates a CSS Values 4 sec. 9.1 numeric math function
-    call to a float. Returns [None] when an arg references an unresolved
-    variable. *)
+(** [eval_math_fn fn] evaluates a CSS Values 4 (ED) sec. 9.1 numeric math
+    function call to a float. Returns [None] when an arg references an
+    unresolved variable. *)
 
 val read_numeric_expression : Cursor.t -> float
 (** [read_numeric_expression t] parses and evaluates a numeric math expression,

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -417,8 +417,8 @@ type angle =
       (** Spec-invalid [<angle>] input (e.g. [asin(<angle>)] - inverse trig
           takes [<number>], not [<angle>]) that upstream tools preserve
           verbatim. The pretty-printer emits the tokens unchanged; the
-          [Optimize.drop_invalid] pass removes any declaration whose typed value
-          reduces to this arm under [--minify]. *)
+          [Optimize.drop_invalid] pass, which every serialisation runs, removes
+          any declaration whose typed value reduces to this arm. *)
 
 type alpha =
   | None
@@ -453,7 +453,8 @@ type length_percentage =
       (** Spec-invalid input cascade detected (e.g. [width: asin(sin(45deg))]
           - the inner reduction yields an angle, but [<length-percentage>]
             doesn't accept angles). Pretty-printer emits the tokens verbatim;
-            [Optimize.drop_invalid] removes the declaration under [--minify]. *)
+            [Optimize.drop_invalid] removes the declaration on every
+            serialisation. *)
 
 type number_percentage =
   | Num of float

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -39,15 +39,14 @@ type 'a var = {
 type 'a env = { name : string; indices : int list; fallback : 'a option }
 type calc_op = Add | Sub | Mul | Div
 
-(** CSS Values 4 sec. 10.7.1 math constants - emitted at the source byte
-    sequence (e.g. [pi], [e]) rather than their floating-point evaluation, so
-    pretty pp preserves [calc(2 * pi)] instead of writing [calc(6.28318530718)].
-*)
+(** CSS Values 4 sec. 10.7 math constants - emitted at the source byte sequence
+    (e.g. [pi], [e]) rather than their floating-point evaluation, so pretty pp
+    preserves [calc(2 * pi)] instead of writing [calc(6.28318530718)]. *)
 type math_const = Pi | E | Infinity | Neg_infinity | Nan
 
-(** CSS Values 4 sec. 9.1 numeric math function arguments. Self-recursive so
-    nested calls round-trip ([pow(2, sqrt(100))]) and arithmetic with constants
-    stays as a tree ([(e - exp(1))]). *)
+(** CSS Values 4 (ED) sec. 9.1 numeric math function arguments. Self-recursive
+    so nested calls round-trip ([pow(2, sqrt(100))]) and arithmetic with
+    constants stays as a tree ([(e - exp(1))]). *)
 type math_arg =
   | Lit of float
   | Dim of float * string
@@ -60,9 +59,9 @@ type math_arg =
   | Parens_arg of math_arg
   | Math_call of math_fn
 
-(** CSS Values 4 sec. 9.1 numeric math functions. Each arm preserves its source
-    arg shape so pretty pp re-emits [name(args)]; the optimizer evaluates to
-    [Num] under minify. *)
+(** CSS Values 4 (ED) sec. 9.1 numeric math functions. Each arm preserves its
+    source arg shape so pretty pp re-emits [name(args)]; the optimizer evaluates
+    to [Num] under minify. *)
 and math_fn =
   | Sin of angle_arg
   | Cos of angle_arg
@@ -102,9 +101,9 @@ type 'a calc =
   | Nested of 'a calc (* Explicitly nested calc(), rendered as calc(inner) *)
   | Parens of 'a calc (* Parenthesized expression, rendered as (inner) *)
   | Math_fn of math_fn
-(* CSS Values 4 sec. 9.1 numeric math functions ([sin], [cos], [hypot], ...).
-   Pretty pp emits [name(args)] preserving source shape; minify pp / optimizer
-   evaluates to [Num]. *)
+(* CSS Values 4 (ED) sec. 9.1 numeric math functions ([sin], [cos], [hypot],
+   ...). Pretty pp emits [name(args)] preserving source shape; minify pp /
+   optimizer evaluates to [Num]. *)
 
 type attr_syntax = Length | Length_percentage | Color | Number | Percentage
 

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2640,8 +2640,8 @@ let read_reference_body_as_string (r : Cursor.t) : string * string option =
     information which would need to be resolved from a variable registry or
     context. *)
 let read_reference (r : Cursor.t) : string * string option =
-  (* CSS Syntax 3 sec. 4.3.6: EOF inside a function is a parse error, tolerated
-     only when the fallback list opened with a comma (a sec. 4.3.5
+  (* CSS Syntax 3 (ED) sec. 4.3.6: EOF inside a function is a parse error,
+     tolerated only when the fallback list opened with a comma (a sec. 4.3.5
      [<string-token>] may have eaten the closing [)]) so a recoverable name +
      fallback survives. Without a fallback there is no recovery signal, so it is
      rejected. *)


### PR DESCRIPTION
`css.mli` had a run of doc comments attached one type too early, so odoc showed align-content's prose and MDN link on `font_size` and left the last type of each run undocumented. The branch also corrects the `Optimize.drop_invalid` contract, which five interfaces gated on `--minify` when `Css.pp` applies it to every serialisation, and renumbers the CSS Syntax 3 citations, which came off both the TR snapshot and the editor's draft.

Comments and doc strings only. The CLI's output over every `.css` file under `test/` is byte-identical before and after.
