### PR TITLE
diff: bound a report by differences, not tree levels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -171,6 +171,9 @@ difference wherever the two are not equivalent.
   question. `Css.Values.normalize_color` loses its unused `in_feature_query`
   argument, and `Css.Declaration.parse_opaque_declaration` reads a declaration
   without its typed grammar (#587)
+- `cascade diff --depth` is gone: a report is bounded by whole differences
+  now, not by tree levels. Pass `--limit=none` where `--depth=max` was, and
+  `--limit=N` where a level was pinned (#792)
 
 ### Parsing
 
@@ -1058,6 +1061,10 @@ difference wherever the two are not equivalent.
 
 ### CLI tools
 
+- `cascade diff --limit` bounds how many differences a report prints, and the
+  automatic shaping now spends its budget on whole entries rather than cutting
+  every entry's body: a wide report named every selector and explained none
+  (#792)
 - `cascade diff` renders a character with no glyph as an escape, so a
   difference in line endings shows as one and a control byte in a stylesheet
   can no longer drive the reader's terminal (#791)

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ usable as a CI check.
 | Flag | Purpose |
 |---|---|
 | `--diff=MODE` | What counts as "no difference": `auto` (default), `tree`, `string` or `canonical`, as above. |
-| `--depth=auto\|max\|N` | How many levels of the difference tree to print. `auto` (default) prints it whole while it stays short, then falls back to the deepest level that fits; `max` always prints it whole; an integer pins a level. A cut subtree carries the number of lines hidden. |
+| `--limit=auto\|none\|N` | How many top-level differences to print. `auto` (default) prints them all while the report stays short, then keeps as many as fit, each one whole and never fewer than one; `none` prints every one; an integer prints exactly that many. A shortened report ends with the number left out. |
 | `--lossless` | Disable bounded colour and numeric approximation in the `--diff=canonical` canonicalisation, so two sheets that differ only by a fold within an approximation budget report as different rather than equal. Has no effect outside `--diff=canonical`. |
 | `--prune-unused-custom-props` | Drop the custom-property bindings nothing references, on both sides, before comparing under `--diff=canonical`, so two sheets that differ only by a dead binding compare equal. The comparison is then blind to dead-custom-property divergences. Has no effect outside `--diff=canonical`. |
 | `--color=WHEN` | `auto` (default), `always` or `never`. `CASCADE_COLOR` sets the same thing; `NO_COLOR` overrides both. |

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -4,10 +4,15 @@ type mode = Auto | Tree | String | Canonical
 
 let err_read path msg = Error (`Msg (Fmt.str "Error reading %s: %s" path msg))
 
-let err_depth s =
+let err_limit s =
   Error
     (`Msg
-       (Fmt.str "invalid depth %S: expected auto, max, or a positive integer" s))
+       (String.concat ""
+          [
+            "invalid limit \"";
+            String.escaped s;
+            "\": expected auto, none, or a positive integer";
+          ]))
 
 let read_file path =
   try Ok (Cli_io.read_file path) with Sys_error msg -> err_read path msg
@@ -36,16 +41,18 @@ let run_diff mode ~lossless ~prune_unused_custom_props ~css1 ~css2 =
   Cascade_diff.Css_compare.diff ~mode ~lossless ~prune_unused_custom_props css1
     css2
 
-type depth = Fit | Full | Level of int
+(* How many top-level differences the report names. [Fit_entries] lets the
+   automatic shaping decide, [All_entries] names every one, [Count n] names
+   exactly [n]. *)
+type limit = Fit_entries | All_entries | Count of int
 
 (* A report past this many lines has stopped summarising and started dumping, so
-   [Auto] drops to the deepest level that still fits. *)
+   [Fit_entries] narrows it to the most it can show and still be read. *)
 let auto_line_budget = 40
 
-(* The probe renders the report once per level, and the diff tree is as deep as
-   the stylesheet nests. Stop at a level that summarises any report worth
-   summarising; [--depth=max] is the answer for the rest. *)
-let max_probe_depth = 5
+(* Every entry costs at least the line naming it, so no report fits more entries
+   than the budget has lines. *)
+let max_probe_entries = auto_line_budget
 
 let count_lines s =
   let n = ref 0 in
@@ -55,9 +62,15 @@ let count_lines s =
 (* Parse warnings shown per side before the rest is counted. *)
 let auto_warning_budget = 3
 
-let render_diff ~color ~file1 ~file2 ~depth result =
+(* [none] bounds nothing, warnings included. Every other setting keeps the
+   report short, which a wall of warnings ahead of it would undo. *)
+let warning_budget = function
+  | All_entries -> None
+  | Fit_entries | Count _ -> Some auto_warning_budget
+
+let render_diff ~color ~file1 ~file2 ~entries result =
   let buf = Buffer.create 1024 in
-  Cascade_diff.Css_compare.pp_diff ~expected:file1 ~actual:file2 ~color ?depth
+  Cascade_diff.Css_compare.pp_diff ~expected:file1 ~actual:file2 ~color ?entries
     buf result;
   Buffer.contents buf
 
@@ -68,29 +81,33 @@ let render_warnings ~file1 ~file2 ~max result =
   if Cascade_diff.Css_compare.has_warnings result then Buffer.add_char buf '\n';
   Buffer.contents buf
 
-(* Deepest level whose report still fits the budget, or level 1 when even the
-   roots overflow: the roots are the one thing always worth printing. *)
-let fit_depth render =
-  let rec go level best =
-    if level > max_probe_depth then best
-    else
-      let body = render (Some level) in
-      if count_lines body <= auto_line_budget then go (level + 1) (level, body)
-      else best
-  in
-  go 2 (1, render (Some 1))
+let fits body = count_lines body <= auto_line_budget
 
-let render_at_depth ~color ~file1 ~file2 ~depth result =
-  let render depth = render_diff ~color ~file1 ~file2 ~depth result in
-  match depth with
-  | Full -> (render None, None)
-  | Level n -> (render (Some n), None)
-  | Fit ->
+(* Most entries whose report still fits, by bisection: an entry only ever adds
+   lines, so a count that overflows bounds every larger one. The floor is one
+   entry, however tall: one difference shown whole and a count of the rest is
+   the worst case worth printing, not every difference with its body cut. *)
+let fit_entries render =
+  let rec go low high best =
+    if low > high then best
+    else
+      let mid = low + ((high - low) / 2) in
+      let body = render mid in
+      if fits body then go (mid + 1) high (mid, body) else go low (mid - 1) best
+  in
+  go 2 max_probe_entries (1, render 1)
+
+let render_report ~color ~file1 ~file2 ~limit result =
+  let render entries = render_diff ~color ~file1 ~file2 ~entries result in
+  match limit with
+  | All_entries -> (render None, None)
+  | Count n -> (render (Some n), None)
+  | Fit_entries ->
       let full = render None in
-      if count_lines full <= auto_line_budget then (full, None)
+      if fits full then (full, None)
       else
-        let level, body = fit_depth render in
-        (body, Some level)
+        let n, body = fit_entries (fun n -> render (Some n)) in
+        (body, Some n)
 
 (* Canonical mode compares the two canonical minified forms, so the text under a
    string diff there is those forms and not the files as written. Say which. *)
@@ -100,36 +117,35 @@ let canonical_forms_note mode result =
       "Canonical forms differ:\n"
   | _ -> ""
 
-let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth ~mode result =
+let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~limit ~mode result =
   let stats =
     Cascade_diff.Css_compare.stats ~expected_str:css1 ~actual_str:css2 result
   in
-  let max_warnings =
-    match depth with Full -> None | Fit | Level _ -> Some auto_warning_budget
-  in
+  let max_warnings = warning_budget limit in
   let buf = Buffer.create 1024 in
   Cascade_diff.Css_compare.pp_stats buf stats;
   Buffer.add_string buf
     (canonical_forms_note mode result.Cascade_diff.Css_compare.result);
   Buffer.add_char buf '\n';
   Buffer.add_string buf (render_warnings ~file1 ~file2 ~max:max_warnings result);
-  let body, elided_at = render_at_depth ~color ~file1 ~file2 ~depth result in
+  let body, elided = render_report ~color ~file1 ~file2 ~limit result in
   Buffer.add_string buf body;
   Buffer.add_char buf '\n';
-  (match elided_at with
+  (* A shortened report says how far it was cut and how to release it. *)
+  (match elided with
   | None -> ()
-  | Some level ->
+  | Some n ->
       List.iter (Buffer.add_string buf)
         [
-          "(depth ";
-          string_of_int level;
-          "; use --depth=max for the full report)\n";
+          "(limit ";
+          string_of_int n;
+          "; use --limit=none for the full report)\n";
         ]);
   print_string (Buffer.contents buf)
 
 type canonical_opts = { lossless : bool; prune_unused_custom_props : bool }
 
-let compare_files file1 file2 style_renderer mode depth opts () =
+let compare_files file1 file2 style_renderer mode limit opts () =
   Fmt_tty.setup_std_outputs
     ?style_renderer:(resolve_style_renderer style_renderer)
     ();
@@ -156,17 +172,13 @@ let compare_files file1 file2 style_renderer mode depth opts () =
         | No_diff ->
             (* Equal ASTs can still hide parse-dropped declarations; show the
                warnings so the equality verdict is honest about them. *)
-            let max =
-              match depth with
-              | Full -> None
-              | Fit | Level _ -> Some auto_warning_budget
-            in
+            let max = warning_budget limit in
             print_string (render_warnings ~file1 ~file2 ~max result);
             Fmt.pr "CSS files are identical@.";
             Ok ()
         | String_diff _ | Tree_diff _ | Both_errors _ | Expected_error _
         | Actual_error _ ->
-            print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~depth ~mode
+            print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~limit ~mode
               result;
             (* Differing inputs are a result, not a usage error: exit 1 as
                documented, distinct from cmdliner's reserved error codes. *)
@@ -199,32 +211,33 @@ let mode_arg =
   in
   Arg.(value & opt mode_conv Auto & info [ "diff" ] ~docv:"MODE" ~doc)
 
-let depth_arg =
+let limit_arg =
   let doc =
-    "How many levels of the difference tree to print: $(b,auto) (default) \
-     prints the whole tree when it is short and otherwise falls back to the \
-     deepest level that stays readable, $(b,max) always prints it in full, and \
-     an integer pins an exact level ($(b,1) is the top-level entries alone). \
-     Wherever children are cut off, a $(b,... N more lines) marker records how \
-     much is hidden."
+    "How many top-level differences to print: $(b,auto) (default) prints them \
+     all when the report is short and otherwise keeps as many as stay \
+     readable, each one whole and never fewer than one, $(b,none) prints every \
+     one and every parse warning with it, and an integer prints exactly that \
+     many. Wherever differences are left over, a $(b,... N more differences) \
+     line records how many. Applies to the whole report, so a bound of $(b,1) \
+     is one top-level entry however many sections the report has."
   in
   let parse = function
-    | "auto" -> Ok Fit
-    | "max" | "full" -> Ok Full
+    | "auto" -> Ok Fit_entries
+    | "none" -> Ok All_entries
     | s -> (
         match int_of_string_opt s with
-        | Some n when n >= 1 -> Ok (Level n)
-        | Some _ | None -> err_depth s)
+        | Some n when n >= 1 -> Ok (Count n)
+        | Some _ | None -> err_limit s)
   in
   let print ppf = function
-    | Fit -> Fmt.string ppf "auto"
-    | Full -> Fmt.string ppf "max"
-    | Level n -> Fmt.int ppf n
+    | Fit_entries -> Fmt.string ppf "auto"
+    | All_entries -> Fmt.string ppf "none"
+    | Count n -> Fmt.int ppf n
   in
   Arg.(
     value
-    & opt (conv ~docv:"DEPTH" (parse, print)) Fit
-    & info [ "depth" ] ~docv:"DEPTH" ~doc)
+    & opt (conv ~docv:"LIMIT" (parse, print)) Fit_entries
+    & info [ "limit" ] ~docv:"LIMIT" ~doc)
 
 let lossless_arg =
   let doc =
@@ -266,7 +279,7 @@ let term =
   in
   term_result
     (const compare_files $ file1_arg $ file2_arg $ style_renderer_with_env
-   $ mode_arg $ depth_arg $ canonical_opts $ Cli_log.term)
+   $ mode_arg $ limit_arg $ canonical_opts $ Cli_log.term)
 
 let man =
   [

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -707,10 +707,10 @@ let pp_parse_warnings ?(max = Stdlib.max_int) buf label warnings =
       ]
 
 let pp_result ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
