### PR TITLE
cursor: read an empty url the lexer closed at EOF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- A `url(` that runs into the end of the input reads as the empty url the
+  spec ends it as, instead of dropping the declaration (#894).
+
 - `color-scheme` refuses a repeated `only`, so `color-scheme: only light only`
   no longer parses (#891).
 

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -602,10 +602,9 @@ let url_from_func t (fn : Component.func Component.node) =
 
 let url t =
   match peek t with
-  | Some (Component.Preserved { kind = Token.Url ""; loc }) ->
-      if loc.end_pos - loc.start_pos < 5 then err_expected t "url argument";
-      skip t;
-      ""
+  (* CSS Syntax 3 (ED) sec. 4.3.6 ends a url token at EOF as it does at [)], the
+     missing closer a parse error and nothing more, so the shorter span of
+     [url(] is still a url token holding the empty string. *)
   | Some (Component.Preserved { kind = Token.Url s; _ }) ->
       skip t;
       s

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2346,6 +2346,13 @@ let list_properties () =
   neg_cursor read_declaration "box-shadow: 0";
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
+
+  (* CSS Syntax 3 sec. 4.3.6 ends a url token at EOF as it does at [)]: the
+     missing closer is a parse error and the token still reads. *)
+  check_declaration ~expected:"background-image:url()" "background-image:url(";
+  check_declaration ~expected:"background-image:url(foo)"
+    "background-image:url(foo";
+  check_declaration ~expected:"background-image:url()" "background-image:url()";
   (* CSS Backgrounds 3 sec. 6.1 and CSS Text Decoration 3 sec. 5 both build a
      shadow with &&, so the length run is contiguous and neither the colour nor
      inset may sit inside it. text-shadow takes three lengths, not four, and one


### PR DESCRIPTION
CSS Syntax 3 sec. 4.3.6 ends a url token at EOF as it does at the closing paren, the missing closer a parse error and nothing more. The reader measured the token's source span to tell `url()` from `url(`, which rejected the only spelling a short span can mean, so `background-image: url(` dropped the declaration. Chrome reads it as `url("")`.

Closes the `unclosed-url-at-eof.html` port in the WPT css-syntax corpus.