### PR TITLE
diff: print a rule body as declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1085,6 +1085,11 @@ recorded cases carrying six minifiers' answers.
 - A one-word family name in a custom property compares equal quoted and
   unquoted when a generic family proves the value is a font stack. `"serif"`
   and the other CSS Fonts 4 sec. 2.1.1 exclusions stay distinct (#705)
+- `--diff=tree` prints the body of an added or removed rule as declarations,
+  with the separator and the `!important` flag. A rule gaining
+  `color: red !important` read like one gaining `color: red`, and a value
+  holding a colon of its own gave no sign of where the property name ended
+  (#706)
 
 ### Library
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -184,6 +184,17 @@ let pp_children ~style ~parent_prefix buf render =
         add_strings buf
           [ child_indent ~style ~parent_prefix; "..."; string_of_int n; noun ]
 
+let decl_with_important decl value =
+  if Css.declaration_is_important decl then
+    String.concat "" [ value; " !important" ]
+  else value
+
+(* The one answer to how a declaration reads in the report: the author's own
+   spelling, which keeps a unit difference like [0px] against [0] visible, and
+   the flag, without which a declaration and the one it outranks read alike. *)
+let decl_shown_value decl =
+  decl_with_important decl (Css.declaration_value ~minify:false decl)
+
 (* Print a list of CSS declarations with an action prefix *)
 let pp_declarations ?(style = default_style) ?(parent_prefix = "") buf action
     decls =
@@ -200,17 +211,16 @@ let pp_declarations ?(style = default_style) ?(parent_prefix = "") buf action
   in
   List.iter
     (fun decl ->
-      let prop_name = Css.declaration_name decl in
-      (* Use non-minified values to preserve unit differences like 0px vs 0 *)
-      let prop_value = Css.declaration_value ~minify:false decl in
-      let truncated_value =
-        String_diff.truncate_middle default_truncation_length prop_value
+      let shown =
+        String_diff.truncate_middle default_truncation_length
+          (decl_shown_value decl)
       in
-      Buffer.add_string buf
-        (indent
-        ^ style_text ~color:style.color action
-            (prefix_symbol ^ " " ^ prop_name ^ " " ^ truncated_value)
-        ^ "\n"))
+      let line =
+        String.concat ""
+          [ prefix_symbol; " "; Css.declaration_name decl; ": "; shown ]
+      in
+      add_strings buf
+        [ indent; style_text ~color:style.color action line; "\n" ])
     decls
 
 let pp_property_diff ?(style = default_style) ?(parent_prefix = "") buf
@@ -1196,11 +1206,6 @@ let strings_of_rule (stmt : Css.statement) =
       | Declarations decls -> ("&", decls)
       | _ -> (statement_head stmt, Css.Stylesheet.statement_declarations stmt))
 
-let decl_with_important decl value =
-  if Css.declaration_is_important decl then
-    String.concat "" [ value; " !important" ]
-  else value
-
 let decl_to_prop_value decl =
   ( Css.declaration_name decl,
     decl_with_important decl (Css.declaration_value_for_equivalence decl) )
@@ -1211,9 +1216,7 @@ let decl_to_prop_value decl =
    folds the spellings the two sides chose onto one. *)
 let decl_to_reported_value decl =
   let name, key = decl_to_prop_value decl in
-  ( name,
-    (key, decl_with_important decl (Css.declaration_value ~minify:false decl))
-  )
+  (name, (key, decl_shown_value decl))
 
 let compare_prop_value (name1, value1) (name2, value2) =
   let by_name = String.compare name1 name2 in
@@ -1954,7 +1957,8 @@ let handle_structural_diff rules1 rules2 =
 
 let rule_diffs rules1 rules2 = handle_structural_diff rules1 rules2
 
-(* The values a rule writes for [name], in the order it writes them. *)
+(* Each key and shown value a rule writes for [name], in the order it writes
+   them. *)
 let occurrences_of name props =
   List.filter_map (fun (p, v) -> if p = name then Some v else None) props
 

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -206,8 +206,8 @@ the first file given, then the second.
   --- one.css
   +++ many.css
   ├─ .y
-  │     + top 0
+  │     + top: 0
   └─ .z
-        + left 0
+        + left: 0
   
   [1]

