### PR TITLE
grid: read a span in any operand order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -207,6 +207,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- The span form of `<grid-line>` takes its operands in any order, as the `&&`
+  and `||` combinators in its grammar allow. `grid-column-start: 3 span` is
+  kept and printed `span 3`, where cascade used to drop the declaration (#711)
 - An `@property` syntax component carries at most one multiplier. A chained one
   such as `"<custom-ident>+#"` drops the registration the way a browser does,
   where cascade used to accept it and type a property left unregistered (#707)

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -623,35 +623,28 @@ let read_grid_line_name t =
       (String.concat "" [ "reserved grid line name: "; name ])
   else name
 
-let read_grid_span t =
-  let span_word = Cursor.ident ~keep_case:false t in
-  if span_word <> "span" then
-    Cursor.err t ("Expected 'span' but got " ^ span_word);
-  Cursor.ws t;
-  let first_int : int option = Cursor.option Cursor.int t in
-  Cursor.ws t;
-  let first_name : string option =
-    if Option.is_none first_int && not (grid_line_at_end t) then
-      Cursor.option read_grid_line_name t
-    else None
-  in
-  Cursor.ws t;
-  let second : [ `Name of string | `Num of int ] option =
-    if grid_line_at_end t then None
-    else
-      match first_int with
-      | Some _ ->
-          Option.map
-            (fun name -> `Name name)
-            (Cursor.option read_grid_line_name t)
-      | None -> Option.map (fun n -> `Num n) (Cursor.option Cursor.int t)
-  in
-  match (first_int, first_name, second) with
-  | Some n, None, Some (`Name name) -> Span_num_name (n, name)
-  | Some n, None, None -> Span n
-  | None, Some name, Some (`Num n) -> Span_num_name (n, name)
-  | None, Some name, None -> Span_name name
-  | _ -> Cursor.err_invalid t "invalid span grid line"
+(* [ <integer [1,inf]> || <custom-ident> ]: one or both, in either order. *)
+let read_grid_span_parts t : grid_line =
+  match Cursor.option Cursor.int t with
+  | Some n -> (
+      match Cursor.option read_grid_line_name t with
+      | Some name -> Span_num_name (n, name)
+      | None -> Span n)
+  | None -> (
+      let name = read_grid_line_name t in
+      match Cursor.option Cursor.int t with
+      | Some n -> Span_num_name (n, name)
+      | None -> Span_name name)
+
+(* CSS Grid 2 sec. 8.3: [span && [ <integer [1,inf]> || <custom-ident> ]]. CSS
+   Values 4 sec. 2.2 makes [&&] reorderable, so [span] sits on either side of
+   the group; it reorders only components in the same grouping, so [span] never
+   splits the bracketed [||] pair ([3 span foo] is not a value). *)
+let read_grid_span t : grid_line =
+  let span_first = Cursor.try_ident "span" t in
+  let value = read_grid_span_parts t in
+  if not span_first then Cursor.expect_string "span" t;
+  value
 
 let read_grid_line_number t : grid_line =
   let n = Cursor.int t in
@@ -700,8 +693,11 @@ let rec read_grid_line t : grid_line =
         ("var", fun t -> (Var (Values.read_var read_grid_line t) : grid_line));
       ]
     ~default:(fun t ->
+      (* The span form is tried first: it is the only alternative that reads a
+         trailing [span], and the other two match its group on their own and
+         would leave that [span] behind. *)
       Cursor.one_of
-        [ read_grid_line_number; read_grid_span; read_grid_line_name_value ]
+        [ read_grid_span; read_grid_line_number; read_grid_line_name_value ]
         t)
     t
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4018,6 +4018,28 @@ let test_grid_line () =
   check_grid_line "content-end";
   check_grid_line "inherit";
   neg_cursor read_grid_line "span";
+  (* CSS Grid 2 (ED) sec. 8.3 gives the span branch as [span && [ <integer
+     [1,inf]> || <custom-ident> ]]. CSS Values 4 (ED) sec. 2.2 makes both [&&]
+     and [||] reorderable, so [span] sits on either side of the group and the
+     group's own two parts come in either order. Sec. 8.3 sets "Canonical order:
+     per grammar", which fixes the serialisation at [span <integer>
+     <custom-ident>]. *)
+  check_grid_line "span foo";
+  check_grid_line "span 3 foo";
+  check_grid_line ~expected:"span 3 foo" "span foo 3";
+  check_grid_line ~expected:"span 3" "3 span";
+  check_grid_line ~expected:"span foo" "foo span";
+  check_grid_line ~expected:"span 3 foo" "3 foo span";
+  check_grid_line ~expected:"span 3 foo" "foo 3 span";
+  (* [span] is a keyword, so it matches in any ASCII case (sec. 4.1). *)
+  check_grid_line ~expected:"span 3" "3 SPAN";
+  (* Sec. 2.2 reorders only components in the same grouping, so [span] cannot
+     sit between the two parts of the bracketed [||] group, and only one [span]
+     is part of the value. *)
+  neg_cursor ~allow_partial:true read_grid_line "3 span foo";
+  neg_cursor ~allow_partial:true read_grid_line "foo span 3";
+  neg_cursor ~allow_partial:true read_grid_line "span 3 span";
+  neg_cursor read_grid_line "span span";
   (* CSS Grid 2 (ED) sec. 8.3: "In all the above productions, the
      [<custom-ident>] additionally excludes the keywords span and auto." CSS
      Values 4 (ED) sec. 4.2 excludes the CSS-wide keywords and the reserved
@@ -4026,8 +4048,15 @@ let test_grid_line () =
   neg_cursor ~allow_partial:true read_grid_line "3 AUTO";
   neg_cursor read_grid_line "span auto";
   neg_cursor ~allow_partial:true read_grid_line "span 2 auto";
+  neg_cursor ~allow_partial:true read_grid_line "auto span";
+  neg_cursor ~allow_partial:true read_grid_line "3 span auto";
+  neg_cursor ~allow_partial:true read_grid_line "auto span 3";
+  neg_cursor ~allow_partial:true read_grid_line "3 auto span";
   neg_cursor read_grid_line "default";
   neg_cursor read_grid_line "span default";
+  neg_cursor read_grid_line "default span";
+  neg_cursor ~allow_partial:true read_grid_line "3 default span";
+  neg_cursor read_grid_line "initial span";
   neg_cursor ~allow_partial:true read_grid_line "3 default";
   neg_cursor ~allow_partial:true read_grid_line "3 initial";
   neg_cursor ~allow_partial:true read_grid_line "3 inherit";
@@ -4047,7 +4076,10 @@ let test_grid_line () =
    twice, so both slots carry the sec. 8.3 [<custom-ident>] exclusions. *)
 let test_grid_line_pair () =
   check_grid_line_pair ~expected:"span foo/4" "span foo / 4";
+  check_grid_line_pair ~expected:"span 3/4" "3 span / 4";
+  check_grid_line_pair ~expected:"span foo/span 2 bar" "foo span / span 2 bar";
   neg_cursor ~allow_partial:true read_grid_line_pair "3 auto / 4";
+  neg_cursor ~allow_partial:true read_grid_line_pair "3 span auto / 4";
   neg_cursor read_grid_line_pair "span auto / 2"
 
 let test_grid_template () =


### PR DESCRIPTION
`grid-column-start: 3 span` used to be dropped. The span form of `<grid-line>` joins `span` to its operand group with `&&`, which is reorderable, so a browser keeps that spelling and serialises it `span 3`.