### PR TITLE
properties: accept the shorthands whose components are all optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,13 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- The `white-space`, `text-box` and timeline shorthand values carry the
+  longhands their grammars name. `Css.white_space` replaces `Nowrap`,
+  `Break_spaces` and `Preserve_nowrap` with a `Components` record over
+  white-space-collapse, text-wrap-mode and white-space-trim; `Css.text_box`
+  gains `Normal` and its trim is optional; a timeline item carries an optional
+  axis and an optional inset, and `none` is one such item rather than a case of
+  `Css.timeline_shorthand` (#659)
 - Implementation modules are no longer usable through accidental `Cascade.*`
   aliases: `Baseline`, `Block`, `Common`, `Factor`, `Flatten`, `Inline`,
   `Merge`, `Rule`, `Rule_index`, `Rule_order`, `Shorthand`, `Size`, `Summary`,
@@ -181,6 +188,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A shorthand that spells out one component and leaves the rest to their
+  initial values is read rather than dropped. `text-decoration: red`,
+  `white-space: collapse`, `border-image: round`, `mask-border: alpha`,
+  `scroll-timeline: --t`, `view-timeline: --v inline 10%` and `text-box: cap
+  alphabetic` each name a complete value (#659)
 - A declaration whose grammar ends in an optional component is no longer
   dropped over the tail the declaration consumer strips. `font-style: oblique
   !important`, `rotate: 45deg !important`, `text-box: none;` and

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -4538,15 +4538,46 @@ val text_indent : text_indent_value -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent}
      text-indent} property. *)
 
+(** The white-space-collapse values the [white-space] shorthand carries. *)
+type white_space_collapse_keyword = Properties.white_space_collapse_keyword =
+  | Collapse
+  | Discard
+  | Preserve
+  | Preserve_breaks
+  | Preserve_spaces
+  | Break_spaces
+
+(** The text-wrap-mode values the [white-space] shorthand carries. *)
+type text_wrap_mode_keyword = Properties.text_wrap_mode_keyword =
+  | Wrap
+  | No_wrap
+
+(** The white-space-trim discards. *)
+type white_space_trim_keyword = Properties.white_space_trim_keyword =
+  | Before
+  | After
+  | Inner
+
+(** A white-space-trim value. *)
+type white_space_trim = Properties.white_space_trim =
+  | None
+  | Discards of white_space_trim_keyword list
+
+type white_space_components = Properties.white_space_components = {
+  collapse : white_space_collapse_keyword option;
+  wrap : text_wrap_mode_keyword option;
+  trim : white_space_trim option;
+}
+(** The three longhands [white-space] sets, each present only when spelled out.
+*)
+
 (** CSS white-space values *)
 type white_space = Properties.white_space =
   | Normal
-  | Nowrap
   | Pre
   | Pre_wrap
   | Pre_line
-  | Break_spaces
-  | Preserve_nowrap
+  | Components of white_space_components
   | Inherit
   | Initial
   | Unset

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7152,13 +7152,33 @@ type timeline_axis = Properties.timeline_axis =
   | Revert_layer
   | Var of timeline_axis var
 
+(** One end of a [view-timeline-inset]. *)
+type timeline_inset_item = Properties.timeline_inset_item =
+  | Auto
+  | Length of length_percentage
+
+(** CSS view-timeline-inset values *)
+type timeline_inset = Properties.timeline_inset =
+  | Inset of timeline_inset_item * timeline_inset_item option
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of timeline_inset var
+
+(** The name of one [scroll-timeline] or [view-timeline] item. *)
+type timeline_item_name = Properties.timeline_item_name =
+  | None
+  | Name of string
+
 type timeline_shorthand_item = Properties.timeline_shorthand_item = {
-  name : string;
-  axis : timeline_axis;
+  name : timeline_item_name;
+  axis : timeline_axis option;
+  inset : timeline_inset option;
 }
 
 type timeline_shorthand = Properties.timeline_shorthand =
-  | None
   | Timelines of timeline_shorthand_item list
   | Initial
   | Inherit

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1627,7 +1627,8 @@ let read_motion_value : type a. a property -> Cursor.t -> declaration option =
   | View_timeline_name -> Some (v View_timeline_name (read_timeline_name t))
   | View_timeline_axis -> Some (v View_timeline_axis (read_timeline_axis t))
   | View_timeline_inset -> Some (v View_timeline_inset (read_timeline_inset t))
-  | View_timeline -> Some (v View_timeline (read_timeline_shorthand t))
+  | View_timeline ->
+      Some (v View_timeline (read_timeline_shorthand ~inset:true t))
   | Timeline_scope -> Some (v Timeline_scope (read_timeline_name t))
   | Perspective_origin ->
       Some (v Perspective_origin (read_perspective_origin t))

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -325,24 +325,6 @@ let rec pp_timeline_name : timeline_name Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
-let pp_timeline_shorthand_item : timeline_shorthand_item Pp.t =
- fun ctx { name; axis } ->
-  pp_ident ctx name;
-  Pp.space ctx ();
-  pp_timeline_axis ctx axis
-
-let rec pp_timeline_shorthand : timeline_shorthand Pp.t =
- fun ctx -> function
-  | None -> Pp.string ctx "none"
-  | Timelines items ->
-      Pp.list ~sep:Pp.comma pp_timeline_shorthand_item ctx items
-  | Initial -> Pp.string ctx "initial"
-  | Inherit -> Pp.string ctx "inherit"
-  | Unset -> Pp.string ctx "unset"
-  | Revert -> Pp.string ctx "revert"
-  | Revert_layer -> Pp.string ctx "revert-layer"
-  | Var v -> pp_var pp_timeline_shorthand ctx v
-
 let pp_timeline_inset_item : timeline_inset_item Pp.t =
  fun ctx -> function
   | Auto -> Pp.string ctx "auto"
@@ -363,6 +345,36 @@ let rec pp_timeline_inset : timeline_inset Pp.t =
   | Unset -> Pp.string ctx "unset"
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
+
+let pp_timeline_item_name : timeline_item_name Pp.t =
+ fun ctx -> function
+  | None -> Pp.string ctx "none"
+  | Name name -> pp_ident ctx name
+
+let pp_timeline_shorthand_item : timeline_shorthand_item Pp.t =
+ fun ctx { name; axis; inset } ->
+  pp_timeline_item_name ctx name;
+  Option.iter
+    (fun axis ->
+      Pp.space ctx ();
+      pp_timeline_axis ctx axis)
+    axis;
+  Option.iter
+    (fun inset ->
+      Pp.space ctx ();
+      pp_timeline_inset ctx inset)
+    inset
+
+let rec pp_timeline_shorthand : timeline_shorthand Pp.t =
+ fun ctx -> function
+  | Timelines items ->
+      Pp.list ~sep:Pp.comma pp_timeline_shorthand_item ctx items
+  | Initial -> Pp.string ctx "initial"
+  | Inherit -> Pp.string ctx "inherit"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_timeline_shorthand ctx v
 
 let pp_timing_float ctx f =
   if Float.is_nan f then Pp.nan_value ctx ""
