### PR TITLE
font-weight: read a math function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,12 @@ entry points both moved.
   comma-separated list, one entry per rule line. A caller writing one line
   passes a one-element list (#1024)
 
+- `Cascade.Properties.font_weight` gains `Calc`, so `font-weight: calc(400)`
+  reads where it was dropped. CSS Values 4 sec. 10 allows a math function
+  wherever a `<number>` is allowed, and sec. 10.12 clamps its result rather
+  than dropping the declaration, so `calc(0)` keeps its wrapper where the bare
+  `0` is still refused. Exhaustive visitors must handle the new arm (#1124)
+
 - `Cascade.Stylesheet.font_face_descriptor` loses `Font_tech`, and
   `Cascade.Stylesheet.font_tech_descriptor` and `read_font_tech_descriptor` go
   with it, so `@font-face { font-tech: variations }` is dropped where it was

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -4321,6 +4321,7 @@ type font_weight = Properties.font_weight =
   | Bold
   | Bolder
   | Lighter
+  | Calc of font_weight calc
   | Inherit
   | Initial
   | Unset

--- a/lib/prop_font.ml
+++ b/lib/prop_font.ml
@@ -59,7 +59,15 @@ let rec read_font_weight t : font_weight =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~calls:[ ("var", read_var) ]
+    ~calls:
+      [
+        ("var", read_var);
+        (* CSS Values 4 sec. 10 allows a math function wherever a [<number>] is
+           allowed. One that folds to a constant becomes that weight and is
+           range-checked with it; one that does not stays a calc. *)
+        ( "calc",
+          fun t -> Calc (read_calc ~result_type:`Number read_font_weight t) );
+      ]
     ~default:(fun t ->
       let weight = Cursor.number t in
       if weight >= 1. && weight <= 1000. then (Weight weight : font_weight)
@@ -1354,6 +1362,16 @@ let rec pp_font_weight : font_weight Pp.t =
   | Bold -> Pp.string ctx "bold"
   | Bolder -> Pp.string ctx "bolder"
   | Lighter -> Pp.string ctx "lighter"
+  (* CSS Values 4 sec. 10.12 clamps a math function's result to the range at
+     computed-value time, so [calc(0)] is a weight where the bare [0] is not:
+     the wrapper comes off only when what is inside is a value on its own. *)
+  | Calc c ->
+      let in_range n = n >= 1. && n <= 1000. in
+      pp_calc
+        ~unwrap_num:(match c with Num n -> in_range n | _ -> true)
+        ~unwrap:(fun (v : font_weight) ->
+          match v with Weight n -> in_range n | _ -> true)
+        pp_font_weight ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
@@ -2388,9 +2406,29 @@ let normalize_line_height ?(lossless = false) (lh : line_height) : line_height =
 (* CSS Fonts 4 (ED) sec. 2.2 defines [normal] as "Same as 400" and [bold] as
    "Same as 700", so each keyword and its number name one weight and the number
    is the shorter spelling. *)
-let normalize_font_weight : font_weight -> font_weight = function
+let rec numeric_font_weight_calc_leaves : font_weight calc -> font_weight calc =
+  function
+  | Val (Weight n) -> Num n
+  | Nested inner -> Nested (numeric_font_weight_calc_leaves inner)
+  | Parens inner -> Parens (numeric_font_weight_calc_leaves inner)
+  | Expr (left, op, right) ->
+      Expr
+        ( numeric_font_weight_calc_leaves left,
+          op,
+          numeric_font_weight_calc_leaves right )
+  | other -> other
+
+let rec normalize_font_weight : font_weight -> font_weight = function
   | Normal -> Weight 400.
   | Bold -> Weight 700.
+  (* CSS Values 4 sec. 10.12 clamps a math function's result to the range at
+     computed-value time, so [calc(0)] is a weight and the literal [0] is not:
+     unwrapping one outside [1,1000] would write CSS a browser drops. *)
+  | Calc c as value -> (
+      match eval_calc (numeric_font_weight_calc_leaves c) with
+      | Num n when n >= 1. && n <= 1000. -> Weight n
+      | Val v -> normalize_font_weight v
+      | folded -> if folded == c then value else Calc folded)
   | value -> value
 
 (* sec. 2.3 maps each width keyword onto a percentage, and getComputedStyle()

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -56,6 +56,9 @@ type font_weight =
   | Bold
   | Bolder
   | Lighter
+  | Calc of font_weight calc
+      (** CSS Values 4 sec. 10 allows a math function wherever a [<number>] is
+          allowed, and one that does not fold to a constant stays here. *)
   | Inherit
   | Initial
   | Unset

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2247,6 +2247,16 @@ let animations_timing () =
   neg_cursor read_declaration "animation-delay: calc(inherit + 1s)";
   neg_cursor read_declaration "animation-delay: calc(initial + 1s)";
   neg_cursor read_declaration "animation-delay: calc(unset + 1s)";
+  (* CSS Values 4 (ED) sec. 10: "Math functions can be used ... wherever
+     <length>, <frequency>, <angle>, <time>, <percentage>, <number>, or
+     <integer> values are allowed", and CSS Fonts 4 sec. 2.2 spells font-weight
+     over <number [1,1000]>. Chrome 153 keeps these. *)
+  check_declaration ~expected:"font-weight:calc(400)"
+    ~optimized:"font-weight:400" "font-weight: calc(400)";
+  check_declaration ~expected:"font-weight:calc(100 + 300)"
+    ~optimized:"font-weight:400" "font-weight: calc(100 + 300)";
+  check_declaration ~expected:"font-weight:calc(var(--w))"
+    ~optimized:"font-weight:calc(var(--w))" "font-weight: calc(var(--w))";
   (* CSS Transitions 1 (ED) sec. 2.5 assigns the first <time> of a
      <single-transition> to transition-duration and the second to
      transition-delay, and only the duration is [0s,inf]: a negative delay

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2251,12 +2251,21 @@ let animations_timing () =
      <length>, <frequency>, <angle>, <time>, <percentage>, <number>, or
      <integer> values are allowed", and CSS Fonts 4 sec. 2.2 spells font-weight
      over <number [1,1000]>. Chrome 153 keeps these. *)
-  check_declaration ~expected:"font-weight:calc(400)"
-    ~optimized:"font-weight:400" "font-weight: calc(400)";
+  check_declaration ~expected:"font-weight:400" ~optimized:"font-weight:400"
+    "font-weight: calc(400)";
   check_declaration ~expected:"font-weight:calc(100 + 300)"
     ~optimized:"font-weight:400" "font-weight: calc(100 + 300)";
   check_declaration ~expected:"font-weight:calc(var(--w))"
     ~optimized:"font-weight:calc(var(--w))" "font-weight: calc(var(--w))";
+  (* sec. 10.12 clamps the call's result rather than dropping the declaration,
+     so the wrapper is what makes an out-of-range weight a weight: unwrapping it
+     would write the literal a browser refuses. *)
+  check_declaration ~expected:"font-weight:calc(0)"
+    ~optimized:"font-weight:calc(0)" "font-weight: calc(0)";
+  check_declaration ~expected:"font-weight:calc(1001)"
+    ~optimized:"font-weight:calc(1001)" "font-weight: calc(1001)";
+  neg_cursor read_declaration "font-weight: 0";
+  neg_cursor read_declaration "font-weight: 1001";
   (* CSS Transitions 1 (ED) sec. 2.5 assigns the first <time> of a
      <single-transition> to transition-duration and the second to
      transition-delay, and only the duration is [0s,inf]: a negative delay


### PR DESCRIPTION
`font-weight: calc(400)` was dropped. CSS Values 4 sec. 10 allows a math function wherever a `<number>` is allowed, and Chrome 153 keeps it. `Cascade.Properties.font_weight` gains `Calc`. The wrapper stays wherever the result falls outside `[1,1000]`, because that is what makes the value a weight: sec. 10.12 clamps a call's result at computed-value time while the bare `0` is refused outright, and Chrome agrees on both.