### PR TITLE
line-height: take a length unit and no other

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -364,6 +364,11 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `line-height` takes a length unit and no other, so `line-height: 1s`,
+  `45deg` and `10zz` are dropped with a warning. CSS Inline 3 sec. 5.1 spells
+  the property `normal | <number [0,inf]> | <length-percentage [0,inf]>`, and
+  cascade carried any dimension through (#1003)
+
 - `grid-template` and `grid` name both axes or nothing, so `grid-template: 10px`
   is dropped with a warning where a `grid-template-rows` value stood in for a
   shorthand one. CSS Grid 2 sec. 7.4 spells the shorthand as `none`, a

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -24,7 +24,12 @@ let read_line_height_length t : line_height =
     | Some "em" -> if Pp.string_of_float n = repr then Em n else authored ()
     | Some "%" -> if Pp.string_of_float n = repr then Pct n else authored ()
     | None -> if Pp.string_of_float n = repr then Num n else authored ()
-    | Some _ -> authored ()
+    (* CSS Inline 3 sec. 5.1 spells the property [normal | <number [0,inf]> |
+       <length-percentage [0,inf]>], so a length unit the cases above do not
+       carry still reads and a time, an angle or a name no unit table holds does
+       not. *)
+    | Some u when Values.is_length_unit u -> authored ()
+    | Some u -> Cursor.err_invalid t ("line-height unit: " ^ u)
 
 let rec numeric_line_height_calc_leaves : line_height calc -> line_height calc =
   function

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1809,6 +1809,9 @@ let unit_of_string = function
   | "cqmax" -> Some Cqmax
   | _ -> None
 
+let is_length_unit unit =
+  Option.is_some (unit_of_string (String.lowercase_ascii unit))
+
 let unit_of_length = function
   | Zero -> Some (Px, 0.)
   | Px n -> Some (Px, n)

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -196,6 +196,11 @@ val calc_length_unit : length -> (string * float) option
 (** [calc_length_unit l] is [Some (unit, value)] when [l] is a dimension, with
     the unit lower-cased. A keyword, a [var()] or a math function is [None]. *)
 
+val is_length_unit : string -> bool
+(** [is_length_unit unit] is whether [unit] names a CSS length, whatever its
+    case: the absolute units, the font- and viewport-relative ones, and the
+    container-relative ones. *)
+
 val absolute_unit_px_ratio : string -> float option
 (** [absolute_unit_px_ratio unit] is [Some ratio] when [unit] is one of the
     absolute units CSS Values 4 sec. 6.2 puts on the [px] scale, with [ratio]

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1643,6 +1643,14 @@ let test_line_height () =
     ~into:"calc(28/var(--x))" "calc(28 / var(--x))";
   neg_cursor read_line_height "invalid";
   neg_cursor read_line_height "-1.5";
+  (* CSS Inline 3 sec. 5.1 spells the property [normal | <number [0,inf]> |
+     <length-percentage [0,inf]>], so every length unit reads and nothing else
+     does. *)
+  check_line_height "2ch";
+  check_line_height "3cqw";
+  neg_cursor read_line_height "0s";
+  neg_cursor read_line_height "45deg";
+  neg_cursor read_line_height "10zz";
   (* negative line-height *)
   (* multiple values *)
   neg_cursor ~allow_partial:true read_line_height "normal 1.5"


### PR DESCRIPTION
CSS Inline 3 sec. 5.1 spells `line-height` as `normal | <number [0,inf]> | <length-percentage [0,inf]>`. The carrier that keeps a length unit the specific cases do not model took every dimension, so `line-height: 1s` and `45deg` were written back where every browser drops them. This PR adds `Cascade.Values.is_length_unit`.