### PR TITLE
transition: take none as a property, not the value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- `transition` reads `none` as the property it is when a duration or a timing
+  function follows, so the contraction the optimizer writes for that run of
+  longhands reads back (#911).
+
 - `text-decoration` reads `none` as the line it is when a style or a colour
   follows, so the contraction the optimizer writes for that run of longhands
   reads back (#910).

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1080,26 +1080,40 @@ let read_transition_shorthand t : transition_shorthand =
   }
 
 let rec read_transition t : transition =
-  Cursor.enum "transition"
-    [
-      ("inherit", (Inherit : transition));
-      ("initial", Initial);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-      ("none", None);
-    ]
-    ~default:(fun t : transition ->
-      if Cursor.looking_at_func "var" t then (
-        let snap = Cursor.save t in
-        let value = (Var (read_var read_transition t) : transition) in
-        Cursor.ws t;
-        if Cursor.is_done t then value
-        else (
-          Cursor.restore t snap;
-          Shorthand (read_transition_shorthand t)))
-      else Shorthand (read_transition_shorthand t))
-    t
+  let snap = Cursor.save t in
+  let value =
+    Cursor.enum "transition"
+      [
+        ("inherit", (Inherit : transition));
+        ("initial", Initial);
+        ("unset", Unset);
+        ("revert", Revert);
+        ("revert-layer", Revert_layer);
+        ("none", None);
+      ]
+      ~default:(fun t : transition ->
+        if Cursor.looking_at_func "var" t then (
+          let snap = Cursor.save t in
+          let value = (Var (read_var read_transition t) : transition) in
+          Cursor.ws t;
+          if Cursor.is_done t then value
+          else (
+            Cursor.restore t snap;
+            Shorthand (read_transition_shorthand t)))
+        else Shorthand (read_transition_shorthand t))
+      t
+  in
+  (* CSS Transitions 1 sec. 3: [none] is a [<single-transition-property>], so it
+     is the whole item only when the item ends there. Anything else after it
+     belongs to the same [<single-transition>]. *)
+  match value with
+  | None ->
+      Cursor.ws t;
+      if Cursor.is_done t || Cursor.peek_comma t then value
+      else (
+        Cursor.restore t snap;
+        (Shorthand (read_transition_shorthand t) : transition))
+  | _ -> value
 
 let read_transitions t : transition list =
   Cursor.list ~at_least:1 ~sep:Cursor.comma read_transition t

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2364,6 +2364,17 @@ let list_properties () =
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
 
+  (* CSS Transitions 1 sec. 3: the shorthand takes a
+     <single-transition-property>, and none is one of them, so it is the whole
+     value only when the item ends there. The optimizer contracts a none
+     property beside a duration and a timing function into this spelling. *)
+  check_declaration ~expected:"transition:none" "transition: none";
+  check_declaration ~expected:"transition:none 1s" "transition: none 1s";
+  check_declaration ~expected:"transition:none 1s steps(2,end)"
+    "transition: none 1s steps(2, end)";
+  check_declaration ~expected:"transition:none,opacity 1s"
+    "transition: none, opacity 1s";
+
   (* CSS Text Decoration 4 sec. 2.5: the shorthand is a || of its longhands and
      [none] is a <text-decoration-line>, so it is the whole value only when
      nothing follows it. The optimizer contracts a none line beside a style and


### PR DESCRIPTION
CSS Transitions 1 sec. 3 makes `none` a `<single-transition-property>`, so it is the whole item only when the item ends there. The reader matched it against the whole-value list first, so `transition: none 1s steps(2, end)` left `1s steps(2, end)` over and the declaration was dropped. Chrome accepts it.

Last of the four repros under "the optimizer emits CSS its own reader rejects". All four now survive `minify -> parse -> minify`: `grid: auto-flow / 1fr 1fr` (#884), `place-items` (#909), `text-decoration` (#910) and this one.