### PR TITLE
content: read the image the property replaces with

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@ entry points both moved.
 
 ### Breaking
 
+- `Cascade.Properties.content` gains `Image of background_image`, so
+  `content: url(a.png)` and `content: linear-gradient(red, blue)` read where
+  they were dropped with a warning. CSS Generated Content 3 sec. 2 puts an
+  `<image>` in both the replacement and the list form. Exhaustive visitors must
+  handle the new leaf (#1020)
+
 - `Cascade.Properties.webkit_appearance` gains `Base_select`, so
   `-webkit-appearance: base-select` reads the way `appearance: base-select`
   already did. Exhaustive visitors must handle the new leaf (#1019)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -2325,6 +2325,8 @@ val overflow_y : overflow -> declaration
 type content = Properties.content =
   | String of string
   | Quoted of { value : string; quote : char; repr : string option }
+  | Image of Properties.background_image
+      (** The [<image>] of {!type-background_image}, aliased below. *)
   | None
   | Normal
   | Open_quote

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -2270,6 +2270,7 @@ let rec pp_content : content Pp.t =
             Pp.char ctx quote;
             Pp.string ctx value;
             Pp.char ctx quote)
+  | Image image -> pp_background_image ctx image
   | Open_quote -> Pp.string ctx "open-quote"
   | Close_quote -> Pp.string ctx "close-quote"
   | Attr attr -> Pp.call "attr" (Values.pp_attr_call pp_content) ctx attr
@@ -2652,7 +2653,10 @@ and read_content_single t =
         ("string", read_content_string_ref);
         ("counters", read_content_counters);
       ]
-    ~default:read_content_string t
+    ~default:
+      (Cursor.one_of
+         [ read_content_string; (fun t -> (Image (read_bg_image t) : content)) ])
+    t
 
 and read_content t : content =
   let items = Cursor.list ~sep:Cursor.ws ~at_least:1 read_content_single t in
@@ -3669,8 +3673,9 @@ let string_of_kind_value : type a. a kind -> a -> string =
       | Normal -> "normal"
       | Open_quote -> "open-quote"
       | Close_quote -> "close-quote"
-      | Attr _ | Counter _ | Counters _ | String_ref _ | Content_list _
-      | Inherit | Initial | Unset | Revert | Revert_layer | Var _ ->
+      | Image _ | Attr _ | Counter _ | Counters _ | String_ref _
+      | Content_list _ | Inherit | Initial | Unset | Revert | Revert_layer
+      | Var _ ->
           "initial")
   | Font_weight -> Pp.to_string pp_font_weight value
   | Shadow -> "0 0 #0000"

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3342,9 +3342,14 @@ type object_view_box =
   | Var of object_view_box var
 
 (* Content Types *)
+
+(** CSS Generated Content 3 sec. 2 [content]: the replacement and list forms
+    both take an [<image>], which is the {!type-background_image} vocabulary
+    without its comma list. *)
 type content =
   | String of string
   | Quoted of { value : string; quote : char; repr : string option }
+  | Image of background_image
   | None
   | Normal
   | Open_quote

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -256,7 +256,14 @@ let quoted_strings () =
   (* Strings with special characters *)
   check_declaration ~expected:"content:\"a;b\"" "content: \"a;b\";";
   check_declaration ~expected:"content:\"a:b\"" "content: \"a:b\";";
-  check_declaration ~expected:"content:\"a{b}\"" "content: \"a{b}\";"
+  check_declaration ~expected:"content:\"a{b}\"" "content: \"a{b}\";";
+  (* CSS Generated Content 3 sec. 2 puts an <image> in both the replacement and
+     the list form of the property. *)
+  check_declaration ~expected:"content:url(a.png)" "content: url(a.png)";
+  check_declaration ~expected:"content:linear-gradient(red,blue)"
+    "content: linear-gradient(red, blue)";
+  check_declaration ~expected:"content:\"x\" url(a.png)"
+    "content: \"x\" url(a.png)"
 
 let custom_properties_basic () =
   check_declaration ~expected:"--color:red" "--color: red;";


### PR DESCRIPTION
`content: url(a.png)` was dropped with a warning where every browser paints the image. CSS Generated Content 3 sec. 2 gives the property `[ <content-replacement> | <content-list> ]`, and an `<image>` is in both.