### PR TITLE
ci: run every job against one pinned browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,23 @@ jobs:
 
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
+
+      # The browser oracles compare cascade against a real engine, so every job
+      # has to run the same one. The runner images ship their own Chrome, and it
+      # differs between ubuntu and macos: a property one build implements and
+      # the other does not makes the comparison fail on whichever runner is
+      # behind, whatever the diff under test says. [CHROME] is the override
+      # test/render/browser.ml reads before it goes looking.
+      - name: Install the pinned browser
+        run: |
+          PLAYWRIGHT_BROWSERS_PATH="$HOME/.cache/cascade-browser" \
+            npx --yes playwright@1.63.0 install chromium-headless-shell
+      - name: Point the browser oracles at it
+        shell: bash
+        run: |
+          shell=$(find "$HOME/.cache/cascade-browser" -name chrome-headless-shell -type f | head -1)
+          test -x "$shell"
+          echo "CHROME=$shell" >> "$GITHUB_ENV"
       - run: opam exec -- dune test
 
   lower-bounds:
@@ -43,6 +60,23 @@ jobs:
       # removed upstream) fails here rather than in a downstream opam build.
       - run: opam install . --deps-only --with-test --criteria="+count[version-lag,solution]"
       - run: opam exec -- dune build
+
+      # The browser oracles compare cascade against a real engine, so every job
+      # has to run the same one. The runner images ship their own Chrome, and it
+      # differs between ubuntu and macos: a property one build implements and
+      # the other does not makes the comparison fail on whichever runner is
+      # behind, whatever the diff under test says. [CHROME] is the override
+      # test/render/browser.ml reads before it goes looking.
+      - name: Install the pinned browser
+        run: |
+          PLAYWRIGHT_BROWSERS_PATH="$HOME/.cache/cascade-browser" \
+            npx --yes playwright@1.63.0 install chromium-headless-shell
+      - name: Point the browser oracles at it
+        shell: bash
+        run: |
+          shell=$(find "$HOME/.cache/cascade-browser" -name chrome-headless-shell -type f | head -1)
+          test -x "$shell"
+          echo "CHROME=$shell" >> "$GITHUB_ENV"
       - run: opam exec -- dune test
 
   ascii:

--- a/README.md
+++ b/README.md
@@ -703,6 +703,17 @@ merlint             # lint the OCaml sources
 [samoht opam overlay](https://tangled.org/gazagnaire.org/opam-overlay.git);
 add the repository before `opam install merlint`.
 
+The browser oracles drive a headless Chromium and compare cascade against what
+it does, so they answer for the build they run. CI installs one and points
+`CHROME` at it. Locally the harness takes `CHROME` first and otherwise picks the
+newest build in the puppeteer or playwright cache, so a stale cache answers for
+a browser CI no longer runs:
+
+<!-- $MDX skip -->
+```bash
+npx playwright install chromium-headless-shell
+```
+
 CI runs four jobs: `Build and test` on Linux and macOS, `Lower bounds` against
 the oldest dependency versions that solve, `ASCII source`
 ([scripts/check_ascii.sh](scripts/check_ascii.sh) over the `.ml`, `.mli`,


### PR DESCRIPTION
The browser oracles compare cascade against a real engine, and CI installed none: each job used whatever Chrome its runner image shipped. Those differ, so `Build and test (macos-latest)` failed on `ruby-overhang` with "the browser does not implement it" while the ubuntu jobs passed on the same commit, and the next commit passed on macOS too. `Chrome_gaps.unimplemented` is checked in both directions against that browser, so no static list can satisfy two builds at once.

Every job now installs one pinned headless shell and points `CHROME` at it, the override `browser.ml` already reads first. The full suite is green against that build locally.