### PR TITLE
scope: read the body as block-contents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -859,6 +859,11 @@ to lose a whole rule over one bad piece. Both are gone.
   sec. 6.1 answers a declaration feature by running that exact declaration
   through the rendering browser's parser, so the text is the question (#1067)
 
+- `@scope { color: green }` reads, where the whole at-rule used to be dropped
+  with a warning. CSS Cascade 6 sec. 3.5.2 gives `@scope` a `<block-contents>`
+  body, so a declaration written straight into it applies to the scoping root;
+  cascade read the body as rules only (#1068)
+
 - `Css.inline_vars` sees every place a `var()` can be written: an `@font-face`
   descriptor, `@page` and its margin boxes, a `@keyframes` frame,
   `@position-try`, a `@supports` condition and a nested rule. A descriptor

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -3986,13 +3986,16 @@ and read_supports (r : Cursor.t) : statement =
   Supports (Supports.read query, content)
 
 and read_scope (r : Cursor.t) : statement =
-  (* CSS Cascade 6 sec. 3.5.2: [@scope <start> to <end> { ... }]. The two
-     selectors are kept as raw strings; the block is consumed normally. *)
+  (* CSS Cascade 6 sec. 3.5.2 spells it [@scope <scope-boundaries>? {
+     <block-contents> }], and [<block-contents>] holds declarations as well as
+     rules: a declaration written straight into the body applies to the scoping
+     root, which Chrome reports as a [CSSNestedDeclarations]. The two selectors
+     are kept as raw strings. *)
   Cursor.expect_at_keyword "scope" r;
   Cursor.ws r;
   let prelude_components = Cursor.drain_until_block r in
   let scope_start, scope_end = scope_prelude r prelude_components in
-  let content = Cursor.braces (fun inner -> read_block inner) r in
+  let content = Cursor.braces (fun inner -> read_nesting_block inner) r in
   Scope (scope_start, scope_end, content)
 
 and read_container (r : Cursor.t) : statement =

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -1411,6 +1411,14 @@ let spec_strict_accepts_valid_stylesheets () =
       ("empty page margin box", "@page { @top-center { } }");
       ( "scope with end boundary",
         "@scope (.card) to (.footer) { .title { color: red } }" );
+      (* CSS Cascade 6 sec. 3.5.2 gives [@scope] a [<block-contents>] body, so a
+         declaration written straight into it applies to the scoping root.
+         Chrome 153 reports one as a [CSSNestedDeclarations] inside the
+         [CSSScopeRule]; cascade used to read the body as rules only and drop
+         the whole at-rule. *)
+      ("scope with a bare declaration", "@scope (.s) { color: green }");
+      ( "scope mixing a declaration and a rule",
+        "@scope (.s) { color: green; .a { color: red } }" );
       ( "font-face wildcard unicode range",
         "@font-face { font-family: Icons; src: url(icons.woff2); \
          unicode-range: U+4?? }" );


### PR DESCRIPTION
`@scope { color: green }` was dropped with a warning, and Chrome keeps it as a `CSSNestedDeclarations` inside the `CSSScopeRule`. CSS Cascade 6 sec. 3.5.2 spells the rule `@scope <scope-boundaries>? { <block-contents> }`, and `<block-contents>` holds declarations as well as rules: one written straight into the body applies to the scoping root.

The body was read as rules only, so the declaration was parsed as a selector ("unknown pseudo-class in unforgiving selector list") and took the whole at-rule with it. The nested `@media`/`@supports`/`@layer` bodies already use the block-contents reader.

`parse_recovery --full` over-discards drop from 2 to 1.