### PR TITLE
diff: distinguish repeated container positions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -930,6 +930,9 @@ difference wherever the two are not equivalent.
   properties, with source order breaking ties, so a compatibility block no
   longer makes declarations present on both sides read as added or removed
   (#752)
+- `--diff=tree` tracks each repeated conditional block in source order, so
+  moving a later block past a rule is reported even when an earlier block has
+  the same condition (#779)
 
 ### Library
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1340,16 +1340,26 @@ let order_key_of_stmt stmt =
   | Some (sel, _, _) -> Some (Rule_order (selector_key_of_selector sel))
   | None -> Option.map (fun desc -> Block_order desc) (describe_statement stmt)
 
-(* Order keys in first-occurrence order. *)
+(* Rules take part once per selector: a selector split over several rules moves
+   as one cascade participant. Containers do not have that identity. Separate
+   blocks under the same condition can sit on opposite sides of another rule, so
+   number their occurrences instead of collapsing them onto the first. *)
 let order_keys_in_order stmts =
-  let seen = Hashtbl.create (List.length stmts) in
+  let seen_rules = Hashtbl.create (List.length stmts) in
+  let block_occurrences = Hashtbl.create 8 in
   List.filter_map
     (fun stmt ->
       match order_key_of_stmt stmt with
-      | Some key when not (Hashtbl.mem seen key) ->
-          Hashtbl.add seen key ();
-          Some key
-      | _ -> None)
+      | Some (Rule_order _ as key) when not (Hashtbl.mem seen_rules key) ->
+          Hashtbl.add seen_rules key ();
+          Some (key, 0)
+      | Some (Block_order _ as key) ->
+          let occurrence =
+            Option.value ~default:0 (Hashtbl.find_opt block_occurrences key)
+          in
+          Hashtbl.replace block_occurrences key (occurrence + 1);
+          Some (key, occurrence)
+      | Some (Rule_order _) | None -> None)
     stmts
 
 (* Positions of one longest increasing subsequence of [ranks], by patience
@@ -1397,7 +1407,7 @@ let moved_order_keys stmts1 stmts2 =
   let anchored = increasing_subsequence ranks in
   let moved = Hashtbl.create (Array.length ranks) in
   List.iteri
-    (fun i key -> if not anchored.(i) then Hashtbl.replace moved key ())
+    (fun i (key, _) -> if not anchored.(i) then Hashtbl.replace moved key ())
     common;
   moved
 

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -1195,6 +1195,22 @@ let distant_insertion_is_not_a_move () =
     "twelve insertions are still not a container move" []
     (reordered_containers d)
 
+(* Each repeated condition is a distinct source-order participant. Keeping the
+   first block fixed must not make a later block under the same condition
+   invisible when it crosses a rule. *)
+let later_repeated_media_move_is_reported () =
+  let d =
+    diff_of
+      ~expected:
+        "@media print{.a{color:red}}.x{color:blue}@media \
+         print{.b{color:green}}.y{color:black}"
+      ~actual:
+        "@media print{.a{color:red}}.x{color:blue}.y{color:black}@media \
+         print{.b{color:green}}"
+  in
+  Alcotest.(check (list string))
+    "the later block is a move" [ "print" ] (reordered_containers d)
+
 (* ===== Entries the report cannot name ===== *)
 
 (* The names every rule-level entry claiming an addition or a removal carries.
@@ -1490,6 +1506,8 @@ let suite =
         insertion_ahead_of_media_is_not_a_move;
       Alcotest.test_case "distant insertion is not a move" `Quick
         distant_insertion_is_not_a_move;
+      Alcotest.test_case "later repeated media move is reported" `Quick
+        later_repeated_media_move_is_reported;
       Alcotest.test_case "removed property rule is named" `Quick
         removed_property_rule_is_named;
       Alcotest.test_case "removed keyframes is named" `Quick


### PR DESCRIPTION
Repeated conditional blocks currently share the first block’s ordering key, hiding a later occurrence that moves past a rule.