### PR TITLE
color: clamp a percentage Oklab lightness

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- An out-of-range `oklab()` or `oklch()` lightness written as a percentage
+  clamps as the bare number already did (#904).
+
 - A `-webkit-gradient` point written `center` minifies to the same text as
   the percentage pair it means (#903).
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6478,10 +6478,11 @@ let read_ok_lightness t : percentage option =
     Option.None)
   else
     let n, unit = Cursor.number_with_unit t in
-    (* CSS Color 4 sec. 9.3/9.4: an out-of-range lightness clamps (to [0, 1] for
-       a bare number) rather than invalidating the colour, matching lab/lch. *)
+    (* CSS Color 4 sec. 9.3/9.4: an out-of-range lightness clamps rather than
+       invalidating the colour, matching lab/lch. 0% to 100% names the same 0 to
+       1 a bare number does, so both spellings clamp alike. *)
     match unit with
-    | Some "%" -> Some (Pct n : percentage)
+    | Some "%" -> Some (Pct (max 0. (min 100. n)) : percentage)
     | None -> Some (Num (max 0. (min 1. n)) : percentage)
     | Some u -> Cursor.err_invalid t ("oklch() L unit: " ^ u)
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2364,6 +2364,20 @@ let list_properties () =
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
 
+  (* CSS Color 4 sec. 9.4: an out-of-range Oklab lightness clamps rather than
+     invalidating the colour, and 0% to 100% is the same 0 to 1 a bare number
+     names, so both spellings clamp alike. *)
+  (* pp holds the percentage spelling; each pair asserts that the out-of-range
+     value reads as the in-range one beside it. *)
+  check_declaration ~expected:"color:oklab(100%0 0)" "color: oklab(100% 0 0)";
+  check_declaration ~expected:"color:oklab(100%0 0)" "color: oklab(200% 0 0)";
+  check_declaration ~expected:"color:oklab(0%0 0)" "color: oklab(0% 0 0)";
+  check_declaration ~expected:"color:oklab(0%0 0)" "color: oklab(-200% 0 0)";
+  check_declaration ~expected:"color:oklch(100%0 0)" "color: oklch(100% 0 0)";
+  check_declaration ~expected:"color:oklch(100%0 0)" "color: oklch(200% 0 0)";
+  check_declaration ~expected:"color:oklch(0%0 0)" "color: oklch(0% 0 0)";
+  check_declaration ~expected:"color:oklch(0%0 0)" "color: oklch(-200% 0 0)";
+
   (* [center] minifies to the same pair of percentages a written-out position
      does, and a percentage delimits itself, so neither spelling keeps the space
      between them. *)


### PR DESCRIPTION
CSS Color 4 sec. 9.4 clamps an out-of-range lightness rather than invalidating the colour, and 0% to 100% names the same 0 to 1 a bare number does. Only the bare-number arm clamped, so `oklab(200% 0 0)` stayed out of range until a second read brought it back and the first output was not a fixed point. Chrome resolves both spellings to `oklab(1 0 0)`.

Four of the lightning corpus inputs that `cascade fmt --minify` did not reach a fixed point on.