### PR TITLE
Preserve precision in sRGB colour mixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -501,6 +501,9 @@ difference wherever the two are not equivalent.
 
 ### Minification
 
+- `--minify` converts modern colour operands to floating-point sRGB before
+  resolving an `in srgb` `color-mix()`, so channel bytes are rounded once after
+  interpolation instead of once per operand and again afterward (#755)
 - `--minify` reaches a stable result in one invocation on large stylesheets:
   synthesized shorthands and vendor transition/animation aliases normalize
   before comparison, factoring settles both transfer-size alternatives and

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -3241,33 +3241,11 @@ let static_color_to_linear_srgb (c : color) :
           Some (lin, f255 a)
       | None -> None)
 
-(* Resolve a static colour to its in-gamut sRGB [Hex] form so a [color-mix(in
-   srgb, ...)] over a modern-space argument ([oklch] / [lab] / ...) folds in a
-   single pass: [mix_srgb_bytes] only understands sRGB-family inputs, while the
-   modern spaces resolve through [static_color_to_linear_srgb]. Leaves the
-   colour unchanged when it is already sRGB-foldable, resolves out of gamut, or
-   isn't static. *)
-let resolve_static_srgb (c : color) : color =
-  match static_color_to_srgb_channels c with
-  | Some _ -> c
-  | None -> (
-      match static_color_to_linear_srgb c with
-      | Some (linear, alpha_f) -> (
-          match Color_space.srgb_bytes_of_linear linear with
-          | Some (r, g, b) ->
-              let clamp01 v = Float.max 0. (Float.min 1. v) in
-              let a_byte =
-                Float.to_int (Float.round (clamp01 alpha_f *. 255.))
-              in
-              Hex { r; g; b; a = a_byte }
-          | None -> c)
-      | None -> c)
-
 (* CSS Color 4 sec. 14.2: the sRGB colour a display renders for a static colour,
-   gamut mapping the ones sRGB cannot hold. Unlike [resolve_static_srgb] this
-   always answers, so it serves a caller that has to write an sRGB colour; the
-   optimizer must not use it, as the mapped colour is not the authored one. A
-   colour that is not static is returned unchanged. *)
+   gamut mapping the ones sRGB cannot hold. This always answers, so it serves a
+   caller that has to write an sRGB colour; the optimizer must not use it, as
+   the mapped colour is not the authored one. A colour that is not static is
+   returned unchanged. *)
 let gamut_map_color (c : color) : color =
   match static_color_to_linear_srgb c with
   | None -> c
@@ -7692,17 +7670,46 @@ let normalize_named_color c orig_name =
   | _ -> if name == orig_name then c else Named name
 
 let normalize_srgb_mix color1 color2 ~p1 ~p2 =
