### PR TITLE
diff: drop a rule change that says nothing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- `cascade diff` counts a rule as changed only when its own declarations
+  changed, so a rule holding an edited nested rule is no longer summarised as
+  a difference the report has nothing to show for (#907).
+
 - `cascade diff` shows the declarations a `@keyframes` frame gained, lost or
   changed, instead of naming the frame and saying nothing (#906).
 

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2598,6 +2598,28 @@ let at_rule_text_change text1 text2 =
       removed_properties = [];
     }
 
+(* A [Content_changed] naming a rule whose own declarations are untouched states
+   a difference nothing shows: the rules nested inside it are reported as the
+   nesting containers they are. Dropping it keeps the summary's count and the
+   report's entries in step. *)
+let content_change_says_something (diff : rule_diff) =
+  match diff with
+  | Content_changed
+      {
+        old_declarations;
+        new_declarations;
+        property_changes;
+        added_properties;
+        removed_properties;
+        _;
+      } ->
+      property_changes <> [] || added_properties <> []
+      || removed_properties <> []
+      || not
+           (List.equal Declaration.equal_declaration old_declarations
+              new_declarations)
+  | _ -> true
+
 let to_rule_changes rules1 rules2 : rule_diff list =
   let rules1 =
     List.filter (fun s -> not (is_reported_by_own_processor s)) rules1
@@ -2613,6 +2635,7 @@ let to_rule_changes rules1 rules2 : rule_diff list =
   @ r_regrouped
   |> merge_same_selector_changes ~rules1 ~rules2
   |> dedup_reorders
+  |> List.filter content_change_says_something
 
 (* Generic helpers for processing nested containers *)
 let extract_items_with_positions extract_fn stmts =

--- a/test/cli/diff_nested_block.t
+++ b/test/cli/diff_nested_block.t
@@ -12,7 +12,7 @@ rule it belongs to. Prefixing it the way an at-rule container is named prints
   > EOF
   $ NO_COLOR=1 cascade diff --diff=tree nest-a.css nest-b.css
   CSS: 30 chars vs 31 chars (3.3% diff)
-  Changes: 1 modified rule, 1 changed container
+  Changes: 1 changed container
   
   --- nest-a.css
   +++ nest-b.css

--- a/test/test_tree_diff.ml
+++ b/test/test_tree_diff.ml
@@ -1331,6 +1331,34 @@ let modified_keyframes_names_the_at_rule () =
     "and does not call it a layer" false
     (string_contains ~needle:"@layer" s)
 
+(* A rule whose own declarations are untouched is not a difference: the nested
+   rule that changed is reported as the nesting container it is, and a second
+   entry naming the parent counts a difference the report then has nothing to
+   show for. *)
+let unchanged_parent_of_a_changed_nested_rule () =
+  let d =
+    diff_of ~expected:".a{color:red;&:hover{color:blue}}"
+      ~actual:".a{color:red;&:hover{color:lime}}"
+  in
+  Alcotest.(check int)
+    "the parent is no top-level difference" 0
+    (List.length d.Cascade_diff.Tree_diff.rules);
+  Alcotest.(check bool)
+    "and the nested change is reported" false
+    (Cascade_diff.Tree_diff.is_empty d)
+
+let unchanged_parent_of_an_added_nested_rule () =
+  let d =
+    diff_of ~expected:".a{color:red}"
+      ~actual:".a{color:red;&:hover{color:blue}}"
+  in
+  Alcotest.(check int)
+    "the parent is no top-level difference" 0
+    (List.length d.Cascade_diff.Tree_diff.rules);
+  Alcotest.(check bool)
+    "and the nested rule is reported" false
+    (Cascade_diff.Tree_diff.is_empty d)
+
 (* Naming a frame modified without saying what changed states a difference the
    report then withholds; a frame carries its declarations like any other
    rule. *)
@@ -1650,6 +1678,10 @@ let suite =
         added_namespace_is_an_at_rule_container;
       Alcotest.test_case "removed layer statement is named" `Quick
         removed_layer_statement_is_named;
+      Alcotest.test_case "unchanged parent of a changed nested rule" `Quick
+        unchanged_parent_of_a_changed_nested_rule;
+      Alcotest.test_case "unchanged parent of an added nested rule" `Quick
+        unchanged_parent_of_an_added_nested_rule;
       Alcotest.test_case "modified keyframe shows its change" `Quick
         modified_keyframe_shows_its_change;
       Alcotest.test_case "added keyframe shows its declarations" `Quick


### PR DESCRIPTION
A rule whose own declarations are untouched reached the summary as a `Content_changed` carrying no property change and the same declarations on both sides. The renderer already suppresses such an entry, so the summary counted a difference the report then had nothing to show for: `.a { color: red; &:hover { ... } }` with an edit inside the nested rule counted twice, once as the nesting container that shows the change and once as the parent that shows nothing.

The nested rule is reported as the nesting container it is, so the parent entry is dropped and the count matches the entries.