### PR TITLE
flex: let the basis lead the shorthand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -385,10 +385,11 @@ to lose a whole rule over one bad piece. Both are gone.
   `@font-palette-values` rule, `:dir(auto)`, `@media (min-width: 0)`,
   `@-moz-document`'s URL matchers, a `border-image` repeat keyword standing
   alone, a `text-decoration` component with no line, `white-space: collapse`, a
-  time-valued `round()` in a delay, and a value whose grammar ends in an
-  optional component (#334, #335, #427, #456, #461, #551, #572, #579, #594,
-  #633, #641, #644, #646, #665, #666, #667, #682, #739, #805, #827, #870,
-  #874, #877, #881, #884, #885, #886, #887, #889, #909)
+  time-valued `round()` in a delay, a `flex` shorthand whose basis leads, and a
+  value whose grammar ends in an optional component (#334, #335, #427, #456,
+  #461, #551, #572, #579, #594, #633, #641, #644, #646, #665, #666, #667, #682,
+  #739, #805, #827, #870, #874, #877, #881, #884, #885, #886, #887, #889, #909,
+  #1055)
 
 - `margin` mixes `auto` with lengths in any slot, `border-style` takes the four
   side styles, `border-block-style` and `border-inline-style` take the start and

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -632,7 +632,12 @@ let rec read_flex_basis t : flex_basis =
 
 module Flex = struct
   (* Helper functions for flex parsing *)
-  let read_basis_only t = Basis (read_flex_basis t)
+  (* [flex: auto] is [1 1 auto], which the flex value spells [Auto] rather than
+     as a basis of its own. *)
+  let read_basis_only t =
+    match (read_flex_basis t : flex_basis) with
+    | Auto -> (Auto : flex)
+    | basis -> Basis basis
 
   let read_factor t : flex_factor =
     (* A flex factor is a [<number>]: a [var()], a [calc()] (held unfolded; the
@@ -666,6 +671,21 @@ module Flex = struct
     | None, None -> Grow grow
     | Some s, None -> Grow_shrink (grow, s)
     | _, Some b -> Full (grow, Option.value shrink ~default:(Number 1.0), b)
+
+  (* Sec. 7.1.1 joins the factor group and the basis with a [||], so the basis
+     may lead. An omitted shrink is 1. *)
+  let read_basis_grow_shrink t =
+    let basis = read_flex_basis t in
+    Cursor.ws t;
+    let grow = read_factor t in
+    let shrink =
+      Cursor.option
+        (fun t ->
+          Cursor.ws t;
+          read_factor t)
+        t
+    in
+    Full (grow, Option.value shrink ~default:(Number 1.0), basis)
 end
 
 let rec read_flex t : flex =
@@ -676,9 +696,9 @@ let rec read_flex t : flex =
       ("unset", Unset);
       ("revert", Revert);
       ("revert-layer", Revert_layer);
-      ("auto", Auto);
+      (* [none] is the whole value on its own; [auto] and [content] are also the
+         basis half of the [||], so they are left to the basis reader. *)
       ("none", (None : flex));
-      ("content", Basis Content);
     ]
     ~var:(fun t ->
       (* A lone var() is the whole value; a var() followed by more components is
@@ -689,7 +709,18 @@ let rec read_flex t : flex =
       if Cursor.is_done t || Cursor.peek_comma t then (Var v : flex)
       else (
         Cursor.restore t snap;
-        Cursor.one_of [ Flex.read_grow_shrink_basis; Flex.read_basis_only ] t))
+        Cursor.one_of
+          [
+            Flex.read_grow_shrink_basis;
+            Flex.read_basis_grow_shrink;
+            Flex.read_basis_only;
+          ]
+          t))
     ~default:
-      (Cursor.one_of [ Flex.read_grow_shrink_basis; Flex.read_basis_only ])
+      (Cursor.one_of
+         [
+           Flex.read_grow_shrink_basis;
+           Flex.read_basis_grow_shrink;
+           Flex.read_basis_only;
+         ])
     t

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4084,6 +4084,19 @@ let test_flex () =
      constant calc to 3 is an optimize+minify transform, asserted there. *)
   check_flex "var(--f)";
   check_flex "calc(1 + 2) 1 0";
+  (* CSS Flexbox 1 sec. 7.1.1 joins the factor group and the basis with a [||],
+     so the basis may lead; an omitted shrink is 1. Chrome 153 computes each of
+     these to the same three longhands as the factor-first spelling. *)
+  check_flex ~expected:"1 50%" "50% 1";
+  check_flex ~expected:"1 2 50%" "50% 1 2";
+  check_flex ~expected:"2 10px" "10px 2";
+  check_flex ~expected:"1 auto" "auto 1";
+  check_flex ~expected:"1 content" "content 1";
+  (* The basis sits on one side of the [||] or the other, never between the two
+     factors, and [none] is the whole value on its own. *)
+  neg_cursor ~allow_partial:true read_flex "1 50% 2";
+  neg_cursor ~allow_partial:true read_flex "50% 1 2 3";
+  neg_cursor ~allow_partial:true read_flex "none 1";
   neg_cursor read_flex "invalid-flex"
 
 let test_font_variant_css21 () =


### PR DESCRIPTION
`flex: 50% 1`, `flex: auto 1` and `flex: content 1` used to be dropped with a warning. CSS Flexbox 1 sec. 7.1.1 spells the value `none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]`, and the `||` puts the basis on either side of the factors; only the factor-first order read. Chrome 153 computes each of these to the same three longhands as the factor-first spelling.