### PR TITLE
lib: share eleven helpers written twice or more

### DIFF
--- a/bin/cmd_apply.ml
+++ b/bin/cmd_apply.ml
@@ -22,12 +22,6 @@ let style_node node = function
       Html.set_attribute node "style"
         (Css.inline_style_of_declarations ~minify:true ~mode:Variables decls)
 
-(* Prefix every line of a multi-line diagnostic so a downstream [grep -v
-   "warning"] filters the whole entry, not just the first line. *)
-let report_warning w =
-  Cascade.Error.to_string w |> String.split_on_char '\n'
-  |> List.iter (fun line -> Fmt.epr "warning: %s@." line)
-
 (* [Some sheet] is CSS the projection can use. [None] is a source the parser
    could not turn into any: a fatal syntax error, or a recovery that left no
    statement at all from an input that had something to drop. Neither is a
@@ -39,7 +33,7 @@ let parse_source ~filename ~note css =
       Fmt.epr "Error: %s@." (Cascade.Error.to_string e);
       None
   | Ok { Css.stylesheet; warnings; _ } -> (
-      List.iter report_warning warnings;
+      List.iter Cli_io.report_warning warnings;
       (* Whether the parse produced anything is a question about the statement
          list. Serialising the sheet to answer it asks a different one, and gets
          it wrong: [@charset "UTF-8"] and an [src]-less [@font-face] parse, are

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -189,7 +189,7 @@ let rec holds_unattributed_run stmt =
    differs in importance is decided by importance, not by order. *)
 let declarations_conflict a b =
   Declaration.is_important a = Declaration.is_important b
-  && (not (Shorthand.same_minified_declaration a b))
+  && (not (Declaration.same_minified a b))
   && Shorthand.declarations_overlap a b
 
 (* Two rules whose declarations would reorder unsafely: overlapping selectors

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -133,6 +133,25 @@ module String = struct
       else go (i + 1) (room - 1)
     in
     go i 3
+
+  (* A diagnostic caret goes under the one line it marks, so a marker offset
+     into a whole snippet has to be resolved against the line holding it. The
+     line's own length comes back with it: a caret run is clamped to the line's
+     end, and a caller drawing a single caret ignores it. The newline separating
+     two lines belongs to neither, hence the extra character dropped per line
+     walked past. *)
+  let marker_line lines marker_pos =
+    let rec find line remaining = function
+      | [] -> (0, 0, 0)
+      | [ last ] ->
+          let len = utf8_length last in
+          (line, min remaining len, len)
+      | current :: rest ->
+          let len = utf8_length current in
+          if remaining <= len then (line, remaining, len)
+          else find (line + 1) (remaining - len - 1) rest
+    in
+    find 0 (max 0 marker_pos) lines
 end
 
 let mix_int acc x = ((acc lsl 5) - acc) lxor x

--- a/lib/common.mli
+++ b/lib/common.mli
@@ -72,6 +72,13 @@ module String : sig
   val utf8_lead_after : string -> int -> int
   (** [utf8_lead_after s i] moves [i] forward out of the UTF-8 sequence it falls
       inside, on the same terms as {!utf8_lead_before}. *)
+
+  val marker_line : string list -> int -> int * int * int
+  (** [marker_line lines marker_pos] resolves a character offset into [lines],
+      some text split on newlines, as the index of the line holding it, its
+      column inside that line, and that line's length. Characters are counted as
+      {!utf8_length} counts them, and an offset past the last line clamps to
+      that line's end. *)
 end
 
 val mix_int : int -> int -> int

--- a/lib/component.ml
+++ b/lib/component.ml
@@ -72,6 +72,23 @@ let source_loc : t -> Loc.t = function
 
 let rule_loc : rule -> Loc.t = function Qualified r -> r.loc | At r -> r.loc
 
+let is_whitespace = function
+  | Preserved { kind = Token.Whitespace; _ } -> true
+  | Preserved _ | Block _ | Func _ -> false
+
+(* A real [var()] function anywhere in the components, recursing into function
+   arguments and bracketed blocks. A [var(] inside a string or a url() is an
+   atomic [Preserved] token, never a [Func], so it is data, not a reference. *)
+let rec has_var components =
+  List.exists
+    (fun (c : t) ->
+      match c with
+      | Func { node = { name; arguments; _ }; _ } ->
+          String.lowercase_ascii name = "var" || has_var arguments
+      | Block { node = { value; _ }; _ } -> has_var value
+      | Preserved _ -> false)
+    components
+
 let opening_char : Token.bracket -> char = function
   | Curly -> '{'
   | Paren -> '('

--- a/lib/component.mli
+++ b/lib/component.mli
@@ -61,6 +61,15 @@ val source_loc : t -> Loc.t
 val rule_loc : rule -> Loc.t
 (** [rule_loc r] is the source range spanned by rule [r]. *)
 
+val is_whitespace : t -> bool
+(** [is_whitespace cv] is [true] for a preserved whitespace token. *)
+
+val has_var : t list -> bool
+(** [has_var cvs] is [true] when a [var()] function appears anywhere in [cvs],
+    including inside function arguments and bracketed blocks. A [var(] written
+    inside a string or a [url()] is one atomic preserved token rather than a
+    function, so it is data and does not count. *)
+
 val pp : t Pp.t
 (** [pp] renders a component value as a located debug dump, the {!Token.pp} of a
     whole tree, e.g. [rgb(<number 1>@[4-5])@[0-6]]. Every node shows its own

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -316,25 +316,8 @@ let rec lower_for_minify c =
       if c'' == c' then c else Not c''
   | Style _ | Scroll_state _ -> c
 
-(* A real [var()] function anywhere in the components, recursing into function
-   arguments and bracketed blocks. A [var(] inside a string or url() is an
-   atomic [Preserved] token, never a [Func], so it is data, not a reference. *)
-let rec components_have_var (components : Component.t list) =
-  List.exists
-    (fun (c : Component.t) ->
-      match c with
-      | Component.Func { node = { name; arguments; _ }; _ } ->
-          String.lowercase_ascii name = "var" || components_have_var arguments
-      | Component.Block { node = { value; _ }; _ } -> components_have_var value
-      | Component.Preserved _ -> false)
-    components
-
-let is_whitespace_component = function
-  | Component.Preserved { kind = Token.Whitespace; _ } -> true
-  | _ -> false
-
 let rec drop_leading_whitespace = function
-  | component :: rest when is_whitespace_component component ->
+  | component :: rest when Component.is_whitespace component ->
       drop_leading_whitespace rest
   | components -> components
 
@@ -759,7 +742,7 @@ let unresolved_media_feature components =
               | Some name
                 when (not
                         (trim_components value_components |> components_empty))
-                     && components_have_var value_components ->
+                     && Component.has_var value_components ->
                   let value = string_of_components value_components in
                   Some
                     (Feature_query
@@ -782,7 +765,7 @@ let atom_of_components t components =
   let components = trim_components components in
   let stripped = strip_outer_components components in
   match classify_query_surface t stripped with
-  | _ when components_have_var components -> (
+  | _ when Component.has_var components -> (
       match unresolved_media_feature components with
       | Some query -> query
       | None -> specific_of_components t stripped)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -18,9 +18,9 @@ let rec meta_of_declaration : declaration -> meta option = function
 
 (* Smart constructor. The [hash] field is the stdlib bounded structural hash of
    the (property, value, important) triple, so structurally-equal declarations
-   share a hash (the invariant [Optimize.same_minified_declaration] uses for its
-   O(1) inequality short-circuit). Bounded depth keeps construction O(1) on
-   large value subtrees. *)
+   share a hash (the invariant [same_minified] uses for its O(1) inequality
+   short-circuit). Bounded depth keeps construction O(1) on large value
+   subtrees. *)
 let v (type a) ?(important = false) (property : a Properties.property)
     (value : a) =
   let hash = Hashtbl.seeded_hash_param 30 100 0 (property, value, important) in
@@ -263,13 +263,11 @@ let reject_custom_bad_string t =
     List.exists component_has_bad_string (components_before is_top_level_stop t)
   then Cursor.err_invalid t "bad string in custom property value"
 
-let is_ws_component = function
-  | Component.Preserved { kind = Token.Whitespace; _ } -> true
-  | _ -> false
-
 let invalid_var_arguments arguments =
   match
-    List.filter (fun component -> not (is_ws_component component)) arguments
+    List.filter
+      (fun component -> not (Component.is_whitespace component))
+      arguments
   with
   | Component.Preserved { kind = Token.Ident name; _ } :: rest
     when Custom_property_name.is_valid name -> (
@@ -296,7 +294,7 @@ and component_has_invalid_substitution = function
             (not terminated)
             || not
                  (List.exists
-                    (fun component -> not (is_ws_component component))
+                    (fun component -> not (Component.is_whitespace component))
                     arguments)
         | _ -> false
       in
@@ -324,7 +322,9 @@ let is_substitution_call name arguments =
   (match String.lowercase_ascii_preserve name with
     | "var" | "env" | "attr" -> true
     | _ -> false)
-  && List.exists (fun component -> not (is_ws_component component)) arguments
+  && List.exists
+       (fun component -> not (Component.is_whitespace component))
+       arguments
 
 let rec components_have_substitution components =
   List.exists component_has_substitution components
@@ -603,6 +603,19 @@ type prop_key = Key : 'a Properties.property -> prop_key [@@unboxed]
    same. CSS has one NaN, a parse-time keyword of the <number> grammar (Values 4
    sec. 10.7.2) serialised as calc(NaN) (sec. 10.13). *)
 let equal_declaration (a : declaration) b = Stdlib.compare a b = 0
+
+(* Two declarations minify to the same text exactly when their canonical ASTs
+   are equal (property, value, and importance). After the optimizer's
+   canonicalisation passes the AST is canonical, so structural equality is the
+   minified-equality test - and far cheaper than rendering both to strings. A
+   pp-equal-but-structurally-different pair would be a canonicalisation bug, not
+   something to paper over by comparing rendered text.
+
+   [(==)] short-circuits the same-heap-object case. The cached [hash] (computed
+   once at construction by [v]) short-circuits the (much more common)
+   different-value case in one field-load + int compare without walking the AST;
+   we only fall through to structural equality on a hash collision. *)
+let same_minified a b = a == b || (hash a = hash b && equal_declaration a b)
 let equal_prop_key (a : prop_key) b = a = b
 let hash_prop_key (key : prop_key) = Hashtbl.hash key
 
@@ -2151,7 +2164,7 @@ let validate_regular_property_components t name components =
 let color_fallback_function raw_value =
   let components =
     Cursor.of_string raw_value |> Cursor.remaining
-    |> List.filter (fun component -> not (is_ws_component component))
+    |> List.filter (fun component -> not (Component.is_whitespace component))
   in
   match components with
   | [ Component.Func { node = { name; _ }; _ } ] ->

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -211,6 +211,12 @@ val equal_declaration : declaration -> declaration -> bool
     the [<number>] grammar (Values 4 sec. 10.7.2) serialised as [calc(NaN)]
     (sec. 10.13). *)
 
+val same_minified : declaration -> declaration -> bool
+(** [same_minified a b] is [true] when [a] and [b] render to the same minified
+    text. Two declarations do so exactly when their canonical ASTs agree on
+    property, value and importance, so this is {!equal_declaration} behind the
+    {!hash} pre-filter rather than a comparison of rendered strings. *)
+
 val equal_prop_key : prop_key -> prop_key -> bool
 (** [equal_prop_key a b] tests property identities for equality. *)
 

--- a/lib/declaration_intf.ml
+++ b/lib/declaration_intf.ml
@@ -5,9 +5,9 @@ open Properties_intf
 type 'a kind = 'a Properties_intf.kind
 
 (* [hash] is a structural fingerprint of the declaration, fixed at construction.
-   The optimizer's inner-loop equality ([Optimize.same_minified_declaration])
-   consults it so an inequality verdict is one field load + int compare instead
-   of walking the value AST. Computed eagerly by the [Declaration.v] /
+   The optimizer's inner-loop equality ([Declaration.same_minified]) consults it
+   so an inequality verdict is one field load + int compare instead of walking
+   the value AST. Computed eagerly by the [Declaration.v] /
    [Declaration.theme_guarded] smart constructors -- every code path that builds
    a declaration must go through them so the field stays consistent with the
    [(property, value, important)] / [(var_name, decl)] payload. *)

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -253,20 +253,7 @@ let reported_declaration d =
   in
   (Css.declaration_name d, value)
 
-let restore_group_order table =
-  Hashtbl.to_seq_keys table |> List.of_seq
-  |> List.iter (fun key ->
-      Hashtbl.replace table key (List.rev (Hashtbl.find table key)));
-  table
-
-let group_into_table rules =
-  let tbl = Hashtbl.create 128 in
-  List.iter
-    (fun (k, d) ->
-      let lst = match Hashtbl.find_opt tbl k with Some l -> l | None -> [] in
-      Hashtbl.replace tbl k (d :: lst))
-    rules;
-  restore_group_order tbl
+let group_into_table rules = Group.by ~size:128 Fun.id rules
 
 (* Compare two declaration lists with the same key and emit diffs *)
 let diff_same_key_pair key d1 d2 =

--- a/lib/diff/dune
+++ b/lib/diff/dune
@@ -1,4 +1,7 @@
 (library
  (name cascade_diff)
  (public_name cascade.diff)
+ ; [Group] is an implementation detail shared by the comparators rather than a
+ ; [Cascade_diff.*] module of its own.
+ (private_modules group)
  (libraries cascade))

--- a/lib/diff/group.ml
+++ b/lib/diff/group.ml
@@ -1,0 +1,18 @@
+(** Grouping a list into a hash table of buckets. *)
+
+(* Buckets are built by prepending and reversed once at the end, so grouping
+   stays linear while each bucket still reads in the order the list did. [size]
+   is the table's initial capacity, which decides how keys land in buckets: a
+   caller that walks the result with [Hashtbl.iter] sees that order, so the
+   capacity is part of what it asks for rather than a hint. *)
+let by ~size key items =
+  let tbl = Hashtbl.create size in
+  List.iter
+    (fun item ->
+      let k, v = key item in
+      let bucket = Option.value (Hashtbl.find_opt tbl k) ~default:[] in
+      Hashtbl.replace tbl k (v :: bucket))
+    items;
+  Hashtbl.to_seq_keys tbl |> List.of_seq
+  |> List.iter (fun k -> Hashtbl.replace tbl k (List.rev (Hashtbl.find tbl k)));
+  tbl

--- a/lib/diff/group.mli
+++ b/lib/diff/group.mli
@@ -1,0 +1,6 @@
+(** Grouping a list into a hash table of buckets. *)
+
+val by : size:int -> ('a -> 'k * 'v) -> 'a list -> ('k, 'v list) Hashtbl.t
+(** [by ~size key items] splits [items] into a table of [size] initial capacity,
+    binding each key [key] returns to the values it returned for, in the order
+    [items] gave them. *)

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2624,20 +2624,8 @@ let extract_items_with_positions extract_fn stmts =
     stmts
   |> List.filter_map (fun x -> x)
 
-let restore_group_order table =
-  Hashtbl.to_seq_keys table |> List.of_seq
-  |> List.iter (fun key ->
-      Hashtbl.replace table key (List.rev (Hashtbl.find table key)));
-  table
-
 let group_by_condition items =
-  let tbl = Hashtbl.create 16 in
-  List.iter
-    (fun (pos, cond, rules) ->
-      let existing = try Hashtbl.find tbl cond with Not_found -> [] in
-      Hashtbl.replace tbl cond ((pos, rules) :: existing))
-    items;
-  restore_group_order tbl
+  Group.by ~size:16 (fun (pos, cond, rules) -> (cond, (pos, rules))) items
 
 (* Two sides holding a different number of blocks under one condition split or
    merged them. Where those blocks sit is a separate question, and one
@@ -3073,15 +3061,7 @@ let rec media_condition_differs rules_list1 rules_list2 =
   else None
 
 and media_diff items1 items2 =
-  let group items =
-    let tbl = Hashtbl.create 16 in
-    List.iter
-      (fun (cond, rules) ->
-        let existing = try Hashtbl.find tbl cond with Not_found -> [] in
-        Hashtbl.replace tbl cond (rules :: existing))
-      items;
-    restore_group_order tbl
-  in
+  let group items = Group.by ~size:16 Fun.id items in
   let groups1 = group items1 in
   let groups2 = group items2 in
   let added = ref [] in

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -34,22 +34,6 @@ let context t =
     snippet = snippet t;
   }
 
-(* [Loc.Context.marker_pos] is deliberately relative to the whole public
-   snippet. Rendering is the one place that needs its line and line-relative
-   column, so derive those without changing the snippet record's contract. *)
-let marker_in_lines lines marker_pos =
-  let rec find line remaining = function
-    | [] -> (0, 0, 0)
-    | [ last ] ->
-        let len = Common.String.utf8_length last in
-        (line, min remaining len, len)
-    | current :: rest ->
-        let len = Common.String.utf8_length current in
-        if remaining <= len then (line, remaining, len)
-        else find (line + 1) (remaining - len - 1) rest
-  in
-  find 0 (max 0 marker_pos) lines
-
 let pp_kind : kind Pp.t =
  fun ctx -> function
   | Sort_mismatch { expected; found } ->
@@ -109,7 +93,7 @@ let pp : t Pp.t =
          caret apiece line the marker up under a multibyte snippet. *)
       let lines = String.split_on_char '\n' text in
       let marker_line, marker_pos, line_len =
-        marker_in_lines lines marker_pos
+        Common.String.marker_line lines marker_pos
       in
       let marker_len = max 1 (min marker_len (line_len - marker_pos)) in
       List.iteri

--- a/lib/factor_safe.ml
+++ b/lib/factor_safe.ml
@@ -126,11 +126,6 @@ let specificity_strictly_greater a b =
      && (a.classes > b.classes
         || (a.classes = b.classes && a.elements > b.elements))
 
-let specificity_equal a b =
-  let a = Selector.specificity a in
-  let b = Selector.specificity b in
-  a.ids = b.ids && a.classes = b.classes && a.elements = b.elements
-
 let rule_specificity_beats_on_overlap (target : Stylesheet.rule)
     (skipped : Stylesheet.rule) =
   let target_selectors =
@@ -167,7 +162,9 @@ let specificity_ties (target : Stylesheet.rule) (skipped : Stylesheet.rule) =
           Selector_summary.may_overlap
             (Selector_summary.of_selector target_selector)
             skipped_summary
-          && specificity_equal target_selector skipped_selector)
+          && Selector.equal_specificity
+               (Selector.specificity target_selector)
+               (Selector.specificity skipped_selector))
         target_selectors)
     skipped_selectors
 

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -28,13 +28,9 @@ let remember seen decl =
   let bucket = Hashtbl.find_opt seen hash |> Option.value ~default:[] in
   Hashtbl.replace seen hash (decl :: bucket)
 
-let default_same a b =
-  a == b
-  || Declaration.hash a = Declaration.hash b
-     && Declaration.equal_declaration a b
-
-let v ?(same = default_same) ?(keep = fun (_ : Stylesheet.rule) -> true)
-    (rules : Stylesheet.rule array) =
+let v ?(same = Declaration.same_minified)
+    ?(keep = fun (_ : Stylesheet.rule) -> true) (rules : Stylesheet.rule array)
+    =
   let table = Hashtbl.create 1024 in
   Array.iteri
     (fun row rule ->

--- a/lib/keyframe.mli
+++ b/lib/keyframe.mli
@@ -9,6 +9,10 @@ type position =
       (** CSS Animations 2 sec. 3.2 [<timeline-range-name> <percentage>]
           selector such as [entry 0%]. *)
 
+val timeline_range_names : string list
+(** The [<timeline-range-name>] keywords, accepted both in a keyframe selector
+    position and by the [animation-range] properties. *)
+
 val string_of_position : position -> string
 (** [string_of_position pos] renders a position as CSS string. *)
 

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -536,19 +536,15 @@ let err ?scope t cvs reason =
   let at = match cvs with [] -> t | _ :: _ -> Cursor.sub t cvs in
   fail_parse ?scope (Cursor.condition_error at ~at_rule:"@media" reason)
 
-let is_whitespace_component = function
-  | Component.Preserved { kind = Token.Whitespace; _ } -> true
-  | _ -> false
-
 let rec drop_whitespace = function
-  | component :: rest when is_whitespace_component component ->
+  | component :: rest when Component.is_whitespace component ->
       drop_whitespace rest
   | components -> components
 
 let trim_components components =
   components |> drop_whitespace |> List.rev |> drop_whitespace |> List.rev
 
-let non_whitespace_components = List.filter (Fun.negate is_whitespace_component)
+let non_whitespace_components = List.filter (Fun.negate Component.is_whitespace)
 
 let components_empty components =
   match trim_components components with [] -> true | _ :: _ -> false

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -213,6 +213,20 @@ let token_sp ctx () =
     else
       match out_nth ctx.out (len - 1) with ')' | '%' -> () | _ -> char ctx ' '
 
+(* CSS Syntax 3 (ED) sec. 4: a <percentage-token> ends at its [%], so the
+   separator after one carries no information and elides under minify. Narrower
+   than [token_sp], which also elides after [)]: a function is word-like at its
+   end, and the custom-value serialiser keeps that separator, so eliding it here
+   would make a constructed value disagree with its own reparse. Reads the
+   emitted byte rather than the node, so a spelling that does not end on [%]
+   ([calc(NaN*1%)]) stays spaced. *)
+let pct_sp ctx () =
+  if not ctx.minify then char ctx ' '
+  else
+    let len = out_length ctx.out in
+    if len = 0 then char ctx ' '
+    else match out_nth ctx.out (len - 1) with '%' -> () | _ -> char ctx ' '
+
 let column ctx =
   let len = out_length ctx.out in
   let rec find_newline i =

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -159,6 +159,12 @@ val token_sp : unit t
     otherwise re-tokenise with the next one. Drops the space after [)] or [%]
     since both cleanly close their token (CSS Syntax 3 (ED) sec. 4). *)
 
+val pct_sp : unit t
+(** [pct_sp] writes a separator that only a [%] closes: a regular space in
+    pretty mode, and under minify a space unless the previous output character
+    is [%]. Narrower than {!token_sp}, which also drops the space after [)],
+    where a serialised value has to keep it to reparse as it was written. *)
+
 val cut : unit t
 (** [cut] writes a newline when not minifying. *)
 

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1905,11 +1905,8 @@ let read_animation_range_name t : animation_range_name =
     ]
     t
 
-let animation_range_names =
-  [ "cover"; "contain"; "entry"; "exit"; "entry-crossing"; "exit-crossing" ]
-
 let is_animation_range_name name =
-  List.mem (String.lowercase_ascii_preserve name) animation_range_names
+  List.mem (String.lowercase_ascii_preserve name) Keyframe.timeline_range_names
 
 let read_animation_range_offset t : length_percentage option =
   Cursor.ws t;
@@ -1917,7 +1914,7 @@ let read_animation_range_offset t : length_percentage option =
   else
     match Option.map String.lowercase_ascii_preserve (Cursor.peek_ident t) with
     | Some "normal" -> (None : length_percentage option)
-    | Some next when List.mem next animation_range_names ->
+    | Some next when List.mem next Keyframe.timeline_range_names ->
         (None : length_percentage option)
     | _ -> (Some (Values.read_length_percentage t) : length_percentage option)
 
@@ -1967,7 +1964,7 @@ let rec read_animation_range t : animation_range =
       | Some "normal" ->
           let _ = Cursor.ident t in
           (Normal : animation_range_item)
-      | Some name when List.mem name animation_range_names ->
+      | Some name when List.mem name Keyframe.timeline_range_names ->
           let name : animation_range_name = read_animation_range_name t in
           let lp = read_animation_range_offset t in
           (Named (name, lp) : animation_range_item)

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -178,15 +178,6 @@ let canonicalise_gradient_stops stops =
 let pp_position_offset ctx (lp : Values.length_percentage) =
   pp_length_percentage ~always:true ctx lp
 
-(* A percentage token closes at [%], so its following position component can
-   touch it under minify. A function ending in [)] remains a distinct grammar
-   component and keeps the same separator the custom-value serialiser keeps. *)
-let position_component_space : unit Pp.t =
- fun ctx () ->
-  match Pp.last_char ctx with
-  | Some '%' when Pp.minified ctx -> ()
-  | _ -> Pp.space ctx ()
-
 let rec pp_position_value : position_value Pp.t =
  fun ctx -> function
   | Inherit -> Pp.string ctx "inherit"
@@ -213,14 +204,14 @@ let rec pp_position_value : position_value Pp.t =
   | Bottom_right -> Pp.string ctx "bottom right"
   | XY (a, b) ->
       pp_length ctx a;
-      position_component_space ctx ();
+      Pp.pct_sp ctx ();
       pp_length ctx b
   | Single l -> pp_length ctx l
   | Edge_offset_axis (edge, offset, axis) ->
       Pp.string ctx edge;
       Pp.space ctx ();
       pp_position_offset ctx offset;
-      position_component_space ctx ();
+      Pp.pct_sp ctx ();
       Pp.string ctx axis
   | Axis_edge_offset (axis, edge, offset) ->
       Pp.string ctx axis;
@@ -232,7 +223,7 @@ let rec pp_position_value : position_value Pp.t =
       Pp.string ctx edge1;
       Pp.space ctx ();
       pp_position_offset ctx offset1;
-      position_component_space ctx ();
+      Pp.pct_sp ctx ();
       Pp.string ctx edge2;
       Pp.space ctx ();
       pp_position_offset ctx offset2

--- a/lib/reader.ml
+++ b/lib/reader.ml
@@ -27,20 +27,6 @@ type parse_error = {
 
 exception Parse_error of parse_error
 
-(* Locate a snippet-relative character offset as a line and a column. *)
-let marker_in_lines lines marker_pos =
-  let rec find line remaining = function
-    | [] -> (0, 0)
-    | [ last ] ->
-        let len = Common.String.utf8_length last in
-        (line, min remaining len)
-    | current :: rest ->
-        let len = Common.String.utf8_length current in
-        if remaining <= len then (line, remaining)
-        else find (line + 1) (remaining - len - 1) rest
-  in
-  find 0 (max 0 marker_pos) lines
-
 (** Pretty print parse error with debugging information *)
 let pp_parse_error (err : parse_error) =
   let buf = Buffer.create 256 in
@@ -59,7 +45,9 @@ let pp_parse_error (err : parse_error) =
       Buffer.add_char buf ']');
   if err.context_window <> "" then begin
     let lines = String.split_on_char '\n' err.context_window in
-    let marker_line, marker_pos = marker_in_lines lines err.marker_pos in
+    let marker_line, marker_pos, _ =
+      Common.String.marker_line lines err.marker_pos
+    in
     List.iteri
       (fun i line ->
         Buffer.add_char buf '\n';

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -347,7 +347,7 @@ let merged_selector group =
 
 let merge_adjacent_identical ~ctx (rules : rule list) : rule list =
   let bodies_equal a b =
-    Merge.declarations_equal ~same:Shorthand.same_minified_declaration a b
+    Merge.declarations_equal ~same:Declaration.same_minified a b
   in
   let changed = ref false in
   let rec go = function

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -352,18 +352,15 @@ let candidate ?size_cache ~kind ~finalize g ~consume ~produce =
 let selector_size (r : rule) = Pp.size ~minify:true Selector.pp r.selector
 let decls_inline_cost decls = decls_size decls + List.length decls
 
-let specificity_equal a b =
-  let a = Selector.specificity a in
-  let b = Selector.specificity b in
-  a.ids = b.ids && a.classes = b.classes && a.elements = b.elements
-
 let selectors_tie_and_overlap a b =
   List.exists
     (fun selector_a ->
       let summary_a = Selector_summary.of_selector selector_a in
       List.exists
         (fun selector_b ->
-          specificity_equal selector_a selector_b
+          Selector.equal_specificity
+            (Selector.specificity selector_a)
+            (Selector.specificity selector_b)
           && Selector_summary.may_overlap summary_a
                (Selector_summary.of_selector selector_b))
         (Edge.selectors b))

--- a/lib/rule_candidate.ml
+++ b/lib/rule_candidate.ml
@@ -5,7 +5,7 @@ open Stdlib
 open Rule_rewrite
 module Node_set = Set.Make (Rule_graph.Node_id)
 
-let same_decl = Shorthand.same_minified_declaration
+let same_decl = Declaration.same_minified
 
 (* How much of a declaration's overlap relation its precomputed footprint
    settles. [Slots] is decided by the keys alone; [Custom] by the property name,

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -10,7 +10,7 @@ open Stdlib
 module Decl_tbl = Hashtbl.Make (struct
   type t = Declaration.declaration
 
-  let equal = Shorthand.same_minified_declaration
+  let equal = Declaration.same_minified
   let hash = Declaration.hash
 end)
 
@@ -129,7 +129,7 @@ type t = {
    cascade-neutral inside a fixed origin/layer/scope context. *)
 let declarations_conflict left right =
   left.important = right.important
-  && (not (Shorthand.same_minified_declaration left.decl right.decl))
+  && (not (Declaration.same_minified left.decl right.decl))
   && Shorthand.declarations_overlap_with_keys left.decl left.footprint
        right.decl right.footprint
 
@@ -523,7 +523,7 @@ let add_decl_bucket ~compact bucket key spec summary decl value =
 let collect_decl_table decl groups stamp seen acc =
   Decl_tbl.fold
     (fun decl' ids acc ->
-      if Shorthand.same_minified_declaration decl decl' then acc
+      if Declaration.same_minified decl decl' then acc
       else add_candidates stamp seen acc ids)
     groups acc
 
@@ -1229,7 +1229,7 @@ let produced_declaration_sources graph consume produced produced_decl =
   let nodes = produced_branch_sources graph consume produced in
   match
     declaration_source_refs graph nodes produced_decl
-      ~matches:Shorthand.same_minified_declaration
+      ~matches:Declaration.same_minified
   with
   | _ :: _ as exact when refs_cover_nodes nodes exact -> exact
   | _ :: _ -> fallback_source_refs nodes
@@ -1373,8 +1373,8 @@ let external_candidates graph ~total ~consumed ~seen p =
             | Some inner ->
                 Decl_tbl.iter
                   (fun decl' ids ->
-                    if not (Shorthand.same_minified_declaration ov.decl decl')
-                    then push_ids ids)
+                    if not (Declaration.same_minified ov.decl decl') then
+                      push_ids ids)
                   inner
             | None -> ())
           ov.footprint)

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -169,11 +169,6 @@ let overlap_key_lists_intersect a b =
   let broad = Shorthand.broad_overlap_key in
   overlap_key_in broad a || overlap_key_in broad b || overlap_keys_meet a b
 
-let specificity_equal (a : Selector.specificity) (b : Selector.specificity) =
-  Int.equal a.ids b.ids
-  && Int.equal a.classes b.classes
-  && Int.equal a.elements b.elements
-
 (* [List.exists2] over a zipped pair needs the zip built first, and the inner
    one was built inside the outer closure: B's whole tuple list was rebuilt once
    per element of A. Walking the three parallel lists in step decides the same
@@ -192,7 +187,7 @@ let selectors_order_conflict ?(closed_world = false) selectors_a summaries_a
     (fun selector_a summary_a specificity_a ->
       exists3
         (fun selector_b summary_b specificity_b ->
-          specificity_equal specificity_a specificity_b
+          Selector.equal_specificity specificity_a specificity_b
           &&
           if closed_world then
             (* the caller asserts no element matches two distinct selectors, so

--- a/lib/rule_graph.ml
+++ b/lib/rule_graph.ml
@@ -461,14 +461,6 @@ let empty_id_decl_groups () =
 let empty_selector_decl_groups () =
   { no_element = empty_id_decl_groups (); by_element = String_table.create 4 }
 
-let decl_spec_bucket bucket key =
-  match Overlap_key_table.find_opt bucket key with
-  | Option.Some inner -> inner
-  | Option.None ->
-      let inner = Spec_table.create 4 in
-      Overlap_key_table.replace bucket key inner;
-      inner
-
 let selector_decl_groups inner spec : selector_decl_groups =
   match Spec_table.find_opt inner spec with
   | Option.Some index -> index
@@ -525,7 +517,7 @@ let add_selector_decl ~compact index summary decl value =
 
 let add_decl_bucket ~compact bucket key spec summary decl value =
   add_selector_decl ~compact
-    (selector_decl_groups (decl_spec_bucket bucket key) spec)
+    (selector_decl_groups (spec_bucket bucket key) spec)
     summary decl value
 
 let collect_decl_table decl groups stamp seen acc =

--- a/lib/selector_intf.ml
+++ b/lib/selector_intf.ml
@@ -282,5 +282,13 @@ let equal (a : t) b = a = b
    the chain they share. 256 is the largest budget the runtime honours, and it
    reaches the tail of any selector CSS is written with. *)
 let hash (selector : t) = Hashtbl.hash_param 256 256 selector
-let equal_specificity (a : specificity) b = a = b
+
+(* Three ints, compared field by field: the optimizer asks this inside a
+   quadratic selector walk, where the polymorphic compare's C call and its
+   traversal of the record cost more than the answer. *)
+let equal_specificity (a : specificity) (b : specificity) =
+  Int.equal a.ids b.ids
+  && Int.equal a.classes b.classes
+  && Int.equal a.elements b.elements
+
 let equal_combinator (a : combinator) b = a = b

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3546,23 +3546,6 @@ let rec without_importance = function
 let same_value a b =
   Declaration.equal_declaration (without_importance a) (without_importance b)
 
-(* Two declarations minify to the same text exactly when their canonical ASTs
-   are equal (property, value, and importance). After the optimizer's
-   canonicalisation passes the AST is canonical, so structural equality is the
-   minified-equality test - and far cheaper than rendering both to strings. A
-   pp-equal-but-structurally-different pair would be a canonicalisation bug, not
-   something to paper over by comparing rendered text.
-
-   [(==)] short-circuits the same-heap-object case. The cached
-   [Declaration.hash] (computed once at construction by [Declaration.v]) short-
-   circuits the (much more common) different-value case in one field-load + int
-   compare without walking the AST; we only fall through to structural equality
-   on a hash collision. *)
-let same_minified_declaration (a : declaration) (b : declaration) =
-  a == b
-  || Declaration.hash a = Declaration.hash b
-     && Declaration.equal_declaration a b
-
 (* Only a pair that writes a common cascade slot at the same importance with
    different values constrains its own order: [!important] beats the plain
    declaration wherever the two sit, and an identical pair is its own winner
@@ -3583,7 +3566,7 @@ let commute_fact decl =
 
 let commute_facts_conflict a b =
   a.important = b.important
-  && (not (same_minified_declaration a.decl b.decl))
+  && (not (Declaration.same_minified a.decl b.decl))
   && declarations_overlap_with_keys a.decl a.keys b.decl b.keys
 
 let declarations_commute left right =

--- a/lib/shorthand.mli
+++ b/lib/shorthand.mli
@@ -77,10 +77,6 @@ val same_property : Declaration.declaration -> Declaration.declaration -> bool
 val same_value : Declaration.declaration -> Declaration.declaration -> bool
 (** Same declaration value ignoring importance. *)
 
-val same_minified_declaration :
-  Declaration.declaration -> Declaration.declaration -> bool
-(** Same canonical minified declaration. *)
-
 val declarations_commute :
   Declaration.declaration list -> Declaration.declaration list -> bool
 (** [declarations_commute a b] is [true] when running [a] before [b] and [b]

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2558,27 +2558,17 @@ let read_font_face_desc name r =
         r
   | _ -> Cursor.err_invalid r ("unknown font-face descriptor: " ^ name)
 
+let rec components_upto_semicolon = function
+  | [] | Component.Preserved { kind = Token.Semicolon; _ } :: _ -> []
+  | component :: rest -> component :: components_upto_semicolon rest
+
 (* CSS Variables 1 sec. 3 substitutes [var()] in a property value; an @font-face
    descriptor is not a property, so no descriptor grammar accepts a var() and
    browsers drop the whole declaration. The descriptor readers delegate to the
    shared property readers, which accept var() legitimately in property
    position, so the rejection belongs at the descriptor boundary. *)
-let rec components_have_var (components : Component.t list) =
-  List.exists
-    (fun (component : Component.t) ->
-      match component with
-      | Component.Func { node = { name; arguments; _ }; _ } ->
-          String.lowercase_ascii name = "var" || components_have_var arguments
-      | Component.Block { node = { value; _ }; _ } -> components_have_var value
-      | Component.Preserved _ -> false)
-    components
-
-let rec components_upto_semicolon = function
-  | [] | Component.Preserved { kind = Token.Semicolon; _ } :: _ -> []
-  | component :: rest -> component :: components_upto_semicolon rest
-
 let descriptor_value_has_var r =
-  components_have_var (components_upto_semicolon (Cursor.remaining r))
+  Component.has_var (components_upto_semicolon (Cursor.remaining r))
 
 (* Whether the descriptor called [name] keeps a var() for the inline pass, asked
    of the typed AST rather than of a second list of names: read a value only

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -331,11 +331,7 @@ let to_string t = Pp.to_string ~minify:false pp t
 
 (* ===== Component parser ===== *)
 
-let is_ws = function
-  | Component.Preserved { kind = Token.Whitespace; _ } -> true
-  | _ -> false
-
-let strip_components = List.filter (fun cv -> not (is_ws cv))
+let strip_components = List.filter (fun cv -> not (Component.is_whitespace cv))
 
 let closed_block = function
   | Component.Block { node = { closed; _ }; _ }

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4377,19 +4377,6 @@ let pp_hue_interpolation : hue_interpolation Pp.t =
   | Specified -> Pp.string ctx "specified"
   | Default -> ()
 
-(* CSS Syntax 3 (ED) sec. 4: a [<percentage-token>] ends at its [%], so the
-   separator before the next component carries no information and elides under
-   minify. Narrower than {!Pp.token_sp}, which also elides after [)]: a function
-   is word-like at its end, and the custom-value serialiser keeps that
-   separator, so eliding it here would make a constructed colour disagree with
-   its own reparse. Reads the emitted byte rather than the node so a spelling
-   that does not end on [%] ([calc(NaN*1%)]) stays spaced. *)
-let space_after_percentage : unit Pp.t =
- fun ctx () ->
-  match Pp.last_char ctx with
-  | Some '%' when Pp.minified ctx -> ()
-  | _ -> Pp.space ctx ()
-
 let static_component_can_touch_negative (component : component) =
   match component with
   | Num _ | Pct _ -> true
@@ -4423,15 +4410,14 @@ let pp_color_components ~decimals : component list Pp.t =
 (* Helpers to pretty print CSS color functions using Pp.call *)
 let pp_rgb_args : (channel * channel * channel * alpha) Pp.t =
  fun ctx (r, g, b, alpha) ->
-  Pp.list ~sep:space_after_percentage pp_channel ctx [ r; g; b ];
+  Pp.list ~sep:Pp.pct_sp pp_channel ctx [ r; g; b ];
   pp_opt_alpha ctx alpha
 
 let pp_rgb_func = Pp.call "rgb" pp_rgb_args
 
 let rec pp_rgb : rgb Pp.t =
  fun ctx -> function
-  | Channels { r; g; b } ->
-      Pp.list ~sep:space_after_percentage pp_channel ctx [ r; g; b ]
+  | Channels { r; g; b } -> Pp.list ~sep:Pp.pct_sp pp_channel ctx [ r; g; b ]
   | Var v -> pp_var pp_rgb ctx v
 
 (** Lab-like float string. CSSOM serialisation (CSSOM 1 sec. 6.7.2) drops a
@@ -4511,7 +4497,7 @@ let pp_pct_chroma_hue_alpha ~chroma_pct_scale :
   | None ->
       space_after_color_percentage ctx printed_l ~next:(Some "none");
       Pp.string ctx "none");
-  space_after_percentage ctx ();
+  Pp.pct_sp ctx ();
   pp_hue ctx h;
   pp_opt_alpha ctx alpha
 
@@ -4522,7 +4508,7 @@ let pp_hue_pct_pct_alpha : (hue * percentage * percentage * alpha) Pp.t =
   pp_hue ctx h;
   Pp.space ctx ();
   pp_percentage ctx s;
-  space_after_percentage ctx ();
+  Pp.pct_sp ctx ();
   pp_percentage ctx l;
   pp_opt_alpha ctx a
 
@@ -4568,7 +4554,7 @@ let pp_lab_like_args ~axis_pct_scale :
       (ctx.Pp.minify && starts_unsigned_number a
       && String.length b > 0
       && (b.[0] = '-' || b.[0] = '+'))
-  then space_after_percentage ctx ();
+  then Pp.pct_sp ctx ();
   Pp.string ctx b;
   match alpha with
   | None -> ()

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -5145,9 +5145,9 @@ let vendor_prefixed_shorthands () =
    resolves at parse time, and sec. 10.13 serialises every NaN-valued
    calculation as calc(NaN): CSS has one NaN and one spelling for it, so two
    declarations that spell it are one declaration. The cached [Declaration.hash]
-   already answers that way, and [Shorthand.same_minified_declaration] merges
-   rules on [hash a = hash b && equal_declaration a b], so the two have to agree
-   or a merge is lost. *)
+   already answers that way, and [Declaration.same_minified] merges rules on
+   [hash a = hash b && equal_declaration a b], so the two have to agree or a
+   merge is lost. *)
 let optimized_declarations css =
   Css.of_string_exn css |> Css.optimize |> Css.statements
   |> List.concat_map (function

--- a/test/test_factor_safe.ml
+++ b/test/test_factor_safe.ml
@@ -15,13 +15,8 @@ let rule css =
 
 let decl css = Declaration.of_string css
 
-let same_decl a b =
-  a == b
-  || Declaration.hash a = Declaration.hash b
-     && Declaration.equal_declaration a b
-
 let safe =
-  Factor_safe.v ~same_minified_declaration:same_decl
+  Factor_safe.v ~same_minified_declaration:Declaration.same_minified
     ~declaration_covers:Declaration.same_property
     ~contains_vendor_pseudo_element:(fun _ -> false)
     ~rule_factor_boundary:(fun r -> r.merge_key <> None || r.nested <> [])

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -9,16 +9,11 @@ let rules css =
       |> Array.of_list
   | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
 
-let same a b =
-  a == b
-  || Declaration.hash a = Declaration.hash b
-     && Declaration.equal_declaration a b
-
 let decl css = Declaration.of_string css
 
 let test_rows_are_sorted_unique () =
   let t =
-    Index.v ~same
+    Index.v ~same:Declaration.same_minified
       (rules ".a{color:red;color:red}.b{width:1px}.c{color:red}.d{color:red}")
   in
   Alcotest.(check (array int))
@@ -28,7 +23,7 @@ let test_rows_are_sorted_unique () =
 let test_eligible_filters_rows () =
   let rs = rules ".a{color:red}.b{color:red}.c{color:red}" in
   let t =
-    Index.v ~same
+    Index.v ~same:Declaration.same_minified
       ~keep:(fun rule ->
         not (String.equal (Css.Selector.to_string rule.selector) ".b"))
       rs

--- a/test/test_summary.ml
+++ b/test/test_summary.ml
@@ -24,11 +24,6 @@ let selector_size selector =
 let summary rule =
   Summary.v ~rule_size:(fun _ -> 123) ~decl_size ~selector_size rule
 
-let same a b =
-  a == b
-  || Declaration.hash a = Declaration.hash b
-     && Declaration.equal_declaration a b
-
 let custom_rule ?(selector = ".a") decls =
   rule (selector ^ "{" ^ String.concat ";" decls ^ "}")
 
@@ -43,7 +38,9 @@ let test_rule_identity_and_first_decl () =
   Alcotest.(check bool)
     "declares props" true
     (Summary.declares_all t [ Summary.prop color; Summary.prop width ]);
-  Alcotest.(check bool) "contains color" true (Summary.contains ~same t color);
+  Alcotest.(check bool)
+    "contains color" true
+    (Summary.contains ~same:Declaration.same_minified t color);
   match Summary.decl_for_prop t (Summary.prop color) with
   | Some first ->
       Alcotest.(check string)
@@ -75,7 +72,7 @@ let test_contains_does_not_trust_bloom_hit () =
   Alcotest.(check int) "equality predicate was consulted" 1 !calls;
   Alcotest.(check bool)
     "structural equality confirms containment" true
-    (Summary.contains ~same t color)
+    (Summary.contains ~same:Declaration.same_minified t color)
 
 let test_cached_fields_and_bloom_for_reordered_decls () =
   let t = summary (rule ".a{color:red;width:1px}") in


### PR DESCRIPTION
Eleven non-trivial helpers each had a second copy, so a fix to one reached none of the others, and three of them were the predicate test files hand-copy to feed `Index.v ~same` and `Factor_safe.v ~same_minified_declaration`. Two of the merges needed care rather than a move: `Selector.equal_specificity` used polymorphic compare, which would have slowed a hot quadratic selector walk, and the grouping walk's callers build their tables at different capacities, so the size stays a required argument because `Hashtbl.iter` order follows the bucket layout.