### PR TITLE
Preserve repeating linear gradients with var bodies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,8 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `repeating-linear-gradient(var(...))` now keeps its repeating function name
+  instead of serializing back as a non-repeating linear gradient (#656)
 - A `var()` that supplies the complete body of a radial or conic gradient now
   reads as the exported `Radial_gradient_var` or `Conic_gradient_var` node,
   matching declarations built through those public constructors (#654)

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -1890,6 +1890,8 @@ let read_image_set_body t : background_image =
 let read_repeating_linear_gradient t =
   match Cursor.call "repeating-linear-gradient" t read_linear_gradient_body with
   | Linear_gradient (d, stops) -> Repeating_linear_gradient (d, stops)
+  | Linear_gradient_var v ->
+      Repeating_linear_gradient (Default_direction, [ Var v ])
   | other -> other
 
 let read_repeating_radial_gradient t =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2903,6 +2903,7 @@ let test_background_image () =
      gradient instead. *)
   check_background_image "linear-gradient(red,blue)";
   check_background_image "radial-gradient(red,blue)";
+  check_background_image "repeating-linear-gradient(var(--stops))";
   check_background_image "repeating-radial-gradient(var(--stops))";
   check_background_image "repeating-conic-gradient(var(--stops))";
   check_background_image "-webkit-radial-gradient(var(--stops))";


### PR DESCRIPTION
`repeating-linear-gradient(var(--stops))` was parsed through the standard linear-gradient var-only branch. That branch returned `Linear_gradient_var`, which the repeating adapter passed through unchanged, so serialization silently dropped `repeating-`.

Translate the var-only result to `Repeating_linear_gradient` with the default direction and a single variable stop. The regression test pins the exact roundtrip spelling.