### PR TITLE
values: elide the separator after a percentage in colour functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -578,6 +578,10 @@ recorded cases carrying six minifiers' answers.
 
 ### Minification
 
+- `--minify` spells the boundary after a percentage the same way inside every
+  colour function. A constructed `hsl(120 50% 50%)` or `oklch(.659 76% 203.274)`
+  kept a separator that a parse of those same bytes dropped, so a colour built
+  through the API did not read back as itself (#703)
 - `--minify` spells a token boundary after a percentage one way. A constructed
   `--brand: oklch(63.7% 0.237 25.331)` printed `oklch(63.7%.237 25.331)` while a
   parse of those same bytes printed `oklch(63.7% .237 25.331)`, so minified

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4375,6 +4375,19 @@ let pp_hue_interpolation : hue_interpolation Pp.t =
   | Specified -> Pp.string ctx "specified"
   | Default -> ()
 
+(* CSS Syntax 3 (ED) sec. 4: a [<percentage-token>] ends at its [%], so the
+   separator before the next component carries no information and elides under
+   minify. Narrower than {!Pp.token_sp}, which also elides after [)]: a function
+   is word-like at its end, and the custom-value serialiser keeps that
+   separator, so eliding it here would make a constructed colour disagree with
+   its own reparse. Reads the emitted byte rather than the node so a spelling
+   that does not end on [%] ([calc(NaN*1%)]) stays spaced. *)
+let space_after_percentage : unit Pp.t =
+ fun ctx () ->
+  match Pp.last_char ctx with
+  | Some '%' when Pp.minified ctx -> ()
+  | _ -> Pp.space ctx ()
+
 let static_component_can_touch_negative (component : component) =
   match component with
   | Num _ | Pct _ -> true
@@ -4408,14 +4421,15 @@ let pp_color_components ~decimals : component list Pp.t =
 (* Helpers to pretty print CSS color functions using Pp.call *)
 let pp_rgb_args : (channel * channel * channel * alpha) Pp.t =
  fun ctx (r, g, b, alpha) ->
-  Pp.list ~sep:Pp.space pp_channel ctx [ r; g; b ];
+  Pp.list ~sep:space_after_percentage pp_channel ctx [ r; g; b ];
   pp_opt_alpha ctx alpha
 
 let pp_rgb_func = Pp.call "rgb" pp_rgb_args
 
 let rec pp_rgb : rgb Pp.t =
  fun ctx -> function
-  | Channels { r; g; b } -> Pp.list ~sep:Pp.space pp_channel ctx [ r; g; b ]
+  | Channels { r; g; b } ->
+      Pp.list ~sep:space_after_percentage pp_channel ctx [ r; g; b ]
   | Var v -> pp_var pp_rgb ctx v
 
 (** Lab-like float string. CSSOM serialisation (CSSOM 1 sec. 6.7.2) drops a
@@ -4450,12 +4464,13 @@ let string_of_scaled_color_axis ~pct_scale ctx f =
 
 let space_after_color_percentage ctx (l : percentage option) ~next =
   (* The space between the L channel and the next colour component elides when
-     the L spelling closes its token cleanly and the next token starts with its
-     own boundary: [%] from [Pct], [)] from [Var] / [Calc], or a bare-number end
-     ([4] in [.654]) followed by a sign-token [+] / [-] that starts the next
-     number. [None] / unknown left-hand stays conservative. *)
+     the L spelling closes its token cleanly: a [%] ends its percentage token
+     whatever follows, a [)] from [Var] / [Calc] needs the next token to start
+     its own boundary, and a bare-number end ([4] in [.654]) needs a sign-token
+     [+] / [-] to start the next number. [None] / unknown left-hand stays
+     conservative. *)
   let starts_signed s = String.length s > 0 && (s.[0] = '+' || s.[0] = '-') in
-  let next_safe_after_pct s =
+  let next_safe_after_paren s =
     String.length s > 0
     &&
     match s.[0] with
@@ -4464,11 +4479,12 @@ let space_after_color_percentage ctx (l : percentage option) ~next =
   in
   let elidable =
     Pp.minified ctx
