### PR TITLE
properties: read the multi-value forms these grammars allow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -190,6 +190,10 @@ entry points both moved.
 
 ### Parsing
 
+- `margin` mixes `auto` with lengths in any slot, `border-style` takes the four
+  side styles, `border-block-style` and `border-inline-style` take the start and
+  end edges, and every `border-*-radius` corner takes a horizontal and a
+  vertical radius
 - A `style()` container query takes the single-comparison range CSS Conditional
   Rules 5 defines, `style(--gap = 10px)` included, and rejects an interval whose
   two bounds point different ways; `Css.inline_vars` reads its operands (#805)

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -263,6 +263,11 @@ let logical_border_width value = (Single value : logical_border_width)
 let logical_border_widths start end_ =
   (Pair (start, end_) : logical_border_width)
 
+let logical_border_style value = (Single value : logical_border_style)
+
+let logical_border_styles start end_ =
+  (Pair (start, end_) : logical_border_style)
+
 let transform_list items = (List items : transform)
 let filter_list items = (List items : filter)
 let cursor_url ?hotspot ~fallback url = (Url (url, hotspot, fallback) : cursor)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -5313,6 +5313,22 @@ val logical_border_width : border_width -> logical_border_width
 val logical_border_widths : border_width -> border_width -> logical_border_width
 (** [logical_border_widths start end_] is a two-value logical border width. *)
 
+type logical_border_style = Properties.logical_border_style =
+  | Single of border_style
+  | Pair of border_style * border_style
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of logical_border_style var
+
+val logical_border_style : border_style -> logical_border_style
+(** [logical_border_style s] is a one-value logical border style. *)
+
+val logical_border_styles : border_style -> border_style -> logical_border_style
+(** [logical_border_styles start end_] is a two-value logical border style. *)
+
 (** CSS outline style values. *)
 type outline_style = Properties.outline_style =
   | None
@@ -5507,12 +5523,12 @@ val border_left_style : border_style -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-style}
      border-left-style} property. *)
 
-val border_inline_style : border_style -> declaration
+val border_inline_style : logical_border_style -> declaration
 (** [border_inline_style s] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-style}
      border-inline-style} property. *)
 
-val border_block_style : border_style -> declaration
+val border_block_style : logical_border_style -> declaration
 (** [border_block_style s] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-style}
      border-block-style} property. *)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -566,10 +566,10 @@ let property_value_uses_runtime_subst (type a)
   | Padding_right -> Values.length_has_runtime_subst value
   | Padding_bottom -> Values.length_has_runtime_subst value
   | Padding_left -> Values.length_has_runtime_subst value
-  | Border_top_left_radius -> Values.length_has_runtime_subst value
-  | Border_top_right_radius -> Values.length_has_runtime_subst value
-  | Border_bottom_left_radius -> Values.length_has_runtime_subst value
-  | Border_bottom_right_radius -> Values.length_has_runtime_subst value
+  | Border_top_left_radius -> length_list_has_runtime_subst value
+  | Border_top_right_radius -> length_list_has_runtime_subst value
+  | Border_bottom_left_radius -> length_list_has_runtime_subst value
+  | Border_bottom_right_radius -> length_list_has_runtime_subst value
   | Outline_width -> Properties.border_width_has_runtime_subst value
   | Margin -> length_list_has_runtime_subst value
   | Padding -> length_list_has_runtime_subst value
@@ -839,6 +839,12 @@ let read_nn_length_or_global t =
     ]
     ~default:(read_non_negative_length ~with_keywords:false)
     t
+
+(* CSS Backgrounds 3 (ED) sec. 4.1: each [border-*-radius] corner longhand is
+   [<length-percentage [0,inf]>{1,2}], the horizontal radius then the vertical
+   one; a single value sets both. *)
+let read_corner_radius t =
+  Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2 read_nn_length_or_global t
 
 (* CSS Text 3 section 7: [letter-spacing] is [normal | <length>], [word-spacing]
    is [normal | <length-percentage>]; both accept negative values. *)
@@ -1135,21 +1141,21 @@ let read_radius_gap_value : type a. a property -> Cursor.t -> declaration option
   match prop with
   | Border_radius -> Some (v Border_radius (read_border_radius t))
   | Border_top_left_radius ->
-      Some (v Border_top_left_radius (read_nn_length_or_global t))
+      Some (v Border_top_left_radius (read_corner_radius t))
   | Border_top_right_radius ->
-      Some (v Border_top_right_radius (read_nn_length_or_global t))
+      Some (v Border_top_right_radius (read_corner_radius t))
   | Border_bottom_left_radius ->
-      Some (v Border_bottom_left_radius (read_nn_length_or_global t))
+      Some (v Border_bottom_left_radius (read_corner_radius t))
   | Border_bottom_right_radius ->
-      Some (v Border_bottom_right_radius (read_nn_length_or_global t))
+      Some (v Border_bottom_right_radius (read_corner_radius t))
   | Border_start_start_radius ->
-      Some (v Border_start_start_radius (read_nn_length_or_global t))
+      Some (v Border_start_start_radius (read_corner_radius t))
   | Border_start_end_radius ->
-      Some (v Border_start_end_radius (read_nn_length_or_global t))
+      Some (v Border_start_end_radius (read_corner_radius t))
   | Border_end_start_radius ->
-      Some (v Border_end_start_radius (read_nn_length_or_global t))
+      Some (v Border_end_start_radius (read_corner_radius t))
   | Border_end_end_radius ->
