### PR TITLE
grid: accept place-content baseline positions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -171,6 +171,8 @@ difference wherever the two are not equivalent.
 
 ### Parsing
 
+- A sole baseline position in `place-content` is accepted and defaults its
+  omitted `justify-content` slot to `start`, as required by CSS Align (#739)
 - Custom-property declarations containing a `<bad-string-token>` are dropped
   during stylesheet recovery, so minified output no longer swallows the
   containing rule's closing brace when it is parsed again (#727)

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -496,6 +496,14 @@ let read_place_content_unsafe t =
     ]
     t
 
+(* CSS Align 3 sec. 7.2: the second value usually copies the first, except a
+   baseline position makes justify-content default to start. *)
+let read_place_content_baseline t =
+  match read_place_align_content t with
+  | (Baseline | First_baseline | Last_baseline) as align ->
+      (Align_justify (align, Start) : place_content)
+  | _ -> Cursor.err_invalid t "place-content baseline"
+
 let read_place_content_single t =
   Cursor.enum "place-content"
     [
@@ -527,6 +535,7 @@ let rec read_place_content t : place_content =
            read_place_content_pair;
            read_place_content_safe;
            read_place_content_unsafe;
+           read_place_content_baseline;
            read_place_content_single;
          ])
     t

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4298,6 +4298,15 @@ let test_place_content () =
   check_place_content "start end";
   check_place_content "flex-start center";
   check_place_content "inherit";
+  (* CSS Align 3 sec. 4.2 and 7.2: a baseline position is valid only in the
+     align-content slot. When it is the sole value, justify-content defaults to
+     start instead of copying it. *)
+  check_place_content ~expected:"baseline start" "baseline";
+  check_place_content ~expected:"first baseline start" "first baseline";
+  check_place_content ~expected:"last baseline start" "last baseline";
+  check_place_content "first baseline center";
+  neg_cursor ~allow_partial:true read_place_content "center baseline";
+  neg_cursor ~allow_partial:true read_place_content "baseline first";
   neg_cursor read_place_content "invalid-place"
 
 let test_place_items () =


### PR DESCRIPTION
A sole baseline position in `place-content` was rejected even though CSS Align defines its omitted `justify-content` value as `start`.