### PR TITLE
docs: state the generic-family gate on the equivalence key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1051,6 +1051,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- The `Css.declaration_value_for_equivalence` docstring names the generic
+  family that gates its unquoting: without one in the stream,
+  `--font: "Noto Color Emoji"` and `--font: Noto Color Emoji` are distinct diff
+  keys (#696)
 - Load-bearing minification, parsing, and serialization comments name the CSS
   spec sections that define their initial values, equivalences, grammars, and
   defaults (#677)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1528,9 +1528,14 @@ val declaration_value : ?minify:bool -> ?inline:bool -> declaration -> string
 val declaration_value_for_equivalence : declaration -> string
 (** [declaration_value_for_equivalence decl] is the value of [decl] with a
     quoted multi-word [<string>] in a custom-property token stream rewritten as
-    the equivalent unquoted [<ident>] sequence. Used as a structural-diff key so
-    [--font: "Noto Color Emoji"] and [--font: Noto Color Emoji] compare equal;
-    not for emission, where both forms stay verbatim. *)
+    the equivalent unquoted [<ident>] sequence. The rewrite applies when a
+    generic family in the stream proves the stream is a font-family list, where
+    CSS Fonts 4 sec. 2.1.1 spells the one name both ways: as a structural-diff
+    key, [--font: ui-sans-serif,"Noto Color Emoji"] and
+    [--font: ui-sans-serif,Noto Color Emoji] compare equal. Without that proof
+    the stream is arbitrary tokens, in which one [<string>] is not an [<ident>]
+    sequence, and the two spellings keep distinct keys. Not for emission, where
+    both forms stay verbatim. *)
 
 (** {1 Property Categories}
 

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -119,9 +119,10 @@ val map_custom_value : (string -> string) -> declaration -> declaration
 
 val unquote_custom_font_strings : declaration -> declaration
 (** [unquote_custom_font_strings d] rewrites a quoted multi-word [<string>] in a
-    custom-property token stream as the equivalent unquoted [<ident>] sequence.
-    Equivalence-only normalisation for structural diffing; other declarations
-    pass through unchanged. *)
+    custom-property token stream as the equivalent unquoted [<ident>] sequence,
+    when a generic family in the stream proves the stream is a font-family list.
+    Equivalence-only normalisation for structural diffing; a stream without that
+    proof, and any other declaration, passes through unchanged. *)
 
 val read_property_name : Cursor.t -> string
 (** [read_property_name t] is the property name read from [t]. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3012,6 +3012,42 @@ let spec_custom_tokens () =
   neg_cursor read_declaration "-x: value";
   neg_cursor read_declaration "--x"
 
+(* The structural-diff key unquotes a multi-word family name in a custom
+   property only when a generic family in the stream proves the stream is a
+   font-family list, where CSS Fonts 4 sec. 2.1.1 spells the one name both ways.
+   A custom property is otherwise an arbitrary token stream, and dropping the
+   quotes turns one [<string>] into two [<ident>]s, which is a different value
+   wherever the property substitutes into another grammar. *)
+let custom_font_equivalence_key () =
+  let key css =
+    Css.declaration_value_for_equivalence (Css.Declaration.of_string css)
+  in
+  List.iter
+    (fun (css, expected) -> Alcotest.(check string) css expected (key css))
+    [
+      (* [sans-serif] is only valid in a font-family list, so both spellings of
+         the multi-word name reach the unquoted one. *)
+      ({|--f: a,"Segoe UI",sans-serif|}, "a,Segoe UI,sans-serif");
+      ({|--f: a,Segoe UI,sans-serif|}, "a,Segoe UI,sans-serif");
+      (* No generic family, no proof: the quotes are part of the value. *)
+      ({|--f: a,"Segoe UI",b|}, {|a,"Segoe UI",b|});
+      ({|--f: a,Segoe UI,b|}, "a,Segoe UI,b");
+      (* The rewrite spans a [<string>] holding an [<ident>] sequence, so a
+         single-word name keeps whichever spelling it was written with. *)
+      ({|--f: "Arial",sans-serif|}, {|"Arial",sans-serif|});
+      ({|--f: Arial,sans-serif|}, "Arial,sans-serif");
+    ];
+  let equal a b = String.equal (key a) (key b) in
+  Alcotest.(check bool)
+    "a generic family equates the two spellings" true
+    (equal {|--f: a,"Segoe UI",sans-serif|} {|--f: a,Segoe UI,sans-serif|});
+  Alcotest.(check bool)
+    "without one they stay distinct" false
+    (equal {|--f: a,"Segoe UI",b|} {|--f: a,Segoe UI,b|});
+  Alcotest.(check bool)
+    "a single-word name stays distinct" false
+    (equal {|--f: "Arial",sans-serif|} {|--f: Arial,sans-serif|})
+
 let color_functions () =
   (* color() with alternate spaces and alpha *)
   check_declaration ~expected:"color:color(display-p3 1 0 0/.5)"
@@ -4977,6 +5013,8 @@ let declaration_tests =
       parse_declaration_name_case;
     test_case "spec custom property token stream values" `Quick
       spec_custom_tokens;
+    test_case "a generic family gates the equivalence key" `Quick
+      custom_font_equivalence_key;
     test_case "vendor prefixes" `Quick vendor_prefixes;
     test_case "vendor-prefixed shorthand readers" `Quick
       vendor_prefixed_shorthands;


### PR DESCRIPTION
The `Css.declaration_value_for_equivalence` docstring said that both spellings of a multi-word family name in a custom property compare equal. The rewrite fires only when a generic family in the stream proves the stream is a font-family list, and the docstrings now say so.
