### PR TITLE
background: give the colour to the final layer only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,18 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- A colour reaches the final background layer alone, so `background: red,
+  url(x.png)` is dropped with a warning where every browser drops it and
+  `background: url(x.png), red` reads. CSS Backgrounds 3 sec. 2.10 spells the
+  shorthand `<bg-layer>#? , <final-bg-layer>` and sec. 2.1 paints the colour
+  once below every layer rather than per layer (#1108)
+
+- `-webkit-text-stroke: 100px 200px` is dropped with a warning where the second
+  width used to replace the first, which changed the stroke a browser drew
+  nothing for into one it drew. The property is a `||` of one width and one
+  colour, and CSS Values 4 sec. 2.2 takes each option of a `||` at most once
+  (#1108)
+
 - `gap: -10%` and `text-decoration: fit-content(20rem)` are dropped with a
   warning where every browser drops the declaration. CSS Box Alignment 3 sec.
   8.1 gives every gap a `[0,inf]` range, which the shorthand checked against a

--- a/lib/prop_background.ml
+++ b/lib/prop_background.ml
@@ -2113,8 +2113,21 @@ let rec read_background t : background =
     ~default:(read_background_default read_background)
     t
 
+(* CSS Backgrounds 3 sec. 2.1 gives the [background] shorthand a [<bg-layer># ,
+   <final-bg-layer>]: only the LAST layer carries a [<background-color>],
+   because the colour paints once behind every layer rather than per layer. A
+   colour in an earlier one fills no slot. *)
 let read_backgrounds t : background list =
-  Cursor.list ~sep:Cursor.comma ~at_least:1 read_background t
+  let layers = Cursor.list ~sep:Cursor.comma ~at_least:1 read_background t in
+  let count = List.length layers in
+  List.iteri
+    (fun i (layer : background) ->
+      match layer with
+      | Shorthand { color = Some _; _ } when i < count - 1 ->
+          Cursor.err_invalid t "only the final background layer takes a colour"
+      | _ -> ())
+    layers;
+  layers
 
 (* CSS Backgrounds 3 sec. 5.1: [border-radius = <length-percentage [0,inf]>{1,4}
    [ / <length-percentage [0,inf]>{1,4} ]?]. Reads 1-4 horizontal radii then,

--- a/lib/prop_text.ml
+++ b/lib/prop_text.ml
@@ -2010,18 +2010,26 @@ let pp_webkit_text_stroke : webkit_text_stroke Pp.t =
     s.color;
   if not !wrote then Pp.string ctx "currentColor"
 
+(* The property is a [||] of one width and one colour, and CSS Values 4 sec. 2.2
+   takes each option of a [||] at most once, so a second width fills no slot
+   rather than replacing the first. *)
 let read_webkit_text_stroke t : webkit_text_stroke =
   let width = ref Option.None and color = ref Option.None in
+  let fill slot value =
+    if Option.is_some !slot then
+      Cursor.err_invalid t "-webkit-text-stroke names a component twice";
+    slot := Some value
+  in
   let read_one t =
     match Cursor.peek_ident t with
-    | Some ("thin" | "medium" | "thick") -> width := Some (read_border_width t)
+    | Some ("thin" | "medium" | "thick") -> fill width (read_border_width t)
     | _ -> (
         let snap = Cursor.save t in
         match read_border_width t with
-        | w -> width := Some w
+        | w -> fill width w
         | exception Cursor.Parse_error _ ->
             Cursor.restore t snap;
-            color := Some (Values.read_color t))
+            fill color (Values.read_color t))
   in
   read_one t;
   Cursor.ws t;

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -174,15 +174,6 @@ let spec_ahead : excuse list =
          zero is a <length>; Chrome takes only a dimension";
     };
     {
-      properties = [ "overflow-clip-margin" ];
-      key = Some "css.properties.overflow-clip-margin.border-box";
-      value = "calc(1rem + 2px)";
-      why =
-        "CSS Values 4 sec. 10.1 admits a math function wherever a <length> is \
-         accepted, which CSS Overflow 4 sec. 3.2 is; Chrome takes only a \
-         dimension";
-    };
-    {
       properties = [ "text-align" ];
       key = Some "css.properties.text-align.match-parent";
       value = "match-parent";
@@ -197,16 +188,6 @@ let spec_ahead : excuse list =
       why =
         "CSS Text 4 sec. 2.1: none | [ capitalize | uppercase | lowercase ] || \
          full-width || full-size-kana | math-auto";
-    };
-    {
-      properties = [ "animation"; "-webkit-animation" ];
-      key = Some "css.properties.animation.animation-timeline_included";
-      value = "--x x";
-      why =
-        "CSS Animations 2 sec. 4.12: <single-animation> ends in [ none | \
-         <keyframes-name> ] || <single-animation-timeline>, so a dashed-ident \
-         timeline and a keyframes name fill two slots of one [||]. Chrome took \
-         the timeline back out of the shorthand";
     };
     {
       properties = [ "background-blend-mode" ];
@@ -644,8 +625,58 @@ let lenient_shapes =
     };
   ]
 
