### PR TITLE
optimize: hold the box repeat fold back from a substitution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -545,6 +545,13 @@ difference wherever the two are not equivalent.
   prints as `2px` and merges with a rule that wrote `2px` (#639)
 - `--minify` collapses `margin-inline` and `margin-block` to one value when the
   two edges match, which the four-sided box shorthands already did (#641)
+- `--minify` keeps a repeated side in `margin`, `padding`, `inset`,
+  `border-color`, `border-radius` and their logical forms when any value is a
+  `var()`, `env()` or `attr()`. The 1-4 value forms assign sides by how many
+  values there are, so with `--m: 1px 2px` the fold turned
+  `margin: var(--m) 1px 1px 1px`, five components and invalid after
+  substitution, into four that apply. A reference inside `calc()` is one
+  component and still folds (#737)
 - `--minify` folds `steps(1)` to `step-end`, CSS Easing 1 sec. 2.3 assuming
   `end` when the step position is left out (#641)
 - `--minify` keeps `display: block ruby`. It printed `ruby`, which CSS Display

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -225,7 +225,8 @@ let rec pp_border_radius : border_radius Pp.t =
 let normalize_border_radius ?(strip = true) : border_radius -> border_radius =
  fun value ->
   let group =
-    normalize_box_shorthand (Values.normalize_length_percentage ~strip)
+    normalize_box_shorthand ~is_subst:Values.length_percentage_is_substitution
+      (Values.normalize_length_percentage ~strip)
   in
   match value with
   | Radius { horizontal; vertical } ->

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -146,15 +146,23 @@ let is_zero_length : length -> bool = function
    4.2 says the same for padding, css-logical-1 sec. 4.3 and sec. 4.4 for the
    inset and logical padding/margin shorthands, and CSS Backgrounds 3 (ED) sec.
    3.1 and sec. 4.1 for border-color and border-radius. *)
-let collapse_box_shorthand vs =
-  match vs with
-  | [ a; b; c; d ] when a = b && b = c && c = d -> [ a ]
-  | [ a; b; c; d ] when a = c && b = d -> [ a; b ]
-  | [ a; b; c; d ] when b = d -> [ a; b; c ]
-  | [ a; b; c ] when a = b && b = c -> [ a ]
-  | [ a; b; c ] when a = c -> [ a; b ]
-  | [ a; b ] when a = b -> [ a ]
-  | _ -> vs
+(* The 1-4 value forms assign sides by how many values there are, so a fold is
+   only the shorter spelling of the same declaration while every value stands
+   for one component. A substitution stands for a token sequence of any length,
+   which makes the count unknowable here: folding beside one can move the
+   substituted tokens to other sides, and can turn a declaration that is
+   invalid after substitution into one that applies. *)
+let collapse_box_shorthand ~is_subst vs =
+  if List.exists is_subst vs then vs
+  else
+    match vs with
+    | [ a; b; c; d ] when a = b && b = c && c = d -> [ a ]
+    | [ a; b; c; d ] when a = c && b = d -> [ a; b ]
+    | [ a; b; c; d ] when b = d -> [ a; b; c ]
+    | [ a; b; c ] when a = b && b = c -> [ a ]
+    | [ a; b; c ] when a = c -> [ a; b ]
+    | [ a; b ] when a = b -> [ a ]
+    | _ -> vs
 
 let pp_box_shorthand pp ctx vs = Pp.list ~sep:Pp.token_sp pp ctx vs
 
@@ -165,7 +173,8 @@ let map_preserve = List.map_preserve
 
 (* Canonicalise a box shorthand: normalise each side with [f], then pick the
    shortest of the spellings that name those sides. *)
-let normalize_box_shorthand f vs = collapse_box_shorthand (map_preserve f vs)
+let normalize_box_shorthand ~is_subst f vs =
+  collapse_box_shorthand ~is_subst (map_preserve f vs)
 
 let option_map_preserve f opt =
   match opt with

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3995,7 +3995,9 @@ let normalize_property_value : type a.
   | Baseline_shift -> normalize_baseline_shift value
   | Background_color -> normalize_color value
   | Color -> normalize_color value
-  | Border_color -> normalize_box_shorthand normalize_color value
+  | Border_color ->
+      normalize_box_shorthand ~is_subst:Values.color_is_substitution
+        normalize_color value
   | Border_top_color -> normalize_color value
   | Border_right_color -> normalize_color value
   | Border_bottom_color -> normalize_color value
@@ -4130,20 +4132,44 @@ let normalize_property_value : type a.
   | Scroll_padding_inline_end -> Values.normalize_length ~ctx value
   | Scroll_padding_block_start -> Values.normalize_length ~ctx value
   | Scroll_padding_block_end -> Values.normalize_length ~ctx value
-  | Padding -> normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Padding ->
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Padding_inline ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Padding_block ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Margin -> normalize_box_shorthand (Values.normalize_length ~ctx) value
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
+  | Margin ->
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Margin_inline ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Margin_block -> normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Inset -> normalize_box_shorthand (Values.normalize_length ~ctx) value
-  | Inset_inline -> normalize_box_shorthand (Values.normalize_length ~ctx) value
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
+  | Margin_block ->
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
+  | Inset ->
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
+  | Inset_inline ->
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Inset_inline_start -> map_preserve (Values.normalize_length ~ctx) value
   | Inset_inline_end -> map_preserve (Values.normalize_length ~ctx) value
-  | Inset_block -> normalize_box_shorthand (Values.normalize_length ~ctx) value
+  | Inset_block ->
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Inset_block_start -> map_preserve (Values.normalize_length ~ctx) value
   | Inset_block_end -> map_preserve (Values.normalize_length ~ctx) value
   | Top -> map_preserve (Values.normalize_length ~ctx) value
@@ -4151,17 +4177,29 @@ let normalize_property_value : type a.
   | Bottom -> map_preserve (Values.normalize_length ~ctx) value
   | Left -> map_preserve (Values.normalize_length ~ctx) value
   | Scroll_margin ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Scroll_margin_inline ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Scroll_margin_block ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Scroll_padding ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Scroll_padding_inline ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Scroll_padding_block ->
-      normalize_box_shorthand (Values.normalize_length ~ctx) value
+      normalize_box_shorthand ~is_subst:Values.length_is_substitution
+        (Values.normalize_length ~ctx)
+        value
   | Custom_property _ -> (
       match value with
       | Custom_value ({ value = Tokens components; _ } as r) ->

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5679,48 +5679,45 @@ and read_nested_calc_factor : type a. (Cursor.t -> a) -> Cursor.t -> a calc =
   else Cursor.err t "expected nested calc"
 
 type inferred_calc_type =
-  | Calc_dimension of int
+  | Dimension of int
     (* Exponent 0 is a number, 1 is the contextual numeric value, and
        multiplication/division add/subtract exponents. This retains valid
        cancellation such as [1 / (1 / 50px)]. *)
-  | Calc_deferred
-  | Calc_invalid
+  | Deferred
+  | Invalid
 
 let rec infer_calc_type : type a. a calc -> inferred_calc_type = function
-  | Num _ | Math_const _ | Sibling_index | Sibling_count -> Calc_dimension 0
-  | Val _ -> Calc_dimension 1
+  | Num _ | Math_const _ | Sibling_index | Sibling_count -> Dimension 0
+  | Val _ -> Dimension 1
   (* A var() is substituted before a math function is type-checked. The generic
      math-function AST does not retain enough result-type information to prove
      its type here either, so both stay deferred rather than being guessed. *)
-  | Var _ | Math_fn _ -> Calc_deferred
+  | Var _ | Math_fn _ -> Deferred
   | Nested inner | Parens inner -> infer_calc_type inner
   | Expr (left, (Add | Sub), right) -> (
       match (infer_calc_type left, infer_calc_type right) with
-      | Calc_invalid, _ | _, Calc_invalid -> Calc_invalid
-      | Calc_deferred, _ | _, Calc_deferred -> Calc_deferred
-      | Calc_dimension l, Calc_dimension r ->
-          if l = r then Calc_dimension l else Calc_invalid)
+      | Invalid, _ | _, Invalid -> Invalid
+      | Deferred, _ | _, Deferred -> Deferred
+      | Dimension l, Dimension r -> if l = r then Dimension l else Invalid)
   | Expr (left, Mul, right) -> (
       match (infer_calc_type left, infer_calc_type right) with
-      | Calc_invalid, _ | _, Calc_invalid -> Calc_invalid
-      | Calc_deferred, _ | _, Calc_deferred -> Calc_deferred
-      | Calc_dimension l, Calc_dimension r -> Calc_dimension (l + r))
+      | Invalid, _ | _, Invalid -> Invalid
+      | Deferred, _ | _, Deferred -> Deferred
+      | Dimension l, Dimension r -> Dimension (l + r))
   | Expr (left, Div, right) -> (
       match (infer_calc_type left, infer_calc_type right) with
-      | Calc_invalid, _ | _, Calc_invalid -> Calc_invalid
-      | Calc_deferred, _ | _, Calc_deferred -> Calc_deferred
-      | Calc_dimension l, Calc_dimension r -> Calc_dimension (l - r))
+      | Invalid, _ | _, Invalid -> Invalid
+      | Deferred, _ | _, Deferred -> Deferred
+      | Dimension l, Dimension r -> Dimension (l - r))
 
 let validate_calc_type t result_type calc =
   let inferred = infer_calc_type calc in
   let accepted =
     match (result_type, inferred) with
-    | _, Calc_deferred -> true
-    | `Number, Calc_dimension 0 | `Value, Calc_dimension 1 -> true
-    | `Number_or_value, (Calc_dimension 0 | Calc_dimension 1) -> true
-    | (`Number | `Value | `Number_or_value), (Calc_invalid | Calc_dimension _)
-      ->
-        false
+    | _, Deferred -> true
+    | `Number, Dimension 0 | `Value, Dimension 1 -> true
+    | `Number_or_value, (Dimension 0 | Dimension 1) -> true
+    | (`Number | `Value | `Number_or_value), (Invalid | Dimension _) -> false
   in
   if not accepted then Cursor.err_invalid t "incompatible calc types"
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1607,6 +1607,24 @@ and length_calc_has_runtime_subst : length calc -> bool = function
   | Expr (l, _, r) ->
       length_calc_has_runtime_subst l || length_calc_has_runtime_subst r
 
