### PR TITLE
declaration: hand a property grammar the value and nothing else

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,13 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A declaration whose grammar ends in an optional component is no longer
+  dropped over the tail the declaration consumer strips. `font-style: oblique
+  !important`, `rotate: 45deg !important`, `text-box: none;` and
+  `initial-letter: 2 3;` read the `;` and the `!important` as part of the
+  value and failed, so the declaration went missing from the output with
+  nothing but a warning; CSS Syntax 3 (ED) sec. 5.5.6 hands a property
+  grammar neither (#644)
 - An empty value is no longer a declaration. `border:`, its per-side and
   logical variants and `column-rule:` read as `border: none`, and `outline:`
   printed a value no parser reads back; an empty value matches none of these

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -166,11 +166,8 @@ type head_shape =
   | `Func
   | `Other ]
 
-let peek_head_shape t : head_shape =
-  drop_ws t;
-  match t.cvs with
-  | [] -> `Eof
-  | Component.Preserved { kind; _ } :: _ -> (
+let component_head_shape : Component.t -> head_shape = function
+  | Component.Preserved { kind; _ } -> (
       match kind with
       | Token.Semicolon -> `Semicolon
       | Token.Colon -> `Colon
@@ -178,12 +175,16 @@ let peek_head_shape t : head_shape =
       | Token.Delim "!" -> `Bang
       | Token.Ident _ -> `Ident
       | _ -> `Other)