+let words s = String.split_on_char ' ' (String.trim s)
+
+(* CSS Animations 2 sec. 4.12 ends <single-animation> in [ none |
+   <keyframes-name> ] || <single-animation-timeline>, so a dashed-ident timeline
+   and a keyframes name fill two slots of one [||]. Measured on Chrome 153: it
+   takes the timeline alone ([animation: --t], [animation: 1s --t]) and refuses
+   it beside a name ([spin --t], [flip-block --fallback]), so it took the
+   timeline back out of the shorthand rather than never having it. *)
+let animation_name_beside_timeline s =
+  let ws = List.filter (fun w -> w <> "") (words s) in
+  let dashed w = String.length w > 2 && String.sub w 0 2 = "--" in
+  let timing w =
+    (not (dashed w))
+    && (String.contains w 's' || String.contains w '%'
+       || String.exists (fun c -> c >= '0' && c <= '9') w)
+  in
+  List.exists dashed ws
+  && List.exists (fun w -> (not (dashed w)) && not (timing w)) ws
+
+(* CSS Values 4 sec. 10.1 puts a math function wherever its type is, and CSS
+   Overflow 4 sec. 3.2 gives overflow-clip-margin a <length>. Measured on Chrome
+   153: it takes a literal length and refuses every math function there,
+   [calc(1px)] and [min(1px,2px)] included, so this is not about the negative
+   the value happens to carry. *)
+let math_function s =
+  List.exists
+    (fun fn ->
+      String.length s >= String.length fn
+      && String.sub s 0 (String.length fn) = fn)
+    [ "calc("; "min("; "max("; "clamp(" ]
+
 let spec_ahead_shapes =
   [
+    {
+      shape_properties = [ "animation"; "-webkit-animation" ];
+      shape_name = "a keyframes name beside a dashed-ident timeline";
+      matches = animation_name_beside_timeline;
+      shape_why =
+        "CSS Animations 2 sec. 4.12 ends <single-animation> in [ none | \
+         <keyframes-name> ] || <single-animation-timeline>, so the two fill \
+         two slots of one [||]. Chrome takes the timeline alone and refuses it \
+         beside a name";
+    };
+    {
+      shape_properties = [ "overflow-clip-margin" ];
+      shape_name = "a math function in an overflow clip margin";
+      matches = math_function;
+      shape_why =
+        "CSS Values 4 sec. 10.1 puts a math function wherever its type is, and \
+         CSS Overflow 4 sec. 3.2 gives the property a <length>. Chrome takes a \
+         literal length and refuses every math function there";
+    };
     {
       shape_properties = [ "text-overflow" ];
       shape_name = "a text-overflow Chrome does not implement";

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -209,6 +209,20 @@ let spec_ahead : excuse list =
          the timeline back out of the shorthand";
     };
     {
+      properties = [ "background-blend-mode" ];
+      (* web-features records css.properties.mix-blend-mode.plus-lighter, which
+         Chrome ships, and nothing for the background property, so the lookup
+         cannot answer this one and the verdict is the honest third. *)
+      key = None;
+      value = "plus-lighter";
+      why =
+        "Compositing 2 sec. 3.4.3 spells background-blend-mode \
+         <'mix-blend-mode'>#, and sec. 3.4.1 gives mix-blend-mode <blend-mode> \
+         | plus-lighter, so the value is granted on both. Measured on Chrome \
+         153: it takes plus-lighter on mix-blend-mode and refuses it on \
+         background-blend-mode";
+    };
+    {
       properties = [ "text-overflow" ];
       key = Some "css.properties.text-overflow.string";
       value = "\"...\"";

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -1921,7 +1921,11 @@ let matrix =
       };
       {
         property = "background-blend-mode";
-        positives = [ "normal"; "multiply"; "screen, overlay" ];
+        (* Compositing 2 sec. 3.4.3 spells this <'mix-blend-mode'>#, and sec.
+           3.4.1 gives mix-blend-mode plus-lighter, so the value is granted here
+           too; Chrome takes it on mix-blend-mode alone. Pinned so the excuse
+           for that answers to the fixed population. *)
+        positives = [ "normal"; "multiply"; "screen, overlay"; "plus-lighter" ];
         negatives = [ "normal multiply"; "foo" ];
       };
       {

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -4749,6 +4749,14 @@ let spec_platform_property_vectors () =
          refused one. CSS Logical 1 sec. 4.2 spells the flow-relative pair from
          the same production. *)
       "margin-right: fit-content(20rem)";
+      (* The prefixed stroke is a [||] of one width and one colour, so a second
+         width fills no slot; cascade kept the last and dropped the first, which
+         is a miscompile rather than a loose read. *)
+      "-webkit-text-stroke: 100px 200px";
+      (* CSS Backgrounds 3 sec. 2.1 gives the colour to the FINAL layer alone,
+         so a colour in an earlier one is no background. *)
+      "background: red, currentcolor";
+      "background: red, url(a.png)";
       (* CSS Box Alignment 3 sec. 8.1 gives every gap a [0,inf] range, and the
          row-gap and column-gap longhands already refused a negative one. CSS
          Text Decoration 4 sec. 3 builds the shorthand from its own longhands,

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -7004,17 +7004,29 @@ let bg321_multi_layer_kept () =
     | Ok parsed -> minify parsed.stylesheet
     | Error _ -> Alcotest.failf "failed to parse: %s" css
   in
+  (* Sec. 2.10 spells the shorthand [<bg-layer>#? , <final-bg-layer>], and only
+     the final layer carries a [<background-color>]: sec. 2.1 paints the colour
+     once below every layer rather than per layer. So the colour goes LAST, and
+     a colour in an earlier layer is no background at all. Chrome 153 agrees: it
+     drops [background: red, url(x.png)] and keeps the reverse. *)
   Alcotest.(check bool)
     "multi-layer background preserves both layers" true
-    (let out = normalize ".x { background: red, url(x.png) }" in
+    (let out = normalize ".x { background: url(x.png), red }" in
      Astring.String.is_infix ~affix:"red" out
-     && Astring.String.is_infix ~affix:"url(x.png)" out)
+     && Astring.String.is_infix ~affix:"url(x.png)" out);
+  Alcotest.(check bool)
+    "a colour in an earlier layer is dropped" true
+    (match Css.of_string ~strict:true ".x { background: red, url(x.png) }" with
+    | Ok _ -> false
+    | Error _ -> true)
 
 let fidelity_background_preserved () =
   pretty_preserves ".x { background: red 0% 0% }" [ "0% 0%" ];
   pretty_preserves ".x { background: red 50% 50% / cover no-repeat }"
     [ "50% 50%"; "cover"; "no-repeat" ];
-  pretty_preserves ".x { background: red, url(x.png) }" [ "red"; "url(x.png)" ]
+  (* The colour belongs to the final layer (sec. 2.10), so the round trip is
+     asked of the spelling that has one. *)
+  pretty_preserves ".x { background: url(x.png), red }" [ "red"; "url(x.png)" ]
 
 (* {2 Strings and escapes (CSS Syntax L3 sec. 4.3.7)} *)
 


### PR DESCRIPTION
Two reader defects, one excuse, and two literal excuses replaced by the class they belong to. Accept-set goes from clean on three of eight seeds to **seven of eight**.

`background: red, url(x.png)` parsed. CSS Backgrounds 3 sec. 2.10 spells the shorthand `<bg-layer>#? , <final-bg-layer>`, and sec. 2.1 paints the colour once below every layer rather than per layer, so only the final layer carries one. Chrome drops it and keeps the reverse.

`-webkit-text-stroke: 100px 200px` was worse than accepted: the second width REPLACED the first, turning a declaration the browser drops into one it draws. A `||` takes each option at most once (CSS Values 4 sec. 2.2).

**Two existing tests pinned the background spelling browsers drop**, asserting `background: red, url(x.png)` round-trips. The spec and Chrome agree against them, so they now use `url(x.png), red` and a new case pins that colour-first is refused.

Three browser gaps measured and placed. `background-blend-mode: plus-lighter` gets a literal excuse and a manifest row, since Compositing 2 sec. 3.4.3 grants it and Chrome takes it on `mix-blend-mode` alone. The animation-timeline and `overflow-clip-margin` math excuses become predicates and their literals go: each named one value of a class the browser refuses whole, which is what let a resample strand them.

One finding is left across the eight seeds, `transition: underline, none`, measured as the browser's (CSS Transitions 1 sec. 2.3 gives `<single-transition>` a `none` arm; Chrome reads it alone and refuses any list holding one). Excusing it needs a manifest row, and adding one resamples the population, so it is its own change rather than a rider on this.