### PR TITLE
canonical diff: omit generated reorder positions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -933,6 +933,9 @@ difference wherever the two are not equivalent.
 - `--diff=tree` tracks each repeated conditional block in source order, so
   moving a later block past a rule is reported even when an earlier block has
   the same condition (#779)
+- Canonical diff omits generated-tree positions from reordered rules and
+  containers, where those numbers identified neither input and the rule paired
+  with one could be an unrelated container (#780)
 
 ### Library
 

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -115,6 +115,38 @@ let strip_tool_header css =
 let tree_diff ~(expected : Css.t) ~(actual : Css.t) : Tree_diff.t =
   D.diff ~expected ~actual
 
+(* Canonical mode reparses generated CSS, so these indexes identify neither
+   source AST. Keep the move, but not coordinates or an index-derived partner
+   that a reader cannot locate in either input. *)
+let hide_rule_reorder_position : D.rule_diff -> D.rule_diff = function
+  | D.Reordered r ->
+      D.Reordered
+        { r with expected_pos = -1; actual_pos = -1; swapped_with = None }
+  | ( D.Added _ | D.Removed _ | D.Content_changed _ | D.Selector_changed _
+    | D.Rearranged _ | D.Regrouped _ ) as change ->
+      change
+
+let rec hide_container_reorder_positions : D.container_diff -> D.container_diff
+    = function
+  | D.Modified change ->
+      D.Modified
+        {
+          change with
+          rule_changes = List.map hide_rule_reorder_position change.rule_changes;
+          container_changes =
+            List.map hide_container_reorder_positions change.container_changes;
+        }
+  | D.Reordered change ->
+      D.Reordered { change with expected_pos = -1; actual_pos = -1 }
+  | (D.Added _ | D.Removed _ | D.Block_structure_changed _) as change -> change
+
+let hide_canonical_reorder_positions (diff : D.t) =
+  {
+    D.rules = List.map hide_rule_reorder_position diff.rules;
+    containers = List.map hide_container_reorder_positions diff.containers;
+    layer_order = diff.layer_order;
+  }
+
 (* Collect all rules with their path-qualified selector keys *)
 let rec collect_keyed_rules acc path stmts =
   List.fold_left
@@ -411,6 +443,7 @@ let diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
   | Ok { stylesheet = expected_ast; _ }, Ok { stylesheet = actual_ast; _ } ->
       let structural_diff =
         tree_diff ~expected:expected_ast ~actual:actual_ast
+        |> hide_canonical_reorder_positions
       in
       if is_empty structural_diff then
         fallback_to_string_diff ~expected:expected_canon ~actual:actual_canon

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -89,7 +89,9 @@ type mode = [ `Auto | `Tree | `String | `Canonical ]
       default and remains distinct under [lossless]. Equal outputs are
       {!No_diff}; differing outputs are a difference, reported as a tree diff of
       the two when the walk reaches it and as a string diff of them when it does
-      not.
+      not. A reorder in that tree is named without a position: its index belongs
+      to the generated canonical form and cannot be located in either input. Use
+      [`Tree] when source-AST indexes are useful.
 
     The projection runs no rewrite whose applicability depends on the order the
     input happens to put its rules in. Factoring shared declarations into a

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -1048,16 +1048,20 @@ let pp_container_add_remove ~style ~is_last ~parent_prefix ~label buf
 let pp_container_reorder ~style ~is_last ~parent_prefix buf container_type
     condition expected_pos actual_pos =
   let prefix = tree_prefix ~style ~is_last ~parent_prefix in
-  add_strings buf
-    [
-      prefix;
-      container_label container_type condition;
-      " (position ";
-      string_of_int expected_pos;
-      " \xe2\x86\x92 ";
-      string_of_int actual_pos;
-      ")\n";
-    ]
+  let label = container_label container_type condition in
+  if expected_pos = actual_pos then
+    add_strings buf [ prefix; label; " (moved)\n" ]
+  else
+    add_strings buf
+      [
+        prefix;
+        label;
+        " (position ";
+        string_of_int expected_pos;
+        " \xe2\x86\x92 ";
+        string_of_int actual_pos;
+        ")\n";
+      ]
 
 let rec pp_container_diff ?(style = default_style) ?(is_last = false)
     ?(parent_prefix = "") buf = function

--- a/test/cli/diff_basic.t
+++ b/test/cli/diff_basic.t
@@ -139,7 +139,7 @@ stays ordered: swapping it with the rule is a real difference.
   --- before.css
   +++ after.css
   Rules reordered (1 rules):
-  └─ .a ↔  @media print
+  └─ .a (moved)
   
   [1]
 

--- a/test/cli/diff_reorder_same_position.t
+++ b/test/cli/diff_reorder_same_position.t
@@ -74,3 +74,35 @@ because `.z` left.
   └─ .a (moved)
   
   [1]
+
+Canonical comparison runs on newly serialized and reparsed stylesheets, so
+its rule indexes are positions in that transformed tree, not locations in
+either input. It names a genuine cascade-sensitive move without inventing
+coordinates. Tree comparison still reports the indexes from the source ASTs.
+
+  $ cat > canonical_ref.css <<'CSS'
+  > .a{color:red}.b{color:blue}.c{color:green}
+  > CSS
+  $ cat > canonical_tw.css <<'CSS'
+  > .c{color:green}.a{color:red}.b{color:blue}
+  > CSS
+  $ cascade diff --diff=canonical --depth=max canonical_ref.css canonical_tw.css
+  CSS: 43 chars vs 43 chars (0.0% diff)
+  Changes: 1 reordered rule
+  
+  --- canonical_ref.css
+  +++ canonical_tw.css
+  Rules reordered (1 rules):
+  └─ .c (moved)
+  
+  [1]
+  $ cascade diff --diff=tree --depth=max canonical_ref.css canonical_tw.css
+  CSS: 43 chars vs 43 chars (0.0% diff)
+  Changes: 1 reordered rule
+  
+  --- canonical_ref.css
+  +++ canonical_tw.css
+  Rules reordered (1 rules):
+  └─ .c (position 0) ↔  .b (position 2)
+  
+  [1]

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -30,9 +30,9 @@ rather than as a loss and a gain.
   --- ref.css
   +++ tw.css
   └─ @layer utilities (1 reordered)
-     ├─ .drop-shadow-blue-500\/50 ↔  .drop-shadow-indigo-500
+     ├─ .drop-shadow-blue-500\/50 (moved)
      └─ @supports (color: color-mix(in lab,red,red)) (1 reordered)
-        └─ .drop-shadow-blue-500\/50 ↔  .drop-shadow-indigo-500
+        └─ .drop-shadow-blue-500\/50 (moved)
   
   [1]
 
@@ -138,9 +138,9 @@ gains or loses a declaration, so neither may be reported as modified.
   --- guarded_ref.css
   +++ guarded_tw.css
   └─ @layer utilities (1 reordered)
-     ├─ .x ↔  .y
+     ├─ .x (moved)
      └─ @supports (zoo: bar) (1 reordered)
-        └─ .x ↔  .y
+        └─ .x (moved)
   
   [1]
 


### PR DESCRIPTION
Canonical reorder findings now omit generated-tree coordinates and index-derived partner names while tree mode retains source-AST positions.