### PR TITLE
values: let a math function carry a negative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -428,6 +428,12 @@ to lose a whole rule over one bad piece. Both are gone.
   or initial value, so `width: 37px; width: var(--nope, notalength)` measured
   37px where the browser lays out `auto` (#987)
 
+- A math function carries a negative where the property's range is
+  `[0,inf]`, so `border-right-width: calc(-1px)`, `outline-width: calc(-1px)`
+  and `line-height: calc(-10%)` read, and minified output keeps the call rather
+  than unwrapping it to a bare value the browser drops. CSS Values 4 sec. 10.12
+  checks the range on the value the function resolves to (#1047)
+
 - `overflow-clip-margin: -1px` reads where it was dropped with a warning. CSS
   Overflow 4 sec. 3.2 is `<visual-box> || <length>` with no range on the
   length, and a negative one pulls the clip edge inside the box (#1026)

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -9953,8 +9953,10 @@ val pp_gradient_direction : gradient_direction Pp.t
 val pp_transform : transform Pp.t
 (** [pp_transform] is the pretty printer for transform values. *)
 
-val pp_calc : 'a Pp.t -> 'a calc Pp.t
-(** [pp_calc pp_value] is the pretty printer for calc expressions. *)
+val pp_calc : ?unwrap:('a -> bool) -> 'a Pp.t -> 'a calc Pp.t
+(** [pp_calc ?unwrap pp_value] is the pretty printer for calc expressions.
+    Minified output drops the call around a single leaf, and [unwrap] says which
+    leaves that is safe for. *)
 
 val pp_font_style : font_style Pp.t
 (** [pp_font_style] is the pretty printer for font-style values. *)

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -765,6 +765,37 @@ let normalize_border_width_clamp lower value upper : border_width =
           normalize_border_width_calc_arg value,
           normalize_border_width_calc_arg upper )
 
+(* CSS Values 4 sec. 10.12 keeps a math function valid where its range is
+   exceeded and clamps at used-value time, so [calc(-1px)] is a border width
+   Chrome computes as [0] and [-1px] one it drops. Unwrapping the call would
+   turn the first into the second, which is why {!pp_length} guards its own
+   unwrap the same way. *)
+let negative_border_width : border_width -> bool = function
+  | Px f
+  | Cm f
+  | Mm f
+  | Q f
+  | In f
+  | Pt f
+  | Pc f
+  | Rem f
+  | Em f
+  | Ex f
+  | Cap f
+  | Ic f
+  | Ric f
+  | Rlh f
+  | Ch f
+  | Lh f
+  | Vh f
+  | Vw f
+  | Vmin f
+  | Vmax f
+  | Pct f
+  | Dimension { value = f; _ } ->
+      f < 0.
+  | _ -> false
+
 let rec pp_border_width : border_width Pp.t =
  fun ctx -> function
   | Thin -> Pp.string ctx "thin"
@@ -802,7 +833,10 @@ let rec pp_border_width : border_width Pp.t =
   | Min_content -> Pp.string ctx "min-content"
   | Fit_content -> Pp.string ctx "fit-content"
   | From_font -> Pp.string ctx "from-font"
-  | Calc cv -> pp_calc pp_border_width ctx cv
+  | Calc cv ->
+      pp_calc
+        ~unwrap:(fun v -> not (negative_border_width v))
+        pp_border_width ctx cv
   | Min args -> pp_border_width_minmax "min" ctx args
   | Max args -> pp_border_width_minmax "max" ctx args
   | Clamp (lower, value, upper) -> pp_border_width_clamp ctx lower value upper
@@ -1342,8 +1376,11 @@ let ensure_non_negative_border_width t value =
    one. The units [border_width] names get their own arm; the rest keep their
    value and spelling in [Dimension], the way [length] itself does, so a unit
    [length] learns needs no second table here. *)
-let length_to_border_width t (length : length) : border_width =
-  let non_neg = ensure_non_negative_border_width t in
+let length_to_border_width ?(allow_negative = false) t (length : length) :
+    border_width =
+  let non_neg v =
+    if allow_negative then v else ensure_non_negative_border_width t v
+  in
   let typed_dimension ?repr value unit : border_width =
     let value = non_neg value in
     match String.lowercase_ascii unit with
@@ -1385,16 +1422,26 @@ let length_to_border_width t (length : length) : border_width =
 (* CSS Backgrounds 3 (ED) sec. 3.3: [<line-width>] is [<length [0,inf]> | thin |
    medium | thick] and takes no percentage, which Chrome 146 refuses.
    [length_only] refuses one nested in math as well. *)
-let read_length_as_border_width t =
-  let length = read_length ~with_keywords:false ~length_only:true t in
-  length_to_border_width t length
-
-let rec read_border_width t : border_width =
-  let read_var t : border_width = Var (read_var read_border_width t) in
-  let read_calc t : border_width =
-    Calc (read_calc ~result_type:`Value read_border_width t)
+let read_length_as_border_width ?(allow_negative = false) t =
+  let length =
+    read_length ~allow_negative ~with_keywords:false ~length_only:true t
   in
-  let read_math_arg t = read_calc_expr read_border_width t in
+  length_to_border_width ~allow_negative t length
+
+(* CSS Values 4 sec. 10.12: a math function is valid wherever its type is, and
+   the [0,inf] range of [<line-width>] is checked on the value it resolves to,
+   not on each operand. So [calc(-1px)] reads and a literal [-1px] does not. *)
+let rec read_border_width_in_math t : border_width =
+  read_border_width_with ~allow_negative:true t
+
+and read_border_width_with ~allow_negative t : border_width =
+  let read_var t : border_width =
+    Var (read_var (read_border_width_with ~allow_negative) t)
+  in
+  let read_calc t : border_width =
+    Calc (read_calc ~result_type:`Value read_border_width_in_math t)
+  in
+  let read_math_arg t = read_calc_expr read_border_width_in_math t in
   let read_min t : border_width =
     Min
       (Cursor.call "min" t
@@ -1432,7 +1479,11 @@ let rec read_border_width t : border_width =
         ("max", read_max);
         ("clamp", read_clamp);
       ]
-    ~default:read_length_as_border_width t
+    ~default:(read_length_as_border_width ~allow_negative)
+    t
+
+let read_border_width t : border_width =
+  read_border_width_with ~allow_negative:false t
 
 module Border = struct
   type component =
@@ -2105,7 +2156,10 @@ let normalize_border_width (bw : border_width) : border_width =
   match bw with
   | Calc c -> (
       match normalize_border_width_calc c with
-      | Val v -> v
+      (* The call stays around a negative for the reason {!pp_border_width}
+         keeps it: sec. 10.12 clamps [calc(-1px)] at used-value time and drops a
+         bare [-1px]. *)
+      | Val v when not (negative_border_width v) -> v
       | folded -> Calc folded)
   | Min args -> normalize_border_width_minmax `Min args
   | Max args -> normalize_border_width_minmax `Max args

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -12,10 +12,11 @@ open Values
 open Properties_intf
 open Prop_common
 
-let read_line_height_length t : line_height =
+let read_line_height_length ?(allow_negative = false) t : line_height =
   let n, repr, unit = Cursor.number_repr_with_unit t in
   let n, repr = normalize_signed_zero n repr in
-  if n < 0. then Cursor.err_invalid t "line-height cannot be negative"
+  if n < 0. && not allow_negative then
+    Cursor.err_invalid t "line-height cannot be negative"
   else
     let authored () : line_height = Number { value = n; unit; repr } in
     match unit with
@@ -1291,6 +1292,14 @@ let rec pp_moz_osx_font_smoothing : moz_osx_font_smoothing Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+(* CSS Values 4 sec. 10.12 keeps a math function valid past the [0,inf] range
+   CSS Inline 3 sec. 5.1 gives line-height, and clamps at used-value time, so
+   [calc(-10%)] computes and a bare [-10%] is dropped. The call stays on a
+   negative for that reason. *)
+let negative_line_height : line_height -> bool = function
+  | Num f | Px f | Rem f | Em f | Pct f | Number { value = f; _ } -> f < 0.
+  | _ -> false
+
 let rec pp_line_height : line_height Pp.t =
  fun ctx -> function
   | Normal -> Pp.string ctx "normal"
@@ -1314,7 +1323,10 @@ let rec pp_line_height : line_height Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_line_height ctx v
-  | Calc c -> pp_calc pp_line_height ctx c
+  | Calc c ->
+      pp_calc
+        ~unwrap:(fun v -> not (negative_line_height v))
+        pp_line_height ctx c
 
 let rec pp_font_weight : font_weight Pp.t =
  fun ctx -> function
@@ -1409,11 +1421,34 @@ let rec pp_font : font Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_font ctx v
 
+(* CSS Values 4 sec. 10.12: a math function is valid wherever its type is, and
+   the [0,inf] range of sec. 5.1 is checked on the value it resolves to, not on
+   each operand, so [calc(-10%)] reads where a literal [-10%] does not. *)
+let rec read_line_height_in_math t : line_height =
+  let read_var t : line_height = Var (read_var read_line_height_in_math t) in
+  let read_calc t : line_height =
+    Calc
+      (read_calc ~result_type:`Number_or_value read_line_height_in_math t
+      |> numeric_line_height_calc_leaves)
+  in
+  Cursor.enum_or_calls "line-height"
+    [
+      ("normal", Normal);
+      ("inherit", Inherit);
+      ("initial", Initial);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~calls:[ ("var", read_var); ("calc", read_calc) ]
+    ~default:(read_line_height_length ~allow_negative:true)
+    t
+
 let rec read_line_height t : line_height =
   let read_var t : line_height = Var (read_var read_line_height t) in
   let read_calc t : line_height =
     Calc
-      (read_calc ~result_type:`Number_or_value read_line_height t
+      (read_calc ~result_type:`Number_or_value read_line_height_in_math t
       |> numeric_line_height_calc_leaves)
   in
   Cursor.enum_or_calls "line-height"
@@ -2337,8 +2372,8 @@ let normalize_line_height ?(lossless = false) (lh : line_height) : line_height =
       | Option.Some f -> Num f
       | Option.None -> (
           match Values.eval_calc c with
-          | Values.Num f -> Num f
-          | Values.Val v -> v
+          | Values.Num f when f >= 0. -> Num f
+          | Values.Val v when not (negative_line_height v) -> v
           | folded -> Calc folded))
   | _ -> lh
 

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1371,7 +1371,7 @@ let pp_calc_with : type a.
       let ctx = { ctx with in_calc = true } in
       Pp.call "calc" (pp_calc_contents pp_value) ctx calc
 
-let pp_calc pp_value ctx calc = pp_calc_with pp_value ctx calc
+let pp_calc ?unwrap pp_value ctx calc = pp_calc_with ?unwrap pp_value ctx calc
 
 (* Small helpers *)
 

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -346,8 +346,13 @@ val pp_number_percentage : ?always:bool -> number_percentage Pp.t
 (** [pp_number_percentage ?always] pretty-prints {!number_percentage} values.
     When [always] is true, always includes units even for 0. *)
 
-val pp_calc : 'a Pp.t -> 'a calc Pp.t
-(** [pp_calc pp] pretty-prints [calc] expressions using [pp] for leaf values. *)
+val pp_calc : ?unwrap:('a -> bool) -> 'a Pp.t -> 'a calc Pp.t
+(** [pp_calc ?unwrap pp] pretty-prints [calc] expressions using [pp] for leaf
+    values. Minified output drops the call around a single leaf; [unwrap] says
+    which leaves that is safe for, and defaults to all of them. A leaf outside
+    the property's range is not one: CSS Values 4 sec. 10.12 keeps the call
+    valid there and clamps at used-value time, where the bare value is dropped
+    instead. *)
 
 val pp_color_name : color_name Pp.t
 (** [pp_color_name] pretty-prints {!type-color_name} values. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1317,6 +1317,19 @@ let border_line_width () =
     ~optimized:"border:solid red" "border: medium solid red";
   check_declaration ~expected:"border-top:medium dashed blue"
     ~optimized:"border-top:dashed#00f" "border-top: medium dashed blue";
+  (* CSS Values 4 sec. 10.12 checks the [0,inf] range of a <line-width> and of
+     line-height on the value the math function resolves to, not on each
+     operand, so a negative inside calc() reads and a literal one does not. *)
+  check_declaration ~expected:"border-right-width:calc(-1px)"
+    "border-right-width: calc(-1px)";
+  check_declaration ~expected:"outline-width:calc(-1px)"
+    "outline-width: calc(-1px)";
+  check_declaration ~expected:"border-right:calc(-1px) solid red"
+    "border-right: calc(-1px) solid red";
+  check_declaration ~expected:"line-height:calc(-10%)" "line-height: calc(-10%)";
+  neg_cursor read_declaration "border-right-width: -1px";
+  neg_cursor read_declaration "outline-width: -1px";
+  neg_cursor read_declaration "line-height: -10%";
   check_declaration ~expected:"column-rule:medium solid red"
     ~optimized:"column-rule:solid red" "column-rule: medium solid red";
   (* CSS Gaps 1 sec. 4 gives each gap decoration longhand a comma-separated


### PR DESCRIPTION
`border-right-width: calc(-1px)`, `outline-width: calc(-1px)` and `line-height: calc(-10%)` were dropped with a warning. CSS Values 4 sec. 10.12 checks a range on the value the math function resolves to, not on each operand, so the browser clamps these and drops only the bare literal, which cascade still refuses.

Reader and printer had to move together: reading the call without keeping it emits the bare value the browser refuses. `pp_length` already guarded its unwrap this way, so this gives `border_width` and `line_height` the same guard, in the printer and in normalisation. `text-decoration-thickness: calc(-1px)` still prints `-1px`, since a negative is in range there.