### PR TITLE
declaration: hold a custom property to <declaration-value>

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- A custom property whose value carries an unmatched closer or a bad url is
+  invalid, and an item written as `--x: hover { }` stays a declaration rather
+  than becoming a rule when its value turns out to be bad (#897).
+
 - A unicode range is tokenised only in the `unicode-range` descriptor it
   belongs to, so `u+a` is the selector it reads as everywhere else (#896).
 

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -250,18 +250,25 @@ let reject_unterminated_string_value t =
   if List.exists component_has_unterminated_string (value_components t) then
     Cursor.err_invalid t "unterminated string in declaration value"
 
-let rec component_has_bad_string = function
-  | Component.Preserved { kind = Token.Bad_string; _ } -> true
+(* CSS Syntax 3 (ED) sec. 7.2: a [<declaration-value>] is any token sequence
+   excluding a [<bad-string-token>], a [<bad-url-token>], and an unmatched [)],
+   []] or [}]. A custom property takes [<declaration-value>?] and nothing wider,
+   so a value carrying one of those is invalid rather than opaque. *)
+let rec component_leaves_declaration_value = function
+  | Component.Preserved
+      { kind = Token.Bad_string | Token.Bad_url | Token.Close _; _ } ->
+      true
   | Component.Block { node = { value; _ }; _ } ->
-      List.exists component_has_bad_string value
+      List.exists component_leaves_declaration_value value
   | Component.Func { node = { arguments; _ }; _ } ->
-      List.exists component_has_bad_string arguments
+      List.exists component_leaves_declaration_value arguments
   | Component.Preserved _ -> false
 
 let reject_custom_bad_string t =
   if
-    List.exists component_has_bad_string (components_before is_top_level_stop t)
-  then Cursor.err_invalid t "bad string in custom property value"
+    List.exists component_leaves_declaration_value
+      (components_before is_top_level_stop t)
+  then Cursor.err_invalid t "custom property value is no <declaration-value>"
 
 let invalid_var_arguments arguments =
   match

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3764,8 +3764,26 @@ let item_opens_block inner =
   Cursor.restore inner start;
   found
 
+(* CSS Syntax 3 (ED) sec. 5.5.3 drops a qualified rule whose prelude is an ident
+   starting with [--] followed by a colon, block and all: that item is a
+   declaration however much it looks like a rule, so sec. 5.5.6 recovery takes
+   it, not sec. 5.5.5's. *)
+let item_is_custom_property inner =
+  let start = Cursor.save inner in
+  let answer =
+    match Cursor.peek inner with
+    | Some (Component.Preserved { kind = Token.Ident name; _ })
+      when Custom_property_name.has_prefix name ->
+        Cursor.skip inner;
+        Cursor.ws inner;
+        Cursor.peek_colon inner
+    | _ -> false
+  in
+  Cursor.restore inner start;
+  answer
+
 let skip_invalid_nesting_item r =
-  if item_opens_block r then (
+  if item_opens_block r && not (item_is_custom_property r) then (
     skip_past_rule r;
     Error.Recovery.Rule)
   else (
@@ -4093,10 +4111,10 @@ and read_nesting_declaration_or_statement r =
   (* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so
      [h2:where(...) { ... }] reads as a declaration up to the [{]. Rewind and
      take it as a rule; a genuine bad declaration has no block and still reports
-     as one. *)
+     as one, and a [--x:] prelude is a declaration whatever follows it. *)
   | exception Error.Parse_error _
     when Cursor.restore r start;
-         item_opens_block r ->
+         item_opens_block r && not (item_is_custom_property r) ->
       `Stmt (read_statement r)
 
 (* Helper: Read nested at-rule with declarations content *)
@@ -4212,10 +4230,10 @@ and read_rule_decl_or_nested selector inner decls nested =
   (* CSS Nesting 1 sec. 3 lets a nested rule start with an identifier, so
      [h2:where(...) { ... }] reads as a declaration up to the [{]. Rewind and
      take it as a rule; a genuine bad declaration has no block and still reports
-     as one. *)
+     as one, and a [--x:] prelude is a declaration whatever follows it. *)
   | exception Error.Parse_error _
     when Cursor.restore inner start;
-         item_opens_block inner ->
+         item_opens_block inner && not (item_is_custom_property inner) ->
       read_nested_rule_or_done selector inner decls nested
 
 and read_nested_rule_or_done selector inner decls nested =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3752,7 +3752,17 @@ let spec_custom_tokens () =
     "--bad-string: \"unterminated";
   neg_cursor read_declaration "--: value";
   neg_cursor read_declaration "-x: value";
-  neg_cursor read_declaration "--x"
+  neg_cursor read_declaration "--x";
+
+  (* CSS Syntax 3 sec. 7.2: a <declaration-value> is any token sequence that
+     holds no unmatched closer and no bad-url, so a custom property whose value
+     carries one is invalid rather than opaque. *)
+  check_declaration ~expected:"--x:hover{}" "--x: hover { }";
+  check_declaration ~expected:"--x:a b" "--x: a b";
+  neg_cursor read_declaration "--x: hover { ] }";
+  neg_cursor read_declaration "--x: a ] b";
+  neg_cursor read_declaration "--x: a ) b";
+  neg_cursor read_declaration "--x: url(a b)"
 
 (* CSS Fonts 4 sec. 2.1.1 gives a [<font-family-name>] two spellings, a
    [<string>] and a [<custom-ident>+], and they name the same family whether


### PR DESCRIPTION
CSS Syntax 3 sec. 7.2 excludes a bad string, a bad url and an unmatched `)`, `]` or `}` from a `<declaration-value>`, and CSS Variables 1 sec. 2 gives a custom property that grammar and nothing wider. cascade checked for a bad string alone, so `--x: hover { ] }` became an opaque custom property. Chrome rejects it, and so do `--x: a ] b` and `--x: url(a b)`.

Sec. 5.5.3 also drops a qualified rule whose prelude is a `--` ident followed by a colon, block and all, so the failed item recovers as a bad declaration (sec. 5.5.6) rather than being re-read as a rule.

Closes the `custom-property-rule-ambiguity.html` port, and with it the WPT css-syntax corpus.