### PR TITLE
optimize: add target hyphens and mask prefixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -513,11 +513,10 @@ difference wherever the two are not equivalent.
   before comparison, factoring settles both transfer-size alternatives and
   retries once when settling changes its graph, and selector-branch factoring
   preserves source order after earlier rewrites (#750)
-- Default minification adds the `-webkit-user-select` and
-  `-webkit-backdrop-filter` declarations Safari 16.4 needs, and expands matching
-  `@supports` tests to accept either spelling. `Css.optimize ~targets` exposes
-  the Chrome, Firefox, Safari and iOS Safari versions that own these fallbacks;
-  an authored prefixed declaration remains authoritative (#751)
+- Default minification adds the WebKit fallbacks Safari 16.4 and Chrome 111
+  need for `user-select`, `backdrop-filter`, `hyphens`, `mask` and its
+  compatible layer longhands, including matching `@supports` tests. An
+  authored prefixed declaration remains authoritative (#751, #758)
 - The README states the default minifier's evergreen target, colour tolerance,
   and CSSOM-visible normalisation beside its first example, and describes
   `--lossless --enforce-spec` as conservative rather than source-exact (#743)

--- a/README.md
+++ b/README.md
@@ -470,13 +470,15 @@ is either `ltr` or `rtl`, shortens `:not(:dir(ltr))` to
 `:enabled` or `:disabled`, shortens `input:not(:enabled)` to `input:disabled`.
 A vendor-prefixed declaration (`-moz-box-sizing`) whose unprefixed twin is
 present is dropped, since evergreen browsers understand the unprefixed form.
-Conversely, the target adds `-webkit-user-select` and
-`-webkit-backdrop-filter` beside their standard declarations where Safari
-still needs them. A `min-`/`max-` media or container feature becomes the Media
-Queries 4 range grammar, `(min-width: 700px)` to `(width >= 700px)`. A nested
-selector loses its `&` prefix, `& div` to `div`, which the relaxed nesting
-syntax reads the same way. An `oklab` or `oklch` axis takes the percentage
-spelling wherever it is shorter, `oklch(.7 .304 20)` to
+Conversely, the target adds WebKit fallbacks beside `user-select`,
+`backdrop-filter`, `hyphens`, `mask` and its compatible layer longhands where
+Safari 16.4 or Chrome 111 still needs them. The prefixed `mask-mode` and
+`mask-composite` properties are not generated because their legacy grammars
+differ from the standard properties. A `min-`/`max-` media or container feature
+becomes the Media Queries 4 range grammar, `(min-width: 700px)` to
+`(width >= 700px)`. A nested selector loses its `&` prefix, `& div` to `div`,
+which the relaxed nesting syntax reads the same way. An `oklab` or `oklch` axis
+takes the percentage spelling wherever it is shorter, `oklch(.7 .304 20)` to
 `oklch(.7 76% 20)`.
 
 Each of those state pseudo-class pairs partitions a different set of elements,

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -629,7 +629,17 @@ let flatten_nesting = Flatten.block
 
 (** {1 Stylesheet Optimization} *)
 
-type webkit_fallback = User_select_fallback | Backdrop_filter_fallback
+type webkit_fallback =
+  | User_select_fallback
+  | Backdrop_filter_fallback
+  | Hyphens_fallback
+  | Mask_fallback
+  | Mask_image_fallback
+  | Mask_position_fallback
+  | Mask_size_fallback
+  | Mask_repeat_fallback
+  | Mask_clip_fallback
+  | Mask_origin_fallback
 
 let version_compare (major_a, minor_a) (major_b, minor_b) =
   match Int.compare major_a major_b with
@@ -637,17 +647,37 @@ let version_compare (major_a, minor_a) (major_b, minor_b) =
   | order -> order
 
 let version_at_most version maximum = version_compare version maximum <= 0
+let version_before version minimum = version_compare version minimum < 0
 
 (* The target contract is deliberately owned here rather than by the printer:
    adding a fallback changes the AST and must therefore be explicit to API
    callers. Safari/iOS still require [-webkit-user-select] at the declared
-   baseline, while unprefixed [backdrop-filter] arrived after 17.6. *)
+   baseline, while unprefixed [backdrop-filter] arrived after 17.6, unprefixed
+   [hyphens] arrived in 17, and Chrome needs the compatible [-webkit-mask]
+   shorthand and longhands through 119. [mask-mode] and [mask-composite] are
+   excluded because their prefixed forms have different grammars. *)
 let required_fallback kind targets =
   match kind with
   | User_select_fallback -> true
   | Backdrop_filter_fallback ->
       version_at_most targets.safari (17, 6)
       || version_at_most targets.ios_safari (17, 6)
+  | Hyphens_fallback ->
+      version_before targets.safari (17, 0)
+      || version_before targets.ios_safari (17, 0)
+  | Mask_fallback | Mask_image_fallback | Mask_position_fallback
+  | Mask_size_fallback | Mask_repeat_fallback | Mask_clip_fallback
+  | Mask_origin_fallback ->
+      version_at_most targets.chrome (119, 0)
+
+let webkit_compatible_mask : Properties.mask -> Properties.mask =
+  let strip_layer (layer : Properties.mask_layer) =
+    { layer with mode = Option.none; composite = Option.none }
+  in
+  function
+  | Layer layer -> Layer (strip_layer layer)
+  | Layers layers -> Layers (List.map strip_layer layers)
+  | value -> value
 
 let webkit_fallback_of_declaration targets decl =
   let fallback kind property value important =
@@ -655,11 +685,39 @@ let webkit_fallback_of_declaration targets decl =
       Some (Declaration.v ~important property value)
     else None
   in
+  let opaque_fallback kind property source important =
+    if required_fallback kind targets then
+      match
+        Declaration.parse_opaque_declaration property
+          (Declaration.string_of_value ~minify:true source)
+      with
+      | Some prefixed ->
+          Some (if important then Declaration.important prefixed else prefixed)
+      | None -> None
+    else None
+  in
   match decl with
   | Declaration { property = User_select; value; important; _ } ->
       fallback User_select_fallback Webkit_user_select value important
   | Declaration { property = Backdrop_filter; value; important; _ } ->
       fallback Backdrop_filter_fallback Webkit_backdrop_filter value important
+  | Declaration { property = Hyphens; value; important; _ } ->
+      fallback Hyphens_fallback Webkit_hyphens value important
+  | Declaration { property = Mask; value; important; _ } ->
+      let source = Declaration.v Mask (webkit_compatible_mask value) in
+      opaque_fallback Mask_fallback "-webkit-mask" source important
+  | Declaration { property = Mask_image; value; important; _ } ->
+      fallback Mask_image_fallback Webkit_mask_image value important
+  | Declaration { property = Mask_position; value; important; _ } ->
+      fallback Mask_position_fallback Webkit_mask_position value important
+  | Declaration { property = Mask_size; value; important; _ } ->
+      fallback Mask_size_fallback Webkit_mask_size value important
+  | Declaration { property = Mask_repeat; value; important; _ } ->
+      fallback Mask_repeat_fallback Webkit_mask_repeat value important
+  | Declaration { property = Mask_clip; value; important; _ } ->
+      fallback Mask_clip_fallback Webkit_mask_clip value important
+  | Declaration { property = Mask_origin; value; important; _ } ->
+      fallback Mask_origin_fallback Webkit_mask_origin value important
   | Declaration { property = Unknown_property name; value; important; _ }
     when String.equal name "user-select" ->
       fallback User_select_fallback (Unknown_property "-webkit-user-select")
@@ -668,31 +726,127 @@ let webkit_fallback_of_declaration targets decl =
     when String.equal name "backdrop-filter" ->
       fallback Backdrop_filter_fallback
         (Unknown_property "-webkit-backdrop-filter") value important
+  | Declaration { property = Unknown_property name; value; important; _ }
+    when String.equal name "hyphens" ->
+      fallback Hyphens_fallback (Unknown_property "-webkit-hyphens") value
+        important
+  | Declaration
+      { property = Unknown_property name; value = components; important; _ }
+    when String.equal name "mask" -> (
+      let source = Declaration.v (Unknown_property name) components in
+      let rendered = Declaration.string_of_value ~minify:false source in
+      match Declaration.parse_declaration "mask" rendered with
+      | Some (Declaration { property = Mask; value; _ }) ->
+          let source = Declaration.v Mask (webkit_compatible_mask value) in
+          opaque_fallback Mask_fallback "-webkit-mask" source important
+      | Some _ | None ->
+          fallback Mask_fallback (Unknown_property "-webkit-mask") components
+            important)
+  | Declaration { property = Unknown_property name; value; important; _ }
+    when String.equal name "mask-image" ->
+      fallback Mask_image_fallback (Unknown_property "-webkit-mask-image") value
+        important
+  | Declaration { property = Unknown_property name; value; important; _ }
+    when String.equal name "mask-position" ->
+      fallback Mask_position_fallback (Unknown_property "-webkit-mask-position")
+        value important
+  | Declaration { property = Unknown_property name; value; important; _ }
+    when String.equal name "mask-size" ->
+      fallback Mask_size_fallback (Unknown_property "-webkit-mask-size") value
+        important
+  | Declaration { property = Unknown_property name; value; important; _ }
+    when String.equal name "mask-repeat" ->
+      fallback Mask_repeat_fallback (Unknown_property "-webkit-mask-repeat")
+        value important
+  | Declaration { property = Unknown_property name; value; important; _ }
+    when String.equal name "mask-clip" ->
+      fallback Mask_clip_fallback (Unknown_property "-webkit-mask-clip") value
+        important
+  | Declaration { property = Unknown_property name; value; important; _ }
+    when String.equal name "mask-origin" ->
+      fallback Mask_origin_fallback (Unknown_property "-webkit-mask-origin")
+        value important
   | Theme_guarded _ | Declaration _ -> None
 
 let is_webkit_fallback kind decl =
   match (kind, decl) with
   | User_select_fallback, Declaration { property = Webkit_user_select; _ }
   | ( Backdrop_filter_fallback,
-      Declaration { property = Webkit_backdrop_filter; _ } ) ->
+      Declaration { property = Webkit_backdrop_filter; _ } )
+  | Hyphens_fallback, Declaration { property = Webkit_hyphens; _ }
+  | Mask_image_fallback, Declaration { property = Webkit_mask_image; _ }
+  | Mask_position_fallback, Declaration { property = Webkit_mask_position; _ }
+  | Mask_size_fallback, Declaration { property = Webkit_mask_size; _ }
+  | Mask_repeat_fallback, Declaration { property = Webkit_mask_repeat; _ }
+  | Mask_clip_fallback, Declaration { property = Webkit_mask_clip; _ }
+  | Mask_origin_fallback, Declaration { property = Webkit_mask_origin; _ } ->
       true
   | User_select_fallback, Declaration { property = Unknown_property name; _ } ->
       String.equal name "-webkit-user-select"
   | ( Backdrop_filter_fallback,
       Declaration { property = Unknown_property name; _ } ) ->
       String.equal name "-webkit-backdrop-filter"
+  | Hyphens_fallback, Declaration { property = Unknown_property name; _ } ->
+      String.equal name "-webkit-hyphens"
+  | Mask_fallback, Declaration { property = Unknown_property name; _ } ->
+      String.equal name "-webkit-mask"
+  | Mask_image_fallback, Declaration { property = Unknown_property name; _ } ->
+      String.equal name "-webkit-mask-image"
+  | Mask_position_fallback, Declaration { property = Unknown_property name; _ }
+    ->
+      String.equal name "-webkit-mask-position"
+  | Mask_size_fallback, Declaration { property = Unknown_property name; _ } ->
+      String.equal name "-webkit-mask-size"
+  | Mask_repeat_fallback, Declaration { property = Unknown_property name; _ } ->
+      String.equal name "-webkit-mask-repeat"
+  | Mask_clip_fallback, Declaration { property = Unknown_property name; _ } ->
+      String.equal name "-webkit-mask-clip"
+  | Mask_origin_fallback, Declaration { property = Unknown_property name; _ } ->
+      String.equal name "-webkit-mask-origin"
   | _, (Theme_guarded _ | Declaration _) -> false
 
 let fallback_kind = function
   | Declaration { property = User_select; _ } -> Some User_select_fallback
   | Declaration { property = Backdrop_filter; _ } ->
       Some Backdrop_filter_fallback
+  | Declaration { property = Hyphens; _ } -> Some Hyphens_fallback
+  | Declaration { property = Mask; _ } -> Some Mask_fallback
+  | Declaration { property = Mask_image; _ } -> Some Mask_image_fallback
+  | Declaration { property = Mask_position; _ } -> Some Mask_position_fallback
+  | Declaration { property = Mask_size; _ } -> Some Mask_size_fallback
+  | Declaration { property = Mask_repeat; _ } -> Some Mask_repeat_fallback
+  | Declaration { property = Mask_clip; _ } -> Some Mask_clip_fallback
+  | Declaration { property = Mask_origin; _ } -> Some Mask_origin_fallback
   | Declaration { property = Unknown_property name; _ }
     when String.equal name "user-select" ->
       Some User_select_fallback
   | Declaration { property = Unknown_property name; _ }
     when String.equal name "backdrop-filter" ->
       Some Backdrop_filter_fallback
+  | Declaration { property = Unknown_property name; _ }
+    when String.equal name "hyphens" ->
+      Some Hyphens_fallback
+  | Declaration { property = Unknown_property name; _ }
+    when String.equal name "mask" ->
+      Some Mask_fallback
+  | Declaration { property = Unknown_property name; _ }
+    when String.equal name "mask-image" ->
+      Some Mask_image_fallback
+  | Declaration { property = Unknown_property name; _ }
+    when String.equal name "mask-position" ->
+      Some Mask_position_fallback
+  | Declaration { property = Unknown_property name; _ }
+    when String.equal name "mask-size" ->
+      Some Mask_size_fallback
+  | Declaration { property = Unknown_property name; _ }
+    when String.equal name "mask-repeat" ->
+      Some Mask_repeat_fallback
+  | Declaration { property = Unknown_property name; _ }
+    when String.equal name "mask-clip" ->
+      Some Mask_clip_fallback
+  | Declaration { property = Unknown_property name; _ }
+    when String.equal name "mask-origin" ->
+      Some Mask_origin_fallback
   | Theme_guarded _ | Declaration _ -> None
 
 (* Once an author supplied a prefix for a property, that spelling is theirs:

--- a/test/cli/dead_code.t
+++ b/test/cli/dead_code.t
@@ -81,14 +81,15 @@ is what Baseline "widely available" decides. Safari reads only
   $ cascade --minify prefix.css
   .x{-webkit-backdrop-filter:blur(2px);backdrop-filter:blur(2px)}
 
-The same pair is dead once the unprefixed property is widely available:
-no maintained browser reaches for the WebKit copy.
+Baseline deduplication may remove a pair once the unprefixed property is
+widely available, but the final target pass restores a still-load-bearing
+copy. Chrome 111 through 119 require [-webkit-mask-image].
 
   $ cat > prefix-dead.css <<EOF
   > .x { -webkit-mask-image: url(a.png); mask-image: url(a.png) }
   > EOF
   $ cascade --minify prefix-dead.css
-  .x{mask-image:url(a.png)}
+  .x{-webkit-mask-image:url(a.png);mask-image:url(a.png)}
 
 
 # Rule-level dead code

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -405,35 +405,40 @@ let normalize_expected ~category ~id expected =
          <position> and slash. [no-repeat/cover] is not a valid way to express
          repeat plus size; the shortest valid spelling keeps the initial
          position as [0 0/cover]. Transparent black is #0000, and [url(...)] is
-         self-delimiting before the following slice. *)
+         self-delimiting before the following slice. Chrome 111 also needs the
+         WebKit spelling. *)
       fixture ~category ~id
         ~upstream:
           "a{mask:linear-gradient(#000,transparent) \
            no-repeat/cover;mask-border:url(mask.png) 25/10px round}"
         ~cascade:
-          "a{mask:linear-gradient(#000,#0000)0 0/cover \
+          "a{-webkit-mask:linear-gradient(#000,#0000)0 0/cover \
+           no-repeat;mask:linear-gradient(#000,#0000)0 0/cover \
            no-repeat;mask-border:url(mask.png)25/10px round}"
         upstream
   | "shorthands", "0050" ->
       (* Same transparent-color and url-token boundary policy as
          shorthands/0049: transparent is transparent black, and #0000 is the
          shorter spelling. The [)] before [no-repeat] and before the mask-border
-         slice is token-safe, so both spaces are removable. *)
+         slice is token-safe, so both spaces are removable. Chrome 111 also
+         needs the WebKit spelling. *)
       fixture ~category ~id
         ~upstream:
           "a{mask:linear-gradient(#000,transparent) \
            no-repeat;mask-border:url(mask.png) 25 round}"
         ~cascade:
-          "a{mask:linear-gradient(#000,#0000)no-repeat;mask-border:url(mask.png)25 \
+          "a{-webkit-mask:linear-gradient(#000,#0000)no-repeat;mask:linear-gradient(#000,#0000)no-repeat;mask-border:url(mask.png)25 \
            round}"
         upstream
   | "shorthands", "0051" ->
       (* The later mask shorthand resets the earlier mask-border state; keep the
          fixture's dead-declaration drop, with the shorter #0000 spelling for
-         transparent black. *)
+         transparent black and the WebKit spelling Chrome 111 needs. *)
       fixture ~category ~id
         ~upstream:"a{mask:linear-gradient(#000,transparent)}"
-        ~cascade:"a{mask:linear-gradient(#000,#0000)}" upstream
+        ~cascade:
+          "a{-webkit-mask:linear-gradient(#000,#0000);mask:linear-gradient(#000,#0000)}"
+        upstream
   | "shorthands", "0061" ->
       (* Four longhands with a matching [@property] each merge into one
          [padding] shorthand. A [var()] reference ends at [)], the same

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1767,8 +1767,9 @@ let public_value_combinator_edges () =
     ".card{border-radius:.375rem;gap:.5rem \
      .75rem;font-family:ui-sans-serif,system-ui,sans-serif;text-shadow:1px 2px \
      4px #000;aspect-ratio:16/9;columns:12rem 3;counter-reset:section \
-     1;mask:url(mask.svg);outline:2px solid #00f}.helpers{object-position:10px \
-     20px;text-overflow:clip \"...\";content:\"Section \" \
+     1;-webkit-mask:url(mask.svg);mask:url(mask.svg);outline:2px solid \
+     #00f}.helpers{object-position:10px 20px;text-overflow:clip \
+     \"...\";content:\"Section \" \
      counter(section);background-image:conic-gradient(from 45deg at \
      50%,red,#00f);background-size:20px 30px;object-view-box:inset(0 \
      1px);grid-template-columns:1fr repeat(2,minmax(0,1fr));grid-row:span \

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3668,7 +3668,9 @@ let spec_values_l45_edges () =
     "left 10px top 20%";
   decl_optimizes ~prop:"background-position" ~into:"50%" "center";
   decl_optimizes ~prop:"background-position" ~into:"top" "center top";
-  decl_optimizes ~prop:"mask-position" ~into:"10px 20px" "left 10px top 20px";
+  decl_optimizes_to
+    ~into:"-webkit-mask-position:10px 20px;mask-position:10px 20px"
+    "mask-position:left 10px top 20px";
   List.iter
     (fun input -> neg_cursor read_declaration input)
     [

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1160,13 +1160,15 @@ let test_vendor_prefix_strip () =
    properties that are not, which is exactly the set whose prefix a maintained
    browser may still need. *)
 let test_vendor_prefix_baseline_gate () =
-  let opt ?(enforce_spec = false) css =
+  let opt ?targets ?(enforce_spec = false) css =
     match Css.of_string css with
     | Ok p ->
-        Css.to_string ~minify:true (Css.optimize ~enforce_spec p.stylesheet)
+        Css.to_string ~minify:true
+          (Css.optimize ?targets ~enforce_spec p.stylesheet)
         |> String.trim
     | Error _ -> Alcotest.fail "parse"
   in
+  let chrome_120 = { Css.Optimize.evergreen_targets with chrome = (120, 0) } in
   (* Widely available: every maintained browser reads the unprefixed form, so
      the WebKit copy is dead weight. *)
   Alcotest.(check string)
@@ -1174,7 +1176,7 @@ let test_vendor_prefix_baseline_gate () =
     (opt ".a{-webkit-text-decoration-color:red;text-decoration-color:red}");
   Alcotest.(check string)
     "mask-image prefix drops" ".a{mask-image:none}"
-    (opt ".a{-webkit-mask-image:none;mask-image:none}");
+    (opt ~targets:chrome_120 ".a{-webkit-mask-image:none;mask-image:none}");
   (* box-sizing is the same rule and already collapses; keep it pinned. *)
   Alcotest.(check string)
     "webkit box-sizing prefix drops" ".a{box-sizing:border-box}"
@@ -2854,12 +2856,12 @@ let vendor_alias_pins_intervening_rule () =
        ".a{-webkit-transform:none}.b{transform:rotate(45deg)}.c{-webkit-transform:none}");
   Alcotest.(check string)
     "a prefixed hyphens is not grouped across its unprefixed twin"
