### PR TITLE
values: read a math function at these two ranged slots

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,14 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `Cascade.Properties.zoom` and `border_image_slice_item` gain `Calc`, so
+  `zoom: calc(.5)`, `zoom: calc(50%)` and `border-image-slice: calc(10%)` read
+  where they were dropped with a warning, and minified output keeps the call
+  around a negative one rather than unwrapping it to a literal the browser
+  drops. CSS Values 4 sec. 10.1 puts a math function wherever its type is and
+  sec. 10.13 checks the range on the resolved value. Exhaustive visitors must
+  handle the two new leaves (#1086)
+
 - `Cascade.Properties.interest_delay` carries `Delays of interest_delay_item
   list` where it carried `Normal` and `Durations of duration list`, so
   `interest-delay: normal 120ms` and `120ms normal` read. CSS UI 4 sec. 6.4

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -6135,6 +6135,7 @@ val column_rule_color : color list -> declaration
 type border_image_slice_item = Properties.border_image_slice_item =
   | Number of number
   | Pct of float
+  | Calc of border_image_slice_item calc
 
 type border_image_slice_offsets = Properties.border_image_slice_offsets = {
   offsets : border_image_slice_item list;
@@ -9395,6 +9396,7 @@ type zoom = Properties.zoom =
   | Reset
   | Num of float
   | Pct of float
+  | Calc of zoom calc
   | Initial
   | Inherit
   | Unset

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -1116,8 +1116,19 @@ let pp_bg_size_with_position maybe_space (bg : background_shorthand) ctx =
       pp_background_size ctx size
   | None -> ()
 
-let pp_border_image_slice_item ctx (value : border_image_slice_item) =
-  match value with Number n -> Values.pp_number ctx n | Pct n -> Pp.pct ctx n
+let rec pp_border_image_slice_item ctx (value : border_image_slice_item) =
+  match value with
+  | Number n -> Values.pp_number ctx n
+  | Pct n -> Pp.pct ctx n
+  | Calc c ->
+      (* CSS Values 4 sec. 10.13 keeps the call valid where the [0,inf] range is
+         exceeded, so [calc(-10%)] computes and a bare [-10%] is dropped. *)
+      Values.pp_calc ~unwrap_num:false
+        ~unwrap:(fun v ->
+          match (v : border_image_slice_item) with
+          | Pct f -> f >= 0.
+          | _ -> true)
+        pp_border_image_slice_item ctx c
 
 let pp_border_image_slice_offsets ctx { offsets; fill } =
   Pp.list ~sep:Pp.space pp_border_image_slice_item ctx offsets;
@@ -2326,11 +2337,27 @@ let read_border_image_number t =
   | _ -> ());
   value
 
+let read_slice_percentage_leaf t : border_image_slice_item =
+  Cursor.ws t;
+  Pct (Cursor.pct t)
+
 let read_border_image_slice_item t : border_image_slice_item =
   match Cursor.percentage_opt t with
   | Some n when n >= 0. -> Pct n
   | Some _ -> Cursor.err_invalid t "border-image value cannot be negative"
-  | None -> Number (read_border_image_number t)
+  | None ->
+      (* The number side reads its own math; a percentage one reaches the second
+         arm only because [read_border_image_number] refuses it. *)
+      Cursor.one_of
+        [
+          (fun t ->
+            (Number (read_border_image_number t) : border_image_slice_item));
+          (fun t ->
+            Calc
+              (Values.read_calc ~result_type:`Number_or_value
+                 read_slice_percentage_leaf t));
+        ]
+        t
 
 let read_border_image_slice_value t values has_fill =
   match Cursor.option read_border_image_slice_item t with

--- a/lib/prop_box.ml
+++ b/lib/prop_box.ml
@@ -406,6 +406,14 @@ let rec pp_zoom : zoom Pp.t =
   | Reset -> Pp.string ctx "reset"
   | Num n -> Pp.float ctx n
   | Pct p -> Pp.pct ctx p
+  | Calc c ->
+      (* CSS Values 4 sec. 10.13 keeps the call valid where the [0,inf] range is
+         exceeded and clamps at used-value time, so [zoom: calc(-50%)] computes
+         and a bare [-50%] is dropped. *)
+      pp_calc ~unwrap_num:false
+        ~unwrap:(fun v ->
+          match (v : zoom) with Num f | Pct f -> f >= 0. | _ -> true)
+        pp_zoom ctx c
   | Initial -> Pp.string ctx "initial"
   | Inherit -> Pp.string ctx "inherit"
   | Unset -> Pp.string ctx "unset"
@@ -1159,9 +1167,22 @@ let rec read_float_side (t : Cursor.t) : float_side =
     ~var:(fun t -> Var (Values.read_var read_float_side t))
     t
 
+(* A [<percentage>] operand of a [zoom] math function; a raw [<number>] is left
+   to [read_calc]'s own [Num] path, as [shape-image-threshold] leaves it. *)
+let rec read_zoom_dim_only t : zoom =
+  Cursor.ws t;
+  Cursor.one_of
+    [
+      (fun t -> (Pct (Cursor.pct t) : zoom));
+      (fun t -> (Var (Values.read_var read_zoom_dim_only t) : zoom));
+    ]
+    t
+
 let rec read_zoom (t : Cursor.t) : zoom =
   (* CSS Viewport 1 sec. 3 spells [zoom] as [normal | reset | <number [0,inf]> |
-     <percentage [0,inf]>], so a negative zoom is no zoom. *)
+     <percentage [0,inf]>], so a negative zoom is no zoom. CSS Values 4 sec.
+     10.13 checks that range on the resolved value, so a math function carrying
+     a negative reads and clamps where the literal is dropped. *)
   let non_negative n =
     if n < 0. then Cursor.err_invalid t "zoom cannot be negative" else n
   in
@@ -1174,7 +1195,8 @@ let rec read_zoom (t : Cursor.t) : zoom =
         | None ->
             Cursor.err_invalid t "expected a number or percentage for zoom")
   in
-  Cursor.enum_or_var "zoom"
+  let read_numeric_math t : zoom = Num (Values.read_numeric_expression t) in
+  Cursor.enum_or_calls "zoom"
     [
       ("normal", (Normal : zoom));
       ("reset", Reset);
@@ -1184,7 +1206,18 @@ let rec read_zoom (t : Cursor.t) : zoom =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~var:(fun t -> Var (Values.read_var read_zoom t))
+    ~calls:
+      [
+        ("var", fun t -> Var (Values.read_var read_zoom t));
+        ( "calc",
+          fun t ->
+            Calc
+              (Values.read_calc ~result_type:`Number_or_value read_zoom_dim_only
+                 t) );
+        ("min", read_numeric_math);
+        ("max", read_numeric_math);
+        ("clamp", read_numeric_math);
+      ]
     ~default:read_value t
 
 let read_object_view_box_inset t =

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -228,6 +228,7 @@ type zoom =
   | Reset
   | Num of float
   | Pct of float
+  | Calc of zoom calc
   | Initial
   | Inherit
   | Unset
@@ -3039,10 +3040,17 @@ type mask =
   | Revert_layer
   | Var of mask var
 
+(* CSS Backgrounds 3 sec. 5.2 gives each offset a [<number [0,inf]>] or a
+   [<percentage [0,inf]>]. [Number] carries the math on the number side; [Calc]
+   carries it on the percentage side, which has no other home. *)
+
 (** CSS Backgrounds 3 sec. 5.2 to 5.4 write the numeric halves of the
     border-image slots as [<number [0,inf]>], which a [calc()] satisfies, so
     each carries a {!type-number} rather than a float. *)
-type border_image_slice_item = Number of number | Pct of float
+type border_image_slice_item =
+  | Number of number
+  | Pct of float
+  | Calc of border_image_slice_item calc
 
 type border_image_slice_offsets = {
   offsets : border_image_slice_item list;

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1032,6 +1032,7 @@ let vars_of_tab_size (value : Properties.tab_size) : any_var list =
 let vars_of_zoom (value : Properties.zoom) : any_var list =
   match value with
   | Var v -> [ V v ]
+  | Calc c -> vars_of_calc c
   | Normal | Reset | Num _ | Pct _ | Initial | Inherit | Unset | Revert
   | Revert_layer ->
       []

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4591,6 +4591,10 @@ let spec_platform_property_vectors () =
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
+      ("zoom: calc(.5)", "zoom:calc(.5)");
+      ("zoom: calc(50%)", "zoom:calc(50%)");
+      ("border-image-slice: calc(10%)", "border-image-slice:calc(10%)");
+      ("border-image-slice: calc(-10%)", "border-image-slice:calc(-10%)");
       ("interest-delay: normal 120ms", "interest-delay:normal 120ms");
       ("interest-delay: 120ms normal", "interest-delay:120ms normal");
       ("interest-delay: 1s 2s", "interest-delay:1s 2s");
@@ -4719,6 +4723,8 @@ let spec_platform_property_vectors () =
       "margin-trim: block inline block";
       "field-sizing: auto";
       "mask-composite: plus";
+      "zoom: -50%";
+      "border-image-slice: -10%";
       "interest-delay: normal normal normal";
       "interest-delay-start: normal 1s";
       "grid-row-end: calc(0)";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4592,8 +4592,8 @@ let spec_platform_property_vectors () =
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
       ("zoom: calc(.5)", "zoom:calc(.5)");
-      ("zoom: calc(50%)", "zoom:calc(50%)");
-      ("border-image-slice: calc(10%)", "border-image-slice:calc(10%)");
+      ("zoom: calc(50%)", "zoom:50%");
+      ("border-image-slice: calc(10%)", "border-image-slice:10%");
       ("border-image-slice: calc(-10%)", "border-image-slice:calc(-10%)");
       ("interest-delay: normal 120ms", "interest-delay:normal 120ms");
       ("interest-delay: 120ms normal", "interest-delay:120ms normal");


### PR DESCRIPTION
`zoom` had no math at all and a `border-image-slice` offset had it on the number side only, so `zoom: calc(.5)` and `border-image-slice: calc(10%)` were dropped with a warning. CSS Values 4 sec. 10.1 puts a math function wherever its type is and sec. 10.13 checks the range on the resolved value, so minified output keeps the call around a negative one rather than unwrapping it to a literal every browser drops.