### PR TITLE
list-style-image: read every image the vocabulary holds

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@ entry points both moved.
 
 ### Breaking
 
+- `Cascade.Properties.list_style_image` carries an `Image of background_image`
+  where it carried a `Url of string`. CSS Lists 3 sec. 3.5 gives the property
+  an `<image>`, so `list-style-image: linear-gradient(red, blue)` reads. A
+  caller building a url writes `Image (Url u)`, or `Css.list_style_image_url`
+  (#995)
+
 - `Cascade.Properties.border_image_slice` is a variant carrying the CSS-wide
   keywords, the way its `border-image-width`, `-outset` and `-repeat` siblings
   already were, and the offsets it used to be are
@@ -357,6 +363,11 @@ to lose a whole rule over one bad piece. Both are gone.
   declaration invalid at computed-value time, which is the property's inherited
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
+
+- `list-style-image` reads every `<image>`, so a gradient, an `image-set()` and
+  a `cross-fade()` mark a list item where only a `url()` did. CSS Lists 3 sec.
+  3.5 gives the property the `<image>` vocabulary, minus the comma list only
+  `background-image` takes (#995)
 
 - `page-break-before`, `page-break-after`, `page-break-inside` and
   `border-image-slice` take every CSS-wide keyword, which CSS Cascade 5 sec.

--- a/lib/css.ml
+++ b/lib/css.ml
@@ -280,7 +280,7 @@ let list_style_string value = (String value : list_style_type)
 let list_style_symbols ?kind symbols =
   (Symbols (kind, symbols) : list_style_type)
 
-let list_style_image_url value = (Url value : list_style_image)
+let list_style_image_url value = (Image (Url value) : list_style_image)
 let svg_paint_color value = (Color value : svg_paint)
 let svg_paint_url ?fallback value = (Url (value, fallback) : svg_paint)
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7001,7 +7001,7 @@ val list_style_symbols :
 (** CSS list-style-image values *)
 type list_style_image = Properties.list_style_image =
   | None
-  | Url of string
+  | Image of background_image
   | Inherit
   | Initial
   | Unset

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -142,7 +142,7 @@ let rec pp_list_style_position : list_style_position Pp.t =
 let rec pp_list_style_image : list_style_image Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"
-  | Url u -> Pp.url ctx u
+  | Image i -> pp_background_image ctx i
   | Var v -> pp_var pp_list_style_image ctx v
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
@@ -2456,12 +2456,13 @@ let rec read_list_style_position t : list_style_position =
     ~var:(fun t -> Var (read_var read_list_style_position t))
     t
 
+(* CSS Lists 3 sec. 3.5 gives [list-style-image] an [<image>], so every image
+   the [background-image] vocabulary reads goes here: the comma list is what
+   only that property takes. *)
 let rec read_list_style_image t : list_style_image =
-  let read_url t = (Url (Cursor.url t) : list_style_image) in
   let read_var t : list_style_image = Var (read_var read_list_style_image t) in
   Cursor.one_of
     [
-      read_url;
       (fun t ->
         Cursor.enum_or_calls "list-style-image"
           [
@@ -2474,6 +2475,7 @@ let rec read_list_style_image t : list_style_image =
           ]
           ~calls:[ ("var", read_var) ]
           t);
+      (fun t -> (Image (read_bg_image t) : list_style_image));
     ]
     t
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1726,36 +1726,6 @@ type list_style_position =
   | Revert_layer
   | Var of list_style_position var
 
-type list_style_image =
-  | None
-  | Url of string
-  | Inherit
-  | Initial
-  | Unset
-  | Revert
-  | Revert_layer
-  | Var of list_style_image var
-
-(* CSS Lists 3 sec. 3.6: [list-style] is the shorthand for [list-style-type],
-   [list-style-position], and [list-style-image]. All components are optional;
-   omitted ones reset to the longhand initial ([disc] / [outside] / [none]). The
-   single bare [none] keyword in the source sets both [type_] and [image] to
-   [None]. *)
-type list_style_shorthand = {
-  type_ : list_style_type option;
-  position : list_style_position option;
-  image : list_style_image option;
-}
-
-type list_style =
-  | Shorthand of list_style_shorthand
-  | Inherit
-  | Initial
-  | Unset
-  | Revert
-  | Revert_layer
-  | Var of list_style var
-
 (* Table Types *)
 type table_layout =
   | Auto
@@ -2876,6 +2846,38 @@ and cross_fade_option = {
   image : background_image;
   percent : percentage option;
 }
+
+(* CSS Lists 3 sec. 3.5: [list-style-image] is a [<image>], which is the
+   [background_image] vocabulary without its comma list, or [none]. *)
+type list_style_image =
+  | None
+  | Image of background_image
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of list_style_image var
+
+(* CSS Lists 3 sec. 3.6: [list-style] is the shorthand for [list-style-type],
+   [list-style-position], and [list-style-image]. All components are optional;
+   omitted ones reset to the longhand initial ([disc] / [outside] / [none]). The
+   single bare [none] keyword in the source sets both [type_] and [image] to
+   [None]. *)
+type list_style_shorthand = {
+  type_ : list_style_type option;
+  position : list_style_position option;
+  image : list_style_image option;
+}
+
+type list_style =
+  | Shorthand of list_style_shorthand
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of list_style var
 
 (* Background position can be complex with 1-4 values mixing keywords and
    lengths *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3856,6 +3856,16 @@ let typed_custom_font_family_layer_printing () =
   Alcotest.(check string)
     "layer-independent serialization" theme (render "utilities")
 
+(* CSS Lists 3 sec. 3.5 gives [list-style-image] one [<image>], where
+   [background-image] takes a comma-separated list of them, so the comma is
+   where the two vocabularies part. *)
+let list_style_image_takes_one_image () =
+  check_declaration ~expected:"list-style-image:linear-gradient(red,blue)"
+    "list-style-image: linear-gradient(red, blue)";
+  check_declaration ~expected:"list-style-image:image-set(url(a.png)1x)"
+    "list-style-image: image-set(url(a.png) 1x)";
+  neg_cursor read_declaration "list-style-image: url(a.png), url(b.png)"
+
 (* [parse_custom_property] builds a declaration from a name and value that came
    from outside the parser, so it takes only a pair that writes back as the one
    declaration it claims to be: a [<dashed-ident>] name, written back with the
@@ -6466,6 +6476,8 @@ let declaration_tests =
       typed_custom_font_family_layer_printing;
     test_case "parse_custom_property rejects an escaping pair" `Quick
       parse_custom_property_guard;
+    test_case "list-style-image takes one image" `Quick
+      list_style_image_takes_one_image;
     test_case "custom_property refuses an escaping pair" `Quick
       custom_property_guard;
     test_case "parse_declaration keeps the name out of the value" `Quick

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2371,6 +2371,12 @@ let test_list_style_image () =
   check_list_style_image "none";
   check_list_style_image "inherit";
   check_list_style_image "url(https://example.com/x.png)";
+  (* CSS Lists 3 sec. 3.5 gives the property an [<image>], so every image the
+     vocabulary reads goes here and only the comma list does not. *)
+  check_list_style_image "linear-gradient(red,blue)";
+  check_list_style_image "conic-gradient(in hsl longer hue,red,blue)";
+  check_list_style_image "image-set(url(a.png)1x)";
+  check_list_style_image "cross-fade(url(a.png) 40%,url(b.png))";
   neg_cursor read_list_style_image "invalid-url"
 
 let test_vertical_align () =


### PR DESCRIPTION
CSS Lists 3 sec. 3.5 gives `list-style-image` an `<image>`, which cascade already models for `background-image`. Only a `url()` was read, so a gradient, an `image-set()` and a `cross-fade()` were dropped where every browser keeps them. The comma list is what only `background-image` takes.