### PR TITLE
shorthand: hold a partial animation or transition run to the scope

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -545,6 +545,14 @@ entry points both moved.
 
 ### Minification
 
+- `--minify` contracts an `animation` or `transition` longhand run that leaves
+  one of the shorthand's own longhands unwritten only under
+  `--scope=stylesheet`, which is what the flag promises: the shorthand resets
+  what the run left out, and under the default fragment scope an earlier
+  `transition-timing-function` from another file is not cascade's to reset. A
+  run whose omitted slots the same rule writes back still contracts in either
+  scope (#958)
+
 - `--minify` no longer resets the animation range when it contracts. Scroll
   driven Animations 1 makes `animation-range-start` and `animation-range-end`
   reset-only sub-properties of `animation`, and a rule holding either lost it

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -4891,6 +4891,38 @@ let reset_hazard ~slots_of idx i ~held ~missing ~important =
   in
   scan (i - 1)
 
+(* A slot a declaration after the run writes again is one the shorthand's reset
+   cannot reach: the later write is what the element ends up with, whatever the
+   reset put there. Unlike [*_overwritten_slots] this counts a write back to the
+   slot initial, which answers the reset just as well. *)
+let rec slots_written_after ~slots_of idx ~from =
+  let n = Rule_index.length idx in
+  if from >= n then 0
+  else
+    let rest = slots_written_after ~slots_of idx ~from:(from + 1) in
+    if Rule_index.is_absorbed idx from then rest
+    else slots_of (Rule_index.decl_at idx from) lor rest
+
+let tr_written_slots d =
+  match unwrap_theme_guard d with
+  | Declaration { property = Transition_property; _ } -> tr_slot_bit Property
+  | Declaration { property = Transition_duration; _ } -> tr_slot_bit Duration
+  | Declaration { property = Transition_timing_function; _ } ->
+      tr_slot_bit Timing
+  | Declaration { property = Transition_delay; _ } -> tr_slot_bit Delay
+  | Declaration { property = Transition_behavior; _ } -> tr_slot_bit Behavior
+  | Declaration { property = Transition; _ } | Declaration { property = All; _ }
+    ->
+      all_tr_bits
+  | _ -> 0
+
+let an_written_slots d =
+  match unwrap_theme_guard d with
+  | Declaration { property = Animation_range; _ } ->
+      an_slot_bit Range_start lor an_slot_bit Range_end
+  | Declaration { property = All; _ } -> all_an_bits
+  | d -> an_overwritten_slots d
+
 let tr_reset_hazard = reset_hazard ~slots_of:tr_overwritten_slots
 let td_reset_hazard = reset_hazard ~slots_of:td_overwritten_slots
 let bi_reset_hazard = reset_hazard ~slots_of:bi_overwritten_slots
@@ -5088,7 +5120,7 @@ let compose_columns_via_index idx =
   compose_run_via_index idx ~try_compose:(fun idx i ->
       Option.map (fun d -> (d, 4)) (try_compose_columns_at idx i))
 
-let try_compose_transition_at ~held idx i =
+let try_compose_transition_at ~allow_partial ~held idx i =
   let parts, len = take_run_at idx ~part_of:transition_part_of i in
   if List.length parts < 2 then None
   else
@@ -5103,7 +5135,16 @@ let try_compose_transition_at ~held idx i =
           0 parts
       in
       let missing = all_tr_bits land lnot written in
-      if tr_reset_hazard idx i ~held ~missing ~important then None
+      let unanswered =
+        missing
+        land lnot
+               (slots_written_after ~slots_of:tr_written_slots idx
+                  ~from:(i + len))
+      in
+      if
+        (unanswered <> 0 && not allow_partial)
+        || tr_reset_hazard idx i ~held ~missing ~important
+      then None
       else
         let layer =
           List.fold_left (fun acc (_, (_, f)) -> f acc) empty_tr_shorthand parts
@@ -5114,8 +5155,10 @@ let try_compose_transition_at ~held idx i =
         in
         Some (shorthand, len)
 
-let compose_transition_via_index ~held idx =
-  compose_run_via_index idx ~try_compose:(try_compose_transition_at ~held)
+let compose_transition_via_index ~ctx ~held idx =
+  let allow_partial = scope ctx = `Stylesheet in
+  compose_run_via_index idx
+    ~try_compose:(try_compose_transition_at ~allow_partial ~held)
 
 (* CSS Animations 1 sec. 3.1: [animation] composes from the per-layer animation
    longhands. Compose when a contiguous run sticks to a single layer (no
@@ -5250,7 +5293,7 @@ let empty_an_shorthand : Properties.animation_shorthand =
    only safe when nothing else in the cascade holds that slot. *)
 let an_reset_hazard = reset_hazard ~slots_of:an_overwritten_slots
 
-let try_compose_animation_at ~held idx i =
+let try_compose_animation_at ~allow_partial ~held idx i =
   let parts, len = take_run_at idx ~part_of:animation_part_of i in
   if List.length parts < 2 then None
   else
@@ -5264,7 +5307,19 @@ let try_compose_animation_at ~held idx i =
           0 parts
       in
       let missing = all_an_bits land lnot written in
-      if an_reset_hazard idx i ~held ~missing ~important then None
+      (* A slot the shorthand resets that neither the run nor a later
+         declaration writes is one the surrounding CSS may hold, so contracting
+         needs the whole graph in view. *)
+      let unanswered =
+        missing
+        land lnot
+               (slots_written_after ~slots_of:an_written_slots idx
+                  ~from:(i + len))
+      in
+      if
+        (unanswered <> 0 && not allow_partial)
+        || an_reset_hazard idx i ~held ~missing ~important
+      then None
       else
         let layer =
           List.fold_left (fun acc (_, (_, f)) -> f acc) empty_an_shorthand parts
@@ -5275,8 +5330,10 @@ let try_compose_animation_at ~held idx i =
         in
         Some (shorthand, len)
 
-let compose_animation_via_index ~held idx =
-  compose_run_via_index idx ~try_compose:(try_compose_animation_at ~held)
+let compose_animation_via_index ~ctx ~held idx =
+  let allow_partial = scope ctx = `Stylesheet in
+  compose_run_via_index idx
+    ~try_compose:(try_compose_animation_at ~allow_partial ~held)
 
 let merge_box_shorthand_longhands source decls =
   (* [try_merge_box_shorthand] returns the original declaration when it absorbs
@@ -5908,8 +5965,8 @@ let compose_index_group_b ~held kept =
 let compose_index_group_c ~ctx ~held kept =
   let idx = Rule_index.build (List.map snd kept) in
   compose_mask_via_index ~ctx idx;
-  compose_transition_via_index ~held idx;
-  compose_animation_via_index ~held idx;
+  compose_transition_via_index ~ctx ~held idx;
+  compose_animation_via_index ~ctx ~held idx;
   List.mapi (fun i d -> (i, d)) (Rule_index.to_list idx)
 
 let compose_border_whole_step ~held ~ctx kept =

--- a/test/helpers/css_test_helpers.ml
+++ b/test/helpers/css_test_helpers.ml
@@ -111,7 +111,7 @@ let decl_optimizes ~prop ?held ~into input =
         (Css.to_string ~minify:true (Css.optimize p.stylesheet) |> String.trim)
   | Error _ -> Alcotest.failf "parse failed: %s" (wrap input)
 
-let decl_optimizes_to ?held ~into input =
+let decl_optimizes_to ?held ?scope ~into input =
   let wrap decl = String.concat "" [ ".x{"; decl; "}" ] in
   match Css.of_string ~strict:false (wrap input) with
   | Ok p ->
@@ -125,7 +125,8 @@ let decl_optimizes_to ?held ~into input =
       Alcotest.(check string)
         (wrap input ^ " minify+optimize")
         (wrap into)
-        (Css.to_string ~minify:true (Css.optimize p.stylesheet) |> String.trim)
+        (Css.to_string ~minify:true (Css.optimize ?scope p.stylesheet)
+        |> String.trim)
   | Error _ -> Alcotest.failf "parse failed: %s" (wrap input)
 
 (** [decl_lossless ~prop ~into input] asserts the lossless minify+optimize

--- a/test/helpers/css_test_helpers.mli
+++ b/test/helpers/css_test_helpers.mli
@@ -76,9 +76,12 @@ val decl_optimizes :
     [into] is the spec-canonical shortest spelling, not a snapshot of current
     output. *)
 
-val decl_optimizes_to : ?held:string -> into:string -> string -> unit
-(** [decl_optimizes_to ?held ~into input] is the full-declaration variant of
-    {!decl_optimizes}: [input], [held] and [into] include the property name. *)
+val decl_optimizes_to :
+  ?held:string -> ?scope:Css.Optimize.scope -> into:string -> string -> unit
+(** [decl_optimizes_to ?held ?scope ~into input] is the full-declaration variant
+    of {!decl_optimizes}: [input], [held] and [into] include the property name.
+    [scope] tells the optimizer how much surrounding CSS the input may be
+    embedded in, and defaults to the fragment the optimizer itself assumes. *)
 
 val decl_lossless : prop:string -> into:string -> string -> unit
 (** [decl_lossless ~prop ~into input] checks the minify+optimize path with

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -19,13 +19,14 @@ let unindexed decls = List.map snd decls
 
 (* [decl_optimizes_to] wraps its input in one rule; these cases turn on what a
    neighbouring rule holds, so they optimize a whole sheet. *)
-let sheet_optimizes_to ~into input =
+let sheet_optimizes_to ?scope ~into input =
   match Css.of_string input with
   | Ok { stylesheet; _ } ->
       Alcotest.(check string)
         (String.concat "" [ input; " minify+optimize" ])
         into
-        (String.trim (Css.to_string ~minify:true (Css.optimize stylesheet)))
+        (String.trim
+           (Css.to_string ~minify:true (Css.optimize ?scope stylesheet)))
   | Error e -> Alcotest.failf "parse failed: %s" (Error.to_string e)
 
 let test_declaration_covers_reset_boundaries () =
@@ -503,13 +504,32 @@ let test_transition_contraction_covers_reset_longhands () =
      and [0s] are initials and drop out. *)
   decl_optimizes_to ~into:"transition:color 1s allow-discrete"
     "transition-behavior:allow-discrete;transition-property:color;transition-duration:1s;transition-timing-function:ease;transition-delay:0s";
-  decl_optimizes_to ~into:"transition:color 1s allow-discrete"
+  (* A run leaving a slot out contracts into a shorthand that resets it, and
+     under the fragment scope the optimizer assumes by default the surrounding
+     CSS may hold that slot. So the two runs below keep their longhands, and
+     take the shorthand only once the caller says the input is the whole
+     graph. *)
+  decl_optimizes_to
+    ~into:
+      "transition-property:color;transition-duration:1s;transition-behavior:allow-discrete"
     "transition-property:color;transition-duration:1s;transition-behavior:allow-discrete";
-  decl_optimizes_to ~into:"transition:color 1s allow-discrete"
+  decl_optimizes_to ~scope:`Stylesheet
+    ~into:"transition:color 1s allow-discrete"
+    "transition-property:color;transition-duration:1s;transition-behavior:allow-discrete";
+  decl_optimizes_to
+    ~into:
+      "transition-property:color;transition-behavior:allow-discrete;transition-duration:1s"
     "transition-property:color;transition-behavior:allow-discrete;transition-duration:1s";
-  (* A run covering only the Transitions 1 longhands still contracts: nothing in
-     the rule writes the behaviour, so resetting it to [normal] is a no-op. *)
-  decl_optimizes_to ~into:"transition:color 1s"
+  decl_optimizes_to ~scope:`Stylesheet
+    ~into:"transition:color 1s allow-discrete"
+    "transition-property:color;transition-behavior:allow-discrete;transition-duration:1s";
+  (* A run covering only the Transitions 1 longhands leaves the behaviour to the
+     reset, which is the same partial contraction. *)
+  decl_optimizes_to
+    ~into:
+      "transition-property:color;transition-duration:1s;transition-timing-function:ease;transition-delay:0s"
+    "transition-property:color;transition-duration:1s;transition-timing-function:ease;transition-delay:0s";
+  decl_optimizes_to ~scope:`Stylesheet ~into:"transition:color 1s"
     "transition-property:color;transition-duration:1s;transition-timing-function:ease;transition-delay:0s";
   (* [inherit] is not a shorthand component, so the run cannot carry it and the
      contraction would drop it. *)
@@ -524,20 +544,27 @@ let test_transition_contraction_covers_reset_longhands () =
       "transition-delay:5s;color:red;transition-property:color;transition-duration:1s"
     "transition-delay:5s;color:red;transition-property:color;transition-duration:1s";
   (* An earlier shorthand holds the slots its own run left out. Contracting the
-     later run resets the delay it set. *)
+     later run resets the delay it set, in either scope. *)
   decl_optimizes_to
     ~into:
       "transition:color 1s \
        5s;transition-property:opacity;transition-duration:2s"
     "transition:color 1s ease \
      5s;transition-property:opacity;transition-duration:2s";
+  decl_optimizes_to ~scope:`Stylesheet
+    ~into:
+      "transition:color 1s \
+       5s;transition-property:opacity;transition-duration:2s"
+    "transition:color 1s ease \
+     5s;transition-property:opacity;transition-duration:2s";
   (* An earlier shorthand whose unwritten slots are already initials shadows
-     nothing, so the later run contracts. *)
-  decl_optimizes_to ~into:"transition:opacity 2s"
+     nothing, so the later run contracts once the graph is in view. *)
+  decl_optimizes_to ~scope:`Stylesheet ~into:"transition:opacity 2s"
     "transition:color 1s;transition-property:opacity;transition-duration:2s";
   (* An important longhand outranks the composed shorthand whatever the order,
      so it is not a hazard. *)
-  decl_optimizes_to ~into:"transition-delay:5s!important;transition:color 1s"
+  decl_optimizes_to ~scope:`Stylesheet
+    ~into:"transition-delay:5s!important;transition:color 1s"
     "transition-delay:5s!important;transition-property:color;transition-duration:1s"
 
 (* The slot a contraction resets belongs to the element, not to the rule: any
@@ -1057,26 +1084,34 @@ let test_border_contraction_covers_border_image () =
    name written earlier says [none] and animates nothing. The transition family
    already reasons this way; animation had no coverage arms at all. *)
 let test_animation_contraction_covers_other_rules () =
+  (* [animation] has more longhands than [<single-animation>] can carry, so
+     every run here leaves the shorthand resetting something and each case asks
+     for the whole graph; the control at the end pins the fragment scope. *)
   (* Split across two rules with the same selector: the shortest spelling that
      keeps the name groups the two and carries it into the shorthand. *)
-  sheet_optimizes_to ~into:".a{animation:spin 2s linear}"
+  sheet_optimizes_to ~scope:`Stylesheet ~into:".a{animation:spin 2s linear}"
     ".a{animation-name:spin}.a{animation-duration:2s;animation-timing-function:linear}";
   (* Same rule: the name is reset by a contraction that does not carry it, so
      the run stays expanded. *)
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:".a{animation-name:spin;color:red;animation-duration:2s}"
     ".a{animation-name:spin;color:red;animation-duration:2s}";
   (* An important name outranks the non-important shorthand whatever the order,
      so the run contracts. *)
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:".a{animation-name:spin!important;color:red;animation:2s linear}"
     ".a{animation-name:spin!important;color:red;animation-duration:2s;animation-timing-function:linear}";
   (* A non-important name is reset by the contraction, so the run stays
      expanded. *)
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:
       ".a{animation-name:spin;color:red;animation-duration:2s;animation-timing-function:linear}"
-    ".a{animation-name:spin;color:red;animation-duration:2s;animation-timing-function:linear}"
+    ".a{animation-name:spin;color:red;animation-duration:2s;animation-timing-function:linear}";
+  (* The control: the first input under the fragment scope. *)
+  sheet_optimizes_to
+    ~into:
+      ".a{animation-duration:2s;animation-timing-function:linear;animation-name:spin}"
+    ".a{animation-name:spin}.a{animation-duration:2s;animation-timing-function:linear}"
 
 (* Scroll-driven Animations 1 (ED) appendix A.3 makes the two animation-range
    longhands reset-only sub-properties of [animation], which Chrome 146 agrees
@@ -1104,14 +1139,18 @@ let test_animation_resets_the_range () =
     "animation:x 1s;animation-range:normal!important"
 
 let test_transition_contraction_covers_other_rules () =
+  (* Every case here contracts a run that leaves a slot to the shorthand's
+     reset, so each one asks for the whole graph. Under the fragment scope the
+     run stays expanded whatever the neighbours say, which the two controls at
+     the end pin. *)
   (* Same rule, both sides of the guard. A non-important holder is reset by the
      contraction, so the run stays expanded; an important one outranks the
      non-important shorthand whatever the order, so the run contracts. *)
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:
       ".a{transition-behavior:allow-discrete;color:red;transition-property:color;transition-duration:1s}"
     ".a{transition-behavior:allow-discrete;color:red;transition-property:color;transition-duration:1s}";
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:
       ".a{transition-behavior:allow-discrete!important;color:red;transition:color \
        1s}"
@@ -1119,23 +1158,26 @@ let test_transition_contraction_covers_other_rules () =
   (* Split across two rules with the same selector, the element sees exactly the
      cascade above. The behaviour has to survive, and the shortest spelling that
      keeps it groups the two rules and carries it into the shorthand. *)
-  sheet_optimizes_to ~into:".a{transition:color 1s allow-discrete}"
+  sheet_optimizes_to ~scope:`Stylesheet
+    ~into:".a{transition:color 1s allow-discrete}"
     ".a{transition-behavior:allow-discrete}.a{transition-property:color;transition-duration:1s}";
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:".a{transition:color 1s;transition-behavior:allow-discrete!important}"
     ".a{transition-behavior:allow-discrete!important}.a{transition-property:color;transition-duration:1s}";
   (* Both important: the shorthand no longer loses to the holder, so dropping
      the behaviour would change what the element animates. *)
-  sheet_optimizes_to ~into:".a{transition:color 1s allow-discrete!important}"
+  sheet_optimizes_to ~scope:`Stylesheet
+    ~into:".a{transition:color 1s allow-discrete!important}"
     ".a{transition-behavior:allow-discrete!important}.a{transition-property:color!important;transition-duration:1s!important}";
   (* An unrelated rule between them changes nothing: the holder is still in the
      cascade the second rule lands on. *)
-  sheet_optimizes_to ~into:".a{transition:color 1s allow-discrete}.b{color:red}"
+  sheet_optimizes_to ~scope:`Stylesheet
+    ~into:".a{transition:color 1s allow-discrete}.b{color:red}"
     ".a{transition-behavior:allow-discrete}.b{color:red}.a{transition-property:color;transition-duration:1s}";
   (* A rule between them that writes the same family keeps the two apart, so
      there is no grouping to carry the behaviour into and the run stays
      expanded. *)
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:
       ".a{transition-behavior:allow-discrete}.b{transition:opacity \
        2s}.a{transition-property:color;transition-duration:1s}"
@@ -1143,25 +1185,35 @@ let test_transition_contraction_covers_other_rules () =
      2s}.a{transition-property:color;transition-duration:1s}";
   (* The holder needs no relation to the run's selector: an element carrying
      both classes reads one cascade. *)
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:
       ".b{transition-behavior:allow-discrete}.a{transition-property:color;transition-duration:1s}"
     ".b{transition-behavior:allow-discrete}.a{transition-property:color;transition-duration:1s}";
   (* The other side of the guard, so it stays a hazard test and not a blanket
      refusal: a neighbour holding the slot at its initial resets to the same
      thing, and an important neighbour outranks the shorthand. *)
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:".b{transition-behavior:normal}.a{transition:color 1s}"
     ".b{transition-behavior:normal}.a{transition-property:color;transition-duration:1s}";
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:
       ".b{transition-behavior:allow-discrete!important}.a{transition:color 1s}"
     ".b{transition-behavior:allow-discrete!important}.a{transition-property:color;transition-duration:1s}";
   (* A slot the rule itself rewrites after the run is not at risk from a
      neighbour holding it: the rewrite lands after the reset. *)
