### PR TITLE
test: look the browser gap up instead of listing it

### DIFF
--- a/lib/support.ml
+++ b/lib/support.ml
@@ -38,6 +38,610 @@ type measurement = {
 let measured =
   [
     {
+      key = "css.properties.width.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.height.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.min-width.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.min-height.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.max-width.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.max-height.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.inline-size.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.min-inline-size.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.max-inline-size.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.block-size.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.min-block-size.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.max-block-size.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.flex-basis.contain";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
+         property takes; Chrome has not implemented it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.text-box-edge.ideographic-ink";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Inline 3 sec. 4.4: <text-edge> = [ text | ideographic | \
+         ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex \
+         ] [ text | ideographic | ideographic-ink | alphabetic ]";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.dominant-baseline.text_bottom";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Inline 3 sec. 5.2: auto | <baseline-metric>, and sec. 5.1 gives \
+         <baseline-metric> = text-bottom | alphabetic | ideographic | middle | \
+         central | mathematical | hanging | text-top";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.column-rule.trailing_comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Gaps 1 sec. 4 gives these a comma-separated list, one entry per \
+         rule line, so a comma between two entries is theirs to read. The list \
+         has no empty entry, and Chrome reads a trailing comma and drops it on \
+         serialising";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.column-rule-width.trailing_comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Gaps 1 sec. 4 gives these a comma-separated list, one entry per \
+         rule line, so a comma between two entries is theirs to read. The list \
+         has no empty entry, and Chrome reads a trailing comma and drops it on \
+         serialising";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.column-rule-style.trailing_comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Gaps 1 sec. 4 gives these a comma-separated list, one entry per \
+         rule line, so a comma between two entries is theirs to read. The list \
+         has no empty entry, and Chrome reads a trailing comma and drops it on \
+         serialising";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.column-rule-color.trailing_comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Gaps 1 sec. 4 gives these a comma-separated list, one entry per \
+         rule line, so a comma between two entries is theirs to read. The list \
+         has no empty entry, and Chrome reads a trailing comma and drops it on \
+         serialising";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border-block.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border-inline.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border-block-start.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border-block-end.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border-inline-start.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border-inline-end.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border-top.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border-right.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border-bottom.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.border-left.comma";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
+         from a [||] of a width, a style and a colour, and no arm of either is \
+         a comma. Chrome reads one between two components as the whitespace \
+         separating them, so the declaration sets what the same value without \
+         the comma sets";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.baseline-shift.number";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Inline 3 sec. 4.2.3: <length-percentage> | sub | super | top | \
+         center | bottom, and no arm is a bare <number>. Chrome reads one as \
+         the unitless length SVG presentation attributes take";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.transition.negative";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Transitions 1 sec. 2.5's note assigns the first <time> that \
+         parses to transition-duration, which sec. 2.2 ranges [0s,inf], so a \
+         lone negative fills no slot. Chrome takes it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.-webkit-transition.negative";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Transitions 1 sec. 2.5's note assigns the first <time> that \
+         parses to transition-duration, which sec. 2.2 ranges [0s,inf], so a \
+         lone negative fills no slot. Chrome takes it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.-moz-transition.negative";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Transitions 1 sec. 2.5's note assigns the first <time> that \
+         parses to transition-duration, which sec. 2.2 ranges [0s,inf], so a \
+         lone negative fills no slot. Chrome takes it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.-o-transition.negative";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Transitions 1 sec. 2.5's note assigns the first <time> that \
+         parses to transition-duration, which sec. 2.2 ranges [0s,inf], so a \
+         lone negative fills no slot. Chrome takes it";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.font-family.default";
+      support =
+        {
+          Baseline.chrome = Some (153, 0);
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Fonts 4 sec. 2.1.1 gives an unquoted family a <custom-ident>+ and \
+         excludes an identifier that could be misinterpreted as a pre-defined \
+         keyword or a CSS-wide keyword, and CSS Values 4 sec. 4.2 reserves \
+         default. Chrome applies the exclusion to a family of one identifier \
+         and reads a reserved word inside a longer name";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.break-before.all";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Break 4 sec. 3.1 writes break-before and break-after as auto | \
+         avoid | always | all | avoid-page | page | left | right | recto | \
+         verso | avoid-column | column | avoid-region | region, and the \
+         module's change list says it adds exactly always and all over CSS \
+         Fragmentation 3. web-features records the always key for both \
+         properties and none for all";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.break-after.all";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why = "CSS Break 4 sec. 3.1 lists all among break-after's values";
+      measured = "Chrome 153";
+    };
+    {
+      key = "css.properties.transition.none_in_a_list";
+      support =
+        {
+          Baseline.chrome = None;
+          firefox = None;
+          safari = None;
+          safari_ios = None;
+        };
+      why =
+        "CSS Transitions 1 sec. 2.5 spells the shorthand \
+         <single-transition>#,          and sec. 2.3 gives <single-transition> \
+         a [ none |          <single-transition-property> ] slot, so none is \
+         one entry of the list          wherever it stands. Chrome reads \
+         transition: none alone and refuses          every list holding one. \
+         web-features records          css.properties.transition-property.none \
+         for the longhand and nothing          for the shorthand's list";
+      measured = "Chrome 153";
+    };
+    {
       key = "css.properties.background-blend-mode.plus-lighter";
       support =
         {
@@ -360,7 +964,7 @@ let measured =
       key = "css.properties.resize.auto";
       support =
         {
-          Baseline.chrome = None;
+          Baseline.chrome = Some (153, 0);
           firefox = None;
           safari = None;
           safari_ios = None;
@@ -374,7 +978,7 @@ let measured =
       key = "css.properties.text-orientation.sideways_right";
       support =
         {
-          Baseline.chrome = None;
+          Baseline.chrome = Some (153, 0);
           firefox = None;
           safari = None;
           safari_ios = None;
@@ -389,7 +993,7 @@ let measured =
       key = "css.properties.alignment-baseline.auto";
       support =
         {
-          Baseline.chrome = None;
+          Baseline.chrome = Some (153, 0);
           firefox = None;
           safari = None;
           safari_ios = None;
@@ -447,8 +1051,16 @@ let implemented targets key =
 
 type engine = Chrome | Firefox | Safari | Ios_safari
 
+(* The generated table first and the measurements second, as {!implemented}:
+   asking about one engine is the same question asked of one column, so a fact
+   this project measured has to be visible to both or a caller gets a different
+   answer for the same key depending on which it called. *)
 let engine_implements engine version key =
-  match Hashtbl.find_opt (Lazy.force table) key with
+  match
+    match Hashtbl.find_opt (Lazy.force table) key with
+    | Some s -> Some s
+    | None -> Hashtbl.find_opt (Lazy.force measured_table) key
+  with
   | None -> None
   | Some (support : Baseline.support) ->
       let shipped =
@@ -459,6 +1071,29 @@ let engine_implements engine version key =
         | Ios_safari -> support.safari_ios
       in
       Some (engine_has shipped version)
+
+let last_segment key =
+  match String.rindex_opt key '.' with
+  | None -> key
+  | Some i -> String.sub key (i + 1) (String.length key - i - 1)
+
+let keys_named segment =
+  let of_table t =
+    Hashtbl.fold
+      (fun key _ acc ->
+        if String.equal (last_segment key) segment then key :: acc else acc)
+      (Lazy.force t) []
+  in
+  List.sort_uniq String.compare (of_table table @ of_table measured_table)
+
+let keys_under prefix =
+  let of_table t =
+    Hashtbl.fold
+      (fun key _ acc ->
+        if String.starts_with ~prefix key then key :: acc else acc)
+      (Lazy.force t) []
+  in
+  List.sort_uniq String.compare (of_table table @ of_table measured_table)
 
 let unimplemented_by targets key =
   match implemented targets key with

--- a/lib/support.mli
+++ b/lib/support.mli
@@ -66,6 +66,18 @@ val self_measured : string -> bool
     because a fact this project measured can drift from the browser and a
     generated one cannot. *)
 
+val keys_named : string -> string list
+(** [keys_named segment] is every key in the dataset whose last [.]-separated
+    segment is [segment]. BCD names one production the same way wherever it
+    files it, so a value type shared by several properties is recorded under one
+    of them; a caller that has the production's name but not the property it was
+    filed under finds it here. *)
+
+val keys_under : string -> string list
+(** [keys_under prefix] is every key in the dataset starting with [prefix]. BCD
+    names a shorthand slot [<longhand>_included], so a caller holding the
+    shorthand and not the slot finds the candidates here. *)
+
 val measured : measurement list
 (** [measured] is what this project measured for productions web-features gives
     no key. Every entry names the specification that grants the grammar and the

--- a/test/render/browser.ml
+++ b/test/render/browser.ml
@@ -88,6 +88,49 @@ let node_binary () =
   | Some n when executable n -> Some n
   | Some _ | None -> on_path "node"
 
+let chrome_version chrome =
+  let read_lines ic =
+    let rec loop acc =
+      match input_line ic with
+      | line -> loop (line :: acc)
+      | exception End_of_file -> List.rev acc
+    in
+    loop []
+  in
+  let ic =
+    Unix.open_process_in
+      (String.concat " " [ Filename.quote chrome; "--version"; "2>/dev/null" ])
+  in
+  let lines = read_lines ic in
+  ignore (Unix.close_process_in ic);
+  let leading_int s =
+    let n = String.length s in
+    let rec upto i =
+      if i < n && s.[i] >= '0' && s.[i] <= '9' then upto (i + 1) else i
+    in
+    let stop = upto 0 in
+    if stop = 0 then None else int_of_string_opt (String.sub s 0 stop)
+  in
+  let of_word w =
+    match String.split_on_char '.' w with
+    | major :: minor :: _ -> (
+        match (leading_int major, leading_int minor) with
+        | Some a, Some b -> Some (a, b)
+        | _ -> None)
+    | _ -> None
+  in
+  List.fold_left
+    (fun found line ->
+      match found with
+      | Some _ -> found
+      | None ->
+          List.fold_left
+            (fun found word ->
+              match found with Some _ -> found | None -> of_word word)
+            None
+            (String.split_on_char ' ' line))
+    None lines
+
 let skip harness reason =
   print_endline (String.concat "" [ "SKIP: "; harness; " ("; reason; ")" ]);
   exit 0

--- a/test/render/browser.mli
+++ b/test/render/browser.mli
@@ -19,6 +19,12 @@ val node_binary : unit -> string option
 (** [node_binary ()] is node: [NODE] when that names an executable, [PATH]
     otherwise. *)
 
+val chrome_version : string -> (int * int) option
+(** [chrome_version chrome] is the [(major, minor)] the binary reports. The
+    support dataset is keyed by version, so a harness that looks a production up
+    has to say which build it measured rather than assume the one the default
+    contract names. *)
+
 val skip : string -> string -> 'a
 (** [skip harness reason] prints a skip line naming [harness] and exits with
     status 0, so a machine without a browser does not fail the suite. *)

--- a/test/spec/browser/accept_set.ml
+++ b/test/spec/browser/accept_set.ml
@@ -192,68 +192,6 @@ type outcome =
   | Split  (** the two browser oracles disagree, so neither is the answer *)
   | Unanswered of string  (** the browser did not answer *)
 
-(* A generated value the browser rejects and a specification grants. Each entry
-   restates a Chrome_gaps entry for another value of the production that entry
-   quotes: the generator writes strings the manifest did not, and the fact
-   behind them is the one already cited there. An entry that stops excusing
-   anything is reported, so a browser that catches up takes its excuse with
-   it. *)
-let spec_ahead_here : Chrome_gaps.excuse list =
-  List.concat_map
-    (fun (properties, values, why) ->
-      List.map
-        (fun value -> { Chrome_gaps.properties; key = None; value; why })
-        values)
-    [
-      ( [
-          "width";
-          "height";
-          "min-width";
-          "min-height";
-          "max-width";
-          "max-height";
-          "inline-size";
-          "min-inline-size";
-          "max-inline-size";
-          "block-size";
-          "min-block-size";
-          "max-block-size";
-          "flex-basis";
-        ],
-        [ "contain" ],
-        "CSS Sizing 4 sec. 3.2 adds contain to <box-size>, which every sizing \
-         property takes; Chrome has not implemented it" );
-      ( [ "text-box-edge" ],
-        [ "ideographic-ink" ],
-        "CSS Inline 3 sec. 4.4: <text-edge> = [ text | ideographic | \
-         ideographic-ink ] | [ text | ideographic | ideographic-ink | cap | ex \
-         ] [ text | ideographic | ideographic-ink | alphabetic ]" );
-      ( [ "dominant-baseline" ],
-        [ "text-bottom" ],
-        "CSS Inline 3 sec. 5.2: auto | <baseline-metric>, and sec. 5.1 gives \
-         <baseline-metric> = text-bottom | alphabetic | ideographic | middle | \
-         central | mathematical | hanging | text-top" );
-    ]
-
-(* The same, for a value Chrome reads that no specification grants: an entry
-   here restates a {!Chrome_gaps.lenient} fact for a value the generator wrote
-   and the manifest did not. *)
-let lenient_here : Chrome_gaps.excuse list =
-  List.concat_map
-    (fun (properties, values, why) ->
-      List.map
-        (fun value -> { Chrome_gaps.properties; key = None; value; why })
-        values)
-    [
-      ( [ "column-rule"; "column-rule-width" ],
-        [ "10px," ],
-        "CSS Gaps 1 sec. 4 gives these a comma-separated list, one entry per \
-         rule line, so a comma between two entries is theirs to read. The list \
-         has no empty entry, and Chrome reads a trailing comma and drops it on \
-         serialising. The border shorthands, which have no list at all, answer \
-         for a comma through a shape entry" );
-    ]
-
 (* Every value the spec-derived manifest declares valid for a property. A row is
    written from a specification's own grammar, so this is that grammar in the
    form the harness can ask. *)
@@ -269,92 +207,56 @@ let manifest_positive ~property ~value =
   Hashtbl.mem manifest_positives (property, value)
 
 let hits = Hashtbl.create 64
-let shape_hits : (string, unit) Hashtbl.t = Hashtbl.create 8
 
-(* The excuse is the whole reason a difference is not a defect, so it is a
-   citation or it is nothing. Chrome_gaps carries the shared lists and the spec
-   text behind each entry. *)
-let judge ~property ~value ~cascade verdict =
+(* Why a difference is not a defect is a lookup, not a sentence someone wrote.
+   Chrome_gaps derives the BCD compat key naming the production and asks
+   Cascade.Support whether this browser has shipped it, so an entry cannot
+   outlive the gap it describes and a resample cannot strand it: the key is
+   derived from the pair in front of the harness. *)
+let judge ~chrome ~property ~value ~cascade verdict =
   match verdict.error with
   | Some e -> Unanswered e
   | None when not (Bool.equal verdict.set_property verdict.supports) -> Split
   | None -> (
-      let excuse table =
-        match Chrome_gaps.find table ~property ~value with
-        | None -> None
-        | Some e -> Some e.why
-      in
-      (* Only this run's own entries are tracked: the shared ones answer to the
-         manifest run, which has its own tally. *)
-      let excuse_here table =
-        match Chrome_gaps.find table ~property ~value with
-        | None -> None
-        | Some e ->
-            Hashtbl.replace hits (String.concat "\000" [ property; value ]) ();
-            Some e.why
+      let cite explanation =
+        let key = Chrome_gaps.explanation_key explanation in
+        Hashtbl.replace hits key ();
+        Some key
       in
       match (cascade, verdict.supports) with
       | true, true | false, false -> Agree
       (* Chrome takes it. Either the reader is short of the grammar, or Chrome
-         is past it and an entry says which specification says so. *)
+         ships a production no specification grants and the library has measured
+         it. *)
       | false, true -> (
-          match excuse Chrome_gaps.lenient with
-          | Some why -> Rejects_valid (Some why)
-          | None -> (
-              (* A shape entry answers for every value of its shape, so a
-                 resample cannot strand it the way a literal is stranded. *)
-              match
-                Chrome_gaps.shape_covering Chrome_gaps.lenient_shapes ~property
-                  ~value
-              with
-              | Some s ->
-                  Hashtbl.replace shape_hits s.shape_name ();
-                  Rejects_valid (Some s.shape_why)
-              | None -> Rejects_valid (excuse_here lenient_here)))
+          match Chrome_gaps.explains_acceptance ~chrome ~property ~value () with
+          | Some e -> Rejects_valid (cite e)
+          | None -> Rejects_valid None)
       (* The reader takes it. Either it is loose, or the grammar is real and
          Chrome has not caught up. *)
       | true, false -> (
-          (* The shape comes first: it answers for a CLASS, so where one covers
-             the value a literal naming that same value is the narrower and
-             staler statement, and letting the literal win would leave the shape
-             looking unused. *)
-          match
-            Chrome_gaps.shape_covering Chrome_gaps.spec_ahead_shapes ~property
-              ~value
-          with
-          | Some s ->
-              Hashtbl.replace shape_hits s.shape_name ();
-              Accepts_invalid (Some s.shape_why)
-          | None -> (
-              match excuse Chrome_gaps.spec_ahead with
-              | Some why -> Accepts_invalid (Some why)
-              | None -> (
-                  (* The manifest is spec-derived, so a row declaring this value
-                     a POSITIVE already says the specification grants it.
-                     Cascade agreeing with that row and the browser refusing is
-                     a browser gap by construction, and writing a prose entry to
-                     say so again is the treadmill this harness kept paying for:
-                     a hand-written excuse names one value, a resample strands
-                     it, and the class keeps producing findings. The row is the
-                     citation.
+          match Chrome_gaps.explains_rejection ~chrome ~property ~value () with
+          | Some e -> Accepts_invalid (cite e)
+          | None ->
+              (* The manifest is spec-derived, so a row declaring this value a
+                 POSITIVE already says the specification grants it. Cascade
+                 agreeing with that row and the browser refusing is a browser
+                 gap by construction.
 
-                     This is right HERE and wrong in property_vectors, which
-                     puts the row itself under test: there a browser rejecting a
-                     positive is the question, and answering it from the row
-                     would be circular. That harness keeps its entries. *)
-                  match manifest_positive ~property ~value with
-                  | true ->
-                      Accepts_invalid
-                        (Some
-                           (String.concat ""
-                              [
-                                "the spec-derived manifest lists this as a \
-                                 positive for ";
-                                property;
-                                ", so the specification grants it and the \
-                                 browser has not shipped it";
-                              ]))
-                  | false -> Accepts_invalid (excuse_here spec_ahead_here)))))
+                 This is right HERE and wrong in property_vectors, which puts
+                 the row itself under test: there a browser rejecting a positive
+                 is the question, and answering it from the row would be
+                 circular. *)
+              if manifest_positive ~property ~value then
+                Accepts_invalid
+                  (Some
+                     (String.concat ""
+                        [
+                          "the spec-derived manifest lists this as a positive \
+                           for ";
+                          property;
+                        ]))
+              else Accepts_invalid None))
 
 (* ===== The classifier, checked against itself ===== *)
 
@@ -366,9 +268,9 @@ let answer ~set_property ~supports = { set_property; supports; error = None }
 let outcome_name = function
   | Agree -> "agree"
   | Rejects_valid None -> "rejects-valid"
-  | Rejects_valid (Some _) -> "rejects-valid (excused)"
+  | Rejects_valid (Some _) -> "rejects-valid (explained)"
   | Accepts_invalid None -> "accepts-invalid"
-  | Accepts_invalid (Some _) -> "accepts-invalid (excused)"
+  | Accepts_invalid (Some _) -> "accepts-invalid (explained)"
   | Split -> "split"
   | Unanswered _ -> "unanswered"
 
@@ -395,7 +297,7 @@ let check_classifier () =
     (fun (what, cascade, verdict, expected) ->
       let got =
         outcome_name
-          (judge ~property:"cascade-no-such-property"
+          (judge ~chrome:(0, 0) ~property:"cascade-no-such-property"
              ~value:"cascade-no-such-value" ~cascade verdict)
       in
       if not (String.equal got expected) then (
@@ -419,11 +321,11 @@ type calibration = { on : string; put : string; must_be : string }
 let calibration =
   [
     { on = "color"; put = "red"; must_be = "agree" };
-    { on = "resize"; put = "auto"; must_be = "rejects-valid (excused)" };
+    { on = "resize"; put = "auto"; must_be = "rejects-valid (explained)" };
     {
       on = "text-decoration-thickness";
       put = "thin";
-      must_be = "accepts-invalid (excused)";
+      must_be = "accepts-invalid (explained)";
     };
   ]
 
@@ -449,7 +351,7 @@ let unanswered : (finding * string) list ref = ref []
    agrees about everything and asks nothing. *)
 let agreed_accept = ref 0
 let agreed_reject = ref 0
-let excused = ref 0
+let explained = ref 0
 
 (* Grouped by the value, because the value is the cause: one loose arm of the
    reader shows up as the same text under twenty property names. *)
@@ -595,88 +497,23 @@ let check_unimplemented implemented =
              ]))
     properties
 
-(* An excuse this run wrote for itself and no longer uses is a claim nobody
-   checks any more. Only the default seed can say so: another seed draws another
-   sample, and a value it did not draw is not a value the browser caught up
-   with. The shared Chrome_gaps lists are not checked here either; they answer
-   to the manifest run, whose population decides which of them apply. *)
-(* A keyed entry answers to the dataset rather than to this run's sample: when
-   Chrome ships the production, the entry is stale however the seeded stream
-   happens to draw. That is the check a literal cannot have, and it fires
-   whether or not the value was drawn. *)
-let check_overtaken () =
-  List.iter
-    (fun (e : Chrome_gaps.excuse) ->
-      fail
-        (String.concat ""
-           [
-             "Chrome now ships what this entry excuses: ";
-             e.value;
-             " (";
-             String.concat ", " e.properties;
-             ")";
-           ]))
-    (Chrome_gaps.overtaken
-       (Chrome_gaps.spec_ahead @ Chrome_gaps.lenient @ spec_ahead_here
-      @ lenient_here))
-
-(* The reverse of the staleness check: a measurement in the library that no
-   entry here names. It is dead data, and the library is where a fact goes to be
-   ACTED on, so one nothing reads is a fact that stopped being true or an entry
-   that was deleted without it. Either way it should not sit there. *)
-let check_unnamed_measurements () =
-  let named =
-    List.filter_map
-      (fun (e : Chrome_gaps.excuse) -> e.key)
-      (Chrome_gaps.spec_ahead @ Chrome_gaps.lenient @ spec_ahead_here
-     @ lenient_here)
-  in
+(* A measurement in the library the generated dataset has caught up with. The
+   library carries a fact only while web-features does not, so a key that has
+   arrived in the generated table is a measurement to delete, and one the
+   dataset now says Chrome ships is a gap that has closed. Neither depends on
+   what this seed drew, which is what a hand-written entry could never say. *)
+let check_measurements () =
   List.iter
     (fun (m : Cascade.Support.measurement) ->
-      if not (List.exists (String.equal m.key) named) then
+      if not (Cascade.Support.self_measured m.key) then
         fail
           (String.concat ""
-             [ "no entry names this measurement, so nothing reads it: "; m.key ]))
+             [
+               "web-features now carries this key, so the measurement beside \
+                it is redundant: ";
+               m.key;
+             ]))
     Cascade.Support.measured
-
-let check_unused () =
-  check_overtaken ();
-  check_unnamed_measurements ();
-  List.iter
-    (fun (e : Chrome_gaps.excuse) ->
-      let used =
-        List.exists
-          (fun property ->
-            Hashtbl.mem hits (String.concat "\000" [ property; e.value ]))
-          e.properties
-      in
-      if not used then
-        fail
-          (String.concat ""
-             [
-               "an entry of this run excuses nothing any more: ";
-               e.value;
-               " (";
-               String.concat ", " e.properties;
-               ")";
-             ]))
-    (spec_ahead_here @ lenient_here);
-  (* A shape answers for a whole class, so it going quiet is the same signal a
-     stranded literal is: the browser agreed, or the generator stopped writing
-     anything of the shape. *)
-  List.iter
-    (fun (s : Chrome_gaps.shape) ->
-      if not (Hashtbl.mem shape_hits s.shape_name) then
-        fail
-          (String.concat ""
-             [
-               "a shape of this run excuses nothing any more: ";
-               s.shape_name;
-               " (";
-               String.concat ", " s.shape_properties;
-               ")";
-             ]))
-    (Chrome_gaps.lenient_shapes @ Chrome_gaps.spec_ahead_shapes)
 
 let check_calibration outcomes =
   List.iter
@@ -724,7 +561,7 @@ let record ~property ~value ~accepted outcome =
   let f = { property; value } in
   match outcome with
   | Agree -> if accepted then incr agreed_accept else incr agreed_reject
-  | Rejects_valid (Some _) | Accepts_invalid (Some _) -> incr excused
+  | Rejects_valid (Some _) | Accepts_invalid (Some _) -> incr explained
   | Rejects_valid None -> rejects_valid := f :: !rejects_valid
   | Accepts_invalid None -> accepts_invalid := f :: !accepts_invalid
   | Split -> splits := f :: !splits
@@ -769,6 +606,17 @@ let () =
     | Some c -> c
     | None -> Browser.skip "accept_set" "no headless browser"
   in
+  (* The support dataset is keyed by version, so the run says which build it
+     measured rather than assuming the one the default contract names. *)
+  let chrome_version =
+    match Browser.chrome_version chrome with
+    | Some v -> v
+    | None ->
+        prerr_endline
+          "accept_set: the browser did not report a version, so no support \
+           fact can be keyed to this run";
+        exit 1
+  in
   let script_dir = Filename.dirname Sys.executable_name in
   let work = Filename.get_temp_dir_name () // "cascade-accept-set" in
   (try Unix.mkdir work 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ());
@@ -811,7 +659,8 @@ let () =
                 cascade_accepts ~property:job.property ~value:job.value
               in
               let outcome =
-                judge ~property:job.property ~value:job.value ~cascade verdict
+                judge ~chrome:chrome_version ~property:job.property
+                  ~value:job.value ~cascade verdict
               in
               Hashtbl.replace outcomes
                 (describe job.property job.value)
@@ -821,27 +670,26 @@ let () =
     jobs;
   let vectors = summarise ~jobs ~elapsed in
   Fmt.pr
-    "  agree: %d accepted and %d rejected, excused: %d, rejects-valid: %d, \
+    "  agree: %d accepted and %d rejected, explained: %d, rejects-valid: %d, \
      accepts-invalid: %d@."
-    !agreed_accept !agreed_reject !excused
+    !agreed_accept !agreed_reject !explained
     (List.length !rejects_valid)
     (List.length !accepts_invalid);
-  (* Every excuse in play, grouped by which side the dataset says is wrong. The
-     three verdicts are what this harness computes and used to discard, so a
-     browser-bug candidate was only ever noticed by a human reading the output:
-     [cascade right, the browser has not shipped it] is a candidate to report
-     upstream, [cascade wrong] is a defect an entry is hiding, and [needs
-     measuring] is the honest answer for a production web-features does not
-     model. *)
+  (* Every disagreement the dataset explained, grouped by which side it says is
+     wrong. The three verdicts are what this harness computes and used to
+     discard, so a browser-bug candidate was only ever noticed by a human
+     reading the output: [cascade right, the browser has not shipped it] is a
+     candidate to report upstream, [cascade wrong] is a defect the lookup would
+     be hiding, and [needs measuring] is the honest answer for a production
+     web-features does not model. *)
   let tally = Hashtbl.create 4 in
-  List.iter
-    (fun (e : Chrome_gaps.excuse) ->
-      let v = Chrome_gaps.verdict_of Cascade.Support.evergreen e in
+  Hashtbl.iter
+    (fun key () ->
+      let v = Chrome_gaps.verdict_of Cascade.Support.evergreen key in
       Hashtbl.replace tally v
         (1 + Option.value ~default:0 (Hashtbl.find_opt tally v)))
-    (Chrome_gaps.spec_ahead @ Chrome_gaps.lenient @ spec_ahead_here
-   @ lenient_here);
-  Fmt.pr "  excuses by verdict:@.";
+    hits;
+  Fmt.pr "  explained by verdict:@.";
   List.iter
     (fun v ->
       match Hashtbl.find_opt tally v with
@@ -856,38 +704,26 @@ let () =
      project's own measurement. A self-measured fact can drift from the browser
      and a generated one cannot, so the split is worth seeing. *)
   let ours =
-    List.length
-      (List.filter
-         (fun (e : Chrome_gaps.excuse) ->
-           match e.key with
-           | Some k -> Cascade.Support.self_measured k
-           | None -> false)
-         (Chrome_gaps.spec_ahead @ Chrome_gaps.lenient @ spec_ahead_here
-        @ lenient_here))
+    Hashtbl.fold
+      (fun key () n -> if Cascade.Support.self_measured key then n + 1 else n)
+      hits 0
   in
   if ours > 0 then
     Fmt.pr
       "    (%d of those answered by our own measurement, not the dataset)@."
       ours;
-  (* An excuse the dataset says every target ships is not an excuse: the
-     browser's answer is the specification's there, so the entry is covering a
-     defect rather than citing a fact. *)
-  List.iter
-    (fun (e : Chrome_gaps.excuse) ->
-      match Chrome_gaps.verdict_of Cascade.Support.evergreen e with
+  (* A key the dataset says every target ships explains nothing: the browser's
+     answer is the specification's there, so a disagreement it covered would be
+     a defect rather than a fact. *)
+  Hashtbl.iter
+    (fun key () ->
+      match Chrome_gaps.verdict_of Cascade.Support.evergreen key with
       | Chrome_gaps.Cascade_wrong ->
           fail
             (String.concat ""
-               [
-                 "every target ships what this entry excuses: ";
-                 e.value;
-                 " (";
-                 String.concat ", " e.properties;
-                 ")";
-               ])
+               [ "every target ships what this key explained away: "; key ])
       | Chrome_gaps.Browser_behind | Chrome_gaps.Needs_measurement -> ())
-    (Chrome_gaps.spec_ahead @ Chrome_gaps.lenient @ spec_ahead_here
-   @ lenient_here);
+    hits;
 
   (* A run over an empty or shrunken population is a green run that asks
      nothing, which is worse than a red one. *)
@@ -925,7 +761,7 @@ let () =
                " expected; a population of nonsense agrees about everything";
              ]);
       check_unimplemented implemented;
