### PR TITLE
grid: accept flex-valued track math

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -174,6 +174,9 @@ difference wherever the two are not equivalent.
 
 ### Parsing
 
+- Grid track sizes accept math functions that resolve to `<flex>`, including
+  `calc(1fr * 2)`, `min(1fr, 2fr)` and `clamp(100px, 1fr, 300px)`, in explicit,
+  repeated and automatic tracks (#749)
 - A sole baseline position in `place-content` is accepted and defaults its
   omitted `justify-content` slot to `start`, as required by CSS Align (#739)
 - Custom-property declarations containing a `<bad-string-token>` are dropped

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3917,6 +3917,12 @@ type grid_auto_flow = Properties.grid_auto_flow =
   | Var of grid_auto_flow var
 
 (** CSS grid template values *)
+type grid_flex_math = Properties.grid_flex_math =
+  | Calc_flex of math_arg
+  | Min_flex of math_arg list
+  | Max_flex of math_arg list
+  | Clamp_flex of math_arg * math_arg * math_arg
+
 type grid_template = Properties.grid_template =
   | None
   | Px of float
@@ -3930,6 +3936,7 @@ type grid_template = Properties.grid_template =
   | Zero
   | Length of length
   | Fr of float
+  | Flex_math of grid_flex_math
   | Auto
   | Min_content
   | Max_content

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -925,7 +925,7 @@ module Grid_template = struct
       expect_flex_math inner arg;
       arg
     in
-    (Flex_math (Calc_flex arg) : grid_template)
+    (Calc_flex arg : grid_flex_math)
 
   let read_flex_extreme name make t =
     let args =
@@ -945,7 +945,7 @@ module Grid_template = struct
       Cursor.expect_eof inner;
       args
     in
-    (Flex_math (make args) : grid_template)
+    make args
 
   let read_flex_clamp t =
     let min, value, max =
@@ -970,17 +970,15 @@ module Grid_template = struct
             "grid clamp() must carry a <flex> track value");
       (min, value, max)
     in
-    (Flex_math (Clamp_flex (min, value, max)) : grid_template)
+    (Clamp_flex (min, value, max) : grid_flex_math)
 
   let read_flex_math t =
     match Cursor.peek t with
     | Some (Component.Func { node = { name; _ }; _ }) -> (
         match String.lowercase_ascii name with
         | "calc" -> read_flex_calc t
-        | "min" ->
-            read_flex_extreme "min" (fun xs -> (Min_flex xs : grid_flex_math)) t
-        | "max" ->
-            read_flex_extreme "max" (fun xs -> (Max_flex xs : grid_flex_math)) t
+        | "min" -> read_flex_extreme "min" (fun xs -> Min_flex xs) t
+        | "max" -> read_flex_extreme "max" (fun xs -> Max_flex xs) t
         | "clamp" -> read_flex_clamp t
         | _ -> Cursor.err_expected t "<flex> math function")
     | _ -> Cursor.err_expected t "<flex> math function"
@@ -989,7 +987,7 @@ module Grid_template = struct
     (* Accept a single breadth: length, fr, or keywords *)
     Cursor.one_of
       [
-        read_flex_math;
+        (fun t -> (Flex_math (read_flex_math t) : grid_template));
         read_fr;
         read_length_as_grid;
         (fun t ->
@@ -1106,9 +1104,17 @@ module Grid_template = struct
                 (Repeat (count, tracks) : grid_template) );
           ]
         ~default:(fun t ->
-          Cursor.one_of [ read_flex_math; read_length_as_grid; read_fr ] t)
+          Cursor.one_of
+            [
+              (fun t -> (Flex_math (read_flex_math t) : grid_template));
+              read_length_as_grid;
+              read_fr;
+            ]
+            t)
         t
 end
+
+let read_grid_flex_math = Grid_template.read_flex_math
 
 let grid_template_needs_raw_template cvs =
   let rec has_string = function

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -163,6 +163,21 @@ let pp_grid_auto_flow_shorthand ctx = function
       in
       Pp.list ~sep:Pp.space pp_component ctx components
 
+let pp_grid_flex_math : grid_flex_math Pp.t =
+ fun ctx -> function
+  | Calc_flex arg -> Pp.call "calc" pp_math_arg ctx arg
+  | Min_flex args -> Pp.call "min" (Pp.list ~sep:Pp.comma pp_math_arg) ctx args
+  | Max_flex args -> Pp.call "max" (Pp.list ~sep:Pp.comma pp_math_arg) ctx args
+  | Clamp_flex (min, value, max) ->
+      Pp.call "clamp"
+        (fun ctx (min, value, max) ->
+          pp_math_arg ctx min;
+          Pp.comma ctx ();
+          pp_math_arg ctx value;
+          Pp.comma ctx ();
+          pp_math_arg ctx max)
+        ctx (min, value, max)
+
 let rec pp_grid_template : grid_template Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"
