### PR TITLE
layout: give the container shorthand a name list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,13 @@ entry points both moved.
 
 ### Breaking
 
+- `Cascade.Properties.container_shorthand` holds a `container_name` where it
+  held a `string option`, so `container: markers stroke fill` reads and
+  `container: inline-size` names a container instead of typing one. CSS
+  Conditional 5 sec. 3.3 makes the name half required and sec. 3.2 spells it
+  `none | <custom-ident>+`, which also excludes `and`, `not` and `or` from a
+  container name (#1013)
+
 - `Cascade.Properties.position_try_fallbacks` holds
   `position_try_fallback_entry list`, whose `Area` entry carries the
   `<position-area>` CSS Anchor Positioning 1 sec. 6.1 allows beside the

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -3334,14 +3334,15 @@ let user_select value = v User_select value
 let webkit_user_select value = v Webkit_user_select value
 let container_type value = v Container_type value
 
-let container_name value =
+let container_name_of_string value : container_name =
   let names = String.split_on_char ' ' value |> List.filter (( <> ) "") in
-  match names with
-  | [ "none" ] -> v Container_name (None : container_name)
-  | _ -> v Container_name (Names names)
+  match names with [ "none" ] -> None | _ -> Names names
+
+let container_name value = v Container_name (container_name_of_string value)
 
 let container ?type_ name =
-  v Container (Shorthand { name = Some name; ctype = type_ })
+  v Container
+    (Shorthand { name = container_name_of_string name; ctype = type_ })
 
 let transform value = v Transform [ value ]
 

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -314,17 +314,15 @@ let rec pp_container_shorthand : container_shorthand Pp.t =
   | Unset -> Pp.string ctx "unset"
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
-  | Shorthand { name; ctype } -> (
-      match (name, ctype) with
-      | None, None -> () (* Should not happen, but emit nothing *)
-      | Some n, None -> Pp.string ctx n
-      | None, Some t -> pp_container_type ctx t
-      | Some n, Some t ->
-          Pp.string ctx n;
+  | Shorthand { name; ctype } ->
+      pp_container_name ctx name;
+      Option.iter
+        (fun t ->
           Pp.sp ctx ();
           Pp.char ctx '/';
           Pp.sp ctx ();
           pp_container_type ctx t)
+        ctype
 
 let rec pp_content_visibility : content_visibility Pp.t =
  fun ctx -> function
@@ -457,8 +455,22 @@ let rec read_container_type (t : Cursor.t) : container_type =
       (Var (Values.read_var read_container_type t) : container_type))
     t
 
+(* CSS Conditional 5 sec. 3.2 excludes [none], [and], [not] and [or] from a
+   container name, and CSS Values 4 sec. 3.2 excludes [default] and the CSS-wide
+   keywords from every [<custom-ident>]. *)
 let container_name_reserved =
-  [ "none"; "default"; "initial"; "inherit"; "unset"; "revert"; "revert-layer" ]
+  [
+    "none";
+    "and";
+    "not";
+    "or";
+    "default";
+    "initial";
+    "inherit";
+    "unset";
+    "revert";
+    "revert-layer";
+  ]
 
 let read_container_custom_ident t =
   let ident = Cursor.ident ~keep_case:true t in
@@ -588,51 +600,38 @@ let rec read_contain_intrinsic_longhand (t : Cursor.t) :
      t
     : contain_intrinsic_longhand)
 
+(* Sec. 3.3 gives the shorthand a required [<'container-name'>], so every
+   keyword before the slash is a name: [container: inline-size] names a
+   container, it does not type one. *)
+let read_container_shorthand_name t : container_name =
+  match Cursor.peek_ident t with
+  | Some "none" ->
+      let _ = Cursor.ident t in
+      (None : container_name)
+  | _ ->
+      Names
+        (Cursor.list ~sep:Cursor.ws ~at_least:1 read_container_custom_ident t)
+
 let rec read_container_shorthand (t : Cursor.t) : container_shorthand =