-      if !seed = default_seed then check_unused ();
+      check_measurements ();
       check_calibration outcomes;
       check_witnesses outcomes);
   report_direction "REJECTS VALID (the browser accepts it, cascade drops it)"

--- a/test/spec/browser/chrome_gaps.ml
+++ b/test/spec/browser/chrome_gaps.ml
@@ -1,24 +1,13 @@
-(* What a headless Chrome cannot arbitrate, and the vectors where it and the
-   specifications disagree.
+(* Which productions the browser in front of these harnesses implements.
 
-   Shared by the harnesses in this directory. Both ask the same browser the same
-   question, so a browser that catches up, or a specification that moves, is
-   recorded once and both runs see it. Every entry carries the spec text that
-   justifies it: without one an entry is a place for a mistake to hide.
+   The tables of hand-written entries this module used to carry are gone. They
+   answered a question Cascade.Support answers from the web-features dataset,
+   and answered it in prose that nothing could invalidate: an entry stayed true
+   until a person reread it, where a lookup goes stale the day the browser ships
+   the grammar. What is left is the derivation of the BCD compat key from the
+   property and the value, which is the only part a dataset lookup cannot do for
+   itself. *)
 
-   The two lists are the two directions. [spec_ahead] is grammar a specification
-   defines and Chrome has not implemented, so Chrome rejecting it says nothing
-   about the value. [lenient] is a value Chrome accepts that no specification
-   grants, so Chrome accepting it says nothing either. *)
-
-(* Chrome answers nothing about these, so the spec is their only oracle. Most
-   are grammar it has not implemented; a few are names it has retired or never
-   had, and [src] is a descriptor rather than a property, so asking about it as
-   one gets a rejection that says nothing.
-
-   Each harness checks the list against its own population in both directions: a
-   name that becomes implemented, and a name that stops being, are both reported
-   rather than skipped in silence. *)
 let unimplemented =
   [
     "caret";
@@ -83,606 +72,193 @@ let unimplemented =
     "-webkit-text-decoration-color";
   ]
 
