### PR TITLE
values: preserve integer token values

### DIFF
--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -298,10 +298,7 @@ let number_opt t =
 
 let integer_opt t =
   take_token_if
-    (function
-      | Token.Number_tok { value; number_flag = Token.Integer; _ } ->
-          Some (int_of_float value)
-      | _ -> None)
+    (function Token.Number_tok number -> Token.integer_opt number | _ -> None)
     t
 
 let percentage_opt t =

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -617,8 +617,9 @@ let typed_function_value component : value option =
 
 let value_of_number (number : Token.number) =
   match number.number_flag with
-  | Token.Integer -> Integer (int_of_float number.value)
-  | Token.Number -> Number number.value
+  | Token.Integer ->
+      Option.map (fun value -> Integer value) (Token.integer_opt number)
+  | Token.Number -> Some (Number number.value)
 
 let read_value_with_unit value unit : value option =
   match length_of_value value unit with
@@ -631,7 +632,7 @@ let read_value_with_unit value unit : value option =
 let value_of_components_opt components =
   match non_whitespace_components components with
   | [ Component.Preserved { kind = Token.Number_tok number; _ } ] ->
-      Some (value_of_number number)
+      value_of_number number
   | [ Component.Preserved { kind = Token.Percentage number; _ } ] ->
       Some (Length (Values_intf.Pct number.value))
   | [ Component.Preserved { kind = Token.Dimension { number; unit_ }; _ } ] ->

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -867,10 +867,7 @@ let rec read_z_index t : z_index =
       ("revert-layer", Revert_layer);
     ]
     ~calls:[ ("calc", read_calc_z); ("var", read_var_z) ]
-    ~default:(fun t ->
-      let n = Cursor.number t in
-      if Float.is_integer n then Index (int_of_float n)
-      else Cursor.err_invalid t "z-index must be integer")
+    ~default:(fun t -> Index (Cursor.int t))
     t
 
 let read_aspect_ratio_number t =

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -306,10 +306,7 @@ let rec read_order t : order =
       ("revert-layer", Revert_layer);
     ]
     ~calls:[ ("calc", read_calc_order); ("var", read_var) ]
-    ~default:(fun t ->
-      let n = Cursor.number t in
-      if Float.is_integer n then (Int (int_of_float n) : order)
-      else Cursor.err_invalid t "order must be integer")
+    ~default:(fun t -> (Int (Cursor.int t) : order))
     t
 
 let rec read_flex_wrap t : flex_wrap =

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -741,13 +741,21 @@ let repr_is_signed (number : Token.number) =
   let r = number.repr in
   String.length r > 0 && (r.[0] = '+' || r.[0] = '-')
 
+let integer_token t (number : Token.number) =
+  match Token.integer_opt number with
+  | Some value -> value
+  | None when number.number_flag = Token.Integer ->
+      Cursor.err_invalid t "integer outside supported range"
+  | None -> Cursor.err_expected t "integer"
+
 (* Parse a [<signless-integer>] (no leading [+]/[-] in the token repr). *)
 let read_signless_integer t =
   match Cursor.peek t with
   | Some (Component.Preserved { kind = Token.Number_tok n; _ })
     when not (repr_is_signed n) ->
+      let value = integer_token t n in
       Cursor.skip t;
-      int_of_float n.value
+      value
   | _ -> Cursor.err_expected t "signless integer"
 
 (* Parse a [<signed-integer>]: a single number token whose repr starts with [+]
@@ -755,9 +763,12 @@ let read_signless_integer t =
 let read_signed_integer_opt t =
   match Cursor.peek t with
   | Some (Component.Preserved { kind = Token.Number_tok n; _ })
-    when repr_is_signed n ->
-      Cursor.skip t;
-      Some (int_of_float n.value)
+    when repr_is_signed n && n.number_flag = Token.Integer -> (
+      match Token.integer_opt n with
+      | Some value ->
+          Cursor.skip t;
+          Some value
+      | None -> None)
   | _ -> None
 
 (* After an [<n-dimension>] or n-ident, consume the optional offset tail: -
@@ -790,18 +801,19 @@ let ensure_no_ws_after_plus t =
    from CSS Syntax 3 (ED) section 6.2. Assumes the cursor is positioned on a
    [Dimension] component. *)
 let read_nth_dimension t number unit_ =
+  let coefficient = integer_token t number in
   if is_n_unit unit_ then (
     Cursor.skip t;
-    An_plus_b (int_of_float number.Token.value, read_an_tail t))
+    An_plus_b (coefficient, read_an_tail t))
   else
     match ndashdigit_b unit_ with
     | Some b ->
         Cursor.skip t;
