### PR TITLE
grid: reject reserved idents as line names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -210,6 +210,11 @@ recorded cases carrying six minifiers' answers.
 - An `@property` syntax component carries at most one multiplier. A chained one
   such as `"<custom-ident>+#"` drops the registration the way a browser does,
   where cascade used to accept it and type a property left unregistered (#707)
+- Grid line names reject the idents that are not `<custom-ident>`s in that
+  position: `span`, `auto`, `default` and the CSS-wide keywords, in every ASCII
+  case. `grid-template-columns: [span] 1px` and `grid-row-start: 3 auto` are
+  dropped the way a browser drops them, rather than kept as a declaration that
+  then applies (#708)
 - Trailing content inside a parenthesised or bracketed sub-expression makes the
   whole value invalid, as it does in a browser. `width: calc((1px 2px))` used
   to keep the prefix a reader recognised and drop the rest (#701)

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -606,13 +606,21 @@ let grid_line_at_end t =
   | Some (Component.Preserved { kind = Token.Delim "/"; _ }) -> true
   | _ -> false
 
-(* CSS Grid 2 sec. 8.3 excludes [span] from the [<custom-ident>] of a grid line
-   name. That exclusion is on the keyword, so it reads case-insensitively while
-   the name itself keeps the author's case (CSS Values 4 sec. 4.1 and 4.2). *)
+(* CSS Grid 2 sec. 8.3 and sec. 7.2.2 exclude [span] and [auto] from the
+   [<custom-ident>] of a grid line name; CSS Values 4 sec. 4.2 excludes the
+   CSS-wide keywords and the reserved [default] from every [<custom-ident>].
+   Each exclusion is on a keyword, so it reads case-insensitively while the name
+   itself keeps the author's case (sec. 4.1 and 4.2). *)
+let excluded_grid_line_name name =
+  match String.lowercase_ascii_preserve name with
+  | "span" | "auto" | "default" -> true
+  | lowered -> is_css_wide_keyword lowered
+
 let read_grid_line_name t =
   let name = Cursor.ident t in
-  if String.lowercase_ascii_preserve name = "span" then
-    Cursor.err_invalid t "duplicate span grid line"
+  if excluded_grid_line_name name then
+    Cursor.err_invalid t
+      (String.concat "" [ "reserved grid line name: "; name ])
   else name
 
 let read_grid_span t =
@@ -654,12 +662,24 @@ let read_grid_line_number t : grid_line =
   match name with Some name -> Num_name (n, name) | None -> Num n
 
 let read_grid_line_name_value t : grid_line =
-  let name = read_grid_line_name t in
-  Cursor.ws t;
-  let n : int option =
-    if grid_line_at_end t then None else Cursor.option Cursor.int t
-  in
-  match n with Some n -> Num_name (n, name) | None -> Name name
+  match Cursor.peek_ident t with
+  | Some keyword when is_css_wide_keyword keyword ->
+      (* CSS Cascade 5 sec. 7.3: explicit defaulting takes the whole
+         declaration, so a CSS-wide keyword reaches a [<grid-line>] as the
+         entire value and never as the [<custom-ident>] of a line. [Name]
+         carries it. *)
+      let name = Cursor.ident t in
+      Cursor.ws t;
+      if not (Cursor.is_done t) then
+        Cursor.err_invalid t "CSS-wide keyword mixed with other values";
+      Name name
+  | _ -> (
+      let name = read_grid_line_name t in
+      Cursor.ws t;
+      let n : int option =
+        if grid_line_at_end t then None else Cursor.option Cursor.int t
+      in
+      match n with Some n -> Num_name (n, name) | None -> Name name)
 
 let read_grid_line_calc t : grid_line =
   (* read_calc handles the calc(...) wrapper itself *)
@@ -805,8 +825,7 @@ module Grid_template = struct
         let names =
           Cursor.list ~at_least:0
             ~sep:(fun i -> Cursor.ws i)
-            (fun i -> Cursor.ident i)
-            inner
+            read_grid_line_name inner
         in
         Line_names names)
       t
@@ -885,6 +904,29 @@ let grid_template_components_well_formed cvs =
   in
   well_formed cvs
 
+(* CSS Grid 2 sec. 7.4: every [[...]] block in a [grid-template] value is a
+   [<line-names>], so the sec. 7.2.2 exclusions reach the blocks the [<string>]
+   form keeps as raw text as well. *)
+let line_names_block_valid value =
+  List.for_all
+    (function
+      | Component.Preserved { kind = Token.Ident name; _ } ->
+          not (excluded_grid_line_name name)
+      | _ -> true)
+    value
+
+let rec grid_template_line_names_valid = function
+  | [] -> true
+  | Component.Block { node = { opening; value; _ }; _ } :: rest ->
+      (match opening with
+        | Token.Square -> line_names_block_valid value
+        | Token.Curly | Token.Paren -> grid_template_line_names_valid value)
+      && grid_template_line_names_valid rest
+  | Component.Func { node = { arguments; _ }; _ } :: rest ->
+      grid_template_line_names_valid arguments
+      && grid_template_line_names_valid rest
+  | _ :: rest -> grid_template_line_names_valid rest
+
 let read_grid_template_tracks t =
   let tracks =
     Cursor.list ~sep:(fun t -> Cursor.ws t) Grid_template.read_single_track t
@@ -909,6 +951,8 @@ let rec read_grid_template t : grid_template =
       Cursor.err_invalid t "grid-template duplicate slash form";
     if not (grid_template_components_well_formed cvs) then
       Cursor.err_invalid t "grid-template malformed raw template";
+    if not (grid_template_line_names_valid cvs) then
+      Cursor.err_invalid t "grid-template reserved line name";
     let raw = Cursor.consume_to_decl_end ~trim:true t in
     Template
       (Parser.to_string_minified (Cursor.remaining (Cursor.of_string raw))))

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3987,7 +3987,12 @@ let test_grid_area () =
   check_grid_area ~expected:"1/2/3/4" "1 / 2 / 3 / 4";
   check_grid_area "auto";
   check_grid_area "span 2";
-  neg_cursor read_grid_area "1/2/3/4/5"
+  neg_cursor read_grid_area "1/2/3/4/5";
+  (* CSS Grid 2 (ED) sec. 8.4 composes four [<grid-line>]s, so every slot
+     carries the sec. 8.3 [<custom-ident>] exclusions. *)
+  check_grid_area ~expected:"a/b/c/d" "a / b / c / d";
+  neg_cursor ~allow_partial:true read_grid_area "3 auto/1/2/3";
+  neg_cursor ~allow_partial:true read_grid_area "1/2/3/span default"
 
 let test_font () =
   check_font "16px serif";
@@ -4012,7 +4017,38 @@ let test_grid_line () =
   check_grid_line "main-start";
   check_grid_line "content-end";
   check_grid_line "inherit";
-  neg_cursor read_grid_line "span"
+  neg_cursor read_grid_line "span";
+  (* CSS Grid 2 (ED) sec. 8.3: "In all the above productions, the
+     [<custom-ident>] additionally excludes the keywords span and auto." CSS
+     Values 4 (ED) sec. 4.2 excludes the CSS-wide keywords and the reserved
+     [default] from every [<custom-ident>], in all ASCII case permutations. *)
+  neg_cursor ~allow_partial:true read_grid_line "3 auto";
+  neg_cursor ~allow_partial:true read_grid_line "3 AUTO";
+  neg_cursor read_grid_line "span auto";
+  neg_cursor ~allow_partial:true read_grid_line "span 2 auto";
+  neg_cursor read_grid_line "default";
+  neg_cursor read_grid_line "span default";
+  neg_cursor ~allow_partial:true read_grid_line "3 default";
+  neg_cursor ~allow_partial:true read_grid_line "3 initial";
+  neg_cursor ~allow_partial:true read_grid_line "3 inherit";
+  neg_cursor ~allow_partial:true read_grid_line "3 unset";
+  neg_cursor ~allow_partial:true read_grid_line "3 revert";
+  neg_cursor ~allow_partial:true read_grid_line "3 revert-layer";
+  (* CSS Cascade 5 (ED) sec. 7.3: explicit defaulting takes the whole
+     declaration, so a CSS-wide keyword is a [<grid-line>] on its own only. *)
+  check_grid_line "initial";
+  neg_cursor read_grid_line "initial 3";
+  (* [<grid-line>] has no [none] and no [dense] keyword, so neither is excluded
+     from its [<custom-ident>]. *)
+  check_grid_line "none";
+  check_grid_line "3 none"
+
+(* CSS Grid 2 (ED) sec. 8.4: grid-row / grid-column pair the same [<grid-line>]
+   twice, so both slots carry the sec. 8.3 [<custom-ident>] exclusions. *)
+let test_grid_line_pair () =
+  check_grid_line_pair ~expected:"span foo/4" "span foo / 4";
+  neg_cursor ~allow_partial:true read_grid_line_pair "3 auto / 4";
+  neg_cursor read_grid_line_pair "span auto / 2"
 
 let test_grid_template () =
   check_grid_template "none";
@@ -4050,7 +4086,46 @@ let test_grid_template () =
   check_grid_template "fit-content(10px)";
   check_grid_template "fit-content( 10px )" ~expected:"fit-content(10px)";
   neg_cursor read_grid_template "minmax(1px,2px,3px)";
-  neg_cursor read_grid_template "fit-content(10px 20px)"
+  neg_cursor read_grid_template "fit-content(10px 20px)";
+  (* CSS Grid 2 (ED) sec. 7.2.2: [<line-names> = '[' <custom-ident>* ']'], and
+     "A line name cannot be span or auto, i.e. the [<custom-ident>] in the
+     [<line-names>] production excludes the keywords span and auto." CSS Values
+     4 (ED) sec. 4.2 excludes the CSS-wide keywords and the reserved [default]
+     from every [<custom-ident>]. Each exclusion is on a keyword, so it holds in
+     all ASCII case permutations. *)
+  check_grid_template ~expected:"[a]1px" "[a] 1px";
+  check_grid_template ~expected:"[a b]1px" "[a b] 1px";
+  check_grid_template ~expected:"1px[a]" "1px [a]";
+  neg_cursor read_grid_template "[span] 1px";
+  neg_cursor read_grid_template "[SPAN] 1px";
+  neg_cursor read_grid_template "[auto] 1px";
+  neg_cursor read_grid_template "[Auto] 1px";
+  neg_cursor read_grid_template "[default] 1px";
+  neg_cursor read_grid_template "[DeFaUlT] 1px";
+  neg_cursor read_grid_template "[initial] 1px";
+  neg_cursor read_grid_template "[inherit] 1px";
+  neg_cursor read_grid_template "[unset] 1px";
+  neg_cursor read_grid_template "[revert] 1px";
+  neg_cursor read_grid_template "[revert-layer] 1px";
+  neg_cursor read_grid_template "[a span] 1px";
+  neg_cursor ~allow_partial:true read_grid_template "1px [span]";
+  (* Nothing else is excluded: the brackets make the position unambiguous, so a
+     track keyword is an ordinary line name, and [<custom-ident>*] matches the
+     empty list. *)
+  check_grid_template ~expected:"[]1px" "[] 1px";
+  check_grid_template ~expected:"[none]1px" "[none] 1px";
+  check_grid_template ~expected:"[dense]1px" "[dense] 1px";
+  check_grid_template ~expected:"[auto-fill]1px" "[auto-fill] 1px";
+  (* sec. 7.2.3: [repeat()] holds a track list, so its line-name positions carry
+     the same exclusions. *)
+  check_grid_template ~expected:"repeat(2,[a]1px)" "repeat(2, [a] 1px)";
+  neg_cursor read_grid_template "repeat(2, [span] 1px)";
+  neg_cursor read_grid_template "repeat(2, 1px [auto])";
+  (* sec. 7.4: the [<string>] form of grid-template keeps its value as raw text,
+     and its bracketed positions are [<line-names>] just the same. *)
+  check_grid_template ~expected:"[a]\"x\" 1px" "[a] \"x\" 1px";
+  neg_cursor read_grid_template "[span] \"x\" 1px";
+  neg_cursor read_grid_template "\"x\" 1px [auto]"
 
 let test_grid_template_areas () =
   check_grid_template_areas ~expected:"\"nav main\"\". foot\""
@@ -5018,6 +5093,7 @@ let tests =
     test_case "grid template" `Quick test_grid_template;
     test_case "grid template areas" `Quick test_grid_template_areas;
     test_case "grid line" `Quick test_grid_line;
+    test_case "grid line pair" `Quick test_grid_line_pair;
     test_case "symbols type" `Quick test_symbols_type;
     test_case "list style symbol" `Quick test_list_style_symbol;
     test_case "font variant east asian feature" `Quick test_east_asian_feature;
@@ -5310,6 +5386,7 @@ let additional_tests =
     test_case "aspect_ratio" `Quick test_aspect_ratio;
     test_case "flex" `Quick test_flex;
     test_case "grid_line" `Quick test_grid_line;
+    test_case "grid_line_pair" `Quick test_grid_line_pair;
     test_case "grid_template" `Quick test_grid_template;
     test_case "justify_content" `Quick test_justify_content;
     test_case "outline_style" `Quick test_outline_style;


### PR DESCRIPTION
A grid line name accepted any ident, so cascade kept declarations a browser drops, such as `grid-template-columns: [span] 1px` and `grid-row-start: 3 auto`. CSS Grid 2 sec. 7.2.2 and sec. 8.3 exclude `span` and `auto` from the `<custom-ident>` of a line name, and CSS Values 4 sec. 4.2 excludes the CSS-wide keywords and `default` from every `<custom-ident>`.

A lone CSS-wide keyword is still accepted, since explicit defaulting takes the whole declaration; it is excluded only as the name inside a composed `<grid-line>`.
