### PR TITLE
context: answer a cyclic binding with the reference's fallback in a length

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -352,7 +352,9 @@ to lose a whole rule over one bad piece. Both are gone.
   property's grammar refuses, and a CSS-wide keyword, whose meaning CSS
   Variables 1 sec. 2.1 leaves to the cascade. Sec. 3 puts the fallback in only
   for a property holding its guaranteed-invalid initial value, so
-  `Css.eval_stylesheet` measured `8px` where the browser lays out `auto` (#991)
+  `Css.eval_stylesheet` measured `8px` where the browser lays out `auto`. A
+  binding that references itself is that initial value, and there the fallback
+  answers in a length as it already did elsewhere (#991, #992)
 
 - `Css.Declaration.parse_custom_property` takes the empty value, the one CSS
   Variables 1 sec. 2 gives a custom property alongside every

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -1090,10 +1090,24 @@ module Calc_residual = struct
         simplify_calc_value ops simplify simplify_calc ~authored ~visited calc
     | None -> simplify_plain_value ops simplify simplify_calc ~visited value
 
+  (* A binding that resolves to a reference of its own is a cycle, which CSS
+     Variables 1 sec. 3 makes the guaranteed-invalid value, so the consumer's
+     fallback answers for it. This is the reading {!Var_residual} already takes
+     for a value with no calc arm. *)
+  let calc_var_result (type a) (ops : a ops) simplify_resolved ~visited
+      (var : a Values.var) (value : a) : a =
+    if Option.is_none (ops.as_var value) then value
+    else
+      match (var.Values.fallback : a Values.fallback) with
+      | Values.Fallback fb -> simplify_resolved ~authored:false ~visited fb
+      | Values.Syntax_fallback _ | Values.Var_fallback _ | Values.Empty
+      | Values.Empty2 | Values.None ->
+          value
+
   let simplify_calc_var ops resolve_var simplify_var_record simplify_resolved
       ~visited var =
     match resolve_var ~simplify:simplify_resolved ~visited var with
-    | Some value -> value
+    | Some value -> calc_var_result ops simplify_resolved ~visited var value
     | None ->
         ops.of_var
           (simplify_var_record ~simplify:simplify_resolved ~visited var)
@@ -1109,7 +1123,9 @@ module Calc_residual = struct
       | Values.Val value -> calc_of_value ~visited value
       | Values.Var var -> (
           match resolve_var ~simplify:simplify_resolved ~visited var with
-          | Some value -> calc_of_value ~visited value
+          | Some value ->
+              calc_of_value ~visited
+                (calc_var_result ops simplify_resolved ~visited var value)
           | None ->
               Values.Var
                 (simplify_var_record ~simplify:simplify_resolved ~visited var))

--- a/test/test_context.ml
+++ b/test/test_context.ml
@@ -2692,7 +2692,12 @@ let unreadable_binding_is_not_an_absent_one () =
       ("inherit", ".a{width:var(--x,8px)}");
       (* A binding this resolver can read still answers. *)
       ("2px", ".a{width:2px}");
-    ]
+    ];
+  (* Sec. 3 makes a custom property that references itself invalid at
+     computed-value time, which is the guaranteed-invalid value, so there the
+     reference's fallback is exactly the answer. *)
+  check_eval_stylesheet "--x: var(--x)" ~ctx:(ctx "var(--x)")
+    ~expected:".a{width:8px}" ".a{width:var(--x,8px)}"
 
 let suite =
   ( "context",


### PR DESCRIPTION
CSS Variables 1 sec. 3 makes a custom property that references itself invalid at computed-value time, which is the guaranteed-invalid value, so a reference to it takes its fallback. The value arm read it that way and the calc arm handed the residual reference back instead, so `--x: var(--x)` left `width: var(--x, 8px)` unanswered where the browser lays out 8px.