### PR TITLE
animation: parse view-timeline inset slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- `Properties.View_timeline` carries a `view_timeline_shorthand` instead of a
+  `timeline_shorthand`. Its items include the shorthand's optional inset slot,
+  so values such as `view-timeline:--v 10% 20%` parse and round-trip (#669)
 - `timeline_shorthand_item.axis` is optional. The scroll and view timeline
   shorthand grammars make their axis slots optional; omitted axes now parse as
   `None` and round-trip without being rewritten as `block` (#668)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7136,6 +7136,22 @@ type timeline_shorthand = Properties.timeline_shorthand =
   | Revert_layer
   | Var of timeline_shorthand var
 
+type view_timeline_shorthand_item = Properties.view_timeline_shorthand_item = {
+  name : string;
+  axis : timeline_axis option;
+  inset : Properties.timeline_inset option;
+}
+
+type view_timeline_shorthand = Properties.view_timeline_shorthand =
+  | None
+  | Timelines of view_timeline_shorthand_item list
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of view_timeline_shorthand var
+
 val touch_action : touch_action -> declaration
 (** [touch_action action] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action}

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1627,7 +1627,7 @@ let read_motion_value : type a. a property -> Cursor.t -> declaration option =
   | View_timeline_name -> Some (v View_timeline_name (read_timeline_name t))
   | View_timeline_axis -> Some (v View_timeline_axis (read_timeline_axis t))
   | View_timeline_inset -> Some (v View_timeline_inset (read_timeline_inset t))
-  | View_timeline -> Some (v View_timeline (read_timeline_shorthand t))
+  | View_timeline -> Some (v View_timeline (read_view_timeline_shorthand t))
   | Timeline_scope -> Some (v Timeline_scope (read_timeline_name t))
   | Perspective_origin ->
       Some (v Perspective_origin (read_perspective_origin t))

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -367,6 +367,32 @@ let rec pp_timeline_inset : timeline_inset Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+let pp_view_timeline_shorthand_item : view_timeline_shorthand_item Pp.t =
+ fun ctx { name; axis; inset } ->
+  pp_ident ctx name;
+  Option.iter
+    (fun axis ->
+      Pp.space ctx ();
+      pp_timeline_axis ctx axis)
+    axis;
+  Option.iter
+    (fun inset ->
+      Pp.space ctx ();
+      pp_timeline_inset ctx inset)
+    inset
+
+let rec pp_view_timeline_shorthand : view_timeline_shorthand Pp.t =
+ fun ctx -> function
+  | None -> Pp.string ctx "none"
+  | Timelines items ->
+      Pp.list ~sep:Pp.comma pp_view_timeline_shorthand_item ctx items
+  | Initial -> Pp.string ctx "initial"
+  | Inherit -> Pp.string ctx "inherit"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_view_timeline_shorthand ctx v
+
 let pp_timing_float ctx f =
   if Float.is_nan f then Pp.nan_value ctx ""
   else Pp.string ctx (Pp.string_of_float ~drop_leading_zero:(Pp.minified ctx) f)
@@ -691,9 +717,10 @@ let rec read_timeline_shorthand t : timeline_shorthand =
     ]
     ~var:(fun t -> Var (Values.read_var read_timeline_shorthand t))
     ~default:(fun t ->
-      Timelines
-        (Cursor.list ~sep:Cursor.comma ~at_least:1 read_timeline_shorthand_item
-           t))
+      (Timelines
+         (Cursor.list ~sep:Cursor.comma ~at_least:1 read_timeline_shorthand_item
+            t)
+        : timeline_shorthand))
     t
 
 let read_timeline_inset_item t : timeline_inset_item =
@@ -721,6 +748,58 @@ let rec read_timeline_inset t : timeline_inset =
       | [ first ] -> (Inset (first, None) : timeline_inset)
       | [ first; second ] -> (Inset (first, Some second) : timeline_inset)
       | _ -> Cursor.err_expected t "timeline-inset")
