### PR TITLE
color: read a missing channel as the zero it behaves as

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -699,9 +699,13 @@ entry points both moved.
 - Canonical diff normalises the rules inside every at-rule that has a block, so
   the result no longer depends on which at-rule encloses a rule. It normalised
   inside `@layer` and `@media` but not inside `@scope` or `@when` (#393)
-- A fully transparent `oklab()` with a missing axis, such as
-  `oklab(0% none none / 0)`, compares equal to transparent black.
-  Non-transparent forms stay distinct (#312)
+- A `none` colour channel compares as the zero CSS Color 4 sec. 4.4 makes a
+  missing component behave as, so the `oklab(0% none none / .5)` a minifier
+  writes for a colour it reached by conversion compares equal to the hex
+  cascade folds the same colour to. Where the stylesheet interpolates the
+  colour instead - a gradient stop, a `color-mix()` operand, a `@keyframes`
+  frame, `@starting-style` - the two spellings stay distinct, since sec. 13.3
+  gives a missing component the other colour's rather than a zero (#312, #847)
 - A relative-colour function keeps its origin as a typed colour, so `red` and
   `#f00` compare equal in `rgb()`, `oklab()` and the rest, including inside
   custom properties (#313)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -704,8 +704,9 @@ entry points both moved.
   writes for a colour it reached by conversion compares equal to the hex
   cascade folds the same colour to. Where the stylesheet interpolates the
   colour instead - a gradient stop, a `color-mix()` operand, a `@keyframes`
-  frame, `@starting-style` - the two spellings stay distinct, since sec. 13.3
-  gives a missing component the other colour's rather than a zero (#312, #847)
+  frame, `@starting-style`, a rule that transitions the property it sets - the
+  two spellings stay distinct, since sec. 13.3 gives a missing component the
+  other colour's rather than a zero (#312, #847)
 - A relative-colour function keeps its origin as a typed colour, so `red` and
   `#f00` compare equal in `rgb()`, `oklab()` and the rest, including inside
   custom properties (#313)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7862,7 +7862,7 @@ val of_string_exn :
 
     Tools for optimizing CSS output for performance and file size. *)
 
-val canonicalize_rule_order : t -> t
+val canonicalize_rule_order : ?lossless:bool -> t -> t
 (** [canonicalize_rule_order t] projects cascade-equivalent stylesheets to one
     deterministic form: selector-list rules expand onto their branches,
     same-selector rules coalesce when no intervening write can observe the move
@@ -7889,11 +7889,18 @@ val canonicalize_rule_order : t -> t
     emission cannot do because a Level 3 parser rejects the shorter forms. A
     [color(srgb ...)] whose channels all land on a whole byte is keyed as the
     [rgb()] spelling of the same colour, which emission cannot do either because
-    [color()] needs a browser that parses it. An identical
-    [-webkit-text-decoration-color] compatibility declaration is dropped when
-    its unprefixed twin is present; a differing or prefixed-only declaration is
-    retained. These are comparison-side normalisations; this function does not
-    change {!val-optimize}'s configured emission policy. *)
+    [color()] needs a browser that parses it. A [none] channel of a Lab-family
+    colour standing as a whole colour-longhand value is keyed as the zero CSS
+    Color 4 sec. 4.4 says a missing component behaves as, so a converted
+    achromatic [oklab()] meets the hex a minifier writes for it; sec. 13.3 keeps
+    that off the positions the sheet interpolates, so a gradient stop, a
+    [color-mix()] operand, a custom-property token stream, [@keyframes] and
+    [@starting-style] keep their [none], and [lossless] bounds how far the
+    resolved colour respells. An identical [-webkit-text-decoration-color]
+    compatibility declaration is dropped when its unprefixed twin is present; a
+    differing or prefixed-only declaration is retained. These are
+    comparison-side normalisations; this function does not change
+    {!val-optimize}'s configured emission policy. *)
 
 val optimize :
   ?scope:Optimize.scope ->

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7894,13 +7894,14 @@ val canonicalize_rule_order : ?lossless:bool -> t -> t
     Color 4 sec. 4.4 says a missing component behaves as, so a converted
     achromatic [oklab()] meets the hex a minifier writes for it; sec. 13.3 keeps
     that off the positions the sheet interpolates, so a gradient stop, a
-    [color-mix()] operand, a custom-property token stream, [@keyframes] and
-    [@starting-style] keep their [none], and [lossless] bounds how far the
-    resolved colour respells. An identical [-webkit-text-decoration-color]
-    compatibility declaration is dropped when its unprefixed twin is present; a
-    differing or prefixed-only declaration is retained. These are
-    comparison-side normalisations; this function does not change
-    {!val-optimize}'s configured emission policy. *)
+    [color-mix()] operand, a custom-property token stream, [@keyframes],
+    [@starting-style] and a colour whose own rule transitions the property it
+    writes keep their [none], and [lossless] bounds how far the resolved colour
+    respells. An identical [-webkit-text-decoration-color] compatibility
+    declaration is dropped when its unprefixed twin is present; a differing or
+    prefixed-only declaration is retained. These are comparison-side
+    normalisations; this function does not change {!val-optimize}'s configured
+    emission policy. *)
 
 val optimize :
   ?scope:Optimize.scope ->

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -51,15 +51,15 @@ let rec important = function
    The pretty-printer is a pure serialiser of the result; this is where semantic
    value folds live (see [Properties.normalize_property_value]). *)
 let rec normalize ?(lossless = false) ?(exact_srgb = false)
-    ?(ctx = Values.default_calc_ctx) = function
+    ?(resolve_missing = false) ?(ctx = Values.default_calc_ctx) = function
   | Declaration { property; value; important; _ } as decl ->
       let value' =
-        Properties.normalize_property_value ~lossless ~exact_srgb ~ctx property
-          value
+        Properties.normalize_property_value ~lossless ~exact_srgb
+          ~resolve_missing ~ctx property value
       in
       if value' == value then decl else v ~important property value'
   | Theme_guarded g as themed ->
-      let decl = normalize ~lossless ~exact_srgb ~ctx g.decl in
+      let decl = normalize ~lossless ~exact_srgb ~resolve_missing ~ctx g.decl in
       if decl == g.decl then themed else theme_guarded ~var_name:g.var_name decl
 
 let is_custom_property_name = Custom_property_name.is_valid

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -45,14 +45,16 @@ val important : declaration -> declaration
 val normalize :
   ?lossless:bool ->
   ?exact_srgb:bool ->
+  ?resolve_missing:bool ->
   ?ctx:Values.calc_ctx ->
   declaration ->
   declaration
 (** [normalize ?lossless d] applies AST-level semantic value canonicalisation so
     the optimizer holds a canonical declaration and the pretty-printer stays a
     pure serialiser. [lossless] disables bounded colour and numeric
-    approximation. [exact_srgb] is {!Properties.normalize_property_value}'s flag
-    of the same name, for the canonical diff projection only. *)
+    approximation. [exact_srgb] and [resolve_missing] are
+    {!Properties.normalize_property_value}'s flags of the same names, for the
+    canonical diff projection only. *)
 
 val to_string : ?minify:bool -> t -> string
 (** [to_string ~minify d] converts a declaration to CSS source text. *)

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -505,7 +505,7 @@ let canonical_of_stylesheet ~lossless ~prune_unused_custom_props stylesheet =
        normalization cannot synthesize the nesting the projection removes. *)
     Some
       (stylesheet |> optimize |> Css.flatten_nesting |> optimize
-     |> Css.canonicalize_rule_order
+      |> Css.canonicalize_rule_order ~lossless
       |> Css.to_string ~minify:true ~lossless)
   with Invalid_argument _ -> None
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4213,13 +4213,16 @@ let canonicalize_math_whitespace_components comps =
 let normalize_property_value : type a.
     ?lossless:bool ->
     ?exact_srgb:bool ->
