### PR TITLE
minify: fold a repeated border side

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -544,6 +544,11 @@ entry points both moved.
 
 ### Minification
 
+- `--minify` folds a repeated side of `border-width` and of the three border
+  logical axes to the shortest spelling naming the same sides, as it already
+  did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px
+  2px` minifies to `border-width: 2px` (#917)
+
 - `--minify` no longer contracts a run of longhands one of which is `inherit`,
   `unset`, `revert` or `revert-layer`. A CSS-wide keyword is a whole
   declaration value, so pasting one into a shorthand made a declaration every

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -374,8 +374,13 @@ let normalize_logical_border_color ?(lossless = false) :
   match value with
   | Single c -> preserve_if_equal value (Single (normalize_color ~lossless c))
   | Pair (a, b) ->
-      preserve_if_equal value
-        (Pair (normalize_color ~lossless a, normalize_color ~lossless b))
+      let a = normalize_color ~lossless a and b = normalize_color ~lossless b in
+      if
+        (not (is_color_substitution a))
+        && (not (is_color_substitution b))
+        && Values.equal_color a b
+      then Single a
+      else preserve_if_equal value (Pair (a, b))
   | other -> other
 
 let rec normalize_shadow ?(lossless = false) : shadow -> shadow =
@@ -1946,12 +1951,37 @@ let border_width_has_runtime_subst (bw : border_width) : bool =
   | Clamp (lower, value, upper) -> calc lower || calc value || calc upper
   | _ -> false
 
+(* CSS Logical 1 sec. 4.3 and 4.4: an axis shorthand takes [<side>{1,2}], so a
+   repeated side has a shorter spelling naming the same two sides, exactly as
+   [collapse_box_shorthand] picks one for the four-side families. An arbitrary
+   substitution defers the component count to computed-value time, so a pair
+   holding one keeps both. *)
 let normalize_logical_border_width :
     logical_border_width -> logical_border_width =
  fun value ->
   match value with
   | Single w -> Single (normalize_border_width w)
-  | Pair (a, b) -> Pair (normalize_border_width a, normalize_border_width b)
+  | Pair (a, b) ->
+      let a = normalize_border_width a and b = normalize_border_width b in
+      if
+        (not (is_border_width_substitution a))
+        && (not (is_border_width_substitution b))
+        && equal_border_width a b
+      then Single a
+      else Pair (a, b)
+  | other -> other
+
+(* [border-style] takes keywords, so the axis has nothing to canonicalise per
+   value and only the spelling is at stake. *)
+let normalize_logical_border_style :
+    logical_border_style -> logical_border_style =
+ fun value ->
+  match value with
+  | Pair (a, b)
+    when (not (is_border_style_substitution a))
+         && (not (is_border_style_substitution b))
+         && equal_border_style a b ->
+      Single a
   | other -> other
 
 (* CSS Backgrounds 3 (ED) sec. 3.4: a shorthand sets every longhand it covers,

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -189,6 +189,10 @@ let is_border_style_substitution : border_style -> bool = function
   | Var _ -> true
   | _ -> false
 
+let is_border_width_substitution : border_width -> bool = function
+  | Var _ -> true
+  | _ -> false
+
 (* Canonicalise a box shorthand: normalise each side with [f], then pick the
    shortest of the spellings that name those sides. Keep the authored number of
    components when arbitrary substitution defers their computed arity. *)

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4490,7 +4490,9 @@ let normalize_property_value : type a.
   | Flood_opacity -> normalize_opacity value
   | Line_height -> normalize_line_height ~lossless value
   | Vertical_align -> normalize_vertical_align value
-  | Border_width -> map_preserve normalize_border_width value
+  | Border_width ->
+      normalize_box_shorthand ~is_substitution:is_border_width_substitution
+        normalize_border_width value
   | Border_top_width -> normalize_border_width value
   | Border_right_width -> normalize_border_width value
   | Border_bottom_width -> normalize_border_width value
@@ -4501,6 +4503,8 @@ let normalize_property_value : type a.
   | Border_block_end_width -> normalize_border_width value
   | Border_inline_width -> normalize_logical_border_width value
   | Border_block_width -> normalize_logical_border_width value
+  | Border_inline_style -> normalize_logical_border_style value
+  | Border_block_style -> normalize_logical_border_style value
   | Transition_duration -> Values.normalize_duration ~ctx value
   | Transition_delay -> Values.normalize_duration ~ctx value
   | Animation_duration -> Values.normalize_duration ~ctx value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -544,6 +544,21 @@ let special_cases () =
     "inset: 1px 1px 1px 1px";
   check_declaration ~expected:"border-color:red red red red"
     ~optimized:"border-color:red" "border-color: red red red red";
+  (* CSS Backgrounds 3 (ED) sec. 3.2 and 3.3 assign [border-width] and
+     [border-style] over the same four sides, and CSS Logical 1 sec. 4.3 and 4.4
+     give each of the three border axes its own one-to-two assignment. *)
+  check_declaration ~expected:"border-width:2px 2px 2px 2px"
+    ~optimized:"border-width:2px" "border-width: 2px 2px 2px 2px";
+  check_declaration ~expected:"border-width:2px 3px 2px 3px"
+    ~optimized:"border-width:2px 3px" "border-width: 2px 3px 2px 3px";
+  check_declaration ~expected:"border-inline-width:2px 2px"
+    ~optimized:"border-inline-width:2px" "border-inline-width: 2px 2px";
+  check_declaration ~expected:"border-block-width:1px 2px"
+    ~optimized:"border-block-width:1px 2px" "border-block-width: 1px 2px";
+  check_declaration ~expected:"border-block-style:solid solid"
+    ~optimized:"border-block-style:solid" "border-block-style: solid solid";
+  check_declaration ~expected:"border-inline-color:red red"
+    ~optimized:"border-inline-color:red" "border-inline-color: red red";
 
   (* CSS Lists 3 (ED) sec. 3.6: [list-style] is [<'list-style-position'> ||
      <'list-style-image'> || <'list-style-type'>], so a component left out takes


### PR DESCRIPTION
`border-width` and the three border logical axes kept a repeated value that the `margin`, `padding` and `border-color` spellings already fold away, so `border-width: 2px 2px 2px 2px` survived minification and `--diff=canonical` could not equate `border-inline-width: 2px 2px` with its own expansion. Follow-up to #916.