### PR TITLE
line-clamp: read a math function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,12 @@ entry points both moved.
   comma-separated list, one entry per rule line. A caller writing one line
   passes a one-element list (#1024)
 
+- `Cascade.Properties.webkit_line_clamp` gains `Calc`, so
+  `-webkit-line-clamp: calc(2)` reads where it was dropped. CSS Values 4 sec.
+  10 allows a math function wherever an `<integer>` is allowed, and sec. 10.12
+  rounds and clamps its result, so `calc(.5)` keeps its wrapper where the bare
+  `.5` is still refused. Exhaustive visitors must handle the new arm (#1125)
+
 - `Cascade.Properties.font_weight` gains `Calc`, so `font-weight: calc(400)`
   reads where it was dropped. CSS Values 4 sec. 10 allows a math function
   wherever a `<number>` is allowed, and sec. 10.12 clamps its result rather

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -8245,6 +8245,7 @@ type webkit_box_orient = Properties.webkit_box_orient =
 type webkit_line_clamp = Properties.webkit_line_clamp =
   | None
   | Lines of int
+  | Calc of webkit_line_clamp calc
   | Inherit
   | Initial
   | Unset

--- a/lib/prop_ui.ml
+++ b/lib/prop_ui.ml
@@ -802,12 +802,44 @@ let rec pp_webkit_line_clamp : webkit_line_clamp Pp.t =
  fun ctx -> function
   | None -> Pp.string ctx "none"
   | Lines n -> Pp.int ctx n
+  (* An [<integer>] slot: sec. 10.12 rounds the call and refuses the fraction
+     written on its own, and the count has to be positive, so the wrapper comes
+     off only around a leaf that is a line count by itself. *)
+  | Calc c ->
+      pp_calc
+        ~unwrap_num:
+          (match c with Num n -> Float.is_integer n && n >= 1. | _ -> true)
+        pp_webkit_line_clamp ctx c
   | Inherit -> Pp.string ctx "inherit"
   | Initial -> Pp.string ctx "initial"
   | Unset -> Pp.string ctx "unset"
   | Revert -> Pp.string ctx "revert"
   | Revert_layer -> Pp.string ctx "revert-layer"
   | Var v -> pp_var pp_webkit_line_clamp ctx v
+
+(* CSS Values 4 sec. 10.12 rounds a math function in an [<integer>] slot and
+   clamps it to the range, so a call that folds to a line count is that count
+   and one that does not keeps its wrapper. *)
+let rec numeric_line_clamp_calc_leaves :
+    webkit_line_clamp calc -> webkit_line_clamp calc = function
+  | Val (Lines n) -> Num (float_of_int n)
+  | Nested inner -> Nested (numeric_line_clamp_calc_leaves inner)
+  | Parens inner -> Parens (numeric_line_clamp_calc_leaves inner)
+  | Expr (left, op, right) ->
+      Expr
+        ( numeric_line_clamp_calc_leaves left,
+          op,
+          numeric_line_clamp_calc_leaves right )
+  | other -> other
+
+let normalize_webkit_line_clamp (value : webkit_line_clamp) : webkit_line_clamp
+    =
+  match value with
+  | Calc c -> (
+      match eval_calc (numeric_line_clamp_calc_leaves c) with
+      | Num n when Float.is_integer n && n >= 1. -> Lines (int_of_float n)
+      | folded -> if folded == c then value else Calc folded)
+  | value -> value
 
 let rec read_user_select t : user_select =
   Cursor.enum_or_var "user-select"
@@ -1095,7 +1127,15 @@ let rec read_webkit_line_clamp t : webkit_line_clamp =
       ("revert", Revert);
       ("revert-layer", Revert_layer);
     ]
-    ~calls:[ ("var", read_var) ]
+    ~calls:
+      [
+        ("var", read_var);
+        (* CSS Values 4 sec. 10 allows a math function wherever an [<integer>]
+           is allowed. *)
+        ( "calc",
+          fun t ->
+            Calc (read_calc ~result_type:`Number read_webkit_line_clamp t) );
+      ]
     ~default:(fun t ->
       let n = Cursor.int t in
       if n <= 0 then Cursor.err_invalid t "-webkit-line-clamp must be positive";

--- a/lib/properties.ml
+++ b/lib/properties.ml
@@ -4489,6 +4489,7 @@ let normalize_property_value : type a.
   | Gap -> normalize_gap value
   | Font_size -> normalize_font_size value
   | Font_weight -> normalize_font_weight value
+  | Webkit_line_clamp -> normalize_webkit_line_clamp value
   | Font_family -> normalize_font_family value
   | Font_stretch -> normalize_font_stretch value
   | Font -> normalize_font value

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -4663,6 +4663,10 @@ type moz_orient =
 type webkit_line_clamp =
   | None
   | Lines of int
+  | Calc of webkit_line_clamp calc
+      (** CSS Values 4 sec. 10 allows a math function wherever an [<integer>] is
+          allowed, and sec. 10.12 rounds its result, so a fractional call is a
+          line count where the bare fraction is not. *)
   | Inherit
   | Initial
   | Unset

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2247,6 +2247,20 @@ let animations_timing () =
   neg_cursor read_declaration "animation-delay: calc(inherit + 1s)";
   neg_cursor read_declaration "animation-delay: calc(initial + 1s)";
   neg_cursor read_declaration "animation-delay: calc(unset + 1s)";
+  (* sec. 10 allows a math function wherever an <integer> is allowed, and sec.
+     10.12 rounds the call and clamps it, so a fractional or out-of-range call
+     keeps its wrapper where the bare literal is refused. Chrome 153 agrees on
+     each of these. *)
+  check_declaration ~expected:"-webkit-line-clamp:2"
+    ~optimized:"-webkit-line-clamp:2" "-webkit-line-clamp: calc(2)";
+  check_declaration ~expected:"-webkit-line-clamp:calc(1 + 1)"
+    ~optimized:"-webkit-line-clamp:2" "-webkit-line-clamp: calc(1 + 1)";
+  check_declaration ~expected:"-webkit-line-clamp:calc(.5)"
+    ~optimized:"-webkit-line-clamp:calc(.5)" "-webkit-line-clamp: calc(.5)";
+  check_declaration ~expected:"-webkit-line-clamp:calc(0)"
+    ~optimized:"-webkit-line-clamp:calc(0)" "-webkit-line-clamp: calc(0)";
+  neg_cursor read_declaration "-webkit-line-clamp: 0";
+  neg_cursor read_declaration "-webkit-line-clamp: .5";
   (* CSS Values 4 (ED) sec. 10: "Math functions can be used ... wherever
      <length>, <frequency>, <angle>, <time>, <percentage>, <number>, or
      <integer> values are allowed", and CSS Fonts 4 sec. 2.2 spells font-weight


### PR DESCRIPTION
`-webkit-line-clamp: calc(2)` was dropped. CSS Values 4 sec. 10 allows a math function wherever an `<integer>` is allowed, and Chrome 153 keeps it. `Cascade.Properties.webkit_line_clamp` gains `Calc`. A call that folds to a positive whole number becomes that count; `calc(.5)` and `calc(0)` keep their wrapper, because sec. 10.12 rounds and clamps a call's result where the bare literal is refused outright, and Chrome agrees.