### PR TITLE
align: check the gap range and the decoration thickness slot

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,13 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `gap: -10%` and `text-decoration: fit-content(20rem)` are dropped with a
+  warning where every browser drops the declaration. CSS Box Alignment 3 sec.
+  8.1 gives every gap a `[0,inf]` range, which the shorthand checked against a
+  list of unit constructors that omitted the percentage, and CSS Text
+  Decoration 4 sec. 2.3 spells the thickness slot `auto | from-font |
+  <length-percentage>`. Both longhands already refused these (#1101)
+
 - A `var()` whose custom property resolves through another one keeps its
   reference rather than taking its fallback, so `--n: 5px; --x: var(--n);
   color: var(--x, lime)` computes the inherited colour as every browser does

--- a/lib/prop_align.ml
+++ b/lib/prop_align.ml
@@ -712,31 +712,15 @@ let rec pp_align_content : align_content Pp.t =
 (* CSS Box Alignment 3 sec. 8.3: each half is a [<'row-gap'>], which is
    [normal | <length-percentage [0,inf]>]. The keyword is read here rather than
    taken from the length grammar, which does not carry it. *)
+(* CSS Box Alignment 3 sec. 8.1 spells every gap [normal | <length-percentage
+   [0,inf]>], so the range is the grammar's and not a list of units: reading it
+   through the length reader's own [allow_negative] keeps the percentage in the
+   check, which an enumerated list of unit constructors had left out. *)
 let read_gap_half t =
-  let len =
-    Cursor.enum "gap" [ ("normal", (Normal : length)) ] ~default:read_length t
-  in
-  match len with
-  | Px v
-  | Rem v
-  | Em v
-  | Ch v
-  | Ex v
-  | Vw v
-  | Vh v
-  | Vmin v
-  | Vmax v
-  | Pt v
-  | Pc v
-  | In v
-  | Cm v
-  | Mm v
-  | Q v
-    when v < 0.0 ->
-      Cursor.err t "gap values cannot be negative"
-  | Auto | Inherit | Initial | Unset | Revert | Revert_layer | Fit_content ->
-      Cursor.err t "gap values must be explicit lengths, not keywords"
-  | _ -> len
+  Cursor.enum "gap"
+    [ ("normal", (Normal : length)) ]
+    ~default:(read_length ~allow_negative:false ~with_keywords:false)
+    t
 
 let rec read_gap t : gap =
   Cursor.enum_or_whole_value_var "gap"

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -101,7 +101,16 @@ module Text_decoration = struct
         (fun t -> Line (read_text_decoration_line t));
         (fun t -> Style (read_text_decoration_style t));
         (fun t -> Color (read_color t));
-        (fun t -> Thickness (read_length t));
+        (* CSS Text Decoration 4 sec. 3 fills this slot with a
+           [<'text-decoration-thickness'>], which sec. 2.3 spells [auto |
+           from-font | <length-percentage>], so no sizing function belongs here.
+           The longhand already reads it that way. *)
+        (fun t ->
+          Thickness
+            (Cursor.enum "text-decoration-thickness"
+               [ ("auto", (Auto : length)); ("from-font", From_font) ]
+               ~default:(read_length ~with_keywords:false)
+               t));
       ]
       t
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4749,6 +4749,13 @@ let spec_platform_property_vectors () =
          refused one. CSS Logical 1 sec. 4.2 spells the flow-relative pair from
          the same production. *)
       "margin-right: fit-content(20rem)";
+      (* CSS Box Alignment 3 sec. 8.1 gives every gap a [0,inf] range, and the
+         row-gap and column-gap longhands already refused a negative one. CSS
+         Text Decoration 4 sec. 3 builds the shorthand from its own longhands,
+         so a sizing function reaches neither. *)
+      "gap: -10%";
+      "gap: 1px -10%";
+      "text-decoration: fit-content(20rem)";
       (* CSS Position 3 sec. 3.1 gives every inset longhand the same [auto |
          <length-percentage>], and sec. 3.2 builds the shorthand from it, so no
          sizing function reaches those either. *)


### PR DESCRIPTION
Two more places a shorthand disagreed with its own longhands. `gap: -10%` parsed because the shorthand checked its `[0,inf]` range against a hand-written list of unit constructors that omitted `Pct`; it now reads through the length reader's own range check, so the percentage is in it. `text-decoration: fit-content(20rem)` parsed because the shorthand read a bare length where CSS Text Decoration 4 sec. 2.3 spells the slot `auto | from-font | <length-percentage>`. Both longhands already refused both.