### PR TITLE
grid: check every path a line index reaches

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -588,6 +588,15 @@ to lose a whole rule over one bad piece. Both are gone.
   and it borrowed the comma-separated reader `background-image` uses. This
   release adds `Cascade.Properties.read_border_image_source` (#1078)
 
+- A math function at an `<integer>` is read and kept, so `z-index: calc(.5)`,
+  `order: calc(1.4)` and `grid-row-end: calc(.5)` are declarations where they
+  were dropped with a warning, and minified output keeps the call rather than
+  unwrapping it to a fraction the browser drops. CSS Values 4 sec. 10.12 rounds
+  the result to the nearest integer instead of refusing it. A grid line index
+  is checked against its range wherever it sits, so `grid-row-end: calc(0)` and
+  `grid-column-start: balance 0` are dropped as `0` already was
+  (#1080)
+
 - `line-height` takes a length unit and no other, so `line-height: 1s`,
   `45deg` and `10zz` are dropped with a warning. CSS Inline 3 sec. 5.1 spells
   the property `normal | <number [0,inf]> | <length-percentage [0,inf]>`, and

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -9975,10 +9975,13 @@ val pp_gradient_direction : gradient_direction Pp.t
 val pp_transform : transform Pp.t
 (** [pp_transform] is the pretty printer for transform values. *)
 
-val pp_calc : ?unwrap:('a -> bool) -> 'a Pp.t -> 'a calc Pp.t
-(** [pp_calc ?unwrap pp_value] is the pretty printer for calc expressions.
-    Minified output drops the call around a single leaf, and [unwrap] says which
-    leaves that is safe for. *)
+val pp_calc :
+  ?unwrap_num:bool -> ?unwrap:('a -> bool) -> 'a Pp.t -> 'a calc Pp.t
+(** [pp_calc ?unwrap_num ?unwrap pp_value] is the pretty printer for calc
+    expressions. Minified output drops the call around a single leaf, and
+    [unwrap] says which leaves that is safe for. [unwrap_num] is the same
+    question for a bare number leaf, which a property taking an [<integer>]
+    answers no to. *)
 
 val pp_font_style : font_style Pp.t
 (** [pp_font_style] is the pretty printer for font-style values. *)

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -392,7 +392,7 @@ let rec pp_z_index : z_index Pp.t =
  fun ctx -> function
   | Auto -> Pp.string ctx "auto"
   | Index i -> Pp.int ctx i
-  | Calc c -> pp_calc pp_z_index ctx c
+  | Calc c -> pp_calc ~unwrap_num:false pp_z_index ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"

--- a/lib/prop_flex.ml
+++ b/lib/prop_flex.ml
@@ -120,7 +120,7 @@ let normalize_flex (value : flex) : flex =
 let rec pp_order : order Pp.t =
  fun ctx -> function
   | Int i -> Pp.int ctx i
-  | Calc c -> pp_calc pp_order ctx c
+  | Calc c -> pp_calc ~unwrap_num:false pp_order ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -71,7 +71,7 @@ let rec pp_grid_line : grid_line Pp.t =
       Pp.int ctx n;
       Pp.char ctx ' ';
       pp_ident ctx name
-  | Calc c -> pp_calc pp_grid_line ctx c
+  | Calc c -> pp_calc ~unwrap_num:false pp_grid_line ctx c
   | Var v -> pp_var pp_grid_line ctx v
 
 let rec pp_grid_line_pair : grid_line_pair Pp.t =
@@ -746,9 +746,14 @@ let read_grid_span t : grid_line =
   if not span_first then Cursor.expect_string "span" t;
   value
 
-let read_grid_line_number t : grid_line =
-  let n = Cursor.int t in
+(* CSS Grid 2 sec. 8.3 spells the index [ <integer [-inf,-1]> | <integer
+   [1,inf]> ], so zero is no line however the value reaches the slot. *)
+let check_grid_line_index t n =
   if n = 0 then Cursor.err_invalid t "grid line index cannot be zero";
+  n
+
+let read_grid_line_number t : grid_line =
+  let n = check_grid_line_index t (Cursor.int t) in
   Cursor.ws t;
   let name : string option =
     if grid_line_at_end t then None else Some (read_grid_line_name t)
@@ -771,13 +776,14 @@ let read_grid_line_name_value t : grid_line =
       let name = read_grid_line_name t in
       Cursor.ws t;
       let n : int option =
-        if grid_line_at_end t then None else Cursor.option Cursor.int t
+        if grid_line_at_end t then None
+        else Cursor.option (fun t -> check_grid_line_index t (Cursor.int t)) t
       in
       match n with Some n -> Num_name (n, name) | None -> Name name)
 
 let read_grid_line_calc t : grid_line =
   match read_integer_calc "grid-line" t with
-  | `Int n -> Num n
+  | `Int n -> Num (check_grid_line_index t n)
   | `Calc expr -> Calc expr
 
 let rec read_grid_line t : grid_line =

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1373,7 +1373,8 @@ let pp_calc_with : type a.
       let ctx = { ctx with in_calc = true } in
       Pp.call "calc" (pp_calc_contents pp_value) ctx calc
 
-let pp_calc ?unwrap pp_value ctx calc = pp_calc_with ?unwrap pp_value ctx calc
+let pp_calc ?unwrap_num ?unwrap pp_value ctx calc =
+  pp_calc_with ?unwrap_num ?unwrap pp_value ctx calc
 
 (* Small helpers *)
 
@@ -5786,12 +5787,12 @@ let read_integer_calc : type a.
           (String.concat "" [ "unexpected value in "; name; " calc" ]))
       t
   in
+  (* CSS Values 4 sec. 10.12 rounds a math function at an [<integer>] to the
+     nearest integer rather than refusing it, so a fractional result keeps the
+     call and rounds where the value is used. *)
   match eval_numeric_calc expr with
   | Some f when Float.is_integer f -> `Int (int_of_float f)
-  | Some _ ->
-      Cursor.err_invalid t
-        (String.concat "" [ name; " calc must evaluate to integer" ])
-  | None -> `Calc expr
+  | Some _ | None -> `Calc expr
 
 let read_integer name t =
   if Cursor.looking_at_calc t then

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -346,13 +346,16 @@ val pp_number_percentage : ?always:bool -> number_percentage Pp.t
 (** [pp_number_percentage ?always] pretty-prints {!number_percentage} values.
     When [always] is true, always includes units even for 0. *)
 
-val pp_calc : ?unwrap:('a -> bool) -> 'a Pp.t -> 'a calc Pp.t
-(** [pp_calc ?unwrap pp] pretty-prints [calc] expressions using [pp] for leaf
-    values. Minified output drops the call around a single leaf; [unwrap] says
-    which leaves that is safe for, and defaults to all of them. A leaf outside
-    the property's range is not one: CSS Values 4 sec. 10.12 keeps the call
-    valid there and clamps at used-value time, where the bare value is dropped
-    instead. *)
+val pp_calc :
+  ?unwrap_num:bool -> ?unwrap:('a -> bool) -> 'a Pp.t -> 'a calc Pp.t
+(** [pp_calc ?unwrap_num ?unwrap pp] pretty-prints [calc] expressions using [pp]
+    for leaf values. Minified output drops the call around a single leaf;
+    [unwrap] says which leaves that is safe for, and defaults to all of them. A
+    leaf outside the property's range is not one: CSS Values 4 sec. 10.12 keeps
+    the call valid there and clamps at used-value time, where the bare value is
+    dropped instead. [unwrap_num] is the same question for a bare number leaf,
+    which a property taking an [<integer>] answers no to: sec. 10.12 rounds the
+    call and drops the fraction written on its own. *)
 
 val pp_color_name : color_name Pp.t
 (** [pp_color_name] pretty-prints {!type-color_name} values. *)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4591,6 +4591,10 @@ let spec_platform_property_vectors () =
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
+      ("grid-row-end: calc(.5)", "grid-row-end:calc(.5)");
+      ("grid-column-start: calc(1.4)", "grid-column-start:calc(1.4)");
+      ("z-index: calc(.5)", "z-index:calc(.5)");
+      ("order: calc(1.4)", "order:calc(1.4)");
       ("font-language-override: \"ENG\"", "font-language-override:\"ENG\"");
       ("font-language-override: \"A\"", "font-language-override:\"A\"");
       ("offset-path: path('M 0 0 L 1 1')", "offset-path:path(\"M 0 0 L 1 1\")");
@@ -4693,6 +4697,9 @@ let spec_platform_property_vectors () =
       "margin-trim: block inline block";
       "field-sizing: auto";
       "mask-composite: plus";
+      "grid-row-end: calc(0)";
+      "grid-column-start: balance 0";
+      "grid-row-end: balance 0";
       "border-image: none, none";
       "border-image: url(a.png), none";
       "border-image-source: none, none";


### PR DESCRIPTION
A math function at an `<integer>` was refused for not evaluating to one, so `z-index: calc(.5)`, `order: calc(1.4)` and `grid-row-end: calc(.5)` were dropped with a warning; CSS Values 4 sec. 10.12 rounds the result instead. Minified output keeps the call, since the bare fraction is a value the browser drops, and the range check the plain form runs now also covers the calc and trailing-name paths, so `grid-row-end: calc(0)` and `grid-column-start: balance 0` go the way `0` already did.