+    t
+
+let read_view_timeline_shorthand_item t : view_timeline_shorthand_item =
+  (* Scroll-driven Animations 1 sec. 3.4.4: the name is followed by
+     [<'view-timeline-axis'> || <'view-timeline-inset'>]?, so try each missing
+     slot until neither consumes input. *)
+  Cursor.ws t;
+  let name = Cursor.ident ~keep_case:true t in
+  if not (Custom_property_name.is_valid name) then
+    Cursor.err_invalid t "timeline name";
+  let axis = ref Option.None in
+  let inset = ref Option.None in
+  let try_axis () =
+    if !axis <> Option.None then false
+    else
+      match Cursor.option read_timeline_axis t with
+      | Some value ->
+          axis := Some value;
+          true
+      | None -> false
+  in
+  let try_inset () =
+    if !inset <> Option.None then false
+    else
+      match Cursor.option read_timeline_inset t with
+      | Some value ->
+          inset := Some value;
+          true
+      | None -> false
+  in
+  let rec loop () =
+    Cursor.ws t;
+    if try_axis () || try_inset () then loop ()
+  in
+  loop ();
+  { name; axis = !axis; inset = !inset }
+
+let rec read_view_timeline_shorthand t : view_timeline_shorthand =
+  Cursor.enum_or_var "view-timeline"
+    [
+      ("none", (None : view_timeline_shorthand));
+      ("initial", Initial);
+      ("inherit", Inherit);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (Values.read_var read_view_timeline_shorthand t))
+    ~default:(fun t ->
+      Timelines
+        (Cursor.list ~sep:Cursor.comma ~at_least:1
+           read_view_timeline_shorthand_item t))
     t
 
 let read_steps_direction t : steps_direction =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3623,7 +3623,8 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Animation_timeline, value -> value
   | Animation_range, value -> value
   | (Animation_range_start | Animation_range_end), value -> value
-  | (Scroll_timeline | View_timeline), value -> value
+  | Scroll_timeline, value -> value
+  | View_timeline, value -> value
   | (Scroll_timeline_name | View_timeline_name | Timeline_scope), value -> value
   | (Scroll_timeline_axis | View_timeline_axis), value -> value
   | View_transition_name, value -> value
@@ -4585,7 +4586,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | View_timeline_name -> pp pp_timeline_name
   | View_timeline_axis -> pp pp_timeline_axis
   | View_timeline_inset -> pp pp_timeline_inset
-  | View_timeline -> pp pp_timeline_shorthand
+  | View_timeline -> pp pp_view_timeline_shorthand
   | Timeline_scope -> pp pp_timeline_name
   | Perspective_origin -> pp pp_perspective_origin
   | Object_position -> pp pp_position_value

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -134,11 +134,17 @@ val read_shadow : Cursor.t -> shadow
 (** [read_shadow t] parses a {!val-shadow} value from [t]. *)
 
 val read_timeline_shorthand : Cursor.t -> timeline_shorthand
-(** [read_timeline_shorthand t] parses [scroll-timeline] and [view-timeline]. *)
+(** [read_timeline_shorthand t] parses [scroll-timeline]. *)
 
 val pp_timeline_shorthand : timeline_shorthand Pp.t
-(** [pp_timeline_shorthand] pretty-prints [scroll-timeline] and [view-timeline]
-    shorthand values. *)
+(** [pp_timeline_shorthand] pretty-prints [scroll-timeline] shorthand values. *)
+
+val read_view_timeline_shorthand : Cursor.t -> view_timeline_shorthand
+(** [read_view_timeline_shorthand t] parses [view-timeline]. *)
+
+val pp_view_timeline_shorthand : view_timeline_shorthand Pp.t
+(** [pp_view_timeline_shorthand] pretty-prints [view-timeline] shorthand values.
+*)
 
 val pp_timeline_axis : timeline_axis Pp.t
 (** [pp_timeline_axis] pretty-prints a timeline axis. *)
@@ -291,12 +297,20 @@ val read_timeline_inset_item : Cursor.t -> timeline_inset_item
 (** [read_timeline_inset_item t] parses one [view-timeline-inset] item. *)
 
 val pp_timeline_shorthand_item : timeline_shorthand_item Pp.t
-(** [pp_timeline_shorthand_item] pretty-prints one [scroll-timeline]/
-    [view-timeline] shorthand item. *)
+(** [pp_timeline_shorthand_item] pretty-prints one [scroll-timeline] shorthand
+    item. *)
 
 val read_timeline_shorthand_item : Cursor.t -> timeline_shorthand_item
-(** [read_timeline_shorthand_item t] parses one [scroll-timeline]/
-    [view-timeline] shorthand item. *)
+(** [read_timeline_shorthand_item t] parses one [scroll-timeline] shorthand
+    item. *)
+
+val pp_view_timeline_shorthand_item : view_timeline_shorthand_item Pp.t
+(** [pp_view_timeline_shorthand_item] pretty-prints one [view-timeline]
+    shorthand item. *)
+
+val read_view_timeline_shorthand_item : Cursor.t -> view_timeline_shorthand_item
+(** [read_view_timeline_shorthand_item t] parses one [view-timeline] shorthand
+    item. *)
 
 val pp_font_variant_emoji : font_variant_emoji Pp.t
 (** [pp_font_variant_emoji] pretty-prints [font-variant-emoji]. *)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3903,6 +3903,22 @@ type timeline_inset =
   | Revert_layer
   | Var of timeline_inset var
 
