### PR TITLE
shadow: read each slot as a plain length

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -345,11 +345,12 @@ to lose a whole rule over one bad piece. Both are gone.
   intrinsic-sizing keyword, and a `<time>` or `<angle>` needs its unit. Cascade
   read them wherever it read a length, so `border-width: 50%`, `perspective:
   50%`, `top: min-content`, `margin-top: none`, `transition-duration: 0`,
-  `rotate: 0`, `columns: calc(50% + 25%)` and `scroll-margin-top: calc(50% +
-  25%)` all parsed, the last four turning a declaration browsers drop into one
-  that works. `Css.Values.read_length` gains `?sizing` and
-  `read_non_negative_length` gains `?length_only` (#871, #879, #880, #951,
-  #952, #953, #954, #1056, #1058)
+  `rotate: 0`, `columns: calc(50% + 25%)`, `scroll-margin-top: calc(50% + 25%)`,
+  `box-shadow: 20px 10%` and a negative shadow blur all parsed, most of them
+  turning a declaration browsers drop into one that works.
+  `Css.Values.read_length` gains `?sizing` and `read_non_negative_length` gains
+  `?length_only` (#871, #879, #880, #951, #952, #953, #954, #1056, #1058,
+  #1059)
 
 - Each grid property takes its own grammar. Values a browser drops are dropped
   (`grid-template-columns: [a]`, `[span] 1px`, `grid-column-start: 0`, `span

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -65,10 +65,21 @@ module Shadow = struct
     let _ : bool = try_color () in
     let _ : bool = try_inset () in
     let lengths_rev = ref [] in
+    (* Sec. 6.2 writes the run [<length>{2} [ <length [0,inf]> <length>? ]?], so
+       every slot is a plain length - no percentage, nested in math or not, and
+       no keyword - and the blur is the one slot with a floor. A math function
+       holds no value to compare, so only a literal is turned away there. *)
     let rec read_lengths_loop n =
       if n >= 4 then ()
       else
-        match Cursor.option (fun t -> read_length t) t with
+        let allow_negative = n <> 2 in
+        match
+          Cursor.option
+            (fun t ->
+              read_length ~allow_negative ~with_keywords:false ~length_only:true
+                t)
+            t
+        with
         | Some l ->
             lengths_rev := l :: !lengths_rev;
             Cursor.ws t;
@@ -386,7 +397,11 @@ let normalize_logical_border_color ?(lossless = false) :
 let rec normalize_shadow ?(lossless = false) : shadow -> shadow =
  fun value ->
   let normalize_body (s : shadow_body) : shadow_body =
-    let blur = option_map_preserve Values.normalize_length s.blur in
+    (* The blur is the one slot with a floor, so unwrapping a math function
+       there could turn a value browsers take into one they drop. *)
+    let blur =
+      option_map_preserve (Values.normalize_length ~non_negative:true) s.blur
+    in
     let spread = option_map_preserve Values.normalize_length s.spread in
     let color = option_map_preserve (normalize_color ~lossless) s.color in
     (* CSS Backgrounds 3 sec. 6.1 orders the optional blur then spread lengths

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -861,9 +861,13 @@ let normalize_text_shadow ?(lossless = false) : text_shadow -> text_shadow =
            {
              h_offset = Values.normalize_length s.h_offset;
              v_offset = Values.normalize_length s.v_offset;
+             (* The blur has a floor, so unwrapping a math function there could
+                turn a value browsers take into one they drop. *)
              blur =
                drop_default ~is_default:is_zero_length
-                 (option_map_preserve Values.normalize_length s.blur);
+                 (option_map_preserve
+                    (Values.normalize_length ~non_negative:true)
+                    s.blur);
              color = option_map_preserve (normalize_color ~lossless) s.color;
            })
   | other -> other
@@ -2184,6 +2188,32 @@ module Text_shadow = struct
     (lengths, color)
 end
 
+(* The run is offsets then blur, and CSS Backgrounds 3 sec. 6.2 gives the
+   [<shadow>] this one shares its slots a plain length in each, with a floor on
+   the blur alone. A math function holds no value to compare, so only a literal
+   is turned away there. The run caps at three: there is no spread slot to hold
+   a fourth. *)
+let read_shadow_lengths t =
+  let lengths_rev = ref [] in
+  let rec loop n =
+    if n >= 3 then ()
+    else
+      let allow_negative = n <> 2 in
+      match
+        Cursor.option
+          (fun t ->
+            read_length ~allow_negative ~with_keywords:false ~length_only:true t)
+          t
+      with
+      | Option.Some l ->
+          lengths_rev := l :: !lengths_rev;
+          Cursor.ws t;
+          loop (n + 1)
+      | Option.None -> ()
+  in
+  loop 0;
+  List.rev !lengths_rev
+
 let rec read_text_shadow t : text_shadow =
   let read_var t : text_shadow = Var (read_var read_text_shadow t) in
   Cursor.enum_or_calls "text-shadow"
@@ -2198,8 +2228,7 @@ let rec read_text_shadow t : text_shadow =
     ~calls:[ ("var", read_var) ]
     ~default:(fun t ->
       (* CSS Text Decoration 3 sec. 5: [<color>? && <length>{2,3}]. The && puts
-         the colour on either side of the length run but never inside it, and
-         caps the run at three: there is no spread slot to hold a fourth. *)
+         the colour on either side of the length run but never inside it. *)
       let color : color option ref = ref (Option.None : color option) in
       let try_color () =
         match !color with
@@ -2212,20 +2241,9 @@ let rec read_text_shadow t : text_shadow =
             | Option.None -> ())
       in
       try_color ();
-      let lengths_rev = ref [] in
-      let rec read_lengths_loop n =
-        if n >= 3 then ()
-        else
-          match Cursor.option (fun t -> read_length t) t with
-          | Option.Some l ->
-              lengths_rev := l :: !lengths_rev;
-              Cursor.ws t;
-              read_lengths_loop (n + 1)
-          | Option.None -> ()
-      in
-      read_lengths_loop 0;
+      let lengths = read_shadow_lengths t in
       try_color ();
-      match List.rev !lengths_rev with
+      match lengths with
       | h :: v :: rest ->
           let blur =
             match rest with b :: _ -> Option.Some b | _ -> Option.None

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2561,6 +2561,29 @@ let list_properties () =
   neg_cursor read_declaration "box-shadow: 0";
   neg_cursor read_declaration "text-shadow: 1px";
   neg_cursor read_declaration "box-shadow: inset inset 0 0 1px";
+  (* Sec. 6.2 writes the run [<length>{2} [ <length [0,inf]> <length>? ]?]: a
+     plain length in every slot, and a floor on the blur alone. Chrome 153
+     agrees on each of these. *)
+  neg_cursor read_declaration "box-shadow: 10% 20%";
+  neg_cursor read_declaration "box-shadow: 20px 10%";
+  neg_cursor read_declaration "box-shadow: auto 10%";
+  neg_cursor read_declaration "text-shadow: 10px 20%";
+  neg_cursor read_declaration "text-shadow: auto 10px";
+  neg_cursor read_declaration "box-shadow: 10px 20px -5px";
+  neg_cursor read_declaration "text-shadow: 10px 20px -5px";
+  check_declaration ~expected:"box-shadow:10px 20px 5px -3px"
+    "box-shadow: 10px 20px 5px -3px";
+  (* A math function holds no value to compare, so the blur takes one and keeps
+     it: unwrapping [calc(-5px)] would emit the literal the reader refuses. *)
+  check_declaration ~expected:"box-shadow:10px 20px calc(-5px)"
+    ~optimized:"box-shadow:10px 20px calc(-5px)"
+    "box-shadow: 10px 20px calc(-5px)";
+  check_declaration ~expected:"text-shadow:10px 20px calc(-5px)"
+    ~optimized:"text-shadow:10px 20px calc(-5px)"
+    "text-shadow: 10px 20px calc(-5px)";
+  check_declaration ~expected:"box-shadow:10px 20px calc(2px + 3px)"
+    ~optimized:"box-shadow:10px 20px 5px"
+    "box-shadow: 10px 20px calc(2px + 3px)";
 
   (* CSS Transitions 1 sec. 3: the shorthand takes a
      <single-transition-property>, and none is one of them, so it is the whole


### PR DESCRIPTION
`box-shadow: 20px 10%`, `box-shadow: auto 10%`, `text-shadow: 10px 20%` and a negative blur all used to read, and Chrome 153 drops every one. CSS Backgrounds 3 sec. 6.2 writes the run as `<length>{2} [ <length [0,inf]> <length>? ]?`, which `box-shadow` and `text-shadow` share: a plain length in every slot, and a floor on the blur alone.

The blur's fold moves with it. `box-shadow: 10px 20px calc(-5px)` is valid, because the range is checked on the resolved value, but unwrapping the call emitted the literal the reader now refuses; that fold keeps the call, as the border width's does since #1047.