### PR TITLE
properties: expose filter function name helpers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -772,6 +772,9 @@ entry points both moved.
 
 ### Library
 
+- `Properties.read_filter_function` and `pp_filter_function` expose the names
+  used by `Omitted` filter values (#872).
+
 - `Css.Context.matches_media` respects zero-valued boolean features and
   resolution units, preserves unknown through negation, and matches an empty
   query list (#868).

--- a/lib/prop_filter.ml
+++ b/lib/prop_filter.ml
@@ -115,6 +115,25 @@ let filter_function_name = function
   | Saturate_function -> "saturate"
   | Sepia_function -> "sepia"
 
+let pp_filter_function ctx fn = Pp.string ctx (filter_function_name fn)
+
+let read_filter_function t =
+  Cursor.enum "optional filter function"
+    (List.map
+       (fun fn -> (filter_function_name fn, fn))
+       [
+         Blur_function;
+         Brightness_function;
+         Contrast_function;
+         Grayscale_function;
+         Hue_rotate_function;
+         Invert_function;
+         Opacity_function;
+         Saturate_function;
+         Sepia_function;
+       ])
+    t
+
 let pp_blur_length ctx (length : length) =
   match length with
   | Calc (Val value) -> (

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1587,6 +1587,15 @@ val pp_rotate_value : rotate_value Pp.t
 val read_rotate_value : Cursor.t -> rotate_value
 (** [read_rotate_value t] is the [rotate_value] parsed from [t]. *)
 
+val pp_filter_function : filter_function Pp.t
+(** [pp_filter_function] prints the name of a filter function with an optional
+    argument, without parentheses. *)
+
+val read_filter_function : Cursor.t -> filter_function
+(** [read_filter_function t] reads the name of a filter function with an
+    optional argument. [drop-shadow] is excluded because its arguments are
+    mandatory. *)
+
 val pp_filter : filter Pp.t
 (** [pp_filter] is the pretty-printer for [filter]. *)
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -373,6 +373,9 @@ let check_text_shadow =
 let check_shadow = check_value_cursor "shadow" read_shadow pp_shadow
 let check_filter = check_value_cursor "filter" read_filter pp_filter
 
+let check_filter_function =
+  check_value_cursor "filter function" read_filter_function pp_filter_function
+
 let check_background_attachment =
   check_value_cursor "background-attachment" read_background_attachment
     pp_background_attachment
@@ -3798,6 +3801,26 @@ let test_text_shadow () =
   check_text_shadow "0 0 10px";
   neg_cursor read_text_shadow "invalid-shadow"
 
+let test_filter_function () =
+  List.iter
+    (fun name ->
+      check_filter_function ~roundtrip:true name;
+      check_filter_function ~expected:name (String.uppercase_ascii name))
+    [
+      "blur";
+      "brightness";
+      "contrast";
+      "grayscale";
+      "hue-rotate";
+      "invert";
+      "opacity";
+      "saturate";
+      "sepia";
+    ];
+  neg_cursor read_filter_function "drop-shadow";
+  neg_cursor read_filter_function "unknown";
+  neg_cursor read_filter_function "blur()"
+
 let test_filter () =
   check_filter "none";
   check_filter "blur(5px)";
@@ -5305,6 +5328,7 @@ let tests =
     test_case "background-image" `Quick test_background_image;
     test_case "url escaping" `Quick test_url_escaping;
     test_case "filter" `Quick test_filter;
+    test_case "filter function" `Quick test_filter_function;
     test_case "pp property value" `Quick test_pp_property_value;
     test_case "spec current property grammar edges" `Quick
       spec_property_grammar_edges;


### PR DESCRIPTION
Follow-up to #870, which added `filter_function` without the reader and printer `check_api_consistency` requires, leaving `dune runtest` red. This adds both, with round-trip coverage for each name.
