### PR TITLE
diff: carry the dropped construct's text on the error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,8 +26,10 @@ entry points both moved.
 
 - `cascade diff` exits 2, not 0, when it finds no difference and had to drop a
   declaration or a rule it could not read: what it dropped reached neither side
-  of the comparison, so identity is not a verdict it can give. A gate that
-  reads any non-zero status as "differs" needs updating (#832, #833, #834)
+  of the comparison, so identity is not a verdict it can give. Two sides that
+  dropped the same source text still exit 0: the comparison did see the same
+  thing twice there. A gate that reads any non-zero status as "differs" needs
+  updating (#832, #833, #834, #835)
 - `Cascade.Error.t` gains `recovery`, which says whether the reader dropped the
   construct the error is about or kept it in the output. Exhaustive record
   patterns must bind it or add `_`; `Cascade.Error.v` fills it in (#834)

--- a/bin/cmd_diff.ml
+++ b/bin/cmd_diff.ml
@@ -74,7 +74,37 @@ let warning_budget = function
    at [Sort.Property_value] names an [@charset] the reader dropped and an
    [@font-face] it kept, so the kind and the sort cannot tell them apart. *)
 let dropped construct (w : Cascade.Error.t) =
-  Cascade.Error.Recovery.equal w.recovery (Dropped construct)
+  match w.recovery with
+  | Dropped d -> Cascade.Error.Recovery.equal_construct d.construct construct
+  | Recovered -> false
+
+(* What one side lost, in the order its reader reported it. *)
+let losses ws =
+  List.filter_map
+    (fun (w : Cascade.Error.t) ->
+      match w.recovery with
+      | Cascade.Error.Recovery.Dropped { construct; text } ->
+          Some (construct, text)
+      | Recovered -> None)
+    ws
+
+(* One loss accounts for another when the two readers threw away the same
+   construct spelled the same way. A loss the reader could not name accounts for
+   nothing: nothing shows the other side lost those same bytes. *)
+let accounts_for (c1, t1) (c2, t2) =
+  Cascade.Error.Recovery.equal_construct c1 c2
+  &&
+  match (t1, t2) with
+  | Some a, Some b -> String.equal a b
+  | None, _ | _, None -> false
+
+(* Two sides that lost the same run of text saw the same thing twice, so what
+   they hid cannot separate them and the comparison's verdict stands. *)
+let losses_cancel (result : Cascade_diff.Css_compare.t) =
+  let expected = losses result.expected_warnings in
+  let actual = losses result.actual_warnings in
+  List.compare_lengths expected actual = 0
+  && List.for_all2 accounts_for expected actual
 
 (* Counted per side, because the question is whether either input hid something
    from the comparison, not how many the pair hid between them. *)
@@ -98,7 +128,6 @@ let unread_of result =
   }
 
 let has_sides s = s.expected > 0 || s.actual > 0
-let has_unread u = has_sides u.declarations || has_sides u.rules
 
 let render_sides ~what ~file1 ~file2 s =
   if not (has_sides s) then ""
@@ -493,10 +522,10 @@ let json_document ~file1 ~file2 ~mode ~css1 ~css2 ~unread result =
   let outcome = result.Cascade_diff.Css_compare.result in
   (* A declaration or a rule the reader refuses is dropped from both sides, so a
      comparison that found no difference has not shown the two files to be
-     identical. *)
+     identical - unless the two sides lost the same text. *)
   let identical =
     match outcome with
-    | No_diff -> not (has_unread unread)
+    | No_diff -> losses_cancel result
     | Tree_diff _ | String_diff _ | Both_errors _ | Expected_error _
     | Actual_error _ ->
         false
@@ -535,7 +564,8 @@ let print_json_report ~file1 ~file2 ~mode ~css1 ~css2 ~opts =
   print_newline ();
   match result.Cascade_diff.Css_compare.result with
   | No_diff ->
-      if has_unread unread then Stdlib.exit Cli_exit.cannot_determine else Ok ()
+      if losses_cancel result then Ok ()
+      else Stdlib.exit Cli_exit.cannot_determine
   | Tree_diff _ | String_diff _ | Both_errors _ | Expected_error _
   | Actual_error _ ->
       Stdlib.exit 1
@@ -559,15 +589,14 @@ let compare_sources ~color ~mode ~limit ~json ~opts (css1, file1) (css2, file2)
            so the equality verdict is honest about them. *)
         let max = warning_budget limit in
         print_string (render_warnings ~file1 ~file2 ~max result);
