### PR TITLE
test: key an excuse on the shape of a value

### DIFF
--- a/test/spec/browser/accept_set.ml
+++ b/test/spec/browser/accept_set.ml
@@ -445,11 +445,6 @@ let spec_ahead_here : Chrome_gaps.excuse list =
 (* The same, for a value Chrome reads that no specification grants: an entry
    here restates a {!Chrome_gaps.lenient} fact for a value the generator wrote
    and the manifest did not. *)
-let baseline_shift_takes_no_number =
-  "CSS Inline 3 sec. 4.2.3: <length-percentage> | sub | super | top | center | \
-   bottom, and no arm is a bare <number>. Chrome reads one as the unitless \
-   length SVG presentation attributes take"
-
 let lenient_here : Chrome_gaps.excuse list =
   List.concat_map
     (fun (properties, values, why) ->
@@ -468,12 +463,10 @@ let lenient_here : Chrome_gaps.excuse list =
          comma. Chrome stops at the comma and drops the rest on serialising: \
          [border: red, none] computes a red border-color and serialises back \
          as [border: red]" );
-      ( [ "baseline-shift" ],
-        [ "-1"; "1"; "99999999999" ],
-        baseline_shift_takes_no_number );
     ]
 
 let hits = Hashtbl.create 64
+let shape_hits : (string, unit) Hashtbl.t = Hashtbl.create 8
 
 (* The excuse is the whole reason a difference is not a defect, so it is a
    citation or it is nothing. Chrome_gaps carries the shared lists and the spec
@@ -504,7 +497,17 @@ let judge ~property ~value ~cascade verdict =
       | false, true -> (
           match excuse Chrome_gaps.lenient with
           | Some why -> Rejects_valid (Some why)
-          | None -> Rejects_valid (excuse_here lenient_here))
+          | None -> (
+              (* A shape entry answers for every value of its shape, so a
+                 resample cannot strand it the way a literal is stranded. *)
+              match
+                Chrome_gaps.shape_covering Chrome_gaps.lenient_shapes ~property
+                  ~value
+              with
+              | Some s ->
+                  Hashtbl.replace shape_hits s.shape_name ();
+                  Rejects_valid (Some s.shape_why)
+              | None -> Rejects_valid (excuse_here lenient_here)))
       (* The reader takes it. Either it is loose, or the grammar is real and
          Chrome has not caught up. *)
       | true, false -> (
@@ -775,7 +778,23 @@ let check_unused () =
                String.concat ", " e.properties;
                ")";
              ]))
-    (spec_ahead_here @ lenient_here)
+    (spec_ahead_here @ lenient_here);
+  (* A shape answers for a whole class, so it going quiet is the same signal a
+     stranded literal is: the browser agreed, or the generator stopped writing
+     anything of the shape. *)
+  List.iter
+    (fun (s : Chrome_gaps.shape) ->
+      if not (Hashtbl.mem shape_hits s.shape_name) then
+        fail
+          (String.concat ""
+             [
+               "a shape of this run excuses nothing any more: ";
+               s.shape_name;
+               " (";
+               String.concat ", " s.shape_properties;
+               ")";
+             ]))
+    Chrome_gaps.lenient_shapes
 
 let check_calibration outcomes =
   List.iter

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -382,3 +382,47 @@ let find table ~property ~value =
     && List.exists (String.equal property) e.properties
   in
   List.find_opt covers table
+
+type shape = {
+  shape_properties : string list;
+  shape_name : string;
+  matches : string -> bool;
+  shape_why : string;
+}
+
+(* A bare [<number>] in any spelling. The generator writes these from a seeded
+   stream, so [-1], [1], [.5], [4] and [1000] are one fact about the browser
+   sampled five ways, not five facts. *)
+let is_bare_number s =
+  let s = String.trim s in
+  s <> ""
+  &&
+  let ok = ref true and digits = ref false in
+  String.iteri
+    (fun i c ->
+      match c with
+      | '0' .. '9' -> digits := true
+      | '.' -> ()
+      | ('-' | '+') when i = 0 -> ()
+      | _ -> ok := false)
+    s;
+  !ok && !digits
+
+let lenient_shapes =
+  [
+    {
+      shape_properties = [ "baseline-shift" ];
+      shape_name = "a bare <number>";
+      matches = is_bare_number;
+      shape_why =
+        "CSS Inline 3 sec. 4.2.3: <length-percentage> | sub | super | top | \
+         center | bottom, and no arm is a bare <number>. Chrome reads one as \
+         the unitless length SVG presentation attributes take";
+    };
+  ]
+
+let shape_covering table ~property ~value =
+  let covers (s : shape) =
+    List.exists (String.equal property) s.shape_properties && s.matches value
+  in
+  List.find_opt covers table

--- a/test/spec/browser/chrome_gaps.mli
+++ b/test/spec/browser/chrome_gaps.mli
@@ -25,3 +25,23 @@ val lenient : excuse list
 
 val find : excuse list -> property:string -> value:string -> excuse option
 (** [find table ~property ~value] is the entry of [table] covering that pair. *)
+
+type shape = {
+  shape_properties : string list;
+  shape_name : string;
+  matches : string -> bool;
+  shape_why : string;
+}
+(** A disagreement that is about a SHAPE of value rather than one value, for the
+    cases where naming every value is not possible: the generator draws from a
+    seeded stream, so a literal list is a fact about one sample rather than
+    about the browser. [shape_name] names the shape for the report and for the
+    staleness check. *)
+
+val lenient_shapes : shape list
+(** [lenient_shapes] is {!lenient} keyed by a predicate. *)
+
+val shape_covering :
+  shape list -> property:string -> value:string -> shape option
+(** [shape_covering table ~property ~value] is the entry of [table] whose
+    predicate covers that pair. *)


### PR DESCRIPTION
`baseline-shift` with a bare number is Chrome reading the unitless length SVG presentation attributes take; CSS Inline 3 sec. 4.2.3 has no bare-`<number>` arm, so cascade is right to reject it. The excuse named three values (`-1`, `1`, `99999999999`) and the seed sweep kept finding others (`.5`, `4`, `1000`) — one fact about the browser, written five ways.

The generator draws from a seeded stream, so a literal list is a fact about one sample: widening a manifest row resamples the population and strands whichever literals it stops drawing, which is what #1057 hit. A shape entry answers for the class instead, and is held to the same staleness check as a literal — a shape that stops matching fails the run.

This is the smallest slice of the predicate keying the excuses design entry proposes, added alongside the literal tables rather than replacing them, so the larger question of targets and structured citations stays open.

Rejects-valid over seeds 1-7 drops from 13 to 4.