### PR TITLE
stylesheet: separate @scope from a bare scope-end

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- Minified `@scope to (...)` keeps the space before `to`, which it needs to
+  read back as `@scope` rather than as an at-rule named `@scopeto` (#898).
+
 - A custom property whose value carries an unmatched closer or a bad url is
   invalid, and an item written as `--x: hover { }` stays a declaration rather
   than becoming a rule when its value turns out to be bad (#897).

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1602,7 +1602,11 @@ and pp_scope_statement ctx start end_ content =
   | None -> ());
   (match end_ with
   | Some e ->
-      Pp.string ctx (if Pp.minified ctx then "to (" else " to (");
+      (* [@scope] and [to] are both ident-shaped, so with nothing between them
+         they lex as the one at-keyword [@scopeto]. The [)] closing a start
+         selector already delimits them. *)
+      if (not (Pp.minified ctx)) || Option.is_none start then Pp.char ctx ' ';
+      Pp.string ctx "to (";
       pp_scope_selector ctx e;
       Pp.string ctx ")"
   | None -> ());

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -3793,6 +3793,11 @@ let spec_current_at_rules () =
      }";
   check_stylesheet ~expected:"@scope(.card)to (.footer){.title{color:red}}"
     "@scope (.card) to (.footer) { .title { color: red } }";
+  (* [@scope] and [to] are both ident-shaped, so with nothing between them they
+     lex as the one at-keyword [@scopeto]. The [)] closing a start selector
+     already delimits them. *)
+  check_stylesheet ~expected:"@scope to (.footer){.title{color:red}}"
+    "@scope to (.footer) { .title { color: red } }";
   check_stylesheet ~expected:"@scope(.card){.title{color:red}}"
     "@scope (.card) { .title { color: red } }";
   (* The scope-end selector list is held in authored order by pp; only optimize


### PR DESCRIPTION
`@scope` and `to` are both ident-shaped, so `@scope to (.footer)` minified to `@scopeto (.footer)`, which reads back as an at-rule named `@scopeto` and is dropped. The space was omitted whenever a start selector was absent, leaving no closing paren to delimit the two idents.

One of the lightning corpus inputs that `cascade fmt --minify` did not reach a fixed point on.