### PR TITLE
transition-property: read the custom-ident the production names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -364,6 +364,12 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `transition-property` reads every `<custom-ident>` and refuses the one CSS
+  Values 4 sec. 3.2 excludes, so `transition-property: normal` names a property
+  and `default` no longer does. `transition: allow-discrete allow-discrete`
+  fills the behaviour slot and the property slot, as the `||` in CSS
+  Transitions 1 sec. 2.4 allows (#998)
+
 - A `var()`, `env()` or `attr()` written inside another function defers the
   property's grammar the way one written beside it does, so
   `offset-rotate: color-mix(var(--a), var(--b))` and

--- a/fuzz/fuzz_properties.ml
+++ b/fuzz/fuzz_properties.ml
@@ -1036,7 +1036,7 @@ let negative_branch_vectors =
     "animation-composition:add replace";
     "animation-range-start:entry exit";
     "animation-range-end:10% 20%";
-    "transition:allow-discrete allow-discrete";
+    "transition:allow-discrete allow-discrete allow-discrete";
     "overscroll-behavior-inline:contain none";
     "overscroll-behavior-block:hidden";
     "scroll-snap-align:start center end";

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -954,13 +954,12 @@ let rec read_transition_property_value t : transition_property_value =
   in
   let read_property_ident t =
     let name = Cursor.ident ~keep_case:true t in
-    (* CSS Transitions 1 section 2.1: [transition-property] is a
-       [<custom-ident>], so it excludes keywords reserved for other slots of the
-       [transition] shorthand. [normal] and [allow-discrete] are the
-       [transition-behavior] enum and would silently absorb a duplicate (e.g.
-       [transition: normal normal]) into the property slot. *)
-    if List.mem (String.lowercase_ascii name) [ "normal"; "allow-discrete" ]
-    then
+    (* CSS Transitions 1 sec. 2.1 gives [transition-property] a
+       [<custom-ident>], and CSS Values 4 sec. 3.2 excludes [default] and the
+       CSS-wide keywords from that production and nothing else. What the
+       [transition] shorthand can tell apart in a slot is the shorthand reader's
+       question, not this one's. *)
+    if String.equal (String.lowercase_ascii name) "default" then
       Cursor.err_invalid t
         ("transition-property cannot be reserved keyword: " ^ name)
     else Property name

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4494,7 +4494,7 @@ let spec_platform_property_vectors () =
       "background-image: image-set(url(a.png))";
       "border-image: linear-gradient(red, blue) fill fill";
       "font: bold serif";
-      "transition: allow-discrete allow-discrete";
+      "transition: allow-discrete allow-discrete allow-discrete";
       "scroll-timeline: block --scroller";
       "view-timeline: inline --reveal";
     ]


### PR DESCRIPTION
CSS Transitions 1 sec. 2.1 gives `transition-property` a `<custom-ident>`, and CSS Values 4 sec. 3.2 excludes `default` from that production and nothing else. cascade had it the other way round: `normal` and `allow-discrete` were refused and `default` was read. What the `transition` shorthand can tell apart in a slot is the shorthand reader's question.