### PR TITLE
declaration: let a nested substitution defer the grammar too

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -364,6 +364,13 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- A `var()`, `env()` or `attr()` written inside another function defers the
+  property's grammar the way one written beside it does, so
+  `offset-rotate: color-mix(var(--a), var(--b))` and
+  `flex-basis: sign(var(--x))` are kept. CSS Variables 1 sec. 3 assumes the
+  grammar valid at parse time for a property that *contains* such a call, and
+  cascade counted only a top-level one (#997)
+
 - `shape-image-threshold` reads a percentage and a number outside the `[0, 1]`
   range. CSS Shapes 1 sec. 6.2 takes an `<opacity-value>` and clamps it at
   computed-value time, so `shape-image-threshold: 50%` and `1.5` are values the

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -366,16 +366,12 @@ let raw_value_has_invalid_substitution raw_value =
   |> components_have_invalid_substitution
 
 let raw_value_contains_substitution raw_value =
-  (* A top-level substitution leaves the typed reader unable to validate the
-     result, so cascade keeps the value verbatim. One nested inside another
-     function does not extend that leniency to the surrounding tokens; only a
-     top-level one counts. *)
-  let is_top_level = function
-    | Component.Func { node = { name; arguments; _ }; _ } ->
-        is_substitution_call name arguments
-    | _ -> false
-  in
-  Cursor.of_string raw_value |> Cursor.remaining |> List.exists is_top_level
+  (* CSS Variables 1 sec. 3: "if a property contains one or more var()
+     functions, and those functions are syntactically valid, the entire
+     property's grammar must be assumed to be valid at parse time". A call
+     written inside another function is one the property contains, so the
+     leniency reaches the tokens around it too. *)
+  Cursor.of_string raw_value |> Cursor.remaining |> components_have_substitution
 
 (** Check for and consume [!important] (case-insensitive per CSS Syntax). *)
 let read_importance t =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1070,14 +1070,18 @@ let flexbox_flex_and_basis () =
   check_declaration ~expected:"flex-basis:calc(var(--spacing)*4)"
     "flex-basis: calc(var(--spacing) * 4)";
   (* Math functions over <length-percentage> are valid flex-basis values and
-     round-trip; sign() yields a <number> and is rejected. *)
+     round-trip; sign() yields a <number> and is rejected, unless a var() in it
+     defers the whole grammar to computed-value time (CSS Variables 1 sec.
+     3). *)
   check_declaration ~expected:"flex-basis:min(10px,100%)"
     "flex-basis: min(10px, 100%)";
   check_declaration ~expected:"flex-basis:clamp(1px,var(--spacing),100%)"
     "flex-basis: clamp(1px, var(--spacing), 100%)";
   check_declaration ~expected:"flex-basis:abs(var(--x))"
     "flex-basis: abs(var(--x))";
-  neg_cursor read_declaration "flex-basis: sign(var(--x))";
+  check_declaration ~expected:"flex-basis:sign(var(--x))"
+    "flex-basis: sign(var(--x))";
+  neg_cursor read_declaration "flex-basis: sign(1px)";
   (* order: a calc carrying a var stays a typed calc and round-trips; an
      all-numeric order calc folds to an integer. *)
   check_declaration ~expected:"order:2" "order: 2";


### PR DESCRIPTION
CSS Variables 1 sec. 3 assumes a property's grammar valid at parse time when the property *contains* a syntactically valid `var()`. cascade counted only a call written at the top of the value, so `offset-rotate: color-mix(var(--a), var(--b))` and `flex-basis: sign(var(--x))` were dropped where every browser keeps them until computed-value time.