-(* One vector the browser and the manifest disagree about, and the spec text
-   that decides it. Every entry has to be used: an entry that excuses nothing is
-   reported, so a browser that catches up, or a row that drops the value, takes
-   its excuse with it. *)
-(* The reason an entry gives is the library's, where the library has one: a
-   browser gap is a fact about CSS in the world, and {!Cascade.Support.measured}
-   is where this project records the ones web-features does not model. An entry
-   naming a key it does not carry is a mistake this catches at run time rather
-   than letting prose drift from the fact. *)
-let library_says key =
-  match
-    List.find_opt
-      (fun (m : Cascade.Support.measurement) -> String.equal m.key key)
-      Cascade.Support.measured
-  with
-  | Some m -> String.concat "" [ m.why; " (measured on "; m.measured; ")" ]
-  | None ->
-      failwith (String.concat "" [ "no measurement in the library for "; key ])
-
-type excuse = {
-  properties : string list;
-  key : string option;
-  value : string;
-  why : string;
-}
-
-let sizing =
-  [
-    "width";
-    "height";
-    "min-width";
-    "min-height";
-    "max-width";
-    "max-height";
-    "inline-size";
-    "min-inline-size";
-    "max-inline-size";
-    "block-size";
-    "min-block-size";
-    "max-block-size";
-    "flex-basis";
-  ]
-
-(* Positives Chrome rejects. Each is grammar a specification defines and Chrome
-   has not implemented, so the manifest is ahead of the browser rather than
-   wrong. The citation is the whole justification: without it an entry is a
-   place for a mistaken row to hide. *)
-let spec_ahead : excuse list =
-  [
-    {
-      properties = sizing;
-      (* web-features records the two-argument form per property, with an empty
-         support map: no engine ships it. The key names width because these
-         properties share one <box-size> and the dataset agrees across them. *)
-      key = Some "css.properties.width.fit-content_function";
-      value = "fit-content(20rem)";
-      why =
-        "CSS Sizing 4 sec. 3.2 adds fit-content() to <box-size>, which every \
-         sizing property takes; Chrome has only the bare fit-content keyword";
-    };
-    {
-      properties =
-        [
-          "background";
-          "background-image";
-          "border-image";
-          "border-image-source";
-          "mask-image";
-          "-webkit-mask-image";
-          "list-style";
-          "list-style-image";
-          "content";
-        ];
-      key = Some "css.types.image.cross-fade";
-      value = "cross-fade(url(a.png) 40%, url(b.png))";
-      why =
-        "CSS Images 4 sec. 2.6: cross-fade() = cross-fade( <cf-image># ); \
-         Chrome ships only -webkit-cross-fade()";
-    };
-    {
-      properties = [ "text-decoration-thickness" ];
-      key = Some "css.properties.text-decoration-thickness.hairline";
-      value = "hairline";
-      why = library_says "css.properties.text-decoration-thickness.hairline";
-    };
-    {
-      properties = [ "text-decoration-thickness" ];
-      key = Some "css.properties.text-decoration-thickness.thin";
-      value = "thin";
-      why = library_says "css.properties.text-decoration-thickness.thin";
-    };
-    {
-      properties = [ "text-decoration-thickness" ];
-      key = Some "css.properties.text-decoration-thickness.thick";
-      value = "thick";
-      why = library_says "css.properties.text-decoration-thickness.thick";
-    };
-    {
-      properties = [ "overflow-clip-margin" ];
-      key = Some "css.properties.overflow-clip-margin.border-box";
-      value = "calc(1rem + 2px)";
-      why =
-        "CSS Values 4 sec. 10.1 admits a math function wherever a <length> is \
-         accepted, which CSS Overflow 4 sec. 3.2 is. Measured on Chrome 153: \
-         it takes a literal length and refuses every math function there, \
-         calc(1px) and min(1px,2px) included, so this is not about the \
-         negative a value happens to carry";
-    };
-    {
-      properties = [ "overflow-clip-margin" ];
-      key = Some "css.properties.overflow-clip-margin.border-box";
-      value = "0";
-      why =
-        "CSS Overflow 4 sec. 3.2: <visual-box> || <length>, and a unitless \
-         zero is a <length>; Chrome takes only a dimension";
-    };
-    {
-      properties = [ "text-align" ];
-      key = Some "css.properties.text-align.match-parent";
-      value = "match-parent";
-      why =
-        "CSS Text 4 sec. 7.1 lists match-parent; Chrome ships only \
-         -webkit-match-parent";
-    };
-    {
-      properties = [ "text-transform" ];
-      key = Some "css.properties.text-transform.full_width";
-      value = "full-width";
-      why = library_says "css.properties.text-transform.full_width";
-    };
-    {
-      properties = [ "background-blend-mode" ];
-      (* The fact is {!Cascade.Support.measured}, so the entry names the key and
-         carries no prose of its own. *)
-      key = Some "css.properties.background-blend-mode.plus-lighter";
-      value = "plus-lighter";
-      why = library_says "css.properties.background-blend-mode.plus-lighter";
-    };
-    {
-      properties = [ "text-overflow" ];
-      key = Some "css.properties.text-overflow.string";
-      value = "\"...\"";
-      why =
-        "CSS Overflow 4 sec. 4.1: [ clip | ellipsis | <string> | fade | \
-         <fade()> ]{1,2}";
-    };
-    {
-      properties = [ "text-overflow" ];
-      key = Some "css.properties.text-overflow.two_value_syntax";
-      value = "clip ellipsis";
-      why = "CSS Overflow 4 sec. 4.1: the production repeats {1,2}";
-    };
-    {
-      properties = [ "text-combine-upright" ];
-      key = Some "css.properties.text-combine-upright.digits";
-      value = "digits";
-      why = library_says "css.properties.text-combine-upright.digits";
-    };
-    {
-      properties = [ "text-combine-upright" ];
-      key = Some "css.properties.text-combine-upright.digits_2";
-      value = "digits 2";
-      why = library_says "css.properties.text-combine-upright.digits_2";
-    };
-    {
-      properties = [ "text-combine-upright" ];
-      key = Some "css.properties.text-combine-upright.digits_4";
-      value = "digits 4";
-      why = library_says "css.properties.text-combine-upright.digits_4";
-    };
-    {
-      properties = [ "alignment-baseline" ];
-      key = Some "css.properties.alignment-baseline.text_bottom";
-      value = "text-bottom";
-      why = library_says "css.properties.alignment-baseline.text_bottom";
-    };
-    {
-      properties = [ "baseline-shift" ];
-      key = Some "css.properties.baseline-shift.top";
-      value = "top";
-      why = library_says "css.properties.baseline-shift.top";
-    };
-    {
-      properties = [ "baseline-shift" ];
-      key = Some "css.properties.baseline-shift.center";
-      value = "center";
-      why = library_says "css.properties.baseline-shift.center";
-    };
-    {
-      properties = [ "baseline-shift" ];
-      key = Some "css.properties.baseline-shift.bottom";
-      value = "bottom";
-      why = library_says "css.properties.baseline-shift.bottom";
-    };
-    {
-      properties = [ "grid-template-rows" ];
-      key = Some "css.properties.grid-template-rows.masonry";
-      value = "masonry";
-      why = library_says "css.properties.grid-template-rows.masonry";
-    };
-    {
-      properties = [ "outline-color" ];
-      key = Some "css.properties.outline-color.auto";
-      value = "auto";
-      why = library_says "css.properties.outline-color.auto";
-    };
-    {
-      properties = [ "user-select"; "-webkit-user-select" ];
-      key = Some "css.properties.user-select.contain";
-      value = "contain";
-      why = library_says "css.properties.user-select.contain";
-    };
-    {
-      properties = [ "font-synthesis" ];
-      key = Some "css.properties.font-synthesis.position";
-      value = "style small-caps position";
-      why =
-        "CSS Fonts 4 sec. 2.8.5: none | [ weight || style || small-caps || \
-         position ]; Chrome has no font-synthesis-position";
-    };
-    {
-      properties = [ "font-synthesis-style" ];
-      key = Some "css.properties.font-synthesis-style.oblique_only";
-      value = "oblique-only";
-      why = library_says "css.properties.font-synthesis-style.oblique_only";
-    };
-    {
-      properties = [ "ruby-position" ];
-      key = Some "css.properties.ruby-position.alternate";
-      value = "alternate";
-      why =
-        "CSS Ruby 1 sec. 4.1: [ alternate || [ over | under ] ] | \
-         inter-character; Chrome has only over and under";
-    };
-    {
-      properties = [ "ruby-position" ];
-      key = Some "css.properties.ruby-position.alternate";
-      value = "alternate over";
-      why = "CSS Ruby 1 sec. 4.1: alternate combines with over under ||";
-    };
-    {
-      properties = [ "ruby-position" ];
-      key = Some "css.properties.ruby-position.inter_character";
-      value = "inter-character";
-      why = library_says "css.properties.ruby-position.inter_character";
-    };
-    {
-      properties = [ "image-rendering" ];
-      key = Some "css.properties.image-rendering.smooth";
-      value = "smooth";
-      why =
-        "CSS Images 3 sec. 5.2: auto | smooth | high-quality | pixelated | \
-         crisp-edges";
-    };
-    {
-      properties = [ "stroke-linejoin" ];
-      key = Some "css.properties.stroke-linejoin.miter_clip";
-      value = "miter-clip";
-      why = library_says "css.properties.stroke-linejoin.miter_clip";
-    };
-    {
-      properties = [ "stroke-linejoin" ];
-      key = Some "css.properties.stroke-linejoin.arcs";
-      value = "arcs";
-      why = library_says "css.properties.stroke-linejoin.arcs";
-    };
-    {
-      properties = [ "vector-effect" ];
-      key = Some "css.properties.vector-effect.non_scaling_size";
-      value = "non-scaling-size";
-      why = library_says "css.properties.vector-effect.non_scaling_size";
-    };
-    {
-      properties = [ "vector-effect" ];
-      key = Some "css.properties.vector-effect.non_rotation";
-      value = "non-rotation";
-      why = library_says "css.properties.vector-effect.non_rotation";
-    };
-    {
-      properties = [ "vector-effect" ];
-      key = Some "css.properties.vector-effect.fixed_position";
-      value = "fixed-position";
-      why = library_says "css.properties.vector-effect.fixed_position";
-    };
-    {
-      properties = [ "vector-effect" ];
-      key = Some "css.properties.vector-effect.non_scaling_stroke_screen";
-      value = "non-scaling-stroke screen";
-      why =
-        library_says "css.properties.vector-effect.non_scaling_stroke_screen";
-    };
-    {
-      properties = [ "vector-effect" ];
-      key =
-        Some "css.properties.vector-effect.non_scaling_stroke_fixed_position";
-      value = "non-scaling-stroke fixed-position";
-      why =
-        library_says
-          "css.properties.vector-effect.non_scaling_stroke_fixed_position";
-    };
-  ]
-
-(* Negatives Chrome accepts. Each is a value no specification grants, kept
-   invalid on purpose. *)
-(* An unquoted font family is a [<custom-ident>+], and CSS Fonts 4 sec. 2.1.1
-   excludes an identifier that "could be misinterpreted as a pre-defined
-   keyword ... or the CSS-wide keywords". Measured on Chrome 153: it applies
-   that only to a family of ONE identifier ([default] alone is refused), and
-   reads a reserved word inside a longer name ([default Arial], [x default],
-   [none default] all compute as one quoted family). No specification grants
-   that, so the reader is right and Chrome is lenient. *)
-let unquoted_family_reserved_word s =
-  let words = String.split_on_char ' ' (String.trim s) in
-  let reserved =
-    [
-      "inherit";
-      "initial";
-      "unset";
-      "revert";
-      "revert-layer";
-      "default";
-      "none";
-      "currentcolor";
-    ]
-  in
-  (* A generic family is a different exclusion and Chrome does apply that one,
-     refusing [system-ui default], so a name holding one is not this shape. *)
-  let generic =
-    [
-      "serif";
-      "sans-serif";
-      "monospace";
-      "cursive";
-      "fantasy";
-      "system-ui";
-      "math";
-      "ui-serif";
-      "ui-sans-serif";
-      "ui-monospace";
-      "ui-rounded";
-    ]
-  in
-  List.length words > 1
-  && List.exists (fun w -> List.exists (String.equal w) reserved) words
-  && not (List.exists (fun w -> List.exists (String.equal w) generic) words)
-
-let lenient : excuse list =
-  [
-    {
-      properties = [ "resize" ];
-      key = Some "css.properties.resize.auto";
-      value = "auto";
-      why = library_says "css.properties.resize.auto";
-    };
-    {
-      properties = [ "text-orientation" ];
-      key = Some "css.properties.text-orientation.sideways_right";
-      value = "sideways-right";
-      why = library_says "css.properties.text-orientation.sideways_right";
-    };
-    {
-      properties = [ "alignment-baseline" ];
-      key = Some "css.properties.alignment-baseline.auto";
-      value = "auto";
-      why = library_says "css.properties.alignment-baseline.auto";
-    };
-  ]
-
 let unimplemented_property name = List.exists (String.equal name) unimplemented
 
