### PR TITLE
diff: count a terminating newline as a terminator, not a line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1058,6 +1058,9 @@ difference wherever the two are not equivalent.
 
 ### CLI tools
 
+- A `cascade diff` character-level hunk no longer ends with a context line
+  holding one space when the inputs end in a newline: the empty string a
+  final newline leaves behind is the terminator, not a line (#790)
 - `cascade diff` indexes structural, nesting, and reported-selector matches,
   making a sheet where every rule changes scale near-linearly (#786)
 - `cascade diff` keeps trailing context around a difference between short

--- a/lib/diff/string_diff.ml
+++ b/lib/diff/string_diff.ml
@@ -120,12 +120,21 @@ let diff ?(context_size = 3) ~expected actual =
       let diff_line_exp = match remaining_exp with [] -> "" | h :: _ -> h in
       let diff_line_act = match remaining_act with [] -> "" | h :: _ -> h in
 
+      (* A file ending in a newline has no line after it: the empty string that
+         [split_on_char] leaves behind is the terminator, not content. *)
+      let drop_final_terminator lines =
+        match List.rev lines with "" :: rest -> List.rev rest | _ -> lines
+      in
       (* Get context lines after the diff *)
       let context_after_exp =
-        match remaining_exp with [] -> [] | _ :: t -> list_take context_size t
+        match remaining_exp with
+        | [] -> []
+        | _ :: t -> list_take context_size (drop_final_terminator t)
       in
       let context_after_act =
-        match remaining_act with [] -> [] | _ :: t -> list_take context_size t
+        match remaining_act with
+        | [] -> []
+        | _ :: t -> list_take context_size (drop_final_terminator t)
       in
       let context_after = zip_with_empty context_after_exp context_after_act in
 

--- a/test/test_string_diff.ml
+++ b/test/test_string_diff.ml
@@ -125,6 +125,62 @@ let pp_with_labels () =
         "pp with labels produces output" true
         (String.length output > 0)
 
+(* A file ending in a newline has N lines, not N+1: the empty string
+   [split_on_char] leaves behind is the terminator. Printing it as context adds
+   a line holding one space, below the difference the report is about. *)
+let pp_trailing_newline_adds_no_context_line () =
+  let expected = "a\nb\n" in
+  let actual = "a\nx\n" in
+  match Cascade_diff.String_diff.diff ~expected actual with
+  | None -> Alcotest.fail "expected Some"
+  | Some d ->
+      let buf = Buffer.create 256 in
+      Cascade_diff.String_diff.pp buf d;
+      Alcotest.(check string)
+        "a terminating newline contributes no context line"
+        (String.concat "\n"
+           [
+             "Strings differ at position 2 (line 1, col 0)";
+             "";
+             "--- Expected";
+             "+++ Actual";
+             "@@ position 2 @@";
+             " a";
+             "-b";
+             "+x";
+             " ^";
+             "";
+           ])
+        (Buffer.contents buf)
+
+(* A real empty line before the terminator is context and stays visible. Only
+   the final empty element created by the terminating newline is synthetic. *)
+let pp_trailing_blank_line_keeps_one_context_line () =
+  let expected = "a\nb\n\n" in
+  let actual = "a\nx\n\n" in
+  match Cascade_diff.String_diff.diff ~expected actual with
+  | None -> Alcotest.fail "expected Some"
+  | Some d ->
+      let buf = Buffer.create 256 in
+      Cascade_diff.String_diff.pp buf d;
+      Alcotest.(check string)
+        "one authored blank context line remains"
+        (String.concat "\n"
+           [
+             "Strings differ at position 2 (line 1, col 0)";
+             "";
+             "--- Expected";
+             "+++ Actual";
+             "@@ position 2 @@";
+             " a";
+             "-b";
+             "+x";
+             " ^";
+             " ";
+             "";
+           ])
+        (Buffer.contents buf)
+
 let pp_short_lines_keeps_after_context () =
   let expected = "a\nb\nc\nd\ne" in
   let actual = "a\nx\nc\nd\ne" in
@@ -185,4 +241,8 @@ let suite =
       Alcotest.test_case "pp with labels" `Quick pp_with_labels;
       Alcotest.test_case "pp short lines keeps after context" `Quick
         pp_short_lines_keeps_after_context;
+      Alcotest.test_case "pp trailing newline adds no context line" `Quick
+        pp_trailing_newline_adds_no_context_line;
+      Alcotest.test_case "pp trailing blank line keeps one context line" `Quick
+        pp_trailing_blank_line_keeps_one_context_line;
     ] )


### PR DESCRIPTION
A file ending in a newline has N lines, but splitting on the newline leaves an empty final element that #785 now prints as trailing context, so a character-level hunk ends with a line holding one space. Every other diff tool counts the terminator the same way.