### PR TITLE
resolve: answer :empty where the spec and the engines agree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -781,6 +781,10 @@ entry points both moved.
 - `Css.Context.matches_container` requires the supplied container to support
   all queried features, so negation and disjunction cannot make an ineligible
   container match (#868).
+- `Resolve.Make.match_selector` answers `:empty` for the elements Selectors 4
+  and the engines agree on, declining only the element whose children are
+  document white space alone. `Resolve.supported` is unchanged, so `cascade
+  apply` and `cascade prune` keep such a rule as before (#873).
 
 - `cascade` drops its `uutf` dependency for the stdlib UTF-8 decoder, which
   counts one replacement character per maximal subpart of an ill-formed

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -15,27 +15,12 @@ type match_result = Matches | No_match | Unsupported
 type reading = Browser | Spec
 
 let of_bool b = if b then Matches else No_match
+let is_browser = function Browser -> true | Spec -> false
 
-(* The forms selectors-4 defines and no engine implements as defined. Sec. 6.3
-   gives the [s] flag "identical to" semantics; engines refuse the selector, and
-   the rule carrying it with it. Sec. 13.2 represents an element "that has no
-   children except, optionally, document white space characters", and its own
-   note records that Level 2 and Level 3 did not - the change engines have not
-   taken. Under [Browser] the matcher declines both: an answer would be a fact
-   about the specification, and its callers rewrite pages a browser renders. The
-   selector_match differential is what keeps this list in step, since a form
-   cascade decides and the browser refuses shows up there. *)
-let unimplemented =
-  Selector.any (function
-    | Selector.Empty | Selector.Attribute (_, _, _, Some Selector.Sensitive) ->
-        true
-    | _ -> false)
-
-(* [Unsupported] beats both answers in every combining form. That is what keeps
-   it a fact about the selector alone: were a compound to settle on [No_match]
-   because one part failed before an unsupported part was looked at, the same
-   selector would come back unsupported against one node and merely unmatched
-   against another, and {!supported} could not exist. *)
+(* [Unsupported] beats both answers in every combining form, so a declined part
+   carries the whole selector however deep it sits. A compound that settled on
+   [No_match] because one part failed before a declined part was looked at would
+   hand back a definite answer cascade does not have. *)
 let conj a b =
   match (a, b) with
   | Unsupported, _ | _, Unsupported -> Unsupported
@@ -304,12 +289,9 @@ module Make (N : NODE) = struct
   let inclusive_siblings n =
     match N.parent n with None -> [ n ] | Some p -> N.children p
 
-  (* [nth_position ~from_end n keep] is [n]'s 1-based index among the inclusive
-     siblings [keep] admits, or [None] when [n] is not one of them and so is
-     among the An+Bth of nothing. Only elements are listed: a {!NODE} keeps text
-     out of [children], which is what sec. 13 asks for. *)
-  let nth_position ~from_end n keep =
-    let sibs = List.filter keep (inclusive_siblings n) in
+  (* [nth_index ~from_end n sibs] is [n]'s 1-based index in [sibs], or [None]
+     when it is not one of them and so is among the An+Bth of nothing. *)
+  let nth_index ~from_end n sibs =
     let sibs = if from_end then List.rev sibs else sibs in
     let rec index i = function
       | [] -> None
@@ -317,6 +299,12 @@ module Make (N : NODE) = struct
       | _ :: rest -> index (i + 1) rest
     in
     index 1 sibs
+
+  (* [nth_position ~from_end n keep] indexes [n] among the inclusive siblings
+     [keep] admits. Only elements are listed: a {!NODE} keeps text out of
+     [children], which is what sec. 13 asks for. *)
+  let nth_position ~from_end n keep =
+    nth_index ~from_end n (List.filter keep (inclusive_siblings n))
 
   let nth_matches ~from_end nth keep n =
     match nth_position ~from_end n keep with
@@ -375,13 +363,32 @@ module Make (N : NODE) = struct
     N.children n = []
     && List.for_all (String.for_all is_document_white_space) (N.text_children n)
 
+  (* The element sec. 13.2's own note parts from Level 2 and Level 3 over: no
+     child element, and text that is document white space and not nothing. An
+     element with no children at all is [:empty] to every level, and one holding
+     an element or other text is [:empty] to none, so the levels differ here and
+     nowhere else. A zero-length text node is not "data has a non-zero length"
+     and so counts for no level either way. *)
+  let white_space_only n =
+    is_empty n && List.exists (fun t -> String.length t > 0) (N.text_children n)
+
+  (* selectors-4 sec. 13.2 as the engines read it, which is Level 3: white space
+     leaves an element out of [:empty]. Cascade does not answer that reading, it
+     declines the element it would have to answer differently from the spec. *)
+  let empty_answer reading n =
+    match reading with
+    | Spec -> of_bool (is_empty n)
+    | Browser when white_space_only n -> Unsupported
+    | Browser -> of_bool (is_empty n)
+
   (* Selectors 4 is far wider than a matcher with no document behind it can
      decide, so the answer has three values. [Unsupported] is not "does not
-     match": it is "this library has no model for this selector", and a caller
-     must not read it as a negative - {!Apply} keeps such a rule in the
-     stylesheet rather than inline it and drop it. Every arm returning it does
-     so without consulting the node, which is what {!supported} rests on. *)
-  let rec match_selector (sel : Selector.t) n : match_result =
+     match": it is "cascade has no answer here", and a caller must not read it
+     as a negative - {!Apply} keeps such a rule in the stylesheet rather than
+     inline it and drop it. Most arms returning it do so without consulting the
+     node, and [:empty] under [Browser] is the one that asks: sec. 13.2 is a
+     question about the element, so only some elements go unanswered. *)
+  let rec match_selector ~reading (sel : Selector.t) n : match_result =
     match sel with
     | Selector.Universal None -> Matches
     | Selector.Element (None, name) ->
@@ -391,14 +398,22 @@ module Make (N : NODE) = struct
     (* selectors-4 sec. 16: an [<attr-modifier>] follows a matcher and a value,
        so a presence test carrying one is not an attribute selector. *)
     | Selector.Attribute (None, _, Selector.Presence, Some _) -> Unsupported
+    (* sec. 6.3 gives the [s] flag "identical to" semantics; engines refuse the
+       selector, and the rule carrying it with it. Nothing about the element
+       enters into that, so the decline is the same for every one. *)
+    | Selector.Attribute (_, _, _, Some Selector.Sensitive)
+      when is_browser reading ->
+        Unsupported
     | Selector.Attribute (None, name, m, flag) ->
         of_bool (attr_matches ~fold:(attr_fold flag) n name m)
     | Selector.Compound ps ->
-        List.fold_left (fun acc p -> conj acc (match_selector p n)) Matches ps
-    | Selector.List ss | Selector.Is ss | Selector.Where ss -> any ss n
-    | Selector.Not ss -> negate (any ss n)
+        List.fold_left
+          (fun acc p -> conj acc (match_selector ~reading p n))
+          Matches ps
+    | Selector.List ss | Selector.Is ss | Selector.Where ss -> any ~reading ss n
+    | Selector.Not ss -> negate (any ~reading ss n)
     | Selector.Combined _ -> (
-        match anchors sel n with
+        match anchors ~reading sel n with
         | None -> Unsupported
         | Some [] -> No_match
         | Some (_ :: _) -> Matches)
@@ -411,9 +426,11 @@ module Make (N : NODE) = struct
     | Selector.First_child -> of_bool (is_first n)
     | Selector.Last_child -> of_bool (is_last n)
     | Selector.Only_child -> of_bool (is_first n && is_last n)
-    | Selector.Empty -> of_bool (is_empty n)
-    | Selector.Nth_child (nth, of_) -> nth_child ~from_end:false nth of_ n
-    | Selector.Nth_last_child (nth, of_) -> nth_child ~from_end:true nth of_ n
+    | Selector.Empty -> empty_answer reading n
+    | Selector.Nth_child (nth, of_) ->
+        nth_child ~reading ~from_end:false nth of_ n
+    | Selector.Nth_last_child (nth, of_) ->
+        nth_child ~reading ~from_end:true nth of_ n
     | Selector.Nth_of_type (nth, None) ->
         of_bool (nth_matches ~from_end:false nth (same_type n) n)
     | Selector.Nth_last_of_type (nth, None) ->
@@ -422,7 +439,9 @@ module Make (N : NODE) = struct
     | Selector.Last_of_type -> of_bool (last_of_type n)
     | Selector.Only_of_type -> of_bool (first_of_type n && last_of_type n)
     | Selector.Has rs ->
-        List.fold_left (fun acc r -> disj acc (has_relative n r)) No_match rs
+        List.fold_left
+          (fun acc r -> disj acc (has_relative ~reading n r))
+          No_match rs
     (* sec. 13.4.1 and sec. 13.4.2 give the typed forms an [An+B] and nothing
        else, so an [of S] on one is not a selector any UA takes. *)
     | Selector.Nth_of_type (_, Some _) | Selector.Nth_last_of_type (_, Some _)
@@ -433,24 +452,36 @@ module Make (N : NODE) = struct
        stateful, generated or tree-external form. *)
     | _ -> Unsupported
 
