### PR TITLE
properties: fold the logical minimum-size initial to auto

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1027,9 +1027,9 @@ recorded cases carrying six minifiers' answers.
 - Load-bearing minification, parsing, and serialization comments name the CSS
   spec sections that define their initial values, equivalences, grammars, and
   defaults (#677)
-- `min-inline-size:initial` and `min-block-size:initial` minify to `0`, their
-  CSS Logical Level 1 initial value, rather than the physical minimum-size
-  properties' `auto` initial value (#675)
+- `min-inline-size:initial` and `min-block-size:initial` minify to `auto`, the
+  initial value they share with `min-width` and `min-height`, rather than to a
+  zero that drops a flex item's automatic minimum size (#675, #681)
 - Border-radius normalization uses the shared box-shorthand normalizer instead
   of spelling its map-and-collapse composition inline (#663)
 - Property normalizers reuse `Common.List.map_preserve` instead of carrying a

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3383,10 +3383,14 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Height, Length Initial -> Length Auto
   | Min_width, Length Initial -> Length Auto
   | Min_height, Length Initial -> Length Auto
-  (* CSS Logical 1 sec. 4.1 keeps the logical minimum-size initial value at [0],
-     unlike the physical properties' [auto] from CSS Sizing 3 sec. 3.1.2. *)
-  | Min_inline_size, Length Initial -> Length Zero
-  | Min_block_size, Length Initial -> Length Zero
+  (* The logical twins fold to [auto] too. Two stale tables say [0] and neither
+     governs: CSS2 sec. 10.4 predates CSS Sizing 3, and CSS Logical 1 sec. 4.1's
+     own [Initial: 0] line copies that superseded CSS2 value while its [Value:
+     <'min-width'>] line and sec. 4 ("paired properties share a computed value")
+     both bind these to min-width. [auto] is the automatic minimum size, not
+     zero, so folding to [0] would let a flex item shrink below its content. *)
+  | Min_inline_size, Length Initial -> Length Auto
+  | Min_block_size, Length Initial -> Length Auto
   (* Keep this fallback exhaustive: a new property must make this match fail to
      compile until its initial-value fold has been considered. *)
   | Custom_property _, value -> value

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -140,6 +140,33 @@ let pure_minify_value_fallbacks () =
     ".btn{--tw-duration:.2s;transition-duration:.2s;color:hsl(120 50% 50%)}"
     (Css.to_string ~minify:true stylesheet)
 
+(* [to_string ~minify:true] is a pure formatter, so a constructed AST reaches
+   the printer without the normalize pass. A keyword whose spec-equivalent value
+   the optimiser substitutes must therefore survive pure minification verbatim:
+   holding [initial] is always correct, whereas printing the wrong equivalent
+   would change layout for a consumer that never calls [Css.optimize]. Every
+   test around the initial-value fold otherwise goes through the parser, which
+   runs normalization. *)
+let constructed_initial_keyword_fold () =
+  let sheet keyword =
+    v [ rule ~selector:btn [ min_inline_size keyword; min_block_size keyword ] ]
+  in
+  Alcotest.(check string)
+    "pure minify holds the initial keyword"
+    ".btn{min-inline-size:initial;min-block-size:initial}"
+    (Css.to_string ~minify:true (sheet Initial));
+  (* CSS Logical 1 sec. 4 gives each logical minimum-size property and its
+     physical counterpart one shared computed value, so [initial] resolves
+     through min-width / min-height to CSS Sizing 3 sec. 3.1.2's [auto]. *)
+  Alcotest.(check string)
+    "optimize folds the keyword to auto"
+    ".btn{min-inline-size:auto;min-block-size:auto}"
+    (minify (sheet Initial));
+  Alcotest.(check string)
+    "both phases hold an explicit auto"
+    ".btn{min-inline-size:auto;min-block-size:auto}"
+    (Css.to_string ~minify:true (sheet Auto))
+
 let explicit_phase_pipeline () =
   let stylesheet =
     v
@@ -2044,6 +2071,8 @@ let suite =
       Alcotest.test_case "minify flag" `Quick minify_flag;
       Alcotest.test_case "pure minify value fallbacks" `Quick
         pure_minify_value_fallbacks;
+      Alcotest.test_case "constructed initial keyword fold" `Quick
+        constructed_initial_keyword_fold;
       Alcotest.test_case "explicit phase pipeline" `Quick
         explicit_phase_pipeline;
       Alcotest.test_case "important declarations" `Quick important_integration;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -660,10 +660,15 @@ let lengths () =
   check_declaration ~expected:"margin:auto" "margin: auto";
   check_declaration ~expected:"width:auto" "width: auto";
   check_declaration ~expected:"height:auto" "height: auto";
+  (* CSS Logical 1 sec. 4 pairs each logical minimum-size property with its
+     physical counterpart and gives the pair one shared computed value, so
+     [initial] resolves through min-width / min-height to CSS Sizing 3 sec.
+     3.1.2's [auto]. [expected] pins the pp-held form (the keyword is not folded
+     at print time); [optimized] pins the normalize fold. *)
   check_declaration ~expected:"min-inline-size:initial"
-    ~optimized:"min-inline-size:0" "min-inline-size: initial";
+    ~optimized:"min-inline-size:auto" "min-inline-size: initial";
   check_declaration ~expected:"min-block-size:initial"
-    ~optimized:"min-block-size:0" "min-block-size: initial";
+    ~optimized:"min-block-size:auto" "min-block-size: initial";
 
   (* Min/max content *)
   check_declaration ~expected:"width:min-content" "width: min-content";

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -491,12 +491,16 @@ let test_transform_origin_position_nodes_factor () =
    late for declaration hashes to meet during factoring. *)
 let test_remaining_printer_fold_spellings_factor () =
   Alcotest.(check string)
-    "logical minimum initial factors with zero" ".a,.b{min-inline-size:0}"
+    "logical minimum initial factors with auto" ".a,.b{min-inline-size:auto}"
+    (optimize_str ".a{min-inline-size:initial}.b{min-inline-size:auto}");
+  Alcotest.(check string)
+    "logical minimum initial stays distinct from zero"
+    ".a{min-inline-size:auto}.b{min-inline-size:0}"
     (optimize_str ".a{min-inline-size:initial}.b{min-inline-size:0}");
   Alcotest.(check string)
-    "logical minimum initial stays distinct from auto"
-    ".a{min-inline-size:0}.b{min-inline-size:auto}"
-    (optimize_str ".a{min-inline-size:initial}.b{min-inline-size:auto}");
+    "logical block minimum initial factors with auto"
+    ".a,.b{min-block-size:auto}"
+    (optimize_str ".a{min-block-size:initial}.b{min-block-size:auto}");
   Alcotest.(check string)
     "milliseconds factor with seconds" ".a,.b{transition-duration:.5s}"
     (optimize_str ".a{transition-duration:500ms}.b{transition-duration:.5s}");


### PR DESCRIPTION
`min-inline-size: initial` and `min-block-size: initial` used to minify to `0`; now they minify to `auto`. CSS Logical 1 sec. 4 gives a logical property and its physical counterpart one shared computed value, so the keyword resolves through `min-width` to CSS Sizing 3 sec. 3.1.2's `auto`. Substituting a real zero drops the automatic minimum size and lets a flex item shrink below its content.

This reverses #675, which followed the `Initial: 0` line in CSS Logical 1 sec. 4.1's own table. That line carries over CSS2 sec. 10.4's value, which CSS Sizing 3 supersedes and notes it supersedes. Chrome sides with Sizing 3: in a flex container `min-inline-size: initial` computes to `auto` and lays out at 250px where `0` gives 100px.
