### PR TITLE
fonts: use descriptor family-name grammars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -207,6 +207,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `@font-face` and `@font-palette-values` use their descriptor-specific
+  `font-family` grammars. The former accepts exactly one named family, the
+  latter accepts a non-empty comma-separated list, and both reject unquoted
+  generic-family and CSS-wide keywords.
 - `steps()` rejects fractional counts, and `jump-none` requires at least two
   steps. Other step positions continue to require a positive integer count.
 - `mask-border` accepts a lone mode keyword, and `border-image` rejects one

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -627,11 +627,11 @@ let simplify_unicode_range_descriptor visible =
     ~as_var:(function Properties.Var v -> Some v | _ -> None)
     ~of_var:(fun v -> (Properties.Var v : Properties.unicode_range))
 
-(* CSS Fonts 4 sec. 2.1 makes [font-family] a [<family-name>#] list, so a
-   [var()] stands for a whole stack as readily as for one entry and the type
-   nests through [List]. That is the model the property already uses
-   ({!Context.simplify_font_family}), so read the descriptor the same way rather
-   than a second one. *)
+(* Read a referenced custom value with the property parser so a property-style
+   stack remains visible as [List]. [substitute_font_face] validates the result
+   against the descriptor's single-name grammar below. Using the narrower reader
+   here would conflate an invalid referenced value with a missing custom
+   property and retain the unresolved [var()] instead. *)
 let simplify_font_family_descriptor visible =
   simplify_nested_var visible ~read:Properties.read_font_family
     ~as_var:(function Properties.Var v -> Some v | _ -> None)
@@ -752,7 +752,15 @@ let universal_eval ~scopes ~at_path =
 
 let substitute_font_face ~scopes ~at_path descriptors =
   let visible = universal_visible_customs ~scopes ~at_path in
-  List.map (simplify_font_face_descriptor visible) descriptors
+  List.filter_map
+    (fun descriptor ->
+      match simplify_font_face_descriptor visible descriptor with
+      | Font_family [ family ] as descriptor
+        when Properties.is_font_family_name_value family ->
+          Some descriptor
+      | Font_family _ -> None
+      | descriptor -> Some descriptor)
+    descriptors
 
 let substitute_page_with_margins ~scopes ~at_path sel descriptors margins =
   let visible = universal_visible_customs ~scopes ~at_path in

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -640,14 +640,19 @@ let unquote_font_family_strings components =
    words include a reserved word, since dropping the quotes there turns the word
    into the keyword. The unquoted multi-word form is shorter but is not the
    CSSOM-canonical serialization, so [enforce_spec] keeps the quotes. *)
-let pp_family_name ctx s =
+let pp_family_name_with_keywords is_keyword ctx s =
   if
     Pp.minified ctx && (not ctx.Pp.enforce_spec)
     && can_unquote_font_family_name s
   then Pp.string ctx s
-  else if is_font_family_keyword_name s || not (is_font_family_ident_word s)
-  then Pp.quoted_string ctx s
+  else if is_keyword s || not (is_font_family_ident_word s) then
+    Pp.quoted_string ctx s
   else Pp.string ctx s
+
+let pp_family_name = pp_family_name_with_keywords is_font_family_keyword_name
+
+let pp_descriptor_family_name =
+  pp_family_name_with_keywords is_font_family_reserved_word
 
 let is_generic_family : font_family -> bool = function
   | Sans_serif | Serif | Monospace | Cursive | Fantasy | System_ui
@@ -765,6 +770,12 @@ let rec pp_font_family : font_family Pp.t =
         else Parser.string_of_components tokens
       in
       Pp.string ctx rendered
+
+let rec pp_font_family_name : font_family Pp.t =
+ fun ctx -> function
+  | Name name -> pp_descriptor_family_name ctx name
+  | Var var -> pp_var pp_font_family_name ctx var
+  | family -> pp_font_family ctx family
 
 let normalize_font_style : font_style -> font_style =
   let na = Values.normalize_angle in
@@ -1391,6 +1402,53 @@ let font_family_css_keywords : (string * font_family) list =
    authored. *)
 let font_family_keywords : (string * font_family) list =
   font_family_generic_css @ font_family_css_keywords
