### PR TITLE
grid: preserve place-content component vars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -177,11 +177,9 @@ difference wherever the two are not equivalent.
 - Declarations containing a non-empty `var()`, `env()` or `attr()` call defer
   CSS-wide keyword mix validation until substitution, instead of being dropped
   while the substituted token stream is still unknown (#726)
-- A `var()` beside other components keeps the declaration typed, where
-  `border-radius`, `gap`, `transform-origin` and `border-spacing` read the
-  reference as the whole value and fell back to an opaque token stream, so the
-  components next to it lost their folds and `cascade diff --diff=canonical`
-  called two equivalent sheets different (#729)
+- Component `var()` values in `border-radius`, `gap`, `transform-origin`,
+  `border-spacing` and `place-content` stay typed, preserving adjacent folds
+  and variable discovery (#729, #734)
 - `revert-rule` is reserved wherever a grammar accepts a `<custom-ident>`, so
   it no longer survives inside grid line-name lists as an ordinary name (#724)
 - The grid track-list grammars are the ones a browser applies: `grid-auto-rows`

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -396,7 +396,10 @@ let rec pp_place_content : place_content Pp.t =
   | Align_justify (a, j) ->
       let a_s = Pp.to_string ~minify:(Pp.minified ctx) pp_align_content a in
       let j_s = Pp.to_string ~minify:(Pp.minified ctx) pp_justify_content j in
-      if Pp.minified ctx && a_s = j_s then Pp.string ctx a_s
+      let can_omit_justify =
+        match (a, j) with Var _, _ | _, Var _ -> false | _ -> true
+      in
+      if Pp.minified ctx && can_omit_justify && a_s = j_s then Pp.string ctx a_s
       else (
         Pp.string ctx a_s;
         Pp.space ctx ();
@@ -489,7 +492,7 @@ let read_place_content_single t =
     t
 
 let rec read_place_content t : place_content =
-  Cursor.enum_or_var "place-content"
+  Cursor.enum_or_whole_value_var "place-content"
     [
       ("inherit", (Inherit : place_content));
       ("initial", Initial);

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1058,7 +1058,11 @@ let vars_of_justify_self (value : Properties.justify_self) =
   match value with Var v -> [ V v ] | _ -> []
 
 let vars_of_place_content (value : Properties.place_content) =
-  match value with Var v -> [ V v ] | _ -> []
+  match value with
+  | Var v -> [ V v ]
+  | Align_justify (align, justify) ->
+      vars_of_align_content align @ vars_of_justify_content justify
+  | _ -> []
 
 let vars_of_place_items (value : Properties.place_items) =
   match value with Var v -> [ V v ] | _ -> []

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -24,6 +24,13 @@ let check_specified_value name css expected =
     name expected
     (Css.Declaration.string_of_value ~minify:false decl)
 
+let check_visible_var name css expected =
+  let declaration = Css.Declaration.of_string css in
+  let names =
+    Css.vars_of_declarations [ declaration ] |> List.map Css.any_var_name
+  in
+  Alcotest.(check (list string)) name [ expected ] names
+
 let check_declarations input expected_count =
   let r = Cursor.of_string input in
   let decls = read_declarations r in
@@ -1479,6 +1486,20 @@ let component_var_keeps_typed_value () =
   check_declaration ~expected:"border-radius:var(--x)" "border-radius: var(--x)";
   check_declaration ~expected:"border-radius:var(--x) inherit"
     "border-radius: var(--x) inherit";
+  (* CSS Values 4 sec. 4.1 makes a keyword ASCII case-insensitive, so a typed
+     read answers with the keyword where an opaque stream keeps the case the
+     author wrote. *)
+  check_specified_value "place-content reads its components"
+    "place-content: var(--p) CENTER" "var(--p) center";
+  check_visible_var "place-content component var stays visible"
+    "place-content:var(--p) center" "--p";
+  (* A var() can substitute more than one component. Keeping two equal
+     references is therefore cardinality-sensitive: if [--p] is [center end],
+     the two-reference spelling is invalid after substitution while a folded
+     single reference is valid. *)
+  check_declaration ~expected:"place-content:var(--p) var(--p)"
+    ~optimized:"place-content:var(--p) var(--p)"
+    "place-content: var(--p) var(--p)";
   check_specified_value "overflow slots are unchanged"
     "overflow: var(--o) HIDDEN" "var(--o) hidden"
 


### PR DESCRIPTION
Stacked on #731. `place-content` now keeps a leading component `var()` typed so adjacent keywords can fold without losing variable visibility or substitution cardinality.