### PR TITLE
mask: type the CSSOM position axes and read initial slots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -628,6 +628,11 @@ entry points both moved.
   written `initial`, which names the value the shorthand resets each slot to
   (#940)
 
+- `Css.Properties` gains `-webkit-mask-position-x` and `-webkit-mask-position-y`,
+  the spelling the CSSOM reports when it expands `mask`; the pair contracts
+  into `-webkit-mask-position`, and an `initial` mask longhand fills its slot
+  the way a background one does (#941)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1419,6 +1419,10 @@ let read_background_value : type a. a property -> Cursor.t -> declaration option
       Some (v Background_position_x (read_background_position_x t))
   | Background_position_y ->
       Some (v Background_position_y (read_background_position_y t))
+  | Webkit_mask_position_x ->
+      Some (v Webkit_mask_position_x (read_background_position_x t))
+  | Webkit_mask_position_y ->
+      Some (v Webkit_mask_position_y (read_background_position_y t))
   | Background_repeat ->
       Some (v Background_repeat (read_background_repeat_list t))
   | Background_size -> Some (v Background_size (read_background_size_list t))

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -629,6 +629,8 @@ let pp_property : type a. a property Pp.t =
   | Background_position -> Pp.string ctx "background-position"
   | Background_position_x -> Pp.string ctx "background-position-x"
   | Background_position_y -> Pp.string ctx "background-position-y"
+  | Webkit_mask_position_x -> Pp.string ctx "-webkit-mask-position-x"
+  | Webkit_mask_position_y -> Pp.string ctx "-webkit-mask-position-y"
   | Background_repeat -> Pp.string ctx "background-repeat"
   | Background_size -> Pp.string ctx "background-size"
   | Webkit_font_smoothing -> Pp.string ctx "-webkit-font-smoothing"
@@ -1050,9 +1052,10 @@ let property_class : type a. a property -> a property_class = function
   | Background_image | Background_origin | Background_clip
   | Webkit_background_clip | Animation | Aspect_ratio | Overflow_x | Overflow_y
   | Overflow_block | Overflow_inline | Vertical_align | Background_position
-  | Background_position_x | Background_position_y | Background_repeat
-  | Background_size | Webkit_line_clamp | Webkit_box_orient | Moz_orient
-  | Text_overflow | Backdrop_filter | Webkit_backdrop_filter | Webkit_mask_image
+  | Background_position_x | Background_position_y | Webkit_mask_position_x
+  | Webkit_mask_position_y | Background_repeat | Background_size
+  | Webkit_line_clamp | Webkit_box_orient | Moz_orient | Text_overflow
+  | Backdrop_filter | Webkit_backdrop_filter | Webkit_mask_image
   | Webkit_mask_composite | Webkit_mask_source_type | Webkit_mask_size
   | Webkit_mask_position | Webkit_mask_repeat | Webkit_mask_clip
   | Webkit_mask_origin | Mask_image | Mask_composite | Mask_mode | Mask_size
@@ -1528,6 +1531,8 @@ let property_tag : type a. a property -> int = function
   | Background_position -> 401
   | Background_position_x -> 537
   | Background_position_y -> 538
+  | Webkit_mask_position_x -> 546
+  | Webkit_mask_position_y -> 547
   | Background_repeat -> 402
   | Background_size -> 403
   | Webkit_font_smoothing -> 404
@@ -2106,6 +2111,8 @@ let eq_property : type a b. a property -> b property -> (a, b) Type.eq option =
   | Background_position, Background_position -> Some Equal
   | Background_position_x, Background_position_x -> Some Equal
   | Background_position_y, Background_position_y -> Some Equal
+  | Webkit_mask_position_x, Webkit_mask_position_x -> Some Equal
+  | Webkit_mask_position_y, Webkit_mask_position_y -> Some Equal
   | Background_repeat, Background_repeat -> Some Equal
   | Background_size, Background_size -> Some Equal
   | Webkit_font_smoothing, Webkit_font_smoothing -> Some Equal
@@ -2947,6 +2954,8 @@ let read_any_property t =
   | "background-position" -> Prop Background_position
   | "background-position-x" -> Prop Background_position_x
   | "background-position-y" -> Prop Background_position_y
+  | "-webkit-mask-position-x" -> Prop Webkit_mask_position_x
+  | "-webkit-mask-position-y" -> Prop Webkit_mask_position_y
   | "background-repeat" -> Prop Background_repeat
   | "background-size" -> Prop Background_size
   | "border-block" -> Prop Border_block
@@ -4070,6 +4079,7 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Font_family, value -> value
   | (Background_position | Webkit_mask_position | Mask_position), value -> value
   | (Background_position_x | Background_position_y), value -> value
+  | (Webkit_mask_position_x | Webkit_mask_position_y), value -> value
   | (Background_repeat | Webkit_mask_repeat | Mask_repeat), value -> value
   | Webkit_font_smoothing, value -> value
   | Moz_osx_font_smoothing, value -> value
@@ -4343,6 +4353,8 @@ let normalize_property_value : type a.
   | Background_position -> map_preserve normalize_position_value value
   | Background_position_x -> normalize_background_position_axis value
   | Background_position_y -> normalize_background_position_axis value
+  | Webkit_mask_position_x -> normalize_background_position_axis value
+  | Webkit_mask_position_y -> normalize_background_position_axis value
   | Mask_position -> map_preserve normalize_position_value value
   | Webkit_mask_position -> map_preserve normalize_position_value value
   | Text_indent -> normalize_text_indent value
@@ -4922,6 +4934,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Background_position -> pp pp_background_position
   | Background_position_x -> pp pp_background_position_axis
   | Background_position_y -> pp pp_background_position_axis
+  | Webkit_mask_position_x -> pp pp_background_position_axis
+  | Webkit_mask_position_y -> pp pp_background_position_axis
   | Background_repeat -> pp pp_background_repeat
   | Background_size -> pp pp_background_size
   | Moz_osx_font_smoothing -> pp pp_moz_osx_font_smoothing

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -5132,6 +5132,8 @@ type 'a property =
   | Background_position : background_position property
   | Background_position_x : background_position_axis property
   | Background_position_y : background_position_axis property
+  | Webkit_mask_position_x : background_position_axis property
+  | Webkit_mask_position_y : background_position_axis property
   | Background_repeat : background_repeat property
   | Background_size : background_size property
   | Webkit_font_smoothing : webkit_font_smoothing property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -702,7 +702,10 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Mask_image | Webkit_mask_image -> [ key "mask-image" ]
   | Mask_repeat | Webkit_mask_repeat -> [ key "mask-repeat" ]
   | Mask_size | Webkit_mask_size -> [ key "mask-size" ]
-  | Mask_position | Webkit_mask_position -> [ key "mask-position" ]
+  | Mask_position | Webkit_mask_position ->
+      [ key "-webkit-mask-position-x"; key "-webkit-mask-position-y" ]
+  | Webkit_mask_position_x -> [ key "-webkit-mask-position-x" ]
+  | Webkit_mask_position_y -> [ key "-webkit-mask-position-y" ]
   | Mask_origin | Webkit_mask_origin -> [ key "mask-origin" ]
   | Mask_clip | Webkit_mask_clip -> [ key "mask-clip" ]
   | Mask_mode -> [ key "mask-mode" ]
@@ -2611,6 +2614,22 @@ let duo_container idx i =
    axis longhands, [Start] here the x axis. The shorthand carries one position
    per layer, so a single-valued pair is what composes; the four-value edge form
    needs each axis to name its own edge. *)
+let extract_webkit_mask_position_part :
+    declaration ->
+    (axis_side
+    * (Properties.background_position_axis option
+      * Properties.background_position_axis option)
+    * bool)
+    option = function
+  | Declaration { property = Webkit_mask_position_x; value = Var _; _ }
+  | Declaration { property = Webkit_mask_position_y; value = Var _; _ } ->
+      None
+  | Declaration { property = Webkit_mask_position_x; value; important; _ } ->
+      Some (Start, (Some value, Option.None), important)
+  | Declaration { property = Webkit_mask_position_y; value; important; _ } ->
+      Some (End, (Option.None, Some value), important)
+  | _ -> None
+
 let extract_background_position_part :
     declaration ->
     (axis_side
@@ -2656,19 +2675,17 @@ let position_of_axes (x : Properties.background_position_axis)
           Some (Edge_offset_edge_offset (edge_name ex, ox, edge_name ey, oy))
       | _ -> Option.None)
 
-let duo_background_position idx i =
+let duo_position_axes idx property extract i =
   let build ~important ~start ~end_ =
     let x, _ = start and _, y = end_ in
     match (x, y) with
     | Some x, Some y ->
         Option.map
-          (fun p -> Declaration.v ~important Background_position [ p ])
+          (fun p -> Declaration.v ~important property [ p ])
           (position_of_axes x y)
     | _ -> Option.None
   in
-  try_compose_axis_pair_at idx
-    ~foldable:(fun _ -> true)
-    ~extract:extract_background_position_part ~build i
+  try_compose_axis_pair_at idx ~foldable:(fun _ -> true) ~extract ~build i
 
 (* CSS Text 4 sec. 3: [white-space] is a shorthand of [white-space-collapse] and
    [text-wrap-mode], and sec. 3 table 1 gives the four pairs a single keyword
@@ -2830,7 +2847,12 @@ let pair_axes ~ctx idx i =
     (fun () -> duo_animation_range idx i);
     (fun () -> duo_scroll_timeline idx i);
     (fun () -> duo_container idx i);
-    (fun () -> duo_background_position idx i);
+    (fun () ->
+      duo_position_axes idx Background_position extract_background_position_part
+        i);
+    (fun () ->
+      duo_position_axes idx Webkit_mask_position
+        extract_webkit_mask_position_part i);
     (fun () -> duo_white_space idx i);
     (fun () -> duo_text_wrap idx i);
     (fun () -> duo_webkit_text_stroke idx i);
@@ -4226,47 +4248,70 @@ let compose_background_shorthand ~ctx decls =
 let mask_image_part : declaration -> Properties.background_image option =
   function
   | Declaration { property = Mask_image; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (None : Properties.background_image)
+      | v -> Some v)
   | _ -> None
 
 let mask_repeat_part : declaration -> Properties.background_repeat option =
   function
   | Declaration { property = Mask_repeat; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Repeat : Properties.background_repeat)
+      | v -> Some v)
   | _ -> None
 
 let mask_size_part : declaration -> Properties.background_size option = function
   | Declaration { property = Mask_size; value; _ } -> (
       match value with
-      | Inherit | Initial | Unset | Revert | Revert_layer | Var _ -> None
+      | Inherit | Unset | Revert | Revert_layer | Var _ -> None
+      | Initial -> Some (Auto : Properties.background_size)
       | v -> Some v)
   | _ -> None
 
+(* The two spellings share a cascade slot, and the CSSOM reports the prefixed
+   one when it expands [mask], so either fills the position slot. *)
 let mask_position_part : declaration -> Properties.position_value option =
   function
   | Declaration { property = Mask_position; value; _ } ->
+      background_position_singleton value
+  | Declaration { property = Webkit_mask_position; value; _ } ->
       background_position_singleton value
   | _ -> None
 
 let mask_origin_part : declaration -> Properties.mask_box option = function
   | Declaration { property = Mask_origin; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Border_box : Properties.mask_box)
+      | v -> Some v)
   | _ -> None
 
 let mask_clip_part : declaration -> Properties.mask_box option = function
   | Declaration { property = Mask_clip; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Border_box : Properties.mask_box)
