### PR TITLE
rule_order: merge an adjacent pair before sorting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -366,9 +366,10 @@ entry points both moved.
 
 ### Minification
 
-- `cascade diff --diff=canonical` no longer reports a rule as moved when the
-  two sheets spell one selector as a nested branch and as its flat expansion,
-  where `&` substitution built a compound the reader never produces (#825)
+- `cascade diff --diff=canonical` reports a rule as moved only when it really
+  moved. Writing one selector as a nested branch or as its flat expansion, and
+  writing two rules of one selector next to each other or as a single rule, now
+  compare equal, so a sheet and its minified form agree (#825, #826)
 - Nesting no longer emits a selector no engine matches: a rule under a
   pseudo-element parent is dropped wherever it sits, as is a branch extending
   that compound with a pseudo-class it does not take (#818, #822, #823)

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -453,9 +453,16 @@ let coalesce ~canon_body ?parent changed (run : (statement * rule list) list) :
    two same-selector occurrences that a conflicting element previously kept
    apart, enabling a merge the source order hid, so equivalent sheets converge
    regardless of which arrangement they started from. Each merging round removes
-   at least one element, so this terminates. *)
+   at least one element, so this terminates.
+
+   Fold what the run already offers before sorting it. Sorting is free to move
+   two same-selector occurrences apart, and a pair the input wrote adjacent has
+   an empty interval and so always merges; taking it first is what makes the
+   merged and unmerged spellings of that pair converge, where sorting first
+   strands the one that arrived already foldable. *)
 let rec settle ~canon_body ?parent changed (run : (statement * rule list) list)
     : statement list =
+  let run = coalesce ~canon_body ?parent changed run in
   let stmts = sort_run ?parent changed run in
   let sorted =
     List.filter_map

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -302,6 +302,32 @@ let canonical_movable_at_rule_ignores_nesting () =
     (equal ".L a{color:#888}.L a:where(.dark){color:#666}"
        ".L a:where(.dark){color:#666}.L a{color:#888}")
 
+(* Two adjacent rules of one selector are always safe to fold together, so a
+   sheet that writes them apart and one that writes them merged are the same
+   sheet. Sorting first could pull the pair apart and strand a merge that was
+   there to begin with. *)
+let canonical_folds_an_adjacent_same_selector_pair () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  let apart =
+    "@media(prefers-color-scheme:dark){.g:where(.system,.system \
+     *){--t:var(--c);scrollbar-color:var(--h) var(--t)}}.w:where(.dark,.dark \
+     *){--t:#ffffff1a}.w:where(.dark,.dark *){scrollbar-color:var(--h) \
+     var(--t)}.b:where(.dark,.dark \
+     *){background-image:linear-gradient(var(--s))}"
+  in
+  let merged =
+    "@media(prefers-color-scheme:dark){.g:where(.system,.system \
+     *){--t:var(--c);scrollbar-color:var(--h) var(--t)}}.w:where(.dark,.dark \
+     *){--t:#ffffff1a;scrollbar-color:var(--h) var(--t)}.b:where(.dark,.dark \
+     *){background-image:linear-gradient(var(--s))}"
+  in
+  Alcotest.(check bool)
+    "an adjacent pair folds either way" true (equal apart merged);
+  (* The pair that must stay apart: folding these would drop the first write. *)
+  Alcotest.(check bool)
+    "two writes of one property stay distinct" false
+    (equal ".w{color:red}.w{color:blue}" ".w{color:blue}.w{color:red}")
+
 (* CSS Nesting 1 sec. 3.4 keeps a declaration written after a nested rule where
    the author wrote it, which only matters for a property the nested rule also
    sets. Where nothing clashes across the boundary the two spellings compute the
@@ -1729,4 +1755,6 @@ let suite =
         canonical_nested_and_flattened_selectors_are_equal;
       Alcotest.test_case "canonical movable at-rule ignores nesting" `Quick
         canonical_movable_at_rule_ignores_nesting;
+      Alcotest.test_case "canonical folds an adjacent same-selector pair" `Quick
+        canonical_folds_an_adjacent_same_selector_pair;
     ] )


### PR DESCRIPTION
Two rules with the same selector written next to each other can always be merged into one. The canonical projection sorted before it merged, and the sort could move the pair apart, after which the merge no longer applied. A sheet and its minified form then compared as different even though nothing had moved.

On a 662KB stylesheet this takes the spurious findings from 67 to 14.