### PR TITLE
dedup: keep a vendor image fallback written as a shorthand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -503,6 +503,10 @@ difference wherever the two are not equivalent.
 
 ### Minification
 
+- `--minify` keeps a vendor-prefixed gradient written with the `background`,
+  `mask`, `border-image` or `mask-border` shorthand, as it already did for the
+  longhand. Canonical diff had reported two sheets differing only there as
+  identical (#782)
 - Invalid math results in `shape-margin` and `offset-distance` are dropped like
   those in every other `<length-percentage>` property (#766)
 - `--flatten-nesting` leaves the optimised stylesheet flat even when later

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -1241,11 +1241,35 @@ let background_image_is_vendor : Properties.background_image -> bool = function
       true
   | _ -> false
 
+(* A shorthand carries the same image the longhand does, so the prefixed
+   spelling is the same fallback whichever property writes it. [background] and
+   [mask] carry one image per layer; [border-image] and [mask-border] carry a
+   single source. *)
+let background_layer_is_vendor (layer : Properties.background) =
+  match layer with
+  | Shorthand { image = Some image; _ } -> background_image_is_vendor image
+  | _ -> false
+
+let mask_layer_is_vendor (layer : Properties.mask_layer) =
+  match layer.image with
+  | Some image -> background_image_is_vendor image
+  | _ -> false
+
+let mask_value_is_vendor (value : Properties.mask) =
+  match value with
+  | Layer layer -> mask_layer_is_vendor layer
+  | Layers layers -> List.exists mask_layer_is_vendor layers
+  | _ -> false
+
+let border_image_source_is_vendor (value : Properties.border_image) =
+  match value.source with
+  | Some image -> background_image_is_vendor image
+  | _ -> false
+
 (* A value whose rendering begins with a vendor prefix (-webkit-, -moz-, -ms-,
-   -o-). Only [display] keywords and [background-image] gradients render that
-   way, so a structural match is exhaustive. Preserves legacy fallbacks like
-   [display:-webkit-box;display:flex]: old browsers understand only the prefixed
-   spelling, so dropping the earlier declaration removes a real compat fallback. *)
+   -o-). Preserves legacy fallbacks like [display:-webkit-box;display:flex]: old
+   browsers understand only the prefixed spelling, so dropping the earlier
+   declaration removes a real compat fallback. *)
 (* All the intrinsic sizing properties carry a [length_percentage] value. A GADT
    or-pattern does not refine the value type, so each constructor is matched on
    its own; everything else is not a sizing fallback. *)
@@ -1281,6 +1305,13 @@ let rec value_is_vendor_prefixed decl =
       background_image_is_vendor value
   | Declaration { property = Border_image_source; value; _ } ->
       background_image_is_vendor value
+  | Declaration { property = Background; value; _ } ->
+      List.exists background_layer_is_vendor value
+  | Declaration { property = Mask; value; _ } -> mask_value_is_vendor value
+  | Declaration { property = Border_image; value; _ } ->
+      border_image_source_is_vendor value
+  | Declaration { property = Mask_border; value; _ } ->
+      border_image_source_is_vendor value
   (* [position:-webkit-sticky;position:sticky] and the [text-align] equivalent
      are the same browser-compat pattern: old Safari only understands the
      prefixed keyword, so the earlier declaration is a real fallback. *)

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -589,6 +589,25 @@ let test_deduplicate_keeps_legacy_fallbacks () =
     ]
     (decl_strings result)
 
+let test_deduplicate_keeps_shorthand_vendor_image_fallbacks () =
+  (* A vendor-prefixed gradient inside a shorthand is a real fallback for the
+     unprefixed gradient, just like the equivalent longhand. *)
+  let result =
+    ".a{background:-webkit-linear-gradient(top,#111,#222);background:linear-gradient(#333,#444);border-image:-webkit-linear-gradient(top,#111,#222);border-image:linear-gradient(#333,#444);mask:-webkit-linear-gradient(top,#111,#222);mask:linear-gradient(#333,#444)}"
+    |> decls |> Shorthand.deduplicate_declarations
+  in
+  Alcotest.(check (list string))
+    "vendor-prefixed gradient fallbacks inside shorthands are kept"
+    [
+      "background:-webkit-linear-gradient(top,#111,#222)";
+      "background:linear-gradient(#333,#444)";
+      "border-image:-webkit-linear-gradient(top,#111,#222)";
+      "border-image:linear-gradient(#333,#444)";
+      "mask:-webkit-linear-gradient(top,#111,#222)";
+      "mask:linear-gradient(#333,#444)";
+    ]
+    (decl_strings result)
+
 let test_same_value_ignores_importance () =
   Alcotest.(check bool)
     "importance alone does not change the value" true
@@ -686,6 +705,8 @@ let suite =
         test_stylesheet_scope_prior_longhand_guard;
       Alcotest.test_case "deduplicate keeps legacy fallbacks" `Quick
         test_deduplicate_keeps_legacy_fallbacks;
+      Alcotest.test_case "deduplicate keeps shorthand vendor image fallbacks"
+        `Quick test_deduplicate_keeps_shorthand_vendor_image_fallbacks;
       Alcotest.test_case "same value ignores importance" `Quick
         test_same_value_ignores_importance;
       Alcotest.test_case "page-break alias shadowing" `Quick


### PR DESCRIPTION
`cascade fmt --minify` deleted a vendor-prefixed gradient written with `background`, `mask`, `border-image` or `mask-border`, while keeping the same fallback written with the matching longhand. An engine that does not understand the later value paints the earlier one, so `--diff=canonical` reported two sheets differing only there as identical.