### PR TITLE
values: validate calc result types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -523,8 +523,9 @@ difference wherever the two are not equivalent.
 - `Css.to_string ~minify:true` keeps choosing the shorter exact spelling for
   constructed millisecond durations and degree hues without running the AST
   optimisation phase (#678)
-- `--minify` keeps zero terms in `calc()` sums unless their units match another
-  term: removing a mixed-unit zero can change the calculation's type (#676)
+- `calc()` keeps type-bearing zero terms with compatible dimensions and rejects
+  incompatible result types at property boundaries, where
+  `width:calc(1px + 0)` used to survive (#676, #731)
 - `--minify` folds a value's spelling before two rules are compared, so rules
   that wrote one declaration two ways factor into one: a component left at its
   longhand's initial in the `border`, `column-rule`, `outline`, `list-style`,

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -962,8 +962,10 @@ let rec read_text_decoration_thickness t =
         ("var", fun t -> Var (read_var read_text_decoration_thickness t));
         ( "calc",
           fun t ->
-            Calc (read_calc (read_non_negative_length ~with_keywords:false) t)
-        );
+            Calc
+              (read_calc ~result_type:`Value
+                 (read_non_negative_length ~with_keywords:false)
+                 t) );
       ]
     ~default:(read_non_negative_length ~with_keywords:false)
     t

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1294,7 +1294,9 @@ let length_to_border_width t (length : length) : border_width =
 
 let rec read_border_width t : border_width =
   let read_var t : border_width = Var (read_var read_border_width t) in
-  let read_calc t : border_width = Calc (read_calc read_border_width t) in
+  let read_calc t : border_width =
+    Calc (read_calc ~result_type:`Value read_border_width t)
+  in
   let read_math_arg t = read_calc_expr read_border_width t in
   let read_min t : border_width =
     Min

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -476,7 +476,11 @@ let rec read_opacity t : opacity =
     ~calls:
       [
         ("var", read_var);
-        ("calc", fun t -> Calc (Values.read_calc read_opacity_dim_only t));
+        ( "calc",
+          fun t ->
+            Calc
+              (Values.read_calc ~result_type:`Number_or_value
+                 read_opacity_dim_only t) );
         ("min", read_numeric_math);
         ("max", read_numeric_math);
         ("clamp", read_numeric_math);
@@ -849,7 +853,9 @@ let rec read_z_index t : z_index =
   let read_calc_z t : z_index =
     (* read_calc handles the calc(...) wrapper itself *)
     let expr =
-      read_calc (fun _ -> Cursor.err t "unexpected value in z-index calc") t
+      read_calc ~result_type:`Number
+        (fun _ -> Cursor.err t "unexpected value in z-index calc")
+        t
     in
     match eval_numeric_calc expr with
     | Some f when Float.is_integer f -> Index (int_of_float f)

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -289,7 +289,9 @@ let rec read_order t : order =
   let read_calc_order t =
     (* read_calc handles the calc(...) wrapper itself *)
     let expr =
-      read_calc (fun _ -> Cursor.err t "unexpected value in order calc") t
+      read_calc ~result_type:`Number
+        (fun _ -> Cursor.err t "unexpected value in order calc")
+        t
     in
     match eval_numeric_calc expr with
     | Some f when Float.is_integer f -> (Int (int_of_float f) : order)
@@ -427,7 +429,8 @@ let rec read_flex_factor t : flex_factor =
     ~calls:
       [
         ("var", fun t -> Var (Values.read_var read_flex_factor t));
-        ("calc", fun t -> Calc (read_calc read_flex_factor t));
+        ( "calc",
+          fun t -> Calc (read_calc ~result_type:`Number read_flex_factor t) );
       ]
     ~default:read_number t
 
@@ -544,7 +547,7 @@ let rec read_flex_basis t : flex_basis =
     ~calls:
       [
         ("var", fun t -> Var (read_var read_flex_basis t));
-        ("calc", fun t -> Calc (read_calc read_flex_basis t));
+        ("calc", fun t -> Calc (read_calc ~result_type:`Value read_flex_basis t));
       ]
     ~default:(fun t ->
       let pos = Cursor.save t in
@@ -566,7 +569,7 @@ module Flex = struct
        number. *)
     if Cursor.looking_at_func "var" t then Var (read_var read_flex_factor t)
     else if Cursor.looking_at_func "calc" t then
-      Calc (read_calc read_flex_factor t)
+      Calc (read_calc ~result_type:`Number read_flex_factor t)
     else Number (read_non_negative_flex_number t)
 
   let read_grow_shrink_basis t =

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -92,7 +92,9 @@ let rec read_font_style t : font_style =
 
 let rec read_font_size t : font_size =
   let read_var t : font_size = Var (read_var read_font_size t) in
-  let read_calc t : font_size = Calc (read_calc read_font_size t) in
+  let read_calc t : font_size =
+    Calc (read_calc ~result_type:`Value read_font_size t)
+  in
   let read_length t : font_size =
     let len = read_non_negative_length ~with_keywords:false t in
     Length len
@@ -1269,7 +1271,9 @@ let rec pp_font : font Pp.t =
 let rec read_line_height t : line_height =
   let read_var t : line_height = Var (read_var read_line_height t) in
   let read_calc t : line_height =
-    Calc (read_calc read_line_height t |> numeric_line_height_calc_leaves)
+    Calc
+      (read_calc ~result_type:`Number_or_value read_line_height t
+      |> numeric_line_height_calc_leaves)
   in
   Cursor.enum_or_calls "line-height"
     [

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -700,7 +700,9 @@ let read_grid_line_name_value t : grid_line =
 let read_grid_line_calc t : grid_line =
   (* read_calc handles the calc(...) wrapper itself *)
   let expr =
-    read_calc (fun _ -> Cursor.err t "unexpected value in grid-line calc") t
+    read_calc ~result_type:`Number
+      (fun _ -> Cursor.err t "unexpected value in grid-line calc")
+      t
   in
   match eval_numeric_calc expr with
   | Some f when Float.is_integer f -> Num (int_of_float f)

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -510,7 +510,9 @@ let rec read_stroke_miterlimit t : stroke_miterlimit =
     ~calls:
       [
         ("var", fun t -> Var (Values.read_var read_stroke_miterlimit t));
-        ("calc", fun t -> Calc (read_calc read_stroke_miterlimit t));
+        ( "calc",
+          fun t ->
+            Calc (read_calc ~result_type:`Number read_stroke_miterlimit t) );
       ]
     ~default:(fun t -> (Number (read_miterlimit_number t) : stroke_miterlimit))
     t

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1916,7 +1916,9 @@ let rec read_text_decoration_skip_ink t : text_decoration_skip_ink =
 
 let rec read_vertical_align t : vertical_align =
   let read_var t : vertical_align = Var (read_var read_vertical_align t) in
-  let read_calc t : vertical_align = Calc (read_calc read_vertical_align t) in
+  let read_calc t : vertical_align =
+    Calc (read_calc ~result_type:`Value read_vertical_align t)
+  in
   Cursor.enum_or_calls "vertical-align"
     [
       ("baseline", (Baseline : vertical_align));

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -1044,7 +1044,8 @@ let rec read_rotate_value t : rotate_value =
     ~calls:
       [
         ("var", fun t -> (Var (read_var read_rotate_value t) : rotate_value));
-        ("calc", fun t -> Angle (Calc (read_calc read_angle t)));
+        ( "calc",
+          fun t -> Angle (Calc (read_calc ~result_type:`Value read_angle t)) );
       ]
     ~default:(fun t ->
       Cursor.one_of

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5678,8 +5678,55 @@ and read_nested_calc_factor : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
       (Cursor.call "-webkit-calc" t (fun inner -> read_calc_expr read_a inner))
   else Cursor.err t "expected nested calc"
 
-let read_calc : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
- fun read_a t ->
+type inferred_calc_type =
+  | Dimension of int
+    (* Exponent 0 is a number, 1 is the contextual numeric value, and
+       multiplication/division add/subtract exponents. This retains valid
+       cancellation such as [1 / (1 / 50px)]. *)
+  | Deferred
+  | Invalid
+
+let rec infer_calc_type : type a. a calc -> inferred_calc_type = function
+  | Num _ | Math_const _ | Sibling_index | Sibling_count -> Dimension 0
+  | Val _ -> Dimension 1
+  (* A var() is substituted before a math function is type-checked. The generic
+     math-function AST does not retain enough result-type information to prove
+     its type here either, so both stay deferred rather than being guessed. *)
+  | Var _ | Math_fn _ -> Deferred
+  | Nested inner | Parens inner -> infer_calc_type inner
+  | Expr (left, (Add | Sub), right) -> (
+      match (infer_calc_type left, infer_calc_type right) with
+      | Invalid, _ | _, Invalid -> Invalid
+      | Deferred, _ | _, Deferred -> Deferred
+      | Dimension l, Dimension r -> if l = r then Dimension l else Invalid)
+  | Expr (left, Mul, right) -> (
+      match (infer_calc_type left, infer_calc_type right) with
+      | Invalid, _ | _, Invalid -> Invalid
+      | Deferred, _ | _, Deferred -> Deferred
+      | Dimension l, Dimension r -> Dimension (l + r))
+  | Expr (left, Div, right) -> (
+      match (infer_calc_type left, infer_calc_type right) with
+      | Invalid, _ | _, Invalid -> Invalid
+      | Deferred, _ | _, Deferred -> Deferred
+      | Dimension l, Dimension r -> Dimension (l - r))
+
+let validate_calc_type t result_type calc =
+  let inferred = infer_calc_type calc in
+  let accepted =
+    match (result_type, inferred) with
+    | _, Deferred -> true
+    | `Number, Dimension 0 | `Value, Dimension 1 -> true
+    | `Number_or_value, (Dimension 0 | Dimension 1) -> true
+    | (`Number | `Value | `Number_or_value), (Invalid | Dimension _) -> false
+  in
+  if not accepted then Cursor.err_invalid t "incompatible calc types"
+
+let read_calc : type a.
+    ?result_type:[ `Number | `Number_or_value | `Value ] ->
+    (Cursor.t -> a) ->
+    Cursor.t ->
+    a calc =
+ fun ?result_type read_a t ->
   Cursor.ws t;
   let read name =
     Cursor.call name t (fun inner ->
@@ -5689,6 +5736,9 @@ let read_calc : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
            be rejected. *)
         Cursor.ws inner;
         Cursor.expect_eof inner;
+        Option.iter
+          (fun result_type -> validate_calc_type inner result_type result)
+          result_type;
         result)
   in
   if Cursor.looking_at_func "calc" t then read "calc"
@@ -5775,7 +5825,7 @@ and read_calc_length ~with_keywords t : length =
   if Cursor.looking_at_calc t then
     (* Same exception as [read_length_percentage]: inside [calc()] the
        non-negative constraint applies to the resolved value. *)
-    Calc (read_calc (read_length ~with_keywords) t)
+    Calc (read_calc ~result_type:`Value (read_length ~with_keywords) t)
   else Cursor.err t "expected calc"
 
 and read_env_length ~allow_negative ~with_keywords t : length =