-    &&
-    match (l, next) with
-    | Some (Pct _ | Var _ | Calc _), Some s -> next_safe_after_pct s
-    | Some (Num _), Some s -> starts_signed s
-    | _ -> false
+    && (Pp.last_char ctx = Some '%'
+       ||
+       match (l, next) with
+       | Some (Var _ | Calc _), Some s -> next_safe_after_paren s
+       | Some (Num _), Some s -> starts_signed s
+       | _ -> false)
   in
   if not elidable then Pp.space ctx ()
 
@@ -4502,7 +4518,7 @@ let pp_pct_chroma_hue_alpha ~chroma_pct_scale :
   | None ->
       space_after_color_percentage ctx printed_l ~next:(Some "none");
       Pp.string ctx "none");
-  Pp.space ctx ();
+  space_after_percentage ctx ();
   pp_hue ctx h;
   pp_opt_alpha ctx alpha
 
@@ -4513,7 +4529,7 @@ let pp_hue_pct_pct_alpha : (hue * percentage * percentage * alpha) Pp.t =
   pp_hue ctx h;
   Pp.space ctx ();
   pp_percentage ctx s;
-  Pp.space ctx ();
+  space_after_percentage ctx ();
   pp_percentage ctx l;
   pp_opt_alpha ctx a
 
@@ -4559,7 +4575,7 @@ let pp_lab_like_args ~axis_pct_scale :
       (ctx.Pp.minify && starts_unsigned_number a
       && String.length b > 0
       && (b.[0] = '-' || b.[0] = '+'))
-  then Pp.space ctx ();
+  then space_after_percentage ctx ();
   Pp.string ctx b;
   match alpha with
   | None -> ()

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -206,7 +206,7 @@ let normalize_expected ~category ~id expected =
          oracle rounds to 1 (203.3): at this chroma a 1-decimal hue shifts the
          rendered colour. *)
       fixture ~category ~id ~upstream:"a{color:oklch(.659 .304 203.3)}"
