### PR TITLE
README: state the default minification contract

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -495,6 +495,9 @@ difference wherever the two are not equivalent.
 
 ### Minification
 
+- The README states the default minifier's evergreen target, colour tolerance,
+  and CSSOM-visible normalisation beside its first example, and describes
+  `--lossless --enforce-spec` as conservative rather than source-exact (#743)
 - Lossless optimization keeps otherwise-independent declarations in authored
   order, so stylesheet text and CSSOM enumeration no longer change solely for
   gzip alignment (#742)

--- a/README.md
+++ b/README.md
@@ -4,20 +4,36 @@ A command-line tool for **formatting**, **minifying**, **inlining**,
 **structurally diffing**, and **pruning** CSS. Ships one binary (`cascade`)
 and, for OCaml users, the library it is built on.
 
-```text
-$ cascade --minify style.css > style.min.css
-$ cascade diff a.css b.css
+<!-- $MDX skip -->
+```bash
+cascade --minify style.css > style.min.css
+cascade diff a.css b.css
 ```
+
+Default minification is practical, not byte-for-byte preservation: it targets
+maintained evergreen browsers and may approximate colours within `0.002`
+Delta-EOK. Parsing and serialisation also normalise raw token spelling,
+including CSSOM-observable custom-property strings. For a more conservative
+contract, disable approximation and browser-baseline assumptions:
+
+<!-- $MDX skip -->
+```bash
+opam exec -- cascade --minify --lossless --enforce-spec style.css
+```
+
+That combination retains authored declaration order, but it still does not
+preserve comments, whitespace, exact source spelling, or every CSSOM-visible
+string.
 
 Cascade works from a typed CSS AST rather than the raw text, so every command
 emits valid CSS by construction and reasons about the cascade instead of
-guessing from bytes. `cascade fmt --minify` applies only cascade-safe transforms
-(deduplication, rule merging, selector grouping, colour and value
-canonicalisation), and optimises for the bytes that actually ship: compressed
-transfer size rather than raw length. `cascade diff` compares the parsed
-structure, so a refactor that reorders rules or regroups declarations without
-changing what they compute reads as no difference rather than a wall of red and
-green. The same engine backs the `cascade` OCaml library.
+guessing from bytes. `cascade fmt --minify` uses cascade analysis for structural
+transforms (deduplication, rule merging, and selector grouping), canonicalises
+colours and values under the contract above, and optimises for the bytes that
+actually ship: compressed transfer size rather than raw length. `cascade diff`
+compares the parsed structure, so a refactor that reorders rules or regroups
+declarations without changing what they compute reads as no difference rather
+than a wall of red and green. The same engine backs the `cascade` OCaml library.
 
 On the SatCSS corpus of real-world stylesheets, cascade is competitive on both
 size and speed; the head-to-head numbers are in [BENCHMARKS.md](BENCHMARKS.md).

--- a/test/cram/dune
+++ b/test/cram/dune
@@ -1,4 +1,5 @@
 (cram
  (applies_to :whole_subtree)
  (deps
+  ../../README.md
   (package cascade)))

--- a/test/cram/readme_contract.t/run.t
+++ b/test/cram/readme_contract.t/run.t
@@ -1,0 +1,20 @@
+The first example carries the minifier's practical contract instead of making
+readers discover its observable trade-offs much later in the manual.
+
+  $ readme="$PWD/../../../README.md"
+  $ opening=$(sed -n '1,36p' "$readme")
+  $ printf '%s\n' "$opening" | grep -Fq '0.002'
+  $ printf '%s\n' "$opening" | grep -Fq 'maintained evergreen'
+  $ printf '%s\n' "$opening" | grep -Fq 'custom-property strings'
+  $ printf '%s\n' "$opening" | grep -Fq 'not byte-for-byte'
+
+The conservative command remains a skipped shell example: neither MDX nor a
+reader should mistake it for an exact-source-preservation promise.
+
+  $ awk '
+  >   /<!-- \$MDX skip -->/ { skip = NR }
+  >   /^```bash$/ { in_shell = 1; marked = (NR == skip + 1); next }
+  >   /^```$/ { in_shell = 0 }
+  >   in_shell && marked && /--minify --lossless --enforce-spec/ { found = 1 }
+  >   END { exit !found }
+  > ' "$readme"


### PR DESCRIPTION
Readers now see the evergreen target, colour tolerance, and CSSOM-visible normalisation limits before choosing the default or conservative flags.