### PR TITLE
properties: centralize inheritance metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -506,6 +506,10 @@ difference wherever the two are not equivalent.
 - Canonical diff compares authored nesting through its flattened selector
   expansion, so equivalent nested and flat stylesheets do not leave residuals
   (#760)
+- Property inheritance is one exhaustive classification keyed by the typed
+  property identity. `cascade apply --minimal` now drops inherited
+  `writing-mode` restatements, and computed-value `unset` resolution cannot
+  drift onto a different table (#763)
 - Default `--minify` evaluates all-static unitless `line-height:calc()`
   arithmetic to its six-significant-figure output budget, so `calc(28/18)`
   becomes `1.55556`. `--lossless` keeps repeating quotients symbolic, and

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -19,47 +19,10 @@ let inlinable = Resolve.supported
    properties land on it). *)
 let no_style = [ "head"; "meta"; "title"; "base"; "link"; "style"; "script" ]
 
-(* CSS inherited properties (a conservative set: missing one only keeps a
-   redundant declaration; a differential test guards against dropping a needed
-   one). *)
-let inherited =
-  [
-    "color";
-    "font";
-    "font-family";
-    "font-size";
-    "font-weight";
-    "font-style";
-    "font-variant";
-    "font-stretch";
-    "font-feature-settings";
-    "line-height";
-    "letter-spacing";
-    "word-spacing";
-    "text-align";
-    "text-indent";
-    "text-transform";
-    "text-shadow";
-    "white-space";
-    "word-break";
-    "overflow-wrap";
-    "hyphens";
-    "tab-size";
-    "visibility";
-    "cursor";
-    "direction";
-    "list-style";
-    "list-style-type";
-    "list-style-position";
-    "list-style-image";
-    "quotes";
-    "caption-side";
-    "border-collapse";
-    "border-spacing";
-    "empty-cells";
-  ]
-
-let is_inherited p = List.mem (String.lowercase_ascii p) inherited
+let rec declaration_is_inherited = function
+  | Declaration.Declaration { property; _ } ->
+      Properties.property_is_inherited property
+  | Declaration.Theme_guarded { decl; _ } -> declaration_is_inherited decl
 
 module SMap = Map.Make (String)
 
@@ -463,7 +426,7 @@ module Make (Node : Resolve.NODE) = struct
               let p = String.lowercase_ascii (Declaration.property_name d) in
               match footprint d with
               | Every_slot -> (d :: kept, [])
-              | Slots keys when not (is_inherited p) ->
+              | Slots keys when not (declaration_is_inherited d) ->
                   (d :: kept, forget keys ctx)
               | Slots keys ->
                   let v = decl_value d in

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -670,27 +670,6 @@ let kind_equal : type a b.
   | Properties.Font_src, Properties.Font_src -> Some Refl
   | _ -> None
 
-(* CSS Cascade 5 sec. 7.2 lists inherited properties; the rest default to the
-   property's initial value when no value is supplied. *)
-let property_is_inherited = function
-  | "color" | "cursor" | "direction" | "font-family" | "font-feature-settings"
-  | "font-kerning" | "font-language-override" | "font-optical-sizing"
-  | "font-size" | "font-size-adjust" | "font-stretch" | "font-style"
-  | "font-synthesis" | "font-variant" | "font-variant-alternates"
-  | "font-variant-caps" | "font-variant-east-asian" | "font-variant-emoji"
-  | "font-variant-ligatures" | "font-variant-numeric" | "font-variant-position"
-  | "font-weight" | "font" | "hyphens" | "letter-spacing" | "line-height"
-  | "list-style" | "list-style-image" | "list-style-position"
-  | "list-style-type" | "orphans" | "quotes" | "tab-size" | "text-align"
-  | "text-align-last" | "text-decoration-skip-ink" | "text-emphasis"
-  | "text-emphasis-color" | "text-emphasis-position" | "text-emphasis-style"
-  | "text-indent" | "text-justify" | "text-orientation" | "text-rendering"
-  | "text-shadow" | "text-transform" | "text-underline-position" | "visibility"
-  | "white-space" | "widows" | "word-break" | "word-spacing" | "word-wrap"
-  | "writing-mode" ->
-      true
-  | _ -> false
-
 let read_full_components read components =
   match
     let cursor = Cursor.of_components components in
@@ -3570,8 +3549,7 @@ and resolve_typed : type b.
   let value = simplify value in
   Option.value
     (Option.bind (css_wide_of value) (fun keyword ->
-         resolve_css_wide_keyword ~layer_order ctx ~important
-           ~property_name:(property_name property) keyword))
+         resolve_css_wide_keyword ~layer_order ctx ~important ~property keyword))
     ~default:(Declaration.v ~important property value)
 
 and eval_kind : type a.
