### PR TITLE
values: read a string the input ended as the string it is

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -281,16 +281,19 @@ to lose a whole rule over one bad piece. Both are gone.
   constructed declaration and a parsed one compare and hash equally (#478,
   #485, #495, #651, #652, #653, #654, #657, #674, #683, #888)
 
+- `border-image` compares a slice against its initial without a polymorphic
+  equality, which walked another module's representation (#935)
+
 - A value the input ended in the middle of a string keeps its declaration. CSS
   Syntax 3 sec. 4.3.5 ends a string at EOF as the string it read and only a
   newline makes a `<bad-string-token>`, which sec. 7.2 excludes; cascade treated
   the two alike and dropped the rule, and printed the value back without its
-  closing quote so the rest of the sheet was swallowed (#NNN)
+  closing quote so the rest of the sheet was swallowed (#972)
 
 - The `@font-face` `src` descriptor reads an empty `url()` and drops only the
   item it cannot read. CSS Fonts 4 sec. 4.3.1 leaves an unusable reference to
   loading and keeps the descriptor while any item parses, so a trailing comma
-  and an unreadable neighbour no longer cost the whole font (#NNN)
+  and an unreadable neighbour no longer cost the whole font (#972)
 
 - A bad piece is dropped on its own and the rule around it survives. A nested
   rule, a descriptor, a stray `;`, a margin at-rule, an `@counter-style` with no

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -281,6 +281,17 @@ to lose a whole rule over one bad piece. Both are gone.
   constructed declaration and a parsed one compare and hash equally (#478,
   #485, #495, #651, #652, #653, #654, #657, #674, #683, #888)
 
+- A value the input ended in the middle of a string keeps its declaration. CSS
+  Syntax 3 sec. 4.3.5 ends a string at EOF as the string it read and only a
+  newline makes a `<bad-string-token>`, which sec. 7.2 excludes; cascade treated
+  the two alike and dropped the rule, and printed the value back without its
+  closing quote so the rest of the sheet was swallowed (#NNN)
+
+- The `@font-face` `src` descriptor reads an empty `url()` and drops only the
+  item it cannot read. CSS Fonts 4 sec. 4.3.1 leaves an unusable reference to
+  loading and keeps the descriptor while any item parses, so a trailing comma
+  and an unreadable neighbour no longer cost the whole font (#NNN)
+
 - A bad piece is dropped on its own and the rule around it survives. A nested
   rule, a descriptor, a stray `;`, a margin at-rule, an `@counter-style` with no
   descriptor, an `@media` condition, an `@font-face` descriptor name, an

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -378,13 +378,19 @@ let source_slice t loc =
       then None
       else Some (String.sub source loc.start_pos (loc.end_pos - loc.start_pos))
 
+(* The slice is the author's own bytes, which is what a caller keeping the
+   spelling wants. CSS Syntax 3 (ED) sec. 4.3.5 ends a string at EOF as the
+   string it read, and those bytes stop at the opening quote: printing them back
+   leaves the value swallowing whatever follows, so that one has no slice and
+   the caller writes the value out instead. *)
 let string_repr_with_quote_opt t =
   match peek t with
   | Some
       (Component.Preserved
-         ({ kind = Token.String { value; quote; _ }; loc } : Token.t)) ->
+         ({ kind = Token.String { value; quote; terminated }; loc } : Token.t))
+    ->
       skip t;
-      Some (value, quote, source_slice t loc)
+      Some (value, quote, if terminated then source_slice t loc else None)
   | _ -> None
 
 let url_opt t = take_token_if (function Token.Url s -> Some s | _ -> None) t

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -70,13 +70,10 @@ let is_custom_property_name = Custom_property_name.is_valid
    declaration it is written into: it closes the enclosing block, or turns the
    rest of the stylesheet into a string. *)
 let rec component_stays_in_declaration = function
+  (* sec. 4.3.5 ends a string at EOF as the string it read and only a newline
+     makes it a [<bad-string-token>], so the first stays in the value. *)
   | Component.Preserved
-      {
-        kind =
-          ( Token.Close _ | Token.Bad_string | Token.Bad_url
-          | Token.String { terminated = false; _ } );
-        _;
-      } ->
+      { kind = Token.Close _ | Token.Bad_string | Token.Bad_url; _ } ->
       false
   | Component.Preserved _ -> true
   | Component.Block { node = { closed; value; _ }; _ } ->
@@ -236,10 +233,13 @@ let reject_curly_block_value t =
   if List.exists component_has_curly_block (value_components t) then
     Cursor.err_invalid t "curly block in declaration value"
 
+(* CSS Syntax 3 (ED) sec. 4.3.5 ends a string at a newline as a
+   [<bad-string-token>] and at EOF as the [<string-token>] it read, and sec. 7.2
+   excludes only the first from a [<declaration-value>]. So a value the input
+   ended in the middle of a string carries a string like any other, and Chrome
+   151 keeps the declaration. *)
 let rec component_has_unterminated_string = function
-  | Component.Preserved { kind = Token.String { terminated = false; _ }; _ }
-  | Component.Preserved { kind = Token.Bad_string; _ } ->
-      true
+  | Component.Preserved { kind = Token.Bad_string; _ } -> true
   | Component.Block { node = { value; _ }; _ } ->
       List.exists component_has_unterminated_string value
   | Component.Func { node = { arguments; _ }; _ } ->

--- a/lib/font_face.ml
+++ b/lib/font_face.ml
@@ -230,11 +230,15 @@ let read_function_arg name t =
     Cursor.err_invalid inner ("empty " ^ name ^ "()");
   value
 
+(* CSS Fonts 4 (ED) sec. 4.3.1 writes [<font-src>] as [<url> [format(...)]?
+   [tech(...)]? | local(...)], and puts no emptiness rule on the [<url>]. sec.
+   4.3 leaves an unusable reference to loading, where the user agent "loads the
+   next font in the list", so an empty url is a font that never arrives rather
+   than a descriptor that does not parse. Chrome 151 keeps it. *)
 let read_url t =
   match Cursor.url_opt t with
-  | Some "" -> Cursor.err_invalid t "url() argument"
   | Some url -> `Bare url
-  | None -> (
+  | None ->
       Cursor.call "url" t @@ fun inner ->
       Cursor.ws inner;
       let value =
@@ -243,9 +247,7 @@ let read_url t =
         | None -> `Bare (Cursor.consume_remaining_as_string ~trim:true inner)
       in
       Cursor.expect_eof inner;
-      match value with
-      | `Bare "" | `Quoted ("", _) -> Cursor.err_invalid inner "url() argument"
-      | _ -> value)
+      value
 
 let read_src_modifier t =
   Cursor.ws t;
@@ -297,22 +299,36 @@ let rec read_src_entry t =
     comma between entries ([src: local("") url(test.woff)]). Match cleancss /
     lightningcss / esbuild and accept the whitespace-only form too, treating it
     as if a comma were present. *)
+(* sec. 4.3.1: an entry whose component value does not parse, or whose format or
+   tech the agent does not support, is left out of the list rather than failing
+   the descriptor, and only an empty list at the end is the parse error. The
+   component value is the whole comma-separated item, so an item is kept or
+   dropped as one: [url(f.woff2) garbage] is a single item that does not parse
+   and takes the descriptor with it, while a trailing comma and an unreadable
+   neighbour cost themselves alone. Chrome 151 answers the same way on each. *)
 and read_src t =
-  let sep t =
-    Cursor.ws t;
-    if Cursor.comma_opt t then (
-      Cursor.ws t;
-      if Cursor.is_done t || Cursor.peek_semicolon t then
-        Cursor.err_invalid t "trailing comma in font src")
-    else
-      (* No comma - whitespace alone separates entries; succeed silently so
-         [Cursor.list]'s peeker calls back into [read_src_entry]. *)
-      ()
+  let at_end () = Cursor.is_done t || Cursor.peek_semicolon t in
+  let rec skip_item () =
+    if at_end () || Cursor.comma_opt t then ()
+    else (
+      Cursor.skip t;
+      skip_item ())
   in
-  let entries = Cursor.list ~at_least:1 ~sep read_src_entry t in
-  Cursor.ws t;
-  if (not (Cursor.is_done t)) && not (Cursor.peek_semicolon t) then
-    Cursor.err t "unexpected tokens after font src";
+  (* [kept] is the items that parsed; [item] the entries of the one being read,
+     which the whitespace form above can make several. *)
+  let rec loop kept item =
+    Cursor.ws t;
+    if at_end () then item @ kept
+    else if Cursor.comma_opt t then loop (item @ kept) []
+    else
+      match read_src_entry t with
+      | entry -> loop kept (entry :: item)
+      | exception Cursor.Parse_error _ ->
+          skip_item ();
+          loop kept []
+  in
+  let entries = List.rev (loop [] []) in
+  if entries = [] then Cursor.err_invalid t "no readable font src";
   entries
 
 let src_of_string s =

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1145,7 +1145,11 @@ let normalize_border_image : border_image -> border_image =
   let slice_initial =
     drop
       (fun (s : border_image_slice) ->
-        (not s.fill) && s.offsets = [ (Pct 100. : border_image_slice_item) ])
+        (not s.fill)
+        &&
+        match s.offsets with
+        | [ (Pct 100. : border_image_slice_item) ] -> true
+        | _ -> false)
       value.slice
   in
   let outset =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3862,6 +3862,9 @@ let parse_custom_property_guard () =
       ("{a:b;}", "--x:{a:b;}");
       ("red/*", "--x:red");
       (" ", "--x: ");
+      (* CSS Syntax 3 (ED) sec. 4.3.5 ends a string at EOF as the string it
+         read, so this is one declaration value and writes back closed. *)
+      ("\"abc", "--x:\"abc\"");
       (* Not one declaration value: each of these closes the enclosing block,
          starts a second declaration, or runs to end of input. *)
       ("red}", "<rejected>");
@@ -3872,7 +3875,6 @@ let parse_custom_property_guard () =
       ("red]", "<rejected>");
       ("rgb(1,2,3", "<rejected>");
       ("{a:b", "<rejected>");
-      ("\"abc", "<rejected>");
       ("", "<rejected>");
     ];
   List.iter
@@ -3945,15 +3947,17 @@ let custom_property_guard () =
       (* CSS Syntax 3 sec. 4.3.6 returns the [<url-token>] at end of input, so
          [url(foo] is the same token [url(foo)] is. *)
       ("url(foo", "<round-trips>");
+      (* sec. 4.3.5 ends a string at EOF as the string it read, so this one is a
+         declaration value and writes back closed. *)
+      ("\"abc", "<round-trips>");
       (* Not a [<declaration-value>]: a second declaration, a closed rule, an
-         unterminated function, block or string, an unmatched bracket. *)
+         unterminated function or block, an unmatched bracket. *)
       ("red;--b:blue", "<refused>");
       ("red} .evil{color:lime", "<refused>");
       ("red}", "<refused>");
       ("rgb(1,2,3", "<refused>");
       ("url(foo bar)", "<refused>");
       ("{a:b", "<refused>");
-      ("\"abc", "<refused>");
       ("red)", "<refused>");
       ("red]", "<refused>");
     ];

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -276,13 +276,28 @@ let spec_fontface_src_minify_edges () =
         "var(--font-src,url(fallback.woff2)format(woff2))" );
     ]
 
