### PR TITLE
Remove invalid flex-basis From_font constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- `flex_basis.From_font` is gone. `from-font` is not part of the `<width>`
+  grammar accepted by `flex-basis`; the constructor printed CSS that the
+  `flex-basis` reader correctly rejects (#658)
 - Implementation modules are no longer usable through accidental `Cascade.*`
   aliases: `Baseline`, `Block`, `Common`, `Factor`, `Flatten`, `Inline`,
   `Merge`, `Rule`, `Rule_index`, `Rule_order`, `Shorthand`, `Size`, `Summary`,

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3441,7 +3441,6 @@ type flex_basis = Properties.flex_basis =
   | Fit_content_arg of length
   | Max_content
   | Min_content
-  | From_font
   | Clamp of length * length * length
   | Min of length list
   | Max of length list

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -230,7 +230,6 @@ let rec pp_flex_basis : flex_basis Pp.t =
       Pp.char ctx ')'
   | Max_content -> Pp.string ctx "max-content"
   | Min_content -> Pp.string ctx "min-content"
-  | From_font -> Pp.string ctx "from-font"
   (* Math functions mirror [length]; reuse its printer. *)
   | Clamp (a, b, c) -> pp_length ctx (Clamp (a, b, c))
   | Min xs -> pp_length ctx (Min xs)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -600,7 +600,6 @@ type flex_basis =
   | Fit_content_arg of length
   | Max_content
   | Min_content
-  | From_font
   (* Math functions over [<length-percentage>] (CSS Values 4 sec. 10). Args
      reuse [length] (which already carries [Pct]) and mirror the [length]
      constructors; [flex_basis_of_length] carries them across and the printer

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4558,11 +4558,6 @@ let radial_gradient_var_has_one_node () =
 let conic_gradient_var_has_one_node () =
   gradient_var "conic-gradient" (fun var -> Css.Conic_gradient_var var)
 
-let public_flex_basis_constructor_is_readable () =
-  let constructed = Css.flex_basis (Css.From_font : Css.flex_basis) in
-  let printed = Css.Declaration.to_string ~minify:true constructed in
-  ignore (Css.Declaration.of_string printed : Css.Declaration.declaration)
-
 let nan_has_one_node () =
   (* The keyword and the calculation that lands on NaN are the same value. *)
   let keyword = sole_declaration ".a{opacity:calc(NaN)}" in
@@ -4661,8 +4656,6 @@ let declaration_tests =
       radial_gradient_var_has_one_node;
     test_case "conic gradient var has one node" `Quick
       conic_gradient_var_has_one_node;
-    test_case "public flex-basis constructor is readable" `Quick
-      public_flex_basis_constructor_is_readable;
     test_case "NaN is one declared value" `Quick nan_declaration_is_one_value;
     test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4558,6 +4558,11 @@ let radial_gradient_var_has_one_node () =
 let conic_gradient_var_has_one_node () =
   gradient_var "conic-gradient" (fun var -> Css.Conic_gradient_var var)
 
+let public_flex_basis_constructor_is_readable () =
+  let constructed = Css.flex_basis (Css.From_font : Css.flex_basis) in
+  let printed = Css.Declaration.to_string ~minify:true constructed in
+  ignore (Css.Declaration.of_string printed : Css.Declaration.declaration)
+
 let nan_has_one_node () =
   (* The keyword and the calculation that lands on NaN are the same value. *)
   let keyword = sole_declaration ".a{opacity:calc(NaN)}" in
@@ -4656,6 +4661,8 @@ let declaration_tests =
       radial_gradient_var_has_one_node;
     test_case "conic gradient var has one node" `Quick
       conic_gradient_var_has_one_node;
+    test_case "public flex-basis constructor is readable" `Quick
+      public_flex_basis_constructor_is_readable;
     test_case "NaN is one declared value" `Quick nan_declaration_is_one_value;
     test_case "NaN has one node" `Quick nan_has_one_node;
     test_case "hex spellings have one node" `Quick hex_spellings_have_one_node;


### PR DESCRIPTION
## Summary

- remove the accidental `From_font` branch from the public `flex_basis` type
- keep the spec-valid `from-font` constructors for other properties unchanged
- document the API break

## Why

`flex-basis` accepts `content` or a `<width>`, and `from-font` belongs to neither grammar. The public constructor emitted `flex-basis:from-font`, which Cascade itself correctly rejected when reading the declaration back.

## Testing

- `opam exec -- dune fmt`
- `opam exec -- dune build`
- `opam exec -- merlint --build`
- `env -u NO_COLOR opam exec -- dune test`