-  (* Syntax: container: [<custom-ident>] [ / <container-type> ]? *)
-  let is_container_type_keyword ident =
-    match String.lowercase_ascii ident with
-    | "normal" | "inline-size" | "size" | "scroll-state" -> true
-    | _ -> false
-  in
-  let validate_name_before_slash ident =
-    if is_container_type_keyword ident then
-      Cursor.err_invalid t
-        ("container shorthand type keyword used as name: " ^ ident);
-    if List.mem (String.lowercase_ascii ident) container_name_reserved then
-      Cursor.err_invalid t ("reserved container-name ident: " ^ ident)
-  in
-  Cursor.ws t;
-  match Cursor.peek t with
-  | Some (Component.Func { node = { name; _ }; _ })
-    when String.lowercase_ascii_preserve name = "var" ->
-      (Var (Values.read_var read_container_shorthand t) : container_shorthand)
-  | _ -> (
-      let first = Cursor.ident t in
+  Cursor.enum_or_var "container"
+    [
+      ("initial", (Initial : container_shorthand));
+      ("inherit", Inherit);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t ->
+      (Var (Values.read_var read_container_shorthand t) : container_shorthand))
+    ~default:(fun t ->
+      let name = read_container_shorthand_name t in
       Cursor.ws t;
-      match Cursor.peek_delim t with
-      | Some '/' ->
-          (* We have: name / type *)
-          validate_name_before_slash first;
-          Cursor.expect '/' t;
-          Cursor.ws t;
-          let ctype = read_container_type t in
-          Shorthand { name = Some first; ctype = Some ctype }
-      | _ -> (
-          (* Just a name, or just a type? Check if it's a valid
-             container-type *)
-          match first with
-          | "normal" -> Shorthand { name = None; ctype = Some Normal }
-          | "inline-size" -> Shorthand { name = None; ctype = Some Inline_size }
-          | "size" -> Shorthand { name = None; ctype = Some Size }
-          | "scroll-state" ->
-              Shorthand { name = None; ctype = Some Scroll_state }
-          | "initial" -> Initial
-          | "inherit" -> Inherit
-          | "unset" -> Unset
-          | "revert" -> Revert
-          | "revert-layer" -> Revert_layer
-          | _ -> Shorthand { name = Some first; ctype = None }))
+      if Cursor.slash_opt t then (
+        Cursor.ws t;
+        (Shorthand { name; ctype = Some (read_container_type t) }
+          : container_shorthand))
+      else Shorthand { name; ctype = Option.None })
+    t
 
 let rec read_contain t : contain =
   let read_contain_value t : contain =

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3931,9 +3931,11 @@ type offset =
   | Revert_layer
   | Var of offset var
 
-(* Container shorthand: name / type *)
+(** CSS Conditional 5 sec. 3.3 [container]:
+    [<'container-name'> [ / <'container-type'> ]?]. The name half is required,
+    and only the [None] and [Names] arms of {!type-container_name} reach it. *)
 type container_shorthand =
-  | Shorthand of { name : string option; ctype : container_type option }
+  | Shorthand of { name : container_name; ctype : container_type option }
   | Initial
   | Inherit
   | Unset

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -2628,8 +2628,7 @@ let duo_container idx i =
     in
     let value : Properties.container_shorthand option =
       match (name : Properties.container_name option) with
-      | Some None -> Some (Shorthand { name = Some "none"; ctype })
-      | Some (Names [ n ]) -> Some (Shorthand { name = Some n; ctype })
+      | Some ((None | Names _) as name) -> Some (Shorthand { name; ctype })
       | _ -> Option.None
     in
     Option.map (Declaration.v ~important Container) value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4419,6 +4419,11 @@ let spec_platform_property_vectors () =
          <name>] alone; pins the canonical form for the typed shorthand emitter
          ([container : ?type_:_ -> container_name -> declaration]). *)
       ("container: card", "container:card");
+      (* CSS Conditional 5 sec. 3.3 makes every keyword before the slash part of
+         the required [<'container-name'>], which sec. 3.2 spells [none |
+         <custom-ident>+]. *)
+      ("container: card inline-size", "container:card inline-size");
+      ("container: inline-size", "container:inline-size");
       ("overscroll-behavior: contain", "overscroll-behavior:contain");
       ("overscroll-behavior-inline: none", "overscroll-behavior-inline:none");
       ("overscroll-behavior-block: contain", "overscroll-behavior-block:contain");
@@ -4936,7 +4941,7 @@ let spec_remaining_prop_vectors () =
       "mix-blend-mode: multiply plus-lighter";
       "shape-image-threshold: 1.5 2";
       "container-name: none card";
-      "container: card inline-size";
+      "container-name: and";
       "anchor-name: target";
       "anchor-name: --a none";
       "position-anchor: --a --b";


### PR DESCRIPTION
`container: markers stroke fill` was dropped with a warning, and `container: inline-size` set `container-type` where the browser sets `container-name`. CSS Conditional 5 sec. 3.3 makes the name half of the shorthand required, so every keyword before the slash is part of the `none | <custom-ident>+` of sec. 3.2.