### PR TITLE
rule_graph: answer reachability from a held set, not a fresh walk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -559,6 +559,10 @@ recorded cases carrying six minifiers' answers.
 - `--minify` canonicalises logical minimum sizes, duration units and stepped
   functions, transform origins and hue-angle units before declaration hashes
   are compared, so equivalent rules factor under all five spellings (#647)
+- `--minify` settles each rule's reachable set in the dependency graph once
+  instead of re-walking the graph per question, so ordering a run no longer
+  costs the cube of its rule count. The slowest corpus stylesheet took about
+  80s of CPU and now takes under 2s, for byte-identical output (#664)
 - `--minify` folds a value's spelling before two rules are compared, so rules
   that wrote one declaration two ways factor into one: a component left at its
   longhand's initial in the `border`, `column-rule`, `outline`, `list-style`,

--- a/bench/source-order/bench_source_order.ml
+++ b/bench/source-order/bench_source_order.ml
@@ -37,13 +37,42 @@ let words rules =
   let w3 = run 3 in
   (w3 -. w1) /. 2.
 
+(* What a graph costs to build says nothing about what it costs to use, and this
+   bench weighed only the build while an asymptotic regression shipped in the
+   questions. Orienting a factoring asks which of two nodes has to come first,
+   once per ordered pair, so a run of N rules is asked about N^2 pairs; counting
+   the nodes those answers expand is immune to whatever else the machine is
+   doing, and stays flat per node when the edges are only passed over once. *)
+let expansions rules =
+  let g = Rule_graph.of_rules rules in
+  let n = Rule_graph.node_count g in
+  for i = 0 to n - 1 do
+    for j = 0 to n - 1 do
+      ignore
+        (Sys.opaque_identity
+           (Rule_graph.precedes g
+              (Rule_graph.Node_id.of_int_exn i)
+              (Rule_graph.Node_id.of_int_exn j)))
+    done
+  done;
+  (n, Rule_graph.reachability_expansions g)
+
+let sizes = [ 500; 1000; 2000; 4000 ]
+let shapes = [ "A"; "B"; "C"; "D" ]
+
 let () =
   print_endline "shape n words_per_build";
   List.iter
     (fun s ->
+      List.iter (fun n -> Fmt.pr "%s %d %.0f@." s n (words (shape s n))) sizes)
+    shapes;
+  print_endline "shape n pairs expansions per_node";
+  List.iter
+    (fun s ->
       List.iter
         (fun n ->
-          let rules = shape s n in
-          Fmt.pr "%s %d %.0f@." s n (words rules))
-        [ 500; 1000; 2000; 4000 ])
-    [ "A"; "B"; "C"; "D" ]
+          let nodes, spent = expansions (shape s n) in
+          Fmt.pr "%s %d %d %d %.2f@." s n (nodes * nodes) spent
+            (float_of_int spent /. float_of_int (max nodes 1)))
+        sizes)
+    shapes

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -83,7 +83,6 @@ let merge_named_layers_by_name = Block.merge_named_layers_by_name
 let merge_lone_nested_rule = Nest.merge_lone
 let hoist_declaration_runs = Nest.hoist_declaration_runs
 let synthesize_nesting_statements = Nest.statements