-        ~cascade:"a{color:oklch(.659 76% 203.274)}" upstream
+        ~cascade:"a{color:oklch(.659 76%203.274)}" upstream
   | "colors", "0046" ->
       (* cascade keeps 3 hue decimals (180.457 vs the oracle's 180.5); the
          oklab() leading-channel space elision is the usual safe-token-boundary
@@ -229,7 +229,7 @@ let normalize_expected ~category ~id expected =
           "a{color:lch(54.3 100.5 274.5/.746);background-color:lab(54.3 -60.5 \
            70.8)}"
         ~cascade:
-          "a{color:lch(54.3 67% 274.456/.746);background-color:lab(54.3-60.5 \
+          "a{color:lch(54.3 67%274.456/.746);background-color:lab(54.3-60.5 \
            70.8)}"
         upstream
   | "colors", "0048" ->

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -158,7 +158,7 @@ let pure_minify_value_fallbacks () =
   in
   Alcotest.(check string)
     "constructed value fallbacks"
-    ".btn{--tw-duration:.2s;transition-duration:.2s;color:hsl(120 50% 50%)}"
+    ".btn{--tw-duration:.2s;transition-duration:.2s;color:hsl(120 50%50%)}"
     (Css.to_string ~minify:true stylesheet)
 
 (* [to_string ~minify:true] is a pure formatter, so a constructed AST reaches

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -270,10 +270,54 @@ let constructed_custom_property_reparses () =
   fixed_point "constructed custom property" (v [ rule ~selector:btn [ decl ] ]);
   fixed_point "parsed custom property"
     (Css.of_string_exn ".btn{--brand:oklch(63.7% .237 25.331)}");
-  (* [hsl()] is the control: the typed printer keeps the separator between its
-     two percentages, and a reparse holds that spelling. *)
+  (* A parsed typed colour is its own fixed point: the typed printer and the
+     custom-value serialiser have to agree on the percentage boundary. *)
   fixed_point "typed percentage pair"
     (Css.of_string_exn ".btn{color:hsl(120 50% 50%)}");
+  (* [%] closes its token (CSS Syntax 3 (ED) sec. 4), so a constructed colour
+     has to spell the boundary after a percentage the way a reparse of its own
+     bytes does. *)
+  List.iter
+    (fun (name, color) ->
+      let decl, _ = Css.var name Css.Color color in
+      fixed_point
+        (String.concat "" [ "constructed "; name ])
+        (v [ rule ~selector:btn [ decl ] ]))
+    [
+      ("hsl", Css.hsl 120. 50. 50.);
+      ("hwb", Css.hwb 120. 30. 40.);
+      ("hsla", Css.hsla 120. 50. 50. 0.5);
+      ("hwba", Css.hwba 120. 30. 40. 0.5);
+      ( "rgb-percentage-channels",
+        Css.Values.Rgb (Channels { r = Pct 50.; g = Pct 60.; b = Pct 70. }) );
+      ("oklch-percentage-chroma", Css.oklch 50. 0.304 120.);
+      ( "oklch-none-chroma",
+        Css.Values.Oklch
+          {
+            l = Some (Pct 50.);
+            c = Option.None;
+            h = Unitless 120.;
+            alpha = None;
+          } );
+      ( "oklab-none-axis",
+        Css.Values.Oklab
+          { l = Some (Pct 50.); a = Option.None; b = Some 0.12; alpha = None }
+      );
+      ( "rgb-var-channel",
+        Css.Values.Rgb
+          (Channels
+             { r = Pct 50.; g = Var (Css.Values.var_ref "g"); b = Pct 70. }) );
+      (* The other side of the same boundary: a [var()] closes on [)], which the
+         custom-value serialiser keeps separated, so that gap stays. *)
+      ( "hsl-var-saturation",
+        Css.Values.Hsl
+          {
+            h = Unitless 120.;
+            s = Var (Css.Values.var_ref "s");
+            l = Pct 50.;
+            a = None;
+          } );
+    ];
   (* A custom property never comes out longer than it went in. [%] closes the
      percentage, so the reader has no boundary to restore. *)
   List.iter
@@ -296,6 +340,7 @@ let constructed_custom_property_reparses () =
       ":root{--x:50%.5}";
       ".btn{--brand:oklch(63.7% .237 25.331)}";
       ".btn{color:hsl(120 50% 50%)}";
+      ".btn{color:hwb(120 30% 40%)}";
     ]
 
 let explicit_phase_pipeline () =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -617,12 +617,12 @@ let colors () =
     "color: rgb(0, 255, 0)";
   decl_optimizes_to ~held:"color:rgb(255 0 0/.5)" ~into:"color:#ff000080"
     "color: rgba(255, 0, 0, 0.5)";
-  decl_optimizes_to ~held:"color:hsl(0 100% 50%)" ~into:"color:red"
+  decl_optimizes_to ~held:"color:hsl(0 100%50%)" ~into:"color:red"
     "color: hsl(0, 100%, 50%)";
-  decl_optimizes_to ~held:"color:hsl(120 100% 50%/.5)" ~into:"color:#00ff0080"
+  decl_optimizes_to ~held:"color:hsl(120 100%50%/.5)" ~into:"color:#00ff0080"
     "color: hsla(120, 100%, 50%, 0.5)";
-  decl_optimizes_to ~held:"color:hsl(.5turn 50% 50%/var(--a))"
-    ~into:"color:hsl(180 50% 50%/var(--a))"
+  decl_optimizes_to ~held:"color:hsl(.5turn 50%50%/var(--a))"
+    ~into:"color:hsl(180 50%50%/var(--a))"
     "color: hsl(.5turn 50% 50% / var(--a))";
 
   check_declaration ~expected:"background-color:red" "background-color: red";

--- a/test/test_factor.ml
+++ b/test/test_factor.ml
@@ -513,7 +513,7 @@ let test_remaining_printer_fold_spellings_factor () =
        ".a{transition-duration:round(1.1s,.5s)}.b{transition-duration:1s}");
   Alcotest.(check string)
     "angle hue factors with bare degrees"
-    ".a,.b{color:hsl(180 50% 50%/var(--a))}"
+    ".a,.b{color:hsl(180 50%50%/var(--a))}"
     (optimize_str
        ".a{color:hsl(.5turn 50% 50%/var(--a))}.b{color:hsl(180 50% \
         50%/var(--a))}")

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -3055,14 +3055,14 @@ let target_minify_enforce_spec_split () =
      --enforce-spec emits the spec-canonical resolved form, which is the number,
      and never introduces a percentage even when it would be shorter. *)
   check_modes "oklch chroma uses the shorter percentage on the default target"