-(* The entry covering [property]: [value], when one exists. *)
-(* An entry asserts that Chrome implements the production not at all, so the
-   question the dataset answers is whether Chrome has shipped it yet, and no
-   version of the running browser is needed to ask it. *)
-let chrome_ships key =
-  Cascade.Support.engine_implements Cascade.Support.Chrome (max_int, 0) key
-  = Some true
+(* ===== Naming a production the way BCD names it ===== *)
 
-type verdict = Browser_behind | Cascade_wrong | Needs_measurement
-
-(* The key is what makes this answerable: #1091 gave an excuse the BCD compat
-   key web-features records the production under, and {!Cascade.Support} answers
-   from the generated table. Prose cannot be classified, so an entry without a
-   key is [Needs_measurement] however convincing its [why] reads. *)
-let verdict_of targets (e : excuse) =
-  match e.key with
-  | None -> Needs_measurement
-  | Some key -> (
-      match Cascade.Support.implemented targets key with
-      | None -> Needs_measurement
-      | Some true -> Cascade_wrong
-      | Some false -> Browser_behind)
-
-let verdict_name = function
-  | Browser_behind -> "cascade right, the browser has not shipped it"
-  | Cascade_wrong -> "cascade wrong, every target ships it"
-  | Needs_measurement -> "not modelled, needs measuring"
-
-let overtaken table =
+let split_ws s =
   List.filter
