### PR TITLE
test: ask a browser what the @font-face descriptors take

### DIFF
--- a/lib/stylesheet.ml
+++ b/lib/stylesheet.ml
@@ -2557,6 +2557,7 @@ let rec read_font_variant_descriptor r : font_variant_descriptor =
 
 let read_font_face_desc name r =
   match name with
+  (* FONT_FACE_DESCRIPTOR_START - Used by test/spec/browser *)
   | "font-family" -> read_font_family_descriptor r
   | "src" -> read_descriptor_value Font_face.read_src (fun v -> Src v) r
   | "font-style" -> read_font_style_descriptor r
@@ -2595,6 +2596,7 @@ let read_font_face_desc name r =
       read_descriptor_value Font_face.read_metric_override
         (fun v -> Line_gap_override v)
         r
+  (* FONT_FACE_DESCRIPTOR_END - Used by test/spec/browser *)
   | _ -> Cursor.err_invalid r ("unknown font-face descriptor: " ^ name)
 
 let rec components_upto_semicolon = function

--- a/test/spec/browser/descriptor_set.ml
+++ b/test/spec/browser/descriptor_set.ml
@@ -1,0 +1,573 @@
+(* Does cascade read exactly the @font-face descriptors a browser reads?
+
+   The accept-set differential next door cannot ask this. A descriptor is not a
+   property: CSS.supports takes a property name, el.style.setProperty fills an
+   inline block, and both refuse [src] and [unicode-range] outright. So the
+   @font-face grammar, the one place a stylesheet names a font file, had no
+   browser oracle at all while every property around it had two.
+
+   What CSSOM exposes instead is the parsed rule. descriptors.js puts each value
+   to two entry points into the same parser, insertRule into a <style> element's
+   sheet and replaceSync on a constructed one, and reads back whether the rule
+   still spells the descriptor. A value they disagree about is a fact about the
+   browser, so it is reported rather than decided.
+
+   Three populations, and each answers a different question.
+
+   The manifest positives and negatives ask whether the spec-derived vectors in
+   Descriptor_grammar are true of a browser. Nothing in that manifest is derived
+   from cascade, but nothing checked it against anything either, and a negative
+   is where that hides: cascade rejects the value, the row calls it invalid, the
+   test passes, and a reader limitation reads as a grammar rule.
+
+   The generated values ask the accept-set question, the one the manifest
+   cannot: over a population nobody wrote by hand, does cascade keep exactly
+   what the browser keeps. A value the browser takes and cascade drops means
+   cascade cannot read a sheet the browser can. A value cascade keeps and the
+   browser drops means cascade's model of the page has a declaration the page
+   does not, so a diff can certify a difference that does not exist.
+
+   And the descriptors themselves: every descriptor cascade models must have a
+   row, or this run says nothing about it beyond what the generator happened to
+   draw.
+
+   A descriptor the browser has not shipped cannot arbitrate anything, which is
+   a fact about browsers rather than about this run, so it is looked up in
+   Cascade.Support under the BCD key web-features carries. A descriptor the
+   dataset says this build ships, that then takes none of the manifest's
+   positives, is a failure and not an excuse.
+
+   Both directions are exercised rather than quiet. Making the CSS-wide refusal
+   in read_descriptor_value a no-op reports 25 values cascade would keep and the
+   browser drops; making unicode-range refuse everything reports 5 the browser
+   keeps and cascade would drop.
+
+   Skips cleanly, with status 0, when node or a headless Chromium is missing.
+   CASCADE_NO_BROWSER silences the run, and a silenced gate is not a pass: only
+   the value that says so exits 0.
+
+   Reproducing one finding:
+
+   dune exec test/spec/browser/descriptor_set.exe -- --only src --seed 0 *)
+
+open Cascade
+module Grammar = Cascade_spec_inventory.Descriptor_grammar
+
+let ( // ) = Filename.concat
+
+(* The value generator lives in the inventory library, so this harness draws the
+   same population the property sweeps do. *)
+let values_for = Cascade_spec_inventory.Value_gen.values_for
+
+(* ===== The population ===== *)
+
+let modelled = List.sort_uniq String.compare Font_face_descriptors.all
+
+(* A rename in the library, or a generator that stopped generating, would
+   otherwise turn this run into a green one that asks nothing. *)
+let minimum_descriptors = 10
+let minimum_values = 200
+let minimum_arbitrated = 100
+
+(* CSS Fonts 4 sec. 4.2 and 4.3 make font-family and src required: a @font-face
+   missing either is invalid as a whole, so every sheet carries both and the
+   descriptor under test takes over its own slot. *)
+let base_family = "Brand"
+let base_src = "url(brand.woff2)"
+
+let sheet ~descriptor ~value =
+  let family, src, extra =
+    match descriptor with
+    | "font-family" -> (value, base_src, None)
+    | "src" -> (base_family, value, None)
+    | _ -> (base_family, base_src, Some (descriptor, value))
+  in
+  String.concat ""
+    ([ "@font-face{font-family:"; family; ";src:"; src ]
+    @ (match extra with None -> [] | Some (name, v) -> [ ";"; name; ":"; v ])
+    @ [ "}" ])
+
+type kind = Positive | Negative | Generated
+
+type job = {
+  id : string;
+  descriptor : string;
+  value : string;
+  kind : kind;
+  sheet : string;
+}
+
+(* CSS Variables 1 sec. 3 substitutes var() in a property value and a descriptor
+   is not a property, so a browser drops any descriptor holding one. cascade
+   parks the reference for the inline pass to substitute at build time, which is
+   a different claim from "this is a value the browser reads", and test_inline
+   is where that claim is checked. Drawing them here would ask this harness a
+   question it is not the oracle for. *)
+let drawable value =
+  let rec at i =
+    i + 4 <= String.length value
+    && (String.equal (String.sub value i 4) "var(" || at (i + 1))
+  in
+  not (at 0)
+
+let jobs ~seed ~only =
+  let n = ref 0 in
+  let fresh () =
+    incr n;
+    string_of_int !n
+  in
+  let job descriptor kind value =
+    { id = fresh (); descriptor; value; kind; sheet = sheet ~descriptor ~value }
+  in
+  List.concat_map
+    (fun descriptor ->
+      if (not (String.equal only "")) && not (String.equal only descriptor) then
+        []
+      else
+        let manifest =
+          match Grammar.row_for descriptor with
+          | None -> []
+          | Some row ->
+              List.map (job descriptor Positive) row.positives
+              @ List.map (job descriptor Negative) row.negatives
+        in
+        (* The generator draws from the manifest too, so a value the row already
+           decides would otherwise arrive twice and be judged by both rules at
+           once. *)
+        let decided value =
+          match Grammar.row_for descriptor with
+          | None -> false
+          | Some row ->
+              List.exists (String.equal value) row.positives
+              || List.exists (String.equal value) row.negatives
+        in
+        manifest
+        @ List.map (job descriptor Generated)
+            (List.filter
+               (fun v -> drawable v && not (decided v))
+               (values_for ~seed descriptor)))
+    modelled
+
+(* ===== The reader ===== *)
+
+(* Accepted means the reader kept the rule and said nothing against it. A
+   warning is the parser reporting that it dropped or recovered something, so it
+   is not an acceptance however much of the sheet survived. *)
+let cascade_accepts job =
+  match Css.of_string job.sheet with
+  | exception Error.Parse_error _ -> false
+  | exception Reader.Parse_error _ -> false
+  | Error _ -> false
+  | Ok { warnings = _ :: _; _ } -> false
+  | Ok { stylesheet; warnings = []; _ } ->
+      not (List.is_empty (Css.statements stylesheet))
+
+(* ===== The driver ===== *)
+
+type verdict = { parsed : bool; constructed : bool; error : string option }
+
+let read_lines ic =
+  let rec loop acc =
+    match input_line ic with
+    | line -> loop (line :: acc)
+    | exception End_of_file -> List.rev acc
+  in
+  loop []
+
+let run_driver ~node ~chrome ~script ~jobs ~work =
+  let errors = work // "descriptors.err" in
+  let cmd =
+    String.concat " "
+      [
+        String.concat "" [ "CHROME="; Filename.quote chrome ];
+        Filename.quote node;
+        Filename.quote script;
+        Filename.quote jobs;
+        Filename.quote work;
+        String.concat "" [ "2>"; Filename.quote errors ];
+      ]
+  in
+  let ic = Unix.open_process_in cmd in
+  let lines = read_lines ic in
+  match Unix.close_process_in ic with
+  | Unix.WEXITED 0 -> Ok lines
+  | _ ->
+      let ic = open_in errors in
+      let text = read_lines ic in
+      close_in ic;
+      Error (String.concat "\n" text)
+
+let parse_driver_output lines =
+  let table = Hashtbl.create 4096 in
+  List.iter
+    (fun line ->
+      match String.split_on_char '\t' line with
+      | [ "v"; id; p; o ] ->
+          Hashtbl.replace table id
+            {
+              parsed = String.equal p "1";
+              constructed = String.equal o "1";
+              error = None;
+            }
+      | "x" :: id :: rest ->
+          Hashtbl.replace table id
+            {
+              parsed = false;
+              constructed = false;
+              error = Some (String.concat "\t" rest);
+            }
+      | _ -> ())
+    lines;
+  table
+
+(* ===== Which browser this run answers for ===== *)
+
+(* The support dataset is keyed by version, so the harness says which build it
+   measured rather than assuming the one the default contract names. *)
+let chrome_version chrome =
+  let ic =
+    Unix.open_process_in
+      (String.concat " " [ Filename.quote chrome; "--version"; "2>/dev/null" ])
+  in
+  let lines = read_lines ic in
+  ignore (Unix.close_process_in ic);
+  let leading_int s =
+    let n = String.length s in
+    let rec upto i =
+      if i < n && s.[i] >= '0' && s.[i] <= '9' then upto (i + 1) else i
+    in
+    let stop = upto 0 in
+    if stop = 0 then None else int_of_string_opt (String.sub s 0 stop)
+  in
+  let of_word w =
+    match String.split_on_char '.' w with
+    | major :: minor :: _ -> (
+        match (leading_int major, leading_int minor) with
+        | Some a, Some b -> Some (a, b)
+        | _ -> None)
+    | _ -> None
+  in
+  List.fold_left
+    (fun found line ->
+      match found with
+      | Some _ -> found
+      | None ->
+          List.fold_left
+            (fun found word ->
+              match found with Some _ -> found | None -> of_word word)
+            None
+            (String.split_on_char ' ' line))
+    None lines
+
+(* ===== Reporting ===== *)
+
+let failures = ref 0
+let arbitrated = ref 0
+let splits = ref 0
+let behind = ref 0
+let lenient = ref 0
+
+let fail line =
+  incr failures;
+  Fmt.pr "FAIL %s@." line
+
+let describe job = String.concat "" [ job.descriptor; ": "; job.value ]
+
+(* ===== Skipping ===== *)
+
+(* Silencing a gate is not the same as passing it, so only the value that says
+   the run checks nothing exits 0. A machine with no browser still skips: there
+   is nothing there to silence. *)
+let acknowledged = "unchecked"
+
+let check_suppression () =
+  match Browser.getenv "CASCADE_NO_BROWSER" with
+  | None -> ()
+  | Some v when String.equal v acknowledged ->
+      Browser.skip "descriptor_set"
+        (String.concat ""
+           [
+             "CASCADE_NO_BROWSER="; acknowledged; ", so this run checks nothing";
+           ])
+  | Some v ->
+      prerr_endline
+        (String.concat ""
+           [
+             "FAIL: descriptor_set is suppressed by CASCADE_NO_BROWSER=";
+             v;
+             "; a gate that did not run is not a pass. Set CASCADE_NO_BROWSER=";
+             acknowledged;
+             " to exit 0 and say so.";
+           ]);
+      exit 1
+
+(* ===== Main ===== *)
+
+let write_jobs file jobs =
+  let oc = open_out file in
+  output_string oc
+    (Json.to_string
+       (Json.Arr
+          (List.map
+             (fun j ->
+               Json.Obj
+                 [
+                   ("id", Json.Str j.id);
+                   ("descriptor", Json.Str j.descriptor);
+                   ("value", Json.Str j.value);
+                   ("sheet", Json.Str j.sheet);
+                 ])
+             jobs)));
+  close_out oc
+
+let arg name default =
+  let rec loop = function
+    | a :: v :: _ when String.equal a name -> v
+    | _ :: rest -> loop rest
+    | [] -> default
+  in
+  loop (Array.to_list Sys.argv)
+
+let support_key descriptor =
+  String.concat "" [ "css.at-rules.font-face."; descriptor ]
+
+(* A descriptor this browser takes no positive of cannot arbitrate a single
+   value of it. Whether that is the browser being behind is a fact about
+   browsers, so it is looked up rather than asserted here. *)
+let report_unshipped ~version descriptor =
+  let key = support_key descriptor in
+  match Support.engine_implements Support.Chrome version key with
+  | Some true ->
+      fail
+        (String.concat ""
+           [
+             descriptor;
+             ": the browser took none of the manifest's positives, and ";
+             key;
+             " says this build shipped it";
+           ])
+  | Some false ->
+      Fmt.pr "  behind: %s (%s says this build has not shipped it)@." descriptor
+        key
+  | None ->
+      fail
+        (String.concat ""
+           [
+             descriptor;
+             ": the browser took none of the manifest's positives and ";
+             key;
+             " is not in the support dataset, so nothing says whether the \
+              browser is behind or the row is wrong; measure it into \
+              Cascade.Support";
+           ])
+
+let () =
+  check_suppression ();
+  let seed = int_of_string (arg "--seed" "0") in
+  let only = arg "--only" "" in
+  let selected d = String.equal only "" || String.equal only d in
+  let node =
+    match Browser.node_binary () with
+    | Some n -> n
+    | None -> Browser.skip "descriptor_set" "no node"
+  in
+  let chrome =
+    match Browser.chrome_binary () with
+    | Some c -> c
+    | None -> Browser.skip "descriptor_set" "no headless browser"
+  in
+  let version =
+    match chrome_version chrome with
+    | Some v -> v
+    | None ->
+        prerr_endline
+          "descriptor_set: the browser did not report a version, so no support \
+           fact can be keyed to this run";
+        exit 1
+  in
+  if List.length modelled < minimum_descriptors then (
+    prerr_endline
+      (String.concat ""
+         [
+           "descriptor_set: the population is ";
+           string_of_int (List.length modelled);
+           " descriptor(s), fewer than the ";
+           string_of_int minimum_descriptors;
+           " expected; the FONT_FACE_DESCRIPTOR markers moved";
+         ]);
+    exit 1);
+  let jobs = jobs ~seed ~only in
+  if String.equal only "" && List.length jobs < minimum_values then (
+    prerr_endline
+      (String.concat ""
+         [
+           "descriptor_set: the population is ";
+           string_of_int (List.length jobs);
+           " value(s), fewer than the ";
+           string_of_int minimum_values;
+           " expected; the generator stopped generating";
+         ]);
+    exit 1);
+  let script_dir = Filename.dirname Sys.executable_name in
+  let work = Filename.get_temp_dir_name () // "cascade-descriptor-set" in
+  (try Unix.mkdir work 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
+  let jobs_file = work // "jobs.json" in
+  write_jobs jobs_file jobs;
+  let started = Unix.gettimeofday () in
+  let lines =
+    match
+      run_driver ~node ~chrome
+        ~script:(script_dir // "descriptors.js")
+        ~jobs:jobs_file ~work
+    with
+    | Ok lines -> lines
+    | Error err ->
+        prerr_endline
+          (String.concat ""
+             [ "descriptor_set: the browser driver failed:\n"; err ]);
+        exit 1
+  in
+  let elapsed = Unix.gettimeofday () -. started in
+  let table = parse_driver_output lines in
+  (* Counted per descriptor so a descriptor the browser has not shipped is one
+     line rather than one per value of it. *)
+  let positives_taken = Hashtbl.create 32 in
+  let bump t k =
+    Hashtbl.replace t k (1 + Option.value ~default:0 (Hashtbl.find_opt t k))
+  in
+  let pending = ref [] in
+  List.iter
+    (fun job ->
+      match Hashtbl.find_opt table job.id with
+      | None ->
+          fail
+            (String.concat ""
+               [ describe job; ": the browser did not answer for this value" ])
+      | Some { error = Some e; _ } ->
+          fail (String.concat "" [ describe job; ": the browser raised: "; e ])
+      | Some { parsed; constructed; error = None } ->
+          if not (Bool.equal parsed constructed) then (
+            incr splits;
+            fail
+              (String.concat ""
+                 [
+                   describe job;
+                   ": insertRule and replaceSync disagree, so the browser \
+                    cannot arbitrate this value";
+                 ]))
+          else begin
+            (match job.kind with
+            | Positive when parsed -> bump positives_taken job.descriptor
+            | Positive | Negative | Generated -> ());
+            let reads = cascade_accepts job in
+            match (job.kind, reads, parsed) with
+            (* The row decides. cascade agreeing with it is the answer, and the
+               browser is the second opinion whose divergence is reported. *)
+            | Positive, true, true | Negative, false, false -> incr arbitrated
+            | Positive, true, false ->
+                incr behind;
+                Fmt.pr
+                  "  behind: %s (the row grants it, the browser drops it)@."
+                  (describe job)
+            | Negative, false, true ->
+                incr lenient;
+                Fmt.pr
+                  "  lenient: %s (the row refuses it, the browser takes it)@."
+                  (describe job)
+            | Positive, false, _ ->
+                fail
+                  (String.concat ""
+                     [
+                       describe job;
+                       ": the row grants this value and cascade drops it";
+                     ])
+            | Negative, true, _ ->
+                fail
+                  (String.concat ""
+                     [
+                       describe job;
+                       ": the row refuses this value and cascade reads it";
+                     ])
+            (* No row covers a generated value, so the browser is the only
+               oracle there is, and closing a finding means writing the value
+               into the row with the section that decides it. *)
+            | Generated, r, p when Bool.equal r p -> incr arbitrated
+            | Generated, _, _ -> pending := (job, reads) :: !pending
+          end)
+    jobs;
+  (* A descriptor the browser has no answer for explains every disagreement
+     under it, so it is reported once and its values are not reported again. *)
+  let unshipped = Hashtbl.create 8 in
+  List.iter
+    (fun descriptor ->
+      match Grammar.row_for descriptor with
+      | None -> (
+          (* A descriptor with no current grammar is not an oversight when the
+             support dataset carries it: web-features records what browsers
+             ship, and a removed-but-shipped descriptor is exactly that. One
+             that neither a section nor the dataset knows is cascade's
+             invention. *)
+          match
+            Support.implemented Support.evergreen (support_key descriptor)
+          with
+          | Some _ ->
+              Fmt.pr
+                "  no row: %s (no current section grants it, and %s records it \
+                 as shipped)@."
+                descriptor (support_key descriptor)
+          | None ->
+              fail
+                (String.concat ""
+                   [
+                     descriptor;
+                     ": cascade models this descriptor, no Descriptor_grammar \
+                      row grants it, and ";
+                     support_key descriptor;
+                     " is not in the support dataset either";
+                   ]))
+      | Some _ ->
+          if
+            Option.value ~default:0
+              (Hashtbl.find_opt positives_taken descriptor)
+            = 0
+          then (
+            Hashtbl.replace unshipped descriptor ();
+            report_unshipped ~version descriptor))
+    (List.filter selected modelled);
+  List.iter
+    (fun (job, reads) ->
+      if not (Hashtbl.mem unshipped job.descriptor) then
+        fail
+          (String.concat ""
+             [
+               describe job;
+               (if reads then
+                  ": cascade reads it and the browser drops it, so a diff over \
+                   this sheet certifies a declaration the page does not have"
+                else
+                  ": the browser reads it and cascade drops it, so every \
+                   verdict cascade gives over this sheet is unproven");
+             ]))
+    (List.rev !pending);
+  let major, minor = version in
+  Fmt.pr
+    "descriptor_set: %d value(s) over %d descriptor(s), Chrome %d.%d, %.1fs@."
+    (List.length jobs)
+    (List.length (List.filter selected modelled))
+    major minor elapsed;
+  Fmt.pr
+    "  arbitrated: %d, browser behind: %d, browser lenient: %d, splits: %d, \
+     failures: %d@."
+    !arbitrated !behind !lenient !splits !failures;
+  (* A run that agrees about nothing is not a clean run, it is a blind one. *)
+  if String.equal only "" && !arbitrated < minimum_arbitrated then
+    fail
+      (String.concat ""
+         [
+           "only ";
+           string_of_int !arbitrated;
+           " value(s) were arbitrated, fewer than the ";
+           string_of_int minimum_arbitrated;
+           " expected: the run asked the browser almost nothing";
+         ]);
+  if !failures > 0 then exit 1

--- a/test/spec/browser/descriptors.js
+++ b/test/spec/browser/descriptors.js
@@ -1,0 +1,128 @@
+// Ask a headless browser whether each @font-face descriptor value is valid CSS.
+//
+//   node descriptors.js JOBS.json WORKDIR
+//
+// JOBS.json is written by descriptor_set.exe: an array of {id, sheet,
+// descriptor}. A descriptor is not a property, so neither oracle the property
+// harnesses use can answer here: CSS.supports takes a property name and
+// el.style.setProperty fills an inline block, and both refuse a descriptor.
+// What CSSOM exposes instead is the parsed rule, so each job is put to two
+// independent entry points into the same grammar:
+//
+//   p   insertRule(sheet) into a <style> element's sheet, and the parsed
+//       CSSFontFaceRule still spells the descriptor in its cssText
+//   o   replaceSync(sheet) on a constructed CSSStyleSheet, read back the same
+//       way
+//
+// Both are the CSS parser reached by a different entry point, and a job they
+// disagree about is a fact about the browser rather than about cascade, so the
+// run reports it instead of picking a side. Two things are deliberately not
+// the second oracle. rule.style.setProperty is a PROPERTY setter, so it takes
+// every CSS-wide keyword whatever the descriptor grammar says, and would call
+// [ascent-override: inherit] valid on every descriptor at once. And
+// getPropertyValue answers "" for a descriptor that is a shorthand, which
+// would call font-variant unimplemented on a browser that reads it, so the
+// read-back is of the rule's own text.
+//
+// Output is TSV on stdout, one record per line:
+//   v <job> <p> <o>      each 0 or 1
+//   x <job> <error>
+// A tab never appears in a job id or in either verdict, so the fields are
+// unambiguous.
+//
+// All the jobs of one chunk share a single browser launch. No layout or style
+// recalculation is involved: the descriptors are read straight off the rule.
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const CHROME = process.env.CHROME;
+const jobsFile = process.argv[2];
+const workDir = process.argv[3];
+const CHUNK_BYTES = 512 * 1024;
+
+// Runs inside the page.
+const HARNESS = `
+function dSheet(doc, text) {
+  var el = doc.createElement('style');
+  doc.head.appendChild(el);
+  var sheet = el.sheet;
+  try { sheet.insertRule(text, 0); } catch (e) { return null; }
+  return sheet.cssRules.length ? sheet.cssRules[0] : null;
+}
+function dHolds(rule, descriptor) {
+  if (!rule || !rule.cssText) return 0;
+  return rule.cssText.indexOf(descriptor + ':') >= 0 ? 1 : 0;
+}
+function dJob(doc, job, out) {
+  var p = 0, o = 0;
+  try {
+    p = dHolds(dSheet(doc, job.sheet), job.descriptor);
+  } catch (e) {
+    out.push(['x', job.id, String((e && e.message) || e)].join('\\t'));
+    return;
+  }
+  try {
+    var built = new CSSStyleSheet();
+    built.replaceSync(job.sheet);
+    o = dHolds(built.cssRules.length ? built.cssRules[0] : null, job.descriptor);
+  } catch (e) {
+    out.push(['x', job.id, String((e && e.message) || e)].join('\\t'));
+    return;
+  }
+  out.push(['v', job.id, p, o].join('\\t'));
+}
+function dMain(jobs) {
+  var out = [];
+  jobs.forEach(function (job) {
+    try { dJob(document, job, out); }
+    catch (e) { out.push(['x', job.id, String((e && e.message) || e)].join('\\t')); }
+  });
+  var text = out.join('\\n');
+  document.body.setAttribute('data-v',
+    btoa(unescape(encodeURIComponent(text))));
+}
+`;
+
+function page(jobs) {
+  const payload = JSON.stringify(jobs).replace(/</g, '\\u003c');
+  return '<!doctype html><html><head><meta charset="utf-8"></head><body>' +
+    '<script id="d-jobs" type="application/json">' + payload + '</script>' +
+    '<script>' + HARNESS +
+    'dMain(JSON.parse(document.getElementById("d-jobs").textContent));</script>' +
+    '</body></html>';
+}
+
+function chunks(jobs) {
+  const out = [];
+  let cur = [], size = 0;
+  for (const job of jobs) {
+    const n = JSON.stringify(job).length;
+    if (cur.length && size + n > CHUNK_BYTES) { out.push(cur); cur = []; size = 0; }
+    cur.push(job);
+    size += n;
+  }
+  if (cur.length) out.push(cur);
+  return out;
+}
+
+function run(jobs, index) {
+  // Absolute: a file:// URL has no notion of the process's directory.
+  const file = path.resolve(workDir, 'descriptors-' + index + '.html');
+  fs.writeFileSync(file, page(jobs));
+  const dom = execFileSync(CHROME, [
+    '--headless', '--disable-gpu', '--no-sandbox',
+    '--virtual-time-budget=120000', '--dump-dom', 'file://' + file,
+  ], { encoding: 'utf8', maxBuffer: 1 << 28 });
+  const m = dom.match(/data-v="([^"]*)"/);
+  if (!m) throw new Error('the page produced no result for chunk ' + index);
+  return Buffer.from(m[1], 'base64').toString('utf8');
+}
+
+const jobs = JSON.parse(fs.readFileSync(jobsFile, 'utf8'));
+const parts = chunks(jobs);
+parts.forEach(function (chunk, i) {
+  const text = run(chunk, i);
+  if (text.length) process.stdout.write(text + '\n');
+});

--- a/test/spec/browser/dune
+++ b/test/spec/browser/dune
@@ -10,6 +10,11 @@
 ; the reader drops and the browser takes, CSS the reader keeps and the browser
 ; discards - are reported apart.
 ;
+; descriptor_set: the same question about @font-face descriptors, which no
+; accept-set oracle could reach because a descriptor is not a property:
+; CSS.supports and el.style both answer about properties only. The probe there
+; is insertRule plus a read-back off CSSFontFaceRule.style.
+;
 ; The chrome and node probing is the one in test/render, shared rather than
 ; rewritten.
 
@@ -36,15 +41,41 @@
  (action
   (with-stdout-to
    reader_properties.ml
-   (run ./gen_reader_properties.exe %{properties}))))
+   (run
+    ./gen_reader_properties.exe
+    %{properties}
+    PROPERTY_MATCHING_START
+    PROPERTY_MATCHING_END
+    400))))
+
+; The @font-face descriptor population, from the same dispatch-table reading:
+; read_font_face_desc in lib/stylesheet.ml is the only place that says which
+; descriptors cascade models.
+
+(rule
+ (target font_face_descriptors.ml)
+ (deps
+  (:stylesheet ../../../lib/stylesheet.ml)
+  gen_reader_properties.exe)
+ (action
+  (with-stdout-to
+   font_face_descriptors.ml
+   (run
+    ./gen_reader_properties.exe
+    %{stylesheet}
+    FONT_FACE_DESCRIPTOR_START
+    FONT_FACE_DESCRIPTOR_END
+    10))))
 
 (executables
- (names property_vectors accept_set)
+ (names property_vectors accept_set descriptor_set)
  (modules
   property_vectors
   accept_set
+  descriptor_set
   chrome_gaps
   reader_properties
+  font_face_descriptors
   browser
   json)
  (libraries cascade cascade_spec_inventory fmt unix))
