### PR TITLE
grid: reject shorthand forms in template longhands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -217,6 +217,9 @@ recorded cases carrying six minifiers' answers.
   used to read the wider `grid-template-*` grammar, so a line-name block, a
   `repeat()`, `none` or a slash form parsed and applied where a browser drops
   the declaration (#712)
+- `grid-template-columns` and `grid-template-rows` reject the slash and string
+  area forms reserved for the `grid-template` shorthand instead of applying
+  them as longhand values (#717)
 - A grid track list carries at least one track size, and never two line-name
   blocks in a row. `grid-template-columns: [a]` and `1px [a] [b] 2px` are
   dropped the way a browser drops them, inside a `repeat()` body and in the
@@ -1124,6 +1127,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Library
 
+- `Css.Properties.read_grid_template_tracks` parses the track-list grammar of
+  `grid-template-columns` and `grid-template-rows` without accepting the wider
+  shorthand forms handled by `read_grid_template` (#717)
 - The `Css.declaration_value_for_equivalence` docstring names the generic
   family that gates its unquoting: without one in the stream,
   `--font: "Noto Color Emoji"` and `--font: Noto Color Emoji` are distinct diff

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -752,8 +752,6 @@ let read_shape_outside t =
   Cursor.expect_eof t;
   raw
 
-let read_grid_template_list t = read_grid_template t
-
 (* Some properties (shape-margin, scroll-padding, padding, etc.) require a
    non-negative length-percentage. Detect a leading [-] number/percentage and
    reject before delegating to the typed reader. *)
@@ -1325,9 +1323,9 @@ let read_grid_value : type a. a property -> Cursor.t -> declaration option =
  fun prop t ->
   match prop with
   | Grid_template_columns ->
-      Some (v Grid_template_columns (read_grid_template_list t))
+      Some (v Grid_template_columns (read_grid_template_tracks t))
   | Grid_template_rows ->
-      Some (v Grid_template_rows (read_grid_template_list t))
+      Some (v Grid_template_rows (read_grid_template_tracks t))
   | Grid_row_start -> Some (v Grid_row_start (read_grid_line t))
   | Grid_row_end -> Some (v Grid_row_end (read_grid_line t))
   | Grid_column_start -> Some (v Grid_column_start (read_grid_line t))

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -924,6 +924,10 @@ val pp_grid_template_areas : grid_template_areas Pp.t
 val read_grid_template : Cursor.t -> grid_template
 (** [read_grid_template t] is the [grid_template] parsed from [t]. *)
 
+val read_grid_template_tracks : Cursor.t -> grid_template
+(** [read_grid_template_tracks t] is the [grid-template-columns] or
+    [grid-template-rows] track list parsed from [t]. *)
+
 val read_grid_auto_tracks : Cursor.t -> grid_template
 (** [read_grid_auto_tracks t] is the [grid-auto-columns] / [grid-auto-rows]
     value parsed from [t]. CSS Grid 2 (ED) sec. 7.6 gives those properties

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1944,6 +1944,12 @@ let grid () =
 
   check_declaration ~expected:"grid-template-rows:repeat(2,minmax(0,1fr))"
     "grid-template-rows: repeat(2, minmax(0, 1fr))";
+  (* CSS Grid 2 (ED) sec. 7.2 gives the longhands a track-list grammar. The
+     slash and string-area forms belong only to grid-template in sec. 7.4. *)
+  neg_cursor read_declaration "grid-template-columns: 1px / 2px";
+  neg_cursor read_declaration "grid-template-rows: 1px / 2px";
+  neg_cursor read_declaration "grid-template-columns: \"a\" 1px";
+  neg_cursor read_declaration "grid-template-rows: \"a\" 1px";
 
   (* Grid areas *)
   check_declaration


### PR DESCRIPTION
The public `read_grid_template_tracks` reader now gives the two longhands their own grammar instead of accepting slash and string-area shorthand forms.