### PR TITLE
transform: read a basic shape as an offset-path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@ entry points both moved.
 
 ### Breaking
 
+- `Cascade.Properties.offset_path` gains `Shape of clip_path`, so
+  `offset-path: circle(50%) content-box` reads where a basic shape or a
+  reference box was dropped with a warning. CSS Motion Path 1 sec. 2.1 gives
+  the property `<basic-shape> || <coord-box>`. Exhaustive visitors must handle
+  the new leaf (#1011)
+
 - `Cascade.Properties.page_size` gains `Initial`, `Unset`, `Revert` and
   `Revert_layer`. Exhaustive visitors must handle the four new leaves (#1004)
 

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -916,7 +916,7 @@ let read_clip_path_ellipse t : clip_path =
       Cursor.expect_eof inner;
       Clip_path_ellipse { rx; ry; position })
 
-let read_polygon_fill_rule inner =
+let read_polygon_fill_rule inner : clip_path_fill_rule option =
   match Cursor.peek_ident inner with
   | Some "nonzero" ->
       Cursor.skip inner;

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -686,6 +686,7 @@ let rec pp_offset_path : offset_path Pp.t =
   | Url url -> Pp.url ctx url
   | Path path -> Pp.call "path" Pp.quoted_string ctx path
   | Ray ray -> Pp.call "ray" pp_ray ctx ray
+  | Shape shape -> Prop_mask.pp_clip_path ctx shape
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -1362,7 +1363,21 @@ let rec read_offset_path t : offset_path =
         ( "var",
           fun t -> (Var (Values.read_var read_offset_path t) : offset_path) );
       ]
-    ~default:read_offset_path_url_token t
+      (* CSS Motion Path 1 sec. 2.1: [<offset-path> || <coord-box>], where
+         [<offset-path>] holds [<basic-shape>]. A shape and a reference box read
+         the way [clip-path] reads them; only that property's [none] and [url()]
+         arms belong to the enum above instead. *)
+    ~default:
+      (Cursor.one_of
+         [
+           read_offset_path_url_token;
+           (fun t ->
+             match Prop_mask.read_clip_path t with
+             | (Clip_path_none : clip_path) | Clip_path_url _ ->
+                 Cursor.err_expected t "offset-path shape"
+             | shape -> (Shape shape : offset_path));
+         ])
+    t
 
 let read_ray t : ray =
   Cursor.call "ray" t @@ fun inner ->
@@ -1445,7 +1460,7 @@ let starts_offset_path t =
   Cursor.lookahead
     (fun t ->
       match Cursor.option read_offset_path t with
-      | Some (None | Url _ | Path _ | Ray _ : offset_path) -> true
+      | Some (None | Url _ | Path _ | Ray _ | Shape _ : offset_path) -> true
       | Some _ | Option.None -> false)
     t
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3759,11 +3759,101 @@ type ray = {
   position : position_value option;
 }
 
