### PR TITLE
diff: report a keyframes block as its own at-rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1051,6 +1051,8 @@ difference wherever the two are not equivalent.
 
 ### CLI tools
 
+- `cascade diff` names a changed `@keyframes` block as the at-rule it is,
+  in place of the `@layer @keyframes spin` line it printed (#784)
 - `cascade diff` reports the two sizes without a percentage when the first
   file is empty, in place of the `(0.0% diff)` it printed for a pair sharing
   nothing (#783)

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2823,7 +2823,11 @@ let extract_layer_name stmt =
   | None -> None
 
 let keyframes_container_info name =
-  { container_type = `Layer; condition = "@keyframes " ^ name; rules = [] }
+  {
+    container_type = `At_rule;
+    condition = String.concat "" [ "@keyframes "; name ];
+    rules = [];
+  }
 
 let keyframe_frames_diff frames1 frames2 =
   let key_of (frame : Css.keyframe) = frame.selector in

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -1259,6 +1259,21 @@ let removed_charset_is_named () =
     "the entry names what was dropped" true
     (string_contains ~needle:"@charset" (render d))
 
+(* A [@keyframes] block is an at-rule of its own. Naming it as a [@layer] prints
+   "@layer @keyframes spin", which describes no CSS construct. *)
+let modified_keyframes_names_the_at_rule () =
+  let d =
+    diff_of ~expected:"@keyframes spin{from{opacity:0}to{opacity:1}}"
+      ~actual:"@keyframes spin{from{opacity:0}to{opacity:.5}}"
+  in
+  let s = render d in
+  Alcotest.(check bool)
+    "the entry names the keyframes block" true
+    (string_contains ~needle:"@keyframes spin" s);
+  Alcotest.(check bool)
+    "and does not call it a layer" false
+    (string_contains ~needle:"@layer" s)
+
 let removed_layer_statement_is_named () =
   let d =
     diff_of ~expected:"@layer a,b;.x{color:red}" ~actual:".x{color:red}"
@@ -1516,6 +1531,8 @@ let suite =
         removed_charset_is_named;
       Alcotest.test_case "removed layer statement is named" `Quick
         removed_layer_statement_is_named;
+      Alcotest.test_case "modified keyframes names the at-rule" `Quick
+        modified_keyframes_names_the_at_rule;
       Alcotest.test_case "selector group split reported" `Quick
         diff_selector_group_split_reported;
       Alcotest.test_case "selector group merge reported" `Quick


### PR DESCRIPTION
A modified `@keyframes` block was filed under the layer container type, so the report line read `@layer @keyframes spin`, naming no CSS construct. The at-rule container type beside it renders the condition verbatim, which is what a selectorless at-rule needs.