### PR TITLE
test: excuse an unimplemented text-overflow by shape

### DIFF
--- a/test/spec/browser/accept_set.ml
+++ b/test/spec/browser/accept_set.ml
@@ -420,10 +420,6 @@ let spec_ahead_here : Chrome_gaps.excuse list =
         [ "contain" ],
         "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
          property takes; Chrome has not implemented it" );
-      ( [ "text-overflow" ],
-        [ "\"text\"" ],
-        "CSS Overflow 4 sec. 4.1: [ clip | ellipsis | <string> | fade | \
-         <fade()> ]{1,2}, and every one of these is a <string>" );
       ( [ "text-box-edge" ],
         [ "ideographic-ink" ],
         "CSS Inline 3 sec. 4.4: <text-edge> = [ text | ideographic | \
@@ -507,7 +503,15 @@ let judge ~property ~value ~cascade verdict =
       | true, false -> (
           match excuse Chrome_gaps.spec_ahead with
           | Some why -> Accepts_invalid (Some why)
-          | None -> Accepts_invalid (excuse_here spec_ahead_here)))
+          | None -> (
+              match
+                Chrome_gaps.shape_covering Chrome_gaps.spec_ahead_shapes
+                  ~property ~value
+              with
+              | Some s ->
+                  Hashtbl.replace shape_hits s.shape_name ();
+                  Accepts_invalid (Some s.shape_why)
+              | None -> Accepts_invalid (excuse_here spec_ahead_here))))
 
 (* ===== The classifier, checked against itself ===== *)
 
@@ -788,7 +792,7 @@ let check_unused () =
                String.concat ", " s.shape_properties;
                ")";
              ]))
-    Chrome_gaps.lenient_shapes
+    (Chrome_gaps.lenient_shapes @ Chrome_gaps.spec_ahead_shapes)
 
 let check_calibration outcomes =
   List.iter

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -410,6 +410,48 @@ let is_bare_number s =
 
 let has_comma s = String.contains s ','
 
+(* Splits on whitespace outside a quoted string, so a <string> arm carrying a
+   space stays one part. *)
+let value_parts s =
+  let parts = ref [] and buf = Buffer.create 16 and quote = ref None in
+  let flush () =
+    if Buffer.length buf > 0 then (
+      parts := Buffer.contents buf :: !parts;
+      Buffer.clear buf)
+  in
+  String.iter
+    (fun c ->
+      match (!quote, c) with
+      | Some q, _ when Char.equal c q ->
+          quote := None;
+          Buffer.add_char buf c
+      | Some _, _ -> Buffer.add_char buf c
+      | None, ('"' | '\'') ->
+          quote := Some c;
+          Buffer.add_char buf c
+      | None, (' ' | '\t' | '\n' | '\r' | '\012') -> flush ()
+      | None, _ -> Buffer.add_char buf c)
+    s;
+  flush ();
+  List.rev !parts
+
+let is_quoted p =
+  String.length p >= 2
+  && (Char.equal p.[0] '"' || Char.equal p.[0] '\'')
+  && Char.equal p.[String.length p - 1] p.[0]
+
+(* Every value CSS Overflow 4 sec. 4.1 grants but the one-value [clip |
+   ellipsis] half Chrome implements. *)
+let unimplemented_text_overflow s =
+  let arm p =
+    List.exists (String.equal p) [ "clip"; "ellipsis"; "fade" ]
+    || is_quoted p
+    || String.starts_with ~prefix:"fade(" p
+  in
+  match value_parts s with
+  | [] | [ "clip" ] | [ "ellipsis" ] -> false
+  | parts -> List.length parts <= 2 && List.for_all arm parts
+
 let lenient_shapes =
   [
     {
@@ -450,6 +492,19 @@ let lenient_shapes =
         "CSS Inline 3 sec. 4.2.3: <length-percentage> | sub | super | top | \
          center | bottom, and no arm is a bare <number>. Chrome reads one as \
          the unitless length SVG presentation attributes take";
+    };
+  ]
+
+let spec_ahead_shapes =
+  [
+    {
+      shape_properties = [ "text-overflow" ];
+      shape_name = "a text-overflow Chrome does not implement";
+      matches = unimplemented_text_overflow;
+      shape_why =
+        "CSS Overflow 4 sec. 4.1: [ clip | ellipsis | <string> | fade | \
+         <fade()> ]{1,2}, and Chrome implements the one-value [ clip | \
+         ellipsis ] half of it";
     };
   ]
 

--- a/test/spec/browser/chrome_gaps.mli
+++ b/test/spec/browser/chrome_gaps.mli
@@ -41,6 +41,9 @@ type shape = {
 val lenient_shapes : shape list
 (** [lenient_shapes] is {!lenient} keyed by a predicate. *)
 
+val spec_ahead_shapes : shape list
+(** [spec_ahead_shapes] is {!spec_ahead} keyed by a predicate. *)
+
 val shape_covering :
   shape list -> property:string -> value:string -> shape option
 (** [shape_covering table ~property ~value] is the entry of [table] whose


### PR DESCRIPTION
Chrome implements the one-value `clip | ellipsis` half of CSS Overflow 4 sec. 4.1 and refuses the rest, so every string the seeded stream writes is the same fact and a literal list of them says more about the sample than about the browser. This gives `Chrome_gaps` a `spec_ahead_shapes` table, the counterpart of the `lenient_shapes` added in #1075, held to the same staleness check.