### PR TITLE
cursor: read a var() beside other components as one operand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -177,6 +177,11 @@ difference wherever the two are not equivalent.
 - Declarations containing a non-empty `var()`, `env()` or `attr()` call defer
   CSS-wide keyword mix validation until substitution, instead of being dropped
   while the substituted token stream is still unknown (#726)
+- A `var()` beside other components keeps the declaration typed, where
+  `border-radius`, `gap`, `transform-origin` and `border-spacing` read the
+  reference as the whole value and fell back to an opaque token stream, so the
+  components next to it lost their folds and `cascade diff --diff=canonical`
+  called two equivalent sheets different (#729)
 - `revert-rule` is reserved wherever a grammar accepts a `<custom-ident>`, so
   it no longer survives inside grid line-name lists as an ordinary name (#724)
 - The grid track-list grammars are the ones a browser applies: `grid-auto-rows`

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -856,6 +856,28 @@ let enum_or_var ?default label idents ~var t =
       var t
   | _ -> enum ?default label idents t
 
+(* CSS Cascade 5 sec. 6 gives the CSS-wide keywords the whole declaration value,
+   and a [var()] standing for all of it reads the same way. A reader that owns
+   the whole value therefore takes the [var] branch only when the reference
+   spans that value: one with components after it is an operand of the grammar
+   [default] reads, so the value goes there instead. *)
+let enum_or_whole_value_var ?default label idents ~var t =
+  ws t;
+  match peek t with
+  | Some (Component.Func { node = { name; _ }; _ })
+    when String.lowercase_ascii_preserve name = "var" -> (
+      let snap = save t in
+      let read_default () =
+        restore t snap;
+        enum ?default label idents t
+      in
+      match var t with
+      | v ->
+          ws t;
+          if is_done t then v else read_default ()
+      | exception Parse_error _ -> read_default ())
+  | _ -> enum ?default label idents t
+
 let enum_or_calls ?default label idents ?(calls = []) t =
   ws t;
   match peek t with

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -511,7 +511,15 @@ val enum_or_var :
 (** [enum_or_var label idents ~var t] is {!val-enum_or_calls} specialised to the
     common case of "match a CSS keyword from [idents], or read [var(...)] via
     [var]". Removes the boilerplate of writing the [var] entry in a [calls] list
-    at every typed-property reader. *)
+    at every typed-property reader. [var] reads whatever the caller is reading,
+    which for a reader called once per shorthand slot is that slot. *)
+
+val enum_or_whole_value_var :
+  ?default:(t -> 'a) -> string -> (string * 'a) list -> var:(t -> 'a) -> t -> 'a
+(** [enum_or_whole_value_var] is {!val-enum_or_var} for a reader that owns the
+    whole declaration value, where [var] stands for all of it. A [var()] with
+    components after it is an operand of [default]'s grammar rather than the
+    value, so such a value goes to [default]. *)
 
 (** {1 Higher-order combinators} *)
 

--- a/lib/prop_align.ml
+++ b/lib/prop_align.ml
@@ -744,7 +744,7 @@ let rec read_gap t : gap =
         Cursor.err t "gap values must be explicit lengths, not keywords"
     | _ -> len
   in
-  Cursor.enum_or_var "gap"
+  Cursor.enum_or_whole_value_var "gap"
     [
       ("inherit", (Inherit : gap));
       ("initial", Initial);

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1881,7 +1881,7 @@ let read_border_radius_inline t : border_radius =
   Radius { horizontal; vertical }
 
 let rec read_border_radius (t : Cursor.t) : border_radius =
-  Cursor.enum_or_var "border-radius"
+  Cursor.enum_or_whole_value_var "border-radius"
     [
       ("inherit", (Inherit : border_radius));
       ("initial", Initial);
@@ -2006,7 +2006,7 @@ let rec read_border_spacing t : border_spacing =
         Cursor.err_invalid t "border-spacing requires a <length>"
     | _ -> l
   in
-  Cursor.enum_or_var "border-spacing" []
+  Cursor.enum_or_whole_value_var "border-spacing" []
     ~var:(fun t -> Var (Values.read_var read_border_spacing t))
     ~default:(fun t ->
       (Lengths

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -1220,7 +1220,7 @@ module Transform_origin = struct
 end
 
 let rec read_transform_origin (t : Cursor.t) : transform_origin =
-  Cursor.enum_or_var "transform-origin"
+  Cursor.enum_or_whole_value_var "transform-origin"
     [
       ("initial", (Initial : transform_origin));
       ("inherit", Inherit);

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1456,26 +1456,29 @@ let box_shorthand_repeats () =
    only as the entire value, and a lone [var()] takes it the same way.
    Committing to the whole-value reading on sight of a leading [var()] left the
    components after it unread, so the typed parse failed and the declaration was
-   carried as an opaque token stream, costing every fold its other components
-   had. *)
+   carried as an opaque token stream, costing the components beside the
+   reference every fold they have on their own. *)
 let component_var_keeps_typed_value () =
   check_declaration ~expected:"border-radius:var(--x)0px"
     ~optimized:"border-radius:var(--x)0" "border-radius: var(--x) 0px";
+  (* The four-value form is top-left, top-right, bottom-right, bottom-left, so a
+     fourth value equal to the second is the longer spelling of three, as it is
+     for the other box shorthands. *)
   check_declaration ~expected:"border-radius:var(--x)1px 1px 1px"
-    ~optimized:"border-radius:var(--x)1px 1px 1px"
+    ~optimized:"border-radius:var(--x)1px 1px"
     "border-radius: var(--x) 1px 1px 1px";
-  (* CSS Values 4 sec. 4.1 makes a keyword ASCII case-insensitive, so a typed
-     read answers with the keyword where an opaque stream keeps the case the
-     author wrote. *)
-  check_specified_value "place-items reads its components"
-    "place-items: var(--p) CENTER" "var(--p) center";
-  check_specified_value "place-content reads its components"
-    "place-content: var(--p) CENTER" "var(--p) center";
-  check_specified_value "grid-auto-flow reads its components"
-    "grid-auto-flow: var(--f) DENSE" "var(--f) dense";
-  (* Controls: a lone [var()] is the whole value, and a reader whose grammar
-     takes one component per slot keeps reading it that way. *)
+  check_declaration ~expected:"gap:var(--g) 0px" ~optimized:"gap:var(--g) 0"
+    "gap: var(--g) 0px";
+  check_declaration ~expected:"transform-origin:var(--t) 0px"
+    ~optimized:"transform-origin:var(--t) 0" "transform-origin: var(--t) 0px";
+  check_declaration ~expected:"border-spacing:var(--s) 0px"
+    ~optimized:"border-spacing:var(--s) 0" "border-spacing: var(--s) 0px";
+  (* Controls: a lone [var()] is the whole value, a CSS-wide keyword after one
+     is still the invalid mix that keeps the declaration opaque, and a reader
+     whose grammar takes one component per slot keeps reading it that way. *)
   check_declaration ~expected:"border-radius:var(--x)" "border-radius: var(--x)";
+  check_declaration ~expected:"border-radius:var(--x) inherit"
+    "border-radius: var(--x) inherit";
   check_specified_value "overflow slots are unchanged"
     "overflow: var(--o) HIDDEN" "var(--o) hidden"
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1450,6 +1450,35 @@ let box_shorthand_repeats () =
   check_declaration ~expected:"padding:1px 2px 1px 3px"
     ~optimized:"padding:1px 2px 1px 3px" "padding: 1px 2px 1px 3px"
 
+(* A [var()] standing beside other components is one operand of the property's
+   own grammar rather than a substitution of the whole value: CSS Cascade 5 sec.
+   6 keeps the whole-value reading for the CSS-wide keywords, which are valid
+   only as the entire value, and a lone [var()] takes it the same way.
+   Committing to the whole-value reading on sight of a leading [var()] left the
+   components after it unread, so the typed parse failed and the declaration was
+   carried as an opaque token stream, costing every fold its other components
+   had. *)
+let component_var_keeps_typed_value () =
+  check_declaration ~expected:"border-radius:var(--x)0px"
+    ~optimized:"border-radius:var(--x)0" "border-radius: var(--x) 0px";
+  check_declaration ~expected:"border-radius:var(--x)1px 1px 1px"
+    ~optimized:"border-radius:var(--x)1px 1px 1px"
+    "border-radius: var(--x) 1px 1px 1px";
+  (* CSS Values 4 sec. 4.1 makes a keyword ASCII case-insensitive, so a typed
+     read answers with the keyword where an opaque stream keeps the case the
+     author wrote. *)
+  check_specified_value "place-items reads its components"
+    "place-items: var(--p) CENTER" "var(--p) center";
+  check_specified_value "place-content reads its components"
+    "place-content: var(--p) CENTER" "var(--p) center";
+  check_specified_value "grid-auto-flow reads its components"
+    "grid-auto-flow: var(--f) DENSE" "var(--f) dense";
+  (* Controls: a lone [var()] is the whole value, and a reader whose grammar
+     takes one component per slot keeps reading it that way. *)
+  check_declaration ~expected:"border-radius:var(--x)" "border-radius: var(--x)";
+  check_specified_value "overflow slots are unchanged"
+    "overflow: var(--o) HIDDEN" "var(--o) hidden"
+
 (* CSS Tables 3 (ED) writes [border-spacing] as one or two non-negative lengths
    and reads a single one as "both the horizontal and vertical spacing", so a
    pair of equal lengths is the longer spelling of that one value. The per-side
@@ -5261,6 +5290,8 @@ let declaration_tests =
     test_case "mask-border mode slot" `Quick mask_border_mode_slot;
     test_case "mask-border mode only" `Quick mask_border_mode_only;
     test_case "box shorthand repeats" `Quick box_shorthand_repeats;
+    test_case "component var keeps typed value" `Quick
+      component_var_keeps_typed_value;
     test_case "border-spacing pair" `Quick border_spacing_pair;
     test_case "background repeat axes" `Quick background_repeat_axes;
     test_case "background drained layer" `Quick background_drained_layer;


### PR DESCRIPTION
`border-radius: var(--x) 0px` was carried as an opaque token stream: the reader took the leading `var()` for the whole value and left `0px` unread, so the components beside a reference lost every typed fold, two spellings of one value stopped factoring together, and `cascade diff --diff=canonical` reported equivalent sheets as different. `gap`, `transform-origin` and `border-spacing` read the same way.

A reader called once per shorthand slot, such as the one behind `overflow` and `place-self`, keeps taking a leading `var()` as its slot, so the rule is opt-in through `Cursor.enum_or_whole_value_var` rather than a change to `enum_or_var`.