### PR TITLE
border-image: fill the shorthand slots in any order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,12 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `border-image` and `mask-border` fill their slots in any order, so
+  `border-image: 50% none` and `round none 30` read where they were dropped
+  with a warning. CSS Backgrounds 3 sec. 6.1 combines the source, the slice
+  with its slash-separated width and outset, and the repeat with `||`, and the
+  reader took them in one fixed order (#1089)
+
 - `Cascade.Properties.ruby_overhang` gains `Spaces`, so
   `ruby-overhang: spaces` reads where it was dropped with a warning. CSS Ruby 1
   sec. 5.1 spells the property `auto | spaces`, and cascade read only `auto`

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -2539,52 +2539,80 @@ let read_mask_border_mode t =
    background-image takes a comma-separated list of them. *)
 let read_border_image_source t : background_image = read_bg_image t
 
-let read_border_image_shorthand ~mask_mode t : border_image =
-  let read_mode t =
-    if mask_mode then Cursor.option read_mask_border_mode t
-    else (None : mask_border_mode option)
-  in
-  let source = Cursor.option read_border_image_source t in
+(* The slice carries its slash-separated width and outset, so the three read as
+   one member of the [||] rather than three that could be reordered apart. *)
+let read_border_image_slice_group t =
+  let slice = read_border_image_slice_offsets t in
   Cursor.ws t;
-  (* sec. 8.7 puts [mask-border-mode] in [||] combination with the other slots,
-     so the keyword may appear after [<source>] (before the slice) or after
-     [<repeat>]. Try the early slot first; combine with the trailing slot
-     below. *)
-  let mode_early = read_mode t in
-  Cursor.ws t;
-  let slice = Cursor.option read_border_image_slice_offsets t in
-  let width, outset =
+  if Cursor.slash_opt t then (
+    let width =
+      Some
+        (read_border_image_box_values ~what:"width" read_border_image_width_item
+           t)
+    in
     Cursor.ws t;
-    if Cursor.slash_opt t then (
-      let width =
+    if Cursor.slash_opt t then
+      ( slice,
+        width,
         Some
-          (read_border_image_box_values ~what:"width"
-             read_border_image_width_item t)
-      in
-      Cursor.ws t;
-      if Cursor.slash_opt t then
-        ( width,
-          Some
-            (read_border_image_box_values ~what:"outset"
-               read_border_image_outset_item t) )
-      else (width, None))
-    else (None, None)
+          (read_border_image_box_values ~what:"outset"
+             read_border_image_outset_item t) )
+    else (slice, width, None))
+  else (slice, None, None)
+
+let read_border_image_shorthand ~mask_mode t : border_image =
+  let source : background_image option ref = ref Option.None
+  and slice : border_image_slice_offsets option ref = ref Option.None
+  and width : border_image_width_item list option ref = ref Option.None
+  and outset : border_image_outset_item list option ref = ref Option.None
+  and repeat : border_image_repeat_keyword list option ref = ref Option.None
+  and mode : mask_border_mode option ref = ref Option.None in
+  let fill : 'a. filled:bool -> (Cursor.t -> 'a) -> ('a -> unit) -> bool =
+   fun ~filled read set ->
+    (not filled)
+    &&
+    match Cursor.option read t with
+    | Some value ->
+        set value;
+        true
+    | None -> false
   in
-  Cursor.ws t;
-  let repeat = Cursor.option read_border_image_repeat_keywords t in
-  Cursor.ws t;
-  let mode_late : mask_border_mode option =
-    if Option.is_some mode_early then (None : mask_border_mode option)
-    else read_mode t
+  (* Sec. 6.1 combines the source, the slice group and the repeat with [||], and
+     CSS Masking 1 (ED) sec. 8.7 adds [mask-border-mode] to the same group, so
+     each fills its slot wherever the author wrote it. *)
+  let rec loop () =
+    Cursor.ws t;
+    let filled =
+      fill ~filled:(Option.is_some !source) read_border_image_source (fun v ->
+          source := Option.Some v)
+      || fill ~filled:(Option.is_some !slice) read_border_image_slice_group
+           (fun (s, w, o) ->
+             slice := Option.Some s;
+             width := w;
+             outset := o)
+      || fill ~filled:(Option.is_some !repeat) read_border_image_repeat_keywords
+           (fun v -> repeat := Option.Some v)
+      || mask_mode
+         && fill ~filled:(Option.is_some !mode) read_mask_border_mode (fun v ->
+             mode := Option.Some v)
+    in
+    if filled then loop ()
   in
-  let mode = match mode_early with Some _ -> mode_early | None -> mode_late in
-  (match (source, slice, repeat, mode) with
-  | None, None, None, None ->
+  loop ();
+  (match (!source, !slice, !repeat, !mode) with
+  | Option.None, Option.None, Option.None, Option.None ->
       Cursor.err_expected t
         (if mask_mode then "mask-border source, slice, repeat, or mode"
          else "border-image source, slice, or repeat")
   | _ -> ());
-  { source; slice; width; outset; repeat; mode }
+  {
+    source = !source;
+    slice = !slice;
+    width = !width;
+    outset = !outset;
+    repeat = !repeat;
+    mode = !mode;
+  }
 
 let read_border_image t : border_image =
   read_border_image_shorthand ~mask_mode:false t

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4591,6 +4591,10 @@ let spec_platform_property_vectors () =
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
+      ("border-image: 50% none", "border-image:50%");
+      ("border-image: 1 none", "border-image:1");
+      ("border-image: round none 30", "border-image:30 round");
+      ("border-image: 30 / 2 url(a.png)", "border-image:url(a.png)30/2");
       ("ruby-overhang: spaces", "ruby-overhang:spaces");
       ("-webkit-mask-origin: content", "-webkit-mask-origin:content");
       ("-webkit-mask-origin: padding", "-webkit-mask-origin:padding");

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4591,9 +4591,11 @@ let spec_platform_property_vectors () =
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
-      ("border-image: 50% none", "border-image:50%");
-      ("border-image: 1 none", "border-image:1");
-      ("border-image: round none 30", "border-image:30 round");
+      (* Sec. 6.1 lists the slots source, slice, width, outset then repeat, so
+         the canonical serialisation reorders what the author interleaved. *)
+      ("border-image: 50% none", "border-image:none 50%");
+      ("border-image: 1 none", "border-image:none 1");
+      ("border-image: round none 30", "border-image:none 30 round");
       ("border-image: 30 / 2 url(a.png)", "border-image:url(a.png)30/2");
       ("ruby-overhang: spaces", "ruby-overhang:spaces");
       ("-webkit-mask-origin: content", "-webkit-mask-origin:content");


### PR DESCRIPTION
`border-image: 50% none` and `round none 30` were dropped with a warning because the reader took the source, then the slice, then the repeat, leaving anything that led with a later slot unconsumed. CSS Backgrounds 3 sec. 6.1 combines the three with `||`, and CSS Masking 1 sec. 8.7 adds `mask-border-mode` to the same group.