-        let unread = unread_of result in
-        match has_unread unread with
-        | false ->
+        match losses_cancel result with
+        | true ->
             Fmt.pr "CSS files are identical@.";
             Ok ()
-        | true ->
+        | false ->
             (* The comparison saw no difference and never saw what the parse
                dropped either, so identity is not a verdict it can give. *)
-            print_string (render_unread ~file1 ~file2 unread);
+            print_string (render_unread ~file1 ~file2 (unread_of result));
             Fmt.pr "Cannot determine whether the CSS files are identical@.";
             Stdlib.exit Cli_exit.cannot_determine)
     | String_diff _ | Tree_diff _ | Both_errors _ | Expected_error _

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2447,7 +2447,7 @@ let read_declaration_step t acc =
    declaration is dropped, reading resumes past the next [;], and the
    surrounding rule survives. *)
 let recover_declaration_step t acc e =
-  Cursor.push_warning t ~recovery:Error.Recovery.(Dropped Declaration) e;
+  Cursor.push_warning t ~recovery:Error.Recovery.(dropped Declaration) e;
   Cursor.skip_past_semicolon t;
   acc
 

--- a/lib/error.ml
+++ b/lib/error.ml
@@ -1,14 +1,37 @@
 module Recovery = struct
   type construct = Declaration | Rule
-  type t = Dropped of construct | Recovered
+
+  type t =
+    | Dropped of { construct : construct; text : string option }
+    | Recovered
+
+  let equal_construct a b =
+    match (a, b) with
+    | Declaration, Declaration | Rule, Rule -> true
+    | (Declaration | Rule), _ -> false
 
   let equal a b =
     match (a, b) with
-    | Dropped Declaration, Dropped Declaration
-    | Dropped Rule, Dropped Rule
-    | Recovered, Recovered ->
-        true
+    | Dropped a, Dropped b ->
+        equal_construct a.construct b.construct
+        && Option.equal String.equal a.text b.text
+    | Recovered, Recovered -> true
     | (Dropped _ | Recovered), _ -> false
+
+  (* A span outside the source names nothing, and a zero-width one names no
+     bytes, so neither yields text. *)
+  let text_of source { Loc.start_pos; end_pos } =
+    if start_pos >= 0 && end_pos > start_pos && end_pos <= String.length source
+    then Some (String.sub source start_pos (end_pos - start_pos))
+    else None
+
+  let dropped ?source ?loc construct =
+    let text =
+      match (source, loc) with
+      | Some source, Some loc -> text_of source loc
+      | Some _, None | None, Some _ | None, None -> None
+    in
+    Dropped { construct; text }
 end
 
 type kind =

--- a/lib/error.mli
+++ b/lib/error.mli
@@ -12,15 +12,29 @@ module Recovery : sig
     | Rule  (** A rule or an at-rule, and everything it holds. *)
 
   type t =
-    | Dropped of construct
+    | Dropped of { construct : construct; text : string option }
         (** The construct's text reaches neither the AST nor anything printed
-            back out from it, so a caller reading the parse never sees it. *)
+            back out from it, so a caller reading the parse never sees it.
+            [text] is that source text, for a caller comparing one parse's
+            losses against another's. [None] leaves the loss unnamed: the
+            recovery point held no span for the whole construct. *)
     | Recovered
         (** The construct survives into the output. The error reports on it
             without costing it. *)
 
+  val equal_construct : construct -> construct -> bool
+  (** [equal_construct a b] is whether [a] and [b] are the same construct. *)
+
   val equal : t -> t -> bool
