### PR TITLE
values: read a math function in a number slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,12 @@ entry points both moved.
   `flex: 1e999px` read where they were dropped with a warning. Exhaustive
   visitors must handle the new leaf (#1023)
 
+- The `Number` of `Cascade.Properties.dash_length` carries a `number` where it
+  carried a `float`, and `animation_iteration_count` replaces its `Num of float`
+  with `Count of number`, so `stroke-dasharray: calc(1 + 2)` and
+  `animation-iteration-count: calc(.5)` read. A caller building a literal writes
+  `Number (Num 4.)` and `Count (Num 1.)` (#1048)
+
 - The `Number` of `Cascade.Properties.border_image_width_item`,
   `border_image_outset_item` and `border_image_slice_item` carries a `number`
   where it carried a `float`, so `border-image-width: calc(1 + 2)` reads. CSS
@@ -783,6 +789,9 @@ to lose a whole rule over one bad piece. Both are gone.
   reference used to be dropped at parse time, and `Css.custom_props` missed a
   name declared inside `@scope`, `@starting-style`, `@-moz-document`, `@when`
   or `@else` (#322, #341, #342, #375, #423, #555, #571, #573, #575, #577)
+
+- `Css.vars_of_declarations` reports the `var()` inside a `stroke-dasharray` or
+  `stroke-dashoffset` dash, where it returned nothing (#1048)
 
 - Substitution preserves what the declaration was. A custom property keeps its
   cascade layer and caller metadata, a `page-break-*` declaration survives as

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -6833,7 +6833,7 @@ type animation_play_state = Properties.animation_play_state =
 
 (** CSS animation iteration count values *)
 type animation_iteration_count = Properties.animation_iteration_count =
-  | Num of float
+  | Count of number
   | Infinite
   | Counts of animation_iteration_count list
   | Initial
@@ -8637,7 +8637,7 @@ val stroke_miterlimit : stroke_miterlimit -> declaration
      [stroke-dasharray]} writes each dash as a [<length-percentage>] or a bare
     number in user units, the way {!type-stroke_width} does. *)
 type dash_length = Properties.dash_length =
-  | Number of float
+  | Number of number
   | Length of length_percentage
 
 (** SVG 2

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -33,6 +33,18 @@ let normalize_animation_range : animation_range -> animation_range =
              option_map_preserve normalize_animation_range_item b ))
   | other -> other
 
+(* Sec. 3.4 gives the count a plain [<number>], so a static math function on it
+   folds like any other. *)
+let rec normalize_animation_iteration_count ~ctx :
+    animation_iteration_count -> animation_iteration_count =
+ fun value ->
+  match value with
+  | Count n -> preserve_if_equal value (Count (Values.normalize_number ~ctx n))
+  | Counts counts ->
+      preserve_if_equal value
+        (Counts (map_preserve (normalize_animation_iteration_count ~ctx) counts))
+  | other -> other
+
 let normalize_timeline_inset_item : timeline_inset_item -> timeline_inset_item =
  fun value ->
   match value with
@@ -85,7 +97,7 @@ let rec pp_animation_iteration_count : animation_iteration_count Pp.t =
   | Counts counts ->
       Pp.list ~sep:Pp.comma pp_animation_iteration_count ctx counts
   | Infinite -> Pp.string ctx "infinite"
-  | Num n -> Pp.float ctx n
+  | Count n -> Values.pp_number ctx n
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -1210,16 +1222,25 @@ let rec read_animation_fill_mode t : animation_fill_mode =
       | values -> Fill_modes values)
     t
 