-    ?depth buf = function
+    ?depth ?entries buf = function
   | Tree_diff d ->
       (* Show structural differences *)
-      D.pp ~expected ~actual ~color ?depth buf d
+      D.pp ~expected ~actual ~color ?depth ?entries buf d
   | String_diff sdiff ->
       String_diff.pp ~expected_label:expected ~actual_label:actual buf sdiff
   | No_diff -> ()
@@ -743,16 +743,16 @@ let pp_warnings ?(expected = "Expected") ?(actual = "Actual") ?max buf t =
 let has_warnings t = t.expected_warnings <> [] || t.actual_warnings <> []
 
 let pp_diff ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
-    ?depth buf t =
-  pp_result ~expected ~actual ~color ?depth buf t.result
+    ?depth ?entries buf t =
+  pp_result ~expected ~actual ~color ?depth ?entries buf t.result
 
-let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false) ?depth buf
-    t =
+let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false) ?depth
+    ?entries buf t =
   (* Warnings come first: a dropped declaration qualifies every line below it,
      and trailing them puts that caveat past the end of a long report. *)
   pp_warnings ~expected ~actual buf t;
   if has_warnings t then Buffer.add_char buf '\n';
-  pp_diff ~expected ~actual ~color ?depth buf t
+  pp_diff ~expected ~actual ~color ?depth ?entries buf t
 
 let add_pct buf char_diff_pct =
   let rounded = Float.round (char_diff_pct *. 10.0) /. 10.0 in

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -145,17 +145,19 @@ val pp :
   ?actual:string ->
   ?color:bool ->
   ?depth:int ->
