### PR TITLE
diff: fold insignificant whitespace into the tree-diff key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1064,6 +1064,15 @@ recorded cases carrying six minifiers' answers.
 - `cascade diff` no longer aborts on a reordered selector holding the same rule
   index on both sides. The report is buffered, so the assertion that met such a
   move cost the whole report; the move is now named without a coordinate (#582)
+- `--diff=tree` compares a value on its minified spelling, so insignificant
+  whitespace stops reading as a change: a custom property written `16 / 9`
+  matches `16/9`, and a typed `padding: 0.50px` matches `padding: .5px`. The
+  space CSS Values 4 (ED) sec. 10.8 requires around a math `+` or `-`, and the
+  space beside a `var()`, still separate two values (#702)
+- `--diff=tree` prints a changed declaration the way its own file spells it. The
+  value shown was read off the comparison key, so a custom property holding a
+  quoted multi-word family name was reported unquoted on both sides, a spelling
+  neither file held (#702)
 
 ### Library
 

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -290,8 +290,9 @@ let declaration_value ?(minify = false) ?(inline = false) decl =
   Declaration.string_of_value ~minify ~inline decl
 
 let declaration_value_for_equivalence decl =
-  Declaration.string_of_value ~minify:false
-    (Declaration.unquote_custom_font_strings decl)
+  Declaration.string_of_value ~minify:true
+    (Declaration.canonicalize_custom_whitespace
+       (Declaration.unquote_custom_font_strings decl))
 
 (* Override rule function to return statement directly *)
 let rule ~selector ?nested ?merge_key declarations =

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1526,16 +1526,27 @@ val declaration_value : ?minify:bool -> ?inline:bool -> declaration -> string
     default values. *)
 
 val declaration_value_for_equivalence : declaration -> string
-(** [declaration_value_for_equivalence decl] is the value of [decl] with a
-    quoted multi-word [<string>] in a custom-property token stream rewritten as
-    the equivalent unquoted [<ident>] sequence. The rewrite applies when a
-    generic family in the stream proves the stream is a font-family list, where
-    CSS Fonts 4 sec. 2.1.1 spells the one name both ways: as a structural-diff
-    key, [--font: ui-sans-serif,"Noto Color Emoji"] and
+(** [declaration_value_for_equivalence decl] is the minified value of [decl], so
+    a structural diff keys a typed property on its shortest spelling and
+    [padding: 0.50px] and [padding: .5px] compare equal.
+
+    A custom-property token stream, whose bytes {!declaration_value} keeps
+    verbatim, also loses the whitespace CSS reads as nothing: the whitespace CSS
+    Values 4 (ED) sec. 10.8 leaves optional around a math [*] and [/], and the
+    whitespace a closing bracket already accounts for. So [--r: 16 / 9] and
+    [--r: 16/9] compare equal, while the space sec. 10.8 requires around a math
+    [+] or [-], and the space beside a [var()], [env()] or [attr()] that sec.
+    2.5 substitutes textually into its neighbour, keep two spellings apart.
+
+    A quoted multi-word [<string>] in that stream is rewritten as the equivalent
+    unquoted [<ident>] sequence, when a generic family in the stream proves the
+    stream is a font-family list, where CSS Fonts 4 sec. 2.1.1 spells the one
+    name both ways: [--font: ui-sans-serif,"Noto Color Emoji"] and
     [--font: ui-sans-serif,Noto Color Emoji] compare equal. Without that proof
     the stream is arbitrary tokens, in which one [<string>] is not an [<ident>]
-    sequence, and the two spellings keep distinct keys. Not for emission, where
-    both forms stay verbatim. *)
+    sequence, and the two spellings keep distinct keys.
+
+    Not for emission, where every one of these forms stays verbatim. *)
 
 (** {1 Property Categories}
 

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -161,6 +161,29 @@ let unquote_custom_font_strings = function
            })
   | decl -> decl
 
+(* Equivalence-only normalisation for structural diffing: drop the whitespace of
+   a custom-property stream that CSS reads as nothing. Cascade keeps that
+   whitespace verbatim on output, since the stream is opaque and the author's
+   bytes are what a [var()] substitutes; two streams that differ only there are
+   still the same value. *)
+let canonicalize_custom_whitespace = function
+  | Declaration
+      {
+        property = Custom_property _ as property;
+        value = Custom_value ({ value = Tokens components; _ } as cv);
+        important;
+        _;
+      } ->
+      v ~important property
+        (Custom_value
+           {
+             cv with
+             value =
+               Tokens
+                 (Properties.canonicalize_math_whitespace_components components);
+           })
+  | decl -> decl
+
 (* Parser functions *)
 
 (** Parse a property name. Property names are plain idents in the component

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -124,6 +124,16 @@ val unquote_custom_font_strings : declaration -> declaration
     Equivalence-only normalisation for structural diffing; a stream without that
     proof, and any other declaration, passes through unchanged. *)
 
+val canonicalize_custom_whitespace : declaration -> declaration
+(** [canonicalize_custom_whitespace d] drops from a custom-property token stream
+    the whitespace CSS reads as nothing: around the [*] and [/] of CSS Values 4
+    (ED) sec. 10.8 arithmetic, and after a function or block whose closing
+    bracket already separates it from what follows. The whitespace sec. 10.8
+    requires around a math [+] or [-] stays, and so does the whitespace next to
+    a [var()], [env()] or [attr()] whose substitution would otherwise merge with
+    its neighbour. Equivalence-only normalisation for structural diffing; any
+    other declaration passes through unchanged. *)
+
 val read_property_name : Cursor.t -> string
 (** [read_property_name t] is the property name read from [t]. *)
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1196,13 +1196,24 @@ let strings_of_rule (stmt : Css.statement) =
       | Declarations decls -> ("&", decls)
       | _ -> (statement_head stmt, Css.Stylesheet.statement_declarations stmt))
 
