### PR TITLE
fuzz: mutate with a keyword no property takes twice

### DIFF
--- a/fuzz/fuzz_properties.ml
+++ b/fuzz/fuzz_properties.ml
@@ -712,13 +712,21 @@ let invalid_property_mutation
        token/substitution layer instead. *)
     pick [ "var()"; value ^ " attr()"; value ^ " env()" ] buf 4
   else
+    (* A negative is invalid as a whole value, which does not make it invalid
+       after a positive one: in a && or || grammar it is often exactly the
+       component the positive was missing, as [text-indent: 10% hanging] is. CSS
+       Cascade 5 sec. 7.3 gives a trailing mutation that holds for every
+       property instead, since a CSS-wide keyword is the whole value or
+       nothing. *)
     match byte_at buf 4 mod 6 with
     | 0 -> pick row.negatives buf 5
     | 1 -> "initial " ^ value
     | 2 -> "inherit " ^ value
     | 3 -> "var()"
     | 4 -> value ^ " )"
-    | _ -> value ^ " " ^ pick row.negatives buf 6
+    | _ ->
+        value ^ " "
+        ^ pick [ "initial"; "inherit"; "unset"; "revert"; "revert-layer" ] buf 6
 
 let var_token_stream_fallback buf =
   pick

--- a/test/spec/inventory/property_grammar.mli
+++ b/test/spec/inventory/property_grammar.mli
@@ -8,7 +8,12 @@ type row = {
 }
 
 val rows : row list
-(** Spec-derived positive and negative vectors for every modeled property. *)
+(** Spec-derived positive and negative vectors for every modeled property.
+
+    A negative is invalid as a complete value. It may still be a valid
+    component: in a [&&] or [||] grammar, [hanging] is no [text-indent] on its
+    own and a perfectly good one after a length. Generators must not assume that
+    appending a negative to a positive yields an invalid declaration. *)
 
 val property_names : string list
 (** [property_names] is the unique modeled property names covered by rows. *)


### PR DESCRIPTION
The inventory mutation appended a manifest negative to a positive and expected the result to be invalid. A negative is invalid as a whole value, which does not make it invalid after a positive one: in a `&&` or `||` grammar it is often exactly the component the positive was missing, so `text-indent: 10% hanging`, `color-scheme: dark only` and `grid-column-start: 1 span` were all reported as parser bugs when Chrome accepts them.

CSS Cascade 5 sec. 7.3 makes a CSS-wide keyword the whole value or nothing, so a trailing one is invalid for every property. Verified against all 455 rows.