### PR TITLE
box: take the negative overflow-clip-margin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -428,6 +428,10 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- `overflow-clip-margin: -1px` reads where it was dropped with a warning. CSS
+  Overflow 4 sec. 3.2 is `<visual-box> || <length>` with no range on the
+  length, and a negative one pulls the clip edge inside the box (#1026)
+
 - `text-box: auto` reads where it was dropped with a warning. CSS Inline 3
   sec. 4.4 gives `text-box-edge` the value `auto | <text-edge>`, so `auto` is
   one half of the sec. 6.1 shorthand rather than a keyword the longhand keeps

--- a/fuzz/fuzz_stylesheet.ml
+++ b/fuzz/fuzz_stylesheet.ml
@@ -429,7 +429,6 @@ let invalid_platform_declaration_vector buf i =
       "filter:blur(red)";
       "grid-template-areas:\"a\" \"a b\"";
       "shape-margin:-1px";
-      "overflow-clip-margin:-1px";
       "scrollbar-width:wide";
       "scrollbar-gutter:stable auto";
       "font-palette:1";

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -608,13 +608,16 @@ let read_overflow_clip_box_item (box : overflow_clip_box option ref) t =
           false)
   | Some _ -> false
 
+(* CSS Overflow 4 sec. 3.2 spells [overflow-clip-margin] as [<visual-box> ||
+   <length>], with no range on the length, so a negative one pulls the clip edge
+   inside the box. *)
 let read_overflow_clip_length_item (length : length option ref) t =
   Cursor.ws t;
   match !length with
   | None ->
       length :=
         Some
-          (read_length ~allow_negative:false ~with_keywords:false
+          (read_length ~allow_negative:true ~with_keywords:false
              ~length_only:true t);
       true
   | Some _ -> false

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3356,6 +3356,10 @@ let invalid () =
   neg "contain-intrinsic-width: 200%";
   neg "tab-size: 50%";
   neg "overflow-clip-margin: 50%";
+  (* CSS Overflow 4 sec. 3.2 is [<visual-box> || <length>], with no range on the
+     length, so a negative one pulls the clip edge inside the box. *)
+  check_declaration ~expected:"overflow-clip-margin:-1px"
+    "overflow-clip-margin: -1px";
   neg "column-width: -5px"
 
 let spec_property_grammar_table_expansion () =
@@ -3530,7 +3534,6 @@ let spec_property_grammar_table_expansion () =
       ("container-type", "inline-size size");
       ("container", "/ inline-size");
       ("overflow", "visible clip scroll");
-      ("overflow-clip-margin", "-1px");
       ("overscroll-behavior", "contain none auto");
       ("scroll-snap-type", "mandatory x");
       ("scrollbar-width", "wide");
@@ -4576,7 +4579,6 @@ let spec_platform_property_vectors () =
       "anchor-name: tooltip";
       "position-anchor: tooltip";
       "shape-margin: -1px";
-      "overflow-clip-margin: -1px";
       "overflow-anchor: sometimes";
       "scrollbar-width: wide";
       "scrollbar-gutter: stable auto";


### PR DESCRIPTION
`overflow-clip-margin: -1px` was dropped with a warning. CSS Overflow 4 sec. 3.2 spells the property `<visual-box> || <length>` with no range on the length, and Chrome 152 reads a negative one, which pulls the clip edge inside the box.