-  (** [equal a b] is whether [a] and [b] are the same recovery. *)
+  (** [equal a b] is whether [a] and [b] are the same recovery. Two unnamed
+      losses compare equal here; a caller weighing one parse's losses against
+      another's wants a [text] on both sides instead. *)
+
+  val dropped : ?source:string -> ?loc:Loc.t -> construct -> t
+  (** [dropped ~source ~loc construct] is a {!Dropped} recovery naming the text
+      [loc] spans in [source]. [loc] must cover the whole construct, not the
+      point the failure was reported at. Called without both arguments, or with
+      a span [source] does not cover, it names no text. *)
 end
 
 type kind =

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -1038,9 +1038,11 @@ let is_custom_property_shape prelude =
 let consume_qualified_rule ?(nested = false) ~meta lexer ~start_loc ~warnings :
     Component.qualified_rule option =
   let drop end_loc =
+    (* [start_loc] is the rule's first token and [end_loc] the one that ended
+       the attempt, so the union spans the rule the sheet loses. *)
     let loc = Loc.union start_loc end_loc in
     warn ~meta lexer warnings
-      ~recovery:Error.Recovery.(Dropped Rule)
+      ~recovery:Error.Recovery.(dropped ~source:(Lexer.source lexer) ~loc Rule)
       (Error.unterminated loc Sort.Qualified_rule);
     None
   in
@@ -1063,7 +1065,7 @@ let consume_qualified_rule ?(nested = false) ~meta lexer ~start_loc ~warnings :
           (* Dropping the rule is what the spec asks for, but it still has to be
              reported: [Css.of_string] warns for every rule it drops. *)
           warn ~meta lexer warnings
-            ~recovery:Error.Recovery.(Dropped Rule)
+            ~recovery:Error.Recovery.(dropped Rule)
             (Error.sort_mismatch loc ~sort:Sort.Qualified_rule
                ~expected:Sort.Selector ~found:Sort.Declaration);
           None)
@@ -1163,7 +1165,7 @@ let declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings cvs :
       in
       if value_has_invalid_block ~is_custom value || has_bad_token value then (
         warn ~meta lexer warnings
-          ~recovery:Error.Recovery.(Dropped Declaration)
+          ~recovery:Error.Recovery.(dropped Declaration)
           (Error.unexpected_token name_loc ~sort:Sort.Declaration
              (Token.Open Token.Curly));
         None)
@@ -1176,7 +1178,7 @@ let declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings cvs :
         Some { node = { name; value; important }; loc }
   | _ ->
       warn ~meta lexer warnings
-        ~recovery:Error.Recovery.(Dropped Declaration)
+        ~recovery:Error.Recovery.(dropped Declaration)
         (Error.missing_token name_loc ~sort:Sort.Declaration "':'");
       None
 
@@ -1234,7 +1236,7 @@ let consume_decl_list_item ~meta lexer ~warnings tok =
       | None -> `Skip)
   | _ ->
       warn ~meta lexer warnings
-        ~recovery:Error.Recovery.(Dropped Declaration)
+        ~recovery:Error.Recovery.(dropped Declaration)
         (Error.unexpected_token tok.loc ~sort:Sort.Declaration tok.kind);
       skip_bad_declaration lexer tok;
       `Skip

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2149,7 +2149,7 @@ let read_keyframe_or_skip inner acc =
   | frame -> frame :: acc
   | exception Cursor.Parse_error e ->
       Cursor.restore inner snap;
-      Cursor.push_warning inner ~recovery:Error.Recovery.(Dropped Rule) e;
+      Cursor.push_warning inner ~recovery:Error.Recovery.(dropped Rule) e;
       skip_past_rule inner;
       acc
 
@@ -2169,7 +2169,7 @@ let read_keyframes_step inner acc =
 
 let read_keyframes_block inner =
   read_items_with_recovery ~skip:skip_past_rule
