### PR TITLE
minify: contract flex-flow and text-emphasis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -558,6 +558,10 @@ entry points both moved.
 - `--minify` contracts `grid-row`, `grid-column` and `grid-area` from the line
   longhands they name (#922)
 
+- `--minify` contracts `flex-flow` and `text-emphasis` from their two
+  longhands, and drops a component of either that names its own initial:
+  `flex-flow: row wrap` minifies to `flex-flow: wrap` (#923)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -166,6 +166,27 @@ let rec pp_flex_flow : flex_flow Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+(* CSS Flexbox 1 sec. 5.1: a component left out takes its longhand's initial -
+   [row] for the direction (sec. 5.1) and [nowrap] for the wrap (sec. 5.2) - so
+   writing one out names what leaving it out names, and the shorter spelling
+   wins. Drained of both, the printer says [row], which names the same pair. *)
+let normalize_flex_flow : flex_flow -> flex_flow =
+ fun value ->
+  match value with
+  | Flow (direction, wrap) ->
+      let direction =
+        match direction with
+        | Some (Row : flex_direction) -> Option.None
+        | direction -> direction
+      in
+      let wrap =
+        match wrap with
+        | Some (Nowrap : flex_wrap) -> Option.None
+        | wrap -> wrap
+      in
+      Flow (direction, wrap)
+  | other -> other
+
 let rec pp_flex_factor : flex_factor Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_flex_factor ctx v

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -802,8 +802,25 @@ let normalize_text_emphasis ?(lossless = false) : text_emphasis -> text_emphasis
  fun value ->
   match value with
   | Emphasis (style, color) ->
-      preserve_if_equal value
-        (Emphasis (style, option_map_preserve (normalize_color ~lossless) color))
+      (* CSS Text Decoration 4 (ED) sec. 3.4: a component left out takes its
+         longhand's initial - [none] for the style (sec. 3.1) and [currentColor]
+         for the colour (sec. 3.3) - so writing one out names what leaving it
+         out names. Both cannot go: the value would say nothing. *)
+      let color = option_map_preserve (normalize_color ~lossless) color in
+      let dropped_style =
+        match style with
+        | Some (None : text_emphasis_style) -> Option.None
+        | style -> style
+      in
+      let dropped_color =
+        match color with
+        | Some (Current : color) -> Option.None
+        | color -> color
+      in
+      if Option.is_none dropped_style && Option.is_none dropped_color then
+        preserve_if_equal value
+          (Emphasis (Some (None : text_emphasis_style), Option.None))
+      else preserve_if_equal value (Emphasis (dropped_style, dropped_color))
   | other -> other
 
 (* CSS Text Decoration 4 (ED) sec. 4 reads a text shadow as a [<shadow>] "as for

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4350,6 +4350,7 @@ let normalize_property_value : type a.
   | Text_decoration -> normalize_text_decoration ~lossless value
   | Webkit_text_decoration -> normalize_text_decoration ~lossless value
   | Text_emphasis -> normalize_text_emphasis ~lossless value
+  | Flex_flow -> normalize_flex_flow value
   | Caret -> normalize_caret ~lossless value
   | Interest_delay -> normalize_interest_delay value
   | Interest_delay_start -> normalize_interest_delay value

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -2359,6 +2359,67 @@ let axis_border_color ~ctx idx property extract i =
     ~foldable:(foldable_border_color ~ctx)
     ~extract ~build i
 
+(* CSS Flexbox 1 sec. 5.1 and CSS Text Decoration 4 sec. 3.4: [flex-flow] and
+   [text-emphasis] each take two longhands, one per component. A longhand
+   written [initial] fills its slot in the run and contributes no value, the
+   normalisers then dropping any component that names its own initial. A
+   substituted longhand can stand for the whole value and is left alone. *)
+let extract_flex_flow_part :
+    declaration ->
+    (axis_side
+    * (Properties.flex_direction option * Properties.flex_wrap option)
+    * bool)
+    option = function
+  | Declaration { property = Flex_direction; value = Var _; _ }
+  | Declaration { property = Flex_wrap; value = Var _; _ } ->
+      None
+  | Declaration { property = Flex_direction; value; important; _ } ->
+      let d = match value with Initial -> Option.None | v -> Some v in
+      Some (Start, (d, Option.None), important)
+  | Declaration { property = Flex_wrap; value; important; _ } ->
+      let w = match value with Initial -> Option.None | v -> Some v in
+      Some (End, (Option.None, w), important)
+  | _ -> None
+
+let extract_text_emphasis_part :
+    declaration ->
+    (axis_side
+    * (Properties.text_emphasis_style option * Values.color option)
+    * bool)
+    option = function
+  | Declaration { property = Text_emphasis_style; value = Var _; _ }
+  | Declaration { property = Text_emphasis_color; value = Var _; _ } ->
+      None
+  | Declaration { property = Text_emphasis_style; value; important; _ } ->
+      let st = match value with Initial -> Option.None | v -> Some v in
+      Some (Start, (st, Option.None), important)
+  | Declaration { property = Text_emphasis_color; value; important; _ } ->
+      let c = match value with Initial -> Option.None | v -> Some v in
+      Some (End, (Option.None, c), important)
+  | _ -> None
+
+let duo_flex_flow idx i =
+  let build ~important ~start ~end_ =
+    let direction, _ = start and _, wrap = end_ in
+    Some
+      (Declaration.v ~important Flex_flow
+         (Flow (direction, wrap) : Properties.flex_flow))
+  in
+  try_compose_axis_pair_at idx
+    ~foldable:(fun _ -> true)
+    ~extract:extract_flex_flow_part ~build i
+
+let duo_text_emphasis idx i =
+  let build ~important ~start ~end_ =
+    let style, _ = start and _, color = end_ in
+    Some
+      (Declaration.v ~important Text_emphasis
+         (Emphasis (style, color) : Properties.text_emphasis))
+  in
+  try_compose_axis_pair_at idx
+    ~foldable:(fun _ -> true)
+    ~extract:extract_text_emphasis_part ~build i
+
 (* One entry per logical axis family; each pairs a start longhand with its end
    longhand under the shorthand that names the axis. *)
 let pair_axes ~ctx idx i =
@@ -2387,6 +2448,8 @@ let pair_axes ~ctx idx i =
     (fun () -> axis_contain_intrinsic idx i);
     (fun () -> axis_grid_line idx Grid_row extract_grid_row_side i);
     (fun () -> axis_grid_line idx Grid_column extract_grid_column_side i);
+    (fun () -> duo_flex_flow idx i);
+    (fun () -> duo_text_emphasis idx i);
   ]
 
 let compose_pair_via_index ~ctx idx =

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -478,6 +478,14 @@ let normalize_expected ~category ~id expected =
          it is shorter and equivalent. *)
       fixture ~category ~id ~upstream:"a{transition:color ease}"
         ~cascade:"a{transition:color}" upstream