+      | v -> Some v)
   | _ -> None
 
 let mask_mode_part : declaration -> Properties.mask_mode option = function
   | Declaration { property = Mask_mode; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Match_source : Properties.mask_mode)
+      | v -> Some v)
   | _ -> None
 
 let mask_composite_part : declaration -> Properties.mask_composite option =
   function
   | Declaration { property = Mask_composite; value; _ } -> (
-      match value with Inherit | Initial | Unset -> None | v -> Some v)
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Add : Properties.mask_composite)
+      | v -> Some v)
   | _ -> None
 
 type mask_part = Properties.mask_layer -> Properties.mask_layer

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2644,6 +2644,8 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Background_position, value -> List.concat_map vars_of_position_value value
   | Background_position_x, value -> vars_of_background_position_axis value
   | Background_position_y, value -> vars_of_background_position_axis value
+  | Webkit_mask_position_x, value -> vars_of_background_position_axis value
+  | Webkit_mask_position_y, value -> vars_of_background_position_axis value
   | Mask_position, value -> List.concat_map vars_of_position_value value
   | Webkit_mask_position, value -> List.concat_map vars_of_position_value value
   (* Remaining typed longhands. *)

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -1011,6 +1011,20 @@ let test_background_initial_slots () =
       ".x{background-image:url(a.png);background-position:50%;background-size:cover;background-repeat:no-repeat;background-attachment:inherit;background-origin:initial;background-clip:initial;background-color:initial}"
     ".x{background-image:url(a.png);background-position:50%;background-size:cover;background-repeat:no-repeat;background-attachment:inherit;background-origin:initial;background-clip:initial;background-color:initial}"
 
