### PR TITLE
properties: preserve logical min-size initial

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1003,6 +1003,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- `min-inline-size:initial` and `min-block-size:initial` minify to `0`, their
+  CSS Logical Level 1 initial value, rather than the physical minimum-size
+  properties' `auto` initial value (#675)
 - Border-radius normalization uses the shared box-shorthand normalizer instead
   of spelling its map-and-collapse composition inline (#663)
 - Property normalizers reuse `Common.List.map_preserve` instead of carrying a

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3375,8 +3375,10 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Height, Length Initial -> Length Auto
   | Min_width, Length Initial -> Length Auto
   | Min_height, Length Initial -> Length Auto
-  | Min_inline_size, Length Initial -> Length Auto
-  | Min_block_size, Length Initial -> Length Auto
+  (* CSS Logical 1 sec. 4.1 keeps the logical minimum-size initial value at [0],
+     unlike the physical properties' [auto] from CSS Sizing 3 sec. 3.1.2. *)
+  | Min_inline_size, Length Initial -> Length Zero
+  | Min_block_size, Length Initial -> Length Zero
   (* Keep this fallback exhaustive: a new property must make this match fail to
      compile until its initial-value fold has been considered. *)
   | Custom_property _, value -> value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -661,7 +661,9 @@ let lengths () =
   check_declaration ~expected:"width:auto" "width: auto";
   check_declaration ~expected:"height:auto" "height: auto";
   check_declaration ~expected:"min-inline-size:initial"
-    ~optimized:"min-inline-size:auto" "min-inline-size: initial";
+    ~optimized:"min-inline-size:0" "min-inline-size: initial";
+  check_declaration ~expected:"min-block-size:initial"
+    ~optimized:"min-block-size:0" "min-block-size: initial";
 
   (* Min/max content *)
   check_declaration ~expected:"width:min-content" "width: min-content";

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -491,7 +491,11 @@ let test_transform_origin_position_nodes_factor () =
    late for declaration hashes to meet during factoring. *)
 let test_remaining_printer_fold_spellings_factor () =
   Alcotest.(check string)
-    "logical minimum initial factors with auto" ".a,.b{min-inline-size:auto}"
+    "logical minimum initial factors with zero" ".a,.b{min-inline-size:0}"
+    (optimize_str ".a{min-inline-size:initial}.b{min-inline-size:0}");
+  Alcotest.(check string)
+    "logical minimum initial stays distinct from auto"
+    ".a{min-inline-size:0}.b{min-inline-size:auto}"
     (optimize_str ".a{min-inline-size:initial}.b{min-inline-size:auto}");
   Alcotest.(check string)
     "milliseconds factor with seconds" ".a,.b{transition-duration:.5s}"


### PR DESCRIPTION
Fix minification of min-inline-size:initial and min-block-size:initial to use 0. CSS Logical Properties Level 1 section 4.1 keeps their initial value distinct from the auto initial value of physical min-width and min-height.

The regression tests also ensure logical initial values factor with 0 and stay distinct from auto.

Tests: opam exec -- dune fmt; opam exec -- dune build; env -u NO_COLOR opam exec -- dune test --display short