### PR TITLE
Remove identity shadow spread helper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -969,6 +969,8 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- Shadow serialization passes its spread value directly to the length printer;
+  the fold migration left an identity helper and one needless binding (#660)
 - `Syntax.is_ident` answers whether a whole string is one CSS ident (CSS
   Syntax 3 sec. 4.3.11), the check `Parser.escape_ident` already made for
   emission; a per-character scan reads a leading `-` as ident-start and misses `-4` (#626)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -133,17 +133,10 @@ let pp_color_after_length ctx color =
   Pp.space ctx ();
   pp_color ctx color
 
-(* Faithful: a default-zero spread is dropped in [normalize_shadow], not here.
-   [Some Zero] re-parses differently from [None] ([0 1px 3px 0] vs [0 1px 3px]),
-   so collapsing it is a node-changing fold that belongs in the AST normalize
-   pass, leaving pp a pure serialiser. *)
-let pp_shadow_spread _ctx (spread : length option) : length option = spread
-
 let pp_shadow_body ctx { h_offset; v_offset; blur; spread; color } =
   pp_length ctx h_offset;
   Pp.space ctx ();
   pp_length ctx v_offset;
-  let spread = pp_shadow_spread ctx spread in
   pp_opt_space pp_length ctx blur;
   pp_opt_space pp_length ctx spread;
   match color with Some c -> pp_color_after_length ctx c | None -> ()


### PR DESCRIPTION
## Summary

- remove the identity `pp_shadow_spread` helper left by the fold migration
- pass the unchanged spread value directly to the existing length printer

## Testing

- `opam exec -- dune fmt`
- `opam exec -- dune build`
- `opam exec -- merlint --build`
- `env -u NO_COLOR opam exec -- dune test`