+type view_timeline_shorthand_item = {
+  name : string;
+  axis : timeline_axis option;
+  inset : timeline_inset option;
+}
+
+type view_timeline_shorthand =
+  | None
+  | Timelines of view_timeline_shorthand_item list
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of view_timeline_shorthand var
+
 type overscroll_behavior =
   | Auto
   | Contain
@@ -4881,7 +4897,7 @@ type 'a property =
   | View_timeline_name : timeline_name property
   | View_timeline_axis : timeline_axis property
   | View_timeline_inset : timeline_inset property
-  | View_timeline : timeline_shorthand property
+  | View_timeline : view_timeline_shorthand property
   | Timeline_scope : timeline_name property
   | Perspective : length property
   | Perspective_origin : perspective_origin property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -858,13 +858,17 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Container -> [ key "container-name"; key "container-type" ]
   | Container_name -> [ key "container-name" ]
   | Container_type -> [ key "container-type" ]
-  (* Scroll-driven Animations 1 sec. 2.3.3 and 3.4.4. [view-timeline-inset] is
-     not part of [view-timeline]. *)
+  (* Scroll-driven Animations 1 sec. 2.3.3 and 3.4.4. *)
   | Scroll_timeline ->
       [ key "scroll-timeline-name"; key "scroll-timeline-axis" ]
   | Scroll_timeline_name -> [ key "scroll-timeline-name" ]
   | Scroll_timeline_axis -> [ key "scroll-timeline-axis" ]
-  | View_timeline -> [ key "view-timeline-name"; key "view-timeline-axis" ]
+  | View_timeline ->
+      [
+        key "view-timeline-name";
+        key "view-timeline-axis";
+        key "view-timeline-inset";
+      ]
   | View_timeline_name -> [ key "view-timeline-name" ]
   | View_timeline_axis -> [ key "view-timeline-axis" ]
   (* CSS UI 4 sec. 5.2.4. *)

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1711,9 +1711,9 @@ let vars_of_timeline_name (value : Properties.timeline_name) =
 let vars_of_timeline_shorthand (value : Properties.timeline_shorthand) =
   match value with
   | Var v -> [ V v ]
-  | Timelines items ->
+  | (Timelines items : Properties.timeline_shorthand) ->
       List.concat_map
-        (fun { Properties.axis; _ } ->
+        (fun ({ Properties.axis; _ } : Properties.timeline_shorthand_item) ->
           Option.fold ~none:[] ~some:vars_of_timeline_axis axis)
         items
   | _ -> []
@@ -1728,6 +1728,18 @@ let vars_of_timeline_inset (value : Properties.timeline_inset) =
       vars_of_timeline_inset_item first
       @ Option.value ~default:[] (Option.map vars_of_timeline_inset_item second)
   | Initial | Inherit | Unset | Revert | Revert_layer -> []
+
+let vars_of_view_timeline_shorthand (value : Properties.view_timeline_shorthand)
+    =
+  match value with
+  | Var v -> [ V v ]
+  | Timelines items ->
+      List.concat_map
+        (fun { Properties.axis; inset; _ } ->
+          Option.fold ~none:[] ~some:vars_of_timeline_axis axis
+          @ Option.fold ~none:[] ~some:vars_of_timeline_inset inset)
+        items
+  | _ -> []
 
 let vars_of_direction (value : Properties.direction) =
   match value with Var v -> [ V v ] | _ -> []
@@ -2403,7 +2415,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | View_timeline_name, value -> vars_of_timeline_name value
   | View_timeline_axis, value -> vars_of_timeline_axis value
   | View_timeline_inset, value -> vars_of_timeline_inset value
-  | View_timeline, value -> vars_of_timeline_shorthand value
+  | View_timeline, value -> vars_of_view_timeline_shorthand value
   | Timeline_scope, value -> vars_of_timeline_name value
   | Webkit_appearance, value -> vars_of_webkit_appearance value
   | Webkit_background_clip, value -> vars_of_background_box value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3962,6 +3962,12 @@ let timeline_name_only () =
         (String.concat "" [ "a{"; declaration; "}" ]))
     [ ("scroll-timeline", "--t"); ("view-timeline", "--v") ]
 
