### PR TITLE
test: put the property grammar manifest to a browser

### DIFF
--- a/test/spec/browser/dune
+++ b/test/spec/browser/dune
@@ -1,0 +1,35 @@
+; The property grammar manifest, checked against a headless browser: every
+; positive must be valid CSS to it and every negative invalid, so a row cannot
+; be written until cascade agrees with it. Skips, with status 0, when node or a
+; browser is missing.
+;
+; The chrome and node probing is the one in test/render, shared rather than
+; rewritten; only the page script is new, because no existing one answers
+; whether a declaration is valid.
+
+(copy_files#
+ (files ../../render/browser.ml*))
+
+(copy_files#
+ (files ../../render/json.ml*))
+
+(executable
+ (name property_vectors)
+ (libraries cascade_spec_inventory fmt unix))
+
+; The executable reads its page script at run time, so it has to sit next to it
+; in the build directory.
+
+(rule
+ (alias default)
+ (deps
+  (glob_files *.js))
+ (action (progn)))
+
+(rule
+ (alias runtest)
+ (deps
+  (glob_files *.js)
+  property_vectors.exe)
+ (action
+  (run %{exe:property_vectors.exe})))

--- a/test/spec/browser/property_vectors.ml
+++ b/test/spec/browser/property_vectors.ml
@@ -1,0 +1,684 @@
+(* Every vector in the property grammar manifest, put to a headless browser.
+
+   The manifest is the largest hand-written oracle in the suite. Nothing in it
+   is derived from cascade, but nothing checked it against anything either, so a
+   row could be written until cascade agreed with it and the suite would stay
+   green. A negative is where that hides: cascade rejects the value, the row
+   calls it invalid, the test passes, and a reader limitation reads as a grammar
+   rule.
+
+   This run gives the manifest a source of truth that is not cascade. Every
+   positive must be valid CSS to a browser and every negative must be invalid to
+   it, and the exceptions are enumerated below with the spec text that justifies
+   each one, so an excuse cannot be added without saying what it is for.
+
+   Skips cleanly, with status 0, when node or a headless Chromium is missing.
+   CASCADE_NO_BROWSER silences the run, and a silenced gate is not a pass: only
+   the value that says so exits 0. *)
+
+let ( // ) = Filename.concat
+
+(* ===== What the browser cannot arbitrate ===== *)
+
+(* Chrome implements none of these, so it accepts no vector for them and the
+   spec is their only oracle. The list is checked both ways below: a name that
+   becomes implemented, and a name that stops being, are both reported rather
+   than skipped in silence. *)
+let unarbitrable =
+  [
+    "caret";
+    "nav-up";
+    "nav-down";
+    "nav-left";
+    "nav-right";
+    "initial-letter-align";
+    "initial-letter-wrap";
+    "inline-sizing";
+    "line-fit-edge";
+    "line-height-step";
+    "margin-trim";
+    "mask-border";
+    "min-intrinsic-sizing";
+    "ruby-merge";
+    "text-decoration-skip";
+    "text-decoration-skip-box";
+    "text-decoration-skip-inset";
+    "text-decoration-skip-self";
+    "text-decoration-skip-spaces";
+    "text-emphasis-skip";
+    "glyph-orientation-vertical";
+    "image-resolution";
+    "font-synthesis-position";
+    "-moz-appearance";
+    "-moz-osx-font-smoothing";
+    "-ms-filter";
+    "-o-transition";
+    "-webkit-backdrop-filter";
+    "-webkit-hyphens";
+    "-webkit-mask-source-type";
+    "-webkit-text-decoration";
+    "-webkit-text-decoration-color";
+  ]
+
+(* ===== The exceptions ===== *)
+
+(* One vector the browser and the manifest disagree about, and the spec text
+   that decides it. Every entry has to be used: an entry that excuses nothing is
+   reported, so a browser that catches up, or a row that drops the value, takes
+   its excuse with it. *)
+type excuse = { properties : string list; value : string; why : string }
+
+let sizing =
+  [
+    "width";
+    "height";
+    "min-width";
+    "min-height";
+    "max-width";
+    "max-height";
+    "inline-size";
+    "min-inline-size";
+    "max-inline-size";
+    "block-size";
+    "min-block-size";
+    "max-block-size";
+    "flex-basis";
+  ]
+
+(* Positives Chrome rejects. Each is grammar a specification defines and Chrome
+   has not implemented, so the manifest is ahead of the browser rather than
+   wrong. The citation is the whole justification: without it an entry is a
+   place for a mistaken row to hide. *)
+let spec_ahead : excuse list =
+  [
+    {
+      properties = sizing;
+      value = "fit-content(20rem)";
+      why =
+        "CSS Sizing 4 sec. 3.2 adds fit-content() to <box-size>, which every \
+         sizing property takes; Chrome has only the bare fit-content keyword";
+    };
+    {
+      properties = [ "background"; "background-image" ];
+      value = "cross-fade(url(a.png) 40%, url(b.png))";
+      why =
+        "CSS Images 4 sec. 2.6: cross-fade() = cross-fade( <cf-image># ); \
+         Chrome ships only -webkit-cross-fade()";
+    };
+    {
+      properties = [ "text-decoration-thickness" ];
+      value = "hairline";
+      why =
+        "CSS Text Decoration 4 sec. 2.4 takes <line-width>, and CSS Borders 4 \
+         sec. 2.3 defines <line-width> = <length [0,inf]> | hairline | thin | \
+         medium | thick";
+    };
+    {
+      properties = [ "text-decoration-thickness" ];
+      value = "thin";
+      why = "CSS Borders 4 sec. 2.3: thin is a <line-width>";
+    };
+    {
+      properties = [ "text-decoration-thickness" ];
+      value = "thick";
+      why = "CSS Borders 4 sec. 2.3: thick is a <line-width>";
+    };
+    {
+      properties = [ "overflow-clip-margin" ];
+      value = "0";
+      why =
+        "CSS Overflow 4 sec. 3.2: <visual-box> || <length>, and a unitless \
+         zero is a <length>; Chrome takes only a dimension";
+    };
+    {
+      properties = [ "overflow-clip-margin" ];
+      value = "calc(1rem + 2px)";
+      why =
+        "CSS Values 4 sec. 10.1 admits a math function wherever a <length> is \
+         accepted, which CSS Overflow 4 sec. 3.2 is; Chrome takes only a \
+         dimension";
+    };
+    {
+      properties = [ "text-align" ];
+      value = "match-parent";
+      why =
+        "CSS Text 4 sec. 7.1 lists match-parent; Chrome ships only \
+         -webkit-match-parent";
+    };
+    {
+      properties = [ "text-transform" ];
+      value = "full-width";
+      why =
+        "CSS Text 4 sec. 2.1: none | [ capitalize | uppercase | lowercase ] || \
+         full-width || full-size-kana | math-auto";
+    };
+    {
+      properties = [ "text-overflow" ];
+      value = "\"...\"";
+      why =
+        "CSS Overflow 4 sec. 4.1: [ clip | ellipsis | <string> | fade | \
+         <fade()> ]{1,2}";
+    };
+    {
+      properties = [ "text-overflow" ];
+      value = "clip ellipsis";
+      why = "CSS Overflow 4 sec. 4.1: the production repeats {1,2}";
+    };
+    {
+      properties = [ "text-combine-upright" ];
+      value = "digits";
+      why =
+        "CSS Writing Modes 4 sec. 9.1: none | all | [ digits <integer [2,4]>? \
+         ]; Chrome has only none and all";
+    };
+    {
+      properties = [ "text-combine-upright" ];
+      value = "digits 2";
+      why = "CSS Writing Modes 4 sec. 9.1: the integer ranges over [2,4]";
+    };
+    {
+      properties = [ "text-combine-upright" ];
+      value = "digits 4";
+      why = "CSS Writing Modes 4 sec. 9.1: the integer ranges over [2,4]";
+    };
+    {
+      properties = [ "alignment-baseline" ];
+      value = "text-bottom";
+      why =
+        "CSS Inline 3 sec. 4.2.2: baseline | <baseline-metric>, and \
+         <baseline-metric> begins text-bottom | alphabetic | ideographic; \
+         Chrome implements the SVG 1.1 keyword set";
+    };
+    {
+      properties = [ "baseline-shift" ];
+      value = "top";
+      why =
+        "CSS Inline 3 sec. 4.2.3: <length-percentage> | sub | super | top | \
+         center | bottom";
+    };
+    {
+      properties = [ "baseline-shift" ];
+      value = "center";
+      why = "CSS Inline 3 sec. 4.2.3 lists center";
+    };
+    {
+      properties = [ "baseline-shift" ];
+      value = "bottom";
+      why = "CSS Inline 3 sec. 4.2.3 lists bottom";
+    };
+    {
+      properties = [ "grid-template-rows" ];
+      value = "masonry";
+      why =
+        "the CSS Grid 3 Working Draft of 2024 added masonry to \
+         grid-template-rows, and Firefox ships it; the current draft has \
+         replaced it with display: grid-lanes, so this row is the one entry \
+         here that wants a decision rather than a browser";
+    };
+    {
+      properties = [ "user-select"; "-webkit-user-select" ];
+      value = "contain";
+      why =
+        "CSS UI 4 sec. 6.1: auto | text | none | contain | all; \
+         -webkit-user-select is the browser's legacy name for the same \
+         property";
+    };
+    {
+      properties = [ "font-synthesis" ];
+      value = "style small-caps position";
+      why =
+        "CSS Fonts 4 sec. 2.8.5: none | [ weight || style || small-caps || \
+         position ]; Chrome has no font-synthesis-position";
+    };
+    {
+      properties = [ "font-synthesis-style" ];
+      value = "oblique-only";
+      why = "CSS Fonts 4 sec. 2.8.2: auto | none | oblique-only";
+    };
+    {
+      properties = [ "ruby-position" ];
+      value = "alternate";
+      why =
+        "CSS Ruby 1 sec. 4.1: [ alternate || [ over | under ] ] | \
+         inter-character; Chrome has only over and under";
+    };
+    {
+      properties = [ "ruby-position" ];
+      value = "alternate over";
+      why = "CSS Ruby 1 sec. 4.1: alternate combines with over under ||";
+    };
+    {
+      properties = [ "ruby-position" ];
+      value = "inter-character";
+      why = "CSS Ruby 1 sec. 4.1 lists inter-character";
+    };
+    {
+      properties = [ "image-rendering" ];
+      value = "smooth";
+      why =
+        "CSS Images 3 sec. 5.2: auto | smooth | high-quality | pixelated | \
+         crisp-edges";
+    };
+    {
+      properties = [ "-webkit-mask-clip" ];
+      value = "no-clip";
+      why =
+        "CSS Masking 1 sec. 7.5: [ <coord-box> | no-clip ]#; Chrome takes \
+         no-clip on mask-clip but not on its own -webkit- alias of it";
+    };
+    {
+      properties = [ "stroke-linejoin" ];
+      value = "miter-clip";
+      why =
+        "SVG Strokes sec. 2.6: miter | miter-clip | round | bevel | arcs; \
+         Chrome has miter, round and bevel";
+    };
+    {
+      properties = [ "stroke-linejoin" ];
+      value = "arcs";
+      why = "SVG Strokes sec. 2.6 lists arcs";
+    };
+    {
+      properties = [ "vector-effect" ];
+      value = "non-scaling-size";
+      why =
+        "SVG 2 sec. 8.13: none | [ non-scaling-stroke | non-scaling-size | \
+         non-rotation | fixed-position ]+ [ viewport | screen ]?; Chrome has \
+         only non-scaling-stroke";
+    };
+    {
+      properties = [ "vector-effect" ];
+      value = "non-rotation";
+      why = "SVG 2 sec. 8.13 lists non-rotation";
+    };
+    {
+      properties = [ "vector-effect" ];
+      value = "fixed-position";
+      why = "SVG 2 sec. 8.13 lists fixed-position";
+    };
+    {
+      properties = [ "vector-effect" ];
+      value = "non-scaling-stroke screen";
+      why = "SVG 2 sec. 8.13: the effect list is followed by viewport | screen";
+    };
+    {
+      properties = [ "vector-effect" ];
+      value = "non-scaling-stroke fixed-position";
+      why = "SVG 2 sec. 8.13: the effects themselves repeat with +";
+    };
+  ]
+
+(* Negatives Chrome accepts. Each is a value no specification grants, kept
+   invalid on purpose. *)
+let lenient : excuse list =
+  [
+    {
+      properties = [ "resize" ];
+      value = "auto";
+      why =
+        "CSS UI 4 sec. 4.1: none | both | horizontal | vertical | block | \
+         inline. Chrome accepts auto, no specification defines it";
+    };
+    {
+      properties = [ "text-orientation" ];
+      value = "sideways-right";
+      why =
+        "CSS Writing Modes 4 sec. 5.1: mixed | upright | sideways. \
+         sideways-right is a compatibility alias browsers may keep, not \
+         grammar";
+    };
+    {
+      properties = [ "alignment-baseline" ];
+      value = "auto";
+      why =
+        "CSS Inline 3 sec. 4.2.2: baseline | <baseline-metric>, and no arm is \
+         auto. Chrome accepts it from the SVG 1.1 grammar";
+    };
+  ]
+
+(* ===== Jobs ===== *)
+
+type kind = Positive | Negative | Probe
+type job = { id : string; property : string; value : string; kind : kind }
+
+(* Any real property takes a CSS-wide keyword, so this answers "does the browser
+   implement this property at all" without asking about a grammar. *)
+let probe_value = "inherit"
+let unarbitrable_property name = List.exists (String.equal name) unarbitrable
+
+let jobs () =
+  let n = ref 0 in
+  let fresh () =
+    incr n;
+    string_of_int !n
+  in
+  List.concat_map
+    (fun (row : Cascade_spec_inventory.Property_grammar.row) ->
+      let probe =
+        {
+          id = fresh ();
+          property = row.property;
+          value = probe_value;
+          kind = Probe;
+        }
+      in
+      if unarbitrable_property row.property then [ probe ]
+      else
+        probe
+        :: List.map
+             (fun value ->
+               {
+                 id = fresh ();
+                 property = row.property;
+                 value;
+                 kind = Positive;
+               })
+             row.positives
+        @ List.map
+            (fun value ->
+              { id = fresh (); property = row.property; value; kind = Negative })
+            row.negatives)
+    Cascade_spec_inventory.Property_grammar.rows
+
+(* ===== The driver ===== *)
+
+type verdict = { set_property : bool; supports : bool; error : string option }
+
+let read_lines ic =
+  let rec loop acc =
+    match input_line ic with
+    | line -> loop (line :: acc)
+    | exception End_of_file -> List.rev acc
+  in
+  loop []
+
+let run_driver ~node ~chrome ~script ~jobs ~work =
+  let errors = work // "vectors.err" in
+  let cmd =
+    String.concat " "
+      [
+        String.concat "" [ "CHROME="; Filename.quote chrome ];
+        Filename.quote node;
+        Filename.quote script;
+        Filename.quote jobs;
+        Filename.quote work;
+        String.concat "" [ "2>"; Filename.quote errors ];
+      ]
+  in
+  let ic = Unix.open_process_in cmd in
+  let lines = read_lines ic in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> Ok lines
+  | _ ->
+      let ic = open_in errors in
+      let text = read_lines ic in
+      close_in ic;
+      Error (String.concat "\n" text)
+
+let parse_driver_output lines =
+  let table = Hashtbl.create 4096 in
+  List.iter
+    (fun line ->
+      match String.split_on_char '\t' line with
+      | [ "v"; id; s; c ] ->
+          Hashtbl.replace table id
+            {
+              set_property = String.equal s "1";
+              supports = String.equal c "1";
+              error = None;
+            }
+      | "x" :: id :: rest ->
+          Hashtbl.replace table id
+            {
+              set_property = false;
+              supports = false;
+              error = Some (String.concat "\t" rest);
+            }
+      | _ -> ())
+    lines;
+  table
+
+(* ===== Judging ===== *)
+
+type outcome =
+  | Confirmed  (** the browser and the manifest agree *)
+  | Excused of string  (** they differ, and an entry above says why *)
+  | Wrong of string  (** they differ, and nothing says why *)
+  | Split  (** the two oracles disagree, so neither is the answer *)
+  | Unanswered of string  (** the browser did not answer *)
+
+let hits = Hashtbl.create 64
+let excuse_key property value = String.concat "\000" [ property; value ]
+
+let excuse table property value =
+  let covers (e : excuse) =
+    String.equal e.value value
+    && List.exists (String.equal property) e.properties
+  in
+  match List.find_opt covers table with
+  | None -> None
+  | Some e ->
+      Hashtbl.replace hits (excuse_key property value) ();
+      Some e.why
+
+let judge job verdict =
+  match verdict.error with
+  | Some e -> Unanswered e
+  | None when not (Bool.equal verdict.set_property verdict.supports) -> Split
+  | None -> (
+      let accepted = verdict.supports in
+      match job.kind with
+      | Probe -> Confirmed
+      | Positive when accepted -> Confirmed
+      | Negative when not accepted -> Confirmed
+      | Positive -> (
+          match excuse spec_ahead job.property job.value with
+          | Some why -> Excused why
+          | None -> Wrong "the browser rejects this positive")
+      | Negative -> (
+          match excuse lenient job.property job.value with
+          | Some why -> Excused why
+          | None -> Wrong "the browser accepts this negative"))
+
+(* ===== Reporting ===== *)
+
+let failures = ref 0
+let confirmed = ref 0
+let excused = ref 0
+
+let fail line =
+  incr failures;
+  Fmt.pr "FAIL %s@." line
+
+let describe job = String.concat "" [ job.property; ": "; job.value ]
+
+let branch = function
+  | Positive -> "positive"
+  | Negative -> "negative"
+  | Probe -> "probe"
+
+let record job outcome =
+  match outcome with
+  | Confirmed -> (
+      (* A probe only says whether the browser has the property; it is not a
+         vector, so it is not something the browser confirmed. *)
+      match job.kind with
+      | Probe -> ()
+      | Positive | Negative -> incr confirmed)
+  | Excused _ -> incr excused
+  | Wrong why -> fail (String.concat "" [ describe job; ": "; why ])
+  | Split ->
+      fail
+        (String.concat ""
+           [
+             describe job;
+             ": setProperty and CSS.supports disagree about this ";
+             branch job.kind;
+           ])
+  | Unanswered e ->
+      fail (String.concat "" [ describe job; ": the browser raised: "; e ])
+
+(* An entry that excuses nothing is a claim nobody checks any more. *)
+let check_unused table label =
+  List.iter
+    (fun (e : excuse) ->
+      let used =
+        List.exists
+          (fun property -> Hashtbl.mem hits (excuse_key property e.value))
+          e.properties
+      in
+      if not used then
+        fail
+          (String.concat ""
+             [
+               label;
+               " excuses nothing any more: ";
+               e.value;
+               " (";
+               String.concat ", " e.properties;
+               ")";
+             ]))
+    table
+
+(* The skip list has to describe the browser in front of it, in both
+   directions. *)
+let check_unarbitrable implemented =
+  List.iter
+    (fun (row : Cascade_spec_inventory.Property_grammar.row) ->
+      let listed = unarbitrable_property row.property in
+      let known =
+        match Hashtbl.find_opt implemented row.property with
+        | Some b -> b
+        | None -> false
+      in
+      if listed && known then
+        fail
+          (String.concat ""
+             [
+               row.property;
+               ": listed as unarbitrable, but the browser implements it";
+             ]);
+      if (not listed) && not known then
+        fail
+          (String.concat ""
+             [
+               row.property;
+               ": the browser does not implement it, so it cannot arbitrate \
+                this row";
+             ]))
+    Cascade_spec_inventory.Property_grammar.rows
+
+(* ===== Skipping ===== *)
+
+(* Silencing a gate is not the same as passing it, so only the value that says
+   the run checks nothing exits 0. A machine with no browser still skips: there
+   is nothing there to silence. *)
+let acknowledged = "unchecked"
+
+let check_suppression () =
+  match Browser.getenv "CASCADE_NO_BROWSER" with
+  | None -> ()
+  | Some v when String.equal v acknowledged ->
+      Browser.skip "property_vectors"
+        (String.concat ""
+           [
+             "CASCADE_NO_BROWSER="; acknowledged; ", so this run checks nothing";
+           ])
+  | Some v ->
+      prerr_endline
+        (String.concat ""
+           [
+             "FAIL: property_vectors is suppressed by CASCADE_NO_BROWSER=";
+             v;
+             "; a gate that did not run is not a pass. Set CASCADE_NO_BROWSER=";
+             acknowledged;
+             " to exit 0 and say so.";
+           ]);
+      exit 1
+
+(* ===== Main ===== *)
+
+let write_jobs file jobs =
+  let oc = open_out file in
+  output_string oc
+    (Json.to_string
+       (Json.Arr
+          (List.map
+             (fun j ->
+               Json.Obj
+                 [
+                   ("id", Json.Str j.id);
+                   ("property", Json.Str j.property);
+                   ("value", Json.Str j.value);
+                 ])
+             jobs)));
+  close_out oc
+
+let () =
+  check_suppression ();
+  let node =
+    match Browser.node_binary () with
+    | Some n -> n
+    | None -> Browser.skip "property_vectors" "no node"
+  in
+  let chrome =
+    match Browser.chrome_binary () with
+    | Some c -> c
+    | None -> Browser.skip "property_vectors" "no headless browser"
+  in
+  let jobs = jobs () in
+  let script_dir = Filename.dirname Sys.executable_name in
+  let work = Filename.get_temp_dir_name () // "cascade-property-vectors" in
+  (try Unix.mkdir work 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let jobs_file = work // "jobs.json" in
+  write_jobs jobs_file jobs;
+  let started = Unix.gettimeofday () in
+  let lines =
+    match
+      run_driver ~node ~chrome
+        ~script:(script_dir // "vectors.js")
+        ~jobs:jobs_file ~work
+    with
+    | Ok lines -> lines
+    | Error err ->
+        prerr_endline
+          (String.concat ""
+             [ "property_vectors: the browser driver failed:\n"; err ]);
+        exit 1
+  in
+  let elapsed = Unix.gettimeofday () -. started in
+  let table = parse_driver_output lines in
+  let implemented = Hashtbl.create 512 in
+  List.iter
+    (fun job ->
+      match Hashtbl.find_opt table job.id with
+      | None ->
+          fail
+            (String.concat ""
+               [ describe job; ": the browser did not answer for this vector" ])
+      | Some verdict ->
+          (match job.kind with
+          | Probe ->
+              Hashtbl.replace implemented job.property
+                (verdict.supports && verdict.set_property)
+          | Positive | Negative -> ());
+          record job (judge job verdict))
+    jobs;
+  check_unarbitrable implemented;
+  check_unused spec_ahead "a spec-ahead-of-the-browser entry";
+  check_unused lenient "a browser-leniency entry";
+  let is_probe job =
+    match job.kind with Probe -> true | Positive | Negative -> false
+  in
+  let probes = List.length (List.filter is_probe jobs) in
+  Fmt.pr
+    "property_vectors: %d vector(s) over %d row(s), %d of them the browser \
+     cannot arbitrate, %.1fs@."
+    (List.length jobs - probes)
+    (List.length Cascade_spec_inventory.Property_grammar.rows)
+    (List.length unarbitrable) elapsed;
+  Fmt.pr "  confirmed: %d, excused: %d, failures: %d@." !confirmed !excused
+    !failures;
+  (* A run that confirms nothing is not a clean run, it is a blind one. *)
+  if !confirmed = 0 then fail "not one vector was confirmed against the browser";
+  if !failures > 0 then exit 1

--- a/test/spec/browser/property_vectors.ml
+++ b/test/spec/browser/property_vectors.ml
@@ -216,6 +216,14 @@ let spec_ahead : excuse list =
          here that wants a decision rather than a browser";
     };
     {
+      properties = [ "outline-color" ];
+      value = "auto";
+      why =
+        "CSS UI 4 sec. 3.4: auto | <'border-top-color'>, and auto is the \
+         initial value; Chrome computes that initial value without accepting \
+         the keyword";
+    };
+    {
       properties = [ "user-select"; "-webkit-user-select" ];
       value = "contain";
       why =

--- a/test/spec/browser/vectors.js
+++ b/test/spec/browser/vectors.js
@@ -1,0 +1,104 @@
+// Ask a headless browser whether each property grammar vector is valid CSS.
+//
+//   node vectors.js JOBS.json WORKDIR
+//
+// JOBS.json is written by property_vectors.exe: an array of {id, property,
+// value}. Each job is put to two independent oracles inside the page:
+//
+//   s   el.style.setProperty(property, value) leaves a non-empty block
+//   c   CSS.supports(property, value)
+//
+// Both are asked of every job. The manifest is judged by their agreement, so a
+// vector they disagree on is a fact about the browser rather than about the
+// manifest, and the run reports it instead of picking a side.
+//
+// Output is TSV on stdout, one record per line:
+//   v <job> <s> <c>      each 0 or 1
+//   x <job> <error>
+// A tab never appears in a job id or in either verdict, so the fields are
+// unambiguous.
+//
+// All the jobs of one chunk share a single browser launch. No layout or style
+// recalculation is involved: setProperty fills the inline block itself.
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const CHROME = process.env.CHROME;
+const jobsFile = process.argv[2];
+const workDir = process.argv[3];
+const CHUNK_BYTES = 512 * 1024;
+
+// Runs inside the page.
+const HARNESS = `
+function vJob(doc, job, out) {
+  var s = 0, c = 0;
+  var el = doc.createElement('div');
+  try {
+    el.style.setProperty(job.property, job.value);
+    s = el.style.length > 0 ? 1 : 0;
+  } catch (e) {
+    out.push(['x', job.id, String((e && e.message) || e)].join('\\t'));
+    return;
+  }
+  try { c = CSS.supports(job.property, job.value) ? 1 : 0; }
+  catch (e) {
+    out.push(['x', job.id, String((e && e.message) || e)].join('\\t'));
+    return;
+  }
+  out.push(['v', job.id, s, c].join('\\t'));
+}
+function vMain(jobs) {
+  var out = [];
+  jobs.forEach(function (job) {
+    try { vJob(document, job, out); }
+    catch (e) { out.push(['x', job.id, String((e && e.message) || e)].join('\\t')); }
+  });
+  var text = out.join('\\n');
+  document.body.setAttribute('data-v',
+    btoa(unescape(encodeURIComponent(text))));
+}
+`;
+
+function page(jobs) {
+  const payload = JSON.stringify(jobs).replace(/</g, '\\u003c');
+  return '<!doctype html><html><head><meta charset="utf-8"></head><body>' +
+    '<script id="v-jobs" type="application/json">' + payload + '</script>' +
+    '<script>' + HARNESS +
+    'vMain(JSON.parse(document.getElementById("v-jobs").textContent));</script>' +
+    '</body></html>';
+}
+
+function chunks(jobs) {
+  const out = [];
+  let cur = [], size = 0;
+  for (const job of jobs) {
+    const n = JSON.stringify(job).length;
+    if (cur.length && size + n > CHUNK_BYTES) { out.push(cur); cur = []; size = 0; }
+    cur.push(job);
+    size += n;
+  }
+  if (cur.length) out.push(cur);
+  return out;
+}
+
+function run(jobs, index) {
+  // Absolute: a file:// URL has no notion of the process's directory.
+  const file = path.resolve(workDir, 'vectors-' + index + '.html');
+  fs.writeFileSync(file, page(jobs));
+  const dom = execFileSync(CHROME, [
+    '--headless', '--disable-gpu', '--no-sandbox',
+    '--virtual-time-budget=120000', '--dump-dom', 'file://' + file,
+  ], { encoding: 'utf8', maxBuffer: 1 << 28 });
+  const m = dom.match(/data-v="([^"]*)"/);
+  if (!m) throw new Error('the page produced no result for chunk ' + index);
+  return Buffer.from(m[1], 'base64').toString('utf8');
+}
+
+const jobs = JSON.parse(fs.readFileSync(jobsFile, 'utf8'));
+const parts = chunks(jobs);
+parts.forEach(function (chunk, i) {
+  const text = run(chunk, i);
+  if (text.length) process.stdout.write(text + '\n');
+});

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -428,16 +428,38 @@ let matrix =
         "-webkit-text-fill-color";
         "-webkit-text-stroke-color";
         "column-rule-color";
-        "outline-color";
-        "fill";
-        "stroke";
-        "accent-color";
-        "caret-color";
         "stop-color";
         "flood-color";
         "lighting-color";
       ]
       [ "red"; "currentColor"; "rgb(0 0 0 / 50%)" ]
+      [ "1px"; "red blue" ]
+    (* SVG 2 sec. 13.2: <paint> = none | <color> | <url> [none | <color>]? |
+       context-fill | context-stroke, none of which a <color> property takes. *)
+  @ rows_for [ "fill"; "stroke" ]
+      [
+        "none";
+        "red";
+        "currentColor";
+        "url(#p)";
+        "url(#p) red";
+        "context-fill";
+        "context-stroke";
+      ]
+      [ "1px"; "auto"; "red blue" ]
+    (* CSS UI 4 sec. 5.2.1: auto | <color> [ auto | <color> ]?, with auto the
+       initial value, so a third component is the first invalid one. *)
+  @ rows_for [ "caret-color" ]
+      [ "auto"; "red"; "currentColor"; "rgb(0 0 0 / 50%)" ]
+      [ "1px"; "red blue green" ]
+    (* CSS UI 4 sec. 7.1: auto | <color>, with auto the initial value. *)
+  @ rows_for [ "accent-color" ]
+      [ "auto"; "red"; "currentColor"; "rgb(0 0 0 / 50%)" ]
+      [ "1px"; "red blue" ]
+    (* CSS UI 4 sec. 3.4: auto | <'border-top-color'>, with auto the initial
+       value. *)
+  @ rows_for [ "outline-color" ]
+      [ "auto"; "red"; "currentColor"; "rgb(0 0 0 / 50%)" ]
       [ "1px"; "red blue" ]
   @ [
       {
@@ -446,6 +468,26 @@ let matrix =
         negatives = [ "1px"; "red blue green black white" ];
       };
     ]
+    (* CSS Backgrounds 3 (ED) sec. 3.2 gives [border-style] the value
+       [<line-style>{1,4}], the box over the four side styles that sec. 3.1
+       gives [border-color]. *)
+  @ rows_for [ "border-style" ]
+      [
+        "none";
+        "solid";
+        "hidden";
+        "solid dashed";
+        "solid dashed dotted";
+        "solid dashed dotted double";
+        "none solid dashed double";
+      ]
+      [ "foo"; "solid dashed dotted double hidden" ]
+    (* CSS Logical 1 (ED) sec. 4.5.2 gives both flow-relative shorthands the
+       value [<'border-top-style'>{1,2}], the start edge then the end edge. *)
+  @ rows_for
+      [ "border-inline-style"; "border-block-style" ]
+      [ "none"; "solid"; "hidden"; "solid dashed" ]
+      [ "foo"; "solid dashed dotted" ]
   @ rows_for
       [
         "border-top-style";
@@ -459,29 +501,7 @@ let matrix =
       ]
       [ "none"; "solid"; "dashed"; "hidden" ]
       [ "solid dashed"; "foo" ]
-  (* CSS Backgrounds 3 (ED) sec. 3.2 gives [border-style] the value
-     [<line-style>{1,4}], the box over the four side styles that sec. 3.1 gives
-     [border-color]. *)
-  @ [
-      {
-        property = "border-style";
-        positives =
-          [
-            "none";
-            "solid";
-            "solid dashed";
-            "solid dashed dotted";
-            "solid dashed dotted double";
-          ];
-        negatives = [ "foo"; "solid dashed dotted double hidden" ];
-      };
-    ]
-  (* CSS Logical 1 (ED) sec. 4.5.2 gives both flow-relative shorthands the value
-     [<'border-top-style'>{1,2}], the start edge then the end edge. *)
-  @ rows_for
-      [ "border-inline-style"; "border-block-style" ]
-      [ "none"; "solid"; "solid dashed" ]
-      [ "foo"; "solid dashed dotted" ]
+    (* CSS Box 4: the padding longhands are one <length-percentage [0,inf]>. *)
   @ rows_for
       [
         "padding-left";
@@ -492,22 +512,12 @@ let matrix =
         "padding-inline-end";
         "padding-block-start";
         "padding-block-end";
-        "stroke-width";
-        "outline-width";
-        "outline-offset";
-        "letter-spacing";
-        "text-indent";
-        "word-spacing";
-        "line-height-step";
-        "overflow-clip-margin";
-        "offset-distance";
-        "shape-margin";
       ]
-      [ "0"; "1px"; "calc(1rem + 2px)" ]
-      [ "auto"; "red"; "1px 2px" ]
-  (* CSS Backgrounds 3 (ED) sec. 4.1 gives every corner longhand the value
-     [<length-percentage [0,inf]>{1,2}]: the horizontal radius then the vertical
-     one, a single value setting both. *)
+      [ "0"; "1px"; "10%"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "1px 2px"; "-1px" ]
+    (* CSS Backgrounds 3 (ED) sec. 4.1 gives every corner longhand the value
+       [<length-percentage [0,inf]>{1,2}]: the horizontal radius then the
+       vertical one, a single value setting both. *)
   @ rows_for
       [
         "border-top-left-radius";
@@ -519,8 +529,45 @@ let matrix =
         "border-end-start-radius";
         "border-end-end-radius";
       ]
-      [ "0"; "1px"; "1px 2px"; "calc(1rem + 2px)" ]
-      [ "auto"; "red"; "1px 2px 3px" ]
+      [ "0"; "1px"; "10%"; "1px 2px"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "1px 2px 3px"; "-1px" ]
+    (* SVG 2 sec. 13.5: stroke-width takes a bare <number> as well. *)
+  @ rows_for [ "stroke-width" ]
+      [ "0"; "1px"; "10%"; "2"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "1px 2px" ]
+    (* CSS UI 4 sec. 3.2: <line-width>, with medium the initial value. *)
+  @ rows_for [ "outline-width" ]
+      [ "thin"; "medium"; "thick"; "0"; "1px"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "1px 2px"; "-1px" ]
+    (* CSS UI 4 sec. 3.3: <length>, which may be negative and takes no
+       percentage. *)
+  @ rows_for [ "outline-offset" ]
+      [ "0"; "1px"; "-1px"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "1px 2px"; "10%" ]
+    (* CSS Text 4 sec. 8.1 and 8.2: normal | <length-percentage>, with normal
+       the initial value. *)
+  @ rows_for
+      [ "letter-spacing"; "word-spacing" ]
+      [ "normal"; "0"; "1px"; "-1px"; "10%"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "1px 2px" ]
+    (* CSS Text 4 sec. 9.1: [ <length-percentage> ] && hanging? && each-line?,
+       so the length is required and the two keywords are not. *)
+  @ rows_for [ "text-indent" ]
+      [ "0"; "1px"; "10%"; "1em hanging"; "2em each-line"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "hanging" ]
+    (* CSS Overflow 4 sec. 3.2: <visual-box> || <length>. *)
+  @ rows_for [ "overflow-clip-margin" ]
+      [ "0"; "1px"; "content-box"; "padding-box 2px"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "1px 2px" ]
+  @ rows_for
+      [ "offset-distance"; "shape-margin" ]
+      [ "0"; "1px"; "10%"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "1px 2px" ]
+    (* CSS Inline 3: line-height-step is a <length>, so a percentage is not
+       one. *)
+  @ rows_for [ "line-height-step" ]
+      [ "0"; "1px"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "1px 2px"; "10%" ]
   (* CSS Transforms 2 sec. 3: [perspective] takes [none], its initial value. CSS
      Text Decoration 4 sec. 5: [text-underline-offset] takes [auto] and may be
      negative. *)
@@ -540,10 +587,17 @@ let matrix =
       [ "margin-left"; "margin-right"; "margin-top"; "margin-bottom" ]
       [ "0"; "1px"; "10%"; "auto"; "anchor-size(width)" ]
       [ "red"; "1px 2px" ]
+    (* CSS Logical 1 sec. 4.4: <'padding-top'>{1,2}. *)
   @ rows_for
-      [ "padding-inline"; "padding-block"; "column-gap"; "row-gap" ]
-      [ "0"; "1rem"; "10%" ]
+      [ "padding-inline"; "padding-block" ]
+      [ "0"; "1rem"; "10%"; "1px 2px" ]
       [ "auto"; "1px 2px 3px"; "red" ]
+    (* CSS Gaps 1 sec. 2.1: normal | <length-percentage [0,inf]> | <line-width>,
+       one value, with normal the initial one. *)
+  @ rows_for
+      [ "column-gap"; "row-gap" ]
+      [ "normal"; "0"; "1rem"; "10%"; "calc(1rem + 2px)" ]
+      [ "auto"; "1px 2px"; "red" ]
   @ rows_for
       [ "margin-inline"; "margin-block" ]
       [ "0"; "1px"; "1px 1px"; "1px 2px"; "auto" ]
@@ -600,23 +654,27 @@ let matrix =
       ]
       [ "auto"; "0"; "1px"; "10%" ]
       [ "red"; "1px 2px"; "-1px" ]
+    (* CSS Sizing 3 sec. 3.1.1 and 3.1.2: auto | <box-size>, so none is not one
+       of them. *)
   @ rows_for
       [
         "height";
         "min-width";
         "min-height";
-        "max-width";
-        "max-height";
         "inline-size";
         "min-inline-size";
-        "max-inline-size";
         "block-size";
         "min-block-size";
-        "max-block-size";
         "flex-basis";
       ]
       [ "auto"; "10%"; "min-content"; "fit-content(20rem)"; "calc(1rem + 2px)" ]
-      [ "red"; "fit-content()"; "1px 2px" ]
+      [ "red"; "none"; "fit-content()"; "1px 2px" ]
+    (* CSS Sizing 3 sec. 3.1.3: none | <box-size>, with none the initial value
+       and no auto arm at all. *)
+  @ rows_for
+      [ "max-width"; "max-height"; "max-inline-size"; "max-block-size" ]
+      [ "none"; "10%"; "min-content"; "fit-content(20rem)"; "calc(1rem + 2px)" ]
+      [ "auto"; "red"; "fit-content()"; "1px 2px" ]
   @ rows_for
       [
         "contain-intrinsic-width";
@@ -626,9 +684,13 @@ let matrix =
       ]
       [ "none"; "100px"; "auto 300px" ]
       [ "auto"; "1px 2px"; "red" ]
+    (* CSS Backgrounds 3 sec. 3.3: <line-width>{1,4} for the box, one value for
+       each longhand. *)
+  @ rows_for [ "border-width" ]
+      [ "thin"; "medium"; "thick"; "1px"; "1px 2px"; "thin medium thick 1px" ]
+      [ "auto"; "thin medium thick 1px 2px"; "red" ]
   @ rows_for
       [
-        "border-width";
         "border-top-width";
         "border-right-width";
         "border-bottom-width";
@@ -639,7 +701,7 @@ let matrix =
         "border-block-end-width";
       ]
       [ "thin"; "medium"; "thick"; "1px" ]
-      [ "auto"; "thin medium thick 1px 2px"; "red" ]
+      [ "auto"; "1px 2px"; "red" ]
   @ [
       {
         property = "border-block";
@@ -701,14 +763,23 @@ let matrix =
       (* Filter Effects 1 sec. 6.1: blur( <length>? ). *)
       [ "none"; "blur(5px)"; "contrast(120%) brightness(.8)"; "blur()" ]
       [ "blur(red)"; "none blur(1px)" ]
-  @ rows_for
-      [
-        "transition-duration";
-        "transition-delay";
-        "animation-duration";
-        "animation-delay";
-      ]
-      [ "0s"; ".2s"; "120ms" ] [ "1px"; "1s 2s" ]
+    (* CSS Transitions 1 sec. 2.2: <time [0s,inf]>#. *)
+  @ rows_for [ "transition-duration" ]
+      [ "0s"; ".2s"; "120ms"; "0s, 1s" ]
+      [ "1px"; "1s 2s"; "-1s" ]
+    (* CSS Transitions 1 sec. 2.4: <time>#, with no lower bound. *)
+  @ rows_for [ "transition-delay" ]
+      [ "0s"; ".2s"; "120ms"; "-1s"; "0s, 1s" ]
+      [ "1px"; "1s 2s" ]
+    (* CSS Animations 2 sec. 4.1: [ auto | <time [0s,inf]> ]#, with auto the
+       initial value. *)
+  @ rows_for [ "animation-duration" ]
+      [ "auto"; "0s"; ".2s"; "120ms"; "1s, 2s" ]
+      [ "1px"; "1s 2s"; "-1s" ]
+    (* CSS Animations 2 sec. 4.8: a <time> list with no lower bound. *)
+  @ rows_for [ "animation-delay" ]
+      [ "0s"; ".2s"; "120ms"; "-1s"; "1s, 2s" ]
+      [ "1px"; "1s 2s" ]
   @ rows_for
       [ "transition-timing-function"; "animation-timing-function" ]
       [ "ease"; "linear"; "steps(4, jump-end)"; "cubic-bezier(.1,.2,.3,.4)" ]
@@ -723,15 +794,21 @@ let matrix =
         "repeat"; "no-repeat"; "repeat-x"; "space round"; "no-repeat no-repeat";
       ]
       [ "repeat no-repeat space"; "foo" ]
+    (* CSS Backgrounds 3 sec. 2.6: <bg-position>#, one position per layer. *)
   @ rows_for
+      [ "background-position"; "mask-position"; "-webkit-mask-position" ]
       [
-        "background-position";
-        "mask-position";
-        "-webkit-mask-position";
-        "object-position";
+        "center";
+        "left 10px top 20px";
+        "10% 20%";
+        "center, left top";
+        "calc(10% + 1px) 20%";
       ]
-      [ "center"; "left 10px top 20px"; "10% 20%"; "calc(10% + 1px) 20%" ]
       [ "left top center"; "foo" ]
+    (* CSS Images 3 sec. 4.6: a single <position>, with no list. *)
+  @ rows_for [ "object-position" ]
+      [ "center"; "left 10px top 20px"; "10% 20%"; "calc(10% + 1px) 20%" ]
+      [ "left top center"; "foo"; "center, center" ]
   @ rows_for
       [ "mask-size"; "-webkit-mask-size" ]
       [ "auto"; "cover"; "contain"; "10px 20%" ]

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -213,8 +213,11 @@ let matrix =
           "blur(5px) contrast(120%)";
           "drop-shadow(0 0 2px black)";
           "opacity(calc(50% + 25%))";
+          (* Filter Effects 1 sec. 6.1: blur() = blur( <length>? ), so the
+             argument may be omitted. drop-shadow() below has no such arm. *)
+          "blur()";
         ];
-      negatives = [ "blur()"; "drop-shadow()" ];
+      negatives = [ "drop-shadow()"; "blur(red)" ];
     };
     {
       property = "font";
@@ -257,10 +260,24 @@ let matrix =
       negatives = [ "underline none"; "wavy solid" ];
     };
     {
+      (* CSS Text Decoration 4 sec. 2.4: auto | from-font | <length-percentage>
+         | <line-width>. The <length-percentage> arm carries no [0,inf] range,
+         so a negative thickness is grammar; <line-width> is the CSS Borders 4
+         sec. 2.3 keyword set. *)
       property = "text-decoration-thickness";
       positives =
-        [ "auto"; "from-font"; "0"; "1px"; "10%"; "hairline"; "thin"; "thick" ];
-      negatives = [ "red"; "1px 2px"; "-1px"; "none"; "min-content"; "stretch" ];
+        [
+          "auto";
+          "from-font";
+          "0";
+          "1px";
+          "10%";
+          "-1px";
+          "hairline";
+          "thin";
+          "thick";
+        ];
+      negatives = [ "red"; "1px 2px"; "none"; "min-content"; "stretch" ];
     };
     {
       property = "white-space";
@@ -314,12 +331,18 @@ let matrix =
       negatives = [ "normal allow-discrete"; "discrete" ];
     };
     {
+      (* CSS Animations 1 sec. 3: <keyframes-name> = <custom-ident> | <string>,
+         and the exclusion covers none and the CSS-wide keywords only, so
+         [infinite] names a keyframe set after an iteration count. *)
       property = "animation";
       positives =
         [
-          "fade 1s linear 2 alternate both running"; "none"; "fade calc(1s * 2)";
+          "fade 1s linear 2 alternate both running";
+          "none";
+          "fade calc(1s * 2)";
+          "infinite infinite";
         ];
-      negatives = [ "1s 2s 3s"; "infinite infinite" ];
+      negatives = [ "1s 2s 3s"; "2 3" ];
     };
     {
       property = "grid-auto-flow";
@@ -347,9 +370,14 @@ let matrix =
       negatives = [ "start center end"; "left right" ];
     };
     {
+      (* CSS Lists 3 sec. 3.6: <'list-style-position'> || <'list-style-image'>
+         || <'list-style-type'>, and CSS Counter Styles 3 sec. 3 makes
+         <counter-style-name> a <custom-ident> excluding none, so [outside]
+         names a counter style after the position keyword. *)
       property = "list-style";
-      positives = [ "square inside"; "none"; "url(marker.png) outside" ];
-      negatives = [ "inside outside"; "square disc" ];
+      positives =
+        [ "square inside"; "none"; "inside outside"; "url(marker.png) outside" ];
+      negatives = [ "square disc"; "inside outside outside" ];
     };
     {
       property = "counter-reset";
@@ -670,8 +698,9 @@ let matrix =
         "-webkit-filter";
         "-ms-filter";
       ]
-      [ "none"; "blur(5px)"; "contrast(120%) brightness(.8)" ]
-      [ "blur()"; "none blur(1px)" ]
+      (* Filter Effects 1 sec. 6.1: blur( <length>? ). *)
+      [ "none"; "blur(5px)"; "contrast(120%) brightness(.8)"; "blur()" ]
+      [ "blur(red)"; "none blur(1px)" ]
   @ rows_for
       [
         "transition-duration";
@@ -841,9 +870,11 @@ let matrix =
         negatives = [ "clip ellipsis clip"; "auto" ];
       };
       {
+        (* CSS Text 4 sec. 5.5: <'text-wrap-mode'> || <'text-wrap-style'>, and
+           sec. 5.4 gives text-wrap-style an auto arm. *)
         property = "text-wrap";
-        positives = [ "wrap"; "nowrap"; "balance"; "pretty" ];
-        negatives = [ "wrap nowrap"; "auto" ];
+        positives = [ "wrap"; "nowrap"; "balance"; "pretty"; "auto" ];
+        negatives = [ "wrap nowrap"; "wrap wrap" ];
       };
       {
         property = "text-wrap-style";
@@ -1049,9 +1080,12 @@ let matrix =
           [ "\"a\" \"a a\""; "\"a .\" \". a\""; "\"nav/main\""; "a b" ];
       };
       {
+        (* CSS Grid 2 sec. 7.4: [ <'grid-template-rows'> / <'grid-template-
+           columns'> ], and sec. 7.2 gives grid-template-rows a none arm. *)
         property = "grid-template";
-        positives = [ "none"; "\"a a\" 1fr / 1fr 1fr"; "subgrid / subgrid" ];
-        negatives = [ "/"; "none / 1fr" ];
+        positives =
+          [ "none"; "none / 1fr"; "\"a a\" 1fr / 1fr 1fr"; "subgrid / subgrid" ];
+        negatives = [ "/"; "1fr / 1fr / 1fr" ];
       };
       {
         property = "grid-area";
@@ -1099,9 +1133,13 @@ let matrix =
         negatives = [ "span"; "1 2" ];
       };
       {
+        (* CSS Backgrounds 3 sec. 6.1: <shadow> = <color>? && [ <length>{2} ...
+           ] && inset?, so two lengths alone are a whole shadow and one is
+           not. *)
         property = "box-shadow";
-        positives = [ "none"; "0 1px 2px rgb(0 0 0 / .2)"; "inset 0 0 1px red" ];
-        negatives = [ "0 0"; "inset inset 0 0 1px" ];
+        positives =
+          [ "none"; "0 0"; "0 1px 2px rgb(0 0 0 / .2)"; "inset 0 0 1px red" ];
+        negatives = [ "0"; "inset inset 0 0 1px" ];
       };
       {
         property = "mix-blend-mode";
@@ -1291,9 +1329,17 @@ let matrix =
         negatives = [ "anchor"; "--a --b" ];
       };
       {
+        (* CSS Anchor Positioning 1 sec. 6.1: none | [ [ <dashed-ident> ||
+           <try-tactic> ] | <position-area> ]#, and || is order-free. *)
         property = "position-try-fallbacks";
-        positives = [ "none"; "--fallback"; "flip-block, --fallback" ];
-        negatives = [ "flip-block --fallback"; "," ];
+        positives =
+          [
+            "none";
+            "--fallback";
+            "flip-block --fallback";
+            "flip-block, --fallback";
+          ];
+        negatives = [ ","; "--a --b" ];
       };
       {
         property = "position-area";
@@ -1463,9 +1509,13 @@ let matrix =
         negatives = [ "none all"; "2" ];
       };
       {
+        (* CSS Syntax 3 sec. 2.2 closes an open function at EOF, so [scroll(] is
+           the valid [scroll()] and cannot be a negative. It is not a positive
+           either: the positive checks append a token after the value, and an
+           unclosed function swallows it. *)
         property = "animation-timeline";
         positives = [ "auto"; "none"; "scroll()"; "--timeline" ];
-        negatives = [ "auto none"; "scroll(" ];
+        negatives = [ "auto none"; "scroll() none" ];
       };
       {
         property = "animation-range";
@@ -1610,9 +1660,12 @@ let matrix =
         negatives = [ "visible hidden"; "none" ];
       };
       {
+        (* CSS Transitions 1 sec. 2.1: none | <single-transition-property>#,
+           where <single-transition-property> = all | <custom-ident>. The
+           exclusion clause names none, inherit and initial, not all. *)
         property = "transition-property";
-        positives = [ "none"; "all"; "opacity, transform" ];
-        negatives = [ "none, opacity"; "all, opacity" ];
+        positives = [ "none"; "all"; "opacity, transform"; "all, opacity" ];
+        negatives = [ "none, opacity"; "opacity, none" ];
       };
       {
         property = "will-change";


### PR DESCRIPTION
The manifest read as an independent spec oracle and was a mirror of cascade: a row was written until cascade agreed with it, so a negative could only ever mean "cascade rejects this". The negatives Chrome accepts are corrected here with citations, and `rows_for` gave a whole group one shared vector pair, so a group was only as correct as its narrowest member; the pooled groups are split.

The manifest test and its fuzz cases go red on that, because cascade rejects vectors the corrected rows now call valid. `column-gap: normal` is one: it shared `padding-inline`'s vectors and was never shown its own initial value.
