### PR TITLE
background: give the border-image numbers a calc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,13 @@ entry points both moved.
 
 ### Breaking
 
+- The `Number` of `Cascade.Properties.border_image_width_item`,
+  `border_image_outset_item` and `border_image_slice_item` carries a `number`
+  where it carried a `float`, so `border-image-width: calc(1 + 2)` reads. CSS
+  Backgrounds 3 secs. 5.2 to 5.4 write those halves as `<number [0,inf]>`, and
+  a `calc()` is one. A caller building a literal writes `Number (Num 1.)`
+  (#1021)
+
 - `Cascade.Properties.content` gains `Image of background_image`, so
   `content: url(a.png)` and `content: linear-gradient(red, blue)` read where
   they were dropped with a warning. CSS Generated Content 3 sec. 2 puts an

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1068,7 +1068,7 @@ let pp_bg_size_with_position maybe_space (bg : background_shorthand) ctx =
   | None -> ()
 
 let pp_border_image_slice_item ctx (value : border_image_slice_item) =
-  match value with Number n -> Pp.float ctx n | Pct n -> Pp.pct ctx n
+  match value with Number n -> Values.pp_number ctx n | Pct n -> Pp.pct ctx n
 
 let pp_border_image_slice_offsets ctx { offsets; fill } =
   Pp.list ~sep:Pp.space pp_border_image_slice_item ctx offsets;
@@ -1088,14 +1088,14 @@ let rec pp_border_image_slice ctx (value : border_image_slice) =
 
 let pp_border_image_width_item ctx (value : border_image_width_item) =
   match value with
-  | Number n -> Pp.float ctx n
+  | Number n -> Values.pp_number ctx n
   | Pct n -> Pp.pct ctx n
   | Length len -> pp_length ctx len
   | Auto -> Pp.string ctx "auto"
 
 let pp_border_image_outset_item ctx (value : border_image_outset_item) =
   match value with
-  | Number n -> Pp.float ctx n
+  | Number n -> Values.pp_number ctx n
   | Length len -> pp_length ctx len
 
 let pp_border_image_repeat_keyword ctx (value : border_image_repeat_keyword) =
@@ -1165,7 +1165,8 @@ let normalize_border_image : border_image -> border_image =
   let outset =
     drop
       (function
-        | [ (Number 0. : border_image_outset_item) ] | [ Length Zero ] -> true
+        | [ (Number (Num 0.) : border_image_outset_item) ] | [ Length Zero ] ->
+            true
         | _ -> false)
       value.outset
   in
@@ -1177,7 +1178,7 @@ let normalize_border_image : border_image -> border_image =
     else
       drop
         (function
-          | [ (Number 1. : border_image_width_item) ] -> true | _ -> false)
+          | [ (Number (Num 1.) : border_image_width_item) ] -> true | _ -> false)
         value.width
   in
   let repeat =
@@ -2238,15 +2239,29 @@ let rec read_border_spacing t : border_spacing =
         : border_spacing))
     t
 
+(* Sec. 5.2 to 5.4 keep the numeric halves at [0,inf]. A [calc()] holds no value
+   to compare, so only a literal is turned away here. Each side is one component
+   of a list, and the whole-value number reader refuses a number after the one
+   it read, so the component is handed to it on its own. *)
+let read_border_image_number t =
+  let value : number =
+    match Cursor.peek t with
+    | Some (Component.Func _ as component) ->
+        let _ = Cursor.next t in
+        Values.read_number (Cursor.of_components [ component ])
+    | _ -> Num (Cursor.number t)
+  in
+  (match value with
+  | (Num n : number) when n < 0. ->
+      Cursor.err_invalid t "border-image value cannot be negative"
+  | _ -> ());
+  value
+
 let read_border_image_slice_item t : border_image_slice_item =
   match Cursor.percentage_opt t with
   | Some n when n >= 0. -> Pct n
   | Some _ -> Cursor.err_invalid t "border-image value cannot be negative"
-  | None -> (
-      match Cursor.number_opt t with
-      | Some n when n >= 0. -> Number n
-      | Some _ -> Cursor.err_invalid t "border-image value cannot be negative"
-      | None -> Cursor.err_expected t "border-image slice")
+  | None -> Number (read_border_image_number t)
 
 let read_border_image_slice_value t values has_fill =
   match Cursor.option read_border_image_slice_item t with
@@ -2310,33 +2325,34 @@ let read_border_image_width_item t : border_image_width_item =
       match Cursor.percentage_opt t with
       | Some n when n >= 0. -> Pct n
       | Some _ -> Cursor.err_invalid t "border-image value cannot be negative"