-let read_animation_count_number t =
-  let n, unit = Cursor.number_with_unit t in
-  match unit with
-  | Some u ->
-      Cursor.err_invalid t
-        ("animation-iteration-count must be unitless, got: " ^ u)
-  | None ->
-      if n < 0. then
-        Cursor.err_invalid t "animation-iteration-count cannot be negative";
-      Num n
+(* Sec. 3.4 gives the count a [<number [0,inf]>]. A [calc()] holds no value to
+   compare, so only a literal is turned away here. Each count is one component
+   of a comma list, and the whole-value number reader refuses anything after the
+   number it read, so the component is handed to it on its own. *)
+let read_animation_count_number t : animation_iteration_count =
+  match Cursor.peek t with
+  | Some (Component.Func _ as component) ->
+      let _ = Cursor.next t in
+      Count (Values.read_number (Cursor.of_components [ component ]))
+  | _ ->
+      let n, unit = Cursor.number_with_unit t in
+      (match unit with
+      | Some u ->
+          Cursor.err_invalid t
+            ("animation-iteration-count must be unitless, got: " ^ u)
+      | None ->
+          if n < 0. then
+            Cursor.err_invalid t "animation-iteration-count cannot be negative");
+      Count (Num n)
 
 let read_animation_count_item t =
   Cursor.enum "animation-iteration-count-item"
@@ -1447,7 +1468,7 @@ module Animation = struct
       (* CSS default: ease *)
       delay = Some (S 0.0);
       (* CSS default: 0s *)
-      iteration_count = Some (Num 1.0);
+      iteration_count = Some (Count (Num 1.0));
       (* CSS default: 1 *)
       direction = Some Normal;
       (* CSS default: normal *)
@@ -1651,7 +1672,7 @@ module Animation = struct
     | Some tf -> not (is_default_timing tf)
 
   let is_iteration : animation_iteration_count option -> bool = function
-    | Some (Num 1.) | None -> false
+    | Some (Count (Num 1.)) | None -> false
     | Some _ -> true
 
   let is_direction : animation_direction option -> bool = function
@@ -1728,8 +1749,8 @@ module Animation = struct
   let iteration ?(quote_name = false) (anim : animation_shorthand) :
       animation_iteration_count option =
     match (anim.iteration_count, effective_ambiguous_kind ~quote_name anim) with
-    | (Some (Num 1.) | None), Some Iteration -> Some (Num 1.)
-    | Some (Num 1.), _ | None, _ -> None
+    | (Some (Count (Num 1.)) | None), Some Iteration -> Some (Count (Num 1.))
+    | Some (Count (Num 1.)), _ | None, _ -> None
     | Some c, _ -> Some c
 
   let direction ?(quote_name = false) (anim : animation_shorthand) :

--- a/lib/prop_svg.ml
+++ b/lib/prop_svg.ml
@@ -66,7 +66,9 @@ let normalize_stroke_width ~ctx (value : stroke_width) : stroke_width =
 
 let normalize_dash_length ~ctx (value : dash_length) : dash_length =
   match value with
-  | Number _ -> value
+  | Number n ->
+      let n' = Values.normalize_number ~ctx n in
+      if n' == n then value else Number n'
   | Length lp ->
       let lp' = Values.normalize_length_percentage ~ctx lp in
       if lp' == lp then value else Length lp'
@@ -165,7 +167,7 @@ let rec pp_stroke_width : stroke_width Pp.t =
 
 let pp_dash_length : dash_length Pp.t =
  fun ctx -> function
-  | Number n -> Pp.float ctx n
+  | Number n -> Values.pp_number ctx n
   | Length lp -> Values.pp_length_percentage ctx lp
 
 let rec pp_stroke_dashoffset : stroke_dashoffset Pp.t =
@@ -393,20 +395,38 @@ let rec read_paint_order t : paint_order =
       (Order (go [ read_paint_order_keyword t ]) : paint_order))
     t
 
+(* Sec. 13.5.6 leaves the number half at [0,inf] when the caller asks. A
+   [calc()] holds no value to compare, so only a literal is turned away here.
+   Each dash is one component of a list, and the whole-value number reader
+   refuses a number after the one it read, so the component is handed to it on
+   its own. *)
+let read_dash_number ~allow_negative t : number =
+  let value : number =
+    match Cursor.peek t with
+    | Some (Component.Func _ as component) ->
+        let _ = Cursor.next t in
+        Values.read_number (Cursor.of_components [ component ])
+    | _ -> Num (Cursor.number t)
+  in
+  (match value with
+  | (Num n : number) when (not allow_negative) && n < 0. ->
+      Cursor.err_invalid t "stroke-dasharray cannot be negative"
+  | _ -> ());
+  value
+
 (* A bare number is user units; anything with a unit or a percent sign is a
    <length-percentage>. *)
 let read_dash_length ?(allow_negative = true) t : dash_length =
