### PR TITLE
properties: add -webkit-text-stroke and its width longhand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -588,6 +588,10 @@ entry points both moved.
   rule that also writes `font-synthesis-position` alone since the shorthand
   resets it (#930)
 
+- `--minify` contracts `-webkit-text-stroke` from its width and colour
+  longhands. The shorthand and `-webkit-text-stroke-width` are new typed
+  properties; only the colour longhand had a spelling before (#931)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1918,6 +1918,10 @@ let read_interaction_value : type a.
   | Ms_user_select -> Some (v Ms_user_select (read_user_select t))
   | Webkit_text_fill_color -> Some (v Webkit_text_fill_color (read_color t))
   | Webkit_text_stroke_color -> Some (v Webkit_text_stroke_color (read_color t))
+  | Webkit_text_stroke_width ->
+      Some (v Webkit_text_stroke_width (read_border_width t))
+  | Webkit_text_stroke ->
+      Some (v Webkit_text_stroke (read_webkit_text_stroke t))
   | Moz_user_select -> Some (v Moz_user_select (read_user_select t))
   | Pointer_events -> Some (v Pointer_events (read_pointer_events t))
   | Resize -> Some (v Resize (read_resize t))

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1928,6 +1928,44 @@ let rec read_white_space_collapse t : white_space_collapse =
     ~var:(fun t -> Var (read_var read_white_space_collapse t))
     t
 
+(* [-webkit-text-stroke] is [<line-width> || <color>]: either component may be
+   left out and either order is accepted, so the two are read by type. A
+   component left out takes its longhand's initial - [0] for the width and
+   [currentColor] for the colour - which is what the printer then omits. *)
+let pp_webkit_text_stroke : webkit_text_stroke Pp.t =
+ fun ctx s ->
+  let wrote = ref false in
+  let sep () = if !wrote then Pp.space ctx () else wrote := true in
+  Option.iter
+    (fun w ->
+      sep ();
+      pp_border_width ctx w)
+    s.width;
+  Option.iter
+    (fun c ->
+      sep ();
+      pp_color ctx c)
+    s.color;
+  if not !wrote then Pp.string ctx "currentColor"
+
+let read_webkit_text_stroke t : webkit_text_stroke =
+  let width = ref Option.None and color = ref Option.None in
+  let read_one t =
+    match Cursor.peek_ident t with
+    | Some ("thin" | "medium" | "thick") -> width := Some (read_border_width t)
+    | _ -> (
+        let snap = Cursor.save t in
+        match read_border_width t with
+        | w -> width := Some w
+        | exception Cursor.Parse_error _ ->
+            Cursor.restore t snap;
+            color := Some (Values.read_color t))
+  in
+  read_one t;
+  Cursor.ws t;
+  if not (Cursor.is_done t || Cursor.peek_comma t) then read_one t;
+  { width = !width; color = !color }
+
 let rec read_word_break t : word_break =
   Cursor.enum_or_var "word-break"
     [

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -468,6 +468,8 @@ let pp_property : type a. a property Pp.t =
   | Webkit_tap_highlight_color -> Pp.string ctx "-webkit-tap-highlight-color"
   | Webkit_text_fill_color -> Pp.string ctx "-webkit-text-fill-color"
   | Webkit_text_stroke_color -> Pp.string ctx "-webkit-text-stroke-color"
+  | Webkit_text_stroke -> Pp.string ctx "-webkit-text-stroke"
+  | Webkit_text_stroke_width -> Pp.string ctx "-webkit-text-stroke-width"
   | Webkit_user_select -> Pp.string ctx "-webkit-user-select"
   | Ms_user_select -> Pp.string ctx "-ms-user-select"
   | Moz_user_select -> Pp.string ctx "-moz-user-select"
@@ -885,6 +887,8 @@ let property_class : type a. a property -> a property_class = function
   | Webkit_tap_highlight_color -> Inherited
   | Webkit_text_fill_color -> Inherited
   | Webkit_text_stroke_color -> Inherited
+  | Webkit_text_stroke -> Inherited
+  | Webkit_text_stroke_width -> Inherited
   | List_style -> Inherited
   | Font -> Inherited
   | Scrollbar_color -> Inherited
@@ -1333,6 +1337,8 @@ let property_tag : type a. a property -> int = function
   | Webkit_text_decoration_color -> 218
   | Webkit_text_fill_color -> 219
   | Webkit_text_stroke_color -> 220
+  | Webkit_text_stroke -> 542
+  | Webkit_text_stroke_width -> 543
   | Text_indent -> 221
   | List_style -> 222
   | Font -> 223
@@ -1901,6 +1907,8 @@ let eq_property : type a b. a property -> b property -> (a, b) Type.eq option =
   | Webkit_text_decoration_color, Webkit_text_decoration_color -> Some Equal
   | Webkit_text_fill_color, Webkit_text_fill_color -> Some Equal
   | Webkit_text_stroke_color, Webkit_text_stroke_color -> Some Equal
+  | Webkit_text_stroke, Webkit_text_stroke -> Some Equal
+  | Webkit_text_stroke_width, Webkit_text_stroke_width -> Some Equal
   | Text_indent, Text_indent -> Some Equal
   | List_style, List_style -> Some Equal
   | Font, Font -> Some Equal
@@ -3239,6 +3247,8 @@ let read_any_property t =
   | "-webkit-tap-highlight-color" -> Prop Webkit_tap_highlight_color
   | "-webkit-text-fill-color" -> Prop Webkit_text_fill_color
   | "-webkit-text-stroke-color" -> Prop Webkit_text_stroke_color
+  | "-webkit-text-stroke" -> Prop Webkit_text_stroke
+  | "-webkit-text-stroke-width" -> Prop Webkit_text_stroke_width
   | "-webkit-user-select" -> Prop Webkit_user_select
   | "-ms-user-select" -> Prop Ms_user_select
   | "-moz-user-select" -> Prop Moz_user_select
@@ -3738,8 +3748,8 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
       | Border_block_start_color | Border_block_end_color | Outline_color
       | Webkit_tap_highlight_color | Webkit_text_decoration_color
       | Webkit_text_fill_color | Webkit_text_stroke_color | Column_rule_color
-      | Stop_color | Flood_color | Lighting_color | Accent_color | Caret_color
-        ),
+      | Webkit_text_stroke | Stop_color | Flood_color | Lighting_color
+      | Accent_color | Caret_color ),
       value ) ->
       value
   | Border_color, value -> value
