### PR TITLE
minify: contract text-wrap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -581,6 +581,9 @@ entry points both moved.
 - `--minify` contracts `white-space` from `white-space-collapse`, which this
   release adds as a typed property, and `text-wrap-mode` (#928)
 
+- `--minify` contracts `text-wrap` from `text-wrap-mode` and `text-wrap-style`
+  (#929)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -2650,6 +2650,62 @@ let duo_white_space idx i =
     ~foldable:(fun _ -> true)
     ~extract:extract_white_space_part ~build i
 
+(* CSS Text 4 sec. 5.1: [text-wrap] is [<'text-wrap-mode'> ||
+   <'text-wrap-style'>] over its two longhands, with [wrap] the mode's initial
+   (sec. 5.2) and [auto] the style's (sec. 5.3), so a longhand at its initial
+   names what leaving the component out names. *)
+let extract_text_wrap_part :
+    declaration ->
+    (axis_side
+    * (Properties.text_wrap_mode option * Properties.text_wrap_style option)
+    * bool)
+    option = function
+  | Declaration { property = Text_wrap_mode; value = Var _; _ }
+  | Declaration { property = Text_wrap_style; value = Var _; _ } ->
+      None
+  | Declaration { property = Text_wrap_mode; value; important; _ } ->
+      Some (Start, (Some value, Option.None), important)
+  | Declaration { property = Text_wrap_style; value; important; _ } ->
+      Some (End, (Option.None, Some value), important)
+  | _ -> None
+
+let text_wrap_of_pair (m : Properties.text_wrap_mode)
+    (st : Properties.text_wrap_style) : Properties.text_wrap option =
+  let mode =
+    match m with
+    | Wrap | Initial -> Some `Wrap
+    | No_wrap -> Some `No_wrap
+    | _ -> Option.None
+  in
+  let style =
+    match st with
+    | Auto | Initial -> Some `Auto
+    | Balance -> Some `Balance
+    | Stable -> Some `Stable
+    | Pretty -> Some `Pretty
+    | _ -> Option.None
+  in
+  match (mode, style) with
+  | Some `Wrap, Some `Auto -> Some (Wrap : Properties.text_wrap)
+  | Some `No_wrap, Some `Auto -> Some No_wrap
+  | Some `Wrap, Some `Balance -> Some Balance
+  | Some `Wrap, Some `Stable -> Some Stable
+  | Some `Wrap, Some `Pretty -> Some Pretty
+  | Some m, Some st -> Some (Mode_style (m, st))
+  | _ -> Option.None
+
+let duo_text_wrap idx i =
+  let build ~important ~start ~end_ =
+    let mode, _ = start and _, style = end_ in
+    match (mode, style) with
+    | Some m, Some st ->
+        Option.map (Declaration.v ~important Text_wrap) (text_wrap_of_pair m st)
+    | _ -> Option.None
+  in
+  try_compose_axis_pair_at idx
+    ~foldable:(fun _ -> true)
+    ~extract:extract_text_wrap_part ~build i
+
 (* One entry per logical axis family; each pairs a start longhand with its end
    longhand under the shorthand that names the axis. *)
 let pair_axes ~ctx idx i =
@@ -2685,6 +2741,7 @@ let pair_axes ~ctx idx i =
     (fun () -> duo_container idx i);
     (fun () -> duo_background_position idx i);
     (fun () -> duo_white_space idx i);
+    (fun () -> duo_text_wrap idx i);
   ]
 
 let compose_pair_via_index ~ctx idx =

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -832,6 +832,26 @@ let test_white_space_composes () =
     ~into:".x{white-space-collapse:preserve;text-wrap-mode:wrap!important}"
     ".x{white-space-collapse:preserve;text-wrap-mode:wrap!important}"
 
+(* CSS Text 4 sec. 5.1: [text-wrap] is [<'text-wrap-mode'> ||
+   <'text-wrap-style'>] over its two longhands, and a longhand at its initial
+   names what leaving the component out names. *)
+let test_text_wrap_composes () =
+  sheet_optimizes_to ~into:".x{text-wrap:balance}"
+    ".x{text-wrap-mode:wrap;text-wrap-style:balance}";
+  sheet_optimizes_to ~into:".x{text-wrap:wrap}"
+    ".x{text-wrap-mode:wrap;text-wrap-style:auto}";
+  sheet_optimizes_to ~into:".x{text-wrap:nowrap}"
+    ".x{text-wrap-mode:nowrap;text-wrap-style:auto}";
+  sheet_optimizes_to ~into:".x{text-wrap:pretty}"
+    ".x{text-wrap-mode:wrap;text-wrap-style:pretty}";
+  (* Neither component at its initial needs both written out. *)
+  sheet_optimizes_to ~into:".x{text-wrap:nowrap balance}"
+    ".x{text-wrap-mode:nowrap;text-wrap-style:balance}";
+  (* Mixed importance is not one declaration. *)
+  sheet_optimizes_to
+    ~into:".x{text-wrap-mode:wrap;text-wrap-style:balance!important}"
+    ".x{text-wrap-mode:wrap;text-wrap-style:balance!important}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1433,6 +1453,7 @@ let suite =
         test_background_position_composes;
       Alcotest.test_case "column rule composes" `Quick test_column_rule_composes;
       Alcotest.test_case "white space composes" `Quick test_white_space_composes;
+      Alcotest.test_case "text wrap composes" `Quick test_text_wrap_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
`text-wrap-mode` and `text-wrap-style` had no composer, so a rule setting both kept two declarations and `--diff=canonical` could not equate them with the `text-wrap` keyword naming the same pair. Follow-up to #928.