### PR TITLE
font-face: read the auto font property descriptors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,12 @@ entry points both moved.
   comma-separated list, one entry per rule line. A caller writing one line
   passes a one-element list (#1024)
 
+- `Cascade.Stylesheet.font_face_descriptor` gains `Font_style_auto`,
+  `Font_weight_auto` and `Font_stretch_auto`, so `@font-face { font-style: auto }`
+  and its two siblings read where they were dropped. CSS Fonts 4 sec. 4.4 gives
+  all three descriptors `auto` as their initial value. Exhaustive visitors must
+  handle the three new arms (#1116)
+
 - `Cascade.Properties.flex_basis` gains `Dimension`, the arm
   `Cascade.Values.length` uses for a length whose authored spelling no typed
   constructor carries, so `flex-basis: 1e3px`, `flex-basis: 10.0px` and

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -183,7 +183,8 @@ let normalize_font_face_descriptor (desc : font_face_descriptor) :
   | Font_family _ | Src _ | Font_style _ | Font_style_range _ | Font_display _
   | Unicode_range _ | Font_variant _ | Font_feature_settings _
   | Font_variation_settings _ | Font_tech _ | Size_adjust _ | Ascent_override _
-  | Descent_override _ | Line_gap_override _ ->
+  | Descent_override _ | Line_gap_override _ | Font_style_auto
+  | Font_weight_auto | Font_stretch_auto ->
       desc
 
 (* [stmt] is returned unchanged when no descriptor moved: the factoring fixpoint

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1323,6 +1323,9 @@ let pp_font_face_descriptor : font_face_descriptor Pp.t =
           Pp.space ctx ();
           Properties.pp_font_weight ctx max_weight)
         (min_weight, max_weight)
+  | Font_style_auto -> pp_descriptor "font-style" Pp.string "auto"
+  | Font_weight_auto -> pp_descriptor "font-weight" Pp.string "auto"
+  | Font_stretch_auto -> pp_descriptor "font-stretch" Pp.string "auto"
   | Font_stretch stretch ->
       pp_descriptor "font-stretch" Properties.pp_font_stretch stretch
   | Font_stretch_range (min_stretch, max_stretch) ->
@@ -2348,32 +2351,44 @@ let read_descriptor_block normalize inner =
    endpoint is well defined, the user agent swapping the two endpoints for font
    matching. The swap is on the computed value, so the descriptor keeps the
    order it was written in. *)
+(* CSS Fonts 4 (ED) sec. 4.4 opens font-style, font-weight and font-width with
+   [auto] and gives it as their initial value, outside the [{1,2}] the rest of
+   the grammar allows: it is the whole value or it is not there. The properties
+   of the same name have no [auto], so the shared readers cannot answer for
+   it. *)
+let descriptor_is_auto value =
+  String.equal (String.lowercase_ascii (String.trim value)) "auto"
+
 let read_font_weight_descriptor r =
   read_descriptor_value Declaration.read_property_value
     (fun value ->
-      let c = Cursor.of_string value in
-      let first = Properties.read_font_weight c in
-      Cursor.ws c;
-      if Cursor.is_done c then Font_weight first
+      if descriptor_is_auto value then Font_weight_auto
       else
-        let second = Properties.read_font_weight c in
+        let c = Cursor.of_string value in
+        let first = Properties.read_font_weight c in
         Cursor.ws c;
-        Cursor.expect_eof c;
-        Font_weight_range (first, second))
+        if Cursor.is_done c then Font_weight first
+        else
+          let second = Properties.read_font_weight c in
+          Cursor.ws c;
+          Cursor.expect_eof c;
+          Font_weight_range (first, second))
     r
 
 let read_font_style_descriptor r =
   read_descriptor_value Declaration.read_property_value
     (fun value ->
-      let c = Cursor.of_string value in
-      let first = Properties.read_font_style c in
-      Cursor.ws c;
-      if Cursor.is_done c then Font_style first
+      if descriptor_is_auto value then Font_style_auto
       else
-        let second = Properties.read_font_style c in
+        let c = Cursor.of_string value in
+        let first = Properties.read_font_style c in
         Cursor.ws c;
-        Cursor.expect_eof c;
-        Font_style_range (first, second))
+        if Cursor.is_done c then Font_style first
+        else
+          let second = Properties.read_font_style c in
+          Cursor.ws c;
+          Cursor.expect_eof c;
+          Font_style_range (first, second))
     r
 
 let validate_nonempty_descriptor r name value =
