### PR TITLE
canonical diff: move var readers across independent guards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -862,6 +862,10 @@ difference wherever the two are not equivalent.
 
 ### Canonical diff
 
+- Canonical diff lets a declaration reading `var()` cross a conditional write
+  to that custom property when the rules write disjoint cascade slots. A
+  competing write to the declaration's own property remains order-sensitive
+  (#776)
 - Canonical diff no longer reports a reorder when equal `@supports` blocks are
   hoisted together across a declaration the later block shadows whenever their
   condition holds. A crossing that changes the winner stays distinct (#775)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7855,24 +7855,26 @@ val canonicalize_rule_order : t -> t
     order among those with disjoint footprints (a shorthand and its longhand, or
     two writes of the same property, keep their cascade-significant order), and
     cascade-independent statements sort into a content-keyed linear extension of
-    the cascade-conflict graph. A [@media] / [@supports] / [@container] block
-    whose transitive content is plain rules moves as one unit, keyed by the
-    union of its rules' conflict footprints; conflicting statements keep their
-    relative order. Two equal [@supports] blocks may merge across an intervening
-    non-important write that the later block shadows with the same selector and
-    property whenever the condition holds. Named [@layer] blocks pin the layer
-    order where they stand. A run of [@property] rules sorts by name, keeping
-    the last registration of each, since CSS Properties and Values API 1 sec. 2
-    makes registrations for different names order-independent. A [@media]
-    prelude is keyed as the Level 4 query Media Queries 4 makes it equal to -
-    [not all and (X)] as [not (X)], [min-X]/[max-X] as the range form, and a
-    lower bound met by an upper bound as the two-sided interval - and an
-    [@container] prelude the same way, which emission cannot do because a Level
-    3 parser rejects the shorter forms. A [color(srgb ...)] whose channels all
-    land on a whole byte is keyed as the [rgb()] spelling of the same colour,
-    which emission cannot do either because [color()] needs a browser that
-    parses it. This is a comparison-side normalisation; {!val-optimize} stays
-    source-stable. *)
+    the cascade-conflict graph. Sharing a selector branch alone is not a
+    conflict in this projection: after branch expansion, only overlapping
+    cascade-property writes constrain their order. A [@media] / [@supports] /
+    [@container] block whose transitive content is plain rules moves as one
+    unit, keyed by the union of its rules' conflict footprints; conflicting
+    statements keep their relative order. Two equal [@supports] blocks may merge
+    across an intervening non-important write that the later block shadows with
+    the same selector and property whenever the condition holds. Named [@layer]
+    blocks pin the layer order where they stand. A run of [@property] rules
+    sorts by name, keeping the last registration of each, since CSS Properties
+    and Values API 1 sec. 2 makes registrations for different names
+    order-independent. A [@media] prelude is keyed as the Level 4 query Media
+    Queries 4 makes it equal to - [not all and (X)] as [not (X)],
+    [min-X]/[max-X] as the range form, and a lower bound met by an upper bound
+    as the two-sided interval - and an [@container] prelude the same way, which
+    emission cannot do because a Level 3 parser rejects the shorter forms. A
+    [color(srgb ...)] whose channels all land on a whole byte is keyed as the
+    [rgb()] spelling of the same colour, which emission cannot do either because
+    [color()] needs a browser that parses it. This is a comparison-side
+    normalisation; {!val-optimize} stays source-stable. *)
 
 val optimize :
   ?scope:Optimize.scope ->

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -69,6 +69,10 @@ type t = {
       (** when set, two distinct selectors are assumed not to match a common
           element (a caller-asserted closed DOM), so they never cascade-conflict
           on selector grounds *)
+  pin_shared_branches : bool;
+      (** whether equal selector branches add conservative structural edges;
+          optimizer rewrites need them, while a canonical projection over
+          already-expanded rules does not *)
   parent : Selector.t option;
       (** the enclosing nesting context; every node's overlap is computed on its
           selector expanded against this, and rewrites reuse it so produced
@@ -255,7 +259,7 @@ let effective_selector (parent : Selector.t option) (r : rule) =
 
 (* Conflict between two nodes of a graph by their stored summaries/branches. *)
 let nodes_conflict_reason t i j =
-  if share_branch t.branches.(i) t.branches.(j) then
+  if t.pin_shared_branches && share_branch t.branches.(i) t.branches.(j) then
     Option.Some Shared_branch_pin
   else if
     overlap_key_lists_intersect t.overlap_keys.(i) t.overlap_keys.(j)
@@ -740,7 +744,8 @@ let index_node t (node : node_id) =
     t.decl_overlaps.(i);
   List.iter (fun branch -> index_add t.branch_index branch node) t.branches.(i)
 
-let of_rules ?parent ?(closed_world = false) (rules : rule list) : t =
+let of_rules ?parent ?(closed_world = false) ?(pin_shared_branches = true)
+    (rules : rule list) : t =
   let rules = Array.of_list rules in
   let n = Array.length rules in
   let summaries = Array.map rule_summary rules in
@@ -758,6 +763,7 @@ let of_rules ?parent ?(closed_world = false) (rules : rule list) : t =
     {
       generation = 0;
       closed_world;
+      pin_shared_branches;
       parent;
       count = n;
       rules;
@@ -1152,6 +1158,7 @@ let produced_graph t ~consume ~total ~new_n produced =
   {
     generation = t.generation + 1;
     closed_world = t.closed_world;
+    pin_shared_branches = t.pin_shared_branches;
     parent = t.parent;
     count = new_n;
     rules = append_slack t.rules ~count:total produced;
@@ -1571,6 +1578,7 @@ let to_rules t : rule list =
   Array.to_list (Array.map (fun i -> t.rules.(i)) order)
 
 let canonicalize t =
-  of_rules ?parent:t.parent ~closed_world:t.closed_world (to_rules t)
+  of_rules ?parent:t.parent ~closed_world:t.closed_world
+    ~pin_shared_branches:t.pin_shared_branches (to_rules t)
 
 let to_canonical_rules = to_rules

--- a/lib/rule_graph.mli
+++ b/lib/rule_graph.mli
@@ -54,14 +54,21 @@ type rewrite_error =
   | Cycle
 
 val of_rules :
-  ?parent:Selector.t -> ?closed_world:bool -> Stylesheet.rule list -> t
+  ?parent:Selector.t ->
+  ?closed_world:bool ->
+  ?pin_shared_branches:bool ->
+  Stylesheet.rule list ->
+  t
 (** [of_rules ?parent rules] builds the graph over [rules] (node [i] is the
     [i]th rule). [parent], when set, is the enclosing nesting selector: each
     rule's relative selector is expanded against it so overlap is computed on
     the effective (parent-qualified) selector rather than the raw nested form.
     [closed_world] (default [false]) makes distinct selectors assumed not to
     match a common element, so they never cascade-conflict on selector grounds.
-*)
+    [pin_shared_branches] (default [true]) adds conservative structural edges
+    between rules sharing a selector branch. Optimizer rewrites need those edges
+    to keep produced residuals contiguous; a consumer projecting rules that have
+    already been expanded may disable them. *)
 
 val node_count : t -> int
 (** Number of nodes. *)
@@ -105,8 +112,8 @@ val declaration_body_key : t -> node_id -> int list
 val conflict : t -> node_id -> node_id -> bool
 (** [conflict t i j] is [true] when nodes [i] and [j] are order-constrained:
     equal-specificity selector branches may match a common element and the rules
-    write a shared equal-importance property (or share a selector branch).
-    Symmetric. *)
+    write a shared equal-importance property, or the graph enables structural
+    pins and they share a selector branch. Symmetric. *)
 
 val order_constrained : t -> node_id -> node_id -> bool
 (** [order_constrained] is a clearer alias for {!val-conflict}. *)

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -150,7 +150,7 @@ let sort_run ?parent changed (run : (statement * rule list) list) :
   if n < 2 then List.map fst run
   else
     let g =
-      Rule_graph.of_rules ?parent
+      Rule_graph.of_rules ?parent ~pin_shared_branches:false
         (List.map (fun (stmt, rules) -> element_node stmt rules) run)
     in
     let keys =
@@ -259,7 +259,7 @@ let drop_shadowed_by_rules later_rules (rule : rule) : rule =
   else { rule with declarations }
 
 let rules_conflict ?parent a b =
-  let graph = Rule_graph.of_rules ?parent [ a; b ] in
+  let graph = Rule_graph.of_rules ?parent ~pin_shared_branches:false [ a; b ] in
   Rule_graph.conflict graph
     (Rule_graph.Node_id.of_int_exn 0)
     (Rule_graph.Node_id.of_int_exn 1)
@@ -424,7 +424,7 @@ let coalesce ~canon_body ?parent changed (run : (statement * rule list) list) :
       let arr = Array.of_list run in
       let n = Array.length arr in
       let graph =
-        Rule_graph.of_rules ?parent
+        Rule_graph.of_rules ?parent ~pin_shared_branches:false
           (List.map (fun (stmt, rules) -> element_node stmt rules) run)
       in
       let scan =

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -29,15 +29,8 @@ rather than as a loss and a gain.
   
   --- ref.css
   +++ tw.css
-  └─ @layer utilities (2 reordered, 2 rearranged)
-     ├─ .drop-shadow-blue-500\/50 (position 3) ↔  .drop-shadow-indigo-500 (position 0)
-     ├─ .drop-shadow-blue-500\/50 (moved between rules)
-     │       --tw-drop-shadow-color: #3080ff80
-     │       --tw-drop-shadow: var(--tw-drop-shadow-size)
-     ├─ .drop-shadow-indigo-500 (moved between rules)
-     │       --tw-drop-shadow-color: oklch(.585 .233 277.117)
-     │       --tw-drop-shadow: var(--tw-drop-shadow-size)
-     ├─ .drop-shadow-indigo-500 (position 0) ↔  .drop-shadow-indigo-500 (position 4)
+  └─ @layer utilities (1 reordered)
+     ├─ .drop-shadow-blue-500\/50 ↔  .drop-shadow-indigo-500
      └─ @supports (color: color-mix(in lab,red,red)) (1 reordered)
         └─ .drop-shadow-blue-500\/50 ↔  .drop-shadow-indigo-500
   
@@ -144,14 +137,8 @@ gains or loses a declaration, so neither may be reported as modified.
   
   --- guarded_ref.css
   +++ guarded_tw.css
-  └─ @layer utilities (1 reordered, 2 rearranged)
-     ├─ .x (position 2) ↔  .y (position 0)
-     ├─ .x (moved between rules)
-     │       --c: 1
-     │       --d: 3
-     ├─ .y (moved between rules)
-     │       --c: 4
-     │       --d: 6
+  └─ @layer utilities (1 reordered)
+     ├─ .x ↔  .y
      └─ @supports (zoo: bar) (1 reordered)
         └─ .x ↔  .y
   

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -312,6 +312,45 @@ let canonical_supports_hoisting () =
         (color:color-mix(in lab,red,red)){.a{color:color-mix(in oklab,red \
         50%,transparent)}.b{color:color-mix(in oklab,blue 50%,transparent)}}")
 
+(* CSS Variables 1 secs. 2 and 3 make a custom property an ordinary cascade slot
+   and substitute its computed value into the property containing [var()]. A
+   [color] declaration therefore reads [--x] without writing it: crossing a
+   guarded [--x] write is safe, while crossing a guarded [color] write is
+   not. *)
+let canonical_var_reader_crosses_guarded_writer () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  let condition = "(color:color-mix(in lab,red,red))" in
+  Alcotest.(check bool)
+    "a var() reader crosses an independent guarded writer" true
+    (equal
+       (String.concat ""
+          [
+            ".a{--x:red}.a{color:var(--x)}@supports ";
+            condition;
+            "{.a{--x:blue}}";
+          ])
+       (String.concat ""
+          [
+            ".a{--x:red}@supports ";
+            condition;
+            "{.a{--x:blue}}.a{color:var(--x)}";
+          ]));
+  Alcotest.(check bool)
+    "a competing guarded write pins the var() reader" false
+    (equal
+       (String.concat ""
+          [
+            ".a{--x:red;color:var(--x)}@supports ";
+            condition;
+            "{.a{color:blue}}";
+          ])
+       (String.concat ""
+          [
+            ".a{--x:red}@supports ";
+            condition;
+            "{.a{color:blue}}.a{color:var(--x)}";
+          ]))
+
 (* Filter Effects 1 sec. 6.1 makes an omitted [hue-rotate()] argument 0, and
    [hue-rotate] names a filter function and nothing else, so the two spellings
    are one value wherever the stream is substituted. *)
@@ -1623,6 +1662,8 @@ let suite =
         `Quick canonical_declaration_after_nested_rule;
       Alcotest.test_case "canonical supports hoisting" `Quick
         canonical_supports_hoisting;
+      Alcotest.test_case "canonical var reader crosses guarded writer" `Quick
+        canonical_var_reader_crosses_guarded_writer;
       Alcotest.test_case "canonical keeps custom-property importance" `Quick
         canonical_important_custom_property_distinct;
       Alcotest.test_case "canonical ignores @property order" `Quick


### PR DESCRIPTION
A shared-selector rewrite pin made canonical diff report a reorder when a `var()` reader crossed an independent conditional custom-property write; the comparison projection now ignores that pin while retaining actual cascade conflicts.