--- a/test/cli/diff_nested_block.t
+++ b/test/cli/diff_nested_block.t
@@ -43,6 +43,6 @@ declaration in the selector column.
   │     - color
   └─ .a { & } (1 added)
      └─ &
-           + color red
+           + color: red
   
   [1]

--- a/test/cli/diff_reorder_same_position.t
+++ b/test/cli/diff_reorder_same_position.t
@@ -23,7 +23,7 @@ coordinate rather than pairing position 1 with position 1.
   --- reversed_ref.css
   +++ reversed_tw.css
   └─ .z
-        - --e 9
+        - --e: 9
   Rules reordered (2 rules):
   ├─ .b (position 2) ↔  .c (position 0)
   └─ .a (moved)
@@ -46,7 +46,7 @@ The same pair inside a container reports through the container renderer.
   +++ layer_tw.css
   └─ @layer u (1 removed, 2 reordered)
      ├─ .z
-     │     - --e 9
+     │     - --e: 9
      ├─ .b (position 2) ↔  .c (position 0)
      └─ .a (moved)
   
@@ -69,7 +69,7 @@ because `.z` left.
   --- shifted_ref.css
   +++ shifted_tw.css
   └─ .z
-        - --e 9
+        - --e: 9
   Rules reordered (1 rules):
   └─ .a (moved)
   

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -32,11 +32,11 @@ rather than as a loss and a gain.
   └─ @layer utilities (2 reordered, 2 rearranged)
      ├─ .drop-shadow-blue-500\/50 (position 3) ↔  .drop-shadow-indigo-500 (position 0)
      ├─ .drop-shadow-blue-500\/50 (moved between rules)
-     │       --tw-drop-shadow-color #3080ff80
-     │       --tw-drop-shadow var(--tw-drop-shadow-size)
+     │       --tw-drop-shadow-color: #3080ff80
+     │       --tw-drop-shadow: var(--tw-drop-shadow-size)
      ├─ .drop-shadow-indigo-500 (moved between rules)
-     │       --tw-drop-shadow-color oklch(.585 .233 277.117)
-     │       --tw-drop-shadow var(--tw-drop-shadow-size)
+     │       --tw-drop-shadow-color: oklch(.585 .233 277.117)
+     │       --tw-drop-shadow: var(--tw-drop-shadow-size)
      ├─ .drop-shadow-indigo-500 (position 0) ↔  .drop-shadow-indigo-500 (position 4)
      └─ @supports (color: color-mix(in lab,red,red)) (1 reordered)
         └─ .drop-shadow-blue-500\/50 ↔  .drop-shadow-indigo-500
@@ -60,8 +60,8 @@ A top-level group reports the same way as one inside a container.
   --- split.css
   +++ joined.css
   └─ .a (moved between rules)
-          color red
-          margin 0
+          color: red
+          margin: 0
   
   [1]
 
@@ -81,8 +81,8 @@ A top-level group reports the same way as one inside a container.
   +++ joined_layer.css
   └─ @layer u (1 rearranged)
      └─ .a (moved between rules)
-             color red
-             margin 0
+             color: red
+             margin: 0
   
   [1]
 
@@ -100,7 +100,7 @@ A declaration that does not survive is reported as a loss.
   --- split.css
   +++ lost.css
   └─ .a
-        - margin 0
+        - margin: 0
   
   [1]
 
@@ -147,11 +147,11 @@ gains or loses a declaration, so neither may be reported as modified.
   └─ @layer utilities (1 reordered, 2 rearranged)
      ├─ .x (position 2) ↔  .y (position 0)
      ├─ .x (moved between rules)
-     │       --c 1
-     │       --d 3
+     │       --c: 1
+     │       --d: 3
      ├─ .y (moved between rules)
-     │       --c 4
-     │       --d 6
+     │       --c: 4
+     │       --d: 6
      └─ @supports (zoo: bar) (1 reordered)
         └─ .x ↔  .y
   
@@ -197,7 +197,7 @@ the exact-match path, which names the move once as well.
   +++ swap_tw.css
   └─ @layer u (1 removed, 1 reordered)
      ├─ .z
