### PR TITLE
properties: hold four readers to the range their grammar states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -367,6 +367,12 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `columns`, `zoom`, `aspect-ratio` and each dash of `stroke-dasharray` refuse
+  a value their grammar's `[0, inf]` range excludes, and `columns` refuses a
+  percentage where CSS Multicol 2 sec. 4.1 gives it a length. `zoom: -1` and
+  `stroke-dasharray: -1` were written back where every browser drops them
+  (#1005)
+
 - The `@page` `size` descriptor sizes a page in lengths, so a percentage, a
   sizing keyword and a negative are dropped with a warning, and it takes every
   CSS-wide keyword. CSS Paged Media 3 sec. 6.4 spells it

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -884,10 +884,14 @@ let rec read_z_index t : z_index =
     t
 
 let read_aspect_ratio_number t =
-  (* CSS Sizing 4 5: an [<aspect-ratio>] component may be a [calc()] that
+  (* CSS Sizing 4 sec. 5: an [<aspect-ratio>] component may be a [calc()] that
      resolves to a number. Keep the number AST for normal-output fidelity; the
-     printer folds constant expressions for minified output. *)
-  read_number t
+     printer folds constant expressions for minified output. The production is
+     [<ratio>], whose CSS Values 4 sec. 6.5 numbers carry a [0,inf] range. *)
+  let n = read_number t in
+  match n with
+  | Num v when v < 0. -> Cursor.err_invalid t "aspect-ratio cannot be negative"
+  | _ -> n
 
 let rec read_aspect_ratio (t : Cursor.t) : aspect_ratio =
   let read_var_ar t : aspect_ratio =
@@ -1113,12 +1117,17 @@ let rec read_float_side (t : Cursor.t) : float_side =
     t
 
 let rec read_zoom (t : Cursor.t) : zoom =
+  (* CSS Viewport 1 sec. 3 spells [zoom] as [normal | reset | <number [0,inf]> |
+     <percentage [0,inf]>], so a negative zoom is no zoom. *)
+  let non_negative n =
+    if n < 0. then Cursor.err_invalid t "zoom cannot be negative" else n
+  in
   let read_value t =
     match Cursor.percentage_opt t with
-    | Some p -> (Pct p : zoom)
+    | Some p -> (Pct (non_negative p) : zoom)
     | None -> (
         match Cursor.number_opt t with
-        | Some n -> Num n
+        | Some n -> Num (non_negative n)
         | None ->
             Cursor.err_invalid t "expected a number or percentage for zoom")
   in

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -319,6 +319,26 @@ let rec read_page_break_inside_value t : page_break_inside_value =
     ~var:(fun t -> Var (Values.read_var read_page_break_inside_value t))
     t
 
+(* CSS Multicol 2 sec. 4.1 spells [column-width] as [auto | <length [0,inf]>]
+   and CSS Paged Media 3 sec. 6.4 sizes a page in [<length [0,inf]>{1,2}], so
+   neither takes a percentage or a sizing keyword. *)
+let is_plain_length (l : length) =
+  match l with
+  (* A math function, a substitution and [zero] are lengths this reader cannot
+     measure and the grammar holds. *)
+  | Zero | Clamp _ | Min _ | Max _ | Minmax _ | Round _ | Mod _ | Rem_fn _
+  | Hypot _ | Abs _ | Sign _ | Calc_size _ | Anchor_size _ | Anchor _ | Attr _
+  | Env _ | Var _ | Calc _ ->
+      true
+  | Pct _ -> false
+  (* The dimension table decides the rest, so a sizing keyword answers
+     [None]. *)
+  | other -> Option.is_some (Values.calc_length_unit other)
+
+let read_plain_length t =
+  let l = read_length ~allow_negative:false ~with_keywords:false t in
+  if is_plain_length l then l else Cursor.err_expected t "length"
+
 let read_columns_count t =
   let n = read_integer "column-count" t in
   if n <= 0 then Cursor.err_invalid t "column count must be positive";
@@ -331,7 +351,9 @@ let read_columns_component t =
         Cursor.expect_string "auto" t;
         `Auto);
       (fun t -> `Count (read_columns_count t));
