### PR TITLE
animation: preserve keyword-shaped keyframe names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,8 +202,8 @@ entry points both moved.
 
 ### Parsing
 
-- `animation` accepts `infinite` as a case-sensitive keyframe name after an
-  iteration count and preserves that meaning when printed (#875).
+- `animation` preserves keyword-shaped keyframe names and their case through
+  parsing and printing, including names supplied by callers (#875, #876).
 
 - Negative `text-decoration-thickness` lengths and percentages are retained,
   including inside `calc()`, instead of dropping valid declarations (#874).

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1294,7 +1294,7 @@ module Animation = struct
     | Name of animation_name option
     | Duration of duration
     | Timing_function of timing_function
-    | Iteration_count of animation_iteration_count * string option
+    | Iteration_count of animation_iteration_count
     | Direction of animation_direction
     | Fill_mode of animation_fill_mode
     | Play_state of animation_play_state
@@ -1452,26 +1452,30 @@ module Animation = struct
       state.timeline_seen := true;
       { acc with timeline = Some tl })
 
-  let apply_component t state (acc : animation_shorthand) component =
+  let apply_component t state (acc : animation_shorthand) (component, keyword) =
     state.component_seen := true;
-    match component with
-    | Name name -> apply_name t state acc name
-    | Duration d -> apply_duration t state acc d
-    | Timing_function tf -> apply_timing t state acc tf
-    | Iteration_count (ic, keyword) -> apply_iteration t state acc ic keyword
-    | Direction dir -> apply_direction t state acc dir
-    | Fill_mode fm -> apply_fill t state acc fm
-    | Play_state ps -> apply_play t state acc ps
-    | Timeline tl -> apply_timeline t state acc tl
+    let had_name = !(state.name_seen) in
+    let acc =
+      match component with
+      | Name name -> apply_name t state acc name
+      | Duration d -> apply_duration t state acc d
+      | Timing_function tf -> apply_timing t state acc tf
+      | Iteration_count ic -> apply_iteration t state acc ic keyword
+      | Direction dir -> apply_direction t state acc dir
+      | Fill_mode fm -> apply_fill t state acc fm
+      | Play_state ps -> apply_play t state acc ps
+      | Timeline tl -> apply_timeline t state acc tl
+    in
+    match (had_name, keyword, acc.name) with
+    | false, Some name, Some (Ambiguous _) ->
+        (* Property keywords are case-insensitive; keyframe names are not. *)
+        { acc with name = Some (Ambiguous name) }
+    | _ -> acc
 
   let read_component t =
     let read_duration t = Duration (read_duration t) in
     let read_timing t = Timing_function (read_timing_function t) in
-    let read_iteration t =
-      (* Preserve the spelling if this keyword becomes a keyframe name. *)
-      let keyword = Cursor.peek_ident t in
-      Iteration_count (read_animation_count_item t, keyword)
-    in
+    let read_iteration t = Iteration_count (read_animation_count_item t) in
     let read_direction t =
       match Option.map String.lowercase_ascii (Cursor.ident_opt t) with
       | Some "normal" -> Direction (Normal : animation_direction)
@@ -1515,22 +1519,26 @@ module Animation = struct
           ("'" ^ v ^ "' is a reserved keyword for animation properties")
       else Name (Some (Name v))
     in
-    Cursor.one_of
-      [
-        read_duration;
-        read_timing;
-        read_iteration;
-        read_direction;
-        read_fill;
-        read_play;
-        read_timeline;
-        read_var_name;
-        read_string_name;
-        (* Animation name - parse this LAST since it accepts any non-reserved
-           identifier *)
-        read_name;
-      ]
-      t
+    let keyword = Cursor.peek_ident t in
+    let component =
+      Cursor.one_of
+        [
+          read_duration;
+          read_timing;
+          read_iteration;
+          read_direction;
+          read_fill;
+          read_play;
+          read_timeline;
+          read_var_name;
+          read_string_name;
+          (* Animation name - parse this LAST since it accepts any non-reserved
+             identifier *)
+          read_name;
+        ]
+        t
+    in
+    (component, keyword)
 
   let read_shorthand t =
     let state = read_state () in
@@ -1600,7 +1608,7 @@ module Animation = struct
 
   let ambiguous_name_kind (anim : animation_shorthand) =
     match anim.name with
-    | Some (Ambiguous name) ->
+    | Some (Ambiguous name | Name name) ->
         animation_shorthand_kind (String.lowercase_ascii name)
     | _ -> None
 
@@ -1749,7 +1757,7 @@ let pp_animation_name_slot ctx state ~quote_ambiguous_name
     Option.iter
       (fun (name : animation_name) ->
         match name with
-        | Ambiguous s when quote_ambiguous_name ->
+        | (Ambiguous s | Name s) when quote_ambiguous_name ->
             pp_animation_space_before state ~starts_with_quote:true
               ~ends_with_quote:true Pp.quoted_string ctx s
         | Quoted s ->
@@ -1772,18 +1780,16 @@ let pp_animation_shorthand : animation_shorthand Pp.t =
   let has_any_non_default = Animation.has_non_defaults anim in
   let name_is_default_none = animation_name_is_default_none ctx anim.name in
   let quote_ambiguous_name = animation_quote_ambiguous_name ctx anim in
-  let iteration_name_last =
-    Animation.ambiguous_name_kind anim = Some Iteration
-    && not quote_ambiguous_name
+  let ambiguous_name_last =
+    Animation.ambiguous_name_kind anim <> None && not quote_ambiguous_name
   in
   pp_animation_initial_none ctx anim ~name_is_default_none ~has_any_non_default;
   (* Cascade canonical order puts the animation [name] first: it is the only
      ident-shaped component that survives the rest defaulting away, so leading
      with it makes "single-token" outputs ([animation:slide]) read naturally and
      matches the common minifier convention. *)
-  (* An unquoted [infinite] name must follow the iteration count, or it would
-     fill that slot instead. This also preserves the name's case. *)
-  if not iteration_name_last then
+  (* An unquoted keyword name must follow the slot it could otherwise fill. *)
+  if not ambiguous_name_last then
     pp_animation_name_slot ctx state ~quote_ambiguous_name anim;
   Pp.option
     (pp_animation_space_before state pp_duration)
@@ -1812,7 +1818,7 @@ let pp_animation_shorthand : animation_shorthand Pp.t =
     (pp_animation_space_before state pp_animation_timeline)
     ctx
     (Animation.timeline ~quote_name:quote_ambiguous_name anim);
-  if iteration_name_last then
+  if ambiguous_name_last then
     pp_animation_name_slot ctx state ~quote_ambiguous_name anim
 
 (* The animation reader fills every slot with its longhand initial, so only the

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2428,6 +2428,74 @@ let animation_infinite_name () =
       "spin infinite infinite";
     ]
 
+let animation_keyword_names () =
+  (* CSS Animations 1 sections 3 and 3.10: names are case-sensitive and
+     colliding keywords fill the other shorthand slots before the name. *)
+  let open Css.Properties in
+  let read input =
+    let cursor = Cursor.of_string input in
+    match read_animation cursor with
+    | Shorthand value when Cursor.is_done cursor -> value
+    | _ -> Alcotest.failf "expected one animation: %s" input
+  in
+  let check_slots expected name input =
+    let actual = read input in
+    (match actual.name with
+    | Some (Name value | Ambiguous value) ->
+        Alcotest.(check string) input name value
+    | _ -> Alcotest.failf "missing name in %s" input);
+    Alcotest.(check bool)
+      (input ^ " keeps non-name slots")
+      true
+      ({ actual with name = None } = { expected with name = None })
+  in
+  let check_print expected name value =
+    List.iter
+      (fun minify ->
+        check_slots expected name (Css.Pp.to_string ~minify pp_animation value))
+      [ false; true ]
+  in
+  List.iter
+    (fun (prefix, names) ->
+      let expected = read (prefix ^ " keyframe") in
+      List.iter
+        (fun name ->
+          List.iter
+            (fun name ->
+              let input = prefix ^ " " ^ name in
+              check_slots expected name input;
+              check_print expected name (Shorthand (read input));
+              check_print expected name
+                (animation_shorthand ~name ?duration:expected.duration
+                   ?timing_function:expected.timing_function
+                   ?delay:expected.delay
+                   ?iteration_count:expected.iteration_count
+                   ?direction:expected.direction ?fill_mode:expected.fill_mode
+                   ?play_state:expected.play_state ?timeline:expected.timeline
+                   ()))
+            [ name; String.uppercase_ascii name ])
+        names)
+    [
+      ( "linear",
+        [
+          "ease";
+          "linear";
+          "ease-in";
+          "ease-out";
+          "ease-in-out";
+          "step-start";
+          "step-end";
+        ] );
+      ("reverse", [ "normal"; "reverse"; "alternate"; "alternate-reverse" ]);
+      ("forwards", [ "forwards"; "backwards"; "both" ]);
+      ("paused", [ "running"; "paused" ]);
+      ("2", [ "infinite" ]);
+    ];
+  let expected = read "keyframe" in
+  List.iter
+    (fun name -> check_print expected name (animation_shorthand ~name ()))
+    [ "EASE"; "LINEAR"; "NORMAL"; "BOTH"; "PAUSED"; "INFINITE" ]
+
 let custom_properties () =
   (* Basic custom properties *)
   check_declaration ~expected:"--color:red" "--color: red";
@@ -5754,6 +5822,7 @@ let declaration_tests =
     test_case "text decoration thickness range" `Quick
       text_decoration_thickness_range;
     test_case "animation infinite name" `Quick animation_infinite_name;
+    test_case "animation keyword names" `Quick animation_keyword_names;
     test_case "text-decoration drained shorthand" `Quick
       text_decoration_drained_shorthand;
     test_case "white-space collapse only" `Quick white_space_collapse_only;


### PR DESCRIPTION
Preserve case-sensitive animation names that collide with shorthand keywords, without changing the other slots when printing parsed or constructed values. Stacked on #875; the regression passes, while the full suite remains red on outstanding backlog defects.