### PR TITLE
css: build the all shorthand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -846,6 +846,8 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Library
 
+- `Css.all` writes the `all` shorthand (#1030)
+
 - `Css` builds `view_transition_name` and `view_transition_class`, with their
   value types (#1029)
 

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -686,6 +686,11 @@ val custom_declarations : ?layer:string -> declaration list -> declaration list
     from [decls]. If [layer] is provided, only declarations from that layer are
     returned. *)
 
+val all : Properties.css_wide -> declaration
+(** [all v] is the {{:https://www.w3.org/TR/css-cascade-5/#all-shorthand} all}
+    shorthand. It resets every longhand to [v] but the two writing-mode ones CSS
+    Cascading 5 sec. 3.3 excepts. *)
+
 (** {2:core_types Core Types & Calculations}
 
     Fundamental types for CSS values, variables, and calculations that underpin

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -3074,6 +3074,7 @@ let position_try value = v Position_try value
 let position_visibility value = v Position_visibility value
 let view_transition_name value = v View_transition_name value
 let view_transition_class value = v View_transition_class value
+let all value = v All value
 let outline_style o = v Outline_style o
 let outline_width len = v Outline_width len
 let outline_color c = v Outline_color c

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -1033,6 +1033,10 @@ val view_transition_name : view_transition_name -> declaration
 val view_transition_class : view_transition_class -> declaration
 (** [view_transition_class v] is the [view-transition-class] property. *)
 
+val all : css_wide -> declaration
+(** [all v] is the [all] property. It resets every longhand to [v] but the two
+    writing-mode ones CSS Cascading 5 sec. 3.3 excepts. *)
+
 val outline_style : outline_style -> declaration
 (** [outline_style v] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/outline-style}

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -2487,6 +2487,18 @@ let view_transition_builders () =
   check "view-transition-class:hero wide"
     (Css.view_transition_class (Classes [ "hero"; "wide" ]))
 
+(* CSS Cascading 5 sec. 3.3 gives [all] every longhand but [direction] and
+   [unicode-bidi]; the optimiser acts on it and the facade could not write
+   one. *)
+let all_shorthand_builder () =
+  let check expected declaration =
+    Alcotest.(check string)
+      expected expected
+      (Css.Declaration.to_string ~minify:true declaration)
+  in
+  check "all:initial" (Css.all Initial);
+  check "all:revert-layer" (Css.all Revert_layer)
+
 let suite =
   ( "css",
     [
@@ -2583,6 +2595,8 @@ let suite =
         anchor_positioning_builders;
       Alcotest.test_case "public view transition builders" `Quick
         view_transition_builders;
+      Alcotest.test_case "public all shorthand builder" `Quick
+        all_shorthand_builder;
       Alcotest.test_case "spec section 4.1 at-rule name case is insensitive"
         `Quick spec_at_rule_name_case_insensitive;
     ] )


### PR DESCRIPTION
The README advertises `all` reset semantics in the optimiser, and `Css` had no way to write the declaration: the property was reachable only by parsing.