### PR TITLE
Parse standalone white-space collapse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -184,6 +184,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `white-space: collapse` reads as the new public `white_space.Collapse` node;
+  a white-space-collapse component is valid without the shorthand's other
+  optional longhands (#666)
 - `text-decoration` accepts a colour, style or thickness without a line value;
   its four components are joined by `||`, so none is individually mandatory
   (#665)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -4545,6 +4545,7 @@ type white_space = Properties.white_space =
   | Pre_wrap
   | Pre_line
   | Break_spaces
+  | Collapse
   | Preserve_nowrap
   | Inherit
   | Initial

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1289,6 +1289,7 @@ let rec pp_white_space : white_space Pp.t =
   | Pre_wrap -> Pp.string ctx "pre-wrap"
   | Pre_line -> Pp.string ctx "pre-line"
   | Break_spaces -> Pp.string ctx "break-spaces"
+  | Collapse -> Pp.string ctx "collapse"
   | Preserve_nowrap -> Pp.string ctx "preserve nowrap"
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
@@ -1755,6 +1756,7 @@ let rec read_white_space t : white_space =
           ("pre-wrap", Pre_wrap);
           ("pre-line", Pre_line);
           ("break-spaces", Break_spaces);
+          ("collapse", Collapse);
           ("inherit", Inherit);
           ("initial", Initial);
           ("unset", Unset);

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1532,6 +1532,7 @@ type white_space =
   | Pre_wrap
   | Pre_line
   | Break_spaces
+  | Collapse
   | Preserve_nowrap
   | Inherit
   | Initial

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3939,6 +3939,12 @@ let text_decoration_optional_line () =
   check_declaration ~roundtrip:true "text-decoration:red";
   check_sheet_roundtrip "text-decoration" "a{text-decoration:red}"
 
+(* CSS Text 4 sec. 3 allows each longhand component of [white-space] on its own;
+   omitted components take their initial values. *)
+let white_space_collapse_only () =
+  check_declaration ~roundtrip:true "white-space:collapse";
+  check_sheet_roundtrip "white-space" "a{white-space:collapse}"
+
 (* CSS Syntax 3 (ED) sec. 5.5.6 "consume a declaration" reads the value with
    [<semicolon-token>] as the stop token, then removes a trailing [!]
    [important] pair from that value and sets the declaration's important flag
@@ -4757,6 +4763,7 @@ let declaration_tests =
       scroll_margin_negative_sheet;
     test_case "text-decoration optional line" `Quick
       text_decoration_optional_line;
+    test_case "white-space collapse only" `Quick white_space_collapse_only;
     test_case "declaration value end" `Quick declaration_value_end;
     test_case "declaration value end (sheet)" `Quick declaration_value_end_sheet;
     test_case "declaration value end negatives" `Quick

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1478,6 +1478,7 @@ let test_white_space () =
   check_white_space "pre-wrap";
   check_white_space "pre-line";
   check_white_space "break-spaces";
+  check_white_space "collapse";
   check_white_space "inherit";
   neg_cursor read_white_space "invalid-space";
   (* hyphenated form incorrect *)


### PR DESCRIPTION
## Summary

- add declaration and strict-sheet regressions for `white-space:collapse`
- add the public `white_space.Collapse` constructor at the established mirrored type sites
- read and print the standalone white-space-collapse component

## Testing

- `opam exec -- dune fmt`
- `opam exec -- dune build`
- `opam exec -- merlint --build`
- `env -u NO_COLOR opam exec -- dune test`