### PR TITLE
Accept repeat-only border-image shorthand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -184,6 +184,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `border-image` accepts a repeat keyword without a source or slice; omitted
+  shorthand slots take their initial values, so `border-image: round` is valid
+  and no longer dropped (#667)
 - `white-space: collapse` reads as the new public `white_space.Collapse` node;
   a white-space-collapse component is valid without the shorthand's other
   optional longhands (#666)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -2168,7 +2168,8 @@ let read_border_image t : border_image =
     else Cursor.option read_mask_border_mode t
   in
   let mode = match mode_early with Some _ -> mode_early | None -> mode_late in
-  (match (source, slice) with
-  | None, None -> Cursor.err_expected t "border-image source or slice"
+  (match (source, slice, repeat) with
+  | None, None, None ->
+      Cursor.err_expected t "border-image source, slice, or repeat"
   | _ -> ());
   { source; slice; width; outset; repeat; mode }

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3945,6 +3945,12 @@ let white_space_collapse_only () =
   check_declaration ~roundtrip:true "white-space:collapse";
   check_sheet_roundtrip "white-space" "a{white-space:collapse}"
 
+(* CSS Backgrounds 3 sec. 5.7 sets omitted border-image shorthand slots to their
+   initial values, so the repeat component is valid on its own. *)
+let border_image_repeat_only () =
+  check_declaration ~roundtrip:true "border-image:round";
+  check_sheet_roundtrip "border-image" "a{border-image:round}"
+
 (* CSS Syntax 3 (ED) sec. 5.5.6 "consume a declaration" reads the value with
    [<semicolon-token>] as the stop token, then removes a trailing [!]
    [important] pair from that value and sets the declaration's important flag
@@ -4764,6 +4770,7 @@ let declaration_tests =
     test_case "text-decoration optional line" `Quick
       text_decoration_optional_line;
     test_case "white-space collapse only" `Quick white_space_collapse_only;
+    test_case "border-image repeat only" `Quick border_image_repeat_only;
     test_case "declaration value end" `Quick declaration_value_end;
     test_case "declaration value end (sheet)" `Quick declaration_value_end_sheet;
     test_case "declaration value end negatives" `Quick


### PR DESCRIPTION
## Summary

- add declaration and strict-sheet regressions for `border-image:round`
- treat a parsed repeat slot as sufficient for a non-empty border-image shorthand
- continue rejecting a shorthand with no source, slice, or repeat component

## Testing

- `opam exec -- dune fmt`
- `opam exec -- dune build`
- `opam exec -- merlint --build`
- `env -u NO_COLOR opam exec -- dune test`