### PR TITLE
test: name every image property the cross-fade gap reaches

### DIFF
--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -128,6 +128,9 @@ let spec_ahead : excuse list =
           "border-image-source";
           "mask-image";
           "-webkit-mask-image";
+          "list-style";
+          "list-style-image";
+          "content";
         ];
       value = "cross-fade(url(a.png) 40%, url(b.png))";
       why =


### PR DESCRIPTION
Chrome ships only `-webkit-cross-fade()`, and the entry recording that named five of the properties taking an `<image>`. A list marker and a content replacement answer to the same fact.