### PR TITLE
values: preserve typed calc zero terms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -541,6 +541,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` keeps zero terms in `calc()` sums unless their units match another
+  term. Removing a mixed-unit zero can change the calculation's type, and a
+  unitless zero is not a valid typed length operand (#676)
 - `--minify` canonicalises programmatically constructed shared `<position>`
   nodes in `transform-origin` to the property's XY/XYZ nodes before hashing, so
   typed position nodes and coordinate origins now factor together (#672)

--- a/fuzz/fuzz_values.ml
+++ b/fuzz/fuzz_values.ml
@@ -648,47 +648,39 @@ let optimize_one css =
       Some (parsed.stylesheet |> Css.optimize |> Css.to_string ~minify:true)
   | Error _ -> None
 
-(* (property, operand, type-matched zero) triples driving the calc-identity
-   invariants below. Spans every value type whose [calc()] folds through the
-   optimize pass now that the printer is a pure serialiser: lengths / percentages
-   ([width], [padding]), the generic number ([opacity]), and the own-typed
-   [line-height] / [<time>] / [font-size] / [vertical-align] / [border-width] /
-   [number-percentage] folds. *)
-(* The third field is the additive identity element when the type folds [x + 0]
-   in the optimize pass: lengths / percentages collapse a typed [0px], numbers a
-   unitless [0]. Own-typed lengths reached only through the generic [eval_calc]
-   ([font-size], [border-width], [<time>]) fold the multiplicative identity but
-   not a typed-zero addition, and a unitless [0] is invalid there, so they carry
-   [None]. *)
+(* Property/operand pairs driving the calc-identity invariants below. Spans
+   every value type whose [calc()] folds through the optimize pass now that the
+   printer is a pure serialiser: lengths / percentages ([width], [padding]), the
+   generic number ([opacity]), and the own-typed [line-height] / [<time>] /
+   [font-size] / [vertical-align] / [border-width] / [number-percentage]
+   folds. *)
 let calc_identity_targets =
   [
-    ("width", "12px", Some "0px");
-    ("width", "var(--a)", Some "0px");
-    ("width", "50%", Some "0px");
-    ("padding", "var(--a)", Some "0px");
-    ("padding", ".5rem", Some "0px");
-    ("opacity", "var(--a)", Some "0");
-    ("opacity", ".5", Some "0");
-    ("line-height", "var(--a)", Some "0");
-    ("transition-duration", "var(--a)", None);
-    ("animation-delay", "var(--a)", None);
-    ("font-size", "16px", None);
-    ("font-size", "var(--a)", None);
-    ("vertical-align", "var(--a)", None);
-    ("border-top-width", "var(--a)", None);
-    ("scale", "var(--a)", Some "0");
-    ("flex-grow", "var(--a)", Some "0");
+    ("width", "12px");
+    ("width", "var(--a)");
+    ("width", "50%");
+    ("padding", "var(--a)");
+    ("padding", ".5rem");
+    ("opacity", "var(--a)");
+    ("opacity", ".5");
+    ("line-height", "var(--a)");
+    ("transition-duration", "var(--a)");
+    ("animation-delay", "var(--a)");
+    ("font-size", "16px");
+    ("font-size", "var(--a)");
+    ("vertical-align", "var(--a)");
+    ("border-top-width", "var(--a)");
+    ("scale", "var(--a)");
+    ("flex-grow", "var(--a)");
   ]
 
 (* CSS Values 4 sec. 10.10.1 identity law: wrapping a value in a
-   value-independent identity ([x * 1], [1 * x], [x / 1], [x + 0], [0 + x], [x -
-   0]) and optimising lands on the same normal form as optimising the bare value
-   - the [var()] reference and the [calc()] wrapper survive, only the redundant
-   arithmetic folds. Drives the shared [Values.calc_identity] through every
-   evaluator the optimize pass reaches, so the generic and per-type folds cannot
-   drift. *)
+   value-independent multiplicative identity ([x * 1], [1 * x], [x / 1]) and
+   optimising lands on the same normal form as optimising the bare value. Drives
+   the shared [Values.calc_identity] through every evaluator the optimize pass
+   reaches, so the generic and per-type folds cannot drift. *)
 let test_calc_identity_law buf =
-  let prop, operand, add_zero = pick calc_identity_targets buf 0 in
+  let prop, operand = pick calc_identity_targets buf 0 in
   let decl v = ".x{" ^ prop ^ ":" ^ v ^ "}" in
   match optimize_one (decl ("calc(" ^ operand ^ ")")) with
   | None -> ()
@@ -700,16 +692,6 @@ let test_calc_identity_law buf =
           "calc(" ^ operand ^ " / 1)";
         ]
       in
-      let additive =
-        match add_zero with
-        | None -> []
-        | Some z ->
-            [
-              "calc(" ^ operand ^ " + " ^ z ^ ")";
-              "calc(" ^ z ^ " + " ^ operand ^ ")";
-              "calc(" ^ operand ^ " - " ^ z ^ ")";
-            ]
-      in
       List.iter
         (fun w ->
           match optimize_one (decl w) with
@@ -717,12 +699,12 @@ let test_calc_identity_law buf =
           | Some got ->
               if got <> bare then
                 failf "calc identity law broken: %S -> %S (bare %S)" w got bare)
-        (multiplicative @ additive)
+        multiplicative
 
 (* The identity and constant folds both converge, so a second optimize pass over
    a calc is a no-op. *)
 let test_calc_optimize_idempotent buf =
-  let prop, operand, _ = pick calc_identity_targets buf 0 in
+  let prop, operand = pick calc_identity_targets buf 0 in
   let css = ".x{" ^ prop ^ ":calc(" ^ operand ^ " * 1)}" in
   match optimize_one css with
   | None -> ()

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -976,11 +976,11 @@ module Calc_residual = struct
           (ops.combine_value_num value Values.Mul n)
     | _ -> None
 
-  (* Value-independent identities ([x * 0], [x * 1], [x + 0], ...) live in
+  (* Value-independent multiplicative identities ([x * 0], [x * 1], ...) live in
      [Values.calc_identity], shared with the AST evaluators so the paths never
      drift. They hold for any operand, so they apply to an unresolved [var()]
-     too; [ops.is_zero] collapses a literal zero ([0px], not just [0]). Tried
-     after the numeric/value folds so a resolved [Val] keeps its typed zero. *)
+     too; [ops.is_zero] collapses a literal zero ([0px], not just [0]). Additive
+     terms fold only through the preceding same-type value combination. *)
   let fold_identity_expr ops left op right =
     Values.calc_identity ~zero:ops.zero ~is_zero:ops.is_zero left op right
 
@@ -1354,10 +1354,12 @@ module Length = struct
     in
     let ops : Values.length Calc_residual.ops =
       let to_number = to_px ctx in
-      let of_number px = Values.Px px in
+      let of_number px =
+        if Float.equal px 0. then Values.Zero else Values.Px px
+      in
       {
         of_unitless_number = (fun _ -> None);
-        zero = Values.Num 0.;
+        zero = Values.Val Values.Zero;
         is_zero = Values.length_is_zero;
         combine_values = combine_numeric_values ~to_number ~of_number;
         combine_value_num = combine_numeric_value_num ~to_number ~of_number;
@@ -1842,7 +1844,9 @@ let simplify_length_percentage ?layer_order ?layer cascade length_ctx value =
     | value -> value
   in
   let ops =
-    let of_number px = Values.Length (Values.Px px) in
+    let of_number px =
+      Values.Length (if Float.equal px 0. then Values.Zero else Values.Px px)
+    in
     let combine_values (left : Values.length_percentage) op
         (right : Values.length_percentage) =
       match (left, op, right) with
@@ -1862,7 +1866,7 @@ let simplify_length_percentage ?layer_order ?layer cascade length_ctx value =
     in
     {
       Calc_residual.of_unitless_number = (fun _ -> None);
-      zero = Values.Num 0.;
+      zero = Values.Val (Values.Length Values.Zero);
       is_zero = (fun v -> match to_px v with Some n -> n = 0. | None -> false);
       combine_values;
       combine_value_num;

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1072,13 +1072,13 @@ let fold_zero_numeric_expr : type a.
       match value with Some 0. -> Some (Num 0.) | _ -> None)
   | _ -> None
 
-(* CSS Values 4 sec. 10.10.1 value-independent calc identities: hold for any
-   finite operand, so they fold even across a kept [var()] (single-valued inside
-   [calc()], so [var * 1 = var]). Identity cases ([x * 1], [x / 1], [x + 0],
-   ...) return the operand verbatim; zero-producing cases take the type's
-   canonical zero from [~zero], and [~is_zero] recognises a typed zero leaf
-   ([0px], not just [0]) so [0px * x] collapses too. Operands are
-   already-evaluated; numeric op numeric is the caller's job. *)
+(* CSS Values 4 sec. 10.10.1 value-independent multiplicative calc identities:
+   these fold even across a kept [var()] ([var * 1 = var]). A zero sum term is
+   deliberately not an identity here: the spec only combines sum children with
+   identical units and warns that removing any other zero can change the calc's
+   type. Zero-producing products take the type's canonical zero from [~zero],
+   and [~is_zero] recognises a typed zero leaf ([0px], not just [0]). Operands
+   are already evaluated; numeric op numeric is the caller's job. *)
 let calc_identity : type a.
     zero:a calc ->
     is_zero:(a -> bool) ->
@@ -1090,12 +1090,6 @@ let calc_identity : type a.
   match (l, op, r) with
   | _, Mul, Num 1. | _, Div, Num 1. -> Some l
   | Num 1., Mul, _ -> Some r
-  (* Additive identity holds for the unitless [0] and for a typed zero ([0px]).
-     [0 - x] is [-x], not [x], so only the [0 +] direction folds on the left. *)
-  | _, (Add | Sub), Num 0. -> Some l
-  | _, (Add | Sub), Val v when is_zero v -> Some l
-  | Num 0., Add, _ -> Some r
-  | Val v, Add, _ when is_zero v -> Some r
   | _, Mul, Num 0. | Num 0., Mul, _ -> Some zero
   (* A typed zero ([0px]) keeps its own spelling here; the optimizer's
      zero-length strip canonicalises it, so a non-optimised serialisation still
@@ -1281,8 +1275,8 @@ let eval_typed_calc : type a.
   in
   settle_computed round (reduce calc)
 
-let pp_calc : type a. a Pp.t -> a calc Pp.t =
- fun pp_value ctx calc ->
+let pp_calc_with : type a. ?unwrap_num:bool -> a Pp.t -> a calc Pp.t =
+ fun ?(unwrap_num = true) pp_value ctx calc ->
   match calc with
   (* CSS Values 4 sec. 10.10: a [var()] inside [calc()] is a runtime
      substitution boundary - the substituted tokens go through calc's typed
@@ -1290,16 +1284,18 @@ let pp_calc : type a. a Pp.t -> a calc Pp.t =
      [calc(var(--x))] to bare [var(--x)] would change which substitution shape
      is valid. *)
   | Val v when Pp.minified ctx -> pp_value ctx v
-  | Num n when Pp.minified ctx -> Pp.float ctx n
+  | Num n when Pp.minified ctx && unwrap_num -> Pp.float ctx n
   | _ ->
       let ctx = { ctx with in_calc = true } in
       Pp.call "calc" (pp_calc_contents pp_value) ctx calc
 
-let pp_calc_presolved : type a. a Pp.t -> a calc Pp.t =
- fun pp_value ctx calc ->
+let pp_calc pp_value ctx calc = pp_calc_with pp_value ctx calc
+
+let pp_calc_presolved : type a. ?unwrap_num:bool -> a Pp.t -> a calc Pp.t =
+ fun ?(unwrap_num = true) pp_value ctx calc ->
   match calc with
   | Val v when Pp.minified ctx -> pp_value ctx v
-  | Num n when Pp.minified ctx -> Pp.float ctx n
+  | Num n when Pp.minified ctx && unwrap_num -> Pp.float ctx n
   | _ ->
       let ctx = { ctx with in_calc = true } in
       Pp.call "calc" (pp_calc_contents pp_value) ctx calc
@@ -1385,10 +1381,9 @@ let rec map_calc : type a b. (a -> b) -> a calc -> b calc =
    minified mode: minified strips space after comma, pretty inserts ", ". Walk
    the raw arg string with a paren-depth counter so commas inside nested calls
    are left untouched. *)
-(* In a length calc tree, any zero-valued length and the unitless [0] are
-   spec-equivalent additive identities; rewriting typed zeros to [Num 0.] lets
-   the generic [eval_calc] simplifier collapse [calc(1px + 0px)] the same way it
-   collapses [calc(1px + 0)]. *)
+(* Recognise literal zeros for top-level canonicalisation and typed products.
+   This does not make them interchangeable in a calc sum: CSS Values 4 sec.
+   10.10.1 only combines identical units and requires other zero terms to stay. *)
 let length_is_zero = function
   | Zero -> true
   | Px f | Cm f | Mm f | Q f | In f | Pt f | Pc f -> f = 0.
@@ -1816,6 +1811,11 @@ let length_of_unit unit n =
   | Cqmin -> Cqmin n
   | Cqmax -> Cqmax n
 
+(* A zero [px] term inside calc() must retain its unit. Only a completed
+   top-level [<length>] can use the shorter unitless-zero representation. *)
+let length_of_calc_unit (unit : length_unit) n : length =
+  match unit with Px -> Px n | _ -> length_of_unit unit n
+
 type linear_term = {
   unit : length_unit;
   value : float;
@@ -1860,23 +1860,11 @@ let ordered_linear_terms terms =
           Hashtbl.replace table unit
             { term with value = term.value +. n; count = term.count + 1 })
     terms;
-  (* CSS Values 4 sec. 10.10: a calc()'s type is the union of its argument
-     types. Dropping [0%] from [calc(100px + 0%)] would narrow
-     [<length-percentage>] to [<length>] and break interpolation, so [0%] is
-     kept as a type sentinel. Other zero terms (e.g. [0px] beside another [px])
-     drop, their unit already in the result. *)
-  let keep_zero_term term =
-    length_unit_is_pct term.unit
-    && Hashtbl.fold
-         (fun _ t acc -> acc + if t.unit = term.unit then 0 else 1)
-         table 0
-       > 0
-  in
-  let terms =
-    Hashtbl.to_seq_values table
-    |> List.of_seq
-    |> List.filter (fun term -> term.value <> 0. || keep_zero_term term)
-  in
+  (* CSS Values 4 sec. 10.10.1 combines identical units, but explicitly keeps
+     zero-valued sum children otherwise: their unit contributes to the calc's
+     type. The table has already combined each identical-unit set, so retain
+     every resulting term, including zero. *)
+  let terms = Hashtbl.to_seq_values table |> List.of_seq in
   let first_pos =
     List.fold_left (fun acc term -> min acc term.first_pos) max_int terms
   in
@@ -1896,7 +1884,7 @@ let linear_terms_with unit_of_value calc =
   in
   let rec aux = function
     | Val v -> Option.map (fun term -> [ term ]) (unit_of_value v)
-    | Num 0. -> Some []
+    (* A unitless zero is still a [<number>] inside calc(), not a typed zero. *)
     | Num _ | Math_const _ | Var _ | Sibling_index | Sibling_count | Math_fn _
       ->
         None
@@ -1934,8 +1922,8 @@ let linear_length_calc calc =
           List.fold_left
             (fun acc { unit; value = n; _ } ->
               let op, n = linear_calc_op first_unit first_value unit n in
-              Expr (acc, op, Val (length_of_unit unit n)))
-            (Val (length_of_unit unit n))
+              Expr (acc, op, Val (length_of_calc_unit unit n)))
+            (Val (length_of_calc_unit unit n))
             rest)
 
 let lp_of_default_string value : length_percentage option =
@@ -2035,7 +2023,7 @@ let unit_of_lp : length_percentage -> (length_unit * float) option = function
   | Env _ | Var _ | Calc _ | Invalid _ -> None
 
 let lp_of_unit unit n : length_percentage =
-  match unit with Pct -> Pct n | unit -> Length (length_of_unit unit n)
+  match unit with Pct -> Pct n | unit -> Length (length_of_calc_unit unit n)
 
 let linear_lp_terms calc = linear_terms_with unit_of_lp calc
 
@@ -2373,7 +2361,7 @@ and pp_generic_length_calc ~always ctx cv =
       pp_calc_wrapped_length ~always ctx length
   | _ ->
       let always = always || calc_contains_var cv in
-      pp_calc_presolved (pp_length ~always) ctx cv
+      pp_calc_presolved ~unwrap_num:false (pp_length ~always) ctx cv
 
 let pp_color_name : color_name Pp.t =
  fun ctx name -> Pp.string ctx (fst (color_name_hex name))
@@ -3674,7 +3662,7 @@ let rec pp_angle : angle Pp.t =
   (* A math function is itself an [<angle>] production, so the [calc()] around
      one is redundant (CSS Values 4 sec. 10.8). *)
   | Calc (Math_fn fn) -> pp_math_fn ctx fn
-  | Calc c -> pp_calc_presolved pp_angle ctx c
+  | Calc c -> pp_calc_presolved ~unwrap_num:false pp_angle ctx c
   | Var v -> pp_var pp_angle ctx v
   | Invalid tokens ->
       Pp.string ctx
@@ -4179,7 +4167,7 @@ let rec pp_length_percentage ?(always = false) : length_percentage Pp.t =
       (* Inline mode substitutes a [var()]'s default value into the calc. *)
       let c = if Pp.minified ctx then resolve_lp_calc_vars ctx c else c in
       let always = always || calc_contains_var c in
-      pp_calc_presolved (pp_length_percentage ~always) ctx c
+      pp_calc_presolved ~unwrap_num:false (pp_length_percentage ~always) ctx c
   | Invalid tokens ->
       Pp.string ctx
         (if Pp.minified ctx then Parser.to_string_minified tokens
@@ -4873,7 +4861,7 @@ let rec pp_duration : duration Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_duration ctx v
-  | Calc c -> pp_calc pp_duration_in_calc ctx c
+  | Calc c -> pp_calc_with ~unwrap_num:false pp_duration_in_calc ctx c
 
 and pp_duration_in_calc : duration Pp.t =
  fun ctx -> function
@@ -4891,7 +4879,7 @@ and pp_duration_in_calc : duration Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_duration ctx v
-  | Calc c -> pp_calc pp_duration_in_calc ctx c
+  | Calc c -> pp_calc_with ~unwrap_num:false pp_duration_in_calc ctx c
 
 let pp_duration_preserve_ms = pp_duration
 

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -629,9 +629,10 @@ val calc_identity :
     Values 4 sec. 10.10.1 identities to one [Expr (l, op, r)] node, returning
     the folded operand when one applies. These hold for any operand including a
     kept [var()] (inside [calc()] a [var()] is single-valued): [x * 1], [1 * x],
-    [x / 1], [x + 0], [0 + x], [x - 0] keep [x]; [x * 0] / [0 * x] reduce to
-    [zero]. [is_zero] recognises a typed zero leaf ([0px]). Numeric [op] numeric
-    is the caller's job. *)
+    and [x / 1] keep [x]; [x * 0] / [0 * x] reduce to [zero]. [is_zero]
+    recognises a typed zero leaf ([0px]). Additive zero terms do not fold here:
+    the spec only combines sum children with identical units. Numeric [op]
+    numeric is the caller's job. *)
 
 val var_name : 'a var -> string
 (** [var_name v] is [v]'s variable name (without --). *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5248,11 +5248,9 @@ let bg35_radius_collapse () =
     "border-radius: 1px 1px 1px 1px collapses to 1px" ".x{border-radius:1px}"
     (normalize ".x { border-radius: 1px 1px 1px 1px }")
 
-(* CSS Values and Units Module Level 4, section 10 (Mathematical Expressions):
-   [calc(<dimension> + 0)] simplifies to [<dimension>] because adding zero is
-   the identity in that dimension. The spec permits the implementation to
-   simplify - cssnano takes the freedom; the shortest spec-equivalent form is
-   the bare dimension. *)
+(* CSS Values 4 sec. 10.10.1 only combines sum children with identical units and
+   explicitly warns that a zero term cannot otherwise be removed: its type can
+   affect the calculation. A unitless zero is not a [<length>] calc term. *)
 let v410_calc_add_zero () =
   let normalize css =
     match Css.of_string ~strict:false css with
@@ -5260,11 +5258,17 @@ let v410_calc_add_zero () =
     | Error _ -> Alcotest.failf "failed to parse: %s" css
   in
   Alcotest.(check string)
-    "calc(1px + 0) simplifies to 1px" ".x{width:1px}"
+    "unitless zero stays in a length sum" ".x{width:calc(1px + 0)}"
     (normalize ".x { width: calc(1px + 0) }");
   Alcotest.(check string)
-    "calc(0 + 1px) simplifies to 1px" ".x{width:1px}"
+    "leading unitless zero stays in a length sum" ".x{width:calc(0 + 1px)}"
     (normalize ".x { width: calc(0 + 1px) }");
+  Alcotest.(check string)
+    "a cross-unit zero stays in a length sum" ".x{width:calc(1em + 0px)}"
+    (normalize ".x { width: calc(1em + 0px) }");
+  Alcotest.(check string)
+    "a zero percentage stays in a length sum" ".x{width:calc(1px + 0%)}"
+    (normalize ".x { width: calc(1px + 0%) }");
   Alcotest.(check string)
     "calc(1px + 0px) simplifies to 1px" ".x{width:1px}"
     (normalize ".x { width: calc(1px + 0px) }")
@@ -6246,7 +6250,7 @@ let v4_10_2_calc_arithmetic () =
     "calc(1px * 0) -> 0" ".x{width:0}"
     (normalize ".x { width: calc(1px * 0) }");
   Alcotest.(check string)
-    "calc(0 + 0) -> 0" ".x{width:0}"
+    "unitless calc zero stays untyped" ".x{width:calc(0)}"
     (normalize ".x { width: calc(0 + 0) }")
 
 let v4102_calc_addition () =
@@ -6545,21 +6549,17 @@ let customprops12_inlining () =
     ".x{padding:calc(var(--spacing))}"
     (normalize ".x { padding: calc(var(--spacing) / 1) }");
   Alcotest.(check string)
-    "calc var plus zero folds, keeping the var reference"
-    ".x{padding:calc(var(--spacing))}"
+    "calc var plus zero keeps the typed term"
+    ".x{padding:calc(var(--spacing) + 0px)}"
     (normalize ".x { padding: calc(var(--spacing) + 0px) }");
   Alcotest.(check string)
-    "calc zero plus var folds, keeping the var reference"
-    ".x{padding:calc(var(--spacing))}"
+    "calc zero plus var keeps the typed term"
+    ".x{padding:calc(0px + var(--spacing))}"
     (normalize ".x { padding: calc(0px + var(--spacing)) }");
   Alcotest.(check string)
-    "calc var minus zero folds, keeping the var reference"
-    ".x{padding:calc(var(--spacing))}"
+    "calc var minus zero keeps the typed term"
+    ".x{padding:calc(var(--spacing) - 0px)}"
     (normalize ".x { padding: calc(var(--spacing) - 0px) }");
-  Alcotest.(check string)
-    "calc nested var identities fold, keeping the var reference"
-    ".x{padding:calc(var(--spacing))}"
-    (normalize ".x { padding: calc((var(--spacing) * 1) + 0px) }");
   Alcotest.(check string)
     "calc var-free left subtree may fold before var"
     ".x{padding:calc(3px + var(--spacing))}"
@@ -7391,7 +7391,7 @@ let v4_10_7_identity_operations () =
     "calc(10px / 1) -> 10px" ".x{width:10px}"
     (normalize ".x { width: calc(10px / 1) }");
   Alcotest.(check string)
-    "calc(0 * 100%) -> 0" ".x{width:0}"
+    "calc(0 * 100%) keeps its percentage type" ".x{width:0%}"
     (normalize ".x { width: calc(0 * 100%) }")
 
 let v4_10_7_percentage_arithmetic () =

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -211,8 +211,8 @@ let test_length () =
   check_length "0vi";
   check_length "0svh";
 
-  (* calc() is held verbatim by pp (a typed boundary); the zero-operand
-     simplification [calc(X + 0)] -> [X] is an optimize fold. *)
+  (* calc() is held verbatim by pp. A unitless zero cannot be removed from a
+     typed sum: it is not a [<length>] operand. *)
   check_length "calc(100% - 0)";
   check_length "calc(10px + 0)";
   check_length "calc(0 + 10px)";
@@ -224,11 +224,11 @@ let test_length () =
   decl_optimizes ~prop:"width" ~held:"0vi" ~into:"0" "0vi";
   decl_optimizes ~prop:"width" ~held:"0svh" ~into:"0" "0svh";
   decl_optimizes ~prop:"width" ~held:"0%" ~into:"0%" "0%";
-  decl_optimizes ~prop:"width" ~held:"calc(100% - 0)" ~into:"100%"
+  decl_optimizes ~prop:"width" ~held:"calc(100% - 0)" ~into:"calc(100% - 0)"
     "calc(100% - 0)";
-  decl_optimizes ~prop:"width" ~held:"calc(10px + 0)" ~into:"10px"
+  decl_optimizes ~prop:"width" ~held:"calc(10px + 0)" ~into:"calc(10px + 0)"
     "calc(10px + 0)";
-  decl_optimizes ~prop:"width" ~held:"calc(0 + 10px)" ~into:"10px"
+  decl_optimizes ~prop:"width" ~held:"calc(0 + 10px)" ~into:"calc(0 + 10px)"
     "calc(0 + 10px)";
 
   neg_cursor read_length "invalid";


### PR DESCRIPTION
CSS Values 4 §10.10.1 only combines calc sum children with identical units and warns that otherwise removing a zero-valued term can change the calculation type.

Keep mixed-unit and unitless zero terms in typed calc sums, preserve typed zero spellings during serialization, and retain the existing same-unit folding. Context simplification now also produces the canonical typed zero for length and length-percentage products.

The test commit covers same-unit and cross-unit sums, percentage sentinels, unresolved variables, typed products, stylesheet minification, and the fuzz identity law.

Spec: https://drafts.csswg.org/css-values-4/#calc-simplification