### PR TITLE
scroll-snap: drop the pair-of-zeroes refusal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -597,6 +597,11 @@ to lose a whole rule over one bad piece. Both are gone.
   `grid-column-start: balance 0` are dropped as `0` already was
   (#1080)
 
+- `scroll-margin-block: 0 0` and `scroll-margin-inline: 0 0` are declarations
+  where a pair of zeroes alone was dropped with a warning. CSS Scroll Snap 1
+  sec. 6.1 spells the logical shorthands `<length>{1,2}` with no rule about
+  what the two lengths may be (#1082)
+
 - `line-height` takes a length unit and no other, so `line-height: 1s`,
   `45deg` and `10zz` are dropped with a warning. CSS Inline 3 sec. 5.1 spells
   the property `normal | <number [0,inf]> | <length-percentage [0,inf]>`, and

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -1927,14 +1927,10 @@ let read_scroll_value : type a. a property -> Cursor.t -> declaration option =
   | Scroll_margin_inline_end ->
       Some (v Scroll_margin_inline_end (read_scroll_margin_length t))
   | Scroll_margin_block ->
-      let lengths =
-        Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2
-          read_scroll_margin_length t
-      in
-      (match lengths with
-      | [ Zero; Zero ] -> Cursor.err_invalid t "duplicate zero scroll margin"
-      | _ -> ());
-      Some (v Scroll_margin_block lengths)
+      Some
+        (v Scroll_margin_block
+           (Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2
+              read_scroll_margin_length t))
   | Scroll_margin_block_start ->
       Some (v Scroll_margin_block_start (read_scroll_margin_length t))
   | Scroll_margin_block_end ->

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4591,6 +4591,8 @@ let spec_platform_property_vectors () =
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
+      ("scroll-margin-block: 0 0", "scroll-margin-block:0 0");
+      ("scroll-margin-inline: 0 0", "scroll-margin-inline:0 0");
       ("grid-row-end: calc(.5)", "grid-row-end:calc(.5)");
       ("grid-column-start: calc(1.4)", "grid-column-start:calc(1.4)");
       ("z-index: calc(.5)", "z-index:calc(.5)");


### PR DESCRIPTION
`scroll-margin-block: 0 0` and `scroll-margin-inline: 0 0` were dropped with a warning while every other pair read. CSS Scroll Snap 1 sec. 6.1 spells the logical shorthands `<length>{1,2}` with no rule about what the two lengths may be, and nothing in the suite asked for the refusal.