### PR TITLE
fonts: model numeric settings structurally

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- `font_weight.Weight` carries a number rather than an integer, and font
+  feature and variation settings carry structured tag/value lists rather than
+  pre-rendered strings. Fractional weights and variation values are preserved,
+  feature indexes may exceed one, and decoded tags are escaped as CSS strings.
 - `position_value.Axis_edge_offset` carries a `length_percentage`, matching the
   percentage-capable `<bg-position>` offset it represents (#673)
 - `text_box.Normal` represents the `normal` shorthand branch, which now parses

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1469,28 +1469,44 @@ type blend_mode = Properties.blend_mode =
   | Revert_layer
   | Var of blend_mode var
 
-(** CSS font-feature-settings values *)
+(** The optional value paired with an OpenType feature tag. *)
+type font_feature_value = Properties.font_feature_value =
+  | On
+  | Off
+  | Index of int
+
+type font_feature_setting = Properties.font_feature_setting = {
+  tag : string;
+  value : font_feature_value option;
+}
+(** One OpenType feature tag and its optional value. *)
+
+(** CSS font-feature-settings values. *)
 type font_feature_settings = Properties.font_feature_settings =
   | Normal
-  | Feature_list of string
+  | Feature_list of font_feature_setting list
   | Inherit
   | Initial
   | Unset
   | Revert
   | Revert_layer
-  | String of string
   | Var of font_feature_settings var
 
-(** CSS font-variation-settings values *)
+type font_variation_setting = Properties.font_variation_setting = {
+  tag : string;
+  value : float;
+}
+(** One OpenType variation axis and its numeric value. *)
+
+(** CSS font-variation-settings values. *)
 type font_variation_settings = Properties.font_variation_settings =
   | Normal
-  | Axis_list of string
+  | Axis_list of font_variation_setting list
   | Inherit
   | Initial
   | Unset
   | Revert
   | Revert_layer
-  | String of string
   | Var of font_variation_settings var
 
 val important : declaration -> declaration
@@ -4119,7 +4135,7 @@ val place_self : align_self * justify_self -> declaration
 
 (** CSS font weight values. *)
 type font_weight = Properties.font_weight =
-  | Weight of int
+  | Weight of float
   | Normal
   | Bold
   | Bolder

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -846,7 +846,7 @@ let rec read_visibility t : visibility =
     t
 
 let rec read_z_index t : z_index =
-  let read_calc_z t =
+  let read_calc_z t : z_index =
     (* read_calc handles the calc(...) wrapper itself *)
     let expr =
       read_calc (fun _ -> Cursor.err t "unexpected value in z-index calc") t
@@ -867,7 +867,7 @@ let rec read_z_index t : z_index =
       ("revert-layer", Revert_layer);
     ]
     ~calls:[ ("calc", read_calc_z); ("var", read_var_z) ]
-    ~default:(fun t -> Index (Cursor.int t))
+    ~default:(fun t -> (Index (Cursor.int t) : z_index))
     t
 
 let read_aspect_ratio_number t =

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -55,10 +55,11 @@ let rec read_font_weight t : font_weight =
     ]
     ~calls:[ ("var", read_var) ]
     ~default:(fun t ->
-      let n = Cursor.number t in
-      let weight = int_of_float n in
-      if weight >= 1 && weight <= 1000 then (Weight weight : font_weight)
-      else err_invalid_value t "font-weight" (string_of_int weight))
+      let weight = Cursor.number t in
+      if weight >= 1. && weight <= 1000. then (Weight weight : font_weight)
+      else
+        err_invalid_value t "font-weight"
+          (Pp.string_of_float ~drop_leading_zero:true weight))
     t
 
 let rec read_font_style t : font_style =
@@ -796,61 +797,47 @@ let rec pp_font_style : font_style Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+let pp_font_feature_value ctx (value : font_feature_value) =
+  match value with
+  | On -> Pp.string ctx "on"
+  | Off -> Pp.string ctx "off"
+  | Index value -> Pp.int ctx value
+
+let pp_font_feature_setting ctx ({ tag; value } : font_feature_setting) =
+  Pp.quoted_string ctx tag;
+  match value with
+  | None -> ()
+  | Some value ->
+      Pp.space ctx ();
+      pp_font_feature_value ctx value
+
 let rec pp_font_feature_settings : font_feature_settings Pp.t =
  fun ctx -> function
   | Normal -> Pp.string ctx "normal"
