### PR TITLE
properties: give font-variant a typed value and contract into it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -202,6 +202,11 @@ entry points both moved.
 
 ### Parsing
 
+- `font-variant` has a typed value and contracts from its seven longhands. It
+  was carried as opaque text, so `small-caps unicase` and `jis78 jis83` parsed
+  where Chrome refuses them, and the seven longhands written out never met the
+  shorthand under `--diff=canonical` (#964)
+
 - `font-variant-alternates` has a typed value. It was carried as opaque text,
   so `swash(fancy) swash(x)`, `swash(inherit)` and a bare ident all parsed
   where Chrome refuses them, and `Css.Properties.Font_variant_alternates` now

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1279,6 +1279,7 @@ let read_type_value : type a. a property -> Cursor.t -> declaration option =
       Some (v White_space_collapse (read_white_space_collapse t))
   | Font_variant_alternates ->
       Some (v Font_variant_alternates (read_font_variant_alternates t))
+  | Font_variant -> Some (v Font_variant (read_font_variant t))
   | Text_decoration -> Some (v Text_decoration (read_text_decoration t))
   | Text_decoration_line ->
       Some (v Text_decoration_line (read_text_decoration_lines t))

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -593,23 +593,26 @@ let read_east_asian_feature t =
     ]
     t
 
+(* sec. 6.5 gives the property one variant option, one width option and [ruby],
+   each at most once. *)
+let invalid_east_asian_feature_set features =
+  let variant_count = ref 0 in
+  let width_count = ref 0 in
+  let seen = ref [] in
+  List.exists
+    (fun feature ->
+      let duplicate = List.mem feature !seen in
+      seen := feature :: !seen;
+      (match feature with
+      | Jis78 | Jis83 | Jis90 | Jis04 | Simplified | Traditional ->
+          incr variant_count
+      | Full_width | Proportional_width -> incr width_count
+      | Ruby -> ());
+      duplicate || !variant_count > 1 || !width_count > 1)
+    features
+
 let rec read_font_variant_east_asian t : font_variant_east_asian =
-  let invalid_feature_set features =
-    let variant_count = ref 0 in
-    let width_count = ref 0 in
-    let seen = ref [] in
-    List.exists
-      (fun feature ->
-        let duplicate = List.mem feature !seen in
-        seen := feature :: !seen;
-        (match feature with
-        | Jis78 | Jis83 | Jis90 | Jis04 | Simplified | Traditional ->
-            incr variant_count
-        | Full_width | Proportional_width -> incr width_count
-        | Ruby -> ());
-        duplicate || !variant_count > 1 || !width_count > 1)
-      features
-  in
+  let invalid_feature_set = invalid_east_asian_feature_set in
   Cursor.enum_or_var "font-variant-east-asian"
     [
       ("normal", (Normal : font_variant_east_asian));
@@ -2007,6 +2010,156 @@ let rec read_font_variant_numeric t : font_variant_numeric =
     ]
     ~var:(fun t -> Var (read_var read_font_variant_numeric t))
     ~default:read_font_variant_numeric_tokens t