+(** CSS Masking 1 sec. 5.1 [<geometry-box>] reference box for [clip-path]: the
+    [<shape-box>] from CSS Shapes 1 plus the SVG-specific boxes. *)
+type clip_geometry_box =
+  | Margin_box
+  | Border_box
+  | Padding_box
+  | Content_box
+  | Fill_box
+  | Stroke_box
+  | View_box
+
+(** CSS Shapes 1 sec. 3.1 [<shape-radius>] for [circle()] / [ellipse()]: a
+    [<length-percentage>] or one of the extent keywords. *)
+type clip_path_extent = Extent_length of length | Closest_side | Farthest_side
+
+type clip_path_fill_rule = Nonzero | Evenodd
+
+(* clip-path property for clipping regions *)
+type clip_path =
+  | Clip_path_none
+  | Clip_path_url of string
+  | Clip_path_inset of {
+      top : length_percentage;
+      right : length_percentage option;
+      bottom : length_percentage option;
+      left : length_percentage option;
+      rounded : border_radius option;
+    }  (** [inset(<length-percentage>{1,4} [round <border-radius>]?)] *)
+  | Clip_path_circle of {
+      radius : clip_path_extent option;
+      position : position_value option;
+    }  (** [circle(<shape-radius>? [at <position>]?)] *)
+  | Clip_path_ellipse of {
+      rx : clip_path_extent option;
+      ry : clip_path_extent option;
+      position : position_value option;
+    }  (** [ellipse(<shape-radius>{2}? [at <position>]?)] *)
+  | Clip_path_polygon of {
+      fill_rule : clip_path_fill_rule option;
+      points : (length * length) list;
+      spaced : bool;
+          (** [true] if the source emitted points without explicit commas. *)
+    }
+  | Clip_path_path of string  (** SVG path data *)
+  | Clip_path_shape of string
+  | Clip_path_box of clip_geometry_box
+      (** Bare reference box, e.g. [clip-path: margin-box]. *)
+  | Clip_path_with_box of {
+      shape : clip_path;
+      box : clip_geometry_box;
+      box_first : bool;
+          (** Source order: [true] if the box appeared before the shape
+              ([padding-box circle(...)]), [false] for
+              [circle(...) padding-box]. *)
+    }
+  | Clip_path_xywh of {
+      x : length_percentage;
+      y : length_percentage;
+      width : length_percentage;
+      height : length_percentage;
+      rounded : border_radius option;
+    }
+      (** [xywh(<length-percentage>{4} [round <border-radius>]?)] - CSS Shapes
+          2. *)
+  | Clip_path_rect of {
+      top : length_percentage;
+      right : length_percentage;
+      bottom : length_percentage;
+      left : length_percentage;
+      rounded : border_radius option;
+    }
+      (** [rect(<length-percentage>{4} [round <border-radius>]?)] - CSS Shapes
+          2. *)
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of clip_path var
+  | Invalid of invalid_value
+      (** Spec-invalid [<basic-shape>] preserved verbatim - e.g.
+          [ellipse(50px 60px at 0 10% 20%)] with a 3-value [<position>] tail.
+          The pretty-printer round-trips the captured tokens; the
+          [Optimize.drop_invalid] pass removes the declaration on every
+          serialisation. *)
+
 type offset_path =
   | None
   | Url of string
   | Path of string
   | Ray of ray
+  | Shape of clip_path
+      (** CSS Motion Path 1 sec. 2.1 [<basic-shape> || <coord-box>], which
+          {!type-clip_path} already models for [clip-path]: the same shape
+          functions and the same reference boxes. *)
   | Initial
   | Inherit
   | Unset
@@ -4633,92 +4723,6 @@ type clip =
   | Revert
   | Revert_layer
   | Var of clip var
-
-(** CSS Masking 1 sec. 5.1 [<geometry-box>] reference box for [clip-path]: the
-    [<shape-box>] from CSS Shapes 1 plus the SVG-specific boxes. *)
-type clip_geometry_box =
-  | Margin_box
-  | Border_box
-  | Padding_box
-  | Content_box
-  | Fill_box
-  | Stroke_box
-  | View_box
-
-(** CSS Shapes 1 sec. 3.1 [<shape-radius>] for [circle()] / [ellipse()]: a
-    [<length-percentage>] or one of the extent keywords. *)
-type clip_path_extent = Extent_length of length | Closest_side | Farthest_side
-
-type clip_path_fill_rule = Nonzero | Evenodd
-
-(* clip-path property for clipping regions *)
-type clip_path =
-  | Clip_path_none
-  | Clip_path_url of string
-  | Clip_path_inset of {
-      top : length_percentage;
-      right : length_percentage option;
-      bottom : length_percentage option;
-      left : length_percentage option;
-      rounded : border_radius option;
-    }  (** [inset(<length-percentage>{1,4} [round <border-radius>]?)] *)
-  | Clip_path_circle of {
-      radius : clip_path_extent option;
-      position : position_value option;
-    }  (** [circle(<shape-radius>? [at <position>]?)] *)
-  | Clip_path_ellipse of {
-      rx : clip_path_extent option;
-      ry : clip_path_extent option;
-      position : position_value option;
-    }  (** [ellipse(<shape-radius>{2}? [at <position>]?)] *)
-  | Clip_path_polygon of {
-      fill_rule : clip_path_fill_rule option;
-      points : (length * length) list;
-      spaced : bool;
-          (** [true] if the source emitted points without explicit commas. *)
-    }
-  | Clip_path_path of string  (** SVG path data *)
-  | Clip_path_shape of string
-  | Clip_path_box of clip_geometry_box
-      (** Bare reference box, e.g. [clip-path: margin-box]. *)
-  | Clip_path_with_box of {
-      shape : clip_path;
-      box : clip_geometry_box;
-      box_first : bool;
-          (** Source order: [true] if the box appeared before the shape
-              ([padding-box circle(...)]), [false] for
-              [circle(...) padding-box]. *)
-    }
-  | Clip_path_xywh of {
-      x : length_percentage;
-      y : length_percentage;
-      width : length_percentage;
-      height : length_percentage;
-      rounded : border_radius option;
-    }
-      (** [xywh(<length-percentage>{4} [round <border-radius>]?)] - CSS Shapes
-          2. *)
-  | Clip_path_rect of {
-      top : length_percentage;
-      right : length_percentage;
-      bottom : length_percentage;
-      left : length_percentage;
-      rounded : border_radius option;
-    }
-      (** [rect(<length-percentage>{4} [round <border-radius>]?)] - CSS Shapes
-          2. *)
-  | Inherit
-  | Initial
-  | Unset
-  | Revert
-  | Revert_layer
-  | Var of clip_path var
-  | Invalid of invalid_value
-      (** Spec-invalid [<basic-shape>] preserved verbatim - e.g.
-          [ellipse(50px 60px at 0 10% 20%)] with a 3-value [<position>] tail.
-          The pretty-printer round-trips the captured tokens; the
-          [Optimize.drop_invalid] pass removes the declaration on every
-          serialisation. *)
 
 type _ kind =
   | Length : length kind

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1214,6 +1214,46 @@ let vars_of_contain_intrinsic_longhand
 let vars_of_margin_trim (value : Properties.margin_trim) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_border_radius (value : Properties.border_radius) =
