### PR TITLE
mask: read every webkit mask compositing operator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -429,11 +429,12 @@ to lose a whole rule over one bad piece. Both are gone.
   `@-moz-document`'s URL matchers, a `border-image` repeat keyword standing
   alone, a `text-decoration` component with no line, `white-space: collapse`, a
   time-valued `round()` in a delay, a `flex` shorthand whose basis leads, a
-  relative `color()` whose alpha is the origin's own, and a value whose grammar
+  relative `color()` whose alpha is the origin's own, the full
+  `-webkit-mask-composite` operator set, and a value whose grammar
   ends in an optional component (#334, #335, #427, #456,
   #461, #551, #572, #579, #594, #633, #641, #644, #646, #665, #666, #667, #682,
   #739, #805, #827, #870, #874, #877, #881, #884, #885, #886, #887, #889, #909,
-  #1055, #1060)
+  #1055, #1060, #1085)
 
 - `margin` mixes `auto` with lengths in any slot, `border-style` takes the four
   side styles, `border-block-style` and `border-inline-style` take the start and

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3269,9 +3269,17 @@ type background_box = Properties.background_box =
 (* Mask-related types *)
 type webkit_mask_composite = Properties.webkit_mask_composite =
   | Source_over
-  | Xor
   | Source_in
   | Source_out
+  | Source_atop
+  | Destination_over
+  | Destination_in
+  | Destination_out
+  | Destination_atop
+  | Xor
+  | Plus_lighter
+  | Clear
+  | Copy
   | Composites of webkit_mask_composite list
   | Inherit
   | Initial

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -428,9 +428,17 @@ let rec pp_webkit_mask_composite : webkit_mask_composite Pp.t =
   | Composites composites ->
       Pp.list ~sep:Pp.comma pp_webkit_mask_composite ctx composites
   | Source_over -> Pp.string ctx "source-over"
-  | Xor -> Pp.string ctx "xor"
   | Source_in -> Pp.string ctx "source-in"
   | Source_out -> Pp.string ctx "source-out"
+  | Source_atop -> Pp.string ctx "source-atop"
+  | Destination_over -> Pp.string ctx "destination-over"
+  | Destination_in -> Pp.string ctx "destination-in"
+  | Destination_out -> Pp.string ctx "destination-out"
+  | Destination_atop -> Pp.string ctx "destination-atop"
+  | Xor -> Pp.string ctx "xor"
+  | Plus_lighter -> Pp.string ctx "plus-lighter"
+  | Clear -> Pp.string ctx "clear"
+  | Copy -> Pp.string ctx "copy"
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -564,9 +572,17 @@ let rec read_webkit_mask_composite t : webkit_mask_composite =
     Cursor.enum "webkit-mask-composite-item"
       [
         ("source-over", (Source_over : webkit_mask_composite));
-        ("xor", Xor);
         ("source-in", Source_in);
         ("source-out", Source_out);
+        ("source-atop", Source_atop);
+        ("destination-over", Destination_over);
+        ("destination-in", Destination_in);
+        ("destination-out", Destination_out);
+        ("destination-atop", Destination_atop);
+        ("xor", Xor);
+        ("plus-lighter", Plus_lighter);
+        ("clear", Clear);
+        ("copy", Copy);
       ]
       t
   in

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -2933,9 +2933,17 @@ type background =
 (** Webkit-prefixed mask-composite values *)
 type webkit_mask_composite =
   | Source_over
-  | Xor
   | Source_in
   | Source_out
+  | Source_atop
+  | Destination_over
+  | Destination_in
+  | Destination_out
+  | Destination_atop
+  | Xor
+  | Plus_lighter
+  | Clear
+  | Copy
   | Composites of webkit_mask_composite list
   | Inherit
   | Initial

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1961,8 +1961,23 @@ let matrix =
       };
       {
         property = "-webkit-mask-composite";
-        positives = [ "source-over"; "xor"; "source-in, source-out" ];
-        negatives = [ "add"; "source-over xor" ];
+        positives =
+          [
+            "source-over";
+            "source-in";
+            "source-out";
+            "source-atop";
+            "destination-over";
+            "destination-in";
+            "destination-out";
+            "destination-atop";
+            "xor";
+            "plus-lighter";
+            "clear";
+            "copy";
+            "source-in, source-out";
+          ];
+        negatives = [ "add"; "plus-darker"; "source-over xor" ];
       };
       {
         property = "-webkit-mask-source-type";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4603,6 +4603,22 @@ let spec_platform_property_vectors () =
       ("order: calc(1.4)", "order:calc(1.4)");
       ("font-language-override: \"ENG\"", "font-language-override:\"ENG\"");
       ("font-language-override: \"A\"", "font-language-override:\"A\"");
+      ("-webkit-mask-composite: clear", "-webkit-mask-composite:clear");
+      ("-webkit-mask-composite: copy", "-webkit-mask-composite:copy");
+      ( "-webkit-mask-composite: source-atop",
+        "-webkit-mask-composite:source-atop" );
+      ( "-webkit-mask-composite: destination-over",
+        "-webkit-mask-composite:destination-over" );
+      ( "-webkit-mask-composite: destination-in",
+        "-webkit-mask-composite:destination-in" );
+      ( "-webkit-mask-composite: destination-out",
+        "-webkit-mask-composite:destination-out" );
+      ( "-webkit-mask-composite: destination-atop",
+        "-webkit-mask-composite:destination-atop" );
+      ( "-webkit-mask-composite: plus-lighter",
+        "-webkit-mask-composite:plus-lighter" );
+      ( "-webkit-mask-composite: copy, destination-in",
+        "-webkit-mask-composite:copy,destination-in" );
       ("offset-path: path('M 0 0 L 1 1')", "offset-path:path(\"M 0 0 L 1 1\")");
       ("offset-distance: 50%", "offset-distance:50%");
       ("font-size-adjust: from-font", "font-size-adjust:from-font");
@@ -4722,6 +4738,8 @@ let spec_platform_property_vectors () =
       "grid-template: \"nav/main\"";
       "grid-template: \"a\" \"a a\"";
       "grid-template: \"a .\" \". a\"";
+      "-webkit-mask-composite: plus-darker";
+      "-webkit-mask-composite: add";
       "offset-distance: -10% -10%";
       "font-size-adjust: from-font 1";
       "font-variant-emoji: smile";


### PR DESCRIPTION
The reader knew four of the twelve compositing operators Chrome takes, so `-webkit-mask-composite: plus-lighter` was dropped with a warning. The property is unprefixed nowhere, which leaves the browser to decide its vocabulary.