### PR TITLE
test: sample computed style in standards mode

### DIFF
--- a/test/render/at_rule_conditions.js
+++ b/test/render/at_rule_conditions.js
@@ -43,6 +43,8 @@ const CHROME = process.env.CHROME;
 const jobsFile = process.argv[2];
 const workDir = process.argv[3];
 
+const frameJs = fs.readFileSync(path.join(__dirname, 'frame.js'), 'utf8');
+
 // Runs inside the page.
 const HARNESS = `
 // Media Queries 4 sec. 2.4: a discrete feature is a keyword out of a fixed
@@ -211,6 +213,15 @@ function acMain(payload) {
   var out = [];
   var style = document.getElementById('ac-sheet');
   var probe = document.getElementById('ac-probe');
+  // A page in the other mode answers about a renderer nobody browses in, and
+  // every verdict below is read out of it: say so and report nothing else.
+  try { rdAssertStandards(document, 'the page'); }
+  catch (e) {
+    out.push(['x', 'page', String((e && e.message) || e)].join('\\t'));
+    document.body.setAttribute('data-v',
+      btoa(unescape(encodeURIComponent(out.join('\\n')))));
+    return;
+  }
   try { acDiscover(payload.env, out); }
   catch (e) { out.push(['x', 'discover', String((e && e.message) || e)].join('\\t')); }
   try { acMedia(payload.env, payload.media, style, probe, out); }
@@ -235,6 +246,7 @@ function page(payload) {
   return '<!doctype html><html><head><meta charset="utf-8">' +
     '<style id="ac-sheet"></style></head><body><div id="ac-probe"></div>' +
     '<script id="ac-jobs" type="application/json">' + json + '</script>' +
+    '<script>' + frameJs + '</script>' +
     '<script>' + HARNESS +
     'acMain(JSON.parse(document.getElementById("ac-jobs").textContent));</script>' +
     '</body></html>';

--- a/test/render/driver.js
+++ b/test/render/driver.js
@@ -29,6 +29,7 @@ const MAX_DIFFS = 200;
 const CHUNK_BYTES = 512 * 1024;
 
 const domJs = fs.readFileSync(path.join(__dirname, 'dom.js'), 'utf8');
+const frameJs = fs.readFileSync(path.join(__dirname, 'frame.js'), 'utf8');
 
 // Runs inside the page.
 const HARNESS = `
