### PR TITLE
supports: preserve unknown parenthesized conditions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,9 @@ entry points both moved.
 
 ### Breaking
 
+- `Css.Supports.t` gains `General_enclosed` for opaque parenthesized feature
+  tests. Exhaustive visitors must preserve this new leaf (#869).
+
 - `Css.Context.query` gains `media_inapplicable`, distinguishing a recognized
   feature that matches no value from an unknown feature. Direct record
   constructors need the new field; `Context.query ()` defaults it to `[]`
@@ -195,9 +198,9 @@ entry points both moved.
 
 ### Parsing
 
-- Unknown enclosed media conditions and unsupported `@supports` function
-  arguments retain their guards, so an applicable `or` branch or negated
-  capability test no longer loses its rules (#867).
+- Unknown enclosed media and `@supports` conditions retain their guards, so
+  applicable `or` branches and negated capability tests no longer lose their
+  rules (#867, #869).
 
 - `margin` mixes `auto` with lengths in any slot, `border-style` takes the four
   side styles, `border-block-style` and `border-inline-style` take the start and

--- a/fuzz/fuzz_supports.ml
+++ b/fuzz/fuzz_supports.ml
@@ -51,7 +51,9 @@ let rec has_mixed_operator = function
   | Css.Supports.And (a, b) | Css.Supports.Or (a, b) ->
       has_mixed_operator a || has_mixed_operator b
   | Css.Supports.Not a -> has_mixed_operator a
-  | Css.Supports.Property _ | Css.Supports.Function _ -> false
+  | Css.Supports.Property _ | Css.Supports.Function _
+  | Css.Supports.General_enclosed _ ->
+      false
 
 let test_mixed_operator_serialization_reparse buf =
   match

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -1433,7 +1433,7 @@ end
 module Match_supports = struct
   (* Leaves match against [q.supports] via the typed [Supports.equal]. *)
   let rec eval q : Supports.t -> bool = function
-    | (Property _ | Function _) as leaf ->
+    | (Property _ | Function _ | General_enclosed _) as leaf ->
         List.exists (Supports.equal leaf) q.supports
     | Not c -> not (eval q c)
     | And (a, b) -> eval q a && eval q b

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -920,6 +920,7 @@ let refs_of_supports_feature : Supports.declaration_feature -> string list =
 let rec refs_of_supports : Supports.t -> string list = function
   | Property feature -> refs_of_supports_feature feature
   | Function _ -> []
+  | General_enclosed text -> refs_of_component_string text
   | Not condition -> refs_of_supports condition
   | And (a, b) | Or (a, b) -> refs_of_supports a @ refs_of_supports b
 

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -876,7 +876,8 @@ let add_declaration_prefixes ~targets decls =
 let rec condition_has_webkit kind = function
   | Supports.Property (Supports.Declaration decl) ->
       is_webkit_fallback kind decl
-  | Supports.Property _ | Supports.Function _ -> false
+  | Supports.Property _ | Supports.Function _ | Supports.General_enclosed _ ->
+      false
   | Supports.Not condition -> condition_has_webkit kind condition
   | Supports.And (a, b) | Supports.Or (a, b) ->
       condition_has_webkit kind a || condition_has_webkit kind b
@@ -893,7 +894,9 @@ let add_condition_prefixes ~targets condition =
                   (Supports.Property (Supports.Declaration prefixed), original)
             | None -> original)
         | Some _ | None -> original)
-    | (Supports.Property _ | Supports.Function _) as leaf -> leaf
+    | (Supports.Property _ | Supports.Function _ | Supports.General_enclosed _)
+      as leaf ->
+        leaf
     | Supports.Not condition as original ->
         let condition' = map condition in
         if condition' == condition then original else Supports.Not condition'

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -20,7 +20,7 @@
     <supports-font-tech-fn> = font-tech( <font-tech> )
     <supports-font-format-fn> = font-format( <font-format> )
     <general-enclosed> = <function-token> <any-value>? )
-                       | ( <any-value> )
+                       | ( <any-value>? )
     v} *)
 
 open Syntax
