### PR TITLE
selector: split a top-level :is() in the AST, not in the printer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -553,6 +553,11 @@ recorded cases carrying six minifiers' answers.
 - `--minify` canonicalises programmatically constructed shared `<position>`
   nodes in `transform-origin` to the property's XY/XYZ nodes before hashing, so
   typed position nodes and coordinate origins now factor together (#672)
+- `--minify` splits a whole-rule `:is(a, b)` whose arguments share one
+  specificity into the selector list `a, b` before rules are compared, so it
+  factors with a rule that wrote the list out; the split reached the printed
+  output only, which left a second pass shorter than the first. A whole-rule
+  `:is(a)` or `:is(*)` loses its wrapper there too (#655)
 - `--minify` collapses repeated sides in the `scroll-margin` and
   `scroll-padding` physical and logical shorthands before declaration hashes
   are compared, so equivalent rules factor together (#650)
@@ -976,6 +981,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Canonical diff
 
+- `:is(a, b)` and the selector list `a, b` compare equal when the arguments
+  share one specificity, which is the split-against-grouped selector list the
+  mode promises to equate (#655)
 - The canonical projection keeps structurally distinct `@container` conditions
   in separate cascade slots even when their minified text is identical. An
   escaped unknown feature such as `(inline-size\>\=10px)` no longer merges into

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2741,8 +2741,10 @@ let canonicalize_is node selectors =
    a one-part compound, and dedup/sort selector-list alternatives by printed
    form (both [List] and the set-based [:is]/[:where]/[:not]/[:has] lists, incl.
    the [:-moz-any]/[:-webkit-any] aliases, whose order Selectors 4 makes
-   irrelevant to matching and specificity). *)
-let canonicalize sel =
+   irrelevant to matching and specificity). [map] hands each node over without
+   saying where it sits, so every rewrite below has to be sound in any position;
+   the one that needs the top of a rule selector is [canonicalize]. *)
+let canonicalize_nodes sel =
   map
     (fun node ->
       let canon ctor selectors =
@@ -2896,24 +2898,33 @@ let rec specificity = function
   | Relative (_, sel) -> specificity sel
   | List xs -> xs |> List.map specificity |> max_specificity
 
-(* Unwrap [:is(s1, s2, ...)] to a selector list only when every argument has the
-   same specificity AND is structurally simple. Selectors 4 sec. 4.2 gives [:is]
-   the [max] specificity of its arguments, so unwrapping changes specificity
-   unless all are already equal. *)
+(* Selectors 4 sec. 4.2 replaces the specificity of [:is()] with that of its
+   most specific argument, so splitting [:is(s1, s2, ...)] into the selector
+   list [s1, s2, ...] holds the weight of every match only when the arguments
+   already agree on one specificity. The arguments also have to be structurally
+   simple: [&] is out because [specificity] reads [Nesting] as zero while CSS
+   Nesting 1 sec. 3 weighs it as the most specific selector in the parent rule,
+   so the equality below would pass on a weight it never measured. *)
 let rec is_unwrap_safe_is_arg : t -> bool = function
   | Element _ | Class _ | Id _ | Universal _ | Attribute _ -> true
   | Compound parts -> List.for_all is_unwrap_safe_is_arg parts
   | _ -> false
 
-let rec top_level_is_unwrap : t -> t = function
-  | Is selectors
-    when List.length selectors >= 2
-         && List.for_all is_unwrap_safe_is_arg selectors
-         &&
-         match List.map specificity selectors with
-         | [] -> false
-         | s :: rest -> List.for_all (fun s' -> s' = s) rest ->
-      List selectors
+let is_unwrap_safe selectors =
+  List.length selectors >= 2
+  && List.for_all is_unwrap_safe_is_arg selectors
+  &&
+  match List.map specificity selectors with
+  | [] -> false
+  | s :: rest -> List.for_all (fun s' -> s' = s) rest
+
+(* Sound only where the [:is()] is a whole rule selector, or a whole member of
+   one top-level list: there the split lands in a selector list, which weighs
+   each branch on its own. Nested inside a [Compound] or a [Combined] it is a
+   grouping boundary and the split would change what matches. *)
+let rec top_level_is_unwrap sel =
+  match sel with
+  | Is selectors when is_unwrap_safe selectors -> List selectors
   | List selectors ->
       let expanded =
         List.concat_map
@@ -2923,19 +2934,11 @@ let rec top_level_is_unwrap : t -> t = function
             | other -> [ other ])
           selectors
       in
-      List expanded
-  | other -> other
+      if list_same expanded selectors then sel
+      else List (canonicalize_unordered_list expanded)
+  | _ -> sel
 
-(* Public [pp] applies the top-level [:is()] unwrap under [minify] so every
-   caller sees the canonical form. The internal [pp] recurses through the
-   un-unwrapped tree because the unwrap is sound only at the entry point: a
-   nested [Is] inside [Combinator]/[Compound] would change matching. *)
-let pp_inner = pp
-
-let pp ctx sel =
-  let sel = if Pp.minified ctx then top_level_is_unwrap sel else sel in
-  pp_inner ctx sel
-
+let canonicalize sel = top_level_is_unwrap (canonicalize_nodes sel)
 let to_string ?minify t = Pp.to_string ?minify pp t
 let to_buffer ?minify buf t = Pp.to_buffer ?minify buf pp t
 

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2911,8 +2911,7 @@ let rec is_unwrap_safe_is_arg : t -> bool = function
   | _ -> false
 
 let is_unwrap_safe selectors =
-  List.length selectors >= 2
-  && List.for_all is_unwrap_safe_is_arg selectors
+  List.for_all is_unwrap_safe_is_arg selectors
   &&
   match List.map specificity selectors with
   | [] -> false
@@ -2921,9 +2920,13 @@ let is_unwrap_safe selectors =
 (* Sound only where the [:is()] is a whole rule selector, or a whole member of
    one top-level list: there the split lands in a selector list, which weighs
    each branch on its own. Nested inside a [Compound] or a [Combined] it is a
-   grouping boundary and the split would change what matches. *)
+   grouping boundary and the split would change what matches. A lone argument
+   goes further than [canonicalize_is] can: that one is node-local and has to
+   leave a type or universal argument wrapped rather than splice it into a
+   compound it cannot see, and here there is no compound to splice into. *)
 let rec top_level_is_unwrap sel =
   match sel with