@@ -107,13 +108,16 @@ function rdJob(doc, job, out) {
 }
 function rdMain(jobs) {
   var out = [];
-  var frame = document.createElement('iframe');
-  frame.width = 1024;
-  frame.height = 768;
-  frame.style.border = '0';
-  document.body.appendChild(frame);
-  var doc = frame.contentDocument;
+  // A frame nobody can sample is every job's failure, and the reader keys an
+  // error by the job it belongs to.
+  var doc = null, broken = null;
+  try { doc = rdStandardsFrame(window, 1024, 768); }
+  catch (e) { broken = String((e && e.message) || e); }
   jobs.forEach(function (job) {
+    if (broken !== null) {
+      out.push(['x', job.id, broken].join('\\t'));
+      return;
+    }
     try { rdJob(doc, job, out); }
     catch (e) { out.push(['x', job.id, String((e && e.message) || e)].join('\\t')); }
   });
@@ -128,6 +132,7 @@ function page(jobs) {
   return '<!doctype html><html><head><meta charset="utf-8"></head><body>' +
     '<script id="rd-jobs" type="application/json">' + payload + '</script>' +
     '<script>' + domJs + '</script>' +
+    '<script>' + frameJs + '</script>' +
     '<script>var MAX_DIFFS = ' + MAX_DIFFS + ';' + HARNESS +
     'rdMain(JSON.parse(document.getElementById("rd-jobs").textContent));</script>' +
     '</body></html>';

--- a/test/render/frame.js
+++ b/test/render/frame.js
@@ -1,0 +1,32 @@
+// The frame the page-side harnesses read computed style out of.
+//
+// A created iframe's document has no doctype, so it is in quirks mode: a
+// unitless length is a length, a percentage height resolves against the
+// viewport instead of an auto-height parent, and a table does not inherit
+// font-size. Every value sampled there answers for a rendering mode no page
+// uses, so a clean run in it says nothing about a run under a doctype.
+//
+// The doctype is written before the frame has parsed anything: a document that
+// has already styled something in quirks mode goes on rendering that way after
+// compatMode says otherwise. The check is what holds the frame in standards
+// mode across a later edit, and every caller reports a failed one as its own
+// kind of error.
+function rdAssertStandards(doc, what) {
+  if (doc.compatMode !== 'CSS1Compat')
+    throw new Error(what + ' is in ' + doc.compatMode + ', not CSS1Compat: ' +
+      'the reading is a quirks-mode one and answers for no page');
+  return doc;
+}
+
+function rdStandardsFrame(win, width, height) {
+  var frame = win.document.createElement('iframe');
+  frame.width = width;
+  frame.height = height;
+  frame.style.border = '0';
+  win.document.body.appendChild(frame);
+  var doc = frame.contentDocument;
+  doc.open();
+  doc.write('<!DOCTYPE html><html><head></head><body></body></html>');
+  doc.close();
+  return rdAssertStandards(frame.contentDocument, 'the sampling frame');
+}

--- a/test/render/parse_recovery.js
+++ b/test/render/parse_recovery.js
@@ -25,6 +25,8 @@ const jobsFile = process.argv[2];
 const workDir = process.argv[3];
 const CHUNK_BYTES = 512 * 1024;
 
+const frameJs = fs.readFileSync(path.join(__dirname, 'frame.js'), 'utf8');
+
 // Runs inside the page.
 const HARNESS = `
 // Descriptors an at-rule exposes as named attributes rather than through a
@@ -85,24 +87,16 @@ function prFacts(doc, css) {
   return { facts: out, error: err };
 }
 function prMain(jobs) {
-  var frame = document.createElement('iframe');
-  frame.width = 64;
-  frame.height = 64;
-  frame.style.border = '0';
-  document.body.appendChild(frame);
-  // A created iframe's document has no doctype, so it parses CSS in quirks
-  // mode, where a unitless length is a length and much else the standards
-  // parser refuses is accepted. Writing a doctype into it is what makes the
-  // oracle the parser a page gets.
-  var doc = frame.contentDocument;
-  doc.open();
-  doc.write('\u003c!DOCTYPE html>\u003chtml>\u003chead>\u003c/head>' +
-    '\u003cbody>\u003c/body>\u003c/html>');
-  doc.close();
-  doc = frame.contentDocument;
   var out = [];
-  if (doc.compatMode !== 'CSS1Compat') {
-    out.push(['x', 'page', 'a', 'the oracle is in ' + doc.compatMode].join('\t'));
+  // The reader takes an error record whatever job it names, so a frame nobody
+  // can read reports once instead of answering every job out of a bad parser.
+  var doc = null;
+  try { doc = rdStandardsFrame(window, 64, 64); }
+  catch (e) {
+    out.push(['x', 'page', 'a', String((e && e.message) || e)].join('\\t'));
+    document.body.setAttribute('data-pr',
+      btoa(unescape(encodeURIComponent(out.join('\\n')))));
+    return;
   }
   jobs.forEach(function (job) {
     ['a', 'b'].forEach(function (side) {
@@ -122,6 +116,7 @@ function page(jobs) {
   const payload = JSON.stringify(jobs).replace(/</g, '\\u003c');
   return '<!doctype html><html><head><meta charset="utf-8"></head><body>' +
     '<script id="pr-jobs" type="application/json">' + payload + '</script>' +
+    '<script>' + frameJs + '</script>' +
     '<script>' + HARNESS +
     'prMain(JSON.parse(document.getElementById("pr-jobs").textContent));</script>' +
     '</body></html>';

--- a/test/render/resolve_diff.js
+++ b/test/render/resolve_diff.js
@@ -32,6 +32,7 @@ const MAX_DIFFS = 60;
 const CHUNK_BYTES = 512 * 1024;
 
 const domJs = fs.readFileSync(path.join(__dirname, 'dom.js'), 'utf8');
+const frameJs = fs.readFileSync(path.join(__dirname, 'frame.js'), 'utf8');
 
 // Runs inside the page.
 const HARNESS = `
@@ -106,16 +107,19 @@ function cdJob(doc, job, out) {
 }
 function cdMain(jobs) {
   var out = [];
-  var frame = document.createElement('iframe');
-  frame.width = 1024;
-  frame.height = 768;
-  frame.style.border = '0';
-  document.body.appendChild(frame);
-  var doc = frame.contentDocument;
+  // A frame nobody can sample is every job's failure, and the reader keys an
+  // error by the job it belongs to.
+  var doc = null, broken = null;
+  try { doc = rdStandardsFrame(window, 1024, 768); }
+  catch (e) { broken = String((e && e.message) || e); }
   // Engines do not agree on computed styles, so a count means something only
   // beside the engine that produced it.
   out.push(['v', navigator.userAgent].join('\t'));
   jobs.forEach(function (job) {
+    if (broken !== null) {
+      out.push(['x', job.id, broken].join('\\t'));
+      return;
+    }
     try { cdJob(doc, job, out); }
     catch (e) { out.push(['x', job.id, String((e && e.message) || e)].join('\\t')); }
   });
@@ -130,6 +134,7 @@ function page(jobs) {
   return '<!doctype html><html><head><meta charset="utf-8"></head><body>' +
     '<script id="cd-jobs" type="application/json">' + payload + '</script>' +
     '<script>' + domJs + '</script>' +
+    '<script>' + frameJs + '</script>' +
     '<script>var MAX_DIFFS = ' + MAX_DIFFS + ';' + HARNESS +
     'cdMain(JSON.parse(document.getElementById("cd-jobs").textContent));</script>' +
     '</body></html>';

--- a/test/render/shorthand.js
+++ b/test/render/shorthand.js
@@ -32,9 +32,12 @@ const jobsFile = process.argv[2];
 const workDir = process.argv[3];
 const CHUNK_BYTES = 512 * 1024;
 
+const frameJs = fs.readFileSync(path.join(__dirname, 'frame.js'), 'utf8');
+
 // Runs inside the page.
 const HARNESS = `
 function shJob(doc, pristine, job, out) {
+  rdAssertStandards(doc, 'the page');
   var el = doc.createElement('div');
   try { el.style.setProperty(job.property, job.value); }
   catch (e) {
@@ -71,6 +74,7 @@ function page(jobs) {
   const payload = JSON.stringify(jobs).replace(/</g, '\\u003c');
   return '<!doctype html><html><head><meta charset="utf-8"></head><body>' +
     '<script id="sh-jobs" type="application/json">' + payload + '</script>' +
+    '<script>' + frameJs + '</script>' +
     '<script>' + HARNESS +
     'shMain(JSON.parse(document.getElementById("sh-jobs").textContent));</script>' +
     '</body></html>';


### PR DESCRIPTION
`driver.js`, which `render_diff` and `canonical_agree` both run, and `resolve_diff.js` built an iframe with no doctype, so every computed style they compared was read in quirks mode. A shared `frame.js` writes the doctype and asserts `CSS1Compat`, and the harnesses that already had one assert it too.

No count moves, because both sides of each comparison shared the error. It cancels everywhere except where quirks masks a real difference: `#a{width:100}` against `#a{width:100px}` is one render in quirks and two in standards, so unitless-length defects were invisible to both oracles, and replaying the corpus in both modes gives 3860 computed-style differences.
