### PR TITLE
css: preserve authored source on request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@ difference wherever the two are not equivalent.
 
 ### Breaking
 
+- `Css.parse` adds `source : Css.Source.t option`; exhaustive record patterns
+  must bind it or add `_`. `Css.of_string ~preserve_source:true` fills it with
+  exact authored comments, syntax, trivia ownership and coordinates (#747)
 - Implementation modules are no longer usable through accidental `Cascade.*`
   aliases: `Baseline`, `Block`, `Common`, `Factor`, `Flatten`, `Inline`,
   `Merge`, `Rule`, `Rule_index`, `Rule_order`, `Shorthand`, `Size`, `Summary`,

--- a/README.md
+++ b/README.md
@@ -514,8 +514,13 @@ frameworks.
   tree, renderer, or computed-style engine. CSS syntax for those features
   parses and prints; analyses that need runtime data take an explicit closed
   context.
-- **Comments and source positions** are not preserved across the
-  parser/printer round trip.
+- **Comments and source positions** are not attached to the typed AST or
+  reproduced by the parser/printer round trip. Library callers that need
+  authored syntax can pass `~preserve_source:true` to `Css.of_string`: the
+  resulting separate, immutable `Css.Source` snapshot retains exact input
+  bytes, comments, located syntax rules, deterministic trivia ownership, and
+  original-byte/line-column mappings. A later AST transform does not invent
+  provenance for nodes it splits, merges, drops, or creates.
 - **`cascade prune` sees only the documents it is given.** A rule whose class
   a script adds at runtime matches nothing in the parsed HTML, so it is
   removed.
@@ -599,6 +604,23 @@ happens to reference it would confine and shadow it.
 `warnings` listing recovered syntax and declaration issues. `~strict:true`
 errors when the lenient parse would have warned. When both succeed, their
 minified outputs are identical.
+
+`Css.of_string ~preserve_source:true` has the same strictness and diagnostics
+but returns `source = Some snapshot`. `Css.Source.contents` is the caller's
+exact string; `preprocessed`, `comments`, and `rules` expose the CSS Syntax
+view, and `original_loc` / `span` map its locations back to original byte
+offsets and one-based line/column positions. Each top-level syntax rule owns the
+bytes from the previous rule's end through its own end, and `trailing_loc` owns
+the rest, so whitespace and recovered material have an unambiguous home. The
+opt-in snapshot retains the original buffer, a second buffer only when CSS
+preprocessing changes it, the component tree, comments, a line index, and an
+offset map when needed; an ordinary parse returns `source = None` and pays none
+of that retention cost.
+
+The snapshot describes the authored parse, not a mutable source map. Optimising
+or flattening the typed stylesheet leaves it unchanged. A transform that needs
+mappings for split, merged, or synthetic nodes must record those mappings while
+performing the transform instead of receiving guessed locations from Cascade.
 
 ### Small runtime footprint
 

--- a/bin/cli_io.ml
+++ b/bin/cli_io.ml
@@ -27,7 +27,7 @@ let die_parse_error e =
 
 let parse ?(enforce_spec = false) ~filename css =
   match Css.of_string ~filename ~enforce_spec css with
-  | Ok { Css.stylesheet; warnings } ->
+  | Ok { Css.stylesheet; warnings; _ } ->
       List.iter report_warning warnings;
       (stylesheet, warnings)
   | Error e -> die_parse_error e

--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -38,7 +38,7 @@ let parse_source ~filename ~note css =
   | Error e ->
       Fmt.epr "Error: %s@." (Cascade.Error.to_string e);
       None
-  | Ok { Css.stylesheet; warnings } -> (
+  | Ok { Css.stylesheet; warnings; _ } -> (
       List.iter report_warning warnings;
       (* Whether the parse produced anything is a question about the statement
          list. Serialising the sheet to answer it asks a different one, and gets

--- a/fuzz/fuzz_container.ml
+++ b/fuzz/fuzz_container.ml
@@ -24,7 +24,7 @@ let assert_invalid_container_contract label input =
         input
         (Css.to_string ~minify:true parsed.stylesheet)
   | Error _ ->
-      let { Css.warnings; stylesheet } = recovered_css label css in
+      let { Css.warnings; stylesheet; _ } = recovered_css label css in
       ignore (Css.to_string ~minify:true stylesheet : string);
       if warnings = [] then
         failf "%s recovered without a lenient warning: %S" label input

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -335,7 +335,7 @@ let assert_strict_rejects_lenient_warns label input =
       failf "%s parsed strictly as invalid CSS: %S -> %S" label input
         (Css.to_string ~minify:true parsed.stylesheet)
   | Error _ ->
-      let { Css.stylesheet; warnings } = recovered_css label input in
+      let { Css.stylesheet; warnings; _ } = recovered_css label input in
       ignore (Css.to_string ~minify:true stylesheet : string);
       if warnings = [] then
         failf "%s recovered without a lenient warning: %S" label input
@@ -345,7 +345,7 @@ let assert_strict_accepts_cleanly label input =
   | Error _ -> failf "%s rejected valid CSS strictly: %S" label input
   | Ok parsed ->
       let strict_output = Css.to_string ~minify:true parsed.stylesheet in
-      let { Css.stylesheet; warnings } = recovered_css label input in
+      let { Css.stylesheet; warnings; _ } = recovered_css label input in
       if warnings <> [] then
         failf "%s emitted lenient warnings for valid CSS: %S" label input;
       let lenient_output = Css.to_string ~minify:true stylesheet in
@@ -1294,7 +1294,7 @@ let test_recovery_keeps_rules buf =
   in
   let css = ".a{color:red}.b{" ^ bad_decl ^ "}.c{display:block}" in
   assert_strict_rejects_lenient_warns "recovery keeps sibling rules" css;
-  let { Css.stylesheet; warnings } =
+  let { Css.stylesheet; warnings; _ } =
     recovered_css "recovery keeps sibling rules" css
   in
   let counts = recovered_declaration_counts stylesheet in
@@ -1314,7 +1314,7 @@ let test_recovery_invalid_rule_boundary buf =
   in
   let css = ".ok{color:green}" ^ invalid_rule ^ ".next{color:blue}" in
   assert_strict_rejects_lenient_warns "invalid rule boundary recovery" css;
-  let { Css.stylesheet; warnings } =
+  let { Css.stylesheet; warnings; _ } =
     recovered_css "invalid rule boundary recovery" css
   in
   let counts = recovered_declaration_counts stylesheet in
@@ -1331,7 +1331,7 @@ let test_recovery_bad_declaration buf =
   in
   let css = ".a{" ^ bad_decl ^ ";color:red}" in
   assert_strict_rejects_lenient_warns "bad declaration recovery" css;
-  let { Css.stylesheet; warnings } =
+  let { Css.stylesheet; warnings; _ } =
     recovered_css "bad declaration recovery" css
   in
   let counts = recovered_declaration_counts stylesheet in

--- a/fuzz/fuzz_supports.ml
+++ b/fuzz/fuzz_supports.ml
@@ -107,7 +107,7 @@ let assert_invalid_supports_contract label input =
         input
         (Css.to_string ~minify:true parsed.stylesheet)
   | Error _ ->
-      let { Css.warnings; stylesheet } = recovered_css label css in
+      let { Css.warnings; stylesheet; _ } = recovered_css label css in
       ignore (Css.to_string ~minify:true stylesheet : string);
       if warnings = [] then
         failf "%s recovered without a lenient warning: %S" label input

--- a/fuzz/helpers/fuzz_helpers.ml
+++ b/fuzz/helpers/fuzz_helpers.ml
@@ -10,7 +10,7 @@ let assert_invalid_declaration_contract label input =
       failf "%s parsed strictly as invalid declaration: %S -> %S" label input
         (Css.to_string ~minify:true parsed.stylesheet)
   | Error _ ->
-      let { Css.warnings; stylesheet } =
+      let { Css.warnings; stylesheet; _ } =
         match Css.of_string ~strict:false css with
         | Ok parsed -> parsed
         | Error err ->

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -542,21 +542,32 @@ let vars_of_declarations = Variables.vars_of_declarations
    one of them met a construct the other knew. *)
 let vars_of_rules = vars_of_stylesheet
 
-type parse = { stylesheet : t; warnings : Error.t list }
+type parse = {
+  stylesheet : t;
+  warnings : Error.t list;
+  source : Source.t option;
+}
 
 let of_string ?(strict = false) ?(filename = "<string>")
-    ?(meta = Loc.default_meta_level) ?(enforce_spec = false) css =
+    ?(meta = Loc.default_meta_level) ?(enforce_spec = false)
+    ?(preserve_source = false) css =
   let stamp e = Error.with_filename ~filename e in
   try
+    let source : Source.t option ref = ref Option.None in
+    let on_source =
+      if preserve_source then
+        Option.Some (fun captured -> source := Option.Some captured)
+      else Option.None
+    in
     let stylesheet, warnings =
-      Stylesheet.parse_stylesheet_partial ~meta ~enforce_spec css
+      Stylesheet.parse_stylesheet_partial ~meta ~enforce_spec ?on_source css
     in
     let warnings = List.map stamp warnings in
     if strict then
       match warnings with
-      | [] -> Ok { stylesheet; warnings }
+      | [] -> Ok { stylesheet; warnings; source = !source }
       | first :: _ -> Error first
-    else Ok { stylesheet; warnings }
+    else Ok { stylesheet; warnings; source = !source }
   with Error.Parse_error error -> Error (stamp error)
 
 let of_string_exn ?strict ?filename ?meta ?enforce_spec css =

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -80,6 +80,7 @@ module Properties = Properties
 module Variables = Variables
 module Optimize = Optimize
 module Stylesheet = Stylesheet
+module Source = Stylesheet.Source
 module Media = Media
 module Container = Container
 module Supports = Supports
@@ -7781,17 +7782,23 @@ val to_buffer :
 (** [to_buffer buf stylesheet] appends the serialised stylesheet to [buf]. Same
     options as {!to_string}. *)
 
-type parse = { stylesheet : t; warnings : Error.t list }
+type parse = {
+  stylesheet : t;
+  warnings : Error.t list;
+  source : Source.t option;
+}
 (** A partially-recovered parse: the {!field-stylesheet} composed of every rule
     that validated successfully, plus the {!field-warnings} accumulated for
     rules that were dropped or section 5.3-recovered. Each warning is an
-    [Error.t] stamped with the source [filename] when one was supplied. *)
+    [Error.t] stamped with the source [filename] when one was supplied.
+    {!field-source} is [Some] only when parsing requested source fidelity. *)
 
 val of_string :
   ?strict:bool ->
   ?filename:string ->
   ?meta:Loc.meta_level ->
   ?enforce_spec:bool ->
+  ?preserve_source:bool ->
   string ->
   (parse, Error.t) result
 (** [of_string ?strict css] parses [css] with CSS Syntax 3 (ED) section 5.4
@@ -7808,7 +7815,13 @@ val of_string :
     default accepts any code point [>= U+0080], so a selector such as
     [.text-\u{2197}] reads rather than being dropped with a warning. Output is
     unaffected either way: a code point outside the range list is hex-escaped.
-*)
+
+    [preserve_source] (default [false]) retains the byte-exact input, located
+    recovered syntax tree, comments, trivia ownership, and source-coordinate
+    mapping in {!field-source}. The snapshot describes only the authored parse:
+    optimising, flattening, mapping, or otherwise transforming
+    {!field-stylesheet} neither mutates it nor fabricates locations for split,
+    merged, dropped, or synthetic nodes. *)
 
 val of_string_exn :
   ?strict:bool ->

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -7,8 +7,11 @@
 
 open Token
 
+type comment = { loc : Loc.t; terminated : bool }
+
 type t = {
   reader : Reader.t;
+  on_comment : (comment -> unit) option;
   (* Token buffer: most-recently-pushed-back at the head. [next] takes from here
      before falling through to the reader. *)
   mutable buffer : Token.t list;
@@ -20,8 +23,12 @@ type t = {
 
 and save = { trace : Token.t list ref; saved_history : Token.t list }
 
-let of_reader reader = { reader; buffer = []; history = []; saves = [] }
-let of_string ?enforce_spec s = of_reader (Reader.of_string ?enforce_spec s)
+let of_reader ?on_comment reader =
+  { reader; on_comment; buffer = []; history = []; saves = [] }
+
+let of_string ?enforce_spec ?on_comment s =
+  of_reader ?on_comment (Reader.of_string ?enforce_spec s)
+
 let source t = Reader.source t.reader
 
 (** {1 Tokenization} *)
@@ -563,38 +570,45 @@ let consume_ident_like_token ?(force_url_function = false) r =
    unterminated comment is a parse error per the spec but we just stop at EOF
    silently. *)
 let rec skip_comment_body r =
-  if Reader.is_done r then ()
+  if Reader.is_done r then false
   else if Reader.looking_at r "*/" then (
     Reader.skip r;
-    Reader.skip r)
+    Reader.skip r;
+    true)
   else (
     Reader.skip r;
     skip_comment_body r)
+
+let consume_comment on_comment r =
+  let start_pos = Reader.position r in
+  Reader.skip r;
+  Reader.skip r;
+  let terminated = skip_comment_body r in
+  let end_pos = Reader.position r in
+  Option.iter
+    (fun f -> f { loc = Loc.v ~start_pos ~end_pos; terminated })
+    on_comment
 
 (* Skip a run of comments without consuming surrounding whitespace: CSS Syntax 3
    (ED) sec. 4.3.2 treats comments as "nothing", so a comment between two
    non-whitespace points disappears rather than becoming a
    <whitespace-token>. *)
-let rec skip_comment_run r =
+let rec skip_comment_run on_comment r =
   if Reader.looking_at r "/*" then (
-    Reader.skip r;
-    Reader.skip r;
-    skip_comment_body r;
-    skip_comment_run r)
+    consume_comment on_comment r;
+    skip_comment_run on_comment r)
 
 (* Consume a run of whitespace code points and any interleaved comments,
    returning [true] when at least one whitespace code point was seen. *)
