### PR TITLE
parser: preserve general-enclosed conditions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -190,6 +190,10 @@ entry points both moved.
 
 ### Parsing
 
+- Unknown enclosed media conditions and unsupported `@supports` function
+  arguments retain their guards, so an applicable `or` branch or negated
+  capability test no longer loses its rules (#867).
+
 - `margin` mixes `auto` with lengths in any slot, `border-style` takes the four
   side styles, `border-block-style` and `border-inline-style` take the start and
   end edges, and every `border-*-radius` corner takes a horizontal and a

--- a/lib/component.ml
+++ b/lib/component.ml
@@ -72,6 +72,18 @@ let source_loc : t -> Loc.t = function
 
 let rule_loc : rule -> Loc.t = function Qualified r -> r.loc | At r -> r.loc
 
+let rec is_any_value components =
+  List.for_all
+    (function
+      | Preserved { kind = Token.Bad_string | Token.Bad_url | Token.Close _; _ }
+        ->
+          false
+      | Block { node = { value; closed; _ }; _ } -> closed && is_any_value value
+      | Func { node = { arguments; terminated; _ }; _ } ->
+          terminated && is_any_value arguments
+      | Preserved _ -> true)
+    components
+
 let is_whitespace = function
   | Preserved { kind = Token.Whitespace; _ } -> true
   | Preserved _ | Block _ | Func _ -> false

--- a/lib/component.mli
+++ b/lib/component.mli
@@ -64,6 +64,11 @@ val rule_loc : rule -> Loc.t
 val is_whitespace : t -> bool
 (** [is_whitespace cv] is [true] for a preserved whitespace token. *)
 
+val is_any_value : t list -> bool
+(** [is_any_value cvs] checks the optional [<any-value>] of a general-enclosed
+    condition: no bad string, bad URL, unmatched closer, or unclosed group,
+    recursively. An empty sequence is allowed. *)
+
 val has_var : t list -> bool
 (** [has_var cvs] is [true] when a [var()] function appears anywhere in [cvs],
     including inside function arguments and bracketed blocks. A [var(] written

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -930,18 +930,24 @@ let rec condition_of_components t components : condition =
   | [] -> err t components "empty media condition"
 
 and condition_in_parens t component : condition =
+  let general_enclosed () =
+    if not (Component.is_any_value [ component ]) then
+      err t [ component ] "invalid general-enclosed media condition";
+    Feature (General_enclosed (string_of_components [ component ]))
+  in
   match component with
   | Component.Block
       { node = { opening = Token.Paren; value; closed = true }; _ } -> (
       match parse_feature_components value with
       | Valid_feature feature -> Feature feature
-      | Invalid_feature -> err t value "invalid media feature"
-      | Not_feature -> condition_of_components t value)
+      | Invalid_feature -> general_enclosed ()
+      | Not_feature -> (
+          try condition_of_components t value
+          with Parse_error _ -> general_enclosed ()))
   | Component.Block { node = { opening = Token.Paren; closed = false; _ }; _ }
     ->
       err t [ component ] "unmatched parenthesis in @media condition"
-  | Component.Func { node = { terminated = true; _ }; _ } ->
-      Feature (General_enclosed (string_of_components [ component ]))
+  | Component.Func { node = { terminated = true; _ }; _ } -> general_enclosed ()
   | Component.Func { node = { terminated = false; _ }; _ } ->
       err t [ component ] "unmatched function in @media condition"
   | Component.Block _ | Component.Preserved _ ->

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -381,17 +381,16 @@ let declaration_of_components t prop value =
 let function_call t (fn : Component.func Component.node) =
   let name = fn.node.name in
   let args = fn.node.arguments in
-  let inner = Cursor.func_sub fn t in
-  if not (fn.node.terminated && components_are_closed args) then
-    err t [ Component.Func fn ] ("Unterminated " ^ name ^ "() in @supports");
-  (* [func] and the readers under it work from the argument text, so both the
-     [Failure] the shared constructor raises and a reader's own [Parse_error]
-     carry a position relative to that text, not to the source. *)
+  if not (Component.is_any_value [ Component.Func fn ]) then
+    err t [ Component.Func fn ] "Invalid general-enclosed function in @supports";
+  (* The feature grammar has priority over the general-enclosed fallback. *)
   match func name (Cursor.string_of_components ~trim:true args) with
   | feature -> feature
-  | exception Failure msg -> err inner args msg
-  | exception Cursor.Parse_error e ->
-      err inner args (Pp.to_string Error.pp_kind e.Error.kind)
+  | exception (Failure _ | Cursor.Parse_error _) ->
+      Function
+        (General
+           ( String.lowercase_ascii name,
+             Cursor.string_of_components ~trim:true args ))
 
 let peek_ident t =
   match Cursor.peek t with

--- a/test/cli/diff_unreadable_rule.t
+++ b/test/cli/diff_unreadable_rule.t
@@ -87,17 +87,17 @@ away differ, and the verdict follows those.
 
   $ cat > media-a.css <<EOF
   > .b{color:red}
-  > @media (bogus^^^){.x{color:red}}
+  > @media ^^^{.x{color:red}}
   > EOF
   $ cat > media-b.css <<EOF
   > .b{color:red}
-  > @media (bogus^^^){.x{color:blue}}
+  > @media ^^^{.x{color:blue}}
   > EOF
   $ cascade diff --diff=canonical media-a.css media-b.css
-  media-a.css and media-b.css parse warning: <string>: bad condition for @media: expected media-in-parens at [22-27] (in at-rule)
+  media-a.css and media-b.css parse warning: <string>: bad condition for @media: expected media type or condition at [21-22] (in at-rule)
   .b{color:red}
-  @media (bogus^^^){.x{color:red}}
-          ^^^^^
+  @media ^^^{.x{color:red}}
+         ^
   
   Unreadable rules: media-a.css 1, media-b.css 1
   Cannot determine whether the CSS files are identical

--- a/test/cli/fmt_parse_failure.t
+++ b/test/cli/fmt_parse_failure.t
@@ -77,7 +77,7 @@ neighbours stay.
 
   $ cat > bad-prelude.css <<EOF
   > .ok { color: red }
-  > @media (bogus^^^) { .x { color: blue } }
+  > @media ^^^ { .x { color: blue } }
   > .ok2 { color: green }
   > EOF
   $ cascade fmt --minify bad-prelude.css 2> /dev/null

--- a/test/cli/media_unitless_zero.t
+++ b/test/cli/media_unitless_zero.t
@@ -22,15 +22,15 @@ always worked.
   $ cascade fmt --minify unit.css
   .keep{color:#00f}@media(width>=0px){.a{color:red}}
 
-A non-zero unitless number is still not a length, so that query is the
-one that recovers, and only that one.
+A non-zero unitless number is not a length, but the enclosed condition
+remains valid general-enclosed syntax and must retain its guard.
 
   $ cat > one.css <<EOF
   > .keep { color: blue }
   > @media (min-width: 1) { .a { color: red } }
   > EOF
   $ cascade fmt --minify one.css 2> /dev/null
-  .keep{color:#00f}
+  .keep{color:#00f}@media(min-width: 1){.a{color:red}}
 
 The range and container spellings take the zero too.
 

--- a/test/cli/parse_error_locations.t
+++ b/test/cli/parse_error_locations.t
@@ -41,13 +41,13 @@ Invalid `@media` query inside `@import`: the media query list of the
 prelude is read the same way as an `@media` rule's.
 
   $ cat > bad-media.css <<EOF
-  > @import url("a.css") (bogus !!!);
+  > @import url("a.css") !!!;
   > .ok { color: red }
   > EOF
   $ cascade --minify bad-media.css 2>&1 | grep -E "warning|color" | head
-  warning: bad-media.css: bad condition for @media: expected media-in-parens at [22-27] (in at-rule)
-  warning: @import url("a.css") (bogus !!!);
-  warning:                       ^^^^^
+  warning: bad-media.css: bad condition for @media: expected media type or condition at [21-22] (in at-rule)
+  warning: @import url("a.css") !!!;
+  warning:                      ^
   warning: .ok { color: red }
   warning: 
   .ok{color:red}

--- a/test/spec/inventory/at_rule_grammar.ml
+++ b/test/spec/inventory/at_rule_grammar.ml
@@ -12,6 +12,14 @@ let invalid feature branch input = { feature; branch; input }
 
 let positive =
   [
+    row "supports" "general-enclosed-font-format"
+      "@supports font-format(\"woff2\"){.x{color:red}}"
+      "@supports font-format(\"woff2\") { .x { color: red } }";
+    row "container" "general-enclosed-empty" "@container(){.x{color:red}}"
+      "@container () { .x { color: red } }";
+    row "media" "general-enclosed-interval"
+      "@media(30em < width > 60em){.x{color:red}}"
+      "@media (30em < width > 60em) { .x { color: red } }";
     row "property" "descriptor-order"
       "@property --accent{syntax:\"<color>\";inherits:true;initial-value:red}"
       "@property --accent { initial-value: red; inherits: true; syntax: \
@@ -160,9 +168,6 @@ let negative =
     invalid "supports" "mixed-operator"
       "@supports (display: grid) and (gap: 1rem) or (color: red) { .x { color: \
        red } }";
-    invalid "supports" "bad-font-format-function"
-      "@supports font-format(\"woff2\") { .x { color: red } }";
-    invalid "container" "empty-query" "@container () { .x { color: red } }";
     invalid "container" "empty-style-query"
       "@container style() { .x { color: red } }";
     invalid "container" "bad-scroll-state-query"

--- a/test/spec/inventory/query_grammar.ml
+++ b/test/spec/inventory/query_grammar.ml
@@ -131,48 +131,69 @@ let media_positive =
       "screen and (width >= 40em), print and (color)";
   ]
 
+(* MQ4 section 3: these are general-enclosed, not malformed queries. *)
+let media_general_enclosed =
+  [
+    row "empty media feature" "()" "()";
+    row "min-width missing value" "(min-width)" "(min-width)";
+    row "missing range value" "(width >=)" "(width >=)";
+    row "empty feature value" "(width:)" "(width:)";
+    row "opposing interval operators" "(30em < width > 60em)"
+      "(30em < width > 60em)";
+    row "double name-first comparison" "(width = 40em = 50em)"
+      "(width = 40em = 50em)";
+    row "incomplete interval" "(400px <= width <=)" "(400px <= width <=)";
+    row "bad aspect ratio" "(aspect-ratio > 16/)" "(aspect-ratio > 16/)";
+    row "bad orientation keyword" "(orientation: diagonal)"
+      "(orientation: diagonal)";
+    row "bad hover keyword" "(hover: sometimes)" "(hover: sometimes)";
+    row "bad any-hover keyword" "(any-hover: fine)" "(any-hover: fine)";
+    row "bad any-pointer keyword" "(any-pointer: hover)" "(any-pointer: hover)";
+    row "bad update keyword" "(update: instant)" "(update: instant)";
+    row "bad overflow-block keyword" "(overflow-block: hidden)"
+      "(overflow-block: hidden)";
+    row "retired overflow-block optional paged"
+      "(overflow-block: optional-paged)" "(overflow-block: optional-paged)";
+    row "bad overflow-inline paged" "(overflow-inline: paged)"
+      "(overflow-inline: paged)";
+    row "bad color-gamut keyword" "(color-gamut: rgb)" "(color-gamut: rgb)";
+    row "bad dynamic-range keyword" "(dynamic-range: ultra)"
+      "(dynamic-range: ultra)";
+    row "bad resolution unit" "(resolution >= 2px)" "(resolution >= 2px)";
+    row "bad scan keyword" "(scan: fast)" "(scan: fast)";
+    row "bad grid keyword" "(grid: yes)" "(grid: yes)";
+    row "bad display-mode keyword" "(display-mode: popup)"
+      "(display-mode: popup)";
+    row "bad environment-blending keyword" "(environment-blending: blend)"
+      "(environment-blending: blend)";
+    row "bad viewport segments value" "(horizontal-viewport-segments: -1)"
+      "(horizontal-viewport-segments: -1)";
+    row "bad color scheme keyword" "(prefers-color-scheme: sepia)"
+      "(prefers-color-scheme: sepia)";
+    row "bad reduced motion keyword" "(prefers-reduced-motion: yes)"
+      "(prefers-reduced-motion: yes)";
+    row "bad reduced transparency keyword" "(prefers-reduced-transparency: yes)"
+      "(prefers-reduced-transparency: yes)";
+    row "bad prefers contrast keyword" "(prefers-contrast: high)"
+      "(prefers-contrast: high)";
+    row "retired prefers contrast forced keyword" "(prefers-contrast: forced)"
+      "(prefers-contrast: forced)";
+    row "bad reduced data keyword" "(prefers-reduced-data: yes)"
+      "(prefers-reduced-data: yes)";
+    row "bad forced colors keyword" "(forced-colors: enabled)"
+      "(forced-colors: enabled)";
+    row "bad nav controls keyword" "(nav-controls: back-button)"
+      "(nav-controls: back-button)";
+    row "bad min prefix on discrete feature" "(min-orientation: portrait)"
+      "(min-orientation: portrait)";
+    row "bad color feature value" "(color: 20example)" "(color: 20example)";
+  ]
+
 let media_negative =
   [
-    invalid "empty media feature" "()";
-    invalid "min-width missing value" "(min-width)";
-    invalid "missing range value" "(width >=)";
-    invalid "empty feature value" "(width:)";
-    invalid "opposing interval operators" "(30em < width > 60em)";
-    invalid "double name-first comparison" "(width = 40em = 50em)";
-    invalid "incomplete interval" "(400px <= width <=)";
-    invalid "bad aspect ratio" "(aspect-ratio > 16/)";
-    invalid "bad orientation keyword" "(orientation: diagonal)";
-    invalid "bad hover keyword" "(hover: sometimes)";
-    invalid "bad any-hover keyword" "(any-hover: fine)";
-    invalid "bad any-pointer keyword" "(any-pointer: hover)";
-    invalid "bad update keyword" "(update: instant)";
-    invalid "bad overflow-block keyword" "(overflow-block: hidden)";
-    invalid "retired overflow-block optional paged"
-      "(overflow-block: optional-paged)";
-    invalid "bad overflow-inline paged" "(overflow-inline: paged)";
-    invalid "bad color-gamut keyword" "(color-gamut: rgb)";
-    invalid "bad dynamic-range keyword" "(dynamic-range: ultra)";
-    invalid "bad resolution unit" "(resolution >= 2px)";
-    invalid "bad scan keyword" "(scan: fast)";
-    invalid "bad grid keyword" "(grid: yes)";
-    invalid "bad display-mode keyword" "(display-mode: popup)";
-    invalid "bad environment-blending keyword" "(environment-blending: blend)";
-    invalid "bad viewport segments value" "(horizontal-viewport-segments: -1)";
-    invalid "bad color scheme keyword" "(prefers-color-scheme: sepia)";
-    invalid "bad reduced motion keyword" "(prefers-reduced-motion: yes)";
-    invalid "bad reduced transparency keyword"
-      "(prefers-reduced-transparency: yes)";
-    invalid "bad prefers contrast keyword" "(prefers-contrast: high)";
-    invalid "retired prefers contrast forced keyword"
-      "(prefers-contrast: forced)";
-    invalid "bad reduced data keyword" "(prefers-reduced-data: yes)";
-    invalid "bad forced colors keyword" "(forced-colors: enabled)";
-    invalid "bad nav controls keyword" "(nav-controls: back-button)";
     invalid "only before feature" "only (color)";
     invalid "missing query after not" "not";
     invalid "reserved or as media type" "or and (color)";
-    invalid "bad min prefix on discrete feature" "(min-orientation: portrait)";
-    invalid "bad color feature value" "(color: 20example)";
     invalid "bad media type condition join" "screen (width)";
     invalid "missing right operand" "(width) and";
     invalid "ungrouped mixed operators" "(width) and (height) or (color)";
@@ -183,18 +204,23 @@ let media_negative =
 let media_recovery =
   [
     row "unknown feature recovers inside list" "(max-weight: 3kg), (color)"
-      "not all, (color)";
+      "(max-weight: 3kg), (color)";
     row "bad bare query recovers inside list" "&test, speech" "not all, speech";
     row "trailing comma branch recovers" "(example, all,), speech"
-      "not all, speech";
+      "(example, all,), speech";
     row "unknown max-weight recovers to next branch"
-      "screen and (max-weight: 3kg) and (color), (color)" "not all, (color)";
+      "screen and (max-weight: 3kg) and (color), (color)"
+      "screen and (max-weight: 3kg) and (color), (color)";
     row "invalid min-prefix recovers inside list"
-      "(min-orientation: portrait), (width)" "not all, (width)";
+      "(min-orientation: portrait), (width)"
+      "(min-orientation: portrait), (width)";
   ]
 
 let container_positive =
   [
+    row "unknown range value" "(width >)" "(width >)";
+    row "unknown interval" "(30em < inline-size > 60em)"
+      "(30em < inline-size > 60em)";
     row "boolean width" "(width)" "(width)";
     row "boolean height" "(height)" "(height)";
     row "boolean inline-size" "(inline-size)" "(inline-size)";
@@ -273,8 +299,6 @@ let container_negative =
     invalid "scroll-state mixed operators"
       "scroll-state((stuck: top) and (snapped: x) or (scrollable: y))";
     invalid "not not query" "not not (width)";
-    invalid "missing range value" "(width >)";
-    invalid "opposing interval operators" "(30em < inline-size > 60em)";
     invalid "equality bound in a style interval" "style(10px = --gap = 20px)";
     invalid "opposing style interval operators" "style(10px < --gap > 20px)";
   ]

--- a/test/spec/inventory/query_grammar.mli
+++ b/test/spec/inventory/query_grammar.mli
@@ -10,6 +10,10 @@ val media_negative : invalid_row list
 (** [media_negative] contains invalid CSS Media Queries branches that recover to
     [not all] under Media Queries error handling. *)
 
+val media_general_enclosed : row list
+(** [media_general_enclosed] contains unknown enclosed conditions retained by
+    the forward-compatible grammar in MQ4 section 3. *)
+
 val media_recovery : row list
 (** [media_recovery] contains invalid-in-part media query lists with their
     spec-mandated recovered serialization. *)

--- a/test/spec/inventory/supports_grammar.ml
+++ b/test/spec/inventory/supports_grammar.ml
@@ -82,24 +82,10 @@ let rows =
       (property "--theme-color" "color(display-p3 1 0 0)");
   ]
 
-let invalid =
+(* Conditional Rules 3 section 6: unsupported functions remain grammatical. *)
+let general_enclosed_functions =
   [
-    "";
-    "()";
-    "display: grid";
-    "(display)";
-    "(: grid)";
-    "(display: grid;)";
-    "(display: grid) and";
-    "(display: grid) or";
-    "(display: grid) and (gap: 1rem) or selector(:has(img))";
-    "font-format(woff2) and or (display: grid)";
-    "selector(:has(img)) or and (display: grid)";
-    "not not (display: grid)";
-    "not (display: grid) and (gap: 1rem)";
-    "not (display: grid) or (gap: 1rem)";
     "selector()";
-    "selector(:has(img)";
     "selector(:has())";
     "selector(:nth-child(2n of))";
     "font-format()";
@@ -116,6 +102,28 @@ let invalid =
     "env()";
     "env(\"safe-area-inset-top\")";
     "env(safe-area-inset-top, fallback)";
+  ]
+
+let invalid =
+  [
+    "font-format(])";
+    "future(url(a b))";
+    "future(\"a\nb\")";
+    "";
+    "()";
+    "display: grid";
+    "(display)";
+    "(: grid)";
+    "(display: grid;)";
+    "(display: grid) and";
+    "(display: grid) or";
+    "(display: grid) and (gap: 1rem) or selector(:has(img))";
+    "font-format(woff2) and or (display: grid)";
+    "selector(:has(img)) or and (display: grid)";
+    "not not (display: grid)";
+    "not (display: grid) and (gap: 1rem)";
+    "not (display: grid) or (gap: 1rem)";
+    "selector(:has(img)";
     "not";
     "not ()";
     "(display: grid) and or (gap: 1rem)";

--- a/test/spec/inventory/supports_grammar.mli
+++ b/test/spec/inventory/supports_grammar.mli
@@ -15,6 +15,9 @@ val rows : row list
 val invalid : string list
 (** [invalid] contains invalid supports-condition grammar branches. *)
 
+val general_enclosed_functions : string list
+(** Functions with unsupported arguments, preserved as general-enclosed. *)
+
 val mutate_invalid : row -> int -> string
 (** [mutate_invalid row salt] returns an invalid condition derived from [row].
 *)

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -262,7 +262,7 @@ let spec_container_unitless_zero_length () =
   check "min-width" "(min-width: 0)" "(min-width:0px)";
   check "min-inline-size" "(min-inline-size: 0)" "(min-inline-size: 0px)";
   check "range" "(width >= 0)" "(width >= 0px)";
-  rejects_invalid "(min-width: 1)"
+  check "unknown unitless nonzero" "(min-width: 1)" "(min-width: 1)"
 
 (* CSS Conditional Rules 5 sec. 6.1 "Size Container Features": "The syntax of a
    <size-feature> is the same as for a media feature", so Media Queries 4 sec.

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -331,6 +331,20 @@ let general_enclosed_roundtrip () =
   check "(unknown-feature: 1)";
   check "(unknown-boolean)"
 
+(* MQ4 sections 3 and 3.1: a failed feature grammar falls back to
+   general-enclosed; it must not invalidate an enclosing disjunction. *)
+let general_enclosed_feature_fallback () =
+  List.iter
+    (fun input ->
+      Alcotest.(check string) input input (to_string (of_string input)))
+    [
+      "(orientation: sideways) or (min-width: 0px)";
+      "(width >=) or (color)";
+      "(future syntax) or (color)";
+      "((color) and) or (color)";
+      "() or (color)";
+    ]
+
 let general_enclosed_in_context () =
   let check src = Alcotest.(check string) src src (to_string (of_string src)) in
   (* negated, listed and combined with a real query *)
@@ -630,6 +644,8 @@ let suite =
       test_case "spec media query boolean and range vectors" `Quick
         spec_media_query_vectors;
       test_case "general-enclosed roundtrip" `Quick general_enclosed_roundtrip;
+      test_case "general-enclosed feature fallback" `Quick
+        general_enclosed_feature_fallback;
       test_case "general-enclosed in context" `Quick general_enclosed_in_context;
       test_case "general-enclosed is not a media type" `Quick
         general_enclosed_is_not_a_media_type;

--- a/test/test_media.ml
+++ b/test/test_media.ml
@@ -311,7 +311,8 @@ let spec_media_query_vectors () =
       Alcotest.(check string)
         row.branch row.expected
         (to_string (of_string row.input)))
-    Cascade_spec_inventory.Query_grammar.media_positive
+    (Cascade_spec_inventory.Query_grammar.media_positive
+   @ Cascade_spec_inventory.Query_grammar.media_general_enclosed)
 
 (* Media Queries 4 3.1 [<general-enclosed>]: both the [<function-token>] form
    and the [( <any-value> )] form are grammatical. An unrecognised one is
@@ -346,6 +347,17 @@ let general_enclosed_feature_fallback () =
     ]
 
 let general_enclosed_in_context () =
+  List.iter
+    (fun input ->
+      Alcotest.(check string)
+        "bad token cannot be general-enclosed" "not all"
+        (to_string (of_string input)))
+    [
+      "(future ]) or (color)";
+      "future(]) or (color)";
+      "future(url(a b)) or (color)";
+      "future(\"a\nb\") or (color)";
+    ];
   let check src = Alcotest.(check string) src src (to_string (of_string src)) in
   (* negated, listed and combined with a real query *)
   check "not theme(static)";
@@ -490,7 +502,7 @@ let spec_media_unitless_zero_length () =
   (* The allowance is [<length>]-only: a [<resolution>] has no unitless zero,
      and a non-zero number is not a length in any feature. *)
   let check_recovers name input =
-    Alcotest.(check string) name "not all" (to_string (of_string input))
+    Alcotest.(check string) name input (to_string (of_string input))
   in
   check_recovers "resolution has no unitless zero" "(min-resolution: 0)";
   check_recovers "non-zero number is not a length" "(min-width: 1)";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -622,7 +622,7 @@ let import_case () =
     ~expected:"@import\"wide.css\"supports(width:stretch)(width>=40em);"
     "@import url(wide.css) supports((width: stretch)) (width >= 40em);";
   neg_cursor read_import_rule "@import url(theme.css) screen layer(theme);";
-  neg_cursor read_import_rule
+  check_import_rule ~expected:"@import\"theme.css\"supports(selector())screen;"
     "@import url(theme.css) supports(selector()) screen;";
   neg_cursor read_import_rule "@import url(theme.css) layer(theme,) screen;"
 
@@ -1572,16 +1572,11 @@ let spec_strict_rejects_invalid_stylesheets () =
       (* Conditional query grammars. *)
       ( "media ungrouped mixed boolean operators",
         "@media (width) and (height) or (color) { .x { color: red } }" );
-      ( "media bad range interval",
-        "@media (30em < width > 60em) { .x { color: red } }" );
       ("media dangling not", "@media not { .x { color: red } }");
       ("media dangling and", "@media screen and { .x { color: red } }");
-      ("media missing range value", "@media (width >= ) { .x { color: red } }");
       ("container empty style query", "@container style() { .x { color: red } }");
       ( "container empty scroll-state query",
         "@container scroll-state() { .x { color: red } }" );
-      ( "supports empty selector function",
-        "@supports selector() { .x { color: red } }" );
       ("supports dangling not", "@supports not { .x { color: red } }");
       ( "supports dangling operator",
         "@supports (display: grid) and { .x { color: red } }" );
@@ -3688,9 +3683,11 @@ let environment_query_boundary () =
      style(--theme: dark) { .card { display: grid } } } }";
   check_stylesheet ~expected:"@supports(display:){.x{color:red}}"
     "@supports (display:) { .x { color: red } }";
-  neg_cursor read "@media (width >= ) { .x { color: red } }";
+  check_stylesheet ~expected:"@media(width >= ){.x{color:red}}"
+    "@media (width >= ) { .x { color: red } }";
   neg_cursor read "@container card style() { .x { color: red } }";
-  neg_cursor read "@container card (width >) { .x { color: red } }"
+  check_stylesheet ~expected:"@container card (width >){.x{color:red}}"
+    "@container card (width >) { .x { color: red } }"
 
 let value_resolution_boundary () =
   let open Css.Values in
@@ -3844,12 +3841,15 @@ let spec_current_at_rules () =
     "@starting-style { .dialog { opacity: 0; translate: 0 1rem } }";
   check_stylesheet ~expected:"@page chapter:left{margin:2cm}"
     "@page chapter:left { margin: 2cm }";
-  neg_cursor read "@media (width >) { .x { color: red } }";
-  neg_cursor read "@supports selector() { .x { color: red } }";
+  check_stylesheet ~expected:"@media(width >){.x{color:red}}"
+    "@media (width >) { .x { color: red } }";
+  check_stylesheet ~expected:"@supports selector(){.x{color:red}}"
+    "@supports selector() { .x { color: red } }";
   neg_cursor read "@scope (.card) .title { color: red }";
   neg_cursor read "@font-palette-values { base-palette: 1; }";
   neg_cursor read "@position-try default { top: 0; }";
-  neg_cursor read "@container () { .x { color: red } }";
+  check_stylesheet ~expected:"@container(){.x{color:red}}"
+    "@container () { .x { color: red } }";
   neg_cursor read "@page : { margin: 1cm }"
 
 let font_palette_values_descriptor_matrix () =
@@ -4048,7 +4048,8 @@ let test_spec_snapshot_tracking_vectors () =
     ~optimized:
       ".card{color:var(--fg);@media(prefers-color-scheme:dark){&{color:#fff}}}";
   neg_cursor read "@layer reset,,base;";
-  neg_cursor read "@container card () { .card { color: red } }";
+  check_stylesheet ~expected:"@container card (){.card{color:red}}"
+    "@container card () { .card { color: red } }";
   neg_cursor read "@supports () { .accent { color: red } }"
 
 (* ignore-test *)
@@ -9124,8 +9125,6 @@ let container_condition_error_spans () =
   (* [style()] spans offsets 30-36; an empty argument list has no components of
      its own, so the call itself carries the span. *)
   check "empty style()" "style()" ("empty style() container query", 30, 37);
-  (* The parenthesised query spans offsets 30-33. *)
-  check "empty query" "(  )" ("empty container query", 30, 34);
   (* [scroll-state(] ends at offset 42, so [bogus] spans 43-47. *)
   check "bad scroll-state()" "scroll-state(bogus)"
     ("invalid scroll-state() container query", 43, 48);
@@ -9174,17 +9173,13 @@ let media_condition_error_spans () =
   in
   (* A lone [not] prefixes nothing; the query itself spans offsets 26-28. *)
   check "prefix with no type" "not" ("expected media type or condition", 26, 29);
-  (* [bogus] inside the parentheses spans offsets 27-31. *)
-  check "junk in parens" "(bogus !!!)" ("expected media-in-parens", 27, 32);
   (* The [or] that follows an [and] spans offsets 46-47. *)
   check "mixed operators" "(color) and (hover) or (a)"
     ("mixed 'and'/'or' media condition", 46, 48);
-  (* The media query list of an [@import] prelude is read the same way: [bogus]
-     spans offsets 22-26. *)
-  one_condition_warning "import prelude"
-    "@import url(\"a.css\") (bogus !!!);\n.ok { color: red }\n"
-    ~at_rule:"@media"
-    ("expected media-in-parens", 22, 27)
+  check_stylesheet ~expected:"@media(bogus !!!){.a{color:blue}}"
+    "@media (bogus !!!) { .a { color: blue } }";
+  check_import_rule ~expected:"@import\"a.css\"(bogus !!!);"
+    "@import url(\"a.css\") (bogus !!!);"
 
 (* An @font-face descriptor whose value does not parse is faulted against the
    value, not against the enclosing block. The descriptor is dropped and the
@@ -9249,9 +9244,8 @@ let supports_condition_error_spans () =
     ("Cannot mix and/or without parentheses in @supports", 45, 47);
   (* The empty parentheses span offsets 29-30. *)
   check "empty parentheses" "()" ("Empty parentheses in @supports", 29, 31);
-  (* [font-format(] ends at offset 40, so [bogus] spans 41-45. *)
-  check "unknown font format" "font-format(bogus)"
-    ("invalid font-format() in @supports", 41, 46)
+  check_stylesheet ~expected:"@supports font-format(bogus){.a{color:blue}}"
+    "@supports font-format(bogus) { .a { color: blue } }"
 
 let additional_tests =
   [

--- a/test/test_supports.ml
+++ b/test/test_supports.ml
@@ -83,6 +83,12 @@ let spec_supports_feature_vectors () =
     let actual = of_string input in
     Alcotest.(check string) name expected (to_string actual)
   in
+  (* Conditional Rules general-enclosed preserves functions whose arguments do
+     not match a supported feature grammar, including under negation. *)
+  check "unknown font format under not" "not font-format(cascade-nope)"
+    "not font-format(cascade-nope)";
+  check "unknown font tech under not" "not font-tech(cascade-nope)"
+    "not font-tech(cascade-nope)";
   check "selector forgiving relative branch" "selector(:has(+ img))"
     "selector(:has(+ img))";
   check "selector current pseudo" "selector(:popover-open)"

--- a/test/test_supports.ml
+++ b/test/test_supports.ml
@@ -115,6 +115,10 @@ let spec_supports_feature_vectors () =
     "((display: grid) and (gap: 1rem)) or selector(:has(img))"
 
 let spec_supports_negative_vectors () =
+  List.iter
+    (fun input ->
+      Alcotest.(check string) input input (to_string (of_string input)))
+    Supports_inventory.general_enclosed_functions;
   let expect_error name input =
     try
       ignore (of_string input);


### PR DESCRIPTION
A media query, `@supports` function or `@container` condition cascade could not parse took its guarded rules with it, where the general-enclosed production keeps them. `@container` reads through `Media.of_string_strict`, so the media fallback covers it too.

Inputs that used to be parse errors are now valid, so the inventory rows, four cram transcripts and three error-span assertions that recorded them move or go: `cascade fmt --minify` on `@media (min-width: 1)` now emits the query instead of dropping it.
