### PR TITLE
diff: name the dropped declaration on the error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,7 @@ entry points both moved.
   of the comparison, so identity is not a verdict it can give. Two sides that
   dropped the same source text still exit 0: the comparison did see the same
   thing twice there. A gate that reads any non-zero status as "differs" needs
-  updating (#832, #833, #834, #835)
+  updating (#832, #833, #834, #835, #836)
 - `Cascade.Error.t` gains `recovery`, which says whether the reader dropped the
   construct the error is about or kept it in the output. Exhaustive record
   patterns must bind it or add `_`; `Cascade.Error.v` fills it in (#834)

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -205,6 +205,29 @@ type snapshot = Component.t list
 let save t = t.cvs
 let restore t s = t.cvs <- s
 
+(* The source range covered by the components consumed since [snap]. A recovery
+   point holds the snapshot from before the item it gave up on, so this names
+   the whole construct it then skipped rather than the point the read failed at.
+   Whitespace at either end sits outside the construct and is left out. *)
+let consumed_span t snap =
+  let rec span acc cvs =
+    if cvs == t.cvs then acc
+    else
+      match cvs with
+      | [] -> None
+      | hd :: tl when is_ws_cv hd -> span acc tl
+      | hd :: tl ->
+          let loc = Component.source_loc hd in
+          let acc =
+            match acc with None -> Some loc | Some l -> Some (Loc.union l loc)
+          in
+          span acc tl
+  in
+  span None snap
+
+let dropped_since t snap construct =
+  Error.Recovery.dropped ?source:t.source ?loc:(consumed_span t snap) construct
+
 (** {1 Errors} *)
 
 exception Parse_error = Error.Parse_error

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -162,6 +162,17 @@ val save : t -> snapshot
 val restore : t -> snapshot -> unit
 (** [restore t s] rewinds [t] to the position captured by [s]. *)
 
+val dropped_since :
+  t -> snapshot -> Error.Recovery.construct -> Error.Recovery.t
+(** [dropped_since t s construct] is a dropped-[construct] recovery naming the
+    source text from the first component [t] consumed since [s] to the last,
+    whitespace at either end left out. A recovery point takes [s] before the
+    item it gives up on and calls this once it has skipped that item, so the
+    recovery names the whole construct the reader threw away rather than the
+    point the read failed at. It names no text when [t] carries no source, when
+    nothing but whitespace was consumed, or when [s] is no snapshot [t] advanced
+    from. *)
+
 val atomic : t -> (unit -> 'a) -> 'a
 (** [atomic t f] runs [f ()] with a snapshot held; if [f] raises {!Parse_error},
     the cursor is restored before the exception propagates. *)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2411,7 +2411,14 @@ let read_declaration t : declaration option =
 type parse_step =
   | Done of declaration list
   | Continue of declaration list
-  | Recover of declaration list * Error.t
+  | Recover of {
+      decls : declaration list;
+      error : Error.t;
+      from : Cursor.snapshot;
+          (* Where the item that is about to be dropped starts. A separator that
+             fails comes after a declaration already committed, so the two
+             recovery arms carry different snapshots. *)
+    }
 
 let check_declaration_separator t acc =
   Cursor.ws t;
@@ -2430,14 +2437,18 @@ let read_declaration_no_recovery t acc =
   | Some decl -> check_declaration_separator t (decl :: acc)
 
 let read_declaration_with_recovery t acc =
+  let start = Cursor.save t in
   match read_declaration t with
   | None -> Done (List.rev acc)
   | Some decl -> (
       let acc = decl :: acc in
+      let after = Cursor.save t in
       match check_declaration_separator t acc with
       | step -> step
-      | exception Error.Parse_error e -> Recover (acc, e))
-  | exception Error.Parse_error e -> Recover (acc, e)
+      | exception Error.Parse_error e ->
+          Recover { decls = acc; error = e; from = after })
+  | exception Error.Parse_error e ->
+      Recover { decls = acc; error = e; from = start }
 
 let read_declaration_step t acc =
   if Cursor.recover t then read_declaration_with_recovery t acc
@@ -2446,9 +2457,11 @@ let read_declaration_step t acc =
 (* CSS Syntax 3 (ED) sec. 5.5.5 ("consume a block's contents"): the invalid
    declaration is dropped, reading resumes past the next [;], and the
    surrounding rule survives. *)
-let recover_declaration_step t acc e =
-  Cursor.push_warning t ~recovery:Error.Recovery.(dropped Declaration) e;
+let recover_declaration_step t acc e ~from =
   Cursor.skip_past_semicolon t;
+  Cursor.push_warning t
+    ~recovery:(Cursor.dropped_since t from Error.Recovery.Declaration)
+    e;
   acc
 
 let rec read_declarations_loop t acc =
@@ -2459,8 +2472,9 @@ let rec read_declarations_loop t acc =
       match read_declaration_step t acc with
       | Done decls -> decls
       | Continue acc -> read_declarations_loop t acc
-      | Recover (acc, e) ->
-          read_declarations_loop t (recover_declaration_step t acc e))
+      | Recover { decls; error; from } ->
+          read_declarations_loop t
+            (recover_declaration_step t decls error ~from))
 
 let read_declarations t =
   Cursor.with_context t "declarations" @@ fun () -> read_declarations_loop t []

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -1150,6 +1150,17 @@ let value_has_invalid_block ~is_custom value =
 let declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings cvs :
     Component.declaration option =
   let is_custom = Custom_property_name.has_prefix name in
+  (* [name_loc] opens the declaration and [cvs] is its body up to the [;], so
+     the union spans what the sheet loses when the pair is refused. *)
+  let dropped () =
+    let loc =
+      List.fold_left
+        (fun l cv -> Loc.union l (Component.source_loc cv))
+        name_loc (trim_ws cvs)
+    in
+    Error.Recovery.dropped ~source:(Lexer.source lexer) ~loc
+      Error.Recovery.Declaration
+  in
   match drop_leading_ws cvs with
   | Preserved { kind = Token.Colon; _ } :: rest ->
       let value1 = trim_ws rest in
@@ -1164,8 +1175,7 @@ let declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings cvs :
         | _ -> (value1, false)
       in
       if value_has_invalid_block ~is_custom value || has_bad_token value then (
-        warn ~meta lexer warnings
-          ~recovery:Error.Recovery.(dropped Declaration)
+        warn ~meta lexer warnings ~recovery:(dropped ())
           (Error.unexpected_token name_loc ~sort:Sort.Declaration
              (Token.Open Token.Curly));
         None)
@@ -1177,8 +1187,7 @@ let declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings cvs :
         in
         Some { node = { name; value; important }; loc }
   | _ ->
-      warn ~meta lexer warnings
-        ~recovery:Error.Recovery.(dropped Declaration)
+      warn ~meta lexer warnings ~recovery:(dropped ())
         (Error.missing_token name_loc ~sort:Sort.Declaration "':'");
       None
 
@@ -1203,17 +1212,17 @@ let consume_declaration_body lexer =
   in
   loop []
 
+(* Answers where the skip stopped, so the caller can report the whole
+   declaration it threw away and not just the token it started on. *)
 let skip_bad_declaration lexer tok =
-  let rec skip () =
+  let rec skip last =
     let t = Lexer.next lexer in
     match t.Token.kind with
-    | Token.Semicolon | Token.Eof -> ()
-    | _ ->
-        let _ = consume_component_value_from lexer t in
-        skip ()
+    | Token.Semicolon -> t.loc
+    | Token.Eof -> last
+    | _ -> skip (Component.source_loc (consume_component_value_from lexer t))
   in
-  let _ = consume_component_value_from lexer tok in
-  skip ()
+  skip (Component.source_loc (consume_component_value_from lexer tok))
 
 let consume_decl_from_ident ~meta lexer ~warnings ~name ~name_loc =
   let body = consume_declaration_body lexer in
@@ -1235,10 +1244,12 @@ let consume_decl_list_item ~meta lexer ~warnings tok =
       | Some item -> `Item item
       | None -> `Skip)
   | _ ->
