### PR TITLE
flex: carry the verbatim length into flex-basis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@ entry points both moved.
 
 ### Breaking
 
+- `Cascade.Properties.flex_basis` gains `Dimension`, the arm
+  `Cascade.Values.length` uses for a length whose authored spelling no typed
+  constructor carries, so `flex-basis: 1e3px`, `flex-basis: 10.0px` and
+  `flex: 1e999px` read where they were dropped with a warning. Exhaustive
+  visitors must handle the new leaf (#1023)
+
 - The `Number` of `Cascade.Properties.border_image_width_item`,
   `border_image_outset_item` and `border_image_slice_item` carries a `number`
   where it carried a `float`, so `border-image-width: calc(1 + 2)` reads. CSS

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3505,6 +3505,7 @@ type flex_basis = Properties.flex_basis =
   | Rem_fn of length * length
   | Hypot of length list
   | Abs of length
+  | Dimension of { value : float; unit : string; repr : string }
   | Calc of flex_basis calc
   | Var of flex_basis var
 

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -267,6 +267,8 @@ let rec pp_flex_basis : flex_basis Pp.t =
   | Rem_fn (a, b) -> pp_length ctx (Rem_fn (a, b))
   | Hypot xs -> pp_length ctx (Hypot xs)
   | Abs a -> pp_length ctx (Abs a)
+  | Dimension { value; unit; repr } ->
+      pp_length ctx (Dimension { value; unit; repr })
   | Var v -> pp_var pp_flex_basis ctx v
   | Calc cv -> pp_calc pp_flex_basis ctx cv
 
@@ -590,6 +592,10 @@ let flex_basis_of_length t (length : length) : flex_basis =
   | Rem_fn (a, b) -> Rem_fn (a, b)
   | Hypot xs -> Hypot xs
   | Abs a -> Abs a
+  (* Every other authored spelling reaches [length] as a [Dimension] carrying
+     its own text, [1e3px] and [10.0px] among them, and sec. 7.2 takes each of
+     them as a [<length-percentage>]. *)
+  | Dimension { value; unit; repr } -> Dimension { value; unit; repr }
   | _ -> Cursor.err_invalid t "unsupported flex-basis value"
 
 let rec read_flex_basis t : flex_basis =

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -621,6 +621,10 @@ type flex_basis =
   | Rem_fn of length * length
   | Hypot of length list
   | Abs of length
+  | Dimension of { value : float; unit : string; repr : string }
+      (** A dimension whose authored spelling the typed constructors above do
+          not carry, e.g. [1e3px] or [10.0px]. {!type-length} holds one the same
+          way. *)
   | Calc of flex_basis calc
   | Var of flex_basis var
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1074,6 +1074,12 @@ let flexbox_flex_and_basis () =
   (* Flex basis *)
   check_declaration ~expected:"flex-basis:auto" "flex-basis: auto";
   check_declaration ~expected:"flex-basis:0px" "flex-basis: 0px";
+  (* CSS Flexbox 1 sec. 7.2 takes a <'width'>, which is every length the
+     document can write, and cascade keeps the authored spelling of the ones no
+     typed constructor carries. *)
+  check_declaration ~expected:"flex-basis:1000px" "flex-basis: 1e3px";
+  check_declaration ~expected:"flex-basis:10px" "flex-basis: 10.0px";
+  check_declaration ~expected:"flex:3.40282e38px" "flex: 1e999px";
   decl_optimizes ~prop:"flex-basis" ~into:"0" "0px";
   check_declaration ~expected:"flex-basis:0%" "flex-basis: 0%";
   check_declaration ~expected:"flex-basis:100px" "flex-basis: 100px";


### PR DESCRIPTION
`flex-basis: 1e3px`, `flex-basis: 10.0px` and `flex: 1e999px` were dropped with a warning while `width` took all three. CSS Flexbox 1 sec. 7.2 gives `flex-basis` a `<'width'>`, so it takes every length `width` does, the ones whose authored spelling cascade keeps verbatim included.