### PR TITLE
css: build the vendor-prefixed longhands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -846,6 +846,12 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Library
 
+- `Css` builds the vendor-prefixed longhands its `{2:vendor_specific}` section
+  documents: the `-webkit-`, `-moz-`, `-ms-` and `-o-` transform, transition,
+  animation, flexbox, box-sizing, border-radius, box-shadow, filter,
+  background-size, text-stroke, appearance and user-select spellings, each
+  taking the value type its unprefixed counterpart takes (#1036)
+
 - `Css` builds the scroll-driven animation properties: `animation_timeline`,
   `animation_range`, `animation_range_start`, `animation_range_end`,
   `scroll_timeline`, `scroll_timeline_name`, `scroll_timeline_axis`,

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7389,6 +7389,185 @@ val contain : contain -> declaration
     @see <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Extensions>
       MDN: CSS Extensions *)
 
+(** {3:vendor_builders Vendor-prefixed longhands}
+
+    Each writes the prefixed spelling of the unprefixed property beside it and
+    takes the same value type. *)
+
+val moz_user_select : user_select -> declaration
+(** [moz_user_select v] is the [-moz-user-select] property. *)
+
+val ms_user_select : user_select -> declaration
+(** [ms_user_select v] is the [-ms-user-select] property. *)
+
+val webkit_text_fill_color : color -> declaration
+(** [webkit_text_fill_color v] is the [-webkit-text-fill-color] property. *)
+
+val webkit_text_stroke_width : border_width -> declaration
+(** [webkit_text_stroke_width v] is the [-webkit-text-stroke-width] property. *)
+
+val webkit_text_stroke_color : color -> declaration
+(** [webkit_text_stroke_color v] is the [-webkit-text-stroke-color] property. *)
+
+val webkit_transform : transform list -> declaration
+(** [webkit_transform v] is the [-webkit-transform] property. *)
+
+val moz_transform : transform list -> declaration
+(** [moz_transform v] is the [-moz-transform] property. *)
+
+val ms_transform : transform list -> declaration
+(** [ms_transform v] is the [-ms-transform] property. *)
+
+val o_transform : transform list -> declaration
+(** [o_transform v] is the [-o-transform] property. *)
+
+val webkit_transition : transition list -> declaration
+(** [webkit_transition v] is the [-webkit-transition] property. *)
+
+val webkit_transition_delay : duration -> declaration
+(** [webkit_transition_delay v] is the [-webkit-transition-delay] property. *)
+
+val webkit_transition_duration : duration -> declaration
+(** [webkit_transition_duration v] is the [-webkit-transition-duration]
+    property. *)
+
+val webkit_transition_property : transition_property -> declaration
+(** [webkit_transition_property v] is the [-webkit-transition-property]
+    property. *)
+
+val webkit_transition_timing_function : timing_function -> declaration
+(** [webkit_transition_timing_function v] is the
+    [-webkit-transition-timing-function] property. *)
+
+val webkit_animation : animation list -> declaration
+(** [webkit_animation v] is the [-webkit-animation] property. *)
+
+val webkit_animation_delay : duration -> declaration
+(** [webkit_animation_delay v] is the [-webkit-animation-delay] property. *)
+
+val webkit_animation_duration : duration -> declaration
+(** [webkit_animation_duration v] is the [-webkit-animation-duration] property.
+*)
+
+val webkit_animation_direction : animation_direction -> declaration
+(** [webkit_animation_direction v] is the [-webkit-animation-direction]
+    property. *)
+
+val webkit_animation_iteration_count : animation_iteration_count -> declaration
+(** [webkit_animation_iteration_count v] is the
+    [-webkit-animation-iteration-count] property. *)
+
+val webkit_animation_name : animation_name -> declaration
+(** [webkit_animation_name v] is the [-webkit-animation-name] property. *)
+
+val webkit_animation_timing_function : timing_function -> declaration
+(** [webkit_animation_timing_function v] is the
+    [-webkit-animation-timing-function] property. *)
+
+val webkit_animation_fill_mode : animation_fill_mode -> declaration
+(** [webkit_animation_fill_mode v] is the [-webkit-animation-fill-mode]
+    property. *)
+
+val webkit_animation_play_state : animation_play_state -> declaration
+(** [webkit_animation_play_state v] is the [-webkit-animation-play-state]
+    property. *)
+
+val webkit_flex_direction : flex_direction -> declaration
+(** [webkit_flex_direction v] is the [-webkit-flex-direction] property. *)
+
+val webkit_flex_wrap : flex_wrap -> declaration
+(** [webkit_flex_wrap v] is the [-webkit-flex-wrap] property. *)
+
+val webkit_flex_flow : flex_flow -> declaration
+(** [webkit_flex_flow v] is the [-webkit-flex-flow] property. *)
+
+val webkit_justify_content : justify_content -> declaration
+(** [webkit_justify_content v] is the [-webkit-justify-content] property. *)
+
+val webkit_align_items : align_items -> declaration
+(** [webkit_align_items v] is the [-webkit-align-items] property. *)
+
+val webkit_align_content : align_content -> declaration
+(** [webkit_align_content v] is the [-webkit-align-content] property. *)
+
+val webkit_align_self : align_self -> declaration
+(** [webkit_align_self v] is the [-webkit-align-self] property. *)
+
+val webkit_border_radius : border_radius -> declaration
+(** [webkit_border_radius v] is the [-webkit-border-radius] property. *)
+
+val webkit_box_sizing : box_sizing -> declaration
+(** [webkit_box_sizing v] is the [-webkit-box-sizing] property. *)
+
+val moz_box_sizing : box_sizing -> declaration
+(** [moz_box_sizing v] is the [-moz-box-sizing] property. *)
+
+val webkit_box_shadow : shadow -> declaration
+(** [webkit_box_shadow v] is the [-webkit-box-shadow] property. *)
+
+val webkit_background_size : background_size -> declaration
+(** [webkit_background_size v] is the [-webkit-background-size] property. *)
+
+val webkit_filter : filter -> declaration
+(** [webkit_filter v] is the [-webkit-filter] property. *)
+
+val moz_animation : animation list -> declaration
+(** [moz_animation v] is the [-moz-animation] property. *)
+
+val moz_animation_delay : duration -> declaration
+(** [moz_animation_delay v] is the [-moz-animation-delay] property. *)
+
+val moz_animation_duration : duration -> declaration
+(** [moz_animation_duration v] is the [-moz-animation-duration] property. *)
+
+val moz_animation_direction : animation_direction -> declaration
+(** [moz_animation_direction v] is the [-moz-animation-direction] property. *)
+
+val moz_animation_iteration_count : animation_iteration_count -> declaration
+(** [moz_animation_iteration_count v] is the [-moz-animation-iteration-count]
+    property. *)
+
+val moz_animation_name : animation_name -> declaration
+(** [moz_animation_name v] is the [-moz-animation-name] property. *)
+
+val moz_animation_timing_function : timing_function -> declaration
+(** [moz_animation_timing_function v] is the [-moz-animation-timing-function]
+    property. *)
+
+val moz_animation_fill_mode : animation_fill_mode -> declaration
+(** [moz_animation_fill_mode v] is the [-moz-animation-fill-mode] property. *)
+
+val moz_animation_play_state : animation_play_state -> declaration
+(** [moz_animation_play_state v] is the [-moz-animation-play-state] property. *)
+
+val moz_transition : transition list -> declaration
+(** [moz_transition v] is the [-moz-transition] property. *)
+
+val moz_transition_delay : duration -> declaration
+(** [moz_transition_delay v] is the [-moz-transition-delay] property. *)
+
+val moz_transition_duration : duration -> declaration
+(** [moz_transition_duration v] is the [-moz-transition-duration] property. *)
+
+val moz_transition_property : transition_property -> declaration
+(** [moz_transition_property v] is the [-moz-transition-property] property. *)
+
+val moz_transition_timing_function : timing_function -> declaration
+(** [moz_transition_timing_function v] is the [-moz-transition-timing-function]
+    property. *)
+
+val moz_border_radius : border_radius -> declaration
+(** [moz_border_radius v] is the [-moz-border-radius] property. *)
+
+val moz_box_shadow : shadow -> declaration
+(** [moz_box_shadow v] is the [-moz-box-shadow] property. *)
+
+val ms_filter : filter -> declaration
+(** [ms_filter v] is the [-ms-filter] property. *)
+
+val o_transition : transition list -> declaration
+(** [o_transition v] is the [-o-transition] property. *)
+
 (** CSS webkit-box-orient values. *)
 type webkit_box_orient = Properties.webkit_box_orient =
   | Horizontal
