### PR TITLE
color: keep a relative color() whose alpha it cannot fold

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -387,11 +387,12 @@ to lose a whole rule over one bad piece. Both are gone.
   `@font-palette-values` rule, `:dir(auto)`, `@media (min-width: 0)`,
   `@-moz-document`'s URL matchers, a `border-image` repeat keyword standing
   alone, a `text-decoration` component with no line, `white-space: collapse`, a
-  time-valued `round()` in a delay, a `flex` shorthand whose basis leads, and a
-  value whose grammar ends in an optional component (#334, #335, #427, #456,
+  time-valued `round()` in a delay, a `flex` shorthand whose basis leads, a
+  relative `color()` whose alpha is the origin's own, and a value whose grammar
+  ends in an optional component (#334, #335, #427, #456,
   #461, #551, #572, #579, #594, #633, #641, #644, #646, #665, #666, #667, #682,
   #739, #805, #827, #870, #874, #877, #881, #884, #885, #886, #887, #889, #909,
-  #1055)
+  #1055, #1060)
 
 - `margin` mixes `auto` with lengths in any slot, `border-style` takes the four
   side styles, `border-block-style` and `border-inline-style` take the start and

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6841,6 +6841,20 @@ let relative_origin_srgb_bytes origin : (int * int * int * int) option =
           | Option.None -> Option.None)
       | Option.None -> Option.None)
 
+(* The call names no alpha of its own, so the origin's carries through. *)
+let folded_srgb_color origin (alpha : alpha) : color option =
+  match relative_origin_srgb_bytes origin with
+  | None -> Option.None
+  | Some (r, g, b, origin_a_byte) ->
+      let a : alpha =
+        match alpha with
+        | None when origin_a_byte = 255 -> None
+        | None -> Num (Float.of_int origin_a_byte /. 255.)
+        | a -> a
+      in
+      Option.Some
+        (Rgba { rgb = Channels { r = Int r; g = Int g; b = Int b }; a })
+
 let try_fold_color_function_static origin t : color option =
   Cursor.ws t;
   let read_keyword kw =
@@ -6855,25 +6869,14 @@ let try_fold_color_function_static origin t : color option =
   else if not (read_keyword "r" && read_keyword "g" && read_keyword "b") then
     Option.None
   else
-    let alpha = read_optional_alpha t in
-    Cursor.ws t;
-    if not (Cursor.is_done t) then Option.None
-    else
-      match relative_origin_srgb_bytes origin with
-      | Some (r, g, b, origin_a_byte) ->
-          let final_alpha : alpha =
-            match alpha with
-            | None when origin_a_byte = 255 -> None
-            | None -> Num (Float.of_int origin_a_byte /. 255.)
-            | a -> a
-          in
-          Option.Some
-            (Rgba
-               {
-                 rgb = Channels { r = Int r; g = Int g; b = Int b };
-                 a = final_alpha;
-               })
-      | None -> Option.None
+    (* The fold is best effort, so an alpha it cannot read is not an error: sec.
+       4.1 puts the origin's [alpha] keyword, and math over it, in that slot,
+       and the caller keeps the call as written when this answers [None]. *)
+    match Cursor.option read_optional_alpha t with
+    | Option.None -> Option.None
+    | Option.Some alpha ->
+        Cursor.ws t;
+        if Cursor.is_done t then folded_srgb_color origin alpha else Option.None
 
 let try_fold_relative_color_static name origin t : color option =
   match name with

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4704,6 +4704,14 @@ let spec_values_l45_edges () =
         "color:rgb(from red r calc(g * 2)10)" );
       ( "color: rgb(from red r calc(g * 2) 10)",
         "color:rgb(from red r calc(g * 2)10)" );
+      (* CSS Color 5 sec. 4.1 puts the origin's [alpha] keyword, and math over
+         it, wherever the function takes an [<alpha-value>], [color()] included.
+         The sRGB self-substitution folds only a numeric alpha, so the keyword
+         forms keep the call. *)
+      ( "color: color(from red srgb r g b / alpha)",
+        "color:color(from red srgb r g b/alpha)" );
+      ( "color: color(from red srgb r g b / calc(alpha * 2))",
+        "color:color(from red srgb r g b/calc(alpha * 2))" );
       (* pp holds the authored node for the Named blue, the rgb()/alpha, and the
          turn unit. The colour cross-fold and angle conversion are optimize
          transforms. *)


### PR DESCRIPTION
`color(from red srgb r g b / alpha)` was dropped with a warning, and every other relative colour function takes the keyword in that slot. CSS Color 5 sec. 4.1 puts the origin's `alpha`, and math over it, wherever the function takes an `<alpha-value>`.

The sRGB self-substitution reads the alpha slot to decide whether it can fold statically. A keyword there raised rather than answering no, so the fold's failure became the declaration's. Chrome 153 accepts the value.