### PR TITLE
ui: let -webkit-appearance take base-select

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,10 @@ entry points both moved.
 
 ### Breaking
 
+- `Cascade.Properties.webkit_appearance` gains `Base_select`, so
+  `-webkit-appearance: base-select` reads the way `appearance: base-select`
+  already did. Exhaustive visitors must handle the new leaf (#1019)
+
 - `Cascade.Properties.flex_wrap` gains `Balance` and `Wrap_reverse_balance`, so
   `flex-wrap: balance` reads where it was dropped with a warning. CSS Flexbox 2
   sec. 5.2 spells the property `nowrap | [ wrap | wrap-reverse ] || balance`.

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -6812,6 +6812,7 @@ type webkit_appearance = Properties.webkit_appearance =
   | Button  (** Button appearance *)
   | Textfield  (** Text field appearance *)
   | Menulist  (** Select/dropdown appearance *)
+  | Base_select  (** The base appearance of a select (Chrome alias) *)
   | Listbox  (** List box appearance *)
   | Checkbox  (** Checkbox appearance *)
   | Radio  (** Radio button appearance *)

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -717,6 +717,7 @@ let rec pp_webkit_appearance : webkit_appearance Pp.t =
   | Button -> Pp.string ctx "button"
   | Textfield -> Pp.string ctx "textfield"
   | Menulist -> Pp.string ctx "menulist"
+  | Base_select -> Pp.string ctx "base-select"
   | Listbox -> Pp.string ctx "listbox"
   | Checkbox -> Pp.string ctx "checkbox"
   | Radio -> Pp.string ctx "radio"
@@ -1024,6 +1025,7 @@ let rec read_webkit_appearance t : webkit_appearance =
       ("button", Button);
       ("textfield", Textfield);
       ("menulist", Menulist);
+      ("base-select", Base_select);
       ("listbox", Listbox);
       ("checkbox", Checkbox);
       ("radio", Radio);

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4484,12 +4484,17 @@ type text_combine_upright =
   | Var of text_combine_upright var
 
 (* Webkit & Mozilla Specific Types *)
+
+(** [-webkit-appearance] is the alias Chrome keeps for [appearance], so it takes
+    the [base-select] CSS Basic User Interface 4 sec. 5.1 gives that property
+    along with the compatibility keywords of its own. *)
 type webkit_appearance =
   | None
   | Auto
   | Button
   | Textfield
   | Menulist
+  | Base_select
   | Listbox
   | Checkbox
   | Radio

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -3771,6 +3771,9 @@ let test_webkit_appearance () =
   check_webkit_appearance "auto";
   check_webkit_appearance "button";
   check_webkit_appearance "textfield";
+  (* The prefixed property is Chrome's alias for [appearance], so it takes the
+     [base-select] of CSS Basic User Interface 4 sec. 5.1. *)
+  check_webkit_appearance "base-select";
   check_webkit_appearance "inherit";
   neg_cursor read_webkit_appearance "invalid-appearance"
 


### PR DESCRIPTION
`-webkit-appearance: base-select` was dropped with a warning while the unprefixed `appearance: base-select` read. The prefixed property is Chrome's alias for `appearance`, and the browser computes one from the other.