### PR TITLE
values: preserve shorthand substitution cardinality

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -533,6 +533,8 @@ difference wherever the two are not equivalent.
   `text-decoration`, `transition` and `font` shorthands, a repeated
   `font-family` entry, a two-value `display` beside its legacy keyword, and a
   box shorthand whose sides repeat (#635, #636, #637, #639, #640, #641)
+- Box shorthands keep authored component counts across top-level substitution
+  functions, preserving computed-value validity and side assignment (#736)
 - `--minify` canonicalises logical minimum sizes, duration units, stepped
   functions, hue-angle units, constructed `transform-origin` positions and
   repeated sides in the `scroll-margin` and `scroll-padding` shorthands before

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -225,7 +225,8 @@ let rec pp_border_radius : border_radius Pp.t =
 let normalize_border_radius ?(strip = true) : border_radius -> border_radius =
  fun value ->
   let group =
-    normalize_box_shorthand (Values.normalize_length_percentage ~strip)
+    normalize_box_shorthand ~is_substitution:is_lp_substitution
+      (Values.normalize_length_percentage ~strip)
   in
   match value with
   | Radius { horizontal; vertical } ->
@@ -233,8 +234,10 @@ let normalize_border_radius ?(strip = true) : border_radius -> border_radius =
       let vertical = option_map_preserve group vertical in
       let vertical =
         match vertical with
-        | Some vs when List.equal Values.equal_length_percentage horizontal vs
-          ->
+        | Some vs
+          when (not (List.exists is_lp_substitution horizontal))
+               && (not (List.exists is_lp_substitution vs))
+               && List.equal Values.equal_length_percentage horizontal vs ->
             Option.None
         | _ -> vertical
       in

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -163,9 +163,34 @@ let normalize_color ?(lossless = false) = Values.normalize_color ~lossless
 let preserve_if_equal before after = if after == before then before else after
 let map_preserve = List.map_preserve
 
+(* CSS Values 5 leaves a value's top-level component sequence unresolved across
+   an arbitrary substitution function until computed-value time. A substitution
+   nested inside calc() or another typed function stays one top-level component,
+   so only these outer AST constructors are cardinality sensitive. *)
+let is_length_substitution : length -> bool = function
+  | Attr _ | Env _ | Var _ -> true
+  | _ -> false
+
+let is_lp_substitution : length_percentage -> bool = function
+  | Length length -> is_length_substitution length
+  | Env _ | Var _ -> true
+  | _ -> false
+
+let is_color_substitution : color -> bool = function
+  | Attribute _ | Var _ -> true
+  | _ -> false
+
 (* Canonicalise a box shorthand: normalise each side with [f], then pick the
-   shortest of the spellings that name those sides. *)
-let normalize_box_shorthand f vs = collapse_box_shorthand (map_preserve f vs)
+   shortest of the spellings that name those sides. Keep the authored number of
+   components when arbitrary substitution defers their computed arity. *)
+let normalize_box_shorthand ~is_substitution f vs =
+  let normalized = map_preserve f vs in
+  if List.exists is_substitution normalized then normalized
+  else collapse_box_shorthand normalized
+
+let normalize_length_box ~ctx =
+  normalize_box_shorthand ~is_substitution:is_length_substitution
+    (Values.normalize_length ~ctx)
 
 let option_map_preserve f opt =
   match opt with

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3995,7 +3995,9 @@ let normalize_property_value : type a.
   | Baseline_shift -> normalize_baseline_shift value
   | Background_color -> normalize_color value
   | Color -> normalize_color value
-  | Border_color -> normalize_box_shorthand normalize_color value
+  | Border_color ->
+      normalize_box_shorthand ~is_substitution:is_color_substitution
+        normalize_color value
   | Border_top_color -> normalize_color value
   | Border_right_color -> normalize_color value
   | Border_bottom_color -> normalize_color value
@@ -4130,38 +4132,29 @@ let normalize_property_value : type a.
   | Scroll_padding_inline_end -> Values.normalize_length ~ctx value
   | Scroll_padding_block_start -> Values.normalize_length ~ctx value
   | Scroll_padding_block_end -> Values.normalize_length ~ctx value
-  | Padding -> normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Padding_inline ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Padding_block ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Margin -> normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Margin_inline ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Margin_block -> normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Inset -> normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Inset_inline -> normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Padding -> normalize_length_box ~ctx value
+  | Padding_inline -> normalize_length_box ~ctx value
+  | Padding_block -> normalize_length_box ~ctx value
+  | Margin -> normalize_length_box ~ctx value
+  | Margin_inline -> normalize_length_box ~ctx value
+  | Margin_block -> normalize_length_box ~ctx value
+  | Inset -> normalize_length_box ~ctx value
+  | Inset_inline -> normalize_length_box ~ctx value
   | Inset_inline_start -> map_preserve (Values.normalize_length ~ctx) value
   | Inset_inline_end -> map_preserve (Values.normalize_length ~ctx) value
-  | Inset_block -> normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Inset_block -> normalize_length_box ~ctx value
   | Inset_block_start -> map_preserve (Values.normalize_length ~ctx) value
   | Inset_block_end -> map_preserve (Values.normalize_length ~ctx) value
   | Top -> map_preserve (Values.normalize_length ~ctx) value
   | Right -> map_preserve (Values.normalize_length ~ctx) value
   | Bottom -> map_preserve (Values.normalize_length ~ctx) value
   | Left -> map_preserve (Values.normalize_length ~ctx) value
-  | Scroll_margin ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Scroll_margin_inline ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Scroll_margin_block ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Scroll_padding ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Scroll_padding_inline ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Scroll_padding_block ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Scroll_margin -> normalize_length_box ~ctx value
+  | Scroll_margin_inline -> normalize_length_box ~ctx value
+  | Scroll_margin_block -> normalize_length_box ~ctx value
+  | Scroll_padding -> normalize_length_box ~ctx value
+  | Scroll_padding_inline -> normalize_length_box ~ctx value
+  | Scroll_padding_block -> normalize_length_box ~ctx value
   | Custom_property _ -> (
       match value with
       | Custom_value ({ value = Tokens components; _ } as r) ->

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1457,6 +1457,62 @@ let box_shorthand_repeats () =
   check_declaration ~expected:"padding:1px 2px 1px 3px"
     ~optimized:"padding:1px 2px 1px 3px" "padding: 1px 2px 1px 3px"
 
+let substitution_shorthand_cardinality () =
+  let concat = String.concat "" in
+  let check_preserved property ~held value =
+    let input = concat [ property; ": "; value ] in
+    let expected = concat [ property; ":"; held ] in
+    check_declaration ~expected ~optimized:expected input
+  in
+  (* CSS Values 5 arbitrary substitution happens before the property's grammar
+     is checked. A top-level var() can therefore contribute several box
+     components: dropping one authored slot can turn an invalid computed value
+     into a valid one or change the side assignment. *)
+  List.iter
+    (fun (property, repeated, separator) ->
+      check_preserved property
+        ~held:
+          (concat
+             [ "var(--v)"; separator; repeated; " "; repeated; " "; repeated ])
+        (concat [ "var(--v) "; repeated; " "; repeated; " "; repeated ]))
+    [
+      ("margin", "1px", "");
+      ("padding", "1px", "");
+      ("inset", "1px", "");
+      ("scroll-margin", "1px", " ");
+      ("scroll-padding", "1px", " ");
+      ("border-color", "red", "");
+    ];
+  List.iter
+    (fun (property, separator) ->
+      check_preserved property
+        ~held:(concat [ "var(--v)"; separator; "var(--v)" ])
+        "var(--v) var(--v)")
+    [
+      ("margin-inline", "");
+      ("margin-block", "");
+      ("padding-inline", "");
+      ("padding-block", "");
+      ("inset-inline", "");
+      ("inset-block", "");
+      ("scroll-margin-inline", " ");
+      ("scroll-margin-block", " ");
+      ("scroll-padding-inline", " ");
+      ("scroll-padding-block", " ");
+    ];
+  (* env() and attr() are substitution functions too; keep the guard attached to
+     the AST shape rather than special-casing var() spellings. *)
+  check_preserved "margin" ~held:"env(safe-area-inset-top)1px 1px 1px"
+    "env(safe-area-inset-top) 1px 1px 1px";
+  check_preserved "margin" ~held:"attr(data-m px)1px 1px 1px"
+    "attr(data-m px) 1px 1px 1px";
+  check_preserved "border-color"
+    ~held:"attr(data-color type(<color>))red red red"
+    "attr(data-color type(<color>)) red red red";
+  check_preserved "border-radius" ~held:"var(--r)1px 1px 1px"
+    "var(--r) 1px 1px 1px";
+  check_preserved "border-radius" ~held:"var(--r)/var(--r)" "var(--r)/var(--r)"
+
 (* A [var()] standing beside other components is one operand of the property's
    own grammar rather than a substitution of the whole value: CSS Cascade 5 sec.
    6 keeps the whole-value reading for the CSS-wide keywords, which are valid
@@ -1468,11 +1524,10 @@ let box_shorthand_repeats () =
 let component_var_keeps_typed_value () =
   check_declaration ~expected:"border-radius:var(--x)0px"
     ~optimized:"border-radius:var(--x)0" "border-radius: var(--x) 0px";
-  (* The four-value form is top-left, top-right, bottom-right, bottom-left, so a
-     fourth value equal to the second is the longer spelling of three, as it is
-     for the other box shorthands. *)
+  (* A top-level var() can expand to several radii, so changing the authored
+     component count is not safe before substitution. *)
   check_declaration ~expected:"border-radius:var(--x)1px 1px 1px"
-    ~optimized:"border-radius:var(--x)1px 1px"
+    ~optimized:"border-radius:var(--x)1px 1px 1px"
     "border-radius: var(--x) 1px 1px 1px";
   check_declaration ~expected:"gap:var(--g) 0px" ~optimized:"gap:var(--g) 0"
     "gap: var(--g) 0px";
@@ -5343,6 +5398,8 @@ let declaration_tests =
     test_case "mask-border mode slot" `Quick mask_border_mode_slot;
     test_case "mask-border mode only" `Quick mask_border_mode_only;
     test_case "box shorthand repeats" `Quick box_shorthand_repeats;
+    test_case "substitution shorthand cardinality" `Quick
+      substitution_shorthand_cardinality;
     test_case "component var keeps typed value" `Quick
       component_var_keeps_typed_value;
     test_case "border-spacing pair" `Quick border_spacing_pair;


### PR DESCRIPTION
Stacked on #735. Box-shorthand folds now preserve authored component counts across top-level substitution functions, avoiding changes to computed-value validity or side assignment.