+  | Is [ single ] when is_unwrap_safe_is_arg single -> single
   | Is selectors when is_unwrap_safe selectors -> List selectors
   | List selectors ->
       let expanded =

--- a/lib/selector.mli
+++ b/lib/selector.mli
@@ -75,14 +75,6 @@ val ( || ) : t -> t -> t
 val pp : t Pp.t
 (** [pp] pretty-prints selectors. *)
 
-val top_level_is_unwrap : t -> t
-(** [top_level_is_unwrap sel] applies the CSS Selectors 4 sec. 4.2 [:is()]
-    unwrap at the top level of a rule selector: a whole-selector
-    [:is(s1, s2, ...)] or [:is] members of a top-level list flatten into the
-    enclosing selector list when each argument is a structurally simple selector
-    ([Element] / [Class] / [Id] / [Universal] / [Attribute], or a [Compound] of
-    those). Returns [sel] unchanged otherwise. *)
-
 val to_string : ?minify:bool -> t -> string
 (** [to_string ?minify sel] renders a selector to a string. *)
 
@@ -122,8 +114,12 @@ val map : (t -> t) -> t -> t
 val canonicalize : t -> t
 (** [canonicalize selector] removes lexical-only redundancy so that distinct
     ASTs denoting the same selector become structurally equal: the implied
-    universal in a compound is dropped ([*::before] -> [::before]) and a
-    one-part compound collapses to that part. Idempotent. *)
+    universal in a compound is dropped ([*::before] -> [::before]), a one-part
+    compound collapses to that part, and a whole-selector [:is(s1, s2, ...)]
+    whose arguments share one specificity becomes the selector list
+    [s1, s2, ...] (CSS Selectors 4 sec. 4.2). [selector] is read as a rule
+    selector, so the split applies at its top level and to the members of its
+    top-level list. Idempotent. *)
 
 val pp_combinator : combinator Pp.t
 (** [pp_combinator] pretty-prints selector combinators. *)

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -17,6 +17,27 @@ let contains_substring s needle =
 
 (* ===== equal tests ===== *)
 
