### PR TITLE
layout: reserve the idents will-change excludes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -394,6 +394,12 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `will-change` refuses the idents its own grammar excludes, so
+  `will-change: none` and `will-change: opacity, none` are dropped with a
+  warning where the browser drops the whole declaration. CSS Will Change 1
+  sec. 2.1 keeps `will-change`, `none`, `all` and `auto` out of the ident a
+  feature names (#1015)
+
 - A `fit-content()`, `calc-size()` or `minmax()` reaches only a property whose
   grammar names it, so `font-size: fit-content(20rem)` and
   `scroll-padding-bottom: fit-content(20rem)` are dropped with a warning. CSS

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -1098,13 +1098,30 @@ let rec read_overscroll_behavior t : overscroll_behavior =
     t
 
 (* Reader for will-change property *)
+(* CSS Will Change 1 sec. 2.1 excludes [will-change], [none], [all] and [auto]
+   from the [<custom-ident>] a feature names, on top of the [default] and the
+   CSS-wide keywords CSS Values 4 sec. 3.2 excludes from every one. The named
+   [scroll-position] and [contents] stay: they match the alternative before it,
+   not the ident. *)
+let will_change_reserved =
+  [
+    "will-change";
+    "none";
+    "all";
+    "auto";
+    "default";
+    "initial";
+    "inherit";
+    "unset";
+    "revert";
+    "revert-layer";
+  ]
+
 let rec read_will_change t : will_change =
   let read_ident t =
     let ident = Cursor.ident ~keep_case:true t in
-    if ident = "auto" then
-      Cursor.err_invalid t "auto cannot be used in a will-change list";
-    if ident = "will-change" then
-      Cursor.err_invalid t "will-change cannot reference itself";
+    if List.mem (String.lowercase_ascii ident) will_change_reserved then
+      Cursor.err_invalid t ("reserved will-change ident: " ^ ident);
     ident
   in
   Cursor.enum_or_var "will-change"

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4931,6 +4931,13 @@ let spec_remaining_prop_vectors () =
       "mask-repeat: no-repeat repeat repeat-x";
       "backdrop-filter: blur(1px, 2px)";
       "will-change: auto, transform";
+      (* CSS Will Change 1 sec. 2.1 excludes these from the ident a feature
+         names, and CSS Values 4 sec. 3.2 excludes [default] from every one. *)
+      "will-change: none";
+      "will-change: all";
+      "will-change: default";
+      "will-change: will-change";
+      "will-change: opacity, none";
       "touch-action: pan-x pan-left";
       "resize: block inline both";
       "transition-property: none, opacity";


### PR DESCRIPTION
`will-change: none` was read as a feature named `none` where the browser drops the declaration. CSS Will Change 1 sec. 2.1 excludes `will-change`, `none`, `all` and `auto` from the ident, and CSS Values 4 sec. 3.2 excludes `default` and the CSS-wide keywords from every custom ident.