-let rec consume_whitespace_run r =
+let rec consume_whitespace_run on_comment r =
   match Reader.peek r with
   | Some c when is_ws c ->
       Reader.skip r;
-      consume_whitespace_run r
+      consume_whitespace_run on_comment r
   | _ ->
       if Reader.looking_at r "/*" then (
-        Reader.skip r;
-        Reader.skip r;
-        skip_comment_body r;
-        consume_whitespace_run r)
+        consume_comment on_comment r;
+        consume_whitespace_run on_comment r)
 
 let hash_flag_now r = if would_start_ident_sequence r then Id else Unrestricted
 
@@ -662,14 +676,14 @@ let consume_name_start_or_delim ~force_url_function r c =
     Reader.skip r;
     Delim (String.make 1 c))
 
-let next_token ?(force_url_function = false) r =
-  skip_comment_run r;
+let next_token ?(force_url_function = false) ?on_comment r =
+  skip_comment_run on_comment r;
   let b = Reader.peek_byte r in
   if b = -1 then Eof
   else
     let c = Char.unsafe_chr b in
     if is_ws c then (
-      consume_whitespace_run r;
+      consume_whitespace_run on_comment r;
       Whitespace)
     else
       match c with
@@ -738,9 +752,9 @@ let next_token ?(force_url_function = false) r =
 (** {1 Stream API (uniform with other stages)} *)
 
 (* Wrap a tokenizer step with source-location capture. *)
