### PR TITLE
resolve: match an attribute selector as HTML does

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -641,6 +641,13 @@ entry points both moved.
   `border-image` longhand in reach holds a value: the shorthand resets that
   whole family, so the contraction dropped it (#943)
 
+- `Css.Resolve` matches an attribute selector the way an HTML document does:
+  the name part folds to ASCII lowercase, the values of the attributes HTML
+  lists fold without needing an `i` flag, and `~=` splits its list on any
+  ASCII whitespace rather than on spaces alone. `cascade apply` and
+  `cascade prune` used to read `[TITLE=x]` and `[type=TEXT]` as matching
+  nothing (#944)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -39,7 +39,18 @@ let negate = function
   | Unsupported -> Unsupported
 
 let ci a b = String.lowercase_ascii a = String.lowercase_ascii b
-let words s = String.split_on_char ' ' s |> List.filter (( <> ) "")
+
+(* selectors-4 sec. 6.1 reads [~=] over "a list of whitespace-separated values",
+   and css-syntax-3 sec. 4.2 counts newline, tab and space as whitespace, a
+   newline being any of line feed, carriage return and form feed. *)
+let is_ascii_ws = function
+  | ' ' | '\t' | '\n' | '\r' | '\012' -> true
+  | _ -> false
+
+let words s =
+  String.split_on_char ' '
+    (String.map (fun c -> if is_ascii_ws c then ' ' else c) s)
+  |> List.filter (( <> ) "")
 
 let contains hay needle =
   let lh = String.length hay and ln = String.length needle in
@@ -59,10 +70,28 @@ let ends s p =
   let ls = String.length s and lp = String.length p in
   ls >= lp && String.sub s (ls - lp) lp = p
 
+(* HTML sec. 4.16.2: "the name part of the CSS attribute selector must first be
+   converted to ASCII lowercase" before it is compared to an attribute name on
+   an HTML element. *)
 let attr_key : Selector.attr_name -> string = function
-  | Selector.Regular s -> s
-  | Selector.Data s -> "data-" ^ s
-  | Selector.Aria a -> Aria.to_string a
+  | Selector.Regular s -> String.lowercase_ascii s
+  | Selector.Data s -> String.lowercase_ascii ("data-" ^ s)
+  | Selector.Aria a -> String.lowercase_ascii (Aria.to_string a)
+
+(* The same section lists the attributes whose VALUE an HTML document compares
+   ASCII case-insensitively however the selector is written. Engines apply it,
+   so it belongs to the browser reading; selectors-4 alone leaves the answer to
+   the document language, which a {!NODE} does not carry. *)
+let html_case_insensitive_value = function
+  | "accept" | "accept-charset" | "align" | "alink" | "axis" | "bgcolor"
+  | "charset" | "checked" | "clear" | "codetype" | "color" | "compact"
+  | "declare" | "defer" | "dir" | "direction" | "disabled" | "enctype" | "face"
+  | "frame" | "hreflang" | "http-equiv" | "lang" | "language" | "link" | "media"
+  | "method" | "multiple" | "nohref" | "noresize" | "noshade" | "nowrap"
+  | "readonly" | "rel" | "rev" | "rules" | "scope" | "scrolling" | "selected"
+  | "shape" | "target" | "text" | "type" | "valign" | "valuetype" | "vlink" ->
+      true
+  | _ -> false
 
 (* The An+B microsyntax (css-syntax-3 sec. 6), where [odd] is [2n+1] and [even]
    is [2n]. It "represents any index i = An + B for any non-negative integer n"
@@ -258,9 +287,14 @@ module Make (N : NODE) = struct
      read as written - the answer [s] gives. Folding is ASCII-only, which is why
      the spec has [green] match [GREEN] but not the umlauted [grun] match its
      own upper case. *)
-  let attr_fold : Selector.attr_flag option -> string -> string = function
+  let attr_fold ~reading name : Selector.attr_flag option -> string -> string =
+    function
     | Some Selector.Insensitive -> String.lowercase_ascii
-    | None | Some Selector.Sensitive -> Fun.id
+    | Some Selector.Sensitive -> Fun.id
+    | None ->
+        if is_browser reading && html_case_insensitive_value (attr_key name)
+        then String.lowercase_ascii
+        else Fun.id
 
   let attr_matches ~fold n name (m : Selector.attribute_match) =
     match N.attribute n (attr_key name) with
@@ -405,7 +439,7 @@ module Make (N : NODE) = struct
       when is_browser reading ->
         Unsupported
     | Selector.Attribute (None, name, m, flag) ->
-        of_bool (attr_matches ~fold:(attr_fold flag) n name m)
+        of_bool (attr_matches ~fold:(attr_fold ~reading name flag) n name m)
     | Selector.Compound ps ->
         List.fold_left
           (fun acc p -> conj acc (match_selector ~reading p n))

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -508,7 +508,16 @@ let test_attribute_case_flags () =
   (* sec. 6.3's own example: [frame=hsides i] styles the attribute "whether that
      value is represented as hsides, HSIDES, hSides, etc." *)
   yes "i folds the case" "[frame=hsides i]" framed;
-  no "without a flag the value is read as written" "[frame=hsides]" framed;
+  (* HTML sec. 4.16.2 lists [frame] among the attributes an HTML document
+     compares ASCII case-insensitively however the selector is written, and the
+     engines apply it, so the browser reading folds without a flag. *)
+  yes "an HTML-folded name folds without a flag" "[frame=hsides]" framed;
+  no ~reading:Resolve.Spec "the specification alone reads it as written"
+    "[frame=hsides]" framed;
+  (* [data-k] is not on that list, so its value is read as written. *)
+  no "a name off the list is read as written" "[data-k=\"gr\u{00dc}n\"]" framed;
+  (* The name part is converted to ASCII lowercase before it is compared. *)
+  yes "the name folds" "[FRAME=hsides]" framed;
   no ~reading:Resolve.Spec "s is identical-to" "[frame=hsides s]" framed;
   yes ~reading:Resolve.Spec "and the written value is identical to itself"
     "[frame=HSIDES s]" framed;


### PR DESCRIPTION
HTML sec. 4.16.2 converts the name part of a CSS attribute selector to ASCII lowercase before comparing it, and compares the values of 46 named attributes ASCII case-insensitively however the selector is written. `Css.Resolve` did neither, so `[TITLE=x]` and `[type=TEXT]` matched nothing and `cascade apply` dropped the declaration. Selectors 4 sec. 6.1 also reads `~=` over a whitespace-separated list, which was split on spaces alone.

Both belong to the browser reading; `~reading:Spec` keeps the language-agnostic answer, since a `NODE` carries no document language. The browser differential goes from 232 selectors / 821 pairs with a wrong match set to 3 / 20; what remains is two undecoded-escape cases and `:nth-child(0)`. Follow-up to #943.