### PR TITLE
diff: order rule differences by expected-side source position

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1065,6 +1065,9 @@ entry points both moved.
 
 ### CLI tools
 
+- `cascade diff` prints rule differences in the order the expected side names
+  the rules, where a hash table's bucket layout decided it, so a report reads
+  down the sheet and `--limit` keeps the differences nearest the top (#814)
 - `cascade diff --json` writes the comparison as one JSON document on standard
   output in place of the report, so a harness reads what changed rather than
   parsing prose. The exit status is unchanged (#799)

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -253,7 +253,20 @@ let reported_declaration d =
   in
   (Css.declaration_name d, value)
 
-let group_into_table rules = Group.by ~size:128 Fun.id rules
+let group_into_table rules = Group.by Fun.id rules
+
+(* The keys the expected side names, in the order it names them. Walking [tbl1]
+   with [Hashtbl.iter] instead would order the report by the stdlib hash and the
+   table's capacity, neither of which is a fact about the sheet. *)
+let keys_in_source_order rules =
+  let seen = Hashtbl.create 128 in
+  List.filter_map
+    (fun (key, _) ->
+      if Hashtbl.mem seen key then None
+      else (
+        Hashtbl.add seen key ();
+        Some key))
+    rules
 
 (* Compare two declaration lists with the same key and emit diffs *)
 let diff_same_key_pair key d1 d2 =
@@ -338,7 +351,12 @@ let build_reorder_diff expected_css actual_css =
   let tbl1 = group_into_table rules1 in
   let tbl2 = group_into_table rules2 in
   let diffs = ref [] in
-  Hashtbl.iter (collect_key_diffs ~tbl2 ~diffs) tbl1;
+  List.iter
+    (fun key ->
+      Option.iter
+        (collect_key_diffs ~tbl2 ~diffs key)
+        (Hashtbl.find_opt tbl1 key))
+    (keys_in_source_order rules1);
   if !diffs = [] then None
   else Some D.{ rules = List.rev !diffs; containers = []; layer_order = None }
 

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -119,6 +119,13 @@ val diff :
     preserves exact colour channels and non-terminating numeric arithmetic
     during canonical comparison.
 
+    Two sheets that hold the same rules and the same declarations, and differ
+    only in the order a rule writes them, leave the structural walk with nothing
+    to say. Mode [`Auto] recovers those differences under the selector each
+    belongs to, in the order the expected side first names those selectors, and
+    a rule only the actual side holds names no expected selector so it is not
+    among them.
+
     [prune_unused_custom_props] (default [false], [`Canonical] mode only) drops
     custom-property bindings referenced by nothing on both sides before
     comparing, so two stylesheets that differ only by a dead binding compare

--- a/lib/diff/group.ml
+++ b/lib/diff/group.ml
@@ -2,10 +2,10 @@
 
 (* Buckets are built by prepending and reversed once at the end, so grouping
    stays linear while each bucket still reads in the order the list did. [size]
-   is the table's initial capacity, which decides how keys land in buckets: a
-   caller that walks the result with [Hashtbl.iter] sees that order, so the
-   capacity is part of what it asks for rather than a hint. *)
-let by ~size key items =
+   is the table's initial capacity and nothing else: it decides which bucket a
+   key lands in, so a caller that needs a defined order over the keys takes it
+   from the list it grouped rather than from [Hashtbl.iter]. *)
+let by ?(size = 16) key items =
   let tbl = Hashtbl.create size in
   List.iter
     (fun item ->

--- a/lib/diff/group.mli
+++ b/lib/diff/group.mli
@@ -1,6 +1,8 @@
 (** Grouping a list into a hash table of buckets. *)
 
-val by : size:int -> ('a -> 'k * 'v) -> 'a list -> ('k, 'v list) Hashtbl.t
-(** [by ~size key items] splits [items] into a table of [size] initial capacity,
-    binding each key [key] returns to the values it returned for, in the order
-    [items] gave them. *)
+val by : ?size:int -> ('a -> 'k * 'v) -> 'a list -> ('k, 'v list) Hashtbl.t
+(** [by key items] binds each key [key] returns to the values it returned for,
+    in the order [items] gave them. [size] (default [16]) is the table's initial
+    capacity, a sizing hint: it decides which bucket a key lands in and so the
+    order [Hashtbl.iter] walks them, which is why a caller that needs a defined
+    order over the keys takes it from [items]. *)

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2625,7 +2625,7 @@ let extract_items_with_positions extract_fn stmts =
   |> List.filter_map (fun x -> x)
 
 let group_by_condition items =
-  Group.by ~size:16 (fun (pos, cond, rules) -> (cond, (pos, rules))) items
+  Group.by (fun (pos, cond, rules) -> (cond, (pos, rules))) items
 
 (* Two sides holding a different number of blocks under one condition split or
    merged them. Where those blocks sit is a separate question, and one
@@ -3061,7 +3061,7 @@ let rec media_condition_differs rules_list1 rules_list2 =
   else None
 
 and media_diff items1 items2 =
-  let group items = Group.by ~size:16 Fun.id items in
+  let group items = Group.by Fun.id items in
   let groups1 = group items1 in
   let groups2 = group items2 in
   let added = ref [] in

--- a/test/cli/diff_report_order.t
+++ b/test/cli/diff_report_order.t
@@ -1,0 +1,90 @@
+CLI: cascade diff - the order rule differences are printed in.
+
+The entries follow the expected side down its source, so a reader compares
+the report against the sheet in one pass and a truncated report names the
+differences nearest the top rather than an arbitrary sample of them.
+
+Each selector below holds two rules the other side swaps. That is a
+cascade-visible move no order key distinguishes, so every selector in the
+sheet carries a difference and nothing but the ordering is under test.
+
+  $ cat > order_ref.css <<'CSS'
+  > .a{margin:0;margin-top:1px}.a{margin-top:1px;margin:0}
+  > .b{margin:0;margin-top:1px}.b{margin-top:1px;margin:0}
+  > .c{margin:0;margin-top:1px}.c{margin-top:1px;margin:0}
+  > .d{margin:0;margin-top:1px}.d{margin-top:1px;margin:0}
+  > CSS
+  $ cat > order_out.css <<'CSS'
+  > .a{margin-top:1px;margin:0}.a{margin:0;margin-top:1px}
+  > .b{margin-top:1px;margin:0}.b{margin:0;margin-top:1px}
+  > .c{margin-top:1px;margin:0}.c{margin:0;margin-top:1px}
+  > .d{margin-top:1px;margin:0}.d{margin:0;margin-top:1px}
+  > CSS
+  $ NO_COLOR=1 cascade diff --limit=none order_ref.css order_out.css
+  CSS: 220 chars vs 220 chars (0.0% diff)
+  Changes: 8 reordered rules
+  
+  --- order_ref.css
+  +++ order_out.css
+  Rules reordered (8 rules):
+  ├─ .a
+  │     * margin ↔ margin-top
+  ├─ .a
+  │     * margin-top ↔ margin
+  ├─ .b
+  │     * margin ↔ margin-top
+  ├─ .b
+  │     * margin-top ↔ margin
+  ├─ .c
+  │     * margin ↔ margin-top
+  ├─ .c
+  │     * margin-top ↔ margin
+  ├─ .d
+  │     * margin ↔ margin-top
+  └─ .d
+        * margin-top ↔ margin
+  
+  [1]
+
+A bounded report is the head of that same order, not a sample of it.
+
+  $ NO_COLOR=1 cascade diff --limit=2 order_ref.css order_out.css
+  CSS: 220 chars vs 220 chars (0.0% diff)
+  Changes: 8 reordered rules
+  
+  --- order_ref.css
+  +++ order_out.css
+  Rules reordered (2 rules):
+  ├─ .a
+  │     * margin ↔ margin-top
+  ├─ .a
+  │     * margin-top ↔ margin
+  └─ ...6 more differences
+  
+  [1]
+
+Renaming the selectors gives them different hashes and lands them in
+different buckets. The report is unmoved: it reads down the sheet, and the
+sheet says .zq, .h, .m3, .r.
+
+  $ cat > wide_ref.css <<'CSS'
+  > .zq{margin:0;margin-top:1px}.zq{margin-top:1px;margin:0}
+  > .h{margin:0;margin-top:1px}.h{margin-top:1px;margin:0}
+  > .m3{margin:0;margin-top:1px}.m3{margin-top:1px;margin:0}
+  > .r{margin:0;margin-top:1px}.r{margin-top:1px;margin:0}
+  > CSS
+  $ cat > wide_out.css <<'CSS'
+  > .zq{margin-top:1px;margin:0}.zq{margin:0;margin-top:1px}
+  > .h{margin-top:1px;margin:0}.h{margin:0;margin-top:1px}
+  > .m3{margin-top:1px;margin:0}.m3{margin:0;margin-top:1px}
+  > .r{margin-top:1px;margin:0}.r{margin:0;margin-top:1px}
+  > CSS
+  $ NO_COLOR=1 cascade diff --limit=none wide_ref.css wide_out.css | grep -E '^(├|└)─'
+  ├─ .zq
+  ├─ .zq
+  ├─ .h
+  ├─ .h
+  ├─ .m3
+  ├─ .m3
+  ├─ .r
+  └─ .r


### PR DESCRIPTION
The report printed its rule differences in `Hashtbl.iter` bucket order, so the sequence a reader saw was a function of the stdlib hash and the table's capacity rather than of the stylesheet. It now follows the expected side's source order, which is what `--limit` truncation implies: the first differences shown are the first in the sheet. The grouping helper's capacity goes back to a default, since it no longer decides anything visible.