### PR TITLE
context: keep a reference whose binding resolves to a value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,13 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- A `var()` whose custom property resolves through another one keeps its
+  reference rather than taking its fallback, so `--n: 5px; --x: var(--n);
+  color: var(--x, lime)` computes the inherited colour as every browser does
+  instead of `lime`. CSS Variables 1 sec. 3 puts the fallback in only where the
+  custom property is the guaranteed-invalid value, and a binding the property's
+  grammar refuses is not that: sec. 2.2 makes the declaration `unset` (#1100)
+
 - A margin or inset property refuses a sizing function, so `margin-right:
   fit-content(20rem)`, `bottom: fit-content(20rem)` and `top: calc-size(auto,
   size)` are dropped with a warning where every browser drops the declaration.

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -863,8 +863,22 @@ module Var_residual = struct
       a =
     with_resolver ?layer_order ?layer cascade ~read_custom:ops.read_custom
     @@ fun ~resolve_var ~simplify_var_record ~unreadable ->
+    (* The reference resolved to a value that is itself a [var()]. Whether the
+       fallback answers for that depends on why: CSS Variables 1 sec. 3 puts the
+       fallback in only where the custom property IS the guaranteed-invalid
+       value, so a chain ending in an UNBOUND name takes it, and one ending in a
+       binding whose value this property's grammar refuses does not. The second
+       is invalid at computed-value time, which sec. 2.2 makes [unset], and the
+       fallback is no answer to it. *)
+    let residual_holds_a_value result =
+      match ops.as_var result with
+      | Some (inner : a Values.var) -> unreadable inner.name
+      | None -> false
+    in
     let rec on_var_residual ~visited (var : a Values.var) result =
       match var.fallback with
+      | Values.Fallback _ when residual_holds_a_value result ->
+          ops.of_var (simplify_var_record ~simplify ~visited var)
       | Values.Fallback fb -> simplify ~authored:false ~visited fb
       | Values.Syntax_fallback _ | Values.Var_fallback _ ->
           ops.of_var (simplify_var_record ~simplify ~visited var)


### PR DESCRIPTION
`--n: 5px; --x: var(--n); color: var(--x, lime)` evaluated to `lime` where every browser computes the inherited colour. CSS Variables 1 sec. 3 puts the fallback in only where the custom property IS the guaranteed-invalid value; `--x` has a value, so `color: 5px` is invalid at computed-value time and sec. 2.2 makes that `unset`.

The direct case (`--x: 5px`) was already right, so the resolver was not at fault: `on_var_residual` took the fallback whenever the resolved value was still a `var()`, without asking whether the inner name was bound. It now asks.

This halves the `custom_property --full` symptom, from 6 jobs to 3. The remainder is a narrower shape (`--x: var(--nope, 7px)`, where the inner reference is unbound but carries its own fallback) that a wider condition does not fix: I tried one and the suite's cyclic-var contract caught it, so it needs the fallback-typing question answered separately.