### PR TITLE
inline: keep every definition of a name the sheet still references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -342,11 +342,11 @@ to lose a whole rule over one bad piece. Both are gone.
   name (#418, #426, #430, #441, #552, #553, #556, #559, #950, #976)
 
 - `--inline-vars` keeps a `var()` live where the definition it names sits on a
-  selector the pass cannot prove reaches the element, since `#o { --x: red }`
-  may well style an ancestor of `#i`. CSS Variables 1 sec. 3 puts the fallback
-  in only for a custom property holding its guaranteed-invalid initial value,
-  and `#i { color: var(--x, lime) }` took `lime` where the browser paints red
-  (#985)
+  selector or in an `@media` the pass cannot prove reaches the element, and
+  every definition of a name still referenced reaches the output. CSS Variables
+  1 sec. 3 puts the fallback in only for a custom property holding its
+  guaranteed-invalid initial value, so `#o { --x: red } #i { color: var(--x,
+  lime) }` took `lime` where the browser paints red (#985, #986)
 
 - A `.` or a `:` names nothing across a space, so `. x a` and `: hover` are
   dropped rather than read as `.x a` and `:hover`. Selectors 4 sec. 5.1 has a

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1185,9 +1185,11 @@ let live_marker () =
   (live, pending, mark)
 
 let live_customs ~consumers ~customs =
-  let path_visible ~scope_path ~consumer_path =
-    at_path_prefix ~outer:scope_path ~inner:consumer_path
-  in
+  (* A reference still in the sheet is answered by the browser's own cascade, so
+     a definition of the name it holds is live wherever it sits. The at-rule
+     path decides what may be folded here; it never decides what a reference
+     left standing can reach. *)
+  let path_visible ~scope_path:_ ~consumer_path:_ = true in
   let visible_ref_set = visible_ref_sets ~path_visible ~consumers in
   let by_name = index_customs (fun (_, _, name, _) -> name) customs in
   let by_scope = index_customs (fun (path, sel, _, _) -> (path, sel)) customs in

--- a/test/cli/inline_vars_scope.t
+++ b/test/cli/inline_vars_scope.t
@@ -12,8 +12,10 @@ preserves the var() reference for non-descendant uses.
   $ cascade --minify --inline-vars scoped-decl.css
   .theme{--c:red;.descendant{color:red}}.other{color:var(--c)}
 
-A variable declared inside @media is in scope only for consumers within
-that @media block.
+A variable declared inside @media is folded only into consumers within
+that @media block. A consumer outside keeps its var() reference, and the
+definition goes to the output with it: the browser answers the reference
+from its own cascade whenever the condition holds.
 
   $ cat > media.css <<EOF
   > @media (min-width: 30em) {
@@ -23,7 +25,7 @@ that @media block.
   > .b { color: var(--brand) }
   > EOF
   $ cascade --minify --inline-vars media.css
-  @media(width>=30em){.a{color:red}}.b{color:var(--brand)}
+  @media(width>=30em){:root{--brand:red}.a{color:red}}.b{color:var(--brand)}
 
 A cascade layer only orders competing declarations, it does not scope
 custom-property visibility (unlike the conditional @media / @container),

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -387,7 +387,13 @@ let test_inline_vars_out_of_scope_definition_stays_live () =
   check_inline_case "a definition that covers the consumer still folds"
     ":root{--x:red}#i{color:var(--x,lime)}" "#i{color:red}";
   check_inline_case "a name the sheet never defines takes the fallback"
-    "#i{color:var(--nope,lime)}" "#i{color:lime}"
+    "#i{color:var(--nope,lime)}" "#i{color:lime}";
+  (* A reference the pass leaves live is answered by the browser's own cascade,
+     so every definition of the name it might reach has to reach the output with
+     it. *)
+  check_inline_case "a live reference keeps the definition it may reach"
+    "@media (min-width:1px){:root{--x:red}}#i{color:var(--x,lime)}"
+    "@media(min-width:1px){:root{--x:red}}#i{color:var(--x,lime)}"
 
 let test_inline_fallback_lists () =
   check_inline_case "font-family multi-comma fallback substitutes as token list"
@@ -775,21 +781,26 @@ let test_inline_layer_flattening () =
     ".x{color:blue}.y{padding:1px}"
 
 (* An at-rule path is a containment test, not an equality: a custom property is
-   visible to a consumer wrapped in every block it sits in and then some, and to
-   nobody outside its own. A [@layer] is transparent to that test, so a path
-   crossing one still has to line the conditional blocks up. Both directions pin
-   the orientation the paths are compared in. *)
+   folded into a consumer wrapped in every block it sits in and then some, and
+   into nobody outside its own. A [@layer] is transparent to that test, so a
+   path crossing one still has to line the conditional blocks up. Both
+   directions pin the orientation the paths are compared in.
+
+   The path decides what may be folded, never what a reference left standing can
+   reach: the browser answers that one from its own cascade under whatever
+   condition holds, so the definition goes to the output with the reference. *)
 let test_inline_at_path_containment () =
   check_inline_case "an outer definition reaches a deeper consumer"
     "@media print{@media (min-width:10px){:root{--x:red}@layer l{@media \
      (min-width:20px){.a{color:var(--x)}}}}}"
     "@media print{@media(min-width:10px){@layer \
      l{@media(min-width:20px){.a{color:red}}}}}";
-  check_inline_case "an inner definition does not reach an outer consumer"
-    "@media print{:root{--x:red}}.a{color:var(--x)}" ".a{color:var(--x)}";
+  check_inline_case "an inner definition is not folded into an outer consumer"
+    "@media print{:root{--x:red}}.a{color:var(--x)}"
+    "@media print{:root{--x:red}}.a{color:var(--x)}";
   check_inline_case "a sibling block at the same depth is not an enclosing one"
     "@media print{:root{--x:red}}@media screen{.a{color:var(--x)}}"
-    "@media screen{.a{color:var(--x)}}"
+    "@media print{:root{--x:red}}@media screen{.a{color:var(--x)}}"
 
 (* Liveness is decided by a fixpoint: a variable is live when a rule that can
    see it reads it, and a variable read by a live one is live too. The chain


### PR DESCRIPTION
A `var()` the pass leaves live is answered by the browser's own cascade, so a definition of its name matters wherever it sits. Liveness was decided by the same at-rule containment that decides folding, so `@media print { :root { --x: red } } .a { color: var(--x) }` lost the definition and `.a` stopped being red on paper.