### PR TITLE
Diff: pair repeated selectors by declarations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -889,6 +889,10 @@ difference wherever the two are not equivalent.
 - `--diff=tree` prints the body of an added or removed rule as declarations,
   with the separator and the `!important` flag, where a rule gaining
   `color: red !important` read like one gaining `color: red` (#706)
+- `--diff=tree` pairs repeated occurrences of one selector by their declaration
+  properties, with source order breaking ties, so a compatibility block no
+  longer makes declarations present on both sides read as added or removed
+  (#752)
 
 ### Library
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1428,6 +1428,14 @@ let build_rule_lookup_tables rules2 =
       in
       Hashtbl.replace rules2_by_props props (r :: existing_props))
     rules2;
+  (* Buckets were built by prepending. Put them back in source order so every
+     equal-quality choice below has a stable positional tie-break. *)
+  Hashtbl.iter
+    (fun key rules -> Hashtbl.replace rules2_by_key key (List.rev rules))
+    rules2_by_key;
+  Hashtbl.iter
+    (fun props rules -> Hashtbl.replace rules2_by_props props (List.rev rules))
+    rules2_by_props;
   (rules2_by_key, rules2_by_props)
 
 (* A rule paired with its partner on the other side: the two selectors and the
@@ -1470,10 +1478,47 @@ let try_exact_match ~moved rules2_by_key used_rules r1 key1 d1 =
       else Some Same
   | None -> None
 
-(* Try to find any rule with the same selector key *)
+(* The multiset of properties a rule writes. Values are deliberately absent: two
+   repeated occurrences that both write [color] stay tied and source order
+   exposes a changed last winner instead of pairing equal values across the
+   sheet. Repeated properties remain repeated in the footprint. *)
+let declaration_footprint declarations =
+  List.map Css.declaration_name declarations |> List.sort String.compare
+
+(* The size of the symmetric multiset difference between two sorted declaration
+   footprints. *)
+let rec footprint_distance one other =
+  match (one, other) with
+  | [], rest | rest, [] -> List.length rest
+  | name1 :: rest1, name2 :: rest2 ->
+      let order = String.compare name1 name2 in
+      if order = 0 then footprint_distance rest1 rest2
+      else if order < 0 then 1 + footprint_distance rest1 other
+      else 1 + footprint_distance one rest2
+
+(* Find the unused same-key rule with the closest declaration footprint. Buckets
+   and this fold are in source order, so the earlier occurrence wins a tie. *)
 let try_same_key_match rules2_by_key used_rules r1 key1 d1 =
   let candidates = try Hashtbl.find rules2_by_key key1 with Not_found -> [] in
-  match List.find_opt (fun r -> not (Hashtbl.mem used_rules r)) candidates with
+  let footprint1 = declaration_footprint d1 in
+  let closest =
+    List.fold_left
+      (fun best r ->
+        if Hashtbl.mem used_rules r then best
+        else
+          let distance =
+            footprint_distance footprint1
+              (declaration_footprint (rule_declarations r))
+          in
+          match best with
+          | None -> Some (distance, r)
+          | Some (best_distance, _) when distance < best_distance ->
+              Some (distance, r)
+          | Some _ -> best)
+      None candidates
+    |> Option.map snd
+  in
+  match closest with
   | Some r2 ->
       Hashtbl.replace used_rules r2 ();
       let d2 = rule_declarations r2 in

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -1057,6 +1057,44 @@ let repeated_property_surplus_is_added () =
     [ ("color", "blue") ]
     (rule_added_properties d)
 
+(* One side may split a selector's declarations around a compatibility
+   container. Pairing repeated selectors by bucket order binds the combined rule
+   to the trailing padding-only occurrence and invents two declaration losses.
+   The closest declaration footprint is the rule before [@supports]. *)
+let repeated_selector_pairs_by_declaration_similarity () =
+  let d =
+    diff_of
+      ~expected:
+        ":root{--c:#364153}.a{position:fixed;color:color-mix(in oklab,var(--c) \
+         25%,transparent);padding:1px}"
+      ~actual:
+        ":root{--c:#364153}.a{position:fixed;color:#36415340}@supports(color:color-mix(in \
+         lab,red,red)){.a{color:color-mix(in oklab,var(--c) \
+         25%,transparent)}}.a{padding:1px}"
+  in
+  let out = render d in
+  Alcotest.(check bool)
+    "position survives" false
+    (Astring.String.is_infix ~affix:"- position: fixed" out);
+  Alcotest.(check bool)
+    "padding survives" false
+    (Astring.String.is_infix ~affix:"+ padding: 1px" out);
+  Alcotest.(check bool)
+    "the compatibility color is still reported" true
+    (Astring.String.is_infix ~affix:"color" out)
+
+(* Values do not make two occurrence footprints more similar. Otherwise these
+   exact values pair across source positions and hide the changed last
+   winner. *)
+let repeated_selector_value_swap_remains_visible () =
+  let d =
+    diff_of ~expected:".a{color:red}.a{color:blue}"
+      ~actual:".a{color:blue}.a{color:red}"
+  in
+  Alcotest.(check bool)
+    "the last-wins change is reported" false
+    (Cascade_diff.Tree_diff.is_empty d)
+
 (* ===== Containers nested past the old recursion cutoff ===== *)
 
 (* The walker recurses on strictly smaller statement lists, so nothing needs a
@@ -1591,6 +1629,10 @@ let suite =
         repeated_property_surplus_is_removed;
       Alcotest.test_case "repeated property surplus is added" `Quick
         repeated_property_surplus_is_added;
+      Alcotest.test_case "repeated selector pairs by declaration similarity"
+        `Quick repeated_selector_pairs_by_declaration_similarity;
+      Alcotest.test_case "repeated selector value swap remains visible" `Quick
+        repeated_selector_value_swap_remains_visible;
       Alcotest.test_case "deeply nested leaf change reported" `Quick
         deeply_nested_leaf_change_reported;
       Alcotest.test_case "deeply nested leaf change named" `Quick


### PR DESCRIPTION
Pair repeated-selector occurrences by their declaration-property footprint, using source order to break ties. This keeps compatibility wrappers from inventing unrelated declaration losses while preserving last-wins value changes.