### PR TITLE
shorthand: refuse a contraction that pastes a css-wide keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -390,6 +390,11 @@ entry points both moved.
 
 ### Minification
 
+- `--minify` no longer contracts a run of longhands one of which is `inherit`,
+  `unset`, `revert` or `revert-layer`. A CSS-wide keyword is a whole
+  declaration value, so pasting one into a shorthand made a declaration every
+  browser drops: `padding-left: inherit` beside its three siblings became
+  `padding: 0 2em 10% inherit` and the element lost all four paddings
 - `--minify` keeps a transition longhand written before a run of other
   transition longhands. The run contracted into the `transition` shorthand,
   which resets the rest of the family, so a `transition-behavior:

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -688,6 +688,12 @@ let rec value_size ?(minify = true) ?(inline = false) decl =
       Pp.size ~minify ~inline pp_property_value (property, value)
   | Theme_guarded { decl; _ } -> value_size ~minify ~inline decl
 
+(* The writer side of the rule [validate_regular_property_components] enforces
+   on input. The reader's exemptions are for keeping an authored value verbatim,
+   so they do not apply here: nothing licenses building such a value. *)
+let value_has_css_wide_mix decl =
+  Properties.value_has_css_wide_mix (string_of_value ~minify:true decl)
+
 (* Helper to validate no extra tokens remain *)
 let validate_no_extra_tokens t =
   Cursor.ws t;

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -267,6 +267,13 @@ val value_size : ?minify:bool -> ?inline:bool -> declaration -> int
 (** [value_size ?minify decl] is the byte length of
     [string_of_value ?minify decl], computed without allocating the string. *)
 
+val value_has_css_wide_mix : declaration -> bool
+(** [value_has_css_wide_mix decl] is [true] when [decl]'s value holds a CSS-wide
+    keyword beside other components. CSS Cascade 5 sec. 7.3 makes such a keyword
+    the whole value of a declaration or nothing, so the reader rejects one and a
+    browser drops the declaration. This is that rule read off an emission, for
+    the composer deciding whether a contraction it built can be written out. *)
+
 (* Single-to-list property helpers. These construct typed declarations for
    properties that accept comma-separated lists, while keeping a simple
    single-value API. *)

--- a/lib/rule_index.ml
+++ b/lib/rule_index.ml
@@ -45,20 +45,24 @@ let is_absorbed t i =
   match t.slots.(i) with Live | Shorthand _ -> false | Absorbed -> true
 
 let splice t ~at ~absorbed ~new_decls =
-  List.iter
-    (fun i ->
-      match t.slots.(i) with
-      | Live -> t.slots.(i) <- Absorbed
-      | Absorbed | Shorthand _ ->
-          failwith "Rule_index.absorb: position already consumed")
-    absorbed;
-  match t.slots.(at) with
-  | Absorbed ->
-      (* [at] is typically the earliest absorbed position, which was just marked
-         Absorbed above; promote it to carry the synthesized shorthand list. *)
-      t.slots.(at) <- Shorthand new_decls
-  | Live -> t.slots.(at) <- Shorthand new_decls
-  | Shorthand _ -> failwith "Rule_index.absorb: shorthand slot already taken"
+  if List.exists Declaration.value_has_css_wide_mix new_decls then false
+  else (
+    List.iter
+      (fun i ->
+        match t.slots.(i) with
+        | Live -> t.slots.(i) <- Absorbed
+        | Absorbed | Shorthand _ ->
+            failwith "Rule_index.absorb: position already consumed")
+      absorbed;
+    (match t.slots.(at) with
+    | Absorbed ->
+        (* [at] is typically the earliest absorbed position, which was just
+           marked Absorbed above; promote it to carry the synthesized shorthand
+           list. *)
+        t.slots.(at) <- Shorthand new_decls
+    | Live -> t.slots.(at) <- Shorthand new_decls
+    | Shorthand _ -> failwith "Rule_index.absorb: shorthand slot already taken");
+    true)
 
 let absorb t ~at ~absorbed ~shorthand =
   splice t ~at ~absorbed ~new_decls:[ shorthand ]

--- a/lib/rule_index.mli
+++ b/lib/rule_index.mli
@@ -29,23 +29,30 @@ val positions : t -> 'a Properties.property -> int list
     property [p] appears in the rule. *)
 
 val absorb :
-  t -> at:int -> absorbed:int list -> shorthand:Declaration.declaration -> unit
+  t -> at:int -> absorbed:int list -> shorthand:Declaration.declaration -> bool
 (** [absorb t ~at ~absorbed ~shorthand] records that [shorthand] should appear
     at position [at] (typically the earliest absorbed position) and that each
     position in [absorbed] is consumed by the shorthand. Repeated absorptions of
-    the same position are a programming error. *)
+    the same position are a programming error. It is {!splice} with a
+    single-declaration list, and refuses on the same terms. *)
 
 val splice :
   t ->
   at:int ->
   absorbed:int list ->
   new_decls:Declaration.declaration list ->
-  unit
+  bool
 (** [splice t ~at ~absorbed ~new_decls] generalises {!absorb}: emit each
     declaration of [new_decls] in order at position [at] and mark every position
     in [absorbed] as consumed. Suits composers that need to replace a contiguous
     run with multiple declarations (e.g. a non-important shorthand followed by a
-    re-stated important longhand). *)
+    re-stated important longhand).
+
+    [false], with the index left untouched, when a declaration of [new_decls]
+    mixes a CSS-wide keyword with other components: CSS Cascade 5 sec. 7.3 makes
+    that invalid CSS whatever family built it, so the index is the one gate
+    every composer's emission passes through. The caller leaves the run as its
+    longhands. *)
 
 val is_absorbed : t -> int -> bool
 (** [is_absorbed t i] is [true] when position [i] has been absorbed by a

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -1474,7 +1474,11 @@ let try_merge_box_shorthand ~original ~property ~vs ~important ~absorb
               preserve_list vs
                 (collapse_box_lengths [ top; right; bottom; left ])
             in
-            (Declaration.v ~important property value, rest'))
+            let merged = Declaration.v ~important property value in
+            (* Absorbing a side into [margin: inherit] leaves the other three
+               holding the keyword beside a concrete one. *)
+            if Declaration.value_has_css_wide_mix merged then (original, rest)
+            else (merged, rest'))
 
 (* CSS Overflow 3 sec. 3.1: [overflow] is the [overflow-x overflow-y] shorthand.
    When the two longhands appear together with matching importance and neither
@@ -1527,7 +1531,9 @@ let merge_overflow_longhands decls =
             let merged =
               Declaration.v ~important Overflow (combined_overflow v_x v_y)
             in
-            go ((idx, merged) :: acc) rest')
+            if Declaration.value_has_css_wide_mix merged then
+              go (item :: acc) rest
+            else go ((idx, merged) :: acc) rest')
     | ((idx, Declaration { property = Overflow_y; value = v_y; important; _ })
        as item)
       :: rest -> (
@@ -1537,7 +1543,9 @@ let merge_overflow_longhands decls =
             let merged =
               Declaration.v ~important Overflow (combined_overflow v_x v_y)
             in
-            go ((idx, merged) :: acc) rest')
+            if Declaration.value_has_css_wide_mix merged then
+              go (item :: acc) rest
+            else go ((idx, merged) :: acc) rest')
     | d :: rest -> go (d :: acc) rest
   in
   preserve_list decls (go [] decls)
@@ -1900,15 +1908,19 @@ let compose_box_via_index ~ctx idx =
     else
       match try_one !i with
       | Some (Single shorthand) ->
-          Rule_index.absorb idx ~at:!i
-            ~absorbed:[ !i; !i + 1; !i + 2; !i + 3 ]
-            ~shorthand;
-          i := !i + 4
+          if
+            Rule_index.absorb idx ~at:!i
+              ~absorbed:[ !i; !i + 1; !i + 2; !i + 3 ]
+              ~shorthand
+          then i := !i + 4
+          else incr i
       | Some (Split decls) ->
-          Rule_index.splice idx ~at:!i
-            ~absorbed:[ !i; !i + 1; !i + 2; !i + 3 ]
-            ~new_decls:decls;
-          i := !i + 4
+          if
+            Rule_index.splice idx ~at:!i
+              ~absorbed:[ !i; !i + 1; !i + 2; !i + 3 ]
+              ~new_decls:decls
+          then i := !i + 4
+          else incr i
       | None -> incr i
   done
 
@@ -2113,8 +2125,9 @@ let compose_pair_via_index idx =
   while !i < n do
     match try_any !i with
     | Some shorthand ->
-        Rule_index.absorb idx ~at:!i ~absorbed:[ !i; !i + 1 ] ~shorthand;
-        i := !i + 2
+        if Rule_index.absorb idx ~at:!i ~absorbed:[ !i; !i + 1 ] ~shorthand then
+          i := !i + 2
+        else incr i
     | None -> incr i
   done
 
@@ -2127,8 +2140,12 @@ let compose_fixed3_via_index idx ~try_compose =
     match try_compose idx !i with
     | None -> incr i
     | Some shorthand ->
-        Rule_index.absorb idx ~at:!i ~absorbed:[ !i; !i + 1; !i + 2 ] ~shorthand;
-        i := !i + 3
+        if
+          Rule_index.absorb idx ~at:!i
+            ~absorbed:[ !i; !i + 1; !i + 2 ]
+            ~shorthand
+        then i := !i + 3
+        else incr i
   done
 
 (* Same walk for a family whose run length varies: [try_compose] reports the
@@ -2144,8 +2161,8 @@ let compose_run_via_index idx ~try_compose =
       | None -> incr i
       | Some (shorthand, k) ->
           let absorbed = List.init k (fun j -> !i + j) in
-          Rule_index.absorb idx ~at:!i ~absorbed ~shorthand;
-          i := !i + k
+          if Rule_index.absorb idx ~at:!i ~absorbed ~shorthand then i := !i + k
+          else incr i
   done
 
 (* Collect the contiguous run of one family's longhands starting at [i], as
@@ -2316,8 +2333,8 @@ let compose_font_via_index idx =
       | None -> incr i
       | Some shorthand ->
           let absorbed = [ !i; !i + 1; !i + 2; !i + 3; !i + 4 ] in
-          Rule_index.absorb idx ~at:!i ~absorbed ~shorthand;
-          i := !i + 5
+          if Rule_index.absorb idx ~at:!i ~absorbed ~shorthand then i := !i + 5
+          else incr i
   done
 
 (* The property a name spells, when the reader types one.
@@ -2685,8 +2702,8 @@ let compose_border_via_index idx =
               !i + 11;
             ]
           in
-          Rule_index.absorb idx ~at:!i ~absorbed ~shorthand;
-          i := !i + 12
+          if Rule_index.absorb idx ~at:!i ~absorbed ~shorthand then i := !i + 12
+          else incr i
   done
 
 (* Compose the [border] shorthand from the three whole-border longhands
@@ -2806,15 +2823,17 @@ let compose_border_whole_via_index ~ctx idx =
       if is_border_image_decl d then ();
       incr i)
     else
+      let step_over () =
+        let d = Rule_index.decl_at idx !i in
+        if is_border_image_decl d then seen_border_image := true;
+        incr i
+      in
       match try_compose_border_whole_at ~ctx idx !i with
       | Some shorthand ->
           let absorbed = [ !i; !i + 1; !i + 2 ] in
-          Rule_index.absorb idx ~at:!i ~absorbed ~shorthand;
-          i := !i + 3
-      | None ->
-          let d = Rule_index.decl_at idx !i in
-          if is_border_image_decl d then seen_border_image := true;
-          incr i
+          if Rule_index.absorb idx ~at:!i ~absorbed ~shorthand then i := !i + 3
+          else step_over ()
+      | None -> step_over ()
   done
 
 (* CSS Backgrounds 3: the [border] shorthand resets [border-image] to its
@@ -2953,19 +2972,7 @@ let try_compose_border_image_at idx i =
 
 let compose_border_image_via_index ~ctx idx =
   if scope ctx <> `Stylesheet then ()