@@ -8455,6 +8634,9 @@ val appearance : appearance -> declaration
 (** [appearance app] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/appearance} appearance}
     property. *)
+
+val moz_appearance : appearance -> declaration
+(** [moz_appearance v] is the [-moz-appearance] property. *)
 
 type tab_size = Properties.tab_size =
   | Int of int

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -3112,6 +3112,73 @@ let view_timeline_name value = v View_timeline_name value
 let view_timeline_axis value = v View_timeline_axis value
 let view_timeline_inset value = v View_timeline_inset value
 let timeline_scope value = v Timeline_scope value
+let moz_user_select value = v Moz_user_select value
+let ms_user_select value = v Ms_user_select value
+let webkit_text_fill_color value = v Webkit_text_fill_color value
+let webkit_text_stroke_width value = v Webkit_text_stroke_width value
+let webkit_text_stroke_color value = v Webkit_text_stroke_color value
+let webkit_transform value = v Webkit_transform value
+let moz_transform value = v Moz_transform value
+let ms_transform value = v Ms_transform value
+let o_transform value = v O_transform value
+let webkit_transition value = v Webkit_transition value
+let webkit_transition_delay value = v Webkit_transition_delay value
+let webkit_transition_duration value = v Webkit_transition_duration value
+let webkit_transition_property value = v Webkit_transition_property value
+
+let webkit_transition_timing_function value =
+  v Webkit_transition_timing_function value
+
+let webkit_animation value = v Webkit_animation value
+let webkit_animation_delay value = v Webkit_animation_delay value
+let webkit_animation_duration value = v Webkit_animation_duration value
+let webkit_animation_direction value = v Webkit_animation_direction value
+
+let webkit_animation_iteration_count value =
+  v Webkit_animation_iteration_count value
+
+let webkit_animation_name value = v Webkit_animation_name value
+
+let webkit_animation_timing_function value =
+  v Webkit_animation_timing_function value
+
+let webkit_animation_fill_mode value = v Webkit_animation_fill_mode value
+let webkit_animation_play_state value = v Webkit_animation_play_state value
+let webkit_flex_direction value = v Webkit_flex_direction value
+let webkit_flex_wrap value = v Webkit_flex_wrap value
+let webkit_flex_flow value = v Webkit_flex_flow value
+let webkit_justify_content value = v Webkit_justify_content value
+let webkit_align_items value = v Webkit_align_items value
+let webkit_align_content value = v Webkit_align_content value
+let webkit_align_self value = v Webkit_align_self value
+let webkit_border_radius value = v Webkit_border_radius value
+let webkit_box_sizing value = v Webkit_box_sizing value
+let moz_box_sizing value = v Moz_box_sizing value
+let webkit_box_shadow value = v Webkit_box_shadow value
+let webkit_background_size value = v Webkit_background_size value
+let webkit_filter value = v Webkit_filter value
+let moz_appearance value = v Moz_appearance value
+let moz_animation value = v Moz_animation value
+let moz_animation_delay value = v Moz_animation_delay value
+let moz_animation_duration value = v Moz_animation_duration value
+let moz_animation_direction value = v Moz_animation_direction value
+let moz_animation_iteration_count value = v Moz_animation_iteration_count value
+let moz_animation_name value = v Moz_animation_name value
+let moz_animation_timing_function value = v Moz_animation_timing_function value
+let moz_animation_fill_mode value = v Moz_animation_fill_mode value
+let moz_animation_play_state value = v Moz_animation_play_state value
+let moz_transition value = v Moz_transition value
+let moz_transition_delay value = v Moz_transition_delay value
+let moz_transition_duration value = v Moz_transition_duration value
+let moz_transition_property value = v Moz_transition_property value
+
+let moz_transition_timing_function value =
+  v Moz_transition_timing_function value
+
+let moz_border_radius value = v Moz_border_radius value
+let moz_box_shadow value = v Moz_box_shadow value
+let ms_filter value = v Ms_filter value
+let o_transition value = v O_transition value
 let outline_style o = v Outline_style o
 let outline_width len = v Outline_width len
 let outline_color c = v Outline_color c

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -1150,6 +1150,183 @@ val view_timeline_inset : timeline_inset -> declaration
 val timeline_scope : timeline_name -> declaration
 (** [timeline_scope v] is the [timeline-scope] property. *)
 
