### PR TITLE
Simplify colour-lightness serialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -969,6 +969,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- The colour-lightness printer returns its unchanged AST value once after
+  serializing it, instead of repeating that identity result in every branch
+  (#661)
 - Shadow serialization passes its spread value directly to the length printer;
   the fold migration left an identity helper and one needless binding (#660)
 - `Syntax.is_ident` answers whether a whole string is one CSS ident (CSS

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4491,20 +4491,14 @@ let starts_unsigned_number s =
    whichever node it is given ([Pct] -> [%], [Num] -> bare number). The
    precision is fixed in the AST normalize pass, so this prints in full. *)
 let pp_color_lightness ctx (l : percentage option) : percentage option =
-  match l with
+  (match l with
   | Some (Pct f) ->
       pp_lab_float ctx f;
-      Pp.char ctx '%';
-      l
-  | Some (Num f) ->
-      pp_lab_float ctx f;
-      l
-  | Some l ->
-      pp_percentage ctx l;
-      Some l
-  | None ->
-      Pp.string ctx "none";
-      None
+      Pp.char ctx '%'
+  | Some (Num f) -> pp_lab_float ctx f
+  | Some l -> pp_percentage ctx l
+  | None -> Pp.string ctx "none");
+  l
 
 let pp_pct_chroma_hue_alpha ~chroma_pct_scale :
     (percentage option * float option * hue * alpha) Pp.t =


### PR DESCRIPTION
## Summary

- serialize each colour-lightness form exactly as before
- return the unchanged lightness AST once after the match instead of once per branch

## Testing

- `opam exec -- dune fmt`
- `opam exec -- dune build`
- `opam exec -- merlint --build`
- `env -u NO_COLOR opam exec -- dune test`