### PR TITLE
lib: decode UTF-8 with the stdlib in place of uutf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -949,6 +949,10 @@ difference wherever the two are not equivalent.
 
 ### Library
 
+- `cascade` drops its `uutf` dependency for the stdlib UTF-8 decoder. A parse
+  error's column now counts one replacement character per maximal subpart of
+  an ill-formed sequence, as a browser does, where the previous decoder
+  counted the whole run as one (#788)
 - The library no longer links `unix`. Timing a factoring iteration for
   `--profile` was its only use of it, and `mtime` reads the monotonic clock the
   measurement wants and ships a js_of_ocaml implementation, so embedding

--- a/README.md
+++ b/README.md
@@ -653,8 +653,7 @@ performing the transform instead of receiving guessed locations from Cascade.
 
 ### Small runtime footprint
 
-The core `cascade` library links
-[uutf](https://erratique.ch/software/uutf), `uri`, `psq`, `logs` and
+The core `cascade` library links `uri`, `psq`, `logs` and
 [mtime](https://erratique.ch/software/mtime), which supplies the monotonic
 clock `--profile` measures factoring iterations against; it does not pull
 `fmt` or `unix`, so js_of_ocaml embedders stay lean. A local jsoo build that

--- a/cascade.opam
+++ b/cascade.opam
@@ -25,7 +25,6 @@ depends: [
   "fmt" {>= "0.10.0"}
   "base-unix"
   "mtime" {>= "2.1.0"}
-  "uutf"
   "uri"
   "psq"
   "logs"

--- a/dune-project
+++ b/dune-project
@@ -31,7 +31,6 @@
   (fmt (>= 0.10.0))
   base-unix
   (mtime (>= 2.1.0))
-  uutf
   uri
   psq
   logs

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -77,8 +77,39 @@ module String = struct
   let lowercase_ascii_preserve s =
     if is_ascii_lower_or_digit s then s else Stdlib.String.lowercase_ascii s
 
-  let utf8_length ?pos ?len s =
-    Uutf.String.fold_utf_8 ?pos ?len (fun n _ _ -> n + 1) 0 s
+  type utf8 = Scalar of Uchar.t | Malformed of int
+
+  (* The window is [[pos, stop)]: a sequence reaching past [stop] is truncated,
+     and the bytes of it that are inside are a maximal subpart of their own. *)
+  let utf8_window pos len s =
+    match len with None -> length s | Some n -> min (pos + n) (length s)
+
+  let utf8_element s stop i =
+    let d = get_utf_8_uchar s i in
+    let n = Uchar.utf_decode_length d in
+    if i + n > stop then Malformed (stop - i)
+    else if Uchar.utf_decode_is_valid d then Scalar (Uchar.utf_decode_uchar d)
+    else Malformed n
+
+  let utf8_decode ?(pos = 0) ?len s =
+    let stop = utf8_window pos len s in
+    if pos >= stop then None else Some (utf8_element s stop pos)
+
+  (* [s], [stop] and [f] ride in parameters rather than in an enclosing scope,
+     which would cost a closure per walk. *)
+  let rec utf8_fold_from f acc s stop i =
+    if i >= stop then acc
+    else
+      let e = utf8_element s stop i in
+      let n =
+        match e with Scalar u -> Uchar.utf_8_byte_length u | Malformed n -> n
+      in
+      utf8_fold_from f (f acc i e) s stop (i + n)
+
+  let utf8_fold ?(pos = 0) ?len f acc s =
+    utf8_fold_from f acc s (utf8_window pos len s) pos
+
+  let utf8_length ?pos ?len s = utf8_fold ?pos ?len (fun n _ _ -> n + 1) 0 s
 
   (* A UTF-8 continuation byte, [10xxxxxx]: an index sitting on one is inside a
      sequence rather than at its start. *)

--- a/lib/common.mli
+++ b/lib/common.mli
@@ -40,9 +40,28 @@ module String : sig
       [Stdlib.String.lowercase_ascii s]. CSS identifiers are overwhelmingly in
       that set, so this avoids the [Bytes.map] allocation for them. *)
 
+  (** One element of UTF-8 text: a Unicode scalar value, or the [n] bytes of a
+      maximal subpart of an ill-formed sequence, the longest prefix that could
+      still open a well-formed one. An ill-formed run holds as many maximal
+      subparts as CSS Syntax 3 (ED) sec. 3.3 puts U+FFFD replacement characters
+      in its place. *)
+  type utf8 = Scalar of Uchar.t | Malformed of int
+
+  val utf8_decode : ?pos:int -> ?len:int -> string -> utf8 option
+  (** [utf8_decode s] is the element at the start of [s], or of its [len] bytes
+      from [pos], and [None] when that window holds no byte. A sequence reaching
+      past the end of the window is truncated, so the bytes of it that are
+      inside are {!constructor-Malformed}. *)
+
+  val utf8_fold :
+    ?pos:int -> ?len:int -> ('a -> int -> utf8 -> 'a) -> 'a -> string -> 'a
+  (** [utf8_fold f acc s] applies {!utf8_decode} along [s], or along its [len]
+      bytes from [pos], passing [f] the byte offset of each element. *)
+
   val utf8_length : ?pos:int -> ?len:int -> string -> int
-  (** [utf8_length s] counts the Unicode scalar values of [s], or of its [len]
-      bytes from [pos], each malformed byte sequence counting as one. *)
+  (** [utf8_length s] counts the elements of [s], or of its [len] bytes from
+      [pos]: one per Unicode scalar value and one per maximal subpart of an
+      ill-formed sequence. *)
 
   val utf8_lead_before : string -> int -> int
   (** [utf8_lead_before s i] moves [i] back to the lead byte of the UTF-8

--- a/lib/dune
+++ b/lib/dune
@@ -59,7 +59,7 @@
   prop_font
   prop_text
   prop_animation)
- (libraries uutf uri psq logs mtime.clock))
+ (libraries uri psq logs mtime.clock))
 
 (mdx
  (files

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -117,14 +117,16 @@ let escape_ident_emit_ascii buf cp =
     Buffer.add_char buf '\\';
     Buffer.add_char buf (Char.chr cp))
 
-(* Emit one code point of an ident-like name, honouring the leading-digit
-   restriction recorded in [needs_leading_escape]. *)
-let escape_ident_emit_cp buf ~needs_leading_escape u =
+(* Emit the code point [s] holds at byte [i], honouring the leading-digit
+   restriction recorded in [needs_leading_escape]. One that needs no escape is
+   copied straight out of [s] rather than encoded again. *)
+let escape_ident_emit_cp buf ~needs_leading_escape s i u =
   let cp = Uchar.to_int u in
   if needs_leading_escape then add_hex_escape_cp buf cp
   else if cp < 0x20 || cp = 0x7F then add_hex_escape_cp buf cp
   else if cp < 0x80 then escape_ident_emit_ascii buf cp
-  else if Lexer.spec_non_ascii_ident_cp cp then Uutf.Buffer.add_utf_8 buf u
+  else if Lexer.spec_non_ascii_ident_cp cp then
+    Buffer.add_substring buf s i (Uchar.utf_8_byte_length u)
   else add_hex_escape_cp buf cp
 
 (* Sec. 4.3.9 opens no ident on [-] then a digit, so the digit is escaped even
@@ -139,15 +141,17 @@ let escape_ident_starts s n =
 let escape_ident_needs_leading (starts_with_digit, starts_dash_digit) i =
   (i = 0 && starts_with_digit) || (i = 1 && starts_dash_digit)
 
-let escape_ident_emit_item buf starts () i = function
-  | `Uchar u ->
+let escape_ident_emit_item buf starts s () i = function
+  | Common.String.Scalar u ->
       let needs_leading_escape = escape_ident_needs_leading starts i in
-      escape_ident_emit_cp buf ~needs_leading_escape u
-  | `Malformed bs ->
+      escape_ident_emit_cp buf ~needs_leading_escape s i u
+  | Common.String.Malformed len ->
       (* Malformed UTF-8 bytes (e.g., a lone continuation byte the lexer's
          [consume_escape] dropped into an ident) can't be re-tokenized as the
          same ident. Hex-escape each byte so the serialized form round-trips. *)
-      String.iter (fun c -> add_hex_escape buf c) bs
+      for j = i to i + len - 1 do
+        add_hex_escape buf s.[j]
+      done
 
 (* [s] and [n] are parameters rather than free variables of an inner loop, which
    would cost a closure on every ident escaped. *)
@@ -156,9 +160,9 @@ let rec ascii_ident_continue_from s n i =
   || Syntax.is_ascii_ident_continue s.[i]
      && ascii_ident_continue_from s n (i + 1)
 
-(* An ident serialises to itself byte-for-byte, so the buffer + Uutf walk below
-   would allocate nothing useful. The empty name is not an ident and has nothing
-   to escape either. *)
+(* An ident serialises to itself byte-for-byte, so the buffer + walk below would
+   allocate nothing useful. The empty name is not an ident and has nothing to
+   escape either. *)
 let escape_ident_needs_no_escape s n = n = 0 || Syntax.is_ident s
 
 let escape_ident s =
@@ -168,11 +172,11 @@ let escape_ident s =
   else
     let buf = Buffer.create n in
     let starts = escape_ident_starts s n in
-    Uutf.String.fold_utf_8 (escape_ident_emit_item buf starts) () s;
+    Common.String.utf8_fold (escape_ident_emit_item buf starts s) () s;
     Buffer.contents buf
 
 (* Every code point of an all-ASCII name serialises to itself, so the buffer +
-   Uutf walk below would allocate nothing useful. *)
+   walk below would allocate nothing useful. *)
 let escape_name_needs_no_escape s n = ascii_ident_continue_from s n 0
 
 let escape_name s =
@@ -180,11 +184,12 @@ let escape_name s =
   if escape_name_needs_no_escape s n then s
   else
     let buf = Buffer.create n in
-    let folder () _ = function
-      | `Uchar u -> escape_ident_emit_cp buf ~needs_leading_escape:false u
-      | `Malformed bs -> Buffer.add_string buf bs
+    let folder () i = function
+      | Common.String.Scalar u ->
+          escape_ident_emit_cp buf ~needs_leading_escape:false s i u
+      | Common.String.Malformed len -> Buffer.add_substring buf s i len
     in
-    Uutf.String.fold_utf_8 folder () s;
+    Common.String.utf8_fold folder () s;
     Buffer.contents buf
 
 let add_escaped_string buf ~quote ~terminated s =

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -127,37 +127,12 @@ let source t = t.input
 let enforce_spec t = t.enforce_spec
 let is_done t = t.pos >= t.len
 
-let utf8_byte_length cp =
-  if cp < 0x80 then 1
-  else if cp < 0x800 then 2
-  else if cp < 0x10000 then 3
-  else 4
-
 (* Decode the UTF-8 code point at [t.pos + offset] to [Some (cp, byte_length)],
-   [None] at EOF or on a malformed sequence. Uutf rejects overlong/surrogate/
-   out-of-range sequences per the Unicode spec. Returns [Some] only when the
-   *first* decoded element is a valid [Uchar]: [fold_utf_8] resyncs past a
-   [Malformed] start, which would fold bad bytes into the following code point
-   (and into an ident-like unit token). *)
-(* ASCII fast path before falling back to Uutf: skips the ref/closure
-   allocation that a [Uutf.String.fold_utf_8] requires per peek. *)
-let first_utf8_chunk_at input p len =
-  if len <= 0 then None
-  else
-    let b = Char.code (String.unsafe_get input p) in
-    if b < 0x80 then Some (Uchar.unsafe_of_int b)
-    else
-      let result = ref None in
-      let seen = ref false in
-      let folder () _ chunk =
-        if !seen then ()
-        else (
-          seen := true;
-          match chunk with `Uchar u -> result := Some u | `Malformed _ -> ())
-      in
-      Uutf.String.fold_utf_8 ~pos:p ~len folder () input;
-      !result
-
+   [None] at EOF or on a malformed sequence. The decoder rejects
+   overlong/surrogate/out-of-range sequences per the Unicode spec, and reading
+   only the element the position opens keeps bad bytes out of the code point
+   that follows them (and out of an ident-like unit token). An ASCII fast path
+   comes first: the byte is its own code point and needs no decoding. *)
 let peek_utf8_at t offset =
   if offset < 0 || offset >= t.len - t.pos then None
   else
@@ -166,11 +141,10 @@ let peek_utf8_at t offset =
     if b < 0x80 then Some (b, 1)
     else
       let len = min 4 (t.len - p) in
-      match first_utf8_chunk_at t.input p len with
-      | None -> None
-      | Some u ->
-          let cp = Uchar.to_int u in
-          Some (cp, utf8_byte_length cp)
+      match Common.String.utf8_decode ~pos:p ~len t.input with
+      | Some (Common.String.Scalar u) ->
+          Some (Uchar.to_int u, Uchar.utf_8_byte_length u)
+      | Some (Common.String.Malformed _) | None -> None
 
 let peek_utf8 t = peek_utf8_at t 0
 
@@ -223,13 +197,13 @@ let err ?got t expected =
   let context, marker_pos = context_window t in
   (* Scan forward from the start of the input, so a newline ends the line it
      sits on and the byte after it opens the next one at column 1. A column
-     counts Unicode scalar values, like the caret. *)
+     counts decoded elements, like the caret. *)
   let line, col =
