### PR TITLE
minify: contract container and view-timeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -566,6 +566,9 @@ entry points both moved.
   longhands, and drops a `scroll-timeline` axis that names its own initial:
   `scroll-timeline: --t block` minifies to `scroll-timeline: --t` (#924)
 
+- `--minify` contracts `container` and `view-timeline` from their longhands,
+  and drops a `view-timeline` axis or inset that names its own initial (#925)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -360,6 +360,30 @@ let normalize_timeline_shorthand : timeline_shorthand -> timeline_shorthand =
   | Timelines items -> Timelines (map_preserve drop_initial_axis items)
   | other -> other
 
+(* Same reading for [view-timeline] (CSS Scroll Animations 1 sec. 5.2), which
+   carries an inset slot as well; [auto] is its initial (sec. 5.3). *)
+let normalize_view_timeline_shorthand :
+    view_timeline_shorthand -> view_timeline_shorthand =
+ fun value ->
+  let drop_initials (item : view_timeline_shorthand_item) =
+    let axis =
+      match item.axis with
+      | Some (Block : timeline_axis) | Some Initial -> Option.None
+      | axis -> axis
+    in
+    let inset =
+      match item.inset with
+      | Some (Inset (Auto, Option.None) : timeline_inset) | Some Initial ->
+          Option.None
+      | inset -> inset
+    in
+    if axis == item.axis && inset == item.inset then item
+    else { item with axis; inset }
+  in
+  match value with
+  | Timelines items -> Timelines (map_preserve drop_initials items)
+  | other -> other
+
 let rec pp_timeline_shorthand : timeline_shorthand Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4300,6 +4300,7 @@ let normalize_property_value : type a.
   | Text_indent -> normalize_text_indent value
   | Animation_range -> normalize_animation_range value
   | Scroll_timeline -> normalize_timeline_shorthand value
+  | View_timeline -> normalize_view_timeline_shorthand value
   | View_timeline_inset -> normalize_timeline_inset value
   | Baseline_shift -> normalize_baseline_shift value
   | Background_color -> normalize_color value

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -2491,6 +2491,45 @@ let duo_scroll_timeline idx i =
     ~foldable:(fun _ -> true)
     ~extract:extract_scroll_timeline_part ~build i
 
+(* CSS Contain 3 sec. 4.3: [container] is [<name> [/ <type>]?] over its two
+   longhands, and [normal] is the type's initial (sec. 4.2), so writing it out
+   names what leaving it out names. The shorthand pairs one name with one type,
+   so a name list has no spelling in it. *)
+let extract_container_part :
+    declaration ->
+    (axis_side
+    * (Properties.container_name option * Properties.container_type option)
+    * bool)
+    option = function
+  | Declaration { property = Container_name; value = Var _; _ }
+  | Declaration { property = Container_type; value = Var _; _ } ->
+      None
+  | Declaration { property = Container_name; value; important; _ } ->
+      Some (Start, (Some value, Option.None), important)
+  | Declaration { property = Container_type; value; important; _ } ->
+      Some (End, (Option.None, Some value), important)
+  | _ -> None
+
+let duo_container idx i =
+  let build ~important ~start ~end_ =
+    let name, _ = start and _, ctype = end_ in
+    let ctype =
+      match ctype with
+      | Some (Normal : Properties.container_type) | Some Initial -> Option.None
+      | ctype -> ctype
+    in
+    let value : Properties.container_shorthand option =
+      match (name : Properties.container_name option) with
+      | Some None -> Some (Shorthand { name = Some "none"; ctype })
+      | Some (Names [ n ]) -> Some (Shorthand { name = Some n; ctype })
+      | _ -> Option.None
+    in
+    Option.map (Declaration.v ~important Container) value
+  in
+  try_compose_axis_pair_at idx
+    ~foldable:(fun _ -> true)
+    ~extract:extract_container_part ~build i
+
 (* One entry per logical axis family; each pairs a start longhand with its end
    longhand under the shorthand that names the axis. *)
 let pair_axes ~ctx idx i =
@@ -2523,6 +2562,7 @@ let pair_axes ~ctx idx i =
     (fun () -> duo_text_emphasis idx i);
     (fun () -> duo_animation_range idx i);
     (fun () -> duo_scroll_timeline idx i);
+    (fun () -> duo_container idx i);
   ]
 
 let compose_pair_via_index ~ctx idx =
@@ -3293,6 +3333,75 @@ let compose_line_via_index idx =
       compose_fixed3_via_index idx
         ~try_compose:(try_compose_line_at ~part_of ~property))
     line_families