-  match Cursor.peek t with
-  | Some (Component.Preserved { kind = Token.Number_tok _; _ }) ->
-      let n = Cursor.number t in
-      if (not allow_negative) && n < 0. then
-        Cursor.err_invalid t "stroke-dasharray cannot be negative";
-      Number n
-  (* The grammar is <length-percentage> | <number>, with no keyword branch, so
-     the intrinsic-sizing keywords a bare length would accept are out. *)
-  | _ ->
-      Length
-        (Values.read_length_percentage ~allow_negative ~with_keywords:false t)
+  Cursor.one_of
+    [
+      (fun t -> (Number (read_dash_number ~allow_negative t) : dash_length));
+      (* The grammar is <length-percentage> | <number>, with no keyword branch,
+         so the intrinsic-sizing keywords a bare length would accept are out. *)
+      (fun t ->
+        Length
+          (Values.read_length_percentage ~allow_negative ~with_keywords:false t));
+    ]
+    t
 
 let rec read_stroke_dashoffset t : stroke_dashoffset =
   Cursor.enum_or_calls "stroke-dashoffset"

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4389,6 +4389,11 @@ let normalize_property_value : type a.
   | Webkit_mask_position -> map_preserve normalize_position_value value
   | Text_indent -> normalize_text_indent value
   | Animation_range -> normalize_animation_range value
+  | Animation_iteration_count -> normalize_animation_iteration_count ~ctx value
+  | Webkit_animation_iteration_count ->
+      normalize_animation_iteration_count ~ctx value
+  | Moz_animation_iteration_count ->
+      normalize_animation_iteration_count ~ctx value
   | Scroll_timeline -> normalize_timeline_shorthand value
   | View_timeline -> normalize_view_timeline_shorthand value
   | View_timeline_inset -> normalize_timeline_inset value

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2384,7 +2384,7 @@ type animation_fill_mode =
   | Var of animation_fill_mode var
 
 type animation_iteration_count =
-  | Num of float
+  | Count of number
   | Infinite
   | Counts of animation_iteration_count list
   | Initial
@@ -4378,8 +4378,10 @@ type stroke_miterlimit =
   | Var of stroke_miterlimit var
 
 (** SVG 2 sec. 13.5.6: one dash length. A bare [<number>] is in user units,
-    which is why this is not plain [length_percentage]. *)
-type dash_length = Number of float | Length of length_percentage
+    which is why this is not plain [length_percentage]. CSS Values 4 sec. 10.1
+    puts a math function wherever a number is, so that half is a {!type-number}.
+*)
+type dash_length = Number of number | Length of length_percentage
 
 (** SVG 2 sec. 13.5.6 [stroke-dashoffset]. *)
 type stroke_dashoffset =

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1569,6 +1569,7 @@ let rec vars_of_animation_iteration_count
   match value with
   | Var v -> [ V v ]
   | Counts counts -> List.concat_map vars_of_animation_iteration_count counts
+  | Count n -> vars_of_number_value n
   | _ -> []
 
 let vars_of_transition_behavior (value : Properties.transition_behavior) =
@@ -1881,11 +1882,22 @@ let vars_of_stroke_width (value : Properties.stroke_width) =
   | Length lp -> vars_of_length_percentage lp
   | _ -> []
 
+let vars_of_dash_length (value : Properties.dash_length) =
+  match value with
+  | Number n -> vars_of_number_value n
+  | Length lp -> vars_of_length_percentage lp
+
 let vars_of_stroke_dashoffset (value : Properties.stroke_dashoffset) =
-  match value with Var v -> [ V v ] | _ -> []
+  match value with
+  | Var v -> [ V v ]
+  | Dash d -> vars_of_dash_length d
+  | _ -> []
 
 let vars_of_stroke_dasharray (value : Properties.stroke_dasharray) =
-  match value with Var v -> [ V v ] | _ -> []
+  match value with
+  | Var v -> [ V v ]
+  | Dashes ds -> List.concat_map vars_of_dash_length ds
+  | _ -> []
 
 let vars_of_paint_order (value : Properties.paint_order) =
   match value with Var v -> [ V v ] | _ -> []

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -2436,7 +2436,7 @@ let svg_longhand_builders () =
   check "stroke-dashoffset:2px"
     (Css.stroke_dashoffset (Dash (Length (Length (Px 2.)))));
   check "stroke-dasharray:4 2"
