### PR TITLE
variables: stop a multiplied syntax component looping forever

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -215,6 +215,11 @@ recorded cases carrying six minifiers' answers.
   case. `grid-template-columns: [span] 1px` and `grid-row-start: 3 auto` are
   dropped the way a browser drops them, rather than kept as a declaration that
   then applies (#708)
+- A `@property` syntax multiplying `<transform-function>`, `<transform-list>`
+  or `<resolution>` no longer hangs the parser. Those readers reported success
+  on an empty stream, and the multiplier repeated them forever (#710)
+- `*` is a `@property` syntax on its own only, so `"*+"` and `"* | <length>"`
+  are rejected the way a browser rejects them (#710)
 - Trailing content inside a parenthesised or bracketed sub-expression makes the
   whole value invalid, as it does in a browser. `width: calc((1px 2px))` used
   to keep the prefix a reader recognised and drop the rest (#701)

--- a/fuzz/fuzz_variables.ml
+++ b/fuzz/fuzz_variables.ml
@@ -101,6 +101,57 @@ let test_var_compare_antisym buf =
   if ab < 0 && ba <= 0 then fail "variable compare not antisymmetric";
   if ab > 0 && ba >= 0 then fail "variable compare not antisymmetric"
 
+(* CSS Properties and Values API 1 (ED) sec. 5.4.3 gives a component a [+] or
+   [#] multiplier, and reading the list repeats the component reader. A reader
+   that reports success without consuming anything never lets that repetition
+   end, so every component reader rejects an empty stream. The universal syntax
+   is the one reader that matches nothing, and sec. 5.4.2 returns it only for
+   the syntax string [*] on its own, where no multiplier can reach it. *)
+let component_names =
+  [
+    "<length>";
+    "<color>";
+    "<number>";
+    "<integer>";
+    "<percentage>";
+    "<length-percentage>";
+    "<angle>";
+    "<time>";
+    "<resolution>";
+    "<custom-ident>";
+    "<string>";
+    "<url>";
+    "<image>";
+    "<transform-function>";
+    "<transform-list>";
+  ]
+
+let syntax_string buf =
+  if byte_at buf 0 mod 2 = 0 then pick component_names buf 1 else cssish buf
+
+(* Only a component reader is exercised: a multiplied or alternated syntax is
+   left alone so a reader that does not consume cannot spin here. *)
+let check_leaf_rejects_empty : type a. string -> a Css.Variables.syntax -> unit
+    =
+ fun name syntax ->
+  match syntax with
+  | Css.Variables.Universal | Css.Variables.Plus _ | Css.Variables.Hash _
+  | Css.Variables.Or _ ->
+      ()
+  | _ -> (
+      match Css.Variables.read_value (Cursor.of_string "") syntax with
+      | exception Cursor.Parse_error _ -> ()
+      | exception Reader.Parse_error _ -> ()
+      | _ -> failf "%S read a value from an empty stream" name)
+
+let test_reader_rejects_empty_stream buf =
+  let name = syntax_string buf in
+  let quoted = String.concat "" [ "\""; name; "\"" ] in
+  match Css.Variables.read_any_syntax (Cursor.of_string quoted) with
+  | exception Cursor.Parse_error _ -> ()
+  | exception Reader.Parse_error _ -> ()
+  | Css.Variables.Syntax syntax -> check_leaf_rejects_empty name syntax
+
 let suite =
   ( "variables",
     [
@@ -116,4 +167,6 @@ let suite =
         test_custom_declaration_name_invariant;
       test_case "compare vars by name antisymmetric" [ bytes ]
         test_var_compare_antisym;
+      test_case "component reader rejects empty stream" [ bytes ]
+        test_reader_rejects_empty_stream;
     ] )

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -162,7 +162,7 @@ let typed_custom_property ?layer name syntax value =
   custom_property ?layer name
     (Pp.to_string ~minify:true (pp_value syntax) value)
 
-(* CSS Properties and Values API 1 section 2 lists the named [<...>] type
+(* CSS Properties and Values API 1 (ED) sec. 5.1 lists the named [<...>] type
    references. Bare ident keywords match the [<custom-ident>] shape so a leading
    letter followed by ident-continue characters counts; this rejects stray
    punctuation. *)
@@ -195,12 +195,11 @@ let read_simple_syntax_component r s : any_syntax =
   | "<image>" -> Syntax Image
   | "<transform-function>" -> Syntax Transform_function
   | "<transform-list>" -> Syntax Transform_list
-  | "*" -> Syntax Universal
   | s when is_ident_keyword s -> Syntax (Ident_keyword s)
   | s -> Cursor.err_invalid r ("Unsupported CSS syntax: " ^ s)
 
-(* CSS Properties and Values API 1 sec. 2: only [+] and [#] are valid syntax
-   multipliers. *)
+(* CSS Properties and Values API 1 (ED) sec. 5.2: only [+] and [#] are valid
+   syntax multipliers. *)
 let apply_syntax_modifier r (Syntax inner) (modifier : char option) : any_syntax
     =
   match modifier with
@@ -228,13 +227,18 @@ let split_syntax_modifier s : string * char option =
 
 let read_syntax (r : Cursor.t) : any_syntax =
   (* CSS @property syntax values must be quoted strings per spec *)
-  let s = Cursor.string r in
+  let s = String.trim (Cursor.string r) in
   let read_component part =
     let body, modifier = split_syntax_modifier (String.trim part) in
     if body = "" then Cursor.err_invalid r "empty CSS syntax component";
     apply_syntax_modifier r (read_simple_syntax_component r body) modifier
   in
-  if String.contains s '|' then
+  (* Sec. 5.4.2 strips the surrounding whitespace, then returns the universal
+     syntax definition only for a string that is [*] and nothing else. As a
+     component [*] is none of the shapes sec. 5.4.3 accepts, so it carries no
+     multiplier and joins no alternation. *)
+  if s = "*" then Syntax Universal
+  else if String.contains s '|' then
     let parts = String.split_on_char '|' s in
     let components = List.map read_component parts in
     match components with
@@ -247,6 +251,14 @@ let read_syntax (r : Cursor.t) : any_syntax =
           (fun (Syntax left) (Syntax right) -> Syntax (Or (left, right)))
           first rest
   else read_component s
+
+(* These types have no reader of their own and take whatever is left. None of
+   them spells a value as nothing, and a reader that succeeded on an empty
+   stream would leave the [+] and [#] repetitions below with no way to stop. *)
+let read_remaining_typed reader what =
+  let value = Cursor.consume_remaining_as_string ~trim:true reader in
+  if value = "" then Cursor.err_expected reader what;
+  value
 
 (** Read a value according to its syntax type *)
 let rec read_value : type a. Cursor.t -> a syntax -> a =
@@ -261,9 +273,9 @@ let rec read_value : type a. Cursor.t -> a syntax -> a =
   | Custom_ident -> Cursor.ident ~keep_case:true reader
   | Url -> Cursor.url reader
   | Image -> Properties.read_background_image reader
-  | Transform_function -> Cursor.consume_remaining_as_string ~trim:true reader
-  | Transform_list -> Cursor.consume_remaining_as_string ~trim:true reader
-  | Resolution -> Cursor.consume_remaining_as_string ~trim:true reader
+  | Transform_function -> read_remaining_typed reader "<transform-function>"
+  | Transform_list -> read_remaining_typed reader "<transform-list>"
+  | Resolution -> read_remaining_typed reader "<resolution>"
   | Length -> Values.read_length reader
   | Color -> Values.read_color reader
   | Number -> Cursor.number reader

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -562,6 +562,51 @@ let spec_property_syntax_multiplier_chain () =
     "chained multipliers drop the registration" ".x{color:red}"
     (render (sheet "<custom-ident>+#"))
 
+(* CSS Properties and Values API 1 (ED) sec. 5.4.3 gives a component a [+] or
+   [#] multiplier, and [read_value] repeats the component reader to read the
+   list. A reader that reports success without consuming anything never lets
+   that repetition end, so every component reader has to reject an empty stream.
+   The universal syntax is the one reader that may match nothing, and sec. 5.4.2
+   returns it only for a syntax string that is [*] and nothing else, so it takes
+   no multiplier and joins no alternation. *)
+let spec_multiplied_component_terminates () =
+  let rejects_empty_stream name =
+    let quoted = String.concat "" [ "\""; name; "\"" ] in
+    match read_any_syntax (Cursor.of_string quoted) with
+    | Syntax syntax -> (
+        match read_value (Cursor.of_string "") syntax with
+        | exception Error.Parse_error _ -> ()
+        | _ -> Alcotest.failf "%s read a value from an empty stream" name)
+  in
+  List.iter rejects_empty_stream
+    [
+      "<length>";
+      "<color>";
+      "<number>";
+      "<integer>";
+      "<percentage>";
+      "<length-percentage>";
+      "<angle>";
+      "<time>";
+      "<resolution>";
+      "<custom-ident>";
+      "<string>";
+      "<url>";
+      "<image>";
+      "<transform-function>";
+      "<transform-list>";
+      "auto";
+    ];
+  (* The universal syntax stands alone. *)
+  check_any_syntax "\"*\"";
+  neg_cursor read_any_syntax "\"*+\"";
+  neg_cursor read_any_syntax "\"*#\"";
+  neg_cursor read_any_syntax "\"* | <length>\"";
+  neg_cursor read_any_syntax "\"<length> | *\"";
+  (* The multipliers these readers sit under stay readable. *)
+  check_any_syntax "\"<transform-function>+\"";
+  check_any_syntax "\"<resolution>+\""
+
 (* Not a roundtrip test *)
 let test_syntax () =
   (* Syntax checking is not available in current implementation *)
@@ -750,6 +795,9 @@ let tests =
     ( "spec property syntax multiplier chain",
       `Quick,
       spec_property_syntax_multiplier_chain );
+    ( "spec multiplied component terminates",
+      `Quick,
+      spec_multiplied_component_terminates );
     ("vars of calc", `Quick, test_vars_of_calc);
     ("vars of property", `Quick, test_vars_of_property);
     ("spec vars of property matrix", `Quick, spec_vars_of_property_matrix);


### PR DESCRIPTION
A `@property` syntax multiplying `<transform-function>`, `<transform-list>` or `<resolution>` made the parser loop forever on input a browser accepts. Those readers take the rest of the stream and so reported success once nothing was left; `*` is now confined to a syntax string of its own, which is what keeps it out of a multiplier.
