### PR TITLE
diff: report a shared parse warning once

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1064,6 +1064,9 @@ difference wherever the two are not equivalent.
 
 ### CLI tools
 
+- `cascade diff` prints a parse warning both inputs raise once, under a label
+  naming both files, so the report's warning budget reaches the warnings only
+  one side raised (#795)
 - `cascade diff --diff=tree` reports two stylesheets that declare different
   `@namespace` URLs as different. It called them identical, though a type
   selector matches in the namespace its sheet declares (#794)

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -59,7 +59,7 @@ let count_lines s =
   String.iter (fun c -> if c = '\n' then incr n) s;
   !n
 
-(* Parse warnings shown per side before the rest is counted. *)
+(* Parse warnings shown before the rest is counted, across both sides. *)
 let auto_warning_budget = 3
 
 (* [none] bounds nothing, warnings included. Every other setting keeps the

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -679,32 +679,57 @@ let compute_stats ~expected_str ~actual_str diff_result =
 let stats = compute_stats
 let add_strings b ls = List.iter (Buffer.add_string b) ls
 
-(* Render each side's parse warnings so a declaration the parser dropped never
-   reads as a phantom structural difference on the side that parsed. Past [max]
-   they are counted rather than printed: a stylesheet that trips the same
-   unsupported syntax hundreds of times would otherwise bury the diff it is
-   meant to qualify. *)
-let pp_parse_warnings ?(max = Stdlib.max_int) buf label warnings =
-  let shown, hidden =
-    let n = List.length warnings in
-    if n <= max then (warnings, 0)
-    else (List.filteri (fun i _ -> i < max) warnings, n - max)
+(* Two warnings are the same complaint when they fail the same way at the same
+   place in the grammar. Where in the byte stream each side ran into it is no
+   part of that. *)
+(* The rendered kind is built once per warning rather than once per comparison:
+   [partition_warnings] compares every pair. *)
+type keyed = { warning : Error.t; kind : string }
+
+let keyed (w : Error.t) =
+  { warning = w; kind = Pp.to_string Error.pp_kind w.kind }
+
+let same_warning a b =
+  Sort.equal a.warning.Error.sort b.warning.Error.sort
+  && List.equal String.equal a.warning.Error.path b.warning.Error.path
+  && String.equal a.kind b.kind
+
+let rec remove_first p = function
+  | [] -> None
+  | x :: xs when p x -> Some xs
+  | x :: xs -> Option.map (fun rest -> x :: rest) (remove_first p xs)
+
+(* Shared warnings keep the expected side's copy, so the snippet under one is
+   the expected side's text. *)
+let partition_warnings expected actual =
+  let rec go exp_only act_only shared = function
+    | [] ->
+        let warnings = List.map (fun k -> k.warning) in
+        ( warnings (List.rev shared),
+          warnings (List.rev exp_only),
+          warnings act_only )
+    | w :: ws -> (
+        match remove_first (same_warning w) act_only with
+        | Some act_only -> go exp_only act_only (w :: shared) ws
+        | None -> go (w :: exp_only) act_only shared ws)
   in
-  List.iter
-    (fun w ->
-      if Buffer.length buf > 0 && Buffer.nth buf (Buffer.length buf - 1) <> '\n'
-      then Buffer.add_char buf '\n';
-      add_strings buf [ label; " parse warning: "; Error.to_string w; "\n" ])
-    shown;
-  if hidden > 0 then
-    add_strings buf
-      [
-        label;
-        ": ";
-        string_of_int hidden;
-        (if hidden = 1 then " more parse warning\n"
-         else " more parse warnings\n");
-      ]
+  go [] (List.map keyed actual) [] (List.map keyed expected)
+
+let pp_warning buf label w =
+  if Buffer.length buf > 0 && Buffer.nth buf (Buffer.length buf - 1) <> '\n'
+  then Buffer.add_char buf '\n';
+  add_strings buf [ label; " parse warning: "; Error.to_string w; "\n" ]
+
+let pp_overflow buf label hidden =
+  if Buffer.length buf > 0 && Buffer.nth buf (Buffer.length buf - 1) <> '\n'
+  then Buffer.add_char buf '\n';
+  add_strings buf
+    [
+      label;
+      ": ";
+      string_of_int hidden;
+      (if hidden = 1 then " more parse warning\n" else " more parse warnings\n");
+    ]
 
 let pp_result ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
     ?depth ?entries buf = function
@@ -736,9 +761,45 @@ let pp_result ?(expected = "Expected") ?(actual = "Actual") ?(color = false)
   | Actual_error e ->
       add_strings buf [ actual; " CSS parse error: "; Error.to_string e ]
 
+(* Render parse warnings so a declaration the parser dropped never reads as a
+   phantom structural difference on the side that parsed. A warning both sides
+   raise is one fact about the input rather than a finding about the diff, so it
+   prints once, under a label naming both files, for one slot of the budget.
+   One-sided warnings take that budget first: they are what qualifies the
+   difference below them. Past [max] the rest are counted rather than printed: a
+   stylesheet that trips the same unsupported syntax hundreds of times would
+   otherwise bury the diff it is meant to qualify. *)
+type warning_side = Expected | Actual | Both
+
+let warnings t =
+  let shared, expected_only, actual_only =
+    partition_warnings t.expected_warnings t.actual_warnings
+  in
+  let tag side = List.map (fun w -> (side, w)) in
+  tag Expected expected_only @ tag Actual actual_only @ tag Both shared
+
 let pp_warnings ?(expected = "Expected") ?(actual = "Actual") ?max buf t =
-  pp_parse_warnings ?max buf expected t.expected_warnings;
-  pp_parse_warnings ?max buf actual t.actual_warnings
+  let shared, expected_only, actual_only =
+    partition_warnings t.expected_warnings t.actual_warnings
+  in
+  let remaining = ref (Option.value max ~default:Stdlib.max_int) in
+  (* One pass: the count of what was left out is part of the report, so the
+     whole list is walked whether or not the budget runs out early. *)
+  let render label ws =
+    let hidden = ref 0 in
+    List.iter
+      (fun w ->
+        if !remaining > 0 then begin
+          decr remaining;
+          pp_warning buf label w
+        end
+        else incr hidden)
+      ws;
+    if !hidden > 0 then pp_overflow buf label !hidden
+  in
+  render expected expected_only;
+  render actual actual_only;
+  render (String.concat "" [ expected; " and "; actual ]) shared
 
 let has_warnings t = t.expected_warnings <> [] || t.actual_warnings <> []
 

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -162,13 +162,28 @@ val pp :
     {!pp_warnings} and {!pp_diff} are the two halves, for callers that need to
     size or bound the sections independently. *)
 
+(** Which side of the comparison raised a warning. *)
+type warning_side = Expected | Actual | Both
+
+val warnings : t -> (warning_side * Error.t) list
+(** [warnings t] is every parse warning the comparison collected, grouped as the
+    report prints them: the warnings only the expected side raised, then those
+    only the actual side raised, then those both raised. A warning both sides
+    raise appears once, as {!constructor-Both}, carrying the expected side's
+    copy, because the same complaint at two byte offsets is one fact about the
+    input. Two warnings are the same complaint when they fail the same way at
+    the same place in the grammar, whatever offset each side reached it at. *)
+
 val pp_warnings :
   ?expected:string -> ?actual:string -> ?max:int -> Buffer.t -> t -> unit
 (** [pp_warnings ?expected ?actual ?max buf result] renders only the parse
-    warnings each side accumulated. [max] caps how many are printed per side
-    (default: all); the remainder is reported as a count, so a stylesheet that
-    trips the same unsupported syntax hundreds of times cannot bury the diff
-    those warnings qualify. *)
+    warnings each side accumulated. A warning both sides raise is rendered once
+    under a label naming both files, with the expected side's snippet, and it
+    counts once against [max]. One-sided warnings lead: expected-only, then
+    actual-only, then shared. [max] caps the total printed across all groups
+    (default: all); the remainder of each group is reported as a count, so a
+    stylesheet that trips the same unsupported syntax hundreds of times cannot
+    bury the diff those warnings qualify. *)
 
 val pp_diff :
   ?expected:string ->

--- a/lib/sort.ml
+++ b/lib/sort.ml
@@ -10,6 +10,9 @@ type t =
   | Property_value
   | Stylesheet
 
+(* A closed enum with no payloads, so structural equality is its equality. *)
+let equal (a : t) (b : t) = a = b
+
 let pp : t Pp.t =
  fun ctx t ->
   let s =

--- a/lib/sort.mli
+++ b/lib/sort.mli
@@ -18,6 +18,9 @@ type t =
   | Property_value  (** The right-hand side of a declaration. *)
   | Stylesheet  (** A whole section 5.4 stylesheet. *)
 
+val equal : t -> t -> bool
+(** [equal a b] is whether [a] and [b] are the same sort. *)
+
 val pp : t Pp.t
 (** [pp] renders the sort as a lowercase identifier, e.g. [at-rule]. *)
 

--- a/test/cli/diff_warnings.t
+++ b/test/cli/diff_warnings.t
@@ -1,0 +1,126 @@
+CLI: cascade diff - a parse warning both inputs raise is reported once.
+
+The two inputs of a diff are usually variants of one source, so a
+declaration the parser rejects is normally rejected on both sides. That is
+one fact about the input, not two findings about the difference: it prints
+once, under a label naming both files, with the first file's snippet. The
+byte offset each side puts it at is no part of its identity.
+
+  $ cat > a.css <<EOF
+  > .x { color: red; float: center; margin: 0 }
+  > EOF
+  $ cat > b.css <<EOF
+  > .x { color: red; width: 0; float: center; margin: 1px }
+  > EOF
+  $ NO_COLOR=1 cascade diff a.css b.css
+  CSS: 44 chars vs 56 chars (27.3% diff)
+  Changes: 1 modified rule
+  
+  a.css and b.css parse warning: <string>: read_declaration/float: bad value for float: unknown float-side: center at [24-30] (in component)
+  .x { color: red; float: center; margin: 0 }
+                          ^^^^^^
+  
+  --- a.css
+  +++ b.css
+  └─ .x
+        + width: 0
+        * margin: 0 -> 1px
+  
+  [1]
+
+A declaration rejected on one side only is what qualifies the difference
+reported below it, so one-sided warnings lead: the first file's, then the
+second file's, then the ones both files raise.
+
+  $ cat > c.css <<EOF
+  > .x { float: center; clear: nope; margin: 0 }
+  > EOF
+  $ cat > d.css <<EOF
+  > .x { float: center; position: nope; margin: 1px }
+  > EOF
+  $ NO_COLOR=1 cascade diff c.css d.css
+  CSS: 45 chars vs 50 chars (11.1% diff)
+  Changes: 1 modified rule
+  
+  c.css parse warning: <string>: read_declaration/clear: bad value for clear: unknown clear: nope at [27-31] (in component)
+  .x { float: center; clear: nope; margin: 0 }
+                             ^^^^
+  d.css parse warning: <string>: read_declaration/position: bad value for position: unknown position: nope at [30-34] (in component)
+  .x { float: center; position: nope; margin: 1px }
+                                ^^^^
+  c.css and d.css parse warning: <string>: read_declaration/float: bad value for float: unknown float-side: center at [12-18] (in component)
+  .x { float: center; clear: nope; margin: 0 }
+              ^^^^^^
+  
+  --- c.css
+  +++ d.css
+  └─ .x
+        - clear: nope
+        + position: nope
+        * margin: 0 -> 1px
+  
+  [1]
+
+The budget is a total over the report and the one-sided warnings claim it
+first. The three warnings both files raise cost one slot between them, so
+the two the budget leaves out are counted once rather than once per side.
+
+  $ cat > e.css <<EOF
+  > .x { float: center; clear: nope; visibility: nope; z-index: nope; margin: 0 }
+  > EOF
+  $ cat > f.css <<EOF
+  > .x { float: center; clear: nope; visibility: nope; position: nope; margin: 1px }
+  > EOF
+  $ NO_COLOR=1 cascade diff e.css f.css
+  CSS: 78 chars vs 81 chars (3.8% diff)
+  Changes: 1 modified rule
+  
+  e.css parse warning: <string>: read_declaration/z-index: bad value for z-index: expected integer at [60-64] (in component)
+  clear: nope; visibility: nope; z-index: nope; margin: 0 }
+                                          ^^^^
+  f.css parse warning: <string>: read_declaration/position: bad value for position: unknown position: nope at [61-65] (in component)
+  lear: nope; visibility: nope; position: nope; margin: 1px }
+                                          ^^^^
+  e.css and f.css parse warning: <string>: read_declaration/float: bad value for float: unknown float-side: center at [12-18] (in component)
+  .x { float: center; clear: nope; visibility: nope; z-index
+              ^^^^^^
+  e.css and f.css: 2 more parse warnings
+  
+  --- e.css
+  +++ f.css
+  └─ .x
+        - z-index: nope
+        + position: nope
+        * margin: 0 -> 1px
+  
+  [1]
+
+One warning past the budget keeps the singular form.
+
+  $ cat > g.css <<EOF
+  > .x { float: center; clear: nope; visibility: nope; z-index: nope; margin: 0 }
+  > EOF
+  $ cat > h.css <<EOF
+  > .x { float: center; clear: nope; visibility: nope; z-index: nope; margin: 1px }
+  > EOF
+  $ NO_COLOR=1 cascade diff g.css h.css
+  CSS: 78 chars vs 80 chars (2.6% diff)
+  Changes: 1 modified rule
+  
+  g.css and h.css parse warning: <string>: read_declaration/float: bad value for float: unknown float-side: center at [12-18] (in component)
+  .x { float: center; clear: nope; visibility: nope; z-index
+              ^^^^^^
+  g.css and h.css parse warning: <string>: read_declaration/clear: bad value for clear: unknown clear: nope at [27-31] (in component)
+  .x { float: center; clear: nope; visibility: nope; z-index: nope; margi
+                             ^^^^
+  g.css and h.css parse warning: <string>: read_declaration/visibility: bad value for visibility: unknown visibility: nope at [45-49] (in component)
+  float: center; clear: nope; visibility: nope; z-index: nope; margin: 0 }
+                                          ^^^^
+  g.css and h.css: 1 more parse warning
+  
+  --- g.css
+  +++ h.css
+  └─ .x
+        * margin: 0 -> 1px
+  
+  [1]


### PR DESCRIPTION
The two inputs of a diff are normally two variants of one source, so a declaration the parser rejects is rejected on both sides: of the 246 reports carrying warnings in a 432-pair corpus sweep, 237 printed the same warning twice. With a budget of three per side a report could spend its whole allowance on two copies of one complaint before reaching the difference they qualify.