+
+(* CSS Fonts 4 sec. 2.1.1: descriptors whose grammar is [<font-family-name>]
+   accept strings and non-empty custom-ident sequences, but not the
+   generic-family or CSS-wide keywords accepted by the [font-family] property.
+   Quoting keeps a keyword available as a family name. *)
+let rec read_font_family_name t : font_family =
+  let read_var t : font_family = Var (read_var read_font_family_name t) in
+  Cursor.ws t;
+  match Cursor.string_opt t with
+  | Some name -> Name name
+  | None when Cursor.looking_at_func "var" t -> read_var t
+  | None ->
+      let rec read_words acc : font_family =
+        match Cursor.peek_ident t with
+        | Some _ ->
+            let word = Cursor.ident ~keep_case:true t in
+            if is_font_family_reserved_word word then
+              Cursor.err_invalid t
+                "reserved word in an unquoted font-family name";
+            Cursor.ws t;
+            read_words (word :: acc)
+        | None -> (
+            match acc with
+            | [] -> Cursor.err_expected t "font-family name"
+            | _ -> Name (String.concat " " (List.rev acc)))
+      in
+      read_words []
+
+let is_font_family_name_value : font_family -> bool = function
+  | Sans_serif | Serif | Monospace | Cursive | Fantasy | System_ui
+  | Ui_sans_serif | Ui_serif | Ui_monospace | Ui_rounded | Math | Inherit
+  | Initial | Unset | Revert | Revert_layer | List _ | Invalid _ ->
+      false
+  | Emoji | Fangsong | Inter | Roboto | Open_sans | Lato | Montserrat | Poppins
+  | Source_sans_pro | Raleway | Oswald | Noto_sans | Ubuntu | Playfair_display
+  | Merriweather | Lora | PT_sans | PT_serif | Nunito | Nunito_sans | Work_sans
+  | Rubik | Fira_sans | Fira_code | JetBrains_mono | IBM_plex_sans
+  | IBM_plex_serif | IBM_plex_mono | Source_code_pro | Space_mono | DM_sans
+  | DM_serif_display | Bebas_neue | Barlow | Mulish | Josefin_sans | Helvetica
+  | Helvetica_neue | Arial | Verdana | Tahoma | Trebuchet_ms | Times_new_roman
+  | Times | Georgia | Cambria | Garamond | Courier_new | Courier
+  | Lucida_console | SF_pro | SF_pro_display | SF_pro_text | SF_mono | NY
+  | Segoe_ui | Segoe_ui_emoji | Segoe_ui_symbol | Apple_color_emoji
+  | Noto_color_emoji | Android_emoji | Twemoji_mozilla | Menlo | Monaco
+  | Consolas | Liberation_mono | SFMono_regular | Cascadia_code | Cascadia_mono
+  | Victor_mono | Inconsolata | Hack | Name _ | Var _ ->
+      true
 
 let rec read_font_family_single t : font_family =
   let read_var t : font_family = Var (read_var read_font_family t) in

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1214,8 +1214,20 @@ val read_outline : Cursor.t -> outline
 val pp_font_family : font_family Pp.t
 (** [pp_font_family] is the pretty-printer for [font_family]. *)
 
+val pp_font_family_name : font_family Pp.t
+(** [pp_font_family_name] is the pretty-printer for a descriptor
+    [<font-family-name>]. *)
+
 val read_font_family : Cursor.t -> font_family
 (** [read_font_family t] is the [font_family] parsed from [t]. *)
+
+val read_font_family_name : Cursor.t -> font_family
+(** [read_font_family_name t] is the descriptor [<font-family-name>] parsed from
+    [t]. Unquoted generic-family and CSS-wide keywords are rejected. *)
+
+val is_font_family_name_value : font_family -> bool
+(** [is_font_family_name_value family] is true when [family] can fill a
+    descriptor [<font-family-name>] slot. *)
 
 val pp_font : font Pp.t
 (** [pp_font] is the pretty-printer for the [font] shorthand. *)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1302,7 +1302,7 @@ let pp_font_face_descriptor : font_face_descriptor Pp.t =
   | Font_family families ->
       pp_descriptor "font-family"
         (fun ctx fams ->
-          Pp.list ~sep:Pp.comma Properties.pp_font_family ctx fams)
+          Pp.list ~sep:Pp.comma Properties.pp_font_family_name ctx fams)
         families
   | Src value -> pp_descriptor "src" Properties.pp_font_src value
   | Font_style style ->