+(* CSS Fonts 4 (ED) sec. 4.3.1 puts no emptiness rule on the [<url>] and leaves
+   an unusable reference to loading, and its per-item parsing drops an item that
+   does not parse rather than the descriptor. So an empty url and a trailing
+   comma are read, which is what Chrome 151 keeps; an item carrying something
+   [<font-src>] does not name still takes the descriptor with it. *)
+let spec_fontface_src_accepted_edges () =
+  List.iter
+    (fun (input, expected) ->
+      Alcotest.(check string)
+        input expected
+        (input |> src_of_string |> string_of_src ~minify:true))
+    [
+      ("url()", "url()");
+      ("url(\"\")", "url()");
+      ("url(\"font.woff2\"),", "url(font.woff2)");
+      ("nonsense,url(\"font.woff2\")", "url(font.woff2)");
+    ]
+
 let spec_fontface_src_invalid_edges () =
   expect_rejected_cases "font-face src" src_of_string string_of_src
     [
       "";
-      "url()";
-      "url(\"\")";
-      "url(\"font.woff2\"),";
       "url(\"font.woff2\") garbage";
       "url(\"font.woff2\") format(\"woff2\") garbage";
       "url(\"font.woff2\") format(\"woff2\") format(\"opentype\")";
@@ -740,6 +755,8 @@ let suite =
         spec_fontface_source_edges;
       test_case "spec font-face metric descriptor edges" `Quick
         spec_fontface_metric_edges;
+      test_case "spec font-face src accepted edges" `Quick
+        spec_fontface_src_accepted_edges;
       test_case "spec font-face src minify edges" `Quick
         spec_fontface_src_minify_edges;
       test_case "spec font-face src invalid edges" `Quick

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -8755,15 +8755,19 @@ let theme_defaults_reject_escaping_value () =
       ("a value carrying a second declaration", "red;--evil:lime");
       ("a value with an unmatched [)]", "red)");
       ("an unterminated function", "rgb(1,2,3");
-      ("an unterminated string", "\"abc");
       ("an empty value", "");
     ];
   (* A comment is consumed by tokenization (CSS Syntax 3 sec. 4.3.2), so
-     ["red/*"] is the one-token value ["red"] and does bind. *)
+     ["red/*"] is the one-token value ["red"] and does bind. sec. 4.3.5 ends a
+     string at EOF as the string it read, so that one binds as well. *)
   Alcotest.(check string)
     "an unterminated comment leaves a value that binds"
     ":root{--ok:blue;--brand:red}.a{color:var(--brand);background-color:var(--ok)}"