-  and any ss n =
-    List.fold_left (fun acc s -> disj acc (match_selector s n)) No_match ss
+  and any ~reading ss n =
+    List.fold_left
+      (fun acc s -> disj acc (match_selector ~reading s n))
+      No_match ss
 
   (* selectors-4 sec. 13.3.1: with [of S] the element must be among the An+Bth
      of "their inclusive siblings that match the selector list S", so [S] both
      filters the list and decides whether [n] is in it at all; without it, [S]
      defaults to [*|*] and the list is every sibling. *)
-  and nth_child ~from_end nth of_ n =
+  and nth_child ~reading ~from_end nth of_ n =
     match of_ with
     | None -> of_bool (nth_matches ~from_end nth (fun _ -> true) n)
     | Some s -> (
-        (* Whether [S] is modelled is a fact about [S] alone, so any node
-           settles it, and asking [n] keeps that answer clear of which siblings
-           happen to be there. *)
-        match any s n with
-        | Unsupported -> Unsupported
-        | Matches | No_match ->
-            of_bool (nth_matches ~from_end nth (fun x -> any s x = Matches) n))
+        (* [S] decides which siblings are counted, so a sibling it goes
+           unanswered over leaves the index itself unknown, [n]'s own answer
+           included. *)
+        let rec kept acc = function
+          | [] -> Some (List.rev acc)
+          | x :: rest -> (
+              match any ~reading s x with
+              | Unsupported -> None
+              | Matches -> kept (x :: acc) rest
+              | No_match -> kept acc rest)
+        in
+        match kept [] (inclusive_siblings n) with
+        | None -> Unsupported
+        | Some sibs -> (
+            match nth_index ~from_end n sibs with
+            | None -> No_match
+            | Some i -> of_bool (nth_hits nth i)))
 
   (* selectors-4 sec. 4.5: [:has()] "represents an element if any of the
      relative selectors would match at least one element when anchored against
@@ -461,24 +492,27 @@ module Make (N : NODE) = struct
      with [n] as the anchor. [complex] is matched against [n] itself only for
      the support it reports, which no node can change; stopping at an empty
      subject list would let the tree decide whether the selector is modelled. *)
