### PR TITLE
stylesheet: recover a bad nested rule past its block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- An invalid nested rule is dropped on its own, leaving the rule that holds
+  it and the rules written after it in place (#895).
+
 - A `url(` that runs into the end of the input reads as the empty url the
   spec ends it as, instead of dropping the declaration (#894).
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3733,6 +3733,11 @@ let read_property_rule (r : Cursor.t) : statement =
 (* Does the item ahead hold a curly block before its terminating [;]? Then it is
    a nested rule, not a declaration, however much its prelude looks like one.
    Leaves the cursor where it found it. *)
+(* CSS Syntax 3 (ED) sec. 5.5.3 consumes a qualified rule whole, block and all,
+   before deciding it is invalid, so sec. 5.5.5 resumes right after that block.
+   Recovering a rule to the next semicolon, which is what sec. 5.5.6 does for a
+   bad declaration, would take the items written after it. The caller rewinds
+   first so the item is skipped from its start. *)
 let item_opens_block inner =
   let start = Cursor.save inner in
   let rec scan () =
@@ -3747,6 +3752,14 @@ let item_opens_block inner =
   let found = scan () in
   Cursor.restore inner start;
   found
+
+let skip_invalid_nesting_item r =
+  if item_opens_block r then (
+    skip_past_rule r;
+    Error.Recovery.Rule)
+  else (
+    Cursor.skip_past_semicolon r;
+    Error.Recovery.Declaration)
 
 (* Discard an at-rule that is invalid in a style rule and resume at the next
    item, the recovery CSS Syntax 3 (ED) sec. 5.5.5 describes. The warning is
@@ -4032,9 +4045,10 @@ and read_nesting_block (r : Cursor.t) : block =
     match read_nesting_item ~prev:acc r with
     | item -> add_item acc item
     | exception Error.Parse_error e ->
-        Cursor.skip_past_semicolon r;
+        Cursor.restore r start;
+        let construct = skip_invalid_nesting_item r in
         Cursor.push_warning r
-          ~recovery:(Cursor.dropped_since r start Error.Recovery.Declaration)
+          ~recovery:(Cursor.dropped_since r start construct)
           e;
         read_items acc
   and add_item acc = function
@@ -4219,9 +4233,10 @@ and read_recovering_rule_item selector inner loop decls nested =
   | `Done result -> result
   | `Continue (decls, nested) -> loop decls nested
   | exception Error.Parse_error e ->
-      Cursor.skip_past_semicolon inner;
+      Cursor.restore inner start;
+      let construct = skip_invalid_nesting_item inner in
       Cursor.push_warning inner
-        ~recovery:(Cursor.dropped_since inner start Error.Recovery.Declaration)
+        ~recovery:(Cursor.dropped_since inner start construct)
         e;
       loop decls nested
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4217,6 +4217,22 @@ let test_nesting_check_stylesheet () =
   check_stylesheet ~expected:".a{& .b{& .c{color:red}}}"
     ".a { & .b { & .c { color: red; } } }"
 
+(* CSS Syntax 3 sec. 5.5.3 consumes a qualified rule whole, block and all,
+   before deciding it is invalid, so sec. 5.5.5 resumes right after that block.
+   Recovering to the next semicolon, which is what sec. 5.5.6 does for a bad
+   declaration, would take every item written after the bad rule and the parent
+   with them. *)
+let nesting_invalid_rule_recovery () =
+  (* Each expectation is what the same sheet gives with the bad rule deleted:
+     dropping it costs the parent nothing and the items around it nothing. *)
+  lenient_recover "invalid nested rule before a good one"
+    ".a { .b <::::invalid::::> {} & .c { color: red } }" ".a .c{color:red}" 1;
+  lenient_recover "invalid nested rule after a good one"
+    ".a { & .c { color: red } .b <::::invalid::::> {} }" ".a .c{color:red}" 1;
+  lenient_recover "invalid nested rule between declarations"
+    ".a { color: red; .b <::::invalid::::> {} & .c { color: blue } }"
+    ".a{color:red;.c{color:#00f}}" 1
+
 (* A nested @layer holds nesting content: bare declarations belong to the parent
    selector, exactly as in @media/@supports. Blink and WebKit both read
    [.a{@layer n{color:red}}] as a layer block wrapping nested declarations. *)
@@ -9297,6 +9313,7 @@ let additional_tests =
     ("nesting deeply nested", `Quick, test_nesting_deep);
     ("nesting with declarations", `Quick, test_nesting_with_declarations);
     ("nesting check_stylesheet", `Quick, test_nesting_check_stylesheet);
+    ("nesting invalid rule recovery", `Quick, nesting_invalid_rule_recovery);
     ( "spec nesting selector and conditional edges",
       `Quick,
       spec_nesting_selector_edges );


### PR DESCRIPTION
CSS Syntax 3 sec. 5.5.3 consumes a qualified rule whole, block and all, before deciding it is invalid, so sec. 5.5.5 resumes right after that block. Recovery ran to the next semicolon instead, which is what sec. 5.5.6 does for a bad declaration and which a rule has not got, so `.a { .b <::::invalid::::> {} & .c {} }` lost `& .c` and `.a` with it.

Closes the `invalid-nested-rules.html` port in the WPT css-syntax corpus.