### PR TITLE
transform: keep rotate's angle apart from its axis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- Minified `rotate` keeps the space between its angle and a negative axis
+  number, which `0deg-1` folded into one dimension (#900).
+
 - A relative colour reads its channels whether or not a space separates them,
   so `rgb(from red 20%g b/alpha)` parses and cascade reads back the minified
   form it writes (#899).

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -959,13 +959,15 @@ let rec pp_rotate_value : rotate_value Pp.t =
   | Axis (0., 0., 1., a) when Pp.minified ctx -> pp_rotate_value ctx (Z a)
   | Axis (x, y, z, a) ->
       (* CSS Transforms 2 sec. 5 [rotate] [<angle> <number>{3}] is shorter under
-         minify when the angle leads (csso convention) and the second / third
-         numbers drop the separator if they start with a sign. *)
+         minify when the angle leads (csso convention) and a following number
+         drops the separator if it starts with a sign. The first number keeps
+         it: the angle ends in its unit, so [0deg-1] is the one dimension
+         [0deg-1] rather than an angle and a number. *)
       let pp_sep ctx (next : float) =
         if Pp.minified ctx && next < 0. then () else Pp.space ctx ()
       in
       pp_required_unit_angle ctx a;
-      pp_sep ctx x;
+      Pp.space ctx ();
       Pp.float ctx x;
       pp_sep ctx y;
       Pp.float ctx y;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2347,6 +2347,14 @@ let list_properties () =
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
 
+  (* CSS Transforms 2 sec. 5: minified [rotate] leads with the angle, and a
+     following axis number that starts with a sign needs no separator. The first
+     one does: the angle ends in its unit, so [0deg-1] is the one dimension
+     [0deg-1]. *)
+  check_declaration ~expected:"rotate:0deg -1 0 0" "rotate: -1 0 0 0deg";
+  check_declaration ~expected:"rotate:45deg 1 0-1" "rotate: 1 0 -1 45deg";
+  check_declaration ~expected:"rotate:x 45deg" "rotate: 1 0 0 45deg";
+
   (* CSS Syntax 3 sec. 4.3.6 ends a url token at EOF as it does at [)]: the
      missing closer is a parse error and the token still reads. *)
   check_declaration ~expected:"background-image:url()" "background-image:url(";


### PR DESCRIPTION
Minified `rotate` leads with the angle and drops the separator before an axis number that starts with a sign. Between two numbers that is safe; after the angle it is not, because the angle ends in its unit: `rotate: -1 0 0 0deg` was written `rotate:0deg-1 0 0`, where `deg-1` lexes as one dimension and the declaration is lost.

One of the lightning corpus inputs that `cascade fmt --minify` did not reach a fixed point on.