### PR TITLE
diff: write the comparison as a JSON document

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1067,6 +1067,9 @@ difference wherever the two are not equivalent.
 
 ### CLI tools
 
+- `cascade diff --json` writes the comparison as one JSON document on standard
+  output in place of the report, so a harness reads what changed rather than
+  parsing prose. The exit status is unchanged (#799)
 - `cascade diff` compares a rule's nested body whatever order the two sides
   write its selector list in, and stops calling that reordering a change: a
   comma group is a set, so the body held the only difference (#798)

--- a/bin/cli_json.ml
+++ b/bin/cli_json.ml
@@ -1,0 +1,81 @@
+type t =
+  | Bool of bool
+  | Int of int
+  | String of string
+  | List of t list
+  | Obj of (string * t) list
+
+let hex_digits = "0123456789abcdef"
+
+(* JSON has no literal for a control byte, so spell it \u00XX; the four with a
+   short escape take it because it reads. *)
+let add_control buf c =
+  let code = Char.code c in
+  Buffer.add_string buf "\\u00";
+  Buffer.add_char buf hex_digits.[code lsr 4];
+  Buffer.add_char buf hex_digits.[code land 0xf]
+
+(* Bytes at or above 0x80 pass through: the input is a CSS file, so they are the
+   continuation bytes of a UTF-8 sequence, and escaping them one at a time would
+   spell a different character. *)
+let add_escaped buf s =
+  let add = Buffer.add_string buf in
+  String.iter
+    (fun c ->
+      match c with
+      | '"' -> add "\\\""
+      | '\\' -> add "\\\\"
+      | '\n' -> add "\\n"
+      | '\r' -> add "\\r"
+      | '\t' -> add "\\t"
+      | '\b' -> add "\\b"
+      | '\012' -> add "\\f"
+      | c when Char.code c < 0x20 -> add_control buf c
+      | c -> Buffer.add_char buf c)
+    s
+
+let add_indent buf level =
+  Buffer.add_char buf '\n';
+  for _ = 1 to 2 * level do
+    Buffer.add_char buf ' '
+  done
+
+let rec add_value buf level = function
+  | Bool b -> Buffer.add_string buf (if b then "true" else "false")
+  | Int n -> Buffer.add_string buf (string_of_int n)
+  | String s ->
+      Buffer.add_char buf '"';
+      add_escaped buf s;
+      Buffer.add_char buf '"'
+  | List [] -> Buffer.add_string buf "[]"
+  | List items ->
+      Buffer.add_char buf '[';
+      List.iteri
+        (fun i item ->
+          if i > 0 then Buffer.add_char buf ',';
+          add_indent buf (level + 1);
+          add_value buf (level + 1) item)
+        items;
+      add_indent buf level;
+      Buffer.add_char buf ']'
+  | Obj [] -> Buffer.add_string buf "{}"
+  | Obj members ->
+      Buffer.add_char buf '{';
+      List.iteri
+        (fun i (name, value) ->
+          if i > 0 then Buffer.add_char buf ',';
+          add_indent buf (level + 1);
+          Buffer.add_char buf '"';
+          add_escaped buf name;
+          Buffer.add_string buf "\": ";
+          add_value buf (level + 1) value)
+        members;
+      add_indent buf level;
+      Buffer.add_char buf '}'
+
+let to_string t =
+  let buf = Buffer.create 1024 in
+  add_value buf 0 t;
+  Buffer.contents buf
+
+let pp ppf t = Fmt.string ppf (to_string t)

--- a/bin/cli_json.mli
+++ b/bin/cli_json.mli
@@ -1,0 +1,23 @@
+(** A JSON writer for the CLI's machine-readable output.
+
+    Cascade has no JSON dependency and this is the only place that needs one, so
+    the writer lives here rather than in the library. It writes, never reads:
+    the only values it has to render are the ones a command builds. *)
+
+(** A JSON value. Numbers are integers because every number the CLI reports is a
+    count or a position. *)
+type t =
+  | Bool of bool
+  | Int of int
+  | String of string
+  | List of t list
+  | Obj of (string * t) list
+
+val to_string : t -> string
+(** [to_string t] renders [t] as an indented JSON document with no trailing
+    newline. Strings are escaped so that a CSS selector or value carrying a
+    quote, a backslash or a control byte survives the round trip; bytes at or
+    above [0x80] pass through, so UTF-8 input stays UTF-8 output. *)
+
+val pp : t Fmt.t
+(** [pp] prints a value as a JSON document, as {!to_string} renders it. *)

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -143,12 +143,340 @@ let print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~limit ~mode result =
         ]);
   print_string (Buffer.contents buf)
 
