### PR TITLE
animation: parse name-only timeline shorthands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- `timeline_shorthand_item.axis` is optional. The scroll and view timeline
+  shorthand grammars make their axis slots optional; omitted axes now parse as
+  `None` and round-trip without being rewritten as `block` (#668)
 - `flex_basis.From_font` is gone. `from-font` is not part of the `<width>`
   grammar accepted by `flex-basis`; the constructor printed CSS that the
   `flex-basis` reader correctly rejects (#658)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7123,7 +7123,7 @@ type timeline_axis = Properties.timeline_axis =
 
 type timeline_shorthand_item = Properties.timeline_shorthand_item = {
   name : string;
-  axis : timeline_axis;
+  axis : timeline_axis option;
 }
 
 type timeline_shorthand = Properties.timeline_shorthand =

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -328,8 +328,11 @@ let rec pp_timeline_name : timeline_name Pp.t =
 let pp_timeline_shorthand_item : timeline_shorthand_item Pp.t =
  fun ctx { name; axis } ->
   pp_ident ctx name;
-  Pp.space ctx ();
-  pp_timeline_axis ctx axis
+  match axis with
+  | None -> ()
+  | Some axis ->
+      Pp.space ctx ();
+      pp_timeline_axis ctx axis
 
 let rec pp_timeline_shorthand : timeline_shorthand Pp.t =
  fun ctx -> function
@@ -673,7 +676,7 @@ let read_timeline_shorthand_item t : timeline_shorthand_item =
   if not (Custom_property_name.is_valid name) then
     Cursor.err_invalid t "timeline name";
   Cursor.ws t;
-  let axis = read_timeline_axis t in
+  let axis = Cursor.option read_timeline_axis t in
   { name; axis }
 
 let rec read_timeline_shorthand t : timeline_shorthand =

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3880,7 +3880,7 @@ type timeline_name =
   | Revert_layer
   | Var of timeline_name var
 
-type timeline_shorthand_item = { name : string; axis : timeline_axis }
+type timeline_shorthand_item = { name : string; axis : timeline_axis option }
 
 type timeline_shorthand =
   | None

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1713,7 +1713,8 @@ let vars_of_timeline_shorthand (value : Properties.timeline_shorthand) =
   | Var v -> [ V v ]
   | Timelines items ->
       List.concat_map
-        (fun { Properties.axis; _ } -> vars_of_timeline_axis axis)
+        (fun { Properties.axis; _ } ->
+          Option.fold ~none:[] ~some:vars_of_timeline_axis axis)
         items
   | _ -> []
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3951,6 +3951,17 @@ let border_image_repeat_only () =
   check_declaration ~roundtrip:true "border-image:round";
   check_sheet_roundtrip "border-image" "a{border-image:round}"
 
+(* Scroll-driven Animations 1 sec. 2.3.3 and 3.4.4 make the axis optional in
+   both named timeline shorthands. *)
+let timeline_name_only () =
+  List.iter
+    (fun (property, name) ->
+      let declaration = String.concat "" [ property; ":"; name ] in
+      check_declaration ~roundtrip:true declaration;
+      check_sheet_roundtrip property
+        (String.concat "" [ "a{"; declaration; "}" ]))
+    [ ("scroll-timeline", "--t"); ("view-timeline", "--v") ]
+
 (* CSS Syntax 3 (ED) sec. 5.5.6 "consume a declaration" reads the value with
    [<semicolon-token>] as the stop token, then removes a trailing [!]
    [important] pair from that value and sets the declaration's important flag
@@ -4771,6 +4782,7 @@ let declaration_tests =
       text_decoration_optional_line;
     test_case "white-space collapse only" `Quick white_space_collapse_only;
     test_case "border-image repeat only" `Quick border_image_repeat_only;
+    test_case "timeline name only" `Quick timeline_name_only;
     test_case "declaration value end" `Quick declaration_value_end;
     test_case "declaration value end (sheet)" `Quick declaration_value_end_sheet;
     test_case "declaration value end negatives" `Quick

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3920,9 +3920,9 @@ let test_timeline_shorthand () =
   check_timeline_shorthand "--main block";
   check_timeline_shorthand "--scroll inline";
   check_timeline_shorthand "--x x";
+  check_timeline_shorthand "--main";
   neg_cursor read_timeline_shorthand "main block";
-  neg_cursor read_timeline_shorthand "--main";
-  neg_cursor read_timeline_shorthand "--main z"
+  neg_cursor ~allow_partial:true read_timeline_shorthand "--main z"
 
 let test_caption_side () =
   check_caption_side "top";
@@ -4564,6 +4564,7 @@ let spec_generated_text_timeline_edges () =
   check_timeline_inset_item "calc(50% + 10px)";
   check_timeline_name ~expected:"--main,--alt" "--main, --alt";
   check_timeline_shorthand_item "--main block";
+  check_timeline_shorthand_item "--main";
   check_view_transition_class "card active";
   check_view_transition_name "match-element";
   neg_cursor read_text_box "trim-start trim-end";
@@ -4595,7 +4596,7 @@ let spec_generated_text_timeline_edges () =
   neg_cursor ~allow_partial:true read_timeline_inset "auto auto auto";
   neg_cursor read_timeline_inset_item "-1px";
   neg_cursor ~allow_partial:true read_timeline_name "none --main";
-  neg_cursor read_timeline_shorthand_item "--main z";
+  neg_cursor ~allow_partial:true read_timeline_shorthand_item "--main z";
   neg_cursor ~allow_partial:true read_view_transition_class "none card";
   neg_cursor ~allow_partial:true read_view_transition_name "match-element card"
 


### PR DESCRIPTION
Scroll Animations 1 makes the axis optional in both the scroll-timeline and view-timeline shorthands. Cascade required it and dropped name-only declarations during recovery.

Represent the axis as an option, preserve its omission when printing, and keep variable discovery over present axes. Add direct and strict stylesheet regressions for both shorthands.

Tests: env -u NO_COLOR opam exec -- dune test