### PR TITLE
selector: keep a class and a pseudo name against their punctuation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -341,6 +341,11 @@ to lose a whole rule over one bad piece. Both are gone.
   refuses a string that is not a selector rather than reading it as an element
   name (#418, #426, #430, #441, #552, #553, #556, #559, #950, #976)
 
+- A `.` or a `:` names nothing across a space, so `. x a` and `: hover` are
+  dropped rather than read as `.x a` and `:hover`. Selectors 4 sec. 5.1 has a
+  class name follow its dot immediately and sec. 3.5 a pseudo-class name its
+  colon, so cascade was matching elements the author never named (#982)
+
 - Keyword, at-rule and function names match without regard to case, so
   `grid-column: SPAN 2`, `@MEDIA`, `RGB()`, `VAR(--x)` and `:dir(LTR)` read
   (#602, #603, #604, #620, #622, #767)

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -458,9 +458,21 @@ let read_attribute_value t =
     | Some _ -> Cursor.err_invalid t "attribute value"
   else (value, quote)
 
+(* Selectors 4 sec. 5.1 spells a class as a [.] "immediately followed by" an
+   ident, and sec. 3.5 a pseudo-class or pseudo-element as its colons followed
+   by the name. Every other reader has the cursor skip whitespace for it, so
+   these three look for it themselves: [. x] names no class, and reading past
+   the space gave the author [.x]. *)
+let expect_adjacent t what =
+  match Cursor.peek_raw t with
+  | Some c when Component.is_whitespace c ->
+      Cursor.err_invalid t (String.concat "" [ "whitespace before the "; what ])
+  | _ -> ()
+
 (** Parse a class selector (.classname) *)
 let read_class t =
   Cursor.expect '.' t;
+  expect_adjacent t "class name";
   let name = Cursor.ident ~keep_case:true t in
   (* No validation needed: Cursor.ident already enforces CSS identifier syntax,
      including parser-valid double-dash identifiers such as .--x. *)
@@ -1794,6 +1806,7 @@ and pseudo_class_calls () = Lazy.force pseudo_class_calls_lazy
 (** Parse pseudo-class (:hover, :nth-child(2n+1), etc.) *)
 and read_pseudo_class ?(allow_unknown = false) t =
   if not (Cursor.colon t) then Cursor.err_expected t "':'";
+  expect_adjacent t "pseudo-class name";
   let all_idents = pseudo_class_all_idents () in
   let calls = pseudo_class_calls () in
   let read_unknown = read_unknown_pseudo_class ~all_idents in
@@ -1806,6 +1819,7 @@ and read_pseudo_class ?(allow_unknown = false) t =
 and read_pseudo_element t =
   if not (Cursor.try_kind_pair Token.Colon Token.Colon t) then
     Cursor.err_expected t "'::'";
+  expect_adjacent t "pseudo-element name";
   Cursor.enum_calls
     [
       ("part", read_part);

--- a/test/test_selector.ml
+++ b/test/test_selector.ml
@@ -680,7 +680,19 @@ let invalid () =
   check ~expected:"[attr=\"value]\"]" "[attr=\"value]";
   neg_parse ":nth-child(2n+)" "invalid nth-child syntax";
   neg_parse ".class,,.other" "double comma in list";
-  neg_parse "div > > span" "double combinator"
+  neg_parse "div > > span" "double combinator";
+  (* Selectors 4 sec. 5.1 spells a class as a [.] "immediately followed by" an
+     ident, and sec. 3.5 a pseudo-class as a [:] followed by its name, so a
+     space between the two names nothing. Reading past it turned [. x a] into
+     [.x a] and [: hover] into [:hover], selectors the author never wrote. *)
+  neg_parse ". x" "space between the dot and the class name";
+  neg_parse "a . b" "space between the dot and the class name after a type";
+  neg_parse ": hover" "space between the colon and the pseudo-class name";
+  neg_parse ":: before" "space between the colons and the pseudo-element name";
+  check_minified_equiv ".x";
+  check_minified_equiv "a .b";
+  check_minified_equiv ":hover";
+  check_minified_equiv "::before"
 
 (* Test broken selectors with Parse_error exceptions. The exact error rendering
    moved when we switched to the component-stream parser; tests now only assert


### PR DESCRIPTION
Selectors 4 sec. 5.1 has a class name follow its dot immediately and sec. 3.5 a pseudo-class name its colon. `. x a` used to read as `.x a` and `: hover` as `:hover`, so cascade matched elements the author never named where every browser drops the rule.