### PR TITLE
animation: accept auto as a duration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- `animation-duration` accepts `auto`, its initial value, instead of dropping
+  the declaration. `Css.duration` gains an `Auto` constructor; the delays and
+  `transition-duration` still reject it (#885).
+
 - `grid` and `grid-template` accept `none` on either side of the slash
   instead of dropping the declaration, and `grid: auto-flow / 200px` now
   serialises to a form cascade reads back (#884).

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -5847,6 +5847,7 @@ type timing_function = Properties.timing_function =
 type duration = Values.duration =
   | Ms of float  (** milliseconds *)
   | S of float  (** seconds *)
+  | Auto  (** [animation-duration] only *)
   | Durations of duration list  (** comma-separated list of durations *)
   | Round of string * duration * duration
   | Mod of duration * duration

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -858,6 +858,13 @@ let read_gap_longhand t =
     [ ("normal", (Normal : length)) ]
     ~default:read_nn_length_or_global t
 
+(* CSS Animations 2 sec. 4.1: [animation-duration] is [ auto | <time [0s,inf]>
+   ]#. The transition durations and both delays keep the time grammar alone. *)
+let read_animation_duration t =
+  Cursor.enum "animation-duration"
+    [ ("auto", (Auto : duration)) ]
+    ~default:read_duration t
+
 (* CSS Text 3 section 7: [letter-spacing] is [normal | <length>], [word-spacing]
    is [normal | <length-percentage>]; both accept negative values. *)
 let read_normal_or_length name t =
@@ -1322,7 +1329,9 @@ let read_vendor_alias_value : type a.
   | Webkit_animation_delay ->
       Some (v Webkit_animation_delay (read_duration_list read_time t))
   | Webkit_animation_duration ->
-      Some (v Webkit_animation_duration (read_duration_list read_duration t))
+      Some
+        (v Webkit_animation_duration
+           (read_duration_list read_animation_duration t))
   | Webkit_animation_direction ->
       Some (v Webkit_animation_direction (read_animation_direction t))
   | Webkit_animation_iteration_count ->
@@ -1353,7 +1362,9 @@ let read_vendor_alias_value : type a.
   | Moz_animation_delay ->
       Some (v Moz_animation_delay (read_duration_list read_time t))
   | Moz_animation_duration ->
-      Some (v Moz_animation_duration (read_duration_list read_duration t))
+      Some
+        (v Moz_animation_duration
+           (read_duration_list read_animation_duration t))
   | Moz_animation_direction ->
       Some (v Moz_animation_direction (read_animation_direction t))
   | Moz_animation_iteration_count ->
@@ -1924,7 +1935,7 @@ let read_interaction_value : type a.
       Some (v Text_combine_upright (read_text_combine_upright t))
   | Animation_name -> Some (v Animation_name (read_animation_name t))
   | Animation_duration ->
-      Some (v Animation_duration (read_duration_list read_duration t))
+      Some (v Animation_duration (read_duration_list read_animation_duration t))
   | Animation_timing_function ->
       Some (v Animation_timing_function (read_timing_function_list t))
   | Animation_delay -> Some (v Animation_delay (read_duration_list read_time t))

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -4857,6 +4857,7 @@ let rec pp_duration_with ~shorten_ms : duration Pp.t =
  fun ctx -> function
   | Ms f -> pp_duration_unit ~shorten_ms ctx f "ms"
   | S f -> pp_duration_unit ctx f "s"
+  | Auto -> Pp.string ctx "auto"
   | Durations durations ->
       Pp.list ~sep:Pp.comma (pp_duration_with ~shorten_ms) ctx durations
   | Round (strategy, value, step) ->

--- a/lib/values_intf.ml
+++ b/lib/values_intf.ml
@@ -559,6 +559,9 @@ type color =
 type duration =
   | Ms of float
   | S of float
+  (* CSS Animations 2 sec. 4.1: [animation-duration] alone has an [auto] arm,
+     and it is that property's initial value. *)
+  | Auto
   | Durations of duration list
   | Round of string * duration * duration
   | Mod of duration * duration

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1878,6 +1878,17 @@ let animations_timing () =
     ~optimized:"transition-duration:1s" "transition-duration: round(1.1s, .5s)";
   check_declaration ~expected:"animation-duration:2.5s"
     "animation-duration: 2.5s";
+  (* CSS Animations 2 sec. 4.1: [ auto | <time [0s,inf]> ]#, with auto the
+     initial value. The time arm keeps its lower bound, and the delays and
+     transition-duration have no auto arm at all. *)
+  check_declaration ~expected:"animation-duration:auto"
+    "animation-duration: auto";
+  check_declaration ~expected:"animation-duration:auto,1s"
+    "animation-duration: auto, 1s";
+  neg_cursor read_declaration "animation-duration: -1s";
+  neg_cursor read_declaration "transition-duration: auto";
+  neg_cursor read_declaration "animation-delay: auto";
+  neg_cursor read_declaration "transition-delay: auto";
 
   check_declaration ~expected:"animation-timing-function:ease"
     "animation-timing-function: ease";


### PR DESCRIPTION
CSS Animations 2 sec. 4.1 gives `animation-duration` the grammar `[ auto | <time [0s,inf]> ]#`, with `auto` as its initial value. cascade's `duration` type had no `auto` arm, so the declaration was dropped.

`Css.duration` gains an `Auto` constructor. Only the `animation-duration` reader produces it, so the delays and `transition-duration` keep rejecting `auto`.