@@ -1409,7 +1409,7 @@ let pp_font_palette_descriptor : font_palette_descriptor Pp.t =
   | Palette_font_family families ->
       Pp.string ctx "font-family:";
       Pp.space_if_pretty ctx ();
-      Pp.list ~sep:Pp.comma Properties.pp_font_family ctx families
+      Pp.list ~sep:Pp.comma Properties.pp_font_family_name ctx families
   | Base_palette base ->
       Pp.string ctx "base-palette:";
       Pp.space_if_pretty ctx ();
@@ -2338,7 +2338,12 @@ let validate_nonempty_descriptor r name value =
 
 let read_font_family_descriptor r =
   read_descriptor_value
-    (fun r -> Cursor.list ~sep:Cursor.comma Properties.read_font_family r)
+    (fun r ->
+      let family = Properties.read_font_family_name r in
+      Cursor.ws r;
+      if not (Cursor.is_done r || Cursor.peek_semicolon r) then
+        Cursor.err_invalid r "trailing tokens after @font-face font-family";
+      [ family ])
     (fun v -> Font_family v)
     r
 
@@ -3008,7 +3013,7 @@ let read_font_palette_descriptor outer inner : font_palette_descriptor =
     match desc_name with
     | "font-family" ->
         Palette_font_family
-          (Cursor.list ~sep:Cursor.comma Properties.read_font_family inner)
+          (Cursor.list ~sep:Cursor.comma Properties.read_font_family_name inner)
     | "base-palette" -> Base_palette (read_base_palette_value inner)
     | "override-colors" ->
         Override_colors

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -149,13 +149,12 @@ let test_inline_font_face_var_resolves () =
       ("size-adjust", "100%");
     ]
 
