### PR TITLE
variables: reject multipliers on transform-list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -224,6 +224,9 @@ recorded cases carrying six minifiers' answers.
 - An `@property` syntax component carries at most one multiplier. A chained one
   such as `"<custom-ident>+#"` drops the registration the way a browser does,
   where cascade used to accept it and type a property left unregistered (#707)
+- The pre-multiplied `@property` syntax `<transform-list>` cannot take `+` or
+  `#`. Those spellings now drop the registration the way a browser does instead
+  of registering a different list type (#713)
 - Grid line names reject the idents that are not `<custom-ident>`s in that
   position: `span`, `auto`, `default` and the CSS-wide keywords, in every ASCII
   case. `grid-template-columns: [span] 1px` and `grid-row-start: 3 auto` are

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -202,11 +202,14 @@ let read_simple_syntax_component r s : any_syntax =
    syntax multipliers. *)
 let apply_syntax_modifier r (Syntax inner) (modifier : char option) : any_syntax
     =
-  match modifier with
-  | None -> Syntax inner
-  | Some '+' -> Syntax (Plus inner)
-  | Some '#' -> Syntax (Hash inner)
-  | Some c ->
+  match (inner, modifier) with
+  | Transform_list, Some ('+' | '#') ->
+      Cursor.err_invalid r
+        "a pre-multiplied CSS syntax component cannot take a multiplier"
+  | inner, None -> Syntax inner
+  | inner, Some '+' -> Syntax (Plus inner)
+  | inner, Some '#' -> Syntax (Hash inner)
+  | _, Some c ->
       Cursor.err_invalid r
         (String.concat ""
            [ "Unsupported CSS syntax modifier: '"; String.make 1 c; "'" ])

--- a/lib/variables_intf.ml
+++ b/lib/variables_intf.ml
@@ -6,7 +6,7 @@ open Properties
 (** {1 Custom Property Syntax} *)
 
 (** Type-safe CSS [@property] syntax descriptors per CSS Properties and Values
-    API 1 sec. 2 (https://drafts.css-houdini.org/css-properties-values-api-1/).
+    API 1 sec. 5 (https://drafts.css-houdini.org/css-properties-values-api-1/).
     The spec admits only the named [<...>] type references below, the universal
     [*], bare [<ident>] keywords, and the [+]/[#] multipliers; alternatives are
     joined by [|]. *)

--- a/test/test_variables.ml
+++ b/test/test_variables.ml
@@ -607,6 +607,17 @@ let spec_multiplied_component_terminates () =
   check_any_syntax "\"<transform-function>+\"";
   check_any_syntax "\"<resolution>+\""
 
+(* CSS Properties and Values API 1 (ED) secs. 5.1, 5.2 and 5.4.3 define
+   [<transform-list>] as a pre-multiplied data type name. Consuming one returns
+   before the optional multiplier step, so applying [+] or [#] makes the whole
+   syntax definition invalid. *)
+let spec_premultiplied_component_rejects_multiplier () =
+  check_any_syntax "\"<transform-list>\"";
+  neg_cursor read_any_syntax "\"<transform-list>+\"";
+  neg_cursor read_any_syntax "\"<transform-list>#\"";
+  neg_cursor read_any_syntax "\"auto | <transform-list>+\"";
+  neg_cursor read_any_syntax "\"<transform-list># | <length>\""
+
 (* Not a roundtrip test *)
 let test_syntax () =
   (* Syntax checking is not available in current implementation *)
@@ -798,6 +809,9 @@ let tests =
     ( "spec multiplied component terminates",
       `Quick,
       spec_multiplied_component_terminates );
+    ( "spec premultiplied component rejects multiplier",
+      `Quick,
+      spec_premultiplied_component_rejects_multiplier );
     ("vars of calc", `Quick, test_vars_of_calc);
     ("vars of property", `Quick, test_vars_of_property);
     ("spec vars of property matrix", `Quick, spec_vars_of_property_matrix);


### PR DESCRIPTION
`<transform-list>` is already pre-multiplied, so accepting `+` or `#` registers a syntax browsers reject.