### PR TITLE
mask: give the prefixed box properties their own vocabulary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,16 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `-webkit-mask-origin` and `-webkit-mask-clip` carry
+  `Cascade.Properties.webkit_mask_box`, WebKit's own box vocabulary, where they
+  carried the `mask_box` of their unprefixed namesakes. They are not aliases:
+  they take `content`, `padding` and `border` beside the `-box` spellings, the
+  clip takes `text`, and neither takes an SVG box or `no-clip`. So
+  `-webkit-mask-origin: content` reads where it was dropped, `mask-origin:
+  no-clip` is dropped as CSS Masking 1 sec. 6.4 asks, and a `mask-clip` value
+  the prefixed property cannot spell no longer generates a `-webkit-mask-clip`
+  declaration every browser drops (#1087)
+
 - `Cascade.Properties.zoom` and `border_image_slice_item` gain `Calc`, so
   `zoom: calc(.5)`, `zoom: calc(50%)` and `border-image-slice: calc(10%)` read
   where they were dropped with a warning, and minified output keeps the call

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -3267,6 +3267,22 @@ type background_box = Properties.background_box =
   | Var of background_box var
 
 (* Mask-related types *)
+type webkit_mask_box = Properties.webkit_mask_box =
+  | Border
+  | Border_box
+  | Content
+  | Content_box
+  | Padding
+  | Padding_box
+  | Text
+  | Layers of webkit_mask_box list
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of webkit_mask_box var
+
 type webkit_mask_composite = Properties.webkit_mask_composite =
   | Source_over
   | Source_in
@@ -7238,13 +7254,13 @@ val webkit_mask_repeat : background_repeat -> declaration
 val mask_repeat : background_repeat -> declaration
 (** [mask_repeat v] is the [mask-repeat] property. *)
 
-val webkit_mask_clip : mask_box -> declaration
+val webkit_mask_clip : webkit_mask_box -> declaration
 (** [webkit_mask_clip v] is the [-webkit-mask-clip] property. *)
 
 val mask_clip : mask_box -> declaration
 (** [mask_clip v] is the [mask-clip] property. *)
 
-val webkit_mask_origin : mask_box -> declaration
+val webkit_mask_origin : webkit_mask_box -> declaration
 (** [webkit_mask_origin v] is the [-webkit-mask-origin] property. *)
 
 val mask_origin : mask_box -> declaration

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2066,8 +2066,10 @@ let read_mask_value : type a. a property -> Cursor.t -> declaration option =
       Some (v Webkit_mask_position (read_background_position t))
   | Webkit_mask_repeat ->
       Some (v Webkit_mask_repeat (read_background_repeat_list t))
-  | Webkit_mask_clip -> Some (v Webkit_mask_clip (read_mask_box_list t))
-  | Webkit_mask_origin -> Some (v Webkit_mask_origin (read_mask_box_list t))
+  | Webkit_mask_clip ->
+      Some (v Webkit_mask_clip (read_webkit_mask_box_list ~clip:true t))
+  | Webkit_mask_origin ->
+      Some (v Webkit_mask_origin (read_webkit_mask_box_list t))
   | Border_image_source ->
       Some (v Border_image_source (read_border_image_source t))
   | Border_image_slice ->
@@ -2085,7 +2087,7 @@ let read_mask_value : type a. a property -> Cursor.t -> declaration option =
   | Mask_size -> Some (v Mask_size (read_background_size_list t))
   | Mask_position -> Some (v Mask_position (read_background_position t))
   | Mask_repeat -> Some (v Mask_repeat (read_background_repeat_list t))
-  | Mask_clip -> Some (v Mask_clip (read_mask_box_list t))
+  | Mask_clip -> Some (v Mask_clip (read_mask_box_list ~clip:true t))
   | Mask_origin -> Some (v Mask_origin (read_mask_box_list t))
   | Mask_type -> Some (v Mask_type (read_mask_type t))
   | All -> Some (v All (Properties.read_css_wide t))

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -1961,13 +1961,13 @@ val webkit_mask_repeat : background_repeat -> declaration
 val mask_repeat : background_repeat -> declaration
 (** [mask_repeat v] is the [mask-repeat] property. *)
 
-val webkit_mask_clip : mask_box -> declaration
+val webkit_mask_clip : webkit_mask_box -> declaration
 (** [webkit_mask_clip v] is the [-webkit-mask-clip] property. *)
 
 val mask_clip : mask_box -> declaration
 (** [mask_clip v] is the [mask-clip] property. *)
 
-val webkit_mask_origin : mask_box -> declaration
+val webkit_mask_origin : webkit_mask_box -> declaration
 (** [webkit_mask_origin v] is the [-webkit-mask-origin] property. *)
 
 val mask_origin : mask_box -> declaration

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -673,7 +673,8 @@ type webkit_fallback_spec =
   | Typed_fallback : {
       kind : webkit_fallback;
       property : 'a Properties.property;
-      webkit_property : 'a Properties.property;
+      webkit_property : 'b Properties.property;
+      convert : 'a -> 'b option;
       name : string;
       webkit_name : string;
       condition : fallback_condition;
@@ -684,7 +685,45 @@ type webkit_fallback_spec =
 let typed_fallback ?(condition = Any_value) kind property webkit_property name
     webkit_name =
   Typed_fallback
-    { kind; property; webkit_property; name; webkit_name; condition }
+    {
+      kind;
+      property;
+      webkit_property;
+      convert = Option.some;
+      name;
+      webkit_name;
+      condition;
+    }
+
+(* The same, where the prefixed property does not take the standard one's
+   vocabulary and a value outside the overlap gets no fallback. *)
+let converted_fallback ?(condition = Any_value) ~convert kind property
+    webkit_property name webkit_name =
+  Typed_fallback
+    { kind; property; webkit_property; convert; name; webkit_name; condition }
+
+(* The prefixed mask box properties take WebKit's older vocabulary, which meets
+   the [<coord-box>] of CSS Masking 1 sec. 6.4 and 6.5 on the three CSS box
+   names alone. A value with no prefixed spelling gets no fallback rather than
+   one the browser drops. *)
+let rec prefixed_mask_box :
+    Properties.mask_box -> Properties.webkit_mask_box option = function
+  | Border_box -> Some Border_box
+  | Content_box -> Some Content_box
+  | Padding_box -> Some Padding_box
+  | Inherit -> Some Inherit
+  | Initial -> Some Initial
+  | Unset -> Some Unset
+  | Revert -> Some Revert
+  | Revert_layer -> Some Revert_layer
+  | Layers layers ->
+      (* One layer outside the overlap costs the whole fallback: the prefixed
+         property reads the list or none of it. *)
+      let mapped = List.filter_map prefixed_mask_box layers in
+      if List.length mapped = List.length layers then
+        Some (Layers mapped : Properties.webkit_mask_box)
+      else None
+  | Fill_box | Stroke_box | View_box | No_clip | Var _ -> None
 
 let webkit_fallback_specs =
   [
@@ -706,10 +745,10 @@ let webkit_fallback_specs =
       "-webkit-mask-size";
     typed_fallback Mask_repeat_fallback Mask_repeat Webkit_mask_repeat
       "mask-repeat" "-webkit-mask-repeat";
-    typed_fallback Mask_clip_fallback Mask_clip Webkit_mask_clip "mask-clip"
-      "-webkit-mask-clip";
-    typed_fallback Mask_origin_fallback Mask_origin Webkit_mask_origin
-      "mask-origin" "-webkit-mask-origin";
+    converted_fallback ~convert:prefixed_mask_box Mask_clip_fallback Mask_clip
+      Webkit_mask_clip "mask-clip" "-webkit-mask-clip";
+    converted_fallback ~convert:prefixed_mask_box Mask_origin_fallback
+      Mask_origin Webkit_mask_origin "mask-origin" "-webkit-mask-origin";
   ]
 
 let fallback_spec_kind = function
@@ -811,10 +850,13 @@ let webkit_fallback_of_declaration targets decl : Declaration.declaration option
   in
   let fallback_from_spec spec =
     match (spec, decl) with
-    | ( Typed_fallback { kind; property; webkit_property; _ },
+    | ( Typed_fallback { kind; property; webkit_property; convert; _ },
         Declaration { property = actual; value; important; _ } ) -> (
         match Properties.eq_property actual property with
-        | Some Equal -> fallback kind webkit_property value important
+        | Some Equal -> (
+            match convert value with
+            | Some value -> fallback kind webkit_property value important
+            | None -> None)
         | None -> None)
     | ( Mask_fallback_spec { webkit_name; _ },
         Declaration { property = Mask; value; important; _ } ) ->

--- a/lib/prop_mask.ml
+++ b/lib/prop_mask.ml
@@ -496,6 +496,23 @@ let rec pp_mask_type : mask_type Pp.t =
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
 
+let rec pp_webkit_mask_box : webkit_mask_box Pp.t =
+ fun ctx -> function
+  | Var v -> pp_var pp_webkit_mask_box ctx v
+  | Layers layers -> Pp.list ~sep:Pp.comma pp_webkit_mask_box ctx layers
+  | Border -> Pp.string ctx "border"
+  | Border_box -> Pp.string ctx "border-box"
+  | Content -> Pp.string ctx "content"
+  | Content_box -> Pp.string ctx "content-box"
+  | Padding -> Pp.string ctx "padding"
+  | Padding_box -> Pp.string ctx "padding-box"
+  | Text -> Pp.string ctx "text"
+  | Inherit -> Pp.string ctx "inherit"
+  | Initial -> Pp.string ctx "initial"
+  | Unset -> Pp.string ctx "unset"
+  | Revert -> Pp.string ctx "revert"
+  | Revert_layer -> Pp.string ctx "revert-layer"
+
 let rec pp_mask_box : mask_box Pp.t =
  fun ctx -> function
   | Var v -> pp_var pp_mask_box ctx v
@@ -681,28 +698,57 @@ let rec read_mask_type t : mask_type =
     ~var:(fun t -> Var (Values.read_var read_mask_type t))
     t
 
-(* Parser for mask_box values (mask-clip and mask-origin) *)
-let rec read_mask_box t : mask_box =
+(* CSS Masking 1 sec. 6.4 gives mask-origin a <coord-box> and sec. 6.5 gives
+   mask-clip a <coord-box> or no-clip, so the extra keyword belongs to the clip
+   alone. *)
+let rec read_mask_box ?(clip = false) t : mask_box =
   Cursor.enum_or_var "mask-box"
-    [
-      ("border-box", (Border_box : mask_box));
-      ("content-box", Content_box);
-      ("fill-box", Fill_box);
-      ("padding-box", Padding_box);
-      ("stroke-box", Stroke_box);
-      ("view-box", View_box);
-      ("no-clip", No_clip);
-      ("inherit", Inherit);
-      ("initial", Initial);
-      ("unset", Unset);
-      ("revert", Revert);
-      ("revert-layer", Revert_layer);
-    ]
-    ~var:(fun t -> Var (Values.read_var read_mask_box t))
+    ([
+       ("border-box", (Border_box : mask_box));
+       ("content-box", Content_box);
+       ("fill-box", Fill_box);
+       ("padding-box", Padding_box);
+       ("stroke-box", Stroke_box);
+       ("view-box", View_box);
+       ("inherit", Inherit);
+       ("initial", Initial);
+       ("unset", Unset);
+       ("revert", Revert);
+       ("revert-layer", Revert_layer);
+     ]
+    @ if clip then [ ("no-clip", (No_clip : mask_box)) ] else [])
+    ~var:(fun t -> Var (Values.read_var (read_mask_box ~clip) t))
     t
 
-let read_mask_box_list t : mask_box =
-  match Cursor.list ~sep:Cursor.comma ~at_least:1 read_mask_box t with
+let read_mask_box_list ?clip t : mask_box =
+  match Cursor.list ~sep:Cursor.comma ~at_least:1 (read_mask_box ?clip) t with
+  | [ one ] -> one
+  | many -> Layers many
+
+(* The prefixed pair takes WebKit's older set; [text] belongs to the clip. *)
+let rec read_webkit_mask_box ?(clip = false) t : webkit_mask_box =
+  Cursor.enum_or_var "-webkit-mask-box"
+    ([
+       ("border", (Border : webkit_mask_box));
+       ("border-box", Border_box);
+       ("content", Content);
+       ("content-box", Content_box);
+       ("padding", Padding);
+       ("padding-box", Padding_box);
+       ("inherit", Inherit);
+       ("initial", Initial);
+       ("unset", Unset);
+       ("revert", Revert);
+       ("revert-layer", Revert_layer);
+     ]
+    @ if clip then [ ("text", (Text : webkit_mask_box)) ] else [])
+    ~var:(fun t -> Var (Values.read_var (read_webkit_mask_box ~clip) t))
+    t
+
+let read_webkit_mask_box_list ?clip t : webkit_mask_box =
+  match
+    Cursor.list ~sep:Cursor.comma ~at_least:1 (read_webkit_mask_box ?clip) t
+  with
   | [ one ] -> one
   | many -> Layers many
 

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -5004,8 +5004,8 @@ let pp_property_value : type a. (a property * a) Pp.t =
   | Webkit_mask_size -> pp pp_background_size
   | Webkit_mask_position -> pp pp_background_position
   | Webkit_mask_repeat -> pp pp_background_repeat
-  | Webkit_mask_clip -> pp pp_mask_box
-  | Webkit_mask_origin -> pp pp_mask_box
+  | Webkit_mask_clip -> pp pp_webkit_mask_box
+  | Webkit_mask_origin -> pp pp_webkit_mask_box
   | Border_image_source -> pp pp_background_image
   | Border_image_slice -> pp pp_border_image_slice
   | Border_image_repeat -> pp pp_border_image_repeat

--- a/lib/properties.mli
+++ b/lib/properties.mli
@@ -1858,11 +1858,23 @@ val read_mask_type : Cursor.t -> mask_type
 val pp_mask_type : mask_type Pp.t
 (** [pp_mask_type] pretty-prints a mask-type value. *)
 
-val read_mask_box : Cursor.t -> mask_box
+val read_mask_box : ?clip:bool -> Cursor.t -> mask_box
 (** [read_mask_box t] parses a single-layer mask-clip or mask-origin value (used
     by the shorthand). *)
 
-val read_mask_box_list : Cursor.t -> mask_box
+val pp_webkit_mask_box : webkit_mask_box Pp.t
+(** [pp_webkit_mask_box] pretty-prints a [-webkit-mask-clip] /
+    [-webkit-mask-origin] box. *)
+
+val read_webkit_mask_box : ?clip:bool -> Cursor.t -> webkit_mask_box
+(** [read_webkit_mask_box ?clip t] parses one prefixed mask box. [clip] admits
+    the [text] keyword, which only [-webkit-mask-clip] takes. *)
+
+val read_webkit_mask_box_list : ?clip:bool -> Cursor.t -> webkit_mask_box
+(** [read_webkit_mask_box_list ?clip t] parses the standalone
+    [-webkit-mask-clip] / [-webkit-mask-origin] value, one box per layer. *)
+
+val read_mask_box_list : ?clip:bool -> Cursor.t -> mask_box
 (** [read_mask_box_list t] parses the standalone mask-clip / mask-origin
     longhand: a comma-separated layer list. *)
 

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -3018,6 +3018,26 @@ type mask_box =
   | Revert_layer
   | Var of mask_box var
 
+(** The box vocabulary of [-webkit-mask-origin] and [-webkit-mask-clip], which
+    is WebKit's older set rather than the [<coord-box>] CSS Masking 1 sec. 6.4
+    and 6.5 give the unprefixed pair: the three CSS box names in both their bare
+    and [-box] spellings, none of the SVG boxes, and [text] on the clip. *)
+type webkit_mask_box =
+  | Border
+  | Border_box
+  | Content
+  | Content_box
+  | Padding
+  | Padding_box
+  | Text  (** Only valid for -webkit-mask-clip *)
+  | Layers of webkit_mask_box list
+  | Inherit
+  | Initial
+  | Unset
+  | Revert
+  | Revert_layer
+  | Var of webkit_mask_box var
+
 type mask_layer = {
   image : background_image option;
   position : position_value option;
@@ -5350,8 +5370,8 @@ type 'a property =
   | Webkit_mask_size : background_size property
   | Webkit_mask_position : background_position property
   | Webkit_mask_repeat : background_repeat property
-  | Webkit_mask_clip : mask_box property
-  | Webkit_mask_origin : mask_box property
+  | Webkit_mask_clip : webkit_mask_box property
+  | Webkit_mask_origin : webkit_mask_box property
   | Mask_image : background_image property
   | Mask_composite : mask_composite property
   | Mask_mode : mask_mode property

--- a/lib/shorthand.ml
+++ b/lib/shorthand.ml
@@ -4462,6 +4462,18 @@ let mask_position_part : declaration -> Properties.position_value option =
       background_position_singleton value
   | _ -> None
 
+(* The prefixed pair's own vocabulary meets the unprefixed [<coord-box>] on the
+   three CSS box names alone, so a bare legacy name or [text] keeps its longhand
+   rather than contracting into a slot that cannot spell it. *)
+let mask_box_of_webkit :
+    Properties.webkit_mask_box -> Properties.mask_box option = function
+  | Border_box -> Some Border_box
+  | Content_box -> Some Content_box
+  | Padding_box -> Some Padding_box
+  | Border | Content | Padding | Text | Layers _ | Inherit | Initial | Unset
+  | Revert | Revert_layer | Var _ ->
+      None
+
 let mask_origin_part : declaration -> Properties.mask_box option = function
   | Declaration { property = Mask_origin; value; _ } -> (
       match value with
@@ -4472,7 +4484,7 @@ let mask_origin_part : declaration -> Properties.mask_box option = function
       match value with
       | Inherit | Unset -> None
       | Initial -> Some (Border_box : Properties.mask_box)
-      | v -> Some v)
+      | v -> mask_box_of_webkit v)
   | _ -> None
 
 let mask_clip_part : declaration -> Properties.mask_box option = function
@@ -4485,7 +4497,7 @@ let mask_clip_part : declaration -> Properties.mask_box option = function
       match value with
       | Inherit | Unset -> None
       | Initial -> Some (Border_box : Properties.mask_box)
-      | v -> Some v)
+      | v -> mask_box_of_webkit v)
   | _ -> None
 
 let mask_mode_part : declaration -> Properties.mask_mode option = function

--- a/lib/variables.ml
+++ b/lib/variables.ml
@@ -1794,6 +1794,9 @@ let vars_of_object_view_box (value : Properties.object_view_box) =
 let vars_of_mask_box (value : Properties.mask_box) =
   match value with Var v -> [ V v ] | _ -> []
 
+let vars_of_webkit_mask_box (value : Properties.webkit_mask_box) =
+  match value with Var v -> [ V v ] | _ -> []
+
 let rec vars_of_webkit_mask_composite (value : Properties.webkit_mask_composite)
     =
   match value with
@@ -2583,9 +2586,9 @@ let vars_of_property : type a. a property -> a -> any_var list =
   | Webkit_box_orient, value -> vars_of_webkit_box_orient value
   | Webkit_font_smoothing, value -> vars_of_webkit_font_smoothing value
   | Webkit_line_clamp, value -> vars_of_webkit_line_clamp value
-  | Webkit_mask_clip, value -> vars_of_mask_box value
+  | Webkit_mask_clip, value -> vars_of_webkit_mask_box value
   | Webkit_mask_composite, value -> vars_of_webkit_mask_composite value
-  | Webkit_mask_origin, value -> vars_of_mask_box value
+  | Webkit_mask_origin, value -> vars_of_webkit_mask_box value
   | Webkit_mask_repeat, value -> vars_of_background_repeat value
   | Webkit_mask_source_type, value -> vars_of_mask_source_type value
   | Webkit_text_size_adjust, value -> vars_of_text_size_adjust value

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -309,13 +309,6 @@ let spec_ahead : excuse list =
          crisp-edges";
     };
     {
-      properties = [ "-webkit-mask-clip" ];
-      value = "no-clip";
-      why =
-        "CSS Masking 1 sec. 7.5: [ <coord-box> | no-clip ]#; Chrome takes \
-         no-clip on mask-clip but not on its own -webkit- alias of it";
-    };
-    {
       properties = [ "stroke-linejoin" ];
       value = "miter-clip";
       why =

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1986,15 +1986,43 @@ let matrix =
       };
       {
         property = "-webkit-mask-clip";
-        positives = [ "border-box"; "padding-box"; "content-box"; "no-clip" ];
+        positives =
+          [
+            "border";
+            "border-box";
+            "content";
+            "content-box";
+            "padding";
+            "padding-box";
+            "text";
+          ];
         negatives =
-          [ "margin-box"; "border-box padding-box content-box content-box" ];
+          [
+            "no-clip";
+            "fill-box";
+            "margin-box";
+            "border-box padding-box content-box content-box";
+          ];
       };
       {
         property = "-webkit-mask-origin";
-        positives = [ "border-box"; "padding-box"; "content-box" ];
+        positives =
+          [
+            "border";
+            "border-box";
+            "content";
+            "content-box";
+            "padding";
+            "padding-box";
+          ];
         negatives =
-          [ "margin-box"; "border-box padding-box content-box content-box" ];
+          [
+            "text";
+            "no-clip";
+            "fill-box";
+            "margin-box";
+            "border-box padding-box content-box content-box";
+          ];
       };
       {
         property = "mask-composite";
@@ -2005,13 +2033,23 @@ let matrix =
         property = "mask-clip";
         positives = [ "border-box"; "padding-box"; "content-box"; "no-clip" ];
         negatives =
-          [ "margin-box"; "border-box padding-box content-box content-box" ];
+          [
+            "text";
+            "content";
+            "margin-box";
+            "border-box padding-box content-box content-box";
+          ];
       };
       {
         property = "mask-origin";
         positives = [ "border-box"; "padding-box"; "content-box" ];
         negatives =
-          [ "margin-box"; "border-box padding-box content-box content-box" ];
+          [
+            "no-clip";
+            "content";
+            "margin-box";
+            "border-box padding-box content-box content-box";
+          ];
       };
       {
         property = "mask-type";

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4591,6 +4591,11 @@ let spec_platform_property_vectors () =
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
+      ("-webkit-mask-origin: content", "-webkit-mask-origin:content");
+      ("-webkit-mask-origin: padding", "-webkit-mask-origin:padding");
+      ("-webkit-mask-origin: border", "-webkit-mask-origin:border");
+      ("-webkit-mask-clip: content", "-webkit-mask-clip:content");
+      ("-webkit-mask-clip: text", "-webkit-mask-clip:text");
       ("zoom: calc(.5)", "zoom:calc(.5)");
       ("zoom: calc(50%)", "zoom:50%");
       ("border-image-slice: calc(10%)", "border-image-slice:10%");
@@ -4723,6 +4728,12 @@ let spec_platform_property_vectors () =
       "margin-trim: block inline block";
       "field-sizing: auto";
       "mask-composite: plus";
+      "mask-origin: no-clip";
+      "-webkit-mask-origin: fill-box";
+      "-webkit-mask-origin: view-box";
+      "-webkit-mask-clip: no-clip";
+      "-webkit-mask-origin: text";
+      "mask-clip: text";
       "zoom: -50%";
       "border-image-slice: -10%";
       "interest-delay: normal normal normal";

--- a/test/test_properties.ml
+++ b/test/test_properties.ml
@@ -674,6 +674,9 @@ let check_field_sizing =
 let check_font_size = check_value_cursor "font_size" read_font_size pp_font_size
 let check_mask_box = check_value_cursor "mask_box" read_mask_box pp_mask_box
 
+let check_webkit_mask_box =
+  check_value_cursor "webkit_mask_box" read_webkit_mask_box pp_webkit_mask_box
+
 let check_mask_composite =
   check_value_cursor "mask_composite" read_mask_composite pp_mask_composite
 
@@ -4774,11 +4777,23 @@ let test_mask_box () =
   check_mask_box "padding-box";
   check_mask_box "fill-box";
   check_mask_box "inherit";
+  (* Measured on Chrome 153: -webkit-mask-clip is WebKit's own property, not an
+     alias of mask-clip, and takes neither fill-box nor no-clip. One layer it
+     cannot spell costs the whole fallback. *)
+  decl_optimizes_to ~into:"mask-clip:border-box,fill-box,no-clip"
+    "mask-clip:border-box,fill-box,no-clip";
   decl_optimizes_to
     ~into:
-      "-webkit-mask-clip:border-box,fill-box,no-clip;mask-clip:border-box,fill-box,no-clip"
-    "mask-clip:border-box,fill-box,no-clip";
+      "-webkit-mask-clip:border-box,content-box;mask-clip:border-box,content-box"
+    "mask-clip:border-box,content-box";
   neg_cursor read_mask_box "invalid-mask-box"
+
+let test_webkit_mask_box () =
+  check_webkit_mask_box "content";
+  check_webkit_mask_box "padding";
+  check_webkit_mask_box "border";
+  check_webkit_mask_box "border-box";
+  neg_cursor read_webkit_mask_box "fill-box"
 
 let test_mask_composite () =
   check_mask_composite "add";
@@ -5912,6 +5927,7 @@ let additional_tests =
     test_case "field_sizing" `Quick test_field_sizing;
     test_case "font_size" `Quick test_font_size;
     test_case "mask_box" `Quick test_mask_box;
+    test_case "webkit_mask_box" `Quick test_webkit_mask_box;
     test_case "mask_composite" `Quick test_mask_composite;
     test_case "mask_mode" `Quick test_mask_mode;
     test_case "mask_type" `Quick test_mask_type;


### PR DESCRIPTION
`-webkit-mask-origin` and `-webkit-mask-clip` shared the `mask_box` type with their unprefixed namesakes, so each of the four read the union of all four keyword sets. Measured on Chrome 153 they are four different vocabularies: the prefixed pair takes `content`, `padding` and `border` beside the `-box` spellings and the clip takes `text`, while neither takes an SVG box or `no-clip`. So `-webkit-mask-origin: content` reads where it was dropped, `mask-origin: no-clip` is dropped as CSS Masking 1 sec. 6.4 asks, and a `mask-clip` value the prefixed property cannot spell no longer generates a `-webkit-mask-clip` declaration every browser drops.