### PR TITLE
Read percentage tokens directly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- Percentage tokens in `color-mix()` variable fallbacks and `font-size` now
+  retain their typed percentage nodes. Both readers tried to consume a number
+  token followed by `%`, but CSS tokenizes the pair as one percentage (#651)
 - The animation and transition delay longhands read time-valued `round()`,
   `mod()` and `rem()` calls instead of dropping the declaration with an
   internal list-parser diagnostic (#646)

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -97,9 +97,8 @@ let rec read_font_size t : font_size =
     Length len
   in
   let read_pct t : font_size =
-    let n = Cursor.number t in
+    let n = Cursor.pct t in
     if n < 0. then Cursor.err_invalid t "negative font-size percentage";
-    Cursor.expect '%' t;
     Pct n
   in
   Cursor.enum_or_calls "font-size"
@@ -1095,11 +1094,9 @@ let rec pp_webkit_font_smoothing : webkit_font_smoothing Pp.t =
 
 (* [<length-percentage>] is the whole of [font-size]'s numeric grammar, so a
    calc built from those leaves is a [<length>] calc and can be handed to the
-   length simplifier. The trip back lands under [Length], percentage included: a
-   [<percentage>] is one token, so the reader takes [font-size: 50%] through
-   [read_non_negative_length] and the [Pct] leaf it produces sits there. A
-   [var()] leaf carries a [font_size]-typed fallback, which does not survive the
-   trip either way. *)
+   length simplifier. The trip back restores the public [font_size.Pct] node for
+   a percentage leaf. A [var()] leaf carries a [font_size]-typed fallback, which
+   does not survive the trip either way. *)
 let rec length_of_font_size_calc : font_size calc -> length calc option =
   function
   | Val (Length l) -> Some (Val l)
@@ -1117,9 +1114,12 @@ let rec length_of_font_size_calc : font_size calc -> length calc option =
       | Some left, Some right -> Some (Expr (left, op, right))
       | _ -> None)
 
+let font_size_of_length (l : length) : font_size =
+  match l with Pct n -> Pct n | l -> Length l
+
 let rec font_size_of_length_calc : length calc -> font_size calc option =
   function
-  | Val l -> Some (Val (Length l))
+  | Val l -> Some (Val (font_size_of_length l))
   | Num n -> Some (Num n)
   | Math_const c -> Some (Math_const c)
   | Math_fn fn -> Some (Math_fn fn)
@@ -1945,7 +1945,7 @@ let normalize_font_size (fs : font_size) : font_size =
               match font_size_of_length_calc folded with
               | Some folded -> Calc folded
               | None -> fs)
-          | length -> Length length))
+          | length -> font_size_of_length length))
   | _ -> fs
 
 let normalize_line_height (lh : line_height) : line_height =

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6509,8 +6509,7 @@ let rec read_percentage_in_color_mix t : percentage =
        verbatim and let substitution-time clamping apply. *)
     Calc (read_calc read_color_mix_calc_pct t)
   else
-    let n = Cursor.number t in
-    Cursor.expect '%' t;
+    let n = Cursor.pct t in
     if n < 0. || n > 100. then
       Cursor.err_invalid t "color-mix percentage must be between 0% and 100%";
     (Pct n : percentage)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3946,6 +3946,11 @@ let test_field_sizing () =
 
 let test_font_size () =
   check_font_size "16px";
+  check_font_size "50%";
+  let parsed = read_font_size (Cursor.of_string "50%") in
+  (match parsed with
+  | Pct n -> Alcotest.(check (float 0.)) "public percentage node" 50. n
+  | _ -> Alcotest.fail "font-size percentage did not use Pct");
   check_font_size "small";
   check_font_size "medium";
   check_font_size "large";

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1349,6 +1349,11 @@ let spec_values_l45_math_color () =
   check_color ~expected:"color-mix(in srgb,var(--c) calc(var(--o)*100%),blue)"
     ~optimized:"color-mix(in srgb,var(--c) calc(var(--o)*100%),#00f)"
     "color-mix(in srgb, var(--c) calc(var(--o) * 100%), blue)";
+  (* A percentage token in a var fallback is still a typed color-mix weight, so
+     it takes the same numeric minification as a top-level weight. *)
+  check_color ~expected:"color-mix(in srgb,red var(--p,30%),blue)"
+    ~optimized:"color-mix(in srgb,red var(--p,30%),#00f)"
+    "color-mix(in srgb, red var(--p, 30.0%), blue)";
   (* Both the colour and the percentage are [var()]: the leading var is the
      colour, so source order is preserved (regression: the two were swapped,
      landing the alpha var in the colour slot). *)


### PR DESCRIPTION
Reads percentage tokens directly in color-mix variable fallbacks and font-size. This preserves the typed fallback node, makes parsed font-size percentages use the public Pct constructor, and keeps folded font-size percentage calculations on that same canonical node so equivalent declarations still factor.

The first commit adds independent regressions for the opaque color-mix fallback and unreachable font-size constructor. The second fixes the two readers and the downstream font-size conversion exposed by the full suite.

Test plan:
- opam exec -- dune fmt
- opam exec -- dune build
- opam exec -- dune exec -- merlint
- env -u NO_COLOR opam exec -- dune test