### PR TITLE
declaration: take the empty value a custom property may hold

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -347,6 +347,11 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `Css.Declaration.parse_custom_property` takes the empty value, the one CSS
+  Variables 1 sec. 2 gives a custom property alongside every
+  `<declaration-value>`, so it now accepts the pairs `custom_property` accepts
+  (#990)
+
 - `--inline-vars` keeps a `var()` live where the definition it names sits on a
   selector or in an `@media` the pass cannot prove reaches the element, or
   holds a CSS-wide keyword, and every definition of a name still referenced

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -803,10 +803,14 @@ let collect_theme_defaults ~theme ~theme_defaults ~keep_set stylesheet =
    makes exactly one custom-property declaration. A name or value that would
    escape it - a [}] closing the block, a top-level [;] starting a second
    declaration, an unterminated string - is not a binding this library can
-   write, so the name stays unresolved and its [var()] reference stays live. *)
+   write, so the name stays unresolved and its [var()] reference stays live. An
+   empty answer is a value a custom property may hold, but here it is the caller
+   saying the name has no default, so it binds nothing either. *)
 let theme_default_declaration (name, value) =
-  let name = Custom_property_name.add_prefix name in
-  Declaration.parse_custom_property name value
+  if String.trim value = "" then Option.None
+  else
+    let name = Custom_property_name.add_prefix name in
+    Declaration.parse_custom_property name value
 
 (* [lookup] restricted to the answers that bind: anything else reads as [None],
    the "no default for this name" answer the rest of the resolver

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2632,8 +2632,11 @@ let parse_opaque_declaration property value =
       Some (read_unknown_property_declaration t name)
     with Cursor.Parse_error _ -> None
 
+(* CSS Variables 1 sec. 2 gives a custom property the value grammar
+   [<declaration-value>?], the empty value included, so this takes the pairs
+   [custom_property] takes and answers with an option rather than raising. *)
 let parse_custom_property name value =
-  if is_custom_property_name name && is_declaration_value value then
+  if is_custom_property_name name && is_optional_declaration_value value then
     parse_declaration name value
   else None
 

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -113,14 +113,15 @@ val parse_opaque_declaration : string -> string -> declaration option
 val parse_custom_property : string -> string -> declaration option
 (** [parse_custom_property name value] is {!parse_declaration} restricted to a
     custom property that a rule can hold. It is [None] unless [name] is a
-    [<dashed-ident>] and [value] is one [<declaration-value>] (CSS Syntax 3 (ED)
-    sec. 7.2): no [<bad-string-token>], no [<bad-url-token>], no unmatched
-    closing bracket, no unterminated function or block, and no top-level [;].
+    [<dashed-ident>] and [value] is the [<declaration-value>?] CSS Variables 1
+    sec. 2 gives a custom property: no [<bad-string-token>], no
+    [<bad-url-token>], no unmatched closing bracket, no unterminated function or
+    block, and no top-level [;] or [!] (CSS Syntax 3 (ED) sec. 7.2). The empty
+    value is one of its values.
 
     Use it for a name or value that comes from outside the parser, where the
     string may close the block it is placed in or start a second declaration.
-    {!custom_property} takes the same pairs and raises on the rest, and also
-    takes the empty value CSS Variables 1 sec. 2 allows. *)
+    {!custom_property} takes the same pairs and raises on the rest. *)
 
 val custom_declaration_layer : declaration -> string option
 (** [custom_declaration_layer d] is the layer of [d], if any. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3842,8 +3842,8 @@ let typed_custom_font_family_layer_printing () =
 (* [parse_custom_property] builds a declaration from a name and value that came
    from outside the parser, so it takes only a pair that writes back as the one
    declaration it claims to be: a [<dashed-ident>] name, written back with the
-   escapes that read it (CSS Syntax 3 sec. 4.3.7), and a CSS Syntax 3 sec. 8.2
-   [<declaration-value>]. *)
+   escapes that read it (CSS Syntax 3 sec. 4.3.7), and the
+   [<declaration-value>?] CSS Variables 1 sec. 2 gives a custom property. *)
 let parse_custom_property_guard () =
   let bind name value =
     match parse_custom_property name value with
@@ -3875,7 +3875,10 @@ let parse_custom_property_guard () =
       ("red]", "<rejected>");
       ("rgb(1,2,3", "<rejected>");
       ("{a:b", "<rejected>");
-      ("", "<rejected>");
+      (* CSS Variables 1 sec. 2 gives a custom property the value grammar
+         [<declaration-value>?], so the empty value is one of its values and
+         writes back as the declaration it names. *)
+      ("", "--x:");
     ];
   List.iter
     (fun (name, expected) ->


### PR DESCRIPTION
CSS Variables 1 sec. 2 gives a custom property the value grammar `<declaration-value>?`, so `--x:` is one of its values. `parse_custom_property` refused it while `custom_property` took it, so the two took different pairs. An empty theme default still binds nothing: there it is the caller saying the name has no default.