### PR TITLE
optimize: synthesize the WebKit decoration-color alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -546,6 +546,10 @@ difference wherever the two are not equivalent.
   need for `user-select`, `backdrop-filter`, `hyphens`, `mask` and its
   compatible layer longhands, including matching `@supports` tests. An
   authored prefixed declaration remains authoritative (#751, #758)
+- Default minification also adds `-webkit-text-decoration-color` beside a
+  `text-decoration-color` whose value is not settled at parse time, which
+  Safari and iOS Safari read under both names through 26.1. A value that reads
+  as a colour keeps the standard property alone (#797)
 - The README states the default minifier's evergreen target, colour tolerance,
   and CSSOM-visible normalisation beside its first example, and describes
   `--lossless --enforce-spec` as conservative rather than source-exact (#743)

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -633,6 +633,7 @@ type webkit_fallback =
   | User_select_fallback
   | Backdrop_filter_fallback
   | Hyphens_fallback
+  | Text_decoration_color_fallback
   | Mask_fallback
   | Mask_image_fallback
   | Mask_position_fallback
@@ -641,6 +642,11 @@ type webkit_fallback =
   | Mask_clip_fallback
   | Mask_origin_fallback
 
+(* A target that cannot read the standard property at all needs the fallback for
+   every value of it. A target that reads both spellings needs it only where the
+   value is not settled at parse time. *)
+type fallback_condition = Any_value | Unresolved_value
+
 type webkit_fallback_spec =
   | Typed_fallback : {
       kind : webkit_fallback;
@@ -648,12 +654,15 @@ type webkit_fallback_spec =
       webkit_property : 'a Properties.property;
       name : string;
       webkit_name : string;
+      condition : fallback_condition;
     }
       -> webkit_fallback_spec
   | Mask_fallback_spec of { name : string; webkit_name : string }
 
-let typed_fallback kind property webkit_property name webkit_name =
-  Typed_fallback { kind; property; webkit_property; name; webkit_name }
+let typed_fallback ?(condition = Any_value) kind property webkit_property name
+    webkit_name =
+  Typed_fallback
+    { kind; property; webkit_property; name; webkit_name; condition }
 
 let webkit_fallback_specs =
   [
@@ -663,6 +672,9 @@ let webkit_fallback_specs =
       Webkit_backdrop_filter "backdrop-filter" "-webkit-backdrop-filter";
     typed_fallback Hyphens_fallback Hyphens Webkit_hyphens "hyphens"
       "-webkit-hyphens";
+    typed_fallback ~condition:Unresolved_value Text_decoration_color_fallback
+      Text_decoration_color Webkit_text_decoration_color "text-decoration-color"
+      "-webkit-text-decoration-color";
     Mask_fallback_spec { name = "mask"; webkit_name = "-webkit-mask" };
     typed_fallback Mask_image_fallback Mask_image Webkit_mask_image "mask-image"
       "-webkit-mask-image";
@@ -681,6 +693,10 @@ let webkit_fallback_specs =
 let fallback_spec_kind = function
   | Typed_fallback { kind; _ } -> kind
   | Mask_fallback_spec _ -> Mask_fallback
+
+let fallback_spec_condition = function
+  | Typed_fallback { condition; _ } -> condition
+  | Mask_fallback_spec _ -> Any_value
 
 let fallback_spec_names = function
   | Typed_fallback { name; webkit_name; _ } -> (name, webkit_name)
@@ -712,7 +728,10 @@ let version_before version minimum = version_compare version minimum < 0
    baseline, while unprefixed [backdrop-filter] arrived after 17.6, unprefixed
    [hyphens] arrived in 17, and Chrome needs the compatible [-webkit-mask]
    shorthand and longhands through 119. [mask-mode] and [mask-composite] are
-   excluded because their prefixed forms have different grammars. *)
+   excluded because their prefixed forms have different grammars. Safari/iOS
+   answer [text-decoration-color] under both spellings through 26.1, so it pairs
+   this boundary with [Unresolved_value]: a settled colour is served by the
+   standard longhand on every declared target. *)
 let required_fallback kind targets =
   match kind with
   | User_select_fallback -> true
@@ -722,6 +741,9 @@ let required_fallback kind targets =
   | Hyphens_fallback ->
       version_before targets.safari (17, 0)
       || version_before targets.ios_safari (17, 0)
+  | Text_decoration_color_fallback ->
+      version_at_most targets.safari (26, 1)
+      || version_at_most targets.ios_safari (26, 1)
   | Mask_fallback | Mask_image_fallback | Mask_position_fallback
   | Mask_size_fallback | Mask_repeat_fallback | Mask_clip_fallback
   | Mask_origin_fallback ->
@@ -760,6 +782,11 @@ let webkit_fallback_of_declaration targets decl : Declaration.declaration option
       | None -> None
     else None
   in
+  let condition_holds spec =
+    match fallback_spec_condition spec with
+    | Any_value -> true
+    | Unresolved_value -> Variables.declaration_uses_var decl
+  in
   let fallback_from_spec spec =
     match (spec, decl) with
     | ( Typed_fallback { kind; property; webkit_property; _ },
@@ -789,15 +816,15 @@ let webkit_fallback_of_declaration targets decl : Declaration.declaration option
           | Some _ | None ->
               fallback Mask_fallback (Unknown_property webkit_name) components
                 important)
-      | Some spec ->
+      | Some spec when condition_holds spec ->
           let kind = fallback_spec_kind spec in
           let _, webkit_name = fallback_spec_names spec in
           fallback kind (Unknown_property webkit_name) components important
-      | None -> None)
+      | Some _ | None -> None)
   | Declaration _ -> (
       match fallback_spec_by_standard_name (Declaration.property_name decl) with
-      | Some spec -> fallback_from_spec spec
-      | None -> None)
+      | Some spec when condition_holds spec -> fallback_from_spec spec
+      | Some _ | None -> None)
 
 let is_webkit_fallback kind decl =
   match (fallback_spec_by_kind kind, decl) with

