### PR TITLE
Drop custom properties containing bad strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -212,6 +212,9 @@ recorded cases carrying six minifiers' answers.
 
 ### Parsing
 
+- Custom-property declarations containing a `<bad-string-token>` are dropped
+  during stylesheet recovery, preventing minified output from swallowing the
+  containing rule's closing brace when it is parsed again (#727)
 - Declarations containing a non-empty `var()`, `env()` or `attr()` call defer
   CSS-wide keyword mix validation until substitution, instead of being dropped
   while the substituted token stream is still unknown (#726)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -203,13 +203,15 @@ let is_decl_value_stop = function
   | Component.Preserved { kind = Token.Semicolon | Token.Delim "!"; _ } -> true
   | _ -> false
 
-let value_components t =
+let components_before stop t =
   let rec take acc = function
     | [] -> List.rev acc
-    | cv :: _ when is_decl_value_stop cv -> List.rev acc
+    | cv :: _ when stop cv -> List.rev acc
     | cv :: rest -> take (cv :: acc) rest
   in
   take [] (Cursor.remaining t)
+
+let value_components t = components_before is_decl_value_stop t
 
 let rec component_is_complete = function
   | Component.Preserved _ -> true
@@ -247,6 +249,19 @@ let rec component_has_unterminated_string = function
 let reject_unterminated_string_value t =
   if List.exists component_has_unterminated_string (value_components t) then
     Cursor.err_invalid t "unterminated string in declaration value"
+
+let rec component_has_bad_string = function
+  | Component.Preserved { kind = Token.Bad_string; _ } -> true
+  | Component.Block { node = { value; _ }; _ } ->
+      List.exists component_has_bad_string value
+  | Component.Func { node = { arguments; _ }; _ } ->
+      List.exists component_has_bad_string arguments
+  | Component.Preserved _ -> false
+
+let reject_custom_bad_string t =
+  if
+    List.exists component_has_bad_string (components_before is_top_level_stop t)
+  then Cursor.err_invalid t "bad string in custom property value"
 
 let is_ws_component = function
   | Component.Preserved { kind = Token.Whitespace; _ } -> true
@@ -2050,6 +2065,7 @@ let read_custom_value_declaration t name : declaration =
      sequence of one or more tokens", so the whitespace after [:] IS the value
      when nothing else follows ([--foo: ;]). Don't skip it before
      [consume_until_semicolon], or the token count becomes input-dependent. *)
+  reject_custom_bad_string t;
   let raw_value = Cursor.consume_until_semicolon ~trim:false t in
   let raw_is_whitespace_only = raw_value <> "" && String.trim raw_value = "" in
   let value_str, is_important = split_custom_important raw_value in

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1771,6 +1771,55 @@ let public_bad_string_prelude_edges () =
         "no unconditional @media is emitted" false
         (Astring.String.is_infix ~affix:"@media{" (minify parsed.stylesheet))
 
+(* CSS Syntax 3 (ED) sec. 4.3.5 ends a <bad-string-token> at the newline, so the
+   token carries an opening quote and nothing to close it. Sec. 7.2 keeps one
+   out of a <declaration-value>, and CSS Custom Properties 1 sec. 2.1 repeats
+   the exclusion for a custom property, so a declaration carrying one is
+   invalid. Emitting it anyway hands the next reader a bare quote: the [}] the
+   rule closes with becomes string content and everything after it is swallowed.
+   Assert the round trip rather than the spelling, which is the property the
+   output owes its own reader. *)
+let public_bad_string_declaration_edges () =
+  let parse label css =
+    match of_string ~strict:false css with
+    | Ok parsed -> parsed
+    | Error err ->
+        Alcotest.failf "%s: lenient parse rejected recoverable CSS: %s" label
+          (Cascade.Error.to_string err)
+  in
+  let label_of parts = String.concat "" parts in
+  let reparses ~survivor label css =
+    let out = Css.to_string ~minify:true (parse label css).stylesheet in
+    let reread = parse (label_of [ label; " (re-read)" ]) out in
+    Alcotest.(check (list string))
+      (label_of [ label; ": minified output re-reads clean" ])
+      []
+      (List.map Cascade.Error.to_string reread.warnings);
+    Alcotest.(check string)
+      (label_of [ label; ": minification is a fixed point" ])
+      out
+      (Css.to_string ~minify:true reread.stylesheet);
+    Alcotest.(check bool)
+      (label_of [ label; ": keeps "; survivor ])
+      true
+      (Astring.String.is_infix ~affix:survivor out)
+  in
+  reparses ~survivor:"b{color:red}" "bad string last in a rule"
+    "a{--t:\"abc\n}b{color:red}";
+  reparses ~survivor:"a{color:red}" "bad string before a later declaration"
+    "a{--t:\"abc\n;color:red}";
+  reparses ~survivor:"b{color:red}" "bad string last in a nested rule"
+    "a{&{--t:\"abc\n}}b{color:red}";
+  reparses ~survivor:"b{color:red}" "bad string last in a conditional group"
+    "@media screen{a{--t:\"abc\n}b{color:red}}";
+  reparses ~survivor:"color:red" "bad string last in a keyframe"
+    "@keyframes k{from{--t:\"abc\n}to{color:red}}";
+  reparses ~survivor:"color:red" "bad string last in @page"
+    "@page{--t:\"abc\n;color:red}";
+  (* Control: a closed string is a <declaration-value> and survives whole. *)
+  reparses ~survivor:"--t:\"abc\"" "a closed string round-trips"
+    "a{--t:\"abc\";color:red}b{color:red}"
+
 (* The value parsers the [list-style] shorthand is built from, exposed so a
    caller can read a single [list-style-type] / [list-style-image]. *)
 let list_style_value_parsers () =
@@ -2308,6 +2357,8 @@ let suite =
       Alcotest.test_case "public parse recovery edges" `Quick public_parse_edges;
       Alcotest.test_case "public bad-string prelude edges" `Quick
         public_bad_string_prelude_edges;
+      Alcotest.test_case "public bad-string declaration edges" `Quick
+        public_bad_string_declaration_edges;
       Alcotest.test_case "spec unknown at-rule reaches the output" `Quick
         unknown_at_rule_reaches_output;
       Alcotest.test_case "spec section 4.1 keyword case is insensitive" `Quick


### PR DESCRIPTION
CSS Syntax excludes bad-string tokens from declaration values, but malformed custom properties could minify to a bare quote that consumed the containing rule closing brace when reparsed. Those declarations are now rejected during stylesheet recovery while surrounding declarations and rules are preserved, matching browser CSSOM behavior.