### PR TITLE
optimize: avoid revisiting merged child blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -743,6 +743,10 @@ difference wherever the two are not equivalent.
   sheet's distant-`@media` merge falls from 24.4M words to 0.4M, and the
   504-file corpus allocates a twentieth less
   (#480, #486, #487, #502, #505, #517, #519, #523, #543, #566)
+- Nested group-rule merges optimize only the newly joined statement list
+  instead of walking already-optimized child blocks again at every ancestor.
+  Doubling the depth of a repeated `@media` merge now doubles optimizer work
+  rather than quadrupling it (#746)
 
 ### Custom properties
 

--- a/lib/ctx.ml
+++ b/lib/ctx.ml
@@ -12,6 +12,10 @@ type t = {
           how the input happened to order its rules, so a canonical projection
           turns them off to stay confluent. *)
   extend_lists : bool;
+  recurse_blocks : bool;
+      (** Whether statement optimization descends into child blocks. A seam pass
+          over two newly merged blocks turns this off because their children
+          were optimized before the merge. *)
   closed_world : bool;
   objective : objective;
   enforce_spec : bool;
@@ -33,6 +37,7 @@ let fragment =
     aggressive = false;
     regroup = true;
     extend_lists = false;
+    recurse_blocks = true;
     closed_world = false;
     objective = `Transfer;
     enforce_spec = false;
@@ -51,6 +56,7 @@ let of_scope ?(lossless = false) ?(aggressive = false) ?(regroup = true)
     aggressive;
     regroup;
     extend_lists;
+    recurse_blocks = true;
     closed_world;
     objective;
     enforce_spec;
@@ -68,6 +74,7 @@ let v ?(lossless = false) ?(aggressive = false) ?(regroup = true)
     aggressive;
     regroup;
     extend_lists;
+    recurse_blocks = true;
     closed_world;
     objective;
     enforce_spec;
@@ -80,11 +87,13 @@ let lossless t = t.lossless
 let aggressive t = t.aggressive
 let regroup t = t.regroup
 let extend_lists t = t.extend_lists
+let recurse_blocks t = t.recurse_blocks
 let closed_world t = t.closed_world
 let objective t = t.objective
 let enforce_spec t = t.enforce_spec
 let stats t = t.stats
 let with_extend_lists extend_lists t = { t with extend_lists }
+let with_recurse_blocks recurse_blocks t = { t with recurse_blocks }
 
 let pp_scope ctx = function
   | `Fragment -> Pp.string ctx "fragment"

--- a/lib/ctx.mli
+++ b/lib/ctx.mli
@@ -72,6 +72,10 @@ val extend_lists : t -> bool
     through the guarded DAG candidate selector, which also keeps the strict
     non-list alternative when that is locally better. *)
 
+val recurse_blocks : t -> bool
+(** Whether statement optimization descends into child blocks. False only for
+    the seam pass over blocks whose children were already optimized. *)
+
 val closed_world : t -> bool
 (** Whether the caller knows the exact HTML the CSS will style.
 
@@ -103,6 +107,10 @@ val stats : t -> Stats.t
 val with_extend_lists : bool -> t -> t
 (** [with_extend_lists enabled ctx] returns [ctx] with only the list-extension
     strategy flag changed. *)
+
+val with_recurse_blocks : bool -> t -> t
+(** [with_recurse_blocks enabled ctx] returns [ctx] with only child-block
+    recursion changed. *)
 
 val pp : t Pp.t
 (** Pretty-printer for debugging. *)

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -187,8 +187,14 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
   match stmts with
   | [] -> stmts
   | _ ->
+      (* A merge concatenates blocks whose children [process_statements] has
+         already optimized. Re-enter only at that new seam: descending again
+         walks a nested child once per ancestor and turns linear depth into
+         quadratic work. Further merges in the seam pass stay shallow too. *)
       let optimize_merged_block =
-        statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
+        statements ?factor_cache
+          ~ctx:(Ctx.with_recurse_blocks false ctx)
+          ~enforce_spec ~owner ~supports
       in
       (* [drop_misplaced_imports] runs first: an [@import] after a style rule is
          invalid and ignored by browsers (CSS Cascade L6 sec. 2), so it must not
@@ -241,7 +247,7 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
       let start' = option_map_preserve canonicalize_scope_selector start in
       let end_' = option_map_preserve canonicalize_scope_selector end_ in
       let optimized_block =
-        statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
+        descend_block ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
       in
       let optimized =
         if start' == start && end_' == end_ && optimized_block == block then
@@ -303,6 +309,11 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
       process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
         (hd :: acc) rest
 
+and descend_block ?factor_cache ~ctx ~enforce_spec ~owner ~supports block =
+  if Ctx.recurse_blocks ctx then
+    statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
+  else block
+
 (* A run of declarations is a declaration list wherever it sits, and nothing
    comes between two writes inside one, so the same deduplication a rule body
    gets applies (CSS Cascade 5 sec. 6.4.4: the later write wins). *)
@@ -316,7 +327,7 @@ and process_declarations_statement ?factor_cache ~ctx ~enforce_spec ~owner
 and process_group_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
     acc stmt block rebuild rest =
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
+    descend_block ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
   in
   let optimized =
     if optimized_block == block then stmt else rebuild optimized_block
@@ -342,7 +353,7 @@ and process_media_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
     acc stmt cond block rest =
   let cond = if enforce_spec then cond else Media.lower_for_minify cond in
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
+    descend_block ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
   in
   let optimized =
     if
@@ -361,7 +372,7 @@ and process_container_statement ?factor_cache ~ctx ~enforce_spec ~owner
     else option_map_preserve Container.lower_for_minify cond
   in
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
+    descend_block ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
   in
   let optimized =
     if
@@ -390,14 +401,14 @@ and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
      hid collapse. *)
   | `True ->
       let block' =
-        statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
+        descend_block ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
       in
       let trailing, acc = pop_trailing_rules acc in
       process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports acc
         (List.concat [ trailing; block'; rest ])
   | `Cond cond' ->
       let block' =
-        statements ?factor_cache ~ctx ~enforce_spec ~owner
+        descend_block ?factor_cache ~ctx ~enforce_spec ~owner
           ~supports:(cond' :: supports) block
       in
       let optimized =
@@ -410,7 +421,7 @@ and process_supports_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
 and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
     acc stmt name block rest =
   let optimized_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
+    descend_block ?factor_cache ~ctx ~enforce_spec ~owner ~supports block
   in
   if is_layer_empty optimized_block then
     match name with
@@ -444,9 +455,10 @@ and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
    the rule's, so it optimizes with the rule as owner. *)
 and rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec ~supports rule =
   let nested =
-    match rule.nested with
-    | [] -> []
-    | nested ->
+    match (Ctx.recurse_blocks ctx, rule.nested) with
+    | false, nested -> nested
+    | true, [] -> []
+    | true, nested ->
         let nested =
           statements ?factor_cache ~ctx ~enforce_spec ~owner:(Some rule)
             ~supports nested
@@ -533,7 +545,9 @@ let drop_shadowed_keyframes (stmts : statement list) : statement list =
 let statements_top_level ?factor_cache ~ctx ~enforce_spec
     (stmts : statement list) : statement list =
   let optimize_merged_block =
-    statements ?factor_cache ~ctx ~enforce_spec ~owner:None ~supports:[]
+    statements ?factor_cache
+      ~ctx:(Ctx.with_recurse_blocks false ctx)
+      ~enforce_spec ~owner:None ~supports:[]
   in
   let stmts' =
     statements ?factor_cache ~ctx ~enforce_spec ~owner:None ~supports:[] stmts

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -795,6 +795,40 @@ let test_optimize_preserves_physical_identity () =
         true (again == canon))
     cases
 
+(* Each level presents one already-optimized nested [@media] block beside a
+   second block with the same condition. Merging the pair must optimize the new
+   seam without recursively walking the first block a second time: doing so at
+   every level makes a linear-size stylesheet take quadratic work. *)
+let test_nested_media_merge_is_linear () =
+  let sheet depth =
+    let b = Buffer.create ((depth * 48) + 16) in
+    let out = Fmt.with_buffer b in
+    for _ = 1 to depth do
+      Buffer.add_string b "@media all{"
+    done;
+    Buffer.add_string b "a{color:red}";
+    for i = depth downto 1 do
+      Fmt.pf out "}@media all{.x%d{color:red}}" i
+    done;
+    match Css.of_string ~strict:false (Buffer.contents b) with
+    | Ok p -> p.stylesheet
+    | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
+  in
+  let measure stylesheet =
+    Gc.full_major ();
+    let before = Gc.minor_words () in
+    let result = Css.optimize stylesheet in
+    ignore (Sys.opaque_identity result);
+    Gc.minor_words () -. before
+  in
+  let small_words = measure (sheet 256) in
+  let large_words = measure (sheet 512) in
+  let ratio = large_words /. small_words in
+  Alcotest.(check bool)
+    (Fmt.str "alloc %.0f -> %.0f (%.2fx for 2x depth)" small_words large_words
+       ratio)
+    true (ratio < 3.)
+
 let test_prune_unused_custom_props () =
   let parse css =
     match Css.of_string ~strict:false css with
@@ -1687,6 +1721,9 @@ let optimize_tests =
     ( "optimize preserves physical identity on a fixed point",
       `Quick,
       test_optimize_preserves_physical_identity );
+    ( "nested media merges take linear work",
+      `Quick,
+      test_nested_media_merge_is_linear );
     ("deduplicate declarations", `Quick, test_deduplicate_declarations);
     ( "opt-in prune unused custom properties",
       `Quick,


### PR DESCRIPTION
Repeated nested group-rule merges re-optimized already-settled child blocks at every ancestor, making depth scale quadratically. This limits each merge to the newly joined statements; the depth benchmark drops from 15.82s to 0.12s at 4,000 levels.