### PR TITLE
align: keep left and right on the inline axis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@ entry points both moved.
 
 ### Breaking
 
+- `Cascade.Properties.align_content` drops `Left`, `Right` and their four
+  `Safe_`/`Unsafe_` spellings, which CSS Box Alignment 3 sec. 4.2 keeps out of
+  `<content-position>`, and `justify_content` gains the `Safe_left` and
+  `Safe_right` it was missing, so `justify-content: safe left` keeps its
+  overflow keyword instead of computing to `left` (#1014)
+
 - `Cascade.Properties.container_shorthand` holds a `container_name` where it
   held a `string option`, so `container: markers stroke fill` reads and
   `container: inline-size` names a container instead of typing one. CSS

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3561,24 +3561,18 @@ type align_content = Properties.align_content =
   | End
   | Flex_start
   | Flex_end
-  | Left
-  | Right
   (* Safe content position values *)
   | Safe_center
   | Safe_start
   | Safe_end
   | Safe_flex_start
   | Safe_flex_end
-  | Safe_left
-  | Safe_right
   (* Unsafe content position values *)
   | Unsafe_center
   | Unsafe_start
   | Unsafe_end
   | Unsafe_flex_start
   | Unsafe_flex_end
-  | Unsafe_left
-  | Unsafe_right
   | Space_between
   | Space_around
   | Space_evenly
@@ -3643,6 +3637,8 @@ type justify_content = Properties.justify_content =
   | Safe_end
   | Safe_flex_start
   | Safe_flex_end
+  | Safe_left
+  | Safe_right
   | Unsafe_center
   | Unsafe_start
   | Unsafe_end

--- a/lib/prop_align.ml
+++ b/lib/prop_align.ml
@@ -114,8 +114,6 @@ module Align_content = struct
         ("end", Safe_end);
         ("flex-start", Safe_flex_start);
         ("flex-end", Safe_flex_end);
-        ("left", Safe_left);
-        ("right", Safe_right);
       ]
       t
 
@@ -129,8 +127,6 @@ module Align_content = struct
         ("end", Unsafe_end);
         ("flex-start", Unsafe_flex_start);
         ("flex-end", Unsafe_flex_end);
-        ("left", Unsafe_left);
-        ("right", Unsafe_right);
       ]
       t
 end
@@ -144,8 +140,6 @@ let rec read_align_content t : align_content =
       ("end", End);
       ("flex-start", Flex_start);
       ("flex-end", Flex_end);
-      ("left", Left);
-      ("right", Right);
       ("space-between", Space_between);
       ("space-around", Space_around);
       ("space-evenly", Space_evenly);
@@ -177,8 +171,8 @@ module Justify_content = struct
         ("end", Safe_end);
         ("flex-start", Safe_flex_start);
         ("flex-end", Safe_flex_end);
-        ("left", Left);
-        ("right", Right);
+        ("left", Safe_left);
+        ("right", Safe_right);
       ]
       t
 
@@ -549,6 +543,8 @@ let rec pp_justify_content : justify_content Pp.t =
   | Safe_end -> Pp.string ctx "safe end"
   | Safe_flex_start -> Pp.string ctx "safe flex-start"
   | Safe_flex_end -> Pp.string ctx "safe flex-end"
+  | Safe_left -> Pp.string ctx "safe left"
+  | Safe_right -> Pp.string ctx "safe right"
   | Unsafe_center -> Pp.string ctx "unsafe center"
   | Unsafe_start -> Pp.string ctx "unsafe start"
   | Unsafe_end -> Pp.string ctx "unsafe end"
@@ -692,22 +688,16 @@ let rec pp_align_content : align_content Pp.t =
   | End -> Pp.string ctx "end"
   | Flex_start -> Pp.string ctx "flex-start"
   | Flex_end -> Pp.string ctx "flex-end"
-  | Left -> Pp.string ctx "left"
-  | Right -> Pp.string ctx "right"
   | Safe_center -> Pp.string ctx "safe center"
   | Safe_start -> Pp.string ctx "safe start"
   | Safe_end -> Pp.string ctx "safe end"
   | Safe_flex_start -> Pp.string ctx "safe flex-start"
   | Safe_flex_end -> Pp.string ctx "safe flex-end"