@@ -78,3 +109,12 @@
   accept_set.exe)
  (action
   (run %{exe:accept_set.exe})))
+
+(rule
+ (alias runtest)
+ (deps
+  (env_var CASCADE_NO_BROWSER)
+  (glob_files *.js)
+  descriptor_set.exe)
+ (action
+  (run %{exe:descriptor_set.exe})))

--- a/test/spec/browser/gen_reader_properties.ml
+++ b/test/spec/browser/gen_reader_properties.ml
@@ -58,12 +58,12 @@ let arm_names line =
       pattern;
     List.rev !names
 
-let names_of lines =
+let names_of ~start ~stop lines =
   let rec loop inside acc = function
     | [] -> List.rev acc
     | line :: rest ->
-        if contains line "PROPERTY_MATCHING_START" then loop true acc rest
-        else if contains line "PROPERTY_MATCHING_END" then List.rev acc
+        if contains line start then loop true acc rest
+        else if contains line stop then List.rev acc
         else if inside then
           loop true (List.rev_append (arm_names line) acc) rest
         else loop false acc rest
@@ -71,12 +71,13 @@ let names_of lines =
   loop false [] lines
 
 (* A rename in the library would otherwise empty the population without failing
-   anything. *)
-let minimum = 400
-
+   anything, so the caller says how many names it expects at least. *)
 let () =
   let source = Sys.argv.(1) in
