### PR TITLE
test: excuse a comma in a border shorthand by shape

### DIFF
--- a/test/spec/browser/accept_set.ml
+++ b/test/spec/browser/accept_set.ml
@@ -450,19 +450,13 @@ let lenient_here : Chrome_gaps.excuse list =
     (fun (properties, values, why) ->
       List.map (fun value -> { Chrome_gaps.properties; value; why }) values)
     [
-      ( [
-          "border";
-          "border-block";
-          "border-inline";
-          "column-rule";
-          "column-rule-width";
-        ],
-        [ "10px,"; "red, none" ],
-        "CSS Backgrounds 3 sec. 4.5 and CSS Multicol 2 sec. 4.3 build these \
-         from [||] of a width, a style and a colour, and no arm of either is a \
-         comma. Chrome stops at the comma and drops the rest on serialising: \
-         [border: red, none] computes a red border-color and serialises back \
-         as [border: red]" );
+      ( [ "column-rule"; "column-rule-width" ],
+        [ "10px," ],
+        "CSS Gaps 1 sec. 4 gives these a comma-separated list, one entry per \
+         rule line, so a comma between two entries is theirs to read. The list \
+         has no empty entry, and Chrome reads a trailing comma and drops it on \
+         serialising. The border shorthands, which have no list at all, answer \
+         for a comma through a shape entry" );
     ]
 
 let hits = Hashtbl.create 64

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -408,8 +408,40 @@ let is_bare_number s =
     s;
   !ok && !digits
 
+let has_comma s = String.contains s ','
+
 let lenient_shapes =
   [
+    {
+      (* Measured on Chrome 153: [border: 1px, dashed, red] sets the same twelve
+         longhands [border: 1px dashed red] does, so both sides of each comma
+         are read and the comma is the separator between them. It is not a list:
+         [border: red, red] and [border: dashed, solid] fill one slot twice and
+         are refused, as they are without the comma. A leading comma ([border: ,
+         red]) and a doubled one ([border: red,,dashed]) are refused. *)
+      shape_properties =
+        [
+          "border";
+          "border-block";
+          "border-inline";
+          "border-block-start";
+          "border-block-end";
+          "border-inline-start";
+          "border-inline-end";
+          "border-top";
+          "border-right";
+          "border-bottom";
+          "border-left";
+        ];
+      shape_name = "a comma in a border shorthand";
+      matches = has_comma;
+      shape_why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+    };
     {
       shape_properties = [ "baseline-shift" ];
       shape_name = "a bare <number>";


### PR DESCRIPTION
`border-inline: none, 0` was reported as a rejects-valid, and it is Chrome's, not cascade's. Measured on Chrome 153: `border-inline: none, 0` computes and serialises exactly as `border-inline: 0` does, and `border: red, none` as `border: red` — the comma and one side of it are discarded rather than read. Three comma-separated parts (`none, 0, 1px`) are refused, so it is not a list either.

No arm of the `border` / `border-block` / `border-inline` grammar is a comma, so any comma there is one fact about the browser. It moves to a shape entry (#1073's mechanism), because a literal list of the values a seeded stream happens to draw is a fact about the sample: `10px,`, `red, none` and `none, 0` were three drawings of one thing. The trailing-comma literal stays, since it also covers the gap shorthands, which do take a list.

Rejects-valid over seeds 1-7 drops from 4 to 2.