+
+(* CSS Fonts 4 (ED) sec. 6.10: the shorthand's components are the seven
+   longhands' own values, so each component reads through its longhand's item
+   reader and lands in that longhand's slot. [||] takes each option at most
+   once, which the slot being filled already says. *)
+let empty_font_variant_shorthand : font_variant_shorthand =
+  {
+    ligatures = [];
+    alternates = [];
+    caps = Option.none;
+    numeric = [];
+    east_asian = [];
+    position = Option.none;
+    emoji = Option.none;
+  }
+
+let font_variant_is_empty (v : font_variant_shorthand) =
+  v.ligatures = [] && v.alternates = [] && Option.is_none v.caps
+  && v.numeric = [] && v.east_asian = [] && Option.is_none v.position
+  && Option.is_none v.emoji
+
+let read_font_variant_caps_component t : font_variant_caps =
+  Cursor.enum "font-variant caps"
+    [
+      ("small-caps", (Small_caps : font_variant_caps));
+      ("all-small-caps", All_small_caps);
+      ("petite-caps", Petite_caps);
+      ("all-petite-caps", All_petite_caps);
+      ("unicase", Unicase);
+      ("titling-caps", Titling_caps);
+    ]
+    t
+
+let read_font_variant_position_component t : font_variant_position =
+  Cursor.enum "font-variant position"
+    [ ("sub", (Sub : font_variant_position)); ("super", Super) ]
+    t
+
+let read_font_variant_emoji_component t : font_variant_emoji =
+  Cursor.enum "font-variant emoji"
+    [
+      ("text", (Text : font_variant_emoji));
+      ("emoji", Emoji);
+      ("unicode", Unicode);
+    ]
+    t
+
+let font_variant_component acc t =
+  let once what = function
+    | Option.Some _ -> Cursor.err_invalid t what
+    | Option.None -> ()
+  in
+  Cursor.one_of
+    [
+      (fun t ->
+        let ligature = read_font_variant_ligature t in
+        let ligatures = acc.ligatures @ [ ligature ] in
+        if has_duplicate_ligature_slot ligatures then
+          Cursor.err_invalid t "font-variant duplicate ligature";
+        { acc with ligatures });
+      (fun t ->
+        let item = read_font_variant_alternates_item t in
+        let alternates = acc.alternates @ [ item ] in
+        let tags = List.map font_variant_alternates_tag alternates in
+        if List.length (List.sort_uniq compare tags) <> List.length tags then
+          Cursor.err_invalid t "font-variant duplicate alternate";
+        { acc with alternates });
+      (fun t ->
+        let caps = read_font_variant_caps_component t in
+        once "font-variant duplicate caps" acc.caps;
+        { acc with caps = Some caps });
+      (fun t ->
+        let token = read_font_variant_numeric_token t in
+        let numeric = acc.numeric @ [ token ] in
+        reject_duplicate_numeric_families t numeric;
+        { acc with numeric });
+      (fun t ->
+        let feature = read_east_asian_feature t in
+        let east_asian = acc.east_asian @ [ feature ] in
+        if invalid_east_asian_feature_set east_asian then
+          Cursor.err_invalid t "font-variant duplicate east-asian";
+        { acc with east_asian });
+      (fun t ->
+        let position = read_font_variant_position_component t in
+        once "font-variant duplicate position" acc.position;
+        { acc with position = Some position });
+      (fun t ->
+        let emoji = read_font_variant_emoji_component t in
+        once "font-variant duplicate emoji" acc.emoji;
+        { acc with emoji = Some emoji });
+    ]
+    t
+
+let read_font_variant_components t : font_variant =
+  let rec loop acc =
+    Cursor.ws t;
+    if Cursor.is_done t then acc
+    else
+      match Cursor.option (font_variant_component acc) t with
+      | Some acc -> loop acc
+      | Option.None -> acc
+  in
+  let value = loop empty_font_variant_shorthand in
+  if font_variant_is_empty value then
+    Cursor.err_expected t "font-variant component";
+  Shorthand value
+
+let rec read_font_variant t : font_variant =
+  Cursor.enum_or_var "font-variant"
+    [
+      ("normal", (Normal : font_variant));
+      ("none", None);
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t -> Var (read_var read_font_variant t))
+    ~default:read_font_variant_components t
+
+let pp_font_variant_shorthand ctx (v : font_variant_shorthand) =
+  let first = ref true in
+  let sep () = if !first then first := false else Pp.space ctx () in
+  let item pp x =
+    sep ();
+    pp ctx x
+  in
+  List.iter (item pp_font_variant_ligature) v.ligatures;
+  List.iter (item pp_font_variant_alternates_item) v.alternates;
+  Option.iter (item pp_font_variant_caps) v.caps;
+  List.iter (item pp_font_variant_numeric_token) v.numeric;
+  List.iter (item pp_east_asian_feature) v.east_asian;
+  Option.iter (item pp_font_variant_position) v.position;
+  Option.iter (item pp_font_variant_emoji) v.emoji;
+  (* Every slot empty declares the seven initials, which is what [normal]
+     declares; the empty string is not a value any parser reads back. *)
+  if !first then Pp.string ctx "normal"
+
+let rec pp_font_variant : font_variant Pp.t =
+ fun ctx -> function
+  | Normal -> Pp.string ctx "normal"
+  | None -> Pp.string ctx "none"
+  | Shorthand v -> pp_font_variant_shorthand ctx v
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_font_variant ctx v
 
 let read_opentype_tag t =
   let tag = Cursor.string t in

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -658,6 +658,7 @@ let pp_property : type a. a property Pp.t =
   | Numeric -> Pp.string ctx "font-variant-numeric"
   | Font_variant_position -> Pp.string ctx "font-variant-position"
   | Font_variant_alternates -> Pp.string ctx "font-variant-alternates"