@@ -3587,8 +3565,15 @@ and eval_kind : type a.
   let simplify, css_wide_of = kind_simplifier ~layer_order ?layer ctx kind in
   resolve_typed ~layer_order ctx simplify css_wide_of property important value
 
-and resolve_css_wide_keyword ~layer_order ctx ~important ~property_name keyword
-    =
+and resolve_css_wide_keyword : type b.
+    layer_order:string list ->
+    t ->
+    important:bool ->
+    property:b Properties.property ->
+    css_wide_keyword ->
+    Declaration.declaration option =
+ fun ~layer_order ctx ~important ~property keyword ->
+  let property_name = property_name property in
   let eval_source ctx decl = eval_typed ~layer_order ctx decl in
   let inherit_source () =
     match inherited_value property_name ctx with
@@ -3597,7 +3582,7 @@ and resolve_css_wide_keyword ~layer_order ctx ~important ~property_name keyword
   in
   let initial_source () = initial_value property_name ctx in
   let unset_source () =
-    if property_is_inherited property_name then inherit_source ()
+    if Properties.property_is_inherited property then inherit_source ()
     else initial_source ()
   in
   let cascade_source () =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -776,6 +776,255 @@ let pp_property : type a. a property Pp.t =
   | Ms_filter -> Pp.string ctx "-ms-filter"
   | O_transition -> Pp.string ctx "-o-transition"
 
