### PR TITLE
Diff: define exact numeric canonicalization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -840,6 +840,10 @@ difference wherever the two are not equivalent.
 
 ### Canonical diff
 
+- Numeric arithmetic has zero approximation tolerance in canonical mode:
+  `calc(28/14)` compares equal to `2`, while `calc(28/18)` stays distinct from
+  a rounded decimal in both default and `--lossless` modes. The default
+  approximation budget remains colour-only (#753)
 - `:is(a, b)` and the selector list `a, b` compare equal when the arguments
   share one specificity, which is the split-against-grouped selector list the
   mode promises to equate (#655)

--- a/README.md
+++ b/README.md
@@ -159,12 +159,16 @@ usable as a CI check.
   Cascade-significant order is kept distinct (two writes of the same
   property, a shorthand and its longhand, a vendor-prefixed alias, `@layer`
   blocks). Equivalent shorthand decompositions are still not modelled.
+  Numeric arithmetic has zero approximation tolerance in both default and
+  `--lossless` modes: an exact quotient such as `calc(28/14)` compares equal to
+  `2`, while `calc(28/18)` remains distinct from every finite decimal spelling.
+  The default mode's bounded approximation applies only to colours.
 
 | Flag | Purpose |
 |---|---|
 | `--diff=MODE` | What counts as "no difference": `auto` (default), `tree`, `string` or `canonical`, as above. |
 | `--depth=auto\|max\|N` | How many levels of the difference tree to print. `auto` (default) prints it whole while it stays short, then falls back to the deepest level that fits; `max` always prints it whole; an integer pins a level. A cut subtree carries the number of lines hidden. |
-| `--lossless` | Disable colour approximation in the `--diff=canonical` canonicalisation, so two sheets that differ only by a fold within the approximation budget report as different rather than equal. Has no effect outside `--diff=canonical`. |
+| `--lossless` | Disable colour approximation in the `--diff=canonical` canonicalisation, so two sheets that differ only by a fold within the approximation budget report as different rather than equal. Numeric arithmetic is exact with or without this flag. Has no effect outside `--diff=canonical`. |
 | `--prune-unused-custom-props` | Drop the custom-property bindings nothing references, on both sides, before comparing under `--diff=canonical`, so two sheets that differ only by a dead binding compare equal. The comparison is then blind to dead-custom-property divergences. Has no effect outside `--diff=canonical`. |
 | `--color=WHEN` | `auto` (default), `always` or `never`. `CASCADE_COLOR` sets the same thing; `NO_COLOR` overrides both. |
 | `-q, --quiet` / `-v, --verbose` | Standard verbosity controls. |

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -232,7 +232,8 @@ let lossless_arg =
      and color-mix() values stay functional and channels keep their full \
      precision. Two stylesheets that only differ by colours folded within the \
      approximation budget then report as different rather than collapsing to \
-     equal. Has no effect outside $(b,--diff=canonical)."
+     equal. Numeric arithmetic is exact with or without this flag. Has no \
+     effect outside $(b,--diff=canonical)."
   in
   Arg.(value & flag & info [ "lossless" ] ~doc)
 

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -78,9 +78,11 @@ type mode = [ `Auto | `Tree | `String | `Canonical ]
     - [`Canonical] -- parse both stylesheets, serialize optimized minified
       outputs, and compare those outputs. This includes value spellings that
       Cascade canonicalizes as equivalent, such as [transparent] and [#0000] in
-      color positions. Equal outputs are {!No_diff}; differing outputs are a
-      difference, reported as a tree diff of the two when the walk reaches it
-      and as a string diff of them when it does not.
+      color positions. Numeric arithmetic only folds exactly: [calc(28/14)] and
+      [2] agree, while [calc(28/18)] does not agree with a rounded decimal in
+      either setting of [lossless]. Equal outputs are {!No_diff}; differing
+      outputs are a difference, reported as a tree diff of the two when the walk
+      reaches it and as a string diff of them when it does not.
 
     The projection runs no rewrite whose applicability depends on the order the
     input happens to put its rules in. Factoring shared declarations into a
@@ -103,7 +105,8 @@ val diff :
 (** [diff ?mode expected actual] returns the diff between two CSS strings. A
     leading [/*! ... */] tool banner on either side is stripped before
     comparison. Parsing failures surface as [_error] variants. [lossless]
-    preserves exact color channels during canonical comparison.
+    preserves exact color channels during canonical comparison; numeric
+    arithmetic is exact whether it is set or not.
 
     [prune_unused_custom_props] (default [false], [`Canonical] mode only) drops
     custom-property bindings referenced by nothing on both sides before

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -226,6 +226,28 @@ let equal_canonical_lossless_exact_srgb () =
     "an off-grid channel keeps its function" false
     (equal ".a{color:color(srgb .501 0 0)}" ".a{color:maroon}")
 
+(* Numeric CSS has no property-independent error metric: an approximation can be
+   multiplied by layout, iteration, or a runtime substitution. Canonical
+   comparison therefore shares the optimizer's exact-division contract rather
+   than extending the deliberately colour-only [--lossless] switch. *)
+let canonical_numeric_division_is_exact () =
+  let equal ?(lossless = false) a b =
+    Cascade_diff.Css_compare.equal ~mode:`Canonical ~lossless a b
+  in
+  Alcotest.(check bool)
+    "an exact quotient folds" true
+    (equal ".a{line-height:calc(28/14)}" ".a{line-height:2}");
+  Alcotest.(check bool)
+    "six significant digits are still an approximation" false
+    (equal ".a{line-height:calc(28/18)}" ".a{line-height:1.55556}");
+  Alcotest.(check bool)
+    "even the nearest emitted decimal is outside zero tolerance" false
+    (equal ".a{line-height:calc(28/18)}" ".a{line-height:1.55555556}");
+  Alcotest.(check bool)
+    "lossless keeps the same exact numeric boundary" false
+    (equal ~lossless:true ".a{line-height:calc(28/18)}"
+       ".a{line-height:1.55556}")
+
 (* CSS Nesting 1 sec. 3.4 keeps a declaration written after a nested rule where
    the author wrote it, which only matters for a property the nested rule also
    sets. Where nothing clashes across the boundary the two spellings compute the
@@ -1578,4 +1600,6 @@ let suite =
         canonical_folds_media_range_spellings;
       Alcotest.test_case "canonical lossless equates exact srgb spellings"
         `Quick equal_canonical_lossless_exact_srgb;
+      Alcotest.test_case "canonical numeric division is exact" `Quick
+        canonical_numeric_division_is_exact;
     ] )


### PR DESCRIPTION
Define numeric arithmetic as exact under canonical comparison in both default and lossless modes; bounded approximation remains colour-only. Add exact-quotient and nearest-decimal boundary tests, and document the contract in the README, API, and CLI help.