### PR TITLE
minify: contract offset

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -612,6 +612,9 @@ entry points both moved.
   keyword list includes `stretch`, so `border-image: url(a.png) 30/1/0 stretch`
   parsed the repeat as part of the outset (#936)
 
+- `--minify` contracts `offset` from a run naming all five of its longhands
+  (#937)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -4766,6 +4766,86 @@ let try_compose_text_decoration_at ~held idx i =
 let compose_text_decoration_via_index ~held idx =
   compose_run_via_index idx ~try_compose:(try_compose_text_decoration_at ~held)
 
+(* Motion Path 1 sec. 2.6: [offset] is [<position>? [<path> [<distance> ||
+   <rotate>]?]? [/ <anchor>]?] over its five longhands, and it resets every one
+   of them, so the run that names the same declaration is all five. A component
+   at its initial - [normal] for the position (sec. 2.1), [0] for the distance
+   (sec. 2.3), [auto] for the rotate (sec. 2.4) and for the anchor (sec. 2.5) -
+   is what leaving it out names. *)
+type offset_part = Position | Path | Distance | Rotate | Anchor
+
+let offset_part_of : declaration -> offset_part option = function
+  | Declaration { property = Offset_position; _ } -> Some Position
+  | Declaration { property = Offset_path; _ } -> Some Path
+  | Declaration { property = Offset_distance; _ } -> Some Distance
+  | Declaration { property = Offset_rotate; _ } -> Some Rotate
+  | Declaration { property = Offset_anchor; _ } -> Some Anchor
+  | _ -> None
+
+let offset_position_of : declaration -> Properties.offset_position option =
+  function
+  | Declaration { property = Offset_position; value = Normal | Initial; _ } ->
+      Option.None
+  | Declaration { property = Offset_position; value; _ } -> Some value
+  | _ -> Option.None
+
+let offset_path_of : declaration -> Properties.offset_path option = function
+  | Declaration { property = Offset_path; value; _ } -> Some value
+  | _ -> Option.None
+
+let offset_distance_of : declaration -> Values.length_percentage option =
+  function
+  | Declaration { property = Offset_distance; value = Length Zero; _ } ->
+      Option.None
+  | Declaration { property = Offset_distance; value; _ } -> Some value
+  | _ -> Option.None
+
+let offset_rotate_of : declaration -> Properties.offset_rotate option = function
+  | Declaration { property = Offset_rotate; value = Auto | Initial; _ } ->
+      Option.None
+  | Declaration { property = Offset_rotate; value; _ } -> Some value
+  | _ -> Option.None
+
+let offset_anchor_of : declaration -> Properties.offset_anchor option = function
+  | Declaration { property = Offset_anchor; value = Auto | Initial; _ } ->
+      Option.None
+  | Declaration { property = Offset_anchor; value; _ } -> Some value
+  | _ -> Option.None
+
+let offset_of_run raw : Properties.offset option =
+  let parts = List.filter_map offset_part_of raw in
+  if List.length (List.sort_uniq compare parts) <> 5 then Option.None
+  else
+    let position = List.find_map offset_position_of raw in
+    let distance = List.find_map offset_distance_of raw in
+    let rotate = List.find_map offset_rotate_of raw in
+    let anchor = List.find_map offset_anchor_of raw in
+    match List.find_map offset_path_of raw with
+    | Some path ->
+        Some
+          (Shorthand
+             { target = With_path { position; path; distance; rotate }; anchor })
+    | Option.None -> Option.None
+
+let try_compose_offset_at idx i =
+  let n = Rule_index.length idx in
+  if i + 4 >= n then None
+  else
+    let positions = List.init 5 (fun j -> i + j) in
+    if List.exists (Rule_index.is_absorbed idx) positions then None
+    else
+      let raw = List.map (Rule_index.decl_at idx) positions in
+      if (not (same_importance raw)) || List.exists has_runtime_substitution raw
+      then None
+      else
+        Option.map
+          (fun v ->
+            (Declaration.v ~important:(is_important (List.hd raw)) Offset v, 5))
+          (offset_of_run raw)
+
+let compose_offset_via_index idx =
+  compose_run_via_index idx ~try_compose:try_compose_offset_at
+
 let try_compose_transition_at ~held idx i =
   let parts, len = take_run_at idx ~part_of:transition_part_of i in
   if List.length parts < 2 then None
@@ -5572,6 +5652,7 @@ let compose_index_group_b ~held kept =
   compose_list_style_via_index idx;
   compose_flex_via_index idx;
   compose_text_decoration_via_index ~held idx;
+  compose_offset_via_index idx;
   compose_border_via_index idx;
   compose_line_via_index idx;
   List.mapi (fun i d -> (i, d)) (Rule_index.to_list idx)

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -960,6 +960,21 @@ let test_border_image_full_run_composes () =
       ".x{border-image-source:url(a.png);border-image-slice:30;border-image-width:1;border-image-outset:0}"
     ".x{border-image-source:url(a.png);border-image-slice:30;border-image-width:1;border-image-outset:0}"
 
+(* Motion Path 1 sec. 2.6: [offset] resets all five of its longhands, so the run
+   naming the same declaration is all five, and a component at its initial is
+   what leaving it out names. *)
+let test_offset_composes () =
+  sheet_optimizes_to ~into:".x{offset:path(\"M 0 0 L 10 10\")10px}"
+    ".x{offset-position:normal;offset-path:path(\"M 0 0 L 10 \
+     10\");offset-distance:10px;offset-rotate:auto;offset-anchor:auto}";
+  sheet_optimizes_to ~into:".x{offset:none}"
+    ".x{offset-position:normal;offset-path:none;offset-distance:0;offset-rotate:auto;offset-anchor:auto}";
+  (* A run missing a longhand would have the shorthand reset it. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{offset-position:normal;offset-path:none;offset-distance:0;offset-rotate:auto}"
+    ".x{offset-position:normal;offset-path:none;offset-distance:0;offset-rotate:auto}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1573,6 +1588,7 @@ let suite =
       Alcotest.test_case "flex keyword forms" `Quick test_flex_keyword_forms;
       Alcotest.test_case "border image full run composes" `Quick
         test_border_image_full_run_composes;
+      Alcotest.test_case "offset composes" `Quick test_offset_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
The family had no composer, so a rule writing `offset-position`, `-path`, `-distance`, `-rotate` and `-anchor` kept five declarations and `--diff=canonical` could not equate them with `offset`. The shorthand resets all five, so only the full run contracts. Follow-up to #936.