### PR TITLE
multicol: give the column rule longhands a list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,12 @@ entry points both moved.
 
 ### Breaking
 
+- `column-rule-width`, `column-rule-style` and `column-rule-color` carry a list
+  where they carried a single value, so `column-rule-style: dotted, dashed`
+  reads. CSS Gaps 1 sec. 4 gives each gap decoration longhand a
+  comma-separated list, one entry per rule line. A caller writing one line
+  passes a one-element list (#1024)
+
 - `Cascade.Properties.flex_basis` gains `Dimension`, the arm
   `Cascade.Values.length` uses for a length whose authored spelling no typed
   constructor carries, so `flex-basis: 1e3px`, `flex-basis: 10.0px` and

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -542,7 +542,7 @@ let property_value_uses_color (type a) (p : Values.color -> bool)
   | Webkit_text_decoration_color -> p value
   | Webkit_text_fill_color -> p value
   | Webkit_text_stroke_color -> p value
-  | Column_rule_color -> p value
+  | Column_rule_color -> List.exists p value
   | Border_inline_color -> logical_color_uses p value
   | Border_block_color -> logical_color_uses p value
   | Box_shadow -> shadow_uses_color p value
@@ -1853,9 +1853,20 @@ let read_object_transition_value : type a.
   | Column_wrap -> Some (v Column_wrap (read_column_wrap t))
   | Column_count -> Some (v Column_count (read_column_count t))
   | Column_rule -> Some (v Column_rule (read_border t))
-  | Column_rule_color -> Some (v Column_rule_color (read_color t))
-  | Column_rule_width -> Some (v Column_rule_width (read_border_width t))
-  | Column_rule_style -> Some (v Column_rule_style (read_border_style t))
+  (* CSS Gaps 1 sec. 4 gives each gap decoration longhand a comma-separated
+     list, one entry per rule line. *)
+  | Column_rule_color ->
+      Some
+        (v Column_rule_color
+           (Cursor.list ~sep:Cursor.comma ~at_least:1 read_color t))
+  | Column_rule_width ->
+      Some
+        (v Column_rule_width
+           (Cursor.list ~sep:Cursor.comma ~at_least:1 read_border_width t))
+  | Column_rule_style ->
+      Some
+        (v Column_rule_style
+           (Cursor.list ~sep:Cursor.comma ~at_least:1 read_border_style t))
   | Column_span -> Some (v Column_span (read_column_span t))
   | _ -> None
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4416,8 +4416,8 @@ let normalize_property_value : type a.
   | Webkit_text_fill_color -> normalize_color value
   | Webkit_text_stroke_color -> normalize_color value
   | Webkit_text_stroke_width -> normalize_border_width value
-  | Column_rule_color -> normalize_color value
-  | Column_rule_width -> normalize_border_width value
+  | Column_rule_color -> List.map normalize_color value
+  | Column_rule_width -> List.map normalize_border_width value
   | Webkit_tap_highlight_color -> normalize_color value
   | Text_emphasis_color -> normalize_color value
   | Outline_color -> normalize_color value
@@ -4803,9 +4803,9 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Webkit_text_stroke_color -> pp pp_color
   | Webkit_text_stroke -> pp pp_webkit_text_stroke
   | Webkit_text_stroke_width -> pp pp_border_width
-  | Column_rule_color -> pp pp_color
-  | Column_rule_width -> pp pp_border_width
-  | Column_rule_style -> pp pp_border_style
+  | Column_rule_color -> pp (Pp.list ~sep:Pp.comma pp_color)
+  | Column_rule_width -> pp (Pp.list ~sep:Pp.comma pp_border_width)
+  | Column_rule_style -> pp (Pp.list ~sep:Pp.comma pp_border_style)
   | Text_indent -> pp pp_text_indent_value
   | Border_spacing -> pp pp_border_spacing
   | Outline_offset -> pp pp_length
@@ -5466,8 +5466,8 @@ let property_value_kind : type a. a property -> a property_value_kind option =
   | Webkit_text_fill_color -> Some Color
   | Webkit_text_stroke_color -> Some Color
   | Webkit_text_stroke_width -> Some Border_width
-  | Column_rule_color -> Some Color
-  | Column_rule_width -> Some Border_width
+  | Column_rule_color -> Some Colors
+  | Column_rule_width -> Some Border_widths
   | Accent_color -> Some Color
   | Caret_color -> Some Color
   | Stop_color -> Some Color

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -5213,9 +5213,11 @@ type 'a property =
   | Column_wrap : column_wrap property
   | Column_count : column_count property
   | Column_rule : border property
-  | Column_rule_width : border_width property
-  | Column_rule_style : border_style property
-  | Column_rule_color : color property
+      (** CSS Gaps 1 sec. 4 gives the three longhands below a comma-separated
+          list, one entry per gap decoration line. *)
+  | Column_rule_width : border_width list property
+  | Column_rule_style : border_style list property
+  | Column_rule_color : color list property
   | Column_span : column_span property
   | Word_spacing : length property
   | Background_attachment : background_attachment property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3692,13 +3692,15 @@ let border_inline_end_part = function
       Some (line_of_color value)
   | _ -> None
 
+(* CSS Gaps 1 sec. 4 gives each longhand a list, and sec. 4.4 writes the
+   shorthand over one line, so only a single-entry list composes. *)
 let column_rule_part = function
-  | Declaration { property = Column_rule_width; value; _ } ->
-      Some (line_of_width value)
-  | Declaration { property = Column_rule_style; value; _ } ->
-      Some (line_of_style value)
-  | Declaration { property = Column_rule_color; value; _ } ->
-      Some (line_of_color value)
+  | Declaration { property = Column_rule_width; value = [ width ]; _ } ->
+      Some (line_of_width width)
+  | Declaration { property = Column_rule_style; value = [ style ]; _ } ->
+      Some (line_of_style style)
+  | Declaration { property = Column_rule_color; value = [ color ]; _ } ->
+      Some (line_of_color color)
   | _ -> None
 
 let try_compose_line_at ~part_of ~property idx i =

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2272,9 +2272,9 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Column_wrap, value -> vars_of_column_wrap value
   | Column_count, value -> vars_of_column_count value
   | Column_rule, value -> vars_of_border value
-  | Column_rule_color, value -> vars_of_color value
-  | Column_rule_width, value -> vars_of_border_width value
-  | Column_rule_style, value -> vars_of_border_style value
+  | Column_rule_color, value -> List.concat_map vars_of_color value
+  | Column_rule_width, value -> List.concat_map vars_of_border_width value
+  | Column_rule_style, value -> List.concat_map vars_of_border_style value
   | Column_span, value -> vars_of_column_span value
   (* Contain *)
   | Contain, value -> vars_of_contain value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1319,6 +1319,15 @@ let border_line_width () =
     ~optimized:"border-top:dashed#00f" "border-top: medium dashed blue";
   check_declaration ~expected:"column-rule:medium solid red"
     ~optimized:"column-rule:solid red" "column-rule: medium solid red";
+  (* CSS Gaps 1 sec. 4 gives each gap decoration longhand a comma-separated
+     list, one entry per rule line. *)
+  check_declaration ~expected:"column-rule-style:dotted,dashed"
+    "column-rule-style: dotted, dashed";
+  check_declaration ~expected:"column-rule-width:1px,2px"
+    "column-rule-width: 1px, 2px";
+  check_declaration ~expected:"column-rule-color:red,blue"
+    ~optimized:"column-rule-color:red,#00f" "column-rule-color: red, blue";
+  neg_cursor read_declaration "column-rule-style: dotted dashed";
   check_declaration ~expected:"border-inline-start:medium dotted red"
     ~optimized:"border-inline-start:dotted red"
     "border-inline-start: medium dotted red";


### PR DESCRIPTION
`column-rule-style: dotted, dashed` was dropped with a warning where the browser draws two rules. CSS Gaps 1 sec. 4 gives `column-rule-width`, `column-rule-style` and `column-rule-color` a comma-separated list with one entry per gap decoration line.