### PR TITLE
shape-image-threshold: read the whole opacity value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -364,6 +364,11 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `shape-image-threshold` reads a percentage and a number outside the `[0, 1]`
+  range. CSS Shapes 1 sec. 6.2 takes an `<opacity-value>` and clamps it at
+  computed-value time, so `shape-image-threshold: 50%` and `1.5` are values the
+  reader dropped where every browser keeps them (#996)
+
 - `list-style-image` reads every `<image>`, so a gradient, an `image-set()` and
   a `cross-fade()` mark a list item where only a `url()` did. CSS Lists 3 sec.
   3.5 gives the property the `<image>` vocabulary, minus the comma list only

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -516,11 +516,15 @@ let rec read_shape_image_threshold t : shape_image_threshold =
   let read_var t : shape_image_threshold =
     Var (read_var read_shape_image_threshold t)
   in
+  (* CSS Shapes 1 sec. 6.2 takes an [<opacity-value>], which CSS Color 4 spells
+     [<number> | <percentage>], and computes it "clamped to the range [0,1]":
+     the clamp is at computed-value time, so a value outside it still reads. *)
   let read_number t : shape_image_threshold =
-    let value = Cursor.number t in
-    if value < 0. || value > 1. then
-      Cursor.err_invalid t "shape-image-threshold must be between 0 and 1";
-    Number value
+    let n, unit = Cursor.number_with_unit t in
+    match unit with
+    | Some "%" -> Number (n /. 100.)
+    | Some unit -> Cursor.err_invalid t ("shape-image-threshold unit: " ^ unit)
+    | None -> Number n
   in
   Cursor.enum_or_calls "shape-image-threshold"
     [

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4873,7 +4873,7 @@ let spec_remaining_prop_vectors () =
       "print-color-adjust: exact economy";
       "isolation: isolate auto";
       "mix-blend-mode: multiply plus-lighter";
-      "shape-image-threshold: 1.5";
+      "shape-image-threshold: 1.5 2";
       "container-name: none card";
       "container: card inline-size";
       "anchor-name: target";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4936,6 +4936,14 @@ let spec_generated_box_layout_edges () =
   check_overflow_clip_box "content-box";
   check_overflow_clip_margin "content-box 1px";
   check_shape_image_threshold ".5";
+  (* CSS Shapes 1 sec. 6.2 takes an [<opacity-value>], which CSS Color 4 spells
+     [<number> | <percentage>], and clamps it to [0,1] at computed-value time,
+     so a value outside the range still reads. *)
+  check_shape_image_threshold "-1";
+  check_shape_image_threshold "2";
+  check_value_cursor "shape_image_threshold" read_shape_image_threshold
+    pp_shape_image_threshold ~expected:".5" "50%";
+  neg_cursor read_shape_image_threshold "2px";
   check_tab_size "4";
   check_zoom "50%";
   check_zoom "normal";
@@ -4977,7 +4985,9 @@ let spec_generated_box_layout_edges () =
   neg_cursor read_min_intrinsic_sizing_keyword "zero";
   neg_cursor read_overflow_clip_box "margin-box";
   neg_cursor ~allow_partial:true read_overflow_clip_margin "1px 2px";
-  neg_cursor read_shape_image_threshold "-1";
+  (* CSS Shapes 1 sec. 6.2 clamps the threshold at computed-value time, so a
+     value outside [0,1] reads; a unit is what it has no place for. *)
+  neg_cursor read_shape_image_threshold "2px";
   neg_cursor read_tab_size "-1"
 
 (* ignore-test: grouped generated-surface vectors. *)


### PR DESCRIPTION
CSS Shapes 1 sec. 6.2 takes an `<opacity-value>`, which CSS Color 4 spells `<number> | <percentage>`, and computes it "clamped to the range [0,1]". The reader took a bare number in that range only, so `50%` and `1.5` were dropped where every browser keeps them.