### PR TITLE
grid: accept none on either side of the slash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- `grid` and `grid-template` accept `none` on either side of the slash
+  instead of dropping the declaration, and `grid: auto-flow / 200px` now
+  serialises to a form cascade reads back (#884).
+
 - Physical and logical box sizes reject unrelated keywords: `none` is only
   valid for maximum sizes, which reject `auto`; `normal`, `from-font` and
   bare `size` are rejected throughout (#882).

--- a/fuzz/fuzz_properties.ml
+++ b/fuzz/fuzz_properties.ml
@@ -1016,7 +1016,6 @@ let negative_branch_vectors =
     "grid-template-areas:\"nav/main\"";
     "grid-template-areas:\"nav main\" \"foot\"";
     "grid-template-areas:\"a .\" \". a\"";
-    "grid-template:none/1fr";
     "animation:1s 2s 3s";
     "animation-composition:add replace";
     "animation-range-start:entry exit";

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -1208,10 +1208,7 @@ let rec read_grid_template t : grid_template =
     if Cursor.slash_opt t then (
       Cursor.ws t;
       let columns = read_grid_template_tracks t in
-      match (rows, columns) with
-      | None, _ | _, None ->
-          err_invalid_value t "grid-template" "none in slash form"
-      | _ -> Split (rows, columns))
+      Split (rows, columns))
     else rows
 
 (* CSS Grid 2 (ED) sec. 7.6: [grid-auto-columns] and [grid-auto-rows] take
@@ -1275,12 +1272,6 @@ let grid_starts_auto_flow t =
   | Some ("auto-flow" | "dense") -> true
   | _ -> false
 
-let read_grid_split t (rows : grid_template) (columns : grid_template) :
-    grid_template =
-  match (rows, columns) with
-  | None, _ | _, None -> err_invalid_value t "grid" "none in slash form"
-  | _ -> Split (rows, columns)
-
 let read_grid_auto_flow_rows t =
   let flow = read_grid_auto_flow_clause `Rows t in
   let auto_rows = read_grid_auto_flow_tracks t in
@@ -1298,7 +1289,7 @@ let read_grid_auto_flow_columns t rows =
 let read_grid_slash_rhs t rows =
   Cursor.ws t;
   if grid_starts_auto_flow t then read_grid_auto_flow_columns t rows
-  else read_grid_split t rows (read_grid_template_tracks t)
+  else Split (rows, read_grid_template_tracks t)
 
 let read_grid_template_or_split t =
   let rows = read_grid_template_tracks t in

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2198,6 +2198,24 @@ let grid () =
   neg_cursor read_declaration "grid-template: 1px / [a]";
   neg_cursor read_declaration "grid: auto-flow [a] / 1px";
 
+  (* CSS Grid 2 sec. 7.4 builds the shorthand from [<'grid-template-rows'> /
+     <'grid-template-columns'>], and sec. 7.2 gives each of those a [none] arm,
+     so [none] is a track list like any other on either side of the slash. *)
+  check_declaration ~expected:"grid-template:none/1fr"
+    "grid-template: none / 1fr";
+  check_declaration ~expected:"grid-template:1fr/none"
+    "grid-template: 1fr / none";
+  check_declaration ~expected:"grid-template:none/none"
+    "grid-template: none / none";
+  check_declaration ~expected:"grid-template:none/auto"
+    "grid-template: none / auto";
+  check_declaration ~expected:"grid:none/200px" "grid: none / 200px";
+  check_declaration ~expected:"grid:200px/none" "grid: 200px / none";
+  check_declaration ~expected:"grid:none/auto" "grid: none / auto";
+  (* sec. 7.8: [auto-flow] with no [<grid-auto-rows>] leaves the row track list
+     empty, which is the same declaration as a [none] rows arm. *)
+  check_declaration ~expected:"grid:none/200px" "grid: auto-flow / 200px";
+
   (* CSS Cascade 5 (ED) sec. 7.3: explicit defaulting takes the whole
      declaration, so a CSS-wide keyword is a placement value on its own and
      never one slot of one. *)
@@ -4044,7 +4062,6 @@ let spec_platform_property_vectors () =
       "background-image: image-set(url(a.png))";
       "border-image: linear-gradient(red, blue) fill fill";
       "font: bold serif";
-      "grid-template: none / 1fr";
       "transition: allow-discrete allow-discrete";
       "scroll-timeline: block --scroller";
       "view-timeline: inline --reveal";


### PR DESCRIPTION
`grid: none / 200px` and `grid-template: none / 1fr` are valid per CSS Grid 2 sec. 7.4, whose slash form is built from grid-template-rows and grid-template-columns, each given a `none` arm by sec. 7.2. cascade dropped every such declaration, and printed `grid: auto-flow / 200px` as `grid: none/200px` which it then could not read back.

Two vector lists pinned `grid-template: none / 1fr` as invalid; the shared inventory manifest already had it right, and Chrome accepts every case in the test.