-let stylesheet_key stmts = Pp.to_string ~minify:true pp_stylesheet stmts
 
 (* Pop the run of [Rule]s most recently pushed onto a reversed accumulator, in
    forward order, with the remaining accumulator. Unwrapping an [@supports] its
@@ -901,17 +900,14 @@ let run_pipeline ~ctx ~enforce_spec ~aggressive stylesheet =
     else 5
   in
   let factor_cache = Factor.cache () in
-  let rec loop n key stmts =
+  let rec loop n stmts =
     if n <= 0 then stmts
     else
       let next = statements_top_level ~factor_cache ~ctx ~enforce_spec stmts in
-      if next == stmts then stmts
-      else if Stylesheet.equal next stmts then stmts
-      else
-        let next_key = stylesheet_key next in
-        if String.equal key next_key then next else loop (n - 1) next_key next
+      if next == stmts || Stylesheet.equal next stmts then stmts
+      else loop (n - 1) next
   in
-  loop cap (stylesheet_key stylesheet) stylesheet
+  loop cap stylesheet
 
 (* Bare names of every custom property referenced through [var()] in the tree.
    Scans the serialized declarations, so it sees references inside opaque values

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -100,6 +100,9 @@ type t = {
   branch_index : node_id list String_table.t;
       (** selector branch -> node ids that carry it; same role as [key_index]
           for the [share_branch] dimension. *)
+  mutable expansions : int;
+      (** nodes expanded to answer reachability questions, for
+          {!reachability_expansions}. *)
 }
 
 (* The two dimensions of the CSS-graph dependency. Two rules conflict - their
@@ -759,6 +762,7 @@ let of_rules ?parent ?(closed_world = false) (rules : rule list) : t =
       succ = [||];
       key_index = Key_tbl.create (max 16 (n * 2));
       branch_index = String_table.create (max 16 (n * 2));
+      expansions = 0;
     }
   in
   for i = 0 to n - 1 do
@@ -787,6 +791,7 @@ let path_exists t source target =
         else if Bytes.get seen i <> '\000' then visit rest
         else begin
           Bytes.set seen i '\001';
+          t.expansions <- t.expansions + 1;
           let next =
             List.fold_left (fun acc (j, _) -> j :: acc) rest t.succ.(i)
           in
@@ -796,6 +801,8 @@ let path_exists t source target =
   source <> target && visit [ source ]
 
 let precedes t i j = t.live.(i) && t.live.(j) && path_exists t i j
+let successors t i = List.map fst t.succ.(i)
+let reachability_expansions t = t.expansions
 let generation t = t.generation
 
 let live_nodes t =
@@ -1055,6 +1062,7 @@ let rewrite_base t ~consume ~produce :
                [add_external_edges] below sees the pre-rewrite index. *)
             key_index = t.key_index;
             branch_index = t.branch_index;
+            expansions = 0;
           }
         in
         Ok (total, consumed_set total consume, graph)

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -55,6 +55,14 @@ type decl_overlap = {
   footprint : Shorthand.overlap_key list;
 }
 
+(* Which nodes each node can reach, as a bitset per node. Orienting a factoring
+   asks the question once per ordered pair of source references, so a run of [n]
+   rules is asked about [n^2] pairs, while the edges are settled the moment a
+   graph is published. Holding the answers turns the pairs into bit tests over
+   one pass of the edges. [Unbuilt] until the first question; [Walked] for a run
+   long enough that holding them costs more than re-asking. *)
+type reachability = Unbuilt | Held of Bytes.t array | Walked
+
 type t = {
   generation : int;
   closed_world : bool;
@@ -100,6 +108,9 @@ type t = {
   branch_index : node_id list String_table.t;
       (** selector branch -> node ids that carry it; same role as [key_index]
           for the [share_branch] dimension. *)
+  mutable reach : reachability;
+      (** reachable set per node, over the [succ] above. Filled on demand: a
+          graph whose order is never questioned holds nothing. *)
   mutable expansions : int;
       (** nodes expanded to answer reachability questions, for
           {!reachability_expansions}. *)
@@ -762,6 +773,7 @@ let of_rules ?parent ?(closed_world = false) (rules : rule list) : t =
       succ = [||];
       key_index = Key_tbl.create (max 16 (n * 2));
       branch_index = String_table.create (max 16 (n * 2));
+      reach = Unbuilt;
       expansions = 0;
     }
   in
@@ -782,7 +794,7 @@ let order_constrained = conflict
    by retaining every transitive edge. Dead rewrite inputs remain in the graph
    as relay vertices, so paths through them continue to constrain the surviving
    nodes. *)
-let path_exists t source target =
+let walk_to t source target =
   let seen = Bytes.make (max t.count 1) '\000' in
   let rec visit = function
     | [] -> false
@@ -798,7 +810,122 @@ let path_exists t source target =
           visit next
         end
   in
