### PR TITLE
properties: give font-variant-alternates a typed value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,11 @@ entry points both moved.
 
 ### Parsing
 
+- `font-variant-alternates` has a typed value. It was carried as opaque text,
+  so `swash(fancy) swash(x)`, `swash(inherit)` and a bare ident all parsed
+  where Chrome refuses them, and `Css.Properties.Font_variant_alternates` now
+  names the property (#963)
+
 - The `scroll-margin`, `scroll-padding` and `border-block` / `border-inline`
   width, style and colour axes contract from their two longhands, as the
   margin, padding and inset axes already did (#915, #916).

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1277,6 +1277,8 @@ let read_type_value : type a. a property -> Cursor.t -> declaration option =
   | White_space -> Some (v White_space (read_white_space t))
   | White_space_collapse ->
       Some (v White_space_collapse (read_white_space_collapse t))
+  | Font_variant_alternates ->
+      Some (v Font_variant_alternates (read_font_variant_alternates t))
   | Text_decoration -> Some (v Text_decoration (read_text_decoration t))
   | Text_decoration_line ->
       Some (v Text_decoration_line (read_text_decoration_lines t))

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -399,6 +399,116 @@ let rec pp_font_variant_caps : font_variant_caps Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_font_variant_caps ctx v
 
+let pp_feature_value_names ctx names = Pp.list ~sep:Pp.comma pp_ident ctx names
+
+let pp_font_variant_alternates_item ctx (item : font_variant_alternates_item) =
+  let call name arg =
+    Pp.string ctx name;
+    Pp.char ctx '(';
+    pp_ident ctx arg;
+    Pp.char ctx ')'
+  in
+  let call_list name args =
+    Pp.string ctx name;
+    Pp.char ctx '(';
+    pp_feature_value_names ctx args;
+    Pp.char ctx ')'
+  in
+  match item with
+  | Stylistic name -> call "stylistic" name
+  | Historical_forms -> Pp.string ctx "historical-forms"
+  | Styleset names -> call_list "styleset" names
+  | Character_variant names -> call_list "character-variant" names
+  | Swash name -> call "swash" name
+  | Ornaments name -> call "ornaments" name
+  | Annotation name -> call "annotation" name
+
+let rec pp_font_variant_alternates : font_variant_alternates Pp.t =
+ fun ctx -> function
+  | Normal -> Pp.string ctx "normal"
+  | Alternates items ->
+      Pp.list ~sep:Pp.space pp_font_variant_alternates_item ctx items
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_font_variant_alternates ctx v
+
+(* A feature value name is a [<custom-ident>], so it is neither a CSS-wide
+   keyword nor [default] (CSS Values 4 sec. 3.2). *)
+let read_feature_value_name t =
+  let name = Cursor.ident t in
+  (match String.lowercase_ascii name with
+  | "inherit" | "initial" | "unset" | "revert" | "revert-layer" | "default" ->
+      Cursor.err_invalid t "font-variant-alternates reserved feature name"
+  | _ -> ());
+  name
+
+let read_feature_value_names t =
+  Cursor.list ~sep:Cursor.comma ~at_least:1 read_feature_value_name t
+
+let read_font_variant_alternates_item t : font_variant_alternates_item =
+  Cursor.ws t;
+  match Cursor.peek_ident t with
+  | Some "historical-forms" ->
+      let _ = Cursor.ident t in
+      Historical_forms
+  | _ ->
+      Cursor.one_of
+        [
+          (fun t ->
+            Cursor.call "stylistic" t (fun t ->
+                Stylistic (read_feature_value_name t)));
+          (fun t ->
+            Cursor.call "styleset" t (fun t ->
+                Styleset (read_feature_value_names t)));
+          (fun t ->
+            Cursor.call "character-variant" t (fun t ->
+                Character_variant (read_feature_value_names t)));
+          (fun t ->
+            Cursor.call "swash" t (fun t -> Swash (read_feature_value_name t)));
+          (fun t ->
+            Cursor.call "ornaments" t (fun t ->
+                Ornaments (read_feature_value_name t)));
+          (fun t ->
+            Cursor.call "annotation" t (fun t ->
+                Annotation (read_feature_value_name t)));
+        ]
+        t
+
+(* [||] takes one or more of its options, each at most once. *)
+let font_variant_alternates_tag : font_variant_alternates_item -> int = function
+  | Stylistic _ -> 0
+  | Historical_forms -> 1
+  | Styleset _ -> 2
+  | Character_variant _ -> 3
+  | Swash _ -> 4
+  | Ornaments _ -> 5
+  | Annotation _ -> 6
+
+let read_font_variant_alternates_items t =
+  let items =
+    Cursor.list ~sep:Cursor.ws ~at_least:1 read_font_variant_alternates_item t
+  in
+  let tags = List.map font_variant_alternates_tag items in
+  if List.length (List.sort_uniq compare tags) <> List.length tags then
+    Cursor.err_invalid t "font-variant-alternates duplicate component";
+  (Alternates items : font_variant_alternates)
+
+let rec read_font_variant_alternates t : font_variant_alternates =
+  Cursor.enum_or_var "font-variant-alternates"
+    [
+      ("normal", (Normal : font_variant_alternates));
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (read_var read_font_variant_alternates t))
+    ~default:read_font_variant_alternates_items t
+
 let rec read_font_variant_caps t : font_variant_caps =
   Cursor.enum_or_var "font-variant-caps"
     [

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -657,6 +657,7 @@ let pp_property : type a. a property Pp.t =
   | Caps -> Pp.string ctx "font-variant-caps"
   | Numeric -> Pp.string ctx "font-variant-numeric"
   | Font_variant_position -> Pp.string ctx "font-variant-position"
+  | Font_variant_alternates -> Pp.string ctx "font-variant-alternates"
   | East_asian -> Pp.string ctx "font-variant-east-asian"
   | Backdrop_filter -> Pp.string ctx "backdrop-filter"
   | Webkit_backdrop_filter -> Pp.string ctx "-webkit-backdrop-filter"
@@ -884,6 +885,7 @@ let property_class : type a. a property -> a property_class = function
   | Forced_color_adjust -> Inherited
   | White_space -> Inherited
   | White_space_collapse -> Inherited
+  | Font_variant_alternates -> Inherited
   | Tab_size -> Inherited
   | Webkit_text_size_adjust -> Inherited
   | Font_feature_settings -> Inherited
@@ -1321,6 +1323,7 @@ let property_tag : type a. a property -> int = function
   | Scroll_snap_type -> 198
   | White_space -> 199
   | White_space_collapse -> 541
+  | Font_variant_alternates -> 548
   | Border -> 200
   | Border_block -> 201
   | Border_block_start -> 202
@@ -1895,6 +1898,7 @@ let eq_property : type a b. a property -> b property -> (a, b) Type.eq option =
   | Scroll_snap_type, Scroll_snap_type -> Some Equal
   | White_space, White_space -> Some Equal
   | White_space_collapse, White_space_collapse -> Some Equal
+  | Font_variant_alternates, Font_variant_alternates -> Some Equal
   | Border, Border -> Some Equal
   | Border_block, Border_block -> Some Equal
   | Border_block_start, Border_block_start -> Some Equal
@@ -3206,6 +3210,7 @@ let read_any_property t =
   | "unicode-bidi" -> Prop Unicode_bidi
   | "white-space" -> Prop White_space
   | "white-space-collapse" -> Prop White_space_collapse
+  | "font-variant-alternates" -> Prop Font_variant_alternates
   | "will-change" -> Prop Will_change
   | "word-break" -> Prop Word_break
   | "word-spacing" -> Prop Word_spacing
@@ -3913,6 +3918,7 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Scroll_snap_type, value -> value
   | White_space, value -> value
   | White_space_collapse, value -> value
+  | Font_variant_alternates, value -> value
   | ( ( Border | Border_block | Border_block_start | Border_block_end
       | Border_inline | Border_inline_start | Border_inline_end | Column_rule
       | Border_top | Border_right | Border_bottom | Border_left ),
@@ -4872,6 +4878,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Container -> pp pp_container_shorthand
   | White_space -> pp pp_white_space
   | White_space_collapse -> pp pp_white_space_collapse
+  | Font_variant_alternates -> pp pp_font_variant_alternates
   | Grid_template_columns -> pp pp_grid_template
   | Grid_template_rows -> pp pp_grid_template
   | Grid_template_areas -> pp pp_grid_template_areas

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2398,6 +2398,9 @@ val read_font_variant_ligatures : Cursor.t -> font_variant_ligatures
 val pp_font_variant_caps : font_variant_caps Pp.t
 (** [pp_font_variant_caps] is the pretty-printer for [font_variant_caps]. *)
 
+val read_font_variant_alternates : Cursor.t -> font_variant_alternates
+(** [read_font_variant_alternates t] parses [font-variant-alternates]. *)
+
 val read_font_variant_caps : Cursor.t -> font_variant_caps
 (** [read_font_variant_caps t] is the [font_variant_caps] parsed from [t]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1249,6 +1249,32 @@ type font_variant_caps =
   | Revert_layer
   | Var of font_variant_caps var
 
+(* CSS Fonts 4 (ED) sec. 6.6: [font-variant-alternates] is [normal | [
+   stylistic(<font-feature-value-name>) || historical-forms ||
+   styleset(<font-feature-value-name>#) ||
+   character-variant(<font-feature-value-name>#) ||
+   swash(<font-feature-value-name>) || ornaments(<font-feature-value-name>) ||
+   annotation(<font-feature-value-name>) ]]. A feature value name is a
+   [<custom-ident>] naming a block of the [@font-feature-values] rule. *)
+type font_variant_alternates_item =
+  | Stylistic of string
+  | Historical_forms
+  | Styleset of string list
+  | Character_variant of string list
+  | Swash of string
+  | Ornaments of string
+  | Annotation of string
+
+type font_variant_alternates =
+  | Normal
+  | Alternates of font_variant_alternates_item list
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of font_variant_alternates var
+
 type font_variant_position =
   | Normal
   | Sub
@@ -5160,6 +5186,7 @@ type 'a property =
   | Caps : font_variant_caps property
   | Numeric : font_variant_numeric property
   | Font_variant_position : font_variant_position property
+  | Font_variant_alternates : font_variant_alternates property
   | East_asian : font_variant_east_asian property
   | Backdrop_filter : filter property
   | Webkit_backdrop_filter : filter property

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1407,6 +1407,10 @@ let vars_of_initial_letter (value : Properties.initial_letter) =
 let vars_of_white_space (value : Properties.white_space) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_font_variant_alternates (value : Properties.font_variant_alternates)
+    =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_white_space_collapse (value : Properties.white_space_collapse) =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2554,6 +2558,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Moz_user_select, value -> vars_of_user_select value
   | White_space, value -> vars_of_white_space value
   | White_space_collapse, value -> vars_of_white_space_collapse value
+  | Font_variant_alternates, value -> vars_of_font_variant_alternates value
   | Word_break, value -> vars_of_word_break value
   | Writing_mode, value -> vars_of_writing_mode value
   | Z_index, value -> vars_of_z_index value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4592,6 +4592,19 @@ let spec_remaining_prop_vectors () =
         "font-variant-numeric:oldstyle-nums tabular-nums stacked-fractions \
          ordinal slashed-zero" );
       ("font-variant-position: sub", "font-variant-position:sub");
+      (* CSS Fonts 4 (ED) sec. 6.6. Chrome 146 reads each of these and refuses a
+         repeated component, a reserved feature name and a bare ident. *)
+      ("font-variant-alternates: normal", "font-variant-alternates:normal");
+      ( "font-variant-alternates: historical-forms",
+        "font-variant-alternates:historical-forms" );
+      ( "font-variant-alternates: swash(fancy)",
+        "font-variant-alternates:swash(fancy)" );
+      ( "font-variant-alternates: styleset(a, b) historical-forms",
+        "font-variant-alternates:styleset(a,b) historical-forms" );
+      ( "font-variant-alternates: character-variant(a, b) annotation(c)",
+        "font-variant-alternates:character-variant(a,b) annotation(c)" );
+      ( "font-variant-alternates: stylistic(a) ornaments(b)",
+        "font-variant-alternates:stylistic(a) ornaments(b)" );
       ("font-variant-east-asian: ruby", "font-variant-east-asian:ruby");
       ( "font-variant-east-asian: traditional proportional-width ruby",
         "font-variant-east-asian:traditional proportional-width ruby" );
@@ -4727,6 +4740,11 @@ let spec_remaining_prop_vectors () =
       "font-variant-numeric: normal tabular-nums";
       "font-variant-numeric: lining-nums oldstyle-nums";
       "font-variant-position: sub super";
+      "font-variant-alternates: swash(fancy) swash(x)";
+      "font-variant-alternates: swash(inherit)";
+      "font-variant-alternates: swash(default)";
+      "font-variant-alternates: bogus";
+      "font-variant-alternates: normal historical-forms";
       "font-variant-east-asian: jis78 jis83";
       "font-variant-east-asian: normal ruby";
       "object-view-box: inset()";


### PR DESCRIPTION
The property was carried as opaque text, so it accepted anything: `swash(fancy) swash(x)`, `swash(inherit)` and a bare ident all parsed where Chrome refuses them. This PR adds `Css.Properties.Font_variant_alternates` and reads CSS Fonts 4 sec. 6.6.