### PR TITLE
color-scheme: bound only to one occurrence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- `color-scheme` refuses a repeated `only`, so `color-scheme: only light only`
+  no longer parses (#891).
+
 - A shadow whose colour or `inset` interrupts the length run is refused, and
   `text-shadow` refuses a fourth length or a second colour rather than
   dropping it (#890).

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -1159,12 +1159,13 @@ let color_scheme_of_idents t names : color_scheme =
       if has_css_wide then
         Cursor.err_invalid t
           "color-scheme: CSS-wide keyword cannot be mixed with other keywords";
-      let non_only_names =
-        List.filter (fun n -> String.lowercase_ascii n <> "only") names
-      in
+      let is_only n = String.equal (String.lowercase_ascii n) "only" in
+      let non_only_names = List.filter (fun n -> not (is_only n)) names in
       if non_only_names = [] then
         Cursor.err_invalid t
           "color-scheme: [only] must be combined with a color scheme";
+      if List.length (List.filter is_only names) > 1 then
+        Cursor.err_invalid t "color-scheme: [only] cannot be repeated";
       Custom names
 
 let rec read_color_scheme t : color_scheme =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4450,6 +4450,8 @@ let spec_remaining_prop_vectors () =
       "position-visibility: anchors-visible always";
       "accent-color: auto red";
       "color-scheme: only only";
+      "color-scheme: only light only";
+      "color-scheme: only dark only";
       "forced-color-adjust: auto none";
       "print-color-adjust: exact economy";
       "isolation: isolate auto";


### PR DESCRIPTION
CSS Color Adjust 1 sec. 2.2 gives `color-scheme` as `normal | [ light | dark | <custom-ident> ]+ && only?`, so `only` appears at most once. The reader checked that `only` accompanied a scheme but never that it appeared once, so `color-scheme: only light only` parsed as a custom-ident list. Chrome rejects it.