### PR TITLE
diff: order container differences by expected-side source position

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1067,7 +1067,9 @@ entry points both moved.
 
 - `cascade diff` prints rule differences in the order the expected side names
   the rules, where a hash table's bucket layout decided it, so a report reads
-  down the sheet and `--limit` keeps the differences nearest the top (#814)
+  down the sheet and `--limit` keeps the differences nearest the top. A
+  container only one side holds prints after every entry that names a place in
+  the expected sheet (#814, #815)
 - `cascade diff --json` writes the comparison as one JSON document on standard
   output in place of the report, so a harness reads what changed rather than
   parsing prose. The exit status is unchanged (#799)

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -258,15 +258,7 @@ let group_into_table rules = Group.by Fun.id rules
 (* The keys the expected side names, in the order it names them. Walking [tbl1]
    with [Hashtbl.iter] instead would order the report by the stdlib hash and the
    table's capacity, neither of which is a fact about the sheet. *)
-let keys_in_source_order rules =
-  let seen = Hashtbl.create 128 in
-  List.filter_map
-    (fun (key, _) ->
-      if Hashtbl.mem seen key then None
-      else (
-        Hashtbl.add seen key ();
-        Some key))
-    rules
+let keys_in_source_order rules = Group.keys Fun.id rules
 
 (* Compare two declaration lists with the same key and emit diffs *)
 let diff_same_key_pair key d1 d2 =

--- a/lib/diff/group.ml
+++ b/lib/diff/group.ml
@@ -16,3 +16,14 @@ let by ?(size = 16) key items =
   Hashtbl.to_seq_keys tbl |> List.of_seq
   |> List.iter (fun k -> Hashtbl.replace tbl k (List.rev (Hashtbl.find tbl k)));
   tbl
+
+let keys key items =
+  let seen = Hashtbl.create 16 in
+  List.filter_map
+    (fun item ->
+      let k, _ = key item in
+      if Hashtbl.mem seen k then None
+      else (
+        Hashtbl.add seen k ();
+        Some k))
+    items

--- a/lib/diff/group.mli
+++ b/lib/diff/group.mli
@@ -6,3 +6,8 @@ val by : ?size:int -> ('a -> 'k * 'v) -> 'a list -> ('k, 'v list) Hashtbl.t
     capacity, a sizing hint: it decides which bucket a key lands in and so the
     order [Hashtbl.iter] walks them, which is why a caller that needs a defined
     order over the keys takes it from [items]. *)
+
+val keys : ('a -> 'k * 'v) -> 'a list -> 'k list
+(** [keys key items] is the distinct keys [key] returns, in the order [items]
+    first names them. It is what a caller walking [by key items] takes its order
+    from, [Hashtbl.iter] answering in bucket order instead. *)

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2679,6 +2679,16 @@ let container_moved ~container_type ~condition_of ~stmts1 ~stmts2 cond rules =
    blocks share is named once for the group. Every condition both sides hold is
    asked, not only the ones whose bodies differ: a block that kept its body and
    swapped with the rule below it changes which declaration wins. *)
+(* Take one value from a condition's bucket, leaving the rest. A stylesheet may
+   write one condition several times, so a bucket holds an occurrence apiece and
+   each is answered where the sheet writes it. *)
+let take_bucket tbl key =
+  match Hashtbl.find_opt tbl key with
+  | Some (v :: rest) ->
+      Hashtbl.replace tbl key rest;
+      Some v
+  | Some [] | None -> None
+
 let container_reorders ~container_type ~condition_of ~moved_conds ~reported
     ~stmts1 ~stmts2 items =
   List.filter_map
@@ -3104,6 +3114,47 @@ and process_modified_container ~container_type ~condition_of ~moved_conds
       container_moved ~container_type ~condition_of ~stmts1 ~stmts2 cond rules1
     else None
 
+(* What one occurrence of a condition on the expected side contributes. A
+   removal comes first and can repeat, since two blocks of one condition may
+   both be gone; everything else is answered once per condition, [settled]
+   recording which, so a later occurrence does not restate it. *)
+and expected_container_entry ~container_type ~condition_of ~moved_conds ~stmts1
+    ~stmts2 ~block_structure_changed ~pending_removed ~pending_modified ~settled
+    ~reported (_pos, cond, block_rules) =
+  match take_bucket pending_removed cond with
+  (* The bucket says a block of this condition is gone; which one is this
+     occurrence, whose own rules are the ones to report. Taking the bucket's
+     copy would pair the first occurrence with whichever block the diff happened
+     to name first. *)
+  | Some _ ->
+      Hashtbl.replace reported cond ();
+      Some (Removed { container_type; condition = cond; rules = block_rules })
+  | None when Hashtbl.mem settled cond -> None
+  | None -> (
+      Hashtbl.replace settled cond ();
+      match Hashtbl.find_opt block_structure_changed cond with
+      | Some (expected_blocks, actual_blocks) ->
+          Hashtbl.replace reported cond ();
+          Some
+            (Block_structure_changed
+               {
+                 container_type;
+                 condition = cond;
+                 expected_blocks;
+                 actual_blocks;
+               })
+      | None -> (
+          match take_bucket pending_modified cond with
+          | Some (rules1, rules2) ->
+              process_modified_container ~container_type ~condition_of
+                ~moved_conds ~stmts1 ~stmts2 ~block_structure_changed ~reported
+                cond rules1 rules2
+          | None when Hashtbl.mem moved_conds cond ->
+              Hashtbl.replace reported cond ();
+              container_moved ~container_type ~condition_of ~stmts1 ~stmts2 cond
+                block_rules
+          | None -> None))
+
 and process_nested_containers ~container_type ~extract_fn ~diff_fn stmts1 stmts2
     =
   let condition_of stmt = Option.map fst (extract_fn stmt) in
@@ -3119,38 +3170,34 @@ and process_nested_containers ~container_type ~extract_fn ~diff_fn stmts1 stmts2
   let items1 = List.filter_map extract_fn stmts1 in
   let items2 = List.filter_map extract_fn stmts2 in
   let added, removed, modified = diff_fn items1 items2 in
-  let diffs = ref [] in
-  Hashtbl.iter
-    (fun cond (expected_blocks, actual_blocks) ->
-      Hashtbl.replace reported cond ();
-      diffs :=
-        Block_structure_changed
-          { container_type; condition = cond; expected_blocks; actual_blocks }
-        :: !diffs)
-    block_structure_changed;
-  List.iter
-    (fun (cond, rules) ->
-      Hashtbl.replace reported cond ();
-      diffs := Added { container_type; condition = cond; rules } :: !diffs)
-    added;
-  List.iter
-    (fun (cond, rules) ->
-      Hashtbl.replace reported cond ();
-      diffs := Removed { container_type; condition = cond; rules } :: !diffs)
-    removed;
-  List.iter
-    (fun (cond, rules1, rules2) ->
-      match
-        process_modified_container ~container_type ~condition_of ~moved_conds
-          ~stmts1 ~stmts2 ~block_structure_changed ~reported cond rules1 rules2
-      with
-      | Some diff -> diffs := diff :: !diffs
-      | None -> ())
-    modified;
+  let pending_removed = Group.by Fun.id removed in
+  let pending_added = Group.by Fun.id added in
+  let pending_modified =
+    Group.by (fun (cond, rules1, rules2) -> (cond, (rules1, rules2))) modified
+  in
+  let settled = Hashtbl.create 8 in
+  let expected_diffs =
+    List.filter_map
+      (expected_container_entry ~container_type ~condition_of ~moved_conds
+         ~stmts1 ~stmts2 ~block_structure_changed ~pending_removed
+         ~pending_modified ~settled ~reported)
+      items_with_pos1
+  in
+  let added_diffs =
+    List.filter_map
+      (fun (_pos, cond, _rules) ->
+        Option.map
+          (fun rules ->
+            Hashtbl.replace reported cond ();
+            Added { container_type; condition = cond; rules })
+          (take_bucket pending_added cond))
+      items_with_pos2
+  in
+  let diffs = ref (expected_diffs @ added_diffs) in
   diffs :=
-    container_reorders ~container_type ~condition_of ~moved_conds ~reported
-      ~stmts1 ~stmts2 items1
-    @ !diffs;
+    !diffs
+    @ container_reorders ~container_type ~condition_of ~moved_conds ~reported
+        ~stmts1 ~stmts2 items1;
   (if !diffs = [] then
      match
        detect_order_only_change ~container_type added removed items1 items2

--- a/test/cli/diff_container_order.t
+++ b/test/cli/diff_container_order.t
@@ -1,0 +1,136 @@
+CLI: cascade diff - the order container differences are printed in.
+
+Container entries follow the expected side down its source, the same
+coordinate rule differences already use, so a reader checks the report
+against the sheet in one pass instead of against a hash table.
+
+The preamble names byte counts and file names, which are not what these
+cases are about, so each run is projected to the report body.
+
+Conditions that hash into one order and are written in another. The
+sheet says print, screen, 10px, 20px, speech.
+
+  $ cat > many_ref.css <<'CSS'
+  > @media print{.a{color:red}}
+  > @media screen{.b{color:red}}
+  > @media (min-width:10px){.c{color:red}}
+  > @media (min-width:20px){.d{color:red}}
+  > @media speech{.e{color:red}}
+  > CSS
+  $ cat > many_out.css <<'CSS'
+  > @media print{.a{color:blue}}
+  > @media screen{.b{color:blue}}
+  > @media (min-width:10px){.c{color:blue}}
+  > @media (min-width:20px){.d{color:blue}}
+  > @media speech{.e{color:blue}}
+  > CSS
+  $ NO_COLOR=1 cascade diff --diff=tree --limit=none many_ref.css many_out.css | sed -n '6,$p'
+  ├─ @media print (1 modified)
+  │  └─ .a
+  │        * color: red -> blue
+  ├─ @media screen (1 modified)
+  │  └─ .b
+  │        * color: red -> blue
+  ├─ @media (min-width: 10px) (1 modified)
+  │  └─ .c
+  │        * color: red -> blue
+  ├─ @media (min-width: 20px) (1 modified)
+  │  └─ .d
+  │        * color: red -> blue
+  └─ @media speech (1 modified)
+     └─ .e
+           * color: red -> blue
+  
+
+A stylesheet may write one condition several times, and two blocks under
+the same condition can sit either side of another block. Each keeps the
+place the sheet gives it, so the two `@media print` entries below are
+not drawn together and the entries between them are not displaced.
+
+  $ cat > twice_ref.css <<'CSS'
+  > @media print{.a{color:red}}
+  > @media screen{.b{color:red}}
+  > @media speech{.c{color:red}}
+  > @media print{.d{color:red}}
+  > CSS
+  $ cat > twice_out.css <<'CSS'
+  > @media screen{.b{color:blue}}
+  > @media speech{.c{color:blue}}
+  > CSS
+  $ NO_COLOR=1 cascade diff --diff=tree --limit=none twice_ref.css twice_out.css | sed -n '6,$p'
+  ├─ @media print (removed)
+  │  └─ .a (removed)
+  ├─ @media screen (1 modified)
+  │  └─ .b
+  │        * color: red -> blue
+  ├─ @media speech (1 modified)
+  │  └─ .c
+  │        * color: red -> blue
+  └─ @media print (removed)
+     └─ .d (removed)
+  
+
+A container only the actual side holds names no place in the expected
+sheet, so it prints after every entry that names one, in the order the
+actual side writes it: @media tv is written before @media all.
+
+  $ cat > add_ref.css <<'CSS'
+  > @media print{.a{color:red}}
+  > @media screen{.b{color:red}}
+  > CSS
+  $ cat > add_out.css <<'CSS'
+  > @media tv{.z{color:red}}
+  > @media print{.a{color:blue}}
+  > @media all{.y{color:red}}
+  > @media screen{.b{color:blue}}
+  > CSS
+  $ NO_COLOR=1 cascade diff --diff=tree --limit=none add_ref.css add_out.css | sed -n '6,$p'
+  ├─ @media print (1 modified)
+  │  └─ .a
+  │        * color: red -> blue
+  ├─ @media screen (1 modified)
+  │  └─ .b
+  │        * color: red -> blue
+  ├─ @media tv (added)
+  │  └─ .z (added)
+  └─ @media all (added)
+     └─ .y (added)
+  
+
+A condition whose two sides hold a different number of blocks reports
+that split or merge, and takes the same place as any other entry.
+
+  $ cat > split_ref.css <<'CSS'
+  > @media print{.a{color:red}}
+  > @media print{.b{color:red}}
+  > @media screen{.c{color:red}}
+  > @media screen{.d{color:red}}
+  > @media speech{.e{color:red}}
+  > @media speech{.f{color:red}}
+  > @media tv{.g{color:red}}
+  > @media tv{.h{color:red}}
+  > CSS
+  $ cat > split_out.css <<'CSS'
+  > @media print{.a{color:red}.b{color:red}}
+  > @media screen{.c{color:red}.d{color:red}}
+  > @media speech{.e{color:red}.f{color:red}}
+  > @media tv{.g{color:red}.h{color:red}}
+  > CSS
+  $ NO_COLOR=1 cascade diff --diff=tree --limit=none split_ref.css split_out.css | sed -n '6,$p'
+  ├─ @media print (2 blocks merged into 1)
+  │     - Block at position 0: .a
+  │     - Block at position 1: .b
+  │     + Block at position 0: .a, .b
+  ├─ @media screen (2 blocks merged into 1)
+  │     - Block at position 2: .c
+  │     - Block at position 3: .d
+  │     + Block at position 1: .c, .d
+  ├─ @media speech (2 blocks merged into 1)
+  │     - Block at position 4: .e
+  │     - Block at position 5: .f
+  │     + Block at position 2: .e, .f
+  └─ @media tv (2 blocks merged into 1)
+        - Block at position 6: .g
+        - Block at position 7: .h
+        + Block at position 3: .g, .h
+  


### PR DESCRIPTION
#814 fixed the rule half; container entries were still ordered by `Hashtbl.iter` bucket layout. They now follow the expected side down its source, with three cases the rule fix did not face: a container only the actual side holds prints after everything positioned, in the order that side writes it; a condition written twice keeps both places rather than drawing its blocks together; and a removal reports the rules of the occurrence it sits at, not whichever block the diff named first.