@@ -70,6 +70,8 @@ type t =
   | Function of function_feature
       (** Function feature test (selector, font-format, font-tech, at-rule,
           named-feature, or env). *)
+  | General_enclosed of string
+      (** Opaque parenthesized condition, including its delimiters. *)
   | Not of t  (** [not (condition)] negation *)
   | And of t * t  (** [(cond1) and (cond2)] conjunction *)
   | Or of t * t  (** [(cond1) or (cond2)] disjunction *)
@@ -272,6 +274,7 @@ let rec pp_aux ~in_and ctx = function
       pp_declaration_feature ctx feature;
       Pp.char ctx ')'
   | Function feature -> pp_function_feature ctx feature
+  | General_enclosed text -> Pp.string ctx text
   | Not cond -> pp_not ~in_and ctx cond
   | And (a, b) -> pp_and ctx a b
   | Or (a, b) -> pp_or ctx a b
@@ -338,16 +341,6 @@ let closed_block = function
   | Component.Func { node = { terminated = closed; _ }; _ } ->
       closed
   | _ -> true
-
-let rec components_are_closed cvs =
-  List.for_all
-    (function
-      | Component.Block { node = { value; closed; _ }; _ } ->
-          closed && components_are_closed value
-      | Component.Func { node = { arguments; terminated; _ }; _ } ->
-          terminated && components_are_closed arguments
-      | Component.Preserved _ -> true)
-    cvs
 
 let contains_top_level_semicolon =
   List.exists (function
@@ -456,19 +449,21 @@ and in_parens ~allow_unwrapped_decl t =
   | _ -> err t [] "Expected supports feature"
 
 and paren_components t value =
-  if strip_components value = [] then
-    err t value "Empty parentheses in @supports";
-  if not (components_are_closed value) then
-    err t value "Unmatched parenthesis in @supports condition";
-  match split_top_level_colon value with
-  | Some (prop, value) -> declaration_of_components t prop value
-  | None ->
-      let inner = Cursor.sub t value in
-      let condition = condition inner in
-      Cursor.ws inner;
-      if not (Cursor.is_done inner) then
-        err inner [] "trailing content in @supports group";
-      condition
+  if not (Component.is_any_value value) then
+    err t value "Invalid general-enclosed condition in @supports";
+  try
+    match split_top_level_colon value with
+    | Some (prop, value) -> declaration_of_components t prop value
+    | None ->
+        let inner = Cursor.sub t value in
+        let condition = condition inner in
+        Cursor.ws inner;
+        if not (Cursor.is_done inner) then
+          err inner [] "trailing content in @supports group";
+        condition
+  with Cursor.Parse_error _ ->
+    General_enclosed
+      (String.concat "" [ "("; Cursor.string_of_components value; ")" ])
 
 let read ?(allow_unwrapped_decl = false) t =
   let cond =
@@ -530,6 +525,7 @@ let rec compare t1 t2 =
   match (t1, t2) with
   | Property d1, Property d2 -> compare_declaration_feature d1 d2
   | Function f1, Function f2 -> compare_function_feature f1 f2
+  | General_enclosed a, General_enclosed b -> String.compare a b
   | Not a, Not b -> compare a b
   | And (a1, b1), And (a2, b2) ->
       let c = compare a1 a2 in
@@ -537,11 +533,13 @@ let rec compare t1 t2 =
   | Or (a1, b1), Or (a2, b2) ->
       let c = compare a1 a2 in
       if c <> 0 then c else compare b1 b2
-  (* Order: Property < Function < Not < And < Or *)
+  (* Order: Property < Function < General_enclosed < Not < And < Or *)
   | Property _, _ -> -1
   | _, Property _ -> 1
   | Function _, _ -> -1
   | _, Function _ -> 1
+  | General_enclosed _, _ -> -1
+  | _, General_enclosed _ -> 1
   | Not _, _ -> -1
   | _, Not _ -> 1
   | And _, _ -> -1
@@ -571,7 +569,7 @@ let equal a b = compare a b = 0
 let max_atoms = 16
 
 let rec collect_atoms acc = function
-  | (Property _ | Function _) as atom ->
+  | (Property _ | Function _ | General_enclosed _) as atom ->
       if List.exists (fun a -> equal a atom) acc then acc
       else if List.length acc >= max_atoms then raise Exit
       else atom :: acc
@@ -624,7 +622,7 @@ let disjoint a b = for_all_bytes (fun x y -> x land y = 0) a b
 let never v = Bytes.for_all (fun c -> c = '\000') v
 
 let rec eval ~atom ~all = function
-  | (Property _ | Function _) as leaf -> atom leaf
+  | (Property _ | Function _ | General_enclosed _) as leaf -> atom leaf
   | Not a -> v_not ~all (eval ~atom ~all a)
   | And (a, b) -> v_and (eval ~atom ~all a) (eval ~atom ~all b)
   | Or (a, b) -> v_or (eval ~atom ~all a) (eval ~atom ~all b)
@@ -640,7 +638,8 @@ let rec reduce ~atom ~world ~all cond =
     else (v, residual)
   in
   match cond with
-  | Property _ | Function _ -> decide (atom cond) (`Cond cond)
+  | Property _ | Function _ | General_enclosed _ ->
+      decide (atom cond) (`Cond cond)
   | Not a ->
       let va, ra = reduce ~atom ~world ~all a in
       let residual =

--- a/lib/supports.mli
+++ b/lib/supports.mli
@@ -60,6 +60,8 @@ type t =
       (** Function feature test: [selector()], [font-format()], [font-tech()],
           [at-rule()], [named-feature()], [env()], or a general-enclosed
           function. *)
+  | General_enclosed of string
+      (** Opaque parenthesized condition, including its delimiters. *)
   | Not of t  (** [not (condition)] negation *)
   | And of t * t  (** [(cond1) and (cond2)] conjunction *)
   | Or of t * t  (** [(cond1) or (cond2)] disjunction *)

--- a/test/render/at_rule_conditions.ml
+++ b/test/render/at_rule_conditions.ml
@@ -503,7 +503,25 @@ let supports_seeds ~seed =
         | 5 -> String.concat "" [ "not ("; a (); " and "; a (); ")" ]
         | _ -> String.concat "" [ "(("; a (); ") or ("; a (); "))" ])
   in
