### PR TITLE
nest: drop a rule nested under a pseudo-element parent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -366,6 +366,9 @@ entry points both moved.
 
 ### Minification
 
+- `--minify` drops a rule nested under a pseudo-element parent, such as `.b` in
+  `.a::before{.b{color:red}}`, where merging the wrapper into it composed
+  `.a::before .b`, a selector the reader refuses and no engine matches (#818)
 - `--minify` merges a `@container` block into an earlier one carrying the same
   name and query across the rules written between them, where only adjacent
   blocks merged and a hoist over a conflicting rule stays refused (#809)

--- a/lib/flatten.ml
+++ b/lib/flatten.ml
@@ -19,25 +19,11 @@ let concat_map_preserve f xs =
 let contains_nesting = Nest.contains
 let substitute_nesting = Nest.substitute
 let combine_with_parent = Nest.combine
+let keep_readable_branches = Nest.keep_readable_branches
 
 let scope_selector_in_context (parent : Selector.t) selector =
   if contains_nesting selector then substitute_nesting ~parent selector
   else selector
-
-(* CSS Selectors 4 sec. 3.6.5: a combinator after a pseudo-element is invalid,
-   and nesting composes exactly that selector out of a valid parent and a valid
-   child. Such a rule matches nothing in any engine, so drop the branches that
-   follow the pseudo-element and keep the ones that extend its compound. *)
-let keep_readable_branches (selector : Selector.t) =
-  let keeps sel = not (Selector.has_combinator_after_pseudo_element sel) in
-  match selector with
-  | Selector.List branches -> (
-      match List.filter keeps branches with
-      | [] -> Option.None
-      | [ branch ] -> Option.Some branch
-      | branches -> Option.Some (Selector.List branches))
-  | sel when keeps sel -> Option.Some sel
-  | _ -> Option.None
 
 let rec flat_rule ?(parent : Selector.t option) (rule : rule) : statement list =
   let selector =

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -74,10 +74,30 @@ let rec combine parent child =
   | _ when contains child -> substitute ~parent child
   | _ -> Selector.Combined (grouped parent, Selector.Descendant, child)
 
+(* CSS Selectors 4 sec. 3.6.5: a combinator after a pseudo-element is invalid,
+   and nesting composes exactly that selector out of a valid parent and a valid
+   child. Such a rule matches nothing in any engine, so drop the branches that
+   follow the pseudo-element and keep the ones that extend its compound. *)
+let keep_readable_branches (selector : Selector.t) =
+  let keeps sel = not (Selector.has_combinator_after_pseudo_element sel) in
+  match selector with
+  | Selector.List branches -> (
+      match List.filter keeps branches with
+      | [] -> Option.None
+      | [ branch ] -> Option.Some branch
+      | branches -> Option.Some (Selector.List branches))
+  | sel when keeps sel -> Option.Some sel
+  | _ -> Option.None
+
+(* Merging composes the same selector flattening does, so it drops the same
+   branches. A wrapper left with no branch to merge into keeps nothing of its
+   own, and the empty-rule pass takes it. *)
 let rec merge_lone (rule : rule) =
   match (rule.declarations, rule.nested) with
-  | [], [ Rule child ] when not (is_list rule.selector) ->
-      merge_lone { child with selector = combine rule.selector child.selector }
+  | [], [ Rule child ] when not (is_list rule.selector) -> (
+      match keep_readable_branches (combine rule.selector child.selector) with
+      | Option.Some selector -> merge_lone { child with selector }
+      | Option.None -> { rule with nested = [] })
   | _ -> rule
 
 (* What a run of nested statements would have to cross to move ahead of them:

--- a/lib/nest.mli
+++ b/lib/nest.mli
@@ -9,8 +9,17 @@ val substitute : ?leftmost:bool -> parent:Selector.t -> Selector.t -> Selector.t
 val combine : Selector.t -> Selector.t -> Selector.t
 (** Combine a parent selector with a nested child selector. *)
 
+val keep_readable_branches : Selector.t -> Selector.t option
+(** [keep_readable_branches sel] keeps the branches of [sel] that a reader
+    accepts, and is [None] when none does. Nesting composes a parent and a child
+    that are each valid into a selector putting a combinator after a
+    pseudo-element, which CSS Selectors 4 sec. 3.6.5 makes invalid and no engine
+    matches. *)
+
 val merge_lone : Stylesheet.rule -> Stylesheet.rule
-(** Merge a pure wrapper rule with its sole nested rule when safe. *)
+(** Merge a pure wrapper rule with its sole nested rule when safe. A merge
+    {!keep_readable_branches} rejects outright leaves the wrapper empty, for the
+    empty-rule pass to drop. *)
 
 val hoist_declaration_runs : Stylesheet.rule -> Stylesheet.rule
 (** [hoist_declaration_runs rule] moves each declaration written after a nested

--- a/test/cli/minify_nesting_pseudo_element.t
+++ b/test/cli/minify_nesting_pseudo_element.t
@@ -1,0 +1,38 @@
+CLI: nesting under a pseudo-element parent, and what --minify reads back.
+
+CSS Selectors 4 sec. 3.6.5 (ED) makes a combinator after a pseudo-element
+invalid, and no engine matches one. Nesting composes exactly that selector out
+of a valid parent and a valid child, so merging a lone wrapper into its sole
+nested rule drops the branches that follow the pseudo-element, as flattening
+already does.
+
+  $ cat > nested.css <<CSS
+  > .a::before { .b { color: red } }
+  > CSS
+  $ cascade --minify nested.css
+  $ cascade --minify --flatten-nesting nested.css
+
+Whatever --minify writes, --minify reads back. Composing a selector the reader
+refuses broke that round trip: the second pass dropped every rule.
+
+  $ cascade --minify nested.css | cascade --minify -
+
+A branch that leaves the pseudo-element last stays, and reads back.
+
+  $ cat > branches.css <<CSS
+  > .a::before { .b, .c & { color: red } }
+  > CSS
+  $ cascade --minify branches.css
+  .c .a:before{color:red}
+  $ cascade --minify branches.css | cascade --minify -
+  .c .a:before{color:red}
+
+A parent with no pseudo-element still merges, and reads back the same way.
+
+  $ cat > plain.css <<CSS
+  > .a { .b { color: red } }
+  > CSS
+  $ cascade --minify plain.css
+  .a .b{color:red}
+  $ cascade --minify plain.css | cascade --minify -
+  .a .b{color:red}

--- a/test/test_nest.ml
+++ b/test/test_nest.ml
@@ -53,6 +53,31 @@ let test_merge_lone_wrapper () =
     "wrapper with declarations preserved" ".card{color:red;.title{width:1px}}"
     (Pp.to_string ~minify:true Stylesheet.pp_rule with_decl)
 
+(* CSS Selectors 4 sec. 3.6.5 makes a combinator after a pseudo-element invalid,
+   and the selector reader refuses [.a::before .b] when it is authored directly.
+   Merging a lone wrapper into its sole nested rule reaches that selector from a
+   valid parent and a valid child, so it applies the rule too, as
+   [Flatten.block] does for the same input: the branches that follow the
+   pseudo-element go, and a wrapper left with nothing goes with the empty
+   rules. *)
+let test_merge_lone_pseudo_element_parent () =
+  let merged css =
+    Pp.to_string ~minify:true Stylesheet.pp_rule (Nest.merge_lone (rule css))
+  in
+  Alcotest.(check string)
+    "a descendant under a pseudo-element parent goes" ".a:before{}"
+    (merged ".a::before{.b{color:red}}");
+  Alcotest.(check string)
+    "a child combinator goes the same way" ".a:before{}"
+    (merged ".a::before{>.b{color:red}}");
+  Alcotest.(check string)
+    "a branch extending the compound stays" ".a:before:hover{color:red}"
+    (merged ".a::before{.b,&:hover{color:red}}");
+  (* Control: no pseudo-element, so the merge is valid and still happens. *)
+  Alcotest.(check string)
+    "a plain parent still merges" ".a .b{color:red}"
+    (merged ".a{.b{color:red}}")
+
 (* CSS Nesting 1 sec. 3.4 holds a declaration written after a nested statement
    behind it. Moving it back is cascade-neutral exactly when it commutes with
    what it crosses, so the hoist is decided per declaration and per property. *)
@@ -109,6 +134,8 @@ let suite =
       Alcotest.test_case "combine relative nested and descendant" `Quick
         test_combine_relative_nested_and_descendant;
       Alcotest.test_case "merge_lone wrapper" `Quick test_merge_lone_wrapper;
+      Alcotest.test_case "merge_lone pseudo-element parent" `Quick
+        test_merge_lone_pseudo_element_parent;
       Alcotest.test_case "hoist declaration runs" `Quick
         test_hoist_declaration_runs;
       Alcotest.test_case "rules synthesizes isolated chain" `Quick


### PR DESCRIPTION
`cascade fmt --minify` turned `.a::before{.b{color:red}}` into `.a:before .b{color:red}`, which its own reader then refuses and no engine matches, so the minifier was not idempotent and its output was not valid input. `Flatten.block` already got this right, so both paths now filter branches through the one predicate rather than two. The round-trip property is pinned in its own right.