### PR TITLE
shadow: stop requiring a blur, spread or colour

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- A shadow whose offsets are both zero is kept, so `box-shadow: 0 0` and
+  `text-shadow: 0 0` parse instead of being dropped (#887).
+
 - `text-wrap` reads its full grammar: `auto` and `stable`, and a wrap mode
   combined with a wrap style in either order. `Css.text_wrap` gains `Auto`,
   `Stable` and `Mode_style` (#886).

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -83,10 +83,6 @@ module Shadow = struct
     let lengths = List.rev !lengths_rev in
     match read_lengths lengths with
     | Some (h_offset, v_offset, blur, spread) ->
-        if
-          blur = None && spread = None && !color = None && h_offset = Zero
-          && v_offset = Zero
-        then err_invalid_value t "shadow" "blur, spread, or color is required";
         let body = { h_offset; v_offset; blur; spread; color = !color } in
         (if !inset then Inset (Body body) else Shadow body : shadow)
     | None -> err_invalid_value t "shadow" "at least two lengths are required"

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2337,6 +2337,15 @@ let misc () =
 let list_properties () =
   (* Box shadow *)
   check_declaration ~expected:"box-shadow:none" "box-shadow: none";
+  (* CSS Backgrounds 3 sec. 6.1: <shadow> is [<color>? && [<length>{2,4}] &&
+     inset?], so the two offsets alone are a whole shadow whatever they hold,
+     and one length is not. *)
+  check_declaration ~expected:"box-shadow:0 0" "box-shadow: 0 0";
+  check_declaration ~expected:"box-shadow:inset 0 0" "box-shadow: inset 0 0";
+  check_declaration ~expected:"text-shadow:0 0" "text-shadow: 0 0";
+  neg_cursor read_declaration "box-shadow: 0";
+  neg_cursor read_declaration "text-shadow: 1px";
+  neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
   check_declaration ~expected:"box-shadow:0 1px 3px rgb(0 0 0/.12)"
     ~optimized:"box-shadow:0 1px 3px #0000001f"
     "box-shadow: 0 1px 3px rgba(0,0,0,0.12)";


### PR DESCRIPTION
CSS Backgrounds 3 sec. 6.1 gives `<shadow>` as `<color>? && [<length>{2,4}] && inset?`, so the two offsets alone are a whole shadow whatever they hold. cascade rejected one whose offsets were both zero, dropping `box-shadow: 0 0` and `text-shadow: 0 0`. A single length is still rejected.