+  ?entries:int ->
   Buffer.t ->
   t ->
   unit
-(** [pp ?expected ?actual ?color ?depth buf result] renders each side's parse
-    warnings into [buf], then formats [result] below them. Warnings lead because
-    a declaration the parser dropped qualifies every difference that follows.
-    The [expected]/[actual] labels are used in the rendered header and warning
-    lines (defaults: ["Expected"], ["Actual"]). [color] (default [false]) wraps
-    diff markers in ANSI escapes; the caller decides whether the destination
-    supports colour. [depth] bounds the rendered tree levels as in
-    {!Tree_diff.pp} (default: unbounded).
+(** [pp ?expected ?actual ?color ?depth ?entries buf result] renders each side's
+    parse warnings into [buf], then formats [result] below them. Warnings lead
+    because a declaration the parser dropped qualifies every difference that
+    follows. The [expected]/[actual] labels are used in the rendered header and
+    warning lines (defaults: ["Expected"], ["Actual"]). [color] (default
+    [false]) wraps diff markers in ANSI escapes; the caller decides whether the
+    destination supports colour. [depth] bounds the rendered tree levels and
+    [entries] the number of top-level entries, both as in {!Tree_diff.pp}
+    (default: unbounded).
 
     {!pp_warnings} and {!pp_diff} are the two halves, for callers that need to
     size or bound the sections independently. *)
@@ -173,11 +175,12 @@ val pp_diff :
   ?actual:string ->
   ?color:bool ->
   ?depth:int ->
+  ?entries:int ->
   Buffer.t ->
   t ->
   unit
-(** [pp_diff ?expected ?actual ?color ?depth buf result] renders only the
-    difference report, without the parse warnings. *)
+(** [pp_diff ?expected ?actual ?color ?depth ?entries buf result] renders only
+    the difference report, without the parse warnings. *)
 
 val has_warnings : t -> bool
 (** [has_warnings result] is [true] when either side accumulated a parse

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -123,6 +123,7 @@ type tree_style = {
 }
 
 let unlimited_depth = max_int
+let unlimited_entries = max_int
 let default_style = { use_tree = false; color = false; depth = unlimited_depth }
 let tree_style = { use_tree = true; color = false; depth = unlimited_depth }
 
@@ -1123,26 +1124,29 @@ let pp_diff_headers ~color buf expected actual =
   add_strings buf
     [ ansi_yellow ~color "+++"; " "; ansi_yellow ~color actual; "\n" ]
 
-let pp_rule_list ~style ~container_count buf rule_list =
+(* [trailing] is how many top-level entries the report still prints after this
+   section: the closing connector belongs to the last of them, not to the last
+   of a section a breadth limit cut short. *)
+let pp_rule_list ~style ~trailing buf rule_list =
   let rule_count = List.length rule_list in
   List.iteri
     (fun i rule_diff ->
-      let is_last = i = rule_count - 1 && container_count = 0 in
+      let is_last = i = rule_count - 1 && trailing = 0 in
       pp_rule_diff ~style ~is_last ~parent_prefix:"" buf rule_diff)
     rule_list
 
-let pp_reordered_section ~style ~container_count buf = function
+let pp_reordered_section ~style ~trailing buf = function
   | [] -> ()
   | lst ->
       add_strings buf
         [ "Rules reordered ("; string_of_int (List.length lst); " rules):\n" ];
-      pp_rule_list ~style ~container_count buf lst
+      pp_rule_list ~style ~trailing buf lst
 
-let pp_containers_section ~style buf containers =
+let pp_containers_section ~style ~trailing buf containers =
   let container_count = List.length containers in
   List.iteri
     (fun i cont_diff ->
-      let is_last = i = container_count - 1 in
+      let is_last = i = container_count - 1 && trailing = 0 in
       pp_container_diff ~style ~is_last ~parent_prefix:"" buf cont_diff)
     containers
 
@@ -1205,24 +1209,40 @@ let pp_layer_swaps ~style buf swapped =
         ]
   | _ -> ()
 
-let pp_layer_order_section ~style buf = function
-  | None -> ()
-  | Some { expected_order; actual_order; swapped } ->
-      Buffer.add_string buf "Cascade layer order changed:\n";
-      pp_children ~style ~parent_prefix:"" buf (fun style buf ->
-          pp_layer_swaps ~style buf swapped;
-          add_strings buf
-            [
-              tree_prefix ~style ~is_last:true ~parent_prefix:"";
-              "order: ";
-              ansi_red ~color:style.color (layer_path_list expected_order);
-              " -> ";
-              ansi_green ~color:style.color (layer_path_list actual_order);
-              "\n";
-            ])
+let pp_layer_order_section ~style buf { expected_order; actual_order; swapped }
+    =
+  Buffer.add_string buf "Cascade layer order changed:\n";
+  pp_children ~style ~parent_prefix:"" buf (fun style buf ->
+      pp_layer_swaps ~style buf swapped;
+      add_strings buf
+        [
+          tree_prefix ~style ~is_last:true ~parent_prefix:"";
+          "order: ";
+          ansi_red ~color:style.color (layer_path_list expected_order);
+          " -> ";
+          ansi_green ~color:style.color (layer_path_list actual_order);
+          "\n";
+        ])
+
+(* Closes a breadth-limited report the way [pp_layer_swaps] closes a capped swap
+   listing: the count the reader needs to know they are seeing a prefix. *)
+let pp_hidden_entries ~style buf hidden =
+  let noun =
+    if hidden = 1 then " more difference\n" else " more differences\n"
+  in
+  add_strings buf
+    [
+      tree_prefix ~style ~is_last:true ~parent_prefix:"";
+      "...";
+      string_of_int hidden;
+      noun;
+    ]
+
+let first n l = List.filteri (fun i _ -> i < n) l
 
 let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
-    ?(depth = unlimited_depth) buf { rules; containers; layer_order } =
+    ?(depth = unlimited_depth) ?(entries = unlimited_entries) buf
+    { rules; containers; layer_order } =
   if rules = [] && containers = [] && Option.is_none layer_order then
     Buffer.add_string buf
       "Structural differences detected in nested contexts (e.g., @media inside \
@@ -1238,14 +1258,35 @@ let pp ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
           match diff with Reordered _ -> true | _ -> false)
         rules
     in
