### PR TITLE
test: pin the animation timeline gap in the manifest

### DIFF
--- a/test/spec/browser/accept_set.ml
+++ b/test/spec/browser/accept_set.ml
@@ -430,12 +430,6 @@ let spec_ahead_here : Chrome_gaps.excuse list =
         "CSS Inline 3 sec. 5.2: auto | <baseline-metric>, and sec. 5.1 gives \
          <baseline-metric> = text-bottom | alphabetic | ideographic | middle | \
          central | mathematical | hanging | text-top" );
-      ( [ "animation"; "-webkit-animation" ],
-        [ "--x x, --y y" ],
-        "CSS Animations 2 sec. 4: <single-animation> ends in [ none | \
-         <keyframes-name> ] || <single-animation-timeline>, so a dashed-ident \
-         timeline and a keyframes name fill two slots of one [||]. Chrome took \
-         the timeline back out of the shorthand" );
     ]
 
 (* The same, for a value Chrome reads that no specification grants: an entry

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -182,6 +182,15 @@ let spec_ahead : excuse list =
          full-width || full-size-kana | math-auto";
     };
     {
+      properties = [ "animation"; "-webkit-animation" ];
+      value = "--x x";
+      why =
+        "CSS Animations 2 sec. 4.12: <single-animation> ends in [ none | \
+         <keyframes-name> ] || <single-animation-timeline>, so a dashed-ident \
+         timeline and a keyframes name fill two slots of one [||]. Chrome took \
+         the timeline back out of the shorthand";
+    };
+    {
       properties = [ "text-overflow" ];
       value = "\"...\"";
       why =

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -378,6 +378,7 @@ let matrix =
           "none";
           "fade calc(1s * 2)";
           "infinite infinite";
+          "--x x";
         ];
       negatives = [ "1s 2s 3s"; "2 3" ];
     };


### PR DESCRIPTION
The excuse for it named a value the seeded accept-set stream had drawn once, so a reseed stranded it. CSS Animations 2 sec. 4.12 puts `<single-animation-timeline>` in the shorthand's `[||]` and Chrome took it back out, which is a fact about a property rather than about a sample, so the vector belongs in the fixed manifest population where a browser that catches up is what moves it.