### PR TITLE
text-decoration: take none as a line, not the value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- `text-decoration` reads `none` as the line it is when a style or a colour
+  follows, so the contraction the optimizer writes for that run of longhands
+  reads back (#910).
+
 - `place-items` reads the `<self-position>` keywords `align-items` takes, so
   `place-items: flex-start baseline` parses and the contraction the optimizer
   writes for that pair of longhands reads back (#909).

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -168,20 +168,34 @@ let read_text_decoration_shorthand t : text_decoration_shorthand =
 
 let rec read_text_decoration t : text_decoration =
   let read_var t : text_decoration = Var (read_var read_text_decoration t) in
-  Cursor.enum_or_calls "text-decoration"
-    [
-      ("inherit", (Inherit : text_decoration));
-      ("initial", Initial);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-      ("none", None);
-    ]
-    ~calls:[ ("var", read_var) ]
-    ~default:(fun t ->
-      let shorthand = read_text_decoration_shorthand t in
-      (Shorthand shorthand : text_decoration))
-    t
+  let snap = Cursor.save t in
+  let value =
+    Cursor.enum_or_calls "text-decoration"
+      [
+        ("inherit", (Inherit : text_decoration));
+        ("initial", Initial);
+        ("unset", Unset);
+        ("revert", Revert);
+        ("revert-layer", Revert_layer);
+        ("none", None);
+      ]
+      ~calls:[ ("var", read_var) ]
+      ~default:(fun t ->
+        let shorthand = read_text_decoration_shorthand t in
+        (Shorthand shorthand : text_decoration))
+      t
+  in
+  (* CSS Text Decoration 4 sec. 2.5: the shorthand is a [||] of its longhands
+     and [none] is a [<text-decoration-line>], so it is the whole value only
+     when nothing follows it. *)
+  match value with
+  | None ->
+      Cursor.ws t;
+      if Cursor.is_done t then value
+      else (
+        Cursor.restore t snap;
+        (Shorthand (read_text_decoration_shorthand t) : text_decoration))
+  | _ -> value
 
 let rec read_text_decoration_skip t : text_decoration_skip =
   Cursor.enum_or_var "text-decoration-skip"

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2364,6 +2364,18 @@ let list_properties () =
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
 
+  (* CSS Text Decoration 4 sec. 2.5: the shorthand is a || of its longhands and
+     [none] is a <text-decoration-line>, so it is the whole value only when
+     nothing follows it. The optimizer contracts a none line beside a style and
+     a colour into exactly this spelling. *)
+  check_declaration ~expected:"text-decoration:none" "text-decoration: none";
+  check_declaration ~expected:"text-decoration:none dotted"
+    "text-decoration: none dotted";
+  check_declaration ~expected:"text-decoration:none dotted #12345680"
+    "text-decoration: none dotted #12345680";
+  check_declaration ~expected:"text-decoration:underline dotted red"
+    "text-decoration: underline dotted red";
+
   (* CSS Align 3 sec. 5.2: [place-items] is [<'align-items'>
      <'justify-items'>?], so it takes every <self-position> keyword align-items
      does, and a lone value sets both axes. The optimizer contracts


### PR DESCRIPTION
CSS Text Decoration 4 sec. 2.5 makes the shorthand a `||` of its longhands, and `none` is a `<text-decoration-line>`. The reader matched `none` against the whole-value list first, so `text-decoration: none dotted #12345680` left `dotted #12345680` over and the declaration was dropped. Chrome accepts it.

The optimizer contracts `text-decoration-line: none` beside a style and a colour into exactly that spelling, so `minify -> parse -> minify` lost the rule. It is a fixed point now.

Third of the four repros under "the optimizer emits CSS its own reader rejects" (#884, #909).