-  | Safe_left -> Pp.string ctx "safe left"
-  | Safe_right -> Pp.string ctx "safe right"
   | Unsafe_center -> Pp.string ctx "unsafe center"
   | Unsafe_start -> Pp.string ctx "unsafe start"
   | Unsafe_end -> Pp.string ctx "unsafe end"
   | Unsafe_flex_start -> Pp.string ctx "unsafe flex-start"
   | Unsafe_flex_end -> Pp.string ctx "unsafe flex-end"
-  | Unsafe_left -> Pp.string ctx "unsafe left"
-  | Unsafe_right -> Pp.string ctx "unsafe right"
   | Space_between -> Pp.string ctx "space-between"
   | Space_around -> Pp.string ctx "space-around"
   | Space_evenly -> Pp.string ctx "space-evenly"

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -478,14 +478,8 @@ let rec pp_place_items : place_items Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
-let read_place_align_content t =
-  match read_align_content t with
-  | Left | Right | Safe_left | Safe_right | Unsafe_left | Unsafe_right ->
-      Cursor.err_invalid t "place-content align value cannot be left or right"
-  | value -> value
-
 let read_place_content_pair t =
-  let a, j = Cursor.pair read_place_align_content read_justify_content t in
+  let a, j = Cursor.pair read_align_content read_justify_content t in
   (Align_justify (a, j) : place_content)
 
 let read_place_content_safe t =
@@ -515,7 +509,7 @@ let read_place_content_unsafe t =
 (* CSS Align 3 sec. 7.2: the second value usually copies the first, except a
    baseline position makes justify-content default to start. *)
 let read_place_content_baseline t =
-  match read_place_align_content t with
+  match read_align_content t with
   | (Baseline | First_baseline | Last_baseline) as align ->
       (Align_justify (align, Start) : place_content)
   | _ -> Cursor.err_invalid t "place-content baseline"

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -311,6 +311,11 @@ type flex_factor =
   | Calc of flex_factor calc
   | Var of flex_factor var
 
+(** CSS Box Alignment 3 sec. 4.2 [align-content]:
+    [normal | <baseline-position> | <content-distribution> |
+     <overflow-position>? <content-position>], where [<content-position>] is
+    [center | start | end | flex-start | flex-end]. The [left] and [right] of
+    {!type-justify_content} belong to the inline axis alone. *)
 type align_content =
   | Normal
   | Baseline
@@ -322,24 +327,18 @@ type align_content =
   | End
   | Flex_start
   | Flex_end
-  | Left
-  | Right
   (* Safe content position values *)
   | Safe_center
   | Safe_start
   | Safe_end
   | Safe_flex_start
   | Safe_flex_end
-  | Safe_left
-  | Safe_right
   (* Unsafe content position values *)
   | Unsafe_center
   | Unsafe_start
   | Unsafe_end
   | Unsafe_flex_start
   | Unsafe_flex_end
-  | Unsafe_left
-  | Unsafe_right
   (* Content distribution *)
   | Space_between
   | Space_around
@@ -440,6 +439,8 @@ type justify_content =
   | Safe_end
   | Safe_flex_start
   | Safe_flex_end
+  | Safe_left
+  | Safe_right
   (* Unsafe content position values *)
   | Unsafe_center
   | Unsafe_start

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1107,7 +1107,17 @@ let flexbox_alignment () =
   check_declaration ~expected:"justify-content:space-around"
     "justify-content: space-around";
   check_declaration ~expected:"justify-content:space-evenly"
-    "justify-content: space-evenly"
+    "justify-content: space-evenly";
+  (* CSS Box Alignment 3 sec. 4.2 keeps [left] and [right] out of
+     [<content-position>], so only the inline axis takes them, and sec. 4.4
+     pairs an overflow keyword with either. *)
+  check_declaration ~expected:"justify-content:safe left"
+    "justify-content: safe left";
+  check_declaration ~expected:"justify-content:safe right"
+    "justify-content: safe right";
+  neg_cursor read_declaration "align-content: right";
+  neg_cursor read_declaration "align-content: unsafe right";
+  neg_cursor read_declaration "place-content: unsafe right"
 
 let borders () =
   (* Border style *)


### PR DESCRIPTION
`align-content: unsafe right` was read where every browser drops it, and `justify-content: safe left` computed to `left`, losing the overflow keyword that decides what happens when the content does not fit. CSS Box Alignment 3 sec. 4.2 gives `left` and `right` to `justify-content` alone.