### PR TITLE
media: replace only the query of the list that fails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -316,6 +316,11 @@ to lose a whole rule over one bad piece. Both are gone.
   `or` branch and a negated capability test no longer lose their rules (#867,
   #869)
 
+- A `@media` prelude replaces only the query of the list that fails, so
+  `@media ,(min-width: 10px)` still guards its rules on the width. Media Queries
+  4 sec. 3.2 replaces one entry at a time; cascade collapsed the whole list to
+  `not all`, and the rules under it matched nothing (#977)
+
 - A selector no browser can match is dropped rather than written back, in a
   nested rule's prelude as well as at top level, and a pseudo-element that
   carries structure keeps the compounds it allows:

--- a/fuzz/fuzz_container.ml
+++ b/fuzz/fuzz_container.ml
@@ -121,7 +121,8 @@ let test_invalid_container_vectors buf =
     if byte_at buf 1 mod 2 = 0 then
       (pick Cascade_spec_inventory.Query_grammar.container_negative buf 2).input
     else
-      Cascade_spec_inventory.Query_grammar.mutate_invalid valid (byte_at buf 3)
+      (Cascade_spec_inventory.Query_grammar.mutate_invalid valid (byte_at buf 3))
+        .input
   in
   assert_invalid_container_contract "invalid container query vector" input
 

--- a/fuzz/fuzz_media.ml
+++ b/fuzz/fuzz_media.ml
@@ -201,15 +201,21 @@ let test_media_feature_family buf =
 
 let test_media_feature_recovery buf =
   let valid = pick Cascade_spec_inventory.Query_grammar.media_positive buf 3 in
-  let input =
+  let input, expected =
     if byte_at buf 4 mod 2 = 0 then
-      (pick Cascade_spec_inventory.Query_grammar.media_negative buf 5).input
+      ( (pick Cascade_spec_inventory.Query_grammar.media_negative buf 5).input,
+        "not all" )
     else
-      Cascade_spec_inventory.Query_grammar.mutate_invalid valid (byte_at buf 6)
+      let m =
+        Cascade_spec_inventory.Query_grammar.mutate_invalid valid
+          (byte_at buf 6)
+      in
+      (m.input, m.recovery)
   in
   let actual = Css.Media.to_string (Css.Media.of_string input) in
-  if actual <> "not all" then
-    failf "invalid media feature family did not recover: %S -> %S" input actual
+  if actual <> expected then
+    failf "invalid media feature family did not recover: %S -> %S, expected %S"
+      input actual expected
 
 (* ===== Soundness of the equivalence [Media.equal] decides ===== *)
 

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -520,21 +520,19 @@ let to_string ?(minify = false) t = Pp.to_string ~minify pp t
 
 (* ===== Parser ===== *)
 
-type recovery_scope = Branch | Query_list
-
 (* A branch failure is buffered rather than raised straight out: [of_components]
    decides from [recover] whether to swallow it into [not all] or re-raise it,
    so the error travels as a value with the span already attached. *)
-exception Parse_error of recovery_scope * Error.t
+exception Parse_error of Error.t
 
-let fail_parse ?(scope = Branch) e = raise (Parse_error (scope, e))
+let fail_parse e = raise (Parse_error e)
 
 (* Anchoring a failure on the components that failed puts the caret on that
    slice of the query. [t] anchors the smallest enclosing construct, for a
    failure that has no components of its own. *)
-let err ?scope t cvs reason =
+let err t cvs reason =
   let at = match cvs with [] -> t | _ :: _ -> Cursor.sub t cvs in
-  fail_parse ?scope (Cursor.condition_error at ~at_rule:"@media" reason)
+  fail_parse (Cursor.condition_error at ~at_rule:"@media" reason)
 
 let rec drop_whitespace = function
   | component :: rest when Component.is_whitespace component ->
@@ -1003,7 +1001,7 @@ let read_media_type_query t components =
   (match (prefix, components) with
   | Some _, (first :: _ as rest)
     when ident_is "not" first || ident_is "only" first ->
-      err ~scope:Query_list t rest "duplicate media query prefix"
+      err t rest "duplicate media query prefix"
   | _ -> ());
   match components with
   | name_component :: rest -> (
@@ -1053,8 +1051,7 @@ let parse_query_branch t components =
   (* Anchor the branch, not the whole query list, so a fallback with no
      components of its own still lands inside the branch that failed. *)
   let t = Cursor.sub t components in
-  try Ok (single_query t components)
-  with Parse_error (scope, e) -> Error (scope, e)
+  try Ok (single_query t components) with Parse_error e -> Error e
 
 let read ?(recover = true) t =
   let components = Cursor.remaining t in
@@ -1062,18 +1059,15 @@ let read ?(recover = true) t =
   if (not saw_comma) && List.for_all components_empty branches then
     (List [] : t)
   else
+    (* CSS Media Queries 4 sec. 3.2 replaces a query that does not match the
+       grammar with [not all] "during parsing", one entry of the comma-separated
+       list at a time, so the branches beside it keep what they say. *)
     let rec parse acc = function
       | [] -> List.rev acc
-      | [ branch ] -> (
-          match parse_query_branch t branch with
-          | Ok query -> List.rev (query :: acc)
-          | Error (_, e) -> if recover then [ not_all_query ] else Error.fail e)
       | branch :: rest -> (
           match parse_query_branch t branch with
           | Ok query -> parse (query :: acc) rest
-          | Error (Query_list, e) ->
-              if recover then [ not_all_query ] else Error.fail e
-          | Error (Branch, e) ->
+          | Error e ->
               if recover then parse (not_all_query :: acc) rest
               else Error.fail e)
     in
@@ -1081,9 +1075,6 @@ let read ?(recover = true) t =
     | false, [ query ] -> query
     | false, [] -> List []
     | false, _ :: _ :: _ -> assert false
-    | true, [ Type { prefix = Some Not; type_ = All; trailing = Option.None } ]
-      ->
-        not_all_query
     | true, queries -> List queries
 
 let of_string s = read (Cursor.of_string s)

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3614,15 +3614,17 @@ let read_layer_name (r : Cursor.t) : layer_name = read_layer_name_component r
 (* Media Queries 5 sec. 3.2: "A media query that does not match the grammar
    [...] must be replaced by not all during parsing", so a prelude the reader
    refuses leaves the rule standing and matching nothing rather than taking the
-   rule and its contents with it. The query is still lost, so it is reported:
-   the recovery is {!Error.Recovery.Recovered}, the rule surviving. *)
+   rule and its contents with it. The replacement is per entry of the list,
+   which the recovering read does; the strict one runs first for the error to
+   report, since the recovery is {!Error.Recovery.Recovered}, the rule
+   surviving. *)
 let read_nested_media_condition t =
   if Cursor.is_done t then Media.List []
   else
     try Media.read ~recover:false t
     with Error.Parse_error e when Cursor.recover t ->
       Cursor.push_warning t ~recovery:Error.Recovery.Recovered e;
-      Media.of_string "not all"
+      Media.read ~recover:true t
 
 let read_rule_selector ?(nested = false) r =
   let prelude = Cursor.drain_until_block r in

--- a/test/spec/inventory/query_grammar.ml
+++ b/test/spec/inventory/query_grammar.ml
@@ -1,8 +1,10 @@
 type row = { branch : string; input : string; expected : string }
 type invalid_row = { branch : string; input : string }
+type mutation = { input : string; recovery : string }
 
 let row branch input expected = { branch; input; expected }
 let invalid branch input = { branch; input }
+let not_all = "not all"
 
 let media_positive =
   [
@@ -214,6 +216,12 @@ let media_recovery =
     row "invalid min-prefix recovers inside list"
       "(min-orientation: portrait), (width)"
       "(min-orientation: portrait), (width)";
+    row "last branch recovers on its own" "speech, &test" "speech, not all";
+    row "double not recovers on its own" "not not screen, print"
+      "not all, print";
+    row "empty first branch recovers on its own" ", speech" "not all, speech";
+    row "empty last branch recovers on its own" "speech," "speech, not all";
+    row "a list of empty branches is one not all each" "," "not all, not all";
   ]
 
 let container_positive =
@@ -303,10 +311,25 @@ let container_negative =
     invalid "opposing style interval operators" "style(10px < --gap > 20px)";
   ]
 
+(* CSS Media Queries 4 sec. 3.2 replaces the one entry of the list that does not
+   match the grammar, so a mutation at either end of a query list lands on the
+   branch at that end and the rest of the list keeps what it says. An opening
+   paren is the exception: it swallows the commas, leaving a single branch. *)
 let mutate_invalid (row : row) salt =
+  let branches = String.split_on_char ',' row.expected in
+  let branches = List.map String.trim branches in
+  let join = String.concat ", " in
+  let last =
+    match List.rev branches with
+    | [] -> not_all
+    | _ :: rest -> join (List.rev (not_all :: rest))
+  in
+  let first =
+    match branches with [] -> not_all | _ :: rest -> join (not_all :: rest)
+  in
   match salt mod 5 with
-  | 0 -> row.input ^ " and"
-  | 1 -> "(" ^ row.input
-  | 2 -> row.input ^ ")"
-  | 3 -> row.input ^ " or"
-  | _ -> "not not " ^ row.input
+  | 0 -> { input = row.input ^ " and"; recovery = last }
+  | 1 -> { input = "(" ^ row.input; recovery = not_all }
+  | 2 -> { input = row.input ^ ")"; recovery = last }
+  | 3 -> { input = row.input ^ " or"; recovery = last }
+  | _ -> { input = "not not " ^ row.input; recovery = first }

--- a/test/spec/inventory/query_grammar.mli
+++ b/test/spec/inventory/query_grammar.mli
@@ -3,6 +3,9 @@
 type row = { branch : string; input : string; expected : string }
 type invalid_row = { branch : string; input : string }
 
+type mutation = { input : string; recovery : string }
+(** A derived invalid query and the serialization it recovers to. *)
+
 val media_positive : row list
 (** [media_positive] contains valid CSS Media Queries branches. *)
 
@@ -24,5 +27,6 @@ val container_positive : row list
 val container_negative : invalid_row list
 (** [container_negative] contains invalid CSS Container Queries branches. *)
 
-val mutate_invalid : row -> int -> string
-(** [mutate_invalid row salt] derives invalid query syntax from [row]. *)
+val mutate_invalid : row -> int -> mutation
+(** [mutate_invalid row salt] derives invalid query syntax from [row], with the
+    serialization Media Queries 4 sec. 3.2 recovers it to. *)

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1961,6 +1961,14 @@ let spec_lenient_recovery_block_statements () =
     "@media screen { @media (min-width: 1px) and { a { color: red } } b { \
      color: blue } }"
     "@media screen{@media not all{a{color:red}}b{color:#00f}}" 1;
+  (* The replacement is per entry of the comma-separated list, so the queries
+     beside the bad one still say what they said. *)
+  lenient_recover "only the bad query of a list is replaced"
+    "@media ,(min-width: 10px) { a { color: red } }"
+    "@media not all,(width>=10px){a{color:red}}" 1;
+  lenient_recover "a list of empty queries is one not all each"
+    "@media all,,all { a { color: red } }"
+    "@media all,not all,all{a{color:red}}" 1;
   lenient_recover "bad @container prelude in @media ends at its block"
     "@media screen { @container (min-width: 1px) !! { a { color: red } } b { \
      color: blue } }"


### PR DESCRIPTION
Media Queries 4 sec. 3.2 replaces a query that does not match the grammar with `not all` one entry of the comma-separated list at a time. `@media ,(min-width: 10px)` used to collapse to a bare `not all`, so rules that should have applied at that width matched nothing.