### PR TITLE
stylesheet: recover from a nameless font-face descriptor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -660,6 +660,11 @@ entry points both moved.
   query is still reported as a warning, and `~strict:true` still refuses the
   stylesheet (#947)
 
+- A `@font-face` descriptor with no name is dropped and the rule kept, as an
+  unknown name and an invalid value already were. The name was read outside
+  the recovery, so `@font-face { font-family: f; : url(a.woff2) }` took the
+  rule and everything the parser had read after it (#948)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2641,8 +2641,11 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
         None
     | _ -> (
         let start = Cursor.save r in
-        let name = Cursor.ident ~keep_case:false r in
         match
+          (* The name is read inside the recovered region: a descriptor with no
+             name at all ([@font-face { : url(a.woff2) }]) fails here, and it is
+             dropped like any other bad one rather than taking the rule. *)
+          let name = Cursor.ident ~keep_case:false r in
           if descriptor_value_has_var r && not (descriptor_resolves_var name)
           then Cursor.err_invalid r ("var() in @font-face descriptor: " ^ name)
           else read_font_face_desc name r
@@ -2653,9 +2656,9 @@ let read_font_face_descriptor (r : Cursor.t) : font_face_descriptor option =
             Some descriptor
         | exception Error.Parse_error e ->
             (* CSS Fonts 4 sec. 4.1 / CSS Syntax 3 (ED) sec. 5.5.5: a descriptor
-               that does not parse - an unknown name (Fontsource's
-               [font-named-instance]) or an invalid value of a known one
-               ([font-display:maybe]) - is dropped and the rest of the
+               that does not parse - one with no name at all, an unknown name
+               (Fontsource's [font-named-instance]) or an invalid value of a
+               known one ([font-display:maybe]) - is dropped and the rest of the
                @font-face is kept, matching browsers. *)
             Cursor.skip_past_semicolon r;
             Cursor.push_warning r

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2566,7 +2566,11 @@ let spec_s7_block_examples () =
   expect_parse_error "@media print { color: red; body { font-size: 10pt } }";
   check_stylesheet ~expected:"@keyframes slide{50%{opacity:1}}"
     "@keyframes slide { color: red; 50% { opacity: 1 } }";
-  expect_parse_error "@font-face { .x { color: red } }"
+  (* A qualified rule is not a descriptor, so it is dropped the way any other
+     bad descriptor is and the @font-face is kept. It then carries neither
+     font-family nor src, so nothing is emitted. Chrome 146 keeps an empty
+     CSSFontFaceRule for the same input. *)
+  check_stylesheet ~expected:"" "@font-face { .x { color: red } }"
 
 (* Not a roundtrip test *)
 let spec_s8_rule_shapes () =


### PR DESCRIPTION
A malformed descriptor in `@font-face` cost the whole rule, so the face went missing. The descriptor is now dropped on its own and the rest of the face is kept.