### PR TITLE
values: preserve pure minify folds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -541,6 +541,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `Css.to_string ~minify:true` keeps choosing the shorter exact spelling for
+  constructed millisecond durations and degree hues without running the AST
+  optimisation phase (#678)
 - `--minify` keeps zero terms in `calc()` sums unless their units match another
   term. Removing a mixed-unit zero can change the calculation's type, and a
   unitless zero is not a valid typed length operand (#676)

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3669,16 +3669,17 @@ let rec pp_angle : angle Pp.t =
         (if Pp.minified ctx then Parser.to_string_minified tokens
          else Parser.string_of_components tokens)
 
-(* A bare or [deg] hue prints in full in both modes: reducing its precision
-   changes the rendered colour, so that is a lossy fold owned by the AST
-   normalize pass ([round_hue]), not the printer, and a consumer serialising a
-   typed oklch with [to_string ~minify:true] round-trips the authored hue. *)
+(* A bare or [deg] hue prints in full precision. Minified output can omit an
+   explicit [deg] exactly; converting another angle unit or reducing precision
+   remains a node-changing fold owned by the AST normalize pass
+   ([round_hue]). *)
 let pp_hue_float ctx f =
   Pp.string ctx (Pp.string_of_float ~drop_leading_zero:true f)
 
 let rec pp_hue : hue Pp.t =
  fun ctx -> function
   | Unitless f -> pp_hue_float ctx f
+  | Angle (Deg f) when Pp.minified ctx -> pp_hue_float ctx f
   | Angle a -> pp_angle ctx a
   | Var v -> pp_var pp_hue ctx v
   | Hue_none -> Pp.string ctx "none"
@@ -4827,10 +4828,30 @@ and pp_color_default : color Pp.t =
 
 let pp_specified_color = pp_color_default
 
+(* CSS Values 4 sec. 7.2: [ms] and [s] are interchangeable. Pure minified
+   serialization picks the shorter exact leaf spelling as a fallback for callers
+   that deliberately skip AST normalization. [shorten_ms:false] keeps the unit
+   where its surrounding grammar asks for source-unit fidelity. *)
+let pp_duration_unit ?(shorten_ms = true) ctx f suffix =
+  if f = 0. then
+    if Pp.minified ctx then Pp.string ctx "0s" else pp_unit ctx f suffix
+  else if (not shorten_ms) || (not (Pp.minified ctx)) || suffix <> "ms" then
+    pp_unit ctx f suffix
+  else
+    let seconds = f /. 1000. in
+    let ms = Pp.string_of_float ~drop_leading_zero:true f in
+    let s = Pp.string_of_float ~drop_leading_zero:true seconds in
+    if String.length s + 1 <= String.length ms + 2 then (
+      Pp.string ctx s;
+      Pp.char ctx 's')
+    else (
+      Pp.string ctx ms;
+      Pp.string ctx "ms")
+
 let rec pp_duration : duration Pp.t =
  fun ctx -> function
-  | Ms f -> pp_unit ctx f "ms"
-  | S f -> pp_unit ctx f "s"
+  | Ms f -> pp_duration_unit ctx f "ms"
+  | S f -> pp_duration_unit ctx f "s"
   | Durations durations -> Pp.list ~sep:Pp.comma pp_duration ctx durations
   | Round (strategy, value, step) ->
       Pp.call "round"
@@ -4866,14 +4887,14 @@ let rec pp_duration : duration Pp.t =
 
 and pp_duration_in_calc : duration Pp.t =
  fun ctx -> function
-  | Ms f -> pp_unit ctx f "ms"
-  | S f -> pp_unit ctx f "s"
+  | Ms f -> pp_duration_unit ~shorten_ms:false ctx f "ms"
+  | S f -> pp_duration_unit ctx f "s"
   | Durations durations ->
       Pp.list ~sep:Pp.comma pp_duration_in_calc ctx durations
   | Round (strategy, value, step) ->
-      pp_duration ctx (Round (strategy, value, step))
-  | Rem (a, b) -> pp_duration ctx (Rem (a, b))
-  | Mod (a, b) -> pp_duration ctx (Mod (a, b))
+      pp_duration_preserve_ms ctx (Round (strategy, value, step))
+  | Rem (a, b) -> pp_duration_preserve_ms ctx (Rem (a, b))
+  | Mod (a, b) -> pp_duration_preserve_ms ctx (Mod (a, b))
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -4882,7 +4903,43 @@ and pp_duration_in_calc : duration Pp.t =
   | Var v -> pp_var pp_duration ctx v
   | Calc c -> pp_calc_with ~unwrap_num:false pp_duration_in_calc ctx c
 
-let pp_duration_preserve_ms = pp_duration
+and pp_duration_preserve_ms : duration Pp.t =
+ fun ctx -> function
+  | Ms f -> pp_duration_unit ~shorten_ms:false ctx f "ms"
+  | S f -> pp_duration_unit ctx f "s"
+  | Durations durations ->
+      Pp.list ~sep:Pp.comma pp_duration_preserve_ms ctx durations
+  | Round (strategy, value, step) ->
+      Pp.call "round"
+        (fun ctx (strategy, value, step) ->
+          if strategy <> "nearest" then (
+            Pp.string ctx strategy;
+            Pp.comma ctx ());
+          pp_duration_preserve_ms ctx value;
+          Pp.comma ctx ();
+          pp_duration_preserve_ms ctx step)
+        ctx (strategy, value, step)
+  | Rem (a, b) ->
+      Pp.call "rem"
+        (fun ctx (a, b) ->
+          pp_duration_preserve_ms ctx a;
+          Pp.comma ctx ();
+          pp_duration_preserve_ms ctx b)
+        ctx (a, b)
+  | Mod (a, b) ->
+      Pp.call "mod"
+        (fun ctx (a, b) ->
+          pp_duration_preserve_ms ctx a;
+          Pp.comma ctx ();
+          pp_duration_preserve_ms ctx b)
+        ctx (a, b)
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_duration_preserve_ms ctx v
+  | Calc c -> pp_calc_with ~unwrap_num:false pp_duration_in_calc ctx c
 
 let rec pp_number : number Pp.t =
  fun ctx -> function

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -227,8 +227,8 @@ val pp_duration : duration Pp.t
 (** [pp_duration] pretty-prints {!duration} values. *)
 
 val pp_duration_preserve_ms : duration Pp.t
-(** [pp_duration_preserve_ms] is an alias of {!pp_duration}. Both printers hold
-    the parsed unit; millisecond shortening is an AST normalization. *)
+(** [pp_duration_preserve_ms] pretty-prints {!duration} values without
+    shortening milliseconds to seconds. *)
 
 val pp_number : number Pp.t
 (** [pp_number] pretty-prints {!number} values. *)

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -122,6 +122,24 @@ let minify_flag () =
   Alcotest.(check string)
     "minified optimize+minify" ".btn{color:red}" (minify stylesheet)
 
+let pure_minify_value_fallbacks () =
+  let stylesheet =
+    v
+      [
+        rule ~selector:btn
+          [
+            Css.Variables.typed_custom_property "--tw-duration" Time (Ms 200.);
+            transition_duration (Ms 200.);
+            color
+              (Hsl { h = Angle (Deg 120.); s = Pct 50.; l = Pct 50.; a = None });
+          ];
+      ]
+  in
+  Alcotest.(check string)
+    "constructed value fallbacks"
+    ".btn{--tw-duration:.2s;transition-duration:.2s;color:hsl(120 50% 50%)}"
+    (Css.to_string ~minify:true stylesheet)
+
 let explicit_phase_pipeline () =
   let stylesheet =
     v
@@ -2024,6 +2042,8 @@ let suite =
       Alcotest.test_case "layers integration" `Quick layers_integration;
       Alcotest.test_case "media queries integration" `Quick media_integration;
       Alcotest.test_case "minify flag" `Quick minify_flag;
+      Alcotest.test_case "pure minify value fallbacks" `Quick
+        pure_minify_value_fallbacks;
       Alcotest.test_case "explicit phase pipeline" `Quick
         explicit_phase_pipeline;
       Alcotest.test_case "important declarations" `Quick important_integration;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1675,7 +1675,7 @@ let animations_timing () =
   check_declaration ~expected:"animation-name:none" "animation-name: none";
 
   check_declaration ~expected:"animation-duration:1s" "animation-duration: 1s";
-  check_declaration ~expected:"animation-duration:500ms"
+  check_declaration ~expected:"animation-duration:.5s"
     ~optimized:"animation-duration:.5s" "animation-duration: 500ms";
   check_declaration ~expected:"transition-duration:round(1.1s,.5s)"
     ~optimized:"transition-duration:1s" "transition-duration: round(1.1s, .5s)";
@@ -1745,7 +1745,7 @@ let animations_timing () =
      [<time>]. [0s] does not drop the unit. *)
   check_declaration ~expected:"animation-delay:0s" "animation-delay: 0s";
   check_declaration ~expected:"animation-delay:1s" "animation-delay: 1s";
-  check_declaration ~expected:"animation-delay:-500ms"
+  check_declaration ~expected:"animation-delay:-.5s"
     ~optimized:"animation-delay:-.5s" "animation-delay: -500ms";
   (* CSS Values 4 sec. 10.3 gives these functions the type of their arguments,
      so time-valued calls fit the delay longhands' [<time>] grammar. *)
@@ -1755,7 +1755,7 @@ let animations_timing () =
     ~optimized:"animation-delay:.1s" "animation-delay:mod(1.1s,.5s)";
   check_declaration ~expected:"animation-delay:rem(1.1s,.5s)"
     ~optimized:"animation-delay:.1s" "animation-delay:rem(1.1s,.5s)";
-  check_declaration ~expected:"transition-duration:var(--d,500ms)"
+  check_declaration ~expected:"transition-duration:var(--d,.5s)"
     ~optimized:"transition-duration:var(--d,.5s)"
     "transition-duration:var(--d,500ms)";
   check_declaration ~expected:"interest-delay:round(1100ms,500ms)"
@@ -2074,7 +2074,7 @@ let list_properties () =
     "transition: opacity 1s ease-in .5s";
   check_declaration ~expected:"transition:opacity .3s,transform .3s"
     "transition: opacity 0.3s, transform 0.3s";
-  check_declaration ~expected:"transition:all 500ms"
+  check_declaration ~expected:"transition:all .5s"
     ~optimized:"transition:all .5s" "transition: all 500ms";
 
   (* Animation *)
@@ -2083,7 +2083,7 @@ let list_properties () =
     "animation: spin 1s linear infinite";
   check_declaration ~expected:"animation:slide .5s ease-out"
     "animation: slide 0.5s ease-out";
-  check_declaration ~expected:"animation:spin 500ms"
+  check_declaration ~expected:"animation:spin .5s"
     ~optimized:"animation:spin .5s" "animation: spin 500ms"
 
 let custom_properties () =

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -284,9 +284,9 @@ let test_color () =
 
   (* Modern color notations. pp preserves the authored function node; the
      equivalent hex form is the optimize+minify oracle. *)
-  check_color ~expected:"hsl(180deg 50% 25%)" ~optimized:"#206060"
+  check_color ~expected:"hsl(180 50% 25%)" ~optimized:"#206060"
     "hsl(180deg 50% 25%)";
-  check_color ~expected:"hwb(90deg 10% 20%)" ~optimized:"#73cc1a"
+  check_color ~expected:"hwb(90 10% 20%)" ~optimized:"#73cc1a"
     "hwb(90deg 10% 20%)";
   check_color ~expected:"hsl(180 50% 25%/.5)" ~optimized:"#20606080"
     "hsl(180 50% 25% / 0.5)";
@@ -296,7 +296,7 @@ let test_color () =
   (* CSS Color 4 section 4.2: alpha [<percentage>] is spec-equivalent to the
      corresponding [<number>] in [\[0, 1\]]; the printer canonicalizes to the
      number form per cssnano. *)
-  check_color ~expected:"hsl(180deg 50% 25%/30%)" ~optimized:"#2060604d"
+  check_color ~expected:"hsl(180 50% 25%/30%)" ~optimized:"#2060604d"
     "hsl(180deg 50% 25% / 30%)";
   check_color ~optimized:"red" "color(srgb 1 0 0)";
   check_color ~expected:"color(display-p3 .8 .2 .1/.5)"
@@ -372,7 +372,7 @@ let test_color () =
   check_color ~expected:"var(--color,)" "var(--color,)";
 
   (* Custom properties inline mode tests with complex color fallbacks *)
-  check_color ~expected:"var(--theme-primary,hsl(210deg 75% 50%))"
+  check_color ~expected:"var(--theme-primary,hsl(210 75% 50%))"
     ~optimized:"var(--theme-primary,#2080df)"
     "var(--theme-primary, hsl(210deg 75% 50%))";
   check_color ~expected:"var(--accent,rgb(255 0 128/80%))"
@@ -556,8 +556,9 @@ let test_angle () =
   neg_cursor read_angle "360.5.5deg"
 
 let test_duration () =
-  (* CSS Values 4 section 7.2: [<time>] requires a unit. pp holds the parsed
-     unit; choosing the shorter equivalent [s] spelling is an optimize fold. *)
+  (* CSS Values 4 section 7.2: [<time>] requires a unit, and [ms] / [s] are
+     interchangeable. Pure minified serialization chooses the shorter exact
+     spelling without running the optimizer. *)
   check_duration "1s";
   check_duration "0s";
   check_duration ~expected:".5s" "0.5s";
@@ -565,14 +566,14 @@ let test_duration () =
   check_duration "10s";
   check_duration "999s";
 
-  check_duration "500ms";
-  check_duration "0ms";
+  check_duration ~expected:".5s" "500ms";
+  check_duration ~expected:"0s" "0ms";
   check_duration "1ms";
-  check_duration "1000ms";
-  check_duration "50.5ms";
-  check_duration "999999ms";
+  check_duration ~expected:"1s" "1000ms";
+  check_duration ~expected:".0505s" "50.5ms";
+  check_duration ~expected:"999.999s" "999999ms";
   check_duration ".1s";
-  check_duration "150ms";
+  check_duration ~expected:".15s" "150ms";
   check_duration "1.5s";
 
   (* CSS Values 4 sec. 10.10.1: a typed <time> scales by a number and same-unit
@@ -697,9 +698,9 @@ let test_minified_value_formatting () =
   check string "minified rem" ".5rem" s;
   let s = Css.Pp.to_string ~minify:true pp_number (Num 0.5) in
   check string "minified number" ".5" s;
-  (* The duration printer holds the unit in minified mode. *)
+  (* The duration printer chooses the shorter exact unit in minified mode. *)
   let s = Css.Pp.to_string ~minify:true pp_duration (Ms 500.) in
-  check string "minified ms" "500ms" s;
+  check string "minified ms" ".5s" s;
   (* Zero stays zero without unit *)
   let s = Css.Pp.to_string ~minify:true pp_length Zero in
   check string "minified zero" "0" s
@@ -989,7 +990,7 @@ let test_color_space () =
   neg_cursor read_color_space ""
 
 let test_hue () =
-  check_hue "180deg";
+  check_hue ~expected:"180" "180deg";
   check_hue ~expected:".5turn" "0.5turn";
   check_hue "200grad";
   check_hue "3.14159rad";


### PR DESCRIPTION
Restore exact minified serialization fallbacks for consumers that construct an AST and call Css.to_string ~minify:true without running Css.optimize.

Millisecond duration leaves choose the shorter equivalent seconds spelling, while pp_duration_preserve_ms remains available for grammars that intentionally retain milliseconds. Explicit degree hues omit the redundant deg unit without converting other angle units or reducing precision.

The test commit covers a constructed whole sheet, typed custom properties, duration longhands and shorthands, var fallbacks, parsed HSL/HWB values, and the leaf printers.