### PR TITLE
diff: omit the size percentage with an empty expected side

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1051,6 +1051,9 @@ difference wherever the two are not equivalent.
 
 ### CLI tools
 
+- `cascade diff` reports the two sizes without a percentage when the first
+  file is empty, in place of the `(0.0% diff)` it printed for a pair sharing
+  nothing (#783)
 - `cascade fmt --import-root DIR` bounds `--inline-imports` filesystem reads to
   the canonical root and its descendants, rejecting both lexical and symlink
   escapes. Omitting it retains unrestricted resolution for trusted CSS (#744)

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -808,11 +808,6 @@ let emit_changes buf stats =
 
 let pp_stats buf stats =
   let char_diff = abs (stats.actual_chars - stats.expected_chars) in
-  let char_diff_pct =
-    if stats.expected_chars > 0 then
-      float_of_int char_diff *. 100.0 /. float_of_int stats.expected_chars
-    else 0.0
-  in
   (* Same order as the [---] / [+++] headers below: expected, then actual. *)
   add_strings buf
     [
@@ -820,8 +815,13 @@ let pp_stats buf stats =
       string_of_int stats.expected_chars;
       " chars vs ";
       string_of_int stats.actual_chars;
-      " chars (";
     ];
-  add_pct buf char_diff_pct;
-  Buffer.add_string buf "% diff)\n";
+  if stats.expected_chars > 0 then (
+    let char_diff_pct =
+      float_of_int char_diff *. 100.0 /. float_of_int stats.expected_chars
+    in
+    Buffer.add_string buf " chars (";
+    add_pct buf char_diff_pct;
+    Buffer.add_string buf "% diff)\n")
+  else Buffer.add_string buf " chars\n";
   emit_changes buf stats

--- a/test/cli/diff_empty.t
+++ b/test/cli/diff_empty.t
@@ -1,0 +1,15 @@
+CLI: cascade diff - size summary with an empty expected side.
+
+When the first file is empty there is no denominator for a percentage, so the
+summary line shows only the two sizes.
+
+  $ printf '' > empty.css
+  $ printf '.a{color:red}\n' > a.css
+  $ NO_COLOR=1 cascade diff empty.css a.css | head -1
+  CSS: 0 chars vs 14 chars
+
+When the second file is empty the denominator is non-empty, so the percentage
+is still printed.
+
+  $ NO_COLOR=1 cascade diff a.css empty.css | head -1
+  CSS: 14 chars vs 0 chars (100.0% diff)


### PR DESCRIPTION
`cascade diff empty.css a.css` opened with `CSS: 0 chars vs 14 chars (0.0% diff)`. The percentage is a ratio against the expected side's size, so an empty expected side leaves no denominator and the constant it fell back to read as almost no difference for a pair sharing nothing.