### PR TITLE
diff: report a reorder only where it can change the cascade

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -630,6 +630,9 @@ entry points both moved.
 
 ### Canonical diff
 
+- A cascade-neutral reordering stays unreported when the two sheets also
+  differ elsewhere, where one changed rule turned every such move in the
+  sheet into a reported difference (#819)
 - Canonical diff equates more rewrites that cannot change what a browser
   computes, such as equal `@supports` blocks hoisted together; a crossing that
   changes which declaration wins stays distinct (#775, #776, #777)

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -224,6 +224,118 @@ let merge_source_reorders (canonical : D.t) (source : D.t) =
     layer_order = canonical.layer_order;
   }
 
+(* A container entry is named by its printed prelude, and the projection keys an
+   [@media] or [@container] prelude to the Level 4 form a source sheet need not
+   write, so the two trees can name one block two ways. Key the source side the
+   same before comparing them: this respells a prelude and moves nothing. *)
+let key_prelude stmt =
+  match Css.as_media stmt with
+  | Some (query, inner) ->
+      Css.media ~condition:(Css.Media.lower_for_minify query) inner
+  | None -> (
+      match Css.as_container stmt with
+      | Some (name, Some condition, inner) ->
+          Css.container ?name
+            ~condition:(Css.Container.lower_for_minify condition)
+            inner
+      | Some (_, None, _) | None -> stmt)
+
+let rec key_query_preludes stmts =
+  List.map
+    (fun stmt ->
+      Css.Stylesheet.map_statement_children key_query_preludes
+        (key_prelude stmt))
+    stmts
+
+type order_gate = {
+  reordered_here : bool;
+  blocks : (D.container_info * order_gate) list;
+}
+(* Whether the projection still disagrees about the order at one level, and the
+   same answer for every block below it. The projection sorts each run whose
+   order no element can observe, so a level it leaves in two orders holds a move
+   an engine can see, and a level it agrees on holds none. Which statement is
+   named as the one that moved stays the inputs' account: a swap has two
+   participants and the two trees need not pick the same one. *)
+
+let container_is_reordered : D.container_diff -> bool = function
+  | D.Reordered _ -> true
+  | D.Modified _ | D.Added _ | D.Removed _ | D.Block_structure_changed _ ->
+      false
+
+let rec gate_of_level rule_changes container_changes =
+  {
+    reordered_here =
+      List.exists rule_is_reordered rule_changes
+      || List.exists container_is_reordered container_changes;
+    blocks = List.filter_map gate_of_container container_changes;
+  }
+
+and gate_of_container :
+    D.container_diff -> (D.container_info * order_gate) option = function
+  | D.Modified change ->
+      Some
+        (change.info, gate_of_level change.rule_changes change.container_changes)
+  (* Blocks merged or split: the walk below cannot pair them up, so this level
+     answers that it cannot tell rather than that nothing moved. *)
+  | D.Block_structure_changed change ->
+      Some
+        ( {
+            D.container_type = change.container_type;
+            condition = change.condition;
+            rules = [];
+          },
+          { reordered_here = true; blocks = [] } )
+  | D.Reordered _ | D.Added _ | D.Removed _ -> None
+
+let gate_of_canonical (diff : D.t) = gate_of_level diff.rules diff.containers
+
+(* A block the canonical tree does not name is one the projection made the same
+   on both sides, so nothing inside it moved. The exception is a nested rule,
+   which the projection flattens away: its statements answer to the level that
+   receives them. *)
+let gate_for gate (info : D.container_info) =
+  match info.container_type with
+  | `Nesting -> Some gate
+  | `Media | `Layer | `Supports | `Container | `Property | `At_rule -> (
+      match List.filter (fun (i, _) -> same_container i info) gate.blocks with
+      | [] -> None
+      | matches ->
+          Some
+            {
+              reordered_here =
+                List.exists (fun (_, g) -> g.reordered_here) matches;
+              blocks = List.concat_map (fun (_, g) -> g.blocks) matches;
+            })
+
+let gated_rule_changes gate changes =
+  if gate.reordered_here then changes
+  else List.filter (fun change -> not (rule_is_reordered change)) changes
+
+let rec gated_container gate : D.container_diff -> D.container_diff option =
+  function
+  | D.Reordered _ as change -> if gate.reordered_here then Some change else None
+  | D.Modified change -> (
+      match gate_for gate change.info with
+      | None -> None
+      | Some gate ->
+          let rule_changes = gated_rule_changes gate change.rule_changes in
+          let container_changes =
+            List.filter_map (gated_container gate) change.container_changes
+          in
+          if rule_changes = [] && container_changes = [] then None
+          else Some (D.Modified { change with rule_changes; container_changes })
+      )
+  | (D.Added _ | D.Removed _ | D.Block_structure_changed _) as change ->
+      Some change
+
+let gate_source_reorders gate (diff : D.t) =
+  {
+    D.rules = gated_rule_changes gate diff.rules;
+    containers = List.filter_map (gated_container gate) diff.containers;
+    layer_order = diff.layer_order;
+  }
+
 (* Collect all rules with their path-qualified selector keys *)
 let rec collect_keyed_rules acc path stmts =
   List.fold_left
@@ -515,15 +627,25 @@ let diff_canonical_parsed ~expected ~actual ~expected_parse ~actual_parse
     ~expected_canon ~actual_canon =
   match (Css.of_string expected_canon, Css.of_string actual_canon) with
   | Ok { stylesheet = expected_ast; _ }, Ok { stylesheet = actual_ast; _ } ->
-      let canonical_diff =
-        tree_diff ~expected:expected_ast ~actual:actual_ast |> without_reorders
+      let canonical_tree =
+        tree_diff ~expected:expected_ast ~actual:actual_ast
       in
+      let canonical_diff = without_reorders canonical_tree in
+      (* A move has to be one the inputs hold and one the cascade can see. The
+         source tree answers the first, the projection the second, and a move
+         missing from either is not reported: neither the churn the projection's
+         own ordering creates around a content change, nor a run the projection
+         is free to sort, which reads the same however either sheet writes
+         it. *)
+      let gate = gate_of_canonical canonical_tree in
       let source_reorders =
         match (expected_parse, actual_parse) with
         | ( Ok { Css.stylesheet = expected_source; _ },
             Ok { Css.stylesheet = actual_source; _ } ) ->
-            tree_diff ~expected:expected_source ~actual:actual_source
-            |> only_reorders
+            tree_diff
+              ~expected:(key_query_preludes expected_source)
+              ~actual:(key_query_preludes actual_source)
+            |> only_reorders |> gate_source_reorders gate
         | Error _, _ | _, Error _ ->
             { D.rules = []; containers = []; layer_order = None }
       in

--- a/lib/diff/css_compare.mli
+++ b/lib/diff/css_compare.mli
@@ -91,9 +91,12 @@ type mode = [ `Auto | `Tree | `String | `Canonical ]
       the two when the walk reaches it and as a string diff of them when it does
       not. A reorder in that tree is named without a position: its index belongs
       to the generated canonical form and cannot be located in either input. Use
-      [`Tree] when source-AST indexes are useful. Only order changes present in
-      the parsed inputs are reported; a content change that perturbs the
-      canonical projection's rule order is not an authored reorder.
+      [`Tree] when source-AST indexes are useful. An order change is reported
+      when the parsed inputs hold it and the projection still leaves that level
+      in two orders. A content change that perturbs the projection's rule order
+      is not an authored reorder, and a run the projection is free to sort reads
+      the same whichever order a sheet writes it in, whether or not the two
+      sheets differ elsewhere.
 
     The projection runs no rewrite whose applicability depends on the order the
     input happens to put its rules in. Factoring shared declarations into a

--- a/test/cli/diff_canonical_source_order.t
+++ b/test/cli/diff_canonical_source_order.t
@@ -46,3 +46,199 @@ element and both write `color`, so swapping the rules changes the winner.
   └─ .a (moved)
   
   [1]
+
+A reordering the projection normalises is not an authored reorder either, and
+one real difference elsewhere does not make it one. These two sheets differ
+only in the order of two rules writing different properties, so no element
+resolves differently either way.
+
+  $ cat > neutral.css <<'CSS'
+  > .a{color:red}.b{margin:0}
+  > CSS
+  $ cat > neutral-swapped.css <<'CSS'
+  > .b{margin:0}.a{color:red}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none neutral.css neutral-swapped.css
+  CSS files are identical
+
+Adding a rule to the second sheet says nothing about that swap, so the report
+names the added rule and stops.
+
+  $ cat > neutral-extra.css <<'CSS'
+  > .b{margin:0}.a{color:red}.y{outline:0}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none neutral.css neutral-extra.css
+  CSS: 26 chars vs 39 chars (50.0% diff)
+  Changes: 1 added rule
+  
+  --- neutral.css
+  +++ neutral-extra.css
+  └─ .y
+        + outline: 0
+  
+  [1]
+
+A whole block reads the same way. CSS Properties and Values API 1 sec. 2 makes
+registrations for different names order-independent, so the order of a run of
+`@property` rules is not a difference, with or without the added rule.
+
+  $ cat > props.css <<'CSS'
+  > @property --a{syntax:"*";inherits:false}@property --b{syntax:"*";inherits:false}@property --c{syntax:"*";inherits:false}.x{color:red}
+  > CSS
+  $ cat > props-shuffled.css <<'CSS'
+  > @property --c{syntax:"*";inherits:false}@property --a{syntax:"*";inherits:false}@property --b{syntax:"*";inherits:false}.x{color:red}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none props.css props-shuffled.css
+  CSS files are identical
+
+  $ cat > props-extra.css <<'CSS'
+  > @property --c{syntax:"*";inherits:false}@property --a{syntax:"*";inherits:false}@property --b{syntax:"*";inherits:false}.x{color:red}.y{outline:0}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none props.css props-extra.css
+  CSS: 134 chars vs 147 chars (9.7% diff)
+  Changes: 1 added rule
+  
+  --- props.css
+  +++ props-extra.css
+  └─ .y
+        + outline: 0
+  
+  [1]
+
+A move the projection does keep is reported however the sheet spells the
+prelude it stands on. Media Queries 4 sec. 4.2 gives `min-width` and the range
+form one meaning, so the projection names the block the second way, and both
+blocks write `color` for `.a`, which an element 25px wide resolves by taking
+whichever comes last.
+
+  $ cat > mq.css <<'CSS'
+  > @media (min-width:10px){.a{color:red}}@media (min-width:20px){.a{color:#00f}}.z{margin:0}
+  > CSS
+  $ cat > mq-swapped.css <<'CSS'
+  > @media (min-width:20px){.a{color:#00f}}@media (min-width:10px){.a{color:red}}.z{margin:1px}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none mq.css mq-swapped.css
+  CSS: 90 chars vs 92 chars (2.2% diff)
+  Changes: 1 modified rule, 1 changed container
+  
+  --- mq.css
+  +++ mq-swapped.css
+  ├─ .z
+  │     * margin: 0 -> 1px
+  └─ @media (width >= 10px) (moved)
+  
+  [1]
+
+Whether a move is a difference is settled by what the two statements write, not
+by whether the sheets also differ somewhere else. Here an `@container` block
+and a bare rule both write `color` for `.a`, so an element inside a 28rem
+container takes whichever comes last, and the move is a difference on its own.
+
+  $ cat > ctr.css <<'CSS'
+  > @container (width>=28rem){.a{color:red}}.a{color:blue}.z{top:0}
+  > CSS
+  $ cat > ctr-moved.css <<'CSS'
+  > .a{color:blue}@container (width>=28rem){.a{color:red}}.z{top:0}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none ctr.css ctr-moved.css
+  CSS: 64 chars vs 64 chars (0.0% diff)
+  Changes: 1 changed container
+  
+  --- ctr.css
+  +++ ctr-moved.css
+  └─ @container (width >= 28rem) (moved)
+  
+  [1]
+
+Changing `.z` as well says nothing about that move, so both are reported.
+
+  $ cat > ctr-moved-edited.css <<'CSS'
+  > .a{color:blue}@container (width>=28rem){.a{color:red}}.z{top:9px}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none ctr.css ctr-moved-edited.css
+  CSS: 64 chars vs 66 chars (3.1% diff)
+  Changes: 1 modified rule, 1 changed container
+  
+  --- ctr.css
+  +++ ctr-moved-edited.css
+  ├─ .z
+  │     * top: 0 -> 9px
+  └─ @container (width >= 28rem) (moved)
+  
+  [1]
+
+The same block over a selector nothing outside it writes `left` for reaches no
+element the rules around it reach, so that move is no difference at all, with
+or without the change to `.z`.
+
+  $ cat > free.css <<'CSS'
+  > @container (width>=28rem){.b{left:0}}.a{color:blue}.z{top:0}
+  > CSS
+  $ cat > free-moved.css <<'CSS'
+  > .a{color:blue}@container (width>=28rem){.b{left:0}}.z{top:0}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none free.css free-moved.css
+  CSS files are identical
+
+  $ cat > free-moved-edited.css <<'CSS'
+  > .a{color:blue}@container (width>=28rem){.b{left:0}}.z{top:9px}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none free.css free-moved-edited.css
+  CSS: 61 chars vs 63 chars (3.3% diff)
+  Changes: 1 modified rule
+  
+  --- free.css
+  +++ free-moved-edited.css
+  └─ .z
+        * top: 0 -> 9px
+  
+  [1]
+
+An `@media` block is read the same way, so the one whose rules reach nothing
+around it moves freely beside a changed declaration.
+
+  $ cat > mfree.css <<'CSS'
+  > @media (min-width:10px){.b{left:0}}.a{color:blue}.z{top:0}
+  > CSS
+  $ cat > mfree-moved.css <<'CSS'
+  > .a{color:blue}@media (min-width:10px){.b{left:0}}.z{top:0}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none mfree.css mfree-moved.css
+  CSS files are identical
+
+  $ cat > mfree-moved-edited.css <<'CSS'
+  > .a{color:blue}@media (min-width:10px){.b{left:0}}.z{top:9px}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none mfree.css mfree-moved-edited.css
+  CSS: 59 chars vs 61 chars (3.4% diff)
+  Changes: 1 modified rule
+  
+  --- mfree.css
+  +++ mfree-moved-edited.css
+  └─ .z
+        * top: 0 -> 9px
+  
+  [1]
+
+A move inside a block reads the block's own answer, and finds it through the
+prelude the projection keys the block by rather than the one the sheet writes.
+Both rules here write `color` for an element carrying either class.
+
+  $ cat > inner.css <<'CSS'
+  > @media (min-width:10px){.a{color:red}.b{color:blue}}.z{top:0}
+  > CSS
+  $ cat > inner-moved.css <<'CSS'
+  > @media (min-width:10px){.b{color:blue}.a{color:red}}.z{top:9px}
+  > CSS
+  $ cascade diff --diff=canonical --limit=none inner.css inner-moved.css
+  CSS: 62 chars vs 64 chars (3.2% diff)
+  Changes: 1 modified rule, 1 changed container
+  
+  --- inner.css
+  +++ inner-moved.css
+  ├─ .z
+  │     * top: 0 -> 9px
+  └─ @media (width >= 10px) (1 reordered)
+     └─ .a (moved)
+  
+  [1]


### PR DESCRIPTION
Canonical mode normalised a cascade-neutral reordering when it was the only difference and reported every one of them the moment anything else differed, because the reorder half of the report was computed from the parsed inputs and never saw the projection. A move is now reported when the inputs hold it and the projection keeps it, so #781's rule that position comes from the inputs is untouched and the significance question is answered separately. On the reporter's case that is 123 entries down to one.