### PR TITLE
declaration: accept negative decoration thickness

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- Negative `text-decoration-thickness` lengths and percentages are retained,
+  including inside `calc()`, instead of dropping valid declarations (#874).
+
 - `blur()` rejects percentages, sizing functions and negative literal lengths,
   including percentages nested in math, instead of emitting invalid filters
   (#871).

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -992,10 +992,10 @@ let rec read_text_decoration_thickness t =
           fun t ->
             Calc
               (read_calc ~result_type:`Value
-                 (read_non_negative_length ~with_keywords:false)
+                 (read_length ~with_keywords:false)
                  t) );
       ]
-    ~default:(read_non_negative_length ~with_keywords:false)
+    ~default:(read_length ~with_keywords:false)
     t
 
 (* Delegate to the proper reader in Properties *)

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -306,6 +306,10 @@ let matrix =
           "1px";
           "10%";
           "-1px";
+          "-10%";
+          "calc(-1px)";
+          "calc(-10%)";
+          "calc(2px - 3px)";
           "hairline";
           "thin";
           "thick";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4528,6 +4528,26 @@ let check_sheet_roundtrip name css =
 
 (* CSS Text Decoration 4 sec. 2.6 joins the line, thickness, style and colour
    components with [||], so no single component is mandatory. *)
+let text_decoration_thickness_range () =
+  (* CSS Text Decoration 4 section 2.4: <length-percentage> has no non-negative
+     grammar range. The minimum device-pixel thickness is a rendering rule. *)
+  List.iter
+    (fun (value, printed) ->
+      check_declaration ~roundtrip:true
+        ~expected:("text-decoration-thickness:" ^ printed)
+        ("text-decoration-thickness:" ^ value))
+    [
+      ("-1px", "-1px");
+      ("-10%", "-10%");
+      ("-.25em", "-.25em");
+      ("calc(-1px)", "-1px");
+      ("calc(-10%)", "-10%");
+      ("calc(2px - 3px)", "calc(2px - 3px)");
+      ("min(-1px,2px)", "min(-1px,2px)");
+    ];
+  check_declaration ~roundtrip:true "text-decoration:underline -1px";
+  none_cursor read_declaration "text-decoration-thickness:-1s"
+
 let text_decoration_optional_line () =
   check_declaration ~roundtrip:true "text-decoration:red";
   check_sheet_roundtrip "text-decoration" "a{text-decoration:red}"
@@ -5688,6 +5708,8 @@ let declaration_tests =
       scroll_margin_negative_sheet;
     test_case "text-decoration optional line" `Quick
       text_decoration_optional_line;
+    test_case "text decoration thickness range" `Quick
+      text_decoration_thickness_range;
     test_case "text-decoration drained shorthand" `Quick
       text_decoration_drained_shorthand;
     test_case "white-space collapse only" `Quick white_space_collapse_only;


### PR DESCRIPTION
Preserve valid negative text-decoration-thickness lengths and percentages, including math expressions, instead of dropping the declaration. Stacked on #873; focused regression and browser checks pass, while the full suite remains red on outstanding backlog defects.