### PR TITLE
values: keep the time unit of a fallback nested in calc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -518,6 +518,9 @@ difference wherever the two are not equivalent.
 
 ### Minification
 
+- `--minify` keeps the authored time unit of a `var()` fallback nested inside a
+  `calc()`, as it already did for the operand beside it. The two spellings
+  printed alike and stopped factoring (#803)
 - `--minify` keeps a vendor-prefixed gradient written with the `background`,
   `mask`, `border-image` or `mask-border` shorthand, as it already did for the
   longhand. Canonical diff had reported two sheets differing only there as

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4840,7 +4840,8 @@ let pp_specified_color = pp_color_default
 (* CSS Values 4 sec. 7.2: [ms] and [s] are interchangeable. Pure minified
    serialization picks the shorter exact leaf spelling as a fallback for callers
    that deliberately skip AST normalization. [shorten_ms:false] keeps the unit
-   where its surrounding grammar asks for source-unit fidelity. *)
+   wherever the normalization would not have converted it either: a [calc()]
+   operand, and the [interest-delay] grammar. *)
 let pp_duration_unit ?(shorten_ms = true) ctx f suffix =
   if f = 0. then
     if Pp.minified ctx then Pp.string ctx "0s" else pp_unit ctx f suffix
@@ -4857,98 +4858,52 @@ let pp_duration_unit ?(shorten_ms = true) ctx f suffix =
       Pp.string ctx ms;
       Pp.string ctx "ms")
 
-let rec pp_duration : duration Pp.t =
+let rec pp_duration_with ~shorten_ms : duration Pp.t =
  fun ctx -> function
-  | Ms f -> pp_duration_unit ctx f "ms"
+  | Ms f -> pp_duration_unit ~shorten_ms ctx f "ms"
   | S f -> pp_duration_unit ctx f "s"
-  | Durations durations -> Pp.list ~sep:Pp.comma pp_duration ctx durations
+  | Durations durations ->
+      Pp.list ~sep:Pp.comma (pp_duration_with ~shorten_ms) ctx durations
   | Round (strategy, value, step) ->
       Pp.call "round"
         (fun ctx (strategy, value, step) ->
           if strategy <> "nearest" then (
             Pp.string ctx strategy;
             Pp.comma ctx ());
-          pp_duration ctx value;
+          pp_duration_with ~shorten_ms ctx value;
           Pp.comma ctx ();
-          pp_duration ctx step)
+          pp_duration_with ~shorten_ms ctx step)
         ctx (strategy, value, step)
   | Rem (a, b) ->
       Pp.call "rem"
         (fun ctx (a, b) ->
-          pp_duration ctx a;
+          pp_duration_with ~shorten_ms ctx a;
           Pp.comma ctx ();
-          pp_duration ctx b)
+          pp_duration_with ~shorten_ms ctx b)
         ctx (a, b)
   | Mod (a, b) ->
       Pp.call "mod"
         (fun ctx (a, b) ->
-          pp_duration ctx a;
+          pp_duration_with ~shorten_ms ctx a;
           Pp.comma ctx ();
-          pp_duration ctx b)
+          pp_duration_with ~shorten_ms ctx b)
         ctx (a, b)
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
-  | Var v -> pp_var pp_duration ctx v
-  | Calc c -> pp_calc_with ~unwrap_num:false pp_duration_in_calc ctx c
+  | Var v -> pp_var (pp_duration_with ~shorten_ms) ctx v
+  (* [normalize_duration] canonicalises a typed [<time>] but folds a [calc()]
+     only when it computes one, so the operands of a [calc()] that reaches the
+     output stay as authored - a [var()] fallback among them. Shortening one
+     here would print two unequal declarations alike and lose them a
+     factoring. *)
+  | Calc c ->
+      pp_calc_with ~unwrap_num:false (pp_duration_with ~shorten_ms:false) ctx c
 
