### PR TITLE
stylesheet: discard a semicolon among a block's contents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -307,7 +307,7 @@ to lose a whole rule over one bad piece. Both are gone.
   an unrecognised at-rule reaches the output with its block intact.
   `Optimize.drop_unknown_at_rules` drops such a rule on request (#374, #380,
   #384, #388, #392, #399, #402, #403, #404, #405, #419, #420, #469, #483,
-  #727, #895, #897, #946, #947, #948, #949)
+  #727, #895, #897, #946, #947, #948, #949, #974)
 
 - An at-rule written among `@font-face` descriptors costs itself alone, as CSS
   Syntax 3 §5.5.5 requires, instead of taking the whole rule with it

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3923,6 +3923,16 @@ and read_block (r : Cursor.t) : block =
   let rec read_statements acc =
     Cursor.ws r;
     if Cursor.is_done r then List.rev acc
+    else if
+      (* CSS Syntax 3 (ED) sec. 5.5.5 discards a [;] among a block's contents,
+         so a stray one costs nothing and the rule after it reads. Chrome 151
+         reads it as the start of a prelude instead and loses the block. *)
+      match Cursor.peek r with
+      | Some (Component.Preserved { kind = Token.Semicolon; _ }) ->
+          Cursor.skip r;
+          true
+      | _ -> false
+    then read_statements acc
     else
       let loc = Cursor.position r in
       let snap = Cursor.save r in

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -792,6 +792,13 @@ let page_case () =
     ~optimized:"";
   check_stylesheet ~expected:"@page foo{margin:1in}"
     "@page foo { margin: 1in; }";
+  (* CSS Syntax 3 (ED) sec. 5.5.5 discards a [;] among a block's contents, so a
+     stray one costs nothing and the rule after it reads. Chrome 151 reads it as
+     the start of a prelude and loses the block instead. *)
+  check_stylesheet ~expected:"@layer{a{color:red}}"
+    "@layer { ; a { color: red } }";
+  check_stylesheet ~expected:"@media all{a{color:red}}"
+    "@media all { ; a { color: red } }";
   check_stylesheet ~expected:"@page:first{margin:2in}"
     "@page :first { margin: 2in; }";
   check_stylesheet ~expected:"@page:left{margin-left:4cm;margin-right:3cm}"


### PR DESCRIPTION
CSS Syntax 3 sec. 5.5.5 discards a `;` between a block's statements, so `@layer { ; a { color: red } }` keeps the rule after it; cascade read the semicolon as the start of a prelude and lost the block.