### PR TITLE
shorthand: read initial as the text-decoration component it names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -568,7 +568,8 @@ entry points both moved.
 - `--minify` contracts the eight border sides from their own three longhands,
   as it already did for `outline`: `border-top-width`, `border-top-style` and
   `border-top-color` written together become `border-top`, and a longhand
-  written `initial` reads as the component the shorthand leaves out (#918, #919)
+  written `initial` reads as the component the shorthand leaves out, as it now
+  does for `text-decoration` (#918, #919, #959)
 
 - `--minify` contracts `border-block` and `border-inline` from the three axis
   shorthands that set the same six longhands between them (#920)

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3308,17 +3308,29 @@ let td_kind_of : declaration -> td_kind option = function
   | Declaration { property = Text_decoration_thickness; _ } -> Some Thickness
   | _ -> None
 
+(* CSS Cascade 5 sec. 7.3 gives a longhand written [initial] the property's
+   initial value, which is what leaving the component out of the shorthand
+   names: [none] for the line (CSS Text Decoration 4 sec. 2.1), [solid] for the
+   style (sec. 2.3) and [currentcolor] for the colour (sec. 2.4). The keyword
+   itself is no shorthand component, so it folds to the value it stands for and
+   the printer drops it with the other initials. *)
 let td_line_of : declaration -> Properties.text_decoration_line list option =
   function
+  | Declaration { property = Text_decoration_line; value = [ Initial ]; _ } ->
+      Some [ (None : Properties.text_decoration_line) ]
   | Declaration { property = Text_decoration_line; value; _ } -> Some value
   | _ -> None
 
 let td_style_of : declaration -> Properties.text_decoration_style option =
   function
+  | Declaration { property = Text_decoration_style; value = Initial; _ } ->
+      Some (Solid : Properties.text_decoration_style)
   | Declaration { property = Text_decoration_style; value; _ } -> Some value
   | _ -> None
 
 let td_color_of : declaration -> Values.color option = function
+  | Declaration { property = Text_decoration_color; value = Initial; _ } ->
+      Some Values.current_color
   | Declaration { property = Text_decoration_color; value; _ } -> Some value
   | _ -> None
 

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -933,7 +933,23 @@ let test_text_decoration_thickness_composes () =
   sheet_optimizes_to
     ~into:
       ".x{text-decoration-line:underline;text-decoration-thickness:2px;text-decoration-style:solid;text-decoration-color:red!important}"
-    ".x{text-decoration-line:underline;text-decoration-thickness:2px;text-decoration-style:solid;text-decoration-color:red!important}"
+    ".x{text-decoration-line:underline;text-decoration-thickness:2px;text-decoration-style:solid;text-decoration-color:red!important}";
+  (* CSS Cascade 5 (ED) sec. 7.3 gives a longhand written [initial] the
+     property's initial value, which is the component the shorthand leaves out,
+     so it contracts the same way the written-out initials do. Chrome 146
+     expands [text-decoration: none] to these four. *)
+  sheet_optimizes_to ~into:".x{text-decoration:none}"
+    ".x{text-decoration-line:none;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial}";
+  sheet_optimizes_to ~into:".x{text-decoration:overline 2px}"
+    ".x{text-decoration-line:overline;text-decoration-thickness:2px;text-decoration-style:initial;text-decoration-color:initial}";
+  sheet_optimizes_to ~into:".x{text-decoration:none red 2px}"
+    ".x{text-decoration-line:initial;text-decoration-thickness:2px;text-decoration-style:solid;text-decoration-color:red}";
+  (* The other CSS-wide keywords name no value of their own, so a run carrying
+     one stays expanded. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{text-decoration-line:overline;text-decoration-thickness:2px;text-decoration-style:inherit;text-decoration-color:red}"
+    ".x{text-decoration-line:overline;text-decoration-thickness:2px;text-decoration-style:inherit;text-decoration-color:red}"
 
 (* CSS Backgrounds 3 (ED) sec. 4.1: an elliptical corner names a horizontal
    radius and a vertical one, and [border-radius] writes the four horizontals,


### PR DESCRIPTION
A longhand written `initial` takes the property's initial value, which is the component the shorthand leaves out. Carrying the keyword itself into a slot is invalid, so the run stayed expanded instead.