+(* The canonical mode promises that split and grouped selector lists compare
+   equal. Selectors 4 sec. 4.2 weighs [:is()] as its most specific argument, so
+   with equal-specificity arguments [:is(a, b)] and [a, b] select the same
+   elements at the same weight and are the same rule written two ways. Where the
+   arguments disagree they are not: the list weighs an [a] match at (0,0,1), the
+   wrapper at (0,1,0). *)
+let equal_canonical_top_level_is_unwrap () =
+  Alcotest.(check bool)
+    ":is(a,b) and a,b are one rule" true
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical ":is(a,b){color:red}"
+       "a,b{color:red}");
+  Alcotest.(check bool)
+    ":is(.x,a) and .x,a are not" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical ":is(.x,a){color:red}"
+       ".x,a{color:red}");
+  (* Sec. 4.4: neither [:where()] nor its arguments contribute specificity. *)
+  Alcotest.(check bool)
+    ":where(a,b) and a,b are not" false
+    (Cascade_diff.Css_compare.equal ~mode:`Canonical ":where(a,b){color:red}"
+       "a,b{color:red}")
+
 let equal_identical () =
   let css = ".a { color: red }" in
   Alcotest.(check bool)
@@ -1543,6 +1564,8 @@ let suite =
         canonical_important_custom_property_distinct;
       Alcotest.test_case "canonical ignores @property order" `Quick
         equal_canonical_ignores_property_order;
+      Alcotest.test_case "canonical splits a top-level :is()" `Quick
+        equal_canonical_top_level_is_unwrap;
       Alcotest.test_case "canonical equates not all and (X) with not (X)" `Quick
         equal_canonical_media_not_all;
       Alcotest.test_case "canonical keeps target-gated content" `Quick

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -1466,6 +1466,68 @@ let canonicalize_pseudo_compound_is () =
   (* [:where()] never unwraps: it contributes zero specificity. *)
   canon ".a:before:where(.b)" ".a::before:where(.b)"
 
+(* Selectors 4 sec. 4.2 replaces the specificity of [:is()] with that of its
+   most specific argument, and its own note contrasts [:is(ul, ol, .list) >
+   [hidden]] with the split list to show the two do not agree. They agree
+   exactly when the arguments already share one specificity, and then a
+   whole-rule [:is(s1, ..., sn)] is the selector list [s1, ..., sn]. The split
+   has to reach the AST: everything downstream that groups rules compares
+   selector nodes. *)
+let canonicalize_top_level_is_unwrap () =
+  let canon expected input =
+    let actual = canonicalize (of_string input) in
+    Alcotest.(check string)
+      ("canonicalize " ^ input) expected
+      (to_string ~minify:true actual);
+    Alcotest.(check bool)
+      (input ^ " canonicalizes to the AST of " ^ expected)
+      true
+      (equal actual (canonicalize (of_string expected)));
+    match Cursor.option read (Cursor.of_string expected) with
+    | Some _ -> ()
+    | None ->
+        Alcotest.failf "canonicalized selector does not parse: %s" expected
+  in
+  let distinct a b =
+    Alcotest.(check bool)
+      (a ^ " and " ^ b ^ " are different selectors")
+      false
+      (equal (canonicalize (of_string a)) (canonicalize (of_string b)))
+  in
+  canon "a,b" ":is(a,b)";
+  canon ".a,.b" ":is(.a,.b)";
+  (* Split into a list that already had members, the alternatives are one
+     unordered set again (sec. 4.1: an element matches a selector list when it
+     matches any of its selectors). *)
+  canon "a,m,z" ":is(a,z),m";
+  canon "a,m,z" "a,z,m";
+  (* Unequal specificity: an [a] match weighs (0,0,1) as a list branch and
+     (0,1,0) under the wrapper. *)
+  canon ":is(.x,a)" ":is(.x,a)";
+  canon ":is(#i,a)" ":is(#i,a)";
+  distinct ":is(.x,a)" ".x,a";
+  distinct ":is(#i,a)" "#i,a";
+  (* Sec. 4.4: neither [:where()] nor any of its arguments contribute
+     specificity, so it never becomes a list, not even one its arguments agree
+     on. *)
+  canon ":where(.x,a)" ":where(.x,a)";
+  canon ":where(a,b)" ":where(a,b)";
+  distinct ":where(a,b)" "a,b";
+  distinct ":where(.x,a)" ".x,a";
+  (* Not the whole selector: there is no enclosing list to split into. *)
+  canon "p:is(.x,a)" "p:is(.x,a)";
+  canon ":is(.x,a) .z" ":is(.x,a) .z";
+  canon "p:is(a,b)" "p:is(a,b)";
+  canon ":is(a,b) .z" ":is(a,b) .z";
+  (* CSS Nesting 1 sec. 3 weighs [&] as the most specific selector in the parent
+     rule, a weight the selector text alone does not name, so an argument
+     holding one never enters the equality test. Split, [&, *] would weigh a
+     universal match at zero where the wrapper weighs it at the parent
+     specificity. *)
+  canon ":is(&,*)" ":is(&,*)";
+  canon ":is(&,.b)" ":is(&,.b)";
+  distinct ":is(&,*)" "&,*"
+
 (* WebKit, "Styling Scrollbars" defines eleven pseudo-classes for the state a
    scrollbar part is in. They are not in any spec, and Chrome 151 and WebKit
    26.5 both read them wherever a pseudo-class goes, so an unforgiving selector
@@ -2835,6 +2897,8 @@ let suite =
         scrollbar_state_pseudo_classes_read;
       test_case "canonicalize pseudo-compound :is()" `Quick
         canonicalize_pseudo_compound_is;
+      test_case "canonicalize top-level :is()" `Quick
+        canonicalize_top_level_is_unwrap;
       test_case "parse errors - nesting depth" `Quick parse_errors_nesting_depth;
       test_case "parse errors - empty list" `Quick parse_errors_empty_list;
       test_case "parse errors - complex" `Quick parse_errors_complex;

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -1504,6 +1504,14 @@ let canonicalize_top_level_is_unwrap () =
      matches any of its selectors). *)
   canon "a,m,z" ":is(a,z),m";
   canon "a,m,z" "a,z,m";
