### PR TITLE
nest: drop a dead nested rule wherever it sits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -366,6 +366,9 @@ entry points both moved.
 
 ### Minification
 
+- `--minify` drops a rule nested under a pseudo-element parent wherever it sits,
+  matching `--flatten-nesting`: a parent carrying declarations of its own, a
+  `@media` block between the two or a level of `&` in between kept it (#822)
 - `--minify` drops a rule nested under a pseudo-element parent, such as `.b` in
   `.a::before{.b{color:red}}`, where merging the wrapper into it composed
   `.a::before .b`, a selector the reader refuses and no engine matches (#818)

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -100,6 +100,55 @@ let rec merge_lone (rule : rule) =
       | Option.None -> { rule with nested = [] })
   | _ -> rule
 
+(* The same question, asked of a rule that stays nested: what has to be readable
+   is the branch composed with the parent, but what the rule keeps is the branch
+   in its own spelling. *)
+let live_under parent branch =
+  Option.is_some (keep_readable_branches (combine parent branch))
+
+let live_branches parent (selector : Selector.t) =
+  match selector with
+  | Selector.List branches -> (
+      match Common.List.filter_preserve (live_under parent) branches with
+      | kept when kept == branches -> Option.Some selector
+      | [] -> Option.None
+      | [ branch ] -> Option.Some branch
+      | kept -> Option.Some (Selector.List kept))
+  | sel -> if live_under parent sel then Option.Some sel else Option.None
+
+(* Only a pseudo-element the parent carries can bar what nests under it, and
+   every rule is walked with its own selector as parent, so a parent without one
+   has nothing dead below to look for. *)
+let under_pseudo_element sel = Selector.any Selector.is_pseudo_element sel
+
+(* Merging is one shape of the composition, and the branches it drops are dead
+   wherever they sit. Walk the body under the parent selector and take them
+   there too, subtree and all, as flattening does: a conditional block keeps its
+   parent's selector for what it wraps, and a kept child becomes the parent of
+   its own. *)
+let rec live_statements parent (stmts : statement list) =
+  Common.List.filter_map_preserve (live_statement parent) stmts
+
+and live_statement parent (stmt : statement) =
+  match stmt with
+  | Rule child -> (
+      match live_branches parent child.selector with
+      | Option.None -> Option.None
+      | Option.Some selector ->
+          let nested = live_statements (combine parent selector) child.nested in
+          if selector == child.selector && nested == child.nested then
+            Option.Some stmt
+          else Option.Some (Rule { child with selector; nested }))
+  | stmt -> Option.Some (map_statement_children (live_statements parent) stmt)
+
+let drop_dead_nested (rule : rule) =
+  match rule.nested with
+  | [] -> rule
+  | _ when not (under_pseudo_element rule.selector) -> rule
+  | body ->
+      let nested = live_statements rule.selector body in
+      if nested == body then rule else { rule with nested }
+
 (* What a run of nested statements would have to cross to move ahead of them:
    every declaration they can write at any depth, read through
    [statement_declarations] and [statement_children] so no block at-rule hides

--- a/lib/nest.mli
+++ b/lib/nest.mli
@@ -16,6 +16,14 @@ val keep_readable_branches : Selector.t -> Selector.t option
     pseudo-element, which CSS Selectors 4 sec. 3.6.5 makes invalid and no engine
     matches. *)
 
+val drop_dead_nested : Stylesheet.rule -> Stylesheet.rule
+(** [drop_dead_nested rule] drops from [rule]'s body every nested rule whose
+    selector, composed with the parent's, {!keep_readable_branches} rejects, and
+    every branch of one that keeps others. A dropped rule takes its own body
+    with it, and a conditional block is walked under the same parent, so the
+    body keeps exactly what flattening it would keep. Physically unchanged when
+    nothing is dead. *)
+
 val merge_lone : Stylesheet.rule -> Stylesheet.rule
 (** Merge a pure wrapper rule with its sole nested rule when safe. A merge
     {!keep_readable_branches} rejects outright leaves the wrapper empty, for the

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -93,6 +93,7 @@ let drop_redundant_layer_decls = Block.drop_redundant_layer_decls
 let drop_empty_rules = Block.drop_empty_rules
 let drop_misplaced_imports = Block.drop_misplaced_imports
 let merge_named_layers_by_name = Block.merge_named_layers_by_name
+let drop_dead_nested_rules = Nest.drop_dead_nested
 let merge_lone_nested_rule = Nest.merge_lone
 let hoist_declaration_runs = Nest.hoist_declaration_runs
 let synthesize_nesting_statements = Nest.statements
@@ -505,7 +506,8 @@ and process_layer_statement ?factor_cache ~ctx ~enforce_spec ~owner ~supports
 (* Optimize one rule's nested statements recursively, then drop the redundant
    nesting prefix (see [drop_nesting_prefix]) and let a run written after them
    rejoin the rule's own declarations wherever the cascade allows. The body is
-   the rule's, so it optimizes with the rule as owner. *)
+   the rule's, so it optimizes with the rule as owner. Dead nested rules go
+   before the hoist, so a declaration behind one is no longer held back. *)
 and rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec ~supports rule =
   let nested =
     match (Ctx.recurse_blocks ctx, rule.nested) with
@@ -519,7 +521,8 @@ and rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec ~supports rule =
         if enforce_spec then nested
         else list_map_preserve drop_nesting_prefix nested
   in
-  let rule = hoist_declaration_runs (rule_with_nested rule nested) in
+  let rule = drop_dead_nested_rules (rule_with_nested rule nested) in
+  let rule = hoist_declaration_runs rule in
   let rule =
     let selector = Selector.canonicalize rule.selector in
     if selector == rule.selector then rule else { rule with selector }

--- a/test/cli/minify_nesting_pseudo_element.t
+++ b/test/cli/minify_nesting_pseudo_element.t
@@ -27,6 +27,39 @@ A branch that leaves the pseudo-element last stays, and reads back.
   $ cascade --minify branches.css | cascade --minify -
   .c .a:before{color:red}
 
+The parent keeps its own declarations, and the dead nested rule goes with the
+one the lone-wrapper merge already took: it matches nothing either way.
+
+  $ cat > kept.css <<CSS
+  > .a::before { color: red; .b { color: blue } }
+  > CSS
+  $ cascade --minify kept.css
+  .a:before{color:red}
+  $ cascade --minify --flatten-nesting kept.css
+  .a:before{color:red}
+  $ cascade --minify kept.css | cascade --minify -
+  .a:before{color:red}
+
+A conditional block keeps its parent's selector for what it wraps, so what it
+wraps is as dead.
+
+  $ cat > media.css <<CSS
+  > .a::before { @media print { .b { color: blue } } }
+  > CSS
+  $ cascade --minify media.css
+  $ cascade --minify --flatten-nesting media.css
+
+The same at a remove: [&] names the pseudo-element parent, so a rule nested
+under it follows the pseudo-element too.
+
+  $ cat > deep.css <<CSS
+  > .a::before { & { color: red; .b { color: blue } } }
+  > CSS
+  $ cascade --minify deep.css
+  .a:before{color:red}
+  $ cascade --minify --flatten-nesting deep.css
+  .a:before{color:red}
+
 A parent with no pseudo-element still merges, and reads back the same way.
 
   $ cat > plain.css <<CSS
@@ -36,3 +69,9 @@ A parent with no pseudo-element still merges, and reads back the same way.
   .a .b{color:red}
   $ cascade --minify plain.css | cascade --minify -
   .a .b{color:red}
+
+  $ cat > plain_nested.css <<CSS
+  > .a { color: red; .b { color: blue } }
+  > CSS
+  $ cascade --minify plain_nested.css
+  .a{color:red;.b{color:#00f}}


### PR DESCRIPTION
A rule nested under a pseudo-element parent matches nothing, and only the merge path dropped it, so a parent carrying declarations of its own kept one where `--flatten-nesting` did not. Follow-up to #818, which fixed the merge path alone.