### PR TITLE
Defer CSS-wide mixes containing substitutions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -212,6 +212,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- Declarations containing a non-empty `var()`, `env()` or `attr()` call defer
+  CSS-wide keyword mix validation until substitution, instead of being dropped
+  while the substituted token stream is still unknown (#726)
 - `revert-rule` is reserved wherever a grammar accepts a `<custom-ident>`, so
   it no longer survives inside grid line-name lists as an ordinary name (#724)
 - The span form of `<grid-line>` takes its operands in any order, as the `&&`

--- a/fuzz/fuzz_properties.ml
+++ b/fuzz/fuzz_properties.ml
@@ -688,15 +688,27 @@ let assert_decl_roundtrip label input =
 let assert_decl_reject label input =
   assert_invalid_declaration_contract label input
 
+let inventory_value_has_substitution value =
+  let value = String.lowercase_ascii value in
+  List.exists
+    (fun name -> Astring.String.is_infix ~affix:(name ^ "(") value)
+    [ "var"; "env"; "attr" ]
+
 let invalid_property_mutation
     (row : Cascade_spec_inventory.Property_grammar.row) value buf =
-  match byte_at buf 4 mod 6 with
-  | 0 -> pick row.negatives buf 5
-  | 1 -> "initial " ^ value
-  | 2 -> "inherit " ^ value
-  | 3 -> "var()"
-  | 4 -> value ^ " )"
-  | _ -> value ^ " " ^ pick row.negatives buf 6
+  if inventory_value_has_substitution value then
+    (* Once an arbitrary substitution is present, otherwise-invalid property
+       grammar is deliberately deferred. Keep these mutations invalid at the CSS
+       token/substitution layer instead. *)
+    pick [ "var()"; value ^ " attr()"; value ^ " env()" ] buf 4
+  else
+    match byte_at buf 4 mod 6 with
+    | 0 -> pick row.negatives buf 5
+    | 1 -> "initial " ^ value
+    | 2 -> "inherit " ^ value
+    | 3 -> "var()"
+    | 4 -> value ^ " )"
+    | _ -> value ^ " " ^ pick row.negatives buf 6
 
 let var_token_stream_fallback buf =
   pick

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -269,19 +269,25 @@ let invalid_var_arguments arguments =
       | _ -> true)
   | _ -> true
 
-let rec components_have_invalid_var components =
-  List.exists component_has_invalid_var components
+let rec components_have_invalid_substitution components =
+  List.exists component_has_invalid_substitution components
 
-and component_has_invalid_var = function
-  | Component.Func { node = { name; arguments; terminated; _ }; _ }
-    when String.lowercase_ascii_preserve name = "var" ->
-      (not terminated)
-      || invalid_var_arguments arguments
-      || components_have_invalid_var arguments
-  | Component.Func { node = { arguments; _ }; _ } ->
-      components_have_invalid_var arguments
+and component_has_invalid_substitution = function
+  | Component.Func { node = { name; arguments; terminated; _ }; _ } ->
+      let invalid_call =
+        match String.lowercase_ascii_preserve name with
+        | "var" -> (not terminated) || invalid_var_arguments arguments
+        | "env" | "attr" ->
+            (not terminated)
+            || not
+                 (List.exists
+                    (fun component -> not (is_ws_component component))
+                    arguments)
+        | _ -> false
+      in
+      invalid_call || components_have_invalid_substitution arguments
   | Component.Block { node = { value; _ }; _ } ->
-      components_have_invalid_var value
+      components_have_invalid_substitution value
   | Component.Preserved _ -> false
 
 let rec components_contain_var components =
@@ -294,21 +300,43 @@ and component_contains_var = function
   | Component.Block { node = { value; _ }; _ } -> components_contain_var value
   | Component.Preserved _ -> false
 
-let raw_value_has_invalid_var raw_value =
-  Cursor.of_string raw_value |> Cursor.remaining |> components_have_invalid_var
+(* CSS Values 5 (ED) sec. 11 groups [var()], [env()] and [attr()] as arbitrary
+   substitution functions: each carries an unknown token stream into the value,
+   so a declaration holding one is valid at parse time and only decided once
+   substitution has run. A call with an empty argument list matches no
+   substitution grammar and so defers nothing. *)
+let is_substitution_call name arguments =
+  (match String.lowercase_ascii_preserve name with
+    | "var" | "env" | "attr" -> true
+    | _ -> false)
+  && List.exists (fun component -> not (is_ws_component component)) arguments
 
-let raw_value_contains_var raw_value =
-  (* CSS Custom Properties 1 section 3: a top-level [var()] leaves the typed
-     reader unable to validate the substituted result, so cascade keeps the
-     value verbatim. A [var()] nested inside another function does not extend
-     that leniency to the surrounding tokens; only a top-level one counts. *)
-  let is_top_level_var = function
-    | Component.Func { node = { name; _ }; _ }
-      when String.lowercase_ascii_preserve name = "var" ->
-        true
+let rec components_have_substitution components =
+  List.exists component_has_substitution components
+
+and component_has_substitution = function
+  | Component.Func { node = { name; arguments; _ }; _ } ->
+      is_substitution_call name arguments
+      || components_have_substitution arguments
+  | Component.Block { node = { value; _ }; _ } ->
+      components_have_substitution value
+  | Component.Preserved _ -> false
+
+let raw_value_has_invalid_substitution raw_value =
+  Cursor.of_string raw_value |> Cursor.remaining
+  |> components_have_invalid_substitution
+
+let raw_value_contains_substitution raw_value =
+  (* A top-level substitution leaves the typed reader unable to validate the
+     result, so cascade keeps the value verbatim. One nested inside another
+     function does not extend that leniency to the surrounding tokens; only a
+     top-level one counts. *)
+  let is_top_level = function
+    | Component.Func { node = { name; arguments; _ }; _ } ->
+        is_substitution_call name arguments
     | _ -> false
   in
-  Cursor.of_string raw_value |> Cursor.remaining |> List.exists is_top_level_var
+  Cursor.of_string raw_value |> Cursor.remaining |> List.exists is_top_level
 
 (** Check for and consume [!important] (case-insensitive per CSS Syntax). *)
 let read_importance t =
@@ -2082,12 +2110,19 @@ let components_are_lone_css_wide cvs =
   | _ -> false
 
 let validate_regular_property_components t name components =
+  (* A substitution function makes the declaration's grammar a computed-value
+     question. This includes [all]: the substitution result can be empty and
+     leave its neighbouring CSS-wide keyword as the whole value. *)
+  let has_substitution = components_have_substitution components in
   if
     (not (property_allows_keyword_as_ident name))
+    && (not has_substitution)
     && Properties.components_have_css_wide_mix components
   then Cursor.err_invalid t "CSS-wide keyword mixed with other values";
-  if name = "all" && not (components_are_lone_css_wide components) then
-    Cursor.err_invalid t "all accepts only CSS-wide keywords"
+  if
+    name = "all" && (not has_substitution)
+    && not (components_are_lone_css_wide components)
+  then Cursor.err_invalid t "all accepts only CSS-wide keywords"
 
 (* Color functions cascade types directly; anything else (e.g. a vendor color
    function or a typed value cascade hasn't grown yet) is treated as a [color]
@@ -2167,11 +2202,11 @@ let is_unknown_property_name = is_decl_unknown_property_name
    declaration-level unknown fallback only needs to handle truly unknown
    properties or property-specific colour fallback edges. *)
 let allows_unknown_fallback name raw_value =
-  (not (raw_value_has_invalid_var raw_value))
+  (not (raw_value_has_invalid_substitution raw_value))
   && (is_unknown_property_name name
      || is_unsupported_color_fallback name raw_value
      || has_var_color_function raw_value
-     || raw_value_contains_var raw_value)
+     || raw_value_contains_substitution raw_value)
 
 let read_font_src_declaration t raw_value =
   ignore raw_value;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3869,6 +3869,24 @@ let css_wide_custom_property_vectors () =
     "--is-important: 1 !important";
   none_cursor read_declaration "--: invalid"
 
+let substitution_defers_css_wide_mix_validation () =
+  List.iter
+    (fun (input, expected) -> check_declaration ~expected input)
+    [
+      ("margin: var(--x) inherit", "margin:var(--x) inherit");
+      ("color: var(--x) initial", "color:var(--x) initial");
+      ("all: var(--x) initial", "all:var(--x) initial");
+      ( "margin: env(safe-area-inset-top) inherit",
+        "margin:env(safe-area-inset-top) inherit" );
+      ("width: attr(data-width px) initial", "width:attr(data-width px) initial");
+    ];
+  (* With no substitution, the CSS-wide keyword is still invalid beside any
+     other component. Empty calls match none of the substitution grammars and do
+     not defer validation either. *)
+  List.iter
+    (fun value -> none_cursor read_declaration ("margin:" ^ value))
+    [ "1px inherit"; "var() inherit"; "env() inherit"; "attr() inherit" ]
+
 type property_grammar_row = Cascade_spec_inventory.Property_grammar.row
 
 let property_grammar_matrix = Cascade_spec_inventory.Property_grammar.rows
@@ -3947,13 +3965,22 @@ let check_property_var (row : property_grammar_row) =
             row.property fallback)
     (row.positives @ token_stream_fallbacks)
 
