### PR TITLE
grid: hold a track breadth to its non-negative range

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -364,6 +364,10 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- A negative length is no grid track, so `grid-template-rows: -2px` and a
+  `minmax()` holding one are dropped with a warning. CSS Grid 2 sec. 7.2 spells
+  a `<track-breadth>` with a `[0,inf]` range on its length (#1001)
+
 - A colour property keeps an unknown function only where its name is vendor
   prefixed. CSS Color 5 sec. 3 closes the `<color>` production, so
   `border-top-color: calc(2px - 3px)` and `color: brightness()` are dropped

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -873,8 +873,12 @@ module Grid_template = struct
     (* [~with_keywords:false]: track keywords (auto / min-content / ...) are a
        separate [one_of] alternative, so this reader handles only real lengths -
        the unit-specific cases below, plus a general [Length] carrier for a
-       [calc()], a [var()] in a [calc()], or a less common unit. *)
-    match read_length ~with_keywords:false t with
+       [calc()], a [var()] in a [calc()], or a less common unit.
+
+       CSS Grid 2 sec. 7.2 spells a [<track-breadth>] as [<length-percentage
+       [0,inf]> | <flex [0,inf]> | min-content | max-content | auto], so a
+       negative length is no breadth. *)
+    match read_length ~allow_negative:false ~with_keywords:false t with
     | Px n -> (Px n : grid_template)
     | Rem n -> Rem n
     | Em n -> Em n

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4209,6 +4209,11 @@ let test_grid_template () =
   check_grid_template "1fr 2fr";
   check_grid_template "auto auto";
   check_grid_template "inherit";
+  (* CSS Grid 2 sec. 7.2 spells a [<track-breadth>] as [<length-percentage
+     [0,inf]> | <flex [0,inf]> | min-content | max-content | auto], so a
+     negative length is no breadth, inside [minmax()] either. *)
+  neg_cursor read_grid_template "-2px";
+  neg_cursor read_grid_template "minmax(-1px, 1fr)";
   (* CSS Grid 2 sec. 7.2: a track is any <length-percentage>, so a calc(), a
      var() inside a calc(), or a less common unit is a valid track, carried by
      the [Length] track. *)


### PR DESCRIPTION
CSS Grid 2 sec. 7.2 spells a `<track-breadth>` as `<length-percentage [0,inf]> | <flex [0,inf]> | min-content | max-content | auto`. The length reader took a signed one, so `grid-template-rows: -2px` and `minmax(-1px, 1fr)` were written back where every browser drops them.