@@ -180,6 +195,7 @@ let rec pp_grid_template : grid_template Pp.t =
      [<length>] only. [0fr] is a zero flex factor, distinct from a [0]
      [<length>] in [grid-template]'s union grammar. *)
   | Fr f -> Pp.unit ctx f "fr"
+  | Flex_math math -> pp_grid_flex_math ctx math
   | Auto -> Pp.string ctx "auto"
   | Min_content -> Pp.string ctx "min-content"
   | Max_content -> Pp.string ctx "max-content"
@@ -864,10 +880,116 @@ module Grid_template = struct
     | Some (n, "fr") -> Fr n
     | _ -> Cursor.err_expected t "<fr>"
 
+  type math_kind = Number | Dimension | Flex | Unknown | Invalid
+
+  let same_math_kind left right =
+    match (left, right) with
+    | Number, Number -> Number
+    | Dimension, Dimension -> Dimension
+    | Flex, Flex -> Flex
+    | Unknown, _ | _, Unknown -> Unknown
+    | Invalid, _ | _, Invalid | _ -> Invalid
+
+  let rec math_arg_kind : math_arg -> math_kind = function
+    | Lit _ | Const _ -> Number
+    | Dim (_, unit_) ->
+        if String.equal (String.lowercase_ascii unit_) "fr" then Flex
+        else Dimension
+    | Var_arg _ | Math_call _ -> Unknown
+    | Parens_arg arg -> math_arg_kind arg
+    | Op (left, (Add | Sub), right) ->
+        same_math_kind (math_arg_kind left) (math_arg_kind right)
+    | Op (left, Mul, right) -> (
+        match (math_arg_kind left, math_arg_kind right) with
+        | Number, kind | kind, Number -> kind
+        | Unknown, _ | _, Unknown -> Unknown
+        | _ -> Invalid)
+    | Op (left, Div, right) -> (
+        match (math_arg_kind left, math_arg_kind right) with
+        | kind, Number -> kind
+        | Flex, Flex | Dimension, Dimension -> Number
+        | Unknown, _ | _, Unknown -> Unknown
+        | _ -> Invalid)
+
+  let expect_flex_math inner arg =
+    Cursor.ws inner;
+    Cursor.expect_eof inner;
+    if math_arg_kind arg <> Flex then
+      Cursor.err_invalid inner "grid math function must resolve to <flex>"
+
+  let read_flex_calc t =
+    let arg =
+      Cursor.call "calc" t @@ fun inner ->
+      Cursor.ws inner;
+      let arg = read_math_arg inner in
+      expect_flex_math inner arg;
+      arg
+    in
+    (Flex_math (Calc_flex arg) : grid_template)
+
+  let read_flex_extreme name make t =
+    let args =
+      Cursor.call name t @@ fun inner ->
+      let args =
+        Cursor.list ~at_least:1 ~sep:Cursor.comma
+          (fun inner ->
+            Cursor.ws inner;
+            let arg = read_math_arg inner in
+            if math_arg_kind arg <> Flex then
+              Cursor.err_invalid inner
+                "grid math function must resolve to <flex>";
+            arg)
+          inner
+      in
+      Cursor.ws inner;
+      Cursor.expect_eof inner;
+      args
+    in
+    (Flex_math (make args) : grid_template)
+
+  let read_flex_clamp t =
+    let min, value, max =
+      Cursor.call "clamp" t @@ fun inner ->
+      Cursor.ws inner;
+      let min = read_math_arg inner in
+      Cursor.ws inner;
+      Cursor.comma inner;
+      Cursor.ws inner;
+      let value = read_math_arg inner in
+      Cursor.ws inner;
+      Cursor.comma inner;
+      Cursor.ws inner;
+      let max = read_math_arg inner in
+      Cursor.ws inner;
+      Cursor.expect_eof inner;
+      let kinds = (math_arg_kind min, math_arg_kind value, math_arg_kind max) in
+      (match kinds with
+      | Flex, Flex, Flex | Dimension, Flex, Dimension -> ()
+      | _ ->
+          Cursor.err_invalid inner
+            "grid clamp() must carry a <flex> track value");
+      (min, value, max)
+    in
+    (Flex_math (Clamp_flex (min, value, max)) : grid_template)
+
+  let read_flex_math t =
+    match Cursor.peek t with
+    | Some (Component.Func { node = { name; _ }; _ }) -> (
+        match String.lowercase_ascii name with
+        | "calc" -> read_flex_calc t
+        | "min" ->
+            read_flex_extreme "min" (fun xs -> (Min_flex xs : grid_flex_math)) t
+        | "max" ->
+            read_flex_extreme "max" (fun xs -> (Max_flex xs : grid_flex_math)) t
+        | "clamp" -> read_flex_clamp t
+        | _ -> Cursor.err_expected t "<flex> math function")
+    | _ -> Cursor.err_expected t "<flex> math function"
+
   let read_track_breadth t : grid_template =
     (* Accept a single breadth: length, fr, or keywords *)
     Cursor.one_of
       [
+        read_flex_math;
         read_fr;
         read_length_as_grid;
         (fun t ->
@@ -983,7 +1105,8 @@ module Grid_template = struct
                 validate_track_list inner tracks;
                 (Repeat (count, tracks) : grid_template) );
           ]