+    ?resolve_missing:bool ->
     ?ctx:Values.calc_ctx ->
     a property ->
     a ->
     a =
- fun ?(lossless = false) ?(exact_srgb = false) ?(ctx = Values.default_calc_ctx)
-     property value ->
-  let normalize_color = Values.normalize_color ~lossless ~exact_srgb in
+ fun ?(lossless = false) ?(exact_srgb = false) ?(resolve_missing = false)
+     ?(ctx = Values.default_calc_ctx) property value ->
+  let normalize_color =
+    Values.normalize_color ~lossless ~exact_srgb ~resolve_missing
+  in
   (* [initial] -> shortest spec-equivalent (e.g. min-width:initial -> auto) is a
      semantic rewrite, so it belongs here, not in pp. *)
   let value = canonical_initial_for_minify property value in

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -40,6 +40,7 @@ val pp_property_value : ('a property * 'a) Pp.t
 val normalize_property_value :
   ?lossless:bool ->
   ?exact_srgb:bool ->
+  ?resolve_missing:bool ->
   ?ctx:Values.calc_ctx ->
   'a property ->
   'a ->
@@ -50,9 +51,11 @@ val normalize_property_value :
     whose folds have not yet migrated out of [pp]. [lossless] disables bounded
     colour and numeric approximation while keeping exact canonicalisation.
 
