### PR TITLE
nest: wrap a parent selector list in :is()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -518,6 +518,9 @@ difference wherever the two are not equivalent.
   identical (#782)
 - Invalid math results in `shape-margin` and `offset-distance` are dropped like
   those in every other `<length-percentage>` property (#766)
+- Flattening a rule nested under a selector list wraps the parent in `:is()`,
+  where `.a,.b{&:hover{color:red}}` printed `.a,.b:hover` and bound `:hover` to
+  the last branch, CSS Nesting 1 sec. 4 (ED) reading `&` as the group (#800)
 - `--flatten-nesting` leaves the optimised stylesheet flat even when later
   regrouping can shorten adjacent selectors by synthesizing nesting (#759)
 - Canonical diff compares authored nesting through its flattened selector

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -6,9 +6,9 @@ let contains sel =
 (* CSS Nesting 1 sec. 4: [&] stands for [:is(<parent selector list>)]. A parent
    that carries a combinator or lists alternatives needs that wrapper, or its
    own structure escapes: dropping it turns [.dark &] over parent [.a .b] into
-   [.dark .a .b], which demands that [.a] itself sit inside [.dark]. Where [&]
-   heads the selector nothing can escape to its left, so the wrapper is
-   redundant there and the parent goes in verbatim. *)
+   [.dark .a .b], which demands that [.a] itself sit inside [.dark]. Where the
+   parent goes in with nothing to its left, [splices_bare] below reads whether
+   the wrapper is redundant. *)
 let complex = function
   | Selector.List _ | Selector.Combined _ | Selector.Relative _ -> true
   | _ -> false
@@ -29,12 +29,37 @@ let rec heads = function
   | Selector.Combined (l, _, _) -> heads l
   | _ -> false
 
+let is_list = function Selector.List _ -> true | _ -> false
+
+(* Selectors 4 sec. 4.2 weighs [:is()] as its most specific argument, so
+   spelling a parent selector list out in place of the wrapper holds each branch
+   at its own weight only when the branches already agree on one. *)
+let one_weight = function
+  | Selector.List (branch :: rest) ->
+      let weight = Selector.specificity branch in
+      List.for_all
+        (fun b -> Selector.equal_specificity (Selector.specificity b) weight)
+        rest
+  | _ -> true
+
+(* The leading-[&] shortcut needs the parent to have no comma of its own: a
+   [List] spliced into a larger selector hands its branches to that selector, so
+   [.a, .b] under [&:hover] reads back as [.a] and [.b:hover] and the
+   pseudo-class binds to the last branch alone. Where the whole selector is the
+   parent there is nothing to splice into, and the list stands for itself. *)
+let splices_bare ~leftmost ~parent sel =
+  if is_list parent then
+    match sel with Selector.Nesting -> one_weight parent | _ -> false
+  else leftmost && heads sel && count_nesting sel = 1
+
 let substitute ?(leftmost = true) ~parent sel =
-  let verbatim =
-    (not (complex parent)) || (leftmost && heads sel && count_nesting sel = 1)
-  in
+  let verbatim = (not (complex parent)) || splices_bare ~leftmost ~parent sel in
   let parent = if verbatim then parent else Selector.Is [ parent ] in
   Selector.map (function Selector.Nesting -> parent | s -> s) sel
+
+(* A parent the nested selector never names still lands inside it, to the left
+   of a combinator, so it needs the same wrapper. *)
+let grouped parent = if is_list parent then Selector.Is [ parent ] else parent
 
 (* CSS Nesting 1 sec. 3: a nested selector list is relative to the parent branch
    by branch, so [.p { a, b { ... } }] is [.p a, .p b]. Combining the parent
@@ -44,11 +69,10 @@ let rec combine parent child =
   match child with
   | Selector.List branches -> Selector.List (List.map (combine parent) branches)
   | Selector.Relative (comb, right) ->
-      Selector.Combined (parent, comb, substitute ~leftmost:false ~parent right)
+      Selector.Combined
+        (grouped parent, comb, substitute ~leftmost:false ~parent right)
   | _ when contains child -> substitute ~parent child
-  | _ -> Selector.Combined (parent, Selector.Descendant, child)
-
-let is_list = function Selector.List _ -> true | _ -> false
+  | _ -> Selector.Combined (grouped parent, Selector.Descendant, child)
 
 let rec merge_lone (rule : rule) =
   match (rule.declarations, rule.nested) with

--- a/test/render/render_diff.ml
+++ b/test/render/render_diff.ml
@@ -154,6 +154,26 @@ let nth_last_of_sheet = {css|li:nth-last-child(2 of .rd-c) { color: #090 }|css}
 let canary_sheet = {css|.k { row-gap: 9px; gap: 1px }|css}
 let canary_reordered = {css|.k { gap: 1px; row-gap: 9px }|css}
 
+(* CSS Nesting 1 sec. 4 reads [&] as [:is(<parent selector list>)], so a comma
+   group under [&:first-child] paints a first child only. The document holds two
+   adjacent [.rd-c], so a flattening that hands the pseudo-class to the last
+   branch alone paints the second one too. The engine reads the nesting itself
+   and the pair renders it against what flattening produced, so the rewrite is
+   judged rather than repeated. *)
+let nest_list_source =
+  {css|
+:is(.rd-c, .rd-d):first-child { color: #00f }
+.rd-c + .rd-c { font-style: italic }
+|css}
+
+let nest_list_nested = {css|.rd-c, .rd-d { &:first-child { color: #00f } }|css}
+
+let flattened css =
+  match Css.of_string ~strict:false css with
+  | Ok { stylesheet; _ } ->
+      Css.to_string ~minify:true (Css.optimize ~flatten_nesting:true stylesheet)
+  | Error _ -> css
+
 (* Two more pairs, one per selector form the derived document has to get right.
    The [i] flag has to build a value the unflagged selector misses, and [of S]
    has to place the element among the siblings [S] matches; a document that
@@ -305,6 +325,17 @@ let inputs () =
         sheets =
           Some [ ("original", canary_sheet); ("reordered", canary_reordered) ];
         expect = Differs "gap resets the row gap the longhand set";
+      };
+      {
+        id = "nest-list";
+        source = nest_list_source;
+        sheets =
+          Some
+            [
+              ("nested", nest_list_nested);
+              ("flattened", flattened nest_list_nested);
+            ];
+        expect = Same;
       };
       {
         id = "attr-flag";

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -128,6 +128,30 @@ let test_nested_selector_list_keeps_parent () =
   check ".p{a::before,a::after{color:red}}" ".p a:before,.p a:after{color:red}";
   check ".p{& a,& b{color:red}}" ".p a,.p b{color:red}"
 
+(* CSS Nesting 1 sec. 4 desugars [&] to the parent rule's selector wrapped in
+   [:is()], and reads a nested selector with no [&] as if it had a leading one.
+   A parent selector list spliced in bare loses that grouping: [.a, .b] under
+   [&:hover] reads back as the two branches [.a] and [.b:hover], so the
+   pseudo-class binds to the last branch alone and the first matches unguarded.
+   Selectors 4 sec. 4.2 weighs [:is()] as its most specific argument, so the
+   wrapper may go only where the whole selector is the parent list and its
+   branches already agree on one specificity. *)
+let test_list_parent_keeps_its_branches () =
+  let check src expected =
+    Alcotest.(check string) src expected (render (Flatten.block (block src)))
+  in
+  check ".a,.b{&:hover{color:red}}" ":is(.a,.b):hover{color:red}";
+  check ".a,.b{.c{color:red}}" ":is(.a,.b) .c{color:red}";
+  check ".a,.b{>.c{color:red}}" ":is(.a,.b)>.c{color:red}";
+  (* every branch of a nested list carries the whole parent *)
+  check ".a,.b{.c,&:hover{color:red}}"
+    ":is(.a,.b) .c,:is(.a,.b):hover{color:red}";
+  (* a second level nests inside the wrapper the first one built *)
+  check ".a,.b{&:hover{&:focus{color:red}}}" ":is(.a,.b):hover:focus{color:red}";
+  (* [&] alone spells the parent list itself, at the weight of each branch *)
+  check ".a,.b{&{color:red}}" ".a,.b{color:red}";
+  check ".a,#b{&{color:red}}" ":is(.a,#b){color:red}"
+
 (* [@-moz-document] groups rules like any other conditional at-rule, so nesting
    inside one flattens and a rule wrapping one keeps its selector: emitting the
    at-rule verbatim from inside a rule drops the parent it was written under. *)
@@ -175,6 +199,8 @@ let suite =
         test_nesting_wraps_complex_parent;
       Alcotest.test_case "nested selector list keeps the parent" `Quick
         test_nested_selector_list_keeps_parent;
+      Alcotest.test_case "list parent keeps its branches" `Quick
+        test_list_parent_keeps_its_branches;
       Alcotest.test_case "flattens inside @-moz-document" `Quick
         test_flattens_inside_moz_document;
       Alcotest.test_case "nested group rules keep the parent" `Quick


### PR DESCRIPTION
Flattening `.a, .b { &:hover {} }` produced `.a,.b:hover`, a two-branch list where `:hover` binds only to `.b` and `.a` matches unconditionally. CSS Nesting 1 (ED) section 4 desugars the nesting selector to the parent's selector list wrapped in `:is()`, which is also where the specificity comes from, so the expansion is `:is(.a,.b):hover`. It reaches `Css.flatten_nesting`, `Resolve`, `cascade apply` and `cascade prune` alike, not only the diff.