### PR TITLE
docs: make README claims concrete

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ significant figures; `--lossless` disables that approximate fold. The exact-only
 rule also governs a `calc()` inside a custom-property value, whose token stream
 is otherwise left opaque.
 
-This is a parser/printer round trip, not a byte-preserving formatter: comments
-are discarded during parsing, and empty rules and invalid declarations are
-dropped in both pretty and minified output.
+Cascade parses the stylesheet into an AST and prints it again. Comments are
+discarded during parsing, and empty rules and invalid declarations are dropped
+in both pretty and minified output.
 
 ### Common recipes
 
@@ -112,14 +112,14 @@ cat style.css | cascade -                                          # read stdin
 | `--objective=transfer\|raw` | Size metric `--minify` optimises for. `transfer` (default) keeps a global-factoring result only when it also shrinks the estimated gzip (DEFLATE) size of the output, since repeated declaration text is nearly free once compressed. `raw` keeps every raw-byte win and drives the factoring fixpoint to convergence, the right objective when the output ships uncompressed (inline style attributes, email HTML), at a large multiple of the default's wall clock. Has no effect without `--minify`. |
 | `--lossless` | Disable bounded approximation under `--minify`. Exact rewrites still run, but repeating static numeric arithmetic stays as `calc()`, and static modern colour-space values and `color-mix()` stay functional. Otherwise-independent declarations retain their authored order instead of being sorted for compression. Has no effect without `--minify`. |
 | `--enforce-spec` | Drop the evergreen-browser baseline target. Cascade still serialises to the shortest form the CSS text and the specs prove on their own, so it keeps every vendor-prefixed declaration, the `min-`/`max-` spelling of a media or container feature, the `&` prefix on a nested selector, the author's `:not(:dir(ltr))` and `input:not(:enabled)`, the number form of an `oklab`/`oklch` axis, and the quotes around a multi-word font family. It also holds the parser to the ident code points CSS Syntax 3 lists, which is the one part that acts without `--minify`. |
-| `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph and unlocks partial-coverage shorthand synthesis. |
+| `--scope=fragment\|stylesheet` | How much surrounding CSS context to assume. `fragment` (default) treats the input as an excerpt; `stylesheet` asserts the input is the whole author CSS graph, allowing Cascade to synthesise shorthands that reset omitted longhands because there are no unseen author declarations to overwrite. |
 | `--closed-world` | Assume you know the exact HTML and that no element ever matches two clashing selectors, so the optimiser may merge rules it would otherwise keep apart. Unsafe: the page can render wrong if such an element appears, including one a script adds at runtime. This is about the HTML, where `--scope` is about how much of the CSS you control; see [Scope](#scope). Has no effect without `--minify`. |
 | `--flatten-nesting` | Desugar nested rules into flat top-level rules for browsers that pre-date CSS Nesting. By default cascade preserves nesting since modern browsers parse it natively and it is usually shorter. |
 | `--inline-imports` | Resolve `@import` against files relative to the input. Without `--import-root`, this may read any local path available to the process and is unsafe for untrusted CSS. |
 | `--import-root=DIR` | Restrict `--inline-imports` to the canonical root and its descendants. Lexical `..` and symlink escapes are rejected; relative roots are resolved from the current working directory. |
 | `--inline-vars` | Substitute `var(--name)` references with their declared values, then drop unused custom properties. Closed-world: assumes no runtime mutation of the variables it inlines. |
 | `--keep-vars=NAMES` | Comma-separated custom-property names to preserve under `--inline-vars`. |
-| `--profile` | Print the optimiser's global factoring fixpoint to stderr after the run: one row per iteration with the rules, bytes and time on each side, then the committed savings and the preflight's own counters. Useful to triage a slow input. Has no effect without `--minify`. |
+| `--profile` | Print the optimiser's global factoring fixpoint to stderr after the run: one row per iteration with the rules, bytes, and time on each side, then the committed savings and the preflight's own counters. Useful to triage a slow input. Has no effect without `--minify`. |
 | `-q, --quiet` / `-v, --verbose` | Standard verbosity controls. |
 
 ### Size
@@ -300,7 +300,7 @@ cascade prune src/*.html style.css | cascade --minify - > style.min.css
 
 ## In a build, CI, or pre-commit hook
 
-A common shape: minify on build, check formatting in CI, diff structurally
+A common shape: minify on build, check formatting in CI, and diff structurally
 in pre-commit hooks.
 
 <!-- $MDX skip -->
@@ -682,7 +682,7 @@ Prose files carry their non-ASCII content.
 Every user-visible change gets an entry in the top version block of
 [CHANGES.md](CHANGES.md), naming the impact rather than the diff.
 
-Four committed oracle corpora cover parser conformance, decoding robustness,
+Four committed oracle corpora cover parser conformance, malformed UTF-8 input,
 and minified-output behaviour. Each directory records its pinned upstream,
 license notice, and exact regeneration command.
 
@@ -751,7 +751,7 @@ reference for what an AST-level dead-rule check can and cannot claim.
 [Values 4](https://www.w3.org/TR/css-values-4/),
 [Color 4](https://www.w3.org/TR/css-color-4/),
 [Cascade 5](https://www.w3.org/TR/css-cascade-5/),
-[Conditional 5](https://www.w3.org/TR/css-conditional-5/),
+[Conditional 5](https://www.w3.org/TR/css-conditional-5/), and
 [Nesting 1](https://www.w3.org/TR/css-nesting-1/).
 
 ## Licence


### PR DESCRIPTION
Replace abstract README wording with the concrete parser/printer, shorthand-reset, and malformed-UTF-8 behaviours it describes. Also make the affected series grammatically explicit without changing the specification titles.