+(* Scroll-driven Animations 1 sec. 3.4.4 includes the optional
+   view-timeline-inset slot in each view-timeline shorthand item. *)
+let view_timeline_inset_slot () =
+  check_declaration ~roundtrip:true "view-timeline:--v 10% 20%";
+  check_sheet_roundtrip "view-timeline" "a{view-timeline:--v 10% 20%}"
+
 (* CSS Syntax 3 (ED) sec. 5.5.6 "consume a declaration" reads the value with
    [<semicolon-token>] as the stop token, then removes a trailing [!]
    [important] pair from that value and sets the declaration's important flag
@@ -4783,6 +4789,7 @@ let declaration_tests =
     test_case "white-space collapse only" `Quick white_space_collapse_only;
     test_case "border-image repeat only" `Quick border_image_repeat_only;
     test_case "timeline name only" `Quick timeline_name_only;
+    test_case "view-timeline inset slot" `Quick view_timeline_inset_slot;
     test_case "declaration value end" `Quick declaration_value_end;
     test_case "declaration value end (sheet)" `Quick declaration_value_end_sheet;
     test_case "declaration value end negatives" `Quick

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -624,6 +624,10 @@ let check_timeline_shorthand =
   check_value_cursor "timeline_shorthand" read_timeline_shorthand
     pp_timeline_shorthand
 
+let check_view_timeline_shorthand =
+  check_value_cursor "view_timeline_shorthand" read_view_timeline_shorthand
+    pp_view_timeline_shorthand
+
 let check_caption_side =
   check_value_cursor "caption_side" read_caption_side pp_caption_side
 
@@ -1147,6 +1151,10 @@ let check_timeline_name =
 let check_timeline_shorthand_item =
   check_value_cursor "timeline_shorthand_item" read_timeline_shorthand_item
     pp_timeline_shorthand_item
+
+let check_view_timeline_shorthand_item =
+  check_value_cursor "view_timeline_shorthand_item"
+    read_view_timeline_shorthand_item pp_view_timeline_shorthand_item
 
 let check_view_transition_class =
   check_value_cursor "view_transition_class" read_view_transition_class
@@ -3924,6 +3932,26 @@ let test_timeline_shorthand () =
   neg_cursor read_timeline_shorthand "main block";
   neg_cursor ~allow_partial:true read_timeline_shorthand "--main z"
 
+let test_view_timeline_shorthand () =
+  check_view_timeline_shorthand "--main";
+  check_view_timeline_shorthand "--main block";
+  check_view_timeline_shorthand "--main 10%";
+  check_view_timeline_shorthand "--main x 10% 20%";
+  check_view_timeline_shorthand ~expected:"--main x 10%" "--main 10% x";
+  check_view_timeline_shorthand "--main 10%,--alt y auto";
+  neg_cursor read_view_timeline_shorthand "main 10%";
+  neg_cursor ~allow_partial:true read_view_timeline_shorthand "--main x y";
+  neg_cursor ~allow_partial:true read_view_timeline_shorthand
+    "--main 10% 20% 30%"
+
+let test_view_timeline_shorthand_item () =
+  check_view_timeline_shorthand_item "--main";
+  check_view_timeline_shorthand_item "--main inline";
+  check_view_timeline_shorthand_item "--main auto 10%";
+  check_view_timeline_shorthand_item ~expected:"--main x 10%" "--main 10% x";
+  neg_cursor read_view_timeline_shorthand_item "main 10%";
+  neg_cursor ~allow_partial:true read_view_timeline_shorthand_item "--main x y"
+
 let test_caption_side () =
   check_caption_side "top";
   check_caption_side "bottom";
@@ -4972,6 +5000,9 @@ let additional_tests =
     test_case "page_size_orientation" `Quick test_page_size_orientation;
     test_case "axis" `Quick test_timeline_axis;
     test_case "timeline_shorthand" `Quick test_timeline_shorthand;
+    test_case "view_timeline_shorthand" `Quick test_view_timeline_shorthand;
+    test_case "view_timeline_shorthand_item" `Quick
+      test_view_timeline_shorthand_item;
     test_case "caption_side" `Quick test_caption_side;
     test_case "color_scheme" `Quick test_color_scheme;
     test_case "columns_value" `Quick test_columns_value;


### PR DESCRIPTION
Scroll Animations 1 includes an optional inset in each view-timeline shorthand item. Cascade shared the scroll-timeline item type, so it had nowhere to store the inset and dropped valid declarations.

Give view-timeline its own typed shorthand value, parse axis and inset in either order, preserve both in printing and variable discovery, and include the inset longhand in shorthand overlap tracking. Add direct, strict stylesheet, parser/printer, and API-consistency coverage.

Tests: env -u NO_COLOR opam exec -- dune test --display short