### PR TITLE
inline: leave a refused substitution to the browser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -341,6 +341,12 @@ to lose a whole rule over one bad piece. Both are gone.
   refuses a string that is not a selector rather than reading it as an element
   name (#418, #426, #430, #441, #552, #553, #556, #559, #950, #976)
 
+- A substituted value the property refuses leaves its `var()` in place rather
+  than being written back or dropped. CSS Variables 1 sec. 3 makes such a
+  declaration invalid at computed-value time, which is the property's inherited
+  or initial value, so `width: 37px; width: var(--nope, notalength)` measured
+  37px where the browser lays out `auto` (#987)
+
 - `--inline-vars` keeps a `var()` live where the definition it names sits on a
   selector or in an `@media` the pass cannot prove reaches the element, and
   every definition of a name still referenced reaches the output. CSS Variables

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -513,11 +513,6 @@ let declaration_with_components decl components : Declaration.declaration option
         | { kind = Token.String _; _ } -> true
         | _ -> false)
     in
-    let has_comma =
-      components_contain (function
-        | { kind = Token.Comma; _ } -> true
-        | _ -> false)
-    in
     (* [font-family] reaches here typed or, when its value never parsed as one,
        as the unknown property of that name; both are the same property. *)
     let is_font_family =
@@ -531,9 +526,13 @@ let declaration_with_components decl components : Declaration.declaration option
     match Declaration.with_value decl value with
     | decl -> Some decl
     | exception Cursor.Parse_error _ ->
-        if is_font_family && has_string components then opaque ()
-        else if has_comma components then None
-        else opaque ()
+        (* [font-family] takes a list of names this reader does not model as
+           one, so the substituted text is written back as it stands. Anywhere
+           else a refused substitution is CSS Variables 1 sec. 3's invalid at
+           computed-value time, which is the property's inherited or initial
+           value: writing the refused text back hands the slot to the
+           declaration before it instead, and dropping it does the same. *)
+        if is_font_family && has_string components then opaque () else None
 
 let should_use_typed_default ~kept visible vars =
   vars <> []
@@ -559,7 +558,12 @@ let apply_substituted_components ctx decl ~original_components components =
     Some (Context.eval ctx decl)
   else
     match declaration_with_components decl components with
-    | None -> None
+    | None ->
+        (* The substitution is no value for this property, so the declaration is
+           invalid at computed-value time and neither the refused text nor the
+           declaration's absence says that. The reference stays, and the browser
+           answers it. *)
+        Some decl
     | Some decl -> Some (Context.eval ctx decl)
 
 (* A name the sheet defines out of this consumer's sight is live here for the

--- a/test/cli/inline_vars_fallback.t
+++ b/test/cli/inline_vars_fallback.t
@@ -12,14 +12,17 @@ as a directly-written value.
   $ cascade --minify --inline-vars basic.css
   .a,.b{color:red}.c{color:#0000}
 
-Nested var() in fallback chains through to the deepest defined value.
+Nested var() in fallback chains through to the deepest defined value. A
+deepest value the property refuses leaves the declaration invalid at
+computed-value time, which is neither the refused text nor the
+declaration's absence, so the reference stays for the browser to answer.
 
   $ cat > nested.css <<EOF
   > .a { color: var(--undef, var(--also-undef, blue)) }
   > .b { color: var(--undef, var(--also-undef, var(--third, fallback))) }
   > EOF
   $ cascade --minify --inline-vars nested.css
-  .a{color:#00f}.b{color:fallback}
+  .a{color:#00f}.b{color:var(--undef,var(--also-undef,var(--third,fallback)))}
 
 A var() with no fallback that cannot resolve preserves the var()
 verbatim - the spec says the declaration is invalid at computed time;
@@ -42,25 +45,26 @@ A fallback containing a calc() reduces after the var() wrapper drops.
 
 A multi-comma fallback list (font-family fallback chain) is preserved -
 commas inside the fallback are part of the fallback's token stream per
-Custom Properties L1 §2. If that token stream is invalid for the
-destination property, the declaration is invalid and drops under
-minification.
+Custom Properties L1 §2. A token stream the destination property refuses
+leaves the declaration invalid at computed-value time, so the reference
+stays.
 
   $ cat > list.css <<EOF
   > .a { font-family: var(--font, "Helvetica Neue", sans-serif) }
   > .b { color: var(--undef, red, blue) }
   > EOF
   $ cascade --minify --inline-vars list.css
-  .a{font-family:Helvetica Neue,sans-serif}
+  .a{font-family:Helvetica Neue,sans-serif}.b{color:var(--undef,red,blue)}
 
-An empty fallback collapses to an empty value when the wrapper drops;
-for a property that does not accept an empty value, minification drops
-the invalid declaration.
+An empty fallback substitutes to an empty value; for a property that
+does not accept one the declaration is invalid at computed-value time,
+so the reference stays.
 
   $ cat > empty.css <<EOF
   > .a { color: var(--undef,) }
   > EOF
   $ cascade --minify --inline-vars empty.css 2>&1 | grep -v "warning" || true
+  .a{color:var(--undef,)}
 
 A non-trivial fallback is NOT eagerly inlined when the var() name
 resolves elsewhere - only an unresolvable reference emits the fallback.

--- a/test/cli/inline_vars_scope.t
+++ b/test/cli/inline_vars_scope.t
@@ -114,14 +114,16 @@ the now-unreferenced custom property is dead-stripped.
   .a{color:red}
 
 A two-cycle [--a -> --b -> --a] is detected and both definitions stay
-verbatim with consumers falling back.
+verbatim. The consumer's fallback is no colour, so its declaration is
+invalid at computed-value time and the reference stays for the browser
+to answer.
 
   $ cat > two-cycle.css <<EOF
   > :root { --a: var(--b); --b: var(--a) }
   > .x { color: var(--a, fallback) }
   > EOF
   $ cascade --minify --inline-vars two-cycle.css 2>&1 | grep -v "warning"
-  :root{--a:var(--b);--b:var(--a)}.x{color:fallback}
+  :root{--a:var(--b);--b:var(--a)}.x{color:var(--a,fallback)}
 
 A three-step indirect cycle [--a -> --b -> --c -> --a] is detected the
 same way.
@@ -135,7 +137,7 @@ same way.
   > .x { color: var(--a, fallback) }
   > EOF
   $ cascade --minify --inline-vars three-cycle.css 2>&1 | grep -v "warning"
-  :root{--a:var(--b);--b:var(--c);--c:var(--a)}.x{color:fallback}
+  :root{--a:var(--b);--b:var(--c);--c:var(--a)}.x{color:var(--a,fallback)}
 
 A var() inside a string token is NOT substituted - per CSS Custom
 Properties L1 §2 substitution does not look inside [<string>] tokens.

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -362,10 +362,14 @@ let test_inline_import_supports_query_modes () =
     (input |> Css.inline_imports ~query:evergreen loader |> minified)
 
 let test_inline_vars_fallback_edges () =
+  (* [fallback] is no colour, so the second declaration is invalid at
+     computed-value time and neither its refused text nor its absence says so:
+     the reference stays for the browser to answer. *)
   check_inline_case "nested missing vars use deepest fallback"
     ".a{color:var(--undef,var(--also-undef,blue))}.b{color:var(--undef,var(--also-undef,var(--third,fallback)))}"
-    ~optimized:".a{color:#00f}.b{color:fallback}"
-    ".a{color:blue}.b{color:fallback}";
+    ~optimized:
+      ".a{color:#00f}.b{color:var(--undef,var(--also-undef,var(--third,fallback)))}"
+    ".a{color:blue}.b{color:var(--undef,var(--also-undef,var(--third,fallback)))}";
   check_inline_case "missing var without fallback stays unresolved"
     ".a{color:var(--undef)}" ".a{color:var(--undef)}";
   check_inline_case "calc fallback resolves and canonicalizes"
@@ -393,27 +397,37 @@ let test_inline_vars_out_of_scope_definition_stays_live () =
      it. *)
   check_inline_case "a live reference keeps the definition it may reach"
     "@media (min-width:1px){:root{--x:red}}#i{color:var(--x,lime)}"
-    "@media(min-width:1px){:root{--x:red}}#i{color:var(--x,lime)}"
+    "@media(min-width:1px){:root{--x:red}}#i{color:var(--x,lime)}";
+  (* CSS Variables 1 sec. 3 makes a declaration whose substitution the property
+     refuses invalid at computed-value time, which is the property's inherited
+     or initial value and not the declaration written before it. Writing the
+     refused text back hands the slot to that earlier declaration instead, so
+     the reference stays and the browser answers it. *)
+  check_inline_case "a substitution the property refuses keeps the reference"
+    "#i{width:37px;width:var(--nope,notalength)}"
+    "#i{width:37px;width:var(--nope,notalength)}";
+  check_inline_case "an empty binding substituted into a property keeps it"
+    ":root{--x:}#i{content:\"zz\";content:var(--x)}"
+    ":root{--x:}#i{content:\"zz\";content:var(--x)}"
 
 let test_inline_fallback_lists () =
   check_inline_case "font-family multi-comma fallback substitutes as token list"
     ".a{font-family:var(--font,\"Helvetica Neue\",sans-serif)}"
     ".a{font-family:Helvetica Neue,sans-serif}";
-  check_inline_case
-    "invalid color multi-comma fallback drops under minification"
-    ".a{color:var(--undef,red,blue)}" "";
-  check_inline_case "empty fallback makes invalid color declaration drop"
-    ".a{color:var(--undef,)}" ""
+  check_inline_case "invalid color multi-comma fallback keeps the reference"
+    ".a{color:var(--undef,red,blue)}" ".a{color:var(--undef,red,blue)}";
+  check_inline_case "an empty fallback keeps the reference too"
+    ".a{color:var(--undef,)}" ".a{color:var(--undef,)}"
 
 let test_inline_cycle_fallbacks () =
   check_inline_case "self-cycle uses consumer fallback and strips dead var"
     ":root{--x:var(--x)}.a{color:var(--x,red)}" ".a{color:red}";
   check_inline_case "two-cycle uses consumer fallback"
     ":root{--a:var(--b);--b:var(--a)}.x{color:var(--a,fallback)}"
-    ":root{--a:var(--b);--b:var(--a)}.x{color:fallback}";
+    ":root{--a:var(--b);--b:var(--a)}.x{color:var(--a,fallback)}";
   check_inline_case "three-cycle uses consumer fallback"
     ":root{--a:var(--b);--b:var(--c);--c:var(--a)}.x{color:var(--a,fallback)}"
-    ":root{--a:var(--b);--b:var(--c);--c:var(--a)}.x{color:fallback}";
+    ":root{--a:var(--b);--b:var(--c);--c:var(--a)}.x{color:var(--a,fallback)}";
   (* A cyclic custom property is invalid at computed-value time: its own var()
      fallback does not rescue it, so the consumer's fallback wins. *)
   check_inline_case
@@ -917,10 +931,12 @@ let test_inline_keeps_a_page_break_property_from_css () =
       ( ":root{--pb:avoid}.a{page-break-inside:var(--pb)}",
         ".a{break-inside:avoid}" );
       (":root{--pb:left}.a{page-break-after:var(--pb)}", ".a{break-after:left}");
-      (* A substitution the legacy grammar rejects leaves the declaration in
-         place rather than retyping it as a property that would accept it. *)
+      (* A substitution the legacy grammar rejects is invalid at computed-value
+         time, so the reference stays rather than being retyped as a property
+         that would accept it or written back as text the browser drops on
+         reading. *)
       ( ":root{--pb:avoid-page}.a{page-break-inside:var(--pb)}",
-        ".a{page-break-inside:avoid-page}" );
+        ":root{--pb:avoid-page}.a{page-break-inside:var(--pb)}" );
     ]
 
 let suite =


### PR DESCRIPTION
CSS Variables 1 sec. 3 makes a declaration whose substitution the property refuses invalid at computed-value time, which is the property's inherited or initial value. Writing the refused text back hands the slot to the declaration before it, and so does dropping it: `width: 37px; width: var(--nope, notalength)` measured 37px where the browser lays out `auto`. The reference now stays for the browser to answer.