### PR TITLE
docs: say what a clean canonical diff asserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ Compares two CSS files through the parsed CSS structure rather than
 character-by-character: added, removed, modified, and reordered rules are
 detected structurally, and property value changes are reported in terms of CSS
 values. Identical files exit 0; differences exit 1, making `cascade diff`
-usable as a CI check. A comparison that finds no difference but had to drop a
-declaration or a rule it could not read exits 2 instead: what it dropped
+usable as a CI check. Under `--diff=canonical`, exit 0 asserts that no element
+computes a value differing beyond the approximation budget below, not that the
+two files hold the same rules. A comparison that finds no difference but had to
+drop a declaration or a rule it could not read exits 2 instead: what it dropped
 reached neither side, so identity is not a verdict the comparison can give. The
 report and the `--json` document count declarations and rules per side.
 
@@ -175,6 +177,11 @@ report and the `--json` document count declarations and rules per side.
   default, `calc(28/18)` compares equal to Cascade's six-significant-figure
   output `1.55556`; under `--lossless` it remains distinct from every finite
   decimal spelling.
+
+`canonical` ignores what cannot change a computed value, so surplus output that
+renders identically, an empty rule for instance, does not appear in its report.
+A check that must catch surplus output needs `tree` or `string`; a CI gate that
+cares about both runs both.
 
 | Flag | Purpose |
 |---|---|


### PR DESCRIPTION
README describes how `--diff=canonical` works and never says what a clean result claims. A reader looking at exit 0 has no reason to ask what question was answered, and an experienced user recently read a surplus empty rule going unreported as a defect rather than as the mode working.

Exit 0 under canonical asserts that no element computes a value differing beyond the approximation budget, not that the two files hold the same rules. Surplus output that renders identically does not appear in the report, so a check that must catch it needs `tree` or `string`.

The exit-code passage carries the clause and the mode list carries the fuller statement, so neither says it twice.