### PR TITLE
diff: carry what the reader dropped on the error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,7 +27,10 @@ entry points both moved.
 - `cascade diff` exits 2, not 0, when it finds no difference and had to drop a
   declaration or a rule it could not read: what it dropped reached neither side
   of the comparison, so identity is not a verdict it can give. A gate that
-  reads any non-zero status as "differs" needs updating (#832, #833)
+  reads any non-zero status as "differs" needs updating (#832, #833, #834)
+- `Cascade.Error.t` gains `recovery`, which says whether the reader dropped the
+  construct the error is about or kept it in the output. Exhaustive record
+  patterns must bind it or add `_`; `Cascade.Error.v` fills it in (#834)
 - `Cascade.Parser.to_string_custom` is gone. Call
   `Cascade.Parser.string_of_components`, which renders a custom-property token
   stream identically (#806)

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -68,36 +68,13 @@ let warning_budget = function
   | All_entries -> None
   | Fit_entries | Count _ -> Some auto_warning_budget
 
-(* A declaration the reader refuses is dropped from that side's AST, so nothing
-   it holds reaches the verdict. The typed value readers raise [Bad_value] at
-   [Sort.Component] for exactly that refusal. The other kinds name material the
-   parse kept - an unknown at-rule and its block reach the output, an
-   unterminated block is closed with its contents - or a failure above the
-   declaration. *)
-let unreadable_declaration (w : Cascade.Error.t) =
-  match w.kind with
-  | Cascade.Error.Bad_value _ ->
-      Cascade.Sort.equal w.sort Cascade.Sort.Component
-  | Sort_mismatch _ | Unexpected_token _ | Missing_token _ | Bad_selector _
-  | Bad_condition _ | Unknown_at_rule _ | Unterminated _ ->
-      false
-
-(* A rule the reader refuses goes the same way, and takes every declaration and
-   nested rule it holds. Each kind below was checked by running [cascade fmt] on
-   an input that raises it and looking for the construct in the output. An
-   unterminated qualified rule, a prelude read as a declaration, an at-rule
-   condition the grammar refuses and a lexeme the reader needed and did not find
-   all leave nothing behind. An unterminated block is closed with its contents.
-   [Bad_value] at [Sort.Component] is the declaration counted above; elsewhere
-   it, [Bad_selector] and [Unknown_at_rule] report on material the parse
-   kept. *)
-let unreadable_rule (w : Cascade.Error.t) =
-  match w.kind with
-  | Cascade.Error.Unterminated _ ->
-      not (Cascade.Sort.equal w.sort Cascade.Sort.Block)
-  | Sort_mismatch _ | Unexpected_token _ | Missing_token _ | Bad_condition _ ->
-      true
-  | Bad_value _ | Bad_selector _ | Unknown_at_rule _ -> false
+(* What the parse dropped reaches neither side of the comparison, so nothing it
+   holds can affect the verdict. The reader stamps that on the warning at the
+   point it recovers, which is the only place that knows: the same [Bad_value]
+   at [Sort.Property_value] names an [@charset] the reader dropped and an
+   [@font-face] it kept, so the kind and the sort cannot tell them apart. *)
+let dropped construct (w : Cascade.Error.t) =
+  Cascade.Error.Recovery.equal w.recovery (Dropped construct)
 
 (* Counted per side, because the question is whether either input hid something
    from the comparison, not how many the pair hid between them. *)
@@ -116,8 +93,8 @@ let count_sides p (result : Cascade_diff.Css_compare.t) =
 
 let unread_of result =
   {
-    declarations = count_sides unreadable_declaration result;
-    rules = count_sides unreadable_rule result;
+    declarations = count_sides (dropped Declaration) result;
+    rules = count_sides (dropped Rule) result;
   }
 
 let has_sides s = s.expected > 0 || s.actual > 0

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -38,7 +38,9 @@ let sub ?eof_loc t cvs =
     depth = t.depth;
   }
 
-let push_warning t e = t.warnings := e :: !(t.warnings)
+let push_warning t ~recovery e =
+  t.warnings := Error.with_recovery recovery e :: !(t.warnings)
+
 let recover t = t.recover
 let meta t = t.meta
 let source t = t.source

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -49,10 +49,12 @@ val meta : t -> Loc.meta_level
 val source : t -> string option
 (** [source t] is the preprocessed source text that produced [t], when known. *)
 
-val push_warning : t -> Error.t -> unit
-(** [push_warning t e] records [e] as a non-fatal warning on [t]. A validator in
-    recovery mode catches a {!exception-Parse_error}, pushes it here, skips to a
-    recovery point, and keeps going. Drained via {!drain_warnings}. *)
+val push_warning : t -> recovery:Error.Recovery.t -> Error.t -> unit
+(** [push_warning t ~recovery e] records [e] as a non-fatal warning on [t],
+    stamped with what the recovery did to the construct [e] is about. A
+    validator in recovery mode catches a {!exception-Parse_error}, pushes it
+    here, skips to a recovery point, and keeps going. Drained via
+    {!drain_warnings}. *)
 
 val drain_warnings : t -> Error.t list
 (** [drain_warnings t] returns and clears the warnings accumulated on [t] in

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2447,7 +2447,7 @@ let read_declaration_step t acc =
    declaration is dropped, reading resumes past the next [;], and the
    surrounding rule survives. *)
 let recover_declaration_step t acc e =
-  Cursor.push_warning t e;
+  Cursor.push_warning t ~recovery:Error.Recovery.(Dropped Declaration) e;
   Cursor.skip_past_semicolon t;
   acc
 

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -1,3 +1,16 @@
+module Recovery = struct
+  type construct = Declaration | Rule
+  type t = Dropped of construct | Recovered
+
+  let equal a b =
+    match (a, b) with
+    | Dropped Declaration, Dropped Declaration
+    | Dropped Rule, Dropped Rule
+    | Recovered, Recovered ->
+        true
+    | (Dropped _ | Recovered), _ -> false
+end
+
 type kind =
   | Sort_mismatch of { expected : Sort.t; found : Sort.t }
   | Unexpected_token of Token.kind
@@ -19,6 +32,7 @@ type t = {
   kind : kind;
   source : string option;
   filename : string option;
+  recovery : Recovery.t;
 }
 
 let snippet t =
@@ -68,7 +82,7 @@ let pp_kind : kind Pp.t =
       Sort.pp ctx s
 
 let pp : t Pp.t =
- fun ctx ({ loc; sort; path; kind; source = _; filename } as t) ->
+ fun ctx ({ loc; sort; path; kind; source = _; filename; recovery = _ } as t) ->
   (match filename with
   | Some f when f <> "" ->
       Pp.string ctx f;
@@ -110,8 +124,20 @@ let to_string t = Pp.to_string pp t
 
 exception Parse_error of t
 
+(* A raised error is about a construct nothing has decided about yet, so it
+   starts at [Recovered] and the site that catches it stamps what it did. *)
 let v ?(path = Loc.Path.empty) ?source ?filename ~loc ~sort kind =
-  { loc; sort; path = Loc.Path.to_labels path; kind; source; filename }
+  {
+    loc;
+    sort;
+    path = Loc.Path.to_labels path;
+    kind;
+    source;
+    filename;
+    recovery = Recovery.Recovered;
+  }
+
+let with_recovery recovery t = { t with recovery }
 
 let with_filename ?filename t =
   match (filename, t.filename) with

--- a/lib/error.mli
+++ b/lib/error.mli
@@ -5,6 +5,24 @@
     variant is closed: every CSS-syntax-level failure that the parser can emit
     is enumerated here. *)
 
+(** What a recovery point did with the construct an error is about. *)
+module Recovery : sig
+  type construct =
+    | Declaration  (** A [property: value] pair. *)
+    | Rule  (** A rule or an at-rule, and everything it holds. *)
+
+  type t =
+    | Dropped of construct
+        (** The construct's text reaches neither the AST nor anything printed
+            back out from it, so a caller reading the parse never sees it. *)
+    | Recovered
+        (** The construct survives into the output. The error reports on it
+            without costing it. *)
+
+  val equal : t -> t -> bool
+  (** [equal a b] is whether [a] and [b] are the same recovery. *)
+end
+
 type kind =
   | Sort_mismatch of { expected : Sort.t; found : Sort.t }
       (** Got a node of the wrong category, e.g. a component where a declaration
@@ -31,11 +49,14 @@ type t = {
   kind : kind;
   source : string option;
   filename : string option;
+  recovery : Recovery.t;
 }
 (** {!field-path} is a breadcrumb trail from the outermost context down to the
     exact sub-production that failed, rendered with ["/"] separators. {!source}
     carries the raw input string for materialising a snippet on demand via
-    {!snippet}. *)
+    {!snippet}. {!field-recovery} is what became of the construct the error is
+    about, which the site that caught the error fills in through
+    {!with_recovery}. *)
 
 val pp_kind : kind Pp.t
 (** [pp_kind] renders just the reason, e.g.
@@ -85,6 +106,12 @@ val with_filename : ?filename:string -> t -> t
 (** [with_filename ~filename t] stamps [filename] onto [t] when [t] does not
     already carry one. Used by entry points that know the source filename to
     annotate warnings collected by inner readers. *)
+
+val with_recovery : Recovery.t -> t -> t
+(** [with_recovery recovery t] records what the reader did with the construct
+    [t] is about. The raise site knows what failed; only the site that catches
+    the error knows whether the construct survives, so an error carries
+    {!Recovery.Recovered} until such a site stamps it. *)
 
 val with_property : string -> t -> t
 (** [with_property property t] fills in the property name of a {!Bad_value}

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -962,8 +962,9 @@ let rec skip_whitespace_tokens lexer =
 
 (* Push a warning, attaching a source snippet from the lexer's reader when [meta
    = `Full] so section 5.3 recovery warnings carry the same context as raised
-   Cursor errors. Lower meta levels skip the snippet allocation. *)
-let warn ~meta lexer (warnings : Error.t list ref) (e : Error.t) =
+   Cursor errors. Lower meta levels skip the snippet allocation. [recovery] is
+   what this site did with the construct the error is about. *)
+let warn ~meta lexer (warnings : Error.t list ref) ~recovery (e : Error.t) =
   let e =
     match meta with
     | `Full ->
@@ -971,7 +972,7 @@ let warn ~meta lexer (warnings : Error.t list ref) (e : Error.t) =
         Error.v ~source ~loc:e.loc ~sort:e.sort e.kind
     | `None | `Locs -> e
   in
-  warnings := e :: !warnings
+  warnings := Error.with_recovery recovery e :: !warnings
 
 (* Sections 5.5.9 and 5.5.10 auto-close a simple block and a function at EOF,
    which every rule-level caller relies on, and the CR snapshot marks both of
@@ -982,7 +983,8 @@ let warn ~meta lexer (warnings : Error.t list ref) (e : Error.t) =
 let warn_unclosed ~meta lexer warnings (block : Component.block Component.node)
     =
   if not block.node.closed then
-    warn ~meta lexer warnings (Error.unterminated block.loc Sort.Block)
+    warn ~meta lexer warnings ~recovery:Error.Recovery.Recovered
+      (Error.unterminated block.loc Sort.Block)
 
 (* CSS Syntax 3 (ED) sec. 5.5.2. [nested = true] also terminates on a stray
    ['}'] (the spec's "outermost block ended") so block-contents callers can
@@ -1012,32 +1014,34 @@ let consume_at_rule ?(nested = false) ~meta lexer ~name ~start_loc ~warnings :
   in
   loop []
 
+(* A prelude whose first two non-whitespace items are an ident starting with
+   [--] followed by ':' reads as a declaration rather than a selector. The
+   prelude is held reversed, as [consume_qualified_rule] accumulates it. *)
+let is_custom_property_shape prelude =
+  let rec drop_ws = function
+    | Component.Preserved { kind = Token.Whitespace; _ } :: rest -> drop_ws rest
+    | other -> other
+  in
+  match drop_ws (List.rev prelude) with
+  | Component.Preserved { kind = Token.Ident name; _ } :: rest
+    when Custom_property_name.has_prefix name -> (
+      match drop_ws rest with
+      | Component.Preserved { kind = Token.Colon; _ } :: _ -> true
+      | _ -> false)
+  | _ -> false
+
 (* CSS Syntax 3 (ED) sec. 5.5.3. [nested = true] makes a stray ['}'] or a
    top-level ';' before any block end the rule attempt with [None]; the spec
    groups those two with the EOF branch as parse errors, so they are reported
-   the same way. The custom-property-shaped guard discards a rule whose first
-   two non-whitespace prelude items are an ident starting with [--] followed by
-   ':', warning that the prelude read as a declaration rather than a
-   selector. *)
+   the same way. A custom-property-shaped prelude discards the rule, warning
+   that it read as a declaration. *)
 let consume_qualified_rule ?(nested = false) ~meta lexer ~start_loc ~warnings :
     Component.qualified_rule option =
-  let is_custom_property_shape prelude =
-    let rec drop_ws = function
-      | Component.Preserved { kind = Token.Whitespace; _ } :: rest ->
-          drop_ws rest
-      | other -> other
-    in
-    match drop_ws (List.rev prelude) with
-    | Component.Preserved { kind = Token.Ident name; _ } :: rest
-      when Custom_property_name.has_prefix name -> (
-        match drop_ws rest with
-        | Component.Preserved { kind = Token.Colon; _ } :: _ -> true
-        | _ -> false)
-    | _ -> false
-  in
   let drop end_loc =
     let loc = Loc.union start_loc end_loc in
-    warn ~meta lexer warnings (Error.unterminated loc Sort.Qualified_rule);
+    warn ~meta lexer warnings
+      ~recovery:Error.Recovery.(Dropped Rule)
+      (Error.unterminated loc Sort.Qualified_rule);
     None
   in
   let rec loop prelude =
@@ -1059,6 +1063,7 @@ let consume_qualified_rule ?(nested = false) ~meta lexer ~start_loc ~warnings :
           (* Dropping the rule is what the spec asks for, but it still has to be
              reported: [Css.of_string] warns for every rule it drops. *)
           warn ~meta lexer warnings
+            ~recovery:Error.Recovery.(Dropped Rule)
             (Error.sort_mismatch loc ~sort:Sort.Qualified_rule
                ~expected:Sort.Selector ~found:Sort.Declaration);
           None)
@@ -1158,6 +1163,7 @@ let declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings cvs :
       in
       if value_has_invalid_block ~is_custom value || has_bad_token value then (
         warn ~meta lexer warnings
+          ~recovery:Error.Recovery.(Dropped Declaration)
           (Error.unexpected_token name_loc ~sort:Sort.Declaration
              (Token.Open Token.Curly));
         None)
@@ -1170,6 +1176,7 @@ let declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings cvs :
         Some { node = { name; value; important }; loc }
   | _ ->
       warn ~meta lexer warnings
+        ~recovery:Error.Recovery.(Dropped Declaration)
         (Error.missing_token name_loc ~sort:Sort.Declaration "':'");
       None
 
@@ -1227,6 +1234,7 @@ let consume_decl_list_item ~meta lexer ~warnings tok =
       | None -> `Skip)
   | _ ->
       warn ~meta lexer warnings
+        ~recovery:Error.Recovery.(Dropped Declaration)
         (Error.unexpected_token tok.loc ~sort:Sort.Declaration tok.kind);
       skip_bad_declaration lexer tok;
       `Skip

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2120,8 +2120,10 @@ let skip_invalid_item r =
    what the lenient parse warns about. [skip] discards the item that failed, and
    which one it is depends on the body: {!skip_invalid_item} for a body of
    declarations, {!skip_past_rule} for a body of rules, where an item that opens
-   a block ends at that block rather than at a [;] it does not have. *)
-let read_items_with_recovery ~skip step r init =
+   a block ends at that block rather than at a [;] it does not have. [recovery]
+   names the same two bodies: the dropped item is a declaration in the first and
+   a rule in the second. *)
+let read_items_with_recovery ~skip ~recovery step r init =
   let rec loop state =
     if Cursor.recover r then recovering state else continue (step r state)
   and recovering state =
@@ -2129,7 +2131,7 @@ let read_items_with_recovery ~skip step r init =
     match step r state with
     | committed -> continue committed
     | exception Error.Parse_error e ->
-        Cursor.push_warning r e;
+        Cursor.push_warning r ~recovery e;
         Cursor.restore r start;
         skip r;
         loop state
@@ -2147,7 +2149,7 @@ let read_keyframe_or_skip inner acc =
   | frame -> frame :: acc
   | exception Cursor.Parse_error e ->
       Cursor.restore inner snap;
-      Cursor.push_warning inner e;
+      Cursor.push_warning inner ~recovery:Error.Recovery.(Dropped Rule) e;
       skip_past_rule inner;
       acc
 
@@ -2166,7 +2168,9 @@ let read_keyframes_step inner acc =
     | _ -> `More (read_keyframe_or_skip inner acc)
 
 let read_keyframes_block inner =
-  read_items_with_recovery ~skip:skip_past_rule read_keyframes_step inner []
+  read_items_with_recovery ~skip:skip_past_rule
+    ~recovery:Error.Recovery.(Dropped Rule)
+    read_keyframes_step inner []
 
 (* CSS Animations 1 sec. 3: [@keyframes <keyframes-name>], [<keyframes-name> =
    <custom-ident> | <string>]. The reserved spellings ([none], CSS-wide
@@ -2306,6 +2310,7 @@ let read_descriptor_step normalize inner acc =
 
 let read_descriptor_block normalize inner =
   read_items_with_recovery ~skip:skip_invalid_item
+    ~recovery:Error.Recovery.(Dropped Declaration)
     (read_descriptor_step normalize)
     inner []
 
@@ -2613,7 +2618,7 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
            [font-named-instance]) or an invalid value of a known one
            ([font-display:maybe]) - is dropped and the rest of the @font-face is
            kept, matching browsers. *)
-        Cursor.push_warning r e;
+        Cursor.push_warning r ~recovery:Error.Recovery.(Dropped Declaration) e;
         Cursor.skip_past_semicolon r;
         None
 
@@ -2762,6 +2767,7 @@ let read_counter_style_descriptors r =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_invalid_item
+        ~recovery:Error.Recovery.(Dropped Declaration)
         (read_descriptor_body_step read_counter_style_descriptor
            replace_counter_style_descriptor)
         inner [])
@@ -2944,7 +2950,9 @@ let read_page_step inner (descriptors, margins) =
       )
 
 let read_page_body inner =
-  read_items_with_recovery ~skip:skip_invalid_item read_page_step inner ([], [])
+  read_items_with_recovery ~skip:skip_invalid_item
+    ~recovery:Error.Recovery.(Dropped Declaration)
+    read_page_step inner ([], [])
 
 let read_page (r : Cursor.t) : statement =
   Cursor.with_context r "@page" @@ fun () ->
@@ -3033,6 +3041,7 @@ let read_font_palette_descriptors outer =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_invalid_item
+        ~recovery:Error.Recovery.(Dropped Declaration)
         (read_descriptor_body_step
            (read_font_palette_descriptor outer)
            replace_font_palette_descriptor)
@@ -3101,7 +3110,9 @@ let read_font_feature_values_entries outer =
         Cursor.ws inner;
         if Cursor.is_done inner then List.rev acc else loop inner acc
     | exception Error.Parse_error e ->
-        Cursor.push_warning inner e;
+        Cursor.push_warning inner
+          ~recovery:Error.Recovery.(Dropped Declaration)
+          e;
         Cursor.skip_past_semicolon inner;
         loop inner acc
   in
@@ -3133,6 +3144,7 @@ let read_font_feature_values_blocks outer =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_past_rule
+        ~recovery:Error.Recovery.(Dropped Rule)
         (read_font_feature_values_step outer)
         inner [])
     outer
@@ -3211,6 +3223,7 @@ let read_view_transition_descriptors outer =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_invalid_item
+        ~recovery:Error.Recovery.(Dropped Declaration)
         (read_descriptor_body_step
            (read_view_transition_descriptor outer)
            replace_view_transition_descriptor)
@@ -3657,7 +3670,9 @@ let read_property_step r state =
   else `More (read_property_descriptor r state)
 
 let read_property_descriptors (r : Cursor.t) : property_reader_state =
-  read_items_with_recovery ~skip:skip_invalid_item read_property_step r
+  read_items_with_recovery ~skip:skip_invalid_item
+    ~recovery:Error.Recovery.(Dropped Declaration)
+    read_property_step r
     { syntax = None; inherits = None; initial_value = None }
 
 let read_property_rule (r : Cursor.t) : statement =
@@ -3711,7 +3726,9 @@ let item_opens_block inner =
    what [~strict:true] turns into an error. *)
 let drop_nested_at_rule r ~loc reason : statement option =
   skip_past_rule r;
-  Cursor.push_warning r (Error.bad_value loc ~property:"rule" ~reason);
+  Cursor.push_warning r
+    ~recovery:Error.Recovery.(Dropped Rule)
+    (Error.bad_value loc ~property:"rule" ~reason);
   None
 
 (* CSS Nesting 1 sec. 3.4 wraps a run of declarations written after a nested
@@ -3830,7 +3847,8 @@ let rec read_statement (r : Cursor.t) : statement =
              caller that wants it gone. *)
           ignore (Cursor.next_raw r);
           let stmt = read_unknown_at_rule name r in
-          Cursor.push_warning r (Error.unknown_at_rule loc name);
+          Cursor.push_warning r ~recovery:Error.Recovery.Recovered
+            (Error.unknown_at_rule loc name);
           stmt)
   | _ -> Rule (read_rule r)
 
@@ -3848,13 +3866,14 @@ and read_block (r : Cursor.t) : block =
          with it. Strict mode ([not (Cursor.recover r)]) still raises. *)
       | exception Error.Parse_error e when Cursor.recover r ->
           Cursor.restore r snap;
-          Cursor.push_warning r e;
+          Cursor.push_warning r ~recovery:Error.Recovery.(Dropped Rule) e;
           skip_past_rule r;
           read_statements acc
       | Import _ ->
           (* CSS Cascade L6 sec. 2: @import is only valid at the top of the
              stylesheet. Drop a misplaced one rather than emitting it. *)
           Cursor.push_warning r
+            ~recovery:Error.Recovery.(Dropped Rule)
             (Error.bad_value loc ~property:"stylesheet"
                ~reason:"@import is only valid at the top of a stylesheet");
           read_statements acc
@@ -3985,7 +4004,7 @@ and read_nesting_block (r : Cursor.t) : block =
     match read_nesting_item ~prev:acc r with
     | item -> add_item acc item
     | exception Error.Parse_error e ->
-        Cursor.push_warning r e;
+        Cursor.push_warning r ~recovery:Error.Recovery.(Dropped Declaration) e;
         Cursor.skip_past_semicolon r;
         read_items acc
   and add_item acc = function
@@ -4169,7 +4188,7 @@ and read_recovering_rule_item selector inner loop decls nested =
   | `Done result -> result
   | `Continue (decls, nested) -> loop decls nested
   | exception Error.Parse_error e ->
-      Cursor.push_warning inner e;
+      Cursor.push_warning inner ~recovery:Error.Recovery.(Dropped Declaration) e;
       Cursor.skip_past_semicolon inner;
       loop decls nested
 
@@ -4418,7 +4437,13 @@ let validate_partial_strict_warnings loc stmt =
          ~reason:"strict stylesheet warning")
   else None
 
+(* A warning drained from a cursor is stamped where the cursor recorded it. *)
 let add_warning warnings warning = warnings := warning :: !warnings
+
+(* A warning raised beside the statement rather than inside it, so this site
+   says what became of the statement. *)
+let add_statement_warning warnings ~recovery warning =
+  add_warning warnings (Error.with_recovery recovery warning)
 
 let drain_statement_warnings warnings cursor =
   List.iter (add_warning warnings) (Cursor.drain_warnings cursor)
@@ -4432,13 +4457,18 @@ let validate_else_orphan previous rule stmt =
            ~reason:"@else without preceding @when")
   | _ -> None
 
