### PR TITLE
stylesheet: refuse an @page selector list with an empty item

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -284,6 +284,11 @@ to lose a whole rule over one bad piece. Both are gone.
 - `border-image` compares a slice against its initial without a polymorphic
   equality, which walked another module's representation (#935)
 
+- An `@page` prelude with an empty selector in it invalidates the rule. CSS
+  Paged Media 3 sec. 4.2 gives each item of the list a name, pseudo-pages or
+  both, so `@page ,` and `@page foo,` name one that is neither and Chrome drops
+  the rule; cascade read them as an unnamed page (#973)
+
 - A value the input ended in the middle of a string keeps its declaration. CSS
   Syntax 3 sec. 4.3.5 ends a string at EOF as the string it read and only a
   newline makes a `<bad-string-token>`, which sec. 7.2 excludes; cascade treated

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2862,21 +2862,22 @@ let rec page_selector_skip_ws s len i =
    [<page-selector> = <ident-token>? <pseudo-page>*], with each pseudo-page from
    the closed set [first | left | right | blank], so [@page invoice:blank:first]
    is well-formed. *)
+(* CSS Paged Media 3 sec. 4.3 closes [<pseudo-page>] over four names, so each is
+   a keyword and not the page name beside it. *)
+let page_pseudo_of_name r s name =
+  match Common.String.lowercase_ascii_preserve name with
+  | "first" -> First
+  | "left" -> Left
+  | "right" -> Right
+  | "blank" -> Blank
+  | _ -> page_selector_error r s
+
 let parse_page_selectors r selector =
   let s = String.trim selector in
   let len = String.length s in
   let consume_ident = page_selector_consume_ident s len in
   let skip_ws = page_selector_skip_ws s len in
-  let pseudo_of_name name =
-    (* CSS Paged Media 3 sec. 4.3 closes [<pseudo-page>] over four names, so
-       each is a keyword and not the page name beside it. *)
-    match Common.String.lowercase_ascii_preserve name with
-    | "first" -> First
-    | "left" -> Left
-    | "right" -> Right
-    | "blank" -> Blank
-    | _ -> page_selector_error r s
-  in
+  let pseudo_of_name = page_pseudo_of_name r s in
   let consume_pseudo_page i : (page_pseudo * int) option =
     if i >= len || s.[i] <> ':' then None
     else
@@ -2892,7 +2893,12 @@ let parse_page_selectors r selector =
   in
   let rec consume_selectors acc i =
     let i = skip_ws i in
-    if i >= len then List.rev acc
+    (* Reaching the end here is the tail of a [,]: the list is
+       [<page-selector>#] and has no empty item, so a trailing comma is no more
+       a selector list than a lone one. *)
+    if i >= len then (
+      if acc <> [] then page_selector_error r s;
+      List.rev acc)
     else
       let after_ident = consume_ident i in
       let name =
@@ -2900,6 +2906,11 @@ let parse_page_selectors r selector =
         else Some (String.sub s i (after_ident - i))
       in
       let pseudos, after_pseudo = consume_pseudo_pages [] after_ident in
+      (* sec. 4.2 writes a page selector as a name, one or more pseudo-pages, or
+         both, so an item with neither is no selector: [@page ,] names two of
+         them and Chrome 151 drops the rule. The prelude may be absent
+         altogether, which the caller answers before reaching here. *)
+      if Option.is_none name && pseudos = [] then page_selector_error r s;
       let sel = { name; pseudos } in
       let after_pseudo = skip_ws after_pseudo in
       if after_pseudo >= len then List.rev (sel :: acc)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -782,6 +782,16 @@ let spec_fontface_descriptors () =
 let page_case () =
   (* Test page roundtrip *)
   check_stylesheet ~expected:"@page{margin:1in}" "@page { margin: 1in; }";
+  (* CSS Paged Media 3 sec. 4.2 writes the prelude as [<page-selector>#], whose
+     item is a name, one or more pseudo-pages, or both. An item with neither is
+     no selector, so a lone comma and a trailing one both invalidate the rule,
+     which Chrome 151 drops. The prelude may be absent altogether. *)
+  assert_minify_and_optimize "@page , { margin: 1in; }" ~minified:""
+    ~optimized:"";
+  assert_minify_and_optimize "@page foo, { margin: 1in; }" ~minified:""
+    ~optimized:"";
+  check_stylesheet ~expected:"@page foo{margin:1in}"
+    "@page foo { margin: 1in; }";
   check_stylesheet ~expected:"@page:first{margin:2in}"
     "@page :first { margin: 2in; }";
   check_stylesheet ~expected:"@page:left{margin-left:4cm;margin-right:3cm}"


### PR DESCRIPTION
`@page ,` and `@page foo,` name a page that is neither a name nor a pseudo-page, so CSS Paged Media 3 sec. 4.2 makes the rule invalid and Chrome drops it; cascade read them as an unnamed page.