+(* The JSON document. It reports the whole comparison, so the shaping the human
+   report needs (a line budget, colour) has nothing to bound here: a consumer
+   reads the field it wants and ignores the rest. *)
+
+module J = Cli_json
+module D = Cascade_diff.Tree_diff
+
+let json_string s = J.String s
+let json_strings ss = J.List (List.map json_string ss)
+
+(* A member the constructor carries only sometimes is written only when it is
+   there, rather than as a null a reader would have to skip. *)
+let json_opt name f = function None -> [] | Some v -> [ (name, f v) ]
+
+let json_mode = function
+  | Auto -> "auto"
+  | Tree -> "tree"
+  | String -> "string"
+  | Canonical -> "canonical"
+
+let json_container_type = function
+  | `Media -> "media"
+  | `Layer -> "layer"
+  | `Supports -> "supports"
+  | `Container -> "container"
+  | `Property -> "property"
+  | `Nesting -> "nesting"
+  | `At_rule -> "at_rule"
+
+(* The author's own spelling, with the flag the human report also shows: a
+   declaration and the one it outranks read alike without it. *)
+let json_declaration decl =
+  let value = Cascade.Css.declaration_value ~minify:false decl in
+  let value =
+    if Cascade.Css.declaration_is_important decl then
+      String.concat "" [ value; " !important" ]
+    else value
+  in
+  J.Obj
+    [
+      ("property", json_string (Cascade.Css.declaration_name decl));
+      ("value", json_string value);
+    ]
+
+let json_declarations decls = J.List (List.map json_declaration decls)
+
+let json_property (property, value) =
+  J.Obj [ ("property", json_string property); ("value", json_string value) ]
+
+let json_property_change { D.property_name; expected_value; actual_value } =
+  J.Obj
+    [
+      ("property_name", json_string property_name);
+      ("expected_value", json_string expected_value);
+      ("actual_value", json_string actual_value);
+    ]
+
+(* A container's contents are CSS, not a difference, so they are written as the
+   minified text of each statement. *)
+let json_statements stmts =
+  J.List
+    (List.map
+       (fun stmt ->
+         json_string
+           (Cascade.Css.to_string ~minify:true (Cascade.Css.v [ stmt ])))
+       stmts)
+
+(* The three kinds that carry a selector and the declarations under it. *)
+let json_selector_rule selector declarations =
+  [
+    ("selector", json_string selector);
+    ("declarations", json_declarations declarations);
+  ]
+
+let json_content_changed ~selector ~old_declarations ~new_declarations
+    ~property_changes ~added_properties ~removed_properties =
+  [
+    ("selector", json_string selector);
+    ("old_declarations", json_declarations old_declarations);
+    ("new_declarations", json_declarations new_declarations);
+    ("property_changes", J.List (List.map json_property_change property_changes));
+    ("added_properties", J.List (List.map json_property added_properties));
+    ("removed_properties", J.List (List.map json_property removed_properties));
+  ]
+
+let json_reordered ~selector ~expected_pos ~actual_pos ~swapped_with
+    ~old_declarations ~new_declarations =
+  [
+    ("selector", json_string selector);
+    ("expected_pos", J.Int expected_pos);
+    ("actual_pos", J.Int actual_pos);
+  ]
+  @ json_opt "swapped_with" json_string swapped_with
+  @ json_opt "old_declarations" json_declarations old_declarations
+  @ json_opt "new_declarations" json_declarations new_declarations
+
+let json_rule_diff (rule : D.rule_diff) =
+  let entry kind fields = J.Obj (("kind", json_string kind) :: fields) in
+  match rule with
+  | Added { selector; declarations } ->
+      entry "added" (json_selector_rule selector declarations)
+  | Removed { selector; declarations } ->
+      entry "removed" (json_selector_rule selector declarations)
+  | Content_changed
+      {
+        selector;
+        old_declarations;
+        new_declarations;
+        property_changes;
+        added_properties;
+        removed_properties;
+      } ->
+      entry "modified"
+        (json_content_changed ~selector ~old_declarations ~new_declarations
+           ~property_changes ~added_properties ~removed_properties)
+  | Selector_changed { old_selector; new_selector; declarations } ->
+      entry "selector_changed"
+        [
+          ("old_selector", json_string old_selector);
+          ("new_selector", json_string new_selector);
+          ("declarations", json_declarations declarations);
+        ]
+  | Reordered
+      {
+        selector;
+        expected_pos;
+        actual_pos;
+        swapped_with;
+        old_declarations;
+        new_declarations;
+      } ->
+      entry "reordered"
+        (json_reordered ~selector ~expected_pos ~actual_pos ~swapped_with
+           ~old_declarations ~new_declarations)
+  | Rearranged { selector; declarations } ->
+      entry "rearranged" (json_selector_rule selector declarations)
+  | Regrouped { from_selectors; to_selectors } ->
+      entry "regrouped"
+        [
+          ("from_selectors", json_strings from_selectors);
+          ("to_selectors", json_strings to_selectors);
+        ]
+
+let json_container_info { D.container_type; condition; rules } =
+  [
+    ("container_type", json_string (json_container_type container_type));
+    ("condition", json_string condition);
+    ("rules", json_statements rules);
+  ]
+
+let json_blocks blocks =
+  J.List
+    (List.map
+       (fun (position, rules) ->
+         J.Obj
+           [ ("position", J.Int position); ("rules", json_statements rules) ])
+       blocks)
+
+let rec json_container_diff (container : D.container_diff) =
+  let entry change fields =
+    J.Obj
+      (("kind", json_string "container")
+      :: ("change", json_string change)
+      :: fields)
+  in
+  match container with
+  | Added info -> entry "added" (json_container_info info)
+  | Removed info -> entry "removed" (json_container_info info)
+  | Modified { info; actual_rules; rule_changes; container_changes } ->
+      entry "modified"
+        (json_container_info info
+        @ [
+            ("actual_rules", json_statements actual_rules);
+            ( "changes",
+              J.List
+                (List.map json_rule_diff rule_changes
+                @ List.map json_container_diff container_changes) );
+          ])
+  | Reordered { info; expected_pos; actual_pos } ->
+      entry "reordered"
+        (json_container_info info
+        @ [
+            ("expected_pos", J.Int expected_pos);
+            ("actual_pos", J.Int actual_pos);
+          ])
+  | Block_structure_changed
+      { container_type; condition; expected_blocks; actual_blocks } ->
+      entry "block_structure_changed"
+        [
+          ("container_type", json_string (json_container_type container_type));
+          ("condition", json_string condition);
+          ("expected_blocks", json_blocks expected_blocks);
+          ("actual_blocks", json_blocks actual_blocks);
+        ]
+
+let json_layer_order { D.expected_order; actual_order; swapped } =
+  J.Obj
+    [
+      ("kind", json_string "layer_order");
+      ("expected_order", json_strings expected_order);
+      ("actual_order", json_strings actual_order);
+      ( "swapped",
+        J.List
+          (List.map
+             (fun (weaker, stronger) ->
+               J.Obj
+                 [
+                   ("weaker", json_string weaker);
+                   ("stronger", json_string stronger);
+                 ])
+             swapped) );
+    ]
+
+let json_changes (d : D.t) =
+  Option.to_list (Option.map json_layer_order d.layer_order)
+  @ List.map json_rule_diff d.rules
+  @ List.map json_container_diff d.containers
+
+(* Every field of the record but the two texts, under the names the record
+   already uses, so the type and the document stay in step. *)
+let json_stats (s : Cascade_diff.Css_compare.stats) =
+  J.Obj
+    [
+      ("expected_chars", J.Int s.expected_chars);
+      ("actual_chars", J.Int s.actual_chars);
+      ("added_rules", J.Int s.added_rules);
+      ("removed_rules", J.Int s.removed_rules);
+      ("modified_rules", J.Int s.modified_rules);
+      ("reordered_rules", J.Int s.reordered_rules);
+      ("rearranged_rules", J.Int s.rearranged_rules);
+      ("regrouped_rules", J.Int s.regrouped_rules);
+      ("container_changes", J.Int s.container_changes);
+      ("layer_order_swaps", J.Int s.layer_order_swaps);
+    ]
+
+let json_string_diff (sdiff : Cascade_diff.String_diff.t) =
+  let expected_line, actual_line = sdiff.diff_lines in
+  J.Obj
+    [
+      ("position", J.Int sdiff.position);
+      ("line_expected", J.Int sdiff.line_expected);
+      ("column_expected", J.Int sdiff.column_expected);
+      ("line_actual", J.Int sdiff.line_actual);
+      ("column_actual", J.Int sdiff.column_actual);
+      ( "diff_lines",
+        J.Obj
+          [
+            ("expected", json_string expected_line);
+            ("actual", json_string actual_line);
+          ] );
+    ]
+
+let json_side side message =
+  J.Obj [ ("side", json_string side); ("message", json_string message) ]
+
+(* A parse error is the reason there is nothing to compare on that side, so it
+   belongs in the document rather than beside it: a consumer that only reads
+   stdout would otherwise see an empty comparison and no cause. Both sides
+   failing the same way is one fact about the input, as it is for a warning. *)
+let json_errors = function
+  | Cascade_diff.Css_compare.Both_errors (e1, e2) ->
+      let m1 = Cascade.Error.to_string e1 in
+      let m2 = Cascade.Error.to_string e2 in
+      if String.equal m1 m2 then [ json_side "both" m1 ]
+      else [ json_side "expected" m1; json_side "actual" m2 ]
+  | Expected_error e -> [ json_side "expected" (Cascade.Error.to_string e) ]
+  | Actual_error e -> [ json_side "actual" (Cascade.Error.to_string e) ]
+  | No_diff | Tree_diff _ | String_diff _ -> []
+
+(* The library groups the warnings; this only names the sides. *)
+let json_warnings (result : Cascade_diff.Css_compare.t) =
+  let side = function
+    | Cascade_diff.Css_compare.Expected -> "expected"
+    | Actual -> "actual"
+    | Both -> "both"
+  in
+  J.List
+    (List.map
+       (fun (s, w) -> json_side (side s) (Cascade.Error.to_string w))
+       (Cascade_diff.Css_compare.warnings result))
+
+let json_document ~file1 ~file2 ~mode ~css1 ~css2 result =
+  let stats =
+    Cascade_diff.Css_compare.stats ~expected_str:css1 ~actual_str:css2 result
+  in
+  let outcome = result.Cascade_diff.Css_compare.result in
+  let identical =
+    match outcome with
+    | No_diff -> true
+    | Tree_diff _ | String_diff _ | Both_errors _ | Expected_error _
+    | Actual_error _ ->
+        false
+  in
+  let changes = match outcome with Tree_diff d -> json_changes d | _ -> [] in
+  let string_diff =
+    match outcome with
+    | String_diff sdiff -> [ ("string_diff", json_string_diff sdiff) ]
+    | _ -> []
+  in
+  J.Obj
+    ([
+       ("expected", json_string file1);
+       ("actual", json_string file2);
+       ("mode", json_string (json_mode mode));
+       ("identical", J.Bool identical);
+       ("stats", json_stats stats);
+       ("warnings", json_warnings result);
+       ("errors", J.List (json_errors outcome));
+       ("changes", J.List changes);
+     ]
+    @ string_diff)
+
 type canonical_opts = { lossless : bool; prune_unused_custom_props : bool }
+
+let print_json_report ~file1 ~file2 ~mode ~css1 ~css2 ~opts =
+  let result =
+    run_diff mode ~lossless:opts.lossless
+      ~prune_unused_custom_props:opts.prune_unused_custom_props ~css1 ~css2
+  in
+  let document = json_document ~file1 ~file2 ~mode ~css1 ~css2 result in
+  print_string (Cli_json.to_string document);
+  print_newline ();
+  match result.Cascade_diff.Css_compare.result with
+  | No_diff -> Ok ()
+  | Tree_diff _ | String_diff _ | Both_errors _ | Expected_error _
+  | Actual_error _ ->
+      Stdlib.exit 1
 
 (* Each side is its text and the name the report gives it, which is the path for
    a file and [<stdin>] for the stream. *)
-let compare_sources ~color ~mode ~limit ~opts (css1, file1) (css2, file2) =
-  if css1 = css2 then (
+let compare_sources ~color ~mode ~limit ~json ~opts (css1, file1) (css2, file2)
+    =
+  if json then print_json_report ~file1 ~file2 ~mode ~css1 ~css2 ~opts
+  else if css1 = css2 then (
     Fmt.pr "CSS files are identical@.";
     Ok ())
   else
@@ -171,7 +499,7 @@ let compare_sources ~color ~mode ~limit ~opts (css1, file1) (css2, file2) =
            documented, distinct from cmdliner's reserved error codes. *)
         Stdlib.exit 1
 
-let compare_files file1 file2 style_renderer mode limit opts () =
+let compare_files file1 file2 style_renderer mode limit json opts () =
   Fmt_tty.setup_std_outputs
     ?style_renderer:(resolve_style_renderer style_renderer)
     ();
@@ -190,7 +518,7 @@ let compare_files file1 file2 style_renderer mode limit opts () =
   else
     match (read_source file1, read_source file2) with
     | Ok source1, Ok source2 ->
-        compare_sources ~color ~mode ~limit ~opts source1 source2
+        compare_sources ~color ~mode ~limit ~json ~opts source1 source2
     | Error e, _ | _, Error e -> Error e
 
 let file1_arg =
@@ -227,7 +555,9 @@ let limit_arg =
      one and every parse warning with it, and an integer prints exactly that \
      many. Wherever differences are left over, a $(b,... N more differences) \
      line records how many. Applies to the whole report, so a bound of $(b,1) \
-     is one top-level entry however many sections the report has."
+     is one top-level entry however many sections the report has. Ignored \
+     under $(b,--json), which replaces the report with a document naming every \
+     difference."
   in
   let parse = function
     | "auto" -> Ok Fit_entries
@@ -246,6 +576,18 @@ let limit_arg =
     value
     & opt (conv ~docv:"LIMIT" (parse, print)) Fit_entries
     & info [ "limit" ] ~docv:"LIMIT" ~doc)
+
+let json_arg =
+  let doc =
+    "Write the comparison as one JSON document on standard output, in place of \
+     the human report, so a harness can branch on the exit status and read the \
+     detail from the document. The exit status is unchanged. Nothing else \
+     reaches standard output: parse warnings and parse errors are members of \
+     the document rather than lines beside it. Colour and $(b,--limit) shape \
+     the human report only and are ignored here, since the document reports \
+     every difference."
+  in
+  Arg.(value & flag & info [ "json" ] ~doc)
 
 let lossless_arg =
   let doc =
@@ -287,7 +629,7 @@ let term =
   in
   term_result
     (const compare_files $ file1_arg $ file2_arg $ style_renderer_with_env
-   $ mode_arg $ limit_arg $ canonical_opts $ Cli_log.term)
+   $ mode_arg $ limit_arg $ json_arg $ canonical_opts $ Cli_log.term)
 
 let man =
   [
@@ -305,6 +647,8 @@ let man =
     `Pre "  cascade diff reference.css output.css";
     `P "Compare a stylesheet on standard input against a reference:";
     `Pre "  cascade fmt --minify src.css | cascade diff reference.css -";
