### PR TITLE
test: measure manifest coverage against the reader's own names

### DIFF
--- a/scripts/check_properties.ml
+++ b/scripts/check_properties.ml
@@ -166,6 +166,37 @@ let () =
   Fmt.pr "\u{2713} All %d properties are properly mapped in read_property@."
     (StringSet.cardinal all_set);
 
+  (* How much of the reader the grammar manifest covers. The manifest is the
+     population every browser oracle samples from, so a name with no row is a
+     property no oracle asks about, and counting rows cannot say that: a count
+     is what let one row stand in for three grammars.
+
+     Reported rather than fatal, because the gap is real and closing it is its
+     own work. The comparison is against the CSS names [read_property] matches
+     on, so a manifest row for a name it reaches by another route counts as
+     uncovered rather than as a stray row. *)
+  (* Read the EVALUATED rows rather than the source text: [rows_for] expands one
+     source entry into a row per property, so counting [property = "..."]
+     occurrences undercounts, which is the same mistake in miniature. *)
+  let manifest_set =
+    StringSet.of_list
+      (List.map
+         (fun (row : Cascade_spec_inventory.Property_grammar.row) ->
+           row.property)
+         Cascade_spec_inventory.Property_grammar.rows)
+  in
+  let css_names = StringSet.of_list (List.map fst name_table) in
+  let unrowed = StringSet.diff css_names manifest_set in
+  Fmt.pr "\u{2713} the grammar manifest has %d row(s), covering %d of the %d@."
+    (StringSet.cardinal manifest_set)
+    (StringSet.cardinal (StringSet.inter css_names manifest_set))
+    (StringSet.cardinal css_names);
+  if not (StringSet.is_empty unrowed) then
+    Fmt.pr "  %d readable propert(ies) have no row, first 10: %s@."
+      (StringSet.cardinal unrowed)
+      (String.concat ", "
+         (List.filteri (fun i _ -> i < 10) (StringSet.elements unrowed)));
+
   (* The tag table covers every constructor, [Custom_property] and
      [Unknown_property] included, so it is checked against the full list rather
      than the static one [read_any_property] answers for. *)

--- a/scripts/dune
+++ b/scripts/dune
@@ -1,7 +1,7 @@
 (executables
  (names check_properties check_api_consistency check_unknown_properties)
  (modules check_properties check_api_consistency check_unknown_properties)
- (libraries re unix cascade fmt))
+ (libraries re unix cascade cascade_spec_inventory fmt))
 
 (rule
  (alias runtest)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -5587,9 +5587,12 @@ let spec_property_grammar_manifest () =
   in
   if List.length unique_properties <> List.length property_grammar_matrix then
     Alcotest.fail "property grammar manifest has duplicate property rows";
-  Alcotest.(check int)
-    "property grammar manifest covers every tracked spec property name" 455
-    (List.length unique_properties);
+  (* No count here. How much of the reader this manifest covers is derived from
+     the reader's own name table by scripts/check_properties.ml, which reports
+     it every run; a literal here says only that the file did not shrink, and
+     counting rows is what let one row stand in for three grammars. *)
+  if unique_properties = [] then
+    Alcotest.fail "property grammar manifest is empty";
   let failures =
     List.filter_map
       (fun (row : property_grammar_row) ->


### PR DESCRIPTION
The grammar manifest test asserted a literal count of 455 property names, which is the shape of assertion that failed to notice one row standing in for three grammars: it says the file did not shrink and nothing about what it covers.

`scripts/check_properties.ml` already extracts every CSS name `read_property` matches on, so it now reports coverage against the manifest's evaluated rows: **455 rows, covering 455 of 548 readable names, 93 without**. The literal is gone from the test.

One detail worth keeping: the rows have to be read evaluated rather than parsed out of the source, because `rows_for` expands one source entry into a row per property. Counting `property = "..."` occurrences gives 297 and is the same mistake in miniature.