-  source <> target && visit [ source ]
+  visit [ source ]
+
+(* A node's reachable set, one bit per node. The union below runs once per edge
+   of the cone being closed, so it goes a word at a time. *)
+module Reach = struct
+  let v count = Bytes.make ((count + 7) / 8) '\000'
+  let is_set set = Bytes.length set > 0
+
+  let mem set i =
+    Char.code (Bytes.get set (i lsr 3)) land (1 lsl (i land 7)) <> 0
+
+  let add set i =
+    let byte = i lsr 3 in
+    Bytes.set set byte
+      (Char.chr (Char.code (Bytes.get set byte) lor (1 lsl (i land 7))))
+
+  let union ~into set =
+    let len = Bytes.length into in
+    let words = len / 8 in
+    for w = 0 to words - 1 do
+      let at = w * 8 in
+      Bytes.set_int64_ne into at
+        (Int64.logor (Bytes.get_int64_ne into at) (Bytes.get_int64_ne set at))
+    done;
+    for at = words * 8 to len - 1 do
+      Bytes.set into at
+        (Char.chr
+           (Char.code (Bytes.get into at) lor Char.code (Bytes.get set at)))
+    done
+end
+
+(* A run of [n] nodes closes into [n * n / 8] bytes. Past this length each
+   question walks the edges again and the graph holds nothing. *)
+let closure_node_limit = 16384
+
+(* One step of the closure walk: [Open] descends into a node, [Close] unions the
+   sets of its successors - by then settled - into its own. *)
+type reach_step = Open of int | Close of int
+
+let rec union_successors sets set = function
+  | [] -> true
+  | (j, _) :: rest ->
+      let j = Node_id.to_int j in
+      Reach.add set j;
+      (* An unsettled successor at this point is a back edge, which the graph's
+         acyclicity rules out: [of_rules] only ever points a node at a later
+         one, and [rewrite] rejects a rewrite that would close a loop. Answering
+         from an incomplete set would reorder declarations, so say so instead
+         and let the caller fall back to walking. *)
+      Reach.is_set sets.(j)
+      &&
+      (Reach.union ~into:set sets.(j);
+       union_successors sets set rest)
+
+let close_node t sets i =
+  let set = Reach.v t.count in
+  union_successors sets set t.succ.(i)
+  && begin
+    sets.(i) <- set;
+    t.expansions <- t.expansions + 1;
+    true
+  end
+
+(* Settle every node in [source]'s cone, deepest first, skipping what an earlier
+   question already settled. The stack is explicit because a source-order chain
+   is as deep as the run is long, and [opened] keeps a node reached twice within
+   one cone from being descended twice. *)
+let close_cone t sets source =
+  let opened = Bytes.make (max t.count 1) '\000' in
+  let rec loop = function
+    | [] -> true
+    | Close i :: rest -> close_node t sets i && loop rest
+    | Open i :: rest ->
+        if Reach.is_set sets.(i) || Bytes.get opened i <> '\000' then loop rest
+        else begin
+          Bytes.set opened i '\001';
+          loop
+            (List.fold_left
+               (fun acc (j, _) -> Open (Node_id.to_int j) :: acc)
+               (Close i :: rest) t.succ.(i))
+        end
+  in
+  loop [ Open source ]
+
+let reach_sets t =
+  match t.reach with
+  | Held sets -> Option.Some sets
+  | Walked -> Option.None
+  | Unbuilt ->
+      if t.count > closure_node_limit then begin
+        t.reach <- Walked;
+        Option.None
+      end
+      else begin
+        let sets = Array.make (max t.count 1) Bytes.empty in
+        t.reach <- Held sets;
+        Option.Some sets
+      end
+
+let reachable_set t source =
+  match reach_sets t with
+  | Option.None -> Option.None
+  | Option.Some sets ->
+      if Reach.is_set sets.(source) then Option.Some sets.(source)
+      else if close_cone t sets source then Option.Some sets.(source)
+      else begin
+        t.reach <- Walked;
+        Option.None
+      end
+
+let path_exists t source target =
+  source <> target
+  &&
+  match reachable_set t source with
+  | Option.Some set -> Reach.mem set target
+  | Option.None -> walk_to t source target
 
 let precedes t i j = t.live.(i) && t.live.(j) && path_exists t i j
 let successors t i = List.map fst t.succ.(i)
@@ -1012,6 +1139,47 @@ let produced_metadata t produced =
     decl_overlaps,
     overlap_keys )
 