-let tokenize_with_loc ?(force_url_function = false) reader =
+let tokenize_with_loc ?(force_url_function = false) ?on_comment reader =
   let start_pos = Reader.position reader in
-  let kind = next_token ~force_url_function reader in
+  let kind = next_token ~force_url_function ?on_comment reader in
   let end_pos = Reader.position reader in
   Token.v ~kind ~loc:(Loc.v ~start_pos ~end_pos)
 
@@ -777,7 +791,8 @@ let next t =
       tok
   | [] ->
       let tok =
-        tokenize_with_loc ~force_url_function:(force_url_function t) t.reader
+        tokenize_with_loc ~force_url_function:(force_url_function t)
+          ?on_comment:t.on_comment t.reader
       in
       record_consume t tok;
       tok
@@ -787,7 +802,8 @@ let peek t =
   | tok :: _ -> tok
   | [] ->
       let tok =
-        tokenize_with_loc ~force_url_function:(force_url_function t) t.reader
+        tokenize_with_loc ~force_url_function:(force_url_function t)
+          ?on_comment:t.on_comment t.reader
       in
       t.buffer <- [ tok ];
       tok

--- a/lib/lexer.mli
+++ b/lib/lexer.mli
@@ -10,12 +10,21 @@
 type t
 (** A lexer stream: a character cursor plus one-token pushback. *)
 
-val of_reader : Reader.t -> t
-(** [of_reader r] wraps an existing character reader. *)
+type comment = { loc : Loc.t; terminated : bool }
+(** A comment consumed before tokenization. [loc] covers its opening [/*]
+    through its closing [*/], or through end of input when [terminated] is
+    [false]. Comments remain absent from the token stream as CSS Syntax
+    requires; this record is an opt-in tooling hook. *)
 
-val of_string : ?enforce_spec:bool -> string -> t
+val of_reader : ?on_comment:(comment -> unit) -> Reader.t -> t
+(** [of_reader ?on_comment r] wraps an existing character reader. [on_comment]
+    observes each consumed comment exactly once. *)
+
+val of_string :
+  ?enforce_spec:bool -> ?on_comment:(comment -> unit) -> string -> t
 (** [of_string s] builds a fresh reader from an already-decoded UTF-8 string and
-    wraps it. [enforce_spec] is passed to {!Reader.of_string}. *)
+    wraps it. [enforce_spec] is passed to {!Reader.of_string}; [on_comment] has
+    the meaning documented on {!of_reader}. *)
 
 val source : t -> string
 (** [source t] is the full input string the underlying reader was built from. *)

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -1256,12 +1256,12 @@ let with_warnings f =
   let value = f ~warnings in
   { value; warnings = List.rev !warnings }
 
-let stylesheet ?(meta = Loc.default_meta_level) r =
+let stylesheet ?(meta = Loc.default_meta_level) ?on_comment r =
   with_warnings (fun ~warnings ->
-      let lexer = Lexer.of_reader r in
+      let lexer = Lexer.of_reader ?on_comment r in
       consume_list_of_rules ~meta lexer ~top_level:true ~warnings)
 
