### PR TITLE
text: measure tab-size in numbers, not integers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,13 @@ entry points both moved.
   `flex: 1e999px` read where they were dropped with a warning. Exhaustive
   visitors must handle the new leaf (#1023)
 
+- The `Int` of `Cascade.Properties.tab_size` becomes `Number of number`, so
+  `tab-size: 10.5` reads where it was dropped with a warning and
+  `tab-size: calc(1 + 2)` keeps the authored call until it is minified. CSS
+  Text 4 sec. 4.4 measures the tab stop in advance widths, a `<number [0,inf]>`
+  rather than an integer. A caller building a literal writes `Number (Num 4.)`
+  (#1054)
+
 - `column-rule` carries a list where it carried a single value, so
   `column-rule: 1px solid red, 2px dashed blue` reads. CSS Gaps 1 sec. 4.4
   spells the shorthand `<gap-rule>#`, the same list its longhands took in

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -9321,7 +9321,7 @@ val moz_appearance : appearance -> declaration
 (** [moz_appearance v] is the [-moz-appearance] property. *)
 
 type tab_size = Properties.tab_size =
-  | Int of int
+  | Number of number
   | Length of length
   | Initial
   | Inherit

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -3357,7 +3357,7 @@ let border ?width ?style ?color () =
   v Border border_value
 
 let border_block value = v Border_block value
-let tab_size value = v Tab_size (Int value : tab_size)
+let tab_size value = v Tab_size (Number (Num (float_of_int value)) : tab_size)
 let tab_size_value value = v Tab_size (value : tab_size)
 let scrollbar_width value = v Scrollbar_width value
 let scrollbar_color value = v Scrollbar_color value

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -868,9 +868,17 @@ let normalize_text_shadow ?(lossless = false) : text_shadow -> text_shadow =
            })
   | other -> other
 
+let normalize_tab_size ~ctx : tab_size -> tab_size =
+ fun value ->
+  match value with
+  | Number n ->
+      let n' = Values.normalize_number ~ctx n in
+      if n' == n then value else Number n'
+  | other -> other
+
 let rec pp_tab_size : tab_size Pp.t =
  fun ctx -> function
-  | Int i -> Pp.int ctx i
+  | Number n -> Values.pp_number ctx n
   | Length len -> pp_length ~always:true ctx len
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
@@ -2087,25 +2095,26 @@ let rec read_text_size_adjust t : text_size_adjust =
         t
 
 let rec read_tab_size (t : Cursor.t) : tab_size =
-  let number_value t i =
-    if i < 0 then Cursor.err_invalid t "negative tab-size integer";
-    (Int i : tab_size)
+  let checked t (n : number) : tab_size =
+    (match n with
+    | Num f when f < 0. -> Cursor.err_invalid t "negative tab-size"
+    | _ -> ());
+    Number n
   in
+  (* CSS Text 4 sec. 4.4: [<number [0,inf]> | <length [0,inf]>], so a math
+     function lands in whichever slot its result type names, and only a literal
+     has a value to turn away. The measure is a count of advance widths rather
+     than an integer, so a fraction is one. *)
   let read_value t =
-    match Cursor.integer_opt t with
-    | Some i -> number_value t i
-    | None ->
-        (* CSS Text 4 (ED) sec. 4.4: [<number> | <length>], so a math function
-           lands in whichever slot its result type names. *)
-        Cursor.one_of
-          [
-            (fun t -> number_value t (Values.read_integer "tab-size" t));
-            (fun t ->
-              Length
-                (Values.read_length ~allow_negative:false ~with_keywords:false
-                   ~length_only:true t));
-          ]
-          t
+    Cursor.one_of
+      [
+        (fun t -> checked t (Values.read_number t));
+        (fun t ->
+          Length
+            (Values.read_length ~allow_negative:false ~with_keywords:false
+               ~length_only:true t));
+      ]
+      t
   in
   Cursor.enum_or_var "tab-size"
     [

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4390,6 +4390,7 @@ let normalize_property_value : type a.
   | Webkit_mask_position -> map_preserve normalize_position_value value
   | Text_indent -> normalize_text_indent value
   | Animation_range -> normalize_animation_range value
+  | Tab_size -> normalize_tab_size ~ctx value
   | Hyphenate_limit_chars -> normalize_hyphenate_limit_chars ~ctx value
   | Animation_iteration_count -> normalize_animation_iteration_count ~ctx value
   | Webkit_animation_iteration_count ->

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -210,8 +210,10 @@ type shape_image_threshold =
   | Revert_layer
   | Var of shape_image_threshold var
 
+(** CSS Text 4 sec. 4.4 [tab-size]: [<number [0,inf]> | <length [0,inf]>], the
+    tab stop measured in advance widths or in a length. *)
 type tab_size =
-  | Int of int
+  | Number of number
   | Length of length
   | Initial
   | Inherit

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1023,7 +1023,7 @@ let vars_of_overflow_clip_margin (value : Properties.overflow_clip_margin) :
 
 let vars_of_tab_size (value : Properties.tab_size) : any_var list =
   match value with
-  | Int _ -> []
+  | Number n -> vars_of_number_value n
   | Length len -> vars_of_length len
   | Var v -> [ V v ]
   | Initial | Inherit | Unset | Revert | Revert_layer -> []

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4694,8 +4694,11 @@ let test_columns_value () =
    not one of them: sec. 7.2.1 admits a <length-percentage> or a <flex> there,
    never a bare <number>. *)
 let math_function_at_integer_positions () =
-  check_tab_size ~expected:"3" "calc(1 + 2)";
+  (* [tab-size] keeps the authored call because its value is a {!number}; the
+     positions below still hold an [int], so their reader folds to reach it. *)
+  check_tab_size "calc(1 + 2)";
   check_tab_size "4";
+  check_tab_size "10.5";
   check_tab_size "2px";
   check_column_count ~expected:"3" "calc(1 + 2)";
   check_column_count "3";


### PR DESCRIPTION
`tab-size: 10.5` used to be dropped with a warning. CSS Text 4 sec. 4.4 spells the property `<number [0,inf]> | <length [0,inf]>`: the tab stop is a count of advance widths, and a count can be a fraction.

Holding an `int` also forced the reader to fold `calc(1 + 2)` on the spot to reach one; the authored call now survives to `--minify`, which is where the other math folds happen.