+let decl_with_important decl value =
+  if Css.declaration_is_important decl then
+    String.concat "" [ value; " !important" ]
+  else value
+
 let decl_to_prop_value decl =
-  let name = Css.declaration_name decl in
-  let value = Css.declaration_value_for_equivalence decl in
-  let value =
-    if Css.declaration_is_important decl then value ^ " !important" else value
-  in
-  (name, value)
+  ( Css.declaration_name decl,
+    decl_with_important decl (Css.declaration_value_for_equivalence decl) )
+
+(* What a changed declaration puts in the report: the key answers whether the
+   two sides differ, and the author's own spelling is what the reader is shown.
+   Printing the key instead quotes a value neither file holds, since the key
+   folds the spellings the two sides chose onto one. *)
+let decl_to_reported_value decl =
+  let name, key = decl_to_prop_value decl in
+  ( name,
+    (key, decl_with_important decl (Css.declaration_value ~minify:false decl))
+  )
 
 let compare_prop_value (name1, value1) (name2, value2) =
   let by_name = String.compare name1 name2 in
@@ -1962,11 +1973,15 @@ let names_of props =
 let rec zip_occurrences name (modified, added, removed) values1 values2 =
   match (values1, values2) with
   | [], [] -> (modified, added, removed)
-  | v1 :: rest1, v2 :: rest2 ->
+  | (key1, shown1) :: rest1, (key2, shown2) :: rest2 ->
       let modified =
-        if v1 = v2 then modified
+        if String.equal key1 key2 then modified
         else
-          { property_name = name; expected_value = v1; actual_value = v2 }
+          {
+            property_name = name;
+            expected_value = shown1;
+            actual_value = shown2;
+          }
           :: modified
       in
       zip_occurrences name (modified, added, removed) rest1 rest2
@@ -1979,8 +1994,8 @@ let rec zip_occurrences name (modified, added, removed) values1 values2 =
    including added and removed properties *)
 let properties_diff decls1 decls2 : declaration list * string list * string list
     =
-  let props1 = List.map decl_to_prop_value decls1 in
-  let props2 = List.map decl_to_prop_value decls2 in
+  let props1 = List.map decl_to_reported_value decls1 in
+  let props2 = List.map decl_to_reported_value decls2 in
   (* Names the expected side writes first, then the ones only the actual side
      writes, so the report reads in source order. *)
   let names =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3890,7 +3890,7 @@ let strip_after_close_paren ~in_math comps =
    propagates through grouping parens ([Block]s) since those are math operands,
    and turns off when entering a nested non-math function like [var()] which has
    its own grammar. *)
-let rec canonicalize_math_whitespace_components ?(in_math = false) comps =
+let rec canonicalize_math_whitespace ~in_math comps =
   let comps' =
     List.map
       (fun c ->
@@ -3899,16 +3899,14 @@ let rec canonicalize_math_whitespace_components ?(in_math = false) comps =
             let func = wrapped.Component.node in
             let nested_in_math = is_math_function func.name in
             let args =
-              canonicalize_math_whitespace_components ~in_math:nested_in_math
+              canonicalize_math_whitespace ~in_math:nested_in_math
                 func.arguments
             in
             Component.Func
               { wrapped with node = { func with arguments = args } }
         | Component.Block wrapped ->
             let block = wrapped.Component.node in
-            let value =
-              canonicalize_math_whitespace_components ~in_math block.value
-            in
+            let value = canonicalize_math_whitespace ~in_math block.value in
             Component.Block { wrapped with node = { block with value } }
         | Component.Preserved _ -> c)
       comps
