### PR TITLE
token: let a whitespace run carry its own text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -834,6 +834,14 @@ to lose a whole rule over one bad piece. Both are gone.
 
 ### Custom properties
 
+- A custom property's value keeps the whitespace runs the author wrote, where
+  `--x: a  b` used to come back as `a b`. CSS Custom Properties 1 sec. 4.1
+  forbids normalizing it and Chrome returns the run; the ends are still trimmed,
+  and `--minify` still makes its own separator decisions.
+  `Cascade.Token.Whitespace` carries its run, and
+  `Cascade.Parser.to_string_verbatim` is the serializer that writes it back
+  (#1064)
+
 - `Css.inline_vars` sees every place a `var()` can be written: an `@font-face`
   descriptor, `@page` and its margin boxes, a `@keyframes` frame,
   `@position-try`, a `@supports` condition and a nested rule. A descriptor

--- a/fuzz/fuzz_parser.ml
+++ b/fuzz/fuzz_parser.ml
@@ -26,7 +26,7 @@ let bracket_shape = function
   | Token.Square -> "[]"
 
 let rec shape = function
-  | Component.Preserved { kind = Token.Whitespace; _ } -> None
+  | Component.Preserved { kind = Token.Whitespace _; _ } -> None
   | Component.Preserved tok -> Some (Css.Pp.to_string Token.pp_kind tok.kind)
   | Component.Block { node = { opening; value; _ }; _ } ->
       let inner = value |> List.filter_map shape |> String.concat "," in

--- a/lib/component.ml
+++ b/lib/component.ml
@@ -85,7 +85,7 @@ let rec is_any_value components =
     components
 
 let is_whitespace = function
-  | Preserved { kind = Token.Whitespace; _ } -> true
+  | Preserved { kind = Token.Whitespace _; _ } -> true
   | Preserved _ | Block _ | Func _ -> false
 
 (* A real [var()] function anywhere in the components, recursing into function

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -388,7 +388,7 @@ let is_reserved_container_name name =
 let split_named_components components =
   match drop_leading_whitespace components with
   | Component.Preserved { kind = Token.Ident name; _ }
-    :: (Component.Preserved { kind = Token.Whitespace; _ } :: _ as after)
+    :: (Component.Preserved { kind = Token.Whitespace _; _ } :: _ as after)
     when not (is_reserved_container_name name) ->
       let query = trim_components after in
       if starts_query query then Some (name, query) else None
@@ -403,7 +403,7 @@ let has_semicolon_component =
 
 let style_strip_ws =
   List.filter (function
-    | Component.Preserved { kind = Token.Whitespace; _ } -> false
+    | Component.Preserved { kind = Token.Whitespace _; _ } -> false
     | _ -> true)
 
 (* CSS Conditional Rules 5 sec. 5.4 builds <style-range> out of <mf-comparison>
@@ -650,13 +650,15 @@ let range_direction_of_component = function
   | _ -> None
 
 let rec strip_ws = function
-  | Component.Preserved { kind = Token.Whitespace; _ } :: rest -> strip_ws rest
+  | Component.Preserved { kind = Token.Whitespace _; _ } :: rest ->
+      strip_ws rest
   | cvs -> cvs
 
 let non_ws cvs =
   List.filter
     (function
-      | Component.Preserved { kind = Token.Whitespace; _ } -> false | _ -> true)
+      | Component.Preserved { kind = Token.Whitespace _; _ } -> false
+      | _ -> true)
     cvs
 
 let has_opposing_interval_components cvs =

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -89,7 +89,7 @@ let of_reader ?(meta = Loc.default_meta_level) r =
   }
 
 let is_ws_cv : Component.t -> bool = function
-  | Preserved { kind = Token.Whitespace; _ } -> true
+  | Preserved { kind = Token.Whitespace _; _ } -> true
   | _ -> false
 
 let rec drop_ws t =
@@ -495,8 +495,13 @@ let is_semicolon_cv = function
   | Component.Preserved { kind = Token.Semicolon; _ } -> true
   | _ -> false
 
+(* CSS Custom Properties 1 (ED) sec. 4.1 forbids normalizing the whitespace of a
+   custom property's value, and this is what captures it, so the run each
+   whitespace token carries is written back rather than the single space Syntax
+   3 sec. 9.1 gives a reserialized stream. *)
 let consume_until_semicolon ?(trim = false) t =
-  string_of_components ~trim (drain_until_raw is_semicolon_cv t)
+  let s = Parser.to_string_verbatim (drain_until_raw is_semicolon_cv t) in
+  if trim then String.trim s else s
 
 let rec skip_past_semicolon t =
   match next_raw t with

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2203,7 +2203,7 @@ let read_custom_property_payload name value_str =
   else read_custom_property_value (Cursor.of_string value_str)
 
 let whitespace_only_custom_property_value =
-  Tokens [ Component.Preserved (Token.synthetic Token.Whitespace) ]
+  Tokens [ Component.Preserved (Token.synthetic (Token.Whitespace " ")) ]
 
 (* Keep a single space when the raw declaration value was whitespace-only - that
    one space is the spec-required token sequence (CSS Custom Properties for
@@ -2274,7 +2274,7 @@ let components_are_lone_css_wide cvs =
   let non_ws =
     List.filter
       (function
-        | Component.Preserved { kind = Token.Whitespace; _ } -> false
+        | Component.Preserved { kind = Token.Whitespace _; _ } -> false
         | _ -> true)
       cvs
   in
@@ -2857,12 +2857,16 @@ let rec pp : declaration Pp.t =
    itself is the compatibility question. *)
 let rec pp_opaque : declaration Pp.t =
  fun ctx decl ->
-  let pp_components property components important =
+  (* CSS Custom Properties 1 (ED) sec. 4.1 forbids normalizing the whitespace of
+     a custom property's value, so its runs are written back as read. An unknown
+     property has no such rule and takes the Syntax 3 sec. 9.1 serialization. *)
+  let pp_components ?(verbatim = false) property components important =
     pp_property ctx property;
     Pp.char ctx ':';
     Pp.space_if_pretty ctx ();
     Pp.string ctx
       (if Pp.minified ctx then Parser.to_string_minified components
+       else if verbatim then Parser.to_string_verbatim components
        else Parser.string_of_components components);
     if important then
       Pp.string ctx (if ctx.minify then "!important" else " !important")
@@ -2878,7 +2882,7 @@ let rec pp_opaque : declaration Pp.t =
         important;
         _;
       } ->
-      pp_components property components important
+      pp_components ~verbatim:true property components important
   | Declaration _ -> pp ctx decl
   | Theme_guarded { decl; _ } -> pp_opaque ctx decl
 

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -384,7 +384,7 @@ let lookup_visible_custom_components visible name =
 
 let trim_components components =
   let is_ws = function
-    | Component.Preserved { kind = Token.Whitespace; _ } -> true
+    | Component.Preserved { kind = Token.Whitespace _; _ } -> true
     | _ -> false
   in
   let rec drop = function hd :: tl when is_ws hd -> drop tl | xs -> xs in
@@ -923,7 +923,7 @@ and substitute_stmt ~kept ~scopes ~parents ~at_path stmt =
 
 let strip_component_ws =
   List.filter (function
-    | Component.Preserved { kind = Token.Whitespace; _ } -> false
+    | Component.Preserved { kind = Token.Whitespace _; _ } -> false
     | _ -> true)
 
 let rec split_var_fallback acc = function

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -608,16 +608,20 @@ let rec skip_comment_run on_comment r =
     skip_comment_run on_comment r)
 
 (* Consume a run of whitespace code points and any interleaved comments,
-   returning [true] when at least one whitespace code point was seen. *)
-let rec consume_whitespace_run on_comment r =
+   collecting the whitespace into [buf]. CSS Custom Properties 1 (ED) sec. 4.1
+   forbids normalizing the whitespace of a custom property's token stream, so
+   the run's own text is what the token carries; a comment inside it is not
+   whitespace and does not join it. *)
+let rec consume_whitespace_run ?buf on_comment r =
   match Reader.peek r with
   | Some c when is_ws c ->