-    (emit "red/*")
+    (emit "red/*");
+  Alcotest.(check string)
+    "a value the input ended inside a string binds"
+    ":root{--ok:blue;--brand:\"abc\"}.a{color:var(--brand);background-color:var(--ok)}"
+    (emit "\"abc")
 
 (* CSS Syntax 3 sec. 4.3.7: a [\X] escape carries any code point into an ident,
    so [var(--x\3b y)] references the theme name ["x;y"]. The default binds under

--- a/test/test_supports.ml
+++ b/test/test_supports.ml
@@ -276,8 +276,12 @@ let property_guard () =
       ("rgb(1,2,3)", "<round-trips>");
       ("\"a;b\"", "<round-trips>");
       ("url(foo", "<round-trips>");
+      (* CSS Syntax 3 (ED) sec. 4.3.5 ends a string at EOF as the string it
+         read, so a value the input ended inside one carries a string like any
+         other. Only a newline makes a [<bad-string-token>]. *)
+      ("\"abc", "<round-trips>");
       (* Not one: an unmatched closing bracket, a top-level [;], an unterminated
-         function, block or string, a [<bad-url-token>]. *)
+         function or block, a [<bad-url-token>]. *)
       ("red) or (color:blue", "<refused>");
       ("red)", "<refused>");
       ("red]", "<refused>");
@@ -285,7 +289,6 @@ let property_guard () =
       ("red;--b:blue", "<refused>");
       ("rgb(1,2,3", "<refused>");
       ("{a:b", "<refused>");
-      ("\"abc", "<refused>");
       ("url(foo bar)", "<refused>");
     ];
   (* The same holds for a property whose value cascade does not model, which is


### PR DESCRIPTION
CSS Syntax 3 sec. 4.3.5 ends a string at a newline as a `<bad-string-token>` and at EOF as the `<string-token>` it read, and sec. 7.2 excludes only the first from a `<declaration-value>`. Cascade treated the two alike, so `content: "` lost its declaration where Chrome keeps `content: ""`, and the printer wrote the value back without its closing quote, which swallowed the rest of the sheet.

CSS Fonts 4 sec. 4.3.1 parses `src` per item and keeps the descriptor while any item parses, so an empty `url()` and a trailing comma no longer cost the whole font. An item carrying something `<font-src>` does not name still takes the descriptor with it, as in Chrome.

With this the `parse_recovery` oracle over-discards nothing: 17 disagreements to 11, and the browser no longer keeps working CSS that cascade deletes.

Also corrects the polymorphic comparison in #935 that the CI linter refuses.