+(* These four run on a statement the reader read whole and the sheet keeps, so
+   the material each reports on reaches the output. *)
 let validate_partial_statement_warnings warnings validate_prelude rule stmt =
   let loc = rule_loc rule in
-  Option.iter (add_warning warnings) (validate_prelude loc stmt);
-  Option.iter (add_warning warnings) (validate_partial_statement loc stmt);
-  Option.iter (add_warning warnings)
-    (validate_partial_invalid_declarations loc stmt);
-  Option.iter (add_warning warnings) (validate_partial_strict_warnings loc stmt)
+  let add =
+    Option.iter
+      (add_statement_warning warnings ~recovery:Error.Recovery.Recovered)
+  in
+  add (validate_prelude loc stmt);
+  add (validate_partial_statement loc stmt);
+  add (validate_partial_invalid_declarations loc stmt);
+  add (validate_partial_strict_warnings loc stmt)
 
 let read_stylesheet_of_rules ?source ?meta (rules : Component.rule list) :
     stylesheet * Error.t list =
@@ -4462,14 +4492,20 @@ let read_stylesheet_of_rules ?source ?meta (rules : Component.rule list) :
               stmt;
             match validate_else_orphan previous rule stmt with
             | Some w ->
-                add_warning warnings w;
+                add_statement_warning warnings
+                  ~recovery:Error.Recovery.(Dropped Rule)
+                  w;
                 previous := Some stmt;
                 None
             | None ->
                 previous := Some stmt;
                 Some stmt)
         | Error e ->