-      Some (v Border_end_end_radius (read_nn_length_or_global t))
+      Some (v Border_end_end_radius (read_corner_radius t))
   | Gap -> Some (v Gap (Properties.read_gap t))
   | Column_gap -> Some (v Column_gap (read_nn_length_or_global t))
   | Row_gap -> Some (v Row_gap (read_nn_length_or_global t))
@@ -1181,7 +1187,7 @@ let read_box_edge_value : type a. a property -> Cursor.t -> declaration option =
   match prop with
   | Padding -> Some (v Padding (read_padding_shorthand t))
   | Margin -> Some (v Margin (read_margin_shorthand t))
-  | Border_style -> Some (v Border_style (read_border_style t))
+  | Border_style -> Some (v Border_style (read_border_style_box t))
   | Border_width -> Some (v Border_width (read_border_width_box t))
   | Border_top_width -> Some (v Border_top_width (read_border_width t))
   | Border_right_width -> Some (v Border_right_width (read_border_width t))
@@ -1212,8 +1218,10 @@ let read_box_edge_value : type a. a property -> Cursor.t -> declaration option =
       Some (v Border_inline_width (read_logical_border_width t))
   | Border_block_width ->
       Some (v Border_block_width (read_logical_border_width t))
-  | Border_inline_style -> Some (v Border_inline_style (read_border_style t))
-  | Border_block_style -> Some (v Border_block_style (read_border_style t))
+  | Border_inline_style ->
+      Some (v Border_inline_style (read_logical_border_style t))
+  | Border_block_style ->
+      Some (v Border_block_style (read_logical_border_style t))
   | Border_inline_start_style ->
       Some (v Border_inline_start_style (read_border_style t))
   | Border_inline_end_style ->
@@ -2692,7 +2700,7 @@ let background bg = v Background [ bg ]
 let background_color c = v Background_color c
 let color c = v Color c
 let border_color c = v Border_color [ c ]
-let border_style bs = v Border_style bs
+let border_style bs = v Border_style [ bs ]
 let border_top_style bs = v Border_top_style bs
 let border_right_style bs = v Border_right_style bs
 let border_bottom_style bs = v Border_bottom_style bs
@@ -2808,10 +2816,10 @@ let place_items value = v Place_items value
 let place_self value = v Place_self value
 let border_width len = v Border_width [ len ]
 let border_radius len = v Border_radius len
-let border_top_left_radius len = v Border_top_left_radius len
-let border_top_right_radius len = v Border_top_right_radius len
-let border_bottom_left_radius len = v Border_bottom_left_radius len
-let border_bottom_right_radius len = v Border_bottom_right_radius len
+let border_top_left_radius len = v Border_top_left_radius [ len ]
+let border_top_right_radius len = v Border_top_right_radius [ len ]
+let border_bottom_left_radius len = v Border_bottom_left_radius [ len ]
+let border_bottom_right_radius len = v Border_bottom_right_radius [ len ]
 let fill value = v Fill value
 let stroke value = v Stroke value
 let stroke_width value = v Stroke_width value
@@ -3105,10 +3113,10 @@ let border_inline_start_style value = v Border_inline_start_style value
 let border_inline_end_style value = v Border_inline_end_style value
 let border_block_start_style value = v Border_block_start_style value
 let border_block_end_style value = v Border_block_end_style value
-let border_start_start_radius value = v Border_start_start_radius value
-let border_start_end_radius value = v Border_start_end_radius value
-let border_end_start_radius value = v Border_end_start_radius value
-let border_end_end_radius value = v Border_end_end_radius value
+let border_start_start_radius value = v Border_start_start_radius [ value ]
+let border_start_end_radius value = v Border_start_end_radius [ value ]
+let border_end_start_radius value = v Border_end_start_radius [ value ]
+let border_end_end_radius value = v Border_end_end_radius [ value ]
 let webkit_font_smoothing value = v Webkit_font_smoothing value
 let cursor value = v Cursor value
 let user_select value = v User_select value

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -381,12 +381,12 @@ val border_left_style : border_style -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-style}
      border-left-style} property. *)
 
-val border_inline_style : border_style -> declaration
+val border_inline_style : logical_border_style -> declaration
 (** [border_inline_style v] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-style}
      border-inline-style} property. *)
 
-val border_block_style : border_style -> declaration
+val border_block_style : logical_border_style -> declaration
 (** [border_block_style v] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-style}
      border-block-style} property. *)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -904,6 +904,20 @@ let rec pp_logical_border_width : logical_border_width Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_logical_border_width ctx v
 
+let rec pp_logical_border_style : logical_border_style Pp.t =
+ fun ctx -> function
+  | Single s -> pp_border_style ctx s
+  | Pair (start_, end_) ->
+      pp_border_style ctx start_;
+      Pp.space ctx ();
+      pp_border_style ctx end_
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_logical_border_style ctx v
+
 let rec pp_border_spacing : border_spacing Pp.t =
  fun ctx -> function
   | (Lengths lengths : border_spacing) ->
@@ -1215,6 +1229,13 @@ let rec read_border_style t : border_style =
     ~var:(fun t -> Var (read_var read_border_style t))
     t
 
