### PR TITLE
animation: accept infinite as a keyframe name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- `animation` accepts `infinite` as a case-sensitive keyframe name after an
+  iteration count and preserves that meaning when printed (#875).
+
 - Negative `text-decoration-thickness` lengths and percentages are retained,
   including inside `calc()`, instead of dropping valid declarations (#874).
 

--- a/fuzz/fuzz_properties.ml
+++ b/fuzz/fuzz_properties.ml
@@ -230,7 +230,7 @@ let invalid_value property buf =
   | "transition-timing-function" ->
       pick [ "steps()"; "cubic-bezier(1,2)" ] buf 2
   | "transition" -> pick [ "1s 2s 3s"; "ease opacity ease" ] buf 2
-  | "animation" -> pick [ "1s 2s 3s"; "infinite infinite" ] buf 2
+  | "animation" -> pick [ "1s 2s 3s"; "infinite infinite infinite" ] buf 2
   | "background-image" -> pick [ "linear-gradient()"; "image-set()" ] buf 2
   | "background" -> pick [ "red blue"; "red red" ] buf 2
   | "content" -> pick [ "attr()"; "open-quote close-quote none" ] buf 2
@@ -340,8 +340,10 @@ let property_grammar_shorthand_vectors =
       [ "opacity 1s ease"; "all .2s linear .1s" ]
       [ "1s 2s 3s"; "ease opacity ease" ];
     vector "animation" Css.Properties.read_animation Css.Properties.pp_animation
-      [ "spin 1s linear infinite"; "none"; "fade .2s ease" ]
-      [ "1s 2s 3s"; "infinite infinite" ];
+      [
+        "spin 1s linear infinite"; "none"; "fade .2s ease"; "infinite infinite";
+      ]
+      [ "1s 2s 3s"; "infinite infinite infinite" ];
     vector "background" Css.Properties.read_background
       Css.Properties.pp_background
       [ "red"; "url(a.png) no-repeat center/cover"; "none" ]

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1294,7 +1294,7 @@ module Animation = struct
     | Name of animation_name option
     | Duration of duration
     | Timing_function of timing_function
-    | Iteration_count of animation_iteration_count
+    | Iteration_count of animation_iteration_count * string option
     | Direction of animation_direction
     | Fill_mode of animation_fill_mode
     | Play_state of animation_play_state
@@ -1414,15 +1414,12 @@ module Animation = struct
       state.timing_seen := true;
       { acc with timing_function = Some tf })
 
-  let apply_iteration t state acc ic =
+  let apply_iteration t state acc ic keyword =
     if !(state.iteration_seen) then
-      (* CSS Animations 1 section 4.4: [<single-animation-iteration-count>] is
-         [infinite | <number>]; [infinite] is a reserved keyword that cannot be
-         a [<custom-ident>] animation name. Reject the duplicate rather than
-         coercing it into the name slot. *)
-      Cursor.err t "duplicate animation-iteration-count";
-    state.iteration_seen := true;
-    { acc with iteration_count = Some ic }
+      set_string_name t "animation-iteration-count" state.name_seen acc keyword
+    else (
+      state.iteration_seen := true;
+      { acc with iteration_count = Some ic })
 
   let apply_direction t state acc dir =
     if !(state.direction_seen) then
@@ -1461,7 +1458,7 @@ module Animation = struct
     | Name name -> apply_name t state acc name
     | Duration d -> apply_duration t state acc d
     | Timing_function tf -> apply_timing t state acc tf
-    | Iteration_count ic -> apply_iteration t state acc ic
+    | Iteration_count (ic, keyword) -> apply_iteration t state acc ic keyword
     | Direction dir -> apply_direction t state acc dir
     | Fill_mode fm -> apply_fill t state acc fm
     | Play_state ps -> apply_play t state acc ps
@@ -1470,7 +1467,11 @@ module Animation = struct
   let read_component t =
     let read_duration t = Duration (read_duration t) in
     let read_timing t = Timing_function (read_timing_function t) in
-    let read_iteration t = Iteration_count (read_animation_count_item t) in
+    let read_iteration t =
+      (* Preserve the spelling if this keyword becomes a keyframe name. *)
+      let keyword = Cursor.peek_ident t in
+      Iteration_count (read_animation_count_item t, keyword)
+    in
     let read_direction t =
       match Option.map String.lowercase_ascii (Cursor.ident_opt t) with
       | Some "normal" -> Direction (Normal : animation_direction)
@@ -1771,12 +1772,19 @@ let pp_animation_shorthand : animation_shorthand Pp.t =
   let has_any_non_default = Animation.has_non_defaults anim in
   let name_is_default_none = animation_name_is_default_none ctx anim.name in
   let quote_ambiguous_name = animation_quote_ambiguous_name ctx anim in
+  let iteration_name_last =
+    Animation.ambiguous_name_kind anim = Some Iteration
+    && not quote_ambiguous_name
+  in
   pp_animation_initial_none ctx anim ~name_is_default_none ~has_any_non_default;
   (* Cascade canonical order puts the animation [name] first: it is the only
      ident-shaped component that survives the rest defaulting away, so leading
      with it makes "single-token" outputs ([animation:slide]) read naturally and
      matches the common minifier convention. *)
-  pp_animation_name_slot ctx state ~quote_ambiguous_name anim;
+  (* An unquoted [infinite] name must follow the iteration count, or it would
+     fill that slot instead. This also preserves the name's case. *)
+  if not iteration_name_last then
+    pp_animation_name_slot ctx state ~quote_ambiguous_name anim;
   Pp.option
     (pp_animation_space_before state pp_duration)
     ctx (Animation.duration anim);
@@ -1803,7 +1811,9 @@ let pp_animation_shorthand : animation_shorthand Pp.t =
   Pp.option
     (pp_animation_space_before state pp_animation_timeline)
     ctx
-    (Animation.timeline ~quote_name:quote_ambiguous_name anim)
+    (Animation.timeline ~quote_name:quote_ambiguous_name anim);
+  if iteration_name_last then
+    pp_animation_name_slot ctx state ~quote_ambiguous_name anim
 
 (* The animation reader fills every slot with its longhand initial, so only the
    easing needs canonicalising here: its keyword and curve spellings are the

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2385,6 +2385,49 @@ let list_properties () =
   check_declaration ~expected:"animation:spin .5s"
     ~optimized:"animation:spin .5s" "animation: spin 500ms"
 
+let animation_infinite_name () =
+  (* CSS Animations 1 section 3.10 assigns a keyword to another property only
+     when that property has not already been set. Section 3 makes keyframe names
+     case-sensitive, even when their spelling is also a keyword. *)
+  let open Css.Properties in
+  let check_slots input expected_name expected_count =
+    let cursor = Cursor.of_string input in
+    let value = read_animation cursor in
+    Alcotest.(check bool) "consumes animation" true (Cursor.is_done cursor);
+    (match value with
+    | Shorthand { name = Some (Ambiguous name | Name name); iteration_count; _ }
+      ->
+        Alcotest.(check string) "animation name" expected_name name;
+        Alcotest.(check bool)
+          "iteration count" true
+          (iteration_count = Some expected_count)
+    | _ -> Alcotest.failf "missing animation name in %s" input);
+    value
+  in
+  List.iter
+    (fun (input, name, count) ->
+      let value = check_slots input name count in
+      List.iter
+        (fun minify ->
+          let printed = Css.Pp.to_string ~minify pp_animation value in
+          ignore (check_slots printed name count))
+        [ false; true ])
+    [
+      ("infinite infinite", "infinite", Infinite);
+      ("infinite INFINITE", "INFINITE", Infinite);
+      ("INFINITE infinite", "infinite", Infinite);
+      ("2 infinite", "infinite", Num 2.);
+      ("2 InFiNiTe", "InFiNiTe", Num 2.);
+    ];
+  List.iter
+    (fun value -> none_cursor read_declaration ("animation:" ^ value))
+    [
+      "2 3";
+      "infinite 2";
+      "infinite infinite infinite";
+      "spin infinite infinite";
+    ]
+
 let custom_properties () =
   (* Basic custom properties *)
   check_declaration ~expected:"--color:red" "--color: red";
@@ -5710,6 +5753,7 @@ let declaration_tests =
       text_decoration_optional_line;
     test_case "text decoration thickness range" `Quick
       text_decoration_thickness_range;
+    test_case "animation infinite name" `Quick animation_infinite_name;
     test_case "text-decoration drained shorthand" `Quick
       text_decoration_drained_shorthand;
     test_case "white-space collapse only" `Quick white_space_collapse_only;


### PR DESCRIPTION
Accept infinite as a case-sensitive animation name once the iteration count is filled, and preserve the distinction when printing. Stacked on #874; the regression passes, while the full suite remains red on outstanding backlog defects.