### PR TITLE
Show values for gained declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- `Tree_diff.Content_changed` carries property/value pairs in
+  `added_properties` and `removed_properties`, so callers can report the value
+  and priority of a declaration that exists on only one side (#723)
 - Public declaration helpers whose CSS values require a non-empty list now
   raise `Invalid_argument` for `[]` instead of emitting a declaration with no
   value.

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -137,6 +137,13 @@ let sig_of_decls decls =
       let c = String.compare a1 a2 in
       if c <> 0 then c else String.compare b1 b2)
 
+let reported_declaration d =
+  let value = Css.declaration_value ~minify:false d in
+  let value =
+    if Css.declaration_is_important d then value ^ " !important" else value
+  in
+  (Css.declaration_name d, value)
+
 let restore_group_order table =
   Hashtbl.to_seq_keys table |> List.of_seq
   |> List.iter (fun key ->
@@ -182,12 +189,18 @@ let diff_same_key_pair key d1 d2 =
            property_changes = [];
            added_properties =
              List.filter_map
-               (fun (p, _) -> if List.mem_assoc p sig1 then None else Some p)
-               sig2;
+               (fun d ->
+                 let p = Css.declaration_name d in
+                 if List.mem_assoc p sig1 then None
+                 else Some (reported_declaration d))
+               d2;
            removed_properties =
              List.filter_map
-               (fun (p, _) -> if List.mem_assoc p sig2 then None else Some p)
-               sig1;
+               (fun d ->
+                 let p = Css.declaration_name d in
+                 if List.mem_assoc p sig2 then None
+                 else Some (reported_declaration d))
+               d1;
          })
   else None
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -18,8 +18,8 @@ type rule_diff =
       old_declarations : Css.declaration list;
       new_declarations : Css.declaration list;
       property_changes : declaration list;
