### PR TITLE
scroll-snap: refuse a percentage math in a scroll margin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -345,10 +345,11 @@ to lose a whole rule over one bad piece. Both are gone.
   intrinsic-sizing keyword, and a `<time>` or `<angle>` needs its unit. Cascade
   read them wherever it read a length, so `border-width: 50%`, `perspective:
   50%`, `top: min-content`, `margin-top: none`, `transition-duration: 0`,
-  `rotate: 0` and `columns: calc(50% + 25%)` all parsed, the last three turning
-  a declaration browsers drop into one that works.
-  `Css.Values.read_length` gains `?sizing` and `read_non_negative_length` gains
-  `?length_only` (#871, #879, #880, #951, #952, #953, #954, #1056)
+  `rotate: 0`, `columns: calc(50% + 25%)` and `scroll-margin-top: calc(50% +
+  25%)` all parsed, the last four turning a declaration browsers drop into one
+  that works. `Css.Values.read_length` gains `?sizing` and
+  `read_non_negative_length` gains `?length_only` (#871, #879, #880, #951,
+  #952, #953, #954, #1056, #1058)
 
 - Each grid property takes its own grammar. Values a browser drops are dropped
   (`grid-template-columns: [a]`, `[span] 1px`, `grid-column-start: 0`, `span

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -977,7 +977,7 @@ let read_padding_logical_shorthand t =
 (* CSS Scroll Snap 1 sec. 5.1: the [scroll-margin] longhands are [<length>] - an
    unrestricted range, so an outset may be negative just as a margin may. Only
    [scroll-padding] (sec. 4.2) says "Negative values are invalid". "Percentages:
-   n/a" still rules a percentage out. *)
+   n/a" rules a percentage out, nested in math as much as written on its own. *)
 let read_scroll_margin_length t =
   Cursor.enum "scroll-margin length"
     [
@@ -987,10 +987,7 @@ let read_scroll_margin_length t =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~default:(fun t ->
-      match read_length ~with_keywords:false t with
-      | Pct _ -> Cursor.err_invalid t "scroll-margin percentage"
-      | length -> length)
+    ~default:(fun t -> read_length ~with_keywords:false ~length_only:true t)
     t
 
 let read_scroll_padding_length t =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -544,6 +544,16 @@ let special_cases () =
     ~optimized:"scroll-padding-inline:6px" "scroll-padding-inline: 6px 6px";
   check_declaration ~expected:"scroll-padding-block:7px 7px"
     ~optimized:"scroll-padding-block:7px" "scroll-padding-block: 7px 7px";
+  (* Sec. 5.1 writes [scroll-margin] as [<length>{1,4}] with "Percentages: n/a",
+     and a percentage nested in math is still a percentage. Sec. 4.2 gives
+     [scroll-padding] a [<length-percentage>], so only the margin turns one
+     away. Chrome 153 agrees on all four. *)
+  neg_cursor read_declaration "scroll-margin-top: 10%";
+  neg_cursor read_declaration "scroll-margin-top: calc(50% + 25%)";
+  neg_cursor read_declaration "scroll-margin-inline: calc(10% + 1px) 20px";
+  check_declaration ~expected:"scroll-margin-top:calc(1px + 2em)"
+    "scroll-margin-top: calc(1px + 2em)";
+  check_declaration ~expected:"scroll-padding-top:10%" "scroll-padding-top: 10%";
   (* CSS Position 3 (ED) sec. 3.2 defines [inset] as [<'top'>{1,4}], and CSS
      Backgrounds 3 (ED) sec. 3.1 defines [border-color] over the same
      one-to-four side assignment. *)


### PR DESCRIPTION
`scroll-margin-top: calc(50% + 25%)` used to read and minify to `75%`, which browsers drop. CSS Scroll Snap 1 sec. 5.1 writes `scroll-margin` as `<length>{1,4}` with "Percentages: n/a"; the guard turned away a literal percentage but waved every math function through. `scroll-padding` (sec. 4.2) does take a `<length-percentage>` and is unchanged.

Same shape as #1056.