### PR TITLE
minify: fold the two one-word flex forms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -600,6 +600,9 @@ entry points both moved.
 - `--minify` contracts `border-radius` from four elliptical corners, writing
   the horizontal radii before the `/` and the vertical ones after (#933)
 
+- `--minify` writes `flex: none` and `flex: auto` for the triples they name,
+  where it used to spell them out as `0 0 auto` and `1 auto` (#934)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -105,11 +105,16 @@ let normalize_flex (value : flex) : flex =
       let g' = normalize_flex_factor g in
       let s' = normalize_flex_factor s in
       if g' == g && s' == s then value else Grow_shrink (g', s')
-  | Full (g, s, b) ->
+  | Full (g, s, b) -> (
       let g' = normalize_flex_factor g in
       let s' = normalize_flex_factor s in
       let b' = normalize_flex_basis b in
-      if g' == g && s' == s && b' == b then value else Full (g', s', b')
+      (* CSS Flexbox 1 sec. 7.1.1 gives [none] and [auto] as the one-word names
+         of [0 0 auto] and [1 1 auto], and the shorter spelling wins. *)
+      match (g', s', b') with
+      | Number 0., Number 0., (Auto : flex_basis) -> None
+      | Number 1., Number 1., Auto -> Auto
+      | _ -> if g' == g && s' == s && b' == b then value else Full (g', s', b'))
   | _ -> value
 
 let rec pp_order : order Pp.t =

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -931,6 +931,18 @@ let test_border_radius_ellipse_composes () =
      5px;border-top-right-radius:2px;border-bottom-right-radius:3px \
      5px;border-bottom-left-radius:4px 5px}"
 
+(* CSS Flexbox 1 sec. 7.1.1 gives [none] and [auto] as the one-word names of [0
+   0 auto] and [1 1 auto], so a run composing to either takes the shorter
+   spelling. *)
+let test_flex_keyword_forms () =
+  sheet_optimizes_to ~into:".x{flex:none}"
+    ".x{flex-grow:0;flex-shrink:0;flex-basis:auto}";
+  sheet_optimizes_to ~into:".x{flex:auto}"
+    ".x{flex-grow:1;flex-shrink:1;flex-basis:auto}";
+  (* [initial] is [0 1 auto], which has no one-word name of its own. *)
+  sheet_optimizes_to ~into:".x{flex:0 auto}"
+    ".x{flex-grow:0;flex-shrink:1;flex-basis:auto}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1541,6 +1553,7 @@ let suite =
         test_text_decoration_thickness_composes;
       Alcotest.test_case "border radius ellipse composes" `Quick
         test_border_radius_ellipse_composes;
+      Alcotest.test_case "flex keyword forms" `Quick test_flex_keyword_forms;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
`flex: 0 0 auto` and `flex: 1 1 auto` are what CSS Flexbox 1 sec. 7.1.1 names `none` and `auto`, but the normaliser shortened each component and never the triple, so `--diff=canonical` could not equate either keyword with its own expansion. Follow-up to #933.