### PR TITLE
Isolate forced-colour cram probe from NO_COLOR

### DIFF
--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -34,7 +34,7 @@ edit.
 Forcing colour on emits ANSI markers even into a pipe; the default
 resolves to plain off-tty, as the NO_COLOR run above shows.
 
-  $ cascade diff --color=always c.css d.css | cat -v | head -5
+  $ env -u NO_COLOR cascade diff --color=always c.css d.css | cat -v | head -5
   CSS: 18 chars vs 19 chars (5.6% diff)
   Changes: 1 modified rule
   


### PR DESCRIPTION
Makes the forced-colour CLI fixture independent of the test runner's environment. The probe now unsets NO_COLOR explicitly, while the surrounding probes remain explicitly colourless.

Test plan:
- env NO_COLOR=1 opam exec -- dune build --force @test/cli/runtest
- opam exec -- dune fmt
- opam exec -- dune build