-  and has_relative n r =
+  and has_relative ~reading n r =
     let comb, complex =
       match r with
       | Selector.Relative (comb, complex) -> (comb, complex)
       | complex -> (Selector.Descendant, complex)
     in
-    match (relation comb, match_selector complex n) with
+    match (relation ~reading comb, match_selector ~reading complex n) with
     | Some _, complex_answer when complex_answer <> Unsupported ->
         let absolute =
           Selector.Combined (Selector.Universal None, comb, complex)
         in
-        of_bool
-          (List.exists
-             (fun e ->
-               match anchors absolute e with
-               | None -> false
-               | Some found -> List.exists (N.equal n) found)
-             (has_subjects comb n))
+        (* An element in reach that goes unanswered leaves the existence
+           question open, so it carries the whole [:has()] rather than counting
+           as one more element that is not the subject. *)
+        List.fold_left
+          (fun acc e ->
+            disj acc
+              (match anchors ~reading absolute e with
+              | None -> Unsupported
+              | Some found -> of_bool (List.exists (N.equal n) found)))
+          No_match (has_subjects comb n)
     | _ -> Unsupported
 
   (* [Selector] is right-leaning: [a b > c] is [Combined (a, Descendant,
@@ -491,19 +525,28 @@ module Make (N : NODE) = struct
      [comb]-related to [a]. Threading the anchor this way is what the old
      subject-only [combinator] missed for any selector with two or more
      combinators. *)
-  and anchors sel n =
+  and anchors ~reading sel n =
     match sel with
     | Selector.Combined (left, comb, right) -> (
         (* [left] is asked for its own support, separately from whether [right]
            found an anchor: stopping at an empty anchor list would let the node
            decide whether the selector is supported. *)
-        match (anchors right n, match_selector left n, relation comb) with
+        match
+          ( anchors ~reading right n,
+            match_selector ~reading left n,
+            relation ~reading comb )
+        with
         | Some found, left_answer, Some related when left_answer <> Unsupported
           ->
-            Some (List.concat_map (related left) found)
+            List.fold_left
+              (fun acc a ->
+                match (acc, related left a) with
+                | None, _ | _, None -> None
+                | Some xs, Some ys -> Some (List.rev_append ys xs))
+              (Some []) found
         | _ -> None)
     | _ -> (
-        match match_selector sel n with
+        match match_selector ~reading sel n with
         | Unsupported -> None
         | No_match -> Some []
         | Matches -> Some [ n ])
@@ -511,31 +554,35 @@ module Make (N : NODE) = struct
   (* [None] for a combinator that is not a relation between two nodes of this
      tree: [||] picks a cell out of the column it belongs to, and the legacy
      [>>>] and [/deep/] cross a shadow boundary the tree does not have. *)
-  and relation comb =
-    let hits left x = match_selector left x = Matches in
+  and relation ~reading comb =
+    (* [None] once any candidate goes unanswered: an anchor list missing an
+       element [left] might have matched is one a combinator further left reads
+       as a definite miss. *)
+    let hits left xs =
+      List.fold_left
+        (fun acc x ->
+          match (acc, match_selector ~reading left x) with
+          | None, _ | _, Unsupported -> None
+          | Some ks, Matches -> Some (x :: ks)
+          | Some ks, No_match -> Some ks)
+        (Some []) xs
+      |> Option.map List.rev
+    in
+    let of_option = function None -> [] | Some x -> [ x ] in
     match comb with
-    | Selector.Descendant ->
-        Some (fun left a -> List.filter (hits left) (ancestors a))
-    | Selector.Child ->
-        Some
-          (fun left a ->
-            match N.parent a with Some p when hits left p -> [ p ] | _ -> [])
+    | Selector.Descendant -> Some (fun left a -> hits left (ancestors a))
+    | Selector.Child -> Some (fun left a -> hits left (of_option (N.parent a)))
     | Selector.Next_sibling ->
-        Some
-          (fun left a ->
-            match imm_pred a with Some s when hits left s -> [ s ] | _ -> [])
+        Some (fun left a -> hits left (of_option (imm_pred a)))
     | Selector.Subsequent_sibling ->
-        Some (fun left a -> List.filter (hits left) (preceding_siblings a))
+        Some (fun left a -> hits left (preceding_siblings a))
     | Selector.Column | Selector.Shadow_piercing | Selector.Shadow_deep -> None
 
-  (* [Spec] is the matcher above, which reads selectors-4 as written. [Browser]
-     declines the forms no engine implements, so a caller that inlines or
-     deletes never acts on an answer the page's own browser does not give. *)
-  let match_selector ?(reading = Browser) sel n =
-    match reading with
-    | Browser when unimplemented sel -> Unsupported
-    | Browser | Spec -> match_selector sel n
-
+  (* [Spec] is the matcher above reading selectors-4 as written. [Browser]
+     declines what it would otherwise answer against every engine, so a caller
+     that inlines or deletes never acts on an answer the page's own browser does
+     not give. *)
+  let match_selector ?(reading = Browser) sel n = match_selector ~reading sel n
   let matches ?reading sel n = match_selector ?reading sel n = Matches
 
   (* A selector list has no single specificity: a rule [s1, s2 {...}] cascades
@@ -611,8 +658,13 @@ end
 (* The capability side of the matcher, read off the matcher rather than restated
    beside it: a second list of the forms it models would be free to drift from
    the first, and every selector it then wrongly called supported would be one a
-   caller inlines and drops. [Unsupported] never depends on the node, so any
-   node settles the question - this one has nothing on it at all. *)
+   caller inlines and drops.
+
+   {!supported} answers for a node it has not seen, so the probe has to be the
+   node the matcher can say least about. Every arm but [:empty] declines without
+   looking, and [:empty] declines over the element whose only children are
+   document white space, so that is what this node is. Any element the matcher
+   goes unanswered over, it goes unanswered over here. *)
 module Probe = struct
   type t = unit
 
@@ -623,7 +675,7 @@ module Probe = struct
   let attribute () _ = None
   let parent () = None
   let children () = []
-  let text_children () = []
+  let text_children () = [ " " ]
 end
 
 module Probe_matcher = Make (Probe)

--- a/lib/resolve.mli
+++ b/lib/resolve.mli
@@ -52,28 +52,43 @@ type match_result =
   | Matches  (** The selector matches the node. *)
   | No_match  (** The selector is modelled and does not match the node. *)
   | Unsupported
-      (** The selector is outside what the matcher models, so neither answer is
-          available, for any node. *)
+      (** Neither answer is available. Most forms go unanswered for every node,
+          and [:empty] under {!constructor-Browser} for some: see
+          {!type-reading}. *)
 
 (** Which reading of Selectors the matcher answers by.
 
     Two forms selectors-4 defines are implemented by no engine: sec. 6.3's [s]
     attribute flag, which engines refuse along with the rule carrying it, and
     sec. 13.2's [:empty] over an element holding nothing but document white
-    space, the Level 4 change engines have not taken. *)
+    space, the Level 4 change engines have not taken.
+
+    The two are declined differently, because sec. 6.3 is about the selector and
+    sec. 13.2 about the element. The [s] flag is declined for every node. Sec.
+    13.2's note records that Level 2 and Level 3 matched an element with no
+    children at all, which is what every engine still does, so the readings part
+    over the white-space element alone: an element with no children of any kind
+    is [:empty] to both and one holding an element or other text to neither, and
+    {!constructor-Browser} answers those as {!constructor-Spec} does. *)
 type reading =
   | Browser
-      (** Decline those forms. An answer would be a fact about the
-          specification, and {!Apply} inlines a rule out of the stylesheet while
-          {!Prune} deletes it, so either would rewrite a page against the way
-          its own browser renders it. *)
+      (** Decline what the specification and the engines answer differently. An
+          answer there would be a fact about the specification, and {!Apply}
+          inlines a rule out of the stylesheet while {!Prune} deletes it, so
+          either would rewrite a page against the way its own browser renders
+          it. *)
   | Spec  (** Answer them as selectors-4 defines them. *)
 
 val supported : ?reading:reading -> Selector.t -> bool
-(** [supported ?reading sel] is whether the matcher has a model for [sel], that
-    is, whether {!Make.match_selector} answers it with something other than
-    {!constructor-Unsupported}. The answer is a fact about [sel] alone, which is
-    why it needs no node. [reading] defaults to {!constructor-Browser}.
+(** [supported ?reading sel] is whether the matcher answers [sel] for every
+    node, that is, whether {!Make.match_selector} is something other than
+    {!constructor-Unsupported} whatever it is given. The answer is a fact about
+    [sel] alone, which is why it needs no node, and it is the conservative half
+    of the question: [false] says some node goes unanswered, not that this one
+    does. A caller deciding per rule, before it has a node, wants exactly that;
+    one holding a node wants {!Make.match_selector}, which under
+    {!constructor-Browser} answers [:empty] for every element but the one the
+    readings part over. [reading] defaults to {!constructor-Browser}.
 
     Modelled: the universal, type, class, id and attribute selectors, each
     without a namespace, an attribute carrying the [i] case flag or none;
@@ -144,8 +159,10 @@ val prepare : Stylesheet.t -> prepared
 module Make (N : NODE) : sig
   val match_selector : ?reading:reading -> Selector.t -> N.t -> match_result
   (** [match_selector ?reading sel node] is what the matcher can say about [sel]
-      and [node]. It is [Unsupported] exactly when [sel] is not
-      [supported ?reading], for every [node]. [reading] defaults to
+      and [node]. [supported ?reading sel] holding means this never answers
+      {!constructor-Unsupported}, for any [node]; it failing means some node
+      goes unanswered, which under {!constructor-Browser} is the [:empty] one
+      the readings part over and need not be this [node]. [reading] defaults to
       {!constructor-Browser}. *)
 
   val matches : ?reading:reading -> Selector.t -> N.t -> bool

--- a/test/render/selector_match.ml
+++ b/test/render/selector_match.ml
@@ -11,6 +11,15 @@
    that answer in with [No_match], so a direct [resolve] caller cannot tell the
    two apart, and the run counts how often that silence would be wrong.
 
+   {!Cascade.Resolve.supported} is checked against those answers in the one
+   direction a document can settle. It promises an answer for every node, so a
+   node left undecided under it is a broken promise and fails the run. The other
+   way round it promises only that some node goes undecided, and the node it
+   means need not be in this document: [:empty] is declined per rule and
+   answered per element, and a tree built with createElement alone holds no
+   element the readings part over. So a document that decided everything is
+   counted and named, never fatal.
+
    Skips cleanly, with status 0, when node or a headless Chromium is missing,
    and fails when CASCADE_NO_BROWSER asks for silence without acknowledging
    it. *)
@@ -1131,7 +1140,7 @@ let () =
 
   (* --- Classify every pair --- *)
   let wrong = ref [] and rejected = ref [] and undecided = ref [] in
-  let accepted = ref [] and guard = ref [] in
+  let accepted = ref [] and guard = ref [] and conservative = ref [] in
   let missing = ref 0 and pairs = ref 0 and agreed = ref 0 in
   let blind_unsupported = ref 0 in
   let control_status = ref [] in
@@ -1209,7 +1218,7 @@ let () =
                   if List.equal Int.equal mine hits then (
                     incr agreed;
                     if not supported then
-                      record guard
+                      record conservative
                         (finding
                            [
                              "Resolve.supported says no, match_selector \
@@ -1346,7 +1355,12 @@ let () =
     !rejected;
   section "UNSUPPORTED (cascade reads it and declines to decide)" !undecided;
   section "ACCEPTED (cascade reads a selector the browser refuses)" !accepted;
-  section "GUARD (Resolve.supported disagrees with match_selector)" !guard;
+  section "GUARD (Resolve.supported promised an answer match_selector withheld)"
+    !guard;
+  section
+    "CONSERVATIVE (Resolve.supported declines a selector this document never \
+     met a declining element for)"
+    !conservative;
   line "";
   line "calibration:";
   List.iter

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -150,18 +150,20 @@ let titled = elt ~attrs:[ ("title", "x") ] "div" []
    that Level 2 and Level 3 did not - the change engines have not taken. The
    answer to either is a fact about the specification and not about how the page
    renders, and {!Apply} inlines and {!Prune} deletes, so the matcher declines
-   the form rather than rewrite a page against its own browser. *)
+   the form rather than rewrite a page against its own browser.
+
+   The [s] flag is refused whatever the node: sec. 6.3 is about the selector,
+   and an engine that refuses it refuses the rule. Sec. 13.2 is about the
+   element, so the node decides that one - {!test_empty_is_node_dependent}. *)
 let test_declines_what_no_engine_implements () =
   answers "the case-sensitive attribute flag" Resolve.Unsupported "[title=x s]"
     titled;
   answers "on a value the flag rules out" Resolve.Unsupported "[title=X s]"
     titled;
-  answers ":empty" Resolve.Unsupported ":empty" s2;
-  answers ":empty in a compound" Resolve.Unsupported "span:empty" s2;
-  answers ":empty under a negation" Resolve.Unsupported ":not(:empty)" s2;
-  answers ":empty in a relational argument" Resolve.Unsupported ":has(:empty)" a;
-  answers ":empty as one branch of a list" Resolve.Unsupported "span,:empty" s2;
-  answers ":empty left of a combinator" Resolve.Unsupported ":empty span" s2;
+  answers "the flag under a negation" Resolve.Unsupported ":not([title=x s])"
+    titled;
+  answers "the flag in a relational argument" Resolve.Unsupported
+    ":has([title=x s])" titled;
   let declines name s =
     Alcotest.(check bool) name false (Resolve.supported (sel s))
   in
@@ -175,6 +177,64 @@ let test_declines_what_no_engine_implements () =
   Alcotest.(check bool)
     "the spec reading models :empty" true
     (Resolve.supported ~reading:Resolve.Spec (sel ":empty"))
+
+(* Sec. 13.2 represents "an element that has no children except, optionally,
+   document white space characters", and its note records that Level 2 and Level
+   3 did not match the white-space one. So the two readings part over that
+   element and no other: an element with no children at all is [:empty] to both,
+   and one holding an element or text of its own is [:empty] to neither. The
+   decline belongs to the element, not to the selector, and an element the two
+   levels agree on gets the answer they agree on.
+
+   {!Resolve.supported} stays conservative through all of it. It is asked before
+   any node is walked, so it cannot know which element it will be given, and
+   {!Apply} and {!Prune} decide per rule off that answer. *)
+let test_empty_is_node_dependent () =
+  answers "no children at all" Resolve.Matches ":empty" (elt "p" []);
+  answers "an element child" Resolve.No_match ":empty" (elt "p" [ elt "b" [] ]);
+  answers "a text child" Resolve.No_match ":empty" (elt ~text:[ "text" ] "p" []);
+  answers "a no-break space is not document white space" Resolve.No_match
+    ":empty"
+    (elt ~text:[ "\u{00a0}" ] "p" []);
+  (* The one element Level 3 and Level 4 answer differently. *)
+  answers "white space alone" Resolve.Unsupported ":empty"
+    (elt ~text:[ " \t\n" ] "p" []);
+  answers "white space beside text is text to both" Resolve.No_match ":empty"
+    (elt ~text:[ " "; "text" ] "p" []);
+  (* The combining forms carry the node's answer, decline and all. *)
+  answers "in a compound" Resolve.Matches "p:empty" (elt "p" []);
+  answers "under a negation" Resolve.No_match ":not(:empty)" (elt "p" []);
+  answers "as one branch of a list" Resolve.Matches "span,:empty" (elt "p" []);
+  answers "a compound over the declining element" Resolve.Unsupported "p:empty"
+    (elt ~text:[ " " ] "p" []);
+  (* No ancestor of an element holds it and nothing else, so an ancestor is
+     never the element the two levels part over. *)
+  answers "left of a descendant combinator" Resolve.No_match ":empty span" s2;
+  answers "a relational argument the subtree decides" Resolve.Matches
+    ":has(:empty)" a;
+  let declines name s =
+    Alcotest.(check bool) name false (Resolve.supported (sel s))
+  in
+  declines "the rule-level answer stays conservative" ":empty";
+  declines "wherever :empty sits in the selector" "p:empty";
+  declines "including inside a relational argument" ":has(:empty)";
+  declines "and inside an of S" ":nth-child(1 of :empty)"
+
+(* A sibling or a descendant can be the element the two levels part over, and
+   the answer about it has to reach the subject rather than be read as a miss.
+   Folding the decline into "does not match" here would hand a caller a definite
+   answer off an element whose own answer cascade does not have. *)
+let test_empty_declines_through_the_tree () =
+  let ws () = elt ~text:[ " " ] "i" [] in
+  let target = elt "p" [] in
+  let _ = elt "div" [ ws (); target ] in
+  answers "a declining preceding sibling" Resolve.Unsupported ":empty+p" target;
+  let host = elt "div" [ ws () ] in
+  answers "a declining descendant" Resolve.Unsupported ":has(:empty)" host;
+  let indexed = elt "p" [] in
+  let _ = elt "div" [ ws (); indexed ] in
+  answers "a declining sibling in an of S" Resolve.Unsupported
+    ":nth-child(2 of :empty)" indexed
 
 (* selectors-4 sec. 13.2: [:empty] is "an element that has no children except,
    optionally, document white space characters". White space alone leaves an
@@ -858,6 +918,10 @@ let suite =
         test_supported_needs_no_node;
       Alcotest.test_case "declines what no engine implements" `Quick
         test_declines_what_no_engine_implements;
+      Alcotest.test_case "empty is the node's question" `Quick
+        test_empty_is_node_dependent;
+      Alcotest.test_case "empty declines through the tree" `Quick
+        test_empty_declines_through_the_tree;
       Alcotest.test_case "empty counts text children" `Quick
         test_empty_counts_text_children;
       Alcotest.test_case "nth-child indexes from one" `Quick


### PR DESCRIPTION
Selectors 4 sec. 13.2 matches an element whose only children are document white space and the levels the engines implement do not, so #863 declined `:empty` for every element, including the ones both readings answer alike. `Resolve.Make.match_selector` answers those now, where a direct `matches` caller had been reading the decline as "matches nothing".

`Resolve.supported` is unchanged, so `cascade apply` and `cascade prune` keep such a rule exactly as they did after #863. Making the decline node-dependent moves `:nth-child(... of S)`, `:has()` and the combinators, which report unanswered rather than counting an unanswered element as a miss, and the conservative direction of `selector_match`'s guard stops being fatal.
