### PR TITLE
properties: keep a spelling for a drained shorthand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -513,9 +513,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Printing
 
-- `text-decoration` and `mask-border` no longer minify to an empty value.
-  `text-decoration:solid` printed `text-decoration:`, which no parser reads
-  back, once dropping the initial style left the shorthand with no slot (#682)
+- `text-decoration`, `mask-border` and `animation` no longer minify to an
+  empty value. `text-decoration:solid` printed `text-decoration:`, which no
+  parser reads back, once dropping the initial style left no slot (#682)
 - An ident that needs an escape to read back as one keeps it. `.x{--a:-\34 }`
   printed `.x{--a:-4}`, a number rather than the ident `-4`, and
   `@media (-\34 :1)` lost its feature name the same way: CSS Syntax 3 sec.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -197,6 +197,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `mask-border` accepts a lone mode keyword, and `border-image` rejects one
+  anywhere: only mask-border's grammar carries a `<'mask-border-mode'>` slot
+  (#682)
 - `transform-origin` rejects four-component edge-offset `<position>` forms.
   Its grammar accepts one or two X/Y components followed by an optional Z
   length, unlike `perspective-origin`, which accepts a full `<position>` (#680)
@@ -510,6 +513,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Printing
 
+- `text-decoration` and `mask-border` no longer minify to an empty value.
+  `text-decoration:solid` printed `text-decoration:`, which no parser reads
+  back, once dropping the initial style left the shorthand with no slot (#682)
 - An ident that needs an escape to read back as one keeps it. `.x{--a:-\34 }`
   printed `.x{--a:-4}`, a number rather than the ident `-4`, and
   `@media (-\34 :1)` lost its feature name the same way: CSS Syntax 3 sec.

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1886,7 +1886,7 @@ let read_mask_value : type a. a property -> Cursor.t -> declaration option =
   | Mask_image -> Some (v Mask_image (read_background_image t))
   | Mask_composite -> Some (v Mask_composite (read_mask_composite_list t))
   | Mask_mode -> Some (v Mask_mode (read_mask_mode t))
-  | Mask_border -> Some (v Mask_border (read_border_image t))
+  | Mask_border -> Some (v Mask_border (read_mask_border t))
   | Mask_size -> Some (v Mask_size (read_background_size_list t))
   | Mask_position -> Some (v Mask_position (read_background_position t))
   | Mask_repeat -> Some (v Mask_repeat (read_background_repeat_list t))

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1725,13 +1725,18 @@ let animation_quote_ambiguous_name ctx anim =
   && Animation.ambiguous_name_kind anim <> None
   && not (Animation.bare_ambiguous_safe anim)
 
+(* Every other slot holding its initial and the name absent or holding [none]
+   leaves the slot printers with nothing to write. What the value declares then
+   is the eight initials and nothing else, which is what [animation: none]
+   declares (CSS Animations 1 (ED) sec. 4.9); the empty string is not a value
+   any parser reads back. A name that is not the initial writes itself. *)
 let pp_animation_initial_none ctx (anim : animation_shorthand)
     ~name_is_default_none ~has_any_non_default =
   match (anim.name, name_is_default_none, has_any_non_default) with
-  | _, true, true -> ()
+  | _, _, true -> ()
   | Option.None, _, false -> Pp.string ctx "none"
-  | Option.None, _, true -> ()
-  | Option.Some _, _, _ -> ()
+  | Option.Some _, true, false -> Pp.string ctx "none"
+  | Option.Some _, false, false -> ()
 
 let pp_animation_name_slot ctx state ~quote_ambiguous_name
     (anim : animation_shorthand) =

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1133,25 +1133,52 @@ let pp_border_image : border_image Pp.t =
   (match width with
   | None -> ()
   | Some width ->
+      first := false;
       Pp.char ctx '/';
       Pp.list ~sep:Pp.space pp_border_image_width_item ctx width);
   (match outset with
   | None -> ()
   | Some outset ->
+      first := false;
       Pp.char ctx '/';
       Pp.list ~sep:Pp.space pp_border_image_outset_item ctx outset);
   pp_bg_prop maybe_space
     (Pp.list ~sep:Pp.space pp_border_image_repeat_keyword)
     ctx repeat;
-  pp_bg_prop maybe_space pp_mask_border_mode ctx mode
+  pp_bg_prop maybe_space pp_mask_border_mode ctx mode;
+  (* The record is public, so a caller can hand over a value with no slot
+     filled. It declares nothing but the initial longhands, which is what
+     [border-image: none] and [mask-border: none] declare (CSS Backgrounds 3
+     (ED) sec. 5.7, CSS Masking 1 (ED) sec. 8.7); the empty string is not a
+     value any parser reads back. *)
+  if !first then Pp.string ctx "none"
+
+(* A mask-border that fills no slot declares what [mask-border: none] declares,
+   and CSS Masking 1 (ED) sec. 8.1 gives mask-border-source the initial value
+   [none], so that keyword is where the two spellings meet. *)
+let drained_mask_border : border_image =
+  {
+    source = Some (None : background_image);
+    slice = None;
+    width = None;
+    outset = None;
+    repeat = None;
+    mode = None;
+  }
 
 (* CSS Masking 1 (ED) sec. 8.2 gives mask-border-mode the initial value [alpha],
    and sec. 8.7 sets an omitted shorthand slot to its initial value, so an
    explicit [alpha] declares what leaving the slot out declares. [luminance] is
-   the other mode and stays. *)
+   the other mode and stays. Written on its own the mode is the whole value, so
+   dropping it drains the shorthand. *)
 let normalize_mask_border (value : border_image) : border_image =
   match value.mode with
-  | Some (Alpha : mask_border_mode) -> { value with mode = Option.None }
+  | Some (Alpha : mask_border_mode) -> (
+      match
+        (value.source, value.slice, value.width, value.outset, value.repeat)
+      with
+      | None, None, None, None, None -> drained_mask_border
+      | _ -> { value with mode = Option.None })
   | _ -> value
 
 let pp_background_shorthand : background_shorthand Pp.t =
@@ -2134,14 +2161,24 @@ let read_mask_border_mode t =
     [ ("alpha", (Alpha : mask_border_mode)); ("luminance", Luminance) ]
     t
 
-let read_border_image t : border_image =
+(* CSS Backgrounds 3 (ED) sec. 5.7 gives border-image a source, a slice with its
+   width and outset, and a repeat. CSS Masking 1 (ED) sec. 8.7 gives mask-border
+   those same slots and one more, [|| <'mask-border-mode'>]. Nothing else tells
+   the two grammars apart, so [mask_mode] is what says which one the reader is
+   holding. CSS Values 4 (ED) sec. 2.2 has [||] ask for one or more of its
+   options, so a value that fills no slot matches neither grammar. *)
+let read_border_image_shorthand ~mask_mode t : border_image =
+  let read_mode t =
+    if mask_mode then Cursor.option read_mask_border_mode t
+    else (None : mask_border_mode option)
+  in
   let source = Cursor.option read_background_image t in
   Cursor.ws t;
-  (* CSS Masking 1 sec. 8.7 [mask-border-mode] is in [&&] juxtaposition with the
-     other slots, so the keyword may appear after [<source>] (before the slice)
-     or after [<repeat>]. Try the early slot first; combine with the trailing
-     slot below. *)
-  let mode_early = Cursor.option read_mask_border_mode t in
+  (* sec. 8.7 puts [mask-border-mode] in [||] combination with the other slots,
+     so the keyword may appear after [<source>] (before the slice) or after
+     [<repeat>]. Try the early slot first; combine with the trailing slot
+     below. *)
+  let mode_early = read_mode t in
   Cursor.ws t;
   let slice = Cursor.option read_border_image_slice t in
   let width, outset =
@@ -2166,11 +2203,19 @@ let read_border_image t : border_image =
   Cursor.ws t;
   let mode_late : mask_border_mode option =
     if Option.is_some mode_early then (None : mask_border_mode option)
-    else Cursor.option read_mask_border_mode t
+    else read_mode t
   in
   let mode = match mode_early with Some _ -> mode_early | None -> mode_late in
-  (match (source, slice, repeat) with
-  | None, None, None ->
-      Cursor.err_expected t "border-image source, slice, or repeat"
+  (match (source, slice, repeat, mode) with
+  | None, None, None, None ->
+      Cursor.err_expected t
+        (if mask_mode then "mask-border source, slice, repeat, or mode"
+         else "border-image source, slice, or repeat")
   | _ -> ());
   { source; slice; width; outset; repeat; mode }
+
+let read_border_image t : border_image =
+  read_border_image_shorthand ~mask_mode:false t
+
+let read_mask_border t : border_image =
+  read_border_image_shorthand ~mask_mode:true t

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -755,12 +755,14 @@ let normalize_text_indent : text_indent_value -> text_indent_value =
    line, thickness, style and colour longhands, and "Omitted values are set to
    their initial values" - [solid] (sec. 2.2) and [currentcolor] (sec. 2.3).
    Writing an initial out names what leaving it out names, and leaving it out is
-   the shorter spelling. *)
+   the shorter spelling. Written on its own the initial is the whole value, and
+   dropping it drains the shorthand: what is left declares the four initials and
+   nothing else, which is what [none] declares. *)
 let normalize_text_decoration ?(lossless = false) :
     text_decoration -> text_decoration =
  fun value ->
   match value with
-  | Shorthand s ->
+  | Shorthand s -> (
       let style =
         drop_default
           ~is_default:(fun (d : text_decoration_style) -> d = Solid)
@@ -771,9 +773,14 @@ let normalize_text_decoration ?(lossless = false) :
           ~is_default:(fun (c : Values.color) -> c = Values.Current)
           (option_map_preserve (normalize_color ~lossless) s.color)
       in
-      if option_is_phys_same style s.style && option_is_phys_same color s.color
-      then value
-      else Shorthand { s with style; color }
+      match (s.lines, style, color, s.thickness) with
+      | [], Option.None, Option.None, Option.None -> (None : text_decoration)
+      | _ ->
+          if
+            option_is_phys_same style s.style
+            && option_is_phys_same color s.color
+          then value
+          else Shorthand { s with style; color })
   | other -> other
 
 let normalize_text_emphasis ?(lossless = false) : text_emphasis -> text_emphasis
@@ -899,11 +906,16 @@ let pp_text_decoration_shorthand : text_decoration_shorthand Pp.t =
   | Some c ->
       space_if_needed ();
       pp_color ctx c);
-  match thickness with
+  (match thickness with
   | None -> ()
   | Some l ->
       space_if_needed ();
-      pp_length ctx l
+      pp_length ctx l);
+  (* The record is public, so a caller can hand over a value with no slot
+     filled. It declares nothing but the initial longhands, which is what
+     [text-decoration: none] declares (CSS Text Decoration 4 (ED) sec. 2.6); the
+     empty string is not a value any parser reads back. *)
+  if !first then Pp.string ctx "none"
 
 let rec pp_text_decoration : text_decoration Pp.t =
  fun ctx -> function

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -475,6 +475,11 @@ val pp_border_image : border_image Pp.t
 val read_border_image : Cursor.t -> border_image
 (** [read_border_image t] parses the [border-image] shorthand. *)
 
+val read_mask_border : Cursor.t -> border_image
+(** [read_mask_border t] parses the [mask-border] shorthand. It shares
+    {!read_border_image}'s slots and adds the [<'mask-border-mode'>] one, which
+    border-image has no grammar for. *)
+
 val read_grid_template_areas : Cursor.t -> grid_template_areas
 (** [read_grid_template_areas t] parses [grid-template-areas]. *)
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1369,6 +1369,27 @@ let mask_border_mode_slot () =
   check_declaration ~expected:"border-image:url(a.png)"
     ~optimized:"border-image:url(a.png)" "border-image: url(a.png)"
 
+(* CSS Masking 1 (ED) sec. 8.7 writes mask-border as [<'mask-border-source'> ||
+   <'mask-border-slice'> [ / <'mask-border-width'>? [ / <'mask-border-outset'>
+   ]? ]? || <'mask-border-repeat'> || <'mask-border-mode'>], and CSS Values 4
+   (ED) sec. 2.2 has [||] ask for one or more of its options, so the mode on its
+   own is a whole value. sec. 8.2 gives mask-border-mode the initial value
+   [alpha], so [alpha] drains the shorthand and what is left is the six
+   initials, which is what [none] declares (sec. 8.1). CSS Backgrounds 3 (ED)
+   sec. 5.7 writes border-image without a mode slot, so neither keyword is a
+   border-image value wherever it is written. *)
+let mask_border_mode_only () =
+  check_declaration ~roundtrip:true ~expected:"mask-border:alpha"
+    ~optimized:"mask-border:none" "mask-border: alpha";
+  check_declaration ~roundtrip:true ~expected:"mask-border:luminance"
+    ~optimized:"mask-border:luminance" "mask-border: luminance";
+  check_declaration ~expected:"mask-border:none" ~optimized:"mask-border:none"
+    "mask-border: none";
+  neg_cursor read_declaration "border-image: alpha";
+  neg_cursor read_declaration "border-image: luminance";
+  neg_cursor read_declaration "border-image: url(a.png) alpha";
+  neg_cursor read_declaration "border-image: url(a.png) luminance"
+
 (* CSS Box 4 (ED) sec. 3.2 assigns the values of a one-to-four value box
    shorthand to the four sides: one value goes to all four, two to top-bottom
    then left-right, three to top, left-right, bottom. A repeat that those rules
@@ -1586,10 +1607,11 @@ let empty_shorthand_value () =
 (* The record behind each shorthand is public, so a caller can hand the printer
    a value with no slot filled. That value declares nothing but the initial
    longhands, which is what the [none] keyword declares (CSS Backgrounds 3 (ED)
-   sec. 3.4, CSS UI 4 (ED) sec. 3.1, CSS Text Decoration 4 (ED) sec. 2.6), and
-   [none] is the spelling that says so. An empty string is not a spelling of
-   anything: no parser accepts it. [Css.to_string] does not normalize, so the
-   printer is the only thing standing between such a record and the output. *)
+   sec. 3.4 and sec. 5.7, CSS UI 4 (ED) sec. 3.1, CSS Text Decoration 4 (ED)
+   sec. 2.6, CSS Masking 1 (ED) sec. 8.7), and [none] is the spelling that says
+   so. An empty string is not a spelling of anything: no parser accepts it.
+   [Css.to_string] does not normalize, so the printer is the only thing standing
+   between such a record and the output. *)
 let all_initial_shorthand_prints_none () =
   let pp v = Css.Pp.to_string ~minify:true Css.Declaration.pp v in
   let border : Css.border =
@@ -1600,6 +1622,16 @@ let all_initial_shorthand_prints_none () =
   in
   let text_decoration : Css.text_decoration =
     Shorthand { lines = []; style = None; color = None; thickness = None }
+  in
+  let border_image : Css.Properties.border_image =
+    {
+      source = None;
+      slice = None;
+      width = None;
+      outset = None;
+      repeat = None;
+      mode = None;
+    }
   in
   Alcotest.(check string)
     "drained border shorthand" "border:none"
@@ -1618,7 +1650,13 @@ let all_initial_shorthand_prints_none () =
     (pp (Css.Declaration.v Border (Css.border_shorthand ())));
   Alcotest.(check string)
     "text_decoration_shorthand with no slot" "text-decoration:none"
-    (pp (Css.Declaration.v Text_decoration (Css.text_decoration_shorthand ())))
+    (pp (Css.Declaration.v Text_decoration (Css.text_decoration_shorthand ())));
+  Alcotest.(check string)
+    "drained mask-border shorthand" "mask-border:none"
+    (pp (Css.Declaration.v Mask_border border_image));
+  Alcotest.(check string)
+    "drained border-image shorthand" "border-image:none"
+    (pp (Css.Declaration.v Border_image border_image))
 
 let logical_border_shorthands () =
   (* css-logical-1 sec. 4.4.1: border-block-start, border-block-end,
@@ -4905,6 +4943,7 @@ let declaration_tests =
     test_case "background position slot" `Quick background_position_slot;
     test_case "background box slots" `Quick background_box_slots;
     test_case "mask-border mode slot" `Quick mask_border_mode_slot;
+    test_case "mask-border mode only" `Quick mask_border_mode_only;
     test_case "box shorthand repeats" `Quick box_shorthand_repeats;
     test_case "border-spacing pair" `Quick border_spacing_pair;
     test_case "background repeat axes" `Quick background_repeat_axes;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1855,6 +1855,25 @@ let animations_state () =
   check_declaration ~expected:"animation-play-state:paused"
     "animation-play-state: paused"
 
+(* CSS Animations 1 (ED) sec. 4.9 joins the eight components of a
+   [<single-animation>] with [||] and assigns a keyword to a property other than
+   animation-name wherever that property has not been filled yet, so the first
+   [none] of [animation: none none] is the fill mode and the second the name.
+   Both are the initial values of their longhands, so every slot written here
+   holds one, and what the whole declares is what [animation: none] declares. *)
+let animation_drained_shorthand () =
+  check_declaration ~expected:"animation:none" ~optimized:"animation:none"
+    "animation: none none";
+  check_declaration ~expected:"animation:none" ~optimized:"animation:none"
+    "animation: 0s ease 0s 1 normal none running none";
+  (* Controls: the drop still runs wherever a slot outlives it. *)
+  check_declaration ~expected:"animation:1s" ~optimized:"animation:1s"
+    "animation: 1s none";
+  check_declaration ~expected:"animation:slide" ~optimized:"animation:slide"
+    "animation: none slide";
+  check_declaration ~expected:"animation:none" ~optimized:"animation:none"
+    "animation: none"
+
 let transforms () =
   (* Transform functions *)
   check_declaration ~expected:"transform:none" "transform: none";
@@ -4956,6 +4975,7 @@ let declaration_tests =
     test_case "overflow" `Quick overflow;
     test_case "animations (timing)" `Quick animations_timing;
     test_case "animations (state)" `Quick animations_state;
+    test_case "animation drained shorthand" `Quick animation_drained_shorthand;
     test_case "transforms" `Quick transforms;
     test_case "angle units" `Quick angle_units;
     test_case "grid" `Quick grid;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1586,8 +1586,10 @@ let empty_shorthand_value () =
 (* The record behind each shorthand is public, so a caller can hand the printer
    a value with no slot filled. That value declares nothing but the initial
    longhands, which is what the [none] keyword declares (CSS Backgrounds 3 (ED)
-   sec. 3.4, CSS UI 4 (ED) sec. 3.1), and [none] is the spelling that says so.
-   An empty string is not a spelling of anything: no parser accepts it. *)
+   sec. 3.4, CSS UI 4 (ED) sec. 3.1, CSS Text Decoration 4 (ED) sec. 2.6), and
+   [none] is the spelling that says so. An empty string is not a spelling of
+   anything: no parser accepts it. [Css.to_string] does not normalize, so the
+   printer is the only thing standing between such a record and the output. *)
 let all_initial_shorthand_prints_none () =
   let pp v = Css.Pp.to_string ~minify:true Css.Declaration.pp v in
   let border : Css.border =
