### PR TITLE
animation: put none inside the timeline name list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,13 @@ entry points both moved.
   `flex: 1e999px` read where they were dropped with a warning. Exhaustive
   visitors must handle the new leaf (#1023)
 
+- `Cascade.Properties.timeline_name` carries `timeline_ident` entries and the
+  two timeline shorthands drop their `None` arm, so
+  `scroll-timeline-name: none, none` and `scroll-timeline: none, --a x` read
+  where they were dropped with a warning. Scroll-driven Animations 1 secs. 4.1
+  and 5.1 put `none` inside the list; `timeline-scope`, which keeps it for the
+  whole value (sec. 6), moves to its own `timeline_scope` (#1051)
+
 - `Cascade.Properties.timeline_axis` gains `Axes` and `timeline_inset` gains
   `Insets`, so `scroll-timeline-axis: block, inline` and
   `view-timeline-inset: auto, 1rem` read where they were dropped with a

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -8919,13 +8919,41 @@ type timeline_axis = Properties.timeline_axis =
   | Revert_layer
   | Var of timeline_axis var
 
+(** [none | <dashed-ident>#], shared by [scroll-timeline-name],
+    [view-timeline-name] and Scroll-driven Animations 1
+    {{:https://drafts.csswg.org/scroll-animations-1/#propdef-timeline-scope}
+     [timeline-scope]}. *)
+type timeline_ident = Properties.timeline_ident = None | Name of string
+
+type timeline_name = Properties.timeline_name =
+  | Names of timeline_ident list
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of timeline_name var
+
+(** Scroll-driven Animations 1
+    {{:https://drafts.csswg.org/scroll-animations-1/#propdef-timeline-scope}
+     [timeline-scope]}: [none | <dashed-ident>#], where [none] stands for the
+    whole value. *)
+type timeline_scope = Properties.timeline_scope =
+  | None
+  | Names of string list
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of timeline_scope var
+
 type timeline_shorthand_item = Properties.timeline_shorthand_item = {
-  name : string;
+  name : timeline_ident;
   axis : timeline_axis option;
 }
 
 type timeline_shorthand = Properties.timeline_shorthand =
-  | None
   | Timelines of timeline_shorthand_item list
   | Initial
   | Inherit
@@ -8935,13 +8963,12 @@ type timeline_shorthand = Properties.timeline_shorthand =
   | Var of timeline_shorthand var
 
 type view_timeline_shorthand_item = Properties.view_timeline_shorthand_item = {
-  name : string;
+  name : timeline_ident;
   axis : timeline_axis option;
   inset : Properties.timeline_inset option;
 }
 
 type view_timeline_shorthand = Properties.view_timeline_shorthand =
-  | None
   | Timelines of view_timeline_shorthand_item list
   | Initial
   | Inherit
@@ -8949,20 +8976,6 @@ type view_timeline_shorthand = Properties.view_timeline_shorthand =
   | Revert
   | Revert_layer
   | Var of view_timeline_shorthand var
-
-(** [none | <dashed-ident>#], shared by [scroll-timeline-name],
-    [view-timeline-name] and Scroll-driven Animations 1
-    {{:https://drafts.csswg.org/scroll-animations-1/#propdef-timeline-scope}
-     [timeline-scope]}. *)
-type timeline_name = Properties.timeline_name =
-  | None
-  | Names of string list
-  | Initial
-  | Inherit
-  | Unset
-  | Revert
-  | Revert_layer
-  | Var of timeline_name var
 
 (** One edge of Scroll-driven Animations 1
     {{:https://drafts.csswg.org/scroll-animations-1/#propdef-view-timeline-inset}
@@ -9047,7 +9060,7 @@ val view_timeline_axis : timeline_axis -> declaration
 val view_timeline_inset : timeline_inset -> declaration
 (** [view_timeline_inset v] is the [view-timeline-inset] property. *)
 
-val timeline_scope : timeline_name -> declaration
+val timeline_scope : timeline_scope -> declaration
 (** [timeline_scope v] is the [timeline-scope] property. *)
 
 val touch_action : touch_action -> declaration

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1808,7 +1808,7 @@ let read_motion_value : type a. a property -> Cursor.t -> declaration option =
   | View_timeline_axis -> Some (v View_timeline_axis (read_timeline_axis t))
   | View_timeline_inset -> Some (v View_timeline_inset (read_timeline_inset t))
   | View_timeline -> Some (v View_timeline (read_view_timeline_shorthand t))
-  | Timeline_scope -> Some (v Timeline_scope (read_timeline_name t))
+  | Timeline_scope -> Some (v Timeline_scope (read_timeline_scope t))
   | Perspective_origin ->
       Some (v Perspective_origin (read_perspective_origin t))
   | Transform_style -> Some (v Transform_style (read_transform_style t))

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -1147,7 +1147,7 @@ val view_timeline_axis : timeline_axis -> declaration
 val view_timeline_inset : timeline_inset -> declaration
 (** [view_timeline_inset v] is the [view-timeline-inset] property. *)
 
-val timeline_scope : timeline_name -> declaration
+val timeline_scope : timeline_scope -> declaration
 (** [timeline_scope v] is the [timeline-scope] property. *)
 
 val shape_image_threshold : shape_image_threshold -> declaration

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -340,9 +340,14 @@ let rec pp_timeline_axis : timeline_axis Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
-let rec pp_timeline_name : timeline_name Pp.t =
+let pp_timeline_ident : timeline_ident Pp.t =
  fun ctx -> function
-  | Var v -> pp_var pp_timeline_name ctx v
+  | None -> Pp.string ctx "none"
+  | Name name -> pp_ident ctx name
+
+let rec pp_timeline_scope : timeline_scope Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_timeline_scope ctx v
   | None -> Pp.string ctx "none"
   | Names names -> Pp.list ~sep:Pp.comma pp_ident ctx names
   | Initial -> Pp.string ctx "initial"
@@ -351,9 +356,19 @@ let rec pp_timeline_name : timeline_name Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+let rec pp_timeline_name : timeline_name Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_timeline_name ctx v
+  | Names names -> Pp.list ~sep:Pp.comma pp_timeline_ident ctx names
+  | Initial -> Pp.string ctx "initial"
+  | Inherit -> Pp.string ctx "inherit"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+
 let pp_timeline_shorthand_item : timeline_shorthand_item Pp.t =
  fun ctx { name; axis } ->
-  pp_ident ctx name;
+  pp_timeline_ident ctx name;
   match axis with
   | None -> ()
   | Some axis ->
@@ -402,7 +417,6 @@ let normalize_view_timeline_shorthand :
 
 let rec pp_timeline_shorthand : timeline_shorthand Pp.t =
  fun ctx -> function
-  | None -> Pp.string ctx "none"
   | Timelines items ->
       Pp.list ~sep:Pp.comma pp_timeline_shorthand_item ctx items
   | Initial -> Pp.string ctx "initial"
@@ -436,7 +450,7 @@ let rec pp_timeline_inset : timeline_inset Pp.t =
 
 let pp_view_timeline_shorthand_item : view_timeline_shorthand_item Pp.t =
  fun ctx { name; axis; inset } ->
-  pp_ident ctx name;
+  pp_timeline_ident ctx name;
   Option.iter
     (fun axis ->
       Pp.space ctx ();
@@ -450,7 +464,6 @@ let pp_view_timeline_shorthand_item : view_timeline_shorthand_item Pp.t =
 
 let rec pp_view_timeline_shorthand : view_timeline_shorthand Pp.t =
  fun ctx -> function
-  | None -> Pp.string ctx "none"
   | Timelines items ->
       Pp.list ~sep:Pp.comma pp_view_timeline_shorthand_item ctx items
   | Initial -> Pp.string ctx "initial"
@@ -759,11 +772,18 @@ let rec read_timeline_axis t : timeline_axis =
       | axes -> Axes axes)
     t
 
+(* Secs. 4.1 and 5.1 spell the name [[ none | <dashed-ident> ]#], so [none]
+   names one timeline among others rather than the whole value. *)
+let read_timeline_ident t : timeline_ident =
+  Cursor.enum "timeline-name"
+    [ ("none", (None : timeline_ident)) ]
+    ~default:(fun t -> (Name (read_dashed_ident t) : timeline_ident))
+    t
+
 let rec read_timeline_name t : timeline_name =
   Cursor.enum_or_var "timeline-name"
     [
-      ("none", (None : timeline_name));
-      ("initial", Initial);
+      ("initial", (Initial : timeline_name));
       ("inherit", Inherit);
       ("unset", Unset);
       ("revert", Revert);
@@ -771,15 +791,32 @@ let rec read_timeline_name t : timeline_name =
     ]
     ~var:(fun t -> (Var (Values.read_var read_timeline_name t) : timeline_name))
     ~default:(fun t ->
-      (Names (Cursor.list ~sep:Cursor.comma ~at_least:1 read_dashed_ident t)
+      (Names (Cursor.list ~sep:Cursor.comma ~at_least:1 read_timeline_ident t)
         : timeline_name))
+    t
+
+(* Sec. 6 keeps [none] out of the list here: [timeline-scope] is [none |
+   <dashed-ident>#], so the keyword stands for the whole value. *)
+let rec read_timeline_scope t : timeline_scope =
+  Cursor.enum_or_var "timeline-scope"
+    [
+      ("none", (None : timeline_scope));
+      ("initial", Initial);
+      ("inherit", Inherit);
+      ("unset", Unset);
+      ("revert", Revert);
+      ("revert-layer", Revert_layer);
+    ]
+    ~var:(fun t ->
+      (Var (Values.read_var read_timeline_scope t) : timeline_scope))
+    ~default:(fun t ->
+      (Names (Cursor.list ~sep:Cursor.comma ~at_least:1 read_dashed_ident t)
+        : timeline_scope))
     t
 
 let read_timeline_shorthand_item t : timeline_shorthand_item =
   Cursor.ws t;
-  let name = Cursor.ident ~keep_case:true t in
-  if not (Custom_property_name.is_valid name) then
-    Cursor.err_invalid t "timeline name";
+  let name = read_timeline_ident t in
   Cursor.ws t;
   let axis = Cursor.option read_timeline_axis_keyword t in
   { name; axis }
@@ -787,8 +824,7 @@ let read_timeline_shorthand_item t : timeline_shorthand_item =
 let rec read_timeline_shorthand t : timeline_shorthand =
   Cursor.enum_or_var "timeline"
     [
-      ("none", (None : timeline_shorthand));
-      ("initial", Initial);
+      ("initial", (Initial : timeline_shorthand));
       ("inherit", Inherit);
       ("unset", Unset);
       ("revert", Revert);
@@ -844,9 +880,7 @@ let read_view_timeline_shorthand_item t : view_timeline_shorthand_item =
      [<'view-timeline-axis'> || <'view-timeline-inset'>]?, so try each missing
      slot until neither consumes input. *)
   Cursor.ws t;
-  let name = Cursor.ident ~keep_case:true t in
-  if not (Custom_property_name.is_valid name) then
-    Cursor.err_invalid t "timeline name";
+  let name = read_timeline_ident t in
   let axis = ref Option.None in
   let inset = ref Option.None in
   let try_axis () =
@@ -877,8 +911,7 @@ let read_view_timeline_shorthand_item t : view_timeline_shorthand_item =
 let rec read_view_timeline_shorthand t : view_timeline_shorthand =
   Cursor.enum_or_var "view-timeline"
     [
-      ("none", (None : view_timeline_shorthand));
-      ("initial", Initial);
+      ("initial", (Initial : view_timeline_shorthand));
       ("inherit", Inherit);
       ("unset", Unset);
       ("revert", Revert);

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -5085,7 +5085,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | View_timeline_axis -> pp pp_timeline_axis
   | View_timeline_inset -> pp pp_timeline_inset
   | View_timeline -> pp pp_view_timeline_shorthand
-  | Timeline_scope -> pp pp_timeline_name
+  | Timeline_scope -> pp pp_timeline_scope
   | Perspective_origin -> pp pp_perspective_origin
   | Object_position -> pp pp_position_value
   | Rotate -> pp pp_rotate_value

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -172,11 +172,24 @@ val pp_timeline_axis : timeline_axis Pp.t
 val read_timeline_axis : Cursor.t -> timeline_axis
 (** [read_timeline_axis t] parses a timeline axis. *)
 
+val pp_timeline_ident : timeline_ident Pp.t
+(** [pp_timeline_ident] pretty-prints one timeline name. *)
+
+val read_timeline_ident : Cursor.t -> timeline_ident
+(** [read_timeline_ident t] parses one timeline name. *)
+
 val pp_timeline_name : timeline_name Pp.t
 (** [pp_timeline_name] pretty-prints a timeline name list. *)
 
 val read_timeline_name : Cursor.t -> timeline_name
-(** [read_timeline_name t] parses [view-timeline-name] and [timeline-scope]. *)
+(** [read_timeline_name t] parses [scroll-timeline-name] and
+    [view-timeline-name]. *)
+
+val pp_timeline_scope : timeline_scope Pp.t
+(** [pp_timeline_scope] pretty-prints a [timeline-scope]. *)
+
+val read_timeline_scope : Cursor.t -> timeline_scope
+(** [read_timeline_scope t] parses [timeline-scope]. *)
 
 val pp_timeline_inset : timeline_inset Pp.t
 (** [pp_timeline_inset] pretty-prints [view-timeline-inset]. *)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4246,9 +4246,12 @@ type timeline_axis =
   | Revert_layer
   | Var of timeline_axis var
 
+(** Scroll-driven Animations 1 secs. 4.1 and 5.1: one timeline name, [none] or a
+    [<dashed-ident>]. *)
+type timeline_ident = None | Name of string
+
 type timeline_name =
-  | None
-  | Names of string list
+  | Names of timeline_ident list
   | Initial
   | Inherit
   | Unset
@@ -4256,10 +4259,25 @@ type timeline_name =
   | Revert_layer
   | Var of timeline_name var
 
-type timeline_shorthand_item = { name : string; axis : timeline_axis option }
+(** Scroll-driven Animations 1 sec. 6 [timeline-scope]: [none] or a list of the
+    names an element makes visible to its descendants. [none] stands for the
+    whole value here, unlike the name of one timeline. *)
+type timeline_scope =
+  | None
+  | Names of string list
+  | Initial
+  | Inherit
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of timeline_scope var
+
+type timeline_shorthand_item = {
+  name : timeline_ident;
+  axis : timeline_axis option;
+}
 
 type timeline_shorthand =
-  | None
   | Timelines of timeline_shorthand_item list
   | Initial
   | Inherit
@@ -4281,13 +4299,12 @@ type timeline_inset =
   | Var of timeline_inset var
 
 type view_timeline_shorthand_item = {
-  name : string;
+  name : timeline_ident;
   axis : timeline_axis option;
   inset : timeline_inset option;
 }
 
 type view_timeline_shorthand =
-  | None
   | Timelines of view_timeline_shorthand_item list
   | Initial
   | Inherit
@@ -5199,7 +5216,7 @@ type 'a property =
   | View_timeline_axis : timeline_axis property
   | View_timeline_inset : timeline_inset property
   | View_timeline : view_timeline_shorthand property
-  | Timeline_scope : timeline_name property
+  | Timeline_scope : timeline_scope property
   | Perspective : length property
   | Perspective_origin : perspective_origin property
   | Transform_style : transform_style property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -2589,7 +2589,6 @@ let duo_scroll_timeline idx i =
     in
     let value : Properties.timeline_shorthand option =
       match (name : Properties.timeline_name option) with
-      | Some None when Option.is_none axis -> Some None
       | Some (Names [ n ]) -> Some (Timelines [ { name = n; axis } ])
       | _ -> Option.None
     in
@@ -3809,8 +3808,6 @@ let view_timeline_item parts : Properties.view_timeline_shorthand_item option =
   in
   match (name : Properties.timeline_name option) with
   | Some (Names [ n ]) -> Some { name = n; axis; inset }
-  | Some None when Option.is_none axis && Option.is_none inset ->
-      Some { name = "none"; axis; inset }
   | _ -> Option.None
 
 let view_timeline_of_run raw =

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1833,6 +1833,9 @@ let vars_of_user_select (value : Properties.user_select) =
 let vars_of_timeline_axis (value : Properties.timeline_axis) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_timeline_scope (value : Properties.timeline_scope) =
+  match value with Var v -> [ V v ] | _ -> []
+
 let vars_of_timeline_name (value : Properties.timeline_name) =
   match value with Var v -> [ V v ] | _ -> []
 
@@ -2563,7 +2566,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | View_timeline_axis, value -> vars_of_timeline_axis value
   | View_timeline_inset, value -> vars_of_timeline_inset value
   | View_timeline, value -> vars_of_view_timeline_shorthand value
-  | Timeline_scope, value -> vars_of_timeline_name value
+  | Timeline_scope, value -> vars_of_timeline_scope value
   | Webkit_appearance, value -> vars_of_webkit_appearance value
   | Webkit_background_clip, value -> vars_of_background_box value
   | Webkit_box_decoration_break, value -> vars_of_box_decoration_break value

--- a/test/test_css.ml
+++ b/test/test_css.ml
@@ -2619,13 +2619,15 @@ let scroll_driven_animation_builders () =
   check "animation-range-end:cover 100%"
     (Css.animation_range_end (Named (Cover, Some (Pct 100.))));
   check "scroll-timeline:--a block"
-    (Css.scroll_timeline (Timelines [ { name = "--a"; axis = Some Block } ]));
-  check "scroll-timeline-name:--a" (Css.scroll_timeline_name (Names [ "--a" ]));
+    (Css.scroll_timeline
+       (Timelines [ { name = Name "--a"; axis = Some Block } ]));
+  check "scroll-timeline-name:--a"
+    (Css.scroll_timeline_name (Names [ Name "--a" ]));
   check "scroll-timeline-axis:inline" (Css.scroll_timeline_axis Inline);
   check "view-timeline:--a"
     (Css.view_timeline
-       (Timelines [ { name = "--a"; axis = None; inset = None } ]));
-  check "view-timeline-name:--a" (Css.view_timeline_name (Names [ "--a" ]));
+       (Timelines [ { name = Name "--a"; axis = None; inset = None } ]));
+  check "view-timeline-name:--a" (Css.view_timeline_name (Names [ Name "--a" ]));
   check "view-timeline-axis:y" (Css.view_timeline_axis Y);
   check "view-timeline-inset:auto"
     (Css.view_timeline_inset (Inset (Auto, None)));

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -1226,8 +1226,14 @@ let check_timeline_inset_item =
   check_value_cursor "timeline_inset_item" read_timeline_inset_item
     pp_timeline_inset_item
 
+let check_timeline_ident =
+  check_value_cursor "timeline_ident" read_timeline_ident pp_timeline_ident
+
 let check_timeline_name =
   check_value_cursor "name" read_timeline_name pp_timeline_name
+
+let check_timeline_scope =
+  check_value_cursor "timeline_scope" read_timeline_scope pp_timeline_scope
 
 let check_timeline_shorthand_item =
   check_value_cursor "timeline_shorthand_item" read_timeline_shorthand_item
@@ -5372,8 +5378,20 @@ let spec_generated_text_timeline_edges () =
      too. *)
   check_timeline_inset_item "calc(50% + 10px)";
   check_timeline_name ~expected:"--main,--alt" "--main, --alt";
+  check_timeline_ident "none";
+  check_timeline_ident "--main";
+  (* Scroll-driven Animations 1 secs. 4.1 and 5.1 spell the name [[ none |
+     <dashed-ident> ]#], so [none] names one timeline among others. *)
+  check_timeline_name "none,none";
+  check_timeline_name ~expected:"--main,none" "--main, none";
+  (* Sec. 6 keeps [timeline-scope] at [none | <dashed-ident>#], where the
+     keyword stands for the whole value. *)
+  check_timeline_scope "none";
+  check_timeline_scope ~expected:"--main,--alt" "--main, --alt";
+  neg_cursor ~allow_partial:true read_timeline_scope "none,--main";
   check_timeline_shorthand_item "--main block";
   check_timeline_shorthand_item "--main";
+  check_timeline_shorthand_item "none";
   check_view_transition_class "card active";
   check_view_transition_name "match-element";
   neg_cursor ~allow_partial:true read_text_box "trim-start trim-end";

--- a/test/test_shorthand.ml
+++ b/test/test_shorthand.ml
@@ -761,10 +761,11 @@ let test_timeline_range_composes () =
     ".x{scroll-timeline-name:--t;scroll-timeline-axis:block}";
   sheet_optimizes_to ~into:".x{scroll-timeline:none}"
     ".x{scroll-timeline-name:none;scroll-timeline-axis:block}";
-  (* [scroll-timeline: none] sets the axis to [block], so a named axis beside an
-     unnamed timeline has no shorthand spelling. *)
-  sheet_optimizes_to
-    ~into:".x{scroll-timeline-name:none;scroll-timeline-axis:inline}"
+  (* Sec. 4.3 spells the shorthand [<name> <axis>?], and the name half is [none
+     | <dashed-ident>], so [none] pairs with an axis of its own. Chrome 153
+     computes [scroll-timeline: none inline] to the same two longhands and
+     serialises them back into it. *)
+  sheet_optimizes_to ~into:".x{scroll-timeline:none inline}"
     ".x{scroll-timeline-name:none;scroll-timeline-axis:inline}";
   (* Mixed importance is not one declaration. *)
   sheet_optimizes_to


### PR DESCRIPTION
`scroll-timeline-name: none, none` and `scroll-timeline: none, --a x` used to be dropped with a warning. Scroll-driven Animations 1 secs. 4.1 and 5.1 spell the name `[ none | <dashed-ident> ]#`, so `none` names one timeline among others rather than the whole value.

Sec. 6 keeps `none` whole-value for `timeline-scope`, so that property gets its own type here rather than sharing `timeline_name`.