### PR TITLE
animation: validate steps constraints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -201,6 +201,8 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `steps()` rejects fractional counts, and `jump-none` requires at least two
+  steps. Other step positions continue to require a positive integer count.
 - `mask-border` accepts a lone mode keyword, and `border-image` rejects one
   anywhere: only mask-border's grammar carries a `<'mask-border-mode'>` slot
   (#682)

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -832,8 +832,7 @@ module Timing_function = struct
 
   let read_steps t : timing_function =
     Cursor.call "steps" t (fun t ->
-        let n = int_of_float (Cursor.number t) in
-        if n <= 0 then Cursor.err t "steps() requires a positive step count";
+        let n = Cursor.int t in
         let kind =
           Cursor.option
             (fun t ->
@@ -841,6 +840,11 @@ module Timing_function = struct
               read_steps_direction t)
             t
         in
+        (match kind with
+        | Some Jump_none when n < 2 ->
+            Cursor.err t "steps() with jump-none requires at least two steps"
+        | _ when n < 1 -> Cursor.err t "steps() requires a positive step count"
+        | _ -> ());
         Steps (n, kind))
 
   let read_cubic_bezier t : timing_function =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2621,6 +2621,9 @@ let test_timing_function () =
   check_timing_function "steps(4, jump-start)" ~expected:"steps(4,jump-start)";
   check_timing_function "steps( 4 , jump-start )"
     ~expected:"steps(4,jump-start)";
+  check_timing_function "steps(2, jump-none)" ~expected:"steps(2,jump-none)";
+  neg_cursor read_timing_function "steps(1.9)";
+  neg_cursor read_timing_function "steps(1, jump-none)";
   neg_cursor read_timing_function "steps(4, jump-start, red)";
   neg_cursor read_timing_function "steps(4 red)";
   neg_cursor read_timing_function "cubic-bezier(0.1,0.7,1,0.1,0.5)"


### PR DESCRIPTION
Parse step counts as exact integers and apply the CSS Easing 2 lower bound after reading the step position. jump-none requires at least two steps; every other position requires one.