### PR TITLE
shorthand: give each border-image longhand its own held slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -401,6 +401,11 @@ to lose a whole rule over one bad piece. Both are gone.
   it already wrote, so the whole border family written out minifies to
   `border: 1px solid red` alone (#956)
 
+- `--minify` no longer loses a `border-image` a neighbouring rule set when the
+  border longhands contract. The family shared one slot in the hazard model, so
+  a rule holding the slice answered for a neighbour holding the source and the
+  picture went missing from the output (#968)
+
 - `--minify` no longer contracts a run of longhands one of which is `inherit`,
   `unset`, `revert` or `revert-layer`. A CSS-wide keyword is a whole
   declaration value, so pasting one into a shorthand made a declaration every

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -4927,18 +4927,28 @@ let all_an_bits = an_bits an_slots
    transition and animation sets. *)
 let td_thickness_bit = 16384
 
-(* CSS Backgrounds 3 sec. 3.4: [border] resets the whole [border-image] family
-   as well, so that family needs one bit of its own beside the others. *)
-let border_image_bit = 32768
+(* CSS Backgrounds 3 sec. 3.4: [border] resets the whole [border-image] family,
+   and each longhand of it gets a bit rather than the family sharing one: a rule
+   holding the slice says nothing about a neighbour holding the source, and one
+   bit makes the first cancel the second in [held_outside]. *)
+let bi_source_bit = 1 lsl 18
+let bi_slice_bit = 1 lsl 19
+let bi_width_bit = 1 lsl 20
+let bi_outset_bit = 1 lsl 21
+let bi_repeat_bit = 1 lsl 22
+
+let border_image_bit =
+  bi_source_bit lor bi_slice_bit lor bi_width_bit lor bi_outset_bit
+  lor bi_repeat_bit
 
 let bi_overwritten_slots d =
   match unwrap_theme_guard d with
+  | Declaration { property = Border_image_source; _ } -> bi_source_bit
+  | Declaration { property = Border_image_slice; _ } -> bi_slice_bit
+  | Declaration { property = Border_image_width; _ } -> bi_width_bit
+  | Declaration { property = Border_image_outset; _ } -> bi_outset_bit
+  | Declaration { property = Border_image_repeat; _ } -> bi_repeat_bit
   | Declaration { property = Border_image; _ }
-  | Declaration { property = Border_image_source; _ }
-  | Declaration { property = Border_image_slice; _ }
-  | Declaration { property = Border_image_width; _ }
-  | Declaration { property = Border_image_outset; _ }
-  | Declaration { property = Border_image_repeat; _ }
   | Declaration { property = Border; _ } ->
       border_image_bit
   | Declaration { property = All; value = Initial | Unset; _ } -> 0

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -1376,6 +1376,31 @@ let test_transition_contraction_covers_other_rules () =
       ".b{transition-behavior:normal}.a{transition-property:color;transition-duration:1s}"
     ".b{transition-behavior:normal}.a{transition-property:color;transition-duration:1s}"
 
+(* CSS Backgrounds 3 (ED) sec. 3.4: [border] resets the whole border-image
+   family, so a neighbour holding one of those longhands is at risk from a
+   contraction that does not carry it. The family shares no single slot: a rule
+   holding the slice says nothing about the neighbour holding the source, and
+   answering for the two together let the source through. Chrome 146 computes
+   the image on both sides of each pair below. *)
+let test_border_image_held_across_rules () =
+  (* The run holds the slice and the repeat itself; the source next door is the
+     one the contraction would reset, so the shorthand goes in front of the
+     whole family and the reset is overridden. *)
+  sheet_optimizes_to
+    ~into:
+      ".x{border:4px \
+       solid#0000;border-image-source:url(b.png);border-image-slice:30;border-image-repeat:round}"
+    ".x{border-image-source:url(b.png)}.x{border-image-slice:30;border-image-repeat:round;border-width:4px;border-style:solid;border-color:transparent}";
+  (* The same run with nothing of its own to hold. *)
+  sheet_optimizes_to
+    ~into:".x{border:4px solid#0000;border-image-source:url(b.png)}"
+    ".x{border-image-source:url(b.png)}.x{border-width:4px;border-style:solid;border-color:transparent}";
+  (* A neighbour that cannot be reordered into place keeps the run expanded. *)
+  sheet_optimizes_to
+    ~into:
+      ".y{border-image-source:url(b.png)}.x{border-width:4px;border-style:solid;border-color:#0000}"
+    ".y{border-image-source:url(b.png)}.x{border-width:4px;border-style:solid;border-color:transparent}"
+
 let test_drop_redundant_border_longhand () =
   (* [border] sets width/style/color; a later longhand equal to an explicit slot
      is dropped. A differing value or a per-side list is kept. *)
@@ -1935,6 +1960,8 @@ let suite =
         test_mask_full_run_composes;
       Alcotest.test_case "border contraction covers border-image" `Quick
         test_border_contraction_covers_border_image;
+      Alcotest.test_case "border-image held across rules" `Quick
+        test_border_image_held_across_rules;
       Alcotest.test_case "drop redundant border longhand" `Quick
         test_drop_redundant_border_longhand;
       Alcotest.test_case "drop redundant font longhand" `Quick


### PR DESCRIPTION
The border-image family shared one slot in the contraction hazard model, so a rule holding the slice answered for a neighbour holding the source. Contracting the border longhands then reset a picture nothing wrote back, and the minified sheet rendered without it. The `canonical_agree` oracle reported the pair as a conflation; it is now at zero.