### PR TITLE
values: require whitespace around a calc sum operator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -207,6 +207,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- A math function requires whitespace on both sides of its `+` and `-`
+  operators. Values such as `calc(100%- 10px)` are dropped the way a browser
+  drops them, where cascade used to accept them and print back the valid
+  spelling (#699)
 - `@font-face` and `@font-palette-values` use their descriptor-specific
   `font-family` grammars. The former accepts exactly one named family, the
   latter accepts a non-empty comma-separated list, and both reject unquoted

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5287,6 +5287,18 @@ let read_math_constant_factor : type a. Cursor.t -> a calc =
       Cursor.restore t snap;
       Cursor.err t "expected math constant"
 
+(* CSS Values 4 (ED) sec. 10.8: "whitespace is required on both sides of the +
+   and - operators. (The * and / operators can be used without white space
+   around them.)" Browsers enforce it, so a one-sided sum is not a math function
+   and the whole value is invalid. [ws_before] answers for the left side, which
+   the caller must have measured with [skip_ws]: [peek_delim] drops the
+   whitespace before it reports the delimiter. *)
+let skip_sum_operator t ~ws_before =
+  if not ws_before then Cursor.err t "expected whitespace before '+' or '-'";
+  Cursor.skip t;
+  if not (Cursor.skip_ws t) then
+    Cursor.err t "expected whitespace after '+' or '-'"
+
 let rec read_calc_expr : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
  fun read_a t ->
   Cursor.ws t;
@@ -5294,19 +5306,19 @@ let rec read_calc_expr : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
      as [(a - b) - c]. Loop on subsequent operators rather than recursing on the
      right, which would group it as [a - (b - c)]. *)
   let rec loop left =
-    Cursor.ws t;
+    let ws_before = Cursor.skip_ws t in
     match Cursor.peek_delim t with
     | Some '+' ->
         let right =
           Cursor.atomic t (fun () ->
-              Cursor.skip t;
+              skip_sum_operator t ~ws_before;
               read_calc_term read_a t)
         in
         loop (Expr (left, Add, right))
     | Some '-' ->
         let right =
           Cursor.atomic t (fun () ->
-              Cursor.skip t;
+              skip_sum_operator t ~ws_before;
               read_calc_term read_a t)
         in
         loop (Expr (left, Sub, right))
@@ -5322,11 +5334,16 @@ and read_calc_term : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
 and read_calc_term_tail : type a.
     (Cursor.t -> a) -> Cursor.t -> a calc -> a calc =
  fun read_a t left ->
+  (* Put back the whitespace when the next operator is not [*] or [/]: it is the
+     left-hand side [read_calc_expr] measures for a [+] or [-]. *)
+  let snap = Cursor.save t in
   Cursor.ws t;
   match Cursor.peek_delim t with
   | Some '*' -> read_calc_product read_a t left
   | Some '/' -> read_calc_quotient read_a t left
-  | _ -> left
+  | _ ->
+      Cursor.restore t snap;
+      left
 
 and read_calc_product : type a. (Cursor.t -> a) -> Cursor.t -> a calc -> a calc
     =
@@ -5389,17 +5406,17 @@ and read_math_arg t : math_arg = read_math_arg_term t
 
 and read_math_arg_term t =
   let left = read_math_arg_factor t in
-  Cursor.ws t;
+  let ws_before = Cursor.skip_ws t in
   match Cursor.peek_delim t with
   | Some ('+' as c) | Some ('-' as c) ->
-      Cursor.skip t;
-      Cursor.ws t;
+      skip_sum_operator t ~ws_before;
       let op : calc_op = match c with '+' -> Add | _ -> Sub in
       Op (left, op, read_math_arg_term t)
   | _ -> left
 
 and read_math_arg_factor t =
   let left = read_math_arg_unary t in
+  let snap = Cursor.save t in
   Cursor.ws t;
   match Cursor.peek_delim t with
   | Some ('*' as c) | Some ('/' as c) ->
@@ -5407,7 +5424,9 @@ and read_math_arg_factor t =
       Cursor.ws t;
       let op : calc_op = match c with '*' -> Mul | _ -> Div in
       Op (left, op, read_math_arg_factor t)
-  | _ -> left
+  | _ ->
+      Cursor.restore t snap;
+      left
 
 and read_math_arg_unary t =
   Cursor.ws t;

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1666,6 +1666,73 @@ let test_math_arg () =
   check_math_arg "sqrt(4)";
   neg_cursor read_math_arg "foo"
 