+(* CSS Backgrounds 3 (ED) sec. 3.2: [border-style] is [<line-style>{1,4}], the
+   box over the four side styles, as sec. 3.1 gives [border-color] and sec. 3.3
+   gives [border-width] theirs. A CSS-wide keyword reaches a slot only as the
+   lone value; [validate_regular_property_components] rejects the mixes. *)
+let read_border_style_box t : border_style list =
+  Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:4 read_border_style t
+
 (* Helper: ensure border-width values are non-negative per CSS spec *)
 let ensure_non_negative_border_width t value =
   if value < 0.0 then
@@ -1472,6 +1493,29 @@ let rec read_logical_border_width t : logical_border_width =
     ]
     ~var:(fun t -> Var (Values.read_var read_logical_border_width t))
     ~default:read_widths t
+
+(* CSS Logical 1 (ED) sec. 4.5.2: [border-inline-style] and [border-block-style]
+   are [<'border-top-style'>{1,2}], the first value the start edge and the
+   second the end edge. *)
+let rec read_logical_border_style t : logical_border_style =
+  let read_styles t =
+    match
+      Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2 read_border_style t
+    with
+    | [ s ] -> (Single s : logical_border_style)
+    | [ start_; end_ ] -> Pair (start_, end_)
+    | _ -> Cursor.err_expected t "one or two line styles"
+  in
+  Cursor.enum_or_var "logical border style"
+    [
+      ("inherit", (Inherit : logical_border_style));
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (Values.read_var read_logical_border_style t))
+    ~default:read_styles t
 
 let rec read_border_collapse t : border_collapse =
   Cursor.enum_or_var "border-collapse"

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -180,6 +180,10 @@ let is_color_substitution : color -> bool = function
   | Attribute _ | Var _ -> true
   | _ -> false
 
+let is_border_style_substitution : border_style -> bool = function
+  | Var _ -> true
+  | _ -> false
+
 (* Canonicalise a box shorthand: normalise each side with [f], then pick the
    shortest of the spellings that name those sides. Keep the authored number of
    components when arbitrary substitution defers their computed arity. *)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4281,6 +4281,9 @@ let normalize_property_value : type a.
   | Border_color ->
       normalize_box_shorthand ~is_substitution:is_color_substitution
         normalize_color value
+  | Border_style ->
+      normalize_box_shorthand ~is_substitution:is_border_style_substitution
+        Fun.id value
   | Border_top_color -> normalize_color value
   | Border_right_color -> normalize_color value
   | Border_bottom_color -> normalize_color value
@@ -4389,14 +4392,14 @@ let normalize_property_value : type a.
   | Row_gap -> Values.normalize_length ~ctx value
   | Text_underline_offset -> Values.normalize_length ~ctx value
   | Letter_spacing -> Values.normalize_length ~ctx value
-  | Border_top_left_radius -> Values.normalize_length ~ctx value
-  | Border_top_right_radius -> Values.normalize_length ~ctx value
-  | Border_bottom_left_radius -> Values.normalize_length ~ctx value
-  | Border_bottom_right_radius -> Values.normalize_length ~ctx value
-  | Border_start_start_radius -> Values.normalize_length ~ctx value
-  | Border_start_end_radius -> Values.normalize_length ~ctx value
-  | Border_end_start_radius -> Values.normalize_length ~ctx value
-  | Border_end_end_radius -> Values.normalize_length ~ctx value
+  | Border_top_left_radius -> normalize_length_box ~ctx value
+  | Border_top_right_radius -> normalize_length_box ~ctx value
+  | Border_bottom_left_radius -> normalize_length_box ~ctx value
+  | Border_bottom_right_radius -> normalize_length_box ~ctx value
+  | Border_start_start_radius -> normalize_length_box ~ctx value
+  | Border_start_end_radius -> normalize_length_box ~ctx value
+  | Border_end_start_radius -> normalize_length_box ~ctx value
+  | Border_end_end_radius -> normalize_length_box ~ctx value
   | Outline_width -> normalize_border_width value
   | Outline_offset -> Values.normalize_length ~ctx value
   | Line_height_step -> Values.normalize_length ~ctx value
@@ -4537,7 +4540,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Background_color -> pp pp_color
   | Color -> pp pp_color
   | Border_color -> pp (Pp.list ~sep:Pp.token_sp pp_color)
-  | Border_style -> pp pp_border_style
+  | Border_style -> pp (pp_box_shorthand pp_border_style)
   | Border_top_style -> pp pp_border_style
   | Border_right_style -> pp pp_border_style
   | Border_bottom_style -> pp pp_border_style
@@ -4632,10 +4635,10 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Border_block_end_width -> pp pp_border_width
   | Border_image -> pp pp_border_image
   | Border_radius -> pp pp_border_radius
-  | Border_top_left_radius -> pp pp_length
-  | Border_top_right_radius -> pp pp_length
-  | Border_bottom_left_radius -> pp pp_length
-  | Border_bottom_right_radius -> pp pp_length
+  | Border_top_left_radius -> pp (pp_box_shorthand pp_length)
+  | Border_top_right_radius -> pp (pp_box_shorthand pp_length)
+  | Border_bottom_left_radius -> pp (pp_box_shorthand pp_length)
+  | Border_bottom_right_radius -> pp (pp_box_shorthand pp_length)
   | Border_top_color -> pp pp_color
   | Border_right_color -> pp pp_color
   | Border_bottom_color -> pp pp_color
@@ -4648,12 +4651,12 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Border_block_color -> pp pp_logical_border_color
   | Border_inline_width -> pp pp_logical_border_width
   | Border_block_width -> pp pp_logical_border_width
