### PR TITLE
declaration: keep an unknown colour function only behind a vendor prefix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -364,6 +364,12 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- A colour property keeps an unknown function only where its name is vendor
+  prefixed. CSS Color 5 sec. 3 closes the `<color>` production, so
+  `border-top-color: calc(2px - 3px)` and `color: brightness()` are dropped
+  with a warning where cascade wrote them back and every browser drops them
+  (#1000)
+
 - `offset-distance` and `view-timeline-inset` read a negative length. CSS
   Motion Path 1 sec. 2.2 and Scroll Animations 1 sec. 3.4.3 give both a plain
   `<length-percentage>` with no range on it, and cascade held them to a

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2264,9 +2264,11 @@ let validate_regular_property_components t name components =
     && not (components_are_lone_css_wide components)
   then Cursor.err_invalid t "all accepts only CSS-wide keywords"
 
-(* Color functions cascade types directly; anything else (e.g. a vendor color
-   function or a typed value cascade hasn't grown yet) is treated as a [color]
-   declaration cascade should preserve verbatim. *)
+(* Color functions cascade types directly. A vendor one it does not is kept
+   verbatim: the prefix says the vocabulary is an engine's own, so no
+   specification settles it and no browser but that engine reads it either. An
+   unprefixed name cascade does not know is no colour - CSS Color 5 sec. 3
+   closes the production - and every browser drops the declaration. *)
 let color_fallback_function raw_value =
   let components =
     Cursor.of_string raw_value |> Cursor.remaining
@@ -2275,23 +2277,25 @@ let color_fallback_function raw_value =
   match components with
   | [ Component.Func { node = { name; _ }; _ } ] ->
       let fn = String.lowercase_ascii_preserve name in
-      not
-        (List.mem fn
-           [
-             "rgb";
-             "rgba";
-             "hsl";
-             "hsla";
-             "hwb";
-             "lab";
-             "lch";
-             "oklab";
-             "oklch";
-             "color";
-             "color-mix";
-             "light-dark";
-             "var";
-           ])
+      String.length fn > 0
+      && Char.equal fn.[0] '-'
+      && not
+           (List.mem fn
+              [
+                "rgb";
+                "rgba";
+                "hsl";
+                "hsla";
+                "hwb";
+                "lab";
+                "lch";
+                "oklab";
+                "oklch";
+                "color";
+                "color-mix";
+                "light-dark";
+                "var";
+              ])
   | _ -> false
 
 (* A colour function whose arguments contain a [var()] can't be validated until

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3860,6 +3860,19 @@ let typed_custom_font_family_layer_printing () =
   Alcotest.(check string)
     "layer-independent serialization" theme (render "utilities")
 
+(* CSS Color 5 sec. 3 closes the [<color>] production, so a function name it
+   does not hold is no colour and every browser drops the declaration. A vendor
+   name is the exception the reader keeps: the prefix says the vocabulary is an
+   engine's own, which no specification settles either way. *)
+let color_takes_only_a_colour_function () =
+  check_declaration ~expected:"color:-webkit-magic(1)" "color: -webkit-magic(1)";
+  check_declaration ~expected:"color:color-mix(var(--a),var(--b))"
+    "color: color-mix(var(--a), var(--b))";
+  neg_cursor read_declaration "border-top-color: calc(2px - 3px)";
+  neg_cursor read_declaration "border-left-color: brightness()";
+  neg_cursor read_declaration "text-decoration-color: counters(section, \".\")";
+  neg_cursor read_declaration "border-block-start-color: minmax(0, 1fr)"
+
 (* CSS Lists 3 sec. 3.5 gives [list-style-image] one [<image>], where
    [background-image] takes a comma-separated list of them, so the comma is
    where the two vocabularies part. *)
@@ -6482,6 +6495,8 @@ let declaration_tests =
       parse_custom_property_guard;
     test_case "list-style-image takes one image" `Quick
       list_style_image_takes_one_image;
+    test_case "a colour takes only a colour function" `Quick
+      color_takes_only_a_colour_function;
     test_case "custom_property refuses an escaping pair" `Quick
       custom_property_guard;
     test_case "parse_declaration keeps the name out of the value" `Quick


### PR DESCRIPTION
CSS Color 5 sec. 3 closes the `<color>` production, so a function name it does not hold is no colour. cascade kept any single unknown call verbatim in a colour slot, so `border-top-color: calc(2px - 3px)` and `color: brightness()` were written back where every browser drops them. A vendor-prefixed name still goes through: the prefix says the vocabulary is an engine's own, which no specification settles either way.