-  match
-    mix_srgb_bytes
-      (resolve_static_srgb color1)
-      (resolve_static_srgb color2)
-      ~p1 ~p2
-  with
-  | Some (r, g, b, a) -> Some (canonical_color_of_hex r g b a)
-  (* The byte mixer only speaks sRGB bytes, so it declines a mix whose operands
-     or result leave the sRGB gamut. The result is a colour all the same, and
-     [color(srgb ...)] can hold it. *)
-  | Option.None -> mix_in_rectangular_space Srgb color1 color2 ~p1 ~p2
+  let srgb_operand color =
+    match static_color_to_srgb_channels color with
+    | Some (Some r, Some g, Some b, Some a) ->
+        let unit byte = Float.of_int byte /. 255. in
+        Some ((unit r, unit g, unit b), unit a)
+    | Some _ -> None
+    | None ->
+        Option.map
+          (fun (linear, alpha) -> (Color_space.rgb_of_linear_rgb linear, alpha))
+          (static_color_to_linear_srgb color)
+  in
+  match (srgb_operand color1, srgb_operand color2, mix_weights p1 p2) with
+  | Some (rgb1, alpha1), Some (rgb2, alpha2), Some (w1, w2, alpha_mult) -> (
+      let (r, g, b), interp_alpha =
+        premult_mix3 ~w1 ~w2 ~a1:alpha1 ~a2:alpha2 rgb1 rgb2
+      in
+      let alpha = interp_alpha *. alpha_mult in
+      let linear = Color_space.linear_rgb_of_rgb (r, g, b) in
+      match Color_space.srgb_bytes_of_linear linear with
+      | Some (r, g, b) ->
+          let clamp01 v = Float.max 0. (Float.min 1. v) in
+          let a = Float.to_int (Float.round (clamp01 alpha *. 255.)) in
+          Some (canonical_color_of_hex r g b a)
+      | None ->
+          (* CSS Color 4 sec. 10.1 leaves out-of-gamut sRGB coordinates
+             unclamped, so retain them in [color()] notation. *)
+          let round6 v = Float.round (v *. 1e6) /. 1e6 in
+          Some
+            (Color
+               {
+                 space = Srgb;
+                 components = [ Num (round6 r); Num (round6 g); Num (round6 b) ];
+                 alpha = alpha_of_unit_float alpha;
+               }))
+  | _ -> (
+      (* The floating-point converter declines sRGB [none] channels. Keep the
+         channel carry-over behaviour in the byte mixer for that case. *)
+      match mix_srgb_bytes color1 color2 ~p1 ~p2 with
+      | Some (r, g, b, a) -> Some (canonical_color_of_hex r g b a)
+      | Option.None -> None)
 
 let normalize_lab_family_mix effective color1 color2 ~p1 ~p2 =
   match mix_lab_family effective color1 color2 ~p1 ~p2 with

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -1528,6 +1528,23 @@ let spec_color5_function_edges () =
   neg_cursor read_color "color-mix(in, red, blue)";
   neg_cursor read_color "color-mix(in srgb red blue)"
 
+let spec_color5_srgb_float_mix () =
+  (* CSS Color 5 sec. 3: convert modern operands to floating-point sRGB,
+     interpolate there, and quantise only the result. *)
+  check_color ~expected:"color-mix(in srgb,oklch(13%7%261.692),white 20%)"
+    ~optimized:"#353942"
+    "color-mix(in srgb, oklch(13% .028 261.692), white 20%)";
+  (* A nearby result that does not cross a byte-rounding boundary. *)
+  check_color ~expected:"color-mix(in srgb,oklch(13%7%261.692),white 90%)"
+    ~optimized:"#e6e6e7"
+    "color-mix(in srgb, oklch(13% .028 261.692), white 90%)";
+  (* Premultiplication restores the transparent operand's partner channels; the
+     40% percentage sum scales the resulting alpha to 10%. *)
+  check_color
+    ~expected:"color-mix(in srgb,oklch(13%7%261.692/.5) 20%,transparent 20%)"
+    ~optimized:"#0307121a"
+    "color-mix(in srgb, oklch(13% .028 261.692 / .5) 20%, transparent 20%)"
+
 (* CSS Color 5 sec. 3: the result of [color-mix()] is a colour in the named
    interpolation space, and CSS Color 4 sec. 10.1 keeps [color()] coordinates
    unclamped, so a mix that lands outside the sRGB gamut is still a value the
@@ -1841,6 +1858,8 @@ let value_tests =
     test_case "spec values level 4/5 math and color edges" `Quick
       spec_values_l45_math_color;
     test_case "spec color 5 function edges" `Quick spec_color5_function_edges;
+    test_case "spec color 5 floating-point sRGB mix" `Quick
+      spec_color5_srgb_float_mix;
     test_case "spec color 5 mix out of sRGB gamut" `Quick
       spec_color5_mix_out_of_srgb_gamut;
     test_case "spec color 5 mix in rectangular spaces" `Quick


### PR DESCRIPTION
## Summary

- interpolate static modern-colour operands in floating-point sRGB
- quantise only the final in-gamut result while retaining out-of-gamut `color(srgb ...)` and missing-channel carry-over
- cover the rounding boundary, nearby control, premultiplied alpha, and existing `none` interop case

## Tests

- `opam exec -- dune build`
- `opam exec -- dune fmt`
- `opam exec -- dune exec test/test.exe -- test values 52-55`
- `opam exec -- dune exec test/interop/css-minify-tests/test.exe -- test colors 23`
- `opam exec -- merlint`