-  | Border_inline_style -> pp pp_border_style
-  | Border_block_style -> pp pp_border_style
-  | Border_start_start_radius -> pp pp_length
-  | Border_start_end_radius -> pp pp_length
-  | Border_end_start_radius -> pp pp_length
-  | Border_end_end_radius -> pp pp_length
+  | Border_inline_style -> pp pp_logical_border_style
+  | Border_block_style -> pp pp_logical_border_style
+  | Border_start_start_radius -> pp (pp_box_shorthand pp_length)
+  | Border_start_end_radius -> pp (pp_box_shorthand pp_length)
+  | Border_end_start_radius -> pp (pp_box_shorthand pp_length)
+  | Border_end_end_radius -> pp (pp_box_shorthand pp_length)
   | Text_decoration_color -> pp pp_color
   | Webkit_text_decoration_color -> pp pp_color
   | Webkit_tap_highlight_color -> pp pp_color
@@ -5173,14 +5176,14 @@ let property_value_kind : type a. a property -> a property_value_kind option =
   | Row_gap -> Some Length
   | Text_underline_offset -> Some Length
   | Letter_spacing -> Some Length
-  | Border_top_left_radius -> Some Length
-  | Border_top_right_radius -> Some Length
-  | Border_bottom_left_radius -> Some Length
-  | Border_bottom_right_radius -> Some Length
-  | Border_start_start_radius -> Some Length
-  | Border_start_end_radius -> Some Length
-  | Border_end_start_radius -> Some Length
-  | Border_end_end_radius -> Some Length
+  | Border_top_left_radius -> Some Lengths
+  | Border_top_right_radius -> Some Lengths
+  | Border_bottom_left_radius -> Some Lengths
+  | Border_bottom_right_radius -> Some Lengths
+  | Border_start_start_radius -> Some Lengths
+  | Border_start_end_radius -> Some Lengths
+  | Border_end_start_radius -> Some Lengths
+  | Border_end_end_radius -> Some Lengths
   | Outline_width -> Some Border_width
   | Border_top_width -> Some Border_width
   | Border_right_width -> Some Border_width

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -665,6 +665,10 @@ val pp_border_style : border_style Pp.t
 val read_border_style : Cursor.t -> border_style
 (** [read_border_style t] is the [border_style] parsed from [t]. *)
 
+val read_border_style_box : Cursor.t -> border_style list
+(** [read_border_style_box t] is the [<line-style>{1,4}] box the [border-style]
+    shorthand takes (CSS Backgrounds 3 (ED) sec. 3.2). *)
+
 val pp_border_width : border_width Pp.t
 (** [pp_border_width] is the pretty-printer for [border_width]. *)
 
@@ -2146,6 +2150,14 @@ val pp_logical_border_width : logical_border_width Pp.t
 
 val read_logical_border_width : Cursor.t -> logical_border_width
 (** [read_logical_border_width t] is the [logical_border_width] parsed from [t].
+*)
+
+val pp_logical_border_style : logical_border_style Pp.t
+(** [pp_logical_border_style] is the pretty-printer for [logical_border_style].
+*)
+
+val read_logical_border_style : Cursor.t -> logical_border_style
+(** [read_logical_border_style t] is the [logical_border_style] parsed from [t].
 *)
 
 val pp_column_span : column_span Pp.t

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1787,6 +1787,18 @@ type logical_border_width =
   | Revert_layer
   | Var of logical_border_width var
 
+(* border-inline-style / border-block-style take one or two <line-style> values,
+   mirroring logical_border_width. *)
+type logical_border_style =
+  | Single of border_style
+  | Pair of border_style * border_style
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of logical_border_style var
+
 type outline_style =
   | None
   | Solid
@@ -4622,7 +4634,7 @@ type 'a property =
   | Background_color : color property
   | Color : color property
   | Border_color : color list property
-  | Border_style : border_style property
+  | Border_style : border_style list property
   | Border_top_style : border_style property
   | Border_right_style : border_style property
   | Border_bottom_style : border_style property
@@ -4755,10 +4767,10 @@ type 'a property =
   | Border_image_width : border_image_width property
   | Border_image_outset : border_image_outset property
   | Border_radius : border_radius property
-  | Border_top_left_radius : length property
-  | Border_top_right_radius : length property
-  | Border_bottom_left_radius : length property
-  | Border_bottom_right_radius : length property
+  | Border_top_left_radius : length list property
+  | Border_top_right_radius : length list property
+  | Border_bottom_left_radius : length list property
+  | Border_bottom_right_radius : length list property
   | Border_top_color : color property
   | Border_right_color : color property
   | Border_bottom_color : color property
@@ -4769,12 +4781,12 @@ type 'a property =
   | Border_block_end_color : color property
   | Border_inline_color : logical_border_color property
   | Border_block_color : logical_border_color property
-  | Border_inline_style : border_style property
-  | Border_block_style : border_style property
-  | Border_start_start_radius : length property
-  | Border_start_end_radius : length property
-  | Border_end_start_radius : length property
-  | Border_end_end_radius : length property
+  | Border_inline_style : logical_border_style property
+  | Border_block_style : logical_border_style property
+  | Border_start_start_radius : length list property
+  | Border_start_end_radius : length list property
+  | Border_end_start_radius : length list property
+  | Border_end_end_radius : length list property
   | Opacity : opacity property
   | Fill_opacity : opacity property
   | Stroke_opacity : opacity property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -1587,17 +1587,23 @@ let extract_inset_side : declaration -> (box_side * Values.length * bool) option
       Some (Left, v, important)
   | _ -> None
 
