### PR TITLE
Fold static line-height arithmetic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -501,6 +501,10 @@ difference wherever the two are not equivalent.
 
 ### Minification
 
+- Default `--minify` evaluates all-static unitless `line-height:calc()`
+  arithmetic to its six-significant-figure output budget, so `calc(28/18)`
+  becomes `1.55556`. `--lossless` keeps repeating quotients symbolic, and
+  canonical diff follows the same precision mode (#756)
 - `--minify` converts modern colour operands to floating-point sRGB before
   resolving an `in srgb` `color-mix()`, so channel bytes are rounded once after
   interpolation instead of once per operand and again afterward (#755)
@@ -843,10 +847,9 @@ difference wherever the two are not equivalent.
 
 ### Canonical diff
 
-- Numeric arithmetic has zero approximation tolerance in canonical mode:
-  `calc(28/14)` compares equal to `2`, while `calc(28/18)` stays distinct from
-  a rounded decimal in both default and `--lossless` modes. The default
-  approximation budget remains colour-only (#753)
+- Canonical numeric arithmetic has an explicit precision contract:
+  `calc(28/14)` compares equal to `2`; default mode equates `calc(28/18)` with
+  the minifier's `1.55556`, while `--lossless` keeps them distinct (#753, #756)
 - `:is(a, b)` and the selector list `a, b` compare equal when the arguments
   share one specificity, which is the split-against-grouped selector list the
   mode promises to equate (#655)

--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ transforms (deduplication, rule merging, selector grouping, empty-rule
 elimination, nested-rule flattening, shorthand composition, colour
 canonicalisation) and emits minified output.
 
-`calc()` arithmetic folds only when the fold is exactly value-preserving:
-`calc(100/4)` becomes `25`, while `calc(1.75/1.125)` stays as written because
-14/9 has no finite decimal form. Multiplication folds unconditionally, being
-closed over finite decimals; division folds only when the quotient is exact. The
-same rule governs a `calc()` inside a custom-property value, whose token stream
+Exact `calc()` arithmetic folds in every precision mode: `calc(100/4)` becomes
+`25`, while `calc(1.75/1.125)` stays as written because 14/9 has no finite
+decimal form. Multiplication folds unconditionally, being closed over finite
+decimals; division folds only when the quotient is exact. Default minification
+additionally folds all-static unitless `line-height:calc()` arithmetic to six
+significant figures; `--lossless` disables that approximate fold. The exact-only
+rule also governs a `calc()` inside a custom-property value, whose token stream
 is otherwise left opaque.
 
 This is a parser/printer round trip, not a byte-preserving formatter: comments
@@ -147,8 +149,11 @@ usable as a CI check.
 - `tree`: structural diff only; formatting-only differences collapse to
   "identical".
 - `string`: character-level comparison.
-- `canonical`: passes when the two inputs share cascade's canonical minified
-  form, modulo cascade-neutral reordering and regrouping. Declarations or
+- `canonical`: independently parses and optimises each input with the same
+  canonical settings, serialises each result as minified CSS, then compares the
+  two canonical representations byte for byte. `--lossless`, when present, is
+  applied to both projections; the comparison step itself performs no further
+  value interpretation or tolerance. Declarations or
   rules whose footprints are disjoint (they write different properties) may
   swap freely, a `@media`/`@supports`/`@container` block containing only
   plain rules moves as a unit past statements its rules cannot conflict with,

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ cat style.css | cascade -                                          # read stdin
 |---|---|
 | `-m, --minify` | Minify the output. Local linear rewrites always run; the expensive global factoring fixpoint runs only when its preflight predicts useful savings. The top-level pipeline re-runs until the AST stops changing, since rule-order canonicalisation can expose a merge a single pass would miss: up to five times for a sheet of at most 128 rules, once above that. |
 | `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win and drives the factoring fixpoint to convergence, the right objective when the output ships uncompressed (inline style attributes, email HTML), at a large multiple of the default's wall clock. Has no effect without `--minify`. |
-| `--lossless` | Disable colour approximation under `--minify`. Exact colour canonicalisation still runs; static modern colour-space values and `color-mix()` stay functional. Otherwise-independent declarations retain their authored order instead of being sorted for compression. Has no effect without `--minify`. |
+| `--lossless` | Disable bounded approximation under `--minify`. Exact rewrites still run, but repeating static numeric arithmetic stays as `calc()`, and static modern colour-space values and `color-mix()` stay functional. Otherwise-independent declarations retain their authored order instead of being sorted for compression. Has no effect without `--minify`. |
 | `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest form the CSS text and the specs prove on their own, so it keeps every vendor-prefixed declaration, the `min-`/`max-` spelling of a media or container feature, the `&` prefix on a nested selector, the author's `:not(:dir(ltr))` and `input:not(:enabled)`, the number form of an `oklab`/`oklch` axis, and the quotes around a multi-word font family. It also holds the parser to the ident code points CSS Syntax 3 lists, which is the one part that acts without `--minify`. |
 | `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
 | `--closed-world` | Assume you know the exact HTML and that no element ever matches two clashing selectors, so the optimiser may merge rules it would otherwise keep apart. Unsafe: the page can render wrong if such an element appears, including one a script adds at runtime. This is about the HTML, where `--scope` is about how much of the CSS you control; see [Scope](#scope). Has no effect without `--minify`. |
@@ -159,16 +159,17 @@ usable as a CI check.
   Cascade-significant order is kept distinct (two writes of the same
   property, a shorthand and its longhand, a vendor-prefixed alias, `@layer`
   blocks). Equivalent shorthand decompositions are still not modelled.
-  Numeric arithmetic has zero approximation tolerance in both default and
-  `--lossless` modes: an exact quotient such as `calc(28/14)` compares equal to
-  `2`, while `calc(28/18)` remains distinct from every finite decimal spelling.
-  The default mode's bounded approximation applies only to colours.
+  Numeric arithmetic follows the same precision mode as minification: an exact
+  quotient such as `calc(28/14)` compares equal to `2` in either mode. By
+  default, `calc(28/18)` compares equal to Cascade's six-significant-figure
+  output `1.55556`; under `--lossless` it remains distinct from every finite
+  decimal spelling.
 
 | Flag | Purpose |
 |---|---|
 | `--diff=MODE` | What counts as "no difference": `auto` (default), `tree`, `string` or `canonical`, as above. |
 | `--depth=auto\|max\|N` | How many levels of the difference tree to print. `auto` (default) prints it whole while it stays short, then falls back to the deepest level that fits; `max` always prints it whole; an integer pins a level. A cut subtree carries the number of lines hidden. |
-| `--lossless` | Disable colour approximation in the `--diff=canonical` canonicalisation, so two sheets that differ only by a fold within the approximation budget report as different rather than equal. Numeric arithmetic is exact with or without this flag. Has no effect outside `--diff=canonical`. |
+| `--lossless` | Disable bounded colour and numeric approximation in the `--diff=canonical` canonicalisation, so two sheets that differ only by a fold within an approximation budget report as different rather than equal. Has no effect outside `--diff=canonical`. |
 | `--prune-unused-custom-props` | Drop the custom-property bindings nothing references, on both sides, before comparing under `--diff=canonical`, so two sheets that differ only by a dead binding compare equal. The comparison is then blind to dead-custom-property divergences. Has no effect outside `--diff=canonical`. |
 | `--color=WHEN` | `auto` (default), `always` or `never`. `CASCADE_COLOR` sets the same thing; `NO_COLOR` overrides both. |
 | `-q, --quiet` / `-v, --verbose` | Standard verbosity controls. |
@@ -412,7 +413,7 @@ stable tie-break key. Produced group/residual nodes inherit the earliest source
 slot they represent, so the optimiser is source-stable whenever the cascade
 does not force another order.
 
-### Colour approximation
+### Approximation and lossless mode
 
 Cascade folds colours only within `0.002` ΔE<sub>OK</sub> (the CSS Color 4
 Delta-E metric for Oklab/OkLCh). Alpha is separate: functional alpha rounds
@@ -425,6 +426,12 @@ modern-space folds, and static `color-mix()` resolution are disabled.
 Otherwise-independent declarations retain their authored order rather than
 being sorted for compression, preserving their order in stylesheet text and
 CSSOM enumeration.
+
+The default optimiser also evaluates all-static unitless `line-height:calc()`
+arithmetic and writes a non-terminating result to six significant figures.
+Under `--lossless`, exact results still fold but a repeating quotient remains a
+`calc()`. `--enforce-spec` does not change either precision policy; it controls
+browser-target assumptions instead.
 
 ### Scope
 

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -184,8 +184,9 @@ let file2_arg =
 let mode_arg =
   let doc =
     "Diff mode: 'auto' (smart detection), 'tree' (force structural diff), \
-     'string' (force string diff), or 'canonical' (compare optimized canonical \
-     minified serialization)"
+     'string' (force string diff), or 'canonical' (independently optimize and \
+     minify both inputs with the same canonical settings, then compare the \
+     resulting bytes)"
   in
   let mode_conv =
     Arg.enum

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -227,13 +227,13 @@ let depth_arg =
 
 let lossless_arg =
   let doc =
-    "Disable colour approximation in $(b,--diff=canonical) canonicalisation. \
-     Exact colour canonicalisation still runs, but static modern colour-space \
-     and color-mix() values stay functional and channels keep their full \
-     precision. Two stylesheets that only differ by colours folded within the \
-     approximation budget then report as different rather than collapsing to \
-     equal. Numeric arithmetic is exact with or without this flag. Has no \
-     effect outside $(b,--diff=canonical)."
+    "Disable bounded colour and numeric approximation in $(b,--diff=canonical) \
+     canonicalisation. Exact rewrites still run, but repeating static numeric \
+     arithmetic stays as calc(), static modern colour-space and color-mix() \
+     values stay functional, and colour channels keep their full precision. \
+     Two stylesheets that differ only within an approximation budget then \
+     report as different rather than collapsing to equal. Has no effect \
+     outside $(b,--diff=canonical)."
   in
   Arg.(value & flag & info [ "lossless" ] ~doc)
 

--- a/bin/cmd_fmt.ml
+++ b/bin/cmd_fmt.ml
@@ -145,12 +145,12 @@ let enforce_spec_arg =
 
 let lossless_arg =
   let doc =
-    "Disable colour approximation under $(b,--minify). Exact colour \
-     canonicalisation still runs, but static modern colour-space and \
-     color-mix() values stay functional and colour channels keep their normal \
-     serialisation precision. Otherwise-independent declarations retain their \
-     authored order rather than being sorted for compression. Has no effect \
-     without $(b,--minify)."
+    "Disable bounded approximation under $(b,--minify). Exact rewrites still \
+     run, but repeating static numeric arithmetic stays as calc(), static \
+     modern colour-space and color-mix() values stay functional, and colour \
+     channels keep their normal serialisation precision. Otherwise-independent \
+     declarations retain their authored order rather than being sorted for \
+     compression. Has no effect without $(b,--minify)."
   in
   Arg.(value & flag & info [ "lossless" ] ~doc)
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7903,10 +7903,10 @@ val optimize :
     When [flatten_nesting] is [true] (default [false]) the optimizer also
     desugars nested rules into flat top-level rules; see {!Optimize.stylesheet}.
 
-    When [lossless] is [true] (default [false]), colour approximation is
-    disabled while exact colour canonicalisation still runs. Independent
-    declarations retain their authored order rather than being sorted for
-    compression, preserving stylesheet-text and CSSOM observability.
+    When [lossless] is [true] (default [false]), bounded colour and numeric
+    approximation is disabled while exact canonicalisation still runs.
+    Independent declarations retain their authored order rather than being
+    sorted for compression, preserving stylesheet-text and CSSOM observability.
 
     When [enforce_spec] is [true] (default [false]) the optimizer drops the
     evergreen-browser target facts: a vendor-prefixed declaration is kept beside

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -50,9 +50,9 @@ val normalize :
   declaration
 (** [normalize ?lossless d] applies AST-level semantic value canonicalisation so
     the optimizer holds a canonical declaration and the pretty-printer stays a
-    pure serialiser. [lossless] disables colour approximation. [exact_srgb] is
-    {!Properties.normalize_property_value}'s flag of the same name, for the
-    canonical diff projection only. *)
+    pure serialiser. [lossless] disables bounded colour and numeric
+    approximation. [exact_srgb] is {!Properties.normalize_property_value}'s flag
+    of the same name, for the canonical diff projection only. *)
 
 val to_string : ?minify:bool -> t -> string
 (** [to_string ~minify d] converts a declaration to CSS source text. *)

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -78,11 +78,12 @@ type mode = [ `Auto | `Tree | `String | `Canonical ]
     - [`Canonical] -- parse both stylesheets, serialize optimized minified
       outputs, and compare those outputs. This includes value spellings that
       Cascade canonicalizes as equivalent, such as [transparent] and [#0000] in
-      color positions. Numeric arithmetic only folds exactly: [calc(28/14)] and
-      [2] agree, while [calc(28/18)] does not agree with a rounded decimal in
-      either setting of [lossless]. Equal outputs are {!No_diff}; differing
-      outputs are a difference, reported as a tree diff of the two when the walk
-      reaches it and as a string diff of them when it does not.
+      color positions. Numeric arithmetic follows the same precision mode:
+      [calc(28/14)] and [2] always agree; [calc(28/18)] agrees with [1.55556] by
+      default and remains distinct under [lossless]. Equal outputs are
+      {!No_diff}; differing outputs are a difference, reported as a tree diff of
+      the two when the walk reaches it and as a string diff of them when it does
+      not.
 
     The projection runs no rewrite whose applicability depends on the order the
     input happens to put its rules in. Factoring shared declarations into a
@@ -105,8 +106,8 @@ val diff :
 (** [diff ?mode expected actual] returns the diff between two CSS strings. A
     leading [/*! ... */] tool banner on either side is stripped before
     comparison. Parsing failures surface as [_error] variants. [lossless]
-    preserves exact color channels during canonical comparison; numeric
-    arithmetic is exact whether it is set or not.
+    preserves exact colour channels and non-terminating numeric arithmetic
+    during canonical comparison.
 
     [prune_unused_custom_props] (default [false], [`Canonical] mode only) drops
     custom-property bindings referenced by nothing on both sides before

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -5,13 +5,16 @@
     how a non-equal pair is reported.
 
     Cascade does not implement a general CSS semantic-equivalence rewriter. The
-    closest the library comes is mode [`Canonical], which compares the inputs by
-    their optimized canonical minified serialization through
-    {!Cascade.Css.to_string}. That collapses whitespace, color spellings,
-    leading-/trailing-zero normalisations, optimizer-preserved shorthand
-    choices, and other choices the optimizer and pretty-printer make; it does
-    {b not} reason about browser computed values or cascade-affecting rule
-    reorderings.
+    closest the library comes is mode [`Canonical]. It independently parses and
+    optimizes each input with the same canonical settings, canonicalizes
+    cascade-neutral order, serializes both results as minified CSS through
+    {!Cascade.Css.to_string}, then compares those two canonical representations
+    byte for byte. [lossless], when requested, is applied to both projections;
+    the comparison step performs no further value interpretation or tolerance.
+    The projection collapses whitespace, color spellings, leading-/trailing-zero
+    normalisations, optimizer-preserved shorthand choices, and other choices the
+    optimizer and pretty-printer make; it does {b not} reason about browser
+    computed values or cascade-affecting rule reorderings.
 
     The projection optimizes spec-literally: it takes none of the rewrites
     {!Cascade.Css.optimize} justifies with what maintained browsers support,
@@ -75,10 +78,11 @@ type mode = [ `Auto | `Tree | `String | `Canonical ]
     - [`Tree] -- structural diff only; formatting-only differences collapse to
       {!No_diff}.
     - [`String] -- character-level diff; the inputs are not parsed.
-    - [`Canonical] -- parse both stylesheets, serialize optimized minified
-      outputs, and compare those outputs. This includes value spellings that
-      Cascade canonicalizes as equivalent, such as [transparent] and [#0000] in
-      color positions. Numeric arithmetic follows the same precision mode:
+    - [`Canonical] -- pass both stylesheets independently through the same
+      canonical optimization and minified serialization pipeline, then compare
+      the resulting bytes. This includes value spellings that Cascade
+      canonicalizes as equivalent, such as [transparent] and [#0000] in color
+      positions. Numeric arithmetic follows the pipeline's precision mode:
       [calc(28/14)] and [2] always agree; [calc(28/18)] agrees with [1.55556] by
       default and remains distinct under [lossless]. Equal outputs are
       {!No_diff}; differing outputs are a difference, reported as a tree diff of

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -287,9 +287,9 @@ val stylesheet :
     [scope] (default [`Fragment]) gates partial-coverage shorthand synthesis;
     see the {!scope} doc.
 
-    When [lossless] is [true] (default [false]), colour-channel rounding and
-    other lossy approximations are suppressed while exact colour
-    canonicalisation still runs.
+    When [lossless] is [true] (default [false]), colour-channel rounding,
+    non-terminating static numeric folds, and other lossy approximations are
+    suppressed while exact canonicalisation still runs.
 
     When [enforce_spec] is [true] (default [false]) the optimizer drops the
     evergreen-browser target facts and applies only CSS-text-and-spec-provable

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -2010,13 +2010,32 @@ let normalize_font_size (fs : font_size) : font_size =
           | length -> font_size_of_length length))
   | _ -> fs
 
-let normalize_line_height (lh : line_height) : line_height =
+let rec calc_has_computed_input : line_height calc -> bool = function
+  | Math_const _ | Math_fn _ -> true
+  | Nested inner | Parens inner -> calc_has_computed_input inner
+  | Expr (left, _, right) ->
+      calc_has_computed_input left || calc_has_computed_input right
+  | Num _ | Val _ | Var _ | Sibling_index | Sibling_count -> false
+
+(* CSS Values 4 sec. 10.10 simplifies arithmetic over numeric literals to one
+   number. Normal minification emits a non-terminating result at Cascade's
+   six-significant-figure computed-value budget. Lossless mode keeps it for the
+   browser to evaluate, while [eval_calc] still performs exact folds. Math
+   constants and functions retain the existing computed-value path, which owns
+   their precision provenance separately. *)
+let normalize_line_height ?(lossless = false) (lh : line_height) : line_height =
   match lh with
   | Calc c -> (
-      match Values.eval_calc c with
-      | Values.Num f -> Num f
-      | Values.Val v -> v
-      | folded -> Calc folded)
+      match
+        if lossless || calc_has_computed_input c then Option.None
+        else Option.map (Pp.round_sig 6) (Values.eval_numeric_calc c)
+      with
+      | Option.Some f -> Num f
+      | Option.None -> (
+          match Values.eval_calc c with
+          | Values.Num f -> Num f
+          | Values.Val v -> v
+          | folded -> Calc folded))
   | _ -> lh
 
 (* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4177,7 +4177,7 @@ let normalize_property_value : type a.
   | Stroke_opacity -> normalize_opacity value
   | Stop_opacity -> normalize_opacity value
   | Flood_opacity -> normalize_opacity value
-  | Line_height -> normalize_line_height value
+  | Line_height -> normalize_line_height ~lossless value
   | Vertical_align -> normalize_vertical_align value
   | Border_width -> map_preserve normalize_border_width value
   | Border_top_width -> normalize_border_width value

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -41,8 +41,8 @@ val normalize_property_value :
 (** [normalize_property_value ?lossless prop value] applies semantic
     (equivalence) canonicalisation to [value] so the optimizer holds a canonical
     AST and the pretty-printer stays a pure serialiser. Identity for properties
-    whose folds have not yet migrated out of [pp]. [lossless] disables colour
-    approximation while keeping exact colour canonicalisation.
+    whose folds have not yet migrated out of [pp]. [lossless] disables bounded
+    colour and numeric approximation while keeping exact canonicalisation.
 
     [exact_srgb] is {!Values.normalize_color}'s flag of the same name, applied
     to the properties whose whole value is a colour. It is for the canonical

--- a/test/helpers/css_test_helpers.ml
+++ b/test/helpers/css_test_helpers.ml
@@ -130,8 +130,7 @@ let decl_optimizes_to ?held ~into input =
 
 (** [decl_lossless ~prop ~into input] asserts the lossless minify+optimize
     oracle for one declaration. The expected value is still a minified canonical
-    spelling, but color approximation and channel rounding are disabled on both
-    optimize and pp. *)
+    spelling, but bounded approximation is disabled on both optimize and pp. *)
 let decl_lossless ~prop ~into input =
   let wrap v = String.concat "" [ ".x{"; prop; ":"; v; "}" ] in
   match Css.of_string ~strict:false (wrap input) with

--- a/test/helpers/css_test_helpers.mli
+++ b/test/helpers/css_test_helpers.mli
@@ -81,7 +81,7 @@ val decl_optimizes_to : ?held:string -> into:string -> string -> unit
 
 val decl_lossless : prop:string -> into:string -> string -> unit
 (** [decl_lossless ~prop ~into input] checks the minify+optimize path with
-    [~lossless:true] on both optimization and printing. *)
+    bounded approximation disabled on both optimization and printing. *)
 
 val check_parse_error_fields :
   string -> Reader.parse_error -> Reader.parse_error -> unit

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -1600,6 +1600,6 @@ let suite =
         canonical_folds_media_range_spellings;
       Alcotest.test_case "canonical lossless equates exact srgb spellings"
         `Quick equal_canonical_lossless_exact_srgb;
-      Alcotest.test_case "canonical numeric division is exact" `Quick
+      Alcotest.test_case "canonical numeric precision modes" `Quick
         canonical_numeric_division_follows_precision_mode;
     ] )

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -226,11 +226,11 @@ let equal_canonical_lossless_exact_srgb () =
     "an off-grid channel keeps its function" false
     (equal ".a{color:color(srgb .501 0 0)}" ".a{color:maroon}")
 
-(* Numeric CSS has no property-independent error metric: an approximation can be
-   multiplied by layout, iteration, or a runtime substitution. Canonical
-   comparison therefore shares the optimizer's exact-division contract rather
-   than extending the deliberately colour-only [--lossless] switch. *)
-let canonical_numeric_division_is_exact () =
+(* Canonical comparison applies the optimizer's precision mode symmetrically to
+   both inputs. The default six-significant-figure budget therefore equates the
+   minifier's static line-height fold, while [--lossless] keeps the authored
+   quotient distinct from every finite approximation. *)
+let canonical_numeric_division_follows_precision_mode () =
   let equal ?(lossless = false) a b =
     Cascade_diff.Css_compare.equal ~mode:`Canonical ~lossless a b
   in
@@ -238,13 +238,13 @@ let canonical_numeric_division_is_exact () =
     "an exact quotient folds" true
     (equal ".a{line-height:calc(28/14)}" ".a{line-height:2}");
   Alcotest.(check bool)
-    "six significant digits are still an approximation" false
+    "the default precision budget matches minified output" true
     (equal ".a{line-height:calc(28/18)}" ".a{line-height:1.55556}");
   Alcotest.(check bool)
     "even the nearest emitted decimal is outside zero tolerance" false
     (equal ".a{line-height:calc(28/18)}" ".a{line-height:1.55555556}");
   Alcotest.(check bool)
-    "lossless keeps the same exact numeric boundary" false
+    "lossless keeps an exact numeric boundary" false
     (equal ~lossless:true ".a{line-height:calc(28/18)}"
        ".a{line-height:1.55556}")
 
@@ -1601,5 +1601,5 @@ let suite =
       Alcotest.test_case "canonical lossless equates exact srgb spellings"
         `Quick equal_canonical_lossless_exact_srgb;
       Alcotest.test_case "canonical numeric division is exact" `Quick
-        canonical_numeric_division_is_exact;
+        canonical_numeric_division_follows_precision_mode;
     ] )

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1582,6 +1582,15 @@ let test_line_height () =
   check_line_height "inherit";
   check_line_height "1.5";
   check_line_height "120%";
+  decl_optimizes ~prop:"line-height" ~held:"calc(28/18)" ~into:"1.55556"
+    "calc(28 / 18)";
+  decl_optimizes ~prop:"line-height" ~held:"calc(10 + 8)" ~into:"18"
+    "calc(10 + 8)";
+  decl_optimizes ~prop:"line-height" ~held:"calc(7*4)" ~into:"28" "calc(7 * 4)";
+  decl_optimizes ~prop:"line-height" ~held:"calc((28/18))" ~into:"1.55556"
+    "calc((28 / 18))";
+  decl_optimizes ~prop:"line-height" ~held:"calc(28/var(--x))"
+    ~into:"calc(28/var(--x))" "calc(28 / var(--x))";
   neg_cursor read_line_height "invalid";
   neg_cursor read_line_height "-1.5";
   (* negative line-height *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1584,6 +1584,7 @@ let test_line_height () =
   check_line_height "120%";
   decl_optimizes ~prop:"line-height" ~held:"calc(28/18)" ~into:"1.55556"
     "calc(28 / 18)";
+  decl_lossless ~prop:"line-height" ~into:"calc(28/18)" "calc(28 / 18)";
   decl_optimizes ~prop:"line-height" ~held:"calc(10 + 8)" ~into:"18"
     "calc(10 + 8)";
   decl_optimizes ~prop:"line-height" ~held:"calc(7*4)" ~into:"28" "calc(7 * 4)";


### PR DESCRIPTION
All-static unitless line-height arithmetic stayed symbolic under normal minification, unlike Cascade’s documented precision contract. It now folds within the six-significant-figure budget, while --lossless retains non-terminating quotients in both minification and canonical projections.