+(* The CSSOM reports [-webkit-mask-position-x] and [-webkit-mask-position-y]
+   when it expands [mask], and the two share a cascade slot with
+   [mask-position], so the pair contracts into it. *)
+let test_webkit_mask_position_axes () =
+  sheet_optimizes_to ~into:".x{-webkit-mask-position:50%10px}"
+    ".x{-webkit-mask-position-x:50%;-webkit-mask-position-y:10px}";
+  sheet_optimizes_to ~into:".x{-webkit-mask-position:0 0}"
+    ".x{-webkit-mask-position-x:initial;-webkit-mask-position-y:initial}";
+  (* Mixed importance is not one declaration. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{-webkit-mask-position-x:50%;-webkit-mask-position-y:10px!important}"
+    ".x{-webkit-mask-position-x:50%;-webkit-mask-position-y:10px!important}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1628,6 +1642,8 @@ let suite =
       Alcotest.test_case "columns composes" `Quick test_columns_composes;
       Alcotest.test_case "background initial slots" `Quick
         test_background_initial_slots;
+      Alcotest.test_case "webkit mask position axes" `Quick
+        test_webkit_mask_position_axes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
`-webkit-mask-position-x` and `-webkit-mask-position-y` are what the CSSOM reports when it expands `mask`, but both parsed as unknown declarations, and the layer extractors refused `initial` even though it names the value the shorthand resets each slot to. The pair now contracts into `-webkit-mask-position`, which shares a cascade slot with `mask-position`.

This does not yet close the `mask` family in the browser differential: the vendor-alias pass inserts prefixed twins into the run before the layer composer sees it, so the run is no longer contiguous. That ordering is a separate fix. Follow-up to #940.