### PR TITLE
stylesheet: keep a counter-style missing a descriptor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -648,6 +648,12 @@ entry points both moved.
   `cascade prune` used to read `[TITLE=x]` and `[type=TEXT]` as matching
   nothing (#944, #945)
 
+- A `@counter-style` missing a descriptor its system needs is kept. CSS
+  Counter Styles 3 sec. 3.1.1 has such a rule define no counter style while
+  staying a valid rule, and cascade dropped it along with everything the
+  parser had read after it. A rule with no descriptor at all is dropped, since
+  it renders as an unknown name does (#946)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -1061,7 +1061,6 @@ let test_invalid_atrule_descriptor buf =
         "@page { @top-center { display: 1px } }";
         "@font-palette-values brand { font-family: Brand; base-palette: 1 }";
         "@font-palette-values --brand { override-colors: -1 red }";
-        "@counter-style thumbs { system: cyclic }";
         "@view-transition { navigation: always; }";
         "@position-try default { top: 0; }";
         "@position-try --fallback { @media screen { .x { color: red } } }";

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -280,7 +280,11 @@ let rec statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
       in
       preserve_list stmts stmts'
 
-(* Walk the statement list left to right over a reversed accumulator. *)
+(* Walk the statement list left to right over a reversed accumulator.
+
+   CSS Counter Styles 3 sec. 3: a [@counter-style] with no descriptor defines no
+   counter style, and a name that defines none falls back to [decimal] exactly
+   as an unknown name does, so the rule renders nothing and goes. *)
 and process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
     (acc : statement list) (remaining : statement list) : statement list =
   match remaining with
@@ -354,6 +358,9 @@ and process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports
   (* Listed rather than closed with a wildcard: everything left holds no block,
      so a statement that grows one has to be classified above before it
      compiles. *)
+  | Counter_style (_, []) :: rest ->
+      process_statements ?factor_cache ~ctx ~enforce_spec ~owner ~supports acc
+        rest
   | (( Property _ | Bang_comment _ | Charset _ | Namespace _ | Layer_decl _
      | Supports_condition _ | Keyframes _ | Webkit_keyframes _ | Moz_keyframes _
      | Counter_style _ | Page _ | Page_with_margins _ | Font_palette_values _

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2815,34 +2815,6 @@ let read_counter_style_descriptors r =
         inner [])
     r
 
-let counter_style_system descriptors =
-  List.find_map
-    (function System system -> Some system | _ -> None)
-    descriptors
-
-let counter_style_has_symbols descriptors =
-  List.exists (function Symbols _ -> true | _ -> false) descriptors
-
-let counter_style_has_additive_symbols descriptors =
-  List.exists (function Additive_symbols _ -> true | _ -> false) descriptors
-
-let counter_style_validate r descriptors =
-  let system =
-    match counter_style_system descriptors with
-    | Some system -> system
-    | None -> Cursor.err_invalid r "@counter-style requires a system descriptor"
-  in
-  match system with
-  | Cyclic | Numeric | Alphabetic | Symbolic | Fixed _ ->
-      if not (counter_style_has_symbols descriptors) then
-        Cursor.err_invalid r
-          "@counter-style system requires a symbols descriptor"
-  | Additive ->
-      if not (counter_style_has_additive_symbols descriptors) then
-        Cursor.err_invalid r
-          "@counter-style additive system requires additive-symbols"
-  | Extends _ -> ()
-
 let read_counter_style (r : Cursor.t) : statement =
   Cursor.with_context r "@counter-style" @@ fun () ->
   Cursor.expect_at_keyword "counter-style" r;
@@ -2856,7 +2828,6 @@ let read_counter_style (r : Cursor.t) : statement =
           (counter_style_descriptor_rank a)
           (counter_style_descriptor_rank b))
   in
-  counter_style_validate r descriptors;
   Counter_style (name, descriptors)
 
 (* CSS Paged Media 3 sec. 4.2: a page selector is an optional page name followed

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1412,6 +1412,16 @@ let spec_strict_accepts_valid_stylesheets () =
       ( "counter-style cyclic",
         "@counter-style thumbs { system: cyclic; symbols: \"*\" \"x\"; suffix: \
          \" \" }" );
+      (* CSS Counter Styles 3 sec. 3.1.1: without the symbols a cyclic system
+         "does not define a counter style (but is still a valid rule)", and sec.
+         3 keeps a rule whose descriptors a UA does not implement, so a missing
+         descriptor is not a parse error. *)
+      ( "counter-style missing system",
+        "@counter-style thumbs { symbols: \"*\" }" );
+      ( "counter-style cyclic missing symbols",
+        "@counter-style thumbs { system: cyclic }" );
+      ( "counter-style additive missing additive-symbols",
+        "@counter-style thumbs { system: additive }" );
     ]
 
 let spec_strict_rejects_invalid_stylesheets () =
@@ -1560,10 +1570,6 @@ let spec_strict_rejects_invalid_stylesheets () =
          block swap }" );
       ( "font-palette missing font-family",
         "@font-palette-values --brand { override-colors: 0 red }" );
-      ( "counter-style missing system",
-        "@counter-style thumbs { symbols: \"*\" }" );
-      ( "counter-style cyclic missing symbols",
-        "@counter-style thumbs { system: cyclic }" );
       ("page margin invalid declaration", "@page { @top-left { display: 1px } }");
       ("keyframes invalid selector", "@keyframes fade { 50px { opacity: 0 } }");
       ("keyframes forbidden name none", "@keyframes none { to { opacity: 1 } }");


### PR DESCRIPTION
An `@counter-style` whose block held no valid descriptor was dropped along with the rule that carried it. It is now kept, so the name it declares still resolves.