+let produced_graph t ~consume ~total ~new_n produced =
+  let ( p_summaries,
+        p_selectors,
+        p_selector_summaries,
+        p_specificities,
+        p_branches,
+        p_decl_overlaps,
+        p_overlap_keys ) =
+    produced_metadata t produced
+  in
+  {
+    generation = t.generation + 1;
+    closed_world = t.closed_world;
+    parent = t.parent;
+    count = new_n;
+    rules = append_slack t.rules ~count:total produced;
+    summaries = append_slack t.summaries ~count:total p_summaries;
+    origin =
+      append_slack t.origin ~count:total (produced_origins t consume p_branches);
+    live = rewrite_live t ~total ~new_n ~consume;
+    selectors = append_slack t.selectors ~count:total p_selectors;
+    selector_summaries =
+      append_slack t.selector_summaries ~count:total p_selector_summaries;
+    specificities = append_slack t.specificities ~count:total p_specificities;
+    branches = append_slack t.branches ~count:total p_branches;
+    decl_overlaps = append_slack t.decl_overlaps ~count:total p_decl_overlaps;
+    overlap_keys = append_slack t.overlap_keys ~count:total p_overlap_keys;
+    succ =
+      Array.append (Array.sub t.succ 0 total)
+        (Array.make (Array.length produced) []);
+    (* shared with [t]: holds the existing nodes; produced nodes are added by
+       {!rewrite} only once the rewrite is accepted, so [add_external_edges]
+       below sees the pre-rewrite index. *)
+    key_index = t.key_index;
+    branch_index = t.branch_index;
+    (* the produced graph's edges are still being written; it holds no answers
+       until it is published and questioned *)
+    reach = Unbuilt;
+    expansions = 0;
+  }
+
 let rewrite_base t ~consume ~produce :
     (int * bool array * t, rewrite_error) result =
   match validate_consume t consume with
@@ -1022,50 +1190,10 @@ let rewrite_base t ~consume ~produce :
         let total = node_count t in
         let produced = Array.of_list produce in
         let new_n = total + Array.length produced in
-        let ( p_summaries,
-              p_selectors,
-              p_selector_summaries,
-              p_specificities,
-              p_branches,
-              p_decl_overlaps,
-              p_overlap_keys ) =
-          produced_metadata t produced
-        in
-        let graph =
-          {
-            generation = t.generation + 1;
-            closed_world = t.closed_world;
-            parent = t.parent;
-            count = new_n;
-            rules = append_slack t.rules ~count:total produced;
-            summaries = append_slack t.summaries ~count:total p_summaries;
-            origin =
-              append_slack t.origin ~count:total
-                (produced_origins t consume p_branches);
-            live = rewrite_live t ~total ~new_n ~consume;
-            selectors = append_slack t.selectors ~count:total p_selectors;
-            selector_summaries =
-              append_slack t.selector_summaries ~count:total
-                p_selector_summaries;
-            specificities =
-              append_slack t.specificities ~count:total p_specificities;
-            branches = append_slack t.branches ~count:total p_branches;
-            decl_overlaps =
-              append_slack t.decl_overlaps ~count:total p_decl_overlaps;
-            overlap_keys =
-              append_slack t.overlap_keys ~count:total p_overlap_keys;
-            succ =
-              Array.append (Array.sub t.succ 0 total)
-                (Array.make (Array.length produced) []);
-            (* shared with [t]: holds the existing nodes; produced nodes are
-               added by {!rewrite} only once the rewrite is accepted, so
-               [add_external_edges] below sees the pre-rewrite index. *)
-            key_index = t.key_index;
-            branch_index = t.branch_index;
-            expansions = 0;
-          }
-        in
-        Ok (total, consumed_set total consume, graph)
+        Ok
+          ( total,
+            consumed_set total consume,
+            produced_graph t ~consume ~total ~new_n produced )
 
 let add_edge succ i j reason = succ.(i) <- (j, reason) :: succ.(i)
 let old_edge = path_exists

--- a/lib/rule_graph.mli
+++ b/lib/rule_graph.mli
@@ -117,6 +117,18 @@ val precedes : t -> node_id -> node_id -> bool
     local candidate ordering; use {!val-canonical_order} when a full output
     projection is needed. *)
 
