### PR TITLE
animation: accept mixed-case keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -174,6 +174,8 @@ difference wherever the two are not equivalent.
 
 ### Parsing
 
+- Mixed-case keywords in `animation-range` and `scroll()` parse and serialize
+  in their canonical lowercase form (#767)
 - Grid track sizes accept math functions that resolve to `<flex>`, including
   `calc(1fr * 2)`, `min(1fr, 2fr)` and `clamp(100px, 1fr, 300px)`, in explicit,
   repeated and automatic tracks (#749)

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -155,7 +155,7 @@ let split_ws_words s =
   |> List.filter (fun word -> String.length word > 0)
 
 let canonical_scroll_timeline_args args =
-  let words = split_ws_words args in
+  let words = List.map String.lowercase_ascii_preserve (split_ws_words args) in
   let axes = [ "block"; "inline" ] in
   let scrollers = [ "nearest"; "root"; "self" ] in
   if
@@ -1908,11 +1908,14 @@ let read_animation_range_name t : animation_range_name =
 let animation_range_names =
   [ "cover"; "contain"; "entry"; "exit"; "entry-crossing"; "exit-crossing" ]
 
+let is_animation_range_name name =
+  List.mem (String.lowercase_ascii_preserve name) animation_range_names
+
 let read_animation_range_offset t : length_percentage option =
   Cursor.ws t;
   if Cursor.is_done t then (None : length_percentage option)
   else
-    match Cursor.peek_ident t with
+    match Option.map String.lowercase_ascii_preserve (Cursor.peek_ident t) with
     | Some "normal" -> (None : length_percentage option)
     | Some next when List.mem next animation_range_names ->
         (None : length_percentage option)
@@ -1932,7 +1935,7 @@ let rec read_animation_range_item t : animation_range_item =
   let read_item t =
     Cursor.ws t;
     match Cursor.peek_ident t with
-    | Some name when List.mem name animation_range_names ->
+    | Some name when is_animation_range_name name ->
         let name : animation_range_name = read_animation_range_name t in
         let lp = read_animation_range_offset t in
         (Named (name, lp) : animation_range_item)
@@ -1958,7 +1961,9 @@ let rec read_animation_range t : animation_range =
   let read_range t =
     let read_single t =
       Cursor.ws t;
-      match Cursor.peek_ident t with
+      match
+        Option.map String.lowercase_ascii_preserve (Cursor.peek_ident t)
+      with
       | Some "normal" ->
           let _ = Cursor.ident t in
           (Normal : animation_range_item)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3452,8 +3452,10 @@ let spec_platform_property_vectors () =
       ("text-box-trim: trim-both", "text-box-trim:trim-both");
       ("writing-mode: sideways-rl", "writing-mode:sideways-rl");
       ("animation-timeline: scroll()", "animation-timeline:scroll()");
+      ("animation-timeline: scroll(Block)", "animation-timeline:scroll()");
       ( "animation-range: entry 0% exit 100%",
         "animation-range:entry 0%exit 100%" );
+      ("animation-range: Cover 10%", "animation-range:cover 10%");
       ( "transition-behavior: allow-discrete",
         "transition-behavior:allow-discrete" );
       ("view-transition-name: card", "view-transition-name:card");


### PR DESCRIPTION
CSS keyword identifiers are ASCII case-insensitive, but `animation-range` rejected mixed-case range names and `scroll()` skipped canonicalization for mixed-case axis and scroller keywords. Compare these keywords in lowercase so valid values parse and serialize canonically.