-    [exact_srgb] is {!Values.normalize_color}'s flag of the same name, applied
-    to the properties whose whole value is a colour. It is for the canonical
-    diff projection only. *)
+    [exact_srgb] and [resolve_missing] are {!Values.normalize_color}'s flags of
+    the same names, applied to the properties whose whole value is a colour.
+    Both are for the canonical diff projection only. A colour a value nests - a
+    gradient stop, a shadow colour - normalises without either, so
+    [resolve_missing] never reaches a colour the value interpolates. *)
 
 val normalize_custom_property_value :
   ?lossless:bool ->

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -713,6 +713,50 @@ let canonical_color_spellings (stmts : statement list) : statement list =
     (Common.List.map_preserve canonical_color_spelling)
     stmts
 
+(* CSS Color 4 sec. 4.4: "a missing component behaves as a zero value, in the
+   appropriate unit for that component", for every purpose but the ones that
+   combine two colours. A minifier that reaches an achromatic colour by
+   conversion writes those channels as [none] where Cascade writes the hex the
+   colour folds to, and the projection has to read the two as one colour.
+
+   Sec. 13.3 draws the other edge: interpolation gives a missing component the
+   other colour's analogous component rather than a zero, so at a position that
+   interpolates the value the two spellings name two different results.
+   {!Declaration.normalize} resolves the sentinel only for a colour standing as
+   a whole colour-longhand value, which leaves a gradient stop, a [color-mix()]
+   operand, a shadow colour and a custom-property token stream reading their
+   [none] as written. What stays outside this pass's reach is a declaration the
+   sheet interpolates from elsewhere: [@keyframes] and [@starting-style] are the
+   two blocks that exist to be one endpoint of that, so the pass does not
+   descend into them. A [transition] between two ordinary declarations still
+   sees the difference, and this is where the projection stops being able to.
+
+   Guarded like [canonical_color_spelling]: the flagged normalisation is kept
+   only where it moves the colour, so no other value fold rides along. *)
+let canonical_missing_components ~lossless decl =
+  let folded = Declaration.normalize ~lossless ~resolve_missing:true decl in
+  if folded == decl then decl
+  else if
+    Declaration.equal_declaration folded (Declaration.normalize ~lossless decl)
+  then decl
+  else folded
+
+let rec canonical_missing_component_colors ~lossless (stmts : statement list) :
+    statement list =
+  Common.List.map_preserve
+    (fun stmt ->
+      match stmt with
+      | Keyframes _ | Webkit_keyframes _ | Moz_keyframes _ | Starting_style _ ->
+          stmt
+      | stmt ->
+          stmt
+          |> Stylesheet.map_statement_declarations
+               (Common.List.map_preserve
+                  (canonical_missing_components ~lossless))
+          |> Stylesheet.map_statement_children
+               (canonical_missing_component_colors ~lossless))
+    stmts
+
 (* The normal optimizer drops this typed alias under its maintained-browser
    policy, but the canonical optimizer runs spec-literally so it does not erase
    other compatibility content. Apply only the alias equivalence promised by
@@ -952,14 +996,15 @@ let rec canonical_query_preludes (stmts : statement list) : statement list =
       Stylesheet.map_statement_children canonical_query_preludes stmt)
     stmts
 
-let canonicalize (stmts : statement list) : statement list =
+let canonicalize ?(lossless = false) (stmts : statement list) : statement list =
   let changed = ref false in
   let normalized =
     fold_layer_pins
       (canonical_query_preludes
          (sort_property_runs
-            (canonical_color_spellings
-               (normalize_custom_values (canonical_vendor_aliases stmts)))))
+            (canonical_missing_component_colors ~lossless
+               (canonical_color_spellings
+                  (normalize_custom_values (canonical_vendor_aliases stmts))))))
   in
   let result =
     canonicalize_block ~parent:(None : Selector.t option) changed normalized

--- a/lib/rule_order.ml
+++ b/lib/rule_order.ml
@@ -725,11 +725,13 @@ let canonical_color_spellings (stmts : statement list) : statement list =
    {!Declaration.normalize} resolves the sentinel only for a colour standing as
    a whole colour-longhand value, which leaves a gradient stop, a [color-mix()]
    operand, a shadow colour and a custom-property token stream reading their
-   [none] as written. What stays outside this pass's reach is a declaration the
-   sheet interpolates from elsewhere: [@keyframes] and [@starting-style] are the
-   two blocks that exist to be one endpoint of that, so the pass does not
-   descend into them. A [transition] between two ordinary declarations still
-   sees the difference, and this is where the projection stops being able to.
+   [none] as written. A declaration the sheet interpolates from elsewhere is
+   held back too: [@keyframes] and [@starting-style] are the two blocks that
+   exist to be one endpoint of that, so the pass does not descend into them, and
+   a colour whose own rule transitions the property it writes keeps its [none].
+   That guard reads one rule. A transition one rule declares for a colour
+   another rule sets still folds, since seeing it would mean deciding that two
+   selectors match one element, which the projection does not do.
 
    Guarded like [canonical_color_spelling]: the flagged normalisation is kept
    only where it moves the colour, so no other value fold rides along. *)
