### PR TITLE
offset-distance: read the length-percentage without a range

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -364,6 +364,11 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `offset-distance` and `view-timeline-inset` read a negative length. CSS
+  Motion Path 1 sec. 2.2 and Scroll Animations 1 sec. 3.4.3 give both a plain
+  `<length-percentage>` with no range on it, and cascade held them to a
+  non-negative one (#999)
+
 - `transition-property` reads every `<custom-ident>` and refuses the one CSS
   Values 4 sec. 3.2 excludes, so `transition-property: normal` names a property
   and `default` no longer does. `transition: allow-discrete allow-discrete`

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -854,6 +854,20 @@ let read_nn_lp_or_global t =
     ]
     ~default:read_non_negative_length_percentage t
 
+(* CSS Motion Path 1 sec. 2.2 gives [offset-distance] a plain
+   [<length-percentage>], with no range restriction on it. *)
+let read_lp_or_global t =
+  Cursor.enum "length-percentage"
+    [
+      ("inherit", (Length Inherit : length_percentage));
+      ("initial", Length Initial);
+      ("unset", Length Unset);
+      ("revert", Length Revert);
+      ("revert-layer", Length Revert_layer);
+    ]
+    ~default:(Values.read_length_percentage ~with_keywords:false)
+    t
+
 let read_nn_length_or_global ?(length_only = false) t =
   Cursor.enum "non-negative length"
     [
@@ -1173,7 +1187,7 @@ let read_sizing_value : type a. a property -> Cursor.t -> declaration option =
   | Max_block_size -> Some (v Max_block_size (read_box_size ~maximum:true t))
   | Font_size -> Some (v Font_size (Properties.read_font_size t))
   | Perspective -> Some (v Perspective (read_perspective_value t))
-  | Offset_distance -> Some (v Offset_distance (read_nn_lp_or_global t))
+  | Offset_distance -> Some (v Offset_distance (read_lp_or_global t))
   | Shape_margin -> Some (v Shape_margin (read_nn_lp_or_global t))
   | Line_height_step ->
       Some (v Line_height_step (read_nn_length_or_global ~length_only:true t))

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -777,8 +777,9 @@ let read_timeline_inset_item t : timeline_inset_item =
   Cursor.enum "timeline-inset item"
     [ ("auto", (Auto : timeline_inset_item)) ]
     ~default:(fun t ->
-      (Length
-         (read_length_percentage ~allow_negative:false ~with_keywords:false t)
+      (* Scroll Animations 1 sec. 3.4.3 gives each item [auto] or a plain
+         [<length-percentage>], with no range restriction on it. *)
+      (Length (read_length_percentage ~with_keywords:false t)
         : timeline_inset_item))
     t
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4481,7 +4481,7 @@ let spec_platform_property_vectors () =
       "margin-trim: block inline block";
       "field-sizing: auto";
       "mask-composite: plus";
-      "offset-distance: -10%";
+      "offset-distance: -10% -10%";
       "font-size-adjust: from-font 1";
       "font-variant-emoji: smile";
       "initial-letter: 0";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -5272,7 +5272,11 @@ let spec_generated_text_timeline_edges () =
   neg_cursor read_text_wrap_mode "pretty";
   neg_cursor read_text_wrap_style "nowrap";
   neg_cursor ~allow_partial:true read_timeline_inset "auto auto auto";
-  neg_cursor read_timeline_inset_item "-1px";
+  (* Scroll Animations 1 sec. 3.4.3 gives each item [auto] or a plain
+     [<length-percentage>], with no range restriction, so a negative reads. *)
+  check_value_cursor "timeline_inset_item" read_timeline_inset_item
+    pp_timeline_inset_item "-1px";
+  neg_cursor read_timeline_inset_item "1deg";
   neg_cursor ~allow_partial:true read_timeline_name "none --main";
   neg_cursor ~allow_partial:true read_timeline_shorthand_item "--main z";
   neg_cursor ~allow_partial:true read_view_transition_class "none card";


### PR DESCRIPTION
CSS Motion Path 1 sec. 2.2 gives `offset-distance` a plain `<length-percentage>` and Scroll Animations 1 sec. 3.4.3 gives `view-timeline-inset` items the same, neither with a range restriction. cascade held both to a non-negative one, so `offset-distance: -2px` was dropped where every browser keeps it.