### PR TITLE
canonical diff: drop redundant decoration colour alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -862,6 +862,10 @@ difference wherever the two are not equivalent.
 
 ### Canonical diff
 
+- Canonical diff treats identical `-webkit-text-decoration-color` and
+  `text-decoration-color` declarations as Cascade's configured redundant
+  alias. A differing fallback or prefixed-only declaration remains distinct
+  (#777)
 - Canonical diff lets a declaration reading `var()` cross a conditional write
   to that custom property when the rules write disjoint cascade slots. A
   competing write to the declaration's own property remains order-sensitive
@@ -883,8 +887,9 @@ difference wherever the two are not equivalent.
 - The canonical projection no longer deletes content that only a
   browser-support assumption makes dead, which had it report no difference
   between sheets that render differently: a fallback under a baseline-true
-  `@supports`, a vendor-prefixed declaration, an `@import supports()` guard.
-  The respellings gated with those still compare equal (#576)
+  `@supports`, a load-bearing vendor-prefixed declaration, an `@import
+  supports()` guard. The respellings gated with those still compare equal
+  (#576)
 - A redundant `@layer` order pin no longer reads as a difference, so
   `@layer a;@layer a{...}` and `@layer a{...}` compare equal. A pin that fixes
   the order, or one over a position the projection cannot read, is kept (#475)

--- a/README.md
+++ b/README.md
@@ -162,8 +162,11 @@ usable as a CI check.
   selector-list group vs written inline, split vs grouped selector lists)
   compare equal, since none of those moves can change a computed value.
   Cascade-significant order is kept distinct (two writes of the same
-  property, a shorthand and its longhand, a vendor-prefixed alias, `@layer`
-  blocks). Equivalent shorthand decompositions are still not modelled.
+  property, a shorthand and its longhand, a load-bearing vendor-prefixed
+  fallback, `@layer` blocks). An identical
+  `-webkit-text-decoration-color`/`text-decoration-color` twin is normalized
+  away; a differing or prefixed-only declaration remains distinct. Equivalent
+  shorthand decompositions are still not modelled.
   Numeric arithmetic follows the same precision mode as minification: an exact
   quotient such as `calc(28/14)` compares equal to `2` in either mode. By
   default, `calc(28/18)` compares equal to Cascade's six-significant-figure

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7873,8 +7873,11 @@ val canonicalize_rule_order : t -> t
     emission cannot do because a Level 3 parser rejects the shorter forms. A
     [color(srgb ...)] whose channels all land on a whole byte is keyed as the
     [rgb()] spelling of the same colour, which emission cannot do either because
-    [color()] needs a browser that parses it. This is a comparison-side
-    normalisation; {!val-optimize} stays source-stable. *)
+    [color()] needs a browser that parses it. An identical
+    [-webkit-text-decoration-color] compatibility declaration is dropped when
+    its unprefixed twin is present; a differing or prefixed-only declaration is
+    retained. These are comparison-side normalisations; this function does not
+    change {!val-optimize}'s configured emission policy. *)
 
 val optimize :
   ?scope:Optimize.scope ->

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -20,13 +20,15 @@
     {!Cascade.Css.optimize} justifies with what maintained browsers support,
     because those delete content rather than respell it. Taking them leaves the
     declaration written before a baseline-true [@supports] dead, drops a
-    vendor-prefixed declaration whose unprefixed twin is widely available, and
-    clears an [@import supports()] guard, and an engine without the feature
-    reads exactly what each of those deletes - so two sheets that disagree there
-    render differently and the projection keeps them apart. The respellings
-    gated with them, [min-X] into the range form and the Level 3
-    [not all and (X)], delete nothing and are applied by
-    {!Cascade.Css.canonicalize_rule_order} instead.
+    load-bearing vendor-prefixed declaration, and clears an [@import supports()]
+    guard, and an engine without the feature reads exactly what each of those
+    deletes - so two sheets that disagree there render differently and the
+    projection keeps them apart. The respellings gated with them, [min-X] into
+    the range form and the Level 3 [not all and (X)], delete nothing and are
+    applied by {!Cascade.Css.canonicalize_rule_order} instead. That
+    comparison-side pass also drops an identical [-webkit-text-decoration-color]
+    twin, matching Cascade's configured alias normalization; a differing or
+    prefixed-only declaration is retained.
 
     Those bytes are the verdict in mode [`Canonical]. Canonical means equivalent
     inputs project to one form, so two canonical forms that differ are either

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -669,6 +669,14 @@ let canonical_color_spellings (stmts : statement list) : statement list =
     (Common.List.map_preserve canonical_color_spelling)
     stmts
 
+(* The normal optimizer drops this typed alias under its maintained-browser
+   policy, but the canonical optimizer runs spec-literally so it does not erase
+   other compatibility content. Apply only the alias equivalence promised by
+   canonical comparison, at every declaration site. *)
+let canonical_vendor_aliases (stmts : statement list) : statement list =
+  Stylesheet.map_declarations Shorthand.drop_redundant_decoration_color_aliases
+    stmts
+
 (* CSS Properties and Values API 1 sec. 2: registrations for different custom
    property names are order-independent, and for the same name the last one
    wins. So a run of [@property] rules canonicalises to that run sorted by name,
@@ -906,7 +914,8 @@ let canonicalize (stmts : statement list) : statement list =
     fold_layer_pins
       (canonical_query_preludes
          (sort_property_runs
-            (canonical_color_spellings (normalize_custom_values stmts))))
+            (canonical_color_spellings
+               (normalize_custom_values (canonical_vendor_aliases stmts)))))
   in
   let result =
     canonicalize_block ~parent:(None : Selector.t option) changed normalized

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3987,6 +3987,20 @@ let vendor_alias_twin_visual vendor twin =
       v1 = v2 && Bool.equal i1 i2
   | _ -> false
 
+let decoration_color_alias_twin vendor twin =
+  match (vendor, twin) with
+  | ( Declaration
+        {
+          property = Webkit_text_decoration_color;
+          value = v1;
+          important = i1;
+          _;
+        },
+      Declaration
+        { property = Text_decoration_color; value = v2; important = i2; _ } ) ->
+      v1 = v2 && Bool.equal i1 i2
+  | _ -> false
+
 let vendor_alias_twin vendor twin =
   match (vendor, twin) with
   | ( Declaration { property = Webkit_transform; value = v1; important = i1; _ },
@@ -3998,16 +4012,9 @@ let vendor_alias_twin vendor twin =
   | ( Declaration { property = Moz_box_sizing; value = v1; important = i1; _ },
       Declaration { property = Box_sizing; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
-  | ( Declaration
-        {
-          property = Webkit_text_decoration_color;
-          value = v1;
-          important = i1;
-          _;
-        },
-      Declaration
-        { property = Text_decoration_color; value = v2; important = i2; _ } ) ->
-      v1 = v2 && Bool.equal i1 i2
+  | ( Declaration { property = Webkit_text_decoration_color; _ },
+      Declaration { property = Text_decoration_color; _ } ) ->
+      decoration_color_alias_twin vendor twin
   | ( Declaration { property = Webkit_mask_image; value = v1; important = i1; _ },
       Declaration { property = Mask_image; value = v2; important = i2; _ } ) ->
       v1 = v2 && Bool.equal i1 i2
@@ -4036,6 +4043,16 @@ let vendor_alias_twin vendor twin =
       || vendor_alias_twin_transition vendor twin
       || vendor_alias_twin_flex vendor twin
       || vendor_alias_twin_visual vendor twin
+
+(* Canonical comparison follows Cascade's configured normalization for this
+   typed compatibility alias without enabling every target-dependent optimizer
+   rewrite. A differing fallback, mismatched importance, or prefix without a
+   standard twin remains observable and is kept. *)
+let drop_redundant_decoration_color_aliases declarations =
+  filter_preserve
+    (fun declaration ->
+      not (List.exists (decoration_color_alias_twin declaration) declarations))
+    declarations
 
 (* If [name] starts with a CSS vendor prefix ([-webkit-] / [-moz-] / [-ms-] /
    [-o-]) return the unprefixed remainder; otherwise [None]. *)

--- a/lib/shorthand.mli
+++ b/lib/shorthand.mli
@@ -89,6 +89,12 @@ val declarations_commute :
     a different value. Selectors are not read, so two runs that could never meet
     on one element still count as constrained when their properties clash. *)
 
+val drop_redundant_decoration_color_aliases :
+  Declaration.declaration list -> Declaration.declaration list
+(** Drop an identical WebKit [text-decoration-color] compatibility alias when
+    its unprefixed twin is present. Differing values or importance, and a
+    prefixed-only declaration, are kept. *)
+
 val is_all_declaration : Declaration.declaration -> bool
 (** Whether a declaration is the [all] shorthand. *)
 

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -156,6 +156,25 @@ let canonical_keeps_target_gated_content () =
     (equal ".a{color:red;@supports (display:grid){color:blue}}"
        ".a { color: #f00; @supports (display: grid) { color: #00f } }")
 
+(* Cascade's configured normalization treats the WebKit spelling as a typed
+   alias once an identical, widely available unprefixed declaration follows.
+   Canonical comparison should project that redundant twin away without erasing
+   a differing fallback or a prefixed-only declaration. *)
+let canonical_drops_redundant_decoration_color_alias () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  Alcotest.(check bool)
+    "an identical WebKit decoration-color twin is redundant" true
+    (equal ".a{text-decoration-color:red}"
+       ".a{-webkit-text-decoration-color:red;text-decoration-color:red}");
+  Alcotest.(check bool)
+    "a differing WebKit decoration-color fallback remains" false
+    (equal ".a{text-decoration-color:blue}"
+       ".a{-webkit-text-decoration-color:red;text-decoration-color:blue}");
+  Alcotest.(check bool)
+    "a prefixed-only decoration color remains" false
+    (equal ".a{text-decoration-color:red}"
+       ".a{-webkit-text-decoration-color:red}")
+
 (* Media Queries 4 sec. 4.2 gives [min-X]/[max-X] and the range form one
    meaning, and cascade's own minified output writes the range form, so the fold
    has to hold on the comparison side once the projection stops taking the
@@ -1674,6 +1693,8 @@ let suite =
         equal_canonical_media_not_all;
       Alcotest.test_case "canonical keeps target-gated content" `Quick
         canonical_keeps_target_gated_content;
+      Alcotest.test_case "canonical drops redundant decoration-color alias"
+        `Quick canonical_drops_redundant_decoration_color_alias;
       Alcotest.test_case "canonical folds media range spellings" `Quick
         canonical_folds_media_range_spellings;
       Alcotest.test_case "canonical lossless equates exact srgb spellings"


### PR DESCRIPTION
`-webkit-text-decoration-color` remained a semantic difference even when Cascade normalization removes its identical unprefixed twin; canonical comparison now applies that alias fold without dropping load-bearing vendor fallbacks.