-  else
-    let n = Rule_index.length idx in
-    let i = ref 0 in
-    while !i < n do
-      if Rule_index.is_absorbed idx !i then incr i
-      else
-        match try_compose_border_image_at idx !i with
-        | None -> incr i
-        | Some (shorthand, k) ->
-            let absorbed = List.init k (fun j -> !i + j) in
-            Rule_index.absorb idx ~at:!i ~absorbed ~shorthand;
-            i := !i + k
-    done
+  else compose_run_via_index idx ~try_compose:try_compose_border_image_at
 
 let compose_border_image_shorthand ~ctx decls =
   let idx = Rule_index.build (List.map snd decls) in
@@ -3321,15 +3328,17 @@ let compose_mask_via_index ~ctx idx =
       if is_mask_border_decl_raw d then ();
       incr i)
     else
+      let step_over () =
+        let d = Rule_index.decl_at idx !i in
+        if is_mask_border_decl_raw d then seen_mask_border := true;
+        incr i
+      in
       match try_compose_mask_at ~ctx idx !i with
       | Some (shorthand, k) ->
           let absorbed = List.init k (fun j -> !i + j) in
-          Rule_index.absorb idx ~at:!i ~absorbed ~shorthand;
-          i := !i + k
-      | None ->
-          let d = Rule_index.decl_at idx !i in
-          if is_mask_border_decl_raw d then seen_mask_border := true;
-          incr i
+          if Rule_index.absorb idx ~at:!i ~absorbed ~shorthand then i := !i + k
+          else step_over ()
+      | None -> step_over ()
   done
 
 (* The property a [transition-property] entry names, against the property a

--- a/test/test_rule_index.ml
+++ b/test/test_rule_index.ml
@@ -14,6 +14,14 @@ let _solid_outline_color =
 
 let stub_shorthand = red
 
+(* A shorthand the index has to refuse: CSS Cascade 5 sec. 7.3 gives a CSS-wide
+   keyword no meaning beside another component. *)
+let mixed_shorthand =
+  Declaration.v Properties.Margin ([ Px 1.0; Inherit ] : Values.length list)
+
+let commits name t ~at ~absorbed ~shorthand =
+  Alcotest.(check bool) name true (Rule_index.absorb t ~at ~absorbed ~shorthand)
+
 let test_empty_index () =
   let t = Rule_index.build [] in
   Alcotest.(check int) "empty index has length 0" 0 (Rule_index.length t);
@@ -38,7 +46,7 @@ let test_absorb_marks_positions () =
   Alcotest.(check bool)
     "position 0 not absorbed initially" false
     (Rule_index.is_absorbed t 0);
-  Rule_index.absorb t ~at:0 ~absorbed:[ 0; 1 ] ~shorthand:stub_shorthand;
+  commits "absorb commits" t ~at:0 ~absorbed:[ 0; 1 ] ~shorthand:stub_shorthand;
   Alcotest.(check bool)
     "position 0 carries the shorthand (not 'absorbed')" false
     (Rule_index.is_absorbed t 0);
@@ -50,7 +58,7 @@ let test_to_list_emits_shorthand_in_place () =
   let t =
     Rule_index.build [ red; solid_outline_width; solid_outline_style; blue ]
   in
-  Rule_index.absorb t ~at:1 ~absorbed:[ 1; 2 ] ~shorthand:stub_shorthand;
+  commits "absorb commits" t ~at:1 ~absorbed:[ 1; 2 ] ~shorthand:stub_shorthand;
   let out = Rule_index.to_list t in
   Alcotest.(check int) "length unchanged minus absorbed" 3 (List.length out);
   match out with
@@ -64,14 +72,28 @@ let test_to_list_emits_shorthand_in_place () =
 
 let test_absorb_double_consume_raises () =
   let t = Rule_index.build [ red; blue ] in
-  Rule_index.absorb t ~at:0 ~absorbed:[ 0; 1 ] ~shorthand:stub_shorthand;
+  commits "absorb commits" t ~at:0 ~absorbed:[ 0; 1 ] ~shorthand:stub_shorthand;
   let raised =
     try
-      Rule_index.absorb t ~at:1 ~absorbed:[ 1 ] ~shorthand:stub_shorthand;
+      let (_ : bool) =
+        Rule_index.absorb t ~at:1 ~absorbed:[ 1 ] ~shorthand:stub_shorthand
+      in
       false
     with Failure _ -> true
   in
   Alcotest.(check bool) "re-absorbing a slot fails" true raised
+
+let test_absorb_refuses_css_wide_mix () =
+  let t = Rule_index.build [ red; blue ] in
+  Alcotest.(check bool)
+    "a shorthand mixing a css-wide keyword is refused" false
+    (Rule_index.absorb t ~at:0 ~absorbed:[ 0; 1 ] ~shorthand:mixed_shorthand);
+  Alcotest.(check bool)
+    "the refused positions stay live" false
+    (Rule_index.is_absorbed t 1);
+  Alcotest.(check int)
+    "the rule keeps both longhands" 2
+    (List.length (Rule_index.to_list t))
 
 let suite =
   ( "rule_index",
@@ -85,4 +107,6 @@ let suite =
         test_to_list_emits_shorthand_in_place;
       Alcotest.test_case "double-absorb raises" `Quick
         test_absorb_double_consume_raises;
+      Alcotest.test_case "absorb refuses a css-wide mix" `Quick
+        test_absorb_refuses_css_wide_mix;
     ] )

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -867,6 +867,203 @@ let test_box_family_non_equivalence_still_reports () =
     ".a{scroll-margin:1px}"
     ".a{scroll-margin-top:1px;scroll-margin-right:1px;scroll-margin-bottom:1px}"
 
