### PR TITLE
motion: model the offset shorthand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -200,6 +200,11 @@ recorded cases carrying six minifiers' answers.
 - `mask-border` accepts a lone mode keyword, and `border-image` rejects one
   anywhere: only mask-border's grammar carries a `<'mask-border-mode'>` slot
   (#682)
+- `offset` is a typed shorthand. It validates the Motion Path grammar, so an
+  invalid value such as `offset: total nonsense here` is dropped rather than
+  carried as opaque text; its slots canonicalize the way the longhands do, and
+  a slot left at its longhand's initial is dropped where the grammar allows it
+  (#683)
 - `transform-origin` rejects four-component edge-offset `<position>` forms.
   Its grammar accepts one or two X/Y components followed by an optional Z
   length, unlike `perspective-origin`, which accepts a full `<position>` (#680)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1611,6 +1611,7 @@ let read_motion_value : type a. a property -> Cursor.t -> declaration option =
   match prop with
   | Margin_trim -> Some (v Margin_trim (read_margin_trim t))
   | Offset_path -> Some (v Offset_path (read_offset_path t))
+  | Offset -> Some (v Offset (read_offset t))
   | Offset_anchor -> Some (v Offset_anchor (read_offset_anchor t))
   | Offset_position -> Some (v Offset_position (read_offset_position t))
   | Offset_rotate -> Some (v Offset_rotate (read_offset_rotate t))

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -1374,3 +1374,244 @@ let read_ray t : ray =
   Cursor.ws inner;
   Cursor.expect_eof inner;
   { angle; size; contain; position }
+
+(* Motion Path 1 (ED) sec. 2.6: the [offset] shorthand is
+
+   [ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> ||
+   <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?
+
+   Serialised in that order, so the [||] pair always comes back out as the
+   distance then the rotation. Pure serialiser: the initial-slot drops are
+   [normalize_offset]'s. *)
+let pp_offset_target : offset_target Pp.t =
+ fun ctx -> function
+  | Position_only position -> pp_offset_position ctx position
+  | With_path { position; path; distance; rotate } ->
+      Option.iter
+        (fun position ->
+          pp_offset_position ctx position;
+          Pp.token_sp ctx ())
+        position;
+      pp_offset_path ctx path;
+      Option.iter
+        (fun distance ->
+          Pp.token_sp ctx ();
+          pp_length_percentage ~always:true ctx distance)
+        distance;
+      Option.iter
+        (fun rotate ->
+          Pp.token_sp ctx ();
+          pp_offset_rotate ctx rotate)
+        rotate
+
+let rec pp_offset : offset Pp.t =
+ fun ctx -> function
+  | Shorthand { target; anchor } ->
+      pp_offset_target ctx target;
+      Option.iter
+        (fun anchor ->
+          Pp.slash ctx ();
+          pp_offset_anchor ctx anchor)
+        anchor
+  | Initial -> Pp.string ctx "initial"
+  | Inherit -> Pp.string ctx "inherit"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_offset ctx v
+
+(* Whether the cursor sits on a value [read_offset_path] takes as a path rather
+   than as a CSS-wide keyword or a [var()]. None of [none], [path()], [ray()]
+   and a url can start an [<'offset-position'>], so a single lookahead settles
+   which of the two leading slots is being read and the two readers cannot drift
+   apart. *)
+let starts_offset_path t =
+  Cursor.lookahead
+    (fun t ->
+      match Cursor.option read_offset_path t with
+      | Some (None | Url _ | Path _ | Ray _ : offset_path) -> true
+      | Some _ | Option.None -> false)
+    t
+
+(* A [var()] in the leading group could substitute into any of its four slots,
+   so it names no longhand before substitution and the shorthand refuses it; the
+   declaration then keeps its authored text through the unknown-property
+   fallback. The anchor stands alone behind the [/] and takes one. *)
+let reject_var_slot t =
+  if Cursor.looking_at_func "var" t then
+    Cursor.err_invalid t "var() spans no single offset slot"
+
+(* Sec. 2.2 writes [offset-distance] as a plain [<length-percentage>], but
+   cascade's longhand reader is non-negative and an existing oracle
+   ([test_declaration.ml], "offset-distance: -10%") pins that. The slot takes
+   exactly what the longhand takes rather than splitting the model in two; the
+   range itself is one arbitration, not this change. *)
+let read_offset_slot_distance t =
+  reject_var_slot t;
+  Values.read_length_percentage ~allow_negative:false ~with_keywords:false t
+
+let read_offset_slot_rotate t =
+  reject_var_slot t;
+  read_offset_rotate t
+
+(* [<'offset-distance'> || <'offset-rotate'>]: either order, each at most
+   once. *)
+let read_offset_path_tail t =
+  let distance : length_percentage option ref = ref Option.None in
+  let rotate : offset_rotate option ref = ref Option.None in
+  let try_slot : 'a. 'a option ref -> (Cursor.t -> 'a) -> bool =
+   fun slot reader ->
+    if Option.is_some !slot then false
+    else (
+      Cursor.ws t;
+      match Cursor.option reader t with
+      | Option.Some value ->
+          slot := Option.Some value;
+          true
+      | Option.None -> false)
+  in
+  let rec loop () =
+    if
+      try_slot distance read_offset_slot_distance
+      || try_slot rotate read_offset_slot_rotate
+    then loop ()
+  in
+  loop ();
+  (!distance, !rotate)
+
+let read_offset_target t : offset_target =
+  Cursor.ws t;
+  reject_var_slot t;
+  let position =
+    if starts_offset_path t then Option.None
+    else Option.Some (read_offset_position t)
+  in
+  Cursor.ws t;
+  reject_var_slot t;
+  if starts_offset_path t then
+    let path = read_offset_path t in
+    let distance, rotate = read_offset_path_tail t in
+    With_path { position; path; distance; rotate }
+  else
+    match position with
+    | Option.Some position -> Position_only position
+    | Option.None -> Cursor.err_expected t "offset-position or offset-path"
+
+let read_offset_body t : offset =
+  let target = read_offset_target t in
+  Cursor.ws t;
+  let anchor =
+    if Cursor.slash_opt t then (
+      Cursor.ws t;
+      Option.Some (read_offset_anchor t))
+    else Option.None
+  in
+  Cursor.ws t;
+  Cursor.expect_eof t;
+  Shorthand { target; anchor }
+
+let rec read_offset t : offset =
+  let raw = Cursor.consume_to_decl_end ~trim:true t in
+  match String.lowercase_ascii (String.trim raw) with
+  | "inherit" -> Inherit
+  | "initial" -> Initial
+  | "unset" -> Unset
+  | "revert" -> Revert
+  | "revert-layer" -> Revert_layer
+  | _ -> (
+      let is_whole_var () =
+        let r = Cursor.of_string raw in
+        match Values.read_var read_offset r with
+        | (_ : offset var) ->
+            Cursor.ws r;
+            Cursor.is_done r
+        | exception Cursor.Parse_error _ -> false
+      in
+      if is_whole_var () then
+        Var (Values.read_var read_offset (Cursor.of_string raw))
+      else if value_has_css_wide_mix raw then
+        Cursor.err_invalid t "CSS-wide keyword mixed with other values"
+      else
+        try read_offset_body (Cursor.of_string raw)
+        with Cursor.Parse_error _ ->
+          Cursor.err_invalid t "invalid offset shorthand")
+
+(* Sec. 2.2 gives [offset-distance] the initial value [0]. A zero percentage is
+   a different computed value from a zero length, so only a zero length says
+   what omitting the slot says. *)
+let offset_distance_is_initial : length_percentage -> bool = function
+  | Length (Pct _) | Pct _ -> false
+  | Length length -> Values.length_is_zero length
+  | Env _ | Var _ | Calc _ | Invalid _ -> false
+
+let drop_offset_initial_slot (type a) ~(is_initial : a -> bool)
+    (slot : a option) : a option =
+  match slot with Option.Some v when is_initial v -> Option.None | _ -> slot
+
+let normalize_offset_anchor_slot anchor =
+  option_map_preserve normalize_offset_anchor anchor
+  |> drop_offset_initial_slot ~is_initial:(function
+    | (Auto : offset_anchor) -> true
+    | _ -> false)
+
+(* Sec. 2.6 resets all five longhands before applying the slots written
+   explicitly, so a slot holding its longhand's initial says exactly what
+   leaving it out says: drop it. The initials are [normal] (sec. 2.3), [none]
+   (sec. 2.1), [0] (sec. 2.2), [auto] (sec. 2.5) and [auto] (sec. 2.4).
+
+   The path is the one slot whose drop is conditional. [offset-distance] and
+   [offset-rotate] are reachable only behind a path, so dropping it would leave
+   a trailing [50%] to re-read as the position; and the [!] forbids emptying the
+   group, so when every other slot has gone the path [none] stays behind and
+   spells the whole value. *)
+let normalize_offset_target ~ctx (target : offset_target) : offset_target =
+  match target with
+  | Position_only position -> (
+      match normalize_offset_position position with
+      | (Normal : offset_position) ->
+          With_path
+            {
+              position = Option.None;
+              path = (None : offset_path);
+              distance = Option.None;
+              rotate = Option.None;
+            }
+      | position -> Position_only position)
+  | With_path group -> (
+      let position =
+        option_map_preserve normalize_offset_position group.position
+        |> drop_offset_initial_slot ~is_initial:(function
+          | (Normal : offset_position) -> true
+          | _ -> false)
+      in
+      let path = normalize_offset_path group.path in
+      let distance =
+        option_map_preserve
+          (Values.normalize_length_percentage ~ctx)
+          group.distance
+        |> drop_offset_initial_slot ~is_initial:offset_distance_is_initial
+      in
+      let rotate =
+        option_map_preserve normalize_offset_rotate group.rotate
+        |> drop_offset_initial_slot ~is_initial:(function
+          | (Auto : offset_rotate) -> true
+          | _ -> false)
+      in
+      match (position, path, distance, rotate) with
+      | Option.Some position, (None : offset_path), Option.None, Option.None ->
+          Position_only position
+      | _ ->
+          if
+            position == group.position && path == group.path
+            && distance == group.distance && rotate == group.rotate
+          then target
+          else With_path { position; path; distance; rotate })
+
+let normalize_offset ~ctx (value : offset) : offset =
+  match value with
+  | Shorthand { target; anchor } ->
+      let target' = normalize_offset_target ~ctx target in
+      let anchor' = normalize_offset_anchor_slot anchor in
+      if target' == target && anchor' == anchor then value
+      else Shorthand { target = target'; anchor = anchor' }
+  | Initial | Inherit | Unset | Revert | Revert_layer | Var _ -> value

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -517,6 +517,7 @@ let pp_property : type a. a property Pp.t =
       Pp.string ctx "contain-intrinsic-inline-size"
   | Margin_trim -> Pp.string ctx "margin-trim"
   | Offset_path -> Pp.string ctx "offset-path"
+  | Offset -> Pp.string ctx "offset"
   | Offset_anchor -> Pp.string ctx "offset-anchor"
   | Offset_position -> Pp.string ctx "offset-position"
   | Offset_distance -> Pp.string ctx "offset-distance"
@@ -1339,6 +1340,7 @@ let property_tag : type a. a property -> int = function
   | Caret_color -> 533
   | Offset_anchor -> 534
   | Offset_position -> 535
+  | Offset -> 536
 (* PROPERTY_TAG_END *)
 
 (* Two property identities order by tag, and the two payload-carrying
@@ -1700,6 +1702,7 @@ let eq_property : type a b. a property -> b property -> (a, b) Type.eq option =
   | Contain_intrinsic_inline_size, Contain_intrinsic_inline_size -> Some Equal
   | Margin_trim, Margin_trim -> Some Equal
   | Offset_path, Offset_path -> Some Equal
+  | Offset, Offset -> Some Equal
   | Offset_anchor, Offset_anchor -> Some Equal
   | Offset_position, Offset_position -> Some Equal
   | Offset_distance, Offset_distance -> Some Equal
@@ -2706,6 +2709,7 @@ let read_any_property t =
   | "contain-intrinsic-inline-size" -> Prop Contain_intrinsic_inline_size
   | "margin-trim" -> Prop Margin_trim
   | "offset-path" -> Prop Offset_path
+  | "offset" -> Prop Offset
   | "offset-anchor" -> Prop Offset_anchor
   | "offset-position" -> Prop Offset_position
   | "offset-distance" -> Prop Offset_distance
@@ -3361,6 +3365,21 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   (* Motion Path 1 secs. 2.3-2.4: the initial values are [normal] and [auto]. *)
   | Offset_anchor, Initial -> Auto
   | Offset_position, Initial -> Normal
+  (* Sec. 2.6 resets all five longhands, so [initial] and a bare [none] path
+     leave the same computed values behind. *)
+  | Offset, Initial ->
+      Shorthand
+        {
+          target =
+            With_path
+              {
+                position = None;
+                path = (None : offset_path);
+                distance = None;
+                rotate = None;
+              };
+          anchor = None;
+        }
   (* CSS Color 4 sec. 3.3 gives [opacity] the initial value [1]. *)
   | Opacity, Initial -> Opacity_number 1.
   (* CSS Box 4 secs. 3.1 and 4.1 give the margin and padding longhands the
@@ -3664,6 +3683,7 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
       value
   | Margin_trim, value -> value
   | Offset_path, value -> value
+  | Offset, value -> value
   | Offset_anchor, value -> value
   | Offset_position, value -> value
   | Offset_rotate, value -> value
@@ -3929,6 +3949,7 @@ let normalize_property_value : type a.
   | Translate -> normalize_translate_value value
   | Transform_origin -> normalize_transform_origin value
   | Offset_path -> normalize_offset_path value
+  | Offset -> normalize_offset ~ctx value
   | Offset_anchor -> normalize_offset_anchor value
   | Offset_position -> normalize_offset_position value
   | Offset_rotate -> normalize_offset_rotate value
@@ -4602,6 +4623,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Contain_intrinsic_inline_size -> pp pp_contain_intrinsic_longhand
   | Margin_trim -> pp pp_margin_trim
   | Offset_path -> pp pp_offset_path
+  | Offset -> pp pp_offset
   | Offset_anchor -> pp pp_offset_anchor
   | Offset_position -> pp pp_offset_position
   | Offset_distance -> pp (pp_length_percentage ~always:true)

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -411,6 +411,20 @@ val pp_offset_anchor : offset_anchor Pp.t
 val read_offset_anchor : Cursor.t -> offset_anchor
 (** [read_offset_anchor t] parses [offset-anchor]. *)
 
+val pp_offset : offset Pp.t
+(** [pp_offset] pretty-prints the [offset] shorthand. *)
+
+val read_offset : Cursor.t -> offset
+(** [read_offset t] parses the [offset] shorthand. *)
+
+val pp_offset_target : offset_target Pp.t
+(** [pp_offset_target] pretty-prints the required leading group of the [offset]
+    shorthand. *)
+
+val read_offset_target : Cursor.t -> offset_target
+(** [read_offset_target t] parses the required leading group of the [offset]
+    shorthand. *)
+
 val pp_offset_position : offset_position Pp.t
 (** [pp_offset_position] pretty-prints [offset-position]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3646,6 +3646,33 @@ type offset_rotate =
   | Revert_layer
   | Var of offset_rotate var
 
+(* Motion Path 1 (ED) sec. 2.6 gives the [offset] shorthand
+
+   [ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> ||
+   <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?
+
+   The [!] makes the leading group required: a declaration writes a position, a
+   path, or both, and never nothing. [offset-distance] and [offset-rotate] sit
+   inside the path branch, so [With_path] is the only shape that carries them
+   and neither can be written without a path in front. *)
+type offset_target =
+  | Position_only of offset_position
+  | With_path of {
+      position : offset_position option;
+      path : offset_path;
+      distance : length_percentage option;
+      rotate : offset_rotate option;
+    }
+
+type offset =
+  | Shorthand of { target : offset_target; anchor : offset_anchor option }
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of offset var
+
 (* Container shorthand: name / type *)
 type container_shorthand =
   | Shorthand of { name : string option; ctype : container_type option }
@@ -5110,6 +5137,7 @@ type 'a property =
   | Caret_color : color property
   | Offset_anchor : offset_anchor property
   | Offset_position : offset_position property
+  | Offset : offset property
 
 type any_property = Prop : 'a property -> any_property
 

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -174,6 +174,12 @@ let covers_longhand : type a b.
   | Font, Font_size_adjust -> true
   | Font, Font_kerning -> true
   | Font, Font_optical_sizing -> true
+  (* Motion Path 1 sec. 2.6: [offset] resets the five motion path longhands. *)
+  | Offset, Offset_position -> true
+  | Offset, Offset_path -> true
+  | Offset, Offset_distance -> true
+  | Offset, Offset_rotate -> true
+  | Offset, Offset_anchor -> true
   | _ -> false
 
 (* CSS Fragmentation 3 sec. 3.4 aliases [page-break-before/after/inside] to
@@ -684,6 +690,15 @@ let property_slots : type a. a Properties.property -> overlap_key list =
         key "font-language-override";
         key "font-palette";
       ]
+  (* Motion Path 1 sec. 2.6. *)
+  | Offset ->
+      [
+        key "offset-position";
+        key "offset-path";
+        key "offset-distance";
+        key "offset-rotate";
+        key "offset-anchor";
+      ]
   | Font_style -> [ key "font-style" ]
   | Font_weight -> [ key "font-weight" ]
   | Font_stretch -> [ key "font-stretch" ]
@@ -1052,6 +1067,7 @@ let layout_footprint_family_heads =
       Prop Column_rule;
       Prop Contain_intrinsic_size;
       Prop Container;
+      Prop Offset;
     ]
 
 let paint_footprint_family_heads =

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1189,6 +1189,35 @@ let vars_of_offset_rotate (value : Properties.offset_rotate) =
   | Angle angle | With_angle (_, angle) -> vars_of_angle angle
   | Auto | Reverse | Initial | Inherit | Unset | Revert | Revert_layer -> []
 
+let vars_of_offset_target (value : Properties.offset_target) =
+  match value with
+  | Position_only position -> vars_of_offset_position position
+  | With_path { position; path; distance; rotate } ->
+      List.concat
+        [
+          (match position with
+          | Some position -> vars_of_offset_position position
+          | None -> []);
+          vars_of_offset_path path;
+          (match distance with
+          | Some distance -> vars_of_length_percentage distance
+          | None -> []);
+          (match rotate with
+          | Some rotate -> vars_of_offset_rotate rotate
+          | None -> []);
+        ]
+
+let vars_of_offset (value : Properties.offset) =
+  match value with
+  | Var var -> [ V var ]
+  | Shorthand { target; anchor } ->
+      List.append
+        (vars_of_offset_target target)
+        (match anchor with
+        | Some anchor -> vars_of_offset_anchor anchor
+        | None -> [])
+  | Initial | Inherit | Unset | Revert | Revert_layer -> []
+
 let vars_of_flex_basis (value : Properties.flex_basis) =
   match value with Var v -> [ V v ] | Calc c -> vars_of_calc c | _ -> []
 
@@ -2299,6 +2328,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
       vars_of_contain_intrinsic_longhand value
   | Margin_trim, value -> vars_of_margin_trim value
   | Offset_path, value -> vars_of_offset_path value
+  | Offset, value -> vars_of_offset value
   | Offset_anchor, value -> vars_of_offset_anchor value
   | Offset_position, value -> vars_of_offset_position value
   | Offset_rotate, value -> vars_of_offset_rotate value

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -167,6 +167,54 @@ let constructed_initial_keyword_fold () =
     ".btn{min-inline-size:auto;min-block-size:auto}"
     (Css.to_string ~minify:true (sheet Auto))
 
+(* Motion Path 1 (ED) sec. 2.6 puts a [!] on the leading group of the [offset]
+   shorthand, so no combination of slots may serialise to an empty value and
+   none may serialise to a value that reads back as a different one.
+   [Css.to_string ~minify:true] never runs the normalizers, so the printer has
+   to hold that on its own for a caller that builds the AST rather than parsing
+   it. *)
+let constructed_offset_shorthand () =
+  let offset value = Css.Declaration.v Css.Properties.Offset value in
+  let empty_slots : Css.Properties.offset =
+    Shorthand
+      {
+        target =
+          With_path
+            {
+              position = None;
+              path = (None : Css.Properties.offset_path);
+              distance = None;
+              rotate = None;
+            };
+        anchor = None;
+      }
+  in
+  let initial_slots : Css.Properties.offset =
+    Shorthand
+      {
+        target = Position_only (Normal : Css.Properties.offset_position);
+        anchor = Some (Auto : Css.Properties.offset_anchor);
+      }
+  in
+  let stylesheet =
+    v
+      [
+        rule ~selector:btn [ offset empty_slots ];
+        rule ~selector:card [ offset initial_slots ];
+      ]
+  in
+  let printed = Css.to_string ~minify:true stylesheet in
+  Alcotest.(check string)
+    "constructed offset shorthand" ".btn{offset:none}.card{offset:normal/auto}"
+    printed;
+  (* The printed sheet reads back as the sheet that printed it. *)
+  match Css.of_string ~strict:true printed with
+  | Ok { stylesheet; _ } ->
+      Alcotest.(check string)
+        "constructed offset shorthand reparses" printed
+        (String.trim (Css.to_string ~minify:true stylesheet))
+  | Error e -> Alcotest.failf "%s: %s" printed (Error.to_string e)
+
 let explicit_phase_pipeline () =
   let stylesheet =
     v
@@ -2071,6 +2119,8 @@ let suite =
       Alcotest.test_case "minify flag" `Quick minify_flag;
       Alcotest.test_case "pure minify value fallbacks" `Quick
         pure_minify_value_fallbacks;
+      Alcotest.test_case "constructed offset shorthand" `Quick
+        constructed_offset_shorthand;
       Alcotest.test_case "constructed initial keyword fold" `Quick
         constructed_initial_keyword_fold;
       Alcotest.test_case "explicit phase pipeline" `Quick

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3071,6 +3071,148 @@ let test_offset_position () =
   neg_cursor read_offset_position "none";
   neg_cursor read_offset_position "size"
 
+(* Motion Path 1 (ED) sec. 2.6 gives the [offset] shorthand
+
+   [ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> ||
+   <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?
+
+   and says "Omitted values are set to their initial values". The [!] makes the
+   first group required, so a declaration writes at least a position or a path;
+   [offset-distance] and [offset-rotate] live inside the path branch and are
+   unreachable without one. *)
+let offset_sheet css : Css.parse =
+  match Css.of_string ~strict:false css with
+  | Ok parse -> parse
+  | Error e -> Alcotest.failf "%s: %s" css (Error.to_string e)
+
+let offset_minified css =
+  String.trim (Css.to_string ~minify:true (offset_sheet css).stylesheet)
+
+(* A value the grammar rejects is dropped from the sheet and reported, not
+   carried through as opaque text. *)
+let offset_rejects value =
+  let css = String.concat "" [ ".x{offset:"; value; "}" ] in
+  Alcotest.(check string) (css ^ " is dropped") "" (offset_minified css);
+  Alcotest.(check bool)
+    (css ^ " warns") true
+    (match (offset_sheet css).warnings with [] -> false | _ :: _ -> true)
+
+(* [css] survives parse / print / parse unchanged. *)
+let offset_roundtrips css =
+  let once = offset_minified css in
+  Alcotest.(check string) (css ^ " roundtrip") css once;
+  Alcotest.(check string)
+    (css ^ " roundtrip is stable")
+    once (offset_minified once)
+
+let test_offset_shorthand_slots () =
+  (* Each slot on its own: the position branch takes [normal | auto |
+     <position>] (sec. 2.3), the path branch [none | <offset-path>] (sec.
+     2.1). *)
+  offset_roundtrips ".x{offset:auto}";
+  offset_roundtrips ".x{offset:none}";
+  offset_roundtrips ".x{offset:100px}";
+  offset_roundtrips ".x{offset:path(\"M 0 0 H 1\")}";
+  (* The path branch carries the distance and the rotation behind it. *)
+  offset_roundtrips ".x{offset:none 50px}";
+  offset_roundtrips ".x{offset:none reverse}";
+  offset_roundtrips ".x{offset:none 50px reverse 30deg}";
+  offset_roundtrips ".x{offset:path(\"M 0 0 H 1\")-200%}";
+  (* The anchor sits behind the slash (sec. 2.4). *)
+  offset_roundtrips ".x{offset:none/50%}";
+  offset_roundtrips ".x{offset:100px/50%}";
+  (* Every slot at once. *)
+  offset_roundtrips ".x{offset:0 0 path(\"M 0 0 H 1\")10px reverse 45deg/50%}"
+
+let test_offset_shorthand_canonical () =
+  (* Each slot canonicalises the way its longhand does. *)
+  decl_optimizes ~prop:"offset" ~held:"none/center" ~into:"none/50%"
+    "none / center";
+  decl_optimizes ~prop:"offset" ~held:"none/left top" ~into:"none/0 0"
+    "none / left top";
+  decl_optimizes ~prop:"offset" ~held:"left top none" ~into:"0 0"
+    "left top none";
+  (* The [||] pair goes into two slots, so the canonical grammar order comes
+     back out whichever order it went in. *)
+  decl_optimizes ~prop:"offset" ~held:"path(\"M 0 0 H 1\")50px reverse 30deg"
+    ~into:"path(\"M 0 0 H 1\")50px reverse 30deg"
+    "path('M 0 0 H 1') reverse 30deg 50px";
+  (* A slot holding its longhand's initial says what leaving it out says, so it
+     drops: [normal] (sec. 2.3), [0] (sec. 2.2), [auto] (secs. 2.5, 2.4). *)
+  decl_optimizes ~prop:"offset" ~held:"normal none reverse" ~into:"none reverse"
+    "normal none reverse";
+  decl_optimizes ~prop:"offset" ~held:"none 0" ~into:"none" "none 0";
+  decl_optimizes ~prop:"offset" ~held:"path(\"M 0 0 H 1\")auto"
+    ~into:"path(\"M 0 0 H 1\")" "path('M 0 0 H 1') auto";
+  decl_optimizes ~prop:"offset" ~held:"none/auto" ~into:"none" "none / auto";
+  (* The path is the group's initial too, but dropping it is behaviour
+     preserving only when no distance and no rotation are left behind it: both
+     are reachable only through a path, and a bare [50%] re-reads as the
+     position. *)
+  decl_optimizes ~prop:"offset" ~held:"50%none" ~into:"50%" "50% none";
+  decl_optimizes ~prop:"offset" ~held:"none 50%" ~into:"none 50%" "none 50%";
+  (* Dropping every slot would leave an empty value, which is not a declaration.
+     The path [none] is the shortest spelling of the whole group, so it is what
+     stays behind. *)
+  decl_optimizes ~prop:"offset" ~held:"normal" ~into:"none" "normal";
+  decl_optimizes ~prop:"offset" ~held:"normal none/auto" ~into:"none"
+    "normal none / auto"
+
+let test_offset_shorthand_invalid () =
+  offset_rejects "total nonsense here";
+  (* The [!] multiplier: the first group must produce a value. *)
+  offset_rejects "/ center";
+  (* The anchor is required once the slash is written. *)
+  offset_rejects "none /";
+  (* The distance and the rotation need a path in front of them. *)
+  offset_rejects "30deg";
+  offset_rejects "auto 30deg 90px";
+  (* The path may not follow the distance or the rotation. *)
+  offset_rejects "100px 0deg path(\"m 0 0 h 100\")";
+  (* Neither half of the [||] pair may be filled twice. *)
+  offset_rejects "path(\"m 0 0 h 100\") 100px 200px";
+  offset_rejects "path(\"m 0 0 h 100\") auto reverse";
+  offset_rejects "path(\"m 0 0 h 100\") reverse 100px 30deg";
+  offset_rejects "path(\"m 0 0 h 100\") 200% auto 100px";
+  (* Nothing follows the group but the anchor. *)
+  offset_rejects "path(\"m 0 0 h 100\") bottom";
+  (* The anchor is one [<position>]: at most four components. *)
+  offset_rejects "none/10px 20px 30deg";
+  (* A CSS-wide keyword stands alone (CSS Cascade 5 sec. 7.3). *)
+  offset_rejects "initial none";
+  offset_rejects "none/inherit"
+
+(* Motion Path 1 (ED) sec. 2.2 gives [offset-distance] a plain
+   [<length-percentage>] with no [[0,inf]] bound, so a negative distance is
+   valid on the longhand and in the shorthand slot. *)
+let test_offset_distance_negative () =
+  offset_roundtrips ".x{offset-distance:-200%}";
+  offset_roundtrips ".x{offset-distance:-50px}";
+  offset_roundtrips ".x{offset:path(\"M 0 0 H 1\")-200%}"
+
+(* The five longhands keep the behaviour secs. 2.1 to 2.5 give them once the
+   shorthand that resets them is modelled. *)
+let test_offset_longhands_unchanged () =
+  offset_roundtrips ".x{offset-path:none}";
+  offset_roundtrips ".x{offset-path:path(\"M 0 0 H 1\")}";
+  offset_roundtrips ".x{offset-distance:50%}";
+  offset_roundtrips ".x{offset-rotate:auto}";
+  offset_roundtrips ".x{offset-rotate:reverse 30deg}";
+  offset_roundtrips ".x{offset-position:normal}";
+  offset_roundtrips ".x{offset-anchor:auto}";
+  decl_optimizes ~prop:"offset-anchor" ~held:"center" ~into:"50%" "center";
+  decl_optimizes ~prop:"offset-position" ~held:"left top" ~into:"0 0" "left top";
+  decl_optimizes ~prop:"offset-distance" ~held:"0px" ~into:"0" "0px"
+
+(* Two spellings that print alike are one declaration, so the rules carrying
+   them factor into a single selector list. *)
+let test_offset_shorthand_factors () =
+  let css = ".a{offset:none/auto}.b{offset:none 0}.c{offset:normal}" in
+  Alcotest.(check string)
+    "offset spellings coalesce" ".a,.b,.c{offset:none}"
+    (String.trim
+       (Css.to_string ~minify:true (Css.optimize (offset_sheet css).stylesheet)))
+
 let test_translate_value () =
   check_translate_value "none";
   check_translate_value "10px";
@@ -5004,6 +5146,14 @@ let additional_tests =
     test_case "position_value" `Quick test_position_value;
     test_case "offset_anchor" `Quick test_offset_anchor;
     test_case "offset_position" `Quick test_offset_position;
+    test_case "offset shorthand slots" `Quick test_offset_shorthand_slots;
+    test_case "offset shorthand canonical" `Quick
+      test_offset_shorthand_canonical;
+    test_case "offset shorthand invalid" `Quick test_offset_shorthand_invalid;
+    test_case "offset distance negative" `Quick test_offset_distance_negative;
+    test_case "offset longhands unchanged" `Quick
+      test_offset_longhands_unchanged;
+    test_case "offset shorthand factors" `Quick test_offset_shorthand_factors;
     test_case "translate_value" `Quick test_translate_value;
     test_case "user_select" `Quick test_user_select;
     test_case "pointer_events" `Quick test_pointer_events;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -953,6 +953,13 @@ let check_object_view_box =
 let check_offset_path =
   check_value_cursor "offset_path" read_offset_path pp_offset_path
 
+let check_offset =
+  check_value_cursor "offset" read_offset pp_offset ~roundtrip:true
+
+let check_offset_target =
+  check_value_cursor "offset_target" read_offset_target pp_offset_target
+    ~roundtrip:true
+
 let check_offset_anchor =
   check_value_cursor "offset_anchor" read_offset_anchor pp_offset_anchor
 
@@ -3077,9 +3084,9 @@ let test_offset_position () =
    <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?
 
    and says "Omitted values are set to their initial values". The [!] makes the
-   first group required, so a declaration writes at least a position or a path;
-   [offset-distance] and [offset-rotate] live inside the path branch and are
-   unreachable without one. *)
+   leading group required, so a declaration writes at least a position or a
+   path; [offset-distance] and [offset-rotate] live inside the path branch and
+   are unreachable without one. *)
 let offset_sheet css : Css.parse =
   match Css.of_string ~strict:false css with
   | Ok parse -> parse
@@ -3105,26 +3112,49 @@ let offset_roundtrips css =
     (css ^ " roundtrip is stable")
     once (offset_minified once)
 
-let test_offset_shorthand_slots () =
+let test_offset () =
   (* Each slot on its own: the position branch takes [normal | auto |
      <position>] (sec. 2.3), the path branch [none | <offset-path>] (sec.
      2.1). *)
-  offset_roundtrips ".x{offset:auto}";
-  offset_roundtrips ".x{offset:none}";
-  offset_roundtrips ".x{offset:100px}";
-  offset_roundtrips ".x{offset:path(\"M 0 0 H 1\")}";
-  (* The path branch carries the distance and the rotation behind it. *)
-  offset_roundtrips ".x{offset:none 50px}";
-  offset_roundtrips ".x{offset:none reverse}";
-  offset_roundtrips ".x{offset:none 50px reverse 30deg}";
-  offset_roundtrips ".x{offset:path(\"M 0 0 H 1\")-200%}";
+  check_offset "normal";
+  check_offset "auto";
+  check_offset "left top";
+  check_offset "100px";
+  check_offset "none";
+  check_offset "path(\"M 0 0 H 1\")";
+  (* The path branch carries the distance and the rotation behind it, in the
+     grammar's order whichever order the [||] pair was written in. *)
+  check_offset "none 50px";
+  check_offset "none reverse";
+  check_offset ~expected:"none 50px reverse 30deg" "none reverse 30deg 50px";
   (* The anchor sits behind the slash (sec. 2.4). *)
-  offset_roundtrips ".x{offset:none/50%}";
-  offset_roundtrips ".x{offset:100px/50%}";
+  check_offset "none/50%";
+  check_offset "100px/50%";
   (* Every slot at once. *)
-  offset_roundtrips ".x{offset:0 0 path(\"M 0 0 H 1\")10px reverse 45deg/50%}"
+  check_offset
+    ~expected:"left bottom ray(0rad closest-corner)10px auto 30deg/right bottom"
+    "left bottom ray(0rad closest-corner) 10px auto 30deg / right bottom";
+  (* A CSS-wide keyword and a whole-value [var()] stand for the shorthand. *)
+  check_offset "inherit";
+  check_offset "var(--motion,none)";
+  neg_cursor read_offset "total nonsense here";
+  neg_cursor read_offset "path(\"m 0 0 h 100\") auto reverse"
 
-let test_offset_shorthand_canonical () =
+let test_offset_target () =
+  (* The [!] group on its own: a position, a path, or a position then a path. *)
+  check_offset_target "normal";
+  check_offset_target "left top";
+  check_offset_target "none";
+  check_offset_target "normal none";
+  check_offset_target "100px none";
+  check_offset_target "none 50px reverse 30deg";
+  (* The group must produce a value, and the rotation needs a path in front of
+     it. *)
+  neg_cursor read_offset_target "";
+  neg_cursor read_offset_target "30deg";
+  neg_cursor read_offset_target "reverse"
+
+let offset_canonical_slots () =
   (* Each slot canonicalises the way its longhand does. *)
   decl_optimizes ~prop:"offset" ~held:"none/center" ~into:"none/50%"
     "none / center";
@@ -3132,11 +3162,6 @@ let test_offset_shorthand_canonical () =
     "none / left top";
   decl_optimizes ~prop:"offset" ~held:"left top none" ~into:"0 0"
     "left top none";
-  (* The [||] pair goes into two slots, so the canonical grammar order comes
-     back out whichever order it went in. *)
-  decl_optimizes ~prop:"offset" ~held:"path(\"M 0 0 H 1\")50px reverse 30deg"
-    ~into:"path(\"M 0 0 H 1\")50px reverse 30deg"
-    "path('M 0 0 H 1') reverse 30deg 50px";
   (* A slot holding its longhand's initial says what leaving it out says, so it
      drops: [normal] (sec. 2.3), [0] (sec. 2.2), [auto] (secs. 2.5, 2.4). *)
   decl_optimizes ~prop:"offset" ~held:"normal none reverse" ~into:"none reverse"
@@ -3145,6 +3170,9 @@ let test_offset_shorthand_canonical () =
   decl_optimizes ~prop:"offset" ~held:"path(\"M 0 0 H 1\")auto"
     ~into:"path(\"M 0 0 H 1\")" "path('M 0 0 H 1') auto";
   decl_optimizes ~prop:"offset" ~held:"none/auto" ~into:"none" "none / auto";
+  (* [offset: initial] resets the same five longhands a bare [none] path leaves
+     at their initials. *)
+  decl_optimizes ~prop:"offset" ~held:"initial" ~into:"none" "initial";
   (* The path is the group's initial too, but dropping it is behaviour
      preserving only when no distance and no rotation are left behind it: both
      are reachable only through a path, and a bare [50%] re-reads as the
@@ -3158,9 +3186,9 @@ let test_offset_shorthand_canonical () =
   decl_optimizes ~prop:"offset" ~held:"normal none/auto" ~into:"none"
     "normal none / auto"
 
-let test_offset_shorthand_invalid () =
+let offset_invalid_values () =
   offset_rejects "total nonsense here";
-  (* The [!] multiplier: the first group must produce a value. *)
+  (* The [!] multiplier: the leading group must produce a value. *)
   offset_rejects "/ center";
   (* The anchor is required once the slash is written. *)
   offset_rejects "none /";
@@ -3182,17 +3210,24 @@ let test_offset_shorthand_invalid () =
   offset_rejects "initial none";
   offset_rejects "none/inherit"
 
-(* Motion Path 1 (ED) sec. 2.2 gives [offset-distance] a plain
-   [<length-percentage>] with no [[0,inf]] bound, so a negative distance is
-   valid on the longhand and in the shorthand slot. *)
-let test_offset_distance_negative () =
-  offset_roundtrips ".x{offset-distance:-200%}";
-  offset_roundtrips ".x{offset-distance:-50px}";
-  offset_roundtrips ".x{offset:path(\"M 0 0 H 1\")-200%}"
+let offset_slots_roundtrip () =
+  offset_roundtrips ".x{offset:auto}";
+  offset_roundtrips ".x{offset:none}";
+  offset_roundtrips ".x{offset:100px}";
+  offset_roundtrips ".x{offset:path(\"M 0 0 H 1\")}";
+  offset_roundtrips ".x{offset:none 50px}";
+  offset_roundtrips ".x{offset:none reverse}";
+  offset_roundtrips ".x{offset:none 50px reverse 30deg}";
+  offset_roundtrips ".x{offset:none/50%}";
+  offset_roundtrips ".x{offset:100px/50%}";
+  offset_roundtrips ".x{offset:0 0 path(\"M 0 0 H 1\")10px reverse 45deg/50%}";
+  (* A [var()] the shorthand cannot assign to one slot keeps its authored
+     text. *)
+  offset_roundtrips ".x{offset:var(--a) var(--b)}"
 
 (* The five longhands keep the behaviour secs. 2.1 to 2.5 give them once the
    shorthand that resets them is modelled. *)
-let test_offset_longhands_unchanged () =
+let offset_longhand_guards () =
   offset_roundtrips ".x{offset-path:none}";
   offset_roundtrips ".x{offset-path:path(\"M 0 0 H 1\")}";
   offset_roundtrips ".x{offset-distance:50%}";
@@ -3206,7 +3241,7 @@ let test_offset_longhands_unchanged () =
 
 (* Two spellings that print alike are one declaration, so the rules carrying
    them factor into a single selector list. *)
-let test_offset_shorthand_factors () =
+let offset_spellings_factor () =
   let css = ".a{offset:none/auto}.b{offset:none 0}.c{offset:normal}" in
   Alcotest.(check string)
     "offset spellings coalesce" ".a,.b,.c{offset:none}"
@@ -5146,14 +5181,13 @@ let additional_tests =
     test_case "position_value" `Quick test_position_value;
     test_case "offset_anchor" `Quick test_offset_anchor;
     test_case "offset_position" `Quick test_offset_position;
-    test_case "offset shorthand slots" `Quick test_offset_shorthand_slots;
-    test_case "offset shorthand canonical" `Quick
-      test_offset_shorthand_canonical;
-    test_case "offset shorthand invalid" `Quick test_offset_shorthand_invalid;
-    test_case "offset distance negative" `Quick test_offset_distance_negative;
-    test_case "offset longhands unchanged" `Quick
-      test_offset_longhands_unchanged;
-    test_case "offset shorthand factors" `Quick test_offset_shorthand_factors;
+    test_case "offset" `Quick test_offset;
+    test_case "offset_target" `Quick test_offset_target;
+    test_case "offset canonical slots" `Quick offset_canonical_slots;
+    test_case "offset invalid values" `Quick offset_invalid_values;
+    test_case "offset slots roundtrip" `Quick offset_slots_roundtrip;
+    test_case "offset longhand guards" `Quick offset_longhand_guards;
+    test_case "offset spellings factor" `Quick offset_spellings_factor;
     test_case "translate_value" `Quick test_translate_value;
     test_case "user_select" `Quick test_user_select;
     test_case "pointer_events" `Quick test_pointer_events;


### PR DESCRIPTION
`offset` fell through to `Unknown_property`, so `offset: total nonsense here` was carried into the output as text and no slot canonicalised, while every longhand the shorthand resets already validates and folds. It is now typed against Motion Path 1 (ED) section 2.6.

The grammar's required-group multiplier shapes the AST: `offset_target` is either a position or a path group, so no combination of dropped initial slots can print an empty value. The path slot drops only when no distance and no rotation sit behind it, because a bare trailing `50%` reads back as the position. The distance slot takes what cascade's `offset-distance` reader takes rather than the wider range section 2.2 writes; that range is pinned by an existing oracle and is a separate arbitration.
