### PR TITLE
position: pair an offset with an edge keyword

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -844,6 +844,13 @@ to lose a whole rule over one bad piece. Both are gone.
   fractional or out-of-range number instead of truncating (#466, #472, #473,
   #477, #484, #496, #497, #499, #501, #538, #789, #793, #801)
 
+- A `<position>` pairing an offset with an edge keyword reads where it was
+  dropped, so `background-position: 50% bottom` and the same shape on
+  `object-position`, `mask-position`, `transform-origin` and the `background`
+  shorthand are no longer lost. CSS Values 4 sec. 8.3 grants
+  `[ left | center | right | <length-percentage> ] [ top | center | bottom |
+  <length-percentage> ]` (#1122)
+
 - A CSS-wide keyword in an `@font-face` descriptor is dropped, so
   `font-weight: inherit` inside the rule no longer reaches output a browser
   discards. CSS Fonts 4 sec. 4.6 omits them from the descriptor grammars

--- a/lib/prop_image.ml
+++ b/lib/prop_image.ml
@@ -1424,11 +1424,18 @@ module Position_value = struct
     | "center" -> XY ((Pct 50. : length), y)
     | _ -> Cursor.err_invalid t "invalid horizontal position keyword length"
 
+  (* CSS Values 4 (ED) sec. 8.3 spells one alternative [[ left | center | right
+     | <length-percentage> ] [ top | center | bottom | <length-percentage> ]],
+     so the second slot takes any vertical edge and not only [center]. The
+     reverse order is no alternative of the production, so a keyword there is
+     still refused. *)
   let read_length_keyword t : position_value =
     let offset = read_length ~with_keywords:false t in
     Cursor.ws t;
     match Cursor.ident t with
     | "center" -> Single offset
+    | "top" -> XY (offset, (Pct 0. : length))
+    | "bottom" -> XY (offset, (Pct 100. : length))
     | _ -> Cursor.err_invalid t "invalid position length keyword"
 
   (* Read 4-value syntax: keyword offset keyword offset *)

--- a/lib/prop_transform.ml
+++ b/lib/prop_transform.ml
@@ -1170,18 +1170,26 @@ module Transform_origin = struct
         | Single x -> X x
         | position -> Position position)
 
+  (* All-length slots only, so it has to leave an edge keyword to
+     [read_position] rather than stopping short and handing the caller a
+     trailing token: [50% bottom] is a position, not one slot and a leftover. *)
   let read_xyz (t : Cursor.t) : transform_origin =
     let x = read_slot t in
     Cursor.ws t;
-    match Cursor.option read_slot t with
-    | Some y -> (
-        Cursor.ws t;
-        match Cursor.option read_slot t with
-        | Some z -> XYZ (x, y, z)
-        | None -> XY (x, y))
-    (* CSS Transforms 1 sec. 4: a single <length-percentage> sets the X origin
-       and defaults Y to [center] ([50%]); it is not duplicated into Y. *)
-    | None -> X x
+    let origin =
+      match Cursor.option read_slot t with
+      | Some y -> (
+          Cursor.ws t;
+          match Cursor.option read_slot t with
+          | Some z -> XYZ (x, y, z)
+          | None -> XY (x, y))
+      (* CSS Transforms 1 sec. 4: a single <length-percentage> sets the X origin
+         and defaults Y to [center] ([50%]); it is not duplicated into Y. *)
+      | None -> X x
+    in
+    Cursor.ws t;
+    Cursor.expect_eof t;
+    origin
 
   let read_keyword t : keyword =
     Cursor.enum "transform-origin-keyword"

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -495,6 +495,25 @@ let special_cases () =
     "background-position: 30% 50%, 70% 50%;";
   check_declaration ~expected:"background-position:var(--x) 20%"
     "background-position: var(--x) 20%;";
+  (* CSS Values 4 (ED) sec. 8.3 spells one alternative of <position> as "[ left
+     | center | right | <length-percentage> ] [ top | center | bottom |
+     <length-percentage> ]", so an offset in the first slot pairs with an edge
+     keyword in the second. Chrome 153 keeps every one of these and refuses the
+     reverse order, which no alternative grants. *)
+  check_declaration ~expected:"background-position:50% bottom"
+    "background-position: 50% bottom";
+  check_declaration ~expected:"background-position:50% top"
+    "background-position: 50% top";
+  check_declaration ~expected:"background-position:10px bottom"
+    "background-position: 10px bottom";
+  check_declaration ~expected:"object-position:50% bottom"
+    "object-position: 50% bottom";
+  check_declaration ~expected:"transform-origin:50% bottom"
+    "transform-origin: 50% bottom";
+  check_declaration ~expected:"background:url(a.png)50% bottom"
+    "background: url(a.png) 50% bottom";
+  neg_cursor read_declaration "background-position: bottom 50%";
+  neg_cursor read_declaration "object-position: bottom 50%";
   check_declaration ~expected:"mask-position:0 0,10px 10px"
     "mask-position: 0 0, 10px 10px;";
 

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -500,18 +500,19 @@ let special_cases () =
      <length-percentage> ]", so an offset in the first slot pairs with an edge
      keyword in the second. Chrome 153 keeps every one of these and refuses the
      reverse order, which no alternative grants. *)
-  check_declaration ~expected:"background-position:50% bottom"
-    "background-position: 50% bottom";
-  check_declaration ~expected:"background-position:50% top"
-    "background-position: 50% top";
-  check_declaration ~expected:"background-position:10px bottom"
+  check_declaration ~expected:"background-position:50%100%"
+    ~optimized:"background-position:bottom" "background-position: 50% bottom";
+  check_declaration ~expected:"background-position:50%0%"
+    ~optimized:"background-position:top" "background-position: 50% top";
+  check_declaration ~expected:"background-position:10px 100%"
+    ~optimized:"background-position:10px 100%"
     "background-position: 10px bottom";
-  check_declaration ~expected:"object-position:50% bottom"
-    "object-position: 50% bottom";
-  check_declaration ~expected:"transform-origin:50% bottom"
-    "transform-origin: 50% bottom";
-  check_declaration ~expected:"background:url(a.png)50% bottom"
-    "background: url(a.png) 50% bottom";
+  check_declaration ~expected:"object-position:50%100%"
+    ~optimized:"object-position:bottom" "object-position: 50% bottom";
+  check_declaration ~expected:"transform-origin:50% 100%"
+    ~optimized:"transform-origin:50% 100%" "transform-origin: 50% bottom";
+  check_declaration ~expected:"background:url(a.png)50%100%"
+    ~optimized:"background:url(a.png)bottom" "background: url(a.png) 50% bottom";
   neg_cursor read_declaration "background-position: bottom 50%";
   neg_cursor read_declaration "object-position: bottom 50%";
   check_declaration ~expected:"mask-position:0 0,10px 10px"


### PR DESCRIPTION
`background-position: 50% bottom` was dropped, and so was the same shape on `object-position`, `mask-position`, `transform-origin` and the `background` shorthand: the second slot of a two-value `<position>` took only `center`. CSS Values 4 sec. 8.3 spells the alternative `[ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]`, and Chrome 153 keeps every one of these while refusing the reverse order, which no alternative grants. `transform-origin` needed a second fix: its all-length reader succeeded on the offset alone and left the keyword as a trailing token, so the position reader after it never ran.