### PR TITLE
shapes: let shape-image-threshold take a math function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,13 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `Cascade.Properties.shape_image_threshold` gains `Calc`, so
+  `shape-image-threshold: calc(50% + 25%)` and `min(.2,.8)` read where they
+  were dropped with a warning. CSS Shapes 1 sec. 6.2 takes an
+  `<opacity-value>`, and CSS Values 4 sec. 10.1 puts a math function wherever
+  its type is, which `opacity` already read that way. Exhaustive visitors must
+  handle the new leaf (#1072)
+
 - `Cascade.Properties.contain_intrinsic_size_item` gains `None` and
   `Auto_none`, so `contain-intrinsic-width: auto none` and
   `contain-intrinsic-size: none 2ch` read. CSS Sizing 4 sec. 6 spells a slot

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -5669,6 +5669,7 @@ val initial_letter_wrap : initial_letter_wrap -> declaration
     is inside the shape. *)
 type shape_image_threshold = Properties.shape_image_threshold =
   | Number of float
+  | Calc of shape_image_threshold calc
   | Inherit
   | Initial
   | Unset

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -505,6 +505,7 @@ let rec read_opacity t : opacity =
 let rec pp_shape_image_threshold : shape_image_threshold Pp.t =
  fun ctx -> function
   | Number n -> Pp.float ctx n
+  | Calc c -> pp_calc pp_shape_image_threshold ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -512,9 +513,37 @@ let rec pp_shape_image_threshold : shape_image_threshold Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_shape_image_threshold ctx v
 
+(* A [<percentage>] operand of a [shape-image-threshold] math function is the
+   number it denotes (50% = .5), and a raw [<number>] is left to [read_calc]'s
+   own [Num] path, the way [opacity] reads the same [<opacity-value>]. *)
+let rec read_threshold_dim_only t : shape_image_threshold =
+  Cursor.ws t;
+  Cursor.one_of
+    [
+      (fun t -> (Number (Cursor.pct t /. 100.) : shape_image_threshold));
+      (fun t ->
+        Cursor.enum_or_calls "shape-image-threshold"
+          [
+            ("inherit", (Inherit : shape_image_threshold));
+            ("initial", Initial);
+            ("unset", Unset);
+            ("revert", Revert);
+            ("revert-layer", Revert_layer);
+          ]
+          ~calls:
+            [
+              ("var", fun t -> Var (Values.read_var read_threshold_dim_only t));
+            ]
+          t);
+    ]
+    t
+
 let rec read_shape_image_threshold t : shape_image_threshold =
   let read_var t : shape_image_threshold =
     Var (read_var read_shape_image_threshold t)
+  in
+  let read_numeric_math t : shape_image_threshold =
+    Number (Values.read_numeric_expression t)
   in
   (* CSS Shapes 1 sec. 6.2 takes an [<opacity-value>], which CSS Color 4 spells
      [<number> | <percentage>], and computes it "clamped to the range [0,1]":
@@ -534,7 +563,18 @@ let rec read_shape_image_threshold t : shape_image_threshold =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~calls:[ ("var", read_var) ]
+    ~calls:
+      [
+        ("var", read_var);
+        ( "calc",
+          fun t ->
+            Calc
+              (Values.read_calc ~result_type:`Number_or_value
+                 read_threshold_dim_only t) );
+        ("min", read_numeric_math);
+        ("max", read_numeric_math);
+        ("clamp", read_numeric_math);
+      ]
     ~default:read_number t
 
 let rec pp_overflow : overflow Pp.t =
@@ -1210,6 +1250,29 @@ let rec flatten_opacity_pct (c : opacity Values.calc) : opacity Values.calc =
   | Values.Expr (l, op, r) ->
       Values.Expr (flatten_opacity_pct l, op, flatten_opacity_pct r)
   | _ -> c
+
+(* The same fold [opacity] gets, for the same [<opacity-value>]: a percentage
+   leaf is the number it denotes, so a constant expression over percentages
+   reduces to one number rather than staying a call over two. *)
+let rec flatten_threshold_pct (c : shape_image_threshold Values.calc) :
+    shape_image_threshold Values.calc =
+  match c with
+  | Values.Val (Number f) -> Values.Num f
+  | Values.Nested inner -> Values.Nested (flatten_threshold_pct inner)
+  | Values.Parens inner -> Values.Parens (flatten_threshold_pct inner)
+  | Values.Expr (l, op, r) ->
+      Values.Expr (flatten_threshold_pct l, op, flatten_threshold_pct r)
+  | _ -> c
+
+let normalize_shape_image_threshold (v : shape_image_threshold) :
+    shape_image_threshold =
+  match v with
+  | Calc c -> (
+      match Values.eval_calc (flatten_threshold_pct c) with
+      | Values.Num f -> Number f
+      | Values.Val value -> value
+      | folded -> Calc folded)
+  | _ -> v
 
 let normalize_opacity (o : opacity) : opacity =
   match o with

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4393,6 +4393,7 @@ let normalize_property_value : type a.
   | Webkit_mask_position -> map_preserve normalize_position_value value
   | Text_indent -> normalize_text_indent value
   | Animation_range -> normalize_animation_range value
+  | Shape_image_threshold -> normalize_shape_image_threshold value
   | Tab_size -> normalize_tab_size ~ctx value
   | Hyphenate_limit_chars -> normalize_hyphenate_limit_chars ~ctx value
   | Animation_iteration_count -> normalize_animation_iteration_count ~ctx value

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -203,6 +203,7 @@ type opacity =
 
 type shape_image_threshold =
   | Number of float
+  | Calc of shape_image_threshold calc
   | Inherit
   | Initial
   | Unset

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1011,6 +1011,7 @@ let vars_of_shape_image_threshold (value : Properties.shape_image_threshold) :
     any_var list =
   match value with
   | Var v -> [ V v ]
+  | Calc c -> vars_of_calc c
   | Number _ | Inherit | Initial | Unset | Revert | Revert_layer -> []
 
 let vars_of_overflow_clip_margin (value : Properties.overflow_clip_margin) :

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -5124,6 +5124,13 @@ let spec_generated_box_layout_edges () =
   check_shape_image_threshold "2";
   check_value_cursor "shape_image_threshold" read_shape_image_threshold
     pp_shape_image_threshold ~expected:".5" "50%";
+  (* CSS Values 4 sec. 10.1 puts a math function wherever its type is, and
+     [opacity] reads the same [<opacity-value>] that way already. Chrome 153
+     takes each of these. *)
+  check_shape_image_threshold "calc(.2 + .3)";
+  check_value_cursor "shape_image_threshold" read_shape_image_threshold
+    pp_shape_image_threshold ~expected:"calc(.5 + .25)" "calc(50% + 25%)";
+  check_shape_image_threshold ~expected:".2" "min(.2,.8)";
   neg_cursor read_shape_image_threshold "2px";
   check_tab_size "4";
   check_zoom "50%";


### PR DESCRIPTION
`shape-image-threshold: calc(50% + 25%)` and `min(.2,.8)` were dropped with a warning, while `opacity` — which reads the same `<opacity-value>` — took both. CSS Shapes 1 sec. 6.2 takes that value and CSS Values 4 sec. 10.1 puts a math function wherever its type is; the reader had a `var()` call and nothing else.

Mirrors `opacity` throughout: a percentage operand is the number it denotes, a bare number falls to `read_calc`'s own `Num` path, and the constant fold reduces `calc(50% + 25%)` to `.75` rather than leaving `calc(.5 + .25)`.

Found by auditing for hand-rolled unit whitelists, the shape behind #1070.