### PR TITLE
values: refuse a percentage where the grammar names a length

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -691,6 +691,13 @@ entry points both moved.
   `rotate: 0` as `0deg`, turning a declaration browsers drop into one that
   works (#953)
 
+- A property whose grammar names a `<length>` takes no percentage. Chrome
+  refuses `perspective: 50%`, and cascade accepted a percentage there and on
+  `tab-size`, `column-width`, `border-spacing`, `border-image-outset`,
+  `overflow-clip-margin` and the `contain-intrinsic-*` sizes. A negative
+  `column-width` is refused with them. `Css.Values.read_non_negative_length`
+  gains `?length_only` (#954)
+
 - `--minify` folds a repeated side of `border-width` and of the three border
   logical axes to the shortest spelling naming the same sides, as it already
   did for `margin`, `padding` and `border-color`: `border-width: 2px 2px 2px

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -899,7 +899,9 @@ let read_perspective_value t =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~default:(read_non_negative_length ~with_keywords:false)
+    (* CSS Transforms 2 (ED) sec. 3: [perspective] is [none | <length [0,inf]>],
+       so it takes no percentage; Chrome 146 refuses one. *)
+    ~default:(read_non_negative_length ~with_keywords:false ~length_only:true)
     t
 
 (* CSS Text Decoration 4 sec. 2.8: [text-underline-offset] is [auto |

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -2197,7 +2197,7 @@ let read_border_image_repeat_keyword t : border_image_repeat_keyword =
 
 let rec read_border_spacing t : border_spacing =
   let read_numeric_length t =
-    let l = read_length ~allow_negative:false t in
+    let l = read_length ~allow_negative:false ~length_only:true t in
     match l with
     | Auto | Size | None | Normal | Fit_content | Content | Contain
     | Max_content | Min_content | From_font | Hairline | Thin | Medium | Thick
@@ -2289,7 +2289,11 @@ let read_border_image_outset_item t : border_image_outset_item =
   | Some n when n >= 0. -> Number n
   | Some _ -> Cursor.err_invalid t "border-image value cannot be negative"
   | None ->
-      let len = read_length ~allow_negative:false ~with_keywords:false t in
+      (* Sec. 5.4 gives the outset a number or a length, and no percentage. *)
+      let len =
+        read_length ~allow_negative:false ~with_keywords:false ~length_only:true
+          t
+      in
       Length len
 
 let read_border_image_box_step ~what read_item t acc =

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -608,7 +608,10 @@ let read_overflow_clip_length_item (length : length option ref) t =
   Cursor.ws t;
   match !length with
   | None ->
-      length := Some (read_length ~allow_negative:false ~with_keywords:false t);
+      length :=
+        Some
+          (read_length ~allow_negative:false ~with_keywords:false
+             ~length_only:true t);
       true
   | Some _ -> false
 

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -514,16 +514,20 @@ let rec read_position_anchor (t : Cursor.t) : position_anchor =
      t
     : position_anchor)
 
+(* CSS Sizing 4 sec. 5: [contain-intrinsic-size] takes [<length>], and no
+   percentage, which Chrome 146 refuses. *)
 let read_contain_intrinsic_size_item t : contain_intrinsic_size_item =
+  let size t =
+    Values.read_length ~allow_negative:false ~with_keywords:false
+      ~length_only:true t
+  in
   Cursor.ws t;
   match Cursor.peek_ident t with
   | Some "auto" ->
       let _ = Cursor.ident t in
       Cursor.ws t;
-      (Auto (Values.read_length ~allow_negative:false ~with_keywords:false t)
-        : contain_intrinsic_size_item)
-  | _ ->
-      Length (Values.read_length ~allow_negative:false ~with_keywords:false t)
+      (Auto (size t) : contain_intrinsic_size_item)
+  | _ -> Length (size t)
 
 let rec read_contain_intrinsic_size (t : Cursor.t) : contain_intrinsic_size =
   let keywords : (string * contain_intrinsic_size) list =

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -357,7 +357,11 @@ let rec read_column_width t : column_width =
       ("revert-layer", Revert_layer);
     ]
     ~var:(fun t -> Var (Values.read_var read_column_width t))
-    ~default:(fun t -> (Width (read_length t) : column_width))
+      (* CSS Multicol 2 sec. 4.1: [column-width] is [auto | <length [0,inf]>]
+         and takes no percentage, which Chrome 146 refuses. *)
+    ~default:(fun t ->
+      (Width (read_length ~allow_negative:false ~length_only:true t)
+        : column_width))
     t
 
 (* The height takes a length and no percentage, which Chrome 146 refuses. *)

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -2051,7 +2051,8 @@ let rec read_tab_size (t : Cursor.t) : tab_size =
             (fun t -> number_value t (Values.read_integer "tab-size" t));
             (fun t ->
               Length
-                (Values.read_length ~allow_negative:false ~with_keywords:false t));
+                (Values.read_length ~allow_negative:false ~with_keywords:false
+                   ~length_only:true t));
           ]
           t
   in

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6035,8 +6035,9 @@ and read_attr_length_fallback ~allow_negative ~length_only ~with_keywords inner
   else No_fallback
 
 (** Read a non-negative length value (for padding properties) *)
-let read_non_negative_length ?(with_keywords = true) t : length =
-  read_length ~allow_negative:false ~with_keywords t
+let read_non_negative_length ?(with_keywords = true) ?(length_only = false) t :
+    length =
+  read_length ~allow_negative:false ~with_keywords ~length_only t
 
 (** Read a percentage value as float (number followed by %) Used for color
     components where 0-100% clamping is required *)

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -467,7 +467,8 @@ val read_length :
     to a [<length>] as such; it defaults to [false], so a reader whose property
     takes them asks. *)
 
-val read_non_negative_length : ?with_keywords:bool -> Cursor.t -> length
+val read_non_negative_length :
+  ?with_keywords:bool -> ?length_only:bool -> Cursor.t -> length
 (** [read_non_negative_length reader] parses a length value that must be
     non-negative. Used for padding properties, whose CSS Box 4 sec. 4.1 grammar
     excludes negative values. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3219,7 +3219,22 @@ let invalid () =
   neg "animation-duration: 0";
   neg "animation-delay: 0";
   neg "rotate: 0";
-  neg "offset-rotate: 0"
+  neg "offset-rotate: 0";
+
+  (* Each of these is a [<length>] in its own specification and takes no
+     percentage: CSS Transforms 2 sec. 3 for the perspective, CSS Tables 3 sec.
+     4.3.1 for the spacing, CSS Multicol 2 sec. 4.1 for the column width, CSS
+     Backgrounds 3 sec. 5.4 for the outset and CSS Sizing 4 sec. 5 for the
+     intrinsic size. Chrome 146 refuses each. *)
+  neg "perspective: 50%";
+  neg "border-spacing: 50%";
+  neg "column-width: 50%";
+  neg "border-image-outset: 50%";
+  neg "contain-intrinsic-size: 50%";
+  neg "contain-intrinsic-width: 200%";
+  neg "tab-size: 50%";
+  neg "overflow-clip-margin: 50%";
+  neg "column-width: -5px"
 
 let spec_property_grammar_table_expansion () =
   (* Cross-spec property grammar vectors. This grows toward an exhaustive table:


### PR DESCRIPTION
Each of these readers delegated to the general length parser, which takes a percentage, so a value browsers drop parsed and survived minification: `perspective`, `tab-size`, `column-width`, `border-spacing`, `border-image-outset`, `overflow-clip-margin` and the `contain-intrinsic-*` sizes. A negative `column-width` is refused with them. `Css.Values.read_non_negative_length` gains `?length_only`.