### PR TITLE
Align math block whitespace context

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1075,6 +1075,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Canonical diff
 
+- Math-whitespace canonicalisation leaves math context in square and curly
+  blocks, matching the component-value printer and the `()`-only grouping
+  grammar (#720)
 - `:is(a, b)` and the selector list `a, b` compare equal when the arguments
   share one specificity, which is the split-against-grouped selector list the
   mode promises to equate (#655)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3827,7 +3827,7 @@ let is_mul_or_div_delim = function
   | _ -> false
 
 (* Outside a math function only the whitespace adjacent to a [*] or [/] delim is
-   insignificant (CSS Values 4 sec. 10.1): [16 / 9] and [16/9] re-tokenise
+   insignificant (CSS Values 4 sec. 10.8): [16 / 9] and [16/9] re-tokenise
    identically wherever the stream is substituted. Every other separator stays
    (a whitespace token between two values is part of the stream). *)
 let strip_mul_div_whitespace comps =
@@ -3887,9 +3887,9 @@ let strip_after_close_paren ~in_math comps =
 
 (* [in_math] tracks whether the current component list is inside a math
    function's grammar. It enters at the args of a [calc()] / [min()] / ... call,
-   propagates through grouping parens ([Block]s) since those are math operands,
-   and turns off when entering a nested non-math function like [var()] which has
-   its own grammar. *)
+   propagates through grouping paren [Block]s since those are math operands, and
+   turns off in square or curly blocks and nested non-math functions like
+   [var()], which have their own grammars. *)
 let rec canonicalize_math_whitespace ~in_math comps =
   let comps' =
     List.map
@@ -3906,7 +3906,14 @@ let rec canonicalize_math_whitespace ~in_math comps =
               { wrapped with node = { func with arguments = args } }
         | Component.Block wrapped ->
             let block = wrapped.Component.node in
-            let value = canonicalize_math_whitespace ~in_math block.value in
+            let nested_in_math =
+              match block.opening with
+              | Token.Paren -> in_math
+              | Token.Square | Token.Curly -> false
+            in
+            let value =
+              canonicalize_math_whitespace ~in_math:nested_in_math block.value
+            in
             Component.Block { wrapped with node = { block with value } }
         | Component.Preserved _ -> c)
       comps

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5318,9 +5318,9 @@ let skip_sum_operator t ~ws_before =
 let rec read_calc_expr : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
  fun read_a t ->
   Cursor.ws t;
-  (* CSS Values 4 10.7: [+] and [-] are left-associative, so [a - b - c] groups
-     as [(a - b) - c]. Loop on subsequent operators rather than recursing on the
-     right, which would group it as [a - (b - c)]. *)
+  (* CSS Values 4 sec. 10.1 evaluates same-precedence operators left-to-right,
+     so [a - b - c] groups as [(a - b) - c]. Loop on subsequent operators rather
+     than recursing on the right, which would group it as [a - (b - c)]. *)
   let rec loop left =
     let ws_before = Cursor.skip_ws t in
     match Cursor.peek_delim t with

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -5322,8 +5322,7 @@ let additional_tests =
     test_case "outline" `Quick test_outline;
     test_case "outline_shorthand" `Quick test_outline_shorthand;
     test_case "ray_size" `Quick test_ray_size;
-    test_case "canonical math block context" `Quick
-      canonical_math_block_context;
+    test_case "canonical math block context" `Quick canonical_math_block_context;
     test_case "background" `Quick test_background;
     test_case "font_family" `Quick test_font_family;
     test_case "text_shadow" `Quick test_text_shadow;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -5301,6 +5301,17 @@ let test_ray_size () =
     sizes;
   neg_cursor read_ray_size "10px"
 
+(* A square or curly block is not a grouping operand in the CSS math grammar.
+   Canonical whitespace therefore leaves math context when it enters one, just
+   as the component-value printer does. *)
+let canonical_math_block_context () =
+  let components = Cursor.remaining (Cursor.of_string "calc([f() + 1])") in
+  let actual =
+    components |> canonicalize_math_whitespace_components
+    |> Parser.to_string_custom
+  in
+  check string "square block ends math context" "calc([f()+ 1])" actual
+
 let additional_tests =
   [
     test_case "will_change" `Quick test_will_change;
@@ -5311,6 +5322,8 @@ let additional_tests =
     test_case "outline" `Quick test_outline;
     test_case "outline_shorthand" `Quick test_outline_shorthand;
     test_case "ray_size" `Quick test_ray_size;
+    test_case "canonical math block context" `Quick
+      canonical_math_block_context;
     test_case "background" `Quick test_background;
     test_case "font_family" `Quick test_font_family;
     test_case "text_shadow" `Quick test_text_shadow;


### PR DESCRIPTION
Square and curly blocks are not grouping operands in CSS math grammar, so canonicalization no longer propagates math whitespace context into them. The nearby CSS Values references for math whitespace and left-to-right evaluation are corrected.