### PR TITLE
transition: take a negative delay in the shorthand

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -844,6 +844,11 @@ to lose a whole rule over one bad piece. Both are gone.
   fractional or out-of-range number instead of truncating (#466, #472, #473,
   #477, #484, #496, #497, #499, #501, #538, #789, #793, #801)
 
+- The second `<time>` of a `transition` entry takes a negative, so
+  `transition: opacity 1s -1s` reads where it was dropped. CSS Transitions 1
+  sec. 2.5 assigns it to `transition-delay`, which starts the transition
+  partway through; only the duration is `[0s,inf]` (#1123)
+
 - A `<position>` pairing an offset with an edge keyword reads where it was
   dropped, so `background-position: 50% bottom` and the same shape on
   `object-position`, `mask-position`, `transform-origin` and the `background`

--- a/lib/prop_animation.ml
+++ b/lib/prop_animation.ml
@@ -1158,11 +1158,18 @@ let read_transition_behavior_part parts t =
     read_transition_part t read_transition_behavior (fun v ->
         parts.behavior <- Option.Some v)
 
+(* CSS Transitions 1 (ED) sec. 2.5 assigns the first <time> of a
+   <single-transition> to transition-duration and the second to
+   transition-delay. Only the duration is [0s,inf]: sec. 2.4 lets a delay be
+   negative, starting the transition partway through, so the second slot reads
+   the wider grammar. *)
 let read_transition_time_part parts t =
-  if List.length parts.times >= 2 then false
-  else
-    read_transition_part t read_duration (fun v ->
-        parts.times <- v :: parts.times)
+  match parts.times with
+  | [] -> read_transition_part t read_duration (fun v -> parts.times <- [ v ])
+  | [ _ ] ->
+      read_transition_part t read_time (fun v ->
+          parts.times <- v :: parts.times)
+  | _ :: _ :: _ -> false
 
 let transition_duration_delay parts =
   match List.rev parts.times with

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2247,6 +2247,18 @@ let animations_timing () =
   neg_cursor read_declaration "animation-delay: calc(inherit + 1s)";
   neg_cursor read_declaration "animation-delay: calc(initial + 1s)";
   neg_cursor read_declaration "animation-delay: calc(unset + 1s)";
+  (* CSS Transitions 1 (ED) sec. 2.5 assigns the first <time> of a
+     <single-transition> to transition-duration and the second to
+     transition-delay, and only the duration is [0s,inf]: a negative delay
+     starts the transition partway through. Chrome 153 keeps all three. *)
+  check_declaration ~expected:"transition:all 1s -1s" "transition: 1s -1s";
+  check_declaration ~expected:"transition:opacity 1s -1s"
+    "transition: opacity 1s -1s";
+  check_declaration ~expected:"transition:opacity 1s ease-in -1s"
+    "transition: opacity 1s ease-in -1s";
+  (* The duration slot keeps its range, so a lone negative has nowhere to go. *)
+  neg_cursor read_declaration "transition: -1s";
+  neg_cursor read_declaration "transition: -1s 1s";
   check_declaration ~expected:"transition-duration:var(--d,.5s)"
     ~optimized:"transition-duration:var(--d,.5s)"
     "transition-duration:var(--d,500ms)";


### PR DESCRIPTION
`transition: opacity 1s -1s` was dropped. CSS Transitions 1 sec. 2.5 assigns the first `<time>` of a `<single-transition>` to `transition-duration` and the second to `transition-delay`, and only the duration is `[0s,inf]`: a negative delay starts the transition partway through, and Chrome 153 keeps it. Both slots read the duration grammar. A lone `transition: -1s` is still refused, which is the reading sec. 2.5's note asks for.