-     │     - --e 9
+     │     - --e: 9
      └─ .x ↔  .y
   
   [1]

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -1374,29 +1374,53 @@ let key_keeps_two_typed_values_apart =
   distinct_value ~name:"two colours are a difference" "color:#ff0000"
     "color:#ff1100"
 
+(* Every affix the report of [expected] against [actual] has to read. *)
+let report_reads ~name ~expected ~actual affixes =
+  let out = render (diff_of ~expected ~actual) in
+  List.iter
+    (fun affix ->
+      Alcotest.(check bool)
+        (String.concat "" [ name; " reads "; affix ])
+        true
+        (Astring.String.is_infix ~affix out))
+    affixes
+
 (* The key is for matching, not for display: a pair that still differs prints
    the bytes each side's author wrote, not the spelling the key folded them
    onto, which is a value neither file holds. *)
 let report_quotes_the_author_spelling () =
-  let quotes ~name ~expected ~actual affixes =
-    let out = render (diff_of ~expected ~actual) in
-    List.iter
-      (fun affix ->
-        Alcotest.(check bool)
-          (String.concat "" [ name; " reads "; affix ])
-          true
-          (Astring.String.is_infix ~affix out))
-      affixes
-  in
-  quotes ~name:"a custom stream" ~expected:"a{--k:calc(100% - 10px)}"
+  report_reads ~name:"a custom stream" ~expected:"a{--k:calc(100% - 10px)}"
     ~actual:"a{--k:calc(100%- 10px)}"
     [ "calc(100% - 10px)"; "calc(100%- 10px)" ];
-  quotes ~name:"a typed colour" ~expected:"a{color:#ff0000}"
+  report_reads ~name:"a typed colour" ~expected:"a{color:#ff0000}"
     ~actual:"a{color:#ff1100}" [ "#ff0000"; "#ff1100" ];
-  quotes ~name:"a quoted family"
+  report_reads ~name:"a quoted family"
     ~expected:"a{--f:ui-sans-serif,\"Noto Color Emoji\"}"
     ~actual:"a{--f:ui-serif,\"Noto Color Emoji\"}"
     [ "ui-sans-serif,\"Noto Color Emoji\""; "ui-serif,\"Noto Color Emoji\"" ]
+
+(* An added or removed rule shows its whole body, and that body decides which
+   declaration wins: [color:red] and [color:red !important] are not the same
+   rule. Dropping the flag reports the two as one. *)
+let whole_rule_body_carries_the_flag () =
+  let base = "a{color:blue}" in
+  let gained = "a{color:blue}b{color:red!important;margin:0}" in
+  report_reads ~name:"an added rule" ~expected:base ~actual:gained
+    [ "+ color: red !important"; "+ margin: 0" ];
+  report_reads ~name:"a removed rule" ~expected:gained ~actual:base
+    [ "- color: red !important"; "- margin: 0" ]
+
+(* A value may hold a colon of its own, so the body needs the separator a
+   declaration is written with to say where the property name ended. *)
+let whole_rule_body_separates_name_from_value () =
+  let base = "a{color:blue}" in
+  let gained =
+    "a{color:blue}b{background:url(http://x/y.png);--k:var(--u, 1px)}"
+  in
+  report_reads ~name:"a url value" ~expected:base ~actual:gained
+    [ "+ background: url(http://x/y.png)" ];
+  report_reads ~name:"a custom property" ~expected:base ~actual:gained
+    [ "+ --k: var(--u, 1px)" ]
 
 let suite =
   ( "tree_diff",
@@ -1584,6 +1608,10 @@ let suite =
         key_keeps_two_typed_values_apart;
       Alcotest.test_case "report quotes the author spelling" `Quick
         report_quotes_the_author_spelling;
+      Alcotest.test_case "whole rule body carries the flag" `Quick
+        whole_rule_body_carries_the_flag;
+      Alcotest.test_case "whole rule body separates name from value" `Quick
+        whole_rule_body_separates_name_from_value;
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "pp_rule_diff_simple does not crash" `Quick
         pp_rule_diff_simple_ok;


### PR DESCRIPTION
`--diff=tree` used to show the body of an added or removed rule as a property and a value separated by a space, so a rule gaining `color: red !important` read like one gaining `color: red`, and a value holding a colon of its own gave no sign of where the property name ended.

Follow-up to #702.
