### PR TITLE
flex: read the balance flex-wrap takes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,11 @@ entry points both moved.
 
 ### Breaking
 
+- `Cascade.Properties.flex_wrap` gains `Balance` and `Wrap_reverse_balance`, so
+  `flex-wrap: balance` reads where it was dropped with a warning. CSS Flexbox 2
+  sec. 5.2 spells the property `nowrap | [ wrap | wrap-reverse ] || balance`.
+  Exhaustive visitors must handle the two new leaves (#1018)
+
 - `Cascade.Properties.align_content` drops `Left`, `Right` and their four
   `Safe_`/`Unsafe_` spellings, which CSS Box Alignment 3 sec. 4.2 keeps out of
   `<content-position>`, and `justify_content` gains the `Safe_left` and

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3417,6 +3417,8 @@ type flex_wrap = Properties.flex_wrap =
   | Nowrap
   | Wrap
   | Wrap_reverse
+  | Balance
+  | Wrap_reverse_balance
   | Inherit
   | Initial
   | Unset

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -147,6 +147,8 @@ let rec pp_flex_wrap : flex_wrap Pp.t =
   | Nowrap -> Pp.string ctx "nowrap"
   | Wrap -> Pp.string ctx "wrap"
   | Wrap_reverse -> Pp.string ctx "wrap-reverse"
+  | Balance -> Pp.string ctx "balance"
+  | Wrap_reverse_balance -> Pp.string ctx "wrap-reverse balance"
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -330,12 +332,34 @@ let rec read_order t : order =
     ~default:(fun t -> (Int (Cursor.int t) : order))
     t
 
+(* [[ wrap | wrap-reverse ] || balance] is order-free and takes each side at
+   most once, so the pair reads either way round and [balance] alone stands for
+   [wrap balance]. *)
+let read_flex_wrap_balance_pair t : flex_wrap =
+  let direction = ref Option.None and balance = ref false in
+  let rec loop seen =
+    Cursor.ws t;
+    match Cursor.peek_ident t with
+    | Some "balance" when not !balance ->
+        let _ = Cursor.ident t in
+        balance := true;
+        loop true
+    | Some (("wrap" | "wrap-reverse") as d) when Option.is_none !direction ->
+        let _ = Cursor.ident t in
+        direction := Option.Some d;
+        loop true
+    | _ -> if not seen then Cursor.err_expected t "flex-wrap"
+  in
+  loop false;
+  if not !balance then Cursor.err_expected t "balance";
+  match !direction with
+  | Option.Some "wrap-reverse" -> Wrap_reverse_balance
+  | _ -> Balance
+
 let rec read_flex_wrap t : flex_wrap =
   Cursor.enum_or_var "flex-wrap"
     [
       ("nowrap", (Nowrap : flex_wrap));
-      ("wrap", Wrap);
-      ("wrap-reverse", Wrap_reverse);
       ("inherit", Inherit);
       ("initial", Initial);
       ("unset", Unset);
@@ -343,6 +367,16 @@ let rec read_flex_wrap t : flex_wrap =
       ("revert-layer", Revert_layer);
     ]
     ~var:(fun t -> Var (Values.read_var read_flex_wrap t))
+    ~default:(fun t ->
+      Cursor.one_of
+        [
+          read_flex_wrap_balance_pair;
+          (fun t ->
+            Cursor.enum "flex-wrap"
+              [ ("wrap", (Wrap : flex_wrap)); ("wrap-reverse", Wrap_reverse) ]
+              t);
+        ]
+        t)
     t
 
 let read_flex_flow_direction t : flex_direction =
@@ -356,11 +390,17 @@ let read_flex_flow_direction t : flex_direction =
     t
 
 let read_flex_flow_wrap t : flex_wrap =
-  Cursor.enum "flex-flow wrap"
+  Cursor.one_of
     [
-      ("nowrap", (Nowrap : flex_wrap));
-      ("wrap", Wrap);
-      ("wrap-reverse", Wrap_reverse);
+      read_flex_wrap_balance_pair;
+      (fun t ->
+        Cursor.enum "flex-flow wrap"
+          [
+            ("nowrap", (Nowrap : flex_wrap));
+            ("wrap", Wrap);
+            ("wrap-reverse", Wrap_reverse);
+          ]
+          t);
     ]
     t
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -281,10 +281,16 @@ type flex_direction =
   | Revert_layer
   | Var of flex_direction var
 
+(** CSS Flexbox 2 sec. 5.2 [flex-wrap]:
+    [nowrap | [ wrap | wrap-reverse ] || balance]. [wrap] is the direction
+    [balance] carries on its own, so [Balance] is both [balance] and the
+    [wrap balance] that means the same thing. *)
 type flex_wrap =
   | Nowrap
   | Wrap
   | Wrap_reverse
+  | Balance
+  | Wrap_reverse_balance
   | Inherit
   | Initial
   | Unset

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1039,7 +1039,16 @@ let flexbox_direction () =
 let flexbox_wrap () =
   check_declaration ~expected:"flex-wrap:nowrap" "flex-wrap: nowrap";
   check_declaration ~expected:"flex-wrap:wrap" "flex-wrap: wrap";
-  check_declaration ~expected:"flex-wrap:wrap-reverse" "flex-wrap: wrap-reverse"
+  check_declaration ~expected:"flex-wrap:wrap-reverse" "flex-wrap: wrap-reverse";
+  (* CSS Flexbox 2 sec. 5.2: nowrap | [ wrap | wrap-reverse ] || balance, so the
+     pair reads either way round and [balance] alone carries [wrap]. *)
+  check_declaration ~expected:"flex-wrap:balance" "flex-wrap: balance";
+  check_declaration ~expected:"flex-wrap:balance" "flex-wrap: wrap balance";
+  check_declaration ~expected:"flex-wrap:wrap-reverse balance"
+    "flex-wrap: balance wrap-reverse";
+  check_declaration ~expected:"flex-flow:row balance" "flex-flow: row balance";
+  neg_cursor read_declaration "flex-wrap: nowrap balance";
+  neg_cursor read_declaration "flex-wrap: balance balance"
 
 let flexbox_flex_and_basis () =
   (* Flex shorthand *)

--- a/tmp_probe.css
+++ b/tmp_probe.css
@@ -1,7 +1,0 @@
-a{animation:--scroller block}
-b{animation:block}
-c{animation:--scroller}
-d{animation:--scroller inline}
-e{animation:--scroller x}
-f{animation:--scroller y}
-g{animation:--a --b}


### PR DESCRIPTION
`flex-wrap: balance` was dropped with a warning where browsers lay the lines out. CSS Flexbox 2 sec. 5.2 spells the property `nowrap | [ wrap | wrap-reverse ] || balance`, so `balance` stands alone and pairs with either direction in either order.