+    (* The budget is spent in printing order, so the entries a reader is left
+       with are the ones the report would have led with anyway. *)
+    let layer_entries o = if Option.is_none o then 0 else 1 in
+    let budget = max 0 entries in
+    let shown_layers = if budget > 0 then layer_order else None in
+    let budget = budget - layer_entries shown_layers in
+    let shown_rules = first budget meaningful in
+    let budget = budget - List.length shown_rules in
+    let shown_reordered = first budget reordered_rules in
+    let budget = budget - List.length shown_reordered in
+    let shown_containers = first budget containers in
+    let hidden =
+      layer_entries layer_order - layer_entries shown_layers
+      + (List.length meaningful - List.length shown_rules)
+      + (List.length reordered_rules - List.length shown_reordered)
+      + (List.length containers - List.length shown_containers)
+    in
     (* [depth] counts renderable levels; the roots printed here are level 1. *)
     let style = { tree_style with color; depth = max 0 (depth - 1) } in
-    let container_count = List.length containers in
+    (* The count line closes the tree, so a section the budget cut short is no
+       longer the last thing the report prints. *)
+    let hidden_line = if hidden > 0 then 1 else 0 in
+    let after_rules = List.length shown_containers + hidden_line in
     (* The layer order leads: it decides which of the rules below it wins. *)
