### PR TITLE
test: drop two duplicate helpers from the tree-diff suite

### DIFF
--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -666,6 +666,12 @@ let compute_stats ~expected_str ~actual_str diff_result =
 let stats = compute_stats
 let add_strings b ls = List.iter (Buffer.add_string b) ls
 
+(* Every warning line starts fresh: what precedes it in the report ends where it
+   ends, a snippet's caret row included. *)
+let start_line buf =
+  if Buffer.length buf > 0 && Buffer.nth buf (Buffer.length buf - 1) <> '\n'
+  then Buffer.add_char buf '\n'
+
 (* Two warnings are the same complaint when they fail the same way at the same
    place in the grammar. Where in the byte stream each side ran into it is no
    part of that. *)
@@ -703,13 +709,11 @@ let partition_warnings expected actual =
   go [] (List.map keyed actual) [] (List.map keyed expected)
 
 let pp_warning buf label w =
-  if Buffer.length buf > 0 && Buffer.nth buf (Buffer.length buf - 1) <> '\n'
-  then Buffer.add_char buf '\n';
+  start_line buf;
   add_strings buf [ label; " parse warning: "; Error.to_string w; "\n" ]
 
 let pp_overflow buf label hidden =
-  if Buffer.length buf > 0 && Buffer.nth buf (Buffer.length buf - 1) <> '\n'
-  then Buffer.add_char buf '\n';
+  start_line buf;
   add_strings buf
     [
       label;

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -770,11 +770,6 @@ let rearranged_of (d : Cascade_diff.Tree_diff.t) =
       | _ -> None)
     d.rules
 
-let render d =
-  let buf = Buffer.create 256 in
-  Cascade_diff.Tree_diff.pp buf d;
-  Buffer.contents buf
-
 let diff_of ~expected ~actual =
   Cascade_diff.Tree_diff.diff ~expected:(parse expected) ~actual:(parse actual)
 
@@ -1577,11 +1572,8 @@ let changed_rules colour n =
   parse (Buffer.contents buf)
 
 let diff_words expected actual =
-  Gc.full_major ();
-  let words0 = Gc.minor_words () in
-  let diff = Cascade_diff.Tree_diff.diff ~expected ~actual in
-  ignore (Sys.opaque_identity diff);
-  Gc.minor_words () -. words0
+  Css_test_helpers.measure (fun () ->
+      Cascade_diff.Tree_diff.diff ~expected ~actual)
 
 (* Grouping the reported changes by scanning the whole change list once per
    entry makes allocation quadratic in the number of changed rules. Doubling the


### PR DESCRIPTION
Three duplications this stack introduced itself: a `measure` that a consolidation commit skipped, a `render` byte-identical to one already in the same file, and one fresh-line guard written twice in `css_compare`. The guard becomes a named helper, since the invariant is a property of the report rather than a mechanism its callers should each remember.