@@ -1596,6 +1598,9 @@ let all_initial_shorthand_prints_none () =
   let outline : Css.outline =
     Shorthand { width = None; style = None; color = None }
   in
+  let text_decoration : Css.text_decoration =
+    Shorthand { lines = []; style = None; color = None; thickness = None }
+  in
   Alcotest.(check string)
     "drained border shorthand" "border:none"
     (pp (Css.Declaration.v Border border));
@@ -1603,11 +1608,17 @@ let all_initial_shorthand_prints_none () =
     "drained outline shorthand" "outline:none"
     (pp (Css.Declaration.v Outline outline));
   Alcotest.(check string)
+    "drained text-decoration shorthand" "text-decoration:none"
+    (pp (Css.Declaration.v Text_decoration text_decoration));
+  Alcotest.(check string)
     "outline_shorthand with no slot" "outline:none"
     (pp (Css.Declaration.outline (Css.outline_shorthand ())));
   Alcotest.(check string)
     "border_shorthand with no slot" "border:none"
-    (pp (Css.Declaration.v Border (Css.border_shorthand ())))
+    (pp (Css.Declaration.v Border (Css.border_shorthand ())));
+  Alcotest.(check string)
+    "text_decoration_shorthand with no slot" "text-decoration:none"
+    (pp (Css.Declaration.v Text_decoration (Css.text_decoration_shorthand ())))
 
 let logical_border_shorthands () =
   (* css-logical-1 sec. 4.4.1: border-block-start, border-block-end,
@@ -3946,6 +3957,32 @@ let text_decoration_optional_line () =
   check_declaration ~roundtrip:true "text-decoration:red";
   check_sheet_roundtrip "text-decoration" "a{text-decoration:red}"
 
+(* CSS Text Decoration 4 (ED) sec. 2.6 sets an omitted shorthand slot to its
+   initial value - [solid] (sec. 2.2) and [currentcolor] (sec. 2.3) - so a slot
+   written with that value says what leaving it out says. Written alone the slot
+   is all there is, and dropping it drains the shorthand: what is left declares
+   nothing but the four initials, which is what [none] declares. *)
+let text_decoration_drained_shorthand () =
+  check_declaration ~expected:"text-decoration:solid"
+    ~optimized:"text-decoration:none" "text-decoration: solid";
+  check_declaration ~expected:"text-decoration:currentColor"
+    ~optimized:"text-decoration:none" "text-decoration: currentcolor";
+  check_declaration ~expected:"text-decoration:solid currentColor"
+    ~optimized:"text-decoration:none" "text-decoration: solid currentcolor";
+  check_sheet_roundtrip "text-decoration solid" "a{text-decoration:solid}";
+  (* The drop still runs wherever a slot outlives it. *)
+  check_declaration ~expected:"text-decoration:solid red"
+    ~optimized:"text-decoration:red" "text-decoration: solid red";
+  check_declaration ~expected:"text-decoration:underline solid"
+    ~optimized:"text-decoration:underline" "text-decoration: underline solid";
+  check_declaration ~expected:"text-decoration:underline currentColor"
+    ~optimized:"text-decoration:underline"
+    "text-decoration: underline currentcolor";
+  check_declaration ~expected:"text-decoration:solid 2px"
+    ~optimized:"text-decoration:2px" "text-decoration: solid 2px";
+  check_declaration ~expected:"text-decoration:none"
+    ~optimized:"text-decoration:none" "text-decoration: none"
+
 (* CSS Text 4 sec. 3 allows each longhand component of [white-space] on its own;
    omitted components take their initial values. *)
 let white_space_collapse_only () =
@@ -4909,6 +4946,8 @@ let declaration_tests =
       scroll_margin_negative_sheet;
     test_case "text-decoration optional line" `Quick
       text_decoration_optional_line;
+    test_case "text-decoration drained shorthand" `Quick
+      text_decoration_drained_shorthand;
     test_case "white-space collapse only" `Quick white_space_collapse_only;
     test_case "border-image repeat only" `Quick border_image_repeat_only;
     test_case "timeline name only" `Quick timeline_name_only;


### PR DESCRIPTION
`text-decoration: solid`, `mask-border: alpha` and `animation: none none` minified to `text-decoration:`, `mask-border:` and `animation:`, because the last slot each value carried was an initial one and dropping it left nothing to print. Reading a lone `<'mask-border-mode'>` is what mask-border's grammar asks for and border-image's does not, so the reader they share now tells the two apart.
