### PR TITLE
cursor: reject trailing content inside a block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -207,6 +207,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- Trailing content inside a parenthesised or bracketed sub-expression makes the
+  whole value invalid, as it does in a browser. `width: calc((1px 2px))` used
+  to keep the prefix a reader recognised and drop the rest (#701)
 - A math function requires whitespace on both sides of its `+` and `-`
   operators. Values such as `calc(100%- 10px)` are dropped the way a browser
   drops them, where cascade used to accept them and print back the valid

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -752,19 +752,29 @@ let take_block_if pred t : Component.block Component.node option =
       Some b
   | _ -> None
 
+(* A block's grammar ends at its closer, so a reader that stops part-way through
+   the contents has met an invalid value, not a shorter one it may answer with:
+   CSS Syntax 3 (ED) sec. 5.4.1 matches a grammar against the whole
+   component-value list the block holds, or returns failure. [expect_eof] skips
+   leading whitespace itself. *)
+let whole_block f inner =
+  let v = f inner in
+  expect_eof inner;
+  v
+
 let parens f t =
   match take_block_if (fun b -> b = Token.Paren) t with
-  | Some b -> f (sub ~eof_loc:(closer_loc b.loc) t b.node.value)
+  | Some b -> whole_block f (sub ~eof_loc:(closer_loc b.loc) t b.node.value)
   | None -> err_expected t "'('"
 
 let brackets f t =
   match take_block_if (fun b -> b = Token.Square) t with
-  | Some b -> f (sub ~eof_loc:(closer_loc b.loc) t b.node.value)
+  | Some b -> whole_block f (sub ~eof_loc:(closer_loc b.loc) t b.node.value)
   | None -> err_expected t "'['"
 
 let braces f t =
   match take_block_if (fun b -> b = Token.Curly) t with
-  | Some b -> f (sub ~eof_loc:(closer_loc b.loc) t b.node.value)
+  | Some b -> whole_block f (sub ~eof_loc:(closer_loc b.loc) t b.node.value)
   | None -> err_expected t "'{'"
 
 let function_call name f t =
@@ -772,15 +782,16 @@ let function_call name f t =
   | Some (Component.Func fn)
     when String.lowercase_ascii_preserve fn.node.name = name ->
       let _ = next t in
-      Some (f (sub ~eof_loc:(closer_loc fn.loc) t fn.node.arguments))
+      Some
+        (whole_block f (sub ~eof_loc:(closer_loc fn.loc) t fn.node.arguments))
   | _ -> None
 
 let any_function_call f t =
   match peek t with
   | Some (Component.Func fn) ->
       let _ = next t in
-      Some
-        (f fn.node.name (sub ~eof_loc:(closer_loc fn.loc) t fn.node.arguments))
+      let inner = sub ~eof_loc:(closer_loc fn.loc) t fn.node.arguments in
+      Some (whole_block (f fn.node.name) inner)
   | _ -> None
 
 let call name t f =
@@ -792,13 +803,7 @@ let call name t f =
       let arg = sub ~eof_loc:(closer_loc fn.loc) t fn.node.arguments in
       let arg = { arg with depth = t.depth + 1 } in
       if arg.depth > max_nesting_depth then err arg "nesting too deep";
-      (* A function's grammar ends at its closing paren, so whatever [f] left
-         behind is an invalid value, not a shorter one it may answer with (CSS
-         Syntax 3 (ED) sec. 7.2). [expect_eof] skips leading whitespace
-         itself. *)
-      let v = f arg in
-      expect_eof arg;
-      v
+      whole_block f arg
   | _ -> err_expected t (name ^ "(")
 
 (** {1 Enums} *)

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -450,7 +450,9 @@ val expect_eof : t -> unit
 
 val parens : (t -> 'a) -> t -> 'a
 (** [parens f t] consumes a [(...)] block and calls [f] with a fresh cursor over
-    its contents. Raises if the next component is not a parenthesised block. *)
+    its contents. Raises if the next component is not a parenthesised block, or
+    if [f] leaves any of the contents unconsumed: trailing content makes the
+    value invalid, not truncated (CSS Syntax 3 (ED) sec. 5.4.1). *)
 
 val brackets : (t -> 'a) -> t -> 'a
 (** [brackets t f] consumes a [[...]] block similarly. *)
@@ -462,17 +464,19 @@ val call : string -> t -> (t -> 'a) -> 'a
 (** [call name t f] consumes a [name(...)] function call and applies [f] to a
     cursor over its arguments. Raises if no such function is next, or if [f]
     leaves any of the arguments unconsumed: trailing content makes the value
-    invalid, not truncated (CSS Syntax 3 (ED) sec. 7.2). *)
+    invalid, not truncated (CSS Syntax 3 (ED) sec. 5.4.1). *)
 
 val function_call : string -> (t -> 'a) -> t -> 'a option
 (** [function_call name f t] consumes a [name(...)] call and calls [f] over its
-    arguments. Returns [None] without advancing if the next component is not a
-    function with that name, compared ASCII case-insensitively (CSS Values 4
-    sec. 4.1), so [name] is given lowercase. *)
+    arguments, raising if [f] leaves any of them unconsumed, as {!call} does.
+    Returns [None] without advancing if the next component is not a function
+    with that name, compared ASCII case-insensitively (CSS Values 4 sec. 4.1),
+    so [name] is given lowercase. *)
 
 val any_function_call : (string -> t -> 'a) -> t -> 'a option
 (** [any_function_call f t] consumes any function call and applies [f] to its
-    name and argument cursor. *)
+    name and argument cursor, raising if [f] leaves any argument unconsumed, as
+    {!call} does. *)
 
 (** {1 Enums} *)
 

--- a/test/test_cursor.ml
+++ b/test/test_cursor.ml
@@ -207,6 +207,37 @@ let test_call_interior_whitespace () =
   Alcotest.(check bool)
     "outer cursor advanced past the call" true (Cursor.is_done c)
 
+(* [parens], [brackets], [braces] and [function_call] build the same kind of
+   sub-cursor as [call], so the same rule holds: CSS Syntax 3 (ED) sec. 5.4.1
+   matches a grammar against the whole component-value list or returns failure,
+   so a reader that stops on a prefix of a block has met an invalid value, not a
+   shorter one. Real CSS reaches the hole through [width:calc((1px 2px))],
+   [grid-template-columns:[a 1px] 1px] and an [image-set()] option whose
+   [type(<string>)] carries a trailing token; browsers drop all three. *)
+let test_parens_requires_eof () =
+  let c = cursor_of_string "(red green)" in
+  match Cursor.parens (fun inner -> Cursor.ident inner) c with
+  | (_ : string) -> Alcotest.fail "expected Parse_error"
+  | exception Cursor.Parse_error _ -> ()
+
+let test_brackets_requires_eof () =
+  let c = cursor_of_string "[red green]" in
+  match Cursor.brackets (fun inner -> Cursor.ident inner) c with
+  | (_ : string) -> Alcotest.fail "expected Parse_error"
+  | exception Cursor.Parse_error _ -> ()
+
+let test_braces_requires_eof () =
+  let c = cursor_of_string "{red green}" in
+  match Cursor.braces (fun inner -> Cursor.ident inner) c with
+  | (_ : string) -> Alcotest.fail "expected Parse_error"
+  | exception Cursor.Parse_error _ -> ()
+
+let test_function_call_requires_eof () =
+  let c = cursor_of_string "rgb(1 2)" in
+  match Cursor.function_call "rgb" (fun inner -> Cursor.int inner) c with
+  | (_ : int option) -> Alcotest.fail "expected Parse_error"
+  | exception Cursor.Parse_error _ -> ()
+
 let suite =
   ( "cursor",
     [
@@ -242,4 +273,10 @@ let suite =
         test_call_full_consumption_succeeds;
       Alcotest.test_case "call interior whitespace" `Quick
         test_call_interior_whitespace;
+      Alcotest.test_case "parens requires eof" `Quick test_parens_requires_eof;
+      Alcotest.test_case "brackets requires eof" `Quick
+        test_brackets_requires_eof;
+      Alcotest.test_case "braces requires eof" `Quick test_braces_requires_eof;
+      Alcotest.test_case "function call requires eof" `Quick
+        test_function_call_requires_eof;
     ] )

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -231,6 +231,12 @@ let test_length () =
   decl_optimizes ~prop:"width" ~held:"calc(0 + 10px)" ~into:"calc(0 + 10px)"
     "calc(0 + 10px)";
 
+  (* CSS Values 4 sec. 10.8 makes a parenthesised operand a whole [<calc-sum>],
+     so a trailing token inside one invalidates the value rather than shortening
+     it to the prefix; browsers drop both declarations. *)
+  neg_cursor read_length "calc((1px 2px))";
+  neg_cursor read_length "min((1px 2px))";
+
   neg_cursor read_length "invalid";
   neg_cursor read_length "abc";
   neg_cursor read_length "10";


### PR DESCRIPTION
`width: calc((1px 2px))` parsed as `1px` and `grid-template-columns: [a 1px] 1px` as `[a] 1px`, because the block readers answered with whatever prefix their reader recognised; a browser drops both declarations. `Cursor.call` already carried the check and now shares one implementation with them.