+      let end_loc = skip_bad_declaration lexer tok in
+      let loc = Loc.union tok.loc end_loc in
       warn ~meta lexer warnings
-        ~recovery:Error.Recovery.(dropped Declaration)
+        ~recovery:
+          Error.Recovery.(dropped ~source:(Lexer.source lexer) ~loc Declaration)
         (Error.unexpected_token tok.loc ~sort:Sort.Declaration tok.kind);
-      skip_bad_declaration lexer tok;
       `Skip
 
 let consume_list_of_declarations ~meta lexer ~warnings :

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2120,10 +2120,12 @@ let skip_invalid_item r =
    what the lenient parse warns about. [skip] discards the item that failed, and
    which one it is depends on the body: {!skip_invalid_item} for a body of
    declarations, {!skip_past_rule} for a body of rules, where an item that opens
-   a block ends at that block rather than at a [;] it does not have. [recovery]
+   a block ends at that block rather than at a [;] it does not have. [construct]
    names the same two bodies: the dropped item is a declaration in the first and
-   a rule in the second. *)
-let read_items_with_recovery ~skip ~recovery step r init =
+   a rule in the second. The warning is pushed after the skip, which is what
+   fixes how far the loss reaches: the item is dropped from [start] to wherever
+   [skip] leaves the cursor. *)
+let read_items_with_recovery ~skip ~construct step r init =
   let rec loop state =
     if Cursor.recover r then recovering state else continue (step r state)
   and recovering state =
@@ -2131,9 +2133,11 @@ let read_items_with_recovery ~skip ~recovery step r init =
     match step r state with
     | committed -> continue committed
     | exception Error.Parse_error e ->
-        Cursor.push_warning r ~recovery e;
         Cursor.restore r start;
         skip r;
+        Cursor.push_warning r
+          ~recovery:(Cursor.dropped_since r start construct)
+          e;
         loop state
   and continue = function
     | `Done result -> result
