### PR TITLE
shadow: keep the length run contiguous

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- A shadow whose colour or `inset` interrupts the length run is refused, and
+  `text-shadow` refuses a fourth length or a second colour rather than
+  dropping it (#890).
+
 - `transition-property` keeps `all` beside another property, so
   `transition-property: all, opacity` parses. `none` and the CSS-wide
   keywords are still refused in a list (#889).

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -72,7 +72,6 @@ module Shadow = struct
         | Some l ->
             lengths_rev := l :: !lengths_rev;
             Cursor.ws t;
-            let _ : bool = try_inset () in
             read_lengths_loop (n + 1)
         | None -> ()
     in

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -2033,12 +2033,40 @@ let rec read_text_shadow t : text_shadow =
     ]
     ~calls:[ ("var", read_var) ]
     ~default:(fun t ->
-      let components, _ = Cursor.many Text_shadow.read_component t in
-      let lengths, color = Text_shadow.fold_components components in
-      match lengths with
+      (* CSS Text Decoration 3 sec. 5: [<color>? && <length>{2,3}]. The && puts
+         the colour on either side of the length run but never inside it, and
+         caps the run at three: there is no spread slot to hold a fourth. *)
+      let color : color option ref = ref (Option.None : color option) in
+      let try_color () =
+        match !color with
+        | Option.Some _ -> ()
+        | Option.None -> (
+            match Cursor.option (fun t -> read_color t) t with
+            | Option.Some c ->
+                color := Option.Some c;
+                Cursor.ws t
+            | Option.None -> ())
+      in
+      try_color ();
+      let lengths_rev = ref [] in
+      let rec read_lengths_loop n =
+        if n >= 3 then ()
+        else
+          match Cursor.option (fun t -> read_length t) t with
+          | Option.Some l ->
+              lengths_rev := l :: !lengths_rev;
+              Cursor.ws t;
+              read_lengths_loop (n + 1)
+          | Option.None -> ()
+      in
+      read_lengths_loop 0;
+      try_color ();
+      match List.rev !lengths_rev with
       | h :: v :: rest ->
-          let blur = match rest with b :: _ -> Some b | _ -> None in
-          (Text_shadow { h_offset = h; v_offset = v; blur; color }
+          let blur =
+            match rest with b :: _ -> Option.Some b | _ -> Option.None
+          in
+          (Text_shadow { h_offset = h; v_offset = v; blur; color = !color }
             : text_shadow)
       | _ -> err_invalid_value t "text-shadow" "expected at least two lengths")
     t

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2346,6 +2346,22 @@ let list_properties () =
   neg_cursor read_declaration "box-shadow: 0";
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
+  (* CSS Backgrounds 3 sec. 6.1 and CSS Text Decoration 3 sec. 5 both build a
+     shadow with &&, so the length run is contiguous and neither the colour nor
+     inset may sit inside it. text-shadow takes three lengths, not four, and one
+     colour. *)
+  check_declaration ~expected:"text-shadow:1px 1px red"
+    "text-shadow: red 1px 1px";
+  check_declaration ~expected:"text-shadow:1px 1px 2px"
+    "text-shadow: 1px 1px 2px";
+  neg_cursor read_declaration "text-shadow: 1px red 1px";
+  neg_cursor read_declaration "text-shadow: 1px 1px 1px 1px";
+  neg_cursor read_declaration "text-shadow: 1px 1px red 1px";
+  neg_cursor read_declaration "text-shadow: red 1px 1px blue";
+  check_declaration ~expected:"box-shadow:inset 1px 1px"
+    "box-shadow: 1px 1px inset";
+  neg_cursor read_declaration "box-shadow: 1px inset 1px";
+  neg_cursor read_declaration "box-shadow: 1px red 1px";
   check_declaration ~expected:"box-shadow:0 1px 3px rgb(0 0 0/.12)"
     ~optimized:"box-shadow:0 1px 3px #0000001f"
     "box-shadow: 0 1px 3px rgba(0,0,0,0.12)";


### PR DESCRIPTION
A shadow is built with `&&`, so the colour and `inset` sit on either side of the length run and never inside it. Both readers accepted `box-shadow: 1px inset 1px` and `text-shadow: 1px red 1px`, which Chrome rejects.

`text-shadow` was worse: it read a fourth length and a second colour into slots `Css.text_shadow` has not got, so `text-shadow: 1px 1px 1px 1px` parsed and silently came back as `1px 1px 1px`.

CSS Text Decoration 4 sec. 4 does give text-shadow a spread and `inset`, but no engine implements that, so this follows the level 3 grammar the browsers and the shared inventory manifest both use.