-        ~default:(fun t -> Cursor.one_of [ read_length_as_grid; read_fr ] t)
+        ~default:(fun t ->
+          Cursor.one_of [ read_flex_math; read_length_as_grid; read_fr ] t)
         t
 end
 
@@ -1098,7 +1221,8 @@ let rec read_grid_template t : grid_template =
    keywords ([none], [subgrid], [masonry]) nor its slash form. *)
 let rec is_track_size : grid_template -> bool = function
   | Px _ | Rem _ | Em _ | Pct _ | Vw _ | Vh _ | Vmin _ | Vmax _ | Zero
-  | Length _ | Fr _ | Auto | Min_content | Max_content | Fit_content _ ->
+  | Length _ | Fr _ | Flex_math _ | Auto | Min_content | Max_content
+  | Fit_content _ ->
       true
   | Min_max (min, max) -> is_track_size min && is_track_size max
   | Var _ -> true

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -923,6 +923,12 @@ val pp_grid_auto_flow : grid_auto_flow Pp.t
 val read_grid_auto_flow : Cursor.t -> grid_auto_flow
 (** [read_grid_auto_flow t] is the [grid_auto_flow] parsed from [t]. *)
 
+val pp_grid_flex_math : grid_flex_math Pp.t
+(** [pp_grid_flex_math] is the pretty-printer for [grid_flex_math]. *)
+
+val read_grid_flex_math : Cursor.t -> grid_flex_math
+(** [read_grid_flex_math t] is the [grid_flex_math] parsed from [t]. *)
+
 val pp_grid_template : grid_template Pp.t
 (** [pp_grid_template] is the pretty-printer for [grid_template]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -772,6 +772,14 @@ type repeat_count =
   | Auto_fit
   | Var of repeat_count var
 
+(** A CSS Values 4 math function whose result is a Grid [<flex>] track breadth.
+    Kept separate from [length] because [fr] is not a length unit. *)
+type grid_flex_math =
+  | Calc_flex of math_arg
+  | Min_flex of math_arg list
+  | Max_flex of math_arg list
+  | Clamp_flex of math_arg * math_arg * math_arg
+
 type grid_template =
   | None
   (* Single track values *)
@@ -789,6 +797,7 @@ type grid_template =
           specific cases above do not carry: a [calc()], a [var()] inside a
           [calc()], or a less common unit (e.g. [cm], [ch]). *)
   | Fr of float
+  | Flex_math of grid_flex_math
   | Auto
   | Min_content
   | Max_content

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -414,10 +414,13 @@ let check_grid_auto_flow_component =
 let check_grid_template =
   check_value_cursor "grid-template" read_grid_template pp_grid_template
 
-let check_grid_auto_rows =
+let check_grid_flex_math =
+  check_value_cursor "grid-flex-math" read_grid_flex_math pp_grid_flex_math
+
+let roundtrip_grid_auto_rows =
   check_value_cursor "grid-auto-rows" read_grid_auto_tracks pp_grid_template
 
-let check_grid_auto_columns =
+let roundtrip_grid_auto_columns =
   check_value_cursor "grid-auto-columns" read_grid_auto_tracks pp_grid_template
 
 let check_grid_line = check_value_cursor "grid-line" read_grid_line pp_grid_line
@@ -4140,8 +4143,9 @@ let test_grid_template () =
     "repeat(2, calc(1fr * 2))";
   check_grid_template ~roundtrip:true ~expected:"calc(1fr*2)/min(1fr,2fr)"
     "calc(1fr * 2) / min(1fr, 2fr)";