-    ~recovery:Error.Recovery.(Dropped Rule)
+    ~recovery:Error.Recovery.(dropped Rule)
     read_keyframes_step inner []
 
 (* CSS Animations 1 sec. 3: [@keyframes <keyframes-name>], [<keyframes-name> =
@@ -2310,7 +2310,7 @@ let read_descriptor_step normalize inner acc =
 
 let read_descriptor_block normalize inner =
   read_items_with_recovery ~skip:skip_invalid_item
-    ~recovery:Error.Recovery.(Dropped Declaration)
+    ~recovery:Error.Recovery.(dropped Declaration)
     (read_descriptor_step normalize)
     inner []
 
@@ -2618,7 +2618,7 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
            [font-named-instance]) or an invalid value of a known one
            ([font-display:maybe]) - is dropped and the rest of the @font-face is
            kept, matching browsers. *)
-        Cursor.push_warning r ~recovery:Error.Recovery.(Dropped Declaration) e;
+        Cursor.push_warning r ~recovery:Error.Recovery.(dropped Declaration) e;
         Cursor.skip_past_semicolon r;
         None
 
@@ -2767,7 +2767,7 @@ let read_counter_style_descriptors r =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_invalid_item
-        ~recovery:Error.Recovery.(Dropped Declaration)
+        ~recovery:Error.Recovery.(dropped Declaration)
         (read_descriptor_body_step read_counter_style_descriptor
            replace_counter_style_descriptor)
         inner [])
@@ -2951,7 +2951,7 @@ let read_page_step inner (descriptors, margins) =
 
 let read_page_body inner =
   read_items_with_recovery ~skip:skip_invalid_item
-    ~recovery:Error.Recovery.(Dropped Declaration)
+    ~recovery:Error.Recovery.(dropped Declaration)
     read_page_step inner ([], [])
 
 let read_page (r : Cursor.t) : statement =
@@ -3041,7 +3041,7 @@ let read_font_palette_descriptors outer =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_invalid_item
-        ~recovery:Error.Recovery.(Dropped Declaration)
+        ~recovery:Error.Recovery.(dropped Declaration)
         (read_descriptor_body_step
            (read_font_palette_descriptor outer)
            replace_font_palette_descriptor)
@@ -3111,7 +3111,7 @@ let read_font_feature_values_entries outer =
         if Cursor.is_done inner then List.rev acc else loop inner acc
     | exception Error.Parse_error e ->
         Cursor.push_warning inner
-          ~recovery:Error.Recovery.(Dropped Declaration)
+          ~recovery:Error.Recovery.(dropped Declaration)
           e;
         Cursor.skip_past_semicolon inner;
         loop inner acc
@@ -3144,7 +3144,7 @@ let read_font_feature_values_blocks outer =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_past_rule
-        ~recovery:Error.Recovery.(Dropped Rule)
+        ~recovery:Error.Recovery.(dropped Rule)
         (read_font_feature_values_step outer)
         inner [])
     outer
@@ -3223,7 +3223,7 @@ let read_view_transition_descriptors outer =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_invalid_item
-        ~recovery:Error.Recovery.(Dropped Declaration)
+        ~recovery:Error.Recovery.(dropped Declaration)
         (read_descriptor_body_step
            (read_view_transition_descriptor outer)
            replace_view_transition_descriptor)
@@ -3671,7 +3671,7 @@ let read_property_step r state =
 
 let read_property_descriptors (r : Cursor.t) : property_reader_state =
   read_items_with_recovery ~skip:skip_invalid_item
-    ~recovery:Error.Recovery.(Dropped Declaration)
+    ~recovery:Error.Recovery.(dropped Declaration)
     read_property_step r
     { syntax = None; inherits = None; initial_value = None }
 
@@ -3727,7 +3727,7 @@ let item_opens_block inner =
 let drop_nested_at_rule r ~loc reason : statement option =
   skip_past_rule r;
   Cursor.push_warning r
