### PR TITLE
values: read a calc() at every integer position

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -190,6 +190,9 @@ entry points both moved.
 - Grid track sizes accept math functions that resolve to `<flex>`, including
   `calc(1fr * 2)`, `min(1fr, 2fr)` and `clamp(100px, 1fr, 300px)`, in explicit,
   repeated and automatic tracks (#749)
+- `tab-size`, `column-count`, the `columns` shorthand, a `repeat()` track count
+  and a `span` grid line accept a `calc()` resolving to a number, which CSS
+  Values 4 allows wherever an integer is (#827)
 - A sole baseline position in `place-content` is accepted and defaults its
   omitted `justify-content` slot to `start`, as required by CSS Align (#739)
 - Custom-property declarations containing a `<bad-string-token>` are dropped

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -851,16 +851,9 @@ let rec read_visibility t : visibility =
 
 let rec read_z_index t : z_index =
   let read_calc_z t : z_index =
-    (* read_calc handles the calc(...) wrapper itself *)
-    let expr =
-      read_calc ~result_type:`Number
-        (fun _ -> Cursor.err t "unexpected value in z-index calc")
-        t
-    in
-    match eval_numeric_calc expr with
-    | Some f when Float.is_integer f -> Index (int_of_float f)
-    | Some _ -> Cursor.err_invalid t "z-index calc must evaluate to integer"
-    | None -> Calc expr
+    match read_integer_calc "z-index" t with
+    | `Int n -> Index n
+    | `Calc expr -> Calc expr
   in
   let read_var_z t : z_index = Var (read_var read_z_index t) in
   Cursor.enum_or_calls "z-index"

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -287,16 +287,9 @@ let rec pp_flex : flex Pp.t =
 
 let rec read_order t : order =
   let read_calc_order t =
-    (* read_calc handles the calc(...) wrapper itself *)
-    let expr =
-      read_calc ~result_type:`Number
-        (fun _ -> Cursor.err t "unexpected value in order calc")
-        t
-    in
-    match eval_numeric_calc expr with
-    | Some f when Float.is_integer f -> (Int (int_of_float f) : order)
-    | Some _ -> Cursor.err_invalid t "order calc must evaluate to integer"
-    | None -> (Calc expr : order)
+    match read_integer_calc "order" t with
+    | `Int n -> (Int n : order)
+    | `Calc expr -> (Calc expr : order)
   in
   let read_var t : order = Var (read_var read_order t) in
   Cursor.enum_or_calls "order"

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -706,7 +706,7 @@ let read_grid_line_name t =
   else name
 
 let read_grid_span_count t =
-  let n = Cursor.int t in
+  let n = read_integer "grid span" t in
   if n < 1 then Cursor.err_invalid t "grid span count must be positive";
   n
 
@@ -763,16 +763,9 @@ let read_grid_line_name_value t : grid_line =
       match n with Some n -> Num_name (n, name) | None -> Name name)
 
 let read_grid_line_calc t : grid_line =
-  (* read_calc handles the calc(...) wrapper itself *)
-  let expr =
-    read_calc ~result_type:`Number
-      (fun _ -> Cursor.err t "unexpected value in grid-line calc")
-      t
-  in
-  match eval_numeric_calc expr with
-  | Some f when Float.is_integer f -> Num (int_of_float f)
-  | Some _ -> Cursor.err_invalid t "grid-line calc must evaluate to integer"
-  | None -> Calc expr
+  match read_integer_calc "grid-line" t with
+  | `Int n -> Num n
+  | `Calc expr -> Calc expr
 
 let rec read_grid_line t : grid_line =
   Cursor.enum_or_calls "grid-line"
@@ -1020,7 +1013,7 @@ module Grid_template = struct
   let rec read_repeat_count t : repeat_count =
     if Cursor.looking_at t "var(" then Var (Values.read_var read_repeat_count t)
     else
-      match Cursor.option Cursor.int t with
+      match Cursor.option (read_integer "repeat count") t with
       | Some n ->
           if n <= 0 then Cursor.err_invalid t "repeat count must be positive";
           Count n

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -260,7 +260,7 @@ let rec read_page_break_inside_value t : page_break_inside_value =
     t
 
 let read_columns_count t =
-  let n = Cursor.int t in
+  let n = read_integer "column-count" t in
   if n <= 0 then Cursor.err_invalid t "column count must be positive";
   n
 
@@ -341,10 +341,7 @@ let rec read_column_count t : column_count =
       ("revert-layer", Revert_layer);
     ]
     ~var:(fun t -> Var (Values.read_var read_column_count t))
-    ~default:(fun t ->
-      let n = Cursor.int t in
-      if n <= 0 then Cursor.err_invalid t "column count must be positive";
-      Count n)
+    ~default:(fun t -> (Count (read_columns_count t) : column_count))
     t
 
 let rec read_column_span t : column_span =

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1880,13 +1880,24 @@ let rec read_text_size_adjust t : text_size_adjust =
         t
 
 let rec read_tab_size (t : Cursor.t) : tab_size =
+  let number_value t i =
+    if i < 0 then Cursor.err_invalid t "negative tab-size integer";
+    (Int i : tab_size)
+  in
   let read_value t =
     match Cursor.integer_opt t with
-    | Some i ->
-        if i < 0 then Cursor.err_invalid t "negative tab-size integer";
-        (Int i : tab_size)
+    | Some i -> number_value t i
     | None ->
-        Length (Values.read_length ~allow_negative:false ~with_keywords:false t)
+        (* CSS Text 4 (ED) sec. 4.4: [<number> | <length>], so a math function
+           lands in whichever slot its result type names. *)
+        Cursor.one_of
+          [
+            (fun t -> number_value t (Values.read_integer "tab-size" t));
+            (fun t ->
+              Length
+                (Values.read_length ~allow_negative:false ~with_keywords:false t));
+          ]
+          t
   in
   Cursor.enum_or_var "tab-size"
     [

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5684,6 +5684,38 @@ let read_calc : type a.
   else if Cursor.looking_at_func "var" t then Var (read_var read_a t)
   else Cursor.err t "calc() or var()"
 
+(* CSS Values 4 (ED) sec. 10.9: a math function resolving to [<number>] stands
+   wherever an [<integer>] is accepted. A constant expression folds to its
+   integer; one holding a [var()] does not resolve here and stays a calc
+   node. *)
+let read_integer_calc : type a.
+    string -> Cursor.t -> [ `Int of int | `Calc of a calc ] =
+ fun name t ->
+  let expr =
+    read_calc ~result_type:`Number
+      (fun _ ->
+        Cursor.err t
+          (String.concat "" [ "unexpected value in "; name; " calc" ]))
+      t
+  in
+  match eval_numeric_calc expr with
+  | Some f when Float.is_integer f -> `Int (int_of_float f)
+  | Some _ ->
+      Cursor.err_invalid t
+        (String.concat "" [ name; " calc must evaluate to integer" ])
+  | None -> `Calc expr
+
+let read_integer name t =
+  if Cursor.looking_at_calc t then
+    match
+      (read_integer_calc name t : [ `Int of int | `Calc of number calc ])
+    with
+    | `Int n -> n
+    | `Calc _ ->
+        Cursor.err_invalid t
+          (String.concat "" [ name; " calc must evaluate to integer" ])
+  else Cursor.int t
+
 let read_numeric_expression t = read_num_expr t
 
 (* The typed [clamp / minmax / min / max] length readers are part of the

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -598,6 +598,17 @@ val read_calc :
     deferred until substitution. Omitting [result_type] retains the generic AST
     reader behaviour. *)
 
+val read_integer_calc : string -> Cursor.t -> [ `Int of int | `Calc of 'a calc ]
+(** [read_integer_calc name t] parses the math function at an [<integer>]
+    position, which CSS Values 4 sec. 10.9 accepts wherever a literal integer
+    is. A constant expression comes back folded, as [`Int]; one holding a
+    [var()] comes back as [`Calc], for a value type carrying a calc node. [name]
+    names the property in the error a non-integer constant raises. *)
+
+val read_integer : string -> Cursor.t -> int
+(** [read_integer name t] parses an [<integer>] position whose value type
+    carries no calc node: a literal integer, or a [calc()] folding to one. *)
+
 val read_calc_expr : (Cursor.t -> 'a) -> Cursor.t -> 'a calc
 (** [read_calc_expr read t] parses a calc expression body -- the contents of a
     [calc(...)] form without the surrounding [calc(] and [)]. *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4499,6 +4499,28 @@ let test_columns_value () =
   check_columns_value "inherit";
   neg_cursor read_columns_value "invalid-columns"
 
+(* CSS Values 4 (ED) sec. 10.9: a math function that resolves to <number> is
+   valid wherever an <integer> is, so every integer position reads a calc(). The
+   positions here are tab-size's <number> (CSS Text 4 (ED) sec. 4.4),
+   column-count's <integer> and the columns shorthand that carries it (CSS
+   Multicol 1 (ED) sec. 3.2 and 3.3), repeat()'s count (CSS Grid 2 (ED) sec.
+   7.2.3.1) and the span count of <grid-line> (sec. 8.3). A <track-breadth> is
+   not one of them: sec. 7.2.1 admits a <length-percentage> or a <flex> there,
+   never a bare <number>. *)
+let math_function_at_integer_positions () =
+  check_tab_size ~expected:"3" "calc(1 + 2)";
+  check_tab_size "4";
+  check_tab_size "2px";
+  check_column_count ~expected:"3" "calc(1 + 2)";
+  check_column_count "3";
+  check_columns_value ~expected:"3" "calc(1 + 2)";
+  check_columns_value "2";
+  check_grid_template ~expected:"repeat(3,1fr)" "repeat(calc(1 + 2),1fr)";
+  check_grid_template "repeat(2,calc(1px + 2px))";
+  check_grid_line ~expected:"span 3" "span calc(1 + 2)";
+  check_grid_line "span 3";
+  neg_cursor read_grid_template "calc(1 + 2)"
+
 let test_field_sizing () =
   check_field_sizing "content";
   check_field_sizing "fixed";
@@ -5558,6 +5580,8 @@ let additional_tests =
     test_case "caption_side" `Quick test_caption_side;
     test_case "color_scheme" `Quick test_color_scheme;
     test_case "columns_value" `Quick test_columns_value;
+    test_case "math_function_at_integer_positions" `Quick
+      math_function_at_integer_positions;
     test_case "field_sizing" `Quick test_field_sizing;
     test_case "font_size" `Quick test_font_size;
     test_case "mask_box" `Quick test_mask_box;


### PR DESCRIPTION
`tab-size`, `column-count`, the `columns` shorthand, a `repeat()` track count and a `span` grid line dropped a declaration whose value was a `calc()`. CSS Values 4 allows a math function resolving to a number wherever an integer is accepted, so these are now read and folded.

A bare `grid-template-columns: calc(1 + 2)` stays refused: a number is not a track breadth, so that one really is invalid. It is pinned so a wider fix trips on it.

Three readers that already accepted a calc here (`z-index`, `order`, `grid-line`) carried the same block three times; they now share one helper.