### PR TITLE
properties: add the background-position axis longhands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -569,6 +569,11 @@ entry points both moved.
 - `--minify` contracts `container` and `view-timeline` from their longhands,
   and drops a `view-timeline` axis or inset that names its own initial (#925)
 
+- `--minify` contracts `background-position` from `background-position-x` and
+  `background-position-y`, which this release adds as typed properties: they
+  used to parse as unknown declarations, so nothing could equate the shorthand
+  with them (#926)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1413,6 +1413,10 @@ let read_background_value : type a. a property -> Cursor.t -> declaration option
       Some (v Webkit_background_clip (read_background_box_list t))
   | Background_position ->
       Some (v Background_position (read_background_position t))
+  | Background_position_x ->
+      Some (v Background_position_x (read_background_position_x t))
+  | Background_position_y ->
+      Some (v Background_position_y (read_background_position_y t))
   | Background_repeat ->
       Some (v Background_repeat (read_background_repeat_list t))
   | Background_size -> Some (v Background_size (read_background_size_list t))

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1022,6 +1022,31 @@ let rec pp_background_size : background_size Pp.t =
 let pp_background_position : background_position Pp.t =
  fun ctx positions -> Pp.list ~sep:Pp.comma pp_position_value ctx positions
 
+(* CSS Backgrounds 4 sec. 3.3: each axis longhand is [center | [<edge>?
+   <length-percentage>]], the edge naming that axis only. *)
+let pp_position_axis_edge : position_axis_edge Pp.t =
+ fun ctx -> function
+  | Left -> Pp.string ctx "left"
+  | Right -> Pp.string ctx "right"
+  | Top -> Pp.string ctx "top"
+  | Bottom -> Pp.string ctx "bottom"
+
+let rec pp_background_position_axis : background_position_axis Pp.t =
+ fun ctx -> function
+  | Center -> Pp.string ctx "center"
+  | Edge e -> pp_position_axis_edge ctx e
+  | Offset lp -> pp_length_percentage ctx lp
+  | Edge_offset (e, lp) ->
+      pp_position_axis_edge ctx e;
+      Pp.space ctx ();
+      pp_length_percentage ctx lp
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_background_position_axis ctx v
+
 let pp_bg_prop maybe_space pp_func ctx = function
   | Some value ->
       maybe_space ();
@@ -1704,8 +1729,80 @@ let read_background_box_list t : background_box =
   | [ one ] -> one
   | many -> Layers many
 
+(* CSS Backgrounds 4 sec. 3.3 measures a bare offset from the start edge, so
+   [left 10px] and [10px] name the same position and the shorter wins. The zero
+   percentage of the start edge is what [left] / [top] names, and the hundred
+   percent is [right] / [bottom]. *)
+let normalize_background_position_axis :
+    background_position_axis -> background_position_axis =
+ fun value ->
+  let lp = Values.normalize_length_percentage in
+  let start_edge : position_axis_edge -> bool = function
+    | Left | Top -> true
+    | _ -> false
+  in
+  match value with
+  | Offset o -> preserve_if_equal value (Offset (lp o))
+  | Edge_offset (e, o) when start_edge e -> Offset (lp o)
+  | Edge_offset (e, o) -> preserve_if_equal value (Edge_offset (e, lp o))
+  | other -> other
+
 let read_background_position t : background_position =
   Cursor.list ~at_least:1 ~sep:Cursor.comma read_background_position_value t
+
+(* The edge keywords belong to one axis each, so the reader takes the pair its
+   property accepts and refuses the other axis's. An edge may carry an offset
+   from it; a bare offset is measured from the start edge. *)
+let read_background_position_axis ~label ~start_edge ~end_edge =
+  let rec read t : background_position_axis =
+    let edges =
+      [
+        (Pp.to_string pp_position_axis_edge start_edge, start_edge);
+        (Pp.to_string pp_position_axis_edge end_edge, end_edge);
+      ]
+    in
+    let after_edge e t : background_position_axis =
+      if Cursor.is_done t || Cursor.peek_comma t then Edge e
+      else
+        let snap = Cursor.save t in
+        match Values.read_length_percentage t with
+        | lp -> Edge_offset (e, lp)
+        | exception Cursor.Parse_error _ ->
+            Cursor.restore t snap;
+            Edge e
+    in
+    Cursor.enum_or_whole_value_var label
+      [
+        ("inherit", (Inherit : background_position_axis));
+        ("initial", Initial);
+        ("unset", Unset);
+        ("revert", Revert);
+        ("revert-layer", Revert_layer);
+      ]
+      ~var:(fun t -> Var (Values.read_var read t))
+      ~default:(fun t : background_position_axis ->
+        match Cursor.peek_ident t with
+        | Some "center" ->
+            ignore (Cursor.ident_opt t);
+            Center
+        | Some name -> (
+            match List.assoc_opt name edges with
+            | Some e ->
+                ignore (Cursor.ident_opt t);
+                after_edge e t
+            | Option.None -> Cursor.err_expected t label)
+        | Option.None -> Offset (Values.read_length_percentage t))
+      t
+  in
+  read
+
+let read_background_position_x t =
+  read_background_position_axis ~label:"background-position-x" ~start_edge:Left
+    ~end_edge:Right t
+
+let read_background_position_y t =
+  read_background_position_axis ~label:"background-position-y" ~start_edge:Top
+    ~end_edge:Bottom t
 
 module Background_shorthand = struct
   let read_image_item t =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -620,6 +620,8 @@ let pp_property : type a. a property Pp.t =
   | Vertical_align -> Pp.string ctx "vertical-align"
   | Font_family -> Pp.string ctx "font-family"
   | Background_position -> Pp.string ctx "background-position"
+  | Background_position_x -> Pp.string ctx "background-position-x"
+  | Background_position_y -> Pp.string ctx "background-position-y"
   | Background_repeat -> Pp.string ctx "background-repeat"
   | Background_size -> Pp.string ctx "background-size"
   | Webkit_font_smoothing -> Pp.string ctx "-webkit-font-smoothing"
@@ -1037,28 +1039,29 @@ let property_class : type a. a property -> a property_class = function
   | Content_visibility | Filter | Background_image | Background_origin
   | Background_clip | Webkit_background_clip | Animation | Aspect_ratio
   | Overflow_x | Overflow_y | Overflow_block | Overflow_inline | Vertical_align
-  | Background_position | Background_repeat | Background_size
-  | Webkit_line_clamp | Webkit_box_orient | Moz_orient | Text_overflow
-  | Backdrop_filter | Webkit_backdrop_filter | Webkit_mask_image
-  | Webkit_mask_composite | Webkit_mask_source_type | Webkit_mask_size
-  | Webkit_mask_position | Webkit_mask_repeat | Webkit_mask_clip
-  | Webkit_mask_origin | Mask_image | Mask_composite | Mask_mode | Mask_size
-  | Mask_position | Mask_repeat | Mask_clip | Mask_origin | Mask_type
-  | Scroll_snap_align | Scroll_snap_stop | Scroll_behavior | Box_sizing
-  | Field_sizing | Resize | Object_fit | Object_view_box | Appearance
-  | Box_decoration_break | Webkit_box_decoration_break | Content | Counter_reset
-  | Counter_increment | Text_decoration_thickness | Touch_action | Clip | Clear
-  | Float | Scale | Transition | Box_shadow | Vector_effect | Stop_color
-  | Flood_color | Lighting_color | Unicode_bidi | Animation_name
-  | Animation_duration | Animation_timing_function | Animation_delay
-  | Animation_iteration_count | Animation_direction | Animation_fill_mode
-  | Animation_play_state | Animation_composition | Background_blend_mode
-  | Scroll_margin | Scroll_margin_top | Scroll_margin_right
-  | Scroll_margin_bottom | Scroll_margin_left | Scroll_margin_inline
-  | Scroll_margin_inline_start | Scroll_margin_inline_end | Scroll_margin_block
-  | Scroll_margin_block_start | Scroll_margin_block_end | Scroll_padding
-  | Scroll_padding_top | Scroll_padding_right | Scroll_padding_bottom
-  | Scroll_padding_left | Scroll_padding_inline | Scroll_padding_inline_start
+  | Background_position | Background_position_x | Background_position_y
+  | Background_repeat | Background_size | Webkit_line_clamp | Webkit_box_orient
+  | Moz_orient | Text_overflow | Backdrop_filter | Webkit_backdrop_filter
+  | Webkit_mask_image | Webkit_mask_composite | Webkit_mask_source_type
+  | Webkit_mask_size | Webkit_mask_position | Webkit_mask_repeat
+  | Webkit_mask_clip | Webkit_mask_origin | Mask_image | Mask_composite
+  | Mask_mode | Mask_size | Mask_position | Mask_repeat | Mask_clip
+  | Mask_origin | Mask_type | Scroll_snap_align | Scroll_snap_stop
+  | Scroll_behavior | Box_sizing | Field_sizing | Resize | Object_fit
+  | Object_view_box | Appearance | Box_decoration_break
+  | Webkit_box_decoration_break | Content | Counter_reset | Counter_increment
+  | Text_decoration_thickness | Touch_action | Clip | Clear | Float | Scale
+  | Transition | Box_shadow | Vector_effect | Stop_color | Flood_color
+  | Lighting_color | Unicode_bidi | Animation_name | Animation_duration
+  | Animation_timing_function | Animation_delay | Animation_iteration_count
+  | Animation_direction | Animation_fill_mode | Animation_play_state
+  | Animation_composition | Background_blend_mode | Scroll_margin
+  | Scroll_margin_top | Scroll_margin_right | Scroll_margin_bottom
+  | Scroll_margin_left | Scroll_margin_inline | Scroll_margin_inline_start
+  | Scroll_margin_inline_end | Scroll_margin_block | Scroll_margin_block_start
+  | Scroll_margin_block_end | Scroll_padding | Scroll_padding_top
+  | Scroll_padding_right | Scroll_padding_bottom | Scroll_padding_left
+  | Scroll_padding_inline | Scroll_padding_inline_start
   | Scroll_padding_inline_end | Scroll_padding_block
   | Scroll_padding_block_start | Scroll_padding_block_end | Overscroll_behavior
   | Overscroll_behavior_x | Overscroll_behavior_y | Overscroll_behavior_block
@@ -1506,6 +1509,8 @@ let property_tag : type a. a property -> int = function
   | Vertical_align -> 399
   | Font_family -> 400
   | Background_position -> 401
+  | Background_position_x -> 537
+  | Background_position_y -> 538
   | Background_repeat -> 402
   | Background_size -> 403
   | Webkit_font_smoothing -> 404
@@ -2075,6 +2080,8 @@ let eq_property : type a b. a property -> b property -> (a, b) Type.eq option =
   | Vertical_align, Vertical_align -> Some Equal
   | Font_family, Font_family -> Some Equal
   | Background_position, Background_position -> Some Equal
+  | Background_position_x, Background_position_x -> Some Equal
+  | Background_position_y, Background_position_y -> Some Equal
   | Background_repeat, Background_repeat -> Some Equal
   | Background_size, Background_size -> Some Equal
   | Webkit_font_smoothing, Webkit_font_smoothing -> Some Equal
@@ -2914,6 +2921,8 @@ let read_any_property t =
   | "background-clip" -> Prop Background_clip
   | "-webkit-background-clip" -> Prop Webkit_background_clip
   | "background-position" -> Prop Background_position
+  | "background-position-x" -> Prop Background_position_x
+  | "background-position-y" -> Prop Background_position_y
   | "background-repeat" -> Prop Background_repeat
   | "background-size" -> Prop Background_size
   | "border-block" -> Prop Border_block
@@ -4024,6 +4033,7 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Vertical_align, value -> value
   | Font_family, value -> value
   | (Background_position | Webkit_mask_position | Mask_position), value -> value
+  | (Background_position_x | Background_position_y), value -> value
   | (Background_repeat | Webkit_mask_repeat | Mask_repeat), value -> value
   | Webkit_font_smoothing, value -> value
   | Moz_osx_font_smoothing, value -> value
@@ -4295,6 +4305,8 @@ let normalize_property_value : type a.
   | Object_position -> normalize_position_value value
   | Perspective_origin -> normalize_position_value value
   | Background_position -> map_preserve normalize_position_value value
+  | Background_position_x -> normalize_background_position_axis value
+  | Background_position_y -> normalize_background_position_axis value
   | Mask_position -> map_preserve normalize_position_value value
   | Webkit_mask_position -> map_preserve normalize_position_value value
   | Text_indent -> normalize_text_indent value
@@ -4861,6 +4873,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Grid_row_end -> pp pp_grid_line
   | Text_underline_offset -> pp pp_length
   | Background_position -> pp pp_background_position
+  | Background_position_x -> pp pp_background_position_axis
+  | Background_position_y -> pp pp_background_position_axis
   | Background_repeat -> pp pp_background_repeat
   | Background_size -> pp pp_background_size
   | Moz_osx_font_smoothing -> pp pp_moz_osx_font_smoothing

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1938,6 +1938,18 @@ val read_position_value : Cursor.t -> position_value
 val pp_background_position : background_position Pp.t
 (** [pp_background_position] is the pretty-printer for [background_position]. *)
 
+val pp_background_position_axis : background_position_axis Pp.t
+(** [pp_background_position_axis] is the pretty-printer for one axis of
+    [background-position]. *)
+
+val read_background_position_x : Cursor.t -> background_position_axis
+(** [read_background_position_x t] is the [background-position-x] value parsed
+    from [t]. *)
+
+val read_background_position_y : Cursor.t -> background_position_axis
+(** [read_background_position_y t] is the [background-position-y] value parsed
+    from [t]. *)
+
 val read_background_position : Cursor.t -> background_position
 (** [read_background_position t] is the [background_position] parsed from [t].
 *)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2653,6 +2653,24 @@ type position_value =
       string * length_percentage * string * length_percentage
   | Var of position_value var
 
+(* CSS Backgrounds 4 sec. 3.3: [background-position-x] and
+   [background-position-y] each take [center | [<edge>? <length-percentage>]].
+   One type serves both, each edge keyword naming exactly one axis, and the
+   per-property reader refuses the other axis's keywords. *)
+type position_axis_edge = Left | Right | Top | Bottom
+
+type background_position_axis =
+  | Center
+  | Edge of position_axis_edge
+  | Offset of length_percentage
+  | Edge_offset of position_axis_edge * length_percentage
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of background_position_axis var
+
 type radial_gradient_config = {
   shape : radial_shape option;
   size : radial_size option;
@@ -5060,6 +5078,8 @@ type 'a property =
   | Vertical_align : vertical_align property
   | Font_family : font_family property
   | Background_position : background_position property
+  | Background_position_x : background_position_axis property
+  | Background_position_y : background_position_axis property
   | Background_repeat : background_repeat property
   | Background_size : background_size property
   | Webkit_font_smoothing : webkit_font_smoothing property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -63,6 +63,10 @@ let covers_longhand : type a b.
   | Background, Background_image -> true
   | Background, Background_origin -> true
   | Background, Background_position -> true
+  | Background, Background_position_x -> true
+  | Background, Background_position_y -> true
+  | Background_position, Background_position_x -> true
+  | Background_position, Background_position_y -> true
   | Background, Background_repeat -> true
   | Background, Background_size -> true
   | Flex, Flex_grow -> true
@@ -467,7 +471,8 @@ let property_slots : type a. a Properties.property -> overlap_key list =
         key "background-color";
         key "background-image";
         key "background-origin";
-        key "background-position";
+        key "background-position-x";
+        key "background-position-y";
         key "background-repeat";
         key "background-size";
       ]
@@ -477,7 +482,10 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Background_color -> [ key "background-color" ]
   | Background_image -> [ key "background-image" ]
   | Background_origin -> [ key "background-origin" ]
-  | Background_position -> [ key "background-position" ]
+  | Background_position ->
+      [ key "background-position-x"; key "background-position-y" ]
+  | Background_position_x -> [ key "background-position-x" ]
+  | Background_position_y -> [ key "background-position-y" ]
   | Background_repeat -> [ key "background-repeat" ]
   | Background_size | Webkit_background_size -> [ key "background-size" ]
   | Flex -> [ key "flex-grow"; key "flex-shrink"; key "flex-basis" ]
@@ -2530,6 +2538,66 @@ let duo_container idx i =
     ~foldable:(fun _ -> true)
     ~extract:extract_container_part ~build i
 
+(* CSS Backgrounds 4 sec. 3.3: [background-position] is [<x> <y>] over the two
+   axis longhands, [Start] here the x axis. The shorthand carries one position
+   per layer, so a single-valued pair is what composes; the four-value edge form
+   needs each axis to name its own edge. *)
+let extract_background_position_part :
+    declaration ->
+    (axis_side
+    * (Properties.background_position_axis option
+      * Properties.background_position_axis option)
+    * bool)
+    option = function
+  | Declaration { property = Background_position_x; value = Var _; _ }
+  | Declaration { property = Background_position_y; value = Var _; _ } ->
+      None
+  | Declaration { property = Background_position_x; value; important; _ } ->
+      Some (Start, (Some value, Option.None), important)
+  | Declaration { property = Background_position_y; value; important; _ } ->
+      Some (End, (Option.None, Some value), important)
+  | _ -> None
+
+let position_of_axes (x : Properties.background_position_axis)
+    (y : Properties.background_position_axis) : Properties.position_value option
+    =
+  let axis_length : Properties.background_position_axis -> Values.length option
+      = function
+    | Center -> Some (Pct 50.)
+    | Edge Left | Edge Top -> Some Zero
+    | Edge Right | Edge Bottom -> Some (Pct 100.)
+    | Offset (Length l) -> Some l
+    | Offset (Pct p) -> Some (Pct p)
+    | _ -> Option.None
+  in
+  let edge_name : Properties.position_axis_edge -> string = function
+    | Left -> "left"
+    | Right -> "right"
+    | Top -> "top"
+    | Bottom -> "bottom"
+  in
+  match (axis_length x, axis_length y) with
+  | Some lx, Some ly -> Some (Prop_image.position_of_xy lx ly)
+  | _ -> (
+      match (x, y) with
+      | Edge_offset (ex, ox), Edge_offset (ey, oy) ->
+          Some (Edge_offset_edge_offset (edge_name ex, ox, edge_name ey, oy))
+      | _ -> Option.None)
+
+let duo_background_position idx i =
+  let build ~important ~start ~end_ =
+    let x, _ = start and _, y = end_ in
+    match (x, y) with
+    | Some x, Some y ->
+        Option.map
+          (fun p -> Declaration.v ~important Background_position [ p ])
+          (position_of_axes x y)
+    | _ -> Option.None
+  in
+  try_compose_axis_pair_at idx
+    ~foldable:(fun _ -> true)
+    ~extract:extract_background_position_part ~build i
+
 (* One entry per logical axis family; each pairs a start longhand with its end
    longhand under the shorthand that names the axis. *)
 let pair_axes ~ctx idx i =
@@ -2563,6 +2631,7 @@ let pair_axes ~ctx idx i =
     (fun () -> duo_animation_range idx i);
     (fun () -> duo_scroll_timeline idx i);
     (fun () -> duo_container idx i);
+    (fun () -> duo_background_position idx i);
   ]
 
 let compose_pair_via_index ~ctx idx =

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -737,6 +737,13 @@ let vars_of_position_value (value : Properties.position_value) : any_var list =
       vars_of_length_percentage lp1 @ vars_of_length_percentage lp2
   | _ -> []
 
+let vars_of_background_position_axis
+    (value : Properties.background_position_axis) : any_var list =
+  match value with
+  | Var v -> [ V v ]
+  | Offset lp | Edge_offset (_, lp) -> vars_of_length_percentage lp
+  | _ -> []
+
 let rec vars_of_gradient_direction (value : Properties.gradient_direction) :
     any_var list =
   match value with
@@ -2617,6 +2624,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Scroll_padding_block_end, value -> vars_of_length value
   (* One position per background / mask layer, as for [object-position]. *)
   | Background_position, value -> List.concat_map vars_of_position_value value
+  | Background_position_x, value -> vars_of_background_position_axis value
+  | Background_position_y, value -> vars_of_background_position_axis value
   | Mask_position, value -> List.concat_map vars_of_position_value value
   | Webkit_mask_position, value -> List.concat_map vars_of_position_value value
   (* Remaining typed longhands. *)

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -51,11 +51,11 @@ let test_unknown_property_overlap () =
   Alcotest.(check bool)
     "an unknown longhand overlaps the shorthand that resets it" true
     (Shorthand.declarations_overlap (decl "background:red")
-       (decl "background-position-x:10px"));
+       (decl "background-repeat-x:repeat"));
   Alcotest.(check bool)
     "the relation is symmetric" true
     (Shorthand.declarations_overlap
-       (decl "background-position-x:10px")
+       (decl "background-repeat-x:repeat")
        (decl "background:red"));
   (* [grid-row-gap] is the legacy alias of [row-gap], which [gap] resets. *)
   Alcotest.(check bool)
@@ -772,6 +772,27 @@ let test_named_shorthand_composes () =
     ~into:".x{container-name:card;container-type:inline-size!important}"
     ".x{container-name:card;container-type:inline-size!important}"
 
+(* CSS Backgrounds 4 sec. 3.3: [background-position] is [<x> <y>] over the two
+   axis longhands, the first value the x axis. A bare offset is measured from
+   the start edge, so [left 10px] and [10px] name the same position. *)
+let test_background_position_composes () =
+  sheet_optimizes_to ~into:".x{background-position:50% 10px}"
+    ".x{background-position-x:50%;background-position-y:10px}";
+  sheet_optimizes_to ~into:".x{background-position:10px center}"
+    ".x{background-position-x:10px;background-position-y:center}";
+  sheet_optimizes_to ~into:".x{background-position:left center}"
+    ".x{background-position-x:left;background-position-y:center}";
+  sheet_optimizes_to ~into:".x{background-position:right 5% bottom 2px}"
+    ".x{background-position-x:right 5%;background-position-y:bottom 2px}";
+  (* A substituted axis can be the whole value, so it stays put. *)
+  sheet_optimizes_to
+    ~into:".x{background-position-x:var(--x);background-position-y:10px}"
+    ".x{background-position-x:var(--x);background-position-y:10px}";
+  (* Mixed importance is not one declaration. *)
+  sheet_optimizes_to
+    ~into:".x{background-position-x:10px;background-position-y:20px!important}"
+    ".x{background-position-x:10px;background-position-y:20px!important}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1369,6 +1390,8 @@ let suite =
         test_timeline_range_composes;
       Alcotest.test_case "named shorthand composes" `Quick
         test_named_shorthand_composes;
+      Alcotest.test_case "background position composes" `Quick
+        test_background_position_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -776,13 +776,15 @@ let test_named_shorthand_composes () =
    axis longhands, the first value the x axis. A bare offset is measured from
    the start edge, so [left 10px] and [10px] name the same position. *)
 let test_background_position_composes () =
