### PR TITLE
font: hold font-language-override to an OpenType tag

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -576,6 +576,12 @@ to lose a whole rule over one bad piece. Both are gone.
   `<length [0,inf]>{1,2} | auto | [ <page-size> || [ portrait | landscape ]]`
   (#1004)
 
+- `font-language-override` takes an OpenType language system tag and no other
+  string, so `font-language-override: "default"` and `"ENGLISH"` are dropped
+  with a warning. CSS Fonts 4 sec. 6.13 gives the property a four-character
+  tag, padded at the end when it is shorter, and cascade read any string
+  (#1077)
+
 - `line-height` takes a length unit and no other, so `line-height: 1s`,
   `45deg` and `10zz` are dropped with a warning. CSS Inline 3 sec. 5.1 spells
   the property `normal | <number [0,inf]> | <length-percentage [0,inf]>`, and

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -198,6 +198,24 @@ let rec pp_font_language_override : font_language_override Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_font_language_override ctx v
 
+(* An OpenType tag is four printable ASCII characters. CSS Fonts 4 sec. 6.13
+   pads a shorter font-language-override tag with spaces before matching it, so
+   there the tag may be one to four. *)
+let read_opentype_tag ?(padded = false) t =
+  let tag = Cursor.string t in
+  let printable_ascii c =
+    let code = Char.code c in
+    code >= 0x20 && code <= 0x7E
+  in
+  let length = String.length tag in
+  let fits = if padded then length >= 1 && length <= 4 else length = 4 in
+  if (not fits) || not (String.for_all printable_ascii tag) then
+    Cursor.err t
+      (if padded then
+         "OpenType tag must contain one to four printable ASCII characters"
+       else "OpenType tag must contain exactly four printable ASCII characters");
+  tag
+
 let rec read_font_language_override t : font_language_override =
   Cursor.enum_or_calls "font-language-override"
     [
@@ -209,7 +227,8 @@ let rec read_font_language_override t : font_language_override =
       ("revert-layer", Revert_layer);
     ]
     ~calls:[ ("var", fun t -> Var (read_var read_font_language_override t)) ]
-    ~default:(fun t -> (String (Cursor.string t) : font_language_override))
+    ~default:(fun t ->
+      (String (read_opentype_tag ~padded:true t) : font_language_override))
     t
 
 let rec pp_font_synthesis_style : font_synthesis_style Pp.t =
@@ -2233,17 +2252,6 @@ let rec pp_font_variant : font_variant Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_font_variant ctx v
-
-let read_opentype_tag t =
-  let tag = Cursor.string t in
-  let printable_ascii c =
-    let code = Char.code c in
-    code >= 0x20 && code <= 0x7E
-  in
-  if String.length tag <> 4 || not (String.for_all printable_ascii tag) then
-    Cursor.err t
-      "OpenType tag must contain exactly four printable ASCII characters";
-  tag
 
 let read_font_feature_value t : font_feature_value =
   match Cursor.option Cursor.int t with

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4591,6 +4591,8 @@ let spec_platform_property_vectors () =
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
+      ("font-language-override: \"ENG\"", "font-language-override:\"ENG\"");
+      ("font-language-override: \"A\"", "font-language-override:\"A\"");
       ("offset-path: path('M 0 0 L 1 1')", "offset-path:path(\"M 0 0 L 1 1\")");
       ("offset-distance: 50%", "offset-distance:50%");
       ("font-size-adjust: from-font", "font-size-adjust:from-font");
@@ -4691,6 +4693,9 @@ let spec_platform_property_vectors () =
       "margin-trim: block inline block";
       "field-sizing: auto";
       "mask-composite: plus";
+      "font-language-override: \"default\"";
+      "font-language-override: \"ENGLISH\"";
+      "font-language-override: \"\"";
       "grid: \"<\" \">\"";
       "grid: \"\"";
       "grid: \"a\" \"b c\"";


### PR DESCRIPTION
`font-language-override` read any string, so `font-language-override: \"default\"` parsed where every browser drops it. CSS Fonts 4 sec. 6.13 gives the property a four-character OpenType language system tag, padded at the end when it is shorter, and the tag reader the feature and variation settings use was sitting in the same module.