-        An_plus_b (int_of_float number.Token.value, -b)
+        An_plus_b (coefficient, -b)
     | None ->
         if is_ndash unit_ then (
           Cursor.skip t;
-          An_plus_b (int_of_float number.Token.value, -read_signless_integer t))
+          An_plus_b (coefficient, -read_signless_integer t))
         else Cursor.err_expected t "An+B dimension (n / n-N / n-)"
 
 (* Fall-through for ident forms not caught by the explicit predicates: must be

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2971,11 +2971,11 @@ let replace_font_palette_descriptor desc acc =
        acc
 
 let read_base_palette_value inner =
-  match Cursor.number inner with
+  match Cursor.int inner with
   | n ->
-      if n < 0. || Float.floor n <> n then
+      if n < 0 then
         Cursor.err_invalid inner "base-palette index must be non-negative";
-      Index (Float.to_int n)
+      Index n
   | exception Cursor.Parse_error _ -> (
       (* [light] and [dark] are keywords, so CSS Values 4 sec. 4.1 reads them
          case-insensitively; any other ident is the author's own. *)
@@ -2987,13 +2987,13 @@ let read_base_palette_value inner =
       | _ -> Cursor.err_expected inner "base-palette value")
 
 let read_override_color_entry c =
-  let index = Cursor.number c in
-  if index < 0. || Float.floor index <> index then
+  let index = Cursor.int c in
+  if index < 0 then
     Cursor.err_invalid c "override-colors index must be non-negative";
   Cursor.ws c;
   let color = Values.read_color c in
   Cursor.ws c;
-  (Float.to_int index, color)
+  (index, color)
 
 (* CSS Fonts 4 sec. 12.1 gives each [@font-palette-values] descriptor a grammar
    of its own, and the declaration is the whole of it: a trailing [!important]

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -44,6 +44,12 @@ type t = { kind : kind; loc : Loc.t }
 
 let equal_hash_flag (a : hash_flag) b = a = b
 let equal_number_flag (a : number_flag) b = a = b
+
+let integer_opt number =
+  match number.number_flag with
+  | Integer -> int_of_string_opt number.repr
+  | Number -> None
+
 let equal_bracket (a : bracket) b = a = b
 let bracket_rank = function Curly -> 0 | Paren -> 1 | Square -> 2
 let compare_bracket a b = Int.compare (bracket_rank a) (bracket_rank b)

--- a/lib/token.mli
+++ b/lib/token.mli
@@ -80,6 +80,10 @@ val equal_hash_flag : hash_flag -> hash_flag -> bool
 val equal_number_flag : number_flag -> number_flag -> bool
 (** [equal_number_flag a b] tests number token flags for equality. *)
 
+val integer_opt : number -> int option
+(** [integer_opt n] is the exact integer represented by [n], when [n] is an
+    integer token within the native integer range. *)
+
 val equal_bracket : bracket -> bracket -> bool
 (** [equal_bracket a b] tests bracket kinds for equality. *)
 

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -270,7 +270,7 @@ let rec read_value : type a. Cursor.t -> a syntax -> a =
   | Length -> Values.read_length reader
   | Color -> Values.read_color reader
   | Number -> Cursor.number reader
-  | Integer -> int_of_float (Cursor.number reader)
+  | Integer -> Cursor.int reader
   | Percentage -> Values.read_percentage reader
   | Length_percentage -> Values.read_length_percentage reader
   | Angle -> Values.read_angle_unit_required reader

--- a/test/test_cursor.ml
+++ b/test/test_cursor.ml
@@ -26,6 +26,19 @@ let test_number () =
     "first" (Some 1.5) (Cursor.number_opt c);
   Alcotest.(check (option int)) "second" (Some 42) (Cursor.integer_opt c)
 
+(* CSS Values 4 sec. 5 represents an authored integer as an abstract integer.
+   The lexer also retains its decimal representation, so converting through the
+   rounded float must not change an integer that OCaml can represent. A token
+   outside that finite range is not an unrelated machine integer. *)
+let test_integer_precision () =
+  let exact = cursor_of_string "9007199254740993" in
+  Alcotest.(check (option int))
+    "past float precision" (Some 9007199254740993) (Cursor.integer_opt exact);
+  let unsupported = cursor_of_string "999999999999999999999999999999999999" in
+  Alcotest.(check (option int))
+    "outside the OCaml int range" None
+    (Cursor.integer_opt unsupported)
+
 let test_percentage_dimension () =
   let c = cursor_of_string "50% 10px" in
   Alcotest.(check (option (float 0.001)))
@@ -189,6 +202,7 @@ let suite =
     [
       Alcotest.test_case "ident" `Quick test_ident;
       Alcotest.test_case "number" `Quick test_number;
+      Alcotest.test_case "integer precision" `Quick test_integer_precision;
       Alcotest.test_case "percentage / dimension" `Quick
         test_percentage_dimension;
       Alcotest.test_case "parens" `Quick test_parens;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2718,6 +2718,16 @@ let number_formats () =
   (* Scientific notation IS valid in CSS per the spec *)
   check_declaration ~expected:"opacity:100" "opacity: 1e2"
 
+let integer_precision () =
+  check_declaration "order:9007199254740993";
+  check_declaration "grid-template-columns:repeat(9007199254740993,1px)";
+  List.iter
+    (neg_cursor read_declaration)
+    [
+      "order:999999999999999999999999999999999999";
+      "grid-template-columns:repeat(999999999999999999999999999999999999,1px)";
+    ]
+
 let unterminated () =
   (* CSS Syntax 5.3.7 / 4.3.5 auto-close unterminated strings, brackets and
      function calls at EOF. Assert the recovered declaration matches the shape
@@ -5046,6 +5056,7 @@ let declaration_tests =
     test_case "comments handling" `Quick comments;
     test_case "unit case-insensitivity" `Quick unit_case;
     test_case "number formats" `Quick number_formats;
+    test_case "integer precision" `Quick integer_precision;
     test_case "property name case" `Quick property_case;
     test_case "special cases" `Quick special_cases;
     test_case "edge cases" `Quick edge_cases;

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -1973,6 +1973,11 @@ let test_nth () =
   check_nth ~expected:"n-6" "n - 6";
   check_nth ~expected:"6" "+6";
 
+  (* The coefficient and offset are integer tokens, not the rounded float the
+     lexer also carries for number-valued grammars. *)
+  check_nth "9007199254740993";
+  check_nth "9007199254740993n+9007199254740993";
+
   (* Test invalid nth values *)
   (* Nothing here is an [<an+b>], so the reader refuses each outright. *)
   List.iter (neg_cursor read_nth)
@@ -1983,6 +1988,11 @@ let test_nth () =
      enforced. *)
   List.iter (neg_cursor read)
     [ ":nth-child(2 n)"; ":nth-child(3 n)"; ":nth-child(odd+1)" ];
+  List.iter (neg_cursor read_nth)
+    [
+      "999999999999999999999999999999999999";
+      "999999999999999999999999999999999999n+1";
+    ];
   ()
 
 let test_selector () =


### PR DESCRIPTION
Parse integer tokens from their source spelling so values beyond binary64 exact precision remain unchanged. Reject tokens outside the native integer range instead of rounding or wrapping them.