-    "a { color: oklch(.5 .304 200) }" ~default:"a{color:oklch(.5 76% 200)}"
+    "a { color: oklch(.5 .304 200) }" ~default:"a{color:oklch(.5 76%200)}"
     ~spec:"a{color:oklch(.5 .304 200)}";
   check_modes
     "oklch chroma keeps the number when the number is already shortest"
     "a { color: oklch(.5 .1 200) }" ~default:"a{color:oklch(.5 .1 200)}"
     ~spec:"a{color:oklch(.5 .1 200)}";
   check_modes "enforce-spec renders oklch chroma as the canonical number"
-    "a { color: oklch(.5 76% 200) }" ~default:"a{color:oklch(.5 76% 200)}"
+    "a { color: oklch(.5 76% 200) }" ~default:"a{color:oklch(.5 76%200)}"
     ~spec:"a{color:oklch(.5 .304 200)}";
   check_modes "media min-width grammar"
     "@media (min-width: 700px) { a { color: red } }"

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -290,19 +290,19 @@ let test_color () =
 
   (* Modern color notations. pp preserves the authored function node; the
      equivalent hex form is the optimize+minify oracle. *)
-  check_color ~expected:"hsl(180 50% 25%)" ~optimized:"#206060"
+  check_color ~expected:"hsl(180 50%25%)" ~optimized:"#206060"
     "hsl(180deg 50% 25%)";
-  check_color ~expected:"hwb(90 10% 20%)" ~optimized:"#73cc1a"
+  check_color ~expected:"hwb(90 10%20%)" ~optimized:"#73cc1a"
     "hwb(90deg 10% 20%)";
-  check_color ~expected:"hsl(180 50% 25%/.5)" ~optimized:"#20606080"
+  check_color ~expected:"hsl(180 50%25%/.5)" ~optimized:"#20606080"
     "hsl(180 50% 25% / 0.5)";
-  check_color ~expected:"hwb(90 10% 20%)" ~optimized:"#73cc1a" "hwb(90 10% 20%)";
-  check_color ~expected:"hwb(90 10% 20%/.25)" ~optimized:"#73cc1a40"
+  check_color ~expected:"hwb(90 10%20%)" ~optimized:"#73cc1a" "hwb(90 10% 20%)";
+  check_color ~expected:"hwb(90 10%20%/.25)" ~optimized:"#73cc1a40"
     "hwb(90 10% 20% / 0.25)";
   (* CSS Color 4 section 4.2: alpha [<percentage>] is spec-equivalent to the
      corresponding [<number>] in [\[0, 1\]]; the printer canonicalizes to the
      number form per cssnano. *)
-  check_color ~expected:"hsl(180 50% 25%/30%)" ~optimized:"#2060604d"
+  check_color ~expected:"hsl(180 50%25%/30%)" ~optimized:"#2060604d"
     "hsl(180deg 50% 25% / 30%)";
   check_color ~optimized:"red" "color(srgb 1 0 0)";
   check_color ~expected:"color(display-p3 .8 .2 .1/.5)"
@@ -316,7 +316,7 @@ let test_color () =
     "oklch(50% 0.2 30)";
   (* Per CSS Color 4 section 5.1 the printer canonicalizes a percentage rgb()
      form to the equivalent named/hex spelling. *)
-  check_color ~expected:"rgb(100% 0% 0%)" ~optimized:"red" "rgb(100% 0% 0%)";
+  check_color ~expected:"rgb(100%0%0%)" ~optimized:"red" "rgb(100% 0% 0%)";
   check_color ~expected:"oklab(50%.1-.05)" ~optimized:"#88497e"
     "oklab(50% 0.1 -0.05)";
   check_color ~expected:"lch(50%40 120)" ~optimized:"#638038" "lch(50% 40 120)";
@@ -326,11 +326,11 @@ let test_color () =
   (* Mixed channel formats in modern rgb() syntax. Per CSS Color 4 section 5.1
      the printer canonicalizes a fully-opaque rgb() to the equivalent named/hex
      form when shorter, regardless of input channel format. *)
