### PR TITLE
shorthand: judge the transition contraction against the rule run

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -389,6 +389,9 @@ entry points both moved.
   which resets the rest of the family, so a `transition-behavior:
   allow-discrete` ahead of it was deleted and the element stopped transitioning
   discrete values (#843)
+- `--minify` keeps that longhand when it sits in a different rule from the run.
+  The contraction reads one rule, so a holder next door was invisible to it and
+  the reset landed on the element anyway (#845)
 - `cascade diff --diff=canonical` reports a rule as moved only when it really
   moved. Writing one selector as a nested branch or as its flat expansion, and
   writing two rules of one selector next to each other or as a single rule, now

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -116,20 +116,20 @@ let rec collect_rules (stmt_acc : statement list) (rules_acc : rule list) :
       collect_rules (stmt :: stmt_acc) (r :: rules_acc) rest
   | rest -> (List.rev stmt_acc, List.rev rules_acc, rest)
 
-let factor_rules_incremental ?cache ~settle ~ctx rules =
+let factor_rules_incremental ?cache ~settle ~ctx ~held rules =
   Factor.run ?cache ~settle ~ctx
-    ~finalize:(finalize_rule_without_nested ~ctx)
+    ~finalize:(finalize_rule_without_nested ~held ~ctx)
     rules
 
 (* Keep the cheap rule-local pipeline independent of the stylesheet-wide
    factoring budget. [Rule.finalize] normalizes any shorthand it synthesizes, so
    one linear preparation pass reaches the local fixed point even when a large
    stylesheet limits the global walks. *)
-let normalize_rules_locally ~ctx rules =
+let normalize_rules_locally ~ctx ~held rules =
   list_map_preserve (single_rule_without_nested ~ctx) rules
   |> Rule.drop_shadowed
   |> list_map_preserve
-       (finalize_rule_without_nested ~canonicalize_selector:false ~ctx)
+       (finalize_rule_without_nested ~held ~canonicalize_selector:false ~ctx)
 
 let merge_adjacent_and_mark ~ctx invalidated rules =
   let settled = Rule.merge_adjacent_identical ~ctx rules in
@@ -139,13 +139,13 @@ let merge_adjacent_and_mark ~ctx invalidated rules =
   if settled != rules then invalidated := settled :: !invalidated;
   settled
 
-let factor_rules_until_settled ?factor_cache ~ctx rules =
+let factor_rules_until_settled ?factor_cache ~ctx ~held rules =
   let rec loop remaining rules =
     let invalidated = ref [] in
     let next =
       factor_rules_incremental ?cache:factor_cache
         ~settle:(merge_adjacent_and_mark ~ctx invalidated)
-        ~ctx rules
+        ~ctx ~held rules
     in
     let needs_refactor =
       List.exists (fun rules -> rules == next) !invalidated
@@ -536,9 +536,19 @@ and rules_aux ?factor_cache ~ctx ~enforce_spec ~supports (rules : rule list) :
       (rule_with_optimized_nested ?factor_cache ~ctx ~enforce_spec ~supports)
       rules
   in
+  (* A run contracts into a shorthand only when nothing that reaches the same
+     element holds a slot the run leaves out, and one rule cannot show that. The
+     scheduler below reorders and merges, so the summary covers the whole run
+     rather than the prefix before each rule: it stays valid wherever a rule
+     lands. *)
+  let held =
+    List.fold_left
+      (fun held (r : rule) -> Shorthand.held_add held r.declarations)
+      Shorthand.held_none with_optimized_nested
+  in
   (* Apply local rule normalization before the DAG factor scheduler decides
      global selector/declaration grouping. *)
-  let prepared = normalize_rules_locally ~ctx with_optimized_nested in
+  let prepared = normalize_rules_locally ~ctx ~held with_optimized_nested in
   (* Factoring is greedy and global: extracting one shared declaration subset
      can leave behind leftovers that are themselves factorable. The local linear
      optimizations above always run; this incremental gate only decides whether
@@ -550,7 +560,7 @@ and rules_aux ?factor_cache ~ctx ~enforce_spec ~supports (rules : rule list) :
          but settling its result can merge nodes and expose a new graph. Repeat
          only when that cheap postprocessing changed one of the transfer gate's
          alternatives; most sheets still pay for one global walk. *)
-      factor_rules_until_settled ?factor_cache ~ctx prepared
+      factor_rules_until_settled ?factor_cache ~ctx ~held prepared
     end
     else merge_adjacent_and_mark ~ctx (ref []) prepared
   in

--- a/lib/optimize.mli
+++ b/lib/optimize.mli
@@ -86,7 +86,10 @@ val ctx_of_scope :
     apart; unsafe for an unknown DOM. [objective] defaults to [`Transfer]. *)
 
 val compose_shorthands :
-  ctx:ctx -> (int * declaration) list -> (int * declaration) list
+  ?held:Shorthand.held ->
+  ctx:ctx ->
+  (int * declaration) list ->
+  (int * declaration) list
 (** [compose_shorthands ~ctx decls] runs the shorthand-composition pipeline over
     index-tagged declarations: longhands fold into shorthands, resets reorder,
     and shadowed longhands drop. Each declaration it leaves unchanged is

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -200,13 +200,13 @@ let declaration_run ~ctx decls =
   |> deduplicate_declarations_with ~ctx
   |> synthesize_columns |> synthesize_position_try |> preserve_list decls
 
-let finalize ?(canonicalize_selector = true) ~ctx (rule : rule) : rule =
+let finalize ?held ?(canonicalize_selector = true) ~ctx (rule : rule) : rule =
   let normalize_synthesized decl =
     if List.memq decl rule.declarations then decl
     else Declaration.normalize ~lossless:(Ctx.lossless ctx) decl
   in
   let declarations =
-    deduplicate_declarations_with ~ctx rule.declarations
+    deduplicate_declarations_with ?held ~ctx rule.declarations
     |> synthesize_columns |> synthesize_position_try
     |> list_map_preserve normalize_synthesized
     |> sort_commuting ~selector:rule.selector

--- a/lib/rule.mli
+++ b/lib/rule.mli
@@ -9,8 +9,14 @@ val declaration_run :
     declarations run or a bare [Declarations] block. *)
 
 val finalize :
-  ?canonicalize_selector:bool -> ctx:Ctx.t -> Stylesheet.rule -> Stylesheet.rule
-(** Final declaration cleanup before a rule leaves the fixpoint. *)
+  ?held:Shorthand.held ->
+  ?canonicalize_selector:bool ->
+  ctx:Ctx.t ->
+  Stylesheet.rule ->
+  Stylesheet.rule
+(** Final declaration cleanup before a rule leaves the fixpoint. [held] is what
+    the rest of the rule run holds, which shorthand composition needs and the
+    rule alone cannot show. *)
 
 val drop_shadowed : Stylesheet.rule list -> Stylesheet.rule list
 (** Drop same-selector shadowed rules and declarations. *)

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3494,13 +3494,49 @@ let tr_overwritten_slots d =
   | Declaration { property = All; _ } -> all_tr_bits
   | _ -> 0
 
-(* Whether an earlier declaration in the rule holds a slot the run leaves out.
-   The composed shorthand resets every such slot, so composing would drop that
-   value. An important declaration outranks a non-important shorthand whatever
-   the order, so it is only at risk when the run is important too. *)
-let tr_reset_hazard idx i ~missing ~important =
+(* Slots a set of declarations leaves holding something other than the slot
+   initial, split by importance. Composition reads one rule, so a holder in
+   another rule of the same run reaches the scan below only through this. *)
+type held = { normal_slots : int; important_slots : int }
+
+let held_none = { normal_slots = 0; important_slots = 0 }
+let held_nothing h = Int.equal (h.normal_slots lor h.important_slots) 0
+
+let held_add held decls =
+  List.fold_left
+    (fun held d ->
+      let slots = tr_overwritten_slots d in
+      if Int.equal slots 0 then held
+      else if is_important d then
+        { held with important_slots = held.important_slots lor slots }
+      else { held with normal_slots = held.normal_slots lor slots })
+    held decls
+
+(* What the neighbours hold. The rule being composed is judged by the scan
+   below, which reads position as well as value, so a slot it holds itself is
+   dropped here rather than answered twice and less precisely. *)
+let held_outside held decls =
+  if held_nothing held then held
+  else
+    let own = held_add held_none decls in
+    {
+      normal_slots = held.normal_slots land lnot own.normal_slots;
+      important_slots = held.important_slots land lnot own.important_slots;
+    }
+
+(* Whether something that reaches the same element holds a slot the run leaves
+   out. The composed shorthand resets every such slot, so composing would drop
+   that value. An important declaration outranks a non-important shorthand
+   whatever the order, so it is only at risk when the run is important too. *)
+let tr_reset_hazard idx i ~held ~missing ~important =
   (not (Int.equal missing 0))
   &&
+  let outside =
+    if important then held.normal_slots lor held.important_slots
+    else held.normal_slots
+  in
+  (not (Int.equal (missing land outside) 0))
+  ||
   let rec scan j =
     j >= 0
     &&
@@ -3511,7 +3547,7 @@ let tr_reset_hazard idx i ~missing ~important =
   in
   scan (i - 1)
 
-let try_compose_transition_at idx i =
+let try_compose_transition_at ~held idx i =
   let parts, len = take_run_at idx ~part_of:transition_part_of i in
   if List.length parts < 2 then None
   else
@@ -3526,7 +3562,7 @@ let try_compose_transition_at idx i =
           0 parts
       in
       let missing = all_tr_bits land lnot written in
-      if tr_reset_hazard idx i ~missing ~important then None
+      if tr_reset_hazard idx i ~held ~missing ~important then None
       else
         let layer =
           List.fold_left (fun acc (_, (_, f)) -> f acc) empty_tr_shorthand parts
@@ -3537,8 +3573,8 @@ let try_compose_transition_at idx i =
         in
         Some (shorthand, len)
 
-let compose_transition_via_index idx =
-  compose_run_via_index idx ~try_compose:try_compose_transition_at
+let compose_transition_via_index ~held idx =
+  compose_run_via_index idx ~try_compose:(try_compose_transition_at ~held)
 
 (* CSS Animations 1 sec. 3.1: [animation] composes from the per-layer animation
    longhands. Compose when a contiguous run sticks to a single layer (no
@@ -4302,10 +4338,10 @@ let compose_index_group_b kept =
 
 (* Third index group runs at the very end: mask + transition + animation share
    one index. *)
-let compose_index_group_c ~ctx kept =
+let compose_index_group_c ~ctx ~held kept =
   let idx = Rule_index.build (List.map snd kept) in
   compose_mask_via_index ~ctx idx;
-  compose_transition_via_index idx;
+  compose_transition_via_index ~held idx;
   compose_animation_via_index idx;
   List.mapi (fun i d -> (i, d)) (Rule_index.to_list idx)
 
@@ -4314,14 +4350,15 @@ let compose_border_whole_step ~ctx kept =
   compose_border_whole_via_index ~ctx idx;
   List.mapi (fun i d -> (i, d)) (Rule_index.to_list idx)
 
-let compose_shorthands ~ctx kept =
+let compose_shorthands ?(held = held_none) ~ctx kept =
   kept |> compose_index_group_a ~ctx |> reorder_font_resets_before_font
   |> compose_index_group_b |> reorder_border_image_before_border
   |> compose_border_whole_step ~ctx
   |> drop_bimg_shadowed_by_border
   |> compose_border_image_shorthand ~ctx
   |> compose_background_shorthand ~ctx
-  |> reorder_mask_border_before_mask |> compose_index_group_c ~ctx
+  |> reorder_mask_border_before_mask
+  |> compose_index_group_c ~ctx ~held
   |> fun kept ->
   merge_box_shorthand_longhands kept kept |> merge_overflow_longhands
 
@@ -4462,12 +4499,14 @@ let drop_longhands_after_covering_shorthand props =
   let kept = List.filteri (fun i _ -> not dropped.(i)) props in
   preserve_list props kept
 
-let deduplicate_declarations_with ~ctx ?(merge_box = true) props =
+let deduplicate_declarations_with ?(held = held_none) ~ctx ?(merge_box = true)
+    props =
+  let held = held_outside held props in
   let props = drop_longhands_after_covering_shorthand props in
   let indexed_props = List.mapi (fun i decl -> (i, decl)) props in
   let kept = List.rev (List.fold_left deduplicate_step [] indexed_props) in
   let kept =
-    let kept = if merge_box then compose_shorthands ~ctx kept else kept in
+    let kept = if merge_box then compose_shorthands ~held ~ctx kept else kept in
     let kept = drop_vendor_aliases ~ctx kept in
     List.map (fun (_, decl) -> decl) kept
   in

--- a/lib/shorthand.mli
+++ b/lib/shorthand.mli
@@ -104,13 +104,31 @@ val merge_overflow_longhands :
   (int * Declaration.declaration) list -> (int * Declaration.declaration) list
 (** Fold [overflow-x]/[overflow-y] into [overflow]. *)
 
+type held
+(** Shorthand slots a set of declarations leaves holding something other than
+    the slot initial. Composing a run that leaves a slot unwritten resets it, so
+    a run only contracts when nothing that reaches the same element holds it.
+    Composition reads one rule, so holders in the rest of a rule run reach it
+    only through this summary. Carries the [transition] slots; a family that
+    contracts a partial run adds its own. *)
+
+val held_none : held
+(** Nothing held. *)
+
+val held_add : held -> Declaration.declaration list -> held
+(** [held_add held decls] extends [held] with the slots [decls] hold. *)
+
 val compose_shorthands :
+  ?held:held ->
   ctx:Ctx.t ->
   (int * Declaration.declaration) list ->
   (int * Declaration.declaration) list
-(** Compose supported longhand runs into shorthand declarations. *)
+(** Compose supported longhand runs into shorthand declarations. [held] is what
+    the rest of the rule run holds; slots the given declarations hold themselves
+    are judged in place and drop out of it. *)
 
 val deduplicate_declarations_with :
+  ?held:held ->
   ctx:Ctx.t ->
   ?merge_box:bool ->
   Declaration.declaration list ->

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -17,6 +17,17 @@ let decl_strings decls =
 let indexed decls = List.mapi (fun i d -> (i, d)) decls
 let unindexed decls = List.map snd decls
 
+(* [decl_optimizes_to] wraps its input in one rule; these cases turn on what a
+   neighbouring rule holds, so they optimize a whole sheet. *)
+let sheet_optimizes_to ~into input =
+  match Css.of_string input with
+  | Ok { stylesheet; _ } ->
+      Alcotest.(check string)
+        (String.concat "" [ input; " minify+optimize" ])
+        into
+        (String.trim (Css.to_string ~minify:true (Css.optimize stylesheet)))
+  | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
+
 let test_declaration_covers_reset_boundaries () =
   Alcotest.(check bool)
     "all covers ordinary property" true
@@ -529,6 +540,70 @@ let test_transition_contraction_covers_reset_longhands () =
   decl_optimizes_to ~into:"transition-delay:5s!important;transition:color 1s"
     "transition-delay:5s!important;transition-property:color;transition-duration:1s"
 
+(* The slot a contraction resets belongs to the element, not to the rule: any
+   declaration that can reach the same element and holds that slot is at risk,
+   whichever rule it sits in. Composition reads one rule, so it cannot see the
+   holders next door. *)
+let test_transition_contraction_covers_other_rules () =
+  (* Same rule, both sides of the guard. A non-important holder is reset by the
+     contraction, so the run stays expanded; an important one outranks the
+     non-important shorthand whatever the order, so the run contracts. *)
+  sheet_optimizes_to
+    ~into:
+      ".a{transition-behavior:allow-discrete;color:red;transition-property:color;transition-duration:1s}"
+    ".a{transition-behavior:allow-discrete;color:red;transition-property:color;transition-duration:1s}";
+  sheet_optimizes_to
+    ~into:
+      ".a{transition-behavior:allow-discrete!important;color:red;transition:color \
+       1s}"
+    ".a{transition-behavior:allow-discrete!important;color:red;transition-property:color;transition-duration:1s}";
+  (* Split across two rules with the same selector, the element sees exactly the
+     cascade above. The behaviour has to survive, and the shortest spelling that
+     keeps it groups the two rules and carries it into the shorthand. *)
+  sheet_optimizes_to ~into:".a{transition:color 1s allow-discrete}"
+    ".a{transition-behavior:allow-discrete}.a{transition-property:color;transition-duration:1s}";
+  sheet_optimizes_to
+    ~into:".a{transition:color 1s;transition-behavior:allow-discrete!important}"
+    ".a{transition-behavior:allow-discrete!important}.a{transition-property:color;transition-duration:1s}";
+  (* Both important: the shorthand no longer loses to the holder, so dropping
+     the behaviour would change what the element animates. *)
+  sheet_optimizes_to ~into:".a{transition:color 1s allow-discrete!important}"
+    ".a{transition-behavior:allow-discrete!important}.a{transition-property:color!important;transition-duration:1s!important}";
+  (* An unrelated rule between them changes nothing: the holder is still in the
+     cascade the second rule lands on. *)
+  sheet_optimizes_to ~into:".a{transition:color 1s allow-discrete}.b{color:red}"
+    ".a{transition-behavior:allow-discrete}.b{color:red}.a{transition-property:color;transition-duration:1s}";
+  (* A rule between them that writes the same family keeps the two apart, so
+     there is no grouping to carry the behaviour into and the run stays
+     expanded. *)
+  sheet_optimizes_to
+    ~into:
+      ".a{transition-behavior:allow-discrete}.b{transition:opacity \
+       2s}.a{transition-property:color;transition-duration:1s}"
+    ".a{transition-behavior:allow-discrete}.b{transition:opacity \
+     2s}.a{transition-property:color;transition-duration:1s}";
+  (* The holder needs no relation to the run's selector: an element carrying
+     both classes reads one cascade. *)
+  sheet_optimizes_to
+    ~into:
+      ".b{transition-behavior:allow-discrete}.a{transition-property:color;transition-duration:1s}"
+    ".b{transition-behavior:allow-discrete}.a{transition-property:color;transition-duration:1s}";
+  (* The other side of the guard, so it stays a hazard test and not a blanket
+     refusal: a neighbour holding the slot at its initial resets to the same
+     thing, and an important neighbour outranks the shorthand. *)
+  sheet_optimizes_to
+    ~into:".b{transition-behavior:normal}.a{transition:color 1s}"
+    ".b{transition-behavior:normal}.a{transition-property:color;transition-duration:1s}";
+  sheet_optimizes_to
+    ~into:
+      ".b{transition-behavior:allow-discrete!important}.a{transition:color 1s}"
+    ".b{transition-behavior:allow-discrete!important}.a{transition-property:color;transition-duration:1s}";
+  (* A slot the rule itself rewrites after the run is not at risk from a
+     neighbour holding it: the rewrite lands after the reset. *)
+  sheet_optimizes_to
+    ~into:".a{transition:color 1s;color:red;transition-delay:5s}"
+    ".a{transition-property:color;transition-duration:1s;color:red;transition-delay:5s}"
+
 let test_drop_redundant_border_longhand () =
   (* [border] sets width/style/color; a later longhand equal to an explicit slot
      is dropped. A differing value or a per-side list is kept. *)
@@ -821,6 +896,8 @@ let suite =
         test_drop_redundant_transition_longhand;
       Alcotest.test_case "transition contraction covers reset longhands" `Quick
         test_transition_contraction_covers_reset_longhands;
+      Alcotest.test_case "transition contraction covers other rules" `Quick
+        test_transition_contraction_covers_other_rules;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
`--minify` contracted a run of transition longhands into the shorthand while another rule of the same run held a slot the run leaves out, so the reset the shorthand performs deleted that value: `.a{transition-behavior:allow-discrete}.a{transition-property:color;transition-duration:1s}` came out as `.a{transition:color 1s}` and the element stopped transitioning discrete values. #843 guarded this within one rule; the contraction reads one rule, so a holder next door was invisible to it.

Costs 868 bytes over the 504-file corpus (33.8 MB of output) at 0.995x the CPU, all of it from `transition` shorthands with several layers, which the slot summary still reads as holding everything.