-    (Css.stroke_dasharray (Dashes [ Number 4.; Number 2. ]));
+    (Css.stroke_dasharray (Dashes [ Number (Num 4.); Number (Num 2.) ]));
   check "paint-order:stroke fill" (Css.paint_order (Order [ Stroke; Fill ]));
   check "vector-effect:non-scaling-stroke"
     (Css.vector_effect (Effects ([ Non_scaling_stroke ], None)));

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1699,6 +1699,12 @@ let component_var_keeps_typed_value () =
     "border-image-outset: 1PX var(--outset)" "1px var(--outset)";
   check_visible_var "border-image-outset component var stays visible"
     "border-image-outset:var(--outset) 1px" "--outset";
+  check_visible_var "stroke-dasharray math var stays visible"
+    "stroke-dasharray:calc(1 + var(--d)) 2" "--d";
+  check_visible_var "stroke-dashoffset length var stays visible"
+    "stroke-dashoffset:calc(1px + var(--o))" "--o";
+  check_visible_var "animation-iteration-count math var stays visible"
+    "animation-iteration-count:calc(1 + var(--n))" "--n";
   check_specified_value "overflow slots are unchanged"
     "overflow: var(--o) HIDDEN" "var(--o) hidden"
 
@@ -2791,8 +2797,8 @@ let animation_infinite_name () =
       ("infinite infinite", "infinite", Infinite);
       ("infinite INFINITE", "INFINITE", Infinite);
       ("INFINITE infinite", "infinite", Infinite);
-      ("2 infinite", "infinite", Num 2.);
-      ("2 InFiNiTe", "InFiNiTe", Num 2.);
+      ("2 infinite", "infinite", Count (Num 2.));
+      ("2 InFiNiTe", "InFiNiTe", Count (Num 2.));
     ];
   List.iter
     (fun value -> none_cursor read_declaration ("animation:" ^ value))

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2780,6 +2780,9 @@ let test_animation_iteration_count () =
   check_animation_iteration_count "1";
   check_animation_iteration_count "infinite";
   check_animation_iteration_count "2.5";
+  (* CSS Values 4 sec. 10.1: a math function stands where a [<number>] does. *)
+  check_animation_iteration_count "calc(1 + 2)";
+  check_animation_iteration_count "1,calc(2*2)";
   neg_cursor read_animation_iteration_count "invalid-count"
 
 let test_animation_play_state () =
@@ -3732,6 +3735,10 @@ let test_stroke_dashoffset () =
   check_stroke_dashoffset "10%";
   check_stroke_dashoffset "var(--o)";
   check_stroke_dashoffset "-2px";
+  (* CSS Values 4 sec. 10.1 puts a math function wherever its type is, and both
+     halves of the dash grammar are a type. *)
+  check_stroke_dashoffset "calc(1 + 2)";
+  check_stroke_dashoffset "calc(1px + 2px)";
   neg_cursor read_stroke_dashoffset "none"
 
 let test_stroke_dasharray () =
@@ -3743,6 +3750,8 @@ let test_stroke_dasharray () =
   (* Comma and whitespace are the same separator here. *)
   check_stroke_dasharray ~expected:"4 2" "4, 2";
   check_stroke_dasharray "var(--d)";
+  check_stroke_dasharray "calc(1 + 2) 4";
+  check_stroke_dasharray "calc(1px + 2px) 4%";
   neg_cursor read_stroke_dasharray "red";
   (* SVG 2 sec. 13.3 gives each dash a non-negative value; only
      [stroke-dashoffset] takes a signed one. *)


### PR DESCRIPTION
`stroke-dasharray: calc(1 + 2)` and `animation-iteration-count: calc(.5)` used to be dropped with a warning, because a dash length and an iteration count each held a bare float. CSS Values 4 sec. 10.1 puts a math function wherever its type is, so both now carry a `number`.

Follow-up to #1021, which did the same for the border-image halves.