### PR TITLE
test: say which side of a divergence the dataset blames

### DIFF
--- a/test/spec/browser/accept_set.ml
+++ b/test/spec/browser/accept_set.ml
@@ -762,6 +762,52 @@ let () =
     !agreed_accept !agreed_reject !excused
     (List.length !rejects_valid)
     (List.length !accepts_invalid);
+  (* Every excuse in play, grouped by which side the dataset says is wrong. The
+     three verdicts are what this harness computes and used to discard, so a
+     browser-bug candidate was only ever noticed by a human reading the output:
+     [cascade right, the browser has not shipped it] is a candidate to report
+     upstream, [cascade wrong] is a defect an entry is hiding, and [needs
+     measuring] is the honest answer for a production web-features does not
+     model. *)
+  let tally = Hashtbl.create 4 in
+  List.iter
+    (fun (e : Chrome_gaps.excuse) ->
+      let v = Chrome_gaps.verdict_of Cascade.Support.evergreen e in
+      Hashtbl.replace tally v
+        (1 + Option.value ~default:0 (Hashtbl.find_opt tally v)))
+    (Chrome_gaps.spec_ahead @ Chrome_gaps.lenient @ spec_ahead_here
+   @ lenient_here);
+  Fmt.pr "  excuses by verdict:@.";
+  List.iter
+    (fun v ->
+      match Hashtbl.find_opt tally v with
+      | None | Some 0 -> ()
+      | Some n -> Fmt.pr "    %3d  %s@." n (Chrome_gaps.verdict_name v))
+    [
+      Chrome_gaps.Cascade_wrong;
+      Chrome_gaps.Browser_behind;
+      Chrome_gaps.Needs_measurement;
+    ];
+  (* An excuse the dataset says every target ships is not an excuse: the
+     browser's answer is the specification's there, so the entry is covering a
+     defect rather than citing a fact. *)
+  List.iter
+    (fun (e : Chrome_gaps.excuse) ->
+      match Chrome_gaps.verdict_of Cascade.Support.evergreen e with
+      | Chrome_gaps.Cascade_wrong ->
+          fail
+            (String.concat ""
+               [
+                 "every target ships what this entry excuses: ";
+                 e.value;
+                 " (";
+                 String.concat ", " e.properties;
+                 ")";
+               ])
+      | Chrome_gaps.Browser_behind | Chrome_gaps.Needs_measurement -> ())
+    (Chrome_gaps.spec_ahead @ Chrome_gaps.lenient @ spec_ahead_here
+   @ lenient_here);
+
   (* A run over an empty or shrunken population is a green run that asks
      nothing, which is worse than a red one. *)
   if List.length properties < minimum_properties then

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -473,6 +473,26 @@ let chrome_ships key =
   Cascade.Support.engine_implements Cascade.Support.Chrome (max_int, 0) key
   = Some true
 
+type verdict = Browser_behind | Cascade_wrong | Needs_measurement
+
+(* The key is what makes this answerable: #1091 gave an excuse the BCD compat
+   key web-features records the production under, and {!Cascade.Support} answers
+   from the generated table. Prose cannot be classified, so an entry without a
+   key is [Needs_measurement] however convincing its [why] reads. *)
+let verdict_of targets (e : excuse) =
+  match e.key with
+  | None -> Needs_measurement
+  | Some key -> (
+      match Cascade.Support.implemented targets key with
+      | None -> Needs_measurement
+      | Some true -> Cascade_wrong
+      | Some false -> Browser_behind)
+
+let verdict_name = function
+  | Browser_behind -> "cascade right, the browser has not shipped it"
+  | Cascade_wrong -> "cascade wrong, every target ships it"
+  | Needs_measurement -> "not modelled, needs measuring"
+
 let overtaken table =
   List.filter
     (fun (e : excuse) -> Option.fold ~none:false ~some:chrome_ships e.key)

--- a/test/spec/browser/chrome_gaps.mli
+++ b/test/spec/browser/chrome_gaps.mli
@@ -38,6 +38,31 @@ val lenient : excuse list
 val find : excuse list -> property:string -> value:string -> excuse option
 (** [find table ~property ~value] is the entry of [table] covering that pair. *)
 
+(** Which side of a cascade-vs-browser divergence is wrong. Every differential
+    here produces this classification and used to discard it, so a browser-bug
+    candidate was only ever noticed by a human reading the output. *)
+type verdict =
+  | Browser_behind
+      (** A specification defines the grammar and the dataset says a target
+          engine has not shipped it, so cascade is right to read it and the
+          browser's answer says nothing about the value. A candidate to report
+          upstream. *)
+  | Cascade_wrong
+      (** The dataset says every target ships it, so the browser's answer is the
+          specification's and cascade's disagreement is a defect. *)
+  | Needs_measurement
+      (** web-features models no key for it, which is every vendor-prefixed
+          property and every arm BCD gives no key. Neither side is established
+          without measuring, and saying so is the honest third answer. *)
+
+val verdict_of : Cascade.Support.targets -> excuse -> verdict
+(** [verdict_of targets e] classifies the divergence [e] excuses, from its
+    {!excuse.key} and the generated support table. An entry with no key is
+    {!Needs_measurement} however convincing its prose is. *)
+
+val verdict_name : verdict -> string
+(** [verdict_name v] names [v] for a report. *)
+
 val overtaken : excuse list -> excuse list
 (** [overtaken table] is the entries whose {!excuse.key} names a production
     Chrome has since shipped, so the disagreement they excuse is gone and the


### PR DESCRIPTION
Every differential here produces a three-way classification (cascade right and the browser behind, cascade wrong, or nobody knows yet) and discarded it at the end of the run, so a browser-bug candidate was only ever noticed by a human reading the output.

#1090 and #1091 supplied what was missing: `Cascade.Support` answers "do the targets implement this" from the web-features dataset, and an excuse carries the BCD compat key. So the verdict is derivable, and `accept_set` now prints its excuses grouped by it:

    excuses by verdict:
       10  cascade right, the browser has not shipped it
       32  not modelled, needs measuring

The ten are upstream candidates, surfaced automatically rather than by reading prose. The thirty-two are honest: web-features models no key for them, which is every vendor-prefixed property, and no amount of convincing `why` text changes that.

The third verdict is a new failure. An excuse the dataset says every target ships is not an excuse, because the browser's answer is the specification's there, so the entry would be covering a defect; the run now fails on it. Verified by pointing one key at `css.properties.color`.