### PR TITLE
container: parse a style() range comparison

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -180,6 +180,9 @@ difference wherever the two are not equivalent.
 
 ### Parsing
 
+- A `style()` container query takes the single-comparison range CSS Conditional
+  Rules 5 defines, `style(--gap = 10px)` included, and rejects an interval whose
+  two bounds point different ways; `Css.inline_vars` reads its operands (#805)
 - A parse warning whose value matched none of a property's forms says so,
   in place of a reason that opened a list of accepted forms and named
   none of them (#801)

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -23,15 +23,21 @@ and style_query =
   | Any of style_query * style_query
   | Neg of style_query
 
-and style_range = {
-  lower : component_values;
-  lower_op : range_operator;
-  name : string;
-  upper_op : range_operator;
-  upper : component_values;
-}
+and style_range =
+  | Compare of {
+      left : component_values;
+      op : range_operator;
+      right : component_values;
+    }
+  | Interval of {
+      lower : component_values;
+      lower_op : range_operator;
+      name : string;
+      upper_op : range_operator;
+      upper : component_values;
+    }
 
-and range_operator = Lt | Lte | Gt | Gte
+and range_operator = Lt | Lte | Eq | Gt | Gte
 
 and scroll_state_query =
   | State of { name : string; value : string }
@@ -50,6 +56,7 @@ let string_of_components cvs = Cursor.string_of_components ~trim:true cvs
 let string_of_range_operator = function
   | Lt -> "<"
   | Lte -> "<="
+  | Eq -> "="
   | Gt -> ">"
   | Gte -> ">="
 
@@ -62,20 +69,32 @@ let rec string_of_style_query ~minify = function
       let sep = if minify then ":" else ": " in
       String.concat ""
         [ Parser.escape_ident name; sep; string_of_components value ]
-  | Range { lower; lower_op; name; upper_op; upper } ->
+  | Range range ->
       let sep = if minify then "" else " " in
-      String.concat ""
-        [
-          string_of_components lower;
-          sep;
-          string_of_range_operator lower_op;
-          sep;
-          Parser.escape_ident name;
-          sep;
-          string_of_range_operator upper_op;
-          sep;
-          string_of_components upper;
-        ]
+      let parts =
+        match range with
+        | Compare { left; op; right } ->
+            [
+              string_of_components left;
+              sep;
+              string_of_range_operator op;
+              sep;
+              string_of_components right;
+            ]
+        | Interval { lower; lower_op; name; upper_op; upper } ->
+            [
+              string_of_components lower;
+              sep;
+              string_of_range_operator lower_op;
+              sep;
+              Parser.escape_ident name;
+              sep;
+              string_of_range_operator upper_op;
+              sep;
+              string_of_components upper;
+            ]
+      in
+      String.concat "" parts
   | All (a, b) ->
       String.concat ""
         [
@@ -194,19 +213,34 @@ let style_query_rank = function
 
 let compare_values (a : component_values) b = List.compare Component.compare a b
 let compare_range_operator (a : range_operator) b = Stdlib.compare a b
+let style_range_rank = function Compare _ -> 0 | Interval _ -> 1
+
+let rec first_difference = function
+  | [] -> 0
+  | field :: rest ->
+      let c = field () in
+      if c <> 0 then c else first_difference rest
 
 let compare_style_range (r1 : style_range) (r2 : style_range) =
-  let c = String.compare r1.name r2.name in
-  if c <> 0 then c
-  else
-    let c = compare_range_operator r1.lower_op r2.lower_op in
-    if c <> 0 then c
-    else
-      let c = compare_range_operator r1.upper_op r2.upper_op in
-      if c <> 0 then c
-      else
-        let c = compare_values r1.lower r2.lower in
-        if c <> 0 then c else compare_values r1.upper r2.upper
+  match (r1, r2) with
+  | Compare c1, Compare c2 ->
+      first_difference
+        [
+          (fun () -> compare_range_operator c1.op c2.op);
+          (fun () -> compare_values c1.left c2.left);
+          (fun () -> compare_values c1.right c2.right);
+        ]
+  | Interval i1, Interval i2 ->
+      first_difference
+        [
+          (fun () -> String.compare i1.name i2.name);
+          (fun () -> compare_range_operator i1.lower_op i2.lower_op);
+          (fun () -> compare_range_operator i1.upper_op i2.upper_op);
+          (fun () -> compare_values i1.lower i2.lower);
+          (fun () -> compare_values i1.upper i2.upper);
+        ]
+  | (Compare _ | Interval _), _ ->
+      Int.compare (style_range_rank r1) (style_range_rank r2)
 
 let rec compare_style_query q1 q2 =
   match (q1, q2) with
@@ -389,6 +423,12 @@ let style_strip_ws =
     | Component.Preserved { kind = Token.Whitespace; _ } -> false
     | _ -> true)
 
+(* CSS Conditional Rules 5 sec. 5.4 builds <style-range> out of <mf-comparison>
+   and <mf-lt> / <mf-gt>, and Media Queries 4 sec. 3 spells those [<mf-lt> = '<'
+   '='?], [<mf-gt> = '>' '='?], [<mf-eq> = '='] and [<mf-comparison> = <mf-lt> |
+   <mf-gt> | <mf-eq>]. So a bare [=] is a style range operator exactly as it is
+   a media feature one, and [same_direction] is what keeps it out of the two
+   interval branches, which take <mf-lt> twice or <mf-gt> twice. *)
 let take_range_operator = function
   | Component.Preserved { kind = Token.Delim "<"; _ }
     :: Component.Preserved { kind = Token.Delim "="; _ }
@@ -400,7 +440,13 @@ let take_range_operator = function
       Some (Gte, rest)
   | Component.Preserved { kind = Token.Delim "<"; _ } :: rest -> Some (Lt, rest)
   | Component.Preserved { kind = Token.Delim ">"; _ } :: rest -> Some (Gt, rest)
+  | Component.Preserved { kind = Token.Delim "="; _ } :: rest -> Some (Eq, rest)
   | _ -> None
+
+let same_direction lower_op upper_op =
+  match (lower_op, upper_op) with
+  | (Lt | Lte), (Lt | Lte) | (Gt | Gte), (Gt | Gte) -> true
+  | (Lt | Lte | Eq | Gt | Gte), _ -> false
 
 let split_before_range_operator cvs =
   let rec loop before rest =
@@ -411,15 +457,27 @@ let split_before_range_operator cvs =
   in
   loop [] cvs
 
+let style_interval lower lower_op middle upper_op upper =
+  match middle with
+  | [ prop ] -> (
+      match ident_component prop with
+      | Some name
+        when is_custom_property name && upper <> []
+             && same_direction lower_op upper_op ->
+          Some (Range (Interval { lower; lower_op; name; upper_op; upper }))
+      | Some _ | None -> None)
+  | _ -> None
+
 let style_range_query cvs =
   match split_before_range_operator (style_strip_ws cvs) with
-  | Some (lower, lower_op, prop :: rest) when lower <> [] -> (
-      match (ident_component prop, split_before_range_operator rest) with
-      | Some name, Some ([], upper_op, upper)
-        when is_custom_property name && upper <> [] ->
-          Some (Range { lower; lower_op; name; upper_op; upper })
-      | _ -> None)
-  | _ -> None
+  | Some (left, op, rest) when left <> [] -> (
+      match split_before_range_operator rest with
+      | None ->
+          if rest = [] then None
+          else Some (Range (Compare { left; op; right = rest }))
+      | Some (middle, upper_op, upper) ->
+          style_interval left op middle upper_op upper)
+  | Some _ | None -> None
 
 (* Every failure below is an [@container] prelude failure, and the slice of the
    query that failed carries the span the caret must point at. [t] anchors the
@@ -885,15 +943,22 @@ let equal_components (a : component_values) b = List.equal Component.equal a b
 
 let equal_range_operator (a : range_operator) b =
   match (a, b) with
-  | Lt, Lt | Lte, Lte | Gt, Gt | Gte, Gte -> true
-  | (Lt | Lte | Gt | Gte), _ -> false
+  | Lt, Lt | Lte, Lte | Eq, Eq | Gt, Gt | Gte, Gte -> true
+  | (Lt | Lte | Eq | Gt | Gte), _ -> false
 
 let equal_style_range (a : style_range) b =
-  String.equal a.name b.name
-  && equal_range_operator a.lower_op b.lower_op
-  && equal_range_operator a.upper_op b.upper_op
-  && equal_components a.lower b.lower
-  && equal_components a.upper b.upper
+  match (a, b) with
+  | Compare a, Compare b ->
+      equal_range_operator a.op b.op
+      && equal_components a.left b.left
+      && equal_components a.right b.right
+  | Interval a, Interval b ->
+      String.equal a.name b.name
+      && equal_range_operator a.lower_op b.lower_op
+      && equal_range_operator a.upper_op b.upper_op
+      && equal_components a.lower b.lower
+      && equal_components a.upper b.upper
+  | (Compare _ | Interval _), _ -> false
 
 let rec equal_style_query (a : style_query) b =
   match (a, b) with

--- a/lib/container.mli
+++ b/lib/container.mli
@@ -42,15 +42,25 @@ and style_query =
   | Any of style_query * style_query
   | Neg of style_query
 
-and style_range = {
-  lower : component_values;
-  lower_op : range_operator;
-  name : string;
-  upper_op : range_operator;
-  upper : component_values;
-}
+and style_range =
+  | Compare of {
+      left : component_values;
+      op : range_operator;
+      right : component_values;
+    }
+      (** A single comparison, [style(--gap = 10px)] or [style(10px < --gap)].
+          Either operand may name the custom property. *)
+  | Interval of {
+      lower : component_values;
+      lower_op : range_operator;
+      name : string;
+      upper_op : range_operator;
+      upper : component_values;
+    }
+      (** A two-sided interval, [style(10px <= --gap < 20px)]. Both bounds point
+          the same way. *)
 
-and range_operator = Lt | Lte | Gt | Gte
+and range_operator = Lt | Lte | Eq | Gt | Gte
 
 and scroll_state_query =
   | State of { name : string; value : string }

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -929,6 +929,26 @@ let rec refs_of_supports : Supports.t -> string list = function
 let refs_of_queried_name name =
   if Custom_property_name.is_valid name then [ name ] else []
 
+(* CSS Conditional 5 sec. 6.2: a <style-range-value> that is a
+   <custom-property-name> is substituted as if it were wrapped in a var(), so a
+   bare [--gap] operand reads that property just as [var(--gap)] would. *)
+let refs_of_style_range_value value =
+  let named =
+    match trim_components value with
+    | [ Component.Preserved { kind = Token.Ident name; _ } ] ->
+        refs_of_queried_name name
+    | _ -> []
+  in
+  named @ refs_of_components value
+
+let refs_of_style_range : Container.style_range -> string list = function
+  | Compare { left; right; _ } ->
+      refs_of_style_range_value left @ refs_of_style_range_value right
+  | Interval { lower; name; upper; _ } ->
+      refs_of_queried_name name
+      @ refs_of_style_range_value lower
+      @ refs_of_style_range_value upper
+
 (* CSS Conditional 5 sec. 6.2: a [style()] query is evaluated against the
    computed value the queried property has on the query container, its boolean
    form against that property's initial value. The queried name is therefore a
@@ -938,9 +958,7 @@ let rec refs_of_style_query : Container.style_query -> string list = function
   | Boolean name -> refs_of_queried_name name
   | Declaration { name; value } ->
       refs_of_queried_name name @ refs_of_components value
-  | Range { lower; name; upper; _ } ->
-      refs_of_queried_name name @ refs_of_components lower
-      @ refs_of_components upper
+  | Range range -> refs_of_style_range range
   | All (a, b) | Any (a, b) -> refs_of_style_query a @ refs_of_style_query b
   | Neg query -> refs_of_style_query query
 

--- a/test/spec/inventory/query_grammar.ml
+++ b/test/spec/inventory/query_grammar.ml
@@ -213,6 +213,11 @@ let container_positive =
       "style(--theme: dark)";
     row "style range" "style(10px <= --gap < 20px)"
       "style(10px <= --gap < 20px)";
+    row "style range equality" "style(--gap = 10px)" "style(--gap = 10px)";
+    row "style range name-first comparison" "style(--gap > 10px)"
+      "style(--gap > 10px)";
+    row "style range value-first comparison" "style(10px < --gap)"
+      "style(10px < --gap)";
     row "style uppercase function" "STYLE(--theme: dark)" "STYLE(--theme: dark)";
     row "scroll-state stuck" "scroll-state(stuck: top)"
       "scroll-state(stuck: top)";
@@ -270,6 +275,8 @@ let container_negative =
     invalid "not not query" "not not (width)";
     invalid "missing range value" "(width >)";
     invalid "opposing interval operators" "(30em < inline-size > 60em)";
+    invalid "equality bound in a style interval" "style(10px = --gap = 20px)";
+    invalid "opposing style interval operators" "style(10px < --gap > 20px)";
   ]
 
 let mutate_invalid (row : row) salt =

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -358,6 +358,38 @@ let equal_on_opaque_conditions () =
     "an opaque condition does not equal a different one" false
     (equal opaque (of_string "theme(dynamic)"))
 
+(* Conditional Rules 5 sec. 5.4 gives <style-range> a single-comparison branch,
+   [<style-range-value> <mf-comparison> <style-range-value>], alongside the two
+   interval branches. Media Queries 4 sec. 3 spells [<mf-comparison> = <mf-lt> |
+   <mf-gt> | <mf-eq>] with [<mf-eq> = '='], so [=] is a style range operator
+   just as it is a size one. *)
+let spec_style_range_comparison () =
+  let open Css.Container in
+  let round_trips name input =
+    Alcotest.(check string) name input (to_string (of_string input))
+  in
+  round_trips "equality" "style(--gap = 10px)";
+  round_trips "value-first equality" "style(10px = --gap)";
+  round_trips "name-first strict" "style(--gap > 10px)";
+  round_trips "name-first inclusive" "style(--gap <= 10px)";
+  round_trips "value-first strict" "style(10px < --gap)";
+  Alcotest.(check string)
+    "the minified spelling drops the spaces" "style(--gap=10px)"
+    (to_string ~minify:true (of_string "style(--gap = 10px)"));
+  Alcotest.(check bool)
+    "the minified spelling reparses to the same query" true
+    (equal
+       (of_string "style(--gap = 10px)")
+       (of_string (to_string ~minify:true (of_string "style(--gap = 10px)"))));
+  Alcotest.(check bool)
+    "the operator is part of the query" false
+    (equal (of_string "style(--gap = 10px)") (of_string "style(--gap > 10px)"));
+  (* [<mf-eq>] reaches <style-range> only through <mf-comparison>, and the two
+     interval branches take [<mf-lt>] twice or [<mf-gt>] twice. So neither an
+     [=] bound nor a pair of opposing bounds is a <style-range>. *)
+  rejects_invalid "style(10px = --gap = 20px)";
+  rejects_invalid "style(10px < --gap > 20px)"
+
 (* A normal form is already normal, and it is still the query it came from:
    reparsing what [normalize] printed lands back on the same normal form. *)
 let normalize_is_idempotent () =
@@ -421,6 +453,7 @@ let tests =
       test_case "equal ignores function spelling" `Quick
         equal_ignores_function_spelling;
       test_case "equal on opaque conditions" `Quick equal_on_opaque_conditions;
+      test_case "spec style range comparison" `Quick spec_style_range_comparison;
       test_case "normalize is idempotent" `Quick normalize_is_idempotent;
     ]
 

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -673,6 +673,15 @@ let test_inline_style_query_keeps_queried_property () =
   check_inline_case "a range style() query keeps the property it bounds"
     ":root{--n:5}@container style(3 < --n < 10){.z{color:green}}"
     ":root{--n:5}@container style(3<--n<10){.z{color:green}}";
+  (* Conditional Rules 5 sec. 6.2: a <style-range-value> that is a
+     <custom-property-name> is substituted as if it were wrapped in a var(), so
+     an operand spelled as a custom property is read like the bounded one. *)
+  check_inline_case "a range style() query keeps the property bounding it"
+    ":root{--lo:3;--n:5}@container style(--lo < --n < 10){.z{color:green}}"
+    ":root{--lo:3;--n:5}@container style(--lo<--n<10){.z{color:green}}";
+  check_inline_case "a comparison style() query keeps both properties it reads"
+    ":root{--hi:9;--n:5}@container style(--n = --hi){.z{color:green}}"
+    ":root{--hi:9;--n:5}@container style(--n=--hi){.z{color:green}}";
   check_inline_case "both sides of a combined style() query stay live"
     ":root{--a:red;--b:blue}@container style(--a: red) and style(--b: \
      blue){.z{color:green}}"


### PR DESCRIPTION
`@container style(--x = 15)` was rejected, and so were `style(--x > 10)` and every other single-comparison form: only the two-sided interval was implemented. CSS Conditional 5 section 5.4 gives `<style-range>` a `<mf-comparison>` branch, which Media Queries 4 section 3 defines as `<mf-lt> | <mf-gt> | <mf-eq>`, and Chrome matches all of them. The opposing interval `style(10 < --x > 20)` was accepted and is now rejected, as Chrome rejects it.