### PR TITLE
declaration: read the important flag off the last two values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -295,6 +295,13 @@ to lose a whole rule over one bad piece. Both are gone.
   the two alike and dropped the rule, and printed the value back without its
   closing quote so the rest of the sheet was swallowed (#972)
 
+- A custom property whose value holds a `!` outside its `!important` flag is
+  dropped with a warning, and `--x: 1 ! important` is important with the value
+  `1`. CSS Syntax 3 sec. 5.5.6 reads the flag off the last two non-whitespace
+  values and sec. 7.2 keeps what is left free of a top-level `!`; cascade read
+  the spaced flag as part of the value and kept `--x: a!b`, which browsers drop
+  (#979)
+
 - A value carrying an unmatched `)`, `]` or `}` is dropped with a warning even
   where a `var()` sends it down the opaque path. CSS Syntax 3 sec. 7.2 keeps
   those out of a `<declaration-value>`, so `width: var(--x))` is no declaration

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -82,14 +82,24 @@ let rec component_stays_in_declaration = function
       terminated && List.for_all component_stays_in_declaration arguments
 
 (* A top-level [;] ends the declaration, so the tail becomes a second one. It is
-   only a stop at top level: [(a;b)] keeps it inside the block. *)
+   only a stop at top level: [(a;b)] keeps it inside the block. Sec. 7.2 keeps a
+   top-level [!] out of the production for the same reason: sec. 5.5.6 takes the
+   [!important] flag off the end before the value is read, so a [!] still in it
+   belongs to no flag and to no value. *)
 let is_top_level_stop = function
   | Component.Preserved { kind = Token.Semicolon; _ } -> true
   | _ -> false
 
+let is_top_level_bang = function
+  | Component.Preserved { kind = Token.Delim "!"; _ } -> true
+  | _ -> false
+
 let components_stay_in_declaration components =
   List.for_all
-    (fun c -> (not (is_top_level_stop c)) && component_stays_in_declaration c)
+    (fun c ->
+      (not (is_top_level_stop c))
+      && (not (is_top_level_bang c))
+      && component_stays_in_declaration c)
     components
 
 (* CSS Variables 1 sec. 2 gives a custom property the value grammar
@@ -2103,24 +2113,37 @@ let is_font_family_var name =
   || starts_with "default-font-family" bare
   || starts_with "default-mono-font-family" bare
 
-(* For custom properties only, !important is recognised solely as the literal
-   10-character suffix [!important]; [! important] (with whitespace between the
-   bang and the ident) is part of the value, not the importance flag. Per
-   test_declaration's spec_custom_tokens: this matches Tailwind/lightningcss's
-   conservative handling for [--*] values, where any whitespace inside the flag
-   means the user wrote arbitrary tokens, not the cascade marker. *)
-let split_custom_important value =
+(* CSS Syntax 3 (ED) sec. 5.5.6 takes the flag off when the last two
+   non-whitespace values of the declaration are a [!] delim and an ident
+   matching [important], so the whitespace [! important] writes between the two
+   is inside the flag. Chrome 151 reads it that way, and what is left is the
+   value. *)
+let is_ws_char = function
+  | ' ' | '\t' | '\n' | '\r' | '\012' -> true
+  | _ -> false
+
+let trim_end s =
+  let n = ref (String.length s) in
+  while !n > 0 && is_ws_char s.[!n - 1] do
+    decr n
+  done;
+  String.sub s 0 !n
+
+let split_important value =
   let trimmed = String.trim value in
   let len = String.length trimmed in
-  let suffix = "!important" in
-  let suffix_len = String.length suffix in
+  let word = "important" in
+  let word_len = String.length word in
   if
-    len >= suffix_len
-    && String.lowercase_ascii (String.sub trimmed (len - suffix_len) suffix_len)
-       = suffix
+    len > word_len
+    && String.lowercase_ascii (String.sub trimmed (len - word_len) word_len)
+       = word
   then
-    let head = String.sub trimmed 0 (len - suffix_len) in
-    (String.trim head, true)
+    let head = trim_end (String.sub trimmed 0 (len - word_len)) in
+    let head_len = String.length head in
+    if head_len > 0 && Char.equal head.[head_len - 1] '!' then
+      (String.trim (String.sub head 0 (head_len - 1)), true)
+    else (trimmed, false)
   else (trimmed, false)
 
 let read_custom_property_payload name value_str =
@@ -2157,7 +2180,9 @@ let read_custom_value_declaration t name : declaration =
   reject_custom_bad_string t;
   let raw_value = Cursor.consume_until_semicolon ~trim:false t in
   let raw_is_whitespace_only = raw_value <> "" && String.trim raw_value = "" in
-  let value_str, is_important = split_custom_important raw_value in
+  let value_str, is_important = split_important raw_value in
+  if not (is_optional_declaration_value value_str) then
+    Cursor.err_invalid t "custom property value is no <declaration-value>";
   (* custom_property may raise Failure for invalid names like "--" *)
   try
     let custom_value =

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -61,10 +61,17 @@ val to_string : ?minify:bool -> t -> string
 
 val is_declaration_value : string -> bool
 (** [is_declaration_value s] is whether [s] is a [<declaration-value>]: one or
-    more component values with no unmatched closing bracket, no top-level [;],
-    no [<bad-string-token>] or [<bad-url-token>] and no unterminated function,
-    block or string (CSS Syntax 3 (ED) sec. 7.2). Text outside it stops being
-    part of the declaration it is written into. *)
+    more component values with no unmatched closing bracket, no top-level [;] or
+    [!], no [<bad-string-token>] or [<bad-url-token>] and no unterminated
+    function, block or string (CSS Syntax 3 (ED) sec. 7.2). Text outside it
+    stops being part of the declaration it is written into. Pass the value with
+    its [!important] flag already off, as {!split_important} takes it. *)
+
+val split_important : string -> string * bool
+(** [split_important s] is [s] without its [!important] flag, and whether it
+    carried one. CSS Syntax 3 (ED) sec. 5.5.6 takes the flag off when the last
+    two non-whitespace values are a [!] delim and the ident naming the flag, so
+    [1 ! important] carries one and [1 !importantly] does not. *)
 
 val custom_property : ?layer:string -> string -> string -> declaration
 (** [custom_property ?layer name value] is a custom property declaration from

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -172,7 +172,8 @@ let declaration_feature prop value =
    no check. Rendering through the component stream closes a [<url-token>] the
    caller left open, the way the reader's own path already does. *)
 let property prop value =
-  if not (String.equal value "" || Declaration.is_declaration_value value) then
+  let bare, _ = Declaration.split_important value in
+  if not (String.equal value "" || Declaration.is_declaration_value bare) then
     failwith
       (String.concat ""
          [

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4046,7 +4046,10 @@ let spec_custom_tokens () =
     "--tokens: [a, b] (c) { d: e; }";
   check_declaration ~expected:"--empty:" "--empty:";
   check_declaration ~expected:"--commented:a b" "--commented: a /*x*/ b";
-  check_declaration ~expected:"--important-token:1 ! important"
+  (* CSS Syntax 3 (ED) sec. 5.5.6 takes the flag off when the last two
+     non-whitespace values are a [!] delim and an ident matching [important], so
+     the whitespace between the two is inside the flag and not in the value. *)
+  check_declaration ~expected:"--important-token:1!important"
     "--important-token: 1 ! important";
   check_declaration ~expected:"--real-important:1!important"
     "--real-important: 1 !important";
@@ -4074,7 +4077,13 @@ let spec_custom_tokens () =
   neg_cursor read_declaration "--x: hover { ] }";
   neg_cursor read_declaration "--x: a ] b";
   neg_cursor read_declaration "--x: a ) b";
-  neg_cursor read_declaration "--x: url(a b)"
+  neg_cursor read_declaration "--x: url(a b)";
+  (* Sec. 7.2 keeps a top-level [!] out of the production too, so what is left
+     once the flag is off has to hold none. *)
+  neg_cursor read_declaration "--x: a!b";
+  neg_cursor read_declaration "--x: 1px!";
+  neg_cursor read_declaration "--x:! 1px";
+  check_declaration ~expected:"--x:(a!b)" "--x: (a!b)"
 
 (* CSS Fonts 4 sec. 2.1.1 gives a [<font-family-name>] two spellings, a
    [<string>] and a [<custom-ident>+], and they name the same family whether
@@ -4922,8 +4931,10 @@ let css_wide_custom_property_vectors () =
   check_declaration ~expected:"--list:[a,b,c]" "--list: [a, b, c]";
   check_declaration ~expected:"--empty-fallback:var(--missing,)"
     "--empty-fallback: var(--missing,)";
-  check_declaration ~expected:"--not-important:1 ! important"
-    "--not-important: 1 ! important";
+  (* CSS Syntax 3 (ED) sec. 5.5.6 reads the last two non-whitespace values, so
+     the whitespace between [!] and [important] is inside the flag. *)
+  check_declaration ~expected:"--spaced-important:1!important"
+    "--spaced-important: 1 ! important";
   check_declaration ~expected:"--is-important:1!important"
     "--is-important: 1 !important";
   none_cursor read_declaration "--: invalid"

--- a/test/test_supports.ml
+++ b/test/test_supports.ml
@@ -53,6 +53,11 @@ let test_of_string () =
          property "contain-intrinsic-size" "1px" ));
   check "nested function value" "(color: color-mix(in lab, red, red))"
     (property "color" "color-mix(in lab, red, red)");
+  (* CSS Conditional 3 sec. 2.2 tests a [<declaration>], which CSS Syntax 3 (ED)
+     sec. 5.5.6 lets carry the [!important] flag, so the flag comes off the
+     value before the [<declaration-value>] bar applies to it. *)
+  check "property with the important flag" "(display: grid !important)"
+    (property "display" "grid !important");
   check "double parens around property" "((-webkit-hyphens: none))"
     (property "-webkit-hyphens" "none");
   check "complex browser detection"


### PR DESCRIPTION
CSS Syntax 3 sec. 5.5.6 takes the flag when the last two non-whitespace values are a `!` delim and the ident, so `--x: 1 ! important` is important with the value `1`; cascade kept the spaced flag inside the value. Sec. 7.2 then keeps a top-level `!` out of what is left, so `--x: a!b` is dropped as every browser drops it.