### PR TITLE
minify: spell the boundary after a percentage one way

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -575,6 +575,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` spells a token boundary after a percentage one way. A constructed
+  `--brand: oklch(63.7% 0.237 25.331)` printed `oklch(63.7%.237 25.331)` while a
+  parse of those same bytes printed `oklch(63.7% .237 25.331)`, so minified
+  output did not read back as itself, and the separator the reader inserted made
+  `--x:10%5px` come out longer than it went in (#700)
 - `--minify` keeps the whitespace CSS Values 4 requires on both sides of a math
   function's `+` and `-` when it prints a custom property or an unknown
   property. `--w: calc(100% - 10px)` came out as `--w:calc(100%- 10px)`, which

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -435,8 +435,9 @@ let word_like_end : Component.t -> bool = function
         kind =
           ( Whitespace | Open _ | Close _ | Colon | Semicolon | Comma | Cdo
           | Cdc | Bad_string | Bad_url | Eof
-          (* These delim characters are self-delimiting at the end, so a
-             trailing [<delim>] never merges with what follows. *)
+          (* Self-delimiting at the end: [%] closes its percentage token and
+             these delims close themselves, so nothing that follows merges into
+             them. Same rule the typed printer applies as [Pp.token_sp]. *)
           | Hash _ | Percentage _
           | Delim
               ( "!" | "*" | "/" | ">" | "?" | "|" | "&" | "^" | "$" | "=" | "%"
@@ -487,22 +488,10 @@ let pair_forms_multichar_token prev next =
       true
   | _ -> false
 
-let pair_prefers_component_separator prev next =
-  match (prev, next) with
-  | ( Component.Preserved { kind = Token.Percentage _; _ },
-      Component.Preserved
-        {
-          kind = Token.Number_tok _ | Token.Percentage _ | Token.Dimension _;
-          _;
-        } ) ->
-      true
-  | _ -> false
-
 let pair_needs_token_boundary prev next =
   match (prev, next) with
   | _ when signed_number_pair prev next -> false
   | _ when pair_forms_multichar_token prev next -> true
-  | _ when pair_prefers_component_separator prev next -> true
   | ( Component.Preserved
         {
           kind =
@@ -621,11 +610,7 @@ and cvs_to_buffer_min ~in_math buf cvs =
         let rest' = drop_ws rest in
         let separated' =
           match rest' with
-          | next :: _
-            when needs_separator prev next
-                 || Option.fold ~none:false
-                      ~some:(fun p -> pair_prefers_component_separator p next)
-                      prev ->
+          | next :: _ when needs_separator prev next ->
               Buffer.add_char buf ' ';
               true
           | _ -> separated

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -2175,7 +2175,7 @@ let test_loader_import_layer_contract () =
   check_layered_import_loaded "tailwind theme import enters theme layer" ~loader
     ~layer_order
     ~expected:
-      "@layer theme{:root{--color-brand-500:oklch(70% 0.15 \
+      "@layer theme{:root{--color-brand-500:oklch(70%0.15 \
        250);--spacing:0.25rem}}"
     "@import url(theme.css) layer(theme);";
   check_layered_import_loaded "tailwind base import enters base layer" ~loader

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -236,6 +236,68 @@ let constructed_offset_shorthand () =
         (String.trim (Css.to_string ~minify:true stylesheet))
   | Error e -> Alcotest.failf "%s: %s" printed (Error.to_string e)
 
+(* CSS Syntax 3 (ED) sec. 4 ends a percentage-token at the [%], so
+   [oklch(63.7%.237 25.331)] and [oklch(63.7% .237 25.331)] tokenise to one
+   stream and [Css.to_string ~minify:true] may spell the boundary either way. It
+   may not spell it both ways: minified output is the printer's canonical form,
+   so reading it back and printing it again has to give the same bytes.
+   [Css.var] binds a typed value where the reader keeps an opaque token stream,
+   so both sides of the printer answer the same question here. *)
+let constructed_custom_property_reparses () =
+  let modes =
+    [
+      ("default", false, false);
+      ("lossless", true, false);
+      ("enforce-spec", false, true);
+    ]
+  in
+  let fixed_point label sheet =
+    List.iter
+      (fun (mode, lossless, enforce_spec) ->
+        let printed =
+          Css.to_string ~minify:true ~lossless ~enforce_spec sheet
+        in
+        let again =
+          Css.to_string ~minify:true ~lossless ~enforce_spec
+            (Css.of_string_exn printed)
+        in
+        Alcotest.(check string)
+          (String.concat "" [ label; " is its own fixed point ("; mode; ")" ])
+          printed again)
+      modes
+  in
+  let decl, _ = Css.var "brand" Css.Color (Css.oklch 63.7 0.237 25.331) in
+  fixed_point "constructed custom property" (v [ rule ~selector:btn [ decl ] ]);
+  fixed_point "parsed custom property"
+    (Css.of_string_exn ".btn{--brand:oklch(63.7% .237 25.331)}");
+  (* [hsl()] is the control: the typed printer keeps the separator between its
+     two percentages, and a reparse holds that spelling. *)
+  fixed_point "typed percentage pair"
+    (Css.of_string_exn ".btn{color:hsl(120 50% 50%)}");
+  (* A custom property never comes out longer than it went in. [%] closes the
+     percentage, so the reader has no boundary to restore. *)
+  List.iter
+    (fun source ->
+      let printed = Css.to_string ~minify:true (Css.of_string_exn source) in
+      Alcotest.(check string)
+        "minified custom property keeps its spelling" source printed;
+      fixed_point "tight custom property" (Css.of_string_exn source))
+    [ ":root{--x:10%5px}"; ":root{--x:50%.5}" ];
+  (* Pretty output is the upper bound on minified output for the same node. *)
+  List.iter
+    (fun source ->
+      let sheet = Css.of_string_exn source in
+      let minified = Css.to_string ~minify:true sheet in
+      let pretty = Css.to_string sheet in
+      if String.length minified > String.length pretty then
+        Alcotest.failf "minified %S is longer than pretty %S" minified pretty)
+    [
+      ":root{--x:10%5px}";
+      ":root{--x:50%.5}";
+      ".btn{--brand:oklch(63.7% .237 25.331)}";
+      ".btn{color:hsl(120 50% 50%)}";
+    ]
+
 let explicit_phase_pipeline () =
   let stylesheet =
     v
@@ -2144,6 +2206,8 @@ let suite =
         constructed_offset_shorthand;
       Alcotest.test_case "constructed initial keyword fold" `Quick
         constructed_initial_keyword_fold;