+    `P "Read the comparison as JSON instead of the report:";
+    `Pre "  cascade diff --json reference.css output.css";
     `P "Disable colors using flag:";
     `Pre "  cascade diff --color=never reference.css output.css";
     `P "Disable colors using NO_COLOR environment variable:";

--- a/test/cli/diff_json.t
+++ b/test/cli/diff_json.t
@@ -1,0 +1,193 @@
+CLI: `cascade diff --json`, the comparison as one JSON document.
+
+A CI or parity harness given only the tree report has to parse English to
+learn what changed. `--json` writes the whole comparison as one JSON document
+on standard output in place of that report, and leaves the exit status alone,
+so a script branches on the status and reads the detail from the document.
+
+  $ cat > a.css <<EOF
+  > .x { color: red }
+  > EOF
+  $ cat > b.css <<EOF
+  > .x { color: red }
+  > EOF
+
+An identical pair. Every count is zero, `identical` is true, and the status
+is still 0.
+
+  $ cascade diff --json a.css b.css
+  {
+    "expected": "a.css",
+    "actual": "b.css",
+    "mode": "auto",
+    "identical": true,
+    "stats": {
+      "expected_chars": 18,
+      "actual_chars": 18,
+      "added_rules": 0,
+      "removed_rules": 0,
+      "modified_rules": 0,
+      "reordered_rules": 0,
+      "rearranged_rules": 0,
+      "regrouped_rules": 0,
+      "container_changes": 0,
+      "layer_order_swaps": 0
+    },
+    "warnings": [],
+    "errors": [],
+    "changes": []
+  }
+
+One modified rule. The entry names the rule, the property that changed and
+the value each side gives it, and the status is still 1.
+
+  $ cat > d.css <<EOF
+  > .x { color: blue }
+  > EOF
+  $ cascade diff --json a.css d.css
+  {
+    "expected": "a.css",
+    "actual": "d.css",
+    "mode": "auto",
+    "identical": false,
+    "stats": {
+      "expected_chars": 18,
+      "actual_chars": 19,
+      "added_rules": 0,
+      "removed_rules": 0,
+      "modified_rules": 1,
+      "reordered_rules": 0,
+      "rearranged_rules": 0,
+      "regrouped_rules": 0,
+      "container_changes": 0,
+      "layer_order_swaps": 0
+    },
+    "warnings": [],
+    "errors": [],
+    "changes": [
+      {
+        "kind": "modified",
+        "selector": ".x",
+        "old_declarations": [
+          {
+            "property": "color",
+            "value": "red"
+          }
+        ],
+        "new_declarations": [
+          {
+            "property": "color",
+            "value": "blue"
+          }
+        ],
+        "property_changes": [
+          {
+            "property_name": "color",
+            "expected_value": "red",
+            "actual_value": "blue"
+          }
+        ],
+        "added_properties": [],
+        "removed_properties": []
+      }
+    ]
+  }
+  [1]
+
+Both of those are well-formed JSON.
+
+  $ cascade diff --json a.css b.css | python3 -m json.tool > /dev/null; echo $?
+  0
+  $ cascade diff --json a.css d.css | python3 -m json.tool > /dev/null; echo $?
+  0
+
+A difference inside a container is one entry that nests its own changes,
+rather than a rule change hoisted to the top level.
+
+  $ cat > m1.css <<EOF
+  > @media (min-width: 40rem) { .x { color: red } }
+  > EOF
+  $ cat > m2.css <<EOF
+  > @media (min-width: 40rem) { .x { color: blue; top: 0 } }
+  > EOF
+  $ cascade diff --json m1.css m2.css | python3 -m json.tool > /dev/null; echo $?
+  0
+  $ cascade diff --json m1.css m2.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["stats"]["container_changes"], d["identical"])
+  > c = d["changes"][0]
+  > print(c["kind"], c["change"], c["container_type"], c["condition"])
+  > print(c["rules"], c["actual_rules"])
+  > n = c["changes"][0]
+  > print(n["kind"], n["selector"], n["added_properties"], n["property_changes"])'
+  1 False
+  container modified media (min-width: 40rem)
+  ['.x{color:red}'] ['.x{color:blue;top:0}']
+  modified .x [{'property': 'top', 'value': '0'}] [{'property_name': 'color', 'expected_value': 'red', 'actual_value': 'blue'}]
+
+A parse warning is a member of the document, not a line beside it, so the
+document is the only thing on standard output whether or not the parser had
+a complaint. A warning both files raise names both sides once.
+
+  $ cat > w1.css <<EOF
+  > .x { color: red; float: center; margin: 0 }
+  > EOF
+  $ cat > w2.css <<EOF
+  > .x { color: red; float: center; margin: 1px }
+  > EOF
+  $ cascade diff --json w1.css w2.css | python3 -m json.tool > /dev/null; echo $?
+  0
+  $ cascade diff --json w1.css w2.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["errors"])
+  > for w in d["warnings"]:
+  >     print(w["side"], "|", w["message"].splitlines()[0])'
+  []
+  both | <string>: read_declaration/float: bad value for float: unknown float-side: center at [24-30] (in component)
+
+A warning only one file raises names that side.
+
+  $ cat > p1.css <<EOF
+  > .x { clear: nope; margin: 0 }
+  > EOF
+  $ cat > p2.css <<EOF
+  > .x { position: nope; margin: 1px }
+  > EOF
+  $ cascade diff --json p1.css p2.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > for w in d["warnings"]:
+  >     print(w["side"], "|", w["message"].splitlines()[0])'
+  expected | <string>: read_declaration/clear: bad value for clear: unknown clear: nope at [12-16] (in component)
+  actual | <string>: read_declaration/position: bad value for position: unknown position: nope at [15-19] (in component)
+
+The character-diff fallback carries the position and the two lines instead
+of a change list.
+
+  $ cascade diff --json --diff=string a.css d.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["mode"], d["changes"])
+  > s = d["string_diff"]
+  > print(s["position"], s["line_expected"], s["column_expected"])
+  > print(s["diff_lines"]["expected"])
+  > print(s["diff_lines"]["actual"])'
+  string []
+  12 0 12
+  .x { color: red }
+  .x { color: blue }
+
+`--limit` and colour shape the human report, which `--json` replaces, so
+passing either is accepted and leaves the document alone.
+
+  $ cascade diff --json a.css d.css > plain.json
+  [1]
+  $ cascade diff --json --limit=1 --color=always a.css d.css > shaped.json
+  [1]
+  $ cmp plain.json shaped.json && echo same
+  same
+
+A side read from standard input is named the way the report names it.
+
+  $ printf '.x { color: blue }\n' | cascade diff --json - a.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["expected"], d["actual"])'
+  <stdin> a.css


### PR DESCRIPTION
A CI or parity harness had to parse the tree report's text to learn what changed, and that report is shaped for a reader rather than for a parser. `--json` writes the stats, the parse warnings and the structured changes as one document on stdout, leaving the exit status as it is so a script can branch on the status and read the detail from the document.