-    pp_layer_order_section ~style buf layer_order;
-    pp_rule_list ~style ~container_count buf meaningful;
-    pp_reordered_section ~style ~container_count buf reordered_rules;
-    pp_containers_section ~style buf containers)
+    Option.iter (pp_layer_order_section ~style buf) shown_layers;
+    pp_rule_list ~style ~trailing:after_rules buf shown_rules;
+    pp_reordered_section ~style ~trailing:after_rules buf shown_reordered;
+    pp_containers_section ~style ~trailing:hidden_line buf shown_containers;
+    if hidden > 0 then pp_hidden_entries ~style buf hidden)
 
 (* ===== Tree Diff Computation Functions ===== *)
 

--- a/lib/diff/tree_diff.mli
+++ b/lib/diff/tree_diff.mli
@@ -138,19 +138,26 @@ val pp :
   ?actual:string ->
   ?color:bool ->
   ?depth:int ->
+  ?entries:int ->
   Buffer.t ->
   t ->
   unit
-(** [pp ?expected ?actual ?color ?depth buf t] pretty-prints a tree diff with
-    optional labels. Default labels are "Expected" and "Actual". [color]
-    (default [false]) wraps diff markers in ANSI escapes; the printer writes
-    into a buffer, so the caller decides whether the destination supports
+(** [pp ?expected ?actual ?color ?depth ?entries buf t] pretty-prints a tree
+    diff with optional labels. Default labels are "Expected" and "Actual".
+    [color] (default [false]) wraps diff markers in ANSI escapes; the printer
+    writes into a buffer, so the caller decides whether the destination supports
     colour.
 
     [depth] bounds how many tree levels are rendered, the top-level entries
     being level 1 (default: unbounded). A node whose children are cut off is
     followed by a ["... N more lines"] marker, so the report never reads as if
-    the elided subtree were empty. *)
+    the elided subtree were empty.
+
+    [entries] bounds how many top-level entries the whole report renders
+    (default: unbounded), the budget being spent in printing order: the cascade
+    layer order, then the rules, then the reordered rules, then the containers.
+    Each entry that is printed is printed whole, and the report ends with a
+    ["... N more differences"] line counting the rest. *)
 
 val pp_rule_diff_simple : Buffer.t -> rule_diff -> unit
 (** [pp_rule_diff_simple buf rule] pretty-prints a rule diff in a simple format

--- a/test/cli/diff_blocks.t
+++ b/test/cli/diff_blocks.t
@@ -26,7 +26,7 @@ each side.
   > .s3{order:3}
   > @media print{.t3{color:#0f0}}
   > EOF
-  $ NO_COLOR=1 cascade diff --diff=tree --depth=max blocks-split.css blocks-merged.css
+  $ NO_COLOR=1 cascade diff --diff=tree --limit=none blocks-split.css blocks-merged.css
   CSS: 204 chars vs 189 chars (7.4% diff)
   Changes: 1 changed container
   

--- a/test/cli/diff_canonical_source_order.t
+++ b/test/cli/diff_canonical_source_order.t
@@ -15,7 +15,7 @@ the report contains only the declaration change the author made.
   $ cat > after.css <<'CSS'
   > .c{background-color:blue}.a{color:red}.b{margin-top:1px}
   > CSS
-  $ cascade diff --diff=canonical --depth=max before.css after.css
+  $ cascade diff --diff=canonical --limit=none before.css after.css
   CSS: 46 chars vs 57 chars (23.9% diff)
   Changes: 1 modified rule
   
@@ -36,7 +36,7 @@ element and both write `color`, so swapping the rules changes the winner.
   $ cat > move-after.css <<'CSS'
   > .b{color:blue}.a{color:red}
   > CSS
-  $ cascade diff --diff=canonical --depth=max move-before.css move-after.css
+  $ cascade diff --diff=canonical --limit=none move-before.css move-after.css
   CSS: 28 chars vs 28 chars (0.0% diff)
   Changes: 1 reordered rule
   

--- a/test/cli/diff_depth.t
+++ b/test/cli/diff_depth.t
@@ -1,7 +1,7 @@
-CLI: cascade diff - report shaping (depth, warnings, block runs).
+CLI: cascade diff - report shaping (whole reports, warnings).
 
-A small diff prints in full: --depth=auto only steps back once the
-report stops fitting.
+A small diff prints in full: the automatic shaping only steps back once
+the report stops fitting.
 
   $ cat > a.css <<EOF
   > .x { color: red; margin: 0 }
@@ -18,22 +18,6 @@ report stops fitting.
   └─ .x
         * color: red -> blue
         * margin: 0 -> 1px
-  
-  [1]
-
-
-
-Pinning a depth cuts the tree there and records what it hid, so an
-elided subtree never reads as an empty one.
-
-  $ NO_COLOR=1 cascade diff --depth=1 a.css b.css
-  CSS: 29 chars vs 32 chars (10.3% diff)
-  Changes: 1 modified rule
-  
-  --- a.css
-  +++ b.css
-  └─ .x
-        ...2 more lines
   
   [1]
 

--- a/test/cli/diff_limit.t
+++ b/test/cli/diff_limit.t
@@ -1,0 +1,156 @@
+CLI: cascade diff - report shaping (breadth).
+
+A report too wide for the line budget shows fewer differences in full
+rather than every difference with its body cut: three complete entries
+and a count of the rest can be acted on, a column of bare selectors
+cannot.
+
+  $ for i in $(seq 1 20); do
+  >   echo ".r$i { color: red; margin: 0; padding: 0; width: 1px }" >> a.css
+  >   echo ".r$i { color: blue; margin: 1px; padding: 2px; width: 2px }" >> b.css
+  > done
+  $ NO_COLOR=1 cascade diff a.css b.css
+  CSS: 1091 chars vs 1191 chars (9.2% diff)
+  Changes: 20 modified rules
+  
+  --- a.css
+  +++ b.css
+  ├─ .r1
+  │     * color: red -> blue
+  │     * margin: 0 -> 1px
+  │     * padding: 0 -> 2px
+  │     * width: 1px -> 2px
+  ├─ .r2
+  │     * color: red -> blue
+  │     * margin: 0 -> 1px
+  │     * padding: 0 -> 2px
+  │     * width: 1px -> 2px
+  ├─ .r3
+  │     * color: red -> blue
+  │     * margin: 0 -> 1px
+  │     * padding: 0 -> 2px
+  │     * width: 1px -> 2px
+  ├─ .r4
+  │     * color: red -> blue
+  │     * margin: 0 -> 1px
+  │     * padding: 0 -> 2px
+  │     * width: 1px -> 2px
+  ├─ .r5
+  │     * color: red -> blue
+  │     * margin: 0 -> 1px
+  │     * padding: 0 -> 2px
+  │     * width: 1px -> 2px
+  ├─ .r6
+  │     * color: red -> blue
+  │     * margin: 0 -> 1px
+  │     * padding: 0 -> 2px
+  │     * width: 1px -> 2px
+  ├─ .r7
+  │     * color: red -> blue
+  │     * margin: 0 -> 1px
+  │     * padding: 0 -> 2px
+  │     * width: 1px -> 2px
+  └─ ...13 more differences
+  
+  (limit 7; use --limit=none for the full report)
+  [1]
+
+
+
+An explicit count overrides the budget.
+
+  $ NO_COLOR=1 cascade diff --limit=2 a.css b.css
+  CSS: 1091 chars vs 1191 chars (9.2% diff)
+  Changes: 20 modified rules
+  
+  --- a.css
+  +++ b.css
+  ├─ .r1
+  │     * color: red -> blue
+  │     * margin: 0 -> 1px
+  │     * padding: 0 -> 2px
+  │     * width: 1px -> 2px
+  ├─ .r2
+  │     * color: red -> blue
+  │     * margin: 0 -> 1px
+  │     * padding: 0 -> 2px
+  │     * width: 1px -> 2px
+  └─ ...18 more differences
+  
+  [1]
+
+
+
+--limit=none bounds nothing, so every difference is named and only the
+depth fallback shapes the report.
+
+  $ NO_COLOR=1 cascade diff --limit=none a.css b.css | grep -c '\.r[0-9]'
+  20
+  $ NO_COLOR=1 cascade diff --limit=none a.css b.css | grep 'more differences'
+  [1]
+
+
+A report that already fits is printed whole, entry limit or not.
+
+  $ cat > small-a.css <<EOF
+  > .x { color: red; margin: 0 }
+  > EOF
+  $ cat > small-b.css <<EOF
+  > .x { color: blue; margin: 1px }
+  > EOF
+  $ NO_COLOR=1 cascade diff small-a.css small-b.css
+  CSS: 29 chars vs 32 chars (10.3% diff)
+  Changes: 1 modified rule
+  
+  --- small-a.css
+  +++ small-b.css
+  └─ .x
+        * color: red -> blue
+        * margin: 0 -> 1px
+  
+  [1]
+
+
+Truncating a section moves the closing connector onto the count line, so a
+bounded report never ends on a branch with nothing under it.
+
+  $ cat > m-a.css <<EOF
+  > @media print { .a { color: red } }
+  > @media screen { .a { color: red } }
+  > @media (min-width: 10px) { .a { color: red } }
+  > EOF
+  $ cat > m-b.css <<EOF
+  > @media print { .a { color: blue } }
+  > @media screen { .a { color: blue } }
+  > @media (min-width: 10px) { .a { color: blue } }
+  > EOF
+  $ NO_COLOR=1 cascade diff --limit=2 m-a.css m-b.css | grep -cE '^├─'
+  2
+  $ NO_COLOR=1 cascade diff --limit=2 m-a.css m-b.css | grep -E '^└─'
+  └─ ...1 more difference
+
+
+One difference that overflows the budget on its own is still printed whole:
+a difference a reader can act on and a count of the rest is the floor, not
+every difference with its body cut.
+
+  $ for i in 1 2 3; do
+  >   printf '@media (min-width: %spx) {' "$i" >> wide-a.css
+  >   printf '@media (min-width: %spx) {' "$i" >> wide-b.css
+  >   for j in $(seq 1 15); do
+  >     printf ' .r%s { color: red; margin: 0 }' "$j" >> wide-a.css
+  >     printf ' .r%s { color: blue; margin: 1px }' "$j" >> wide-b.css
+  >   done
+  >   printf ' }\n' >> wide-a.css
+  >   printf ' }\n' >> wide-b.css
+  > done
+  $ NO_COLOR=1 cascade diff wide-a.css wide-b.css | grep -cE '^(├|└)─ @media'
+  1
+  $ NO_COLOR=1 cascade diff wide-a.css wide-b.css | grep -c ' -> '
+  30
+  $ NO_COLOR=1 cascade diff wide-a.css wide-b.css | grep 'more lines'
+  [1]
+  $ NO_COLOR=1 cascade diff wide-a.css wide-b.css | tail -3
+  └─ ...2 more differences
+  
+  (limit 1; use --limit=none for the full report)

--- a/test/cli/diff_nesting.t
+++ b/test/cli/diff_nesting.t
@@ -10,7 +10,7 @@ node it stopped at.
   $ cat > deep-b.css <<EOF
   > @media (min-width:1px){@supports (display:grid){@media (min-width:2px){@supports (display:flex){@media (min-width:3px){a{color:blue}}}}}}
   > EOF
-  $ NO_COLOR=1 cascade diff --diff=tree --depth=max deep-a.css deep-b.css
+  $ NO_COLOR=1 cascade diff --diff=tree --limit=none deep-a.css deep-b.css
   CSS: 137 chars vs 138 chars (0.7% diff)
   Changes: 1 changed container
   

--- a/test/cli/diff_reorder_same_position.t
+++ b/test/cli/diff_reorder_same_position.t
@@ -16,7 +16,7 @@ coordinate rather than pairing position 1 with position 1.
   $ cat > reversed_tw.css <<'CSS'
   > .c{--c:3}.a{--c:2}.b{--c:1}
   > CSS
-  $ cascade diff --diff=tree --depth=max reversed_ref.css reversed_tw.css
+  $ cascade diff --diff=tree --limit=none reversed_ref.css reversed_tw.css
   CSS: 37 chars vs 28 chars (24.3% diff)
   Changes: 1 removed rule, 2 reordered rules
   
@@ -38,7 +38,7 @@ The same pair inside a container reports through the container renderer.
   $ cat > layer_tw.css <<'CSS'
   > @layer u{.c{--c:3}.a{--c:2}.b{--c:1}}
   > CSS
-  $ cascade diff --diff=tree --depth=max layer_ref.css layer_tw.css
+  $ cascade diff --diff=tree --limit=none layer_ref.css layer_tw.css
   CSS: 47 chars vs 38 chars (19.1% diff)
   Changes: 1 changed container
   
@@ -62,7 +62,7 @@ because `.z` left.
   $ cat > shifted_tw.css <<'CSS'
   > .b{--c:1}.a{--c:2}
   > CSS
-  $ cascade diff --diff=tree --depth=max shifted_ref.css shifted_tw.css
+  $ cascade diff --diff=tree --limit=none shifted_ref.css shifted_tw.css
   CSS: 28 chars vs 19 chars (32.1% diff)
   Changes: 1 removed rule, 1 reordered rule
   
@@ -86,7 +86,7 @@ coordinates. Tree comparison still reports the indexes from the source ASTs.
   $ cat > canonical_tw.css <<'CSS'
   > .c{color:green}.a{color:red}.b{color:blue}
   > CSS
-  $ cascade diff --diff=canonical --depth=max canonical_ref.css canonical_tw.css
+  $ cascade diff --diff=canonical --limit=none canonical_ref.css canonical_tw.css
   CSS: 43 chars vs 43 chars (0.0% diff)
   Changes: 1 reordered rule
   
@@ -96,7 +96,7 @@ coordinates. Tree comparison still reports the indexes from the source ASTs.
   └─ .c (moved)
   
   [1]
-  $ cascade diff --diff=tree --depth=max canonical_ref.css canonical_tw.css
+  $ cascade diff --diff=tree --limit=none canonical_ref.css canonical_tw.css
   CSS: 43 chars vs 43 chars (0.0% diff)
   Changes: 1 reordered rule
   

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -23,7 +23,7 @@ rather than as a loss and a gain.
   $ cat > tw.css <<'EOF'
   > @layer utilities{.drop-shadow-sm{--tw-drop-shadow-size:drop-shadow(0 1px 2px var(--tw-drop-shadow-color,#00000026));--tw-drop-shadow:drop-shadow(var(--drop-shadow-sm));filter:var(--tw-blur,)var(--tw-brightness,)var(--tw-contrast,)var(--tw-grayscale,)var(--tw-hue-rotate,)var(--tw-invert,)var(--tw-saturate,)var(--tw-sepia,)var(--tw-drop-shadow,)}.drop-shadow-indigo-500{--tw-drop-shadow-color:oklch(58.5%.233 277.117)}@supports(color:color-mix(in lab,red,red)){.drop-shadow-indigo-500{--tw-drop-shadow-color:color-mix(in oklab,var(--color-indigo-500) var(--tw-drop-shadow-alpha),transparent)}}.drop-shadow-indigo-500{--tw-drop-shadow:var(--tw-drop-shadow-size)}.drop-shadow-blue-500\/50{--tw-drop-shadow-color:#3080ff80}@supports(color:color-mix(in lab,red,red)){.drop-shadow-blue-500\/50{--tw-drop-shadow-color:color-mix(in oklab,color-mix(in oklab,var(--color-blue-500) 50%,transparent) var(--tw-drop-shadow-alpha),transparent)}}.drop-shadow-blue-500\/50{--tw-drop-shadow:var(--tw-drop-shadow-size)}}
   > EOF
-  $ cascade diff --diff=canonical --prune-unused-custom-props --depth=max ref.css tw.css
+  $ cascade diff --diff=canonical --prune-unused-custom-props --limit=none ref.css tw.css
   CSS: 1024 chars vs 1003 chars (2.1% diff)
   Changes: 1 changed container
   
@@ -44,7 +44,7 @@ A top-level group reports the same way as one inside a container.
   $ cat > joined.css <<'EOF'
   > .a{color:red;margin:0}.b{color:blue}
   > EOF
-  $ cascade diff --depth=max split.css joined.css
+  $ cascade diff --limit=none split.css joined.css
   CSS: 40 chars vs 37 chars (7.5% diff)
   Changes: 1 rearranged rule
   
@@ -64,7 +64,7 @@ A top-level group reports the same way as one inside a container.
   $ cat > joined_layer.css <<'EOF'
   > @layer u{.a{color:red;margin:0}.b{color:blue}}
   > EOF
-  $ cascade diff --depth=max split_layer.css joined_layer.css
+  $ cascade diff --limit=none split_layer.css joined_layer.css
   CSS: 50 chars vs 47 chars (6.0% diff)
   Changes: 1 changed container
   
@@ -84,7 +84,7 @@ A declaration that does not survive is reported as a loss.
   $ cat > lost.css <<'EOF'
   > .a{color:red}.b{color:blue}
   > EOF
-  $ cascade diff --depth=max split.css lost.css
+  $ cascade diff --limit=none split.css lost.css
   CSS: 40 chars vs 28 chars (30.0% diff)
   Changes: 1 removed rule
   
@@ -103,7 +103,7 @@ an added !important changes what the selector writes.
   $ cat > weighted.css <<'EOF'
   > .a{color:red;margin:0 !important}.b{color:blue}
   > EOF
-  $ cascade diff --depth=max split.css weighted.css
+  $ cascade diff --limit=none split.css weighted.css
   CSS: 40 chars vs 48 chars (20.0% diff)
   Changes: 1 modified rule
   
@@ -129,7 +129,7 @@ gains or loses a declaration, so neither may be reported as modified.
   $ cat > guarded_tw.css <<'EOF'
   > @layer utilities{.y{--c:4}@supports (zoo:bar){.y{--c:5}}.y{--d:6}.x{--c:1}@supports (zoo:bar){.x{--c:2}}.x{--d:3}}
   > EOF
-  $ cascade diff --diff=canonical --depth=max guarded_ref.css guarded_tw.css
+  $ cascade diff --diff=canonical --limit=none guarded_ref.css guarded_tw.css
   CSS: 115 chars vs 115 chars (0.0% diff)
   Changes: 1 changed container
   
@@ -149,7 +149,7 @@ carries the selector and the position that selector holds on each side, not
 the rule that carried it, so the two rules of `.x` crossing `.y` together
 are one fact stated once, and the summary counts what the node reports.
 
-  $ cascade diff --diff=tree --depth=max guarded_ref.css guarded_tw.css
+  $ cascade diff --diff=tree --limit=none guarded_ref.css guarded_tw.css
   CSS: 115 chars vs 115 chars (0.0% diff)
   Changes: 1 changed container
   
@@ -174,7 +174,7 @@ the exact-match path, which names the move once as well.
   $ cat > swap_tw.css <<'EOF'
   > @layer u{.y{--c:4}.x{--c:1}.x{--d:3}}
   > EOF
-  $ cascade diff --diff=tree --depth=max swap_ref.css swap_tw.css
+  $ cascade diff --diff=tree --limit=none swap_ref.css swap_tw.css
   CSS: 47 chars vs 38 chars (19.1% diff)
   Changes: 1 changed container
   

--- a/test/cli/help.t/run.t
+++ b/test/cli/help.t/run.t
@@ -2,10 +2,10 @@ The diff command gets option rows from Cmdliner rather than repeating them in
 the prose manpage.
 
   $ cascade diff --help=plain \
-  > | grep -E '^       --(depth|diff|lossless)(=|$)' \
+  > | grep -E '^       --(diff|limit|lossless)(=|$)' \
   > | sed -E 's/^ +//'
-  --depth=DEPTH (absent=auto)
   --diff=MODE (absent=auto)
+  --limit=LIMIT (absent=auto)
   --lossless
 
 Command exit statuses have one authoritative entry apiece.


### PR DESCRIPTION
`--depth` bounded tree levels, which is an implementation-shaped knob, and on a wide diff it walked down to level 1, cut every entry's body and still overflowed: 89 of the 171 differing reports in a 432-pair corpus sweep ended as a list of selector names explaining none of them. This PR replaces it with `--limit`, which bounds how many differences are printed and spends the budget on whole entries, and takes one corpus pair from 370 lines to 63.