### PR TITLE
grid: reject track lists and placements a browser drops

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -210,6 +210,17 @@ recorded cases carrying six minifiers' answers.
 - The span form of `<grid-line>` takes its operands in any order, as the `&&`
   and `||` combinators in its grammar allow. `grid-column-start: 3 span` is
   kept and printed `span 3`, where cascade used to drop the declaration (#711)
+- `grid-auto-columns` and `grid-auto-rows` take a list of track sizes. They
+  used to read the wider `grid-template-*` grammar, so a line-name block, a
+  `repeat()`, `none` or a slash form parsed and applied where a browser drops
+  the declaration (#712)
+- A grid track list carries at least one track size, and never two line-name
+  blocks in a row. `grid-template-columns: [a]` and `1px [a] [b] 2px` are
+  dropped the way a browser drops them, inside a `repeat()` body and in the
+  `grid` and `grid-template` shorthands as well (#712)
+- The grid placement properties go through the CSS-wide keyword check.
+  `grid-column: 2 / initial` and `grid-area: 1 / 2 / 3 / initial` are dropped,
+  while a lone `grid-column: initial` still reads as explicit defaulting (#712)
 - An `@property` syntax component carries at most one multiplier. A chained one
   such as `"<custom-ident>+#"` drops the registration the way a browser does,
   where cascade used to accept it and type a property left unregistered (#707)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1338,20 +1338,8 @@ let read_grid_value : type a. a property -> Cursor.t -> declaration option =
   | Grid_template -> Some (v Grid_template (read_grid_template t))
   | Grid -> Some (v Grid (read_grid t))
   | Grid_area -> Some (v Grid_area (read_grid_area t))
-  | Grid_auto_columns ->
-      let value = read_grid_template t in
-      (match value with
-      | Subgrid | Masonry ->
-          Cursor.err_invalid t "grid-auto track cannot be subgrid or masonry"
-      | _ -> ());
-      Some (v Grid_auto_columns value)
-  | Grid_auto_rows ->
-      let value = read_grid_template t in
-      (match value with
-      | Subgrid | Masonry ->
-          Cursor.err_invalid t "grid-auto track cannot be subgrid or masonry"
-      | _ -> ());
-      Some (v Grid_auto_rows value)
+  | Grid_auto_columns -> Some (v Grid_auto_columns (read_grid_auto_tracks t))
+  | Grid_auto_rows -> Some (v Grid_auto_rows (read_grid_auto_tracks t))
   | Grid_column -> Some (v Grid_column (read_grid_line_pair t))
   | Grid_row -> Some (v Grid_row (read_grid_line_pair t))
   | _ -> None
@@ -2066,14 +2054,13 @@ let read_custom_property_declaration t : declaration =
 
 (* Properties whose grammar allows multi-token values where a CSS-wide keyword
    can legitimately appear as a non-special ident. [animation-name] /
-   [grid-area] / [will-change] / etc. accept arbitrary ident lists.
-   [font-family] also takes a [<custom-ident>#] list, so a CSS-wide keyword
-   inside the list is invalid CSS (CSS Cascade 5 sec. 7.3) but upstream tools
-   (lightningcss, csso) preserve the source verbatim. *)
+   [will-change] / etc. accept arbitrary ident lists. [font-family] also takes a
+   [<custom-ident>#] list, so a CSS-wide keyword inside the list is invalid CSS
+   (CSS Cascade 5 sec. 7.3) but upstream tools (lightningcss, csso) preserve the
+   source verbatim. *)
 let property_allows_keyword_as_ident = function
-  | "animation-name" | "grid-area" | "grid-row" | "grid-column"
-  | "grid-row-start" | "grid-row-end" | "grid-column-start" | "grid-column-end"
-  | "will-change" | "view-transition-name" | "font-family" | "font" ->
+  | "animation-name" | "will-change" | "view-transition-name" | "font-family"
+  | "font" ->
       true
   | _ -> false
 

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -744,6 +744,29 @@ let read_grid_area t : grid_area =
   in
   Lines { row_start; column_start; row_end; column_end }
 
+(* CSS Grid 2 (ED) sec. 7.2: [<track-list> = [ <line-names>? [ <track-size> |
+   <track-repeat> ] ]+ <line-names>?] puts every [<line-names>] in front of a
+   track size, or last in the list. So a track list carries at least one track
+   size, and never two [<line-names>] in a row. The sec. 7.2.3 [repeat()]
+   bodies, [<explicit-track-list>] and [<auto-track-list>] have the same shape.
+   ([subgrid <line-name-list>?] is the exception, and
+   [read_grid_template_tracks] rejects [subgrid] in a track list before either
+   check runs.) *)
+let track_list_has_track_size (tracks : grid_template list) =
+  List.exists (function Line_names _ -> false | _ -> true) tracks
+
+let rec track_list_names_separated (tracks : grid_template list) =
+  match tracks with
+  | Line_names _ :: Line_names _ :: _ -> false
+  | _ :: rest -> track_list_names_separated rest
+  | [] -> true
+
+let validate_track_list t tracks =
+  if not (track_list_has_track_size tracks) then
+    Cursor.err_invalid t "grid track list without a track size";
+  if not (track_list_names_separated tracks) then
+    Cursor.err_invalid t "grid track list with adjacent line names"
+
 module Grid_template = struct
   let read_length_as_grid t : grid_template =
     (* [~with_keywords:false]: track keywords (auto / min-content / ...) are a
@@ -860,6 +883,7 @@ module Grid_template = struct
                     ~sep:(fun i -> Cursor.ws i)
                     read_single_track inner
                 in
+                validate_track_list inner tracks;
                 (Repeat (count, tracks) : grid_template) );
           ]
         ~default:(fun t -> Cursor.one_of [ read_length_as_grid; read_fr ] t)
@@ -929,14 +953,18 @@ let read_grid_template_tracks t =
   in
   match tracks with
   | [] -> Cursor.err t "Expected at least one grid track"
-  | [ single ] -> single
-  | multiple
-    when List.exists
-           (fun (track : grid_template) ->
-             match track with None | Subgrid | Masonry -> true | _ -> false)
-           multiple ->
-      Cursor.err_invalid t "grid-template standalone keyword in track list"
-  | multiple -> Tracks multiple
+  | [ single ] ->
+      validate_track_list t tracks;
+      single
+  | multiple ->
+      if
+        List.exists
+          (fun (track : grid_template) ->
+            match track with None | Subgrid | Masonry -> true | _ -> false)
+          multiple
+      then Cursor.err_invalid t "grid-template standalone keyword in track list";
+      validate_track_list t multiple;
+      Tracks multiple
 
 let rec read_grid_template t : grid_template =
   if Cursor.looking_at_func "var" t then
@@ -963,6 +991,35 @@ let rec read_grid_template t : grid_template =
           err_invalid_value t "grid-template" "none in slash form"
       | _ -> Split (rows, columns))
     else rows
+
+(* CSS Grid 2 (ED) sec. 7.6: [grid-auto-columns] and [grid-auto-rows] take
+   [<track-size>+], the sec. 7.2 [<track-size>] repeated. That grammar has no
+   [<line-names>] position, no [<track-repeat>], and none of the [<track-list>]
+   keywords ([none], [subgrid], [masonry]) nor its slash form. *)
+let rec is_track_size : grid_template -> bool = function
+  | Px _ | Rem _ | Em _ | Pct _ | Vw _ | Vh _ | Vmin _ | Vmax _ | Zero
+  | Length _ | Fr _ | Auto | Min_content | Max_content | Fit_content _ ->
+      true
+  | Min_max (min, max) -> is_track_size min && is_track_size max
+  | Var _ -> true
+  | None | Inherit | Initial | Unset | Revert | Revert_layer | Repeat _
+  | Tracks _ | Split _ | Auto_flow_columns _ | Auto_flow_rows _ | Named_tracks _
+  | Line_names _ | Template _ | Subgrid | Masonry ->
+      false
+
+let read_grid_auto_tracks t : grid_template =
+  let value = read_grid_template t in
+  let valid =
+    match value with
+    (* CSS Cascade 5 (ED) sec. 7.3: explicit defaulting takes the whole
+       declaration, so a CSS-wide keyword reaches the reader alone. *)
+    | Inherit | Initial | Unset | Revert | Revert_layer | Var _ -> true
+    | Tracks tracks -> List.for_all is_track_size tracks
+    | single -> is_track_size single
+  in
+  if not valid then
+    Cursor.err_invalid t "grid-auto tracks accept a track size only";
+  value
 
 let read_grid_auto_flow_clause side t =
   let rec loop seen_auto_flow seen_dense =

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -924,6 +924,13 @@ val pp_grid_template_areas : grid_template_areas Pp.t
 val read_grid_template : Cursor.t -> grid_template
 (** [read_grid_template t] is the [grid_template] parsed from [t]. *)
 
+val read_grid_auto_tracks : Cursor.t -> grid_template
+(** [read_grid_auto_tracks t] is the [grid-auto-columns] / [grid-auto-rows]
+    value parsed from [t]. CSS Grid 2 (ED) sec. 7.6 gives those properties
+    [<track-size>+], so the value shares the [grid_template] type with
+    [grid-template-columns] but takes none of its line-name, [repeat()] or slash
+    forms. *)
+
 val read_grid : Cursor.t -> grid_template
 (** [read_grid t] is the [grid] shorthand parsed from [t]. *)
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1983,6 +1983,49 @@ let grid () =
     ~into:"grid-auto-flow:dense" "grid-auto-flow: dense row";
   decl_optimizes ~prop:"grid-auto-flow" ~into:"column dense" "column dense";
 
+  (* CSS Grid 2 (ED) sec. 7.6 gives grid-auto-columns and grid-auto-rows
+     [<track-size>+], so they route to a reader with no [<line-names>] position
+     and none of the sec. 7.2 [<track-list>] forms. *)
+  check_declaration ~expected:"grid-auto-rows:1px" "grid-auto-rows: 1px";
+  check_declaration ~expected:"grid-auto-rows:minmax(1px,2px)"
+    "grid-auto-rows: minmax(1px, 2px)";
+  check_declaration ~expected:"grid-auto-columns:1fr 2fr"
+    "grid-auto-columns: 1fr 2fr";
+  check_declaration ~expected:"grid-auto-rows:fit-content(10px)"
+    "grid-auto-rows: fit-content(10px)";
+  check_declaration ~expected:"grid-auto-rows:auto" "grid-auto-rows: auto";
+  check_declaration ~expected:"grid-auto-rows:initial" "grid-auto-rows: initial";
+  neg_cursor read_declaration "grid-auto-rows: [a] 1px";
+  neg_cursor read_declaration "grid-auto-rows: [a]";
+  neg_cursor read_declaration "grid-auto-rows: 1px [a]";
+  neg_cursor read_declaration "grid-auto-columns: [a] 1px";
+  neg_cursor read_declaration "grid-auto-rows: none";
+  neg_cursor read_declaration "grid-auto-rows: subgrid";
+  neg_cursor read_declaration "grid-auto-rows: repeat(2, 1px)";
+  neg_cursor read_declaration "grid-auto-rows: 1px / 2px";
+
+  (* sec. 7.2 keeps every [<line-names>] next to a track size, in the shorthands
+     as well as in grid-template-columns / grid-template-rows. *)
+  check_declaration ~expected:"grid-template-columns:[a]1px"
+    "grid-template-columns: [a] 1px";
+  check_declaration ~expected:"grid-template-columns:1px[a]2px"
+    "grid-template-columns: 1px [a] 2px";
+  neg_cursor read_declaration "grid-template-columns: [a]";
+  neg_cursor read_declaration "grid-template-rows: [a] [b] 1px";
+  neg_cursor read_declaration "grid-template: 1px / [a]";
+  neg_cursor read_declaration "grid: auto-flow [a] / 1px";
+
+  (* CSS Cascade 5 (ED) sec. 7.3: explicit defaulting takes the whole
+     declaration, so a CSS-wide keyword is a placement value on its own and
+     never one slot of one. *)
+  check_declaration ~expected:"grid-column:initial" "grid-column: initial";
+  check_declaration ~expected:"grid-area:initial" "grid-area: initial";
+  neg_cursor read_declaration "grid-column: 2 / initial";
+  neg_cursor read_declaration "grid-row: 2 / initial";
+  neg_cursor read_declaration "grid-area: 1 / 2 / 3 / initial";
+  neg_cursor read_declaration "grid-column: initial / 2";
+  neg_cursor read_declaration "grid-column-start: 2 initial";
+
   (* Grid gaps *)
   check_declaration ~expected:"gap:10px" "gap: 10px";
   check_declaration ~expected:"gap:10px 20px" "gap: 10px 20px";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4157,7 +4157,23 @@ let test_grid_template () =
      and its bracketed positions are [<line-names>] just the same. *)
   check_grid_template ~expected:"[a]\"x\" 1px" "[a] \"x\" 1px";
   neg_cursor read_grid_template "[span] \"x\" 1px";
-  neg_cursor read_grid_template "\"x\" 1px [auto]"
+  neg_cursor read_grid_template "\"x\" 1px [auto]";
+  (* CSS Grid 2 (ED) sec. 7.2: [<track-list> = [ <line-names>? [ <track-size> |
+     <track-repeat> ] ]+ <line-names>?] places a [<line-names>] before a track
+     size or at the very end, so a track list carries at least one track size
+     and never two [<line-names>] in a row. sec. 7.2.3 gives the [repeat()] body
+     the same shape. *)
+  check_grid_template ~expected:"[a]1px[b]" "[a] 1px [b]";
+  check_grid_template ~expected:"1px[a]2px" "1px [a] 2px";
+  check_grid_template ~expected:"repeat(2,1px[a])" "repeat(2, 1px [a])";
+  neg_cursor read_grid_template "[a]";
+  neg_cursor read_grid_template "[a] [b]";
+  neg_cursor read_grid_template "[a] [b] 1px";
+  neg_cursor read_grid_template "1px [a] [b]";
+  neg_cursor read_grid_template "1px [a] [b] 2px";
+  neg_cursor read_grid_template "1px / [a]";
+  neg_cursor read_grid_template "repeat(2,[a])";
+  neg_cursor read_grid_template "repeat(2,[a] [b] 1px)"
 
 let test_grid_template_areas () =
   check_grid_template_areas ~expected:"\"nav main\"\". foot\""


### PR DESCRIPTION
`grid-auto-rows: [a] 1px`, `grid-template-columns: [a]` and `grid-column: 2 / initial` parsed and applied, where a browser drops each of them.

Dropping the grid placement properties from the CSS-wide keyword allowlist also enrols `grid-column: var(--x) / initial` in an existing divergence that affects every property: a value carrying `var()` is rejected over a keyword the browser defers to substitution time.
