### PR TITLE
values: keep the box-size functions out of a plain length

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -367,6 +367,14 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- A `fit-content()`, `calc-size()` or `minmax()` reaches only a property whose
+  grammar names it, so `font-size: fit-content(20rem)` and
+  `scroll-padding-bottom: fit-content(20rem)` are dropped with a warning. CSS
+  Sizing 4 sec. 3.2 puts the first two in `<box-size>` and CSS Grid 2 sec.
+  7.2.1 puts the third in `<track-size>`, and cascade read all three as plain
+  lengths. `mask-size: auto 300px` reads, where the keyword was a whole value
+  only (#1010)
+
 - An empty value is no declaration for any property but a custom one, so
   `quotes:` and `position-try:` are dropped with a warning where the first was
   written back and the second read as `none`. CSS Syntax 3 sec. 5.5.6 gives a

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1717,26 +1717,36 @@ let read_background_repeat_list t : background_repeat =
   | [ one ] -> one
   | many -> Layers many
 
+(* CSS Backgrounds 3 sec. 3.9 spells [<bg-size>] as [[ <length-percentage
+   [0,inf]> | auto ]{1,2} | cover | contain], so [auto] fills one slot of the
+   pair as readily as the whole value, and no sizing function stands in either
+   slot. *)
 let rec read_background_size t : background_size =
+  let read_slot t : length =
+    Cursor.one_of
+      [
+        (fun t ->
+          Cursor.expect_string "auto" t;
+          (Auto : length));
+        read_length ~allow_negative:false ~with_keywords:false;
+      ]
+      t
+  in
   let read_pair t : background_size =
-    let a, b =
-      Cursor.pair
-        (read_length ~allow_negative:false)
-        (read_length ~allow_negative:false)
-        t
-    in
+    let a, b = Cursor.pair read_slot read_slot t in
     Size (a, b)
   in
   let read_single t : background_size =
-    Length (read_length ~allow_negative:false t)
+    match read_slot t with
+    | (Auto : length) -> (Auto : background_size)
+    | len -> Length len
   in
   let read_var_call t : background_size =
     (Var (read_var read_background_size t) : background_size)
   in
   Cursor.enum_or_var "background-size"
     [
-      ("auto", (Auto : background_size));
-      ("cover", Cover);
+      ("cover", (Cover : background_size));
       ("contain", Contain);
       ("inherit", Inherit);
       ("initial", Initial);

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -5909,25 +5909,35 @@ and read_length_function_body ~allow_negative ~length_only ~with_keywords t name
   | None -> Cursor.err t ("unknown function " ^ name)
 
 and length_function_readers ~allow_negative ~length_only ~with_keywords =
-  [
-    ("clamp", read_clamp_length ~length_only);
-    ("minmax", read_minmax_length ~length_only);
-    ("min", read_min_length ~length_only);
-    ("max", read_max_length ~length_only);
-    ( "fit-content",
-      read_fit_content_length ~allow_negative ~length_only ~with_keywords );
-    ("round", read_round_length ~allow_negative ~length_only ~with_keywords);
-    ("mod", read_mod_length ~allow_negative ~length_only ~with_keywords);
-    ("rem", read_rem_length ~allow_negative ~length_only ~with_keywords);
-    ("hypot", read_hypot_length ~allow_negative ~length_only ~with_keywords);
-    ("abs", read_abs_length ~allow_negative ~length_only ~with_keywords);
-    ("sign", read_sign_length ~allow_negative ~length_only ~with_keywords);
-    ( "calc-size",
-      read_calc_size_length ~allow_negative ~length_only ~with_keywords );
-    ("anchor-size", read_anchor_size_length);
-    ("anchor", read_anchor_length ~allow_negative ~length_only ~with_keywords);
-    ("attr", read_attr_length ~allow_negative ~length_only ~with_keywords);
-  ]
+  (* CSS Sizing 4 sec. 3.2 puts [fit-content()] and [calc-size()] in
+     [<box-size>] and CSS Grid 2 sec. 7.2.1 puts [minmax()] in [<track-size>],
+     so a caller reading a plain [<length>] takes none of the three. The math
+     functions and the substitutions stay: those resolve to a length wherever
+     one may stand. *)
+  let sizing_functions =
+    [
+      ("minmax", read_minmax_length ~length_only);
+      ( "fit-content",
+        read_fit_content_length ~allow_negative ~length_only ~with_keywords );
+      ( "calc-size",
+        read_calc_size_length ~allow_negative ~length_only ~with_keywords );
+    ]
+  in
+  (if with_keywords then sizing_functions else [])
+  @ [
+      ("clamp", read_clamp_length ~length_only);
+      ("min", read_min_length ~length_only);
+      ("max", read_max_length ~length_only);
+      ("round", read_round_length ~allow_negative ~length_only ~with_keywords);
+      ("mod", read_mod_length ~allow_negative ~length_only ~with_keywords);
+      ("rem", read_rem_length ~allow_negative ~length_only ~with_keywords);
+      ("hypot", read_hypot_length ~allow_negative ~length_only ~with_keywords);
+      ("abs", read_abs_length ~allow_negative ~length_only ~with_keywords);
+      ("sign", read_sign_length ~allow_negative ~length_only ~with_keywords);
+      ("anchor-size", read_anchor_size_length);
+      ("anchor", read_anchor_length ~allow_negative ~length_only ~with_keywords);
+      ("attr", read_attr_length ~allow_negative ~length_only ~with_keywords);
+    ]
 
 (* CSS Values 4 sec. 10.2: arguments to [clamp()], [min()], [max()], [minmax()]
    are implicit math expressions, so [clamp(.5rem, 2vw + .5rem, 2rem)] is valid

--- a/test/spec/browser/accept_set.ml
+++ b/test/spec/browser/accept_set.ml
@@ -402,6 +402,24 @@ let spec_ahead_here : Chrome_gaps.excuse list =
     (fun (properties, values, why) ->
       List.map (fun value -> { Chrome_gaps.properties; value; why }) values)
     [
+      ( [
+          "width";
+          "height";
+          "min-width";
+          "min-height";
+          "max-width";
+          "max-height";
+          "inline-size";
+          "min-inline-size";
+          "max-inline-size";
+          "block-size";
+          "min-block-size";
+          "max-block-size";
+          "flex-basis";
+        ],
+        [ "contain" ],
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it" );
       ( [ "text-overflow" ],
         [ "\"text\"" ],
         "CSS Overflow 4 sec. 4.1: [ clip | ellipsis | <string> | fade | \

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2856,6 +2856,10 @@ let test_background_size () =
   check_background_size "var(--s)";
   check_background_size "calc(50% + 10px)";
   check_background_size "calc(50% + 10px) auto";
+  (* CSS Backgrounds 3 sec. 3.9 fills each of the two slots with a length or
+     [auto], and no sizing function stands in either. *)
+  check_background_size "auto 300px";
+  neg_cursor read_background_size "fit-content(20rem)";
   (* Comma-separated layer list (CSS Backgrounds 3 sec. 2.9). *)
   decl_optimizes ~prop:"background-size" ~into:"cover,contain" "cover,contain";
   decl_optimizes ~prop:"background-size" ~into:"100px 200px,auto"
@@ -4661,7 +4665,11 @@ let test_font_size () =
   check_font_size "medium";
   check_font_size "large";
   check_font_size "inherit";
-  neg_cursor read_font_size "invalid-font-size"
+  neg_cursor read_font_size "invalid-font-size";
+  (* CSS Fonts 4 sec. 2.5 takes an absolute or relative size, a
+     [<length-percentage>] or [math]; CSS Sizing 4 sec. 3.2's [fit-content()] is
+     a [<box-size>] and no length. *)
+  neg_cursor read_font_size "fit-content(20rem)"
 
 let test_mask_box () =
   check_mask_box "border-box";


### PR DESCRIPTION
CSS Sizing 4 sec. 3.2 puts `fit-content()` and `calc-size()` in `<box-size>` and CSS Grid 2 sec. 7.2.1 puts `minmax()` in `<track-size>`, but the shared length function table offered all three to every caller, so `font-size: fit-content(20rem)` was written back. `<bg-size>` also fills each of its two slots with a length or `auto`, so `mask-size: auto 300px` now reads. `contain` on a sizing property is spec-ahead of Chrome and named as such.