### PR TITLE
font-face: narrow the style and weight descriptors to their grammar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,13 @@ entry points both moved.
   comma-separated list, one entry per rule line. A caller writing one line
   passes a one-element list (#1024)
 
+- `Cascade.Stylesheet.font_face_descriptor` loses `Font_style_range`, so
+  `@font-face { font-style: normal italic }` is dropped where it was read. CSS
+  Fonts 4 sec. 4.4 grants one style range only, a pair of `oblique` angles,
+  which `Cascade.Properties.font_style` carries in a single value. The same
+  section makes the weight descriptor absolute, so `font-weight: lighter` is
+  dropped too (#1117)
+
 - `Cascade.Stylesheet.font_face_descriptor` gains `Font_style_auto`,
   `Font_weight_auto` and `Font_stretch_auto`, so `@font-face { font-style: auto }`
   and its two siblings read where they were dropped. CSS Fonts 4 sec. 4.4 gives

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -180,11 +180,11 @@ let normalize_font_face_descriptor (desc : font_face_descriptor) :
       let high' = stretch high in
       if low' == low && high' == high then desc
       else Font_stretch_range (low', high')
-  | Font_family _ | Src _ | Font_style _ | Font_style_range _ | Font_display _
-  | Unicode_range _ | Font_variant _ | Font_feature_settings _
-  | Font_variation_settings _ | Font_tech _ | Size_adjust _ | Ascent_override _
-  | Descent_override _ | Line_gap_override _ | Font_style_auto
-  | Font_weight_auto | Font_stretch_auto ->
+  | Font_family _ | Src _ | Font_style _ | Font_display _ | Unicode_range _
+  | Font_variant _ | Font_feature_settings _ | Font_variation_settings _
+  | Font_tech _ | Size_adjust _ | Ascent_override _ | Descent_override _
+  | Line_gap_override _ | Font_style_auto | Font_weight_auto | Font_stretch_auto
+    ->
       desc
 
 (* [stmt] is returned unchanged when no descriptor moved: the factoring fixpoint

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1307,13 +1307,6 @@ let pp_font_face_descriptor : font_face_descriptor Pp.t =
   | Src value -> pp_descriptor "src" Properties.pp_font_src value
   | Font_style style ->
       pp_descriptor "font-style" Properties.pp_font_style style
-  | Font_style_range (min_style, max_style) ->
-      pp_descriptor "font-style"
-        (fun ctx (min_style, max_style) ->
-          Properties.pp_font_style ctx min_style;
-          Pp.space ctx ();
-          Properties.pp_font_style ctx max_style)
-        (min_style, max_style)
   | Font_weight weight ->
       pp_descriptor "font-weight" Properties.pp_font_weight weight
   | Font_weight_range (min_weight, max_weight) ->
@@ -2365,11 +2358,18 @@ let read_font_weight_descriptor r =
       if descriptor_is_auto value then Font_weight_auto
       else
         let c = Cursor.of_string value in
-        let first = Properties.read_font_weight c in
+        let absolute () =
+          match Properties.read_font_weight c with
+          | Bolder | Lighter ->
+              Cursor.err_invalid c
+                "relative weight in an @font-face font-weight descriptor"
+          | weight -> weight
+        in
+        let first = absolute () in
         Cursor.ws c;
         if Cursor.is_done c then Font_weight first
         else
-          let second = Properties.read_font_weight c in
+          let second = absolute () in
           Cursor.ws c;
           Cursor.expect_eof c;
           Font_weight_range (first, second))
@@ -2381,14 +2381,10 @@ let read_font_style_descriptor r =
       if descriptor_is_auto value then Font_style_auto
       else
         let c = Cursor.of_string value in
-        let first = Properties.read_font_style c in
+        let style = Properties.read_font_style c in
         Cursor.ws c;
-        if Cursor.is_done c then Font_style first
-        else
-          let second = Properties.read_font_style c in
-          Cursor.ws c;
-          Cursor.expect_eof c;
-          Font_style_range (first, second))
+        Cursor.expect_eof c;
+        Font_style style)
     r
 
 let validate_nonempty_descriptor r name value =

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -305,9 +305,10 @@ and page_margin_rule = {
 and font_face_descriptor =
   | Font_family of Properties.font_family list  (** Font family name *)
   | Src of Font_face.src  (** Font source (url(), local(), etc.) *)
-  | Font_style of Properties.font_style  (** normal, italic, oblique *)
-  | Font_style_range of Properties.font_style * Properties.font_style
-      (** variable font style range, e.g. [normal italic] *)
+  | Font_style of Properties.font_style
+      (** CSS Fonts 4 sec. 4.4 [normal | italic | oblique [<angle>{1,2}]?]. The
+          only range the descriptor grants is a pair of oblique angles, which
+          {!Properties.font_style} carries in one value. *)
   | Font_style_auto
       (** CSS Fonts 4 sec. 4.4 [auto], the initial value: the face is asked for
           its own range rather than told one. *)
@@ -375,8 +376,6 @@ let resolve_font_face_var ~src ~unicode_range ~font_family ~font_style
   | Unicode_range values -> Some (Unicode_range (unicode_range values))
   | Font_family values -> Some (Font_family (font_family values))
   | Font_style value -> Some (Font_style (font_style value))
-  | Font_style_range (low, high) ->
-      Some (Font_style_range (font_style low, font_style high))
   | Font_weight value -> Some (Font_weight (font_weight value))
   | Font_weight_range (low, high) ->
       Some (Font_weight_range (font_weight low, font_weight high))

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -687,12 +687,12 @@ let spec_fontface_descriptors () =
   check_stylesheet
     ~expected:
       "@font-face{font-family:Brand;src:local(Brand),url(brand.woff2)format(woff2)tech(variations);font-weight:400 \
-       700;font-style:normal italic;font-stretch:75% \
+       700;font-style:oblique 0deg 10deg;font-stretch:75% \
        125%;font-display:optional;unicode-range:U+25-FF}"
     "@font-face { font-family: Brand; src: local(\"Brand\"), \
      url(\"brand.woff2\") format(\"woff2\") tech(variations); font-weight: 400 \
-     700; font-style: normal italic; font-stretch: 75% 125%; font-display: \
-     optional; unicode-range: U+0025-00FF; }";
+     700; font-style: oblique 0deg 10deg; font-stretch: 75% 125%; \
+     font-display: optional; unicode-range: U+0025-00FF; }";
   check_stylesheet
     ~expected:
       "@font-face{font-family:MetricAdjusted;src:url(metric.woff2);size-adjust:92%;ascent-override:90%;descent-override:25%;line-gap-override:normal}"
