### PR TITLE
diff: equate nested and flattened selectors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -503,6 +503,9 @@ difference wherever the two are not equivalent.
 
 - `--flatten-nesting` leaves the optimized stylesheet flat even when later
   regrouping can shorten adjacent selectors by synthesizing nesting (#759)
+- Canonical diff compares authored nesting through its flattened selector
+  expansion, so equivalent nested and flat stylesheets do not leave residuals
+  (#760)
 - Default `--minify` evaluates all-static unitless `line-height:calc()`
   arithmetic to its six-significant-figure output budget, so `calc(28/18)`
   becomes `1.55556`. `--lossless` keeps repeating quotients symbolic, and

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -259,8 +259,7 @@ let css_for_semantic_comparison ?property css =
 
 let canonical_of_stylesheet ~lossless ~prune_unused_custom_props stylesheet =
   try
-    Some
-      (stylesheet
+    let optimize stylesheet =
       (* Regrouping - factoring a shared declaration into a selector list,
          synthesising nesting from adjacent rules - depends on how the input
          happened to order its rules, so it is not confluent: the same sheet
@@ -279,9 +278,16 @@ let canonical_of_stylesheet ~lossless ~prune_unused_custom_props stylesheet =
          the Level 3 [not all and (X)] - delete nothing, and
          {!Css.canonicalize_rule_order} applies those on the comparison side
          instead. *)
-      |> Css.optimize ~lossless ~regroup:false ~enforce_spec:true
-           ~prune_unused_custom_props
-      |> Css.canonicalize_rule_order
+      Css.optimize ~lossless ~regroup:false ~enforce_spec:true
+        ~prune_unused_custom_props stylesheet
+    in
+    (* A declaration run written after a nested statement first needs the
+       nesting-aware commute check: flattening turns the statement boundary into
+       a top-level rule boundary. Both passes disable regrouping, so this
+       normalization cannot synthesize the nesting the projection removes. *)
+    Some
+      (stylesheet |> optimize |> Css.flatten_nesting |> optimize
+     |> Css.canonicalize_rule_order
       |> Css.to_string ~minify:true ~lossless)
   with Invalid_argument _ -> None
 

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -248,6 +248,17 @@ let canonical_numeric_division_follows_precision_mode () =
     (equal ~lossless:true ".a{line-height:calc(28/18)}"
        ".a{line-height:1.55556}")
 
+let canonical_nested_and_flattened_selectors_are_equal () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  Alcotest.(check bool)
+    "a nested selector equals its flattened expansion" true
+    (equal ".long-component-name{color:red;&:hover{color:blue}}"
+       ".long-component-name{color:red}.long-component-name:hover{color:blue}");
+  Alcotest.(check bool)
+    "different flattened selectors remain distinct" false
+    (equal ".long-component-name{color:red;&:hover{color:blue}}"
+       ".long-component-name{color:red}.long-component-name:focus{color:blue}")
+
 (* CSS Nesting 1 sec. 3.4 keeps a declaration written after a nested rule where
    the author wrote it, which only matters for a property the nested rule also
    sets. Where nothing clashes across the boundary the two spellings compute the
@@ -267,15 +278,14 @@ let canonical_declaration_after_nested_rule () =
   Alcotest.(check bool)
     "a var() reader crosses a nested definition of what it reads" true
     (equal ".a{width:var(--x);& b{--x:1px}}" ".a{& b{--x:1px}width:var(--x)}");
-  (* The clashing pair is a real difference: hoisting [color] over the nested
-     rule is the miscompile the position exists to prevent. *)
+  (* The clashing pair uses the same effective selector, so its equal
+     specificity makes source order decide the winner. *)
   Alcotest.(check bool)
     "a clashing declaration still differs" false
-    (equal ".a{color:red;& b{color:blue}}" ".a{& b{color:blue}color:red}");
+    (equal ".a{color:red;&{color:blue}}" ".a{&{color:blue}color:red}");
   Alcotest.(check bool)
     "a longhand still clashes with a crossed shorthand" false
-    (equal ".a{margin-top:2px;& b{margin:1px}}"
-       ".a{& b{margin:1px}margin-top:2px}")
+    (equal ".a{margin-top:2px;&{margin:1px}}" ".a{&{margin:1px}margin-top:2px}")
 
 (* Filter Effects 1 sec. 6.1 makes an omitted [hue-rotate()] argument 0, and
    [hue-rotate] names a filter function and nothing else, so the two spellings
@@ -1602,4 +1612,6 @@ let suite =
         `Quick equal_canonical_lossless_exact_srgb;
       Alcotest.test_case "canonical numeric precision modes" `Quick
         canonical_numeric_division_follows_precision_mode;
+      Alcotest.test_case "canonical nested and flattened selectors" `Quick
+        canonical_nested_and_flattened_selectors_are_equal;
     ] )


### PR DESCRIPTION
Canonical diff kept authored nesting, so equivalent nested and flat stylesheets compared unequal. Normalize nesting without regrouping, flatten both inputs, then project the flat forms through the same canonical settings.