### PR TITLE
animation: hold auto as the duration a slot omits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,10 @@ entry points both moved.
 
 ### Parsing
 
+- The `animation` shorthand keeps an explicit `0s` duration, which it used to
+  drop as the initial value; `auto` holds that place now, so
+  `animation: spin 0s` no longer resolves to `animation: spin` (#913).
+
 - A string the input ended before closing is written with its closing quote,
   so a sheet holding one no longer grows a brace on every pass (#912).
 

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1401,8 +1401,8 @@ module Animation = struct
     {
       name = None;
       (* CSS default: none *)
-      duration = Some (S 0.0);
-      (* CSS default: 0s *)
+      duration = Some Auto;
+      (* CSS Animations 2 sec. 4.1: auto, not 0s *)
       timing_function = Some Ease;
       (* CSS default: ease *)
       delay = Some (S 0.0);
@@ -1597,6 +1597,13 @@ module Animation = struct
     | Some d when not (is_zero_duration d) -> true
     | _ -> false
 
+  (* CSS Animations 2 sec. 4.1 makes [auto] the initial duration, so an explicit
+     [0s] is a value of its own and has to print. The delay's initial is still
+     [0s], which is what [is_duration] answers for. *)
+  let is_animation_duration : duration option -> bool = function
+    | Option.None | Some Auto -> false
+    | Some _ -> true
+
   let is_default_timing = function Ease -> true | _ -> false
 
   let is_timing : timing_function option -> bool = function
@@ -1624,7 +1631,7 @@ module Animation = struct
     | Some _ -> true
 
   let has_non_defaults (anim : animation_shorthand) =
-    is_duration anim.duration
+    is_animation_duration anim.duration
     || is_timing anim.timing_function
     || is_duration anim.delay
     || is_iteration anim.iteration_count
@@ -1663,13 +1670,7 @@ module Animation = struct
     | Some Timeline -> is_timeline anim.timeline
 
   let duration (anim : animation_shorthand) : duration option =
-    match (anim.duration, anim.delay) with
-    | Some d, Some delay when is_zero_duration d && is_duration (Some delay) ->
-        Some d
-    | _ -> (
-        match anim.duration with
-        | Some d when not (is_zero_duration d) -> Some d
-        | _ -> None)
+    if is_animation_duration anim.duration then anim.duration else Option.None
 
   let timing ?(quote_name = false) (anim : animation_shorthand) :
       timing_function option =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2082,8 +2082,17 @@ let animations_state () =
 let animation_drained_shorthand () =
   check_declaration ~expected:"animation:none" ~optimized:"animation:none"
     "animation: none none";
-  check_declaration ~expected:"animation:none" ~optimized:"animation:none"
+  (* CSS Animations 2 sec. 4.1 makes auto the initial duration, so an explicit
+     0s is a value of its own: dropping it says auto, which Chrome resolves to a
+     different animation-duration. The delay's initial is still 0s. *)
+  check_declaration ~expected:"animation:0s" ~optimized:"animation:0s"
     "animation: 0s ease 0s 1 normal none running none";
+  check_declaration ~expected:"animation:spin 0s" "animation: spin 0s";
+  check_declaration ~expected:"animation:spin 0s linear"
+    "animation: spin 0s linear";
+  check_declaration ~expected:"animation:spin" "animation: spin";
+  check_declaration ~expected:"animation:spin" "animation: spin auto";
+  check_declaration ~expected:"animation:spin 1s" "animation: spin 1s 0s";
   (* Controls: the drop still runs wherever a slot outlives it. *)
   check_declaration ~expected:"animation:1s" ~optimized:"animation:1s"
     "animation: 1s none";


### PR DESCRIPTION
This answers the pending decision recorded in TODO.md against "the reader rejects 132 valid values": explicit `0s` must be preserved.

CSS Animations 2 sec. 4.1 makes `auto` the initial `animation-duration`, and #885 made cascade read it. The shorthand still carried `0s` as its default slot value, so an explicit `0s` read as absent and was dropped: `animation: spin 0s` minified to `animation: spin`. Chrome resolves the first to `animation-duration: 0s` and the second to `auto`, so that was a silent change of value.

`animation_drained_shorthand`'s `animation: 0s ease 0s 1 normal none running none` expectation moves from `animation:none` to `animation:0s` for the same reason. The delay's initial is still `0s` and is untouched.