### PR TITLE
diff: carry a keyframe's declarations into the report

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- `cascade diff` shows the declarations a `@keyframes` frame gained, lost or
+  changed, instead of naming the frame and saying nothing (#906).
+
 - `color(from <origin> srgb r g b)` folds to the origin when that origin is
   itself a `color()`, not only when it is a hex or a named colour (#905).
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2890,16 +2890,22 @@ let keyframe_frames_diff frames1 frames2 =
   let selector_str (frame : Css.keyframe) =
     Css.Keyframe.to_string frame.selector
   in
+  (* A frame carries its declarations like any other rule: naming one modified
+     without saying what changed states a difference the report then
+     withholds. *)
   let added_changes =
     List.map
       (fun (frame : Css.keyframe) ->
-        (Added { selector = selector_str frame; declarations = [] } : rule_diff))
+        (Added
+           { selector = selector_str frame; declarations = frame.declarations }
+          : rule_diff))
       added
   in
   let removed_changes =
     List.map
       (fun (frame : Css.keyframe) ->
-        (Removed { selector = selector_str frame; declarations = [] }
+        (Removed
+           { selector = selector_str frame; declarations = frame.declarations }
           : rule_diff))
       removed
   in
@@ -2912,15 +2918,7 @@ let keyframe_frames_diff frames1 frames2 =
                f2.declarations)
         then
           Some
-            (Content_changed
-               {
-                 selector = selector_str f1;
-                 old_declarations = [];
-                 new_declarations = [];
-                 property_changes = [];
-                 added_properties = [];
-                 removed_properties = [];
-               })
+            (content_changed (selector_str f1) f1.declarations f2.declarations)
         else None)
       modified_pairs
   in

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -1331,6 +1331,32 @@ let modified_keyframes_names_the_at_rule () =
     "and does not call it a layer" false
     (string_contains ~needle:"@layer" s)
 
+(* Naming a frame modified without saying what changed states a difference the
+   report then withholds; a frame carries its declarations like any other
+   rule. *)
+let modified_keyframe_shows_its_change () =
+  let d =
+    diff_of ~expected:"@keyframes fade{0%{opacity:0}100%{opacity:1}}"
+      ~actual:"@keyframes fade{0%{opacity:.7}100%{opacity:1}}"
+  in
+  let s = render d in
+  Alcotest.(check bool)
+    "the frame that changed is named" true
+    (string_contains ~needle:"0%" s);
+  Alcotest.(check bool)
+    "and the property change is shown" true
+    (string_contains ~needle:"opacity" s)
+
+let added_keyframe_shows_its_declarations () =
+  let d =
+    diff_of ~expected:"@keyframes fade{0%{opacity:0}}"
+      ~actual:"@keyframes fade{0%{opacity:0}100%{opacity:1}}"
+  in
+  let s = render d in
+  Alcotest.(check bool)
+    "the frame that arrived carries its declarations" true
+    (string_contains ~needle:"opacity" s)
+
 let removed_layer_statement_is_named () =
   let d =
     diff_of ~expected:"@layer a,b;.x{color:red}" ~actual:".x{color:red}"
@@ -1624,6 +1650,10 @@ let suite =
         added_namespace_is_an_at_rule_container;
       Alcotest.test_case "removed layer statement is named" `Quick
         removed_layer_statement_is_named;
+      Alcotest.test_case "modified keyframe shows its change" `Quick
+        modified_keyframe_shows_its_change;
+      Alcotest.test_case "added keyframe shows its declarations" `Quick
+        added_keyframe_shows_its_declarations;
       Alcotest.test_case "modified keyframes names the at-rule" `Quick
         modified_keyframes_names_the_at_rule;
       Alcotest.test_case "selector group split reported" `Quick


### PR DESCRIPTION
`keyframe_frames_diff` built its `Added`, `Removed` and `Content_changed` entries with every payload field empty, so `cascade diff` counted a modified frame and then had nothing to show for it: `@keyframes fade (1 modified)` and no line under it. `@media` and `@supports` already reported the same change in full.

A frame now carries its declarations like any other rule, and the modified case goes through `content_changed` so the property diff is computed the same way.