### PR TITLE
cursor: mark the value a reader rejected

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -180,6 +180,9 @@ difference wherever the two are not equivalent.
 
 ### Parsing
 
+- A parse warning marks the value the author wrote rather than the token after
+  it, so the caret no longer lands on the semicolon that closes the
+  declaration (#800)
 - Lenient parsing preserves a declaration-safe value opaquely when a known
   property's typed reader rejects it, while retaining the warning that makes
   strict parsing reject the declaration (#787)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -180,9 +180,12 @@ difference wherever the two are not equivalent.
 
 ### Parsing
 
+- A parse warning whose value matched none of a property's forms says so,
+  in place of a reason that opened a list of accepted forms and named
+  none of them (#801)
 - A parse warning marks the value the author wrote rather than the token after
   it, so the caret no longer lands on the semicolon that closes the
-  declaration (#800)
+  declaration (#801)
 - Lenient parsing preserves a declaration-safe value opaquely when a known
   property's typed reader rejects it, while retaining the warning that makes
   strict parsing reject the declaration (#787)

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -215,8 +215,12 @@ let raise_sort t sort kind loc =
 
 let raise_ t kind loc = raise_sort t sort kind loc
 
-let err ?got t msg =
-  let loc = position t in
+(* [loc] is for a reader that consumed the offending token before deciding it
+   was bad: [position t] has moved on to whatever follows by then, and at the
+   end of a value that is the terminator. Such a reader passes the span it
+   read. *)
+let err ?loc ?got t msg =
+  let loc = match loc with Some loc -> loc | None -> position t in
   match got with
   | Some g ->
       raise_ t
@@ -224,9 +228,9 @@ let err ?got t msg =
         loc
   | None -> raise_ t (Error.Bad_value { property = ""; reason = msg }) loc
 
-let err_invalid t msg = err t ("invalid: " ^ msg)
+let err_invalid ?loc t msg = err ?loc t ("invalid: " ^ msg)
 let err_eof t = raise_ t (Error.Unterminated sort) (position t)
-let err_expected t what = err t ("expected " ^ what)
+let err_expected ?loc t what = err ?loc t ("expected " ^ what)
 
 let err_expected_but_eof t what =
   raise_ t (Error.Missing_token what) (position t)
@@ -480,6 +484,17 @@ let consume_to_decl_end ?(trim = false) t =
   string_of_components ~trim (drain_until_raw ends_declaration_value t)
 
 let drain_to_decl_end t = drain_until_raw ends_declaration_value t
+
+let decl_value_loc t =
+  match
+    List.filter (fun cv -> not (is_ws_cv cv)) (lookahead drain_to_decl_end t)
+  with
+  | [] -> position t
+  | first :: rest ->
+      List.fold_left
+        (fun acc cv -> Loc.union acc (Component.source_loc cv))
+        (Component.source_loc first)
+        rest
 
 let declaration_value t =
   let cvs = drain_to_decl_end t in
@@ -737,9 +752,10 @@ let expect c t =
     err_expected t (String.concat "" [ "'"; String.make 1 c; "'" ])
 
 let expect_string name t =
+  let loc = position t in
   match ident_opt t with
   | Some s when String.lowercase_ascii_preserve s = name -> ()
-  | _ -> err_expected t name
+  | _ -> err_expected ~loc t name
 
 let expect_eof t = if not (is_done t) then err t "unexpected token"
 

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -926,9 +926,11 @@ let option p t =
       restore t snap;
       None
 
+(* The alternatives are anonymous readers, so an exhausted list has no forms to
+   name: report that none matched rather than open a list and leave it empty. *)
 let rec one_of ps t =
   match ps with
-  | [] -> err_expected t "one of"
+  | [] -> err t "no accepted form"
   | p :: rest -> (
       let snap = save t in
       match p t with

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -181,16 +181,19 @@ val try_typed_call : (t -> 'a) -> t -> ('a, Component.t) result
 exception Parse_error of Error.t
 (** Alias for {!Error.Parse_error}. *)
 
-val err : ?got:string -> t -> string -> 'a
-(** [err ?got t msg] raises {!Parse_error} at the current position. *)
+val err : ?loc:Loc.t -> ?got:string -> t -> string -> 'a
+(** [err ?loc ?got t msg] raises {!Parse_error} at the current position, or at
+    [loc] when given. A reader that consumes the offending token before
+    rejecting it passes the span it read: {!val-position} has moved on to
+    whatever follows by then, which at the end of a value is the terminator. *)
 
-val err_invalid : t -> string -> 'a
+val err_invalid : ?loc:Loc.t -> t -> string -> 'a
 (** [err_invalid t msg] is [err t ("invalid: " ^ msg)]. *)
 
 val err_eof : t -> 'a
 (** [err_eof t] raises an "unexpected end of input" error. *)
 
-val err_expected : t -> string -> 'a
+val err_expected : ?loc:Loc.t -> t -> string -> 'a
 (** [err_expected t what] raises with "expected [what]". *)
 
 val err_expected_but_eof : t -> string -> 'a
@@ -361,6 +364,12 @@ val drain_to_decl_end : t -> Component.t list
 (** [drain_to_decl_end t] consumes components up to (but not including) the next
     semicolon or top-level [!] delimiter, returning the drained list without
     serialising it. *)
+
+val decl_value_loc : t -> Loc.t
+(** [decl_value_loc t] is the span the declaration value ahead covers, without
+    consuming it, or {!val-position} when no value is left. A shorthand reader
+    that takes the whole value before deciding it is bad reports against this,
+    since the failure is the value's rather than that of the token after it. *)
 
 val declaration_value : t -> t
 (** [declaration_value t] consumes a declaration's value off [t] and is a cursor

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -681,9 +681,12 @@ let validate_no_extra_tokens t =
   match Cursor.peek_head_shape t with
   | `Eof | `Semicolon | `Bang -> ()
   | _ ->
+      (* The trailing tokens are consumed before they are judged, so the span is
+         theirs rather than that of the terminator they stop at. *)
+      let loc = Cursor.decl_value_loc t in
       let trimmed = Cursor.consume_to_decl_end ~trim:true t in
       if trimmed <> "" then
-        Cursor.err_invalid t
+        Cursor.err_invalid ~loc t
           ("unexpected tokens after property value: " ^ trimmed)
 
 let read_length_box ?(allow_negative = true) t =

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -9,8 +9,8 @@ open Common
 open Values
 open Properties_intf
 
-let err_invalid_value ?got t prop_name value =
-  Cursor.err ?got t ("invalid " ^ prop_name ^ " value: " ^ value)
+let err_invalid_value ?loc ?got t prop_name value =
+  Cursor.err ?loc ?got t ("invalid " ^ prop_name ^ " value: " ^ value)
 
 let rec read_css_wide t : css_wide =
   Cursor.enum_or_var "css-wide keyword"
@@ -315,6 +315,7 @@ let url path : background_image = Url path
 (* <dashed-ident>: shared by anchor-name, position-anchor, position-try
    fallbacks, font-palette and the animation timeline names. *)
 let read_dashed_ident t =
+  let loc = Cursor.position t in
   let ident = Cursor.ident ~keep_case:true t in
   if Custom_property_name.is_valid ident then ident
-  else Cursor.err_invalid t ("expected dashed ident, got: " ^ ident)
+  else Cursor.err_invalid ~loc t ("expected dashed ident, got: " ^ ident)

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -1701,6 +1701,9 @@ let read_font_shorthand r : font_shorthand =
   }
 
 let rec read_font t : font =
+  (* The shorthand is read whole, so a failure is the whole value's; [t] has
+     passed the end of it by the time one is raised. *)
+  let loc = Cursor.decl_value_loc t in
   let raw = Cursor.consume_to_decl_end ~trim:true t in
   let lower = String.lowercase_ascii (String.trim raw) in
   match lower with
@@ -1728,12 +1731,12 @@ let rec read_font t : font =
         let r = Cursor.of_string raw in
         Var (Values.read_var (fun r -> read_font r) r)
       else if value_has_css_wide_mix raw then
-        Cursor.err_invalid t "CSS-wide keyword mixed with other values"
+        Cursor.err_invalid ~loc t "CSS-wide keyword mixed with other values"
       else
         let body =
           try read_font_shorthand (Cursor.of_string raw)
           with Cursor.Parse_error _ ->
-            Cursor.err_invalid t "invalid font shorthand"
+            Cursor.err_invalid ~loc t "invalid font shorthand"
         in
         Shorthand body
 

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -307,16 +307,18 @@ let vector_effect_space_of = function
   | _ -> Option.None
 
 let read_vector_effect_keyword t : vector_effect_keyword =
+  let loc = Cursor.position t in
   let name = Cursor.ident t in
   match vector_effect_keyword_of name with
   | Some k -> k
-  | Option.None -> err_invalid_value t "vector-effect" name
+  | Option.None -> err_invalid_value ~loc t "vector-effect" name
 
 let read_vector_effect_space t : vector_effect_space =
+  let loc = Cursor.position t in
   let name = Cursor.ident t in
   match vector_effect_space_of name with
   | Some s -> s
-  | Option.None -> err_invalid_value t "vector-effect" name
+  | Option.None -> err_invalid_value ~loc t "vector-effect" name
 
 (* [ <effect> ]+ then an optional space keyword, so an ident that names a space
    ends the effect run. *)
@@ -357,10 +359,11 @@ let paint_order_keyword_of = function
   | _ -> None
 
 let read_paint_order_keyword t : paint_order_keyword =
+  let loc = Cursor.position t in
   let name = Cursor.ident t in
   match paint_order_keyword_of name with
   | Some k -> k
-  | None -> err_invalid_value t "paint-order" name
+  | None -> err_invalid_value ~loc t "paint-order" name
 
 (* [||] takes each operand at most once, so a repeat ends the list rather than
    extending it. *)

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -1512,6 +1512,9 @@ let read_offset_body t : offset =
   Shorthand { target; anchor }
 
 let rec read_offset t : offset =
+  (* The shorthand is read whole, so a failure is the whole value's; [t] has
+     passed the end of it by the time one is raised. *)
+  let loc = Cursor.decl_value_loc t in
   let raw = Cursor.consume_to_decl_end ~trim:true t in
   match String.lowercase_ascii (String.trim raw) with
   | "inherit" -> Inherit
@@ -1531,11 +1534,11 @@ let rec read_offset t : offset =
       if is_whole_var () then
         Var (Values.read_var read_offset (Cursor.of_string raw))
       else if value_has_css_wide_mix raw then
-        Cursor.err_invalid t "CSS-wide keyword mixed with other values"
+        Cursor.err_invalid ~loc t "CSS-wide keyword mixed with other values"
       else
         try read_offset_body (Cursor.of_string raw)
         with Cursor.Parse_error _ ->
-          Cursor.err_invalid t "invalid offset shorthand")
+          Cursor.err_invalid ~loc t "invalid offset shorthand")
 
 (* Sec. 2.2 gives [offset-distance] the initial value [0]. A zero percentage is
    a different computed value from a zero length, so only a zero length says

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6981,6 +6981,9 @@ and color_parsers =
 
 and read_color t : color =
   Cursor.ws t;
+  (* The two branches below consume the token before judging it, so they mark
+     [loc] rather than whatever the cursor has moved on to. *)
+  let loc = Cursor.position t in
   let color =
     match Cursor.peek t with
     | Some (Component.Preserved { kind = Token.Hash { value; _ }; _ }) -> (
@@ -6992,13 +6995,13 @@ and read_color t : color =
           || ('A' <= c && c <= 'F')
         in
         if not (len = 3 || len = 4 || len = 6 || len = 8) then
-          Cursor.err_invalid t ("hex color length: " ^ string_of_int len)
+          Cursor.err_invalid ~loc t ("hex color length: " ^ string_of_int len)
         else if not (String.for_all is_hex value) then
-          Cursor.err_invalid t ("hex color digits: " ^ value)
+          Cursor.err_invalid ~loc t ("hex color digits: " ^ value)
         else
           match rgba_of_hex value with
           | Some (r, g, b, a) -> Authored_hex { value; r; g; b; a }
-          | None -> Cursor.err_invalid t ("hex color digits: " ^ value))
+          | None -> Cursor.err_invalid ~loc t ("hex color digits: " ^ value))
     | Some (Component.Func ({ node = { name; _ }; _ } as fn)) -> (
         (* CSS Values 4 sec. 4.1: a function name is a keyword, so it names the
            same function in whatever case it was written. *)
@@ -7014,7 +7017,7 @@ and read_color t : color =
         (* CSS color keywords are case-insensitive. *)
         match read_color_keyword_of_string (String.lowercase_ascii ident) with
         | Some color -> color
-        | None -> Cursor.err t ("unknown color: " ^ ident))
+        | None -> Cursor.err ~loc t ("unknown color: " ^ ident))
     | _ -> Cursor.err t "color"
   in
   Cursor.ws t;

--- a/test/cli/diff_depth.t
+++ b/test/cli/diff_depth.t
@@ -33,7 +33,7 @@ reader failed still qualifies every difference below it.
   CSS: 29 chars vs 34 chars (17.2% diff)
   Changes: 1 modified rule
   
-  warn.css parse warning: <string>: read_declaration/width: bad value for width: expected one of at [24-25] (in component)
+  warn.css parse warning: <string>: read_declaration/width: bad value for width: no accepted form at [24-25] (in component)
   .x { color: red; width: <value> }
                           ^
   

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -213,6 +213,27 @@ let value_span_marks_the_rejected_value () =
       (".x { color: nope red }", "nope");
     ]
 
+(* [Cursor.one_of] fails once every alternative has failed, and the alternatives
+   are anonymous readers, so there is nothing to list after "one of". The reason
+   says that no form matched rather than trailing off. *)
+let bad_value_reason_names_something () =
+  let reasons css =
+    List.filter_map
+      (fun (w : Error.t) ->
+        match w.kind with
+        | Error.Bad_value { reason; _ } -> Some reason
+        | _ -> None)
+      (parse_warnings css)
+  in
+  List.iter
+    (fun (css, expected) ->
+      Alcotest.(check (list string)) css [ expected ] (reasons css))
+    [
+      (".x { top: nope }", "no accepted form");
+      (".x { align-items: nope }", "no accepted form");
+      (".x { aspect-ratio: nope }", "no accepted form");
+    ]
+
 let suite =
   ( "error",
     [
@@ -236,4 +257,6 @@ let suite =
         caret_marks_the_line_it_points_at;
       Alcotest.test_case "value span marks the rejected value" `Quick
         value_span_marks_the_rejected_value;
+      Alcotest.test_case "bad value reason names something" `Quick
+        bad_value_reason_names_something;
     ] )

--- a/test/test_error.ml
+++ b/test/test_error.ml
@@ -1,4 +1,5 @@
-(** Error module tests: rendering of the sealed kind and named constructors. *)
+(** Error module tests: rendering of the sealed kind and named constructors, and
+    where a reader anchors the value it rejects. *)
 
 open Cascade
 
@@ -172,6 +173,46 @@ let source_context () =
            color red;\n\
            ^^^^^")
 
+(* A reader that consumes the offending token before rejecting it still owns
+   that token: the span marks the value the author wrote, not whatever follows
+   it. When the bad value ends the declaration, "whatever follows" is the
+   terminator, so the caret lands on punctuation. *)
+let parse_warnings css =
+  match Css.of_string ~strict:false css with
+  | Error e -> Alcotest.failf "fatal parse error: %s" (Error.to_string e)
+  | Ok { Css.warnings; _ } -> warnings
+
+let marked css =
+  List.map
+    (fun (w : Error.t) ->
+      String.sub css w.loc.start_pos (w.loc.end_pos - w.loc.start_pos))
+    (parse_warnings css)
+
+let value_span_marks_the_rejected_value () =
+  List.iter
+    (fun (css, expected) ->
+      Alcotest.(check (list string)) css [ expected ] (marked css))
+    [
+      (* Readers reached through a keyword table already mark their own
+         value. *)
+      (".x { float: center }", "center");
+      (* Readers that consume first, one per rejecting site. *)
+      (".x { color: nope }", "nope");
+      (".x { font-palette: nope }", "nope");
+      (".x { font: nope }", "nope");
+      (".x { offset: nope }", "nope");
+      (".x { font-style: nope }", "nope");
+      (".x { scrollbar-gutter: nope }", "nope");
+      (".x { paint-order: nope }", "nope");
+      (".x { vector-effect: nope }", "nope");
+      (* A whole-value reader marks the whole value it read. *)
+      (".x { font: bold nope 12pt sans-serif }", "bold nope 12pt sans-serif");
+      (".x { animation-name: slide nope }", "nope");
+      (* The span is one token late rather than pinned to the terminator: a
+         value with something after it marks that something. *)
+      (".x { color: nope red }", "nope");
+    ]
+
 let suite =
   ( "error",
     [
@@ -193,4 +234,6 @@ let suite =
       Alcotest.test_case "ascii caret unmoved" `Quick ascii_caret_unmoved;
       Alcotest.test_case "caret marks the line it points at" `Quick
         caret_marks_the_line_it_points_at;
+      Alcotest.test_case "value span marks the rejected value" `Quick
+        value_span_marks_the_rejected_value;
     ] )


### PR DESCRIPTION
A parse warning marked the token after the offending value, so `color: nope` pointed the caret at the `;` and `color: nope red` pointed it at `red`. Thirty-four properties read that way, consuming a token before judging it, where the correct readers peek first. A second defect rode along: `expected one of` was raised where every alternative had already failed, so it opened a list of accepted forms and named none.