### PR TITLE
declaration: give the empty value to a custom property alone

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -367,6 +367,11 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- An empty value is no declaration for any property but a custom one, so
+  `quotes:` and `position-try:` are dropped with a warning where the first was
+  written back and the second read as `none`. CSS Syntax 3 sec. 5.5.6 gives a
+  declaration one or more component values (#1009)
+
 - `translate`, `transform-origin` and the `animation-range-*` family refuse an
   intrinsic-sizing keyword, so `translate: auto` is dropped with a warning. Each
   grammar names a length in every slot, and the length carrier brought the

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2349,6 +2349,11 @@ let validate_anchor_queries t name components =
   then Cursor.err_invalid t ("anchor-size() is not a value of " ^ name)
 
 let validate_regular_property_components t name components =
+  (* CSS Syntax 3 (ED) sec. 5.5.6 gives a declaration a value of one or more
+     component values, and only a custom property takes the empty one (CSS
+     Variables 1 sec. 2). *)
+  if List.for_all Component.is_whitespace components then
+    Cursor.err_expected t "a value";
   validate_anchor_queries t name components;
   (* A substitution function makes the declaration's grammar a computed-value
      question. This includes [all]: the substitution result can be empty and

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3860,6 +3860,16 @@ let typed_custom_font_family_layer_printing () =
   Alcotest.(check string)
     "layer-independent serialization" theme (render "utilities")
 
+(* CSS Syntax 3 (ED) sec. 5.5.6 gives a declaration a value of one or more
+   component values, and CSS Variables 1 sec. 2 gives the empty one to a custom
+   property alone. *)
+let an_empty_value_is_no_declaration () =
+  check_declaration ~expected:"--x:" "--x:";
+  neg_cursor read_declaration "quotes:";
+  neg_cursor read_declaration "quotes: ";
+  neg_cursor read_declaration "position-try: ";
+  neg_cursor read_declaration "color: "
+
 (* CSS Anchor Positioning 1 sec. 3.2 allows [anchor()] in the inset properties
    and nowhere else, and sec. 5.1 allows [anchor-size()] in the properties
    [@position-try] accepts: the inset, margin, sizing and self-alignment ones,
@@ -6535,6 +6545,8 @@ let declaration_tests =
       grid_shorthand_names_both_axes;
     test_case "an anchor query where the property takes one" `Quick
       anchor_query_where_the_property_takes_one;
+    test_case "an empty value is no declaration" `Quick
+      an_empty_value_is_no_declaration;
     test_case "custom_property refuses an escaping pair" `Quick
       custom_property_guard;
     test_case "parse_declaration keeps the name out of the value" `Quick


### PR DESCRIPTION
CSS Syntax 3 sec. 5.5.6 gives a declaration a value of one or more component values, and CSS Variables 1 sec. 2 gives the empty one to a custom property alone. The per-property checks caught the shorthands anyone had met, so `quotes:` was written back and `position-try:` read as `none`.