+  (* A lone argument shares its own specificity, so the equality holds whatever
+     it is. [canonicalize_is] still holds a type or universal one back, because
+     it cannot see the compound it would land in; at the top of a rule selector
+     there is none. *)
+  canon "a" ":is(a)";
+  canon "*" ":is(*)";
+  canon ".x" ":is(.x)";
+  canon "a" ":is(a,a)";
   (* Unequal specificity: an [a] match weighs (0,0,1) as a list branch and
      (0,1,0) under the wrapper. *)
   canon ":is(.x,a)" ":is(.x,a)";

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -495,7 +495,10 @@ let where_is_cases () =
   (* Test :where() and :is() *)
   check_construct ":where(div)" (where [ element "div" ]);
   check_construct ":where(.a,.b)" (where [ class_ "a"; class_ "b" ]);
-  check_construct "h1,h2" (is_ [ element "h1"; element "h2" ]);
+  (* Splitting an equal-specificity [:is()] into a selector list is a node
+     change reserved for [Selector.canonicalize]; pp is lexical-only and holds
+     the wrapper. *)
+  check_construct ":is(h1,h2)" (is_ [ element "h1"; element "h2" ]);
   check_construct ":not(.active)" (not [ class_ "active" ]);
   ()
 
@@ -541,7 +544,7 @@ let roundtrip () =
     "div.class#id[href]:hover::after";
   check ~expected:".a,.b,.c" ".a, .b, .c";
   check ":where(.a,.b)";
-  check ~expected:"h1,h2,h3" ":is(h1,h2,h3)";
+  check ":is(h1,h2,h3)";
   check ":not(.active)";
 
   (* Escaping roundtrip tests *)
@@ -2816,7 +2819,9 @@ let spec_selector_serialization_invariant_matrix () =
       "::highlight(search-results)";
       "::cue-region(.speaker)";
     ];