+val moz_user_select : user_select -> declaration
+(** [moz_user_select v] is the [-moz-user-select] property. *)
+
+val ms_user_select : user_select -> declaration
+(** [ms_user_select v] is the [-ms-user-select] property. *)
+
+val webkit_text_fill_color : color -> declaration
+(** [webkit_text_fill_color v] is the [-webkit-text-fill-color] property. *)
+
+val webkit_text_stroke_width : border_width -> declaration
+(** [webkit_text_stroke_width v] is the [-webkit-text-stroke-width] property. *)
+
+val webkit_text_stroke_color : color -> declaration
+(** [webkit_text_stroke_color v] is the [-webkit-text-stroke-color] property. *)
+
+val webkit_transform : transform list -> declaration
+(** [webkit_transform v] is the [-webkit-transform] property. *)
+
+val moz_transform : transform list -> declaration
+(** [moz_transform v] is the [-moz-transform] property. *)
+
+val ms_transform : transform list -> declaration
+(** [ms_transform v] is the [-ms-transform] property. *)
+
+val o_transform : transform list -> declaration
+(** [o_transform v] is the [-o-transform] property. *)
+
+val webkit_transition : transition list -> declaration
+(** [webkit_transition v] is the [-webkit-transition] property. *)
+
+val webkit_transition_delay : duration -> declaration
+(** [webkit_transition_delay v] is the [-webkit-transition-delay] property. *)
+
+val webkit_transition_duration : duration -> declaration
+(** [webkit_transition_duration v] is the [-webkit-transition-duration]
+    property. *)
+
+val webkit_transition_property : transition_property -> declaration
+(** [webkit_transition_property v] is the [-webkit-transition-property]
+    property. *)
+
+val webkit_transition_timing_function : timing_function -> declaration
+(** [webkit_transition_timing_function v] is the
+    [-webkit-transition-timing-function] property. *)
+
+val webkit_animation : animation list -> declaration
+(** [webkit_animation v] is the [-webkit-animation] property. *)
+
+val webkit_animation_delay : duration -> declaration
+(** [webkit_animation_delay v] is the [-webkit-animation-delay] property. *)
+
+val webkit_animation_duration : duration -> declaration
+(** [webkit_animation_duration v] is the [-webkit-animation-duration] property.
+*)
+
+val webkit_animation_direction : animation_direction -> declaration
+(** [webkit_animation_direction v] is the [-webkit-animation-direction]
+    property. *)
+
+val webkit_animation_iteration_count : animation_iteration_count -> declaration
+(** [webkit_animation_iteration_count v] is the
+    [-webkit-animation-iteration-count] property. *)
+
+val webkit_animation_name : animation_name -> declaration
+(** [webkit_animation_name v] is the [-webkit-animation-name] property. *)
+
+val webkit_animation_timing_function : timing_function -> declaration
+(** [webkit_animation_timing_function v] is the
+    [-webkit-animation-timing-function] property. *)
+
+val webkit_animation_fill_mode : animation_fill_mode -> declaration
+(** [webkit_animation_fill_mode v] is the [-webkit-animation-fill-mode]
+    property. *)
+
+val webkit_animation_play_state : animation_play_state -> declaration
+(** [webkit_animation_play_state v] is the [-webkit-animation-play-state]
+    property. *)
+
+val webkit_flex_direction : flex_direction -> declaration
+(** [webkit_flex_direction v] is the [-webkit-flex-direction] property. *)
+
+val webkit_flex_wrap : flex_wrap -> declaration
+(** [webkit_flex_wrap v] is the [-webkit-flex-wrap] property. *)
+
+val webkit_flex_flow : flex_flow -> declaration
+(** [webkit_flex_flow v] is the [-webkit-flex-flow] property. *)
+
+val webkit_justify_content : justify_content -> declaration
+(** [webkit_justify_content v] is the [-webkit-justify-content] property. *)
+
+val webkit_align_items : align_items -> declaration
+(** [webkit_align_items v] is the [-webkit-align-items] property. *)
+
+val webkit_align_content : align_content -> declaration
+(** [webkit_align_content v] is the [-webkit-align-content] property. *)
+
+val webkit_align_self : align_self -> declaration
+(** [webkit_align_self v] is the [-webkit-align-self] property. *)
+
+val webkit_border_radius : border_radius -> declaration
+(** [webkit_border_radius v] is the [-webkit-border-radius] property. *)
+
+val webkit_box_sizing : box_sizing -> declaration
+(** [webkit_box_sizing v] is the [-webkit-box-sizing] property. *)
+
+val moz_box_sizing : box_sizing -> declaration
+(** [moz_box_sizing v] is the [-moz-box-sizing] property. *)
+
+val webkit_box_shadow : shadow -> declaration
+(** [webkit_box_shadow v] is the [-webkit-box-shadow] property. *)
+
+val webkit_background_size : background_size -> declaration
+(** [webkit_background_size v] is the [-webkit-background-size] property. *)
+
+val webkit_filter : filter -> declaration
+(** [webkit_filter v] is the [-webkit-filter] property. *)
+
+val moz_appearance : appearance -> declaration
+(** [moz_appearance v] is the [-moz-appearance] property. *)
+
+val moz_animation : animation list -> declaration
+(** [moz_animation v] is the [-moz-animation] property. *)
+
+val moz_animation_delay : duration -> declaration
+(** [moz_animation_delay v] is the [-moz-animation-delay] property. *)
+
+val moz_animation_duration : duration -> declaration
+(** [moz_animation_duration v] is the [-moz-animation-duration] property. *)
+
+val moz_animation_direction : animation_direction -> declaration
+(** [moz_animation_direction v] is the [-moz-animation-direction] property. *)
+
+val moz_animation_iteration_count : animation_iteration_count -> declaration
+(** [moz_animation_iteration_count v] is the [-moz-animation-iteration-count]
+    property. *)
+
+val moz_animation_name : animation_name -> declaration
+(** [moz_animation_name v] is the [-moz-animation-name] property. *)
+
+val moz_animation_timing_function : timing_function -> declaration
+(** [moz_animation_timing_function v] is the [-moz-animation-timing-function]
+    property. *)
+
+val moz_animation_fill_mode : animation_fill_mode -> declaration
+(** [moz_animation_fill_mode v] is the [-moz-animation-fill-mode] property. *)
+
+val moz_animation_play_state : animation_play_state -> declaration
+(** [moz_animation_play_state v] is the [-moz-animation-play-state] property. *)
+
+val moz_transition : transition list -> declaration
+(** [moz_transition v] is the [-moz-transition] property. *)
+
+val moz_transition_delay : duration -> declaration
+(** [moz_transition_delay v] is the [-moz-transition-delay] property. *)
+
+val moz_transition_duration : duration -> declaration
+(** [moz_transition_duration v] is the [-moz-transition-duration] property. *)
+
+val moz_transition_property : transition_property -> declaration
+(** [moz_transition_property v] is the [-moz-transition-property] property. *)
+
+val moz_transition_timing_function : timing_function -> declaration
+(** [moz_transition_timing_function v] is the [-moz-transition-timing-function]
+    property. *)
+
+val moz_border_radius : border_radius -> declaration
+(** [moz_border_radius v] is the [-moz-border-radius] property. *)
+
+val moz_box_shadow : shadow -> declaration
+(** [moz_box_shadow v] is the [-moz-box-shadow] property. *)
+
+val ms_filter : filter -> declaration
+(** [ms_filter v] is the [-ms-filter] property. *)
+
+val o_transition : transition list -> declaration
+(** [o_transition v] is the [-o-transition] property. *)
+
 val all : css_wide -> declaration
 (** [all v] is the [all] property. It resets every longhand to [v] but the two
     writing-mode ones CSS Cascading 5 sec. 3.3 excepts. *)

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -2631,6 +2631,29 @@ let scroll_driven_animation_builders () =
     (Css.view_timeline_inset (Inset (Auto, None)));
   check "timeline-scope:--a" (Css.timeline_scope (Names [ "--a" ]))
 
