### PR TITLE
text: let the text-box edge slot take auto

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -416,6 +416,11 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `text-box: auto` reads where it was dropped with a warning. CSS Inline 3
+  sec. 4.4 gives `text-box-edge` the value `auto | <text-edge>`, so `auto` is
+  one half of the sec. 6.1 shorthand rather than a keyword the longhand keeps
+  to itself (#1022)
+
 - The areas form of `grid-template` is read against its grammar rather than
   kept as any well-formed token run, so `grid-template: 50% "text" infinite`
   and `grid-template: "a" repeat(2, 1fr)` are dropped with a warning. CSS Grid

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1628,25 +1628,32 @@ let read_text_box_edge_keyword t : text_box_edge_keyword =
     ]
     t
 
+(* CSS Inline 3 sec. 4.4 gives [text-box-edge] [auto | <text-edge>], so [auto]
+   is a value of the property rather than a CSS-wide keyword and reaches the
+   [text-box] shorthand along with the rest. *)
 let read_text_box_edge_value t : text_box_edge =
-  let keywords =
-    Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2 read_text_box_edge_keyword
-      t
-  in
-  match keywords with
-  | [ Text ] | [ Ideographic_ink ] -> Edge (List.hd keywords, None)
-  | [ ((Cap | Ex) as first); ((Alphabetic | Text) as second) ]
-  | [ (Text as first); ((Alphabetic | Ideographic) as second) ] ->
-      Edge (first, Some second)
-  | _ -> Cursor.err_invalid t "text-box-edge"
+  match Cursor.peek_ident t with
+  | Some "auto" ->
+      let _ = Cursor.ident t in
+      (Auto : text_box_edge)
+  | _ -> (
+      let keywords =
+        Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2
+          read_text_box_edge_keyword t
+      in
+      match keywords with
+      | [ Text ] | [ Ideographic_ink ] -> Edge (List.hd keywords, None)
+      | [ ((Cap | Ex) as first); ((Alphabetic | Text) as second) ]
+      | [ (Text as first); ((Alphabetic | Ideographic) as second) ] ->
+          Edge (first, Some second)
+      | _ -> Cursor.err_invalid t "text-box-edge")
 
 let rec read_text_box_edge ?(global = true) t : text_box_edge =
   if not global then read_text_box_edge_value t
   else
     Cursor.enum_or_var "text-box-edge"
       [
-        ("auto", (Auto : text_box_edge));
-        ("inherit", Inherit);
+        ("inherit", (Inherit : text_box_edge));
         ("initial", Initial);
         ("unset", Unset);
         ("revert", Revert);

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4874,6 +4874,11 @@ let spec_remaining_prop_vectors () =
       ("initial-letter: 2 3", "initial-letter:2 3");
       ("line-height-step: 4px", "line-height-step:4px");
       ("text-box: trim-both cap alphabetic", "text-box:trim-both cap alphabetic");
+      (* CSS Inline 3 sec. 4.4 gives [text-box-edge] [auto | <text-edge>], so
+         [auto] is one half of the sec. 6.1 shorthand, not a keyword the
+         longhand keeps to itself. *)
+      ("text-box: auto", "text-box:auto");
+      ("text-box: trim-both auto", "text-box:trim-both auto");
       ("field-sizing: content", "field-sizing:content");
       ("margin-trim: block inline", "margin-trim:block inline");
       ("offset-distance: 10%", "offset-distance:10%");


### PR DESCRIPTION
`text-box: auto` was dropped with a warning. CSS Inline 3 sec. 4.4 gives `text-box-edge` the value `auto | <text-edge>`, so `auto` belongs with the rest of the edge grammar rather than with the CSS-wide keywords the shorthand asks the longhand to skip.