### PR TITLE
optimize: stop unquoting a string its registration rejects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -923,6 +923,11 @@ recorded cases carrying six minifiers' answers.
 
 ### Custom properties
 
+- `--minify` keeps the quotes on a `<string>` written to a custom property
+  whose `@property` syntax accepts only an ident sequence. The string matches
+  no arm of that registration, so it is invalid at computed-value time (CSS
+  Properties and Values API 1 (ED) sec. 2.4) and computes to the initial
+  value; unquoted, it computed the name instead (#704)
 - `Css.Variables.read_reference_body_as_string` reads the same `var()`
   argument list as `read_reference_body` and returns the name and the fallback
   as text, for a caller with no value type to pick a typed fallback reader

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -637,20 +637,6 @@ let try_promote_custom_with (type a) (syntax : a Variables.syntax) components =
   | Variables.Time -> Properties.try_read_custom_time components
   | _ -> None
 
-(* Does the registered syntax somewhere accept a [<custom-ident>] (possibly
-   under [+] / [#] / [|] modifiers)? When yes, a [<string>] whose content is a
-   multi-word identifier sequence is spec-equivalent (CSS Fonts 4 sec. 2.1.1 for
-   font-family-shaped registrations), so the promotion pass rewrites it to the
-   equivalent ident sequence before parsing. *)
-let rec syntax_accepts_ident_sequence : type a. a Variables.syntax -> bool =
-  function
-  | Variables.Custom_ident -> true
-  | Variables.Plus s -> syntax_accepts_ident_sequence s
-  | Variables.Hash s -> syntax_accepts_ident_sequence s
-  | Variables.Or (s1, s2) ->
-      syntax_accepts_ident_sequence s1 || syntax_accepts_ident_sequence s2
-  | _ -> false
-
 let promote_registered_custom_decl ~lossless registry decl =
   match decl with
   | Declaration
@@ -663,12 +649,7 @@ let promote_registered_custom_decl ~lossless registry decl =
       match Hashtbl.find_opt registry name with
       | None -> decl
       | Some (Variables.Syntax syntax) -> (
-          let components' =
-            if syntax_accepts_ident_sequence syntax then
-              Properties.unquote_font_family_strings components
-            else components
-          in
-          match try_promote_custom_with syntax components' with
+          match try_promote_custom_with syntax components with
           | Some typed ->
               Declaration.v ~important (Custom_property name)
                 (Custom_value
@@ -679,13 +660,7 @@ let promote_registered_custom_decl ~lossless registry decl =
                      layer;
                      meta;
                    })
-          | None when components' == components -> decl
-          | None ->
-              (* Promotion failed (e.g. [<custom-ident>+] has no typed promotion
-                 path yet) but the string-to-ident rewrite still produces the
-                 canonical opaque AST. *)
-              Declaration.v ~important (Custom_property name)
-                (Custom_value { value = Tokens components'; layer; meta })))
+          | None -> decl))
   | _ -> decl
 
 let promote_registered_custom_properties ~lossless (stmts : statement list) =

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -804,10 +804,14 @@ let canonical_unregistered_custom_font_distinct () =
     "unregistered --font custom property: quoted/unquoted stays distinct" false
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
 
-(* Registered custom property whose syntax matches the font-family grammar gets
-   typed-promoted to the font-family AST, so normalize_font_family applies the
-   same fold as the typed leaf. *)
-let canonical_registered_font_family_quoted_unquoted_equal () =
+(* [<custom-ident>+#] chains two multipliers where CSS Properties and Values API
+   1 (ED) sec. 5.2 allows one per syntax component, so the registration is
+   invalid and [--font] stays an ordinary unregistered custom property. The
+   unregistered case above already settles that state: the consumer is unknown,
+   so the two spellings stay distinct. No registration reaches the font-family
+   position that would make them one name either, [<family-name>] not being
+   among the syntax component names ED sec. 5.1 supports. *)
+let canonical_invalid_registration_font_distinct () =
   let registration =
     "@property \
      --font{syntax:\"<custom-ident>+#\";inherits:true;initial-value:serif}"
@@ -815,7 +819,7 @@ let canonical_registered_font_family_quoted_unquoted_equal () =
   let expected = registration ^ ".x{--font:\"Segoe UI Symbol\"}" in
   let actual = registration ^ ".x{--font:Segoe UI Symbol}" in
   Alcotest.(check bool)
-    "@property-registered font-family custom prop: quoted equals unquoted" true
+    "invalid @property registration: quoted/unquoted stays distinct" false
     (Cascade_diff.Css_compare.equal ~mode:`Canonical expected actual)
 
 (* Custom-property declarations in :root/:host don't have cascade-relevant
@@ -1485,8 +1489,8 @@ let suite =
         canonical_font_family_generic_keyword_distinct;
       Alcotest.test_case "canonical unregistered --font distinct" `Quick
         canonical_unregistered_custom_font_distinct;
-      Alcotest.test_case "canonical registered --font quoted vs unquoted" `Quick
-        canonical_registered_font_family_quoted_unquoted_equal;
+      Alcotest.test_case "canonical invalid --font registration distinct" `Quick
+        canonical_invalid_registration_font_distinct;
       Alcotest.test_case "canonical :root custom-props alphabetised" `Quick
         canonical_root_custom_props_permutation_equal;
       Alcotest.test_case "canonical :host custom-props alphabetised" `Quick

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -955,6 +955,48 @@ let test_promote_registered_reaches_at_rule_declarations () =
     "@supports-condition --x{--c:rgb(255 0 0)}"
     "@supports-condition --x{--c:red}"
 
+(* CSS Fonts 4 sec. 2.1.1 spells one [<family-name>] either as a [<string>] or
+   as a [<custom-ident>+], but the two only name the same family in a
+   font-family position. No registration reaches that position: [<family-name>]
+   is not among the syntax component names CSS Properties and Values API 1 (ED)
+   sec. 5.1 supports, so [<custom-ident>+] is the generic ident-sequence grammar
+   and a quoted string does not match it. The declaration is then invalid at
+   computed-value time (ED sec. 2.4) and computes to the registration's initial
+   value, which unquoting it would replace with the name itself. *)
+let test_promote_registered_keeps_unmatched_string_quoted () =
+  let check name registration body expected =
+    Alcotest.(check string)
+      name (registration ^ expected)
+      (minify (Css.of_string_exn ~strict:false (registration ^ body)))
+  in
+  let idents =
+    "@property \
+     --a{syntax:\"<custom-ident>+\";inherits:false;initial-value:fallbackname}"
+  in
+  check "a multi-word string stays quoted" idents ":root{--a:\"Segoe UI\"}"
+    ":root{--a:\"Segoe UI\"}";
+  check "a single-word string stays quoted" idents ":root{--a:\"Helvetica\"}"
+    ":root{--a:\"Helvetica\"}";
+  check "the ident sequence the registration accepts stays bare" idents
+    ":root{--a:Segoe UI}" ":root{--a:Segoe UI}";
+  (* [<string>] is a registrable component of its own (ED sec. 5.1), so under
+     this alternation both spellings match and each computes to the arm it
+     names: a [content] use reads the quoted one back as text and the bare one
+     not at all. *)
+  let alternation =
+    "@property \
+     --b{syntax:\"<string>|<custom-ident>+\";inherits:false;initial-value:fallbackname}"
+  in
+  check "an alternation keeps the string arm" alternation
+    ":root{--b:\"Segoe UI\"}" ":root{--b:\"Segoe UI\"}";
+  (* A value that does match its registration is still promoted, so no reading
+     of this test is satisfied by switching the pass off. *)
+  let color =
+    "@property --c{syntax:\"<color>\";inherits:false;initial-value:red}"
+  in
+  check "a matching value is still typed-promoted" color
+    ":root{--c:rgb(255 0 0)}" ":root{--c:red}"
+
 (* A colour function carrying a var() is a pending-substitution value (CSS
    Variables L1 section 3): its arity and legacy/modern separator style aren't
    known until substitution, so minify+optimize must keep it verbatim - never
@@ -1660,6 +1702,9 @@ let optimize_tests =
     ( "promote registered reaches at-rule declarations",
       `Quick,
       test_promote_registered_reaches_at_rule_declarations );
+    ( "promote registered keeps an unmatched string quoted",
+      `Quick,
+      test_promote_registered_keeps_unmatched_string_quoted );
     ( "deduplicate declarations preserves physical identity",
       `Quick,
       test_deduplicate_declarations_physical_identity );


### PR DESCRIPTION
A `<string>` written to a custom property whose `@property` syntax accepts only an ident sequence was rewritten into that sequence, which made a declaration match a registration it does not match: it then computed to the name instead of the registration's initial value.

The branch also corrects a test oracle that asserted the two spellings equal. Its registration chains two multipliers where CSS Properties and Values API 1 allows one per syntax component, so the property is unregistered and the unregistered case beside it already pins the two as distinct.
