### PR TITLE
align: read place-items as its two longhands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- `place-items` reads the `<self-position>` keywords `align-items` takes, so
+  `place-items: flex-start baseline` parses and the contraction the optimizer
+  writes for that pair of longhands reads back (#909).
+
 - `cascade diff` counts a rule as changed only when its own declarations
   changed, so a rule holding an edited nested rule is no longer summarised as
   a difference the report has nothing to show for (#907).

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -619,14 +619,33 @@ let read_place_items_default t =
     let justify = read_justify_items t in
     Align_justify (align, justify))
   else
-    let first = read_place_items_first t in
-    Cursor.ws t;
-    match Cursor.option read_justify_items t with
-    | None -> first
-    | Some justify -> (
-        match place_items_align first with
-        | Some align -> Align_justify (align, justify)
-        | None -> Cursor.err_invalid t "place-items two-value")
+    let snap = Cursor.save t in
+    match Cursor.option read_place_items_first t with
+    | Some first -> (
+        Cursor.ws t;
+        match Cursor.option read_justify_items t with
+        | None -> first
+        | Some justify -> (
+            match place_items_align first with
+            | Some align -> Align_justify (align, justify)
+            | None -> Cursor.err_invalid t "place-items two-value"))
+    | None ->
+        (* css-align-3 (ED) sec. 5.2: [place-items] is [<'align-items'>
+           <'justify-items'>?], so it takes every <self-position> keyword
+           align-items does. Those have no single-arm spelling here, so the pair
+           carries them, and a lone value sets both axes: it reads a second time
+           as the justify half. *)
+        Cursor.restore t snap;
+        let align = read_align_items t in
+        Cursor.ws t;
+        let justify =
+          match Cursor.option read_justify_items t with
+          | Some justify -> justify
+          | None ->
+              Cursor.restore t snap;
+              read_justify_items t
+        in
+        Align_justify (align, justify)
 
 let rec read_place_items t : place_items =
   Cursor.ws t;

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2364,6 +2364,17 @@ let list_properties () =
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
 
+  (* CSS Align 3 sec. 5.2: [place-items] is [<'align-items'>
+     <'justify-items'>?], so it takes every <self-position> keyword align-items
+     does, and a lone value sets both axes. The optimizer contracts
+     [align-items: flex-start; justify-items: baseline] into this spelling. *)
+  check_declaration ~expected:"place-items:flex-start baseline"
+    "place-items: flex-start baseline";
+  check_declaration ~expected:"place-items:self-start end"
+    "place-items: self-start end";
+  check_declaration ~expected:"place-items:start baseline"
+    "place-items: start baseline";
+
   (* CSS Color 5 sec. 5.1: [color(from <origin> srgb r g b)] is the origin's own
      sRGB channels, so it folds to the origin whether that was written as a hex
      or as a [color()] the same conversion reaches. *)


### PR DESCRIPTION
CSS Align 3 sec. 5.2 gives `place-items` the grammar `<'align-items'> <'justify-items'>?`, so it takes every `<self-position>` keyword `align-items` does. The reader took a short list instead, so `place-items: flex-start baseline` and `place-items: flex-start` were both dropped while Chrome accepts them.

That closed a loop: the optimizer contracts `align-items: flex-start; justify-items: baseline` into exactly this spelling, so `minify -> parse -> minify` lost the whole rule. It is a fixed point now.

Second of the four repros under "the optimizer emits CSS its own reader rejects"; `grid: auto-flow / 1fr 1fr` was the first (#884).