+let property_value_has_substitution value =
+  let value = String.lowercase_ascii value in
+  List.exists
+    (fun name -> Astring.String.is_infix ~affix:(name ^ "(") value)
+    [ "var"; "env"; "attr" ]
+
 let check_property_trailing_token_rejected (row : property_grammar_row) value =
-  match parse_property_decl row.property (value ^ " )") with
-  | None -> ()
-  | Some (input, serialized, _, _) ->
-      Alcotest.failf
-        "%s positive vector accepted an extra trailing token: %s -> %s"
-        row.property input serialized
+  (* Arbitrary substitutions defer property-grammar validation, including an
+     otherwise-unexpected token beside the function. *)
+  if not (property_value_has_substitution value) then
+    match parse_property_decl row.property (value ^ " )") with
+    | None -> ()
+    | Some (input, serialized, _, _) ->
+        Alcotest.failf
+          "%s positive vector accepted an extra trailing token: %s -> %s"
+          row.property input serialized
 
 (* CSS Syntax 3 (ED) sec. 5.5.6 stops a declaration's value at the top-level [;]
    and lifts a trailing [!important] out of it into the important flag, so every
@@ -5270,6 +5297,8 @@ let declaration_tests =
     test_case "error unclosed block" `Quick error_unclosed_block;
     test_case "unterminated parsing" `Quick unterminated;
     test_case "invalid declarations" `Quick invalid;
+    test_case "substitution defers CSS-wide mix validation" `Quick
+      substitution_defers_css_wide_mix_validation;
     test_case "scroll-margin negative lengths" `Quick scroll_margin_negative;
     test_case "scroll-margin negative lengths (sheet)" `Quick
       scroll_margin_negative_sheet;


### PR DESCRIPTION
CSS Values defers property-grammar validation when a declaration contains an arbitrary substitution function. CSS-wide keyword mixes containing non-empty `var()`, `env()`, or `attr()` calls are preserved until computed-value time, while static mixes and malformed empty calls remain rejected.