-  check_minified_to ".a,.b" ":is(.a, [=bad], .b)";
+  (* Forgiving parsing drops the invalid branch; the split of what is left is
+     [Selector.canonicalize]'s, not pp's. *)
+  check_minified_to ":is(.a,.b)" ":is(.a, [=bad], .b)";
   List.iter
     (fun input -> neg_cursor read input)
     [

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6420,6 +6420,36 @@ let s417_is_unwrap () =
     (normalize ".x .a.b { color: red }")
     (normalize ".x :is(.a):is(.b) { color: red }")
 
+(* CSS Selectors L4 section 4.2 again, at the top of a rule selector: [:is()]
+   takes the specificity of its most specific argument, so equal-specificity
+   arguments make [:is(a, b)] and the selector list [a, b] the same rule. Two
+   rules with the same selector are one rule, and factoring reads selector
+   nodes, so the split has to be an AST rewrite: printed only, the two rules
+   below show one selector, never merge, and a second pass over the output finds
+   the merge the first missed. *)
+let s417_is_unwrap_top_level () =
+  let normalize css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> minify parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let two_rules = ":is(a, b) { color: red } a, b { margin: 0 }" in
+  Alcotest.(check string)
+    ":is(a,b) and a,b are one rule" "a,b{color:red;margin:0}"
+    (normalize two_rules);
+  Alcotest.(check string)
+    "minify is a fixpoint" (normalize two_rules)
+    (normalize (normalize two_rules));
+  (* Unequal specificity, so the list would weigh an [a] match lighter than the
+     wrapper does. *)
+  Alcotest.(check string)
+    ":is(.x,a) keeps its wrapper" ":is(.x,a){color:red}"
+    (normalize ":is(.x, a) { color: red }");
+  (* [:where()] contributes zero specificity, so it never becomes a list. *)
+  Alcotest.(check string)
+    ":where(a,b) keeps its wrapper" ":where(a,b){color:red}"
+    (normalize ":where(a, b) { color: red }")
+
 (* CSS Selectors L4 section 4.2 (compound selector): "if it contains a type
    selector or universal selector, that selector must come first". So a
    single-argument [:is(<type>)] unwraps only into a compound it leads: spliced
@@ -9368,6 +9398,9 @@ let additional_tests =
       `Quick,
       v4107_minmax_reduction );
     ("spec selectors 4 17 :is single-argument unwrap", `Quick, s417_is_unwrap);
+    ( "spec selectors 4 17 :is top-level unwrap",
+      `Quick,
+      s417_is_unwrap_top_level );
     ( "spec selectors 4 4.2 compound type selector first",
       `Quick,
       s442_compound_type_first );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6440,6 +6440,15 @@ let s417_is_unwrap_top_level () =
   Alcotest.(check string)
     "minify is a fixpoint" (normalize two_rules)
     (normalize (normalize two_rules));
+  (* A lone argument has nothing to disagree with, and at the top of a rule
+     selector it is not landing in a compound, so section 3.1 (a type or
+     universal selector comes first in a compound) does not hold it back. *)
+  Alcotest.(check string)
+    ":is(a) unwraps at the top" "a{color:red}"
+    (normalize ":is(a) { color: red }");
+  Alcotest.(check string)
+    ":is(*) unwraps at the top" "*{color:red}"
+    (normalize ":is(*) { color: red }");
   (* Unequal specificity, so the list would weigh an [a] match lighter than the
      wrapper does. *)
   Alcotest.(check string)


### PR DESCRIPTION
The printer rewrote a whole-rule `:is(a, b)` into the selector list `a, b` on its way out, so the split never reached the tree the optimizer works on. Two rules that print the same selector kept distinct nodes and did not factor, which left `--minify` short of its own fixpoint and `--diff=canonical` calling a split list different from the grouped one the README promises it equates. The split runs in `Selector.canonicalize` now, with the rest of the selector normal form.

A whole-rule `:is(a)` or `:is(*)` unwraps too: the node-local rewrite leaves a type or universal argument wrapped because it cannot see the compound it would land in, and a whole rule selector has no compound around it.
