### PR TITLE
nest: drop a branch a pseudo-element's compound refuses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -366,12 +366,9 @@ entry points both moved.
 
 ### Minification
 
-- `--minify` drops a rule nested under a pseudo-element parent wherever it sits,
-  matching `--flatten-nesting`: a parent carrying declarations of its own, a
-  `@media` block between the two or a level of `&` in between kept it (#822)
-- `--minify` drops a rule nested under a pseudo-element parent, such as `.b` in
-  `.a::before{.b{color:red}}`, where merging the wrapper into it composed
-  `.a::before .b`, a selector the reader refuses and no engine matches (#818)
+- Nesting no longer emits a selector no engine matches: a rule under a
+  pseudo-element parent is dropped wherever it sits, as is a branch extending
+  that compound with a pseudo-class it does not take (#818, #822, #823)
 - `--minify` merges a `@container` block into an earlier one carrying the same
   name and query across the rules written between them, where only adjacent
   blocks merged and a hoist over a conflicting rule stays refused (#809)

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -74,12 +74,18 @@ let rec combine parent child =
   | _ when contains child -> substitute ~parent child
   | _ -> Selector.Combined (grouped parent, Selector.Descendant, child)
 
-(* CSS Selectors 4 sec. 3.6.5: a combinator after a pseudo-element is invalid,
-   and nesting composes exactly that selector out of a valid parent and a valid
-   child. Such a rule matches nothing in any engine, so drop the branches that
-   follow the pseudo-element and keep the ones that extend its compound. *)
+(* CSS Selectors 4 sec. 3.6.3 to sec. 3.6.5 bound what may follow a
+   pseudo-element: no combinator, and in its own compound only the
+   pseudo-classes and sub-pseudo-elements that pseudo-element takes. Nesting
+   composes exactly those selectors out of a valid parent and a valid child, so
+   neither half meets the reader's check. Such a rule matches nothing in any
+   engine, so drop the branches that overstep and keep the ones a reader
+   accepts. *)
 let keep_readable_branches (selector : Selector.t) =
-  let keeps sel = not (Selector.has_combinator_after_pseudo_element sel) in
+  let keeps sel =
+    (not (Selector.has_combinator_after_pseudo_element sel))
+    && not (Selector.has_refused_simple_in_compound sel)
+  in
   match selector with
   | Selector.List branches -> (
       match List.filter keeps branches with

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -1397,6 +1397,53 @@ let rec has_combinator_after_pseudo_element = function
       || has_combinator_after_pseudo_element right
   | _ -> false
 
+(* Why a compound may not carry [s] after the pseudo-element it follows.
+   [read_compound] turns each into its own message and [has_refused_simple_-
+   after_pseudo_element] reads the same answer off a built selector, so the two
+   cannot drift. [seen] is the compound's earlier components, most recent
+   first. *)
+type compound_refusal =
+  | Sub_pseudo_element  (** sec. 3.6.4, via [pseudo_element_allows_sub]. *)
+  | Simple_after_pseudo_element  (** sec. 3.6.3, via [is_pe_action]. *)
+  | Pseudo_class_after_pseudo_element
+      (** sec. 3.6.3, via [pseudo_element_allows]. *)
+
+let compound_refusal ~seen s =
+  match List.find_opt is_pseudo_element seen with
+  | Some pe when is_pseudo_element s ->
+      if pseudo_element_allows_sub pe s then Option.None
+      else Option.Some Sub_pseudo_element
+  | Some _ when not (is_pe_action s) -> Option.Some Simple_after_pseudo_element
+  | Some pe when not (pseudo_element_allows pe s) ->
+      Option.Some Pseudo_class_after_pseudo_element
+  | _ -> Option.None
+
+(* The sec. 3.6.3 / 3.6.4 companion of [has_combinator_after_pseudo_element]:
+   nesting extends a pseudo-element's own compound the same way it puts a
+   combinator after one, out of a valid parent and a valid child that neither
+   one meets the reader's check. A pseudo-element inside a functional
+   pseudo-class argument is that argument's own business, as it is for
+   [bars_following_combinator]. *)
+(* Substituting [&] splices the parent compound in as one component, so the walk
+   flattens a nested [Compound] rather than treating it as a simple selector the
+   pseudo-element would refuse outright. *)
+let rec refuses_compound seen = function
+  | [] -> false
+  | Compound inner :: rest -> refuses_compound seen (inner @ rest)
+  | c :: rest -> (
+      match compound_refusal ~seen c with
+      | Some _ -> true
+      | None -> refuses_compound (c :: seen) rest)
+
+let rec has_refused_simple_in_compound = function
+  | List branches -> List.exists has_refused_simple_in_compound branches
+  | Combined (left, _, right) ->
+      has_refused_simple_in_compound left
+      || has_refused_simple_in_compound right
+  | Relative (_, right) -> has_refused_simple_in_compound right
+  | Compound components -> refuses_compound [] components
+  | _ -> false
+
 (* The merged lists are static across the lifetime of the program (every
    constituent is a [let] binding above); memoise them so the [@] cons-chain
    only happens once instead of per [:foo] / [::foo] pseudo read. *)
@@ -1857,15 +1904,14 @@ and read_compound t =
        [:not()]/[:has()] ([read_not_content]/[read_has_content]) and in the rule
        reader when a whole selector list is unknown. *)
     let s = read_simple ~allow_unknown_pseudo_class:true t in
-    match List.find_opt is_pseudo_element acc with
-    | Some pe when is_pseudo_element s ->
-        if pseudo_element_allows_sub pe s then s :: acc
-        else Cursor.err t "pseudo-element not allowed after this pseudo-element"
-    | Some _ when not (is_pe_action s) ->
+    match compound_refusal ~seen:acc s with
+    | Some Sub_pseudo_element ->
+        Cursor.err t "pseudo-element not allowed after this pseudo-element"
+    | Some Simple_after_pseudo_element ->
         Cursor.err t "pseudo-element must be last in compound selector"
-    | Some pe when not (pseudo_element_allows pe s) ->
+    | Some Pseudo_class_after_pseudo_element ->
         Cursor.err t "pseudo-class not allowed after this pseudo-element"
-    | _ -> s :: acc
+    | None -> s :: acc
   in
   let rec loop acc = if can_start () then loop (prepend_simple acc) else acc in
   match loop [] with

--- a/lib/selector.mli
+++ b/lib/selector.mli
@@ -266,6 +266,14 @@ val has_combinator_after_pseudo_element : t -> bool
     without either one being refused. [>>>] and [/deep/] do not count: no engine
     parses them, so the rule never reaches them. *)
 
+val has_refused_simple_in_compound : t -> bool
+(** [has_refused_simple_in_compound sel] is [true] when a compound in [sel]
+    carries, after a pseudo-element, a simple selector that pseudo-element does
+    not take: CSS Selectors 4 sec. 3.6.3 and sec. 3.6.4, the same rows
+    {!of_string} applies while reading. Nesting extends a pseudo-element's
+    compound out of a valid parent and a valid child, so the composed selector
+    escapes the reader's check. *)
+
 val is_pseudo_element : t -> bool
 (** [is_pseudo_element sel] is [true] when [sel] is one simple selector naming a
     pseudo-element: a box other than the originating element, where an

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -63,6 +63,36 @@ let test_pseudo_element_parent_drops_invalid_nesting () =
   (* Control: no pseudo-element, so nesting is valid and lifts as before. *)
   dropped "a plain parent still flattens" ".a{.b{color:red}}" ".a .b{color:red}"
 
+(* CSS Selectors 4 sec. 3.6.3 and sec. 3.6.4 bound what a compound may carry
+   after a pseudo-element, and nesting composes that compound out of a valid
+   parent and a valid child just as it composes a combinator. Chrome 146 drops
+   [a::before:hover], [a::selection:hover] and [a::before:focus] from cssRules
+   and keeps [a::file-selector-button:hover], [a::part(p):hover] and
+   [a::cue:hover]; cascade's reader draws the same line, so the flattener has to
+   draw it too. *)
+let test_pseudo_element_parent_drops_invalid_compound () =
+  let check name css expected =
+    Alcotest.(check string) name expected (render (Flatten.block (block css)))
+  in
+  check "a pseudo-class the pseudo-element refuses goes"
+    ".a::before{&:hover{color:red}}" "";
+  check "so does one after ::selection" ".a::selection{&:hover{color:red}}" "";
+  check "and a second refused user action" ".a::before{&:focus{color:red}}" "";
+  check "a class after the pseudo-element goes" ".a::before{&.b{color:red}}" "";
+  check "so does a sub-pseudo-element it does not define"
+    ".a::before{&::after{color:red}}" "";
+  (* The pseudo-elements that do take a user action keep it. *)
+  check "::file-selector-button takes :hover"
+    ".a::file-selector-button{&:hover{color:red}}"
+    ".a::file-selector-button:hover{color:red}";
+  check "::part() takes :hover" ".a::part(p){&:hover{color:red}}"
+    ".a::part(p):hover{color:red}";
+  check "::cue takes :hover" ".a::cue{&:hover{color:red}}"
+    ".a::cue:hover{color:red}";
+  (* CSS Pseudo-Elements 4 sec. 4.2 defines the ::marker of a ::before. *)
+  check "::before takes ::marker" ".a::before{&::marker{color:red}}"
+    ".a:before::marker{color:red}"
+
 (* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so its
    prelude is ambiguous with a declaration until the block appears:
    [h2:where(...)] reads as the property [h2] with value [where(...)]. Parsing
@@ -191,6 +221,8 @@ let suite =
         test_empty_block_is_empty;
       Alcotest.test_case "pseudo-element parent drops invalid nesting" `Quick
         test_pseudo_element_parent_drops_invalid_nesting;
+      Alcotest.test_case "pseudo-element parent drops an invalid compound"
+        `Quick test_pseudo_element_parent_drops_invalid_compound;
       Alcotest.test_case "nested rule starting with an ident" `Quick
         test_nested_rule_starting_with_ident;
       Alcotest.test_case "bad declaration stays a declaration" `Quick

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -57,9 +57,10 @@ let test_pseudo_element_parent_drops_invalid_nesting () =
   dropped "the parent keeps its own declarations"
     ".a::before{color:red;.b{color:blue}}" ".a:before{color:red}";
   dropped "a child combinator goes the same way" ".a::before{>.b{color:red}}" "";
-  (* Only the branches that follow the pseudo-element go. *)
-  dropped "an amperand branch extending the compound stays"
-    ".a::before{.b,&:hover{color:red}}" ".a:before:hover{color:red}";
+  (* Chrome 146 drops [a::before:hover] from cssRules, and the reader refuses
+     it, so composing it through [&] is dead too. *)
+  dropped "a pseudo-class ::before does not take goes with the rest"
+    ".a::before{.b,&:hover{color:red}}" "";
   (* Control: no pseudo-element, so nesting is valid and lifts as before. *)
   dropped "a plain parent still flattens" ".a{.b{color:red}}" ".a .b{color:red}"
 

--- a/test/test_nest.ml
+++ b/test/test_nest.ml
@@ -71,7 +71,7 @@ let test_merge_lone_pseudo_element_parent () =
     "a child combinator goes the same way" ".a:before{}"
     (merged ".a::before{>.b{color:red}}");
   Alcotest.(check string)
-    "a branch extending the compound stays" ".a:before:hover{color:red}"
+    "a pseudo-class ::before does not take goes too" ".a:before{}"
     (merged ".a::before{.b,&:hover{color:red}}");
   (* Control: no pseudo-element, so the merge is valid and still happens. *)
   Alcotest.(check string)


### PR DESCRIPTION
Nesting composed `.a::before:hover` out of a valid parent and a valid child, so neither half met the reader's check and the flattener emitted a selector Chrome 146 drops from `cssRules` and cascade's own reader refuses. The reader's decision is factored out and now answers both, so the two cannot drift apart. Completes #818 and #822, which covered the combinator case.