### PR TITLE
minify: contract a complete border-image run in any scope

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -603,6 +603,10 @@ entry points both moved.
 - `--minify` writes `flex: none` and `flex: auto` for the triples they name,
   where it used to spell them out as `0 0 auto` and `1 auto` (#934)
 
+- `--minify` contracts `border-image` from a run naming all five of its
+  longhands whatever the scope, where it used to need `--scope=stylesheet`,
+  and drops a component of the shorthand that names its own initial (#935)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1126,6 +1126,62 @@ let pp_mask_border_mode ctx = function
   | (Alpha : mask_border_mode) -> Pp.string ctx "alpha"
   | Luminance -> Pp.string ctx "luminance"
 
+(* CSS Backgrounds 3 sec. 6.1: a component the shorthand leaves out takes its
+   longhand's initial - [none] for the source (sec. 5.1), [100%] for the slice
+   (sec. 5.2), [1] for the width (sec. 5.3), [0] for the outset (sec. 5.4) and
+   [stretch] for the repeat (sec. 5.5) - so writing one out names what leaving
+   it out names. Drained of every slot the shorthand declares nothing but
+   initials, which is what [none] declares, so the source stays to say it. *)
+let normalize_border_image : border_image -> border_image =
+ fun value ->
+  let drop is_initial slot =
+    match slot with Some v when is_initial v -> Option.None | slot -> slot
+  in
+  let source =
+    drop
+      (function (None : background_image) | Initial -> true | _ -> false)
+      value.source
+  in
+  let slice_initial =
+    drop
+      (fun (s : border_image_slice) ->
+        (not s.fill) && s.offsets = [ (Pct 100. : border_image_slice_item) ])
+      value.slice
+  in
+  let outset =
+    drop
+      (function
+        | [ (Number 0. : border_image_outset_item) ] | [ Length Zero ] -> true
+        | _ -> false)
+      value.outset
+  in
+  (* The printer writes one [/] per slot, so a dropped width with a kept outset
+     would put the outset in the width's place. The width only goes when the
+     outset does. *)
+  let width =
+    if Option.is_some outset then value.width
+    else
+      drop
+        (function
+          | [ (Number 1. : border_image_width_item) ] -> true | _ -> false)
+        value.width
+  in
+  let repeat =
+    drop (fun r -> r = [ (Stretch : border_image_repeat_keyword) ]) value.repeat
+  in
+  (* The printer writes the slice before the first [/], so a kept width or
+     outset needs it even at its initial. *)
+  let slice =
+    if Option.is_some width || Option.is_some outset then value.slice
+    else slice_initial
+  in
+  let drained =
+    Option.is_none source && Option.is_none slice && Option.is_none width
+    && Option.is_none outset && Option.is_none repeat
+  in
+  let source = if drained then Some (None : background_image) else source in
+  { value with source; slice; width; outset; repeat }
+
 let pp_border_image : border_image Pp.t =
  fun ctx { source; slice; width; outset; repeat; mode } ->
   let first = ref true in

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4533,6 +4533,7 @@ let normalize_property_value : type a.
   | Flood_opacity -> normalize_opacity value
   | Line_height -> normalize_line_height ~lossless value
   | Vertical_align -> normalize_vertical_align value
+  | Border_image -> normalize_border_image value
   | Border_width ->
       normalize_box_shorthand ~is_substitution:is_border_width_substitution
         normalize_border_width value

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -503,6 +503,10 @@ val pp_mask_border_mode : mask_border_mode Pp.t
 val read_mask_border_mode : Cursor.t -> mask_border_mode
 (** [read_mask_border_mode t] parses a [mask-border] mode keyword. *)
 
+val normalize_border_image : border_image -> border_image
+(** [normalize_border_image v] drops each component of [v] that names its own
+    longhand's initial, which is what leaving the component out names. *)
+
 val pp_border_image : border_image Pp.t
 (** [pp_border_image] pretty-prints the [border-image] shorthand. *)
 

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3903,19 +3903,31 @@ let span_border_image_run_at idx i =
   in
   aux i []
 
-let border_image_run_can_compose run ~foldable ~slice ~width ~outset =
+(* The shorthand resets all five longhands, so a run naming every one of them is
+   the same declaration whatever else the sheet holds. A shorter run leaves the
+   rest to the reset, which is only safe with the whole sheet in view. *)
+let border_image_run_can_compose run ~allow_partial ~foldable ~source ~slice
+    ~width ~outset ~repeat =
   let need_slice =
     (Option.is_some width || Option.is_some outset) && Option.is_none slice
   in
+  let complete =
+    Option.is_some source && Option.is_some slice && Option.is_some width
+    && Option.is_some outset && Option.is_some repeat
+  in
   List.length run >= 2
   && same_importance (List.map snd run)
-  && foldable && not need_slice
+  && foldable && (not need_slice)
+  && (allow_partial || complete)
 
+(* The record is built here rather than read, so the slot-initial fold the
+   reader's values get has to be applied to it as well. *)
 let border_image_shorthand run ~source ~slice ~width ~outset ~repeat =
   Declaration.v
     ~important:(is_important (snd (List.hd run)))
     Border_image
-    { source; slice; width; outset; repeat; mode = None }
+    (Properties.normalize_border_image
+       { source; slice; width; outset; repeat; mode = None })
 
 let record_border_image_longhand
     ~(source : Properties.background_image option ref)
@@ -3940,7 +3952,8 @@ let record_border_image_longhand
   | Declaration { property = Border_image_repeat; _ } -> foldable := false
   | _ -> ()
 
-let compose_border_image_run (run : (int * Declaration.declaration) list) :
+let compose_border_image_run ~allow_partial
+    (run : (int * Declaration.declaration) list) :
     (int * Declaration.declaration) option =
   let source : Properties.background_image option ref = ref Option.None in
   let slice : Properties.border_image_slice option ref = ref Option.None in
@@ -3962,8 +3975,9 @@ let compose_border_image_run (run : (int * Declaration.declaration) list) :
     run;
   if
     not
-      (border_image_run_can_compose run ~foldable:!foldable ~slice:!slice
-         ~width:!width ~outset:!outset)
+      (border_image_run_can_compose run ~allow_partial ~foldable:!foldable
+         ~source:!source ~slice:!slice ~width:!width ~outset:!outset
+         ~repeat:!repeat)
   then Option.None
   else
     let merged =
@@ -3972,18 +3986,19 @@ let compose_border_image_run (run : (int * Declaration.declaration) list) :
     in
     Some (fst (List.hd run), merged)
 
-let try_compose_border_image_at idx i =
+let try_compose_border_image_at ~allow_partial idx i =
   let d = Rule_index.decl_at idx i in
   if not (is_border_image_longhand_decl d) then None
   else
     let run, len = span_border_image_run_at idx i in
-    match compose_border_image_run run with
+    match compose_border_image_run ~allow_partial run with
     | Some (_, shorthand) -> Some (shorthand, len)
     | None -> None
 
 let compose_border_image_via_index ~ctx idx =
-  if scope ctx <> `Stylesheet then ()
-  else compose_run_via_index idx ~try_compose:try_compose_border_image_at
+  let allow_partial = scope ctx = `Stylesheet in
+  compose_run_via_index idx
+    ~try_compose:(try_compose_border_image_at ~allow_partial)
 
 let compose_border_image_shorthand ~ctx decls =
   let idx = Rule_index.build (List.map snd decls) in

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -943,6 +943,23 @@ let test_flex_keyword_forms () =
   sheet_optimizes_to ~into:".x{flex:0 auto}"
     ".x{flex-grow:0;flex-shrink:1;flex-basis:auto}"
 
+(* CSS Backgrounds 3 sec. 6.1: [border-image] resets all five of its longhands,
+   so a run naming every one of them is the same declaration whatever else the
+   sheet holds. A shorter run leaves the rest to the reset, which only the
+   whole-sheet scope can judge. *)
+let test_border_image_full_run_composes () =
+  (* Every component but the source and slice is at its initial, so the
+     shorthand names them by leaving them out. *)
+  sheet_optimizes_to ~into:".x{border-image:url(a.png)30}"
+    ".x{border-image-source:url(a.png);border-image-slice:30;border-image-width:1;border-image-outset:0;border-image-repeat:stretch}";
+  sheet_optimizes_to ~into:".x{border-image:none}"
+    ".x{border-image-source:none;border-image-slice:100%;border-image-width:1;border-image-outset:0;border-image-repeat:stretch}";
+  (* A run missing a longhand would have the shorthand reset it. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{border-image-source:url(a.png);border-image-slice:30;border-image-width:1;border-image-outset:0}"
+    ".x{border-image-source:url(a.png);border-image-slice:30;border-image-width:1;border-image-outset:0}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1554,6 +1571,8 @@ let suite =
       Alcotest.test_case "border radius ellipse composes" `Quick
         test_border_radius_ellipse_composes;
       Alcotest.test_case "flex keyword forms" `Quick test_flex_keyword_forms;
+      Alcotest.test_case "border image full run composes" `Quick
+        test_border_image_full_run_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
The composition was gated on `--scope=stylesheet` because a partial run leaves the longhands it omits to the shorthand's reset. A run naming all five carries no such risk, so it now contracts by default and `--diff=canonical` can equate the shorthand with its own expansion. The shorthand also kept components that spell out their own initial; those now fold, subject to the printer needing a slice before any `/`. Follow-up to #934.