### PR TITLE
Move equivalent-value folds into normalization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -490,6 +490,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` canonicalises logical minimum sizes, duration units and stepped
+  functions, transform origins and hue-angle units before declaration hashes
+  are compared, so equivalent rules factor under all five spellings (#647)
 - `--minify` folds a value's spelling before two rules are compared, so rules
   that wrote one declaration two ways factor into one: a component left at its
   longhand's initial in the `border`, `column-rule`, `outline`, `list-style`,

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -505,8 +505,12 @@ let normalize_transition_shorthand (s : transition_shorthand) :
     | Option.Some d when transition_duration_is_zero d -> Option.None
     | d -> d
   in
-  let duration = drop_zero s.duration in
-  let delay = drop_zero s.delay in
+  let duration =
+    drop_zero (option_map_preserve Values.normalize_duration s.duration)
+  in
+  let delay =
+    drop_zero (option_map_preserve Values.normalize_duration s.delay)
+  in
   let timing_function =
     match option_map_preserve normalize_timing_function s.timing_function with
     | Option.Some Ease -> Option.None
@@ -1715,11 +1719,17 @@ let pp_animation_shorthand : animation_shorthand Pp.t =
    same node question [normalize_timing_function] answers. *)
 let normalize_animation_shorthand (a : animation_shorthand) :
     animation_shorthand =
+  let duration = option_map_preserve Values.normalize_duration a.duration in
+  let delay = option_map_preserve Values.normalize_duration a.delay in
   let timing_function =
     option_map_preserve normalize_timing_function a.timing_function
   in
-  if option_is_phys_same timing_function a.timing_function then a
-  else { a with timing_function }
+  if
+    option_is_phys_same duration a.duration
+    && option_is_phys_same delay a.delay
+    && option_is_phys_same timing_function a.timing_function
+  then a
+  else { a with duration; timing_function; delay }
 
 let normalize_animation : animation -> animation = function
   | Shorthand a as value ->

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -188,6 +188,20 @@ let option_is_phys_same a b =
   | Option.Some a, Option.Some b -> a == b
   | _ -> false
 
+let map_var_preserve f (v : 'a var) : 'a var =
+  let fallback =
+    match v.fallback with
+    | Fallback value ->
+        let value' = f value in
+        if value' == value then v.fallback else Fallback value'
+    | (Empty | Empty2 | None | Syntax_fallback _ | Var_fallback _) as fallback
+      ->
+        fallback
+  in
+  let default = option_map_preserve f v.default in
+  if fallback == v.fallback && default == v.default then v
+  else { v with fallback; default }
+
 (* Drop a shorthand component that equals its longhand initial: a shorthand
    resets every component it leaves out to that initial, so the two spellings
    name one value. *)
@@ -280,15 +294,6 @@ let padded_hex width n =
 (* RGB color helpers *)
 let rgb_black : color = Rgb (Channels { r = Int 0; g = Int 0; b = Int 0 })
 let url path : background_image = Url path
-
-(* CSS Sizing 3 sec. 3.1: [min-width] / [min-height] / [min-inline-size] /
-   [min-block-size] have [auto] as their initial value (not the generic [0]), so
-   under minify [initial] rewrites to the shorter [auto]. *)
-let pp_length_min_max ctx (v : length_percentage) =
-  let v : length_percentage =
-    match v with Length Initial when Pp.minified ctx -> Length Auto | _ -> v
-  in
-  pp_length_percentage ctx v
 
 (* <dashed-ident>: shared by anchor-name, position-anchor, position-try
    fallbacks, font-palette and the animation timeline names. *)

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -279,26 +279,39 @@ let normalize_scale : scale -> scale =
   | XYZ (x, y, z) -> preserve_if_equal value (XYZ (np x, np y, np z))
   | other -> other
 
-(* [transform-origin] had no normalize pass, so [0px 50%] and [0% 50%] (and
-   [left center]) stayed in distinct spellings of the same origin. [0], [0px]
-   and [0%] all place the origin at the same edge, so fold every zero component
-   to the unitless [0] - the canonical form the [left]/[top] keywords already
-   minify to. *)
-let normalize_transform_origin : transform_origin -> transform_origin =
+(* Canonicalise equivalent origin keywords and coordinates before factoring.
+   [0], [0px] and [0%] all place the origin at the same edge. *)
+let rec normalize_transform_origin : transform_origin -> transform_origin =
   let z l =
     match (l : Values.length) with
     | Pct 0. -> (Zero : Values.length)
     | _ -> Values.normalize_length l
   in
+  let pct n = (Pct n : Values.length) in
+  let zero = (Zero : Values.length) in
   fun value ->
     match value with
+    | Center | Center_center -> X (pct 50.)
+    | Left | Left_center -> X zero
+    | Right | Right_center -> X (pct 100.)
+    | Left_top | Top_left -> XY (zero, zero)
+    | Right_top | Top_right -> XY (pct 100., zero)
+    | Left_bottom | Bottom_left -> XY (zero, pct 100.)
+    | Right_bottom | Bottom_right -> XY (pct 100., pct 100.)
+    | Center_top -> Top
+    | Center_bottom -> Bottom
     | X a -> preserve_if_equal value (X (z a))
-    | XY (a, b) -> preserve_if_equal value (XY (z a, z b))
+    | XY (a, b) -> (
+        let a = z a and b = z b in
+        match b with Pct 50. -> X a | _ -> preserve_if_equal value (XY (a, b)))
     | XYZ (a, b, c) -> preserve_if_equal value (XYZ (z a, z b, z c))
     | Position p ->
         preserve_if_equal value (Position (normalize_position_value p))
     | Position_z (p, c) ->
         preserve_if_equal value (Position_z (normalize_position_value p, z c))
+    | Var v ->
+        let v' = map_var_preserve normalize_transform_origin v in
+        if v' == v then value else Var v'
     | other -> other
 
 let normalize_offset_path : offset_path -> offset_path =
@@ -532,30 +545,6 @@ let rec pp_transform_style : transform_style Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
-let pp_transform_origin_pair ctx a b =
-  pp_length ctx a;
-  Pp.space ctx ();
-  pp_length ctx b
-
-let pp_minified_transform_origin ctx value =
-  let pct n = (Pct n : length) in
-  let zero = (Zero : length) in
-  match value with
-  | Center | Center_center -> Some (fun () -> pp_length ctx (pct 50.))
-  | Left | Left_center -> Some (fun () -> pp_length ctx zero)
-  | Right | Right_center -> Some (fun () -> pp_length ctx (pct 100.))
-  | Left_top | Top_left ->
-      Some (fun () -> pp_transform_origin_pair ctx zero zero)
-  | Right_top | Top_right ->
-      Some (fun () -> pp_transform_origin_pair ctx (pct 100.) zero)
-  | Left_bottom | Bottom_left ->
-      Some (fun () -> pp_transform_origin_pair ctx zero (pct 100.))
-  | Right_bottom | Bottom_right ->
-      Some (fun () -> pp_transform_origin_pair ctx (pct 100.) (pct 100.))
-  | Center_top -> Some (fun () -> Pp.string ctx "top")
-  | Center_bottom -> Some (fun () -> Pp.string ctx "bottom")
-  | _ -> None
-
 let pp_transform_origin_keywords ctx = function
   | Center -> Pp.string ctx "center"
   | Center_center -> Pp.string ctx "center center"
@@ -578,41 +567,34 @@ let pp_transform_origin_keywords ctx = function
   | _ -> ()
 
 let rec pp_transform_origin : transform_origin Pp.t =
- fun ctx value ->
-  match
-    if Pp.minified ctx then pp_minified_transform_origin ctx value else None
-  with
-  | Some pp -> pp ()
-  | None -> (
-      match value with
-      | Inherit -> Pp.string ctx "inherit"
-      | Initial -> Pp.string ctx "initial"
-      | Unset -> Pp.string ctx "unset"
-      | Revert -> Pp.string ctx "revert"
-      | Revert_layer -> Pp.string ctx "revert-layer"
-      | Center | Center_center | Left | Right | Top | Bottom | Left_top
-      | Left_center | Left_bottom | Right_top | Right_center | Right_bottom
-      | Center_top | Center_bottom | Top_left | Top_right | Bottom_left
-      | Bottom_right ->
-          pp_transform_origin_keywords ctx value
-      | Position position -> pp_position_value ctx position
-      | X a -> pp_length ctx a
-      | XY (a, Pct 50.) when Pp.minified ctx -> pp_length ctx a
-      | XY (a, b) ->
-          pp_length ctx a;
-          Pp.space ctx ();
-          pp_length ctx b
-      | XYZ (a, b, z) ->
-          pp_length ctx a;
-          Pp.space ctx ();
-          pp_length ctx b;
-          Pp.space ctx ();
-          pp_length ctx z
-      | Position_z (position, z) ->
-          pp_position_value ctx position;
-          Pp.space ctx ();
-          pp_length ctx z
-      | Var v -> pp_var pp_transform_origin ctx v)
+ fun ctx -> function
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | ( Center | Center_center | Left | Right | Top | Bottom | Left_top
+    | Left_center | Left_bottom | Right_top | Right_center | Right_bottom
+    | Center_top | Center_bottom | Top_left | Top_right | Bottom_left
+    | Bottom_right ) as value ->
+      pp_transform_origin_keywords ctx value
+  | Position position -> pp_position_value ctx position
+  | X a -> pp_length ctx a
+  | XY (a, b) ->
+      pp_length ctx a;
+      Pp.space ctx ();
+      pp_length ctx b
+  | XYZ (a, b, z) ->
+      pp_length ctx a;
+      Pp.space ctx ();
+      pp_length ctx b;
+      Pp.space ctx ();
+      pp_length ctx z
+  | Position_z (position, z) ->
+      pp_position_value ctx position;
+      Pp.space ctx ();
+      pp_length ctx z
+  | Var v -> pp_var pp_transform_origin ctx v
 
 let rec pp_transform_box : transform_box Pp.t =
  fun ctx -> function

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -244,6 +244,20 @@ let rec read_interest_delay ?(longhand = false) t : interest_delay =
            read_non_negative_duration t))
     t
 
+let rec normalize_interest_delay : interest_delay -> interest_delay =
+ fun value ->
+  match value with
+  | Durations durations ->
+      preserve_if_equal value
+        (Durations
+           (map_preserve
+              (Values.normalize_duration ~canonicalize_ms:false)
+              durations))
+  | Var v ->
+      let v' = map_var_preserve normalize_interest_delay v in
+      if v' == v then value else Var v'
+  | _ -> value
+
 let read_nav_scope t : nav_scope =
   Cursor.one_of
     [

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3364,7 +3364,395 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Height, Length Initial -> Length Auto
   | Min_width, Length Initial -> Length Auto
   | Min_height, Length Initial -> Length Auto
-  | _ -> value
+  | Min_inline_size, Length Initial -> Length Auto
+  | Min_block_size, Length Initial -> Length Auto
+  (* Keep this fallback exhaustive: a new property must make this match fail to
+     compile until its initial-value fold has been considered. *)
+  | Custom_property _, value -> value
+  | Unknown_property _, value -> value
+  | All, value -> value
+  | ( ( Background_color | Color | Text_decoration_color | Text_emphasis_color
+      | Border_top_color | Border_right_color | Border_bottom_color
+      | Border_left_color | Border_inline_start_color | Border_inline_end_color
+      | Border_block_start_color | Border_block_end_color | Outline_color
+      | Webkit_tap_highlight_color | Webkit_text_decoration_color
+      | Webkit_text_fill_color | Webkit_text_stroke_color | Column_rule_color
+      | Stop_color | Flood_color | Lighting_color | Accent_color | Caret_color
+        ),
+      value ) ->
+      value
+  | Border_color, value -> value
+  | ( ( Border_style | Border_top_style | Border_right_style
+      | Border_bottom_style | Border_left_style | Border_inline_start_style
+      | Border_inline_end_style | Border_block_start_style
+      | Border_block_end_style | Border_inline_style | Border_block_style ),
+      value ) ->
+      value
+  | ( ( Padding | Padding_inline | Padding_block | Margin | Margin_inline
+      | Margin_block | Inset | Inset_inline | Inset_inline_start
+      | Inset_inline_end | Inset_block | Inset_block_start | Inset_block_end
+      | Top | Right | Bottom | Left | Scroll_margin | Scroll_margin_inline
+      | Scroll_margin_block | Scroll_padding | Scroll_padding_inline
+      | Scroll_padding_block ),
+      value ) ->
+      value
+  | ( ( Padding_left | Padding_right | Padding_bottom | Padding_top
+      | Padding_inline_start | Padding_inline_end | Padding_block_start
+      | Padding_block_end | Margin_inline_end | Margin_inline_start
+      | Margin_left | Margin_right | Margin_top | Margin_bottom
+      | Margin_block_start | Margin_block_end | Column_gap | Row_gap
+      | Text_underline_offset | Letter_spacing | Border_top_left_radius
+      | Border_top_right_radius | Border_bottom_left_radius
+      | Border_bottom_right_radius | Border_start_start_radius
+      | Border_start_end_radius | Border_end_start_radius
+      | Border_end_end_radius | Outline_offset | Line_height_step | Perspective
+      | Word_spacing | Text_decoration_thickness | Scroll_margin_top
+      | Scroll_margin_right | Scroll_margin_bottom | Scroll_margin_left
+      | Scroll_margin_inline_start | Scroll_margin_inline_end
+      | Scroll_margin_block_start | Scroll_margin_block_end | Scroll_padding_top
+      | Scroll_padding_right | Scroll_padding_bottom | Scroll_padding_left
+      | Scroll_padding_inline_start | Scroll_padding_inline_end
+      | Scroll_padding_block_start | Scroll_padding_block_end ),
+      value ) ->
+      value
+  | Gap, value -> value
+  | ( ( Width | Height | Min_width | Min_height | Max_width | Max_height
+      | Inline_size | Min_inline_size | Max_inline_size | Block_size
+      | Min_block_size | Max_block_size | Shape_margin | Offset_distance ),
+      value ) ->
+      value
+  | Font_size, value -> value
+  | Line_height, value -> value
+  | Font_weight, value -> value
+  | Font_style, value -> value
+  | Text_align, value -> value
+  | (Text_decoration | Webkit_text_decoration), value -> value
+  | Text_decoration_line, value -> value
+  | Text_decoration_style, value -> value
+  | Text_decoration_skip, value -> value
+  | Text_decoration_skip_self, value -> value
+  | Text_decoration_skip_box, value -> value
+  | Text_decoration_skip_inset, value -> value
+  | Text_decoration_skip_spaces, value -> value
+  | Text_emphasis, value -> value
+  | Text_emphasis_style, value -> value
+  | Text_emphasis_position, value -> value
+  | Text_emphasis_skip, value -> value
+  | Text_orientation, value -> value
+  | Text_transform, value -> value
+  | List_style_type, value -> value
+  | List_style_position, value -> value
+  | List_style_image, value -> value
+  | Display, value -> value
+  | Position, value -> value
+  | Visibility, value -> value
+  | Baseline_source, value -> value
+  | Alignment_baseline, value -> value
+  | Baseline_shift, value -> value
+  | (Flex_direction | Webkit_flex_direction), value -> value
+  | (Flex_wrap | Webkit_flex_wrap), value -> value
+  | (Flex_flow | Webkit_flex_flow), value -> value
+  | Flex, value -> value
+  | (Flex_grow | Flex_shrink), value -> value
+  | Flex_basis, value -> value
+  | Order, value -> value
+  | (Align_items | Webkit_align_items), value -> value
+  | (Justify_content | Webkit_justify_content), value -> value
+  | Justify_items, value -> value
+  | Justify_self, value -> value
+  | (Align_content | Webkit_align_content), value -> value
+  | (Align_self | Webkit_align_self), value -> value
+  | Place_content, value -> value
+  | Place_items, value -> value
+  | Place_self, value -> value
+  | ( ( Grid_template_columns | Grid_template_rows | Grid_template | Grid
+      | Grid_auto_columns | Grid_auto_rows ),
+      value ) ->
+      value
+  | Grid_template_areas, value -> value
+  | Grid_area, value -> value
+  | Grid_auto_flow, value -> value
+  | (Grid_column | Grid_row), value -> value
+  | (Grid_column_start | Grid_column_end | Grid_row_start | Grid_row_end), value
+    ->
+      value
+  | Border_width, value -> value
+  | ( ( Border_top_width | Border_right_width | Border_bottom_width
+      | Border_left_width | Border_inline_start_width | Border_inline_end_width
+      | Border_block_start_width | Border_block_end_width | Outline_width ),
+      value ) ->
+      value
+  | (Border_inline_width | Border_block_width), value -> value
+  | (Border_image | Mask_border), value -> value
+  | (Border_image_source | Webkit_mask_image | Mask_image), value -> value
+  | Border_image_slice, value -> value
+  | Border_image_repeat, value -> value
+  | Border_image_width, value -> value
+  | Border_image_outset, value -> value
+  | (Border_radius | Webkit_border_radius | Moz_border_radius), value -> value
+  | (Border_inline_color | Border_block_color), value -> value
+  | ( (Opacity | Fill_opacity | Stroke_opacity | Stop_opacity | Flood_opacity),
+      value ) ->
+      value
+  | Mix_blend_mode, value -> value
+  | ( (Transform | Webkit_transform | Moz_transform | Ms_transform | O_transform),
+      value ) ->
+      value
+  | Translate, value -> value
+  | Cursor, value -> value
+  | Interactivity, value -> value
+  | Caret_animation, value -> value
+  | Caret_shape, value -> value
+  | Caret, value -> value
+  | (Interest_delay | Interest_delay_start | Interest_delay_end), value -> value
+  | (Nav_up | Nav_right | Nav_down | Nav_left), value -> value
+  | Table_layout, value -> value
+  | Border_collapse, value -> value
+  | Border_spacing, value -> value
+  | (User_select | Webkit_user_select | Moz_user_select | Ms_user_select), value
+    ->
+      value
+  | Pointer_events, value -> value
+  | ( (Overflow | Overflow_x | Overflow_y | Overflow_block | Overflow_inline),
+      value ) ->
+      value
+  | Z_index, value -> value
+  | Outline, value -> value
+  | Outline_style, value -> value
+  | Forced_color_adjust, value -> value
+  | Scroll_snap_type, value -> value
+  | White_space, value -> value
+  | ( ( Border | Border_block | Border_block_start | Border_block_end
+      | Border_inline | Border_inline_start | Border_inline_end | Column_rule
+      | Border_top | Border_right | Border_bottom | Border_left ),
+      value ) ->
+      value
+  | Background, value -> value
+  | Tab_size, value -> value
+  | Zoom, value -> value
+  | (Webkit_text_size_adjust | Text_size_adjust), value -> value
+  | Font_feature_settings, value -> value
+  | Font_variation_settings, value -> value
+  | Text_indent, value -> value
+  | List_style, value -> value
+  | Font, value -> value
+  | Source, value -> value
+  | Webkit_appearance, value -> value
+  | (Webkit_transition | Moz_transition | O_transition | Transition), value ->
+      value
+  | ( ( Webkit_transition_delay | Webkit_transition_duration
+      | Webkit_animation_delay | Webkit_animation_duration | Moz_animation_delay
+      | Moz_animation_duration | Moz_transition_delay | Moz_transition_duration
+      | Transition_duration | Transition_delay | Animation_duration
+      | Animation_delay ),
+      value ) ->
+      value
+  | ( ( Webkit_transition_property | Moz_transition_property
+      | Transition_property ),
+      value ) ->
+      value
+  | ( ( Webkit_transition_timing_function | Webkit_animation_timing_function
+      | Moz_animation_timing_function | Moz_transition_timing_function
+      | Transition_timing_function | Animation_timing_function ),
+      value ) ->
+      value
+  | (Webkit_animation | Moz_animation | Animation), value -> value
+  | ( ( Webkit_animation_direction | Moz_animation_direction
+      | Animation_direction ),
+      value ) ->
+      value
+  | ( ( Webkit_animation_iteration_count | Moz_animation_iteration_count
+      | Animation_iteration_count ),
+      value ) ->
+      value
+  | (Webkit_animation_name | Moz_animation_name | Animation_name), value ->
+      value
+  | ( ( Webkit_animation_fill_mode | Moz_animation_fill_mode
+      | Animation_fill_mode ),
+      value ) ->
+      value
+  | ( ( Webkit_animation_play_state | Moz_animation_play_state
+      | Animation_play_state ),
+      value ) ->
+      value
+  | (Webkit_box_sizing | Moz_box_sizing | Box_sizing), value -> value
+  | (Webkit_box_shadow | Moz_box_shadow | Box_shadow), value -> value
+  | ( (Webkit_background_size | Background_size | Webkit_mask_size | Mask_size),
+      value ) ->
+      value
+  | ( ( Webkit_filter | Ms_filter | Filter | Backdrop_filter
+      | Webkit_backdrop_filter ),
+      value ) ->
+      value
+  | (Moz_appearance | Appearance), value -> value
+  | Container_type, value -> value
+  | Container_name, value -> value
+  | Container, value -> value
+  | Anchor_name, value -> value
+  | Position_anchor, value -> value
+  | Position_try_fallbacks, value -> value
+  | Position_try_order, value -> value
+  | Position_try, value -> value
+  | Position_visibility, value -> value
+  | Position_area, value -> value
+  | Shape_outside, value -> value
+  | Shape_image_threshold, value -> value
+  | Overflow_clip_margin, value -> value
+  | Overflow_anchor, value -> value
+  | Scrollbar_width, value -> value
+  | Scrollbar_color, value -> value
+  | Scrollbar_gutter, value -> value
+  | Font_palette, value -> value
+  | Font_synthesis, value -> value
+  | Text_wrap_mode, value -> value
+  | Text_wrap_style, value -> value
+  | Text_box_trim, value -> value
+  | Text_underline_position, value -> value
+  | Text_box_edge, value -> value
+  | Text_box, value -> value
+  | Inline_sizing, value -> value
+  | Line_fit_edge, value -> value
+  | Interpolate_size, value -> value
+  | Min_intrinsic_sizing, value -> value
+  | Ruby_align, value -> value
+  | Ruby_merge, value -> value
+  | Ruby_overhang, value -> value
+  | Ruby_position, value -> value
+  | Glyph_orientation_vertical, value -> value
+  | Text_combine_upright, value -> value
+  | Animation_timeline, value -> value
+  | Animation_range, value -> value
+  | (Animation_range_start | Animation_range_end), value -> value
+  | (Scroll_timeline | View_timeline), value -> value
+  | (Scroll_timeline_name | View_timeline_name | Timeline_scope), value -> value
+  | (Scroll_timeline_axis | View_timeline_axis), value -> value
+  | View_transition_name, value -> value
+  | View_transition_class, value -> value
+  | Image_orientation, value -> value
+  | Image_rendering, value -> value
+  | Image_resolution, value -> value
+  | Contain_intrinsic_size, value -> value
+  | ( ( Contain_intrinsic_width | Contain_intrinsic_height
+      | Contain_intrinsic_block_size | Contain_intrinsic_inline_size ),
+      value ) ->
+      value
+  | Margin_trim, value -> value
+  | Offset_path, value -> value
+  | Offset_rotate, value -> value
+  | Font_size_adjust, value -> value
+  | Font_variant_emoji, value -> value
+  | Text_spacing_trim, value -> value
+  | Hyphenate_limit_chars, value -> value
+  | Initial_letter, value -> value
+  | Initial_letter_align, value -> value
+  | Initial_letter_wrap, value -> value
+  | Dominant_baseline, value -> value
+  | View_timeline_inset, value -> value
+  | Perspective_origin, value -> value
+  | Transform_style, value -> value
+  | Backface_visibility, value -> value
+  | Object_position, value -> value
+  | Rotate, value -> value
+  | Transition_behavior, value -> value
+  | Overlay, value -> value
+  | Will_change, value -> value
+  | Contain, value -> value
+  | Isolation, value -> value
+  | (Break_before | Break_after), value -> value
+  | Break_inside, value -> value
+  | (Page_break_before | Page_break_after), value -> value
+  | Page_break_inside, value -> value
+  | Page_size, value -> value
+  | Columns, value -> value
+  | Column_width, value -> value
+  | Column_count, value -> value
+  | Column_span, value -> value
+  | Background_attachment, value -> value
+  | Transform_origin, value -> value
+  | Transform_box, value -> value
+  | Text_shadow, value -> value
+  | Clip_path, value -> value
+  | Mask, value -> value
+  | Content_visibility, value -> value
+  | Background_image, value -> value
+  | (Background_origin | Background_clip | Webkit_background_clip), value ->
+      value
+  | Aspect_ratio, value -> value
+  | Vertical_align, value -> value
+  | Font_family, value -> value
+  | (Background_position | Webkit_mask_position | Mask_position), value -> value
+  | (Background_repeat | Webkit_mask_repeat | Mask_repeat), value -> value
+  | Webkit_font_smoothing, value -> value
+  | Moz_osx_font_smoothing, value -> value
+  | Webkit_line_clamp, value -> value
+  | Webkit_box_orient, value -> value
+  | Moz_orient, value -> value
+  | Text_overflow, value -> value
+  | Text_wrap, value -> value
+  | Word_break, value -> value
+  | Overflow_wrap, value -> value
+  | Line_break, value -> value
+  | (Hyphens | Webkit_hyphens), value -> value
+  | Font_stretch, value -> value
+  | Font_optical_sizing, value -> value
+  | Font_kerning, value -> value
+  | Font_language_override, value -> value
+  | Font_synthesis_style, value -> value
+  | Font_synthesis_weight, value -> value
+  | Font_synthesis_small_caps, value -> value
+  | Font_synthesis_position, value -> value
+  | Font_variant_ligatures, value -> value
+  | Caps, value -> value
+  | Numeric, value -> value
+  | Font_variant_position, value -> value
+  | East_asian, value -> value
+  | Webkit_mask_composite, value -> value
+  | Webkit_mask_source_type, value -> value
+  | (Webkit_mask_clip | Webkit_mask_origin | Mask_clip | Mask_origin), value ->
+      value
+  | Mask_composite, value -> value
+  | Mask_mode, value -> value
+  | Mask_type, value -> value
+  | Scroll_snap_align, value -> value
+  | Scroll_snap_stop, value -> value
+  | Scroll_behavior, value -> value
+  | Field_sizing, value -> value
+  | Caption_side, value -> value
+  | Resize, value -> value
+  | Object_fit, value -> value
+  | Object_view_box, value -> value
+  | Color_scheme, value -> value
+  | (Print_color_adjust | Webkit_print_color_adjust), value -> value
+  | (Box_decoration_break | Webkit_box_decoration_break), value -> value
+  | Content, value -> value
+  | (Counter_reset | Counter_increment), value -> value
+  | Quotes, value -> value
+  | Touch_action, value -> value
+  | Clip, value -> value
+  | Clear, value -> value
+  | Float, value -> value
+  | Scale, value -> value
+  | (Fill | Stroke), value -> value
+  | Stroke_width, value -> value
+  | (Fill_rule | Clip_rule), value -> value
+  | Stroke_linecap, value -> value
+  | Stroke_linejoin, value -> value
+  | Stroke_miterlimit, value -> value
+  | Stroke_dashoffset, value -> value
+  | Stroke_dasharray, value -> value
+  | Paint_order, value -> value
+  | Vector_effect, value -> value
+  | Direction, value -> value
+  | Unicode_bidi, value -> value
+  | Writing_mode, value -> value
+  | Text_decoration_skip_ink, value -> value
+  | Animation_composition, value -> value
+  | Background_blend_mode, value -> value
+  | Overscroll_behavior, value -> value
+  | ( ( Overscroll_behavior_x | Overscroll_behavior_y
+      | Overscroll_behavior_block | Overscroll_behavior_inline ),
+      value ) ->
+      value
 
 (* CSS Values L4 sec. 10.10 ("Mathematical Expressions"): inside a math function
    ([calc], [min], [max], [clamp], [round], [mod], [rem], the trig family,
@@ -3596,6 +3984,9 @@ let normalize_property_value : type a.
   | Webkit_text_decoration -> normalize_text_decoration ~lossless value
   | Text_emphasis -> normalize_text_emphasis ~lossless value
   | Caret -> normalize_caret ~lossless value
+  | Interest_delay -> normalize_interest_delay value
+  | Interest_delay_start -> normalize_interest_delay value
+  | Interest_delay_end -> normalize_interest_delay value
   | Fill -> normalize_svg_paint ~lossless value
   | Stroke -> normalize_svg_paint ~lossless value
   | Scrollbar_color -> normalize_scrollbar_color ~lossless value
@@ -3841,15 +4232,15 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Row_gap -> pp pp_length
   | Width -> pp pp_length_percentage
   | Height -> pp pp_length_percentage
-  | Min_width -> pp pp_length_min_max
-  | Min_height -> pp pp_length_min_max
+  | Min_width -> pp pp_length_percentage
+  | Min_height -> pp pp_length_percentage
   | Max_width -> pp pp_length_percentage
   | Max_height -> pp pp_length_percentage
   | Inline_size -> pp pp_length_percentage
-  | Min_inline_size -> pp pp_length_min_max
+  | Min_inline_size -> pp pp_length_percentage
   | Max_inline_size -> pp pp_length_percentage
   | Block_size -> pp pp_length_percentage
-  | Min_block_size -> pp pp_length_min_max
+  | Min_block_size -> pp pp_length_percentage
   | Max_block_size -> pp pp_length_percentage
   | Font_size -> pp pp_font_size
   | Line_height -> pp pp_line_height

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3691,22 +3691,6 @@ let pp_hue_float ctx f =
 let rec pp_hue : hue Pp.t =
  fun ctx -> function
   | Unitless f -> pp_hue_float ctx f
-  | Angle (Deg f) when ctx.minify ->
-      (* During minification, omit 'deg' since it's the default unit *)
-      pp_hue_float ctx f
-  | Angle a when ctx.minify -> (
-      match deg_of_hue (Angle a) with
-      | Some f ->
-          (* A non-degree angle unit canonicalises to bare degrees; the
-             conversion is approximate (radians go through pi), so it rounds
-             here rather than emitting a noise-precision tail. *)
-          let f = normalize_hue f in
-          let s =
-            if ctx.Pp.lossless then Pp.string_of_float ~drop_leading_zero:true f
-            else Pp.string_of_float ~drop_leading_zero:true ~max_decimals:3 f
-          in
-          Pp.string ctx s
-      | None -> pp_angle ctx a)
   | Angle a -> pp_angle ctx a
   | Var v -> pp_var pp_hue ctx v
   | Hue_none -> Pp.string ctx "none"
@@ -3984,10 +3968,63 @@ let eval_time_calc ?(ctx = default_calc_ctx) (c : duration calc) : duration calc
     ~zero:(Val (S 0.) : duration calc)
     ~ctx c
 
-let normalize_duration ?(ctx = default_calc_ctx) (d : duration) : duration =
+(* Choose equivalent time units and evaluate static stepped functions in the
+   AST, before declaration hashes are compared. *)
+let rec normalize_duration ?(ctx = default_calc_ctx) ?(canonicalize_ms = true)
+    (d : duration) : duration =
+  let normalize = normalize_duration ~ctx ~canonicalize_ms in
+  let preserve rebuilt = if rebuilt = d then d else rebuilt in
   match d with
+  | Ms f when canonicalize_ms ->
+      let seconds = f /. 1000. in
+      let ms = Pp.string_of_float ~drop_leading_zero:true f in
+      let s = Pp.string_of_float ~drop_leading_zero:true seconds in
+      if String.length s + 1 <= String.length ms + 2 then S seconds else d
+  | Durations durations ->
+      preserve (Durations (Common.List.map_preserve normalize durations))
+  | Round (strategy, value, step) -> (
+      let value = normalize value and step = normalize step in
+      match (value, step) with
+      | Ms value, Ms step when step <> 0. ->
+          normalize (Ms (round_to_step strategy value step))
+      | S value, S step when step <> 0. ->
+          normalize (S (round_to_step strategy value step))
+      | _ -> preserve (Round (strategy, value, step)))
+  | Rem (a, b) -> (
+      let a = normalize a and b = normalize b in
+      match (a, b) with
+      | Ms a, Ms b when b <> 0. -> normalize (Ms (Float.rem a b))
+      | S a, S b when b <> 0. -> normalize (S (Float.rem a b))
+      | _ -> preserve (Rem (a, b)))
+  | Mod (a, b) -> (
+      let a = normalize a and b = normalize b in
+      match (a, b) with
+      | Ms a, Ms b when b <> 0. -> normalize (Ms (mod_value a b))
+      | S a, S b when b <> 0. -> normalize (S (mod_value a b))
+      | _ -> preserve (Mod (a, b)))
   | Calc c -> (
-      match eval_time_calc ~ctx c with Val v -> v | folded -> Calc folded)
+      match eval_time_calc ~ctx c with
+      | Val v -> normalize v
+      | folded -> preserve (Calc folded))
+  | Var v ->
+      let fallback =
+        match v.fallback with
+        | Fallback value ->
+            let value' = normalize value in
+            if value' == value then v.fallback else Fallback value'
+        | (Empty | Empty2 | None | Syntax_fallback _ | Var_fallback _) as other
+          ->
+            other
+      in
+      let default =
+        match v.default with
+        | Some value ->
+            let value' = normalize value in
+            if value' == value then v.default else Some value'
+        | None -> v.default
+      in
+      if fallback == v.fallback && default == v.default then d
+      else Var { v with fallback; default }
   | _ -> d
 
 (* CSS Values 4 sec. 10.10.1: a typed [<angle>] multiplied or divided by a
@@ -4807,43 +4844,11 @@ and pp_color_default : color Pp.t =
 
 let pp_specified_color = pp_color_default
 
-(* CSS Values 4 sec. 7.2: [ms] and [s] are interchangeable; pick the shorter
-   spelling when minifying. The "s" suffix is one character shorter than "ms",
-   so a millisecond value collapses to seconds when its second-form digits are
-   no longer than the millisecond-form digits. *)
-let pp_duration_unit ?(shorten_ms = true) ctx f suffix =
-  if f = 0. then
-    (* CSS Values 4 6.6: a zero [<time>] still requires the unit (unlike
-       [<length>] where [0] is valid). Pretty mode keeps the source unit; under
-       minify pick [s] as the canonical short spelling. *)
-    if ctx.Pp.minify then Pp.string ctx "0s"
-    else (
-      Pp.string ctx "0";
-      Pp.string ctx suffix)
-  else if (not shorten_ms) || (not ctx.Pp.minify) || suffix <> "ms" then
-    pp_unit ctx f suffix
-  else
-    let in_seconds = f /. 1000. in
-    let ms_str = Pp.string_of_float ~drop_leading_zero:true f in
-    let s_str = Pp.string_of_float ~drop_leading_zero:true in_seconds in
-    if String.length s_str + 1 <= String.length ms_str + 2 then (
-      Pp.string ctx s_str;
-      Pp.string ctx "s")
-    else (
-      Pp.string ctx ms_str;
-      Pp.string ctx "ms")
-
 let rec pp_duration : duration Pp.t =
  fun ctx -> function
-  | Ms f -> pp_duration_unit ctx f "ms"
-  | S f -> pp_duration_unit ctx f "s"
+  | Ms f -> pp_unit ctx f "ms"
+  | S f -> pp_unit ctx f "s"
   | Durations durations -> Pp.list ~sep:Pp.comma pp_duration ctx durations
-  | Round (strategy, Ms value, Ms step) when Pp.minified ctx && step <> 0. ->
-      pp_duration_unit ~shorten_ms:false ctx
-        (round_to_step strategy value step)
-        "ms"
-  | Round (strategy, S value, S step) when Pp.minified ctx && step <> 0. ->
-      pp_duration ctx (S (round_to_step strategy value step))
   | Round (strategy, value, step) ->
       Pp.call "round"
         (fun ctx (strategy, value, step) ->
@@ -4854,10 +4859,6 @@ let rec pp_duration : duration Pp.t =
           Pp.comma ctx ();
           pp_duration ctx step)
         ctx (strategy, value, step)
-  | Rem (Ms a, Ms b) when Pp.minified ctx && b <> 0. ->
-      pp_duration ctx (Ms (Float.rem a b))
-  | Rem (S a, S b) when Pp.minified ctx && b <> 0. ->
-      pp_duration ctx (S (Float.rem a b))
   | Rem (a, b) ->
       Pp.call "rem"
         (fun ctx (a, b) ->
@@ -4865,10 +4866,6 @@ let rec pp_duration : duration Pp.t =
           Pp.comma ctx ();
           pp_duration ctx b)
         ctx (a, b)
-  | Mod (Ms a, Ms b) when Pp.minified ctx && b <> 0. ->
-      pp_duration ctx (Ms (mod_value a b))
-  | Mod (S a, S b) when Pp.minified ctx && b <> 0. ->
-      pp_duration ctx (S (mod_value a b))
   | Mod (a, b) ->
       Pp.call "mod"
         (fun ctx (a, b) ->
@@ -4882,68 +4879,18 @@ let rec pp_duration : duration Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_duration ctx v
-  | Calc c -> pp_calc pp_duration_in_calc ctx c
-
-and pp_duration_preserve_ms : duration Pp.t =
- fun ctx -> function
-  | Ms f -> pp_duration_unit ~shorten_ms:false ctx f "ms"
-  | S f -> pp_duration_unit ctx f "s"
-  | Durations durations ->
-      Pp.list ~sep:Pp.comma pp_duration_preserve_ms ctx durations
-  | Round (strategy, Ms value, Ms step) when Pp.minified ctx && step <> 0. ->
-      pp_duration_preserve_ms ctx (Ms (round_to_step strategy value step))
-  | Round (strategy, S value, S step) when Pp.minified ctx && step <> 0. ->
-      pp_duration_preserve_ms ctx (S (round_to_step strategy value step))
-  | Round (strategy, value, step) ->
-      Pp.call "round"
-        (fun ctx (strategy, value, step) ->
-          if strategy <> "nearest" then (
-            Pp.string ctx strategy;
-            Pp.comma ctx ());
-          pp_duration_preserve_ms ctx value;
-          Pp.comma ctx ();
-          pp_duration_preserve_ms ctx step)
-        ctx (strategy, value, step)
-  | Rem (Ms a, Ms b) when Pp.minified ctx && b <> 0. ->
-      pp_duration_preserve_ms ctx (Ms (Float.rem a b))
-  | Rem (S a, S b) when Pp.minified ctx && b <> 0. ->
-      pp_duration_preserve_ms ctx (S (Float.rem a b))
-  | Rem (a, b) ->
-      Pp.call "rem"
-        (fun ctx (a, b) ->
-          pp_duration_preserve_ms ctx a;
-          Pp.comma ctx ();
-          pp_duration_preserve_ms ctx b)
-        ctx (a, b)
-  | Mod (Ms a, Ms b) when Pp.minified ctx && b <> 0. ->
-      pp_duration_preserve_ms ctx (Ms (mod_value a b))
-  | Mod (S a, S b) when Pp.minified ctx && b <> 0. ->
-      pp_duration_preserve_ms ctx (S (mod_value a b))
-  | Mod (a, b) ->
-      Pp.call "mod"
-        (fun ctx (a, b) ->
-          pp_duration_preserve_ms ctx a;
-          Pp.comma ctx ();
-          pp_duration_preserve_ms ctx b)
-        ctx (a, b)
-  | Inherit -> Pp.string ctx "inherit"
-  | Initial -> Pp.string ctx "initial"
-  | Unset -> Pp.string ctx "unset"
-  | Revert -> Pp.string ctx "revert"
-  | Revert_layer -> Pp.string ctx "revert-layer"
-  | Var v -> pp_var pp_duration_preserve_ms ctx v
   | Calc c -> pp_calc pp_duration_in_calc ctx c
 
 and pp_duration_in_calc : duration Pp.t =
  fun ctx -> function
-  | Ms f -> pp_duration_unit ~shorten_ms:false ctx f "ms"
-  | S f -> pp_duration_unit ctx f "s"
+  | Ms f -> pp_unit ctx f "ms"
+  | S f -> pp_unit ctx f "s"
   | Durations durations ->
       Pp.list ~sep:Pp.comma pp_duration_in_calc ctx durations
   | Round (strategy, value, step) ->
-      pp_duration_preserve_ms ctx (Round (strategy, value, step))
-  | Rem (a, b) -> pp_duration_preserve_ms ctx (Rem (a, b))
-  | Mod (a, b) -> pp_duration_preserve_ms ctx (Mod (a, b))
+      pp_duration ctx (Round (strategy, value, step))
+  | Rem (a, b) -> pp_duration ctx (Rem (a, b))
+  | Mod (a, b) -> pp_duration ctx (Mod (a, b))
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -4951,6 +4898,8 @@ and pp_duration_in_calc : duration Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_duration ctx v
   | Calc c -> pp_calc pp_duration_in_calc ctx c
+
+let pp_duration_preserve_ms = pp_duration
 
 let rec pp_number : number Pp.t =
  fun ctx -> function
@@ -7474,21 +7423,34 @@ let round_color_axis ~lossless ~decimals f =
     let m = 10. ** float_of_int decimals in
     Float.round (f *. m) /. m
 
-(* Round an oklch/lch hue to 3 decimals for the canonical (optimize) form: a
-   bare or [deg] hue keeps its representation, other angle units collapse to the
-   canonical bare degree. A [var()] / [calc()] / [none] hue is left opaque. *)
+(* Round an oklch/lch hue to 3 decimals for the canonical (optimize) form and
+   collapse every concrete angle unit to canonical bare degrees. A [var()] /
+   [calc()] / [none] hue is left opaque. *)
 let round_hue ~lossless (h : hue) : hue =
-  if lossless then h
-  else
-    let r f = round_color_axis ~lossless ~decimals:3 f in
-    match h with
-    | Unitless f -> Unitless (r f)
-    | Angle (Deg f) -> Angle (Deg (r f))
-    | Angle a -> (
-        match deg_of_hue (Angle a) with
-        | Some f -> Unitless (r (normalize_hue f))
-        | None -> h)
-    | Hue_none | Var _ -> h
+  let r f = round_color_axis ~lossless ~decimals:3 f in
+  match h with
+  | Unitless f -> Unitless (r f)
+  | Angle (Deg f) -> Unitless (r f)
+  | Angle a -> (
+      match deg_of_hue (Angle a) with
+      | Some f -> Unitless (r (normalize_hue f))
+      | None -> h)
+  | Hue_none | Var _ -> h
+
+let canonical_hsl_hue ~lossless (h : hue) : hue =
+  match h with
+  | Angle (Deg f) -> Unitless f
+  | Angle a -> (
+      match deg_of_hue (Angle a) with
+      | Some f ->
+          Unitless (round_color_axis ~lossless ~decimals:3 (normalize_hue f))
+      | None -> h)
+  | Unitless _ | Hue_none | Var _ -> h
+
+let canonical_hsl_hue_in_color ~lossless = function
+  | Hsl r -> Hsl { r with h = canonical_hsl_hue ~lossless r.h }
+  | Hwb r -> Hwb { r with h = canonical_hsl_hue ~lossless r.h }
+  | color -> color
 
 let canonical_color_lightness ~lossless ~pct_scale ~axis_max_decimals
     (l : percentage option) : percentage option =
@@ -7663,7 +7625,7 @@ let rec normalize_color ?(lossless = false) ?(exact_srgb = false) (c : color) :
       in
       match bytes with
       | Some (r, g, b, a) -> hex_of_byte_quad r g b a
-      | Option.None -> drop_full_alpha c)
+      | Option.None -> canonical_hsl_hue_in_color ~lossless (drop_full_alpha c))
   | Mix { in_space; hue; color1; percent1; color2; percent2 } ->
       normalize_mix_color ~lossless ~in_space ~hue ~color1 ~percent1 ~color2
         ~percent2

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -227,8 +227,8 @@ val pp_duration : duration Pp.t
 (** [pp_duration] pretty-prints {!duration} values. *)
 
 val pp_duration_preserve_ms : duration Pp.t
-(** [pp_duration_preserve_ms] pretty-prints {!duration} values without
-    shortening milliseconds to seconds. *)
+(** [pp_duration_preserve_ms] is an alias of {!pp_duration}. Both printers hold
+    the parsed unit; millisecond shortening is an AST normalization. *)
 
 val pp_number : number Pp.t
 (** [pp_number] pretty-prints {!number} values. *)
@@ -297,10 +297,12 @@ val normalize_percentage : ?ctx:calc_ctx -> percentage -> percentage
     [<percentage>] [calc()] ([calc(1 / 2 * 100%)] becomes [calc(.5*100%)]),
     keeping any [var()]. *)
 
-val normalize_duration : ?ctx:calc_ctx -> duration -> duration
+val normalize_duration :
+  ?ctx:calc_ctx -> ?canonicalize_ms:bool -> duration -> duration
 (** [normalize_duration d] folds the value-independent parts of a [<time>]
     [calc()] ([calc(var(--d) * 1)] becomes [calc(var(--d))]), keeping any
-    [var()]. *)
+    [var()]. It chooses the shorter seconds spelling by default;
+    [canonicalize_ms:false] preserves millisecond units. *)
 
 val normalize_color : ?lossless:bool -> ?exact_srgb:bool -> color -> color
 (** [normalize_color ?lossless c] canonicalises a color to its shortest

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -606,6 +606,9 @@ let colors () =
     "color: hsl(0, 100%, 50%)";
   decl_optimizes_to ~held:"color:hsl(120 100% 50%/.5)" ~into:"color:#00ff0080"
     "color: hsla(120, 100%, 50%, 0.5)";
+  decl_optimizes_to ~held:"color:hsl(.5turn 50% 50%/var(--a))"
+    ~into:"color:hsl(180 50% 50%/var(--a))"
+    "color: hsl(.5turn 50% 50% / var(--a))";
 
   check_declaration ~expected:"background-color:red" "background-color: red";
   decl_optimizes_to ~held:"border-color:blue" ~into:"border-color:#00f"
@@ -642,6 +645,8 @@ let lengths () =
   check_declaration ~expected:"margin:auto" "margin: auto";
   check_declaration ~expected:"width:auto" "width: auto";
   check_declaration ~expected:"height:auto" "height: auto";
+  check_declaration ~expected:"min-inline-size:initial"
+    ~optimized:"min-inline-size:auto" "min-inline-size: initial";
 
   (* Min/max content *)
   check_declaration ~expected:"width:min-content" "width: min-content";
@@ -1653,8 +1658,10 @@ let animations_timing () =
   check_declaration ~expected:"animation-name:none" "animation-name: none";
 
   check_declaration ~expected:"animation-duration:1s" "animation-duration: 1s";
-  check_declaration ~expected:"animation-duration:.5s" (* 500ms -> .5s *)
-    "animation-duration: 500ms";
+  check_declaration ~expected:"animation-duration:500ms"
+    ~optimized:"animation-duration:.5s" "animation-duration: 500ms";
+  check_declaration ~expected:"transition-duration:round(1.1s,.5s)"
+    ~optimized:"transition-duration:1s" "transition-duration: round(1.1s, .5s)";
   check_declaration ~expected:"animation-duration:2.5s"
     "animation-duration: 2.5s";
 
@@ -1721,15 +1728,21 @@ let animations_timing () =
      [<time>]. [0s] does not drop the unit. *)
   check_declaration ~expected:"animation-delay:0s" "animation-delay: 0s";
   check_declaration ~expected:"animation-delay:1s" "animation-delay: 1s";
-  check_declaration ~expected:"animation-delay:-.5s" "animation-delay: -500ms";
+  check_declaration ~expected:"animation-delay:-500ms"
+    ~optimized:"animation-delay:-.5s" "animation-delay: -500ms";
   (* CSS Values 4 sec. 10.3 gives these functions the type of their arguments,
      so time-valued calls fit the delay longhands' [<time>] grammar. *)
-  check_declaration ~expected:"transition-delay:1s"
-    "transition-delay:round(1.1s,.5s)";
-  check_declaration ~expected:"animation-delay:.1s"
-    "animation-delay:mod(1.1s,.5s)";
-  check_declaration ~expected:"animation-delay:.1s"
-    "animation-delay:rem(1.1s,.5s)";
+  check_declaration ~expected:"transition-delay:round(1.1s,.5s)"
+    ~optimized:"transition-delay:1s" "transition-delay:round(1.1s,.5s)";
+  check_declaration ~expected:"animation-delay:mod(1.1s,.5s)"
+    ~optimized:"animation-delay:.1s" "animation-delay:mod(1.1s,.5s)";
+  check_declaration ~expected:"animation-delay:rem(1.1s,.5s)"
+    ~optimized:"animation-delay:.1s" "animation-delay:rem(1.1s,.5s)";
+  check_declaration ~expected:"transition-duration:var(--d,500ms)"
+    ~optimized:"transition-duration:var(--d,.5s)"
+    "transition-duration:var(--d,500ms)";
+  check_declaration ~expected:"interest-delay:round(1100ms,500ms)"
+    ~optimized:"interest-delay:1000ms" "interest-delay:round(1100ms,500ms)";
   let c = Cursor.of_string "transition-delay:bogus" in
   match read_declaration c with
   | exception
@@ -1802,10 +1815,15 @@ let transforms () =
   (* Per CSS Transforms 1 sec. 4 [center] is shorthand for [50% 50%] and the
      keyword pair [top left] is [0 0]. A single [0] would mean [0 50%], so the
      two-value form must be preserved. *)
-  check_declaration ~expected:"transform-origin:50%" "transform-origin: center";
-  check_declaration ~expected:"transform-origin:0 0"
-    "transform-origin: top left";
-  check_declaration ~expected:"transform-origin:50%" "transform-origin: 50% 50%";
+  check_declaration ~expected:"transform-origin:center"
+    ~optimized:"transform-origin:50%" "transform-origin: center";
+  check_declaration ~expected:"transform-origin:top left"
+    ~optimized:"transform-origin:0 0" "transform-origin: top left";
+  check_declaration ~expected:"transform-origin:50% 50%"
+    ~optimized:"transform-origin:50%" "transform-origin: 50% 50%";
+  check_declaration ~expected:"transform-origin:var(--o,center)"
+    ~optimized:"transform-origin:var(--o,50%)"
+    "transform-origin:var(--o,center)";
   check_declaration ~expected:"transform-origin:10px 20px"
     "transform-origin: 10px 20px"
 
@@ -2039,13 +2057,17 @@ let list_properties () =
     "transition: opacity 1s ease-in .5s";
   check_declaration ~expected:"transition:opacity .3s,transform .3s"
     "transition: opacity 0.3s, transform 0.3s";
+  check_declaration ~expected:"transition:all 500ms"
+    ~optimized:"transition:all .5s" "transition: all 500ms";
 
   (* Animation *)
   check_declaration ~expected:"animation:none" "animation: none";
   check_declaration ~expected:"animation:spin 1s linear infinite"
     "animation: spin 1s linear infinite";
   check_declaration ~expected:"animation:slide .5s ease-out"
-    "animation: slide 0.5s ease-out"
+    "animation: slide 0.5s ease-out";
+  check_declaration ~expected:"animation:spin 500ms"
+    ~optimized:"animation:spin .5s" "animation: spin 500ms"
 
 let custom_properties () =
   (* Basic custom properties *)

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -429,6 +429,29 @@ let test_text_decoration_default_spellings_factor () =
     ".a,.b{text-shadow:1px 1px}"
     (optimize_str ".a{text-shadow:1px 1px 0}.b{text-shadow:1px 1px}")
 
+(* These equivalent spellings were still canonicalised by their printers, too
+   late for declaration hashes to meet during factoring. *)
+let test_remaining_printer_fold_spellings_factor () =
+  Alcotest.(check string)
+    "logical minimum initial factors with auto" ".a,.b{min-inline-size:auto}"
+    (optimize_str ".a{min-inline-size:initial}.b{min-inline-size:auto}");
+  Alcotest.(check string)
+    "milliseconds factor with seconds" ".a,.b{transition-duration:.5s}"
+    (optimize_str ".a{transition-duration:500ms}.b{transition-duration:.5s}");
+  Alcotest.(check string)
+    "origin keyword factors with percentage" ".a,.b{transform-origin:50%}"
+    (optimize_str ".a{transform-origin:center}.b{transform-origin:50%}");
+  Alcotest.(check string)
+    "stepped duration factors with its result" ".a,.b{transition-duration:1s}"
+    (optimize_str
+       ".a{transition-duration:round(1.1s,.5s)}.b{transition-duration:1s}");
+  Alcotest.(check string)
+    "angle hue factors with bare degrees"
+    ".a,.b{color:hsl(180 50% 50%/var(--a))}"
+    (optimize_str
+       ".a{color:hsl(.5turn 50% 50%/var(--a))}.b{color:hsl(180 50% \
+        50%/var(--a))}")
+
 let suite =
   ( "factor",
     [
@@ -478,4 +501,6 @@ let suite =
         test_list_style_default_spellings_factor;
       Alcotest.test_case "spelled-out text decoration defaults factor away"
         `Quick test_text_decoration_default_spellings_factor;