+(* CSS Cascade 5 sec. 7.3: a CSS-wide keyword is the entire value of a
+   declaration or nothing at all. Pasting one into a composed shorthand makes a
+   declaration the reader rejects and a browser drops, so a run holding one has
+   to stay as its longhands. *)
+let unfoldable_css_wide = [ "inherit"; "unset"; "revert"; "revert-layer" ]
+
+(* The emission is checked twice: for the expected text, and for reading back. A
+   declaration the reader rejects is one the browser drops, so an emission that
+   fails to re-read is a rendering change, not a shorter spelling. *)
+let minifies_to name ~into css =
+  let out =
+    match Css.of_string css with
+    | Error e -> Alcotest.failf "%s: parse failed: %s" name (Error.to_string e)
+    | Ok { stylesheet; _ } ->
+        String.trim (Css.to_string ~minify:true (Css.optimize stylesheet))
+  in
+  Alcotest.(check string) name into out;
+  match Css.of_string ~strict:true out with
+  | Ok _ -> ()
+  | Error e ->
+      Alcotest.failf "%s: emission is not readable CSS: %s" name
+        (Error.to_string e)
+
+(* Every family whose composer takes a longhand value as a shorthand component,
+   as the run that composes into it with the last value left open. *)
+let css_wide_component_runs =
+  [
+    ( "padding",
+      "padding-top:1px;padding-right:2px;padding-bottom:3px;padding-left:" );
+    ("margin", "margin-top:1px;margin-right:2px;margin-bottom:3px;margin-left:");
+    ("inset", "top:1px;right:2px;bottom:3px;left:");
+    ( "border-color",
+      "border-top-color:red;border-right-color:#0f0;border-bottom-color:#00f;border-left-color:"
+    );
+    ( "border-width",
+      "border-top-width:1px;border-right-width:2px;border-bottom-width:3px;border-left-width:"
+    );
+    ( "border-radius",
+      "border-top-left-radius:1px;border-top-right-radius:2px;border-bottom-right-radius:3px;border-bottom-left-radius:"
+    );
+    ( "scroll-margin",
+      "scroll-margin-top:1px;scroll-margin-right:2px;scroll-margin-bottom:3px;scroll-margin-left:"
+    );
+    ( "scroll-padding",
+      "scroll-padding-top:1px;scroll-padding-right:2px;scroll-padding-bottom:3px;scroll-padding-left:"
+    );
+    ("gap", "row-gap:1px;column-gap:");
+    ("margin-inline", "margin-inline-start:1px;margin-inline-end:");
+    ("margin-block", "margin-block-start:1px;margin-block-end:");
+    ("padding-inline", "padding-inline-start:1px;padding-inline-end:");
+    ("padding-block", "padding-block-start:1px;padding-block-end:");
+    ("inset-inline", "inset-inline-start:1px;inset-inline-end:");
+    ("inset-block", "inset-block-start:1px;inset-block-end:");
+    ("place-content", "align-content:center;justify-content:");
+    ("place-items", "align-items:center;justify-items:");
+    ("place-self", "align-self:center;justify-self:");
+    ("overflow", "overflow-x:hidden;overflow-y:");
+    ("outline", "outline-width:1px;outline-style:solid;outline-color:");
+    ( "list-style",
+      "list-style-type:square;list-style-position:inside;list-style-image:" );
+    ("flex", "flex-grow:1;flex-shrink:1;flex-basis:");
+    ( "text-decoration",
+      "text-decoration-line:underline;text-decoration-style:solid;text-decoration-color:"
+    );
+    ("border", "border-width:1px;border-style:solid;border-color:");
+  ]
+
+let test_css_wide_keyword_is_not_a_shorthand_component () =
+  List.iter
+    (fun (family, run) ->
+      List.iter
+        (fun keyword ->
+          let css = String.concat "" [ ".a{"; run; keyword; "}" ] in
+          minifies_to (String.concat " " [ family; keyword ]) ~into:css css)
+        unfoldable_css_wide)
+    css_wide_component_runs
+
+(* The keyword reaches the composer from another rule just as well: rules with a
+   matching selector merge before the declarations are composed. *)
+let test_css_wide_keyword_from_another_rule () =
+  List.iter
+    (fun keyword ->
+      minifies_to
+        (String.concat " " [ "margin absorbs a later side"; keyword ])
+        ~into:(String.concat "" [ ".a{margin:"; keyword; ";margin-top:1px}" ])
+        (String.concat "" [ ".a{margin:"; keyword; "}.a{margin-top:1px}" ]);
+      minifies_to
+        (String.concat " " [ "padding absorbs a later side"; keyword ])
+        ~into:(String.concat "" [ ".a{padding:"; keyword; ";padding-top:1px}" ])
+        (String.concat "" [ ".a{padding:"; keyword; "}.a{padding-top:1px}" ]);
+      minifies_to
+        (String.concat " " [ "overflow across two rules"; keyword ])
+        ~into:
+          (String.concat ""
+             [ ".a{overflow-x:hidden;overflow-y:"; keyword; "}" ])
+        (String.concat ""
+           [ ".a{overflow-x:hidden}.a{overflow-y:"; keyword; "}" ]);
+      (* Four sides are four disjoint cascade slots, so the merged rule is free
+         to order them however it likes; what it may not do is contract them. *)
+      minifies_to
+        (String.concat " " [ "four box sides across four rules"; keyword ])
+        ~into:
+          (String.concat ""
+             [
+               ".a{margin-bottom:3px;margin-left:";
+               keyword;
+               ";margin-right:2px;margin-top:1px}";
+             ])
+        (String.concat ""
+           [
+             ".a{margin-top:1px}.a{margin-right:2px}.a{margin-bottom:3px}.a{margin-left:";
+             keyword;
+             "}";
+           ]))
+    unfoldable_css_wide
+
+let test_css_wide_keyword_with_importance () =
+  (* Four important sides: the same-importance box composer. *)
+  minifies_to "every side important"
+    ~into:
+      ".a{margin-top:1px!important;margin-right:2px!important;margin-bottom:3px!important;margin-left:inherit!important}"
+    ".a{margin-top:1px!important;margin-right:2px!important;margin-bottom:3px!important;margin-left:inherit!important}";
+  (* One important side: the mixed-importance split, which emits a shorthand and
+     re-states the important longhand after it. *)
+  minifies_to "an important side beside the keyword"
+    ~into:
+      ".a{margin-top:1px!important;margin-right:2px;margin-bottom:3px;margin-left:inherit}"
+    ".a{margin-top:1px!important;margin-right:2px;margin-bottom:3px;margin-left:inherit}";
+  minifies_to "the keyword is the important side"
+    ~into:
+      ".a{margin-top:1px;margin-right:2px;margin-bottom:3px;margin-left:inherit!important}"
+    ".a{margin-top:1px;margin-right:2px;margin-bottom:3px;margin-left:inherit!important}";
+  minifies_to "an important pair"
+    ~into:".a{row-gap:1px!important;column-gap:unset!important}"
+    ".a{row-gap:1px!important;column-gap:unset!important}";
+  minifies_to "an important run"
+    ~into:
+      ".a{outline-width:1px!important;outline-style:solid!important;outline-color:revert!important}"
+    ".a{outline-width:1px!important;outline-style:solid!important;outline-color:revert!important}";
+  minifies_to "an important shorthand absorbing an important side"
+    ~into:".a{margin:inherit!important;margin-top:1px!important}"
+    ".a{margin:inherit!important}.a{margin-top:1px!important}"
+
+(* A run whose sides are all the same CSS-wide keyword collapses to a lone
+   keyword, which is a whole declaration value and so stays legal. *)
+let test_uniform_css_wide_sides_still_contract () =
+  List.iter
+    (fun keyword ->
+      minifies_to
+        (String.concat " " [ "four identical box sides"; keyword ])
+        ~into:(String.concat "" [ ".a{margin:"; keyword; "}" ])
+        (String.concat ""
+           [
+             ".a{margin-top:";
+             keyword;
+             ";margin-right:";
+             keyword;
+             ";margin-bottom:";
+             keyword;
+             ";margin-left:";
+             keyword;
+             "}";
+           ]);
+      minifies_to
+        (String.concat " " [ "two identical gap axes"; keyword ])
+        ~into:(String.concat "" [ ".a{gap:"; keyword; "}" ])
+        (String.concat ""
+           [ ".a{row-gap:"; keyword; ";column-gap:"; keyword; "}" ]))
+    unfoldable_css_wide
+
+(* [initial] names a value with a concrete spelling, so the box families fold it
+   to that spelling before composition and the run still contracts. *)
+let test_initial_still_folds_in_box_families () =
+  minifies_to "a lone initial side" ~into:".a{margin-left:0}"
+    ".a{margin-left:initial}";
+  minifies_to "initial as the fourth margin side"
+    ~into:".a{margin:1px 2px 3px 0}"
+    ".a{margin-top:1px;margin-right:2px;margin-bottom:3px;margin-left:initial}";
+  minifies_to "initial as the fourth padding side"
+    ~into:".a{padding:1px 2px 3px 0}"
+    ".a{padding-top:1px;padding-right:2px;padding-bottom:3px;padding-left:initial}";
+  minifies_to "four initial sides" ~into:".a{margin:0}"
+    ".a{margin-top:initial;margin-right:initial;margin-bottom:initial;margin-left:initial}";
+  minifies_to "an initial shorthand absorbing a later side"
+    ~into:".a{margin:1px 0 0}" ".a{margin:initial}.a{margin-top:1px}";
+  (* [scroll-margin] and [scroll-padding] keep [initial] as a keyword, so there
+     it is a whole declaration value like the other four and the run stays
+     expanded. Folding it to [0] would let the run contract again. *)
+  minifies_to "initial in a scroll-margin run"
+    ~into:
+      ".a{scroll-margin-top:initial;scroll-margin-right:1px;scroll-margin-bottom:2px;scroll-margin-left:3px}"
+    ".a{scroll-margin-top:initial;scroll-margin-right:1px;scroll-margin-bottom:2px;scroll-margin-left:3px}";
+  minifies_to "initial in a scroll-padding run"
+    ~into:
+      ".a{scroll-padding-top:initial;scroll-padding-right:1px;scroll-padding-bottom:2px;scroll-padding-left:3px}"
+    ".a{scroll-padding-top:initial;scroll-padding-right:1px;scroll-padding-bottom:2px;scroll-padding-left:3px}"
+
 let suite =
   ( "shorthand",
     [
@@ -918,4 +1115,14 @@ let suite =
         test_box_family_shorthand_equivalence;
       Alcotest.test_case "box family non-equivalence still reports" `Quick
         test_box_family_non_equivalence_still_reports;
+      Alcotest.test_case "css-wide keyword is not a shorthand component" `Quick
+        test_css_wide_keyword_is_not_a_shorthand_component;
+      Alcotest.test_case "css-wide keyword from another rule" `Quick
+        test_css_wide_keyword_from_another_rule;
+      Alcotest.test_case "css-wide keyword with importance" `Quick
+        test_css_wide_keyword_with_importance;
+      Alcotest.test_case "uniform css-wide sides still contract" `Quick
+        test_uniform_css_wide_sides_still_contract;
+      Alcotest.test_case "initial still folds in box families" `Quick
+        test_initial_still_folds_in_box_families;
     ] )


### PR DESCRIPTION
`inherit`, `unset`, `revert` and `revert-layer` are only ever a whole declaration value, never a component of one, so `padding-left: inherit` folded into a run produced `padding: 0 2em 10% inherit`, which browsers drop entirely. Cascade's own reader already rejected those strings; only the writer did not know.

The guard sits at the rule index, where every composer commits its emission, and at the two mergers that predate it. `Rule_index.absorb` and `splice` return a `bool` now, and `Declaration.value_has_css_wide_mix` is public. Measured on the 504-fixture corpus: +222 bytes of 33.8 MB, CPU within noise.