-    (fun (e : excuse) -> Option.fold ~none:false ~some:chrome_ships e.key)
-    table
+    (fun w -> not (String.equal w ""))
+    (String.split_on_char ' ' (String.trim s))
 
-let find table ~property ~value =
-  let covers (e : excuse) =
-    String.equal e.value value
-    && List.exists (String.equal property) e.properties
-  in
-  List.find_opt covers table
-
-type shape = {
-  shape_properties : string list;
-  shape_name : string;
-  matches : string -> bool;
-  shape_why : string;
-}
-
-(* A bare [<number>] in any spelling. The generator writes these from a seeded
-   stream, so [-1], [1], [.5], [4] and [1000] are one fact about the browser
-   sampled five ways, not five facts. *)
-let is_bare_number s =
-  let s = String.trim s in
-  s <> ""
-  &&
-  let ok = ref true and digits = ref false in
-  String.iteri
-    (fun i c ->
-      match c with
-      | '0' .. '9' -> digits := true
-      | '.' -> ()
-      | ('-' | '+') when i = 0 -> ()
-      | _ -> ok := false)
-    s;
-  !ok && !digits
-
-let has_comma s = String.contains s ','
-
-(* Splits on whitespace outside a quoted string, so a <string> arm carrying a
-   space stays one part. *)
-let value_parts s =
-  let parts = ref [] and buf = Buffer.create 16 and quote = ref None in
-  let flush () =
-    if Buffer.length buf > 0 then (
-      parts := Buffer.contents buf :: !parts;
-      Buffer.clear buf)
-  in
-  String.iter
-    (fun c ->
-      match (!quote, c) with
-      | Some q, _ when Char.equal c q ->
-          quote := None;
-          Buffer.add_char buf c
-      | Some _, _ -> Buffer.add_char buf c
-      | None, ('"' | '\'') ->
-          quote := Some c;
-          Buffer.add_char buf c
-      | None, (' ' | '\t' | '\n' | '\r' | '\012') -> flush ()
-      | None, _ -> Buffer.add_char buf c)
-    s;
-  flush ();
-  List.rev !parts
+let underscored s = String.map (function '-' -> '_' | c -> c) s
 
 let is_quoted p =
   String.length p >= 2
   && (Char.equal p.[0] '"' || Char.equal p.[0] '\'')
   && Char.equal p.[String.length p - 1] p.[0]
 
-(* Every value CSS Overflow 4 sec. 4.1 grants but the one-value [clip |
-   ellipsis] half Chrome implements. *)
-let unimplemented_text_overflow s =
-  let arm p =
-    List.exists (String.equal p) [ "clip"; "ellipsis"; "fade" ]
-    || is_quoted p
-    || String.starts_with ~prefix:"fade(" p
+(* The function name of [f(...)], when the value is one call. *)
+let call_name s =
+  let s = String.trim s in
+  match String.index_opt s '(' with
+  | Some i when i > 0 && String.length s > i && s.[String.length s - 1] = ')' ->
+      let name = String.sub s 0 i in
+      if String.for_all (fun c -> (c >= 'a' && c <= 'z') || c = '-') name then
+        Some name
+      else None
+  | Some _ | None -> None
+
+(* BCD writes a keyword arm as css.properties.<property>.<value>, some of them
+   with [_] where CSS writes [-]; a multi-slot value under the slot that carries
+   it, so each word is a candidate; a <string> arm as [.string]; and a value
+   type under css.types. Every spelling is a candidate and the dataset decides
+   which one exists, so a production BCD names in a way this does not reach is a
+   measurement in the library rather than a table entry here. *)
+(* A vendor-prefixed property is the same production under another name, and
+   BCD files it under the unprefixed one. *)
+let unprefixed property =
+  List.find_map
+    (fun prefix ->
+      if String.starts_with ~prefix property then
+        Some
+          (String.sub property (String.length prefix)
+             (String.length property - String.length prefix))
+      else None)
+    [ "-webkit-"; "-moz-"; "-ms-"; "-o-" ]
+
+let keys_for ?(prefix = "css.properties") ~property ~value () =
+  let value = String.trim value in
+  let properties = property :: Option.to_list (unprefixed property) in
+  let prop k =
+    List.map (fun p -> String.concat "" [ prefix; "."; p; "."; k ]) properties
   in
