### PR TITLE
page-size: size a page in lengths and take every css-wide keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,9 @@ entry points both moved.
 
 ### Breaking
 
+- `Cascade.Properties.page_size` gains `Initial`, `Unset`, `Revert` and
+  `Revert_layer`. Exhaustive visitors must handle the four new leaves (#1004)
+
 - `Cascade.Properties.list_style_image` carries an `Image of background_image`
   where it carried a `Url of string`. CSS Lists 3 sec. 3.5 gives the property
   an `<image>`, so `list-style-image: linear-gradient(red, blue)` reads. A
@@ -363,6 +366,12 @@ to lose a whole rule over one bad piece. Both are gone.
   declaration invalid at computed-value time, which is the property's inherited
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
+
+- The `@page` `size` descriptor sizes a page in lengths, so a percentage, a
+  sizing keyword and a negative are dropped with a warning, and it takes every
+  CSS-wide keyword. CSS Paged Media 3 sec. 6.4 spells it
+  `<length [0,inf]>{1,2} | auto | [ <page-size> || [ portrait | landscape ]]`
+  (#1004)
 
 - `line-height` takes a length unit and no other, so `line-height: 1s`,
   `45deg` and `10zz` are dropped with a warning. CSS Inline 3 sec. 5.1 spells

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -2210,7 +2210,11 @@ type page_size = Properties.page_size =
   | Named of page_size_name
   | Named_oriented of page_size_name * page_size_orientation
   | Oriented of page_size_orientation
+  | Initial
   | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
   | Var of page_size var
 
 (** CSS columns values for multi-column layout. *)

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -235,7 +235,11 @@ let rec pp_page_size : page_size Pp.t =
       Pp.space ctx ();
       pp_page_size_orientation ctx orientation
   | Oriented orientation -> pp_page_size_orientation ctx orientation
+  | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_page_size ctx v
 
 let rec read_break_value t : break_value =
@@ -476,6 +480,26 @@ let read_page_size_orientation t : page_size_orientation =
     [ ("portrait", Portrait); ("landscape", Landscape) ]
     t
 
+(* CSS Paged Media 3 sec. 6.4 spells the descriptor [<length [0,inf]>{1,2} |
+   auto | [ <page-size> || [ portrait | landscape ]]], so a page is sized in
+   lengths: no percentage and no sizing keyword. *)
+let is_page_length (l : length) =
+  match l with
+  (* A math function, a substitution and [zero] are lengths this reader cannot
+     measure and the grammar holds. *)
+  | Zero | Clamp _ | Min _ | Max _ | Minmax _ | Round _ | Mod _ | Rem_fn _
+  | Hypot _ | Abs _ | Sign _ | Calc_size _ | Anchor_size _ | Anchor _ | Attr _
+  | Env _ | Var _ | Calc _ ->
+      true
+  | Pct _ -> false
+  (* The dimension table decides the rest, so a sizing keyword answers
+     [None]. *)
+  | other -> Option.is_some (Values.calc_length_unit other)
+
+let read_page_length t =
+  let l = read_length ~allow_negative:false ~with_keywords:false t in
+  if is_page_length l then l else Cursor.err_expected t "page size length"
+
 let rec read_page_size t : page_size =
   let read_var_ps t : page_size = Var (read_var read_page_size t) in
   let read_named t =
@@ -495,17 +519,24 @@ let rec read_page_size t : page_size =
     Oriented orientation
   in
   let read_lengths t =
-    let first = read_length t in
+    let first = read_page_length t in
     Cursor.ws t;
     if Cursor.is_done t then Single first
     else
-      let second = read_length t in
+      let second = read_page_length t in
       Cursor.ws t;
       Cursor.expect_eof t;
       Pair (first, second)
   in
   Cursor.enum_or_calls "page-size"
-    [ ("auto", Auto); ("inherit", Inherit) ]
+    [
+      ("auto", Auto);
+      ("initial", Initial);
+      ("inherit", Inherit);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
     ~calls:[ ("var", read_var_ps) ]
     ~default:(Cursor.one_of [ read_named; read_oriented; read_lengths ])
     t

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3959,7 +3959,11 @@ type page_size =
   | Named of page_size_name
   | Named_oriented of page_size_name * page_size_orientation
   | Oriented of page_size_orientation
+  | Initial
   | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
   | Var of page_size var
 
 (* Multi-column Layout Types *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4515,6 +4515,18 @@ let test_page_size () =
   check_page_size "auto";
   check_page_size "8.5in 11in";
   check_page_size ~expected:"A4 landscape" "a4 landscape";
+  (* CSS Paged Media 3 sec. 6.4 sizes a page in [<length [0,inf]>{1,2} | auto |
+     [ <page-size> || [ portrait | landscape ]]], so a percentage, a sizing
+     keyword and a negative are no page size, and CSS Cascade 5 sec. 7.3 gives
+     the descriptor the CSS-wide keywords. *)
+  check_page_size "calc(10px + 1em)";
+  check_page_size "initial";
+  check_page_size "unset";
+  check_page_size "revert-layer";
+  neg_cursor read_page_size "50%";
+  neg_cursor read_page_size "-1px";
+  neg_cursor read_page_size "fit-content(20rem)";
+  neg_cursor ~allow_partial:true read_page_size "10px 20%";
   check_page_size "letter portrait";
   check_page_size "landscape";
   check_page_size "inherit";


### PR DESCRIPTION
CSS Paged Media 3 sec. 6.4 spells the `@page` `size` descriptor as `<length [0,inf]>{1,2} | auto | [ <page-size> || [ portrait | landscape ]]`. The length carrier let `50%` and `fit-content(20rem)` through and took a negative, and the descriptor read `inherit` but none of the other four CSS-wide keywords.