### PR TITLE
optimize: preserve declaration order under --lossless

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -495,6 +495,9 @@ difference wherever the two are not equivalent.
 
 ### Minification
 
+- Lossless optimization keeps otherwise-independent declarations in authored
+  order, so stylesheet text and CSSOM enumeration no longer change solely for
+  gzip alignment (#742)
 - Numeric tokens in custom-property and unknown-property declaration streams
   use their shortest exact spelling, so `--x: 1.0px` becomes `--x:1px` without
   changing adjacent token boundaries. Declaration feature queries keep the

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cat style.css | cascade -                                          # read stdin
 |---|---|
 | `-m, --minify` | Minify the output. Local linear rewrites always run; the expensive global factoring fixpoint runs only when its preflight predicts useful savings. The top-level pipeline re-runs until the AST stops changing, since rule-order canonicalisation can expose a merge a single pass would miss: up to five times for a sheet of at most 128 rules, once above that. |
 | `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win and drives the factoring fixpoint to convergence, the right objective when the output ships uncompressed (inline style attributes, email HTML), at a large multiple of the default's wall clock. Has no effect without `--minify`. |
-| `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Also sorts each rule's declarations into a canonical cross-rule order (keeping cascade-significant pairs in place) so gzip back-references line up. Has no effect without `--minify`. |
+| `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Otherwise-independent declarations retain their authored order instead of being sorted for compression. Has no effect without `--minify`. |
 | `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest form the CSS text and the specs prove on their own, so it keeps every vendor-prefixed declaration, the `min-`/`max-` spelling of a media or container feature, the `&` prefix on a nested selector, the author's `:not(:dir(ltr))` and `input:not(:enabled)`, the number form of an `oklab`/`oklch` axis, and the quotes around a multi-word font family. It also holds the parser to the ident code points CSS Syntax 3 lists, which is the one part that acts without `--minify`. |
 | `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
 | `--closed-world` | Assume you know the exact HTML and that no element ever matches two clashing selectors, so the optimiser may merge rules it would otherwise keep apart. Unsafe: the page can render wrong if such an element appears, including one a script adds at runtime. This is about the HTML, where `--scope` is about how much of the CSS you control; see [Scope](#scope). Has no effect without `--minify`. |
@@ -400,11 +400,10 @@ its canonical spelling and is not gated by that tolerance.
 
 Pass `--lossless` to keep colour values exact: hex/named canonicalisation and
 modern-syntax rewrites still run, but channel rounding, within-budget
-modern-space folds, and static `color-mix()` resolution are disabled. It also
-sorts each rule's declarations into one canonical order across the stylesheet,
-keeping any two whose footprints overlap (same property, or a shorthand and a
-longhand) in place, so gzip back-references line up; the reorder never changes
-a computed value.
+modern-space folds, and static `color-mix()` resolution are disabled.
+Otherwise-independent declarations retain their authored order rather than
+being sorted for compression, preserving their order in stylesheet text and
+CSSOM enumeration.
 
 ### Scope
 

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -147,9 +147,9 @@ let lossless_arg =
     "Disable colour approximation under $(b,--minify). Exact colour \
      canonicalisation still runs, but static modern colour-space and \
      color-mix() values stay functional and colour channels keep their normal \
-     serialisation precision. Also sorts each rule's declarations into a \
-     canonical cross-rule order (keeping cascade-significant pairs in place) \
-     so gzip back-references line up. Has no effect without $(b,--minify)."
+     serialisation precision. Otherwise-independent declarations retain their \
+     authored order rather than being sorted for compression. Has no effect \
+     without $(b,--minify)."
   in
   Arg.(value & flag & info [ "lossless" ] ~doc)
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7880,7 +7880,9 @@ val optimize :
     desugars nested rules into flat top-level rules; see {!Optimize.stylesheet}.
 
     When [lossless] is [true] (default [false]), colour approximation is
-    disabled while exact colour canonicalisation still runs.
+    disabled while exact colour canonicalisation still runs. Independent
+    declarations retain their authored order rather than being sorted for
+    compression, preserving stylesheet-text and CSSOM observability.
 
     When [enforce_spec] is [true] (default [false]) the optimizer drops the
     evergreen-browser target facts: a vendor-prefixed declaration is kept beside

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -38,10 +38,6 @@ let preserve_list = List.preserve
 let rule_with_nested (rule : rule) nested =
   if nested == rule.nested then rule else { rule with nested }
 
-let rule_with_declarations_and_nested (rule : rule) declarations nested =
-  if declarations == rule.declarations && nested == rule.nested then rule
-  else { rule with declarations; nested }
-
 type packed_property = Edge.packed_property =
   | Packed : 'a Properties.property -> packed_property
 
@@ -684,21 +680,6 @@ let promote_registered_custom_properties ~lossless (stmts : statement list) =
      list of the at-rules that came to mind. *)
   map_declarations promote_decls stmts
 
-(* Compressibility pass: put each rule's declarations in a deterministic
-   cross-rule order so gzip back-references line up, keeping cascade-significant
-   (overlapping) pairs in place. A transfer-objective win, so gated to it. *)
-let canonicalize_declaration_order stmts =
-  let rec walk_stmt (stmt : statement) : statement =
-    match stmt with
-    | Rule r ->
-        let declarations = Rule_order.canonical_declarations r.declarations in
-        let nested = list_map_preserve walk_stmt r.nested in
-        let r' = rule_with_declarations_and_nested r declarations nested in
-        if r' == r then stmt else Rule r'
-    | stmt -> map_statement_children (list_map_preserve walk_stmt) stmt
-  in
-  list_map_preserve walk_stmt stmts
-
 (* Under closed-stylesheet scope every [@position-try --name] rule is known. A
    [position-try-fallbacks] entry whose name has no matching rule cannot match
    at runtime, so prune unknown [Name] arms (keeping [Flip_*] and [Var]). When
@@ -961,9 +942,6 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
   let result =
     if prune_unused_custom_props then drop_unused_custom_props result
     else result
-  in
-  let result =
-    if lossless then canonicalize_declaration_order result else result
   in
   Log.debug (fun m ->
       let c = (Stats.snapshot (Ctx.stats ctx)).counters in

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1227,14 +1227,18 @@ let test_lossless_declaration_order () =
         |> String.trim
     | Error _ -> Alcotest.fail "parse"
   in
-  (* Default keeps source order; --lossless sorts declarations into a canonical
-     cross-rule order for gzip alignment. *)
+  (* Both modes keep authored declaration order. [--lossless] narrows the
+     transforms allowed by minification; it does not opt into a CSSOM-visible
+     canonical order. *)
   Alcotest.(check string)
     "default keeps source order" ".a{width:1px;color:red}"
     (opt ".a{width:1px;color:red}");
   Alcotest.(check string)
-    "lossless sorts independent declarations" ".a{color:red;width:1px}"
+    "lossless keeps authored order" ".a{width:1px;color:red}"
     (opt ~lossless:true ".a{width:1px;color:red}");
+  Alcotest.(check string)
+    "lossless keeps reverse authored order" ".a{color:red;width:1px}"
+    (opt ~lossless:true ".a{color:red;width:1px}");
   (* Overlapping declarations keep their relative order (cascade-significant):
      border-top before border-color decides the top colour. *)
   Alcotest.(check string)


### PR DESCRIPTION
The flag no longer changes stylesheet text or CSSOM declaration enumeration solely to improve compression.