### PR TITLE
minify: contract a complete mask run in any scope

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -633,6 +633,10 @@ entry points both moved.
   into `-webkit-mask-position`, and an `initial` mask longhand fills its slot
   the way a background one does (#941)
 
+- `--minify` contracts `mask` from a run naming all eight of its layer
+  longhands whatever the scope, where it used to need `--scope=stylesheet`,
+  and drops a component of the shorthand that names its own initial (#942)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -160,13 +160,45 @@ let rec normalize_clip_path : clip_path -> clip_path =
       if shape == r.shape then value else Clip_path_with_box { r with shape }
   | other -> other
 
+(* CSS Masking 1 sec. 7.9: a component the shorthand leaves out takes its
+   longhand's initial - [none] for the image (sec. 7.1), [0% 0%] for the
+   position (sec. 7.4), [auto] for the size (sec. 7.5), [repeat] for the repeat
+   (sec. 7.3), [border-box] for the origin and the clip (sec. 7.6 and 7.7),
+   [match-source] for the mode (sec. 7.2) and [add] for the composite (sec. 7.8)
+   - so writing one out names what leaving it out names. *)
+let drop_mask_initial : 'a. 'a -> 'a option -> 'a option =
+ fun initial opt ->
+  match opt with Some x when x = initial -> (None : _ option) | _ -> opt
+
+let mask_layer_slots_shared (a : mask_layer) (b : mask_layer) =
+  a.image == b.image && a.position == b.position && a.size == b.size
+  && a.repeat == b.repeat && a.origin == b.origin && a.clip == b.clip
+  && a.mode == b.mode && a.composite == b.composite
+
 let normalize_mask_layer ?(lossless = false) (l : mask_layer) =
   let image =
-    option_map_preserve (normalize_background_image ~lossless) l.image
+    option_map_preserve
+      (normalize_background_image ~lossless)
+      (drop_mask_initial (None : background_image) l.image)
   in
   let position = option_map_preserve normalize_position_value l.position in
-  if image == l.image && position == l.position then l
-  else { l with image; position }
+  let size = drop_mask_initial (Auto : background_size) l.size in
+  (* The size follows the position and a [/], so the position can only go once
+     the size has. *)
+  let position =
+    match position with
+    | Some p when Option.is_none size && p = (XY (Zero, Zero) : position_value)
+      ->
+        (None : position_value option)
+    | _ -> position
+  in
+  let repeat = drop_mask_initial (Repeat : background_repeat) l.repeat in
+  let origin = drop_mask_initial (Border_box : mask_box) l.origin in
+  let clip = drop_mask_initial (Border_box : mask_box) l.clip in
+  let mode = drop_mask_initial (Match_source : mask_mode) l.mode in
+  let composite = drop_mask_initial (Add : mask_composite) l.composite in
+  let l' = { image; position; size; repeat; origin; clip; mode; composite } in
+  if mask_layer_slots_shared l l' then l else l'
 
 let normalize_mask ?(lossless = false) : mask -> mask =
  fun value ->

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -4245,9 +4245,18 @@ let compose_background_shorthand ~ctx decls =
    (the reorder / dead-drop cases are handled separately). Closed-world
    ([`Stylesheet]) only, since the shorthand resets the layer fields the run
    leaves unset. *)
+(* The optimizer writes a [-webkit-] twin beside each mask longhand for old
+   Safari, so a run reaching the composer carries both spellings of a slot.
+   They name one cascade slot and carry one value, so either fills it and the
+   run stays contiguous. *)
 let mask_image_part : declaration -> Properties.background_image option =
   function
   | Declaration { property = Mask_image; value; _ } -> (
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (None : Properties.background_image)
+      | v -> Some v)
+  | Declaration { property = Webkit_mask_image; value; _ } -> (
       match value with
       | Inherit | Unset -> None
       | Initial -> Some (None : Properties.background_image)
@@ -4261,10 +4270,20 @@ let mask_repeat_part : declaration -> Properties.background_repeat option =
       | Inherit | Unset -> None
       | Initial -> Some (Repeat : Properties.background_repeat)
       | v -> Some v)
+  | Declaration { property = Webkit_mask_repeat; value; _ } -> (
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Repeat : Properties.background_repeat)
+      | v -> Some v)
   | _ -> None
 
 let mask_size_part : declaration -> Properties.background_size option = function
   | Declaration { property = Mask_size; value; _ } -> (
+      match value with
+      | Inherit | Unset | Revert | Revert_layer | Var _ -> None
+      | Initial -> Some (Auto : Properties.background_size)
+      | v -> Some v)
+  | Declaration { property = Webkit_mask_size; value; _ } -> (
       match value with
       | Inherit | Unset | Revert | Revert_layer | Var _ -> None
       | Initial -> Some (Auto : Properties.background_size)
@@ -4287,10 +4306,20 @@ let mask_origin_part : declaration -> Properties.mask_box option = function
       | Inherit | Unset -> None
       | Initial -> Some (Border_box : Properties.mask_box)
       | v -> Some v)
+  | Declaration { property = Webkit_mask_origin; value; _ } -> (
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Border_box : Properties.mask_box)
+      | v -> Some v)
   | _ -> None
 
 let mask_clip_part : declaration -> Properties.mask_box option = function
   | Declaration { property = Mask_clip; value; _ } -> (
+      match value with
+      | Inherit | Unset -> None
+      | Initial -> Some (Border_box : Properties.mask_box)
+      | v -> Some v)
+  | Declaration { property = Webkit_mask_clip; value; _ } -> (
       match value with
       | Inherit | Unset -> None
       | Initial -> Some (Border_box : Properties.mask_box)
@@ -4351,19 +4380,36 @@ let empty_mask_layer : Properties.mask_layer =
     composite = None;
   }
 
+(* Same reading as [background]: the layer shorthand resets every slot, so a run
+   naming all eight is the same declaration whatever else the sheet holds. A
+   shorter run leaves the rest to the reset, which only the whole-sheet scope
+   can judge. *)
+let mask_run_is_reset_closed (layer : Properties.mask_layer) =
+  Option.is_some layer.image
+  && Option.is_some layer.position
+  && Option.is_some layer.size
+  && Option.is_some layer.repeat
+  && Option.is_some layer.origin
+  && Option.is_some layer.clip && Option.is_some layer.mode
+  && Option.is_some layer.composite
+
 let try_compose_mask_at ~ctx idx i =
   let parts, len = take_run_at idx ~part_of:mask_part_of i in
   if List.length parts < 2 then None
   else
     let raw_decls = List.map fst parts in
     if not (same_importance raw_decls) then None
-    else if scope ctx <> `Stylesheet then None
-    else if has_prior_family_longhand mask_part_of idx i then None
     else
       let layer =
         List.fold_left (fun acc (_, f) -> f acc) empty_mask_layer parts
       in
-      if layer.image = None then None
+      let permit =
+        match scope ctx with
+        | `Stylesheet -> not (has_prior_family_longhand mask_part_of idx i)
+        | `Fragment -> mask_run_is_reset_closed layer
+      in
+      if not permit then None
+      else if layer.image = None then None
       else
         let shorthand =
           Declaration.v

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -3351,7 +3351,9 @@ let target_evergreen_compatibility_prefixes () =
     (optimized_string ".a{mask:none}");
   Alcotest.(check string)
     "the WebKit mask shorthand omits fields with different legacy grammars"
-    ".a{-webkit-mask:url(a.svg);mask:url(a.svg)luminance add}"
+    (* [add] is the composite's initial (CSS Masking 1 sec. 7.8), which is what
+       leaving the component out names, so the shorthand drops it. *)
+    ".a{-webkit-mask:url(a.svg);mask:url(a.svg)luminance}"
     (optimized_string ".a{mask:url(a.svg) luminance add}");
   Alcotest.(check string)
     "mask fields without equivalent WebKit grammars are not prefixed"

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -1025,6 +1025,21 @@ let test_webkit_mask_position_axes () =
       ".x{-webkit-mask-position-x:50%;-webkit-mask-position-y:10px!important}"
     ".x{-webkit-mask-position-x:50%;-webkit-mask-position-y:10px!important}"
 
+(* CSS Masking 1 sec. 7.9: [mask] resets all eight layer longhands, so a run
+   naming every one of them is the same declaration whatever else the sheet
+   holds, and a component at its initial is what leaving it out names. *)
+let test_mask_full_run_composes () =
+  sheet_optimizes_to
+    ~into:
+      ".x{-webkit-mask:url(a.png)50%/cover no-repeat;mask:url(a.png)50%/cover \
+       no-repeat}"
+    ".x{mask-image:url(a.png);mask-position:50%;mask-size:cover;mask-repeat:no-repeat;mask-origin:border-box;mask-clip:border-box;mask-composite:add;mask-mode:match-source}";
+  (* A run missing a longhand would have the shorthand reset it. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{-webkit-mask-image:url(a.png);mask-image:url(a.png);-webkit-mask-size:cover;mask-size:cover}"
+    ".x{mask-image:url(a.png);mask-size:cover}"
+
 (* CSS Animations 2 sec. 4.11: [animation] resets every longhand it names,
    [animation-name] included, so contracting a run that has no name beside a
    name written earlier says [none] and animates nothing. The transition family
@@ -1644,6 +1659,8 @@ let suite =
         test_background_initial_slots;
       Alcotest.test_case "webkit mask position axes" `Quick
         test_webkit_mask_position_axes;
+      Alcotest.test_case "mask full run composes" `Quick
+        test_mask_full_run_composes;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
The layer composition was gated on `--scope=stylesheet` because a partial run leaves the longhands it omits to the shorthand's reset. A run naming all eight carries no such risk, so it now contracts by default, the way #935 opened up `border-image`. Two things had to come with it: the run carries a `-webkit-` twin beside each longhand, which the optimizer writes for old Safari and which names the same slot, and the shorthand kept components spelling out their own initial. Follow-up to #941.