### PR TITLE
Normalize calc parentheses outside printers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1075,6 +1075,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Canonical diff
 
+- Calc printers preserve authored grouping nodes. Redundant parentheses are
+  removed by value normalization instead, while precedence-sensitive groups
+  are reconstructed from the expression tree (#721)
 - Math-whitespace canonicalisation leaves math context in square and curly
   blocks, matching the component-value printer and the `()`-only grouping
   grammar (#720)

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -947,6 +947,25 @@ let rec calc_contains_var : type a. a calc -> bool = function
   | Nested inner | Parens inner -> calc_contains_var inner
   | Expr (l, _, r) -> calc_contains_var l || calc_contains_var r
 
+(* Drop authored grouping nodes while retaining the expression tree that gives
+   them their meaning. The printer's precedence rules reconstruct parentheses
+   exactly where serialization still needs them. This is an AST normalization,
+   so a non-normalized value keeps every authored [Parens] node. *)
+let rec normalize_calc_parens : type a. a calc -> a calc =
+ fun calc ->
+  match calc with
+  | Parens inner -> normalize_calc_parens inner
+  | Nested inner ->
+      let inner' = normalize_calc_parens inner in
+      if inner' == inner then calc else Nested inner'
+  | Expr (left, op, right) ->
+      let left' = normalize_calc_parens left in
+      let right' = normalize_calc_parens right in
+      if left' == left && right' == right then calc else Expr (left', op, right')
+  | Val _ | Var _ | Num _ | Math_const _ | Math_fn _ | Sibling_index
+  | Sibling_count ->
+      calc
+
 let pp_calc_contents : type a. a Pp.t -> a calc Pp.t =
  fun pp_value ctx calc ->
   let precedence = function Add | Sub -> 1 | Mul | Div -> 2 in
@@ -967,8 +986,6 @@ let pp_calc_contents : type a. a Pp.t -> a calc Pp.t =
           (fun ctx inner ->
             pp_calc_inner ~parent_prec:0 ~right_of_noncommut:false ctx inner)
           ctx inner
-    | Parens inner when Pp.minified ctx ->
-        pp_calc_inner ~parent_prec ~right_of_noncommut ctx inner
     | Parens inner ->
         Pp.char ctx '(';
         pp_calc_inner ~parent_prec:0 ~right_of_noncommut:false ctx inner;
@@ -1123,8 +1140,8 @@ let unwrap_grouping : type a.
   | Var v as leaf when ctx.var_is_single_valued v.name -> leaf
   | reduced -> rewrap reduced
 
-let rec eval_calc : type a. ?ctx:calc_ctx -> a calc -> a calc =
- fun ?(ctx = default_calc_ctx) -> function
+let rec eval_calc_inner : type a. ctx:calc_ctx -> a calc -> a calc =
+ fun ~ctx -> function
   | (Num _ | Val _ | Var _ | Sibling_index | Sibling_count) as leaf -> leaf
   | Math_const _ as leaf -> leaf
   | Math_fn fn when math_fn_contains_var fn -> Math_fn fn
@@ -1136,12 +1153,16 @@ let rec eval_calc : type a. ?ctx:calc_ctx -> a calc -> a calc =
       | Some (Scalar v) -> Num v
       | Some (United _) | None -> Math_fn fn)
   | Nested inner ->
-      unwrap_grouping ~ctx ~rewrap:(fun r -> Nested r) (eval_calc ~ctx inner)
+      unwrap_grouping ~ctx
+        ~rewrap:(fun r -> Nested r)
+        (eval_calc_inner ~ctx inner)
   | Parens inner ->
-      unwrap_grouping ~ctx ~rewrap:(fun r -> Parens r) (eval_calc ~ctx inner)
+      unwrap_grouping ~ctx
+        ~rewrap:(fun r -> Parens r)
+        (eval_calc_inner ~ctx inner)
   | Expr (l, op, r) -> (
-      let l = eval_calc ~ctx l in
-      let r = eval_calc ~ctx r in
+      let l = eval_calc_inner ~ctx l in
+      let r = eval_calc_inner ~ctx r in
       (* Match on the const-folded operands but keep [l] / [r] in the no-fold
          results, so an unreduced expression keeps the short [calc(.. pi ..)].
          Identity rules need a type-aware [Val] inspection (runtime subst?);
@@ -1165,6 +1186,9 @@ let rec eval_calc : type a. ?ctx:calc_ctx -> a calc -> a calc =
               match fold_zero_numeric_expr lc op rc with
               | Some zero -> zero
               | None -> Expr (l, op, r))))