-  | Feature_list s ->
-      (* Feature list contains quoted tags already in the stored string *)
-      Pp.string ctx s
+  | Feature_list settings ->
+      Pp.list ~sep:Pp.comma pp_font_feature_setting ctx settings
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
-  | String s -> Pp.quoted_string ctx s
   | Var v -> pp_var pp_font_feature_settings ctx v
 
-(* Collapse the optional whitespace after each axis-separator comma in a
-   [font-variation-settings] list. Commas inside a quoted axis tag (a 4-char tag
-   may contain U+2C) are left untouched. *)
-let minify_axis_list s =
-  let buf = Buffer.create (String.length s) in
-  let n = String.length s in
-  let in_quote = ref false in
-  let i = ref 0 in
-  while !i < n do
-    let c = s.[!i] in
-    if !in_quote then (
-      Buffer.add_char buf c;
-      if c = '"' then in_quote := false;
-      incr i)
-    else if c = '"' then (
-      Buffer.add_char buf c;
-      in_quote := true;
-      incr i)
-    else if c = ',' then (
-      Buffer.add_char buf ',';
-      incr i;
-      while !i < n && s.[!i] = ' ' do
-        incr i
-      done)
-    else (
-      Buffer.add_char buf c;
-      incr i)
-  done;
-  Buffer.contents buf
+let pp_font_variation_setting ctx ({ tag; value } : font_variation_setting) =
+  Pp.quoted_string ctx tag;
+  Pp.space ctx ();
+  Pp.float ctx value
 
 let rec pp_font_variation_settings : font_variation_settings Pp.t =
  fun ctx -> function
   | Normal -> Pp.string ctx "normal"
-  | Axis_list s ->
-      Pp.string ctx (if Pp.minified ctx then minify_axis_list s else s)
+  | Axis_list settings ->
+      Pp.list ~sep:Pp.comma pp_font_variation_setting ctx settings
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
-  | String s -> Pp.quoted_string ctx s
   | Var v -> pp_var pp_font_variation_settings ctx v
 
 let rec pp_font_palette : font_palette Pp.t =
@@ -1197,7 +1184,7 @@ let rec pp_line_height : line_height Pp.t =
 
 let rec pp_font_weight : font_weight Pp.t =
  fun ctx -> function
-  | Weight n -> Pp.int ctx n
+  | Weight n -> Pp.float ctx n
   | Normal -> Pp.string ctx "normal"
   | Bold -> Pp.string ctx "bold"
   | Bolder -> Pp.string ctx "bolder"
@@ -1843,31 +1830,48 @@ let rec read_font_variant_numeric t : font_variant_numeric =
     ~var:(fun t -> Var (read_var read_font_variant_numeric t))
     ~default:read_font_variant_numeric_tokens t
 
+let read_opentype_tag t =
+  let tag = Cursor.string t in
+  let printable_ascii c =
+    let code = Char.code c in
+    code >= 0x20 && code <= 0x7E
+  in
+  if String.length tag <> 4 || not (String.for_all printable_ascii tag) then
+    Cursor.err t
+      "OpenType tag must contain exactly four printable ASCII characters";
+  tag
+
 let rec read_font_feature_settings t : font_feature_settings =
   let read_var t : font_feature_settings =
     Var (read_var read_font_feature_settings t)
   in
   let read_feature t =
-    let tag_content = Cursor.string t in
-    if String.length tag_content <> 4 then
-      Cursor.err t "font-feature-settings tag must be exactly 4 characters";
-    let tag = "\"" ^ tag_content ^ "\"" in
+    let tag = read_opentype_tag t in
     Cursor.ws t;
-    match Cursor.option Cursor.number t with
-    | Some n ->
-        if n <> 0.0 && n <> 1.0 then
-          Cursor.err t "font-feature-settings value must be 0 or 1";
-        tag ^ " " ^ string_of_int (int_of_float n)
-    | None -> (
-        match Cursor.option Cursor.ident t with
-        | Some "on" -> tag ^ " on"
-        | Some "off" -> tag ^ " off"
-        | Some _ -> Cursor.err t "font-feature-settings value must be on/off"
-        | None -> tag)
+    let value =
+      match Cursor.option Cursor.int t with
+      | Some value ->
+          if value < 0 then
+            Cursor.err t "font-feature-settings value must be non-negative";
+          Some (Index value)
+      | None -> (
+          match Cursor.peek t with
+          | Some (Component.Preserved { kind = Token.Number_tok _; _ }) ->
+              Cursor.err t
+                "font-feature-settings value must be a non-negative integer"
+          | _ -> (
+              match Cursor.option (Cursor.ident ~keep_case:false) t with
+              | Some "on" -> Some On
+              | Some "off" -> Some Off
+              | Some _ ->
+                  Cursor.err t "font-feature-settings value must be on/off"
+              | None -> None))
+    in
+    ({ tag; value } : font_feature_setting)
   in
   let read_feature_list t =
     let items = Cursor.list ~sep:Cursor.comma ~at_least:1 read_feature t in
