### PR TITLE
Use literal aspect-ratio constructors consistently

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- Literal `aspect-ratio` values now use the exported `Ratio` and `Auto_ratio`
+  nodes, matching declarations built through the public constructors and
+  helpers so equal declarations have equal cached hashes (#652)
 - Percentage tokens in `color-mix()` variable fallbacks and `font-size` now
   retain their typed percentage nodes. Both readers tried to consume a number
   token followed by `%`, but CSS tokenizes the pair as one percentage (#651)

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -198,11 +198,8 @@ include Stylesheet
 let radius value = Radius { horizontal = [ Length value ]; vertical = None }
 let gaps ?column row : gap = Lengths { row_gap = Some row; column_gap = column }
 let font_stack fonts = (List fonts : font_family)
-let ratio width height = (Ratio_calc (Num width, Num height) : aspect_ratio)
-
-let auto_ratio width height =
-  (Auto_ratio_calc (Num width, Num height) : aspect_ratio)
-
+let ratio width height = (Ratio (width, height) : aspect_ratio)
+let auto_ratio width height = (Auto_ratio (width, height) : aspect_ratio)
 let position_xy x y = (XY (x, y) : position_value)
 let position_length value = (Single value : position_value)
 let text_overflow_string value = (String value : text_overflow)

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -238,15 +238,24 @@ let normalize_object_view_box (value : object_view_box) : object_view_box =
       else Rect { top; right; bottom; left; rounded }
   | other -> other
 
+let aspect_ratio_of_numbers ~auto (a : number) (b : number) : aspect_ratio =
+  match (auto, a, b) with
+  | false, Num a, Num b -> Ratio (a, b)
+  | true, Num a, Num b -> Auto_ratio (a, b)
+  | false, a, b -> Ratio_calc (a, b)
+  | true, a, b -> Auto_ratio_calc (a, b)
+
 let normalize_aspect_ratio : aspect_ratio -> aspect_ratio =
  fun value ->
   match value with
   | Auto_ratio_calc (a, b) ->
-      preserve_if_equal value
-        (Auto_ratio_calc (Values.normalize_number a, Values.normalize_number b))
+      aspect_ratio_of_numbers ~auto:true
+        (Values.normalize_number a)
+        (Values.normalize_number b)
   | Ratio_calc (a, b) ->
-      preserve_if_equal value
-        (Ratio_calc (Values.normalize_number a, Values.normalize_number b))
+      aspect_ratio_of_numbers ~auto:false
+        (Values.normalize_number a)
+        (Values.normalize_number b)
   | other -> other
 
 let rec pp_display : display Pp.t =
@@ -890,8 +899,8 @@ let rec read_aspect_ratio (t : Cursor.t) : aspect_ratio =
     match Cursor.peek_ident t with
     | Some "auto" ->
         Cursor.skip t;
-        Auto_ratio_calc (w, h)
-    | _ -> Ratio_calc (w, h)
+        aspect_ratio_of_numbers ~auto:true w h
+    | _ -> aspect_ratio_of_numbers ~auto:false w h
   in
   let read_auto t : aspect_ratio =
     match Cursor.peek_ident t with
@@ -901,7 +910,7 @@ let rec read_aspect_ratio (t : Cursor.t) : aspect_ratio =
            following number as a ratio so a trailing separator / whitespace
            (e.g. [aspect-ratio: auto;]) resolves to plain [Auto]. *)
         match Cursor.option read_ratio t with
-        | Some (w, h) -> Auto_ratio_calc (w, h)
+        | Some (w, h) -> aspect_ratio_of_numbers ~auto:true w h
         | None -> Auto)
     | _ -> Cursor.err_expected t "auto"
   in

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4511,6 +4511,18 @@ let distinct_value label a b =
     false
     (Css.Declaration.equal_declaration a b)
 
+let aspect_ratio_has_one_node () =
+  let parsed = Css.Declaration.of_string "aspect-ratio:16/9" in
+  same_text_same_hash "Ratio constructor vs parsed"
+    (Css.aspect_ratio (Css.Ratio (16., 9.)))
+    parsed;
+  same_text_same_hash "ratio helper vs parsed"
+    (Css.aspect_ratio (Css.ratio 16. 9.))
+    parsed;
+  same_text_same_hash "Auto_ratio constructor vs parsed"
+    (Css.aspect_ratio (Css.Auto_ratio (16., 9.)))
+    (Css.Declaration.of_string "aspect-ratio:auto 16/9")
+
 let nan_has_one_node () =
   (* The keyword and the calculation that lands on NaN are the same value. *)
   let keyword = sole_declaration ".a{opacity:calc(NaN)}" in
@@ -4603,6 +4615,7 @@ let declaration_tests =
   [
     (* Core declaration type testing *)
     test_case "declaration" `Quick test_declaration;
+    test_case "aspect-ratio has one node" `Quick aspect_ratio_has_one_node;
     test_case "NaN is one declared value" `Quick nan_declaration_is_one_value;
     test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;


### PR DESCRIPTION
Parses literal aspect-ratio values into the exported Ratio and Auto_ratio nodes and makes the public helpers build those same nodes. Calculated components retain the calc variants, and normalization converts a folded calculation to the literal node, so equal declarations print, compare, and hash equally.

The first commit demonstrates the cached-hash mismatch for direct constructors, helpers, and parsed declarations. The second unifies the reader, helpers, and normalization path.

Test plan:
- opam exec -- dune fmt
- opam exec -- dune build
- opam exec -- dune exec -- merlint
- env -u NO_COLOR opam exec -- dune test