### PR TITLE
minify: contract the logical border shorthands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -549,6 +549,9 @@ entry points both moved.
   `border-top-color` written together become `border-top`, and a longhand
   written `initial` reads as the component the shorthand leaves out (#918, #919)
 
+- `--minify` contracts `border-block` and `border-inline` from the three axis
+  shorthands that set the same six longhands between them (#920)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -2985,6 +2985,29 @@ let try_compose_line_at ~part_of ~property idx i =
                    : Properties.border))
         | _ -> None
 
+(* CSS Logical 1 sec. 4.6: [border-block] and [border-inline] set the width,
+   style and colour of both sides of their axis and reset nothing else, which is
+   what the three axis shorthands set between them. An axis naming two different
+   sides has no slot in the shorthand, so only a single-valued one takes
+   part. *)
+let border_block_axis_part = function
+  | Declaration { property = Border_block_width; value = Single w; _ } ->
+      Some (line_of_width w)
+  | Declaration { property = Border_block_style; value = Single s; _ } ->
+      Some (line_of_style s)
+  | Declaration { property = Border_block_color; value = Single c; _ } ->
+      Some (line_of_color c)
+  | _ -> None
+
+let border_inline_axis_part = function
+  | Declaration { property = Border_inline_width; value = Single w; _ } ->
+      Some (line_of_width w)
+  | Declaration { property = Border_inline_style; value = Single s; _ } ->
+      Some (line_of_style s)
+  | Declaration { property = Border_inline_color; value = Single c; _ } ->
+      Some (line_of_color c)
+  | _ -> None
+
 let line_families =
   Properties.
     [
@@ -2996,6 +3019,8 @@ let line_families =
       (border_block_end_part, Border_block_end);
       (border_inline_start_part, Border_inline_start);
       (border_inline_end_part, Border_inline_end);
+      (border_block_axis_part, Border_block);
+      (border_inline_axis_part, Border_inline);
     ]
 
 let compose_line_via_index idx =

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -630,6 +630,24 @@ let test_line_shorthand_initial_slot () =
   sheet_optimizes_to ~into:".x{border-left:none}"
     ".x{border-left-width:initial;border-left-style:initial;border-left-color:initial}"
 
+(* CSS Logical 1 sec. 4.6: [border-block] and [border-inline] set the width,
+   style and colour of both sides of their axis, which is what the three axis
+   shorthands set between them, so a single-valued run of the three contracts
+   the way [border-width] / [border-style] / [border-color] contract into
+   [border]. *)
+let test_logical_border_whole_composes () =
+  sheet_optimizes_to ~into:".x{border-block:1px solid red}"
+    ".x{border-block-width:1px;border-block-style:solid;border-block-color:red}";
+  sheet_optimizes_to ~into:".x{border-inline:1px solid red}"
+    ".x{border-inline-start-width:1px;border-inline-end-width:1px;border-inline-start-style:solid;border-inline-end-style:solid;border-inline-start-color:red;border-inline-end-color:red}";
+  (* An axis naming two different sides has no slot in the shorthand. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{border-block-width:1px \
+       2px;border-block-style:solid;border-block-color:red}"
+    ".x{border-block-width:1px \
+     2px;border-block-style:solid;border-block-color:red}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1217,6 +1235,8 @@ let suite =
         test_line_shorthand_composes;
       Alcotest.test_case "line shorthand initial slot" `Quick
         test_line_shorthand_initial_slot;
+      Alcotest.test_case "logical border whole composes" `Quick
+        test_logical_border_whole_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
`border-block` and `border-inline` set the same six longhands their three axis shorthands set between them, but only the eight sides contracted, so an axis written out stayed three declarations and `--diff=canonical` could not equate it with the shorthand. Follow-up to #919.