-  sheet_optimizes_to ~into:".x{background-position:50% 10px}"
+  sheet_optimizes_to ~into:".x{background-position:50%10px}"
     ".x{background-position-x:50%;background-position-y:10px}";
-  sheet_optimizes_to ~into:".x{background-position:10px center}"
+  (* Sec. 2.6 reads a lone value as the x axis and centres the y, so the
+     one-value spelling names the same position and is shorter. *)
+  sheet_optimizes_to ~into:".x{background-position:10px}"
     ".x{background-position-x:10px;background-position-y:center}";
-  sheet_optimizes_to ~into:".x{background-position:left center}"
+  sheet_optimizes_to ~into:".x{background-position:0}"
     ".x{background-position-x:left;background-position-y:center}";
-  sheet_optimizes_to ~into:".x{background-position:right 5% bottom 2px}"
+  sheet_optimizes_to ~into:".x{background-position:right 5%bottom 2px}"
     ".x{background-position-x:right 5%;background-position-y:bottom 2px}";
   (* A substituted axis can be the whole value, so it stays put. *)
   sheet_optimizes_to


### PR DESCRIPTION
`background-position-x` and `background-position-y` had no typed spelling, so a sheet setting either parsed it as an unknown declaration and `--diff=canonical` could not equate `background-position` with its own expansion. This PR adds `Css.background_position_axis` and the two properties, and contracts the shorthand from them. Follow-up to #925.