+(* The vendor-specific section documented sixty-odd prefixed longhands and
+   exposed no builder for any of them. *)
+let vendor_prefixed_builders () =
+  let check expected declaration =
+    Alcotest.(check string)
+      expected expected
+      (Css.Declaration.to_string ~minify:true declaration)
+  in
+  check "-webkit-transform:none" (Css.webkit_transform [ None ]);
+  check "-moz-transform:none" (Css.moz_transform [ None ]);
+  check "-ms-transform:none" (Css.ms_transform [ None ]);
+  check "-o-transform:none" (Css.o_transform [ None ]);
+  check "-webkit-animation-duration:1s" (Css.webkit_animation_duration (S 1.));
+  check "-moz-animation-name:spin" (Css.moz_animation_name (Name "spin"));
+  check "-webkit-flex-wrap:wrap" (Css.webkit_flex_wrap Wrap);
+  check "-webkit-align-items:center" (Css.webkit_align_items Center);
+  check "-webkit-box-sizing:border-box" (Css.webkit_box_sizing Border_box);
+  check "-moz-box-sizing:border-box" (Css.moz_box_sizing Border_box);
+  check "-webkit-text-fill-color:red" (Css.webkit_text_fill_color (Named Red));
+  check "-moz-appearance:none" (Css.moz_appearance None);
+  check "-moz-user-select:none" (Css.moz_user_select None);
+  check "-ms-user-select:none" (Css.ms_user_select None)
+
 let suite =
   ( "css",
     [
@@ -2738,6 +2761,8 @@ let suite =
         contain_intrinsic_size_builders;
       Alcotest.test_case "public scroll driven animation builders" `Quick
         scroll_driven_animation_builders;
+      Alcotest.test_case "public vendor prefixed builders" `Quick
+        vendor_prefixed_builders;
       Alcotest.test_case "spec section 4.1 at-rule name case is insensitive"
         `Quick spec_at_rule_name_case_insensitive;
     ] )


### PR DESCRIPTION
`Css`'s vendor-specific section documents the prefixed transform, transition, animation, flexbox and box longhands and exposed a builder for none of them, so a caller emitting a prefixed fallback had to go through the parser. Each builder takes the value type its unprefixed counterpart takes.