### PR TITLE
Reuse shared identity-preserving map

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -969,6 +969,8 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- Property normalizers reuse `Common.List.map_preserve` instead of carrying a
+  second implementation with the same contract (#662)
 - The colour-lightness printer returns its unchanged AST value once after
   serializing it, instead of repeating that identity result in every branch
   (#661)

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -161,15 +161,7 @@ let pp_box_shorthand pp ctx vs = Pp.list ~sep:Pp.token_sp pp ctx vs
 (* Canonicalise a colour to its shortest spelling. *)
 let normalize_color ?(lossless = false) = Values.normalize_color ~lossless
 let preserve_if_equal before after = if after == before then before else after
-
-let map_preserve f xs =
-  let rec loop changed acc = function
-    | [] -> if changed then List.rev acc else xs
-    | x :: rest ->
-        let y = f x in
-        loop (changed || not (y == x)) (y :: acc) rest
-  in
-  loop false [] xs
+let map_preserve = List.map_preserve
 
 (* Canonicalise a box shorthand: normalise each side with [f], then pick the
    shortest of the spellings that name those sides. *)


### PR DESCRIPTION
## Summary

- replace the private property-specific `map_preserve` implementation with an alias to `Common.List.map_preserve`
- keep the existing no-op identity contract while also sharing unchanged list suffixes

## Testing

- `opam exec -- dune fmt`
- `opam exec -- dune build`
- `opam exec -- merlint --build`
- `env -u NO_COLOR opam exec -- dune test`