-  match value_parts s with
-  | [] | [ "clip" ] | [ "ellipsis" ] -> false
-  | parts -> List.length parts <= 2 && List.for_all arm parts
-
-let lenient_family_shape =
-  {
-    shape_properties = [ "font-family"; "font" ];
-    shape_name = "a reserved word inside a longer unquoted family";
-    matches = unquoted_family_reserved_word;
-    shape_why =
-      "CSS Fonts 4 sec. 2.1.1 gives an unquoted family a <custom-ident>+ and \
-       excludes an identifier that could be misinterpreted as a pre-defined \
-       keyword or a CSS-wide keyword. Chrome applies that to a one-identifier \
-       family alone and reads a reserved word inside a longer name";
-  }
-
-let lenient_shapes =
-  [
-    lenient_family_shape;
-    {
-      (* Measured on Chrome 153: [border: 1px, dashed, red] sets the same twelve
-         longhands [border: 1px dashed red] does, so both sides of each comma
-         are read and the comma is the separator between them. It is not a list:
-         [border: red, red] and [border: dashed, solid] fill one slot twice and
-         are refused, as they are without the comma. A leading comma ([border: ,
-         red]) and a doubled one ([border: red,,dashed]) are refused. *)
-      shape_properties =
-        [
-          "border";
-          "border-block";
-          "border-inline";
-          "border-block-start";
-          "border-block-end";
-          "border-inline-start";
-          "border-inline-end";
-          "border-top";
-          "border-right";
-          "border-bottom";
-          "border-left";
-        ];
-      shape_name = "a comma in a border shorthand";
-      matches = has_comma;
-      shape_why =
-        "CSS Backgrounds 3 sec. 4.5 and CSS Logical 1 sec. 4.6 build these \
-         from a [||] of a width, a style and a colour, and no arm of either is \
-         a comma. Chrome reads one between two components as the whitespace \
-         separating them, so the declaration sets what the same value without \
-         the comma sets";
-    };
-    {
-      shape_properties = [ "baseline-shift" ];
-      shape_name = "a bare <number>";
-      matches = is_bare_number;
-      shape_why =
-        "CSS Inline 3 sec. 4.2.3: <length-percentage> | sub | super | top | \
-         center | bottom, and no arm is a bare <number>. Chrome reads one as \
-         the unitless length SVG presentation attributes take";
-    };
-  ]
-
-let words s = String.split_on_char ' ' (String.trim s)
-
-(* CSS Animations 2 sec. 4.12 ends <single-animation> in [ none |
-   <keyframes-name> ] || <single-animation-timeline>, so a dashed-ident timeline
-   and a keyframes name fill two slots of one [||]. Measured on Chrome 153: it
-   takes the timeline alone ([animation: --t], [animation: 1s --t]) and refuses
-   it beside a name ([spin --t], [flip-block --fallback]), so it took the
-   timeline back out of the shorthand rather than never having it. *)
-let animation_name_beside_timeline s =
-  let ws = List.filter (fun w -> w <> "") (words s) in
-  let dashed w = String.length w > 2 && String.sub w 0 2 = "--" in
-  let timing w =
-    (not (dashed w))
-    && (String.contains w 's' || String.contains w '%'
-       || String.exists (fun c -> c >= '0' && c <= '9') w)
+  let words = split_ws value in
+  let whole = prop value @ prop (underscored value) in
+  let joined =
+    match words with
+    | [] | [ _ ] -> []
+    | ws -> prop (String.concat "_" (List.map underscored ws))
   in
-  List.exists dashed ws
-  && List.exists (fun w -> (not (dashed w)) && not (timing w)) ws
-
-(* CSS Values 4 sec. 10.1 puts a math function wherever its type is, and CSS
-   Overflow 4 sec. 3.2 gives overflow-clip-margin a <length>. Measured on Chrome
-   153: it takes a literal length and refuses every math function there,
-   [calc(1px)] and [min(1px,2px)] included, so this is not about the negative
-   the value happens to carry. *)
-let math_function s =
-  List.exists
-    (fun fn ->
-      String.length s >= String.length fn
-      && String.sub s 0 (String.length fn) = fn)
-    [ "calc("; "min("; "max("; "clamp(" ]
-
-let spec_ahead_shapes =
-  [
-    {
-      shape_properties = [ "overflow-clip-margin" ];
-      shape_name = "a math function in an overflow clip margin";
-      matches = math_function;
-      shape_why =
-        "CSS Values 4 sec. 10.1 puts a math function wherever its type is, and \
-         CSS Overflow 4 sec. 3.2 gives the property a <length>. Chrome takes a \
-         literal length and refuses every math function there";
-    };
-    {
-      shape_properties = [ "animation"; "-webkit-animation" ];
-      shape_name = "a keyframes name beside a dashed-ident timeline";
-      matches = animation_name_beside_timeline;
-      shape_why =
-        "CSS Animations 2 sec. 4.12 ends <single-animation> in [ none | \
-         <keyframes-name> ] || <single-animation-timeline>, so the two fill \
-         two slots of one [||]. Chrome takes the timeline alone and refuses it \
-         beside a name";
-    };
-    {
-      shape_properties = [ "text-overflow" ];
-      shape_name = "a text-overflow Chrome does not implement";
-      matches = unimplemented_text_overflow;
-      shape_why =
-        "CSS Overflow 4 sec. 4.1: [ clip | ellipsis | <string> | fade | \
-         <fade()> ]{1,2}, and Chrome implements the one-value [ clip | \
-         ellipsis ] half of it";
-    };
-  ]
-
-let shape_covering table ~property ~value =
-  let covers (s : shape) =
-    List.exists (String.equal property) s.shape_properties && s.matches value
+  (* BCD names an arm a property takes only in its multi-value form after the
+     shape rather than the value: two slots are [two_value_syntax]. *)
+  let arity =
+    match words with [ _; _ ] -> prop "two_value_syntax" | _ -> []
   in
-  List.find_opt covers table
+  let per_word =
+    match words with
+    | [] | [ _ ] -> []
+    | ws -> List.concat_map (fun w -> prop w @ prop (underscored w)) ws
+  in
+  (* A value that is one entry of a comma-separated list is the same keyword
+     doing a different job, and BCD names the job. *)
+  let in_a_list =
+    if String.contains value ',' then
+      List.concat_map
+        (fun entry ->
+          List.concat_map
+            (fun w -> prop (String.concat "" [ underscored w; "_in_a_list" ]))
+            (split_ws entry))
+        (String.split_on_char ',' value)
+    else []
+  in
+  let strings = if is_quoted value then prop "string" else [] in
+  (* Productions web-features does not model still have to be named, and a name
+     nothing derives is a name only a table can reach. These are the shapes a
+     value has rather than the value itself, so they are one name each however
+     the generator spells the member it drew. *)
+  let is_number w =
+    w <> ""
+    && String.for_all
+         (fun c -> (c >= '0' && c <= '9') || c = '.' || c = '-' || c = '+')
+         w
+    && String.exists (fun c -> c >= '0' && c <= '9') w
+  in
+  let shapes =
+    (match words with [ w ] when is_number w -> prop "number" | _ -> [])
+    @ (if String.length value > 0 && value.[String.length value - 1] = ',' then
+         prop "trailing_comma"
+       else [])
+    @ (if String.contains value ',' then prop "comma" else [])
+    @
+    (* A negative of any dimension, not only a bare number: the sign is what the
+       range excludes, whatever unit follows it. *)
+    match words with
+    | [ w ]
+      when String.length w > 1 && w.[0] = '-' && w.[1] >= '0' && w.[1] <= '9' ->
+        prop "negative"
+    | _ -> []
+  in
+  (* A function is filed under the property BCD happened to pick, and named the
+     same way wherever that is, so the whole dataset is searched by name. *)
+  let calls =
+    match call_name value with
+    | None -> []
+    | Some name ->
+        prop (String.concat "" [ underscored name; "_function" ])
+        @ [
+            String.concat "" [ "css.types."; name ];
+            String.concat "" [ "css.types.image."; name ];
+            String.concat "" [ "css.types.color."; name ];
+          ]
+        @ Cascade.Support.keys_named (String.concat "" [ name; "_function" ])
+        @ Cascade.Support.keys_named
+            (String.concat "" [ underscored name; "_function" ])
+  in
+  (* BCD names a slot the shorthand accepts [<longhand>_included], and which
+     slot a value fills is grammar this harness does not have, so every slot the
+     dataset records for the property is a candidate. *)
+  let included =
+    List.concat_map
+      (fun p ->
+        List.filter
+          (fun k -> String.ends_with ~suffix:"_included" k)
+          (Cascade.Support.keys_under
+             (String.concat "" [ prefix; "."; p; "." ])))
+      properties
+  in
+  let bare =
+    List.map (fun p -> String.concat "" [ prefix; "."; p ]) properties
+  in
+  List.fold_left
+    (fun acc k -> if List.exists (String.equal k) acc then acc else acc @ [ k ])
+    []
+    (whole @ joined @ in_a_list @ arity @ strings @ shapes @ calls @ per_word
+   @ included @ bare)
+
+(* ===== What the dataset says about a disagreement ===== *)
+
+type explanation = Not_shipped of string | Shipped_beyond_spec of string
+
+let explanation_key = function
+  | Not_shipped key | Shipped_beyond_spec key -> key
+
+let explains_rejection ?prefix ~chrome ~property ~value () =
+  List.find_map
+    (fun key ->
+      match
+        Cascade.Support.engine_implements Cascade.Support.Chrome chrome key
+      with
+      | Some false -> Some (Not_shipped key)
+      | Some true | None -> None)
+    (keys_for ?prefix ~property ~value ())
+
+(* Only a measured key answers here: the generated table records what browsers
+   ship, which cannot say whether a specification grants it. That judgement is a
+   measurement, and it lives in the library beside the specification text that
+   decided it. *)
+let explains_acceptance ?prefix ~chrome ~property ~value () =
+  List.find_map
+    (fun key ->
+      if
+        Cascade.Support.self_measured key
+        && Cascade.Support.engine_implements Cascade.Support.Chrome chrome key
+           = Some true
+      then Some (Shipped_beyond_spec key)
+      else None)
+    (keys_for ?prefix ~property ~value ())
+
+(* ===== Reporting which side is wrong ===== *)
+
+type verdict = Browser_behind | Cascade_wrong | Needs_measurement
+
+let verdict_of targets key =
+  match Cascade.Support.implemented targets key with
+  | None -> Needs_measurement
+  | Some true -> Cascade_wrong
+  | Some false -> Browser_behind
+
+let verdict_name = function
+  | Browser_behind -> "cascade right, the browser has not shipped it"
+  | Cascade_wrong -> "every target ships it, so cascade is wrong"
+  | Needs_measurement -> "not modelled, needs measuring"

