### PR TITLE
grid: read place-content's leading var() as one operand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -178,10 +178,11 @@ difference wherever the two are not equivalent.
   CSS-wide keyword mix validation until substitution, instead of being dropped
   while the substituted token stream is still unknown (#726)
 - A `var()` beside other components keeps the declaration typed, where
-  `border-radius`, `gap`, `transform-origin` and `border-spacing` read the
-  reference as the whole value and fell back to an opaque token stream, so the
-  components next to it lost their folds and `cascade diff --diff=canonical`
-  called two equivalent sheets different (#729)
+  `border-radius`, `gap`, `transform-origin`, `border-spacing` and
+  `place-content` read the reference as the whole value and fell back to an
+  opaque token stream, so the components next to it lost their folds and
+  `cascade diff --diff=canonical` called two equivalent sheets different
+  (#729, #732)
 - `revert-rule` is reserved wherever a grammar accepts a `<custom-ident>`, so
   it no longer survives inside grid line-name lists as an ordinary name (#724)
 - The grid track-list grammars are the ones a browser applies: `grid-auto-rows`

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -962,8 +962,10 @@ let rec read_text_decoration_thickness t =
         ("var", fun t -> Var (read_var read_text_decoration_thickness t));
         ( "calc",
           fun t ->
-            Calc (read_calc (read_non_negative_length ~with_keywords:false) t)
-        );
+            Calc
+              (read_calc ~result_type:`Value
+                 (read_non_negative_length ~with_keywords:false)
+                 t) );
       ]
     ~default:(read_non_negative_length ~with_keywords:false)
     t

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1294,7 +1294,9 @@ let length_to_border_width t (length : length) : border_width =
 
 let rec read_border_width t : border_width =
   let read_var t : border_width = Var (read_var read_border_width t) in
-  let read_calc t : border_width = Calc (read_calc read_border_width t) in
+  let read_calc t : border_width =
+    Calc (read_calc ~result_type:`Value read_border_width t)
+  in
   let read_math_arg t = read_calc_expr read_border_width t in
   let read_min t : border_width =
     Min

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -476,7 +476,11 @@ let rec read_opacity t : opacity =
     ~calls:
       [
         ("var", read_var);
-        ("calc", fun t -> Calc (Values.read_calc read_opacity_dim_only t));
+        ( "calc",
+          fun t ->
+            Calc
+              (Values.read_calc ~result_type:`Number_or_value
+                 read_opacity_dim_only t) );
         ("min", read_numeric_math);
         ("max", read_numeric_math);
         ("clamp", read_numeric_math);
@@ -849,7 +853,9 @@ let rec read_z_index t : z_index =
   let read_calc_z t : z_index =
     (* read_calc handles the calc(...) wrapper itself *)
     let expr =
-      read_calc (fun _ -> Cursor.err t "unexpected value in z-index calc") t
+      read_calc ~result_type:`Number
+        (fun _ -> Cursor.err t "unexpected value in z-index calc")
+        t
     in
     match eval_numeric_calc expr with
     | Some f when Float.is_integer f -> Index (int_of_float f)

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -289,7 +289,9 @@ let rec read_order t : order =
   let read_calc_order t =
     (* read_calc handles the calc(...) wrapper itself *)
     let expr =
-      read_calc (fun _ -> Cursor.err t "unexpected value in order calc") t
+      read_calc ~result_type:`Number
+        (fun _ -> Cursor.err t "unexpected value in order calc")
+        t
     in
     match eval_numeric_calc expr with
     | Some f when Float.is_integer f -> (Int (int_of_float f) : order)
@@ -427,7 +429,8 @@ let rec read_flex_factor t : flex_factor =
     ~calls:
       [
         ("var", fun t -> Var (Values.read_var read_flex_factor t));
-        ("calc", fun t -> Calc (read_calc read_flex_factor t));
+        ( "calc",
+          fun t -> Calc (read_calc ~result_type:`Number read_flex_factor t) );
       ]
     ~default:read_number t
 
@@ -544,7 +547,7 @@ let rec read_flex_basis t : flex_basis =
     ~calls:
       [
         ("var", fun t -> Var (read_var read_flex_basis t));
-        ("calc", fun t -> Calc (read_calc read_flex_basis t));
+        ("calc", fun t -> Calc (read_calc ~result_type:`Value read_flex_basis t));
       ]
     ~default:(fun t ->
       let pos = Cursor.save t in
@@ -566,7 +569,7 @@ module Flex = struct
        number. *)
     if Cursor.looking_at_func "var" t then Var (read_var read_flex_factor t)
     else if Cursor.looking_at_func "calc" t then
-      Calc (read_calc read_flex_factor t)
+      Calc (read_calc ~result_type:`Number read_flex_factor t)
     else Number (read_non_negative_flex_number t)
 
   let read_grow_shrink_basis t =

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -92,7 +92,9 @@ let rec read_font_style t : font_style =
 
 let rec read_font_size t : font_size =
   let read_var t : font_size = Var (read_var read_font_size t) in
-  let read_calc t : font_size = Calc (read_calc read_font_size t) in
+  let read_calc t : font_size =
+    Calc (read_calc ~result_type:`Value read_font_size t)
+  in
   let read_length t : font_size =
     let len = read_non_negative_length ~with_keywords:false t in
     Length len
@@ -1269,7 +1271,9 @@ let rec pp_font : font Pp.t =
 let rec read_line_height t : line_height =
   let read_var t : line_height = Var (read_var read_line_height t) in
   let read_calc t : line_height =
-    Calc (read_calc read_line_height t |> numeric_line_height_calc_leaves)
+    Calc
+      (read_calc ~result_type:`Number_or_value read_line_height t
+      |> numeric_line_height_calc_leaves)
   in
   Cursor.enum_or_calls "line-height"
     [

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -700,7 +700,9 @@ let read_grid_line_name_value t : grid_line =
 let read_grid_line_calc t : grid_line =
   (* read_calc handles the calc(...) wrapper itself *)
   let expr =
-    read_calc (fun _ -> Cursor.err t "unexpected value in grid-line calc") t
+    read_calc ~result_type:`Number
+      (fun _ -> Cursor.err t "unexpected value in grid-line calc")
+      t
   in
   match eval_numeric_calc expr with
   | Some f when Float.is_integer f -> Num (int_of_float f)

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -489,7 +489,7 @@ let read_place_content_single t =
     t
 
 let rec read_place_content t : place_content =
-  Cursor.enum_or_var "place-content"
+  Cursor.enum_or_whole_value_var "place-content"
     [
       ("inherit", (Inherit : place_content));
       ("initial", Initial);

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -510,7 +510,9 @@ let rec read_stroke_miterlimit t : stroke_miterlimit =
     ~calls:
       [
         ("var", fun t -> Var (Values.read_var read_stroke_miterlimit t));
-        ("calc", fun t -> Calc (read_calc read_stroke_miterlimit t));
+        ( "calc",
+          fun t ->
+            Calc (read_calc ~result_type:`Number read_stroke_miterlimit t) );
       ]
     ~default:(fun t -> (Number (read_miterlimit_number t) : stroke_miterlimit))
     t

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1916,7 +1916,9 @@ let rec read_text_decoration_skip_ink t : text_decoration_skip_ink =
 
 let rec read_vertical_align t : vertical_align =
   let read_var t : vertical_align = Var (read_var read_vertical_align t) in
-  let read_calc t : vertical_align = Calc (read_calc read_vertical_align t) in
+  let read_calc t : vertical_align =
+    Calc (read_calc ~result_type:`Value read_vertical_align t)
+  in
   Cursor.enum_or_calls "vertical-align"
     [
       ("baseline", (Baseline : vertical_align));

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -1044,7 +1044,8 @@ let rec read_rotate_value t : rotate_value =
     ~calls:
       [
         ("var", fun t -> (Var (read_var read_rotate_value t) : rotate_value));
-        ("calc", fun t -> Angle (Calc (read_calc read_angle t)));
+        ( "calc",
+          fun t -> Angle (Calc (read_calc ~result_type:`Value read_angle t)) );
       ]
     ~default:(fun t ->
       Cursor.one_of

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5678,8 +5678,58 @@ and read_nested_calc_factor : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
       (Cursor.call "-webkit-calc" t (fun inner -> read_calc_expr read_a inner))
   else Cursor.err t "expected nested calc"
 
-let read_calc : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
- fun read_a t ->
+type inferred_calc_type =
+  | Calc_dimension of int
+    (* Exponent 0 is a number, 1 is the contextual numeric value, and
+       multiplication/division add/subtract exponents. This retains valid
+       cancellation such as [1 / (1 / 50px)]. *)
+  | Calc_deferred
+  | Calc_invalid
+
+let rec infer_calc_type : type a. a calc -> inferred_calc_type = function
+  | Num _ | Math_const _ | Sibling_index | Sibling_count -> Calc_dimension 0
+  | Val _ -> Calc_dimension 1
+  (* A var() is substituted before a math function is type-checked. The generic
+     math-function AST does not retain enough result-type information to prove
+     its type here either, so both stay deferred rather than being guessed. *)
+  | Var _ | Math_fn _ -> Calc_deferred
+  | Nested inner | Parens inner -> infer_calc_type inner
+  | Expr (left, (Add | Sub), right) -> (
+      match (infer_calc_type left, infer_calc_type right) with
+      | Calc_invalid, _ | _, Calc_invalid -> Calc_invalid
+      | Calc_deferred, _ | _, Calc_deferred -> Calc_deferred
+      | Calc_dimension l, Calc_dimension r ->
+          if l = r then Calc_dimension l else Calc_invalid)
+  | Expr (left, Mul, right) -> (
+      match (infer_calc_type left, infer_calc_type right) with
+      | Calc_invalid, _ | _, Calc_invalid -> Calc_invalid
+      | Calc_deferred, _ | _, Calc_deferred -> Calc_deferred
+      | Calc_dimension l, Calc_dimension r -> Calc_dimension (l + r))
+  | Expr (left, Div, right) -> (
+      match (infer_calc_type left, infer_calc_type right) with
+      | Calc_invalid, _ | _, Calc_invalid -> Calc_invalid
+      | Calc_deferred, _ | _, Calc_deferred -> Calc_deferred
+      | Calc_dimension l, Calc_dimension r -> Calc_dimension (l - r))
+
+let validate_calc_type t result_type calc =
+  let inferred = infer_calc_type calc in
+  let accepted =
+    match (result_type, inferred) with
+    | _, Calc_deferred -> true
+    | `Number, Calc_dimension 0 | `Value, Calc_dimension 1 -> true
+    | `Number_or_value, (Calc_dimension 0 | Calc_dimension 1) -> true
+    | (`Number | `Value | `Number_or_value), (Calc_invalid | Calc_dimension _)
+      ->
+        false
+  in
+  if not accepted then Cursor.err_invalid t "incompatible calc types"
+
+let read_calc : type a.
+    ?result_type:[ `Number | `Number_or_value | `Value ] ->
+    (Cursor.t -> a) ->
+    Cursor.t ->
+    a calc =
+ fun ?result_type read_a t ->
   Cursor.ws t;
   let read name =
     Cursor.call name t (fun inner ->
@@ -5689,6 +5739,9 @@ let read_calc : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
            be rejected. *)
         Cursor.ws inner;
         Cursor.expect_eof inner;
+        Option.iter
+          (fun result_type -> validate_calc_type inner result_type result)
+          result_type;
         result)
   in
   if Cursor.looking_at_func "calc" t then read "calc"
@@ -5775,7 +5828,7 @@ and read_calc_length ~with_keywords t : length =
   if Cursor.looking_at_calc t then
     (* Same exception as [read_length_percentage]: inside [calc()] the
        non-negative constraint applies to the resolved value. *)
-    Calc (read_calc (read_length ~with_keywords) t)
+    Calc (read_calc ~result_type:`Value (read_length ~with_keywords) t)
   else Cursor.err t "expected calc"
 
 and read_env_length ~allow_negative ~with_keywords t : length =
@@ -6007,7 +6060,9 @@ let read_percentage_float t : float =
 let rec read_alpha t : alpha =
   Cursor.ws t;
   let read_var_alpha t : alpha = Var (read_var read_alpha t) in
-  let read_calc_alpha t : alpha = Calc (read_calc read_alpha t) in
+  let read_calc_alpha t : alpha =
+    Calc (read_calc ~result_type:`Number_or_value read_alpha t)
+  in
   let read_none t : alpha =
     Cursor.expect_string "none" t;
     None
@@ -6171,7 +6226,8 @@ let rec read_color_component t : component =
     Cursor.expect_string "none" t;
     Component_none)
   else if Cursor.looking_at t "var(" then Var (read_var read_color_component t)
-  else if Cursor.looking_at_calc t then Calc (read_calc read_color_component t)
+  else if Cursor.looking_at_calc t then
+    Calc (read_calc ~result_type:`Number_or_value read_color_component t)
   else
     let n, unit = Cursor.number_with_unit t in
     match unit with
@@ -6365,7 +6421,7 @@ let rec read_angle_with ~unitless_zero t : angle =
   if Cursor.looking_at t "var(" then
     Var (read_var (read_angle_with ~unitless_zero) t)
   else if Cursor.looking_at_calc t then
-    Calc (read_calc (read_angle_with ~unitless_zero) t)
+    Calc (read_calc ~result_type:`Value (read_angle_with ~unitless_zero) t)
   else if Cursor.looking_at_func "round" t then
     read_angle_round (read_angle_with ~unitless_zero) t
   else if Cursor.looking_at_func "rem" t then
@@ -6597,7 +6653,7 @@ let rec read_percentage_in_color_mix t : percentage =
     (* CSS Color 5 sec. 3: the weight may be a math function. We can't
        bound-check a [calc()] statically (it may carry a [var()]), so we keep it
        verbatim and let substitution-time clamping apply. *)
-    Calc (read_calc read_color_mix_calc_pct t)
+    Calc (read_calc ~result_type:`Value read_color_mix_calc_pct t)
   else
     let n = Cursor.pct t in
     if n < 0. || n > 100. then
@@ -6614,7 +6670,7 @@ let read_optional_percentage t : percentage option =
   if Cursor.looking_at t "var(" then
     Some (Var (read_var read_percentage_in_color_mix t))
   else if Cursor.looking_at_calc t then
-    Some (Calc (read_calc read_color_mix_calc_pct t))
+    Some (Calc (read_calc ~result_type:`Value read_color_mix_calc_pct t))
   else
     match Cursor.percentage_opt t with
     | Some n ->
@@ -7124,7 +7180,9 @@ let rec read_duration_with ?(css_wide = true) ~canonicalize_ms t : duration =
     ~calls:
       [
         ("var", fun t -> Var (read_var read_duration_self t));
-        ("calc", fun t -> Calc (read_calc read_duration_in_calc t));
+        ( "calc",
+          fun t -> Calc (read_calc ~result_type:`Value read_duration_in_calc t)
+        );
         ("round", read_duration_round read_duration_self);
         ( "rem",
           read_duration_binary_call "rem"
@@ -7155,7 +7213,8 @@ let rec read_time_with ?(css_wide = true) t : duration =
     ~calls:
       [
         ("var", fun t -> Var (read_var read_time t));
-        ("calc", fun t -> Calc (read_calc read_time_in_calc t));
+        ( "calc",
+          fun t -> Calc (read_calc ~result_type:`Value read_time_in_calc t) );
         ("round", read_duration_round read_time);
         ( "rem",
           read_duration_binary_call "rem" (fun a b -> Rem (a, b)) read_time );
@@ -7215,7 +7274,7 @@ and read_number_function t =
       | "var" -> Some (Var (read_var read_number t))
       | "calc" ->
           let read_number_dim_only t = Cursor.err t "expected numeric factor" in
-          Some (Calc (read_calc read_number_dim_only t))
+          Some (Calc (read_calc ~result_type:`Number read_number_dim_only t))
       | "min" ->
           Some
             (Num
@@ -7316,7 +7375,8 @@ let read_transition_behavior t : transition_behavior =
 let rec read_percentage t : percentage =
   Cursor.ws t;
   if Cursor.looking_at t "var(" then Var (read_var read_percentage t)
-  else if Cursor.looking_at_calc t then Calc (read_calc read_percentage t)
+  else if Cursor.looking_at_calc t then
+    Calc (read_calc ~result_type:`Value read_percentage t)
   else Pct (Cursor.pct t)
 
 (* CSS Values 4 sec. 10.4: math functions that produce a non-length type ([asin]
@@ -7379,7 +7439,8 @@ and read_length_percentage_calc ~with_keywords t : length_percentage =
        allowed even when the surrounding property is non-negative; the
        non-negative constraint applies to the resolved value, not to inner
        operands. *)
-    Calc (read_calc (read_length_percentage ~with_keywords) t)
+    Calc
+      (read_calc ~result_type:`Value (read_length_percentage ~with_keywords) t)
   else Cursor.err t "expected calc"
 
 (** Read number_percentage value. Inside a [<number-percentage>] [calc()], a raw
@@ -7401,7 +7462,8 @@ let rec read_number_percentage t : number_percentage =
   Cursor.ws t;
   if Cursor.looking_at t "var(" then Var (read_var read_number_percentage t)
   else if Cursor.looking_at_calc t then
-    Calc (read_calc read_number_percentage_dim_only t)
+    Calc
+      (read_calc ~result_type:`Number_or_value read_number_percentage_dim_only t)
   else if
     Cursor.looking_at_func "min" t
     || Cursor.looking_at_func "max" t
@@ -7845,7 +7907,8 @@ let read_calc_op t : calc_op =
 let rec read_component t : component =
   Cursor.ws t;
   if Cursor.looking_at t "var(" then Var (read_var read_component t)
-  else if Cursor.looking_at_calc t then Calc (read_calc read_component t)
+  else if Cursor.looking_at_calc t then
+    Calc (read_calc ~result_type:`Number_or_value read_component t)
   else
     let n, unit = Cursor.number_with_unit t in
     match unit with

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -585,8 +585,16 @@ val read_length_percentage :
 val read_number_percentage : Cursor.t -> number_percentage
 (** [read_number_percentage t] parses a CSS number or percentage. *)
 
-val read_calc : (Cursor.t -> 'a) -> Cursor.t -> 'a calc
-(** [read_calc read t] parses a [calc(...)] expression or a promotable value. *)
+val read_calc :
+  ?result_type:[ `Number | `Number_or_value | `Value ] ->
+  (Cursor.t -> 'a) ->
+  Cursor.t ->
+  'a calc
+(** [read_calc ~result_type read t] parses a [calc(...)] expression or a
+    promotable value and checks that its statically knowable result type matches
+    the property's numeric grammar. Expressions containing [var()] remain
+    deferred until substitution. Omitting [result_type] retains the generic AST
+    reader behaviour. *)
 
 val read_calc_expr : (Cursor.t -> 'a) -> Cursor.t -> 'a calc
 (** [read_calc_expr read t] parses a calc expression body -- the contents of a

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1479,6 +1479,11 @@ let component_var_keeps_typed_value () =
   check_declaration ~expected:"border-radius:var(--x)" "border-radius: var(--x)";
   check_declaration ~expected:"border-radius:var(--x) inherit"
     "border-radius: var(--x) inherit";
+  (* CSS Values 4 sec. 4.1 makes a keyword ASCII case-insensitive, so a typed
+     read answers with the keyword where an opaque stream keeps the case the
+     author wrote. *)
+  check_specified_value "place-content reads its components"
+    "place-content: var(--p) CENTER" "var(--p) center";
   check_specified_value "overflow slots are unchanged"
     "overflow: var(--o) HIDDEN" "var(--o) hidden"
 


### PR DESCRIPTION
`place-content: var(--p) center` was carried as an opaque token stream, so its keyword slot stopped folding. Same whole-value commitment as #729, which left this reader behind.

The remaining readers with this shape (`place-items`, `grid-auto-flow`, `border-image-width`, `border-image-outset`) need a `var()` arm in their component readers as well, so they are not in this change. `background-size` must keep the current reading: its declaration goes through a per-layer reader, where a leading `var()` legitimately has other layers after it.