### PR TITLE
test: excuse a reserved word inside a longer family by shape

### DIFF
--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -392,6 +392,48 @@ let spec_ahead : excuse list =
 
 (* Negatives Chrome accepts. Each is a value no specification grants, kept
    invalid on purpose. *)
+(* An unquoted font family is a [<custom-ident>+], and CSS Fonts 4 sec. 2.1.1
+   excludes an identifier that "could be misinterpreted as a pre-defined
+   keyword ... or the CSS-wide keywords". Measured on Chrome 153: it applies
+   that only to a family of ONE identifier ([default] alone is refused), and
+   reads a reserved word inside a longer name ([default Arial], [x default],
+   [none default] all compute as one quoted family). No specification grants
+   that, so the reader is right and Chrome is lenient. *)
+let unquoted_family_reserved_word s =
+  let words = String.split_on_char ' ' (String.trim s) in
+  let reserved =
+    [
+      "inherit";
+      "initial";
+      "unset";
+      "revert";
+      "revert-layer";
+      "default";
+      "none";
+      "currentcolor";
+    ]
+  in
+  (* A generic family is a different exclusion and Chrome does apply that one,
+     refusing [system-ui default], so a name holding one is not this shape. *)
+  let generic =
+    [
+      "serif";
+      "sans-serif";
+      "monospace";
+      "cursive";
+      "fantasy";
+      "system-ui";
+      "math";
+      "ui-serif";
+      "ui-sans-serif";
+      "ui-monospace";
+      "ui-rounded";
+    ]
+  in
+  List.length words > 1
+  && List.exists (fun w -> List.exists (String.equal w) reserved) words
+  && not (List.exists (fun w -> List.exists (String.equal w) generic) words)
+
 let lenient : excuse list =
   [
     {
@@ -512,8 +554,21 @@ let unimplemented_text_overflow s =
   | [] | [ "clip" ] | [ "ellipsis" ] -> false
   | parts -> List.length parts <= 2 && List.for_all arm parts
 
+let lenient_family_shape =
+  {
+    shape_properties = [ "font-family"; "font" ];
+    shape_name = "a reserved word inside a longer unquoted family";
+    matches = unquoted_family_reserved_word;
+    shape_why =
+      "CSS Fonts 4 sec. 2.1.1 gives an unquoted family a <custom-ident>+ and \
+       excludes an identifier that could be misinterpreted as a pre-defined \
+       keyword or a CSS-wide keyword. Chrome applies that to a one-identifier \
+       family alone and reads a reserved word inside a longer name";
+  }
+
 let lenient_shapes =
   [
+    lenient_family_shape;
     {
       (* Measured on Chrome 153: [border: 1px, dashed, red] sets the same twelve
          longhands [border: 1px dashed red] does, so both sides of each comma

--- a/test/spec/browser/property_vectors.ml
+++ b/test/spec/browser/property_vectors.ml
@@ -146,12 +146,20 @@ type outcome =
 let hits = Hashtbl.create 64
 let excuse_key property value = String.concat "\000" [ property; value ]
 
-let excuse table property value =
+(* A shape answers for a class of values rather than one, so a manifest row
+   pinning a member of the class is excused by it the way a literal entry
+   excuses its own value. *)
+let excuse ?(shapes = []) table property value =
   match Chrome_gaps.find table ~property ~value with
-  | None -> None
   | Some e ->
       Hashtbl.replace hits (excuse_key property value) ();
       Some e.why
+  | None -> (
+      match Chrome_gaps.shape_covering shapes ~property ~value with
+      | Some s ->
+          Hashtbl.replace hits (excuse_key property value) ();
+          Some s.shape_why
+      | None -> None)
 
 let judge job verdict =
   match verdict.error with
@@ -164,11 +172,17 @@ let judge job verdict =
       | Positive when accepted -> Confirmed
       | Negative when not accepted -> Confirmed
       | Positive -> (
-          match excuse spec_ahead job.property job.value with
+          match
+            excuse ~shapes:Chrome_gaps.spec_ahead_shapes spec_ahead job.property
+              job.value
+          with
           | Some why -> Excused why
           | None -> Wrong "the browser rejects this positive")
       | Negative -> (
-          match excuse lenient job.property job.value with
+          match
+            excuse ~shapes:Chrome_gaps.lenient_shapes lenient job.property
+              job.value
+          with
           | Some why -> Excused why
           | None -> Wrong "the browser accepts this negative"))
 

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -273,6 +273,11 @@ let matrix =
           ",";
           "default";
           "system-ui default";
+          (* Chrome reads a reserved word inside a longer unquoted name, which
+             sec. 2.1.1 excludes; a generic family in one (system-ui above) it
+             refuses as the section says. Pinned here so the shape excusing the
+             first is checked against the fixed population. *)
+          "none default";
           "revert-layer, serif";
           "system-ui revert-layer, serif";
         ];


### PR DESCRIPTION
This takes the accept-set rejects-valid count to **0 on every seed 0-7**.

CSS Fonts 4 sec. 2.1.1 excludes an identifier that "could be misinterpreted as a pre-defined keyword ... or the CSS-wide keywords" from an unquoted family. Measured on Chrome 153: it applies that to a family of ONE identifier and reads a reserved word inside a longer name, so `font-family: none default` is a browser leniency the reader is right to refuse. The generic-family exclusion is different and Chrome does apply it, refusing `system-ui default`, so the shape excludes those.

Two supporting changes: the manifest pins one such value, so the shape is checked against the fixed population rather than against whichever values a seed happens to draw; and `property_vectors` now consults the shape tables as `accept_set` already did, since a shape is a shared fact.