-      (fun t -> `Width (read_length t));
+      (* CSS Multicol 2 sec. 4.1 spells [column-width] as [auto | <length
+         [0,inf]>], so a percentage and a negative are no column width. *)
+      (fun t -> `Width (read_plain_length t));
     ]
     t
 
@@ -480,26 +502,6 @@ let read_page_size_orientation t : page_size_orientation =
     [ ("portrait", Portrait); ("landscape", Landscape) ]
     t
 
-(* CSS Paged Media 3 sec. 6.4 spells the descriptor [<length [0,inf]>{1,2} |
-   auto | [ <page-size> || [ portrait | landscape ]]], so a page is sized in
-   lengths: no percentage and no sizing keyword. *)
-let is_page_length (l : length) =
-  match l with
-  (* A math function, a substitution and [zero] are lengths this reader cannot
-     measure and the grammar holds. *)
-  | Zero | Clamp _ | Min _ | Max _ | Minmax _ | Round _ | Mod _ | Rem_fn _
-  | Hypot _ | Abs _ | Sign _ | Calc_size _ | Anchor_size _ | Anchor _ | Attr _
-  | Env _ | Var _ | Calc _ ->
-      true
-  | Pct _ -> false
-  (* The dimension table decides the rest, so a sizing keyword answers
-     [None]. *)
-  | other -> Option.is_some (Values.calc_length_unit other)
-
-let read_page_length t =
-  let l = read_length ~allow_negative:false ~with_keywords:false t in
-  if is_page_length l then l else Cursor.err_expected t "page size length"
-
 let rec read_page_size t : page_size =
   let read_var_ps t : page_size = Var (read_var read_page_size t) in
   let read_named t =
@@ -519,11 +521,11 @@ let rec read_page_size t : page_size =
     Oriented orientation
   in
   let read_lengths t =
-    let first = read_page_length t in
+    let first = read_plain_length t in
     Cursor.ws t;
     if Cursor.is_done t then Single first
     else
-      let second = read_page_length t in
+      let second = read_plain_length t in
       Cursor.ws t;
       Cursor.expect_eof t;
       Pair (first, second)

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -395,13 +395,18 @@ let rec read_paint_order t : paint_order =
 
 (* A bare number is user units; anything with a unit or a percent sign is a
    <length-percentage>. *)
-let read_dash_length t : dash_length =
+let read_dash_length ?(allow_negative = true) t : dash_length =
   match Cursor.peek t with
   | Some (Component.Preserved { kind = Token.Number_tok _; _ }) ->
-      Number (Cursor.number t)
+      let n = Cursor.number t in
+      if (not allow_negative) && n < 0. then
+        Cursor.err_invalid t "stroke-dasharray cannot be negative";
+      Number n
   (* The grammar is <length-percentage> | <number>, with no keyword branch, so
      the intrinsic-sizing keywords a bare length would accept are out. *)
-  | _ -> Length (Values.read_length_percentage ~with_keywords:false t)
+  | _ ->
+      Length
+        (Values.read_length_percentage ~allow_negative ~with_keywords:false t)
 
 let rec read_stroke_dashoffset t : stroke_dashoffset =
   Cursor.enum_or_calls "stroke-dashoffset"
@@ -447,7 +452,9 @@ let rec read_stroke_dasharray t : stroke_dasharray =
         | _ -> false
       in
       let rec go acc =
-        let acc = read_dash_length t :: acc in
+        (* SVG 2 sec. 13.3 gives each dash a non-negative value; only
+           [stroke-dashoffset] takes a signed one. *)
+        let acc = read_dash_length ~allow_negative:false t :: acc in
         Cursor.ws t;
         if Cursor.peek_comma t then begin
           Cursor.comma t;

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -2574,10 +2574,11 @@ val read_stroke_width : Cursor.t -> stroke_width
 val pp_dash_length : dash_length Pp.t
 (** [pp_dash_length] pretty-prints one SVG dash length. *)
 
