### PR TITLE
test: excuse the grammar Chrome has not shipped

### DIFF
--- a/test/spec/browser/accept_set.ml
+++ b/test/spec/browser/accept_set.ml
@@ -424,6 +424,22 @@ let spec_ahead_here : Chrome_gaps.excuse list =
         [ "\"text\"" ],
         "CSS Overflow 4 sec. 4.1: [ clip | ellipsis | <string> | fade | \
          <fade()> ]{1,2}, and every one of these is a <string>" );
+      ( [ "text-box-edge" ],
+        [ "ideographic-ink" ],
+        "CSS Inline 3 sec. 4.4: <text-edge> = [ text | ideographic | \
+         ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex \
+         ] [ text | ideographic | ideographic-ink | alphabetic ]" );
+      ( [ "dominant-baseline" ],
+        [ "text-bottom" ],
+        "CSS Inline 3 sec. 5.2: auto | <baseline-metric>, and sec. 5.1 gives \
+         <baseline-metric> = text-bottom | alphabetic | ideographic | middle | \
+         central | mathematical | hanging | text-top" );
+      ( [ "animation"; "-webkit-animation" ],
+        [ "--scroller block" ],
+        "CSS Animations 2 sec. 4: <single-animation> ends in [ none | \
+         <keyframes-name> ] || <single-animation-timeline>, so a dashed-ident \
+         timeline and a keyframes name fill two slots of one [||]. Chrome took \
+         the timeline back out of the shorthand" );
     ]
 
 (* The same, for a value Chrome reads that no specification grants: an entry

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -120,7 +120,15 @@ let spec_ahead : excuse list =
          sizing property takes; Chrome has only the bare fit-content keyword";
     };
     {
-      properties = [ "background"; "background-image" ];
+      properties =
+        [
+          "background";
+          "background-image";
+          "border-image";
+          "border-image-source";
+          "mask-image";
+          "-webkit-mask-image";
+        ];
       value = "cross-fade(url(a.png) 40%, url(b.png))";
       why =
         "CSS Images 4 sec. 2.6: cross-fade() = cross-fade( <cf-image># ); \

--- a/tmp_probe.css
+++ b/tmp_probe.css
@@ -1,0 +1,7 @@
+a{animation:--scroller block}
+b{animation:block}
+c{animation:--scroller}
+d{animation:--scroller inline}
+e{animation:--scroller x}
+f{animation:--scroller y}
+g{animation:--a --b}


### PR DESCRIPTION
The accept-set oracle reported four values as read-but-invalid where the grammar is real and the browser is behind: `cross-fade()` outside `background-image`, `text-box-edge: ideographic-ink`, `dominant-baseline: text-bottom`, and the timeline slot of the `animation` shorthand. Each excuse carries the section that defines it.