+      Option.iter (fun b -> Buffer.add_char b c) buf;
       Reader.skip r;
-      consume_whitespace_run on_comment r
+      consume_whitespace_run ?buf on_comment r
   | _ ->
       if Reader.looking_at r "/*" then (
         consume_comment on_comment r;
-        consume_whitespace_run on_comment r)
+        consume_whitespace_run ?buf on_comment r)
 
 let hash_flag_now r = if would_start_ident_sequence r then Id else Unrestricted
 
@@ -693,8 +697,9 @@ let next_token ?(force_url_function = false) ?(unicode_ranges = false)
   else
     let c = Char.unsafe_chr b in
     if is_ws c then (
-      consume_whitespace_run on_comment r;
-      Whitespace)
+      let buf = Buffer.create 8 in
+      consume_whitespace_run ~buf on_comment r;
+      Whitespace (Buffer.contents buf))
     else
       match c with
       | '"' ->

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -292,7 +292,10 @@ let add_token_kind buf : Token.kind -> unit = function
   | Token.Dimension { number; unit_ } ->
       Buffer.add_string buf number.repr;
       add_dimension_unit buf unit_
-  | Token.Whitespace -> Buffer.add_char buf ' '
+  (* CSS Syntax 3 (ED) sec. 9.1 serializes a whitespace token as one space,
+     whatever run produced it. A custom property's value is not a reserialized
+     token stream and does not go through here; see {!to_string_custom}. *)
+  | Token.Whitespace _ -> Buffer.add_char buf ' '
   | Token.Unicode_range { start_value; end_value; _ } ->
       add_unicode_range buf ~start_value ~end_value
   | Token.Cdo -> Buffer.add_string buf "<!--"