+val successors : t -> node_id -> node_id list
+(** [successors t i] is the nodes [i] has a direct edge to. A dense run is
+    stored as a transitive chain rather than one edge per constrained pair, so a
+    node that must precede another is not always a direct successor of it;
+    {!val-precedes} is the reachability question. *)
+
+val reachability_expansions : t -> int
+(** [reachability_expansions t] is how many nodes [t] has expanded to answer
+    {!val-precedes}. Each node's reachable set is settled once and reused, so
+    this stays bounded by the node count however many pairs a caller asks about.
+*)
+
 val canonical_order_by : t -> (node_id -> int) -> node_id array
 (** [canonical_order_by t rank] is the live node indices in a linear extension
     of the dependency DAG, choosing among the nodes currently free to come next

--- a/test/test_rule_graph.ml
+++ b/test/test_rule_graph.ml
@@ -515,6 +515,32 @@ let reachability_settles_once () =
         true (spent <= count))
     [ 200; 400 ]
 
+(* Holding a reachable set per node costs a bit per node per node, so past a run
+   length the answers come from walking the edges again. Nothing else reaches
+   that path once the sets are held, and it decides rule order, so check it
+   against the same walk - and check that this length really does take it, by
+   asking one question twice and finding it cost the same again. Raising the
+   length a closure is held for has to revisit this. *)
+let a_long_run_answers_by_walking () =
+  let g = Rule_graph.of_rules (dense_conflict 16385) in
+  let count = Rule_graph.node_count g in
+  let spent () = Rule_graph.reachability_expansions g in
+  let ask i j =
+    let before = spent () in
+    Alcotest.(check bool)
+      (Fmt.str "precedes %d %d over a run of %d" i j count)
+      (reaches g i j)
+      (Rule_graph.precedes g (nid i) (nid j));
+    spent () - before
+  in
+  (* first, before any other question can settle the run *)
+  let once = ask 12 (count - 1) in
+  let again = ask 12 (count - 1) in
+  Alcotest.(check int)
+    (Fmt.str "a repeated question over a run of %d costs the same again" count)
+    once again;
+  List.iter (fun (i, j) -> ignore (ask i j)) [ (0, 1); (count - 1, 0); (7, 7) ]
+
 (* Rules that all write the same declaration have no order to discover: an
    identical pair is its own winner wherever the two sit. The run sits at one
    specificity, where partitioning candidates by specificity separates nothing,
@@ -743,6 +769,8 @@ let suite =
         precedes_agrees_with_a_walk;
       Alcotest.test_case "reachability settles once per node" `Quick
         reachability_settles_once;
+      Alcotest.test_case "a long run answers by walking" `Quick
+        a_long_run_answers_by_walking;
       Alcotest.test_case "dense graph build/project is sub-quadratic" `Quick
         dense_graph_build_is_subquadratic;
       Alcotest.test_case "try_rewrite is sub-quadratic" `Quick

--- a/test/test_rule_graph.ml
+++ b/test/test_rule_graph.ml
@@ -412,6 +412,109 @@ let second_specificity_costs_no_pair () =
     true
     (a1 = 0. || a2 < a1 *. 2.5)
 
+(* An independent oracle for {!Rule_graph.precedes}: a plain walk of the edges
+   the graph exposes, reusing nothing between questions. Dead nodes are walked
+   through, since a compact chain can carry a live-to-live constraint across a
+   node a rewrite consumed. *)
+let reaches g source target =
+  let seen = Array.make (max (Rule_graph.node_count g) 1) false in
+  let rec walk = function
+    | [] -> false
+    | i :: rest ->
+        let i = Rule_graph.Node_id.to_int i in
+        if i = target then true
+        else if seen.(i) then walk rest
+        else begin
+          seen.(i) <- true;
+          walk (Rule_graph.successors g (nid i) @ rest)
+        end
+  in
+  source <> target && walk (Rule_graph.successors g (nid source))
+
+let check_reachability label g =
+  let count = Rule_graph.node_count g in
+  for i = 0 to count - 1 do
+    for j = 0 to count - 1 do
+      let expected =
+        reaches g i j
+        && Rule_graph.is_live g (nid i)
+        && Rule_graph.is_live g (nid j)
+      in
+      Alcotest.(check bool)
+        (Fmt.str "%s: precedes %d %d" label i j)
+        expected
+        (Rule_graph.precedes g (nid i) (nid j))
+    done
+  done
+
+(* [precedes] answers a reachability question over edges that never change once
+   a graph is published, so however it is answered it must agree with a walk of
+   those edges on every ordered pair - including pairs joined only through a
+   node a rewrite consumed, and pairs a compact chain relates without a direct
+   edge. This pins the answer itself, not the rule order it feeds. *)
+let precedes_agrees_with_a_walk () =
+  List.iter
+    (fun (label, css) -> check_reachability label (g_of css))
+    [
+      ("chain", ".a{color:red}.a{color:blue}.a{color:green}.a{color:teal}");
+      ( "forks",
+        ".a{color:red}.b{margin:0}.a{color:blue}.b{margin:1px}.a,.b{top:0}" );
+      ( "mixed specificity",
+        "#i{color:red}.a{color:blue}#i{color:teal}.a.c{color:teal}.a{color:lime}"
+      );
+      ("disjoint", "#a{color:red}#b{color:blue}#c{color:teal}");
+    ];
+  (* A committed rewrite leaves its inputs behind as dead relays, so the walk
+     has to cross them. *)
+  let g =
+    g_of ".early{color:black}.mid{color:red}.mid{color:blue}.late{color:white}"
+  in
+  match
+    Rule_graph.try_rewrite g
+      ~consume:(nids [ 1; 2 ])
+      ~produce:(rules_of ".mid{color:red}.mid{color:blue}")
+  with
+  | None -> Alcotest.fail "replacement should commit"
+  | Some g' -> check_reachability "after rewrite" g'
+
+(* Orienting a factoring asks which of two nodes has to come first, once per
+   ordered pair of source references, so a run of N rules is asked about N^2
+   pairs. The edges are settled the moment the graph is published, so all of
+   those answers follow from one pass over them: the nodes expanded to answer
+   them must stay bounded by the node count, not grow with the pairs asked
+   about. Every rule below writes a distinct value for one property on one
+   element, the shape that makes the run one long chain. *)
+let reachability_settles_once () =
+  let expansions n =
+    let g = Rule_graph.of_rules (dense_conflict n) in
+    let count = Rule_graph.node_count g in
+    let ask i j = ignore (Sys.opaque_identity (Rule_graph.precedes g i j)) in
+    (* Deepest source first, then shallowest: asking the deepest first leaves
+       every later question facing a cone an earlier one already settled, which
+       only stays cheap if a settled node is read rather than descended again.
+       Asking the shallowest first hides that. *)
+    for i = count - 1 downto 0 do
+      for j = 0 to count - 1 do
+        ask (nid i) (nid j)
+      done
+    done;
+    for i = 0 to count - 1 do
+      for j = 0 to count - 1 do
+        ask (nid i) (nid j)
+      done
+    done;
+    (count, Rule_graph.reachability_expansions g)
+  in
+  List.iter
+    (fun n ->
+      let count, spent = expansions n in
+      Alcotest.(check bool)
+        (Fmt.str "%d nodes, %d pairs asked: %d nodes expanded" count
+           (2 * count * count)
+           spent)
+        true (spent <= count))
+    [ 200; 400 ]
+
 (* Rules that all write the same declaration have no order to discover: an
    identical pair is its own winner wherever the two sit. The run sits at one
    specificity, where partitioning candidates by specificity separates nothing,
@@ -636,6 +739,10 @@ let suite =
         try_rewrite_bumps_generation;
       Alcotest.test_case "declaration_body_key buckets identical bodies" `Quick
         declaration_body_key_buckets;
+      Alcotest.test_case "precedes agrees with a walk of the edges" `Quick
+        precedes_agrees_with_a_walk;
+      Alcotest.test_case "reachability settles once per node" `Quick
+        reachability_settles_once;
       Alcotest.test_case "dense graph build/project is sub-quadratic" `Quick
         dense_graph_build_is_subquadratic;
       Alcotest.test_case "try_rewrite is sub-quadratic" `Quick


### PR DESCRIPTION
Minifying the slowest stylesheet in the corpus took about 80s of CPU and now takes under 2s, for byte-identical output on all 504 files.