@@ -2168,8 +2172,7 @@ let read_keyframes_step inner acc =
     | _ -> `More (read_keyframe_or_skip inner acc)
 
 let read_keyframes_block inner =
-  read_items_with_recovery ~skip:skip_past_rule
-    ~recovery:Error.Recovery.(dropped Rule)
+  read_items_with_recovery ~skip:skip_past_rule ~construct:Error.Recovery.Rule
     read_keyframes_step inner []
 
 (* CSS Animations 1 sec. 3: [@keyframes <keyframes-name>], [<keyframes-name> =
@@ -2310,7 +2313,7 @@ let read_descriptor_step normalize inner acc =
 
 let read_descriptor_block normalize inner =
   read_items_with_recovery ~skip:skip_invalid_item
-    ~recovery:Error.Recovery.(dropped Declaration)
+    ~construct:Error.Recovery.Declaration
     (read_descriptor_step normalize)
     inner []
 
@@ -2602,6 +2605,7 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
     Cursor.skip r;
     None)
   else
+    let start = Cursor.save r in
     let name = Cursor.ident ~keep_case:false r in
     match
       if descriptor_value_has_var r && not (descriptor_resolves_var name) then
@@ -2618,8 +2622,10 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
            [font-named-instance]) or an invalid value of a known one
            ([font-display:maybe]) - is dropped and the rest of the @font-face is
            kept, matching browsers. *)
-        Cursor.push_warning r ~recovery:Error.Recovery.(dropped Declaration) e;
         Cursor.skip_past_semicolon r;
+        Cursor.push_warning r
+          ~recovery:(Cursor.dropped_since r start Error.Recovery.Declaration)
+          e;
         None
 
 let read_font_face_block inner =
@@ -2767,7 +2773,7 @@ let read_counter_style_descriptors r =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_invalid_item
-        ~recovery:Error.Recovery.(dropped Declaration)
+        ~construct:Error.Recovery.Declaration
         (read_descriptor_body_step read_counter_style_descriptor
            replace_counter_style_descriptor)
         inner [])
@@ -2951,8 +2957,7 @@ let read_page_step inner (descriptors, margins) =
 
 let read_page_body inner =
   read_items_with_recovery ~skip:skip_invalid_item
-    ~recovery:Error.Recovery.(dropped Declaration)
-    read_page_step inner ([], [])
+    ~construct:Error.Recovery.Declaration read_page_step inner ([], [])
 
 let read_page (r : Cursor.t) : statement =
   Cursor.with_context r "@page" @@ fun () ->
@@ -3041,7 +3046,7 @@ let read_font_palette_descriptors outer =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_invalid_item
-        ~recovery:Error.Recovery.(dropped Declaration)
+        ~construct:Error.Recovery.Declaration
         (read_descriptor_body_step
            (read_font_palette_descriptor outer)
            replace_font_palette_descriptor)
@@ -3104,16 +3109,18 @@ let replace_font_feature_value ((name, _) as entry) acc =
 
 let read_font_feature_values_entries outer =
   let rec loop inner acc =
+    let start = Cursor.save inner in
     match read_font_feature_value_entry outer inner with
     | Some entry -> loop inner (replace_font_feature_value entry acc)
     | None ->
         Cursor.ws inner;
         if Cursor.is_done inner then List.rev acc else loop inner acc
     | exception Error.Parse_error e ->
-        Cursor.push_warning inner
-          ~recovery:Error.Recovery.(dropped Declaration)
-          e;
         Cursor.skip_past_semicolon inner;
+        Cursor.push_warning inner
+          ~recovery:
+            (Cursor.dropped_since inner start Error.Recovery.Declaration)
+          e;
         loop inner acc
   in
   Cursor.braces (fun inner -> loop inner []) outer
@@ -3144,7 +3151,7 @@ let read_font_feature_values_blocks outer =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_past_rule
-        ~recovery:Error.Recovery.(dropped Rule)
+        ~construct:Error.Recovery.Rule
         (read_font_feature_values_step outer)
         inner [])
     outer
@@ -3223,7 +3230,7 @@ let read_view_transition_descriptors outer =
   Cursor.braces
     (fun inner ->
       read_items_with_recovery ~skip:skip_invalid_item
-        ~recovery:Error.Recovery.(dropped Declaration)
+        ~construct:Error.Recovery.Declaration
         (read_descriptor_body_step
            (read_view_transition_descriptor outer)
            replace_view_transition_descriptor)
@@ -3671,8 +3678,7 @@ let read_property_step r state =
 
 let read_property_descriptors (r : Cursor.t) : property_reader_state =
   read_items_with_recovery ~skip:skip_invalid_item
-    ~recovery:Error.Recovery.(dropped Declaration)
-    read_property_step r
+    ~construct:Error.Recovery.Declaration read_property_step r
     { syntax = None; inherits = None; initial_value = None }
 
 let read_property_rule (r : Cursor.t) : statement =
@@ -4001,11 +4007,14 @@ and read_nesting_block (r : Cursor.t) : block =
      nor the rest of the sheet. Strict mode ([not (Cursor.recover r)]) still
      raises. *)
   and read_recovering_item acc =
+    let start = Cursor.save r in
     match read_nesting_item ~prev:acc r with
     | item -> add_item acc item
     | exception Error.Parse_error e ->
-        Cursor.push_warning r ~recovery:Error.Recovery.(dropped Declaration) e;
         Cursor.skip_past_semicolon r;
+        Cursor.push_warning r
+          ~recovery:(Cursor.dropped_since r start Error.Recovery.Declaration)
+          e;
         read_items acc
   and add_item acc = function
     | `Done -> List.rev (seal_declaration_run acc)