-let stylesheet_contents = stylesheet
+let stylesheet_contents ?meta r = stylesheet ?meta r
 
 (* CSS Syntax 3 (ED) sec. 5.4.5: a block's contents is a mix of declarations and
    nested rules. Consecutive declarations are grouped into a single [`Decls]

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -129,10 +129,15 @@ val csv_by_grammar : Reader.t -> grammar -> Component.t list option list output
     groups, then match each group independently. Whitespace-only input returns
     an empty list. *)
 
-val stylesheet : ?meta:Loc.meta_level -> Reader.t -> Component.rule list output
-(** [stylesheet ?meta r] runs section 5.4.3: consume a list of rules with the
-    top-level flag set. CDO and CDC are skipped. [?meta] controls snippet
-    attachment on recovery warnings; see {!Loc.meta_level}. *)
+val stylesheet :
+  ?meta:Loc.meta_level ->
+  ?on_comment:(Lexer.comment -> unit) ->
+  Reader.t ->
+  Component.rule list output
+(** [stylesheet ?meta ?on_comment r] runs section 5.4.3: consume a list of rules
+    with the top-level flag set. CDO and CDC are skipped. [?meta] controls
+    snippet attachment on recovery warnings; see {!Loc.meta_level}. [on_comment]
+    is the opt-in observer documented by {!Lexer.of_reader}. *)
 
 val stylesheet_contents :
   ?meta:Loc.meta_level -> Reader.t -> Component.rule list output

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -4476,6 +4476,179 @@ let read_stylesheet_of_rules ?source ?meta (rules : Component.rule list) :
   in
   (statements, List.rev !warnings)
 
+module Source = struct
+  type comment = { loc : Loc.t; terminated : bool }
+  type rule = { syntax : Component.rule; loc : Loc.t; owned_loc : Loc.t }
+  type position = { byte : int; line : int; column : int }
+  type span = { start : position; end_ : position }
+
+  type t = {
+    original_source : string;
+    preprocessed_source : string;
+    comments : comment list;
+    rules : rule list;
+    trailing_loc : Loc.t;
+    original_offsets : int array option;
+    line_starts : int array;
+  }
+
+  let contents t = t.original_source
+  let preprocessed t = t.preprocessed_source
+  let comments t = t.comments
+  let rules t = t.rules
+  let trailing_loc t = t.trailing_loc
+
+  let check_loc t ({ Loc.start_pos; end_pos } as loc) =
+    let length = String.length t.preprocessed_source in
+    if start_pos < 0 || end_pos < start_pos || end_pos > length then
+      invalid_arg
+        (String.concat ""
+           [
+             "Css.Source: location ";
+             Loc.to_string loc;
+             " is outside [0-";
+             string_of_int length;
+             "]";
+           ])
+
+  let slice t ({ Loc.start_pos; end_pos } as loc) =
+    check_loc t loc;
+    String.sub t.preprocessed_source start_pos (end_pos - start_pos)
+
+  let original_offset t offset =
+    if offset < 0 || offset > String.length t.preprocessed_source then
+      invalid_arg
+        (String.concat ""
+           [
+             "Css.Source: offset ";
+             string_of_int offset;
+             " is outside [0-";
+             string_of_int (String.length t.preprocessed_source);
+             "]";
+           ]);
+    match t.original_offsets with
+    | Option.None -> offset
+    | Option.Some map -> map.(offset)
+
+  let original_loc t ({ Loc.start_pos; end_pos } as loc) =
+    check_loc t loc;
+    Loc.v
+      ~start_pos:(original_offset t start_pos)
+      ~end_pos:(original_offset t end_pos)
+
+  let original_slice t loc =
+    let { Loc.start_pos; end_pos } = original_loc t loc in
+    String.sub t.original_source start_pos (end_pos - start_pos)
+
+  let position t offset =
+    let byte = original_offset t offset in
+    let starts = t.line_starts in
+    let low = ref 0 in
+    let high = ref (Array.length starts) in
+    while !low + 1 < !high do
+      let middle = (!low + !high) / 2 in
+      if starts.(middle) <= offset then low := middle else high := middle
+    done;
+    let line_start = starts.(!low) in
+    let column =
+      Common.String.utf8_length ~pos:line_start ~len:(offset - line_start)
+        t.preprocessed_source
+      + 1
+    in
+    { byte; line = !low + 1; column }
+
+  let span t ({ Loc.start_pos; end_pos } as loc) =
+    check_loc t loc;
+    { start = position t start_pos; end_ = position t end_pos }
+
+  let has_bom input =
+    String.length input >= 3
+    && input.[0] = '\xEF'
+    && input.[1] = '\xBB'
+    && input.[2] = '\xBF'
+
+  (* Boundary map from the CSS-preprocessed buffer back to caller bytes. The two
+     interior byte boundaries of a U+FFFD replacement map to the original NUL's
+     start; lexer/component locations only occur at code-point boundaries, where
+     the map is exact. *)
+  let build_original_offsets original preprocessed =
+    if String.equal original preprocessed then Option.None
+    else
+      let original_length = String.length original in
+      let preprocessed_length = String.length preprocessed in
+      let map = Array.make (preprocessed_length + 1) 0 in
+      let original_pos = ref (if has_bom original then 3 else 0) in
+      let preprocessed_pos = ref 0 in
+      map.(0) <- !original_pos;
+      let emit_byte original_end =
+        incr preprocessed_pos;
+        if !preprocessed_pos > preprocessed_length then
+          invalid_arg "Css.Source: preprocessing map exceeds parsed source";
+        map.(!preprocessed_pos) <- original_end
+      in
+      while !original_pos < original_length do
+        match original.[!original_pos] with
+        | '\x00' ->
+            let start = !original_pos in
+            incr original_pos;
+            emit_byte start;
+            emit_byte start;
+            emit_byte !original_pos
+        | '\r' ->
+            incr original_pos;
+            if
+              !original_pos < original_length && original.[!original_pos] = '\n'
+            then incr original_pos;
+            emit_byte !original_pos
+        | '\x0C' ->
+            incr original_pos;
+            emit_byte !original_pos
+        | _ ->
+            incr original_pos;
+            emit_byte !original_pos
+      done;
+      if !preprocessed_pos <> preprocessed_length then
+        invalid_arg "Css.Source: preprocessing map disagrees with parsed source";
+      Option.Some map
+
+  let line_starts source =
+    let starts = ref [ 0 ] in
+    String.iteri
+      (fun index byte -> if byte = '\n' then starts := (index + 1) :: !starts)
+      source;
+    Array.of_list (List.rev !starts)
+
+  let v ~original ~preprocessed ~comments syntax_rules =
+    let previous_end = ref 0 in
+    let rules =
+      List.map
+        (fun syntax ->
+          let loc = rule_loc syntax in
+          let owned_loc =
+            Loc.v ~start_pos:!previous_end ~end_pos:loc.Loc.end_pos
+          in
+          previous_end := loc.Loc.end_pos;
+          { syntax; loc; owned_loc })
+        syntax_rules
+    in
+    let trailing_loc =
+      Loc.v ~start_pos:!previous_end ~end_pos:(String.length preprocessed)
+    in
+    {
+      original_source = original;
+      preprocessed_source = preprocessed;
+      comments =
+        List.map
+          (fun ({ Lexer.loc; terminated } : Lexer.comment) ->
+            { loc; terminated })
+          comments;
+      rules;
+      trailing_loc;
+      original_offsets = build_original_offsets original preprocessed;
+      line_starts = line_starts preprocessed;
+    }
+end
+
 (* Scan [source] for top-level [/*! ... */] bang comments. The lexer drops
    ordinary comments per CSS Syntax 3 (ED) sec. 4.3.2; bang comments are the
    minifier convention for license headers and need to round-trip. Returns pairs
@@ -4512,28 +4685,9 @@ let extract_bang_comments (source : string) : (int * string) list =
   done;
   List.rev !acc
 
-(* Top-level partial-recovery entry point: combine section 5.3 syntax warnings
-   from [Parser.stylesheet] with per-rule typed-validation warnings. *)
-let parse_stylesheet_partial ?(meta = Loc.default_meta_level)
-    ?(enforce_spec = false) (source : string) : stylesheet * Error.t list =
-  let reader = Reader.of_string ~enforce_spec source in
-  let out = Parser.stylesheet ~meta reader in
-  let sheet, typed_warnings =
-    read_stylesheet_of_rules ~source:(Reader.source reader) ~meta out.value
-  in
-  (* Interleave preserved [/*! ... */] bang comments at their source position by
-     walking the original rules and the bang-comment list in parallel; any bang
-     comments after the last rule are appended at the end. The typed [sheet] may
-     be shorter than [out.value] when validation drops a rule, but each typed
-     statement still corresponds to the next unconsumed rule, so the position
-     mapping survives. *)
+let interleave_bang_comments source rules sheet =
   let bangs = extract_bang_comments source in
-  (* Compare a comment's offset against each rule's END, not its start: a rule's
-     start absorbs an immediately-preceding comment ([/*!x*/a{}] starts at 0),
-     pushing a leading comment after its rule, but the closing-brace end is
-     unaffected by leading trivia, so leading and between-rule comments order
-     before their rule. *)
-  let rule_ends = List.map (fun r -> (rule_loc r).Loc.end_pos) out.value in
+  let rule_ends = List.map (fun r -> (rule_loc r).Loc.end_pos) rules in
   let rec interleave bangs rule_ends sheet =
     match (bangs, rule_ends, sheet) with
     | [], _, _ -> sheet
@@ -4545,7 +4699,41 @@ let parse_stylesheet_partial ?(meta = Loc.default_meta_level)
     | _, _ :: rest_s, stmt :: rest_sheet ->
         stmt :: interleave bangs rest_s rest_sheet
   in
-  let sheet = interleave bangs rule_ends sheet in
+  interleave bangs rule_ends sheet
+
+(* Top-level partial-recovery entry point: combine section 5.3 syntax warnings
+   from [Parser.stylesheet] with per-rule typed-validation warnings. *)
+let parse_stylesheet_partial ?(meta = Loc.default_meta_level)
+    ?(enforce_spec = false) ?on_source (original : string) :
+    stylesheet * Error.t list =
+  let comments, on_comment =
+    match on_source with
+    | Option.None -> (Option.None, Option.None)
+    | Option.Some _ ->
+        let comments = ref [] in
+        ( Option.Some comments,
+          Option.Some (fun comment -> comments := comment :: !comments) )
+  in
+  let reader = Reader.of_string ~enforce_spec original in
+  let out = Parser.stylesheet ~meta ?on_comment reader in
+  let preprocessed = Reader.source reader in
+  let sheet, typed_warnings =
+    read_stylesheet_of_rules ~source:preprocessed ~meta out.value
+  in
+  (* Interleave preserved [/*! ... */] bang comments at their source position by
+     walking the original rules and the bang-comment list in parallel; any bang
+     comments after the last rule are appended at the end. The typed [sheet] may
+     be shorter than [out.value] when validation drops a rule, but each typed
+     statement still corresponds to the next unconsumed rule, so the position
+     mapping survives. *)
+  let sheet = interleave_bang_comments preprocessed out.value sheet in
+  (match (on_source, comments) with
+  | Option.Some emit, Option.Some comments ->
+      emit
+        (Source.v ~original ~preprocessed ~comments:(List.rev !comments)
+           out.value)
+  | Option.None, Option.None -> ()
+  | _ -> assert false);
   (sheet, out.warnings @ typed_warnings)
 
 (** {1 Unknown At-Rule Construction} *)

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -424,15 +424,105 @@ val read_stylesheet_of_rules :
     at its default [`Full]) so dropped-rule warnings carry source- context
     snippets. *)
 
