### PR TITLE
parser: keep the whitespace calc requires around + and -

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -571,6 +571,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` keeps the whitespace CSS Values 4 requires on both sides of a math
+  function's `+` and `-` when it prints a custom property or an unknown
+  property. `--w: calc(100% - 10px)` came out as `--w:calc(100%- 10px)`, which
+  browsers discard, taking every `var(--w)` that read it with them (#697)
 - `Css.to_string ~minify:true` keeps choosing the shorter exact spelling for
   constructed millisecond durations and degree hues without running the AST
   optimisation phase (#678)

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -557,19 +557,49 @@ let pair_needs_token_boundary prev next =
       true
   | _ -> false
 
-let rec cv_to_buffer_min buf = function
+(* CSS Values 4 (ED) sec. 10.8 "Syntax" requires whitespace on both sides of the
+   [+] and [-] operators of a math function, and allows [*] and [/] without any.
+   Sec. 10 names the whole set: [calc()], the comparison functions, the
+   stepped-value, trigonometric, exponential and sign-related families. One
+   table serves every caller - a second copy drifts, and the passes over a
+   custom-property stream then disagree about the same token. *)
+let is_math_function name =
+  match String.lowercase_ascii name with
+  | "calc" | "min" | "max" | "clamp" | "round" | "mod" | "rem" | "sin" | "cos"
+  | "tan" | "asin" | "acos" | "atan" | "atan2" | "pow" | "sqrt" | "hypot"
+  | "log" | "exp" | "abs" | "sign" ->
+      true
+  | _ -> false
+
+let is_plus_or_minus_delim = function
+  | Component.Preserved { kind = Token.Delim ("+" | "-"); _ } -> true
+  | _ -> false
+
+(* Dropping a required separator gives a stream the browser rejects, so a
+   minified serialiser keeps it even though neither neighbour is word-like.
+   [in_math] enters at a math function's arguments and carries through a
+   grouping paren, itself a math operand; a nested function has its own
+   grammar. *)
+let math_sign_boundary ~in_math prev next =
+  in_math && (is_plus_or_minus_delim prev || is_plus_or_minus_delim next)
+
+let block_in_math ~in_math : Token.bracket -> bool = function
+  | Token.Paren -> in_math
+  | Token.Square | Token.Curly -> false
+
+let rec cv_to_buffer_min ~in_math buf = function
   | Preserved t -> add_token_kind buf t.kind
   | Block { node = { opening; value; _ }; _ } ->
       Buffer.add_char buf (opening_char opening);
-      cvs_to_buffer_min buf value;
+      cvs_to_buffer_min ~in_math:(block_in_math ~in_math opening) buf value;
       Buffer.add_char buf (closing_char opening)
   | Func { node = { name; arguments; _ }; _ } ->
       Buffer.add_string buf (escape_ident name);
       Buffer.add_char buf '(';
-      cvs_to_buffer_min buf arguments;
+      cvs_to_buffer_min ~in_math:(is_math_function name) buf arguments;
       Buffer.add_char buf ')'
 
-and cvs_to_buffer_min buf cvs =
+and cvs_to_buffer_min ~in_math buf cvs =
   let rec drop_ws = function
     | cv :: rest when is_whitespace cv -> drop_ws rest
     | other -> other
@@ -579,6 +609,7 @@ and cvs_to_buffer_min buf cvs =
     | None -> false
     | Some p ->
         pair_forms_multichar_token p next
+        || math_sign_boundary ~in_math p next
         || (not (signed_number_pair p next))
            && word_like_end p
            && (not (is_backslash_delim p))
@@ -605,7 +636,7 @@ and cvs_to_buffer_min buf cvs =
         | Some p when (not separated) && pair_needs_token_boundary p cv ->
             Buffer.add_char buf ' '
         | _ -> ());
-        cv_to_buffer_min buf cv;
+        cv_to_buffer_min ~in_math buf cv;
         loop (Some cv) false rest
   in
   loop None false cvs
@@ -614,7 +645,7 @@ let to_string_minified cvs =
   if cvs <> [] && List.for_all is_whitespace cvs then " "
   else
     let buf = Buffer.create 64 in
-    cvs_to_buffer_min buf cvs;
+    cvs_to_buffer_min ~in_math:false buf cvs;
     Buffer.contents buf
 
 let to_string_custom cvs =
@@ -688,20 +719,22 @@ let custom_min_word_boundary p next =
 
 (* Whitespace in a custom-property value is part of the stream a var()
    substitution receives, so a separator around [*] and [/] is collapsed to one
-   space, never deleted: [16 / 9] and [16/9] are distinct streams. *)
-let custom_min_needs_separator prev next rest =
+   space, never deleted: [16 / 9] and [16/9] are distinct streams. Around a
+   math-function [+] or [-] the space is required outright. *)
+let custom_min_needs_separator ~in_math prev next rest =
   match prev with
   | None -> false
   | Some p ->
       pair_forms_multichar_token p next
       || custom_min_is_math_delim p
       || custom_min_is_math_delim next
+      || math_sign_boundary ~in_math p next
       || custom_min_bang_boundary prev next rest
       || custom_min_word_boundary p next
 
-let custom_min_ws_separator buf prev separated rest =
+let custom_min_ws_separator ~in_math buf prev separated rest =
   match rest with
-  | next :: _ when custom_min_needs_separator prev next rest ->
+  | next :: _ when custom_min_needs_separator ~in_math prev next rest ->
       Buffer.add_char buf ' ';
       true
   | _ -> separated
@@ -741,11 +774,14 @@ let add_custom_value_token ~fold_ident buf : Token.kind -> unit = function
   | Token.Ident s -> Buffer.add_string buf (escape_ident (fold_ident s))
   | other -> add_token_kind buf other
 
-let rec cv_to_buffer_custom_min ~fold_ident buf : Component.t -> unit = function
+let rec cv_to_buffer_custom_min ~fold_ident ~in_math buf : Component.t -> unit =
+  function
   | Preserved t -> add_custom_value_token ~fold_ident buf t.kind
   | Block { node = { opening; value; _ }; _ } ->
       Buffer.add_char buf (opening_char opening);
-      cvs_to_buffer_min_custom ~fold_ident buf value;
+      cvs_to_buffer_min_custom ~fold_ident
+        ~in_math:(block_in_math ~in_math opening)
+        buf value;
       Buffer.add_char buf (closing_char opening)
   | Func { node = { name; arguments; _ }; _ }
     when String.lowercase_ascii name = "url" -> (
@@ -757,27 +793,30 @@ let rec cv_to_buffer_custom_min ~fold_ident buf : Component.t -> unit = function
       | None ->
           Buffer.add_string buf (escape_ident name);
           Buffer.add_char buf '(';
-          cvs_to_buffer_min_custom ~fold_ident buf arguments;
+          cvs_to_buffer_min_custom ~fold_ident ~in_math:false buf arguments;
           Buffer.add_char buf ')')
   | Func { node = { name; arguments; _ }; _ } ->
       Buffer.add_string buf (escape_ident name);
       Buffer.add_char buf '(';
-      cvs_to_buffer_min_custom ~fold_ident buf arguments;
+      cvs_to_buffer_min_custom ~fold_ident ~in_math:(is_math_function name) buf
+        arguments;
       Buffer.add_char buf ')'
 
 (* Drops optional whitespace between sibling tokens (like [cvs_to_buffer_min])
    but routes children through [cv_to_buffer_custom_min] so nested function and
    block contents use the custom-property minifier recursively. *)
-and cvs_to_buffer_min_custom ~fold_ident buf cvs =
+and cvs_to_buffer_min_custom ~fold_ident ~in_math buf cvs =
   let rec loop prev separated = function
     | [] -> ()
     | cv :: rest when is_whitespace cv ->
         let rest' = drop_whitespace_components rest in
-        let separated' = custom_min_ws_separator buf prev separated rest' in
+        let separated' =
+          custom_min_ws_separator ~in_math buf prev separated rest'
+        in
         loop prev separated' rest'
     | cv :: rest ->
         custom_min_item_separator buf prev separated cv;
-        cv_to_buffer_custom_min ~fold_ident buf cv;
+        cv_to_buffer_custom_min ~fold_ident ~in_math buf cv;
         loop (Some cv) false rest
   in
   loop None false cvs
@@ -786,7 +825,7 @@ let to_string_custom_minified ?(fold_ident = fold_value_ident) cvs =
   if cvs <> [] && List.for_all is_whitespace cvs then " "
   else
     let buf = Buffer.create 64 in
-    cvs_to_buffer_min_custom ~fold_ident buf cvs;
+    cvs_to_buffer_min_custom ~fold_ident ~in_math:false buf cvs;
     Buffer.contents buf
 
 (** {1 Rule / declaration consumers (section 5.3)} *)

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -42,7 +42,24 @@ val to_string_minified : Component.t list -> string
 (** Like {!string_of_components} but drops whitespace that sits between two
     components where at least one side is not word-like (ident / number / etc.).
     Two word-like components still get a separating space so they don't merge
-    into a single token. *)
+    into a single token, and so does either side of a [+] or [-] operator inside
+    a math function, where CSS Values 4 (ED) section 10.8 requires one. *)
+
+val is_math_function : string -> bool
+(** [is_math_function name] is true for a CSS Values 4 (ED) section 10 math
+    function: [calc()], the comparison functions ([min()], [max()], [clamp()]),
+    the stepped-value ([round()], [mod()], [rem()]), trigonometric ([sin()]
+    through [atan2()]), exponential ([pow()], [sqrt()], [hypot()], [log()],
+    [exp()]) and sign-related ([abs()], [sign()]) families. [name] is matched
+    case insensitively, as CSS function names are. One table serves every
+    caller: a second copy drifts, and the passes over a custom-property stream
+    then disagree about the same token. *)
+
+val is_plus_or_minus_delim : Component.t -> bool
+(** [is_plus_or_minus_delim cv] is true for a [+] or [-] delim token. Inside a
+    math function that token is the operator whose whitespace CSS Values 4 (ED)
+    section 10.8 requires; a sign written as part of a number ([+2]) lexes as
+    one numeric token and is not one of these. *)
 
 val to_string_custom : Component.t list -> string
 (** Variant of {!string_of_components} for CSS Custom Properties Level 1 token

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2999,17 +2999,7 @@ let fold_custom_color ~lossless (c : Component.t) ~fallback =
       | Typed _ -> [ c ])
   | _ -> fallback ()
 
-(* CSS Values 4 sec. 10 names the whole set: [calc()], the comparison functions,
-   the stepped-value, trigonometric, exponential and sign-related families. One
-   table serves every caller - a second copy drifts, and the two passes over a
-   custom-property stream then disagree about the same token. *)
-let is_math_function name =
-  match String.lowercase_ascii name with
-  | "calc" | "min" | "max" | "clamp" | "round" | "mod" | "rem" | "sin" | "cos"
-  | "tan" | "asin" | "acos" | "atan" | "atan2" | "pow" | "sqrt" | "hypot"
-  | "log" | "exp" | "abs" | "sign" ->
-      true
-  | _ -> false
+let is_math_function = Parser.is_math_function
 
 (* A math function is unconditionally a math expression whose type is fixed by
    its operands' units, so when it reduces to a single constant it has that
@@ -3802,33 +3792,30 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
       value ) ->
       value
 
-(* CSS Values L4 sec. 10.10 ("Mathematical Expressions"): inside a math function
-   ([calc], [min], [max], [clamp], [round], [mod], [rem], the trig family,
-   [pow]/[sqrt]/[hypot]/[log]/[exp], [abs]/[sign]) whitespace is *required*
-   around binary [+] and [-] (sign-token disambiguation - stripping it changes
-   [100% - var(--a)] to [100%-var(--a)], where [-var] is one ident-like function
-   token) but *optional* around [*], [/], [(], [)], [,]. Strip the optional
-   whitespace from math-function arguments so two custom-property token streams
-   that differ only there have the same canonical AST. Typed math is already
-   minified by [pp_calc]; this matters for opaque [Tokens _] custom-property
-   values where cascade preserves the author's whitespace verbatim by design.
-   Nested non-math functions ([var()] etc.) get a recursive component walk but
-   no whitespace stripping; nested math functions get their own. *)
-let is_plus_or_minus_delim = function
-  | Component.Preserved { kind = Token.Delim "+"; _ }
-  | Component.Preserved { kind = Token.Delim "-"; _ } ->
-      true
-  | _ -> false
-
+(* CSS Values 4 (ED) sec. 10.8 ("Syntax"): inside a math function whitespace is
+   *required* around binary [+] and [-] (sign-token disambiguation - stripping
+   it changes [100% - var(--a)] to [100%-var(--a)], where [-var] is one
+   ident-like function token) but *optional* around [*], [/], [(], [)], [,].
+   Strip the optional whitespace from math-function arguments so two
+   custom-property token streams that differ only there have the same canonical
+   AST. Typed math is already minified by [pp_calc]; this matters for opaque
+   [Tokens _] custom-property values where cascade preserves the author's
+   whitespace verbatim by design. Nested non-math functions ([var()] etc.) get a
+   recursive component walk but no whitespace stripping; nested math functions
+   get their own. *)
 let strip_math_whitespace comps =
   let rec aux acc = function
     | [] -> List.rev acc
     | (Component.Preserved { kind = Token.Whitespace; _ } as ws) :: rest ->
         let prev_pm =
-          match acc with [] -> false | p :: _ -> is_plus_or_minus_delim p
+          match acc with
+          | [] -> false
+          | p :: _ -> Parser.is_plus_or_minus_delim p
         in
         let next_pm =
-          match rest with [] -> false | n :: _ -> is_plus_or_minus_delim n
+          match rest with
+          | [] -> false
+          | n :: _ -> Parser.is_plus_or_minus_delim n
         in
         if prev_pm || next_pm then aux (ws :: acc) rest else aux acc rest
     | other :: rest -> aux (other :: acc) rest
@@ -3871,8 +3858,11 @@ let is_substitution_func_name name =
 (* Whitespace immediately after a function or block that closes with a hard
    token boundary is insignificant: [drop-shadow(a) drop-shadow(b)] and
    [calc(45deg*-1) in oklab] re-tokenise identically without it, wherever the
-   stream is substituted. Whitespace after a substitution function stays. *)
-let strip_after_close_paren comps =
+   stream is substituted. Whitespace after a substitution function stays, and so
+   does the whitespace before a math operator, which sec. 10.8 requires however
+   hard the boundary on its left: [calc(min(1px,2px) - 3px)] keeps both spaces
+   or the browser drops the declaration. *)
+let strip_after_close_paren ~in_math comps =
   let closes_hard = function
     | Component.Func wrapped ->
         not (is_substitution_func_name wrapped.Component.node.name)
@@ -3885,7 +3875,12 @@ let strip_after_close_paren comps =
         let prev_hard =
           match acc with [] -> false | p :: _ -> closes_hard p
         in
-        if prev_hard then aux acc rest else aux (ws :: acc) rest
+        let next_pm =
+          match rest with
+          | [] -> false
+          | n :: _ -> in_math && Parser.is_plus_or_minus_delim n
+        in
+        if prev_hard && not next_pm then aux acc rest else aux (ws :: acc) rest
     | other :: rest -> aux (other :: acc) rest
   in
   aux [] comps
@@ -3922,7 +3917,7 @@ let rec canonicalize_math_whitespace_components ?(in_math = false) comps =
     if in_math then strip_math_whitespace comps'
     else strip_mul_div_whitespace comps'
   in
-  strip_after_close_paren comps'
+  strip_after_close_paren ~in_math comps'
 
 let normalize_property_value : type a.
     ?lossless:bool ->

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2190,6 +2190,44 @@ let custom_properties () =
   neg_cursor read_declaration "color:var(--x 10px)";
   check_declaration ~expected:"color:var(--x)" "color: var( --x )"
 
+(* CSS Values 4 (ED) sec. 10.8 "Syntax": inside a math function whitespace is
+   required on both sides of the [+] and [-] operators, while [*] and [/] may be
+   written without any. A custom property and an unknown property both carry an
+   opaque token stream that is minified token by token, so deleting that
+   whitespace hands the browser a declaration it drops on the floor. *)
+let math_sign_whitespace () =
+  check_declaration ~expected:"--t:calc(100% - 10px)"
+    ~optimized:"--t:calc(100% - 10px)" "--t: calc(100% - 10px)";
+  check_declaration ~expected:"--t:calc(100% + 10px)"
+    ~optimized:"--t:calc(100% + 10px)" "--t: calc(100% + 10px)";
+  check_declaration ~expected:"--t:calc((100%) - 10px)"
+    ~optimized:"--t:calc((100%) - 10px)" "--t: calc((100%) - 10px)";
+  check_declaration ~expected:"--t:calc(min(1px,2px) - 3px)"
+    ~optimized:"--t:calc(min(1px,2px) - 3px)" "--t: calc(min(1px,2px) - 3px)";
+  check_declaration ~expected:"--t:calc(50% + var(--a))"
+    ~optimized:"--t:calc(50% + var(--a))" "--t: calc(50% + var(--a))";
+  (* An unknown property holds the same opaque stream. *)
+  check_declaration ~expected:"-x-y:calc(100% - 10px)"
+    ~optimized:"-x-y:calc(100% - 10px)" "-x-y: calc(100% - 10px)";
+  check_declaration ~expected:"-x-y:calc(min(1px,2px) - 3px)"
+    ~optimized:"-x-y:calc(min(1px,2px) - 3px)" "-x-y: calc(min(1px,2px) - 3px)";
+  (* The rule is about a [+] / [-] delim token. [calc(1 +2)] lexes as two number
+     tokens with nothing between them but whitespace, so it keeps folding. *)
+  check_declaration ~expected:"--t:calc(1+2)" ~optimized:"--t:calc(1+2)"
+    "--t: calc(1 +2)";
+  (* The reader keeps what it read: the whitespace-free spelling is a different
+     (invalid) declaration, and minifying never inserts a separator. *)
+  check_declaration ~expected:"--t:calc(100%- 10px)"
+    ~optimized:"--t:calc(100%- 10px)" "--t: calc(100%- 10px)";
+  (* Whitespace that no grammar asks for still folds. *)
+  check_declaration ~expected:"--t:16 / 9" ~optimized:"--t:16/9" "--t: 16 / 9";
+  check_declaration ~expected:"--t:calc(var(--base) * 2)"
+    ~optimized:"--t:calc(var(--base)*2)" "--t: calc(var(--base) * 2)";
+  check_declaration ~expected:"--a:cubic-bezier(.4,0,.6,1) infinite"
+    ~optimized:"--a:cubic-bezier(.4,0,.6,1)infinite"
+    "--a: cubic-bezier(.4,0,.6,1) infinite";
+  check_declaration ~expected:"--t:100%x" ~optimized:"--t:100%x" "--t: 100% x"
+
 let important () =
   (* Standard properties with !important *)
   check_declaration ~expected:"color:red!important" "color: red !important";
@@ -5002,6 +5040,7 @@ let declaration_tests =
     (* Custom properties and vendor prefixes *)
     test_case "custom properties basic" `Quick custom_properties_basic;
     test_case "custom properties" `Quick custom_properties;
+    test_case "math sign whitespace" `Quick math_sign_whitespace;
     test_case "custom property values" `Quick custom_property_values;
     test_case "typed custom font family layers print alike" `Quick
       typed_custom_font_family_layer_printing;


### PR DESCRIPTION
A minified custom property or unknown property carrying `calc(100% - 10px)` came out as `calc(100%- 10px)`, which browsers discard, so every `var()` that read it lost its declaration.
