### PR TITLE
Parse lone caret auto as the public constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A literal `caret:auto` now reads as the exported `caret.Auto` node rather
+  than the same text encoded as a one-slot shorthand, so constructed and
+  parsed declarations compare and hash equally (#653)
 - Literal `aspect-ratio` values now use the exported `Ratio` and `Auto_ratio`
   nodes, matching declarations built through the public constructors and
   helpers so equal declarations have equal cached hashes (#652)

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -182,7 +182,10 @@ let read_caret_shorthand t : caret =
   let rec loop color animation shape count =
     if Cursor.is_done t then
       if count = 0 then Cursor.err_expected t "caret"
-      else (Caret (color, animation, shape) : caret)
+      else
+        match (color, animation, shape) with
+        | Some (Auto : color), Option.None, Option.None -> (Auto : caret)
+        | _ -> Caret (color, animation, shape)
     else
       let try_each =
         let attempts =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4523,6 +4523,11 @@ let aspect_ratio_has_one_node () =
     (Css.aspect_ratio (Css.Auto_ratio (16., 9.)))
     (Css.Declaration.of_string "aspect-ratio:auto 16/9")
 
+let caret_auto_has_one_node () =
+  same_text_same_hash "caret Auto constructor vs parsed"
+    (Css.caret (Css.Auto : Css.caret))
+    (Css.Declaration.of_string "caret:auto")
+
 let nan_has_one_node () =
   (* The keyword and the calculation that lands on NaN are the same value. *)
   let keyword = sole_declaration ".a{opacity:calc(NaN)}" in
@@ -4616,6 +4621,7 @@ let declaration_tests =
     (* Core declaration type testing *)
     test_case "declaration" `Quick test_declaration;
     test_case "aspect-ratio has one node" `Quick aspect_ratio_has_one_node;
+    test_case "caret auto has one node" `Quick caret_auto_has_one_node;
     test_case "NaN is one declared value" `Quick nan_declaration_is_one_value;
     test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4304,6 +4304,7 @@ let spec_generated_box_layout_edges () =
 let spec_generated_position_interaction_edges () =
   check_anchor_name ~expected:"--hero,--toast" "--hero, --toast";
   check_caret "red manual block";
+  check_caret "red auto";
   check_caret_animation "manual";
   check_caret_shape "underscore";
   check_container_name "main sidebar";


### PR DESCRIPTION
A lone `caret:auto` parsed as a one-slot shorthand even though the exported `caret.Auto` constructor prints the same CSS. The distinct trees gave otherwise identical declarations different cached hashes.

Collapse only the completed one-slot color-`auto` shorthand to `caret.Auto`. Multi-component forms such as `auto block`, `auto auto`, and `red auto` continue through the shorthand reader.

The regression test compares text and hashes for constructed and parsed declarations; a parser control keeps the combined `red auto` form accepted.