### PR TITLE
diff: exit 2 when a dropped rule leaves the verdict unproven

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,9 +25,9 @@ entry points both moved.
 ### Breaking
 
 - `cascade diff` exits 2, not 0, when it finds no difference and had to drop a
-  declaration it could not read: that declaration reached neither side of the
-  comparison, so identity is not a verdict it can give. A gate that reads any
-  non-zero status as "differs" needs updating (#832)
+  declaration or a rule it could not read: what it dropped reached neither side
+  of the comparison, so identity is not a verdict it can give. A gate that
+  reads any non-zero status as "differs" needs updating (#832, #833)
 - `Cascade.Parser.to_string_custom` is gone. Call
   `Cascade.Parser.string_of_components`, which renders a custom-property token
   stream identically (#806)

--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ character-by-character: added, removed, modified, and reordered rules are
 detected structurally, and property value changes are reported in terms of CSS
 values. Identical files exit 0; differences exit 1, making `cascade diff`
 usable as a CI check. A comparison that finds no difference but had to drop a
-declaration it could not read exits 2 instead: that declaration reached neither
-side, so identity is not a verdict the comparison can give. The report and the
-`--json` document count those declarations per side.
+declaration or a rule it could not read exits 2 instead: what it dropped
+reached neither side, so identity is not a verdict the comparison can give. The
+report and the `--json` document count declarations and rules per side.
 
 `--diff=MODE` controls what counts as "no difference":
 
@@ -324,12 +324,12 @@ cascade diff --diff=canonical origin/main:src/style.css src/style.css
 
 The exit code is 0 when the inputs are identical under the chosen mode, 1 when
 they differ, and 2 when the comparison finds no difference but had to drop a
-declaration it could not read, so cascade slots into any tool that branches on
-exit codes (`git` hooks, `make`, GitHub Actions, ...). The `--minify` pipeline
-is fast enough that a 200 KB stylesheet costs well under 100 ms on the SatCSS
-corpus; `--objective=raw` trades roughly an order of magnitude of wall clock
-for the last few percent of uncompressed bytes and fits a release build rather
-than a watcher loop.
+declaration or a rule it could not read, so cascade slots into any tool that
+branches on exit codes (`git` hooks, `make`, GitHub Actions, ...). The
+`--minify` pipeline is fast enough that a 200 KB stylesheet costs well under
+100 ms on the SatCSS corpus; `--objective=raw` trades roughly an order of
+magnitude of wall clock for the last few percent of uncompressed bytes and fits
+a release build rather than a watcher loop.
 
 ## `--minify` policy
 

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -82,32 +82,70 @@ let unreadable_declaration (w : Cascade.Error.t) =
   | Bad_condition _ | Unknown_at_rule _ | Unterminated _ ->
       false
 
+(* A rule the reader refuses goes the same way, and takes every declaration and
+   nested rule it holds. Each kind below was checked by running [cascade fmt] on
+   an input that raises it and looking for the construct in the output. An
+   unterminated qualified rule, a prelude read as a declaration, an at-rule
+   condition the grammar refuses and a lexeme the reader needed and did not find
+   all leave nothing behind. An unterminated block is closed with its contents.
+   [Bad_value] at [Sort.Component] is the declaration counted above; elsewhere
+   it, [Bad_selector] and [Unknown_at_rule] report on material the parse
+   kept. *)
+let unreadable_rule (w : Cascade.Error.t) =
+  match w.kind with
+  | Cascade.Error.Unterminated _ ->
+      not (Cascade.Sort.equal w.sort Cascade.Sort.Block)
+  | Sort_mismatch _ | Unexpected_token _ | Missing_token _ | Bad_condition _ ->
+      true
+  | Bad_value _ | Bad_selector _ | Unknown_at_rule _ -> false
+
 (* Counted per side, because the question is whether either input hid something
    from the comparison, not how many the pair hid between them. *)
-type unread = { expected : int; actual : int }
+type sides = { expected : int; actual : int }
 
-let count_unread ws = List.length (List.filter unreadable_declaration ws)
+(* Declarations and rules are counted apart, because a consumer reads the two to
+   tell which of them its sheet lost. *)
+type unread = { declarations : sides; rules : sides }
 
-let unread_of (result : Cascade_diff.Css_compare.t) =
+let count_sides p (result : Cascade_diff.Css_compare.t) =
+  let count ws = List.length (List.filter p ws) in
   {
-    expected = count_unread result.expected_warnings;
-    actual = count_unread result.actual_warnings;
+    expected = count result.expected_warnings;
+    actual = count result.actual_warnings;
   }
 
-let has_unread u = u.expected > 0 || u.actual > 0
+let unread_of result =
+  {
+    declarations = count_sides unreadable_declaration result;
+    rules = count_sides unreadable_rule result;
+  }
+
+let has_sides s = s.expected > 0 || s.actual > 0
+let has_unread u = has_sides u.declarations || has_sides u.rules
+
+let render_sides ~what ~file1 ~file2 s =
+  if not (has_sides s) then ""
+  else
+    String.concat ""
+      [
+        "Unreadable ";
+        what;
+        ": ";
+        file1;
+        " ";
+        string_of_int s.expected;
+        ", ";
+        file2;
+        " ";
+        string_of_int s.actual;
+        "\n";
+      ]
 
 let render_unread ~file1 ~file2 u =
   String.concat ""
     [
-      "Unreadable declarations: ";
-      file1;
-      " ";
-      string_of_int u.expected;
-      ", ";
-      file2;
-      " ";
-      string_of_int u.actual;
-      "\n";
+      render_sides ~what:"declarations" ~file1 ~file2 u.declarations;
+      render_sides ~what:"rules" ~file1 ~file2 u.rules;
     ]
 
 let render_diff ~color ~file1 ~file2 ~entries result =
@@ -466,18 +504,19 @@ let json_warnings (result : Cascade_diff.Css_compare.t) =
        (fun (s, w) -> json_side (side s) (Cascade.Error.to_string w))
        (Cascade_diff.Css_compare.warnings result))
 
-(* The count a consumer reads to assert that nothing was hidden from the
-   comparison, beside the verdict that count qualifies. *)
-let json_unread u =
-  J.Obj [ ("expected", J.Int u.expected); ("actual", J.Int u.actual) ]
+(* The counts a consumer reads to assert that nothing was hidden from the
+   comparison, beside the verdict they qualify. *)
+let json_sides s =
+  J.Obj [ ("expected", J.Int s.expected); ("actual", J.Int s.actual) ]
 
 let json_document ~file1 ~file2 ~mode ~css1 ~css2 ~unread result =
   let stats =
     Cascade_diff.Css_compare.stats ~expected_str:css1 ~actual_str:css2 result
   in
   let outcome = result.Cascade_diff.Css_compare.result in
-  (* An unreadable declaration is dropped from both sides, so a comparison that
-     found no difference has not shown the two files to be identical. *)
+  (* A declaration or a rule the reader refuses is dropped from both sides, so a
+     comparison that found no difference has not shown the two files to be
+     identical. *)
   let identical =
     match outcome with
     | No_diff -> not (has_unread unread)
@@ -497,7 +536,8 @@ let json_document ~file1 ~file2 ~mode ~css1 ~css2 ~unread result =
        ("actual", json_string file2);
        ("mode", json_string (json_mode mode));
        ("identical", J.Bool identical);
-       ("unreadable_declarations", json_unread unread);
+       ("unreadable_declarations", json_sides unread.declarations);
+       ("unreadable_rules", json_sides unread.rules);
        ("stats", json_stats stats);
        ("warnings", json_warnings result);
        ("errors", J.List (json_errors outcome));
@@ -538,8 +578,8 @@ let compare_sources ~color ~mode ~limit ~json ~opts (css1, file1) (css2, file2)
     in
     match result.Cascade_diff.Css_compare.result with
     | No_diff -> (
-        (* Equal ASTs can still hide parse-dropped declarations; show the
-           warnings so the equality verdict is honest about them. *)
+        (* Equal ASTs can still hide what the parse dropped; show the warnings
+           so the equality verdict is honest about them. *)
         let max = warning_budget limit in
         print_string (render_warnings ~file1 ~file2 ~max result);
         let unread = unread_of result in
@@ -548,8 +588,8 @@ let compare_sources ~color ~mode ~limit ~json ~opts (css1, file1) (css2, file2)
             Fmt.pr "CSS files are identical@.";
             Ok ()
         | true ->
-            (* The comparison saw no difference and never saw the dropped
-               declarations either, so identity is not a verdict it can give. *)
+            (* The comparison saw no difference and never saw what the parse
+               dropped either, so identity is not a verdict it can give. *)
             print_string (render_unread ~file1 ~file2 unread);
             Fmt.pr "Cannot determine whether the CSS files are identical@.";
             Stdlib.exit Cli_exit.cannot_determine)
@@ -724,22 +764,22 @@ let cmd =
         Cmd.Exit.info
           ~doc:
             "if the CSS files are identical and cascade read every declaration \
-             in them"
+             and every rule in them"
           0;
         Cmd.Exit.info
           ~doc:
             "if the CSS files differ. Under $(b,--diff=canonical) that is any \
              difference between their canonical forms, whether or not the \
-             structural walk reached it. A known difference outranks an \
-             unreadable declaration, so this status wins over 2"
+             structural walk reached it. A known difference outranks anything \
+             cascade could not read, so this status wins over 2"
           1;
         Cmd.Exit.info
           ~doc:
             "if the comparison found no difference and cascade could not read \
-             a declaration one of the files holds. The reader drops such a \
-             declaration from both sides, so the comparison never sees it and \
-             cannot call the two files identical. The report and the \
-             $(b,--json) document both count them per side"
+             a declaration or a rule one of the files holds. The reader drops \
+             it from both sides, so the comparison never sees it and cannot \
+             call the two files identical. The report and the $(b,--json) \
+             document count declarations and rules per side"
           Cli_exit.cannot_determine;
         Cmd.Exit.info ~doc:"on command-line errors or unreadable input files"
           124;

--- a/test/cli/diff_json.t
+++ b/test/cli/diff_json.t
@@ -13,9 +13,9 @@ so a script branches on the status and reads the detail from the document.
   > EOF
 
 An identical pair. Every count is zero, `identical` is true, and the status
-is still 0. `unreadable_declarations` is what makes `identical` provable: it
-counts, per side, the declarations the reader refused and dropped, which the
-comparison therefore never saw.
+is still 0. `unreadable_declarations` and `unreadable_rules` are what make
+`identical` provable: they count, per side, the declarations and the rules the
+reader refused and dropped, which the comparison therefore never saw.
 
   $ cascade diff --json a.css b.css
   {
@@ -24,6 +24,10 @@ comparison therefore never saw.
     "mode": "auto",
     "identical": true,
     "unreadable_declarations": {
+      "expected": 0,
+      "actual": 0
+    },
+    "unreadable_rules": {
       "expected": 0,
       "actual": 0
     },
@@ -57,6 +61,10 @@ the value each side gives it, and the status is still 1.
     "mode": "auto",
     "identical": false,
     "unreadable_declarations": {
+      "expected": 0,
+      "actual": 0
+    },
+    "unreadable_rules": {
       "expected": 0,
       "actual": 0
     },

--- a/test/cli/diff_unreadable_rule.t
+++ b/test/cli/diff_unreadable_rule.t
@@ -1,0 +1,179 @@
+CLI: `cascade diff` does not call two files identical over a rule it could
+not read.
+
+A rule the reader refuses is dropped from both sides before the comparison,
+exactly as a refused declaration is, and it takes everything it holds with
+it. Reporting the pair as identical there claims an equivalence the tool
+never checked, so `cascade diff` gives the same third verdict and exits 2.
+The count is kept apart from the declaration count: a harness reads the two
+to tell what its sheet lost.
+
+A prelude the reader cannot close takes the whole rule. These two sheets
+differ only inside one, so both sides drop it and the comparison sees the
+same thing twice.
+
+  $ cat > rule-a.css <<EOF
+  > .b{color:red}
+  > .a[[ {color:red}
+  > EOF
+  $ cat > rule-b.css <<EOF
+  > .b{color:red}
+  > .a[[ {color:blue}
+  > EOF
+  $ cascade diff --diff=canonical rule-a.css rule-b.css
+  rule-a.css and rule-b.css parse warning: <string>: unterminated qualified-rule at [14-30] (in qualified-rule)
+  .b{color:red}
+  .a[[ {color:red}
+  ^^^^^^^^^^^^^^^^
+  
+  Unreadable rules: rule-a.css 1, rule-b.css 1
+  Cannot determine whether the CSS files are identical
+  [2]
+
+The same dropped rule text on both sides reaches the same verdict. The
+comparison has no more to say here than it had above.
+
+  $ cat > same-a.css <<EOF
+  > .b { color: red }
+  > .a[[ {color:red}
+  > EOF
+  $ cat > same-b.css <<EOF
+  > .b{color:red}
+  > .a[[ {color:red}
+  > EOF
+  $ cascade diff --diff=canonical same-a.css same-b.css
+  same-a.css and same-b.css parse warning: <string>: unterminated qualified-rule at [18-34] (in qualified-rule)
+  .b { color: red }
+  .a[[ {color:red}
+  ^^^^^^^^^^^^^^^^
+  
+  Unreadable rules: same-a.css 1, same-b.css 1
+  Cannot determine whether the CSS files are identical
+  [2]
+
+An at-rule condition the grammar refuses loses more: the at-rule goes and
+every rule nested inside it goes with it.
+
+  $ cat > media-a.css <<EOF
+  > .b{color:red}
+  > @media (bogus^^^){.x{color:red}}
+  > EOF
+  $ cat > media-b.css <<EOF
+  > .b{color:red}
+  > @media (bogus^^^){.x{color:blue}}
+  > EOF
+  $ cascade diff --diff=canonical media-a.css media-b.css
+  media-a.css and media-b.css parse warning: <string>: bad condition for @media: expected media-in-parens at [22-27] (in at-rule)
+  .b{color:red}
+  @media (bogus^^^){.x{color:red}}
+          ^^^^^
+  
+  Unreadable rules: media-a.css 1, media-b.css 1
+  Cannot determine whether the CSS files are identical
+  [2]
+
+A prelude the parser reads as a declaration drops the rule that carried it,
+and that is the same loss.
+
+  $ cat > decl-a.css <<EOF
+  > .b{color:red}
+  > --foo:{color:red}
+  > EOF
+  $ cat > decl-b.css <<EOF
+  > .b{color:red}
+  > --foo:{color:blue}
+  > EOF
+  $ cascade diff --diff=canonical decl-a.css decl-b.css
+  decl-a.css and decl-b.css parse warning: <string>: expected selector but found declaration at [14-31] (in qualified-rule)
+  .b{color:red}
+  --foo:{color:red}
+  ^^^^^^^^^^^^^^^^^
+  
+  Unreadable rules: decl-a.css 1, decl-b.css 1
+  Cannot determine whether the CSS files are identical
+  [2]
+
+A difference the comparison did reach outranks one it could not: the report
+names the difference and the status stays 1.
+
+  $ cat > differ-b.css <<EOF
+  > .b{color:lime}
+  > .a[[ {color:blue}
+  > EOF
+  $ NO_COLOR=1 cascade diff --diff=canonical rule-a.css differ-b.css
+  CSS: 31 chars vs 33 chars (6.5% diff)
+  Changes: 1 modified rule
+  
+  rule-a.css and differ-b.css parse warning: <string>: unterminated qualified-rule at [14-30] (in qualified-rule)
+  .b{color:red}
+  .a[[ {color:red}
+  ^^^^^^^^^^^^^^^^
+  
+  --- rule-a.css
+  +++ differ-b.css
+  └─ .b
+        * color: red -> #0f0
+  
+  [1]
+
+An at-rule cascade does not recognise keeps its prelude and its block, so
+both sides still hold the text and the verdict is proven. `@tailwind base;`
+is the case that reaches cascade from every Tailwind entry stylesheet.
+
+  $ cat > at-a.css <<EOF
+  > @tailwind base; .b{color:red}
+  > EOF
+  $ cat > at-b.css <<EOF
+  > @tailwind base;
+  > .b { color: red }
+  > EOF
+  $ cascade diff --diff=canonical at-a.css at-b.css
+  at-a.css and at-b.css parse warning: <string>: unknown at-rule @tailwind at [0-15] (in at-rule)
+  
+  CSS files are identical
+
+A dropped declaration and a dropped rule are counted apart, so a harness
+reading the report is told which of the two its sheet lost.
+
+  $ cat > mix-a.css <<EOF
+  > .b{grid-template-columns:calc(1 + 2);color:red}
+  > .a[[ {color:red}
+  > EOF
+  $ cat > mix-b.css <<EOF
+  > .b{grid-template-columns:calc(1 + 2);color:red}
+  > .a[[ {color:blue}
+  > EOF
+  $ cascade diff --diff=canonical mix-a.css mix-b.css
+  mix-a.css and mix-b.css parse warning: <string>: unterminated qualified-rule at [48-64] (in qualified-rule)
+  template-columns:calc(1 + 2);color:red}
+  .a[[ {color:red}
+  ^^^^^^^^^^^^^^^^
+  mix-a.css and mix-b.css parse warning: <string>: read_declaration/grid-template-columns: bad value for grid-template-columns: expected at least 1 items (got 0) at [25-36] (in component)
+  .b{grid-template-columns:calc(1 + 2);color:red}
+                           ^^^^^^^^^^^
+  .a[[ {color:red}
+  
+  Unreadable declarations: mix-a.css 1, mix-b.css 1
+  Unreadable rules: mix-a.css 1, mix-b.css 1
+  Cannot determine whether the CSS files are identical
+  [2]
+
+`--json` carries the rule count beside the declaration count, so a harness
+asserts on either without reading the report.
+
+  $ cascade diff --json --diff=canonical mix-a.css mix-b.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["identical"], d["unreadable_declarations"], d["unreadable_rules"])'
+  False {'expected': 1, 'actual': 1} {'expected': 1, 'actual': 1}
+  $ cascade diff --json --diff=canonical at-a.css at-b.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["identical"], d["unreadable_declarations"], d["unreadable_rules"])'
+  True {'expected': 0, 'actual': 0} {'expected': 0, 'actual': 0}
+
+The document and the status agree.
+
+  $ cascade diff --json --diff=canonical rule-a.css rule-b.css > /dev/null
+  [2]
+  $ cascade diff --json --diff=canonical at-a.css at-b.css > /dev/null
+  $ cascade diff --json --diff=canonical rule-a.css differ-b.css > /dev/null
+  [1]


### PR DESCRIPTION
#832 gave `cascade diff` a third verdict for a dropped declaration. A dropped rule is invisible in the same way: two sheets differing only inside a malformed rule reported `CSS files are identical` and exited 0.

The same verdict now covers a rule, including a malformed `@media` condition, which takes every rule inside it as well. `--json` counts rules and declarations separately, per side. An unknown at-rule such as `@tailwind base;` keeps its prelude and block, so it still exits 0.

One case of the shape remains and is tracked separately: `Bad_value` at sort `Property_value` covers both statements that survive and statements that are dropped, so the kind and sort pair cannot tell them apart.