### PR TITLE
diff: equate a one-word family name quoted and unquoted

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1082,6 +1082,9 @@ recorded cases carrying six minifiers' answers.
   value shown was read off the comparison key, so a custom property holding a
   quoted multi-word family name was reported unquoted on both sides, a spelling
   neither file held (#702)
+- A one-word family name in a custom property compares equal quoted and
+  unquoted when a generic family proves the value is a font stack. `"serif"`
+  and the other CSS Fonts 4 sec. 2.1.1 exclusions stay distinct (#705)
 
 ### Library
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1538,13 +1538,14 @@ val declaration_value_for_equivalence : declaration -> string
     [+] or [-], and the space beside a [var()], [env()] or [attr()] that sec.
     2.5 substitutes textually into its neighbour, keep two spellings apart.
 
-    A quoted multi-word [<string>] in that stream is rewritten as the equivalent
-    unquoted [<ident>] sequence, when a generic family in the stream proves the
-    stream is a font-family list, where CSS Fonts 4 sec. 2.1.1 spells the one
-    name both ways: [--font: ui-sans-serif,"Noto Color Emoji"] and
-    [--font: ui-sans-serif,Noto Color Emoji] compare equal. Without that proof
-    the stream is arbitrary tokens, in which one [<string>] is not an [<ident>]
-    sequence, and the two spellings keep distinct keys.
+    A quoted family name in that stream is rewritten as the equivalent unquoted
+    [<ident>] sequence, one word or several, when a generic family in the stream
+    proves the stream is a font-family list, where CSS Fonts 4 sec. 2.1.1 spells
+    the one name both ways: [--font: ui-sans-serif,"Noto Color Emoji"] and
+    [--font: ui-sans-serif,Noto Color Emoji] compare equal, as do
+    [--font: "Arial",sans-serif] and [--font: Arial,sans-serif]. Without that
+    proof the stream is arbitrary tokens, in which one [<string>] is not an
+    [<ident>] sequence, and the two spellings keep distinct keys.
 
     Not for emission, where every one of these forms stays verbatim. *)
 

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -138,12 +138,12 @@ let rec custom_declaration_layer = function
   | Theme_guarded { decl; _ } -> custom_declaration_layer decl
 
 (* Equivalence-only normalisation for structural diffing: rewrite a quoted
-   multi-word [<string>] in a custom-property stream as the equivalent unquoted
-   [<ident>] sequence. The forms substitute identically into [font-family] so
-   cascade treats them as equal, but keeps both verbatim on output (unquoting an
-   opaque custom property could corrupt a [content] use). Gated on a generic
-   family being present, since an unregistered property is otherwise
-   type-unknown. *)
+   family name in a custom-property stream as the equivalent unquoted [<ident>]
+   sequence, one word or several. The forms substitute identically into
+   [font-family] so cascade treats them as equal, but keeps both verbatim on
+   output (unquoting an opaque custom property could corrupt a [content] use).
+   Gated on a generic family being present, since an unregistered property is
+   otherwise type-unknown. *)
 let unquote_custom_font_strings = function
   | Declaration
       {

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -118,11 +118,12 @@ val map_custom_value : (string -> string) -> declaration -> declaration
     unchanged. *)
 
 val unquote_custom_font_strings : declaration -> declaration
