### PR TITLE
token: keep the source text of an escaped token

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -842,6 +842,13 @@ to lose a whole rule over one bad piece. Both are gone.
   `Cascade.Parser.to_string_verbatim` is the serializer that writes it back
   (#1064)
 
+- A custom property's value keeps the escapes the author wrote, so
+  `--v: gre\en` no longer comes back as `gre\E n`. CSS Syntax 3 sec. 9.1
+  serializes an ident by escaping only what must be, which is right for a
+  reserialized token stream and wrong for a value sec. 4.1 says must not be
+  normalized. `Cascade.Token.t` gains `repr`, the source text of a token whose
+  spelling that serialization does not give back (#1065)
+
 - `Css.inline_vars` sees every place a `var()` can be written: an `@font-face`
   descriptor, `@page` and its margin boxes, a `@keyframes` frame,
   `@position-try`, a `@supports` condition and a nested rule. A descriptor

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -387,8 +387,8 @@ let string_repr_with_quote_opt t =
   match peek t with
   | Some
       (Component.Preserved
-         ({ kind = Token.String { value; quote; terminated }; loc } : Token.t))
-    ->
+         ({ kind = Token.String { value; quote; terminated }; loc; _ } :
+           Token.t)) ->
       skip t;
       Some (value, quote, if terminated then source_slice t loc else None)
   | _ -> None

--- a/lib/lexer.ml
+++ b/lib/lexer.ml
@@ -774,7 +774,16 @@ let tokenize_with_loc ?(force_url_function = false) ?(unicode_ranges = false)
     next_token ~force_url_function ~unicode_ranges ?on_comment reader
   in
   let end_pos = Reader.position reader in
-  Token.v ~kind ~loc:(Loc.v ~start_pos ~end_pos)
+  (* Section 9.1 serializes an ident by escaping only what must be, so a token
+     the author wrote with any other escape does not come back byte for byte.
+     Keep the source text for exactly those; a backslash is what marks one. *)
+  let repr =
+    let text =
+      String.sub (Reader.source reader) start_pos (end_pos - start_pos)
+    in
+    if String.contains text '\\' then Some text else None
+  in
+  Token.of_source ~repr ~kind ~loc:(Loc.v ~start_pos ~end_pos)
 
 (* [history] need only retain tokens since the last active [save]. With no saves
    the head is all [force_url_function]/[reconsume] read, so keep a one-element

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -762,6 +762,7 @@ and cvs_to_buffer_min ~minify_numbers ~in_math buf cvs =
    the single ident [ab]. *)
 let rec cv_to_buffer_verbatim buf : Component.t -> unit = function
   | Preserved { kind = Token.Whitespace run; _ } -> Buffer.add_string buf run
+  | Preserved { repr = Some repr; _ } -> Buffer.add_string buf repr
   | Preserved t -> add_token_kind buf t.kind
   | Block { node = { opening; value; _ }; _ } ->
       Buffer.add_char buf (opening_char opening);

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -748,7 +748,7 @@ let unquote_font_family_strings components =
     List.concat_map
       (fun c ->
         match c with
-        | Component.Preserved { kind = Token.String { value; _ }; loc }
+        | Component.Preserved { kind = Token.String { value; _ }; loc; _ }
           when can_unquote_font_family_name value ->
             changed := true;
             interleave loc (words_of value)

--- a/lib/selector.ml
+++ b/lib/selector.ml
@@ -435,7 +435,7 @@ let format_attribute_number n (unit : string option) =
 
 let read_attribute_value_unquoted t =
   match Cursor.peek t with
-  | Some (Component.Preserved { kind = Token.Ident s; loc }) ->
+  | Some (Component.Preserved { kind = Token.Ident s; loc; _ }) ->
       read_attribute_value_ident t s loc
   | Some (Component.Preserved { kind = Token.Number_tok _; _ })
   | Some (Component.Preserved { kind = Token.Dimension _; _ })

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3394,7 +3394,7 @@ let tail_closer text last n =
     match last with
     | Some { Token.kind = Token.String { quote; terminated = false; _ }; _ } ->
         [ String.make 1 quote ]
-    | Some { Token.kind = Token.Url _ | Token.Bad_url; loc }
+    | Some { Token.kind = Token.Url _ | Token.Bad_url; loc; _ }
       when loc.Loc.end_pos = String.length text ->
         [ ")" ]
     | _ -> [ "*/" ]

--- a/lib/token.ml
+++ b/lib/token.ml
@@ -40,7 +40,7 @@ type kind =
   | Close of bracket
   | Eof
 
-type t = { kind : kind; loc : Loc.t }
+type t = { kind : kind; loc : Loc.t; repr : string option }
 
 let equal_hash_flag (a : hash_flag) b = a = b
 let equal_number_flag (a : number_flag) b = a = b
@@ -55,8 +55,9 @@ let bracket_rank = function Curly -> 0 | Paren -> 1 | Square -> 2
 let compare_bracket a b = Int.compare (bracket_rank a) (bracket_rank b)
 let equal_kind (a : kind) b = a = b
 let compare_kind (a : kind) b = Stdlib.compare a b
-let v ~kind ~loc = { kind; loc }
-let synthetic kind = { kind; loc = Loc.dummy }
+let v ~kind ~loc = { kind; loc; repr = None }
+let of_source ~repr ~kind ~loc = { kind; loc; repr }
+let synthetic kind = { kind; loc = Loc.dummy; repr = None }
 
 let pp_kind : kind Pp.t =
  fun ctx -> function
@@ -125,7 +126,7 @@ let pp_kind : kind Pp.t =
   | Eof -> Pp.string ctx "<eof>"
 
 let pp : t Pp.t =
- fun ctx { kind; loc } ->
+ fun ctx { kind; loc; _ } ->
   pp_kind ctx kind;
   Pp.char ctx '@';
   Loc.pp ctx loc

--- a/lib/token.mli
+++ b/lib/token.mli
@@ -75,8 +75,13 @@ type kind =
   | Close of bracket  (** Closing bracket of a balanced group. *)
   | Eof
 
-type t = { kind : kind; loc : Loc.t }
-(** A located token: the section 4.2 payload plus the source range it covers. *)
+type t = { kind : kind; loc : Loc.t; repr : string option }
+(** A located token: the section 4.2 payload, the source range it covers, and
+    the source text when that text is not what serializing the payload gives
+    back. [repr] is [Some] only for a token written with an escape, which is the
+    one spelling section 9.1's serialization does not preserve: [colo\r] and
+    [color] are the same {!constructor-Ident}, and a stream that must round-trip
+    byte for byte needs to tell them apart. *)
 
 val equal_hash_flag : hash_flag -> hash_flag -> bool
 (** [equal_hash_flag a b] tests hash token flags for equality. *)
@@ -103,7 +108,12 @@ val compare_kind : kind -> kind -> int
 *)
 
 val v : kind:kind -> loc:Loc.t -> t
-(** [v ~kind ~loc] is a token with the given payload and location. *)
+(** [v ~kind ~loc] is a token with the given payload and location, spelled the
+    way serializing the payload spells it. *)
+
+val of_source : repr:string option -> kind:kind -> loc:Loc.t -> t
+(** [of_source ~repr ~kind ~loc] is {!val-v} carrying the source text the token
+    was read from; see {!type-t} for when that differs. *)
 
 val synthetic : kind -> t
 (** [synthetic k] is a token with payload [k] and {!Loc.dummy} - for test

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -279,7 +279,13 @@ let custom_properties_basic () =
      whitespace normalization: without it [a/**/b] becomes the ident [ab]. *)
   check_declaration ~minify:false ~expected:"--x: a  b" "--x:a  b";
   check_declaration ~minify:false ~expected:"--sp: a" "--sp:  a  ";
-  check_declaration ~minify:false ~expected:"--c: a b" "--c:a/**/b"
+  check_declaration ~minify:false ~expected:"--c: a b" "--c:a/**/b";
+  (* Section 9.1 serializes an ident by escaping only what must be, so an escape
+     the author wrote otherwise does not come back. A custom property's value is
+     not a reserialized stream, so its tokens keep the text they were read
+     from. *)
+  check_declaration ~minify:false ~expected:"--v: gre\\en" "--v: gre\\en";
+  check_declaration ~minify:false ~expected:"--w: colo\\r" "--w: colo\\r"
 
 let vendor_prefixes () =
   check_declaration ~expected:"-webkit-transform:rotate(45deg)"


### PR DESCRIPTION
`--v: gre\\en` came back as `gre\\E n` and `--w: colo\\r` as `color`. CSS Syntax 3 sec. 9.1 serializes an ident by escaping only what must be, which is the right answer for a reserialized token stream and the wrong one for a value CSS Custom Properties 1 sec. 4.1 says must not be normalized.

`Token.t` gains `repr`, the source text of a token whose spelling that serialization does not give back. The lexer sets it in one place, for a token written with an escape, and only `to_string_verbatim` reads it; `string_of_components` keeps the sec. 9.1 contract its own test pins. Adding a field rather than changing `Token.Ident` kept this to three construction sites instead of ~101.

Follow-up to #1064, which did the same for a whitespace run.