### PR TITLE
Accept place-items baseline positions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ recorded cases carrying six minifiers' answers.
 
 ### Breaking
 
+- `place_items` gains `First_baseline` and `Last_baseline`, preserving the two
+  modifier-first baseline positions accepted by `place-items` (#725)
 - `Tree_diff.Content_changed` carries property/value pairs in
   `added_properties` and `removed_properties`, so callers can report the value
   and priority of a declaration that exists on only one side (#723)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -4088,6 +4088,8 @@ type place_items = Properties.place_items =
   | Center
   | Stretch
   | Baseline
+  | First_baseline
+  | Last_baseline
   | Start_safe
   | End_safe
   | Center_safe

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -416,6 +416,8 @@ let rec pp_place_items : place_items Pp.t =
   | Center -> Pp.string ctx "center"
   | Stretch -> Pp.string ctx "stretch"
   | Baseline -> Pp.string ctx "baseline"
+  | First_baseline -> Pp.string ctx "first baseline"
+  | Last_baseline -> Pp.string ctx "last baseline"
   | Start_safe -> Pp.string ctx "safe start"
   | End_safe -> Pp.string ctx "safe end"
   | Center_safe -> Pp.string ctx "safe center"
@@ -530,8 +532,23 @@ let place_items_align : place_items -> align_items option = function
   | End -> Some End
   | Center -> Some Center
   | Baseline -> Some Baseline
+  | First_baseline -> Some First_baseline
+  | Last_baseline -> Some Last_baseline
   | Stretch -> Some Stretch
   | _ -> None
+
+(* css-align-3 (ED) sec. 4.2: <baseline-position> = [ first | last ]? &&
+   baseline. The [&&] is order-free, but only the modifier-first spelling is
+   read: no browser takes the modifier after the keyword. *)
+let read_place_items_baseline t =
+  let value =
+    Cursor.enum "place-items"
+      [ ("first", (First_baseline : place_items)); ("last", Last_baseline) ]
+      t
+  in
+  Cursor.ws t;
+  Cursor.expect_string "baseline" t;
+  value
 
 let read_place_items_first t =
   Cursor.enum "place-items"
@@ -543,7 +560,7 @@ let read_place_items_first t =
       ("baseline", Baseline);
       ("inherit", Inherit);
     ]
-    t
+    ~default:read_place_items_baseline t
 
 let read_place_items_default t =
   if Cursor.looking_at t "safe" then read_place_items_safe t

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -729,6 +729,8 @@ type place_items =
   | Center
   | Stretch
   | Baseline
+  | First_baseline
+  | Last_baseline
   | Start_safe
   | End_safe
   | Center_safe

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4293,6 +4293,17 @@ let test_place_items () =
   check_place_items "start end";
   check_place_items ~expected:"center" "center center";
   check_place_items "inherit";
+  (* css-align-3 (ED) sec. 4.2: <baseline-position> = [ first | last ]? &&
+     baseline, in either half of the sec. 7.3 shorthand. *)
+  check_place_items "baseline";
+  check_place_items "first baseline";
+  check_place_items "last baseline";
+  check_place_items "first baseline center";
+  check_place_items "center last baseline";
+  check_place_items "first baseline last baseline";
+  (* The && is order-free, but the modifier is only read before the keyword. *)
+  neg_cursor ~allow_partial:true read_place_items "baseline first";
+  neg_cursor ~allow_partial:true read_place_items "baseline last";
   neg_cursor read_place_items "invalid-place"
 
 let test_box_decoration_break () =


### PR DESCRIPTION
`place-items` now accepts and prints the modifier-first `first baseline` and `last baseline` forms, while browser-invalid suffix forms remain rejected. The public `place_items` variant has matching constructors.