### PR TITLE
color: count relative channels by component

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- A relative colour reads its channels whether or not a space separates them,
+  so `rgb(from red 20%g b/alpha)` parses and cascade reads back the minified
+  form it writes (#899).
+
 - Minified `@scope to (...)` keeps the space before `to`, which it needs to
   read back as `@scope` rather than as an at-rule named `@scopeto` (#898).
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6686,6 +6686,11 @@ let normalize_relative_color_tail tail =
   loop 0 false;
   Buffer.contents buf
 
+(* CSS Color 5 sec. 4.1 gives each channel one component value, so the channels
+   are the components before the alpha slash that are not whitespace. Splitting
+   on whitespace instead would miscount the spellings that need no separator:
+   [20%g] is a percentage and an ident, [calc(...)10] a function and a
+   number. *)
 let relative_color_channel_count cvs =
   let is_ws = function
     | Component.Preserved { Token.kind = Whitespace; _ } -> true
@@ -6695,14 +6700,13 @@ let relative_color_channel_count cvs =
     | Component.Preserved { Token.kind = Delim "/"; _ } -> true
     | _ -> false
   in
-  let rec loop count in_channel = function
-    | [] -> if in_channel then count + 1 else count
-    | cv :: _ when is_alpha_sep cv -> if in_channel then count + 1 else count
-    | cv :: rest when is_ws cv ->
-        loop (if in_channel then count + 1 else count) false rest
-    | _ :: rest -> loop count true rest
+  let rec loop count = function
+    | [] -> count
+    | cv :: _ when is_alpha_sep cv -> count
+    | cv :: rest when is_ws cv -> loop count rest
+    | _ :: rest -> loop (count + 1) rest
   in
-  loop 0 false cvs
+  loop 0 cvs
 
 let relative_color_has_empty_alpha cvs =
   let is_ws = function

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4162,6 +4162,16 @@ let spec_values_l45_edges () =
       ("color: color(display-p3 1 0 0 / .5)", "color:color(display-p3 1 0 0/.5)");
       ( "color: rgb(from var(--c) r g b / 50%)",
         "color:rgb(from var(--c) r g b/.5)" );
+      (* Each channel is one component value, so a space between two of them is
+         a separator the tokens do not need: [20%g] is a percentage and an
+         ident, and [calc(...)10] a function and a number. *)
+      ("color: rgb(from red 20%g b / alpha)", "color:rgb(from red 20%g b/alpha)");
+      ( "color: rgb(from red 20% g b / alpha)",
+        "color:rgb(from red 20%g b/alpha)" );
+      ( "color: rgb(from red r calc(g * 2)10)",
+        "color:rgb(from red r calc(g * 2)10)" );
+      ( "color: rgb(from red r calc(g * 2) 10)",
+        "color:rgb(from red r calc(g * 2)10)" );
       (* pp holds the authored node for the Named blue, the rgb()/alpha, and the
          turn unit. The colour cross-fold and angle conversion are optimize
          transforms. *)


### PR DESCRIPTION
CSS Color 5 sec. 4.1 gives each channel one component value, so the channel count is the components before the alpha slash that are not whitespace. cascade split on whitespace instead, so the minified spellings that need no separator read as one channel short: it wrote `rgb(from #639 20%g b/alpha)` and then rejected it. Chrome accepts both `20%g` and `calc(g * 2)10`.

Twelve of the lightning corpus inputs that `cascade fmt --minify` did not reach a fixed point on.