-            add_warning warnings e;
+            (* [read_statement] refused the rule, so the sheet loses it whole:
+               its text reaches no caller reading the parse. *)
+            add_statement_warning warnings
+              ~recovery:Error.Recovery.(Dropped Rule)
+              e;
             None)
       rules
   in

--- a/test/cli/diff_unreadable_statement.t
+++ b/test/cli/diff_unreadable_statement.t
@@ -1,0 +1,87 @@
+CLI: `cascade diff` does not call two files identical over a statement it
+dropped whole.
+
+A statement the reader refuses goes the way of a refused declaration or
+rule: it reaches neither side of the comparison. Two warnings share the
+shape `bad value ... (in property-value)` and mean opposite things. One
+names a `@charset` the reader dropped, the other an `@font-face` cascade
+kept and reported on. The verdict follows what the reader did with the
+statement, not the shape of the warning it left behind.
+
+An `@charset` argument the reader refuses costs the whole statement. These
+two sheets differ only in that argument, so both sides lose it and the
+comparison sees the same thing twice.
+
+  $ cat > charset-a.css <<EOF
+  > .b{color:red}
+  > @charset "a";
+  > EOF
+  $ cat > charset-b.css <<EOF
+  > .b { color: red }
+  > @charset "b";
+  > EOF
+  $ cascade diff --diff=canonical charset-a.css charset-b.css
+  charset-a.css and charset-b.css parse warning: <string>: bad value for @charset: @charset only recognises "UTF-8" at [14-27] (in property-value)
+  
+  Unreadable rules: charset-a.css 1, charset-b.css 1
+  Cannot determine whether the CSS files are identical
+  [2]
+
+An `@font-face` missing `src` reaches the AST whole, so its warning reports
+on material the parse kept and the verdict stays proven.
+
+  $ cat > face-a.css <<EOF
+  > @font-face{font-family:x}
+  > .b{color:red}
+  > EOF
+  $ cat > face-b.css <<EOF
+  > @font-face{font-family:x}
+  > .b { color: red }
+  > EOF
+  $ cascade diff --diff=canonical face-a.css face-b.css
+  face-a.css and face-b.css parse warning: <string>: bad value for @font-face: missing font-family or src descriptor at [0-25] (in property-value)
+  
+  CSS files are identical
+
+The same verdict when the descriptor differs between the two files.
+`--diff=canonical` compares minified forms, and a `src`-less `@font-face`
+names no font to load, so minification drops it from both sides.
+
+  $ cat > face-c.css <<EOF
+  > @font-face{font-family:y}
+  > .b { color: red }
+  > EOF
+  $ cascade diff --diff=canonical face-a.css face-c.css
+  face-a.css and face-c.css parse warning: <string>: bad value for @font-face: missing font-family or src descriptor at [0-25] (in property-value)
+  
+  CSS files are identical
+
+`@tailwind base;` opens every Tailwind entry stylesheet. Cascade keeps the
+at-rule and its prelude, so it costs the verdict nothing.
+
+  $ cat > tw-a.css <<EOF
+  > @tailwind base;
+  > .b{color:red}
+  > EOF
+  $ cat > tw-b.css <<EOF
+  > @tailwind base;
+  > .b { color: red }
+  > EOF
+  $ cascade diff --diff=canonical tw-a.css tw-b.css
+  tw-a.css and tw-b.css parse warning: <string>: unknown at-rule @tailwind at [0-15] (in at-rule)
+  
+  CSS files are identical
+
+`--json` counts the dropped `@charset` among the rules, and the status
+agrees with the document.
+
+  $ cascade diff --json --diff=canonical charset-a.css charset-b.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["identical"], d["unreadable_declarations"], d["unreadable_rules"])'
+  False {'expected': 0, 'actual': 0} {'expected': 1, 'actual': 1}
+  $ cascade diff --json --diff=canonical tw-a.css tw-b.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["identical"], d["unreadable_declarations"], d["unreadable_rules"])'
+  True {'expected': 0, 'actual': 0} {'expected': 0, 'actual': 0}
+  $ cascade diff --json --diff=canonical charset-a.css charset-b.css > /dev/null
+  [2]


### PR DESCRIPTION
#832 and #833 decided what makes a verdict unprovable by matching a warning's kind and sort. That pair cannot answer the question: `Bad_value` at sort `Property_value` covers both a statement the sheet keeps (`@font-face` missing `src`) and one it drops (`@charset foo;`), so a dropped `@charset` still reported identical at exit 0.

An error now carries what became of its construct. A raise site cannot know, since the same error is discarded by a speculative reader or costs the construct depending on the handler, so the recovery point stamps it and the three warning funnels take it as a required argument.

`Error.t` gains a field. Callers build errors through `Error.v`, which fills it in; an exhaustive record pattern binds it or adds `_`.