### PR TITLE
values: lead a calc sum with a positive term

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -990,6 +990,10 @@ to lose a whole rule over one bad piece. Both are gone.
   need a second (#413, #422, #424, #468, #480, #486, #487, #493, #502, #505,
   #507, #517, #519, #523, #542, #543, #566, #664, #746, #750)
 
+- A `calc()` sum leads with a positive term where it has one, so
+  `calc(-10px + 100vw)` minifies to `calc(100vw - 10px)`, and a negative term
+  joins with a minus rather than growing a sign into `calc(3px + -2em)` (#1113)
+
 ### Custom properties
 
 - A custom property's value keeps the whitespace runs the author wrote, where

--- a/lib/values.ml
+++ b/lib/values.ml
@@ -1754,20 +1754,6 @@ type length_unit =
 
 let length_unit_is_pct = function Pct -> true | _ -> false
 
-let length_unit_is_viewport = function
-  | Vw | Vh | Vmin | Vmax | Vi | Vb | Dvh | Dvw | Dvmin | Dvmax | Lvh | Lvw
-  | Lvmin | Lvmax | Svh | Svw | Svmin | Svmax ->
-      true
-  | _ -> false
-
-let length_unit_is_font_relative = function
-  | Rem | Em | Ex | Cap | Ic | Ric | Rlh | Ch | Lh -> true
-  | _ -> false
-
-let length_unit_negative_rank = function
-  | unit when length_unit_is_font_relative unit -> 0
-  | _ -> 1
-
 let unit_of_string = function
   | "px" -> Some Px
   | "cm" -> Some Cm
@@ -1920,31 +1906,26 @@ type linear_term = {
   count : int;
 }
 
+(* CSS Values 4 sec. 10.13 sorts a sum's children before serialising them, so
+   the order carries no meaning and the shortest spelling wins. A positive term
+   leads: [b - a] against [-a + b] spends one byte fewer. Ties keep the authored
+   order. *)
 let linear_term_priority ~first_pos term =
   match (term.value > 0., length_unit_is_pct term.unit) with
   | true, true -> 0
   | true, false when term.first_pos = first_pos && term.count = 1 -> 1
-  | false, false when not (length_unit_is_viewport term.unit) -> 2
-  | true, false when term.count = 1 -> 3
-  | true, false -> 4
-  | false, false -> 5
-  | false, true -> 6
-
-let compare_negative_linear_term a b =
-  let c =
-    compare
-      (length_unit_negative_rank a.unit)
-      (length_unit_negative_rank b.unit)
-  in
-  if c <> 0 then c else compare a.first_pos b.first_pos
+  | true, false when term.count = 1 -> 2
+  | true, false -> 3
+  | false, false -> 4
+  | false, true -> 5
 
 let compare_linear_term ~first_pos a b =
-  let a_priority = linear_term_priority ~first_pos a in
-  let b_priority = linear_term_priority ~first_pos b in
-  let c = compare a_priority b_priority in
-  if c <> 0 then c
-  else if a_priority = 2 then compare_negative_linear_term a b
-  else compare a.first_pos b.first_pos
+  let c =
+    compare
+      (linear_term_priority ~first_pos a)
+      (linear_term_priority ~first_pos b)
+  in
+  if c <> 0 then c else compare a.first_pos b.first_pos
 
 let ordered_linear_terms terms =
   let table = Hashtbl.create 8 in
@@ -1967,13 +1948,7 @@ let ordered_linear_terms terms =
   in
   List.sort (compare_linear_term ~first_pos) terms
 
-let linear_calc_op first_unit first_value unit n =
-  if
-    n < 0. && first_value > 0. && first_unit = Px
-    && length_unit_is_font_relative unit
-  then (Add, n)
-  else if n < 0. then (Sub, -.n)
-  else (Add, n)
+let linear_calc_op n = if n < 0. then (Sub, -.n) else (Add, n)
 
 let linear_terms_with unit_of_value calc =
   let scale factor terms =
@@ -2014,11 +1989,9 @@ let linear_length_calc calc =
       match terms with
       | [] -> Val Zero
       | { unit; value = n; _ } :: rest ->
-          let first_unit = unit in
-          let first_value = n in
           List.fold_left
             (fun acc { unit; value = n; _ } ->
-              let op, n = linear_calc_op first_unit first_value unit n in
+              let op, n = linear_calc_op n in
               Expr (acc, op, Val (length_of_calc_unit unit n)))
             (Val (length_of_calc_unit unit n))
             rest)
@@ -2132,11 +2105,9 @@ let linear_lp_calc calc =
       match terms with
       | [] -> Val (Length Zero)
       | { unit; value = n; _ } :: rest ->
-          let first_unit = unit in
-          let first_value = n in
           List.fold_left
             (fun acc { unit; value = n; _ } ->
-              let op, n = linear_calc_op first_unit first_value unit n in
+              let op, n = linear_calc_op n in
               Expr (acc, op, Val (lp_of_unit unit n)))
             (Val (lp_of_unit unit n))
             rest)

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -6813,10 +6813,40 @@ let multi_value_grammars () =
   neg_cursor read_declaration "border-top-left-radius: -1px";
   neg_cursor read_declaration "border-top-left-radius: 1px 2px 3px"
 
