### PR TITLE
motion: model offset position properties

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -197,6 +197,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `offset-anchor` and `offset-position` are typed properties. They validate
+  their Motion Path grammars, expose `offset_anchor` / `offset_position`
+  values, and canonicalize their `<position>` branches. Generic positions no
+  longer accept length-only keywords such as `normal` as coordinates (#674)
 - Three- and four-value position readers validate horizontal/vertical edge
   pairs instead of accepting arbitrary identifiers or two edges on one axis.
   Generic `<position>` rejects three-value forms, `background-position` keeps

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1611,6 +1611,8 @@ let read_motion_value : type a. a property -> Cursor.t -> declaration option =
   match prop with
   | Margin_trim -> Some (v Margin_trim (read_margin_trim t))
   | Offset_path -> Some (v Offset_path (read_offset_path t))
+  | Offset_anchor -> Some (v Offset_anchor (read_offset_anchor t))
+  | Offset_position -> Some (v Offset_position (read_offset_position t))
   | Offset_rotate -> Some (v Offset_rotate (read_offset_rotate t))
   | Font_size_adjust -> Some (v Font_size_adjust (read_font_size_adjust t))
   | Font_variant_emoji ->

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -1323,14 +1323,9 @@ module Position_value = struct
     || (vertical edge && (horizontal axis || axis = "center"))
 
   let read_xy (t : Cursor.t) : position_value =
-    let x = read_length t in
-    (* Reject global keywords - they should be parsed by read_1_value *)
-    (match x with
-    | Inherit | Initial | Unset | Revert | Revert_layer ->
-        Cursor.err_invalid t "global keywords must be used alone"
-    | _ -> ());
+    let x = read_length ~with_keywords:false t in
     Cursor.ws t;
-    match Cursor.option read_length t with
+    match Cursor.option (read_length ~with_keywords:false) t with
     | Some y -> XY (x, y)
     | None -> Single x
 
@@ -1402,7 +1397,7 @@ module Position_value = struct
   let read_3_value t : position_value =
     let edge1 = Cursor.ident t in
     Cursor.ws t;
-    let offset = read_length_percentage t in
+    let offset = read_length_percentage ~with_keywords:false t in
     Cursor.ws t;
     let axis = Cursor.ident t in
     if valid_edge_axis edge1 axis then Edge_offset_axis (edge1, offset, axis)
@@ -1413,14 +1408,14 @@ module Position_value = struct
     Cursor.ws t;
     let edge = Cursor.ident t in
     Cursor.ws t;
-    let offset = read_length_percentage t in
+    let offset = read_length_percentage ~with_keywords:false t in
     if valid_edge_axis edge axis then Axis_edge_offset (axis, edge, offset)
     else Cursor.err_invalid t "invalid position axis edge offset"
 
   let read_horizontal_keyword_length t : position_value =
     let keyword = Cursor.ident t in
     Cursor.ws t;
-    let y = read_length t in
+    let y = read_length ~with_keywords:false t in
     match keyword with
     | "left" -> XY ((Pct 0. : length), y)
     | "right" -> XY ((Pct 100. : length), y)
@@ -1428,7 +1423,7 @@ module Position_value = struct
     | _ -> Cursor.err_invalid t "invalid horizontal position keyword length"
 
   let read_length_keyword t : position_value =
-    let offset = read_length t in
+    let offset = read_length ~with_keywords:false t in
     Cursor.ws t;
     match Cursor.ident t with
     | "center" -> Single offset
@@ -1438,11 +1433,11 @@ module Position_value = struct
   let read_4_value t : position_value =
     let edge1 = Cursor.ident t in
     Cursor.ws t;
-    let offset1 = read_length_percentage t in
+    let offset1 = read_length_percentage ~with_keywords:false t in
     Cursor.ws t;
     let edge2 = Cursor.ident t in
     Cursor.ws t;
-    let offset2 = read_length_percentage t in
+    let offset2 = read_length_percentage ~with_keywords:false t in
     if
       (horizontal edge1 && vertical edge2)
       || (vertical edge1 && horizontal edge2)

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -337,6 +337,24 @@ let normalize_offset_path : offset_path -> offset_path =
            })
   | other -> other
 
