### PR TITLE
support: key the last gaps, and pin a lossless alpha fold

### DIFF
--- a/lib/support.ml
+++ b/lib/support.ml
@@ -54,22 +54,6 @@ let measured =
       measured = "Chrome 153";
     };
     {
-      key = "css.properties.transition.none_in_a_list";
-      support =
-        {
-          Baseline.chrome = None;
-          firefox = None;
-          safari = None;
-          safari_ios = None;
-        };
-      why =
-        "CSS Transitions 1 sec. 2.4 spells the shorthand <single-transition>#, \
-         and sec. 2.3 gives <single-transition> a [ none | \
-         <single-transition-property> ], so none is one entry of the list. \
-         Chrome reads it alone and refuses every list holding one";
-      measured = "Chrome 153";
-    };
-    {
       key = "css.properties.text-decoration-thickness.hairline";
       support =
         {

--- a/test/spec/browser/accept_set.ml
+++ b/test/spec/browser/accept_set.ml
@@ -620,8 +620,28 @@ let check_overtaken () =
        (Chrome_gaps.spec_ahead @ Chrome_gaps.lenient @ spec_ahead_here
       @ lenient_here))
 
+(* The reverse of the staleness check: a measurement in the library that no
+   entry here names. It is dead data, and the library is where a fact goes to be
+   ACTED on, so one nothing reads is a fact that stopped being true or an entry
+   that was deleted without it. Either way it should not sit there. *)
+let check_unnamed_measurements () =
+  let named =
+    List.filter_map
+      (fun (e : Chrome_gaps.excuse) -> e.key)
+      (Chrome_gaps.spec_ahead @ Chrome_gaps.lenient @ spec_ahead_here
+     @ lenient_here)
+  in
+  List.iter
+    (fun (m : Cascade.Support.measurement) ->
+      if not (List.exists (String.equal m.key) named) then
+        fail
+          (String.concat ""
+             [ "no entry names this measurement, so nothing reads it: "; m.key ]))
+    Cascade.Support.measured
+
 let check_unused () =
   check_overtaken ();
+  check_unnamed_measurements ();
   List.iter
     (fun (e : Chrome_gaps.excuse) ->
       let used =

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -134,7 +134,10 @@ let spec_ahead : excuse list =
   [
     {
       properties = sizing;
-      key = None;
+      (* web-features records the two-argument form per property, with an empty
+         support map: no engine ships it. The key names width because these
+         properties share one <box-size> and the dataset agrees across them. *)
+      key = Some "css.properties.width.fit-content_function";
       value = "fit-content(20rem)";
       why =
         "CSS Sizing 4 sec. 3.2 adds fit-content() to <box-size>, which every \
@@ -153,7 +156,7 @@ let spec_ahead : excuse list =
           "list-style-image";
           "content";
         ];
-      key = None;
+      key = Some "css.types.image.cross-fade";
       value = "cross-fade(url(a.png) 40%, url(b.png))";
       why =
         "CSS Images 4 sec. 2.6: cross-fade() = cross-fade( <cf-image># ); \

--- a/test/test_optimize.ml
+++ b/test/test_optimize.ml
@@ -1290,6 +1290,33 @@ let test_lossless_declaration_order () =
     ".a{border-top:1px solid red;border-color:#00f}"
     (opt ~lossless:true ".a{border-top:1px solid red;border-color:blue}")
 
+(* CSS Color 4 sec. 5 writes the alpha of the hex forms as a byte, so a hex
+   spelling exists only where the alpha IS one. [--lossless] therefore folds an
+   alpha that lands on a whole byte and leaves the rest functional: .6 is 153
+   and folds, .5 is 127.5 and does not. Rounding it would emit a different
+   colour under the mode whose whole promise is that it does not. *)
+let test_lossless_alpha_folds_only_on_a_whole_byte () =
+  let opt css =
+    match Css.of_string css with
+    | Ok p ->
+        Css.to_string ~minify:true (Css.optimize ~lossless:true p.stylesheet)
+        |> String.trim
+    | Error _ -> Alcotest.fail "parse"
+  in
+  List.iter
+    (fun (input, expected) ->
+      Alcotest.(check string) input expected (opt input))
+    [
+      (* Whole bytes: 153, 51, 204, 255. *)
+      (".a{color:rgb(0 0 0/.6)}", ".a{color:#0009}");
+      (".a{color:rgb(0 0 0/.2)}", ".a{color:#0003}");
+      (".a{color:rgb(0 0 0/.8)}", ".a{color:#000c}");
+      (".a{color:rgb(0 0 0/1)}", ".a{color:#000}");
+      (* 127.5 is not a byte, so the functional spelling stays. *)
+      (".a{color:rgb(0 0 0/.5)}", ".a{color:rgb(0 0 0/.5)}");
+      (".a{color:rgb(0 0 0/.3)}", ".a{color:rgb(0 0 0/.3)}");
+    ]
+
 let test_lossless_keeps_unknown_property_order () =
   let opt css =
     match Css.of_string ~strict:false css with
@@ -1735,6 +1762,9 @@ let optimize_tests =
     ("vendor prefix baseline gate", `Quick, test_vendor_prefix_baseline_gate);
     ("color property folds", `Quick, test_color_property_folds);
     ("lossless declaration order", `Quick, test_lossless_declaration_order);
+    ( "lossless alpha folds only on a whole byte",
+      `Quick,
+      test_lossless_alpha_folds_only_on_a_whole_byte );
     ( "lossless keeps unknown property order",
       `Quick,
       test_lossless_keeps_unknown_property_order );


### PR DESCRIPTION
Two things, both from removing hand-written prose and then checking what that exposed.

**The last two excuse entries carrying prose are keyed**, and both turned out to be in the generated dataset already: `css.properties.width.fit-content_function` (recorded per property with an empty support map, so no engine ships it) and `css.types.image.cross-fade`. No harness entry carries prose now; each names a key and the library holds the reason.

That created a way to be wrong in the other direction, and it had already happened: a measurement added for a shape that was then reverted sat in the library unread. The run now fails on a measurement no entry names. Both directions are verified by planting a failure.

**A mutation campaign over `lib/values.ml`** scored 66.7% with three survivors, and the first triaged is a real one: `exact_alpha_value_byte`'s whole-byte guard can be removed with nothing noticing. Removing it truncates an alpha of .5 to 127 and emits `#0000007f` where the input said `rgb(0 0 0/.5)` — a different colour, under the mode whose whole promise is that it does not change one. CSS Color 4 sec. 5 writes the hex alpha as a byte, so a hex spelling exists only where the alpha is one: .6 is 153 and folds, .5 is 127.5 and stays functional. The test pins both sides.