### PR TITLE
declaration: hold an opaque value to the declaration-value grammar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -295,6 +295,11 @@ to lose a whole rule over one bad piece. Both are gone.
   the two alike and dropped the rule, and printed the value back without its
   closing quote so the rest of the sheet was swallowed (#972)
 
+- A value carrying an unmatched `)`, `]` or `}` is dropped with a warning even
+  where a `var()` sends it down the opaque path. CSS Syntax 3 sec. 7.2 keeps
+  those out of a `<declaration-value>`, so `width: var(--x))` is no declaration
+  at all; cascade wrote it back where every browser drops it (#978)
+
 - The `@font-face` `src` descriptor reads an empty `url()` and drops only the
   item it cannot read. CSS Fonts 4 sec. 4.3.1 leaves an unusable reference to
   loading and keeps the descriptor while any item parses, so a trailing comma

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -270,6 +270,13 @@ let reject_custom_bad_string t =
       (components_before is_top_level_stop t)
   then Cursor.err_invalid t "custom property value is no <declaration-value>"
 
+(* The same bar for a value the typed readers hand to the opaque path: a [var()]
+   postpones the property grammar to computed-value time, not the token
+   grammar. *)
+let reject_opaque_bad_token t =
+  if List.exists component_leaves_declaration_value (value_components t) then
+    Cursor.err_invalid t "declaration value is no <declaration-value>"
+
 let invalid_var_arguments arguments =
   match
     List.filter
@@ -2320,6 +2327,7 @@ let read_unknown_property_declaration t name =
   validate_complete_declaration_value t;
   reject_curly_block_value t;
   reject_unterminated_string_value t;
+  reject_opaque_bad_token t;
   let raw_value = Cursor.consume_to_decl_end ~trim:true t in
   let is_important = read_importance t in
   validate_no_extra_tokens t;

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -4296,6 +4296,21 @@ let nesting_invalid_rule_recovery () =
     ".a { color: red; .b <::::invalid::::> {} & .c { color: blue } }"
     ".a{color:red;.c{color:#00f}}" 1
 
+(* CSS Syntax 3 (ED) sec. 7.2 keeps an unmatched [)], []] or [}] out of a
+   [<declaration-value>], so a value carrying one is no declaration at all. The
+   rule holds for a value the typed readers hand to the opaque path as much as
+   for one they read: a [var()] postpones the property grammar to computed-value
+   time, not the token grammar. *)
+let opaque_value_is_a_declaration_value () =
+  lenient_recover "unmatched close paren after a var()"
+    ".a { width: var(--x)); color: green }" ".a{color:green}" 1;
+  lenient_recover "unmatched close bracket before a var()"
+    ".a { width: ]var(--x); color: green }" ".a{color:green}" 1;
+  lenient_recover "unmatched close bracket after a var()"
+    ".a { width: var(--x)]; color: green }" ".a{color:green}" 1;
+  lenient_recover "unmatched close paren under an unknown property"
+    ".a { cascade-nope: a)b; color: green }" ".a{color:green}" 1
+
 (* Selectors 4 sec. 3.9 makes a selector list carrying an unknown pseudo-class
    invalid, and CSS Nesting 1 sec. 2 gives a nested style rule a selector list
    for its prelude, so the nested rule goes and the ones around it stay. An
@@ -9430,6 +9445,9 @@ let additional_tests =
       unicode_range_only_in_its_descriptor );
     ("nesting invalid rule recovery", `Quick, nesting_invalid_rule_recovery);
     ("nested prelude is unforgiving", `Quick, nested_prelude_is_unforgiving);
+    ( "opaque value is a declaration value",
+      `Quick,
+      opaque_value_is_a_declaration_value );
     ("unterminated string closes", `Quick, unterminated_string_closes);
     ( "spec nesting selector and conditional edges",
       `Quick,


### PR DESCRIPTION
CSS Syntax 3 sec. 7.2 keeps an unmatched `)`, `]` or `}` out of a `<declaration-value>`. A value the typed readers hand to the opaque path skipped that check, so `width: var(--x))` was written back where every browser drops it.