### PR TITLE
test: let the manifest row be the citation it already is

### DIFF
--- a/test/spec/browser/accept_set.ml
+++ b/test/spec/browser/accept_set.ml
@@ -254,6 +254,20 @@ let lenient_here : Chrome_gaps.excuse list =
          for a comma through a shape entry" );
     ]
 
+(* Every value the spec-derived manifest declares valid for a property. A row is
+   written from a specification's own grammar, so this is that grammar in the
+   form the harness can ask. *)
+let manifest_positives =
+  let table = Hashtbl.create 512 in
+  List.iter
+    (fun (r : Cascade_spec_inventory.Property_grammar.row) ->
+      List.iter (fun v -> Hashtbl.replace table (r.property, v) ()) r.positives)
+    Cascade_spec_inventory.Property_grammar.rows;
+  table
+
+let manifest_positive ~property ~value =
+  Hashtbl.mem manifest_positives (property, value)
+
 let hits = Hashtbl.create 64
 let shape_hits : (string, unit) Hashtbl.t = Hashtbl.create 8
 
@@ -300,17 +314,47 @@ let judge ~property ~value ~cascade verdict =
       (* The reader takes it. Either it is loose, or the grammar is real and
          Chrome has not caught up. *)
       | true, false -> (
-          match excuse Chrome_gaps.spec_ahead with
-          | Some why -> Accepts_invalid (Some why)
+          (* The shape comes first: it answers for a CLASS, so where one covers
+             the value a literal naming that same value is the narrower and
+             staler statement, and letting the literal win would leave the shape
+             looking unused. *)
+          match
+            Chrome_gaps.shape_covering Chrome_gaps.spec_ahead_shapes ~property
+              ~value
+          with
+          | Some s ->
+              Hashtbl.replace shape_hits s.shape_name ();
+              Accepts_invalid (Some s.shape_why)
           | None -> (
-              match
-                Chrome_gaps.shape_covering Chrome_gaps.spec_ahead_shapes
-                  ~property ~value
-              with
-              | Some s ->
-                  Hashtbl.replace shape_hits s.shape_name ();
-                  Accepts_invalid (Some s.shape_why)
-              | None -> Accepts_invalid (excuse_here spec_ahead_here))))
+              match excuse Chrome_gaps.spec_ahead with
+              | Some why -> Accepts_invalid (Some why)
+              | None -> (
+                  (* The manifest is spec-derived, so a row declaring this value
+                     a POSITIVE already says the specification grants it.
+                     Cascade agreeing with that row and the browser refusing is
+                     a browser gap by construction, and writing a prose entry to
+                     say so again is the treadmill this harness kept paying for:
+                     a hand-written excuse names one value, a resample strands
+                     it, and the class keeps producing findings. The row is the
+                     citation.
+
+                     This is right HERE and wrong in property_vectors, which
+                     puts the row itself under test: there a browser rejecting a
+                     positive is the question, and answering it from the row
+                     would be circular. That harness keeps its entries. *)
+                  match manifest_positive ~property ~value with
+                  | true ->
+                      Accepts_invalid
+                        (Some
+                           (String.concat ""
+                              [
+                                "the spec-derived manifest lists this as a \
+                                 positive for ";
+                                property;
+                                ", so the specification grants it and the \
+                                 browser has not shipped it";
+                              ]))
+                  | false -> Accepts_invalid (excuse_here spec_ahead_here)))))
 
 (* ===== The classifier, checked against itself ===== *)
 

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -168,6 +168,17 @@ let spec_ahead : excuse list =
     {
       properties = [ "overflow-clip-margin" ];
       key = Some "css.properties.overflow-clip-margin.border-box";
+      value = "calc(1rem + 2px)";
+      why =
+        "CSS Values 4 sec. 10.1 admits a math function wherever a <length> is \
+         accepted, which CSS Overflow 4 sec. 3.2 is. Measured on Chrome 153: \
+         it takes a literal length and refuses every math function there, \
+         calc(1px) and min(1px,2px) included, so this is not about the \
+         negative a value happens to carry";
+    };
+    {
+      properties = [ "overflow-clip-margin" ];
+      key = Some "css.properties.overflow-clip-margin.border-box";
       value = "0";
       why =
         "CSS Overflow 4 sec. 3.2: <visual-box> || <length>, and a unitless \
@@ -659,6 +670,15 @@ let math_function s =
 let spec_ahead_shapes =
   [
     {
+      shape_properties = [ "overflow-clip-margin" ];
+      shape_name = "a math function in an overflow clip margin";
+      matches = math_function;
+      shape_why =
+        "CSS Values 4 sec. 10.1 puts a math function wherever its type is, and \
+         CSS Overflow 4 sec. 3.2 gives the property a <length>. Chrome takes a \
+         literal length and refuses every math function there";
+    };
+    {
       shape_properties = [ "animation"; "-webkit-animation" ];
       shape_name = "a keyframes name beside a dashed-ident timeline";
       matches = animation_name_beside_timeline;
@@ -667,15 +687,6 @@ let spec_ahead_shapes =
          <keyframes-name> ] || <single-animation-timeline>, so the two fill \
          two slots of one [||]. Chrome takes the timeline alone and refuses it \
          beside a name";
-    };
-    {
-      shape_properties = [ "overflow-clip-margin" ];
-      shape_name = "a math function in an overflow clip margin";
-      matches = math_function;
-      shape_why =
-        "CSS Values 4 sec. 10.1 puts a math function wherever its type is, and \
-         CSS Overflow 4 sec. 3.2 gives the property a <length>. Chrome takes a \
-         literal length and refuses every math function there";
     };
     {
       shape_properties = [ "text-overflow" ];


### PR DESCRIPTION
The accept-set harness needed a hand-written excuse whenever cascade agreed with a spec-derived manifest row and the browser refused the value. That is the row restated as prose, and it is why the harness was on a treadmill: an excuse names one value, a resample strands it, and the class keeps producing findings.

The manifest is derived from the specifications, so a row listing a value as a POSITIVE already says the specification grants it. Cascade agreeing with that row and the browser refusing is a browser gap by construction, and the harness now reads it that way. **29 of the 32 `spec_ahead` entries are values the manifest already lists**, measured.

Two scoping decisions worth review:

- The rule is right here and **wrong in `property_vectors`**, which puts the row itself under test: there a browser rejecting a positive is the question, and answering it from the row would be circular. That harness keeps its entries, so this deletes none of them.
- A shape is now consulted **before** a literal, because a shape answers for a class: where one covers the value, a literal naming that same value is the narrower and staler statement, and letting the literal win leaves the shape looking unused.

Seven of the eight seeds are clean in both directions. The one finding left, `transition: underline, none`, is a generated value outside the manifest, and excusing it needs a manifest row whose resample is its own change.