+  | Font_variant -> Pp.string ctx "font-variant"
   | East_asian -> Pp.string ctx "font-variant-east-asian"
   | Backdrop_filter -> Pp.string ctx "backdrop-filter"
   | Webkit_backdrop_filter -> Pp.string ctx "-webkit-backdrop-filter"
@@ -886,6 +887,7 @@ let property_class : type a. a property -> a property_class = function
   | White_space -> Inherited
   | White_space_collapse -> Inherited
   | Font_variant_alternates -> Inherited
+  | Font_variant -> Inherited
   | Tab_size -> Inherited
   | Webkit_text_size_adjust -> Inherited
   | Font_feature_settings -> Inherited
@@ -1324,6 +1326,7 @@ let property_tag : type a. a property -> int = function
   | White_space -> 199
   | White_space_collapse -> 541
   | Font_variant_alternates -> 548
+  | Font_variant -> 549
   | Border -> 200
   | Border_block -> 201
   | Border_block_start -> 202
@@ -1899,6 +1902,7 @@ let eq_property : type a b. a property -> b property -> (a, b) Type.eq option =
   | White_space, White_space -> Some Equal
   | White_space_collapse, White_space_collapse -> Some Equal
   | Font_variant_alternates, Font_variant_alternates -> Some Equal
+  | Font_variant, Font_variant -> Some Equal
   | Border, Border -> Some Equal
   | Border_block, Border_block -> Some Equal
   | Border_block_start, Border_block_start -> Some Equal
@@ -3211,6 +3215,7 @@ let read_any_property t =
   | "white-space" -> Prop White_space
   | "white-space-collapse" -> Prop White_space_collapse
   | "font-variant-alternates" -> Prop Font_variant_alternates
+  | "font-variant" -> Prop Font_variant
   | "will-change" -> Prop Will_change
   | "word-break" -> Prop Word_break
   | "word-spacing" -> Prop Word_spacing
@@ -3919,6 +3924,7 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | White_space, value -> value
   | White_space_collapse, value -> value
   | Font_variant_alternates, value -> value
