### PR TITLE
text: parse edge-only text-box shorthand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- `text_box.Box` carries an optional trim value. The `text-box` grammar makes
+  both shorthand slots optional; edge-only values such as `cap alphabetic` now
+  parse and preserve the omitted trim slot (#670)
 - `Properties.View_timeline` carries a `view_timeline_shorthand` instead of a
   `timeline_shorthand`. Its items include the shorthand's optional inset slot,
   so values such as `view-timeline:--v 10% 20%` parse and round-trip (#669)

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1102,11 +1102,12 @@ let rec pp_text_box_edge : text_box_edge Pp.t =
 let rec pp_text_box : text_box Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_text_box ctx v
+  | Box (None, None) -> pp_text_box_trim ctx Trim_both
   | Box (trim, edge) ->
-      pp_text_box_trim ctx trim;
+      Option.iter (pp_text_box_trim ctx) trim;
       Option.iter
         (fun edge ->
-          Pp.space ctx ();
+          if Option.is_some trim then Pp.space ctx ();
           pp_text_box_edge ctx edge)
         edge
   | Initial -> Pp.string ctx "initial"
@@ -1496,13 +1497,19 @@ let rec read_text_wrap_style t : text_wrap_style =
     ~var:(fun t -> Var (read_var read_text_wrap_style t))
     t
 
-let rec read_text_box_trim t : text_box_trim =
-  Cursor.enum_or_var "text-box-trim"
+let read_text_box_trim_value t : text_box_trim =
+  Cursor.enum "text-box-trim"
     [
       ("none", (None : text_box_trim));
       ("trim-start", Trim_start);
       ("trim-end", Trim_end);
       ("trim-both", Trim_both);
+    ]
+    t
+
+let rec read_text_box_trim t : text_box_trim =
+  Cursor.enum_or_var "text-box-trim"
+    [
       ("inherit", Inherit);
       ("initial", Initial);
       ("unset", Unset);
@@ -1510,7 +1517,7 @@ let rec read_text_box_trim t : text_box_trim =
       ("revert-layer", Revert_layer);
     ]
     ~var:(fun t -> Var (read_var read_text_box_trim t))
-    t
+    ~default:read_text_box_trim_value t
 
 let read_text_box_edge_keyword t : text_box_edge_keyword =
   Cursor.enum "text-box-edge"
@@ -1563,13 +1570,36 @@ let rec read_text_box t : text_box =
     ]
     ~var:(fun t -> (Var (Values.read_var read_text_box t) : text_box))
     ~default:(fun t ->
-      let trim = read_text_box_trim t in
-      Cursor.ws t;
-      let edge : text_box_edge option =
-        if Cursor.is_done t then None
-        else Some (read_text_box_edge ~global:false t)
+      (* CSS Inline 3 sec. 6.1 joins the trim and edge slots with [||], so
+         either may be omitted and they may appear in either order. *)
+      let trim = ref Option.None in
+      let edge = ref Option.None in
+      let try_trim () =
+        if !trim <> Option.None then false
+        else
+          match Cursor.option read_text_box_trim_value t with
+          | Some value ->
+              trim := Some value;
+              true
+          | None -> false
       in
-      (Box (trim, edge) : text_box))
+      let try_edge () =
+        if !edge <> Option.None then false
+        else
+          match Cursor.option (read_text_box_edge ~global:false) t with
+          | Some value ->
+              edge := Some value;
+              true
+          | None -> false
+      in
+      let rec loop () =
+        Cursor.ws t;
+        if try_trim () || try_edge () then loop ()
+      in
+      loop ();
+      if !trim = Option.None && !edge = Option.None then
+        Cursor.err_invalid t "text-box";
+      (Box (!trim, !edge) : text_box))
     t
 
 let read_line_fit_edge_keyword t : line_fit_edge_keyword =

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1339,7 +1339,7 @@ type text_box_edge =
   | Var of text_box_edge var
 
 type text_box =
-  | Box of text_box_trim * text_box_edge option
+  | Box of text_box_trim option * text_box_edge option
   | Inherit
   | Initial
   | Unset

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1272,7 +1272,7 @@ let vars_of_text_box (value : Properties.text_box) =
   match value with
   | Var v -> [ V v ]
   | Box (trim, edge) ->
-      vars_of_text_box_trim trim
+      Option.value ~default:[] (Option.map vars_of_text_box_trim trim)
       @ Option.value ~default:[] (Option.map vars_of_text_box_edge edge)
   | Initial | Inherit | Unset | Revert | Revert_layer -> []
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3968,6 +3968,12 @@ let view_timeline_inset_slot () =
   check_declaration ~roundtrip:true "view-timeline:--v 10% 20%";
   check_sheet_roundtrip "view-timeline" "a{view-timeline:--v 10% 20%}"
 
+(* CSS Inline 3 sec. 6.1 joins text-box-trim and text-box-edge with [||], so the
+   edge is valid without an explicit trim value. *)
+let text_box_edge_only () =
+  check_declaration ~roundtrip:true "text-box:cap alphabetic";
+  check_sheet_roundtrip "text-box" "a{text-box:cap alphabetic}"
+
 (* CSS Syntax 3 (ED) sec. 5.5.6 "consume a declaration" reads the value with
    [<semicolon-token>] as the stop token, then removes a trailing [!]
    [important] pair from that value and sets the declaration's important flag
@@ -4790,6 +4796,7 @@ let declaration_tests =
     test_case "border-image repeat only" `Quick border_image_repeat_only;
     test_case "timeline name only" `Quick timeline_name_only;
     test_case "view-timeline inset slot" `Quick view_timeline_inset_slot;
+    test_case "text-box edge only" `Quick text_box_edge_only;
     test_case "declaration value end" `Quick declaration_value_end;
     test_case "declaration value end (sheet)" `Quick declaration_value_end_sheet;
     test_case "declaration value end negatives" `Quick

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4560,6 +4560,8 @@ let spec_generated_position_interaction_edges () =
 (* ignore-test: grouped generated-surface vectors. *)
 let spec_generated_text_timeline_edges () =
   check_text_box "trim-both text alphabetic";
+  check_text_box "cap alphabetic";
+  check_text_box ~expected:"trim-both cap alphabetic" "cap alphabetic trim-both";
   check_text_box_edge "text ideographic";
   check_text_box_edge_keyword "ideographic-ink";
   check_text_box_trim "trim-both";
@@ -4595,7 +4597,8 @@ let spec_generated_text_timeline_edges () =
   check_timeline_shorthand_item "--main";
   check_view_transition_class "card active";
   check_view_transition_name "match-element";
-  neg_cursor read_text_box "trim-start trim-end";
+  neg_cursor ~allow_partial:true read_text_box "trim-start trim-end";
+  neg_cursor read_text_box "cap";
   neg_cursor read_text_box_edge "text text";
   neg_cursor read_text_box_edge_keyword "baseline";
   neg_cursor read_text_box_trim "trim";


### PR DESCRIPTION
CSS Inline 3 joins text-box-trim and text-box-edge with ||. Cascade required trim first, so it dropped edge-only and reverse-order declarations.\n\nRepresent trim as optional, parse the two slots in either order, preserve omission in printing, and update variable discovery. Add direct, strict stylesheet, positive-order, and negative coverage.\n\nTests: env -u NO_COLOR opam exec -- dune test --display short