--- a/test/spec/browser/chrome_gaps.mli
+++ b/test/spec/browser/chrome_gaps.mli
@@ -1,6 +1,21 @@
-(** What a headless Chrome cannot arbitrate, and the vectors where it and the
-    specifications disagree. Shared by the browser-backed harnesses here, so a
-    browser that catches up is recorded once rather than in each of them. *)
+(** Which productions the browser in front of these harnesses implements.
+
+    A differential between cascade and a browser produces disagreements, and
+    most of them are not defects: a browser that has not shipped a grammar
+    rejects CSS the specifications grant, and one that ships more than they
+    grant accepts CSS no specification does. Both are facts about browsers.
+
+    This used to hold them as a table of property-value pairs with prose. It
+    does not any more. {!Cascade.Support} answers "does this engine implement
+    this production" from the web-features dataset, so the only thing a harness
+    needs is the BCD compat key naming the production, and BCD names one from
+    the property and the value. That is what this derives. A disagreement the
+    dataset explains is reported as the fact it is, and one it does not explain
+    is a finding.
+
+    The consequence is that nothing here can talk a defect away. A hand-written
+    entry stays true until someone rereads it; a lookup goes stale the day the
+    browser ships the grammar, and the harness says so on the next run. *)
 
 val unimplemented : string list
 (** [unimplemented] is the property names Chrome implements no grammar for, so
@@ -11,42 +26,67 @@ val unimplemented_property : string -> bool
 (** [unimplemented_property name] is [true] when [name] is in {!unimplemented}.
 *)
 
-type excuse = {
-  properties : string list;
-  key : string option;
-  value : string;
-  why : string;
-}
-(** One property-value pair the browser and the specifications disagree about,
-    with the spec text that decides it.
+val keys_for :
+  ?prefix:string -> property:string -> value:string -> unit -> string list
+(** [keys_for ~property ~value ()] is the BCD compat keys that could name this
+    production, most specific first.
 
-    [key] is the BCD compat key web-features records the production under, when
-    it records one. That is what makes the entry checkable: {!Support} says
-    whether Chrome has since shipped it, so the entry goes stale when the
-    browser catches up rather than when a seeded generator stops drawing the
-    literal. [None] is a production web-features does not model, which no lookup
-    can answer and which stays a measurement. *)
+    BCD names a keyword arm [css.properties.<property>.<value>], writing some
+    values with [_] where CSS writes [-], names a multi-slot value after the
+    slot that carries it, and names a value type under [css.types]. Each of
+    those is a candidate, and the dataset decides which one exists. Deriving
+    rather than listing is what keeps a browser gap from needing a hand-written
+    entry that nothing can invalidate.
 
-val spec_ahead : excuse list
-(** [spec_ahead] is grammar a specification defines and Chrome rejects, so a
-    Chrome rejection says nothing about the value. *)
+    [prefix] is the BCD namespace, [css.properties] by default; a descriptor is
+    filed under [css.at-rules.font-face]. *)
 
-val lenient : excuse list
-(** [lenient] is a value Chrome accepts that no specification grants, so a
-    Chrome acceptance says nothing about the value. *)
+(** What the support dataset says about a disagreement. *)
+type explanation =
+  | Not_shipped of string
+      (** the key names a production this browser has not shipped, so its
+          rejection says nothing about the value *)
+  | Shipped_beyond_spec of string
+      (** the key names a production this browser has shipped and no
+          specification grants, so its acceptance says nothing about the value
+      *)
 
-val find : excuse list -> property:string -> value:string -> excuse option
-(** [find table ~property ~value] is the entry of [table] covering that pair. *)
+val explanation_key : explanation -> string
+(** [explanation_key e] is the BCD key [e] cites. *)
 
-(** Which side of a cascade-vs-browser divergence is wrong. Every differential
-    here produces this classification and used to discard it, so a browser-bug
-    candidate was only ever noticed by a human reading the output. *)
+val explains_rejection :
+  ?prefix:string ->
+  chrome:Cascade.Support.version ->
+  property:string ->
+  value:string ->
+  unit ->
+  explanation option
+(** [explains_rejection ~chrome ~property ~value ()] is [Some] when the dataset
+    says this Chrome has not shipped a production naming that pair, so cascade
+    reading a value the browser rejects is the browser being behind. *)
+
+val explains_acceptance :
+  ?prefix:string ->
+  chrome:Cascade.Support.version ->
+  property:string ->
+  value:string ->
+  unit ->
+  explanation option
+(** [explains_acceptance ~chrome ~property ~value ()] is [Some] when the dataset
+    records a production this Chrome ships that no specification grants, so
+    cascade rejecting a value the browser accepts is the browser being lenient.
+
+    Only {!Cascade.Support.self_measured} keys answer here. The generated table
+    records what browsers ship, which cannot say whether a specification grants
+    it; that judgement is a measurement, and it lives in the library beside the
+    specification text that decided it. *)
+
+(** Which side of a cascade-vs-browser divergence is wrong. *)
 type verdict =
   | Browser_behind
       (** A specification defines the grammar and the dataset says a target
-          engine has not shipped it, so cascade is right to read it and the
-          browser's answer says nothing about the value. A candidate to report
-          upstream. *)
+          engine has not shipped it, so cascade is right to read it. A candidate
+          to report upstream. *)
   | Cascade_wrong
       (** The dataset says every target ships it, so the browser's answer is the
           specification's and cascade's disagreement is a defect. *)
@@ -55,40 +95,9 @@ type verdict =
           property and every arm BCD gives no key. Neither side is established
           without measuring, and saying so is the honest third answer. *)
 
-val verdict_of : Cascade.Support.targets -> excuse -> verdict
-(** [verdict_of targets e] classifies the divergence [e] excuses, from its
-    {!excuse.key} and the generated support table. An entry with no key is
-    {!Needs_measurement} however convincing its prose is. *)
+val verdict_of : Cascade.Support.targets -> string -> verdict
+(** [verdict_of targets key] classifies a divergence explained by [key], from
+    the generated support table. *)
 
 val verdict_name : verdict -> string
 (** [verdict_name v] names [v] for a report. *)
-
-val overtaken : excuse list -> excuse list
-(** [overtaken table] is the entries whose {!excuse.key} names a production
-    Chrome has since shipped, so the disagreement they excuse is gone and the
-    entry has to go with it. An entry with no key is never overtaken: nothing
-    can answer for it, which is the cost of a production web-features does not
-    model. *)
-
-type shape = {
-  shape_properties : string list;
-  shape_name : string;
-  matches : string -> bool;
-  shape_why : string;
-}
-(** A disagreement that is about a SHAPE of value rather than one value, for the
-    cases where naming every value is not possible: the generator draws from a
-    seeded stream, so a literal list is a fact about one sample rather than
-    about the browser. [shape_name] names the shape for the report and for the
-    staleness check. *)
-
-val lenient_shapes : shape list
-(** [lenient_shapes] is {!lenient} keyed by a predicate. *)
-
-val spec_ahead_shapes : shape list
-(** [spec_ahead_shapes] is {!spec_ahead} keyed by a predicate. *)
-
-val shape_covering :
-  shape list -> property:string -> value:string -> shape option
-(** [shape_covering table ~property ~value] is the entry of [table] whose
-    predicate covers that pair. *)

--- a/test/spec/browser/descriptor_set.ml
+++ b/test/spec/browser/descriptor_set.ml
@@ -35,7 +35,7 @@
    a fact about browsers rather than about this run, so it is looked up in
    Cascade.Support under the BCD key web-features carries. A descriptor the
    dataset says this build ships, that then takes none of the manifest's
-   positives, is a failure and not an excuse.
+   positives, is a failure and not something to look past.
 
    Both directions are exercised rather than quiet. Making the CSS-wide refusal
    in read_descriptor_value a no-op reports 25 values cascade would keep and the
@@ -435,6 +435,10 @@ let () =
   let bump t k =
     Hashtbl.replace t k (1 + Option.value ~default:0 (Hashtbl.find_opt t k))
   in
+  (* A descriptor no current specification defines has no grammar to judge a
+     generated value against, so the browser's answer about one says nothing: it
+     is the leftovers of a removed section either way. *)
+  let ungoverned descriptor = Option.is_none (Grammar.row_for descriptor) in
   let pending = ref [] in
   List.iter
     (fun job ->
@@ -489,9 +493,23 @@ let () =
                        ": the row refuses this value and cascade reads it";
                      ])
             (* No row covers a generated value, so the browser is the only
-               oracle there is, and closing a finding means writing the value
-               into the row with the section that decides it. *)
+               oracle there is. A disagreement the support dataset explains is
+               the browser's, looked up the way the property harnesses look one
+               up: BCD files a descriptor under css.at-rules.font-face. *)
             | Generated, r, p when Bool.equal r p -> incr arbitrated
+            | Generated, true, false
+              when Option.is_some
+                     (Chrome_gaps.explains_rejection
+                        ~prefix:"css.at-rules.font-face" ~chrome:version
+                        ~property:job.descriptor ~value:job.value ()) ->
+                incr behind
+            | Generated, false, true
+              when Option.is_some
+                     (Chrome_gaps.explains_acceptance
+                        ~prefix:"css.at-rules.font-face" ~chrome:version
+                        ~property:job.descriptor ~value:job.value ()) ->
+                incr lenient
+            | Generated, _, _ when ungoverned job.descriptor -> ()
             | Generated, _, _ -> pending := (job, reads) :: !pending
           end)
     jobs;

--- a/test/spec/browser/property_vectors.ml
+++ b/test/spec/browser/property_vectors.ml
@@ -9,8 +9,9 @@
 
    This run gives the manifest a source of truth that is not cascade. Every
    positive must be valid CSS to a browser and every negative must be invalid to
-   it, and the exceptions are enumerated below with the spec text that justifies
-   each one, so an excuse cannot be added without saying what it is for.
+   it, and a difference stands unless the support dataset names a production
+   this browser has not shipped, which is a lookup rather than a sentence
+   somebody wrote.
 
    Skips cleanly, with status 0, when node or a headless Chromium is missing.
    CASCADE_NO_BROWSER silences the run, and a silenced gate is not a pass: only