@@ -3842,7 +3852,7 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | ( ( Border_top_width | Border_right_width | Border_bottom_width
       | Border_left_width | Border_inline_start_width | Border_inline_end_width
       | Border_block_start_width | Border_block_end_width | Outline_width
-      | Column_rule_width ),
+      | Column_rule_width | Webkit_text_stroke_width ),
       value ) ->
       value
   | (Border_inline_width | Border_block_width), value -> value
@@ -4353,6 +4363,7 @@ let normalize_property_value : type a.
   | Webkit_text_decoration_color -> normalize_color value
   | Webkit_text_fill_color -> normalize_color value
   | Webkit_text_stroke_color -> normalize_color value
+  | Webkit_text_stroke_width -> normalize_border_width value
   | Column_rule_color -> normalize_color value
   | Column_rule_width -> normalize_border_width value
   | Webkit_tap_highlight_color -> normalize_color value
@@ -4723,6 +4734,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Webkit_tap_highlight_color -> pp pp_color
   | Webkit_text_fill_color -> pp pp_color
   | Webkit_text_stroke_color -> pp pp_color
+  | Webkit_text_stroke -> pp pp_webkit_text_stroke
+  | Webkit_text_stroke_width -> pp pp_border_width
   | Column_rule_color -> pp pp_color
   | Column_rule_width -> pp pp_border_width
   | Column_rule_style -> pp pp_border_style