+module Source : sig
+  (** Immutable source fidelity captured by
+      [parse_stylesheet_partial ~on_source].
+
+      This is a separate syntax snapshot rather than metadata attached to the
+      typed stylesheet. The separation keeps ordinary parsing and constructed
+      ASTs allocation-neutral and avoids claiming false provenance after a
+      transform splits, merges, drops, or synthesises typed nodes. *)
+
+  type t
+
+  type comment = { loc : Loc.t; terminated : bool }
+  (** A lexer-recognised comment. [loc] indexes {!preprocessed}; [terminated] is
+      [false] when the closing [*/] was recovered at end of input. *)
+
+  type rule = {
+    syntax : Component.rule;
+        (** The complete located CSS Syntax component tree for this rule. *)
+    loc : Loc.t;
+        (** The rule's semantic range in {!preprocessed}. A directly adjacent
+            leading comment can be included because comments disappear before
+            token emission. *)
+    owned_loc : Loc.t;
+        (** The non-overlapping range from the previous rule's end (or byte 0)
+            through this rule's end. It gives all leading whitespace, comments,
+            and recovered material one deterministic owner. *)
+  }
+
+  type position = {
+    byte : int;
+        (** Byte offset in the exact caller input returned by {!contents}. *)
+    line : int;  (** One-based line in the CSS-preprocessed character stream. *)
+    column : int;
+        (** One-based Unicode-scalar column in the preprocessed stream. *)
+  }
+
+  type span = { start : position; end_ : position }
+
+  val contents : t -> string
+  (** [contents t] is the caller's byte-exact input, including a UTF-8 BOM,
+      CRLF, form feed, NUL, whitespace, and comments. *)
+
+  val preprocessed : t -> string
+  (** [preprocessed t] is the CSS Syntax section 3.3 input indexed by every
+      {!Loc.t}: BOM removed, NUL replaced by U+FFFD, and CR/FF/CRLF normalised
+      to LF. When preprocessing changes nothing this is the same immutable
+      string as {!contents}, so no duplicate source buffer is retained. *)
+
+  val comments : t -> comment list
+  (** [comments t] lists every actual lexer comment in source order;
+      comment-like bytes inside strings and URL tokens are not reported. *)
+
+  val rules : t -> rule list
+  (** [rules t] is every syntax-recovered top-level rule, including rules later
+      rejected by typed validation. *)
+
+  val trailing_loc : t -> Loc.t
+  (** [trailing_loc t] owns everything after the final rule. Together with the
+      {!rule.owned_loc} ranges it partitions {!preprocessed} exactly. *)
+
+  val slice : t -> Loc.t -> string
+  (** [slice t loc] extracts [loc] from {!preprocessed}. Raises
+      [Invalid_argument] when [loc] is outside the snapshot. *)
+
+  val original_loc : t -> Loc.t -> Loc.t
+  (** [original_loc t loc] maps preprocessed boundaries back to byte offsets in
+      {!contents}. Boundaries emitted by the lexer/components map exactly; the
+      two interior UTF-8 byte boundaries of a replacement U+FFFD map to the
+      original NUL's start. *)
+
+  val original_slice : t -> Loc.t -> string
+  (** [original_slice t loc] extracts the caller bytes covered by
+      [original_loc t loc]. *)
+
+  val position : t -> int -> position
+  (** [position t offset] maps a preprocessed byte boundary to source-map-ready
+      original byte offset plus CSS line and Unicode-scalar column. *)
+
+  val span : t -> Loc.t -> span
+  (** [span t loc] maps both boundaries of [loc] with {!position}. *)
+end
+
 val parse_stylesheet_partial :
   ?meta:Loc.meta_level ->
   ?enforce_spec:bool ->
+  ?on_source:(Source.t -> unit) ->
   string ->
   stylesheet * Error.t list
 (** [parse_stylesheet_partial ?meta source] runs section 5.3 recovery via
     {!Parser.stylesheet} and then typed-validates each recovered rule via
     {!read_stylesheet_of_rules}. Warnings from both stages are combined in
-    source order. *)
+    source order.
+
+    Pass [~on_source] to opt into one immutable authored-syntax snapshot from
+    the same parse. It retains the exact input, preprocessed input when
+    different, located syntax tree, comment records, line index, and original-
+    byte boundary map. Transforming the returned typed stylesheet never mutates
+    the snapshot and deliberately creates no inferred source map for split,
+    merged, dropped, or synthetic nodes. *)
 
 (** {1 Pretty Printing} *)
 

