### PR TITLE
shorthand: model animation as resetting the range longhands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -545,6 +545,13 @@ entry points both moved.
 
 ### Minification
 
+- `--minify` no longer resets the animation range when it contracts. Scroll
+  driven Animations 1 makes `animation-range-start` and `animation-range-end`
+  reset-only sub-properties of `animation`, and a rule holding either lost it
+  when the surrounding longhands became the shorthand. A range or a timeline
+  written after the shorthand that only restates the reset is now dropped
+  (#957)
+
 - `--minify` drops a `border-image` that names nothing but initials after a
   `border`, which CSS Backgrounds 3 sec. 3.4 already resets it to. The whole
   border family written out as longhands now minifies to `border: 1px solid

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -80,9 +80,10 @@ let covers_longhand : type a b.
   | Transition, Transition_delay -> true
   | Transition, Transition_behavior -> true
   (* CSS Animations 2 sec. 4.11 and 4.12: [animation] resets every longhand
-     [animation_keys] names, [animation-timeline] included.
-     [animation-composition] and the [animation-range-*] longhands are not part
-     of it and are absent here for that reason. *)
+     [animation_keys] names, [animation-timeline] included. Scroll-driven
+     Animations 1 appendix A.3 makes the two [animation-range-*] longhands
+     reset-only sub-properties of it, so they are reset as well.
+     [animation-composition] is no part of it and is absent for that reason. *)
   | Animation, Animation_name -> true
   | Animation, Animation_duration -> true
   | Animation, Animation_timing_function -> true
@@ -92,6 +93,9 @@ let covers_longhand : type a b.
   | Animation, Animation_fill_mode -> true
   | Animation, Animation_play_state -> true
   | Animation, Animation_timeline -> true
+  | Animation, Animation_range -> true
+  | Animation, Animation_range_start -> true
+  | Animation, Animation_range_end -> true
   (* CSS Logical 1: physical-axis pairs. *)
   | Margin_inline, Margin_inline_start -> true
   | Margin_inline, Margin_inline_end -> true
@@ -378,6 +382,8 @@ let animation_keys =
     key "animation-fill-mode";
     key "animation-play-state";
     key "animation-timeline";
+    key "animation-range-start";
+    key "animation-range-end";
   ]
 
 let transition_keys =
@@ -570,8 +576,8 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Moz_animation_play_state ->
       [ key "animation-play-state" ]
   | Animation_timeline -> [ key "animation-timeline" ]
-  (* Scroll-driven Animations 1 sec. 5.3: [animation-range] is its own
-     shorthand, and [animation] does not reset either end. *)
+  (* Scroll-driven Animations 1 appendix A.3: [animation-range] is its own
+     shorthand over the two ends. *)
   | Animation_range ->
       [ key "animation-range-start"; key "animation-range-end" ]
   | Animation_range_start -> [ key "animation-range-start" ]
@@ -4735,9 +4741,23 @@ type an_slot =
   | Fill
   | Play
   | Timeline
+  | Range_start
+  | Range_end
 
 let an_slots =
-  [ Name; Duration; Timing; Delay; Iteration; Direction; Fill; Play; Timeline ]
+  [
+    Name;
+    Duration;
+    Timing;
+    Delay;
+    Iteration;
+    Direction;
+    Fill;
+    Play;
+    Timeline;
+    Range_start;
+    Range_end;
+  ]
 
 let an_slot_bit : an_slot -> int = function
   | Name -> 32
@@ -4749,6 +4769,8 @@ let an_slot_bit : an_slot -> int = function
   | Fill -> 2048
   | Play -> 4096
   | Timeline -> 8192
+  | Range_start -> 65536
+  | Range_end -> 131072
 
 let an_bits slots = List.fold_left (fun acc s -> acc lor an_slot_bit s) 0 slots
 let all_an_bits = an_bits an_slots
@@ -4801,6 +4823,11 @@ let an_overwritten_slots d =
   | Declaration { property = Animation_fill_mode; _ } -> an_slot_bit Fill
   | Declaration { property = Animation_play_state; _ } -> an_slot_bit Play
   | Declaration { property = Animation_timeline; _ } -> an_slot_bit Timeline
+  | Declaration { property = Animation_range_start; _ } ->
+      an_slot_bit Range_start
+  | Declaration { property = Animation_range_end; _ } -> an_slot_bit Range_end
+  | Declaration { property = Animation_range; _ } ->
+      an_slot_bit Range_start lor an_slot_bit Range_end
   | Declaration { property = Animation; _ } -> all_an_bits
   (* CSS Cascade 5 sec. 3.2: [all] writes every longhand, and no animation
      longhand inherits, so [initial] and [unset] both leave the initials. *)
@@ -6000,6 +6027,32 @@ let implied_longhand covering covered : Declaration.declaration option =
              all-initial [border-image] says. *)
           | Declaration { property = Properties.Border_image; _ } ->
               Some (Declaration.v Border_image drained_border_image)
+          | _ -> None)
+      | _ -> None)
+  | Declaration { property = Properties.Animation; value; _ } -> (
+      (* Scroll-driven Animations 1 appendix A.3 and CSS Animations 2 sec. 4.12
+         make the timeline and the two range ends reset-only sub-properties: the
+         shorthand has no slot for a range, so it always writes [normal] there.
+         Single animation only; a comma list assigns per-item values. *)
+      match (value : Properties.animation list) with
+      | [ Properties.Shorthand s ] -> (
+          match unwrap_theme_guard covered with
+          | Declaration { property = Properties.Animation_timeline; _ } ->
+              Some
+                (Declaration.v Animation_timeline
+                   (Option.value s.timeline ~default:Properties.Auto))
+          | Declaration { property = Properties.Animation_range_start; _ } ->
+              Some
+                (Declaration.v Animation_range_start
+                   (Normal : Properties.animation_range_item))
+          | Declaration { property = Properties.Animation_range_end; _ } ->
+              Some
+                (Declaration.v Animation_range_end
+                   (Normal : Properties.animation_range_item))
+          | Declaration { property = Properties.Animation_range; _ } ->
+              Some
+                (Declaration.v Animation_range
+                   (Range (Normal, None) : Properties.animation_range))
           | _ -> None)
       | _ -> None)
   | Declaration { property = Properties.Font; value; _ } -> (

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -1078,6 +1078,31 @@ let test_animation_contraction_covers_other_rules () =
       ".a{animation-name:spin;color:red;animation-duration:2s;animation-timing-function:linear}"
     ".a{animation-name:spin;color:red;animation-duration:2s;animation-timing-function:linear}"
 
+(* Scroll-driven Animations 1 (ED) appendix A.3 makes the two animation-range
+   longhands reset-only sub-properties of [animation], which Chrome 146 agrees
+   with: [animation-range-start: 20%] beside the shorthand computes to [normal].
+   So a range the rule holds blocks the contraction, a range written after the
+   shorthand is the reset spelled out, and one written before it is dead. *)
+let test_animation_resets_the_range () =
+  sheet_optimizes_to
+    ~into:
+      ".a{animation-range-start:20%;animation-name:x;animation-duration:1s;animation-timing-function:linear}"
+    ".a{animation-range-start:20%;animation-name:x;animation-duration:1s;animation-timing-function:linear}";
+  decl_optimizes_to ~into:"animation:x 1s" "animation-range:20%;animation:x 1s";
+  decl_optimizes_to ~into:"animation:x 1s"
+    "animation:x 1s;animation-range:normal";
+  decl_optimizes_to ~into:"animation:x 1s"
+    "animation:x 1s;animation-range-start:normal;animation-range-end:normal";
+  decl_optimizes_to ~into:"animation:x 1s"
+    "animation:x 1s;animation-timeline:auto";
+  (* A range or a timeline the shorthand does not write is a real override. *)
+  decl_optimizes_to ~into:"animation:x 1s;animation-range:20%"
+    "animation:x 1s;animation-range:20%";
+  decl_optimizes_to ~into:"animation:x 1s;animation-timeline:view()"
+    "animation:x 1s;animation-timeline:view()";
+  decl_optimizes_to ~into:"animation:x 1s;animation-range:normal!important"
+    "animation:x 1s;animation-range:normal!important"
+
 let test_transition_contraction_covers_other_rules () =
   (* Same rule, both sides of the guard. A non-important holder is reset by the
      contraction, so the run stays expanded; an important one outranks the
@@ -1644,6 +1669,8 @@ let suite =
         test_transition_contraction_covers_other_rules;
       Alcotest.test_case "animation contraction covers other rules" `Quick
         test_animation_contraction_covers_other_rules;
+      Alcotest.test_case "animation resets the range" `Quick
+        test_animation_resets_the_range;
       Alcotest.test_case "scroll axis pair composes" `Quick
         test_scroll_axis_pair_composes;
       Alcotest.test_case "border axis pair composes" `Quick


### PR DESCRIPTION
Scroll-driven Animations 1 appendix A.3 makes `animation-range-start` and `animation-range-end` reset-only sub-properties of `animation`, and Chrome 146 agrees. Cascade modelled the opposite, so a rule holding a range lost it when the surrounding longhands contracted and the minified output rendered differently from its input.