### PR TITLE
font-face: refuse a CSS-wide keyword in a descriptor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -824,6 +824,11 @@ to lose a whole rule over one bad piece. Both are gone.
   fractional or out-of-range number instead of truncating (#466, #472, #473,
   #477, #484, #496, #497, #499, #501, #538, #789, #793, #801)
 
+- A CSS-wide keyword in an `@font-face` descriptor is dropped, so
+  `font-weight: inherit` inside the rule no longer reaches output a browser
+  discards. CSS Fonts 4 sec. 4.6 omits them from the descriptor grammars
+  (#1115)
+
 ### Printing
 
 - `text-decoration`, `mask-border`, `animation` and `mask` no longer minify to

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2260,10 +2260,32 @@ let read_moz_document_condition r : moz_document_condition =
 
 (* Read a font-face descriptor *)
 (* Helper to read descriptor value after colon *)
+(* CSS Fonts 4 (ED) sec. 4.4 writes each font property descriptor's grammar out
+   in full, and sec. 4.6 gives the settings descriptors the corresponding
+   property's values "except that the CSS-wide keywords are omitted". No
+   descriptor grammar takes one. The shared property readers a descriptor
+   delegates to do take them, so the refusal belongs at this boundary, next to
+   the var() one. *)
+let refuse_css_wide_descriptor r =
+  let save = Cursor.save r in
+  (match Cursor.peek r with
+  | Some (Component.Preserved { kind = Token.Ident name; _ })
+    when Properties.is_css_wide_keyword name ->
+      Cursor.skip r;
+      Cursor.ws r;
+      let alone = Cursor.is_done r || Cursor.peek_semicolon r in
+      Cursor.restore r save;
+      if alone then
+        Cursor.err_invalid r
+          ("CSS-wide keyword in @font-face descriptor: " ^ name)
+  | _ -> ());
+  Cursor.restore r save
+
 let read_descriptor_value read_fn constructor r =
   Cursor.ws r;
   if not (Cursor.colon r) then Cursor.err_expected r "':'";
   Cursor.ws r;
+  refuse_css_wide_descriptor r;
   constructor (read_fn r)
 
 (* One item of a descriptor body: a descriptor, a stray [;] that CSS Syntax 3

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -725,6 +725,52 @@ let spec_fontface_descriptors () =
   check_stylesheet ~expected:"" "@font-face { src: url(font.woff2); }";
   check_stylesheet ~expected:"" "@font-face { font-family: Brand; }";
   check_stylesheet ~expected:"" "@font-face { font-display: swap; }";
+  (* CSS Fonts 4 (ED) sec. 4.4 writes the font property descriptors' grammars
+     out in full, and sec. 4.6 gives the settings descriptors the corresponding
+     property's values "except that the CSS-wide keywords are omitted". No
+     descriptor grammar takes one, so the declaration goes and the rest of the
+     rule stays. The descriptors below delegate to the property readers, which
+     take them legitimately in property position. *)
+  List.iter
+    (fun keyword ->
+      List.iter
+        (fun descriptor ->
+          check_stylesheet
+            ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+            (String.concat ""
+               [
+                 "@font-face { font-family: Brand; src: url(font.woff2); ";
+                 descriptor;
+                 ": ";
+                 keyword;
+                 "; }";
+               ]))
+        [
+          "font-style";
+          "font-weight";
+          "font-stretch";
+          "font-feature-settings";
+          "font-variation-settings";
+          "font-variant";
+          "font-display";
+          "font-tech";
+          "size-adjust";
+          "ascent-override";
+          "descent-override";
+          "line-gap-override";
+          "unicode-range";
+        ])
+    [ "inherit"; "initial"; "unset"; "revert"; "revert-layer" ];
+  (* sec. 4.2 and 4.3 make font-family and src required, so a CSS-wide keyword
+     in either costs the whole rule the way any other missing one does. *)
+  check_stylesheet ~expected:""
+    "@font-face { font-family: inherit; src: url(font.woff2); }";
+  check_stylesheet ~expected:"" "@font-face { font-family: Brand; src: unset; }";
+  (* A family name that merely starts with one is a name, not a keyword: sec.
+     2.1.1 asks only that a bare identifier not BE a CSS-wide keyword. *)
+  check_stylesheet
+    ~expected:"@font-face{font-family:inherited Sans;src:url(font.woff2)}"
+    "@font-face { font-family: inherited Sans; src: url(font.woff2); }";
   (* An unknown descriptor (e.g. Fontsource's non-standard font-named-instance)
      is dropped; the rest of the @font-face is kept, like browsers. *)
   check_stylesheet


### PR DESCRIPTION
`@font-face { font-weight: inherit }` was read and printed back, and a browser drops the declaration. CSS Fonts 4 sec. 4.6 gives the settings descriptors the corresponding property's values "except that the CSS-wide keywords are omitted", and sec. 4.4 writes the font property descriptors' grammars out without them; the descriptors delegate to the property readers, which take them because a property does.