@@ -4184,12 +4193,15 @@ and read_rule_body selector inner =
   loop [] []
 
 and read_recovering_rule_item selector inner loop decls nested =
+  let start = Cursor.save inner in
   match read_rule_item selector inner decls nested with
   | `Done result -> result
   | `Continue (decls, nested) -> loop decls nested
   | exception Error.Parse_error e ->
-      Cursor.push_warning inner ~recovery:Error.Recovery.(dropped Declaration) e;
       Cursor.skip_past_semicolon inner;
+      Cursor.push_warning inner
+        ~recovery:(Cursor.dropped_since inner start Error.Recovery.Declaration)
+        e;
       loop decls nested
 
 and read_rule ?(nested = false) (r : Cursor.t) : rule =

--- a/test/cli/diff_unreadable_verdict.t
+++ b/test/cli/diff_unreadable_verdict.t
@@ -54,6 +54,46 @@ had above.
   Cannot determine whether the CSS files are identical
   [2]
 
+Both sides losing the same run of source text is the exception. There the
+comparison did see the same thing twice, so the equality it found holds and
+the status is 0. These two spell the unreadable declaration alike and differ
+only where the comparison could read both sides.
+
+  $ cat > text-a.css <<EOF
+  > .g{grid-template-columns:calc(1 + 2);color:red}
+  > EOF
+  $ cat > text-b.css <<EOF
+  > .g{grid-template-columns:calc(1 + 2);color:#f00}
+  > EOF
+  $ cascade diff --diff=canonical text-a.css text-b.css
+  text-a.css and text-b.css parse warning: <string>: read_declaration/grid-template-columns: bad value for grid-template-columns: expected at least 1 items (got 0) at [25-36] (in component)
+  .g{grid-template-columns:calc(1 + 2);color:red}
+                           ^^^^^^^^^^^
+  
+  CSS files are identical
+
+`--json` still counts the declaration each side lost, and reports the pair
+identical.
+
+  $ cascade diff --json --diff=canonical text-a.css text-b.css | python3 -c 'import json,sys
+  > d = json.load(sys.stdin)
+  > print(d["identical"], d["unreadable_declarations"])'
+  True {'expected': 1, 'actual': 1}
+
+A declaration the two sides spell differently is not the same loss, however
+alike the two failures look. These two name a different property of the same
+length, so the reader gives up at the same offset on both sides and the
+message it prints is no evidence they lost the same declaration.
+
+  $ cat > prop-a.css <<EOF
+  > .g{grid-auto-flow:calc(1 + 2);color:red}
+  > EOF
+  $ cat > prop-b.css <<EOF
+  > .g{grid-auto-rows:calc(1 + 2);color:#f00}
+  > EOF
+  $ cascade diff --diff=canonical prop-a.css prop-b.css > /dev/null
+  [2]
+
 A difference the comparison did reach outranks one it could not: the report
 names the difference and the status stays 1.
 
@@ -125,6 +165,7 @@ The document and the status agree: `--json` reports the same three verdicts.
   $ cascade diff --json --diff=canonical same-a.css same-b.css > /dev/null
   [2]
   $ cascade diff --json --diff=canonical plain-a.css plain-b.css > /dev/null
+  $ cascade diff --json --diff=canonical text-a.css text-b.css > /dev/null
   $ cascade diff --json --diff=canonical same-a.css differ-b.css > /dev/null
   [1]
 

--- a/test/cli/diff_unreadable_verdict.t
+++ b/test/cli/diff_unreadable_verdict.t
@@ -19,9 +19,10 @@ Both files read whole and compare equal. That verdict is proven, so it stays
   $ cascade diff --diff=canonical plain-a.css plain-b.css
   CSS files are identical
 
-The same unreadable declaration on both sides. Every browser drops both
-copies, so the two files may well render alike - but that is the one
-declaration cascade did not read, and the count says so per side.
+The same unreadable declaration on both sides, spelled differently. Every
+browser drops both copies, so the two files may well render alike - but the
+run of source text each sheet lost is a different run, so neither loss
+accounts for the other and the count reports both.
 
   $ cat > same-a.css <<EOF
   > .g { grid-template-columns: calc(1 + 2); color: red }


### PR DESCRIPTION
#835 let a recovery point record the dropped construct's span, so `cascade diff` exits 2 only when the two sides lost different bytes. It filled the rule sites. A dropped declaration recorded nothing, so it always cost the verdict, even when both sides dropped the same text.

Every declaration recovery site now records its span. `Cursor.dropped_since` derives it from the components consumed since a snapshot, with whitespace at either end dropped, so the recorded text is the declaration and not the run between it and the next one.

The span covers the property name, not just the value the reader refused: `grid-auto-flow: calc(1 + 2)` and `grid-auto-rows: calc(1 + 2)` report the same failure position and the same snippet, and still exit 2.

Five sites still record nothing, all of them rules.