### PR TITLE
inline: give vertical-align a length-percentage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,13 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `Cascade.Properties.vertical_align` carries a `Length of length_percentage`
+  where it carried `Zero`, `Px`, `Rem`, `Em`, `Pct` and `Calc`, so
+  `vertical-align: 2ch`, `2vh`, `2cap` and `max(1rem,2vw)` read. CSS Inline 3
+  sec. 4.2 gives the property a `<length-percentage>`, which every length unit
+  is; the reader carried a list of four. A caller building a literal writes
+  `Length (Px 10.)` (#1070)
+
 - The `Number` of `Cascade.Properties.dash_length` carries a `number` where it
   carried a `float`, and `animation_iteration_count` replaces its `Num of float`
   with `Count of number`, so `stroke-dasharray: calc(1 + 2)` and

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -8474,12 +8474,7 @@ type vertical_align = Properties.vertical_align =
   | Text_bottom
   | Sub
   | Super
-  | Zero
-  | Px of float
-  | Rem of float
-  | Em of float
-  | Pct of float
-  | Calc of vertical_align calc
+  | Length of length_percentage
   | Inherit
   | Initial
   | Unset

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -13,18 +13,11 @@ open Properties_intf
 open Prop_common
 open Prop_background
 
+(* CSS Inline 3 sec. 4.2 gives the property a [<length-percentage>], so every
+   length unit is valid here and the intrinsic-sizing keywords a bare length
+   reader would take are not. *)
 let read_vertical_align_length t : vertical_align =
-  let n, unit = Cursor.number_with_unit t in
-  match unit with
-  | Some "px" -> Px n
-  | Some "rem" -> Rem n
-  | Some "em" -> Em n
-  | Some "%" -> Pct n
-  (* A unitless [0] is the valid zero <length> (CSS Values 4 sec. 6); any other
-     unitless number is not a length and is rejected. *)
-  | None when n = 0. -> Zero
-  | None -> Cursor.err_invalid t "vertical-align requires a unit"
-  | Some u -> Cursor.err_invalid t ("invalid vertical-align unit: " ^ u)
+  Length (read_length_percentage ~with_keywords:false t)
 
 let rec read_text_align t : text_align =
   Cursor.enum_or_var "text-align"
@@ -1442,12 +1435,7 @@ let rec pp_vertical_align : vertical_align Pp.t =
   | Text_bottom -> Pp.string ctx "text-bottom"
   | Sub -> Pp.string ctx "sub"
   | Super -> Pp.string ctx "super"
-  | Zero -> Pp.string ctx "0"
-  | Px f -> Pp.unit ctx f "px"
-  | Rem f -> Pp.unit ctx f "rem"
-  | Em f -> Pp.unit ctx f "em"
-  | Pct p -> Pp.pct ctx p
-  | Calc c -> pp_calc pp_vertical_align ctx c
+  | Length lp -> pp_length_percentage ~always:true ctx lp
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -2148,9 +2136,6 @@ let rec read_text_decoration_skip_ink t : text_decoration_skip_ink =
 
 let rec read_vertical_align t : vertical_align =
   let read_var t : vertical_align = Var (read_var read_vertical_align t) in
-  let read_calc t : vertical_align =
-    Calc (read_calc ~result_type:`Value read_vertical_align t)
-  in
   Cursor.enum_or_calls "vertical-align"
     [
       ("baseline", (Baseline : vertical_align));
@@ -2167,7 +2152,7 @@ let rec read_vertical_align t : vertical_align =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~calls:[ ("var", read_var); ("calc", read_calc) ]
+    ~calls:[ ("var", read_var) ]
     ~default:read_vertical_align_length t
 
 module Text_shadow = struct
@@ -2262,8 +2247,9 @@ let text_decoration_shorthand ?lines ?style ?color ?thickness () :
 
 let normalize_vertical_align (va : vertical_align) : vertical_align =
   match va with
-  | Calc c -> (
-      match Values.eval_calc c with Values.Val v -> v | folded -> Calc folded)
+  | Length lp ->
+      let lp' = Values.normalize_length_percentage lp in
+      if lp' == lp then va else Length lp'
   | _ -> va
 
 let read_initial_letter_align_keyword t : initial_letter_align_keyword =

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1761,6 +1761,10 @@ type table_layout =
   | Revert_layer
   | Var of table_layout var
 
+(** CSS Inline 3 sec. 4.2 [vertical-align]: the keywords, or a
+    [<length-percentage>] raising the box by that much. Every length unit is one
+    of them, which is why this is not a list of the four the property is usually
+    written with. *)
 type vertical_align =
   | Baseline
   | Top
@@ -1770,12 +1774,7 @@ type vertical_align =
   | Text_bottom
   | Sub
   | Super
-  | Zero
-  | Px of float
-  | Rem of float
-  | Em of float
-  | Pct of float
-  | Calc of vertical_align calc
+  | Length of length_percentage
   | Inherit
   | Initial
   | Unset

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -2423,7 +2423,17 @@ let test_vertical_align () =
   (* A unitless 0 is the valid zero <length> and stays unitless; any other
      unitless number is not a length. *)
   check_vertical_align "0";
+  (* Every length unit is a [<length-percentage>], so the reader takes no list
+     of its own: [ch], [vh] and [cap] read like [px], and a math function over
+     them does too. Chrome 153 takes all four. *)
+  check_vertical_align "2ch";
+  check_vertical_align "2vh";
+  check_vertical_align "2cap";
+  check_vertical_align "max(1rem,2vw)";
   neg_cursor read_vertical_align "5";
+  (* The grammar has no keyword branch, so the intrinsic sizes a bare length
+     reader would take are out. *)
+  neg_cursor read_vertical_align "min-content";
   neg_cursor read_vertical_align "invalid-align"
 
 let test_font_family () =


### PR DESCRIPTION
`vertical-align: 2ch`, `2vh`, `2cap` and `max(1rem,2vw)` were dropped with a warning; Chrome 153 takes all four. CSS Inline 3 sec. 4.2 spells the property as the keywords or a `<length-percentage>`, and every length unit is one — the reader carried `px`, `rem`, `em` and `%` and turned the rest away by name.

Six constructors collapse into one `Length of length_percentage`, which also subsumes the hand-rolled `Calc` arm. A unitless `5` is still refused, and so are the intrinsic sizes, since the grammar has no keyword branch.