### PR TITLE
inline: count a name written inside another reference's fallback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -352,7 +352,7 @@ to lose a whole rule over one bad piece. Both are gone.
   every definition of a name still referenced reaches the output. CSS Variables
   1 sec. 3 puts the fallback in only for a custom property holding its
   guaranteed-invalid initial value, so `#o { --x: red } #i { color: var(--x,
-  lime) }` took `lime` where the browser paints red (#985, #986)
+  lime) }` took `lime` where the browser paints red (#985, #986, #988)
 
 - A `.` or a `:` names nothing across a space, so `. x a` and `: hover` are
   dropped rather than read as `.x a` and `:hover`. Selectors 4 sec. 5.1 has a

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1056,7 +1056,14 @@ let refs_of_declaration decl =
         _;
       } ->
       refs_of_components (Properties.components_of_custom_property_value value)
-  | _ -> names_of_vars (Variables.vars_of_declarations [ decl ])
+  | _ ->
+      (* The typed reading names the [var()] the value is built on; a name
+         written inside another reference's fallback reaches the census only
+         through the token stream, and it is referenced like any other. *)
+      names_of_vars (Variables.vars_of_declarations [ decl ])
+      @ refs_of_component_string
+          (Declaration.string_of_value ~minify:false decl)
+      |> List.sort_uniq String.compare
 
 (* Collect, per declaration, its scope and the var names its body references.
    [consumers] are non-custom declarations (direct liveness); [customs] are

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -408,7 +408,12 @@ let test_inline_vars_out_of_scope_definition_stays_live () =
     "#i{width:37px;width:var(--nope,notalength)}";
   check_inline_case "an empty binding substituted into a property keeps it"
     ":root{--x:}#i{content:\"zz\";content:var(--x)}"
-    ":root{--x:}#i{content:\"zz\";content:var(--x)}"
+    ":root{--x:}#i{content:\"zz\";content:var(--x)}";
+  (* A name written inside another reference's fallback is referenced like any
+     other, so its definition is live. *)
+  check_inline_case "a name inside a fallback keeps its definition"
+    "#i{--x:;width:var(--nope,var(--x,8px))}"
+    "#i{--x:;width:var(--nope,var(--x,8px))}"
 
 let test_inline_fallback_lists () =
   check_inline_case "font-family multi-comma fallback substitutes as token list"


### PR DESCRIPTION
The liveness census read the typed value, which names the `var()` the value is built on and not one written inside its fallback. `#i { --x: ; width: var(--nope, var(--x, 8px)) }` lost the `--x` definition, so the browser answered the reference with `8px` instead of the empty value.