+(* ignore-test: a calc() sum spans every length property, not one. *)
+let test_calc_sum_shortest_spelling () =
+  (* CSS Values 4 (ED) sec. 10.13 Serialization sorts a sum's children before
+     serialising them, so the order the author wrote carries no meaning and
+     every order is the same value. Minify takes the shortest of them: a
+     leading negative term spends a byte on its own sign and another on the [+]
+     that joins the next, where a leading positive term spends neither. *)
+  (* [held] is the input itself: pp serialises what it was given, and picking
+     between two spellings of one value is the optimizer's job. *)
+  let shortest ~into input =
+    decl_optimizes ~prop:"width" ~held:input ~into input
+  in
+  shortest ~into:"calc(100vw - 10px)" "calc(-10px + 100vw)";
+  shortest ~into:"calc(100vw - 10px)" "calc(100vw - 10px)";
+  shortest ~into:"calc(50vmin - 2em)" "calc(-2em + 50vmin)";
+  shortest ~into:"calc(3px - 2em)" "calc(-2em + 3px)";
+  (* The join reads the same whichever unit leads: a negative term is [- 2em],
+     never [+ -2em]. *)
+  shortest ~into:"calc(3px - 2em)" "calc(3px - 2em)";
+  shortest ~into:"calc(3em - 2px)" "calc(3em - 2px)";
+  (* With no positive term to lead, the authored order stands: every spelling is
+     the same length. *)
+  shortest ~into:"calc(-1px - 2em)" "calc(-1px - 2em)";
+  shortest ~into:"calc(-2em - 1px)" "calc(-2em - 1px)";
+  (* A percentage leads what it is mixed with, and still only when positive. *)
+  shortest ~into:"calc(10% - 5vw)" "calc(-5vw + 10%)";
+  shortest ~into:"calc(5vw - 10%)" "calc(-10% + 5vw)"
+
 let declaration_tests =
   [
     (* Core declaration type testing *)
     test_case "declaration" `Quick test_declaration;
+    test_case "calc sum shortest spelling" `Quick
+      test_calc_sum_shortest_spelling;
     test_case "aspect-ratio has one node" `Quick aspect_ratio_has_one_node;
     test_case "caret auto has one node" `Quick caret_auto_has_one_node;
     test_case "radial gradient var has one node" `Quick


### PR DESCRIPTION
`calc(-10px + 100vw)` minified to itself, a byte longer than the `calc(100vw - 10px)` it is equal to, and `calc(3px - 2em)` grew a sign into `calc(3px + -2em)`. A sum's children may be sorted freely, so minify now leads with a positive term wherever there is one.