### PR TITLE
grid: record why the masonry track value stays

### DIFF
--- a/lib/css.mli
+++ b/lib/css.mli
@@ -4105,6 +4105,9 @@ type grid_template = Properties.grid_template =
   | Template of string
   | Subgrid
   | Masonry
+      (** CSS Grid 3 (ED) removed this value, and it stays because Firefox ships
+          it behind a pref: refusing it would drop a declaration a shipping
+          browser renders. *)
   | Var of grid_template var
 
 (** CSS grid-template-areas values *)

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -841,6 +841,15 @@ type grid_template =
   | Template of string
   | Subgrid
   | Masonry
+      (** CSS Grid 3 (ED) REMOVED this value, replacing the masonry track
+          vocabulary with a single [flow-tolerance] property, and web-features
+          records no compat key for it, so no target set can arbitrate it
+          either. It stays because Firefox ships it behind a pref: refusing it
+          would drop a declaration a shipping browser renders, which is the
+          destructive direction. The four [masonry-*] and [item-flow] properties
+          of the same draft are not modelled here at all, and survive on the
+          generic unknown-property path that keeps any property cascade does not
+          know. *)
   | Var of grid_template var
 
 type grid_template_areas =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4591,6 +4591,15 @@ let spec_platform_property_vectors () =
       ("accent-color: auto", "accent-color:auto");
       ("mask-mode: alpha", "mask-mode:alpha");
       ("mask-composite: add", "mask-composite:add");
+      (* CSS Grid 3 (ED) removed the masonry track vocabulary, and Firefox ships
+         this value behind a pref, so cascade keeps reading it rather than
+         dropping author CSS a browser renders. The other properties of that
+         draft are not modelled, and ride the unknown-property path any unknown
+         name rides. *)
+      ("grid-template-rows: masonry", "grid-template-rows:masonry");
+      ("grid-template-columns: masonry", "grid-template-columns:masonry");
+      ("masonry-direction: row", "masonry-direction:row");
+      ("item-flow: row", "item-flow:row");
       (* Sec. 6.1 lists the slots source, slice, width, outset then repeat, so
          the canonical serialisation reorders what the author interleaved. *)
       ("border-image: 50% none", "border-image:none 50%");


### PR DESCRIPTION
`grid-template-rows: masonry` is a value CSS Grid 3 removed, so whether cascade should still read it has been an open question. It stays: web-features records no compat key for it, so no target set can arbitrate it, and Firefox ships it behind a pref, which makes refusing it the destructive choice.

Four properties of the same draft (`item-flow`, `masonry-direction`, `masonry-slack`, `masonry-fill`) looked like part of the same question and are not: cascade does not model them, and they survive on the generic unknown-property path that keeps `not-a-real-property` too. Tests pin both halves so the distinction is not rediscovered.