### PR TITLE
border-image-slice: take every css-wide keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,17 @@ entry points both moved.
 
 ### Breaking
 
+- `Cascade.Properties.border_image_slice` is a variant carrying the CSS-wide
+  keywords, the way its `border-image-width`, `-outset` and `-repeat` siblings
+  already were, and the offsets it used to be are
+  `border_image_slice_offsets`, which is what the `border_image` shorthand
+  record holds. A caller building the record writes `Slices { offsets; fill }`
+  (#994)
+
+- `Cascade.Properties.page_break_value` and `page_break_inside_value` gain
+  `Initial`, `Unset`, `Revert` and `Revert_layer`. Exhaustive visitors must
+  handle the four new leaves (#993)
+
 - `Css.filter` gains `Omitted of filter_function` to retain empty calls.
   Exhaustive visitors must handle this leaf; normalization equates it with
   its specified default (#870).
@@ -347,9 +358,10 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
-- `page-break-before`, `page-break-after` and `page-break-inside` take every
-  CSS-wide keyword, which CSS Cascade 5 sec. 7.3 gives to every property, and
-  each one reaches the `break-*` alias unmoved. Only `inherit` was read (#993)
+- `page-break-before`, `page-break-after`, `page-break-inside` and
+  `border-image-slice` take every CSS-wide keyword, which CSS Cascade 5 sec.
+  7.3 gives to every property. The `page-break-*` aliases read only `inherit`
+  and `border-image-slice` read none of them (#993, #994)
 
 - A `var()` whose custom property the evaluator cannot read a value from keeps
   its reference rather than taking its fallback: an empty binding, one the

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1070,11 +1070,21 @@ let pp_bg_size_with_position maybe_space (bg : background_shorthand) ctx =
 let pp_border_image_slice_item ctx (value : border_image_slice_item) =
   match value with Number n -> Pp.float ctx n | Pct n -> Pp.pct ctx n
 
-let pp_border_image_slice ctx { offsets; fill } =
+let pp_border_image_slice_offsets ctx { offsets; fill } =
   Pp.list ~sep:Pp.space pp_border_image_slice_item ctx offsets;
   if fill then (
     Pp.space ctx ();
     Pp.string ctx "fill")
+
+let rec pp_border_image_slice ctx (value : border_image_slice) =
+  match value with
+  | Slices offsets -> pp_border_image_slice_offsets ctx offsets
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+  | Var v -> pp_var pp_border_image_slice ctx v
 
 let pp_border_image_width_item ctx (value : border_image_width_item) =
   match value with
@@ -1144,7 +1154,7 @@ let normalize_border_image : border_image -> border_image =
   in
   let slice_initial =
     drop
-      (fun (s : border_image_slice) ->
+      (fun (s : border_image_slice_offsets) ->
         (not s.fill)
         &&
         match s.offsets with
@@ -1201,7 +1211,7 @@ let pp_border_image : border_image Pp.t =
     else Pp.space ctx ()
   in
   pp_bg_prop maybe_space pp_background_image ctx source;
-  pp_bg_prop maybe_space pp_border_image_slice ctx slice;
+  pp_bg_prop maybe_space pp_border_image_slice_offsets ctx slice;
   (match width with
   | None -> ()
   | Some width ->
@@ -2248,7 +2258,7 @@ let read_border_image_slice_step t values has_fill =
         `Continue (values, true)
     | _ -> read_border_image_slice_value t values has_fill
 
-let read_border_image_slice t : border_image_slice =
+let read_border_image_slice_offsets t : border_image_slice_offsets =
   let rec loop values has_fill =
     match read_border_image_slice_step t values has_fill with
     | `Stop -> (values, has_fill)
@@ -2259,6 +2269,24 @@ let read_border_image_slice t : border_image_slice =
   | [], true -> Cursor.err_invalid t "border-image fill requires slice values"
   | [], false -> Cursor.err_expected t "border-image slice"
   | offsets, fill -> { offsets; fill }
+
+(* CSS Cascade 5 sec. 7.3 gives the longhand the CSS-wide keywords; the
+   shorthand takes offsets alone. *)
+let rec read_border_image_slice t : border_image_slice =
+  match Cursor.peek_ident t with
+  | Some ("initial" | "inherit" | "unset" | "revert" | "revert-layer" | "var")
+    ->
+      Cursor.enum_or_var "border-image-slice"
+        [
+          ("initial", (Initial : border_image_slice));
+          ("inherit", Inherit);
+          ("unset", Unset);
+          ("revert", Revert);
+          ("revert-layer", Revert_layer);
+        ]
+        ~var:(fun t -> Var (Values.read_var read_border_image_slice t))
+        t
+  | Some _ | None -> Slices (read_border_image_slice_offsets t)
 
 let read_border_image_width_item t : border_image_width_item =
   let auto t =
@@ -2397,7 +2425,7 @@ let read_border_image_shorthand ~mask_mode t : border_image =
      below. *)
   let mode_early = read_mode t in
   Cursor.ws t;
-  let slice = Cursor.option read_border_image_slice t in
+  let slice = Cursor.option read_border_image_slice_offsets t in
   let width, outset =
     Cursor.ws t;
     if Cursor.slash_opt t then (

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -466,11 +466,20 @@ val pp_border_image_slice_item : border_image_slice_item Pp.t
 val read_border_image_slice_item : Cursor.t -> border_image_slice_item
 (** [read_border_image_slice_item t] parses one [border-image-slice] item. *)
 
+val pp_border_image_slice_offsets : border_image_slice_offsets Pp.t
+(** [pp_border_image_slice_offsets] pretty-prints the offsets a
+    [border-image-slice] carries, the part the [border-image] shorthand takes.
+*)
+
+val read_border_image_slice_offsets : Cursor.t -> border_image_slice_offsets
+(** [read_border_image_slice_offsets t] parses those offsets. *)
+
 val pp_border_image_slice : border_image_slice Pp.t
 (** [pp_border_image_slice] pretty-prints [border-image-slice]. *)
 
 val read_border_image_slice : Cursor.t -> border_image_slice
-(** [read_border_image_slice t] parses [border-image-slice]. *)
+(** [read_border_image_slice t] parses the [border-image-slice] longhand,
+    including the CSS-wide keywords. *)
 
 val read_border_image_repeat : Cursor.t -> border_image_repeat
 (** [read_border_image_repeat t] parses the [border-image-repeat] longhand,

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3006,10 +3006,21 @@ type mask =
 
 type border_image_slice_item = Number of float | Pct of float
 
-type border_image_slice = {
+type border_image_slice_offsets = {
   offsets : border_image_slice_item list;
   fill : bool;
 }
+
+(* CSS Backgrounds 3 sec. 5.2: [border-image-slice] is one to four offsets with
+   an optional [fill]; the longhand also takes the CSS-wide keywords. *)
+type border_image_slice =
+  | Slices of border_image_slice_offsets
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of border_image_slice var
 
 type border_image_width_item =
   | Number of float
@@ -3060,7 +3071,7 @@ type mask_border_mode = Alpha | Luminance
 
 type border_image = {
   source : background_image option;
-  slice : border_image_slice option;
+  slice : border_image_slice_offsets option;
   width : border_image_width_item list option;
   outset : border_image_outset_item list option;
   repeat : border_image_repeat_keyword list option;

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -4126,7 +4126,7 @@ let border_image_shorthand run ~source ~slice ~width ~outset ~repeat =
 
 let record_border_image_longhand
     ~(source : Properties.background_image option ref)
-    ~(slice : Properties.border_image_slice option ref)
+    ~(slice : Properties.border_image_slice_offsets option ref)
     ~(width : Properties.border_image_width_item list option ref)
     ~(outset : Properties.border_image_outset_item list option ref)
     ~(repeat : Properties.border_image_repeat_keyword list option ref) ~foldable
@@ -4134,8 +4134,9 @@ let record_border_image_longhand
   match d with
   | Declaration { property = Border_image_source; value; _ } ->
       source := Some value
-  | Declaration { property = Border_image_slice; value; _ } ->
-      slice := Some value
+  | Declaration { property = Border_image_slice; value = Slices offsets; _ } ->
+      slice := Some offsets
+  | Declaration { property = Border_image_slice; _ } -> foldable := false
   | Declaration { property = Border_image_width; value = Widths l; _ } ->
       width := Some l
   | Declaration { property = Border_image_width; _ } -> foldable := false
@@ -4151,7 +4152,9 @@ let compose_border_image_run ~allow_partial
     (run : (int * Declaration.declaration) list) :
     (int * Declaration.declaration) option =
   let source : Properties.background_image option ref = ref Option.None in
-  let slice : Properties.border_image_slice option ref = ref Option.None in
+  let slice : Properties.border_image_slice_offsets option ref =
+    ref Option.None
+  in
   let width : Properties.border_image_width_item list option ref =
     ref Option.None
   in

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -754,6 +754,10 @@ let check_border_image_slice =
   check_value_cursor "border_image_slice" read_border_image_slice
     pp_border_image_slice
 
+let check_border_image_slice_offsets =
+  check_value_cursor "border_image_slice_offsets"
+    read_border_image_slice_offsets pp_border_image_slice_offsets
+
 let check_border_image_slice_item =
   check_value_cursor "border_image_slice_item" read_border_image_slice_item
     pp_border_image_slice_item
@@ -4877,6 +4881,14 @@ let spec_generated_box_layout_edges () =
   check_border_image_outset_item "2px";
   check_border_image_repeat_keyword "round";
   check_border_image_slice "30 fill";
+  (* CSS Cascade 5 sec. 7.3 gives the longhand the CSS-wide keywords; the
+     offsets the shorthand takes are the same value without them. *)
+  check_border_image_slice "initial";
+  check_border_image_slice "inherit";
+  check_border_image_slice "unset";
+  check_border_image_slice "revert";
+  check_border_image_slice "revert-layer";
+  check_border_image_slice_offsets "30 fill";
   check_border_image_slice_item "30%";
   check_border_image_width_item "auto";
   check_border_spacing "1px 2px";


### PR DESCRIPTION
CSS Cascade 5 sec. 7.3 gives every property the CSS-wide keywords, and `border-image-width`, `-outset` and `-repeat` already carried them. `border-image-slice` was a bare record, so `border-image-slice: initial` was dropped; it is now a variant like its siblings, and the offsets the `border-image` shorthand folds are `border_image_slice_offsets`.