### PR TITLE
parser: write the quote an unterminated string needs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- A string the input ended before closing is written with its closing quote,
+  so a sheet holding one no longer grows a brace on every pass (#912).
+
 - `transition` reads `none` as the property it is when a duration or a timing
   function follows, so the contraction the optimizer writes for that run of
   longhands reads back (#911).

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -192,7 +192,7 @@ let escape_name s =
     Common.String.utf8_fold folder () s;
     Buffer.contents buf
 
-let add_escaped_string buf ~quote ~terminated s =
+let add_escaped_string buf ~quote s =
   Buffer.add_char buf quote;
   String.iter
     (fun c ->
@@ -203,7 +203,7 @@ let add_escaped_string buf ~quote ~terminated s =
       else if code < 0x20 || code = 0x7F then add_hex_escape buf c
       else Buffer.add_char buf c)
     s;
-  if terminated then Buffer.add_char buf quote
+  Buffer.add_char buf quote
 
 let add_escaped_url buf s =
   Buffer.add_string buf "url(";
@@ -265,12 +265,14 @@ let add_token_kind buf : Token.kind -> unit = function
   | Token.Hash { value; _ } ->
       Buffer.add_char buf '#';
       Buffer.add_string buf (escape_name value)
-  | Token.String { value; quote = _; terminated } ->
+  | Token.String { value; quote = _; _ } ->
       (* Normalize quoting to double-quote (the original quote is kept on the
          token only for quote-sensitive lookups like @charset). CSS Syntax 3
-         (ED) sec. 4.3.5 recovers an unterminated string; the [terminated] flag
-         is preserved so one round-trips, emitting without its closing quote. *)
-      add_escaped_string buf ~quote:'"' ~terminated value
+         (ED) sec. 4.3.5 returns the string token when the input ends before the
+         closing quote, so what it holds is a string and prints as one. Omitting
+         the quote to keep the original bytes leaves the value swallowing the
+         brace after it, and the sheet grows one per pass. *)
+      add_escaped_string buf ~quote:'"' value
   | Token.Bad_string ->
       (* A bad string keeps no text, so serialize the shortest source that
          re-tokenizes as one, the way [Bad_url] serializes to [url(a b)]. CSS

--- a/lib/token.mli
+++ b/lib/token.mli
@@ -38,8 +38,8 @@ type kind =
           [@charset] per CSS Syntax 3 (ED) sec. 8.3) and to round-trip the input
           style. [terminated] is [false] when the lexer reached EOF without
           seeing the closing quote (CSS Syntax 3 (ED) sec. 4.3.5 returns the
-          string token but flags a parse error); the serializer omits the
-          closing quote so the original byte sequence is preserved. *)
+          string token but flags a parse error); the serializer writes the
+          closing quote either way, since what the token holds is a string. *)
   | Bad_string
       (** Unterminated string (newline or EOF before the closing quote). *)
   | Url of string

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3870,7 +3870,10 @@ let spec_custom_tokens () =
     "var(--a, var(--b, { color: red; }))";
   check_declaration ~expected:"--nested-var:var(--a,var(--b,{color:red;}))"
     "--nested-var: var(--a, var(--b, { color: red; }))";
-  check_declaration ~expected:"--bad-string:\"unterminated"
+  (* CSS Syntax 3 sec. 4.3.5 returns the string token when the input ends before
+     the closing quote, so the value holds a string and prints as one. Keeping
+     the original bytes instead left it swallowing whatever followed. *)
+  check_declaration ~expected:"--bad-string:\"unterminated\""
     "--bad-string: \"unterminated";
   neg_cursor read_declaration "--: value";
   neg_cursor read_declaration "-x: value";

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4227,6 +4227,15 @@ let test_nesting_check_stylesheet () =
    Recovering to the next semicolon, which is what sec. 5.5.6 does for a bad
    declaration, would take every item written after the bad rule and the parent
    with them. *)
+(* CSS Syntax 3 sec. 4.3.5 returns the string token when the input ends before
+   the closing quote, so the token is a string and prints as one. Omitting the
+   quote to keep the original bytes leaves the value swallowing the brace that
+   follows, and the sheet grows one per pass. *)
+let unterminated_string_closes () =
+  check_stylesheet ~expected:"foo{--foo:\"foo\"}" "foo{--foo:\"foo";
+  check_stylesheet ~expected:"foo{--foo:\"foo\"}" "foo{--foo:\"foo\"}";
+  check_stylesheet ~expected:"foo{content:\"a\"}" "foo{content:\"a\"}"
+
 let nesting_invalid_rule_recovery () =
   (* Each expectation is what the same sheet gives with the bad rule deleted:
      dropping it costs the parent nothing and the items around it nothing. *)
@@ -9344,6 +9353,7 @@ let additional_tests =
       `Quick,
       unicode_range_only_in_its_descriptor );
     ("nesting invalid rule recovery", `Quick, nesting_invalid_rule_recovery);
+    ("unterminated string closes", `Quick, unterminated_string_closes);
     ( "spec nesting selector and conditional edges",
       `Quick,
       spec_nesting_selector_edges );


### PR DESCRIPTION
CSS Syntax 3 sec. 4.3.5 returns the string token when the input ends before the closing quote, so what the token holds is a string. The serializer omitted the quote to keep the original bytes, which left the value swallowing the brace that closed the rule: `foo { --foo:"foo` printed `foo{--foo:"foo}`, and every further pass added another brace.

This is the ruling recorded in TODO.md against `printer drops a separator the reader needs` ("spec is more important" when told it costs the byte-identical raw round trip), so `test_declaration.ml`'s `--bad-string` expectation moves with it.