### PR TITLE
grid: name both axes in the shorthand or nothing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -364,6 +364,11 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `grid-template` and `grid` name both axes or nothing, so `grid-template: 10px`
+  is dropped with a warning where a `grid-template-rows` value stood in for a
+  shorthand one. CSS Grid 2 sec. 7.4 spells the shorthand as `none`, a
+  `rows / columns` pair, or a track list built from strings (#1002)
+
 - A negative length is no grid track, so `grid-template-rows: -2px` and a
   `minmax()` holding one are dropped with a warning. CSS Grid 2 sec. 7.2 spells
   a `<track-breadth>` with a `[0,inf]` range on its length (#1001)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1463,6 +1463,28 @@ let read_background_value : type a. a property -> Cursor.t -> declaration option
   | Background_blend_mode -> Some (read_background_blend_mode_value t)
   | _ -> None
 
+(* CSS Grid 2 sec. 7.4 spells [grid-template] as [none], a
+   [<'grid-template-rows'> / <'grid-template-columns'>] pair, or a track list
+   built from strings. A bare track list is a [grid-template-rows] value and no
+   [grid-template] one, and sec. 7.8 gives [grid] the same forms plus the two
+   [auto-flow] ones. *)
+let names_both_axes : Properties.grid_template -> bool = function
+  | None | Inherit | Initial | Unset | Revert | Revert_layer | Var _ | Split _
+  | Auto_flow_columns _ | Auto_flow_rows _ | Named_tracks _ | Template _ ->
+      true
+  | Px _ | Rem _ | Em _ | Pct _ | Vw _ | Vh _ | Vmin _ | Vmax _ | Zero
+  | Length _ | Fr _ | Flex_math _ | Auto | Min_content | Max_content | Min_max _
+  | Fit_content _ | Repeat _ | Tracks _ | Line_names _ | Subgrid | Masonry ->
+      false
+
+let read_grid_template_shorthand ~name t =
+  let value =
+    if String.equal name "grid" then read_grid t else read_grid_template t
+  in
+  if not (names_both_axes value) then
+    Cursor.err_invalid t (name ^ " names one axis only");
+  value
+
 let read_grid_value : type a. a property -> Cursor.t -> declaration option =
  fun prop t ->
   match prop with
@@ -1477,8 +1499,10 @@ let read_grid_value : type a. a property -> Cursor.t -> declaration option =
   | Grid_auto_flow -> Some (v Grid_auto_flow (read_grid_auto_flow t))
   | Grid_template_areas ->
       Some (v Grid_template_areas (read_grid_template_areas t))
-  | Grid_template -> Some (v Grid_template (read_grid_template t))
-  | Grid -> Some (v Grid (read_grid t))
+  | Grid_template ->
+      Some
+        (v Grid_template (read_grid_template_shorthand ~name:"grid-template" t))
+  | Grid -> Some (v Grid (read_grid_template_shorthand ~name:"grid" t))
   | Grid_area -> Some (v Grid_area (read_grid_area t))
   | Grid_auto_columns -> Some (v Grid_auto_columns (read_grid_auto_tracks t))
   | Grid_auto_rows -> Some (v Grid_auto_rows (read_grid_auto_tracks t))

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3860,6 +3860,23 @@ let typed_custom_font_family_layer_printing () =
   Alcotest.(check string)
     "layer-independent serialization" theme (render "utilities")
 
+(* CSS Grid 2 sec. 7.4 spells [grid-template] as [none], a
+   [<'grid-template-rows'> / <'grid-template-columns'>] pair, or a track list
+   built from strings, and sec. 7.8 gives [grid] those forms plus the two
+   [auto-flow] ones. A bare track list names one axis, which is a
+   [grid-template-rows] value and no shorthand one. *)
+let grid_shorthand_names_both_axes () =
+  check_declaration ~expected:"grid-template:10px/20px"
+    "grid-template: 10px / 20px";
+  check_declaration ~expected:"grid-template:none" "grid-template: none";
+  check_declaration ~expected:"grid-template:\"a\" 10px"
+    "grid-template: \"a\" 10px";
+  check_declaration ~expected:"grid:none/1fr" "grid: auto-flow / 1fr";
+  neg_cursor read_declaration "grid-template: 10px";
+  neg_cursor read_declaration "grid-template: auto";
+  neg_cursor read_declaration "grid: 10px";
+  neg_cursor read_declaration "grid: subgrid"
+
 (* CSS Color 5 sec. 3 closes the [<color>] production, so a function name it
    does not hold is no colour and every browser drops the declaration. A vendor
    name is the exception the reader keeps: the prefix says the vocabulary is an
@@ -6497,6 +6514,8 @@ let declaration_tests =
       list_style_image_takes_one_image;
     test_case "a colour takes only a colour function" `Quick
       color_takes_only_a_colour_function;
+    test_case "a grid shorthand names both axes" `Quick
+      grid_shorthand_names_both_axes;
     test_case "custom_property refuses an escaping pair" `Quick
       custom_property_guard;
     test_case "parse_declaration keeps the name out of the value" `Quick


### PR DESCRIPTION
CSS Grid 2 sec. 7.4 spells `grid-template` as `none`, a `<'grid-template-rows'> / <'grid-template-columns'>` pair, or a track list built from strings, and sec. 7.8 gives `grid` those forms plus the two `auto-flow` ones. The longhand and the shorthand share one value type, so `grid-template: 10px` was written back where every browser drops it.