+(* ignore-test: the calc operator grammar spans every math function. *)
+let test_calc_operator_whitespace () =
+  (* CSS Values 4 (ED) sec. 10.8 Syntax: "whitespace is required on both sides
+     of the + and - operators. (The * and / operators can be used without white
+     space around them.)" A one-sided sum is not a math function at all, so the
+     value is dropped rather than re-emitted in the valid spelling. *)
+  neg_cursor read_length "calc(100%- 10px)";
+  neg_cursor read_length "calc(100%+ 10px)";
+  neg_cursor read_length "calc(100% -10px)";
+  neg_cursor read_length "calc(1px- 2px)";
+  neg_cursor read_length "calc(1px -(2px))";
+  neg_cursor read_length "-webkit-calc(100%- 10px)";
+  (* A parenthesised operand on either side of the operator. *)
+  neg_cursor read_length "calc((1px)- 2px)";
+  neg_cursor read_length "calc((1px)+ 2px)";
+  neg_cursor read_length "calc((1px) -(2px))";
+  (* The rule holds inside a parenthesised sub-expression as well as around
+     it. *)
+  neg_cursor read_length "calc((1px + 2px)- 3px)";
+  neg_cursor read_length "calc((1px+ 2px) - 3px)";
+  (* var() and a nested math function are operands like any other. *)
+  neg_cursor read_length "calc(var(--a)- 2px)";
+  neg_cursor read_length "calc(var(--a)+ 2px)";
+  neg_cursor read_length "calc(min(1px,2px)- 3px)";
+  neg_cursor read_length "calc(min(1px,2px)+ 3px)";
+  neg_cursor read_length "calc(sqrt(4)- 1px)";
+  (* A product binds tighter, so the sum operator after it still needs its own
+     whitespace. *)
+  neg_cursor read_length "calc(1px*2- 1px)";
+  (* The <calc-sum> in a math function argument obeys the same rule. *)
+  neg_cursor read_length "calc(sqrt(4- 1) * 1px)";
+  neg_cursor read_math_arg "1- 2";
+  neg_cursor read_math_arg "4+ 1";
+  (* A sign absorbed into a number token is a different failure: there is no
+     delimiter to space out, and [calc(1 +2)] is rejected for leaving [+2]
+     unconsumed. *)
+  neg_cursor read_length "calc(1 +2)";
+
+  (* The accepted spellings, checked against the pretty form: minify drops the
+     optional whitespace around [*] and [/] and the redundant parentheses,
+     which is a separate concern from which spellings parse. *)
+  (* [*] and [/] take whitespace on neither, one or both sides. *)
+  check_length ~minify:false ~expected:"calc(2px * 1.5)" "calc(2px*1.5)";
+  check_length ~minify:false ~expected:"calc(2px * 1.5)" "calc(2px *1.5)";
+  check_length ~minify:false ~expected:"calc(2px * 1.5)" "calc(2px* 1.5)";
+  check_length ~minify:false "calc(2px * 1.5)";
+  check_length ~minify:false ~expected:"calc(2px / 1.5)" "calc(2px/1.5)";
+  check_length ~minify:false ~expected:"calc(2px / 1.5)" "calc(2px /1.5)";
+  check_length ~minify:false ~expected:"calc(2px / 1.5)" "calc(2px/ 1.5)";
+  check_length ~minify:false "calc(2px / 1.5)";
+  (* A sign glued to the first operand of a term is unary, not a sum. *)
+  check_length ~minify:false "calc(-1px + 2px)";
+  check_length ~minify:false "calc((-1px))";
+  (* The spaced spelling of each rejection above stays valid. *)
+  check_length ~minify:false "calc(100% - 10px)";
+  check_length ~minify:false "calc(1px - (2px))";
+  check_length ~minify:false "calc((1px) - (2px))";
+  check_length ~minify:false "calc((1px + 2px) - 3px)";
+  check_length ~minify:false "calc(min(1px, 2px) - 3px)";
+  check_length ~minify:false "calc(sqrt(4) - 1px)";
+  check_length ~minify:false "calc(sqrt(4 - 1) * 1px)";
+  check_length ~minify:false "calc(1px * 2 - 1px)";
+  check_length ~minify:false ~expected:"calc(100% - 10px)"
+    "-webkit-calc(100% - 10px)";
+  check_math_arg "1 - 2";
+  check_math_arg "4 + 1"
+
 let value_tests =
   [
     test_case "system_color" `Quick test_system_color;
@@ -1712,6 +1779,7 @@ let value_tests =
     test_case "invalid_value" `Quick test_invalid_value;
     test_case "math_const" `Quick test_math_const;
     test_case "math_arg" `Quick test_math_arg;
+    test_case "calc operator whitespace" `Quick test_calc_operator_whitespace;
     test_case "number" `Quick test_number;
     test_case "attr_syntax" `Quick test_attr_syntax;
     test_case "attr_type" `Quick test_attr_type;


### PR DESCRIPTION
`calc(100%- 10px)` used to parse and print back as `calc(100% - 10px)`, turning a declaration the browser discards into one that applies. #697 fixed the printer side of the same rule; this is the reader side, and it covers the `<calc-sum>` inside every math function argument, not just `calc()`.
