### PR TITLE
lint: compare these values by their own equality

### DIFF
--- a/lib/prop_filter.ml
+++ b/lib/prop_filter.ml
@@ -188,7 +188,8 @@ let rec normalize_filter ?(lossless = false) : filter -> filter =
       preserve_if_equal value (Drop_shadow (normalize_shadow ~lossless s))
   | Hue_rotate a ->
       let a = Values.normalize_angle a in
-      if a = Deg 0. then Omitted Hue_rotate_function
+      if match a with Deg 0. -> true | _ -> false then
+        Omitted Hue_rotate_function
       else preserve_if_equal value (Hue_rotate a)
   | Brightness x -> amount Brightness_function (fun n -> Brightness n) x
   | Contrast x -> amount Contrast_function (fun n -> Contrast n) x

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2560,9 +2560,13 @@ let animation_infinite_name () =
     | Shorthand { name = Some (Ambiguous name | Name name); iteration_count; _ }
       ->
         Alcotest.(check string) "animation name" expected_name name;
-        Alcotest.(check bool)
-          "iteration count" true
-          (iteration_count = Some expected_count)
+        let shown c =
+          Css.Pp.to_string ~minify:true pp_animation_iteration_count c
+        in
+        Alcotest.(check (option string))
+          "iteration count"
+          (Some (shown expected_count))
+          (Option.map shown iteration_count)
     | _ -> Alcotest.failf "missing animation name in %s" input);
     value
   in
@@ -2606,10 +2610,15 @@ let animation_keyword_names () =
     | Some (Name value | Ambiguous value) ->
         Alcotest.(check string) input name value
     | _ -> Alcotest.failf "missing name in %s" input);
-    Alcotest.(check bool)
+    (* The slots read the same when the value they print does, and the printed
+       form says which slot differs when they do not. *)
+    let without_name v =
+      Css.Pp.to_string ~minify:true pp_animation
+        (Shorthand { v with name = Option.None })
+    in
+    Alcotest.(check string)
       (input ^ " keeps non-name slots")
-      true
-      ({ actual with name = None } = { expected with name = None })
+      (without_name expected) (without_name actual)
   in
   let check_print expected name value =
     List.iter


### PR DESCRIPTION
CI's Lint job fails on three E106 polymorphic comparisons: an angle against `Deg 0.` in the filter normaliser, an iteration count against `Some expected`, and two animation shorthand records with the name cleared. The angle becomes a pattern match; the two test sites compare the printed form, which also says which slot differs when they disagree.

The three predate this chain (they came in with #870, #875 and #876), and the locally installed merlint does not report E106 at all, so they only show up in CI.