### PR TITLE
test: resolve the cascade against the browser

### DIFF
--- a/test/render/dune
+++ b/test/render/dune
@@ -12,9 +12,12 @@
 ;
 ; canonical_agree: a pair --diff=canonical reports identical must compute the
 ; same style in the browser for every element of a document derived from it.
+;
+; resolve_diff: the declarations Resolve says win for an element must compute
+; the same style, in the browser, as the stylesheet they came from.
 
 (executables
- (names render_diff shorthand_expand canonical_agree)
+ (names render_diff shorthand_expand canonical_agree resolve_diff)
  (libraries cascade cascade_diff fmt unix))
 
 ; The executables read their driver scripts at run time, so those have to sit
@@ -87,3 +90,14 @@
   canonical_agree.exe)
  (action
   (run %{exe:canonical_agree.exe})))
+
+(rule
+ (alias runtest)
+ (deps
+  (glob_files *.js)
+  resolve_diff.exe)
+ (action
+  (setenv
+   CASCADE_RENDER_ARTIFACTS
+   %{workspace_root}/tmp/render-diff
+   (run %{exe:resolve_diff.exe}))))

--- a/test/render/resolve_diff.js
+++ b/test/render/resolve_diff.js
@@ -1,0 +1,169 @@
+// Resolve each job's stylesheet in a headless browser twice and report, for
+// every element, every computed-style property the two legs disagree on.
+//
+//   node resolve_diff.js JOBS.json WORKDIR
+//
+// JOBS.json is written by resolve_diff.exe: an array of jobs, each carrying the
+// document, the stylesheet, and the declarations cascade resolved for every
+// element of it.
+//
+// The first leg puts the stylesheet in a <style> element and lets the browser
+// cascade it. The second empties that element and writes cascade's answer into
+// each element's style attribute instead. Both legs are the same document, the
+// same engine and the same user-agent style, so a property the two spell
+// differently is a declaration cascade let win that the browser did not, or
+// the other way round.
+//
+// Output is TSV on stdout, one record per line:
+//   d <job> <element index> <property> <browser value> <cascade value>
+//   n <job> <elements> <properties> <styled elements> <differences>
+//   v <user agent>
+//   x <job> <error>
+// A tab never appears in a computed-style value, so the fields are unambiguous.
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const CHROME = process.env.CHROME;
+const jobsFile = process.argv[2];
+const workDir = process.argv[3];
+const MAX_DIFFS = 60;
+const CHUNK_BYTES = 512 * 1024;
+
+const domJs = fs.readFileSync(path.join(__dirname, 'dom.js'), 'utf8');
+
+// Runs inside the page.
+const HARNESS = `
+function cdReset(doc) {
+  doc.head.textContent = '';
+  doc.body.textContent = '';
+  var b = doc.body.attributes;
+  for (var i = b.length - 1; i >= 0; i--) doc.body.removeAttribute(b[i].name);
+}
+function cdProps(cs) {
+  var props = [];
+  // A custom property reaches the render only through a var() in a real
+  // property, and those are resolved in the values compared below.
+  for (var i = 0; i < cs.length; i++)
+    if (cs[i].indexOf('--') !== 0) props.push(cs[i]);
+  return props;
+}
+function cdSnapshot(view, els, props) {
+  var snap = [], n = props.length;
+  for (var i = 0; i < els.length; i++) {
+    var cs = view.getComputedStyle(els[i]);
+    var row = new Array(n);
+    for (var j = 0; j < n; j++) row[j] = cs.getPropertyValue(props[j]);
+    snap.push(row);
+  }
+  return snap;
+}
+function cdJob(doc, job, out) {
+  cdReset(doc);
+  rdBuild(doc, job);
+  var view = doc.defaultView;
+  var els = Array.prototype.slice.call(doc.body.querySelectorAll('*'));
+  // The two sides address elements by position, so a document the builder did
+  // not build the way the projection read it makes every later record about
+  // the wrong element. Say so instead of reporting one.
+  if (els.length !== job.tags.length) {
+    out.push(['x', job.id, 'the document has ' + els.length +
+              ' elements and the projection ' + job.tags.length].join('\\t'));
+    return;
+  }
+  for (var i = 0; i < els.length; i++)
+    if (els[i].tagName.toLowerCase() !== job.tags[i]) {
+      out.push(['x', job.id, 'element ' + i + ' is a ' +
+                els[i].tagName.toLowerCase() + ' and the projection read a ' +
+                job.tags[i]].join('\\t'));
+      return;
+    }
+  var style = doc.createElement('style');
+  doc.head.appendChild(style);
+  style.textContent = job.css;
+  var props = cdProps(view.getComputedStyle(doc.body));
+  var cascaded = cdSnapshot(view, els, props);
+  // The author sheet goes, cascade's answer arrives. The user-agent style
+  // stays on both sides, and so does the document.
+  style.textContent = '';
+  var styled = 0;
+  for (i = 0; i < els.length; i++) {
+    if (job.styles[i]) styled++;
+    els[i].setAttribute('style', job.styles[i]);
+  }
+  var projected = cdSnapshot(view, els, props);
+  var diffs = 0;
+  for (var e = 0; e < els.length; e++)
+    for (var j = 0; j < props.length; j++)
+      if (cascaded[e][j] !== projected[e][j]) {
+        diffs++;
+        if (diffs <= MAX_DIFFS)
+          out.push(['d', job.id, e, props[j], cascaded[e][j],
+                    projected[e][j]].join('\\t'));
+      }
+  out.push(['n', job.id, els.length, props.length, styled, diffs].join('\\t'));
+}
+function cdMain(jobs) {
+  var out = [];
+  var frame = document.createElement('iframe');
+  frame.width = 1024;
+  frame.height = 768;
+  frame.style.border = '0';
+  document.body.appendChild(frame);
+  var doc = frame.contentDocument;
+  // Engines do not agree on computed styles, so a count means something only
+  // beside the engine that produced it.
+  out.push(['v', navigator.userAgent].join('\t'));
+  jobs.forEach(function (job) {
+    try { cdJob(doc, job, out); }
+    catch (e) { out.push(['x', job.id, String((e && e.message) || e)].join('\\t')); }
+  });
+  var text = out.join('\\n');
+  document.body.setAttribute('data-cd',
+    btoa(unescape(encodeURIComponent(text))));
+}
+`;
+
+function page(jobs) {
+  const payload = JSON.stringify(jobs).replace(/</g, '\\u003c');
+  return '<!doctype html><html><head><meta charset="utf-8"></head><body>' +
+    '<script id="cd-jobs" type="application/json">' + payload + '</script>' +
+    '<script>' + domJs + '</script>' +
+    '<script>var MAX_DIFFS = ' + MAX_DIFFS + ';' + HARNESS +
+    'cdMain(JSON.parse(document.getElementById("cd-jobs").textContent));</script>' +
+    '</body></html>';
+}
+
+function chunks(jobs) {
+  const out = [];
+  let cur = [], size = 0;
+  for (const job of jobs) {
+    const n = JSON.stringify(job).length;
+    if (cur.length && size + n > CHUNK_BYTES) { out.push(cur); cur = []; size = 0; }
+    cur.push(job);
+    size += n;
+  }
+  if (cur.length) out.push(cur);
+  return out;
+}
+
+function run(jobs, index) {
+  // Absolute: a file:// URL has no notion of the process's directory.
+  const file = path.resolve(workDir, 'page-' + index + '.html');
+  fs.writeFileSync(file, page(jobs));
+  const dom = execFileSync(CHROME, [
+    '--headless', '--disable-gpu', '--no-sandbox',
+    '--virtual-time-budget=120000', '--dump-dom', 'file://' + file,
+  ], { encoding: 'utf8', maxBuffer: 1 << 28 });
+  const m = dom.match(/data-cd="([^"]*)"/);
+  if (!m) throw new Error('the page produced no result for chunk ' + index);
+  return Buffer.from(m[1], 'base64').toString('utf8');
+}
+
+const jobs = JSON.parse(fs.readFileSync(jobsFile, 'utf8'));
+const parts = chunks(jobs);
+parts.forEach(function (chunk, i) {
+  const text = run(chunk, i);
+  if (text.length) process.stdout.write(text + '\n');
+});

