### PR TITLE
diff: compare a namespace statement on its whole text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1064,6 +1064,9 @@ difference wherever the two are not equivalent.
 
 ### CLI tools
 
+- `cascade diff --diff=tree` reports two stylesheets that declare different
+  `@namespace` URLs as different. It called them identical, though a type
+  selector matches in the namespace its sheet declares (#794)
 - `cascade diff --limit` bounds how many differences a report prints, and the
   automatic shaping now spends its budget on whole entries rather than cutting
   every entry's body: a wide report named every selector and explained none

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2519,14 +2519,14 @@ let at_rule_body (stmt : Css.statement) : at_rule_body option =
       Some (Declarations (Css.Stylesheet.statement_declarations stmt))
   | Font_face _ | Counter_style _ | Page_with_margins _ | Font_palette_values _
   | Font_feature_values _ | View_transition _ | Viewport _ | Webkit_keyframes _
-  | Moz_keyframes _ | Unknown_at_rule _ ->
+  | Moz_keyframes _ | Unknown_at_rule _ | Namespace _ ->
       Some Opaque
   (* Owned by another processor: a rule and a bare nesting block by the rule
      matcher, a container by [moved_order_keys], [@keyframes] and [@property] by
      their own, and the rest carry no body to compare. *)
   | Rule _ | Declarations _ | Layer _ | Media _ | Container _ | Supports _
   | Origin _ | Keyframes _ | Property _ | Layer_decl _ | Import _ | Charset _
-  | Namespace _ | Bang_comment _ ->
+  | Bang_comment _ ->
       None
 
 (* [process_at_rules] owns these statements, so leaving them in the rule diff as

--- a/test/cli/diff_prelude.t
+++ b/test/cli/diff_prelude.t
@@ -1,0 +1,19 @@
+CLI: cascade diff - a prelude statement that changed is a difference.
+
+A type selector matches in the namespace its sheet declares, so two sheets
+naming different namespace URLs style different elements. The structural
+mode must not call them identical, and the report must name the at-rule
+that changed.
+
+  $ cat > a.css <<EOF
+  > @namespace url(http://a.example);
+  > .x { color: red }
+  > EOF
+  $ cat > b.css <<EOF
+  > @namespace url(http://b.example);
+  > .x { color: red }
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=tree a.css b.css > report.txt
+  [1]
+  $ grep -q '@namespace' report.txt && echo named
+  named

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -1262,10 +1262,10 @@ let changed_namespace_is_a_difference () =
     "and the entry names the at-rule" true
     (string_contains ~needle:"@namespace" (render d))
 
-(* The selectorless-at-rule machinery is what owns the namespace statement, so
-   a change has to surface as a container entry, not fall through to the rule
-   walk where it currently shares the universal selector and gets paired with
-   other selectorless statements. *)
+(* The selectorless-at-rule machinery is what owns the namespace statement, so a
+   change has to surface as a container entry, not fall through to the rule walk
+   where it currently shares the universal selector and gets paired with other
+   selectorless statements. *)
 let changed_namespace_is_an_at_rule_container () =
   let d =
     diff_of ~expected:"@namespace url(http://a.example);.x{color:red}"

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -1246,6 +1246,47 @@ let removed_keyframes_is_named () =
   Alcotest.(check (list string))
     "no rule-level entry without a name" [] (added_or_removed_names d)
 
+(* A type selector matches in the namespace its sheet declares, so two sheets
+   that name different namespace URLs style different elements. The description
+   a prelude statement is keyed on has to carry the URL, or the two are one
+   entry and the walk reports nothing. *)
+let changed_namespace_is_a_difference () =
+  let d =
+    diff_of ~expected:"@namespace url(http://a.example);.x{color:red}"
+      ~actual:"@namespace url(http://b.example);.x{color:red}"
+  in
+  Alcotest.(check bool)
+    "changing the namespace URL is a difference" false
+    (Cascade_diff.Tree_diff.is_empty d);
+  Alcotest.(check bool)
+    "and the entry names the at-rule" true
+    (string_contains ~needle:"@namespace" (render d))
+
+(* The selectorless-at-rule machinery is what owns the namespace statement, so
+   a change has to surface as a container entry, not fall through to the rule
+   walk where it currently shares the universal selector and gets paired with
+   other selectorless statements. *)
+let changed_namespace_is_an_at_rule_container () =
+  let d =
+    diff_of ~expected:"@namespace url(http://a.example);.x{color:red}"
+      ~actual:"@namespace url(http://b.example);.x{color:red}"
+  in
+  Alcotest.(check bool)
+    "namespace URL change is reported as a container diff" true
+    (Cascade_diff.Tree_diff.count_containers_by_type `At_rule d > 0)
+
+let added_namespace_is_an_at_rule_container () =
+  let d =
+    diff_of ~expected:".x{color:red}"
+      ~actual:"@namespace url(http://a.example);.x{color:red}"
+  in
+  Alcotest.(check bool)
+    "adding a namespace is a difference" false
+    (Cascade_diff.Tree_diff.is_empty d);
+  Alcotest.(check bool)
+    "the added namespace is an at-rule container" true
+    (Cascade_diff.Tree_diff.has_container_added_of_type `At_rule d)
+
 (* Nothing else reports a [@charset], so the rule level has to keep it - and
    name it. *)
 let removed_charset_is_named () =
@@ -1562,6 +1603,12 @@ let suite =
         removed_keyframes_is_named;
       Alcotest.test_case "removed charset is named" `Quick
         removed_charset_is_named;
+      Alcotest.test_case "changed namespace is a difference" `Quick
+        changed_namespace_is_a_difference;
+      Alcotest.test_case "changed namespace is an at-rule container" `Quick
+        changed_namespace_is_an_at_rule_container;
+      Alcotest.test_case "added namespace is an at-rule container" `Quick
+        added_namespace_is_an_at_rule_container;
       Alcotest.test_case "removed layer statement is named" `Quick
         removed_layer_statement_is_named;
       Alcotest.test_case "modified keyframes names the at-rule" `Quick


### PR DESCRIPTION
`cascade diff --diff=tree` exited 0 on two stylesheets declaring different `@namespace` URLs. The prelude description dropped the URL, so both sides shared one key and the structural walk saw nothing, though a type selector matches in the namespace its sheet declares and the two style different elements.