### PR TITLE
minify: contract columns over the height and wrap slots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -619,6 +619,11 @@ entry points both moved.
   and `column-wrap` properties CSS Multicol 2 adds. Chrome expands `columns`
   to all four longhands, so `columns` now records resetting both (#938)
 
+- `--minify` contracts `columns` from a run naming all four of its longhands,
+  and no longer synthesises it over a rule that sets `column-height` or
+  `column-wrap`, which the shorthand resets. `columns: auto 3` minifies to
+  `columns: 3` (#939)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -100,6 +100,12 @@ let break_inside_of_page_break (value : page_break_inside_value) :
   | Inherit -> Some Inherit
   | Var _ -> None
 
+(* CSS Multicol 2 sec. 4.5 leaves an omitted component at its longhand's
+   initial, and [auto] is the width's (sec. 4.1), so [auto <count>] names what
+   [<count>] names and the shorter spelling wins. *)
+let normalize_columns_value : columns_value -> columns_value =
+ fun value -> match value with Auto_count n -> Count n | other -> other
+
 let rec pp_columns_value : columns_value Pp.t =
  fun ctx -> function
   | Auto -> Pp.string ctx "auto"

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4544,6 +4544,7 @@ let normalize_property_value : type a.
   | Line_height -> normalize_line_height ~lossless value
   | Vertical_align -> normalize_vertical_align value
   | Border_image -> normalize_border_image value
+  | Columns -> normalize_columns_value value
   | Border_width ->
       normalize_box_shorthand ~is_substitution:is_border_width_substitution
         normalize_border_width value

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2179,6 +2179,10 @@ val read_page_break_inside_value : Cursor.t -> page_break_inside_value
 (** [read_page_break_inside_value t] is the legacy [page-break-inside] value
     parsed from [t]. *)
 
+val normalize_columns_value : columns_value -> columns_value
+(** [normalize_columns_value v] drops an explicit [auto] width beside a count,
+    which is what leaving the component out names. *)
+
 val pp_columns_value : columns_value Pp.t
 (** [pp_columns_value] is the pretty-printer for [columns_value]. *)
 

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -84,6 +84,22 @@ let columns_value_of_longhands width count : Properties.columns_value =
 (* Compose the unique [column-width]/[column-count] pair into [columns] when
    both carry a plain (non-[var()], non-CSS-wide) matching-importance value, at
    the position of the first. *)
+(* CSS Multicol 2 sec. 4.5: the shorthand sets the height too, and Chrome 146
+   has it reset [column-wrap] as well, so synthesising it over a rule that
+   writes either at a value other than its [auto] initial would drop that
+   value. *)
+let columns_holds_reset_slot d =
+  match d with
+  | Declaration { property = Column_height; value; _ } -> (
+      match (value : Properties.column_height) with
+      | Auto | Initial -> false
+      | _ -> true)
+  | Declaration { property = Column_wrap; value; _ } -> (
+      match (value : Properties.column_wrap) with
+      | Auto | Initial -> false
+      | _ -> true)
+  | _ -> false
+
 let synthesize_columns decls =
   let width_of d : (Properties.column_width * bool) option =
     match d with
@@ -100,41 +116,44 @@ let synthesize_columns decls =
   let uniq f =
     match List.filter_map f decls with [ x ] -> Some x | _ -> None
   in
-  match (uniq width_of, uniq count_of) with
-  | Some (w, wi), Some (c, ci) when wi = ci -> (
-      let plain_width :
-          Properties.column_width -> [ `Auto | `Width of Values.length ] option
-          = function
-        | Auto -> Some `Auto
-        | Width l -> Some (`Width l)
-        | _ -> None
-      in
-      let plain_count :
-          Properties.column_count -> [ `Auto | `Count of int ] option = function
-        | Auto -> Some `Auto
-        | Count n -> Some (`Count n)
-        | _ -> None
-      in
-      match (plain_width w, plain_count c) with
-      | Some w, Some c ->
-          let shorthand =
-            Declaration.v ~important:wi Properties.Columns
-              (columns_value_of_longhands w c)
-          in
-          let placed = ref false in
-          List.filter_map
-            (fun d ->
-              match d with
-              | Declaration { property = Column_width; _ }
-              | Declaration { property = Column_count; _ } ->
-                  if !placed then None
-                  else (
-                    placed := true;
-                    Some shorthand)
-              | _ -> Some d)
-            decls
-      | _ -> decls)
-  | _ -> decls
+  if List.exists columns_holds_reset_slot decls then decls
+  else
+    match (uniq width_of, uniq count_of) with
+    | Some (w, wi), Some (c, ci) when wi = ci -> (
+        let plain_width :
+            Properties.column_width ->
+            [ `Auto | `Width of Values.length ] option = function
+          | Auto -> Some `Auto
+          | Width l -> Some (`Width l)
+          | _ -> None
+        in
+        let plain_count :
+            Properties.column_count -> [ `Auto | `Count of int ] option =
+          function
+          | Auto -> Some `Auto
+          | Count n -> Some (`Count n)
+          | _ -> None
+        in
+        match (plain_width w, plain_count c) with
+        | Some w, Some c ->
+            let shorthand =
+              Declaration.v ~important:wi Properties.Columns
+                (columns_value_of_longhands w c)
+            in
+            let placed = ref false in
+            List.filter_map
+              (fun d ->
+                match d with
+                | Declaration { property = Column_width; _ }
+                | Declaration { property = Column_count; _ } ->
+                    if !placed then None
+                    else (
+                      placed := true;
+                      Some shorthand)
+                | _ -> Some d)
+              decls
+        | _ -> decls)
+    | _ -> decls
 
 (* CSS Anchor Positioning 1: [position-try] is [<order> || <fallbacks>]. No
    typed [position-try] shorthand exists, so the synthesised value is re-parsed

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -4860,6 +4860,71 @@ let try_compose_offset_at idx i =
 let compose_offset_via_index idx =
   compose_run_via_index idx ~try_compose:try_compose_offset_at
 
+(* CSS Multicol 2 sec. 4.5: [columns] sets the width, the count and the height,
+   and Chrome 146 has it reset [column-wrap] too, so the run naming the same
+   declaration is all four. The shorthand has no spelling for a height other
+   than its [auto] initial, so a run carrying one keeps its longhands. *)
+type columns_part = Width | Count | Height | Wrap
+
+let columns_part_of : declaration -> columns_part option = function
+  | Declaration { property = Column_width; _ } -> Some Width
+  | Declaration { property = Column_count; _ } -> Some Count
+  | Declaration { property = Column_height; _ } -> Some Height
+  | Declaration { property = Column_wrap; _ } -> Some Wrap
+  | _ -> None
+
+let columns_initial_tail : declaration -> bool = function
+  | Declaration { property = Column_height; value; _ } -> (
+      match (value : Properties.column_height) with
+      | Auto | Initial -> true
+      | _ -> false)
+  | Declaration { property = Column_wrap; value; _ } -> (
+      match (value : Properties.column_wrap) with
+      | Auto | Initial -> true
+      | _ -> false)
+  | _ -> true
+
+let columns_width_of : declaration -> Properties.column_width option = function
+  | Declaration { property = Column_width; value; _ } -> Some value
+  | _ -> Option.None
+
+let columns_count_of : declaration -> Properties.column_count option = function
+  | Declaration { property = Column_count; value; _ } -> Some value
+  | _ -> Option.None
+
+let columns_of_run raw : Properties.columns_value option =
+  let width = List.find_map columns_width_of raw in
+  let count = List.find_map columns_count_of raw in
+  match (width, count) with
+  | Some Auto, Some Auto -> Some (Auto : Properties.columns_value)
+  | Some Auto, Some (Count n) -> Some (Auto_count n)
+  | Some (Width w), Some Auto -> Some (Width w)
+  | Some (Width w), Some (Count n) -> Some (Both (w, n))
+  | _ -> Option.None
+
+let try_compose_columns_at idx i =
+  let n = Rule_index.length idx in
+  if i + 3 >= n then None
+  else
+    let positions = List.init 4 (fun j -> i + j) in
+    if List.exists (Rule_index.is_absorbed idx) positions then None
+    else
+      let raw = List.map (Rule_index.decl_at idx) positions in
+      let parts = List.filter_map columns_part_of raw in
+      if
+        (not (same_importance raw))
+        || List.length (List.sort_uniq compare parts) <> 4
+        || not (List.for_all columns_initial_tail raw)
+      then None
+      else
+        Option.map
+          (Declaration.v ~important:(is_important (List.hd raw)) Columns)
+          (columns_of_run raw)
+
+let compose_columns_via_index idx =
+  compose_run_via_index idx ~try_compose:(fun idx i ->
+      Option.map (fun d -> (d, 4)) (try_compose_columns_at idx i))
+
 let try_compose_transition_at ~held idx i =
   let parts, len = take_run_at idx ~part_of:transition_part_of i in
   if List.length parts < 2 then None
@@ -5667,6 +5732,7 @@ let compose_index_group_b ~held kept =
   compose_flex_via_index idx;
   compose_text_decoration_via_index ~held idx;
   compose_offset_via_index idx;
+  compose_columns_via_index idx;
   compose_border_via_index idx;
   compose_line_via_index idx;
   List.mapi (fun i d -> (i, d)) (Rule_index.to_list idx)

--- a/test/interop/css-minify-tests/test.ml
+++ b/test/interop/css-minify-tests/test.ml
@@ -478,6 +478,13 @@ let normalize_expected ~category ~id expected =
          it is shorter and equivalent. *)
       fixture ~category ~id ~upstream:"a{transition:color ease}"
         ~cascade:"a{transition:color}" upstream