-  let names = names_of (read_lines source) in
+  let start = Sys.argv.(2) in
+  let stop = Sys.argv.(3) in
+  let minimum = int_of_string Sys.argv.(4) in
+  let names = names_of ~start ~stop (read_lines source) in
   if List.length names < minimum then (
     prerr_endline
       (String.concat ""
@@ -85,16 +86,22 @@ let () =
            source;
            " yielded ";
            string_of_int (List.length names);
-           " property names, fewer than the ";
+           " names, fewer than the ";
            string_of_int minimum;
-           " expected; the PROPERTY_MATCHING markers moved";
+           " expected; the ";
+           start;
+           " markers moved";
          ]);
     exit 1);
   let buf = Buffer.create 16384 in
   Buffer.add_string buf
-    "(* Generated from lib/properties.ml by gen_reader_properties.ml. *)\n\n\
-     let all =\n\
-    \  [\n";
+    (String.concat ""
+       [
+         "(* Generated from ";
+         source;
+         " by gen_reader_properties.ml. *)\n\n";
+         "let all =\n  [\n";
+       ]);
   List.iter
     (fun name ->
       Buffer.add_string buf "    \"";

--- a/test/spec/inventory/descriptor_grammar.ml
+++ b/test/spec/inventory/descriptor_grammar.ml
@@ -1,0 +1,111 @@
+type row = {
+  descriptor : string;
+  positives : string list;
+  negatives : string list;
+  why : string;
+}
+
+let row descriptor why positives negatives =
+  { descriptor; positives; negatives; why }
+
+(* Sections are CSS Fonts 4 (ED) unless the row says otherwise. Values a browser
+   and the specification disagree about are deliberately absent: this is the
+   grammar, and where a browser has not caught up the harness reads the support
+   dataset rather than a vector written to match it. *)
+let rows =
+  [
+    row "font-family" "sec. 4.2 <font-family-name> = <string> | <custom-ident>+"
+      [ "Brand"; "\"Brand Sans\""; "Brand Sans"; "'Brand'"; "B2" ]
+      [
+        "serif";
+        "default";
+        (* CSS Values 4 sec. 4.2 reserves [default], so no <custom-ident> of a
+           sequence may be one. *)
+        "none default";
+        "Brand!";
+        "Red/Black";
+        "\"Brand";
+      ];
+    row "src" "sec. 4.3.1 <font-src-list>"
+      [
+        "url(brand.woff2)";
+        "url(brand.woff2) format(\"woff2\")";
+        "url(brand.woff2) format(woff2)";
+        "local(Brand)";
+        "local(\"Brand\")";
+        "local(Brand), url(brand.woff2)";
+        "url(brand.woff2) format(\"woff2\") tech(variations)";
+      ]
+      [ "nonsense"; "format(\"woff2\")"; "url(brand.woff2) format()" ];
+    row "font-style"
+      "sec. 4.4 auto | normal | italic | left | right | oblique [<angle \
+       [-90deg,90deg]>{1,2}]?"
+      [
+        "auto";
+        "normal";
+        "italic";
+        "oblique";
+        "oblique 10deg";
+        "oblique 0deg 10deg";
+      ]
+      [ "normal italic"; "italic oblique"; "bold"; "oblique 10px" ];
+    row "font-weight"
+      "sec. 4.4 auto | <font-weight-absolute>{1,2}, over normal | bold | \
+       <number [1,1000]>"
+      [ "auto"; "normal"; "bold"; "400"; "1"; "1000"; "100 900"; "bold 400" ]
+      [ "lighter"; "bolder"; "400 lighter"; "normal bold italic" ];
+    row "font-stretch"
+      "sec. 4.4 auto | <'font-width'>{1,2}, under the sec. 2.3.1 legacy name"
+      [ "auto"; "normal"; "condensed"; "75%"; "75% 125%"; "normal condensed" ]
+      [ "condensed 75% 100%"; "75px"; "wider" ];
+    row "font-display" "sec. 4.7 auto | block | swap | fallback | optional"
+      [ "auto"; "block"; "swap"; "fallback"; "optional" ]
+      [ "maybe"; "swap block"; "0" ];
+    row "unicode-range" "sec. 4.5 <unicode-range-token>#"
+      [ "U+0-7F"; "U+25-FF"; "U+1F600-1F64F"; "U+???"; "U+0-7F, U+100" ]
+      [ "red"; "0-7F"; "U+0-7F U+100" ];
+    row "font-feature-settings" "sec. 4.6 normal | <feature-tag-value>#"
+      [
+        "normal";
+        "\"kern\"";
+        "\"kern\" 1";
+        "\"kern\" on";
+        "\"kern\" off";
+        "\"kern\" 1, \"liga\" 0";
+      ]
+      [ "kern"; "\"kern\" bogus"; "\"kern\" 1 2" ];
+    row "font-variation-settings" "sec. 4.6 normal | [<string> <number>]#"
+      [ "normal"; "\"wght\" 650"; "\"wght\" 650, \"wdth\" 100" ]
+      [
+        "wght 650";
+        "\"wght\" bold";
+        "650 \"wght\"";
+        (* The pair is [<string> <number>]: a tag with no number is half a
+           value, and [on]/[off] belong to font-feature-settings. *)
+        "\"wght\"";
+        "\"text\"";
+        "\"liga\" off";
+      ];
+    (* CSS Fonts 4 removed this descriptor per WG resolution and Chrome 153
+       still reads it, so it stays modelled and the row cites the last section
+       that spelled it. *)
+    row "font-variant"
+      "CSS Fonts 3 sec. 7.3, the sec. 6.9 font-variant property values inside \
+       the rule; CSS Fonts 4 removed the descriptor"
+      [ "normal"; "none"; "small-caps"; "common-ligatures small-caps" ]
+      [ "bogus-variant"; "1"; "small-caps 1" ];
+    row "size-adjust" "CSS Fonts 5 (ED) sec. 4.10 <percentage [0,inf]>"
+      [ "0%"; "92%"; "100%"; "300%" ]
+      [ "-1%"; "100"; "normal" ];
+    row "ascent-override" "sec. 4.9 normal | <percentage [0,inf]>"
+      [ "normal"; "0%"; "90%" ] [ "-1%"; "90"; "auto" ];
+    row "descent-override" "sec. 4.9 normal | <percentage [0,inf]>"
+      [ "normal"; "0%"; "25%" ] [ "-1%"; "25"; "auto" ];
+    row "line-gap-override" "sec. 4.9 normal | <percentage [0,inf]>"
+      [ "normal"; "0%"; "10%" ] [ "-1%"; "10"; "auto" ];
+  ]
+
+let descriptors = List.map (fun r -> r.descriptor) rows
+
+let row_for descriptor =
+  List.find_opt (fun r -> String.equal r.descriptor descriptor) rows

--- a/test/spec/inventory/descriptor_grammar.mli
+++ b/test/spec/inventory/descriptor_grammar.mli
@@ -1,0 +1,31 @@
+(** Spec-derived vectors for the [@font-face] descriptors.
+
+    A descriptor is not a property, so {!Property_grammar} cannot carry these:
+    [src] and [unicode-range] have no property of the same name, and the ones
+    that do ([font-style], [font-weight]) are given a narrower grammar inside
+    the rule than outside it. Every row names the CSS Fonts section that grants
+    or refuses the vector, and a browser arbitrates the row rather than cascade.
+
+    A positive is a complete descriptor value the specification grants. A
+    negative is one it does not, and it may still be a valid fragment: [10deg]
+    is no [font-style] alone and a good one after [oblique]. *)
+
+type row = {
+  descriptor : string;  (** the descriptor name, as written in the rule *)
+  positives : string list;
+  negatives : string list;
+  why : string;  (** the section that spells the grammar *)
+}
+(** A row is the citation. Where a browser and a row disagree, the row decides
+    and the divergence is reported as the browser's: it is the section that says
+    whether [font-weight: bold 400] is a value, not the engine in front of it.
+*)
+
+val rows : row list
+(** Every [@font-face] descriptor this project has spec vectors for. *)
+
+val descriptors : string list
+(** [descriptors] is the descriptor names {!rows} covers. *)
+
+val row_for : string -> row option
+(** [row_for descriptor] is the row named [descriptor]. *)


### PR DESCRIPTION
The descriptor grammars had no browser oracle, because both accept-set oracles answer about properties: `CSS.supports` takes a property name and `el.style.setProperty` fills an inline block, so neither reaches `src` or `unicode-range`. This drives the parser through `insertRule` and again through `replaceSync`, reads the descriptor back off the rule's own text, and judges the spec-derived rows in the new `Descriptor_grammar` alongside the generated accept-set population. 841 values over 14 descriptors: 832 arbitrated, 4 where the browser is behind the section, 5 where it is more lenient, no disagreement between the two parser entry points. Making the CSS-wide refusal a no-op reports 25, so the branch is exercised rather than quiet.