### PR TITLE
resolve: decline the selectors no engine implements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -823,6 +823,10 @@ entry points both moved.
 
 ### CLI tools
 
+- `cascade apply` and `cascade prune` leave alone the two selector forms
+  Selectors 4 defines and no engine implements, `:empty` over an element
+  holding only white space and the `s` attribute flag, where `apply` used to
+  inline a declaration the browser does not apply (#863)
 - `cascade diff` prints rule differences in the order the expected side names
   the rules, where a hash table's bucket layout decided it, so a report reads
   down the sheet and `--limit` keeps the ones nearest the top (#814, #815)

--- a/lib/apply.ml
+++ b/lib/apply.ml
@@ -12,7 +12,8 @@ module SSet = Set.Make (String)
    stylesheet, so a selector {!Resolve.supported} does not cover would leave its
    declarations nowhere at all: matched by nobody here, and gone from the sheet
    the browser reads. Deriving the set from the matcher is what stops the two
-   from parting ways. *)
+   from parting ways, and the default reading is {!Resolve.constructor-Browser},
+   since what is left has to render the way the page it came from does. *)
 let inlinable = Resolve.supported
 
 (* Elements that never carry inline styles ([html] is stylable so :root custom

--- a/lib/prune.mli
+++ b/lib/prune.mli
@@ -4,7 +4,9 @@
     every element of every document answers {!Resolve.constructor-No_match}. A
     selector the matcher has no model for is kept and never counted as unused:
     {!Resolve.constructor-Unsupported} is not "does not match", so reading it as
-    one deletes a rule nothing ruled out.
+    one deletes a rule nothing ruled out. The matcher is asked under
+    {!Resolve.constructor-Browser}, so a rule the page's own browser still
+    applies is never removed on the strength of a reading no engine has shipped.
 
     Only selectors are read. A [@media], [@supports] or [@container] condition
     asks about a device, a user agent or a layout container, none of which a

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -12,8 +12,24 @@ module type NODE = sig
 end
 
 type match_result = Matches | No_match | Unsupported
+type reading = Browser | Spec
 
 let of_bool b = if b then Matches else No_match
+
+(* The forms selectors-4 defines and no engine implements as defined. Sec. 6.3
+   gives the [s] flag "identical to" semantics; engines refuse the selector, and
+   the rule carrying it with it. Sec. 13.2 represents an element "that has no
+   children except, optionally, document white space characters", and its own
+   note records that Level 2 and Level 3 did not - the change engines have not
+   taken. Under [Browser] the matcher declines both: an answer would be a fact
+   about the specification, and its callers rewrite pages a browser renders. The
+   selector_match differential is what keeps this list in step, since a form
+   cascade decides and the browser refuses shows up there. *)
+let unimplemented =
+  Selector.any (function
+    | Selector.Empty | Selector.Attribute (_, _, _, Some Selector.Sensitive) ->
+        true
+    | _ -> false)
 
 (* [Unsupported] beats both answers in every combining form. That is what keeps
    it a fact about the selector alone: were a compound to settle on [No_match]
@@ -512,16 +528,24 @@ module Make (N : NODE) = struct
         Some (fun left a -> List.filter (hits left) (preceding_siblings a))
     | Selector.Column | Selector.Shadow_piercing | Selector.Shadow_deep -> None
 
-  let matches sel n = match_selector sel n = Matches
+  (* [Spec] is the matcher above, which reads selectors-4 as written. [Browser]
+     declines the forms no engine implements, so a caller that inlines or
+     deletes never acts on an answer the page's own browser does not give. *)
+  let match_selector ?(reading = Browser) sel n =
+    match reading with
+    | Browser when unimplemented sel -> Unsupported
+    | Browser | Spec -> match_selector sel n
+
+  let matches ?reading sel n = match_selector ?reading sel n = Matches
 
   (* A selector list has no single specificity: a rule [s1, s2 {...}] cascades
      as if duplicated per branch, so the specificity that applies to [node] is
      that of the highest-specificity branch matching [node], not the whole
      list. *)
-  let matched_specificity sel node =
+  let matched_specificity ~reading sel node =
     match Selector.as_list sel with
     | Some branches -> (
-        match List.filter (fun b -> matches b node) branches with
+        match List.filter (fun b -> matches ~reading b node) branches with
         | [] -> Selector.specificity sel
         | b :: rest ->
             List.fold_left
@@ -531,7 +555,7 @@ module Make (N : NODE) = struct
               (Selector.specificity b) rest)
     | None -> Selector.specificity sel
 
-  let resolve_prepared { layer_order; rules } node =
+  let resolve_prepared ?(reading = Browser) { layer_order; rules } node =
     let upsert acc d =
       let k = Declaration.property_name d in
       (k, d) :: List.remove_assoc k acc
@@ -540,10 +564,10 @@ module Make (N : NODE) = struct
       rules
       |> List.mapi (fun i (layer, r) ->
           let sel = Stylesheet.selector r in
-          if matches sel node then
+          if matches ~reading sel node then
             Some
               ( Option.map layer_key layer,
-                matched_specificity sel node,
+                matched_specificity ~reading sel node,
                 i,
                 Stylesheet.declarations r )
           else None)
@@ -580,7 +604,8 @@ module Make (N : NODE) = struct
     List.fold_left upsert [] (bucket ~important:false @ bucket ~important:true)
     |> List.rev_map snd
 
-  let resolve sheet node = resolve_prepared (prepare sheet) node
+  let resolve ?reading sheet node =
+    resolve_prepared ?reading (prepare sheet) node
 end
 
 (* The capability side of the matcher, read off the matcher rather than restated
@@ -603,4 +628,5 @@ end
 
 module Probe_matcher = Make (Probe)
 
-let supported sel = Probe_matcher.match_selector sel () <> Unsupported
+let supported ?reading sel =
+  Probe_matcher.match_selector ?reading sel () <> Unsupported

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -55,23 +55,40 @@ type match_result =
       (** The selector is outside what the matcher models, so neither answer is
           available, for any node. *)
 
-val supported : Selector.t -> bool
-(** [supported sel] is whether the matcher has a model for [sel], that is,
-    whether {!Make.match_selector} answers it with something other than
+(** Which reading of Selectors the matcher answers by.
+
+    Two forms selectors-4 defines are implemented by no engine: sec. 6.3's [s]
+    attribute flag, which engines refuse along with the rule carrying it, and
+    sec. 13.2's [:empty] over an element holding nothing but document white
+    space, the Level 4 change engines have not taken. *)
+type reading =
+  | Browser
+      (** Decline those forms. An answer would be a fact about the
+          specification, and {!Apply} inlines a rule out of the stylesheet while
+          {!Prune} deletes it, so either would rewrite a page against the way
+          its own browser renders it. *)
+  | Spec  (** Answer them as selectors-4 defines them. *)
+
+val supported : ?reading:reading -> Selector.t -> bool
+(** [supported ?reading sel] is whether the matcher has a model for [sel], that
+    is, whether {!Make.match_selector} answers it with something other than
     {!constructor-Unsupported}. The answer is a fact about [sel] alone, which is
-    why it needs no node.
+    why it needs no node. [reading] defaults to {!constructor-Browser}.
 
     Modelled: the universal, type, class, id and attribute selectors, each
-    without a namespace, an attribute carrying either case flag ([i], [s]) or
-    none; [:root] and [:scope], which name the same element here (selectors-4
-    sec. 8.4) since no scoping root is ever handed to the matcher; [:empty]; the
-    child-indexed [:first-child], [:last-child], [:only-child], [:nth-child()]
-    and [:nth-last-child()], the last two with or without their [of S] argument;
-    the typed [:first-of-type], [:last-of-type], [:only-of-type],
-    [:nth-of-type()] and [:nth-last-of-type()]; [:has()]; the descendant, child
-    and sibling combinators; and [:is()], [:where()], [:not()] and selector
-    lists over those - a list is only as modelled as its least modelled branch,
-    and so is an [of S] or a [:has()] argument.
+    without a namespace, an attribute carrying the [i] case flag or none;
+    [:root] and [:scope], which name the same element here (selectors-4 sec.
+    8.4) since no scoping root is ever handed to the matcher; the child-indexed
+    [:first-child], [:last-child], [:only-child], [:nth-child()] and
+    [:nth-last-child()], the last two with or without their [of S] argument; the
+    typed [:first-of-type], [:last-of-type], [:only-of-type], [:nth-of-type()]
+    and [:nth-last-of-type()]; [:has()]; the descendant, child and sibling
+    combinators; and [:is()], [:where()], [:not()] and selector lists over those
+    \- a list is only as modelled as its least modelled branch, and so is an
+    [of S] or a [:has()] argument.
+
+    Modelled under {!constructor-Spec} alone: [:empty] and an attribute carrying
+    the [s] case flag, the two forms {!type-reading} is about.
 
     Not modelled, and for two different reasons. Some forms would need a {!NODE}
     to carry more than a tree of named elements: anything with a namespace,
@@ -125,27 +142,30 @@ val prepare : Stylesheet.t -> prepared
     the flattening per node. *)
 
 module Make (N : NODE) : sig
-  val match_selector : Selector.t -> N.t -> match_result
-  (** [match_selector sel node] is what the matcher can say about [sel] and
-      [node]. It is [Unsupported] exactly when [sel] is not {!supported}, for
-      every [node]. *)
+  val match_selector : ?reading:reading -> Selector.t -> N.t -> match_result
+  (** [match_selector ?reading sel node] is what the matcher can say about [sel]
+      and [node]. It is [Unsupported] exactly when [sel] is not
+      [supported ?reading], for every [node]. [reading] defaults to
+      {!constructor-Browser}. *)
 
-  val matches : Selector.t -> N.t -> bool
-  (** [matches sel node] is whether [sel] is known to match [node], that is,
-      whether {!match_selector} is [Matches]. It folds [Unsupported] in with
-      [No_match], so a caller that has to tell the two apart wants
+  val matches : ?reading:reading -> Selector.t -> N.t -> bool
+  (** [matches ?reading sel node] is whether [sel] is known to match [node],
+      that is, whether {!match_selector} is [Matches]. It folds [Unsupported] in
+      with [No_match], so a caller that has to tell the two apart wants
       {!match_selector}. *)
 
-  val resolve_prepared : prepared -> N.t -> Declaration.declaration list
-  (** [resolve_prepared prepared node] is {!resolve} against an already
+  val resolve_prepared :
+    ?reading:reading -> prepared -> N.t -> Declaration.declaration list
+  (** [resolve_prepared ?reading prepared node] is {!resolve} against an already
       {!prepare}d sheet. Same result, without redoing the sheet-only work per
       node. *)
 
-  val resolve : Stylesheet.t -> N.t -> Declaration.declaration list
-  (** [resolve sheet node] is [resolve_prepared (prepare sheet) node]: the
-      declarations that win for [node] after flattening nesting and applying the
-      cascade: selector matching, [!important] over normal, then cascade layer,
-      specificity and source order. [@layer] blocks and [@layer a, b;]
+  val resolve :
+    ?reading:reading -> Stylesheet.t -> N.t -> Declaration.declaration list
+  (** [resolve ?reading sheet node] is [resolve_prepared (prepare sheet) node]:
+      the declarations that win for [node] after flattening nesting and applying
+      the cascade: selector matching, [!important] over normal, then cascade
+      layer, specificity and source order. [@layer] blocks and [@layer a, b;]
       statements order the layers by first appearance, sublayers included and
       each parent behind its own sublayers; among normal declarations the last
       layer wins and an unlayered declaration beats them all, and for

--- a/test/cli/apply_comments.t
+++ b/test/cli/apply_comments.t
@@ -21,20 +21,3 @@ each run on its own, so merging them moves the element's width.
   <p style="color:red"><!-- empty but for this --></p>
   
   </body></html>
-
-A comment is not a text node, so it does not stop an element being
-:empty (Selectors 4 sec. 13.2).
-
-  $ cat > empty.html <<EOF
-  > <html><head><style>p:empty{color:red}</style></head><body>
-  > <p id="comment"><!-- c --></p>
-  > <p id="text">t</p>
-  > </body></html>
-  > EOF
-
-  $ cascade apply empty.html 2> /dev/null
-  <html><head><style></style></head><body>
-  <p style="color:red" id="comment"><!-- c --></p>
-  <p id="text">t</p>
-  
-  </body></html>

--- a/test/cli/apply_empty.t
+++ b/test/cli/apply_empty.t
@@ -1,12 +1,11 @@
 CLI: [cascade apply] and the :empty pseudo-class.
 
-Selectors 4 §13.2 says :empty represents "an element that has no
-children except, optionally, document white space characters", and
-that "only element nodes and content nodes (such as [DOM] text nodes,
-and entity references) whose data has a non-zero length must be
-considered as affecting emptiness". Document white space characters
-are spaces (U+0020), tabs (U+0009) and segment breaks (CSS Text 4
-§4.3), so U+00A0 is not one of them.
+Selectors 4 §13.2 represents with :empty "an element that has no
+children except, optionally, document white space characters", and its
+own note records that Level 2 and Level 3 did not match an element
+holding nothing but white space. No engine has taken that change, so
+an answer here states what the specification says rather than what the
+page does.
 
   $ cat > empty.html <<EOF
   > <html><head><style>p:empty{color:red}</style></head><body>
@@ -18,17 +17,19 @@ are spaces (U+0020), tabs (U+0009) and segment breaks (CSS Text 4
   > </body></html>
   > EOF
 
-An element with a text child is not :empty, so it must not be painted;
-one holding nothing but white space is. The entity reference resolves
-to U+00A0, which is not document white space, so that paragraph is not
-empty either.
+Inlining takes the rule out of the stylesheet, so painting an element
+on the strength of that answer would write a page that renders
+differently from the one it was read from. The rule stays where the
+browser reads it and no paragraph is painted here.
 
   $ cascade apply empty.html
-  <html><head><style></style></head><body>
-  <p style="color:red" id="void"></p>
-  <p style="color:red" id="spaces">  </p>
+  Kept 1 rule(s) with no inline form in a <style> block.
+  <html><head><style></style><style>p:empty{color:red}</style></head><body>
+  <p id="void"></p>
+  <p id="spaces">  </p>
   <p id="text">text</p>
   <p id="child"><span></span></p>
   <p id="nbsp">&nbsp;</p>
   
   </body></html>
+

--- a/test/cli/prune.t
+++ b/test/cli/prune.t
@@ -189,11 +189,14 @@ that matters in practice, and it survives on [<html>].
   }
 
 
-# Only text nodes decide :empty
+# :empty is kept for want of a shipped model
 
 
-Selectors 4 sec. 13.2 counts element nodes and non-empty text nodes; a
-comment is neither, so [#b] is empty and [#c] is not.
+Selectors 4 sec. 13.2 matches an element holding nothing but document
+white space, and its own note records that Level 2 and Level 3 did
+not. No engine has taken that change, so a verdict here would rest on
+what the specification says rather than on what the browser applies,
+and removing a rule on it would delete one the page still uses.
 
   $ cat > empty-page.html <<EOF
   > <html><head></head><body>
@@ -208,10 +211,10 @@ comment is neither, so [#b] is empty and [#c] is not.
   $ cascade prune --dry-run empty-page.html empty.css
   documents: 1, elements: 6
   
-  used, fewest matched elements first:
-       2  p:empty
+  no verdict, kept: the matcher has no model for the selector.
+    p:empty
   
-  rules: 1 total, 0 removed, 1 kept as used, 0 kept without a verdict
+  rules: 1 total, 0 removed, 0 kept as used, 1 kept without a verdict
   
   Unused means unused in these documents: a class a script adds at runtime is not in them.
 

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -5,6 +5,7 @@ type node = {
   id : string option;
   classes : string list;
   attrs : (string * string) list;
+  text : string list;
   mutable parent : node option;
   children : node list;
 }
@@ -19,13 +20,13 @@ module Node = struct
   let attribute n key = List.assoc_opt key n.attrs
   let parent n = n.parent
   let children n = n.children
-  let text_children _ = []
+  let text_children n = n.text
 end
 
 module A = Apply.Make (Node)
 
-let node ?id ?(classes = []) ?(attrs = []) ?(children = []) name =
-  let n = { name; id; classes; attrs; parent = None; children } in
+let node ?id ?(classes = []) ?(attrs = []) ?(text = []) ?(children = []) name =
+  let n = { name; id; classes; attrs; text; parent = None; children } in
   List.iter (fun c -> c.parent <- Some n) children;
   n
 
@@ -455,6 +456,19 @@ let projects_attribute_rule_with_case_flag () =
     ~inline:"" ~keep:"" ~kept:0
     (node ~attrs:[ ("data-k", "x") ] "p")
 
+(* Inlining takes the rule out of the sheet, so the projection has to agree with
+   the browser that reads what is left. Selectors 4 sec. 6.3 gives [s]
+   "identical to" semantics and every engine refuses the selector outright; sec.
+   13.2 matches an element holding only document white space, and its own note
+   records that Level 2 and Level 3 did not - the change engines have not taken.
+   Painting either element writes a style the page did not have. *)
+let keeps_a_rule_no_engine_implements () =
+  check_split "case-sensitive attribute" ~css:"p[data-k=\"X\" s]{color:red}"
+    ~inline:"" ~keep:"p[data-k=\"X\" s]{color:red}" ~kept:1
+    (node ~attrs:[ ("data-k", "X") ] "p");
+  check_split "white space alone" ~css:"p:empty{color:red}" ~inline:""
+    ~keep:"p:empty{color:red}" ~kept:1 (node ~text:[ " " ] "p")
+
 (* The control: without the flag the selector is representable, so it projects
    onto the element and leaves nothing behind. *)
 let projects_attribute_rule_to_inline_style () =
@@ -648,6 +662,8 @@ let suite =
         unrelated_kept_property_still_inlines;
       Alcotest.test_case "projects an attribute rule with a case flag" `Quick
         projects_attribute_rule_with_case_flag;
+      Alcotest.test_case "keeps a rule no engine implements" `Quick
+        keeps_a_rule_no_engine_implements;
       Alcotest.test_case "projects an attribute rule to inline style" `Quick
         projects_attribute_rule_to_inline_style;
       Alcotest.test_case "keeps a rule with a namespaced element" `Quick

--- a/test/test_apply.ml
+++ b/test/test_apply.ml
@@ -445,15 +445,11 @@ let unrelated_kept_property_still_inlines () =
     (node ~classes:[ "m" ] "ul")
 
 (* selectors-4 sec. 6.3: an [i] flag matches the attribute's value ASCII
-   case-insensitively and an [s] flag matches it "identical to", so the matcher
-   represents both and the rule projects or drops on the value the element
-   actually carries. *)
+   case-insensitively, so the rule projects onto an element carrying the value
+   in another case. *)
 let projects_attribute_rule_with_case_flag () =
   check_split "case-insensitive attribute" ~css:"p[data-k=\"X\" i]{color:red}"
     ~inline:"color:red" ~keep:"" ~kept:0
-    (node ~attrs:[ ("data-k", "x") ] "p");
-  check_split "case-sensitive attribute" ~css:"p[data-k=\"X\" s]{color:red}"
-    ~inline:"" ~keep:"" ~kept:0
     (node ~attrs:[ ("data-k", "x") ] "p")
 
 (* Inlining takes the rule out of the sheet, so the projection has to agree with
@@ -464,7 +460,7 @@ let projects_attribute_rule_with_case_flag () =
    Painting either element writes a style the page did not have. *)
 let keeps_a_rule_no_engine_implements () =
   check_split "case-sensitive attribute" ~css:"p[data-k=\"X\" s]{color:red}"
-    ~inline:"" ~keep:"p[data-k=\"X\" s]{color:red}" ~kept:1
+    ~inline:"" ~keep:"p[data-k=X s]{color:red}" ~kept:1
     (node ~attrs:[ ("data-k", "X") ] "p");
   check_split "white space alone" ~css:"p:empty{color:red}" ~inline:""
     ~keep:"p:empty{color:red}" ~kept:1 (node ~text:[ " " ] "p")

--- a/test/test_prune.ml
+++ b/test/test_prune.ml
@@ -99,9 +99,12 @@ let root_matches_the_root_element () =
   check_verdicts "verdicts" [ Prune.Used 1 ] r;
   Alcotest.(check string) "sheet" ":root{--brand:red}" (css r)
 
-(* Selectors 4 sec. 13.2 counts element nodes and non-empty text nodes, so the
-   paragraph holding text is not [:empty] and the two divs with neither are. *)
-let empty_reads_text_children_only () =
+(* Selectors 4 sec. 13.2 counts element nodes and non-empty text nodes, and
+   matches an element holding nothing but document white space - the Level 4
+   change no engine has taken. Pruning on that reading would delete a rule the
+   browser still applies, so the matcher declines it and the rule stays without
+   a verdict. *)
+let keeps_empty_for_want_of_a_shipped_model () =
   let tree =
     node "html"
       ~children:
@@ -112,7 +115,8 @@ let empty_reads_text_children_only () =
         ]
   in
   let r = P.analyse ~sheet:(parse "div:empty{color:red}") [ tree ] in
-  check_verdicts "verdicts" [ Prune.Used 1 ] r
+  check_verdicts "verdicts" [ Prune.Unmodelled ] r;
+  Alcotest.(check string) "sheet" "div:empty{color:red}" (css r)
 
 (* A condition is a question about the device, not about the document, so the
    rules inside a group block are judged by their own selectors. *)
@@ -193,8 +197,8 @@ let suite =
         keeps_a_selector_the_matcher_cannot_decide;
       Alcotest.test_case "root matches the root element" `Quick
         root_matches_the_root_element;
-      Alcotest.test_case "empty reads text children only" `Quick
-        empty_reads_text_children_only;
+      Alcotest.test_case "keeps empty for want of a shipped model" `Quick
+        keeps_empty_for_want_of_a_shipped_model;
       Alcotest.test_case "a condition is not a selector" `Quick
         a_condition_is_not_a_selector;
       Alcotest.test_case "drops a group block left with nothing" `Quick

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -51,8 +51,12 @@ let s2 = elt ~id:"s2" "span" []
 let a = elt ~id:"a" "div" [ s1 ]
 let b = elt ~id:"b" "div" [ s2 ]
 let section = elt "section" [ a; b ]
-let yes name s n = Alcotest.(check bool) name true (R.matches (sel s) n)
-let no name s n = Alcotest.(check bool) name false (R.matches (sel s) n)
+
+let yes ?reading name s n =
+  Alcotest.(check bool) name true (R.matches ?reading (sel s) n)
+
+let no ?reading name s n =
+  Alcotest.(check bool) name false (R.matches ?reading (sel s) n)
 
 let test_simple () =
   yes "element" "span" s1;
@@ -88,8 +92,9 @@ let match_result =
       | Resolve.Unsupported -> Fmt.string ppf "Unsupported")
     ( = )
 
-let answers name expected s n =
-  Alcotest.check match_result name expected (R.match_selector (sel s) n)
+let answers ?reading name expected s n =
+  Alcotest.check match_result name expected
+    (R.match_selector ?reading (sel s) n)
 
 (* A selector the matcher has no model for is not a selector that fails to
    match: the caller has to be able to tell the two apart, or it drops a rule it
@@ -120,7 +125,7 @@ let test_supported_needs_no_node () =
   in
   check "class" true ".c";
   check "attribute" true "[data-k=\"X\"]";
-  check "structural" true "p:empty";
+  check "structural" true "p:first-child";
   check "descendant" true "div span";
   check "attribute case flag" true "[data-k=\"X\" i]";
   check "child-indexed" true ":nth-child(2n+1)";
@@ -161,14 +166,24 @@ let test_declines_what_no_engine_implements () =
     Alcotest.(check bool) name false (Resolve.supported (sel s))
   in
   declines "supported settles it without a node" ":empty";
-  declines "and for the case-sensitive flag" "[title=x s]"
+  declines "and for the case-sensitive flag" "[title=x s]";
+  (* The model is still there: the spec reading answers both. *)
+  answers ~reading:Resolve.Spec "the flag reads the value as written"
+    Resolve.Matches "[title=x s]" titled;
+  answers ~reading:Resolve.Spec "and rules the other case out" Resolve.No_match
+    "[title=X s]" titled;
+  Alcotest.(check bool)
+    "the spec reading models :empty" true
+    (Resolve.supported ~reading:Resolve.Spec (sel ":empty"))
 
 (* selectors-4 sec. 13.2: [:empty] is "an element that has no children except,
    optionally, document white space characters". White space alone leaves an
    element empty, any other text does not, and U+00A0 is not document white
    space (css-text-4 sec. 4.3) - the spec lists [<div>&nbsp;</div>] among the
-   elements [div:empty] does not represent. *)
+   elements [div:empty] does not represent. This is the reading engines have not
+   taken, so it is the one {!Resolve.constructor-Spec} answers. *)
 let test_empty_counts_text_children () =
+  let yes = yes ~reading:Resolve.Spec and no = no ~reading:Resolve.Spec in
   yes "no children at all" ":empty" (elt "p" []);
   yes "spaces, tabs and newlines" ":empty" (elt ~text:[ " \t\n" ] "p" []);
   no "a text child" ":empty" (elt ~text:[ "text" ] "p" []);
@@ -434,8 +449,9 @@ let test_attribute_case_flags () =
      value is represented as hsides, HSIDES, hSides, etc." *)
   yes "i folds the case" "[frame=hsides i]" framed;
   no "without a flag the value is read as written" "[frame=hsides]" framed;
-  no "s is identical-to" "[frame=hsides s]" framed;
-  yes "and the written value is identical to itself" "[frame=HSIDES s]" framed;
+  no ~reading:Resolve.Spec "s is identical-to" "[frame=hsides s]" framed;
+  yes ~reading:Resolve.Spec "and the written value is identical to itself"
+    "[frame=HSIDES s]" framed;
   (* "ASCII case insensitivity allows green to match GREEN. However, gruen [with
      an umlaut] would not match GRUEN [with an umlaut]." *)
   no "i folds ASCII only" "[data-k=\"gr\u{00fc}n\" i]" framed;
@@ -445,9 +461,9 @@ let test_attribute_case_flags () =
   yes "a substring" "[frame*=sid i]" framed;
   yes "a hyphen list" "[lang|=en i]" framed;
   (* sec. 6.3's second example: [type="a" s] and [type="A" s] are two rules *)
-  yes "s keeps the two apart" "[type=\"a\" s]" type_lower;
-  no "the other way round" "[type=\"a\" s]" type_upper;
-  yes "and back" "[type=\"A\" s]" type_upper;
+  yes ~reading:Resolve.Spec "s keeps the two apart" "[type=\"a\" s]" type_lower;
+  no ~reading:Resolve.Spec "the other way round" "[type=\"a\" s]" type_upper;
+  yes ~reading:Resolve.Spec "and back" "[type=\"A\" s]" type_upper;
   yes "i puts them together" "[type=\"a\" i]" type_lower;
   yes "both ways" "[type=\"a\" i]" type_upper
 

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -136,6 +136,33 @@ let test_supported_needs_no_node () =
   check "stateful" false ":hover";
   check "one bad branch spoils the list" false "span,div:hover"
 
+let titled = elt ~attrs:[ ("title", "x") ] "div" []
+
+(* Two forms selectors-4 defines that no engine implements as defined. Sec. 6.3
+   gives the [s] flag "identical to" semantics; every engine refuses the
+   selector instead, and the rule carrying it with it. Sec. 13.2 matches an
+   element whose only content is document white space, and its own note records
+   that Level 2 and Level 3 did not - the change engines have not taken. The
+   answer to either is a fact about the specification and not about how the page
+   renders, and {!Apply} inlines and {!Prune} deletes, so the matcher declines
+   the form rather than rewrite a page against its own browser. *)
+let test_declines_what_no_engine_implements () =
+  answers "the case-sensitive attribute flag" Resolve.Unsupported "[title=x s]"
+    titled;
+  answers "on a value the flag rules out" Resolve.Unsupported "[title=X s]"
+    titled;
+  answers ":empty" Resolve.Unsupported ":empty" s2;
+  answers ":empty in a compound" Resolve.Unsupported "span:empty" s2;
+  answers ":empty under a negation" Resolve.Unsupported ":not(:empty)" s2;
+  answers ":empty in a relational argument" Resolve.Unsupported ":has(:empty)" a;
+  answers ":empty as one branch of a list" Resolve.Unsupported "span,:empty" s2;
+  answers ":empty left of a combinator" Resolve.Unsupported ":empty span" s2;
+  let declines name s =
+    Alcotest.(check bool) name false (Resolve.supported (sel s))
+  in
+  declines "supported settles it without a node" ":empty";
+  declines "and for the case-sensitive flag" "[title=x s]"
+
 (* selectors-4 sec. 13.2: [:empty] is "an element that has no children except,
    optionally, document white space characters". White space alone leaves an
    element empty, any other text does not, and U+00A0 is not document white
@@ -813,6 +840,8 @@ let suite =
         test_unsupported_is_not_no_match;
       Alcotest.test_case "supported needs no node" `Quick
         test_supported_needs_no_node;
+      Alcotest.test_case "declines what no engine implements" `Quick
+        test_declines_what_no_engine_implements;
       Alcotest.test_case "empty counts text children" `Quick
         test_empty_counts_text_children;
       Alcotest.test_case "nth-child indexes from one" `Quick


### PR DESCRIPTION
`cascade apply` inlined a declaration Chrome does not apply: it decided `:empty`, which Selectors 4 matches over an element holding only white space where no engine does, and the `s` attribute flag, which every engine refuses along with the rule carrying it. The page it wrote rendered differently from the page it read.

Resolve answers under a browser reading by default now, so apply keeps such a rule in the stylesheet and prune keeps it without a verdict. The decline is whole-selector, so `:empty` stops being applied even where cascade and Chrome agreed and the cram case pinning that agreement goes; #873 narrows it back. `supported`, `matches`, `resolve` and `match_selector` all take `?reading`, and `~reading:Spec` still asks what Selectors 4 says.
