### PR TITLE
reader: put the caret under the line it marks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -952,6 +952,9 @@ difference wherever the two are not equivalent.
 
 ### Library
 
+- `Reader.pp_parse_error` puts its caret immediately below the line it marks,
+  where a multi-line context window printed the caret below the whole window
+  at a column measured from its start (#793)
 - `cascade` drops its `uutf` dependency for the stdlib UTF-8 decoder. A parse
   error's column now counts one replacement character per maximal subpart of
   an ill-formed sequence, as a browser does, where the previous decoder

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -27,48 +27,51 @@ type parse_error = {
 
 exception Parse_error of parse_error
 
+(* Locate a snippet-relative character offset as a line and a column. *)
+let marker_in_lines lines marker_pos =
+  let rec find line remaining = function
+    | [] -> (0, 0)
+    | [ last ] ->
+        let len = Common.String.utf8_length last in
+        (line, min remaining len)
+    | current :: rest ->
+        let len = Common.String.utf8_length current in
+        if remaining <= len then (line, remaining)
+        else find (line + 1) (remaining - len - 1) rest
+  in
+  find 0 (max 0 marker_pos) lines
+
 (** Pretty print parse error with debugging information *)
 let pp_parse_error (err : parse_error) =
-  let callstack_str =
-    if err.callstack = [] then ""
-    else "\n    [stack: " ^ String.concat " -> " err.callstack ^ "]"
-  in
-  let context_str =
-    if err.context_window = "" then ""
-    else
-      (* Don't trim the context - show it as-is to preserve position accuracy *)
-      let context_lines = String.split_on_char '\n' err.context_window in
-      let context_display =
-        match context_lines with
-        | [] -> err.context_window
-        | [ line ] -> line (* Single line - show it all *)
-        | _ ->
-            (* If multi-line, show each line *)
-            String.concat "\n" context_lines
-      in
-      let marker =
-        if
-          err.marker_pos > 0
-          && err.marker_pos <= Common.String.utf8_length err.context_window
-        then String.make err.marker_pos ' ' ^ "^"
-        else
-          (* Fallback if marker position is out of bounds *)
-          String.make 20 ' ' ^ "^"
-      in
-      "\n" ^ context_display ^ "\n" ^ marker
-  in
-  String.concat ""
-    [
-      err.message;
-      " at ";
-      err.filename;
-      ":";
-      string_of_int err.line;
-      ":";
-      string_of_int err.col;
-      callstack_str;
-      context_str;
-    ]
+  let buf = Buffer.create 256 in
+  Buffer.add_string buf err.message;
+  Buffer.add_string buf " at ";
+  Buffer.add_string buf err.filename;
+  Buffer.add_char buf ':';
+  Buffer.add_string buf (string_of_int err.line);
+  Buffer.add_char buf ':';
+  Buffer.add_string buf (string_of_int err.col);
+  (match err.callstack with
+  | [] -> ()
+  | callstack ->
+      Buffer.add_string buf "\n    [stack: ";
+      Buffer.add_string buf (String.concat " -> " callstack);
+      Buffer.add_char buf ']');
+  if err.context_window <> "" then begin
+    let lines = String.split_on_char '\n' err.context_window in
+    let marker_line, marker_pos = marker_in_lines lines err.marker_pos in
+    List.iteri
+      (fun i line ->
+        Buffer.add_char buf '\n';
+        Buffer.add_string buf line;
+        if i = marker_line then begin
+          Buffer.add_char buf '\n';
+          Buffer.add_string buf (String.make marker_pos ' ');
+          Buffer.add_char buf '^'
+        end)
+      lines
+  end;
+  Buffer.contents buf
 
 (* Pretty-printer for the parser state *)
 let pp (ctx : Pp.ctx) (t : t) =

--- a/test/test_reader.ml
+++ b/test/test_reader.ml
@@ -346,6 +346,34 @@ let error_renders_three_part_location () =
     (String.ends_with ~suffix:" at theme.css:2:2"
        (first_line (with_filename error "theme.css")))
 
+(* The context window can span both sides of the failing line. Its caret belongs
+   immediately below that line, at a column measured from the line start. *)
+let error_renders_caret_on_marked_line () =
+  let error = error_at "first\nsecond\nthird" 8 in
+  Alcotest.(check string)
+    "caret interrupts the context below the marked line"
+    (String.concat ""
+       [
+         "a character the input never holds at <CSS input>:2:3\n";
+         "first\n";
+         "second\n";
+         "  ^\n";
+         "third";
+       ])
+    (pp_parse_error error)
+
+(* Position zero is a valid marker, not an out-of-bounds request for the old
+   arbitrary twenty-column fallback. *)
+let error_renders_caret_at_context_start () =
+  let error = error_at "abc" 0 in
+  Alcotest.(check string)
+    "caret at zero"
+    (String.concat ""
+       [
+         "a character the input never holds at <CSS input>:1:1\n"; "abc\n"; "^";
+       ])
+    (pp_parse_error error)
+
 let tests_call_stack () =
   callstack_case ();
   with_context_case ();
@@ -364,7 +392,9 @@ let tests_error_position () =
   error_ascii_caret_holds ();
   error_context_window_keeps_code_points ();
   error_filename_names_the_source ();
-  error_renders_three_part_location ()
+  error_renders_three_part_location ();
+  error_renders_caret_on_marked_line ();
+  error_renders_caret_at_context_start ()
 
 let suite =
   ( "reader",


### PR DESCRIPTION
`Reader.pp_parse_error` now derives a line-local caret position from its existing snippet-relative marker, so multiline context puts the caret immediately under the marked line. Position zero remains column zero, and output construction now uses a buffer.