### PR TITLE
text: read hyphenate-limit-chars slot by slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,13 @@ entry points both moved.
   `flex: 1e999px` read where they were dropped with a warning. Exhaustive
   visitors must handle the new leaf (#1023)
 
+- `Cascade.Properties.hyphenate_limit_chars` gives each slot a
+  `hyphenate_limit_chars_item`, `Auto` or a `Chars` count, where it carried a
+  bare `int` and a whole-value `Auto`, so `hyphenate-limit-chars: auto 3` and
+  `hyphenate-limit-chars: calc(1 + 2)` read where they were dropped with a
+  warning. CSS Text 4 sec. 6.3.4 spells the property
+  `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
+
 - The `Number` of `Cascade.Properties.dash_length` carries a `number` where it
   carried a `float`, and `animation_iteration_count` replaces its `Num of float`
   with `Count of number`, so `stroke-dasharray: calc(1 + 2)` and

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -2764,11 +2764,17 @@ type text_spacing_trim = Properties.text_spacing_trim =
   | Revert_layer
   | Var of text_spacing_trim var
 
-type hyphenate_limit_chars = Properties.hyphenate_limit_chars =
+type hyphenate_limit_chars_item = Properties.hyphenate_limit_chars_item =
   | Auto
-  | One of int
-  | Two of int * int
-  | Three of int * int * int
+  | Chars of number
+
+type hyphenate_limit_chars = Properties.hyphenate_limit_chars =
+  | One of hyphenate_limit_chars_item
+  | Two of hyphenate_limit_chars_item * hyphenate_limit_chars_item
+  | Three of
+      hyphenate_limit_chars_item
+      * hyphenate_limit_chars_item
+      * hyphenate_limit_chars_item
   | Inherit
   | Initial
   | Unset

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -772,6 +772,31 @@ let normalize_text_indent : text_indent_value -> text_indent_value =
    the shorter spelling. Written on its own the initial is the whole value, and
    dropping it drains the shorthand: what is left declares the four initials and
    nothing else, which is what [none] declares. *)
+let normalize_hyphenate_limit_chars_item ~ctx :
+    hyphenate_limit_chars_item -> hyphenate_limit_chars_item =
+ fun item ->
+  match item with
+  | Auto -> item
+  | Chars n ->
+      let n' = Values.normalize_number ~ctx n in
+      if n' == n then item else Chars n'
+
+let normalize_hyphenate_limit_chars ~ctx :
+    hyphenate_limit_chars -> hyphenate_limit_chars =
+ fun value ->
+  let item = normalize_hyphenate_limit_chars_item ~ctx in
+  match value with
+  | One a ->
+      let a' = item a in
+      if a' == a then value else One a'
+  | Two (a, b) ->
+      let a' = item a and b' = item b in
+      if a' == a && b' == b then value else Two (a', b')
+  | Three (a, b, c) ->
+      let a' = item a and b' = item b and c' = item c in
+      if a' == a && b' == b && c' == c then value else Three (a', b', c')
+  | other -> other
+
 let normalize_text_decoration ?(lossless = false) :
     text_decoration -> text_decoration =
  fun value ->
@@ -1210,21 +1235,25 @@ let rec pp_text_spacing_trim : text_spacing_trim Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+let pp_hyphenate_limit_chars_item : hyphenate_limit_chars_item Pp.t =
+ fun ctx -> function
+  | Auto -> Pp.string ctx "auto"
+  | Chars n -> Values.pp_number ctx n
+
 let rec pp_hyphenate_limit_chars : hyphenate_limit_chars Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_hyphenate_limit_chars ctx v
-  | Auto -> Pp.string ctx "auto"
-  | One a -> Pp.int ctx a
+  | One a -> pp_hyphenate_limit_chars_item ctx a
   | Two (a, b) ->
-      Pp.int ctx a;
+      pp_hyphenate_limit_chars_item ctx a;
       Pp.space ctx ();
-      Pp.int ctx b
+      pp_hyphenate_limit_chars_item ctx b
   | Three (a, b, c) ->
-      Pp.int ctx a;
+      pp_hyphenate_limit_chars_item ctx a;
       Pp.space ctx ();
-      Pp.int ctx b;
+      pp_hyphenate_limit_chars_item ctx b;
       Pp.space ctx ();
-      Pp.int ctx c
+      pp_hyphenate_limit_chars_item ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -1845,34 +1874,49 @@ let rec read_text_spacing_trim t : text_spacing_trim =
     ~var:(fun t -> Var (read_var read_text_spacing_trim t))
     t
 
+(* Sec. 6.3.4 writes each slot [auto | <integer [0,inf]>]; Chrome 152 refuses
+   the zero the range grants, so the literal floor stays at one. A math function
+   holds no value to compare, and the whole-value number reader refuses anything
+   after the number it read, so the component is handed to it on its own. *)
+let read_hyphenate_limit_chars_item t : hyphenate_limit_chars_item =
+  Cursor.enum "hyphenate-limit-chars"
+    [ ("auto", (Auto : hyphenate_limit_chars_item)) ]
+    ~default:(fun t ->
+      match Cursor.peek t with
+      | Some (Component.Func _ as component) ->
+          let _ = Cursor.next t in
+          Chars (Values.read_number (Cursor.of_components [ component ]))
+      | _ ->
+          let n = Cursor.int t in
+          if n < 1 then
+            Cursor.err_invalid t "hyphenate-limit-chars must be >= 1";
+          Chars (Num (float_of_int n)))
+    t
+
 let rec read_hyphenate_limit_chars t : hyphenate_limit_chars =
-  let read_counts t =
-    let counts =
-      Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:3 Cursor.int t
+  let read_slots t =
+    let slots =
+      Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:3
+        read_hyphenate_limit_chars_item t
     in
-    let check_count n =
-      if n < 1 then Cursor.err_invalid t "hyphenate-limit-chars must be >= 1"
-    in
-    List.iter check_count counts;
     Cursor.ws t;
     Cursor.expect_eof t;
-    match counts with
+    match slots with
     | [ a ] -> (One a : hyphenate_limit_chars)
     | [ a; b ] -> Two (a, b)
     | [ a; b; c ] -> Three (a, b, c)
-    | _ -> Cursor.err_invalid t "expected one to three integers"
+    | _ -> Cursor.err_invalid t "expected one to three slots"
   in
   Cursor.enum_or_calls "hyphenate-limit-chars"
     [
-      ("auto", (Auto : hyphenate_limit_chars));
-      ("inherit", Inherit);
+      ("inherit", (Inherit : hyphenate_limit_chars));
       ("initial", Initial);
       ("unset", Unset);
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
     ~calls:[ ("var", fun t -> Var (read_var read_hyphenate_limit_chars t)) ]
-    ~default:read_counts t
+    ~default:read_slots t
 
 let rec read_white_space t : white_space =
   Cursor.ws t;

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4389,6 +4389,7 @@ let normalize_property_value : type a.
   | Webkit_mask_position -> map_preserve normalize_position_value value
   | Text_indent -> normalize_text_indent value
   | Animation_range -> normalize_animation_range value
+  | Hyphenate_limit_chars -> normalize_hyphenate_limit_chars ~ctx value
   | Animation_iteration_count -> normalize_animation_iteration_count ~ctx value
   | Webkit_animation_iteration_count ->
       normalize_animation_iteration_count ~ctx value

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1196,6 +1196,14 @@ val pp_text_spacing_trim : text_spacing_trim Pp.t
 val read_text_spacing_trim : Cursor.t -> text_spacing_trim
 (** [read_text_spacing_trim t] is the [text_spacing_trim] parsed from [t]. *)
 
+val pp_hyphenate_limit_chars_item : hyphenate_limit_chars_item Pp.t
+(** [pp_hyphenate_limit_chars_item] pretty-prints one [hyphenate-limit-chars]
+    slot. *)
+
+val read_hyphenate_limit_chars_item : Cursor.t -> hyphenate_limit_chars_item
+(** [read_hyphenate_limit_chars_item t] parses one [hyphenate-limit-chars] slot.
+*)
+
 val pp_hyphenate_limit_chars : hyphenate_limit_chars Pp.t
 (** [pp_hyphenate_limit_chars] pretty-prints a [hyphenate_limit_chars]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1475,11 +1475,22 @@ type text_spacing_trim =
   | Revert_layer
   | Var of text_spacing_trim var
 
+(** CSS Text 4 sec. 6.3.4: one slot of [hyphenate-limit-chars], a minimum
+    character count or [auto] for the count the UA picks. CSS Values 4 sec. 10.1
+    puts a math function where the count is. *)
+type hyphenate_limit_chars_item = Auto | Chars of number
+
+(** CSS Text 4 sec. 6.3.4 [hyphenate-limit-chars]: the minimum characters in a
+    hyphenated word, then before the hyphen, then after it. A missing third slot
+    repeats the second and a missing second is [auto], so [One Auto] is the
+    initial value. *)
 type hyphenate_limit_chars =
-  | Auto
-  | One of int
-  | Two of int * int
-  | Three of int * int * int
+  | One of hyphenate_limit_chars_item
+  | Two of hyphenate_limit_chars_item * hyphenate_limit_chars_item
+  | Three of
+      hyphenate_limit_chars_item
+      * hyphenate_limit_chars_item
+      * hyphenate_limit_chars_item
   | Inherit
   | Initial
   | Unset

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1445,7 +1445,15 @@ let vars_of_text_spacing_trim (value : Properties.text_spacing_trim) =
   match value with Var v -> [ V v ] | _ -> []
 
 let vars_of_hyphenate_limit_chars (value : Properties.hyphenate_limit_chars) =
-  match value with Var v -> [ V v ] | _ -> []
+  let slot (item : Properties.hyphenate_limit_chars_item) =
+    match item with Auto -> [] | Chars n -> vars_of_number_value n
+  in
+  match value with
+  | Var v -> [ V v ]
+  | One a -> slot a
+  | Two (a, b) -> slot a @ slot b
+  | Three (a, b, c) -> slot a @ slot b @ slot c
+  | _ -> []
 
 let vars_of_initial_letter (value : Properties.initial_letter) =
   match value with Var v -> [ V v ] | _ -> []

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1705,6 +1705,8 @@ let component_var_keeps_typed_value () =
     "stroke-dashoffset:calc(1px + var(--o))" "--o";
   check_visible_var "animation-iteration-count math var stays visible"
     "animation-iteration-count:calc(1 + var(--n))" "--n";
+  check_visible_var "hyphenate-limit-chars slot var stays visible"
+    "hyphenate-limit-chars:var(--n) 3" "--n";
   check_specified_value "overflow slots are unchanged"
     "overflow: var(--o) HIDDEN" "var(--o) hidden"
 

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -915,6 +915,10 @@ let check_grid_template_areas =
   check_value_cursor "grid_template_areas" read_grid_template_areas
     pp_grid_template_areas
 
+let check_hyphenate_limit_chars_item =
+  check_value_cursor "hyphenate_limit_chars_item"
+    read_hyphenate_limit_chars_item pp_hyphenate_limit_chars_item
+
 let check_hyphenate_limit_chars =
   check_value_cursor "hyphenate_limit_chars" read_hyphenate_limit_chars
     pp_hyphenate_limit_chars
@@ -5020,7 +5024,16 @@ let spec_generated_box_layout_edges () =
   check_flex_flow "row wrap";
   check_grid_line_pair ~expected:"1/span 2" "1 / span 2";
   check_grid_template_areas ~expected:"\"a a\"\"b c\"" "\"a a\" \"b c\"";
+  check_hyphenate_limit_chars_item "auto";
+  check_hyphenate_limit_chars_item "6";
   check_hyphenate_limit_chars "3 4 5";
+  (* CSS Text 4 sec. 6.3.4 gives every slot [auto | <integer>], and CSS Values 4
+     sec. 10.1 puts a math function where the integer is. *)
+  check_hyphenate_limit_chars "auto";
+  check_hyphenate_limit_chars "auto 3";
+  check_hyphenate_limit_chars "3 auto auto";
+  check_hyphenate_limit_chars "calc(1 + 2)";
+  check_hyphenate_limit_chars "auto calc(1 + 2)";
   check_initial_letter "2 3";
   check_initial_letter_align "border-box alphabetic";
   check_initial_letter_align_keyword "hanging";
@@ -5073,6 +5086,8 @@ let spec_generated_box_layout_edges () =
   neg_cursor read_grid_line_pair "span";
   neg_cursor read_grid_template_areas "\"a .\" \". a\"";
   neg_cursor read_hyphenate_limit_chars "3 4 5 6";
+  neg_cursor read_hyphenate_limit_chars "3.0";
+  neg_cursor read_hyphenate_limit_chars "calc(2px)";
   neg_cursor read_initial_letter ".5";
   neg_cursor read_initial_letter_align "alphabetic alphabetic";
   neg_cursor read_initial_letter_align_keyword "cap-height";


### PR DESCRIPTION
`hyphenate-limit-chars: auto 3`, the example CSS Text 4 sec. 6.3.4 gives, used to be dropped with a warning, and so did a math function in any slot. The property held one whole-value `auto` and three bare integers; each slot is now its own `auto`-or-count value.