### PR TITLE
values: require a unit on a time and an angle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -686,6 +686,11 @@ entry points both moved.
   `margin-top: none` parsed. `Css.Values.read_length` gains `?sizing` for the
   readers whose property takes them (#952)
 
+- A time and an angle need their unit. CSS Values 4 sec. 6.2 omits it only for
+  a zero length, and cascade read `transition-duration: 0` as `0s` and
+  `rotate: 0` as `0deg`, turning a declaration browsers drop into one that
+  works (#953)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -775,13 +775,14 @@ let rec read_offset_rotate t : offset_rotate =
   let read_mode_first t : offset_rotate =
     let mode = read_offset_rotate_mode t in
     Cursor.ws t;
-    match Cursor.option read_angle t with
+    match Cursor.option read_angle_unit_required t with
     | Some angle -> With_angle (mode, angle)
     | None -> (
         match mode with Auto -> (Auto : offset_rotate) | Reverse -> Reverse)
   in
   let read_angle_first t : offset_rotate =
-    let angle = read_angle t in
+    (* Same reading as [rotate]: the angle carries a unit. *)
+    let angle = read_angle_unit_required t in
     Cursor.ws t;
     match Cursor.option read_offset_rotate_mode t with
     | Some mode -> With_angle (mode, angle)
@@ -1029,7 +1030,9 @@ let read_rotate_angle_axis_tail angle t =
    x|y|z] or [<angle> <number>{3}]. Try angle-first after the plain forms;
    consume the angle, then look for a trailing axis. *)
 let read_rotate_angle_then_axis t : rotate_value =
-  let angle = read_angle t in
+  (* CSS Values 4 (ED) sec. 6.2 omits the unit only for a zero length, so the
+     angle here carries one; Chrome 146 refuses [rotate: 0]. *)
+  let angle = read_angle_unit_required t in
   Cursor.ws t;
   if Cursor.is_done t then Angle angle else read_rotate_angle_axis_tail angle t
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -7111,24 +7111,27 @@ let duration_css_wide =
     ("revert-layer", Revert_layer);
   ]
 
+(* CSS Values 4 (ED) sec. 6.2: "the unit may be omitted [...] only for zero
+   lengths", so a bare [0] is not a time. Reading one as [0s] turned input a
+   browser refuses into a declaration that works. *)
 let read_duration_number ~canonicalize_ms:_ t : duration =
   let n, unit_raw = Cursor.number_with_unit t in
   if n < 0.0 then Cursor.err_invalid t "negative durations are not allowed"
   else
     let unit = String.lowercase_ascii (Option.value unit_raw ~default:"") in
     match unit with
-    | "" when n = 0.0 -> S 0.0
     | "s" -> S n
     | "ms" -> Ms n
+    | "" -> Cursor.err_invalid t "a time needs a unit, [0] included"
     | _ -> Cursor.err_invalid t ("duration unit: " ^ unit)
 
 let read_time_number t : duration =
   let n, unit_raw = Cursor.number_with_unit t in
   let unit = String.lowercase_ascii (Option.value unit_raw ~default:"") in
   match unit with
-  | "" when n = 0.0 -> S 0.0
   | "s" -> S n
   | "ms" -> Ms n
+  | "" -> Cursor.err_invalid t "a time needs a unit, [0] included"
   | _ -> Cursor.err_invalid t ("time unit: " ^ unit)
 
 let read_duration_round read_duration_self t =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3199,7 +3199,27 @@ let invalid () =
   neg "outline-width: 200%";
   neg "column-rule-width: 10%";
   neg "-webkit-text-stroke-width: 20%";
-  neg "border-width: calc(50%)"
+  neg "border-width: calc(50%)";
+
+  (* CSS Sizing 3 sec. 5 gives the intrinsic sizes to the sizing properties, so
+     a property reading a plain length does not take them. Chrome 146 refuses
+     each of these. *)
+  neg "top: min-content";
+  neg "top: normal";
+  neg "margin-top: none";
+  neg "inset: min-content";
+  neg "column-width: min-content";
+  neg "background-size: min-content";
+
+  (* CSS Values 4 (ED) sec. 6.2 omits the unit only for a zero length, so a bare
+     [0] is neither a time nor an angle. Cascade used to read one as [0s] or
+     [0deg], turning input Chrome 146 refuses into a working declaration. *)
+  neg "transition-duration: 0";
+  neg "transition-delay: 0";
+  neg "animation-duration: 0";
+  neg "animation-delay: 0";
+  neg "rotate: 0";
+  neg "offset-rotate: 0"
 
 let spec_property_grammar_table_expansion () =
   (* Cross-spec property grammar vectors. This grows toward an exhaustive table:


### PR DESCRIPTION
CSS Values 4 sec. 6.2 omits the unit only for a zero length. Cascade read `transition-duration: 0` as `0s` and `rotate: 0` as `0deg`, turning a declaration browsers drop into one that works.