### PR TITLE
transition: let all sit in a property list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- `transition-property` keeps `all` beside another property, so
+  `transition-property: all, opacity` parses. `none` and the CSS-wide
+  keywords are still refused in a list (#889).
+
 - `position-try-fallbacks` reads a dashed ident and a try tactic together in
   either order, rejecting only a repeated component. `Fallbacks` now carries
   a component group per entry (#888).

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -936,9 +936,12 @@ let read_transition_property t : transition_property =
     if Cursor.comma_opt t then loop (v :: acc) else List.rev (v :: acc)
   in
   let values = loop [] in
+  (* CSS Transitions 1 sec. 2.1: the exclusion clause names none, inherit and
+     initial as what a list of more than one may not hold. [all] is an ordinary
+     <single-transition-property> and combines with the rest. *)
   let singleton_only : transition_property_value -> bool = function
-    | All | None | Initial | Inherit | Unset | Revert | Revert_layer -> true
-    | Property _ | Var _ -> false
+    | None | Initial | Inherit | Unset | Revert | Revert_layer -> true
+    | All | Property _ | Var _ -> false
   in
   if List.length values > 1 && List.exists singleton_only values then
     Cursor.err_invalid t "transition-property singleton value in list";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4295,6 +4295,13 @@ let spec_remaining_prop_vectors () =
       ("resize: block", "resize:block");
       ( "transition-property: opacity, display",
         "transition-property:opacity,display" );
+      (* CSS Transitions 1 sec. 2.1: none | <single-transition-property>#, where
+         <single-transition-property> is [all | <custom-ident>]. The exclusion
+         clause names none, inherit and initial as the values a list of more
+         than one may not hold; all is not among them. *)
+      ("transition-property: all, opacity", "transition-property:all,opacity");
+      ("transition-property: opacity, all", "transition-property:opacity,all");
+      ("transition-property: all, all", "transition-property:all,all");
       ("animation-composition: add", "animation-composition:add");
       ("animation-range-start: entry 10%", "animation-range-start:entry 10%");
       ("animation-range-end: exit 90%", "animation-range-end:exit 90%");
@@ -4418,6 +4425,8 @@ let spec_remaining_prop_vectors () =
       "touch-action: pan-x pan-left";
       "resize: block inline both";
       "transition-property: none, opacity";
+      "transition-property: opacity, none";
+      "transition-property: inherit, opacity";
       "animation-composition: add replace";
       "animation-range-start: exit entry";
       "view-timeline-inset: auto auto auto";


### PR DESCRIPTION
CSS Transitions 1 sec. 2.1 gives `transition-property` as `none | <single-transition-property>#`, where `<single-transition-property>` is `all | <custom-ident>`. Its exclusion clause names `none`, `inherit` and `initial` as what a list of more than one may not hold. cascade grouped `all` with those, so `transition-property: all, opacity` was dropped. Chrome accepts it, and `all, all` too.