### PR TITLE
text-wrap: read the mode and style components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- `text-wrap` reads its full grammar: `auto` and `stable`, and a wrap mode
+  combined with a wrap style in either order. `Css.text_wrap` gains `Auto`,
+  `Stable` and `Mode_style` (#886).
+
 - `animation-duration` accepts `auto`, its initial value, instead of dropping
   the declaration. `Css.duration` gains an `Auto` constructor; the delays and
   `transition-duration` still reject it (#885).

--- a/fuzz/fuzz_properties.ml
+++ b/fuzz/fuzz_properties.ml
@@ -461,8 +461,16 @@ let property_grammar_ui_vectors =
       [ "clip"; "ellipsis"; "\"...\""; "clip ellipsis" ]
       [ "clip ellipsis clip"; "auto" ];
     vector "text-wrap" Css.Properties.read_text_wrap Css.Properties.pp_text_wrap
-      [ "wrap"; "nowrap"; "balance"; "pretty" ]
-      [ "wrap nowrap"; "auto" ];
+      [
+        "wrap";
+        "nowrap";
+        "auto";
+        "balance";
+        "stable";
+        "pretty";
+        "nowrap balance";
+      ]
+      [ "wrap nowrap"; "balance pretty" ];
     vector "overflow-wrap" Css.Properties.read_overflow_wrap
       Css.Properties.pp_overflow_wrap
       [ "normal"; "break-word"; "anywhere" ]

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -2467,8 +2467,12 @@ val text_overflow : text_overflow -> declaration
 type text_wrap = Properties.text_wrap =
   | Wrap
   | No_wrap
+  | Auto
   | Balance
+  | Stable
   | Pretty
+  | Mode_style of [ `Wrap | `No_wrap ] * [ `Auto | `Balance | `Stable | `Pretty ]
+      (** both components, printed mode-first *)
   | Inherit
   | Initial
   | Unset

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1040,8 +1040,19 @@ let rec pp_text_wrap : text_wrap Pp.t =
   | Var v -> pp_var pp_text_wrap ctx v
   | Wrap -> Pp.string ctx "wrap"
   | No_wrap -> Pp.string ctx "nowrap"
+  | Auto -> Pp.string ctx "auto"
   | Balance -> Pp.string ctx "balance"
+  | Stable -> Pp.string ctx "stable"
   | Pretty -> Pp.string ctx "pretty"
+  | Mode_style (mode, style) ->
+      Pp.string ctx (match mode with `Wrap -> "wrap" | `No_wrap -> "nowrap");
+      Pp.space ctx ();
+      Pp.string ctx
+        (match style with
+        | `Auto -> "auto"
+        | `Balance -> "balance"
+        | `Stable -> "stable"
+        | `Pretty -> "pretty")
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -1464,12 +1475,16 @@ let rec read_text_overflow t : text_overflow =
     ]
     t
 
+(* CSS Text 4 sec. 5.5: [<'text-wrap-mode'> || <'text-wrap-style'>], so each
+   side appears at most once and either may be omitted. *)
 let rec read_text_wrap t : text_wrap =
-  Cursor.enum_or_var "text-wrap"
+  let single =
     [
       ("wrap", (Wrap : text_wrap));
       ("nowrap", No_wrap);
+      ("auto", Auto);
       ("balance", Balance);
+      ("stable", Stable);
       ("pretty", Pretty);
       ("inherit", Inherit);
       ("initial", Initial);
@@ -1477,8 +1492,46 @@ let rec read_text_wrap t : text_wrap =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~var:(fun t -> Var (read_var read_text_wrap t))
-    t
+  in
+  let first =
+    Cursor.enum_or_var "text-wrap" single
+      ~var:(fun t -> Var (read_var read_text_wrap t))
+      t
+  in
+  let mode_of : text_wrap -> _ = function
+    | Wrap -> Some `Wrap
+    | No_wrap -> Some `No_wrap
+    | _ -> None
+  in
+  let style_of : text_wrap -> _ = function
+    | Auto -> Some `Auto
+    | Balance -> Some `Balance
+    | Stable -> Some `Stable
+    | Pretty -> Some `Pretty
+    | _ -> None
+  in
+  let second () =
+    Cursor.ws t;
+    match Cursor.peek_ident t with
+    | Some _ -> Cursor.option (Cursor.enum "text-wrap" single) t
+    | None -> None
+  in
+  match (mode_of first, style_of first) with
+  | Some mode, _ -> (
+      match second () with
+      | Some other -> (
+          match style_of other with
+          | Some style -> Mode_style (mode, style)
+          | None -> Cursor.err_invalid t "text-wrap repeats its wrap mode")
+      | None -> first)
+  | _, Some style -> (
+      match second () with
+      | Some other -> (
+          match mode_of other with
+          | Some mode -> Mode_style (mode, style)
+          | None -> Cursor.err_invalid t "text-wrap repeats its wrap style")
+      | None -> first)
+  | None, None -> first
 
 let rec read_text_wrap_mode t : text_wrap_mode =
   Cursor.enum_or_var "text-wrap-mode"

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1293,11 +1293,18 @@ type text_overflow =
   | Revert_layer
   | Var of text_overflow var
 
+(* CSS Text 4 sec. 5.5: [text-wrap] is [<'text-wrap-mode'> ||
+   <'text-wrap-style'>]. A single component names the arm it came from;
+   [Mode_style] carries both, and prints mode-first whatever order it was
+   written in. *)
 type text_wrap =
   | Wrap
   | No_wrap
+  | Auto
   | Balance
+  | Stable
   | Pretty
+  | Mode_style of [ `Wrap | `No_wrap ] * [ `Auto | `Balance | `Stable | `Pretty ]
   | Inherit
   | Initial
   | Unset

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -972,7 +972,29 @@ let text_properties () =
   check_declaration ~expected:"white-space:pre-wrap" "white-space: pre-wrap";
   check_declaration ~expected:"white-space:pre-line" "white-space: pre-line";
   check_declaration ~expected:"white-space:break-spaces"
-    "white-space: break-spaces"
+    "white-space: break-spaces";
+
+  (* CSS Text 4 sec. 5.5: [text-wrap] is [<'text-wrap-mode'> ||
+     <'text-wrap-style'>], with sec. 5.1 giving the mode [wrap | nowrap] and
+     sec. 5.4 the style [auto | balance | stable | pretty]. Either component may
+     be omitted and they may appear in either order, but neither may repeat. *)
+  check_declaration ~expected:"text-wrap:wrap" "text-wrap: wrap";
+  check_declaration ~expected:"text-wrap:nowrap" "text-wrap: nowrap";
+  check_declaration ~expected:"text-wrap:auto" "text-wrap: auto";
+  check_declaration ~expected:"text-wrap:balance" "text-wrap: balance";
+  check_declaration ~expected:"text-wrap:pretty" "text-wrap: pretty";
+  check_declaration ~expected:"text-wrap:stable" "text-wrap: stable";
+  check_declaration ~expected:"text-wrap:nowrap balance"
+    "text-wrap: nowrap balance";
+  (* The two components print mode-first whichever order they arrived in, which
+     is how Chrome serialises them too. *)
+  check_declaration ~expected:"text-wrap:nowrap balance"
+    "text-wrap: balance nowrap";
+  check_declaration ~expected:"text-wrap:wrap auto" "text-wrap: wrap auto";
+  neg_cursor read_declaration "text-wrap: wrap nowrap";
+  neg_cursor read_declaration "text-wrap: wrap wrap";
+  neg_cursor read_declaration "text-wrap: balance pretty";
+  neg_cursor read_declaration "text-wrap: wrap balance pretty"
 
 let flexbox_direction () =
   (* Flex direction *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1523,12 +1523,17 @@ let test_text_overflow () =
 let test_text_wrap () =
   check_text_wrap "wrap";
   check_text_wrap "nowrap";
+  check_text_wrap "auto";
   check_text_wrap "balance";
+  check_text_wrap "stable";
   check_text_wrap "pretty";
+  check_text_wrap "nowrap balance";
+  check_text_wrap ~expected:"nowrap balance" "balance nowrap";
   check_text_wrap "inherit";
   neg_cursor read_text_wrap "invalid-wrap";
   (* contradictory *)
   neg_cursor ~allow_partial:true read_text_wrap "wrap nowrap";
+  neg_cursor ~allow_partial:true read_text_wrap "balance pretty";
   (* wrong form *)
   neg_cursor read_text_wrap "no-wrap";
   neg_cursor read_text_wrap "balanced"


### PR DESCRIPTION
CSS Text 4 sec. 5.5 defines `text-wrap` as `<'text-wrap-mode'> || <'text-wrap-style'>`. cascade read a single keyword from a flat enum, so it dropped `auto` and `stable` and every two-component declaration such as `text-wrap: nowrap balance`.

`Css.text_wrap` gains `Auto`, `Stable` and `Mode_style`, which prints mode-first whichever order it was written in, matching Chrome. Two vector lists pinned `text-wrap: auto` as invalid; the shared inventory manifest already had it right.