### PR TITLE
properties: accept custom counter style names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- Custom counter-style names are accepted in `list-style-type` and `list-style`,
+  with case and position-keyword disambiguation preserved. `list_style_type`
+  gains `Name of string` (#877).
+
 - `animation` preserves keyword-shaped keyframe names and their case through
   parsing and printing, including names supplied by callers (#875, #876).
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -6968,6 +6968,7 @@ type list_style_type = Properties.list_style_type =
   | Trad_chinese_informal
   | Trad_chinese_formal
   | Ethiopic_numeric
+  | Name of string  (** A case-sensitive custom counter-style name. *)
   | String of string
   | Symbols of symbols_type option * list_style_symbol list
   | Inherit

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -117,6 +117,7 @@ let rec pp_list_style_type : list_style_type Pp.t =
   | Trad_chinese_informal -> Pp.string ctx "trad-chinese-informal"
   | Trad_chinese_formal -> Pp.string ctx "trad-chinese-formal"
   | Ethiopic_numeric -> Pp.string ctx "ethiopic-numeric"
+  | Name name -> pp_ident ctx name
   | String s -> Pp.quoted_string ctx s
   | Symbols (kind, symbols) ->
       Pp.call "symbols" pp_list_style_symbols ctx (kind, symbols)
@@ -167,8 +168,24 @@ let pp_list_style_shorthand : list_style_shorthand Pp.t =
           if !first then first := false else Pp.space ctx ();
           pp ctx v
     in
-    emit pp_list_style_type type_;
-    emit pp_list_style_position position;
+    let ambiguous_type =
+      match type_ with
+      | Some (Name name) ->
+          let lower = String.lowercase_ascii name in
+          lower = "inside" || lower = "outside"
+      | _ -> false
+    in
+    (* A position-shaped counter name must follow an explicit position, even
+       when normalisation has removed the default [outside] slot. *)
+    if ambiguous_type then begin
+      emit pp_list_style_position
+        (Some (Option.value ~default:Outside position));
+      emit pp_list_style_type type_
+    end
+    else begin
+      emit pp_list_style_type type_;
+      emit pp_list_style_position position
+    end;
     emit pp_list_style_image image;
     (* Everything was an initial value and got dropped: the shorthand still
        needs one token. Emit the type initial [disc] (the shortest spelling of
@@ -2371,6 +2388,11 @@ let rec read_list_style_type t : list_style_type =
          [
            (fun t -> Cursor.call "symbols" t read_symbols_body);
            (fun t -> (String (Cursor.string t) : list_style_type));
+           (fun t ->
+             let name = Cursor.ident t in
+             if String.lowercase_ascii name = "default" then
+               Cursor.err_invalid t "reserved counter-style name";
+             (Name name : list_style_type));
          ])
     t
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1657,6 +1657,7 @@ type list_style_type =
   | Trad_chinese_informal
   | Trad_chinese_formal
   | Ethiopic_numeric
+  | Name of string
   | String of string
   | Symbols of symbols_type option * list_style_symbol list
   | Inherit

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -1968,9 +1968,9 @@ let list_style_value_parsers () =
   ok "upper-roman" (Css.parse_list_style_type "upper-roman");
   ok "url()" (Css.parse_list_style_image "url(/carrot.png)");
   ok "none" (Css.parse_list_style_image "none");
-  Alcotest.(check bool)
-    "an unknown counter style is rejected" true
-    (Css.parse_list_style_type "nonsense-style" = None)
+  (* CSS Lists 3 section 3.4 falls back to decimal if a named style is absent;
+     the name is still valid at parse time. *)
+  ok "nonsense-style" (Css.parse_list_style_type "nonsense-style")
 
 (* [font-family] takes a stack, and a token defined as one is what a theme feeds
    back in, so a var() among the entries has to survive the read. *)
@@ -2023,7 +2023,7 @@ let option_value_parser_contracts () =
       ( "list-style-type",
         (fun s -> Option.is_some (Css.parse_list_style_type s)),
         "square",
-        "nonsense-style",
+        "default",
         "square junk" );
       ( "list-style-image",
         (fun s -> Option.is_some (Css.parse_list_style_image s)),

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2496,6 +2496,34 @@ let animation_keyword_names () =
     (fun name -> check_print expected name (animation_shorthand ~name ()))
     [ "EASE"; "LINEAR"; "NORMAL"; "BOTH"; "PAUSED"; "INFINITE" ]
 
+let list_style_custom_names () =
+  (* CSS Lists 3 sections 3.4 and 3.6 allow custom counter-style names,
+     including names that collide with an already-filled position slot. The
+     referenced counter style need not be defined in this stylesheet. *)
+  List.iter
+    (fun name -> check_declaration ~roundtrip:true ("list-style-type:" ^ name))
+    [ "footsteps"; "FootSteps"; "inside"; "OUTSIDE"; "--markers" ];
+  List.iter
+    (fun (value, expected) ->
+      check_declaration ~roundtrip:true ~expected:("list-style:" ^ expected)
+        ~optimized:("list-style:" ^ expected) ("list-style:" ^ value))
+    [
+      ("FootSteps inside", "FootSteps inside");
+      ("inside outside", "inside outside");
+      ("inside OUTSIDE", "inside OUTSIDE");
+      ("outside inside", "outside inside");
+      ("outside OUTSIDE", "outside OUTSIDE");
+      ("inside inside", "inside inside");
+    ];
+  List.iter
+    (none_cursor read_declaration)
+    [
+      "list-style-type:default";
+      "list-style-type:FootSteps Other";
+      "list-style:inside outside outside";
+      "list-style:inside FootSteps Other";
+    ]
+
 let custom_properties () =
   (* Basic custom properties *)
   check_declaration ~expected:"--color:red" "--color: red";
@@ -5823,6 +5851,7 @@ let declaration_tests =
       text_decoration_thickness_range;
     test_case "animation infinite name" `Quick animation_infinite_name;
     test_case "animation keyword names" `Quick animation_keyword_names;
+    test_case "list-style custom names" `Quick list_style_custom_names;
     test_case "text-decoration drained shorthand" `Quick
       text_decoration_drained_shorthand;
     test_case "white-space collapse only" `Quick white_space_collapse_only;

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2314,8 +2314,9 @@ let test_list_style_type () =
   check_list_style_type "katakana";
   check_list_style_type "ethiopic-numeric";
   check_list_style_type "disclosure-open";
-  (* An unknown bare identifier is still rejected (no @counter-style here). *)
-  neg_cursor read_list_style_type "invalid-style";
+  (* CSS Lists 3 section 3.4 accepts custom counter-style names, but the
+     <custom-ident> grammar reserves [default]. *)
+  neg_cursor read_list_style_type "default";
   (* CSS Lists 3 sec. 6.2: [symbols() = symbols( <symbols-type>? [ <string> |
      <image> ]+ )]. [Cursor.call] did not require the reader to consume its
      whole sub-cursor, so a trailing token the [<symbols-type>? [<string> |


### PR DESCRIPTION
Accept custom counter-style names without requiring a local definition, preserving case and position-keyword disambiguation through shorthand minification. Stacked on #876; the regression passes, while the full suite remains red on outstanding backlog defects.