### PR TITLE
resolve: decode the escapes in an unquoted attribute value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -646,7 +646,7 @@ entry points both moved.
   lists fold without needing an `i` flag, and `~=` splits its list on any
   ASCII whitespace rather than on spaces alone. `cascade apply` and
   `cascade prune` used to read `[TITLE=x]` and `[type=TEXT]` as matching
-  nothing (#944)
+  nothing (#944, #945)
 
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already

--- a/lib/resolve.ml
+++ b/lib/resolve.ml
@@ -301,20 +301,27 @@ module Make (N : NODE) = struct
     | None -> false
     | Some v -> (
         let v = fold v in
+        (* An unquoted value keeps the escapes it was written with so the
+           printer round-trips them, so the characters it stands for are what
+           the comparison wants. A quoted one is decoded already. *)
+        let raw s = fold (Selector.unescape_attribute_value s) in
+        let quoted s = fold s in
+        let hyphen s = v = s || starts v (String.concat "" [ s; "-" ]) in
         match m with
         | Selector.Presence -> true
-        | Selector.Exact s | Selector.Exact_quoted (s, _) -> v = fold s
-        | Selector.Whitespace_list s | Selector.Whitespace_list_quoted (s, _) ->
-            List.mem (fold s) (words v)
-        | Selector.Prefix s | Selector.Prefix_quoted (s, _) ->
-            s <> "" && starts v (fold s)
-        | Selector.Suffix s | Selector.Suffix_quoted (s, _) ->
-            s <> "" && ends v (fold s)
-        | Selector.Substring s | Selector.Substring_quoted (s, _) ->
-            s <> "" && contains v (fold s)
-        | Selector.Hyphen_list s | Selector.Hyphen_list_quoted (s, _) ->
-            let s = fold s in
-            v = s || starts v (String.concat "" [ s; "-" ]))
+        | Selector.Exact s -> v = raw s
+        | Selector.Exact_quoted (s, _) -> v = quoted s
+        | Selector.Whitespace_list s -> List.mem (raw s) (words v)
+        | Selector.Whitespace_list_quoted (s, _) ->
+            List.mem (quoted s) (words v)
+        | Selector.Prefix s -> s <> "" && starts v (raw s)
+        | Selector.Prefix_quoted (s, _) -> s <> "" && starts v (quoted s)
+        | Selector.Suffix s -> s <> "" && ends v (raw s)
+        | Selector.Suffix_quoted (s, _) -> s <> "" && ends v (quoted s)
+        | Selector.Substring s -> s <> "" && contains v (raw s)
+        | Selector.Substring_quoted (s, _) -> s <> "" && contains v (quoted s)
+        | Selector.Hyphen_list s -> hyphen (raw s)
+        | Selector.Hyphen_list_quoted (s, _) -> hyphen (quoted s))
 
   (* selectors-4 sec. 13.3: the child-indexed pseudo-classes read an element's
      "relative index amongst its siblings", counting the inclusive ones, since

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -407,6 +407,7 @@ let list selectors =
   | [] -> invalid_arg "CSS selector list cannot be empty"
   | _ -> List selectors
 
+let unescape_attribute_value = unescape_selector_name
 let is_compound_list = function List _ -> true | _ -> false
 let as_list = function List sels -> Some sels | _ -> None
 let compound selectors = Compound selectors

--- a/lib/selector.mli
+++ b/lib/selector.mli
@@ -13,6 +13,12 @@ val element : ?ns:ns -> string -> t
 (** [element ?ns name] element selector (e.g., "div"). Validates CSS
     identifiers; raises [Invalid_argument] on invalid. *)
 
+val unescape_attribute_value : string -> string
+(** [unescape_attribute_value v] is [v] with its CSS escapes decoded. An
+    unquoted attribute value keeps the escapes it was written with so the
+    printer round-trips them, and a matcher compares against the characters they
+    stand for. *)
+
 val class_ : string -> t
 (** [class_ name] class selector from raw (unescaped) string. Accepts any
     serializable characters including special chars that will be escaped during

--- a/test/test_resolve.ml
+++ b/test/test_resolve.ml
@@ -534,6 +534,10 @@ let test_attribute_case_flags () =
   no ~reading:Resolve.Spec "the other way round" "[type=\"a\" s]" type_upper;
   yes ~reading:Resolve.Spec "and back" "[type=\"A\" s]" type_upper;
   yes "i puts them together" "[type=\"a\" i]" type_lower;
+  (* An unquoted value keeps the escapes it was written with so the printer
+     round-trips them; the match reads the characters they stand for. *)
+  yes "an escaped unquoted value decodes" "[frame=\\48 SIDES]" framed;
+  yes "an escaped punctuation decodes" "[lang=EN\\-GB]" framed;
   yes "both ways" "[type=\"a\" i]" type_upper
 
 (* selectors-4 sec. 8.4: ":scope represents this scoping root", and "if there is


### PR DESCRIPTION
An unquoted attribute value keeps the escapes it was written with so the printer round-trips them, but the matcher compared that text rather than the characters it stands for, so `[title=\\68 ello]` matched nothing. A quoted value is decoded when it is read and is compared as it was. The browser differential goes from 3 selectors with a wrong match set to 1, which is `:nth-child(0)`. Follow-up to #944.