### PR TITLE
optimize: merge a distant same-name @container block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -524,6 +524,9 @@ difference wherever the two are not equivalent.
 
 ### Minification
 
+- `--minify` merges a `@container` block into an earlier one carrying the same
+  name and query across the rules written between them, where only adjacent
+  blocks merged and a hoist over a conflicting rule stays refused (#809)
 - `--minify` keeps the authored time unit of a `var()` fallback nested inside a
   `calc()`, as it already did for the operand beside it. The two spellings
   printed alike and stopped factoring (#803)

--- a/lib/block.ml
+++ b/lib/block.ml
@@ -202,62 +202,74 @@ let rules_conflict (r1 : rule) (r2 : rule) =
        (fun a -> List.exists (declarations_conflict a) r2.declarations)
        r1.declarations
 
-let needs_distant_media_merge stmts =
-  let conds =
-    List.filter_map (function Media (c, _) -> Some c | _ -> None) stmts
-  in
-  let rec dup = function
-    | [] -> false
-    | c :: rest -> List.exists (Media.equal c) rest || dup rest
-  in
-  dup conds
+(* Only cross statements whose cascade is pure source order: plain rules and
+   conditional groups. Layers, origins, scopes, imports, etc. establish
+   ordering/context that hoisting past would change. *)
+let crossable_by_distant_merge = function
+  | Rule _ | Declarations _ | Media _ | Supports _ | Container _ -> true
+  | _ -> false
 
-(* CSS Conditional 3: same-condition [@media] blocks are spec-equivalent to one
-   block. Merge a later block into the first occurrence when hoisting it past
-   the intervening statements cannot reorder a conflicting rule.
+(* CSS Conditional Rules 5 sec. 2: a conditional group rule applies its contents
+   when its condition holds, so two blocks under one prelude carry the same
+   content as one block over their concatenation. A distant merge adds a move to
+   that equivalence: the later block's declarations come to sit before the
+   statements written between the two, and order of appearance decides the
+   cascade only between a pair of declarations that does not commute. So the
+   merge stands when nothing the hoisted block writes conflicts with anything
+   the statements it crosses write, and those statements are all ones the
+   cascade reads in source order.
+
+   [prelude] reads the identity two blocks of one family have to share, with the
+   body under it, and answers [None] for every other statement; [equal_prelude]
+   decides when two identities are one; [build] puts a merged body back under
+   one; [hoistable] is a family's own refusal to move a body at all.
 
    [owner] is the style rule whose body [stmts] is, when it is one. A
    declarations run in that body sets properties on [owner] (CSS Nesting 1 sec.
    3.4), so the analysis below only sees it once it can name the rule the run
    belongs to. *)
-(* Only cross statements whose cascade is pure source order: plain rules and
-   conditional groups. Layers, origins, scopes, imports, etc. establish
-   ordering/context that hoisting past would change. *)
-let crossable_by_distant_media = function
-  | Rule _ | Declarations _ | Media _ | Supports _ | Container _ -> true
-  | _ -> false
+let has_distant_partner ~prelude ~equal_prelude stmts =
+  let keys = List.filter_map (fun s -> Option.map fst (prelude s)) stmts in
+  let rec dup = function
+    | [] -> false
+    | k :: rest -> List.exists (equal_prelude k) rest || dup rest
+  in
+  dup keys
 
-(* Split [out] at the first [@media] whose condition is [cond], into what comes
-   before it, its own block, and what sits between it and the caller. *)
-let split_at_media cond out :
+(* Split [out] at the first block whose prelude is [key], into what comes before
+   it, its own body, and what sits between it and the caller. *)
+let split_at_prelude ~prelude ~equal_prelude key out :
     (statement list * statement list * statement list) option =
   let rec go before :
       statement list ->
       (statement list * statement list * statement list) option = function
     | [] -> None
-    | Media (c, b) :: after when Media.equal c cond ->
-        Some (List.rev before, b, after)
-    | x :: rest -> go (x :: before) rest
+    | stmt :: after -> (
+        match prelude stmt with
+        | Some (k, body) when equal_prelude k key ->
+            Some (List.rev before, body, after)
+        | Some _ | None -> go (stmt :: before) after)
   in
   go [] out
 
-let try_distant_media_merge ~leaves ~unattributed out cond block :
-    statement list option =
+let try_distant_merge ~prelude ~equal_prelude ~build ~leaves ~unattributed out
+    key block : statement list option =
   let hoisted = leaves block in
-  match split_at_media cond out with
+  match split_at_prelude ~prelude ~equal_prelude key out with
   | None -> None
   | Some (before, target, after)
-    when List.for_all crossable_by_distant_media after ->
+    when List.for_all crossable_by_distant_merge after ->
       let crossed = leaves after in
       if
         unattributed block || unattributed after
         || List.exists (fun h -> List.exists (rules_conflict h) crossed) hoisted
       then None
-      else Some (before @ [ Media (cond, target @ block) ] @ after)
+      else Some (before @ [ build key (target @ block) ] @ after)
   | Some _ -> None
 
-let merge_distant_media ?owner ?(optimize_merged_block = Fun.id) stmts =
-  if not (needs_distant_media_merge stmts) then stmts
+let merge_distant ~prelude ~equal_prelude ~build ~hoistable ?owner
+    ~optimize_merged_block stmts =
+  if not (has_distant_partner ~prelude ~equal_prelude stmts) then stmts
   else
     let leaves stmts = List.concat_map (leaf_rules ?parent:owner) stmts in
     let unattributed stmts =
@@ -265,24 +277,33 @@ let merge_distant_media ?owner ?(optimize_merged_block = Fun.id) stmts =
     in
     (* The accumulator is carried reversed, as the consecutive-block passes
        nearby carry theirs: appending to the end copies it once per statement,
-       which costs a square in the statement count. Only a [@media] statement
+       which costs a square in the statement count. Only a block of the family
        needs it in order, to find the partner it merges into, and [rev_map] puts
        the result back in source order. *)
     let step rout stmt =
-      match stmt with
-      | Media (cond, block) when not (has_nested_preference_media block) -> (
+      match prelude stmt with
+      | Some (key, block) when hoistable block -> (
           match
-            try_distant_media_merge ~leaves ~unattributed (List.rev rout) cond
-              block
+            try_distant_merge ~prelude ~equal_prelude ~build ~leaves
+              ~unattributed (List.rev rout) key block
           with
           | Some out' -> List.rev out'
           | None -> stmt :: rout)
-      | _ -> stmt :: rout
+      | Some _ | None -> stmt :: rout
     in
     List.fold_left step [] stmts
-    |> List.rev_map (function
-      | Media (c, b) -> Media (c, optimize_merged_block b)
-      | s -> s)
+    |> List.rev_map (fun stmt ->
+        match prelude stmt with
+        | Some (key, body) -> build key (optimize_merged_block body)
+        | None -> stmt)
+
+let merge_distant_media ?owner ?(optimize_merged_block = Fun.id) stmts =
+  merge_distant
+    ~prelude:(function Media (cond, block) -> Some (cond, block) | _ -> None)
+    ~equal_prelude:Media.equal
+    ~build:(fun cond block -> Media (cond, block))
+    ~hoistable:(fun block -> not (has_nested_preference_media block))
+    ?owner ~optimize_merged_block stmts
 
 (* CSS Conditional Rules 5: adjacent same-condition [@supports] / [@container]
    blocks may be merged because the cascade evaluates them identically. Mirror
@@ -378,6 +399,22 @@ let merge_consecutive_containers ?(optimize_merged_block = Fun.id)
           | None -> merge (stmt :: acc) None rest)
     in
     merge [] None stmts
+
+(* Reaching the partner a statement is written between is the move
+   [merge_distant] argues for, and a [@container] keys it on the whole prelude.
+   Conditional Rules 5 sec. 5.4 resolves the query against the nearest ancestor
+   the [<container-name>] selects, so an unnamed [@container (width>10px)] and
+   [@container main (width>10px)] ask about different elements however equal
+   their conditions read, and two names select one ancestor only when they are
+   the one ident. *)
+let merge_distant_containers ?owner ?(optimize_merged_block = Fun.id) stmts =
+  merge_distant
+    ~prelude:(function
+      | Container (name, cond, block) -> Some ((name, cond), block) | _ -> None)
+    ~equal_prelude:same_container
+    ~build:(fun (name, cond) block -> Container (name, cond, block))
+    ~hoistable:(fun _ -> true)
+    ?owner ~optimize_merged_block stmts
 
 (* CSS Transitions 2 sec. 3.3: [@starting-style] takes no prelude, so two
    adjacent blocks hold the same starting styles, in the same order, as one

--- a/lib/block.mli
+++ b/lib/block.mli
@@ -37,6 +37,15 @@ val merge_consecutive_containers :
   Stylesheet.statement list
 (** Merge adjacent [@container] blocks with identical names and conditions. *)
 
+val merge_distant_containers :
+  ?owner:Stylesheet.rule ->
+  ?optimize_merged_block:
+    (Stylesheet.statement list -> Stylesheet.statement list) ->
+  Stylesheet.statement list ->
+  Stylesheet.statement list
+(** Merge a later [@container] block with the same name and condition into the
+    first occurrence when the hoist reorders no conflicting rule. *)
+
 val merge_consecutive_starting_style :
   ?optimize_merged_block:
     (Stylesheet.statement list -> Stylesheet.statement list) ->

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -84,6 +84,7 @@ let merge_consecutive_media = Block.merge_consecutive_media
 let merge_distant_media = Block.merge_distant_media
 let merge_consecutive_supports = Block.merge_consecutive_supports
 let merge_consecutive_containers = Block.merge_consecutive_containers
+let merge_distant_containers = Block.merge_distant_containers
 let merge_consecutive_starting_style = Block.merge_consecutive_starting_style
 let is_layer_empty = Block.is_layer_empty
 let collect_empty_layer_names = Block.collect_empty_layer_names
@@ -271,6 +272,7 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
           |> merge_distant_media ?owner ~optimize_merged_block
           |> merge_consecutive_supports ~optimize_merged_block
           |> merge_consecutive_containers ~optimize_merged_block
+          |> merge_distant_containers ?owner ~optimize_merged_block
           |> merge_consecutive_starting_style ~optimize_merged_block
         in
         stmts |> merge_layer_declarations |> drop_empty_rules

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -220,6 +220,21 @@ val merge_consecutive_containers :
 (** [merge_consecutive_containers stmts] merges adjacent [@container] blocks
     with identical names and conditions. *)
 
+val merge_distant_containers :
+  ?owner:rule ->
+  ?optimize_merged_block:(statement list -> statement list) ->
+  statement list ->
+  statement list
+(** [merge_distant_containers ?owner stmts] merges a later [@container] block
+    with the same name and condition into the first occurrence, on the argument
+    {!merge_distant_media} makes for [@media] and the same [owner].
+
+    The name is half the identity: CSS Conditional Rules 5 sec. 5.4 resolves the
+    query against the nearest ancestor the [<container-name>] selects, so a
+    named and an unnamed block ask about different elements however equal their
+    conditions read, and two named ones merge only when the names are the one
+    ident. *)
+
 val merge_consecutive_starting_style :
   ?optimize_merged_block:(statement list -> statement list) ->
   statement list ->

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -41,6 +41,9 @@ let _ : merge_block = Optimize.merge_consecutive_containers
 let _ : merge_block = Optimize.merge_consecutive_starting_style
 let _ : ?owner:Stylesheet.rule -> merge_block = Optimize.merge_distant_media
 
+let _ : ?owner:Stylesheet.rule -> merge_block =
+  Optimize.merge_distant_containers
+
 let _ : Stylesheet.statement list -> Stylesheet.statement list =
   Optimize.merge_named_layers_by_name
 

--- a/test/render/render_diff.ml
+++ b/test/render/render_diff.ml
@@ -183,6 +183,38 @@ let attr_flag_unflagged = {css|[data-rd="b"] { color: #00f }|css}
 let nth_of_sheet = {css|:nth-child(2 of .rd-a) { color: #00f }|css}
 let nth_of_other = {css|:nth-child(2 of .rd-b) { color: #00f }|css}
 
+(* Two same-condition [@container] blocks with a rule between them, over an
+   element the sheet makes a query container: the optimizer hoists the second
+   block over that rule, and the browser has to compute the same style either
+   way. Nothing generated carries a container query, so without this the sweep
+   never renders one. *)
+let distant_container_sheet =
+  {css|
+.rd-cq { container-type: inline-size; width: 300px }
+@container (width >= 100px) { .rd-cq .rd-cr { color: #00f } }
+.rd-cs { background-color: #0f0 }
+@container (width >= 100px) { .rd-cq .rd-ct { padding-left: 6px } }
+|css}
+
+(* The same shape with the crossed rule writing the colour the blocks write, and
+   beside it the merge a pass that skipped the conflict check would make. The
+   source paints red and the merge paints green, so a harness that reports no
+   difference here cannot see a wrong container merge at all. *)
+let container_conflict_sheet =
+  {css|
+.rd-cw { container-type: inline-size; width: 300px }
+@container (width >= 100px) { .rd-cw .rd-cx { color: #00f } }
+.rd-cw .rd-cx { color: #090 }
+@container (width >= 100px) { .rd-cw .rd-cx { color: #f00 } }
+|css}
+
+let container_conflict_hoisted =
+  {css|
+.rd-cw { container-type: inline-size; width: 300px }
+@container (width >= 100px) { .rd-cw .rd-cx { color: #00f } .rd-cw .rd-cx { color: #f00 } }
+.rd-cw .rd-cx { color: #090 }
+|css}
+
 (* [Differs] is the expected-failure marker: the harness fails when the pair it
    names renders the same, so a fix cannot leave the pin behind. *)
 type expectation = Same | Differs of string
@@ -319,6 +351,19 @@ let inputs () =
     [
       sheet "smoke" smoke_sheet;
       sheet "nth-last-child-of" nth_last_of_sheet;
+      sheet "distant-container" distant_container_sheet;
+      {
+        id = "container-conflict";
+        source = container_conflict_sheet;
+        sheets =
+          Some
+            [
+              ("original", container_conflict_sheet);
+              ("hoisted", container_conflict_hoisted);
+            ];
+        expect =
+          Differs "the hoisted block loses the colour the crossed rule set";
+      };
       {
         id = "canary";
         source = canary_sheet;

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -2189,6 +2189,61 @@ let test_distant_media_merge () =
        ".a{@media (width>=1px){color:red}@media \
         (width>=1px){color:green}color:blue}")
 
+(* CSS Conditional Rules 5 sec. 5: a [@container] rule applies to an element
+   when the container its name selects matches its query, so two blocks under
+   one name and one query hold the same content as one block over their
+   concatenation. What a distant merge has to earn is the move: hoisting the
+   later block over the statements written between changes the order of
+   appearance of its declarations against theirs, and an element computes that
+   differently only where a pair of declarations does not commute. *)
+let test_distant_container_merge () =
+  (* Conditional Rules 5 sec. 5.4: the query container is the nearest ancestor
+     the name selects, so [main] and [side] ask about different elements. The
+     conditions are the same characters and the blocks still hold apart. *)
+  Alcotest.(check string)
+    "keeps distinct container names apart"
+    "@container main (width>=10px){.a{color:red}}.c{background:#00f}@container \
+     side (width>=10px){.b{color:green}}"
+    (minify_str
+       "@container main \
+        (width>=10px){.a{color:red}}.c{background:blue}@container side \
+        (width>=10px){.b{color:green}}");
+  (* An unnamed query takes the nearest ancestor container whatever its name,
+     which is not the nearest one called [main]. *)
+  Alcotest.(check string)
+    "keeps a named and an unnamed query apart"
+    "@container main \
+     (width>=10px){.a{color:red}}.c{background:#00f}@container(width>=10px){.b{color:green}}"
+    (minify_str
+       "@container main \
+        (width>=10px){.a{color:red}}.c{background:blue}@container \
+        (width>=10px){.b{color:green}}");
+  (* The crossed rule writes the colour slot the hoisted block writes on a
+     selector it overlaps, so hoisting computes blue where the source computes
+     green. *)
+  Alcotest.(check string)
+    "keeps blocks apart on a conflicting reorder"
+    "@container(width>=10px){.a{color:red}}.a{color:green}@container(width>=10px){.a{color:#00f}}"
+    (minify_str
+       "@container (width>=10px){.a{color:red}}.a{color:green}@container \
+        (width>=10px){.a{color:blue}}");
+  (* A layer statement establishes cascade order; never merge across it. *)
+  Alcotest.(check string)
+    "no merge across a layer statement"
+    "@container(width>=10px){.a{color:red}}@layer \
+     theme;@container(width>=10px){.b{color:#00f}}"
+    (minify_str
+       "@container (width>=10px){.a{color:red}}@layer theme;@container \
+        (width>=10px){.b{color:blue}}");
+  (* The crossed rule sets another property on another selector, so no element
+     computes anything differently once the block moves before it. *)
+  Alcotest.(check string)
+    "merges across a non-conflicting intervening rule"
+    "@container(width>=10px){.a{color:red}.b{color:green}}.c{background:#00f}"
+    (minify_str
+       "@container (width>=10px){.a{color:red}}.c{background:blue}@container \
+        (width>=10px){.b{color:green}}")
+
 let test_keep_bang_comment_leading () =
   (* A bang comment (/*! ... */) is preserved by minify; it stays where it was
      authored rather than being moved past the following rule. *)
@@ -5355,6 +5410,7 @@ let selector_merging_tests =
       `Quick,
       test_custom_value_close_paren_whitespace );
     ("distant @media merge when safe", `Quick, test_distant_media_merge);
+    ("distant @container merge when safe", `Quick, test_distant_container_merge);
     ( "leading bang comment stays leading",
       `Quick,
       test_keep_bang_comment_leading );


### PR DESCRIPTION
`merge_distant_media` reaches a later same-condition block across intervening rules; `@container` had only the adjacent pass, so a block separated from its twin could never merge. Both families now share one walk and one safety argument, keyed for containers on the whole prelude, so a named and an unnamed query with the same condition stay apart because they select different ancestors.