### PR TITLE
stylesheet: replace an invalid media query with not all

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -654,6 +654,12 @@ entry points both moved.
   parser had read after it. A rule with no descriptor at all is dropped, since
   it renders as an unknown name does (#946)
 
+- An `@media` whose query does not match the grammar keeps its rule and its
+  contents, matching nothing. Media Queries 5 sec. 3.2 replaces such a query
+  with `not all`, and cascade dropped the rule and everything inside it. The
+  query is still reported as a warning, and `~strict:true` still refuses the
+  stylesheet (#947)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3595,11 +3595,18 @@ let read_supports_condition (r : Cursor.t) : statement =
 
 let read_layer_name (r : Cursor.t) : layer_name = read_layer_name_component r
 
+(* Media Queries 5 sec. 3.2: "A media query that does not match the grammar
+   [...] must be replaced by not all during parsing", so a prelude the reader
+   refuses leaves the rule standing and matching nothing rather than taking the
+   rule and its contents with it. The query is still lost, so it is reported:
+   the recovery is {!Error.Recovery.Recovered}, the rule surviving. *)
 let read_nested_media_condition t =
   if Cursor.is_done t then Media.List []
   else
     try Media.read ~recover:false t
-    with Error.Parse_error _ -> Media.of_string "not all"
+    with Error.Parse_error e when Cursor.recover t ->
+      Cursor.push_warning t ~recovery:Error.Recovery.Recovered e;
+      Media.of_string "not all"
 
 let read_rule_selector ?(nested = false) r =
   let prelude = Cursor.drain_until_block r in
@@ -3933,10 +3940,10 @@ and read_media (r : Cursor.t) : statement =
   let condition_components = Cursor.drain_until_block r in
   let query = Cursor.sub r condition_components in
   let content = Cursor.braces (fun inner -> read_block inner) r in
-  let condition =
-    if Cursor.is_done query then Media.List []
-    else Media.read ~recover:false query
-  in
+  let condition = read_nested_media_condition query in
+  List.iter
+    (fun w -> Cursor.push_warning r ~recovery:Error.Recovery.Recovered w)
+    (Cursor.drain_warnings query);
   Media (condition, content)
 
 and read_supports (r : Cursor.t) : statement =

--- a/test/cli/diff_unreadable_rule.t
+++ b/test/cli/diff_unreadable_rule.t
@@ -79,11 +79,10 @@ comparison never saw, so that verdict stays unproven.
   Cannot determine whether the CSS files are identical
   [2]
 
-An at-rule condition the grammar refuses loses more: the at-rule goes and
-every rule nested inside it goes with it. Both sides report the failure at
-the same offsets over the same snippet, because the offset marks where the
-condition gave up rather than what the reader threw away. The rules thrown
-away differ, and the verdict follows those.
+A media condition the grammar refuses loses nothing: Media Queries 5 sec. 3.2
+replaces it with `not all`, so both sides keep the block and the comparison
+reaches the rules inside it. The condition is still reported as a warning, on
+both sides, at the offset where it gave up.
 
   $ cat > media-a.css <<EOF
   > .b{color:red}
@@ -94,12 +93,41 @@ away differ, and the verdict follows those.
   > @media ^^^{.x{color:blue}}
   > EOF
   $ cascade diff --diff=canonical media-a.css media-b.css
+  CSS: 40 chars vs 41 chars (2.5% diff)
+  Changes: 1 changed container
+  
   media-a.css and media-b.css parse warning: <string>: bad condition for @media: expected media type or condition at [21-22] (in at-rule)
   .b{color:red}
   @media ^^^{.x{color:red}}
          ^
   
-  Unreadable rules: media-a.css 1, media-b.css 1
+  --- media-a.css
+  +++ media-b.css
+  └─ @media not all (1 modified)
+     └─ .x
+           * color: red -> #00f
+  
+  [1]
+
+An at-rule condition with no such rule behind it does lose the block, and
+every rule nested inside it goes with it. The rules thrown away differ, and
+the verdict follows those.
+
+  $ cat > sup-a.css <<EOF
+  > .b{color:red}
+  > @supports ^^^{.x{color:red}}
+  > EOF
+  $ cat > sup-b.css <<EOF
+  > .b{color:red}
+  > @supports ^^^{.x{color:blue}}
+  > EOF
+  $ cascade diff --diff=canonical sup-a.css sup-b.css
+  sup-a.css and sup-b.css parse warning: <string>: bad condition for @supports: Expected supports feature at [24-25] (in at-rule)
+  .b{color:red}
+  @supports ^^^{.x{color:red}}
+            ^
+  
+  Unreadable rules: sup-a.css 1, sup-b.css 1
   Cannot determine whether the CSS files are identical
   [2]
 

--- a/test/cli/fmt_parse_failure.t
+++ b/test/cli/fmt_parse_failure.t
@@ -72,8 +72,9 @@ that carried it, and the rules either side are written.
   $ cascade fmt --minify bad-selector.css 2> /dev/null
   .ok{color:red}.ok2{color:green}
 
-An at-rule prelude it cannot read is the same shape: the block goes, its
-neighbours stay.
+A media query it cannot read is not the same shape. Media Queries 5 sec. 3.2
+replaces such a query with `not all`, so the block stays, matches nothing, and
+its neighbours are untouched either way.
 
   $ cat > bad-prelude.css <<EOF
   > .ok { color: red }
@@ -81,6 +82,16 @@ neighbours stay.
   > .ok2 { color: green }
   > EOF
   $ cascade fmt --minify bad-prelude.css 2> /dev/null
+  .ok{color:red}@media not all{.x{color:#00f}}.ok2{color:green}
+
+A prelude with no such rule behind it does go, and its neighbours stay.
+
+  $ cat > bad-at-rule.css <<EOF
+  > .ok { color: red }
+  > @supports ^^^ { .x { color: blue } }
+  > .ok2 { color: green }
+  > EOF
+  $ cascade fmt --minify bad-at-rule.css 2> /dev/null
   .ok{color:red}.ok2{color:green}
 
 An input with no rules to begin with is legitimately empty: nothing was

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1926,10 +1926,14 @@ let spec_lenient_recovery_block_statements () =
     "@supports (color: red) { @supports (display: grid) bogus { a { color: red \
      } } b { color: blue } }"
     "@supports(color:red){b{color:#00f}}" 1;
-  lenient_recover "bad @media prelude in @media ends at its block"
+  (* Media Queries 5 sec. 3.2 replaces a query that does not match the grammar
+     with [not all] rather than dropping the rule, so the rule and its contents
+     survive and match nothing. [@supports] and [@container] above still drop:
+     their own specifications are read separately. *)
+  lenient_recover "bad @media prelude in @media is replaced by not all"
     "@media screen { @media (min-width: 1px) and { a { color: red } } b { \
      color: blue } }"
-    "@media screen{b{color:#00f}}" 1;
+    "@media screen{@media not all{a{color:red}}b{color:#00f}}" 1;
   lenient_recover "bad @container prelude in @media ends at its block"
     "@media screen { @container (min-width: 1px) !! { a { color: red } } b { \
      color: blue } }"


### PR DESCRIPTION
A bad `@media` condition took the whole block with it. CSS Conditional 3 sec. 2.1 replaces such a query with `not all`, so the block is now kept, never applies, and the lost condition is reported as a warning.