### PR TITLE
test: read a changed value in the report's own spelling

### DIFF
--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2395,6 +2395,12 @@ val read_font_variant_ligatures : Cursor.t -> font_variant_ligatures
 (** [read_font_variant_ligatures t] is the [font_variant_ligatures] parsed from
     [t]. *)
 
+val pp_font_variant : font_variant Pp.t
+(** [pp_font_variant] prints the [font-variant] shorthand. *)
+
+val pp_font_variant_alternates : font_variant_alternates Pp.t
+(** [pp_font_variant_alternates] prints [font-variant-alternates]. *)
+
 val pp_font_variant_caps : font_variant_caps Pp.t
 (** [pp_font_variant_caps] is the pretty-printer for [font_variant_caps]. *)
 

--- a/scripts/check_api_consistency.ml
+++ b/scripts/check_api_consistency.ml
@@ -39,6 +39,13 @@ let ignored_types =
     "colon_form";
     "vt_class_selector";
     "url_form";
+    "font_variant_shorthand";
+    "font_variant_alternates_item";
+    "position_axis_edge";
+    "background_position_axis";
+    (* Slots of the value that owns them: the [font-variant] record and one of
+       its alternate components, and the axis and edge a [<position>] writes.
+       Each is read through its owner's reader, never on its own. *)
     (* Serialization metadata, not standalone CSS syntax. *)
     "custom_value";
     (* Token-stream custom properties are parsed through declarations and

--- a/test/diff_report/diff_report.ml
+++ b/test/diff_report/diff_report.ml
@@ -1770,7 +1770,11 @@ let text_cases =
       after = "@keyframes fade{0%{opacity:0.7}100%{opacity:1}}";
       names = [ "0%" ];
       under = [ "@keyframes fade" ];
-      holds = Some ("0%", "opacity", "0", "0.7");
+      (* The report spells a value the way cascade prints it, which for a
+         fractional number is CSS Values 4 sec. 6.7.2 without the leading zero.
+         No raw token text is kept anywhere in the AST, so the digits the file
+         holds are not cascade's to echo; [.7] and [0.7] are one value. *)
+      holds = Some ("0%", "opacity", "0", ".7");
     };
     {
       case = "keyframe-added";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -851,6 +851,27 @@ let check_font_synthesis_weight =
   check_value_cursor "font_synthesis_weight" read_font_synthesis_weight
     pp_font_synthesis_weight
 
+let check_font_variant =
+  check_value_cursor "font_variant" read_font_variant pp_font_variant
+
+let check_font_variant_alternates =
+  check_value_cursor "font_variant_alternates" read_font_variant_alternates
+    pp_font_variant_alternates
+
+let check_white_space_collapse =
+  check_value_cursor "white_space_collapse" read_white_space_collapse
+    pp_white_space_collapse
+
+let check_column_height =
+  check_value_cursor "column_height" read_column_height pp_column_height
+
+let check_column_wrap =
+  check_value_cursor "column_wrap" read_column_wrap pp_column_wrap
+
+let check_webkit_text_stroke =
+  check_value_cursor "webkit_text_stroke" read_webkit_text_stroke
+    pp_webkit_text_stroke
+
 let check_font_variant_caps =
   check_value_cursor "font_variant_caps" read_font_variant_caps
     pp_font_variant_caps
@@ -4798,6 +4819,14 @@ let spec_generated_animation_font_edges () =
   check_font_synthesis_small_caps "auto";
   check_font_synthesis_style "oblique-only";
   check_font_synthesis_weight "auto";
+  check_font_variant "small-caps";
+  check_font_variant "common-ligatures small-caps tabular-nums";
+  check_font_variant_alternates "swash(fancy)";
+  check_font_variant_alternates "styleset(a,b) historical-forms";
+  check_white_space_collapse "preserve-breaks";
+  check_column_height "10em";
+  check_column_wrap "wrap";
+  check_webkit_text_stroke "1px red";
   check_font_variant_caps "small-caps";
   check_font_variant_east_asian "jis78 ruby";
   check_east_asian_feature "jis04";

--- a/test/test_values.ml
+++ b/test/test_values.ml
@@ -8,7 +8,9 @@ open Css_test_helpers
 (* One-liner check functions for each CSS value type *)
 let check_length = check_value_cursor "length" read_length pp_length
 
-let check_sizing =
+(* Not a [check_<type>]: the sizing keywords are lengths, read through the same
+   [length] parser with its own grammar switch on. *)
+let length_with_sizing =
   check_value_cursor "length" (read_length ~sizing:true) pp_length
 
 (* Always assert both paths. pp serializes the parsed colour ([expected], held);
@@ -113,18 +115,18 @@ let test_length () =
   (* CSS Sizing 3 sec. 5 gives the intrinsic sizes to the sizing properties, so
      the reader takes them only where the property does and the default refuses
      them. *)
-  check_sizing "max-content";
-  check_sizing "min-content";
-  check_sizing "fit-content";
+  length_with_sizing "max-content";
+  length_with_sizing "min-content";
+  length_with_sizing "fit-content";
   (* Legacy vendor-prefixed intrinsic sizing keywords (Bootstrap,
      Fontsource). *)
-  check_sizing "-webkit-max-content";
-  check_sizing "-webkit-min-content";
-  check_sizing "-webkit-fit-content";
-  check_sizing "-moz-max-content";
-  check_sizing "-moz-min-content";
-  check_sizing "-moz-fit-content";
-  check_sizing "from-font";
+  length_with_sizing "-webkit-max-content";
+  length_with_sizing "-webkit-min-content";
+  length_with_sizing "-webkit-fit-content";
+  length_with_sizing "-moz-max-content";
+  length_with_sizing "-moz-min-content";
+  length_with_sizing "-moz-fit-content";
+  length_with_sizing "from-font";
   List.iter
     (fun keyword ->
       neg_cursor (fun t -> ignore (read_length t : Css.Values.length)) keyword)


### PR DESCRIPTION
Two corrections the suite was reporting.

`cascade diff` names a changed value in cascade's own spelling, so `opacity: 0.7` reads as `.7`. No raw token text is kept anywhere in the AST, and a fractional number prints without its leading zero in both modes (CSS Values 4 sec. 6.7.2), so the digits the file holds are not cascade's to echo; the two spell one value.

The API consistency check also passes again: six typed properties this release adds reached the public interface without the printer, the value checker or the test the script asks of each type, and four slot types were being read as standalone grammars they are not.