@@ -2394,15 +2409,17 @@ let read_font_family_descriptor r =
 let read_font_stretch_descriptor r =
   read_descriptor_value Declaration.read_property_value
     (fun value ->
-      let c = Cursor.of_string value in
-      let first = Properties.read_font_stretch c in
-      Cursor.ws c;
-      if Cursor.is_done c then Font_stretch first
+      if descriptor_is_auto value then Font_stretch_auto
       else
-        let second = Properties.read_font_stretch c in
+        let c = Cursor.of_string value in
+        let first = Properties.read_font_stretch c in
         Cursor.ws c;
-        Cursor.expect_eof c;
-        Font_stretch_range (first, second))
+        if Cursor.is_done c then Font_stretch first
+        else
+          let second = Properties.read_font_stretch c in
+          Cursor.ws c;
+          Cursor.expect_eof c;
+          Font_stretch_range (first, second))
     r
 
 (* CSS Syntax 3 (ED) sec. 4.3.14: this descriptor's value is the one place in

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -308,13 +308,18 @@ and font_face_descriptor =
   | Font_style of Properties.font_style  (** normal, italic, oblique *)
   | Font_style_range of Properties.font_style * Properties.font_style
       (** variable font style range, e.g. [normal italic] *)
+  | Font_style_auto
+      (** CSS Fonts 4 sec. 4.4 [auto], the initial value: the face is asked for
+          its own range rather than told one. *)
   | Font_weight of Properties.font_weight  (** normal, bold, 100-900 *)
   | Font_weight_range of Properties.font_weight * Properties.font_weight
       (** variable font weight range, e.g. [100 900] *)
+  | Font_weight_auto  (** sec. 4.4 [auto], as {!Font_style_auto}. *)
   | Font_stretch of Properties.font_stretch
       (** normal, condensed, expanded, etc. *)
   | Font_stretch_range of Properties.font_stretch * Properties.font_stretch
       (** variable font stretch range, e.g. [50% 200%] *)
+  | Font_stretch_auto  (** sec. 4.4 [auto], as {!Font_style_auto}. *)
   | Font_display of Properties.font_display
       (** auto, block, swap, fallback, optional *)
   | Unicode_range of Properties.unicode_range list
@@ -389,3 +394,5 @@ let resolve_font_face_var ~src ~unicode_range ~font_family ~font_style
   | Line_gap_override value -> Some (Line_gap_override (metric_override value))
   | Font_tech value -> Some (Font_tech (font_tech value))
   | Size_adjust value -> Some (Size_adjust (size_adjust value))
+  (* A keyword holds no var() to resolve. *)
+  | Font_style_auto | Font_weight_auto | Font_stretch_auto -> None

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -761,6 +761,32 @@ let spec_fontface_descriptors () =
           "unicode-range";
         ])
     [ "inherit"; "initial"; "unset"; "revert"; "revert-layer" ];
+  (* CSS Fonts 4 (ED) sec. 4.4 opens each of the three font property descriptors
+     with [auto] and gives it as their initial value, so a variable font is
+     asked for its own range rather than told one. Chrome 153 keeps all
+     three. *)
+  check_stylesheet
+    ~expected:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-style:auto}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-style: auto; }";
+  check_stylesheet
+    ~expected:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-weight:auto}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-weight: auto; \
+     }";
+  check_stylesheet
+    ~expected:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-stretch:auto}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-stretch: \
+     auto; }";
+  (* [auto] is the whole value: sec. 4.4 puts it outside the {1,2} range, so it
+     pairs with nothing. *)
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-weight: auto \
+     400; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-style: normal \
+     auto; }";
   (* sec. 4.2 and 4.3 make font-family and src required, so a CSS-wide keyword
      in either costs the whole rule the way any other missing one does. *)
   check_stylesheet ~expected:""


### PR DESCRIPTION
`@font-face { font-style: auto }`, and the same for `font-weight` and `font-stretch`, were dropped. CSS Fonts 4 sec. 4.4 opens each of the three grammars with `auto` and gives it as their initial value, and Chrome 153 keeps all three, so a sheet using them read into cascade as a different sheet. This PR adds `Font_style_auto`, `Font_weight_auto` and `Font_stretch_auto` to `Cascade.Stylesheet.font_face_descriptor`.