### PR TITLE
Optimize: add evergreen compatibility prefixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -510,7 +510,7 @@ difference wherever the two are not equivalent.
   `-webkit-backdrop-filter` declarations Safari 16.4 needs, and expands matching
   `@supports` tests to accept either spelling. `Css.optimize ~targets` exposes
   the Chrome, Firefox, Safari and iOS Safari versions that own these fallbacks;
-  an authored prefixed declaration remains authoritative.
+  an authored prefixed declaration remains authoritative (#751)
 - The README states the default minifier's evergreen target, colour tolerance,
   and CSSOM-visible normalisation beside its first example, and describes
   `--lossless --enforce-spec` as conservative rather than source-exact (#743)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -506,6 +506,11 @@ difference wherever the two are not equivalent.
   before comparison, factoring settles both transfer-size alternatives and
   retries once when settling changes its graph, and selector-branch factoring
   preserves source order after earlier rewrites (#750)
+- Default minification adds the `-webkit-user-select` and
+  `-webkit-backdrop-filter` declarations Safari 16.4 needs, and expands matching
+  `@supports` tests to accept either spelling. `Css.optimize ~targets` exposes
+  the Chrome, Firefox, Safari and iOS Safari versions that own these fallbacks;
+  an authored prefixed declaration remains authoritative.
 - The README states the default minifier's evergreen target, colour tolerance,
   and CSSOM-visible normalisation beside its first example, and describes
   `--lossless --enforce-spec` as conservative rather than source-exact (#743)

--- a/README.md
+++ b/README.md
@@ -445,18 +445,23 @@ an element can appear on, including one a script builds at runtime.
 
 ### Target browsers
 
-The default minify targets maintained evergreen browsers rendering an HTML
-document, and takes six facts from that target. The HTML direction model,
-where every element is either `ltr` or `rtl`, shortens `:not(:dir(ltr))` to
+The default minify targets Chrome 111, Firefox 128, Safari 16.4 and iOS Safari
+16.4 rendering an HTML document. The same record is public as
+`Css.Optimize.evergreen_targets`; library callers can pass a different
+`Css.Optimize.targets` record. The HTML direction model, where every element
+is either `ltr` or `rtl`, shortens `:not(:dir(ltr))` to
 `:dir(rtl)`. The HTML form-control model, which says an `input` is either
 `:enabled` or `:disabled`, shortens `input:not(:enabled)` to `input:disabled`.
 A vendor-prefixed declaration (`-moz-box-sizing`) whose unprefixed twin is
-present is dropped, since evergreen browsers understand the unprefixed form. A
-`min-`/`max-` media or container feature becomes the Media Queries 4 range
-grammar, `(min-width: 700px)` to `(width >= 700px)`. A nested selector loses
-its `&` prefix, `& div` to `div`, which the relaxed nesting syntax reads the
-same way. An `oklab` or `oklch` axis takes the percentage spelling wherever it
-is shorter, `oklch(.7 .304 20)` to `oklch(.7 76% 20)`.
+present is dropped, since evergreen browsers understand the unprefixed form.
+Conversely, the target adds `-webkit-user-select` and
+`-webkit-backdrop-filter` beside their standard declarations where Safari
+still needs them. A `min-`/`max-` media or container feature becomes the Media
+Queries 4 range grammar, `(min-width: 700px)` to `(width >= 700px)`. A nested
+selector loses its `&` prefix, `& div` to `div`, which the relaxed nesting
+syntax reads the same way. An `oklab` or `oklch` axis takes the percentage
+spelling wherever it is shorter, `oklch(.7 .304 20)` to
+`oklch(.7 76% 20)`.
 
 Each of those state pseudo-class pairs partitions a different set of elements,
 and outside its own set an element matches neither half, so the rewrite runs
@@ -473,10 +478,12 @@ serialisation, and holds the parser to the ident code points CSS Syntax 3 lists
 rather than reading anything above U+007F. That last one is the only part of the
 flag that acts without `--minify`.
 
-An `@supports` condition is not a target fact. CSS Conditional Rules 3 section
-6.1 defines support as the rendering browser accepting the declaration, down to
-a per-installation experimental-feature preference, so the author's guard is a
-question for that browser and both modes keep it.
+An `@supports` condition is never assumed true or false. CSS Conditional Rules
+3 section 6.1 defines support as the rendering browser accepting the
+declaration, down to a per-installation experimental-feature preference, so
+the author's guard remains a question for that browser. When a target requires
+a prefixed spelling, Cascade asks the equivalent disjunction, for example
+`(-webkit-backdrop-filter: ...) or (backdrop-filter: ...)`.
 
 ## CSS specification coverage
 
@@ -564,10 +571,11 @@ Output:
 Properties, values, and selectors are sealed OCaml ADTs, so invalid
 constructions are caught at compile time. Structural transforms (`fold`,
 `map`, `sort`, `flatten_nesting`), `Css.inline_imports`, and
-`Css.optimize ?flatten_nesting ?aggressive ?lossless ?enforce_spec ?scope` are
-the main entry points for AST-level work. Transforms that need information
-beyond CSS text take an explicit closed `Css.Context.t` rather than reading
-ambient runtime state.
+`Css.optimize ?targets ?flatten_nesting ?aggressive ?lossless ?enforce_spec
+?scope` is the main entry point for AST-level work. Transforms that need
+information beyond CSS text take an explicit context rather than reading
+ambient runtime state; `Css.Optimize.evergreen_targets` names the default
+browser contract.
 
 Structural diff lives in the separate `cascade.diff` sub-library
 (`Cascade_diff.Css_compare`, `Cascade_diff.Tree_diff`,

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -668,10 +668,10 @@ let inline_style_of_declarations ?(optimize = false) ?minify ?mode declarations
   in
   render_inline_style ?minify ?mode declarations
 
-let optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
-    ?regroup ?closed_world ?objective ?prune_unused_custom_props ?stats
-    stylesheet =
-  Optimize.stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec
+let optimize ?scope ?targets ?flatten_nesting ?lossless ?enforce_spec
+    ?aggressive ?regroup ?closed_world ?objective ?prune_unused_custom_props
+    ?stats stylesheet =
+  Optimize.stylesheet ?scope ?targets ?flatten_nesting ?lossless ?enforce_spec
     ?aggressive ?regroup ?closed_world ?objective ?prune_unused_custom_props
     ?stats stylesheet
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7874,6 +7874,7 @@ val canonicalize_rule_order : t -> t
 
 val optimize :
   ?scope:Optimize.scope ->
+  ?targets:Optimize.targets ->
   ?flatten_nesting:bool ->
   ?lossless:bool ->
   ?enforce_spec:bool ->
@@ -7885,16 +7886,19 @@ val optimize :
   ?stats:Stats.t ->
   t ->
   t
-(** [optimize ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
-     ?regroup ?closed_world ?objective ?prune_unused_custom_props ?stats
-     stylesheet] applies CSS optimizations to the stylesheet, including merging
-    consecutive identical selectors and combining rules with identical
+(** [optimize ?scope ?targets ?flatten_nesting ?lossless ?enforce_spec
+     ?aggressive ?regroup ?closed_world ?objective ?prune_unused_custom_props
+     ?stats stylesheet] applies CSS optimizations to the stylesheet, including
+    merging consecutive identical selectors and combining rules with identical
     properties. Preserves CSS cascade semantics for any DOM, unless
     [closed_world] is set.
 
     [scope] (default [`Fragment]) gates partial-coverage shorthand synthesis.
     Pass [`Stylesheet] when the caller controls the whole author stylesheet
     graph. See {!Optimize.scope} for the details.
+
+    [targets] defaults to {!Optimize.evergreen_targets} and owns compatibility
+    prefix generation. It is ignored when [enforce_spec] is [true].
 
     When [flatten_nesting] is [true] (default [false]) the optimizer also
     desugars nested rules into flat top-level rules; see {!Optimize.stylesheet}.

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -13,6 +13,22 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 type scope = Ctx.scope
 type objective = [ `Raw | `Transfer ]
+type browser_version = int * int
+
+type targets = {
+  chrome : browser_version;
+  firefox : browser_version;
+  safari : browser_version;
+  ios_safari : browser_version;
+}
+
+let evergreen_targets =
+  {
+    chrome = (111, 0);
+    firefox = (128, 0);
+    safari = (16, 4);
+    ios_safari = (16, 4);
+  }
 
 (* Optimisation context threaded from the entry points to the shorthand
    composers. [scope] drives fragment-vs-stylesheet decisions; [registered]
@@ -613,6 +629,176 @@ let flatten_nesting = Flatten.block
 
 (** {1 Stylesheet Optimization} *)
 
+type webkit_fallback = User_select_fallback | Backdrop_filter_fallback
+
+let version_compare (major_a, minor_a) (major_b, minor_b) =
+  match Int.compare major_a major_b with
+  | 0 -> Int.compare minor_a minor_b
+  | order -> order
+
+let version_at_most version maximum = version_compare version maximum <= 0
+
+(* The target contract is deliberately owned here rather than by the printer:
+   adding a fallback changes the AST and must therefore be explicit to API
+   callers. Safari/iOS still require [-webkit-user-select] at the declared
+   baseline, while unprefixed [backdrop-filter] arrived after 17.6. *)
+let required_fallback kind targets =
+  match kind with
+  | User_select_fallback -> true
+  | Backdrop_filter_fallback ->
+      version_at_most targets.safari (17, 6)
+      || version_at_most targets.ios_safari (17, 6)
+
+let webkit_fallback_of_declaration targets decl =
+  let fallback kind property value important =
+    if required_fallback kind targets then
+      Some (Declaration.v ~important property value)
+    else None
+  in
+  match decl with
+  | Declaration { property = User_select; value; important; _ } ->
+      fallback User_select_fallback Webkit_user_select value important
+  | Declaration { property = Backdrop_filter; value; important; _ } ->
+      fallback Backdrop_filter_fallback Webkit_backdrop_filter value important
+  | Declaration { property = Unknown_property name; value; important; _ }
+    when String.equal name "user-select" ->
+      fallback User_select_fallback (Unknown_property "-webkit-user-select")
+        value important
+  | Declaration { property = Unknown_property name; value; important; _ }
+    when String.equal name "backdrop-filter" ->
+      fallback Backdrop_filter_fallback
+        (Unknown_property "-webkit-backdrop-filter") value important
+  | Theme_guarded _ | Declaration _ -> None
+
+let is_webkit_fallback kind decl =
+  match (kind, decl) with
+  | User_select_fallback, Declaration { property = Webkit_user_select; _ }
+  | ( Backdrop_filter_fallback,
+      Declaration { property = Webkit_backdrop_filter; _ } ) ->
+      true
+  | User_select_fallback, Declaration { property = Unknown_property name; _ } ->
+      String.equal name "-webkit-user-select"
+  | ( Backdrop_filter_fallback,
+      Declaration { property = Unknown_property name; _ } ) ->
+      String.equal name "-webkit-backdrop-filter"
+  | _, (Theme_guarded _ | Declaration _) -> false
+
+let fallback_kind = function
+  | Declaration { property = User_select; _ } -> Some User_select_fallback
+  | Declaration { property = Backdrop_filter; _ } ->
+      Some Backdrop_filter_fallback
+  | Declaration { property = Unknown_property name; _ }
+    when String.equal name "user-select" ->
+      Some User_select_fallback
+  | Declaration { property = Unknown_property name; _ }
+    when String.equal name "backdrop-filter" ->
+      Some Backdrop_filter_fallback
+  | Theme_guarded _ | Declaration _ -> None
+
+(* Once an author supplied a prefix for a property, that spelling is theirs:
+   synthesising another value could change what WebKit sees. Otherwise mirror
+   every standard declaration so source-order fallback semantics stay intact. *)
+let add_declaration_prefixes ~targets decls =
+  let author_owns kind = List.exists (is_webkit_fallback kind) decls in
+  let rec loop changed acc = function
+    | [] -> if changed then List.rev acc else decls
+    | decl :: rest -> (
+        match fallback_kind decl with
+        | Some kind when not (author_owns kind) -> (
+            match webkit_fallback_of_declaration targets decl with
+            | Some prefixed -> loop true (decl :: prefixed :: acc) rest
+            | None -> loop changed (decl :: acc) rest)
+        | Some _ | None -> loop changed (decl :: acc) rest)
+  in
+  loop false [] decls
+
+let rec condition_has_webkit kind = function
+  | Supports.Property (Supports.Declaration decl) ->
+      is_webkit_fallback kind decl
+  | Supports.Property _ | Supports.Function _ -> false
+  | Supports.Not condition -> condition_has_webkit kind condition
+  | Supports.And (a, b) | Supports.Or (a, b) ->
+      condition_has_webkit kind a || condition_has_webkit kind b
+
+let add_condition_prefixes ~targets condition =
+  let author_owns kind = condition_has_webkit kind condition in
+  let rec map = function
+    | Supports.Property (Supports.Declaration decl) as original -> (
+        match fallback_kind decl with
+        | Some kind when not (author_owns kind) -> (
+            match webkit_fallback_of_declaration targets decl with
+            | Some prefixed ->
+                Supports.Or
+                  (Supports.Property (Supports.Declaration prefixed), original)
+            | None -> original)
+        | Some _ | None -> original)
+    | (Supports.Property _ | Supports.Function _) as leaf -> leaf
+    | Supports.Not condition as original ->
+        let condition' = map condition in
+        if condition' == condition then original else Supports.Not condition'
+    | Supports.And (a, b) as original ->
+        let a' = map a and b' = map b in
+        if a' == a && b' == b then original else Supports.And (a', b')
+    | Supports.Or (a, b) as original ->
+        let a' = map a and b' = map b in
+        if a' == a && b' == b then original else Supports.Or (a', b')
+  in
+  map condition
+
+let rec add_conditional_prefixes ~targets = function
+  | Media_condition _ as condition -> condition
+  | Supports_condition_test condition as original ->
+      let condition' = add_condition_prefixes ~targets condition in
+      if condition' == condition then original
+      else Supports_condition_test condition'
+  | And (a, b) as original ->
+      let a' = add_conditional_prefixes ~targets a
+      and b' = add_conditional_prefixes ~targets b in
+      if a' == a && b' == b then original else And (a', b')
+  | Or (a, b) as original ->
+      let a' = add_conditional_prefixes ~targets a
+      and b' = add_conditional_prefixes ~targets b in
+      if a' == a && b' == b then original else Or (a', b')
+
+let compatibility_declaration_sites =
+  {
+    element_rule = true;
+    animation_frame = true;
+    page_box = true;
+    position_fallback = true;
+    condition_test = false;
+  }
+
+let add_compatibility_prefixes ~targets stylesheet =
+  let rewrite original =
+    let stmt =
+      match original with
+      | Supports (condition, body) ->
+          let condition' = add_condition_prefixes ~targets condition in
+          if condition' == condition then original
+          else Supports (condition', body)
+      | Import ({ supports = Some condition; _ } as rule) ->
+          let condition' = add_condition_prefixes ~targets condition in
+          if condition' == condition then original
+          else Import { rule with supports = Some condition' }
+      | When (condition, body) ->
+          let condition' = add_conditional_prefixes ~targets condition in
+          if condition' == condition then original else When (condition', body)
+      | Else (Some condition, body) ->
+          let condition' = add_conditional_prefixes ~targets condition in
+          if condition' == condition then original
+          else Else (Some condition', body)
+      | _ -> original
+    in
+    let stmt =
+      if at_declaration_site compatibility_declaration_sites stmt then
+        map_statement_declarations (add_declaration_prefixes ~targets) stmt
+      else stmt
+    in
+    if stmt == original then Keep else Replace stmt
+  in
+  edit_statements rewrite stylesheet
+
 (* A WebKit workaround is a property of the declaration, so it applies wherever
    the declaration sits. *)
 let apply_property_duplication (stylesheet : t) : t =
@@ -958,9 +1144,9 @@ let drop_unused_custom_props (stmts : statement list) : statement list =
   in
   list_map_preserve prune stmts
 
-let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
-    ?(enforce_spec = false) ?(aggressive = false) ?(regroup = true)
-    ?(closed_world = false) ?(objective = `Transfer)
+let stylesheet ?scope ?(targets = evergreen_targets) ?(flatten_nesting = false)
+    ?(lossless = false) ?(enforce_spec = false) ?(aggressive = false)
+    ?(regroup = true) ?(closed_world = false) ?(objective = `Transfer)
     ?(prune_unused_custom_props = false) ?stats (stylesheet : t) : t =
   let scope = Option.value scope ~default:`Fragment in
   let ctx = single_valued_calc_ctx stylesheet in
@@ -988,6 +1174,9 @@ let stylesheet ?scope ?(flatten_nesting = false) ?(lossless = false)
   let result =
     if prune_unused_custom_props then drop_unused_custom_props result
     else result
+  in
+  let result =
+    if enforce_spec then result else add_compatibility_prefixes ~targets result
   in
   Log.debug (fun m ->
       let c = (Stats.snapshot (Ctx.stats ctx)).counters in

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -27,6 +27,21 @@ type objective = [ `Raw | `Transfer ]
 (** The size objective for global factoring. [`Raw] keeps raw-byte wins;
     [`Transfer] rejects a result that grows the estimated DEFLATE size. *)
 
+type browser_version = int * int
+
+type targets = {
+  chrome : browser_version;
+  firefox : browser_version;
+  safari : browser_version;
+  ios_safari : browser_version;
+}
+(** Browser versions whose compatibility fallbacks an optimization run owns.
+    Versions are [(major, minor)]. *)
+
+val evergreen_targets : targets
+(** The default compatibility contract: Chrome 111, Firefox 128, Safari 16.4,
+    and iOS Safari 16.4. *)
+
 (** {1 Declaration Optimization} *)
 
 val duplicate_buggy_properties : declaration list -> declaration list
@@ -232,8 +247,15 @@ val apply_property_duplication : t -> t
 (** [apply_property_duplication ss] applies only property duplication for
     browser compatibility without other optimizations. *)
 
+val add_compatibility_prefixes : targets:targets -> t -> t
+(** [add_compatibility_prefixes ~targets ss] adds the vendor-prefixed
+    declarations and feature-query alternatives required by [targets]. An
+    authored prefixed property owns its fallback and is never supplemented. The
+    transform is idempotent. *)
+
 val stylesheet :
   ?scope:scope ->
+  ?targets:targets ->
   ?flatten_nesting:bool ->
   ?lossless:bool ->
   ?enforce_spec:bool ->
@@ -245,19 +267,22 @@ val stylesheet :
   ?stats:Stats.t ->
   t ->
   t
-(** [stylesheet ?scope ?flatten_nesting ?lossless ?enforce_spec ?aggressive
-     ?regroup ?closed_world ?objective ?prune_unused_custom_props ?stats ss]
-    optimizes an entire stylesheet while preserving cascade semantics for any
-    DOM (with [closed_world] off, the default). When [@supports] blocks are
-    present alongside top-level rules, optimization is limited because the
-    stylesheet structure separates rules from [@supports] blocks, losing their
-    relative ordering.
+(** [stylesheet ?scope ?targets ?flatten_nesting ?lossless ?enforce_spec
+     ?aggressive ?regroup ?closed_world ?objective ?prune_unused_custom_props
+     ?stats ss] optimizes an entire stylesheet while preserving cascade
+    semantics for any DOM (with [closed_world] off, the default). When
+    [@supports] blocks are present alongside top-level rules, optimization is
+    limited because the stylesheet structure separates rules from [@supports]
+    blocks, losing their relative ordering.
 
     When [flatten_nesting] is [true] (default [false]) nested rules are
     desugared into flat rules: child selectors with [&] have the parent selector
     substituted in, child selectors without [&] are joined to the parent with
     the descendant combinator, and at-rules nested inside a rule are emitted at
     the top level with the parent selector applied to their inner rules.
+
+    [targets] defaults to {!evergreen_targets} and owns compatibility-prefix
+    generation. It is ignored when [enforce_spec] is [true].
 
     [scope] (default [`Fragment]) gates partial-coverage shorthand synthesis;
     see the {!scope} doc.

--- a/test/interop/lightning/test.ml
+++ b/test/interop/lightning/test.ml
@@ -5,8 +5,9 @@
     expected value is one candidate oracle answer. During [@@regen-traces], the
     configured minifier CLIs are run over the same input and their outputs or
     crashes are cached in the trace. Normal test runs never shell out to oracle
-    tools: Cascade passes if its output is no longer than the shortest valid
-    cached candidate.
+    tools: each valid cached candidate receives Cascade's declared target
+    prefixes, then Cascade passes if its output is no longer than the shortest
+    adjusted candidate.
 
     Each trace record is treated as a complete stylesheet, matching the way the
     upstream minifier CLIs see the input: closed over the fixture CSS text for
@@ -106,6 +107,18 @@ let shortest_length (candidates : candidate list) =
   List.fold_left
     (fun acc ({ css; _ } : candidate) -> min acc (String.length css))
     max_int candidates
+
+let add_declared_target_prefixes ({ tool; css } : candidate) =
+  match Css.of_string ~strict:false css with
+  | Error _ -> { tool; css }
+  | Ok parsed ->
+      let css =
+        parsed.stylesheet
+        |> Css.Optimize.add_compatibility_prefixes
+             ~targets:Css.Optimize.evergreen_targets
+        |> Css.to_string ~minify:true
+      in
+      { tool; css }
 
 let canonical_minified css =
   if css = "" then Ok ""
@@ -416,7 +429,15 @@ let classify (pair : Trace_pairs.t) =
         List.map (fun issue -> Rejected_candidate issue) rejected
         @ List.map (fun issue -> Failed_candidate issue) pair.failures
       in
-      let best = shortest_length candidates in
+      (* The cached CLIs ran without browser targets, while Cascade's default
+         optimizer owns a concrete browser baseline. Compare byte counts only
+         after applying that one public target transform to each accepted
+         candidate; running Cascade's whole optimizer here would turn this
+         arbitrage check into a comparison against itself. *)
+      let scored_candidates =
+        List.map add_declared_target_prefixes candidates
+      in
+      let best = shortest_length scored_candidates in
       (* Neither measure below can see a construct Cascade deletes. Length
          scoring cannot: a deletion always reads as a shorter output.
          [validate_candidate] cannot either, because it routes the source and
@@ -447,7 +468,7 @@ let classify (pair : Trace_pairs.t) =
         else if String.length actual <= best then Pass
         else
           let shortest =
-            candidates
+            scored_candidates
             |> List.filter (fun (c : candidate) -> String.length c.css = best)
             |> List.map (fun (c : candidate) ->
                 c.tool ^ ":" ^ display_css c.css)

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1790,9 +1790,9 @@ let optimize_tests =
 
 (** {1 Selector merging tests (cascade semantics)} *)
 
-let optimized_string ?scope ?(enforce_spec = false) css =
+let optimized_string ?scope ?targets ?(enforce_spec = false) css =
   css |> Cursor.of_string |> Css.Stylesheet.read
-  |> Css.Optimize.stylesheet ?scope ~enforce_spec
+  |> Css.Optimize.stylesheet ?scope ?targets ~enforce_spec
   |> Css.Stylesheet.to_string ~minify:true ~enforce_spec
   |> String.trim
 
@@ -3255,8 +3255,8 @@ let target_evergreen_compatibility_prefixes () =
     (optimized_string ".a{user-select:none!important}");
   Alcotest.(check string)
     "the declared target prefixes feature tests and their declarations"
-    "@supports ((-webkit-backdrop-filter:var(--tw)) or \
-     (backdrop-filter:var(--tw))){.a{-webkit-backdrop-filter:var(--tw);backdrop-filter:var(--tw)}}"
+    "@supports(-webkit-backdrop-filter:var(--tw))or \
+     (backdrop-filter:var(--tw)){.a{-webkit-backdrop-filter:var(--tw);backdrop-filter:var(--tw)}}"
     (optimized_string
        "@supports(backdrop-filter:var(--tw)){.a{backdrop-filter:var(--tw)}}");
   Alcotest.(check string)
@@ -3273,6 +3273,18 @@ let target_evergreen_compatibility_prefixes () =
     "spec-only mode does not synthesize target fallbacks"
     ".a{user-select:none;backdrop-filter:blur(1px)}"
     (optimized_string ~enforce_spec:true
+       ".a{user-select:none;backdrop-filter:blur(1px)}");
+  let newer_webkit =
+    {
+      Css.Optimize.evergreen_targets with
+      safari = (18, 0);
+      ios_safari = (18, 0);
+    }
+  in
+  Alcotest.(check string)
+    "a newer WebKit target drops only the obsolete fallback"
+    ".a{-webkit-user-select:none;user-select:none;backdrop-filter:blur(1px)}"
+    (optimized_string ~targets:newer_webkit
        ".a{user-select:none;backdrop-filter:blur(1px)}")
 
 let c61_no_layer_media_merge () =

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -3244,6 +3244,37 @@ let target_minify_enforce_spec_split () =
     ~default:"@container sidebar (width>=700px){a{color:red}}"
     ~spec:"@container sidebar (min-width:700px){a{color:red}}"
 
+let target_evergreen_compatibility_prefixes () =
+  Alcotest.(check string)
+    "the declared target adds WebKit declaration fallbacks"
+    ".a{-webkit-user-select:none;user-select:none;-webkit-backdrop-filter:blur(1px);backdrop-filter:blur(1px)}"
+    (optimized_string ".a{user-select:none;backdrop-filter:blur(1px)}");
+  Alcotest.(check string)
+    "the declaration fallback preserves importance"
+    ".a{-webkit-user-select:none!important;user-select:none!important}"
+    (optimized_string ".a{user-select:none!important}");
+  Alcotest.(check string)
+    "the declared target prefixes feature tests and their declarations"
+    "@supports ((-webkit-backdrop-filter:var(--tw)) or \
+     (backdrop-filter:var(--tw))){.a{-webkit-backdrop-filter:var(--tw);backdrop-filter:var(--tw)}}"
+    (optimized_string
+       "@supports(backdrop-filter:var(--tw)){.a{backdrop-filter:var(--tw)}}");
+  Alcotest.(check string)
+    "an authored fallback is not duplicated"
+    ".a{-webkit-backdrop-filter:blur(1px);backdrop-filter:blur(1px)}"
+    (optimized_string
+       ".a{-webkit-backdrop-filter:blur(1px);backdrop-filter:blur(1px)}");
+  Alcotest.(check string)
+    "decoration color needs no prefix for the declared target"
+    ".prose a{text-decoration:underline;text-decoration-color:var(--c)}"
+    (optimized_string
+       ".prose{a{text-decoration:underline;text-decoration-color:var(--c)}}");
+  Alcotest.(check string)
+    "spec-only mode does not synthesize target fallbacks"
+    ".a{user-select:none;backdrop-filter:blur(1px)}"
+    (optimized_string ~enforce_spec:true
+       ".a{user-select:none;backdrop-filter:blur(1px)}")
+
 let c61_no_layer_media_merge () =
   (* CSS Cascade section 6.4.4.2: a layer statement between matching media
      queries still establishes layer order at that point. Media-query merging
@@ -5263,6 +5294,9 @@ let selector_merging_tests =
     ( "target minify and enforce-spec split",
       `Quick,
       target_minify_enforce_spec_split );
+    ( "target evergreen compatibility prefixes",
+      `Quick,
+      target_evergreen_compatibility_prefixes );
     ( "a nested block keeps its declaration separator",
       `Quick,
       nested_block_separator );


### PR DESCRIPTION
Add the WebKit declaration and feature-query fallbacks required by the declared Chrome 111, Firefox 128, Safari/iOS 16.4 target, with explicit public target ownership and authored-prefix precedence. Keep minifier-oracle size comparisons target-aligned and pin the behavior with focused regression tests.