-    ".a{-webkit-hyphens:none}.b{hyphens:auto}.c{-webkit-hyphens:none}"
+    ".a{-webkit-hyphens:none}.b{-webkit-hyphens:auto;hyphens:auto}.c{-webkit-hyphens:none}"
     (optimized_string
        ".a{-webkit-hyphens:none}.b{hyphens:auto}.c{-webkit-hyphens:none}");
   Alcotest.(check string)
     "a prefixed mask longhand is not grouped across its unprefixed twin"
-    ".a{-webkit-mask-size:auto}.b{mask-size:cover}.c{-webkit-mask-size:auto}"
+    ".a{-webkit-mask-size:auto}.b{-webkit-mask-size:cover;mask-size:cover}.c{-webkit-mask-size:auto}"
     (optimized_string
        ".a{-webkit-mask-size:auto}.b{mask-size:cover}.c{-webkit-mask-size:auto}");
   (* A prefix names one slot, not its whole family, so an unrelated intervening
@@ -3250,6 +3252,23 @@ let target_evergreen_compatibility_prefixes () =
     ".a{-webkit-user-select:none;user-select:none;-webkit-backdrop-filter:blur(1px);backdrop-filter:blur(1px)}"
     (optimized_string ".a{user-select:none;backdrop-filter:blur(1px)}");
   Alcotest.(check string)
+    "the declared target adds WebKit hyphens and mask longhand fallbacks"
+    ".a{-webkit-hyphens:auto;hyphens:auto;-webkit-mask-image:none;mask-image:none;-webkit-mask-position:50%;mask-position:50%;-webkit-mask-size:cover;mask-size:cover;-webkit-mask-repeat:no-repeat;mask-repeat:no-repeat;-webkit-mask-clip:border-box;mask-clip:border-box;-webkit-mask-origin:content-box;mask-origin:content-box}"
+    (optimized_string
+       ".a{hyphens:auto;mask-image:none;mask-position:center;mask-size:cover;mask-repeat:no-repeat;mask-clip:border-box;mask-origin:content-box}");
+  Alcotest.(check string)
+    "the declared target adds the WebKit mask shorthand"
+    ".a{-webkit-mask:none;mask:none}"
+    (optimized_string ".a{mask:none}");
+  Alcotest.(check string)
+    "the WebKit mask shorthand omits fields with different legacy grammars"
+    ".a{-webkit-mask:url(a.svg);mask:url(a.svg)luminance add}"
+    (optimized_string ".a{mask:url(a.svg) luminance add}");
+  Alcotest.(check string)
+    "mask fields without equivalent WebKit grammars are not prefixed"
+    ".a{mask-mode:luminance;mask-composite:add}"
+    (optimized_string ".a{mask-mode:luminance;mask-composite:add}");
+  Alcotest.(check string)
     "the declaration fallback preserves importance"
     ".a{-webkit-user-select:none!important;user-select:none!important}"
     (optimized_string ".a{user-select:none!important}");
@@ -3260,10 +3279,23 @@ let target_evergreen_compatibility_prefixes () =
     (optimized_string
        "@supports(backdrop-filter:var(--tw)){.a{backdrop-filter:var(--tw)}}");
   Alcotest.(check string)
+    "the declared target prefixes mask feature tests and declarations"
+    "@supports(-webkit-mask:none)or \
+     (mask:none){.a{-webkit-mask:none;mask:none}}"
+    (optimized_string "@supports(mask:none){.a{mask:none}}");
+  Alcotest.(check string)
     "an authored fallback is not duplicated"
     ".a{-webkit-backdrop-filter:blur(1px);backdrop-filter:blur(1px)}"
     (optimized_string
        ".a{-webkit-backdrop-filter:blur(1px);backdrop-filter:blur(1px)}");
+  Alcotest.(check string)
+    "an authored mask fallback is not duplicated"
+    ".a{-webkit-mask-size:contain;mask-size:cover}"
+    (optimized_string ".a{-webkit-mask-size:contain;mask-size:cover}");
+  Alcotest.(check string)
+    "a synthesized mask shorthand preserves importance"
+    ".a{-webkit-mask:none!important;mask:none!important}"
+    (optimized_string ".a{mask:none!important}");
   Alcotest.(check string)
     "decoration color needs no prefix for the declared target"
     ".prose a{text-decoration:underline;text-decoration-color:var(--c)}"
@@ -3271,9 +3303,9 @@ let target_evergreen_compatibility_prefixes () =
        ".prose{a{text-decoration:underline;text-decoration-color:var(--c)}}");
   Alcotest.(check string)
     "spec-only mode does not synthesize target fallbacks"