+  | "shorthands", "0027" ->
+      (* The fixture keeps the explicit [auto] width. CSS Multicol 2 sec. 4.1
+         makes [auto] the width's initial and sec. 4.5 leaves an omitted
+         component there, so the count alone names the same pair and is
+         shorter. *)
+      fixture ~category ~id ~upstream:"a{columns:auto 3}"
+        ~cascade:"a{columns:3}" upstream
   | "shorthands", "0014" ->
       (* The fixture contracts the three longhands into [text-decoration]. CSS
          Text Decoration 4 sec. 2.5 makes the shorthand reset

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1397,6 +1397,11 @@ let shorthand_longhand_order_cases =
     ( "overscroll-behavior",
       ".a{overscroll-behavior:auto;overscroll-behavior-x:contain}",
       ".a{overscroll-behavior:auto;overscroll-behavior-x:contain}" );
+    (* CSS Multicol 2 sec. 4.5: the shorthand resets the height and the wrap, so
+       synthesising it over a rule that writes either would drop it. *)
+    ( "columns",
+      ".a{column-height:5em;column-width:10em;column-count:2}",
+      ".a{column-height:5em;column-width:10em;column-count:2}" );
     ( "container",
       ".a{container:a/size;container-type:normal}",
       ".a{container:a/size;container-type:normal}" );

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -975,6 +975,25 @@ let test_offset_composes () =
       ".x{offset-position:normal;offset-path:none;offset-distance:0;offset-rotate:auto}"
     ".x{offset-position:normal;offset-path:none;offset-distance:0;offset-rotate:auto}"
 
+(* CSS Multicol 2 sec. 4.5: [columns] sets the width, the count and the height,
+   and Chrome 146 has it reset [column-wrap] too, so the run naming the same
+   declaration is all four and the shorthand only stands for a height at its
+   [auto] initial. *)
+let test_columns_composes () =
+  sheet_optimizes_to ~into:".x{columns:10em 2}"
+    ".x{column-width:10em;column-count:2;column-height:auto;column-wrap:auto}";
+  sheet_optimizes_to ~into:".x{columns:auto}"
+    ".x{column-width:auto;column-count:auto;column-height:auto;column-wrap:auto}";
+  (* [auto] is the width's initial, so the count alone names the same pair. *)
+  sheet_optimizes_to ~into:".x{columns:3}"
+    ".x{column-width:auto;column-count:3;column-height:auto;column-wrap:auto}";
+  (* The shorthand has no spelling for a height of its own, so that run keeps
+     its longhands. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{column-width:10em;column-count:2;column-height:5em;column-wrap:auto}"
+    ".x{column-width:10em;column-count:2;column-height:5em;column-wrap:auto}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1589,6 +1608,7 @@ let suite =
       Alcotest.test_case "border image full run composes" `Quick
         test_border_image_full_run_composes;
       Alcotest.test_case "offset composes" `Quick test_offset_composes;
+      Alcotest.test_case "columns composes" `Quick test_columns_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
The synthesis read `column-width` and `column-count` only, so a rule that also set `column-height` or `column-wrap` lost it to the shorthand's reset, and a run naming all four never contracted at all. `columns: auto 3` now minifies to `columns: 3`, since `auto` is the width's initial; the interop corpus records a Cascade oracle for shorthands/0027. Follow-up to #938.