-  sheet_optimizes_to
+  sheet_optimizes_to ~scope:`Stylesheet
     ~into:".a{transition:color 1s;color:red;transition-delay:5s}"
-    ".a{transition-property:color;transition-duration:1s;color:red;transition-delay:5s}"
+    ".a{transition-property:color;transition-duration:1s;color:red;transition-delay:5s}";
+  (* The controls: the same two inputs under the fragment scope the optimizer
+     assumes by default. *)
+  sheet_optimizes_to
+    ~into:
+      ".a{transition-behavior:allow-discrete;transition-property:color;transition-duration:1s}"
+    ".a{transition-behavior:allow-discrete}.a{transition-property:color;transition-duration:1s}";
+  sheet_optimizes_to
+    ~into:
+      ".b{transition-behavior:normal}.a{transition-property:color;transition-duration:1s}"
+    ".b{transition-behavior:normal}.a{transition-property:color;transition-duration:1s}"
 
 let test_drop_redundant_border_longhand () =
   (* [border] sets width/style/color; a later longhand equal to an explicit slot


### PR DESCRIPTION
A run leaving one of the shorthand's longhands unwritten contracts into a declaration that resets it, and under the fragment scope the surrounding CSS may be holding it, which is what `--scope` documents. Such a run now needs `--scope=stylesheet`; a slot the same rule writes after the run is answered and still contracts in either scope.