### PR TITLE
parser: drop to_string_custom, a second binding of one body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@ difference wherever the two are not equivalent.
 
 ### Breaking
 
+- `Cascade.Parser.to_string_custom` is gone. It was a second binding of the
+  same body as `Cascade.Parser.string_of_components`, which renders a
+  custom-property token stream identically; call that instead (#806)
 - `cascade` requires `cmdliner >= 2.0.0`, the release that stops `Arg.file`
   checking a `-` argument for existence, which is what lets either side of
   `cascade diff` name standard input (#796)

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -759,15 +759,6 @@ let to_string_minified cvs = to_string_minified_with ~minify_numbers:false cvs
 let to_string_minified_numbers cvs =
   to_string_minified_with ~minify_numbers:true cvs
 
-let to_string_custom cvs =
-  let buf = Buffer.create 64 in
-  cvs_to_buffer buf cvs;
-  Buffer.contents buf
-
-(* Custom-property values are opaque token streams (CSS Custom Properties 1), so
-   [to_string_custom] keeps authored whitespace. This minified rendering is for
-   canonical output only: collapse optional whitespace in blocks and function
-   args while preserving token boundaries. *)
 let url_string_can_unquote s =
   not
     (String.exists
@@ -946,6 +937,10 @@ and cvs_to_buffer_min_custom ~fold_ident ~in_math buf cvs =
   in
   loop None false false cvs
 
+(* Custom-property values are opaque token streams (CSS Custom Properties 1), so
+   [string_of_components] keeps every optional whitespace token. This minified
+   rendering is for canonical output only: collapse optional whitespace in
+   blocks and function args while preserving token boundaries. *)
 let to_string_custom_minified ?(fold_ident = fold_value_ident) cvs =
   if cvs <> [] && List.for_all is_whitespace cvs then " "
   else

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -35,8 +35,13 @@ val reconsume : t -> Component.t -> unit
 
 val string_of_components : Component.t list -> string
 (** [string_of_components cvs] renders a component-value list back to source
-    text. Whitespace tokens serialize to a single space; the output is
-    parse-equivalent but not byte-identical. *)
+    text that re-tokenizes to the same stream, as CSS Syntax 3 (ED) section 9.1
+    requires. A [<whitespace-token>] is a whole run of whitespace carrying no
+    text, so authored whitespace comes back as one space rather than byte for
+    byte, and a space is added wherever two adjacent components would otherwise
+    merge into a single token. This is the whitespace-keeping renderer for every
+    stream, the opaque custom-property values of CSS Custom Properties 1
+    included. *)
 
 val to_string_minified : Component.t list -> string
 (** Like {!string_of_components} but drops whitespace that sits between two
@@ -66,11 +71,6 @@ val is_plus_or_minus_delim : Component.t -> bool
     math function that token is the operator whose whitespace CSS Values 4 (ED)
     section 10.8 requires; a sign written as part of a number ([+2]) lexes as
     one numeric token and is not one of these. *)
-
-val to_string_custom : Component.t list -> string
-(** Variant of {!string_of_components} for CSS Custom Properties Level 1 token
-    streams. Whitespace is preserved at the top level and inside nested blocks
-    and functions. *)
 
 val fold_value_ident : string -> string
 (** [fold_value_ident s] is the canonical lower-case spelling of [s] when [s]

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3267,7 +3267,7 @@ let is_color_function name =
    shortest non-keyword spelling, falling back to [fallback ()] when it does not
    actually parse as a complete colour. *)
 let fold_custom_color ~lossless (c : Component.t) ~fallback =
-  let text = Parser.to_string_custom [ c ] in
+  let text = Parser.string_of_components [ c ] in
   let cur = Cursor.of_string text in
   match
     try Some (Values.read_color cur) with Cursor.Parse_error _ -> None
@@ -3292,7 +3292,7 @@ let is_math_function = Parser.is_math_function
    ambiguous (length vs number percentage) so it stays verbatim, as does a
    function that still references a [var()] (it does not reduce to a leaf). *)
 let fold_custom_calc (c : Component.t) ~fallback =
-  let text = Parser.to_string_custom [ c ] in
+  let text = Parser.string_of_components [ c ] in
   (* Parse the whole token as one typed value and fold only when it reduces to a
      single concrete leaf (not a [calc()] that still carries a [var()]). *)
   let try_typed : type a.
@@ -3348,7 +3348,7 @@ let hue_rotate_zero_argument (func : Component.func) =
   String.lowercase_ascii func.name = "hue-rotate"
   && func.arguments <> []
   &&
-  let cur = Cursor.of_string (Parser.to_string_custom func.arguments) in
+  let cur = Cursor.of_string (Parser.string_of_components func.arguments) in
   match read_angle_unit_required cur with
   | exception Cursor.Parse_error _ -> false
   | angle ->
@@ -3385,7 +3385,7 @@ let rec normalize_shadow_colors ~lossless (shadow : shadow) =
    the full shadow optimiser here would also drop explicit default lengths from
    an otherwise opaque custom-property token stream. *)
 let canonicalize_custom_shadow_components ~lossless components =
