### PR TITLE
declaration: accept normal in gap longhands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- `row-gap` and `column-gap` accept `normal` and preserve its layout-dependent
+  meaning during optimisation (#881).
+
 - `outline-offset` and `line-height-step` reject percentages, including inside
   math functions. Negative lengths remain valid for `outline-offset` (#879,
   #880).

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -853,6 +853,11 @@ let read_nn_length_or_global ?(length_only = false) t =
 let read_corner_radius t =
   Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2 read_nn_length_or_global t
 
+let read_gap_longhand t =
+  Cursor.enum "gap"
+    [ ("normal", (Normal : length)) ]
+    ~default:read_nn_length_or_global t
+
 (* CSS Text 3 section 7: [letter-spacing] is [normal | <length>], [word-spacing]
    is [normal | <length-percentage>]; both accept negative values. *)
 let read_normal_or_length name t =
@@ -1165,8 +1170,8 @@ let read_radius_gap_value : type a. a property -> Cursor.t -> declaration option
   | Border_end_end_radius ->
       Some (v Border_end_end_radius (read_corner_radius t))
   | Gap -> Some (v Gap (Properties.read_gap t))
-  | Column_gap -> Some (v Column_gap (read_nn_length_or_global t))
-  | Row_gap -> Some (v Row_gap (read_nn_length_or_global t))
+  | Column_gap -> Some (v Column_gap (read_gap_longhand t))
+  | Row_gap -> Some (v Row_gap (read_gap_longhand t))
   | _ -> None
 
 let read_layout_value : type a. a property -> Cursor.t -> declaration option =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2640,6 +2640,35 @@ let line_height_step_length_only () =
       "45deg";
     ]
 
+let gap_normal () =
+  (* CSS Box Alignment 3 sections 8.1 and 8.2 admit normal in both gap longhands
+     and either shorthand slot. Its used value depends on layout, so normal
+     cannot be replaced with zero without a layout context. *)
+  List.iter
+    (fun property ->
+      List.iter
+        (fun value ->
+          let css = property ^ ":" ^ value in
+          check_declaration ~roundtrip:true ~optimized:css css)
+        [ "normal"; "10%"; "2px" ];
+      check_declaration ~roundtrip:true (property ^ ":var(--gap,normal)");
+      check_declaration ~roundtrip:true ~expected:(property ^ ":normal")
+        (property ^ ":NORMAL");
+      List.iter
+        (fun value -> none_cursor read_declaration (property ^ ":" ^ value))
+        [ "normal normal"; "normal 2px"; "auto"; "-2px" ])
+    [ "row-gap"; "column-gap" ];
+  List.iter
+    (fun value ->
+      let css = "gap:" ^ value in
+      check_declaration ~roundtrip:true ~optimized:css css)
+    [ "normal"; "normal 2px"; "2px normal"; "normal 10%" ];
+  check_declaration ~roundtrip:true ~expected:"gap:normal"
+    ~optimized:"gap:normal" "gap:normal normal";
+  List.iter
+    (fun value -> none_cursor read_declaration ("gap:" ^ value))
+    [ "normal inherit"; "inherit normal"; "normal normal normal" ]
+
 let custom_properties () =
   (* Basic custom properties *)
   check_declaration ~expected:"--color:red" "--color: red";
@@ -5971,6 +6000,7 @@ let declaration_tests =
     test_case "auto is not a color" `Quick auto_is_not_a_color;
     test_case "outline-offset length only" `Quick outline_offset_length_only;
     test_case "line-height-step length only" `Quick line_height_step_length_only;
+    test_case "gap normal" `Quick gap_normal;
     test_case "text-decoration drained shorthand" `Quick
       text_decoration_drained_shorthand;
     test_case "white-space collapse only" `Quick white_space_collapse_only;


### PR DESCRIPTION
Preserve the layout-dependent normal value in row-gap and column-gap. The regression and browser checks pass; the full suite remains red on outstanding backlog defects.