### PR TITLE
parser: require non-empty grammar lists

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- `Cursor.list` requires at least one item by default. Grammars that permit an
+  empty list must now opt into it with `~at_least:0`. Empty CSS grammar lists
+  and non-positive explicit `repeat()` counts are rejected.
 - `font_weight.Weight` carries a number rather than an integer, and font
   feature and variation settings carry structured tag/value lists rather than
   pre-rendered strings. Fractional weights and variation values are preserved,

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -971,7 +971,7 @@ let rec list_collect sep item t acc n max =
   | Done items -> items
   | Continue (acc, n) -> list_collect sep item t acc n max
 
-let list ?sep ?(at_least = 0) ?at_most item t =
+let list ?sep ?(at_least = 1) ?at_most item t =
   let max = Option.value at_most ~default:max_int in
   let items = list_collect sep item t [] 0 max in
   let len = List.length items in

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -521,7 +521,8 @@ val one_of : (t -> 'a) list -> t -> 'a
 val list :
   ?sep:(t -> unit) -> ?at_least:int -> ?at_most:int -> (t -> 'a) -> t -> 'a list
 (** [list ?sep ?at_least ?at_most item t] parses items separated by [sep]
-    (default: no separator). A [sep] only commits once another [item] parses
+    (default: no separator). Lists require at least one item unless [at_least]
+    is specified explicitly. A [sep] only commits once another [item] parses
     after it, so a trailing separator with nothing following it is left
     unconsumed for the caller rather than silently dropped. Enforces cardinality
     bounds. Too few items raise ["expected at least N items (got M)"], the

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -893,7 +893,7 @@ let read_timing_function_list t =
 
 let read_duration_list (read_one : Cursor.t -> Values.duration) t :
     Values.duration =
-  match Cursor.list ~sep:Cursor.comma read_one t with
+  match Cursor.list ~sep:Cursor.comma ~at_least:0 read_one t with
   | [] -> Cursor.err_expected t "time value"
   | [ value ] -> value
   | values -> Durations values

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -789,7 +789,9 @@ module Grid_template = struct
     if Cursor.looking_at t "var(" then Var (Values.read_var read_repeat_count t)
     else
       match Cursor.option Cursor.int t with
-      | Some n -> Count n
+      | Some n ->
+          if n <= 0 then Cursor.err_invalid t "repeat count must be positive";
+          Count n
       | None -> (
           match Cursor.ident t with
           | "auto-fill" -> Auto_fill
@@ -801,7 +803,7 @@ module Grid_template = struct
       (fun inner ->
         Cursor.ws inner;
         let names =
-          Cursor.list
+          Cursor.list ~at_least:0
             ~sep:(fun i -> Cursor.ws i)
             (fun i -> Cursor.ident i)
             inner

--- a/test/test_cursor.ml
+++ b/test/test_cursor.ml
@@ -138,6 +138,16 @@ let test_list_at_least_message () =
       | _ -> Alcotest.fail "expected Bad_value")
   | _ -> Alcotest.fail "expected Parse_error"
 
+let test_list_default_cardinality () =
+  let required = cursor_of_string "" in
+  (match Cursor.list Cursor.ident required with
+  | exception Cursor.Parse_error _ -> ()
+  | _ -> Alcotest.fail "expected the default list to require an item");
+  let optional = cursor_of_string "" in
+  Alcotest.(check (list string))
+    "an empty list is explicit" []
+    (Cursor.list ~at_least:0 Cursor.ident optional)
+
 (* CSS Values 4 sec. 5.7.3: a [#] list's comma never trails the last item. [sep]
    must only commit once another [item] parses after it, or a trailing separator
    is silently dropped and the list looks complete when it is not. *)
@@ -217,6 +227,8 @@ let suite =
         test_triple_rewinds_on_failure;
       Alcotest.test_case "list ~at_least message" `Quick
         test_list_at_least_message;
+      Alcotest.test_case "list default cardinality" `Quick
+        test_list_default_cardinality;
       Alcotest.test_case "list rejects a trailing separator" `Quick
         test_list_trailing_separator;
       Alcotest.test_case "list without a trailing separator" `Quick

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4514,7 +4514,11 @@ let non_empty_list_grammar () =
       "background-blend-mode:normal";
       "width:hypot(3px,4px)";
       "grid-template-columns:repeat(2,1px)";
-    ]
+    ];
+  (* Grid 2 defines a line-name block with a [*] multiplier, so this is the one
+     audited grammar list that deliberately remains empty. *)
+  check_declaration ~expected:"grid-template-columns:[]1px"
+    "grid-template-columns:[] 1px"
 
 (* CSS Values 4 sec. 5.7.3: a [#] multiplier's comma never trails the last item.
    [min()]/[max()] take a comma-separated [<calc-sum>] list (sec. 10.2), and

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4492,6 +4492,30 @@ let function_argument_validity () =
   check_declaration ~expected:"transform:skew(10deg,20deg)"
     "transform:skew( 10deg , 20deg )"
 
+(* CSS list productions are non-empty unless their grammar says otherwise.
+   Backgrounds 3 gives both longhands a comma-separated item list, CSS Values 4
+   gives [hypot()] one or more calculations, and Grid 2 gives [repeat()] a
+   positive explicit count followed by one or more tracks. *)
+let non_empty_list_grammar () =
+  List.iter
+    (neg_cursor read_declaration)
+    [
+      "background-image:";
+      "background-blend-mode:";
+      "width:hypot()";
+      "grid-template-columns:repeat(2,)";
+      "grid-template-columns:repeat(0,1px)";
+      "grid-template-columns:repeat(-2,1px)";
+    ];
+  List.iter
+    (fun css -> check_declaration ~roundtrip:true css)
+    [
+      "background-image:none";
+      "background-blend-mode:normal";
+      "width:hypot(3px,4px)";
+      "grid-template-columns:repeat(2,1px)";
+    ]
+
 (* CSS Values 4 sec. 5.7.3: a [#] multiplier's comma never trails the last item.
    [min()]/[max()] take a comma-separated [<calc-sum>] list (sec. 10.2), and
    [matrix()]/[matrix3d()] (CSS Transforms 1 sec. 12.1, 2 sec. 12.2) a
@@ -5036,6 +5060,7 @@ let declaration_tests =
     test_case "line-width invalid math argument" `Quick
       line_width_invalid_math_argument;
     test_case "function argument validity" `Quick function_argument_validity;
+    test_case "non-empty list grammar" `Quick non_empty_list_grammar;
     test_case "list rejects a trailing separator" `Quick
       list_trailing_separator_invalid;
     test_case "border-radius keyword radii" `Quick border_radius_keyword_radii;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1260,6 +1260,12 @@ let strict_reject name css =
         true
         (List.length warnings > 0)
 
+let non_empty_font_family_descriptors () =
+  strict_reject "empty @font-face font-family"
+    "@font-face { font-family:; src: url(brand.woff2) }";
+  strict_reject "empty @font-palette-values font-family"
+    "@font-palette-values --brand { font-family: }"
+
 let lenient_recover name css expected min_warnings =
   let { Css.stylesheet; warnings } =
     match Css.of_string ~strict:false css with
@@ -2295,6 +2301,9 @@ let stylesheet_tests =
     ( "spec font-face descriptor matrix",
       `Quick,
       spec_font_face_descriptor_matrix );
+    ( "non-empty font-family descriptors",
+      `Quick,
+      non_empty_font_family_descriptors );
     ("spec keyframes selector matrix", `Quick, spec_keyframes_selector_matrix);
     ("spec keyframes shadow colour var", `Quick, spec_keyframes_shadow_color_var);
     ("page", `Quick, page_case);


### PR DESCRIPTION
Make `Cursor.list` require at least one item by default, with explicit opt-in for the empty grid line-name production and the duration reader's tailored diagnostic. Reject empty background, `hypot()`, `repeat()`, and font-family descriptor lists, and non-positive explicit repeat counts.