### PR TITLE
declaration: distinguish sizing keyword domains

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- Physical and logical box sizes reject unrelated keywords: `none` is only
+  valid for maximum sizes, which reject `auto`; `normal`, `from-font` and
+  bare `size` are rejected throughout (#882).
+
 - `row-gap` and `column-gap` accept `normal` and preserve its layout-dependent
   meaning during optimisation (#881).
 

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1115,31 +1115,31 @@ let read_color_value : type a. a property -> Cursor.t -> declaration option =
       Some (v Webkit_text_decoration_color (read_color t))
   | _ -> None
 
+let read_box_size ?(maximum = false) t =
+  match read_length_percentage ~allow_negative:false t with
+  | Length (Normal | From_font | Size) ->
+      Cursor.err_invalid t "expected a box size"
+  | Length Auto when maximum ->
+      Cursor.err_invalid t "maximum sizes do not accept auto"
+  | Length None when not maximum ->
+      Cursor.err_invalid t "only maximum sizes accept none"
+  | size -> size
+
 let read_sizing_value : type a. a property -> Cursor.t -> declaration option =
  fun prop t ->
   match prop with
-  | Width -> Some (v Width (read_length_percentage ~allow_negative:false t))
-  | Height -> Some (v Height (read_length_percentage ~allow_negative:false t))
-  | Min_width ->
-      Some (v Min_width (read_length_percentage ~allow_negative:false t))
-  | Min_height ->
-      Some (v Min_height (read_length_percentage ~allow_negative:false t))
-  | Max_width ->
-      Some (v Max_width (read_length_percentage ~allow_negative:false t))
-  | Max_height ->
-      Some (v Max_height (read_length_percentage ~allow_negative:false t))
-  | Inline_size ->
-      Some (v Inline_size (read_length_percentage ~allow_negative:false t))
-  | Min_inline_size ->
-      Some (v Min_inline_size (read_length_percentage ~allow_negative:false t))
-  | Max_inline_size ->
-      Some (v Max_inline_size (read_length_percentage ~allow_negative:false t))
-  | Block_size ->
-      Some (v Block_size (read_length_percentage ~allow_negative:false t))
-  | Min_block_size ->
-      Some (v Min_block_size (read_length_percentage ~allow_negative:false t))
-  | Max_block_size ->
-      Some (v Max_block_size (read_length_percentage ~allow_negative:false t))
+  | Width -> Some (v Width (read_box_size t))
+  | Height -> Some (v Height (read_box_size t))
+  | Min_width -> Some (v Min_width (read_box_size t))
+  | Min_height -> Some (v Min_height (read_box_size t))
+  | Max_width -> Some (v Max_width (read_box_size ~maximum:true t))
+  | Max_height -> Some (v Max_height (read_box_size ~maximum:true t))
+  | Inline_size -> Some (v Inline_size (read_box_size t))
+  | Min_inline_size -> Some (v Min_inline_size (read_box_size t))
+  | Max_inline_size -> Some (v Max_inline_size (read_box_size ~maximum:true t))
+  | Block_size -> Some (v Block_size (read_box_size t))
+  | Min_block_size -> Some (v Min_block_size (read_box_size t))
+  | Max_block_size -> Some (v Max_block_size (read_box_size ~maximum:true t))
   | Font_size -> Some (v Font_size (Properties.read_font_size t))
   | Perspective -> Some (v Perspective (read_perspective_value t))
   | Offset_distance -> Some (v Offset_distance (read_nn_lp_or_global t))

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2669,6 +2669,50 @@ let gap_normal () =
     (fun value -> none_cursor read_declaration ("gap:" ^ value))
     [ "normal inherit"; "inherit normal"; "normal normal normal" ]
 
+let sizing_keyword_domains () =
+  (* CSS Sizing 3 sections 3.1.1-3.1.3 distinguish auto sizes from none
+     maximums. CSS Logical Properties 1 section 4.1 uses the same grammars for
+     the corresponding flow-relative dimensions. *)
+  List.iter
+    (fun dimension ->
+      List.iter
+        (fun (prefix, valid, invalid) ->
+          let property = prefix ^ dimension in
+          List.iter
+            (fun value ->
+              check_declaration ~roundtrip:true (property ^ ":" ^ value))
+            [
+              valid;
+              "min-content";
+              "max-content";
+              "fit-content(10%)";
+              "0";
+              "2px";
+              "10%";
+              "calc(1em + 2px)";
+              "inherit";
+              "initial";
+              "unset";
+              "revert";
+              "revert-layer";
+              "var(--size," ^ invalid ^ ")";
+            ];
+          List.iter
+            (fun value -> none_cursor read_declaration (property ^ ":" ^ value))
+            [
+              invalid;
+              String.uppercase_ascii invalid;
+              "normal";
+              "from-font";
+              "size";
+            ])
+        [
+          ("", "auto", "none");
+          ("min-", "auto", "none");
+          ("max-", "none", "auto");
+        ])
+    [ "width"; "height"; "inline-size"; "block-size" ]
+
 let custom_properties () =
   (* Basic custom properties *)
   check_declaration ~expected:"--color:red" "--color: red";
@@ -6001,6 +6045,7 @@ let declaration_tests =
     test_case "outline-offset length only" `Quick outline_offset_length_only;
     test_case "line-height-step length only" `Quick line_height_step_length_only;
     test_case "gap normal" `Quick gap_normal;
+    test_case "sizing keyword domains" `Quick sizing_keyword_domains;
     test_case "text-decoration drained shorthand" `Quick
       text_decoration_drained_shorthand;
     test_case "white-space collapse only" `Quick white_space_collapse_only;


### PR DESCRIPTION
Reject unrelated keywords in physical and logical box sizes while preserving intrinsic sizes and deferred variables. The regression passes; the full suite remains red on backlog defects.