### PR TITLE
color: type-check a relative colour's channel expressions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -352,6 +352,13 @@ to lose a whole rule over one bad piece. Both are gone.
   `?length_only` (#871, #879, #880, #951, #952, #953, #954, #1056, #1058,
   #1059)
 
+- A relative colour's channel expressions are type-checked. CSS Color 5 sec.
+  4.1 substitutes a channel keyword as a `<number>`, so
+  `rgb(from red calc(r + 10%) g b)` and `lch(from red l c calc(h + 90deg))` add
+  a number to a percentage and to an angle; both used to read and every browser
+  drops them. The multiplying forms, `hwb(from red h calc(w * 1%) b)` among
+  them, still read (#1061)
+
 - Each grid property takes its own grammar. Values a browser drops are dropped
   (`grid-template-columns: [a]`, `[span] 1px`, `grid-column-start: 0`, `span
   -1`), `grid-auto-rows` refuses the area forms `grid-template` owns, `subgrid`

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -6855,6 +6855,87 @@ let folded_srgb_color origin (alpha : alpha) : color option =
       Option.Some
         (Rgba { rgb = Channels { r = Int r; g = Int g; b = Int b }; a })
 
+(* CSS Color 5 secs. 4.3 to 4.9 and 5.1 name the channel keywords each relative
+   colour function binds; [alpha] is bound by all of them. *)
+let relative_channel_keywords name =
+  let channels =
+    match name with
+    | "rgb" -> [ "r"; "g"; "b" ]
+    | "hsl" -> [ "h"; "s"; "l" ]
+    | "hwb" -> [ "h"; "w"; "b" ]
+    | "lab" | "oklab" -> [ "l"; "a"; "b" ]
+    | "lch" | "oklch" -> [ "l"; "c"; "h" ]
+    | "color" -> [ "r"; "g"; "b"; "x"; "y"; "z" ]
+    | _ -> []
+  in
+  "alpha" :: channels
+
+(* Sec. 4.1 substitutes each keyword with the origin's channel as a [<number>],
+   so a channel expression is typed like any other math: [calc(w + 10%)] adds a
+   number to a percentage and [calc(h + 90deg)] a number to an angle, neither of
+   which a browser takes, while [calc(w * 1%)] multiplies and is fine.
+   Substituting a literal number is what lets the ordinary calc inference answer
+   that, rather than a second type system written for this one place. *)
+let rec substitute_channel_numbers keywords (c : Component.t) : Component.t =
+  match c with
+  | Component.Preserved ({ kind = Token.Ident id; _ } as tok)
+    when List.mem (String.lowercase_ascii id) keywords ->
+      Component.Preserved
+        {
+          tok with
+          kind =
+            Token.Number_tok { value = 1.; repr = "1"; number_flag = Integer };
+        }
+  | Component.Func ({ node; _ } as n) ->
+      Component.Func
+        {
+          n with
+          node =
+            {
+              node with
+              Component.arguments =
+                List.map (substitute_channel_numbers keywords) node.arguments;
+            };
+        }
+  | Component.Block ({ node; _ } as n) ->
+      Component.Block
+        {
+          n with
+          node =
+            {
+              node with
+              Component.value =
+                List.map (substitute_channel_numbers keywords) node.value;
+            };
+        }
+  | other -> other
+
+(* Any dimension or percentage is the contextual value the inference weighs
+   against a bare number; which dimension it is does not change the answer. *)
+let read_relative_channel_unit t : unit =
+  match Cursor.peek t with
+  | Some
+      (Component.Preserved { kind = Token.Percentage _ | Token.Dimension _; _ })
+    ->
+      Cursor.skip t
+  | _ -> Cursor.err t "relative colour channel"
+
+let check_relative_channel_math name components =
+  let keywords = relative_channel_keywords name in
+  if keywords <> [ "alpha" ] then
+    List.iter
+      (fun component ->
+        match substitute_channel_numbers keywords component with
+        | Component.Func { node = { name = fn; _ }; _ } as substituted
+          when String.lowercase_ascii fn = "calc" ->
+            ignore
+              (read_calc ~result_type:`Number_or_value
+                 read_relative_channel_unit
+                 (Cursor.of_components [ substituted ])
+                : unit calc)
+        | _ -> ())
+      components
+
 let try_fold_color_function_static origin t : color option =
   Cursor.ws t;
   let read_keyword kw =
@@ -6965,6 +7046,7 @@ and read_relative_rgb t : color =
   let origin = read_color t in
   Cursor.ws t;
   let tail_components = Cursor.remaining t in
+  check_relative_channel_math "rgb" tail_components;
   if relative_color_has_empty_alpha tail_components then
     Cursor.err_expected t "relative rgb alpha";
   let tail =
@@ -7025,6 +7107,7 @@ and read_relative_color name t : color =
   Cursor.ws t;
   let origin = read_color t in
   Cursor.ws t;
+  check_relative_channel_math name (Cursor.remaining t);
   let snap = Cursor.save t in
   match try_fold_relative_color_static name origin t with
   | Some folded -> folded

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -3168,6 +3168,18 @@ let custom_properties () =
      its whole sub-cursor, so [var(--x 10px)] silently dropped [ 10px] and
      answered [var(--x)]. *)
   neg_cursor read_declaration "color:var(--x 10px)";
+  (* CSS Color 5 sec. 4.1 substitutes a relative colour's channel keyword as a
+     [<number>], so adding a percentage or an angle to one is the same type
+     error it is anywhere else in a math function. Chrome 153 refuses every one
+     of these and takes the multiplying forms above. *)
+  neg_cursor read_declaration "color: rgb(from red calc(r + 10%) g b)";
+  neg_cursor read_declaration "color: hsl(from red calc(h + 90deg) s l)";
+  neg_cursor read_declaration "color: hsl(from red h calc(s + 10%) l)";
+  neg_cursor read_declaration "color: hwb(from red h calc(w + 10%) b)";
+  neg_cursor read_declaration "color: lab(from red calc(l + 10%) a b)";
+  neg_cursor read_declaration "color: lch(from red l c calc(h + 90deg))";
+  neg_cursor read_declaration "color: oklab(from red calc(l + 10%) a b)";
+  neg_cursor read_declaration "color: color(from red srgb calc(r + 10%) g b)";
   check_declaration ~expected:"color:var(--x)" "color: var( --x )"
 
 (* A numeric token's source spelling is not part of its value. Opaque custom-
@@ -4712,6 +4724,13 @@ let spec_values_l45_edges () =
         "color:color(from red srgb r g b/alpha)" );
       ( "color: color(from red srgb r g b / calc(alpha * 2))",
         "color:color(from red srgb r g b/calc(alpha * 2))" );
+      (* Sec. 4.1 substitutes a channel keyword as a [<number>], so the ordinary
+         math typing decides the rest: multiplying by a percentage gives a
+         percentage, which the slot takes. *)
+      ( "color: hwb(from red h calc(w * 1%) b)",
+        "color:hwb(from red h calc(w * 1%) b)" );
+      ( "color: lch(from red l c calc(h + 90))",
+        "color:lch(from red l c calc(h + 90))" );
       (* pp holds the authored node for the Named blue, the rgb()/alpha, and the
          turn unit. The colour cross-fold and angle conversion are optimize
          transforms. *)


### PR DESCRIPTION
`rgb(from red calc(r + 10%) g b)` and `lch(from red l c calc(h + 90deg))` used to read, and every browser drops them. CSS Color 5 sec. 4.1 substitutes each channel keyword with the origin's channel as a `<number>`, so adding a percentage or an angle to one is the same type error it is anywhere else in a math function.

The tail of a relative colour is kept as an opaque string and was never typed. Substituting a literal number for each channel keyword lets the existing calc inference answer the question, rather than a second type system written for this one place, so the multiplying forms (`calc(w * 1%)` is a percentage, which the slot takes) still read. Checked against Chrome 153 over the eight functions: 17 of 17 agree.