+
+let eval_calc ?(ctx = default_calc_ctx) calc =
+  normalize_calc_parens (eval_calc_inner ~ctx calc)
 
 (* A subtree Cascade has to evaluate to a float of its own: a math constant or a
    math function. A fold that consumes one lands a computed coefficient in the
@@ -1273,7 +1297,7 @@ let eval_typed_calc : type a.
     let reduced, computed = reduce inner in
     (unwrap_grouping ~ctx ~rewrap reduced, computed)
   in
-  settle_computed round (reduce calc)
+  normalize_calc_parens (settle_computed round (reduce calc))
 
 let pp_calc_with : type a. ?unwrap_num:bool -> a Pp.t -> a calc Pp.t =
  fun ?(unwrap_num = true) pp_value ctx calc ->

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2897,9 +2897,9 @@ let unterminated () =
      an explicit closer would have produced -- the parser must not silently drop
      content. *)
   check_declaration ~expected:"content:\"abc\"" "content: \"abc";
-  (* The auto-closed inner parens collapse to a single value, leaving the outer
-     mixed-unit calc preserved. *)
-  check_declaration ~expected:"width:calc(100% - 10px)"
+  (* The cursor parser preserves the auto-closed inner parens. The stylesheet
+     recovery path drops this incomplete declaration before normalization. *)
+  check_declaration ~expected:"width:calc(100% - (10px))"
     "width: calc(100% - (10px)";
   (* Declaration-level recovery can accept the unterminated color function; the
      stylesheet parser drops it, so assert the optimize oracle directly through

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -711,6 +711,36 @@ let test_minified_value_formatting () =
   let s = Css.Pp.to_string ~minify:true pp_length Zero in
   check string "minified zero" "0" s
 
+(* Parenthesis removal is an AST normalization, not a printer choice. The
+   printer preserves the parsed tree; normalization drops only groups whose
+   removal does not change precedence or associativity. *)
+let calc_parenthesis_layering () =
+  let render value = Css.Pp.to_string ~minify:true pp_length value in
+  let parse source = read_length (Cursor.of_string source) in
+  let cases =
+    [
+      ( "calc((1px + var(--a)) - 3px)",
+        "calc((1px + var(--a)) - 3px)",
+        "calc(1px + var(--a) - 3px)" );
+      ( "calc((1px - var(--a)) * 3)",
+        "calc((1px - var(--a))*3)",
+        "calc((1px - var(--a))*3)" );
+      ( "calc((100% - var(--a)) / 2)",
+        "calc((100% - var(--a))/2)",
+        "calc((100% - var(--a))/2)" );
+      ( "calc(1px - (var(--a) + 3px))",
+        "calc(1px - (var(--a) + 3px))",
+        "calc(1px - (var(--a) + 3px))" );
+    ]
+  in
+  List.iter
+    (fun (source, printed, optimized) ->
+      let parsed = parse source in
+      check string "printer preserves parsed groups" printed (render parsed);
+      check string "normalizer owns redundant groups" optimized
+        (render (normalize_length parsed)))
+    cases
+
 (* Not a roundtrip test *)
 let test_regular_value_formatting () =
   let s = Css.Pp.to_string pp_length (Rem 0.5) in
@@ -1759,6 +1789,7 @@ let value_tests =
     (* Additional value tests *)
     test_case "var default inline" `Quick test_var_default_inline;
     test_case "minified value formatting" `Quick test_minified_value_formatting;
+    test_case "calc parenthesis layering" `Quick calc_parenthesis_layering;
     test_case "regular value formatting" `Quick test_regular_value_formatting;
     test_case "oklch printing" `Quick test_color_oklch_printing;
     test_case "oklch none hue" `Quick test_color_oklch_none_hue;


### PR DESCRIPTION
Redundant calc parentheses are removed during value normalization rather than low-level printing, keeping raw AST serialization faithful while normalized output stays compact. Precedence-sensitive groups remain intact.