@@ -741,6 +743,15 @@ let canonical_missing_components ~lossless decl =
   then decl
   else folded
 
+let canonical_missing_components_in_rule ~lossless decls =
+  Common.List.map_preserve
+    (fun decl ->
+      let folded = canonical_missing_components ~lossless decl in
+      if folded == decl || not (Shorthand.transitioned_in_rule decls decl) then
+        folded
+      else decl)
+    decls
+
 let rec canonical_missing_component_colors ~lossless (stmts : statement list) :
     statement list =
   Common.List.map_preserve
@@ -751,8 +762,7 @@ let rec canonical_missing_component_colors ~lossless (stmts : statement list) :
       | stmt ->
           stmt
           |> Stylesheet.map_statement_declarations
-               (Common.List.map_preserve
-                  (canonical_missing_components ~lossless))
+               (canonical_missing_components_in_rule ~lossless)
           |> Stylesheet.map_statement_children
                (canonical_missing_component_colors ~lossless))
     stmts

--- a/lib/rule_order.mli
+++ b/lib/rule_order.mli
@@ -24,7 +24,8 @@ val canonical_declarations :
     shorthand and a longhand) since that is cascade-significant. Physically
     unchanged when already canonical. *)
 
-val canonicalize : Stylesheet.statement list -> Stylesheet.statement list
+val canonicalize :
+  ?lossless:bool -> Stylesheet.statement list -> Stylesheet.statement list
 (** [canonicalize stmts] reorders each maximal run of consecutive reorderable
     style rules into the canonical order described above. At-rules, nested
     rules, and custom-property rules are barriers: they keep their position and
@@ -55,6 +56,17 @@ val canonicalize : Stylesheet.statement list -> Stylesheet.statement list
     that fold applies: a declaration is kept exactly as it came in unless the
     colour moved. Emission cannot make the same rewrite, since [color()] needs a
     browser that parses it.
+
+    A [none] channel of a Lab-family colour standing as a whole colour-longhand
+    value is read as the zero CSS Color 4 sec. 4.4 says a missing component
+    behaves as, so [oklab(0% none none / .5)] folds like [oklab(0% 0 0 / .5)]
+    and meets the hex a minifier writes for it. Sec. 13.3 keeps that off every
+    position the sheet interpolates: a gradient stop, a [color-mix()] operand, a
+    shadow colour and a custom-property token stream keep their [none], and the
+    pass does not enter [@keyframes] or [@starting-style]. [lossless] is passed
+    through to the fold so the resolved colour respells no further than the
+    caller's precision mode allows. Emission keeps [none], which is what the
+    value says.
 
     A top-level [@layer] statement loses every name whose removal leaves the
     sheet's layer order alone, and goes away once it has none left. CSS Cascade

--- a/lib/rule_order.mli
+++ b/lib/rule_order.mli
@@ -62,10 +62,11 @@ val canonicalize :
     behaves as, so [oklab(0% none none / .5)] folds like [oklab(0% 0 0 / .5)]
     and meets the hex a minifier writes for it. Sec. 13.3 keeps that off every
     position the sheet interpolates: a gradient stop, a [color-mix()] operand, a
-    shadow colour and a custom-property token stream keep their [none], and the
-    pass does not enter [@keyframes] or [@starting-style]. [lossless] is passed
-    through to the fold so the resolved colour respells no further than the
-    caller's precision mode allows. Emission keeps [none], which is what the
+    shadow colour and a custom-property token stream keep their [none], the pass
+    does not enter [@keyframes] or [@starting-style], and a colour whose own
+    rule transitions the property it writes keeps its [none]. [lossless] is
+    passed through to the fold so the resolved colour respells no further than
+    the caller's precision mode allows. Emission keeps [none], which is what the
     value says.
 
     A top-level [@layer] statement loses every name whose removal leaves the

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3332,6 +3332,65 @@ let compose_mask_via_index ~ctx idx =
           incr i
   done
 
+(* The property a [transition-property] entry names, against the property a
+   declaration writes. A shorthand there transitions every longhand it covers,
+   so [transition-property: background] reaches [background-color]. A name
+   outside the typed table names no property this can be asked about. *)
+let named_property_covers : type a. string -> a Properties.property -> bool =
+ fun name target ->
+  match property_of_name name with
+  | Some (Prop named) -> (
+      match Properties.eq_property named target with
+      | Some Equal -> true
+      | None -> covers_longhand named target)
+  | None -> false
+
+(* CSS Transitions 1 sec. 2.1: [none] transitions nothing, [all] transitions
+   everything, and [all] is the initial. A CSS-wide keyword resolves to that
+   initial or to a list from outside the sheet, and a [var()] is unread, so both
+   read as [all]. *)
+let transition_entry_covers : type a.
+    Properties.transition_property_value -> a Properties.property -> bool =
+ fun entry target ->
+  match entry with
+  | None -> false
+  | Property name -> named_property_covers name target
+  | All | Initial | Inherit | Unset | Revert | Revert_layer | Var _ -> true
+
+let transition_layer_covers : type a.
+    Properties.transition -> a Properties.property -> bool =
+ fun layer target ->
+  match layer with
+  | None -> false
+  | Shorthand s -> transition_entry_covers s.property target
+  | Inherit | Initial | Unset | Revert | Revert_layer | Var _ -> true
+
+(* [all] is in because its only values are CSS-wide keywords, and [inherit]
+   there brings the parent's transition down onto this element. *)
+let declaration_transitions : type a.
+    declaration -> a Properties.property -> bool =
+ fun decl target ->
+  let layers = List.exists (fun l -> transition_layer_covers l target) in
+  let entries = List.exists (fun e -> transition_entry_covers e target) in
+  match unwrap_theme_guard decl with
+  | Declaration { property = Transition; value; _ } -> layers value
+  | Declaration { property = Webkit_transition; value; _ } -> layers value
+  | Declaration { property = Moz_transition; value; _ } -> layers value
+  | Declaration { property = O_transition; value; _ } -> layers value
+  | Declaration { property = Transition_property; value; _ } -> entries value
+  | Declaration { property = Webkit_transition_property; value; _ } ->
+      entries value
+  | Declaration { property = Moz_transition_property; value; _ } ->
+      entries value
+  | Declaration { property = All; _ } -> true
+  | _ -> false
+
+let transitioned_in_rule decls decl =
+  match unwrap_theme_guard decl with
+  | Declaration { property; _ } ->
+      List.exists (fun d -> declaration_transitions d property) decls
+  | _ -> false
+
 (* CSS Transitions 2 sec. 2.6: [transition] composes from
    [transition-{property,duration,timing-function,delay,behavior}]. Compose when
    a contiguous run covers a single layer (each longhand carries a one-entry

--- a/lib/shorthand.mli
+++ b/lib/shorthand.mli
@@ -94,6 +94,16 @@ val drop_redundant_decoration_color_aliases :
 val is_all_declaration : Declaration.declaration -> bool
 (** Whether a declaration is the [all] shorthand. *)
 
+val transitioned_in_rule :
+  Declaration.declaration list -> Declaration.declaration -> bool
+(** [transitioned_in_rule decls d] is [true] when one of [decls] declares a
+    transition reaching the property [d] writes. [transition],
+    [transition-property] and their vendor spellings are read: an entry naming
+    that property or a shorthand covering it reaches it, and so do [all], the
+    [all] shorthand and any value that does not resolve to a property list. Only
+    [decls] are read, so a transition another rule declares for the same element
+    reads as [false]. *)
+
 val merge_box_shorthand_longhands :
   (int * Declaration.declaration) list ->
   (int * Declaration.declaration) list ->

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7645,12 +7645,40 @@ let round_lab_family_axes ~lossless (c : color) : color =
   | Lab r -> Lab { r with l = lab_l r.l; a = r1 r.a; b = r1 r.b }
   | other -> other
 
+(* CSS Color 4 sec. 4.4: "a missing component behaves as a zero value, in the
+   appropriate unit for that component", and the spec names rendering the colour
+   and converting it to another space among the purposes that holds for. The
+   sRGB family already resolves its own [none] channels that way on the path
+   through [static_color_to_srgb_bytes]; the Lab family reaches no fold at all
+   while a channel is missing, so a converted achromatic OKLab and the hex it
+   stands for never meet. This is that half, written as its own step so the
+   folds below read one shape of colour.
+
+   Sec. 13.3 is why it is not unconditional: interpolation gives a missing
+   component the other colour's analogous component instead of a zero, so the
+   two spellings are two different ramps there. *)
+let zero_missing_components (c : color) : color =
+  let lightness (l : percentage option) : percentage option =
+    match l with Option.None -> Some (Pct 0.) | l -> l
+  in
+  let axis (a : float option) =
+    match a with Option.None -> Some 0. | a -> a
+  in
+  let hue (h : hue) : hue = match h with Hue_none -> Unitless 0. | h -> h in
+  match c with
+  | Lab r -> Lab { r with l = lightness r.l; a = axis r.a; b = axis r.b }
+  | Oklab r -> Oklab { r with l = lightness r.l; a = axis r.a; b = axis r.b }
+  | Lch r -> Lch { r with l = lightness r.l; c = axis r.c; h = hue r.h }
+  | Oklch r -> Oklch { r with l = lightness r.l; c = axis r.c; h = hue r.h }
+  | other -> other
+
 (* AST-level color canonicalisation: the value-changing colour folds live here,
    producing a canonical [color] so [pp_color] stays a pure serialiser. The sRGB
    fold runs on the authored coefficients first; [round_lab_family_axes] then
    rounds only what survives in its own colour space. *)
-let rec normalize_color ?(lossless = false) ?(exact_srgb = false) (c : color) :
-    color =
+let rec normalize_color ?(lossless = false) ?(exact_srgb = false)
+    ?(resolve_missing = false) (c : color) : color =
+  let c = if resolve_missing then zero_missing_components c else c in
   let normalize_color ?(lossless = lossless) =
     normalize_color ~lossless ~exact_srgb
   in

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -307,7 +307,8 @@ val normalize_duration :
     [var()]. It chooses the shorter seconds spelling by default;
     [canonicalize_ms:false] preserves millisecond units. *)
 
-val normalize_color : ?lossless:bool -> ?exact_srgb:bool -> color -> color
+val normalize_color :
+  ?lossless:bool -> ?exact_srgb:bool -> ?resolve_missing:bool -> color -> color
 (** [normalize_color ?lossless c] canonicalises a color to its shortest
     spelling: a static colour in any space folds through sRGB to hex/named, hex
     shortens, and named<->hex picks the shorter. [lossless] disables lossy
@@ -318,7 +319,16 @@ val normalize_color : ?lossless:bool -> ?exact_srgb:bool -> color -> color
     additionally folds a [color(srgb ...)] whose channels all land on a whole
     byte, the one [color()] conversion that loses nothing. It exists for the
     canonical diff projection, where [color(srgb 1 0 0)] and [rgb(255 0 0)] must
-    not read as a difference; emission leaves the authored function alone. *)
+    not read as a difference; emission leaves the authored function alone.
+
+    [resolve_missing] (default [false]) reads a [none] channel of a Lab-family
+    colour as the zero CSS Color 4 sec. 4.4 says a missing component behaves as,
+    so [oklab(0% none none / .5)] folds like [oklab(0% 0 0 / .5)] does. It is
+    not carried into a nested colour, because sec. 13.3 gives a missing
+    component the other colour's analogous component wherever two colours are
+    interpolated: a [color-mix()] operand, a [var()] fallback and a
+    relative-colour origin keep their [none]. Like [exact_srgb] it is for the
+    canonical diff projection, and emission never sets it. *)
 
 val pp_number_percentage : ?always:bool -> number_percentage Pp.t
 (** [pp_number_percentage ?always] pretty-prints {!number_percentage} values.

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -664,6 +664,81 @@ let canonical_fully_transparent_missing_oklab () =
        ".a { background-color: oklab(0% none none / .5) }"
        ".a { background-color: #0000 }")
 
+(* CSS Color 4 sec. 4.4: outside the situations that combine two colours, "a
+   missing component behaves as a zero value, in the appropriate unit for that
+   component", and that explicitly covers rendering the colour and converting it
+   to another space. So an achromatic OKLab written with [none] chroma axes -
+   what lightningcss emits for a colour it produced by conversion - is the same
+   colour as the hex Cascade folds it to, and the projection has to say so.
+
+   Sec. 13.3 is the carve-out: where two colours are interpolated, a missing
+   component takes the other colour's analogous component instead of a zero, so
+   the two spellings are two different ramps. The fold therefore fires only on a
+   colour standing as a whole colour-longhand value, never on one the value
+   itself feeds to an interpolation. *)
+let canonical_missing_color_components_as_zero () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  Alcotest.(check bool)
+    "missing OKLab axes read as zero against the hex" true
+    (equal ".x{outline-color:oklab(0% none none / .5)}"
+       ".x{outline-color:#00000080}");
+  Alcotest.(check bool)
+    "the zero-spelled axes still read as that hex" true
+    (equal ".x{outline-color:oklab(0% 0 0 / .5)}" ".x{outline-color:#00000080}");
+  Alcotest.(check bool)
+    "the two spellings agree with each other" true
+    (equal ".x{outline-color:oklab(0% none none / .5)}"
+       ".x{outline-color:oklab(0% 0 0 / .5)}");
+  (* Nothing about the fold is specific to black: a missing axis is a zero at
+     any lightness. *)
+  Alcotest.(check bool)
+    "a missing axis reads as zero away from black" true
+    (equal ".x{outline-color:oklab(50% none none)}"
+       ".x{outline-color:oklab(50% 0 0)}");
+  (* Sec. 4.4.1: the hue of a zero-chroma OKLCh is powerless, so the two
+     spellings are one colour there as well. *)
+  Alcotest.(check bool)
+    "a missing powerless hue reads as zero" true
+    (equal ".x{outline-color:oklch(50% 0 none)}"
+       ".x{outline-color:oklch(50% 0 0)}");
+  (* A different colour stays a different colour: the resolved axes do not move
+     the lightness or the alpha. *)
+  Alcotest.(check bool)
+    "the resolved colour keeps its alpha" false
+    (equal ".x{outline-color:oklab(0% none none / .5)}"
+       ".x{outline-color:#00000040}")
+
+(* The sec. 13.3 side of the line. At each of these positions the stylesheet
+   itself pairs the colour with another one, so [none] and [0] name two
+   different results and the projection must keep them apart. *)
+let canonical_missing_components_survive_interpolation () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  Alcotest.(check bool)
+    "a gradient stop keeps its missing axes" false
+    (equal
+       ".x{background-image:linear-gradient(in oklab,oklab(0% none \
+        none),oklab(100% .2 .1))}"
+       ".x{background-image:linear-gradient(in oklab,#000,oklab(100% .2 .1))}");
+  Alcotest.(check bool)
+    "a color-mix operand keeps its missing axes" false
+    (equal ".x{color:color-mix(in oklab,oklab(0% none none) 50%,var(--y))}"
+       ".x{color:color-mix(in oklab,#000 50%,var(--y))}");
+  Alcotest.(check bool)
+    "a keyframe keeps its missing axes" false
+    (equal "@keyframes k{from{color:oklab(0% none none)}to{color:#fff}}"
+       "@keyframes k{from{color:#000}to{color:#fff}}");
+  Alcotest.(check bool)
+    "a @starting-style value keeps its missing axes" false
+    (equal "@starting-style{.x{color:oklab(0% none none)}}"
+       "@starting-style{.x{color:#000}}");
+  (* A mix Cascade can fold reports the same fact through the folded colour: the
+     missing axes take the other operand's, so the two mixes are two colours. *)
+  Alcotest.(check bool)
+    "a folded mix carries the missing axes forward" false
+    (equal
+       ".x{color:color-mix(in oklab,oklab(0% none none) 50%,oklab(100% .2 .1))}"
+       ".x{color:color-mix(in oklab,#000 50%,oklab(100% .2 .1))}")
+
 let canonical_custom_font_family_quotes () =
   (* A quoted multi-word font name and the unquoted ident sequence substitute
      identically into font-family, so canonical comparison equates them inside a
@@ -1638,6 +1713,10 @@ let suite =
         canonical_relative_color_origin;
       Alcotest.test_case "canonical fully transparent missing oklab" `Quick
         canonical_fully_transparent_missing_oklab;
+      Alcotest.test_case "canonical missing colour components as zero" `Quick
+        canonical_missing_color_components_as_zero;
+      Alcotest.test_case "canonical missing components under interpolation"
+        `Quick canonical_missing_components_survive_interpolation;
       Alcotest.test_case "canonical custom font-family quotes" `Quick
         canonical_custom_font_family_quotes;
       Alcotest.test_case "canonical custom calc percentage" `Quick

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -753,6 +753,58 @@ let canonical_missing_components_survive_interpolation () =
        ".x{color:color-mix(in oklab,oklab(0% none none) 50%,oklab(100% .2 .1))}"
        ".x{color:color-mix(in oklab,#000 50%,oklab(100% .2 .1))}")
 
+(* A rule that transitions the property it also sets makes that declaration one
+   endpoint of an interpolation, which is the sec. 13.3 carve-out again: the
+   [none] axes take the other endpoint's, the zeros stay zero, and the browser
+   walks two different ramps. The property list is what decides, not the
+   duration: a fragment is compared without the rest of the page's cascade, so
+   another sheet can supply the duration this one leaves at its initial. *)
+let canonical_missing_components_under_transition () =
+  let equal a b = Cascade_diff.Css_compare.equal ~mode:`Canonical a b in
+  Alcotest.(check bool)
+    "the shorthand naming the property keeps the axes apart" false
+    (equal ".x{color:oklab(0% none none/.5);transition:color 1s}"
+       ".x{color:#00000080;transition:color 1s}");
+  Alcotest.(check bool)
+    "the longhand naming the property keeps the axes apart" false
+    (equal ".x{color:oklab(0% none none/.5);transition-property:color}"
+       ".x{color:#00000080;transition-property:color}");
+  Alcotest.(check bool)
+    "all names every property, this one included" false
+    (equal ".x{color:oklab(0% none none/.5);transition-property:all}"
+       ".x{color:#00000080;transition-property:all}");
+  (* A shorthand in [transition-property] transitions the longhands it covers,
+     so [background] reaches [background-color]. *)
+  Alcotest.(check bool)
+    "a transitioned shorthand reaches its colour longhand" false
+    (equal
+       ".x{background-color:oklab(0% none none/.5);transition:background 1s}"
+       ".x{background-color:#00000080;transition:background 1s}");
+  (* Nothing interpolates the colour here, so sec. 4.4 reads the missing axes as
+     zero and the two spellings are one colour again. *)
+  Alcotest.(check bool)
+    "a transition on another property leaves the fold alone" true
+    (equal ".x{color:oklab(0% none none/.5);transition:opacity 1s}"
+       ".x{color:#00000080;transition:opacity 1s}");
+  Alcotest.(check bool)
+    "none transitions nothing" true
+    (equal ".x{color:oklab(0% none none/.5);transition-property:none}"
+       ".x{color:#00000080;transition-property:none}");
+  (* The static case the fold exists for. *)
+  Alcotest.(check bool)
+    "a rule with no transition still folds" true
+    (equal ".x{color:oklab(0% none none/.5)}" ".x{color:#00000080}");
+  (* The blocks that exist to be an interpolation endpoint are skipped whole,
+     transition or no transition. *)
+  Alcotest.(check bool)
+    "a keyframe keeps its missing axes" false
+    (equal "@keyframes k{from{color:oklab(0% none none)}to{color:#fff}}"
+       "@keyframes k{from{color:#000}to{color:#fff}}");
+  Alcotest.(check bool)
+    "a @starting-style value keeps its missing axes" false
+    (equal "@starting-style{.x{color:oklab(0% none none)}}"
+       "@starting-style{.x{color:#000}}")
+
 let canonical_custom_font_family_quotes () =
   (* A quoted multi-word font name and the unquoted ident sequence substitute
      identically into font-family, so canonical comparison equates them inside a
@@ -1731,6 +1783,8 @@ let suite =
         canonical_missing_color_components_as_zero;
       Alcotest.test_case "canonical missing components under interpolation"
         `Quick canonical_missing_components_survive_interpolation;
+      Alcotest.test_case "canonical missing components under a transition"
+        `Quick canonical_missing_components_under_transition;
       Alcotest.test_case "canonical custom font-family quotes" `Quick
         canonical_custom_font_family_quotes;
       Alcotest.test_case "canonical custom calc percentage" `Quick

--- a/test/test_css_compare.ml
+++ b/test/test_css_compare.ml
@@ -706,7 +706,21 @@ let canonical_missing_color_components_as_zero () =
   Alcotest.(check bool)
     "the resolved colour keeps its alpha" false
     (equal ".x{outline-color:oklab(0% none none / .5)}"
-       ".x{outline-color:#00000040}")
+       ".x{outline-color:#00000040}");
+  (* Resolving the sentinel is a respelling inside the colour, so it applies
+     under [--lossless] too, and stops where that mode stops: the OKLab does not
+     cross into sRGB. *)
+  let lossless a b =
+    Cascade_diff.Css_compare.equal ~mode:`Canonical ~lossless:true a b
+  in
+  Alcotest.(check bool)
+    "lossless resolves the axes" true
+    (lossless ".x{outline-color:oklab(0% none none / .5)}"
+       ".x{outline-color:oklab(0% 0 0 / .5)}");
+  Alcotest.(check bool)
+    "lossless keeps the OKLab out of sRGB" false
+    (lossless ".x{outline-color:oklab(0% none none / .5)}"
+       ".x{outline-color:#00000080}")
 
 (* The sec. 13.3 side of the line. At each of these positions the stylesheet
    itself pairs the colour with another one, so [none] and [0] name two


### PR DESCRIPTION
Canonical comparison answered differently for one colour depending on how its channels were spelled: `oklab(0% 0 0 / .5)` compared equal to `#00000080`, `oklab(0% none none / .5)` did not. lightningcss writes an achromatic colour it reached by conversion with `none` channels, so every Tailwind parity comparison over such a colour reported a difference that was not one.

CSS Color 4 sec. 13.3 keeps the fold off every position the sheet interpolates, so a gradient stop, a `color-mix()` operand, `@keyframes`, `@starting-style` and a colour whose own rule transitions the property it writes all keep their `none`. That guard reads one rule, so a transition another rule declares for the same element is the residual, and it is stated in the code rather than papered over.