+
+(* CSS Scroll Animations 1 sec. 5.2: [view-timeline] is [<name> <axis>?
+   <inset>?] over its three longhands, with [block] the axis's initial (sec.
+   5.1) and [auto] the inset's (sec. 5.3), so a modifier written out at its
+   initial names what leaving it out names. The shorthand pairs one name with
+   its own modifiers, so a name list has no spelling in it. *)
+type view_timeline_part =
+  | Name of Properties.timeline_name
+  | Axis of Properties.timeline_axis
+  | Inset of Properties.timeline_inset
+
+let view_timeline_part_of : declaration -> view_timeline_part option = function
+  | Declaration { property = View_timeline_name; value; _ } -> Some (Name value)
+  | Declaration { property = View_timeline_axis; value; _ } -> Some (Axis value)
+  | Declaration { property = View_timeline_inset; value; _ } ->
+      Some (Inset value)
+  | _ -> None
+
+let view_timeline_slot = function Name _ -> 0 | Axis _ -> 1 | Inset _ -> 2
+
+let view_timeline_item parts : Properties.view_timeline_shorthand_item option =
+  let pick f = List.find_map f parts in
+  let name = pick (function Name n -> Some n | _ -> Option.None) in
+  let axis =
+    pick (function
+      | Axis (Block : Properties.timeline_axis) | Axis Initial -> Option.None
+      | Axis a -> Some a
+      | _ -> Option.None)
+  in
+  let inset =
+    pick (function
+      | Inset (Inset (Auto, Option.None) : Properties.timeline_inset)
+      | Inset Initial ->
+          Option.None
+      | Inset i -> Some i
+      | _ -> Option.None)
+  in
+  match (name : Properties.timeline_name option) with
+  | Some (Names [ n ]) -> Some { name = n; axis; inset }
+  | Some None when Option.is_none axis && Option.is_none inset ->
+      Some { name = "none"; axis; inset }
+  | _ -> Option.None
+
+let view_timeline_of_run raw =
+  let parts = List.filter_map view_timeline_part_of raw in
+  let slots = List.sort_uniq compare (List.map view_timeline_slot parts) in
+  if List.length slots <> 3 then None else view_timeline_item parts
+
+let try_compose_view_timeline_at idx i =
+  let n = Rule_index.length idx in
+  if i + 2 >= n then None
+  else
+    let positions = [ i; i + 1; i + 2 ] in
+    if List.exists (Rule_index.is_absorbed idx) positions then None
+    else
+      let raw = List.map (Rule_index.decl_at idx) positions in
+      if (not (same_importance raw)) || List.exists has_runtime_substitution raw
+      then None
+      else
+        Option.map
+          (fun item ->
+            Declaration.v
+              ~important:(is_important (List.hd raw))
+              View_timeline
+              (Timelines [ item ] : Properties.view_timeline_shorthand))
+          (view_timeline_of_run raw)
+
+let compose_view_timeline_via_index idx =
+  compose_fixed3_via_index idx ~try_compose:try_compose_view_timeline_at
 
 (* Compose the [border] shorthand from the three whole-border longhands
    [border-width] / [border-style] / [border-color] when they appear as a
@@ -5072,6 +5181,7 @@ let compose_index_group_a ~ctx kept =
   compose_box_via_index ~ctx idx;
   compose_pair_via_index ~ctx idx;
   compose_outline_via_index idx;
+  compose_view_timeline_via_index idx;
   List.mapi (fun i d -> (i, d)) (Rule_index.to_list idx)
 
 (* Second index group runs after the font-reset reorder. Font + list-style +

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1407,7 +1407,7 @@ let shorthand_longhand_order_cases =
       ".a{scroll-timeline:--a;scroll-timeline-axis:inline}" );
     ( "view-timeline",
       ".a{view-timeline:--a block;view-timeline-axis:inline}",
-      ".a{view-timeline:--a block;view-timeline-axis:inline}" );
+      ".a{view-timeline:--a;view-timeline-axis:inline}" );
     ("caret", ".a{caret:red;caret-shape:bar}", ".a{caret:red;caret-shape:bar}");
     ( "text-box",
       ".a{text-box:trim-both cap alphabetic;text-box-edge:auto}",

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -745,6 +745,33 @@ let test_timeline_range_composes () =
       ".x{animation-range-start:normal;animation-range-end:normal!important}"
     ".x{animation-range-start:normal;animation-range-end:normal!important}"
 
+(* CSS Contain 3 sec. 4.3 and CSS Scroll Animations 1 sec. 5.2: [container] is
+   [<name> [/ <type>]?] and [view-timeline] is [<name> <axis>? <inset>?], each
+   over its own name longhand and its modifiers. A modifier at its initial names
+   what leaving it out names. *)
+let test_named_shorthand_composes () =
+  sheet_optimizes_to ~into:".x{container:card/inline-size}"
+    ".x{container-name:card;container-type:inline-size}";
+  sheet_optimizes_to ~into:".x{container:none}"
+    ".x{container-name:none;container-type:normal}";
+  sheet_optimizes_to ~into:".x{container:card}"
+    ".x{container-name:card;container-type:normal}";
+  sheet_optimizes_to ~into:".x{view-timeline:--v}"
+    ".x{view-timeline-name:--v;view-timeline-axis:block;view-timeline-inset:auto}";
+  sheet_optimizes_to ~into:".x{view-timeline:--v inline}"
+    ".x{view-timeline-name:--v;view-timeline-axis:inline;view-timeline-inset:auto}";
+  sheet_optimizes_to ~into:".x{view-timeline:none}"
+    ".x{view-timeline-name:none;view-timeline-axis:block;view-timeline-inset:auto}";
+  (* An unnamed timeline carries no modifier, so a non-initial one beside it has
+     no shorthand spelling. *)
+  sheet_optimizes_to
+    ~into:".x{view-timeline-name:none;view-timeline-axis:inline}"
+    ".x{view-timeline-name:none;view-timeline-axis:inline}";
+  (* Mixed importance is not one declaration. *)
+  sheet_optimizes_to
+    ~into:".x{container-name:card;container-type:inline-size!important}"
+    ".x{container-name:card;container-type:inline-size!important}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1340,6 +1367,8 @@ let suite =
       Alcotest.test_case "duo keyword composes" `Quick test_duo_keyword_composes;
       Alcotest.test_case "timeline and range compose" `Quick
         test_timeline_range_composes;
+      Alcotest.test_case "named shorthand composes" `Quick
+        test_named_shorthand_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
Neither had a composer, and `view-timeline` kept an axis or inset naming its own initial, so `--diff=canonical` could not equate either shorthand with its longhands. Follow-up to #924.