### PR TITLE
declaration: let an anchor query reach only the properties that take one

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -367,6 +367,12 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- An `anchor()` or `anchor-size()` reaches only the properties that take one,
+  so `padding-bottom: anchor-size(width)` and `translate: anchor-size(width)`
+  are dropped with a warning. CSS Anchor Positioning 1 sec. 3.2 keeps `anchor()`
+  to the inset properties and sec. 5.1 keeps `anchor-size()` to the ones
+  `@position-try` accepts (#1006)
+
 - `columns`, `zoom`, `aspect-ratio` and each dash of `stroke-dasharray` refuse
   a value their grammar's `[0, inf]` range excludes, and `columns` refuses a
   percentage where CSS Multicol 2 sec. 4.1 gives it a length. `zoom: -1` and

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2273,7 +2273,83 @@ let components_are_lone_css_wide cvs =
       String.equal n "var" || String.equal n "env" || String.equal n "attr"
   | _ -> false
 
+(* CSS Anchor Positioning 1 sec. 3.2 allows [anchor()] in the inset properties
+   and nowhere else, and sec. 5.1 allows [anchor-size()] in the properties
+   [@position-try] accepts: the inset, margin, sizing and self-alignment ones,
+   plus [position-anchor] and [position-area]. A call written anywhere else is
+   invalid, so the declaration goes. *)
+let inset_properties =
+  [
+    "top";
+    "right";
+    "bottom";
+    "left";
+    "inset";
+    "inset-block";
+    "inset-block-start";
+    "inset-block-end";
+    "inset-inline";
+    "inset-inline-start";
+    "inset-inline-end";
+  ]
+
+let anchor_size_properties =
+  inset_properties
+  @ [
+      "margin";
+      "margin-top";
+      "margin-right";
+      "margin-bottom";
+      "margin-left";
+      "margin-block";
+      "margin-block-start";
+      "margin-block-end";
+      "margin-inline";
+      "margin-inline-start";
+      "margin-inline-end";
+      "width";
+      "height";
+      "min-width";
+      "min-height";
+      "max-width";
+      "max-height";
+      "block-size";
+      "inline-size";
+      "min-block-size";
+      "min-inline-size";
+      "max-block-size";
+      "max-inline-size";
+      "align-self";
+      "justify-self";
+      "place-self";
+      "position-anchor";
+      "position-area";
+    ]
+
+let rec components_call_named names components =
+  List.exists (component_calls_named names) components
+
+and component_calls_named names = function
+  | Component.Func { node = { name; arguments; _ }; _ } ->
+      List.exists (String.equal (String.lowercase_ascii_preserve name)) names
+      || components_call_named names arguments
+  | Component.Block { node = { value; _ }; _ } ->
+      components_call_named names value
+  | Component.Preserved _ -> false
+
+let validate_anchor_queries t name components =
+  let allowed table = List.exists (String.equal name) table in
+  if
+    components_call_named [ "anchor" ] components
+    && not (allowed inset_properties)
+  then Cursor.err_invalid t ("anchor() is not a value of " ^ name);
+  if
+    components_call_named [ "anchor-size" ] components
+    && not (allowed anchor_size_properties)
+  then Cursor.err_invalid t ("anchor-size() is not a value of " ^ name)
+
 let validate_regular_property_components t name components =
+  validate_anchor_queries t name components;
   (* A substitution function makes the declaration's grammar a computed-value
      question. This includes [all]: the substitution result can be empty and
      leave its neighbouring CSS-wide keyword as the whole value. *)
@@ -2284,7 +2360,7 @@ let validate_regular_property_components t name components =
     && Properties.components_have_css_wide_mix components
   then Cursor.err_invalid t "CSS-wide keyword mixed with other values";
   if
-    name = "all" && (not has_substitution)
+    String.equal name "all" && (not has_substitution)
     && not (components_are_lone_css_wide components)
   then Cursor.err_invalid t "all accepts only CSS-wide keywords"
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3860,6 +3860,23 @@ let typed_custom_font_family_layer_printing () =
   Alcotest.(check string)
     "layer-independent serialization" theme (render "utilities")
 
+(* CSS Anchor Positioning 1 sec. 3.2 allows [anchor()] in the inset properties
+   and nowhere else, and sec. 5.1 allows [anchor-size()] in the properties
+   [@position-try] accepts: the inset, margin, sizing and self-alignment ones,
+   plus [position-anchor] and [position-area]. *)
+let anchor_query_where_the_property_takes_one () =
+  check_declaration ~expected:"left:anchor(right)" "left: anchor(right)";
+  check_declaration ~expected:"width:anchor-size(width)"
+    "width: anchor-size(width)";
+  check_declaration ~expected:"margin-left:anchor-size(width)"
+    "margin-left: anchor-size(width)";
+  check_declaration ~expected:"width:calc(anchor-size(width) + 2px)"
+    "width: calc(anchor-size(width) + 2px)";
+  neg_cursor read_declaration "width: anchor(right)";
+  neg_cursor read_declaration "padding-bottom: anchor-size(width)";
+  neg_cursor read_declaration "translate: anchor-size(width)";
+  neg_cursor read_declaration "scroll-margin: anchor-size(width)"
+
 (* CSS Grid 2 sec. 7.4 spells [grid-template] as [none], a
    [<'grid-template-rows'> / <'grid-template-columns'>] pair, or a track list
    built from strings, and sec. 7.8 gives [grid] those forms plus the two
@@ -6516,6 +6533,8 @@ let declaration_tests =
       color_takes_only_a_colour_function;
     test_case "a grid shorthand names both axes" `Quick
       grid_shorthand_names_both_axes;
+    test_case "an anchor query where the property takes one" `Quick
+      anchor_query_where_the_property_takes_one;
     test_case "custom_property refuses an escaping pair" `Quick
       custom_property_guard;
     test_case "parse_declaration keeps the name out of the value" `Quick


### PR DESCRIPTION
CSS Anchor Positioning 1 sec. 3.2 allows `anchor()` in the inset properties and nowhere else, and sec. 5.1 allows `anchor-size()` in the properties `@position-try` accepts. The length reader carries both wherever a length goes, so `padding-bottom: anchor-size(width)` and `width: anchor(right)` were written back where every browser drops them.