### PR TITLE
values: keep a negative calc's call where the range starts at zero

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -413,6 +413,14 @@ to lose a whole rule over one bad piece. Both are gone.
   `column-wrap`. `border-image-outset` and `border-image-width` reject a keyword
   their grammar does not carry (#926, #927, #928, #936, #938, #941)
 
+- A `calc()` whose result falls below zero keeps its call on a property whose
+  range starts there. CSS Values 4 sec. 10.3 keeps such a call valid and clamps
+  at used-value time, so `width: calc(-10px)` computes to `0px` where
+  `width: -10px` is dropped, and folding the call away turned a working
+  declaration into one browsers throw out. `width: calc(10px * sign(-1vw))` was
+  the case that read back as nothing at all. A property that takes a negative
+  folds as before (#967)
+
 - A value keeps every digit and every unit the author wrote unless the shorter
   spelling means the same number. `.4285714em` came out short, `calc(hypot(1px,
   1px))` came out as `1.41421356`, and a computed dimension past a million units

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -201,9 +201,9 @@ let normalize_box_shorthand ~is_substitution f vs =
   if List.exists is_substitution normalized then normalized
   else collapse_box_shorthand normalized
 
-let normalize_length_box ~ctx =
+let normalize_length_box ?(non_negative = false) ~ctx =
   normalize_box_shorthand ~is_substitution:is_length_substitution
-    (Values.normalize_length ~ctx)
+    (Values.normalize_length ~non_negative ~ctx)
 
 let option_map_preserve f opt =
   match opt with

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4333,19 +4333,30 @@ let normalize_property_value : type a.
   | Offset_position -> normalize_offset_position value
   | Offset_rotate -> normalize_offset_rotate value
   | Font_style -> normalize_font_style value
-  | Width -> Values.normalize_length_percentage ~ctx value
-  | Height -> Values.normalize_length_percentage ~ctx value
-  | Min_width -> Values.normalize_length_percentage ~ctx value
-  | Min_height -> Values.normalize_length_percentage ~ctx value
-  | Min_inline_size -> Values.normalize_length_percentage ~ctx value
-  | Min_block_size -> Values.normalize_length_percentage ~ctx value
-  | Max_width -> Values.normalize_length_percentage ~ctx value
-  | Max_height -> Values.normalize_length_percentage ~ctx value
-  | Inline_size -> Values.normalize_length_percentage ~ctx value
-  | Max_inline_size -> Values.normalize_length_percentage ~ctx value
-  | Block_size -> Values.normalize_length_percentage ~ctx value
-  | Max_block_size -> Values.normalize_length_percentage ~ctx value
-  | Shape_margin -> Values.normalize_length_percentage ~ctx value
+  | Width -> Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Height -> Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Min_width ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Min_height ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Min_inline_size ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Min_block_size ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Max_width ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Max_height ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Inline_size ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Max_inline_size ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Block_size ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Max_block_size ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
+  | Shape_margin ->
+      Values.normalize_length_percentage ~non_negative:true ~ctx value
   | Offset_distance -> Values.normalize_length_percentage ~ctx value
   | Border_radius -> normalize_border_radius value
   | Background_image ->
@@ -4474,14 +4485,15 @@ let normalize_property_value : type a.
   | Webkit_animation -> map_preserve normalize_animation value
   | Moz_animation -> map_preserve normalize_animation value
   | Animation_timing_function -> normalize_timing_function value
-  | Padding_left -> Values.normalize_length ~ctx value
-  | Padding_right -> Values.normalize_length ~ctx value
-  | Padding_bottom -> Values.normalize_length ~ctx value
-  | Padding_top -> Values.normalize_length ~ctx value
-  | Padding_inline_start -> Values.normalize_length ~ctx value
-  | Padding_inline_end -> Values.normalize_length ~ctx value
-  | Padding_block_start -> Values.normalize_length ~ctx value
-  | Padding_block_end -> Values.normalize_length ~ctx value
+  | Padding_left -> Values.normalize_length ~non_negative:true ~ctx value
+  | Padding_right -> Values.normalize_length ~non_negative:true ~ctx value
+  | Padding_bottom -> Values.normalize_length ~non_negative:true ~ctx value
+  | Padding_top -> Values.normalize_length ~non_negative:true ~ctx value
+  | Padding_inline_start ->
+      Values.normalize_length ~non_negative:true ~ctx value
+  | Padding_inline_end -> Values.normalize_length ~non_negative:true ~ctx value
+  | Padding_block_start -> Values.normalize_length ~non_negative:true ~ctx value
+  | Padding_block_end -> Values.normalize_length ~non_negative:true ~ctx value
   | Margin_inline_end -> Values.normalize_length ~ctx value
   | Margin_inline_start -> Values.normalize_length ~ctx value
   | Margin_left -> Values.normalize_length ~ctx value
@@ -4490,22 +4502,28 @@ let normalize_property_value : type a.
   | Margin_bottom -> Values.normalize_length ~ctx value
   | Margin_block_start -> Values.normalize_length ~ctx value
   | Margin_block_end -> Values.normalize_length ~ctx value
-  | Column_gap -> Values.normalize_length ~ctx value
-  | Row_gap -> Values.normalize_length ~ctx value
+  | Column_gap -> Values.normalize_length ~non_negative:true ~ctx value
+  | Row_gap -> Values.normalize_length ~non_negative:true ~ctx value
   | Text_underline_offset -> Values.normalize_length ~ctx value
   | Letter_spacing -> Values.normalize_length ~ctx value
-  | Border_top_left_radius -> normalize_length_box ~ctx value
-  | Border_top_right_radius -> normalize_length_box ~ctx value
-  | Border_bottom_left_radius -> normalize_length_box ~ctx value
-  | Border_bottom_right_radius -> normalize_length_box ~ctx value
-  | Border_start_start_radius -> normalize_length_box ~ctx value
-  | Border_start_end_radius -> normalize_length_box ~ctx value
-  | Border_end_start_radius -> normalize_length_box ~ctx value
-  | Border_end_end_radius -> normalize_length_box ~ctx value
+  | Border_top_left_radius -> normalize_length_box ~non_negative:true ~ctx value
+  | Border_top_right_radius ->
+      normalize_length_box ~non_negative:true ~ctx value
+  | Border_bottom_left_radius ->
+      normalize_length_box ~non_negative:true ~ctx value
+  | Border_bottom_right_radius ->
+      normalize_length_box ~non_negative:true ~ctx value
+  | Border_start_start_radius ->
+      normalize_length_box ~non_negative:true ~ctx value
+  | Border_start_end_radius ->
+      normalize_length_box ~non_negative:true ~ctx value
+  | Border_end_start_radius ->
+      normalize_length_box ~non_negative:true ~ctx value
+  | Border_end_end_radius -> normalize_length_box ~non_negative:true ~ctx value
   | Outline_width -> normalize_border_width value
   | Outline_offset -> Values.normalize_length ~ctx value
-  | Line_height_step -> Values.normalize_length ~ctx value
-  | Perspective -> Values.normalize_length ~ctx value
+  | Line_height_step -> Values.normalize_length ~non_negative:true ~ctx value
+  | Perspective -> Values.normalize_length ~non_negative:true ~ctx value
   | Word_spacing -> Values.normalize_length ~ctx value
   | Text_decoration_thickness -> Values.normalize_length ~ctx value
   | Stroke_width -> normalize_stroke_width ~ctx value
@@ -4517,17 +4535,23 @@ let normalize_property_value : type a.
   | Scroll_margin_inline_end -> Values.normalize_length ~ctx value
   | Scroll_margin_block_start -> Values.normalize_length ~ctx value
   | Scroll_margin_block_end -> Values.normalize_length ~ctx value
-  | Scroll_padding_top -> Values.normalize_length ~ctx value
-  | Scroll_padding_right -> Values.normalize_length ~ctx value
-  | Scroll_padding_bottom -> Values.normalize_length ~ctx value
-  | Scroll_padding_left -> Values.normalize_length ~ctx value
-  | Scroll_padding_inline_start -> Values.normalize_length ~ctx value
-  | Scroll_padding_inline_end -> Values.normalize_length ~ctx value
-  | Scroll_padding_block_start -> Values.normalize_length ~ctx value
-  | Scroll_padding_block_end -> Values.normalize_length ~ctx value
-  | Padding -> normalize_length_box ~ctx value
-  | Padding_inline -> normalize_length_box ~ctx value
-  | Padding_block -> normalize_length_box ~ctx value
+  | Scroll_padding_top -> Values.normalize_length ~non_negative:true ~ctx value
+  | Scroll_padding_right ->
+      Values.normalize_length ~non_negative:true ~ctx value
+  | Scroll_padding_bottom ->
+      Values.normalize_length ~non_negative:true ~ctx value
+  | Scroll_padding_left -> Values.normalize_length ~non_negative:true ~ctx value
+  | Scroll_padding_inline_start ->
+      Values.normalize_length ~non_negative:true ~ctx value
+  | Scroll_padding_inline_end ->
+      Values.normalize_length ~non_negative:true ~ctx value
+  | Scroll_padding_block_start ->
+      Values.normalize_length ~non_negative:true ~ctx value
+  | Scroll_padding_block_end ->
+      Values.normalize_length ~non_negative:true ~ctx value
+  | Padding -> normalize_length_box ~non_negative:true ~ctx value
+  | Padding_inline -> normalize_length_box ~non_negative:true ~ctx value
+  | Padding_block -> normalize_length_box ~non_negative:true ~ctx value
   | Margin -> normalize_length_box ~ctx value
   | Margin_inline -> normalize_length_box ~ctx value
   | Margin_block -> normalize_length_box ~ctx value

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1299,15 +1299,73 @@ let eval_typed_calc : type a.
   in
   normalize_calc_parens (settle_computed round (reduce calc))
 
-let pp_calc_with : type a. ?unwrap_num:bool -> a Pp.t -> a calc Pp.t =
- fun ?(unwrap_num = true) pp_value ctx calc ->
+(* A dimension the author could not have written as a literal. CSS Values 4 sec.
+   10.3 keeps a [calc()] valid wherever its range is exceeded and clamps at
+   used-value time, so [width: calc(-10px)] is a declaration Chrome computes as
+   [0px] while [width: -10px] is one it drops. Folding the call away on such a
+   property has to stop at the sign. *)
+let negative_length : length -> bool = function
+  | Px f
+  | Cm f
+  | Mm f
+  | Q f
+  | In f
+  | Pt f
+  | Pc f
+  | Rem f
+  | Em f
+  | Ex f
+  | Cap f
+  | Ic f
+  | Ric f
+  | Rlh f
+  | Pct f
+  | Vw f
+  | Vh f
+  | Vmin f
+  | Vmax f
+  | Vi f
+  | Vb f
+  | Dvh f
+  | Dvw f
+  | Dvmin f
+  | Dvmax f
+  | Lvh f
+  | Lvw f
+  | Lvmin f
+  | Lvmax f
+  | Svh f
+  | Svw f
+  | Svmin f
+  | Svmax f
+  | Cqw f
+  | Cqh f
+  | Cqi f
+  | Cqb f
+  | Cqmin f
+  | Cqmax f
+  | Ch f
+  | Lh f
+  | Dimension { value = f; _ } ->
+      f < 0.
+  | _ -> false
+
+let pp_calc_with : type a.
+    ?unwrap_num:bool -> ?unwrap:(a -> bool) -> a Pp.t -> a calc Pp.t =
+ fun ?(unwrap_num = true) ?(unwrap = fun _ -> true) pp_value ctx calc ->
   match calc with
   (* CSS Values 4 sec. 10.10: a [var()] inside [calc()] is a runtime
      substitution boundary - the substituted tokens go through calc's typed
      grammar, not the surrounding property's grammar. Unwrapping
      [calc(var(--x))] to bare [var(--x)] would change which substitution shape
      is valid. *)
-  | Val v when Pp.minified ctx -> pp_value ctx v
+  (* CSS Values 4 sec. 10.3 keeps a [calc()] valid where its range is exceeded
+     and clamps at used-value time, so [width: calc(-10px)] is a declaration
+     Chrome computes as [0px] and [width: -10px] one it drops. Which properties
+     those are is not knowable here, so the wrapper stays on a value that reads
+     back differently without it; [Declaration.normalize] unwraps the rest,
+     where the property is in hand. *)
+  | Val v when Pp.minified ctx && unwrap v -> pp_value ctx v
   | Num n when Pp.minified ctx && unwrap_num -> Pp.float ctx n
   | _ ->
       let ctx = { ctx with in_calc = true } in
@@ -2394,7 +2452,9 @@ and pp_generic_length_calc ~always ctx cv =
       pp_calc_wrapped_length ~always ctx length
   | _ ->
       let always = always || calc_contains_var cv in
-      pp_calc_with ~unwrap_num:false (pp_length ~always) ctx cv
+      pp_calc_with ~unwrap_num:false
+        ~unwrap:(fun v -> not (negative_length v))
+        (pp_length ~always) ctx cv
 
 let pp_color_name : color_name Pp.t =
  fun ctx name -> Pp.string ctx (fst (color_name_hex name))
@@ -3742,8 +3802,8 @@ let strip_zero_length (l : length) : length =
 
 (* [strip] is true for a top-level [<length>] (a direct property/shorthand
    value) and false for a calc / math-function operand, which keeps its unit. *)
-let rec normalize_length ?(strip = true) ?(ctx = default_calc_ctx) (l : length)
-    : length =
+let rec normalize_length ?(strip = true) ?(non_negative = false)
+    ?(ctx = default_calc_ctx) (l : length) : length =
   let nf = normalize_length ~strip:false ~ctx in
   let result =
     match l with
@@ -3752,6 +3812,7 @@ let rec normalize_length ?(strip = true) ?(ctx = default_calc_ctx) (l : length)
           cv |> eval_length_calc ~ctx |> linear_length_calc
           |> eval_length_calc ~ctx
         with
+        | Val v when non_negative && negative_length v -> l
         | Val v -> v
         | folded -> Calc folded)
     | Clamp (mn, v, mx) -> (
@@ -3818,15 +3879,16 @@ let rec normalize_length ?(strip = true) ?(ctx = default_calc_ctx) (l : length)
 (* Fold the numeric parts of a length-percentage [calc()], keeping any [var()]:
    [calc(var(--x) + 1px + 2px)] -> [calc(var(--x) + 3px)], [calc(1px + 2px)] ->
    [3px]. A wrapped [<length>] folds its own math functions. *)
-let normalize_length_percentage ?(strip = true) ?(ctx = default_calc_ctx)
-    (lp : length_percentage) : length_percentage =
+let normalize_length_percentage ?(strip = true) ?(non_negative = false)
+    ?(ctx = default_calc_ctx) (lp : length_percentage) : length_percentage =
   match lp with
   | Calc c -> (
       match c |> eval_lp_calc ~ctx |> linear_lp_calc |> eval_lp_calc ~ctx with
+      | Val (Length v) when non_negative && negative_length v -> lp
       | Val v -> v
       | folded -> Calc folded)
   | Length l ->
-      let l' = normalize_length ~strip ~ctx l in
+      let l' = normalize_length ~strip ~non_negative ~ctx l in
       if l' == l then lp else Length l'
   | _ -> lp
 
@@ -4179,7 +4241,14 @@ let rec pp_length_percentage ?(always = false) : length_percentage Pp.t =
       (* Inline mode substitutes a [var()]'s default value into the calc. *)
       let c = if Pp.minified ctx then resolve_lp_calc_vars ctx c else c in
       let always = always || calc_contains_var c in
-      pp_calc_with ~unwrap_num:false (pp_length_percentage ~always) ctx c
+      pp_calc_with ~unwrap_num:false
+        ~unwrap:(fun v ->
+          match (v : length_percentage) with
+          | Length l -> not (negative_length l)
+          | Pct f -> f >= 0.
+          | _ -> true)
+        (pp_length_percentage ~always)
+        ctx c
   | Invalid tokens ->
       Pp.string ctx
         (if Pp.minified ctx then Parser.to_string_minified tokens

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -258,14 +258,21 @@ val default_calc_ctx : calc_ctx
     context-dependent calc rewrite is a no-op. *)
 
 val normalize_length_percentage :
-  ?strip:bool -> ?ctx:calc_ctx -> length_percentage -> length_percentage
+  ?strip:bool ->
+  ?non_negative:bool ->
+  ?ctx:calc_ctx ->
+  length_percentage ->
+  length_percentage
 (** [normalize_length_percentage lp] folds the numeric parts of a [calc()],
     keeping any [var()]: [calc(var(--x) + 1px + 2px)] becomes
     [calc(var(--x) + 3px)], and [calc(1px + 2px)] becomes [3px]. [strip]
     (default [true]) also drops a wrapped zero length's unit; pass [strip:false]
-    for CSS function operands. *)
+    for CSS function operands. [non_negative] keeps the call when the fold lands
+    below zero, which a property whose range starts there reads back and a
+    literal of the same value does not (CSS Values 4 sec. 10.3). *)
 
-val normalize_length : ?strip:bool -> ?ctx:calc_ctx -> length -> length
+val normalize_length :
+  ?strip:bool -> ?non_negative:bool -> ?ctx:calc_ctx -> length -> length
 (** [normalize_length ?strip l] evaluates the static CSS math functions on a
     [<length>] (min / max / clamp reduce to one dimension on shared units; round
     / mod / rem / hypot / abs fold on {!Calc.px}; calc folds through the

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1719,6 +1719,44 @@ let mask_drained_layer () =
     ~optimized:"-webkit-mask:url(a.png),none;mask:url(a.png),none"
     "mask: url(a.png), none"
 
+(* CSS Values 4 (ED) sec. 10.3 keeps a [calc()] valid where its range is
+   exceeded and clamps at used-value time, so a property whose range starts at
+   zero reads [calc(-10px)] and drops [-10px]. Chrome 146 computes the first as
+   [0px] and drops the second, so the call stays on and folding it away would
+   write a declaration browsers throw out. A property that takes a negative
+   folds as before. *)
+let negative_calc_keeps_the_call () =
+  List.iter
+    (fun prop ->
+      check_declaration ~expected:(prop ^ ":calc(-10px)")
+        ~optimized:(prop ^ ":calc(-10px)") (prop ^ ": calc(-10px)"))
+    [
+      "width";
+      "height";
+      "min-width";
+      "max-width";
+      "inline-size";
+      "padding-left";
+      "padding-inline-start";
+      "column-gap";
+      "row-gap";
+      "perspective";
+      "scroll-padding-top";
+      "border-top-left-radius";
+    ];
+  List.iter
+    (fun prop ->
+      check_declaration ~expected:(prop ^ ":calc(-10px)")
+        ~optimized:(prop ^ ":-10px") (prop ^ ": calc(-10px)"))
+    [ "margin-left"; "top"; "text-decoration-thickness"; "outline-offset" ];
+  (* A fold that stays in range is unaffected. *)
+  check_declaration ~expected:"width:calc(1px + 2px)" ~optimized:"width:3px"
+    "width: calc(1px + 2px)";
+  (* The record this was found on: the sign is known but the result is not a
+     length any of these properties reads as a literal. *)
+  check_declaration ~expected:"width:calc(10px*sign(-1vw))"
+    ~optimized:"width:calc(10px*sign(-1vw))" "width: calc(10px * sign(-1vw))"
+
 (* CSS Backgrounds 3 (ED) sec. 2.10 resets every longhand the shorthand covers,
    so a layer that fills no slot declares what [background: none] declares. [0
    0] is the shortest spelling of that layer, so it is the node the spellings
@@ -5293,20 +5331,25 @@ let check_sheet_roundtrip name css =
    components with [||], so no single component is mandatory. *)
 let text_decoration_thickness_range () =
   (* CSS Text Decoration 4 section 2.4: <length-percentage> has no non-negative
-     grammar range. The minimum device-pixel thickness is a rendering rule. *)
+     grammar range. The minimum device-pixel thickness is a rendering rule.
+     Unwrapping a negative [calc()] is the optimizer's to make and not the
+     printer's: which properties read the bare value back is a fact about the
+     property, so the two spellings differ in the held form and meet in the
+     optimised one. *)
   List.iter
-    (fun (value, printed) ->
+    (fun (value, printed, optimized) ->
       check_declaration ~roundtrip:true
         ~expected:("text-decoration-thickness:" ^ printed)
+        ~optimized:("text-decoration-thickness:" ^ optimized)
         ("text-decoration-thickness:" ^ value))
     [
-      ("-1px", "-1px");
-      ("-10%", "-10%");
-      ("-.25em", "-.25em");
-      ("calc(-1px)", "-1px");
-      ("calc(-10%)", "-10%");
-      ("calc(2px - 3px)", "calc(2px - 3px)");
-      ("min(-1px,2px)", "min(-1px,2px)");
+      ("-1px", "-1px", "-1px");
+      ("-10%", "-10%", "-10%");
+      ("-.25em", "-.25em", "-.25em");
+      ("calc(-1px)", "calc(-1px)", "-1px");
+      ("calc(-10%)", "calc(-10%)", "-10%");
+      ("calc(2px - 3px)", "calc(2px - 3px)", "-1px");
+      ("min(-1px,2px)", "min(-1px,2px)", "-1px");
     ];
   check_declaration ~roundtrip:true "text-decoration:underline -1px";
   none_cursor read_declaration "text-decoration-thickness:-1s"
@@ -6428,6 +6471,7 @@ let declaration_tests =
       component_var_keeps_typed_value;
     test_case "border-spacing pair" `Quick border_spacing_pair;
     test_case "background repeat axes" `Quick background_repeat_axes;
+    test_case "negative calc keeps the call" `Quick negative_calc_keeps_the_call;
     test_case "mask drained layer" `Quick mask_drained_layer;
     test_case "background drained layer" `Quick background_drained_layer;
     test_case "border line-color" `Quick border_line_color;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -6350,9 +6350,18 @@ let v4102_calc_single () =
   Alcotest.(check string)
     "calc(1px) -> 1px" ".x{width:1px}"
     (normalize ".x { width: calc(1px) }");
+  (* CSS Values 4 (ED) sec. 10.3 keeps a [calc()] valid where the property's
+     range is exceeded and clamps at used-value time, so [width: calc(-5px)]
+     computes to [0px] in Chrome 146 and [width: -5px] is dropped there. The
+     call stays on where the range starts at zero and folds where it does
+     not. *)
   Alcotest.(check string)
-    "calc(-5px) -> -5px" ".x{width:-5px}"
+    "calc(-5px) on a non-negative property keeps the call"
+    ".x{width:calc(-5px)}"
     (normalize ".x { width: calc(-5px) }");
+  Alcotest.(check string)
+    "calc(-5px) -> -5px" ".x{margin-left:-5px}"
+    (normalize ".x { margin-left: calc(-5px) }");
   Alcotest.(check string)
     "calc(1) -> 1" ".x{aspect-ratio:1}"
     (normalize ".x { aspect-ratio: calc(1) }")


### PR DESCRIPTION
CSS Values 4 sec. 10.3 keeps a `calc()` valid past the property's range and clamps at used-value time, so Chrome computes `width: calc(-10px)` as `0px` and drops `width: -10px`. Cascade folded the call to the literal on seventeen properties whose range starts at zero, turning a working declaration into one browsers throw out; `width: calc(10px * sign(-1vw))` was the lightning record that read back as nothing at all.

The printer cannot know which property it is serialising for, so it stops at the sign and `Declaration.normalize` folds the rest, where the property is in hand. A property that takes a negative is unaffected.