-  | Component.Block { node = { opening; _ }; _ } :: _ -> (
+  | Component.Block { node = { opening; _ }; _ } -> (
       match opening with
       | Token.Curly -> `Curly_block
       | Token.Paren -> `Paren_block
       | Token.Square -> `Square_block)
-  | Component.Func _ :: _ -> `Func
+  | Component.Func _ -> `Func
+
+let peek_head_shape t : head_shape =
+  drop_ws t;
+  match t.cvs with [] -> `Eof | cv :: _ -> component_head_shape cv
 
 let next_raw t =
   match t.cvs with
@@ -462,10 +463,6 @@ let is_semicolon_cv = function
   | Component.Preserved { kind = Token.Semicolon; _ } -> true
   | _ -> false
 
-let is_bang_cv = function
-  | Component.Preserved { kind = Token.Delim "!"; _ } -> true
-  | _ -> false
-
 let consume_until_semicolon ?(trim = false) t =
   string_of_components ~trim (drain_until_raw is_semicolon_cv t)
 
@@ -474,12 +471,23 @@ let rec skip_past_semicolon t =
   | None -> ()
   | Some cv -> if not (is_semicolon_cv cv) then skip_past_semicolon t
 
-let consume_to_decl_end ?(trim = false) t =
-  string_of_components ~trim
-    (drain_until_raw (fun cv -> is_semicolon_cv cv || is_bang_cv cv) t)
+(* CSS Syntax 3 (ED) sec. 5.5.6 reads a declaration's value with
+   [<semicolon-token>] as the stop token, then removes a trailing [!]
+   [important] pair from that value and sets the declaration's important flag
+   instead. Both are therefore the declaration consumer's to read, never the
+   property grammar's, and [head_shape] is what says which is which. *)
+let ends_declaration_value cv =
+  match component_head_shape cv with `Semicolon | `Bang -> true | _ -> false
 
-let drain_to_decl_end t =
-  drain_until_raw (fun cv -> is_semicolon_cv cv || is_bang_cv cv) t
+let consume_to_decl_end ?(trim = false) t =
+  string_of_components ~trim (drain_until_raw ends_declaration_value t)
+
+let drain_to_decl_end t = drain_until_raw ends_declaration_value t
+
+let declaration_value t =
+  let cvs = drain_to_decl_end t in
+  let eof_loc = Option.map Component.source_loc (peek_raw t) in
+  sub ?eof_loc t cvs
 
 let is_slash_cv = function
   | Component.Preserved { kind = Token.Delim "/"; _ } -> true

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -362,6 +362,18 @@ val drain_to_decl_end : t -> Component.t list
     semicolon or top-level [!] delimiter, returning the drained list without
     serialising it. *)
 
+val declaration_value : t -> t
+(** [declaration_value t] consumes a declaration's value off [t] and is a cursor
+    over it alone.
+
+    CSS Syntax 3 (ED) sec. 5.5.6 reads the value with [<semicolon-token>] as the
+    stop token, then lifts a trailing [!] [important] pair out of it into the
+    declaration's important flag. A property grammar is handed what is left,
+    which holds neither, so a reader whose grammar has an optional trailing
+    component asks {!is_done} and nothing more: the [;] and the [!] stay on [t]
+    for the declaration consumer to finish. End-of-input errors on the value
+    anchor at whichever of the two stopped it. *)
+
 val consume_to_slash_or_semicolon : ?trim:bool -> t -> string
 (** [consume_to_slash_or_semicolon t] consumes and serializes components up to,
     but not including, the next top-level slash delimiter or semicolon. *)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2164,8 +2164,9 @@ let allows_unknown_fallback name raw_value =
 
 let read_font_src_declaration t raw_value =
   ignore raw_value;
-  let decl = v Source (Properties.read_font_src t) in
-  validate_no_extra_tokens t;
+  let value = Cursor.declaration_value t in
+  let decl = v Source (Properties.read_font_src value) in
+  validate_no_extra_tokens value;
   let is_important = read_importance t in
   validate_no_extra_tokens t;
   if is_important then important decl else decl
@@ -2203,8 +2204,9 @@ let read_typed_value_declaration : type a. a property -> Cursor.t -> declaration
          Stamp the property back on so the warning names it ([bad value for
          background-image:]). *)
       let read () =
-        let decl = read_value prop_type t in
-        validate_no_extra_tokens t;
+        let value = Cursor.declaration_value t in
+        let decl = read_value prop_type value in
+        validate_no_extra_tokens value;
         let is_important = read_importance t in
         validate_no_extra_tokens t;
         (match Cursor.peek_delim t with

--- a/lib/prop_align.ml
+++ b/lib/prop_align.ml
@@ -347,7 +347,6 @@ let rec read_justify_items t : justify_items =
         let _ = Cursor.ident t in
         Legacy_right
     | None -> Legacy
-    | Some _ when Cursor.peek_semicolon t -> Legacy
     | Some s -> err_invalid_value t "justify-items legacy" s
   in
   Cursor.enum_or_var "justify-items"

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1808,8 +1808,7 @@ let animation_range_names =
 
 let read_animation_range_offset t : length_percentage option =
   Cursor.ws t;
-  if Cursor.is_done t || Cursor.peek_semicolon t then
-    (None : length_percentage option)
+  if Cursor.is_done t then (None : length_percentage option)
   else
     match Cursor.peek_ident t with
     | Some "normal" -> (None : length_percentage option)
@@ -1871,7 +1870,7 @@ let rec read_animation_range t : animation_range =
     in
     let first = read_single t in
     Cursor.ws t;
-    if Cursor.is_done t || Cursor.peek_semicolon t then Range (first, None)
+    if Cursor.is_done t then Range (first, None)
     else
       let second = read_single t in
       Range (first, Some second)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1995,8 +1995,6 @@ let rec read_border_spacing t : border_spacing =
         : border_spacing))
     t
 
-let border_image_at_end t = Cursor.is_done t || Cursor.peek_semicolon t
-
 let read_border_image_slice_item t : border_image_slice_item =
   match Cursor.percentage_opt t with
   | Some n when n >= 0. -> Pct n
@@ -2017,7 +2015,7 @@ let read_border_image_slice_value t values has_fill =
 
 let read_border_image_slice_step t values has_fill =
   Cursor.ws t;
-  if border_image_at_end t || Cursor.peek_delim t = Some '/' then `Stop
+  if Cursor.is_done t || Cursor.peek_delim t = Some '/' then `Stop
   else
     match Cursor.peek_ident t with
     | Some "fill" ->
