### PR TITLE
error: put the caret under the line it marks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1062,6 +1062,9 @@ difference wherever the two are not equivalent.
   making a sheet where every rule changes scale near-linearly (#786)
 - `cascade diff` keeps trailing context around a difference between short
   lines, where it previously stopped immediately after the caret (#785)
+- A parse warning puts its caret under the line it marks, at that line's own
+  column. A snippet spanning several lines drew it below the whole window,
+  indented from the first line, so it underlined nothing (#789)
 - `cascade diff` names a changed `@keyframes` block as the at-rule it is,
   in place of the `@layer @keyframes spin` line it printed (#784)
 - `cascade diff` reports the two sizes without a percentage when the first

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -34,6 +34,22 @@ let context t =
     snippet = snippet t;
   }
 
+(* [Loc.Context.marker_pos] is deliberately relative to the whole public
+   snippet. Rendering is the one place that needs its line and line-relative
+   column, so derive those without changing the snippet record's contract. *)
+let marker_in_lines lines marker_pos =
+  let rec find line remaining = function
+    | [] -> (0, 0, 0)
+    | [ last ] ->
+        let len = Common.String.utf8_length last in
+        (line, min remaining len, len)
+    | current :: rest ->
+        let len = Common.String.utf8_length current in
+        if remaining <= len then (line, remaining, len)
+        else find (line + 1) (remaining - len - 1) rest
+  in
+  find 0 (max 0 marker_pos) lines
+
 let pp_kind : kind Pp.t =
  fun ctx -> function
   | Sort_mismatch { expected; found } ->
@@ -88,13 +104,23 @@ let pp : t Pp.t =
   match snippet t with
   | None -> ()
   | Some { text; marker_pos; marker_len } ->
-      Pp.cut ctx ();
-      Pp.string ctx text;
-      Pp.cut ctx ();
-      (* Both counts are columns rather than bytes, so a space and a caret
-         apiece line the marker up under a multibyte snippet. *)
-      Pp.string ctx (String.make marker_pos ' ');
-      Pp.string ctx (String.make (max 1 marker_len) '^')
+      (* The caret line goes under the line it marks rather than under the whole
+         window. Both counts are columns rather than bytes, so a space and a
+         caret apiece line the marker up under a multibyte snippet. *)
+      let lines = String.split_on_char '\n' text in
+      let marker_line, marker_pos, line_len =
+        marker_in_lines lines marker_pos
+      in
+      let marker_len = max 1 (min marker_len (line_len - marker_pos)) in
+      List.iteri
+        (fun i line ->
+          Pp.cut ctx ();
+          Pp.string ctx line;
+          if i = marker_line then (
+            Pp.cut ctx ();
+            Pp.string ctx (String.make marker_pos ' ');
+            Pp.string ctx (String.make marker_len '^')))
+        lines
 
 let to_string t = Pp.to_string pp t
 

--- a/test/cli/parse_error_locations.t
+++ b/test/cli/parse_error_locations.t
@@ -18,8 +18,8 @@ query lands the warning on the junk.
   warning: bad-supports.css: bad condition for @supports: trailing content at [45-55] (in at-rule)
   warning:  color: red }
   warning: @supports (display: grid) extra-junk { .a { color: blue } }
+  warning:                           ^^^^^^^^^^
   warning: .also-ok { color
-  warning:                                         ^^^^^^^^^^
   .ok{color:red}.also-ok{color:green}
 
 Invalid `@container` query: malformed `style()` reports at the query
@@ -33,8 +33,8 @@ slice, not at the start of the file.
   warning: bad-container.css: bad condition for @container: empty style() container query at [30-37] (in at-rule)
   warning: .ok { color: red }
   warning: @container style() { .a { color: blue } }
+  warning:            ^^^^^^^
   warning: 
-  warning:                               ^^^^^^^
   .ok{color:red}
 
 Invalid `@media` query inside `@import`: the media query list of the
@@ -47,7 +47,7 @@ prelude is read the same way as an `@media` rule's.
   $ cascade --minify bad-media.css 2>&1 | grep -E "warning|color" | head
   warning: bad-media.css: bad condition for @media: expected media-in-parens at [22-27] (in at-rule)
   warning: @import url("a.css") (bogus !!!);
+  warning:                       ^^^^^
   warning: .ok { color: red }
   warning: 
-  warning:                       ^^^^^
   .ok{color:red}

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -133,6 +133,33 @@ let ascii_caret_unmoved () =
      a { color: bogus; }\n\
     \           ^^^^^"
 
+let caret_marks_the_line_it_points_at () =
+  (* The marked value sits on the third line of the window, so the caret line
+     comes straight after that line, at that line's own column. *)
+  let source =
+    ".header {\n  color: red;\n  float: center;\n  margin: 0;\n}\n"
+  in
+  let start_pos = String.length ".header {\n  color: red;\n  float: " in
+  let e =
+    Error.v ~source
+      ~loc:(Loc.v ~start_pos ~end_pos:(start_pos + String.length "center"))
+      ~sort:Sort.Property_value
+      (Error.Bad_value { property = "float"; reason = "unknown float-side" })
+  in
+  check "caret marks the line it points at" e
+    (String.concat "\n"
+       [
+         "bad value for float: unknown float-side at [33-39] (in \
+          property-value)";
+         ".header {";
+         "  color: red;";
+         "  float: center;";
+         "         ^^^^^^";
+         "  margin: 0;";
+         "}";
+         "";
+       ])
+
 let source_context () =
   let t = Cursor.of_string "color red;" in
   match Cursor.colon t with
@@ -164,4 +191,6 @@ let suite =
       Alcotest.test_case "window never splits a code point" `Quick
         window_never_splits_a_code_point;
       Alcotest.test_case "ascii caret unmoved" `Quick ascii_caret_unmoved;
+      Alcotest.test_case "caret marks the line it points at" `Quick
+        caret_marks_the_line_it_points_at;
     ] )


### PR DESCRIPTION
`Error.pp` now inserts a warning caret immediately after the line it marks when the snippet spans newlines. The renderer derives line-local coordinates from the existing snippet-relative marker, preserving `Loc.Context.snippet`'s public record and semantics.