@@ -6007,7 +6057,9 @@ let read_percentage_float t : float =
 let rec read_alpha t : alpha =
   Cursor.ws t;
   let read_var_alpha t : alpha = Var (read_var read_alpha t) in
-  let read_calc_alpha t : alpha = Calc (read_calc read_alpha t) in
+  let read_calc_alpha t : alpha =
+    Calc (read_calc ~result_type:`Number_or_value read_alpha t)
+  in
   let read_none t : alpha =
     Cursor.expect_string "none" t;
     None
@@ -6171,7 +6223,8 @@ let rec read_color_component t : component =
     Cursor.expect_string "none" t;
     Component_none)
   else if Cursor.looking_at t "var(" then Var (read_var read_color_component t)
-  else if Cursor.looking_at_calc t then Calc (read_calc read_color_component t)
+  else if Cursor.looking_at_calc t then
+    Calc (read_calc ~result_type:`Number_or_value read_color_component t)
   else
     let n, unit = Cursor.number_with_unit t in
     match unit with
@@ -6365,7 +6418,7 @@ let rec read_angle_with ~unitless_zero t : angle =
   if Cursor.looking_at t "var(" then
     Var (read_var (read_angle_with ~unitless_zero) t)
   else if Cursor.looking_at_calc t then
-    Calc (read_calc (read_angle_with ~unitless_zero) t)
+    Calc (read_calc ~result_type:`Value (read_angle_with ~unitless_zero) t)
   else if Cursor.looking_at_func "round" t then
     read_angle_round (read_angle_with ~unitless_zero) t
   else if Cursor.looking_at_func "rem" t then
@@ -6597,7 +6650,7 @@ let rec read_percentage_in_color_mix t : percentage =
     (* CSS Color 5 sec. 3: the weight may be a math function. We can't
        bound-check a [calc()] statically (it may carry a [var()]), so we keep it
        verbatim and let substitution-time clamping apply. *)
-    Calc (read_calc read_color_mix_calc_pct t)
+    Calc (read_calc ~result_type:`Value read_color_mix_calc_pct t)
   else
     let n = Cursor.pct t in
     if n < 0. || n > 100. then
