### PR TITLE
container: keep the spelling of a query condition

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -849,6 +849,11 @@ to lose a whole rule over one bad piece. Both are gone.
   normalized. `Cascade.Token.t` gains `repr`, the source text of a token whose
   spelling that serialization does not give back (#1065)
 
+- A container or media query keeps the escapes the author wrote, so
+  `@container (min-width: 1\0px)` no longer reaches the output with a raw
+  U+FFFD where the escape was. The condition is the question the rendering
+  browser is asked, not a value to respell (#1066)
+
 - `Css.inline_vars` sees every place a `var()` can be written: an `@font-face`
   descriptor, `@page` and its margin boxes, a `@keyframes` frame,
   `@position-try`, a `@supports` condition and a nested rule. A descriptor

--- a/lib/container.ml
+++ b/lib/container.ml
@@ -51,7 +51,8 @@ let format_rem f =
   if String.ends_with ~suffix:"." s then String.sub s 0 (String.length s - 1)
   else s
 
-let string_of_components cvs = Cursor.string_of_components ~trim:true cvs
+let string_of_components cvs =
+  Cursor.string_of_components_verbatim ~trim:true cvs
 
 let string_of_range_operator = function
   | Lt -> "<"

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -142,6 +142,12 @@ let string_of_components ?(trim = false) cvs =
   let s = Parser.string_of_components cvs in
   if trim then String.trim s else s
 
+(* A conditional group's prelude is the question the rendering browser is asked,
+   so the escape the author wrote survives; see {!Parser.to_string_verbatim}. *)
+let string_of_components_verbatim ?(trim = false) cvs =
+  let s = Parser.to_string_verbatim cvs in
+  if trim then String.trim s else s
+
 let string_of_remaining ?(trim = false) t =
   string_of_components ~trim (remaining t)
 

--- a/lib/cursor.mli
+++ b/lib/cursor.mli
@@ -98,6 +98,12 @@ val string_of_components : ?trim:bool -> Component.t list -> string
     useful for at-rule preludes that must be split structurally before being
     preserved as raw CSS text. *)
 
+val string_of_components_verbatim : ?trim:bool -> Component.t list -> string
+(** [string_of_components_verbatim cvs] is {!string_of_components} except that a
+    whitespace run and an escaped token write back the text they were read from.
+    A conditional group's prelude is the question the rendering browser is
+    asked, so its spelling survives. *)
+
 val string_of_remaining : ?trim:bool -> t -> string
 (** [string_of_remaining t] serializes the unconsumed tail without advancing
     [t]. *)

--- a/lib/media.ml
+++ b/lib/media.ml
@@ -547,8 +547,10 @@ let non_whitespace_components = List.filter (Fun.negate Component.is_whitespace)
 let components_empty components =
   match trim_components components with [] -> true | _ :: _ -> false
 
+(* A media or container query is the question the rendering browser is asked, so
+   a general-enclosed feature keeps the spelling the author wrote. *)
 let string_of_components components =
-  Cursor.string_of_components ~trim:true components
+  Cursor.string_of_components_verbatim ~trim:true components
 
 let ident_component = function
   | Component.Preserved { kind = Token.Ident name; _ } -> Some name

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -186,7 +186,7 @@ let property prop value =
   let value =
     if String.equal value "" then value
     else
-      Cursor.string_of_components ~trim:true
+      Cursor.string_of_components_verbatim ~trim:true
         (Cursor.remaining (Cursor.of_string value))
   in
   Property (declaration_feature prop value)
@@ -364,7 +364,7 @@ let declaration_of_components t prop value =
     err t value "Invalid declaration in @supports";
   match property_ident (strip_components prop) with
   | Some name -> (
-      let text = Cursor.string_of_components ~trim:true value in
+      let text = Cursor.string_of_components_verbatim ~trim:true value in
       (* [declaration_feature] is the shared constructor, so it reports through
          [Failure]; re-raise it against the declaration's own components. *)
       match declaration_feature name text with
@@ -378,13 +378,13 @@ let function_call t (fn : Component.func Component.node) =
   if not (Component.is_any_value [ Component.Func fn ]) then
     err t [ Component.Func fn ] "Invalid general-enclosed function in @supports";
   (* The feature grammar has priority over the general-enclosed fallback. *)
-  match func name (Cursor.string_of_components ~trim:true args) with
+  match func name (Cursor.string_of_components_verbatim ~trim:true args) with
   | feature -> feature
   | exception (Failure _ | Cursor.Parse_error _) ->
       Function
         (General
            ( String.lowercase_ascii name,
-             Cursor.string_of_components ~trim:true args ))
+             Cursor.string_of_components_verbatim ~trim:true args ))
 
 let peek_ident t =
   match Cursor.peek t with
@@ -464,7 +464,8 @@ and paren_components t value =
         condition
   with Cursor.Parse_error _ ->
     General_enclosed
-      (String.concat "" [ "("; Cursor.string_of_components value; ")" ])
+      (String.concat ""
+         [ "("; Cursor.string_of_components_verbatim value; ")" ])
 
 let read ?(allow_unwrapped_decl = false) t =
   let cond =

--- a/test/test_container.ml
+++ b/test/test_container.ml
@@ -22,6 +22,13 @@ let test_string_output () =
   Alcotest.(check string)
     "raw" "(width > 0px)"
     (to_string (of_string "(width > 0px)"));
+  (* A container condition is the question the rendering browser is asked, so
+     the escape the author wrote survives. CSS Syntax 3 sec. 4.3.7 decodes [\\0]
+     to U+FFFD, and writing that code point back raw is a different spelling of
+     the same query; Chrome 153 keeps the escape in [conditionText]. *)
+  Alcotest.(check string)
+    "an escape in a general-enclosed feature" "(min-width: 1\\0px)"
+    (to_string (of_string "(min-width: 1\\0px)"));
   Alcotest.(check string)
     "style query raw" "style(--theme: dark)"
     (to_string (of_string "style(--theme: dark)"));


### PR DESCRIPTION
`@container (min-width: 1\\0px)` reached the output with a raw U+FFFD where the escape was. A general-enclosed feature is reserialized from its components, and CSS Syntax 3 sec. 9.1 respells an escape there; the condition is the question the rendering browser is asked, so it now writes back the text it was read from. Chrome 153 keeps the escape in `conditionText`.

`parse_recovery --full` drops from 3 findings to 2. The two that remain are both `@supports`, whose condition holds a typed declaration that has already become a string before any serializer sees it; that needs its own change and is recorded on the entry.

Builds on #1065, which put the source text on the token.