### PR TITLE
context: keep a reference whose fallback this property cannot type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,9 +86,10 @@ entry points both moved.
 - A `var()` whose custom property resolves through another one keeps its
   reference rather than taking its fallback, so `--n: 5px; --x: var(--n);
   color: var(--x, lime)` computes the inherited colour as every browser does
-  instead of `lime`. CSS Variables 1 sec. 3 puts the fallback in only where the
-  custom property is the guaranteed-invalid value, and a binding the property's
-  grammar refuses is not that: sec. 2.2 makes the declaration `unset` (#1100)
+  instead of `lime`, and so does `--x: var(--nope, 7px)`. CSS Variables 1 sec.
+  3 puts the fallback in only where the custom property is the
+  guaranteed-invalid value, and a binding the property's grammar refuses is not
+  that: sec. 2.2 makes the declaration `unset` (#1100, #1102)
 
 - A margin or inset property refuses a sizing function, so `margin-right:
   fit-content(20rem)`, `bottom: fit-content(20rem)` and `top: calc-size(auto,

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -872,7 +872,20 @@ module Var_residual = struct
        fallback is no answer to it. *)
     let residual_holds_a_value result =
       match ops.as_var result with
-      | Some (inner : a Values.var) -> unreadable inner.name
+      | Some (inner : a Values.var) -> (
+          (* Bound, and holding a value this property's grammar refuses. *)
+          unreadable inner.name
+          ||
+          match inner.fallback with
+          (* [Syntax_fallback] is a fallback the reader kept but could not type
+             in this property's position, so the chain resolves to a value the
+             property refuses. A typed [Fallback] is the opposite: it resolves
+             to a value the property takes, and the resolver hands that back
+             rather than a residual. *)
+          | Values.Syntax_fallback _ -> true
+          | Values.Fallback _ | Values.Empty | Values.Empty2 | Values.None
+          | Values.Var_fallback _ ->
+              false)
       | None -> false
     in
     let rec on_var_residual ~visited (var : a Values.var) result =


### PR DESCRIPTION
Completes #1100 and takes `custom_property --full` to clean: 3242 jobs, every transform computing what the browser computes.

`--x: var(--nope, 7px); color: var(--x, lime)` evaluated to `lime` where the browser computes the inherited colour. The inner reference is unbound but carries a fallback, so the chain still resolves to a value and the outer fallback must not apply.

The distinguishing fact had to be measured rather than reasoned about: reading `var(--nope, 7px)` in colour position leaves the inner fallback as `Syntax_fallback`, the arm for a fallback the reader kept but could not type in this property's position. A typed `Fallback` is the opposite case and the resolver hands back its value rather than a residual, which is why widening the condition to `Fallback` (tried first) broke the cyclic-var contract instead.