### PR TITLE
Collapse repeated scroll shorthand sides

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -490,6 +490,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` collapses repeated sides in the `scroll-margin` and
+  `scroll-padding` physical and logical shorthands before declaration hashes
+  are compared, so equivalent rules factor together (#650)
 - `--minify` canonicalises logical minimum sizes, duration units and stepped
   functions, transform origins and hue-angle units before declaration hashes
   are compared, so equivalent rules factor under all five spellings (#647)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4096,12 +4096,18 @@ let normalize_property_value : type a.
   | Right -> map_preserve (Values.normalize_length ~ctx) value
   | Bottom -> map_preserve (Values.normalize_length ~ctx) value
   | Left -> map_preserve (Values.normalize_length ~ctx) value
-  | Scroll_margin -> map_preserve (Values.normalize_length ~ctx) value
-  | Scroll_margin_inline -> map_preserve (Values.normalize_length ~ctx) value
-  | Scroll_margin_block -> map_preserve (Values.normalize_length ~ctx) value
-  | Scroll_padding -> map_preserve (Values.normalize_length ~ctx) value
-  | Scroll_padding_inline -> map_preserve (Values.normalize_length ~ctx) value
-  | Scroll_padding_block -> map_preserve (Values.normalize_length ~ctx) value
+  | Scroll_margin ->
+      normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Scroll_margin_inline ->
+      normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Scroll_margin_block ->
+      normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Scroll_padding ->
+      normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Scroll_padding_inline ->
+      normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Scroll_padding_block ->
+      normalize_box_shorthand (Values.normalize_length ~ctx) value
   | Custom_property _ -> (
       match value with
       | Custom_value ({ value = Tokens components; _ } as r) ->

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -513,6 +513,21 @@ let special_cases () =
      two sides. *)
   check_declaration ~expected:"padding-inline:1px 1px"
     ~optimized:"padding-inline:1px" "padding-inline: 1px 1px";
+  (* CSS Scroll Snap 1 sec. 4.1 and 5.1 use the same one-to-four side assignment
+     for the physical shorthands and the same one-to-two assignment for their
+     logical axis shorthands. *)
+  check_declaration ~expected:"scroll-margin:1px 1px 1px 1px"
+    ~optimized:"scroll-margin:1px" "scroll-margin: 1px 1px 1px 1px";
+  check_declaration ~expected:"scroll-margin-inline:2px 2px"
+    ~optimized:"scroll-margin-inline:2px" "scroll-margin-inline: 2px 2px";
+  check_declaration ~expected:"scroll-margin-block:3px 3px"
+    ~optimized:"scroll-margin-block:3px" "scroll-margin-block: 3px 3px";
+  check_declaration ~expected:"scroll-padding:4px 5px 4px 5px"
+    ~optimized:"scroll-padding:4px 5px" "scroll-padding: 4px 5px 4px 5px";
+  check_declaration ~expected:"scroll-padding-inline:6px 6px"
+    ~optimized:"scroll-padding-inline:6px" "scroll-padding-inline: 6px 6px";
+  check_declaration ~expected:"scroll-padding-block:7px 7px"
+    ~optimized:"scroll-padding-block:7px" "scroll-padding-block: 7px 7px";
   (* CSS Position 3 (ED) sec. 3.2 defines [inset] as [<'top'>{1,4}], and CSS
      Backgrounds 3 (ED) sec. 3.1 defines [border-color] over the same
      one-to-four side assignment. *)

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -243,6 +243,30 @@ let test_box_shorthand_repeats_factor () =
   Alcotest.(check string)
     "border-color takes the same collapse" ".a,.b{border-color:red}"
     (optimize_str ".a{border-color:red red red red}.b{border-color:red}");
+  Alcotest.(check string)
+    "scroll-margin factors with the single value" ".a,.b{scroll-margin:1px}"
+    (optimize_str ".a{scroll-margin:1px 1px 1px 1px}.b{scroll-margin:1px}");
+  Alcotest.(check string)
+    "scroll-margin-inline factors with the single value"
+    ".a,.b{scroll-margin-inline:2px}"
+    (optimize_str ".a{scroll-margin-inline:2px 2px}.b{scroll-margin-inline:2px}");
+  Alcotest.(check string)
+    "scroll-margin-block factors with the single value"
+    ".a,.b{scroll-margin-block:3px}"
+    (optimize_str ".a{scroll-margin-block:3px 3px}.b{scroll-margin-block:3px}");
+  Alcotest.(check string)
+    "scroll-padding factors with the repeated axis"
+    ".a,.b{scroll-padding:4px 5px}"
+    (optimize_str ".a{scroll-padding:4px 5px 4px 5px}.b{scroll-padding:4px 5px}");
+  Alcotest.(check string)
+    "scroll-padding-inline factors with the single value"
+    ".a,.b{scroll-padding-inline:6px}"
+    (optimize_str
+       ".a{scroll-padding-inline:6px 6px}.b{scroll-padding-inline:6px}");
+  Alcotest.(check string)
+    "scroll-padding-block factors with the single value"
+    ".a,.b{scroll-padding-block:7px}"
+    (optimize_str ".a{scroll-padding-block:7px 7px}.b{scroll-padding-block:7px}");
   (* CSS Backgrounds 3 (ED) sec. 4.1 collapses each radii group on its own, and
      with no slash the values set both axes equally. *)
   Alcotest.(check string)


### PR DESCRIPTION
Normalizes repeated sides in scroll-margin and scroll-padding before declaration hashes are compared. The physical and logical shorthand forms now use the same box-shorthand normalizer as margin, padding, and inset, allowing equivalent rules to factor together.

The first commit adds held-versus-optimized and factoring regressions for all six dispatch arms. The second copies the established normalizer into those arms.

Test plan:
- opam exec -- dune fmt
- opam exec -- dune build
- opam exec -- dune exec -- merlint
- env -u NO_COLOR opam exec -- dune test