### PR TITLE
diff: read a stylesheet from standard input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@ difference wherever the two are not equivalent.
 
 ### Breaking
 
+- `cascade` requires `cmdliner >= 2.0.0`, the release that stops `Arg.file`
+  checking a `-` argument for existence, which is what lets either side of
+  `cascade diff` name standard input (#796)
 - `Css.parse` adds `source : Css.Source.t option`; exhaustive record patterns
   must bind it or add `_`. `Css.of_string ~preserve_source:true` fills it with
   exact authored comments, syntax, trivia ownership and coordinates (#747)
@@ -1064,6 +1067,9 @@ difference wherever the two are not equivalent.
 
 ### CLI tools
 
+- `cascade diff` reads either side from standard input when the argument is
+  `-`, so the output of a build can be compared without a temporary file. The
+  report names that side `<stdin>` (#796)
 - `cascade diff` prints a parse warning both inputs raise once, under a label
   naming both files, so the report's warning budget reaches the warnings only
   one side raised (#795)

--- a/bin/cli_io.ml
+++ b/bin/cli_io.ml
@@ -14,6 +14,11 @@ let read_stdin () =
     Buffer.contents buf
   with End_of_file -> Buffer.contents buf
 
+(* A stylesheet and the name to report it under. [-] is standard input, which
+   has no path, so it borrows the name every command already gives it. *)
+let read_source path =
+  if path = "-" then (read_stdin (), "<stdin>") else (read_file path, path)
+
 let report_warning w =
   (* Prefix every line of a multi-line diagnostic so a downstream [grep -v
      "warning"] filters the whole entry, not just the first line. *)
@@ -38,8 +43,7 @@ let parse_css ?enforce_spec ~filename css =
 type input = { stylesheet : Css.t; filename : string; recovered : bool }
 
 let read_input ?enforce_spec path =
-  let css = if path = "-" then read_stdin () else read_file path in
-  let filename = if path = "-" then "<stdin>" else path in
+  let css, filename = read_source path in
   let stylesheet, warnings = parse ?enforce_spec ~filename css in
   { stylesheet; filename; recovered = warnings <> [] }
 

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -14,8 +14,8 @@ let err_limit s =
             "\": expected auto, none, or a positive integer";
           ]))
 
-let read_file path =
-  try Ok (Cli_io.read_file path) with Sys_error msg -> err_read path msg
+let read_source path =
+  try Ok (Cli_io.read_source path) with Sys_error msg -> err_read path msg
 
 let no_color_var = "NO_COLOR"
 
@@ -145,6 +145,32 @@ let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~limit ~mode result =
 
 type canonical_opts = { lossless : bool; prune_unused_custom_props : bool }
 
+(* Each side is its text and the name the report gives it, which is the path for
+   a file and [<stdin>] for the stream. *)
+let compare_sources ~color ~mode ~limit ~opts (css1, file1) (css2, file2) =
+  if css1 = css2 then (
+    Fmt.pr "CSS files are identical@.";
+    Ok ())
+  else
+    let result =
+      run_diff mode ~lossless:opts.lossless
+        ~prune_unused_custom_props:opts.prune_unused_custom_props ~css1 ~css2
+    in
+    match result.Cascade_diff.Css_compare.result with
+    | No_diff ->
+        (* Equal ASTs can still hide parse-dropped declarations; show the
+           warnings so the equality verdict is honest about them. *)
+        let max = warning_budget limit in
+        print_string (render_warnings ~file1 ~file2 ~max result);
+        Fmt.pr "CSS files are identical@.";
+        Ok ()
+    | String_diff _ | Tree_diff _ | Both_errors _ | Expected_error _
+    | Actual_error _ ->
+        print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~limit ~mode result;
+        (* Differing inputs are a result, not a usage error: exit 1 as
+           documented, distinct from cmdliner's reserved error codes. *)
+        Stdlib.exit 1
+
 let compare_files file1 file2 style_renderer mode limit opts () =
   Fmt_tty.setup_std_outputs
     ?style_renderer:(resolve_style_renderer style_renderer)
@@ -157,40 +183,22 @@ let compare_files file1 file2 style_renderer mode limit opts () =
     | `Ansi_tty -> true
     | `None -> false
   in
-  match (read_file file1, read_file file2) with
-  | Ok css1, Ok css2 -> (
-      if css1 = css2 then (
-        Fmt.pr "CSS files are identical@.";
-        Ok ())
-      else
-        let result =
-          run_diff mode ~lossless:opts.lossless
-            ~prune_unused_custom_props:opts.prune_unused_custom_props ~css1
-            ~css2
-        in
-        match result.Cascade_diff.Css_compare.result with
-        | No_diff ->
-            (* Equal ASTs can still hide parse-dropped declarations; show the
-               warnings so the equality verdict is honest about them. *)
-            let max = warning_budget limit in
-            print_string (render_warnings ~file1 ~file2 ~max result);
-            Fmt.pr "CSS files are identical@.";
-            Ok ()
-        | String_diff _ | Tree_diff _ | Both_errors _ | Expected_error _
-        | Actual_error _ ->
-            print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~limit ~mode
-              result;
-            (* Differing inputs are a result, not a usage error: exit 1 as
-               documented, distinct from cmdliner's reserved error codes. *)
-            Stdlib.exit 1)
-  | Error e, _ | _, Error e -> Error e
+  (* The stream is read once and cannot be rewound, so [-] on both sides has no
+     second side to compare the first against. *)
+  if file1 = "-" && file2 = "-" then
+    Error (`Msg "cannot compare standard input with itself")
+  else
+    match (read_source file1, read_source file2) with
+    | Ok source1, Ok source2 ->
+        compare_sources ~color ~mode ~limit ~opts source1 source2
+    | Error e, _ | _, Error e -> Error e
 
 let file1_arg =
-  let doc = "First CSS file to compare (expected/reference)" in
+  let doc = "First CSS file to compare (expected/reference; use - for stdin)" in
   Arg.(required & pos 0 (some file) None & info [] ~docv:"FILE1" ~doc)
 
 let file2_arg =
-  let doc = "Second CSS file to compare (actual/test)" in
+  let doc = "Second CSS file to compare (actual/test; use - for stdin)" in
   Arg.(required & pos 1 (some file) None & info [] ~docv:"FILE2" ~doc)
 
 let mode_arg =
@@ -295,6 +303,8 @@ let man =
     `S Manpage.s_examples;
     `P "Compare two CSS files:";
     `Pre "  cascade diff reference.css output.css";
+    `P "Compare a stylesheet on standard input against a reference:";
+    `Pre "  cascade fmt --minify src.css | cascade diff reference.css -";
     `P "Disable colors using flag:";
     `Pre "  cascade diff --color=never reference.css output.css";
     `P "Disable colors using NO_COLOR environment variable:";

--- a/cascade.opam
+++ b/cascade.opam
@@ -28,7 +28,7 @@ depends: [
   "uri"
   "psq"
   "logs"
-  "cmdliner" {>= "1.1.0"}
+  "cmdliner" {>= "2.0.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -34,4 +34,4 @@
   uri
   psq
   logs
-  (cmdliner (>= 1.1.0))))
+  (cmdliner (>= 2.0.0))))

--- a/test/cli/diff_stdin.t
+++ b/test/cli/diff_stdin.t
@@ -1,0 +1,55 @@
+CLI: `cascade diff` reading a stylesheet from standard input.
+
+Diffing what a build just produced against a reference is what this command
+is for, and a pipe is how a build hands it over, so `-` names the stream on
+standard input for either side. The report calls that side `<stdin>`, the
+name the rest of the CLI already gives it.
+
+  $ cat > ref.css <<EOF
+  > .a{color:red}
+  > EOF
+
+The expected side read from the stream.
+
+  $ printf '.a{color:blue}\n' | NO_COLOR=1 cascade diff - ref.css
+  CSS: 15 chars vs 14 chars (6.7% diff)
+  Changes: 1 modified rule
+  
+  --- <stdin>
+  +++ ref.css
+  └─ .a
+        * color: blue -> red
+  
+  [1]
+
+The actual side read from the stream.
+
+  $ printf '.a{color:blue}\n' | NO_COLOR=1 cascade diff ref.css -
+  CSS: 14 chars vs 15 chars (7.1% diff)
+  Changes: 1 modified rule
+  
+  --- ref.css
+  +++ <stdin>
+  └─ .a
+        * color: red -> blue
+  
+  [1]
+
+A stream that matches the file it is compared against reports identity.
+
+  $ printf '.a{color:red}\n' | cascade diff - ref.css
+  CSS files are identical
+
+Standard input cannot be read twice, so `-` on both sides is a command-line
+error rather than a stream compared with itself.
+
+  $ printf '.a{color:red}\n' | cascade diff - - 2>&1
+  cascade: cannot compare standard input with itself
+  [124]
+
+Every other argument still has to name something that exists.
+
+  $ NO_COLOR=1 cascade diff missing.css ref.css 2> err.txt
+  [124]
+  $ grep -c "no 'missing.css' file or directory" err.txt
+  1


### PR DESCRIPTION
`cascade diff - ref.css` failed with `Error reading -`, so comparing what a build just produced against a reference needed a temporary file. Either side now accepts `-`, named `<stdin>` in the report as the rest of the CLI already spells it, and `cascade diff - -` is refused before either side is read.