### PR TITLE
transform: keep an intrinsic-sizing keyword out of a length slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -367,6 +367,11 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `translate`, `transform-origin` and the `animation-range-*` family refuse an
+  intrinsic-sizing keyword, so `translate: auto` is dropped with a warning. Each
+  grammar names a length in every slot, and the length carrier brought the
+  keywords with it (#1007)
+
 - An `anchor()` or `anchor-size()` reaches only the properties that take one,
   so `padding-bottom: anchor-size(width)` and `translate: anchor-size(width)`
   are dropped with a warning. CSS Anchor Positioning 1 sec. 3.2 keeps `anchor()`

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1992,6 +1992,12 @@ let read_animation_range_name t : animation_range_name =
 let is_animation_range_name name =
   List.mem (String.lowercase_ascii_preserve name) Keyframe.timeline_range_names
 
+(* Scroll Animations 1 sec. 5.1 spells each item [normal | <length-percentage> |
+   <timeline-range-name> <length-percentage>?], so the intrinsic-sizing keywords
+   a bare length would accept are out. *)
+let read_range_length_percentage t =
+  Values.read_length_percentage ~with_keywords:false t
+
 let read_animation_range_offset t : length_percentage option =
   Cursor.ws t;
   if Cursor.is_done t then (None : length_percentage option)
@@ -2000,7 +2006,7 @@ let read_animation_range_offset t : length_percentage option =
     | Some "normal" -> (None : length_percentage option)
     | Some next when List.mem next Keyframe.timeline_range_names ->
         (None : length_percentage option)
-    | _ -> (Some (Values.read_length_percentage t) : length_percentage option)
+    | _ -> (Some (read_range_length_percentage t) : length_percentage option)
 
 let rec read_animation_range_item t : animation_range_item =
   let keywords : (string * animation_range_item) list =
@@ -2021,7 +2027,7 @@ let rec read_animation_range_item t : animation_range_item =
         let lp = read_animation_range_offset t in
         (Named (name, lp) : animation_range_item)
     | _ ->
-        let lp = Values.read_length_percentage t in
+        let lp = read_range_length_percentage t in
         Offset lp
   in
   Cursor.enum_or_var "animation-range-item" keywords
@@ -2053,7 +2059,7 @@ let rec read_animation_range t : animation_range =
           let lp = read_animation_range_offset t in
           (Named (name, lp) : animation_range_item)
       | _ ->
-          let lp = Values.read_length_percentage t in
+          let lp = read_range_length_percentage t in
           Offset lp
     in
     let first = read_single t in

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -885,18 +885,21 @@ let rec read_translate_value t : translate_value =
 
      - [translate: var(--t)] is a whole-value [var()] -- produce [Var _]. -
      [translate: var(--x) var(--y)] is per-slot -- produce [XY (_, _)]. *)
+  (* The grammar names lengths, so the intrinsic-sizing keywords a bare length
+     would accept are out. *)
+  let read_slot t = read_length ~with_keywords:false t in
   let read_lengths_from t (x : length) : translate_value =
     Cursor.ws t;
-    match Cursor.option read_length t with
+    match Cursor.option read_slot t with
     | Some y -> (
         Cursor.ws t;
-        match Cursor.option read_length t with
+        match Cursor.option read_slot t with
         | Some z -> XYZ (x, y, z)
         | None -> XY (x, y))
     | None -> X x
   in
   let read_lengths t : translate_value =
-    let x = read_length t in
+    let x = read_slot t in
     read_lengths_from t x
   in
   let read_var_or_components t : translate_value =
@@ -906,7 +909,7 @@ let rec read_translate_value t : translate_value =
     if Cursor.is_done t then whole_var
     else
       let () = Cursor.restore t snap in
-      let x = read_length t in
+      let x = read_slot t in
       read_lengths_from t x
   in
   Cursor.enum_or_calls "translate"
@@ -1139,6 +1142,13 @@ let rec read_scale t : scale =
 module Transform_origin = struct
   type keyword = Center | Left | Right | Top | Bottom
 
+  (* CSS Transforms 1 sec. 4 spells the property [[ left | center | right | top
+     | bottom | <length-percentage> ] | [ [ left | center | right |
+     <length-percentage> ] [ top | center | bottom | <length-percentage> ] ]
+     <length>? | ...], so each slot is a length or one of those keywords and the
+     intrinsic-sizing ones a bare length would accept are out. *)
+  let read_slot t = read_length ~with_keywords:false t
+
   let read_position t : transform_origin =
     let position =
       match read_position_value t with
@@ -1147,7 +1157,7 @@ module Transform_origin = struct
       | position -> position
     in
     Cursor.ws t;
-    match Cursor.option read_length t with
+    match Cursor.option read_slot t with
     | Some z -> (
         match position with
         | XY (x, y) -> XYZ (x, y, z)
@@ -1160,12 +1170,12 @@ module Transform_origin = struct
         | position -> Position position)
 
   let read_xyz (t : Cursor.t) : transform_origin =
-    let x = read_length t in
+    let x = read_slot t in
     Cursor.ws t;
-    match Cursor.option read_length t with
+    match Cursor.option read_slot t with
     | Some y -> (
         Cursor.ws t;
-        match Cursor.option read_length t with
+        match Cursor.option read_slot t with
         | Some z -> XYZ (x, y, z)
         | None -> XY (x, y))
     (* CSS Transforms 1 sec. 4: a single <length-percentage> sets the X origin

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3419,6 +3419,9 @@ let test_translate_value () =
   check_translate_value "50% 100%";
   check_translate_value "var(--my-translate)";
   check_translate_value ~expected:"var(--x)var(--y)" "var(--x) var(--y)";
+  (* CSS Transforms 2 sec. 5 names lengths in every slot, so the
+     intrinsic-sizing keywords a bare length would accept are out. *)
+  neg_cursor read_translate_value "auto";
   neg_cursor read_translate_value "invalid-translate"
 
 let test_user_select () =
@@ -3843,6 +3846,9 @@ let test_transform_origin () =
   check_transform_origin "left top 10px";
   check_transform_origin "center top 10px";
   check_transform_origin "inherit";
+  (* CSS Transforms 1 sec. 4 names lengths and edge keywords, so the
+     intrinsic-sizing ones are out. *)
+  neg_cursor read_transform_origin "auto";
   neg_cursor read_transform_origin "invalid-origin"
 
 let test_text_shadow () =
@@ -4852,6 +4858,11 @@ let spec_generated_animation_font_edges () =
   check_animation_name ~expected:"fade,slide" "fade, slide";
   check_animation_range ~expected:"entry 0%exit 100%" "entry 0% exit 100%";
   check_animation_range "entry";
+  (* Scroll Animations 1 sec. 5.1 names [normal], a length-percentage and a
+     range name, so the intrinsic-sizing keywords a bare length would accept are
+     out. *)
+  neg_cursor read_animation_range "auto";
+  neg_cursor read_animation_range_item "auto";
   (* the <length-percentage> offset takes a held (non-reducible) calc(). *)
   check_animation_range_item "entry calc(50% + 10px)";
   check_animation_range_item "cover 20%";


### PR DESCRIPTION
CSS Transforms 2 sec. 5, CSS Transforms 1 sec. 4 and Scroll Animations 1 sec. 5.1 each name a length in every slot they read. The length carrier accepts `auto`, `fit-content` and the rest, so `translate: auto` and `animation-range: auto` were written back where every browser drops them.