-    Feature_list (String.concat ", " items)
+    Feature_list items
   in
   Cursor.enum_or_calls "font-feature-settings"
     [
@@ -1886,26 +1890,14 @@ let rec read_font_variation_settings t : font_variation_settings =
     Var (read_var read_font_variation_settings t)
   in
   let read_axis t =
-    let tag_content = Cursor.string t in
-    if String.length tag_content <> 4 then
-      Cursor.err t
-        "font-variation-settings axis tag must be exactly 4 characters";
-    String.iter
-      (fun c ->
-        let code = Char.code c in
-        if code < 0x20 || code > 0x7E then
-          Cursor.err t
-            "font-variation-settings axis tag must contain only ASCII \
-             characters (U+20 - U+7E)")
-      tag_content;
-    let tag = "\"" ^ tag_content ^ "\"" in
+    let tag = read_opentype_tag t in
     Cursor.ws t;
     let value = Cursor.number t in
-    tag ^ " " ^ string_of_int (int_of_float value)
+    ({ tag; value } : font_variation_setting)
   in
   let read_axis_list t =
     let items = Cursor.list ~sep:Cursor.comma ~at_least:1 read_axis t in
-    Axis_list (String.concat ", " items)
+    Axis_list items
   in
   Cursor.enum_or_calls "font-variation-settings"
     [
@@ -1962,8 +1954,8 @@ let normalize_line_height (lh : line_height) : line_height =
    "Same as 700", so each keyword and its number name one weight and the number
    is the shorter spelling. *)
 let normalize_font_weight : font_weight -> font_weight = function
-  | Normal -> Weight 400
-  | Bold -> Weight 700
+  | Normal -> Weight 400.
+  | Bold -> Weight 700.
   | value -> value
 
 (* sec. 2.3 maps each width keyword onto a percentage, and getComputedStyle()
@@ -2035,7 +2027,7 @@ let normalize_font : font -> font =
       let weight =
         option_map_preserve normalize_font_weight s.weight
         |> drop_font_initial_slot ~is_initial:(function
-          | (Normal : font_weight) | Weight 400 -> true
+          | (Normal : font_weight) | Weight 400. -> true
           | _ -> false)
       in
       let stretch =

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1841,36 +1841,38 @@ let read_opentype_tag t =
       "OpenType tag must contain exactly four printable ASCII characters";
   tag
 
+let read_font_feature_value t : font_feature_value =
+  match Cursor.option Cursor.int t with
+  | Some value ->
+      if value < 0 then
+        Cursor.err t "font-feature-settings value must be non-negative";
+      Index value
+  | None ->
+      Cursor.enum "font-feature-settings value"
+        [ ("on", (On : font_feature_value)); ("off", Off) ]
+        t
+
+let read_font_feature_setting t : font_feature_setting =
+  let tag = read_opentype_tag t in
+  Cursor.ws t;
+  let value =
+    match Cursor.peek t with
+    | Some
+        (Component.Preserved { kind = Token.Number_tok _ | Token.Ident _; _ })
+      ->
+        Some (read_font_feature_value t)
+    | _ -> None
+  in
+  { tag; value }
+
 let rec read_font_feature_settings t : font_feature_settings =
   let read_var t : font_feature_settings =
     Var (read_var read_font_feature_settings t)
   in
-  let read_feature t =
-    let tag = read_opentype_tag t in
-    Cursor.ws t;
-    let value =
-      match Cursor.option Cursor.int t with
-      | Some value ->
-          if value < 0 then
-            Cursor.err t "font-feature-settings value must be non-negative";
-          Some (Index value)
-      | None -> (
-          match Cursor.peek t with
-          | Some (Component.Preserved { kind = Token.Number_tok _; _ }) ->
-              Cursor.err t
-                "font-feature-settings value must be a non-negative integer"
-          | _ -> (
-              match Cursor.option (Cursor.ident ~keep_case:false) t with
-              | Some "on" -> Some On
-              | Some "off" -> Some Off
-              | Some _ ->
-                  Cursor.err t "font-feature-settings value must be on/off"
-              | None -> None))
-    in
-    ({ tag; value } : font_feature_setting)
-  in
   let read_feature_list t =
-    let items = Cursor.list ~sep:Cursor.comma ~at_least:1 read_feature t in
+    let items =
+      Cursor.list ~sep:Cursor.comma ~at_least:1 read_font_feature_setting t
+    in
     Feature_list items
   in
   Cursor.enum_or_calls "font-feature-settings"
@@ -1885,18 +1887,20 @@ let rec read_font_feature_settings t : font_feature_settings =
     ~calls:[ ("var", read_var) ]
     ~default:read_feature_list t
 
+let read_font_variation_setting t : font_variation_setting =
+  let tag = read_opentype_tag t in
+  Cursor.ws t;
+  let value = Cursor.number t in
+  { tag; value }
+
 let rec read_font_variation_settings t : font_variation_settings =
   let read_var t : font_variation_settings =
     Var (read_var read_font_variation_settings t)
   in
-  let read_axis t =
-    let tag = read_opentype_tag t in
-    Cursor.ws t;
-    let value = Cursor.number t in
-    ({ tag; value } : font_variation_setting)
-  in
   let read_axis_list t =
-    let items = Cursor.list ~sep:Cursor.comma ~at_least:1 read_axis t in
+    let items =
+      Cursor.list ~sep:Cursor.comma ~at_least:1 read_font_variation_setting t
+    in
     Axis_list items
   in
   Cursor.enum_or_calls "font-variation-settings"

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1272,12 +1272,34 @@ val read_font_variant_numeric : Cursor.t -> font_variant_numeric
 (** [read_font_variant_numeric t] is the [font_variant_numeric] parsed from [t].
 *)
 
+val pp_font_feature_value : font_feature_value Pp.t
+(** [pp_font_feature_value] is the pretty-printer for [font_feature_value]. *)
+
+val read_font_feature_value : Cursor.t -> font_feature_value
+(** [read_font_feature_value t] is the [font_feature_value] parsed from [t]. *)
+
+val pp_font_feature_setting : font_feature_setting Pp.t
+(** [pp_font_feature_setting] is the pretty-printer for [font_feature_setting].
+*)
+
+val read_font_feature_setting : Cursor.t -> font_feature_setting
+(** [read_font_feature_setting t] is the [font_feature_setting] parsed from [t].
+*)
+
 val pp_font_feature_settings : font_feature_settings Pp.t
 (** [pp_font_feature_settings] is the pretty-printer for
     [font_feature_settings]. *)
 
 val read_font_feature_settings : Cursor.t -> font_feature_settings
 (** [read_font_feature_settings t] is the [font_feature_settings] parsed from
+    [t]. *)
+
+val pp_font_variation_setting : font_variation_setting Pp.t
+(** [pp_font_variation_setting] is the pretty-printer for
+    [font_variation_setting]. *)
+
+val read_font_variation_setting : Cursor.t -> font_variation_setting
+(** [read_font_variation_setting t] is the [font_variation_setting] parsed from
     [t]. *)
 
 val pp_font_variation_settings : font_variation_settings Pp.t

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -51,7 +51,7 @@ type line_height =
   | Var of line_height var
 
 type font_weight =
-  | Weight of int
+  | Weight of float
   | Normal
   | Bold
   | Bolder
@@ -2050,26 +2050,29 @@ type font_variant_numeric =
     }
   | Var of font_variant_numeric var
 
+type font_feature_value = On | Off | Index of int
+type font_feature_setting = { tag : string; value : font_feature_value option }
+
 type font_feature_settings =
   | Normal
-  | Feature_list of string
+  | Feature_list of font_feature_setting list
   | Inherit
   | Initial
   | Unset
   | Revert
   | Revert_layer
-  | String of string
   | Var of font_feature_settings var
+
+type font_variation_setting = { tag : string; value : float }
 
 type font_variation_settings =
   | Normal
-  | Axis_list of string
+  | Axis_list of font_variation_setting list
   | Inherit
   | Initial
   | Unset
   | Revert
   | Revert_layer
-  | String of string
   | Var of font_variation_settings var
 
 (* Transform & Animation Types *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1854,9 +1854,11 @@ let test_font_weight () =
   check_font_weight "normal";
   check_font_weight "bold";
   check_font_weight "700";
+  check_font_weight "650.5";
   check_font_weight "1000";
   check_font_weight "lighter";
   neg_cursor read_font_weight "invalid-weight";
+  neg_cursor read_font_weight "0.5";
   neg_cursor read_font_weight "1001";
   (* out of range *)
   neg_cursor ~allow_partial:true read_font_weight "normal bold";
@@ -2489,12 +2491,24 @@ let test_font_feature_settings () =
   check_font_feature_settings "inherit";
   check_font_feature_settings "\"kern\"";
   check_font_feature_settings "\"liga\" 0";
+  (* CSS Fonts 4 sec. 6.12 permits every non-negative integer as a feature
+     selection index and requires a four-character printable ASCII tag. The tag
+     is a CSS string, so its decoded quote must be escaped again by pp. *)
+  check_font_feature_settings "\"swsh\" 2";
+  check_font_feature_settings ~expected:"\"a\\\"bc\" 3" "\"a\\22 bc\" 3";
+  neg_cursor read_font_feature_settings "\"éab\" 1";
+  neg_cursor read_font_feature_settings "\"kern\" 1.5";
   neg_cursor read_font_feature_settings "invalid-feature"
 
 let test_font_variation_settings () =
   check_font_variation_settings "normal";
   check_font_variation_settings "inherit";
   check_font_variation_settings "\"wght\" 400";
+  (* CSS Fonts 4 sec. 8.2 pairs a printable four-character tag with a number,
+     not an integer. Re-serialize the decoded tag through the CSS printer. *)
+  check_font_variation_settings "\"wght\" 123.5";
+  check_font_variation_settings ~expected:"\"a\\\"bc\" 123.5"
+    "\"a\\22 bc\" 123.5";
   neg_cursor read_font_variation_settings "invalid-variation"
 
 let test_transform_style () =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -293,9 +293,21 @@ let check_font_variant_numeric =
   check_value_cursor "font-variant-numeric" read_font_variant_numeric
     pp_font_variant_numeric
 
+let check_font_feature_value =
+  check_value_cursor "font-feature-value" read_font_feature_value
+    pp_font_feature_value
+
+let check_font_feature_setting =
+  check_value_cursor "font-feature-setting" read_font_feature_setting
+    pp_font_feature_setting
+
 let check_font_feature_settings =
   check_value_cursor "font-feature-settings" read_font_feature_settings
     pp_font_feature_settings
+
+let check_font_variation_setting =
+  check_value_cursor "font-variation-setting" read_font_variation_setting
+    pp_font_variation_setting
 
 let check_font_variation_settings =
   check_value_cursor "font-variation-settings" read_font_variation_settings
@@ -2486,6 +2498,19 @@ let test_font_variant_numeric () =
   check_font_variant_numeric "tabular-nums";
   neg_cursor read_font_variant_numeric "invalid-variant"
 
+let test_font_feature_value () =
+  check_font_feature_value "on";
+  check_font_feature_value "off";
+  check_font_feature_value "2";
+  neg_cursor read_font_feature_value "-1";
+  neg_cursor read_font_feature_value "1.5"
+
+let test_font_feature_setting () =
+  check_font_feature_setting "\"kern\"";
+  check_font_feature_setting "\"swsh\" 2";
+  check_font_feature_setting ~expected:"\"a\\\"bc\" on" "\"a\\22 bc\" on";
+  neg_cursor read_font_feature_setting "\"bad\""
+
 let test_font_feature_settings () =
   check_font_feature_settings "normal";
   check_font_feature_settings "inherit";
@@ -2505,7 +2530,7 @@ let test_font_feature_settings () =
   in
   check string "structured font feature settings" "\"a\\\"bc\" 2,\"kern\" on"
     (Css.Pp.to_string ~minify:true pp_font_feature_settings structured);
-  neg_cursor read_font_feature_settings "\"éab\" 1";
+  neg_cursor read_font_feature_settings "\"\\e9 ab\" 1";
   neg_cursor read_font_feature_settings "\"kern\" 1.5";
   neg_cursor read_font_feature_settings "invalid-feature"
 
@@ -2526,6 +2551,12 @@ let test_font_variation_settings () =
     "\"a\\\"bc\" 123.5,\"wght\" 650.25"
     (Css.Pp.to_string ~minify:true pp_font_variation_settings structured);
   neg_cursor read_font_variation_settings "invalid-variation"
+
+let test_font_variation_setting () =
+  check_font_variation_setting "\"wght\" 123.5";
+  check_font_variation_setting ~expected:"\"a\\\"bc\" 123.5"
+    "\"a\\22 bc\" 123.5";
+  neg_cursor read_font_variation_setting "\"bad\" 1"
 
 let test_transform_style () =
   check_transform_style "flat";
@@ -5180,7 +5211,10 @@ let additional_tests =
     test_case "vertical_align" `Quick test_vertical_align;
     test_case "font_stretch" `Quick test_font_stretch;
     test_case "font_variant_numeric" `Quick test_font_variant_numeric;
+    test_case "font_feature_value" `Quick test_font_feature_value;
+    test_case "font_feature_setting" `Quick test_font_feature_setting;
     test_case "font_feature_settings" `Quick test_font_feature_settings;
+    test_case "font_variation_setting" `Quick test_font_variation_setting;
     test_case "font_variation_settings" `Quick test_font_variation_settings;
     test_case "transform_style" `Quick test_transform_style;
     test_case "backface_visibility" `Quick test_backface_visibility;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2496,6 +2496,15 @@ let test_font_feature_settings () =
      is a CSS string, so its decoded quote must be escaped again by pp. *)
   check_font_feature_settings "\"swsh\" 2";
   check_font_feature_settings ~expected:"\"a\\\"bc\" 3" "\"a\\22 bc\" 3";
+  let structured =
+    Feature_list
+      [
+        { tag = "a\"bc"; value = Some (Index 2) };
+        { tag = "kern"; value = Some On };
+      ]
+  in
+  check string "structured font feature settings" "\"a\\\"bc\" 2,\"kern\" on"
+    (Css.Pp.to_string ~minify:true pp_font_feature_settings structured);
   neg_cursor read_font_feature_settings "\"éab\" 1";
   neg_cursor read_font_feature_settings "\"kern\" 1.5";
   neg_cursor read_font_feature_settings "invalid-feature"
@@ -2509,6 +2518,13 @@ let test_font_variation_settings () =
   check_font_variation_settings "\"wght\" 123.5";
   check_font_variation_settings ~expected:"\"a\\\"bc\" 123.5"
     "\"a\\22 bc\" 123.5";
+  let structured =
+    Axis_list
+      [ { tag = "a\"bc"; value = 123.5 }; { tag = "wght"; value = 650.25 } ]
+  in
+  check string "structured font variation settings"
+    "\"a\\\"bc\" 123.5,\"wght\" 650.25"
+    (Css.Pp.to_string ~minify:true pp_font_variation_settings structured);
   neg_cursor read_font_variation_settings "invalid-variation"
 
 let test_transform_style () =
@@ -4369,7 +4385,8 @@ let test_css_wide () =
 
 let spec_property_grammar_edges () =
   check_font_feature_settings "\"kern\" on";
-  check_font_feature_settings "\"liga\" off, \"calt\" 1";
+  check_font_feature_settings ~expected:"\"liga\" off,\"calt\" 1"
+    "\"liga\" off, \"calt\" 1";
   check_font_variation_settings ~expected:"\"wght\" 650,\"wdth\" 75"
     "\"wght\" 650, \"wdth\" 75";
   check_timing_function "linear(0, .25 50%, 1)";
@@ -4388,7 +4405,7 @@ let spec_property_grammar_edges () =
   check_clip_path "rect(0px 0px 10px 10px)";
   check_content "counter(page)";
   check_content "counters(section, \".\")";
-  neg_cursor read_font_feature_settings "\"kern\" 2";
+  neg_cursor read_font_feature_settings "\"kern\" -1";
   neg_cursor read_font_variation_settings "\"wg\" 400";
   neg_cursor read_timing_function "linear()";
   neg_cursor read_timing_function "steps(0, jump-end)";


### PR DESCRIPTION
Carry font weights and variation values as numbers, and feature/axis settings as typed tag/value pairs. Validate OpenType tags and serialize them through the CSS string printer so fractional values and escapes survive.