+  let from_list = List.concat_map vars_of_length_percentage in
+  match value with
+  | Var v -> [ V v ]
+  | Radius { horizontal; vertical } ->
+      from_list horizontal
+      @ Option.value ~default:[] (Option.map from_list vertical)
+  | Inherit | Initial | Unset | Revert | Revert_layer -> []
+
+let vars_of_clip_path_extent (value : Properties.clip_path_extent) =
+  match value with Extent_length l -> vars_of_length l | _ -> []
+
+let rec vars_of_clip_path (value : Properties.clip_path) =
+  match value with
+  | Var v -> [ V v ]
+  | Clip_path_inset { top; right; bottom; left; rounded } ->
+      vars_of_length_percentage top
+      @ Option.value ~default:[] (Option.map vars_of_length_percentage right)
+      @ Option.value ~default:[] (Option.map vars_of_length_percentage bottom)
+      @ Option.value ~default:[] (Option.map vars_of_length_percentage left)
+      @ Option.value ~default:[] (Option.map vars_of_border_radius rounded)
+  | Clip_path_circle { radius; _ } ->
+      Option.value ~default:[] (Option.map vars_of_clip_path_extent radius)
+  | Clip_path_ellipse { rx; ry; _ } ->
+      Option.value ~default:[] (Option.map vars_of_clip_path_extent rx)
+      @ Option.value ~default:[] (Option.map vars_of_clip_path_extent ry)
+  | Clip_path_polygon { points; _ } ->
+      List.concat_map (fun (a, b) -> vars_of_length a @ vars_of_length b) points
+  | Clip_path_box _ -> []
+  | Clip_path_with_box { shape; _ } -> vars_of_clip_path shape
+  | Clip_path_xywh { x; y; width; height; rounded }
+  | Clip_path_rect
+      { top = x; right = y; bottom = width; left = height; rounded } ->
+      vars_of_length_percentage x
+      @ vars_of_length_percentage y
+      @ vars_of_length_percentage width
+      @ vars_of_length_percentage height
+      @ Option.value ~default:[] (Option.map vars_of_border_radius rounded)
+  | _ -> []
+
 let vars_of_ray (value : Properties.ray) =
   vars_of_angle value.angle
   @ Option.fold ~none:[] ~some:vars_of_position_value value.position
@@ -1222,6 +1262,7 @@ let vars_of_offset_path (value : Properties.offset_path) =
   match value with
   | Var v -> [ V v ]
   | Ray ray -> vars_of_ray ray
+  | Shape shape -> vars_of_clip_path shape
   | None | Url _ | Path _ | Initial | Inherit | Unset | Revert | Revert_layer ->
       []
 
@@ -1707,48 +1748,8 @@ let vars_of_clip (value : Properties.clip) =
       vars_of_length a @ vars_of_length b @ vars_of_length c @ vars_of_length d
   | _ -> []
 
