### PR TITLE
position-try: read a fallback's components as a group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- `position-try-fallbacks` reads a dashed ident and a try tactic together in
+  either order, rejecting only a repeated component. `Fallbacks` now carries
+  a component group per entry (#888).
+
 - A shadow whose offsets are both zero is kept, so `box-shadow: 0 0` and
   `text-shadow: 0 0` parse instead of being dropped (#887).
 

--- a/fuzz/fuzz_properties.ml
+++ b/fuzz/fuzz_properties.ml
@@ -1039,7 +1039,7 @@ let negative_branch_vectors =
     "view-timeline-inset:auto auto auto";
     "container:card/inline-size/size";
     "position-area:top bottom";
-    "position-try-fallbacks:flip-block --below";
+    "position-try-fallbacks:flip-block flip-block";
     "position-try-order:most-width normal";
     "position-visibility:always anchors-visible";
     "overlay:auto none";

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -1101,10 +1101,15 @@ let rec prune_position_try_decl known (decl : Declaration.declaration) :
         important;
         _;
       } -> (
-      let keep = function
-        | (Properties.Name s : Properties.position_try_fallback) ->
-            Hashtbl.mem known s
-        | _ -> true
+      (* An entry names at most one [@position-try] rule; a tactics-only entry
+         names none and always survives. *)
+      let keep group =
+        List.for_all
+          (function
+            | (Properties.Name s : Properties.position_try_fallback) ->
+                Hashtbl.mem known s
+            | _ -> true)
+          group
       in
       match list_filter_preserve keep items with
       | [] -> None

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -104,7 +104,9 @@ let rec pp_position_try_fallbacks : position_try_fallbacks Pp.t =
   | Var v -> pp_var pp_position_try_fallbacks ctx v
   | None -> Pp.string ctx "none"
   | Fallbacks fallbacks ->
-      Pp.list ~sep:Pp.comma pp_position_try_fallback ctx fallbacks
+      Pp.list ~sep:Pp.comma
+        (Pp.list ~sep:Pp.space pp_position_try_fallback)
+        ctx fallbacks
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -718,6 +720,28 @@ let read_position_try_fallback t =
       | _ -> assert false)
   | _ -> Name (read_dashed_ident t)
 
+(* One [<dashed-ident> || <try-tactic>] entry. [||] is order-free and takes each
+   component at most once, so the group reads in any order and is held
+   name-first with the tactics in block, inline, start order. *)
+let read_position_try_fallback_group t =
+  let components =
+    Cursor.list ~sep:Cursor.ws ~at_least:1 read_position_try_fallback t
+  in
+  let pick p = List.filter p components in
+  let name =
+    pick (function (Name _ : position_try_fallback) -> true | _ -> false)
+  in
+  let block = pick (function Flip_block -> true | _ -> false) in
+  let inline = pick (function Flip_inline -> true | _ -> false) in
+  let start = pick (function Flip_start -> true | _ -> false) in
+  if
+    List.length name > 1
+    || List.length block > 1
+    || List.length inline > 1
+    || List.length start > 1
+  then Cursor.err_invalid t "position-try-fallbacks repeats a component";
+  name @ block @ inline @ start
+
 let rec read_position_try_fallbacks t : position_try_fallbacks =
   let keywords : (string * position_try_fallbacks) list =
     [
@@ -735,8 +759,8 @@ let rec read_position_try_fallbacks t : position_try_fallbacks =
          : position_try_fallbacks))
      ~default:(fun t ->
        (Fallbacks
-          (Cursor.list ~sep:Cursor.comma ~at_least:1 read_position_try_fallback
-             t)
+          (Cursor.list ~sep:Cursor.comma ~at_least:1
+             read_position_try_fallback_group t)
          : position_try_fallbacks))
      t
     : position_try_fallbacks)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3335,9 +3335,12 @@ type position_try_fallback =
   | Flip_start
   | Name of string
 
+(* CSS Anchor Positioning 1 sec. 6.1: each comma-separated entry is
+   [<dashed-ident> || <try-tactic>], so it holds a group of components rather
+   than a single one. *)
 type position_try_fallbacks =
   | None
-  | Fallbacks of position_try_fallback list
+  | Fallbacks of position_try_fallback list list
   | Initial
   | Inherit
   | Unset

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4321,6 +4321,18 @@ let spec_remaining_prop_vectors () =
       ("position-area: top span-left", "position-area:top span-left");
       ( "position-try-fallbacks: --below, flip-block",
         "position-try-fallbacks:--below,flip-block" );
+      (* CSS Anchor Positioning 1 sec. 6.1: [<dashed-ident> || <try-tactic>],
+         and <try-tactic> is itself [flip-block || flip-inline || flip-start].
+         || is order-free, so each component appears at most once in any order
+         and reads back name-first. *)
+      ( "position-try-fallbacks: flip-block --below",
+        "position-try-fallbacks:--below flip-block" );
+      ( "position-try-fallbacks: --below flip-block",
+        "position-try-fallbacks:--below flip-block" );
+      ( "position-try-fallbacks: flip-inline flip-block",
+        "position-try-fallbacks:flip-block flip-inline" );
+      ( "position-try-fallbacks: --a flip-start, flip-inline",
+        "position-try-fallbacks:--a flip-start,flip-inline" );
       ("scrollbar-color: auto", "scrollbar-color:auto");
       ("overlay: auto", "overlay:auto");
       ( "transition-behavior: allow-discrete",
@@ -4423,8 +4435,9 @@ let spec_remaining_prop_vectors () =
       "anchor-name: target";
       "anchor-name: --a none";
       "position-anchor: --a --b";
+      "position-try-fallbacks: --a --b";
+      "position-try-fallbacks: flip-block flip-block";
       "position-area: top bottom";
-      "position-try-fallbacks: flip-block --below";
       "overlay: auto none";
       "transition-behavior: allow-discrete normal";
       "font-size-adjust: ex-height";


### PR DESCRIPTION
CSS Anchor Positioning 1 sec. 6.1 makes each comma-separated entry `<dashed-ident> || <try-tactic>`, with `<try-tactic>` itself `flip-block || flip-inline || flip-start`. cascade read one component per entry, so `position-try-fallbacks: flip-block --below` was dropped.

An entry now holds a component group, read in any order and kept name-first with the tactics in block, inline, start order, which is how Chrome serialises it. A repeated component is rejected. Two vector lists pinned the valid combination as invalid.