-val read_dash_length : Cursor.t -> dash_length
-(** [read_dash_length t] is the [dash_length] parsed from [t]. A bare number is
-    in user units; anything carrying a unit or a percent sign is a
-    [<length-percentage>]. *)
+val read_dash_length : ?allow_negative:bool -> Cursor.t -> dash_length
+(** [read_dash_length ?allow_negative t] is the [dash_length] parsed from [t]. A
+    bare number is in user units; anything carrying a unit or a percent sign is
+    a [<length-percentage>]. [allow_negative] defaults to [true], which is what
+    [stroke-dashoffset] takes; a dash of [stroke-dasharray] takes [false]. *)
 
 val pp_stroke_dashoffset : stroke_dashoffset Pp.t
 (** [pp_stroke_dashoffset] pretty-prints a [stroke-dashoffset]. *)

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1343,7 +1343,11 @@ let test_zoom () =
   check_zoom "reset";
   check_zoom "50%";
   check_zoom "1.5";
-  neg_cursor read_zoom "not-a-zoom"
+  neg_cursor read_zoom "not-a-zoom";
+  (* CSS Viewport 1 sec. 3 spells the property [normal | reset | <number
+     [0,inf]> | <percentage [0,inf]>]. *)
+  neg_cursor read_zoom "-1";
+  neg_cursor read_zoom "-10%"
 
 let test_border_style () =
   check_border_style "none";
@@ -3700,6 +3704,7 @@ let test_stroke_dashoffset () =
   check_stroke_dashoffset "4px";
   check_stroke_dashoffset "10%";
   check_stroke_dashoffset "var(--o)";
+  check_stroke_dashoffset "-2px";
   neg_cursor read_stroke_dashoffset "none"
 
 let test_stroke_dasharray () =
@@ -3711,7 +3716,11 @@ let test_stroke_dasharray () =
   (* Comma and whitespace are the same separator here. *)
   check_stroke_dasharray ~expected:"4 2" "4, 2";
   check_stroke_dasharray "var(--d)";
-  neg_cursor read_stroke_dasharray "red"
+  neg_cursor read_stroke_dasharray "red";
+  (* SVG 2 sec. 13.3 gives each dash a non-negative value; only
+     [stroke-dashoffset] takes a signed one. *)
+  neg_cursor read_stroke_dasharray "-1";
+  neg_cursor read_stroke_dasharray "-1px"
 
 let test_unicode_bidi () =
   check_unicode_bidi "normal";
@@ -4002,7 +4011,10 @@ let test_aspect_ratio () =
   check_aspect_ratio "1.5";
   check_aspect_ratio "1";
   check_aspect_ratio "inherit";
-  neg_cursor read_aspect_ratio "invalid-ratio"
+  neg_cursor read_aspect_ratio "invalid-ratio";
+  (* CSS Sizing 4 sec. 5 takes a [<ratio>], whose CSS Values 4 sec. 6.5 numbers
+     carry a [0,inf] range. *)
+  neg_cursor read_aspect_ratio "-1"
 
 let test_flex () =
   check_flex "1";
@@ -4598,7 +4610,11 @@ let test_columns_value () =
   check_columns_value "auto";
   check_columns_value "2";
   check_columns_value "inherit";
-  neg_cursor read_columns_value "invalid-columns"
+  neg_cursor read_columns_value "invalid-columns";
+  (* CSS Multicol 2 sec. 4.1 spells [column-width] as [auto | <length [0,inf]>],
+     so a percentage and a negative are no column width. *)
+  neg_cursor read_columns_value "-1px";
+  neg_cursor read_columns_value "50%"
 
 (* CSS Values 4 (ED) sec. 10.9: a math function that resolves to <number> is
    valid wherever an <integer> is, so every integer position reads a calc(). The


### PR DESCRIPTION
`columns` (CSS Multicol 2 sec. 4.1), `zoom` (CSS Viewport 1 sec. 3), `aspect-ratio` (CSS Sizing 4 sec. 5) and each dash of `stroke-dasharray` (SVG 2 sec. 13.3) carry a `[0, inf]` range their readers took a value outside, and `columns` took a percentage where its grammar gives it a length. `stroke-dashoffset` keeps its signed value.