+      Alcotest.test_case "remaining printer folds factor together" `Quick
+        test_remaining_printer_fold_spellings_factor;
     ] )

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3394,10 +3394,10 @@ let test_text_decoration_skip_ink () =
 
 let test_transform_origin () =
   (* Per CSS Transforms 1 sec. 4 the keyword [center] is shorthand for [50%] and
-     matched-pair shorthand collapses to a single value. Per shortest- wins
-     (Lightning CSS) the printer emits the numeric form. *)
-  check_transform_origin ~expected:"50%" "center";
-  check_transform_origin ~expected:"0 0" "left top";
+     matched-pair shorthand collapses to a single value during optimization. The
+     value printer preserves the parsed node. *)
+  check_transform_origin "center";
+  check_transform_origin "left top";
   (* A single value sets the X origin; Y defaults to center (50%), so it must
      not be duplicated onto the Y axis: [100%] means [100% 50%], not [100%
      100%], and [0] means [0 50%], not [0 0]. Only [50%] coincides with center.

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -284,9 +284,9 @@ let test_color () =
 
   (* Modern color notations. pp preserves the authored function node; the
      equivalent hex form is the optimize+minify oracle. *)
-  check_color ~expected:"hsl(180 50% 25%)" ~optimized:"#206060"
+  check_color ~expected:"hsl(180deg 50% 25%)" ~optimized:"#206060"
     "hsl(180deg 50% 25%)";
-  check_color ~expected:"hwb(90 10% 20%)" ~optimized:"#73cc1a"
+  check_color ~expected:"hwb(90deg 10% 20%)" ~optimized:"#73cc1a"
     "hwb(90deg 10% 20%)";
   check_color ~expected:"hsl(180 50% 25%/.5)" ~optimized:"#20606080"
     "hsl(180 50% 25% / 0.5)";
@@ -296,7 +296,7 @@ let test_color () =
   (* CSS Color 4 section 4.2: alpha [<percentage>] is spec-equivalent to the
      corresponding [<number>] in [\[0, 1\]]; the printer canonicalizes to the
      number form per cssnano. *)
-  check_color ~expected:"hsl(180 50% 25%/30%)" ~optimized:"#2060604d"
+  check_color ~expected:"hsl(180deg 50% 25%/30%)" ~optimized:"#2060604d"
     "hsl(180deg 50% 25% / 30%)";
   check_color ~optimized:"red" "color(srgb 1 0 0)";
   check_color ~expected:"color(display-p3 .8 .2 .1/.5)"
@@ -372,7 +372,7 @@ let test_color () =
   check_color ~expected:"var(--color,)" "var(--color,)";
 
   (* Custom properties inline mode tests with complex color fallbacks *)
-  check_color ~expected:"var(--theme-primary,hsl(210 75% 50%))"
+  check_color ~expected:"var(--theme-primary,hsl(210deg 75% 50%))"
     ~optimized:"var(--theme-primary,#2080df)"
     "var(--theme-primary, hsl(210deg 75% 50%))";
   check_color ~expected:"var(--accent,rgb(255 0 128/80%))"
@@ -556,11 +556,8 @@ let test_angle () =
   neg_cursor read_angle "360.5.5deg"
 
 let test_duration () =
-  (* CSS Values 4 section 7.2: [<time>] requires a unit. s and ms convert
-     exactly (1s = 1000ms), so a duration decodes to one canonical magnitude and
-     pp prints its shortest spelling - whichever of s/ms is shorter - as a
-     same-node choice. (Contrast <angle>, where rad does not convert exactly, so
-     the units stay distinct nodes and conversion is an optimize transform.) *)
+  (* CSS Values 4 section 7.2: [<time>] requires a unit. pp holds the parsed
+     unit; choosing the shorter equivalent [s] spelling is an optimize fold. *)
   check_duration "1s";
   check_duration "0s";
   check_duration ~expected:".5s" "0.5s";
@@ -568,14 +565,14 @@ let test_duration () =
   check_duration "10s";
   check_duration "999s";
 
-  check_duration ~expected:".5s" "500ms";
-  check_duration ~expected:"0s" "0ms";
+  check_duration "500ms";
+  check_duration "0ms";
   check_duration "1ms";
-  check_duration ~expected:"1s" "1000ms";
-  check_duration ~expected:".0505s" "50.5ms";
-  check_duration ~expected:"999.999s" "999999ms";
+  check_duration "1000ms";
+  check_duration "50.5ms";
+  check_duration "999999ms";
   check_duration ".1s";
-  check_duration ~expected:".15s" "150ms";
+  check_duration "150ms";
   check_duration "1.5s";
 
   (* CSS Values 4 sec. 10.10.1: a typed <time> scales by a number and same-unit
@@ -700,10 +697,9 @@ let test_minified_value_formatting () =
   check string "minified rem" ".5rem" s;
   let s = Css.Pp.to_string ~minify:true pp_number (Num 0.5) in
   check string "minified number" ".5" s;
-  (* Duration normalizes to shorter form in minified mode *)
+  (* The duration printer holds the unit in minified mode. *)
   let s = Css.Pp.to_string ~minify:true pp_duration (Ms 500.) in
-  check string "minified ms" ".5s" s;
-  (* 500ms -> .5s is shorter *)
+  check string "minified ms" "500ms" s;
   (* Zero stays zero without unit *)
   let s = Css.Pp.to_string ~minify:true pp_length Zero in
   check string "minified zero" "0" s
@@ -993,10 +989,10 @@ let test_color_space () =
   neg_cursor read_color_space ""
 
 let test_hue () =
-  check_hue ~expected:"180" "180deg";
-  check_hue ~expected:"180" "0.5turn";
-  check_hue ~expected:"180" "200grad";
-  check_hue ~expected:"180" "3.14159rad";
+  check_hue "180deg";
+  check_hue ~expected:".5turn" "0.5turn";
+  check_hue "200grad";
+  check_hue "3.14159rad";
   neg_cursor read_hue "invalid";
   neg_cursor read_hue "abc";
   check_hue "180";


### PR DESCRIPTION
Moves the last printer-only value folds into normalization before declaration hashes are compared. This covers logical minimum sizes, duration spellings and stepped functions, transform origins, and hue-angle units, including typed variable fallbacks and shorthand paths.

The first commit adds held-versus-optimized and factoring regressions. The second implements normalization and makes the initial-value canonicalization match exhaustive so new properties must be considered explicitly.

Test plan:
- opam exec -- dune fmt
- opam exec -- dune build
- opam exec -- dune exec -- merlint
- env -u NO_COLOR opam exec -- dune test