### PR TITLE
test: share the allocation-guard measure helper

### DIFF
--- a/test/helpers/css_test_helpers.ml
+++ b/test/helpers/css_test_helpers.ml
@@ -202,3 +202,11 @@ let check_construct name to_string expected value =
 
 (** Common CSS-wide keywords *)
 let css_wide_keywords = [ "inherit"; "unset"; "revert"; "revert-layer" ]
+
+(** Minor words allocated by a thunk, for the allocation guards *)
+let measure f =
+  Gc.full_major ();
+  let w0 = Gc.minor_words () in
+  let r = f () in
+  ignore (Sys.opaque_identity r);
+  Gc.minor_words () -. w0

--- a/test/helpers/css_test_helpers.mli
+++ b/test/helpers/css_test_helpers.mli
@@ -101,3 +101,13 @@ val check_construct : string -> ('a -> string) -> string -> 'a -> unit
 val css_wide_keywords : string list
 (** [css_wide_keywords] is the list of common CSS-wide keywords used across CSS
     specifications. *)
+
+val measure : (unit -> 'a) -> float
+(** [measure f] is the minor words [f] allocates, read as the difference of a
+    counter that only grows, so a collection inside [f] does not disturb it.
+    [Gc.full_major] starts every reading from the same heap state, so collection
+    and finalisation owed by an earlier case is not charged to whichever thunk
+    runs next; the allocation guards compare two readings as a ratio, which
+    holds only if both were taken alike. [Sys.opaque_identity] keeps the result
+    live to the end of the call, so the compiler cannot satisfy a guard by
+    deleting the allocation it counts. *)

--- a/test/test_block.ml
+++ b/test/test_block.ml
@@ -1,4 +1,5 @@
 open Cascade
+open Css_test_helpers
 
 let block css =
   match Css.of_string css with
@@ -264,13 +265,6 @@ let test_merge_media_joins_two_spellings_of_one_bound () =
     "two spellings of one bound merge into one block" 1 (List.length merged)
 
 (* --- allocation / complexity guard --- *)
-
-let measure f =
-  Gc.full_major ();
-  let w0 = Gc.minor_words () in
-  let r = f () in
-  ignore (Sys.opaque_identity r);
-  Gc.minor_words () -. w0
 
 (* [n] plain rules with one [@media print] block at each end, so the pass has
    exactly one merge to make and [n] statements to carry while it looks for the

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -1,6 +1,7 @@
 (** Common helper tests. *)
 
 open Cascade
+open Css_test_helpers
 module L = Common.List
 
 let ref_int = Alcotest.testable (fun p r -> Fmt.int p !r) ( == )
@@ -74,13 +75,6 @@ let test_filter_map_preserve_keeps_noop_identity () =
   Alcotest.(check int) "replacement length" 3 (L.length replaced)
 
 (* --- allocation guard --- *)
-
-let measure f =
-  Gc.full_major ();
-  let w0 = Gc.minor_words () in
-  let r = f () in
-  ignore (Sys.opaque_identity r);
-  Gc.minor_words () -. w0
 
 (* The string shapes a stylesheet hashes: an empty name, a short ident, a
    hyphenated property, a long custom property, a value with punctuation, and a

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -1,4 +1,5 @@
 open Cascade
+open Css_test_helpers
 
 let parse s = Css.of_string_exn ~strict:false s
 let minified css = Css.to_string ~minify:true css
@@ -793,13 +794,6 @@ let test_inline_vars_liveness_propagates_through_scopes () =
     (holds_substring "--dead" out)
 
 (* --- allocation / complexity guard --- *)
-
-let measure f =
-  Gc.full_major ();
-  let w0 = Gc.minor_words () in
-  let r = f () in
-  ignore (Sys.opaque_identity r);
-  Gc.minor_words () -. w0
 
 (* [depth] nested [@media print] blocks around one rule that declares and reads
    a single custom property. The variable count, the scope count and the

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -817,11 +817,7 @@ let test_nested_media_merge_is_linear () =
     | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
   in
   let measure stylesheet =
-    Gc.full_major ();
-    let before = Gc.minor_words () in
-    let result = Css.optimize stylesheet in
-    ignore (Sys.opaque_identity result);
-    Gc.minor_words () -. before
+    Css_test_helpers.measure (fun () -> Css.optimize stylesheet)
   in
   let small_words = measure (sheet 256) in
   let large_words = measure (sheet 512) in

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -1,6 +1,7 @@
 (** Tests for the CSS Syntax Level 3 section 5 parser algorithms. *)
 
 open Cascade
+open Css_test_helpers
 
 (* Shorthand constructors mirroring Parser.component_value so test data is
    readable. *)
@@ -1481,13 +1482,6 @@ let spec_comment_recovery_edges () =
   Alcotest.(check int) "one rule after hidden brace" 1 (List.length rs)
 
 (* --- allocation guard --- *)
-
-let measure f =
-  Gc.full_major ();
-  let w0 = Gc.minor_words () in
-  let r = f () in
-  ignore (Sys.opaque_identity r);
-  Gc.minor_words () -. w0
 
 let alloc_tokens = 500
 

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -1,4 +1,5 @@
 open Cascade
+open Css_test_helpers
 
 (* A minimal in-memory element tree to exercise {!Resolve.Make} without a
    DOM. *)
@@ -690,13 +691,6 @@ let test_apply_compute () =
   Alcotest.(check bool) "kept css is non-empty" true (result.keep_css <> "")
 
 (* --- allocation / complexity guard --- *)
-
-let measure f =
-  Gc.full_major ();
-  let w0 = Gc.minor_words () in
-  let r = f () in
-  ignore (Sys.opaque_identity r);
-  Gc.minor_words () -. w0
 
 let sheet_of_size n =
   let b = Buffer.create ((n * 20) + 32) in

--- a/test/test_rule.ml
+++ b/test/test_rule.ml
@@ -1,4 +1,5 @@
 open Cascade
+open Css_test_helpers
 
 let rules css =
   match Css.of_string css with
@@ -63,13 +64,6 @@ let disjoint_property_run n =
     Fmt.pf formatter ".a{p%d:0}" i
   done;
   rules (Buffer.contents buffer)
-
-let measure f =
-  Gc.full_major ();
-  let w0 = Gc.minor_words () in
-  let r = f () in
-  ignore (Sys.opaque_identity r);
-  Gc.minor_words () -. w0
 
 (* A rule's property should be looked up in the later writes for its selector,
    not compared with every declaration written by every later rule. Counting

--- a/test/test_rule_candidate.ml
+++ b/test/test_rule_candidate.ml
@@ -1,4 +1,5 @@
 open Cascade
+open Css_test_helpers
 
 let rules css =
   match Css.of_string ~strict:false css with
@@ -231,13 +232,6 @@ let nested_merge_safety_reads_each_block_once () =
     (b = 0. || a < b *. 3.)
 
 (* --- allocation / complexity guards --- *)
-
-let measure f =
-  Gc.full_major ();
-  let w0 = Gc.minor_words () in
-  let r = f () in
-  ignore (Sys.opaque_identity r);
-  Gc.minor_words () -. w0
 
 (* [members] rules that write the same [props] custom properties, each differing
    on one of them, is the densest shape the default-value search sees: every

--- a/test/test_rule_graph.ml
+++ b/test/test_rule_graph.ml
@@ -1,6 +1,7 @@
 (** Graph invariants for the cascade-dependency rule ordering. *)
 
 open Cascade
+open Css_test_helpers
 
 let parse s =
   match Css.of_string ~strict:false s with
@@ -357,13 +358,6 @@ let declaration_body_key_buckets () =
     = Rule_graph.declaration_body_key g (nid 2))
 
 (* --- allocation / complexity guards --- *)
-
-let measure f =
-  Gc.full_major ();
-  let w0 = Gc.minor_words () in
-  let r = f () in
-  ignore (Sys.opaque_identity r);
-  Gc.minor_words () -. w0
 
 (* [n] rules on the same selector and property form a dense (all-pairs) conflict
    graph - the worst case for edge construction and topological ordering. *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -10507,13 +10507,6 @@ let render_sheet n =
   Fmt.flush out ();
   Css.of_string_exn (Buffer.contents b)
 
-let measure f =
-  Gc.full_major ();
-  let w0 = Gc.minor_words () in
-  let r = f () in
-  ignore (Sys.opaque_identity r);
-  Gc.minor_words () -. w0
-
 (* A serialiser walks the tree once. Presizing the buffer from a [Pp.size]
    prepass walks it a second time, and the counter sink skips only the output
    bytes: [normalise], [printable_statements] and every printer below them run


### PR DESCRIPTION
Ten test files each carried a byte-identical `measure`, the `Gc.full_major` / `minor_words` / `opaque_identity` harness the allocation guards read their ratios from, so a change to that protocol would have landed in one file of ten. It moves to `test/helpers/`, which exists for exactly this; no call site and no assertion changes.