-    ~recovery:Error.Recovery.(Dropped Rule)
+    ~recovery:Error.Recovery.(dropped Rule)
     (Error.bad_value loc ~property:"rule" ~reason);
   None
 
@@ -3866,14 +3866,14 @@ and read_block (r : Cursor.t) : block =
          with it. Strict mode ([not (Cursor.recover r)]) still raises. *)
       | exception Error.Parse_error e when Cursor.recover r ->
           Cursor.restore r snap;
-          Cursor.push_warning r ~recovery:Error.Recovery.(Dropped Rule) e;
+          Cursor.push_warning r ~recovery:Error.Recovery.(dropped Rule) e;
           skip_past_rule r;
           read_statements acc
       | Import _ ->
           (* CSS Cascade L6 sec. 2: @import is only valid at the top of the
              stylesheet. Drop a misplaced one rather than emitting it. *)
           Cursor.push_warning r
-            ~recovery:Error.Recovery.(Dropped Rule)
+            ~recovery:Error.Recovery.(dropped Rule)
             (Error.bad_value loc ~property:"stylesheet"
                ~reason:"@import is only valid at the top of a stylesheet");
           read_statements acc
@@ -4004,7 +4004,7 @@ and read_nesting_block (r : Cursor.t) : block =
     match read_nesting_item ~prev:acc r with
     | item -> add_item acc item
     | exception Error.Parse_error e ->
-        Cursor.push_warning r ~recovery:Error.Recovery.(Dropped Declaration) e;
+        Cursor.push_warning r ~recovery:Error.Recovery.(dropped Declaration) e;
         Cursor.skip_past_semicolon r;
         read_items acc
   and add_item acc = function
@@ -4188,7 +4188,7 @@ and read_recovering_rule_item selector inner loop decls nested =
   | `Done result -> result
   | `Continue (decls, nested) -> loop decls nested
   | exception Error.Parse_error e ->
-      Cursor.push_warning inner ~recovery:Error.Recovery.(Dropped Declaration) e;
+      Cursor.push_warning inner ~recovery:Error.Recovery.(dropped Declaration) e;
       Cursor.skip_past_semicolon inner;
       loop decls nested
 
@@ -4482,6 +4482,12 @@ let read_stylesheet_of_rules ?source ?meta (rules : Component.rule list) :
     List.filter_map
       (fun rule ->
         let cursor, result = read_statement_of_rule ?source ?meta rule in
+        (* [rule_loc] spans the rule the parser handed over, prelude and block
+           alike, so it names what a drop costs the sheet. The error's own
+           location marks where the read gave up inside it. *)
+        let lost () =
+          Error.Recovery.(dropped ?source ~loc:(rule_loc rule) Rule)
+        in
         (* Drain declaration-level warnings first so source order is preserved:
            decl warnings come from inside the rule, the rule-level error (if
            any) comes after them. *)
@@ -4492,9 +4498,7 @@ let read_stylesheet_of_rules ?source ?meta (rules : Component.rule list) :
               stmt;
             match validate_else_orphan previous rule stmt with
             | Some w ->
-                add_statement_warning warnings
-                  ~recovery:Error.Recovery.(Dropped Rule)
-                  w;
+                add_statement_warning warnings ~recovery:(lost ()) w;
                 previous := Some stmt;
                 None
             | None ->
@@ -4503,9 +4507,7 @@ let read_stylesheet_of_rules ?source ?meta (rules : Component.rule list) :
         | Error e ->
             (* [read_statement] refused the rule, so the sheet loses it whole:
                its text reaches no caller reading the parse. *)
-            add_statement_warning warnings
-              ~recovery:Error.Recovery.(Dropped Rule)
-              e;
+            add_statement_warning warnings ~recovery:(lost ()) e;
             None)
       rules
   in

--- a/test/cli/diff_unreadable_rule.t
+++ b/test/cli/diff_unreadable_rule.t
@@ -8,9 +8,13 @@ never checked, so `cascade diff` gives the same third verdict and exits 2.
 The count is kept apart from the declaration count: a harness reads the two
 to tell what its sheet lost.
 
