### PR TITLE
diff: exit 2 when a dropped declaration leaves the verdict unproven

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@ entry points both moved.
 
 ### Breaking
 
+- `cascade diff` exits 2, not 0, when it finds no difference and had to drop a
+  declaration it could not read: that declaration reached neither side of the
+  comparison, so identity is not a verdict it can give. A gate that reads any
+  non-zero status as "differs" needs updating (#832)
 - `Cascade.Parser.to_string_custom` is gone. Call
   `Cascade.Parser.string_of_components`, which renders a custom-property token
   stream identically (#806)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ Compares two CSS files through the parsed CSS structure rather than
 character-by-character: added, removed, modified, and reordered rules are
 detected structurally, and property value changes are reported in terms of CSS
 values. Identical files exit 0; differences exit 1, making `cascade diff`
-usable as a CI check.
+usable as a CI check. A comparison that finds no difference but had to drop a
+declaration it could not read exits 2 instead: that declaration reached neither
+side, so identity is not a verdict the comparison can give. The report and the
+`--json` document count those declarations per side.
 
 `--diff=MODE` controls what counts as "no difference":
 
@@ -319,13 +322,14 @@ cascade diff --diff=tree src/style.css /tmp/fmt.css
 cascade diff --diff=canonical origin/main:src/style.css src/style.css
 ```
 
-The exit code is 0 when the inputs are identical under the chosen mode and 1
-otherwise, so cascade slots into any tool that branches on exit codes (`git`
-hooks, `make`, GitHub Actions, ...). The `--minify` pipeline is fast enough
-that a 200 KB stylesheet costs well under 100 ms on the SatCSS corpus;
-`--objective=raw` trades roughly an order of magnitude of wall clock for the
-last few percent of uncompressed bytes and fits a release build rather than a
-watcher loop.
+The exit code is 0 when the inputs are identical under the chosen mode, 1 when
+they differ, and 2 when the comparison finds no difference but had to drop a
+declaration it could not read, so cascade slots into any tool that branches on
+exit codes (`git` hooks, `make`, GitHub Actions, ...). The `--minify` pipeline
+is fast enough that a 200 KB stylesheet costs well under 100 ms on the SatCSS
+corpus; `--objective=raw` trades roughly an order of magnitude of wall clock
+for the last few percent of uncompressed bytes and fits a release build rather
+than a watcher loop.
 
 ## `--minify` policy
 

--- a/bin/cli_exit.ml
+++ b/bin/cli_exit.ml
@@ -1,3 +1,9 @@
+(* The verdict a comparison reaches when it finds no difference and could not
+   read part of what it compared: it has nothing to report and cannot claim the
+   inputs are equivalent either. Cmdliner reserves 123, 124 and 125, so 2 is
+   free. *)
+let cannot_determine = 2
+
 let by_code a b =
   Int.compare Cmdliner.Cmd.Exit.(info_code a) Cmdliner.Cmd.Exit.(info_code b)
 

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -68,6 +68,48 @@ let warning_budget = function
   | All_entries -> None
   | Fit_entries | Count _ -> Some auto_warning_budget
 
+(* A declaration the reader refuses is dropped from that side's AST, so nothing
+   it holds reaches the verdict. The typed value readers raise [Bad_value] at
+   [Sort.Component] for exactly that refusal. The other kinds name material the
+   parse kept - an unknown at-rule and its block reach the output, an
+   unterminated block is closed with its contents - or a failure above the
+   declaration. *)
+let unreadable_declaration (w : Cascade.Error.t) =
+  match w.kind with
+  | Cascade.Error.Bad_value _ ->
+      Cascade.Sort.equal w.sort Cascade.Sort.Component
+  | Sort_mismatch _ | Unexpected_token _ | Missing_token _ | Bad_selector _
+  | Bad_condition _ | Unknown_at_rule _ | Unterminated _ ->
+      false
+
+(* Counted per side, because the question is whether either input hid something
+   from the comparison, not how many the pair hid between them. *)
+type unread = { expected : int; actual : int }
+
+let count_unread ws = List.length (List.filter unreadable_declaration ws)
+
+let unread_of (result : Cascade_diff.Css_compare.t) =
+  {
+    expected = count_unread result.expected_warnings;
+    actual = count_unread result.actual_warnings;
+  }
+
+let has_unread u = u.expected > 0 || u.actual > 0
+
+let render_unread ~file1 ~file2 u =
+  String.concat ""
+    [
+      "Unreadable declarations: ";
+      file1;
+      " ";
+      string_of_int u.expected;
+      ", ";
+      file2;
+      " ";
+      string_of_int u.actual;
+      "\n";
+    ]
+
 let render_diff ~color ~file1 ~file2 ~entries result =
   let buf = Buffer.create 1024 in
   Cascade_diff.Css_compare.pp_diff ~expected:file1 ~actual:file2 ~color ?entries
@@ -424,14 +466,21 @@ let json_warnings (result : Cascade_diff.Css_compare.t) =
        (fun (s, w) -> json_side (side s) (Cascade.Error.to_string w))
        (Cascade_diff.Css_compare.warnings result))
 
-let json_document ~file1 ~file2 ~mode ~css1 ~css2 result =
+(* The count a consumer reads to assert that nothing was hidden from the
+   comparison, beside the verdict that count qualifies. *)
+let json_unread u =
+  J.Obj [ ("expected", J.Int u.expected); ("actual", J.Int u.actual) ]
+
+let json_document ~file1 ~file2 ~mode ~css1 ~css2 ~unread result =
   let stats =
     Cascade_diff.Css_compare.stats ~expected_str:css1 ~actual_str:css2 result
   in
   let outcome = result.Cascade_diff.Css_compare.result in
+  (* An unreadable declaration is dropped from both sides, so a comparison that
+     found no difference has not shown the two files to be identical. *)
   let identical =
     match outcome with
-    | No_diff -> true
+    | No_diff -> not (has_unread unread)
     | Tree_diff _ | String_diff _ | Both_errors _ | Expected_error _
     | Actual_error _ ->
         false
@@ -448,6 +497,7 @@ let json_document ~file1 ~file2 ~mode ~css1 ~css2 result =
        ("actual", json_string file2);
        ("mode", json_string (json_mode mode));
        ("identical", J.Bool identical);
+       ("unreadable_declarations", json_unread unread);
        ("stats", json_stats stats);
        ("warnings", json_warnings result);
        ("errors", J.List (json_errors outcome));
@@ -462,11 +512,13 @@ let print_json_report ~file1 ~file2 ~mode ~css1 ~css2 ~opts =
     run_diff mode ~lossless:opts.lossless
       ~prune_unused_custom_props:opts.prune_unused_custom_props ~css1 ~css2
   in
-  let document = json_document ~file1 ~file2 ~mode ~css1 ~css2 result in
+  let unread = unread_of result in
+  let document = json_document ~file1 ~file2 ~mode ~css1 ~css2 ~unread result in
   print_string (Cli_json.to_string document);
   print_newline ();
   match result.Cascade_diff.Css_compare.result with
-  | No_diff -> Ok ()
+  | No_diff ->
+      if has_unread unread then Stdlib.exit Cli_exit.cannot_determine else Ok ()
   | Tree_diff _ | String_diff _ | Both_errors _ | Expected_error _
   | Actual_error _ ->
       Stdlib.exit 1
@@ -485,13 +537,22 @@ let compare_sources ~color ~mode ~limit ~json ~opts (css1, file1) (css2, file2)
         ~prune_unused_custom_props:opts.prune_unused_custom_props ~css1 ~css2
     in
     match result.Cascade_diff.Css_compare.result with
-    | No_diff ->
+    | No_diff -> (
         (* Equal ASTs can still hide parse-dropped declarations; show the
            warnings so the equality verdict is honest about them. *)
         let max = warning_budget limit in
         print_string (render_warnings ~file1 ~file2 ~max result);
-        Fmt.pr "CSS files are identical@.";
-        Ok ()
+        let unread = unread_of result in
+        match has_unread unread with
+        | false ->
+            Fmt.pr "CSS files are identical@.";
+            Ok ()
+        | true ->
+            (* The comparison saw no difference and never saw the dropped
+               declarations either, so identity is not a verdict it can give. *)
+            print_string (render_unread ~file1 ~file2 unread);
+            Fmt.pr "Cannot determine whether the CSS files are identical@.";
+            Stdlib.exit Cli_exit.cannot_determine)
     | String_diff _ | Tree_diff _ | Both_errors _ | Expected_error _
     | Actual_error _ ->
         print_diff_report ~color ~file1 ~file2 ~css1 ~css2 ~limit ~mode result;
@@ -660,13 +721,26 @@ let cmd =
   let exits =
     Cli_exit.with_defaults
       [
-        Cmd.Exit.info ~doc:"if the CSS files are identical" 0;
+        Cmd.Exit.info
+          ~doc:
+            "if the CSS files are identical and cascade read every declaration \
+             in them"
+          0;
         Cmd.Exit.info
           ~doc:
             "if the CSS files differ. Under $(b,--diff=canonical) that is any \
              difference between their canonical forms, whether or not the \
-             structural walk reached it"
+             structural walk reached it. A known difference outranks an \
+             unreadable declaration, so this status wins over 2"
           1;
+        Cmd.Exit.info
+          ~doc:
+            "if the comparison found no difference and cascade could not read \
+             a declaration one of the files holds. The reader drops such a \
+             declaration from both sides, so the comparison never sees it and \
+             cannot call the two files identical. The report and the \
+             $(b,--json) document both count them per side"
+          Cli_exit.cannot_determine;
         Cmd.Exit.info ~doc:"on command-line errors or unreadable input files"
           124;
       ]

--- a/test/cli/diff_json.t
+++ b/test/cli/diff_json.t
@@ -13,7 +13,9 @@ so a script branches on the status and reads the detail from the document.
   > EOF
 
 An identical pair. Every count is zero, `identical` is true, and the status
-is still 0.
+is still 0. `unreadable_declarations` is what makes `identical` provable: it
+counts, per side, the declarations the reader refused and dropped, which the
+comparison therefore never saw.
 
   $ cascade diff --json a.css b.css
   {
@@ -21,6 +23,10 @@ is still 0.
     "actual": "b.css",
     "mode": "auto",
     "identical": true,
+    "unreadable_declarations": {
+      "expected": 0,
+      "actual": 0
+    },
     "stats": {
       "expected_chars": 18,
       "actual_chars": 18,
@@ -50,6 +56,10 @@ the value each side gives it, and the status is still 1.
     "actual": "d.css",
     "mode": "auto",
     "identical": false,
+    "unreadable_declarations": {
+      "expected": 0,
+      "actual": 0
+    },
     "stats": {
       "expected_chars": 18,
       "actual_chars": 19,

--- a/test/cli/diff_unreadable_verdict.t
+++ b/test/cli/diff_unreadable_verdict.t
@@ -1,0 +1,134 @@
+CLI: `cascade diff` does not call two files identical over a declaration it
+could not read.
+
+A declaration the reader refuses is dropped from both sides before the
+comparison, so nothing it says can reach the verdict. Reporting the pair as
+identical there claims an equivalence the tool never checked. `cascade diff`
+has a third verdict for it and exits 2, so a harness that gates on the status
+is told the answer is unknown rather than given the wrong one.
+
+Both files read whole and compare equal. That verdict is proven, so it stays
+`identical` at exit 0.
+
+  $ cat > plain-a.css <<EOF
+  > .g { color: red }
+  > EOF
+  $ cat > plain-b.css <<EOF
+  > .g{color:#f00}
+  > EOF
+  $ cascade diff --diff=canonical plain-a.css plain-b.css
+  CSS files are identical
+
+The same unreadable declaration on both sides. Every browser drops both
+copies, so the two files may well render alike - but that is the one
+declaration cascade did not read, and the count says so per side.
+
+  $ cat > same-a.css <<EOF
+  > .g { grid-template-columns: calc(1 + 2); color: red }
+  > EOF
+  $ cat > same-b.css <<EOF
+  > .g{grid-template-columns:calc(1 + 2);color:red}
+  > EOF
+  $ cascade diff --diff=canonical same-a.css same-b.css
+  same-a.css and same-b.css parse warning: <string>: read_declaration/grid-template-columns: bad value for grid-template-columns: expected at least 1 items (got 0) at [28-39] (in component)
+  .g { grid-template-columns: calc(1 + 2); color: red }
+                              ^^^^^^^^^^^
+  
+  Unreadable declarations: same-a.css 1, same-b.css 1
+  Cannot determine whether the CSS files are identical
+  [2]
+
+The same verdict when the two unreadable declarations carry different text.
+The comparison never saw either one, so it has no more to say here than it
+had above.
+
+  $ cat > other-b.css <<EOF
+  > .g{grid-template-columns:calc(9 + 9);color:red}
+  > EOF
+  $ cascade diff --diff=canonical same-a.css other-b.css
+  same-a.css and other-b.css parse warning: <string>: read_declaration/grid-template-columns: bad value for grid-template-columns: expected at least 1 items (got 0) at [28-39] (in component)
+  .g { grid-template-columns: calc(1 + 2); color: red }
+                              ^^^^^^^^^^^
+  
+  Unreadable declarations: same-a.css 1, other-b.css 1
+  Cannot determine whether the CSS files are identical
+  [2]
+
+A difference the comparison did reach outranks one it could not: the report
+names the difference and the status stays 1.
+
+  $ cat > differ-b.css <<EOF
+  > .g{grid-template-columns:calc(9 + 9);color:blue}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=canonical same-a.css differ-b.css
+  CSS: 54 chars vs 49 chars (9.3% diff)
+  Changes: 1 modified rule
+  
+  same-a.css and differ-b.css parse warning: <string>: read_declaration/grid-template-columns: bad value for grid-template-columns: expected at least 1 items (got 0) at [28-39] (in component)
+  .g { grid-template-columns: calc(1 + 2); color: red }
+                              ^^^^^^^^^^^
+  
+  --- same-a.css
+  +++ differ-b.css
+  └─ .g
+        * color: red -> #00f
+  
+  [1]
+
+A declaration only one side holds reaches the same verdict: the side that
+kept it has nothing to compare against the side that dropped it.
+
+  $ cat > one-a.css <<EOF
+  > .g{color:red}
+  > EOF
+  $ cat > one-b.css <<EOF
+  > .g{grid-template-columns:calc(1 + 2);color:red}
+  > EOF
+  $ cascade diff --diff=canonical one-a.css one-b.css
+  one-b.css parse warning: <string>: read_declaration/grid-template-columns: bad value for grid-template-columns: expected at least 1 items (got 0) at [25-36] (in component)
+  .g{grid-template-columns:calc(1 + 2);color:red}
+                           ^^^^^^^^^^^
+  
+  Unreadable declarations: one-a.css 0, one-b.css 1
+  Cannot determine whether the CSS files are identical
+  [2]
+
+An unknown at-rule is not an unreadable declaration. Cascade keeps the rule
+and its block, both sides hold the same text, and the verdict is proven.
+
+  $ cat > at-a.css <<EOF
+  > @tailwind base; .g{color:red}
+  > EOF
+  $ cat > at-b.css <<EOF
+  > @tailwind base;
+  > .g { color: red }
+  > EOF
+  $ cascade diff --diff=canonical at-a.css at-b.css
+  at-a.css and at-b.css parse warning: <string>: unknown at-rule @tailwind at [0-15] (in at-rule)
+  
+  CSS files are identical
+
+`--json` carries the count per side, so a harness asserts "nothing unread on
+either side, and identical" without reading the report.
+
+  $ cascade diff --json --diff=canonical same-a.css same-b.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["identical"], d["unreadable_declarations"])'
+  False {'expected': 1, 'actual': 1}
+  $ cascade diff --json --diff=canonical plain-a.css plain-b.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["identical"], d["unreadable_declarations"])'
+  True {'expected': 0, 'actual': 0}
+
+The document and the status agree: `--json` reports the same three verdicts.
+
+  $ cascade diff --json --diff=canonical same-a.css same-b.css > /dev/null
+  [2]
+  $ cascade diff --json --diff=canonical plain-a.css plain-b.css > /dev/null
+  $ cascade diff --json --diff=canonical same-a.css differ-b.css > /dev/null
+  [1]
+
+`--help` documents the status.
+
+  $ cascade diff --help=plain | sed -n '/^EXIT STATUS/,/^ENVIRONMENT/p' | grep -c '^       2   '
+  1


### PR DESCRIPTION
`cascade diff` compares parsed ASTs, so a declaration the reader refuses is dropped from both sides and cannot affect the verdict. Two sheets differing only in such a declaration reported `CSS files are identical` and exited 0.

The comparison now has a third answer. It exits 2 when it finds no difference but had to drop a declaration it could not read, and the report and `--json` document carry the count for each side. A real difference still exits 1.

A CI gate that reads any non-zero status as "differs" needs updating.

One case of the same shape is still open and tracked separately: a dropped *rule* is invisible in the same way.