### PR TITLE
gaps: read column-rule as a list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,11 @@ entry points both moved.
   `flex: 1e999px` read where they were dropped with a warning. Exhaustive
   visitors must handle the new leaf (#1023)
 
+- `column-rule` carries a list where it carried a single value, so
+  `column-rule: 1px solid red, 2px dashed blue` reads. CSS Gaps 1 sec. 4.4
+  spells the shorthand `<gap-rule>#`, the same list its longhands took in
+  #1024. A caller writing one line passes a one-element list (#1053)
+
 - `Cascade.Properties.animation_range_item` gains `Items` and `animation_range`
   gains `Ranges`, so `animation-range: normal, normal` and
   `animation-range-start: 10%, normal` read where they were dropped with a

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -6075,7 +6075,7 @@ val border :
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/border} border}
     shorthand property. *)
 
-val column_rule : border -> declaration
+val column_rule : border list -> declaration
 (** [column_rule v] is the
     {{:https://developer.mozilla.org/en-US/docs/Web/CSS/column-rule}
      column-rule} shorthand property. *)

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -553,7 +553,7 @@ let property_value_uses_color (type a) (p : Values.color -> bool)
   | Border_bottom -> border_uses_color p value
   | Border_left -> border_uses_color p value
   | Border_block -> border_uses_color p value
-  | Column_rule -> border_uses_color p value
+  | Column_rule -> List.exists (border_uses_color p) value
   | Outline -> outline_uses_color p value
   | Background_image -> List.exists (background_image_uses_color p) value
   | Webkit_mask_image -> background_image_uses_color p value
@@ -1852,7 +1852,12 @@ let read_object_transition_value : type a.
   | Column_height -> Some (v Column_height (read_column_height t))
   | Column_wrap -> Some (v Column_wrap (read_column_wrap t))
   | Column_count -> Some (v Column_count (read_column_count t))
-  | Column_rule -> Some (v Column_rule (read_border t))
+  (* CSS Gaps 1 sec. 4.4 spells [column-rule] as a [<gap-rule>#], one entry per
+     rule line, the same list its longhands carry. *)
+  | Column_rule ->
+      Some
+        (v Column_rule
+           (Cursor.list ~sep:Cursor.comma ~at_least:1 read_border t))
   (* CSS Gaps 1 sec. 4 gives each gap decoration longhand a comma-separated
      list, one entry per rule line. *)
   | Column_rule_color ->

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -2369,7 +2369,7 @@ val page_break_inside : page_break_inside_value -> declaration
 val columns : columns_value -> declaration
 (** [columns v] is the CSS [columns] property for multi-column layout. *)
 
-val column_rule : border -> declaration
+val column_rule : border list -> declaration
 (** [column_rule v] is the CSS [column-rule] shorthand property. *)
 
 val border_block : border -> declaration

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3933,10 +3933,11 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
   | Font_variant_alternates, value -> value
   | Font_variant, value -> value
   | ( ( Border | Border_block | Border_block_start | Border_block_end
-      | Border_inline | Border_inline_start | Border_inline_end | Column_rule
-      | Border_top | Border_right | Border_bottom | Border_left ),
+      | Border_inline | Border_inline_start | Border_inline_end | Border_top
+      | Border_right | Border_bottom | Border_left ),
       value ) ->
       value
+  | Column_rule, value -> value
   | Background, value -> value
   | Tab_size, value -> value
   | Zoom, value -> value
@@ -4443,7 +4444,7 @@ let normalize_property_value : type a.
   | Border_right -> normalize_border ~lossless value
   | Border_bottom -> normalize_border ~lossless value
   | Border_left -> normalize_border ~lossless value
-  | Column_rule -> normalize_border ~lossless value
+  | Column_rule -> List.map (normalize_border ~lossless) value
   | Outline -> normalize_outline ~lossless value
   | Box_shadow -> normalize_shadow ~lossless value
   | Text_shadow -> map_preserve (normalize_text_shadow ~lossless) value
@@ -4842,7 +4843,7 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Column_height -> pp pp_column_height
   | Column_wrap -> pp pp_column_wrap
   | Column_count -> pp pp_column_count
-  | Column_rule -> pp pp_border
+  | Column_rule -> pp (Pp.list ~sep:Pp.comma pp_border)
   | Column_span -> pp pp_column_span
   | Transform_style -> pp pp_transform_style
   | Backface_visibility -> pp pp_backface_visibility

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -5246,7 +5246,7 @@ type 'a property =
   | Column_height : column_height property
   | Column_wrap : column_wrap property
   | Column_count : column_count property
-  | Column_rule : border property
+  | Column_rule : border list property
       (** CSS Gaps 1 sec. 4 gives the three longhands below a comma-separated
           list, one entry per gap decoration line. *)
   | Column_rule_width : border_width list property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -3702,7 +3702,7 @@ let column_rule_part = function
       Some (line_of_color color)
   | _ -> None
 
-let try_compose_line_at ~part_of ~property idx i =
+let try_compose_line_at ~part_of ~build idx i =
   let n = Rule_index.length idx in
   if i + 2 >= n then None
   else
@@ -3717,9 +3717,8 @@ let try_compose_line_at ~part_of ~property idx i =
         | [ Some (p1, s1); Some (p2, s2); Some (p3, s3) ]
           when List.length (List.sort_uniq compare [ p1; p2; p3 ]) = 3 ->
             Some
-              (Declaration.v
+              (build
                  ~important:(is_important (List.hd raw))
-                 property
                  (Shorthand (merge_line s1 (merge_line s2 s3))
                    : Properties.border))
         | _ -> None
@@ -3748,26 +3747,32 @@ let border_inline_axis_part = function
   | _ -> None
 
 let line_families =
+  let one property ~important value = Declaration.v ~important property value in
+  (* Sec. 4.4 writes [column-rule] as a [<gap-rule>#], so one composed line is a
+     one-entry list rather than a bare value. *)
+  let listed property ~important value =
+    Declaration.v ~important property [ value ]
+  in
   Properties.
     [
-      (border_top_part, Border_top);
-      (border_right_part, Border_right);
-      (border_bottom_part, Border_bottom);
-      (border_left_part, Border_left);
-      (border_block_start_part, Border_block_start);
-      (border_block_end_part, Border_block_end);
-      (border_inline_start_part, Border_inline_start);
-      (border_inline_end_part, Border_inline_end);
-      (column_rule_part, Column_rule);
-      (border_block_axis_part, Border_block);
-      (border_inline_axis_part, Border_inline);
+      (border_top_part, one Border_top);
+      (border_right_part, one Border_right);
+      (border_bottom_part, one Border_bottom);
+      (border_left_part, one Border_left);
+      (border_block_start_part, one Border_block_start);
+      (border_block_end_part, one Border_block_end);
+      (border_inline_start_part, one Border_inline_start);
+      (border_inline_end_part, one Border_inline_end);
+      (column_rule_part, listed Column_rule);
+      (border_block_axis_part, one Border_block);
+      (border_inline_axis_part, one Border_inline);
     ]
 
 let compose_line_via_index idx =
   List.iter
-    (fun (part_of, property) ->
+    (fun (part_of, build) ->
       compose_fixed3_via_index idx
-        ~try_compose:(try_compose_line_at ~part_of ~property))
+        ~try_compose:(try_compose_line_at ~part_of ~build))
     line_families
 
 (* CSS Scroll Animations 1 sec. 5.2: [view-timeline] is [<name> <axis>?

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -2297,7 +2297,7 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Column_height, value -> vars_of_column_height value
   | Column_wrap, value -> vars_of_column_wrap value
   | Column_count, value -> vars_of_column_count value
-  | Column_rule, value -> vars_of_border value
+  | Column_rule, value -> List.concat_map vars_of_border value
   | Column_rule_color, value -> List.concat_map vars_of_color value
   | Column_rule_width, value -> List.concat_map vars_of_border_width value
   | Column_rule_style, value -> List.concat_map vars_of_border_style value

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1340,6 +1340,11 @@ let border_line_width () =
     "column-rule-width: 1px, 2px";
   check_declaration ~expected:"column-rule-color:red,blue"
     ~optimized:"column-rule-color:red,#00f" "column-rule-color: red, blue";
+  (* Sec. 4.4 writes the shorthand [<gap-rule>#] over the same list. *)
+  check_declaration ~expected:"column-rule:0,0" "column-rule: 0, 0";
+  check_declaration ~expected:"column-rule:1px solid red,2px dashed blue"
+    ~optimized:"column-rule:1px solid red,2px dashed#00f"
+    "column-rule: 1px solid red, 2px dashed blue";
   neg_cursor read_declaration "column-rule-style: dotted dashed";
   check_declaration ~expected:"border-inline-start:medium dotted red"
     ~optimized:"border-inline-start:dotted red"


### PR DESCRIPTION
`column-rule: 1px solid red, 2px dashed blue` used to be dropped with a warning. CSS Gaps 1 sec. 4.4 spells the shorthand `<gap-rule>#`, one entry per rule line, which is the list its three longhands already carry.

Follow-up to #1024.