--- a/test/interop/wpt/test.ml
+++ b/test/interop/wpt/test.ml
@@ -328,7 +328,7 @@ let non_ascii_codepoints =
     (* The range list is what [~enforce_spec:true] selects; reading defaults to
        any code point >= U+0080, which these counter-tests would not see. *)
     match Cascade.Css.of_string ~strict:false ~enforce_spec:true css with
-    | Ok { Cascade.Css.stylesheet; warnings = _ } ->
+    | Ok { Cascade.Css.stylesheet; warnings = _; _ } ->
         List.length (Cascade.Css.rule_statements stylesheet) = 1
     | Error _ -> false
   in

--- a/test/interop_runner/test.ml
+++ b/test/interop_runner/test.ml
@@ -176,7 +176,7 @@ let read_trace path =
 let cascade_minify input =
   match Cascade.Css.of_string ~strict:false input with
   | Error e -> Error (Cascade.Error.to_string e)
-  | Ok { Cascade.Css.stylesheet; warnings = _ } ->
+  | Ok { Cascade.Css.stylesheet; warnings = _; _ } ->
       Ok
         (stylesheet
         |> Cascade.Css.optimize ~scope:`Stylesheet

--- a/test/spec/test.ml
+++ b/test/spec/test.ml
@@ -120,7 +120,7 @@ let rejects_invalid css =
         (to_string ~minify:true parsed.stylesheet)
 
 let recover css expected min_warnings =
-  let { stylesheet; warnings } =
+  let { stylesheet; warnings; _ } =
     match of_string ~strict:false css with
     | Ok parsed -> parsed
     | Error e -> Alcotest.fail (Cascade.Error.to_string e)
@@ -137,7 +137,7 @@ let recover css expected min_warnings =
 
 (* Lenient [preserves_non_minified]: keeps [preserves], drops [drops], warns. *)
 let recover_non_minified css ~preserves ~drops min_warnings =
-  let { stylesheet; warnings } =
+  let { stylesheet; warnings; _ } =
     match of_string ~strict:false css with
     | Ok parsed -> parsed
     | Error e -> Alcotest.fail (Cascade.Error.to_string e)

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -20,6 +20,142 @@ open Css
    ~minify:true] used to behave implicitly. *)
 let minify s = s |> Css.optimize |> Css.to_string ~minify:true
 
+let parse_with_source ?(strict = false) source =
+  match Css.of_string ~strict ~preserve_source:true source with
+  | Ok ({ source = Some source; _ } as parsed) -> (parsed, source)
+  | Ok { source = None; _ } ->
+      Alcotest.fail "source-preserving parse returned no source snapshot"
+  | Error error ->
+      Alcotest.failf "source-preserving parse rejected %S: %s" source
+        (Error.to_string error)
+
+let source_fidelity_roundtrip_and_locations () =
+  let original = "\xEF\xBB\xBF/* lead */\r\n.a{color:rgb(300)}\r\n/* tail */" in
+  let preprocessed = "/* lead */\n.a{color:rgb(300)}\n/* tail */" in
+  (match Css.of_string original with
+  | Ok { source = None; _ } -> ()
+  | Ok { source = Some _; _ } ->
+      Alcotest.fail "ordinary parse unexpectedly retained source"
+  | Error error -> Alcotest.fail (Error.to_string error));
+  let parsed, source = parse_with_source original in
+  Alcotest.(check string)
+    "exact caller bytes round-trip" original
+    (Css.Source.contents source);
+  Alcotest.(check string)
+    "CSS preprocessing is inspectable" preprocessed
+    (Css.Source.preprocessed source);
+  (match Css.Source.comments source with
+  | [ leading; trailing ] ->
+      Alcotest.(check string)
+        "leading comment bytes" "/* lead */"
+        (Css.Source.slice source leading.loc);
+      Alcotest.(check bool) "leading comment terminated" true leading.terminated;
+      Alcotest.(check string)
+        "leading comment original bytes" "/* lead */"
+        (Css.Source.original_slice source leading.loc);
+      Alcotest.(check string)
+        "leading comment original location" "[3-13]"
+        (Loc.to_string (Css.Source.original_loc source leading.loc));
+      Alcotest.(check string)
+        "trailing comment bytes" "/* tail */"
+        (Css.Source.slice source trailing.loc)
+  | comments ->
+      Alcotest.failf "expected two comments, got %d" (List.length comments));
+  (match Css.Source.rules source with
+  | [ rule ] ->
+      Alcotest.(check string)
+        "semantic rule location" "[11-29]" (Loc.to_string rule.loc);
+      Alcotest.(check string)
+        "rule owns its leading trivia" "[0-29]"
+        (Loc.to_string rule.owned_loc);
+      let start = Css.Source.position source rule.loc.start_pos in
+      Alcotest.(check int) "original byte offset" 15 start.byte;
+      Alcotest.(check int) "line" 2 start.line;
+      Alcotest.(check int) "column" 1 start.column
+  | rules ->
+      Alcotest.failf "expected one syntax rule, got %d" (List.length rules));
+  Alcotest.(check bool) "typed diagnostic retained" true (parsed.warnings <> []);
+  let warning = List.hd parsed.warnings in
+  let span = Css.Source.span source (Error.context warning).Loc.Context.loc in
+  Alcotest.(check int) "diagnostic source line" 2 span.start.line;
+  let _, replaced = parse_with_source "\x00a{}" in
+  Alcotest.(check string)
+    "NUL is visible in caller bytes" "\x00a{}"
+    (Css.Source.contents replaced);
+  Alcotest.(check string)
+    "NUL is preprocessed to replacement character" "\xEF\xBF\xBDa{}"
+    (Css.Source.preprocessed replaced);
+  Alcotest.(check string)
+    "replacement range maps back to one caller byte" "[0-1]"
+    (Loc.to_string
+       (Css.Source.original_loc replaced (Loc.v ~start_pos:0 ~end_pos:3)))
+
+let source_fidelity_owns_all_trivia () =
+  let input = " /* before a */ .a{}\n/* before b */ .b{} /* after */ " in
+  let _, source = parse_with_source input in
+  let owned =
+    List.map
+      (fun (rule : Css.Source.rule) -> Css.Source.slice source rule.owned_loc)
+      (Css.Source.rules source)
+  in
+  let trailing = Css.Source.slice source (Css.Source.trailing_loc source) in
+  Alcotest.(check string)
+    "rule-owned text plus trailing trivia partitions the source" input
+    (String.concat "" (owned @ [ trailing ]));
+  let _, unterminated = parse_with_source "a{}/* tail" in
+  (match Css.Source.comments unterminated with
+  | [ comment ] ->
+      Alcotest.(check bool)
+        "unterminated comment recorded" false comment.terminated;
+      Alcotest.(check string)
+        "unterminated comment bytes" "/* tail"
+        (Css.Source.slice unterminated comment.loc)
+  | comments ->
+      Alcotest.failf "expected one unterminated comment, got %d"
+        (List.length comments));
+  let _, strings =
+    parse_with_source "a{content:\"/* not a comment */\"}/* actual */"
+  in
+  (match Css.Source.comments strings with
+  | [ comment ] ->
+      Alcotest.(check string)
+        "comment-looking string bytes stay inside the string" "/* actual */"
+        (Css.Source.slice strings comment.loc)
+  | comments ->
+      Alcotest.failf "expected only the actual comment, got %d"
+        (List.length comments));
+  let _, unchanged = parse_with_source "a{}" in
+  Alcotest.(check bool)
+    "unchanged input buffer is shared" true
+    (Css.Source.contents unchanged == Css.Source.preprocessed unchanged)
+
+let source_fidelity_is_an_immutable_snapshot () =
+  let nested, nested_source =
+    parse_with_source ".a{color:red;& .b{color:blue}}"
+  in
+  let flattened = Css.flatten_nesting nested.stylesheet in
+  Alcotest.(check int)
+    "one authored syntax rule" 1
+    (List.length (Css.Source.rules nested_source));
+  Alcotest.(check int)
+    "flattening splits the typed rule" 2 (List.length flattened);
+  Alcotest.(check string)
+    "split transform leaves source snapshot unchanged"
+    ".a{color:red;& .b{color:blue}}"
+    (Css.Source.contents nested_source);
+  let adjacent, adjacent_source =
+    parse_with_source ".a{color:red}.b{color:red}"
+  in
+  let merged = Css.optimize adjacent.stylesheet in
+  Alcotest.(check int)
+    "two authored syntax rules" 2
+    (List.length (Css.Source.rules adjacent_source));
+  Alcotest.(check int) "optimization merges typed rules" 1 (List.length merged);
+  Alcotest.(check string)
+    "merge transform leaves source snapshot unchanged"
+    ".a{color:red}.b{color:red}"
+    (Css.Source.contents adjacent_source)
+
 (* Helper selectors for tests *)
 let btn = Selector.class_ "btn"
 let card = Selector.class_ "card"
@@ -2286,6 +2422,12 @@ let suite =
     [
       (* Integration tests using public Css interface only *)
       Alcotest.test_case "CSS generation end-to-end" `Quick generation;
+      Alcotest.test_case "source fidelity round-trip and locations" `Quick
+        source_fidelity_roundtrip_and_locations;
+      Alcotest.test_case "source fidelity owns all trivia" `Quick
+        source_fidelity_owns_all_trivia;
+      Alcotest.test_case "source fidelity snapshot survives transforms" `Quick
+        source_fidelity_is_an_immutable_snapshot;
       Alcotest.test_case "optimization flag works" `Quick optimization_flag;
       Alcotest.test_case "non-empty declaration lists" `Quick
         nonempty_declaration_lists;

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -334,7 +334,7 @@ let spec_fontface_var_descriptor_edges () =
     let lenient =
       match Css.of_string input with
       | Error _ -> [ Fmt.str "%s: lenient parse rejected %S" descriptor input ]
-      | Ok { Css.stylesheet; warnings } -> (
+      | Ok { Css.stylesheet; warnings; _ } -> (
           let printed = Css.to_string ~minify:true stylesheet |> String.trim in
           (if String.equal printed kept then []
            else
@@ -375,7 +375,7 @@ let spec_fontface_var_descriptor_kept () =
     let input = source descriptor in
     match Css.of_string input with
     | Error _ -> [ Fmt.str "%s: lenient parse rejected %S" descriptor input ]
-    | Ok { Css.stylesheet; warnings } -> (
+    | Ok { Css.stylesheet; warnings; _ } -> (
         let printed = Css.to_string ~minify:true stylesheet |> String.trim in
         (if String.equal printed input then []
          else [ Fmt.str "%s: printed %S, expected %S" descriptor printed input ])

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -1063,7 +1063,7 @@ let spec_qualified_custom_prop_warns () =
   | Error _ -> ()
   | Ok _ -> Alcotest.fail "strict mode accepted a silently dropped rule");
   (match Css.of_string input with
-  | Ok { Css.stylesheet; warnings = [ _ ] } ->
+  | Ok { Css.stylesheet; warnings = [ _ ]; _ } ->
       Alcotest.(check string)
         "nothing survives the drop" ""
         (Css.to_string ~minify:true stylesheet)
@@ -1095,7 +1095,7 @@ let spec_unterminated_repairs_warn () =
      mode has to have something to reject. *)
   let repaired input ~expect ~sort =
     match Css.of_string input with
-    | Ok { Css.stylesheet; warnings = [ w ] } -> (
+    | Ok { Css.stylesheet; warnings = [ w ]; _ } -> (
         Alcotest.(check string)
           "the repair does not move the output" expect
           (Css.to_string ~minify:true stylesheet);

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1220,7 +1220,7 @@ let strict_accept name css =
   match Css.of_string ~strict:true css with
   | Ok parsed ->
       let strict_output = minify parsed.stylesheet in
-      let { Css.stylesheet; warnings } =
+      let { Css.stylesheet; warnings; _ } =
         match Css.of_string ~strict:false css with
         | Ok parsed -> parsed
         | Error err ->
@@ -1247,7 +1247,7 @@ let strict_reject name css =
         ("strict error carries detail for " ^ name)
         true
         (String.length (string_of_strict_error err) > 0);
-      let { Css.stylesheet; warnings } =
+      let { Css.stylesheet; warnings; _ } =
         match Css.of_string ~strict:false css with
         | Ok parsed -> parsed
         | Error err ->
@@ -1291,7 +1291,7 @@ let font_family_descriptor_grammar () =
     "@font-palette-values --brand { font-family: inherit }"
 
 let lenient_recover name css expected min_warnings =
-  let { Css.stylesheet; warnings } =
+  let { Css.stylesheet; warnings; _ } =
     match Css.of_string ~strict:false css with
     | Ok parsed -> parsed
     | Error err ->
@@ -2635,7 +2635,7 @@ let test_invalid_at_rules () =
 let css_syntax_recovery () =
   let check_strict name css expected =
     match Css.of_string ~strict:true css with
-    | Ok { Css.stylesheet; warnings = _ } ->
+    | Ok { Css.stylesheet; warnings = _; _ } ->
         Alcotest.(check string)
           (name ^ " stylesheet") expected
           (minify stylesheet |> String.trim)
@@ -2644,7 +2644,7 @@ let css_syntax_recovery () =
           (Cascade.Error.to_string err)
   in
   let check_recovery name css expected min_warnings =
-    let { Css.stylesheet; warnings } =
+    let { Css.stylesheet; warnings; _ } =
       match Css.of_string ~strict:false css with
       | Ok parsed -> parsed
       | Error err ->
@@ -2683,7 +2683,7 @@ let css_syntax_recovery_structural () =
         | None -> Alcotest.fail "expected recovered qualified rule")
   in
   let check_counts name css expected_counts min_warnings =
-    let { Css.stylesheet; warnings } =
+    let { Css.stylesheet; warnings; _ } =
       match Css.of_string ~strict:false css with
       | Ok parsed -> parsed
       | Error err ->
@@ -2965,7 +2965,7 @@ let s552_unknown_at_rule_eof_closers () =
      unterminated. *)
   let self_delimiting name printed =
     let input = String.concat "" [ printed; ".z{color:red}" ] in
-    let { Css.stylesheet; warnings } =
+    let { Css.stylesheet; warnings; _ } =
       match Css.of_string ~strict:false input with
       | Ok parsed -> parsed
       | Error err ->
@@ -9099,7 +9099,7 @@ let container_condition_error_spans () =
     | Error err ->
         Alcotest.failf "%s: lenient parse failed: %s" name
           (Cascade.Error.to_string err)
-    | Ok { Css.stylesheet; warnings } -> (
+    | Ok { Css.stylesheet; warnings; _ } -> (
         Alcotest.(check int)
           (name ^ ": sibling rule survives")
           1
@@ -9140,7 +9140,7 @@ let one_condition_warning name input ~at_rule (reason, start_pos, end_pos) =
   | Error err ->
       Alcotest.failf "%s: lenient parse failed: %s" name
         (Cascade.Error.to_string err)
-  | Ok { Css.stylesheet; warnings } -> (
+  | Ok { Css.stylesheet; warnings; _ } -> (
       Alcotest.(check int)
         (name ^ ": sibling rule survives")
         1
@@ -9202,7 +9202,7 @@ let descriptor_value_error_spans () =
     | Error err ->
         Alcotest.failf "%s: lenient parse failed: %s" name
           (Cascade.Error.to_string err)
-    | Ok { Css.stylesheet; warnings } -> (
+    | Ok { Css.stylesheet; warnings; _ } -> (
         Alcotest.(check int)
           (name ^ ": sibling rule survives")
           1
@@ -9980,7 +9980,7 @@ let additional_tests =
     ( "partial recovery: Css.of_string ~strict:false entry point",
       `Quick,
       fun () ->
-        let { Css.stylesheet; warnings } =
+        let { Css.stylesheet; warnings; _ } =
           match
             Css.of_string ~strict:false
               ".a { color: red; } .b { color: rgb(300); }"
@@ -10049,7 +10049,7 @@ let additional_tests =
     ( "partial recovery: unclosed brace recovered per 5.3.7",
       `Quick,
       fun () ->
-        let { Css.stylesheet; warnings = _ } =
+        let { Css.stylesheet; warnings = _; _ } =
           match Css.of_string ~strict:false ".btn { color: red;" with
           | Ok parsed -> parsed
           | Error err ->
@@ -10064,7 +10064,7 @@ let additional_tests =
       fun () ->
         (* CSS Syntax 5.4.4: an invalid declaration is discarded while the
            enclosing rule and its other declarations survive. *)
-        let { Css.stylesheet; warnings } =
+        let { Css.stylesheet; warnings; _ } =
           match
             Css.of_string ~strict:false
               ".a { color: invalidcolor; color: red; }"
@@ -10132,7 +10132,7 @@ let additional_tests =
         (* [@layer base;] parses through section 5.5.2 to an at-rule with [block
            = None]. The replay cursor must still present a terminating [;] to
            [read_layer], otherwise the at-rule is silently dropped. *)
-        let { Css.stylesheet; warnings } =
+        let { Css.stylesheet; warnings; _ } =
           match Css.of_string ~strict:false "@layer base;" with
           | Ok parsed -> parsed
           | Error err ->
@@ -10147,7 +10147,7 @@ let additional_tests =
       fun () ->
         (* Section 5.4.1: an at-rule with no handler is discarded with a typed
            warning; the surrounding stylesheet continues to parse. *)
-        let { Css.stylesheet; warnings } =
+        let { Css.stylesheet; warnings; _ } =
           match
             Css.of_string ~strict:false
               "@unknown-rule { color: red; } .a { color: blue; }"
@@ -10176,7 +10176,7 @@ let additional_tests =
            [Reader.Parse_error] shape, bypassing the partial-parse contract. It
            now becomes a typed [Bad_condition] warning while surrounding rules
            keep parsing. *)
-        let { Css.stylesheet; warnings } =
+        let { Css.stylesheet; warnings; _ } =
           match
             Css.of_string ~strict:false
               "@supports not-a-function foo { .a { color: red } } .b { color: \


### PR DESCRIPTION
Tooling could not recover comments or original byte/line locations after parsing without running a separate parser. `Css.of_string ~preserve_source:true` now returns an immutable authored-syntax snapshot from the existing parse while ordinary callers retain no source buffers.