@@ -663,32 +675,6 @@ let rec read_timeline_name t : timeline_name =
         : timeline_name))
     t
 
-let read_timeline_shorthand_item t : timeline_shorthand_item =
-  Cursor.ws t;
-  let name = Cursor.ident ~keep_case:true t in
-  if not (Custom_property_name.is_valid name) then
-    Cursor.err_invalid t "timeline name";
-  Cursor.ws t;
-  let axis = read_timeline_axis t in
-  { name; axis }
-
-let rec read_timeline_shorthand t : timeline_shorthand =
-  Cursor.enum_or_var "timeline"
-    [
-      ("none", (None : timeline_shorthand));
-      ("initial", Initial);
-      ("inherit", Inherit);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-    ]
-    ~var:(fun t -> Var (Values.read_var read_timeline_shorthand t))
-    ~default:(fun t ->
-      Timelines
-        (Cursor.list ~sep:Cursor.comma ~at_least:1 read_timeline_shorthand_item
-           t))
-    t
-
 let read_timeline_inset_item t : timeline_inset_item =
   Cursor.enum "timeline-inset item"
     [ ("auto", (Auto : timeline_inset_item)) ]
@@ -697,6 +683,12 @@ let read_timeline_inset_item t : timeline_inset_item =
          (read_length_percentage ~allow_negative:false ~with_keywords:false t)
         : timeline_inset_item))
     t
+
+let read_timeline_inset_pair t : timeline_inset =
+  match Cursor.list ~at_least:1 ~at_most:2 read_timeline_inset_item t with
+  | [ first ] -> (Inset (first, None) : timeline_inset)
+  | [ first; second ] -> (Inset (first, Some second) : timeline_inset)
+  | _ -> Cursor.err_expected t "timeline-inset"
 
 let rec read_timeline_inset t : timeline_inset =
   Cursor.enum_or_var "timeline-inset"
@@ -709,11 +701,65 @@ let rec read_timeline_inset t : timeline_inset =
     ]
     ~var:(fun t ->
       (Var (Values.read_var read_timeline_inset t) : timeline_inset))
+    ~default:read_timeline_inset_pair t
+
+let read_timeline_axis_keyword t : timeline_axis =
+  Cursor.enum "timeline-axis"
+    [
+      ("block", (Block : timeline_axis));
+      ("inline", (Inline : timeline_axis));
+      ("x", (X : timeline_axis));
+      ("y", (Y : timeline_axis));
+    ]
+    t
+
+let read_timeline_item_name t : timeline_item_name =
+  Cursor.enum "timeline name"
+    [ ("none", (None : timeline_item_name)) ]
     ~default:(fun t ->
-      match Cursor.list ~at_least:1 ~at_most:2 read_timeline_inset_item t with
-      | [ first ] -> (Inset (first, None) : timeline_inset)
-      | [ first; second ] -> (Inset (first, Some second) : timeline_inset)
-      | _ -> Cursor.err_expected t "timeline-inset")
+      let name = Cursor.ident ~keep_case:true t in
+      if not (Custom_property_name.is_valid name) then
+        Cursor.err_invalid t "timeline name";
+      (Name name : timeline_item_name))
+    t
+
+(* Scroll-driven Animations 1 (ED) sec. 2.3.3 gives [scroll-timeline] items
+   [<'scroll-timeline-name'> <'scroll-timeline-axis'>?] and sec. 3.4.4 gives
+   [view-timeline] items [<'view-timeline-name'> [ <'view-timeline-axis'> ||
+   <'view-timeline-inset'> ]?]. The name is the only mandatory part, and the
+   inset slot is view-timeline's alone. *)
+let read_timeline_shorthand_item ?(inset = false) t : timeline_shorthand_item =
+  Cursor.ws t;
+  let name = read_timeline_item_name t in
+  Cursor.ws t;
+  let axis = Cursor.option read_timeline_axis_keyword t in
+  Cursor.ws t;
+  let inset =
+    if inset then Cursor.option read_timeline_inset_pair t else Option.None
+  in
+  Cursor.ws t;
+  let axis =
+    match axis with
+    | Some _ -> axis
+    | None -> Cursor.option read_timeline_axis_keyword t
+  in
+  { name; axis; inset }
+
+let rec read_timeline_shorthand ?(inset = false) t : timeline_shorthand =
+  Cursor.enum_or_var "timeline"
+    [
+      ("initial", (Initial : timeline_shorthand));
+      ("inherit", Inherit);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (Values.read_var (read_timeline_shorthand ~inset) t))
+    ~default:(fun t ->
+      Timelines
+        (Cursor.list ~sep:Cursor.comma ~at_least:1
+           (read_timeline_shorthand_item ~inset)
+           t))
     t
 
 let read_steps_direction t : steps_direction =

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1155,10 +1155,18 @@ let pp_border_image : border_image Pp.t =
 (* CSS Masking 1 (ED) sec. 8.2 gives mask-border-mode the initial value [alpha],
    and sec. 8.7 sets an omitted shorthand slot to its initial value, so an
    explicit [alpha] declares what leaving the slot out declares. [luminance] is
-   the other mode and stays. *)
+   the other mode and stays, and so does an [alpha] that is the only slot filled
+   in: with nothing left the value would serialize empty. *)
 let normalize_mask_border (value : border_image) : border_image =
+  let fills_another_slot =
+    Option.is_some value.source
+    || Option.is_some value.slice || Option.is_some value.width
+    || Option.is_some value.outset
+    || Option.is_some value.repeat
+  in
   match value.mode with
-  | Some (Alpha : mask_border_mode) -> { value with mode = Option.None }
+  | Some (Alpha : mask_border_mode) when fills_another_slot ->
+      { value with mode = Option.None }
   | _ -> value
 
 let pp_background_shorthand : background_shorthand Pp.t =
@@ -2176,7 +2184,10 @@ let read_border_image t : border_image =
     else Cursor.option read_mask_border_mode t
   in
   let mode = match mode_early with Some _ -> mode_early | None -> mode_late in