-      | None -> (
-          match Cursor.number_opt t with
-          | Some n when n >= 0. -> Number n
-          | Some _ ->
-              Cursor.err_invalid t "border-image value cannot be negative"
-          | None ->
+      | None ->
+          Cursor.one_of
+            [
+              (fun t ->
+                (Number (read_border_image_number t) : border_image_width_item));
               (* Sec. 5.3 gives the width a number, a length-percentage or
                  [auto], read above. The generic length reader carries keywords
                  of its own - [stretch] and [contain] among them, which name a
                  repeat here - so this call takes none. *)
-              let len =
-                read_length ~allow_negative:false ~with_keywords:false t
-              in
-              Length len))
+              (fun t ->
+                Length
+                  (read_length ~allow_negative:false ~with_keywords:false t));
+            ]
+            t)
 
 (* Sec. 5.4 gives the outset a number or a length per side and no keyword. *)
 let read_border_image_outset_item t : border_image_outset_item =
-  match Cursor.number_opt t with
-  | Some n when n >= 0. -> Number n
-  | Some _ -> Cursor.err_invalid t "border-image value cannot be negative"
-  | None ->
+  Cursor.one_of
+    [
+      (fun t ->
+        (Number (read_border_image_number t) : border_image_outset_item));
       (* Sec. 5.4 gives the outset a number or a length, and no percentage. *)
-      let len =
-        read_length ~allow_negative:false ~with_keywords:false ~length_only:true
-          t
-      in
-      Length len
+      (fun t ->
+        Length
+          (read_length ~allow_negative:false ~with_keywords:false
+             ~length_only:true t));
+    ]
+    t
 
 let read_border_image_box_step ~what read_item t acc =
   Cursor.ws t;

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3013,7 +3013,10 @@ type mask =
   | Revert_layer
   | Var of mask var
 
-type border_image_slice_item = Number of float | Pct of float
+(** CSS Backgrounds 3 sec. 5.2 to 5.4 write the numeric halves of the
+    border-image slots as [<number [0,inf]>], which a [calc()] satisfies, so
+    each carries a {!type-number} rather than a float. *)
+type border_image_slice_item = Number of number | Pct of float
 
 type border_image_slice_offsets = {
   offsets : border_image_slice_item list;
@@ -3032,12 +3035,12 @@ type border_image_slice =
   | Var of border_image_slice var
 
 type border_image_width_item =
-  | Number of float
+  | Number of number
   | Pct of float
   | Length of length
   | Auto
 
-type border_image_outset_item = Number of float | Length of length
+type border_image_outset_item = Number of number | Length of length
 type border_image_repeat_keyword = Stretch | Repeat | Round | Space
 
 (* CSS Backgrounds 3 sec. 5.5: [border-image-repeat] is one or two keywords

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -861,7 +861,10 @@ let vars_of_border_image_width (value : Properties.border_image_width) :
   | Widths values ->
       List.concat_map
         (fun (item : Properties.border_image_width_item) ->
-          match item with Length length -> vars_of_length length | _ -> [])
+          match item with
+          | Length length -> vars_of_length length
+          | Number n -> vars_of_number_value n
+          | _ -> [])
         values
   | _ -> []
 
@@ -872,7 +875,9 @@ let vars_of_border_image_outset (value : Properties.border_image_outset) :
   | Outsets values ->
       List.concat_map
         (fun (item : Properties.border_image_outset_item) ->
-          match item with Length length -> vars_of_length length | _ -> [])
+          match item with
+          | Length length -> vars_of_length length
+          | Number n -> vars_of_number_value n)
         values
   | _ -> []
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4109,11 +4109,16 @@ let test_border_image_width () =
   check_border_image_width "10px";
   check_border_image_width "auto";
   check_border_image_width "1 2";
+  (* CSS Backgrounds 3 sec. 5.3 writes the number half as <number [0,inf]>,
+     which a calc() satisfies. *)
+  check_border_image_width "calc(1 + 2)";
+  check_border_image_width "calc(1 + 2) 3";
   check_border_image_width "inherit";
   neg_cursor read_border_image_width "blue"
 
 let test_border_image_outset () =
   check_border_image_outset "1";
+  check_border_image_outset "calc(1 + 2)";
   check_border_image_outset "10px";
   check_border_image_outset "1 2";
   check_border_image_outset "inherit";


### PR DESCRIPTION
`border-image-width: calc(1 + 2)` was dropped with a warning, and so were the matching `border-image-outset` and `border-image-slice` values. CSS Backgrounds 3 secs. 5.2 to 5.4 write those halves as `<number [0,inf]>`, which a math function satisfies.