### PR TITLE
ui: read interest-delay slot by slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,14 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `Cascade.Properties.interest_delay` carries `Delays of interest_delay_item
+  list` where it carried `Normal` and `Durations of duration list`, so
+  `interest-delay: normal 120ms` and `120ms normal` read. CSS UI 4 sec. 6.4
+  spells the shorthand `<'interest-delay-start'>{1,2}` and each longhand
+  `normal | <time>`, so `normal` fills one slot rather than standing for the
+  whole value. A caller writing a single keyword passes `Delays [ Normal ]`
+  (#1083)
+
 - `Cascade.Properties.animation_timeline` gains `Timelines`, so
   `animation-timeline: none, auto` and `scroll(), view()` read. CSS Animations
   2 sec. 5 spells the property `<single-animation-timeline>#`, one entry per

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -7408,9 +7408,12 @@ type caret = Properties.caret =
 val caret : caret -> declaration
 (** [caret caret] is the CSS [caret] property. *)
 
-type interest_delay = Properties.interest_delay =
+type interest_delay_item = Properties.interest_delay_item =
   | Normal
-  | Durations of duration list
+  | Time of duration
+
+type interest_delay = Properties.interest_delay =
+  | Delays of interest_delay_item list
   | Inherit
   | Initial
   | Unset

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -229,11 +229,14 @@ let read_non_negative_duration t =
   | S f when f < 0. -> Cursor.err_invalid t "negative duration"
   | duration -> duration
 
+let read_interest_delay_item t : interest_delay_item =
+  if Cursor.try_ident "normal" t then Normal
+  else Time (read_non_negative_duration t)
+
 let rec read_interest_delay ?(longhand = false) t : interest_delay =
   Cursor.enum_or_var "interest-delay"
     [
-      ("normal", (Normal : interest_delay));
-      ("inherit", Inherit);
+      ("inherit", (Inherit : interest_delay));
       ("initial", Initial);
       ("unset", Unset);
       ("revert", Revert);
@@ -242,20 +245,27 @@ let rec read_interest_delay ?(longhand = false) t : interest_delay =
     ~var:(fun t -> Var (Values.read_var (read_interest_delay ~longhand) t))
     ~default:(fun t ->
       let at_most = if longhand then 1 else 2 in
-      Durations
+      Delays
         (Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most
-           read_non_negative_duration t))
+           read_interest_delay_item t))
     t
+
+let normalize_interest_delay_item : interest_delay_item -> interest_delay_item =
+ fun item ->
+  match item with
+  | Normal -> item
+  | Time duration ->
+      let duration' =
+        Values.normalize_duration ~canonicalize_ms:false duration
+      in
+      if duration' == duration then item else Time duration'
 
 let rec normalize_interest_delay : interest_delay -> interest_delay =
  fun value ->
   match value with
-  | Durations durations ->
+  | Delays delays ->
       preserve_if_equal value
-        (Durations
-           (map_preserve
-              (Values.normalize_duration ~canonicalize_ms:false)
-              durations))
+        (Delays (map_preserve normalize_interest_delay_item delays))
   | Var v ->
       let v' = map_var_preserve normalize_interest_delay v in
       if v' == v then value else Var v'
@@ -571,11 +581,14 @@ let rec pp_caret : caret Pp.t =
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_caret ctx v
 
-let rec pp_interest_delay : interest_delay Pp.t =
+let pp_interest_delay_item : interest_delay_item Pp.t =
  fun ctx -> function
   | Normal -> Pp.string ctx "normal"
-  | Durations durations ->
-      Pp.list ~sep:Pp.space pp_duration_preserve_ms ctx durations
+  | Time duration -> pp_duration_preserve_ms ctx duration
+
+let rec pp_interest_delay : interest_delay Pp.t =
+ fun ctx -> function
+  | Delays delays -> Pp.list ~sep:Pp.space pp_interest_delay_item ctx delays
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1939,6 +1939,13 @@ val pp_interest_delay : interest_delay Pp.t
 val read_interest_delay : ?longhand:bool -> Cursor.t -> interest_delay
 (** [read_interest_delay t] is the [interest_delay] parsed from [t]. *)
 
+val pp_interest_delay_item : interest_delay_item Pp.t
+(** [pp_interest_delay_item] is the pretty-printer for [interest_delay_item]. *)
+
+val read_interest_delay_item : Cursor.t -> interest_delay_item
+(** [read_interest_delay_item t] is the one slot of an [interest_delay] parsed
+    from [t]. *)
+
 val pp_nav_scope : nav_scope Pp.t
 (** [pp_nav_scope] is the pretty-printer for [nav_scope]. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3206,9 +3206,13 @@ type caret =
   | Revert_layer
   | Var of caret var
 
+(** One slot of an interest delay: CSS UI 4 sec. 6.4 gives
+    [interest-delay-start] and [interest-delay-end] the value [normal | <time>].
+*)
+type interest_delay_item = Normal | Time of duration
+
 type interest_delay =
-  | Normal
-  | Durations of duration list
+  | Delays of interest_delay_item list
   | Inherit
   | Initial
   | Unset

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4591,6 +4591,10 @@ let spec_platform_property_vectors () =
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
+      ("interest-delay: normal 120ms", "interest-delay:normal 120ms");
+      ("interest-delay: 120ms normal", "interest-delay:120ms normal");
+      ("interest-delay: 1s 2s", "interest-delay:1s 2s");
+      ("interest-delay: normal", "interest-delay:normal");
       ("scroll-margin-block: 0 0", "scroll-margin-block:0 0");
       ("scroll-margin-inline: 0 0", "scroll-margin-inline:0 0");
       ("grid-row-end: calc(.5)", "grid-row-end:calc(.5)");
@@ -4699,6 +4703,8 @@ let spec_platform_property_vectors () =
       "margin-trim: block inline block";
       "field-sizing: auto";
       "mask-composite: plus";
+      "interest-delay: normal normal normal";
+      "interest-delay-start: normal 1s";
       "grid-row-end: calc(0)";
       "grid-column-start: balance 0";
       "grid-row-end: balance 0";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -958,6 +958,10 @@ let check_interactivity =
 let check_interest_delay =
   check_value_cursor "interest_delay" read_interest_delay pp_interest_delay
 
+let check_interest_delay_item =
+  check_value_cursor "interest_delay_item" read_interest_delay_item
+    pp_interest_delay_item
+
 let check_interpolate_size =
   check_value_cursor "interpolate_size" read_interpolate_size
     pp_interpolate_size
@@ -5190,6 +5194,9 @@ let spec_generated_position_interaction_edges () =
   check_container_name "main sidebar";
   check_interactivity "inert";
   check_interest_delay "100ms 200ms";
+  check_interest_delay "normal 120ms";
+  check_interest_delay_item "normal";
+  check_interest_delay_item "120ms";
   check_margin_trim "block-start inline-end";
   check_margin_trim_axis "inline";
   check_margin_trim_edge "block-end";


### PR DESCRIPTION
`normal` stood for the whole value, so it could not share the shorthand with a time and `interest-delay: normal 120ms` was dropped with a warning. CSS UI 4 sec. 6.4 spells the shorthand `<'interest-delay-start'>{1,2}` and each longhand `normal | <time>`. `Cascade.Properties.interest_delay` now carries `Delays of interest_delay_item list` where it carried `Normal` and `Durations`, so a caller writing the keyword passes `Delays [ Normal ]`.