### PR TITLE
test: pin an unmatched at-rule condition as preserved

### DIFF
--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -1066,14 +1066,12 @@ let test_invalid_atrule_descriptor buf =
         "@position-try default { top: 0; }";
         "@position-try --fallback { @media screen { .x { color: red } } }";
         "@namespace svg;";
-        "@container () { .x { color: red } }";
         "@container style() { .x { color: red } }";
         "@container scroll-state() { .x { color: red } }";
         "@scope () { .x { color: red } }";
         "@scope (.x) to () { .x { color: red } }";
         "@starting-style;";
         "@media screen and { .x { color: red } }";
-        "@media (width >= ) { .x { color: red } }";
         "@supports not { .x { color: red } }";
         "@supports (display: grid) and (color: red) or (width: 1px) { .x { \
          color: red } }";

--- a/test/spec/inventory/at_rule_grammar.ml
+++ b/test/spec/inventory/at_rule_grammar.ml
@@ -17,6 +17,9 @@ let positive =
       "@supports font-format(\"woff2\") { .x { color: red } }";
     row "container" "general-enclosed-empty" "@container(){.x{color:red}}"
       "@container () { .x { color: red } }";
+    row "media" "general-enclosed-incomplete-comparison"
+      "@media(width >= ){.x{color:red}}"
+      "@media (width >= ) { .x { color: red } }";
     row "media" "general-enclosed-interval"
       "@media(30em < width > 60em){.x{color:red}}"
       "@media (30em < width > 60em) { .x { color: red } }";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -3843,6 +3843,11 @@ let spec_current_at_rules () =
     "@page chapter:left { margin: 2cm }";
   check_stylesheet ~expected:"@media(width >){.x{color:red}}"
     "@media (width >) { .x { color: red } }";
+  (* Mediaqueries 5 sec. 3.1 sends a condition no grammar claims to
+     <general-enclosed>, which a parser keeps and never matches. Chrome keeps
+     both of these in cssText for the same reason. *)
+  check_stylesheet ~expected:"@media(width >= ){.x{color:red}}"
+    "@media (width >= ) { .x { color: red } }";
   check_stylesheet ~expected:"@supports selector(){.x{color:red}}"
     "@supports selector() { .x { color: red } }";
   neg_cursor read "@scope (.card) .title { color: red }";


### PR DESCRIPTION
`@container ()` and `@media (width >= )` are `<general-enclosed>`: a parser keeps the condition and never matches it. Chrome keeps both in `cssText`, the shared at-rule inventory lists the first as a positive, and #867 and #869 made cascade preserve them. The fuzz vector list still called them invalid.

No behaviour change; both are now pinned deterministically as well.