### PR TITLE
border: read one image in a border-image source

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -582,6 +582,12 @@ to lose a whole rule over one bad piece. Both are gone.
   tag, padded at the end when it is shorter, and cascade read any string
   (#1077)
 
+- `border-image`, `border-image-source` and `mask-border` take one image, so
+  `border-image: none, none` is dropped with a warning. CSS Backgrounds 3
+  sec. 5.1 and CSS Masking 1 sec. 8.2 give the source slot a single `<image>`,
+  and it borrowed the comma-separated reader `background-image` uses. This
+  release adds `Cascade.Properties.read_border_image_source` (#1078)
+
 - `line-height` takes a length unit and no other, so `line-height: 1s`,
   `45deg` and `10zz` are dropped with a warning. CSS Inline 3 sec. 5.1 spells
   the property `normal | <number [0,inf]> | <length-percentage [0,inf]>`, and

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2073,7 +2073,7 @@ let read_mask_value : type a. a property -> Cursor.t -> declaration option =
   | Webkit_mask_clip -> Some (v Webkit_mask_clip (read_mask_box_list t))
   | Webkit_mask_origin -> Some (v Webkit_mask_origin (read_mask_box_list t))
   | Border_image_source ->
-      Some (v Border_image_source (read_background_image t))
+      Some (v Border_image_source (read_border_image_source t))
   | Border_image_slice ->
       Some (v Border_image_slice (read_border_image_slice t))
   | Border_image_repeat ->

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -2507,12 +2507,17 @@ let read_mask_border_mode t =
    the two grammars apart, so [mask_mode] is what says which one the reader is
    holding. CSS Values 4 (ED) sec. 2.2 has [||] ask for one or more of its
    options, so a value that fills no slot matches neither grammar. *)
+(* CSS Backgrounds 3 sec. 5.1 gives border-image-source a single [<image>],
+   and CSS Masking 1 (ED) sec. 8.2 gives mask-border-source the same, where
+   background-image takes a comma-separated list of them. *)
+let read_border_image_source t : background_image = read_bg_image t
+
 let read_border_image_shorthand ~mask_mode t : border_image =
   let read_mode t =
     if mask_mode then Cursor.option read_mask_border_mode t
     else (None : mask_border_mode option)
   in
-  let source = Cursor.option read_background_image t in
+  let source = Cursor.option read_border_image_source t in
   Cursor.ws t;
   (* sec. 8.7 puts [mask-border-mode] in [||] combination with the other slots,
      so the keyword may appear after [<source>] (before the slice) or after

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1802,6 +1802,10 @@ val read_background_images : Cursor.t -> background_image list
 (** [read_background_images t] parses a comma-separated list of
     [background_image]s. *)
 
+val read_border_image_source : Cursor.t -> background_image
+(** [read_border_image_source t] is the single image a border-image or
+    mask-border source takes, where {!read_background_image} takes a list. *)
+
 val minify_background_image : background_image -> background_image
 (** [minify_background_image img] converts named colors in gradient stops to
     their shortest hex form, matching Lightning CSS behavior. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4693,6 +4693,10 @@ let spec_platform_property_vectors () =
       "margin-trim: block inline block";
       "field-sizing: auto";
       "mask-composite: plus";
+      "border-image: none, none";
+      "border-image: url(a.png), none";
+      "border-image-source: none, none";
+      "mask-border: none, none";
       "font-language-override: \"default\"";
       "font-language-override: \"ENGLISH\"";
       "font-language-override: \"\"";


### PR DESCRIPTION
The source slot of `border-image`, `border-image-source` and `mask-border` borrowed `background-image`'s reader, and with it a comma-separated list none of the three has a grammar for, so `border-image: none, none` parsed where the browser drops it. This PR adds `Cascade.Properties.read_border_image_source`.