-      added_properties : string list;
-      removed_properties : string list;
+      added_properties : (string * string) list;
+      removed_properties : (string * string) list;
     }
   | Selector_changed of {
       old_selector : string;
@@ -392,16 +392,17 @@ let pp_content_changed_body ~style ~child_prefix buf ~old_declarations
     ~new_declarations ~property_changes ~added_properties ~removed_properties
     ~has_any_changes =
   let indent = child_indent ~style ~parent_prefix:child_prefix in
-  List.iter
-    (fun prop_name ->
-      add_strings buf
-        [ indent; ansi_red ~color:style.color ("- " ^ prop_name); "\n" ])
-    removed_properties;
-  List.iter
-    (fun prop_name ->
-      add_strings buf
-        [ indent; ansi_green ~color:style.color ("+ " ^ prop_name); "\n" ])
-    added_properties;
+  let pp_presence marker paint (prop_name, value) =
+    let value = String_diff.truncate_middle default_truncation_length value in
+    add_strings buf
+      [
+        indent;
+        paint ~color:style.color (marker ^ " " ^ prop_name ^ ": " ^ value);
+        "\n";
+      ]
+  in
+  List.iter (pp_presence "-" ansi_red) removed_properties;
+  List.iter (pp_presence "+" ansi_green) added_properties;
   pp_property_diffs ~style ~parent_prefix:child_prefix buf property_changes;
   pp_reorder ~style ~parent_prefix:child_prefix old_declarations
     new_declarations buf;
@@ -1989,15 +1990,15 @@ let rec zip_occurrences name (modified, added, removed) values1 values2 =
           :: modified
       in
       zip_occurrences name (modified, added, removed) rest1 rest2
-  | _ :: rest1, [] ->
-      zip_occurrences name (modified, added, name :: removed) rest1 []
-  | [], _ :: rest2 ->
-      zip_occurrences name (modified, name :: added, removed) [] rest2
+  | (_, shown) :: rest1, [] ->
+      zip_occurrences name (modified, added, (name, shown) :: removed) rest1 []
+  | [], (_, shown) :: rest2 ->
+      zip_occurrences name (modified, (name, shown) :: added, removed) [] rest2
 
 (* Helper function to compute property diffs between two declaration lists,
    including added and removed properties *)
-let properties_diff decls1 decls2 : declaration list * string list * string list
-    =
+let properties_diff decls1 decls2 :
+    declaration list * (string * string) list * (string * string) list =
   let props1 = List.map decl_to_reported_value decls1 in
   let props2 = List.map decl_to_reported_value decls2 in
   (* Names the expected side writes first, then the ones only the actual side
@@ -2580,8 +2581,8 @@ let property_descriptor_changes prop1 prop2 =
         | _ -> None)
       descs1
   in
-  let only_in others (name, _) =
-    if List.mem_assoc name others then None else Some name
+  let only_in others ((name, _) as descriptor) =
+    if List.mem_assoc name others then None else Some descriptor
   in
   ( changed,
     List.filter_map (only_in descs1) descs2,

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -18,8 +18,8 @@ type rule_diff =
       old_declarations : Css.declaration list;
       new_declarations : Css.declaration list;
       property_changes : declaration list;
-      added_properties : string list;
-      removed_properties : string list;
+      added_properties : (string * string) list;
+      removed_properties : (string * string) list;
     }
   | Selector_changed of {
       old_selector : string;

--- a/test/cli/diff_depth.t
+++ b/test/cli/diff_depth.t
@@ -56,7 +56,7 @@ qualifies every difference below it.
   --- a.css
   +++ warn.css
   └─ .x
-        - margin
+        - margin: 0
   
   [1]
 

--- a/test/cli/diff_nested_block.t
+++ b/test/cli/diff_nested_block.t
@@ -40,7 +40,7 @@ declaration in the selector column.
   --- run-a.css
   +++ run-b.css
   ├─ .a
-  │     - color
+  │     - color: red
   └─ .a { & } (1 added)
      └─ &
            + color: red

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -413,8 +413,10 @@ let diff_property_initial_value_added () =
         | _ -> [])
       d.containers
   in
-  Alcotest.(check (list string))
-    "names the descriptor gained" [ "initial-value" ] added
+  Alcotest.(check (list (pair string string)))
+    "names the descriptor gained"
+    [ ("initial-value", "red") ]
+    added
 
 (* ===== Container (media) changes ===== *)
 
@@ -822,7 +824,7 @@ let lost_declaration_is_not_a_move () =
     (List.length (rearranged_of d));
   Alcotest.(check bool)
     "the loss is still reported" true
-    (Astring.String.is_infix ~affix:"- margin" (render d))
+    (Astring.String.is_infix ~affix:"- margin: 0" (render d))
 
 let gained_declaration_is_not_a_move () =
   let d =
@@ -835,6 +837,15 @@ let gained_declaration_is_not_a_move () =
   Alcotest.(check bool)
     "the difference is still reported" false
     (Cascade_diff.Tree_diff.is_empty d)
+
+let gained_declaration_shows_value () =
+  let d =
+    diff_of ~expected:".a{color:red}"
+      ~actual:".a{color:red;margin:100px!important}"
+  in
+  Alcotest.(check bool)
+    "the gained value and priority are reported" true
+    (Astring.String.is_infix ~affix:"+ margin: 100px !important" (render d))
 
 let changed_value_is_not_a_move () =
   let d =
@@ -1033,15 +1044,17 @@ let repeated_property_pairs_every_occurrence () =
 let repeated_property_surplus_is_removed () =
   let d = diff_of ~expected:"a{color:red;color:blue}" ~actual:"a{color:red}" in
   Alcotest.(check (list string)) "no value changed" [] (rule_property_changes d);
-  Alcotest.(check (list string))
-    "the occurrence with no counterpart is removed" [ "color" ]
+  Alcotest.(check (list (pair string string)))
+    "the occurrence with no counterpart is removed"
+    [ ("color", "blue") ]
     (rule_removed_properties d)
 
 let repeated_property_surplus_is_added () =
   let d = diff_of ~expected:"a{color:red}" ~actual:"a{color:red;color:blue}" in
   Alcotest.(check (list string)) "no value changed" [] (rule_property_changes d);
-  Alcotest.(check (list string))
-    "the occurrence with no counterpart is added" [ "color" ]
+  Alcotest.(check (list (pair string string)))
+    "the occurrence with no counterpart is added"
+    [ ("color", "blue") ]
     (rule_added_properties d)
 
 (* ===== Containers nested past the old recursion cutoff ===== *)
@@ -1543,6 +1556,8 @@ let suite =
         lost_declaration_is_not_a_move;
       Alcotest.test_case "gained declaration is not a move" `Quick
         gained_declaration_is_not_a_move;
+      Alcotest.test_case "gained declaration shows value" `Quick
+        gained_declaration_shows_value;
       Alcotest.test_case "changed value is not a move" `Quick
         changed_value_is_not_a_move;
       Alcotest.test_case "added important is not a move" `Quick


### PR DESCRIPTION
Tree diffs now retain and display the authored value and `!important` priority for declarations present on only one side. The public `Content_changed.added_properties` and `removed_properties` fields change from name lists to pair lists.