### PR TITLE
image: drop the space center does not need

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- A `-webkit-gradient` point written `center` minifies to the same text as
+  the percentage pair it means (#903).
+
 - A `-webkit-gradient` `color-stop()` takes a number as well as a percentage,
   so cascade reads back the minified form it writes (#902).
 

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -371,7 +371,9 @@ let pp_webkit_gradient_point ctx = function
   | Webkit_gradient.Left_bottom ->
       Pp.string ctx (if Pp.minified ctx then "0 100%" else "left bottom")
   | Webkit_gradient.Center ->
-      Pp.string ctx (if Pp.minified ctx then "50% 50%" else "center center")
+      (* A percentage delimits itself, so the pair needs no space between them
+         and the written-out position prints the same way. *)
+      Pp.string ctx (if Pp.minified ctx then "50%50%" else "center center")
   | Webkit_gradient.Position position -> pp_position_value ctx position
 
 let pp_webkit_gradient_position ctx (pct : percentage) =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2364,6 +2364,19 @@ let list_properties () =
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
 
+  (* [center] minifies to the same pair of percentages a written-out position
+     does, and a percentage delimits itself, so neither spelling keeps the space
+     between them. *)
+  check_declaration
+    ~expected:
+      "background:-webkit-gradient(radial,50%50%,0,50%50%,100,from(blue),to(yellow))"
+    "background: -webkit-gradient(radial, center center, 0, center center, \
+     100, from(blue), to(yellow))";
+  check_declaration
+    ~expected:
+      "background:-webkit-gradient(radial,50%50%,0,50%50%,100,from(#00f),to(#ff0))"
+    "background: -webkit-gradient(radial, 50% 50%, 0, 50% 50%, 100, \
+     from(#00f), to(#ff0))";
   (* A [-webkit-gradient] stop position is a number or a percentage, and the
      minified spelling is the number, so both read back. *)
   check_declaration


### PR DESCRIPTION
A `-webkit-gradient` point written `center center` minified to `50% 50%` while the same pair written out minified to `50%50%`, so the two spellings of one value disagreed and the first output was not a fixed point. A percentage delimits itself, so neither needs the space.

One of the lightning corpus inputs that `cascade fmt --minify` did not reach a fixed point on.