### PR TITLE
border-image: refuse a keyword in a box value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -607,6 +607,11 @@ entry points both moved.
   longhands whatever the scope, where it used to need `--scope=stylesheet`,
   and drops a component of the shorthand that names its own initial (#935)
 
+- `border-image-outset` and `border-image-width` reject a keyword their
+  grammar does not carry. Both read through the generic length reader, whose
+  keyword list includes `stretch`, so `border-image: url(a.png) 30/1/0 stretch`
+  parsed the repeat as part of the outset (#936)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -2255,11 +2255,14 @@ let read_border_image_slice t : border_image_slice =
   | offsets, fill -> { offsets; fill }
 
 let read_border_image_width_item t : border_image_width_item =
-  match Cursor.peek_ident t with
-  | Some "auto" ->
-      ignore (Cursor.ident t : string);
-      Auto
-  | _ -> (
+  let auto t =
+    Cursor.enum "border-image-width"
+      [ ("auto", (Auto : border_image_width_item)) ]
+      t
+  in
+  match Cursor.option auto t with
+  | Some value -> value
+  | None -> (
       match Cursor.percentage_opt t with
       | Some n when n >= 0. -> Pct n
       | Some _ -> Cursor.err_invalid t "border-image value cannot be negative"
@@ -2269,15 +2272,22 @@ let read_border_image_width_item t : border_image_width_item =
           | Some _ ->
               Cursor.err_invalid t "border-image value cannot be negative"
           | None ->
-              let len = read_length ~allow_negative:false t in
+              (* Sec. 5.3 gives the width a number, a length-percentage or
+                 [auto], read above. The generic length reader carries keywords
+                 of its own - [stretch] and [contain] among them, which name a
+                 repeat here - so this call takes none. *)
+              let len =
+                read_length ~allow_negative:false ~with_keywords:false t
+              in
               Length len))
 
+(* Sec. 5.4 gives the outset a number or a length per side and no keyword. *)
 let read_border_image_outset_item t : border_image_outset_item =
   match Cursor.number_opt t with
   | Some n when n >= 0. -> Number n
   | Some _ -> Cursor.err_invalid t "border-image value cannot be negative"
   | None ->
-      let len = read_length ~allow_negative:false t in
+      let len = read_length ~allow_negative:false ~with_keywords:false t in
       Length len
 
 let read_border_image_box_step ~what read_item t acc =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3152,7 +3152,17 @@ let invalid () =
   neg "color: red inherit";
   neg "font-size: unset 12px";
   neg "opacity: revert 0.5";
-  neg "z-index: revert-layer 10"
+  neg "z-index: revert-layer 10";
+
+  (* CSS Backgrounds 3 (ED) sec. 5.4 gives [border-image-outset] a number or a
+     length per side and no keyword, and sec. 5.3 lets [border-image-width] add
+     [auto] and nothing else. The generic length reader takes a keyword list of
+     its own, [stretch] included, which is a repeat keyword here. *)
+  neg "border-image-outset: stretch";
+  neg "border-image-outset: 0 stretch";
+  neg "border-image-outset: auto";
+  neg "border-image-width: stretch";
+  neg "border-image-width: 1 min-content"
 
 let spec_property_grammar_table_expansion () =
   (* Cross-spec property grammar vectors. This grows toward an exhaustive table:

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4253,7 +4253,9 @@ let spec_platform_property_vectors () =
     "width: attr(data-w px, calc(10px + 0px))";
   check_declaration
     ~expected:"border-image:linear-gradient(red,blue)30 fill/10px/1 stretch"
-    ~optimized:"border-image:linear-gradient(red,blue)30 fill/10px/1 stretch"
+      (* [stretch] is the repeat's initial (CSS Backgrounds 3 sec. 5.5), which
+         is what leaving the component out names. *)
+    ~optimized:"border-image:linear-gradient(red,blue)30 fill/10px/1"
     "border-image: linear-gradient(red, blue) 30 fill / 10px / 1 stretch";
   List.iter
     (fun input -> neg_cursor read_declaration input)


### PR DESCRIPTION
`border-image-outset` takes a number or a length per side and `border-image-width` adds `auto`, but both fell through to the generic length reader, whose keyword list carries `stretch` and `contain` among others. `border-image: url(a.png) 30/1/0 stretch` therefore read the repeat as a second outset value. The browser differential counts 8 fewer accepts-invalid vectors with no new rejects-valid. Follow-up to #935.