### PR TITLE
context: resolve CSS-wide keywords for every property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -506,6 +506,9 @@ difference wherever the two are not equivalent.
 - Canonical diff compares authored nesting through its flattened selector
   expansion, so equivalent nested and flat stylesheets do not leave residuals
   (#760)
+- Computed-value evaluation resolves direct `inherit`, `initial`, `unset`,
+  `revert` and `revert-layer` values for every typed property, including value
+  shapes without a property-specific optimizer (#764)
 - Property inheritance is one exhaustive classification keyed by the typed
   property identity. `cascade apply --minimal` now drops inherited
   `writing-mode` restatements, and computed-value `unset` resolution cannot

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -2387,6 +2387,21 @@ let simplify_filter ?layer_order ?layer cascade length_ctx value =
 
 type css_wide_keyword = Inherit | Initial | Unset | Revert | Revert_layer
 
+(* [pp_property_value] is exhaustive over the sealed property GADT, so this
+   generic path cannot silently miss a newly added property. CSS-wide keywords
+   are reserved from every property's ordinary grammar, making an exact minified
+   rendering unambiguous here. *)
+let css_wide_of_property_value property value =
+  match
+    Pp.to_string ~minify:true Properties.pp_property_value (property, value)
+  with
+  | "inherit" -> Some Inherit
+  | "initial" -> Some Initial
+  | "unset" -> Some Unset
+  | "revert" -> Some Revert
+  | "revert-layer" -> Some Revert_layer
+  | _ -> None
+
 let css_wide_of_length (value : Values.length) =
   match value with
   | Values.Inherit -> Some Inherit
@@ -3531,10 +3546,17 @@ let rec eval_typed ?layer_order ?layer ctx decl =
       Declaration.theme_guarded ~var_name
         (eval_typed ~layer_order ?layer ctx decl)
   | Declaration.Declaration { property; value; important; _ } -> (
-      match Properties.property_value_kind property with
-      | Some kind ->
-          eval_kind ~layer_order ?layer ctx kind property important value
-      | None -> decl)
+      match css_wide_of_property_value property value with
+      | Some keyword ->
+          Option.value
+            (resolve_css_wide_keyword ~layer_order ctx ~important ~property
+               keyword)
+            ~default:decl
+      | None -> (
+          match Properties.property_value_kind property with
+          | Some kind ->
+              eval_kind ~layer_order ?layer ctx kind property important value
+          | None -> decl))
 
 and resolve_typed : type b.
     layer_order:string list ->

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2684,8 +2684,9 @@ val read_any_property : Cursor.t -> any_property
 (** [read_any_property t] parses any CSS property. *)
 
 val property_value_kind : 'a property -> 'a property_value_kind option
-(** [property_value_kind property] classifies property value shapes that have a
-    shared typed evaluator. *)
+(** [property_value_kind property] returns the optional property-specific
+    evaluator for a value shape. Generic context evaluation, including direct
+    CSS-wide keywords, does not depend on this specialization. *)
 
 (** {2 Function names} *)
 

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -1023,11 +1023,15 @@ let test_computed_value_resolution_contract () =
         [
           Css.Declaration.of_string "color: blue";
           Css.Declaration.of_string "font-size: 10px";
+          Css.Declaration.of_string "line-height: 1.5";
+          Css.Declaration.of_string "border-collapse: collapse";
         ]
       ~initial_values:
         [
           Css.Declaration.of_string "display: inline";
           Css.Declaration.of_string "width: auto";
+          Css.Declaration.of_string "line-height: normal";
+          Css.Declaration.of_string "border-collapse: separate";
         ]
       ~base_url:"https://example.test/css/app.css"
       ~root_font_size:(Css.Values.Px 16.) ~parent_font_size:(Css.Values.Px 10.)
@@ -1045,6 +1049,14 @@ let test_computed_value_resolution_contract () =
     ~expected:"blue" "color: unset";
   check_eval_value "unset on non-inherited property uses initial value" ~ctx
     ~expected:"auto" "width: unset";
+  check_eval_value "line-height inherit uses inherited value" ~ctx
+    ~expected:"1.5" "line-height: inherit";
+  check_eval_value "line-height unset uses inherited value" ~ctx ~expected:"1.5"
+    "line-height: unset";
+  check_eval_value "line-height initial uses initial value" ~ctx
+    ~expected:"normal" "line-height: initial";
+  check_eval_value "border-collapse unset uses inherited value" ~ctx
+    ~expected:"collapse" "border-collapse: unset";
   check_eval_value "currentColor uses explicit current color" ~ctx
     ~expected:"red" "border-color: currentColor";
   check_eval_value "custom property var resolves from context" ~ctx


### PR DESCRIPTION
`Css.Context.eval` left CSS-wide keywords unresolved for property types without a specialized evaluator. Direct CSS-wide values now resolve for every typed property; stacked on #763 for inherited-property classification.