### PR TITLE
test: declare the browser gates' dependency on CASCADE_NO_BROWSER

### DIFF
--- a/test/inline/dune
+++ b/test/inline/dune
@@ -8,13 +8,13 @@
 ; The comparison itself: apply and --minify must leave every element's computed
 ; style unchanged, over the committed fixtures. CASCADE and CANON_FILTER are
 ; set here because run.sh otherwise builds them with dune, and a dune inside a
-; dune action blocks on the workspace lock. (universe) for the same reason the
-; test/render rules carry it: the answer depends on the installed browser.
+; dune action blocks on the workspace lock. run.sh reads CASCADE_NO_BROWSER, so
+; the rule declares it for the same reason the test/render rules do.
 
 (rule
  (alias runtest)
  (deps
-  (universe)
+  (env_var CASCADE_NO_BROWSER)
   (source_tree fixtures)
   xtest.js
   minify_page.js
@@ -30,14 +30,13 @@
 
 ; The controls that license every count run.sh prints are checked on every
 ; machine rather than only where a browser is installed: test_selfcheck.sh
-; drives run.sh through a stub browser that is unstable on demand. It skips,
-; with status 0, when node is missing, which is why it depends on (universe):
-; whether node is there is not something dune can digest, and a cached skip
-; would answer for a machine that has one.
+; drives run.sh through a stub browser that is unstable on demand. It sets
+; CASCADE_NO_BROWSER itself on the two legs that check it and unsets it for the
+; rest, so the rule does not depend on the ambient value.
 
 (rule
  (alias runtest)
- (deps (universe) run.sh xtest.js minify_page.js freeze_page.js)
+ (deps run.sh xtest.js minify_page.js freeze_page.js)
  (action
   (run
    sh

--- a/test/render/dune
+++ b/test/render/dune
@@ -63,12 +63,10 @@
    %{exe:shorthand_expand.exe}
    %{exe:canonical_agree.exe})))
 
-; Every other rule below depends on (universe), because what it answers
-; depends on the installed browser and on whether it may be launched at all,
-; and dune can digest neither. Without it a run that never reached a browser
-; is stored as a success, and with the shared cache enabled for user rules
-; that success is then replayed for every later run on the machine, in every
-; worktree.
+; Every rule below reads CASCADE_NO_BROWSER, so each one declares it: a run
+; the variable silenced digests apart from a run that reached a browser, and
+; is never replayed for it. The installed browser is not digested, so a skip
+; taken for want of one stands until something else in the rule changes.
 
 ; The sweep reads the committed CSS corpora, so the rule has to bring them
 ; into the build directory it runs in.
@@ -76,7 +74,7 @@
 (rule
  (alias runtest)
  (deps
-  (universe)
+  (env_var CASCADE_NO_BROWSER)
   (glob_files *.js)
   (source_tree ../interop/css-minify-tests/traces/tests)
   (source_tree ../examples)
@@ -90,7 +88,7 @@
 (rule
  (alias runtest)
  (deps
-  (universe)
+  (env_var CASCADE_NO_BROWSER)
   (glob_files *.js)
   shorthand_expand.exe)
  (action
@@ -102,7 +100,7 @@
 (rule
  (alias runtest)
  (deps
-  (universe)
+  (env_var CASCADE_NO_BROWSER)
   (glob_files *.js)
   (source_tree ../interop/css-minify-tests/traces/tests)
   (source_tree ../examples)
@@ -113,6 +111,7 @@
 (rule
  (alias runtest)
  (deps
+  (env_var CASCADE_NO_BROWSER)
   (glob_files *.js)
   resolve_diff.exe)
  (action
@@ -127,6 +126,7 @@
 (rule
  (alias runtest)
  (deps
+  (env_var CASCADE_NO_BROWSER)
   (glob_files *.js)
   at_rule_conditions.exe)
  (action
@@ -138,7 +138,7 @@
 (rule
  (alias runtest)
  (deps
-  (universe)
+  (env_var CASCADE_NO_BROWSER)
   (glob_files *.js)
   parse_recovery.exe)
  (action
@@ -147,7 +147,7 @@
 (rule
  (alias runtest)
  (deps
-  (universe)
+  (env_var CASCADE_NO_BROWSER)
   (glob_files *.js)
   selector_match.exe)
  (action

--- a/test/spec/browser/dune
+++ b/test/spec/browser/dune
@@ -58,9 +58,13 @@
   (glob_files *.js))
  (action (progn)))
 
+; Both harnesses read CASCADE_NO_BROWSER, so both rules declare it: a run the
+; variable silenced digests apart from a run that reached a browser.
+
 (rule
  (alias runtest)
  (deps
+  (env_var CASCADE_NO_BROWSER)
   (glob_files *.js)
   property_vectors.exe)
  (action
@@ -69,6 +73,7 @@
 (rule
  (alias runtest)
  (deps
+  (env_var CASCADE_NO_BROWSER)
   (glob_files *.js)
   accept_set.exe)
  (action


### PR DESCRIPTION
`(universe)` kept the browser harnesses that declared it out of dune's cache, so a second `dune runtest` re-ran them; `(env_var CASCADE_NO_BROWSER)` puts the one ambient input these rules have into the action digest instead, which is what a suppressed run needed to be digested apart from a real one.

`resolve_diff` and `at_rule_conditions` never declared the variable at all, so a run it silenced was stored and replayed as a browser pass. The trade is that the installed browser is not digested either, so `test/inline`'s skip for want of node becomes cacheable.
