### PR TITLE
values: parse stepped functions in delay values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- The animation and transition delay longhands read time-valued `round()`,
+  `mod()` and `rem()` calls instead of dropping the declaration with an
+  internal list-parser diagnostic (#646)
 - A declaration whose grammar ends in an optional component is no longer
   dropped over the tail the declaration consumer strips. `font-style: oblique
   !important`, `rotate: 45deg !important`, `text-box: none;` and

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -803,7 +803,8 @@ let read_timing_function_list t =
 
 let read_duration_list (read_one : Cursor.t -> Values.duration) t :
     Values.duration =
-  match Cursor.list ~sep:Cursor.comma ~at_least:1 read_one t with
+  match Cursor.list ~sep:Cursor.comma read_one t with
+  | [] -> Cursor.err_expected t "time value"
   | [ value ] -> value
   | values -> Durations values
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7118,6 +7118,11 @@ let rec read_time_with ?(css_wide = true) t : duration =
       [
         ("var", fun t -> Var (read_var read_time t));
         ("calc", fun t -> Calc (read_calc read_time_in_calc t));
+        ("round", read_duration_round read_time);
+        ( "rem",
+          read_duration_binary_call "rem" (fun a b -> Rem (a, b)) read_time );
+        ( "mod",
+          read_duration_binary_call "mod" (fun a b -> Mod (a, b)) read_time );
       ]
     t
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1721,7 +1721,24 @@ let animations_timing () =
      [<time>]. [0s] does not drop the unit. *)
   check_declaration ~expected:"animation-delay:0s" "animation-delay: 0s";
   check_declaration ~expected:"animation-delay:1s" "animation-delay: 1s";
-  check_declaration ~expected:"animation-delay:-.5s" "animation-delay: -500ms"
+  check_declaration ~expected:"animation-delay:-.5s" "animation-delay: -500ms";
+  (* CSS Values 4 sec. 10.3 gives these functions the type of their arguments,
+     so time-valued calls fit the delay longhands' [<time>] grammar. *)
+  check_declaration ~expected:"transition-delay:1s"
+    "transition-delay:round(1.1s,.5s)";
+  check_declaration ~expected:"animation-delay:.1s"
+    "animation-delay:mod(1.1s,.5s)";
+  check_declaration ~expected:"animation-delay:.1s"
+    "animation-delay:rem(1.1s,.5s)";
+  let c = Cursor.of_string "transition-delay:bogus" in
+  match read_declaration c with
+  | exception
+      Error.Parse_error { kind = Error.Bad_value { property; reason }; _ } ->
+      Alcotest.(check string) "diagnostic property" "transition-delay" property;
+      Alcotest.(check string) "diagnostic reason" "expected time value" reason
+  | exception Error.Parse_error e ->
+      Alcotest.failf "unexpected diagnostic: %s" (Error.to_string e)
+  | _ -> Alcotest.fail "expected an invalid delay to be rejected"
 
 let animations_state () =
   check_declaration ~expected:"animation-iteration-count:1"


### PR DESCRIPTION
`transition-delay` and `animation-delay` dropped time-valued `round()`, `mod()`, and `rem()` calls; they now accept the same stepped functions as duration values and diagnose invalid inputs as time values.