-and pp_duration_in_calc : duration Pp.t =
- fun ctx -> function
-  | Ms f -> pp_duration_unit ~shorten_ms:false ctx f "ms"
-  | S f -> pp_duration_unit ctx f "s"
-  | Durations durations ->
-      Pp.list ~sep:Pp.comma pp_duration_in_calc ctx durations
-  | Round (strategy, value, step) ->
-      pp_duration_preserve_ms ctx (Round (strategy, value, step))
-  | Rem (a, b) -> pp_duration_preserve_ms ctx (Rem (a, b))
-  | Mod (a, b) -> pp_duration_preserve_ms ctx (Mod (a, b))
-  | Inherit -> Pp.string ctx "inherit"
-  | Initial -> Pp.string ctx "initial"
-  | Unset -> Pp.string ctx "unset"
-  | Revert -> Pp.string ctx "revert"
-  | Revert_layer -> Pp.string ctx "revert-layer"
-  | Var v -> pp_var pp_duration ctx v
-  | Calc c -> pp_calc_with ~unwrap_num:false pp_duration_in_calc ctx c
-
-and pp_duration_preserve_ms : duration Pp.t =
- fun ctx -> function
-  | Ms f -> pp_duration_unit ~shorten_ms:false ctx f "ms"
-  | S f -> pp_duration_unit ctx f "s"
-  | Durations durations ->
-      Pp.list ~sep:Pp.comma pp_duration_preserve_ms ctx durations
-  | Round (strategy, value, step) ->
-      Pp.call "round"
-        (fun ctx (strategy, value, step) ->
-          if strategy <> "nearest" then (
-            Pp.string ctx strategy;
-            Pp.comma ctx ());
-          pp_duration_preserve_ms ctx value;
-          Pp.comma ctx ();
-          pp_duration_preserve_ms ctx step)
-        ctx (strategy, value, step)
-  | Rem (a, b) ->
-      Pp.call "rem"
-        (fun ctx (a, b) ->
-          pp_duration_preserve_ms ctx a;
-          Pp.comma ctx ();
-          pp_duration_preserve_ms ctx b)
-        ctx (a, b)
-  | Mod (a, b) ->
-      Pp.call "mod"
-        (fun ctx (a, b) ->
-          pp_duration_preserve_ms ctx a;
-          Pp.comma ctx ();
-          pp_duration_preserve_ms ctx b)
-        ctx (a, b)
-  | Inherit -> Pp.string ctx "inherit"
-  | Initial -> Pp.string ctx "initial"
-  | Unset -> Pp.string ctx "unset"
-  | Revert -> Pp.string ctx "revert"
-  | Revert_layer -> Pp.string ctx "revert-layer"
-  | Var v -> pp_var pp_duration_preserve_ms ctx v
-  | Calc c -> pp_calc_with ~unwrap_num:false pp_duration_in_calc ctx c
+let pp_duration : duration Pp.t = pp_duration_with ~shorten_ms:true
+let pp_duration_preserve_ms : duration Pp.t = pp_duration_with ~shorten_ms:false
 
 let rec pp_number : number Pp.t =
  fun ctx -> function

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -224,7 +224,9 @@ val angle_degrees_opt : angle -> float option
     angles such as [calc()] and [var()] return [None]. *)
 
 val pp_duration : duration Pp.t
-(** [pp_duration] pretty-prints {!duration} values. *)
+(** [pp_duration] pretty-prints {!duration} values. Minified output shortens a
+    millisecond leaf to seconds where that is exact and no longer, except inside
+    a [calc()], whose operands {!normalize_duration} leaves as authored. *)
 
 val pp_duration_preserve_ms : duration Pp.t
 (** [pp_duration_preserve_ms] pretty-prints {!duration} values without

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1953,6 +1953,31 @@ let animations_timing () =
     "transition-duration:var(--d,500ms)";
   check_declaration ~expected:"interest-delay:round(1100ms,500ms)"
     ~optimized:"interest-delay:1000ms" "interest-delay:round(1100ms,500ms)";
+  (* CSS Values 4 sec. 7.2: [ms] and [s] are interchangeable, and the shorter
+     spelling is picked by the AST normalisation, which canonicalises a typed
+     [<time>] - a [round()] operand, a [var()] fallback - but leaves the
+     operands of a [calc()] that survives to the output as authored. The printer
+     mirrors that split at every depth, so a fallback nested inside a [calc()]
+     keeps its unit exactly like the operand beside it: two declarations that
+     print alike must be structurally alike. *)
+  check_declaration ~expected:"transition-duration:calc(var(--d,1000ms))"
+    ~optimized:"transition-duration:calc(var(--d,1000ms))"
+    "transition-duration:calc(var(--d,1000ms))";
+  check_declaration
+    ~expected:"transition-duration:calc(var(--a,var(--b,1000ms)))"
+    ~optimized:"transition-duration:calc(var(--a,var(--b,1000ms)))"
+    "transition-duration:calc(var(--a,var(--b,1000ms)))";
+  check_declaration ~expected:"transition-duration:calc(var(--x) + 1500ms)"
+    ~optimized:"transition-duration:calc(var(--x) + 1500ms)"
+    "transition-duration:calc(var(--x) + 1500ms)";
+  check_declaration ~expected:"transition-duration:round(var(--d,1s),1s)"
+    ~optimized:"transition-duration:round(var(--d,1s),1s)"
+    "transition-duration:round(var(--d,1000ms),1s)";
+  (* [interest-delay] keeps authored milliseconds for its own operands, so a
+     fallback nested in one of its [calc()] operands keeps them too. *)
+  check_declaration ~expected:"interest-delay:calc(var(--a,var(--b,1000ms)))"
+    ~optimized:"interest-delay:calc(var(--a,var(--b,1000ms)))"
+    "interest-delay:calc(var(--a,var(--b,1000ms)))";
   let c = Cursor.of_string "transition-delay:bogus" in
   match read_declaration c with
   | exception


### PR DESCRIPTION
Three near-copies of the duration printer disagreed on one arm: the one written to preserve `ms` inside `calc()` recursed into the one that shortens it, so a `var()` fallback nested a level deeper lost its unit. Two rules could then render byte-identical while their ASTs differed, which is the canonicalisation bug `lib/shorthand.ml:3625` names. The three collapse into one printer parameterised on that choice.