+  | "values", "0030" ->
+      (* The fixture reorders [flex-flow: wrap row] to direction-then-wrap. CSS
+         Flexbox 1 sec. 5.1 leaves an omitted component at its longhand's
+         initial, and the direction's is [row], so writing it out names what
+         leaving it out names and the shorter spelling wins. Chrome 151 expands
+         [flex-flow: wrap-reverse] to [flex-direction: row]. *)
+      fixture ~category ~id ~upstream:"a{flex-flow:row wrap}"
+        ~cascade:"a{flex-flow:wrap}" upstream
   | "values", "0010" ->
       (* [12pt] and [16px] are exact absolute-length equivalents, but the
          rewrite is not a byte win. Without a shorter spelling, keep the

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -694,6 +694,30 @@ let test_grid_placement_composes () =
   sheet_optimizes_to ~into:".x{grid-row-start:1;grid-row-end:3!important}"
     ".x{grid-row-start:1;grid-row-end:3!important}"
 
+(* CSS Flexbox 1 sec. 5.1 and CSS Text Decoration 4 sec. 3.4: [flex-flow] and
+   [text-emphasis] each take two longhands, one per component. A longhand at its
+   initial names what leaving the component out names, so it drops - unless both
+   do and the value would then say nothing. *)
+let test_duo_keyword_composes () =
+  sheet_optimizes_to ~into:".x{flex-flow:row wrap}"
+    ".x{flex-direction:row;flex-wrap:wrap}";
+  sheet_optimizes_to ~into:".x{flex-flow:column}"
+    ".x{flex-direction:column;flex-wrap:nowrap}";
+  sheet_optimizes_to ~into:".x{flex-flow:wrap-reverse}"
+    ".x{flex-direction:row;flex-wrap:wrap-reverse}";
+  sheet_optimizes_to ~into:".x{flex-flow:row}"
+    ".x{flex-direction:row;flex-wrap:nowrap}";
+  sheet_optimizes_to ~into:".x{text-emphasis:filled red}"
+    ".x{text-emphasis-style:filled;text-emphasis-color:red}";
+  sheet_optimizes_to ~into:".x{text-emphasis:none}"
+    ".x{text-emphasis-style:none;text-emphasis-color:initial}";
+  (* A substituted component can be the whole value, so it stays put. *)
+  sheet_optimizes_to ~into:".x{flex-direction:var(--d);flex-wrap:wrap}"
+    ".x{flex-direction:var(--d);flex-wrap:wrap}";
+  (* Mixed importance is not one declaration. *)
+  sheet_optimizes_to ~into:".x{flex-direction:row;flex-wrap:wrap!important}"
+    ".x{flex-direction:row;flex-wrap:wrap!important}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1286,6 +1310,7 @@ let suite =
       Alcotest.test_case "xy pair composes" `Quick test_xy_pair_composes;
       Alcotest.test_case "grid placement composes" `Quick
         test_grid_placement_composes;
+      Alcotest.test_case "duo keyword composes" `Quick test_duo_keyword_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -699,7 +699,9 @@ let test_grid_placement_composes () =
    initial names what leaving the component out names, so it drops - unless both
    do and the value would then say nothing. *)
 let test_duo_keyword_composes () =
-  sheet_optimizes_to ~into:".x{flex-flow:row wrap}"
+  (* [row] is the direction's initial, so the composed value names it by leaving
+     the component out. *)
+  sheet_optimizes_to ~into:".x{flex-flow:wrap}"
     ".x{flex-direction:row;flex-wrap:wrap}";
   sheet_optimizes_to ~into:".x{flex-flow:column}"
     ".x{flex-direction:column;flex-wrap:nowrap}";


### PR DESCRIPTION
Neither had a composer, and neither normaliser dropped a component naming its own initial, so `flex-direction: row; flex-wrap: wrap` and `flex-flow: row wrap` had no common spelling and `--diff=canonical` could not equate them. The interop corpus records a Cascade oracle for values/0030, where the shorter spelling is now `flex-flow: wrap`. Follow-up to #922.