### PR TITLE
minify: contract animation-range and scroll-timeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -562,6 +562,10 @@ entry points both moved.
   longhands, and drops a component of either that names its own initial:
   `flex-flow: row wrap` minifies to `flex-flow: wrap` (#923)
 
+- `--minify` contracts `animation-range` and `scroll-timeline` from their two
+  longhands, and drops a `scroll-timeline` axis that names its own initial:
+  `scroll-timeline: --t block` minifies to `scroll-timeline: --t` (#924)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -344,6 +344,22 @@ let pp_timeline_shorthand_item : timeline_shorthand_item Pp.t =
       Pp.space ctx ();
       pp_timeline_axis ctx axis
 
+(* CSS Scroll Animations 1 sec. 4.3: [scroll-timeline] is [<name> <axis>?], and
+   an axis left out takes [scroll-timeline-axis]'s initial (sec. 4.2), which is
+   [block]. Writing it out names what leaving it out names, so the shorter
+   spelling wins. *)
+let normalize_timeline_shorthand : timeline_shorthand -> timeline_shorthand =
+ fun value ->
+  let drop_initial_axis (item : timeline_shorthand_item) =
+    match item.axis with
+    | Some (Block : timeline_axis) | Some Initial ->
+        { item with axis = Option.None }
+    | _ -> item
+  in
+  match value with
+  | Timelines items -> Timelines (map_preserve drop_initial_axis items)
+  | other -> other
+
 let rec pp_timeline_shorthand : timeline_shorthand Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4299,6 +4299,7 @@ let normalize_property_value : type a.
   | Webkit_mask_position -> map_preserve normalize_position_value value
   | Text_indent -> normalize_text_indent value
   | Animation_range -> normalize_animation_range value
+  | Scroll_timeline -> normalize_timeline_shorthand value
   | View_timeline_inset -> normalize_timeline_inset value
   | Baseline_shift -> normalize_baseline_shift value
   | Background_color -> normalize_color value

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -2420,6 +2420,77 @@ let duo_text_emphasis idx i =
     ~foldable:(fun _ -> true)
     ~extract:extract_text_emphasis_part ~build i
 
+(* CSS Animations 2 sec. 6.3 and CSS Scroll Animations 1 sec. 4.3:
+   [animation-range] is [<start> <end>?] and [scroll-timeline] is [<name>
+   <axis>?], each written over its own two longhands. *)
+let extract_animation_range_part :
+    declaration ->
+    (axis_side
+    * (Properties.animation_range_item option
+      * Properties.animation_range_item option)
+    * bool)
+    option = function
+  | Declaration { property = Animation_range_start; value = Var _; _ }
+  | Declaration { property = Animation_range_end; value = Var _; _ } ->
+      None
+  | Declaration { property = Animation_range_start; value; important; _ } ->
+      Some (Start, (Some value, Option.None), important)
+  | Declaration { property = Animation_range_end; value; important; _ } ->
+      Some (End, (Option.None, Some value), important)
+  | _ -> None
+
+let extract_scroll_timeline_part :
+    declaration ->
+    (axis_side
+    * (Properties.timeline_name option * Properties.timeline_axis option)
+    * bool)
+    option = function
+  | Declaration { property = Scroll_timeline_name; value = Var _; _ }
+  | Declaration { property = Scroll_timeline_axis; value = Var _; _ } ->
+      None
+  | Declaration { property = Scroll_timeline_name; value; important; _ } ->
+      Some (Start, (Some value, Option.None), important)
+  | Declaration { property = Scroll_timeline_axis; value; important; _ } ->
+      Some (End, (Option.None, Some value), important)
+  | _ -> None
+
+let duo_animation_range idx i =
+  let build ~important ~start ~end_ =
+    let range_start, _ = start and _, range_end = end_ in
+    match range_start with
+    | Option.None -> Option.None
+    | Some range_start ->
+        Some
+          (Declaration.v ~important Animation_range
+             (Range (range_start, range_end) : Properties.animation_range))
+  in
+  try_compose_axis_pair_at idx
+    ~foldable:(fun _ -> true)
+    ~extract:extract_animation_range_part ~build i
+
+(* [scroll-timeline: none] leaves the axis at [block], so a named axis beside an
+   unnamed timeline has no shorthand spelling, and neither has a name list: the
+   shorthand pairs each name with its own axis. *)
+let duo_scroll_timeline idx i =
+  let build ~important ~start ~end_ =
+    let name, _ = start and _, axis = end_ in
+    let axis =
+      match axis with
+      | Some (Block : Properties.timeline_axis) | Some Initial -> Option.None
+      | axis -> axis
+    in
+    let value : Properties.timeline_shorthand option =
+      match (name : Properties.timeline_name option) with
+      | Some None when Option.is_none axis -> Some None
+      | Some (Names [ n ]) -> Some (Timelines [ { name = n; axis } ])
+      | _ -> Option.None
+    in
+    Option.map (Declaration.v ~important Scroll_timeline) value
+  in
+  try_compose_axis_pair_at idx
+    ~foldable:(fun _ -> true)
+    ~extract:extract_scroll_timeline_part ~build i
+
 (* One entry per logical axis family; each pairs a start longhand with its end
    longhand under the shorthand that names the axis. *)
 let pair_axes ~ctx idx i =
@@ -2450,6 +2521,8 @@ let pair_axes ~ctx idx i =
     (fun () -> axis_grid_line idx Grid_column extract_grid_column_side i);
     (fun () -> duo_flex_flow idx i);
     (fun () -> duo_text_emphasis idx i);
+    (fun () -> duo_animation_range idx i);
+    (fun () -> duo_scroll_timeline idx i);
   ]
 
 let compose_pair_via_index ~ctx idx =

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1400,9 +1400,11 @@ let shorthand_longhand_order_cases =
     ( "container",
       ".a{container:a/size;container-type:normal}",
       ".a{container:a/size;container-type:normal}" );
+    (* CSS Scroll Animations 1 sec. 4.2 makes [block] the axis's initial, so the
+       shorthand names it by leaving the component out. *)
     ( "scroll-timeline",
       ".a{scroll-timeline:--a block;scroll-timeline-axis:inline}",
-      ".a{scroll-timeline:--a block;scroll-timeline-axis:inline}" );
+      ".a{scroll-timeline:--a;scroll-timeline-axis:inline}" );
     ( "view-timeline",
       ".a{view-timeline:--a block;view-timeline-axis:inline}",
       ".a{view-timeline:--a block;view-timeline-axis:inline}" );

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -720,6 +720,29 @@ let test_duo_keyword_composes () =
   sheet_optimizes_to ~into:".x{flex-direction:row;flex-wrap:wrap!important}"
     ".x{flex-direction:row;flex-wrap:wrap!important}"
 
