### PR TITLE
variables: read one multiplier per @property syntax component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -207,6 +207,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- An `@property` syntax component carries at most one multiplier. A chained one
+  such as `"<custom-ident>+#"` drops the registration the way a browser does,
+  where cascade used to accept it and type a property left unregistered (#707)
 - Trailing content inside a parenthesised or bracketed sub-expression makes the
   whole value invalid, as it does in a browser. `width: calc((1px 2px))` used
   to keep the prefix a reader recognised and drop the rest (#701)

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -212,30 +212,27 @@ let apply_syntax_modifier r (Syntax inner) (modifier : char option) : any_syntax
         (String.concat ""
            [ "Unsupported CSS syntax modifier: '"; String.make 1 c; "'" ])
 
-(* CSS Properties and Values API 1 allows one modifier per syntax-component, but
-   the [+#] chain is the natural shape for font-family-like registrations, so
-   allow exactly that ([<custom-ident>+#]); [++], [##] and the reverse [#+]
-   still reject via the unrecognised body. *)
-let split_syntax_modifiers s : string * char list =
+(* CSS Properties and Values API 1 (ED) sec. 5.4.3 sets a component's multiplier
+   from a single [+] or [#] and returns, so a component carries at most one.
+   Sec. 5.4.2 accepts only EOF or [|] after a component, which fails the whole
+   syntax definition on a second multiplier; here that one is left in the body
+   for [read_simple_syntax_component] to reject, the route [++], [##] and [#+]
+   already take. *)
+let split_syntax_modifier s : string * char option =
   let n = String.length s in
-  if n = 0 then (s, [])
+  if n = 0 then (s, None)
   else
     let last = s.[n - 1] in
-    if last <> '+' && last <> '#' then (s, [])
-    else if n >= 2 && s.[n - 2] = '+' && last = '#' then
-      (String.sub s 0 (n - 2), [ '+'; '#' ])
-    else (String.sub s 0 (n - 1), [ last ])
+    if last <> '+' && last <> '#' then (s, None)
+    else (String.sub s 0 (n - 1), Some last)
 
 let read_syntax (r : Cursor.t) : any_syntax =
   (* CSS @property syntax values must be quoted strings per spec *)
   let s = Cursor.string r in
   let read_component part =
-    let body, modifiers = split_syntax_modifiers (String.trim part) in
+    let body, modifier = split_syntax_modifier (String.trim part) in
     if body = "" then Cursor.err_invalid r "empty CSS syntax component";
-    let base = read_simple_syntax_component r body in
-    List.fold_left
-      (fun acc m -> apply_syntax_modifier r acc (Some m))
-      base modifiers
+    apply_syntax_modifier r (read_simple_syntax_component r body) modifier
   in
   if String.contains s '|' then
     let parts = String.split_on_char '|' s in

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -517,6 +517,51 @@ let spec_property_syntax_edges () =
   neg_cursor read_any_syntax "\"<unknown>\"";
   neg_cursor read_any_syntax "\"<length\""
 
+(* CSS Properties and Values API 1 (ED) sec. 5.4.3 "Consume a Syntax Component"
+   consumes at most one multiplier: after the component name it consumes a
+   single [+] or [#] and returns. Sec. 5.4.2 then accepts only EOF or [|] after
+   a component, so a second multiplier fails the whole syntax definition. Sec.
+   3.1 makes an unreadable syntax string an invalid descriptor, which leaves
+   [@property] without the descriptor it requires and drops the registration -
+   the state [<custom-ident>#+], [<custom-ident>++] and [<custom-ident>##]
+   already reach. Sec. 5.3 puts a multiplier inside an alternation arm, where
+   one per arm stays valid. *)
+let spec_property_syntax_multiplier_chain () =
+  check_any_syntax "\"<custom-ident>+\"";
+  check_any_syntax "\"<custom-ident>#\"";
+  neg_cursor read_any_syntax "\"<custom-ident>+#\"";
+  neg_cursor read_any_syntax "\"<custom-ident>#+\"";
+  neg_cursor read_any_syntax "\"<custom-ident>++\"";
+  neg_cursor read_any_syntax "\"<custom-ident>##\"";
+  (* One multiplier per alternation arm, on either side of the [|]. *)
+  check_any_syntax ~expected:"\"<length>+|auto\"" "\"<length>+ | auto\"";
+  check_any_syntax ~expected:"\"auto|<color>#\"" "\"auto | <color>#\"";
+  neg_cursor read_any_syntax "\"<length>+# | auto\"";
+  neg_cursor read_any_syntax "\"auto | <color>#+\"";
+  (* The registration a rejected syntax string costs. An [initial-value] of two
+     idents parses only under the [+], so the surviving rule is one that kept
+     its multiplier and typed the value at it. *)
+  let render css =
+    match Css.of_string ~strict:false css with
+    | Ok parsed -> Css.to_string ~minify:true parsed.stylesheet
+    | Error _ -> Alcotest.failf "failed to parse: %s" css
+  in
+  let sheet syn =
+    String.concat ""
+      [
+        "@property --p{syntax:\"";
+        syn;
+        "\";inherits:false;initial-value:a b}.x{color:red}";
+      ]
+  in
+  Alcotest.(check string)
+    "one multiplier registers and types the initial value"
+    (sheet "<custom-ident>+")
+    (render (sheet "<custom-ident>+"));
+  Alcotest.(check string)
+    "chained multipliers drop the registration" ".x{color:red}"
+    (render (sheet "<custom-ident>+#"))
+
 (* Not a roundtrip test *)
 let test_syntax () =
   (* Syntax checking is not available in current implementation *)
@@ -702,6 +747,9 @@ let tests =
     ("custom property name edges", `Quick, custom_property_name_edges);
     ("any_syntax", `Quick, test_any_syntax);
     ("spec property syntax descriptor edges", `Quick, spec_property_syntax_edges);
+    ( "spec property syntax multiplier chain",
+      `Quick,
+      spec_property_syntax_multiplier_chain );
     ("vars of calc", `Quick, test_vars_of_calc);
     ("vars of property", `Quick, test_vars_of_property);
     ("spec vars of property matrix", `Quick, spec_vars_of_property_matrix);


### PR DESCRIPTION
A syntax component carries at most one multiplier, so `"<custom-ident>+#"` makes the whole `@property` rule invalid. Cascade used to accept the chain and register the property, which changed what every declaration of it computed to; it now drops the rule, the route `#+`, `++` and `##` already took.
