### PR TITLE
animation: read animation-timeline as a list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,11 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `Cascade.Properties.animation_timeline` gains `Timelines`, so
+  `animation-timeline: none, auto` and `scroll(), view()` read. CSS Animations
+  2 sec. 5 spells the property `<single-animation-timeline>#`, one entry per
+  animation. Exhaustive visitors must handle the new leaf (#1074)
+
 - `Cascade.Properties.shape_image_threshold` gains `Calc`, so
   `shape-image-threshold: calc(50% + 25%)` and `min(.2,.8)` read where they
   were dropped with a warning. CSS Shapes 1 sec. 6.2 takes an

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -6882,6 +6882,7 @@ and animation_timeline = Properties.animation_timeline =
   | Name of string
   | Scroll of string
   | View of string
+  | Timelines of animation_timeline list
   | Initial
   | Inherit
   | Unset

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -226,6 +226,8 @@ let canonical_view_timeline_args args =
 let rec pp_animation_timeline : animation_timeline Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_animation_timeline ctx v
+  | Timelines timelines ->
+      Pp.list ~sep:Pp.comma pp_animation_timeline ctx timelines
   | None -> Pp.string ctx "none"
   | Auto -> Pp.string ctx "auto"
   | Name name -> pp_ident ctx name
@@ -655,7 +657,18 @@ let rec pp_transition : transition Pp.t =
   | Var v -> pp_var pp_transition ctx v
   | Shorthand s -> pp_transition_shorthand ctx s
 
+(* CSS Animations 2 sec. 5 spells the property [<single-animation-timeline>#],
+   one entry per animation. A [var()] and the CSS-wide keywords stand for the
+   whole value, which is why they are read inside the entry rather than beside
+   the list: an entry that is one of them is the only entry. *)
 let rec read_animation_timeline (t : Cursor.t) : animation_timeline =
+  match
+    Cursor.list ~sep:Cursor.comma ~at_least:1 read_animation_timeline_one t
+  with
+  | [ timeline ] -> timeline
+  | timelines -> Timelines timelines
+
+and read_animation_timeline_one (t : Cursor.t) : animation_timeline =
   Cursor.ws t;
   match Cursor.peek t with
   | Some (Component.Func { node = { name; _ }; _ })

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2460,6 +2460,7 @@ and animation_timeline =
   | Name of string
   | Scroll of string
   | View of string
+  | Timelines of animation_timeline list
   | Initial
   | Inherit
   | Unset

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1164,8 +1164,11 @@ let vars_of_font_palette (value : Properties.font_palette) =
 let vars_of_font_synthesis (value : Properties.font_synthesis) =
   match value with Var v -> [ V v ] | _ -> []
 
-let vars_of_animation_timeline (value : Properties.animation_timeline) =
-  match value with Var v -> [ V v ] | _ -> []
+let rec vars_of_animation_timeline (value : Properties.animation_timeline) =
+  match value with
+  | Var v -> [ V v ]
+  | Timelines timelines -> List.concat_map vars_of_animation_timeline timelines
+  | _ -> []
 
 let rec vars_of_animation_range_item (value : Properties.animation_range_item) =
   match value with

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -1364,6 +1364,15 @@ let border_line_width () =
     "column-rule-width: 1px, 2px";
   check_declaration ~expected:"column-rule-color:red,blue"
     ~optimized:"column-rule-color:red,#00f" "column-rule-color: red, blue";
+  (* CSS Animations 2 sec. 5 spells [animation-timeline] as
+     [<single-animation-timeline>#], one entry per animation. Chrome 153 takes
+     each of these. *)
+  check_declaration ~expected:"animation-timeline:none,auto"
+    "animation-timeline: none, auto";
+  check_declaration ~expected:"animation-timeline:--a,none"
+    "animation-timeline: --a, none";
+  check_declaration ~expected:"animation-timeline:scroll(),view()"
+    "animation-timeline: scroll(), view()";
   (* Sec. 4.4 writes the shorthand [<gap-rule>#] over the same list. *)
   check_declaration ~expected:"column-rule:0,0" "column-rule: 0, 0";
   check_declaration ~expected:"column-rule:1px solid red,2px dashed blue"


### PR DESCRIPTION
`animation-timeline: none, auto` and `scroll(), view()` were dropped with a warning. CSS Animations 2 sec. 5 spells the property `<single-animation-timeline>#`, one entry per animation.

It was the last member of the timeline family still reading a single value: #1050 through #1052 gave the axis, inset, name and range their lists, and this one was in a different spec so it was missed.