### PR TITLE
supports: keep the property name the author spelled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,14 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- An `@supports` condition keeps the property name the author spelled, so
+  `@supports (colo\r: green)` reads back as written instead of as
+  `(color: green)`. CSS Conditional 3 sec. 7.4 returns "the condition that was
+  specified", and the token stream simplifications it allows are permitted
+  rather than required, so minified output still takes the shortest spelling.
+  `Cascade.Supports.Declaration` carries the name beside the declaration,
+  because a typed property is a constructor and cannot hold the escape (#1092)
+
 - Compatibility-prefix generation asks the web-features dataset which targets
   read a property unprefixed, where it carried browser versions written into
   the source. A `backdrop-filter` targeting Safari 17.0 to 17.6 keeps its

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2882,6 +2882,35 @@ let rec pp : declaration Pp.t =
 (* A declaration feature query hands the authored declaration to another parser.
    Minify its separators, but keep opaque numeric token spellings: the spelling
    itself is the compatibility question. *)
+(* The value half of {!pp_opaque}, for a caller writing the property name
+   itself: an [\@supports] feature keeps the name the author spelled, which the
+   typed property behind it cannot reproduce. *)
+let rec pp_opaque_value : declaration Pp.t =
+ fun ctx decl ->
+  let pp_components components important =
+    Pp.string ctx
+      (if Pp.minified ctx then Parser.to_string_minified components
+       else Parser.to_string_verbatim components);
+    if important then
+      Pp.string ctx (if ctx.minify then "!important" else " !important")
+  in
+  match decl with
+  | Declaration { property = Unknown_property _; value; important; _ } ->
+      pp_components value important
+  | Declaration
+      {
+        property = Custom_property _;
+        value = Custom_value { value = Tokens components; _ };
+        important;
+        _;
+      } ->
+      pp_components components important
+  | Declaration { property; value; important; _ } ->
+      pp_property_value ctx (property, value);
+      if important then
+        Pp.string ctx (if ctx.minify then "!important" else " !important")
+  | Theme_guarded { decl; _ } -> pp_opaque_value ctx decl
+
 let rec pp_opaque : declaration Pp.t =
  fun ctx decl ->
   (* Every caller of this is an [@supports] condition, and CSS Conditional Rules

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -28,6 +28,12 @@ val pp_property : 'a Properties.property Pp.t
 val pp : t Pp.t
 (** [pp] is the pretty-printer for declarations. *)
 
+val pp_opaque_value : t Pp.t
+(** [pp_opaque_value] is the value half of {!pp_opaque}, for a caller writing
+    the property name itself. An [\@supports] feature does, because it keeps the
+    name the author spelled and the typed property behind it cannot reproduce
+    that. *)
+
 val pp_opaque : t Pp.t
 (** [pp_opaque] minifies separators but preserves authored numeric token
     spellings in an opaque declaration value. It serves declaration feature

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -1015,7 +1015,8 @@ let rec refs_of_media : Media.t -> string list = function
 
 let refs_of_supports_feature : Supports.declaration_feature -> string list =
   function
-  | Declaration decl -> names_of_vars (Variables.vars_of_declarations [ decl ])
+  | Declaration (_, decl) ->
+      names_of_vars (Variables.vars_of_declarations [ decl ])
   | Empty _ | Unsupported _ | Vendor_flag_enabled -> []
 
 let rec refs_of_supports : Supports.t -> string list = function

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -912,7 +912,7 @@ let add_declaration_prefixes ~targets decls =
   loop false [] decls
 
 let rec condition_has_webkit kind = function
-  | Supports.Property (Supports.Declaration decl) ->
+  | Supports.Property (Supports.Declaration (_, decl)) ->
       is_webkit_fallback kind decl
   | Supports.Property _ | Supports.Function _ | Supports.General_enclosed _ ->
       false
@@ -923,13 +923,19 @@ let rec condition_has_webkit kind = function
 let add_condition_prefixes ~targets condition =
   let author_owns kind = condition_has_webkit kind condition in
   let rec map = function
-    | Supports.Property (Supports.Declaration decl) as original -> (
+    | Supports.Property (Supports.Declaration (_, decl)) as original -> (
         match fallback_kind decl with
         | Some kind when not (author_owns kind) -> (
             match webkit_fallback_of_declaration targets decl with
             | Some prefixed ->
+                (* Cascade writes this one, so it carries no authored
+                   spelling. *)
+                let name =
+                  Supports.property_name (Declaration.property_name prefixed)
+                in
                 Supports.Or
-                  (Supports.Property (Supports.Declaration prefixed), original)
+                  ( Supports.Property (Supports.Declaration (name, prefixed)),
+                    original )
             | None -> original)
         | Some _ | None -> original)
     | (Supports.Property _ | Supports.Function _ | Supports.General_enclosed _)

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -25,10 +25,10 @@
 
 open Syntax
 
-type property_name = Property_name of string
+type property_name = Property_name of { name : string; repr : string option }
 
 type declaration_feature =
-  | Declaration of Declaration.t
+  | Declaration of property_name * Declaration.t
   | Empty of property_name
   | Unsupported of property_name * string
   | Vendor_flag_enabled
@@ -127,7 +127,7 @@ let string_of_font_tech = function
    serializes to (CSS Syntax 3 (ED) sec. 9) rather than against its own bytes:
    read raw, such a name ends the declaration early and never looks like the
    single ident it is. *)
-let property_name name =
+let property_name ?repr name =
   let reader = Cursor.of_string (Parser.escape_ident name) in
   let parsed =
     try Cursor.ident ~keep_case:true reader
@@ -140,13 +140,13 @@ let property_name name =
     if Custom_property_name.has_prefix parsed then parsed
     else String.lowercase_ascii parsed
   in
-  Property_name name
+  Property_name { name; repr }
 
-let string_of_property_name (Property_name name) = name
+let string_of_property_name (Property_name { name; _ }) = name
 
-let declaration_feature prop value =
+let declaration_feature ?repr prop value =
   match (String.lowercase_ascii prop, String.lowercase_ascii value) with
-  | _, "" -> Empty (property_name prop)
+  | _, "" -> Empty (property_name ?repr prop)
   | "-vendor-flag", "enabled" -> Vendor_flag_enabled
   | _ -> (
       (* The name and the value stay apart: read as one text, a name carrying a
@@ -159,9 +159,9 @@ let declaration_feature prop value =
          reading would hand back a different one: [rgba(0,0,0,.5)] and
          [#ff0000ff] name grammars a browser can accept one of and refuse the
          other. *)
-      let name = property_name prop in
+      let name = property_name ?repr prop in
       match Declaration.parse_opaque_declaration prop value with
-      | Some decl -> Declaration decl
+      | Some decl -> Declaration (name, decl)
       | None -> Unsupported (name, String.trim value))
 
 (* [property] takes authored CSS text and writes it between the feature's own
@@ -235,16 +235,28 @@ let func name args =
 
 (* ===== Pretty printing ===== *)
 
-let escaped_property_name name =
-  Parser.escape_ident (string_of_property_name name)
+(* CSS Conditional 3 (ED) sec. 7.4 has [conditionText] return "the condition
+   that was specified", allowing "token stream simplifications" and forbidding
+   logical ones. An escape decodes to the same [<ident-token>] in every
+   conformant implementation, so re-spelling one is a simplification the section
+   permits rather than requires: pretty output writes back the bytes the author
+   wrote, and minified output takes the shortest spelling the section allows. *)
+let escaped_property_name ~verbatim ctx (Property_name { name; repr }) =
+  match repr with
+  | Some repr when verbatim && not (Pp.minified ctx) -> repr
+  | Some _ | None -> Parser.escape_ident name
 
-let pp_declaration_feature ctx = function
-  | Declaration decl -> Declaration.pp_opaque ctx decl
+let pp_declaration_feature ?(verbatim = true) ctx = function
+  | Declaration (name, decl) ->
+      Pp.string ctx (escaped_property_name ~verbatim ctx name);
+      Pp.char ctx ':';
+      Pp.space_if_pretty ctx ();
+      Declaration.pp_opaque_value ctx decl
   | Empty name ->
-      Pp.string ctx (escaped_property_name name);
+      Pp.string ctx (escaped_property_name ~verbatim ctx name);
       Pp.char ctx ':'
   | Unsupported (name, value) ->
-      Pp.string ctx (escaped_property_name name);
+      Pp.string ctx (escaped_property_name ~verbatim ctx name);
       Pp.char ctx ':';
       Pp.space_if_pretty ctx ();
       Pp.string ctx value
@@ -269,69 +281,73 @@ let pp_function_feature ctx = function
   | Env name -> Pp.call "env" Pp.string ctx name
   | General (name, args) -> Pp.call name Pp.string ctx args
 
-let rec pp_aux ~in_and ctx = function
+let rec pp_aux ~verbatim ~in_and ctx = function
   | Property feature ->
       Pp.char ctx '(';
-      pp_declaration_feature ctx feature;
+      pp_declaration_feature ~verbatim ctx feature;
       Pp.char ctx ')'
   | Function feature -> pp_function_feature ctx feature
   | General_enclosed text -> Pp.string ctx text
-  | Not cond -> pp_not ~in_and ctx cond
-  | And (a, b) -> pp_and ctx a b
-  | Or (a, b) -> pp_or ctx a b
+  | Not cond -> pp_not ~verbatim ~in_and ctx cond
+  | And (a, b) -> pp_and ~verbatim ctx a b
+  | Or (a, b) -> pp_or ~verbatim ctx a b
 
-and pp_not ~in_and ctx cond =
+and pp_not ~verbatim ~in_and ctx cond =
   if in_and then Pp.char ctx '(';
   Pp.string ctx "not ";
   (match cond with
   | And _ | Or _ ->
       Pp.char ctx '(';
-      pp_aux ~in_and ctx cond;
+      pp_aux ~verbatim ~in_and ctx cond;
       Pp.char ctx ')'
-  | _ -> pp_aux ~in_and ctx cond);
+  | _ -> pp_aux ~verbatim ~in_and ctx cond);
   if in_and then Pp.char ctx ')'
 
-and pp_and_branch ctx = function
+and pp_and_branch ~verbatim ctx = function
   | Or _ as branch ->
       Pp.char ctx '(';
-      pp_aux ~in_and:true ctx branch;
+      pp_aux ~verbatim ~in_and:true ctx branch;
       Pp.char ctx ')'
-  | branch -> pp_aux ~in_and:true ctx branch
+  | branch -> pp_aux ~verbatim ~in_and:true ctx branch
 
-and pp_and ctx a b =
-  pp_and_branch ctx a;
+and pp_and ~verbatim ctx a b =
+  pp_and_branch ~verbatim ctx a;
   (* CSS Conditional 3 sec. 6: a [)and ] sequence is unambiguous so the leading
      space is droppable under minify; the trailing space is required to keep
      [and(] from re-tokenising as a function call. *)
   Pp.sp ctx ();
   Pp.string ctx "and ";
-  pp_and_branch ctx b
+  pp_and_branch ~verbatim ctx b
 
-and pp_or_branch ~is_left ctx = function
+and pp_or_branch ~verbatim ~is_left ctx = function
   | And (a, b) ->
       Pp.char ctx '(';
-      pp_or_and_left ~is_left ctx a;
+      pp_or_and_left ~verbatim ~is_left ctx a;
       Pp.string ctx " and ";
-      pp_aux ~in_and:true ctx b;
+      pp_aux ~verbatim ~in_and:true ctx b;
       Pp.char ctx ')'
-  | Not _ as branch -> pp_aux ~in_and:true ctx branch
-  | branch -> pp_aux ~in_and:false ctx branch
+  | Not _ as branch -> pp_aux ~verbatim ~in_and:true ctx branch
+  | branch -> pp_aux ~verbatim ~in_and:false ctx branch
 
-and pp_or_and_left ~is_left ctx = function
+and pp_or_and_left ~verbatim ~is_left ctx = function
   | Property _ as branch when Pp.minified ctx && is_left ->
       Pp.char ctx '(';
-      pp_aux ~in_and:true ctx branch;
+      pp_aux ~verbatim ~in_and:true ctx branch;
       Pp.char ctx ')'
-  | branch -> pp_aux ~in_and:true ctx branch
+  | branch -> pp_aux ~verbatim ~in_and:true ctx branch
 
-and pp_or ctx a b =
-  pp_or_branch ~is_left:true ctx a;
+and pp_or ~verbatim ctx a b =
+  pp_or_branch ~verbatim ~is_left:true ctx a;
   Pp.sp ctx ();
   Pp.string ctx "or ";
-  pp_or_branch ~is_left:false ctx b
+  pp_or_branch ~verbatim ~is_left:false ctx b
 
-let pp ctx t = pp_aux ~in_and:false ctx t
-let to_string t = Pp.to_string ~minify:false pp t
+(* [verbatim] writes back the spelling the author used; the default serialises a
+   stylesheet, so it does. {!to_string} turns it off because its callers use the
+   result as an identity for a condition rather than as output, and two
+   spellings of one condition must key together there. *)
+let pp ?(verbatim = true) ctx t = pp_aux ~verbatim ~in_and:false ctx t
+let to_string ?(minify = false) t = Pp.to_string ~minify (pp ~verbatim:false) t
 
 (* ===== Component parser ===== *)
 
@@ -349,7 +365,8 @@ let contains_top_level_semicolon =
     | _ -> false)
 
 let property_ident = function
-  | [ Component.Preserved { kind = Token.Ident name; _ } ] -> Some name
+  | [ Component.Preserved { kind = Token.Ident name; repr; _ } ] ->
+      Some (name, repr)
   | _ -> None
 
 (* Anchoring a failure on the components that failed puts the caret on that
@@ -363,11 +380,11 @@ let declaration_of_components t prop value =
   if contains_top_level_semicolon value then
     err t value "Invalid declaration in @supports";
   match property_ident (strip_components prop) with
-  | Some name -> (
+  | Some (name, repr) -> (
       let text = Cursor.string_of_components_verbatim ~trim:true value in
       (* [declaration_feature] is the shared constructor, so it reports through
          [Failure]; re-raise it against the declaration's own components. *)
-      match declaration_feature name text with
+      match declaration_feature ?repr name text with
       | feature -> Property feature
       | exception Failure msg -> err t (prop @ value) msg)
   | None -> err t prop "Invalid declaration in @supports"
@@ -510,7 +527,7 @@ let compare_declaration_feature d1 d2 =
   | Empty n1, Empty n2 ->
       String.compare (string_of_property_name n1) (string_of_property_name n2)
   | Vendor_flag_enabled, Vendor_flag_enabled -> 0
-  | Declaration d1, Declaration d2 -> compare_declaration d1 d2
+  | Declaration (_, d1), Declaration (_, d2) -> compare_declaration d1 d2
   | Unsupported (n1, v1), Unsupported (n2, v2) ->
       let c =
         String.compare (string_of_property_name n1) (string_of_property_name n2)

--- a/lib/supports.mli
+++ b/lib/supports.mli
@@ -5,13 +5,20 @@
 
 type property_name
 
+val property_name : ?repr:string -> string -> property_name
+(** [property_name ?repr name] is the name of a declaration feature. [repr] is
+    the spelling the author wrote when it differs from [name], which is how an
+    escape survives the round trip; a name cascade generates has none. *)
+
 type declaration_feature =
-  | Declaration of Declaration.t
-      (** The declaration the feature tests. Its value is the component stream
-          the author wrote, read through
+  | Declaration of property_name * Declaration.t
+      (** The declaration the feature tests, with the name as the author spelled
+          it. Its value is the component stream the author wrote, read through
           {!Declaration.parse_opaque_declaration}: a browser answers the feature
-          by parsing that exact declaration, so the property's typed grammar
-          never re-spells it. *)
+          by parsing that exact declaration, so neither half is re-spelled. The
+          name is carried beside the declaration because a typed property is a
+          constructor, which cannot hold the escape [colo\r] was written with.
+      *)
   | Empty of property_name
   | Unsupported of property_name * string
   | Vendor_flag_enabled
@@ -80,13 +87,22 @@ val func : string -> string -> t
 (** [func name args] parses [args] as CSS component values for a supports
     function feature. *)
 
-val to_string : t -> string
-(** [to_string cond] renders the condition as a CSS [\@supports] string. *)
+val to_string : ?minify:bool -> t -> string
+(** [to_string ?minify cond] renders the condition as a CSS [\@supports] string,
+    for use as its identity: it does not keep an authored spelling, so two
+    spellings of one condition render alike. See {!pp}. *)
 
-val pp : t Pp.t
-(** [pp ctx cond] prints the condition with context-aware spacing. *)
+val pp : ?verbatim:bool -> Pp.ctx -> t -> unit
+(** [pp ?verbatim ctx cond] serialises a condition. [verbatim] (default [true])
+    writes back the spelling the author used for a property name, which CSS
+    Conditional 3 (ED) sec. 7.4 asks for by returning "the condition that was
+    specified": the simplifications it allows are permitted rather than
+    required, so only minified output takes them. Pass [false] where the result
+    is an identity for a condition rather than output, so two spellings of one
+    condition agree. *)
 
-val pp_declaration_feature : declaration_feature Pp.t
+val pp_declaration_feature :
+  ?verbatim:bool -> Pp.ctx -> declaration_feature -> unit
 (** [pp_declaration_feature ctx feature] prints a supports declaration feature
     without the surrounding condition parentheses. *)
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -7249,6 +7249,19 @@ let s4370_supports_property_name_escapes () =
         "@supports(--x\\;y:red)and (color:red){.a{color:red}}" );
       ( "@supports not (--x\\3b y:red){.a{color:red}}",
         "@supports not (--x\\;y:red){.a{color:red}}" );
+      (* A typed property spelled with an escape keeps that spelling too. The
+         browser answers the feature by running the authored declaration through
+         its own parser and echoes those bytes back in [conditionText], so
+         respelling [colo\\r] as [color] makes a different question of the same
+         condition. *)
+      ( "@supports (colo\\r:green){.a{color:red}}",
+        "@supports(colo\\r:green){.a{color:red}}" );
+      ( "@supports (colo\\r:){.a{color:red}}",
+        "@supports(colo\\r:){.a{color:red}}" );
+      ( "@supports (colo\\r:gre\\65 n){.a{color:red}}",
+        "@supports(colo\\r:gre\\65 n){.a{color:red}}" );
+      ( "@supports (unknown\\-prop:x){.a{color:red}}",
+        "@supports(unknown\\-prop:x){.a{color:red}}" );
       (* A name needing no escape keeps its spelling. *)
       ( "@supports (--xy:red){.a{color:red}}",
         "@supports(--xy:red){.a{color:red}}" );

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -7249,24 +7249,38 @@ let s4370_supports_property_name_escapes () =
         "@supports(--x\\;y:red)and (color:red){.a{color:red}}" );
       ( "@supports not (--x\\3b y:red){.a{color:red}}",
         "@supports not (--x\\;y:red){.a{color:red}}" );
-      (* A typed property spelled with an escape keeps that spelling too. The
-         browser answers the feature by running the authored declaration through
-         its own parser and echoes those bytes back in [conditionText], so
-         respelling [colo\\r] as [color] makes a different question of the same
-         condition. *)
+      (* Sec. 7.4 allows a token stream simplification and forbids a logical
+         one. An escape decodes to the same [<ident-token>] in every conformant
+         implementation, so minified output may take the shortest spelling of a
+         name however the author wrote it, and the name of a typed property
+         answers to that as a custom property's does. What the author wrote
+         survives unminified; see the pretty check below. *)
       ( "@supports (colo\\r:green){.a{color:red}}",
-        "@supports(colo\\r:green){.a{color:red}}" );
-      ( "@supports (colo\\r:){.a{color:red}}",
-        "@supports(colo\\r:){.a{color:red}}" );
-      ( "@supports (colo\\r:gre\\65 n){.a{color:red}}",
-        "@supports(colo\\r:gre\\65 n){.a{color:red}}" );
+        "@supports(color:green){.a{color:red}}" );
+      ("@supports (colo\\r:){.a{color:red}}", "@supports(color:){.a{color:red}}");
       ( "@supports (unknown\\-prop:x){.a{color:red}}",
-        "@supports(unknown\\-prop:x){.a{color:red}}" );
+        "@supports(unknown-prop:x){.a{color:red}}" );
       (* A name needing no escape keeps its spelling. *)
       ( "@supports (--xy:red){.a{color:red}}",
         "@supports(--xy:red){.a{color:red}}" );
       ( "@supports (color:red){.a{color:red}}",
         "@supports(color:red){.a{color:red}}" );
+    ]
+
+(* Sec. 7.4 has [conditionText] return "the condition that was specified", and
+   the token stream simplifications it allows are permitted rather than
+   required, so unminified output writes back the bytes the author wrote.
+   Measured on Chrome 153: conditionText echoes those same bytes, normalising
+   neither [colo\r] to [color] nor [--x\3b y] to [--x\;y]. *)
+let s4370_supports_property_name_pretty_verbatim () =
+  List.iter
+    (fun (css, fragment) -> pretty_preserves css [ fragment ])
+    [
+      ("@supports (colo\\r:green){.a{color:red}}", "colo\\r");
+      ("@supports (colo\\r:){.a{color:red}}", "colo\\r");
+      ("@supports (--x\\3b y:red){.a{color:red}}", "--x\\3b y");
+      ("@supports (unknown\\-prop:x){.a{color:red}}", "unknown\\-prop");
+      ("@supports not (colo\\r:green){.a{color:red}}", "colo\\r");
     ]
 
 let fidelity_string_escape_preserved () =
@@ -9702,6 +9716,9 @@ let additional_tests =
     ( "spec conditional 3 2.2 supports property name escapes",
       `Quick,
       s4370_supports_property_name_escapes );
+    ( "spec conditional 3 7.4 supports property name pretty verbatim",
+      `Quick,
+      s4370_supports_property_name_pretty_verbatim );
     ("spec cascade 5 6.4.1 layer name parts", `Quick, s641_layer_name_parts);
     ( "fidelity string escape preserved",
       `Quick,


### PR DESCRIPTION
`@supports (colo\\r: green)` read back as `(color: green)`, because the typed property behind the name is a constructor and the escape it was written with had nowhere to live. CSS Conditional 3 sec. 7.4 has `conditionText` return "the condition that was specified" and allows only token stream simplifications; those are permitted rather than required, so the name survives unminified and minified output still takes the shortest spelling. Chrome echoes the authored bytes for every spelling measured.

`Supports.to_string` now renders a condition for use as its identity rather than as output, which is what its callers in the diff need: two spellings of one condition have to key together there.