### PR TITLE
docs: cite semantic rewrite rules

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1006,6 +1006,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- Load-bearing minification, parsing, and serialization comments name the CSS
+  spec sections that define their initial values, equivalences, grammars, and
+  defaults (#677)
 - `min-inline-size:initial` and `min-block-size:initial` minify to `0`, their
   CSS Logical Level 1 initial value, rather than the physical minimum-size
   properties' `auto` initial value (#675)

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -196,10 +196,11 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
         statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
       in
       (* [drop_misplaced_imports] runs first: an [@import] after a style rule is
-         invalid and ignored by browsers, so it must not act as a cascade
-         boundary. Stripping it up front lets the rules it falsely separated
-         merge in this same pass, keeping [statements] idempotent (stripping
-         after the merge would leave a re-run to combine them). *)
+         invalid and ignored by browsers (CSS Cascade L6 sec. 2), so it must not
+         act as a cascade boundary. Stripping it up front lets the rules it
+         falsely separated merge in this same pass, keeping [statements]
+         idempotent (stripping after the merge would leave a re-run to combine
+         them). *)
       let stmts' =
         let stmts =
           drop_misplaced_imports stmts

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -386,11 +386,12 @@ let rec normalize_shadow ?(lossless = false) : shadow -> shadow =
     let blur = option_map_preserve Values.normalize_length s.blur in
     let spread = option_map_preserve Values.normalize_length s.spread in
     let color = option_map_preserve (normalize_color ~lossless) s.color in
-    (* Drop a trailing optional length equal to its [0] default, contiguously
-       from the end. [spread] is always the last token, so a zero spread drops
-       freely; a zero blur drops only when no spread follows - otherwise it is
-       positional and dropping it would re-bind the spread as the blur (e.g. [0
-       1px 0 5px] must keep the [0] blur). *)
+    (* CSS Backgrounds 3 sec. 6.1 orders the optional blur then spread lengths
+       and defaults each missing value to [0]. Drop a trailing zero contiguously
+       from the end: [spread] is last and drops freely; a zero blur drops only
+       when no spread follows - otherwise it is positional and dropping it would
+       re-bind the spread as the blur (e.g. [0 1px 0 5px] must keep the [0]
+       blur). *)
     let spread : length option =
       match spread with Some sp when is_zero_length sp -> None | _ -> spread
     in

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3356,11 +3356,15 @@ let box_is_all_initial : length list -> bool = function
 let canonical_initial_for_minify : type a. a property -> a -> a =
  fun prop value ->
   match (prop, value) with
+  (* CSS2 sec. 9.9.1 gives [z-index] the initial value [auto]. *)
   | Z_index, Initial -> Auto
   (* Motion Path 1 secs. 2.3-2.4: the initial values are [normal] and [auto]. *)
   | Offset_anchor, Initial -> Auto
   | Offset_position, Initial -> Normal
+  (* CSS Color 4 sec. 3.3 gives [opacity] the initial value [1]. *)
   | Opacity, Initial -> Opacity_number 1.
+  (* CSS Box 4 secs. 3.1 and 4.1 give the margin and padding longhands the
+     initial value [0]. *)
   | Margin, vs when box_is_all_initial vs -> [ Px 0. ]
   | Padding, vs when box_is_all_initial vs -> [ Px 0. ]
   | Margin_top, Initial -> Px 0.
@@ -3371,6 +3375,10 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Padding_right, Initial -> Px 0.
   | Padding_bottom, Initial -> Px 0.
   | Padding_left, Initial -> Px 0.
+  (* CSS Sizing 3 secs. 3.1.1-3.1.2 gives [width] / [height] and their physical
+     minimum-size properties the initial value [auto]. This is level-sensitive:
+     CSS2 sec. 10.4 instead gives [min-width] / [min-height] the initial value
+     [0]. *)
   | Width, Length Initial -> Length Auto
   | Height, Length Initial -> Length Auto
   | Min_width, Length Initial -> Length Auto

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -29,7 +29,8 @@ let pp_attr_flag ctx = function
       Pp.char ctx 's'
   | None -> ()
 
-(* Check if an attribute value needs quoting according to CSS specs *)
+(* CSS Selectors 4 sec. 6.2 accepts an [<ident-token>] or [<string-token>] as an
+   attribute match value. Quotes can drop only when this text is a CSS ident. *)
 let attr_value_needs_quoting value =
   if value = "" then true
   else
@@ -61,10 +62,11 @@ let pp_quoted_attr_value quote ctx value =
 
 let pp_attr_value ?quote ctx value =
   (* Under minify, drop the surrounding quotes when the value is a CSS ident
-     since the two forms are spec-equivalent and the bare form is shorter. The
-     non-minified path keeps the quotes for source fidelity - the user who wrote
-     [type="text"] expects to read [type="text"] back, even if [type=text] would
-     parse the same way. *)
+     since CSS Selectors 4 sec. 6.2 accepts the ident and string forms at the
+     same grammar position and the bare form is shorter. The non-minified path
+     keeps the quotes for source fidelity - the user who wrote [type="text"]
+     expects to read [type="text"] back, even if [type=text] would parse the
+     same way. *)
   if String.contains value '\\' then Pp.string ctx value
   else if Pp.minified ctx && not (attr_value_needs_quoting value) then
     Pp.string ctx value
@@ -262,8 +264,9 @@ let int_of_hex c =
   | 'A' .. 'F' -> Char.code c - Char.code 'A' + 10
   | _ -> invalid_arg "not a hex digit"
 
