### PR TITLE
border-width: refuse a percentage line width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -675,6 +675,11 @@ entry points both moved.
   without selector punctuation in it, so `@scope (})` became an element
   selector named `}` (#950)
 
+- A line width takes no percentage. CSS Backgrounds 3 sec. 3.3 gives
+  `<line-width>` a length, so `border-width: 50%` and the same value on the 40
+  other properties reading one, `outline-width` and `-webkit-text-stroke-width`
+  among them, are refused as browsers refuse them (#951)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1367,6 +1367,13 @@ let length_to_border_width t (length : length) : border_width =
       | Some (unit, value) -> typed_dimension value unit
       | None -> err_invalid_value t "border-width" "unsupported length type")
 
+(* CSS Backgrounds 3 (ED) sec. 3.3: [<line-width>] is [<length [0,inf]> | thin |
+   medium | thick] and takes no percentage, which Chrome 146 refuses.
+   [length_only] refuses one nested in math as well. *)
+let read_length_as_border_width t =
+  let length = read_length ~with_keywords:false ~length_only:true t in
+  length_to_border_width t length
+
 let rec read_border_width t : border_width =
   let read_var t : border_width = Var (read_var read_border_width t) in
   let read_calc t : border_width =
@@ -1391,11 +1398,6 @@ let rec read_border_width t : border_width =
     | [ lower; value; upper ] -> Clamp (lower, value, upper)
     | _ -> Cursor.err_invalid t "invalid clamp"
   in
-  let read_length_as_border_width t =
-    let length = read_length ~with_keywords:false t in
-    length_to_border_width t length
-  in
-
   Cursor.enum_or_calls "border-width"
     [
       ("thin", (Thin : border_width));

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3179,7 +3179,17 @@ let invalid () =
   neg "column-height: none";
   neg "column-height: normal";
   neg "column-wrap: sideways";
-  neg "column-wrap: 10px"
+  neg "column-wrap: 10px";
+
+  (* CSS Backgrounds 3 (ED) sec. 3.3: [<line-width>] is [<length [0,inf]> | thin
+     | medium | thick] and takes no percentage, in math or out of it. Chrome 146
+     refuses one. *)
+  neg "border-width: 50%";
+  neg "border-top-width: 50%";
+  neg "outline-width: 200%";
+  neg "column-rule-width: 10%";
+  neg "-webkit-text-stroke-width: 20%";
+  neg "border-width: calc(50%)"
 
 let spec_property_grammar_table_expansion () =
   (* Cross-spec property grammar vectors. This grows toward an exhaustive table:


### PR DESCRIPTION
CSS Backgrounds 3 sec. 3.3 gives `<line-width>` a length, so `border-width: 50%` and the same value on the forty other properties reading one, `outline-width` and `-webkit-text-stroke-width` among them, are now refused as browsers refuse them.