### PR TITLE
Reserve revert-rule as CSS-wide

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -210,6 +210,8 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- `revert-rule` is reserved wherever a grammar accepts a `<custom-ident>`, so
+  it no longer survives inside grid line-name lists as an ordinary name (#724)
 - The span form of `<grid-line>` takes its operands in any order, as the `&&`
   and `||` combinators in its grammar allow. `grid-column-start: 3 span` is
   kept and printed `span 3`, where cascade used to drop the declaration (#711)

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -34,7 +34,7 @@ let rec pp_css_wide : css_wide Pp.t =
   | Var v -> Values.pp_var pp_css_wide ctx v
 
 let css_wide_keywords =
-  [ "initial"; "inherit"; "unset"; "revert"; "revert-layer" ]
+  [ "initial"; "inherit"; "unset"; "revert"; "revert-layer"; "revert-rule" ]
 
 let is_css_wide_keyword value =
   List.mem (String.lowercase_ascii value) css_wide_keywords

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4073,9 +4073,11 @@ let test_grid_line () =
   neg_cursor ~allow_partial:true read_grid_line "3 unset";
   neg_cursor ~allow_partial:true read_grid_line "3 revert";
   neg_cursor ~allow_partial:true read_grid_line "3 revert-layer";
+  neg_cursor ~allow_partial:true read_grid_line "3 revert-rule";
   (* CSS Cascade 5 (ED) sec. 7.3: explicit defaulting takes the whole
      declaration, so a CSS-wide keyword is a [<grid-line>] on its own only. *)
   check_grid_line "initial";
+  check_grid_line "revert-rule";
   neg_cursor read_grid_line "initial 3";
   (* [<grid-line>] has no [none] and no [dense] keyword, so neither is excluded
      from its [<custom-ident>]. *)
@@ -4149,6 +4151,7 @@ let test_grid_template () =
   neg_cursor read_grid_template "[unset] 1px";
   neg_cursor read_grid_template "[revert] 1px";
   neg_cursor read_grid_template "[revert-layer] 1px";
+  neg_cursor read_grid_template "[revert-rule] 1px";
   neg_cursor read_grid_template "[a span] 1px";
   neg_cursor ~allow_partial:true read_grid_template "1px [span]";
   (* Nothing else is excluded: the brackets make the position unambiguous, so a


### PR DESCRIPTION
`revert-rule` is a CSS-wide keyword and must be excluded from `<custom-ident>` values, so grid line-name lists now reject it while a lone grid-line value remains accepted.