### PR TITLE
test: group the vector excuses by verdict too

### DIFF
--- a/test/render/parse_recovery.ml
+++ b/test/render/parse_recovery.ml
@@ -682,6 +682,13 @@ let verdict answer =
     let full = excess ca cb @ excess cb ca in
     { over = []; under = []; rewritten = List.sort_uniq String.compare full }
 
+(* MEASURED 2026-09-07: web-features records no [css.syntax.*] compat key at
+   all, so the verdict machinery {!Chrome_gaps.verdict_of} answers with cannot
+   reach a recovery deviation, and never will while BCD models none. The
+   permanent answer for this harness is the third verdict, "not modelled, needs
+   measuring", which is why the deviation below carries the measurement and the
+   spec text rather than a key: there is nothing to look it up in. *)
+
 (* The one deviation that is the browser's. CSS Syntax 3 (ED) sec. 5.5.5
    discards a [<semicolon-token>] among a block's contents and carries on, and
    Chrome 151 stops consuming there instead, losing the rest of the block. It

--- a/test/spec/browser/property_vectors.ml
+++ b/test/spec/browser/property_vectors.ml
@@ -394,6 +394,28 @@ let () =
     skipped elapsed;
   Fmt.pr "  confirmed: %d, excused: %d, failures: %d@." !confirmed !excused
     !failures;
+  (* The same grouping accept_set reports: which side of each excused divergence
+     the generated support table blames. An entry the dataset says every target
+     ships is covering a defect rather than citing a fact, and accept_set fails
+     on one, so this reports the split without repeating that check. *)
+  let tally = Hashtbl.create 4 in
+  List.iter
+    (fun (e : Chrome_gaps.excuse) ->
+      let v = Chrome_gaps.verdict_of Cascade.Support.evergreen e in
+      Hashtbl.replace tally v
+        (1 + Option.value ~default:0 (Hashtbl.find_opt tally v)))
+    (spec_ahead @ lenient);
+  Fmt.pr "  excuses by verdict:@.";
+  List.iter
+    (fun v ->
+      match Hashtbl.find_opt tally v with
+      | None | Some 0 -> ()
+      | Some n -> Fmt.pr "    %3d  %s@." n (Chrome_gaps.verdict_name v))
+    [
+      Chrome_gaps.Cascade_wrong;
+      Chrome_gaps.Browser_behind;
+      Chrome_gaps.Needs_measurement;
+    ];
   (* A run that confirms nothing is not a clean run, it is a blind one. *)
   if !confirmed = 0 then fail "not one vector was confirmed against the browser";
   if !failures > 0 then exit 1


### PR DESCRIPTION
`property_vectors` shares the excuse tables #1106 taught `accept_set` to group, and reported them by table where the question a reader has is which side is wrong. Same report, same classifier: 10 upstream candidates, 28 not modelled by web-features. The fatal case stays in `accept_set` rather than being repeated.

It also settles a question that was open: whether the recovery and matching harnesses want keys too. They cannot have them. web-features records **no `css.syntax.*` compat key at all**, so the lookup can never reach a parse-recovery deviation, and inventing a key would be prose wearing a key's clothes. "Not modelled, needs measuring" is the permanent honest verdict there, and `parse_recovery` now says so beside the one deviation it carries.