### PR TITLE
values: make the intrinsic sizes opt-in

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -680,6 +680,12 @@ entry points both moved.
   other properties reading one, `outline-width` and `-webkit-text-stroke-width`
   among them, are refused as browsers refuse them (#951)
 
+- The intrinsic sizes belong to the sizing properties. CSS Sizing 3 sec. 5
+  gives `min-content` and its siblings to `width` and the rest, and cascade
+  read them wherever it read a length, so `top: min-content` and
+  `margin-top: none` parsed. `Css.Values.read_length` gains `?sizing` for the
+  readers whose property takes them (#952)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1129,8 +1129,10 @@ let read_color_value : type a. a property -> Cursor.t -> declaration option =
       Some (v Webkit_text_decoration_color (read_color t))
   | _ -> None
 
+(* CSS Sizing 3 sec. 5: the box sizes are the properties the intrinsic sizes
+   belong to, so this reader asks for them. *)
 let read_box_size ?(maximum = false) t =
-  match read_length_percentage ~allow_negative:false t with
+  match read_length_percentage ~allow_negative:false ~sizing:true t with
   | Length (Normal | From_font | Size) ->
       Cursor.err_invalid t "expected a box size"
   | Length Auto when maximum ->

--- a/lib/prop_align.ml
+++ b/lib/prop_align.ml
@@ -719,31 +719,36 @@ let rec pp_align_content : align_content Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
 
 (* Gap shorthand parser *)
-let rec read_gap t : gap =
-  let read_non_negative_length t =
-    let len = read_length t in
-    match len with
-    | Px v
-    | Rem v
-    | Em v
-    | Ch v
-    | Ex v
-    | Vw v
-    | Vh v
-    | Vmin v
-    | Vmax v
-    | Pt v
-    | Pc v
-    | In v
-    | Cm v
-    | Mm v
-    | Q v
-      when v < 0.0 ->
-        Cursor.err t "gap values cannot be negative"
-    | Auto | Inherit | Initial | Unset | Revert | Revert_layer | Fit_content ->
-        Cursor.err t "gap values must be explicit lengths, not keywords"
-    | _ -> len
+(* CSS Box Alignment 3 sec. 8.3: each half is a [<'row-gap'>], which is
+   [normal | <length-percentage [0,inf]>]. The keyword is read here rather than
+   taken from the length grammar, which does not carry it. *)
+let read_gap_half t =
+  let len =
+    Cursor.enum "gap" [ ("normal", (Normal : length)) ] ~default:read_length t
   in
+  match len with
+  | Px v
+  | Rem v
+  | Em v
+  | Ch v
+  | Ex v
+  | Vw v
+  | Vh v
+  | Vmin v
+  | Vmax v
+  | Pt v
+  | Pc v
+  | In v
+  | Cm v
+  | Mm v
+  | Q v
+    when v < 0.0 ->
+      Cursor.err t "gap values cannot be negative"
+  | Auto | Inherit | Initial | Unset | Revert | Revert_layer | Fit_content ->
+      Cursor.err t "gap values must be explicit lengths, not keywords"
+  | _ -> len
+
+let rec read_gap t : gap =
   Cursor.enum_or_whole_value_var "gap"
     [
       ("inherit", (Inherit : gap));
@@ -754,9 +759,9 @@ let rec read_gap t : gap =
     ]
     ~var:(fun t -> Var (read_var read_gap t))
     ~default:(fun t ->
-      let first_length = read_non_negative_length t in
+      let first_length = read_gap_half t in
       Cursor.ws t;
-      let second_length = Cursor.option read_non_negative_length t in
+      let second_length = Cursor.option read_gap_half t in
       match second_length with
       | Some col_gap ->
           (Lengths { row_gap = Some first_length; column_gap = Some col_gap }

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -568,14 +568,20 @@ let rec read_flex_basis t : flex_basis =
         ("var", fun t -> Var (read_var read_flex_basis t));
         ("calc", fun t -> Calc (read_calc ~result_type:`Value read_flex_basis t));
       ]
+      (* CSS Flexbox 1 sec. 7.2.3 reads the basis as a [<'width'>], so it takes
+         the intrinsic sizes the box sizes take. *)
     ~default:(fun t ->
+      let size t =
+        read_length ~allow_negative:false ~sizing:true t
+        |> flex_basis_of_length t
+      in
       let pos = Cursor.save t in
       match Cursor.option Cursor.number_with_unit t with
       | Some (0.0, None) -> (Zero : flex_basis)
       | Some _ ->
           Cursor.restore t pos;
-          read_length ~allow_negative:false t |> flex_basis_of_length t
-      | None -> read_length ~allow_negative:false t |> flex_basis_of_length t)
+          size t
+      | None -> size t)
     t
 
 module Flex = struct

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5095,34 +5095,46 @@ let read_length_unit ?(allow_negative = true) ?(length_only = false) t =
              [calc(1x + 2x)] still parses. *)
           Cursor.err_invalid t ("unknown dimension unit: " ^ unit))
 
-let read_length_keyword t : length =
+(* CSS Values 4 (ED) sec. 6 gives a [<length>] no keyword of its own beyond the
+   CSS-wide ones, and [auto] belongs to nearly every property that reads one.
+   The intrinsic sizes ([min-content] and the rest) belong to CSS Sizing 3 sec.
+   5 alone, so a property reading a length asks for them; [top: min-content] and
+   [margin-top: none] are values Chrome 146 refuses. *)
+let length_cssvalue_keywords : (string * length) list =
+  [
+    ("auto", (Auto : length));
+    ("inherit", Inherit);
+    ("initial", Initial);
+    ("unset", Unset);
+    ("revert", Revert);
+    ("revert-layer", Revert_layer);
+  ]
+
+let length_sizing_keywords : (string * length) list =
+  [
+    ("none", (None : length));
+    ("normal", Normal);
+    ("size", Size);
+    ("max-content", Max_content);
+    ("min-content", Min_content);
+    ("fit-content", Fit_content);
+    (* Legacy vendor-prefixed intrinsic sizing keywords (kept as a fallback for
+       old Safari / Firefox; the unprefixed forms above win in modern ones). *)
+    ("-webkit-max-content", Webkit_max_content);
+    ("-webkit-min-content", Webkit_min_content);
+    ("-webkit-fit-content", Webkit_fit_content);
+    ("-moz-max-content", Moz_max_content);
+    ("-moz-min-content", Moz_min_content);
+    ("-moz-fit-content", Moz_fit_content);
+    ("contain", Contain);
+    ("stretch", Stretch);
+    ("from-font", From_font);
+  ]
+
+let read_length_keyword ?(sizing = true) t : length =
   Cursor.enum "length"
-    [
-      ("auto", (Auto : length));
-      ("none", None);
-      ("normal", Normal);
-      ("size", Size);
-      ("max-content", Max_content);
-      ("min-content", Min_content);
-      ("fit-content", Fit_content);
-      (* Legacy vendor-prefixed intrinsic sizing keywords (kept as a fallback
-         for old Safari / Firefox; the unprefixed forms above win in modern
-         ones). *)
-      ("-webkit-max-content", Webkit_max_content);
-      ("-webkit-min-content", Webkit_min_content);
-      ("-webkit-fit-content", Webkit_fit_content);
-      ("-moz-max-content", Moz_max_content);
-      ("-moz-min-content", Moz_min_content);
-      ("-moz-fit-content", Moz_fit_content);
-      ("contain", Contain);
-      ("stretch", Stretch);
-      ("from-font", From_font);
-      ("inherit", Inherit);
-      ("initial", Initial);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-    ]
+    (if sizing then length_cssvalue_keywords @ length_sizing_keywords
+     else length_cssvalue_keywords)
     t
 
 let calc_factor_is_dimension : type a. a calc -> bool = function
@@ -5760,7 +5772,7 @@ let read_attr_type_hint inner : attr_type option =
   else read_plain_attr_type_hint inner
 
 let rec read_length ?(allow_negative = true) ?(with_keywords = true)
-    ?(length_only = false) t : length =
+    ?(sizing = false) ?(length_only = false) t : length =
   Cursor.ws t;
   let parsers =
     [
@@ -5772,7 +5784,7 @@ let rec read_length ?(allow_negative = true) ?(with_keywords = true)
     ]
   in
   let parsers =
-    if with_keywords then read_length_keyword :: parsers else parsers
+    if with_keywords then read_length_keyword ~sizing :: parsers else parsers
   in
   Cursor.one_of parsers t
 
@@ -5970,15 +5982,17 @@ and read_sign_length ~allow_negative ~length_only ~with_keywords inner =
     (fun (value : length) -> (Sign value : length))
     inner
 
+(* CSS Values 5 (ED) sec. 12: [calc-size()] takes a sizing basis and then a
+   calculation over [size], so both halves read the intrinsic sizes whatever
+   property the function sits in. *)
 and read_calc_size_length ~allow_negative ~length_only ~with_keywords inner =
-  let basis = read_length ~allow_negative ~length_only ~with_keywords inner in
+  let read t =
+    read_length ~allow_negative ~length_only ~with_keywords ~sizing:true t
+  in
+  let basis = read inner in
   Cursor.ws inner;
   Cursor.comma inner;
-  let calc =
-    read_calc_expr
-      (read_length ~allow_negative ~length_only ~with_keywords)
-      inner
-  in
+  let calc = read_calc_expr read inner in
   Cursor.ws inner;
   Cursor.expect_eof inner;
   Calc_size (basis, calc)
@@ -7329,13 +7343,13 @@ let read_length_percentage_pct ~allow_negative t : length_percentage =
   if (not allow_negative) && n < 0.0 then Cursor.err_invalid t "negative";
   Pct n
 
-let read_length_percentage_length ~allow_negative ~with_keywords t :
+let read_length_percentage_length ~allow_negative ~with_keywords ~sizing t :
     length_percentage =
-  Length (read_length ~allow_negative ~with_keywords t)
+  Length (read_length ~allow_negative ~with_keywords ~sizing t)
 
 (** Read length_percentage value *)
 let rec read_length_percentage ?(allow_negative = true) ?(with_keywords = true)
-    t : length_percentage =
+    ?(sizing = false) t : length_percentage =
   Cursor.ws t;
   Cursor.one_of
     [
@@ -7344,7 +7358,7 @@ let rec read_length_percentage ?(allow_negative = true) ?(with_keywords = true)
       read_length_percentage_calc ~with_keywords;
       read_invalid_length_percentage_function;
       read_length_percentage_pct ~allow_negative;
-      read_length_percentage_length ~allow_negative ~with_keywords;
+      read_length_percentage_length ~allow_negative ~with_keywords ~sizing;
     ]
     t
 

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -455,12 +455,17 @@ val normalize_signed_zero : float -> string -> float * string
 val read_length :
   ?allow_negative:bool ->
   ?with_keywords:bool ->
+  ?sizing:bool ->
   ?length_only:bool ->
   Cursor.t ->
   length
 (** [read_length t] parses a CSS length. [length_only] excludes percentages,
     including those nested in math, and sizing-only functions. It defaults to
-    [false] for readers whose grammar permits length-percentage values. *)
+    [false] for readers whose grammar permits length-percentage values. [sizing]
+    adds the intrinsic sizes CSS Sizing 3 sec. 5 defines - [min-content],
+    [fit-content] and the rest - which belong to the sizing properties and not
+    to a [<length>] as such; it defaults to [false], so a reader whose property
+    takes them asks. *)
 
 val read_non_negative_length : ?with_keywords:bool -> Cursor.t -> length
 (** [read_non_negative_length reader] parses a length value that must be
@@ -597,7 +602,11 @@ val read_percentage : Cursor.t -> percentage
 (** [read_percentage t] parses a CSS percentage. *)
 
 val read_length_percentage :
-  ?allow_negative:bool -> ?with_keywords:bool -> Cursor.t -> length_percentage
+  ?allow_negative:bool ->
+  ?with_keywords:bool ->
+  ?sizing:bool ->
+  Cursor.t ->
+  length_percentage
 (** [read_length_percentage t] parses a CSS length or percentage. *)
 
 val read_number_percentage : Cursor.t -> number_percentage

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -557,6 +557,16 @@ let special_cases () =
     ~optimized:"border-block-width:1px 2px" "border-block-width: 1px 2px";
   check_declaration ~expected:"border-block-style:solid solid"
     ~optimized:"border-block-style:solid" "border-block-style: solid solid";
+  (* CSS Sizing 3 sec. 5 gives the intrinsic sizes to the sizing properties, so
+     those keep them where a property reading a plain length does not. [gap]
+     reads [normal] from CSS Box Alignment 3 sec. 8.3. *)
+  check_declaration ~expected:"width:min-content" ~optimized:"width:min-content"
+    "width: min-content";
+  check_declaration ~expected:"max-width:none" ~optimized:"max-width:none"
+    "max-width: none";
+  check_declaration ~expected:"flex-basis:min-content"
+    ~optimized:"flex-basis:min-content" "flex-basis: min-content";
+  check_declaration ~expected:"gap:normal" ~optimized:"gap:normal" "gap: normal";
   check_declaration ~expected:"column-height:auto"
     ~optimized:"column-height:auto" "column-height: auto";
   check_declaration ~expected:"column-height:10px"

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -8,6 +8,9 @@ open Css_test_helpers
 (* One-liner check functions for each CSS value type *)
 let check_length = check_value_cursor "length" read_length pp_length
 
+let check_sizing =
+  check_value_cursor "length" (read_length ~sizing:true) pp_length
+
 (* Always assert both paths. pp serializes the parsed colour ([expected], held);
    optimize+minify canonicalizes it ([optimized]). When [optimized] is omitted
    the colour has no shorter spec-equivalent spelling (already canonical, or a
@@ -107,18 +110,25 @@ let test_length () =
   (* Keywords *)
   check_length "auto";
   check_length "inherit";
-  check_length "max-content";
-  check_length "min-content";
-  check_length "fit-content";
+  (* CSS Sizing 3 sec. 5 gives the intrinsic sizes to the sizing properties, so
+     the reader takes them only where the property does and the default refuses
+     them. *)
+  check_sizing "max-content";
+  check_sizing "min-content";
+  check_sizing "fit-content";
   (* Legacy vendor-prefixed intrinsic sizing keywords (Bootstrap,
      Fontsource). *)
-  check_length "-webkit-max-content";
-  check_length "-webkit-min-content";
-  check_length "-webkit-fit-content";
-  check_length "-moz-max-content";
-  check_length "-moz-min-content";
-  check_length "-moz-fit-content";
-  check_length "from-font";
+  check_sizing "-webkit-max-content";
+  check_sizing "-webkit-min-content";
+  check_sizing "-webkit-fit-content";
+  check_sizing "-moz-max-content";
+  check_sizing "-moz-min-content";
+  check_sizing "-moz-fit-content";
+  check_sizing "from-font";
+  List.iter
+    (fun keyword ->
+      neg_cursor (fun t -> ignore (read_length t : Css.Values.length)) keyword)
+    [ "max-content"; "min-content"; "fit-content"; "from-font" ];
 
   (* Edge cases *)
   check_length "0";


### PR DESCRIPTION
CSS Sizing 3 sec. 5 gives `min-content` and its siblings to the sizing properties, but cascade read them wherever it read a length, so `top: min-content` and `margin-top: none` parsed. This PR adds `?sizing` to `Css.Values.read_length` for the readers whose property takes them.