-    Uutf.String.fold_utf_8 ~len:t.pos
+    Common.String.utf8_fold ~len:t.pos
       (fun (line, col) _ decoded ->
         match decoded with
-        | `Uchar u when Uchar.to_int u = 0x0A -> (line + 1, 1)
-        | `Uchar _ | `Malformed _ -> (line, col + 1))
+        | Common.String.Scalar u when Uchar.to_int u = 0x0A -> (line + 1, 1)
+        | Common.String.Scalar _ | Common.String.Malformed _ -> (line, col + 1))
       (1, 1) t.input
   in
   raise

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2177,12 +2177,12 @@ let add_selector_uchar buf ~add_ascii i u =
   if cp < 0x80 then add_ascii i (Char.chr cp)
   else add_selector_hex_escape buf cp
 
-let add_selector_malformed buf ~add_ascii i bytes =
-  String.iteri
-    (fun offset c ->
-      if Char.code c < 0x80 then add_ascii (i + offset) c
-      else add_selector_hex_escape buf (Char.code c))
-    bytes
+let add_selector_malformed buf ~add_ascii name i len =
+  for j = i to i + len - 1 do
+    let c = name.[j] in
+    if Char.code c < 0x80 then add_ascii j c
+    else add_selector_hex_escape buf (Char.code c)
+  done
 
 (* Fast path: most identifiers in real CSS are pure ASCII without any of the
    characters the full escaper would need to handle. [is_safe_nmchar] is the
@@ -2233,16 +2233,17 @@ let escape_selector_name name =
     let add_ascii = add_selector_ascii buf ~first_needs_hex_escape in
     (* A name with escapable punctuation but no byte >= 0x80 (the common
        Tailwind case: [hover:p-4], [w-1/2], [bg-[#fff]]) has no multi-byte
-       sequence to decode, so escape it byte by byte and skip [Uutf], which
+       sequence to decode, so escape it byte by byte and skip the decoder, which
        would box a [Uchar] per character. [String.iteri]'s index is the byte
-       offset, which equals the [Uutf] fold's index for single-byte input. *)
+       offset, which equals the fold's index for single-byte input. *)
     if name_is_ascii name then String.iteri add_ascii name
     else begin
       let folder () i = function
-        | `Uchar u -> add_selector_uchar buf ~add_ascii i u
-        | `Malformed bytes -> add_selector_malformed buf ~add_ascii i bytes
+        | Common.String.Scalar u -> add_selector_uchar buf ~add_ascii i u
+        | Common.String.Malformed len ->
+            add_selector_malformed buf ~add_ascii name i len
       in
-      Uutf.String.fold_utf_8 folder () name
+      Common.String.utf8_fold folder () name
     end;
     Buffer.contents buf
 

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -32,17 +32,17 @@ let is_ident_cp cp =
 (* [i] is a byte offset, so [i = 0] is the first code point. Malformed UTF-8
    names no code point and so names no ident. *)
 let ident_code_point ok i = function
-  | `Uchar u ->
+  | Common.String.Scalar u ->
       let cp = Uchar.to_int u in
       ok && if i = 0 then is_ident_start_cp cp else is_ident_cp cp
-  | `Malformed _ -> false
+  | Common.String.Malformed _ -> false
 
 let is_ident s =
   let n = String.length s in
   if n = 0 || starts_dash_digit s || (n = 1 && s.[0] = '-') then false
   else if is_ascii_ident_start s.[0] && ascii_ident_continue_from s n 1 then
     true
-  else Uutf.String.fold_utf_8 ident_code_point true s
+  else Common.String.utf8_fold ident_code_point true s
 
 let url_needs_quotes =
   String.exists (function

--- a/test/cram/runtime_deps.t/run.t
+++ b/test/cram/runtime_deps.t/run.t
@@ -3,7 +3,7 @@ the library promises: an embedder targeting js_of_ocaml pays for every entry.
 Alphabetical, and mtime comes along because mtime.clock exports it.
 
   $ ocamlfind query -format '%(requires)' cascade
-  logs mtime mtime.clock psq uri uutf
+  logs mtime mtime.clock psq uri
 
 Measuring how long a factoring iteration takes needs a monotonic clock, so the
 library reads one from mtime rather than the wall clock in unix.  Nothing else

--- a/test/interop/utf8/test.ml
+++ b/test/interop/utf8/test.ml
@@ -3,11 +3,15 @@
     Feeds Markus Kuhn's UTF-8 stress test through
     [Cascade.Css.of_string ~strict:false] and asserts the parser does not raise,
     regardless of ill-formed input. CSS Syntax L3 sec. 3.3 requires malformed
-    UTF-8 to be replaced with U+FFFD rather than rejected.
+    UTF-8 to be replaced with U+FFFD rather than rejected. How many U+FFFD one
+    ill-formed run stands for is what the counting tests below pin, since a
+    parse error's column and its caret are measured in those elements.
 
     Traces: [traces/UTF-8-test.txt] from
     [https://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt] (CC BY 4.0).
     Regenerate: [REGEN=1 dune build @@test/interop/utf8/regen-traces]. *)
+
+module Reader = Cascade.Reader
 
 let trace_path = "traces/UTF-8-test.txt"
 
@@ -43,6 +47,47 @@ let test_per_line () =
         (parses_without_crash line))
     lines
 
+(* The Unicode standard, sec. 3.9 "U+FFFD Substitution of Maximal Subparts",
+   works this very sequence: [61 F1 80 80 E1 80 C2 62 80 63 80 BF 64] converts
+   to [a FFFD FFFD FFFD b FFFD c FFFD FFFD d]. An ill-formed run yields one
+   U+FFFD per maximal subpart, the longest prefix that could still open a
+   well-formed sequence, so the six subparts here are [F1 80 80], [E1 80], [C2],
+   [80], [80] and [BF]: six replacement characters plus four letters, ten
+   elements from thirteen bytes. Browsers substitute by this rule, which is what
+   makes a column counted in these elements the column a browser reports. *)
+let maximal_subparts = "a\xf1\x80\x80\xe1\x80\xc2b\x80c\x80\xbfd"
+
+let test_maximal_subpart_count () =
+  Alcotest.(check int)
+    "one element per maximal subpart" 10
+    (Cascade.Common.String.utf8_length maximal_subparts);
+  (* [E1 80] could still open a three-byte sequence, [A] cannot continue one, so
+     the run ends there and the letter is an element of its own. *)
+  Alcotest.(check int)
+    "an ASCII byte after a truncated sequence stands alone" 2
+    (Cascade.Common.String.utf8_length "\xe1\x80A")
+
+(* Fail at byte [pos] of [input] and report where the reader says that is. *)
+let error_line_and_column input pos =
+  let open Reader in
+  let r = of_string input in
+  for _ = 1 to pos do
+    skip r
+  done;
+  match err r "a character the input never holds" with
+  | (_ : unit) -> Alcotest.failf "expected a parse error at byte %d" pos
+  | exception Parse_error error -> (error.line, error.col)
+
+(* A column is one element of the decoded text, counted from 1, so an error just
+   past the ten elements of [maximal_subparts] sits in column 11. *)
+let test_error_column_after_ill_formed () =
+  Alcotest.(check (pair int int))
+    "column past the tenth element" (1, 11)
+    (error_line_and_column maximal_subparts (String.length maximal_subparts));
+  Alcotest.(check (pair int int))
+    "column past a truncated sequence and the letter after it" (1, 3)
+    (error_line_and_column "\xe1\x80A" 3)
+
 let () =
   Alcotest.run "utf8_boundary"
     [
@@ -50,5 +95,10 @@ let () =
         [
           ("whole file", `Quick, test_whole_file);
           ("per line", `Quick, test_per_line);
+        ] );
+      ( "maximal subparts",
+        [
+          ("element count", `Quick, test_maximal_subpart_count);
+          ("error column", `Quick, test_error_column_after_ill_formed);
         ] );
     ]


### PR DESCRIPTION
`uutf` was used at seven sites for two functions the stdlib now provides, so the dependency goes and one decoding rule lives in `Common.String`. Two of those sites count decoded elements, and their answer changes on input that is not valid UTF-8: the stdlib decoder stops at the maximal subpart of an ill-formed sequence, so a parse error's column counts what a browser counts rather than one per swallowed run.