### PR TITLE
properties: add white-space-collapse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -578,6 +578,9 @@ entry points both moved.
   `column-rule-style`, which this release adds as typed properties beside the
   colour longhand it already had (#927)
 
+- `--minify` contracts `white-space` from `white-space-collapse`, which this
+  release adds as a typed property, and `text-wrap-mode` (#928)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1271,6 +1271,8 @@ let read_type_value : type a. a property -> Cursor.t -> declaration option =
   | Text_align -> Some (v Text_align (read_text_align t))
   | Text_transform -> Some (v Text_transform (read_text_transform t))
   | White_space -> Some (v White_space (read_white_space t))
+  | White_space_collapse ->
+      Some (v White_space_collapse (read_white_space_collapse t))
   | Text_decoration -> Some (v Text_decoration (read_text_decoration t))
   | Text_decoration_line ->
       Some (v Text_decoration_line (read_text_decoration_lines t))

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1894,6 +1894,40 @@ let rec read_white_space t : white_space =
         ~var:(fun t -> Var (read_var read_white_space t))
         t
 
+(* CSS Text 4 sec. 3.1. *)
+let rec pp_white_space_collapse : white_space_collapse Pp.t =
+ fun ctx -> function
+  | Collapse -> Pp.string ctx "collapse"
+  | Discard -> Pp.string ctx "discard"
+  | Preserve -> Pp.string ctx "preserve"
+  | Preserve_breaks -> Pp.string ctx "preserve-breaks"
+  | Preserve_spaces -> Pp.string ctx "preserve-spaces"
+  | Break_spaces -> Pp.string ctx "break-spaces"
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_white_space_collapse ctx v
+
+let rec read_white_space_collapse t : white_space_collapse =
+  Cursor.enum_or_var "white-space-collapse"
+    [
+      ("collapse", (Collapse : white_space_collapse));
+      ("discard", Discard);
+      ("preserve", Preserve);
+      ("preserve-breaks", Preserve_breaks);
+      ("preserve-spaces", Preserve_spaces);
+      ("break-spaces", Break_spaces);
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (read_var read_white_space_collapse t))
+    t
+
 let rec read_word_break t : word_break =
   Cursor.enum_or_var "word-break"
     [

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -457,6 +457,7 @@ let pp_property : type a. a property Pp.t =
   | Clear -> Pp.string ctx "clear"
   | Float -> Pp.string ctx "float"
   | White_space -> Pp.string ctx "white-space"
+  | White_space_collapse -> Pp.string ctx "white-space-collapse"
   | Border -> Pp.string ctx "border"
   | Background -> Pp.string ctx "background"
   | Tab_size -> Pp.string ctx "tab-size"
@@ -876,6 +877,7 @@ let property_class : type a. a property -> a property_class = function
   | Pointer_events -> Inherited
   | Forced_color_adjust -> Inherited
   | White_space -> Inherited
+  | White_space_collapse -> Inherited
   | Tab_size -> Inherited
   | Webkit_text_size_adjust -> Inherited
   | Font_feature_settings -> Inherited
@@ -1309,6 +1311,7 @@ let property_tag : type a. a property -> int = function
   | Forced_color_adjust -> 197
   | Scroll_snap_type -> 198
   | White_space -> 199
+  | White_space_collapse -> 541
   | Border -> 200
   | Border_block -> 201
   | Border_block_start -> 202
@@ -1876,6 +1879,7 @@ let eq_property : type a b. a property -> b property -> (a, b) Type.eq option =
   | Forced_color_adjust, Forced_color_adjust -> Some Equal
   | Scroll_snap_type, Scroll_snap_type -> Some Equal
   | White_space, White_space -> Some Equal
+  | White_space_collapse, White_space_collapse -> Some Equal
   | Border, Border -> Some Equal
   | Border_block, Border_block -> Some Equal
   | Border_block_start, Border_block_start -> Some Equal
@@ -3176,6 +3180,7 @@ let read_any_property t =
   | "transition-timing-function" -> Prop Transition_timing_function
   | "unicode-bidi" -> Prop Unicode_bidi
   | "white-space" -> Prop White_space
+  | "white-space-collapse" -> Prop White_space_collapse
   | "will-change" -> Prop Will_change
   | "word-break" -> Prop Word_break
   | "word-spacing" -> Prop Word_spacing
@@ -3880,6 +3885,7 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Forced_color_adjust, value -> value
   | Scroll_snap_type, value -> value
   | White_space, value -> value
+  | White_space_collapse, value -> value
   | ( ( Border | Border_block | Border_block_start | Border_block_end
       | Border_inline | Border_inline_start | Border_inline_end | Column_rule
       | Border_top | Border_right | Border_bottom | Border_left ),
@@ -4826,6 +4832,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Container_type -> pp pp_container_type
   | Container -> pp pp_container_shorthand
   | White_space -> pp pp_white_space
+  | White_space_collapse -> pp pp_white_space_collapse
   | Grid_template_columns -> pp pp_grid_template
   | Grid_template_rows -> pp pp_grid_template
   | Grid_template_areas -> pp pp_grid_template_areas

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1178,6 +1178,14 @@ val pp_text_size_adjust : text_size_adjust Pp.t
 val pp_white_space : white_space Pp.t
 (** [pp_white_space] is the pretty-printer for [white_space]. *)
 
+val pp_white_space_collapse : white_space_collapse Pp.t
+(** [pp_white_space_collapse] is the pretty-printer for [white_space_collapse].
+*)
+
+val read_white_space_collapse : Cursor.t -> white_space_collapse
+(** [read_white_space_collapse t] is the [white_space_collapse] parsed from [t].
+*)
+
 val read_white_space : Cursor.t -> white_space
 (** [read_white_space t] is the [white_space] parsed from [t]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1568,6 +1568,22 @@ type white_space =
   | Revert_layer
   | Var of white_space var
 
+(* CSS Text 4 sec. 3.1: [white-space-collapse] says how white space and segment
+   breaks in the source collapse. *)
+type white_space_collapse =
+  | Collapse
+  | Discard
+  | Preserve
+  | Preserve_breaks
+  | Preserve_spaces
+  | Break_spaces
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of white_space_collapse var
+
 type word_break =
   | Normal
   | Break_all
@@ -4876,6 +4892,7 @@ type 'a property =
   | Forced_color_adjust : forced_color_adjust property
   | Scroll_snap_type : scroll_snap_type property
   | White_space : white_space property
+  | White_space_collapse : white_space_collapse property
   | Border : border property
   | Border_block : border property
   | Border_block_start : border property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -931,6 +931,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   (* CSS Text 4 sec. 3 and 5.1: [white-space] and [text-wrap] both reset
      [text-wrap-mode]. *)
   | White_space -> [ key "white-space-collapse"; key "text-wrap-mode" ]
+  | White_space_collapse -> [ key "white-space-collapse" ]
   | Text_wrap -> [ key "text-wrap-mode"; key "text-wrap-style" ]
   | Text_wrap_mode -> [ key "text-wrap-mode" ]
   | Text_wrap_style -> [ key "text-wrap-style" ]
@@ -2604,6 +2605,51 @@ let duo_background_position idx i =
     ~foldable:(fun _ -> true)
     ~extract:extract_background_position_part ~build i
 
+(* CSS Text 4 sec. 3: [white-space] is a shorthand of [white-space-collapse] and
+   [text-wrap-mode], and sec. 3 table 1 gives the four pairs a single keyword
+   names. A pair outside that table has no one-keyword spelling and stays two
+   declarations. *)
+let extract_white_space_part :
+    declaration ->
+    (axis_side
+    * (Properties.white_space_collapse option
+      * Properties.text_wrap_mode option)
+    * bool)
+    option = function
+  | Declaration { property = White_space_collapse; value = Var _; _ }
+  | Declaration { property = Text_wrap_mode; value = Var _; _ } ->
+      None
+  | Declaration { property = White_space_collapse; value; important; _ } ->
+      Some (Start, (Some value, Option.None), important)
+  | Declaration { property = Text_wrap_mode; value; important; _ } ->
+      Some (End, (Option.None, Some value), important)
+  | _ -> None
+
+let white_space_of_pair (c : Properties.white_space_collapse)
+    (m : Properties.text_wrap_mode) : Properties.white_space option =
+  match (c, m) with
+  | Collapse, Wrap -> Some Normal
+  | Collapse, No_wrap -> Some Nowrap
+  | Preserve, Wrap -> Some Pre_wrap
+  | Preserve, No_wrap -> Some Pre
+  | Preserve_breaks, Wrap -> Some Pre_line
+  | Break_spaces, Wrap -> Some Break_spaces
+  | _ -> Option.None
+
+let duo_white_space idx i =
+  let build ~important ~start ~end_ =
+    let collapse, _ = start and _, mode = end_ in
+    match (collapse, mode) with
+    | Some c, Some m ->
+        Option.map
+          (Declaration.v ~important White_space)
+          (white_space_of_pair c m)
+    | _ -> Option.None
+  in
+  try_compose_axis_pair_at idx
+    ~foldable:(fun _ -> true)
+    ~extract:extract_white_space_part ~build i
+
 (* One entry per logical axis family; each pairs a start longhand with its end
    longhand under the shorthand that names the axis. *)
 let pair_axes ~ctx idx i =
@@ -2638,6 +2684,7 @@ let pair_axes ~ctx idx i =
     (fun () -> duo_scroll_timeline idx i);
     (fun () -> duo_container idx i);
     (fun () -> duo_background_position idx i);
+    (fun () -> duo_white_space idx i);
   ]
 
 let compose_pair_via_index ~ctx idx =

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1401,6 +1401,9 @@ let vars_of_initial_letter (value : Properties.initial_letter) =
 let vars_of_white_space (value : Properties.white_space) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_white_space_collapse (value : Properties.white_space_collapse) =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_word_break (value : Properties.word_break) =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2538,6 +2541,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Webkit_text_stroke_color, value -> vars_of_color value
   | Moz_user_select, value -> vars_of_user_select value
   | White_space, value -> vars_of_white_space value
+  | White_space_collapse, value -> vars_of_white_space_collapse value
   | Word_break, value -> vars_of_word_break value
   | Writing_mode, value -> vars_of_writing_mode value
   | Z_index, value -> vars_of_z_index value

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -809,6 +809,29 @@ let test_column_rule_composes () =
       ".x{column-rule-width:1px;column-rule-style:solid;column-rule-color:red!important}"
     ".x{column-rule-width:1px;column-rule-style:solid;column-rule-color:red!important}"
 
+(* CSS Text 4 sec. 3: [white-space] is a shorthand of [white-space-collapse] and
+   [text-wrap-mode], and one keyword names each of the four pairs its table
+   lists. *)
+let test_white_space_composes () =
+  sheet_optimizes_to ~into:".x{white-space:pre-wrap}"
+    ".x{white-space-collapse:preserve;text-wrap-mode:wrap}";
+  sheet_optimizes_to ~into:".x{white-space:normal}"
+    ".x{white-space-collapse:collapse;text-wrap-mode:wrap}";
+  sheet_optimizes_to ~into:".x{white-space:pre}"
+    ".x{white-space-collapse:preserve;text-wrap-mode:nowrap}";
+  sheet_optimizes_to ~into:".x{white-space:nowrap}"
+    ".x{white-space-collapse:collapse;text-wrap-mode:nowrap}";
+  sheet_optimizes_to ~into:".x{white-space:pre-line}"
+    ".x{white-space-collapse:preserve-breaks;text-wrap-mode:wrap}";
+  (* A pair outside that table has no one-keyword spelling. *)
+  sheet_optimizes_to
+    ~into:".x{white-space-collapse:preserve-spaces;text-wrap-mode:wrap}"
+    ".x{white-space-collapse:preserve-spaces;text-wrap-mode:wrap}";
+  (* Mixed importance is not one declaration. *)
+  sheet_optimizes_to
+    ~into:".x{white-space-collapse:preserve;text-wrap-mode:wrap!important}"
+    ".x{white-space-collapse:preserve;text-wrap-mode:wrap!important}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1409,6 +1432,7 @@ let suite =
       Alcotest.test_case "background position composes" `Quick
         test_background_position_composes;
       Alcotest.test_case "column rule composes" `Quick test_column_rule_composes;
+      Alcotest.test_case "white space composes" `Quick test_white_space_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
`white-space-collapse` had no typed spelling, so it parsed as an unknown declaration and `--diff=canonical` could not equate the pair it forms with `text-wrap-mode` against the `white-space` keyword naming the same two. Follow-up to #927.