+(* Whether the property inherits by default, as defined by each property's
+   specification. Keep this exhaustive over the sealed property GADT: adding a
+   constructor must force a decision here. Names without a typed constructor
+   stay in [Unknown_property], where the payload is the only identity available.
+   Shorthands count as inherited when every longhand they reset inherits. *)
+let property_is_inherited : type a. a property -> bool = function
+  | Unknown_property name -> (
+      match String.lowercase_ascii name with
+      | "empty-cells" | "font-variant" | "font-variant-alternates" | "orphans"
+      | "text-align-last" | "text-justify" | "text-rendering" | "widows"
+      | "word-wrap" ->
+          true
+      | _ -> false)
+  | Color -> true
+  | Font_size -> true
+  | Line_height -> true
+  | Font_weight -> true
+  | Font_style -> true
+  | Text_align -> true
+  | Text_underline_offset -> true
+  | Text_decoration_skip -> true
+  | Text_decoration_skip_box -> true
+  | Text_decoration_skip_inset -> true
+  | Text_decoration_skip_spaces -> true
+  | Text_emphasis -> true
+  | Text_emphasis_style -> true
+  | Text_emphasis_color -> true
+  | Text_emphasis_position -> true
+  | Text_emphasis_skip -> true
+  | Text_orientation -> true
+  | Text_transform -> true
+  | Letter_spacing -> true
+  | List_style_type -> true
+  | List_style_position -> true
+  | List_style_image -> true
+  | Visibility -> true
+  | Fill_opacity -> true
+  | Stroke_opacity -> true
+  | Cursor -> true
+  | Interactivity -> true
+  | Caret_animation -> true
+  | Caret_shape -> true
+  | Caret -> true
+  | Interest_delay -> true
+  | Interest_delay_start -> true
+  | Interest_delay_end -> true
+  | Border_collapse -> true
+  | Border_spacing -> true
+  | Pointer_events -> true
+  | Forced_color_adjust -> true
+  | White_space -> true
+  | Tab_size -> true
+  | Webkit_text_size_adjust -> true
+  | Font_feature_settings -> true
+  | Font_variation_settings -> true
+  | Webkit_tap_highlight_color -> true
+  | Webkit_text_fill_color -> true
+  | Webkit_text_stroke_color -> true
+  | Text_indent -> true
+  | List_style -> true
+  | Font -> true
+  | Scrollbar_color -> true
+  | Line_height_step -> true
+  | Font_palette -> true
+  | Font_synthesis -> true
+  | Text_wrap_mode -> true
+  | Text_wrap_style -> true
+  | Text_underline_position -> true
+  | Text_box_edge -> true
+  | Inline_sizing -> true
+  | Line_fit_edge -> true
+  | Interpolate_size -> true
+  | Ruby_align -> true
+  | Ruby_merge -> true
+  | Ruby_overhang -> true
+  | Ruby_position -> true
+  | Glyph_orientation_vertical -> true
+  | Text_combine_upright -> true
+  | Image_orientation -> true
+  | Image_rendering -> true
+  | Image_resolution -> true
+  | Font_size_adjust -> true
+  | Font_variant_emoji -> true
+  | Text_spacing_trim -> true
+  | Hyphenate_limit_chars -> true
+  | Initial_letter_align -> true
+  | Initial_letter_wrap -> true
+  | Dominant_baseline -> true
+  | Word_spacing -> true
+  | Text_shadow -> true
+  | Font_family -> true
+  | Webkit_font_smoothing -> true
+  | Moz_osx_font_smoothing -> true
+  | Text_wrap -> true
+  | Word_break -> true
+  | Overflow_wrap -> true
+  | Line_break -> true
+  | Hyphens -> true
+  | Webkit_hyphens -> true
+  | Font_stretch -> true
+  | Font_optical_sizing -> true
+  | Font_kerning -> true
+  | Font_language_override -> true
+  | Font_synthesis_style -> true
+  | Font_synthesis_weight -> true
+  | Font_synthesis_small_caps -> true
+  | Font_synthesis_position -> true
+  | Font_variant_ligatures -> true
+  | Caps -> true
+  | Numeric -> true
+  | Font_variant_position -> true
+  | East_asian -> true
+  | Caption_side -> true
+  | Color_scheme -> true
+  | Print_color_adjust -> true
+  | Webkit_print_color_adjust -> true
+  | Quotes -> true
+  | Text_size_adjust -> true
+  | Fill -> true
+  | Stroke -> true
+  | Stroke_width -> true
+  | Fill_rule -> true
+  | Clip_rule -> true
+  | Stroke_linecap -> true
+  | Stroke_linejoin -> true
+  | Stroke_miterlimit -> true
+  | Stroke_dashoffset -> true
+  | Stroke_dasharray -> true
+  | Paint_order -> true
+  | Direction -> true
+  | Writing_mode -> true
+  | Text_decoration_skip_ink -> true
+  | Accent_color -> true
+  | Caret_color -> true
+  | Custom_property _ | All | Background_color | Border_color | Border_style
+  | Border_top_style | Border_right_style | Border_bottom_style
+  | Border_left_style | Border_inline_start_style | Border_inline_end_style
+  | Border_block_start_style | Border_block_end_style | Padding | Padding_left
+  | Padding_right | Padding_bottom | Padding_top | Padding_inline
+  | Padding_inline_start | Padding_inline_end | Padding_block
+  | Padding_block_start | Padding_block_end | Margin | Margin_inline_end
+  | Margin_inline_start | Margin_left | Margin_right | Margin_top
+  | Margin_bottom | Margin_inline | Margin_block | Margin_block_start
+  | Margin_block_end | Gap | Column_gap | Row_gap | Width | Height | Min_width
+  | Min_height | Max_width | Max_height | Inline_size | Min_inline_size
+  | Max_inline_size | Block_size | Min_block_size | Max_block_size
+  | Text_decoration | Text_decoration_line | Text_decoration_style
+  | Text_decoration_color | Text_decoration_skip_self | Display | Position
+  | Baseline_source | Alignment_baseline | Baseline_shift | Flex_direction
+  | Flex_wrap | Flex_flow | Flex | Flex_grow | Flex_shrink | Flex_basis | Order
+  | Align_items | Justify_content | Justify_items | Justify_self | Align_content
+  | Align_self | Place_content | Place_items | Place_self
+  | Grid_template_columns | Grid_template_rows | Grid_template_areas
+  | Grid_template | Grid | Grid_area | Grid_auto_flow | Grid_auto_columns
+  | Grid_auto_rows | Grid_column | Grid_row | Grid_column_start
+  | Grid_column_end | Grid_row_start | Grid_row_end | Border_width
+  | Border_top_width | Border_right_width | Border_bottom_width
+  | Border_left_width | Border_inline_start_width | Border_inline_end_width
+  | Border_block_start_width | Border_block_end_width | Border_inline_width
+  | Border_block_width | Border_image | Border_image_source | Border_image_slice
+  | Border_image_repeat | Border_image_width | Border_image_outset
+  | Border_radius | Border_top_left_radius | Border_top_right_radius
+  | Border_bottom_left_radius | Border_bottom_right_radius | Border_top_color
+  | Border_right_color | Border_bottom_color | Border_left_color
+  | Border_inline_start_color | Border_inline_end_color
+  | Border_block_start_color | Border_block_end_color | Border_inline_color
+  | Border_block_color | Border_inline_style | Border_block_style
+  | Border_start_start_radius | Border_start_end_radius
+  | Border_end_start_radius | Border_end_end_radius | Opacity | Stop_opacity
+  | Flood_opacity | Mix_blend_mode | Transform | Translate | Nav_up | Nav_right
+  | Nav_down | Nav_left | Table_layout | User_select | Overflow | Inset
+  | Inset_inline | Inset_inline_start | Inset_inline_end | Inset_block
+  | Inset_block_start | Inset_block_end | Top | Right | Bottom | Left | Z_index
+  | Outline | Outline_style | Outline_width | Outline_color | Outline_offset
+  | Scroll_snap_type | Border | Border_block | Border_block_start
+  | Border_block_end | Border_inline | Border_inline_start | Border_inline_end
+  | Background | Zoom | Webkit_user_select | Moz_user_select | Ms_user_select
+  | Webkit_text_decoration | Webkit_text_decoration_color | Source
+  | Webkit_appearance | Webkit_transform | Moz_transform | Ms_transform
+  | O_transform | Webkit_transition | Webkit_transition_delay
+  | Webkit_transition_duration | Webkit_transition_property
+  | Webkit_transition_timing_function | Webkit_animation
+  | Webkit_animation_delay | Webkit_animation_duration
+  | Webkit_animation_direction | Webkit_animation_iteration_count
+  | Webkit_animation_name | Webkit_animation_timing_function
+  | Webkit_animation_fill_mode | Webkit_animation_play_state
+  | Webkit_flex_direction | Webkit_flex_wrap | Webkit_flex_flow
+  | Webkit_justify_content | Webkit_align_items | Webkit_align_content
+  | Webkit_align_self | Webkit_border_radius | Webkit_box_sizing
+  | Moz_box_sizing | Webkit_box_shadow | Webkit_background_size | Webkit_filter
+  | Moz_appearance | Moz_animation | Moz_animation_delay
+  | Moz_animation_duration | Moz_animation_direction
+  | Moz_animation_iteration_count | Moz_animation_name
+  | Moz_animation_timing_function | Moz_animation_fill_mode
+  | Moz_animation_play_state | Moz_transition | Moz_transition_delay
+  | Moz_transition_duration | Moz_transition_property
+  | Moz_transition_timing_function | Moz_border_radius | Moz_box_shadow
+  | Ms_filter | O_transition | Container_type | Container_name | Container
+  | Anchor_name | Position_anchor | Position_try_fallbacks | Position_try_order
+  | Position_try | Position_visibility | Position_area | Shape_outside
+  | Shape_margin | Shape_image_threshold | Overflow_clip_margin
+  | Overflow_anchor | Scrollbar_width | Scrollbar_gutter | Text_box_trim
+  | Text_box | Min_intrinsic_sizing | Animation_timeline | Animation_range
+  | Animation_range_start | Animation_range_end | Scroll_timeline
+  | Scroll_timeline_name | Scroll_timeline_axis | View_transition_name
+  | View_transition_class | Contain_intrinsic_size | Contain_intrinsic_width
+  | Contain_intrinsic_height | Contain_intrinsic_block_size
+  | Contain_intrinsic_inline_size | Margin_trim | Offset_path | Offset_distance
+  | Offset_rotate | Initial_letter | View_timeline_name | View_timeline_axis
+  | View_timeline_inset | View_timeline | Timeline_scope | Perspective
+  | Perspective_origin | Transform_style | Backface_visibility | Object_position
+  | Rotate | Transition_duration | Transition_timing_function | Transition_delay
+  | Transition_property | Transition_behavior | Overlay | Will_change | Contain
+  | Isolation | Break_before | Break_after | Break_inside | Page_break_before
+  | Page_break_after | Page_break_inside | Page_size | Columns | Column_width
+  | Column_count | Column_rule | Column_rule_color | Column_span
+  | Background_attachment | Border_top | Border_right | Border_bottom
+  | Border_left | Transform_origin | Transform_box | Clip_path | Mask
+  | Mask_border | Content_visibility | Filter | Background_image
+  | Background_origin | Background_clip | Webkit_background_clip | Animation
+  | Aspect_ratio | Overflow_x | Overflow_y | Overflow_block | Overflow_inline
+  | Vertical_align | Background_position | Background_repeat | Background_size
+  | Webkit_line_clamp | Webkit_box_orient | Moz_orient | Text_overflow
+  | Backdrop_filter | Webkit_backdrop_filter | Webkit_mask_image
+  | Webkit_mask_composite | Webkit_mask_source_type | Webkit_mask_size
+  | Webkit_mask_position | Webkit_mask_repeat | Webkit_mask_clip
+  | Webkit_mask_origin | Mask_image | Mask_composite | Mask_mode | Mask_size
+  | Mask_position | Mask_repeat | Mask_clip | Mask_origin | Mask_type
+  | Scroll_snap_align | Scroll_snap_stop | Scroll_behavior | Box_sizing
+  | Field_sizing | Resize | Object_fit | Object_view_box | Appearance
+  | Box_decoration_break | Webkit_box_decoration_break | Content | Counter_reset
+  | Counter_increment | Text_decoration_thickness | Touch_action | Clip | Clear
+  | Float | Scale | Transition | Box_shadow | Vector_effect | Stop_color
+  | Flood_color | Lighting_color | Unicode_bidi | Animation_name
+  | Animation_duration | Animation_timing_function | Animation_delay
+  | Animation_iteration_count | Animation_direction | Animation_fill_mode
+  | Animation_play_state | Animation_composition | Background_blend_mode
+  | Scroll_margin | Scroll_margin_top | Scroll_margin_right
+  | Scroll_margin_bottom | Scroll_margin_left | Scroll_margin_inline
+  | Scroll_margin_inline_start | Scroll_margin_inline_end | Scroll_margin_block
+  | Scroll_margin_block_start | Scroll_margin_block_end | Scroll_padding
+  | Scroll_padding_top | Scroll_padding_right | Scroll_padding_bottom
+  | Scroll_padding_left | Scroll_padding_inline | Scroll_padding_inline_start
+  | Scroll_padding_inline_end | Scroll_padding_block
+  | Scroll_padding_block_start | Scroll_padding_block_end | Overscroll_behavior
+  | Overscroll_behavior_x | Overscroll_behavior_y | Overscroll_behavior_block
+  | Overscroll_behavior_inline | Offset_anchor | Offset_position | Offset ->
+      false
+
 (* Whether the name [pp_property] gives [property] under minify can carry
    [value]. CSS Fragmentation 3 sec. 3.4 defines the [page-break-*] alias of
    [break-*] by a value mapping table, so the [break-*] name a [page-break-*]

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -6,6 +6,12 @@ include module type of Properties_intf
 val pp_property : 'a property Pp.t
 (** [pp_property] is the pretty-printer for property names. *)
 
+val property_is_inherited : 'a property -> bool
+(** [property_is_inherited property] is whether [property] inherits by default.
+    Shorthands return [true] when every longhand they reset inherits. The
+    classification is exhaustive over the property GADT, so adding a property
+    requires an explicit decision here. *)
+
 val minified_name_carries : 'a property -> 'a -> bool
 (** [minified_name_carries property value] is whether the name {!pp_property}
     gives [property] under minify can carry [value]. A [page-break-*] property

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -283,6 +283,29 @@ let minimal_keeps_a_relative_value () =
   dropped "color:hsl(210 40% 96%)";
   dropped "color:#f1f5f9"
 
+(* CSS Writing Modes 4 sec. 7.1 makes [writing-mode] inherited. A declaration on
+   a child that restates its ancestor's element-independent value therefore
+   contributes nothing in minimal mode, just like the other inherited
+   properties. *)
+let minimal_drops_a_writing_mode_restatement () =
+  let child = node "p" in
+  let root = node ~children:[ child ] "div" in
+  let result =
+    A.compute ~minimal:true
+      ~sheet:(parse "div{writing-mode:vertical-rl}p{writing-mode:vertical-rl}")
+      [ root ]
+  in
+  let style n =
+    match List.find_opt (fun (m, _) -> Node.equal m n) result.styles with
+    | Some (_, decls) -> inline_style decls
+    | None -> Alcotest.fail "no assignment for the node"
+  in
+  Alcotest.(check string)
+    "the ancestor establishes writing-mode" "writing-mode:vertical-rl"
+    (style root);
+  Alcotest.(check string)
+    "the inherited restatement is redundant" "" (style child)
+
 (* [minimal] drops a restated inherited declaration because the same text is
    already in force from an ancestor, but a shorthand also resets every longhand
    it does not mention, and an element in between can set one of those: the
@@ -605,6 +628,8 @@ let suite =
         minimal_keeps_what_a_ua_rule_would_win;
       Alcotest.test_case "minimal keeps a relative value" `Quick
         minimal_keeps_a_relative_value;
+      Alcotest.test_case "minimal drops a writing-mode restatement" `Quick
+        minimal_drops_a_writing_mode_restatement;
       Alcotest.test_case "minimal keeps a restatement that resets a longhand"
         `Quick minimal_keeps_a_restatement_that_resets_a_longhand;
       Alcotest.test_case "keeps the property a scoped rule sets" `Quick


### PR DESCRIPTION
`Css.Context.eval` and `cascade apply --minimal` used divergent inheritance tables, so `unset` and redundant inherited declarations could disagree. One exhaustive property classification now drives both.