-  (match (source, slice) with
-  | None, None -> Cursor.err_expected t "border-image source or slice"
+  (* css-backgrounds-3 sec. 5.7 joins source, slice and repeat with [||] (CSS
+     Masking 1 sec. 8.7 adds the mode), so any one of them makes a value; only
+     an empty one is invalid. *)
+  (match (source, slice, repeat, mode) with
+  | None, None, None, None -> Cursor.err_expected t "border-image"
   | _ -> ());
   { source; slice; width; outset; repeat; mode }

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1291,16 +1291,60 @@ let rec pp_ruby_position : ruby_position Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_ruby_position ctx v
 
+let pp_white_space_collapse_keyword : white_space_collapse_keyword Pp.t =
+ fun ctx -> function
+  | Collapse -> Pp.string ctx "collapse"
+  | Discard -> Pp.string ctx "discard"
+  | Preserve -> Pp.string ctx "preserve"
+  | Preserve_breaks -> Pp.string ctx "preserve-breaks"
+  | Preserve_spaces -> Pp.string ctx "preserve-spaces"
+  | Break_spaces -> Pp.string ctx "break-spaces"
+
+let pp_text_wrap_mode_keyword : text_wrap_mode_keyword Pp.t =
+ fun ctx -> function
+  | Wrap -> Pp.string ctx "wrap"
+  | No_wrap -> Pp.string ctx "nowrap"
+
+let pp_white_space_trim_keyword : white_space_trim_keyword Pp.t =
+ fun ctx -> function
+  | Before -> Pp.string ctx "discard-before"
+  | After -> Pp.string ctx "discard-after"
+  | Inner -> Pp.string ctx "discard-inner"
+
+let pp_white_space_trim : white_space_trim Pp.t =
+ fun ctx -> function
+  | None -> Pp.string ctx "none"
+  | Discards keywords ->
+      Pp.list ~sep:Pp.space pp_white_space_trim_keyword ctx keywords
+
+let pp_white_space_components : white_space_components Pp.t =
+ fun ctx { collapse; wrap; trim } ->
+  let first = ref true in
+  let sep () = if !first then first := false else Pp.space ctx () in
+  Option.iter
+    (fun c ->
+      sep ();
+      pp_white_space_collapse_keyword ctx c)
+    collapse;
+  Option.iter
+    (fun w ->
+      sep ();
+      pp_text_wrap_mode_keyword ctx w)
+    wrap;
+  Option.iter
+    (fun t ->
+      sep ();
+      pp_white_space_trim ctx t)
+    trim
+
 let rec pp_white_space : white_space Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_white_space ctx v
   | Normal -> Pp.string ctx "normal"
-  | Nowrap -> Pp.string ctx "nowrap"
   | Pre -> Pp.string ctx "pre"
   | Pre_wrap -> Pp.string ctx "pre-wrap"
   | Pre_line -> Pp.string ctx "pre-line"
-  | Break_spaces -> Pp.string ctx "break-spaces"
-  | Preserve_nowrap -> Pp.string ctx "preserve nowrap"
+  | Components components -> pp_white_space_components ctx components
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -1768,31 +1812,122 @@ let rec read_hyphenate_limit_chars t : hyphenate_limit_chars =
     ~calls:[ ("var", fun t -> Var (read_var read_hyphenate_limit_chars t)) ]
     ~default:read_counts t
 
+let read_white_space_collapse_keyword t : white_space_collapse_keyword =
+  Cursor.enum "white-space-collapse"
+    [
+      ("collapse", (Collapse : white_space_collapse_keyword));
+      ("discard", Discard);
+      ("preserve", Preserve);
+      ("preserve-breaks", Preserve_breaks);
+      ("preserve-spaces", Preserve_spaces);
+      ("break-spaces", Break_spaces);
+    ]
+    t
+
+let read_text_wrap_mode_keyword t : text_wrap_mode_keyword =
+  Cursor.enum "text-wrap-mode"
+    [ ("wrap", (Wrap : text_wrap_mode_keyword)); ("nowrap", No_wrap) ]
+    t
+
+let read_white_space_trim_keyword t : white_space_trim_keyword =
+  Cursor.enum "white-space-trim"
+    [
+      ("discard-before", (Before : white_space_trim_keyword));
+      ("discard-after", After);
+      ("discard-inner", Inner);
+    ]
+    t
+
+(* css-text-4 (ED) sec. 3: [white-space-trim] is [none | discard-before ||
+   discard-after || discard-inner], so the discards form one run and each names
+   itself at most once. *)
+let rank_white_space_trim_keyword : white_space_trim_keyword -> int = function
+  | Before -> 0
+  | After -> 1
+  | Inner -> 2
+
+let read_white_space_trim t : white_space_trim =
+  Cursor.enum "white-space-trim"
+    [ ("none", (None : white_space_trim)) ]
+    ~default:(fun t ->
+      let keywords =
+        Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:3
+          read_white_space_trim_keyword t
+      in
+      let distinct =
+        List.sort_uniq
+          (fun a b ->
+            Int.compare
+              (rank_white_space_trim_keyword a)
+              (rank_white_space_trim_keyword b))
+          keywords
+      in
+      if List.compare_lengths distinct keywords <> 0 then
+        Cursor.err_invalid t "white-space-trim";
+      (Discards keywords : white_space_trim))
+    t
+
+(* css-text-4 (ED) sec. 3: [normal | pre | pre-wrap | pre-line |
+   <'white-space-collapse'> || <'text-wrap-mode'> || <'white-space-trim'>]. The
+   [||] binds tighter than the [|], so the last three longhands are one group:
+   each stands alone, in any order, and any left out takes its initial value. *)
+module White_space = struct
+  type component =
+    | Collapse_slot of white_space_collapse_keyword
+    | Wrap_slot of text_wrap_mode_keyword
+    | Trim_slot of white_space_trim
+
+  let empty = { collapse = Option.None; wrap = Option.None; trim = Option.None }
+
+  let read_component t =
+    Cursor.one_of
+      [
+        (fun t -> Collapse_slot (read_white_space_collapse_keyword t));
+        (fun t -> Wrap_slot (read_text_wrap_mode_keyword t));
+        (fun t -> Trim_slot (read_white_space_trim t));
+      ]
+      t
+
+  let merge t acc = function
+    | Collapse_slot c when Option.is_none acc.collapse ->
+        { acc with collapse = Option.Some c }
+    | Wrap_slot w when Option.is_none acc.wrap ->
+        { acc with wrap = Option.Some w }
+    | Trim_slot tr when Option.is_none acc.trim ->
+        { acc with trim = Option.Some tr }
+    | Collapse_slot _ -> Cursor.err t "duplicate white-space-collapse"
+    | Wrap_slot _ -> Cursor.err t "duplicate text-wrap-mode"
+    | Trim_slot _ -> Cursor.err t "duplicate white-space-trim"
+end
+
+let read_white_space_components t : white_space_components =
+  let components, _ =
+    Cursor.fold_many White_space.read_component ~init:White_space.empty
+      ~f:(White_space.merge t) t
+  in
+  if
+    Option.is_none components.collapse
+    && Option.is_none components.wrap
+    && Option.is_none components.trim
+  then Cursor.err_expected t "white-space";
+  components
+
 let rec read_white_space t : white_space =
-  Cursor.ws t;
-  match Cursor.peek_ident t with
-  | Some "preserve" ->
-      ignore (Cursor.ident t : string);
-      Cursor.ws t;
-      Cursor.expect_string "nowrap" t;
-      Preserve_nowrap
-  | _ ->
-      Cursor.enum_or_var "white-space"
-        [
-          ("normal", (Normal : white_space));
-          ("nowrap", Nowrap);
-          ("pre", Pre);
-          ("pre-wrap", Pre_wrap);
-          ("pre-line", Pre_line);
-          ("break-spaces", Break_spaces);
-          ("inherit", Inherit);
-          ("initial", Initial);
-          ("unset", Unset);
-          ("revert", Revert);
-          ("revert-layer", Revert_layer);
-        ]
-        ~var:(fun t -> Var (read_var read_white_space t))
-        t
+  Cursor.enum_or_var "white-space"
+    [
+      ("normal", (Normal : white_space));
+      ("pre", Pre);
+      ("pre-wrap", Pre_wrap);
+      ("pre-line", Pre_line);
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (read_var read_white_space t))
+    ~default:(fun t -> Components (read_white_space_components t))
+    t
 
 let rec read_word_break t : word_break =
   Cursor.enum_or_var "word-break"

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -174,12 +174,12 @@ let rec read_text_decoration t : text_decoration =
     ~calls:[ ("var", read_var) ]
     ~default:(fun t ->
       let shorthand = read_text_decoration_shorthand t in
-      (* For the main text-decoration property, require at least one line
-         decoration *)
-      if shorthand.lines = [] then
-        Cursor.err t
-          "text-decoration requires at least one line decoration (underline, \
-           overline, or line-through)"
+      (* css-text-decor-4 sec. 2.6 joins the four components with [||], so any
+         single one of them stands alone; only an empty value is invalid. *)
+      if
+        shorthand.lines = [] && shorthand.style = None && shorthand.color = None
+        && shorthand.thickness = None
+      then Cursor.err_expected t "text-decoration"
       else (Shorthand shorthand : text_decoration))
     t
 
@@ -755,7 +755,8 @@ let normalize_text_indent : text_indent_value -> text_indent_value =
    line, thickness, style and colour longhands, and "Omitted values are set to
    their initial values" - [solid] (sec. 2.2) and [currentcolor] (sec. 2.3).
    Writing an initial out names what leaving it out names, and leaving it out is
-   the shorter spelling. *)
+   the shorter spelling. The last component has to stay: a value with nothing
+   left in it serializes to an empty declaration, which names nothing at all. *)
 let normalize_text_decoration ?(lossless = false) :
     text_decoration -> text_decoration =
  fun value ->
