### PR TITLE
supports: keep the spelling of a condition's declaration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -854,6 +854,11 @@ to lose a whole rule over one bad piece. Both are gone.
   U+FFFD where the escape was. The condition is the question the rendering
   browser is asked, not a value to respell (#1066)
 
+- An `@supports` condition keeps the escapes the author wrote, so
+  `@supports (color: gre\en)` no longer respells them. CSS Conditional Rules 3
+  sec. 6.1 answers a declaration feature by running that exact declaration
+  through the rendering browser's parser, so the text is the question (#1067)
+
 - `Css.inline_vars` sees every place a `var()` can be written: an `@font-face`
   descriptor, `@page` and its margin boxes, a `@keyframes` frame,
   `@position-try`, a `@supports` condition and a nested rule. A descriptor

--- a/lib/cursor.ml
+++ b/lib/cursor.ml
@@ -522,8 +522,11 @@ let rec skip_past_semicolon t =
 let ends_declaration_value cv =
   match component_head_shape cv with `Semicolon | `Bang -> true | _ -> false
 
+(* An unknown property's value is a stream cascade keeps rather than one it
+   respells, the same as a custom property's, so it writes back the text it was
+   read from; see {!string_of_components_verbatim}. *)
 let consume_to_decl_end ?(trim = false) t =
-  string_of_components ~trim (drain_until_raw ends_declaration_value t)
+  string_of_components_verbatim ~trim (drain_until_raw ends_declaration_value t)
 
 let drain_to_decl_end t = drain_until_raw ends_declaration_value t
 

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2857,17 +2857,17 @@ let rec pp : declaration Pp.t =
    itself is the compatibility question. *)
 let rec pp_opaque : declaration Pp.t =
  fun ctx decl ->
-  (* CSS Custom Properties 1 (ED) sec. 4.1 forbids normalizing the whitespace of
-     a custom property's value, so its runs are written back as read. An unknown
-     property has no such rule and takes the Syntax 3 sec. 9.1 serialization. *)
-  let pp_components ?(verbatim = false) property components important =
+  (* Every caller of this is an [@supports] condition, and CSS Conditional Rules
+     3 sec. 6.1 answers a declaration feature by running that exact declaration
+     through the rendering browser's parser. The text is the question, so it is
+     written back as read rather than respelled. *)
+  let pp_components property components important =
     pp_property ctx property;
     Pp.char ctx ':';
     Pp.space_if_pretty ctx ();
     Pp.string ctx
       (if Pp.minified ctx then Parser.to_string_minified components
-       else if verbatim then Parser.to_string_verbatim components
-       else Parser.string_of_components components);
+       else Parser.to_string_verbatim components);
     if important then
       Pp.string ctx (if ctx.minify then "!important" else " !important")
   in
@@ -2882,7 +2882,7 @@ let rec pp_opaque : declaration Pp.t =
         important;
         _;
       } ->
-      pp_components ~verbatim:true property components important
+      pp_components property components important
   | Declaration _ -> pp ctx decl
   | Theme_guarded { decl; _ } -> pp_opaque ctx decl
 

--- a/test/test_supports.ml
+++ b/test/test_supports.ml
@@ -81,7 +81,13 @@ let test_current_work_vectors () =
     "font-tech(color-COLRv1)";
   check "supports complex selector and property"
     "selector(:has(img)) and (container-type: inline-size)"
-    "selector(:has(img)) and (container-type: inline-size)"
+    "selector(:has(img)) and (container-type: inline-size)";
+  (* CSS Conditional Rules 3 sec. 6.1 answers a declaration feature by running
+     that exact declaration through the rendering browser's parser, so the text
+     is the question and its escapes survive. Chrome 153 keeps the escape in
+     [conditionText]. *)
+  check "an escape in a declaration feature" "(color: gre\\en)"
+    "(color: gre\\en)"
 
 let spec_supports_feature_vectors () =
   let check name input expected =


### PR DESCRIPTION
`@supports (color: gre\\en)` came back as `gre\\E n`. CSS Conditional Rules 3 sec. 6.1 answers a declaration feature by running that exact declaration through the rendering browser's parser, so the text is the question rather than a value to respell.

The value was serialized twice: once when it was captured (`consume_to_decl_end`) and again from the reparse of that text (`pp_opaque`). Both used the CSS Syntax 3 sec. 9.1 serialization, which escapes only what must be, so the first render had already lost the spelling by the time the second ran. Both now write back the text they read.

`parse_recovery --full` drops from 2 findings to 1. The one left is `@supports (colo\\r: green)`, where it is the property NAME that is respelled: it is held as a plain string and printed through `escape_ident`, a different path from the value.