@@ -18,19 +19,11 @@
 
 let ( // ) = Filename.concat
 
-(* The browser's own gaps live in Chrome_gaps, shared with the accept-set
-   differential next door: both ask the same browser the same question, so a
-   browser that catches up is recorded once. *)
-
-type excuse = Chrome_gaps.excuse = {
-  properties : string list;
-  key : string option;
-  value : string;
-  why : string;
-}
-
-let spec_ahead = Chrome_gaps.spec_ahead
-let lenient = Chrome_gaps.lenient
+(* Why a browser's answer differs from the manifest is a lookup, not a sentence
+   someone wrote: Chrome_gaps derives the BCD compat key naming the production
+   and asks Cascade.Support whether this build has shipped it. Shared with the
+   accept-set differential next door, so a browser that catches up moves both
+   answers at the next dataset run. *)
 
 (* ===== Jobs ===== *)
 
@@ -138,30 +131,20 @@ let parse_driver_output lines =
 
 type outcome =
   | Confirmed  (** the browser and the manifest agree *)
-  | Excused of string  (** they differ, and an entry above says why *)
+  | Explained of string
+      (** they differ, and the support dataset names the production *)
   | Wrong of string  (** they differ, and nothing says why *)
   | Split  (** the two oracles disagree, so neither is the answer *)
   | Unanswered of string  (** the browser did not answer *)
 
 let hits = Hashtbl.create 64
-let excuse_key property value = String.concat "\000" [ property; value ]
 
-(* A shape answers for a class of values rather than one, so a manifest row
-   pinning a member of the class is excused by it the way a literal entry
-   excuses its own value. *)
-let excuse ?(shapes = []) table property value =
-  match Chrome_gaps.find table ~property ~value with
-  | Some e ->
-      Hashtbl.replace hits (excuse_key property value) ();
-      Some e.why
-  | None -> (
-      match Chrome_gaps.shape_covering shapes ~property ~value with
-      | Some s ->
-          Hashtbl.replace hits (excuse_key property value) ();
-          Some s.shape_why
-      | None -> None)
+let cite explanation =
+  let key = Chrome_gaps.explanation_key explanation in
+  Hashtbl.replace hits key ();
+  Explained key
 
-let judge job verdict =
+let judge ~chrome job verdict =
   match verdict.error with
   | Some e -> Unanswered e
   | None when not (Bool.equal verdict.set_property verdict.supports) -> Split
@@ -173,24 +156,24 @@ let judge job verdict =
       | Negative when not accepted -> Confirmed
       | Positive -> (
           match
-            excuse ~shapes:Chrome_gaps.spec_ahead_shapes spec_ahead job.property
-              job.value
+            Chrome_gaps.explains_rejection ~chrome ~property:job.property
+              ~value:job.value ()
           with
-          | Some why -> Excused why
+          | Some e -> cite e
           | None -> Wrong "the browser rejects this positive")
       | Negative -> (
           match
-            excuse ~shapes:Chrome_gaps.lenient_shapes lenient job.property
-              job.value
+            Chrome_gaps.explains_acceptance ~chrome ~property:job.property
+              ~value:job.value ()
           with
-          | Some why -> Excused why
+          | Some e -> cite e
           | None -> Wrong "the browser accepts this negative"))
 
 (* ===== Reporting ===== *)
 
 let failures = ref 0
 let confirmed = ref 0
-let excused = ref 0
+let explained = ref 0
 
 let fail line =
   incr failures;
@@ -211,7 +194,7 @@ let record job outcome =
       match job.kind with
       | Probe -> ()
       | Positive | Negative -> incr confirmed)
-  | Excused _ -> incr excused
+  | Explained _ -> incr explained
   | Wrong why -> fail (String.concat "" [ describe job; ": "; why ])
   | Split ->
       fail
@@ -223,28 +206,6 @@ let record job outcome =
            ])
   | Unanswered e ->
       fail (String.concat "" [ describe job; ": the browser raised: "; e ])
-
-(* An entry that excuses nothing is a claim nobody checks any more. *)
-let check_unused table label =
-  List.iter
-    (fun (e : excuse) ->
-      let used =
-        List.exists
-          (fun property -> Hashtbl.mem hits (excuse_key property e.value))
-          e.properties
-      in
-      if not used then
-        fail
-          (String.concat ""
-             [
-               label;
-               " excuses nothing any more: ";
-               e.value;
-               " (";
-               String.concat ", " e.properties;
-               ")";
-             ]))
-    table
 
 (* The skip list has to describe the browser in front of it, in both
    directions. *)
@@ -332,6 +293,17 @@ let () =
     | Some c -> c
     | None -> Browser.skip "property_vectors" "no headless browser"
   in
+  (* The support dataset is keyed by version, so the run says which build it
+     measured rather than assuming the one the default contract names. *)
+  let chrome_version =
+    match Browser.chrome_version chrome with
+    | Some v -> v
+    | None ->
+        prerr_endline
+          "property_vectors: the browser did not report a version, so no \
+           support fact can be keyed to this run";
+        exit 1
+  in
   let jobs = jobs () in
   let script_dir = Filename.dirname Sys.executable_name in
   let work = Filename.get_temp_dir_name () // "cascade-property-vectors" in
@@ -368,11 +340,9 @@ let () =
               Hashtbl.replace implemented job.property
                 (verdict.supports && verdict.set_property)
           | Positive | Negative -> ());
-          record job (judge job verdict))
+          record job (judge ~chrome:chrome_version job verdict))
     jobs;
   check_unarbitrable implemented;
-  check_unused spec_ahead "a spec-ahead-of-the-browser entry";
-  check_unused lenient "a browser-leniency entry";
   let is_probe job =
     match job.kind with Probe -> true | Positive | Negative -> false
   in
@@ -392,20 +362,21 @@ let () =
     (List.length jobs - probes)
     (List.length Cascade_spec_inventory.Property_grammar.rows)
     skipped elapsed;
-  Fmt.pr "  confirmed: %d, excused: %d, failures: %d@." !confirmed !excused
+  Fmt.pr "  confirmed: %d, explained: %d, failures: %d@." !confirmed !explained
     !failures;
-  (* The same grouping accept_set reports: which side of each excused divergence
-     the generated support table blames. An entry the dataset says every target
-     ships is covering a defect rather than citing a fact, and accept_set fails
-     on one, so this reports the split without repeating that check. *)
+  (* The same grouping accept_set reports: which side of each explained
+     divergence the generated support table blames. A key the dataset says every
+     target ships would be covering a defect rather than citing a fact, and
+     accept_set fails on one, so this reports the split without repeating that
+     check. *)
   let tally = Hashtbl.create 4 in
-  List.iter
-    (fun (e : Chrome_gaps.excuse) ->
-      let v = Chrome_gaps.verdict_of Cascade.Support.evergreen e in
+  Hashtbl.iter
+    (fun key () ->
+      let v = Chrome_gaps.verdict_of Cascade.Support.evergreen key in
       Hashtbl.replace tally v
         (1 + Option.value ~default:0 (Hashtbl.find_opt tally v)))
-    (spec_ahead @ lenient);
-  Fmt.pr "  excuses by verdict:@.";
+    hits;
+  Fmt.pr "  explained by verdict:@.";
   List.iter
     (fun v ->
       match Hashtbl.find_opt tally v with

--- a/test/spec/inventory/descriptor_grammar.ml
+++ b/test/spec/inventory/descriptor_grammar.ml
@@ -86,14 +86,6 @@ let rows =
         "\"text\"";
         "\"liga\" off";
       ];
-    (* CSS Fonts 4 removed this descriptor per WG resolution and Chrome 153
-       still reads it, so it stays modelled and the row cites the last section
-       that spelled it. *)
-    row "font-variant"
-      "CSS Fonts 3 sec. 7.3, the sec. 6.9 font-variant property values inside \
-       the rule; CSS Fonts 4 removed the descriptor"
-      [ "normal"; "none"; "small-caps"; "common-ligatures small-caps" ]
-      [ "bogus-variant"; "1"; "small-caps 1" ];
     row "size-adjust" "CSS Fonts 5 (ED) sec. 4.10 <percentage [0,inf]>"
       [ "0%"; "92%"; "100%"; "300%" ]
       [ "-1%"; "100"; "normal" ];

--- a/test/spec/inventory/descriptor_grammar.mli
+++ b/test/spec/inventory/descriptor_grammar.mli
@@ -22,7 +22,10 @@ type row = {
 *)
 
 val rows : row list
-(** Every [@font-face] descriptor this project has spec vectors for. *)
+(** Every [@font-face] descriptor a current specification defines. A descriptor
+    a specification has REMOVED has no row: there is no grammar left to check a
+    browser against, and writing one from the section that used to define it
+    would put a harness in the position of testing a browser's leftovers. *)
 
 val descriptors : string list
 (** [descriptors] is the descriptor names {!rows} covers. *)

--- a/test/spec/inventory/property_grammar.ml
+++ b/test/spec/inventory/property_grammar.ml
@@ -358,12 +358,18 @@ let matrix =
       negatives = [ "1 2 3 4"; "red" ];
     };
     {
+      (* CSS Transitions 1 (ED) sec. 2.5 spells the shorthand
+         [<single-transition>#] over [<single-transition> = [ none |
+         <single-transition-property> ] || <time> || <easing-function> ||
+         <time>], so [none] is one entry of the list wherever it stands and not
+         a whole-value keyword. *)
       property = "transition";
       positives =
         [
           "opacity 1s ease-in .2s";
           "all .2s linear .1s";
           "opacity calc(500ms + .5s)";
+          "opacity 1s, none";
         ];
       negatives = [ "1s 2s 3s"; "ease opacity ease" ];
     };


### PR DESCRIPTION
The browser harnesses carried 40 property-value pairs with prose saying which specification granted the value and that Chrome had not shipped it. Every one restated something `Cascade.Support` answers from the web-features dataset, in a form nothing could invalidate: an entry stayed true until a person reread it, and a resample stranded it.

BCD names a production from the property and the value, so `Chrome_gaps` now derives the compat key and the dataset decides. A production web-features does not model is a measurement in the library, beside the specification text that decided it, and the derivation reaches it by the same naming rules. `chrome_gaps.ml` goes from 752 lines to 190. `accept_set` is clean on all eight seeds and `property_vectors` on all 2751 vectors, with no hand-written entry left in either.