### PR TITLE
string diff: keep context after short lines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1051,6 +1051,8 @@ difference wherever the two are not equivalent.
 
 ### CLI tools
 
+- `cascade diff` keeps trailing context around a difference between short
+  lines, where it previously stopped immediately after the caret (#785)
 - `cascade diff` names a changed `@keyframes` block as the at-rule it is,
   in place of the `@layer @keyframes spin` line it printed (#784)
 - `cascade diff` reports the two sizes without a percentage when the first

--- a/lib/diff/string_diff.ml
+++ b/lib/diff/string_diff.ml
@@ -231,7 +231,7 @@ let pp ?(config = default_config) ?(expected_label = "Expected")
 
   (* Print the diff lines with appropriate formatting *)
   let diff_exp, diff_act = t.diff_lines in
-  match format_diff_line ~config diff_exp diff_act with
+  (match format_diff_line ~config diff_exp diff_act with
   | `Equal ->
       add_strings buf [ "-"; diff_exp; "\n" ];
       add_strings buf [ "+"; diff_act; "\n" ]
@@ -243,7 +243,7 @@ let pp ?(config = default_config) ?(expected_label = "Expected")
   | `Medium (exp, act, pos) | `Long (exp, act, pos) ->
       add_strings buf [ "-"; exp; "\n" ];
       add_strings buf [ "+"; act; "\n" ];
-      if t.line_expected = t.line_actual then pp_caret ~indent:1 buf pos;
+      if t.line_expected = t.line_actual then pp_caret ~indent:1 buf pos);
 
-      (* Print context after *)
-      List.iter (pp_line_pair buf) t.context_after
+  (* Print context after *)
+  List.iter (pp_line_pair buf) t.context_after

--- a/test/test_string_diff.ml
+++ b/test/test_string_diff.ml
@@ -125,6 +125,34 @@ let pp_with_labels () =
         "pp with labels produces output" true
         (String.length output > 0)
 
+let pp_short_lines_keeps_after_context () =
+  let expected = "a\nb\nc\nd\ne" in
+  let actual = "a\nx\nc\nd\ne" in
+  match Cascade_diff.String_diff.diff ~expected actual with
+  | None -> Alcotest.fail "expected Some"
+  | Some d ->
+      let buf = Buffer.create 256 in
+      Cascade_diff.String_diff.pp buf d;
+      Alcotest.(check string)
+        "short lines keep trailing context"
+        (String.concat "\n"
+           [
+             "Strings differ at position 2 (line 1, col 0)";
+             "";
+             "--- Expected";
+             "+++ Actual";
+             "@@ position 2 @@";
+             " a";
+             "-b";
+             "+x";
+             " ^";
+             " c";
+             " d";
+             " e";
+             "";
+           ])
+        (Buffer.contents buf)
+
 (* ===== Suite ===== *)
 
 let suite =
@@ -155,4 +183,6 @@ let suite =
         truncate_preserves_start_and_end;
       Alcotest.test_case "pp does not crash" `Quick pp_does_not_crash;
       Alcotest.test_case "pp with labels" `Quick pp_with_labels;
+      Alcotest.test_case "pp short lines keeps after context" `Quick
+        pp_short_lines_keeps_after_context;
     ] )


### PR DESCRIPTION
String diffs now print their computed trailing context after every line-format branch, so short changed lines retain the same surrounding context as medium and long lines.