### PR TITLE
rule_order: fold a factored group back into its branch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -378,7 +378,9 @@ entry points both moved.
 - `cascade diff --diff=canonical` reports a rule as moved only when it really
   moved. Writing one selector as a nested branch or as its flat expansion, and
   writing two rules of one selector next to each other or as a single rule, now
-  compare equal, so a sheet and its minified form agree (#825, #826)
+  compare equal, so a sheet and its minified form agree. A declaration hoisted
+  into a selector-list group also compares equal to the same declaration
+  written inline in every branch of that group (#825, #826, #831)
 - Nesting emits only selectors a browser can match. A rule nested under a
   pseudo-element parent is dropped wherever it sits, and so is a branch that
   adds a pseudo-class the pseudo-element does not accept (#818, #822, #823)

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -202,27 +202,60 @@ let expand_lists (stmt : statement) : statement list =
 let coalesced_declarations decls = Shorthand.deduplicate_declarations decls
 
 (* Mutable state of one coalescing scan: the run's elements, the graph nodes
-   accumulated into each surviving element, and which elements remain. *)
+   accumulated into each surviving element, which elements remain, and which
+   were plain style rules in the run as it was read. *)
 type scan = {
   graph : Rule_graph.t;
   arr : (statement * rule list) array;
+  plain : bool array;
   members : int list array;
   alive : bool array;
   mutable merged_any : bool;
 }
 
-(* Nothing strictly between [lo] and [hi] conflicts with any accumulated
-   occurrence in [mems]: moving those writes across the interval is
-   unobservable. *)
+(* Two rules that agree wherever they meet. Restrict each to the declarations
+   that overlap the other rule at all; when those two sequences are equal, the
+   writes reaching any one property are the same declarations in the same order
+   whichever rule comes first, so swapping the two changes no computed value.
+   The graph's test is pairwise, and a prefixed property beside its unprefixed
+   twin writes one slot twice, so it reads the two copies of a hoisted group as
+   tied writers of that slot. Factoring produces exactly that shape: it writes
+   one declaration list into every branch of the group. *)
+let overlapping_writes_equal (a : rule) (b : rule) =
+  let with_keys (r : rule) =
+    List.map (fun d -> (d, Shorthand.declaration_overlap_keys d)) r.declarations
+  in
+  let touching x y =
+    List.filter_map
+      (fun (decl, keys) ->
+        let meets (other, other_keys) =
+          Shorthand.declarations_overlap_with_keys decl keys other other_keys
+        in
+        if List.exists meets y then Some decl else None)
+      x
+  in
+  let a = with_keys a and b = with_keys b in
+  List.equal Declaration.same_minified (touching a b) (touching b a)
+
+(* Nothing strictly between [lo] and [hi] observes any accumulated occurrence in
+   [mems] moving across it. A graph conflict between two rules that write the
+   overlapping slots identically is not observable, so it does not count; only
+   plain style rules qualify, since a conditional block stands in the graph for
+   the concatenation of its interior rules and that sequence is not the one any
+   single element sees. *)
 let interval_clear scan ~lo ~hi mems =
   let node i = Rule_graph.Node_id.of_int_exn i in
+  let observed m a =
+    Rule_graph.conflict scan.graph (node m) (node a)
+    && not
+         (scan.plain.(m) && scan.plain.(a)
+         && overlapping_writes_equal
+              (Rule_graph.node_rule scan.graph (node m))
+              (Rule_graph.node_rule scan.graph (node a)))
+  in
   let ok = ref true in
   for m = lo + 1 to hi - 1 do
-    if
-      List.exists
-        (fun a -> Rule_graph.conflict scan.graph (node m) (node a))
-        mems
-    then ok := false
+    if List.exists (observed m) mems then ok := false
   done;
   !ok
 
@@ -431,6 +464,10 @@ let coalesce ~canon_body ?parent changed (run : (statement * rule list) list) :
         {
           graph;
           arr;
+          plain =
+            Array.map
+              (fun (stmt, _) -> match stmt with Rule _ -> true | _ -> false)
+              arr;
           members = Array.init n (fun i -> [ i ]);
           alive = Array.make n true;
           merged_any = false;

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -328,6 +328,39 @@ let canonical_folds_an_adjacent_same_selector_pair () =
     "two writes of one property stay distinct" false
     (equal ".w{color:red}.w{color:blue}" ".w{color:blue}.w{color:red}")
 
+(* Factoring writes one declaration list into every branch of a selector list,
+   so the expanded copies are identical wherever they meet. A prefixed property
+   beside its unprefixed twin writes one cascade slot twice, and the pairwise
+   conflict test reads the two copies as tied writers of that slot; the
+   projection has to see that both rules write the same thing and fold the group
+   back. *)
+let canonical_folds_a_factored_vendor_twin_group () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  let inline =
+    ".o95{--t:opacity(95%);-webkit-backdrop-filter:var(--t);backdrop-filter:var(--t)}.o100{--t:opacity(100%);-webkit-backdrop-filter:var(--t);backdrop-filter:var(--t)}"
+  in
+  let factored =
+    ".o100,.o95{--t:opacity(95%);-webkit-backdrop-filter:var(--t);backdrop-filter:var(--t)}.o100{--t:opacity(100%)}"
+  in
+  Alcotest.(check bool)
+    "a hoisted vendor-twin group folds back inline" true (equal inline factored);
+  (* Same shape, but the group in between writes the slot with a different
+     value, so the two spellings disagree on an element carrying both classes:
+     [backdrop-filter] ends at [blur(1px)] on the left and at [opacity(100%)] on
+     the right. *)
+  Alcotest.(check bool)
+    "a different write in between stays distinct" false
+    (equal
+       ".o100{-webkit-backdrop-filter:var(--t);backdrop-filter:var(--t)}.o95{-webkit-backdrop-filter:blur(1px);backdrop-filter:blur(1px)}.o100{--t:opacity(100%)}"
+       ".o95{-webkit-backdrop-filter:blur(1px);backdrop-filter:blur(1px)}.o100{--t:opacity(100%);-webkit-backdrop-filter:var(--t);backdrop-filter:var(--t)}");
+  (* Hoisting the group above the specialisation flips [--t] on [.o100]: the
+     group wins it at [opacity(95%)] where the inline spelling has
+     [opacity(100%)]. Folding backwards is what would equate these. *)
+  Alcotest.(check bool)
+    "a group written after the specialisation stays distinct" false
+    (equal inline
+       ".o100{--t:opacity(100%)}.o100,.o95{--t:opacity(95%);-webkit-backdrop-filter:var(--t);backdrop-filter:var(--t)}")
+
 (* CSS Nesting 1 sec. 3.4 keeps a declaration written after a nested rule where
    the author wrote it, which only matters for a property the nested rule also
    sets. Where nothing clashes across the boundary the two spellings compute the
@@ -1757,4 +1790,6 @@ let suite =
         canonical_movable_at_rule_ignores_nesting;
       Alcotest.test_case "canonical folds an adjacent same-selector pair" `Quick
         canonical_folds_an_adjacent_same_selector_pair;
+      Alcotest.test_case "canonical folds a factored vendor-twin group" `Quick
+        canonical_folds_a_factored_vendor_twin_group;
     ] )

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -359,7 +359,20 @@ let canonical_folds_a_factored_vendor_twin_group () =
   Alcotest.(check bool)
     "a group written after the specialisation stays distinct" false
     (equal inline
-       ".o100{--t:opacity(100%)}.o100,.o95{--t:opacity(95%);-webkit-backdrop-filter:var(--t);backdrop-filter:var(--t)}")
+       ".o100{--t:opacity(100%)}.o100,.o95{--t:opacity(95%);-webkit-backdrop-filter:var(--t);backdrop-filter:var(--t)}");
+  (* A conditional block writes its declarations under several selectors, so
+     reading its body as one declaration list says nothing about what any single
+     element sees. These two blocks hold the same list under swapped selectors,
+     and folding the [@media (hover)] pair across the one in between hands [.p]
+     [blue] on the left and [red] on the right. *)
+  Alcotest.(check bool)
+    "a block keeps its distance from a block writing the same list" false
+    (equal
+       "@media (hover){.p{color:red}.q{color:blue}}@media \
+        (min-width:1px){.q{color:red}.p{color:blue}}@media \
+        (hover){.r{color:lime}}"
+       "@media (min-width:1px){.q{color:red}.p{color:blue}}@media \
+        (hover){.p{color:red}.q{color:blue}.r{color:lime}}")
 
 (* CSS Nesting 1 sec. 3.4 keeps a declaration written after a nested rule where
    the author wrote it, which only matters for a property the nested rule also


### PR DESCRIPTION
A declaration hoisted into a selector-list group compared unequal to the same declaration written inline in every branch. The canonical projection would not merge two occurrences of one selector when a rule between them wrote the same property under a vendor-prefixed alias: `-webkit-backdrop-filter` and `backdrop-filter` share an overlap key, and the same-value exemption only matched the same spelling, so the pair counted as two writers of one slot.

The projection now ignores that conflict when both rules are plain style rules and the declarations they both write are equal. Merging is then a transposition, so the last writer of every spelling is unchanged in either direction.

On a 662KB stylesheet this removes 14 spurious findings, all `.backdrop-*` utilities.