### PR TITLE
Keep component separators after functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1075,6 +1075,8 @@ recorded cases carrying six minifiers' answers.
 
 ### Canonical diff
 
+- Typed position and colour printers retain a component separator after a
+  function-closing parenthesis, matching custom-value serialisation (#722)
 - Calc printers preserve authored grouping nodes. Redundant parentheses are
   removed by value normalization instead, while precedence-sensitive groups
   are reconstructed from the expression tree (#721)

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -178,6 +178,15 @@ let canonicalise_gradient_stops stops =
 let pp_position_offset ctx (lp : Values.length_percentage) =
   pp_length_percentage ~always:true ctx lp
 
+(* A percentage token closes at [%], so its following position component can
+   touch it under minify. A function ending in [)] remains a distinct grammar
+   component and keeps the same separator the custom-value serialiser keeps. *)
+let position_component_space : unit Pp.t =
+ fun ctx () ->
+  match Pp.last_char ctx with
+  | Some '%' when Pp.minified ctx -> ()
+  | _ -> Pp.space ctx ()
+
 let rec pp_position_value : position_value Pp.t =
  fun ctx -> function
   | Inherit -> Pp.string ctx "inherit"
@@ -204,14 +213,14 @@ let rec pp_position_value : position_value Pp.t =
   | Bottom_right -> Pp.string ctx "bottom right"
   | XY (a, b) ->
       pp_length ctx a;
-      Pp.token_sp ctx ();
+      position_component_space ctx ();
       pp_length ctx b
   | Single l -> pp_length ctx l
   | Edge_offset_axis (edge, offset, axis) ->
       Pp.string ctx edge;
       Pp.space ctx ();
       pp_position_offset ctx offset;
-      Pp.token_sp ctx ();
+      position_component_space ctx ();
       Pp.string ctx axis
   | Axis_edge_offset (axis, edge, offset) ->
       Pp.string ctx axis;
@@ -223,7 +232,7 @@ let rec pp_position_value : position_value Pp.t =
       Pp.string ctx edge1;
       Pp.space ctx ();
       pp_position_offset ctx offset1;
-      Pp.token_sp ctx ();
+      position_component_space ctx ();
       Pp.string ctx edge2;
       Pp.space ctx ();
       pp_position_offset ctx offset2

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4489,24 +4489,15 @@ let string_of_scaled_color_axis ~pct_scale ctx f =
 let space_after_color_percentage ctx (l : percentage option) ~next =
   (* The space between the L channel and the next colour component elides when
      the L spelling closes its token cleanly: a [%] ends its percentage token
-     whatever follows, a [)] from [Var] / [Calc] needs the next token to start
-     its own boundary, and a bare-number end ([4] in [.654]) needs a sign-token
-     [+] / [-] to start the next number. [None] / unknown left-hand stays
-     conservative. *)
+     whatever follows, and a bare-number end ([4] in [.654]) needs a sign-token
+     [+] / [-] to start the next number. Functions and [None] / unknown
+     left-hand values stay conservative. *)
   let starts_signed s = String.length s > 0 && (s.[0] = '+' || s.[0] = '-') in
-  let next_safe_after_paren s =
-    String.length s > 0
-    &&
-    match s.[0] with
-    | '0' .. '9' | '.' | '+' | '-' | '#' -> true
-    | _ -> false
-  in
   let elidable =
     Pp.minified ctx
     && (Pp.last_char ctx = Some '%'
        ||
        match (l, next) with
-       | Some (Var _ | Calc _), Some s -> next_safe_after_paren s
        | Some (Num _), Some s -> starts_signed s
        | _ -> false)
   in

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -465,6 +465,8 @@ let special_cases () =
   check_declaration ~expected:"background-position:30%50%,70%50%"
     ~optimized:"background-position:30%,70%"
     "background-position: 30% 50%, 70% 50%;";
+  check_declaration ~expected:"background-position:var(--x) 20%"
+    "background-position: var(--x) 20%;";
   check_declaration ~expected:"mask-position:0 0,10px 10px"
     "mask-position: 0 0, 10px 10px;";
 

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -764,7 +764,20 @@ let test_color_oklch_printing () =
   let open Css.Values in
   let c = oklch 50.0 0.123 30.0 in
   let s = Css.Pp.to_string pp_color c in
-  Alcotest.(check string) "oklch printing" "oklch(50% .123 30)" s
+  Alcotest.(check string) "oklch printing" "oklch(50% .123 30)" s;
+  let dynamic =
+    Oklch
+      {
+        l = Some (Var (var_ref "l"));
+        c = Some 0.237;
+        h = Unitless 25.;
+        alpha = None;
+      }
+  in
+  Alcotest.(check string)
+    "a dynamic lightness keeps its following separator"
+    "oklch(var(--l) .237 25)"
+    (Css.Pp.to_string ~minify:true pp_color dynamic)
 
 (* A [none] hue is a missing component, not the number zero: it stays [none]
    through printing, and the colour cannot fold to a hex because a hex would pin


### PR DESCRIPTION
Typed position and colour printers now retain component separators after function-closing parentheses, matching custom-value serialization. Percentage-token boundaries remain compact because `%` closes the token unambiguously.