### PR TITLE
canonical diff: accept safely hoisted supports blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -862,6 +862,9 @@ difference wherever the two are not equivalent.
 
 ### Canonical diff
 
+- Canonical diff no longer reports a reorder when equal `@supports` blocks are
+  hoisted together across a declaration the later block shadows whenever their
+  condition holds. A crossing that changes the winner stays distinct (#775)
 - Canonical numeric arithmetic has an explicit precision contract:
   `calc(28/14)` compares equal to `2`; default mode equates `calc(28/18)` with
   the minifier's `1.55556`, while `--lossless` keeps them distinct (#753, #756)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7858,11 +7858,13 @@ val canonicalize_rule_order : t -> t
     the cascade-conflict graph. A [@media] / [@supports] / [@container] block
     whose transitive content is plain rules moves as one unit, keyed by the
     union of its rules' conflict footprints; conflicting statements keep their
-    relative order, and named [@layer] blocks pin the layer order where they
-    stand. A run of [@property] rules sorts by name, keeping the last
-    registration of each, since CSS Properties and Values API 1 sec. 2 makes
-    registrations for different names order-independent. A [@media] prelude is
-    keyed as the Level 4 query Media Queries 4 makes it equal to -
+    relative order. Two equal [@supports] blocks may merge across an intervening
+    non-important write that the later block shadows with the same selector and
+    property whenever the condition holds. Named [@layer] blocks pin the layer
+    order where they stand. A run of [@property] rules sorts by name, keeping
+    the last registration of each, since CSS Properties and Values API 1 sec. 2
+    makes registrations for different names order-independent. A [@media]
+    prelude is keyed as the Level 4 query Media Queries 4 makes it equal to -
     [not all and (X)] as [not (X)], [min-X]/[max-X] as the range form, and a
     lower bound met by an upper bound as the two-sided interval - and an
     [@container] prelude the same way, which emission cannot do because a Level

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -226,6 +226,70 @@ let interval_clear scan ~lo ~hi mems =
   done;
   !ok
 
+(* Moving an earlier [@supports] block down to a later block with the same
+   condition happens only when that condition is true. In that case a
+   declaration in the later block can make an intervening declaration
+   irrelevant: an identical selector writing the same non-important property
+   wins after both the original and merged order. Remove only those exact
+   shadowed writes before asking whether the earlier block still conflicts with
+   the interval. Other statements and importance combinations stay pinned. *)
+let drop_shadowed_by_rules later_rules (rule : rule) : rule =
+  let selector = Pp.to_string ~minify:true Selector.pp rule.selector in
+  let shadowed : (Declaration.prop_key, unit) Hashtbl.t = Hashtbl.create 8 in
+  List.iter
+    (fun (later : rule) ->
+      if
+        String.equal selector
+          (Pp.to_string ~minify:true Selector.pp later.selector)
+      then
+        List.iter
+          (fun decl ->
+            if not (Declaration.is_important decl) then
+              Hashtbl.replace shadowed (Declaration.property_key decl) ())
+          later.declarations)
+    later_rules;
+  let declarations =
+    List.filter
+      (fun decl ->
+        Declaration.is_important decl
+        || not (Hashtbl.mem shadowed (Declaration.property_key decl)))
+      rule.declarations
+  in
+  if List.compare_lengths declarations rule.declarations = 0 then rule
+  else { rule with declarations }
+
+let rules_conflict ?parent a b =
+  let graph = Rule_graph.of_rules ?parent [ a; b ] in
+  Rule_graph.conflict graph
+    (Rule_graph.Node_id.of_int_exn 0)
+    (Rule_graph.Node_id.of_int_exn 1)
+
+let supports_merge_down_clear ?parent scan ~from ~into =
+  match (fst scan.arr.(from), fst scan.arr.(into)) with
+  | Supports _, Supports _ ->
+      let moving = element_node (fst scan.arr.(from)) (snd scan.arr.(from)) in
+      let later_rules = snd scan.arr.(into) in
+      let node i = Rule_graph.Node_id.of_int_exn i in
+      let rec clear i =
+        if i >= into then true
+        else
+          let conflicts =
+            match fst scan.arr.(i) with
+            | Rule rule ->
+                let residual = drop_shadowed_by_rules later_rules rule in
+                residual.declarations <> []
+                && rules_conflict ?parent moving residual
+            | _ ->
+                List.exists
+                  (fun member ->
+                    Rule_graph.conflict scan.graph (node i) (node member))
+                  scan.members.(from)
+          in
+          (not conflicts) && clear (i + 1)
+      in
+      clear (from + 1)
+  | _ -> false
+
 (* The shape a run element folds in: a style rule merges declaration lists under
    one selector, a conditional block concatenates bodies under an unchanged
    prelude. [element_shape] is the one place the statements that can pair are
@@ -323,8 +387,11 @@ module Shape_table = Hashtbl.Make (Shape_key)
 (* Fold the earlier occurrence [i] down into [j] when nothing in between
    observes its writes moving; otherwise fold [j]'s writes up into [i] when
    nothing in between observes those. *)
-let try_merge ~canon_body scan changed ~last ~key i j =
-  if interval_clear scan ~lo:i ~hi:j scan.members.(i) then begin
+let try_merge ~canon_body ?parent scan changed ~last ~key i j =
+  if
+    interval_clear scan ~lo:i ~hi:j scan.members.(i)
+    || supports_merge_down_clear ?parent scan ~from:i ~into:j
+  then begin
     merge ~canon_body scan changed ~from:i ~into:j;
     Shape_table.replace last key j
   end
@@ -376,7 +443,7 @@ let coalesce ~canon_body ?parent changed (run : (statement * rule list) list) :
         | Some key -> (
             match Shape_table.find_opt last key with
             | Some i when scan.alive.(i) ->
-                try_merge ~canon_body scan changed ~last ~key i j
+                try_merge ~canon_body ?parent scan changed ~last ~key i j
             | _ -> Shape_table.replace last key j)
       done;
       if not scan.merged_any then run

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -287,6 +287,31 @@ let canonical_declaration_after_nested_rule () =
     "a longhand still clashes with a crossed shorthand" false
     (equal ".a{margin-top:2px;&{margin:1px}}" ".a{&{margin:1px}margin-top:2px}")
 
+let canonical_supports_hoisting () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  Alcotest.(check bool)
+    "equivalent supports blocks merge after disjoint rules" true
+    (equal
+       ".a{color:red}@supports (color:color-mix(in \
+        lab,red,red)){.a{color:color-mix(in oklab,red \
+        50%,transparent)}}.x{display:block}.b{color:blue}@supports \
+        (color:color-mix(in lab,red,red)){.b{color:color-mix(in oklab,blue \
+        50%,transparent)}}.y{display:grid}"
+       ".a{color:red}.x{display:block}.b{color:blue}.y{display:grid}@supports \
+        (color:color-mix(in lab,red,red)){.a{color:color-mix(in oklab,red \
+        50%,transparent)}.b{color:color-mix(in oklab,blue 50%,transparent)}}");
+  Alcotest.(check bool)
+    "an overlapping rule prevents supports hoisting" false
+    (equal
+       ".a{color:red}@supports (color:color-mix(in \
+        lab,red,red)){.a{color:color-mix(in oklab,red \
+        50%,transparent)}}.a{color:green}.b{color:blue}@supports \
+        (color:color-mix(in lab,red,red)){.b{color:color-mix(in oklab,blue \
+        50%,transparent)}}.y{display:grid}"
+       ".a{color:red}.a{color:green}.b{color:blue}.y{display:grid}@supports \
+        (color:color-mix(in lab,red,red)){.a{color:color-mix(in oklab,red \
+        50%,transparent)}.b{color:color-mix(in oklab,blue 50%,transparent)}}")
+
 (* Filter Effects 1 sec. 6.1 makes an omitted [hue-rotate()] argument 0, and
    [hue-rotate] names a filter function and nothing else, so the two spellings
    are one value wherever the stream is substituted. *)
@@ -1596,6 +1621,8 @@ let suite =
         `Quick canonical_custom_hue_rotate_zero;
       Alcotest.test_case "canonical folds a disjoint trailing declaration"
         `Quick canonical_declaration_after_nested_rule;
+      Alcotest.test_case "canonical supports hoisting" `Quick
+        canonical_supports_hoisting;
       Alcotest.test_case "canonical keeps custom-property importance" `Quick
         canonical_important_custom_property_distinct;
       Alcotest.test_case "canonical ignores @property order" `Quick


### PR DESCRIPTION
Canonical comparison kept equal `@supports` blocks separated when an intervening rule overlapped an earlier guarded declaration, even if the later guarded block shadows that rule whenever the condition holds.

Allow only that exact same-selector, same-property, non-important shadow during merge-down. Truly order-changing crossings remain distinct.