-  check_color ~optimized:"olive" "rgb(50% 128 0)";
-  check_color ~optimized:"red" "rgb(255 0% 0)";
+  check_color ~expected:"rgb(50%128 0)" ~optimized:"olive" "rgb(50% 128 0)";
+  check_color ~expected:"rgb(255 0%0)" ~optimized:"red" "rgb(255 0% 0)";
   check_color ~optimized:"navy" "rgb(0 0 50%)";
   (* Mixed channels with alpha (numeric) *)
-  check_color ~expected:"rgb(50% 128 0/.5)" ~optimized:"#80800080"
+  check_color ~expected:"rgb(50%128 0/.5)" ~optimized:"#80800080"
     "rgb(50% 128 0 / 0.5)";
 
   (* Named colors - all variants. Under minification, named colors serialize to
@@ -378,7 +378,7 @@ let test_color () =
   check_color ~expected:"var(--color,)" "var(--color,)";
 
   (* Custom properties inline mode tests with complex color fallbacks *)
-  check_color ~expected:"var(--theme-primary,hsl(210 75% 50%))"
+  check_color ~expected:"var(--theme-primary,hsl(210 75%50%))"
     ~optimized:"var(--theme-primary,#2080df)"
     "var(--theme-primary, hsl(210deg 75% 50%))";
   check_color ~expected:"var(--accent,rgb(255 0 128/80%))"
@@ -408,7 +408,7 @@ let test_color () =
   neg_cursor read_color "abc";
   neg_cursor read_color "#gg";
   check_color ~expected:"rgb(255 0 0)" ~optimized:"red" "rgb(256, 0, 0)";
-  check_color ~expected:"hsl(1 50% 50%)" ~optimized:"#bf4240"
+  check_color ~expected:"hsl(1 50%50%)" ~optimized:"#bf4240"
     "hsl(361, 50%, 50%)";
   neg_cursor read_color "";
   (* Unknown color keyword *)
@@ -433,9 +433,9 @@ let lossless_color () =
 let lossless_alpha () =
   decl_lossless ~prop:"color" ~into:"rgb(10 20 30/.74567)"
     "rgb(10 20 30 / 0.74567)";
-  decl_lossless ~prop:"color" ~into:"hsl(200 50% 40%/.74567)"
+  decl_lossless ~prop:"color" ~into:"hsl(200 50%40%/.74567)"
     "hsl(200 50% 40% / 0.74567)";
-  decl_lossless ~prop:"color" ~into:"hwb(200 20% 30%/.74567)"
+  decl_lossless ~prop:"color" ~into:"hwb(200 20%30%/.74567)"
     "hwb(200 20% 30% / 0.74567)";
   decl_lossless ~prop:"color" ~into:"oklch(.55432 .12276 180.4567/.74567)"
     "oklch(0.55432 0.12276 180.4567 / 0.74567)";
@@ -1294,8 +1294,8 @@ let test_rgb () =
   check_rgb "255 0 0";
   check_rgb "128 128 128";
   check_rgb "0 255 0";
-  check_rgb "50% 0% 100%";
-  check_rgb "255 50% 0";
+  check_rgb ~expected:"50%0%100%" "50% 0% 100%";
+  check_rgb ~expected:"255 50%0" "255 50% 0";
   (* RGB with variables *)
   check_rgb "var(--r) 0 0";
   check_rgb "var(--rgb-channels)";
@@ -1372,8 +1372,7 @@ let spec_values_l45_math_color () =
   check_color ~expected:"color-mix(in oklab,red var(--p),blue)"
     ~optimized:"color-mix(in oklab,red var(--p),#00f)"
     "color-mix(in oklab, var(--p) red, blue)";
-  check_color ~expected:"hsl(0 50% 50%)" ~optimized:"#bf4040"
-    "hsl(none 50% 50%)";
+  check_color ~expected:"hsl(0 50%50%)" ~optimized:"#bf4040" "hsl(none 50% 50%)";
   check_color ~expected:"rgb(from var(--c) r g b/.5)"
     "rgb(from var(--c) r g b / 50%)";
   check_color ~expected:"color(display-p3 none .5 1)"


### PR DESCRIPTION
Follow-up to #700. A percentage token ends at its `%`, so the custom-value serialiser drops the separator that follows it while the typed printer kept it, and a colour built through the API did not read back as itself. The gap after a `var()` stays, because a function is word-like at its end and the serialiser keeps that separator there.
