### PR TITLE
diff: key a supports block on its condition, not its spelling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,13 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- Two spellings of one `@supports` condition are one block to the diff, so a
+  sheet writing `(color: color-mix(in lab, red, red))` and one writing it
+  without the spaces compare inside the block rather than across two. CSS
+  Conditional 3 sec. 7.4 calls that the same condition. `Cascade.Supports.pp`
+  and `to_string` gain `?verbatim`, which tells a serialiser from an identity
+  (#1095)
+
 - An `@supports` condition keeps the property name the author spelled, so
   `@supports (colo\r: green)` reads back as written instead of as
   `(color: green)`. CSS Conditional 3 sec. 7.4 returns "the condition that was

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -2885,12 +2885,13 @@ let rec pp : declaration Pp.t =
 (* The value half of {!pp_opaque}, for a caller writing the property name
    itself: an [\@supports] feature keeps the name the author spelled, which the
    typed property behind it cannot reproduce. *)
-let rec pp_opaque_value : declaration Pp.t =
+let rec pp_opaque_value ?(verbatim = true) : declaration Pp.t =
  fun ctx decl ->
   let pp_components components important =
     Pp.string ctx
-      (if Pp.minified ctx then Parser.to_string_minified components
-       else Parser.to_string_verbatim components);
+      (if verbatim && not (Pp.minified ctx) then
+         Parser.to_string_verbatim components
+       else Parser.to_string_minified components);
     if important then
       Pp.string ctx (if ctx.minify then "!important" else " !important")
   in
@@ -2909,7 +2910,7 @@ let rec pp_opaque_value : declaration Pp.t =
       pp_property_value ctx (property, value);
       if important then
         Pp.string ctx (if ctx.minify then "!important" else " !important")
-  | Theme_guarded { decl; _ } -> pp_opaque_value ctx decl
+  | Theme_guarded { decl; _ } -> pp_opaque_value ~verbatim ctx decl
 
 let rec pp_opaque : declaration Pp.t =
  fun ctx decl ->

--- a/lib/declaration.mli
+++ b/lib/declaration.mli
@@ -28,11 +28,13 @@ val pp_property : 'a Properties.property Pp.t
 val pp : t Pp.t
 (** [pp] is the pretty-printer for declarations. *)
 
-val pp_opaque_value : t Pp.t
-(** [pp_opaque_value] is the value half of {!pp_opaque}, for a caller writing
-    the property name itself. An [\@supports] feature does, because it keeps the
-    name the author spelled and the typed property behind it cannot reproduce
-    that. *)
+val pp_opaque_value : ?verbatim:bool -> t Pp.t
+(** [pp_opaque_value ?verbatim] is the value half of {!pp_opaque}, for a caller
+    writing the property name itself. An [\@supports] feature does, because it
+    keeps the name the author spelled and the typed property behind it cannot
+    reproduce that. [verbatim] (default [true]) writes the value as the author
+    spelled it; [false] takes the canonical spelling in either mode, for a
+    caller building an identity rather than output. *)
 
 val pp_opaque : t Pp.t
 (** [pp_opaque] minifies separators but preserves authored numeric token

--- a/lib/diff/css_compare.ml
+++ b/lib/diff/css_compare.ml
@@ -36,7 +36,11 @@ type stats = {
 let supports_path_and_inner stmt =
   match Css.as_supports stmt with
   | Some (cond, inner) ->
-      Some ("@supports " ^ Css.Supports.to_string cond, inner)
+      (* The key folds two spellings of one condition: CSS Conditional 3 (ED)
+         sec. 7.4 allows a token stream simplification, so [(colo\r:x)] and
+         [(color:x)] ask the same question and only the printer keeps them
+         apart. *)
+      Some ("@supports " ^ Css.Supports.to_string ~verbatim:false cond, inner)
   | None -> None
 
 let media_path_and_inner stmt =

--- a/lib/diff/tree_diff.ml
+++ b/lib/diff/tree_diff.ml
@@ -2879,7 +2879,13 @@ let extract_media_as_string stmt =
 
 let extract_supports_as_string stmt =
   match Css.as_supports stmt with
-  | Some (cond, rules) -> Some (Css.Supports.to_string cond, rules)
+  | Some (cond, rules) ->
+      (* Two spellings of one condition are one block: CSS Conditional 3 (ED)
+         sec. 7.4 calls a token stream simplification the same condition, so a
+         sheet writing [(color:color-mix(in lab, red, red))] and one writing it
+         without the spaces must compare inside the block rather than across
+         two. *)
+      Some (Css.Supports.to_string ~verbatim:false cond, rules)
   | None -> None
 
 (* The name [layer_diff] keys a layer on: the CSS text of the name, so a [.] one

--- a/lib/supports.ml
+++ b/lib/supports.ml
@@ -251,7 +251,7 @@ let pp_declaration_feature ?(verbatim = true) ctx = function
       Pp.string ctx (escaped_property_name ~verbatim ctx name);
       Pp.char ctx ':';
       Pp.space_if_pretty ctx ();
-      Declaration.pp_opaque_value ctx decl
+      Declaration.pp_opaque_value ~verbatim ctx decl
   | Empty name ->
       Pp.string ctx (escaped_property_name ~verbatim ctx name);
       Pp.char ctx ':'
@@ -347,7 +347,9 @@ and pp_or ~verbatim ctx a b =
    result as an identity for a condition rather than as output, and two
    spellings of one condition must key together there. *)
 let pp ?(verbatim = true) ctx t = pp_aux ~verbatim ~in_and:false ctx t
-let to_string ?(minify = false) t = Pp.to_string ~minify (pp ~verbatim:false) t
+
+let to_string ?(minify = false) ?(verbatim = true) t =
+  Pp.to_string ~minify (pp ~verbatim) t
 
 (* ===== Component parser ===== *)
 

--- a/lib/supports.mli
+++ b/lib/supports.mli
@@ -87,10 +87,12 @@ val func : string -> string -> t
 (** [func name args] parses [args] as CSS component values for a supports
     function feature. *)
 
-val to_string : ?minify:bool -> t -> string
-(** [to_string ?minify cond] renders the condition as a CSS [\@supports] string,
-    for use as its identity: it does not keep an authored spelling, so two
-    spellings of one condition render alike. See {!pp}. *)
+val to_string : ?minify:bool -> ?verbatim:bool -> t -> string
+(** [to_string ?minify ?verbatim cond] renders the condition as a CSS
+    [\@supports] string. [verbatim] (default [true]) keeps the spelling the
+    author used, as {!pp} does. Pass [false] for an identity: two spellings of
+    one condition then render alike, which is what a comparator keying a block
+    by its condition needs. *)
 
 val pp : ?verbatim:bool -> Pp.ctx -> t -> unit
 (** [pp ?verbatim ctx cond] serialises a condition. [verbatim] (default [true])

--- a/test/cli/diff_same_selector.t
+++ b/test/cli/diff_same_selector.t
@@ -17,6 +17,14 @@ split over three rules with another selector's rules between them. Both
 groups keep every declaration they write, so each reports as one move
 rather than as a loss and a gain.
 
+The two sides spell the feature query differently, with and without the
+spaces after the commas. CSS Conditional 3 (ED) sec. 7.4 calls that the same
+condition, allowing "reducing whitespace to a single space or omitting it in
+cases where it is known to be optional", so the comparator keys the block on
+the condition rather than on its spelling and compares INSIDE it. The move
+therefore shows twice: once for the two bare rules at the layer level, and
+once for the rule the feature query holds.
+
   $ cat > ref.css <<'EOF'
   > @layer utilities{.drop-shadow-sm{--tw-drop-shadow-size:drop-shadow(0 1px 2px var(--tw-drop-shadow-color,#00000026));--tw-drop-shadow:drop-shadow(var(--drop-shadow-sm));filter:var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,)}.drop-shadow-blue-500\/50{--tw-drop-shadow-color:#3080ff80}@supports (color:color-mix(in lab, red, red)){.drop-shadow-blue-500\/50{--tw-drop-shadow-color:color-mix(in oklab, color-mix(in oklab, var(--color-blue-500) 50%, transparent) var(--tw-drop-shadow-alpha), transparent)}}.drop-shadow-blue-500\/50{--tw-drop-shadow:var(--tw-drop-shadow-size)}.drop-shadow-indigo-500{--tw-drop-shadow-color:oklch(58.5% .233 277.117)}@supports (color:color-mix(in lab, red, red)){.drop-shadow-indigo-500{--tw-drop-shadow-color:color-mix(in oklab, var(--color-indigo-500) var(--tw-drop-shadow-alpha), transparent)}}.drop-shadow-indigo-500{--tw-drop-shadow:var(--tw-drop-shadow-size)}}
   > EOF
@@ -30,7 +38,9 @@ rather than as a loss and a gain.
   --- ref.css
   +++ tw.css
   └─ @layer utilities (1 reordered)
-     └─ .drop-shadow-blue-500\/50 (moved)
+     ├─ .drop-shadow-blue-500\/50 (moved)
+     └─ @supports (color: color-mix(in lab,red,red)) (1 reordered)
+        └─ .drop-shadow-blue-500\/50 (moved)
   
   [1]
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -7260,6 +7260,12 @@ let s4370_supports_property_name_escapes () =
       ("@supports (colo\\r:){.a{color:red}}", "@supports(color:){.a{color:red}}");
       ( "@supports (unknown\\-prop:x){.a{color:red}}",
         "@supports(unknown-prop:x){.a{color:red}}" );
+      (* Both halves take their canonical spelling under minify, and each is
+         independent of the other. *)
+      ( "@supports (colo\\r:gre\\en){.a{color:red}}",
+        "@supports(color:gre\\E n){.a{color:red}}" );
+      ( "@supports (color:gre\\en){.a{color:red}}",
+        "@supports(color:gre\\E n){.a{color:red}}" );
       (* A name needing no escape keeps its spelling. *)
       ( "@supports (--xy:red){.a{color:red}}",
         "@supports(--xy:red){.a{color:red}}" );
@@ -7281,6 +7287,9 @@ let s4370_supports_property_name_pretty_verbatim () =
       ("@supports (--x\\3b y:red){.a{color:red}}", "--x\\3b y");
       ("@supports (unknown\\-prop:x){.a{color:red}}", "unknown\\-prop");
       ("@supports not (colo\\r:green){.a{color:red}}", "colo\\r");
+      (* The value half keeps the author's spelling on the same terms. *)
+      ("@supports (color:gre\\en){.a{color:red}}", "gre\\en");
+      ("@supports (colo\\r:gre\\en){.a{color:red}}", "gre\\en");
     ]
 
 let fidelity_string_escape_preserved () =


### PR DESCRIPTION
`@supports (color: gre\\en){...}` did not read back as what it wrote: the comparator keys a block by its condition TEXT, so the authored spelling and the canonical one were two blocks. CSS Conditional 3 sec. 7.4 calls them the same condition, allowing "reducing whitespace to a single space or omitting it in cases where it is known to be optional".

The cause is that `Supports.to_string` was serving as both a serialiser and an identity; `?verbatim` now tells them apart, and the diff asks for the identity.

**This changes one report.** `test/cli/diff_same_selector.t` has two sides that spell one feature query differently, so its block now matches across them and the move inside it is reported as well as the two at the layer level. That is the point of the fix rather than a side effect, and the test's prose now says so.