-    ".a{user-select:none;backdrop-filter:blur(1px)}"
+    ".a{user-select:none;backdrop-filter:blur(1px);hyphens:auto;mask:none}"
     (optimized_string ~enforce_spec:true
-       ".a{user-select:none;backdrop-filter:blur(1px)}");
+       ".a{user-select:none;backdrop-filter:blur(1px);hyphens:auto;mask:none}");
   let newer_webkit =
     {
       Css.Optimize.evergreen_targets with
@@ -3285,7 +3317,44 @@ let target_evergreen_compatibility_prefixes () =
     "a newer WebKit target drops only the obsolete fallback"
     ".a{-webkit-user-select:none;user-select:none;backdrop-filter:blur(1px)}"
     (optimized_string ~targets:newer_webkit
-       ".a{user-select:none;backdrop-filter:blur(1px)}")
+       ".a{user-select:none;backdrop-filter:blur(1px)}");
+  let safari_16_6 =
+    {
+      Css.Optimize.evergreen_targets with
+      chrome = (120, 0);
+      safari = (16, 6);
+      ios_safari = (17, 0);
+    }
+  in
+  Alcotest.(check string)
+    "Safari 16.6 still receives the hyphens fallback"
+    ".a{-webkit-hyphens:auto;hyphens:auto}"
+    (optimized_string ~targets:safari_16_6 ".a{hyphens:auto}");
+  let ios_safari_16_7 =
+    {
+      Css.Optimize.evergreen_targets with
+      chrome = (120, 0);
+      safari = (17, 0);
+      ios_safari = (16, 7);
+    }
+  in
+  Alcotest.(check string)
+    "iOS Safari 16.7 still receives the hyphens fallback"
+    ".a{-webkit-hyphens:auto;hyphens:auto}"
+    (optimized_string ~targets:ios_safari_16_7 ".a{hyphens:auto}");
+  let targets_past_hyphens_and_mask_prefixes =
+    {
+      Css.Optimize.evergreen_targets with
+      chrome = (120, 0);
+      safari = (17, 0);
+      ios_safari = (17, 0);
+    }
+  in
+  Alcotest.(check string)
+    "targets past the compatibility boundaries omit hyphens and mask prefixes"
+    ".a{hyphens:auto;mask-image:none}"
+    (optimized_string ~targets:targets_past_hyphens_and_mask_prefixes
+       ".a{hyphens:auto;mask-image:none}")
 
 let c61_no_layer_media_merge () =
   (* CSS Cascade section 6.4.4.2: a layer statement between matching media

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4524,8 +4524,10 @@ let test_mask_box () =
   check_mask_box "padding-box";
   check_mask_box "fill-box";
   check_mask_box "inherit";
-  decl_optimizes ~prop:"mask-clip" ~into:"border-box,fill-box,no-clip"
-    "border-box,fill-box,no-clip";
+  decl_optimizes_to
+    ~into:
+      "-webkit-mask-clip:border-box,fill-box,no-clip;mask-clip:border-box,fill-box,no-clip"
+    "mask-clip:border-box,fill-box,no-clip";
   neg_cursor read_mask_box "invalid-mask-box"
 
 let test_mask_composite () =


### PR DESCRIPTION
Add the WebKit fallbacks required by Cascade's declared targets: hyphens before Safari 17, and the compatible mask shorthand and longhands before Chrome 120. Preserve authored fallbacks, and omit mask-mode and mask-composite because their legacy WebKit grammars are not equivalent.