### PR TITLE
color: fold a relative colour over any convertible origin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- `color(from <origin> srgb r g b)` folds to the origin when that origin is
+  itself a `color()`, not only when it is a hex or a named colour (#905).
+
 - An out-of-range `oklab()` or `oklch()` lightness written as a percentage
   clamps as the bare number already did (#904).
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6726,6 +6726,24 @@ let relative_color_has_empty_alpha cvs =
   in
   loop cvs
 
+(* The origin may be a [color()] node, which the byte converter has no arm for.
+   The linear route covers every space whose matrices are wired up, so a
+   relative colour folds whether its origin was written as a hex or as the
+   [color()] the same conversion reaches. *)
+let relative_origin_srgb_bytes origin : (int * int * int * int) option =
+  match static_color_to_srgb_bytes origin with
+  | Some _ as found -> found
+  | Option.None -> (
+      match static_color_to_linear_srgb origin with
+      | Some (linear, alpha_f) -> (
+          match Color_space.srgb_bytes_of_linear linear with
+          | Some (r, g, b) ->
+              let clamp01 v = Float.max 0.0 (Float.min 1.0 v) in
+              Some
+                (r, g, b, Float.to_int (Float.round (clamp01 alpha_f *. 255.0)))
+          | Option.None -> Option.None)
+      | Option.None -> Option.None)
+
 let try_fold_color_function_static origin t : color option =
   Cursor.ws t;
   let read_keyword kw =
@@ -6744,7 +6762,7 @@ let try_fold_color_function_static origin t : color option =
     Cursor.ws t;
     if not (Cursor.is_done t) then Option.None
     else
-      match static_color_to_srgb_bytes origin with
+      match relative_origin_srgb_bytes origin with
       | Some (r, g, b, origin_a_byte) ->
           let final_alpha : alpha =
             match alpha with

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2364,6 +2364,18 @@ let list_properties () =
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
 
+  (* CSS Color 5 sec. 5.1: [color(from <origin> srgb r g b)] is the origin's own
+     sRGB channels, so it folds to the origin whether that was written as a hex
+     or as a [color()] the same conversion reaches. *)
+  check_declaration ~expected:"color:rgb(179 128 77)"
+    "color: color(from #b3804d srgb r g b)";
+  check_declaration ~expected:"color:rgb(179 128 77)"
+    "color: color(from color(srgb .7 .5 .3) srgb r g b)";
+  check_declaration ~expected:"color:rgb(179 128 77/.4)"
+    "color: color(from color(srgb .7 .5 .3/40%) srgb r g b)";
+  check_declaration ~expected:"color:rgb(179 128 77)"
+    "color: color(from color(from color(srgb .7 .5 .3) srgb r g b) srgb r g b)";
+
   (* CSS Color 4 sec. 9.4: an out-of-range Oklab lightness clamps rather than
      invalidating the colour, and 0% to 100% is the same 0 to 1 a bare number
      names, so both spellings clamp alike. *)


### PR DESCRIPTION
CSS Color 5 sec. 5.1 makes `color(from <origin> srgb r g b)` the origin's own sRGB channels. The fold asked `static_color_to_srgb_bytes`, which has no `color()` arm, so an origin written as `color(srgb .7 .5 .3)` kept the relative form that a second read then collapsed. The linear route already covers every space whose matrices are wired up.

Thirteen of the lightning corpus inputs that `cascade fmt --minify` did not reach a fixed point on, leaving one.