### PR TITLE
nest: keep the wrapper for a parent that leads with a type selector

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -499,9 +499,10 @@ to lose a whole rule over one bad piece. Both are gone.
   read from (#341, #343, #344, #349, #372, #374, #389, #396, #560)
 
 - Nesting emits only selectors a browser can match: a rule nested under a
-  pseudo-element parent is dropped wherever it sits, flattening a rule nested
-  under a selector list wraps the parent in `:is()`, and `--flatten-nesting`
-  leaves the result flat (#759, #800, #818, #822, #823)
+  pseudo-element parent is dropped wherever it sits, a selector-list or
+  type-selector parent keeps its `:is()` wrapper so `a { .x& { } }` flattens to
+  `.x:is(a)` and not the class `.xa`, and `--flatten-nesting` leaves the result
+  flat (#759, #800, #818, #822, #823, #975)
 
 - Default minification adds the WebKit fallbacks Safari 16.4 and Chrome 111
   need, with matching `@supports` tests, and drops a vendor prefix only when its

--- a/lib/nest.ml
+++ b/lib/nest.ml
@@ -52,8 +52,42 @@ let splices_bare ~leftmost ~parent sel =
     match sel with Selector.Nesting -> one_weight parent | _ -> false
   else leftmost && heads sel && count_nesting sel = 1
 
+(* Selectors 4 sec. 4.1: a type or universal selector leads its compound. A
+   parent carrying one can only go in bare where the [&] leads too, so [.x &]
+   under [a] is [a .x] and [.x&] is not [.xa], which reads back as one class
+   named [xa] and matches nothing the author wrote. The wrapper puts it where
+   any simple selector may stand, at the weight sec. 4.2 gives it. *)
+let rec leads_compound = function
+  | Selector.Element _ | Selector.Universal _ -> true
+  | Selector.Compound (x :: _) -> leads_compound x
+  | _ -> false
+
+let nesting_leads_every_compound sel =
+  let rec walk ~leading = function
+    | Selector.Nesting -> leading
+    | Selector.Compound (x :: rest) ->
+        walk ~leading x
+        && List.for_all
+             (fun s ->
+               not
+                 (Selector.any
+                    (function Selector.Nesting -> true | _ -> false)
+                    s))
+             rest
+    | Selector.Combined (l, _, r) ->
+        walk ~leading:true l && walk ~leading:true r
+    | Selector.Relative (_, r) -> walk ~leading:true r
+    | Selector.List branches -> List.for_all (walk ~leading:true) branches
+    | s ->
+        not (Selector.any (function Selector.Nesting -> true | _ -> false) s)
+  in
+  walk ~leading:true sel
+
 let substitute ?(leftmost = true) ~parent sel =
-  let verbatim = (not (complex parent)) || splices_bare ~leftmost ~parent sel in
+  let verbatim =
+    ((not (complex parent)) || splices_bare ~leftmost ~parent sel)
+    && ((not (leads_compound parent)) || nesting_leads_every_compound sel)
+  in
   let parent = if verbatim then parent else Selector.Is [ parent ] in
   Selector.map (function Selector.Nesting -> parent | s -> s) sel
 

--- a/test/test_flatten.ml
+++ b/test/test_flatten.ml
@@ -147,6 +147,25 @@ let test_nesting_wraps_complex_parent () =
   check ".a .b{&:hover{color:red}}" ".a .b:hover{color:red}";
   check ".a .b{& .c{color:red}}" ".a .b .c{color:red}"
 
+(* Selectors 4 sec. 4.1 puts the type or universal selector first in a compound,
+   so a parent that starts with one cannot be spliced in after another simple
+   selector: [.x&] under [a] would read back as a single class named [xa]. CSS
+   Nesting 1 sec. 4 keeps the [:is()] wrapper for that case. *)
+let test_nesting_wraps_type_parent () =
+  let check src expected =
+    Alcotest.(check string) src expected (render (Flatten.block (block src)))
+  in
+  check "a{.x&{color:red}}" ".x:is(a){color:red}";
+  check "a.c{.x&{color:red}}" ".x:is(a.c){color:red}";
+  check "*{.x&{color:red}}" ".x:is(*){color:red}";
+  (* [&] at the head of every compound leaves the type selector where it may
+     stand, so the parent goes in bare *)
+  check "a{&.x{color:red}}" "a.x{color:red}";
+  check "a{&:hover{color:red}}" "a:hover{color:red}";
+  check "a{.x &{color:red}}" ".x a{color:red}";
+  (* a parent with no type selector to lead needs no wrapper either way *)
+  check ".c{.x&{color:red}}" ".x.c{color:red}"
+
 (* CSS Nesting 1 sec. 3: a nested selector list is relative to the parent branch
    by branch. Combining the parent with the list as a whole put the combinator
    on the first branch only, and every later branch escaped as a top-level
@@ -230,6 +249,8 @@ let suite =
         test_bad_declaration_still_a_declaration;
       Alcotest.test_case "nesting wraps a complex parent" `Quick
         test_nesting_wraps_complex_parent;
+      Alcotest.test_case "nesting wraps a type parent" `Quick
+        test_nesting_wraps_type_parent;
       Alcotest.test_case "nested selector list keeps the parent" `Quick
         test_nested_selector_list_keeps_parent;
       Alcotest.test_case "list parent keeps its branches" `Quick


### PR DESCRIPTION
Selectors 4 sec. 4.1 puts a type or universal selector first in its compound, so `a { .x& { color: red } }` used to flatten to `.xa`, one class name that matches nothing the author wrote; now it flattens to `.x:is(a)`.