@@ -787,6 +787,40 @@ let spec_fontface_descriptors () =
   check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
     "@font-face { font-family: Brand; src: url(font.woff2); font-style: normal \
      auto; }";
+  (* sec. 4.4 spells the font-style descriptor [auto | normal | italic | left |
+     right | oblique [<angle>{1,2}]?], so the only range it grants is a pair of
+     oblique angles. Two keywords are two values of a grammar that takes one,
+     and Chrome 153 drops them. *)
+  check_stylesheet
+    ~expected:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-style:oblique \
+       0deg 10deg}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-style: \
+     oblique 0deg 10deg; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-style: normal \
+     italic; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-style: italic \
+     oblique; }";
+  (* sec. 4.4 writes the weight descriptor [auto | <font-weight-absolute>{1,2}]
+     over [<font-weight-absolute> = normal | bold | <number [1,1000]>], so the
+     relative keywords the property takes are not values here: there is no
+     inherited weight for them to be relative to. *)
+  check_stylesheet
+    ~expected:
+      "@font-face{font-family:Brand;src:url(font.woff2);font-weight:400 700}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
+     normal bold; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
+     lighter; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
+     bolder; }";
+  check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"
+    "@font-face { font-family: Brand; src: url(font.woff2); font-weight: 400 \
+     lighter; }";
   (* sec. 4.2 and 4.3 make font-family and src required, so a CSS-wide keyword
      in either costs the whole rule the way any other missing one does. *)
   check_stylesheet ~expected:""

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -809,7 +809,8 @@ let spec_fontface_descriptors () =
      inherited weight for them to be relative to. *)
   check_stylesheet
     ~expected:
-      "@font-face{font-family:Brand;src:url(font.woff2);font-weight:400 700}"
+      "@font-face{font-family:Brand;src:url(font.woff2);font-weight:normal \
+       bold}"
     "@font-face { font-family: Brand; src: url(font.woff2); font-weight: \
      normal bold; }";
   check_stylesheet ~expected:"@font-face{font-family:Brand;src:url(font.woff2)}"


### PR DESCRIPTION
`@font-face { font-style: normal italic }` and `font-weight: lighter` were read and printed back, and Chrome 153 drops both. CSS Fonts 4 sec. 4.4 spells the style descriptor `auto | normal | italic | left | right | oblique [<angle>{1,2}]?`, whose only range is a pair of oblique angles, and the weight descriptor `auto | <font-weight-absolute>{1,2}` over `normal | bold | <number [1,1000]>`. The descriptors delegate to the property readers, which are wider. `Cascade.Stylesheet.font_face_descriptor` loses `Font_style_range`.