@@ -771,7 +772,10 @@ let normalize_text_decoration ?(lossless = false) :
           ~is_default:(fun (c : Values.color) -> c = Values.Current)
           (option_map_preserve (normalize_color ~lossless) s.color)
       in
-      if option_is_phys_same style s.style && option_is_phys_same color s.color
+      if
+        (s.lines = [] && style = None && color = None && s.thickness = None)
+        || option_is_phys_same style s.style
+           && option_is_phys_same color s.color
       then value
       else Shorthand { s with style; color }
   | other -> other

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1106,11 +1106,18 @@ let rec pp_text_box_edge : text_box_edge Pp.t =
 let rec pp_text_box : text_box Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_text_box ctx v
+  | Normal -> Pp.string ctx "normal"
   | Box (trim, edge) ->
-      pp_text_box_trim ctx trim;
+      let first = ref true in
+      let sep () = if !first then first := false else Pp.space ctx () in
+      Option.iter
+        (fun trim ->
+          sep ();
+          pp_text_box_trim ctx trim)
+        trim;
       Option.iter
         (fun edge ->
-          Pp.space ctx ();
+          sep ();
           pp_text_box_edge ctx edge)
         edge
   | Initial -> Pp.string ctx "initial"
@@ -1499,6 +1506,16 @@ let rec read_text_wrap_style t : text_wrap_style =
     ~var:(fun t -> Var (read_var read_text_wrap_style t))
     t
 
+let read_text_box_trim_keyword t : text_box_trim =
+  Cursor.enum "text-box-trim"
+    [
+      ("none", (None : text_box_trim));
+      ("trim-start", Trim_start);
+      ("trim-end", Trim_end);
+      ("trim-both", Trim_both);
+    ]
+    t
+
 let rec read_text_box_trim t : text_box_trim =
   Cursor.enum_or_var "text-box-trim"
     [
@@ -1555,10 +1572,14 @@ let rec read_text_box_edge ?(global = true) t : text_box_edge =
         (Var (Values.read_var read_text_box_edge t) : text_box_edge))
       ~default:read_text_box_edge_value t
 
+(* css-inline-3 (ED) sec. 6.1: [normal | <'text-box-trim'> ||
+   <'text-box-edge'>]. Either slot may be left out, in either order, and
+   omitting the trim sets it to [trim-both] rather than to its initial value. *)
 let rec read_text_box t : text_box =
   Cursor.enum_or_var "text-box"
     [
-      ("initial", (Initial : text_box));
+      ("normal", (Normal : text_box));
+      ("initial", Initial);
       ("inherit", Inherit);
       ("unset", Unset);
       ("revert", Revert);
@@ -1566,13 +1587,18 @@ let rec read_text_box t : text_box =
     ]
     ~var:(fun t -> (Var (Values.read_var read_text_box t) : text_box))
     ~default:(fun t ->
-      let trim = read_text_box_trim t in
+      let trim = Cursor.option read_text_box_trim_keyword t in
       Cursor.ws t;
-      let edge : text_box_edge option =
-        if Cursor.is_done t then None
-        else Some (read_text_box_edge ~global:false t)
+      let edge = Cursor.option (read_text_box_edge ~global:false) t in
+      Cursor.ws t;
+      let trim =
+        match trim with
+        | Some _ -> trim
+        | None -> Cursor.option read_text_box_trim_keyword t
       in
-      (Box (trim, edge) : text_box))
+      match (trim, edge) with
+      | None, None -> Cursor.err_expected t "text-box"
+      | _ -> (Box (trim, edge) : text_box))
     t
 
 let read_line_fit_edge_keyword t : line_fit_edge_keyword =

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1081,6 +1081,40 @@ val pp_initial_letter : initial_letter Pp.t
 val pp_text_size_adjust : text_size_adjust Pp.t
 (** [pp_text_size_adjust] pretty-prints a text-size-adjust value. *)
 
+val pp_white_space_collapse_keyword : white_space_collapse_keyword Pp.t
+(** [pp_white_space_collapse_keyword] pretty-prints a white-space-collapse
+    keyword. *)
+
+val read_white_space_collapse_keyword : Cursor.t -> white_space_collapse_keyword
+(** [read_white_space_collapse_keyword t] parses a white-space-collapse keyword.
+*)
+
+val pp_text_wrap_mode_keyword : text_wrap_mode_keyword Pp.t
+(** [pp_text_wrap_mode_keyword] pretty-prints a text-wrap-mode keyword. *)
+
+val read_text_wrap_mode_keyword : Cursor.t -> text_wrap_mode_keyword
+(** [read_text_wrap_mode_keyword t] parses a text-wrap-mode keyword. *)
+
+val pp_white_space_trim_keyword : white_space_trim_keyword Pp.t
+(** [pp_white_space_trim_keyword] pretty-prints one white-space-trim discard. *)
+
+val read_white_space_trim_keyword : Cursor.t -> white_space_trim_keyword
+(** [read_white_space_trim_keyword t] parses one white-space-trim discard. *)
+
+val pp_white_space_trim : white_space_trim Pp.t
+(** [pp_white_space_trim] pretty-prints a white-space-trim value. *)
+
+val read_white_space_trim : Cursor.t -> white_space_trim
+(** [read_white_space_trim t] parses a white-space-trim value. *)
+
+val pp_white_space_components : white_space_components Pp.t
+(** [pp_white_space_components] pretty-prints the longhands [white-space] spells
+    out, in grammar order. *)
+
+val read_white_space_components : Cursor.t -> white_space_components
+(** [read_white_space_components t] parses the [||] group of
+    white-space-collapse, text-wrap-mode and white-space-trim. *)
+
 val pp_white_space : white_space Pp.t
 (** [pp_white_space] is the pretty-printer for [white_space]. *)
 

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -133,8 +133,17 @@ val pp_shadow : shadow Pp.t
 val read_shadow : Cursor.t -> shadow
 (** [read_shadow t] parses a {!val-shadow} value from [t]. *)
 
