### PR TITLE
minify: contract the elliptical border corners

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -597,6 +597,9 @@ entry points both moved.
   losing a thickness set elsewhere, and the run that does write the thickness
   now contracts where it did not before (#932)
 
+- `--minify` contracts `border-radius` from four elliptical corners, writing
+  the horizontal radii before the `/` and the vertical ones after (#933)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -1656,6 +1656,28 @@ let extract_border_radius_corner :
       Some (Left, v, important)
   | _ -> None
 
+(* An elliptical corner names a horizontal radius and a vertical one. CSS
+   Backgrounds 3 (ED) sec. 4.1 writes the four horizontals, then [/], then the
+   four verticals, so the four corners compose into one box per axis. *)
+let extract_border_radius_ellipse :
+    declaration -> (box_side * (Values.length * Values.length) * bool) option =
+  function
+  | Declaration
+      { property = Border_top_left_radius; value = [ h; v ]; important; _ } ->
+      Some (Top, (h, v), important)
+  | Declaration
+      { property = Border_top_right_radius; value = [ h; v ]; important; _ } ->
+      Some (Right, (h, v), important)
+  | Declaration
+      { property = Border_bottom_right_radius; value = [ h; v ]; important; _ }
+    ->
+      Some (Bottom, (h, v), important)
+  | Declaration
+      { property = Border_bottom_left_radius; value = [ h; v ]; important; _ }
+    ->
+      Some (Left, (h, v), important)
+  | _ -> None
+
 (* CSS Scroll Snap 1 sec. 4.2 and 5.1: [scroll-padding] sets the four snapport
    insets and [scroll-margin] the four snap area outsets, each assigning its
    sides exactly as [padding] and [margin] do. *)
@@ -1744,6 +1766,15 @@ let build_border_radius_box ~important ~top ~right ~bottom ~left =
   Some
     (Declaration.v ~important Border_radius
        (Radius { horizontal; vertical = None }))
+
+let build_border_radius_ellipse ~important ~top ~right ~bottom ~left =
+  let lp v : Values.length_percentage = Length v in
+  let axis f =
+    List.map lp (collapse_box_lengths [ f top; f right; f bottom; f left ])
+  in
+  Some
+    (Declaration.v ~important Border_radius
+       (Radius { horizontal = axis fst; vertical = Some (axis snd) }))
 
 let build_scroll_margin_box ~important ~top ~right ~bottom ~left =
   Some
@@ -1951,6 +1982,9 @@ let box_composers ~ctx idx =
     try_same len extract_padding_side build_padding_box;
     try_same len extract_inset_side build_inset_box;
     try_same len extract_border_radius_corner build_border_radius_box;
+    try_same
+      (fun (h, v) -> len h && len v)
+      extract_border_radius_ellipse build_border_radius_ellipse;
     try_same len extract_scroll_margin_side build_scroll_margin_box;
     try_same len extract_scroll_padding_side build_scroll_padding_box;
     try_same width border_width_of build_border_width_box;

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -908,6 +908,29 @@ let test_text_decoration_thickness_composes () =
       ".x{text-decoration-line:underline;text-decoration-thickness:2px;text-decoration-style:solid;text-decoration-color:red!important}"
     ".x{text-decoration-line:underline;text-decoration-thickness:2px;text-decoration-style:solid;text-decoration-color:red!important}"
 
+(* CSS Backgrounds 3 (ED) sec. 4.1: an elliptical corner names a horizontal
+   radius and a vertical one, and [border-radius] writes the four horizontals,
+   then [/], then the four verticals. *)
+let test_border_radius_ellipse_composes () =
+  sheet_optimizes_to ~into:".x{border-radius:1px 2px 3px 4px/5px}"
+    ".x{border-top-left-radius:1px 5px;border-top-right-radius:2px \
+     5px;border-bottom-right-radius:3px 5px;border-bottom-left-radius:4px 5px}";
+  sheet_optimizes_to ~into:".x{border-radius:10%/20%}"
+    ".x{border-top-left-radius:10% 20%;border-top-right-radius:10% \
+     20%;border-bottom-right-radius:10% 20%;border-bottom-left-radius:10% 20%}";
+  sheet_optimizes_to ~into:".x{border-radius:1px 2px/3px 4px}"
+    ".x{border-top-left-radius:1px 3px;border-top-right-radius:2px \
+     4px;border-bottom-right-radius:1px 3px;border-bottom-left-radius:2px 4px}";
+  (* Mixing a round corner with an elliptical one has no box spelling. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{border-top-left-radius:1px \
+       5px;border-top-right-radius:2px;border-bottom-right-radius:3px \
+       5px;border-bottom-left-radius:4px 5px}"
+    ".x{border-top-left-radius:1px \
+     5px;border-top-right-radius:2px;border-bottom-right-radius:3px \
+     5px;border-bottom-left-radius:4px 5px}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1516,6 +1539,8 @@ let suite =
         test_webkit_text_stroke_composes;
       Alcotest.test_case "text decoration thickness composes" `Quick
         test_text_decoration_thickness_composes;
+      Alcotest.test_case "border radius ellipse composes" `Quick
+        test_border_radius_ellipse_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
The corner extractor only took a single-valued corner, so four corners naming both axes stayed four declarations and `--diff=canonical` could not equate them with the slash form of `border-radius`. Follow-up to #932.