### PR TITLE
resolve: sort a layer's own rules after its sublayers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -755,6 +755,9 @@ entry points both moved.
 - `Css.Resolve` answers `:nth-child(... of S)`, the typed `:nth-of-type()`
   family, `:has()`, the `i` and `s` attribute case flags and `:scope`, which
   read `Unsupported` and left `Css.Apply` keeping the rule (#607)
+- `Css.Resolve` ranks a cascade layer's own rules after every one of its
+  sublayers, as css-cascade-5 sec. 6.4.3 requires, so `@layer a` outranks
+  `@layer a.b` however the two were declared
 - `Resolve.prepare` and `Resolve.Make.resolve_prepared` split the sheet-only
   work out of `resolve`, so a caller walking a document buckets the rules once
   rather than per node, allocating 4.6x less over ten queries (#567)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -205,6 +205,8 @@ entry points both moved.
 - Lenient parsing preserves a value opaquely when the property is unknown, the
   value carries a runtime substitution, or it is a colour fallback; a value the
   typed reader rejects is an invalid declaration and is dropped (#787, #813)
+- `display` accepts `grid-lanes` and `inline-grid-lanes`, the two values CSS
+  Grid 3 sec. 2.2 establishes grid lanes layout with
 - Grid track sizes accept math functions that resolve to `<flex>`, including
   `calc(1fr * 2)`, `min(1fr, 2fr)` and `clamp(100px, 1fr, 300px)`, in explicit,
   repeated and automatic tracks (#749)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -1899,6 +1899,8 @@ type display = Properties.display =
   | Inline_flex
   | Grid
   | Inline_grid
+  | Grid_lanes
+  | Inline_grid_lanes
   | None
   | Flow_root
   | Table

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -49,6 +49,11 @@ let read_display_legacy t : display =
       ("inline-flex", Inline_flex);
       ("grid", Grid);
       ("inline-grid", Inline_grid);
+      (* CSS Grid 3 (ED) sec. 2.2 adds these two to [display] and to neither
+         [<display-inside>] nor [<display-outside>], so they are whole values
+         and pair with nothing. *)
+      ("grid-lanes", Grid_lanes);
+      ("inline-grid-lanes", Inline_grid_lanes);
       ("flow-root", Flow_root);
       ("table", Table);
       ("table-row", Table_row);
@@ -268,6 +273,8 @@ let rec pp_display : display Pp.t =
   | Inline_flex -> Pp.string ctx "inline-flex"
   | Grid -> Pp.string ctx "grid"
   | Inline_grid -> Pp.string ctx "inline-grid"
+  | Grid_lanes -> Pp.string ctx "grid-lanes"
+  | Inline_grid_lanes -> Pp.string ctx "inline-grid-lanes"
   | Flow_root -> Pp.string ctx "flow-root"
   | Table -> Pp.string ctx "table"
   | Table_row -> Pp.string ctx "table-row"

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -72,6 +72,8 @@ type display =
   | Inline_flex
   | Grid
   | Inline_grid
+  | Grid_lanes
+  | Inline_grid_lanes
   | None
   | Flow_root
   | Table

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -83,9 +83,10 @@ let nth_hits nth i =
 
 (* Cascade layers. Layer names form a tree: [@layer a.b] names the sublayer [b]
    of [a], and so does [@layer a { @layer b { ... } }]. The cascade only needs
-   the flattened pre-order of that tree, so a layer is keyed by its path - the
-   idents from the root down - and the order is a list of paths, oldest first
-   (css-cascade-5 sec. 6.4.2). *)
+   that tree flattened, so a layer is keyed by its path - the idents from the
+   root down - and the order is a list of paths, weakest first: siblings by
+   first declaration (css-cascade-5 sec. 6.4.2), each parent after the whole of
+   its subtree (sec. 6.4.3). *)
 
 let parent_layer path =
   match List.rev path with [] | [ _ ] -> None | _ :: up -> Some (List.rev up)
@@ -108,30 +109,25 @@ let layer_key path =
 
 let qualify parent name = match parent with None -> name | Some p -> p @ name
 
-let rec is_ancestor p n =
-  match (p, n) with
-  | [], _ -> true
-  | _ :: _, [] -> false
-  | x :: xs, y :: ys -> String.equal x y && is_ancestor xs ys
-
 (* A sublayer is ordered inside its parent, not at the end of the sheet: in
    [@layer a.b {} @layer c {} @layer a.d {}] the layer [a.d] joins [a]'s subtree
-   and so still precedes [c]. *)
+   and so still precedes [c]. A parent's own rules close that subtree
+   (css-cascade-5 sec. 6.4.3: "Unlayered rules are sorted later than any layered
+   rules within the same parent layer"), so [p]'s entry stands for them and sits
+   last in its run: a new sublayer goes immediately before it, which is past
+   every sublayer declared earlier. *)
 let insert_layer order name =
   if List.exists (Stylesheet.equal_layer_name name) order then order
   else
     match parent_layer name with
     | None -> order @ [ name ]
     | Some p ->
-        (* [p]'s subtree is contiguous, so the insertion point is just past its
-           last member; [entered] says the scan has reached it. *)
-        let rec insert entered = function
-          | x :: rest when is_ancestor p x -> x :: insert true rest
-          | rest when entered -> name :: rest
+        let rec insert = function
           | [] -> [ name ]
-          | x :: rest -> x :: insert entered rest
+          | x :: rest when Stylesheet.equal_layer_name p x -> name :: x :: rest
+          | x :: rest -> x :: insert rest
         in
-        insert false order
+        insert order
 
 (* Naming a sublayer creates its ancestors first, so [@layer a.b] declares [a]
    then [a.b]. *)

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -98,16 +98,17 @@ val layer_order : Stylesheet.t -> string list
     however it was written ([@layer a.b] or [@layer a { @layer b }]). Each ident
     of a path carries the escapes that read it back (css-syntax-3 sec. 2.1), so
     the layer named [a.b] is the path [a\.b] and stays apart from the sublayer
-    [a.b]. Layers come in order of first appearance with each sublayer inside
-    its parent's run (css-cascade-5 sec. 6.4.2), and an [@layer a, b;] statement
-    declares its names there just as a block does. Every anonymous
-    [@layer { ... }] block is a layer of its own, keyed by a path holding a
-    U+0000 that no author can write - a caller that prints these paths has to
-    spell those out itself. The layers counted are those {!Make.resolve} ranks
-    against, so a layer declared inside one of the blocks it does not walk - a
-    conditional group rule ([@media], [@supports], [@container],
-    [@-moz-document], [@when], [@else]), [@starting-style], [@scope], or an
-    origin wrapper - is not part of this order.
+    [a.b]. Sibling layers come in order of first appearance, each sublayer
+    inside its parent's run (css-cascade-5 sec. 6.4.2) and the parent itself at
+    the end of that run, since its own rules sort after every rule in a sublayer
+    (sec. 6.4.3). An [@layer a, b;] statement declares its names there just as a
+    block does. Every anonymous [@layer { ... }] block is a layer of its own,
+    keyed by a path holding a U+0000 that no author can write - a caller that
+    prints these paths has to spell those out itself. The layers counted are
+    those {!Make.resolve} ranks against, so a layer declared inside one of the
+    blocks it does not walk - a conditional group rule ([@media], [@supports],
+    [@container], [@-moz-document], [@when], [@else]), [@starting-style],
+    [@scope], or an origin wrapper - is not part of this order.
 
     This is the [~layer_order] that {!Stylesheet.cascade_layer_precedence_rank}
     expects. *)
@@ -145,9 +146,10 @@ module Make (N : NODE) : sig
       declarations that win for [node] after flattening nesting and applying the
       cascade: selector matching, [!important] over normal, then cascade layer,
       specificity and source order. [@layer] blocks and [@layer a, b;]
-      statements order the layers by first appearance, sublayers included; among
-      normal declarations the last layer wins and an unlayered declaration beats
-      them all, and for [!important] declarations that order reverses.
+      statements order the layers by first appearance, sublayers included and
+      each parent behind its own sublayers; among normal declarations the last
+      layer wins and an unlayered declaration beats them all, and for
+      [!important] declarations that order reverses.
 
       Style rules and [@layer] are the only blocks walked. A rule inside a
       conditional group rule ([@media], [@supports], [@container],

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -700,6 +700,10 @@ let display () =
   c ~expected:"display:inline-flex" "display: inline-flex";
   c ~expected:"display:grid" "display: grid";
   c ~expected:"display:inline-grid" "display: inline-grid";
+  (* CSS Grid 3 (ED, 2 September 2026) sec. 2.2: "New values: grid-lanes |
+     inline-grid-lanes". *)
+  c ~expected:"display:grid-lanes" "display: grid-lanes";
+  c ~expected:"display:inline-grid-lanes" "display: inline-grid-lanes";
   c ~expected:"display:table" "display: table";
   c ~expected:"display:table-row" "display: table-row";
   c ~expected:"display:table-cell" "display: table-cell";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1225,6 +1225,11 @@ let test_display () =
   check_display "inline-flex";
   check_display "grid";
   check_display "inline-grid";
+  (* CSS Grid 3 (ED, 2 September 2026) sec. 2.2 adds two values to [display]:
+     "New values: grid-lanes | inline-grid-lanes". They establish grid lanes
+     layout at block and inline level. *)
+  check_display "grid-lanes";
+  check_display "inline-grid-lanes";
   check_display "flow-root";
   check_display "table";
   check_display "table-row";
@@ -1262,6 +1267,10 @@ let test_display () =
   (* CSS-wide keyword supported by this reader *)
   check_display "unset";
   neg_cursor read_display "invalid-display";
+  (* sec. 2.2 states the two as whole [display] values and adds neither to
+     [<display-inside>], so neither pairs with a [<display-outside>]. *)
+  neg_cursor ~allow_partial:true read_display "block grid-lanes";
+  neg_cursor ~allow_partial:true read_display "inline inline-grid-lanes";
   (* multiple values *)
   neg_cursor ~allow_partial:true read_display "block inline";
   neg_cursor read_display "flex-";

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -520,16 +520,67 @@ let resolved_color css =
 
 (* Layer names form a tree (css-cascade-5 sec. 6.4.2): [@layer a.b] creates [a]
    first and nests [b] inside it, and a later [@layer a.d] is ordered inside [a]
-   too, so it stays before a top-level layer declared in between. *)
+   too, so it stays before a top-level layer declared in between. Sec. 6.4.3
+   puts the parent's own rules at the end of that subtree: "Unlayered rules are
+   sorted later than any layered rules within the same parent layer (if any)."
+   So [a] outranks [a.b], however the two were written. *)
 let test_resolve_nested_layers () =
   Alcotest.(check (option string))
-    "a sublayer comes after its parent" (Some "color:red")
+    "a sublayer comes before its parent's own rules" (Some "color:blue")
     (resolved_color "@layer a.b{span{color:red}}@layer a{span{color:blue}}");
   Alcotest.(check (option string))
     "a top-level layer sorts after the whole subtree" (Some "color:green")
     (resolved_color
        "@layer a.b{span{color:red}}@layer c{span{color:green}}@layer \
         a.d{span{color:blue}}")
+
+(* The same sec. 6.4.3 rule over every way of writing the pair. A parent's own
+   rules sit in an implicit sub-layer that closes its subtree, so among normal
+   declarations the parent beats each of its sublayers and among important ones
+   every sublayer beats it. Neither answer depends on which was declared first,
+   nor on whether the sublayer is named, nested as a block, anonymous, or only
+   pre-declared by an [@layer a, b;] statement. *)
+let test_parent_layer_closes_its_subtree () =
+  Alcotest.(check (option string))
+    "the parent wins when it is declared second" (Some "color:blue")
+    (resolved_color "@layer a.b{span{color:red}}@layer a{span{color:blue}}");
+  Alcotest.(check (option string))
+    "and when it is declared first" (Some "color:red")
+    (resolved_color "@layer a{span{color:red}}@layer a.b{span{color:blue}}");
+  Alcotest.(check (option string))
+    "the sublayer wins for important, sublayer declared first"
+    (Some "color:red!important")
+    (resolved_color
+       "@layer a.b{span{color:red!important}}@layer \
+        a{span{color:blue!important}}");
+  Alcotest.(check (option string))
+    "the sublayer wins for important, parent declared first"
+    (Some "color:blue!important")
+    (resolved_color
+       "@layer a{span{color:red!important}}@layer \
+        a.b{span{color:blue!important}}");
+  Alcotest.(check (option string))
+    "a sublayer block nested in its parent orders the same way"
+    (Some "color:blue")
+    (resolved_color "@layer a{@layer b{span{color:red}}span{color:blue}}");
+  Alcotest.(check (option string))
+    "an anonymous block nested in a parent is one of its sublayers"
+    (Some "color:blue")
+    (resolved_color "@layer a{@layer{span{color:red}}span{color:blue}}");
+  Alcotest.(check (option string))
+    "a statement declaring the parent first does not move its own rules"
+    (Some "color:blue")
+    (resolved_color
+       "@layer a;@layer a.b{span{color:red}}@layer a{span{color:blue}}");
+  Alcotest.(check (option string))
+    "a statement declaring the sublayer first does not either"
+    (Some "color:blue")
+    (resolved_color
+       "@layer a.b;@layer a{span{color:blue}}@layer a.b{span{color:red}}");
+  Alcotest.(check (list string))
+    "the parent closes the run its sublayers open" [ "a.b"; "a.d"; "a"; "c" ]
+    (Resolve.layer_order
+       (sheet_of "@layer a.b{span{color:red}}@layer c{}@layer a.d{}"))
 
 (* Each unnamed [@layer { }] block is a layer of its own, so two of them order
    like any other pair: the last wins for normal declarations, the first for
@@ -595,7 +646,7 @@ let test_resolve_skips_conditional_and_scoped_blocks () =
    not part of that order. *)
 let test_layer_order_counts_the_blocks_resolve_walks () =
   Alcotest.(check (list string))
-    "a nested @layer block is counted" [ "a"; "a.b" ]
+    "a nested @layer block is counted" [ "a.b"; "a" ]
     (Resolve.layer_order (sheet_of "@layer a{@layer b{span{color:red}}}"));
   List.iter
     (fun (label, before, after) ->
@@ -656,10 +707,10 @@ let test_resolve_escaped_dot_layers () =
    an ident cannot pass for the separator between two. *)
 let test_layer_order_escaped_dot () =
   Alcotest.(check (list string))
-    "a dot inside an ident is not a path separator" [ "a"; "a.b"; "a\\.b" ]
+    "a dot inside an ident is not a path separator" [ "a.b"; "a"; "a\\.b" ]
     (Resolve.layer_order (sheet_of "@layer a.b;@layer a\\2e b;"));
   Alcotest.(check (list string))
-    "a sublayer of the layer named a.b" [ "a\\.b"; "a\\.b.c" ]
+    "a sublayer of the layer named a.b" [ "a\\.b.c"; "a\\.b" ]
     (Resolve.layer_order (sheet_of "@layer a\\2e b.c;"))
 
 (* {!Apply.Make} reuses the same {!Node} adapter: a static rule projects onto
@@ -795,6 +846,8 @@ let suite =
         test_resolve_cascade;
       Alcotest.test_case "nested layer names order as a tree" `Quick
         test_resolve_nested_layers;
+      Alcotest.test_case "a parent layer closes its own subtree" `Quick
+        test_parent_layer_closes_its_subtree;
       Alcotest.test_case "anonymous layers are distinct" `Quick
         test_resolve_anonymous_layers;
       Alcotest.test_case "resolve skips conditional and scoped blocks" `Quick


### PR DESCRIPTION
css-cascade-5 sec. 6.4.3 sorts unlayered rules later than any layered rules within the same parent layer, so `@layer a.b{...}@layer a{...}` gives the `a` block the win. Cascade ranked a parent at its first-declaration point, inverting every parent-versus-sublayer conflict, and four assertions in `test_resolve.ml` encoded that order.

Also adds `display: grid-lanes` and `inline-grid-lanes`, which CSS Grid 3 gives display and which cascade dropped. That widens the public `Css.display` variant, so an exhaustive match downstream stops compiling.
