### PR TITLE
properties: add column-height and column-wrap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -615,6 +615,10 @@ entry points both moved.
 - `--minify` contracts `offset` from a run naming all five of its longhands
   (#937)
 
+- `Css.column_height` and `Css.column_wrap` are new, with the `column-height`
+  and `column-wrap` properties CSS Multicol 2 adds. Chrome expands `columns`
+  to all four longhands, so `columns` now records resetting both (#938)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1787,6 +1787,8 @@ let read_object_transition_value : type a.
   | Page_size -> Some (v Page_size (read_page_size t))
   | Columns -> Some (v Columns (read_columns_value t))
   | Column_width -> Some (v Column_width (read_column_width t))
+  | Column_height -> Some (v Column_height (read_column_height t))
+  | Column_wrap -> Some (v Column_wrap (read_column_wrap t))
   | Column_count -> Some (v Column_count (read_column_count t))
   | Column_rule -> Some (v Column_rule (read_border t))
   | Column_rule_color -> Some (v Column_rule_color (read_color t))

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -131,6 +131,30 @@ let rec pp_column_width : column_width Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+(* CSS Multicol 2 sec. 4.2 and 4.4. *)
+let rec pp_column_height : column_height Pp.t =
+ fun ctx -> function
+  | Auto -> Pp.string ctx "auto"
+  | Height len -> pp_length ctx len
+  | Var v -> pp_var pp_column_height ctx v
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+
+let rec pp_column_wrap : column_wrap Pp.t =
+ fun ctx -> function
+  | Auto -> Pp.string ctx "auto"
+  | Nowrap -> Pp.string ctx "nowrap"
+  | Wrap -> Pp.string ctx "wrap"
+  | Var v -> pp_var pp_column_wrap ctx v
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+
 let rec pp_column_count : column_count Pp.t =
  fun ctx -> function
   | Auto -> Pp.string ctx "auto"
@@ -328,6 +352,43 @@ let rec read_column_width t : column_width =
     ]
     ~var:(fun t -> Var (Values.read_var read_column_width t))
     ~default:(fun t -> (Width (read_length t) : column_width))
+    t
+
+(* The height takes a length and no percentage, which Chrome 146 refuses. *)
+let rec read_column_height t : column_height =
+  Cursor.enum_or_var "column-height"
+    [
+      ("auto", (Auto : column_height));
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (Values.read_var read_column_height t))
+    ~default:(fun t ->
+      (* The generic length reader carries a keyword list of its own -
+         [min-content], [none] and [normal] among them - and the height takes
+         none of those beside its own [auto]. *)
+      (Height
+         (read_length ~length_only:true ~allow_negative:false
+            ~with_keywords:false t)
+        : column_height))
+    t
+
+let rec read_column_wrap t : column_wrap =
+  Cursor.enum_or_var "column-wrap"
+    [
+      ("auto", (Auto : column_wrap));
+      ("nowrap", Nowrap);
+      ("wrap", Wrap);
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (Values.read_var read_column_wrap t))
     t
 
 let rec read_column_count t : column_count =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -586,6 +586,8 @@ let pp_property : type a. a property Pp.t =
   | Page_size -> Pp.string ctx "size"
   | Columns -> Pp.string ctx "columns"
   | Column_width -> Pp.string ctx "column-width"
+  | Column_height -> Pp.string ctx "column-height"
+  | Column_wrap -> Pp.string ctx "column-wrap"
   | Column_count -> Pp.string ctx "column-count"
   | Column_rule -> Pp.string ctx "column-rule"
   | Column_rule_width -> Pp.string ctx "column-rule-width"
@@ -1041,9 +1043,9 @@ let property_class : type a. a property -> a property_class = function
   | Transition_property | Transition_behavior | Overlay | Will_change | Contain
   | Isolation | Break_before | Break_after | Break_inside | Page_break_before
   | Page_break_after | Page_break_inside | Page_size | Columns | Column_width
-  | Column_count | Column_rule | Column_rule_color | Column_rule_width
-  | Column_rule_style | Column_span | Background_attachment | Border_top
-  | Border_right | Border_bottom | Border_left | Transform_origin
+  | Column_height | Column_wrap | Column_count | Column_rule | Column_rule_color
+  | Column_rule_width | Column_rule_style | Column_span | Background_attachment
+  | Border_top | Border_right | Border_bottom | Border_left | Transform_origin
   | Transform_box | Mask | Mask_border | Content_visibility | Filter
   | Background_image | Background_origin | Background_clip
   | Webkit_background_clip | Animation | Aspect_ratio | Overflow_x | Overflow_y
@@ -1489,6 +1491,8 @@ let property_tag : type a. a property -> int = function
   | Page_size -> 368
   | Columns -> 369
   | Column_width -> 370
+  | Column_height -> 544
+  | Column_wrap -> 545
   | Column_count -> 371
   | Column_rule -> 372
   | Column_rule_color -> 373
@@ -2065,6 +2069,8 @@ let eq_property : type a b. a property -> b property -> (a, b) Type.eq option =
   | Page_size, Page_size -> Some Equal
   | Columns, Columns -> Some Equal
   | Column_width, Column_width -> Some Equal
+  | Column_height, Column_height -> Some Equal
+  | Column_wrap, Column_wrap -> Some Equal
   | Column_count, Column_count -> Some Equal
   | Column_rule, Column_rule -> Some Equal
   | Column_rule_color, Column_rule_color -> Some Equal
@@ -2977,6 +2983,8 @@ let read_any_property t =
   | "page-break-inside" -> Prop Page_break_inside
   | "columns" -> Prop Columns
   | "column-width" -> Prop Column_width
+  | "column-height" -> Prop Column_height
+  | "column-wrap" -> Prop Column_wrap
   | "column-count" -> Prop Column_count
   | "column-rule" -> Prop Column_rule
   | "column-rule-color" -> Prop Column_rule_color
@@ -4043,6 +4051,8 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Page_size, value -> value
   | Columns, value -> value
   | Column_width, value -> value
+  | Column_height, value -> value
+  | Column_wrap, value -> value
   | Column_count, value -> value
   | Column_span, value -> value
   | Background_attachment, value -> value
@@ -4767,6 +4777,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Page_size -> pp pp_page_size
   | Columns -> pp pp_columns_value
   | Column_width -> pp pp_column_width
+  | Column_height -> pp pp_column_height
+  | Column_wrap -> pp pp_column_wrap
   | Column_count -> pp pp_column_count
   | Column_rule -> pp pp_border
   | Column_span -> pp pp_column_span

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -872,6 +872,18 @@ val pp_flex : flex Pp.t
 val read_flex : Cursor.t -> flex
 (** [read_flex t] is the [flex] parsed from [t]. *)
 
+val pp_column_height : column_height Pp.t
+(** [pp_column_height] is the pretty-printer for [column_height]. *)
+
+val read_column_height : Cursor.t -> column_height
+(** [read_column_height t] is the [column_height] parsed from [t]. *)
+
+val pp_column_wrap : column_wrap Pp.t
+(** [pp_column_wrap] is the pretty-printer for [column_wrap]. *)
+
+val read_column_wrap : Cursor.t -> column_wrap
+(** [read_column_wrap t] is the [column_wrap] parsed from [t]. *)
+
 val pp_column_width : column_width Pp.t
 (** [pp_column_width] is the pretty-printer for [column_width]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3933,6 +3933,30 @@ type column_count =
   | Revert_layer
   | Var of column_count var
 
+(* CSS Multicol 2 sec. 4.2: [column-height] is [auto | <length [0,inf]>]; it
+   takes no percentage, which Chrome 146 refuses. Sec. 4.4 gives [column-wrap]
+   the three keywords below. Both start at [auto]. *)
+type column_height =
+  | Auto
+  | Height of length
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of column_height var
+
+type column_wrap =
+  | Auto
+  | Nowrap
+  | Wrap
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of column_wrap var
+
 type column_span =
   | None
   | All
@@ -5071,6 +5095,8 @@ type 'a property =
   | Page_size : page_size property
   | Columns : columns_value property
   | Column_width : column_width property
+  | Column_height : column_height property
+  | Column_wrap : column_wrap property
   | Column_count : column_count property
   | Column_rule : border property
   | Column_rule_width : border_width property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -151,6 +151,10 @@ let covers_longhand : type a b.
   | Webkit_text_stroke, Webkit_text_stroke_width -> true
   | Webkit_text_stroke, Webkit_text_stroke_color -> true
   (* CSS Multicol 1 sec. 4.3: [column-rule] is the three rule longhands. *)
+  | Columns, Column_width -> true
+  | Columns, Column_count -> true
+  | Columns, Column_height -> true
+  | Columns, Column_wrap -> true
   | Column_rule, Column_rule_width -> true
   | Column_rule, Column_rule_style -> true
   | Column_rule, Column_rule_color -> true
@@ -813,9 +817,19 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Overflow_block -> [ key "overflow-block" ]
   | Overflow_inline -> [ key "overflow-inline" ]
   (* CSS Multicol 1 sec. 3.3. *)
-  | Columns -> [ key "column-width"; key "column-count" ]
+  (* CSS Multicol 2 sec. 4.5: [columns] sets the width, the count and the
+     height, and Chrome 146 has it reset [column-wrap] as well. *)
+  | Columns ->
+      [
+        key "column-width";
+        key "column-count";
+        key "column-height";
+        key "column-wrap";
+      ]
   | Column_width -> [ key "column-width" ]
   | Column_count -> [ key "column-count" ]
+  | Column_height -> [ key "column-height" ]
+  | Column_wrap -> [ key "column-wrap" ]
   (* CSS Multicol 1 sec. 4.4: [column-rule] resets the rule width, style and
      colour. Naming those three is what keeps [column-rule-color] from reading
      as a slot of its own that [column-rule] never touches. *)

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -879,6 +879,12 @@ let vars_of_border_image_outset (value : Properties.border_image_outset) :
 let vars_of_column_width (value : Properties.column_width) : any_var list =
   match value with Var v -> [ V v ] | Width l -> vars_of_length l | _ -> []
 
+let vars_of_column_height (value : Properties.column_height) : any_var list =
+  match value with Var v -> [ V v ] | Height l -> vars_of_length l | _ -> []
+
+let vars_of_column_wrap (value : Properties.column_wrap) : any_var list =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_column_count (value : Properties.column_count) : any_var list =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2249,6 +2255,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
   (* Columns *)
   | Columns, value -> vars_of_columns_value value
   | Column_width, value -> vars_of_column_width value
+  | Column_height, value -> vars_of_column_height value
+  | Column_wrap, value -> vars_of_column_wrap value
   | Column_count, value -> vars_of_column_count value
   | Column_rule, value -> vars_of_border value
   | Column_rule_color, value -> vars_of_color value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -557,6 +557,12 @@ let special_cases () =
     ~optimized:"border-block-width:1px 2px" "border-block-width: 1px 2px";
   check_declaration ~expected:"border-block-style:solid solid"
     ~optimized:"border-block-style:solid" "border-block-style: solid solid";
+  check_declaration ~expected:"column-height:auto"
+    ~optimized:"column-height:auto" "column-height: auto";
+  check_declaration ~expected:"column-height:10px"
+    ~optimized:"column-height:10px" "column-height: 10px";
+  check_declaration ~expected:"column-wrap:wrap" ~optimized:"column-wrap:wrap"
+    "column-wrap: wrap";
   check_declaration ~expected:"border-inline-color:red red"
     ~optimized:"border-inline-color:red" "border-inline-color: red red";
 
@@ -3162,7 +3168,18 @@ let invalid () =
   neg "border-image-outset: 0 stretch";
   neg "border-image-outset: auto";
   neg "border-image-width: stretch";
-  neg "border-image-width: 1 min-content"
+  neg "border-image-width: 1 min-content";
+
+  (* CSS Multicol 2 sec. 4.2 gives [column-height] a length and no percentage,
+     which Chrome 146 refuses, and sec. 4.4 gives [column-wrap] three
+     keywords. *)
+  neg "column-height: 50%";
+  neg "column-height: nowrap";
+  neg "column-height: min-content";
+  neg "column-height: none";
+  neg "column-height: normal";
+  neg "column-wrap: sideways";
+  neg "column-wrap: 10px"
 
 let spec_property_grammar_table_expansion () =
   (* Cross-spec property grammar vectors. This grows toward an exhaustive table:


### PR DESCRIPTION
CSS Multicol 2 adds both properties and Chrome 146 expands `columns` to all four longhands, but neither had a typed spelling, so a sheet setting one parsed an unknown declaration and nothing recorded that `columns` resets it. The grammars are checked against Chrome: `column-height` refuses a percentage, `column-wrap` takes `auto | nowrap | wrap`. Follow-up to #937.