### PR TITLE
shorthand: keep the transition behaviour slot when contracting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -384,6 +384,11 @@ entry points both moved.
 
 ### Minification
 
+- `--minify` keeps a transition longhand written before a run of other
+  transition longhands. The run contracted into the `transition` shorthand,
+  which resets the rest of the family, so a `transition-behavior:
+  allow-discrete` ahead of it was deleted and the element stopped transitioning
+  discrete values (#843)
 - `cascade diff --diff=canonical` reports a rule as moved only when it really
   moved. Writing one selector as a nested branch or as its flat expansion, and
   writing two rules of one selector next to each other or as a single rule, now

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3328,12 +3328,27 @@ let compose_mask_via_index ~ctx idx =
           incr i
   done
 
-(* CSS Transitions 1 sec. 2.1: [transition] composes from
-   [transition-{property,duration,timing-function,delay}]. Compose when a
-   contiguous run covers a single layer (each longhand carries a one-entry
+(* CSS Transitions 2 sec. 2.6: [transition] composes from
+   [transition-{property,duration,timing-function,delay,behavior}]. Compose when
+   a contiguous run covers a single layer (each longhand carries a one-entry
    list), the importance matches, no CSS-wide keyword leaks in, and
    [transition-property] is present (it has no default, so the shorthand needs
-   it). *)
+   it).
+
+   The shorthand writes all five slots, so a run leaving one out resets that
+   slot to its initial. That is a no-op unless something earlier in the rule
+   already put another value there, which [tr_reset_hazard] rules out. *)
+type tr_slot = Property | Duration | Timing | Delay | Behavior
+
+let tr_slots = [ Property; Duration; Timing; Delay; Behavior ]
+
+let tr_slot_bit : tr_slot -> int = function
+  | Property -> 1
+  | Duration -> 2
+  | Timing -> 4
+  | Delay -> 8
+  | Behavior -> 16
+
 let transition_property_singleton :
     Properties.transition_property ->
     Properties.transition_property_value option = function
@@ -3372,25 +3387,46 @@ let tr_delay_part : declaration -> Values.duration option = function
       duration_singleton value
   | _ -> None
 
+(* [transition-behavior] is a [<single-transition>] component, so a run can
+   carry it into the shorthand. A CSS-wide keyword has no component spelling,
+   and a [var()] there reads back into the property slot, which the reader tries
+   first. *)
+let behavior_singleton :
+    Properties.transition_behavior -> Properties.transition_behavior option =
+  function
+  | Inherit | Initial | Unset | Revert | Revert_layer | Var _ -> None
+  | b -> Some b
+
+let tr_behavior_part : declaration -> Properties.transition_behavior option =
+  function
+  | Declaration { property = Transition_behavior; value; _ } ->
+      behavior_singleton value
+  | _ -> None
+
 type tr_part =
   Properties.transition_shorthand -> Properties.transition_shorthand
 
-type tr_updater = declaration -> tr_part option
+type tr_updater = declaration -> (tr_slot * tr_part) option
 
 let lift_tr_part :
     'a.
+    tr_slot ->
     (declaration -> 'a option) ->
     (Properties.transition_shorthand -> 'a -> Properties.transition_shorthand) ->
     tr_updater =
- fun extract set d ->
-  match extract d with Some v -> Some (fun s -> set s v) | None -> None
+ fun slot extract set d ->
+  match extract d with Some v -> Some (slot, fun s -> set s v) | None -> None
 
 let tr_updaters : tr_updater list =
   [
-    lift_tr_part tr_property_part (fun s v -> { s with property = v });
-    lift_tr_part tr_duration_part (fun s v -> { s with duration = Some v });
-    lift_tr_part tr_timing_part (fun s v -> { s with timing_function = Some v });
-    lift_tr_part tr_delay_part (fun s v -> { s with delay = Some v });
+    lift_tr_part Property tr_property_part (fun s v -> { s with property = v });
+    lift_tr_part Duration tr_duration_part (fun s v ->
+        { s with duration = Some v });
+    lift_tr_part Timing tr_timing_part (fun s v ->
+        { s with timing_function = Some v });
+    lift_tr_part Delay tr_delay_part (fun s v -> { s with delay = Some v });
+    lift_tr_part Behavior tr_behavior_part (fun s v ->
+        { s with behavior = Some v });
   ]
 
 let transition_part_of (d : declaration) =
@@ -3413,6 +3449,68 @@ let has_transition_property_decl raw_decls =
       | _ -> false)
     raw_decls
 
+let tr_bits slots = List.fold_left (fun acc s -> acc lor tr_slot_bit s) 0 slots
+let all_tr_bits = tr_bits tr_slots
+
+let tr_zero_duration : Values.duration -> bool = function
+  | S 0. | Ms 0. -> true
+  | _ -> false
+
+let tr_layer_holds_slot (s : Properties.transition_shorthand) : tr_slot -> bool
+    = function
+  | Property -> ( match s.property with All -> false | _ -> true)
+  | Duration -> (
+      match s.duration with None -> false | Some d -> not (tr_zero_duration d))
+  | Timing -> (
+      match s.timing_function with None | Some Ease -> false | Some _ -> true)
+  | Delay -> (
+      match s.delay with None -> false | Some d -> not (tr_zero_duration d))
+  | Behavior -> (
+      match s.behavior with None | Some Normal -> false | Some _ -> true)
+
+(* Slots [d] leaves holding something other than the slot initial: [all] for the
+   property, [0s] for the two times, [ease] for the easing, [normal] for the
+   behaviour. A slot written back to its initial is not at risk from a shorthand
+   that resets it to the same thing. *)
+let tr_overwritten_slots d =
+  let bit slot cond = if cond then tr_slot_bit slot else 0 in
+  match unwrap_theme_guard d with
+  | Declaration { property = Transition_property; value; _ } ->
+      bit Property (match value with [ All ] -> false | _ -> true)
+  | Declaration { property = Transition_duration; value; _ } ->
+      bit Duration (not (tr_zero_duration value))
+  | Declaration { property = Transition_timing_function; value; _ } ->
+      bit Timing (match value with Ease -> false | _ -> true)
+  | Declaration { property = Transition_delay; value; _ } ->
+      bit Delay (not (tr_zero_duration value))
+  | Declaration { property = Transition_behavior; value; _ } ->
+      bit Behavior (match value with Normal -> false | _ -> true)
+  | Declaration { property = Transition; value = [ Shorthand s ]; _ } ->
+      tr_bits (List.filter (tr_layer_holds_slot s) tr_slots)
+  | Declaration { property = Transition; _ } -> all_tr_bits
+  (* CSS Cascade 5 sec. 3.2: [all] writes every longhand. No transition longhand
+     inherits, so [initial] and [unset] both leave the initials. *)
+  | Declaration { property = All; value = Initial | Unset; _ } -> 0
+  | Declaration { property = All; _ } -> all_tr_bits
+  | _ -> 0
+
+(* Whether an earlier declaration in the rule holds a slot the run leaves out.
+   The composed shorthand resets every such slot, so composing would drop that
+   value. An important declaration outranks a non-important shorthand whatever
+   the order, so it is only at risk when the run is important too. *)
+let tr_reset_hazard idx i ~missing ~important =
+  (not (Int.equal missing 0))
+  &&
+  let rec scan j =
+    j >= 0
+    &&
+    let d = Rule_index.decl_at idx j in
+    (important || not (is_important d))
+    && not (Int.equal (tr_overwritten_slots d land missing) 0)
+    || scan (j - 1)
+  in
+  scan (i - 1)
+
 let try_compose_transition_at idx i =
   let parts, len = take_run_at idx ~part_of:transition_part_of i in
   if List.length parts < 2 then None
@@ -3421,16 +3519,23 @@ let try_compose_transition_at idx i =
     if not (same_importance raw_decls) then None
     else if not (has_transition_property_decl raw_decls) then None
     else
-      let layer =
-        List.fold_left (fun acc (_, f) -> f acc) empty_tr_shorthand parts
+      let important = is_important (List.hd raw_decls) in
+      let written =
+        List.fold_left
+          (fun acc (_, (slot, _)) -> acc lor tr_slot_bit slot)
+          0 parts
       in
-      let shorthand =
-        Declaration.v
-          ~important:(is_important (List.hd raw_decls))
-          Transition
-          [ (Shorthand layer : Properties.transition) ]
-      in
-      Some (shorthand, len)
+      let missing = all_tr_bits land lnot written in
+      if tr_reset_hazard idx i ~missing ~important then None
+      else
+        let layer =
+          List.fold_left (fun acc (_, (_, f)) -> f acc) empty_tr_shorthand parts
+        in
+        let shorthand =
+          Declaration.v ~important Transition
+            [ (Shorthand layer : Properties.transition) ]
+        in
+        Some (shorthand, len)
 
 let compose_transition_via_index idx =
   compose_run_via_index idx ~try_compose:try_compose_transition_at

--- a/test/render/render_diff.ml
+++ b/test/render/render_diff.ml
@@ -141,6 +141,16 @@ a[href^="https"], .card p { text-decoration: underline; color: #00f }
 .card p::before { content: "> "; background: red; background-position-x: 10px }
 |css}
 
+(* The [transition] shorthand resets [transition-behavior], and a run of the
+   other transition longhands does not write that slot. Contracting the run into
+   the shorthand therefore has to carry the behaviour over, or the element stops
+   transitioning discrete values. getComputedStyle reports the slot, so the
+   browser settles it. *)
+let transition_behavior_sheet =
+  {css|
+.rd-tb { transition-behavior: allow-discrete; transition-property: color; transition-duration: 1s; transition-timing-function: ease; transition-delay: 0s }
+|css}
+
 (* [of S] counted from the end. No corpus sheet carries the form and no pair
    below pins it, since a sheet without it renders the same page; what it buys
    is the probe - the driver reports a selector the derived document fails to
@@ -350,6 +360,7 @@ let inputs () =
   let all =
     [
       sheet "smoke" smoke_sheet;
+      sheet "transition-behavior" transition_behavior_sheet;
       sheet "nth-last-child-of" nth_last_of_sheet;
       sheet "distant-container" distant_container_sheet;
       {

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -482,6 +482,53 @@ let test_drop_redundant_transition_longhand () =
   decl_optimizes_to ~into:"transition:all 1s;transition-delay:1s"
     "transition:all 1s;transition-delay:1s"
 
+(* CSS Transitions 2 sec. 2.6: [transition] resets [transition-behavior] along
+   with the four Transitions 1 longhands. A run that leaves a slot unwritten
+   contracts only when nothing earlier in the rule set that slot to something
+   other than its initial, otherwise the shorthand silently resets it. *)
+let test_transition_contraction_covers_reset_longhands () =
+  (* The behaviour is a component of [<single-transition>], so a run carrying it
+     contracts and keeps it, whichever side of the run it sits on. Both [ease]
+     and [0s] are initials and drop out. *)
+  decl_optimizes_to ~into:"transition:color 1s allow-discrete"
+    "transition-behavior:allow-discrete;transition-property:color;transition-duration:1s;transition-timing-function:ease;transition-delay:0s";
+  decl_optimizes_to ~into:"transition:color 1s allow-discrete"
+    "transition-property:color;transition-duration:1s;transition-behavior:allow-discrete";
+  decl_optimizes_to ~into:"transition:color 1s allow-discrete"
+    "transition-property:color;transition-behavior:allow-discrete;transition-duration:1s";
+  (* A run covering only the Transitions 1 longhands still contracts: nothing in
+     the rule writes the behaviour, so resetting it to [normal] is a no-op. *)
+  decl_optimizes_to ~into:"transition:color 1s"
+    "transition-property:color;transition-duration:1s;transition-timing-function:ease;transition-delay:0s";
+  (* [inherit] is not a shorthand component, so the run cannot carry it and the
+     contraction would drop it. *)
+  decl_optimizes_to
+    ~into:
+      "transition-behavior:inherit;transition-property:color;transition-duration:1s"
+    "transition-behavior:inherit;transition-property:color;transition-duration:1s";
+  (* Same rule for the delay: an unrelated declaration splits it off the run, so
+     the run no longer covers the slot the shorthand resets. *)
+  decl_optimizes_to
+    ~into:
+      "transition-delay:5s;color:red;transition-property:color;transition-duration:1s"
+    "transition-delay:5s;color:red;transition-property:color;transition-duration:1s";
+  (* An earlier shorthand holds the slots its own run left out. Contracting the
+     later run resets the delay it set. *)
+  decl_optimizes_to
+    ~into:
+      "transition:color 1s \
+       5s;transition-property:opacity;transition-duration:2s"
+    "transition:color 1s ease \
+     5s;transition-property:opacity;transition-duration:2s";
+  (* An earlier shorthand whose unwritten slots are already initials shadows
+     nothing, so the later run contracts. *)
+  decl_optimizes_to ~into:"transition:opacity 2s"
+    "transition:color 1s;transition-property:opacity;transition-duration:2s";
+  (* An important longhand outranks the composed shorthand whatever the order,
+     so it is not a hazard. *)
+  decl_optimizes_to ~into:"transition-delay:5s!important;transition:color 1s"
+    "transition-delay:5s!important;transition-property:color;transition-duration:1s"
+
 let test_drop_redundant_border_longhand () =
   (* [border] sets width/style/color; a later longhand equal to an explicit slot
      is dropped. A differing value or a per-side list is kept. *)
@@ -772,6 +819,8 @@ let suite =
         test_drop_redundant_flex_longhand;
       Alcotest.test_case "drop redundant transition longhand" `Quick
         test_drop_redundant_transition_longhand;
+      Alcotest.test_case "transition contraction covers reset longhands" `Quick
+        test_transition_contraction_covers_reset_longhands;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
`--minify` dropped a `transition-behavior` declaration written before a run of transition longhands, and the `transition` shorthand it composed reset that slot to `normal`. A discrete property animated before minification and jumped after it.

The contraction carries the behaviour into the shorthand's own slot, which CSS Transitions 2 defines, so the output is both shorter and correct. Where a slot the run does not write is left holding a non-initial value, the contraction is refused instead.

Two cases with no `transition-behavior` in them are fixed by the same guard: a delay separated from the run by an unrelated declaration, and a delay carried by an earlier `transition` shorthand.

The same shape is live for `animation` and `background` and is tracked separately.