### PR TITLE
box: refuse a sizing function in a margin longhand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,13 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- A margin longhand refuses a sizing function, so `margin-right:
+  fit-content(20rem)` and `margin-top: calc-size(auto, size)` are dropped with a
+  warning where every browser drops the declaration. CSS Box 4 sec. 3.1 gives
+  each longhand `<length-percentage> | auto`, and the `margin` shorthand already
+  read its components that way. This release adds
+  `Cascade.Values.read_margin_length` (#1096)
+
 - Two spellings of one `@supports` condition are one block to the diff, so a
   sheet writing `(color: color-mix(in lab, red, red))` and one writing it
   without the spaces compare inside the block rather than across two. CSS

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -868,6 +868,11 @@ let read_lp_or_global t =
     ~default:(Values.read_length_percentage ~with_keywords:false)
     t
 
+(* CSS Box 4 sec. 3.1 gives a margin longhand [<length-percentage> | auto], and
+   CSS Cascade 5 sec. 7.3 gives every property the CSS-wide keywords, which a
+   longhand takes as its whole value where a shorthand component cannot. *)
+let read_margin_length_or_global t = Values.read_margin_length ~global:true t
+
 let read_nn_length_or_global ?(length_only = false) t =
   Cursor.enum "non-negative length"
     [
@@ -1559,22 +1564,32 @@ let read_spacing_value : type a. a property -> Cursor.t -> declaration option =
   | Padding_block_start ->
       Some (v Padding_block_start (read_nn_length_or_global t))
   | Padding_block_end -> Some (v Padding_block_end (read_nn_length_or_global t))
-  | Margin_left -> Some (v Margin_left (read_length t))
-  | Margin_right -> Some (v Margin_right (read_length t))
-  | Margin_top -> Some (v Margin_top (read_length t))
-  | Margin_bottom -> Some (v Margin_bottom (read_length t))
+  (* CSS Box 4 sec. 3.1 gives every margin longhand [<length-percentage> |
+     auto], and CSS Logical 1 sec. 4.2 builds the flow-relative pair from that
+     same production, so a sizing function reaches none of them. The shorthand
+     already read its components this way. *)
+  | Margin_left -> Some (v Margin_left (read_margin_length_or_global t))
+  | Margin_right -> Some (v Margin_right (read_margin_length_or_global t))
+  | Margin_top -> Some (v Margin_top (read_margin_length_or_global t))
+  | Margin_bottom -> Some (v Margin_bottom (read_margin_length_or_global t))
   | Margin_inline ->
       Some
         (v Margin_inline
-           (Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2 read_length t))
-  | Margin_inline_start -> Some (v Margin_inline_start (read_length t))
-  | Margin_inline_end -> Some (v Margin_inline_end (read_length t))
+           (Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2
+              read_margin_length_or_global t))
+  | Margin_inline_start ->
+      Some (v Margin_inline_start (read_margin_length_or_global t))
+  | Margin_inline_end ->
+      Some (v Margin_inline_end (read_margin_length_or_global t))
   | Margin_block ->
       Some
         (v Margin_block
-           (Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2 read_length t))
-  | Margin_block_start -> Some (v Margin_block_start (read_length t))
-  | Margin_block_end -> Some (v Margin_block_end (read_length t))
+           (Cursor.list ~sep:Cursor.ws ~at_least:1 ~at_most:2
+              read_margin_length_or_global t))
+  | Margin_block_start ->
+      Some (v Margin_block_start (read_margin_length_or_global t))
+  | Margin_block_end ->
+      Some (v Margin_block_end (read_margin_length_or_global t))
   | _ -> None
 
 let read_list_align_value : type a. a property -> Cursor.t -> declaration option

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -8118,21 +8118,37 @@ let read_padding_shorthand t : length list =
         t)
     t
 
+(* CSS Box 4 sec. 3.1 gives a margin [<length-percentage> | auto], so no sizing
+   function reaches it. [global] adds the CSS-wide keywords of CSS Cascade 5
+   sec. 7.3, which a longhand takes as its whole value and a shorthand component
+   cannot; a [var()] fallback stands for a whole value, so it takes them too. *)
+
 (** Read margin shorthand property (1-4 values). CSS Box 4 (ED) sec. 3.2 gives
     [margin] the value [<'margin-top'>{1,4}] and sec. 3.1 gives [margin-top] the
     value [<length-percentage> | auto], so [auto] is a component of the box and
     stands in any slot beside any length. Only the CSS-wide keywords of CSS
     Cascade 5 sec. 6 own the whole value. *)
+let rec read_margin_length ?(global = false) t : length =
+  if Cursor.looking_at_func "var" t then
+    Var (read_var (read_margin_length ~global:true) t)
+  else
+    Cursor.enum "margin component"
+      (("auto", (Auto : length))
+      ::
+      (if global then
+         [
+           ("inherit", (Inherit : length));
+           ("initial", Initial);
+           ("unset", Unset);
+           ("revert", Revert);
+           ("revert-layer", Revert_layer);
+         ]
+       else []))
+      ~default:(read_length ~with_keywords:false)
+      t
+
 let read_margin_shorthand t : length list =
-  let rec read_margin_component t : length =
-    if Cursor.looking_at_func "var" t then
-      Var (read_var read_margin_component t)
-    else
-      Cursor.enum "margin component"
-        [ ("auto", (Auto : length)) ]
-        ~default:(read_length ~with_keywords:false)
-        t
-  in
+  let read_margin_component = read_margin_length in
   Cursor.enum "margin"
     [
       ("inherit", [ (Inherit : length) ]);

--- a/lib/values.mli
+++ b/lib/values.mli
@@ -493,6 +493,13 @@ val read_non_negative_length :
     non-negative. Used for padding properties, whose CSS Box 4 sec. 4.1 grammar
     excludes negative values. *)
 
+val read_margin_length : ?global:bool -> Cursor.t -> length
+(** [read_margin_length ?global t] parses one margin component: CSS Box 4 sec.
+    3.1 gives a margin longhand [<length-percentage> | auto], so this takes
+    [auto] and a length and no sizing function. [global] (default [false]) also
+    takes the CSS-wide keywords, which a longhand may be but a shorthand
+    component may not. *)
+
 val read_padding_shorthand : Cursor.t -> length list
 (** [read_padding_shorthand reader] parses a padding shorthand property
     accepting 1-4 space-separated non-negative length values (CSS Box 4 sec.

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4744,6 +4744,15 @@ let spec_platform_property_vectors () =
       "margin-trim: block inline block";
       "field-sizing: auto";
       "mask-composite: plus";
+      (* CSS Box 4 sec. 3.1 gives every margin longhand [<length-percentage> |
+         auto], so a sizing function reaches none of them; the shorthand already
+         refused one. CSS Logical 1 sec. 4.2 spells the flow-relative pair from
+         the same production. *)
+      "margin-right: fit-content(20rem)";
+      "margin-left: fit-content(20rem)";
+      "margin-block-end: fit-content(20rem)";
+      "margin-inline: fit-content(20rem)";
+      "margin-top: calc-size(auto, size)";
       "mask-origin: no-clip";
       "-webkit-mask-origin: fill-box";
       "-webkit-mask-origin: view-box";


### PR DESCRIPTION
`margin-right: fit-content(20rem)` and `margin-top: calc-size(auto, size)` parsed where every browser drops the declaration. CSS Box 4 sec. 3.1 gives each longhand `<length-percentage> | auto`, and the `margin` shorthand already read its components that way, so the two halves of one property disagreed. Both now share the component reader, which also keeps the CSS-wide keywords a longhand may be and a shorthand component may not.