### PR TITLE
selector: lift a combinator out of the compound & built

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -366,6 +366,9 @@ entry points both moved.
 
 ### Minification
 
+- `cascade diff --diff=canonical` no longer reports a rule as moved when the
+  two sheets spell one selector as a nested branch and as its flat expansion,
+  where `&` substitution built a compound the reader never produces (#825)
 - Nesting no longer emits a selector no engine matches: a rule under a
   pseudo-element parent is dropped wherever it sits, as is a branch extending
   that compound with a pseudo-class it does not take (#818, #822, #823)

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2754,6 +2754,24 @@ let canonicalize_unordered_list selectors =
   in
   List.sort (fun (k1, _) (k2, _) -> String.compare k1 k2) uniq |> List.map snd
 
+(* Substituting [&] splices a complex parent into a compound's leading slot,
+   giving [Compound [Combined (.L, a); :where(.dark)]] where reading the same
+   selector back gives [Combined (.L, Compound [a; :where(.dark)])]. The two
+   serialise alike and only the second is a compound in the grammar's sense, a
+   sequence of simple selectors, so the trailing components move onto the
+   subject. Without this the two spellings stay structurally distinct while
+   printing identically, and every structural comparison reads them apart. *)
+let rec lift_leading_combinator = function
+  | Combined (left, comb, right) :: rest ->
+      let subject =
+        match lift_leading_combinator (right :: rest) with
+        | Some lifted -> lifted
+        | None -> (
+            match right :: rest with [ one ] -> one | cs -> Compound cs)
+      in
+      Some (Combined (left, comb, subject))
+  | _ -> None
+
 (* [map] rewrites a compound's components before the compound itself, so the
    [Is] branch below has already spliced a single-argument [:is()] into this
    list. A component the reader refuses after the pseudo-element can only have
@@ -2812,13 +2830,16 @@ let canonicalize_nodes sel =
       in
       match node with
       | Compound components -> (
-          match
-            rewrap_pseudo_compound (drop_redundant_universal components)
-          with
-          | [ single ] -> single
-          | components' ->
-              if list_same components' components then node
-              else Compound components')
+          match lift_leading_combinator components with
+          | Some lifted -> lifted
+          | None -> (
+              match
+                rewrap_pseudo_compound (drop_redundant_universal components)
+              with
+              | [ single ] -> single
+              | components' ->
+                  if list_same components' components then node
+                  else Compound components'))
       | List selectors -> canon (fun xs -> List xs) selectors
       | Where selectors -> canon (fun xs -> Where xs) selectors
       | Is selectors -> canonicalize_is node selectors

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -278,6 +278,30 @@ let canonical_nested_and_flattened_selectors_are_equal () =
     (equal ".long-component-name{color:red;&:hover{color:blue}}"
        ".long-component-name{color:red}.long-component-name:focus{color:blue}")
 
+(* A zero-specificity nested branch ties with its parent, so the two orders are
+   both cascade-significant and the projection has to place a movable at-rule
+   the same way whichever spelling it meets. Minify synthesizes the nesting, so
+   a sheet that disagreed with its own minified form could not certify it. *)
+let canonical_movable_at_rule_ignores_nesting () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  let flat =
+    "@media(hover){.M mark{color:#fff}}.L a{color:#888}.L \
+     a:where(.dark){color:#666}"
+  in
+  let nested =
+    "@media(hover){.M mark{color:#fff}}.L \
+     a{color:#888;&:where(.dark){color:#666}}"
+  in
+  Alcotest.(check bool)
+    "a movable at-rule lands alike either side of a :where() nesting" true
+    (equal flat nested);
+  (* The pair the projection must still keep apart: swapping two tied writers of
+     one property on overlapping selectors changes which one wins. *)
+  Alcotest.(check bool)
+    "tied writers keep their order" false
+    (equal ".L a{color:#888}.L a:where(.dark){color:#666}"
+       ".L a:where(.dark){color:#666}.L a{color:#888}")
+
 (* CSS Nesting 1 sec. 3.4 keeps a declaration written after a nested rule where
    the author wrote it, which only matters for a property the nested rule also
    sets. Where nothing clashes across the boundary the two spellings compute the
@@ -1703,4 +1727,6 @@ let suite =
         canonical_numeric_division_follows_precision_mode;
       Alcotest.test_case "canonical nested and flattened selectors" `Quick
         canonical_nested_and_flattened_selectors_are_equal;
+      Alcotest.test_case "canonical movable at-rule ignores nesting" `Quick
+        canonical_movable_at_rule_ignores_nesting;
     ] )


### PR DESCRIPTION
Substituting a complex parent into a compound's leading slot produced `Compound [Combined (.L, a); :where(.dark)]`, where reading the same selector back gives `Combined (.L, Compound [a; :where(.dark)])`. Both serialise as `.L a:where(.dark)` and only the second is a compound in the grammar's sense, so `Selector.canonicalize` did not meet its documented promise that distinct ASTs denoting one selector become structurally equal.

The visible consequence is in `--diff=canonical`: minify synthesises nesting, so a sheet and its own minified form disagreed on where a movable at-rule belongs, and the differ reported a rule as moved. That matters for anyone certifying a minified sheet against the sheet they verified.

This closes one cause. A larger sheet still shows the same class of report from a different cause, tracked separately.