### PR TITLE
declaration: restrict line-height-step to lengths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,8 +202,9 @@ entry points both moved.
 
 ### Parsing
 
-- `outline-offset` rejects percentages, including inside math functions,
-  while retaining negative lengths (#879).
+- `outline-offset` and `line-height-step` reject percentages, including inside
+  math functions. Negative lengths remain valid for `outline-offset` (#879,
+  #880).
 
 - `auto` is rejected in colour values and SVG paint, including nested colour
   functions and paint-server fallbacks. Explicit UI-property alternatives and

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -834,7 +834,7 @@ let read_nn_lp_or_global t =
     ]
     ~default:read_non_negative_length_percentage t
 
-let read_nn_length_or_global t =
+let read_nn_length_or_global ?(length_only = false) t =
   Cursor.enum "non-negative length"
     [
       ("inherit", (Inherit : length));
@@ -843,7 +843,8 @@ let read_nn_length_or_global t =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~default:(read_non_negative_length ~with_keywords:false)
+    ~default:
+      (read_length ~allow_negative:false ~with_keywords:false ~length_only)
     t
 
 (* CSS Backgrounds 3 (ED) sec. 4.1: each [border-*-radius] corner longhand is
@@ -1138,7 +1139,8 @@ let read_sizing_value : type a. a property -> Cursor.t -> declaration option =
   | Perspective -> Some (v Perspective (read_perspective_value t))
   | Offset_distance -> Some (v Offset_distance (read_nn_lp_or_global t))
   | Shape_margin -> Some (v Shape_margin (read_nn_lp_or_global t))
-  | Line_height_step -> Some (v Line_height_step (read_nn_length_or_global t))
+  | Line_height_step ->
+      Some (v Line_height_step (read_nn_length_or_global ~length_only:true t))
   | _ -> None
 
 let read_radius_gap_value : type a. a property -> Cursor.t -> declaration option

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2602,6 +2602,44 @@ let outline_offset_length_only () =
       "45deg";
     ]
 
+let line_height_step_length_only () =
+  (* CSS Rhythmic Sizing 1 section 3 takes <length [0,infinity]> with no
+     percentage basis; section 1.2 also admits CSS-wide keywords. *)
+  List.iter
+    (fun value ->
+      check_declaration ~roundtrip:true ("line-height-step:" ^ value))
+    [
+      "0";
+      "4px";
+      "1em";
+      "calc(1em - 2px)";
+      "min(1em,2px)";
+      "inherit";
+      "initial";
+      "unset";
+      "revert";
+      "revert-layer";
+      "var(--step,10%)";
+    ];
+  List.iter
+    (fun value -> none_cursor read_declaration ("line-height-step:" ^ value))
+    [
+      "10%";
+      "0%";
+      "calc(1% + 2px)";
+      "min(1%,2px)";
+      "max(1px,2%)";
+      "clamp(0px,10%,2px)";
+      "-4px";
+      "auto";
+      "normal";
+      "none";
+      "min-content";
+      "fit-content(2px)";
+      "1s";
+      "45deg";
+    ]
+
 let custom_properties () =
   (* Basic custom properties *)
   check_declaration ~expected:"--color:red" "--color: red";
@@ -5932,6 +5970,7 @@ let declaration_tests =
     test_case "list-style custom names" `Quick list_style_custom_names;
     test_case "auto is not a color" `Quick auto_is_not_a_color;
     test_case "outline-offset length only" `Quick outline_offset_length_only;
+    test_case "line-height-step length only" `Quick line_height_step_length_only;
     test_case "text-decoration drained shorthand" `Quick
       text_decoration_drained_shorthand;
     test_case "white-space collapse only" `Quick white_space_collapse_only;


### PR DESCRIPTION
Reject percentage and sizing-function line-height steps without changing percentage support for padding and gaps. The spec regression passes; the full suite remains red on backlog defects, and the browser oracle cannot arbitrate this property.