### PR TITLE
parser: drop a declaration whose value the typed reader rejects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -191,9 +191,10 @@ entry points both moved.
   value the author wrote rather than the token after it, below the line it
   marks and at that line's own column in characters. A value matching no form
   of a property says so (#472, #477, #789, #793, #801)
-- Lenient parsing preserves a declaration-safe value opaquely when a known
-  property's typed reader rejects it, while retaining the warning that makes
-  strict parsing reject the declaration (#787)
+- Lenient parsing preserves a value opaquely when the property is unknown, the
+  value carries a runtime substitution, or it is a colour fallback. A value the
+  typed reader rejects is an invalid declaration and is dropped, as it always
+  was (#787, #813)
 - Mixed-case keywords in `animation-range` and `scroll()` parse and serialize
   in their canonical lowercase form (#767)
 - Grid track sizes accept math functions that resolve to `<flex>`, including

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -1298,7 +1298,7 @@ let test_recovery_keeps_rules buf =
     recovered_css "recovery keeps sibling rules" css
   in
   let counts = recovered_declaration_counts stylesheet in
-  if not (List.equal Int.equal counts [ 1; 1; 1 ]) then
+  if not (List.equal Int.equal counts [ 1; 0; 1 ]) then
     failf "CSS Syntax recovery changed rule/declaration shape: %S" css;
   if warnings = [] then failf "recovery emitted no warning: %S" css
 
@@ -1335,7 +1335,7 @@ let test_recovery_bad_declaration buf =
     recovered_css "bad declaration recovery" css
   in
   let counts = recovered_declaration_counts stylesheet in
-  if not (List.equal Int.equal counts [ 2 ]) then
+  if not (List.equal Int.equal counts [ 1 ]) then
     failf "CSS Syntax recovery dropped valid declaration after invalid one: %S"
       css;
   if warnings = [] then failf "bad declaration emitted no warning: %S" css

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2320,27 +2320,20 @@ let read_regular_property_declaration t : declaration =
       (String.trim (Parser.string_of_components components))
   else
     try read_typed_property_declaration t start
-    with Cursor.Parse_error error as exn ->
+    with Cursor.Parse_error _ as exn ->
+      (* A declaration-shaped token stream is not a valid declaration: a value
+         the typed reader rejects is one a browser rejects, and README states
+         that those are dropped. The fallback carries the values that are valid
+         CSS this reader cannot represent, which is what
+         [allows_unknown_fallback] names. *)
       let raw_value = String.trim (Parser.string_of_components components) in
-      let already_allowed = allows_unknown_fallback name raw_value in
-      let preserve_opaque =
-        already_allowed || (Cursor.recover t && is_declaration_value raw_value)
-      in
-      if not preserve_opaque then raise exn;
+      if not (allows_unknown_fallback name raw_value) then raise exn;
       Cursor.restore t start;
       let name = String.lowercase_ascii_preserve (read_property_name t) in
       Cursor.ws t;
       if not (Cursor.colon t) then Cursor.err_expected t "':'";
       Cursor.ws t;
-      let declaration = read_unknown_property_declaration t name in
-      if not already_allowed then
-        (* The exception was caught inside [read_declaration]'s context, so add
-           the label it would have gained on the old recovery path. Recording it
-           after the opaque replay succeeds keeps structurally unsafe input on
-           the ordinary one-warning recovery path. *)
-        Cursor.push_warning t
-          { error with path = "read_declaration" :: error.path };
-      declaration
+      read_unknown_property_declaration t name
 
 (* [read_regular_property_declaration] with the name step replaced by the
    property itself. [name] serves the validation and the opaque fallback; the

--- a/test/cli/diff_depth.t
+++ b/test/cli/diff_depth.t
@@ -23,8 +23,8 @@ the report stops fitting.
 
 
 
-Parse warnings lead the report: an opaquely retained declaration whose typed
-reader failed still qualifies every difference below it.
+Parse warnings lead the report: a declaration the parser dropped
+qualifies every difference below it.
 
   $ cat > warn.css <<EOF
   > .x { color: red; width: <value> }
@@ -41,7 +41,6 @@ reader failed still qualifies every difference below it.
   +++ warn.css
   └─ .x
         - margin: 0
-        + width: <value>
   
   [1]
 

--- a/test/cli/diff_warnings.t
+++ b/test/cli/diff_warnings.t
@@ -55,8 +55,6 @@ second file's, then the ones both files raise.
   --- c.css
   +++ d.css
   └─ .x
-        - clear: nope
-        + position: nope
         * margin: 0 -> 1px
   
   [1]
@@ -89,8 +87,6 @@ the two the budget leaves out are counted once rather than once per side.
   --- e.css
   +++ f.css
   └─ .x
-        - z-index: nope
-        + position: nope
         * margin: 0 -> 1px
   
   [1]

--- a/test/cli/fmt_parse_failure.t
+++ b/test/cli/fmt_parse_failure.t
@@ -32,20 +32,21 @@ Reading from stdin reports the same way.
   $ grep '^Error' err3.txt
   Error: <stdin>: parse dropped every rule; refusing to write an empty stylesheet
 
-A rule whose only declaration has a declaration-safe value that the typed
-reader rejects is preserved opaquely. The parse leaves a printable
-statement and reports the typed failure as a warning.
+A rule whose only declaration does not validate is a partial loss, not a
+total one. CSS Syntax 3 sec. 5.4.4 discards the declaration and returns
+the rule that held it, so the parse leaves a statement; that statement
+has nothing to print, so the output is empty all the same.
 
   $ cat > one-bad-rule.css <<EOF
   > .b { color: notacolor }
   > EOF
   $ cascade fmt one-bad-rule.css > out2.css 2> err2.txt
   $ wc -c < out2.css | tr -d ' '
-  27
+  0
   $ grep '^Error' err2.txt
   [1]
 
-The declaration's typed failure is still reported.
+The declaration that went is still reported.
 
   $ grep -c 'notacolor' err2.txt
   2
@@ -58,7 +59,7 @@ the exit status stays 0.
   > .ok { color: blue }
   > EOF
   $ cascade fmt --minify partial.css 2> /dev/null
-  .b{color:notacolor}.ok{color:#00f}
+  .ok{color:#00f}
 
 Whatever the parser lost. A selector it cannot read takes the whole rule
 that carried it, and the rules either side are written.

--- a/test/cli/inline_imports_errors.t
+++ b/test/cli/inline_imports_errors.t
@@ -10,9 +10,9 @@ preserved.
   $ cascade --minify --inline-imports missing.css 2>&1 | grep -v "warning"
   @import"does-not-exist.css";.a{color:red}
 
-An imported file with a typed value error: the error is reported via warning
-and the declaration-safe value is preserved opaquely; the imported and entry
-rules all pass through.
+An imported file with a parse error: the error is reported via warning
+and the broken rule is dropped; surviving rules pass through and the
+entry's own rules are preserved.
 
   $ cat > broken.css <<EOF
   > .b { color: notacolor }
@@ -23,7 +23,7 @@ rules all pass through.
   > .e { color: green }
   > EOF
   $ cascade --minify --inline-imports entry-broken.css 2>&1 | grep -v "warning"
-  .b{color:notacolor}.ok{color:#00f}.e{color:green}
+  .ok{color:#00f}.e{color:green}
 
 A non-CSS binary file referenced by @import: parse errors yield warnings
 and no content is inlined.

--- a/test/cli/invalid_declaration_dropped.t
+++ b/test/cli/invalid_declaration_dropped.t
@@ -1,0 +1,49 @@
+CLI: an invalid declaration is dropped, a valid untyped one is kept.
+
+README: "empty rules and invalid declarations are dropped in both pretty and
+minified output". A value a browser rejects is an invalid declaration, so it
+goes, whatever shape its token stream has. The opaque fallback is for a value
+that is valid CSS the typed reader cannot represent, which is a different
+thing and is pinned below.
+
+Each of these has a value no browser accepts. The declaration goes and the
+rule with it.
+
+  $ cat > invalid.css <<EOF
+  > a{width:calc(100%- 10px)}
+  > b{transform:translateX(10px red)}
+  > c{display:list-item table}
+  > d{animation-timing-function:steps(1.5)}
+  > e{grid-column-start:0}
+  > f{grid-template-columns:1px [a] [b] 2px}
+  > g{position-area:left block-start}
+  > h{transform-origin:left 10px top 20px}
+  > i{clip-path:inset(1px round auto)}
+  > j{offset:total nonsense here}
+  > k{grid-column-start:span -1}
+  > l{border-width:max(1px,red)}
+  > EOF
+  $ cascade fmt --minify invalid.css 2>/dev/null
+
+
+The same holds without --minify, since the contract names both.
+
+  $ cascade fmt invalid.css 2>/dev/null
+
+
+Each one warns rather than failing the run.
+
+  $ cascade fmt --minify invalid.css 2>&1 >/dev/null | grep -c "bad value\|invalid"
+  12
+
+What the opaque fallback is for, and must keep doing: an unknown property name,
+a value carrying a runtime substitution, and a colour fallback. None of these
+is a value the typed reader rejects as invalid.
+
+  $ cat > opaque.css <<EOF
+  > a{-vendor-thing:whatever it likes}
+  > b{width:var(--w)}
+  > c{color:color(display-p3 1 0 0)}
+  > EOF
+  $ cascade fmt --minify opaque.css
+  a{-vendor-thing:whatever it likes}b{width:var(--w)}c{color:color(display-p3 1 0 0)}

--- a/test/spec/test.ml
+++ b/test/spec/test.ml
@@ -283,7 +283,7 @@ let syntax_escapes () =
 
 (* SS 5.3.7 / 5.4 - Parse errors recover locally *)
 let syntax_recovery () =
-  recover ".a { color: invalid; color: red }" ".a{color:invalid;color:red}" 1;
+  recover ".a { color: invalid; color: red }" ".a{color:red}" 1;
   (* CSS Selectors 4 section 3.9: an unknown pseudo-class at an unforgiving site
      is a spec deviation. Lenient mode preserves it for forward compatibility
      and warns; strict mode escalates (pinned by [cross_mode_pinning]). *)
@@ -403,11 +403,10 @@ let values_absolute_lengths () =
   roundtrip ".x { width: 1pc }" ".x{width:1pc}";
   (* Values 4 SS 10.2 / Values 5 SS 6.5: unknown / future unit identifiers make
      the typed value invalid. Strict rejects (pinned by [cross_mode_pinning]);
-     lenient keeps the declaration-safe stream for forward compatibility and
-     surfaces the unknown unit as a warning. *)
-  recover ".x { width: 1unknown; height: 10px }"
-    ".x{width:1unknown;height:10px}" 1;
-  recover ".x { font-size: 16xyz }" ".x{font-size:16xyz}" 1
+     lenient recovers by dropping the declaration and surfacing the unknown unit
+     as a warning. *)
+  recover ".x { width: 1unknown; height: 10px }" ".x{height:10px}" 1;
+  recover ".x { font-size: 16xyz }" "" 1
 
 (* SS 6.2 - Relative lengths *)
 let values_relative_lengths () =

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1886,40 +1886,11 @@ let public_parse_edges () =
           rules
       in
       Alcotest.(check (list int))
-        "partial parser retains declaration-safe typed failures" [ 1; 1; 1 ]
-        declaration_counts;
+        "partial parser discards invalid declarations, not containing rules"
+        [ 0; 1; 0 ] declaration_counts;
       Alcotest.(check int)
         "partial parser reports invalid rules" 2
-        (List.length parsed.warnings);
-      let opaque =
-        match of_string ~strict:false ".a{animation:#fff}" with
-        | Ok parsed -> parsed
-        | Error err ->
-            Alcotest.failf "lenient parse rejected declaration-safe CSS: %s"
-              (Cascade.Error.to_string err)
-      in
-      Alcotest.(check string)
-        "known property typed failure survives as authored CSS"
-        ".a{animation:#fff}"
-        (Css.to_string ~minify:true opaque.stylesheet);
-      Alcotest.(check int)
-        "known property typed failure remains a warning" 1
-        (List.length opaque.warnings);
-      let opaque_fallbacks =
-        match
-          of_string ~strict:false
-            ".a{color:futurecolor(1);color:nonsense}@page{width:1px;width:future(1);height:future(1);height:nonsense}"
-        with
-        | Ok parsed -> parsed
-        | Error err ->
-            Alcotest.failf "lenient parse rejected opaque fallbacks: %s"
-              (Cascade.Error.to_string err)
-      in
-      Alcotest.(check string)
-        "same-property opaque fallbacks survive optimization and page parsing"
-        ".a{color:futurecolor(1);color:nonsense}@page{width:1px;width:future(1);height:future(1);height:nonsense}"
-        (opaque_fallbacks.stylesheet |> Css.optimize
-       |> Css.to_string ~minify:true)
+        (List.length parsed.warnings)
 
 (* A newline inside a string produces a <bad-string-token>. In an at-rule
    prelude that token used to serialize to nothing, so [@media <bad-string>]

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3190,25 +3190,9 @@ let offset_sheet css : Css.parse =
 let offset_minified css =
   String.trim (Css.to_string ~minify:true (offset_sheet css).stylesheet)
 
-(* A value the typed grammar rejects stays in a lenient sheet when its component
-   stream is declaration-safe. It remains opaque and reported, so strict mode
-   still rejects it. *)
-let offset_preserves_untyped value =
-  let css = String.concat "" [ ".x{offset:"; value; "}" ] in
-  let preserved = offset_minified css in
-  Alcotest.(check bool)
-    (css ^ " is preserved") true
-    (not (String.equal preserved ""));
-  Alcotest.(check string)
-    (css ^ " remains stable") preserved
-    (offset_minified preserved);
-  Alcotest.(check bool)
-    (css ^ " warns") true
-    (match (offset_sheet css).warnings with [] -> false | _ :: _ -> true)
-
-(* Declaration-level validation rejects CSS-wide keyword mixtures before the
-   typed offset reader is tried, so they remain ordinary recovery drops. *)
-let offset_drops value =
+(* A value the grammar rejects is dropped from the sheet and reported, not
+   carried through as opaque text. *)
+let offset_rejects value =
   let css = String.concat "" [ ".x{offset:"; value; "}" ] in
   Alcotest.(check string) (css ^ " is dropped") "" (offset_minified css);
   Alcotest.(check bool)
@@ -3298,28 +3282,28 @@ let offset_canonical_slots () =
     "normal none / auto"
 
 let offset_invalid_values () =
-  offset_preserves_untyped "total nonsense here";
+  offset_rejects "total nonsense here";
   (* The [!] multiplier: the leading group must produce a value. *)
-  offset_preserves_untyped "/ center";
+  offset_rejects "/ center";
   (* The anchor is required once the slash is written. *)
-  offset_preserves_untyped "none /";
+  offset_rejects "none /";
   (* The distance and the rotation need a path in front of them. *)
-  offset_preserves_untyped "30deg";
-  offset_preserves_untyped "auto 30deg 90px";
+  offset_rejects "30deg";
+  offset_rejects "auto 30deg 90px";
   (* The path may not follow the distance or the rotation. *)
-  offset_preserves_untyped "100px 0deg path(\"m 0 0 h 100\")";
+  offset_rejects "100px 0deg path(\"m 0 0 h 100\")";
   (* Neither half of the [||] pair may be filled twice. *)
-  offset_preserves_untyped "path(\"m 0 0 h 100\") 100px 200px";
-  offset_preserves_untyped "path(\"m 0 0 h 100\") auto reverse";
-  offset_preserves_untyped "path(\"m 0 0 h 100\") reverse 100px 30deg";
-  offset_preserves_untyped "path(\"m 0 0 h 100\") 200% auto 100px";
+  offset_rejects "path(\"m 0 0 h 100\") 100px 200px";
+  offset_rejects "path(\"m 0 0 h 100\") auto reverse";
+  offset_rejects "path(\"m 0 0 h 100\") reverse 100px 30deg";
+  offset_rejects "path(\"m 0 0 h 100\") 200% auto 100px";
   (* Nothing follows the group but the anchor. *)
-  offset_preserves_untyped "path(\"m 0 0 h 100\") bottom";
+  offset_rejects "path(\"m 0 0 h 100\") bottom";
   (* The anchor is one [<position>]: at most four components. *)
-  offset_preserves_untyped "none/10px 20px 30deg";
+  offset_rejects "none/10px 20px 30deg";
   (* A CSS-wide keyword stands alone (CSS Cascade 5 sec. 7.3). *)
-  offset_drops "initial none";
-  offset_drops "none/inherit"
+  offset_rejects "initial none";
+  offset_rejects "none/inherit"
 
 let offset_slots_roundtrip () =
   offset_roundtrips ".x{offset:auto}";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1595,11 +1595,9 @@ let spec_strict_rejects_invalid_stylesheets () =
 
 let spec_lenient_recovery_stylesheets () =
   lenient_recover "bad declaration then good declaration"
-    ".a { color: invalid-color; color: red }"
-    ".a{color:invalid-color;color:red}" 1;
+    ".a { color: invalid-color; color: red }" ".a{color:red}" 1;
   lenient_recover "bad declaration keeps sibling rule"
-    ".a { color: rgb(300); } .b { color: red }"
-    ".a{color:rgb(300)}.b{color:red}" 1;
+    ".a { color: rgb(300); } .b { color: red }" ".b{color:red}" 1;
   (* CSS Syntax 3 sec. 5.4.2 consumes the at-rule and its block whatever the
      name, so what recovers here is the rule after it, not the at-rule. *)
   lenient_recover "unknown at-rule keeps its neighbour"
@@ -1618,74 +1616,74 @@ let spec_lenient_recovery_stylesheets () =
     ".a { color: red; @else { color: green } background: blue }"
     ".a{color:red;background:#00f}" 1
 
-(* A typed value failure with a declaration-safe stream is retained opaquely in
-   lenient mode and reported. CSS Syntax 3 sec. 5.4.4 recovery still drops a
-   structurally unsafe declaration at the next top-level [;]. A nested at-rule's
-   body is <block-contents> just like a style rule's (CSS Nesting 1 sec. 3.3),
-   so the same boundary applies inside it. *)
+(* CSS Syntax 3 sec. 5.4.4 "consume a style block's contents" ends an invalid
+   declaration at the next top-level [;], and a [{}] met on the way is one
+   component value of the value being skipped, not a stopping point. A nested
+   at-rule's body is <block-contents> just like a style rule's (CSS Nesting 1
+   sec. 3.3), so the same recovery applies inside it: Blink 146 drops the one
+   declaration and keeps every neighbour, the enclosing group rule and the rest
+   of the sheet. *)
 let spec_lenient_recovery_nested_at_rule_declarations () =
+  let recovered = ".a{@media screen{color:red;background:#00f}}" in
   lenient_recover "bad declaration first in a nested at-rule"
-    ".a { @media screen { width: 10; color: red; background: blue } }"
-    ".a{@media screen{width:10;color:red;background:#00f}}" 1;
+    ".a { @media screen { width: 10; color: red; background: blue } }" recovered
+    1;
   lenient_recover "bad declaration mid-run in a nested at-rule"
-    ".a { @media screen { color: red; width: 10; background: blue } }"
-    ".a{@media screen{color:red;width:10;background:#00f}}" 1;
+    ".a { @media screen { color: red; width: 10; background: blue } }" recovered
+    1;
   lenient_recover "bad declaration last in a nested at-rule"
-    ".a { @media screen { color: red; background: blue; width: 10 } }"
-    ".a{@media screen{color:red;background:#00f;width:10}}" 1;
-  lenient_recover "sole untyped declaration of a nested at-rule preserved"
-    ".a { @media screen { width: 10 } }" ".a{@media screen{width:10}}" 1;
+    ".a { @media screen { color: red; background: blue; width: 10 } }" recovered
+    1;
+  lenient_recover "sole declaration of a nested at-rule dropped"
+    ".a { @media screen { width: 10 } }" "" 1;
   lenient_recover "bad declaration in a nested style rule"
-    ".a { & b { color: red; width: 10; margin: 0 } }"
-    ".a b{color:red;width:10;margin:0}" 1;
+    ".a { & b { color: red; width: 10; margin: 0 } }" ".a b{color:red;margin:0}"
+    1;
   lenient_recover "bad declaration in a style rule under a nested at-rule"
     ".a { @media screen { & b { color: red; width: 10; margin: 0 } } }"
-    ".a{@media screen{& b{color:red;width:10;margin:0}}}" 1;
+    ".a{@media screen{& b{color:red;margin:0}}}" 1;
   lenient_recover "bad declaration in a doubly nested at-rule"
     ".a { @media screen { @container (width > 0px) { color: red; width: 10; \
      background: blue } } }"
-    ".a{@media \
-     screen{@container(width>0px){color:red;width:10;background:#00f}}}"
-    1;
+    ".a{@media screen{@container(width>0px){color:red;background:#00f}}}" 1;
   lenient_recover "nested at-rule keeps recovery in @layer"
     ".a { @layer x { color: red; width: 10; background: blue } }"
-    ".a{@layer x{color:red;width:10;background:#00f}}" 1;
+    ".a{@layer x{color:red;background:#00f}}" 1;
   lenient_recover "nested at-rule keeps recovery in @scope"
     ".a { @scope (.b) { color: red; width: 10; background: blue } }"
-    ".a{@scope(.b){color:red;width:10;background:#00f}}" 1;
+    ".a{@scope(.b){color:red;background:#00f}}" 1;
   lenient_recover "nested at-rule keeps recovery in @starting-style"
     ".a { @starting-style { color: red; width: 10; background: blue } }"
-    ".a{@starting-style{color:red;width:10;background:#00f}}" 1;
+    ".a{@starting-style{color:red;background:#00f}}" 1;
   (* A [{}] in the dropped value is consumed with it; the run resumes at the [;]
      after it. An unclosed function has no such [;] - the tokenizer closes it at
      the end of the block, so it swallows the rest, as Blink does. *)
   lenient_recover "curly block inside a dropped value is skipped with it"
     ".a { @media screen { color: red; width: {1}; background: blue } }"
-    ".a{@media screen{color:red;background:#00f}}" 1;
+    recovered 1;
   lenient_recover "unclosed function swallows the rest of the block"
     ".a { @media screen { color: red; width: calc(1px; background: blue } }"
     ".a{@media screen{color:red}}" 1;
   lenient_recover "a run of stray tokens is dropped like a bad declaration"
-    ".a { @media screen { color: red; !!!; background: blue } }"
-    ".a{@media screen{color:red;background:#00f}}" 1
+    ".a { @media screen { color: red; !!!; background: blue } }" recovered 1
 
-(* An opaque declaration keeps its place in the declaration run around nested
-   rules. *)
+(* A dropped declaration leaves no gap: the run written around it is one run, as
+   it is in Blink 146, the same way a dropped at-rule leaves one. *)
 let spec_lenient_recovery_nested_declaration_run () =
   lenient_recover "bad declaration immediately before a nested rule"
     ".a { @media screen { width: 10; & b { color: red } } }"
-    ".a{@media screen{width:10;& b{color:red}}}" 1;
+    ".a{@media screen{& b{color:red}}}" 1;
   lenient_recover "bad declaration immediately after a nested rule"
     ".a { @media screen { & b { color: red } width: 10; background: blue } }"
-    ".a{@media screen{& b{color:red}width:10;background:#00f}}" 1;
-  lenient_recover "opaque declaration stays in the run before a rule"
+    ".a{@media screen{& b{color:red}background:#00f}}" 1;
+  lenient_recover "dropped declaration does not seal the run before a rule"
     ".a { @media screen { color: red; width: 10; background: blue; & b { \
      margin: 0 } } }"
-    ".a{@media screen{color:red;width:10;background:#00f;& b{margin:0}}}" 1;
-  lenient_recover "opaque declaration stays in the run it opened"
+    ".a{@media screen{color:red;background:#00f;& b{margin:0}}}" 1;
+  lenient_recover "dropped declaration does not seal the run it opened"
     ".a { @media screen { width: 10; color: red; & b { margin: 0 } background: \
      blue } }"
-    ".a{@media screen{width:10;color:red;& b{margin:0}background:#00f}}" 1
+    ".a{@media screen{color:red;& b{margin:0}background:#00f}}" 1
 
 (* [css] reports exactly [expected] warnings leniently, and [~strict:true]
    rejects it exactly when the lenient parse warned. *)
@@ -1716,23 +1714,24 @@ let spec_recovery_warns_once_per_declaration () =
     1;
   check ".a { @media screen { color: red; background: blue } }" 0
 
-(* The declaration-safe/unsafe recovery boundary also applies to descriptors in
-   page and margin contexts. A complete but untyped value stays opaque; a value
-   with a curly block or an unclosed function is still discarded without taking
-   its neighbours. *)
+(* CSS Paged Media 3 sec. 4.1: "If an error is encountered during the processing
+   of a declaration block within a page or a margin context, the Rules for
+   handling parsing errors apply; that is, valid declarations within the block
+   are applied." One bad descriptor therefore costs that descriptor, not the
+   [@page] holding it and not the sheet holding that. The discard follows CSS
+   Syntax 3 sec. 5.4.4 for a declaration - up to the next top-level [;], a [{}]
+   met on the way counting as one component value of the value being skipped -
+   and sec. 5.4.2 for an at-rule, which ends at its block or its [;]. Blink 146
+   keeps both neighbours in every case below. *)
 let spec_lenient_recovery_page_descriptors () =
   let recovered = "@page{margin:1cm;margin-top:2cm}" in
   lenient_recover "bad descriptor first in @page"
-    "@page { width: 10; margin: 1cm; margin-top: 2cm }"
-    "@page{width:10;margin:1cm;margin-top:2cm}" 1;
+    "@page { width: 10; margin: 1cm; margin-top: 2cm }" recovered 1;
   lenient_recover "bad descriptor mid-body in @page"
-    "@page { margin: 1cm; width: 10; margin-top: 2cm }"
-    "@page{margin:1cm;width:10;margin-top:2cm}" 1;
+    "@page { margin: 1cm; width: 10; margin-top: 2cm }" recovered 1;
   lenient_recover "bad descriptor last in @page"
-    "@page { margin: 1cm; margin-top: 2cm; width: 10 }"
-    "@page{margin:1cm;margin-top:2cm;width:10}" 1;
-  lenient_recover "sole untyped descriptor of @page preserved"
-    "@page { width: 10 }" "@page{width:10}" 1;
+    "@page { margin: 1cm; margin-top: 2cm; width: 10 }" recovered 1;
+  lenient_recover "sole descriptor of @page dropped" "@page { width: 10 }" "" 1;
   lenient_recover "curly block inside a dropped page value is skipped with it"
     "@page { margin: 1cm; width: {1}; margin-top: 2cm }" recovered 1;
   lenient_recover "two curly blocks in a dropped page value are one skip"
@@ -1769,8 +1768,7 @@ let spec_lenient_recovery_page_descriptors () =
 let spec_lenient_recovery_page_margin_box () =
   let recovered = "@page{@top-center{content:\"x\";margin:0}}" in
   lenient_recover "bad descriptor in a page margin box"
-    "@page { @top-center { content: \"x\"; width: 10; margin: 0 } }"
-    "@page{@top-center{content:\"x\";width:10;margin:0}}" 1;
+    "@page { @top-center { content: \"x\"; width: 10; margin: 0 } }" recovered 1;
   lenient_recover "at-rule in a page margin box ends at its block"
     "@page { @top-center { @media screen { a: b } content: \"x\"; margin: 0 } }"
     recovered 1;
@@ -1783,21 +1781,21 @@ let spec_lenient_recovery_page_margin_box () =
   lenient_recover "selector-shaped item alone in a page margin box"
     "@page { @top-center { .a { b: c } } }" "" 1
 
-(* An opaque descriptor keeps its source-order place among the page's
-   declarations. Margin boxes are emitted after that declaration run. *)
+(* A dropped descriptor leaves no gap: the page keeps the descriptors written
+   around it in source order, and its margin boxes keep theirs. *)
 let spec_lenient_recovery_page_body_order () =
   lenient_recover "bad descriptor before a page margin box"
     "@page { margin: 1cm; width: 10; @top-center { content: \"x\" } \
      margin-top: 2cm }"
-    "@page{margin:1cm;width:10;margin-top:2cm;@top-center{content:\"x\"}}" 1;
+    "@page{margin:1cm;margin-top:2cm;@top-center{content:\"x\"}}" 1;
   lenient_recover "bad descriptor after a page margin box"
     "@page { margin: 1cm; @top-center { content: \"x\" } width: 10; \
      margin-top: 2cm }"
-    "@page{margin:1cm;width:10;margin-top:2cm;@top-center{content:\"x\"}}" 1;
+    "@page{margin:1cm;margin-top:2cm;@top-center{content:\"x\"}}" 1;
   lenient_recover "bad descriptor between two page margin boxes"
     "@page { @top-center { content: \"x\" } width: 10; @bottom-center { \
      content: \"y\" } margin: 1cm }"
-    "@page{width:10;margin:1cm;@top-center{content:\"x\"}@bottom-center{content:\"y\"}}"
+    "@page{margin:1cm;@top-center{content:\"x\"}@bottom-center{content:\"y\"}}"
     1
 
 (* Each dropped page descriptor reports once, and [~strict:true] rejects exactly
@@ -2660,15 +2658,16 @@ let css_syntax_recovery () =
       (name ^ " warning count") true
       (List.length warnings >= min_warnings)
   in
-  (* Syntactically valid unknown declarations are preserved. A declaration-safe
-     value rejected by a known property's typed reader is preserved opaquely in
-     lenient mode and reported; malformed streams are still dropped. *)
+  (* Syntactically valid unknown declarations are preserved (browsers do, and
+     dropping changes the stylesheet for vendor properties / future spec
+     additions / properties Cascade just doesn't model). Only malformed or
+     known-but-invalid declarations are dropped (see [invalid declaration] case
+     below). *)
   check_strict "unknown declaration"
     ".btn { unknown-property: value; color: red; }"
     ".btn{unknown-property:value;color:red}";
   check_recovery "invalid declaration"
-    ".btn { color: invalid-color; color: red; }"
-    ".btn{color:invalid-color;color:red}" 1;
+    ".btn { color: invalid-color; color: red; }" ".btn{color:red}" 1;
   check_recovery "invalid selector list"
     ".ok { color: green } .bad:not() { color: red }" ".ok{color:green}" 1;
   check_recovery "unknown at-rule"
@@ -2699,13 +2698,13 @@ let css_syntax_recovery_structural () =
       (name ^ " warning count") true
       (List.length warnings >= min_warnings)
   in
-  (* Declaration-safe typed failures survive opaquely; qualified rules retain
-     them while the warnings preserve the strict/spec signal. *)
-  check_counts "bad declarations stay in their rules"
+  (* CSS Syntax 5.4.4: invalid declarations are discarded; qualified rules
+     survive even if every declaration in the rule was invalid. *)
+  check_counts "bad declarations leave empty rules"
     ".a { color: rgb(300); } .b { color: red; } .c { width: calc(1px + ); }"
-    [ 1; 1; 1 ] 2;
+    [ 0; 1; 0 ] 2;
   check_counts "bad declaration does not discard later declaration"
-    ".a { color: rgb(300); background-color: red; }" [ 2 ] 1;
+    ".a { color: rgb(300); background-color: red; }" [ 1 ] 1;
   check_counts "bad selector list drops rule only"
     ".ok { color: green } .bad:not() { color: red } .next { color: blue }"
     [ 1; 1 ] 1;
@@ -6306,7 +6305,7 @@ let v4_10_2_calc_arithmetic () =
     "calc(1px * 0) -> 0" ".x{width:0}"
     (normalize ".x { width: calc(1px * 0) }");
   Alcotest.(check string)
-    "a numeric calc remains opaque in lenient mode" ".x{width:calc(0 + 0)}"
+    "a numeric calc cannot be a width" ""
     (normalize ".x { width: calc(0 + 0) }")
 
 let v4102_calc_addition () =


### PR DESCRIPTION
README states that invalid declarations are dropped in both pretty and minified output. #787 widened the opaque fallback to any declaration-shaped token stream, which every invalid value also satisfies, so a dozen values a browser rejects were written back verbatim instead. The fallback returns to what it covered before: an unknown property, a runtime substitution, or a colour fallback. Seven oracles that had been rewritten to expect the values kept are restored, including the spec vectors citing CSS Syntax 3.