### PR TITLE
stylesheet: refuse an unparseable @scope bound

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -665,6 +665,11 @@ entry points both moved.
   the recovery, so `@font-face { font-family: f; : url(a.woff2) }` took the
   rule and everything the parser had read after it (#948)
 
+- An `@scope` bound that does not parse invalidates the rule, as it does in
+  browsers. Such a bound used to become the `:invalid` pseudo-class, so
+  `@scope ) { .a { color: green } }` scoped the block to whatever form
+  controls were in an invalid state (#949)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3574,15 +3574,17 @@ let scope_prelude r prelude_components : Selector.t option * Selector.t option =
       Cursor.err_invalid r "@scope start selector cannot be empty";
     if end_cvs <> [] && end_parens && end_ = "" then
       Cursor.err_invalid r "@scope end selector cannot be empty";
-    (* Parse each bound into a selector; an unparseable bound is
-       [Selector.Invalid]. *)
+    (* CSS Cascade 6 sec. 3.5.2 gives each bound a [<complex-selector-list>], so
+       a bound that does not parse leaves the prelude invalid and the rule with
+       it, which is what Chrome 146 does. [Selector.Invalid] stood here as a
+       placeholder, but it is the [:invalid] pseudo-class: emitting it scoped
+       the block to whatever form controls are in an invalid state. *)
     let opt s : Selector.t option =
       if s = "" then None
       else
         match Selector.of_string s with
         | sel -> Some sel
-        | exception (Cursor.Parse_error _ | Invalid_argument _) ->
-            Some Selector.Invalid
+        | exception Invalid_argument m -> Cursor.err_invalid r m
     in
     (opt start, opt end_)
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1576,6 +1576,12 @@ let spec_strict_rejects_invalid_stylesheets () =
       ( "keyframes forbidden css-wide name",
         "@keyframes initial { to { opacity: 1 } }" );
       (* Conditional query grammars. *)
+      (* CSS Cascade 6 sec. 3.5.2 gives each [@scope] bound a complex selector
+         list, so a bound that does not parse leaves the prelude invalid. It
+         used to become the [:invalid] pseudo-class, scoping the block to
+         whatever form controls were in an invalid state. *)
+      ("scope unparseable start bound", "@scope ) { .a { color: green } }");
+      ("scope unparseable end bound", "@scope (.s) to ) { .a { color: green } }");
       ( "media ungrouped mixed boolean operators",
         "@media (width) and (height) or (color) { .x { color: red } }" );
       ("media dangling not", "@media not { .x { color: red } }");


### PR DESCRIPTION
An `@scope` prelude cascade could not read became a rule scoped to `:invalid`, which matches form controls. It is now refused.