### PR TITLE
Reuse box-shorthand normalizer for border radius

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -969,6 +969,8 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- Border-radius normalization uses the shared box-shorthand normalizer instead
+  of spelling its map-and-collapse composition inline (#663)
 - Property normalizers reuse `Common.List.map_preserve` instead of carrying a
   second implementation with the same contract (#662)
 - The colour-lightness printer returns its unchanged AST value once after

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -224,9 +224,8 @@ let rec pp_border_radius : border_radius Pp.t =
    horizontal one says what omitting it says. *)
 let normalize_border_radius ?(strip = true) : border_radius -> border_radius =
  fun value ->
-  let group vs =
-    collapse_box_shorthand
-      (map_preserve (Values.normalize_length_percentage ~strip) vs)
+  let group =
+    normalize_box_shorthand (Values.normalize_length_percentage ~strip)
   in
   match value with
   | Radius { horizontal; vertical } ->


### PR DESCRIPTION
## Summary

- replace the inline map-and-collapse composition in border-radius normalization
- use the shared `normalize_box_shorthand` helper with the same length-percentage normalizer

## Testing

- `opam exec -- dune fmt`
- `opam exec -- dune build`
- `opam exec -- merlint --build`
- `env -u NO_COLOR opam exec -- dune test`