@@ -3918,6 +3916,9 @@ let rec canonicalize_math_whitespace_components ?(in_math = false) comps =
     else strip_mul_div_whitespace comps'
   in
   strip_after_close_paren ~in_math comps'
+
+let canonicalize_math_whitespace_components comps =
+  canonicalize_math_whitespace ~in_math:false comps
 
 let normalize_property_value : type a.
     ?lossless:bool ->

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -86,6 +86,15 @@ val unquote_font_family_strings : custom_value -> custom_value
     holding a word that sec. 2.1.1 excludes from [<custom-ident>], and any token
     that isn't a [<string>] pass through unchanged. *)
 
+val canonicalize_math_whitespace_components : custom_value -> custom_value
+(** [canonicalize_math_whitespace_components components] drops the whitespace of
+    [components] that CSS reads as nothing: around the [*] and [/] of CSS Values
+    4 (ED) sec. 10.8 arithmetic, and after a function or block whose closing
+    bracket already separates it from what follows. The whitespace sec. 10.8
+    requires around a math [+] or [-], and the whitespace next to a [var()],
+    [env()] or [attr()] whose substitution would otherwise merge with its
+    neighbour, both stay. *)
+
 val components_have_generic_family : custom_value -> bool
 (** [components_have_generic_family components] is [true] when a bare ident in
     [components] matches a generic font family ([sans-serif], [ui-monospace],

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -1296,6 +1296,108 @@ let wholesale_block_shows_every_child () =
         wanted)
     cases
 
+(* ===== Whitespace the matching key folds ===== *)
+
+(* Each side is one rule holding one declaration, so the report is empty exactly
+   when the two spellings share a matching key. *)
+let value_pair ~folds ~name one other () =
+  let wrap decl = String.concat "" [ "a{"; decl; "}" ] in
+  let d = diff_of ~expected:(wrap one) ~actual:(wrap other) in
+  Alcotest.(check bool) name folds (Cascade_diff.Tree_diff.is_empty d)
+
+let folded_value = value_pair ~folds:true
+let distinct_value = value_pair ~folds:false
+
+(* CSS Values 4 (ED) sec. 10.8 leaves the whitespace around [*] and [/] optional
+   inside a math function, so both streams substitute the same tokens. *)
+let key_folds_whitespace_in_calc =
+  folded_value ~name:"a spaced calc division is the spaceless one"
+    "--k:calc(2 / 1.5)" "--k:calc(2/1.5)"
+
+(* Outside a math function the whitespace next to a [*] or [/] is insignificant
+   too (CSS Values 4 sec. 10.1): [16 / 9] and [16/9] re-tokenise identically. *)
+let key_folds_whitespace_around_a_bare_slash =
+  folded_value ~name:"a spaced ratio is the spaceless one" "--k:16 / 9"
+    "--k:16/9"
+
+(* A function that is not a substitution function closes on [)], a token
+   boundary nothing on its right can merge across, so the space after it
+   separates nothing. *)
+let key_folds_whitespace_after_a_function =
+  folded_value ~name:"a space after a closed function is nothing"
+    "--k:cubic-bezier(.4,0,.6,1) infinite" "--k:cubic-bezier(.4,0,.6,1)infinite"
+
+(* CSS Syntax 3 ends a percentage token at the [%], so the number that follows
+   cannot merge into it and the space between them carries nothing. *)
+let key_folds_whitespace_after_a_percentage =
+  folded_value ~name:"a space after a percentage is nothing"
+    "--k:oklch(63.7% .237 25.331)" "--k:oklch(63.7%.237 25.331)"
+
+(* The key reads a typed value through the same minified spelling, so a number
+   written long and a number written short stop reading as a change. *)
+let key_folds_a_typed_number_spelling =
+  folded_value ~name:"a padded number is the short one" "padding:0.50px"
+    "padding:.5px"
+
+(* ===== Whitespace the matching key keeps ===== *)
+
+(* Sec. 10.8 requires the whitespace around a binary [+] or [-]: [100%- 10px] is
+   not the same declaration written shorter, it is one the browser drops. *)
+let key_keeps_whitespace_around_a_calc_sum =
+  distinct_value ~name:"a calc sum missing its space is a difference"
+    "--k:calc(100% - 10px)" "--k:calc(100%- 10px)"
+
+(* CSS Values 4 sec. 2.5 substitutes a [var()] body textually, so the space
+   after one separates the two substituted streams and is part of the value. *)
+let key_keeps_whitespace_between_two_vars =
+  distinct_value ~name:"a space between two var() is a difference"
+    "--k:var(--a) var(--b)" "--k:var(--a)var(--b)"
+
+let key_keeps_whitespace_after_a_var =
+  distinct_value ~name:"a space after a var() is a difference"
+    "--k:var(--a) 10px" "--k:var(--a)10px"
+
+(* Two idents against one: the streams hold different tokens, whatever the
+   property they are substituted into reads them as. *)
+let key_keeps_whitespace_between_two_idents =
+  distinct_value ~name:"two idents are not one" "--k:a b" "--k:ab"
+
+(* No generic family in the stream, so nothing proves it is a font-family list
+   and a [<string>] there is not the equivalent [<ident>] sequence. *)
+let key_keeps_quotes_without_a_generic_family =
+  distinct_value ~name:"an unproven quoted family is a difference"
+    "--k:a,\"Segoe UI\",b" "--k:a,Segoe UI,b"
+
+(* Two typed values that differ still differ, however far the minified spelling
+   shortens each of them. *)
+let key_keeps_two_typed_values_apart =
+  distinct_value ~name:"two colours are a difference" "color:#ff0000"
+    "color:#ff1100"
+
+(* The key is for matching, not for display: a pair that still differs prints
+   the bytes each side's author wrote, not the spelling the key folded them
+   onto, which is a value neither file holds. *)
+let report_quotes_the_author_spelling () =
+  let quotes ~name ~expected ~actual affixes =
+    let out = render (diff_of ~expected ~actual) in
+    List.iter
+      (fun affix ->
+        Alcotest.(check bool)
+          (String.concat "" [ name; " reads "; affix ])
+          true
+          (Astring.String.is_infix ~affix out))
+      affixes
+  in
+  quotes ~name:"a custom stream" ~expected:"a{--k:calc(100% - 10px)}"
+    ~actual:"a{--k:calc(100%- 10px)}"
+    [ "calc(100% - 10px)"; "calc(100%- 10px)" ];
+  quotes ~name:"a typed colour" ~expected:"a{color:#ff0000}"
+    ~actual:"a{color:#ff1100}" [ "#ff0000"; "#ff1100" ];
+  quotes ~name:"a quoted family"
+    ~expected:"a{--f:ui-sans-serif,\"Noto Color Emoji\"}"
+    ~actual:"a{--f:ui-serif,\"Noto Color Emoji\"}"
+    [ "ui-sans-serif,\"Noto Color Emoji\""; "ui-serif,\"Noto Color Emoji\"" ]
+
 let suite =
   ( "tree_diff",
     [
@@ -1458,6 +1560,30 @@ let suite =
         deeply_nested_identical_is_empty;
       Alcotest.test_case "wholesale block shows every child" `Quick
         wholesale_block_shows_every_child;
+      Alcotest.test_case "key folds whitespace in calc" `Quick
+        key_folds_whitespace_in_calc;
+      Alcotest.test_case "key folds whitespace around a bare slash" `Quick
+        key_folds_whitespace_around_a_bare_slash;
+      Alcotest.test_case "key folds whitespace after a function" `Quick
+        key_folds_whitespace_after_a_function;
+      Alcotest.test_case "key folds whitespace after a percentage" `Quick
+        key_folds_whitespace_after_a_percentage;
+      Alcotest.test_case "key folds a typed number spelling" `Quick
+        key_folds_a_typed_number_spelling;
+      Alcotest.test_case "key keeps whitespace around a calc sum" `Quick
+        key_keeps_whitespace_around_a_calc_sum;
+      Alcotest.test_case "key keeps whitespace between two vars" `Quick
+        key_keeps_whitespace_between_two_vars;
+      Alcotest.test_case "key keeps whitespace after a var" `Quick
+        key_keeps_whitespace_after_a_var;
+      Alcotest.test_case "key keeps whitespace between two idents" `Quick
+        key_keeps_whitespace_between_two_idents;
+      Alcotest.test_case "key keeps quotes without a generic family" `Quick
+        key_keeps_quotes_without_a_generic_family;
+      Alcotest.test_case "key keeps two typed values apart" `Quick
+        key_keeps_two_typed_values_apart;
+      Alcotest.test_case "report quotes the author spelling" `Quick
+        report_quotes_the_author_spelling;
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "pp_rule_diff_simple does not crash" `Quick
         pp_rule_diff_simple_ok;


### PR DESCRIPTION
`--diff=tree` keyed a custom property's value on its bytes, so a space CSS reads as nothing was a difference there and nowhere else, and a caller had to reprint both sheets to get past it. The report printed that key back rather than the declaration, which for a quoted multi-word family name quoted a spelling neither file held.