### PR TITLE
shorthand: compose the scroll logical axes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,9 @@ entry points both moved.
 
 ### Parsing
 
+- The `scroll-margin` and `scroll-padding` logical axes contract from their
+  two longhands, as the margin, padding and inset axes already did (#915).
+
 - Contracting animation longhands into `animation` no longer resets a longhand
   the run does not write, so `animation-name` set in another rule survives
   minification (#914).

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -2020,6 +2020,44 @@ let extract_margin_block_side :
       Some (End, value, important)
   | _ -> None
 
+(* CSS Scroll Snap 1 sec. 6.1 and 6.2: the scroll-margin and scroll-padding
+   logical axes take [<length>{1,2}], the shape the margin and padding axes
+   take, so the same pair composition applies. *)
+let extract_scroll_margin_block_side :
+    declaration -> (axis_side * Values.length * bool) option = function
+  | Declaration { property = Scroll_margin_block_start; value; important; _ } ->
+      Some (Start, value, important)
+  | Declaration { property = Scroll_margin_block_end; value; important; _ } ->
+      Some (End, value, important)
+  | _ -> None
+
+let extract_scroll_margin_inline_side :
+    declaration -> (axis_side * Values.length * bool) option = function
+  | Declaration { property = Scroll_margin_inline_start; value; important; _ }
+    ->
+      Some (Start, value, important)
+  | Declaration { property = Scroll_margin_inline_end; value; important; _ } ->
+      Some (End, value, important)
+  | _ -> None
+
+let extract_scroll_padding_block_side :
+    declaration -> (axis_side * Values.length * bool) option = function
+  | Declaration { property = Scroll_padding_block_start; value; important; _ }
+    ->
+      Some (Start, value, important)
+  | Declaration { property = Scroll_padding_block_end; value; important; _ } ->
+      Some (End, value, important)
+  | _ -> None
+
+let extract_scroll_padding_inline_side :
+    declaration -> (axis_side * Values.length * bool) option = function
+  | Declaration { property = Scroll_padding_inline_start; value; important; _ }
+    ->
+      Some (Start, value, important)
+  | Declaration { property = Scroll_padding_inline_end; value; important; _ } ->
+      Some (End, value, important)
+  | _ -> None
+
 let extract_padding_inline_side :
     declaration -> (axis_side * Values.length * bool) option = function
   | Declaration { property = Padding_inline_start; value; important; _ } ->
@@ -2108,30 +2146,30 @@ let compose_pair_via_index idx =
     let build ~important ~value = Declaration.v ~important property value in
     try_compose_axis_pair_at idx ~extract ~build i
   in
+  (* One entry per logical axis family; each pairs a start longhand with its end
+     longhand under the shorthand that names the axis. *)
+  let axes i =
+    [
+      (fun () -> axis Margin_inline extract_margin_inline_side i);
+      (fun () -> axis Margin_block extract_margin_block_side i);
+      (fun () -> axis Padding_inline extract_padding_inline_side i);
+      (fun () -> axis Padding_block extract_padding_block_side i);
+      (fun () -> axis Inset_inline extract_inset_inline_side i);
+      (fun () -> axis Inset_block extract_inset_block_side i);
+      (fun () -> axis Scroll_margin_inline extract_scroll_margin_inline_side i);
+      (fun () -> axis Scroll_margin_block extract_scroll_margin_block_side i);
+      (fun () ->
+        axis Scroll_padding_inline extract_scroll_padding_inline_side i);
+      (fun () -> axis Scroll_padding_block extract_scroll_padding_block_side i);
+    ]
+  in
   let try_any i =
     match try_compose_gap_at idx i with
     | Some _ as r -> r
     | None -> (
-        match axis Margin_inline extract_margin_inline_side i with
+        match List.find_map (fun f -> f ()) (axes i) with
         | Some _ as r -> r
-        | None -> (
-            match axis Margin_block extract_margin_block_side i with
-            | Some _ as r -> r
-            | None -> (
-                match axis Padding_inline extract_padding_inline_side i with
-                | Some _ as r -> r
-                | None -> (
-                    match axis Padding_block extract_padding_block_side i with
-                    | Some _ as r -> r
-                    | None -> (
-                        match axis Inset_inline extract_inset_inline_side i with
-                        | Some _ as r -> r
-                        | None -> (
-                            match
-                              axis Inset_block extract_inset_block_side i
-                            with
-                            | Some _ as r -> r
-                            | None -> try_compose_place_at idx i))))))
+        | None -> try_compose_place_at idx i)
   in
   let n = Rule_index.length idx in
   let i = ref 0 in

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -544,6 +544,25 @@ let test_transition_contraction_covers_reset_longhands () =
    declaration that can reach the same element and holds that slot is at risk,
    whichever rule it sits in. Composition reads one rule, so it cannot see the
    holders next door. *)
+(* CSS Scroll Snap 1 sec. 6.1 and 6.2 give the scroll-margin and scroll-padding
+   logical axes the same [<length>{1,2}] shape the margin and padding axes have,
+   so the pair composes the same way. Without it the canonical comparator cannot
+   equate the shorthand with its own longhands. *)
+let test_scroll_axis_pair_composes () =
+  sheet_optimizes_to ~into:".x{scroll-margin-block:1px 2px}"
+    ".x{scroll-margin-block-start:1px;scroll-margin-block-end:2px}";
+  sheet_optimizes_to ~into:".x{scroll-margin-inline:1px}"
+    ".x{scroll-margin-inline-start:1px;scroll-margin-inline-end:1px}";
+  sheet_optimizes_to ~into:".x{scroll-padding-block:1px 2px}"
+    ".x{scroll-padding-block-start:1px;scroll-padding-block-end:2px}";
+  sheet_optimizes_to ~into:".x{scroll-padding-inline:3em}"
+    ".x{scroll-padding-inline-start:3em;scroll-padding-inline-end:3em}";
+  (* Mixed importance is not one declaration. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{scroll-margin-block-start:1px;scroll-margin-block-end:2px!important}"
+    ".x{scroll-margin-block-start:1px;scroll-margin-block-end:2px!important}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1123,6 +1142,8 @@ let suite =
         test_transition_contraction_covers_other_rules;
       Alcotest.test_case "animation contraction covers other rules" `Quick
         test_animation_contraction_covers_other_rules;
+      Alcotest.test_case "scroll axis pair composes" `Quick
+        test_scroll_axis_pair_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
CSS Scroll Snap 1 sec. 6.1 and 6.2 give the `scroll-margin` and `scroll-padding` logical axes the same `<length>{1,2}` shape the margin, padding and inset axes have, but the axis-pair table listed only those three. The scroll ones never contracted, so the canonical comparator could not equate `scroll-margin-block: 1px 2px` with `scroll-margin-block-start: 1px; scroll-margin-block-end: 2px` and reported a difference between a declaration and itself.

Takes `shorthand_expand` from 52 failing families to 48. The chain of nested matches became a list, since it now has ten entries.