### PR TITLE
lexer: gate unicode ranges behind the flag that allows them

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- A unicode range is tokenised only in the `unicode-range` descriptor it
+  belongs to, so `u+a` is the selector it reads as everywhere else (#896).
+
 - An invalid nested rule is dropped on its own, leaving the rule that holds
   it and the rules written after it in place (#895).
 

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -63,9 +63,9 @@ let lex_to_cv_list parser =
    which is what the lexer indexes against. Using the caller's raw string would
    desync [Loc.offset] from [Loc.snippet] when the input contains BOM, NUL, CR,
    FF, or CRLF. *)
-let of_string ?(meta = Loc.default_meta_level) s =
+let of_string ?(meta = Loc.default_meta_level) ?unicode_ranges s =
   let reader = Reader.of_string s in
-  let parser = Parser.of_reader reader in
+  let parser = Parser.of_reader ?unicode_ranges reader in
   {
     cvs = lex_to_cv_list parser;
     source = Some (Reader.source reader);

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -60,9 +60,11 @@ val drain_warnings : t -> Error.t list
 (** [drain_warnings t] returns and clears the warnings accumulated on [t] in
     source order. *)
 
-val of_string : ?meta:Loc.meta_level -> string -> t
-(** [of_string ?meta s] lexes [s] into a {!Component.t} list and wraps it. The
-    trailing [Eof] token is dropped. *)
+val of_string : ?meta:Loc.meta_level -> ?unicode_ranges:bool -> string -> t
+(** [of_string ?meta ?unicode_ranges s] lexes [s] into a {!Component.t} list and
+    wraps it. The trailing [Eof] token is dropped. [unicode_ranges] is passed to
+    {!Lexer.of_reader}, and only the value of a [unicode-range] descriptor sets
+    it. *)
 
 val of_reader : ?meta:Loc.meta_level -> Reader.t -> t
 (** [of_reader ?meta r] consumes the rest of [r]'s input as a component stream

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -282,7 +282,7 @@ let context_for ?(kept = []) visible =
   Context.v ~custom_properties:(List.rev visible.decls)
     ~runtime_vars:(runtime_var_names kept) ()
 
-let read_custom_components read = function
+let read_custom_components ?(unicode_ranges = false) read = function
   | Declaration.Declaration
       {
         property = Properties.Custom_property _;
@@ -290,9 +290,15 @@ let read_custom_components read = function
         _;
       } -> (
       try
+        let components = Properties.components_of_custom_property_value value in
         let cursor =
-          Cursor.of_components
-            (Properties.components_of_custom_property_value value)
+          (* CSS Syntax 3 (ED) sec. 5.5.11: a custom property holds the tokens
+             it was written with, lexed without unicode ranges. A descriptor
+             that asks for them reads the substituted text afresh. *)
+          if unicode_ranges then
+            Cursor.of_string ~unicode_ranges:true
+              (Parser.to_string_minified components)
+          else Cursor.of_components components
         in
         let parsed = read cursor in
         Cursor.ws cursor;
@@ -301,9 +307,9 @@ let read_custom_components read = function
       with Cursor.Parse_error _ -> None)
   | _ -> None
 
-let lookup_visible_custom visible name read =
+let lookup_visible_custom ?unicode_ranges visible name read =
   List.find_map
-    (fun (_, decl) -> read_custom_components read decl)
+    (fun (_, decl) -> read_custom_components ?unicode_ranges read decl)
     (named visible name)
 
 let custom_value_components = function
@@ -594,15 +600,17 @@ let simplify_font_src_descriptor visible entries =
    [leaf] receives the walk so a value nesting its own type carries the same
    [visited] set inwards; without that a reference reachable both directly and
    through the nesting would not terminate. *)
-let simplify_nested_var visible ~read ~(as_var : 'a -> 'a Values.var option)
-    ~(of_var : 'a Values.var -> 'a)
+let simplify_nested_var ?unicode_ranges visible ~read
+    ~(as_var : 'a -> 'a Values.var option) ~(of_var : 'a Values.var -> 'a)
     ~(leaf :
        (visited:string list -> 'a -> 'a) -> visited:string list -> 'a -> 'a)
     (value : 'a) : 'a =
   let rec simplify ~visited (value : 'a) : 'a =
     match as_var value with
     | Some var when not (List.mem var.Values.name visited) -> (
-        match lookup_visible_custom visible var.Values.name read with
+        match
+          lookup_visible_custom ?unicode_ranges visible var.Values.name read
+        with
         | Some found -> simplify ~visited:(var.Values.name :: visited) found
         | None -> (
             (* Nothing defines the name: CSS Variables 1 sec. 3 falls back to
@@ -617,13 +625,14 @@ let simplify_nested_var visible ~read ~(as_var : 'a -> 'a Values.var option)
   simplify ~visited:[] value
 
 (* The common case: the value is flat, so a non-[Var] holds no reference. *)
-let simplify_typed_var visible ~read ~as_var ~of_var value =
-  simplify_nested_var visible ~read ~as_var ~of_var
+let simplify_typed_var ?unicode_ranges visible ~read ~as_var ~of_var value =
+  simplify_nested_var ?unicode_ranges visible ~read ~as_var ~of_var
     ~leaf:(fun _simplify ~visited:_ value -> value)
     value
 
 let simplify_unicode_range_descriptor visible =
-  simplify_typed_var visible ~read:Properties.read_unicode_range
+  simplify_typed_var ~unicode_ranges:true visible
+    ~read:Properties.read_unicode_range
     ~as_var:(function Properties.Var v -> Some v | _ -> None)
     ~of_var:(fun v -> (Properties.Var v : Properties.unicode_range))
 

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -12,6 +12,10 @@ type comment = { loc : Loc.t; terminated : bool }
 type t = {
   reader : Reader.t;
   on_comment : (comment -> unit) option;
+  (* CSS Syntax 3 (ED) sec. 4.3.1 takes "unicode ranges allowed", defaulting to
+     false; sec. 4.3.14 names its one caller, the value of a unicode-range
+     descriptor. With it unset, [u+a] is an ident, a delim and an ident. *)
+  mutable unicode_ranges : bool;
   (* Token buffer: most-recently-pushed-back at the head. [next] takes from here
      before falling through to the reader. *)
   mutable buffer : Token.t list;
@@ -23,11 +27,16 @@ type t = {
 
 and save = { trace : Token.t list ref; saved_history : Token.t list }
 
-let of_reader ?on_comment reader =
-  { reader; on_comment; buffer = []; history = []; saves = [] }
+let of_reader ?on_comment ?(unicode_ranges = false) reader =
+  { reader; on_comment; unicode_ranges; buffer = []; history = []; saves = [] }
 
-let of_string ?enforce_spec ?on_comment s =
-  of_reader ?on_comment (Reader.of_string ?enforce_spec s)
+let of_string ?enforce_spec ?on_comment ?unicode_ranges s =
+  of_reader ?on_comment ?unicode_ranges (Reader.of_string ?enforce_spec s)
+
+let with_unicode_ranges t f =
+  let saved = t.unicode_ranges in
+  t.unicode_ranges <- true;
+  Fun.protect ~finally:(fun () -> t.unicode_ranges <- saved) f
 
 let source t = Reader.source t.reader
 
@@ -676,7 +685,8 @@ let consume_name_start_or_delim ~force_url_function r c =
     Reader.skip r;
     Delim (String.make 1 c))
 
-let next_token ?(force_url_function = false) ?on_comment r =
+let next_token ?(force_url_function = false) ?(unicode_ranges = false)
+    ?on_comment r =
   skip_comment_run on_comment r;
   let b = Reader.peek_byte r in
   if b = -1 then Eof
@@ -741,7 +751,7 @@ let next_token ?(force_url_function = false) ?on_comment r =
           Reader.skip r;
           Close Curly
       | c when is_digit c -> consume_numeric_token r
-      | ('U' | 'u') when would_start_unicode_range r ->
+      | ('U' | 'u') when unicode_ranges && would_start_unicode_range r ->
           consume_unicode_range_token r
       | c when is_name_start_ascii c || c >= '\x80' ->
           consume_name_start_or_delim ~force_url_function r c
@@ -752,9 +762,12 @@ let next_token ?(force_url_function = false) ?on_comment r =
 (** {1 Stream API (uniform with other stages)} *)
 
 (* Wrap a tokenizer step with source-location capture. *)
-let tokenize_with_loc ?(force_url_function = false) ?on_comment reader =
+let tokenize_with_loc ?(force_url_function = false) ?(unicode_ranges = false)
+    ?on_comment reader =
   let start_pos = Reader.position reader in
-  let kind = next_token ~force_url_function ?on_comment reader in
+  let kind =
+    next_token ~force_url_function ~unicode_ranges ?on_comment reader
+  in
   let end_pos = Reader.position reader in
   Token.v ~kind ~loc:(Loc.v ~start_pos ~end_pos)
 
@@ -792,7 +805,7 @@ let next t =
   | [] ->
       let tok =
         tokenize_with_loc ~force_url_function:(force_url_function t)
-          ?on_comment:t.on_comment t.reader
+          ~unicode_ranges:t.unicode_ranges ?on_comment:t.on_comment t.reader
       in
       record_consume t tok;
       tok
@@ -803,7 +816,7 @@ let peek t =
   | [] ->
       let tok =
         tokenize_with_loc ~force_url_function:(force_url_function t)
-          ?on_comment:t.on_comment t.reader
+          ~unicode_ranges:t.unicode_ranges ?on_comment:t.on_comment t.reader
       in
       t.buffer <- [ tok ];
       tok

--- a/lib/lexer.mli
+++ b/lib/lexer.mli
@@ -16,15 +16,29 @@ type comment = { loc : Loc.t; terminated : bool }
     [false]. Comments remain absent from the token stream as CSS Syntax
     requires; this record is an opt-in tooling hook. *)
 
-val of_reader : ?on_comment:(comment -> unit) -> Reader.t -> t
-(** [of_reader ?on_comment r] wraps an existing character reader. [on_comment]
-    observes each consumed comment exactly once. *)
+val of_reader :
+  ?on_comment:(comment -> unit) -> ?unicode_ranges:bool -> Reader.t -> t
+(** [of_reader ?on_comment ?unicode_ranges r] wraps an existing character
+    reader. [on_comment] observes each consumed comment exactly once.
+    [unicode_ranges] is CSS Syntax 3 (ED) sec. 4.3.1's "unicode ranges allowed",
+    defaulting to [false]: sec. 4.3.14 names its one caller, the value of a
+    [unicode-range] descriptor, so everywhere else [u+a] is an ident, a delim
+    and an ident. *)
 
 val of_string :
-  ?enforce_spec:bool -> ?on_comment:(comment -> unit) -> string -> t
+  ?enforce_spec:bool ->
+  ?on_comment:(comment -> unit) ->
+  ?unicode_ranges:bool ->
+  string ->
+  t
 (** [of_string s] builds a fresh reader from an already-decoded UTF-8 string and
-    wraps it. [enforce_spec] is passed to {!Reader.of_string}; [on_comment] has
-    the meaning documented on {!of_reader}. *)
+    wraps it. [enforce_spec] is passed to {!Reader.of_string}; [on_comment] and
+    [unicode_ranges] have the meaning documented on {!of_reader}. *)
+
+val with_unicode_ranges : t -> (unit -> 'a) -> 'a
+(** [with_unicode_ranges t f] runs [f] with CSS Syntax 3 (ED) sec. 4.3.1's
+    "unicode ranges allowed" set, restoring it afterwards. Sec. 5.5.11 is the
+    one caller: the value of a [unicode-range] descriptor. *)
 
 val source : t -> string
 (** [source t] is the full input string the underlying reader was built from. *)

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -10,8 +10,8 @@ open Syntax
 type t = { lexer : Lexer.t; mutable lookback : Component.t option }
 
 let of_lexer lexer = { lexer; lookback = None }
-let of_reader r = of_lexer (Lexer.of_reader r)
-let of_string s = of_reader (Reader.of_string s)
+let of_reader ?unicode_ranges r = of_lexer (Lexer.of_reader ?unicode_ranges r)
+let of_string ?unicode_ranges s = of_reader ?unicode_ranges (Reader.of_string s)
 
 (** {1 section 5.3 algorithms operating on a {!Lexer.t}} *)
 
@@ -1225,7 +1225,13 @@ let skip_bad_declaration lexer tok =
   skip (Component.source_loc (consume_component_value_from lexer tok))
 
 let consume_decl_from_ident ~meta lexer ~warnings ~name ~name_loc =
-  let body = consume_declaration_body lexer in
+  (* CSS Syntax 3 (ED) sec. 5.5.11: the value of a unicode-range descriptor is
+     the one place in the language the tokenizer is asked for unicode ranges. *)
+  let body =
+    if String.equal (String.lowercase_ascii name) "unicode-range" then
+      Lexer.with_unicode_ranges lexer (fun () -> consume_declaration_body lexer)
+    else consume_declaration_body lexer
+  in
   match declaration_of_buffer ~meta lexer ~name ~name_loc ~warnings body with
   | Some d -> Some (`Decl d)
   | None -> None

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -11,11 +11,12 @@ type t
 val of_lexer : Lexer.t -> t
 (** [of_lexer l] wraps an existing lexer stream. *)
 
-val of_reader : Reader.t -> t
-(** [of_reader r] builds a lexer from [r] and wraps it. *)
+val of_reader : ?unicode_ranges:bool -> Reader.t -> t
+(** [of_reader ?unicode_ranges r] builds a lexer from [r] and wraps it.
+    [unicode_ranges] is passed to {!Lexer.of_reader}. *)
 
-val of_string : string -> t
-(** [of_string s] builds a fresh reader and lexer from [s]. *)
+val of_string : ?unicode_ranges:bool -> string -> t
+(** [of_string ?unicode_ranges s] builds a fresh reader and lexer from [s]. *)
 
 (** {1 Stream API} *)
 

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2378,11 +2378,22 @@ let read_font_stretch_descriptor r =
         Font_stretch_range (first, second))
     r
 
+(* CSS Syntax 3 (ED) sec. 4.3.14: this descriptor's value is the one place in
+   the language the tokenizer is asked for unicode ranges, so re-lex it with the
+   flag the rest of the sheet is read without. *)
 let read_unicode_range_descriptor r =
   read_descriptor_value
     (fun cur ->
-      Cursor.list ~at_least:1 ~sep:Cursor.comma Properties.read_unicode_range
-        cur)
+      let raw = Cursor.consume_to_decl_end ~trim:true cur in
+      let inner = Cursor.of_string ~unicode_ranges:true raw in
+      let values =
+        Cursor.list ~at_least:1 ~sep:Cursor.comma Properties.read_unicode_range
+          inner
+      in
+      Cursor.ws inner;
+      if not (Cursor.is_done inner) then
+        Cursor.err_invalid cur "unicode-range trailing tokens";
+      values)
     (fun vs -> Unicode_range vs)
     r
 

--- a/test/helpers/css_test_helpers.ml
+++ b/test/helpers/css_test_helpers.ml
@@ -74,15 +74,15 @@ let check_error parse input expected =
     applies [parse], pretty-prints with [pp_func], and asserts the result equals
     the spec-derived [input] or [expected]. Use this for parsers whose signature
     is [Cursor.t -> 'a]. *)
-let check_value_cursor type_name parse pp_func ?(minify = true)
+let check_value_cursor ?unicode_ranges type_name parse pp_func ?(minify = true)
     ?(roundtrip = false) ?expected input =
   let expected = Option.value ~default:input expected in
-  let c = Cursor.of_string input in
+  let c = Cursor.of_string ?unicode_ranges input in
   let v = parse c in
   let s = Css.Pp.to_string ~minify pp_func v in
   Alcotest.(check string) (Fmt.str "%s %s" type_name input) expected s;
   if roundtrip then
-    let c2 = Cursor.of_string s in
+    let c2 = Cursor.of_string ?unicode_ranges s in
     let v2 = parse c2 in
     let s2 = Css.Pp.to_string ~minify pp_func v2 in
     Alcotest.(check string) (Fmt.str "roundtrip %s %s" type_name input) s s2

--- a/test/helpers/css_test_helpers.mli
+++ b/test/helpers/css_test_helpers.mli
@@ -52,6 +52,7 @@ val check_error : (Cursor.t -> 'a) -> string -> string -> unit
     [expected]. Use to pin down error shape exactly. *)
 
 val check_value_cursor :
+  ?unicode_ranges:bool ->
   string ->
   (Cursor.t -> 'a) ->
   'a Css.Pp.t ->

--- a/test/spec/inventory/syntax_grammar.ml
+++ b/test/spec/inventory/syntax_grammar.ml
@@ -6,7 +6,11 @@ let parser branch input = { branch; input }
 
 let token_rows =
   [
-    token "unicode range wildcard" "U+4??" [ "<unicode-range U+400-4FF>" ];
+    (* CSS Syntax 3 sec. 4.3.1 leaves "unicode ranges allowed" unset outside the
+       value of a unicode-range descriptor (sec. 4.3.14), so this is what the
+       tokenizer gives everywhere else. *)
+    token "unicode range wildcard" "U+4??"
+      [ "<ident U>"; "<number +4>"; "<delim '?'>"; "<delim '?'>" ];
     token "bad string newline" "\"oops\n" [ "<bad-string>"; "<ws>" ];
     token "bad url whitespace" "url(a b) foo"
       [ "<bad-url>"; "<ws>"; "<ident foo>" ];

--- a/test/test_lexer.ml
+++ b/test/test_lexer.ml
@@ -2,8 +2,8 @@
 
 open Cascade
 
-let tokens_of ?enforce_spec css =
-  let lexer = Lexer.of_string ?enforce_spec css in
+let tokens_of ?enforce_spec ?unicode_ranges css =
+  let lexer = Lexer.of_string ?enforce_spec ?unicode_ranges css in
   let rec loop acc =
     let tok = Lexer.next lexer in
     match tok.Token.kind with
@@ -15,9 +15,14 @@ let tokens_of ?enforce_spec css =
 let pp_tokens kinds =
   String.concat " " (List.map (Css.Pp.to_string Token.pp_kind) kinds)
 
-let check ?enforce_spec input expected_summary =
-  let got = pp_tokens (tokens_of ?enforce_spec input) in
+let check ?enforce_spec ?unicode_ranges input expected_summary =
+  let got = pp_tokens (tokens_of ?enforce_spec ?unicode_ranges input) in
   Alcotest.(check string) (Fmt.str "tokenize %S" input) expected_summary got
+
+(* CSS Syntax 3 sec. 4.3.14: the tokenizer produces a unicode-range only for the
+   value of a unicode-range descriptor, so these vectors ask for it. *)
+let check_range input expected_summary =
+  check ~unicode_ranges:true input expected_summary
 
 let check_first_hash input expected_value expected_flag =
   match tokens_of input with
@@ -72,15 +77,15 @@ let spec_token_railroad_diagrams () =
 
 let spec_unicode_range_tokens () =
   (* CSS Syntax Level 3 sections 4.1, 4.3.11, and 4.3.14. *)
-  check "U+26" "<unicode-range U+26>";
-  check "u+0-7f" "<unicode-range U+0-7F>";
-  check "U+0025-00FF" "<unicode-range U+25-FF>";
-  check "U+4??" "<unicode-range U+400-4FF>";
-  check "U+10????" "<unicode-range U+100000-10FFFF>";
-  check "U+??????" "<unicode-range U+0-FFFFFF>";
-  check "U+1234567" "<unicode-range U+123456> <number 7>";
-  check "U+12??-f" "<unicode-range U+1200-12FF> <ident -f>";
-  check "u+???????" "<unicode-range U+0-FFFFFF> <delim '?'>";
+  check_range "U+26" "<unicode-range U+26>";
+  check_range "u+0-7f" "<unicode-range U+0-7F>";
+  check_range "U+0025-00FF" "<unicode-range U+25-FF>";
+  check_range "U+4??" "<unicode-range U+400-4FF>";
+  check_range "U+10????" "<unicode-range U+100000-10FFFF>";
+  check_range "U+??????" "<unicode-range U+0-FFFFFF>";
+  check_range "U+1234567" "<unicode-range U+123456> <number 7>";
+  check_range "U+12??-f" "<unicode-range U+1200-12FF> <ident -f>";
+  check_range "u+???????" "<unicode-range U+0-FFFFFF> <delim '?'>";
   check "u+-1" "<ident u> <delim '+'> <number -1>";
   check "u+" "<ident u> <delim '+'>";
   check "u+g" "<ident u> <delim '+'> <ident g>"
@@ -261,7 +266,7 @@ let spec12_tokenization_checklist () =
   check "+10 -2.5 1e2 1e+2 1e-2 4e5px"
     "<number +10> <ws> <number -2.5> <ws> <number 1e2> <ws> <number 1e+2> <ws> \
      <number 1e-2> <ws> <dimension 4e5px>";
-  check "U+26 u+a" "<unicode-range U+26> <ws> <unicode-range U+A>"
+  check_range "U+26 u+a" "<unicode-range U+26> <ws> <unicode-range U+A>"
 
 let spec_token_boundary_edges () =
   (* CSS Syntax Level 3 section 9 serialization constraints are driven by
@@ -304,7 +309,7 @@ let spec_wpt_url_unicode_edges () =
   (* WPT url-whitespace-consumption and inclusive-ranges vectors. *)
   check "url(  \tfoo\\ bar\n )" "<url foo bar>";
   check "url(foo)/**/url(bar)" "<url foo> <url bar>";
-  check "U+000000-10FFFF U+10FFFF U+110000"
+  check_range "U+000000-10FFFF U+10FFFF U+110000"
     "<unicode-range U+0-10FFFF> <ws> <unicode-range U+10FFFF> <ws> \
      <unicode-range U+110000>";
   check "a<!--b-->c" "<ident a> <CDO> <ident b--> <delim '>'> <ident c>"

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -40,8 +40,11 @@ let check_font_style =
 let check_font_display =
   check_value_cursor "font-display" read_font_display pp_font_display
 
+(* CSS Syntax 3 sec. 5.5.11 is the one caller that asks the tokenizer for
+   unicode ranges, so these vectors read as that descriptor's value does. *)
 let check_unicode_range =
-  check_value_cursor "unicode-range" read_unicode_range pp_unicode_range
+  check_value_cursor ~unicode_ranges:true "unicode-range" read_unicode_range
+    pp_unicode_range
 
 let check_text_align =
   check_value_cursor "text-align" read_text_align pp_text_align

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4233,6 +4233,28 @@ let nesting_invalid_rule_recovery () =
     ".a { color: red; .b <::::invalid::::> {} & .c { color: blue } }"
     ".a{color:red;.c{color:#00f}}" 1
 
+(* CSS Syntax 3 sec. 4.3.1 consumes a unicode-range token only while "unicode
+   ranges allowed" is set, and sec. 4.3.14 says the one caller that sets it is
+   the value of a unicode-range descriptor. Everywhere else [u+a] is an ident, a
+   delim and an ident, which the selector grammar reads as a sibling
+   combination. *)
+let unicode_range_only_in_its_descriptor () =
+  check_stylesheet ~expected:"u+a{color:red}" "u+a { color: red }";
+  check_stylesheet ~expected:"a{color:red}u+a{color:blue}"
+    "a { color: red } u+a { color: blue }";
+  check_stylesheet ~expected:"u+a b{color:red}" "u+a b { color: red }";
+  check_stylesheet
+    ~expected:"@font-face{font-family:X;src:url(a.woff2);unicode-range:U+0-7F}"
+    "@font-face { font-family: X; src: url(a.woff2); unicode-range: U+0-7F }";
+  check_stylesheet
+    ~expected:"@font-face{font-family:X;src:url(a.woff2);unicode-range:U+4??}"
+    "@font-face { font-family: X; src: url(a.woff2); unicode-range: U+4?? }";
+  check_stylesheet
+    ~expected:
+      "@font-face{font-family:X;src:url(a.woff2);unicode-range:U+26,U+0-7F}"
+    "@font-face { font-family: X; src: url(a.woff2); unicode-range: U+26, \
+     U+0-7F }"
+
 (* A nested @layer holds nesting content: bare declarations belong to the parent
    selector, exactly as in @media/@supports. Blink and WebKit both read
    [.a{@layer n{color:red}}] as a layer block wrapping nested declarations. *)
@@ -9313,6 +9335,9 @@ let additional_tests =
     ("nesting deeply nested", `Quick, test_nesting_deep);
     ("nesting with declarations", `Quick, test_nesting_with_declarations);
     ("nesting check_stylesheet", `Quick, test_nesting_check_stylesheet);
+    ( "unicode range only in its descriptor",
+      `Quick,
+      unicode_range_only_in_its_descriptor );
     ("nesting invalid rule recovery", `Quick, nesting_invalid_rule_recovery);
     ( "spec nesting selector and conditional edges",
       `Quick,


### PR DESCRIPTION
CSS Syntax 3 sec. 4.3.1 takes a "unicode ranges allowed" boolean defaulting to false, and sec. 4.3.14 says the algorithm "is only called during consume the value of a unicode-range descriptor". cascade produced a unicode-range token wherever `U+` could start one, so `u+a { color: green }` was a single token and the rule was dropped.

The flag now defaults off and is set where that value is consumed: the declaration reader (sec. 5.5.11), the `@font-face` descriptor reader, and var substitution into the descriptor.

Closes the `unicode-range-selector.html` port in the WPT css-syntax corpus.