### PR TITLE
values: type remaining component vars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -180,6 +180,9 @@ difference wherever the two are not equivalent.
 - Component `var()` values in `border-radius`, `gap`, `transform-origin`,
   `border-spacing` and `place-content` stay typed, preserving adjacent folds
   and variable discovery (#729, #734)
+- Component `var()` values in `place-items`, `grid-auto-flow` and border-image
+  dimensions stay typed, preserving adjacent folds, ASCII keyword handling and
+  variable discovery (#735)
 - `revert-rule` is reserved wherever a grammar accepts a `<custom-ident>`, so
   it no longer survives inside grid line-name lists as an ordinary name (#724)
 - The grid track-list grammars are the ones a browser applies: `grid-auto-rows`

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3894,6 +3894,12 @@ type repeat_count = Properties.repeat_count =
   | Auto_fit
   | Var of repeat_count var
 
+(** One component in a [grid-auto-flow] value. *)
+type grid_auto_flow_component = Properties.grid_auto_flow_component =
+  | Axis of [ `Row | `Column ]
+  | Dense
+  | Var of grid_auto_flow_component var
+
 (** CSS grid-auto-flow values *)
 type grid_auto_flow = Properties.grid_auto_flow =
   | Row
@@ -3901,6 +3907,7 @@ type grid_auto_flow = Properties.grid_auto_flow =
   | Dense
   | Row_dense
   | Column_dense
+  | Components of grid_auto_flow_component list
   | Inherit
   | Initial
   | Unset

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -2127,7 +2127,7 @@ let rec read_border_image_repeat t : border_image_repeat =
     t
 
 let rec read_border_image_width t : border_image_width =
-  Cursor.enum_or_var "border-image-width"
+  Cursor.enum_or_whole_value_var "border-image-width"
     [
       ("inherit", (Inherit : border_image_width));
       ("initial", Initial);
@@ -2143,7 +2143,7 @@ let rec read_border_image_width t : border_image_width =
     t
 
 let rec read_border_image_outset t : border_image_outset =
-  Cursor.enum_or_var "border-image-outset"
+  Cursor.enum_or_whole_value_var "border-image-outset"
     [
       ("inherit", (Inherit : border_image_outset));
       ("initial", Initial);

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -21,6 +21,13 @@ open Prop_align
 let normalize_grid_auto_flow : grid_auto_flow -> grid_auto_flow =
  fun value -> match value with Row_dense -> Dense | other -> other
 
+let rec pp_grid_auto_flow_component : grid_auto_flow_component Pp.t =
+ fun ctx -> function
+  | Axis `Row -> Pp.string ctx "row"
+  | Axis `Column -> Pp.string ctx "column"
+  | Dense -> Pp.string ctx "dense"
+  | Var v -> pp_var pp_grid_auto_flow_component ctx v
+
 let rec pp_grid_auto_flow : grid_auto_flow Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_grid_auto_flow ctx v
@@ -29,6 +36,8 @@ let rec pp_grid_auto_flow : grid_auto_flow Pp.t =
   | Dense -> Pp.string ctx "dense"
   | Row_dense -> Pp.string ctx "row dense"
   | Column_dense -> Pp.string ctx "column dense"
+  | Components components ->
+      Pp.list ~sep:Pp.space pp_grid_auto_flow_component ctx components
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -145,6 +154,14 @@ let pp_grid_auto_flow_shorthand ctx = function
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_grid_auto_flow ctx v
+  | Components components ->
+      let pp_component ctx (component : grid_auto_flow_component) =
+        match component with
+        | Axis (`Row | `Column) -> Pp.string ctx "auto-flow"
+        | Dense -> Pp.string ctx "dense"
+        | Var v -> pp_var pp_grid_auto_flow_component ctx v
+      in
+      Pp.list ~sep:Pp.space pp_component ctx components
 
 let rec pp_grid_template : grid_template Pp.t =
  fun ctx -> function
@@ -431,7 +448,10 @@ let rec pp_place_items : place_items Pp.t =
       let j_s = Pp.to_string ~minify:(Pp.minified ctx) pp_justify_items j in
       (* CSS Align 3 sec. 7.3: when align and justify render to the same token,
          the single-value spelling is canonical. *)
-      if Pp.minified ctx && a_s = j_s then Pp.string ctx a_s
+      let can_omit_justify =
+        match (a, j) with Var _, _ | _, Var _ -> false | _ -> true
+      in
+      if Pp.minified ctx && can_omit_justify && a_s = j_s then Pp.string ctx a_s
       else (
         Pp.string ctx a_s;
         Pp.space ctx ();
@@ -568,6 +588,11 @@ let read_place_items_first t =
 let read_place_items_default t =
   if Cursor.looking_at t "safe" then read_place_items_safe t
   else if Cursor.looking_at t "stretch" then read_place_items_stretch t
+  else if Cursor.looking_at_func "var" t then (
+    let align = read_align_items t in
+    Cursor.ws t;
+    let justify = read_justify_items t in
+    Align_justify (align, justify))
   else
     let first = read_place_items_first t in
     Cursor.ws t;
@@ -580,7 +605,7 @@ let read_place_items_default t =
 
 let rec read_place_items t : place_items =
   Cursor.ws t;
-  Cursor.enum_or_var "place-items"
+  Cursor.enum_or_whole_value_var "place-items"
     [
       ("inherit", (Inherit : place_items));
       ("initial", Initial);
@@ -591,8 +616,33 @@ let rec read_place_items t : place_items =
     ~var:(fun t -> Var (read_var read_place_items t))
     ~default:read_place_items_default t
 
+let rec read_grid_auto_flow_component t : grid_auto_flow_component =
+  Cursor.enum_or_var "grid-auto-flow component"
+    [
+      ("row", (Axis `Row : grid_auto_flow_component));
+      ("column", Axis `Column);
+      ("dense", Dense);
+    ]
+    ~var:(fun t -> Var (read_var read_grid_auto_flow_component t))
+    t
+
+let grid_auto_flow_of_components t (components : grid_auto_flow_component list)
+    =
+  match components with
+  | [ Axis `Row ] -> Row
+  | [ Axis `Column ] -> Column
+  | [ Dense ] -> Dense
+  | [ Axis `Row; Dense ] | [ Dense; Axis `Row ] -> Row_dense
+  | [ Axis `Column; Dense ] | [ Dense; Axis `Column ] -> Column_dense
+  | components
+    when List.exists
+           (function (Var _ : grid_auto_flow_component) -> true | _ -> false)
+           components ->
+      Components components
+  | _ -> Cursor.err_invalid t "grid-auto-flow component combination"
+
 let rec read_grid_auto_flow t : grid_auto_flow =
-  Cursor.enum_or_var "grid-auto-flow"
+  Cursor.enum_or_whole_value_var "grid-auto-flow"
     [
       ("inherit", (Inherit : grid_auto_flow));
       ("initial", Initial);
@@ -602,21 +652,8 @@ let rec read_grid_auto_flow t : grid_auto_flow =
     ]
     ~var:(fun t -> Var (read_var read_grid_auto_flow t))
     ~default:(fun t ->
-      let v = Cursor.ident t in
-      Cursor.ws t;
-      let second = Cursor.option Cursor.ident t in
-      match (v, second) with
-      | "row", Some "dense" -> Row_dense
-      | "row", None -> Row
-      | "column", Some "dense" -> Column_dense
-      | "column", None -> Column
-      | "dense", Some "row" -> Row_dense
-      | "dense", Some "column" -> Column_dense
-      | "dense", None -> Dense
-      | _, Some _ ->
-          err_invalid_value t "grid-auto-flow"
-            (v ^ " " ^ Option.value second ~default:"")
-      | _ -> err_invalid_value t "grid-auto-flow" v)
+      Cursor.list ~sep:Cursor.ws read_grid_auto_flow_component t
+      |> grid_auto_flow_of_components t)
     t
 
 let grid_line_at_end t =

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -909,6 +909,14 @@ val pp_place_items : place_items Pp.t
 val read_place_items : Cursor.t -> place_items
 (** [read_place_items t] is the [place_items] parsed from [t]. *)
 
+val pp_grid_auto_flow_component : grid_auto_flow_component Pp.t
+(** [pp_grid_auto_flow_component] is the pretty-printer for one [grid_auto_flow]
+    component. *)
+
+val read_grid_auto_flow_component : Cursor.t -> grid_auto_flow_component
+(** [read_grid_auto_flow_component t] is one [grid_auto_flow] component parsed
+    from [t]. *)
+
 val pp_grid_auto_flow : grid_auto_flow Pp.t
 (** [pp_grid_auto_flow] is the pretty-printer for [grid_auto_flow]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -744,12 +744,18 @@ type place_items =
   | Var of place_items var
 
 (* Grid Types *)
+type grid_auto_flow_component =
+  | Axis of [ `Row | `Column ]
+  | Dense
+  | Var of grid_auto_flow_component var
+
 type grid_auto_flow =
   | Row
   | Column
   | Dense
   | Row_dense
   | Column_dense
+  | Components of grid_auto_flow_component list
   | Inherit
   | Initial
   | Unset

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -849,11 +849,25 @@ let vars_of_border_image_repeat (value : Properties.border_image_repeat) :
 
 let vars_of_border_image_width (value : Properties.border_image_width) :
     any_var list =
-  match value with Var v -> [ V v ] | _ -> []
+  match value with
+  | Var v -> [ V v ]
+  | Widths values ->
+      List.concat_map
+        (fun (item : Properties.border_image_width_item) ->
+          match item with Length length -> vars_of_length length | _ -> [])
+        values
+  | _ -> []
 
 let vars_of_border_image_outset (value : Properties.border_image_outset) :
     any_var list =
-  match value with Var v -> [ V v ] | _ -> []
+  match value with
+  | Var v -> [ V v ]
+  | Outsets values ->
+      List.concat_map
+        (fun (item : Properties.border_image_outset_item) ->
+          match item with Length length -> vars_of_length length | _ -> [])
+        values
+  | _ -> []
 
 let vars_of_column_width (value : Properties.column_width) : any_var list =
   match value with Var v -> [ V v ] | Width l -> vars_of_length l | _ -> []
@@ -1065,10 +1079,21 @@ let vars_of_place_content (value : Properties.place_content) =
   | _ -> []
 
 let vars_of_place_items (value : Properties.place_items) =
+  match value with
+  | Var v -> [ V v ]
+  | Align_justify (align, justify) ->
+      vars_of_align_items align @ vars_of_justify_items justify
+  | _ -> []
+
+let vars_of_grid_flow_component (value : Properties.grid_auto_flow_component) =
   match value with Var v -> [ V v ] | _ -> []
 
 let vars_of_grid_auto_flow (value : Properties.grid_auto_flow) =
-  match value with Var v -> [ V v ] | _ -> []
+  match value with
+  | Var v -> [ V v ]
+  | Components components ->
+      List.concat_map vars_of_grid_flow_component components
+  | _ -> []
 
 let vars_of_container_name (value : Properties.container_name) =
   match value with Var v -> [ V v ] | _ -> []

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1500,6 +1500,35 @@ let component_var_keeps_typed_value () =
   check_declaration ~expected:"place-content:var(--p) var(--p)"
     ~optimized:"place-content:var(--p) var(--p)"
     "place-content: var(--p) var(--p)";
+  check_specified_value "place-items reads a leading component var"
+    "place-items: var(--pi) CENTER" "var(--pi) center";
+  check_specified_value "place-items keeps its existing trailing component var"
+    "place-items: CENTER var(--pi)" "center var(--pi)";
+  check_visible_var "place-items component var stays visible"
+    "place-items:var(--pi) center" "--pi";
+  check_declaration ~expected:"place-items:var(--pi) var(--pi)"
+    ~optimized:"place-items:var(--pi) var(--pi)"
+    "place-items: var(--pi) var(--pi)";
+  check_specified_value "grid-auto-flow keywords are case-insensitive"
+    "grid-auto-flow: ROW DENSE" "row dense";
+  check_specified_value "grid-auto-flow reads a leading component var"
+    "grid-auto-flow: var(--flow) DENSE" "var(--flow) dense";
+  check_specified_value "grid-auto-flow reads a trailing component var"
+    "grid-auto-flow: ROW var(--flow)" "row var(--flow)";
+  check_visible_var "grid-auto-flow component var stays visible"
+    "grid-auto-flow:row var(--flow)" "--flow";
+  check_specified_value "border-image-width reads a leading component var"
+    "border-image-width: var(--width) AUTO" "var(--width) auto";
+  check_specified_value "border-image-width reads a trailing component var"
+    "border-image-width: AUTO var(--width)" "auto var(--width)";
+  check_visible_var "border-image-width component var stays visible"
+    "border-image-width:var(--width) auto" "--width";
+  check_specified_value "border-image-outset reads a leading component var"
+    "border-image-outset: var(--outset) 1PX" "var(--outset) 1px";
+  check_specified_value "border-image-outset reads a trailing component var"
+    "border-image-outset: 1PX var(--outset)" "1px var(--outset)";
+  check_visible_var "border-image-outset component var stays visible"
+    "border-image-outset:var(--outset) 1px" "--outset";
   check_specified_value "overflow slots are unchanged"
     "overflow: var(--o) HIDDEN" "var(--o) hidden"
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -407,6 +407,10 @@ let check_content = check_value_cursor "content" read_content pp_content
 let check_grid_auto_flow =
   check_value_cursor "grid-auto-flow" read_grid_auto_flow pp_grid_auto_flow
 
+let check_grid_auto_flow_component =
+  check_value_cursor "grid-auto-flow component" read_grid_auto_flow_component
+    pp_grid_auto_flow_component
+
 let check_grid_template =
   check_value_cursor "grid-template" read_grid_template pp_grid_template
 
@@ -1811,6 +1815,14 @@ let test_grid_auto_flow () =
   (* opposite of dense, not valid *)
   (* not a valid value *)
   neg_cursor read_grid_auto_flow "horizontal"
+
+let test_grid_auto_flow_component () =
+  check_grid_auto_flow_component "row";
+  check_grid_auto_flow_component "column";
+  check_grid_auto_flow_component "dense";
+  check_grid_auto_flow_component "var(--flow,dense)";
+  neg_cursor read_grid_auto_flow_component "auto-flow";
+  neg_cursor read_grid_auto_flow_component "sparse"
 
 let test_background_box () =
   check_background_box "border-box";
@@ -5161,6 +5173,7 @@ let tests =
       enum_readers_accept_leading_ws;
     test_case "property names" `Quick test_property_names;
     (* Additional coverage for missing readers *)
+    test_case "grid auto-flow component" `Quick test_grid_auto_flow_component;
     test_case "grid auto-flow" `Quick test_grid_auto_flow;
     test_case "grid template" `Quick test_grid_template;
     test_case "grid template areas" `Quick test_grid_template_areas;


### PR DESCRIPTION
Stacked on #734. Leading component `var()` values no longer force affected multi-component properties into opaque token streams, preserving canonicalisation and variable discovery.