### PR TITLE
text: parse normal text-box shorthand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- `text_box.Normal` represents the `normal` shorthand branch, which now parses
+  and round-trips instead of being dropped (#671)
 - `text_box.Box` carries an optional trim value. The `text-box` grammar makes
   both shorthand slots optional; edge-only values such as `cap alphabetic` now
   parse and preserve the omitted trim slot (#670)

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1102,6 +1102,7 @@ let rec pp_text_box_edge : text_box_edge Pp.t =
 let rec pp_text_box : text_box Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_text_box ctx v
+  | Normal -> Pp.string ctx "normal"
   | Box (None, None) -> pp_text_box_trim ctx Trim_both
   | Box (trim, edge) ->
       Option.iter (pp_text_box_trim ctx) trim;
@@ -1562,6 +1563,7 @@ let rec read_text_box_edge ?(global = true) t : text_box_edge =
 let rec read_text_box t : text_box =
   Cursor.enum_or_var "text-box"
     [
+      ("normal", (Normal : text_box));
       ("initial", (Initial : text_box));
       ("inherit", Inherit);
       ("unset", Unset);

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1339,6 +1339,7 @@ type text_box_edge =
   | Var of text_box_edge var
 
 type text_box =
+  | Normal
   | Box of text_box_trim option * text_box_edge option
   | Inherit
   | Initial

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1274,7 +1274,7 @@ let vars_of_text_box (value : Properties.text_box) =
   | Box (trim, edge) ->
       Option.value ~default:[] (Option.map vars_of_text_box_trim trim)
       @ Option.value ~default:[] (Option.map vars_of_text_box_edge edge)
-  | Initial | Inherit | Unset | Revert | Revert_layer -> []
+  | Normal | Initial | Inherit | Unset | Revert | Revert_layer -> []
 
 let vars_of_inline_sizing (value : Properties.inline_sizing) =
   match value with Var v -> [ V v ] | _ -> []

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3974,6 +3974,11 @@ let text_box_edge_only () =
   check_declaration ~roundtrip:true "text-box:cap alphabetic";
   check_sheet_roundtrip "text-box" "a{text-box:cap alphabetic}"
 
+(* CSS Inline 3 sec. 6.1 gives [normal] its own text-box shorthand branch. *)
+let text_box_normal () =
+  check_declaration ~roundtrip:true "text-box:normal";
+  check_sheet_roundtrip "text-box" "a{text-box:normal}"
+
 (* CSS Syntax 3 (ED) sec. 5.5.6 "consume a declaration" reads the value with
    [<semicolon-token>] as the stop token, then removes a trailing [!]
    [important] pair from that value and sets the declaration's important flag
@@ -4797,6 +4802,7 @@ let declaration_tests =
     test_case "timeline name only" `Quick timeline_name_only;
     test_case "view-timeline inset slot" `Quick view_timeline_inset_slot;
     test_case "text-box edge only" `Quick text_box_edge_only;
+    test_case "text-box normal" `Quick text_box_normal;
     test_case "declaration value end" `Quick declaration_value_end;
     test_case "declaration value end (sheet)" `Quick declaration_value_end_sheet;
     test_case "declaration value end negatives" `Quick

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4561,6 +4561,7 @@ let spec_generated_position_interaction_edges () =
 let spec_generated_text_timeline_edges () =
   check_text_box "trim-both text alphabetic";
   check_text_box "cap alphabetic";
+  check_text_box "normal";
   check_text_box ~expected:"trim-both cap alphabetic" "cap alphabetic trim-both";
   check_text_box_edge "text ideographic";
   check_text_box_edge_keyword "ideographic-ink";


### PR DESCRIPTION
CSS Inline 3 gives normal its own text-box shorthand branch. Cascade only tried the component slots, so it rejected and dropped text-box:normal.\n\nAdd an explicit Normal constructor, parse and print it, and account for it in variable discovery. Add direct parser, strict stylesheet, and value-reader regressions.\n\nTests: env -u NO_COLOR opam exec -- dune test --display short