### PR TITLE
grid-line: read a math function beside a line name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,13 @@ entry points both moved.
   comma-separated list, one entry per rule line. A caller writing one line
   passes a one-element list (#1024)
 
+- `Cascade.Properties.grid_line` gains `Calc_name`, so
+  `grid-row-start: center calc(2)` and `grid-row-start: calc(2) center` read
+  where both were dropped. CSS Grid 2 sec. 8.3 joins the index and the name
+  with `&&`, so the name sits on either side, and CSS Values 4 sec. 10 puts a
+  math function wherever an `<integer>` goes. Exhaustive visitors must handle
+  the new arm (#1126)
+
 - `Cascade.Properties.webkit_line_clamp` gains `Calc`, so
   `-webkit-line-clamp: calc(2)` reads where it was dropped. CSS Values 4 sec.
   10 allows a math function wherever an `<integer>` is allowed, and sec. 10.12

--- a/lib/css.mli
+++ b/lib/css.mli
@@ -4131,6 +4131,7 @@ type grid_line = Properties.grid_line =
   | Span_name of string  (** span <custom-ident> *)
   | Span_num_name of int * string  (** span <integer> <custom-ident> *)
   | Calc of grid_line calc  (** calc(12 * -1), etc. *)
+  | Calc_name of grid_line calc * string  (** calc(2) <custom-ident> *)
   | Var of grid_line var
 
 type grid_line_pair = Properties.grid_line_pair =

--- a/lib/prop_grid.ml
+++ b/lib/prop_grid.ml
@@ -53,6 +53,13 @@ let rec pp_grid_line : grid_line Pp.t =
       Pp.int ctx n;
       Pp.char ctx ' ';
       pp_ident ctx name
+  | Calc_name (c, name) ->
+      (* [unwrap_num:false] as the bare [Calc] arm below: sec. 10.12 rounds a
+         call in an [<integer>] slot, so the wrapper is what makes a fraction a
+         line index. *)
+      pp_calc ~unwrap_num:false pp_grid_line ctx c;
+      Pp.char ctx ' ';
+      pp_ident ctx name
   | Span n ->
       Pp.string ctx "span";
       Pp.char ctx ' ';
@@ -775,16 +782,36 @@ let read_grid_line_name_value t : grid_line =
   | _ -> (
       let name = read_grid_line_name t in
       Cursor.ws t;
-      let n : int option =
-        if grid_line_at_end t then None
-        else Cursor.option (fun t -> check_grid_line_index t (Cursor.int t)) t
-      in
-      match n with Some n -> Num_name (n, name) | None -> Name name)
+      if grid_line_at_end t then Name name
+      else
+        (* CSS Values 4 sec. 10 allows a math function wherever an [<integer>]
+           is allowed, so the index of a named line may be one. *)
+        let index t =
+          if Cursor.looking_at_calc t then
+            match read_integer_calc "grid-line" t with
+            | `Int n -> Num_name (check_grid_line_index t n, name)
+            | `Calc expr -> Calc_name (expr, name)
+          else Num_name (check_grid_line_index t (Cursor.int t), name)
+        in
+        match Cursor.option index t with Some line -> line | None -> Name name)
 
 let read_grid_line_calc t : grid_line =
-  match read_integer_calc "grid-line" t with
-  | `Int n -> Num (check_grid_line_index t n)
-  | `Calc expr -> Calc expr
+  let line =
+    match read_integer_calc "grid-line" t with
+    | `Int n -> `Int (check_grid_line_index t n)
+    | `Calc expr -> `Calc expr
+  in
+  Cursor.ws t;
+  (* sec. 8.3's [&&] puts the name on either side of the index, so a call in
+     that slot takes a trailing name like a literal does. *)
+  let name : string option =
+    if grid_line_at_end t then None else Cursor.option read_grid_line_name t
+  in
+  match (line, name) with
+  | `Int n, None -> Num n
+  | `Int n, Some name -> Num_name (n, name)
+  | `Calc expr, None -> Calc expr
+  | `Calc expr, Some name -> Calc_name (expr, name)
 
 let rec read_grid_line t : grid_line =
   Cursor.enum_or_calls "grid-line"

--- a/lib/properties_intf.ml
+++ b/lib/properties_intf.ml
@@ -874,6 +874,9 @@ type grid_line =
   | Span_name of string
   | Span_num_name of int * string
   | Calc of grid_line calc
+  | Calc_name of grid_line calc * string
+      (** CSS Values 4 sec. 10 allows a math function wherever an [<integer>] is
+          allowed, so the index of a named line may be one. *)
   | Var of grid_line var
 
 type grid_line_pair =

--- a/test/test_declaration.ml
+++ b/test/test_declaration.ml
@@ -2247,6 +2247,26 @@ let animations_timing () =
   neg_cursor read_declaration "animation-delay: calc(inherit + 1s)";
   neg_cursor read_declaration "animation-delay: calc(initial + 1s)";
   neg_cursor read_declaration "animation-delay: calc(unset + 1s)";
+  (* CSS Grid 2 sec. 8.3 spells a <grid-line> index and its name with [&&], so
+     the name sits on either side of the index, and sec. 10 puts a math function
+     wherever an <integer> goes. Chrome 153 keeps all four and serialises them
+     index-first. *)
+  check_declaration ~expected:"grid-row-start:2 center"
+    ~optimized:"grid-row-start:2 center" "grid-row-start: center calc(2)";
+  check_declaration ~expected:"grid-row-start:2 center"
+    ~optimized:"grid-row-start:2 center" "grid-row-start: calc(2) center";
+  check_declaration ~expected:"grid-row-start:calc(.5) center"
+    ~optimized:"grid-row-start:calc(.5) center"
+    "grid-row-start: center calc(.5)";
+  check_declaration ~expected:"grid-area:2 center"
+    ~optimized:"grid-area:2 center" "grid-area: center calc(2)";
+  (* sec. 8.3 writes the index [<integer [-inf,-1]> | <integer [1,inf]>], and
+     zero is in neither range whichever way it is spelled. Chrome refuses both
+     of these too. *)
+  neg_cursor read_declaration "grid-row-start: calc(0)";
+  neg_cursor read_declaration "grid-row-start: center calc(0)";
+  neg_cursor read_declaration "grid-row-start: center 0";
+
   (* sec. 10 allows a math function wherever an <integer> is allowed, and sec.
      10.12 rounds the call and clamps it, so a fractional or out-of-range call
      keeps its wrapper where the bare literal is refused. Chrome 153 agrees on


### PR DESCRIPTION
`grid-row-start: center calc(2)` and `grid-row-start: calc(2) center` were both dropped, and Chrome 153 keeps both. CSS Grid 2 sec. 8.3 joins a `<grid-line>` index and its name with `&&`, so the name sits on either side, and CSS Values 4 sec. 10 puts a math function wherever an `<integer>` goes. `Cascade.Properties.grid_line` gains `Calc_name`. Zero stays refused however it is spelled, since sec. 8.3's two ranges exclude it.