### PR TITLE
canonical diff: report source reorderings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -936,6 +936,9 @@ difference wherever the two are not equivalent.
 - Canonical diff omits generated-tree positions from reordered rules and
   containers, where those numbers identified neither input and the rule paired
   with one could be an unrelated container (#780)
+- Canonical diff derives reorder findings from the parsed inputs instead of the
+  independently ordered projection, where one declaration change could make
+  unchanged rules read as reordered (#781)
 
 ### Library
 

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -147,6 +147,83 @@ let hide_canonical_reorder_positions (diff : D.t) =
     layer_order = diff.layer_order;
   }
 
+(* The canonical tree supplies normalized content changes; the source tree
+   supplies authored ordering changes. Partition the two structured diffs, then
+   merge their matching container paths back into one report. *)
+let rule_is_reordered : D.rule_diff -> bool = function
+  | D.Reordered _ -> true
+  | D.Added _ | D.Removed _ | D.Content_changed _ | D.Selector_changed _
+  | D.Rearranged _ | D.Regrouped _ ->
+      false
+
+let select_rule_reorders keep =
+  List.filter (fun change -> Bool.equal keep (rule_is_reordered change))
+
+let rec select_container_reorders keep :
+    D.container_diff -> D.container_diff option = function
+  | D.Reordered _ as change -> if keep then Some change else None
+  | D.Modified change ->
+      let rule_changes = select_rule_reorders keep change.rule_changes in
+      let container_changes =
+        List.filter_map
+          (select_container_reorders keep)
+          change.container_changes
+      in
+      if rule_changes = [] && container_changes = [] then None
+      else Some (D.Modified { change with rule_changes; container_changes })
+  | (D.Added _ | D.Removed _ | D.Block_structure_changed _) as change ->
+      if keep then None else Some change
+
+let select_reorders keep (diff : D.t) =
+  {
+    D.rules = select_rule_reorders keep diff.rules;
+    containers =
+      List.filter_map (select_container_reorders keep) diff.containers;
+    layer_order = (if keep then None else diff.layer_order);
+  }
+
+let without_reorders = select_reorders false
+let only_reorders = select_reorders true
+
+let same_container (a : D.container_info) (b : D.container_info) =
+  a.container_type = b.container_type && String.equal a.condition b.condition
+
+(* A conditional block can contain both a normalized content change and a source
+   reorder. Join those entries instead of printing the block twice. The tag
+   claims a target after one merge, so repeated equal conditions pair by
+   occurrence rather than all folding into the first block. *)
+let rec merge_container_change source = function
+  | [] -> [ (true, source) ]
+  | (false, D.Modified target) :: rest -> (
+      match source with
+      | D.Modified additions when same_container target.info additions.info ->
+          ( true,
+            D.Modified
+              {
+                target with
+                rule_changes = target.rule_changes @ additions.rule_changes;
+                container_changes =
+                  merge_container_changes target.container_changes
+                    additions.container_changes;
+              } )
+          :: rest
+      | _ -> (false, D.Modified target) :: merge_container_change source rest)
+  | target :: rest -> target :: merge_container_change source rest
+
+and merge_container_changes canonical source =
+  let tagged = List.map (fun change -> (false, change)) canonical in
+  List.fold_left
+    (fun changes addition -> merge_container_change addition changes)
+    tagged source
+  |> List.map snd
+
+let merge_source_reorders (canonical : D.t) (source : D.t) =
+  {
+    D.rules = canonical.rules @ source.rules;
+    containers = merge_container_changes canonical.containers source.containers;
+    layer_order = canonical.layer_order;
+  }
+
 (* Collect all rules with their path-qualified selector keys *)
 let rec collect_keyed_rules acc path stmts =
   List.fold_left
@@ -441,8 +518,20 @@ let diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
     ~expected_canon ~actual_canon =
   match (Css.of_string expected_canon, Css.of_string actual_canon) with
   | Ok { stylesheet = expected_ast; _ }, Ok { stylesheet = actual_ast; _ } ->
+      let canonical_diff =
+        tree_diff ~expected:expected_ast ~actual:actual_ast |> without_reorders
+      in
+      let source_reorders =
+        match (expected_parse, actual_parse) with
+        | ( Ok { Css.stylesheet = expected_source; _ },
+            Ok { Css.stylesheet = actual_source; _ } ) ->
+            tree_diff ~expected:expected_source ~actual:actual_source
+            |> only_reorders
+        | Error _, _ | _, Error _ ->
+            { D.rules = []; containers = []; layer_order = None }
+      in
       let structural_diff =
-        tree_diff ~expected:expected_ast ~actual:actual_ast
+        merge_source_reorders canonical_diff source_reorders
         |> hide_canonical_reorder_positions
       in
       if is_empty structural_diff then

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -91,7 +91,9 @@ type mode = [ `Auto | `Tree | `String | `Canonical ]
       the two when the walk reaches it and as a string diff of them when it does
       not. A reorder in that tree is named without a position: its index belongs
       to the generated canonical form and cannot be located in either input. Use
-      [`Tree] when source-AST indexes are useful.
+      [`Tree] when source-AST indexes are useful. Only order changes present in
+      the parsed inputs are reported; a content change that perturbs the
+      canonical projection's rule order is not an authored reorder.
 
     The projection runs no rewrite whose applicability depends on the order the
     input happens to put its rules in. Factoring shared declarations into a

--- a/test/cli/diff_canonical_source_order.t
+++ b/test/cli/diff_canonical_source_order.t
@@ -1,0 +1,48 @@
+CLI: canonical diff reports source-order changes, not projection churn.
+
+Canonical rule ordering is computed from each sheet's cascade dependencies.
+Changing one declaration can therefore change the generated order of rules
+that stayed at the same source position. That projection churn is not an
+authored reorder and must not be reported as one.
+
+Here `.a` is second in both inputs. Changing `.c` removes its conflict with
+`.a`, which changes their order in the independently canonicalized trees, but
+the report contains only the declaration change the author made.
+
+  $ cat > before.css <<'CSS'
+  > .c{color:blue}.a{color:red}.b{margin-top:1px}
+  > CSS
+  $ cat > after.css <<'CSS'
+  > .c{background-color:blue}.a{color:red}.b{margin-top:1px}
+  > CSS
+  $ cascade diff --diff=canonical --depth=max before.css after.css
+  CSS: 46 chars vs 57 chars (23.9% diff)
+  Changes: 1 modified rule
+  
+  --- before.css
+  +++ after.css
+  └─ .c
+        - color: #00f
+        + background-color: #00f
+  
+  [1]
+
+A real source-order change remains visible. These selectors can match the same
+element and both write `color`, so swapping the rules changes the winner.
+
+  $ cat > move-before.css <<'CSS'
+  > .a{color:red}.b{color:blue}
+  > CSS
+  $ cat > move-after.css <<'CSS'
+  > .b{color:blue}.a{color:red}
+  > CSS
+  $ cascade diff --diff=canonical --depth=max move-before.css move-after.css
+  CSS: 28 chars vs 28 chars (0.0% diff)
+  Changes: 1 reordered rule
+  
+  --- move-before.css
+  +++ move-after.css
+  Rules reordered (1 rules):
+  └─ .a (moved)
+  
+  [1]

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -30,9 +30,7 @@ rather than as a loss and a gain.
   --- ref.css
   +++ tw.css
   └─ @layer utilities (1 reordered)
-     ├─ .drop-shadow-blue-500\/50 (moved)
-     └─ @supports (color: color-mix(in lab,red,red)) (1 reordered)
-        └─ .drop-shadow-blue-500\/50 (moved)
+     └─ .drop-shadow-blue-500\/50 (moved)
   
   [1]
 


### PR DESCRIPTION
Canonical reports now take normalized content changes from the canonical projection but reorder findings from the parsed inputs, preventing projection churn from masquerading as authored moves.