-  List.concat [ supports_leaves; generated ]
+  let enclosed =
+    List.concat_map
+      (fun leaf ->
+        [
+          leaf;
+          String.concat "" [ "not "; leaf ];
+          String.concat "" [ leaf; " or (display: grid)" ];
+          String.concat "" [ leaf; " and (display: grid)" ];
+        ])
+      [
+        "(future syntax)";
+        "()";
+        "(display)";
+        "(: grid)";
+        "(display: grid;)";
+        "((display: grid) and)";
+      ]
+  in
+  List.concat [ supports_leaves; generated; enclosed ]
 
 (* ===== The [@container] population ===== *)
 
@@ -768,7 +786,9 @@ let parse_container text =
   match Container.of_string text with exception _ -> None | c -> Some c
 
 let supports_leaf (c : Supports.t) =
-  match c with Property _ | Function _ -> true | Not _ | And _ | Or _ -> false
+  match c with
+  | Property _ | Function _ | General_enclosed _ -> true
+  | Not _ | And _ | Or _ -> false
 
 (* A rewrite is checked by asking the browser about the rewritten text, so the
    rewrite joins the population. Reading the query back out of the parser is a

--- a/test/spec/inventory/supports_grammar.ml
+++ b/test/spec/inventory/supports_grammar.ml
@@ -109,12 +109,11 @@ let invalid =
     "font-format(])";
     "future(url(a b))";
     "future(\"a\nb\")";
+    "(future ])";
+    "(future url(a b))";
+    "(future \"a\nb\")";
     "";
-    "()";
     "display: grid";
-    "(display)";
-    "(: grid)";
-    "(display: grid;)";
     "(display: grid) and";
     "(display: grid) or";
     "(display: grid) and (gap: 1rem) or selector(:has(img))";
@@ -125,7 +124,6 @@ let invalid =
     "not (display: grid) or (gap: 1rem)";
     "selector(:has(img)";
     "not";
-    "not ()";
     "(display: grid) and or (gap: 1rem)";
     "((display: grid)";
     "(display: grid";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4050,7 +4050,8 @@ let test_spec_snapshot_tracking_vectors () =
   neg_cursor read "@layer reset,,base;";
   check_stylesheet ~expected:"@container card (){.card{color:red}}"
     "@container card () { .card { color: red } }";
-  neg_cursor read "@supports () { .accent { color: red } }"
+  check_stylesheet ~expected:"@supports(){.accent{color:red}}"
+    "@supports () { .accent { color: red } }"
 
 (* ignore-test *)
 let test_snapshot_membership_matrix () =
@@ -9242,8 +9243,8 @@ let supports_condition_error_spans () =
   (* The [or] that follows an [and] spans offsets 45-46. *)
   check "mixed operators" "(a:b) and (c:d) or (e:f)"
     ("Cannot mix and/or without parentheses in @supports", 45, 47);
-  (* The empty parentheses span offsets 29-30. *)
-  check "empty parentheses" "()" ("Empty parentheses in @supports", 29, 31);
+  check_stylesheet ~expected:"@supports(){.a{color:blue}}"
+    "@supports () { .a { color: blue } }";
   check_stylesheet ~expected:"@supports font-format(bogus){.a{color:blue}}"
     "@supports font-format(bogus) { .a { color: blue } }"
 

--- a/test/test_supports.ml
+++ b/test/test_supports.ml
@@ -144,6 +144,23 @@ let spec_supports_negative_vectors () =
     Cascade_spec_inventory.Supports_grammar.invalid
 
 let spec_supports_structural_vectors () =
+  let unknown = of_string "(future syntax)" in
+  Alcotest.(check bool)
+    "unknown enclosed atom differs from a function" false
+    (equal unknown (of_string "future(syntax)"));
+  Alcotest.(check bool)
+    "unknown feature is false in an empty explicit context" true
+    (Css.Context.matches_supports (Css.Context.query ()) (Not unknown));
+  Alcotest.(check bool)
+    "explicit future capability is respected" true
+    (Css.Context.matches_supports
+       (Css.Context.query ~supports:[ unknown ] ())
+       unknown);
+  (match simplify_under ~context:[] unknown with
+  | `Cond retained ->
+      Alcotest.(check bool)
+        "open world retains unknown guard" true (equal unknown retained)
+  | `True | `False -> Alcotest.fail "unknown guard folded without context");
   List.iter
     (fun (row : Supports_inventory.row) ->
       let actual = of_string row.input in

--- a/test/test_supports.ml
+++ b/test/test_supports.ml
@@ -83,6 +83,19 @@ let spec_supports_feature_vectors () =
     let actual = of_string input in
     Alcotest.(check string) name expected (to_string actual)
   in
+  (* CSS Conditional Rules 3 section 6 includes parenthesized general-enclosed
+     alongside declaration and nested-condition features. *)
+  List.iter
+    (fun input -> check "parenthesized general-enclosed" input input)
+    [
+      "not (future syntax)";
+      "()";
+      "(display)";
+      "(: grid)";
+      "(display: grid;)";
+      "((display: grid) and)";
+      "(future syntax) or (display: grid)";
+    ];
   (* Conditional Rules general-enclosed preserves functions whose arguments do
      not match a supported feature grammar, including under negation. *)
   check "unknown font format under not" "not font-format(cascade-nope)"


### PR DESCRIPTION
An `@supports` condition cascade could not parse was a parse error, so `not (unknown-thing)` lost the rules a browser keeps. An unknown parenthesized test is opaque now and answers only from the supplied context.

`Css.Supports.t` gains a `General_enclosed` constructor, which is breaking, and `Css.inline_vars` reads the custom-property references inside such a condition, so a binding used only there is no longer pruned.
