### PR TITLE
selector: hold a nested rule's prelude to the unforgiving bar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -316,12 +316,13 @@ to lose a whole rule over one bad piece. Both are gone.
   `or` branch and a negated capability test no longer lose their rules (#867,
   #869)
 
-- A selector no browser can match is dropped rather than written back, and a
-  pseudo-element that carries structure keeps the compounds it allows:
+- A selector no browser can match is dropped rather than written back, in a
+  nested rule's prelude as well as at top level, and a pseudo-element that
+  carries structure keeps the compounds it allows:
   `::file-selector-button:hover` and a chained `::part(label)::before` survive
   where a combinator after a pseudo-element does not. `Css.Selector.of_string`
   refuses a string that is not a selector rather than reading it as an element
-  name (#418, #426, #430, #441, #552, #553, #556, #559, #950)
+  name (#418, #426, #430, #441, #552, #553, #556, #559, #950, #976)
 
 - Keyword, at-rule and function names match without regard to case, so
   `grid-column: SPAN 2`, `@MEDIA`, `RGB()`, `VAR(--x)` and `:dir(LTR)` read

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -2015,7 +2015,11 @@ let read_relative t =
   Cursor.ws t;
   if not (Cursor.is_done t) then
     Cursor.err t "unexpected characters after selector";
-  match selectors with [ s ] -> s | _ -> List selectors
+  let result = match selectors with [ s ] -> s | _ -> List selectors in
+  (* A nested style rule's prelude is a selector list like any other, so it is
+     unforgiving too. *)
+  validate_unforgiving_pseudo t result;
+  result
 
 (* CSS Nesting 1 sec. 3: a nested selector is implicitly relative to [&], so a
    leading [& <combinator>] is redundant: [& .bar] -> [.bar], [& > .bar] -> [>

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4288,6 +4288,20 @@ let nesting_invalid_rule_recovery () =
     ".a { color: red; .b <::::invalid::::> {} & .c { color: blue } }"
     ".a{color:red;.c{color:#00f}}" 1
 
+(* Selectors 4 sec. 3.9 makes a selector list carrying an unknown pseudo-class
+   invalid, and CSS Nesting 1 sec. 2 gives a nested style rule a selector list
+   for its prelude, so the nested rule goes and the ones around it stay. An
+   escaped [;] is an ident code point, so [color:green\;] is a type selector and
+   a pseudo-class named [green;], which is the same case reached through a
+   declaration that failed. *)
+let nested_prelude_is_unforgiving () =
+  lenient_recover "unknown pseudo-class in a nested prelude"
+    ".a { b:future-pseudo { color: red } & .c { color: blue } }"
+    ".a .c{color:#00f}" 1;
+  lenient_recover "escaped semicolon leaves a pseudo-class behind"
+    "a { color: green\\; & { color: red } .c { z-index: 1 } }" "a .c{z-index:1}"
+    1
+
 (* CSS Syntax 3 sec. 4.3.1 consumes a unicode-range token only while "unicode
    ranges allowed" is set, and sec. 4.3.14 says the one caller that sets it is
    the value of a unicode-range descriptor. Everywhere else [u+a] is an ident, a
@@ -9407,6 +9421,7 @@ let additional_tests =
       `Quick,
       unicode_range_only_in_its_descriptor );
     ("nesting invalid rule recovery", `Quick, nesting_invalid_rule_recovery);
+    ("nested prelude is unforgiving", `Quick, nested_prelude_is_unforgiving);
     ("unterminated string closes", `Quick, unterminated_string_closes);
     ( "spec nesting selector and conditional edges",
       `Quick,


### PR DESCRIPTION
Selectors 4 sec. 3.9 makes an unknown pseudo-class invalidate the selector list it sits in, and a nested style rule's prelude is one. `a { b:future-pseudo { color: red } }` used to reach the output; now the nested rule is dropped and the rules around it stay, as in the browser.