--- a/test/render/resolve_diff.ml
+++ b/test/render/resolve_diff.ml
@@ -1,0 +1,589 @@
+(* Resolve a stylesheet against a document twice and check that the two agree:
+   once by the browser, which cascades the sheet itself, and once by
+   {!Cascade.Resolve}, whose answer is written into each element's style
+   attribute and computed by the same browser. A disagreement is a declaration
+   one of them let win and the other did not.
+
+   The browser is the oracle for both halves: it decides which declaration wins
+   in the first leg and what a winning declaration computes to in the second, so
+   nothing here derives an expectation from the library under test.
+
+   Skips cleanly, with status 0, when node or a headless Chromium is missing, or
+   when CASCADE_NO_BROWSER is set. *)
+
+open Cascade
+
+let ( // ) = Filename.concat
+
+module R = Resolve.Make (Resolve_gen.Node)
+
+(* ===== Files ===== *)
+
+let rec mkdir_p dir =
+  if not (Sys.file_exists dir) then (
+    mkdir_p (Filename.dirname dir);
+    try Unix.mkdir dir 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
+
+let write file contents =
+  let oc = open_out file in
+  output_string oc contents;
+  close_out oc
+
+let read_file file =
+  let ic = open_in_bin file in
+  let n = in_channel_length ic in
+  let s = really_input_string ic n in
+  close_in ic;
+  s
+
+let contains haystack needle =
+  let n = String.length needle and h = String.length haystack in
+  let rec at i =
+    i + n <= h && (String.sub haystack i n = needle || at (i + 1))
+  in
+  n = 0 || at 0
+
+(* ===== Jobs ===== *)
+
+(* [Differs] is a control, not a pin: the projection is fed a perturbed sheet
+   whose cascade lands somewhere else, so the browser must contradict it. A
+   control that reports nothing says the comparison is blind, and a run that
+   cannot see a wrong winner it planted proves nothing about the ones it did
+   not. *)
+type expect = Same | Differs of string
+
+type job = {
+  id : string;
+  expect : expect;
+  doc : Resolve_gen.doc;
+  rendered : Css.t;  (** what the browser cascades *)
+  projected : Css.t;  (** what {!Cascade.Resolve} is asked about *)
+}
+
+let parse css =
+  match Css.of_string ~strict:false css with
+  | Ok { stylesheet; _ } -> stylesheet
+  | Error _ ->
+      prerr_endline (String.concat "" [ "resolve_diff: unparsed sheet: "; css ]);
+      exit 1
+
+(* ===== The documents the hand-written jobs run against ===== *)
+
+let probe_doc =
+  Resolve_gen.(
+    doc
+      [
+        elt ~id:"kid" ~classes:[ "k"; "a"; "card" ] "div"
+          [ elt ~classes:[ "k"; "b" ] "p" [] ];
+      ])
+
+(* ===== Calibration =====
+
+   Each pair plants one cascade answer twice: once as the library gets it, which
+   must agree with the browser, and once with the projection resolving a sheet
+   perturbed so that a different declaration wins, which the browser must
+   contradict. The perturbation is in the harness's own input, never in the
+   library. *)
+let calibration =
+  [
+    ( "order",
+      "p.k{color:#f00}p.k{color:#00f}",
+      "p.k{color:#00f}p.k{color:#f00}",
+      "the later of two equal rules wins" );
+    ( "specificity",
+      ".k{color:#f00}#kid{color:#00f}",
+      ".k{color:#f00}:where(#kid){color:#00f}",
+      ":where() adds no specificity, so the class would win" );
+    ( "important",
+      ".k{color:#f00!important}#kid{color:#00f}",
+      ".k{color:#f00}#kid{color:#00f}",
+      "without the flag the more specific rule wins" );
+    ( "layer-order",
+      "@layer a{.k{color:#f00}}@layer b{.k{color:#00f}}",
+      "@layer b{.k{color:#00f}}@layer a{.k{color:#f00}}",
+      "the last layer wins, so swapping them changes the winner" );
+    ( "layer-important",
+      "@layer a{.k{color:#f00!important}}@layer b{.k{color:#00f!important}}",
+      "@layer b{.k{color:#00f!important}}@layer a{.k{color:#f00!important}}",
+      "important reverses the layer order, so swapping them changes the winner"
+    );
+    (* The winning set holds a shorthand and a longhand at once, so the control
+       has to move their order rather than replace either. *)
+    ( "shorthand-order",
+      "#kid{margin:4px}.k{margin-top:20px}",
+      ":where(#kid){margin:4px}.k{margin-top:20px}",
+      "with the id's specificity gone the longhand outranks the shorthand" );
+  ]
+
+let calibration_jobs =
+  List.concat_map
+    (fun (name, css, mutated, why) ->
+      let sheet = parse css in
+      [
+        {
+          id = String.concat "" [ "calib-"; name ];
+          expect = Same;
+          doc = probe_doc;
+          rendered = sheet;
+          projected = sheet;
+        };
+        {
+          id = String.concat "" [ "calib-"; name; "-perturbed" ];
+          expect = Differs why;
+          doc = probe_doc;
+          rendered = sheet;
+          projected = parse mutated;
+        };
+      ])
+    calibration
+
+(* ===== Probes =====
+
+   One mechanism each, written small enough that a failure names the rule it
+   broke. The browser answers every one of them. *)
+let probes =
+  [
+    (* css-cascade-5 sec. 6.4.4: among normal declarations an unlayered one
+       beats every layered one, whichever order they are written in. *)
+    ("unlayered-wins", "@layer a{.k{color:#f00}}.k{color:#00f}");
+    ("unlayered-wins-first", ".k{color:#00f}@layer a{.k{color:#f00}}");
+    (* And among important ones that reverses: the layered declaration wins. *)
+    ( "unlayered-loses-important",
+      "@layer a{.k{color:#f00!important}}.k{color:#00f!important}" );
+    ( "important-beats-normal-across-layers",
+      "@layer a{.k{color:#f00!important}}.k{color:#00f}" );
+    (* css-cascade-5 (ED) sec. 6.4.3: "Cascade layers are sorted by the order in
+       which they first are declared, with nested layers grouped within their
+       parent layer. Unlayered rules are sorted later than any layered rules
+       within the same parent layer": a layer's own rules sit in an implicit
+       sublayer after its explicit ones, so [a] beats [a.b] and, being first,
+       loses to it among important declarations. *)
+    ( "sublayer-before-parent",
+      "@layer a.b{.k{color:#f00}}@layer a{.k{color:#00f}}" );
+    ( "sublayer-before-parent-important",
+      "@layer a.b{.k{color:#f00!important}}@layer a{.k{color:#00f!important}}"
+    );
+    ("sublayer-in-a-block", "@layer a{@layer b{.k{color:#f00}}.k{color:#00f}}");
+    ( "parent-before-sublayer",
+      "@layer a{.k{color:#f00}}@layer a.b{.k{color:#00f}}" );
+    ( "sublayer-inside-the-subtree",
+      "@layer a.b{.k{color:#00f}}@layer c{.k{color:#f00}}@layer \
+       a.d{.k{color:#0f0}}" );
+    (* sec. 6.4.1: a layer statement declares the order before any block
+       does. *)
+    ( "statement-fixes-the-order",
+      "@layer util,base;@layer base{.k{color:#f00}}@layer util{.k{color:#00f}}"
+    );
+    ( "statement-order-important",
+      "@layer util,base;@layer base{.k{color:#f00!important}}@layer \
+       util{.k{color:#00f!important}}" );
+    (* Each anonymous block is a layer of its own, ordered where it is
+       written. *)
+    ("anonymous-layers", "@layer{.k{color:#f00}}@layer{.k{color:#00f}}");
+    ( "anonymous-layers-important",
+      "@layer{.k{color:#f00!important}}@layer{.k{color:#00f!important}}" );
+    (* selectors-4 sec. 17: [:is()] and [:not()] take their most specific
+       argument, [:where()] takes none. *)
+    ("is-takes-its-argument", ".k{color:#f00}:is(#nope,.k){color:#00f}");
+    ("where-takes-nothing", ".k{color:#00f}:where(#kid){color:#f00}");
+    ("not-takes-its-argument", "p{color:#f00}:not(.zzz){color:#00f}");
+    (* An attribute selector is a class-level component. *)
+    ("attribute-specificity", "div{color:#f00}[id]{color:#00f}");
+    (* CSS Nesting 1 sec. 4: [&] carries the specificity of [:is(<parent
+       selector list>)], which is its most specific branch, not the branch that
+       matched. *)
+    ( "nesting-parent-list-specificity",
+      ".a,#lead{& .b{color:#00f}}.card .b{color:#f00}" );
+    ("nesting-implicit-descendant", ".card{color:#f00;.b{color:#00f}}");
+    ("nesting-compound", "p{color:#f00}.card{&.a{color:#00f}}");
+    (* A shorthand resets every longhand it covers, so which one wins the slot
+       depends on where each sits in the cascade, not on which is longer. *)
+    ("shorthand-loses-a-slot", "#kid{margin-top:20px}.k{margin:4px}");
+    ("shorthand-wins-a-slot", "#kid{margin:4px}.k{margin-top:20px}");
+    ( "shorthand-loses-to-important",
+      "#kid{margin:4px}.k{margin-top:20px!important}" );
+    ("shorthand-across-layers", "@layer a{.k{margin-top:20px}}.k{margin:4px}");
+    (* A selector list cascades as one rule per branch, each with its own
+       specificity. *)
+    ("selector-list-branch-specificity", "#kid,.zzz{color:#f00}p.k{color:#00f}");
+  ]
+
+let probe_jobs =
+  List.map
+    (fun (name, css) ->
+      let sheet = parse css in
+      {
+        id = String.concat "" [ "probe-"; name ];
+        expect = Same;
+        doc = probe_doc;
+        rendered = sheet;
+        projected = sheet;
+      })
+    probes
+
+(* ===== Generated jobs ===== *)
+
+let generated seeds =
+  List.map
+    (fun seed ->
+      let sheet = Resolve_gen.stylesheet ~seed in
+      {
+        id = String.concat "" [ "seed-"; string_of_int seed ];
+        expect = Same;
+        doc = Resolve_gen.document ~seed;
+        rendered = sheet;
+        projected = sheet;
+      })
+    seeds
+
+(* ===== Projection =====
+
+   The declarations {!Cascade.Resolve} says win, in the order it returns them:
+   weakest first, so a shorthand and a longhand of one family land in the style
+   attribute in the order the cascade ranked them and the browser resolves their
+   overlap the way it would have in the sheet. *)
+let style_of prepared node =
+  R.resolve_prepared prepared node
+  |> List.map (Declaration.to_string ~minify:true)
+  |> String.concat ";"
+
+let job_json job =
+  let prepared = Resolve.prepare job.projected in
+  let subjects = Resolve_gen.subjects job.doc in
+  let fields =
+    match Resolve_gen.json_of_doc job.doc with
+    | Json.Obj fields -> fields
+    | other -> [ ("dom", other) ]
+  in
+  Json.Obj
+    ((("id", Json.Str job.id) :: fields)
+    @ [
+        ("css", Json.Str (Css.to_string ~minify:true job.rendered));
+        ( "tags",
+          Json.Arr (List.map (fun e -> Json.Str (Resolve_gen.tag e)) subjects)
+        );
+        ( "styles",
+          Json.Arr (List.map (fun e -> Json.Str (style_of prepared e)) subjects)
+        );
+      ])
+
+(* ===== Driver protocol ===== *)
+
+type diff = {
+  index : int;
+  property : string;
+  browser : string;
+  cascade : string;
+}
+
+type result = {
+  diffs : diff list;
+  reported : int;
+  elements : int;
+  properties : int;
+  styled : int;
+  errors : string list;
+}
+
+let empty_result =
+  {
+    diffs = [];
+    reported = 0;
+    elements = 0;
+    properties = 0;
+    styled = 0;
+    errors = [];
+  }
+
+let int_of s = try int_of_string (String.trim s) with Failure _ -> 0
+let user_agent = ref "unknown"
+
+let parse_driver_output lines =
+  let table = Hashtbl.create 16 in
+  let get id = try Hashtbl.find table id with Not_found -> empty_result in
+  List.iter
+    (fun line ->
+      match String.split_on_char '\t' line with
+      | [ "d"; id; index; property; browser; cascade ] ->
+          let r = get id in
+          Hashtbl.replace table id
+            {
+              r with
+              diffs =
+                r.diffs
+                @ [ { index = int_of index; property; browser; cascade } ];
+            }
+      | [ "n"; id; elements; properties; styled; diffs ] ->
+          let r = get id in
+          Hashtbl.replace table id
+            {
+              r with
+              elements = int_of elements;
+              properties = int_of properties;
+              styled = int_of styled;
+              reported = int_of diffs;
+            }
+      | [ "v"; ua ] -> user_agent := ua
+      | "x" :: id :: rest ->
+          let r = get id in
+          Hashtbl.replace table id
+            { r with errors = r.errors @ [ String.concat "\t" rest ] }
+      | _ -> ())
+    lines;
+  table
+
+let read_lines ic =
+  let rec loop acc =
+    match input_line ic with
+    | line -> loop (line :: acc)
+    | exception End_of_file -> List.rev acc
+  in
+  loop []
+
+let run_driver ~node ~chrome ~script ~jobs ~work =
+  let errors = work // "driver.err" in
+  let cmd =
+    String.concat " "
+      [
+        String.concat "" [ "CHROME="; Filename.quote chrome ];
+        Filename.quote node;
+        Filename.quote script;
+        Filename.quote jobs;
+        Filename.quote work;
+        String.concat "" [ "2>"; Filename.quote errors ];
+      ]
+  in
+  let ic = Unix.open_process_in cmd in
+  let lines = read_lines ic in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> Ok lines
+  | _ ->
+      let ic = open_in errors in
+      let text = read_lines ic in
+      close_in ic;
+      Error (String.concat "\n" text)
+
+(* ===== Artefacts ===== *)
+
+(* Two pages that rebuild the run: one the browser cascades, one carrying
+   cascade's answer, so a failure opens in a browser as the pair it was. *)
+let repro ~css ~dom ~styles =
+  String.concat ""
+    [
+      "<!doctype html><html><head><meta charset=\"utf-8\"><style>";
+      css;
+      "</style></head><body><script id=\"cd-doc\" type=\"application/json\">";
+      dom;
+      "</script><script id=\"cd-styles\" type=\"application/json\">";
+      styles;
+      "</script><script src=\"dom.js\"></script><script>rdBuild(document, \
+       JSON.parse(document.getElementById('cd-doc').textContent));var \
+       s=JSON.parse(document.getElementById('cd-styles').textContent);if(s.length){var \
+       e=document.body.querySelectorAll('*');for(var \
+       i=0;i<e.length;i++)e[i].setAttribute('style',s[i]);}</script></body></html>";
+    ]
+
+let write_artefacts ~dir ~script_dir ~job ~diffs =
+  mkdir_p dir;
+  let dom = Json.to_string (Resolve_gen.json_of_doc job.doc) in
+  let prepared = Resolve.prepare job.projected in
+  let subjects = Resolve_gen.subjects job.doc in
+  let styles = List.map (fun e -> style_of prepared e) subjects in
+  let css = Css.to_string ~minify:true job.rendered in
+  write (dir // "dom.json") dom;
+  write (dir // "dom.js") (read_file (script_dir // "dom.js"));
+  write (dir // "sheet.css") (Css.to_string job.rendered);
+  if not (String.equal css (Css.to_string ~minify:true job.projected)) then
+    write (dir // "projected.css") (Css.to_string job.projected);
+  write (dir // "page-cascaded.html") (repro ~css ~dom ~styles:"[]");
+  write
+    (dir // "page-projected.html")
+    (repro ~css:"" ~dom
+       ~styles:
+         (Json.to_string (Json.Arr (List.map (fun s -> Json.Str s) styles))));
+  let buf = Buffer.create 4096 in
+  List.iteri
+    (fun i (e, s) ->
+      Buffer.add_string buf (string_of_int i);
+      Buffer.add_char buf '\t';
+      Buffer.add_string buf (Resolve_gen.label job.doc e);
+      Buffer.add_char buf '\t';
+      Buffer.add_string buf s;
+      Buffer.add_char buf '\n')
+    (List.combine subjects styles);
+  write (dir // "styles.tsv") (Buffer.contents buf);
+  let buf = Buffer.create 4096 in
+  List.iter
+    (fun d ->
+      Buffer.add_string buf
+        (String.concat "\t"
+           [ string_of_int d.index; d.property; d.browser; d.cascade ]);
+      Buffer.add_char buf '\n')
+    diffs;
+  write (dir // "diff.tsv") (Buffer.contents buf)
+
+(* ===== Main ===== *)
+
+let artefact_root () =
+  let dir =
+    match Browser.getenv "CASCADE_RENDER_ARTIFACTS" with
+    | Some d -> d // "resolve"
+    | None -> "tmp" // "resolve-diff"
+  in
+  if Filename.is_relative dir then Sys.getcwd () // dir else dir
+
+let skip reason = Browser.skip "resolve_diff" reason
+let is_control job = match job.expect with Differs _ -> true | Same -> false
+
+let () =
+  let seeds = ref 48 in
+  let only = ref None in
+  let sheet_files = ref [] in
+  let sheet_doc = ref 1 in
+  let args =
+    [
+      ("--seeds", Arg.Set_int seeds, "N generated sheets (default 48)");
+      ( "--only",
+        Arg.String (fun s -> only := Some s),
+        "SUBSTRING run the jobs whose id holds SUBSTRING" );
+      ( "--sheet",
+        Arg.String (fun f -> sheet_files := f :: !sheet_files),
+        "FILE run a job over the CSS in FILE, repeatable" );
+      ( "--doc",
+        Arg.Set_int sheet_doc,
+        "SEED the document --sheet runs against (default 1)" );
+    ]
+  in
+  Arg.parse args
+    (fun a -> raise (Arg.Bad (String.concat "" [ "unexpected argument "; a ])))
+    "resolve_diff [--seeds N] [--only SUBSTRING] [--sheet FILE [--doc SEED]]";
+  if Option.is_some (Browser.getenv "CASCADE_NO_BROWSER") then
+    skip "CASCADE_NO_BROWSER is set";
+  let node =
+    match Browser.node_binary () with Some n -> n | None -> skip "no node"
+  in
+  let chrome =
+    match Browser.chrome_binary () with
+    | Some c -> c
+    | None -> skip "no headless browser"
+  in
+  let jobs =
+    match List.rev !sheet_files with
+    | [] ->
+        calibration_jobs @ probe_jobs
+        @ generated (List.init !seeds (fun i -> i + 1))
+    | files ->
+        List.map
+          (fun file ->
+            let sheet = parse (read_file file) in
+            {
+              id = Filename.remove_extension (Filename.basename file);
+              expect = Same;
+              doc = Resolve_gen.document ~seed:!sheet_doc;
+              rendered = sheet;
+              projected = sheet;
+            })
+          files
+  in
+  let jobs =
+    match !only with
+    | None -> jobs
+    | Some needle -> List.filter (fun j -> contains j.id needle) jobs
+  in
+  let script_dir = Filename.dirname Sys.executable_name in
+  let root = artefact_root () in
+  let work = root // ".work" in
+  mkdir_p work;
+  let jobs_file = work // "jobs.json" in
+  write jobs_file (Json.to_string (Json.Arr (List.map job_json jobs)));
+  let started = Unix.gettimeofday () in
+  let lines =
+    match
+      run_driver ~node ~chrome
+        ~script:(script_dir // "resolve_diff.js")
+        ~jobs:jobs_file ~work
+    with
+    | Ok lines -> lines
+    | Error err ->
+        prerr_endline
+          (String.concat "\n"
+             [ "resolve_diff: the browser driver failed:"; err ]);
+        exit 1
+  in
+  let elapsed = Unix.gettimeofday () -. started in
+  let table = parse_driver_output lines in
+  let failures = ref 0 in
+  let elements = ref 0 in
+  let styled = ref 0 in
+  let comparisons = ref 0 in
+  let properties = ref 0 in
+  let differences = ref 0 in
+  let controls = ref 0 in
+  List.iter
+    (fun job ->
+      let r = try Hashtbl.find table job.id with Not_found -> empty_result in
+      elements := !elements + r.elements;
+      styled := !styled + r.styled;
+      properties := max !properties r.properties;
+      comparisons := !comparisons + (r.elements * r.properties);
+      List.iter
+        (fun e ->
+          incr failures;
+          Fmt.pr "FAIL %s: %s@." job.id e)
+        r.errors;
+      let subjects = Resolve_gen.subjects job.doc in
+      let report () =
+        differences := !differences + r.reported;
+        let dir = root // job.id in
+        write_artefacts ~dir ~script_dir ~job ~diffs:r.diffs;
+        Fmt.pr "FAIL %s: %d computed-style difference(s)@." job.id r.reported;
+        Fmt.pr "  sheet: %s@." (Css.to_string ~minify:true job.rendered);
+        List.iteri
+          (fun i d ->
+            if i < 8 then
+              let label =
+                match List.nth_opt subjects d.index with
+                | Some e -> Resolve_gen.label job.doc e
+                | None -> string_of_int d.index
+              in
+              Fmt.pr "  %s %s: browser %S, cascade %S@." label d.property
+                d.browser d.cascade)
+          r.diffs;
+        Fmt.pr "  artefacts: %s@." dir
+      in
+      match job.expect with
+      | Same ->
+          if r.reported > 0 then (
+            incr failures;
+            report ())
+      | Differs why ->
+          if r.reported = 0 then (
+            incr failures;
+            Fmt.pr
+              "FAIL %s: the perturbed projection (%s) computed the same style, \
+               so the comparison is blind@."
+              job.id why)
+          else incr controls)
+    jobs;
+  Fmt.pr
+    "resolve_diff: %d job(s), %d element(s), %d styled, %d properties, %d \
+     comparison(s), %.1fs@."
+    (List.length jobs) !elements !styled !properties !comparisons elapsed;
+  Fmt.pr "  browser: %s@." !user_agent;
+  Fmt.pr "  controls that reported a planted wrong winner: %d of %d@." !controls
+    (List.length (List.filter is_control jobs));
+  Fmt.pr "  differences: %d@." !differences;
+  (* An empty population and a clean run look the same from outside, so the run
+     says which it was. *)
+  let thin =
+    !elements < 300 || !styled < 150 || !properties < 100
+    || !comparisons < 100_000
+  in
+  if List.length !sheet_files = 0 && Option.is_none !only && thin then (
+    incr failures;
+    Fmt.pr
+      "FAIL the population is too thin to have tested anything: %d element(s), \
+       %d styled, %d properties, %d comparison(s)@."
+      !elements !styled !properties !comparisons);
+  Fmt.pr "  failures: %d@." !failures;
+  if !failures > 0 then exit 1

--- a/test/render/resolve_gen.ml
+++ b/test/render/resolve_gen.ml
@@ -1,0 +1,323 @@
+open Cascade
+
+(* A linear congruential generator: a finding has to reproduce from its seed on
+   every machine, which Random does not promise across versions. *)
+type rng = { mutable state : int }
+
+let rng seed = { state = seed * 2654435761 land max_int }
+
+let next r =
+  r.state <- ((r.state * 2862933555777941757) + 3037000493) land max_int;
+  r.state
+
+let int r n = if n <= 1 then 0 else next r mod n
+let pick r l = List.nth l (int r (List.length l))
+let chance r n = int r n = 0
+
+(* ===== Vocabulary =====
+
+   One fixed vocabulary for the document and the selectors, so a generated rule
+   has elements to match: random markup and random selectors meet nowhere. None
+   of it names [html], [head] or [body]. *)
+
+let tags = [ "div"; "p"; "span"; "section"; "li" ]
+let classes = [ "a"; "b"; "card" ]
+let ids = [ "lead"; "foot" ]
+let attr_values = [ "v"; "w" ]
+
+(* ===== Documents ===== *)
+
+type element = {
+  tag : string;
+  eid : string option;
+  cls : string list;
+  attrs : (string * string) list;
+  kids : element list;
+  mutable up : element option;
+}
+
+type doc = { root : element; subjects : element list }
+
+let elt ?id ?(classes = []) ?(attrs = []) tag kids =
+  { tag; eid = id; cls = classes; attrs; kids; up = None }
+
+let rec tie parent e =
+  e.up <- parent;
+  List.iter (tie (Some e)) e.kids
+
+(* Document order, [body]'s descendants only: the driver enumerates the same set
+   with body.querySelectorAll('*'), and the two lists have to line up. *)
+let rec preorder e = e :: List.concat_map preorder e.kids
+
+let doc children =
+  let body = elt "body" children in
+  let root = elt "html" [ elt "head" []; body ] in
+  tie None root;
+  { root; subjects = List.concat_map preorder children }
+
+let subjects d = d.subjects
+let tag e = e.tag
+
+module Node = struct
+  type t = element
+
+  (* Identity, not structure: two sibling [<div>] with the same classes are
+     different elements and a matcher locating one among its siblings has to
+     tell them apart. Every element carries a mutable field, so no two are
+     shared. *)
+  let equal (a : t) (b : t) = a == b
+  let name e = Some e.tag
+  let id e = e.eid
+  let classes e = e.cls
+
+  (* [id] and [class] are attributes as much as any other, and a document that
+     reports them only through the accessors named after them makes [\[id\]] and
+     [\[class~="a"\]] match nothing. *)
+  let attribute e n =
+    match (n, e.cls) with
+    | "id", _ -> e.eid
+    | "class", [] -> None
+    | "class", cls -> Some (String.concat " " cls)
+    | _ -> List.assoc_opt n e.attrs
+
+  let parent e = e.up
+  let children e = e.kids
+  let text_children _ = []
+end
+
+(* [body] and [head] are the document's own scaffolding, so a path starts at
+   [body]'s children: the elements a sheet is resolved against. *)
+let path d e =
+  let rec up e acc =
+    match e.up with
+    | None -> acc
+    | Some p when Node.equal p d.root -> acc
+    | Some p ->
+        let rec index i = function
+          | [] -> i
+          | x :: _ when Node.equal x e -> i
+          | _ :: rest -> index (i + 1) rest
+        in
+        up p
+          (String.concat ""
+             [ e.tag; ":nth-child("; string_of_int (index 1 p.kids); ")" ]
+          :: acc)
+  in
+  String.concat ">" (up e [])
+
+let label d e =
+  let buf = Buffer.create 32 in
+  Buffer.add_string buf (path d e);
+  (match e.eid with
+  | None -> ()
+  | Some i ->
+      Buffer.add_char buf '#';
+      Buffer.add_string buf i);
+  List.iter
+    (fun c ->
+      Buffer.add_char buf '.';
+      Buffer.add_string buf c)
+    e.cls;
+  Buffer.contents buf
+
+let rec json_of_element e =
+  Json.Obj
+    ([ ("t", Json.Str e.tag) ]
+    @ (match e.eid with None -> [] | Some i -> [ ("i", Json.Str i) ])
+    @ [
+        ("c", Json.Arr (List.map (fun c -> Json.Str c) e.cls));
+        ( "a",
+          Json.Arr
+            (List.map
+               (fun (k, v) -> Json.Arr [ Json.Str k; Json.Str v ])
+               e.attrs) );
+        ("k", Json.Arr (List.map json_of_element e.kids));
+      ])
+
+let json_of_doc d =
+  let body =
+    match d.root.kids with _ :: body :: _ -> body.kids | _ -> d.subjects
+  in
+  Json.Obj
+    [ ("dom", Json.Obj [ ("k", Json.Arr (List.map json_of_element body)) ]) ]
+
+let rec take n l =
+  match (n, l) with 0, _ | _, [] -> [] | n, x :: tl -> x :: take (n - 1) tl
+
+let some r n l =
+  let shuffled =
+    List.map (fun x -> (int r 1000, x)) l
+    |> List.sort (fun (a, _) (b, _) -> Int.compare a b)
+    |> List.map snd
+  in
+  take n shuffled
+
+let element r ~depth ~free_ids =
+  let rec go depth =
+    let cls = some r (int r 3) classes in
+    let id =
+      if chance r 5 then (
+        match !free_ids with
+        | [] -> None
+        | i :: rest ->
+            free_ids := rest;
+            Some i)
+      else None
+    in
+    let attrs = if chance r 3 then [ ("data-k", pick r attr_values) ] else [] in
+    let kids =
+      if depth <= 0 then [] else List.init (int r 3) (fun _ -> go (depth - 1))
+    in
+    elt ?id ~classes:cls ~attrs (pick r tags) kids
+  in
+  go depth
+
+let document ~seed =
+  let r = rng ((seed * 7919) + 13) in
+  let free_ids = ref ids in
+  let n = 3 + int r 3 in
+  doc (List.init n (fun _ -> element r ~depth:3 ~free_ids))
+
+(* ===== Selectors =====
+
+   Every form the cascade weighs differently: a class, an id and a type for the
+   three specificity components, [:where()] for a part that adds none, [:is()]
+   and [:not()] for a part that adds its argument's, and the combinators, whose
+   left-hand compounds count too. *)
+
+let simple r =
+  let cls () = Selector.class_ (pick r classes) in
+  let typ () = Selector.element (pick r tags) in
+  match int r 18 with
+  | 0 -> cls ()
+  | 1 -> typ ()
+  | 2 -> Selector.id (pick r ids)
+  | 3 -> Selector.attribute "data-k" (Selector.Exact (pick r attr_values))
+  | 4 -> Selector.compound [ typ (); cls () ]
+  | 5 -> Selector.compound [ cls (); Selector.First_child ]
+  | 6 ->
+      Selector.compound [ typ (); Selector.Nth_child (Selector.Index 2, None) ]
+  | 7 -> Selector.compound [ typ (); Selector.not [ cls () ] ]
+  | 8 -> Selector.compound [ cls (); Selector.where [ cls (); typ () ] ]
+  | 9 ->
+      Selector.compound
+        [ typ (); Selector.Is [ cls (); Selector.id (pick r ids) ] ]
+  | 10 -> Selector.where [ typ () ]
+  | 11 -> Selector.compound [ typ (); Selector.Last_child ]
+  | 12 ->
+      Selector.compound
+        [ cls (); Selector.has [ Selector.Relative (Selector.Child, typ ()) ] ]
+  | 13 -> Selector.compound [ typ (); Selector.Empty ]
+  | 14 ->
+      Selector.compound
+        [ cls (); Selector.Nth_last_child (Selector.Index 1, None) ]
+  (* The [i] flag has to match a value the unflagged form misses, so the value
+     is spelled in the case the document does not carry. *)
+  | 15 ->
+      Selector.attribute ~flag:Selector.Insensitive "data-k"
+        (Selector.Exact (String.uppercase_ascii (pick r attr_values)))
+  | 16 -> Selector.compound [ typ (); Selector.Only_child ]
+  | _ ->
+      Selector.compound
+        [ cls (); Selector.Nth_child (Selector.Odd, Some [ cls () ]) ]
+
+let combinators =
+  [
+    Selector.Descendant;
+    Selector.Child;
+    Selector.Next_sibling;
+    Selector.Subsequent_sibling;
+  ]
+
+let selector r =
+  match int r 6 with
+  | 0 | 1 -> Selector.combine (simple r) (pick r combinators) (simple r)
+  | 2 -> Selector.list [ simple r; simple r ]
+  | _ -> simple r
+
+(* ===== Declarations =====
+
+   A sheet writes a handful of slots over and over: what makes the cascade
+   decide is several rules reaching for one slot on one element, so breadth of
+   properties would only dilute the run. Every value of a slot differs from
+   every other, so a declaration that wins where another should have shows up in
+   the computed style. *)
+
+type slot = Color | Background | Opacity | Weight | Margin | Padding
+
+let slots = [ Color; Background; Opacity; Weight; Margin; Padding ]
+let palette = [ "#f00"; "#0f0"; "#00f"; "#123456"; "#ff0" ]
+let px r = Css.Values.Px (float_of_int (4 + (2 * int r 10)))
+
+let declaration r = function
+  | Color -> Css.color (Css.Values.hex (pick r palette))
+  | Background -> Css.background_color (Css.Values.hex (pick r palette))
+  | Opacity ->
+      Css.opacity (Css.Opacity_number (float_of_int (1 + int r 9) /. 10.))
+  | Weight ->
+      Css.font_weight
+        (Css.Weight (float_of_int (pick r [ 100; 400; 700; 900 ])))
+  (* A shorthand and a longhand of one family: whichever the cascade ranks last
+     resets the slot the other wrote, so their order in the winning set is as
+     much a cascade answer as the winner itself. *)
+  | Margin -> if chance r 3 then Css.margin [ px r ] else Css.margin_top (px r)
+  | Padding ->
+      if chance r 3 then Css.padding [ px r; px r ] else Css.padding_left (px r)
+
+let declarations r contended =
+  let n = 1 + int r 3 in
+  List.init n (fun _ ->
+      let d = declaration r (pick r contended) in
+      if chance r 4 then Css.important d else d)
+
+(* ===== Statements ===== *)
+
+let layer_names = [ [ "base" ]; [ "theme" ]; [ "theme"; "dark" ]; [ "util" ] ]
+
+let rule r contended =
+  Css.rule ~selector:(selector r) (declarations r contended)
+
+(* CSS Nesting 1 sec. 2: a nested rule's selector is relative to the parent, and
+   one written without [&] carries an implied descendant combinator. Both forms
+   are generated: the flattening the cascade runs first has to compose either
+   into the same selector the browser reads directly. *)
+let nested_selector r =
+  match int r 3 with
+  | 0 -> Selector.combine Selector.Nesting Selector.Descendant (simple r)
+  | 1 ->
+      Selector.compound [ Selector.Nesting; Selector.class_ (pick r classes) ]
+  | _ -> simple r
+
+let nested_rule r contended =
+  Css.rule ~selector:(selector r)
+    ~nested:
+      [ Css.rule ~selector:(nested_selector r) (declarations r contended) ]
+    (declarations r contended)
+
+let statement r contended =
+  match int r 12 with
+  | 0 | 1 | 2 | 3 | 4 -> rule r contended
+  | 5 | 6 ->
+      Css.layer ~name:(pick r layer_names)
+        (List.init
+           (1 + int r 2)
+           (fun _ ->
+             if chance r 3 then nested_rule r contended else rule r contended))
+  | 7 -> Css.layer (List.init (1 + int r 2) (fun _ -> rule r contended))
+  | 8 | 9 -> nested_rule r contended
+  | 10 -> Css.layer_decl (some r 2 layer_names)
+  | _ ->
+      Css.layer ~name:[ "base" ]
+        [ Css.layer ~name:[ "inner" ] [ rule r contended ]; rule r contended ]
+
+let stylesheet ~seed =
+  let r = rng ((seed * 104729) + 7) in
+  let contended = some r (3 + int r 2) slots in
+  let n = 4 + int r 6 in
+  let statements = List.init n (fun _ -> statement r contended) in
+  (* A layer statement up front orders layers before any block declares them,
+     which is the order the cascade has to rank by. *)
+  let head =
+    if chance r 2 then [ Css.layer_decl [ [ "util" ]; [ "base" ] ] ] else []
+  in
+  Css.v (head @ statements)

--- a/test/render/resolve_gen.mli
+++ b/test/render/resolve_gen.mli
@@ -1,0 +1,57 @@
+(** Seeded documents and stylesheets for the cascade differential.
+
+    The sheets here are built to make the cascade decide: most rules write the
+    same handful of properties, so several declarations compete for one slot on
+    one element and something has to win. Which one is the question
+    {!Cascade.Resolve} answers and the browser settles.
+
+    Document and sheet are drawn from one fixed vocabulary of tags, classes, ids
+    and attributes, so a generated selector has elements to match. Neither ever
+    names [html], [head] or [body]: those three carry the user-agent style the
+    comparison leaves alone on both sides. *)
+
+type element
+(** An element of a synthesised document. *)
+
+type doc
+(** A synthesised document: the [html], [head] and [body] scaffolding, and the
+    elements a sheet is resolved against. *)
+
+module Node : Cascade.Resolve.NODE with type t = element
+(** The document as the library's matcher reads it. *)
+
+val elt :
+  ?id:string ->
+  ?classes:string list ->
+  ?attrs:(string * string) list ->
+  string ->
+  element list ->
+  element
+(** [elt ?id ?classes ?attrs tag children] is one element. Parent links are tied
+    by {!doc}, so an element belongs to the one document it is passed to. *)
+
+val doc : element list -> doc
+(** [doc children] is the document whose [body] holds [children]. *)
+
+val document : seed:int -> doc
+(** [document ~seed] is the document for [seed]. *)
+
+val stylesheet : seed:int -> Cascade.Css.t
+(** [stylesheet ~seed] is the sheet for [seed]: rules, [@layer] blocks and
+    statements, nested rules and [!important], over the vocabulary {!document}
+    builds from. *)
+
+val subjects : doc -> element list
+(** [subjects d] is every element under [body], in document order: the elements
+    the differential resolves and the browser reports on, and in the order the
+    driver enumerates them. *)
+
+val tag : element -> string
+(** [tag e] is [e]'s element name. *)
+
+val label : doc -> element -> string
+(** [label d e] names [e] in a report: its tag, id and classes, and its path
+    from [body]. *)
+
+val json_of_doc : doc -> Json.t
+(** [json_of_doc d] is [d] as [dom.js] builds it. *)


### PR DESCRIPTION
Nothing asked whether cascade picks the same winning declaration a browser picks. This drives Chrome over generated documents and sheets covering specificity, source order, importance, `@layer` and nesting, comparing every computed property but the custom ones.

It is red, and every failure is one defect: a parent layer's own rules rank at the parent's first-declaration point instead of after its sublayers. #859 closes it.
