### PR TITLE
animation: read the animation range as a list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,13 @@ entry points both moved.
   `flex: 1e999px` read where they were dropped with a warning. Exhaustive
   visitors must handle the new leaf (#1023)
 
+- `Cascade.Properties.animation_range_item` gains `Items` and `animation_range`
+  gains `Ranges`, so `animation-range: normal, normal` and
+  `animation-range-start: 10%, normal` read where they were dropped with a
+  warning. Scroll-driven Animations 1 secs. 3.1 to 3.3 put a `#` on both ends
+  and on the shorthand. Exhaustive visitors must handle the two new leaves
+  (#1052)
+
 - `Cascade.Properties.timeline_name` carries `timeline_ident` entries and the
   two timeline shorthands drop their `None` arm, so
   `scroll-timeline-name: none, none` and `scroll-timeline: none, --a x` read

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -9008,6 +9008,7 @@ type animation_range_name = Properties.animation_range_name =
 (** Sec. 6.2: one end of [animation-range]. *)
 type animation_range_item = Properties.animation_range_item =
   | Normal
+  | Items of animation_range_item list
   | Offset of length_percentage
   | Named of animation_range_name * length_percentage option
   | Initial
@@ -9020,6 +9021,7 @@ type animation_range_item = Properties.animation_range_item =
 (** Sec. 6.2 [animation-range]: the start then the end. *)
 type animation_range = Properties.animation_range =
   | Range of animation_range_item * animation_range_item option
+  | Ranges of animation_range list
   | Initial
   | Inherit
   | Unset

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -255,6 +255,7 @@ let pp_animation_range_name : animation_range_name Pp.t =
 let rec pp_animation_range_item : animation_range_item Pp.t =
  fun ctx -> function
   | Normal -> Pp.string ctx "normal"
+  | Items items -> Pp.list ~sep:Pp.comma pp_animation_range_item ctx items
   | Offset lp -> pp_length_percentage ~always:true ctx lp
   | Named (name, None) -> pp_animation_range_name ctx name
   | Named (name, Some lp) ->
@@ -282,6 +283,7 @@ let animation_range_needs_space ctx =
 let rec pp_animation_range : animation_range Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_animation_range ctx v
+  | Ranges ranges -> Pp.list ~sep:Pp.comma pp_animation_range ctx ranges
   | Range (first, None) -> pp_animation_range_item ctx first
   | Range (first, Some Normal) -> pp_animation_range_item ctx first
   | Range
@@ -2080,7 +2082,8 @@ let read_range_length_percentage t =
 
 let read_animation_range_offset t : length_percentage option =
   Cursor.ws t;
-  if Cursor.is_done t then (None : length_percentage option)
+  if Cursor.is_done t || Cursor.peek_comma t then
+    (None : length_percentage option)
   else
     match Option.map String.lowercase_ascii_preserve (Cursor.peek_ident t) with
     | Some "normal" -> (None : length_percentage option)
@@ -2088,32 +2091,41 @@ let read_animation_range_offset t : length_percentage option =
         (None : length_percentage option)
     | _ -> (Some (read_range_length_percentage t) : length_percentage option)
 
+(* Secs. 3.1 and 3.2 spell each end [[ normal | <length-percentage> |
+   <timeline-range-name> <length-percentage>? ]#], one entry per animation, so
+   [normal] names one end among others rather than the whole value. *)
+let read_animation_range_one t : animation_range_item =
+  Cursor.ws t;
+  match Option.map String.lowercase_ascii_preserve (Cursor.peek_ident t) with
+  | Some "normal" ->
+      let _ = Cursor.ident t in
+      (Normal : animation_range_item)
+  | Some name when is_animation_range_name name ->
+      let name : animation_range_name = read_animation_range_name t in
+      let lp = read_animation_range_offset t in
+      Named (name, lp)
+  | _ -> Offset (read_range_length_percentage t)
+
 let rec read_animation_range_item t : animation_range_item =
   let keywords : (string * animation_range_item) list =
     [
-      ("normal", (Normal : animation_range_item));
-      ("initial", Initial);
+      ("initial", (Initial : animation_range_item));
       ("inherit", Inherit);
       ("unset", Unset);
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
   in
-  let read_item t =
-    Cursor.ws t;
-    match Cursor.peek_ident t with
-    | Some name when is_animation_range_name name ->
-        let name : animation_range_name = read_animation_range_name t in
-        let lp = read_animation_range_offset t in
-        (Named (name, lp) : animation_range_item)
-    | _ ->
-        let lp = read_range_length_percentage t in
-        Offset lp
-  in
   Cursor.enum_or_var "animation-range-item" keywords
     ~var:(fun t ->
       (Var (Values.read_var read_animation_range_item t) : animation_range_item))
-    ~default:read_item t
+    ~default:(fun t ->
+      match
+        Cursor.list ~sep:Cursor.comma ~at_least:1 read_animation_range_one t
+      with
+      | [ item ] -> item
+      | items -> Items items)
+    t
 
 let rec read_animation_range t : animation_range =
   let keywords : (string * animation_range) list =
@@ -2125,32 +2137,22 @@ let rec read_animation_range t : animation_range =
       ("revert-layer", Revert_layer);
     ]
   in
+  (* Sec. 3.3 spells the shorthand [[ <start> <end>? ]#], so a comma ends one
+     entry the way the end of the value does. *)
   let read_range t =
-    let read_single t =
-      Cursor.ws t;
-      match
-        Option.map String.lowercase_ascii_preserve (Cursor.peek_ident t)
-      with
-      | Some "normal" ->
-          let _ = Cursor.ident t in
-          (Normal : animation_range_item)
-      | Some name when List.mem name Keyframe.timeline_range_names ->
-          let name : animation_range_name = read_animation_range_name t in
-          let lp = read_animation_range_offset t in
-          (Named (name, lp) : animation_range_item)
-      | _ ->
-          let lp = read_range_length_percentage t in
-          Offset lp
-    in
-    let first = read_single t in
+    let first = read_animation_range_one t in
     Cursor.ws t;
-    if Cursor.is_done t then Range (first, None)
+    if Cursor.is_done t || Cursor.peek_comma t then Range (first, None)
     else
-      let second = read_single t in
+      let second = read_animation_range_one t in
       Range (first, Some second)
   in
   (Cursor.enum_or_var "animation-range" keywords
      ~var:(fun t ->
        (Var (Values.read_var read_animation_range t) : animation_range))
-     ~default:read_range t
+     ~default:(fun t ->
+       match Cursor.list ~sep:Cursor.comma ~at_least:1 read_range t with
+       | [ range ] -> range
+       | ranges -> Ranges ranges)
+     t
     : animation_range)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3664,6 +3664,7 @@ type animation_range_name =
 
 type animation_range_item =
   | Normal
+  | Items of animation_range_item list
   | Offset of length_percentage
   | Named of animation_range_name * length_percentage option
   | Initial
@@ -3675,6 +3676,7 @@ type animation_range_item =
 
 type animation_range =
   | Range of animation_range_item * animation_range_item option
+  | Ranges of animation_range list
   | Initial
   | Inherit
   | Unset

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1166,17 +1166,19 @@ let vars_of_font_synthesis (value : Properties.font_synthesis) =
 let vars_of_animation_timeline (value : Properties.animation_timeline) =
   match value with Var v -> [ V v ] | _ -> []
 
-let vars_of_animation_range_item (value : Properties.animation_range_item) =
+let rec vars_of_animation_range_item (value : Properties.animation_range_item) =
   match value with
   | Var v -> [ V v ]
   | Normal -> []
+  | Items items -> List.concat_map vars_of_animation_range_item items
   | Offset lp | Named (_, Some lp) -> vars_of_length_percentage lp
   | Named (_, None) -> []
   | Initial | Inherit | Unset | Revert | Revert_layer -> []
 
-let vars_of_animation_range (value : Properties.animation_range) =
+let rec vars_of_animation_range (value : Properties.animation_range) =
   match value with
   | Var v -> [ V v ]
+  | Ranges ranges -> List.concat_map vars_of_animation_range ranges
   | Range (first, second) ->
       vars_of_animation_range_item first
       @ Option.fold ~none:[] ~some:vars_of_animation_range_item second

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4925,6 +4925,14 @@ let spec_generated_animation_font_edges () =
   check_animation_name ~expected:"fade,slide" "fade, slide";
   check_animation_range ~expected:"entry 0%exit 100%" "entry 0% exit 100%";
   check_animation_range "entry";
+  (* Scroll-driven Animations 1 secs. 3.1 to 3.3 put a [#] on both ends and on
+     the shorthand, one entry per animation. *)
+  check_animation_range "normal,normal";
+  check_animation_range "cover,contain";
+  check_animation_range ~expected:"entry 10%exit 90%,cover"
+    "entry 10% exit 90%, cover";
+  check_animation_range_item ~expected:"10%,normal" "10%, normal";
+  check_animation_range_item ~expected:"cover,contain" "cover, contain";
   (* Scroll Animations 1 sec. 5.1 names [normal], a length-percentage and a
      range name, so the intrinsic-sizing keywords a bare length would accept are
      out. *)


### PR DESCRIPTION
`animation-range: normal, normal` and `animation-range-start: 10%, normal` used to be dropped with a warning. Scroll-driven Animations 1 secs. 3.1 to 3.3 put a `#` on the shorthand and on both its ends, one entry per animation.