### PR TITLE
Optimize: eliminate large-sheet canonical drift

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -501,6 +501,11 @@ difference wherever the two are not equivalent.
 
 ### Minification
 
+- `--minify` reaches a stable result in one invocation on large stylesheets:
+  synthesized shorthands and vendor transition/animation aliases normalize
+  before comparison, factoring settles both transfer-size alternatives and
+  retries once when settling changes its graph, and selector-branch factoring
+  preserves source order after earlier rewrites (#0)
 - The README states the default minifier's evergreen target, colour tolerance,
   and CSSOM-visible normalisation beside its first example, and describes
   `--lossless --enforce-spec` as conservative rather than source-exact (#743)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -505,7 +505,7 @@ difference wherever the two are not equivalent.
   synthesized shorthands and vendor transition/animation aliases normalize
   before comparison, factoring settles both transfer-size alternatives and
   retries once when settling changes its graph, and selector-branch factoring
-  preserves source order after earlier rewrites (#0)
+  preserves source order after earlier rewrites (#750)
 - The README states the default minifier's evergreen target, colour tolerance,
   and CSSOM-visible normalisation beside its first example, and describes
   `--lossless --enforce-spec` as conservative rather than source-exact (#743)

--- a/bin/cli_exit.ml
+++ b/bin/cli_exit.ml
@@ -5,7 +5,9 @@ let with_defaults custom =
   let is_overridden default =
     List.exists
       (fun info ->
-        Cmdliner.Cmd.Exit.info_code info = Cmdliner.Cmd.Exit.info_code default)
+        Int.equal
+          (Cmdliner.Cmd.Exit.info_code info)
+          (Cmdliner.Cmd.Exit.info_code default))
       custom
   in
   Cmdliner.Cmd.Exit.defaults

--- a/lib/factor.ml
+++ b/lib/factor.ml
@@ -180,7 +180,7 @@ let log_transfer_revert ~fixpoint summary =
         fixpoint
         (Preflight.declaration_count summary))
 
-let run_segment ?cache ~ctx ~finalize (rules : rule list) =
+let run_segment ?cache ?(settle = Fun.id) ~ctx ~finalize (rules : rule list) =
   let key = Option.map (fun _ -> cache_key ~ctx rules) cache in
   match
     match (cache, key) with
@@ -203,17 +203,18 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
         if known_revert || not (should_run_preflight ~ctx summary) then begin
           Stats.skip_fixpoint stats;
           log_skip ~known_revert summary;
-          ordered_rules rules graph
+          settle (ordered_rules rules graph)
         end
         else begin
           let fixpoint = Stats.start_fixpoint stats in
-          let unfactored = ordered_rules rules graph in
-          let factored =
+          let unfactored = settle (ordered_rules rules graph) in
+          let optimized =
             optimize_graph ~ctx ~finalize ~fixpoint ~local_iteration:1 rules
               graph
           in
+          let factored = settle optimized in
           if
-            factored != rules
+            optimized != rules
             && factored_grows_transfer ~ctx ~unfactored ~factored
           then begin
             Stats.revert_fixpoint stats;
@@ -242,5 +243,5 @@ let run_segment ?cache ~ctx ~finalize (rules : rule list) =
    property by name (a [var()] consumer writes its own property, not the one it
    reads), so disjoint writes reorder freely and the whole list is one
    segment. *)
-let run ?cache ~ctx ~finalize (rules : rule list) =
-  run_segment ?cache ~ctx ~finalize rules
+let run ?cache ?settle ~ctx ~finalize (rules : rule list) =
+  run_segment ?cache ?settle ~ctx ~finalize rules

--- a/lib/factor.mli
+++ b/lib/factor.mli
@@ -10,8 +10,11 @@ val cache : unit -> cache
 
 val run :
   ?cache:cache ->
+  ?settle:(Stylesheet.rule list -> Stylesheet.rule list) ->
   ctx:Ctx.t ->
   finalize:(Stylesheet.rule -> Stylesheet.rule) ->
   Stylesheet.rule list ->
   Stylesheet.rule list
-(** Run the DAG-backed factor fixpoint. *)
+(** Run the DAG-backed factor fixpoint. [settle] (default identity) applies
+    cheap postprocessing to both sides of the transfer-size gate, so the gate
+    compares the actual alternatives returned to its caller. *)

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -98,8 +98,43 @@ let rec collect_rules (stmt_acc : statement list) (rules_acc : rule list) :
       collect_rules (stmt :: stmt_acc) (r :: rules_acc) rest
   | rest -> (List.rev stmt_acc, List.rev rules_acc, rest)
 
-let factor_rules_incremental ?cache ~ctx rules =
-  Factor.run ?cache ~ctx ~finalize:(finalize_rule_without_nested ~ctx) rules
+let factor_rules_incremental ?cache ~settle ~ctx rules =
+  Factor.run ?cache ~settle ~ctx
+    ~finalize:(finalize_rule_without_nested ~ctx)
+    rules
+
+(* Keep the cheap rule-local pipeline independent of the stylesheet-wide
+   factoring budget. [Rule.finalize] normalizes any shorthand it synthesizes, so
+   one linear preparation pass reaches the local fixed point even when a large
+   stylesheet limits the global walks. *)
+let normalize_rules_locally ~ctx rules =
+  list_map_preserve (single_rule_without_nested ~ctx) rules
+  |> Rule.drop_shadowed
+  |> list_map_preserve
+       (finalize_rule_without_nested ~canonicalize_selector:false ~ctx)
+
+let merge_adjacent_and_mark ~ctx invalidated rules =
+  let settled = Rule.merge_adjacent_identical ~ctx rules in
+  (* Each produced rule is fully normalized by the scheduler's finalizer. A node
+     merge is therefore the only settling step that changes the candidate graph
+     and requires another global walk. *)
+  if settled != rules then invalidated := settled :: !invalidated;
+  settled
+
+let factor_rules_until_settled ?factor_cache ~ctx rules =
+  let rec loop remaining rules =
+    let invalidated = ref [] in
+    let next =
+      factor_rules_incremental ?cache:factor_cache
+        ~settle:(merge_adjacent_and_mark ~ctx invalidated)
+        ~ctx rules
+    in
+    let needs_refactor =
+      List.exists (fun rules -> rules == next) !invalidated
+    in
+    if needs_refactor && remaining > 1 then loop (remaining - 1) next else next
+  in
+  loop 2 rules
 
 (* [@scope] bounds are parsed selectors; canonicalize them like any other
    selector so a list bound is de-duplicated and ordered consistently. *)
@@ -482,30 +517,27 @@ and rules_aux ?factor_cache ~ctx ~enforce_spec ~supports (rules : rule list) :
   in
   (* Apply local rule normalization before the DAG factor scheduler decides
      global selector/declaration grouping. *)
-  let prepared =
-    list_map_preserve (single_rule_without_nested ~ctx) with_optimized_nested
-  in
-  let prepared = Rule.drop_shadowed prepared in
-  let prepared =
-    list_map_preserve
-      (finalize_rule_without_nested ~canonicalize_selector:false ~ctx)
-      prepared
-  in
+  let prepared = normalize_rules_locally ~ctx with_optimized_nested in
   (* Factoring is greedy and global: extracting one shared declaration subset
      can leave behind leftovers that are themselves factorable. The local linear
      optimizations above always run; this incremental gate only decides whether
      the expensive global factoring fixpoint is likely to buy enough bytes to
      justify the full indexed scheduler walk. *)
   let factored =
-    if Ctx.regroup ctx then
-      factor_rules_incremental ?cache:factor_cache ~ctx prepared
-    else prepared
+    if Ctx.regroup ctx then begin
+      (* The global scheduler reaches a fixed point for the graph it receives,
+         but settling its result can merge nodes and expose a new graph. Repeat
+         only when that cheap postprocessing changed one of the transfer gate's
+         alternatives; most sheets still pay for one global walk. *)
+      factor_rules_until_settled ?factor_cache ~ctx prepared
+    end
+    else merge_adjacent_and_mark ~ctx (ref []) prepared
   in
   (* After factoring so the greedy scheduler sees the unconstrained input (a
      local pre-merge can lock a pair together and hide a larger group): this
      only picks up the merges factoring did not make because its preflight
      skipped the run or the transfer gate discarded its result. *)
-  Rule.merge_adjacent_identical ~ctx factored
+  factored
 
 (* CSS Animations 1 sec. 3: [@keyframes name] re-declaration overrides the
    earlier definition in source order. Drop earlier same-name keyframes; the

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4077,9 +4077,14 @@ let normalize_property_value : type a.
   | Display -> normalize_display value
   | Overflow -> normalize_overflow value
   | Transition -> map_preserve normalize_transition value
+  | Webkit_transition -> map_preserve normalize_transition value
+  | Moz_transition -> map_preserve normalize_transition value
+  | O_transition -> map_preserve normalize_transition value
   | List_style -> normalize_list_style value
   | Transition_timing_function -> normalize_timing_function value
   | Animation -> map_preserve normalize_animation value
+  | Webkit_animation -> map_preserve normalize_animation value
+  | Moz_animation -> map_preserve normalize_animation value
   | Animation_timing_function -> normalize_timing_function value
   | Padding_left -> Values.normalize_length ~ctx value
   | Padding_right -> Values.normalize_length ~ctx value

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -201,9 +201,14 @@ let declaration_run ~ctx decls =
   |> synthesize_columns |> synthesize_position_try |> preserve_list decls
 
 let finalize ?(canonicalize_selector = true) ~ctx (rule : rule) : rule =
+  let normalize_synthesized decl =
+    if List.memq decl rule.declarations then decl
+    else Declaration.normalize ~lossless:(Ctx.lossless ctx) decl
+  in
   let declarations =
     deduplicate_declarations_with ~ctx rule.declarations
     |> synthesize_columns |> synthesize_position_try
+    |> list_map_preserve normalize_synthesized
     |> sort_commuting ~selector:rule.selector
     |> preserve_list rule.declarations
   in

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -1584,7 +1584,6 @@ let single_selector_branch_key (rule : rule) : string option =
   | _ -> Option.None
 
 let selector_branch_size selector = Pp.size ~minify:true Selector.pp selector
-let selector_rank = Rule_graph.Node_id.to_int
 
 let add_single_selector_receivers receivers id rule =
   match single_selector_branch_key rule with
@@ -1644,11 +1643,11 @@ let seen_key receiver_id group_id branch_key =
        (Rule_graph.Node_id.to_int group_id))
     (hash_string branch_key)
 
-let add_selector_inline_candidate ?size_cache ?touching ~finalize g ~rank ~seen
+let add_selector_inline_candidate ?size_cache ?touching ~finalize g ~seen
     ~candidates ~receiver_id ~group_id ~branch_key ~remaining_selectors =
   if
     Rule_graph.Node_id.compare receiver_id group_id <> 0
-    && rank receiver_id < rank group_id
+    && Rule_graph.precedes g receiver_id group_id
     && (touches_node touching receiver_id || touches_node touching group_id)
   then
     match
@@ -1664,7 +1663,7 @@ let add_selector_inline_candidate ?size_cache ?touching ~finalize g ~rank ~seen
         end
 
 let selector_branch_inline_for_group ?size_cache ?touching ~finalize g
-    ~receivers ~rank ~seen ~candidates group_id group =
+    ~receivers ~seen ~candidates group_id group =
   if rule_eligible group && group.declarations <> [] then
     match selector_branches group with
     | [] | [ _ ] -> ()
@@ -1681,19 +1680,18 @@ let selector_branch_inline_for_group ?size_cache ?touching ~finalize g
               |> Option.value ~default:[]
               |> List.iter (fun receiver_id ->
                   add_selector_inline_candidate ?size_cache ?touching ~finalize
-                    g ~rank ~seen ~candidates ~receiver_id ~group_id ~branch_key
+                    g ~seen ~candidates ~receiver_id ~group_id ~branch_key
                     ~remaining_selectors))
           selectors
 
 let selector_branch_inline_candidates ?size_cache ?touching ~finalize g =
   let touching = touching_set touching in
   let receivers = single_selector_receivers g in
-  let rank = selector_rank in
   let seen_groups = Int_table.create 128 in
   let candidates = ref [] in
   List.iter
     (fun (group_id, group) ->
-      selector_branch_inline_for_group ?size_cache ~finalize g ~receivers ~rank
+      selector_branch_inline_for_group ?size_cache ~finalize g ~receivers
         ~seen:seen_groups ~candidates ?touching group_id group)
     (live_rules g);
   !candidates

--- a/lib/rule_scheduler.ml
+++ b/lib/rule_scheduler.ml
@@ -100,14 +100,12 @@ let affected_nodes graph (candidate : Rule_rewrite.candidate) =
   candidate.consume
   @ produced_ids ~first:first_produced ~count:(List.length candidate.produce)
 
-let run ~ctx ~finalize graph =
-  let max_iterations = max_iterations graph in
-  let refresh_after_commit = Rule_graph.node_count graph <= 128 in
-  let candidates_by_key = Hashtbl.create 256 in
-  let next_key, queue =
-    Rule_candidate.enumerate ~ctx ~finalize graph
-    |> enqueue candidates_by_key 0 Queue.empty
-  in
+let initial_queue ~ctx ~finalize graph candidates_by_key =
+  Rule_candidate.enumerate ~ctx ~finalize graph
+  |> enqueue candidates_by_key 0 Queue.empty
+
+let scheduler_loop ~max_iterations ~refresh_after_commit ~ctx ~finalize
+    candidates_by_key =
   let rec loop iteration refreshed graph next_key queue =
     if iteration >= max_iterations then graph
     else
@@ -149,4 +147,18 @@ let run ~ctx ~finalize graph =
                     loop (iteration + 1) false graph' next_key queue
                   else loop (iteration + 1) false graph' next_key queue))
   in
-  loop 0 false graph next_key queue
+  loop
+
+let run ~ctx ~finalize graph =
+  let candidates_by_key = Hashtbl.create 256 in
+  let next_key, queue = initial_queue ~ctx ~finalize graph candidates_by_key in
+  let loop =
+    scheduler_loop ~max_iterations:(max_iterations graph)
+      ~refresh_after_commit:(Rule_graph.node_count graph <= 128)
+      ~ctx ~finalize candidates_by_key
+  in
+  (* The initial queue was enumerated from this exact graph. If it is empty, or
+     every candidate is rejected without a rewrite, enumerating it again cannot
+     discover anything new. A committed rewrite marks the queue stale below and
+     still gets the usual drain-time refresh. *)
+  loop 0 true graph next_key queue

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1944,6 +1944,23 @@ let test_factoring_reaches_fixpoint () =
   Alcotest.(check string)
     "interacting factorings converge in one pass" once (minify_str once)
 
+let test_large_stylesheet_reaches_local_fixpoint () =
+  (* Large sheets deliberately limit the expensive global factoring walk, but
+     rule-local normalization must still converge. Composing these longhands
+     creates a shorthand whose explicit initial delay only disappears when the
+     synthesized declaration itself is normalized. *)
+  let padding =
+    List.init 129 (fun i -> Fmt.str ".padding-%d{z-index:%d}" i i)
+    |> String.concat ""
+  in
+  let input =
+    padding
+    ^ ".target{transition-property:opacity;transition-duration:70ms;transition-delay:0ms;transition-timing-function:linear}"
+  in
+  let once = minify_str input in
+  Alcotest.(check string)
+    "large-sheet local rewrites converge in one pass" once (minify_str once)
+
 let test_no_factor_across_conflict () =
   (* CSS Cascade 6.1: the two .x rules conflict on color, so they merge (last
      wins). The later .y carries the first .x's value, but grouping it with that
@@ -5060,6 +5077,9 @@ let selector_merging_tests =
     ( "factoring reaches fixpoint in one pass",
       `Quick,
       test_factoring_reaches_fixpoint );
+    ( "large stylesheet reaches local fixpoint",
+      `Quick,
+      test_large_stylesheet_reaches_local_fixpoint );
     ("no factor across conflict", `Quick, test_no_factor_across_conflict);
     ( "zero box side covered by shorthand",
       `Quick,

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1930,6 +1930,16 @@ let test_factor_interval_keeps_overrides () =
     (minify_str
        ".a{display:block;color:red}.b{display:block;color:blue}.a{display:block;color:red}.c{display:block;color:red}")
 
+let test_factor_selector_branch_keeps_later_override () =
+  (* Extracting the shared overflow/position declarations must not let the
+     earlier selector-list branch overwrite the later .scroll-item a z-index.
+     Only that branch is overridden; .scroll-pic-frame keeps z-index:100. *)
+  Alcotest.(check string)
+    "selector-list branch keeps its later override"
+    ".scroll-item a,.scroll-pic-frame,.scroll-pic-wrap{overflow:hidden;position:relative}.scroll-item a{border:1px solid#fff;display:block;height:162px;width:198px;z-index:50}.scroll-pic-frame{z-index:100}.scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}"
+    (minify_str
+       ".scroll-item a,.scroll-pic-frame{overflow:hidden;position:relative;z-index:100}.scroll-pic-wrap{overflow:hidden;position:relative}.scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}.scroll-item a{border:1px solid #fff;display:block;height:162px;width:198px;z-index:50}")
+
 let test_factoring_reaches_fixpoint () =
   (* Factoring one shared subset can expose another: grouping .a/.b on color:red
      leaves .b with padding:0, now groupable with .c. A correct optimizer
@@ -5090,6 +5100,9 @@ let selector_merging_tests =
     ("factor shared declarations", `Quick, test_factor_shared_declarations);
     ("factor weighted intervals", `Quick, test_factor_interval_schedule);
     ("factor interval overrides", `Quick, test_factor_interval_keeps_overrides);
+    ( "factor selector branch keeps later override",
+      `Quick,
+      test_factor_selector_branch_keeps_later_override );
     ( "factoring reaches fixpoint in one pass",
       `Quick,
       test_factoring_reaches_fixpoint );

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1936,7 +1936,7 @@ let test_factor_selector_branch_keeps_later_override () =
      Only that branch is overridden; .scroll-pic-frame keeps z-index:100. *)
   Alcotest.(check string)
     "selector-list branch keeps its later override"
-    ".scroll-item a,.scroll-pic-frame,.scroll-pic-wrap{overflow:hidden;position:relative}.scroll-item a{border:1px solid#fff;display:block;height:162px;width:198px;z-index:50}.scroll-pic-frame{z-index:100}.scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}"
+    ".scroll-item a,.scroll-pic-frame,.scroll-pic-wrap{overflow:hidden;position:relative}.scroll-item a,.scroll-pic-frame{z-index:100}.scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}.scroll-item a{border:1px solid#fff;display:block;height:162px;width:198px;z-index:50}"
     (minify_str
        ".scroll-item a,.scroll-pic-frame{overflow:hidden;position:relative;z-index:100}.scroll-pic-wrap{overflow:hidden;position:relative}.scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}.scroll-item a{border:1px solid #fff;display:block;height:162px;width:198px;z-index:50}")
 
@@ -1986,6 +1986,25 @@ let test_large_stylesheet_normalizes_vendor_aliases () =
   let once = minify_str input in
   Alcotest.(check string)
     "large-sheet aliases compare normalized values" once (minify_str once)
+
+let test_large_stylesheet_factoring_reaches_fixpoint () =
+  (* Large graphs refresh candidates in batches. The refreshed batch can itself
+     expose another profitable grouping, which must be enumerated before the
+     scheduler returns. Inert custom-property rules select the large-graph path
+     without participating in these factoring groups. *)
+  let padding =
+    List.init 129 (fun i ->
+        Fmt.str ".factor-padding-%d{--factor-padding-%d:0}" i i)
+    |> String.concat ""
+  in
+  let input =
+    padding
+    ^ ".scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}.scroll-item a{border:1px solid #fff;display:block;height:162px;overflow:hidden;position:relative;width:198px;z-index:50}.part-h-m{margin-right:20px;width:360px}.part-j-l,.part-j-m,.part-j-r{display:inline;float:left}.part-n-l,.part-n-m,.part-n-r{display:inline;float:left}.part-n-l{margin-right:20px;width:240px}.mod44-list{display:inline;float:right;margin-right:5px}.mod44-list li{display:inline;float:left;line-height:34px;height:34px;margin-right:5px}.mod-a .tab-nav-a a{border-left:0;float:left;line-height:23px;height:23px;padding:0}.mod-a .tab-nav-a span{border-left:0;float:left;line-height:23px;height:23px;padding:0 2px}"
+  in
+  let once = minify_str input in
+  Alcotest.(check string)
+    "large-sheet factoring converges in one scheduler run" once
+    (minify_str once)
 
 let test_no_factor_across_conflict () =
   (* CSS Cascade 6.1: the two .x rules conflict on color, so they merge (last
@@ -5112,6 +5131,9 @@ let selector_merging_tests =
     ( "large stylesheet normalizes vendor aliases",
       `Quick,
       test_large_stylesheet_normalizes_vendor_aliases );
+    ( "large stylesheet factoring reaches fixpoint",
+      `Quick,
+      test_large_stylesheet_factoring_reaches_fixpoint );
     ("no factor across conflict", `Quick, test_no_factor_across_conflict);
     ( "zero box side covered by shorthand",
       `Quick,

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1961,6 +1961,22 @@ let test_large_stylesheet_reaches_local_fixpoint () =
   Alcotest.(check string)
     "large-sheet local rewrites converge in one pass" once (minify_str once)
 
+let test_large_stylesheet_normalizes_vendor_aliases () =
+  (* Alias comparison must see the normalized typed values. Otherwise the
+     prefixed 250ms/500ms values differ structurally from the normalized .25s/
+     .5s unprefixed twins until the serialized output is parsed again. *)
+  let padding =
+    List.init 129 (fun i -> Fmt.str ".vendor-padding-%d{z-index:%d}" i i)
+    |> String.concat ""
+  in
+  let input =
+    padding
+    ^ ".target{-webkit-transition:opacity 250ms;transition:opacity 250ms;-webkit-animation:spin 500ms linear;animation:spin 500ms linear}"
+  in
+  let once = minify_str input in
+  Alcotest.(check string)
+    "large-sheet aliases compare normalized values" once (minify_str once)
+
 let test_no_factor_across_conflict () =
   (* CSS Cascade 6.1: the two .x rules conflict on color, so they merge (last
      wins). The later .y carries the first .x's value, but grouping it with that
@@ -5080,6 +5096,9 @@ let selector_merging_tests =
     ( "large stylesheet reaches local fixpoint",
       `Quick,
       test_large_stylesheet_reaches_local_fixpoint );
+    ( "large stylesheet normalizes vendor aliases",
+      `Quick,
+      test_large_stylesheet_normalizes_vendor_aliases );
     ("no factor across conflict", `Quick, test_no_factor_across_conflict);
     ( "zero box side covered by shorthand",
       `Quick,

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1936,9 +1936,15 @@ let test_factor_selector_branch_keeps_later_override () =
      Only that branch is overridden; .scroll-pic-frame keeps z-index:100. *)
   Alcotest.(check string)
     "selector-list branch keeps its later override"
-    ".scroll-item a,.scroll-pic-frame,.scroll-pic-wrap{overflow:hidden;position:relative}.scroll-item a,.scroll-pic-frame{z-index:100}.scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}.scroll-item a{border:1px solid#fff;display:block;height:162px;width:198px;z-index:50}"
+    ".scroll-item \
+     a,.scroll-pic-frame,.scroll-pic-wrap{overflow:hidden;position:relative}.scroll-item \
+     a,.scroll-pic-frame{z-index:100}.scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}.scroll-item \
+     a{border:1px solid#fff;display:block;height:162px;width:198px;z-index:50}"
     (minify_str
-       ".scroll-item a,.scroll-pic-frame{overflow:hidden;position:relative;z-index:100}.scroll-pic-wrap{overflow:hidden;position:relative}.scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}.scroll-item a{border:1px solid #fff;display:block;height:162px;width:198px;z-index:50}")
+       ".scroll-item \
+        a,.scroll-pic-frame{overflow:hidden;position:relative;z-index:100}.scroll-pic-wrap{overflow:hidden;position:relative}.scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}.scroll-item \
+        a{border:1px solid \
+        #fff;display:block;height:162px;width:198px;z-index:50}")
 
 let test_factoring_reaches_fixpoint () =
   (* Factoring one shared subset can expose another: grouping .a/.b on color:red
@@ -1981,7 +1987,8 @@ let test_large_stylesheet_normalizes_vendor_aliases () =
   in
   let input =
     padding
-    ^ ".target{-webkit-transition:opacity 250ms;transition:opacity 250ms;-webkit-animation:spin 500ms linear;animation:spin 500ms linear}"
+    ^ ".target{-webkit-transition:opacity 250ms;transition:opacity \
+       250ms;-webkit-animation:spin 500ms linear;animation:spin 500ms linear}"
   in
   let once = minify_str input in
   Alcotest.(check string)
@@ -1999,7 +2006,15 @@ let test_large_stylesheet_factoring_reaches_fixpoint () =
   in
   let input =
     padding
-    ^ ".scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}.scroll-item a{border:1px solid #fff;display:block;height:162px;overflow:hidden;position:relative;width:198px;z-index:50}.part-h-m{margin-right:20px;width:360px}.part-j-l,.part-j-m,.part-j-r{display:inline;float:left}.part-n-l,.part-n-m,.part-n-r{display:inline;float:left}.part-n-l{margin-right:20px;width:240px}.mod44-list{display:inline;float:right;margin-right:5px}.mod44-list li{display:inline;float:left;line-height:34px;height:34px;margin-right:5px}.mod-a .tab-nav-a a{border-left:0;float:left;line-height:23px;height:23px;padding:0}.mod-a .tab-nav-a span{border-left:0;float:left;line-height:23px;height:23px;padding:0 2px}"
+    ^ ".scroll-item{display:inline;float:left;height:164px;overflow:hidden;width:200px}.scroll-item \
+       a{border:1px solid \
+       #fff;display:block;height:162px;overflow:hidden;position:relative;width:198px;z-index:50}.part-h-m{margin-right:20px;width:360px}.part-j-l,.part-j-m,.part-j-r{display:inline;float:left}.part-n-l,.part-n-m,.part-n-r{display:inline;float:left}.part-n-l{margin-right:20px;width:240px}.mod44-list{display:inline;float:right;margin-right:5px}.mod44-list \
+       li{display:inline;float:left;line-height:34px;height:34px;margin-right:5px}.mod-a \
+       .tab-nav-a \
+       a{border-left:0;float:left;line-height:23px;height:23px;padding:0}.mod-a \
+       .tab-nav-a \
+       span{border-left:0;float:left;line-height:23px;height:23px;padding:0 \
+       2px}"
   in
   let once = minify_str input in
   Alcotest.(check string)


### PR DESCRIPTION
## Summary

- normalize freshly synthesized shorthands and prefixed transition/animation values before optimizer comparisons
- use graph precedence for selector-branch rewrites so later overrides remain later
- settle both transfer-size alternatives and retry factoring once only when adjacent merging changes the chosen graph
- avoid re-enumerating an unchanged scheduler graph and satisfy the current exit-code lint

## Verification

- opam exec -- dune build
- opam exec -- dune fmt
- opam exec -- dune test
- opam exec -- merlint --build (0 issues)
- 72 production sources minified twice and compared canonically: 72/72 stable
- 504-file SatCSS A/B: 100,218 fewer raw bytes and 10,718 fewer gzip bytes; four-worker CPU +12.8% for the conditional convergence retry