-(* CSS Fonts 4 sec. 2.1 makes the [font-family] descriptor a [<family-name>#]
-   list, so a [var()] stands for a whole stack as readily as for one entry, and
-   a reference nested in the list has to be followed too. The property already
-   reads both shapes into the same type; the descriptor answers the same way. A
-   reference back onto its own name resolves once and then stands, as CSS
-   Variables 1 sec. 3 leaves an unresolvable reference in place. *)
-let test_inline_font_face_family_list () =
+(* CSS Fonts 4 sec. 4.2 makes the [font-family] descriptor exactly one
+   [<font-family-name>]. A build-time [var()] may stand for that name, but a
+   property-style family stack does not become valid when it arrives through a
+   reference. Raw and referenced list entries are rejected at the same
+   descriptor boundary. *)
+let test_inline_font_face_family_name () =
   let check (name, css, expected) =
     let inlined = minified (Css.inline_vars (parse css)) in
     Alcotest.(check string) name expected inlined
@@ -164,13 +163,13 @@ let test_inline_font_face_family_list () =
     [
       ( "a var() standing for the whole stack",
         ":root{--f:Arial,sans-serif}@font-face{font-family:var(--f);src:local(a)}",
-        "@font-face{font-family:Arial,sans-serif;src:local(a)}" );
+        "" );
       ( "a var() standing for one entry",
         ":root{--f:sans-serif}@font-face{font-family:Arial,var(--f);src:local(a)}",
-        "@font-face{font-family:Arial,sans-serif;src:local(a)}" );
+        "" );
       ( "a var() naming itself inside a stack",
         ":root{--f:Arial,var(--f)}@font-face{font-family:b,var(--f);src:local(a)}",
-        "@font-face{font-family:b,Arial,var(--f);src:local(a)}" );
+        "" );
     ]
 
 (* CSS Fonts 4 sec. 4.4 takes the font-width descriptor as
@@ -981,6 +980,6 @@ let suite =
       Alcotest.test_case
         "inline vars resolve the @font-face descriptors the parser keeps" `Quick
         test_inline_font_face_var_descriptors;
-      Alcotest.test_case "inline vars resolve a @font-face family list" `Quick
-        test_inline_font_face_family_list;
+      Alcotest.test_case "inline vars reject @font-face family lists" `Quick
+        test_inline_font_face_family_name;
     ] )

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -719,7 +719,7 @@ let spec_fontface_descriptors () =
      url(\"sparse.woff2\"); ; }";
   check_stylesheet
     ~expected:
-      "@font-face{font-family:emoji;src:url(emoji.woff2);unicode-range:U+1F600-1F64F,U+???}"
+      "@font-face{font-family:Emoji;src:url(emoji.woff2);unicode-range:U+1F600-1F64F,U+???}"
     "@font-face { font-family: Emoji; src: url(emoji.woff2); unicode-range: \
      U+1F600-1F64F, U+???; }";
   check_stylesheet ~expected:"" "@font-face { src: url(font.woff2); }";
@@ -1260,11 +1260,35 @@ let strict_reject name css =
         true
         (List.length warnings > 0)
 
-let non_empty_font_family_descriptors () =
+let font_family_descriptor_grammar () =
+  strict_accept "single named @font-face family"
+    "@font-face { font-family: Brand; src: url(brand.woff2) }";
+  strict_accept "quoted generic word as @font-face family name"
+    "@font-face { font-family: \"serif\"; src: url(serif.woff2) }";
+  strict_accept "named @font-palette-values family list"
+    "@font-palette-values --brand { font-family: Brand, \"Color Font\" }";
+  strict_accept "quoted generic word as palette family name"
+    "@font-palette-values --serif { font-family: \"serif\" }";
   strict_reject "empty @font-face font-family"
     "@font-face { font-family:; src: url(brand.woff2) }";
+  strict_reject "multiple @font-face families"
+    "@font-face { font-family: Brand, Other; src: url(brand.woff2) }";
+  strict_reject "generic @font-face family"
+    "@font-face { font-family: serif; src: url(serif.woff2) }";
+  strict_reject "generic word in an unquoted @font-face family"
+    "@font-face { font-family: Brand serif; src: url(brand.woff2) }";
+  strict_reject "CSS-wide @font-face family"
+    "@font-face { font-family: inherit; src: url(brand.woff2) }";
   strict_reject "empty @font-palette-values font-family"
-    "@font-palette-values --brand { font-family: }"
+    "@font-palette-values --brand { font-family: }";
+  strict_reject "generic @font-palette-values family"
+    "@font-palette-values --serif { font-family: serif }";
+  strict_reject "generic in an @font-palette-values family list"
+    "@font-palette-values --brand { font-family: Brand, serif }";
+  strict_reject "generic word in an unquoted palette family"
+    "@font-palette-values --brand { font-family: Brand serif }";
+  strict_reject "CSS-wide @font-palette-values family"
+    "@font-palette-values --brand { font-family: inherit }"
 
 let lenient_recover name css expected min_warnings =
   let { Css.stylesheet; warnings } =
@@ -2301,9 +2325,7 @@ let stylesheet_tests =
     ( "spec font-face descriptor matrix",
       `Quick,
       spec_font_face_descriptor_matrix );
-    ( "non-empty font-family descriptors",
-      `Quick,
-      non_empty_font_family_descriptors );
+    ("font-family descriptor grammar", `Quick, font_family_descriptor_grammar);
     ("spec keyframes selector matrix", `Quick, spec_keyframes_selector_matrix);
     ("spec keyframes shadow colour var", `Quick, spec_keyframes_shadow_color_var);
     ("page", `Quick, page_case);


### PR DESCRIPTION
Parse and print @font-face and @font-palette-values font-family descriptors with their CSS Fonts family-name grammars. @font-face now accepts one named family, palette values accept a non-empty named-family list, and property-style stacks, generic families, and CSS-wide keywords are rejected even after build-time variable substitution.