@@ -358,7 +361,7 @@ let is_backslash_delim = function
   | _ -> false
 
 let is_whitespace = function
-  | Preserved { kind = Token.Whitespace; _ } -> true
+  | Preserved { kind = Token.Whitespace _; _ } -> true
   | _ -> false
 
 let numeric_repr ~minify number =
@@ -481,7 +484,7 @@ let rec cv_to_buffer buf : Component.t -> unit = function
       Buffer.add_char buf ')'
 
 (* The serialised [Delim "\\"] is "\\\n", which already supplies a separator;
-   eat the next whitespace so [Delim "\\"; Whitespace] round-trips cleanly. *)
+   eat the next whitespace so [Delim "\\"; Whitespace _] round-trips cleanly. *)
 and cvs_to_buffer buf cvs =
   let rec loop prev = function
     | [] -> ()
@@ -513,7 +516,7 @@ let word_like_end : Component.t -> bool = function
   | Preserved
       {
         kind =
-          ( Whitespace | Open _ | Close _ | Colon | Semicolon | Comma | Cdo
+          ( Whitespace _ | Open _ | Close _ | Colon | Semicolon | Comma | Cdo
           | Cdc | Bad_string | Bad_url | Eof
           (* Self-delimiting at the end: [%] closes its percentage token and
              these delims close themselves, so nothing that follows merges into
@@ -539,7 +542,7 @@ let word_like_start : Component.t -> bool = function
   | Preserved
       {
         kind =
-          ( Whitespace | Close _ | Colon | Semicolon | Comma | Cdo | Cdc
+          ( Whitespace _ | Close _ | Colon | Semicolon | Comma | Cdo | Cdc
           | Bad_string | Bad_url | Eof
           | Delim
               ( "!" | "*" | "/" | ">" | "?" | "|" | "&" | "^" | "$" | "=" | "~"
@@ -749,6 +752,49 @@ and cvs_to_buffer_min ~minify_numbers ~in_math buf cvs =
   in
   loop None false false cvs
 
+(* CSS Custom Properties 1 (ED) sec. 4.1: a custom property's value "must not"
+   have its whitespace normalized, so the stream a var() substitutes keeps the
+   runs the author wrote. Syntax 3 sec. 9.1's one-space serialization is the
+   right answer for a reserialized token stream and the wrong one here, which is
+   why this is its own entry point rather than a flag on that one. The boundary
+   space {!cvs_to_buffer} inserts between components that would otherwise merge
+   is NOT whitespace normalization and is kept: dropping it turns [a/**/b] into
+   the single ident [ab]. *)
+let rec cv_to_buffer_verbatim buf : Component.t -> unit = function
+  | Preserved { kind = Token.Whitespace run; _ } -> Buffer.add_string buf run
+  | Preserved t -> add_token_kind buf t.kind
+  | Block { node = { opening; value; _ }; _ } ->
+      Buffer.add_char buf (opening_char opening);
+      cvs_to_buffer_verbatim buf value;
+      Buffer.add_char buf (closing_char opening)
+  | Func { node = { name; arguments; _ }; _ } ->
+      Buffer.add_string buf (escape_ident name);
+      Buffer.add_char buf '(';
+      cvs_to_buffer_verbatim buf arguments;
+      Buffer.add_char buf ')'
+
+and cvs_to_buffer_verbatim buf cvs =
+  let rec loop prev = function
+    | [] -> ()
+    | cv :: rest
+      when is_whitespace cv
+           && match prev with Some p -> is_backslash_delim p | None -> false ->
+        loop prev rest
+    | cv :: rest ->
+        (match prev with
+        | Some p when normal_pair_needs_token_boundary p cv ->
+            Buffer.add_char buf ' '
+        | _ -> ());
+        cv_to_buffer_verbatim buf cv;
+        loop (Some cv) rest
+  in
+  loop None cvs
+
+let to_string_verbatim cvs =
+  let buf = Buffer.create 32 in
+  cvs_to_buffer_verbatim buf cvs;
+  Buffer.contents buf
+
 let to_string_minified_with ~minify_numbers cvs =
   if cvs <> [] && List.for_all is_whitespace cvs then " "
   else
@@ -775,7 +821,7 @@ let url_args_as_bare_string args =
   let stripped =
     List.filter
       (function
-        | Component.Preserved { kind = Token.Whitespace; _ } -> false
+        | Component.Preserved { kind = Token.Whitespace _; _ } -> false
         | _ -> true)
       args
   in
@@ -957,7 +1003,7 @@ let to_string_custom_minified ?(fold_ident = fold_value_ident) cvs =
    leaking the loop body. *)
 let rec skip_whitespace_tokens lexer =
   match (Lexer.peek lexer).Token.kind with
-  | Token.Whitespace ->
+  | Token.Whitespace _ ->
       let _ = Lexer.next lexer in
       skip_whitespace_tokens lexer
   | _ -> ()
@@ -1021,7 +1067,8 @@ let consume_at_rule ?(nested = false) ~meta lexer ~name ~start_loc ~warnings :
    prelude is held reversed, as [consume_qualified_rule] accumulates it. *)
 let is_custom_property_shape prelude =
   let rec drop_ws = function
-    | Component.Preserved { kind = Token.Whitespace; _ } :: rest -> drop_ws rest
+    | Component.Preserved { kind = Token.Whitespace _; _ } :: rest ->
+        drop_ws rest
     | other -> other
   in
   match drop_ws (List.rev prelude) with
@@ -1085,7 +1132,7 @@ let consume_list_of_rules ~meta lexer ~top_level ~warnings : Component.rule list
     let tok = Lexer.next lexer in
     match tok.Token.kind with
     | Token.Eof -> List.rev acc
-    | Token.Whitespace -> loop acc
+    | Token.Whitespace _ -> loop acc
     | (Token.Cdo | Token.Cdc) when top_level -> loop acc
     | Token.Cdo | Token.Cdc -> (
         Lexer.reconsume lexer tok;
@@ -1241,7 +1288,7 @@ let consume_decl_from_ident ~meta lexer ~warnings ~name ~name_loc =
 let consume_decl_list_item ~meta lexer ~warnings tok =
   match tok.Token.kind with
   | Token.Eof -> `Done
-  | Token.Whitespace | Token.Semicolon | Token.Close Curly -> `Skip
+  | Token.Whitespace _ | Token.Semicolon | Token.Close Curly -> `Skip
   | Token.At_keyword name ->
       let ar = consume_at_rule ~meta lexer ~name ~start_loc:tok.loc ~warnings in
       `Item (`At ar)
@@ -1345,7 +1392,7 @@ let consume_block_contents ~meta lexer ~warnings : block_item list =
     | Token.Eof | Token.Close Curly ->
         flush ();
         List.rev !result
-    | Token.Whitespace | Token.Semicolon -> loop ()
+    | Token.Whitespace _ | Token.Semicolon -> loop ()
     | Token.At_keyword name ->
         flush ();
         let ar =
@@ -1436,13 +1483,13 @@ let list_of_component_values r =
 
 let rec next_non_ws p =
   match next p with
-  | Preserved { kind = Token.Whitespace; _ } -> next_non_ws p
+  | Preserved { kind = Token.Whitespace _; _ } -> next_non_ws p
   | cv -> cv
 
 let rec rest_is_ws_then_eof p =
   match next p with
   | Preserved { kind = Token.Eof; _ } -> true
-  | Preserved { kind = Token.Whitespace; _ } -> rest_is_ws_then_eof p
+  | Preserved { kind = Token.Whitespace _; _ } -> rest_is_ws_then_eof p
   | _ -> false
 
 let component_value r =
@@ -1473,7 +1520,7 @@ let csv_component_values r =
 
 let trim_component_value_whitespace cvs =
   let is_ws = function
-    | Preserved { kind = Token.Whitespace; _ } -> true
+    | Preserved { kind = Token.Whitespace _; _ } -> true
     | _ -> false
   in
   let rec drop_leading = function
@@ -1484,7 +1531,7 @@ let trim_component_value_whitespace cvs =
 
 let component_values_are_whitespace_only cvs =
   List.for_all
-    (function Preserved { kind = Token.Whitespace; _ } -> true | _ -> false)
+    (function Preserved { kind = Token.Whitespace _; _ } -> true | _ -> false)
     cvs
 
 let matches_grammar r grammar =

--- a/lib/parser.mli
+++ b/lib/parser.mli
@@ -44,6 +44,12 @@ val string_of_components : Component.t list -> string
     stream, the opaque custom-property values of CSS Custom Properties 1
     included. *)
 
+val to_string_verbatim : Component.t list -> string
+(** [to_string_verbatim cvs] is {!string_of_components} except that a
+    [<whitespace-token>] writes back the run it was read from. CSS Custom
+    Properties 1 (ED) section 4.1 forbids normalizing the whitespace of a custom
+    property's value, which is the one stream that needs this. *)
+
 val to_string_minified : Component.t list -> string
 (** Like {!string_of_components} but drops whitespace that sits between two
     components where at least one side is not word-like (ident / number / etc.).

--- a/lib/prop_common.ml
+++ b/lib/prop_common.ml
@@ -65,7 +65,7 @@ let components_have_css_wide_mix components =
   let non_ws =
     List.filter
       (function
-        | Component.Preserved { kind = Token.Whitespace; _ } -> false
+        | Component.Preserved { kind = Token.Whitespace _; _ } -> false
         | _ -> true)
       components
   in

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -741,7 +741,7 @@ let unquote_font_family_strings components =
     | [ w ] -> [ Component.Preserved (Token.v ~kind:(Token.Ident w) ~loc) ]
     | w :: rest ->
         Component.Preserved (Token.v ~kind:(Token.Ident w) ~loc)
-        :: Component.Preserved (Token.v ~kind:Token.Whitespace ~loc)
+        :: Component.Preserved (Token.v ~kind:(Token.Whitespace " ") ~loc)
         :: interleave loc rest
   in
   let result =
@@ -1758,7 +1758,7 @@ let components_have_generic_family components =
 
 let long_generic_family_start r =
   let is_ws = function
-    | Component.Preserved { kind = Token.Whitespace; _ } -> true
+    | Component.Preserved { kind = Token.Whitespace _; _ } -> true
     | _ -> false
   in
   let is_comma = function

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -938,7 +938,7 @@ let read_polygon_point inner =
 
 let polygon_has_ws_after_comma inner =
   match Cursor.peek_raw inner with
-  | Some (Component.Preserved { kind = Token.Whitespace; _ }) -> true
+  | Some (Component.Preserved { kind = Token.Whitespace _; _ }) -> true
   | _ -> false
 
 let read_polygon_points inner =

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -3599,11 +3599,14 @@ let pp_value : type a. (a kind * a) Pp.t =
   | Number_percentage -> pp pp_number_percentage
   | Opacity -> pp pp_opacity
   | Value ->
+      (* CSS Custom Properties 1 (ED) sec. 4.1 forbids normalizing the
+         whitespace of the stream a [var()] substitutes, so the runs come back
+         as they were read. *)
       let rendered =
         if Pp.minified ctx then
           Parser.to_string_custom_minified
             ~fold_ident:Values.fold_custom_value_ident value
-        else Parser.string_of_components value
+        else Parser.to_string_verbatim value
       in
       Pp.string ctx rendered
   | Shadow -> pp pp_shadow
@@ -4187,7 +4190,7 @@ let canonical_initial_for_minify : type a. a property -> a -> a =
 let strip_math_whitespace comps =
   let rec aux acc = function
     | [] -> List.rev acc
-    | (Component.Preserved { kind = Token.Whitespace; _ } as ws) :: rest ->
+    | (Component.Preserved { kind = Token.Whitespace _; _ } as ws) :: rest ->
         let prev_pm =
           match acc with
           | [] -> false
@@ -4214,7 +4217,7 @@ let is_mul_or_div_delim = function
 let strip_mul_div_whitespace comps =
   let rec aux acc = function
     | [] -> List.rev acc
-    | (Component.Preserved { kind = Token.Whitespace; _ } as ws) :: rest ->
+    | (Component.Preserved { kind = Token.Whitespace _; _ } as ws) :: rest ->
         let prev_md =
           match acc with [] -> false | p :: _ -> is_mul_or_div_delim p
         in
@@ -4252,7 +4255,7 @@ let strip_after_close_paren ~in_math comps =
   in
   let rec aux acc = function
     | [] -> List.rev acc
-    | (Component.Preserved { kind = Token.Whitespace; _ } as ws) :: rest ->
+    | (Component.Preserved { kind = Token.Whitespace _; _ } as ws) :: rest ->
         let prev_hard =
           match acc with [] -> false | p :: _ -> closes_hard p
         in

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -806,7 +806,7 @@ let read_an_tail t =
    between the [+] and [n]. *)
 let ensure_no_ws_after_plus t =
   match Cursor.peek_raw t with
-  | Some (Component.Preserved { kind = Token.Whitespace; _ }) ->
+  | Some (Component.Preserved { kind = Token.Whitespace _; _ }) ->
       Cursor.err_invalid t "whitespace after '+'"
   | _ -> ()
 
@@ -1899,7 +1899,7 @@ and read_compound t =
   Cursor.ws t;
   let can_start () =
     match Cursor.peek_raw t with
-    | Some (Component.Preserved { kind = Token.Whitespace; _ }) -> false
+    | Some (Component.Preserved { kind = Token.Whitespace _; _ }) -> false
     | _ ->
         (match Cursor.peek_delim t with
           | Some ('.' | '*' | '&') -> true

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3840,7 +3840,7 @@ let read_else ~body (r : Cursor.t) : statement =
     match
       List.filter
         (function
-          | Component.Preserved { kind = Token.Whitespace; _ } -> false
+          | Component.Preserved { kind = Token.Whitespace _; _ } -> false
           | _ -> true)
         prelude
     with

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -25,7 +25,7 @@ type kind =
   | Number_tok of number
   | Percentage of number
   | Dimension of { number : number; unit_ : string }
-  | Whitespace
+  | Whitespace of string
   | Unicode_range of {
       start_value : int;
       end_value : int;
@@ -103,7 +103,7 @@ let pp_kind : kind Pp.t =
       Pp.string ctx number.repr;
       Pp.string ctx unit_;
       Pp.char ctx '>'
-  | Whitespace -> Pp.string ctx "<ws>"
+  | Whitespace _ -> Pp.string ctx "<ws>"
   | Unicode_range { start_value; end_value; _ } ->
       Pp.string ctx "<unicode-range U+";
       Pp.hex ctx start_value;

--- a/lib/token.mli
+++ b/lib/token.mli
@@ -51,7 +51,11 @@ type kind =
   | Number_tok of number
   | Percentage of number
   | Dimension of { number : number; unit_ : string }
-  | Whitespace  (** Any run of whitespace characters. *)
+  | Whitespace of string
+      (** A run of whitespace characters, carrying its own text. CSS Custom
+          Properties 1 (ED) sec. 4.1 forbids normalizing the whitespace of a
+          custom property's token stream, so the run is kept rather than
+          collapsed to one space. *)
   | Unicode_range of {
       start_value : int;
       end_value : int;

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -527,12 +527,14 @@ let pp_calc_op : calc_op Pp.t =
       Pp.string ctx "/";
       Pp.space_if_pretty ctx ()
 
+(* CSS Custom Properties 1 (ED) sec. 4.1 forbids normalizing the whitespace of
+   the streams this prints, so the runs come back as they were read. *)
 let pp_component_values ctx values =
   let value =
     if Pp.minified ctx then
       Parser.to_string_custom_minified ~fold_ident:fold_custom_value_ident
         values
-    else Parser.string_of_components values
+    else Parser.to_string_verbatim values
   in
   Pp.string ctx value
 
@@ -6791,7 +6793,7 @@ let normalize_relative_color_tail tail =
    number. *)
 let relative_color_channel_count cvs =
   let is_ws = function
-    | Component.Preserved { Token.kind = Whitespace; _ } -> true
+    | Component.Preserved { Token.kind = Whitespace _; _ } -> true
     | _ -> false
   in
   let is_alpha_sep = function
@@ -6808,7 +6810,7 @@ let relative_color_channel_count cvs =
 
 let relative_color_has_empty_alpha cvs =
   let is_ws = function
-    | Component.Preserved { Token.kind = Whitespace; _ } -> true
+    | Component.Preserved { Token.kind = Whitespace _; _ } -> true
     | _ -> false
   in
   let rec only_ws = function

--- a/test/interop/wpt/test.ml
+++ b/test/interop/wpt/test.ml
@@ -765,7 +765,7 @@ let serialize_consecutive_tokens =
     let non_ws cvs =
       List.filter
         (function
-          | Cascade.Component.Preserved { kind = Cascade.Token.Whitespace; _ }
+          | Cascade.Component.Preserved { kind = Cascade.Token.Whitespace _; _ }
             ->
               false
           | _ -> true)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -271,7 +271,15 @@ let custom_properties_basic () =
   check_declaration ~expected:"--complex:var(--other,10px)"
     "--complex: var(--other, 10px);";
   check_declaration ~expected:"--important:value!important"
-    "--important: value !important;"
+    "--important: value !important;";
+  (* CSS Custom Properties 1 (ED) sec. 4.1 forbids normalizing the whitespace of
+     a custom property's value, and Chrome 153 returns [a b] for the first of
+     these and [a] for the second, so a run survives and the ends are trimmed.
+     The boundary space between two components that would otherwise merge is not
+     whitespace normalization: without it [a/**/b] becomes the ident [ab]. *)
+  check_declaration ~minify:false ~expected:"--x: a  b" "--x:a  b";
+  check_declaration ~minify:false ~expected:"--sp: a" "--sp:  a  ";
+  check_declaration ~minify:false ~expected:"--c: a b" "--c:a/**/b"
 
 let vendor_prefixes () =
   check_declaration ~expected:"-webkit-transform:rotate(45deg)"

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -671,7 +671,7 @@ let spec_serialization_roundtrip_boundaries () =
   let non_ws cvs =
     List.filter
       (function
-        | Component.Preserved { kind = Token.Whitespace; _ } -> false
+        | Component.Preserved { kind = Token.Whitespace _; _ } -> false
         | _ -> true)
       cvs
   in
@@ -718,7 +718,7 @@ let spec_serialization_bad_string_roundtrip () =
   (match components with
   | [
    Component.Preserved { kind = Token.Bad_string; _ };
-   Component.Preserved { kind = Token.Whitespace; _ };
+   Component.Preserved { kind = Token.Whitespace _; _ };
    Component.Preserved { kind = Token.Ident "x"; _ };
   ] ->
       ()
@@ -727,7 +727,7 @@ let spec_serialization_bad_string_roundtrip () =
   match list serialized with
   | [
    Component.Preserved { kind = Token.Bad_string; _ };
-   Component.Preserved { kind = Token.Whitespace; _ };
+   Component.Preserved { kind = Token.Whitespace _; _ };
    Component.Preserved { kind = Token.Ident "x"; _ };
   ] ->
       ()
@@ -808,9 +808,9 @@ let spec_wpt_parser_branch_matrix () =
   (match list "a url(foo\"bar) next" with
   | [
    Component.Preserved { kind = Token.Ident "a"; _ };
-   Component.Preserved { kind = Token.Whitespace; _ };
+   Component.Preserved { kind = Token.Whitespace _; _ };
    Component.Preserved { kind = Token.Bad_url; _ };
-   Component.Preserved { kind = Token.Whitespace; _ };
+   Component.Preserved { kind = Token.Whitespace _; _ };
    Component.Preserved { kind = Token.Ident "next"; _ };
   ] ->
       ()

--- a/test/test_token.ml
+++ b/test/test_token.ml
@@ -26,7 +26,7 @@ let simple () =
   check "colon" Token.Colon "<:>";
   check "semicolon" Token.Semicolon "<;>";
   check "comma" Token.Comma "<,>";
-  check "whitespace" Token.Whitespace "<ws>";
+  check "whitespace" (Token.Whitespace " ") "<ws>";
   check "cdo" Token.Cdo "<CDO>";
   check "cdc" Token.Cdc "<CDC>";
   check "eof" Token.Eof "<eof>"


### PR DESCRIPTION
`--x: a  b` used to come back as `a b`. CSS Custom Properties 1 sec. 4.1 forbids normalizing the whitespace of a custom property's value, and Chrome 153 returns the run; the ends are still trimmed, and `--minify` still makes its own separator decisions.

The value was captured by reserializing the component stream, and CSS Syntax 3 sec. 9.1 turns every run into one space there, so the information was gone before any printer saw it. `Token.Whitespace` now carries its run and the capture writes it back through `Parser.to_string_verbatim`; `string_of_components` keeps the one-space contract sec. 9.1 states, which is what its own test pins.

The boundary space between two components that would otherwise merge stays, since it is not whitespace normalization: dropping it turned `a/**/b` into the single ident `ab`, which the minifier interop corpus caught.