### PR TITLE
Accept text-decoration without a line value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -184,6 +184,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `text-decoration` accepts a colour, style or thickness without a line value;
+  its four components are joined by `||`, so none is individually mandatory
+  (#665)
 - A CSS-wide keyword mixed into a `font-family` list now reads as the exported
   `font_family.Invalid` node, preserving the source for typed invalid-value
   recovery instead of raising during property parsing (#657)

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -98,6 +98,10 @@ module Text_decoration = struct
 
   let empty = { lines = []; style = None; color = None; thickness = None }
 
+  let is_empty { lines; style; color; thickness } =
+    lines = [] && Option.is_none style && Option.is_none color
+    && Option.is_none thickness
+
   let read_component t =
     Cursor.one_of
       [
@@ -158,6 +162,8 @@ let read_text_decoration_shorthand t : text_decoration_shorthand =
     Cursor.fold_many Text_decoration.read_component ~init:Text_decoration.empty
       ~f:(Text_decoration.merge t) t
   in
+  if Text_decoration.is_empty acc then
+    Cursor.err_expected t "text-decoration value";
   Text_decoration.to_shorthand acc
 
 let rec read_text_decoration t : text_decoration =
@@ -174,13 +180,7 @@ let rec read_text_decoration t : text_decoration =
     ~calls:[ ("var", read_var) ]
     ~default:(fun t ->
       let shorthand = read_text_decoration_shorthand t in
-      (* For the main text-decoration property, require at least one line
-         decoration *)
-      if shorthand.lines = [] then
-        Cursor.err t
-          "text-decoration requires at least one line decoration (underline, \
-           overline, or line-through)"
-      else (Shorthand shorthand : text_decoration))
+      (Shorthand shorthand : text_decoration))
     t
 
 let rec read_text_decoration_skip t : text_decoration_skip =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3933,6 +3933,12 @@ let check_sheet_roundtrip name css =
         (String.trim (Css.to_string ~minify:true stylesheet))
   | Error e -> Alcotest.failf "%s: %s" css (Error.to_string e)
 
+(* CSS Text Decoration 4 sec. 2.6 joins the line, thickness, style and colour
+   components with [||], so no single component is mandatory. *)
+let text_decoration_optional_line () =
+  check_declaration ~roundtrip:true "text-decoration:red";
+  check_sheet_roundtrip "text-decoration" "a{text-decoration:red}"
+
 (* CSS Syntax 3 (ED) sec. 5.5.6 "consume a declaration" reads the value with
    [<semicolon-token>] as the stop token, then removes a trailing [!]
    [important] pair from that value and sets the declaration's important flag
@@ -4749,6 +4755,8 @@ let declaration_tests =
     test_case "scroll-margin negative lengths" `Quick scroll_margin_negative;
     test_case "scroll-margin negative lengths (sheet)" `Quick
       scroll_margin_negative_sheet;
+    test_case "text-decoration optional line" `Quick
+      text_decoration_optional_line;
     test_case "declaration value end" `Quick declaration_value_end;
     test_case "declaration value end (sheet)" `Quick declaration_value_end_sheet;
     test_case "declaration value end negatives" `Quick

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1995,13 +1995,12 @@ let test_text_decoration () =
   check_text_decoration "line-through";
   check_text_decoration ~expected:"none" "none";
   neg_cursor ~allow_partial:true read_text_decoration "invalid-decoration";
-  neg_cursor read_text_decoration "underline line-through underline";
   (* duplicate - per CSS spec, || combinator means each component at most
      once *)
-  neg_cursor read_text_decoration "solid";
-  (* that's a style *)
-  (* that's a color *)
-  neg_cursor read_text_decoration "red"
+  neg_cursor read_text_decoration "underline line-through underline";
+  (* A style or colour is valid without a line: every component is optional. *)
+  check_text_decoration "solid";
+  check_text_decoration "red"
 
 let test_text_decoration_shorthand () =
   (* Test individual parts. The printer holds every component it parsed;


### PR DESCRIPTION
## Summary

- add declaration and strict-sheet regressions for `text-decoration:red`
- accept any non-empty combination of the shorthand’s four `||` components
- update the stale property test that treated standalone style and colour values as invalid

## Testing

- `opam exec -- dune fmt`
- `opam exec -- dune build`
- `opam exec -- merlint --build`
- `env -u NO_COLOR opam exec -- dune test`