+      Alcotest.test_case "constructed custom property reparses" `Quick
+        constructed_custom_property_reparses;
       Alcotest.test_case "explicit phase pipeline" `Quick
         explicit_phase_pipeline;
       Alcotest.test_case "important declarations" `Quick important_integration;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4023,15 +4023,17 @@ let test_spec_snapshot_tracking_vectors () =
      } }"
   in
   (* The condition keeps [0.1] as written: it is the declaration the browser is
-     asked to parse, not a value to re-spell. The guarded rule folds. *)
+     asked to parse, not a value to re-spell. Its insignificant whitespace goes,
+     as it does everywhere else in a prelude: [%] closes the percentage token,
+     so [50%0.1] is the same two tokens. The guarded rule folds. *)
   check_stylesheet
     ~expected:
-      "@supports(color:oklch(50% 0.1 20)){.accent{color:oklch(50%.1 20)}}"
+      "@supports(color:oklch(50%0.1 20)){.accent{color:oklch(50%.1 20)}}"
     oklch_support;
   assert_minify_and_optimize oklch_support
     ~minified:
-      "@supports(color:oklch(50% 0.1 20)){.accent{color:oklch(50%.1 20)}}"
-    ~optimized:"@supports(color:oklch(50% 0.1 20)){.accent{color:#944a4b}}";
+      "@supports(color:oklch(50%0.1 20)){.accent{color:oklch(50%.1 20)}}"
+    ~optimized:"@supports(color:oklch(50%0.1 20)){.accent{color:#944a4b}}";
   let nested_media =
     ".card { color: var(--fg); @media (prefers-color-scheme: dark) { & { \
      color: white } } }"


### PR DESCRIPTION
`Css.to_string ~minify:true` answered the same lexical question two ways inside one call: the typed printer dropped the separator after a percentage while the reader wrote one back into an opaque custom-property stream, so `oklch(63.7%.237 25.331)` did not read back as itself, and `--x:10%5px` came out longer than it went in.

One `@supports` prelude in the suite changes bytes; headless Chrome evaluates the guard the same in both spellings.