### PR TITLE
position: validate edge-offset grammar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- `position_value.Axis_edge_offset` carries a `length_percentage`, matching the
+  percentage-capable `<bg-position>` offset it represents (#673)
 - `text_box.Normal` represents the `normal` shorthand branch, which now parses
   and round-trips instead of being dropped (#671)
 - `text_box.Box` carries an optional trim value. The `text-box` grammar makes
@@ -195,6 +197,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- Three- and four-value position readers validate horizontal/vertical edge
+  pairs instead of accepting arbitrary identifiers or two edges on one axis.
+  Generic `<position>` rejects three-value forms, `background-position` keeps
+  its valid three-value extension, and `transform-origin` greedily separates
+  an optional Z length from its position (#673)
 - `border-image` accepts a repeat keyword without a source or slice; omitted
   shorthand slots take their initial values, so `border-image: round` is valid
   and no longer dropped (#667)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -2387,7 +2387,7 @@ type position_value = Properties.position_value =
   | Revert
   | Revert_layer
   | Edge_offset_axis of string * length_percentage * string
-  | Axis_edge_offset of string * string * length
+  | Axis_edge_offset of string * string * length_percentage
   | Edge_offset_edge_offset of
       string * length_percentage * string * length_percentage
   | Var of position_value var

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1658,7 +1658,7 @@ let read_background_box_list t : background_box =
   | many -> Layers many
 
 let read_background_position t : background_position =
-  Cursor.list ~at_least:1 ~sep:Cursor.comma read_position_value t
+  Cursor.list ~at_least:1 ~sep:Cursor.comma read_background_position_value t
 
 module Background_shorthand = struct
   let read_image_item t =
@@ -1670,7 +1670,7 @@ module Background_shorthand = struct
       if bg.image = None then { bg with image = Some img } else bg
 
   let read_position_size_item t =
-    let pos = read_position_value t in
+    let pos = read_background_position_value t in
     Cursor.ws t;
     let size_opt =
       if Cursor.slash_opt t then Some (read_background_size t) else None

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -218,7 +218,7 @@ let rec pp_position_value : position_value Pp.t =
       Pp.space ctx ();
       Pp.string ctx edge;
       Pp.space ctx ();
-      pp_length ctx offset
+      pp_position_offset ctx offset
   | Edge_offset_edge_offset (edge1, offset1, edge2, offset2) ->
       Pp.string ctx edge1;
       Pp.space ctx ();
@@ -767,8 +767,8 @@ let position_pair x y =
   match (x, y) with Some x, Some y -> Some (x, y) | _ -> None
 
 (* The horizontal and vertical components of a statically-known position; [None]
-   when a component is dynamic ([var()], [calc()], [env()]) or offset from a
-   non-zero edge ([right]/[bottom] offsets need the box size). *)
+   when a component is dynamic ([var()], [calc()], [env()]) or uses a non-zero
+   length offset from [right]/[bottom], which needs the box size. *)
 let position_xy : position_value -> (Values.length * Values.length) option =
   function
   | Center -> Some (position_pct 50., position_pct 50.)
@@ -791,8 +791,7 @@ let position_xy : position_value -> (Values.length * Values.length) option =
   | Edge_offset_axis ((("top" | "bottom") as edge), off, axis) ->
       position_pair (horizontal_position axis) (position_edge_offset edge off)
   | Axis_edge_offset (axis, (("top" | "bottom") as edge), off) ->
-      position_pair (horizontal_position axis)
-        (position_edge_offset edge (Length off))
+      position_pair (horizontal_position axis) (position_edge_offset edge off)
   | Edge_offset_edge_offset
       ((("left" | "right") as x_edge), x, (("top" | "bottom") as y_edge), y) ->
       position_pair
@@ -830,7 +829,7 @@ let normalize_position_value ?(strip = true) : position_value -> position_value
       | Edge_offset_axis (e, lp, a) ->
           preserve_if_equal value (Edge_offset_axis (e, offset lp, a))
       | Axis_edge_offset (a, e, l) ->
-          preserve_if_equal value (Axis_edge_offset (a, e, length l))
+          preserve_if_equal value (Axis_edge_offset (a, e, offset l))
       | Edge_offset_edge_offset (e1, lp1, e2, lp2) ->
           preserve_if_equal value
             (Edge_offset_edge_offset (e1, offset lp1, e2, offset lp2))
@@ -1316,6 +1315,13 @@ module Position_value = struct
     | Revert
     | Revert_layer
 
+  let horizontal = function "left" | "right" -> true | _ -> false
+  let vertical = function "top" | "bottom" -> true | _ -> false
+
+  let valid_edge_axis edge axis =
+    (horizontal edge && (vertical axis || axis = "center"))
+    || (vertical edge && (horizontal axis || axis = "center"))
+
   let read_xy (t : Cursor.t) : position_value =
     let x = read_length t in
     (* Reject global keywords - they should be parsed by read_1_value *)
@@ -1399,17 +1405,17 @@ module Position_value = struct
     let offset = read_length_percentage t in
     Cursor.ws t;
     let axis = Cursor.ident t in
-    Edge_offset_axis (edge1, offset, axis)
+    if valid_edge_axis edge1 axis then Edge_offset_axis (edge1, offset, axis)
+    else Cursor.err_invalid t "invalid three-value position"
 
   let read_axis_edge_offset t : position_value =
     let axis = Cursor.ident t in
     Cursor.ws t;
     let edge = Cursor.ident t in
     Cursor.ws t;
-    let offset = read_length t in
-    match (axis, edge) with
-    | "center", ("top" | "bottom") -> Axis_edge_offset (axis, edge, offset)
-    | _ -> Cursor.err_invalid t "invalid position axis edge offset"
+    let offset = read_length_percentage t in
+    if valid_edge_axis edge axis then Axis_edge_offset (axis, edge, offset)
+    else Cursor.err_invalid t "invalid position axis edge offset"
 
   let read_horizontal_keyword_length t : position_value =
     let keyword = Cursor.ident t in
@@ -1437,23 +1443,37 @@ module Position_value = struct
     let edge2 = Cursor.ident t in
     Cursor.ws t;
     let offset2 = read_length_percentage t in
-    Edge_offset_edge_offset (edge1, offset1, edge2, offset2)
+    if
+      (horizontal edge1 && vertical edge2)
+      || (vertical edge1 && horizontal edge2)
+    then Edge_offset_edge_offset (edge1, offset1, edge2, offset2)
+    else Cursor.err_invalid t "invalid four-value position"
 end
+
+let common_position_readers read_var =
+  [
+    Position_value.read_horizontal_keyword_length;
+    Position_value.read_length_keyword;
+    Position_value.read_xy;
+    Position_value.read_2_value;
+    Position_value.read_1_value;
+    read_var;
+  ]
 
 let rec read_position_value t : position_value =
   let read_var t : position_value = Var (read_var read_position_value t) in
   Cursor.one_of
-    [
-      Position_value.read_4_value;
-      Position_value.read_axis_edge_offset;
-      Position_value.read_3_value;
-      Position_value.read_horizontal_keyword_length;
-      Position_value.read_length_keyword;
-      Position_value.read_xy;
-      Position_value.read_2_value;
-      Position_value.read_1_value;
-      read_var;
-    ]
+    (Position_value.read_4_value :: common_position_readers read_var)
+    t
+
+let rec read_background_position_value t : position_value =
+  let read_var t : position_value =
+    Var (read_var read_background_position_value t)
+  in
+  Cursor.one_of
+    (Position_value.read_4_value :: Position_value.read_axis_edge_offset
+   :: Position_value.read_3_value
+    :: common_position_readers read_var)
     t
 
 module Radial_config = struct

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -1064,15 +1064,19 @@ module Transform_origin = struct
   type keyword = Center | Left | Right | Top | Bottom
 
   let read_position t : transform_origin =
-    let position =
-      Cursor.one_of
-        [ Position_value.read_4_value; Position_value.read_3_value ]
-        t
-    in
+    let position = read_position_value t in
     Cursor.ws t;
     match Cursor.option read_length t with
-    | Some z -> Position_z (position, z)
-    | None -> Position position
+    | Some z -> (
+        match position with
+        | XY (x, y) -> XYZ (x, y, z)
+        | Single x -> XYZ (x, (Pct 50. : length), z)
+        | position -> Position_z (position, z))
+    | None -> (
+        match position with
+        | XY (x, y) -> XY (x, y)
+        | Single x -> X x
+        | position -> Position position)
 
   let read_xyz (t : Cursor.t) : transform_origin =
     let x = read_length t in
@@ -1127,7 +1131,10 @@ module Transform_origin = struct
 
   let read_keywords t =
     let keywords = Cursor.list ~at_least:1 ~at_most:2 read_keyword t in
-    merge_keywords t keywords
+    let origin = merge_keywords t keywords in
+    Cursor.ws t;
+    Cursor.expect_eof t;
+    origin
 
   let read_center_center t =
     let first = Cursor.ident t in
@@ -1151,9 +1158,9 @@ let rec read_transform_origin (t : Cursor.t) : transform_origin =
       Cursor.one_of
         [
           Transform_origin.read_center_center;
-          Transform_origin.read_position;
-          Transform_origin.read_keywords;
           Transform_origin.read_xyz;
+          Transform_origin.read_keywords;
+          Transform_origin.read_position;
         ]
         t)
     t

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2593,7 +2593,7 @@ type position_value =
   | Revert_layer
   (* 3-value syntax: edge offset axis (e.g., "right 0.5rem center") *)
   | Edge_offset_axis of string * length_percentage * string
-  | Axis_edge_offset of string * string * length
+  | Axis_edge_offset of string * string * length_percentage
   (* 4-value syntax: edge1 offset1 edge2 offset2 *)
   | Edge_offset_edge_offset of
       string * length_percentage * string * length_percentage

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -720,7 +720,7 @@ let vars_of_position_value (value : Properties.position_value) : any_var list =
   | Single l -> vars_of_length l
   | XY (l1, l2) -> vars_of_length l1 @ vars_of_length l2
   | Edge_offset_axis (_, lp, _) -> vars_of_length_percentage lp
-  | Axis_edge_offset (_, _, length) -> vars_of_length length
+  | Axis_edge_offset (_, _, offset) -> vars_of_length_percentage offset
   | Edge_offset_edge_offset (_, lp1, _, lp2) ->
       vars_of_length_percentage lp1 @ vars_of_length_percentage lp2
   | _ -> []

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3979,6 +3979,50 @@ let text_box_normal () =
   check_declaration ~roundtrip:true "text-box:normal";
   check_sheet_roundtrip "text-box" "a{text-box:normal}"
 
+(* CSS Values 4 sec. 8.3 allows four edge-offset components but excludes the
+   three-value form. CSS Backgrounds 3 sec. 2.6 retains valid three-value
+   <bg-position>s, while CSS Transforms 1 sec. 4 can place a Z length after a
+   two-value origin. *)
+let edge_offset_position_grammar () =
+  List.iter
+    (fun (declaration, expected) ->
+      check_declaration ~expected ~roundtrip:true declaration;
+      let css = String.concat "" [ "a{"; declaration; "}" ] in
+      let expected_css = String.concat "" [ "a{"; expected; "}" ] in
+      match Css.of_string ~strict:true css with
+      | Error e -> Alcotest.failf "%s: %s" css (Error.to_string e)
+      | Ok { stylesheet; _ } ->
+          Alcotest.(check string)
+            "edge-offset position sheet roundtrip" expected_css
+            (String.trim (Css.to_string ~minify:true stylesheet)))
+    [
+      ("background-position:left top 10px", "background-position:left top 10px");
+      ("background-position:left top 10%", "background-position:left top 10%");
+      ( "background-position:center top 10px",
+        "background-position:center top 10px" );
+      ( "background-position:center left 10px",
+        "background-position:center left 10px" );
+      ("background-position:top 10px left", "background-position:top 10px left");
+      ("transform-origin:left 10px", "transform-origin:0% 10px");
+      ("transform-origin:left top 10px", "transform-origin:left top 10px");
+      ("transform-origin:center top 10px", "transform-origin:center top 10px");
+    ];
+  List.iter
+    (fun declaration ->
+      none_cursor read_declaration declaration;
+      let css = String.concat "" [ "a{"; declaration; "}" ] in
+      match Css.of_string ~strict:true css with
+      | Error _ -> ()
+      | Ok _ -> Alcotest.failf "strict parsing accepted %s" css)
+    [
+      "transform-origin:foo 1px bar 2px";
+      "background-position:left 1px right 2px";
+      "object-position:left 1px middle";
+      "perspective-origin:top 1px bottom";
+      "object-position:left 1px top";
+      "perspective-origin:left top 1px";
+    ]
+
 (* CSS Syntax 3 (ED) sec. 5.5.6 "consume a declaration" reads the value with
    [<semicolon-token>] as the stop token, then removes a trailing [!]
    [important] pair from that value and sets the declaration's important flag
@@ -4803,6 +4847,7 @@ let declaration_tests =
     test_case "view-timeline inset slot" `Quick view_timeline_inset_slot;
     test_case "text-box edge only" `Quick text_box_edge_only;
     test_case "text-box normal" `Quick text_box_normal;
+    test_case "edge-offset position grammar" `Quick edge_offset_position_grammar;
     test_case "declaration value end" `Quick declaration_value_end;
     test_case "declaration value end (sheet)" `Quick declaration_value_end_sheet;
     test_case "declaration value end negatives" `Quick

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2990,12 +2990,42 @@ let test_conic_gradient_config () =
    animation-range. A unit ends in an ident instead ([10px 0] would re-tokenise
    as the single dimension [10px0]), so that space stays. *)
 let test_background_position () =
+  let assert_complete input =
+    let t = Cursor.of_string input in
+    ignore (read_background_position t);
+    Cursor.ws t;
+    if not (Cursor.is_done t) then
+      Alcotest.failf "background-position left input after %S" input
+  in
+  let assert_axis_edge input axis edge =
+    let t = Cursor.of_string input in
+    match read_background_position t with
+    | [ Axis_edge_offset (got_axis, got_edge, _) ] ->
+        Alcotest.(check string) input axis got_axis;
+        Alcotest.(check string) input edge got_edge
+    | _ -> Alcotest.failf "background-position lost edge offset in %S" input
+  in
   check_background_position "center";
   check_background_position "left top";
   check_background_position ~roundtrip:true ~expected:"100%0" "right 0";
   check_background_position ~roundtrip:true ~expected:"100%-15.625rem"
     "right -15.625rem";
   check_background_position "right .5rem center";
+  check_background_position "left top 10px";
+  check_background_position "left top 10%";
+  check_background_position "center top 10px";
+  check_background_position "center left 10px";
+  check_background_position "top 10px left";
+  List.iter assert_complete
+    [
+      "left top 10px";
+      "left top 10%";
+      "center top 10px";
+      "center left 10px";
+      "top 10px left";
+    ];
+  assert_axis_edge "center top 10px" "center" "top";
+  assert_axis_edge "center left 10px" "center" "left";
   check_background_position ~roundtrip:true ~expected:"50%25%" "50% 25%";
   check_background_position "inherit";
   neg_cursor ~allow_partial:true read_background_position "invalid-position"
@@ -3003,9 +3033,16 @@ let test_background_position () =
 let test_position_value () =
   check_position_value "center";
   check_position_value "left top";
+  check_position_value "top 20px left 10px";
   check_position_value ~roundtrip:true ~expected:"50%25%" "50% 25%";
   check_position_value "inherit";
-  neg_cursor ~allow_partial:true read_position_value "invalid-position"
+  neg_cursor ~allow_partial:true read_position_value "invalid-position";
+  neg_cursor read_position_value "foo 1px bar 2px";
+  neg_cursor ~allow_partial:true read_position_value "left 1px right 2px";
+  neg_cursor ~allow_partial:true read_position_value "left 1px middle";
+  neg_cursor ~allow_partial:true read_position_value "top 1px bottom";
+  neg_cursor ~allow_partial:true read_position_value "left 1px top";
+  neg_cursor ~allow_partial:true read_position_value "left top 1px"
 
 let test_translate_value () =
   check_translate_value "none";
@@ -3430,6 +3467,9 @@ let test_transform_origin () =
   check_transform_origin "0";
   check_transform_origin "50% 25%";
   check_transform_origin "50% 50% 10px";
+  check_transform_origin ~expected:"0% 10px" "left 10px";
+  check_transform_origin "left top 10px";
+  check_transform_origin "center top 10px";
   check_transform_origin "inherit";
   neg_cursor read_transform_origin "invalid-origin"
 


### PR DESCRIPTION
CSS Values 4 excludes three-component generic <position> and requires horizontal/vertical edge pairs in four-component forms; CSS Backgrounds 3 retains valid three-component <bg-position>. Cascade accepted arbitrary or same-axis identifiers, exposed three-value forms to every position property, rejected percentage offsets in one valid background form, and did not greedily separate the optional Z length of transform-origin.

Split generic and background readers, validate edge axes, carry length-percentage offsets, and make transform-origin separate its optional Z component. Add direct, strict-sheet, complete-consumption, AST-shape, and low-level valid/invalid coverage.

Tests: env -u NO_COLOR opam exec -- dune test --display short