-  let t = Cursor.of_string (Parser.to_string_custom components) in
+  let t = Cursor.of_string (Parser.string_of_components components) in
   match try Some (read_shadow t) with Cursor.Parse_error _ -> None with
   | Some shadow when Cursor.is_done t -> (
       let shadow = normalize_shadow_colors ~lossless shadow in
@@ -3516,7 +3516,7 @@ let pp_value : type a. (a kind * a) Pp.t =
         if Pp.minified ctx then
           Parser.to_string_custom_minified
             ~fold_ident:Values.fold_custom_value_ident value
-        else Parser.to_string_custom value
+        else Parser.string_of_components value
       in
       Pp.string ctx rendered
   | Shadow -> pp pp_shadow
@@ -3575,7 +3575,7 @@ let string_of_kind_value : type a. a kind -> a -> string =
   | Number_percentage -> Values.string_of_number_percentage value
   | Number -> Pp.to_string pp_number value
   | Int -> string_of_int value
-  | Value -> Parser.to_string_custom value
+  | Value -> Parser.string_of_components value
   | Content -> (
       match value with
       | String "" -> "\"\""

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -414,7 +414,7 @@ let pp_syntax_fallback ctx value =
     (if Pp.minified ctx then
        Parser.to_string_custom_minified ~fold_ident:fold_custom_value_ident
          value
-     else Parser.to_string_custom value)
+     else Parser.string_of_components value)
 
 let pp_var_ref ctx name =
   pp_var_open ctx name;
@@ -532,7 +532,7 @@ let pp_component_values ctx values =
     if Pp.minified ctx then
       Parser.to_string_custom_minified ~fold_ident:fold_custom_value_ident
         values
-    else Parser.to_string_custom values
+    else Parser.string_of_components values
   in
   Pp.string ctx value
 
@@ -4785,7 +4785,7 @@ and pp_color_var (ctx : Pp.ctx) (v : color var) =
         if Pp.minified ctx then
           Parser.to_string_custom_minified ~fold_ident:fold_custom_value_ident
             value
-        else Parser.to_string_custom value
+        else Parser.string_of_components value
       in
       Pp.string ctx (first_top_level_comma_segment rendered)
   | _ when Pp.minified ctx -> (

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -25,7 +25,7 @@ let custom_value_var_empty_fallback name =
       };
   ]
 
-let string_of_custom_value = Parser.to_string_custom
+let string_of_custom_value = Parser.string_of_components
 
 (* The first dashed-ident argument of a [var()] is the referenced custom
    property; leading whitespace is skipped. *)

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -523,6 +523,17 @@ let spec_list_components_entry () =
   Alcotest.(check string)
     "comments preserve token boundary" "a b"
     (Parser.string_of_components (parse_list "a/*x*/b"));
+  (* Section 4.3.1 consumes a whole run of whitespace into one
+     <whitespace-token> that carries no text, and section 9.1 serializes that
+     token as a single space, so a run comes back as one space rather than byte
+     for byte. This is the only whitespace guarantee the reserializer can make
+     and the one its documentation states. *)
+  Alcotest.(check int)
+    "a whitespace run is one component" 3
+    (List.length (parse_list "a \t\n  b"));
+  Alcotest.(check string)
+    "a whitespace run serializes to one space" "a b"
+    (Parser.string_of_components (parse_list "a \t\n  b"));
   Alcotest.(check string)
     "EOF closes nested blocks and functions" "[a f(b)]"
     (Parser.string_of_components (parse_list "[a f(b"));

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -5403,7 +5403,7 @@ let canonical_math_block_context () =
   let components = Cursor.remaining (Cursor.of_string "calc([f() + 1])") in
   let actual =
     components |> canonicalize_math_whitespace_components
-    |> Parser.to_string_custom
+    |> Parser.string_of_components
   in
   check string "square block ends math context" "calc([f()+ 1])" actual
 


### PR DESCRIPTION
`Parser.string_of_components` and `Parser.to_string_custom` were the same body exported twice, documented as if they differed: one said whitespace serialises to a single space, the other that it is preserved. Neither caller could depend on that difference, because `Token.Whitespace` is nullary and the authored bytes are gone before either function runs. The surviving doc states the guarantee that does hold, that the output re-tokenizes to the same stream with whitespace normalised to one space.

Removing a public function breaks `tw` at `lib/tools/entrypoint.ml:143`, a rename to `Parser.string_of_components`. tw pins cascade main through opam, so that one-liner has to land in the same window as this; it is filed in tw's TODO and waiting on this PR.