### PR TITLE
image: read a numeric color-stop position

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- A `-webkit-gradient` `color-stop()` takes a number as well as a percentage,
+  so cascade reads back the minified form it writes (#902).
+
 - A quoted `animation-name` that spells `none`, `default` or a CSS-wide
   keyword keeps its quotes, which unquoting turned into a different
   declaration and, in a list, into none at all (#901).

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -1835,7 +1835,13 @@ let read_webkit_gradient_stop t =
     when String.lowercase_ascii_preserve name = "color-stop" ->
       Cursor.call "color-stop" t (fun inner ->
           Cursor.ws inner;
-          let position = read_percentage inner in
+          (* The legacy stop position is a number or a percentage, and the
+             minified spelling is the number, so both read back. *)
+          let position : percentage =
+            match Cursor.number_opt inner with
+            | Some n -> Num n
+            | None -> read_percentage inner
+          in
           Cursor.ws inner;
           Cursor.comma inner;
           Cursor.ws inner;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2364,6 +2364,21 @@ let list_properties () =
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
 
+  (* A [-webkit-gradient] stop position is a number or a percentage, and the
+     minified spelling is the number, so both read back. *)
+  check_declaration
+    ~expected:
+      "background:-webkit-gradient(linear,0 0,0 \
+       100%,from(#00f),color-stop(.5,red),to(#ff0))"
+    "background: -webkit-gradient(linear, 0 0, 0 100%, from(#00f), \
+     color-stop(.5, red), to(#ff0))";
+  check_declaration
+    ~expected:
+      "background:-webkit-gradient(linear,0 0,0 \
+       100%,from(#00f),color-stop(.5,red),to(#ff0))"
+    "background: -webkit-gradient(linear, 0 0, 0 100%, from(#00f), \
+     color-stop(50%, red), to(#ff0))";
+
   (* CSS Transforms 2 sec. 5: minified [rotate] leads with the angle, and a
      following axis number that starts with a sign needs no separator. The first
      one does: the angle ends in its unit, so [0deg-1] is the one dimension


### PR DESCRIPTION
The legacy `-webkit-gradient` stop position is a number or a percentage, and minified output writes the number (`color-stop(.5, red)` for `color-stop(50%, red)`). The reader took a percentage alone, so cascade could not read back a minified gradient with a middle stop. Chrome accepts both spellings.

Two of the lightning corpus inputs that `cascade fmt --minify` did not reach a fixed point on.