### PR TITLE
page-break: take every css-wide keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -347,6 +347,10 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `page-break-before`, `page-break-after` and `page-break-inside` take every
+  CSS-wide keyword, which CSS Cascade 5 sec. 7.3 gives to every property, and
+  each one reaches the `break-*` alias unmoved. Only `inherit` was read (#993)
+
 - A `var()` whose custom property the evaluator cannot read a value from keeps
   its reference rather than taking its fallback: an empty binding, one the
   property's grammar refuses, and a CSS-wide keyword, whose meaning CSS

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -2156,7 +2156,11 @@ type page_break_value = Properties.page_break_value =
   | Avoid
   | Left
   | Right
+  | Initial
   | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
   | Var of page_break_value var
       (** CSS Fragmentation 3 sec. 3.4 deprecated [page-break-inside]
           vocabulary. *)
@@ -2164,7 +2168,11 @@ type page_break_value = Properties.page_break_value =
 type page_break_inside_value = Properties.page_break_inside_value =
   | Auto
   | Avoid
+  | Initial
   | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
   | Var of page_break_inside_value var
 
 val page_break_before : page_break_value -> declaration

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -67,14 +67,22 @@ let rec pp_page_break_value : page_break_value Pp.t =
   | Avoid -> Pp.string ctx "avoid"
   | Left -> Pp.string ctx "left"
   | Right -> Pp.string ctx "right"
+  | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
 
 let rec pp_page_break_inside_value : page_break_inside_value Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_page_break_inside_value ctx v
   | Auto -> Pp.string ctx "auto"
   | Avoid -> Pp.string ctx "avoid"
+  | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
 
 (* CSS Fragmentation 3 sec. 3.4 defines the page-break-* aliases by a value
    mapping table: [auto | left | right | avoid] map to themselves and [always]
@@ -89,7 +97,13 @@ let break_of_page_break (value : page_break_value) : break_value option =
   | Avoid -> Some Avoid
   | Left -> Some Left
   | Right -> Some Right
+  (* CSS Cascade 5 sec. 7.3 gives every property the CSS-wide keywords, and the
+     alias and its target take each one alike. *)
+  | Initial -> Some Initial
   | Inherit -> Some Inherit
+  | Unset -> Some Unset
+  | Revert -> Some Revert
+  | Revert_layer -> Some Revert_layer
   | Var _ -> None
 
 let break_inside_of_page_break (value : page_break_inside_value) :
@@ -97,7 +111,11 @@ let break_inside_of_page_break (value : page_break_inside_value) :
   match value with
   | Auto -> Some Auto
   | Avoid -> Some Avoid
+  | Initial -> Some Initial
   | Inherit -> Some Inherit
+  | Unset -> Some Unset
+  | Revert -> Some Revert
+  | Revert_layer -> Some Revert_layer
   | Var _ -> None
 
 (* CSS Multicol 2 sec. 4.5 leaves an omitted component at its longhand's
@@ -274,7 +292,11 @@ let rec read_page_break_value t : page_break_value =
       ("avoid", Avoid);
       ("left", Left);
       ("right", Right);
+      ("initial", Initial);
       ("inherit", Inherit);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
     ]
     ~var:(fun t -> Var (Values.read_var read_page_break_value t))
     t
@@ -284,7 +306,11 @@ let rec read_page_break_inside_value t : page_break_inside_value =
     [
       ("auto", (Auto : page_break_inside_value));
       ("avoid", Avoid);
+      ("initial", Initial);
       ("inherit", Inherit);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
     ]
     ~var:(fun t -> Var (Values.read_var read_page_break_inside_value t))
     t

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3901,13 +3901,21 @@ type page_break_value =
   | Avoid
   | Left
   | Right
+  | Initial
   | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
   | Var of page_break_value var
 
 type page_break_inside_value =
   | Auto
   | Avoid
+  | Initial
   | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
   | Var of page_break_inside_value var
 
 (* CSS Paged Media 3 sec. 7.1 [size] descriptor: optional page size keyword

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3712,6 +3712,23 @@ let spec_break3_page_break_var () =
         "page-break-inside: avoid",
         "break-inside:avoid" );
       ("page-break-inside: auto", "page-break-inside: auto", "break-inside:auto");
+      (* CSS Cascade 5 sec. 7.3 gives every property the CSS-wide keywords, and
+         the alias and its target take each one alike. *)
+      ( "page-break-after: initial",
+        "page-break-after: initial",
+        "break-after:initial" );
+      ( "page-break-before: unset",
+        "page-break-before: unset",
+        "break-before:unset" );
+      ( "page-break-after: revert",
+        "page-break-after: revert",
+        "break-after:revert" );
+      ( "page-break-inside: revert-layer",
+        "page-break-inside: revert-layer",
+        "break-inside:revert-layer" );
+      ( "page-break-inside: inherit",
+        "page-break-inside: inherit",
+        "break-inside:inherit" );
     ];
   (* The [var()] declaration is the property it names, not an opaque one that
      happens to spell the same: it answers [same_property] against a keyword


### PR DESCRIPTION
CSS Cascade 5 sec. 7.3 gives every property the CSS-wide keywords. `page-break-before`, `page-break-after` and `page-break-inside` read only `inherit`, so `page-break-after: initial` was dropped where every browser keeps it.