### PR TITLE
minify: read an initial background longhand as a filled slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -624,6 +624,10 @@ entry points both moved.
   `column-wrap`, which the shorthand resets. `columns: auto 3` minifies to
   `columns: 3` (#939)
 
+- `--minify` contracts `background` from a run whose untouched longhands are
+  written `initial`, which names the value the shorthand resets each slot to
+  (#940)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -2632,6 +2632,9 @@ let position_of_axes (x : Properties.background_position_axis)
     =
   let axis_length : Properties.background_position_axis -> Values.length option
       = function
+    (* CSS Backgrounds 3 sec. 3.6 starts the position at [0% 0%], so [initial]
+       on an axis names the zero offset. *)
+    | Initial -> Some (Pct 0.)
     | Center -> Some (Pct 50.)
     | Edge Left | Edge Top -> Some Zero
     | Edge Right | Edge Bottom -> Some (Pct 100.)
@@ -4028,8 +4031,8 @@ let background_image_singleton :
   function
   | [ img ] -> (
       match img with
-      | Inherit | Initial | Unset | Revert | Revert_layer | Var _ | List _ ->
-          None
+      | Initial -> Some (None : Properties.background_image)
+      | Inherit | Unset | Revert | Revert_layer | Var _ | List _ -> None
       | _ -> Some img)
   | _ -> None
 
@@ -4039,9 +4042,16 @@ let background_position_singleton :
   | [ pos ] -> Some pos
   | _ -> None
 
+(* CSS Cascade 5 sec. 7.3: [initial] is the property's initial value, which is
+   exactly what the shorthand writes to a slot left out, so a longhand spelled
+   that way fills its slot. [inherit] and [unset] name the parent's value
+   instead and cannot. The initials are CSS Backgrounds 3 sec. 3.1 to 3.10. *)
 let bg_color_part : declaration -> Values.color option = function
   | Declaration { property = Background_color; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Transparent : Values.color)
+      | v -> Some v)
   | _ -> None
 
 let bg_image_part : declaration -> Properties.background_image option = function
@@ -4052,7 +4062,10 @@ let bg_image_part : declaration -> Properties.background_image option = function
 let bg_repeat_part : declaration -> Properties.background_repeat option =
   function
   | Declaration { property = Background_repeat; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Repeat : Properties.background_repeat)
+      | v -> Some v)
   | _ -> None
 
 let bg_position_part : declaration -> Properties.position_value option =
@@ -4064,24 +4077,34 @@ let bg_position_part : declaration -> Properties.position_value option =
 let bg_size_part : declaration -> Properties.background_size option = function
   | Declaration { property = Background_size; value; _ } -> (
       match value with
-      | Inherit | Initial | Unset | Revert | Revert_layer | Var _ -> None
+      | Inherit | Unset | Revert | Revert_layer | Var _ -> None
+      | Initial -> Some (Auto : Properties.background_size)
       | v -> Some v)
   | _ -> None
 
 let bg_attachment_part : declaration -> Properties.background_attachment option
     = function
   | Declaration { property = Background_attachment; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Scroll : Properties.background_attachment)
+      | v -> Some v)
   | _ -> None
 
 let bg_origin_part : declaration -> Properties.background_box option = function
   | Declaration { property = Background_origin; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Padding_box : Properties.background_box)
+      | v -> Some v)
   | _ -> None
 
 let bg_clip_part : declaration -> Properties.background_box option = function
   | Declaration { property = Background_clip; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Border_box : Properties.background_box)
+      | v -> Some v)
   | _ -> None
 
 type bg_part =

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -994,6 +994,23 @@ let test_columns_composes () =
       ".x{column-width:10em;column-count:2;column-height:5em;column-wrap:auto}"
     ".x{column-width:10em;column-count:2;column-height:5em;column-wrap:auto}"
 
+(* CSS Cascade 5 sec. 7.3: [initial] is the property's initial value, which is
+   what [background] writes to a slot left out, so a run whose untouched slots
+   are spelled that way is reset-closed and contracts. *)
+let test_background_initial_slots () =
+  sheet_optimizes_to ~into:".x{background:url(a.png)50%/cover no-repeat}"
+    ".x{background-image:url(a.png);background-position:50%;background-size:cover;background-repeat:no-repeat;background-attachment:initial;background-origin:initial;background-clip:initial;background-color:initial}";
+  (* Every slot at its initial is what [background: none] names, which the
+     printer spells with the position it keeps. *)
+  sheet_optimizes_to ~into:".x{background:0 0}"
+    ".x{background-image:none;background-position-x:initial;background-position-y:initial;background-size:initial;background-repeat:initial;background-attachment:initial;background-origin:initial;background-clip:initial;background-color:initial}";
+  (* [inherit] names the parent's value, not the initial, so it cannot fill a
+     slot the shorthand resets. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{background-image:url(a.png);background-position:50%;background-size:cover;background-repeat:no-repeat;background-attachment:inherit;background-origin:initial;background-clip:initial;background-color:initial}"
+    ".x{background-image:url(a.png);background-position:50%;background-size:cover;background-repeat:no-repeat;background-attachment:inherit;background-origin:initial;background-clip:initial;background-color:initial}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1609,6 +1626,8 @@ let suite =
         test_border_image_full_run_composes;
       Alcotest.test_case "offset composes" `Quick test_offset_composes;
       Alcotest.test_case "columns composes" `Quick test_columns_composes;
+      Alcotest.test_case "background initial slots" `Quick
+        test_background_initial_slots;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
The layer extractors refused every CSS-wide keyword, but `initial` names the property's initial value, which is exactly what the shorthand writes to a slot left out. A run spelled the way the CSSOM reports one was therefore not reset-closed and never contracted, so `--diff=canonical` could not equate `background` with its own expansion. `inherit` and `unset` name the parent's value and still cannot fill a slot. Follow-up to #939.