### PR TITLE
grid: reject invalid line indexes and spans

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -210,6 +210,9 @@ recorded cases carrying six minifiers' answers.
 - The span form of `<grid-line>` takes its operands in any order, as the `&&`
   and `||` combinators in its grammar allow. `grid-column-start: 3 span` is
   kept and printed `span 3`, where cascade used to drop the declaration (#711)
+- A grid line index cannot be zero and a grid span count must be positive.
+  Values such as `grid-column-start: 0`, `span 0` and `span -1` now drop the
+  declaration the way a browser does instead of being applied (#714)
 - `grid-auto-columns` and `grid-auto-rows` take a list of track sizes. They
   used to read the wider `grid-template-*` grammar, so a line-name block, a
   `repeat()`, `none` or a slash form parsed and applied where a browser drops

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -623,16 +623,21 @@ let read_grid_line_name t =
       (String.concat "" [ "reserved grid line name: "; name ])
   else name
 
+let read_grid_span_count t =
+  let n = Cursor.int t in
+  if n < 1 then Cursor.err_invalid t "grid span count must be positive";
+  n
+
 (* [ <integer [1,inf]> || <custom-ident> ]: one or both, in either order. *)
 let read_grid_span_parts t : grid_line =
-  match Cursor.option Cursor.int t with
+  match Cursor.option read_grid_span_count t with
   | Some n -> (
       match Cursor.option read_grid_line_name t with
       | Some name -> Span_num_name (n, name)
       | None -> Span n)
   | None -> (
       let name = read_grid_line_name t in
-      match Cursor.option Cursor.int t with
+      match Cursor.option read_grid_span_count t with
       | Some n -> Span_num_name (n, name)
       | None -> Span_name name)
 
@@ -648,9 +653,10 @@ let read_grid_span t : grid_line =
 
 let read_grid_line_number t : grid_line =
   let n = Cursor.int t in
+  if n = 0 then Cursor.err_invalid t "grid line index cannot be zero";
   Cursor.ws t;
   let name : string option =
-    if grid_line_at_end t then None else Cursor.option read_grid_line_name t
+    if grid_line_at_end t then None else Some (read_grid_line_name t)
   in
   match name with Some name -> Num_name (n, name) | None -> Num n
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4018,6 +4018,16 @@ let test_grid_line () =
   check_grid_line "content-end";
   check_grid_line "inherit";
   neg_cursor read_grid_line "span";
+  (* The ordinary integer branch in sec. 8.3 excludes zero, with or without a
+     line name. Negative indexes remain valid. *)
+  neg_cursor read_grid_line "0";
+  neg_cursor read_grid_line "0 foo";
+  (* CSS Grid 2 (ED) sec. 8.3 restricts the integer in a span to [1,inf].
+     Negative integers and zero are invalid in either operand order. *)
+  neg_cursor read_grid_line "span 0";
+  neg_cursor read_grid_line "0 span";
+  neg_cursor read_grid_line "span -1";
+  neg_cursor read_grid_line "-1 span";
   (* CSS Grid 2 (ED) sec. 8.3 gives the span branch as [span && [ <integer
      [1,inf]> || <custom-ident> ]]. CSS Values 4 (ED) sec. 2.2 makes both [&&]
      and [||] reorderable, so [span] sits on either side of the group and the


### PR DESCRIPTION
Zero grid-line indexes and non-positive span counts were applied even though browsers discard those declarations.