@@ -5379,6 +5392,7 @@ let property_value_kind : type a. a property -> a property_value_kind option =
   | Webkit_text_decoration_color -> Some Color
   | Webkit_text_fill_color -> Some Color
   | Webkit_text_stroke_color -> Some Color
+  | Webkit_text_stroke_width -> Some Border_width
   | Column_rule_color -> Some Color
   | Column_rule_width -> Some Border_width
   | Accent_color -> Some Color

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1186,6 +1186,13 @@ val read_white_space_collapse : Cursor.t -> white_space_collapse
 (** [read_white_space_collapse t] is the [white_space_collapse] parsed from [t].
 *)
 
+val pp_webkit_text_stroke : webkit_text_stroke Pp.t
+(** [pp_webkit_text_stroke] is the pretty-printer for [webkit_text_stroke]. *)
+
+val read_webkit_text_stroke : Cursor.t -> webkit_text_stroke
+(** [read_webkit_text_stroke t] is the [-webkit-text-stroke] shorthand parsed
+    from [t]. *)
+
 val read_white_space : Cursor.t -> white_space
 (** [read_white_space t] is the [white_space] parsed from [t]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1825,6 +1825,11 @@ type logical_border_style =
   | Revert_layer
   | Var of logical_border_style var
 
+(* [-webkit-text-stroke] is [<line-width> || <color>] over its two longhands. It
+   is not in a CSS specification; the shape is what WebKit and Blink accept and
+   what their CSSOM reports back. *)
+type webkit_text_stroke = { width : border_width option; color : color option }
+
 type outline_style =
   | None
   | Solid
@@ -4913,6 +4918,8 @@ type 'a property =
   | Webkit_text_decoration : text_decoration property
   | Webkit_text_decoration_color : color property
   | Webkit_text_fill_color : color property
+  | Webkit_text_stroke : webkit_text_stroke property
+  | Webkit_text_stroke_width : border_width property
   | Webkit_text_stroke_color : color property
   | Text_indent : text_indent_value property
   | List_style : list_style property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -148,6 +148,8 @@ let covers_longhand : type a b.
   | Font_synthesis, Font_synthesis_style -> true
   | Font_synthesis, Font_synthesis_small_caps -> true
   | Font_synthesis, Font_synthesis_position -> true
+  | Webkit_text_stroke, Webkit_text_stroke_width -> true
+  | Webkit_text_stroke, Webkit_text_stroke_color -> true
   (* CSS Multicol 1 sec. 4.3: [column-rule] is the three rule longhands. *)
   | Column_rule, Column_rule_width -> true
   | Column_rule, Column_rule_style -> true
@@ -905,6 +907,12 @@ let property_slots : type a. a Properties.property -> overlap_key list =
       [ key "overscroll-behavior-x"; key "overscroll-behavior-y" ]
   | Overscroll_behavior_x -> [ key "overscroll-behavior-x" ]
   | Overscroll_behavior_y -> [ key "overscroll-behavior-y" ]
+  (* [-webkit-text-stroke] is [<line-width> || <color>] over its two
+     longhands. *)
+  | Webkit_text_stroke ->
+      [ key "-webkit-text-stroke-width"; key "-webkit-text-stroke-color" ]
+  | Webkit_text_stroke_width -> [ key "-webkit-text-stroke-width" ]
+  | Webkit_text_stroke_color -> [ key "-webkit-text-stroke-color" ]
   (* CSS Contain 3 sec. 4.3. *)
   | Container -> [ key "container-name"; key "container-type" ]
   | Container_name -> [ key "container-name" ]
@@ -2712,6 +2720,32 @@ let duo_text_wrap idx i =
     ~foldable:(fun _ -> true)
     ~extract:extract_text_wrap_part ~build i
 
+(* [-webkit-text-stroke] is [<line-width> || <color>] over its two longhands.
+   Both are typed differently, so either order names the same declaration. *)
+let extract_webkit_stroke_part :
+    declaration ->
+    (axis_side * (Properties.border_width option * Values.color option) * bool)
+    option = function
+  | Declaration { property = Webkit_text_stroke_width; value = Var _; _ }
+  | Declaration { property = Webkit_text_stroke_color; value = Var _; _ } ->
+      None
+  | Declaration { property = Webkit_text_stroke_width; value; important; _ } ->
+      Some (Start, (Some value, Option.None), important)
+  | Declaration { property = Webkit_text_stroke_color; value; important; _ } ->
+      Some (End, (Option.None, Some value), important)
+  | _ -> None
+
+let duo_webkit_text_stroke idx i =
+  let build ~important ~start ~end_ =
+    let width, _ = start and _, color = end_ in
+    Some
+      (Declaration.v ~important Webkit_text_stroke
+         ({ width; color } : Properties.webkit_text_stroke))
+  in
+  try_compose_axis_pair_at idx
+    ~foldable:(fun _ -> true)
+    ~extract:extract_webkit_stroke_part ~build i
+
 (* One entry per logical axis family; each pairs a start longhand with its end
    longhand under the shorthand that names the axis. *)
 let pair_axes ~ctx idx i =
@@ -2748,6 +2782,7 @@ let pair_axes ~ctx idx i =
     (fun () -> duo_background_position idx i);
     (fun () -> duo_white_space idx i);
     (fun () -> duo_text_wrap idx i);
+    (fun () -> duo_webkit_text_stroke idx i);
   ]
 
 let compose_pair_via_index ~ctx idx =

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2539,6 +2539,10 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Ms_user_select, value -> vars_of_user_select value
   | Webkit_text_fill_color, value -> vars_of_color value
   | Webkit_text_stroke_color, value -> vars_of_color value
