### PR TITLE
Parse invalid font-family lists as typed values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -181,6 +181,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A CSS-wide keyword mixed into a `font-family` list now reads as the exported
+  `font_family.Invalid` node, preserving the source for typed invalid-value
+  recovery instead of raising during property parsing (#657)
 - `repeating-linear-gradient(var(...))` now keeps its repeating function name
   instead of serializing back as a non-repeating linear gradient (#656)
 - A `var()` that supplies the complete body of a radial or conic gradient now

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1465,6 +1465,7 @@ let rec read_font_family_single t : font_family =
   | None -> Cursor.err t "expected font-family value"
 
 and read_font_family t : font_family =
+  let source = Cursor.remaining t in
   (* CSS Cascade 5 sec. 7.3: a CSS-wide keyword ([inherit] / [initial] / [unset]
      / [revert] / [revert-layer]) must stand alone; mixed inside a
      [<custom-ident>#] list it makes the whole declaration invalid. *)
@@ -1485,9 +1486,9 @@ and read_font_family t : font_family =
   | [ x ] -> x
   | _ when List.exists is_css_wide items ->
       (* CSS Cascade 5 sec. 7.3: a CSS-wide keyword must be the sole value; in a
-         [<family-name>#] list it makes the whole declaration invalid. *)
-      Cursor.err_invalid t
-        "font-family: a CSS-wide keyword cannot appear in a family list"
+         [<family-name>#] list it makes the whole declaration invalid. Keep the
+         source for the declaration-level invalid-value recovery pass. *)
+      Invalid source
   | l -> List l
 
 let read_shorthand_line_height_typed r : line_height =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2151,6 +2151,18 @@ let important () =
 
 let invalid () =
   let neg = none_cursor read_declaration in
+  let typed_invalid input =
+    let cursor = Cursor.of_string input in
+    match read_declaration cursor with
+    | Some declaration ->
+        Alcotest.(check bool)
+          (input ^ " is represented as invalid")
+          true
+          (Css.Declaration.is_invalid declaration)
+    | None -> Alcotest.failf "expected a typed invalid declaration for %S" input
+    | exception Error.Parse_error _ ->
+        Alcotest.failf "expected a typed invalid declaration for %S" input
+  in
   (* Unknown property names are syntactically valid declarations. *)
   check_declaration ~expected:"not-a-property:value" "not-a-property: value";
   (* Invalid property names *)
@@ -2167,7 +2179,8 @@ let invalid () =
   neg "font-weight: green";
   neg "font-family: default";
   neg "font-family: system-ui default";
-  neg "font-family: revert-layer, serif";
+  typed_invalid "font-family: Arial, inherit";
+  typed_invalid "font-family: revert-layer, serif";
   neg "font-family: system-ui revert-layer, serif";
 
   (* CSS-wide keywords mixing - should fail when mixed with other values *)
@@ -3580,6 +3593,7 @@ let check_property_positive (row : property_grammar_row) value =
 let check_property_negative (row : property_grammar_row) value =
   match parse_property_decl row.property value with
   | None -> ()
+  | Some (_, _, decl, _) when Css.Declaration.is_invalid decl -> ()
   | Some (input, serialized, _, _) ->
       Alcotest.failf "%s negative vector parsed: %s -> %s" row.property input
         serialized

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2418,6 +2418,13 @@ let test_font_family () =
   check_font_family ~roundtrip:true ~expected:"Foo sans" "\"Foo sans\"";
   check_font_family ~roundtrip:true ~expected:"Times New Roman"
     "\"Times New Roman\"";
+  let invalid = read_font_family (Cursor.of_string "Arial, inherit") in
+  (match invalid with
+  | Invalid tokens ->
+      Alcotest.(check string)
+        "invalid family list source is preserved" "Arial, inherit"
+        (Parser.string_of_components tokens)
+  | _ -> Alcotest.fail "expected an Invalid font-family node");
   (* Test actual invalid cases *)
   neg_cursor read_font_family "123invalid";
   (* identifier can't start with number *)


### PR DESCRIPTION
The public `font_family.Invalid` node documents source-preserving recovery for lists that mix a CSS-wide keyword with family names, but `read_font_family` raised instead. That bypassed the typed invalid-value path entirely.

Capture the original component list and return `Invalid` when a completed family list contains a CSS-wide keyword. Declarations are marked invalid for the existing `drop_invalid` serialization pass; malformed unquoted names still fail parsing.

Tests cover the public constructor, declaration invalid marker, and the generated negative grammar inventory.