+  | Font_variant, value -> value
   | ( ( Border | Border_block | Border_block_start | Border_block_end
       | Border_inline | Border_inline_start | Border_inline_end | Column_rule
       | Border_top | Border_right | Border_bottom | Border_left ),
@@ -4879,6 +4885,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | White_space -> pp pp_white_space
   | White_space_collapse -> pp pp_white_space_collapse
   | Font_variant_alternates -> pp pp_font_variant_alternates
+  | Font_variant -> pp pp_font_variant
   | Grid_template_columns -> pp pp_grid_template
   | Grid_template_rows -> pp pp_grid_template
   | Grid_template_areas -> pp pp_grid_template_areas

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2398,6 +2398,9 @@ val read_font_variant_ligatures : Cursor.t -> font_variant_ligatures
 val pp_font_variant_caps : font_variant_caps Pp.t
 (** [pp_font_variant_caps] is the pretty-printer for [font_variant_caps]. *)
 
+val read_font_variant : Cursor.t -> font_variant
+(** [read_font_variant t] parses the [font-variant] shorthand. *)
+
 val read_font_variant_alternates : Cursor.t -> font_variant_alternates
 (** [read_font_variant_alternates t] parses [font-variant-alternates]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2136,6 +2136,31 @@ type font_variant_numeric =
     }
   | Var of font_variant_numeric var
 
+(* CSS Fonts 4 (ED) sec. 6.10: [font-variant] is [normal | none | [ <ligatures>
+   || <alternates> || <caps> || <numeric> || <east-asian> || <position> ||
+   <emoji> ]] over its seven longhands, each written at most once. A slot the
+   value leaves out is reset to that longhand's initial. *)
+type font_variant_shorthand = {
+  ligatures : font_variant_ligature list;
+  alternates : font_variant_alternates_item list;
+  caps : font_variant_caps option;
+  numeric : font_variant_numeric_token list;
+  east_asian : east_asian_feature list;
+  position : font_variant_position option;
+  emoji : font_variant_emoji option;
+}
+
+type font_variant =
+  | Normal
+  | None
+  | Shorthand of font_variant_shorthand
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of font_variant var
+
 type font_feature_value = On | Off | Index of int
 type font_feature_setting = { tag : string; value : font_feature_value option }
 
@@ -5187,6 +5212,7 @@ type 'a property =
   | Numeric : font_variant_numeric property
   | Font_variant_position : font_variant_position property
   | Font_variant_alternates : font_variant_alternates property
+  | Font_variant : font_variant property
   | East_asian : font_variant_east_asian property
   | Backdrop_filter : filter property
   | Webkit_backdrop_filter : filter property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -211,6 +211,15 @@ let covers_longhand : type a b.
   | Font, Font_size_adjust -> true
   | Font, Font_kerning -> true
   | Font, Font_optical_sizing -> true
+  | Font, Font_variant_alternates -> true
+  (* CSS Fonts 4 sec. 6.10: [font-variant] resets its seven longhands. *)
+  | Font_variant, Font_variant_ligatures -> true
+  | Font_variant, Font_variant_alternates -> true
+  | Font_variant, Caps -> true
+  | Font_variant, Numeric -> true
+  | Font_variant, East_asian -> true
+  | Font_variant, Font_variant_position -> true
+  | Font_variant, Font_variant_emoji -> true
   (* Motion Path 1 sec. 2.6: [offset] resets the five motion path longhands. *)
   | Offset, Offset_position -> true
   | Offset, Offset_path -> true
@@ -738,6 +747,18 @@ let property_slots : type a. a Properties.property -> overlap_key list =
         key "font-optical-sizing";
         key "font-language-override";
         key "font-palette";
+        key "font-variant-alternates";
+      ]
+  (* CSS Fonts 4 sec. 6.10. *)
+  | Font_variant ->
+      [
+        key "font-variant-ligatures";
+        key "font-variant-alternates";
+        key "font-variant-caps";
+        key "font-variant-numeric";
+        key "font-variant-east-asian";
+        key "font-variant-position";
+        key "font-variant-emoji";
       ]
   (* Motion Path 1 sec. 2.6. *)
   | Offset ->
@@ -755,6 +776,7 @@ let property_slots : type a. a Properties.property -> overlap_key list =
   | Line_height -> [ key "line-height" ]
   | Font_family -> [ key "font-family" ]
   | Font_variant_ligatures -> [ key "font-variant-ligatures" ]
+  | Font_variant_alternates -> [ key "font-variant-alternates" ]
   | Caps -> [ key "font-variant-caps" ]
   | Numeric -> [ key "font-variant-numeric" ]
   | Font_variant_position -> [ key "font-variant-position" ]
@@ -5434,6 +5456,157 @@ let compose_grid_via_index idx =
   compose_run_via_index idx ~try_compose:(fun idx i ->
       Option.map (fun d -> (d, 6)) (try_compose_grid_at idx i))
 
+(* CSS Fonts 4 (ED) sec. 6.10: [font-variant] writes its seven longhands, so the
+   run naming the same declaration is all seven. A longhand at [normal] is the
+   slot the shorthand leaves out; a CSS-wide keyword or a [var()] is the whole
+   declaration value and no shorthand component. *)
+(* [`None] is the [font-variant: none] form, which the ligatures longhand alone
+   can ask for and which carries no other component. *)
+let fv_ligatures_of : declaration -> [ `Slot of _ | `None ] option = function
+  | Declaration { property = Font_variant_ligatures; value = Normal; _ } ->
+      Some (`Slot [])
+  | Declaration { property = Font_variant_ligatures; value = None; _ } ->
+      Some `None
+  | Declaration { property = Font_variant_ligatures; value = Ligatures l; _ } ->
+      Some (`Slot l)
+  | _ -> None
+
+let fv_alternates_of : declaration -> _ list option = function
+  | Declaration { property = Font_variant_alternates; value = Normal; _ } ->
+      Some []
+  | Declaration { property = Font_variant_alternates; value = Alternates l; _ }
+    ->
+      Some l
+  | _ -> None
+
+let fv_caps_of : declaration -> Properties.font_variant_caps option option =
+  function
+  | Declaration { property = Caps; value = Normal; _ } -> Some Option.None
+  | Declaration
+      {
+        property = Caps;
+        value =
+          ( Small_caps | All_small_caps | Petite_caps | All_petite_caps
+          | Unicase | Titling_caps ) as caps;
+        _;
+      } ->
+      Some (Some caps)
+  | _ -> None
+
+let fv_numeric_of : declaration -> _ list option = function
+  | Declaration { property = Numeric; value = Normal; _ } -> Some []
+  | Declaration { property = Numeric; value = Tokens tokens; _ } -> Some tokens
+  | Declaration
+      {
+        property = Numeric;
+        value =
+          Composed
+            {
+              ordinal;
+              slashed_zero;
+              numeric_figure;
+              numeric_spacing;
+              numeric_fraction;
+            };
+        _;
+      } ->
+      Some
+        (List.filter_map Fun.id
+           [
+             numeric_figure;
+             numeric_spacing;
+             numeric_fraction;
+             ordinal;
+             slashed_zero;
+           ])
+  | _ -> None
+
+let fv_east_asian_of : declaration -> _ list option = function
+  | Declaration { property = East_asian; value = Normal; _ } -> Some []
+  | Declaration { property = East_asian; value = Features f; _ } -> Some f
+  | _ -> None
+
+let fv_position_of :
+    declaration -> Properties.font_variant_position option option = function
+  | Declaration { property = Font_variant_position; value = Normal; _ } ->
+      Some Option.None
+  | Declaration
+      { property = Font_variant_position; value = (Sub | Super) as p; _ } ->
+      Some (Some p)
+  | _ -> None
+
+let fv_emoji_of : declaration -> Properties.font_variant_emoji option option =
+  function
+  | Declaration { property = Font_variant_emoji; value = Normal; _ } ->
+      Some Option.None
+  | Declaration
+      {
+        property = Font_variant_emoji;
+        value = (Text | Emoji | Unicode) as e;
+        _;
+      } ->
+      Some (Some e)
+  | _ -> None
+
+let font_variant_of_run raw : Properties.font_variant option =
+  let ligatures = List.find_map fv_ligatures_of raw in
+  let alternates = List.find_map fv_alternates_of raw in
+  let caps = List.find_map fv_caps_of raw in
+  let numeric = List.find_map fv_numeric_of raw in
+  let east_asian = List.find_map fv_east_asian_of raw in
+  let position = List.find_map fv_position_of raw in
+  let emoji = List.find_map fv_emoji_of raw in
+  match (ligatures, alternates, caps, numeric, east_asian, position, emoji) with
+  | ( Some ligatures,
+      Some alternates,
+      Some caps,
+      Some numeric,
+      Some east_asian,
+      Some position,
+      Some emoji ) -> (
+      let others_empty =
+        alternates = [] && Option.is_none caps && numeric = []
+        && east_asian = [] && Option.is_none position && Option.is_none emoji
+      in
+      match ligatures with
+      | `None when others_empty -> Some (None : Properties.font_variant)
+      | `None -> Option.None
+      | `Slot ligatures ->
+          if ligatures = [] && others_empty then Some Normal
+          else
+            Some
+              (Shorthand
+                 {
+                   ligatures;
+                   alternates;
+                   caps;
+                   numeric;
+                   east_asian;
+                   position;
+                   emoji;
+                 }))
+  | _ -> Option.None
+
+let try_compose_font_variant_at idx i =
+  let n = Rule_index.length idx in
+  if i + 6 >= n then None
+  else
+    let positions = List.init 7 (fun j -> i + j) in
+    if List.exists (Rule_index.is_absorbed idx) positions then None
+    else
+      let raw = List.map (Rule_index.decl_at idx) positions in
+      (* Each slot reader answers for one longhand, so a run missing one or
+         naming one twice leaves a slot empty and does not compose. *)
+      if not (same_importance raw) then None
+      else
+        Option.map
+          (Declaration.v ~important:(is_important (List.hd raw)) Font_variant)
+          (font_variant_of_run raw)
+
+let compose_font_variant_via_index idx =
+  compose_run_via_index idx ~try_compose:(fun idx i ->
+      Option.map (fun d -> (d, 7)) (try_compose_font_variant_at idx i))
+
 let try_compose_transition_at ~allow_partial ~held idx i =
   let parts, len = take_run_at idx ~part_of:transition_part_of i in
   if List.length parts < 2 then None
@@ -6267,6 +6440,7 @@ let compose_index_group_b ~held kept =
   compose_text_decoration_via_index ~held idx;
   compose_offset_via_index idx;
   compose_columns_via_index idx;
+  compose_font_variant_via_index idx;
   compose_grid_via_index idx;
   compose_grid_template_via_index idx;
   compose_border_via_index

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1407,6 +1407,9 @@ let vars_of_initial_letter (value : Properties.initial_letter) =
 let vars_of_white_space (value : Properties.white_space) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_font_variant (value : Properties.font_variant) =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_font_variant_alternates (value : Properties.font_variant_alternates)
     =
   match value with Var v -> [ V v ] | _ -> []
@@ -2559,6 +2562,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | White_space, value -> vars_of_white_space value
   | White_space_collapse, value -> vars_of_white_space_collapse value
   | Font_variant_alternates, value -> vars_of_font_variant_alternates value
+  | Font_variant, value -> vars_of_font_variant value
   | Word_break, value -> vars_of_word_break value
   | Writing_mode, value -> vars_of_writing_mode value
   | Z_index, value -> vars_of_z_index value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4595,6 +4595,14 @@ let spec_remaining_prop_vectors () =
       (* CSS Fonts 4 (ED) sec. 6.6. Chrome 146 reads each of these and refuses a
          repeated component, a reserved feature name and a bare ident. *)
       ("font-variant-alternates: normal", "font-variant-alternates:normal");
+      (* CSS Fonts 4 (ED) sec. 6.10. Chrome 146 reads each of these and refuses
+         a component written twice over. *)
+      ("font-variant: normal", "font-variant:normal");
+      ("font-variant: none", "font-variant:none");
+      ("font-variant: small-caps", "font-variant:small-caps");
+      ( "font-variant: common-ligatures small-caps tabular-nums ruby sub text",
+        "font-variant:common-ligatures small-caps tabular-nums ruby sub text" );
+      ("font-variant: swash(a) small-caps", "font-variant:swash(a) small-caps");
       ( "font-variant-alternates: historical-forms",
         "font-variant-alternates:historical-forms" );
       ( "font-variant-alternates: swash(fancy)",
@@ -4741,6 +4749,10 @@ let spec_remaining_prop_vectors () =
       "font-variant-numeric: lining-nums oldstyle-nums";
       "font-variant-position: sub super";
       "font-variant-alternates: swash(fancy) swash(x)";
+      "font-variant: small-caps unicase";
+      "font-variant: common-ligatures no-common-ligatures";
+      "font-variant: jis78 jis83";
+      "font-variant: bogus";
       "font-variant-alternates: swash(inherit)";
       "font-variant-alternates: swash(default)";
       "font-variant-alternates: bogus";

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -951,6 +951,35 @@ let test_text_decoration_thickness_composes () =
       ".x{text-decoration-line:overline;text-decoration-thickness:2px;text-decoration-style:inherit;text-decoration-color:red}"
     ".x{text-decoration-line:overline;text-decoration-thickness:2px;text-decoration-style:inherit;text-decoration-color:red}"
 
+(* CSS Fonts 4 (ED) sec. 6.10: [font-variant] writes its seven longhands, and a
+   longhand at [normal] is the component the shorthand leaves out. Chrome 146
+   expands each shorthand below to the run beside it. *)
+let test_font_variant_composes () =
+  sheet_optimizes_to ~into:".x{font-variant:small-caps}"
+    ".x{font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variant-caps:small-caps;font-variant-alternates:normal;font-variant-position:normal;font-variant-emoji:normal}";
+  sheet_optimizes_to ~into:".x{font-variant:normal}"
+    ".x{font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variant-alternates:normal;font-variant-position:normal;font-variant-emoji:normal}";
+  sheet_optimizes_to ~into:".x{font-variant:common-ligatures}"
+    ".x{font-variant-ligatures:common-ligatures;font-variant-numeric:normal;font-variant-east-asian:normal;font-variant-caps:normal;font-variant-alternates:normal;font-variant-position:normal;font-variant-emoji:normal}";
+  sheet_optimizes_to ~into:".x{font-variant:none}"
+    ".x{font-variant-ligatures:none;font-variant-numeric:normal;font-variant-east-asian:normal;font-variant-caps:normal;font-variant-alternates:normal;font-variant-position:normal;font-variant-emoji:normal}";
+  (* [none] is the whole value, so it has no spelling beside another
+     component. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{font-variant-ligatures:none;font-variant-numeric:normal;font-variant-east-asian:normal;font-variant-caps:small-caps;font-variant-alternates:normal;font-variant-position:normal;font-variant-emoji:normal}"
+    ".x{font-variant-ligatures:none;font-variant-numeric:normal;font-variant-east-asian:normal;font-variant-caps:small-caps;font-variant-alternates:normal;font-variant-position:normal;font-variant-emoji:normal}";
+  (* A CSS-wide keyword is no component, and a run missing one of the seven is
+     not the same declaration. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variant-caps:inherit;font-variant-alternates:normal;font-variant-position:normal;font-variant-emoji:normal}"
+    ".x{font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variant-caps:inherit;font-variant-alternates:normal;font-variant-position:normal;font-variant-emoji:normal}";
+  sheet_optimizes_to
+    ~into:
+      ".x{font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variant-caps:small-caps;font-variant-position:normal;font-variant-emoji:normal}"
+    ".x{font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variant-caps:small-caps;font-variant-position:normal;font-variant-emoji:normal}"
+
 (* CSS Grid 2 (ED) sec. 7.8: [grid] writes the three template longhands and the
    three auto ones, and only one of its two auto-flow axes can be spelled, so
    the other axis and its track size have to be at the initials the shorthand
@@ -1838,6 +1867,8 @@ let suite =
         test_font_synthesis_composes;
       Alcotest.test_case "webkit text stroke composes" `Quick
         test_webkit_text_stroke_composes;
+      Alcotest.test_case "font-variant composes" `Quick
+        test_font_variant_composes;
       Alcotest.test_case "grid composes" `Quick test_grid_composes;
       Alcotest.test_case "grid-template composes" `Quick
         test_grid_template_composes;


### PR DESCRIPTION
The shorthand was carried as opaque text, so it accepted a component written twice over (`small-caps unicase`, `jis78 jis83`) and the seven longhands written out never met it under `--diff=canonical`. This PR adds `Css.Properties.Font_variant`, reads CSS Fonts 4 sec. 6.10, and contracts the run into the shorthand.