+  | Webkit_text_stroke_width, value -> vars_of_border_width value
+  | Webkit_text_stroke, value ->
+      Option.fold ~none:[] ~some:vars_of_border_width value.width
+      @ Option.fold ~none:[] ~some:vars_of_color value.color
   | Moz_user_select, value -> vars_of_user_select value
   | White_space, value -> vars_of_white_space value
   | White_space_collapse, value -> vars_of_white_space_collapse value

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -874,6 +874,19 @@ let test_font_synthesis_composes () =
       ".x{font-synthesis-weight:none;font-synthesis-style:none;font-synthesis-small-caps:none!important}"
     ".x{font-synthesis-weight:none;font-synthesis-style:none;font-synthesis-small-caps:none!important}"
 
+(* [-webkit-text-stroke] is [<line-width> || <color>] over its two longhands,
+   the shape the border sides take, so the pair contracts the same way. *)
+let test_webkit_text_stroke_composes () =
+  sheet_optimizes_to ~into:".x{-webkit-text-stroke:1px red}"
+    ".x{-webkit-text-stroke-width:1px;-webkit-text-stroke-color:red}";
+  sheet_optimizes_to ~into:".x{-webkit-text-stroke:0 currentColor}"
+    ".x{-webkit-text-stroke-width:0;-webkit-text-stroke-color:currentcolor}";
+  (* Mixed importance is not one declaration. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{-webkit-text-stroke-width:1px;-webkit-text-stroke-color:red!important}"
+    ".x{-webkit-text-stroke-width:1px;-webkit-text-stroke-color:red!important}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1478,6 +1491,8 @@ let suite =
       Alcotest.test_case "text wrap composes" `Quick test_text_wrap_composes;
       Alcotest.test_case "font synthesis composes" `Quick
         test_font_synthesis_composes;
+      Alcotest.test_case "webkit text stroke composes" `Quick
+        test_webkit_text_stroke_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
Only `-webkit-text-stroke-color` had a typed spelling, so the shorthand and `-webkit-text-stroke-width` parsed as unknown declarations and `--diff=canonical` could not equate one with the other. No CSS specification defines this shorthand; the grammar the new type carries is what WebKit and Blink accept and what their CSSOM reports back. Follow-up to #930.