### PR TITLE
selector: hold the name shortcut to ident code points

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -670,6 +670,11 @@ entry points both moved.
   `@scope ) { .a { color: green } }` scoped the block to whatever form
   controls were in an invalid state (#949)
 
+- `Css.Selector.of_string` refuses a string that is not a selector rather than
+  reading it as an element name. Its single-name shortcut accepted anything
+  without selector punctuation in it, so `@scope (})` became an element
+  selector named `}` (#950)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2028,6 +2028,16 @@ let rec drop_redundant_nesting_prefix (sel : t) : t =
   | List sels -> List (List.map drop_redundant_nesting_prefix sels)
   | other -> other
 
+(* CSS Syntax 3 (ED) sec. 4.3.11 builds an identifier from ident code points -
+   letters, digits, [-], [_] and anything non-ASCII - and escapes. The shortcut
+   below reads the whole string as one name, so anything else in it means the
+   string is not a name: selector punctuation ([:], [>], [,] ...) but equally a
+   [}] or a [;], which name nothing and used to be taken for an element. *)
+let is_ident_code_point c =
+  match c with
+  | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '-' -> true
+  | c -> Char.code c >= 0x80
+
 let is_unescaped_selector_syntax s start =
   let len = String.length s in
   let rec loop i =
@@ -2038,10 +2048,8 @@ let is_unescaped_selector_syntax s start =
           let j = ref i in
           skip_css_escape s j;
           loop !j
-      | ':' | '(' | ')' | '[' | ']' | ',' | '>' | '+' | '~' | '|' | '*' | ' '
-      | '\t' | '\n' | '\r' | '\012' ->
-          true
-      | _ -> loop (i + 1)
+      | c when is_ident_code_point c -> loop (i + 1)
+      | _ -> true
   in
   loop start
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1582,6 +1582,10 @@ let spec_strict_rejects_invalid_stylesheets () =
          whatever form controls were in an invalid state. *)
       ("scope unparseable start bound", "@scope ) { .a { color: green } }");
       ("scope unparseable end bound", "@scope (.s) to ) { .a { color: green } }");
+      (* The single-name shortcut in [Selector.of_string] read the whole bound
+         as an element name. CSS Syntax 3 (ED) sec. 4.3.11 builds a name from
+         ident code points, and a [}] is not one, so the bound names nothing. *)
+      ("scope bound that is not a name", "@scope (}) { .a { color: green } }");
       ( "media ungrouped mixed boolean operators",
         "@media (width) and (height) or (color) { .x { color: red } }" );
       ("media dangling not", "@media not { .x { color: red } }");


### PR DESCRIPTION
The single-name shortcut in `Selector.of_string` accepted anything without selector punctuation in it, so `@scope (})` parsed as an element selector named `}`. It now requires CSS Syntax 3 sec. 4.2 ident code points.