### PR TITLE
minify: read an initial border longhand as an omitted slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -546,7 +546,8 @@ entry points both moved.
 
 - `--minify` contracts the eight border sides from their own three longhands,
   as it already did for `outline`: `border-top-width`, `border-top-style` and
-  `border-top-color` written together become `border-top` (#918)
+  `border-top-color` written together become `border-top`, and a longhand
+  written `initial` reads as the component the shorthand leaves out (#918, #919)
 
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -2864,14 +2864,23 @@ let compose_border_via_index idx =
 let no_line : Properties.border_shorthand =
   { width = None; style = None; color = None }
 
+(* CSS Cascade 5 sec. 7.3: [initial] is the property's initial value, which is
+   what the shorthand assigns to a component left out, so the longhand fills its
+   slot in the run and contributes no value to it. *)
 let line_of_width v : line_part * Properties.border_shorthand =
-  (Width, { no_line with width = Some v })
+  match (v : Properties.border_width) with
+  | Initial -> (Width, no_line)
+  | v -> (Width, { no_line with width = Some v })
 
 let line_of_style v : line_part * Properties.border_shorthand =
-  (Style, { no_line with style = Some v })
+  match (v : Properties.border_style) with
+  | Initial -> (Style, no_line)
+  | v -> (Style, { no_line with style = Some v })
 
 let line_of_color v : line_part * Properties.border_shorthand =
-  (Color, { no_line with color = Some v })
+  match (v : Values.color) with
+  | Initial -> (Color, no_line)
+  | v -> (Color, { no_line with color = Some v })
 
 let merge_line (a : Properties.border_shorthand)
     (b : Properties.border_shorthand) : Properties.border_shorthand =

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -618,6 +618,18 @@ let test_line_shorthand_composes () =
       ".x{border-bottom-width:1px;border-bottom-style:solid;border-bottom-color:red!important}"
     ".x{border-bottom-width:1px;border-bottom-style:solid;border-bottom-color:red!important}"
 
+(* CSS Cascade 5 sec. 7.3: [initial] is the property's initial value, which is
+   what the shorthand assigns to a slot left out, so a longhand written that way
+   names the same declaration as an omitted component. *)
+let test_line_shorthand_initial_slot () =
+  sheet_optimizes_to ~into:".x{border-block-start:thin dashed}"
+    ".x{border-block-start-width:thin;border-block-start-style:dashed;border-block-start-color:initial}";
+  sheet_optimizes_to ~into:".x{border-top:dashed red}"
+    ".x{border-top-width:initial;border-top-style:dashed;border-top-color:red}";
+  (* Every slot at its initial is what [none] names. *)
+  sheet_optimizes_to ~into:".x{border-left:none}"
+    ".x{border-left-width:initial;border-left-style:initial;border-left-color:initial}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1203,6 +1215,8 @@ let suite =
         test_border_axis_pair_composes;
       Alcotest.test_case "line shorthand composes" `Quick
         test_line_shorthand_composes;
+      Alcotest.test_case "line shorthand initial slot" `Quick
+        test_line_shorthand_initial_slot;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
A component the shorthand leaves out takes its longhand's initial value, so a run holding `border-block-start-color: initial` names the same declaration as `border-block-start: thin dashed`. The composer used to keep the keyword as a slot value and the contraction was then refused for carrying a CSS-wide keyword beside other components. Follow-up to #918.