@@ -2067,7 +2065,7 @@ let read_border_image_outset_item t : border_image_outset_item =
 
 let read_border_image_box_step ~what read_item t acc =
   Cursor.ws t;
-  if border_image_at_end t || Cursor.peek_delim t = Some '/' then `Stop
+  if Cursor.is_done t || Cursor.peek_delim t = Some '/' then `Stop
   else
     match Cursor.option read_item t with
     | Some value ->

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -185,17 +185,11 @@ let rec read_overflow_single (t : Cursor.t) : overflow =
 let read_overflow t : overflow =
   let first = read_overflow_single t in
   Cursor.ws t;
-  if
-    Cursor.is_done t || Cursor.peek_semicolon t
-    || Cursor.peek_delim t = Some '!'
-  then first
+  if Cursor.is_done t then first
   else
     let second = read_overflow_single t in
     Cursor.ws t;
-    if
-      (not (Cursor.is_done t))
-      && not (Cursor.peek_semicolon t || Cursor.peek_delim t = Some '!')
-    then Cursor.expect_eof t;
+    Cursor.expect_eof t;
     Overflow_pair (first, second)
 
 (* [object-view-box] has its own [Inset] / [Xywh] / [Rect] variants distinct
@@ -600,7 +594,7 @@ let read_overflow_clip_length_item (length : length option ref) t =
 
 let rec read_overflow_clip_margin_items box length consumed t =
   Cursor.ws t;
-  if Cursor.is_done t || Cursor.peek_semicolon t then consumed
+  if Cursor.is_done t then consumed
   else
     let snap = Cursor.save t in
     if

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -76,11 +76,11 @@ let rec read_font_style t : font_style =
     ~default:(fun t ->
       Cursor.expect_string "oblique" t;
       Cursor.ws t;
-      if Cursor.is_done t || Cursor.peek_semicolon t then Oblique
+      if Cursor.is_done t then Oblique
       else
         let first = read_angle t in
         Cursor.ws t;
-        if Cursor.is_done t || Cursor.peek_semicolon t then Oblique_angle first
+        if Cursor.is_done t then Oblique_angle first
         else
           (* CSS Fonts 4 sec. 4.4 swaps the endpoints of a descending [oblique
              <angle> <angle>] range rather than rejecting it, so the reader

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -600,7 +600,7 @@ let rec read_grid_auto_flow t : grid_auto_flow =
     t
 
 let grid_line_at_end t =
-  Cursor.is_done t || Cursor.peek_semicolon t
+  Cursor.is_done t
   ||
   match Cursor.peek t with
   | Some (Component.Preserved { kind = Token.Delim "/"; _ }) -> true

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -537,7 +537,7 @@ let rec read_contain_intrinsic_size (t : Cursor.t) : contain_intrinsic_size =
   let read_intrinsic t =
     let first = read_contain_intrinsic_size_item t in
     Cursor.ws t;
-    if Cursor.is_done t || Cursor.peek_semicolon t then Intrinsic (first, None)
+    if Cursor.is_done t then Intrinsic (first, None)
     else
       let second = read_contain_intrinsic_size_item t in
       Intrinsic (first, Some second)

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -1030,18 +1030,17 @@ let rec read_clip_path (t : Cursor.t) : clip_path =
   in
   (* CSS Masking 1 sec. 5.1 [<basic-shape> || <geometry-box>]: a shape and a
      reference box may appear in either order, or just a box on its own. *)
-  let at_end t = Cursor.is_done t || Cursor.peek_semicolon t in
   match read_clip_geometry_box_opt t with
   | Some box ->
       Cursor.ws t;
-      if at_end t then Clip_path_box box
+      if Cursor.is_done t then Clip_path_box box
       else
         let shape = read_basic_shape t in
         Clip_path_with_box { shape; box; box_first = true }
   | None -> (
       let shape = read_basic_shape t in
       Cursor.ws t;
-      if at_end t then shape
+      if Cursor.is_done t then shape
       else
         match read_clip_geometry_box_opt t with
         | Some box -> Clip_path_with_box { shape; box; box_first = false }

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -384,32 +384,30 @@ let read_page_size_orientation t : page_size_orientation =
 
 let rec read_page_size t : page_size =
   let read_var_ps t : page_size = Var (read_var read_page_size t) in
-  let at_end t = Cursor.is_done t || Cursor.peek_semicolon t in
-  let expect_value_end t = if not (at_end t) then Cursor.expect_eof t in
   let read_named t =
     let name = read_page_size_name t in
     Cursor.ws t;
-    if at_end t then Named name
+    if Cursor.is_done t then Named name
     else
       let orientation = read_page_size_orientation t in
       Cursor.ws t;
-      expect_value_end t;
+      Cursor.expect_eof t;
       Named_oriented (name, orientation)
   in
   let read_oriented t =
     let orientation = read_page_size_orientation t in
     Cursor.ws t;
-    expect_value_end t;
+    Cursor.expect_eof t;
     Oriented orientation
   in
   let read_lengths t =
     let first = read_length t in
     Cursor.ws t;
-    if at_end t then Single first
+    if Cursor.is_done t then Single first
     else
       let second = read_length t in
       Cursor.ws t;
-      expect_value_end t;
+      Cursor.expect_eof t;
       Pair (first, second)
   in
   Cursor.enum_or_calls "page-size"

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -281,11 +281,7 @@ let rec read_text_indent_value t : text_indent_value =
       let length = ref Option.None in
       let hanging = ref false in
       let each_line = ref false in
-      let at_end t =
-        Cursor.is_done t || Cursor.peek_semicolon t
-        || Cursor.peek_delim t = Some '!'
-      in
-      while not (at_end t) do
+      while not (Cursor.is_done t) do
         Cursor.ws t;
         match Cursor.peek_ident t with
         | Some "hanging" when not !hanging ->
@@ -1964,8 +1960,7 @@ let rec read_initial_letter t : initial_letter =
     let size = Cursor.number t in
     if size < 1. then Cursor.err_invalid t "initial-letter size must be >= 1";
     Cursor.ws t;
-    if Cursor.is_done t || Cursor.peek_semicolon t then
-      (Size size : initial_letter)
+    if Cursor.is_done t then (Size size : initial_letter)
     else
       let sink = Cursor.int t in
       if sink < 1 then Cursor.err_invalid t "initial-letter sink must be >= 1";

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -970,8 +970,7 @@ let read_rotate_angle_axis_tail angle t =
 let read_rotate_angle_then_axis t : rotate_value =
   let angle = read_angle t in
   Cursor.ws t;
-  if Cursor.is_done t || Cursor.peek_semicolon t then Angle angle
-  else read_rotate_angle_axis_tail angle t
+  if Cursor.is_done t then Angle angle else read_rotate_angle_axis_tail angle t
 
 let rec read_rotate_value t : rotate_value =
   Cursor.enum_or_calls "rotate"

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -180,7 +180,7 @@ let read_caret_shape_component t : caret_shape =
 
 let read_caret_shorthand t : caret =
   let rec loop color animation shape count =
-    if Cursor.is_done t || Cursor.peek_semicolon t then
+    if Cursor.is_done t then
       if count = 0 then Cursor.err_expected t "caret"
       else (Caret (color, animation, shape) : caret)
     else
@@ -1153,7 +1153,7 @@ let color_scheme_of_idents t names : color_scheme =
 let rec read_color_scheme t : color_scheme =
   let rec read_idents acc =
     Cursor.ws t;
-    if Cursor.is_done t || Cursor.peek_semicolon t then List.rev acc
+    if Cursor.is_done t then List.rev acc
     else read_idents (Cursor.ident t :: acc)
   in
   match Cursor.peek t with
@@ -1216,9 +1216,6 @@ let outline_style_keywords =
 let outline_starts_style t =
   List.exists (fun kw -> Cursor.looking_at t kw) outline_style_keywords
 
-let outline_at_end t =
-  Cursor.is_done t || Cursor.peek_semicolon t || Cursor.peek_delim t = Some '!'
-
 let read_outline_part ~width ~style ~color t =
   if Cursor.looking_at_func "var" t then
     (* A var() is type-ambiguous; assign it to the next unfilled
@@ -1249,7 +1246,7 @@ let read_outline_part ~width ~style ~color t =
 let read_outline_parts ~width ~style ~color t =
   let rec loop () =
     Cursor.ws t;
-    if not (outline_at_end t) then (
+    if not (Cursor.is_done t) then (
       read_outline_part ~width ~style ~color t;
       loop ())
   in

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -526,11 +526,40 @@ let invalid_css_is_not_empty_css () =
       Alcotest.(check int) ("kept count: " ^ css) 0 result.kept)
     [ "@@@@ }}} {{{ !!! ;;;"; ""; "a{" ]
 
+(* [Apply] resolves through the same declaration reader, so a value the reader
+   dropped over its own [!important] never reached the resolved style. CSS
+   Syntax 3 (ED) sec. 5.5.6 lifts that tail out of the value before any grammar
+   sees it, and CSS Cascade 5 sec. 6.2 ranks what it flags above a normal
+   declaration of the same property. *)
+let important_declaration_reaches_the_resolved_style () =
+  List.iter
+    (fun (css, expected) ->
+      let n = node ~classes:[ "x" ] "p" in
+      let result = A.compute ~sheet:(parse css) [ n ] in
+      Alcotest.(check string)
+        ("inline declarations: " ^ css)
+        expected
+        (match result.styles with
+        | [ (_, decls) ] -> inline_style decls
+        | _ -> Alcotest.failf "expected one inline assignment for %s" css))
+    [
+      ( ".x{font-style:oblique !important;color:red}",
+        "font-style:oblique;color:red" );
+      ( ".x{color-scheme:dark !important;color:red}",
+        "color-scheme:dark;color:red" );
+      (".x{text-box:none;color:red}", "text-box:none;color:red");
+      (* The flag still decides the cascade: the important declaration wins over
+         a later normal one for the same property. *)
+      (".x{color:red !important}.x{color:blue}", "color:red");
+    ]
+
 let suite =
   ( "apply",
     [
       Alcotest.test_case "projects static rule to inline style" `Quick
         projects_static_rule_to_inline_style;
+      Alcotest.test_case "important declaration reaches the resolved style"
+        `Quick important_declaration_reaches_the_resolved_style;
       Alcotest.test_case "keeps stateful rule in css" `Quick
         keeps_stateful_rule_in_css;
       Alcotest.test_case "projects layered rule to inline style" `Quick

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -530,27 +530,47 @@ let invalid_css_is_not_empty_css () =
    dropped over its own [!important] never reached the resolved style. CSS
    Syntax 3 (ED) sec. 5.5.6 lifts that tail out of the value before any grammar
    sees it, and CSS Cascade 5 sec. 6.2 ranks what it flags above a normal
-   declaration of the same property. *)
+   declaration of the same property. Asserted on the declaration rather than on
+   the serialised attribute, which orders the two ranks. *)
 let important_declaration_reaches_the_resolved_style () =
   List.iter
-    (fun (css, expected) ->
+    (fun (css, property, value, important) ->
       let n = node ~classes:[ "x" ] "p" in
       let result = A.compute ~sheet:(parse css) [ n ] in
-      Alcotest.(check string)
-        ("inline declarations: " ^ css)
-        expected
-        (match result.styles with
-        | [ (_, decls) ] -> inline_style decls
-        | _ -> Alcotest.failf "expected one inline assignment for %s" css))
+      let decls =
+        match result.styles with
+        | [ (_, decls) ] -> decls
+        | _ -> Alcotest.failf "expected one inline assignment for %s" css
+      in
+      match
+        List.find_opt
+          (fun d -> String.equal (Css.Declaration.property_name d) property)
+          decls
+      with
+      | None ->
+          Alcotest.failf "%s: %s did not reach the resolved style" css property
+      | Some d ->
+          Alcotest.(check string)
+            (css ^ ": " ^ property)
+            value
+            (Css.Declaration.string_of_value ~minify:true d);
+          Alcotest.(check bool)
+            (css ^ ": " ^ property ^ " keeps its flag")
+            important
+            (Css.Declaration.is_important d))
     [
       ( ".x{font-style:oblique !important;color:red}",
-        "font-style:oblique;color:red" );
+        "font-style",
+        "oblique",
+        true );
       ( ".x{color-scheme:dark !important;color:red}",
-        "color-scheme:dark;color:red" );
-      (".x{text-box:none;color:red}", "text-box:none;color:red");
+        "color-scheme",
+        "dark",
+        true );
+      (".x{text-box:none;color:red}", "text-box", "none", false);
       (* The flag still decides the cascade: the important declaration wins over
          a later normal one for the same property. *)
-      (".x{color:red !important}.x{color:blue}", "color:red");
+      (".x{color:red !important}.x{color:blue}", "color", "red", true);
     ]
 
 let suite =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3575,6 +3575,37 @@ let check_property_trailing_token_rejected (row : property_grammar_row) value =
         "%s positive vector accepted an extra trailing token: %s -> %s"
         row.property input serialized
 
+(* CSS Syntax 3 (ED) sec. 5.5.6 stops a declaration's value at the top-level [;]
+   and lifts a trailing [!important] out of it into the important flag, so every
+   vector the grammar accepts bare it has to accept with either tail behind it,
+   and to the same value. *)
+let check_property_value_tail (row : property_grammar_row) value =
+  let bare = row.property ^ ":" ^ value in
+  match parse_property_decl row.property value with
+  | None -> Alcotest.failf "%s positive vector rejected: %s" row.property value
+  | Some (_, _, decl, _) ->
+      let expected = Css.Declaration.string_of_value ~minify:true decl in
+      List.iter
+        (fun (suffix, important) ->
+          let input = bare ^ suffix in
+          let c = Cursor.of_string input in
+          match read_declaration c with
+          | None ->
+              Alcotest.failf "%s dropped the declaration: %s" row.property input
+          | exception (Cursor.Parse_error _ | Reader.Parse_error _) ->
+              Alcotest.failf "%s rejected the declaration: %s" row.property
+                input
+          | Some tailed ->
+              Alcotest.(check string)
+                (Fmt.str "%s holds the value of %S" input bare)
+                expected
+                (Css.Declaration.string_of_value ~minify:true tailed);
+              Alcotest.(check bool)
+                (Fmt.str "%s important flag" input)
+                important
+                (Css.Declaration.is_important tailed))
+        [ (";", false); (" !important", true); (" !important;", true) ]
+
 let check_property_name (row : property_grammar_row) =
   if String.trim row.property <> row.property then
     Alcotest.failf "%S has leading or trailing property-name whitespace"
@@ -3682,6 +3713,7 @@ let check_property_row (row : property_grammar_row) =
   check_manifest_calc_surface row;
   List.iter (check_property_positive row) row.positives;
   List.iter (check_property_trailing_token_rejected row) row.positives;
+  List.iter (check_property_value_tail row) row.positives;
   List.iter (check_property_negative row) row.negatives;
   List.iter
     (check_property_css_wide row)
@@ -3832,6 +3864,166 @@ let check_sheet_roundtrip name css =
         css
         (String.trim (Css.to_string ~minify:true stylesheet))
   | Error e -> Alcotest.failf "%s: %s" css (Error.to_string e)
+
+(* CSS Syntax 3 (ED) sec. 5.5.6 "consume a declaration" reads the value with
+   [<semicolon-token>] as the stop token, then removes a trailing [!]
+   [important] pair from that value and sets the declaration's important flag
+   instead. A property grammar therefore never sees a [;] or an [!important],
+   and neither may change what the value in front of it parses to. *)
+let value_tail_forms property value =
+  let bare = String.concat "" [ property; ":"; value ] in
+  [
+    (bare, false);
+    (bare ^ ";", false);
+    (bare ^ " !important", true);
+    (bare ^ "!important", true);
+    (bare ^ " !important;", true);
+    (bare ^ " !IMPORTANT", true);
+  ]
+
+let read_one_declaration what input =
+  let c = Cursor.of_string input in
+  match read_declaration c with
+  | Some decl -> decl
+  | None -> Alcotest.failf "%s: %S read no declaration" what input
+  | exception Error.Parse_error e ->
+      Alcotest.failf "%s: %S was rejected: %s" what input (Error.to_string e)
+
+(* The value a declaration holds, and its important flag, are independent of the
+   tail the declaration consumer strips. Compared against the tail-free spelling
+   rather than a pinned string, so the invariant is what is asserted. *)
+let check_value_end property value =
+  let bare = String.concat "" [ property; ":"; value ] in
+  let expected =
+    Css.Declaration.string_of_value ~minify:true
+      (read_one_declaration "value end" bare)
+  in
+  List.iter
+    (fun (input, important) ->
+      let decl = read_one_declaration "value end" input in
+      Alcotest.(check string)
+        (Fmt.str "%S holds the value of %S" input bare)
+        expected
+        (Css.Declaration.string_of_value ~minify:true decl);
+      Alcotest.(check bool)
+        (Fmt.str "%S important flag" input)
+        important
+        (Css.Declaration.is_important decl);
+      (* A declaration cascade prints has to read back as itself: the minified
+         spelling of an important declaration ends in [!important], which is the
+         very tail the reader has to see past. *)
+      let printed = Css.Declaration.to_string ~minify:true decl in
+      Alcotest.(check string)
+        (Fmt.str "%S reparses" printed)
+        printed
+        (Css.Declaration.to_string ~minify:true
+           (read_one_declaration "value end reparse" printed)))
+    (value_tail_forms property value)
+
+(* One reader per spelling of the end-of-value question that was open-coded:
+   readers that ended on cursor exhaustion alone dropped the declaration over a
+   [;] as well as over an [!important], readers that also peeked for a [;]
+   dropped it over an [!important] only. Each entry is a property whose grammar
+   has an optional trailing component, so the reader has to ask the question at
+   all. *)
+let value_end_properties =
+  [
+    ("font-style", "oblique");
+    ("caret", "red");
+    ("color-scheme", "dark");
+    ("rotate", "45deg");
+    ("clip-path", "border-box");
+    ("animation-range", "normal");
+    ("contain-intrinsic-size", "auto 300px");
+    ("text-box", "none");
+    ("hyphenate-limit-chars", "6");
+    ("initial-letter", "2 3");
+    ("justify-items", "legacy");
+    ("overflow-clip-margin", "1px");
+    ("grid-row", "span 2");
+    ("border-image-slice", "30%");
+    ("size", "A4");
+    ("mask-border-slice", "30%");
+    ("column-rule", "1px");
+    ("text-emphasis", "filled");
+    ("scale", "2");
+    ("transform-origin", "left");
+    (* Controls: readers that already spelled the question with all three of its
+       answers, and a value with no optional tail at all. *)
+    ("overflow", "hidden");
+    ("color", "red");
+  ]
+
+let declaration_value_end () =
+  List.iter
+    (fun (property, value) -> check_value_end property value)
+    value_end_properties
+
+(* The pretty spelling of a declaration ends in a [;], so a reader that stops at
+   the value's last component and then fails on the [;] cannot read back what
+   cascade itself wrote. *)
+let declaration_value_end_sheet () =
+  List.iter
+    (fun (property, value) ->
+      List.iter
+        (fun (decl, _) ->
+          let css = String.concat "" [ "x{"; decl; "}" ] in
+          match Css.of_string ~strict:true css with
+          | Error e -> Alcotest.failf "%s: %s" css (Error.to_string e)
+          | Ok { stylesheet; _ } -> (
+              let minified =
+                String.trim (Css.to_string ~minify:true stylesheet)
+              in
+              let pretty = Css.to_string ~minify:false stylesheet in
+              match Css.of_string ~strict:true pretty with
+              | Error e ->
+                  Alcotest.failf "reparse of %S: %s" pretty (Error.to_string e)
+              | Ok p ->
+                  Alcotest.(check string)
+                    (Fmt.str "%S survives a pretty round trip" css)
+                    minified
+                    (String.trim (Css.to_string ~minify:true p.stylesheet))))
+        (value_tail_forms property value))
+    value_end_properties
+
+(* Seeing past the tail is not licence to accept it: a [!] that does not open
+   [!important], a second [!important], a value component after one, and a value
+   with more components than the grammar has slots all stay invalid. *)
+let declaration_value_end_negatives () =
+  List.iter
+    (neg_cursor read_declaration)
+    [
+      "color:red !foo";
+      "color:red !important !important";
+      "color:red !important blue";
+      "font-style:oblique !";
+      "text-box:none !foo";
+      "rotate:45deg 45deg 45deg 45deg";
+      "rotate:45deg 45deg !important";
+      "initial-letter:2 3 4";
+      "hyphenate-limit-chars:2 3 4 5";
+      "font-style:oblique 20deg 30deg 40deg";
+      (* CSS Sizing 4 sec. 5.2 spells [contain-intrinsic-size] as [[ auto? [
+         none | <length [0,inf]> ] ]{1,2}], so a third slot is one too many. *)
+      "contain-intrinsic-size:auto 300px 400px 500px";
+      "animation-range:normal normal normal";
+    ]
+
+(* A cursor over a function's arguments is asking a different question: its
+   grammar ends at the closing paren, where neither a [;] nor an [!] can stand,
+   so it must still be read to true end of input. Widening it would accept an
+   argument list longer than the function takes. *)
+let function_argument_end_negatives () =
+  List.iter
+    (neg_cursor read_declaration)
+    [
+      "transform:skew(10deg,red)";
+      "transform:matrix(1,2,3,4,5,6,7)";
+      "transform:translate(1px,2px,3px)";
+      "clip-path:inset(1px 2px 3px 4px 5px)";
+      "transform:rotate(45deg,45deg)";
+      "background:linear-gradient(red,blue) extra";
+    ]
 
 (* CSS Shapes 1 sec. 6.1: [shape-outside] is [none | [<basic-shape> ||
    <shape-box>] | <image>]. The reader only looked at the first component and
@@ -4450,6 +4642,12 @@ let declaration_tests =
     test_case "scroll-margin negative lengths" `Quick scroll_margin_negative;
     test_case "scroll-margin negative lengths (sheet)" `Quick
       scroll_margin_negative_sheet;
+    test_case "declaration value end" `Quick declaration_value_end;
+    test_case "declaration value end (sheet)" `Quick declaration_value_end_sheet;
+    test_case "declaration value end negatives" `Quick
+      declaration_value_end_negatives;
+    test_case "function argument end negatives" `Quick
+      function_argument_end_negatives;
     test_case "shape-outside grammar" `Quick shape_outside_grammar;
     test_case "shape-outside grammar (sheet)" `Quick shape_outside_sheet;
     test_case "line-width invalid math argument" `Quick


### PR DESCRIPTION
A property grammar with an optional trailing component was handed the value with the semicolon and the importance flag still in front of it, read them as part of the value and failed, so an important `font-style: oblique` and a `text-box: none;` went missing from the output with nothing but a warning, and cascade could not read back what it had printed itself. The value now has a cursor of its own, per CSS Syntax 3 (ED) sec. 5.5.6, and `Cursor.is_done` is the one answer a reader needs.

Stacked on #643, whose citation numbering the new comments follow.