### PR TITLE
shorthand: drop an initial border-image after a border

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -545,6 +545,11 @@ entry points both moved.
 
 ### Minification
 
+- `--minify` drops a `border-image` that names nothing but initials after a
+  `border`, which CSS Backgrounds 3 sec. 3.4 already resets it to. The whole
+  border family written out as longhands now minifies to `border: 1px solid
+  red` alone, where a `border-image: none` trailed it (#956)
+
 - `--minify` contracts the eight border sides from their own three longhands,
   as it already did for `outline`: `border-top-width`, `border-top-style` and
   `border-top-color` written together become `border-top`, and a longhand

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -5906,6 +5906,16 @@ let compose_shorthands ?(held = held_none) ~ctx kept =
   |> fun kept ->
   merge_box_shorthand_longhands kept kept |> merge_overflow_longhands
 
+let drained_border_image : Properties.border_image =
+  {
+    source = None;
+    slice = None;
+    width = None;
+    outset = None;
+    repeat = None;
+    mode = None;
+  }
+
 (* The longhand declaration a shorthand assigns to a slot it covers: the slot
    value if set, else that longhand's initial. A later longhand equal to this is
    a redundant no-op. [None] when the shorthand does not cover the longhand or
@@ -5986,6 +5996,10 @@ let implied_longhand covering covered : Declaration.declaration option =
               Option.map border_width s.width
           | Declaration { property = Properties.Border_style; _ } ->
               Option.map border_style s.style
+          (* sec. 3.4 also resets [border-image], so the shorthand says what an
+             all-initial [border-image] says. *)
+          | Declaration { property = Properties.Border_image; _ } ->
+              Some (Declaration.v Border_image drained_border_image)
           | _ -> None)
       | _ -> None)
   | Declaration { property = Properties.Font; value; _ } -> (
@@ -6054,6 +6068,9 @@ let deduplicate_declarations_with ?(held = held_none) ~ctx ?(merge_box = true)
     let kept = drop_vendor_aliases ~ctx kept in
     List.map (fun (_, decl) -> decl) kept
   in
+  (* Composition writes shorthands the input did not carry, so the longhands one
+     of them now restates are only visible on a second pass. *)
+  let kept = drop_longhands_after_covering_shorthand kept in
   let result = duplicate_buggy_properties kept in
   (* Each pipeline step keeps untouched declarations, so [preserve_list]
      restores the input list when every declaration is physically unchanged -

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -1150,7 +1150,20 @@ let test_drop_redundant_border_longhand () =
   decl_optimizes_to ~into:"border:1px solid red;border-color:#00f"
     "border:1px solid red;border-color:blue";
   decl_optimizes_to ~into:"border:1px solid red;border-color:red green"
-    "border:1px solid red;border-color:red green"
+    "border:1px solid red;border-color:red green";
+  (* CSS Backgrounds 3 (ED) sec. 3.4 resets [border-image] too, so an
+     all-initial one after the shorthand says what the shorthand said. A
+     picture, or a stronger importance, is a real declaration. *)
+  decl_optimizes_to ~into:"border:1px solid red"
+    "border:1px solid red;border-image:none";
+  decl_optimizes_to ~into:"border:1px solid red;border-image:url(a.png)"
+    "border:1px solid red;border-image:url(a.png)";
+  decl_optimizes_to ~into:"border:1px solid red;border-image:none!important"
+    "border:1px solid red;border-image:none!important";
+  (* Composition writes the shorthand the input never carried, and the
+     border-image run it leaves behind is redundant against it. *)
+  decl_optimizes_to ~into:"border:1px solid red"
+    "border-top-width:1px;border-right-width:1px;border-bottom-width:1px;border-left-width:1px;border-top-style:solid;border-right-style:solid;border-bottom-style:solid;border-left-style:solid;border-top-color:red;border-right-color:red;border-bottom-color:red;border-left-color:red;border-image-source:none;border-image-slice:100%;border-image-width:1;border-image-outset:0;border-image-repeat:stretch"
 
 let test_drop_redundant_font_longhand () =
   (* [font] resets style/weight/stretch/line-height to normal; a later longhand


### PR DESCRIPTION
The redundant-longhand pass ran only on the input, so a shorthand that composition wrote could not make anything redundant. Composing the border family left the `border-image` reset spelled out beside the shorthand that performs it.