### PR TITLE
font-face: drop the font-tech descriptor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,13 @@ entry points both moved.
   comma-separated list, one entry per rule line. A caller writing one line
   passes a one-element list (#1024)
 
+- `Cascade.Stylesheet.font_face_descriptor` loses `Font_tech`, and
+  `Cascade.Stylesheet.font_tech_descriptor` and `read_font_tech_descriptor` go
+  with it, so `@font-face { font-tech: variations }` is dropped where it was
+  read. CSS Fonts 4 sec. 4 lists the descriptors and no `font-tech` is among
+  them: `<font-tech>` is the keyword sec. 11.1 defines for `tech()` inside
+  `src` and for `font-tech()` in `@supports`, both of which still read (#1118)
+
 - `Cascade.Stylesheet.font_face_descriptor` loses `Font_style_range`, so
   `@font-face { font-style: normal italic }` is dropped where it was read. CSS
   Fonts 4 sec. 4.4 grants one style range only, a pair of `oblique` angles,

--- a/lib/inline.ml
+++ b/lib/inline.ml
@@ -787,11 +787,6 @@ let simplify_metric_override_descriptor visible =
     ~as_var:(function Font_face.Var v -> Some v | _ -> Option.None)
     ~of_var:(fun v -> (Font_face.Var v : Font_face.metric_override))
 
-let simplify_font_tech_descriptor visible =
-  simplify_typed_var visible ~read:read_font_tech_descriptor
-    ~as_var:(function Var v -> Some v | Tech _ -> Option.None)
-    ~of_var:(fun v -> (Var v : font_tech_descriptor))
-
 let simplify_size_adjust_descriptor visible =
   simplify_typed_var visible ~read:Font_face.read_size_adjust
     ~as_var:(function
@@ -817,7 +812,6 @@ let simplify_font_face_descriptor visible descriptor =
       ~font_variation_settings:
         (simplify_font_variation_settings_descriptor visible)
       ~metric_override:(simplify_metric_override_descriptor visible)
-      ~font_tech:(simplify_font_tech_descriptor visible)
       ~size_adjust:(simplify_size_adjust_descriptor visible)
       descriptor
   with

--- a/lib/optimize.ml
+++ b/lib/optimize.ml
@@ -182,9 +182,8 @@ let normalize_font_face_descriptor (desc : font_face_descriptor) :
       else Font_stretch_range (low', high')
   | Font_family _ | Src _ | Font_style _ | Font_display _ | Unicode_range _
   | Font_variant _ | Font_feature_settings _ | Font_variation_settings _
-  | Font_tech _ | Size_adjust _ | Ascent_override _ | Descent_override _
-  | Line_gap_override _ | Font_style_auto | Font_weight_auto | Font_stretch_auto
-    ->
+  | Size_adjust _ | Ascent_override _ | Descent_override _ | Line_gap_override _
+  | Font_style_auto | Font_weight_auto | Font_stretch_auto ->
       desc
 
 (* [stmt] is returned unchanged when no descriptor moved: the factoring fixpoint

--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -1279,10 +1279,6 @@ let pp_font_variant_descriptor_value ctx = function
   | Numeric value -> Properties.pp_font_variant_numeric_token ctx value
   | East_asian value -> Properties.pp_east_asian_feature ctx value
 
-let rec pp_font_tech_descriptor ctx : font_tech_descriptor -> unit = function
-  | Tech tech -> Pp.string ctx (Supports.string_of_font_tech tech)
-  | Var var -> Values.pp_var pp_font_tech_descriptor ctx var
-
 let rec pp_font_variant_descriptor ctx = function
   | Normal -> Pp.string ctx "normal"
   | None -> Pp.string ctx "none"
@@ -1342,7 +1338,6 @@ let pp_font_face_descriptor : font_face_descriptor Pp.t =
   | Font_variation_settings value ->
       pp_descriptor "font-variation-settings"
         Properties.pp_font_variation_settings value
-  | Font_tech value -> pp_descriptor "font-tech" pp_font_tech_descriptor value
   | Size_adjust value ->
       pp_descriptor "size-adjust" Font_face.pp_size_adjust value
   | Ascent_override value ->
@@ -2532,19 +2527,6 @@ let read_font_variant_descriptor_value r =
   | Some value -> value
   | None -> Cursor.err_invalid r ("font-variant descriptor value: " ^ ident)
 
-(* CSS Fonts 4 sec. 11.1 spells [<font-tech>] as a keyword, so an unknown ident
-   is a parse error rather than text to carry through. *)
-let rec read_font_tech_descriptor r : font_tech_descriptor =
-  match Cursor.peek r with
-  | Some (Component.Func { node = { name; _ }; _ })
-    when String.lowercase_ascii name = "var" ->
-      Var (Values.read_var read_font_tech_descriptor r)
-  | Some _ | Option.None -> (
-      let ident = Cursor.ident r in
-      match Supports.font_tech_of_string (String.lowercase_ascii ident) with
-      | Some tech -> Tech tech
-      | Option.None -> Cursor.err_invalid r ("font-tech descriptor: " ^ ident))
-
 let read_font_variant_keywords r : font_variant_descriptor =
   let at_value_end () = Cursor.is_done r || Cursor.peek_semicolon r in
   let snap = Cursor.save r in
@@ -2597,8 +2579,6 @@ let read_font_face_desc name r =
       read_descriptor_value Properties.read_font_variation_settings
         (fun v -> Font_variation_settings v)
         r
-  | "font-tech" ->
-      read_descriptor_value read_font_tech_descriptor (fun v -> Font_tech v) r
   | "size-adjust" ->
       read_descriptor_value Font_face.read_size_adjust
         (fun v -> Size_adjust v)
@@ -2645,8 +2625,7 @@ let descriptor_resolves_var name =
            ~font_family:Fun.id ~font_style:Fun.id ~font_weight:Fun.id
            ~font_stretch:Fun.id ~font_display:Fun.id ~font_variant:Fun.id
            ~font_feature_settings:Fun.id ~font_variation_settings:Fun.id
-           ~metric_override:Fun.id ~font_tech:Fun.id ~size_adjust:Fun.id
-           descriptor)
+           ~metric_override:Fun.id ~size_adjust:Fun.id descriptor)
   | exception Error.Parse_error _ -> false
 
 (* CSS Syntax 3 (ED) sec. 5.5.5 gives an [<at-keyword-token>] to "consume an

--- a/lib/stylesheet.mli
+++ b/lib/stylesheet.mli
@@ -594,11 +594,6 @@ val pp_import_rule : import_rule Pp.t
 val read_import_rule : Cursor.t -> import_rule
 (** [read_import_rule r] parses an import rule. *)
 
-val read_font_tech_descriptor : Cursor.t -> font_tech_descriptor
-(** [read_font_tech_descriptor r] parses the [font-tech] descriptor of an
-    [\@font-face] rule: one [<font-tech>] keyword (CSS Fonts 4 sec. 11.1), or a
-    [var()] reference the inline pass resolves. *)
-
 val pp_layer_name : layer_name Pp.t
 (** [pp_layer_name] prints a [<layer-name>]: each ident with the escapes that
     read it back (CSS Syntax 3 (ED) sec. 2.1), joined by the [.] separators of

--- a/lib/stylesheet_intf.ml
+++ b/lib/stylesheet_intf.ml
@@ -282,13 +282,6 @@ and font_variant_descriptor =
   | Values of font_variant_descriptor_value list
   | Var of font_variant_descriptor Values.var
 
-(** CSS Fonts 4 sec. 11.1 [<font-tech>], shared with [font-tech()] in
-    [\@supports]. No descriptor grammar takes a [var()] (sec. 4.1), so [Var]
-    parks a reference until the inline pass substitutes it. *)
-and font_tech_descriptor =
-  | Tech of Supports.font_tech
-  | Var of font_tech_descriptor Values.var
-
 and font_variant_descriptor_value =
   | Ligature of Properties.font_variant_ligature
   | Caps of Properties.font_variant_caps
@@ -330,7 +323,6 @@ and font_face_descriptor =
       (** OpenType feature settings *)
   | Font_variation_settings of Properties.font_variation_settings
       (** Variable font settings *)
-  | Font_tech of font_tech_descriptor  (** [font-tech] descriptor *)
   | Size_adjust of Font_face.size_adjust  (** Size adjustment percentage *)
   | Ascent_override of Font_face.metric_override  (** Ascent metric override *)
   | Descent_override of Font_face.metric_override
@@ -370,7 +362,7 @@ let equal (a : stylesheet) b = a = b
     so both sides have to answer for it. *)
 let resolve_font_face_var ~src ~unicode_range ~font_family ~font_style
     ~font_weight ~font_stretch ~font_display ~font_variant
-    ~font_feature_settings ~font_variation_settings ~metric_override ~font_tech
+    ~font_feature_settings ~font_variation_settings ~metric_override
     ~size_adjust = function
   | Src value -> Some (Src (src value))
   | Unicode_range values -> Some (Unicode_range (unicode_range values))
@@ -391,7 +383,6 @@ let resolve_font_face_var ~src ~unicode_range ~font_family ~font_style
   | Ascent_override value -> Some (Ascent_override (metric_override value))
   | Descent_override value -> Some (Descent_override (metric_override value))
   | Line_gap_override value -> Some (Line_gap_override (metric_override value))
-  | Font_tech value -> Some (Font_tech (font_tech value))
   | Size_adjust value -> Some (Size_adjust (size_adjust value))
   (* A keyword holds no var() to resolve. *)
   | Font_style_auto | Font_weight_auto | Font_stretch_auto -> None

--- a/test/test_font_face.ml
+++ b/test/test_font_face.ml
@@ -429,7 +429,6 @@ let spec_fontface_var_descriptor_kept () =
         "ascent-override";
         "descent-override";
         "line-gap-override";
-        "font-tech";
         "size-adjust";
       ]
   with

--- a/test/test_inline.ml
+++ b/test/test_inline.ml
@@ -39,7 +39,6 @@ let font_face_descriptors =
     ("font-variant", "normal");
     ("font-feature-settings", "normal");
     ("font-variation-settings", "normal");
-    ("font-tech", "variations");
     ("size-adjust", "100%");
     ("ascent-override", "normal");
     ("descent-override", "normal");
@@ -100,7 +99,6 @@ let test_inline_font_face_var_descriptors () =
       "font-variant";
       "font-feature-settings";
       "font-variation-settings";
-      "font-tech";
       "size-adjust";
       "ascent-override";
       "descent-override";
@@ -146,7 +144,6 @@ let test_inline_font_face_var_resolves () =
       ("ascent-override", "normal");
       ("descent-override", "90%");
       ("line-gap-override", "10%");
-      ("font-tech", "variations");
       ("size-adjust", "100%");
     ]
 

--- a/test/test_stylesheet.ml
+++ b/test/test_stylesheet.ml
@@ -753,7 +753,6 @@ let spec_fontface_descriptors () =
           "font-variation-settings";
           "font-variant";
           "font-display";
-          "font-tech";
           "size-adjust";
           "ascent-override";
           "descent-override";
@@ -3985,9 +3984,14 @@ let spec_current_at_rules () =
        --brand{font-family:Brand;base-palette:1;override-colors:0 red}"
     "@font-palette-values --brand { font-family: Brand; base-palette: 1; \
      override-colors: 0 red; }";
+  (* CSS Fonts 4 (ED) sec. 4 lists the @font-face descriptors and [font-tech] is
+     not one: [<font-tech>] is the keyword sec. 11.1 defines for [tech()] inside
+     [src] and for [font-tech()] in @supports. Chrome 153 drops the declaration,
+     and BCD carries a css.at-rules.font-face key for every real descriptor and
+     none for this one. *)
   check_stylesheet
     ~expected:
-      "@font-face{font-family:ColorFont;src:url(color.woff2)tech(color-COLRv1);font-tech:color-COLRv1}"
+      "@font-face{font-family:ColorFont;src:url(color.woff2)tech(color-COLRv1)}"
     "@font-face { font-family: ColorFont; src: url(color.woff2) \
      tech(color-COLRv1); font-tech: color-COLRv1; }";
   check_stylesheet ~expected:"@view-transition{navigation:auto}"


### PR DESCRIPTION
`@font-face { font-tech: variations }` was read and printed back. No CSS Fonts section defines a `font-tech` descriptor, BCD carries a `css.at-rules.font-face` key for every real one and none for this, and Chrome 153 drops the declaration, so cascade was emitting CSS nothing accepts. The `<font-tech>` keyword itself stays where sec. 11.1 puts it: `tech()` inside `src`, and `font-tech()` in `@supports`.