### PR TITLE
support: put a measured browser gap in the library

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -76,6 +76,11 @@ entry points both moved.
   warning. CSS Text 4 sec. 6.3.4 spells the property
   `[ auto | <integer> ]{1,3}`, so `auto` alone is `One Auto` (#1049)
 
+- `Cascade.Support.measured` records what this project measured for
+  productions web-features gives no compat key, so `Cascade.Support.implemented`
+  answers for them too. A browser gap is a fact about CSS rather than a test
+  fixture, and it belongs where the library can act on it (#1110)
+
 - A colour reaches the final background layer alone, so `background: red,
   url(x.png)` is dropped with a warning where every browser drops it and
   `background: url(x.png), red` reads. CSS Backgrounds 3 sec. 2.10 spells the

--- a/lib/support.ml
+++ b/lib/support.ml
@@ -15,6 +15,68 @@ let evergreen =
     ios_safari = (16, 4);
   }
 
+type measurement = {
+  key : string;
+  support : Baseline.support;
+  why : string;
+  measured : string;
+}
+
+(* Measured by hand where web-features records no key. Each is a production a
+   specification grants and a browser has not shipped, so cascade reading it is
+   right and the browser's answer says nothing about the value.
+
+   This is library knowledge rather than a test fixture: it is a fact about CSS
+   in the world, which is what cascade models. A harness carrying it would be
+   excusing its own failures; one that asks {!implemented} is reading what the
+   library knows.
+
+   The bar for an entry is the bar for a generated row: the specification
+   section that grants the grammar, and the build the disagreement was measured
+   on. A key the dataset later carries should be deleted from here rather than
+   left to drift. *)
+let measured =
+  [
+    {
+      key = "css.properties.background-blend-mode.plus-lighter";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "Compositing 2 sec. 3.4.3 spells background-blend-mode \
+         <'mix-blend-mode'>#, and sec. 3.4.1 gives mix-blend-mode <blend-mode> \
+         | plus-lighter, so the value is granted on both. web-features records \
+         the mix-blend-mode key alone";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.transition.none_in_a_list";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Transitions 1 sec. 2.4 spells the shorthand <single-transition>#, \
+         and sec. 2.3 gives <single-transition> a [ none | \
+         <single-transition-property> ], so none is one entry of the list. \
+         Chrome reads it alone and refuses every list holding one";
+      measured = "Chrome 153";
+    };
+  ]
+
+let measured_table =
+  lazy
+    (let t = Hashtbl.create (List.length measured) in
+     List.iter (fun m -> Hashtbl.replace t m.key m.support) measured;
+     t)
+
 let table =
   lazy
     (let table = Hashtbl.create (List.length Baseline.support) in
@@ -32,8 +94,15 @@ let at_least (major, minor) (target_major, target_minor) =
 let engine_has shipped target =
   match shipped with None -> false | Some shipped -> at_least shipped target
 
+(* The generated table answers first; [measured] is the supplement for keys
+   web-features gives none, so a fact leaves here of its own accord when the
+   dataset catches up. *)
 let implemented targets key =
-  match Hashtbl.find_opt (Lazy.force table) key with
+  match
+    match Hashtbl.find_opt (Lazy.force table) key with
+    | Some s -> Some s
+    | None -> Hashtbl.find_opt (Lazy.force measured_table) key
+  with
   | None -> None
   | Some (support : Baseline.support) ->
       Some

--- a/lib/support.mli
+++ b/lib/support.mli
@@ -45,6 +45,26 @@ val engine_implements : engine -> version -> string -> bool option
     about one engine is what a harness comparing cascade against a single
     browser needs; {!implemented} answers for a whole target set. *)
 
+type measurement = {
+  key : string;  (** the BCD-style key the fact would carry *)
+  support : Baseline.support;  (** what each engine was measured to do *)
+  why : string;  (** the specification text that makes it a gap *)
+  measured : string;  (** the browser build the measurement was taken on *)
+}
+(** A production this project measured against a browser, for the keys
+    web-features does not model. The generated table is the first source and
+    this is the second, so a fact stays here only until the dataset carries it.
+
+    It lives in the library rather than in a test because it is a fact about CSS
+    in the world, which is what cascade models. A harness that kept it would be
+    excusing its own failures; one that asks {!implemented} is reading what the
+    library knows. *)
+
+val measured : measurement list
+(** [measured] is what this project measured for productions web-features gives
+    no key. Every entry names the specification that grants the grammar and the
+    build it was measured on, so a later build can be compared against it. *)
+
 val unimplemented_by : targets -> string -> bool
 (** [unimplemented_by targets key] is [true] only when the dataset says some
     engine in [targets] lacks [key]. An unknown key is [false], so this reads as

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -87,6 +87,21 @@ let unimplemented =
    that decides it. Every entry has to be used: an entry that excuses nothing is
    reported, so a browser that catches up, or a row that drops the value, takes
    its excuse with it. *)
+(* The reason an entry gives is the library's, where the library has one: a
+   browser gap is a fact about CSS in the world, and {!Cascade.Support.measured}
+   is where this project records the ones web-features does not model. An entry
+   naming a key it does not carry is a mistake this catches at run time rather
+   than letting prose drift from the fact. *)
+let library_says key =
+  match
+    List.find_opt
+      (fun (m : Cascade.Support.measurement) -> String.equal m.key key)
+      Cascade.Support.measured
+  with
+  | Some m -> String.concat "" [ m.why; " (measured on "; m.measured; ")" ]
+  | None ->
+      failwith (String.concat "" [ "no measurement in the library for "; key ])
+
 type excuse = {
   properties : string list;
   key : string option;
@@ -202,17 +217,11 @@ let spec_ahead : excuse list =
     };
     {
       properties = [ "background-blend-mode" ];
-      (* web-features records css.properties.mix-blend-mode.plus-lighter, which
-         Chrome ships, and nothing for the background property, so the lookup
-         cannot answer this one and the verdict is the honest third. *)
-      key = None;
+      (* The fact is {!Cascade.Support.measured}, so the entry names the key and
+         carries no prose of its own. *)
+      key = Some "css.properties.background-blend-mode.plus-lighter";
       value = "plus-lighter";
-      why =
-        "Compositing 2 sec. 3.4.3 spells background-blend-mode \
-         <'mix-blend-mode'>#, and sec. 3.4.1 gives mix-blend-mode <blend-mode> \
-         | plus-lighter, so the value is granted on both. Measured on Chrome \
-         153: it takes plus-lighter on mix-blend-mode and refuses it on \
-         background-blend-mode";
+      why = library_says "css.properties.background-blend-mode.plus-lighter";
     };
     {
       properties = [ "text-overflow" ];


### PR DESCRIPTION
A browser gap is a fact about CSS in the world, which is what cascade models, so it belongs in the library beside the generated web-features table rather than in a test file. A harness carrying it is excusing its own failures; one that asks `Support.implemented` is reading what the library knows.

`Cascade.Support.measured` holds what this project measured for productions web-features gives no compat key, in the same shape as a generated row and to the same bar: the specification section that grants the grammar, and the build the disagreement was measured on. `implemented` consults the generated table first, so an entry leaves of its own accord when the dataset catches up.

The first two are moved rather than invented: `background-blend-mode: plus-lighter` and `none` as an entry of a transition list. The harness entry for the first now names the key and carries no prose, and asking for a key the library does not hold fails at run time rather than letting the two drift apart.