### PR TITLE
context: preserve condition evaluation semantics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@ entry points both moved.
 
 ### Breaking
 
+- `Css.Context.query` gains `media_inapplicable`, distinguishing a recognized
+  feature that matches no value from an unknown feature. Direct record
+  constructors need the new field; `Context.query ()` defaults it to `[]`
+  (#868).
+
 - `cascade diff` exits 2, not 0, when it finds no difference and had to drop a
   declaration or a rule it could not read: what it dropped reached neither side
   of the comparison, so identity is not a verdict it can give. Two sides that
@@ -751,6 +756,13 @@ entry points both moved.
   (#779, #780, #781)
 
 ### Library
+
+- `Css.Context.matches_media` respects zero-valued boolean features and
+  resolution units, preserves unknown through negation, and matches an empty
+  query list (#868).
+- `Css.Context.matches_container` requires the supplied container to support
+  all queried features, so negation and disjunction cannot make an ineligible
+  container match (#868).
 
 - `cascade` drops its `uutf` dependency for the stdlib UTF-8 decoder, which
   counts one replacement character per maximal subpart of an ill-formed

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -46,6 +46,7 @@ type query = {
   media_features : Media.t list;
       (** Media features the rendering environment claims to expose. Build
           entries with [Media.feature] or [Media.boolean]. *)
+  media_inapplicable : Media.name list;
   supports : Supports.t list;
       (** Capability flags the environment claims to support, normally a
           [Supports.Property]/[Supports.Func] leaf. Compound forms
@@ -148,14 +149,22 @@ let empty_query =
   {
     media_type = None;
     media_features = [];
+    media_inapplicable = [];
     supports = [];
     container_name = None;
     container_features = [];
   }
 
-let query ?media_type ?(media_features = []) ?(supports = []) ?container_name
-    ?(container_features = []) () =
-  { media_type; media_features; supports; container_name; container_features }
+let query ?media_type ?(media_features = []) ?(media_inapplicable = [])
+    ?(supports = []) ?container_name ?(container_features = []) () =
+  {
+    media_type;
+    media_features;
+    media_inapplicable;
+    supports;
+    container_name;
+    container_features;
+  }
 
 let empty_loader = { base_url = None; imports = [] }
 let loader ?base_url ?(imports = []) () = { base_url; imports }
@@ -1388,7 +1397,12 @@ module Media_value = struct
     | Number n -> Some n
     | Ratio (a, b) when b <> 0 -> Some (float_of_int a /. float_of_int b)
     | Ratio _ -> None
-    | Resolution_value (n, _) -> Some n
+    | Resolution_value (n, unit) -> (
+        match String.lowercase_ascii unit with
+        | "dppx" | "x" -> Some n
+        | "dpi" -> Some (n /. 96.)
+        | "dpcm" -> Some (n *. 2.54 /. 96.)
+        | _ -> None)
     | Ident _ | Function _ -> None
 
   let cmp_op : Media.cmp -> float -> float -> bool = function
@@ -1438,6 +1452,23 @@ module Match_media = struct
   open Media
 
   type feature_table = Media.t list
+  type truth = True | False | Unknown
+
+  let of_bool = function true -> True | false -> False
+  let of_option = function Some value -> of_bool value | None -> Unknown
+  let negate = function True -> False | False -> True | Unknown -> Unknown
+
+  let conjunction a b =
+    match (a, b) with
+    | False, _ | _, False -> False
+    | True, True -> True
+    | Unknown, _ | _, Unknown -> Unknown
+
+  let disjunction a b =
+    match (a, b) with
+    | True, _ | _, True -> True
+    | False, False -> False
+    | Unknown, _ | _, Unknown -> Unknown
 
   let strip_min_max = function
     | Media.Min name -> Some (`Min, name)
@@ -1447,23 +1478,23 @@ module Match_media = struct
   let lookup_value (table : feature_table) feature_name : Media.value option =
     List.find_map (media_feature_value feature_name) table
 
-  let feature_present (table : feature_table) name =
-    List.exists
-      (fun q ->
-        Option.is_some (media_feature_value (Media.string_of_name name) q))
-      table
+  let boolean_value : Media.value -> bool option = function
+    | Ident (None | No_preference) -> Some false
+    | Ident _ -> Some true
+    | value -> Option.map (fun n -> n <> 0.) (Media_value.to_number value)
 
-  let eval_feature (table : feature_table) : Media.feature -> bool =
+  let eval_feature q : Media.feature -> truth =
     let with_lookup name f =
-      match lookup_value table (Media.string_of_name name) with
-      | None -> false
-      | Some actual -> Option.value ~default:false (f actual)
+      if List.exists (Media.equal_name name) q.media_inapplicable then False
+      else
+        match lookup_value q.media_features (Media.string_of_name name) with
+        | None -> Unknown
+        | Some actual -> of_option (f actual)
     in
     function
-    (* Media Queries 4 3.1: an unrecognised <general-enclosed> is [unknown], and
-       unknown becomes false where a boolean is expected. *)
-    | General_enclosed _ -> false
-    | Boolean name -> feature_present table name
+    (* MQ4 section 3.1: preserve unknown until the whole query is evaluated. *)
+    | General_enclosed _ -> Unknown
+    | Boolean name -> with_lookup name boolean_value
     | Plain (name, value) -> (
         match strip_min_max name with
         | Some (`Min, base) ->
@@ -1491,21 +1522,28 @@ module Match_media = struct
     | Print -> q.media_type = Some "print"
     | Other s -> q.media_type = Some s
 
-  let rec eval_condition q : Media.condition -> bool = function
-    | Feature f -> eval_feature q.media_features f
-    | Not c -> not (eval_condition q c)
-    | And (a, b) -> eval_condition q a && eval_condition q b
-    | Or (a, b) -> eval_condition q a || eval_condition q b
+  let rec eval_condition q : Media.condition -> truth = function
+    | Feature f -> eval_feature q f
+    | Not c -> negate (eval_condition q c)
+    | And (a, b) -> conjunction (eval_condition q a) (eval_condition q b)
+    | Or (a, b) -> disjunction (eval_condition q a) (eval_condition q b)
 
-  let rec eval q : Media.t -> bool = function
+  let rec eval_query q : Media.t -> truth = function
     | Cond c -> eval_condition q c
     | Type { prefix; type_; trailing } -> (
         let body =
-          eval_medium q type_
-          && Option.fold ~none:true ~some:(eval_condition q) trailing
+          conjunction
+            (of_bool (eval_medium q type_))
+            (Option.fold ~none:True ~some:(eval_condition q) trailing)
         in
-        match prefix with Some Media.Not -> not body | _ -> body)
-    | List qs -> List.exists (eval q) qs
+        match prefix with Some Media.Not -> negate body | _ -> body)
+    | List [] -> True
+    | List qs ->
+        List.fold_left
+          (fun acc query -> disjunction acc (eval_query q query))
+          False qs
+
+  let eval q query = eval_query q query = True
 end
 
 (** {2 Container-query evaluation (CSS Conditional 5 sec. 5.4)}
@@ -1584,27 +1622,71 @@ module Match_container = struct
       q.container_features
     || eval_scroll_state_query q query
 
-  let rec eval q ?name : Container.t -> bool =
-    let media_q = { q with media_features = media_features_of q } in
+  let rec feature_available table = function
+    | Media.Min name | Media.Max name -> feature_available table name
+    | name ->
+        Option.is_some
+          (Match_media.lookup_value table (Media.string_of_name name))
+
+  let rec media_available table : Media.condition -> bool = function
+    | Feature (General_enclosed _) -> false
+    | Feature
+        ( Plain (name, _)
+        | Boolean name
+        | Range (name, _, _)
+        | Range_rev (_, _, name)
+        | Interval (_, _, name, _, _) ) ->
+        feature_available table name
+    | Not condition -> media_available table condition
+    | And (a, b) | Or (a, b) ->
+        media_available table a && media_available table b
+
+  (* Conditional Rules 5 section 5.4: all features must select the same eligible
+     container, even when an [or] branch would already be true. *)
+  let rec eligible q table : Container.t -> bool = function
+    | Min_width_rem _ | Min_width_px _ -> feature_available table Media.Width
+    | Feature_query (Media.Cond condition) -> media_available table condition
+    | Feature_query (Media.Type _ | Media.List _) -> false
+    | Named (name, condition) ->
+        name_matches ~name q && eligible q table condition
+    | And (a, b) | Or (a, b) -> eligible q table a && eligible q table b
+    | Not condition -> eligible q table condition
+    | Style _ -> true
+    | Scroll_state _ ->
+        List.exists
+          (function Container.Scroll_state _ -> true | _ -> false)
+          q.container_features
+
+  let rec eval_condition q : Container.t -> Match_media.truth =
+    let media_q =
+      { q with media_features = media_features_of q; media_inapplicable = [] }
+    in
     fun cond ->
-      if not (name_matches ?name q) then false
-      else
-        let min_width l =
-          Media.Cond
-            (Media.Feature (Media.Plain (Media.Min Media.Width, Media.Length l)))
-        in
-        match cond with
-        | Min_width_rem rem ->
-            Match_media.eval media_q (min_width (Values.Rem rem))
-        | Min_width_px px ->
-            Match_media.eval media_q (min_width (Values.Px (float_of_int px)))
-        | Named (n, inner) -> eval q ~name:n inner
-        | Style { query; _ } -> style_match q ~query
-        | Scroll_state { query; _ } -> eval_scroll_state q ~query
-        | And (a, b) -> eval q a && eval q b
-        | Or (a, b) -> eval q a || eval q b
-        | Not c -> not (eval q c)
-        | Feature_query media -> Match_media.eval media_q media
+      let min_width l =
+        Media.Cond
+          (Media.Feature (Media.Plain (Media.Min Media.Width, Media.Length l)))
+      in
+      match cond with
+      | Min_width_rem rem ->
+          Match_media.eval_query media_q (min_width (Values.Rem rem))
+      | Min_width_px px ->
+          Match_media.eval_query media_q
+            (min_width (Values.Px (float_of_int px)))
+      | Named (_, inner) -> eval_condition q inner
+      | Style { query; _ } -> Match_media.of_bool (style_match q ~query)
+      | Scroll_state { query; _ } ->
+          Match_media.of_bool (eval_scroll_state q ~query)
+      | And (a, b) ->
+          Match_media.conjunction (eval_condition q a) (eval_condition q b)
+      | Or (a, b) ->
+          Match_media.disjunction (eval_condition q a) (eval_condition q b)
+      | Not c -> Match_media.negate (eval_condition q c)
+      | Feature_query media -> Match_media.eval_query media_q media
+
+  let eval q ?name condition =
+    name_matches ?name q
+    && eligible q (media_features_of q) condition
+    && eval_condition q condition = Match_media.True
 end
 
 (** {2 Selector matching (CSS Selectors 4)}

--- a/lib/context.mli
+++ b/lib/context.mli
@@ -61,6 +61,9 @@ type query = {
   media_features : Media.t list;
       (** Media features the rendering environment claims to expose. Build
           entries with {!Media.val-feature} or {!Media.boolean}. *)
+  media_inapplicable : Media.name list;
+      (** Recognized features that cannot match any value in this environment.
+          Their tests are false, unlike unknown features. *)
   supports : Supports.t list;
       (** Capability flags the rendering environment claims to support. Each
           entry is normally a [Supports.Property] or [Supports.Func] leaf, built
@@ -151,6 +154,7 @@ val empty_query : query
 val query :
   ?media_type:string ->
   ?media_features:Media.t list ->
+  ?media_inapplicable:Media.name list ->
   ?supports:Supports.t list ->
   ?container_name:string ->
   ?container_features:Container.t list ->
@@ -278,14 +282,18 @@ val matches_selector : document -> Selector.t -> bool
     checked but the document is not a tree. *)
 
 val matches_media : query -> Media.t -> bool
-(** [matches_media q m] evaluates [m] against [q.media_features]. *)
+(** [matches_media q m] evaluates [m] against [q.media_features]. Missing values
+    remain unknown through boolean operators, unless the feature is explicitly
+    {!field-media_inapplicable}. Only a true final result matches. An empty
+    media list matches. *)
 
 val matches_supports : query -> Supports.t -> bool
 (** [matches_supports q cond] evaluates [cond] against [q.supports_table]. *)
 
 val matches_container : query -> ?name:string -> Container.t -> bool
 (** [matches_container q ?name cond] evaluates [cond] against the container
-    query state in [q]. *)
+    query state in [q]. The supplied container must expose every size or
+    scroll-state feature used by the condition before boolean evaluation. *)
 
 val resolve_url : loader -> string -> (string, string) result
 (** [resolve_url loader href] resolves [href] against

--- a/test/render/at_rule_conditions.ml
+++ b/test/render/at_rule_conditions.ml
@@ -723,11 +723,10 @@ let parse_driver_output lines =
 
 (* ===== The query context, built out of what the browser reported ===== *)
 
-(* "?" is a feature the browser does not recognise and "-" one it recognises and
-   exposes no value of. Neither is something the environment claims, so neither
-   enters the table. A feature reporting more than one keyword is a threshold
-   feature, which one value cannot stand for; the first is taken and the reading
-   is reported. *)
+(* "?" is unknown; "-" is recognized but matches no value. Keep these states
+   distinct in the explicit context, since negation distinguishes them. A
+   feature reporting multiple keywords is a threshold feature; the first value
+   is taken and the reading is reported. *)
 let env_reading env =
   let entries =
     Hashtbl.fold
@@ -1259,9 +1258,17 @@ let () =
     List.map
       (fun e ->
         let features = table_of_env e.env_id in
+        let media_inapplicable =
+          List.filter_map
+            (fun (name, value) ->
+              if String.equal value "-" then Some (Media.name_of_string name)
+              else None)
+            (env_reading e.env_id)
+        in
         ( e,
           features,
-          Context.query ~media_type:"screen" ~media_features:features () ))
+          Context.query ~media_type:"screen" ~media_features:features
+            ~media_inapplicable () ))
       environments
   in
   List.iter

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -935,6 +935,70 @@ let check_supports_match name ~ctx ~expected input =
     name expected
     (Css.Context.matches_supports ctx condition)
 
+(* MQ4 sections 2.4.2, 3.1, and 5.1: boolean feature values, unknown
+   propagation, and resolution units are independent parts of matching. *)
+let media_boolean_values () =
+  let ctx =
+    Css.Context.query
+      ~media_features:
+        (List.map Css.Media.of_string
+           [
+             "(monochrome: 0)";
+             "(color-index: 0)";
+             "(grid: 0)";
+             "(forced-colors: none)";
+             "(prefers-reduced-motion: no-preference)";
+             "(color: 8)";
+           ])
+      ()
+  in
+  List.iter
+    (check_media_match "zero or none is false" ~ctx ~expected:false)
+    [
+      "(monochrome)";
+      "(color-index)";
+      "(grid)";
+      "(forced-colors)";
+      "(prefers-reduced-motion)";
+    ];
+  check_media_match "nonzero is true" ~ctx ~expected:true "(color)"
+
+let media_unknown_logic () =
+  let ctx =
+    Css.Context.query ~media_type:"screen"
+      ~media_features:[ Css.Media.of_string "(width: 800px)" ]
+      ()
+  in
+  List.iter
+    (fun (input, expected) -> check_media_match input ~ctx ~expected input)
+    [
+      ("not (cascade-unknown: 1)", false);
+      ("not (orientation: sideways)", false);
+      ("not ((orientation: sideways) or (width < 0px))", false);
+      ("not ((orientation: sideways) and (width < 0px))", true);
+      ("(orientation: sideways) or (width >= 0px)", true);
+      ("not screen and (orientation: sideways)", false);
+      ("not print and (orientation: sideways)", true);
+      ("", true);
+    ]
+
+let media_resolution_units () =
+  let ctx =
+    Css.Context.query
+      ~media_features:[ Css.Media.of_string "(resolution: 1dppx)" ]
+      ()
+  in
+  List.iter
+    (check_media_match "equivalent resolution units" ~ctx ~expected:true)
+    [
+      "(resolution: 96dpi)";
+      "(resolution: 1dppx)";
+      "(resolution >= 37dpcm)";
+      "(resolution < 38dpcm)";
+    ];
+  check_media_match "larger resolution does not match" ~ctx ~expected:false
+    "(resolution: 192dpi)"
+
 let check_container_match name ~ctx ?name:container_name ~expected input =
   let condition = Css.Container.of_string input in
   Alcotest.(check bool)
@@ -2590,6 +2654,9 @@ let suite =
         test_document_selector_context_contract;
       Alcotest.test_case "query context evaluation contract" `Quick
         test_query_context_evaluation_contract;
+      Alcotest.test_case "media boolean values" `Quick media_boolean_values;
+      Alcotest.test_case "media unknown logic" `Quick media_unknown_logic;
+      Alcotest.test_case "media resolution units" `Quick media_resolution_units;
       Alcotest.test_case "loader context contract" `Quick
         test_loader_context_contract;
       Alcotest.test_case "animation context contract" `Quick

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -999,11 +999,50 @@ let media_resolution_units () =
   check_media_match "larger resolution does not match" ~ctx ~expected:false
     "(resolution: 192dpi)"
 
+let media_inapplicable_feature () =
+  let ctx = Css.Context.query ~media_inapplicable:[ Css.Media.Scan ] () in
+  check_media_match "recognized inapplicable feature is false, not unknown" ~ctx
+    ~expected:true "not (scan: progressive)";
+  check_media_match "inapplicable boolean is false" ~ctx ~expected:false
+    "(scan)";
+  check_media_match "an absent feature remains unknown" ~ctx ~expected:false
+    "not (cascade-unknown: 1)"
+
 let check_container_match name ~ctx ?name:container_name ~expected input =
   let condition = Css.Container.of_string input in
   Alcotest.(check bool)
     name expected
     (Css.Context.matches_container ctx ?name:container_name condition)
+
+(* Conditional Rules 5 section 5.4 selects a container supporting every queried
+   feature before evaluating the boolean expression. *)
+let container_feature_eligibility () =
+  let ctx =
+    Css.Context.query
+      ~container_features:[ Css.Container.of_string "(width: 500px)" ]
+      ()
+  in
+  List.iter
+    (check_container_match "no eligible container" ~ctx ~expected:false)
+    [
+      "(width >= 400px) or (height >= 900px)";
+      "(width >= 400px) or (cascade-unknown: 1)";
+      "not (cascade-unknown: 1)";
+      "not scroll-state(stuck: top)";
+    ];
+  check_container_match "eligible negation" ~ctx ~expected:true
+    "not (width >= 900px)";
+  let ctx =
+    Css.Context.query
+      ~container_features:
+        [
+          Css.Container.of_string "(width: 500px)";
+          Css.Container.of_string "(height: 300px)";
+        ]
+      ()
+  in
+  check_container_match "both axes are eligible" ~ctx ~expected:true
+    "(width >= 400px) or (height >= 900px)"
 
 let check_resolved_url name ~loader ~expected input =
   match Css.Context.resolve_url loader input with
@@ -2657,6 +2696,10 @@ let suite =
       Alcotest.test_case "media boolean values" `Quick media_boolean_values;
       Alcotest.test_case "media unknown logic" `Quick media_unknown_logic;
       Alcotest.test_case "media resolution units" `Quick media_resolution_units;
+      Alcotest.test_case "media inapplicable feature" `Quick
+        media_inapplicable_feature;
+      Alcotest.test_case "container feature eligibility" `Quick
+        container_feature_eligibility;
       Alcotest.test_case "loader context contract" `Quick
         test_loader_context_contract;
       Alcotest.test_case "animation context contract" `Quick


### PR DESCRIPTION
An unknown media feature evaluated as false, so `not (unknown: x)` came out true and a guarded block was kept or dropped on a guess. Evaluation is three-valued now, and a container query is evaluated only against an eligible container.

`Css.Context.query` gains a `media_inapplicable` field, which is breaking for anyone building one, and several matching answers move with the new evaluation; the changelog names them.
