### PR TITLE
multicol: refuse a percentage math in the columns width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -344,11 +344,11 @@ to lose a whole rule over one bad piece. Both are gone.
 - A property whose grammar names a `<length>` takes neither a percentage nor an
   intrinsic-sizing keyword, and a `<time>` or `<angle>` needs its unit. Cascade
   read them wherever it read a length, so `border-width: 50%`, `perspective:
-  50%`, `top: min-content`, `margin-top: none`, `transition-duration: 0` and
-  `rotate: 0` all parsed, the last two turning a declaration browsers drop into
-  one that works. `Css.Values.read_length` gains `?sizing` and
-  `read_non_negative_length` gains `?length_only` (#871, #879, #880, #951,
-  #952, #953, #954)
+  50%`, `top: min-content`, `margin-top: none`, `transition-duration: 0`,
+  `rotate: 0` and `columns: calc(50% + 25%)` all parsed, the last three turning
+  a declaration browsers drop into one that works.
+  `Css.Values.read_length` gains `?sizing` and `read_non_negative_length` gains
+  `?length_only` (#871, #879, #880, #951, #952, #953, #954, #1056)
 
 - Each grid property takes its own grammar. Values a browser drops are dropped
   (`grid-template-columns: [a]`, `[span] 1px`, `grid-column-start: 0`, `span

--- a/lib/prop_multicol.ml
+++ b/lib/prop_multicol.ml
@@ -324,8 +324,9 @@ let rec read_page_break_inside_value t : page_break_inside_value =
    neither takes a percentage or a sizing keyword. *)
 let is_plain_length (l : length) =
   match l with
-  (* A math function, a substitution and [zero] are lengths this reader cannot
-     measure and the grammar holds. *)
+  (* A substitution and [zero] are lengths this reader cannot measure and the
+     grammar holds. A math function reaches here only once [length_only] has had
+     it, so its own type is settled. *)
   | Zero | Clamp _ | Min _ | Max _ | Minmax _ | Round _ | Mod _ | Rem_fn _
   | Hypot _ | Abs _ | Sign _ | Calc_size _ | Anchor_size _ | Anchor _ | Attr _
   | Env _ | Var _ | Calc _ ->
@@ -336,7 +337,9 @@ let is_plain_length (l : length) =
   | other -> Option.is_some (Values.calc_length_unit other)
 
 let read_plain_length t =
-  let l = read_length ~allow_negative:false ~with_keywords:false t in
+  let l =
+    read_length ~allow_negative:false ~with_keywords:false ~length_only:true t
+  in
   if is_plain_length l then l else Cursor.err_expected t "length"
 
 let read_columns_count t =

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -4696,7 +4696,15 @@ let test_columns_value () =
   (* CSS Multicol 2 sec. 4.1 spells [column-width] as [auto | <length [0,inf]>],
      so a percentage and a negative are no column width. *)
   neg_cursor read_columns_value "-1px";
-  neg_cursor read_columns_value "50%"
+  neg_cursor read_columns_value "50%";
+  (* A percentage nested in math is still a percentage, so the width slot takes
+     no math whose own type is one. Chrome 153 refuses each of these three and
+     takes the two below. *)
+  neg_cursor read_columns_value "calc(50% + 25%)";
+  neg_cursor read_columns_value "calc(50% - 25%)";
+  neg_cursor read_columns_value "clamp(1px,50%,2px)";
+  check_columns_value "calc(1px + 2em)";
+  check_columns_value "min(1px,2px)"
 
 (* CSS Values 4 (ED) sec. 10.9: a math function that resolves to <number> is
    valid wherever an <integer> is, so every integer position reads a calc(). The


### PR DESCRIPTION
`columns: calc(50% + 25%)` used to read, and Chrome 153 drops it. CSS Multicol 2 sec. 4.1 spells `column-width` as `auto | <length [0,inf]>`; the guard turned away a literal percentage but waved every math function through, so a call whose own type is a percentage reached the width slot. `columns: calc(1px + 2em)` and `columns: min(1px,2px)` still read.