### PR TITLE
cli: make generated help authoritative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -963,6 +963,9 @@ difference wherever the two are not equivalent.
 
 ### CLI tools
 
+- CLI help lists each option and exit status once, and `cascade prune --help`
+  classifies representative selectors through the resolver instead of naming
+  `:nth-child()` as unsupported (#740)
 - `cascade prune PAGE.html... STYLE.css` removes the rules a set of HTML
   documents cannot use, and `--dry-run` reports instead, ranking what survives
   by how few elements matched it. A rule goes only when the matcher has a model

--- a/bin/cli_exit.ml
+++ b/bin/cli_exit.ml
@@ -1,0 +1,13 @@
+let by_code a b =
+  Int.compare Cmdliner.Cmd.Exit.(info_code a) Cmdliner.Cmd.Exit.(info_code b)
+
+let with_defaults custom =
+  let is_overridden default =
+    List.exists
+      (fun info ->
+        Cmdliner.Cmd.Exit.info_code info = Cmdliner.Cmd.Exit.info_code default)
+      custom
+  in
+  Cmdliner.Cmd.Exit.defaults
+  |> List.filter (fun info -> not (is_overridden info))
+  |> List.rev_append custom |> List.sort by_code

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -146,6 +146,21 @@ let term = Term.(const run $ minimal_arg $ html_arg $ css_arg $ const ())
 
 let cmd =
   let doc = "Resolve a stylesheet into an HTML page's inline styles" in
+  let exits =
+    Cli_exit.with_defaults
+      [
+        Cmd.Exit.info
+          ~doc:"on success, including a parse that recovered some of the input"
+          0;
+        Cmd.Exit.info
+          ~doc:
+            "if a $(b,<style>) block or $(i,EXTRA.css) parsed to nothing; the \
+             page is still written, without those styles"
+          1;
+        Cmd.Exit.info ~doc:"on command-line errors or unreadable input files"
+          124;
+      ]
+  in
   let man =
     [
       `S Manpage.s_description;
@@ -163,13 +178,6 @@ let cmd =
          element is a sibling like any other, and a kept rule may select \
          across it. A block the parser cannot use keeps its text as well, \
          rather than being emptied along with the blocks that were projected.";
-      `S Manpage.s_exit_status;
-      `P "$(tname) exits with:";
-      `I ("0", "on success, including a parse that recovered some of the input");
-      `I
-        ( "1",
-          "if a $(b,<style>) block or $(i,EXTRA.css) parsed to nothing; the \
-           page is still written, without those styles" );
     ]
   in
-  Cmd.v (Cmd.info "apply" ~doc ~man) Term.(term_result term)
+  Cmd.v (Cmd.info "apply" ~doc ~man ~exits) Term.(term_result term)

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -277,42 +277,6 @@ let man =
     `I ("-", "Property value changes");
     `I ("-", "Reordered rules");
     `I ("-", "Changes in @media, @layer, and other at-rules");
-    `S Manpage.s_options;
-    `P "The --diff option controls the comparison mode:";
-    `I
-      ( "--diff=auto",
-        "Smart detection: use tree diff for structural changes, string diff \
-         otherwise (default)" );
-    `I
-      ( "--diff=tree",
-        "Force structural tree-based diff (useful for debugging CSS parser \
-         behavior)" );
-    `I
-      ( "--diff=string",
-        "Force character-by-character string diff (faster, less intelligent)" );
-    `I
-      ( "--diff=canonical",
-        "Compare canonical minified CSS before reporting a diff" );
-    `I
-      ( "--depth=auto|max|N",
-        "Levels of the difference tree to print. $(b,auto) (default) prints it \
-         whole while it stays short, then falls back to the deepest level that \
-         fits; $(b,max) always prints it whole; an integer pins a level. Cut \
-         subtrees are marked with the number of lines hidden." );
-    `I
-      ( "--lossless",
-        "Disable colour approximation under $(b,--diff=canonical): colour \
-         channels keep their authored precision and static modern colour-space \
-         values stay functional. No effect outside canonical mode." );
-    `S Manpage.s_exit_status;
-    `P "$(tname) exits with:";
-    `I ("0", "if the CSS files are identical");
-    `I
-      ( "1",
-        "if the CSS files differ. Under $(b,--diff=canonical) that is any \
-         difference between their canonical forms, whether or not the \
-         structural walk reached it" );
-    `I ("124", "on command-line errors or unreadable input files");
     `S Manpage.s_examples;
     `P "Compare two CSS files:";
     `Pre "  cascade diff reference.css output.css";
@@ -324,4 +288,18 @@ let man =
 
 let cmd =
   let doc = "Compare two CSS files with structural analysis" in
-  Cmd.v (Cmd.info "diff" ~doc ~man ~envs:[ no_color_env ]) term
+  let exits =
+    Cli_exit.with_defaults
+      [
+        Cmd.Exit.info ~doc:"if the CSS files are identical" 0;
+        Cmd.Exit.info
+          ~doc:
+            "if the CSS files differ. Under $(b,--diff=canonical) that is any \
+             difference between their canonical forms, whether or not the \
+             structural walk reached it"
+          1;
+        Cmd.Exit.info ~doc:"on command-line errors or unreadable input files"
+          124;
+      ]
+  in
+  Cmd.v (Cmd.info "diff" ~doc ~man ~envs:[ no_color_env ] ~exits) term

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -291,14 +291,6 @@ let man =
       "The two $(b,--inline-*) flags are explicit closed-world opt-ins: \
        $(b,--inline-imports) assumes you control file resolution and \
        $(b,--inline-vars) assumes no runtime mutation of custom properties.";
-    `S Manpage.s_exit_status;
-    `P "$(tname) exits with:";
-    `I ("0", "on success, including a parse that recovered some of the input");
-    `I
-      ( "1",
-        "if the input cannot be read, or if parse recovery left no statement \
-         at all. An output that is empty because the stylesheet held nothing a \
-         browser acts on is a success" );
     `S Manpage.s_examples;
     `P "Pretty-print a CSS file:";
     `Pre "  cascade fmt style.css";
@@ -314,4 +306,18 @@ let man =
 
 let cmd =
   let doc = "Format, minify, and inline CSS files" in
-  Cmd.v (Cmd.info "fmt" ~doc ~man) term
+  let exits =
+    Cli_exit.with_defaults
+      [
+        Cmd.Exit.info
+          ~doc:"on success, including a parse that recovered some of the input"
+          0;
+        Cmd.Exit.info
+          ~doc:
+            "if the input cannot be read, or if parse recovery left no \
+             statement at all. An output that is empty because the stylesheet \
+             held nothing a browser acts on is a success"
+          1;
+      ]
+  in
+  Cmd.v (Cmd.info "fmt" ~doc ~man ~exits) term

--- a/bin/cmd_prune.ml
+++ b/bin/cmd_prune.ml
@@ -6,6 +6,7 @@
 open Cmdliner
 module Css = Cascade.Css
 module Selector = Cascade.Selector
+module Resolve = Cascade.Resolve
 module Prune = Cascade.Prune
 module P = Prune.Make (Html_node)
 
@@ -131,8 +132,40 @@ let files_arg =
 
 let term = Term.(const run $ dry_run_arg $ files_arg $ const ())
 
+let selector_examples_doc =
+  let samples =
+    [ ".item"; ":nth-child(2n+1)"; ":has(.child)"; ":hover"; "::before" ]
+  in
+  let modelled, unmodelled =
+    List.partition
+      (fun sample -> Resolve.supported (Selector.of_string sample))
+      samples
+  in
+  String.concat ""
+    [
+      "Representative selectors are classified by the resolver itself; \
+       modelled examples: ";
+      String.concat ", " modelled;
+      "; unmodelled examples: ";
+      String.concat ", " unmodelled;
+      ".";
+    ]
+
 let cmd =
   let doc = "Remove the CSS rules a set of documents cannot use" in
+  let exits =
+    Cli_exit.with_defaults
+      [
+        Cmd.Exit.info ~doc:"on success" 0;
+        Cmd.Exit.info
+          ~doc:
+            "if the documents hold no element, or the stylesheet parsed to \
+             nothing"
+          1;
+        Cmd.Exit.info ~doc:"on command-line errors or unreadable input files"
+          124;
+      ]
+  in
   let man =
     [
       `S Manpage.s_description;
@@ -143,13 +176,15 @@ let cmd =
       `P
         "A rule is removed only when the matcher has a model for its selector \
          and every element answers that it does not match. A selector outside \
-         what the matcher models ($(b,:hover), a pseudo-element, \
-         $(b,:nth-child())) is kept and never counted as unused, and so is a \
-         selector list with one such branch. A $(b,@media), $(b,@supports) or \
-         $(b,@container) condition is never evaluated: it asks about a device, \
-         not about a document, so the rules inside are judged by their own \
-         selectors. A statement that names no element ($(b,@keyframes), \
-         $(b,@font-face), $(b,@property), $(b,@import), $(b,@layer)) is kept.";
+         what the matcher models is kept and never counted as unused, and so \
+         is a selector list with one such branch.";
+      `P selector_examples_doc;
+      `P
+        "A $(b,@media), $(b,@supports) or $(b,@container) condition is never \
+         evaluated: it asks about a device, not about a document, so the rules \
+         inside are judged by their own selectors. A statement that names no \
+         element ($(b,@keyframes), $(b,@font-face), $(b,@property), \
+         $(b,@import), $(b,@layer)) is kept.";
       `P
         "The documents are the whole of what the analysis sees. A class a \
          script adds at runtime is not in them, so a rule waiting for one is \
@@ -158,13 +193,6 @@ let cmd =
         "Nesting is flattened before anything is judged, since a nested \
          selector is written against its parent. Pipe the result through \
          $(b,cascade --minify) to nest it again.";
-      `S Manpage.s_exit_status;
-      `P "$(tname) exits with:";
-      `I ("0", "on success");
-      `I
-        ( "1",
-          "if the documents hold no element, or the stylesheet parsed to \
-           nothing" );
     ]
   in
-  Cmd.v (Cmd.info "prune" ~doc ~man) Term.(term_result term)
+  Cmd.v (Cmd.info "prune" ~doc ~man ~exits) Term.(term_result term)

--- a/test/cli/dune
+++ b/test/cli/dune
@@ -1,3 +1,4 @@
 (cram
+ (applies_to :whole_subtree)
  (deps
   (package cascade)))

--- a/test/cli/help.t/run.t
+++ b/test/cli/help.t/run.t
@@ -1,0 +1,28 @@
+The diff command gets option rows from Cmdliner rather than repeating them in
+the prose manpage.
+
+  $ cascade diff --help=plain \
+  > | grep -E '^       --(depth|diff|lossless)(=|$)' \
+  > | sed -E 's/^ +//'
+  --depth=DEPTH (absent=auto)
+  --diff=MODE (absent=auto)
+  --lossless
+
+Command exit statuses have one authoritative entry apiece.
+
+  $ for command in apply diff fmt prune; do
+  >   cascade "$command" --help=plain \
+  >   | grep -E '^       (0|1|123|124|125) ' \
+  >   | sed -E 's/^ +([0-9]+).*/\1/' \
+  >   | sort | uniq -d | sed "s/^/$command: /"
+  > done
+  > echo unique
+  unique
+
+Prune help asks the resolver which representative selectors it models, so the
+description cannot classify :nth-child() as unsupported again.
+
+  $ cascade prune --help=plain \
+  > | tr '\n' ' ' | tr -s ' ' \
+  > | grep -o 'modelled examples: [^;]*; unmodelled examples: [^.]*\.'
+  modelled examples: .item, :nth-child(2n+1), :has(.child); unmodelled examples: :hover, ::before.


### PR DESCRIPTION
The duplicated rows assigned exit code 124 conflicting meanings and mislabeled a modeled structural selector as unsupported.