### PR TITLE
ruby: read the spaces overhang

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,12 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `Cascade.Properties.ruby_overhang` gains `Spaces`, so
+  `ruby-overhang: spaces` reads where it was dropped with a warning. CSS Ruby 1
+  sec. 5.1 spells the property `auto | spaces`, and cascade read only `auto`
+  and the `none` browsers keep as a legacy alias. Exhaustive visitors must
+  handle the new leaf (#1088)
+
 - `-webkit-mask-origin` and `-webkit-mask-clip` carry
   `Cascade.Properties.webkit_mask_box`, WebKit's own box vocabulary, where they
   carried the `mask_box` of their unprefixed namesakes. They are not aliases:

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -2729,6 +2729,7 @@ type ruby_align = Properties.ruby_align =
 
 type ruby_overhang = Properties.ruby_overhang =
   | Auto
+  | Spaces
   | None
   | Inherit
   | Initial

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -1343,6 +1343,7 @@ let rec pp_ruby_align : ruby_align Pp.t =
 let rec pp_ruby_overhang : ruby_overhang Pp.t =
  fun ctx -> function
   | Auto -> Pp.string ctx "auto"
+  | Spaces -> Pp.string ctx "spaces"
   | None -> Pp.string ctx "none"
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
@@ -1808,6 +1809,7 @@ let rec read_ruby_overhang t : ruby_overhang =
   Cursor.enum_or_var "ruby-overhang"
     [
       ("auto", (Auto : ruby_overhang));
+      ("spaces", Spaces);
       ("none", None);
       ("inherit", Inherit);
       ("initial", Initial);

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -1567,8 +1567,11 @@ type ruby_align =
   | Revert_layer
   | Var of ruby_align var
 
+(* CSS Ruby 1 sec. 5.1: [auto | spaces]. [None] is the older spelling Chrome and
+   Firefox still read, and serialise as [spaces]. *)
 type ruby_overhang =
   | Auto
+  | Spaces
   | None
   | Inherit
   | Initial

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4591,6 +4591,7 @@ let spec_platform_property_vectors () =
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
+      ("ruby-overhang: spaces", "ruby-overhang:spaces");
       ("-webkit-mask-origin: content", "-webkit-mask-origin:content");
       ("-webkit-mask-origin: padding", "-webkit-mask-origin:padding");
       ("-webkit-mask-origin: border", "-webkit-mask-origin:border");


### PR DESCRIPTION
`ruby-overhang: spaces` was dropped with a warning. CSS Ruby 1 sec. 5.1 spells the property `auto | spaces`, and cascade read `auto` and the `none` browsers keep as a legacy alias of `spaces`, but not the keyword itself.