### PR TITLE
filter: accept omitted function arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@ entry points both moved.
 
 ### Breaking
 
+- `Css.filter` gains `Omitted of filter_function` to retain empty calls.
+  Exhaustive visitors must handle this leaf; normalization equates it with
+  its specified default (#870).
+
 - `Css.Supports.t` gains `General_enclosed` for opaque parenthesized feature
   tests. Exhaustive visitors must preserve this new leaf (#869).
 
@@ -197,6 +201,10 @@ entry points both moved.
   `--limit=N` where a level was pinned (#792)
 
 ### Parsing
+
+- `filter` and backdrop/vendor variants accept omitted function arguments,
+  retaining the empty call and shortening explicit defaults when optimized
+  (#870).
 
 - Unknown enclosed media and `@supports` conditions retain their guards, so
   applicable `or` branches and negated capability tests no longer lose their

--- a/fuzz/fuzz_declaration.ml
+++ b/fuzz/fuzz_declaration.ml
@@ -250,7 +250,7 @@ let invalid_feature_decl buf =
       "object-view-box:inset()";
       "image-rendering:pixelated smooth";
       "mask-size:contain cover";
-      "backdrop-filter:blur()";
+      "backdrop-filter:blur(1px, 2px)";
       "will-change:auto, transform";
       "animation-composition:add replace";
       "scroll-timeline-axis:block inline";

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -6176,9 +6176,22 @@ val translate : translate_value -> declaration
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/translate} translate}
     property. *)
 
+(** Filter functions with an optional argument. *)
+type filter_function = Properties.filter_function =
+  | Blur_function
+  | Brightness_function
+  | Contrast_function
+  | Grayscale_function
+  | Hue_rotate_function
+  | Invert_function
+  | Opacity_function
+  | Saturate_function
+  | Sepia_function
+
 (** CSS filter values *)
 type filter = Properties.filter =
   | None  (** No filter *)
+  | Omitted of filter_function  (** Function with its argument omitted. *)
   | Blur of length  (** blur(px) *)
   | Brightness of number_percentage  (** brightness(%) *)
   | Contrast of number_percentage  (** contrast(%) *)

--- a/lib/prop_filter.ml
+++ b/lib/prop_filter.ml
@@ -96,11 +96,25 @@ let rec read_blend_mode t : blend_mode =
     ~calls:[ ("var", read_var) ]
     t
 
-let read_blur t : filter = Cursor.call "blur" t (fun t -> Blur (read_length t))
+let read_blur t : filter =
+  Cursor.call "blur" t (fun t ->
+      if Cursor.is_done t then Omitted Blur_function else Blur (read_length t))
+
+let filter_function_name = function
+  | Blur_function -> "blur"
+  | Brightness_function -> "brightness"
+  | Contrast_function -> "contrast"
+  | Grayscale_function -> "grayscale"
+  | Hue_rotate_function -> "hue-rotate"
+  | Invert_function -> "invert"
+  | Opacity_function -> "opacity"
+  | Saturate_function -> "saturate"
+  | Sepia_function -> "sepia"
 
 let rec pp_filter : filter Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"
+  | Omitted fn -> Pp.call (filter_function_name fn) Pp.nop ctx ()
   | Blur l -> Pp.call "blur" pp_length ctx l
   | Brightness n ->
       Pp.call "brightness" (pp_number_percentage ~always:true) ctx n
@@ -126,55 +140,64 @@ let rec pp_filter : filter Pp.t =
 
 let rec normalize_filter ?(lossless = false) : filter -> filter =
  fun value ->
-  let np = Values.normalize_number_percentage in
+  let amount fn make n =
+    match Values.normalize_number_percentage n with
+    | Num 1. | Pct 100. -> Omitted fn
+    | n -> preserve_if_equal value (make n)
+  in
   match value with
+  | Blur l ->
+      let omitted =
+        match l with Pct _ -> false | l -> Values.length_is_zero l
+      in
+      if omitted then Omitted Blur_function else value
   | Drop_shadow s ->
       preserve_if_equal value (Drop_shadow (normalize_shadow ~lossless s))
   | Hue_rotate a ->
-      preserve_if_equal value (Hue_rotate (Values.normalize_angle a))
-  | Brightness x -> preserve_if_equal value (Brightness (np x))
-  | Contrast x -> preserve_if_equal value (Contrast (np x))
-  | Grayscale x -> preserve_if_equal value (Grayscale (np x))
-  | Invert x -> preserve_if_equal value (Invert (np x))
-  | Opacity x -> preserve_if_equal value (Opacity (np x))
-  | Saturate x -> preserve_if_equal value (Saturate (np x))
-  | Sepia x -> preserve_if_equal value (Sepia (np x))
+      let a = Values.normalize_angle a in
+      if a = Deg 0. then Omitted Hue_rotate_function
+      else preserve_if_equal value (Hue_rotate a)
+  | Brightness x -> amount Brightness_function (fun n -> Brightness n) x
+  | Contrast x -> amount Contrast_function (fun n -> Contrast n) x
+  | Grayscale x -> amount Grayscale_function (fun n -> Grayscale n) x
+  | Invert x -> amount Invert_function (fun n -> Invert n) x
+  | Opacity x -> amount Opacity_function (fun n -> Opacity n) x
+  | Saturate x -> amount Saturate_function (fun n -> Saturate n) x
+  | Sepia x -> amount Sepia_function (fun n -> Sepia n) x
   | List filters ->
       preserve_if_equal value
         (List (map_preserve (normalize_filter ~lossless) filters))
   | other -> other
 
 module Filter = struct
+  let read_amount fn make t : filter =
+    Cursor.call (filter_function_name fn) t (fun t ->
+        if Cursor.is_done t then Omitted fn
+        else make (Values.read_number_percentage t))
+
   let read_brightness t : filter =
-    Cursor.call "brightness" t (fun t ->
-        Brightness (Values.read_number_percentage t))
+    read_amount Brightness_function (fun n -> Brightness n) t
 
   let read_contrast t : filter =
-    Cursor.call "contrast" t (fun t ->
-        Contrast (Values.read_number_percentage t))
+    read_amount Contrast_function (fun n -> Contrast n) t
 
   let read_grayscale t : filter =
-    Cursor.call "grayscale" t (fun t : filter ->
-        Grayscale (Values.read_number_percentage t))
+    read_amount Grayscale_function (fun n -> Grayscale n) t
 
   let read_hue_rotate t : filter =
     Cursor.call "hue-rotate" t (fun t ->
-        if Cursor.is_done t then Hue_rotate (Deg 0.)
+        if Cursor.is_done t then Omitted Hue_rotate_function
         else Hue_rotate (read_angle t))
 
-  let read_invert t : filter =
-    Cursor.call "invert" t (fun t -> Invert (Values.read_number_percentage t))
+  let read_invert t : filter = read_amount Invert_function (fun n -> Invert n) t
 
   let read_opacity t : filter =
-    Cursor.call "opacity" t (fun t : filter ->
-        Opacity (Values.read_number_percentage t))
+    read_amount Opacity_function (fun n -> Opacity n) t
 
   let read_saturate t : filter =
-    Cursor.call "saturate" t (fun t ->
-        Saturate (Values.read_number_percentage t))
+    read_amount Saturate_function (fun n -> Saturate n) t
 
-  let read_sepia t : filter =
-    Cursor.call "sepia" t (fun t -> Sepia (Values.read_number_percentage t))
+  let read_sepia t : filter = read_amount Sepia_function (fun n -> Sepia n) t
 
   let read_drop_shadow t : filter =
     Cursor.call "drop-shadow" t (fun t ->

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2469,8 +2469,20 @@ type text_shadow =
   | Revert_layer
   | Var of text_shadow var
 
+type filter_function =
+  | Blur_function
+  | Brightness_function
+  | Contrast_function
+  | Grayscale_function
+  | Hue_rotate_function
+  | Invert_function
+  | Opacity_function
+  | Saturate_function
+  | Sepia_function
+
 type filter =
   | None
+  | Omitted of filter_function
   | Blur of length
   | Brightness of number_percentage
   | Contrast of number_percentage

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -4,6 +4,20 @@ type row = {
   negatives : string list;
 }
 
+(* Filter Effects 1 section 6.1: drop-shadow alone requires arguments. *)
+let omitted_filters =
+  [
+    "blur()";
+    "brightness()";
+    "contrast()";
+    "grayscale()";
+    "hue-rotate()";
+    "invert()";
+    "opacity()";
+    "saturate()";
+    "sepia()";
+  ]
+
 let matrix =
   [
     {
@@ -213,10 +227,8 @@ let matrix =
           "blur(5px) contrast(120%)";
           "drop-shadow(0 0 2px black)";
           "opacity(calc(50% + 25%))";
-          (* Filter Effects 1 sec. 6.1: blur() = blur( <length>? ), so the
-             argument may be omitted. drop-shadow() below has no such arm. *)
-          "blur()";
-        ];
+        ]
+        @ omitted_filters;
       negatives = [ "drop-shadow()"; "blur(red)" ];
     };
     {
@@ -761,7 +773,8 @@ let matrix =
         "-ms-filter";
       ]
       (* Filter Effects 1 sec. 6.1: blur( <length>? ). *)
-      [ "none"; "blur(5px)"; "contrast(120%) brightness(.8)"; "blur()" ]
+      ([ "none"; "blur(5px)"; "contrast(120%) brightness(.8)" ]
+      @ omitted_filters)
       [ "blur(red)"; "none blur(1px)" ]
     (* CSS Transitions 1 sec. 2.2: <time [0s,inf]>#. *)
   @ rows_for [ "transition-duration" ]

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3410,6 +3410,36 @@ let color_functions () =
   check_declaration ~expected:"color:color(display-p3 1 0 0/.5)"
     "color: color(display-p3 1 0 0 / 0.5)"
 
+let filter_omitted_arguments () =
+  (* Filter Effects 1 section 6.1: omitted blur/hue-rotate arguments default to
+     zero; all optional number-percentage arguments default to one. *)
+  List.iter
+    (fun prop ->
+      List.iter
+        (fun (fn, default) ->
+          let omitted = String.concat "" [ prop; ":"; fn; "()" ] in
+          let explicit =
+            String.concat "" [ prop; ":"; fn; "("; default; ")" ]
+          in
+          check_declaration ~expected:omitted omitted;
+          let canonical text =
+            of_string text |> normalize |> string_of_value ~minify:true
+          in
+          Alcotest.(check string)
+            omitted (canonical explicit) (canonical omitted))
+        [
+          ("blur", "0px");
+          ("brightness", "1");
+          ("contrast", "1");
+          ("grayscale", "1");
+          ("hue-rotate", "0deg");
+          ("invert", "1");
+          ("opacity", "1");
+          ("saturate", "1");
+          ("sepia", "1");
+        ])
+    [ "filter"; "backdrop-filter"; "-webkit-backdrop-filter" ]
+
 let angle_units () =
   check_declaration ~expected:"transform:rotate(.5turn)"
     "transform: rotate(0.5turn)";
@@ -5572,6 +5602,7 @@ let declaration_tests =
     test_case "animations (state)" `Quick animations_state;
     test_case "animation drained shorthand" `Quick animation_drained_shorthand;
     test_case "transforms" `Quick transforms;
+    test_case "filter omitted arguments" `Quick filter_omitted_arguments;
     test_case "angle units" `Quick angle_units;
     test_case "grid" `Quick grid;
     test_case "list properties" `Quick list_properties;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2784,7 +2784,7 @@ let spec_property_grammar_table_expansion () =
       ("shape-margin", "-1px");
       ("color", "light-dark(black)");
       ("mix-blend-mode", "normal multiply");
-      ("filter", "blur()");
+      ("filter", "blur(1px, 2px)");
       ("font", "bold serif");
       ("font-stretch", "-10%");
       ("font-feature-settings", "\"kern\" maybe");
@@ -3422,6 +3422,8 @@ let filter_omitted_arguments () =
             String.concat "" [ prop; ":"; fn; "("; default; ")" ]
           in
           check_declaration ~expected:omitted omitted;
+          check_declaration ~expected:omitted
+            (String.concat "" [ prop; ":"; fn; "( /**/ )" ]);
           let canonical text =
             of_string text |> normalize |> string_of_value ~minify:true
           in
@@ -3960,7 +3962,7 @@ let spec_remaining_prop_vectors () =
       "mask-border: fill fill";
       "mask-size: contain cover";
       "mask-repeat: no-repeat repeat repeat-x";
-      "backdrop-filter: blur()";
+      "backdrop-filter: blur(1px, 2px)";
       "will-change: auto, transform";
       "touch-action: pan-x pan-left";
       "resize: block inline both";


### PR DESCRIPTION
Eight of the nine filter functions rejected the empty call Filter Effects permits, so `blur()` and its siblings were dropped rather than taking their default. The omitted form is the canonical one now, so `brightness(1)` and `blur(0)` shorten under `--optimize`.

`Css.filter` gains an `Omitted` constructor and a `filter_function` type, which is breaking, and which leaves `dune runtest` red on `check_api_consistency` until #872 supplies the reader and printer.