+(* CSS Custom Properties 1 sec. 3 replaces a [var()] with the custom property's
+   token sequence, of any length, and [env()] and [attr()] substitute the same
+   way, so such a value need not stand for one component of the grammar around
+   it. A reference nested in a [calc()] or another function is one component
+   whatever it holds, so only a top-level one answers true. *)
+let length_is_substitution : length -> bool = function
+  | Var _ | Env _ | Attr _ -> true
+  | _ -> false
+
+let length_percentage_is_substitution : length_percentage -> bool = function
+  | Var _ | Env _ -> true
+  | Length l -> length_is_substitution l
+  | _ -> false
+
+let color_is_substitution : color -> bool = function
+  | Var _ -> true
+  | _ -> false
+
 (* Reduce a computed coefficient to the serialised precision, returning the leaf
    unchanged when every digit already prints. A [<percentage>] is left alone:
    [Pp.pct] prints its coefficient in full in both modes, so there is no budget

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -192,6 +192,20 @@ val length_has_runtime_subst : length -> bool
 (** [length_has_runtime_subst l] is [true] when [l] is [var()] / [env()] /
     [attr()] / an anchor query, or a [calc()] containing one. *)
 
+val length_is_substitution : length -> bool
+(** [length_is_substitution l] is [true] when [l] is a top-level [var()],
+    [env()] or [attr()], which substitutes a token sequence of any length and so
+    need not stand for one component of the grammar around it. A reference
+    nested in a [calc()] is one component whatever it holds. *)
+
+val length_percentage_is_substitution : length_percentage -> bool
+(** [length_percentage_is_substitution] is {!val-length_is_substitution} over a
+    [<length-percentage>]. *)
+
+val color_is_substitution : color -> bool
+(** [color_is_substitution] is {!val-length_is_substitution} over a [<color>].
+*)
+
 val calc_length_unit : length -> (string * float) option
 (** [calc_length_unit l] is [Some (unit, value)] when [l] is a dimension, with
     the unit lower-cased. A keyword, a [var()] or a math function is [None]. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1461,11 +1461,10 @@ let box_shorthand_repeats () =
 let component_var_keeps_typed_value () =
   check_declaration ~expected:"border-radius:var(--x)0px"
     ~optimized:"border-radius:var(--x)0" "border-radius: var(--x) 0px";
-  (* The four-value form is top-left, top-right, bottom-right, bottom-left, so a
-     fourth value equal to the second is the longer spelling of three, as it is
-     for the other box shorthands. *)
+  (* The repeat fold that would drop the fourth value here is held back by the
+     reference in the first: see [box_shorthand_repeats_keep_substitution]. *)
   check_declaration ~expected:"border-radius:var(--x)1px 1px 1px"
-    ~optimized:"border-radius:var(--x)1px 1px"
+    ~optimized:"border-radius:var(--x)1px 1px 1px"
     "border-radius: var(--x) 1px 1px 1px";
   check_declaration ~expected:"gap:var(--g) 0px" ~optimized:"gap:var(--g) 0"
     "gap: var(--g) 0px";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1487,6 +1487,37 @@ let component_var_keeps_typed_value () =
   check_specified_value "overflow slots are unchanged"
     "overflow: var(--o) HIDDEN" "var(--o) hidden"
 
+(* A [var()], [env()] or [attr()] substitutes a token sequence of any length, so
+   such a value need not stand for one component of the grammar around it. The
+   1-4 value box forms assign sides by how many components there are, so
+   dropping a repeat beside a reference changes which sides the substituted
+   tokens reach: with [--m: 1px 2px], [margin: var(--m) 1px 1px 1px] is five
+   components, which is invalid at computed-value time, where the folded
+   [margin: var(--m) 1px 1px] is four and applies. A reference inside a [calc()]
+   is one component whatever it holds, so that one still folds. *)
+let box_shorthand_repeats_keep_substitution () =
+  check_declaration ~expected:"margin:var(--m)1px 1px 1px"
+    ~optimized:"margin:var(--m)1px 1px 1px" "margin: var(--m) 1px 1px 1px";
+  check_declaration ~expected:"padding:var(--p)2px var(--p)2px"
+    ~optimized:"padding:var(--p)2px var(--p)2px"
+    "padding: var(--p) 2px var(--p) 2px";
+  check_declaration ~expected:"margin-inline:var(--m)var(--m)"
+    ~optimized:"margin-inline:var(--m)var(--m)"
+    "margin-inline: var(--m) var(--m)";
+  check_declaration ~expected:"border-radius:var(--r)1px 1px 1px"
+    ~optimized:"border-radius:var(--r)1px 1px 1px"
+    "border-radius: var(--r) 1px 1px 1px";
+  check_declaration ~expected:"border-color:var(--c)red var(--c)red"
+    ~optimized:"border-color:var(--c)red var(--c)red"
+    "border-color: var(--c) red var(--c) red";
+  (* Controls: a reference inside [calc()] is one component, and a list with no
+     reference folds as it did. *)
+  check_declaration ~expected:"margin:calc(var(--m) + 1px)1px 1px 1px"
+    ~optimized:"margin:calc(var(--m) + 1px)1px 1px"
+    "margin: calc(var(--m) + 1px) 1px 1px 1px";
+  check_declaration ~expected:"margin:1px 1px 1px 1px" ~optimized:"margin:1px"
+    "margin: 1px 1px 1px 1px"
+
 (* CSS Tables 3 (ED) writes [border-spacing] as one or two non-negative lengths
    and reads a single one as "both the horizontal and vertical spacing", so a
    pair of equal lengths is the longer spelling of that one value. The per-side
@@ -5298,6 +5329,8 @@ let declaration_tests =
     test_case "mask-border mode slot" `Quick mask_border_mode_slot;
     test_case "mask-border mode only" `Quick mask_border_mode_only;
     test_case "box shorthand repeats" `Quick box_shorthand_repeats;
+    test_case "box shorthand repeats keep substitution" `Quick
+      box_shorthand_repeats_keep_substitution;
     test_case "component var keeps typed value" `Quick
       component_var_keeps_typed_value;
     test_case "border-spacing pair" `Quick border_spacing_pair;


### PR DESCRIPTION
With `--m: 1px 2px`, `margin: var(--m) 1px 1px 1px` is five components after substitution and invalid at computed-value time, but the repeat fold dropped the fourth value and left four components that apply, so a declaration a browser ignores started painting margins. The 1-4 value forms assign sides by how many values there are, and a substitution stands for a token sequence of any length, so the fold now stands down when any value is a `var()`, `env()` or `attr()`. A reference inside `calc()` is one component whatever it holds and still folds.

`gap` has the same hazard through a different route: `pp_gap` collapses two equal lengths itself, so the fix there is to move that fold out of the printer, and it is not in this change. Commit b23f3146 is a prerequisite: merlint E334 on the type #731 added fails every commit in the tree, so nothing could land behind it.