### PR TITLE
syntax: end an at-rule in a declaration block at its own block

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -864,6 +864,11 @@ to lose a whole rule over one bad piece. Both are gone.
   body, so a declaration written straight into it applies to the scoping root;
   cascade read the body as rules only (#1068)
 
+- An at-rule inside a keyframe or descriptor block costs only itself, where it
+  used to take the rest of the block: `@keyframes k { to { @e {} opacity: 1 } }`
+  keeps the opacity. CSS Syntax 3 sec. 5.5.5 consumes an at-rule there, so it
+  ends at its own block rather than at the next `;` (#1069)
+
 - `Css.inline_vars` sees every place a `var()` can be written: an `@font-face`
   descriptor, `@page` and its margin boxes, a `@keyframes` frame,
   `@position-try`, a `@supports` condition and a nested rule. A descriptor

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2693,10 +2693,39 @@ let recover_declaration_step t acc e ~from =
     e;
   acc
 
+(* CSS Syntax 3 (ED) sec. 5.5.5 consumes an AT-RULE when a block's contents meet
+   an at-keyword, so it ends at its own block or [;], not at the next [;] the
+   way an invalid declaration does. A keyframe or descriptor block has no
+   grammar for one, so it is dropped - but only it: [@keyframes
+   k{to{@e{}opacity:1}}] keeps the opacity, which is what the browser keeps
+   too. *)
+let skip_at_rule t =
+  Cursor.skip t;
+  let rec go () =
+    match Cursor.peek_head_shape t with
+    | `Eof -> ()
+    | `Curly_block | `Semicolon -> Cursor.skip t
+    | _ ->
+        Cursor.skip t;
+        go ()
+  in
+  go ()
+
 let rec read_declarations_loop t acc =
   Cursor.ws t;
   match Cursor.peek t with
   | None -> List.rev acc
+  | Some _ when Option.is_some (Cursor.peek_at_keyword t) ->
+      let from = Cursor.save t in
+      let error =
+        try Cursor.err t "at-rule in a declaration block"
+        with Cursor.Parse_error e -> e
+      in
+      skip_at_rule t;
+      Cursor.push_warning t
+        ~recovery:(Cursor.dropped_since t from Error.Recovery.Rule)
+        error;
+      read_declarations_loop t acc
   | _ -> (
       match read_declaration_step t acc with
       | Done decls -> decls

--- a/test/render/parse_recovery.ml
+++ b/test/render/parse_recovery.ml
@@ -695,8 +695,19 @@ let verdict answer =
    it honest. The day Chrome fixes this the corpus stops producing a finding of
    the shape and the run says the excuse is stale; a finding of any other shape
    is fatal whatever the input holds. *)
+(* [@keyframes] belongs here for the same reason as the conditional groups: its
+   contents are rules (keyframe rules), so section 5.5.5's "discard and
+   continue" applies to a [;] among them. Chrome 153 keeps only the frames after
+   the [;], dropping [from] in [@keyframes k{;from{opacity:0}to{opacity:1}}]. *)
 let rule_block_at_rules =
-  [ "@media"; "@supports"; "@container"; "@layer"; "@starting-style" ]
+  [
+    "@media";
+    "@supports";
+    "@container";
+    "@layer";
+    "@starting-style";
+    "@keyframes";
+  ]
 
 let semicolon_in_a_rule_block css =
   let n = String.length css in

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -2292,6 +2292,15 @@ let spec_lenient_recovery_keyframes_at_rule () =
        "from { color: red } @zzz [a] { to { color: pink } } 50% { background: \
         lime }")
     recovered 1;
+  (* Sec. 5.5.5 consumes an AT-RULE when a block's contents meet an at-keyword,
+     so it ends at its own block rather than at the next [;]: a keyframe's
+     declarations after one survive. Chrome 153 keeps both frames here. *)
+  lenient_recover "an at-rule inside a keyframe block costs only itself"
+    "@keyframes k { from { y: 0 } to { @e {} opacity: 1 } }"
+    "@keyframes k{0%{y:0}to{opacity:1}}" 1;
+  lenient_recover "an at-rule inside a descriptor block costs only itself"
+    "@font-face { font-family: X; @e {} src: url(a.woff2) }"
+    "@font-face{font-family:X;src:url(a.woff2)}" 1;
   lenient_recover "two at-rules in @keyframes are dropped one at a time"
     (body
        "from { color: red } @media print { a: b } @supports (display: grid) { \


### PR DESCRIPTION
`@keyframes k { from { y: 0 } to { @e {} opacity: 1 } }` lost the whole `to` frame; Chrome keeps both frames. CSS Syntax 3 sec. 5.5.5 consumes an AT-RULE when a block's contents meet an at-keyword, so it ends at its own block rather than at the next `;`. The declarations reader had no branch for one, so it fell into declaration recovery, which skips to the next `;` and took the rest of the block with it. `@font-face` and the other descriptor blocks recover the same way now.

Also adds `@keyframes` to the harness's excused browser deviation: its contents are keyframe rules, so a `;` among them is sec. 5.5.5's "discard and continue", and Chrome stops there instead — the same shape already excused for the conditional groups. Measured: Chrome drops the `from` frame in `@keyframes k{;from{opacity:0}to{opacity:1}}`.

`parse_recovery --full` is now **0 over-discard, 0 under-discard**. The one finding left is the prelude respelling, which is a separate open question.