-  check_grid_auto_rows ~roundtrip:true ~expected:"calc(1fr*2)" "calc(1fr * 2)";
-  check_grid_auto_columns ~roundtrip:true ~expected:"min(1fr,2fr)"
+  roundtrip_grid_auto_rows ~roundtrip:true ~expected:"calc(1fr*2)"
+    "calc(1fr * 2)";
+  roundtrip_grid_auto_columns ~roundtrip:true ~expected:"min(1fr,2fr)"
     "min(1fr, 2fr)";
   check_grid_template "10cm";
   check_grid_template ~expected:"minmax(calc(var(--x)*2),1fr)"
@@ -4220,6 +4224,12 @@ let test_grid_template () =
   neg_cursor read_grid_template "1px / [a]";
   neg_cursor read_grid_template "repeat(2,[a])";
   neg_cursor read_grid_template "repeat(2,[a] [b] 1px)"
+
+let test_grid_flex_math () =
+  check_grid_flex_math ~roundtrip:true ~expected:"calc(1fr*2)" "calc(1fr * 2)";
+  check_grid_flex_math ~roundtrip:true ~expected:"min(1fr,2fr)" "min(1fr, 2fr)";
+  check_grid_flex_math ~roundtrip:true "clamp(100px,1fr,300px)";
+  neg_cursor read_grid_flex_math "calc(100px)"
 
 let test_grid_template_areas () =
   check_grid_template_areas ~expected:"\"nav main\"\". foot\""
@@ -5514,6 +5524,7 @@ let additional_tests =
     test_case "flex" `Quick test_flex;
     test_case "grid_line" `Quick test_grid_line;
     test_case "grid_line_pair" `Quick test_grid_line_pair;
+    test_case "grid_flex_math" `Quick test_grid_flex_math;
     test_case "grid_template" `Quick test_grid_template;
     test_case "justify_content" `Quick test_justify_content;
     test_case "outline_style" `Quick test_outline_style;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -414,6 +414,12 @@ let check_grid_auto_flow_component =
 let check_grid_template =
   check_value_cursor "grid-template" read_grid_template pp_grid_template
 
+let check_grid_auto_rows =
+  check_value_cursor "grid-auto-rows" read_grid_auto_tracks pp_grid_template
+
+let check_grid_auto_columns =
+  check_value_cursor "grid-auto-columns" read_grid_auto_tracks pp_grid_template
+
 let check_grid_line = check_value_cursor "grid-line" read_grid_line pp_grid_line
 
 let check_align_items =
@@ -4122,6 +4128,21 @@ let test_grid_template () =
   check_grid_template ~roundtrip:true ~expected:"calc(var(--x)*2)1fr"
     "calc(var(--x) * 2) 1fr";
   check_grid_template "calc(100px + 1rem)";
+  (* CSS Values 4 sec. 10.8 lets a math function resolve to <flex>, and CSS Grid
+     2 sec. 7.2.1 accepts that type as a track breadth. Keep the function typed
+     as a flex track instead of routing it through the length reader. *)
+  check_grid_template ~roundtrip:true ~expected:"calc(1fr*2)" "calc(1fr * 2)";
+  check_grid_template ~roundtrip:true ~expected:"min(1fr,2fr)" "min(1fr, 2fr)";
+  check_grid_template ~roundtrip:true "clamp(100px,1fr,300px)";
+  check_grid_template ~roundtrip:true ~expected:"min(100px,200px)"
+    "min(100px, 200px)";
+  check_grid_template ~roundtrip:true ~expected:"repeat(2,calc(1fr*2))"
+    "repeat(2, calc(1fr * 2))";
+  check_grid_template ~roundtrip:true ~expected:"calc(1fr*2)/min(1fr,2fr)"
+    "calc(1fr * 2) / min(1fr, 2fr)";
+  check_grid_auto_rows ~roundtrip:true ~expected:"calc(1fr*2)" "calc(1fr * 2)";
+  check_grid_auto_columns ~roundtrip:true ~expected:"min(1fr,2fr)"
+    "min(1fr, 2fr)";
   check_grid_template "10cm";
   check_grid_template ~expected:"minmax(calc(var(--x)*2),1fr)"
     "minmax(calc(var(--x) * 2), 1fr)";


### PR DESCRIPTION
Grid track readers routed math functions through the length parser, rejecting functions whose result is `<flex>` where track breadths accept that type.