-let vars_of_border_radius (value : Properties.border_radius) =
-  let from_list = List.concat_map vars_of_length_percentage in
-  match value with
-  | Var v -> [ V v ]
-  | Radius { horizontal; vertical } ->
-      from_list horizontal
-      @ Option.value ~default:[] (Option.map from_list vertical)
-  | Inherit | Initial | Unset | Revert | Revert_layer -> []
-
 let vars_of_perspective_origin (value : Properties.perspective_origin) =
   vars_of_position_value value
-
-let vars_of_clip_path_extent (value : Properties.clip_path_extent) =
-  match value with Extent_length l -> vars_of_length l | _ -> []
-
-let rec vars_of_clip_path (value : Properties.clip_path) =
-  match value with
-  | Var v -> [ V v ]
-  | Clip_path_inset { top; right; bottom; left; rounded } ->
-      vars_of_length_percentage top
-      @ Option.value ~default:[] (Option.map vars_of_length_percentage right)
-      @ Option.value ~default:[] (Option.map vars_of_length_percentage bottom)
-      @ Option.value ~default:[] (Option.map vars_of_length_percentage left)
-      @ Option.value ~default:[] (Option.map vars_of_border_radius rounded)
-  | Clip_path_circle { radius; _ } ->
-      Option.value ~default:[] (Option.map vars_of_clip_path_extent radius)
-  | Clip_path_ellipse { rx; ry; _ } ->
-      Option.value ~default:[] (Option.map vars_of_clip_path_extent rx)
-      @ Option.value ~default:[] (Option.map vars_of_clip_path_extent ry)
-  | Clip_path_polygon { points; _ } ->
-      List.concat_map (fun (a, b) -> vars_of_length a @ vars_of_length b) points
-  | Clip_path_box _ -> []
-  | Clip_path_with_box { shape; _ } -> vars_of_clip_path shape
-  | Clip_path_xywh { x; y; width; height; rounded }
-  | Clip_path_rect
-      { top = x; right = y; bottom = width; left = height; rounded } ->
-      vars_of_length_percentage x
-      @ vars_of_length_percentage y
-      @ vars_of_length_percentage width
-      @ vars_of_length_percentage height
-      @ Option.value ~default:[] (Option.map vars_of_border_radius rounded)
-  | _ -> []
 
 let vars_of_object_view_box (value : Properties.object_view_box) =
   match value with

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3392,6 +3392,22 @@ let offset_slots_roundtrip () =
      text. *)
   offset_roundtrips ".x{offset:var(--a) var(--b)}"
 
+(* Sec. 2.1 gives [offset-path] a [<basic-shape> || <coord-box>] branch beside
+   [ray()], [url()] and [path()], so every shape function [clip-path] takes is a
+   motion path too, alone or with a reference box. The shorthand's leading group
+   holds the same branch. *)
+let offset_path_basic_shapes () =
+  offset_roundtrips ".x{offset-path:circle()}";
+  offset_roundtrips ".x{offset-path:circle(50%)}";
+  offset_roundtrips ".x{offset-path:ellipse(10px 20px at 0 0)}";
+  offset_roundtrips ".x{offset-path:inset(10px)}";
+  offset_roundtrips ".x{offset-path:xywh(0 0 100% 100%)}";
+  offset_roundtrips ".x{offset-path:polygon(0 0,10px 0,0 10px)}";
+  offset_roundtrips ".x{offset-path:content-box}";
+  offset_roundtrips ".x{offset-path:circle(50%) content-box}";
+  offset_roundtrips ".x{offset:content-box}";
+  offset_roundtrips ".x{offset:circle(50%)10px}"
+
 (* The five longhands keep the behaviour secs. 2.1 to 2.5 give them once the
    shorthand that resets them is modelled. *)
 let offset_longhand_guards () =
@@ -5671,6 +5687,7 @@ let additional_tests =
     test_case "offset invalid values" `Quick offset_invalid_values;
     test_case "offset slots roundtrip" `Quick offset_slots_roundtrip;
     test_case "offset longhand guards" `Quick offset_longhand_guards;
+    test_case "offset path basic shapes" `Quick offset_path_basic_shapes;
     test_case "offset spellings factor" `Quick offset_spellings_factor;
     test_case "translate_value" `Quick test_translate_value;
     test_case "user_select" `Quick test_user_select;


### PR DESCRIPTION
`offset-path: circle(50%)`, `inset(10px)` and a bare `content-box` were dropped with a warning where every browser accepts them. CSS Motion Path 1 sec. 2.1 gives the property `<basic-shape> || <coord-box>`, which is what `clip-path` already models, so `Properties.offset_path` gains `Shape of clip_path`.