### PR TITLE
sizing: put none inside a contain-intrinsic slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,13 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `Cascade.Properties.contain_intrinsic_size_item` gains `None` and
+  `Auto_none`, so `contain-intrinsic-width: auto none` and
+  `contain-intrinsic-size: none 2ch` read. CSS Sizing 4 sec. 6 spells a slot
+  `auto? [ none | <length [0,inf]> ]`, so `none` sits in a slot rather than
+  standing for the whole value. Exhaustive visitors must handle the two new
+  leaves (#1071)
+
 - `Cascade.Properties.vertical_align` carries a `Length of length_percentage`
   where it carried `Zero`, `Px`, `Rem`, `Em`, `Pct` and `Calc`, so
   `vertical-align: 2ch`, `2vh`, `2cap` and `max(1rem,2vw)` read. CSS Inline 3

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7910,7 +7910,9 @@ val container_type : container_type -> declaration
      [contain-intrinsic-size]}, a length that the [auto] prefix lets a
     remembered size override. *)
 type contain_intrinsic_size_item = Properties.contain_intrinsic_size_item =
+  | None
   | Length of length
+  | Auto_none
   | Auto of length
 
 (** CSS Sizing 4

--- a/lib/prop_layout.ml
+++ b/lib/prop_layout.ml
@@ -248,7 +248,12 @@ let rec pp_position_area : position_area Pp.t =
 
 let pp_contain_intrinsic_size_item : contain_intrinsic_size_item Pp.t =
  fun ctx -> function
+  | None -> Pp.string ctx "none"
   | Length len -> pp_length ~always:true ctx len
+  | Auto_none ->
+      Pp.string ctx "auto";
+      Pp.space ctx ();
+      Pp.string ctx "none"
   | Auto len ->
       Pp.string ctx "auto";
       Pp.space ctx ();
@@ -540,24 +545,35 @@ let rec read_position_anchor (t : Cursor.t) : position_anchor =
 
 (* CSS Sizing 4 sec. 5: [contain-intrinsic-size] takes [<length>], and no
    percentage, which Chrome 146 refuses. *)
+(* Sec. 6: [auto? [ none | <length [0,inf]> ]], so [none] is one of the two
+   things the optional [auto] may precede. *)
 let read_contain_intrinsic_size_item t : contain_intrinsic_size_item =
   let size t =
     Values.read_length ~allow_negative:false ~with_keywords:false
       ~length_only:true t
   in
+  let none_or_size t ~auto : contain_intrinsic_size_item =
+    Cursor.ws t;
+    match Cursor.peek_ident t with
+    | Some "none" ->
+        let _ = Cursor.ident t in
+        if auto then Auto_none else None
+    | _ -> if auto then Auto (size t) else Length (size t)
+  in
   Cursor.ws t;
   match Cursor.peek_ident t with
   | Some "auto" ->
       let _ = Cursor.ident t in
-      Cursor.ws t;
-      (Auto (size t) : contain_intrinsic_size_item)
-  | _ -> Length (size t)
+      none_or_size t ~auto:true
+  | _ -> none_or_size t ~auto:false
 
 let rec read_contain_intrinsic_size (t : Cursor.t) : contain_intrinsic_size =
+  (* [none] is not a whole-value keyword here: sec. 6 puts it inside each of the
+     one or two slots, so [none 2ch] is a pair and a lone [none] is a one-slot
+     value that prints the same. *)
   let keywords : (string * contain_intrinsic_size) list =
     [
-      ("none", None);
-      ("initial", Initial);
+      ("initial", (Initial : contain_intrinsic_size));
       ("inherit", Inherit);
       ("unset", Unset);
       ("revert", Revert);

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3745,7 +3745,13 @@ type image_resolution =
   | Revert_layer
   | Var of image_resolution var
 
-type contain_intrinsic_size_item = Length of length | Auto of length
+(** CSS Sizing 4 sec. 6 spells one slot [auto? [ none | <length [0,inf]> ]], so
+    the keyword takes the [auto] prefix as a length does. *)
+type contain_intrinsic_size_item =
+  | None
+  | Length of length
+  | Auto_none
+  | Auto of length
 
 type contain_intrinsic_size =
   | None

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1201,7 +1201,9 @@ let vars_of_image_resolution (value : Properties.image_resolution) =
 
 let vars_of_intrinsic_size_item (value : Properties.contain_intrinsic_size_item)
     =
-  match value with Length len | Auto len -> vars_of_length len
+  match value with
+  | Length len | Auto len -> vars_of_length len
+  | None | Auto_none -> []
 
 let vars_of_contain_intrinsic_size (value : Properties.contain_intrinsic_size) =
   match value with

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -5063,6 +5063,17 @@ let spec_generated_box_layout_edges () =
   check_contain_intrinsic_longhand "auto 10px";
   check_contain_intrinsic_size "auto 10px 20px";
   check_contain_intrinsic_size_item "auto 10px";
+  (* CSS Sizing 4 sec. 6 spells a slot [auto? [ none | <length [0,inf]> ]], so
+     [none] is one of the two things the optional [auto] may precede and it sits
+     in a slot rather than standing for the whole value. Chrome 153 takes each
+     of these. *)
+  check_contain_intrinsic_longhand "auto none";
+  check_contain_intrinsic_longhand "none";
+  check_contain_intrinsic_size "none 2ch";
+  check_contain_intrinsic_size "auto none";
+  check_contain_intrinsic_size "none";
+  check_contain_intrinsic_size_item "none";
+  check_contain_intrinsic_size_item "auto none";
   check_counter_item "section 2";
   check_counter_set "section 2 subsection";
   check_dominant_baseline "text-bottom";


### PR DESCRIPTION
`contain-intrinsic-width: auto none` and `contain-intrinsic-size: none 2ch` were dropped with a warning; Chrome 153 takes both. CSS Sizing 4 sec. 6 spells a slot `auto? [ none | <length [0,inf]> ]`, so `none` is one of the two things the optional `auto` may precede, and the shorthand repeats that slot `{1,2}` rather than taking `none` for the whole value.

The item held only a length, so neither form had a representation. `none` also leaves the shorthand's whole-value keyword list, since a lone `none` is a one-slot value that prints the same.