+(* CSS Animations 2 sec. 6.3 and CSS Scroll Animations 1 sec. 4.3:
+   [animation-range] is [<start> <end>?] and [scroll-timeline] is [<name>
+   <axis>?], each over its own two longhands. *)
+let test_timeline_range_composes () =
+  sheet_optimizes_to ~into:".x{animation-range:normal}"
+    ".x{animation-range-start:normal;animation-range-end:normal}";
+  sheet_optimizes_to ~into:".x{animation-range:entry 10%exit 90%}"
+    ".x{animation-range-start:entry 10%;animation-range-end:exit 90%}";
+  sheet_optimizes_to ~into:".x{scroll-timeline:--t block}"
+    ".x{scroll-timeline-name:--t;scroll-timeline-axis:block}";
+  sheet_optimizes_to ~into:".x{scroll-timeline:none}"
+    ".x{scroll-timeline-name:none;scroll-timeline-axis:block}";
+  (* [scroll-timeline: none] sets the axis to [block], so a named axis beside an
+     unnamed timeline has no shorthand spelling. *)
+  sheet_optimizes_to
+    ~into:".x{scroll-timeline-name:none;scroll-timeline-axis:inline}"
+    ".x{scroll-timeline-name:none;scroll-timeline-axis:inline}";
+  (* Mixed importance is not one declaration. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{animation-range-start:normal;animation-range-end:normal!important}"
+    ".x{animation-range-start:normal;animation-range-end:normal!important}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1313,6 +1336,8 @@ let suite =
       Alcotest.test_case "grid placement composes" `Quick
         test_grid_placement_composes;
       Alcotest.test_case "duo keyword composes" `Quick test_duo_keyword_composes;
+      Alcotest.test_case "timeline and range compose" `Quick
+        test_timeline_range_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -728,7 +728,9 @@ let test_timeline_range_composes () =
     ".x{animation-range-start:normal;animation-range-end:normal}";
   sheet_optimizes_to ~into:".x{animation-range:entry 10%exit 90%}"
     ".x{animation-range-start:entry 10%;animation-range-end:exit 90%}";
-  sheet_optimizes_to ~into:".x{scroll-timeline:--t block}"
+  (* [block] is the axis's initial, so the composed value names it by leaving
+     the component out. *)
+  sheet_optimizes_to ~into:".x{scroll-timeline:--t}"
     ".x{scroll-timeline-name:--t;scroll-timeline-axis:block}";
   sheet_optimizes_to ~into:".x{scroll-timeline:none}"
     ".x{scroll-timeline-name:none;scroll-timeline-axis:block}";


### PR DESCRIPTION
Neither had a composer, and `scroll-timeline` kept an axis naming its own initial, so `--diff=canonical` could not equate either shorthand with its two longhands. Follow-up to #923.