### PR TITLE
transform: canonicalize position origins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -530,6 +530,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` canonicalises programmatically constructed shared `<position>`
+  nodes in `transform-origin` to the property's XY/XYZ nodes before hashing, so
+  typed position nodes and coordinate origins now factor together (#672)
 - `--minify` collapses repeated sides in the `scroll-margin` and
   `scroll-padding` physical and logical shorthands before declaration hashes
   are compared, so equivalent rules factor together (#650)

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -729,42 +729,80 @@ let position_offset_zero (lp : Values.length_percentage) :
     Values.length_percentage =
   match lp with Pct 0. | Length (Pct 0.) -> Length Zero | lp -> lp
 
+let position_pct n : Values.length = Pct n
+
+let static_position_offset : Values.length_percentage -> Values.length option =
+  function
+  | Length l -> Some l
+  | Pct n -> Some (position_pct n)
+  | Env _ | Var _ | Calc _ | Invalid _ -> None
+
+let position_edge_offset edge offset =
+  match edge with
+  | "left" | "top" -> static_position_offset offset
+  | "right" | "bottom" -> (
+      match offset with
+      | Pct n -> Some (position_pct (100. -. n))
+      | Length l -> (
+          match Values.normalize_length l with
+          | Zero -> Some (position_pct 100.)
+          | Pct n -> Some (position_pct (100. -. n))
+          | _ -> None)
+      | Env _ | Var _ | Calc _ | Invalid _ -> None)
+  | _ -> None
+
+let horizontal_position = function
+  | "left" -> Some (position_pct 0.)
+  | "center" -> Some (position_pct 50.)
+  | "right" -> Some (position_pct 100.)
+  | _ -> None
+
+let vertical_position = function
+  | "top" -> Some (position_pct 0.)
+  | "center" -> Some (position_pct 50.)
+  | "bottom" -> Some (position_pct 100.)
+  | _ -> None
+
+let position_pair x y =
+  match (x, y) with Some x, Some y -> Some (x, y) | _ -> None
+
 (* The horizontal and vertical components of a statically-known position; [None]
    when a component is dynamic ([var()], [calc()], [env()]) or offset from a
    non-zero edge ([right]/[bottom] offsets need the box size). *)
 let position_xy : position_value -> (Values.length * Values.length) option =
-  let pct n : Values.length = Pct n in
-  let static_offset : Values.length_percentage -> Values.length option =
-    function
-    | Length l -> Some l
-    | Pct n -> Some (pct n)
-    | Env _ | Var _ | Calc _ | Invalid _ -> None
-  in
   function
-  | Center -> Some (pct 50., pct 50.)
-  | Left -> Some (pct 0., pct 50.)
-  | Right -> Some (pct 100., pct 50.)
-  | Top -> Some (pct 50., pct 0.)
-  | Bottom -> Some (pct 50., pct 100.)
-  | Left_top | Top_left -> Some (pct 0., pct 0.)
-  | Left_center -> Some (pct 0., pct 50.)
-  | Left_bottom | Bottom_left -> Some (pct 0., pct 100.)
-  | Right_top | Top_right -> Some (pct 100., pct 0.)
-  | Right_center -> Some (pct 100., pct 50.)
-  | Right_bottom | Bottom_right -> Some (pct 100., pct 100.)
-  | Center_top -> Some (pct 50., pct 0.)
-  | Center_bottom -> Some (pct 50., pct 100.)
+  | Center -> Some (position_pct 50., position_pct 50.)
+  | Left -> Some (position_pct 0., position_pct 50.)
+  | Right -> Some (position_pct 100., position_pct 50.)
+  | Top -> Some (position_pct 50., position_pct 0.)
+  | Bottom -> Some (position_pct 50., position_pct 100.)
+  | Left_top | Top_left -> Some (position_pct 0., position_pct 0.)
+  | Left_center -> Some (position_pct 0., position_pct 50.)
+  | Left_bottom | Bottom_left -> Some (position_pct 0., position_pct 100.)
+  | Right_top | Top_right -> Some (position_pct 100., position_pct 0.)
+  | Right_center -> Some (position_pct 100., position_pct 50.)
+  | Right_bottom | Bottom_right -> Some (position_pct 100., position_pct 100.)
+  | Center_top -> Some (position_pct 50., position_pct 0.)
+  | Center_bottom -> Some (position_pct 50., position_pct 100.)
   | XY (x, y) -> Some (x, y)
-  | Single x -> Some (x, pct 50.)
-  | Edge_offset_axis ("left", off, "center") ->
-      Option.map (fun x -> (x, pct 50.)) (static_offset off)
-  | Edge_offset_axis ("left", off, "top") ->
-      Option.map (fun x -> (x, pct 0.)) (static_offset off)
-  | Axis_edge_offset ("center", "top", off) -> Some (pct 50., off)
-  | Edge_offset_edge_offset ("left", x, "top", y) -> (
-      match (static_offset x, static_offset y) with
-      | Some x, Some y -> Some (x, y)
-      | _ -> None)
+  | Single x -> Some (x, position_pct 50.)
+  | Edge_offset_axis ((("left" | "right") as edge), off, axis) ->
+      position_pair (position_edge_offset edge off) (vertical_position axis)
+  | Edge_offset_axis ((("top" | "bottom") as edge), off, axis) ->
+      position_pair (horizontal_position axis) (position_edge_offset edge off)
+  | Axis_edge_offset (axis, (("top" | "bottom") as edge), off) ->
+      position_pair (horizontal_position axis)
+        (position_edge_offset edge (Length off))
+  | Edge_offset_edge_offset
+      ((("left" | "right") as x_edge), x, (("top" | "bottom") as y_edge), y) ->
+      position_pair
+        (position_edge_offset x_edge x)
+        (position_edge_offset y_edge y)
+  | Edge_offset_edge_offset
+      ((("top" | "bottom") as y_edge), y, (("left" | "right") as x_edge), x) ->
+      position_pair
+        (position_edge_offset x_edge x)
+        (position_edge_offset y_edge y)
   | _ -> None
 
 (* The parser's node for the shortest spelling of a static (x, y) position: [x]

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -305,10 +305,17 @@ let rec normalize_transform_origin : transform_origin -> transform_origin =
         let a = z a and b = z b in
         match b with Pct 50. -> X a | _ -> preserve_if_equal value (XY (a, b)))
     | XYZ (a, b, c) -> preserve_if_equal value (XYZ (z a, z b, z c))
-    | Position p ->
-        preserve_if_equal value (Position (normalize_position_value p))
-    | Position_z (p, c) ->
-        preserve_if_equal value (Position_z (normalize_position_value p, z c))
+    | Position p -> (
+        let p = normalize_position_value p in
+        match position_xy p with
+        | Some (a, b) -> normalize_transform_origin (XY (a, b))
+        | None -> preserve_if_equal value (Position p))
+    | Position_z (p, c) -> (
+        let p = normalize_position_value p in
+        let c = z c in
+        match position_xy p with
+        | Some (a, b) -> normalize_transform_origin (XYZ (a, b, c))
+        | None -> preserve_if_equal value (Position_z (p, c)))
     | Var v ->
         let v' = map_var_preserve normalize_transform_origin v in
         if v' == v then value else Var v'

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -453,6 +453,40 @@ let test_text_decoration_default_spellings_factor () =
     ".a,.b{text-shadow:1px 1px}"
     (optimize_str ".a{text-shadow:1px 1px 0}.b{text-shadow:1px 1px}")
 
+(* A typed caller can build transform-origin with the shared [position_value]
+   nodes even though authored CSS uses the property's narrower grammar. Those
+   nodes must canonicalise to XY/XYZ before declarations are hashed. *)
+let test_transform_origin_position_nodes_factor () =
+  let optimize_with parsed value =
+    match Css.of_string parsed with
+    | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
+    | Ok { stylesheet; _ } ->
+        let declaration = Declaration.v Properties.Transform_origin value in
+        Css.concat
+          [
+            stylesheet;
+            Css.v
+              [ Css.rule ~selector:(Selector.of_string ".b") [ declaration ] ];
+          ]
+        |> Css.optimize |> Css.to_string ~minify:true
+  in
+  let offset edge amount = (edge, (Length amount : Values.length_percentage)) in
+  let position x_edge x y_edge y =
+    let x_edge, x = offset x_edge x and y_edge, y = offset y_edge y in
+    (Properties.Edge_offset_edge_offset (x_edge, x, y_edge, y)
+      : Properties.position_value)
+  in
+  Alcotest.(check string)
+    "position node factors with an XY origin"
+    ".a,.b{transform-origin:10px 20px}"
+    (optimize_with ".a{transform-origin:10px 20px}"
+       (Properties.Position (position "left" (Px 10.) "top" (Px 20.))));
+  Alcotest.(check string)
+    "position node factors with an XYZ origin"
+    ".a,.b{transform-origin:10px 20px 30px}"
+    (optimize_with ".a{transform-origin:10px 20px 30px}"
+       (Properties.Position_z (position "left" (Px 10.) "top" (Px 20.), Px 30.)))
+
 (* These equivalent spellings were still canonicalised by their printers, too
    late for declaration hashes to meet during factoring. *)
 let test_remaining_printer_fold_spellings_factor () =
@@ -525,6 +559,8 @@ let suite =
         test_list_style_default_spellings_factor;
       Alcotest.test_case "spelled-out text decoration defaults factor away"
         `Quick test_text_decoration_default_spellings_factor;
+      Alcotest.test_case "transform origin position nodes factor" `Quick
+        test_transform_origin_position_nodes_factor;
       Alcotest.test_case "remaining printer folds factor together" `Quick
         test_remaining_printer_fold_spellings_factor;
     ] )


### PR DESCRIPTION
Typed callers can construct transform-origin Position and Position_z values with the shared position_value nodes, while parsed coordinate origins use XY and XYZ. Equivalent values then print the same but hash differently, so factoring can miss them.

Canonicalize static shared position nodes, including reversed axes and right/bottom percentage offsets, then unwrap them to XY or XYZ before hashing. The 2D and 3D regressions construct the shared nodes through the typed API.

Tests: opam exec -- dune build; opam exec -- dune exec test/test.exe -- test factor