### PR TITLE
position: refuse a sizing function in an inset property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,12 +76,13 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
-- A margin longhand refuses a sizing function, so `margin-right:
-  fit-content(20rem)` and `margin-top: calc-size(auto, size)` are dropped with a
-  warning where every browser drops the declaration. CSS Box 4 sec. 3.1 gives
-  each longhand `<length-percentage> | auto`, and the `margin` shorthand already
-  read its components that way. This release adds
-  `Cascade.Values.read_margin_length` (#1096)
+- A margin or inset property refuses a sizing function, so `margin-right:
+  fit-content(20rem)`, `bottom: fit-content(20rem)` and `top: calc-size(auto,
+  size)` are dropped with a warning where every browser drops the declaration.
+  CSS Box 4 sec. 3.1 and CSS Position 3 sec. 3.1 give both families
+  `<length-percentage> | auto`, and the `margin` shorthand already read its
+  components that way. This release adds `Cascade.Values.read_margin_length`
+  (#1096, #1097)
 
 - Two spellings of one `@supports` condition are one block to the diff, so a
   sheet writing `(color: color-mix(in lab, red, red))` and one writing it

--- a/lib/declaration.ml
+++ b/lib/declaration.ml
@@ -728,17 +728,19 @@ let validate_no_extra_tokens t =
         Cursor.err_invalid ~loc t
           ("unexpected tokens after property value: " ^ trimmed)
 
-let read_length_box ?(allow_negative = true) t =
-  let values =
-    Cursor.list ~at_least:1 ~at_most:4
-      (fun r -> read_length ~allow_negative r)
-      t
-  in
+(* CSS Position 3 sec. 3.1 gives every inset property [auto |
+   <length-percentage>] and sec. 3.2 builds [inset] from it, so no sizing
+   function reaches any of them. That is the same production CSS Box 4 sec. 3.1
+   gives a margin, so they share its component reader. *)
+let read_inset_length t = Values.read_margin_length ~global:true t
+
+let read_length_box t =
+  let values = Cursor.list ~at_least:1 ~at_most:4 read_inset_length t in
   if values = [] then Cursor.err_expected t "length value";
   values
 
-let read_inset_longhand t = [ read_length t ]
-let read_inset_axis t = Cursor.list ~at_least:1 ~at_most:2 read_length t
+let read_inset_longhand t = [ read_inset_length t ]
+let read_inset_axis t = Cursor.list ~at_least:1 ~at_most:2 read_inset_length t
 
 let read_border_width_box t =
   Cursor.list ~at_least:1 ~at_most:4 read_border_width t

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4749,6 +4749,14 @@ let spec_platform_property_vectors () =
          refused one. CSS Logical 1 sec. 4.2 spells the flow-relative pair from
          the same production. *)
       "margin-right: fit-content(20rem)";
+      (* CSS Position 3 sec. 3.1 gives every inset longhand the same [auto |
+         <length-percentage>], and sec. 3.2 builds the shorthand from it, so no
+         sizing function reaches those either. *)
+      "bottom: fit-content(20rem)";
+      "top: calc-size(auto, size)";
+      "inset: fit-content(20rem)";
+      "inset-inline-start: fit-content(20rem)";
+      "inset-block: fit-content(20rem)";
       "margin-left: fit-content(20rem)";
       "margin-block-end: fit-content(20rem)";
       "margin-inline: fit-content(20rem)";


### PR DESCRIPTION
The same leak #1096 closed for margin, in the family that spells the same production: CSS Position 3 sec. 3.1 gives every inset property `auto | <length-percentage>` and sec. 3.2 builds the shorthand from it, so `bottom: fit-content(20rem)` and `inset: fit-content(20rem)` parsed where every browser drops the declaration. Both families now share one component reader.