### PR TITLE
animation: quote a keyframes name spelling a keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- A quoted `animation-name` that spells `none`, `default` or a CSS-wide
+  keyword keeps its quotes, which unquoting turned into a different
+  declaration and, in a list, into none at all (#901).
+
 - Minified `rotate` keeps the space between its angle and a negative axis
   number, which `0deg-1` folded into one dimension (#900).
 

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -92,18 +92,28 @@ let rec pp_animation_iteration_count : animation_iteration_count Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+(* The names a [<custom-ident>] may not spell, so the string arm is the only one
+   that carries them and the quotes are part of the value. *)
+let keyframes_name_needs_quotes name =
+  match String.lowercase_ascii name with
+  | "none" | "default" | "inherit" | "initial" | "unset" | "revert"
+  | "revert-layer" ->
+      true
+  | _ -> false
+
 let rec pp_animation_name : animation_name Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"
   | Name name -> pp_ident ctx name
   | Ambiguous name -> pp_ident ctx name
   | Quoted name ->
-      (* CSS Animations 1 sec. 3: [<keyframes-name>] excludes [none], the
-         CSS-wide keywords, and [default]. A source [animation-name: "none"]
-         therefore can't refer to a real [@keyframes none] - it's invalid input
-         that browsers tolerate. Minified output drops the quotes so the value
-         collapses to the equivalent (and shorter) keyword form. *)
-      if Pp.minified ctx then Pp.string ctx name else Pp.quoted_string ctx name
+      (* CSS Animations 1 sec. 3: a [<keyframes-name>] is a [<custom-ident>] or
+         a [<string>], and only the ident arm excludes [none], [default] and the
+         CSS-wide keywords. Unquoting one of those names writes a different
+         declaration, and in a list it writes no declaration at all. *)
+      if Pp.minified ctx && not (keyframes_name_needs_quotes name) then
+        Pp.string ctx name
+      else Pp.quoted_string ctx name
   | Names names -> Pp.list ~sep:Pp.comma pp_animation_name ctx names
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1892,6 +1892,23 @@ let animations_timing () =
   check_declaration ~expected:"animation-name:slide-in"
     "animation-name: slide-in";
   check_declaration ~expected:"animation-name:none" "animation-name: none";
+  (* CSS Animations 1 sec. 3: a <keyframes-name> is a <custom-ident> or a
+     <string>, and only the ident arm excludes none, default and the CSS-wide
+     keywords. Unquoting such a name is a different declaration, and in a list
+     it is no declaration at all. *)
+  check_declaration ~expected:"animation-name:\"unset\""
+    "animation-name: \"unset\"";
+  check_declaration ~expected:"animation-name:\"none\""
+    "animation-name: \"none\"";
+  check_declaration ~expected:"animation-name:\"default\""
+    "animation-name: \"default\"";
+  check_declaration ~expected:"animation-name:\"UNSET\""
+    "animation-name: \"UNSET\"";
+  check_declaration ~expected:"animation-name:\"unset\",\"revert\""
+    "animation-name: \"unset\", \"revert\"";
+  check_declaration ~expected:"animation-name:slide" "animation-name: \"slide\"";
+  check_declaration ~expected:"animation-name:a,b"
+    "animation-name: \"a\", \"b\"";
 
   check_declaration ~expected:"animation-duration:1s" "animation-duration: 1s";
   check_declaration ~expected:"animation-duration:.5s"


### PR DESCRIPTION
CSS Animations 1 sec. 3 gives `<keyframes-name>` two arms, a `<custom-ident>` and a `<string>`, and only the ident arm excludes `none`, `default` and the CSS-wide keywords. Minified output dropped the quotes from every string name, so `animation-name: "unset"` came back as explicit defaulting and `animation-name: "unset", "revert"` did not parse at all. Chrome keeps the quotes on exactly these names.

One of the lightning corpus inputs that `cascade fmt --minify` did not reach a fixed point on.