### PR TITLE
transform: reject edge-offset origins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -197,6 +197,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `transform-origin` rejects four-component edge-offset `<position>` forms.
+  Its grammar accepts one or two X/Y components followed by an optional Z
+  length, unlike `perspective-origin`, which accepts a full `<position>` (#680)
 - `offset-anchor` and `offset-position` are typed properties. They validate
   their Motion Path grammars, expose `offset_anchor` / `offset_position`
   values, and canonicalize their `<position>` branches. Generic positions no

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -1134,7 +1134,12 @@ module Transform_origin = struct
   type keyword = Center | Left | Right | Top | Bottom
 
   let read_position t : transform_origin =
-    let position = read_position_value t in
+    let position =
+      match read_position_value t with
+      | Edge_offset_axis _ | Axis_edge_offset _ | Edge_offset_edge_offset _ ->
+          err_invalid_value t "transform-origin" "edge-offset position"
+      | position -> position
+    in
     Cursor.ws t;
     match Cursor.option read_length t with
     | Some z -> (

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1568,7 +1568,7 @@ let matrix =
       };
       {
         property = "perspective-origin";
-        positives = [ "center"; "left top"; "10px 20%" ];
+        positives = [ "center"; "left top"; "left 10px top 20px"; "10px 20%" ];
         negatives = [ "left right"; "top bottom" ];
       };
       {
@@ -1645,14 +1645,8 @@ let matrix =
       {
         property = "transform-origin";
         positives =
-          [
-            "center";
-            "left top";
-            "left 10px top 20px";
-            "10px 20px";
-            "calc(10% + 1px) 20px";
-          ];
-        negatives = [ "left right"; "top bottom" ];
+          [ "center"; "left top"; "10px 20px"; "calc(10% + 1px) 20px" ];
+        negatives = [ "left right"; "top bottom"; "left 10px top 20px" ];
       };
       {
         property = "transform-box";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2257,7 +2257,7 @@ let spec_property_grammar_table_expansion () =
       ("translate", "10px 20px");
       ("rotate", "1 0 0 45deg");
       ("scale", "1.2 2");
-      ("transform-origin", "left 10px top 20px");
+      ("perspective-origin", "left 10px top 20px");
       ("transition", "opacity 1s ease-in .2s");
       ("transition-behavior", "allow-discrete");
       ("animation", "fade 1s linear 2 alternate both running");
@@ -3983,8 +3983,8 @@ let text_box_normal () =
 
 (* CSS Values 4 sec. 8.3 allows four edge-offset components but excludes the
    three-value form. CSS Backgrounds 3 sec. 2.6 retains valid three-value
-   <bg-position>s, while CSS Transforms 1 sec. 4 can place a Z length after a
-   two-value origin. *)
+   <bg-position>s, while CSS Transforms 1 sec. 4 gives transform-origin a
+   narrower grammar with an optional Z length after a two-value origin. *)
 let edge_offset_position_grammar () =
   List.iter
     (fun (declaration, expected) ->
@@ -4005,6 +4005,8 @@ let edge_offset_position_grammar () =
       ( "background-position:center left 10px",
         "background-position:center left 10px" );
       ("background-position:top 10px left", "background-position:top 10px left");
+      ( "perspective-origin:left 10px top 20px",
+        "perspective-origin:left 10px top 20px" );
       ("transform-origin:left 10px", "transform-origin:0% 10px");
       ("transform-origin:left top 10px", "transform-origin:left top 10px");
       ("transform-origin:center top 10px", "transform-origin:center top 10px");
@@ -4018,6 +4020,10 @@ let edge_offset_position_grammar () =
       | Ok _ -> Alcotest.failf "strict parsing accepted %s" css)
     [
       "transform-origin:foo 1px bar 2px";
+      "transform-origin:left 1px top 2px";
+      "transform-origin:right 10% bottom 20%";
+      "transform-origin:top 2px left 1px";
+      "transform-origin:left 1px top 2px 3px";
       "background-position:left 1px right 2px";
       "object-position:left 1px middle";
       "perspective-origin:top 1px bottom";


### PR DESCRIPTION
CSS Transforms gives transform-origin a narrower grammar than generic <position>. The property reused the generic reader and therefore accepted invalid four-component edge-offset forms, with or without a trailing Z length.

Reject shared position nodes that carry edge-offset syntax while preserving valid one- and two-component origins plus the optional Z length. Move the old positive vector to the negative inventory and keep perspective-origin as a control that accepts a full <position>.

Tests: opam exec -- dune build; opam exec -- dune exec test/test.exe -- test declaration