@@ -6614,7 +6667,7 @@ let read_optional_percentage t : percentage option =
   if Cursor.looking_at t "var(" then
     Some (Var (read_var read_percentage_in_color_mix t))
   else if Cursor.looking_at_calc t then
-    Some (Calc (read_calc read_color_mix_calc_pct t))
+    Some (Calc (read_calc ~result_type:`Value read_color_mix_calc_pct t))
   else
     match Cursor.percentage_opt t with
     | Some n ->
@@ -7124,7 +7177,9 @@ let rec read_duration_with ?(css_wide = true) ~canonicalize_ms t : duration =
     ~calls:
       [
         ("var", fun t -> Var (read_var read_duration_self t));
-        ("calc", fun t -> Calc (read_calc read_duration_in_calc t));
+        ( "calc",
+          fun t -> Calc (read_calc ~result_type:`Value read_duration_in_calc t)
+        );
         ("round", read_duration_round read_duration_self);
         ( "rem",
           read_duration_binary_call "rem"
@@ -7155,7 +7210,8 @@ let rec read_time_with ?(css_wide = true) t : duration =
     ~calls:
       [
         ("var", fun t -> Var (read_var read_time t));
-        ("calc", fun t -> Calc (read_calc read_time_in_calc t));
+        ( "calc",
+          fun t -> Calc (read_calc ~result_type:`Value read_time_in_calc t) );
         ("round", read_duration_round read_time);
         ( "rem",
           read_duration_binary_call "rem" (fun a b -> Rem (a, b)) read_time );
@@ -7215,7 +7271,7 @@ and read_number_function t =
       | "var" -> Some (Var (read_var read_number t))
       | "calc" ->
           let read_number_dim_only t = Cursor.err t "expected numeric factor" in
-          Some (Calc (read_calc read_number_dim_only t))
+          Some (Calc (read_calc ~result_type:`Number read_number_dim_only t))
       | "min" ->
           Some
             (Num
@@ -7316,7 +7372,8 @@ let read_transition_behavior t : transition_behavior =
 let rec read_percentage t : percentage =
   Cursor.ws t;
   if Cursor.looking_at t "var(" then Var (read_var read_percentage t)
-  else if Cursor.looking_at_calc t then Calc (read_calc read_percentage t)
+  else if Cursor.looking_at_calc t then
+    Calc (read_calc ~result_type:`Value read_percentage t)
   else Pct (Cursor.pct t)
 
 (* CSS Values 4 sec. 10.4: math functions that produce a non-length type ([asin]
@@ -7379,7 +7436,8 @@ and read_length_percentage_calc ~with_keywords t : length_percentage =
        allowed even when the surrounding property is non-negative; the
        non-negative constraint applies to the resolved value, not to inner
        operands. *)
-    Calc (read_calc (read_length_percentage ~with_keywords) t)
+    Calc
+      (read_calc ~result_type:`Value (read_length_percentage ~with_keywords) t)
   else Cursor.err t "expected calc"
 
 (** Read number_percentage value. Inside a [<number-percentage>] [calc()], a raw
@@ -7401,7 +7459,8 @@ let rec read_number_percentage t : number_percentage =
   Cursor.ws t;
   if Cursor.looking_at t "var(" then Var (read_var read_number_percentage t)
   else if Cursor.looking_at_calc t then
-    Calc (read_calc read_number_percentage_dim_only t)
+    Calc
+      (read_calc ~result_type:`Number_or_value read_number_percentage_dim_only t)
   else if
     Cursor.looking_at_func "min" t
     || Cursor.looking_at_func "max" t
@@ -7845,7 +7904,8 @@ let read_calc_op t : calc_op =
 let rec read_component t : component =
   Cursor.ws t;
   if Cursor.looking_at t "var(" then Var (read_var read_component t)
-  else if Cursor.looking_at_calc t then Calc (read_calc read_component t)
+  else if Cursor.looking_at_calc t then
+    Calc (read_calc ~result_type:`Number_or_value read_component t)
   else
     let n, unit = Cursor.number_with_unit t in
     match unit with

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -585,8 +585,16 @@ val read_length_percentage :
 val read_number_percentage : Cursor.t -> number_percentage
 (** [read_number_percentage t] parses a CSS number or percentage. *)
 
-val read_calc : (Cursor.t -> 'a) -> Cursor.t -> 'a calc
-(** [read_calc read t] parses a [calc(...)] expression or a promotable value. *)
+val read_calc :
+  ?result_type:[ `Number | `Number_or_value | `Value ] ->
+  (Cursor.t -> 'a) ->
+  Cursor.t ->
+  'a calc
+(** [read_calc ~result_type read t] parses a [calc(...)] expression or a
+    promotable value and checks that its statically knowable result type matches
+    the property's numeric grammar. Expressions containing [var()] remain
+    deferred until substitution. Omitting [result_type] retains the generic AST
+    reader behaviour. *)
 
 val read_calc_expr : (Cursor.t -> 'a) -> Cursor.t -> 'a calc
 (** [read_calc_expr read t] parses a calc expression body -- the contents of a

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -5281,21 +5281,43 @@ let bg35_radius_collapse () =
     "border-radius: 1px 1px 1px 1px collapses to 1px" ".x{border-radius:1px}"
     (normalize ".x { border-radius: 1px 1px 1px 1px }")
 
-(* CSS Values 4 sec. 10.10.1 only combines sum children with identical units and
-   explicitly warns that a zero term cannot otherwise be removed: its type can
-   affect the calculation. A unitless zero is not a [<length>] calc term. *)
+(* CSS Values 4 sec. 10.9 determines a math function's type before simplifying
+   it. A unitless zero is a [<number>], so adding it to a dimension or using the
+   numeric result where a dimension is required makes the declaration invalid.
+   Variables remain deferred until substitution, and zero terms with compatible
+   dimension types remain valid. *)
 let v410_calc_add_zero () =
   let normalize css =
     match Css.of_string ~strict:false css with
     | Ok parsed -> minify parsed.stylesheet
     | Error _ -> Alcotest.failf "failed to parse: %s" css
   in
-  Alcotest.(check string)
-    "unitless zero stays in a length sum" ".x{width:calc(1px + 0)}"
-    (normalize ".x { width: calc(1px + 0) }");
-  Alcotest.(check string)
-    "leading unitless zero stays in a length sum" ".x{width:calc(0 + 1px)}"
-    (normalize ".x { width: calc(0 + 1px) }");
+  let rejects label css =
+    Alcotest.(check bool)
+      label true
+      (match Css.of_string ~strict:true css with
+      | Error _ -> true
+      | Ok _ -> false)
+  in
+  let accepts label css =
+    Alcotest.(check bool)
+      label true
+      (match Css.of_string ~strict:true css with
+      | Ok _ -> true
+      | Error _ -> false)
+  in
+  rejects "number plus length is rejected" ".x { width: calc(0 + 1px) }";
+  rejects "length plus number is rejected" ".x { width: calc(1px + 0) }";
+  rejects "a numeric calc cannot be a width" ".x { width: calc(0) }";
+  rejects "number plus angle is rejected" ".x { rotate: calc(45deg + 0) }";
+  rejects "number plus time is rejected"
+    ".x { transition-duration: calc(1s + 0) }";
+  rejects "number plus percentage is rejected" ".x { opacity: calc(.5 + 0%) }";
+  rejects "line-height number plus percentage is rejected"
+    ".x { line-height: calc(1 + 0%) }";
+  accepts "number plus number remains valid" ".x { opacity: calc(.5 + 0) }";
+  accepts "a variable keeps type checking deferred"
+    ".x { width: calc(var(--size) + 0) }";
   Alcotest.(check string)
     "a cross-unit zero stays in a length sum" ".x{width:calc(1em + 0px)}"
     (normalize ".x { width: calc(1em + 0px) }");
@@ -6283,7 +6305,7 @@ let v4_10_2_calc_arithmetic () =
     "calc(1px * 0) -> 0" ".x{width:0}"
     (normalize ".x { width: calc(1px * 0) }");
   Alcotest.(check string)
-    "unitless calc zero stays untyped" ".x{width:calc(0)}"
+    "a numeric calc cannot be a width" ""
     (normalize ".x { width: calc(0 + 0) }")
 
 let v4102_calc_addition () =

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -211,11 +211,13 @@ let test_length () =
   check_length "0vi";
   check_length "0svh";
 
-  (* calc() is held verbatim by pp. A unitless zero cannot be removed from a
-     typed sum: it is not a [<length>] operand. *)
-  check_length "calc(100% - 0)";
-  check_length "calc(10px + 0)";
-  check_length "calc(0 + 10px)";
+  (* CSS Values 4 sec. 10.9: a unitless zero inside a math function has the
+     [<number>] type. It cannot be added to a [<length-percentage>], and a lone
+     numeric result cannot satisfy [<length-percentage>] either. *)
+  neg_cursor read_length "calc(100% - 0)";
+  neg_cursor read_length "calc(10px + 0)";
+  neg_cursor read_length "calc(0 + 10px)";
+  neg_cursor read_length "calc(0)";
 
   (* optimize+minify strips the unit from a zero length and folds calc; 0% stays
      a percentage. *)
@@ -224,12 +226,10 @@ let test_length () =
   decl_optimizes ~prop:"width" ~held:"0vi" ~into:"0" "0vi";
   decl_optimizes ~prop:"width" ~held:"0svh" ~into:"0" "0svh";
   decl_optimizes ~prop:"width" ~held:"0%" ~into:"0%" "0%";
-  decl_optimizes ~prop:"width" ~held:"calc(100% - 0)" ~into:"calc(100% - 0)"
-    "calc(100% - 0)";
-  decl_optimizes ~prop:"width" ~held:"calc(10px + 0)" ~into:"calc(10px + 0)"
-    "calc(10px + 0)";
-  decl_optimizes ~prop:"width" ~held:"calc(0 + 10px)" ~into:"calc(0 + 10px)"
-    "calc(0 + 10px)";
+  (* Typed zero terms remain valid and keep contributing their types. *)
+  check_length "calc(1em + 0px)";
+  check_length "calc(1px + 0%)";
+  check_length "calc(var(--size) + 0)";
 
   (* CSS Values 4 sec. 10.8 makes a parenthesised operand a whole [<calc-sum>],
      so a trailing token inside one invalidates the value rather than shortening


### PR DESCRIPTION
Unitless numeric `calc()` results were accepted by dimensional properties; property boundaries now reject statically incompatible result types while deferring expressions containing `var()`.