-(* Unescape CSS escapes per spec: \XX...XX (1-6 hex) or \X (any char). Handles
-   both hex escapes (e.g., \3A for ':') and simple escapes (e.g., \:). *)
+(* Unescape CSS escapes per CSS Syntax 3 sec. 4.3.7: \XX...XX (1-6 hex) or \X
+   (any char). Handles both hex escapes (e.g., \3A for ':') and simple escapes
+   (e.g., \:). *)
 (* Helper to process hex escape sequences. Returns (codepoint, next_index) *)
 let process_hex_escape s i len =
   let rec consume_hex acc n idx =

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4184,8 +4184,9 @@ let rec pp_number_percentage ?(always = false) : number_percentage Pp.t =
   | Var v -> pp_var (pp_number_percentage ~always) ctx v
   | Calc c -> pp_calc (pp_number_percentage ~always) ctx c
 
-(* AST-level [<number-percentage>] canonicalisation: at a typed leaf where [%] and
-   number are spec-equivalent (100% = 1), pick the shorter so
+(* AST-level [<number-percentage>] canonicalisation: CSS Transforms 2 secs. 5 and
+   12.1-12.2 and Filter Effects 1 sec. 6.1 define typed positions where [%] and
+   number are equivalent (100% = 1). Pick the shorter leaf so
    [pp_number_percentage] serialises a canonical node. [Var] / [Calc] are left
    alone (inside calc() [%] and number aren't interchangeable). *)
 (* [<number-percentage>] shares [<percentage>]'s scaling/combining; the type is
@@ -7386,8 +7387,8 @@ let drop_full_alpha (c : color) : color =
   | Lch r -> Lch { r with alpha = normalize_alpha r.alpha }
   | _ -> c
 
-(* oklch/oklab/lch/lab lightness: [<percentage>] and [<number>] are
-   spec-equivalent at this leaf ([num = pct *. pct_scale]: ok* L 100% = 1,
+(* CSS Color 4 secs. 16.3-16.4 makes [<percentage>] and [<number>] equivalent
+   for oklch/oklab/lch/lab lightness ([num = pct *. pct_scale]: ok* L 100% = 1,
    lch/lab L 100% = 100). Canonicalise to the shorter spelling here, in the AST
    normalize pass, so [pp_color_lightness] serialises the node faithfully rather
    than swapping percentage for number at print time. *)

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -283,9 +283,10 @@ val normalize_number_percentage :
 (** [normalize_number_percentage np] picks the shorter spelling for a typed
     [<number-percentage>] leaf where percentage and number are spec-equivalent
     (100% = 1, e.g. transform [scale()], the [scale] property, and the [filter]
-    [brightness()]/[contrast()]/... functions). [Var] and {!module-Calc}
-    sub-forms stay opaque - inside a [calc()], the two spellings are not
-    interchangeable. *)
+    [brightness()]/[contrast()]/... functions; CSS Transforms 2 secs. 5 and
+    12.1-12.2 and Filter Effects 1 sec. 6.1). [Var] and {!module-Calc} sub-forms
+    stay opaque - inside a [calc()], the two spellings are not interchangeable.
+*)
 
 val normalize_number : ?ctx:calc_ctx -> number -> number
 (** [normalize_number n] evaluates the static CSS math functions on a [<number>]
@@ -445,17 +446,17 @@ val read_length :
 
 val read_non_negative_length : ?with_keywords:bool -> Cursor.t -> length
 (** [read_non_negative_length reader] parses a length value that must be
-    non-negative. Used for padding properties which cannot have negative values
-    per CSS specification. *)
+    non-negative. Used for padding properties, whose CSS Box 4 sec. 4.1 grammar
+    excludes negative values. *)
 
 val read_padding_shorthand : Cursor.t -> length list
 (** [read_padding_shorthand reader] parses a padding shorthand property
-    accepting 1-4 space-separated non-negative length values according to CSS
-    specification. *)
+    accepting 1-4 space-separated non-negative length values (CSS Box 4 sec.
+    4.2). *)
 
 val read_margin_shorthand : Cursor.t -> length list
 (** [read_margin_shorthand reader] parses a margin shorthand property accepting
-    1-4 space-separated length values according to CSS specification. *)
+    1-4 space-separated length values (CSS Box 4 sec. 3.2). *)
 
 val read_color : Cursor.t -> color
 (** [read_color t] parses a CSS color (hex, rgb/rgba, keywords, etc.). *)
@@ -555,8 +556,8 @@ val read_angle : Cursor.t -> angle
 
 val read_angle_unit_required : Cursor.t -> angle
 (** [read_angle_unit_required t] parses a generic CSS [<angle>] value, where
-    bare zero is invalid. Legacy property contexts that allow unitless zero use
-    {!read_angle}. *)
+    bare zero is invalid under CSS Values 4 sec. 7.1. Legacy property contexts
+    that allow unitless zero use {!read_angle}. *)
 
 val read_duration : Cursor.t -> duration
 (** [read_duration t] parses a CSS duration. *)


### PR DESCRIPTION
Name the CSS specification sections behind load-bearing semantic claims in the implementation and public parser documentation.

The citations cover property initial values, misplaced imports, number/percentage equivalence, Lab-family lightness serialization, padding and margin grammars, generic angle rejection, attribute selector quoting, escaped code points, and shadow defaults. This is a comments-only change.

Cross-checked against the current CSSWG editor drafts for CSS Sizing 3, CSS Box 4, CSS Transforms 2, Filter Effects 1, CSS Color 4, Selectors 4, CSS Syntax 3, and CSS Backgrounds 3.