--- a/test/cli/prefix_text_decoration_color.t
+++ b/test/cli/prefix_text_decoration_color.t
@@ -1,0 +1,37 @@
+CLI: --minify mirrors an unresolved text-decoration-color under the WebKit name.
+
+Safari and iOS Safari answer text-decoration-color under the legacy
+-webkit- spelling as well as the standard one, and the compatibility data
+every browser-targeting minifier reads reports the standard longhand as
+covered only from 26.2. The default target is Safari and iOS Safari 16.4, so
+a value whose colour is not settled at parse time is mirrored under both
+names, standard last so it wins wherever it is understood.
+
+  $ cat > unresolved.css <<CSS
+  > .a { text-decoration-color: var(--c) }
+  > CSS
+  $ cascade --minify unresolved.css
+  .a{-webkit-text-decoration-color:var(--c);text-decoration-color:var(--c)}
+
+A value that reads as a colour is served by the standard longhand on every
+declared target, so it carries no alias.
+
+  $ cat > literal.css <<CSS
+  > .a { text-decoration-color: blue }
+  > CSS
+  $ cascade --minify literal.css
+  .a{text-decoration-color:#00f}
+
+An authored prefixed declaration owns the compatibility spelling: it keeps its
+own value and is not supplemented.
+
+  $ cat > authored.css <<CSS
+  > .a { -webkit-text-decoration-color: red; text-decoration-color: var(--c) }
+  > CSS
+  $ cascade --minify authored.css
+  .a{-webkit-text-decoration-color:red;text-decoration-color:var(--c)}
+
+--enforce-spec drops the target facts, leaving the authored declaration alone.
+
+  $ cascade --minify --enforce-spec unresolved.css
+  .a{text-decoration-color:var(--c)}

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -148,16 +148,18 @@ let test_duplicate_buggy_properties () =
     [ "-webkit-text-decoration:inherit" ]
     (List.map (Css.Declaration.to_string ~minify:true) duplicated);
 
-  (* -webkit-text-decoration-color is a compatibility property, not a generated
-     fallback for the standard property. External minifiers preserve authored
-     prefixed/unprefixed pairs and do not synthesize either spelling. *)
+  (* Synthesizing -webkit-text-decoration-color is the target-driven layer's
+     decision, taken against the declared browser versions;
+     target_evergreen_compatibility_prefixes covers it. This pass carries no
+     targets, so it duplicates only the properties WebKit reads wrongly and
+     leaves authored prefixed and unprefixed spellings distinct. *)
   let pp_decls decls =
     List.map (Css.Declaration.to_string ~minify:true) decls
   in
   let standard_color =
     duplicate_buggy_properties [ v Text_decoration_color (hex_color "0000ff") ]
   in
-  check (list string) "standard decoration color is not prefixed"
+  check (list string) "the target-less pass does not prefix a decoration color"
     [ "text-decoration-color:#00f" ]
     (pp_decls standard_color);
   let prefixed_color =
@@ -1051,7 +1053,13 @@ let test_var_color_functions_preserved () =
   same ".x{background-color:rgba(var(--rgb),var(--op))}";
   same ".x{border-color:rgba(var(--rgb),var(--op))}";
   same ".x{outline-color:rgba(var(--rgb),var(--op))}";
-  same ".x{text-decoration-color:rgba(var(--rgb),var(--op))}";
+  (* text-decoration-color also takes the WebKit alias at the declared targets,
+     which target_evergreen_compatibility_prefixes owns. The pending value is
+     what has to survive, and it survives on both spellings. *)
+  Alcotest.(check string)
+    "a decoration colour keeps its pending value"
+    ".x{-webkit-text-decoration-color:rgba(var(--rgb),var(--op));text-decoration-color:rgba(var(--rgb),var(--op))}"
+    (opt ".x{text-decoration-color:rgba(var(--rgb),var(--op))}");
   same ".x{caret-color:rgba(var(--rgb),var(--op))}";
   same ".x{fill:rgba(var(--rgb),var(--op))}";
   same ".x{stroke:rgba(var(--rgb),var(--op))}";
@@ -3320,10 +3328,30 @@ let target_evergreen_compatibility_prefixes () =
     ".a{-webkit-mask:none!important;mask:none!important}"
     (optimized_string ".a{mask:none!important}");
   Alcotest.(check string)
-    "decoration color needs no prefix for the declared target"
-    ".prose a{text-decoration:underline;text-decoration-color:var(--c)}"
+    "an unresolved decoration color takes the WebKit spelling too"
+    ".prose \
+     a{text-decoration:underline;-webkit-text-decoration-color:var(--c);text-decoration-color:var(--c)}"
     (optimized_string
        ".prose{a{text-decoration:underline;text-decoration-color:var(--c)}}");
+  Alcotest.(check string)
+    "a decoration color read as a colour keeps the standard property alone"
+    ".a{text-decoration-color:#00f}"
+    (optimized_string ".a{text-decoration-color:blue}");
+  Alcotest.(check string)
+    "the decoration color fallback preserves importance"
+    ".a{-webkit-text-decoration-color:var(--c)!important;text-decoration-color:var(--c)!important}"
+    (optimized_string ".a{text-decoration-color:var(--c)!important}");
+  Alcotest.(check string)
+    "an authored decoration color fallback is not supplemented"
+    ".a{-webkit-text-decoration-color:red;text-decoration-color:var(--c)}"
+    (optimized_string
+       ".a{-webkit-text-decoration-color:red;text-decoration-color:var(--c)}");
+  Alcotest.(check string)
+    "the declared target prefixes a decoration color feature test"
+    "@supports(-webkit-text-decoration-color:var(--c))or \
+     (text-decoration-color:var(--c)){.a{-webkit-text-decoration-color:var(--c);text-decoration-color:var(--c)}}"
+    (optimized_string
+       "@supports(text-decoration-color:var(--c)){.a{text-decoration-color:var(--c)}}");
   Alcotest.(check string)
     "spec-only mode does not synthesize target fallbacks"
     ".a{user-select:none;backdrop-filter:blur(1px);hyphens:auto;mask:none}"
@@ -3377,7 +3405,42 @@ let target_evergreen_compatibility_prefixes () =
     "targets past the compatibility boundaries omit hyphens and mask prefixes"
     ".a{hyphens:auto;mask-image:none}"
     (optimized_string ~targets:targets_past_hyphens_and_mask_prefixes
-       ".a{hyphens:auto;mask-image:none}")
+       ".a{hyphens:auto;mask-image:none}");
+  let safari_26_1 =
+    {
+      Css.Optimize.evergreen_targets with
+      safari = (26, 1);
+      ios_safari = (26, 1);
+    }
+  in
+  Alcotest.(check string)
+    "Safari 26.1 still receives the decoration color fallback"
+    ".a{-webkit-text-decoration-color:var(--c);text-decoration-color:var(--c)}"
+    (optimized_string ~targets:safari_26_1 ".a{text-decoration-color:var(--c)}");
+  let ios_safari_26_1 =
+    {
+      Css.Optimize.evergreen_targets with
+      safari = (26, 2);
+      ios_safari = (26, 1);
+    }
+  in
+  Alcotest.(check string)
+    "iOS Safari 26.1 still receives the decoration color fallback"
+    ".a{-webkit-text-decoration-color:var(--c);text-decoration-color:var(--c)}"
+    (optimized_string ~targets:ios_safari_26_1
+       ".a{text-decoration-color:var(--c)}");
+  let targets_past_decoration_color_prefix =
+    {
+      Css.Optimize.evergreen_targets with
+      safari = (26, 2);
+      ios_safari = (26, 2);
+    }
+  in
+  Alcotest.(check string)
+    "targets past the decoration color boundary omit its fallback"
+    ".a{text-decoration-color:var(--c)}"
+    (optimized_string ~targets:targets_past_decoration_color_prefix
+       ".a{text-decoration-color:var(--c)}")
 
 let c61_no_layer_media_merge () =
   (* CSS Cascade section 6.4.4.2: a layer statement between matching media


### PR DESCRIPTION
Safari and iOS Safari through 26.1 read `text-decoration-color` under its legacy `-webkit-` name, and default minification emitted only the standard property. A declaration whose value is not settled at parse time now carries both spellings; a value that reads as a colour keeps the standard longhand alone, as does an authored prefixed declaration.

The boundary and the value condition were measured against Lightning CSS at cascade's own default targets. Firefox and Chrome never require the alias.