+(* [border-radius] gives the horizontal radii before the [/] and the vertical
+   ones after it, so a corner naming both axes has no slot in the box the four
+   corners compose. Only a single-valued corner takes part. *)
 let extract_border_radius_corner :
     declaration -> (box_side * Values.length * bool) option = function
-  | Declaration { property = Border_top_left_radius; value; important; _ } ->
-      Some (Top, value, important)
-  | Declaration { property = Border_top_right_radius; value; important; _ } ->
-      Some (Right, value, important)
-  | Declaration { property = Border_bottom_right_radius; value; important; _ }
-    ->
-      Some (Bottom, value, important)
-  | Declaration { property = Border_bottom_left_radius; value; important; _ } ->
-      Some (Left, value, important)
+  | Declaration
+      { property = Border_top_left_radius; value = [ v ]; important; _ } ->
+      Some (Top, v, important)
+  | Declaration
+      { property = Border_top_right_radius; value = [ v ]; important; _ } ->
+      Some (Right, v, important)
+  | Declaration
+      { property = Border_bottom_right_radius; value = [ v ]; important; _ } ->
+      Some (Bottom, v, important)
+  | Declaration
+      { property = Border_bottom_left_radius; value = [ v ]; important; _ } ->
+      Some (Left, v, important)
   | _ -> None
 
 (* CSS Scroll Snap 1 sec. 4.2 and 5.1: [scroll-padding] sets the four snapport
@@ -1709,12 +1715,10 @@ let build_border_width_box ~important ~top ~right ~bottom ~left =
     (Declaration.v ~important Border_width
        (collapse_box_by same_border_width [ top; right; bottom; left ]))
 
-(* [border-style] carries a single keyword, so only a box with one distinct
-   style has a shorthand spelling. *)
 let build_border_style_box ~important ~top ~right ~bottom ~left =
-  match collapse_box_by same_border_style [ top; right; bottom; left ] with
-  | [ style ] -> Some (Declaration.v ~important Border_style style)
-  | _ -> None
+  Some
+    (Declaration.v ~important Border_style
+       (collapse_box_by same_border_style [ top; right; bottom; left ]))
 
 let build_border_color_box ~important ~top ~right ~bottom ~left =
   Some
@@ -2708,7 +2712,7 @@ let try_compose_border_whole_at ~ctx idx i =
           (function
             | Declaration { property = Border_width; value = [ w ]; _ } ->
                 width := Some w
-            | Declaration { property = Border_style; value = s; _ } ->
+            | Declaration { property = Border_style; value = [ s ]; _ } ->
                 style := Some s
             | Declaration { property = Border_color; value = [ c ]; _ } ->
                 color := Some c

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7850,9 +7850,11 @@ let read_padding_shorthand t : length list =
         t)
     t
 
-(** Read margin shorthand property (1-4 values) Source:
-    https://www.w3.org/TR/CSS21/box.html#margin-properties CSS margin accepts
-    1-4 space-separated values *)
+(** Read margin shorthand property (1-4 values). CSS Box 4 (ED) sec. 3.2 gives
+    [margin] the value [<'margin-top'>{1,4}] and sec. 3.1 gives [margin-top] the
+    value [<length-percentage> | auto], so [auto] is a component of the box and
+    stands in any slot beside any length. Only the CSS-wide keywords of CSS
+    Cascade 5 sec. 6 own the whole value. *)
 let read_margin_shorthand t : length list =
   let rec read_margin_component t : length =
     if Cursor.looking_at_func "var" t then
@@ -7863,12 +7865,9 @@ let read_margin_shorthand t : length list =
         ~default:(read_length ~with_keywords:false)
         t
   in
-  (* CSS margin accepts 1-4 space-separated values *)
-  (* CSS-wide keywords must be the only value when present *)
   Cursor.enum "margin"
     [
-      ("auto", [ Auto ]);
-      ("inherit", [ Inherit ]);
+      ("inherit", [ (Inherit : length) ]);
       ("initial", [ Initial ]);
       ("unset", [ Unset ]);
       ("revert", [ Revert ]);

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1430,6 +1430,14 @@ let vars_of_logical_border_width (value : Properties.logical_border_width) =
       vars_of_border_width start_ @ vars_of_border_width end_
   | _ -> []
 
+let vars_of_logical_border_style (value : Properties.logical_border_style) =
+  match value with
+  | Var v -> [ V v ]
+  | Single s -> vars_of_border_style s
+  | Pair (start_, end_) ->
+      vars_of_border_style start_ @ vars_of_border_style end_
+  | _ -> []
+
 let vars_of_outline (value : Properties.outline) =
   match value with
   | Var v -> [ V v ]
@@ -2093,22 +2101,22 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Border_block_color, value -> vars_of_logical_border_color value
   | Border_inline_width, value -> vars_of_logical_border_width value
   | Border_block_width, value -> vars_of_logical_border_width value
-  | Border_inline_style, value -> vars_of_border_style value
-  | Border_block_style, value -> vars_of_border_style value
-  | Border_start_start_radius, value -> vars_of_length value
-  | Border_start_end_radius, value -> vars_of_length value
-  | Border_end_start_radius, value -> vars_of_length value
-  | Border_end_end_radius, value -> vars_of_length value
+  | Border_inline_style, value -> vars_of_logical_border_style value
+  | Border_block_style, value -> vars_of_logical_border_style value
+  | Border_start_start_radius, value -> vars_of_length_list value
+  | Border_start_end_radius, value -> vars_of_length_list value
+  | Border_end_start_radius, value -> vars_of_length_list value
+  | Border_end_end_radius, value -> vars_of_length_list value
   | Text_decoration_color, value -> vars_of_color value
   | Webkit_text_decoration_color, value -> vars_of_color value
   | Webkit_tap_highlight_color, value -> vars_of_color value
   | Outline_color, value -> vars_of_color value
   (* Border radius *)
   | Border_radius, value -> vars_of_border_radius value
-  | Border_top_left_radius, value -> vars_of_length value
-  | Border_top_right_radius, value -> vars_of_length value
-  | Border_bottom_left_radius, value -> vars_of_length value
-  | Border_bottom_right_radius, value -> vars_of_length value
+  | Border_top_left_radius, value -> vars_of_length_list value
+  | Border_top_right_radius, value -> vars_of_length_list value
+  | Border_bottom_left_radius, value -> vars_of_length_list value
+  | Border_bottom_right_radius, value -> vars_of_length_list value
   | Border_image, value -> vars_of_border_image value
   (* Outline offset *)
   | Outline_offset, value -> vars_of_length value
@@ -2153,7 +2161,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | O_transform, value -> vars_of_transform_list value
   | Translate, value -> vars_of_translate_value value
   (* Border style properties *)
-  | Border_style, value -> vars_of_border_style value
+  | Border_style, value -> List.concat_map vars_of_border_style value
   | Border_top_style, value -> vars_of_border_style value
   | Border_right_style, value -> vars_of_border_style value
   | Border_bottom_style, value -> vars_of_border_style value

--- a/test/cram/public_surface.t/retained.ml
+++ b/test/cram/public_surface.t/retained.ml
@@ -77,7 +77,7 @@ let _ :
 let _ : Declaration.t -> bool =
  fun d ->
   match Declaration.value_of d Properties.Border_style with
-  | Some (Var _) -> true
+  | Some [ Var _ ] -> true
   | Some _ | None -> false
 
 (* The witness the value is read at is the one {!Declaration.property_key}

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -420,13 +420,10 @@ let matrix =
     ]
   @ rows_for
       [
-        "border-style";
         "border-top-style";
         "border-right-style";
         "border-bottom-style";
         "border-left-style";
-        "border-inline-style";
-        "border-block-style";
         "border-inline-start-style";
         "border-inline-end-style";
         "border-block-start-style";
@@ -434,6 +431,29 @@ let matrix =
       ]
       [ "none"; "solid"; "dashed"; "hidden" ]
       [ "solid dashed"; "foo" ]
+  (* CSS Backgrounds 3 (ED) sec. 3.2 gives [border-style] the value
+     [<line-style>{1,4}], the box over the four side styles that sec. 3.1 gives
+     [border-color]. *)
+  @ [
+      {
+        property = "border-style";
+        positives =
+          [
+            "none";
+            "solid";
+            "solid dashed";
+            "solid dashed dotted";
+            "solid dashed dotted double";
+          ];
+        negatives = [ "foo"; "solid dashed dotted double hidden" ];
+      };
+    ]
+  (* CSS Logical 1 (ED) sec. 4.5.2 gives both flow-relative shorthands the value
+     [<'border-top-style'>{1,2}], the start edge then the end edge. *)
+  @ rows_for
+      [ "border-inline-style"; "border-block-style" ]
+      [ "none"; "solid"; "solid dashed" ]
+      [ "foo"; "solid dashed dotted" ]
   @ rows_for
       [
         "padding-left";
@@ -444,14 +464,6 @@ let matrix =
         "padding-inline-end";
         "padding-block-start";
         "padding-block-end";
-        "border-top-left-radius";
-        "border-top-right-radius";
-        "border-bottom-left-radius";
-        "border-bottom-right-radius";
-        "border-start-start-radius";
-        "border-start-end-radius";
-        "border-end-start-radius";
-        "border-end-end-radius";
         "stroke-width";
         "outline-width";
         "outline-offset";
@@ -465,6 +477,22 @@ let matrix =
       ]
       [ "0"; "1px"; "calc(1rem + 2px)" ]
       [ "auto"; "red"; "1px 2px" ]
+  (* CSS Backgrounds 3 (ED) sec. 4.1 gives every corner longhand the value
+     [<length-percentage [0,inf]>{1,2}]: the horizontal radius then the vertical
+     one, a single value setting both. *)
+  @ rows_for
+      [
+        "border-top-left-radius";
+        "border-top-right-radius";
+        "border-bottom-left-radius";
+        "border-bottom-right-radius";
+        "border-start-start-radius";
+        "border-start-end-radius";
+        "border-end-start-radius";
+        "border-end-end-radius";
+      ]
+      [ "0"; "1px"; "1px 2px"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "1px 2px 3px" ]
   (* CSS Transforms 2 sec. 3: [perspective] takes [none], its initial value. CSS
      Text Decoration 4 sec. 5: [text-underline-offset] takes [auto] and may be
      negative. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -5418,6 +5418,14 @@ let multi_value_grammars () =
   reads_back "border-style: none dashed none solid";
   check_declaration ~expected:"border-style:solid" "border-style: solid";
   check_declaration ~expected:"border-style:none" "border-style: none";
+  (* The box fills the sides by position, so a list repeating what those rules
+     already supply is the longer spelling of the same declaration and
+     canonicalises to the shortest, as [border-color]'s does. pp holds the
+     authored node; the fold is a normalize step. *)
+  check_declaration ~expected:"border-style:dashed dashed dashed dashed"
+    ~optimized:"border-style:dashed" "border-style: dashed dashed dashed dashed";
+  check_declaration ~expected:"border-style:dashed none dashed"
+    ~optimized:"border-style:dashed none" "border-style: dashed none dashed";
   neg_cursor read_declaration "border-style: solid solid solid solid solid";
   neg_cursor read_declaration "border-style: solid 1px";
 
@@ -5460,6 +5468,10 @@ let multi_value_grammars () =
     "border-top-left-radius: 1px";
   check_declaration ~expected:"border-top-left-radius:50%"
     "border-top-left-radius: 50%";
+  (* One value already sets both radii, so a vertical radius equal to the
+     horizontal one says what omitting it says. *)
+  check_declaration ~expected:"border-top-left-radius:1px 1px"
+    ~optimized:"border-top-left-radius:1px" "border-top-left-radius: 1px 1px";
   (* The shorthand already spelled both axes across the slash, and keeps to
      it. *)
   check_declaration ~expected:"border-radius:10%/20%" "border-radius: 10% / 20%";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -5356,6 +5356,117 @@ let hex_spellings_have_one_node () =
   distinct_value "#fff vs #fff8" short_lower
     (sole_declaration ".e{color:#FFF8}")
 
+(* Cascade keeps no raw-token sidecar, so a printed declaration is rebuilt from
+   its typed values alone: reading the print back has to land on the node that
+   printed it, not merely on the same text. *)
+let reads_back input =
+  let d = Css.Declaration.of_string input in
+  let printed = Css.Declaration.to_string ~minify:true d in
+  Alcotest.(check bool)
+    (input ^ ": the print reads back as the same node")
+    true
+    (Css.Declaration.equal_declaration d (Css.Declaration.of_string printed))
+
+(* Four families whose grammar takes more component values than the reader took.
+   Each block pins the multi-value forms the grammar allows, the single-value
+   forms that already worked, and the neighbouring grammar that must not widen
+   with them. *)
+let multi_value_grammars () =
+  (* CSS Box 4 (ED) sec. 3.2 gives [margin] the value [<'margin-top'>{1,4}] and
+     sec. 3.1 gives [margin-top] the value [<length-percentage> | auto], so
+     [auto] is a component of the box: it may stand in any of the four slots and
+     beside any length, at any count. It is not a whole-value keyword. *)
+  check_declaration ~roundtrip:true ~expected:"margin:auto 2px"
+    "margin: auto 2px";
+  check_declaration ~roundtrip:true ~expected:"margin:auto auto auto 2px"
+    "margin: auto auto auto 2px";
+  check_declaration ~roundtrip:true ~expected:"margin:2px auto auto"
+    "margin: 2px auto auto";
+  reads_back "margin: auto 2px";
+  reads_back "margin: auto auto auto 2px";
+  (* Working before the widening, so a fix must not move them. *)
+  check_declaration ~expected:"margin:auto" "margin: auto";
+  check_declaration ~expected:"margin:0 auto" "margin: 0 auto";
+  check_declaration ~expected:"margin:10px auto" "margin: 10px auto";
+  check_declaration ~expected:"margin:0 auto 20px" "margin: 0 auto 20px";
+  check_declaration ~expected:"margin:1px 2px 3px 4px" "margin: 1px 2px 3px 4px";
+  check_declaration ~expected:"margin-inline:0 auto" "margin-inline: 0 auto";
+  (* A fifth component is outside {1,4}, and the CSS-wide keywords stay
+     whole-value (CSS Cascade 5 sec. 6). *)
+  neg_cursor read_declaration "margin: 1px 2px 3px 4px 5px";
+  neg_cursor read_declaration "margin: inherit 1px";
+  (* Sec. 4.1 gives [padding] the same {1,4} box over [<length-percentage
+     [0,inf]>], which has no [auto], so widening the margin box must leave this
+     one alone. *)
+  neg_cursor read_declaration "padding: 0 auto";
+  neg_cursor read_declaration "padding: auto";
+
+  (* CSS Backgrounds 3 (ED) sec. 3.2, "Line Patterns: the border-style
+     properties": [border-style] is [<line-style>{1,4}], the box shorthand over
+     the four side styles, exactly as sec. 3.1 gives [border-color] and sec. 3.3
+     gives [border-width] theirs. *)
+  check_declaration ~roundtrip:true ~expected:"border-style:double dashed"
+    "border-style: double dashed";
+  check_declaration ~roundtrip:true ~expected:"border-style:solid none"
+    "border-style: solid none";
+  check_declaration ~roundtrip:true ~expected:"border-style:none none solid"
+    "border-style: none none solid";
+  check_declaration ~roundtrip:true
+    ~expected:"border-style:none dashed none solid"
+    "border-style: none dashed none solid";
+  reads_back "border-style: double dashed";
+  reads_back "border-style: none dashed none solid";
+  check_declaration ~expected:"border-style:solid" "border-style: solid";
+  check_declaration ~expected:"border-style:none" "border-style: none";
+  neg_cursor read_declaration "border-style: solid solid solid solid solid";
+  neg_cursor read_declaration "border-style: solid 1px";
+
+  (* CSS Logical 1 (ED) sec. 4.5.2, "Flow-Relative Border Styles": the
+     [border-block-style] and [border-inline-style] shorthands are
+     [<'border-top-style'>{1,2}], the first value the start edge and the second
+     the end edge, as sec. 4.5.1 gives the widths and sec. 4.5.3 the colours. *)
+  check_declaration ~roundtrip:true ~expected:"border-block-style:dashed double"
+    "border-block-style: dashed double";
+  check_declaration ~roundtrip:true
+    ~expected:"border-inline-style:dashed double"
+    "border-inline-style: dashed double";
+  check_declaration ~roundtrip:true ~expected:"border-inline-style:solid none"
+    "border-inline-style: solid none";
+  reads_back "border-block-style: dashed double";
+  reads_back "border-inline-style: dashed double";
+  check_declaration ~expected:"border-block-style:solid"
+    "border-block-style: solid";
+  check_declaration ~expected:"border-inline-style:dashed"
+    "border-inline-style: dashed";
+  (* A third value is outside {1,2}; the sibling widths already stop there. *)
+  neg_cursor read_declaration "border-inline-style: solid dashed dotted";
+  neg_cursor read_declaration "border-block-style: solid dashed dotted";
+
+  (* CSS Backgrounds 3 (ED) sec. 4.1, "Curve Radii: the border-radius
+     properties": each corner longhand is [<length-percentage [0,inf]>{1,2}],
+     "The first value is the horizontal radius, the second the vertical radius."
+     The 11 March 2024 CR draft numbers both sections the same way. *)
+  check_declaration ~roundtrip:true ~expected:"border-top-left-radius:1px 5px"
+    "border-top-left-radius: 1px 5px";
+  check_declaration ~roundtrip:true
+    ~expected:"border-bottom-right-radius:10%20%"
+    "border-bottom-right-radius: 10% 20%";
+  check_declaration ~roundtrip:true
+    ~expected:"border-start-start-radius:1px 5px"
+    "border-start-start-radius: 1px 5px";
+  reads_back "border-top-left-radius: 1px 5px";
+  reads_back "border-bottom-right-radius: 10% 20%";
+  check_declaration ~expected:"border-top-left-radius:1px"
+    "border-top-left-radius: 1px";
+  check_declaration ~expected:"border-top-left-radius:50%"
+    "border-top-left-radius: 50%";
+  (* The shorthand already spelled both axes across the slash, and keeps to
+     it. *)
+  check_declaration ~expected:"border-radius:10%/20%" "border-radius: 10% / 20%";
+  (* [0,inf] bars a negative radius, and a third value is outside {1,2}. *)
+  neg_cursor read_declaration "border-top-left-radius: -1px";
+  neg_cursor read_declaration "border-top-left-radius: 1px 2px 3px"
+
 let declaration_tests =
   [
     (* Core declaration type testing *)
@@ -5418,6 +5529,7 @@ let declaration_tests =
     test_case "flexbox flex+basis" `Quick flexbox_flex_and_basis;
     test_case "flexbox alignment" `Quick flexbox_alignment;
     test_case "borders" `Quick borders;
+    test_case "multi-value grammars" `Quick multi_value_grammars;
     test_case "outline line-width" `Quick outline_line_width;
     test_case "border line-width" `Quick border_line_width;
     test_case "border line-style" `Quick border_line_style;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -941,6 +941,10 @@ let check_logical_border_color =
   check_value_cursor "logical_border_color" read_logical_border_color
     pp_logical_border_color
 
+let check_logical_border_style =
+  check_value_cursor "logical_border_style" read_logical_border_style
+    pp_logical_border_style
+
 let check_logical_border_width =
   check_value_cursor "logical_border_width" read_logical_border_width
     pp_logical_border_width
@@ -4835,6 +4839,7 @@ let spec_generated_box_layout_edges () =
   check_line_fit_edge "text alphabetic";
   check_line_fit_edge_keyword "ideographic-ink";
   check_logical_border_color "red blue";
+  check_logical_border_style "solid dashed";
   check_logical_border_width "1px 2px";
   decl_optimizes ~prop:"border-inline-color" ~held:"red blue" ~into:"red #00f"
     "red blue";
@@ -4878,6 +4883,7 @@ let spec_generated_box_layout_edges () =
   neg_cursor read_line_fit_edge "text text";
   neg_cursor read_line_fit_edge_keyword "baseline";
   neg_cursor ~allow_partial:true read_logical_border_color "red blue green";
+  neg_cursor ~allow_partial:true read_logical_border_style "solid dashed dotted";
   neg_cursor ~allow_partial:true read_logical_border_width "1px 2px 3px";
   neg_cursor read_min_intrinsic_sizing "legacy legacy";
   neg_cursor read_min_intrinsic_sizing_keyword "zero";


### PR DESCRIPTION
`margin` rejected a leading `auto`, and `border-style`, the logical border-style pair and the corner radii each took one value where the grammar allows more, so cascade could not read sheets a browser accepts. The manifest rows that declared those forms invalid encoded cascade's old readers rather than the spec, and are corrected here with citations.

`Css.border_inline_style` and `Css.border_block_style` take a `logical_border_style` now, which is breaking, and `--minify` composes multi-value `border-style` boxes it previously declined to emit.