-(** [unquote_custom_font_strings d] rewrites a quoted multi-word [<string>] in a
+(** [unquote_custom_font_strings d] rewrites a quoted family name in a
     custom-property token stream as the equivalent unquoted [<ident>] sequence,
-    when a generic family in the stream proves the stream is a font-family list.
-    Equivalence-only normalisation for structural diffing; a stream without that
-    proof, and any other declaration, passes through unchanged. *)
+    one word or several, when a generic family in the stream proves the stream
+    is a font-family list. Equivalence-only normalisation for structural
+    diffing; a stream without that proof, and any other declaration, passes
+    through unchanged. *)
 
 val canonicalize_custom_whitespace : declaration -> declaration
 (** [canonicalize_custom_whitespace d] drops from a custom-property token stream

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -588,6 +588,12 @@ let is_font_family_keyword_name s =
 
 let can_unquote_font_family_name s =
   match String.split_on_char ' ' s with
+  | [] -> false
+  | [ w ] ->
+      (* A [<custom-ident>+] of one word is still a [<custom-ident>+], so a lone
+         name unquotes as a sequence does, against the wider exclusion: the
+         words only a lone position reads as a keyword are excluded too. *)
+      is_font_family_ident_word w && not (is_font_family_keyword_name w)
   | _ :: _ :: _ as words ->
       (* The exclusion is stated per identifier, so it holds at every word of a
          [<custom-ident>+] sequence and not only at a lone one: [inherit test]
@@ -597,16 +603,13 @@ let can_unquote_font_family_name s =
         (fun w ->
           is_font_family_ident_word w && not (is_font_family_reserved_word w))
         words
-  | _ -> false
 
-(* Walk a component stream and rewrite each [<string>] token whose content is a
-   multi-word identifier sequence (the [can_unquote_font_family_name] guard) as
-   an explicit [<ident>] sequence. Used by the [@property]-registered custom
-   property promotion path when the registered syntax accepts [<custom-ident>+]
-   - the two forms ([custom-ident>+] vs [<string>]) are spec-equivalent there
-   (CSS Fonts 4 sec. 2.1.1), so the rewrite produces a single canonical AST. The
-   guard keeps a name holding a reserved word quoted, so no rewrite turns a word
-   of the sequence into a keyword. *)
+(* Walk a component stream and rewrite each [<string>] token whose content is an
+   identifier sequence (the [can_unquote_font_family_name] guard) as an explicit
+   [<ident>] sequence. Only for a stream a generic family has proven to be a
+   font stack, where CSS Fonts 4 sec. 2.1.1 makes the two forms one name. The
+   guard keeps a name holding an excluded word quoted, so no rewrite turns a
+   word of the sequence into a keyword. *)
 let unquote_font_family_strings components =
   let changed = ref false in
   let words_of s =

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -78,13 +78,13 @@ val read_custom_property_value :
 
 val unquote_font_family_strings : custom_value -> custom_value
 (** [unquote_font_family_strings components] rewrites each [<string>] token
-    whose content is a multi-word identifier sequence as the equivalent
-    [<ident> <whitespace> <ident> ...] component sequence. Used by the
-    [@property]-registered custom-property promotion when the registered syntax
-    accepts [<custom-ident>+] (CSS Fonts 4 sec. 2.1.1 makes the two forms
-    equivalent in font-family-typed positions). A single-word string, a string
+    whose content is an identifier sequence as the equivalent
+    [<ident> <whitespace> <ident> ...] component sequence, which CSS Fonts 4
+    sec. 2.1.1 spells as the same [<font-family-name>], one word or several.
+    Only for a stream a generic family has proven to be a font stack. A string
     holding a word that sec. 2.1.1 excludes from [<custom-ident>], and any token
-    that isn't a [<string>] pass through unchanged. *)
+    that isn't a [<string>], pass through unchanged; a name of one word also
+    clears [emoji], [fangsong] and [none]. *)
 
 val canonicalize_math_whitespace_components : custom_value -> custom_value
 (** [canonicalize_math_whitespace_components components] drops the whitespace of

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -553,12 +553,14 @@ let normalize_custom_value v =
   go 0 None;
   Buffer.contents buf
 
-(* A multi-word font name spells the same family quoted or as the bare ident
-   sequence it unquotes to (CSS Fonts 4 sec. 2.1.1), and a custom property
-   holding a font stack substitutes either form identically into [font-family].
-   Emission keeps whichever the author wrote, so the projection folds the quoted
-   form onto the ident sequence - the same normalisation the structural
-   comparator applies through {!Css.declaration_value_for_equivalence}. *)
+(* A font name spells the same family quoted or as the bare ident sequence it
+   unquotes to, one word or several (CSS Fonts 4 sec. 2.1.1). A bare generic
+   family in the stream is what proves the custom property holds a font stack;
+   with that proof either form substitutes identically into [font-family], and
+   without it the stream is arbitrary tokens and neither form may move. Emission
+   keeps whichever the author wrote, so the projection folds the quoted form
+   onto the ident sequence - the same normalisation the structural comparator
+   applies through {!Css.declaration_value_for_equivalence}. *)
 let normalize_custom_declaration d =
   Declaration.unquote_custom_font_strings
     (Declaration.map_custom_value normalize_custom_value d)

--- a/lib/rule_order.mli
+++ b/lib/rule_order.mli
@@ -41,8 +41,9 @@ val canonicalize : Stylesheet.statement list -> Stylesheet.statement list
     is the identity media type. That direction loses support in a Level 3
     parser, so it belongs to the projection rather than to emission.
 
-    A custom property holding a font stack has each quoted multi-word family
-    name rewritten as the [<ident>] sequence it unquotes to, which CSS Fonts 4
+    A bare generic family in a custom property's token stream proves the stream
+    is a font stack, and each quoted family name in it is then rewritten as the
+    [<ident>] sequence it unquotes to, one word or several, which CSS Fonts 4
     sec. 2.1.1 makes the same family name. Emission keeps whichever spelling the
     author wrote, since unquoting an opaque token stream could corrupt a
     [content] use, so again only the projection can bring the two together.

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3050,12 +3050,15 @@ let spec_custom_tokens () =
   neg_cursor read_declaration "-x: value";
   neg_cursor read_declaration "--x"
 
-(* The structural-diff key unquotes a multi-word family name in a custom
-   property only when a generic family in the stream proves the stream is a
-   font-family list, where CSS Fonts 4 sec. 2.1.1 spells the one name both ways.
-   A custom property is otherwise an arbitrary token stream, and dropping the
-   quotes turns one [<string>] into two [<ident>]s, which is a different value
-   wherever the property substitutes into another grammar. *)
+(* CSS Fonts 4 sec. 2.1.1 gives a [<font-family-name>] two spellings, a
+   [<string>] and a [<custom-ident>+], and they name the same family whether
+   that ident sequence runs to one word or several, so the structural-diff key
+   folds the quoted spelling onto the bare one. The fold needs a generic family
+   in the stream to prove the stream is a font-family list: a custom property is
+   otherwise an arbitrary token stream, in which dropping the quotes is a
+   different value wherever the property substitutes into another grammar. A
+   name the section excludes from [<custom-ident>] keeps its quotes, since
+   unquoting it would name the keyword instead of the family. *)
 let custom_font_equivalence_key () =
   let key css =
     Css.declaration_value_for_equivalence (Css.Declaration.of_string css)
@@ -3070,10 +3073,27 @@ let custom_font_equivalence_key () =
       (* No generic family, no proof: the quotes are part of the value. *)
       ({|--f: a,"Segoe UI",b|}, {|a,"Segoe UI",b|});
       ({|--f: a,Segoe UI,b|}, "a,Segoe UI,b");
-      (* The rewrite spans a [<string>] holding an [<ident>] sequence, so a
-         single-word name keeps whichever spelling it was written with. *)
-      ({|--f: "Arial",sans-serif|}, {|"Arial",sans-serif|});
+      (* A [<custom-ident>+] of one word is still a [<custom-ident>+], so the
+         lone name reaches the unquoted spelling from either side of the generic
+         family. *)
+      ({|--f: "Arial",sans-serif|}, "Arial,sans-serif");
       ({|--f: Arial,sans-serif|}, "Arial,sans-serif");
+      ({|--f: sans-serif,"Arial"|}, "sans-serif,Arial");
+      (* The gate rules the lone name as it rules the sequence. *)
+      ({|--f: "Arial",b|}, {|"Arial",b|});
+      ({|--f: Arial,b|}, "Arial,b");
+      (* The words sec. 2.1.1 excludes from [<custom-ident>] keep their quotes:
+         [font-family:serif] names the generic family and [font-family:inherit]
+         the CSS-wide keyword, so unquoting either loses the author's family. *)
+      ({|--f: "serif",sans-serif|}, {|"serif",sans-serif|});
+      ({|--f: "default",sans-serif|}, {|"default",sans-serif|});
+      ({|--f: "inherit",sans-serif|}, {|"inherit",sans-serif|});
+      ({|--f: "emoji",sans-serif|}, {|"emoji",sans-serif|});
+      (* A name with no [<custom-ident>] spelling at all keeps its quotes: [+]
+         is no ident code point, and a word opening on a digit tokenises as a
+         number rather than an ident. *)
+      ({|--f: "Foo+Bar",sans-serif|}, {|"Foo+Bar",sans-serif|});
+      ({|--f: "Foo Bar 2",sans-serif|}, {|"Foo Bar 2",sans-serif|});
     ];
   let equal a b = String.equal (key a) (key b) in
   Alcotest.(check bool)
@@ -3083,8 +3103,14 @@ let custom_font_equivalence_key () =
     "without one they stay distinct" false
     (equal {|--f: a,"Segoe UI",b|} {|--f: a,Segoe UI,b|});
   Alcotest.(check bool)
-    "a single-word name stays distinct" false
-    (equal {|--f: "Arial",sans-serif|} {|--f: Arial,sans-serif|})
+    "a single-word name equates too" true
+    (equal {|--f: "Arial",sans-serif|} {|--f: Arial,sans-serif|});
+  Alcotest.(check bool)
+    "a single-word name without a generic family stays distinct" false
+    (equal {|--f: "Arial",b|} {|--f: Arial,b|});
+  Alcotest.(check bool)
+    "a quoted generic family stays distinct from the keyword" false
+    (equal {|--f: "serif",sans-serif|} {|--f: serif,sans-serif|})
 
 let color_functions () =
   (* color() with alternate spaces and alpha *)


### PR DESCRIPTION
A quoted one-word family name in a custom property read as a difference from the bare ident spelling, though CSS Fonts 4 sec. 2.1.1 makes the two one family name once a generic family in the stream proves the value is a font stack. Emission is unchanged: both spellings still print as written.