+Two sides that lost the same source text are the exception. There the
+comparison did see the same thing twice, so the equality it found holds and
+the status is 0. The counts still report what each side lost.
+
 A prelude the reader cannot close takes the whole rule. These two sheets
-differ only inside one, so both sides drop it and the comparison sees the
-same thing twice.
+differ inside one, so each side drops a different rule and neither loss is
+accounted for by the other.
 
   $ cat > rule-a.css <<EOF
   > .b{color:red}
@@ -30,8 +34,10 @@ same thing twice.
   Cannot determine whether the CSS files are identical
   [2]
 
-The same dropped rule text on both sides reaches the same verdict. The
-comparison has no more to say here than it had above.
+The same dropped rule text on both sides costs the verdict nothing. What the
+two sheets still hold compares equal, and the rule each of them lost was the
+same run of bytes, so the status is 0. The two sides carry it at different
+offsets, which the text comparison does not care about.
 
   $ cat > same-a.css <<EOF
   > .b { color: red }
@@ -47,12 +53,37 @@ comparison has no more to say here than it had above.
   .a[[ {color:red}
   ^^^^^^^^^^^^^^^^
   
-  Unreadable rules: same-a.css 1, same-b.css 1
+  CSS files are identical
+
+`--json` still counts the rule each side lost. The counts say what the parse
+dropped; they no longer withhold the verdict on their own.
+
+  $ cascade diff --json --diff=canonical same-a.css same-b.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["identical"], d["unreadable_rules"])'
+  True {'expected': 1, 'actual': 1}
+
+A rule only one side dropped leaves the other side holding text the
+comparison never saw, so that verdict stays unproven.
+
+  $ cat > kept-a.css <<EOF
+  > .b{color:red}
+  > EOF
+  $ cascade diff --diff=canonical kept-a.css same-b.css
+  same-b.css parse warning: <string>: unterminated qualified-rule at [14-30] (in qualified-rule)
+  .b{color:red}
+  .a[[ {color:red}
+  ^^^^^^^^^^^^^^^^
+  
+  Unreadable rules: kept-a.css 0, same-b.css 1
   Cannot determine whether the CSS files are identical
   [2]
 
 An at-rule condition the grammar refuses loses more: the at-rule goes and
-every rule nested inside it goes with it.
+every rule nested inside it goes with it. Both sides report the failure at
+the same offsets over the same snippet, because the offset marks where the
+condition gave up rather than what the reader threw away. The rules thrown
+away differ, and the verdict follows those.
 
   $ cat > media-a.css <<EOF
   > .b{color:red}
@@ -173,6 +204,9 @@ asserts on either without reading the report.
 The document and the status agree.
 
   $ cascade diff --json --diff=canonical rule-a.css rule-b.css > /dev/null
+  [2]
+  $ cascade diff --json --diff=canonical same-a.css same-b.css > /dev/null
+  $ cascade diff --json --diff=canonical kept-a.css same-b.css > /dev/null
   [2]
   $ cascade diff --json --diff=canonical at-a.css at-b.css > /dev/null
   $ cascade diff --json --diff=canonical rule-a.css differ-b.css > /dev/null


### PR DESCRIPTION
#832 to #834 made `cascade diff` exit 2 whenever it dropped something it could not read. That is broader than it needs to be: when both sides dropped the same text, both sheets hold the same thing and there is nothing left to determine.

A recovery point can now record the dropped construct's source span, and the comparison exits 2 only when the two sides lost different bytes. A site that does not record a span keeps the old answer, so the change is safe where it is not yet filled in.

Two sites record one: a rule dropped from a stylesheet, and a qualified rule the parser could not close. The declaration recovery loops still record nothing, so a dropped declaration keeps exiting 2.

The span is the construct's own, not the error's location. Those differ: `@media (bogus^^^){...}` reports the same failure position and the same snippet on both sides while the dropped rules differ, and that pair still exits 2.