-val read_timeline_shorthand : Cursor.t -> timeline_shorthand
-(** [read_timeline_shorthand t] parses [scroll-timeline] and [view-timeline]. *)
+val pp_timeline_item_name : timeline_item_name Pp.t
+(** [pp_timeline_item_name] pretty-prints the name of one [scroll-timeline] or
+    [view-timeline] item. *)
+
+val read_timeline_item_name : Cursor.t -> timeline_item_name
+(** [read_timeline_item_name t] parses [none] or a dashed ident. *)
+
+val read_timeline_shorthand : ?inset:bool -> Cursor.t -> timeline_shorthand
+(** [read_timeline_shorthand ?inset t] parses [scroll-timeline] and, with
+    [inset] set, [view-timeline], whose items carry an inset the
+    [scroll-timeline] grammar has no slot for. *)
 
 val pp_timeline_shorthand : timeline_shorthand Pp.t
 (** [pp_timeline_shorthand] pretty-prints [scroll-timeline] and [view-timeline]
@@ -294,7 +303,8 @@ val pp_timeline_shorthand_item : timeline_shorthand_item Pp.t
 (** [pp_timeline_shorthand_item] pretty-prints one [scroll-timeline]/
     [view-timeline] shorthand item. *)
 
-val read_timeline_shorthand_item : Cursor.t -> timeline_shorthand_item
+val read_timeline_shorthand_item :
+  ?inset:bool -> Cursor.t -> timeline_shorthand_item
 (** [read_timeline_shorthand_item t] parses one [scroll-timeline]/
     [view-timeline] shorthand item. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1340,7 +1340,8 @@ type text_box_edge =
   | Var of text_box_edge var
 
 type text_box =
-  | Box of text_box_trim * text_box_edge option
+  | Normal
+  | Box of text_box_trim option * text_box_edge option
   | Inherit
   | Initial
   | Unset

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3897,18 +3897,6 @@ type timeline_name =
   | Revert_layer
   | Var of timeline_name var
 
-type timeline_shorthand_item = { name : string; axis : timeline_axis }
-
-type timeline_shorthand =
-  | None
-  | Timelines of timeline_shorthand_item list
-  | Initial
-  | Inherit
-  | Unset
-  | Revert
-  | Revert_layer
-  | Var of timeline_shorthand var
-
 type timeline_inset_item = Auto | Length of length_percentage
 
 type timeline_inset =
@@ -3919,6 +3907,23 @@ type timeline_inset =
   | Revert
   | Revert_layer
   | Var of timeline_inset var
+
+type timeline_item_name = None | Name of string
+
+type timeline_shorthand_item = {
+  name : timeline_item_name;
+  axis : timeline_axis option;
+  inset : timeline_inset option;
+}
+
+type timeline_shorthand =
+  | Timelines of timeline_shorthand_item list
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of timeline_shorthand var
 
 type overscroll_behavior =
   | Auto

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1527,14 +1527,30 @@ type dominant_baseline =
   | Revert_layer
   | Var of dominant_baseline var
 
+type white_space_collapse_keyword =
+  | Collapse
+  | Discard
+  | Preserve
+  | Preserve_breaks
+  | Preserve_spaces
+  | Break_spaces
+
+type text_wrap_mode_keyword = Wrap | No_wrap
+type white_space_trim_keyword = Before | After | Inner
+type white_space_trim = None | Discards of white_space_trim_keyword list
+
+type white_space_components = {
+  collapse : white_space_collapse_keyword option;
+  wrap : text_wrap_mode_keyword option;
+  trim : white_space_trim option;
+}
+
 type white_space =
   | Normal
-  | Nowrap
   | Pre
   | Pre_wrap
   | Pre_line
-  | Break_spaces
-  | Preserve_nowrap
+  | Components of white_space_components
   | Inherit
   | Initial
   | Unset

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1272,9 +1272,9 @@ let vars_of_text_box (value : Properties.text_box) =
   match value with
   | Var v -> [ V v ]
   | Box (trim, edge) ->
-      vars_of_text_box_trim trim
+      Option.value ~default:[] (Option.map vars_of_text_box_trim trim)
       @ Option.value ~default:[] (Option.map vars_of_text_box_edge edge)
-  | Initial | Inherit | Unset | Revert | Revert_layer -> []
+  | Normal | Initial | Inherit | Unset | Revert | Revert_layer -> []
 
 let vars_of_inline_sizing (value : Properties.inline_sizing) =
   match value with Var v -> [ V v ] | _ -> []

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1708,15 +1708,6 @@ let vars_of_timeline_axis (value : Properties.timeline_axis) =
 let vars_of_timeline_name (value : Properties.timeline_name) =
   match value with Var v -> [ V v ] | _ -> []
 
-let vars_of_timeline_shorthand (value : Properties.timeline_shorthand) =
-  match value with
-  | Var v -> [ V v ]
-  | Timelines items ->
-      List.concat_map
-        (fun { Properties.axis; _ } -> vars_of_timeline_axis axis)
-        items
-  | _ -> []
-
 let vars_of_timeline_inset_item (value : Properties.timeline_inset_item) =
   match value with Auto -> [] | Length lp -> vars_of_length_percentage lp
 
@@ -1727,6 +1718,17 @@ let vars_of_timeline_inset (value : Properties.timeline_inset) =
       vars_of_timeline_inset_item first
       @ Option.value ~default:[] (Option.map vars_of_timeline_inset_item second)
   | Initial | Inherit | Unset | Revert | Revert_layer -> []
+
+let vars_of_timeline_shorthand (value : Properties.timeline_shorthand) =
+  match value with
+  | Var v -> [ V v ]
+  | Timelines items ->
+      List.concat_map
+        (fun { Properties.axis; inset; _ } ->
+          Option.value ~default:[] (Option.map vars_of_timeline_axis axis)
+          @ Option.value ~default:[] (Option.map vars_of_timeline_inset inset))
+        items
+  | _ -> []
 
 let vars_of_direction (value : Properties.direction) =
   match value with Var v -> [ V v ] | _ -> []

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1683,7 +1683,16 @@ let matrix =
       {
         property = "mask-border";
         positives =
-          [ "none"; "url(mask.svg) 30 fill"; "url(mask.svg) 30 / 10px" ];
+          [
+            "none";
+            "url(mask.svg) 30 fill";
+            "url(mask.svg) 30 / 10px";
+            (* CSS Masking 1 sec. 8.7 joins the slots with [||], so the repeat
+               or the mode alone is a complete value. *)
+            "round";
+            "alpha";
+            "luminance";
+          ];
         negatives = [ "fill fill"; "fill fill fill" ];
       };
       {

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -891,8 +891,28 @@ let matrix =
       };
       {
         property = "text-box";
-        positives = [ "none"; "trim-both cap alphabetic"; "trim-start text" ];
-        negatives = [ "cap trim-both"; "trim-start cap alphabetic text" ];
+        positives =
+          [
+            "none";
+            "normal";
+            "trim-both cap alphabetic";
+            "trim-start text";
+            (* css-inline-3 sec. 6.1 joins trim and edge with [||], and omitting
+               the trim sets it to trim-both, so the edge alone is a complete
+               value. *)
+            "text";
+            "cap alphabetic";
+            "ex text";
+          ];
+        negatives =
+          [
+            "cap trim-both";
+            "trim-start cap alphabetic text";
+            "trim-start trim-end";
+            (* [cap] is only in the two-value branch of <text-edge> (sec. 5.2),
+               so it names no edge on its own. *)
+            "cap";
+          ];
       };
       {
         property = "text-box-edge";

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1693,6 +1693,12 @@ let matrix =
             "none";
             "linear-gradient(red, blue) 30";
             "linear-gradient(red, blue) 30 fill / 10px / 1 stretch";
+            (* css-backgrounds-3 sec. 5.7 joins source, slice and repeat with
+               [||] and sets omitted values to their initial values, so the
+               repeat alone is a complete value. *)
+            "round";
+            "stretch";
+            "round space";
           ];
         negatives = [ "none none"; "linear-gradient(red, blue) fill fill" ];
       };

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -275,8 +275,39 @@ let matrix =
     };
     {
       property = "white-space";
-      positives = [ "normal"; "pre"; "preserve nowrap" ];
-      negatives = [ "pre normal"; "wrap nowrap preserve" ];
+      positives =
+        [
+          "normal";
+          "pre";
+          "pre-wrap";
+          "pre-line";
+          "nowrap";
+          "break-spaces";
+          "preserve nowrap";
+          (* css-text-4 sec. 3 makes the last four alternatives one [||] group
+             over white-space-collapse, text-wrap-mode and white-space-trim, so
+             any one of the three alone is a complete value. *)
+          "collapse";
+          "preserve";
+          "preserve-breaks";
+          "wrap";
+          "discard-before";
+          (* [none] is white-space-trim's own first alternative. *)
+          "none";
+          "collapse wrap";
+          "discard-before discard-after";
+          "preserve nowrap discard-inner";
+        ];
+      negatives =
+        [
+          "pre normal";
+          "wrap nowrap preserve";
+          "collapse preserve";
+          "discard-before discard-before";
+          (* text-wrap-style is not in the shorthand. *)
+          "balance";
+          "collapse balance";
+        ];
     };
     {
       property = "word-break";

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -253,7 +253,18 @@ let matrix =
     };
     {
       property = "text-decoration";
-      positives = [ "underline"; "underline wavy red 2px" ];
+      positives =
+        [
+          "underline";
+          "underline wavy red 2px";
+          (* css-text-decor-4 sec. 2.6 combines the four components with [||],
+             so any one of them alone is a complete value. *)
+          "red";
+          "solid";
+          "2px";
+          "solid red";
+          "wavy 1px red";
+        ];
       negatives = [ "underline none"; "wavy solid" ];
     };
     {

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1590,8 +1590,27 @@ let matrix =
       };
       {
         property = "scroll-timeline";
-        positives = [ "none"; "--scroller block"; "--x x, --y y" ];
-        negatives = [ "block --scroller"; "--a --b" ];
+        positives =
+          [
+            "none";
+            "--scroller block";
+            "--x x, --y y";
+            (* scroll-animations-1 sec. 2.3.3 is [[ <'scroll-timeline-name'>
+               <'scroll-timeline-axis'>? ]#], so the axis is optional and each
+               name may be [none]. *)
+            "--t";
+            "--x, --y";
+            "none block";
+          ];
+        negatives =
+          [
+            "block --scroller";
+            "--a --b";
+            (* The name is not optional. *)
+            "inline";
+            (* The inset belongs to view-timeline only. *)
+            "--t 10%";
+          ];
       };
       {
         property = "scroll-timeline-name";
@@ -1605,8 +1624,28 @@ let matrix =
       };
       {
         property = "view-timeline";
-        positives = [ "none"; "--reveal inline"; "--x x, --y y" ];
-        negatives = [ "inline --reveal"; "--a --b" ];
+        positives =
+          [
+            "none";
+            "--reveal inline";
+            "--x x, --y y";
+            (* scroll-animations-1 sec. 3.4.4 is [[ <'view-timeline-name'> [
+               <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#]. *)
+            "--v";
+            "--x, --y";
+            "none block";
+            "--v auto";
+            "--v inline 10%";
+            "--v 10px 20px";
+          ];
+        negatives =
+          [
+            "inline --reveal";
+            "--a --b";
+            (* The name is not optional. *)
+            "inline";
+            "10%";
+          ];
       };
       {
         property = "view-timeline-name";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -915,6 +915,12 @@ let text_properties () =
     "text-decoration: underline dotted";
   check_declaration ~expected:"text-decoration:underline red"
     ~optimized:"text-decoration:underline red" "text-decoration: underline red";
+  (* CSS Masking 1 (ED) sec. 8.2 makes [alpha] the initial mask-border-mode, so
+     it folds away next to another slot but stays when it is the only one. *)
+  check_declaration ~expected:"mask-border:url(m.svg)30 alpha"
+    ~optimized:"mask-border:url(m.svg)30" "mask-border: url(m.svg) 30 alpha";
+  check_declaration ~expected:"mask-border:alpha" ~optimized:"mask-border:alpha"
+    "mask-border: alpha";
   (* An initial that is the only component stays: with nothing left to name the
      longhands it resets, the declaration would serialize to an empty value. *)
   check_declaration ~expected:"text-decoration:solid"

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -915,6 +915,12 @@ let text_properties () =
     "text-decoration: underline dotted";
   check_declaration ~expected:"text-decoration:underline red"
     ~optimized:"text-decoration:underline red" "text-decoration: underline red";
+  (* An initial that is the only component stays: with nothing left to name the
+     longhands it resets, the declaration would serialize to an empty value. *)
+  check_declaration ~expected:"text-decoration:solid"
+    ~optimized:"text-decoration:solid" "text-decoration: solid";
+  check_declaration ~expected:"text-decoration:currentColor"
+    ~optimized:"text-decoration:currentColor" "text-decoration: currentcolor";
 
   (* Text transform *)
   check_declaration ~expected:"text-transform:none" "text-transform: none";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1479,13 +1479,34 @@ let test_white_space () =
   check_white_space "pre-line";
   check_white_space "break-spaces";
   check_white_space "inherit";
+  check_white_space "preserve nowrap";
+  (* css-text-4 sec. 3: the tail of the propdef is one [||] group over
+     white-space-collapse, text-wrap-mode and white-space-trim, so each of the
+     three stands alone and the group takes them in any order. *)
+  check_white_space ~roundtrip:true "collapse";
+  check_white_space ~roundtrip:true "preserve";
+  check_white_space ~roundtrip:true "preserve-breaks";
+  check_white_space ~roundtrip:true "preserve-spaces";
+  check_white_space ~roundtrip:true "discard";
+  check_white_space ~roundtrip:true "wrap";
+  check_white_space ~roundtrip:true "discard-before";
+  (* [none] is white-space-trim's own first alternative. *)
+  check_white_space ~roundtrip:true "none";
+  check_white_space ~roundtrip:true "collapse wrap";
+  check_white_space ~roundtrip:true ~expected:"collapse wrap" "wrap collapse";
+  check_white_space ~roundtrip:true "discard-before discard-after";
+  check_white_space ~roundtrip:true "preserve nowrap discard-inner";
   neg_cursor read_white_space "invalid-space";
   (* hyphenated form incorrect *)
   neg_cursor read_white_space "no-wrap";
   (* contradictory *)
   neg_cursor ~allow_partial:true read_white_space "normal nowrap";
-  (* incomplete *)
-  neg_cursor read_white_space "preserve"
+  (* each slot of the [||] group takes at most one value *)
+  neg_cursor ~allow_partial:true read_white_space "collapse preserve";
+  neg_cursor ~allow_partial:true read_white_space
+    "discard-before discard-before";
+  (* text-wrap-style is not one of the three longhands *)
+  neg_cursor read_white_space "balance"
 
 let test_word_break () =
   check_word_break "normal";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -640,8 +640,13 @@ let check_page_size_orientation =
 let check_timeline_axis =
   check_value_cursor "axis" read_timeline_axis pp_timeline_axis
 
-let check_timeline_shorthand =
-  check_value_cursor "timeline_shorthand" read_timeline_shorthand
+let check_timeline_item_name =
+  check_value_cursor "timeline_item_name" read_timeline_item_name
+    pp_timeline_item_name
+
+let check_timeline_shorthand ?inset =
+  check_value_cursor "timeline_shorthand"
+    (read_timeline_shorthand ?inset)
     pp_timeline_shorthand
 
 let check_caption_side =
@@ -3977,6 +3982,11 @@ let test_timeline_axis () =
   neg_cursor read_timeline_axis "z";
   neg_cursor read_timeline_axis "auto"
 
+let test_timeline_item_name () =
+  check_timeline_item_name "none";
+  check_timeline_item_name "--main";
+  neg_cursor read_timeline_item_name "main"
+
 let test_timeline_shorthand () =
   check_timeline_shorthand "--main block";
   check_timeline_shorthand "--scroll inline";
@@ -3987,6 +3997,13 @@ let test_timeline_shorthand () =
   check_timeline_shorthand ~roundtrip:true "--main";
   check_timeline_shorthand ~roundtrip:true ~expected:"--x,--y" "--x, --y";
   check_timeline_shorthand ~roundtrip:true "none block";
+  (* Sec. 3.4.4 adds the inset to the view-timeline item, in either order with
+     the axis. *)
+  check_timeline_shorthand ~inset:true ~roundtrip:true "--v auto";
+  check_timeline_shorthand ~inset:true ~roundtrip:true "--v inline 10%";
+  check_timeline_shorthand ~inset:true ~roundtrip:true
+    ~expected:"--v inline 10%" "--v 10% inline";
+  check_timeline_shorthand ~inset:true ~roundtrip:true "--v 10px 20px";
   neg_cursor read_timeline_shorthand "main block";
   (* The name is not optional, so a bare axis names nothing. *)
   neg_cursor read_timeline_shorthand "inline";
@@ -5058,6 +5075,7 @@ let additional_tests =
     test_case "page_size_name" `Quick test_page_size_name;
     test_case "page_size_orientation" `Quick test_page_size_orientation;
     test_case "axis" `Quick test_timeline_axis;
+    test_case "timeline_item_name" `Quick test_timeline_item_name;
     test_case "timeline_shorthand" `Quick test_timeline_shorthand;
     test_case "caption_side" `Quick test_caption_side;
     test_case "color_scheme" `Quick test_color_scheme;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3981,9 +3981,19 @@ let test_timeline_shorthand () =
   check_timeline_shorthand "--main block";
   check_timeline_shorthand "--scroll inline";
   check_timeline_shorthand "--x x";
+  (* scroll-animations-1 sec. 2.3.3 is [[ <'scroll-timeline-name'>
+     <'scroll-timeline-axis'>? ]#]: the axis is optional and each name of the
+     list may be [none]. *)
+  check_timeline_shorthand ~roundtrip:true "--main";
+  check_timeline_shorthand ~roundtrip:true ~expected:"--x,--y" "--x, --y";
+  check_timeline_shorthand ~roundtrip:true "none block";
   neg_cursor read_timeline_shorthand "main block";
-  neg_cursor read_timeline_shorthand "--main";
-  neg_cursor read_timeline_shorthand "--main z"
+  (* The name is not optional, so a bare axis names nothing. *)
+  neg_cursor read_timeline_shorthand "inline";
+  (* The reader stops at [z] and the declaration rejects the leftovers. *)
+  neg_cursor ~allow_partial:true read_timeline_shorthand "--main z";
+  (* The inset is view-timeline's alone. *)
+  neg_cursor ~allow_partial:true read_timeline_shorthand "--main 10%"
 
 let test_caption_side () =
   check_caption_side "top";
@@ -4632,6 +4642,8 @@ let spec_generated_text_timeline_edges () =
   check_timeline_inset_item "calc(50% + 10px)";
   check_timeline_name ~expected:"--main,--alt" "--main, --alt";
   check_timeline_shorthand_item "--main block";
+  check_timeline_shorthand_item "--main";
+  check_timeline_shorthand_item "none";
   check_view_transition_class "card active";
   check_view_transition_name "match-element";
   (* Two trims: the reader takes the first and leaves the second, and the
@@ -4665,7 +4677,7 @@ let spec_generated_text_timeline_edges () =
   neg_cursor ~allow_partial:true read_timeline_inset "auto auto auto";
   neg_cursor read_timeline_inset_item "-1px";
   neg_cursor ~allow_partial:true read_timeline_name "none --main";
-  neg_cursor read_timeline_shorthand_item "--main z";
+  neg_cursor ~allow_partial:true read_timeline_shorthand_item "--main z";
   neg_cursor ~allow_partial:true read_view_transition_class "none card";
   neg_cursor ~allow_partial:true read_view_transition_name "match-element card"
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1994,14 +1994,18 @@ let test_text_decoration () =
   check_text_decoration "underline";
   check_text_decoration "line-through";
   check_text_decoration ~expected:"none" "none";
+  (* css-text-decor-4 sec. 2.6: the four components are joined by [||], so a
+     lone style, colour or thickness is a complete value. *)
+  check_text_decoration ~roundtrip:true "solid";
+  check_text_decoration ~roundtrip:true "red";
+  check_text_decoration ~roundtrip:true "2px";
+  check_text_decoration ~roundtrip:true "solid red";
+  check_text_decoration ~roundtrip:true ~expected:"wavy red 1px" "wavy 1px red";
   neg_cursor ~allow_partial:true read_text_decoration "invalid-decoration";
   neg_cursor read_text_decoration "underline line-through underline";
   (* duplicate - per CSS spec, || combinator means each component at most
      once *)
-  neg_cursor read_text_decoration "solid";
-  (* that's a style *)
-  (* that's a color *)
-  neg_cursor read_text_decoration "red"
+  neg_cursor read_text_decoration "underline none"
 
 let test_text_decoration_shorthand () =
   (* Test individual parts. The printer holds every component it parsed;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4519,6 +4519,14 @@ let spec_generated_position_interaction_edges () =
 (* ignore-test: grouped generated-surface vectors. *)
 let spec_generated_text_timeline_edges () =
   check_text_box "trim-both text alphabetic";
+  (* css-inline-3 sec. 6.1: [<'text-box-trim'> || <'text-box-edge'>], and
+     omitting the trim sets it to trim-both, so an edge alone is a value. *)
+  check_text_box ~roundtrip:true "normal";
+  check_text_box ~roundtrip:true "text";
+  check_text_box ~roundtrip:true "cap alphabetic";
+  check_text_box ~roundtrip:true "ex text";
+  (* sec. 5.2 puts [cap] only in the two-value branch of <text-edge>. *)
+  neg_cursor read_text_box "cap";
   check_text_box_edge "text ideographic";
   check_text_box_edge_keyword "ideographic-ink";
   check_text_box_trim "trim-both";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -55,6 +55,26 @@ let check_text_overflow =
 
 let check_text_wrap = check_value_cursor "text-wrap" read_text_wrap pp_text_wrap
 
+let check_white_space_collapse_keyword =
+  check_value_cursor "white-space-collapse" read_white_space_collapse_keyword
+    pp_white_space_collapse_keyword
+
+let check_text_wrap_mode_keyword =
+  check_value_cursor "text-wrap-mode" read_text_wrap_mode_keyword
+    pp_text_wrap_mode_keyword
+
+let check_white_space_trim_keyword =
+  check_value_cursor "white-space-trim keyword" read_white_space_trim_keyword
+    pp_white_space_trim_keyword
+
+let check_white_space_trim =
+  check_value_cursor "white-space-trim" read_white_space_trim
+    pp_white_space_trim
+
+let check_white_space_components =
+  check_value_cursor "white-space components" read_white_space_components
+    pp_white_space_components
+
 let check_white_space =
   check_value_cursor "white-space" read_white_space pp_white_space
 
@@ -1507,6 +1527,38 @@ let test_white_space () =
     "discard-before discard-before";
   (* text-wrap-style is not one of the three longhands *)
   neg_cursor read_white_space "balance"
+
+let test_white_space_collapse_keyword () =
+  check_white_space_collapse_keyword "collapse";
+  check_white_space_collapse_keyword "discard";
+  check_white_space_collapse_keyword "preserve";
+  check_white_space_collapse_keyword "preserve-breaks";
+  check_white_space_collapse_keyword "preserve-spaces";
+  check_white_space_collapse_keyword "break-spaces";
+  neg_cursor read_white_space_collapse_keyword "normal"
+
+let test_text_wrap_mode_keyword () =
+  check_text_wrap_mode_keyword "wrap";
+  check_text_wrap_mode_keyword "nowrap";
+  neg_cursor read_text_wrap_mode_keyword "balance"
+
+let test_white_space_trim_keyword () =
+  check_white_space_trim_keyword "discard-before";
+  check_white_space_trim_keyword "discard-after";
+  check_white_space_trim_keyword "discard-inner";
+  neg_cursor read_white_space_trim_keyword "none"
+
+let test_white_space_trim () =
+  check_white_space_trim "none";
+  check_white_space_trim "discard-before discard-inner";
+  neg_cursor ~allow_partial:true read_white_space_trim "discard-before none"
+
+let test_white_space_components () =
+  check_white_space_components ~roundtrip:true "preserve nowrap";
+  check_white_space_components ~roundtrip:true "discard-after";
+  check_white_space_components ~roundtrip:true ~expected:"collapse wrap"
+    "wrap collapse";
+  neg_cursor read_white_space_components "normal"
 
 let test_word_break () =
   check_word_break "normal";
@@ -4668,6 +4720,12 @@ let tests =
     test_case "text-overflow" `Quick test_text_overflow;
     test_case "text-wrap" `Quick test_text_wrap;
     test_case "white-space" `Quick test_white_space;
+    test_case "white-space-collapse keyword" `Quick
+      test_white_space_collapse_keyword;
+    test_case "text-wrap-mode keyword" `Quick test_text_wrap_mode_keyword;
+    test_case "white-space-trim keyword" `Quick test_white_space_trim_keyword;
+    test_case "white-space-trim" `Quick test_white_space_trim;
+    test_case "white-space components" `Quick test_white_space_components;
     test_case "word-break" `Quick test_word_break;
     test_case "overflow-wrap" `Quick test_overflow_wrap;
     test_case "hyphens" `Quick test_hyphens;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4561,7 +4561,9 @@ let spec_generated_text_timeline_edges () =
   check_timeline_shorthand_item "--main block";
   check_view_transition_class "card active";
   check_view_transition_name "match-element";
-  neg_cursor read_text_box "trim-start trim-end";
+  (* Two trims: the reader takes the first and leaves the second, and the
+     declaration-level rejection is pinned in the shared inventory. *)
+  neg_cursor ~allow_partial:true read_text_box "trim-start trim-end";
   neg_cursor read_text_box_edge "text text";
   neg_cursor read_text_box_edge_keyword "baseline";
   neg_cursor read_text_box_trim "trim";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4213,6 +4213,11 @@ let spec_generated_box_layout_edges () =
   check_baseline_shift "10%";
   check_baseline_source "first";
   check_border_image ~expected:"url(border.png)30" "url(border.png) 30";
+  (* css-backgrounds-3 sec. 5.7 sets omitted values to their initial values, so
+     [border-image-repeat] on its own is a complete value. *)
+  check_border_image ~roundtrip:true "round";
+  check_border_image ~roundtrip:true "stretch";
+  check_border_image ~roundtrip:true "round space";
   check_border_image_outset_item "2px";
   check_border_image_repeat_keyword "round";
   check_border_image_slice "30 fill";


### PR DESCRIPTION
Six readers required a component their grammar leaves optional, so a valid declaration was dropped with only a warning on stderr: `text-decoration: red`, `white-space: collapse`, `border-image: round`, `scroll-timeline: --t`, `view-timeline: --v` and `text-box: cap alphabetic`. Each names a complete value that resets the rest of its longhands to their initial values. `mask-border` shares the border-image reader and gains the same, and view-timeline items gain the inset slot the shorthand grammar has always had.

Accepting those forms exposed two ways to serialize an empty value, since the optimizer folds a component that equals its longhand initial: `text-decoration: solid` printed as `text-decoration:` and `mask-border: alpha` as `mask-border:`. Both folds now stop at the last remaining component.

`scroll-timeline: inline` and `text-box: cap` stay rejected: the timeline name is not optional, and `cap` appears only in the two-value branch of `<text-edge>`.