+let rec normalize_offset_anchor (value : offset_anchor) =
+  match value with
+  | Position position ->
+      preserve_if_equal value (Position (normalize_position_value position))
+  | Var var ->
+      let var' = map_var_preserve normalize_offset_anchor var in
+      if var' == var then value else Var var'
+  | other -> other
+
+let rec normalize_offset_position (value : offset_position) =
+  match value with
+  | Position position ->
+      preserve_if_equal value (Position (normalize_position_value position))
+  | Var var ->
+      let var' = map_var_preserve normalize_offset_position var in
+      if var' == var then value else Var var'
+  | other -> other
+
 let normalize_offset_rotate : offset_rotate -> offset_rotate =
   let na = Values.normalize_angle in
   fun value ->
@@ -673,6 +691,58 @@ let rec pp_offset_path : offset_path Pp.t =
   | Unset -> Pp.string ctx "unset"
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
+
+let rec pp_offset_anchor : offset_anchor Pp.t =
+ fun ctx -> function
+  | Auto -> Pp.string ctx "auto"
+  | Position position -> pp_position_value ctx position
+  | Initial -> Pp.string ctx "initial"
+  | Inherit -> Pp.string ctx "inherit"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var var -> pp_var pp_offset_anchor ctx var
+
+let rec pp_offset_position : offset_position Pp.t =
+ fun ctx -> function
+  | Normal -> Pp.string ctx "normal"
+  | Auto -> Pp.string ctx "auto"
+  | Position position -> pp_position_value ctx position
+  | Initial -> Pp.string ctx "initial"
+  | Inherit -> Pp.string ctx "inherit"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var var -> pp_var pp_offset_position ctx var
+
+let rec read_offset_anchor t : offset_anchor =
+  Cursor.enum_or_calls "offset-anchor"
+    [
+      ("auto", Auto);
+      ("initial", Initial);
+      ("inherit", Inherit);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~calls:[ ("var", fun t -> Var (read_var read_offset_anchor t)) ]
+    ~default:(fun t -> (Position (read_position_value t) : offset_anchor))
+    t
+
+let rec read_offset_position t : offset_position =
+  Cursor.enum_or_calls "offset-position"
+    [
+      ("normal", Normal);
+      ("auto", Auto);
+      ("initial", Initial);
+      ("inherit", Inherit);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~calls:[ ("var", fun t -> Var (read_var read_offset_position t)) ]
+    ~default:(fun t -> (Position (read_position_value t) : offset_position))
+    t
 
 let pp_offset_rotate_mode : offset_rotate_mode Pp.t =
  fun ctx -> function

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -517,6 +517,8 @@ let pp_property : type a. a property Pp.t =
       Pp.string ctx "contain-intrinsic-inline-size"
   | Margin_trim -> Pp.string ctx "margin-trim"
   | Offset_path -> Pp.string ctx "offset-path"
+  | Offset_anchor -> Pp.string ctx "offset-anchor"
+  | Offset_position -> Pp.string ctx "offset-position"
   | Offset_distance -> Pp.string ctx "offset-distance"
   | Offset_rotate -> Pp.string ctx "offset-rotate"
   | Font_size_adjust -> Pp.string ctx "font-size-adjust"
@@ -1335,6 +1337,8 @@ let property_tag : type a. a property -> int = function
   | Overscroll_behavior_inline -> 531
   | Accent_color -> 532
   | Caret_color -> 533
+  | Offset_anchor -> 534
+  | Offset_position -> 535
 (* PROPERTY_TAG_END *)
 
 (* Two property identities order by tag, and the two payload-carrying
@@ -1696,6 +1700,8 @@ let eq_property : type a b. a property -> b property -> (a, b) Type.eq option =
   | Contain_intrinsic_inline_size, Contain_intrinsic_inline_size -> Some Equal
   | Margin_trim, Margin_trim -> Some Equal
   | Offset_path, Offset_path -> Some Equal
+  | Offset_anchor, Offset_anchor -> Some Equal
+  | Offset_position, Offset_position -> Some Equal
   | Offset_distance, Offset_distance -> Some Equal
   | Offset_rotate, Offset_rotate -> Some Equal
   | Font_size_adjust, Font_size_adjust -> Some Equal
@@ -2700,6 +2706,8 @@ let read_any_property t =
   | "contain-intrinsic-inline-size" -> Prop Contain_intrinsic_inline_size
   | "margin-trim" -> Prop Margin_trim
   | "offset-path" -> Prop Offset_path
+  | "offset-anchor" -> Prop Offset_anchor
+  | "offset-position" -> Prop Offset_position
   | "offset-distance" -> Prop Offset_distance
   | "offset-rotate" -> Prop Offset_rotate
   | "font-size-adjust" -> Prop Font_size_adjust
@@ -3349,6 +3357,9 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
  fun prop value ->
   match (prop, value) with
   | Z_index, Initial -> Auto
+  (* Motion Path 1 secs. 2.3-2.4: the initial values are [normal] and [auto]. *)
+  | Offset_anchor, Initial -> Auto
+  | Offset_position, Initial -> Normal
   | Opacity, Initial -> Opacity_number 1.
   | Margin, vs when box_is_all_initial vs -> [ Px 0. ]
   | Padding, vs when box_is_all_initial vs -> [ Px 0. ]
@@ -3639,6 +3650,8 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
       value
   | Margin_trim, value -> value
   | Offset_path, value -> value
+  | Offset_anchor, value -> value
+  | Offset_position, value -> value
   | Offset_rotate, value -> value
   | Font_size_adjust, value -> value
   | Font_variant_emoji, value -> value
@@ -3902,6 +3915,8 @@ let normalize_property_value : type a.
   | Translate -> normalize_translate_value value
   | Transform_origin -> normalize_transform_origin value
   | Offset_path -> normalize_offset_path value
+  | Offset_anchor -> normalize_offset_anchor value
+  | Offset_position -> normalize_offset_position value
   | Offset_rotate -> normalize_offset_rotate value
   | Font_style -> normalize_font_style value
   | Width -> Values.normalize_length_percentage ~ctx value
@@ -4573,6 +4588,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Contain_intrinsic_inline_size -> pp pp_contain_intrinsic_longhand
   | Margin_trim -> pp pp_margin_trim
   | Offset_path -> pp pp_offset_path
+  | Offset_anchor -> pp pp_offset_anchor
+  | Offset_position -> pp pp_offset_position
   | Offset_distance -> pp (pp_length_percentage ~always:true)
   | Offset_rotate -> pp pp_offset_rotate
   | Font_size_adjust -> pp pp_font_size_adjust

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -405,6 +405,18 @@ val pp_offset_path : offset_path Pp.t
 val read_offset_path : Cursor.t -> offset_path
 (** [read_offset_path t] parses [offset-path]. *)
 
+val pp_offset_anchor : offset_anchor Pp.t
+(** [pp_offset_anchor] pretty-prints [offset-anchor]. *)
+
+val read_offset_anchor : Cursor.t -> offset_anchor
+(** [read_offset_anchor t] parses [offset-anchor]. *)
+
+val pp_offset_position : offset_position Pp.t
+(** [pp_offset_position] pretty-prints [offset-position]. *)
+
+val read_offset_position : Cursor.t -> offset_position
+(** [read_offset_position t] parses [offset-position]. *)
+
 val pp_animation_range_item : animation_range_item Pp.t
 (** [pp_animation_range_item] pretty-prints one [<single-animation-range>]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3611,6 +3611,27 @@ type offset_path =
   | Revert_layer
   | Var of offset_path var
 
+type offset_anchor =
+  | Auto
+  | Position of position_value
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of offset_anchor var
+
+type offset_position =
+  | Normal
+  | Auto
+  | Position of position_value
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of offset_position var
+
 type offset_rotate_mode = Auto | Reverse
 
 type offset_rotate =
@@ -5087,6 +5108,8 @@ type 'a property =
   | Overscroll_behavior_inline : overscroll_behavior property
   | Accent_color : color property
   | Caret_color : color property
+  | Offset_anchor : offset_anchor property
+  | Offset_position : offset_position property
 
 type any_property = Prop : 'a property -> any_property
 

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1171,6 +1171,18 @@ let vars_of_offset_path (value : Properties.offset_path) =
   | None | Url _ | Path _ | Initial | Inherit | Unset | Revert | Revert_layer ->
       []
 
+let vars_of_offset_anchor (value : Properties.offset_anchor) =
+  match value with
+  | Var var -> [ V var ]
+  | Position position -> vars_of_position_value position
+  | Auto | Initial | Inherit | Unset | Revert | Revert_layer -> []
+
+let vars_of_offset_position (value : Properties.offset_position) =
+  match value with
+  | Var var -> [ V var ]
+  | Position position -> vars_of_position_value position
+  | Normal | Auto | Initial | Inherit | Unset | Revert | Revert_layer -> []
+
 let vars_of_offset_rotate (value : Properties.offset_rotate) =
   match value with
   | Var v -> [ V v ]
@@ -2287,6 +2299,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
       vars_of_contain_intrinsic_longhand value
   | Margin_trim, value -> vars_of_margin_trim value
   | Offset_path, value -> vars_of_offset_path value
+  | Offset_anchor, value -> vars_of_offset_anchor value
+  | Offset_position, value -> vars_of_offset_position value
   | Offset_rotate, value -> vars_of_offset_rotate value
   | All, value -> vars_of_css_wide value
   | Direction, value -> vars_of_direction value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4023,6 +4023,61 @@ let edge_offset_position_grammar () =
       "perspective-origin:left top 1px";
     ]
 
+(* Motion Path 1 secs. 2.3-2.4 define offset-position as [normal | auto |
+   <position>] and offset-anchor as [auto | <position>]. Both use the generic
+   <position> grammar, not background's three-value extension. *)
+let offset_position_properties () =
+  List.iter
+    (fun (declaration, expected) ->
+      check_declaration ~expected ~roundtrip:true declaration;
+      let css = String.concat "" [ "a{"; declaration; "}" ] in
+      let expected_css = String.concat "" [ "a{"; expected; "}" ] in
+      match Css.of_string ~strict:true css with
+      | Error e -> Alcotest.failf "%s: %s" css (Error.to_string e)
+      | Ok { stylesheet; _ } ->
+          Alcotest.(check string)
+            "offset position property sheet roundtrip" expected_css
+            (String.trim (Css.to_string ~minify:true stylesheet)))
+    [
+      ("offset-anchor:auto", "offset-anchor:auto");
+      ("offset-anchor:center", "offset-anchor:center");
+      ("offset-anchor:left top", "offset-anchor:left top");
+      ("offset-anchor:20% 30%", "offset-anchor:20%30%");
+      ("offset-anchor:left 10px top 20px", "offset-anchor:left 10px top 20px");
+      ("offset-position:normal", "offset-position:normal");
+      ("offset-position:auto", "offset-position:auto");
+      ("offset-position:center", "offset-position:center");
+      ("offset-position:left top", "offset-position:left top");
+      ("offset-position:20% 30%", "offset-position:20%30%");
+      ( "offset-position:left 10px top 20px",
+        "offset-position:left 10px top 20px" );
+    ];
+  decl_optimizes ~prop:"offset-anchor" ~into:"50%" "center";
+  decl_optimizes ~prop:"offset-anchor" ~into:"0 0" "left top";
+  decl_optimizes ~prop:"offset-anchor" ~into:"auto" "initial";
+  decl_optimizes ~prop:"offset-position" ~into:"50%" "center";
+  decl_optimizes ~prop:"offset-position" ~into:"0 0" "left top";
+  decl_optimizes ~prop:"offset-position" ~into:"normal" "initial";
+  List.iter
+    (fun declaration ->
+      none_cursor read_declaration declaration;
+      let css = String.concat "" [ "a{"; declaration; "}" ] in
+      match Css.of_string ~strict:true css with
+      | Error _ -> ()
+      | Ok _ -> Alcotest.failf "strict parsing accepted %s" css)
+    [
+      "offset-anchor:foo bar baz";
+      "offset-anchor:normal";
+      "offset-anchor:size";
+      "offset-anchor:auto center";
+      "offset-anchor:left top 10px";
+      "offset-position:foo bar baz";
+      "offset-position:none";
+      "offset-position:normal center";
+      "offset-position:left top 10px";
+      "object-position:normal";
+    ]
+
 (* CSS Syntax 3 (ED) sec. 5.5.6 "consume a declaration" reads the value with
    [<semicolon-token>] as the stop token, then removes a trailing [!]
    [important] pair from that value and sets the declaration's important flag
@@ -4848,6 +4903,7 @@ let declaration_tests =
     test_case "text-box edge only" `Quick text_box_edge_only;
     test_case "text-box normal" `Quick text_box_normal;
     test_case "edge-offset position grammar" `Quick edge_offset_position_grammar;
+    test_case "offset position properties" `Quick offset_position_properties;
     test_case "declaration value end" `Quick declaration_value_end;
     test_case "declaration value end (sheet)" `Quick declaration_value_end_sheet;
     test_case "declaration value end negatives" `Quick

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -953,6 +953,12 @@ let check_object_view_box =
 let check_offset_path =
   check_value_cursor "offset_path" read_offset_path pp_offset_path
 
+let check_offset_anchor =
+  check_value_cursor "offset_anchor" read_offset_anchor pp_offset_anchor
+
+let check_offset_position =
+  check_value_cursor "offset_position" read_offset_position pp_offset_position
+
 let check_offset_rotate =
   check_value_cursor "offset_rotate" read_offset_rotate pp_offset_rotate
 
@@ -3044,6 +3050,27 @@ let test_position_value () =
   neg_cursor ~allow_partial:true read_position_value "left 1px top";
   neg_cursor ~allow_partial:true read_position_value "left top 1px"
 
+let test_offset_anchor () =
+  check_offset_anchor "auto";
+  check_offset_anchor "center";
+  check_offset_anchor "left top";
+  check_offset_anchor "left 10px top 20px";
+  check_offset_anchor "var(--anchor,left top)";
+  check_offset_anchor "inherit";
+  neg_cursor read_offset_anchor "normal";
+  neg_cursor read_offset_anchor "size"
+
+let test_offset_position () =
+  check_offset_position "normal";
+  check_offset_position "auto";
+  check_offset_position "center";
+  check_offset_position "20% 30%" ~expected:"20%30%";
+  check_offset_position "left 10px top 20px";
+  check_offset_position "var(--position,center)";
+  check_offset_position "inherit";
+  neg_cursor read_offset_position "none";
+  neg_cursor read_offset_position "size"
+
 let test_translate_value () =
   check_translate_value "none";
   check_translate_value "10px";
@@ -4975,6 +5002,8 @@ let additional_tests =
     test_case "background_image" `Quick test_background_image;
     test_case "background_position" `Quick test_background_position;
     test_case "position_value" `Quick test_position_value;
+    test_case "offset_anchor" `Quick test_offset_anchor;
+    test_case "offset_position" `Quick test_offset_position;
     test_case "translate_value" `Quick test_translate_value;
     test_case "user_select" `Quick test_user_select;
     test_case "pointer_events" `Quick test_pointer_events;


### PR DESCRIPTION
Motion Path 1 defines offset-anchor as auto or <position>, and offset-position as normal, auto, or <position>. Cascade treated both names as opaque unknown properties, so invalid values survived and position normalization never ran.

Add distinct typed value grammars, readers, printers, normalization, recursive var handling, variable discovery, property identity mappings, and API coverage. Generic <position> coordinates now also use the keyword-free length reader, preventing values such as normal from masquerading as coordinates.

Tests: env -u NO_COLOR opam exec -- dune test --display short